### PR TITLE
Typo Fix

### DIFF
--- a/templates/web/docs/api/secrets.mustache
+++ b/templates/web/docs/api/secrets.mustache
@@ -164,7 +164,7 @@
       <span class="docSubtext">POST {{baseuri}}/api/v1/private/METADATA_KEY/burn</span>
 
       <p>
-        Burn a secren that has not been read yet.
+        Burn a secret that has not been read yet.
       </p>
 
       <div class="options">


### PR DESCRIPTION
'secren' -> 'secret'