### PR TITLE
Improve password generation button styling

### DIFF
--- a/BUILD.yml
+++ b/BUILD.yml
@@ -1,4 +1,4 @@
 ---
 :MAJOR: 0
-:MINOR: 13
+:MINOR: 14
 :PATCH: 0

--- a/public/web/css/main.css
+++ b/public/web/css/main.css
@@ -68,6 +68,22 @@
   text-shadow: 1px 1px 0 #740500;
 }
 
+.btn-secondary {
+  -webkit-font-smoothing: antialiased;
+  width: 74%;
+  margin-left: 13%;
+  margin-right: 10%;
+  background-repeat: repeat-x;
+  background-image: none;
+  color: #444!important;
+  text-shadow: 0 -1px 0 rgba(0,0,0,0.00);
+}
+.btn-secondary:hover {
+  background-color: buttonface !important;
+  text-shadow: 0px 1px 0 #fff;
+}
+
+
 
 
 

--- a/templates/web/partial/create_secret_form.mustache
+++ b/templates/web/partial/create_secret_form.mustache
@@ -37,7 +37,8 @@
     </div>
     {{/display_options}}
     <button class="create btn btn-large btn-block btn-custom cufon" type="submit" name="kind" value="share" >{{i18n.COMMON.button_create_secret}}{{^authenticated}}*{{/authenticated}}</button>
-    <button class="generate btn btn-large btn-block cufon" type="submit" name="kind" value="generate" >{{i18n.COMMON.button_generate_secret}}</button>
+    <hr>
+    <button class="generate btn btn-large btn-block btn-secondary cufon" type="submit" name="kind" value="generate" >{{i18n.COMMON.button_generate_secret}}</button>
   </fieldset>
 </form>
 <script type="text/javascript">


### PR DESCRIPTION
Adjusted styling of the 'Generate Secret' button on the secret creation form for improved visual distinction and usability. Applied secondary button class and added horizontal ruler above for clearer separation from primary action. This helps users easily differentiate between generating a secret value and creating/sharing a secret entry.

Fixes #286

## Screenshots

#### After
![Capture-2024-06-10-141205](https://github.com/onetimesecret/onetimesecret/assets/1206/c4de98b1-cd31-4a03-8600-23eec780eeae)

### Before
![Capture-2024-06-11-000250](https://github.com/onetimesecret/onetimesecret/assets/1206/a1f53f33-a55f-42e6-96ff-8289e1eec563)
