### PR TITLE
Change to work natively with current app config

### DIFF
--- a/etc/redis.conf
+++ b/etc/redis.conf
@@ -7,7 +7,7 @@ dir /var/lib/onetime/
 dbfilename default.rdb
 appendfilename default.aof
 
-# requirepass CHANGEME
+requirepass CHANGEME
 
 bind 127.0.0.1
 port 7179


### PR DESCRIPTION
When I  was trying to spin this up in a docker container with the default files here, this line commented in the redis config made the application error out. If CHANGEME was provided by default as the redis database password, the app should work almost perfectly out of a cloned version of the repo.