### PR TITLE
Update Gemfile.lock to match current Gemfile

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,11 +14,11 @@ GEM
     bcrypt-ruby (3.0.0)
     builder (3.2.2)
     caesars (0.7.4)
-    daemons (1.2.4)
+    daemons (1.4.1)
     docile (1.1.5)
     drydock (0.6.9)
     encryptor (1.1.3)
-    eventmachine (1.2.0.1)
+    eventmachine (1.2.7)
     familia (0.7.1)
       gibbler (>= 0.8.6)
       multi_json (>= 0.0.5)
@@ -75,10 +75,10 @@ GEM
     sysinfo (0.7.3)
       drydock
       storable
-    thin (1.5.0)
-      daemons (>= 1.0.9)
-      eventmachine (>= 0.12.6)
-      rack (>= 1.0.0)
+    thin (1.8.0)
+      daemons (~> 1.0, >= 1.0.9)
+      eventmachine (~> 1.0, >= 1.0.4)
+      rack (>= 1, < 3)
     treetop (1.4.15)
       polyglot
       polyglot (>= 0.3.1)
@@ -106,7 +106,7 @@ DEPENDENCIES
   rudy (= 0.9.8.020)
   storable (= 0.8.9)
   sysinfo (= 0.7.3)
-  thin (= 1.5.0)
+  thin (= 1.8.0)
   yajl-ruby (= 1.4.1)
 
 BUNDLED WITH


### PR DESCRIPTION
They got out-of-sync in e4db6265d984cb98fc2bd111de77846b85e4c8c1

This means trying to `bundle install --deployment` (like in the
Dockerfile) fails with this message:

~~~
You are trying to install in deployment mode after changing
your Gemfile. Run `bundle install` elsewhere and add the
updated Gemfile.lock to version control.

The dependencies in your gemfile changed

You have added to the Gemfile:
* thin (= 1.8.0)

You have deleted from the Gemfile:
* thin (= 1.5.0)
~~~

Fixes #160