### PR TITLE
#20240702 Update GA triggers for docker image builds

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,10 +2,10 @@ name: Docker
 
 on:
   push:
-    branches: [ "develop", "rel/*", "feature/*" ]
-    tags: [ "rel/*" ]
+    branches: [ "develop", "feature/*" ]
+    tags: [ "v*" ]
   pull_request:
-    branches: [ "rel/*", "feature/*" ]
+    branches: [ "develop", "feature/*", "rel/*" ]
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
This pull request updates the release trigger for Docker image publishing. It modifies the trigger to only consider tags starting with 'v' to denote versioned releases, excluding development branches from unnecessary publishing. The changes ensure that Docker images are published only for stable releases intended for production use, helping avoid wasted builds and resources on branches without finalized changes.