### PR TITLE
Added Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM ruby:2.3.1
+
+#
+# Make sure to edit etc/config in this repo prior to building this container.
+#
+
+RUN \
+  apt-get update -qq && \
+  apt-get install -y \
+  build-essential \
+  ntp \
+  libevent-dev \
+  zlib1g \
+  zlib1g-dev \
+  openssl \
+  libreadline-gplv2-dev
+
+ENV APP_HOME /app
+RUN mkdir $APP_HOME
+ADD . $APP_HOME
+WORKDIR $APP_HOME
+
+RUN bundle install --deployment --without dev
+
+ENV PORT=7143
+EXPOSE $PORT
+CMD bundle exec thin -R config.ru -p $PORT -a 0.0.0.0 start

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,7 +19,7 @@ GEM
     docile (1.1.0)
     drydock (0.6.9)
     encryptor (1.1.3)
-    eventmachine (1.0.3)
+    eventmachine (1.2.0.1)
     familia (0.7.1)
       gibbler (>= 0.8.6)
       multi_json (>= 0.0.5)

--- a/config.ru
+++ b/config.ru
@@ -48,5 +48,8 @@ else
   apps.each_pair do |path,app|
     map(path) { run app }
   end
+  ['img', 'css', 'js'].each do |s|
+    map("/"+s+"/") { run Rack::File.new("#{PUBLIC_DIR}/"+s) }
+  end
   #$SAFE = 1  # http://www.rubycentral.com/pickaxe/taint.html
 end


### PR DESCRIPTION
Added default Dockerfile for onetimesecret.

There is one piece of this PR that you will not like and I don't like either, but I left it in so that we could talk about how to solve this.

Why I am referring to is this block of code in the prod section of `config.ru`:

``` ruby
['img', 'css', 'js'].each do |s|
  map("/"+s+"/") { run Rack::File.new("#{PUBLIC_DIR}/"+s) }
end
```

By default, it does not seem that `public/web/` is route-able within the production Rack config.

What am I doing wrong here? I feel like I am missing something obvious.
