### PR TITLE
Update email validation with Truemail

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,8 @@ plugin 'bundler-graph'
 
 source 'https://rubygems.org/'
 
+gem 'truemail'
+
 gem 'addressable'
 
 gem 'rack'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,6 +94,7 @@ GEM
     ruby_http_client (3.5.5)
     sendgrid-ruby (6.7.0)
       ruby_http_client (~> 3.4)
+    simpleidn (0.2.3)
     storable (0.10.0)
     strscan (3.1.0)
     sysinfo (0.10.0)
@@ -104,6 +105,8 @@ GEM
       eventmachine (~> 1.0, >= 1.0.4)
       rack (>= 1, < 3)
     timeout (0.4.1)
+    truemail (3.3.1)
+      simpleidn (~> 0.2.1)
     tryouts (2.2.0)
       sysinfo (~> 0.10)
     unicode-display_width (2.5.0)
@@ -138,6 +141,7 @@ DEPENDENCIES
   storable
   sysinfo
   thin
+  truemail
   tryouts
   uri-redis (~> 1.2)
   yajl-ruby

--- a/config.ru
+++ b/config.ru
@@ -32,6 +32,7 @@ apps = {
 Onetime.boot! :app
 
 if Otto.env?(:dev)
+
   # DEV: Run web apps with extra logging and reloading
   apps.each_pair do |path, app|
     map(path) do
@@ -45,10 +46,10 @@ if Otto.env?(:dev)
     end
   end
 else
+
   # PROD: run barebones webapps
   apps.each_pair do |path, app|
     app.option[:public] = PUBLIC_DIR
     map(path) { run app }
   end
-  # $SAFE = 1  # http://www.rubycentral.com/pickaxe/taint.html
 end

--- a/config.ru
+++ b/config.ru
@@ -29,7 +29,7 @@ apps = {
   '/colonel'    => Otto.new("#{APP_DIR}/colonel/routes")
 }
 
-Onetime.load! :app
+Onetime.boot! :app
 
 if Otto.env?(:dev)
   # DEV: Run web apps with extra logging and reloading

--- a/lib/onetime.rb
+++ b/lib/onetime.rb
@@ -17,6 +17,8 @@ require 'familia'
 require 'storable'
 require 'sendgrid-ruby'
 
+require 'truemail'
+
 SYSLOG = Syslog.open('onetime') unless defined?(SYSLOG)
 
 Familia.apiversion = nil

--- a/lib/onetime.rb
+++ b/lib/onetime.rb
@@ -56,9 +56,12 @@ module Onetime
       SecureRandom.hex
     end
 
-    def boot!(mode = nil, _base = Onetime::HOME)
+    def boot!(mode = nil)
       OT.mode = mode unless mode.nil?
       @conf = OT::Config.load # load config before anything else.
+
+      OT::Config.after_load
+
       @locales = OT.load_locales
       @sysinfo ||= SysInfo.new.freeze
       @instance ||= [OT.sysinfo.hostname, OT.sysinfo.user, $$, OT::VERSION.to_s, OT.now.to_i].gibbler.freeze
@@ -178,6 +181,15 @@ module Onetime
             end
       Onetime.info msg
       Kernel.exit(1)
+    end
+
+    def after_load(email_address = nil)
+      email_address ||= OT.conf[:emailer][:from]
+      OT.info "Setting TrueMail verifier email to #{email_address}"
+
+      Truemail.configure do |config|
+        config.verifier_email = email_address
+      end
     end
 
     def exists?

--- a/lib/onetime.rb
+++ b/lib/onetime.rb
@@ -191,6 +191,10 @@ module Onetime
 
       Truemail.configure do |config|
         config.verifier_email = email_address
+        # config.connection_timeout = 2 # Set the timeout to 2 seconds
+        config.smtp_fail_fast = true
+        config.not_rfc_mx_lookup_flow = true
+        config.dns = %w[208.67.222.222 8.8.8.8 8.8.4.4 208.67.220.220]
       end
     end
 

--- a/lib/onetime/boot.rb
+++ b/lib/onetime/boot.rb
@@ -1,1 +1,0 @@
-#  require File.expand_path("../config/boot.rb", __FILE__)

--- a/lib/onetime/boot.rb
+++ b/lib/onetime/boot.rb
@@ -1,0 +1,1 @@
+#  require File.expand_path("../config/boot.rb", __FILE__)

--- a/lib/onetime/cli.rb
+++ b/lib/onetime/cli.rb
@@ -6,7 +6,7 @@ require 'familia/tools'
 
 class OT::CLI < Drydock::Command
   def init
-    OT.load! :cli
+    OT.boot! :cli
   end
 
   def register_build

--- a/lib/onetime/irb.rb
+++ b/lib/onetime/irb.rb
@@ -1,5 +1,4 @@
-
 require 'onetime'
 
-Onetime.info "Calling Onetime.load!..."
-Onetime.load! :cli
+Onetime.info 'Calling Onetime.boot!...'
+Onetime.boot! :cli

--- a/lib/onetime/logic/base.rb
+++ b/lib/onetime/logic/base.rb
@@ -1,19 +1,26 @@
-
-
 module Onetime
   module Logic
     class Base
       unless defined?(Onetime::Logic::Base::MOBILE_REGEX)
         MOBILE_REGEX = /^\+?\d{9,16}$/
-        EMAIL_REGEX = %r{^(?:[_a-z0-9-]+)(\.[_a-z0-9-]+)*@([a-z0-9-]+)(\.[a-zA-Z0-9\-\.]+)*(\.[a-z]{2,12})$}i
+        EMAIL_REGEX = /^(?:[_a-z0-9-]+)(\.[_a-z0-9-]+)*@([a-z0-9-]+)(\.[a-zA-Z0-9\-\.]+)*(\.[a-z]{2,12})$/i
       end
 
       attr_reader :sess, :cust, :params, :locale, :processed_params, :plan
-      def initialize(sess, cust, params=nil, locale=nil)
-        @sess, @cust, @params, @locale = sess, cust, params, locale
-        @processed_params ||= {}  # TODO: Remove
+
+      def initialize(sess, cust, params = nil, locale = nil)
+        @sess = sess
+        @cust = cust
+        @params = params
+        @locale = locale
+        @processed_params ||= {} # TODO: Remove
         process_params if respond_to?(:process_params) && @params
-        process_generic_params if @params  # TODO: Remove
+        process_generic_params if @params # TODO: Remove
+      end
+
+      def valid_email?(guess)
+        OT.ld "[valid_email?] Guess: #{guess}"
+        Truemail.validate(guess, with: :regex).result.valid?
       end
 
       protected
@@ -24,66 +31,70 @@ module Onetime
       def process_generic_params
         # remember to set with ||=
       end
+
       def form_fields
         OT.ld "No form_fields method for #{self.class}"
         {}
       end
-      def raise_form_error msg
+
+      def raise_form_error(msg)
         ex = OT::FormError.new
         ex.message = msg
         ex.form_fields = form_fields
         raise ex
       end
+
       def plan
         @plan = Onetime::Plan.plan(cust.planid) unless cust.nil?
         @plan ||= Onetime::Plan.plan('anonymous')
       end
-      def limit_action event
+
+      def limit_action(event)
         return if plan.paid?
+
         sess.event_incr! event
-      end
-      def valid_email?(guess)
-        !guess.to_s.match(EMAIL_REGEX).nil?
-      end
-      def valid_mobile?(guess)
-        !guess.to_s.tr('-.','').match(MOBILE_REGEX).nil?
       end
     end
 
-
     class << self
       attr_writer :stathat_apikey, :stathat_enabled
+
       def stathat_apikey
         @stathat_apikey ||= Onetime.conf[:stathat][:apikey]
       end
+
       def stathat_enabled
         return unless Onetime.conf.has_key?(:stathat)
+
         @stathat_enabled = Onetime.conf[:stathat][:enabled] if @stathat_enabled.nil?
         @stathat_enabled
       end
-      def stathat_count name, count, wait=0.500
-        return false if ! stathat_enabled
+
+      def stathat_count(name, count, wait = 0.500)
+        return false unless stathat_enabled
+
         begin
           Timeout.timeout(wait) do
             StatHat::API.ez_post_count(name, stathat_apikey, count)
           end
-        rescue SocketError => ex
-          OT.info "Cannot connect to StatHat: #{ex.message}"
+        rescue SocketError => e
+          OT.info "Cannot connect to StatHat: #{e.message}"
         rescue Timeout::Error
-          OT.info "timeout calling stathat"
+          OT.info 'timeout calling stathat'
         end
       end
-      def stathat_value name, value, wait=0.500
-        return false if ! stathat_enabled
+
+      def stathat_value(name, value, wait = 0.500)
+        return false unless stathat_enabled
 
         begin
           Timeout.timeout(wait) do
             StatHat::API.ez_post_value(name, stathat_apikey, value)
           end
-        rescue SocketError => ex
-          OT.info "Cannot connect to StatHat: #{ex.message}"
+        rescue SocketError => e
+          OT.info "Cannot connect to StatHat: #{e.message}"
         rescue Timeout::Error
-          OT.info "timeout calling stathat"
+          OT.info 'timeout calling stathat'
         end
       end
     end

--- a/try/10_utils_try.rb
+++ b/try/10_utils_try.rb
@@ -4,7 +4,7 @@ require_relative '../lib/onetime'
 
 # Use the default config file for tests
 OT::Config.path = File.join(__dir__, '..', 'etc', 'config.test')
-OT.load!
+OT.boot!
 
 ## Create a strand
 Onetime::Utils.strand.class

--- a/try/11_entropy_try.rb
+++ b/try/11_entropy_try.rb
@@ -4,8 +4,7 @@ require_relative '../lib/onetime'
 
 # Use the default config file for tests
 OT::Config.path = File.join(__dir__, '..', 'etc', 'config.test')
-OT.load! :cli
-
+OT.boot! :cli
 
 ## Clear values
 OT::Entropy.generate 2

--- a/try/15_config_try.rb
+++ b/try/15_config_try.rb
@@ -4,8 +4,7 @@ require_relative '../lib/onetime'
 
 # Use the default config file for tests
 OT::Config.path = File.join(__dir__, '..', 'etc', 'config.test')
-OT.load! :cli
-
+OT.boot! :cli
 
 ## Finds a config path
 relative_path = Onetime::Config.path.gsub("#{__dir__}/", '')
@@ -21,8 +20,8 @@ relative_path
 [@config[:site].class, @config[:redis].class]
 #=> [Hash, Hash]
 
-## OT.load!
-OT.load! :tryouts
+## OT.boot!
+OT.boot! :tryouts
 [OT.mode, OT.conf.class]
 #=> [:tryouts, Hash]
 

--- a/try/15_config_try.rb
+++ b/try/15_config_try.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'pry'
 require_relative '../lib/onetime'
 
 # Use the default config file for tests
@@ -32,3 +33,30 @@ Onetime.global_secret.nil?
 ## Has default global secret
 Onetime.global_secret
 #=> 'SuP0r_53cRU7'
+
+## Sets the Truemail verifier email address
+Truemail.configuration.verifier_email.nil?
+#=> false
+
+## Sets the Truemail verifier email address to the default from address
+Truemail.configuration.verifier_email
+#=> 'changeme@example.com'
+
+## Truemail knows an invalid email address
+Truemail.valid?(Onetime.global_secret)
+#=> false
+
+## Truemail knows a valid email address
+validator = Truemail.validate('test@onetimesecret.com', with: :regex)
+validator.result.valid?
+#=> true
+
+## Truemail knows another invalid email address
+validator = Truemail.validate('-_test@onetimesecret.com', with: :regex)
+validator.result.valid?
+#=> false
+
+## Truemail knows yet another invalid email address
+validator = Truemail.validate('test@onetimesecret.c.n', with: :regex)
+validator.result.valid?
+#=> false

--- a/try/15_config_try.rb
+++ b/try/15_config_try.rb
@@ -7,6 +7,21 @@ require_relative '../lib/onetime'
 OT::Config.path = File.join(__dir__, '..', 'etc', 'config.test')
 OT.boot! :cli
 
+@email_address ||= OT.conf[:emailer][:from]
+
+@truemail_test_config = Truemail::Configuration.new do |config|
+  config.verifier_email = @email_address
+
+  config.whitelisted_emails = [
+    'tryouts+test1@onetimesecret.com',
+    'tryouts+test2@onetimesecret.com'
+  ]
+  config.blacklisted_emails = [
+    'tryouts+test3@onetimesecret.com',
+    'tryouts+test4@onetimesecret.com'
+  ]
+end
+
 ## Finds a config path
 relative_path = Onetime::Config.path.gsub("#{__dir__}/", '')
 relative_path
@@ -58,5 +73,23 @@ validator.result.valid?
 
 ## Truemail knows yet another invalid email address
 validator = Truemail.validate('test@onetimesecret.c.n', with: :regex)
+validator.result.valid?
+#=> false
+
+## Truemail knows an allow listed email
+validator = Truemail.validate(
+  'tryouts+test1@onetimesecret.com',
+  #   with: :regex,
+  custom_configuration: @truemail_test_config
+)
+validator.result.valid?
+#=> true
+
+## Truemail knows a deny listed email
+validator = Truemail.validate(
+  'tryouts+test3@onetimesecret.com',
+  #   with: :regex,
+  custom_configuration: @truemail_test_config
+)
 validator.result.valid?
 #=> false

--- a/try/15_config_try.rb
+++ b/try/15_config_try.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'pry'
 require_relative '../lib/onetime'
 
 # Use the default config file for tests

--- a/try/20_metadata_try.rb
+++ b/try/20_metadata_try.rb
@@ -4,8 +4,7 @@ require_relative '../lib/onetime'
 
 # Use the default config file for tests
 OT::Config.path = File.join(__dir__, '..', 'etc', 'config.test')
-OT.load!
-
+OT.boot!
 
 ## Keys are consistent for Metadata
 @metadata = Onetime::Metadata.new :metadata, :entropy
@@ -27,7 +26,6 @@ OT.load!
 p @metadata2.all
 @metadata2.exists?
 #=> true
-
 
 @metadata.destroy!
 @metadata2.destroy!

--- a/try/21_secret_try.rb
+++ b/try/21_secret_try.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
+
 #
 require_relative '../lib/onetime'
 
 # Use the default config file for tests
 OT::Config.path = File.join(__dir__, '..', 'etc', 'config.test')
-OT.load! :app
+OT.boot! :app
 
 ## Can create Secret
 s = Onetime::Secret.new :private
@@ -23,7 +24,7 @@ s.rediskey
 #=> 'secret:l6vqq07wykrr54srddgnhcqxl2m1mgo:object'
 
 ## But can be modified with entropy
-s = Onetime::Secret.new :shared, [:some, :fixed, :values]
+s = Onetime::Secret.new :shared, %i[some fixed values]
 s.rediskey
 #=> 'secret:hqwly8r21k2wf1kv28y7mjaid0s2u8p:object'
 

--- a/try/22_value_encryption_try.rb
+++ b/try/22_value_encryption_try.rb
@@ -4,7 +4,7 @@ require_relative '../lib/onetime'
 
 # Use the default config file for tests
 OT::Config.path = File.join(__dir__, '..', 'etc', 'config.test')
-OT.load! :app
+OT.boot! :app
 
 ## Can store a value
 s = Onetime::Secret.new :shared
@@ -37,10 +37,9 @@ s.encrypt_value 'poop', key: 'tryouts'
 Onetime.instance_variable_set(:@global_secret, 'NEWVALUE')
 begin
   s.decrypted_value
-rescue => ex
-  ex.class
+rescue StandardError => e
+  e.class
 end
 #=> OpenSSL::Cipher::CipherError
-
 
 Onetime::Secret.new(:shared).destroy!

--- a/try/23_passphrase_try.rb
+++ b/try/23_passphrase_try.rb
@@ -4,16 +4,16 @@ require_relative '../lib/onetime'
 
 # Use the default config file for tests
 OT::Config.path = File.join(__dir__, '..', 'etc', 'config.test')
-OT.load!
+OT.boot!
 
 ## Can store a passphrase
 s = Onetime::Secret.new :shared
-s.passphrase = "poop"
+s.passphrase = 'poop'
 s.passphrase
 #=> 'poop'
 
 ## Can store a one-way, encrypted passphrase
 s = Onetime::Secret.new :shared
-s.update_passphrase "poop"
+s.update_passphrase 'poop'
 [s.passphrase_encryption, s.passphrase?('poop')]
 #=> [1, true]

--- a/try/25_customer_try.rb
+++ b/try/25_customer_try.rb
@@ -4,7 +4,7 @@ require_relative '../lib/onetime'
 
 # Load the app
 OT::Config.path = File.join(__dir__, '..', 'etc', 'config.test')
-OT.load! :app
+OT.boot! :app
 
 # Setup some variables for these tryouts
 @now = DateTime.now

--- a/try/30_session_try.rb
+++ b/try/30_session_try.rb
@@ -4,16 +4,17 @@ require_relative '../lib/onetime'
 
 # Use the default config file for tests
 OT::Config.path = File.join(__dir__, '..', 'etc', 'config.test')
-OT.load!
+OT.boot!
 
 # Sessions don't have unique IDs by default
-s1, s2 = OT::Session.new, OT::Session.new
+s1 = OT::Session.new
+s2 = OT::Session.new
 s1.sessid == s2.sessid
 #=> true
 
 # Can set form fields
 @sess = OT::Session.new
-ret = @sess.set_form_fields :custid => 'tryouts', :planid => :testing
+ret = @sess.set_form_fields custid: 'tryouts', planid: :testing
 ret.class
 #=> String
 

--- a/try/35_ratelimit_try.rb
+++ b/try/35_ratelimit_try.rb
@@ -4,7 +4,7 @@ require_relative '../lib/onetime'
 
 # Use the default config file for tests
 OT::Config.path = File.join(__dir__, '..', 'etc', 'config.test')
-OT.load!
+OT.boot!
 
 @stamp = OT::RateLimit.eventstamp
 
@@ -35,8 +35,8 @@ OT::RateLimit.exceeded? :delano_limit, 4
 
 ## A limited event raises an exception
 begin
-  4.times { p OT::RateLimit.incr! :tryouts, :delano_limit }  # 4 is one more than 3
-rescue OT::LimitExceeded => ex
+  4.times { p OT::RateLimit.incr! :tryouts, :delano_limit } # 4 is one more than 3
+rescue OT::LimitExceeded => e
   :success
 end
 #=> :success

--- a/try/40_email_template_try.rb
+++ b/try/40_email_template_try.rb
@@ -4,7 +4,7 @@ require_relative '../lib/onetime'
 
 # Use the default config file for tests
 OT::Config.path = File.join(__dir__, '..', 'etc', 'config.test')
-OT.load!
+OT.boot!
 
 @cust = OT::Customer.new :tryouts
 @secret = OT::Secret.new :tryouts

--- a/try/50_subdomain_try.rb
+++ b/try/50_subdomain_try.rb
@@ -4,7 +4,7 @@ require_relative '../lib/onetime'
 
 # Use the default config file for tests
 OT::Config.path = File.join(__dir__, '..', 'etc', 'config.test')
-OT.load! :app
+OT.boot! :app
 
 ## Can create Subdomain instance
 s = Onetime::Subdomain.new 'tryouts@onetimesecret.com'

--- a/try/60_logic_base_try.rb
+++ b/try/60_logic_base_try.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require_relative '../lib/onetime'
+
+# frozen_string_literal: true
+
+require_relative '../lib/onetime'
+
+# Load the app
+OT::Config.path = File.join(__dir__, '..', 'etc', 'config.test')
+OT.boot! :app
+
+# Setup some variables for these tryouts
+@now = DateTime.now
+@from_address = OT.conf[:emailer][:from]
+@email_address = 'tryouts@onetimesecret.com'
+@sess = OT::Session.new
+@cust = OT::Customer.new @email_address
+@sess.event_clear! :send_feedback
+@params = {}
+@locale = 'en'
+@obj = OT::Logic::CreateAccount.new @sess, @cust
+
+# TRYOUTS
+
+## Can create CreateAccount instance
+@obj.class
+#=> Onetime::Logic::CreateAccount
+
+## Knows an invalid address
+@obj.valid_email?('bogusjourney')
+#=> false
+
+## Knows a valid email address
+@obj.valid_email?(@email_address)
+#=> true
+
+## Can't tell the diff between a valid email syntax and a deliverable
+## email address. The default from address is changeme@example.com so
+# @ it's a valid email string but not an actual, real mailbox.
+##
+## This is b/c currently we only perform regex validation.
+##
+@obj.valid_email?(@from_address)
+#=> true

--- a/try/68_receive_feedback_try.rb
+++ b/try/68_receive_feedback_try.rb
@@ -4,7 +4,7 @@ require_relative '../lib/onetime'
 
 # Load the app
 OT::Config.path = File.join(__dir__, '..', 'etc', 'config.test')
-OT.load! :app
+OT.boot! :app
 
 # Setup some variables for these tryouts
 @now = DateTime.now
@@ -75,7 +75,7 @@ count_before = @model_class.recent.count
 email_address = "tryouts2+#{@now}@onetimesecret.com"
 sess = OT::Session.new
 cust = OT::Customer.new email_address
-obj = OT::Logic::ReceiveFeedback.new sess, cust, {msg: 'Some feedback'}
+obj = OT::Logic::ReceiveFeedback.new sess, cust, { msg: 'Some feedback' }
 obj.process
 count_after = @model_class.recent.count
 count_after - count_before
@@ -84,7 +84,7 @@ count_after - count_before
 ## Sending feedback as an anonymous user raises a concern
 cust = OT::Customer.anonymous
 sess = OT::Session.new 'id123', 'tryouts', cust
-params = {msg: 'This is a test feedback'}
+params = { msg: 'This is a test feedback' }
 obj = OT::Logic::ReceiveFeedback.new sess, cust, params
 sess.event_clear! :send_feedback
 begin
@@ -96,7 +96,7 @@ end
 
 ## Feedback model exposes a recent method
 recent_feedback = @model_class.recent
-most_recent_pair = recent_feedback.to_a.last  # as an array [key, value]
+most_recent_pair = recent_feedback.to_a.last # as an array [key, value]
 most_recent_pair[0]
 #=> "#{@params[:msg]} [#{@email_address}]"
 

--- a/try/68_receive_feedback_try.rb
+++ b/try/68_receive_feedback_try.rb
@@ -17,7 +17,6 @@ OT.boot! :app
   msg: 'This is a test feedback'
 }
 @locale = 'en'
-puts 'before2'
 
 # TRYOUTS
 


### PR DESCRIPTION
This pull request updates the email validation in the codebase to use the Truemail gem. Truemail provides comprehensive email validation by checking the domain, MX records, and SMTP server to ensure that the email address is valid. This will help us avoid sending emails to invalid addresses and improve our mail deliverability.

This work only replaces the regex logic and doesn't use the advanced features from Truemail. Later on we'll check the deliverability etc.

Fixes #392