### PR TITLE
Fix invalid %-encoding in POST request handling

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -22,6 +22,12 @@ AllCops:
   UseCache: true
   MaxFilesInCache: 100
   TargetRubyVersion: 3.0
+  Exclude:
+    - 'migrate/**/*.rb'
+    - 'migrate/*.rb'
+    - 'try/**/*'
+    - 'try/*.rb'
+    - 'vendor/**/*'
 
 Gemspec/DeprecatedAttributeAssignment:
   Enabled: true

--- a/lib/middleware/handle_invalid_percent_encoding.rb
+++ b/lib/middleware/handle_invalid_percent_encoding.rb
@@ -1,0 +1,76 @@
+
+require 'rack'
+require 'logger'
+
+
+# Rack::HandleInvalidPercentEncoding
+#
+# This middleware addresses the challenge of handling malformed percent-encoded
+# data in HTTP requests. Instead of attempting to guess or fix invalid encodings,
+# which could lead to silent but deadly data corruption, it:
+#
+# 1. Detects invalid percent-encoding early in the request processing.
+# 2. Returns a 400 Bad Request with a clear error message.
+# 3. Logs the error for debugging and monitoring.
+#
+# This approach prioritizes security and transparency, providing meaningful
+# feedback to API consumers and end-users while preventing potential
+# application crashes or unpredictable behavior.
+#
+# Based on community solution by Henrik N:
+# https://stackoverflow.com/questions/24648206/ruby-on-rails-invalid-byte-sequence-in-utf-8-due-to-bot/24727310#24727310
+#
+class Rack::HandleInvalidPercentEncoding
+  @default_content_type = 'application/json'
+  @default_charset      = 'utf-8'
+
+  class << self
+    attr_reader :default_content_type, :default_charset
+  end
+
+  attr_reader :logger
+
+  def initialize(app, io: $stdout)
+    @app = app
+    @logger = Logger.new(io)
+  end
+
+  def call(env)
+
+    # The instantiated request object isn't available until later in the
+    # middleware chain so we need to create our own instance here in order
+    # to attempt triggering the error. We use the dup method to avoid
+    # modifying the original env object.
+    request = Rack::Request.new(env.dup)
+
+    begin
+      # Calling request.params is sufficient to trigger the error
+      # without needing to muck further into Rack internals.
+      #
+      # See https://github.com/rack/rack/issues/337#issuecomment-46453404
+      #
+      request.params
+
+    rescue ArgumentError => e
+      raise e unless e.message =~ /invalid %-encoding/
+      rack_input = request.get_header('rack.input').read
+
+      message = "`#{e.message}` in one of the following params: #{rack_input}"
+      logger.info "[handle-invalid-percent-encoding] #{message}"
+      content_type = env['HTTP_ACCEPT'] || self.class.default_content_type
+      status = 400
+      body   = { error: 'Bad Request', message: e.message }.to_json
+      return [
+        status,
+        {
+          'Content-Type': "#{content_type}; charset=#{self.class.default_charset}",
+           'Content-Length': body.bytesize.to_s
+        },
+        [body]
+      ]
+    else
+
+      @app.call(env)
+    end
+  end
+end

--- a/support/powershell/Create-Password-Link.ps1
+++ b/support/powershell/Create-Password-Link.ps1
@@ -1,0 +1,171 @@
+
+
+<#
+.SYNOPSIS
+This demo script simulates generating a strong password and creates a one-time secret using the OneTimeSecret service. (Passwords are actually randomly selected from a pre-defined list.)
+
+NOTE: Not meant for production use.
+
+.DESCRIPTION
+The script performs the following actions:
+1. Sets up environment variables for the OneTimeSecret service.
+2. Configures TLS 1.2 for secure communication.
+3. Imports the OneTimeSecret module.
+4. Defines a function that selects a random password from a pre-defined list. This mimics the output expected from System.Web.Security.Membership.GeneratePassword() (which is not available on macos Powershell).
+5. Sets the authorization token for OneTimeSecret.
+6. Generates a strong password.
+7. Creates a new one-time secret with the generated password.
+
+.NOTES
+Prerequisites:
+- PowerShell 7.0 or later (for null-coalescing operator)
+- OneTimeSecret module must be installed
+- System.Web assembly for password generation
+
+Environment Variables:
+BASE_URL: The base URL for the OneTimeSecret service (default: "http://localhost:7143/")
+OTS_USER_EMAIL: User email for OneTimeSecret authentication
+OTS_API_KEY: API key for OneTimeSecret authentication
+
+.EXAMPLE
+To run the script:
+1. Set the required environment variables:
+   $env:BASE_URL = "http://localhost:7143/"
+   $env:OTS_USER_EMAIL = "your_email@example.com"
+   $env:OTS_API_KEY = "your_api_key"
+2. Run the script:
+   .\script_name.ps1
+
+.LINK
+https://github.com/chelnak/OneTimeSecret
+#>
+
+# Rest of your script content follows...
+
+$BaseUrl = $env:BASE_URL ?? "http://localhost:7143/"
+$UserEmail = $env:OTS_USER_EMAIL
+$APIKey = $env:OTS_API_KEY
+
+# SET TLS LEVEL
+# Ensure we're using TLS 1.2 for secure communication
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
+# Import the OneTimeSecret module for OTP functionality
+Import-Module OneTimeSecret
+
+# Add System.Web assembly for password generation
+Add-Type -AssemblyName System.Web
+
+# Function to Generate Strong Password
+Function GenerateStrongPassword ([Parameter(Mandatory=$true)][int]$PasswordLenght)
+{
+    Add-Type -AssemblyName System.Web
+    $PassComplexCheck = $false
+    do {
+
+        # Generate a random password
+        #
+        # $newPassword=[System.Web.Security.Membership]::GeneratePassword($PasswordLenght,1)
+        #
+        # If you are using a `*nix` platform (Mac or Linux) you will
+        # see the error `Unable to find type [System.Web.Security.Membership]`
+        # because the `System.Web.Security.Membership` module is not part of
+        # PS Core on `*nix` platforms. You can overcome this by providing
+        # a password using this argument:
+        #
+        # `-adminPassword $(ConvertTo-SecureString -AsPlainText
+        # -Force '<Some Password Here>')`
+        #
+        # https://github.com/microsoft/OpenHack-FHIR/pull/11/files
+        #
+        # List of predefined passwords (see GeneratePassword.rb)
+        $predefinedPasswordsWithSpecial = @(
+            'z%!8UP', # ok
+            '>%nYF8', '/b37U', 'g3H{l',
+            '8%g)5T', # ok
+            'm%vB6[',
+            'I%4}?w', # too few arguments
+            '8%!_eJ', # ok
+            'Abcd%', 'D%efg', 'Tr+5n', 'w+9UG',
+            'V9r@R', # malformed format string - %R
+            'M&w8x'
+        )
+        $predefinedPasswordsOnlyBroken = @(
+            'z%!8UP%R',
+            'I%4}?w', # too few arguments
+            'V9r@R' # malformed format string - %R
+        )
+         List of predefined passwords without special characters
+        $predefinedPasswordsWithoutSpecial = @(
+            'Tr5nw9UG', 'z8UPnYF8', 'b37Ug3Hl',
+            '8g5TmvB6', 'I4wJ8eJ', 'V9rRM8wx'
+        )
+
+        # Randomly select a password from the list
+        $newPassword = Get-Random -InputObject $predefinedPasswordsWithSpecial
+
+        # Check if the password meets complexity requirements
+        If (($newPassword -cmatch "[A-Z\p{Lu}\s]") `
+            -and ($newPassword -cmatch "[a-z\p{Ll}\s]") `
+            -and ($newPassword -match "[\d]") `
+            -and ($newPassword -match "[^\w]")
+        )
+        {
+            $PassComplexCheck=$True
+        }
+
+        # Explanation:
+        #
+        # Checks if the generated password meets requirements:
+        #
+        # 1. ($newPassword -cmatch "[A-Z\p{Lu}\s]")
+        #    - Checks for at least one uppercase letter
+        #    - [A-Z] matches any uppercase ASCII letter
+        #    - \p{Lu} matches any Unicode uppercase letter
+        #    - \s matches any whitespace character (though this might not be desirable in a password)
+        #
+        # 2. ($newPassword -cmatch "[a-z\p{Ll}\s]")
+        #    - Checks for at least one lowercase letter
+        #    - [a-z] matches any lowercase ASCII letter
+        #    - \p{Ll} matches any Unicode lowercase letter
+        #    - \s matches any whitespace character (again, might not be desirable)
+        #
+        # 3. ($newPassword -match "[\d]")
+        #    - Checks for at least one digit
+        #    - [\d] is equivalent to [0-9]
+        #
+        # 4. ($newPassword -match "[^\w]")
+        #    - Checks for at least one non-word character (special character)
+        #    - [^\w] matches any character that is not a word character
+        #    - Word characters include A-Z, a-z, 0-9, and underscore (_)
+        #    - So this checks for characters like @, #, $, %, etc.
+        #
+        # If all these conditions are met, $PassComplexCheck is set to True,
+        # indicating that the password meets the required complexity standards.
+
+    } While ($PassComplexCheck -eq $false)
+
+    return $newPassword
+} #end function
+
+Write-Host "Setting Set-OTSAuthorizationToken"
+
+# Set the authorization token for OneTimeSecret
+# https://github.com/chelnak/OneTimeSecret/blob/master/src/Functions/Public/Set-OTSAuthorizationToken.ps1
+Set-OTSAuthorizationToken -Username $ -APIKey $APIKey -BaseUrl $BaseUrl
+
+Write-Host "Generating a strong password"
+
+# Set New Complex Password
+# Generate a new 14-character strong password
+$MyPassword = GenerateStrongPassword(14)
+
+Write-Host $MyPassword  # Display the generated password
+
+Write-Host "Generating OTP Link"
+
+# Create a new OTS shared secret with the generated password
+# TTL (Time To Live) is set to 3600 seconds (1 hour)
+$MySecret = New-OTSSharedSecret -Secret $MyPassword -Ttl 3200
+
+Write-Host $MySecret  # Display the created secret details

--- a/support/powershell/GeneratePassword.rb
+++ b/support/powershell/GeneratePassword.rb
@@ -1,0 +1,54 @@
+
+# Namespace: System.Web.Security
+# Membership.GeneratePassword(Int32, Int32) Method
+#
+# The GeneratePassword method is used to generate a random
+# password and is most commonly used by the ResetPassword
+# method implemented by a membership provider to reset the
+# password for a user to a new, temporary password.
+#
+# The generated password only contains alphanumeric
+# characters and the following punctuation marks:
+# !@#$%^&*()_-+=[{]};:<>|./?. No hidden or non-printable
+# control characters are included in the generated password.
+#
+# https://learn.microsoft.com/en-us/dotnet/api/system.web.security.membership.generatepassword?view=netframework-4.8.1#system-web-security-membership-generatepassword(system-int32-system-int32)
+#
+class PasswordGenerator
+  LOWER_CASE = ('a'..'z').to_a
+  UPPER_CASE = ('A'..'Z').to_a
+  NUMBERS = ('0'..'9').to_a
+  SPECIAL_CHARS = '!@#$%^&*()_-+=[{]};:<>|./?'.chars
+
+  def self.generate(length = 12)
+    all_chars = LOWER_CASE + UPPER_CASE + NUMBERS + SPECIAL_CHARS
+
+    # Ensure at least one of each type
+    password = [
+      LOWER_CASE.sample,
+      UPPER_CASE.sample,
+      NUMBERS.sample,
+      SPECIAL_CHARS.sample
+    ]
+
+    # Fill the rest with random characters
+    (length - password.count).times do
+      password << all_chars.sample
+    end
+
+    # Shuffle the password to randomize the guaranteed characters' positions
+    password.shuffle.join
+  end
+
+  def self.meets_criteria?(password)
+    password.match?(/[a-z]/) &&
+      password.match?(/[A-Z]/) &&
+      password.match?(/\d/) &&
+      password.match?(/[#{Regexp.escape(SPECIAL_CHARS.join)}]/)
+  end
+end
+
+# Usage
+password = PasswordGenerator.generate(5)
+puts "Generated Password: #{password}"
+puts "Meets Criteria: #{PasswordGenerator.meets_criteria?(password)}"

--- a/try/06_rack_request_params_try.rb
+++ b/try/06_rack_request_params_try.rb
@@ -7,42 +7,35 @@ require_relative '../lib/onetime'
 OT::Config.path = File.join(__dir__, '..', 'etc', 'config.test')
 OT.boot! :app
 
-# NOTE: ABOUT LAMBDAS: We wrap associative arrays in lambdas to
+# NOTE ABOUT LAMBDAS: We wrap associative arrays in lambdas to
 # ensure that identical values are used in each test. What you
 # see is what you get. There's no dark magic or any further
 # complications. It's just a robust way to keep things DRY.
 
 # URL-encoded data with multiple parameters.
-@env_url_encoded_multiple = lambda {
-                               {
-                                 'REQUEST_METHOD' => 'POST',
+@env_url_encoded_multiple = lambda {{
+  'REQUEST_METHOD' => 'POST',
   'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
   'rack.input' => StringIO.new('key1=value1%25&key2=value2%')
-                               }
-}
+}}
 
 # URL-encoded data with misplaced percent sign.
-@env_url_encoded_misplaced_percent = lambda {
-                                        {
-                                          'REQUEST_METHOD' => 'POST',
+@env_url_encoded_misplaced_percent = lambda {{
+  'REQUEST_METHOD' => 'POST',
   'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
   'rack.input' => StringIO.new('key=value%with%pe%rcent')
-                                        }
-}
+}}
 
 # JSON payload with percent sign
-@env_json = lambda {
-               {
-                 'REQUEST_METHOD' => 'POST',
+@env_json = lambda {{
+  'REQUEST_METHOD' => 'POST',
   'CONTENT_TYPE' => 'application/json',
   'rack.input' => StringIO.new('{"key":"value%with%pe%rcent"}')
-               }
-}
+}}
 
 # Multipart form-data with percent sign
-@env_multipart = lambda {
-                    {
-                      'REQUEST_METHOD' => 'POST',
+@env_multipart = lambda {{
+  'REQUEST_METHOD' => 'POST',
   'CONTENT_TYPE' => 'multipart/form-data; boundary=---------------------------abcdefg',
   'rack.input' => StringIO.new(
     "-----------------------------abcdefg\r\n" \
@@ -51,8 +44,7 @@ OT.boot! :app
     "value%with%pe%rcent\r\n" \
     "-----------------------------abcdefg--\r\n"
   )
-                    }
-}
+}}
 
 
 ## Can handle URL-encoded data with multiple parameters

--- a/try/06_rack_request_params_try.rb
+++ b/try/06_rack_request_params_try.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+
+require_relative '../lib/onetime'
+
+# Use the default config file for tests
+OT::Config.path = File.join(__dir__, '..', 'etc', 'config.test')
+OT.boot! :app
+
+# NOTE: ABOUT LAMBDAS: We wrap associative arrays in lambdas to
+# ensure that identical values are used in each test. What you
+# see is what you get. There's no dark magic or any further
+# complications. It's just a robust way to keep things DRY.
+
+# URL-encoded data with multiple parameters.
+@env_url_encoded_multiple = lambda {
+                               {
+                                 'REQUEST_METHOD' => 'POST',
+  'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
+  'rack.input' => StringIO.new('key1=value1%25&key2=value2%')
+                               }
+}
+
+# URL-encoded data with misplaced percent sign.
+@env_url_encoded_misplaced_percent = lambda {
+                                        {
+                                          'REQUEST_METHOD' => 'POST',
+  'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
+  'rack.input' => StringIO.new('key=value%with%pe%rcent')
+                                        }
+}
+
+# JSON payload with percent sign
+@env_json = lambda {
+               {
+                 'REQUEST_METHOD' => 'POST',
+  'CONTENT_TYPE' => 'application/json',
+  'rack.input' => StringIO.new('{"key":"value%with%pe%rcent"}')
+               }
+}
+
+# Multipart form-data with percent sign
+@env_multipart = lambda {
+                    {
+                      'REQUEST_METHOD' => 'POST',
+  'CONTENT_TYPE' => 'multipart/form-data; boundary=---------------------------abcdefg',
+  'rack.input' => StringIO.new(
+    "-----------------------------abcdefg\r\n" \
+    "Content-Disposition: form-data; name=\"key\"\r\n" \
+    "\r\n" \
+    "value%with%pe%rcent\r\n" \
+    "-----------------------------abcdefg--\r\n"
+  )
+                    }
+}
+
+
+## Can handle URL-encoded data with multiple parameters
+env = @env_url_encoded_multiple.call
+req = Rack::Request.new(env)
+begin
+  params = req.params
+rescue ArgumentError => e
+  "Error: #{e.message}"
+end
+#=> "Error: invalid %-encoding (value2%)"
+
+
+## Can access raw body
+env = @env_url_encoded_misplaced_percent.call
+req = Rack::Request.new(env)
+"Raw body: #{req.body.read}"
+#=> "Raw body: key=value%with%pe%rcent"
+
+
+## Can handle invalid percent-encoding
+env = @env_url_encoded_misplaced_percent.call
+req = Rack::Request.new(env)
+begin
+  params = req.params
+rescue ArgumentError => e
+  "Error: #{e.message}"
+end
+#=> "Error: invalid %-encoding (value%with%pe%rcent)"
+
+
+## Can handle JSON payload with percent sign
+env = @env_json.call
+req = Rack::Request.new(env)
+begin
+  body = JSON.parse(req.body.read)
+  body.to_json
+rescue JSON::ParserError => e
+  nil # an exception isn't raised
+end
+#=> "{\"key\":\"value%with%pe%rcent\"}"
+
+
+
+## Can handle multipart form-data with percent sign
+env = @env_multipart.call
+req = Rack::Request.new(env)
+begin
+  params = req.params
+  "Params: #{params['key']}"
+rescue ArgumentError => e
+  nil # an exception isn't raised
+end
+#=> "Params: value%with%pe%rcent"


### PR DESCRIPTION
An error is being thrown when processing POST requests containing %-encoded data with `application/x-www-form-urlencoded` content-type. This pull request addresses the issue by adding a middleware, `Rack::HandleInvalidPercentEncoding`, to handle invalid percent encodings in HTTP requests. The middleware detects invalid encodings early in the request processing pipeline and returns a 400 Bad Request response with a clear error message. It also logs the error for monitoring and debugging purposes.

This pull request includes the following changes:

- Added a middleware to handle invalid percent encodings in HTTP requests.
- Excluded migrations and tryouts from RuboCop analysis.
- Added powershell example and tryouts to replicate the behavior.
- Fixed invalid percent encoding error by normalizing characters.
- Added appropriate logging to new middleware for additional visibility.

References:

- [Ruby on Rails "invalid byte sequence in UTF-8" due to bot](https://stackoverflow.com/questions/24648206/ruby-on-rails-invalid-byte-sequence-in-utf-8-due-to-bot/24727310#24727310)
- [Invalid % Encoding #2159](https://github.com/ruby-grape/grape/issues/2159)
- [invalid %-encoding error in application for malformed uri #337](https://github.com/rack/rack/issues/337)
- [Invalid or incomplete POST parameters](https://thomasleecopeland.com/2018/08/12/invalid-or-incomplete-post-parameters.html)
- [Rails/Rack: "ArgumentError: invalid %-encoding" for POST data](https://stackoverflow.com/questions/15769681/rails-rack-argumenterror-invalid-encoding-for-post-data/24615414#24615414)