### PR TITLE
Correct instructions in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ When you send people sensitive info like passwords and private links via email o
     $ sudo chown ots /var/log/onetime /var/run/onetime /var/lib/onetime
     $ mkdir /etc/onetime
     $ cp -R etc/* /etc/onetime/
-    $ [secure the /etc/onetime directory to prevent unauthorized access]
+    $ [secure the /etc/onetime and /var/lib/onetime directory to prevent unauthorized access]
     $ [edit settings in /etc/onetime/config]
     $ [edit settings in /etc/onetime/redis.conf]
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ Upgrading to 0.9 should be seemless, however b/c of new functionality you will n
     :locales:
       - en
       - es
+      - de
+      - nl
 
 You run your configuration from `/etc/onetime/config` you will also need to copy the `./etc/locale` directory to `/etc/onetime/locale`:
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ When you send people sensitive info like passwords and private links via email o
     # DEBIAN
     $ sudo apt-get update
     $ sudo apt-get install build-essential
-    $ sudo apt-get install ntp libyaml-dev libevent-dev zlib1g zlib1g-dev openssl libssl-dev libxml2 libreadline5-dev
+    $ sudo apt-get install ntp libyaml-dev libevent-dev zlib1g zlib1g-dev openssl libssl-dev libxml2 libreadline-gplv2-dev
     $ mkdir ~/sources
 
     # CENTOS
@@ -66,7 +66,9 @@ When you send people sensitive info like passwords and private links via email o
     $ bin/ots init
     $ sudo mkdir /var/log/onetime /var/run/onetime /var/lib/onetime
     $ sudo chown ots /var/log/onetime /var/run/onetime /var/lib/onetime
-    $ cp etc/* /etc/onetime/
+    $ mkdir /etc/onetime
+    $ cp -R etc/* /etc/onetime/
+    $ [secure the /etc/onetime directory to prevent unauthorized access]
     $ [edit settings in /etc/onetime/config]
     $ [edit settings in /etc/onetime/redis.conf]
 


### PR DESCRIPTION
1. Fixes https://github.com/onetimesecret/onetimesecret/issues/30
2. Adds one missing `mkdir`
3. Fixes  `cp` command to copy all files (otherwise the `locale` dir would be missing)
4. Adds note to remind user to secure the config directory (it contains passwords and other secrets!)
5. Update the language config suggestion