### PR TITLE
Ssl toggle support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM ruby:2.2.3
+
+RUN groupadd -r ots && useradd -r -m -g ots ots
+RUN apt-get update
+RUN apt-get install -y build-essential libyaml-dev libevent-dev zlib1g zlib1g-dev openssl libssl-dev libxml2 git
+
+RUN gem install bundler
+RUN mkdir -p /etc/onetime && chown ots /etc/onetime
+ADD . /home/ots/onetime
+
+RUN cd /home/ots/onetime && bundle install --frozen --deployment --without=dev
+
+RUN mkdir -p /var/log/onetime /var/run/onetime /var/lib/onetime
+RUN chown ots /var/log/onetime /var/run/onetime /var/lib/onetime
+RUN cp -r /home/ots/onetime/etc/* /etc/onetime
+
+EXPOSE 7143
+
+ENTRYPOINT echo $ots_domain | xargs -I domurl sed -ir 's/:domain:/:domain: domurl/g' /etc/onetime/config \
+&& echo $ots_host | xargs -I hosturl sed -ir 's/:host:/:host: hosturl/g' /etc/onetime/config \
+&& dd if=/dev/urandom bs=40 count=1 | openssl sha1 | grep stdin | awk '{print $2}' | xargs -I key sed -ir 's/:secret:/:secret: key/g' /etc/onetime/config \
+&& cd /home/ots/onetime/ \
+&& bundle exec thin -e dev -R config.ru -p 7143 start

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ EXPOSE 7143
 
 ENTRYPOINT echo $ots_domain | xargs -I domurl sed -ir 's/:domain:/:domain: domurl/g' /etc/onetime/config \
 && echo $ots_host | xargs -I hosturl sed -ir 's/:host:/:host: hosturl/g' /etc/onetime/config \
+&& echo $ots_ssl | xargs -I hostssl sed ir 's/:ssl:/:ssl: hostssl/g' /etc/onetime/config \
 && dd if=/dev/urandom bs=40 count=1 | openssl sha1 | grep stdin | awk '{print $2}' | xargs -I key sed -ir 's/:secret:/:secret: key/g' /etc/onetime/config \
 && cd /home/ots/onetime/ \
 && bundle exec thin -e dev -R config.ru -p 7143 start

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ source "https://rubygems.org/"
 gem 'addressable', '2.2.6'
 gem 'rack', '1.4.5'
 gem 'yajl-ruby', '1.1.0'
-gem 'thin', '1.5.0'
+gem 'thin', '~> 1.6.4'
 
 gem 'mustache', '0.99.3'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,11 +15,11 @@ GEM
     builder (3.2.2)
     caesars (0.7.4)
     crack (0.1.8)
-    daemons (1.1.9)
+    daemons (1.2.3)
     docile (1.1.0)
     drydock (0.6.9)
     encryptor (1.1.3)
-    eventmachine (1.0.3)
+    eventmachine (1.0.8)
     familia (0.7.1)
       gibbler (>= 0.8.6)
       multi_json (>= 0.0.5)
@@ -74,10 +74,10 @@ GEM
     sysinfo (0.7.3)
       drydock
       storable
-    thin (1.5.0)
-      daemons (>= 1.0.9)
-      eventmachine (>= 0.12.6)
-      rack (>= 1.0.0)
+    thin (1.6.4)
+      daemons (~> 1.0, >= 1.0.9)
+      eventmachine (~> 1.0, >= 1.0.4)
+      rack (~> 1.0)
     treetop (1.4.15)
       polyglot
       polyglot (>= 0.3.1)
@@ -105,8 +105,8 @@ DEPENDENCIES
   rudy (= 0.9.8.020)
   storable (= 0.8.9)
   sysinfo (= 0.7.3)
-  thin (= 1.5.0)
+  thin (~> 1.6.4)
   yajl-ruby (= 1.1.0)
 
 BUNDLED WITH
-   1.10.2
+   1.10.6

--- a/etc/config
+++ b/etc/config
@@ -1,7 +1,7 @@
 :site:
   :host:
   :domain:
-  :ssl: false
+  :ssl:
   # NOTE Once the secret is set, do not change it (keep a backup offsite)
   :secret: 
 :redis:

--- a/etc/config
+++ b/etc/config
@@ -1,11 +1,11 @@
 :site:
-  :host: localhost:7143
-  :domain: localhost
+  :host:
+  :domain:
   :ssl: false
   # NOTE Once the secret is set, do not change it (keep a backup offsite)
-  :secret: CHANGEME
+  :secret: 
 :redis:
-  :uri: 'redis://user:CHANGEME@127.0.0.1:7179/0?timeout=10&thread_safe=false&logging=false'
+  :uri: 'redis://redis:6379/0?timeout=10&thread_safe=false&logging=false'
   :config: /etc/onetime/redis.conf
 :colonels:
   - CHANGEME@EXAMPLE.com
@@ -72,4 +72,3 @@
 #    - - basic_v1
 #      - professional_v2
 #      - agency_v2
-


### PR DESCRIPTION
Ref: JIRA SYS-1346

Update the container such that true/false values can be injected into the ssl portion of the config file.  This should prevent us from hosting a service that stores secrets securely but then sends them to you over plaintext http when you view them.