### PR TITLE
Added redirects for Passenger

### DIFF
--- a/lib/onetime/app/web.rb
+++ b/lib/onetime/app/web.rb
@@ -65,7 +65,7 @@ module Onetime
     end
 
     def receive_feedback
-      publically do
+      publically('/feedback') do
         logic = OT::Logic::ReceiveFeedback.new sess, cust, req.params
         logic.raise_concerns
         logic.process
@@ -74,7 +74,7 @@ module Onetime
     end
 
     def create_secret
-      publically(req.request_path) do
+      publically('/') do
         logic = OT::Logic::CreateSecret.new sess, cust, req.params
         logic.raise_concerns
         logic.process
@@ -142,4 +142,3 @@ module Onetime
     end
   end
 end
-

--- a/lib/onetime/app/web/account.rb
+++ b/lib/onetime/app/web/account.rb
@@ -51,7 +51,7 @@ module Onetime
     end
 
     def request_reset
-      publically do
+      publically('/forgot') do
         if req.params[:key]
           logic = OT::Logic::ResetPassword.new sess, cust, req.params
           logic.raise_concerns
@@ -93,7 +93,7 @@ module Onetime
 
     def create_account
       #publically("/signup/#{req.params[:planid]}") do
-      publically() do
+      publically('/signup') do
         deny_agents!
         logic = OT::Logic::CreateAccount.new sess, cust, req.params
         logic.raise_concerns


### PR DESCRIPTION
When serving this application out through Passenger, certain actions
would lead to a HTTP 500 error. After inspecting the Rack::Request.env
attribute, it appears that request_path is missing and/or not set when
using Passenger. And since this value is used to redirect the user in
certain cases, Rack was throwing an error because it was nil. The fix
was to statically set the redirect variable for certain actions.