### PR TITLE
Update otsgo client library

### DIFF
--- a/public/web/404.html
+++ b/public/web/404.html
@@ -171,29 +171,17 @@
       <a href="/info/privacy">Privacy</a> |
       <a href="/info/terms">Terms &amp; Conditions</a> |
       <a href="/contributor">Contributors</a> |
+      <a href="https://status.onetimesecret.com/">Status</a> |
       <a href="/info/security">Security</a>
     </p>
-    <div class="tagline">
-      Follow our latest news:
-      <p>
-        <a href="https://www.facebook.com/pages/One-Time-Secret/284990691536190" title="Join us on Facebook"><img class="socialicon" src="/img/icon-facebook.png" height="16" width="16" alt="facebook icon" /></a>
-        <a href="https://twitter.com/onetimesecret" title="Join us on Twitter"><img class="socialicon" src="/img/icon-twitter.png" height="16" width="16" alt="twitter icon" /></a>
-      </p>
-      <p class="release"></p>
-    </div>
 
   </div>
 
 </div> <!-- /container -->
 
 <script src="/js/vendor/bootstrap.min.js"></script>
-
 <script src="/js/plugins.js?a62900a4"></script>
 <script src="/js/main.js?a62900a4"></script>
-<script type="text/javascript">
-  //$('.jumbotron h1').removeClass('temp-kerning');
-  //Cufon.refresh();
-</script>
 
 </body>
 </html>

--- a/public/web/maintenance.html
+++ b/public/web/maintenance.html
@@ -166,29 +166,16 @@
       <a href="/info/privacy">Privacy</a> |
       <a href="/info/terms">Terms &amp; Conditions</a> |
       <a href="/contributor">Contributors</a> |
+      <a href="https://status.onetimesecret.com/">Status</a> |
       <a href="/info/security">Security</a>
     </p>
-    <div class="tagline">
-      Follow our latest news:
-      <p>
-        <a href="https://www.facebook.com/pages/One-Time-Secret/284990691536190" title="Join us on Facebook"><img class="socialicon" src="/img/icon-facebook.png" height="16" width="16" alt="facebook icon" /></a>
-        <a href="https://twitter.com/onetimesecret" title="Join us on Twitter"><img class="socialicon" src="/img/icon-twitter.png" height="16" width="16" alt="twitter icon" /></a>
-      </p>
-      <p class="release"></p>
-    </div>
-
   </div>
 
 </div> <!-- /container -->
 
 <script src="/js/vendor/bootstrap.min.js"></script>
-
 <script src="/js/plugins.js?a62900a4"></script>
 <script src="/js/main.js?a62900a4"></script>
-<script type="text/javascript">
-  //$('.jumbotron h1').removeClass('temp-kerning');
-  //Cufon.refresh();
-</script>
 
 </body>
 </html>

--- a/templates/web/docs/api/libs.mustache
+++ b/templates/web/docs/api/libs.mustache
@@ -22,33 +22,37 @@
       <h4>Usage Example</h4>
       <pre class="colourize">
 &lt;?php
-  include('onetime-api.php');
-  $myOnetime = new OneTimeSecret;
+  include 'onetime-api.php';
+
+  $myOnetime = new OneTimeSecret();
   $myOnetime->setCustomerID('YOUR_EMAIL');
   $myOnetime->setToken('YOUR_OTS_APIKEY');
   $myOnetime->setRecipient('delano@onetimesecret.com');
   $myOnetime->setTTL(7200);
   $myResult = $myOnetime->shareSecret('Jazz, jazz and more jazz.', 'thepassword');
-  print $myOnetime->getSecretURI($myResult);
+  echo $myOnetime->getSecretURI($myResult);
 ?&gt;
       </pre>
 
       <h3 class="cufon docTitle dotted">Ruby</h3>
 
       <a href="https://github.com/onetimesecret/onetime-ruby" title="Ruby library - One-Time Secret"><strong>Download onetime-api.rb</strong></a><br/>
-      <em>by <a href="http://delanotes.com/">Delano Mandelbaum</a> (added 2011-12-21)</em>
+      <em>by <a href="http://delanotes.com/">Delano Mandelbaum</a> (updated 2024-06-09)</em>
 
       <h4>Usage Example</h4>
       <pre class="colourize">
 require 'onetime/api'
-api = Onetime::API.new 'YOUR_EMAIL', 'YOUR_OTS_APIKEY'
+
+api = Onetime::API.new('YOUR_EMAIL', 'YOUR_OTS_APIKEY')
 options = {
-  :secret => 'Jazz, jazz and more jazz.',
-  :recipient => 'delano@onetimesecret.com',
-  :ttl => 7200
+  secret: 'Jazz, jazz and more jazz.',
+  recipient: 'delano@onetimesecret.com',
+  ttl: 7200
 }
-ret = api.post '/share', options
+
+ret = api.post('/share', options)
 puts ret['secret_key']
+
       </pre>
 
       <h3 class="cufon docTitle dotted">Python</h3>
@@ -279,7 +283,7 @@ URL=$(echo "secret" | ots_share)
 
 # share a multi line secret via HEREDOC.
 URL=$(ots_share <<-EOF
-	This is a Secret
+      This is a Secret
     ... on multiple lines
 EOF
 )

--- a/templates/web/docs/api/libs.mustache
+++ b/templates/web/docs/api/libs.mustache
@@ -380,21 +380,48 @@ fmt.Println(response.Status)
 
       <h4>Usage Example as Scripting API</h4>
       <pre class="colourize">
-$ ots share -h
-Share or generate a random secret
+# source for use anonymously (secrets created anonymously)
+source ots.bash
 
-Usage:
-  ots share [flags]
+# or, source with specific auth credentials
+APIUSER="USERNAME"
+APIKEY="APIKEY"
+source ots.bash -u $APIUSER -k $APIKEY
 
-Flags:
-  -f, --from-stdin          Read from stdin
-  -g, --generate            Generate a short, unique secret. This is useful for temporary passwords, one-time pads, salts, etc.
-  -h, --help                help for share
-  -p, --passphrase string   a string that the recipient must know to view the secret. This value is also used to encrypt the secret and is bcrypted before being stored so we only have this value in transit.
-  -r, --recipient string    an email address. We will send a friendly email containing the secret link (NOT the secret itself).
-  -s, --secret string       the secret value which is encrypted before being stored. There is a maximum length based on your plan that is enforced (1k-10k)
-  -t, --ttl int             the maximum amount of time, in seconds, that the secret should survive (i.e. time-to-live). Once this time expires, the secret will be deleted and not recoverable. (default 604800)
+# check status of server
+ots_status
 
+# create a secret and get back the URL
+URL=$(echo "secret" | ots_share)
+
+# share a multi line secret via HEREDOC.
+URL=$(ots_share <<-EOF
+      This is a Secret
+      ... on multiple lines
+EOF
+)
+
+# pass options to share or generate.
+URL=$(ots_share ttl=600 \
+                  passphrase="shared-secret" \
+                  recipient="someone@somewhere.com" <<< "SECRET")
+
+# fetch the secret data
+local DATA="$(ots_retrieve "$URL")"
+
+# share/generate a new secret, and get back the private metadata key
+local KEY=$(ots_metashare <<< "SECRET")
+local KEY=$(ots_metagenerate)
+
+# get a list of private metadata keys recently created.
+# note that this requires valid autnentication credentials
+local -a RECENT=( $(ots_recent) )
+
+# check on the current state of a secret, given the private key
+ots_state $KEY
+
+# burn a secret, given the private key
+ots_burn $KEY
       </pre>
 
       <h4>Usage Example as CLI</h4>

--- a/templates/web/docs/api/libs.mustache
+++ b/templates/web/docs/api/libs.mustache
@@ -7,17 +7,29 @@
     <ul id="docnav">
       <li class=""><a href="/docs/api" title="">Overview</a></li>
       <li class=""><a href="/docs/api/secrets" title="">Secrets</a></li>
-      <li class="selected"><a href="/docs/api/libs" title="">Client Libraries</a></li>
+      <li class="selected">
+        <a href="/docs/api/libs" title="">Client Libraries</a>
+      </li>
     </ul>
 
-    <p class="centre"><em class="larger">BETA API - updated 2017-04-27 (<a href="/feedback">Have a question?</a>)</em></p>
+    <p class="centre">
+      <em class="larger"
+        >BETA API - updated 2017-04-27 (<a href="/feedback">Have a question?</a
+        >)</em
+      >
+    </p>
 
     <div id="topicContent">
-
       <h3 class="cufon docTitle dotted">PHP</h3>
 
-      <a href="/libs/onetime-api.php" title="PHP library - One-Time Secret"><strong>Download onetime-api.php</strong></a><br/>
-      <em>by <a href="http://christopher.murtagh.name/">Christopher Murtagh</a> (added 2011-12-21)</em>
+      <a href="/libs/onetime-api.php" title="PHP library - One-Time Secret"
+        ><strong>Download onetime-api.php</strong></a
+      ><br />
+      <em
+        >by
+        <a href="http://christopher.murtagh.name/">Christopher Murtagh</a>
+        (added 2011-12-21)</em
+      >
 
       <h4>Usage Example</h4>
       <pre class="colourize">
@@ -36,8 +48,15 @@
 
       <h3 class="cufon docTitle dotted">Ruby</h3>
 
-      <a href="https://github.com/onetimesecret/onetime-ruby" title="Ruby library - One-Time Secret"><strong>Download onetime-api.rb</strong></a><br/>
-      <em>by <a href="http://delanotes.com/">Delano Mandelbaum</a> (updated 2024-06-09)</em>
+      <a
+        href="https://github.com/onetimesecret/onetime-ruby"
+        title="Ruby library - One-Time Secret"
+        ><strong>Download onetime-api.rb</strong></a
+      ><br />
+      <em
+        >by <a href="http://delanotes.com/">Delano Mandelbaum</a> (updated
+        2024-06-09)</em
+      >
 
       <h4>Usage Example</h4>
       <pre class="colourize">
@@ -57,8 +76,15 @@ puts ret['secret_key']
 
       <h3 class="cufon docTitle dotted">Python</h3>
 
-      <a href="https://github.com/slashpass/onetimesecret-cli" title="Python library - OneTimeSecretCli"><strong>Github</strong></a><br/>
-      <em>by <a href="https://github.com/slashpass">slashpass</a> (added 2021-07-08)</em>
+      <a
+        href="https://github.com/slashpass/onetimesecret-cli"
+        title="Python library - OneTimeSecretCli"
+        ><strong>Github</strong></a
+      ><br />
+      <em
+        >by <a href="https://github.com/slashpass">slashpass</a> (added
+        2021-07-08)</em
+      >
 
       <h4>Usage Example</h4>
       <pre class="colourize">
@@ -68,9 +94,16 @@ cli = OneTimeSecretCli(ONETIMESECRET_USER, ONETIMESECRET_KEY)
 cli.create_link("secret") # return a link like https://onetimesecret.com/secret/xxxxxxxxxxx
       </pre>
 
-
-      <a href="https://github.com/utter-step/py_onetimesecret" title="Python library - One-Time Secret"><strong>Download onetimesecret.py</strong></a><br/>
-      <em>by <a href="https://github.com/utter-step/">Vladislav Stepanov</a> (added 2012-06-26)</em>
+      <a
+        href="https://github.com/utter-step/py_onetimesecret"
+        title="Python library - One-Time Secret"
+        ><strong>Download onetimesecret.py</strong></a
+      ><br />
+      <em
+        >by
+        <a href="https://github.com/utter-step/">Vladislav Stepanov</a> (added
+        2012-06-26)</em
+      >
 
       <h4>Usage Example</h4>
       <pre class="colourize">
@@ -84,11 +117,17 @@ print o.retrieve_secret(secret["secret_key"])
 # u'value': u'test'}
       </pre>
 
-
       <h3 class="cufon docTitle dotted">Perl</h3>
 
-      <a href="http://search.cpan.org/~kyled/Net-OneTimeSecret/lib/Net/OneTimeSecret.pm" title="Perl library - One-Time Secret"><strong>Download Net::OneTimeSecret</strong></a><br/>
-      <em>by <a href="http://www.shoffle.com/">Kyle Dawkins</a> (added 2012-01-06)</em>
+      <a
+        href="http://search.cpan.org/~kyled/Net-OneTimeSecret/lib/Net/OneTimeSecret.pm"
+        title="Perl library - One-Time Secret"
+        ><strong>Download Net::OneTimeSecret</strong></a
+      ><br />
+      <em
+        >by <a href="http://www.shoffle.com/">Kyle Dawkins</a> (added
+        2012-01-06)</em
+      >
 
       <h4>Usage Example</h4>
       <pre class="colourize">
@@ -114,8 +153,15 @@ printf( "%s\n", $secret->{value} );
 
       <h3 class="cufon docTitle dotted">Java</h3>
 
-      <a href="https://github.com/mpawlowski/onetime-java" title="Java library - One-Time Secret"><strong>Download onetime-java</strong></a><br/>
-      <em>by <a href="https://github.com/mpawlowski">Marcin Pawlowski</a> (added 2014-05-22)</em>
+      <a
+        href="https://github.com/mpawlowski/onetime-java"
+        title="Java library - One-Time Secret"
+        ><strong>Download onetime-java</strong></a
+      ><br />
+      <em
+        >by <a href="https://github.com/mpawlowski">Marcin Pawlowski</a> (added
+        2014-05-22)</em
+      >
 
       <h4>Usage Example</h4>
       <pre class="colourize">
@@ -140,8 +186,16 @@ assertEquals(generateResponse.getValue(), retrieveResponse.getValue());
 
       <h3 class="cufon docTitle dotted">C#</h3>
 
-      <a href="https://github.com/utter-step/OneTimeSharp" title="C# library - One-Time Secret"><strong>Download OneTimeSharp</strong></a><br/>
-      <em>by <a href="https://github.com/utter-step/">Vladislav Stepanov</a> (added 2014-05-29)</em>
+      <a
+        href="https://github.com/utter-step/OneTimeSharp"
+        title="C# library - One-Time Secret"
+        ><strong>Download OneTimeSharp</strong></a
+      ><br />
+      <em
+        >by
+        <a href="https://github.com/utter-step/">Vladislav Stepanov</a> (added
+        2014-05-29)</em
+      >
 
       <h4>Usage Example</h4>
       <pre class="colourize">
@@ -171,8 +225,15 @@ class Test
 
       <h3 class="cufon docTitle dotted">Go</h3>
 
-      <a href="https://github.com/corbaltcode/go-onetimesecret" title="Go library - One-Time Secret"><strong>Download onetimesecret</strong></a><br/>
-      <em>by <a href="https://github.com/corbaltcode/">Corbalt</a> (added 2021-12-10)</em>
+      <a
+        href="https://github.com/corbaltcode/go-onetimesecret"
+        title="Go library - One-Time Secret"
+        ><strong>Download onetimesecret</strong></a
+      ><br />
+      <em
+        >by <a href="https://github.com/corbaltcode/">Corbalt</a> (added
+        2021-12-10)</em
+      >
 
       <h4>Usage Example</h4>
       <pre class="colourize">
@@ -216,8 +277,15 @@ flsdlaun6hwczqu9utmc0vts5xj9xu1
 
       <h3 class="cufon docTitle dotted">PowerShell</h3>
 
-      <a href="https://github.com/chelnak/OneTimeSecret" title="PowerShell Module - OneTimeSecret"><strong>Download OneTimeSecret</strong></a><br/>
-      <em>by <a href="https://www.helloitscraig.co.uk">Craig Gumbley</a> (updated 2017-04-28)</em>
+      <a
+        href="https://github.com/chelnak/OneTimeSecret"
+        title="PowerShell Module - OneTimeSecret"
+        ><strong>Download OneTimeSecret</strong></a
+      ><br />
+      <em
+        >by <a href="https://www.helloitscraig.co.uk">Craig Gumbley</a> (updated
+        2017-04-28)</em
+      >
 
       <h4>Usage Example</h4>
       <pre class="colourize">
@@ -239,8 +307,15 @@ Get-Command -Module OneTimeSecret | Select Name
 
       <h3 class="cufon docTitle dotted">Go</h3>
 
-      <a href="https://github.com/chelnak/onetimesecret-go" title="Onetimesecret Go Client"><strong>Download OneTimeSecret-Go</strong></a><br/>
-      <em>by <a href="https://www.helloitscraig.co.uk">Craig Gumbley</a> (updated 2020-08-20)</em>
+      <a
+        href="https://github.com/chelnak/onetimesecret-go"
+        title="Onetimesecret Go Client"
+        ><strong>Download OneTimeSecret-Go</strong></a
+      ><br />
+      <em
+        >by <a href="https://www.helloitscraig.co.uk">Craig Gumbley</a> (updated
+        2020-08-20)</em
+      >
 
       <h4>Usage Example</h4>
       <pre class="colourize">
@@ -262,8 +337,15 @@ fmt.Println(response.Status)
 
       <h3 class="cufon docTitle dotted">Bash</h3>
 
-      <a href="https://github.com/eengstrom/onetimesecret-bash" title="Bash API and CLI - OneTimeSecret"><strong>Download OneTimeSecret-bash</strong></a><br/>
-      <em>by <a href="https://eengstrom.github.io/">Eric Engstrom</a> (updated 2018-12-19)</em>
+      <a
+        href="https://github.com/eengstrom/onetimesecret-bash"
+        title="Bash API and CLI - OneTimeSecret"
+        ><strong>Download OneTimeSecret-bash</strong></a
+      ><br />
+      <em
+        >by <a href="https://eengstrom.github.io/">Eric Engstrom</a> (updated
+        2018-12-19)</em
+      >
 
       <h4>Usage Example as Scripting API</h4>
       <pre class="colourize">
@@ -319,23 +401,28 @@ SECRET
 ^D
 
 # Share a secret (via HEREDOC)
-./ots share <<-EOF
-    This is a mulit-line secret via HEREDOC.
-    Somthing else goes here.
+./ots share &lt;&lt;-EOF
+      This is a mulit-line secret via HEREDOC.
+      Somthing else goes here.
 EOF
 
 # Get/Retrieve a secret:
-./ots get <key|url>
-./ots retrieve <key|url>
+./ots get &lt;key|url&gt;
+./ots retrieve &lt;key|url&gt;
 
 # Burn a secret:
-./ots burn <key|url>
+./ots burn &lt;key|url&gt;
 
 # Use --help for complete list of command line actions and known options:
 ./ots --help
       </pre>
 
-      <p><em class="msg">If you implement another language, let us know and we'll add it here!</em></p>
+      <p>
+        <em class="msg"
+          >If you implement another language, let us know and we'll add it
+          here!</em
+        >
+      </p>
     </div>
   </div>
 </div>

--- a/templates/web/docs/api/libs.mustache
+++ b/templates/web/docs/api/libs.mustache
@@ -79,7 +79,7 @@ puts ret['secret_key']
       <a
         href="https://github.com/slashpass/onetimesecret-cli"
         title="Python library - OneTimeSecretCli"
-        ><strong>Github</strong></a
+        ><strong>Github page - onetimesecret-cli</strong></a
       ><br />
       <em
         >by <a href="https://github.com/slashpass">slashpass</a> (added
@@ -97,7 +97,7 @@ cli.create_link("secret") # return a link like https://onetimesecret.com/secret/
       <a
         href="https://github.com/utter-step/py_onetimesecret"
         title="Python library - One-Time Secret"
-        ><strong>Download onetimesecret.py</strong></a
+        ><strong>Github page - py_onetimesecret</strong></a
       ><br />
       <em
         >by
@@ -122,7 +122,7 @@ print o.retrieve_secret(secret["secret_key"])
       <a
         href="http://search.cpan.org/~kyled/Net-OneTimeSecret/lib/Net/OneTimeSecret.pm"
         title="Perl library - One-Time Secret"
-        ><strong>Download Net::OneTimeSecret</strong></a
+        ><strong>Net::OneTimeSecret on CPAN</strong></a
       ><br />
       <em
         >by <a href="http://www.shoffle.com/">Kyle Dawkins</a> (added
@@ -156,7 +156,7 @@ printf( "%s\n", $secret->{value} );
       <a
         href="https://github.com/mpawlowski/onetime-java"
         title="Java library - One-Time Secret"
-        ><strong>Download onetime-java</strong></a
+        ><strong>Github page - onetime-java</strong></a
       ><br />
       <em
         >by <a href="https://github.com/mpawlowski">Marcin Pawlowski</a> (added
@@ -189,7 +189,7 @@ assertEquals(generateResponse.getValue(), retrieveResponse.getValue());
       <a
         href="https://github.com/utter-step/OneTimeSharp"
         title="C# library - One-Time Secret"
-        ><strong>Download OneTimeSharp</strong></a
+        ><strong>Github page - OneTimeSharp</strong></a
       ><br />
       <em
         >by
@@ -228,7 +228,7 @@ class Test
       <a
         href="https://github.com/corbaltcode/go-onetimesecret"
         title="Go library - One-Time Secret"
-        ><strong>Download onetimesecret</strong></a
+        ><strong>Github page - onetimesecret</strong></a
       ><br />
       <em
         >by <a href="https://github.com/corbaltcode/">Corbalt</a> (added
@@ -280,7 +280,7 @@ flsdlaun6hwczqu9utmc0vts5xj9xu1
       <a
         href="https://github.com/chelnak/OneTimeSecret"
         title="PowerShell Module - OneTimeSecret"
-        ><strong>Download OneTimeSecret</strong></a
+        ><strong>Github page - OneTimeSecret</strong></a
       ><br />
       <em
         >by <a href="https://www.helloitscraig.co.uk">Craig Gumbley</a> (updated
@@ -310,7 +310,7 @@ Get-Command -Module OneTimeSecret | Select Name
       <a
         href="https://github.com/chelnak/onetimesecret-go"
         title="Onetimesecret Go Client"
-        ><strong>Download OneTimeSecret-Go</strong></a
+        ><strong>Github page - OneTimeSecret-Go</strong></a
       ><br />
       <em
         >by <a href="https://www.helloitscraig.co.uk">Craig Gumbley</a> (updated
@@ -371,7 +371,7 @@ fmt.Println(response.Status)
       <a
         href="https://github.com/eengstrom/onetimesecret-bash"
         title="Bash API and CLI - OneTimeSecret"
-        ><strong>Download OneTimeSecret-bash</strong></a
+        ><strong>Github page - OneTimeSecret-bash</strong></a
       ><br />
       <em
         >by <a href="https://eengstrom.github.io/">Eric Engstrom</a> (updated
@@ -380,48 +380,21 @@ fmt.Println(response.Status)
 
       <h4>Usage Example as Scripting API</h4>
       <pre class="colourize">
-# source for use anonymously (secrets created anonymously)
-source ots.bash
+$ ots share -h
+Share or generate a random secret
 
-# or, source with specific auth credentials
-APIUSER="USERNAME"
-APIKEY="APIKEY"
-source ots.bash -u $APIUSER -k $APIKEY
+Usage:
+  ots share [flags]
 
-# check status of server
-ots_status
+Flags:
+  -f, --from-stdin          Read from stdin
+  -g, --generate            Generate a short, unique secret. This is useful for temporary passwords, one-time pads, salts, etc.
+  -h, --help                help for share
+  -p, --passphrase string   a string that the recipient must know to view the secret. This value is also used to encrypt the secret and is bcrypted before being stored so we only have this value in transit.
+  -r, --recipient string    an email address. We will send a friendly email containing the secret link (NOT the secret itself).
+  -s, --secret string       the secret value which is encrypted before being stored. There is a maximum length based on your plan that is enforced (1k-10k)
+  -t, --ttl int             the maximum amount of time, in seconds, that the secret should survive (i.e. time-to-live). Once this time expires, the secret will be deleted and not recoverable. (default 604800)
 
-# create a secret and get back the URL
-URL=$(echo "secret" | ots_share)
-
-# share a multi line secret via HEREDOC.
-URL=$(ots_share <<-EOF
-      This is a Secret
-    ... on multiple lines
-EOF
-)
-
-# pass options to share or generate.
-URL=$(ots_share ttl=600 \
-                passphrase="shared-secret" \
-                recipient="someone@somewhere.com" <<< "SECRET")
-
-# fetch the secret data
-local DATA="$(ots_retrieve "$URL")"
-
-# share/generate a new secret, and get back the private metadata key
-local KEY=$(ots_metashare <<< "SECRET")
-local KEY=$(ots_metagenerate)
-
-# get a list of private metadata keys recently created.
-# note that this requires valid autnentication credentials
-local -a RECENT=( $(ots_recent) )
-
-# check on the current state of a secret, given the private key
-ots_state $KEY
-
-# burn a secret, given the private key
-ots_burn $KEY
       </pre>
 
       <h4>Usage Example as CLI</h4>

--- a/templates/web/docs/api/libs.mustache
+++ b/templates/web/docs/api/libs.mustache
@@ -350,20 +350,20 @@ fmt.Println(response.Status)
 
       <h4>Usage Example</h4>
       <pre class="colourize">
-            $ ots share -h
-            Share or generate a random secret
+$ ots share -h
+Share or generate a random secret
 
-            Usage:
-              ots share [flags]
+Usage:
+      ots share [flags]
 
-            Flags:
-              -f, --from-stdin          Read from stdin
-              -g, --generate            Generate a short, unique secret. This is useful for temporary passwords, one-time pads, salts, etc.
-              -h, --help                help for share
-              -p, --passphrase string   a string that the recipient must know to view the secret. This value is also used to encrypt the secret and is bcrypted before being stored so we only have this value in transit.
-              -r, --recipient string    an email address. We will send a friendly email containing the secret link (NOT the secret itself).
-              -s, --secret string       the secret value which is encrypted before being stored. There is a maximum length based on your plan that is enforced (1k-10k)
-              -t, --ttl int             the maximum amount of time, in seconds, that the secret should survive (i.e. time-to-live). Once this time expires, the secret will be deleted and not recoverable. (default 604800)
+Flags:
+      -f, --from-stdin          Read from stdin
+      -g, --generate            Generate a short, unique secret. This is useful for temporary passwords, one-time pads, salts, etc.
+      -h, --help                help for share
+      -p, --passphrase string   a string that the recipient must know to view the secret. This value is also used to encrypt the secret and is bcrypted before being stored so we only have this value in transit.
+      -r, --recipient string    an email address. We will send a friendly email containing the secret link (NOT the secret itself).
+      -s, --secret string       the secret value which is encrypted before being stored. There is a maximum length based on your plan that is enforced (1k-10k)
+      -t, --ttl int             the maximum amount of time, in seconds, that the secret should survive (i.e. time-to-live). Once this time expires, the secret will be deleted and not recoverable. (default 604800)
 
       </pre>
       <h3 class="cufon docTitle dotted">Bash</h3>

--- a/templates/web/docs/api/libs.mustache
+++ b/templates/web/docs/api/libs.mustache
@@ -335,6 +335,37 @@ if err != nil {
 fmt.Println(response.Status)
       </pre>
 
+      <h3 class="docTitle dotted">Go (CLI)</h3>
+
+      <a
+        href="https://github.com/emdneto/otsgo"
+        title="Go utility - One-Time Secret"
+        ><strong>Github page</strong></a
+      ><br />
+      <em
+        >by <a href="https://github.com/emdneto">
+            Emídio Neto</a> (added
+        2024-06-09)</em
+      >
+
+      <h4>Usage Example</h4>
+      <pre class="colourize">
+            $ ots share -h
+            Share or generate a random secret
+
+            Usage:
+              ots share [flags]
+
+            Flags:
+              -f, --from-stdin          Read from stdin
+              -g, --generate            Generate a short, unique secret. This is useful for temporary passwords, one-time pads, salts, etc.
+              -h, --help                help for share
+              -p, --passphrase string   a string that the recipient must know to view the secret. This value is also used to encrypt the secret and is bcrypted before being stored so we only have this value in transit.
+              -r, --recipient string    an email address. We will send a friendly email containing the secret link (NOT the secret itself).
+              -s, --secret string       the secret value which is encrypted before being stored. There is a maximum length based on your plan that is enforced (1k-10k)
+              -t, --ttl int             the maximum amount of time, in seconds, that the secret should survive (i.e. time-to-live). Once this time expires, the secret will be deleted and not recoverable. (default 604800)
+
+      </pre>
       <h3 class="cufon docTitle dotted">Bash</h3>
 
       <a


### PR DESCRIPTION
Completes #283 

This pull request includes updates to the otsgo client library. The changes include minor updates to the 404 and maintenance pages, an update to the Ruby example, cleaned up formatting, added the otsgo client, updated link text, and fixed the spacing in the `<pre>` tag.

Signed-off-by: delano <delano@onetimesecret.com>