### PR TITLE
Bump eventmachine version to work with Ruby 2.2.*

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,7 +19,7 @@ GEM
     docile (1.1.0)
     drydock (0.6.9)
     encryptor (1.1.3)
-    eventmachine (1.0.3)
+    eventmachine (1.2.0.1)
     familia (0.7.1)
       gibbler (>= 0.8.6)
       multi_json (>= 0.0.5)
@@ -109,4 +109,4 @@ DEPENDENCIES
   yajl-ruby (= 1.1.0)
 
 BUNDLED WITH
-   1.10.2
+   1.13.5


### PR DESCRIPTION
The current version of eventmachine is 1.0.3, which has known build problems with Ruby 2.2.0-dev and greater: https://github.com/eventmachine/eventmachine/issues/495

Bumping the version to at least 1.0.4 fixes the problem, but I went ahead and bumped up to the latest stable. Let me know if you'd like to just take the patch version bump, or go about this in a different way.