### PR TITLE
Upgrade gem dependencies for redis-rb 5+

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,19 +24,20 @@ gem 'addressable'
 
 gem 'rack'
 
+gem 'multi_json'
 gem 'thin'
 gem 'yajl-ruby'
 
 gem 'mustache'
 
 gem 'drydock'
-gem 'familia', '~> 0.9'
+gem 'familia', '>= 0.10.0'
 gem 'gibbler'
-gem 'otto', '~> 1.0', '>= 1.0'
-gem 'redis', '~> 4.8'
+gem 'otto', '~> 1.0.1'
+gem 'redis', '~> 5.2.0'
 gem 'storable'
 gem 'sysinfo'
-gem 'uri-redis', '~> 1.2'
+gem 'uri-redis', '~> 1.3.0'
 
 gem 'bcrypt'
 gem 'encryptor', '= 1.1.3'

--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,7 @@ gem 'yajl-ruby'
 gem 'mustache'
 
 gem 'drydock'
-gem 'familia', '>= 0.10.0'
+gem 'familia', '>= 0.10.1'
 gem 'gibbler'
 gem 'otto', '~> 1.0.1'
 gem 'redis', '~> 5.2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,14 +14,14 @@ GEM
       ruby-dap (~> 0.1.2)
     coderay (1.1.3)
     connection_pool (2.4.1)
-    csv (3.2.6)
+    csv (3.3.0)
     daemons (1.4.1)
     date (3.3.4)
     drydock (0.6.9)
     encryptor (1.1.3)
-    erubi (1.12.0)
+    erubi (1.13.0)
     eventmachine (1.2.7)
-    familia (0.10.0)
+    familia (0.10.1)
     gibbler (1.0.0)
       attic (~> 1.0)
       rake (~> 13.0)
@@ -42,7 +42,7 @@ GEM
     multi_xml (0.7.1)
       bigdecimal (~> 3.1)
     mustache (1.1.1)
-    net-imap (0.3.7)
+    net-imap (0.4.13)
       date
       net-protocol
     net-pop (0.1.2)
@@ -55,7 +55,7 @@ GEM
     otto (1.0.1)
       addressable (>= 2.2.6)
       rack (>= 1.2.1)
-    parallel (1.24.0)
+    parallel (1.25.1)
     parser (3.3.3.0)
       ast (~> 2.4.1)
       racc
@@ -66,7 +66,7 @@ GEM
     pry-byebug (3.10.1)
       byebug (~> 11.0)
       pry (>= 0.13, < 0.15)
-    public_suffix (5.0.5)
+    public_suffix (5.1.0)
     racc (1.8.0)
     rack (2.2.9)
     rainbow (3.1.1)
@@ -79,7 +79,7 @@ GEM
     redis-client (0.22.2)
       connection_pool
     regexp_parser (2.9.2)
-    rexml (3.2.9)
+    rexml (3.3.0)
       strscan
     rubocop (1.64.1)
       json (~> 2.3)
@@ -105,13 +105,13 @@ GEM
     sendgrid-ruby (6.7.0)
       ruby_http_client (~> 3.4)
     simpleidn (0.2.3)
-    sorbet (0.5.11428)
-      sorbet-static (= 0.5.11428)
-    sorbet-runtime (0.5.11428)
-    sorbet-static (0.5.11428-universal-darwin)
-    sorbet-static-and-runtime (0.5.11428)
-      sorbet (= 0.5.11428)
-      sorbet-runtime (= 0.5.11428)
+    sorbet (0.5.11435)
+      sorbet-static (= 0.5.11435)
+    sorbet-runtime (0.5.11435)
+    sorbet-static (0.5.11435-universal-darwin)
+    sorbet-static-and-runtime (0.5.11435)
+      sorbet (= 0.5.11435)
+      sorbet-runtime (= 0.5.11435)
     spoom (1.3.2)
       erubi (>= 1.10.0)
       prism (>= 0.19.0)
@@ -160,7 +160,7 @@ DEPENDENCIES
   byebug-dap
   drydock
   encryptor (= 1.1.3)
-  familia (>= 0.10.0)
+  familia (>= 0.10.1)
   gibbler
   httparty
   mail
@@ -192,4 +192,4 @@ RUBY VERSION
    ruby 3.2.4p170
 
 BUNDLED WITH
-   2.5.9
+   2.4.12

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,19 +13,15 @@ GEM
       byebug (~> 11.1)
       ruby-dap (~> 0.1.2)
     coderay (1.1.3)
-    csv (0.1.0)
+    connection_pool (2.4.1)
+    csv (3.2.6)
     daemons (1.4.1)
     date (3.3.4)
     drydock (0.6.9)
     encryptor (1.1.3)
     erubi (1.12.0)
     eventmachine (1.2.7)
-    familia (0.9.3)
-      gibbler (~> 1.0.0)
-      multi_json (~> 1.15)
-      redis (>= 4.8, < 7)
-      storable (~> 0.10.0)
-      uri-redis (>= 1.0.0)
+    familia (0.10.0)
     gibbler (1.0.0)
       attic (~> 1.0)
       rake (~> 13.0)
@@ -78,7 +74,10 @@ GEM
     rbi (0.1.13)
       prism (>= 0.18.0, < 1.0.0)
       sorbet-runtime (>= 0.5.9204)
-    redis (4.8.1)
+    redis (5.2.0)
+      redis-client (>= 0.22.0)
+    redis-client (0.22.2)
+      connection_pool
     regexp_parser (2.9.2)
     rexml (3.2.9)
       strscan
@@ -109,9 +108,7 @@ GEM
     sorbet (0.5.11428)
       sorbet-static (= 0.5.11428)
     sorbet-runtime (0.5.11428)
-    sorbet-static (0.5.11428-aarch64-linux)
     sorbet-static (0.5.11428-universal-darwin)
-    sorbet-static (0.5.11428-x86_64-linux)
     sorbet-static-and-runtime (0.5.11428)
       sorbet (= 0.5.11428)
       sorbet-runtime (= 0.5.11428)
@@ -154,11 +151,7 @@ GEM
       yard (>= 0.9)
 
 PLATFORMS
-  aarch64-linux
-  arm64-darwin-22
-  arm64-darwin-23
-  arm64-darwin-24
-  x86_64-linux
+  universal-darwin
 
 DEPENDENCIES
   addressable
@@ -167,16 +160,17 @@ DEPENDENCIES
   byebug-dap
   drydock
   encryptor (= 1.1.3)
-  familia (~> 0.9)
+  familia (>= 0.10.0)
   gibbler
   httparty
   mail
+  multi_json
   mustache
-  otto (~> 1.0, >= 1.0)
+  otto (~> 1.0.1)
   pry
   pry-byebug
   rack
-  redis (~> 4.8)
+  redis (~> 5.2.0)
   rubocop
   rubocop-performance
   rubocop-thread_safety
@@ -191,11 +185,11 @@ DEPENDENCIES
   thin
   truemail
   tryouts
-  uri-redis (~> 1.2)
+  uri-redis (~> 1.3.0)
   yajl-ruby
 
 RUBY VERSION
    ruby 3.2.4p170
 
 BUNDLED WITH
-   2.4.19
+   2.5.9

--- a/lib/onetime.rb
+++ b/lib/onetime.rb
@@ -94,9 +94,13 @@ module Onetime
       begin
         # Make sure we're able to connect to separate Redis databases.
         # Some services like Upstash provide only db 0.
-        16.times { |idx| OT.ld format('Connecting to %s (%s)', Familia.redis(idx).uri, Familia.redis(idx).ping) }
+        16.times { |idx|
+          uri = Familia.redis.id
+          ping_result = Familia.redis(idx).ping
+          OT.ld format('Connecting to %s (%s)', uri, ping_result)
+        }
       rescue Redis::CannotConnectError => e
-        OT.le "Cannot connect to redis #{Familia.uri} (#{e.class})"
+        OT.le "Cannot connect to redis #{Familia.id} (#{e.class})"
         exit 1
       rescue StandardError => e
         OT.le "Unexpected error `#{e}` (#{e.class})"

--- a/try/10_utils_try.rb
+++ b/try/10_utils_try.rb
@@ -2,6 +2,8 @@
 
 require_relative '../lib/onetime'
 
+# Familia.debug = true
+
 # Use the default config file for tests
 OT::Config.path = File.join(__dir__, '..', 'etc', 'config.test')
 OT.boot!


### PR DESCRIPTION
This pull request upgrades the redis gem dependencies to their latest versions. It includes the following changes:

- Bumps the `familia` version to `>= 0.10.1`.
- Bumps the `redis` version to `~> 5.2.0`.
- Bumps the `uri-redis` version to `~> 1.3.0`.
- Bumps the `otto` version to `~> 1.0.1`.
- Adds explicit `multi_json` dependency.

These updates ensure compatibility with recent changes and take advantage of bug fixes and improvements in the dependency libraries.

Related to #238, #427