### PR TITLE
Package with Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.git
+
+.bundle
+log
+tmp
+.rudy
+
+.ruby-version
+
+.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,46 @@
+# To use this image, you need a Redis database with persistence enabled.
+# You can start one with Docker using i.e.:
+#
+# $ docker run -p 6379:6379 -d redis
+#
+# Then start this image, specifying the URL of the redis database:
+#
+# $ docker run -p 3000:3000 -d \
+#     -e ONETIMESECRET_REDIS_URL="redis://172.17.0.1:6379/0" \
+#     onetimesecret
+#
+# It will be accessible on http://localhost:3000.
+#
+# Production deployment
+# ---------------------
+#
+# When deploying to production, you should protect your Redis instance
+# with authentication or Redis networks. You should also enable
+# persistence and save the data somewhere, to make sure it doesn't get
+# lost when the server restarts.
+#
+# You should also change the secret to something else, and specify the
+# domain it will be deployed on.
+# For instance, if OTS will be accessible from https://example.com:
+#
+# $ docker run -p 3000:3000 -d \
+#     -e ONETIMESECRET_REDIS_URL="redis://user:password@host:port/0" \
+#     -e ONETIMESECRET_SSL=true -e ONETIMESECRET_HOST=example.com \
+#     -e ONETIMESECRET_SECRET="<put your own secret here>" \
+#     onetimesecret
+
+FROM ruby:2.3
+
+WORKDIR /usr/src/app
+COPY Gemfile Gemfile.lock ./
+RUN bundle install --frozen --deployment --without=dev
+COPY . .
+CMD ["bundle", "exec", "thin", "-R", "config.ru", "start"]
+
+EXPOSE 3000
+ENV RACK_ENV prod
+ENV ONETIMESECRET_SSL=false \
+    ONETIMESECRET_HOST=localhost:3000 \
+    ONETIMESECRET_SECRET=CHANGEME \
+    ONETIMESECRET_REDIS_URL= \
+    ONETIMESECRET_COLONEL=

--- a/config.ru
+++ b/config.ru
@@ -5,6 +5,8 @@
 #     $ thin -e dev -R config.ru -p 7143 start
 #     $ tail -f /var/log/system.log
 
+$stdout.sync = true
+
 ENV['RACK_ENV'] ||= 'prod'
 ENV['APP_ROOT'] = ::File.expand_path(::File.join(::File.dirname(__FILE__)))
 $:.unshift(::File.join(ENV['APP_ROOT']))
@@ -43,6 +45,7 @@ if Otto.env?(:dev)
 else
   # PROD: run barebones webapps
   apps.each_pair do |path,app|
+    app.option[:public] = PUBLIC_DIR
     map(path) { run app }
   end
   #$SAFE = 1  # http://www.rubycentral.com/pickaxe/taint.html

--- a/etc/config
+++ b/etc/config
@@ -1,16 +1,16 @@
 :site:
-  :host: localhost:7143
+  :host: <%= ENV['ONETIMESECRET_HOST'] || 'localhost:7143' %>
   :domain: localhost
-  :ssl: false
+  :ssl: <%= ENV['ONETIMESECRET_SSL'] == 'true' %>
   # NOTE Once the secret is set, do not change it (keep a backup offsite)
-  :secret: CHANGEME
+  :secret: <%= ENV['ONETIMESECRET_SECRET'] || 'CHANGEME' %>
 :redis:
-  :uri: 'redis://user:CHANGEME@127.0.0.1:7179/0?timeout=10&thread_safe=false&logging=false'
+  :uri: <%= (ENV['ONETIMESECRET_REDIS_URL'] || 'redis://user:CHANGEME@127.0.0.1:7179/0') + '?timeout=10&thread_safe=false&logging=false' %>
   :config: /etc/onetime/redis.conf
 :colonels:
   # Accounts created with the following email addresses
   # are automatically considered admins of the system.
-  - CHANGEME@EXAMPLE.com
+  - <%= ENV['ONETIMESECRET_COLONEL'] || 'CHANGEME@EXAMPLE.com' %>
 :emailer:
   :mode: :sendgrid
   :account: CHANGEME

--- a/lib/onetime.rb
+++ b/lib/onetime.rb
@@ -4,6 +4,7 @@ require 'bundler/setup'
 
 require 'onetime/core_ext'
 
+require 'erb'
 require 'syslog'
 
 require 'encryptor'
@@ -135,7 +136,7 @@ module Onetime
     attr_reader :env, :base, :bootstrap
     def load path=self.path
       raise ArgumentError, "Bad path (#{path})" unless File.readable?(path)
-      YAML.load_file path
+      YAML.load(ERB.new(File.read(path)).result)
     rescue => ex
       SYSLOG.err ex.message
       msg = path =~ /locale/ ?


### PR DESCRIPTION
This PR adds `.dockerignore` and `Dockerfile` to allow it to be deployed with Docker. The Dockerfile contains instructions & examples of use.

This Dockerfile contains many improvements with respect to #110, see https://github.com/onetimesecret/onetimesecret/pull/110#issuecomment-710808082.

To allow the application to run correctly under docker, some extra changes have been made:
 - Allow the application to be configured by environment variables too (this is how Docker usually works)
 - `config.ru`: Set stdout to be always unbuffered (so logs appear immediately). This is useful for both Docker and other environments.
 - `config.ru`: Set `PUBLIC_DIR` in production environment too, otherwise `public` files are not served.

If you don't like those changes, tell me and I'll find a workaround.