### PR TITLE
Limit feedback to authenticated users

### DIFF
--- a/lib/onetime/logic.rb
+++ b/lib/onetime/logic.rb
@@ -14,6 +14,7 @@ module Onetime
 
       def raise_concerns
         limit_action :send_feedback
+        raise_form_error "You need an account to do that" if cust.anonymous?
         if @msg.empty? || @msg =~ /#{Regexp.escape("question or comment")}/
           raise_form_error "You can be more original than that!"
         end

--- a/lib/onetime/logic.rb
+++ b/lib/onetime/logic.rb
@@ -22,6 +22,7 @@ module Onetime
 
       def process
         @msg = "#{msg} [%s]" % [cust.anonymous? ? sess.ipaddress : cust.custid]
+        OT.ld [:receive_feedback, msg].inspect
         OT::Feedback.add @msg
         sess.set_info_message "Message received. Send as much as you like!"
       end

--- a/lib/onetime/logic.rb
+++ b/lib/onetime/logic.rb
@@ -1,88 +1,10 @@
 require 'stathat'
 require 'timeout'
 
+require_relative 'logic/base'
+
 module Onetime
   module Logic
-    class << self
-      attr_writer :stathat_apikey, :stathat_enabled
-      def stathat_apikey
-        @stathat_apikey ||= Onetime.conf[:stathat][:apikey]
-      end
-      def stathat_enabled
-        return unless Onetime.conf.has_key?(:stathat)
-        @stathat_enabled = Onetime.conf[:stathat][:enabled] if @stathat_enabled.nil?
-        @stathat_enabled
-      end
-      def stathat_count name, count, wait=0.500
-        return false if ! stathat_enabled
-        begin
-          Timeout.timeout(wait) do
-            StatHat::API.ez_post_count(name, stathat_apikey, count)
-          end
-        rescue SocketError => ex
-          OT.info "Cannot connect to StatHat: #{ex.message}"
-        rescue Timeout::Error
-          OT.info "timeout calling stathat"
-        end
-      end
-      def stathat_value name, value, wait=0.500
-        return false if ! stathat_enabled
-        begin
-          Timeout.timeout(wait) do
-            StatHat::API.ez_post_value(name, stathat_apikey, value)
-          end
-        rescue SocketError => ex
-          OT.info "Cannot connect to StatHat: #{ex.message}"
-        rescue Timeout::Error
-          OT.info "timeout calling stathat"
-        end
-      end
-    end
-    class Base
-      unless defined?(Onetime::Logic::Base::MOBILE_REGEX)
-        MOBILE_REGEX = /^\+?\d{9,16}$/
-        EMAIL_REGEX = %r{^(?:[_a-z0-9-]+)(\.[_a-z0-9-]+)*@([a-z0-9-]+)(\.[a-zA-Z0-9\-\.]+)*(\.[a-z]{2,12})$}i
-      end
-      attr_reader :sess, :cust, :params, :locale, :processed_params, :plan
-      def initialize(sess, cust, params=nil, locale=nil)
-        @sess, @cust, @params, @locale = sess, cust, params, locale
-        @processed_params ||= {}
-        process_params if respond_to?(:process_params) && @params
-        process_generic_params if @params
-      end
-      protected
-
-      # Generic params that can appear anywhere are processed here.
-      # This is called in initialize AFTER process_params so that
-      # values set here don't overwrite values that already exist.
-      def process_generic_params
-        # remember to set with ||=
-      end
-      def form_fields
-        OT.ld "No form_fields method for #{self.class}"
-        {}
-      end
-      def raise_form_error msg
-        ex = OT::FormError.new
-        ex.message = msg
-        ex.form_fields = form_fields
-        raise ex
-      end
-      def plan
-        @plan = Onetime::Plan.plan(cust.planid) unless cust.nil?
-        @plan ||= Onetime::Plan.plan('anonymous')
-      end
-      def limit_action event
-        return if plan.paid?
-        sess.event_incr! event
-      end
-      def valid_email?(guess)
-        !guess.to_s.match(EMAIL_REGEX).nil?
-      end
-      def valid_mobile?(guess)
-        !guess.to_s.tr('-.','').match(MOBILE_REGEX).nil?
-      end
-    end
 
     class ReceiveFeedback < OT::Logic::Base
       attr_reader :msg

--- a/lib/onetime/logic/base.rb
+++ b/lib/onetime/logic/base.rb
@@ -11,9 +11,9 @@ module Onetime
       attr_reader :sess, :cust, :params, :locale, :processed_params, :plan
       def initialize(sess, cust, params=nil, locale=nil)
         @sess, @cust, @params, @locale = sess, cust, params, locale
-        @processed_params ||= {}
+        @processed_params ||= {}  # TODO: Remove
         process_params if respond_to?(:process_params) && @params
-        process_generic_params if @params
+        process_generic_params if @params  # TODO: Remove
       end
 
       protected

--- a/lib/onetime/logic/base.rb
+++ b/lib/onetime/logic/base.rb
@@ -1,0 +1,91 @@
+
+
+module Onetime
+  module Logic
+    class Base
+      unless defined?(Onetime::Logic::Base::MOBILE_REGEX)
+        MOBILE_REGEX = /^\+?\d{9,16}$/
+        EMAIL_REGEX = %r{^(?:[_a-z0-9-]+)(\.[_a-z0-9-]+)*@([a-z0-9-]+)(\.[a-zA-Z0-9\-\.]+)*(\.[a-z]{2,12})$}i
+      end
+
+      attr_reader :sess, :cust, :params, :locale, :processed_params, :plan
+      def initialize(sess, cust, params=nil, locale=nil)
+        @sess, @cust, @params, @locale = sess, cust, params, locale
+        @processed_params ||= {}
+        process_params if respond_to?(:process_params) && @params
+        process_generic_params if @params
+      end
+
+      protected
+
+      # Generic params that can appear anywhere are processed here.
+      # This is called in initialize AFTER process_params so that
+      # values set here don't overwrite values that already exist.
+      def process_generic_params
+        # remember to set with ||=
+      end
+      def form_fields
+        OT.ld "No form_fields method for #{self.class}"
+        {}
+      end
+      def raise_form_error msg
+        ex = OT::FormError.new
+        ex.message = msg
+        ex.form_fields = form_fields
+        raise ex
+      end
+      def plan
+        @plan = Onetime::Plan.plan(cust.planid) unless cust.nil?
+        @plan ||= Onetime::Plan.plan('anonymous')
+      end
+      def limit_action event
+        return if plan.paid?
+        sess.event_incr! event
+      end
+      def valid_email?(guess)
+        !guess.to_s.match(EMAIL_REGEX).nil?
+      end
+      def valid_mobile?(guess)
+        !guess.to_s.tr('-.','').match(MOBILE_REGEX).nil?
+      end
+    end
+
+
+    class << self
+      attr_writer :stathat_apikey, :stathat_enabled
+      def stathat_apikey
+        @stathat_apikey ||= Onetime.conf[:stathat][:apikey]
+      end
+      def stathat_enabled
+        return unless Onetime.conf.has_key?(:stathat)
+        @stathat_enabled = Onetime.conf[:stathat][:enabled] if @stathat_enabled.nil?
+        @stathat_enabled
+      end
+      def stathat_count name, count, wait=0.500
+        return false if ! stathat_enabled
+        begin
+          Timeout.timeout(wait) do
+            StatHat::API.ez_post_count(name, stathat_apikey, count)
+          end
+        rescue SocketError => ex
+          OT.info "Cannot connect to StatHat: #{ex.message}"
+        rescue Timeout::Error
+          OT.info "timeout calling stathat"
+        end
+      end
+      def stathat_value name, value, wait=0.500
+        return false if ! stathat_enabled
+
+        begin
+          Timeout.timeout(wait) do
+            StatHat::API.ez_post_value(name, stathat_apikey, value)
+          end
+        rescue SocketError => ex
+          OT.info "Cannot connect to StatHat: #{ex.message}"
+        rescue Timeout::Error
+          OT.info "timeout calling stathat"
+        end
+      end
+    end
+  end
+end

--- a/lib/onetime/models.rb
+++ b/lib/onetime/models.rb
@@ -173,17 +173,18 @@ module Onetime
       attr_reader :values
       def add msg
         self.values.add OT.now.to_i, msg
+        # Auto-trim the set to keep only the most recent 30 days of feedback
         self.values.remrangebyscore 0, OT.now.to_i-30.days
       end
       # Returns a Hash like: {"msg1"=>"1322644672", "msg2"=>"1322644668"}
       def all
-        ret = self.values.revrangeraw(0, -1, :with_scores => true)
-        Hash[*ret]
+        ret = self.values.revrangeraw(0, -1, withscores: true)
+        Hash[ret]
       end
       def recent duration=30.days, epoint=OT.now.to_i
         spoint = OT.now.to_i-duration
-        ret = self.values.rangebyscoreraw(spoint, epoint, :with_scores => true)
-        Hash[ret.each_slice(2).to_a]
+        ret = self.values.rangebyscoreraw(spoint, epoint, withscores: true)
+        Hash[ret]
       end
     end
   end

--- a/lib/onetime/models.rb
+++ b/lib/onetime/models.rb
@@ -19,6 +19,12 @@ class Onetime::RateLimit < Familia::String
       count
     end
     alias_method :increment!, :incr!
+    def clear! identifier, event
+      lmtr = new identifier, event
+      ret = lmtr.clear
+      OT.ld [:clear, event, identifier, ret].inspect
+      ret
+    end
     def exceeded? event, count
       (count) > (events[event] || DEFAULT_LIMIT)
     end
@@ -60,7 +66,12 @@ module Onetime::Models
   end
   module RateLimited
     def event_incr! event
+      # Uses the external identifier of the implementing class to keep
+      # track of the event count. e.g. sess.external_identifier.
       OT::RateLimit.incr! external_identifier, event
+    end
+    def event_clear! event
+      OT::RateLimit.clear! external_identifier, event
     end
     def external_identifier
       raise RuntimeError, "TODO: #{self.class}.external_identifier"

--- a/templates/web/footer.mustache
+++ b/templates/web/footer.mustache
@@ -6,8 +6,15 @@
     <form class="form form-inline" action="/feedback" method="post">
       {{{add_shrimp}}}
       <div class="input-append">
-        <input class="span6" name="msg" id="appendedInputButton" type="text" placeholder="{{i18n.COMMON.feedback_text}}">
-        <button class="btn" type="submit">{{i18n.COMMON.button_send_feedback}}</button>
+        {{^authenticated}}
+          <input class="span6" name="msg" id="appendedInputButton" type="text" placeholder="Login to send feedback">
+          <button class="btn" type="submit" disabled>{{i18n.COMMON.button_send_feedback}}</button>
+        {{/authenticated}}
+        {{#authenticated}}
+          <input class="span6
+          " name="msg" id="appendedInputButton" type="text" placeholder="{{i18n.COMMON.feedback_text}}">
+          <button class="btn" type="submit">{{i18n.COMMON.button_send_feedback}}</button>
+        {{/authenticated}}
       </div>
     </form>
     {{/display_feedback}}

--- a/try/25_customer_try.rb
+++ b/try/25_customer_try.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require_relative '../lib/onetime'
+
+# Load the app
+OT::Config.path = File.join(__dir__, '..', 'etc', 'config.test')
+OT.load! :app
+
+# Setup some variables for these tryouts
+@now = DateTime.now
+@model_class = OT::Customer
+@email_address = "tryouts+#{@now}@onetimesecret.com"
+@cust = OT::Customer.new @email_address
+
+# TRYOUTS
+
+## New instance of customer has no planid (not saved yet)
+@cust.planid
+#=> nil
+
+## New instance of customer has a custid
+@cust.custid
+#=> @email_address
+
+## New instance of customer has a rediskey
+@cust.rediskey
+#=> "customer:#{@email_address}:object"
+
+## Object name and rediskey are equivalent
+@cust.rediskey.eql?(@cust.name)
+#=> true

--- a/try/68_receive_feedback_try.rb
+++ b/try/68_receive_feedback_try.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require_relative '../lib/onetime'
+
+# Load the app
+OT::Config.path = File.join(__dir__, '..', 'etc', 'config.test')
+OT.load! :app
+
+# Setup some variables for these tryouts
+@now = DateTime.now
+@model_class = OT::Feedback
+@sess = OT::Session.new
+@cust = OT::Customer.new "tryouts+#{@now}@onetimesecret.com"
+@sess.event_clear! :send_feedback
+@params = {
+  msg: "This is a test feedback"
+}
+@locale = 'en'
+puts 'before2'
+
+# TRYOUTS
+
+## Can create ReceiveFeedback instance
+obj = OT::Logic::ReceiveFeedback.new @sess, @cust
+obj.class
+#=> Onetime::Logic::ReceiveFeedback
+
+## Can create ReceiveFeedback instance w/ params
+obj = OT::Logic::ReceiveFeedback.new @sess, @cust, @params
+obj.params.keys
+#=> [:msg]
+
+## Can create ReceiveFeedback instance w/ params and locale
+obj = OT::Logic::ReceiveFeedback.new @sess, @cust, @params, @locale
+obj.locale
+#=> 'en'
+
+## Params are processed
+obj = OT::Logic::ReceiveFeedback.new @sess, @cust, @params
+obj.msg
+#=> 'This is a test feedback'
+
+## Concerns can be raised when no message is given
+obj = OT::Logic::ReceiveFeedback.new @sess, @cust, {}
+begin
+  obj.raise_concerns
+rescue Onetime::FormError => e
+  [e.class, e.message]
+end
+#=> [Onetime::FormError, "You can be more original than that!"]
+
+## Concerns are not raised when a message is given
+obj = OT::Logic::ReceiveFeedback.new @sess, @cust, @params
+obj.raise_concerns
+#=> [Onetime::FormError, "You can be more original than that!"]
+
+## Sending feedback provides a UI message
+obj = OT::Logic::ReceiveFeedback.new @sess, @cust, @params
+obj.process
+@sess.info_message
+#=> 'Message received. Send as much as you like!'
+
+## Sending populates the Feedback model's sorted set key in redis
+count_before = @model_class.recent.count
+obj = OT::Logic::ReceiveFeedback.new @sess, @cust, @params
+count_after = @model_class.recent.count
+obj.process
+[count_after, count_before]
+#=> 1
+
+## Sending feedback provides a UI message
+cust = OT::Customer.anonymous
+sess = OT::Session.new 'id123', 'tryouts', cust
+params = {msg: 'This is a test feedback'}
+obj = OT::Logic::ReceiveFeedback.new sess, cust, params
+sess.event_clear! :send_feedback
+begin
+  obj.raise_concerns
+rescue Onetime::FormError => e
+  [e.class, e.message]
+end
+#=> [Onetime::FormError, "You need an account to do that"]
+
+
+# Cleanup
+puts 'clearing limiters'
+@sess.event_clear! :send_feedback


### PR DESCRIPTION
Fixes issue #382.

This pull request restricts the display of feedback form inputs and submit button to authenticated users only. This prevents sending feedback without being logged in and ensures a consistent UI for anonymous visitors. The changes include conditional logic to disable form fields and change placeholders for anonymous users, while still allowing authenticated users to submit feedback.

Additionally, this pull request includes several other improvements and fixes:

- Separates the base logic class (no functional changes)

- Improves feedback acceptance checks by adding validation to require a logged-in customer before accepting feedback

- Adds rate limit clearing support to reset the count for a given event and identifier

- Adds customer tryouts to test customer instance methods like planid, custid, and rediskey

- Fixes syntax for Redis client >= 4.0.0, using the newer supported option `:withscores`

These changes aim to limit feedback to authenticated users, reduce spam, and ensure that feedback is more likely to be genuine and actionable.