### PR TITLE
Improve logging and error handling

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -38,3 +38,4 @@ spoom_*
 .history
 .vscode
 .dev-container
+.certs/

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ vendor
 data/
 *.toml
 !pr_agent.toml
+.certs/
+Caddyfile

--- a/lib/onetime.rb
+++ b/lib/onetime.rb
@@ -147,33 +147,34 @@ module Onetime
       File.chmod(chmod, filename)
     end
 
-    def info(*msg)
-      # prefix = "I(#{Time.now.to_i}):  "
-      # msg = "#{prefix}" << msg.join("#{$/}#{prefix}")
-      msg = msg.join($/)
-      return unless mode?(:app) || mode?(:cli)
-
-      warn(msg) if STDOUT.tty?
-      SYSLOG.info msg
+    def info(*msgs)
+      return unless mode?(:app) || mode?(:cli) # can reduce output in tryouts
+      msg = msgs.join("#{$/}")
+      stdout("I", msg)
     end
 
-    def le(*msg)
-      prefix = "E(#{Time.now.to_i}):  "
-      msg = "#{prefix}" << msg.join("#{$/}#{prefix}")
-      warn(msg) if STDOUT.tty?
-      SYSLOG.err msg
+    def le(*msgs)
+      msg = msgs.join("#{$/}")
+      stderr("E", msg)
     end
 
-    def ld(*msg)
+    def ld(*msgs)
       return unless Onetime.debug
+      msg = msgs.join("#{$/}")
+      stderr("D", msg)
+    end
 
-      prefix = "D(#{Time.now.to_i}):  "
-      msg = "#{prefix}" << msg.join("#{$/}#{prefix}")
-      if STDOUT.tty?
-        warn(msg)
-      else
-        SYSLOG.crit msg
-      end
+    private
+    def stdout(prefix, msg)
+      stamp = Time.now.to_i
+      logline = "%s(%s): %s" % [prefix, stamp, msg]
+      STDOUT.puts(logline)
+    end
+
+    def stderr(prefix, msg)
+      stamp = Time.now.to_i
+      logline = "%s(%s): %s" % [prefix, stamp, msg]
+      STDERR.puts(logline)
     end
   end
 

--- a/lib/onetime/config.rb
+++ b/lib/onetime/config.rb
@@ -16,7 +16,7 @@ module Onetime
 
       YAML.load(ERB.new(File.read(path)).result)
     rescue StandardError => e
-      SYSLOG.err e.message
+      OT.err e.message
       msg = if path =~ /locale/
               "Error loading locale: #{path} (#{e.message})"
             else


### PR DESCRIPTION
### **User description**
Simplified OT logging methods and removed `Syslog` in favor of trusty STDOUT/STDERR.

Fixes #459 #460


___

### **PR Type**
Enhancement, Configuration changes


___

### **Description**
- Simplified logging methods by removing `Syslog` and using STDOUT/STDERR.
- Added private methods `stdout` and `stderr` for standardized logging format.
- Updated `info`, `le`, and `ld` methods to use new logging methods.
- Replaced `SYSLOG.err` with `OT.err` for error logging in configuration.
- Added `.certs/` directory to `.dockerignore`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>onetime.rb</strong><dd><code>Simplify logging methods and remove `Syslog`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
lib/onetime.rb

<li>Simplified logging methods by removing <code>Syslog</code> and using STDOUT/STDERR.<br> <li> Added private methods <code>stdout</code> and <code>stderr</code> for standardized logging <br>format.<br> <li> Updated <code>info</code>, <code>le</code>, and <code>ld</code> methods to use new logging methods.<br>


</details>
    

  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/461/files#diff-fdca55a2ee0875c33af04f1ecd5140eee8528d6756a21ab4837f579da61f0d37">+22/-21</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>config.rb</strong><dd><code>Update error logging method in configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
lib/onetime/config.rb

- Replaced `SYSLOG.err` with `OT.err` for error logging.



</details>
    

  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/461/files#diff-ef8528e98ccc09f9e1104d5942cdc820a1a35defc502edebe5a19eecb07dc8e5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.dockerignore</strong><dd><code>Update .dockerignore to include .certs directory</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
.dockerignore

- Added `.certs/` directory to `.dockerignore`.



</details>
    

  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/461/files#diff-2f754321d62f08ba8392b9b168b83e24ea2852bb5d815d63e767f6c3d23c6ac5">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

