### PR TITLE
[#441] Model-specific fix for nil Metadata#update_fields

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,7 @@ gem 'yajl-ruby'
 gem 'mustache'
 
 gem 'drydock'
-gem 'familia', '>= 0.10.1'
+gem 'familia', '~> 0.10.2'
 gem 'gibbler'
 gem 'otto', '~> 1.0.1'
 gem 'redis', '~> 5.2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,7 +21,12 @@ GEM
     encryptor (1.1.3)
     erubi (1.13.0)
     eventmachine (1.2.7)
-    familia (0.10.1)
+    familia (0.10.2)
+      gibbler (~> 1.0.0)
+      multi_json (~> 1.15)
+      redis (>= 4.8.1, < 6.0)
+      storable (~> 0.10.0)
+      uri-redis (~> 1.3)
     gibbler (1.0.0)
       attic (~> 1.0)
       rake (~> 13.0)
@@ -159,7 +164,7 @@ DEPENDENCIES
   byebug-dap
   drydock
   encryptor (= 1.1.3)
-  familia (>= 0.10.1)
+  familia (~> 0.10.2)
   gibbler
   httparty
   mail

--- a/lib/onetime/models/metadata.rb
+++ b/lib/onetime/models/metadata.rb
@@ -20,7 +20,7 @@ module Onetime
       super name, :db => 7, :ttl => 7.days
     end
     def update_fields hsh={}
-      hsh[:custid] ||= custid
+      hsh[:custid] ||= custid || ''  # anything but nil, see #441
       super hsh
     end
     def identifier


### PR DESCRIPTION
### **User description**
Rhymes with Brooke Shields.

Also, this change resolves the error when verifying account.


___

### **PR Type**
Bug fix, Dependencies


___

### **Description**
- Added a fallback to ensure `custid` is not nil in the `update_fields` method of the `Metadata` model.
- Updated `familia` gem version from `>= 0.10.1` to `~> 0.10.2`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>metadata.rb</strong><dd><code>Ensure `custid` is not nil in `update_fields` method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
lib/onetime/models/metadata.rb

<li>Added a fallback to ensure <code>custid</code> is not nil in <code>update_fields</code> method.<br>


</details>
    

  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/443/files#diff-37c1391c13ede3383947f3799790fdd1cce1e9c6793c28caaed3aa4caa53a1fb">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Dependencies
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Gemfile</strong><dd><code>Update `familia` gem version to `~> 0.10.2`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
Gemfile

- Updated `familia` gem version from `>= 0.10.1` to `~> 0.10.2`.



</details>
    

  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/443/files#diff-d09ea66f8227784ff4393d88a19836f321c915ae10031d16c93d67e6283ab55f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

