### PR TITLE
Fix UX issue for expired secrets (#276)

### DIFF
--- a/lib/onetime/logic.rb
+++ b/lib/onetime/logic.rb
@@ -204,7 +204,7 @@ module Onetime
       end
 
       def success?
-        !cust.nil? && !cust.anonymous? && (cust.passphrase?(@passwd) || @colonel.passphrase?(@passwd))
+        !cust.nil? && !cust.anonymous? && (cust.passphrase?(@passwd) || (!@colonel.nil? && @colonel.passphrase?(@passwd)))
       end
 
       private

--- a/templates/web/footer.mustache
+++ b/templates/web/footer.mustache
@@ -60,4 +60,3 @@
 <!-- {{via_hn}}:{{via_test}}:{{via_reddit}} -->
 </body>
 </html>
-

--- a/templates/web/unknown_secret.mustache
+++ b/templates/web/unknown_secret.mustache
@@ -1,21 +1,162 @@
-{{>header}}
 
-  <div class="row-fluid">
-    <div class="span12">
-      <h3 class="cufon">Unknown Secret</h3>
+<!DOCTYPE html>
+<!--[if lt IE 7]>      <html class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
+<!--[if IE 7]>         <html class="no-js lt-ie9 lt-ie8"> <![endif]-->
+<!--[if IE 8]>         <html class="no-js lt-ie9"> <![endif]-->
+<!--[if gt IE 8]><!--> <html class="no-js"> <!--<![endif]-->
+<head>
+  <meta charset="utf-8">
+  <meta name="referrer" content="no-referrer">
+  <link rel="shortcut icon" type="image/png" href="/img/favicon.png">
+  {{#no_cache}}
+  <meta http-equiv="pragma" content="no-cache">
+  <meta http-equiv="expires" content="-1">
+  {{/no_cache}}
+  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+  <title>{{title}} - {{subtitle}}</title>
+  <meta name="description" content="{{description}}">
+  <meta name="keywords" content="{{keywords}}">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <link rel="stylesheet" href="/css/bootstrap.min.css">
+  <style type="text/css">
+    body {
+      padding-top: 0px;
+      font-family: georgia,serif;
+    }
+    h3.text-muted {
+      opacity: 80%;
+      color: #333;
+    }
+    .tagline a {
+      opacity: 50%
+    }
+    .container-narrow {
+      margin: 0 auto;
+      max-width: 640px;
+    }
+    .container-narrow > hr {
+      margin: 30px 0;
+    }
+    .masthead {
+      color: #ccc;
+    }
+    .masthead .nav {
+      margin-top: 24px;
+      padding: 0px;
+    }
+    .muted-image {
+      filter: grayscale(70%);
+      opacity: 0.5;
+    }
+    #logo {
+      background-image: url('/img/logo-48.png');
+      display: inline-block;
+      width: 48px;
+      height: 48px;
+    }
+    #coremessage {
+      margin-top: 10%;
+      margin-bottom: 30%;
+    }
+    #coremessage p {
+      margin-top: 10%;
+    }
+    @media (min-width: 481px) {
+      #contentTab {
+        margin-top: 20px;
+      }
+    }
+    @media (max-width: 480px) {
+      #logo {
+        background-image: url('/img/logo-36.png');
+        display: inline-block;
+        width: 36px;
+        height: 36px;
+      }
+      .masthead .nav {
+        margin-top: 18px;
+        padding: 0px;
+      }
+    }
+  </style>
+  <script src="/js/vendor/cufon-yui.js" type="text/javascript"></script>
+  <script src="/js/vendor/officina.font.js" type="text/javascript"></script>
+  <link href="/css/bootstrap-responsive.min.css" rel="stylesheet" >
+  <link href="/css/alertify.css" rel="stylesheet">
+  <link href="/css/main.css?{{ot_version_id}}" rel="stylesheet">
+  {{#css}}
+  <link href="{{to_s}}" media="screen" rel="Stylesheet" type="text/css" />
+  {{/css}}
+  <script type="text/javascript">
+  {{#jsvars}}
+    var {{name}} = {{{value}}};
+  {{/jsvars}}
+  </script>
+  <script src="/js/vendor/jquery-3.6.0.min.js"></script>
 
-      <div class="alert">
-        <button type="button" class="close" data-dismiss="alert">&times;</button>
-        It either never existed or has already been viewed.
-      </div>
+</head>
+<body id="{{body_class}}">
+<div id="banner"><div class="broadcast">{{{i18n.COMMON.broadcast}}}</div></div>
+<div class="container-narrow">
+
+  <div class="masthead">
+    <div class="nav pull-right">
+    {{#display_masthead}}
+
+      {{^authenticated}}
+      {{/authenticated}}
+
+      {{#authenticated}}
+        <a href="/" class="home">{{cust.custid}}</a> {{#colonel}}<a href="{{baseotsuri}}/colonel/" title="" class="nounderline">*</a>{{/colonel}} |
+        <a href="{{baseotsuri}}/account" title="Your Account">{{i18n.COMMON.header_dashboard}}</a> |
+        <a href="{{baseotsuri}}/logout" title="Log out of One-Time Secret">{{i18n.COMMON.header_logout}}</a>
+      {{/authenticated}}
+
+      {{^is_default_locale}}
+      | <a href="?locale={{i18n.default}}" title="View site in {{i18n.default}}">{{i18n.default}}</a>
+      {{/is_default_locale}}
+
+    {{/display_masthead}}
 
     </div>
+    <a href="{{baseotsuri}}/"><h3 id="logo" class="muted-image"></h3></a>
   </div>
 
-  <div class="row-fluid">
-    <div class="span12">
-      <a class="btn btn-large btn-block btn-custom cufon" href="/" class="">Share a secret of your own</a>
+{{! HEADER END }}
+
+<div id="coremessage" class="row-fluid">
+    <div class="span1"></div>
+    <div class="span10 text-muted italic">
+        <div class="alert alert-info">
+          <h4>That information is no longer available. 😩</h4>
+        </div>
+        <p>
+          <strong>Please follow-up with the person that sent you this link.</strong>
+        </p>
     </div>
-  </div>
+    <div class="span1"></div>
+</div>
 
-{{>footer}}
+{{! FOOTER START }}
+
+<hr/>
+
+<div id="footer" class="mt-5">
+    <div class="tagline">
+        <p><a href="{{baseotsuri}}/" title="Go to our homepage">
+            {{baseotsuri}}
+        </a></p>
+    </div>
+</div>
+
+</div> <!-- /container -->
+
+<script src="/js/vendor/bootstrap.min.js"></script>
+<script src="/js/plugins.js?{{ot_version_id}}"></script>
+<script src="/js/main.js?{{ot_version_id}}"></script>
+{{#js}}
+<script src="{{to_s}}" type="text/javascript"></script>
+{{/js}}
+
+</body>
+</html>


### PR DESCRIPTION
Fixes #276.

This pull request fixes a critical UX issue for inexperienced users. Currently, when a secret is expired, the feedback message is muted and the "Share a secret of your own" button is dominant. This can confuse users and lead them to create a new secret instead of accessing the expired one. The proposed fix ensures that the page for viewing a secret always has a terminal state design, clearly indicating that the secret has expired. This will prevent users from mistakenly creating a new secret and guide them to the correct action. 

Big thanks to @shakiba for raising this up. 

### Context

With these changes:

![No such secret - One Time · 11 49 · 04-06](https://github.com/onetimesecret/onetimesecret/assets/1206/ab434dab-a707-433b-a988-81f716e99e90)


#### Before

![No such secret - One Time · 11 48 · 04-06](https://github.com/onetimesecret/onetimesecret/assets/1206/8aedca64-873a-4f3c-b58a-cf57084f1cff)
