### PR TITLE
Partial revert for Ruby 3 syntax changes

### DIFF
--- a/lib/onetime.rb
+++ b/lib/onetime.rb
@@ -312,9 +312,9 @@ module Onetime
     class << self
       attr_reader :plans
 
-      def add_plan(planid, *)
+      def add_plan(planid, *args)
         @plans ||= {}
-        new_plan = new(planid, *)
+        new_plan = new(planid, *args)
         plans[new_plan.planid] = new_plan
         plans[new_plan.planid.gibbler.short] = new_plan
       end

--- a/try/15_config_try.rb
+++ b/try/15_config_try.rb
@@ -6,7 +6,7 @@ require_relative '../lib/onetime'
 OT::Config.path = File.join(__dir__, '..', 'etc', 'config.test')
 OT.boot! :cli
 
-@email_address ||= OT.conf[:emailer][:from]
+@email_address = OT.conf[:emailer][:from]
 
 @truemail_test_config = Truemail::Configuration.new do |config|
   config.verifier_email = @email_address


### PR DESCRIPTION
This pull request is a partial revert for commit 4b9ae8cc0cb707 (PR #393) that introduced Ruby 3 syntax changes. The revert specifically addresses the `add_plan` method in the `Plan` class, ensuring that it accepts arguments as intended and doesn't potentially cause a syntax error. 

See:
https://github.com/onetimesecret/onetimesecret/actions/runs/9477905643/job/2611329
<img width="844" alt="Screenshot 2024-06-12 at 08 40 28" src="https://github.com/onetimesecret/onetimesecret/assets/1206/d01fa00e-e009-4cfa-adfc-8444450dc7bd">
