### PR TITLE
Add operating system packages upgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,10 @@ ARG PACKAGES="build-essential autoconf m4 sudo"
 # Fast fail on errors while installing system packages
 RUN set -eux && \
     apt-get update && \
-    apt-get install -y $PACKAGES
+    apt-get upgrade -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" && \
+    apt-get install -y $PACKAGES && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN gem update --system
 RUN gem install bundler


### PR DESCRIPTION
This adds the OS packages upgrade. Onetime Secret seems to be compatible with Ruby 2.6 at best, and the ruby:2.6-slim upstream image is currently based on an outdated Debian image.