### PR TITLE
feat: adding renovate.json for renovatebot

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    "docker:pinDigests",
+    "helpers:pinGitHubActionDigests",
+    ":pinDevDependencies"
+  ],
+  "separateMinorPatch": true,
+  "separateMultipleMajor": true,
+  "separateMultipleMinor": true,
+  "labels": [
+    "auto-update"
+  ],
+  "recreateWhen": "always",
+  "forkProcessing": "enabled",
+  "timezone": "America/Los_Angeles",
+  "schedule": [
+    "before 6am"
+  ]
+}


### PR DESCRIPTION
Merge this PR and then install: https://github.com/apps/renovate and once a day this will run and generate PR's. But if you want to disregard updates entirely [just remove line 15](https://github.com/venkatamutyala/onetimesecret/blob/develop/renovate.json#L15) and the default behavior should not re-open. 

I keep it as `always` so I repeatedly get reminded to eventually upgrade to the newer/latest version.

To uninstall just remove it using one of these links:
If you are using an org: https://github.com/organizations/onetimesecret/settings/installations
If you are using a personal account: https://github.com/settings/installations (obviously you would want to be logged into the onetimesecret user)

Here is an example of what it's like in my account: https://github.com/venkatamutyala/onetimesecret/issues/1
That issue will be created by renovatebot and it'll persist indefinitely. As you can see there are a lot of updates. It also lets you see all the updatable versions for many packages so rather then going to the very latest you can check the box for the PR/version you want to have created. 

Closes: https://github.com/onetimesecret/onetimesecret/issues/305