### PR TITLE
Create housekeeping.yml

### DIFF
--- a/.github/workflows/housekeeping.yml
+++ b/.github/workflows/housekeeping.yml
@@ -1,0 +1,38 @@
+# Onetime Secret Ops
+#
+# This workflow notifies and closes issues and PRs that have had no activity for a specified amount of time.
+#
+# Documentation:
+# https://github.com/actions/stale
+name: Surface stale issues and pull requests
+
+on:
+  schedule:
+  - cron: '27 4 * * *'
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+    - uses: actions/stale@v9
+      with:
+        stale-issue-message: 'Just a heads up -- this issue is now stale (open 90 days with no activity). It will close automatically in a few weeks. You can comment or remove the stale label to restart the clock.'
+        close-issue-message: 'This issue is now closed. 🌻'
+        stale-pr-message: 'Just a heads up -- this PR is now stale (open 45 days with no activity). It will close automatically in a couple weeks. You can comment or remove the stale label to restart the clock.'
+        close-pr-message: 'This PR is now closed.'
+        days-before-issue-stale: 90
+        days-before-issue-close: 28
+        days-before-pr-stale: 45
+        days-before-pr-close: 14
+        exempt-pr-labels: auto-update,dependencies,security
+        exempt-issue-labels: security,improvement,bug
+        exempt-draft-pr: true
+        stale-issue-label: Stale Boetticher
+        stale-pr-label: Stale Boetticher
+        
+          


### PR DESCRIPTION
Warns and then closes issues and PRs that have had no activity for a specified amount of time.

---

The configuration must be on the default branch and the default values will:

Add a label "Stale" on issues and pull requests after 60 days of inactivity and comment on them Close the stale issues and pull requests after 7 days of inactivity If an update/comment occur on stale issues or pull requests, the stale label will be removed and the timer will restart