### PR TITLE
Added autofocus to secret textarea

### DIFF
--- a/public/web/v3.html
+++ b/public/web/v3.html
@@ -149,7 +149,7 @@
     <p class="lead">Keep sensitive info out of your email and chat logs.</p>
     <form id="createSecret">
       <fieldset>
-        <textarea rows="7" class="btn-block" placeholder=""></textarea>
+        <textarea autofocus rows="7" class="btn-block" placeholder=""></textarea>
         <button class="btn btn-large btn-block btn-custom cufon" type="submit">Create a secret link*</button>
       </fieldset>
     </form>


### PR DESCRIPTION
I use onetimesecret almost daily for work, often using ctrl+t to open a new tab, type o and then press enter for it to autofill and take me to onetimesecret. Adding autofocus means once the page loads, if you type it will already be inputting the content into the secret, saving time clicking :)