### PR TITLE
Add support for deleting account aka "you're in" modal danger style

### DIFF
--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -12,5 +12,5 @@ jobs:
     - uses: actions/first-interaction@v1
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        issue-message: "Thanks for taking the time to create an issue -- @delano"
-        pr-message: "Thanks so much for contributing to onetimesecret -- @delano"
+        issue-message: "Hey thanks for taking the time to create an issue -- @delano"
+        pr-message: "Sweet, thanks for the PR. Ping me here if you need anything -- @delano"

--- a/.github/workflows/housekeeping.yml
+++ b/.github/workflows/housekeeping.yml
@@ -21,9 +21,9 @@ jobs:
     steps:
     - uses: actions/stale@28ca1036281a5e5922ead5184a1bbf96e5fc984e # v9
       with:
-        stale-issue-message: 'Just a heads up -- this issue is now stale (open 90 days with no activity). It will close automatically in a few weeks. You can comment or remove the stale label to restart the clock.'
+        stale-issue-message: 'Just a heads up -- this issue is being marked stale (open 90 days with no activity). It will close automatically in a few weeks. You can comment or remove the stale label to restart the clock.'
         close-issue-message: 'This issue is now closed. 🌻'
-        stale-pr-message: 'Just a heads up -- this PR is now stale (open 45 days with no activity). It will close automatically in a couple weeks. You can comment or remove the stale label to restart the clock.'
+        stale-pr-message: 'Just a heads up -- this PR is being marked stale (open 45 days with no activity). It will close automatically in a couple weeks. You can comment or remove the stale label to restart the clock.'
         close-pr-message: 'This PR is now closed.'
         days-before-issue-stale: 90
         days-before-issue-close: 28
@@ -34,5 +34,3 @@ jobs:
         exempt-draft-pr: true
         stale-issue-label: Stale Boetticher
         stale-pr-label: Stale Boetticher
-        
-          

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -41,8 +41,8 @@ on:
 
 jobs:
   build:
-    # runs-on: ubuntu-latest
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
+    # runs-on: self-hosted
 
     strategy:
       matrix:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -42,7 +42,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    # runs-on: self-hosted
 
     strategy:
       matrix:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -41,7 +41,8 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    # runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     strategy:
       matrix:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -41,6 +41,14 @@ on:
 
 jobs:
   build:
+    # Can also be set to `self-hosted` if worker is running. Possible
+    # issue when switching (or trying to run a mix of github-hosted
+    # and self-hosted). All workflows in the repo stopped being queued
+    # up after having a self-hosted worker registered and available
+    # and then manually shutdown and removed. To the extent that open
+    # PRs showed 0 checks at all (as though there were no workflow
+    # yaml files at all). Adding a new workflow in a test branch
+    # seemed to wake up the dragon and all was well in the world.
     runs-on: ubuntu-latest
 
     strategy:

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,7 @@
 {
+  "parser": "vue",
   "tabWidth": 2,
   "useTabs": false,
+  "bracketSameLine": true,
   "endOfLine": "lf"
 }

--- a/config.ru
+++ b/config.ru
@@ -33,6 +33,11 @@ Onetime.boot! :app
 
 if Otto.env?(:dev)
 
+  if Onetime.debug
+    require 'pry-byebug'
+    Otto.debug = true
+  end
+
   # DEV: Run web apps with extra logging and reloading
   apps.each_pair do |path, app|
     map(path) do
@@ -45,8 +50,8 @@ if Otto.env?(:dev)
       run app
     end
   end
-else
 
+else
   # PROD: run barebones webapps
   apps.each_pair do |path, app|
     app.option[:public] = PUBLIC_DIR

--- a/etc/config.test
+++ b/etc/config.test
@@ -55,3 +55,4 @@
   :show_metadata: 1000
   :show_secret: 1000
   :burn_secret: 1000
+  :destroy_account: 5

--- a/lib/onetime.rb
+++ b/lib/onetime.rb
@@ -422,6 +422,10 @@ module Onetime
       @event = event
       @count = count
     end
+
+    def message
+      "[limit-exceeded] #{identifier} for #{event} (#{count})"
+    end
   end
 end
 

--- a/lib/onetime/app/web/account.rb
+++ b/lib/onetime/app/web/account.rb
@@ -166,7 +166,7 @@ module Onetime
     end
 
     def update_account
-      authenticated do
+      authenticated('/account') do
         logic = OT::Logic::UpdateAccount.new sess, cust, req.params, locale
         logic.raise_concerns
         logic.process
@@ -175,7 +175,7 @@ module Onetime
     end
 
     def destroy_account
-      authenticated do
+      authenticated('/account') do
         logic = OT::Logic::DestroyAccount.new sess, cust, req.params, locale
         logic.raise_concerns
         logic.process

--- a/lib/onetime/app/web/account.rb
+++ b/lib/onetime/app/web/account.rb
@@ -174,6 +174,14 @@ module Onetime
       end
     end
 
+    def destroy_account
+      authenticated do
+        logic = OT::Logic::DestroyAccount.new sess, cust, req.params, locale
+        logic.raise_concerns
+        logic.process
+        res.redirect app_path('/account')
+      end
+    end
     def update_subdomain
       authenticated('/account') do
         logic = OT::Logic::UpdateSubdomain.new sess, cust, req.params, locale

--- a/lib/onetime/app/web/base.rb
+++ b/lib/onetime/app/web/base.rb
@@ -48,7 +48,9 @@ module Onetime
       def check_referrer!
         return if @check_referrer_ran
         @check_referrer_ran = true
-        OT.ld  "[check-referrer] #{req.referrer} (#{req.referrer.class}) - #{req.path}"
+        unless req.referrer.nil?
+          OT.ld("[check-referrer] #{req.referrer} (#{req.referrer.class}) - #{req.path}")
+        end
         return if req.referrer.nil? || req.referrer.match(Onetime.conf[:site][:host])
         sess.referrer ||= req.referrer
       end

--- a/lib/onetime/app/web/routes
+++ b/lib/onetime/app/web/routes
@@ -45,7 +45,7 @@ GET   /dashboard                                 Onetime::App#dashboard
 POST  /dashboard                                 Onetime::App#create_secret
 
 GET   /account                                   Onetime::App#account
-POST  /account                                   Onetime::App#update_account
+POST  /account/change_password                   Onetime::App#update_account
 POST  /account/passgen                           Onetime::App#update_account
 POST  /account/apikey                            Onetime::App#generate_apikey
 POST  /account/subdomain                         Onetime::App#update_subdomain

--- a/lib/onetime/app/web/routes
+++ b/lib/onetime/app/web/routes
@@ -46,6 +46,7 @@ POST  /dashboard                                 Onetime::App#create_secret
 
 GET   /account                                   Onetime::App#account
 POST  /account/change_password                   Onetime::App#update_account
+POST  /account/destroy                           Onetime::App#destroy_account
 POST  /account/passgen                           Onetime::App#update_account
 POST  /account/apikey                            Onetime::App#generate_apikey
 POST  /account/subdomain                         Onetime::App#update_subdomain

--- a/lib/onetime/app/web/routes
+++ b/lib/onetime/app/web/routes
@@ -29,7 +29,6 @@ GET   /info/security                             Onetime::App::Info#security
 GET   /info/terms                                Onetime::App::Info#terms
 
 GET   /pricing                                   Onetime::App#pricing
-#GET   /business                                  Onetime::App#business_pricing
 GET   /signup                                    Onetime::App#signup
 GET   /signup/:planid                            Onetime::App#signup
 POST  /signup                                    Onetime::App#create_account

--- a/lib/onetime/logic.rb
+++ b/lib/onetime/logic.rb
@@ -287,10 +287,10 @@ module Onetime
         @modified ||= []
         limit_action :update_account
         if ! @currentp.empty?
-          raise_form_error "Current password does not match" unless cust.passphrase?(@currentp)
-          raise_form_error "New passwords do not match" unless @newp == @newp2
+          raise_form_error "Current password is incorrect" unless cust.passphrase?(@currentp)
+          raise_form_error "New password cannot be the same as current password" if @newp == @currentp
           raise_form_error "New password is too short" unless @newp.size >= 6
-          raise_form_error "New password cannot match current password" if @newp == @currentp
+          raise_form_error "New passwords do not match" unless @newp == @newp2
         end
         if ! @passgen_token.empty?
           raise_form_error "Token is too short" if @passgen_token.size < 6

--- a/lib/onetime/logic.rb
+++ b/lib/onetime/logic.rb
@@ -276,7 +276,7 @@ module Onetime
     end
 
     class UpdateAccount < OT::Logic::Base
-      attr_reader :modified, :subdomain
+      attr_reader :modified
       def process_params
         @currentp = params[:currentp].to_s.strip.slice(0,60)
         @newp = params[:newp].to_s.strip.slice(0,60)

--- a/lib/onetime/logic.rb
+++ b/lib/onetime/logic.rb
@@ -143,6 +143,7 @@ module Onetime
       end
       def raise_concerns
         limit_action :destroy_session
+        OT.info "[destroy-session] #{@custid} #{@sess.ipaddress}"
       end
       def process
         sess.destroy!

--- a/lib/onetime/logic.rb
+++ b/lib/onetime/logic.rb
@@ -78,26 +78,26 @@ module Onetime
       attr_reader :custid, :stay
       attr_reader :session_ttl
       def process_params
-        @custid = params[:u].to_s.downcase.strip
+        @potential_custid = params[:u].to_s.downcase.strip
         @passwd = params[:p]
         #@stay = params[:stay].to_s == "true"
         @stay = true # Keep sessions alive by default
         @session_ttl = (stay ? 30.days : 20.minutes).to_i
-        if @custid.to_s.index(':as:')
-          @colonelname, @custid = *@custid.downcase.split(':as:')
+        if @potential_custid.to_s.index(':as:')
+          @colonelname, @potential_custid = *@potential_custid.downcase.split(':as:')
         else
-          @custid = @custid.downcase if @custid
+          @potential_custid = @potential_custid.downcase if @potential_custid
         end
         if @passwd.to_s.empty?
           @cust = nil
-        elsif @colonelname && OT::Customer.exists?(@colonelname) && OT::Customer.exists?(@custid)
-          OT.info "[login-as-attempt] #{@colonelname} as #{@custid} #{@sess.ipaddress}"
+        elsif @colonelname && OT::Customer.exists?(@colonelname) && OT::Customer.exists?(@potential_custid)
+          OT.info "[login-as-attempt] #{@colonelname} as #{@potential_custid} #{@sess.ipaddress}"
           potential = OT::Customer.load @colonelname
           @colonel = potential if potential.passphrase?(@passwd)
-          @cust = OT::Customer.load @custid if @colonel.role?(:colonel)
+          @cust = OT::Customer.load @potential_custid if @colonel.role?(:colonel)
           sess['authenticated_by'] = @colonel.custid
-          OT.info "[login-as-success] #{@colonelname} as #{@custid} #{@sess.ipaddress}"
-        elsif (potential = OT::Customer.load(@custid))
+          OT.info "[login-as-success] #{@colonelname} as #{@potential_custid} #{@sess.ipaddress}"
+        elsif (potential = OT::Customer.load(@potential_custid))
           @cust = potential if potential.passphrase?(@passwd)
         end
       end

--- a/lib/onetime/models.rb
+++ b/lib/onetime/models.rb
@@ -55,12 +55,13 @@ module Onetime::Models
     end
     def passphrase? guess
       begin
-        ret = !has_passphrase? || BCrypt::Password.new(passphrase) == guess
+        ret = BCrypt::Password.new(passphrase) == guess
         @passphrase_temp = guess if ret  # used to decrypt the value
         ret
       rescue BCrypt::Errors::InvalidHash => ex
-        msg = "[old-passphrase]"
-        !has_passphrase? || (!guess.to_s.empty? && passphrase.to_s.downcase.strip == guess.to_s.downcase.strip)
+        prefix = "[old-passphrase]"
+        OT.ld "#{prefix} Invalid passphrase hash: #{ex.message}"
+        (!guess.to_s.empty? && passphrase.to_s.downcase.strip == guess.to_s.downcase.strip)
       end
     end
   end

--- a/lib/onetime/models.rb
+++ b/lib/onetime/models.rb
@@ -15,7 +15,9 @@ class Onetime::RateLimit < Familia::String
       count = lmtr.increment
       lmtr.update_expiration
       OT.ld [:limit, event, identifier, count].inspect
-      raise OT::LimitExceeded.new(identifier, event, count) if exceeded?(event, count)
+      if exceeded?(event, count)
+        raise OT::LimitExceeded.new(identifier, event, count)
+      end
       count
     end
     alias_method :increment!, :incr!

--- a/lib/onetime/models/session.rb
+++ b/lib/onetime/models/session.rb
@@ -72,7 +72,8 @@ class Onetime::Session < Familia::HashKey
     @sessid  # Don't call the method
   end
   # Used by the limiter to estimate a unique client. We can't use
-  # the session ID b/c they can choose to not send the cookie.
+  # the session ID b/c the request agent can choose to not send
+  # the cookie (which hash the session ID).
   def external_identifier
     elements = []
     elements << ipaddress || 'UNKNOWNIP'
@@ -82,7 +83,7 @@ class Onetime::Session < Familia::HashKey
     @external_identifier
   end
   def stale?
-    self[:stale].to_s == "true"
+    self[:stale].to_s == 'true'
   end
   def update_fields hsh={}
     hsh[:sessid] ||= sessid
@@ -98,7 +99,7 @@ class Onetime::Session < Familia::HashKey
     @sessid = newid
     # This update is important b/c it ensures that the
     # data gets written to redis.
-    update_fields :stale => false
+    update_fields :stale => 'false'
     sessid
   end
   def shrimp? guess

--- a/public/web/css/main.css
+++ b/public/web/css/main.css
@@ -85,10 +85,7 @@
 
 
 
-
-
 #footer {
-
   text-align: center;
   line-height: 90%;
   padding: 0px;
@@ -214,6 +211,8 @@ div.private{font-size: 18px; line-height: 18px; margin-top: 20px;}
 .strikethrough {
   text-decoration: line-through;
 }
+.roomier { padding: 5px; }
+.small { font-size: 90%; }
 .smaller { font-size: 85%; }
 .larger { font-size: 120%; }
 .centre { text-align: center }
@@ -225,6 +224,9 @@ div.private{font-size: 18px; line-height: 18px; margin-top: 20px;}
 .hilite {background:#ff0;}
 .hilite2 {background:#6ff;}
 
+.modal-danger {
+  border: 5px solid #d9534f;
+}
 
 .err, .msg { font-weight: bold; padding: 8px; line-height: 32px; width: 100%; }
 .err { background-color: red; color: #fff }

--- a/templates/web/account.mustache
+++ b/templates/web/account.mustache
@@ -23,8 +23,8 @@
 
           <p><strong>Account type: {{plan.options.name}}</strong></p>
           <div class="well options-box">
-            <div class="title">Change Password</div>
-          <form action="/account" method="post" class="">
+          <div class="title">Update Password</div>
+          <form action="/account/change_password" method="post" class>
             {{{add_shrimp}}}
             <input type="hidden" name="tabindex" value="account" />
             <fieldset>

--- a/templates/web/account.mustache
+++ b/templates/web/account.mustache
@@ -1,28 +1,29 @@
 {{>header}}
 
+<div class="row-fluid">
+  <div class="span12">
+    <ul class="nav nav-tabs" id="contentTab">
+      <li class="active"><a href="#home">Manage Account</a></li>
+      {{#plan.options.cname}}
+      <li><a href="#cname">Branding</a></li>
+      {{/plan.options.cname}}
+      {{#plan.options.api}}
+      <li><a href="#apikey">API Key</a></li>
+      {{/plan.options.api}}
+      {{#colonel}}
+      <li><a href="#labs">Labs</a></li>
+      {{/colonel}}
+    </ul>
 
-  <div class="row-fluid">
-    <div class="span12">
+    <div class="tab-content">
+      <div class="tab-pane active" id="home">
+        {{>partial/session_messages}}
 
-      <ul class="nav nav-tabs" id="contentTab">
-        <li class="active"><a href="#home">Account</a></li>
-        {{#plan.options.cname}}
-        <li><a href="#cname">Branding</a></li>
-        {{/plan.options.cname}}
-        {{#plan.options.api}}
-        <li><a href="#apikey">API Key</a></li>
-        {{/plan.options.api}}
-        {{#colonel}}
-        <li><a href="#labs">Labs</a></li>
-        {{/colonel}}
-      </ul>
-
-      <div class="tab-content">
-        <div class="tab-pane active" id="home">
-          {{>partial/session_messages}}
-
-          <p><strong>Account type: {{plan.options.name}}</strong></p>
-          <div class="well options-box">
+        <h3>Your Account</h3>
+        <p>
+          <strong>Account type: {{ plan.options.name }}</strong>
+        </p>
+        <div class="well options-box">
           <div class="title">Update Password</div>
           <form action="/account/change_password" method="post" class>
             {{{add_shrimp}}}
@@ -31,25 +32,45 @@
               <div class="control-group">
                 <label class="control-label" for="custidField">Current Password</label>
                 <div class="controls">
-                  <input type="password" name="currentp" id="custidField" class="input-xlarge" value="{{form_fields.custid}}" placeholder="" />
+                  <input
+                    type="password"
+                    name="currentp"
+                    id="custidField"
+                    class="input-medium"
+                    value
+                    placeholder />
                 </div>
-                <label class="control-label" for="passField">Password</label>
+                <label class="control-label" for="passField">New Password</label>
                 <div class="controls">
-                  <input type="password" name="newp" id="passField" class="input-medium" value="" placeholder="" />
+                  <input
+                    type="password"
+                    name="newp"
+                    id="passField"
+                    class="input-large"
+                    value
+                    placeholder />
                 </div>
-                <label class="control-label" for="pass2Field">Confirm Password</label>
+                <label class="control-label" for="pass2Field">Confirm</label>
                 <div class="controls">
-                  <input type="password" name="newp2" id="pass2Field" class="input-medium" value="" placeholder="" />
+                  <input
+                    type="password"
+                    name="newp2"
+                    id="pass2Field"
+                    class="input-large"
+                    value
+                    placeholder />
                 </div>
               </div>
               <div class="control-group">
                 <div class="controls">
-                  <button type="submit" class="btn btn-inverse cufon">Save Password</button>
+                  <button type="submit" class="btn btn-inverse">
+                    Update
+                  </button>
                 </div>
               </div>
             </fieldset>
           </form>
-          </div>
+        </div>
 
         <hr>
 
@@ -114,133 +135,139 @@
             <strong>{{ customer_since }}</strong>.</em>
         </p>
 
-          {{#contributor}}
-          <p class="lighter"><em>You became a <a href="/contributor">contributor</a> on <strong>{{contributor_since}}</strong>.</em></p>
-          {{/contributor}}
-
-        </div>
-
-        {{#plan.options.api}}
-        <div class="tab-pane" id="apikey">
-
-          <h2 for="custid">Your API key:</h2>
-
-          {{>partial/session_messages}}
-
-          <form action="/account/apikey" method="post">
-            {{{add_shrimp}}}
-            <input type="hidden" name="tabindex" value="apikey" />
-            {{#cust.apitoken}}
-            <div>
-              <pre class="hilite">{{#cust.apitoken}}{{cust.apitoken}}{{/cust.apitoken}}</pre>
-              <p class="smaller lighter">DO NOT SHARE YOUR KEY. When in doubt, generate a new one.</p>
-            </div>
-            <button class="btn btn-inverse cufon" type="submit">Regenerate Key</button>
-            {{/cust.apitoken}}
-            {{^cust.apitoken}}
-            <button class="btn btn-inverse cufon" type="submit">Generate Key</button>
-            {{/cust.apitoken}}
-          </form>
-          <hr/>
-        </div>
-        {{/plan.options.api}}
-
-        {{#plan.options.cname}}
-        <div class="tab-pane" id="cname">
-          {{>partial/session_messages}}
-          <hr/>
-
-          <form action="/account/subdomain" method="post">
-            {{{add_shrimp}}}
-            <input type="hidden" name="tabindex" value="cname" />
-
-            <strong><label for="cnameField"></label>
-            <input type="text" name="cname" id="cnameField" class="short" value="{{cname}}" />.onetimesecret.com</strong> {{#has_cname}}(<a href="{{cname_uri}}" class="smaller lighter">Link</a>){{/has_cname}}<br/>
-            <hr/>
-            <label for="companyField">Company:</label>
-            <input type="text" name="company" id="companyField" class="long" value="{{cust_subdomain.company}}" /><br/>
-
-            <label for="homepageField">Homepage:</label>
-            <input type="text" name="homepage" id="homepageField" class="long" value="{{cust_subdomain.homepage}}" /><br/>
-
-            <label for="contactField">Contact Name:</label>
-            <input type="text" name="contact" id="contactField" class="long" value="{{cust_subdomain.contact}}" /><br/>
-
-            <label for="emailField">Contact Email:</label>
-            <input type="text" name="email" id="emailField" class="long" value="{{cust_subdomain.email}}" /><br/>
-            <div class="smaller lighter">Emails are sent from this address. If you have problems, let us know.</div>
-
-            <label for="logoURLField">Logo URL:</label>
-            <input type="text" name="logo_uri" id="logoURLField" class="long" value="{{cust_subdomain.logo_uri}}" /><br/>
-
-            <label for="colorPrimaryField">Primary color:</label>
-            <input type="text" name="cp" id="colorPrimaryField" class="short" value="{{cust_subdomain.primary_color}}" /><br/>
-
-            <label for="colorSecondaryField">Secondary color:</label>
-            <input type="text" name="cs" id="colorSecondaryField" class="short" value="{{cust_subdomain.secondary_color}}" /><br/>
-
-            <label for="colorBorderField">Border color:</label>
-            <input type="text" name="cb" id="colorBorderField" class="short" value="{{cust_subdomain.border_color}}" /><br/>
-
-            <span id="fireSmall" class="button"><button type="submit">Update Branding</button></span>
-          </form>
-
-        </div>
-        {{/plan.options.cname}}
-
-        {{#colonel}}
-        <div class="tab-pane" id="labs">
-
-          <em class="msg">These features are experimental.</em>
-
-          <h2 class="intro">Password Generator </h2>
-          <p><a href="" id="generatedBookmarklet">OTPassGen</a> &lt;-- drag to toolbar</p>
-          <!--<p>Password formula: unique token + host + master password</p>-->
-          <form action="/account/passgen" method="post">
-            {{{add_shrimp}}}
-            <input type="hidden" name="tabindex" value="labs" />
-            <p>
-              Your unique token:<br/>
-              <input id="uniqueToken" name="passgen_token" value="{{token}}" class="selectable" size="60" /><br/>
-              <span class="lighter smaller">(Hint: you can change it to anything you like)</span>
-            </p>
-            <span id="fireSmall" class="button"><button type="submit">Update Token</button></span>
-          </form>
-          <p class="smaller">Careful: make a note of your unique token.</p>
-          <script type="text/javascript" src="/js/passgen-template.js"></script>
-          <script type="text/javascript">
-            function updateBookmarklet(token) {
-              var template = '(' + passgenTemplate.toString() + ')();'
-              var jscontent = Mustache.to_html(template, {CHANGEMECHANGEME: token})
-              var packer = new Packer;
-              var bookmarklet = encodeURI(packer.pack(jscontent, false));
-              $('#generatedBookmarklet').attr('href', 'javascript:/*v0.3*/' + bookmarklet)
-            }
-            //$('#uniqueToken').change(function() {
-            //  updateBookmarklet($('#uniqueToken').val());
-            //});
-            //updateBookmarklet($('#uniqueToken').val());
-          </script>
-
-          <h3>Try it !</h3>
-
-          <ol>
-            <li>Drag the link above to your toolbar</li>
-            <li>Click on the input box below</li>
-            <li>Click the bookmarklet</li>
-            <li>Enter a Master Password (can be anything)</li>
-            <li>Hit enter or click "Generate"</li>
-          </ol>
-          <p><input id="" type="password" class="long" /></p>
-
-
-        </div>
-        {{/colonel}}
-
+        {{#contributor}}
+        <p class="lighter">
+          <em>You became a <a href="/contributor">contributor</a> on
+            <strong>{{ contributor_since }}</strong>.</em>
+        </p>
+        {{/contributor}}
       </div>
+
+      {{#plan.options.api}}
+      <div class="tab-pane" id="apikey">
+        <h3 for="custid">API Key</h3>
+
+        {{>partial/session_messages}}
+
+        <form action="/account/apikey" method="post">
+          {{{add_shrimp}}}
+          <input type="hidden" name="tabindex" value="apikey" />
+          {{#cust.apitoken}}
+          <div>
+            <pre class="hilite">{{#cust.apitoken}}{{ cust.apitoken }}{{/cust.apitoken}}</pre>
+            <p class="smaller lighter">
+              DO NOT SHARE YOUR KEY. When in doubt, generate a new one.
+            </p>
+          </div>
+          <button class="btn btn-inverse cufon" type="submit">
+            Regenerate Key
+          </button>
+          {{/cust.apitoken}}
+          {{^cust.apitoken}}
+          <button class="btn btn-inverse cufon" type="submit">
+            Generate Key
+          </button>
+          {{/cust.apitoken}}
+        </form>
+        <hr />
+      </div>
+      {{/plan.options.api}}
+
+      {{#plan.options.cname}}
+      <div class="tab-pane" id="cname">
+        <h3 for="custid">Custom Subdomain</h3>
+
+        {{>partial/session_messages}}
+        <hr />
+
+        <form action="/account/subdomain" method="post">
+          {{{add_shrimp}}}
+          <input type="hidden" name="tabindex" value="cname" />
+
+          <strong><label for="cnameField"></label>
+            <input
+              type="text"
+              name="cname"
+              id="cnameField"
+              class="short"
+              value="{{ cname }}" />.onetimesecret.com</strong>
+          {{#has_cname}}(<a href="{{ cname_uri }}" class="smaller lighter">Link</a>){{/has_cname}}<br />
+          <hr />
+          <label for="companyField">Company:</label>
+          <input
+            type="text"
+            name="company"
+            id="companyField"
+            class="long"
+            value="{{ cust_subdomain.company }}" /><br />
+
+          <label for="homepageField">Homepage:</label>
+          <input
+            type="text"
+            name="homepage"
+            id="homepageField"
+            class="long"
+            value="{{ cust_subdomain.homepage }}" /><br />
+
+          <label for="contactField">Contact Name:</label>
+          <input
+            type="text"
+            name="contact"
+            id="contactField"
+            class="long"
+            value="{{ cust_subdomain.contact }}" /><br />
+
+          <label for="emailField">Contact Email:</label>
+          <input
+            type="text"
+            name="email"
+            id="emailField"
+            class="long"
+            value="{{ cust_subdomain.email }}" /><br />
+          <div class="smaller lighter">
+            Emails are sent from this address. If you have problems, let us
+            know.
+          </div>
+
+          <label for="logoURLField">Logo URL:</label>
+          <input
+            type="text"
+            name="logo_uri"
+            id="logoURLField"
+            class="long"
+            value="{{ cust_subdomain.logo_uri }}" /><br />
+
+          <label for="colorPrimaryField">Primary color:</label>
+          <input
+            type="text"
+            name="cp"
+            id="colorPrimaryField"
+            class="short"
+            value="{{ cust_subdomain.primary_color }}" /><br />
+
+          <label for="colorSecondaryField">Secondary color:</label>
+          <input
+            type="text"
+            name="cs"
+            id="colorSecondaryField"
+            class="short"
+            value="{{ cust_subdomain.secondary_color }}" /><br />
+
+          <label for="colorBorderField">Border color:</label>
+          <input
+            type="text"
+            name="cb"
+            id="colorBorderField"
+            class="short"
+            value="{{ cust_subdomain.border_color }}" /><br />
+
+          <span id="fireSmall" class="button"><button type="submit">Update Branding</button></span>
+        </form>
+      </div>
+      {{/plan.options.cname}}
 
     </div>
   </div>
-
+</div>
 
 {{>footer}}

--- a/templates/web/account.mustache
+++ b/templates/web/account.mustache
@@ -51,7 +51,68 @@
           </form>
           </div>
 
-          <p class="lighter"><em>Created <strong>{{cust.secrets_created}}</strong> secrets since <strong>{{customer_since}}</strong>.</em></p>
+        <hr>
+
+        <div class="well well-large well-danger options-box">
+          <div class="title primary">Delete Account</div>
+
+          <div class="control-group">
+            <p class="small">
+              Please be advised:
+              <ul class="small">
+                <li><strong>Secrets will remain active until they expire.</strong> </li>
+                <li>Any secrets you wish to remove, <span class="underline">burn them before continuing.</span></li>
+                <li>Deleting your account is <em>permanent and non-reversable</em>.</li>
+              </ul>
+            </p>
+
+          </div>
+          <div class="control-group">
+            <div class="controls">
+              <button type data-toggle="modal" data-target="#yourInModalDanger" class="btn btn-danger">
+                Permanently Delete Account
+              </button>
+              <p class="lighter roomier small">
+                <em>Deleting {{ cust.custid }}</em>
+              </p>
+            </div>
+          </div>
+
+        </div>
+        <!-- Modal: Delete Account -->
+        <div id="yourInModalDanger" class="modal modal-danger hide fade" tabindex="-1" role="dialog"
+          aria-labelledby="yourInModalDangerLabel" aria-hidden="true">
+          <form action="/account/destroy" method="post" class>
+            {{{add_shrimp}}}
+            <input type="hidden" name="tabindex" value="destroy" />
+            <fieldset>
+              <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>
+                <h3 id="yourInModalDangerLabel">Delete Account</h3>
+              </div>
+              <div class="modal-body">
+                <p>Yes I do indeed concur, wholeheartedly.</p>
+                <div class="controls">
+                  <input
+                    type="password"
+                    name="currentp"
+                    id="custidField"
+                    class="input-medium"
+                    placeholder="Password" />
+                </div>
+              </div>
+              <div class="modal-footer">
+                <button class="btn" data-dismiss="modal" aria-hidden="true">Close</button>
+                <button class="btn btn-danger">Delete Account</button>
+              </div>
+            </fieldset>
+          </form>
+        </div>
+
+        <p class="lighter">
+          <em>Created <strong>{{ cust.secrets_created }}</strong> secrets since
+            <strong>{{ customer_since }}</strong>.</em>
+        </p>
 
           {{#contributor}}
           <p class="lighter"><em>You became a <a href="/contributor">contributor</a> on <strong>{{contributor_since}}</strong>.</em></p>

--- a/templates/web/not_found.mustache
+++ b/templates/web/not_found.mustache
@@ -9,8 +9,9 @@
     <ul class="nav">
       <li class="alt"><a href="/"></a></li>
     </ul>
-
-    <a class="btn btn-large btn-block btn-custom cufon" href="/" class="">Go share a secret!</a>
+    <br><br><br>
+    <br><br><br>
+    <a class="btn btn-large btn-block btn-secondary" href="/">Go share a secret!</a>
 
   </div>
 

--- a/templates/web/partial/session_messages.mustache
+++ b/templates/web/partial/session_messages.mustache
@@ -1,14 +1,14 @@
 
-{{#messages.info}}
-<div class="alert alert-info">
-  <button type="button" class="close" data-dismiss="alert">&times;</button>
-  {{to_s}}
-</div>
-{{/messages.info}}
-
 {{#messages.error}}
 <div class="alert alert-error">
   <button type="button" class="close" data-dismiss="alert">&times;</button>
   <strong>{{i18n.COMMON.oops}}</strong> {{to_s}}
 </div>
 {{/messages.error}}
+
+{{#messages.info}}
+<div class="alert alert-info">
+  <button type="button" class="close" data-dismiss="alert">&times;</button>
+  {{to_s}}
+</div>
+{{/messages.info}}

--- a/try/60_logic_base_try.rb
+++ b/try/60_logic_base_try.rb
@@ -2,10 +2,6 @@
 
 require_relative '../lib/onetime'
 
-# frozen_string_literal: true
-
-require_relative '../lib/onetime'
-
 # Load the app
 OT::Config.path = File.join(__dir__, '..', 'etc', 'config.test')
 OT.boot! :app

--- a/try/61_logic_destroy_account_try.rb
+++ b/try/61_logic_destroy_account_try.rb
@@ -1,0 +1,148 @@
+# frozen_string_literal: true
+
+require_relative '../lib/onetime'
+
+# Load the app
+OT::Config.path = File.join(__dir__, '..', 'etc', 'config.test')
+OT.boot! :app
+
+# Setup some variables for these tryouts
+@email_address = 'changeme@example.com'
+@now = DateTime.now
+@sess = OT::Session.new
+@sess.event_clear! :destroy_account
+@cust = OT::Customer.new @email_address
+@sess.event_clear! :send_feedback
+@params = {
+  currentp: 'pa55w0rd'
+}
+
+def generate_random_email
+  # Generate a random username
+  username = (0...8).map { ('a'..'z').to_a[rand(26)] }.join
+  # Define a domain
+  domain = "onetimesecret.com"
+  # Combine to form an email address
+  "#{username}@#{domain}"
+end
+
+# TRYOUTS
+
+## Can create DestroyAccount instance
+obj = OT::Logic::DestroyAccount.new @sess, @cust, @params
+obj.params[:currentp]
+#=> @params[:currentp]
+
+## Processing params removes leading and trailing whitespace
+## from current password, but not in the middle.
+password_guess = '   padded p455   '
+obj = OT::Logic::DestroyAccount.new @sess, @cust, currentp: password_guess
+obj.process_params
+#=> 'padded p455'
+
+
+## Raises an error if no params are passed at all
+obj = OT::Logic::DestroyAccount.new @sess, @cust
+begin
+  obj.raise_concerns
+rescue => e
+  puts e.backtrace
+  [e.class, e.message]
+end
+#=> [Onetime::FormError, 'Password does not match.']
+
+
+## Raises an error if the current password is nil
+obj = OT::Logic::DestroyAccount.new @sess, @cust, currentp: nil
+begin
+  obj.raise_concerns
+rescue => e
+  [e.class, e.message]
+end
+#=> [Onetime::FormError, 'Password confirmation is required.']
+
+
+## Raises an error if the current password is empty
+obj = OT::Logic::DestroyAccount.new @sess, @cust, currentp: ''
+begin
+  obj.raise_concerns
+rescue => e
+  [e.class, e.message]
+end
+#=> [Onetime::FormError, 'Password confirmation is required.']
+
+
+## Raises an error if the password is incorrect
+cust = OT::Customer.new generate_random_email
+password_guess = 'wrong password'
+obj = OT::Logic::DestroyAccount.new @sess, cust, @params
+cust.update_passphrase password_guess
+begin
+  obj.raise_concerns
+rescue => e
+  [e.class, e.message]
+end
+#=> [Onetime::FormError, 'Password does not match.']
+
+
+## No errors are raised as long as the password is correct
+cust = OT::Customer.new generate_random_email
+password_guess = @params[:currentp]
+obj = OT::Logic::DestroyAccount.new @sess, cust, @params
+cust.update_passphrase password_guess
+obj.raise_concerns
+#=> nil
+
+
+## Too many attempts is throttled by rate limiting
+cust = OT::Customer.new generate_random_email
+password_guess = @params[:currentp]
+obj = OT::Logic::DestroyAccount.new @sess, cust, @params
+cust.update_passphrase password_guess
+
+# Make sure we start from 0
+@sess.event_clear! :destroy_account
+
+last_error = nil
+6.times do
+  begin
+    obj.raise_concerns
+  rescue => e
+    last_error = [e.class, e.message]
+  end
+end
+@sess.event_clear! :destroy_account
+last_error
+#=> [OT::LimitExceeded, '[limit-exceeded] 9b8yjehe955u8l6kicd1jz90xqj8nz for destroy_account (6)']
+
+## Attempt to process the request without calling raise_concerns first
+password_guess = @params[:currentp]
+obj = OT::Logic::DestroyAccount.new @sess, @cust, @params
+begin
+  obj.process
+rescue => e
+  [e.class, e.message]
+end
+#=> [Onetime::FormError, "We have concerns about that request."]
+
+## Process the request and destroy the account
+cust = OT::Customer.new generate_random_email
+obj = OT::Logic::DestroyAccount.new @sess, cust, @params
+cust.update_passphrase @params[:currentp]
+obj.raise_concerns
+obj.process
+[cust.role, cust.verified, cust.passphrase]
+#=> ['user_deleted_customer', 'false', '']
+
+## Destroyed account gets a new api key
+cust = OT::Customer.new generate_random_email
+first_token = cust.regenerate_apitoken  # first we need to set an api key
+obj = OT::Logic::DestroyAccount.new @sess, cust, @params
+cust.update_passphrase @params[:currentp]
+obj.raise_concerns
+obj.process
+first_token.eql?(cust.apitoken)
+#=> false
+
+
+@sess.event_clear! :destroy_account


### PR DESCRIPTION
The changes introduce a new feature allowing users to delete their accounts, along with several UI and backend improvements. Previously deleting an account required a support request.

1. **Account Deletion Feature**:
   - Added a new section in the account management UI for deleting accounts.
   - Introduced a modal confirmation dialog for account deletion.
   - Implemented backend logic to handle account deletion, including password confirmation and marking the account for expiration.

2. **UI Enhancements**:
   - Updated the account management UI to improve clarity and usability.
   - Changed labels and button texts for better user understanding.
   - Added new CSS classes for styling the account deletion modal and other UI elements (including "you're in" modal danger style).
   - Improved the layout and structure of the account management page.

3. **Backend Logic Improvements**:
   - Refactored the `process_params` method to use `@potential_custid` instead of `@custid` for better clarity.
   - Added new validation checks for password updates to reduce annoyance level.
   - Introduced logging for account deletion and session destruction events.

4. **Miscellaneous**:
   - Updated `.prettierrc` configuration for consistent code formatting.
   - Added conditional logging for referrer checks to avoid nil errors.

Fixes #404

---

![image](https://github.com/onetimesecret/onetimesecret/assets/1206/ab064217-1cf3-49f8-8fe2-1ac0a7426d71)
![image](https://github.com/onetimesecret/onetimesecret/assets/1206/07ccc412-072d-4fec-9e02-7d4efbca0240)
