### PR TITLE
Fix invalid URI Encoding in API request handling

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -63,6 +63,7 @@ Metrics/ModuleLength:
   CountAsOne: ['method_call']
 
 Performance/Size:
+  Enabled: true
   Exclude:
   #   - lib/example.rb
 

--- a/Gemfile
+++ b/Gemfile
@@ -24,9 +24,6 @@ gem 'addressable'
 
 gem 'rack'
 
-# Part of fix for Fix invalid %-encoding in POST request handling #463
-gem 'rack-utf8_sanitizer'
-
 gem 'multi_json'
 gem 'thin'
 gem 'yajl-ruby'

--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,9 @@ gem 'addressable'
 
 gem 'rack'
 
+# Part of fix for Fix invalid %-encoding in POST request handling #463
+gem 'rack-utf8_sanitizer'
+
 gem 'multi_json'
 gem 'thin'
 gem 'yajl-ruby'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,6 +75,8 @@ GEM
     public_suffix (5.1.0)
     racc (1.8.0)
     rack (2.2.9)
+    rack-utf8_sanitizer (1.9.1)
+      rack (>= 1.0, < 4.0)
     rainbow (3.1.1)
     rake (13.0.6)
     rbi (0.1.13)
@@ -181,6 +183,7 @@ DEPENDENCIES
   pry
   pry-byebug
   rack
+  rack-utf8_sanitizer
   redis (~> 5.2.0)
   rubocop
   rubocop-performance

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,8 +75,6 @@ GEM
     public_suffix (5.1.0)
     racc (1.8.0)
     rack (2.2.9)
-    rack-utf8_sanitizer (1.9.1)
-      rack (>= 1.0, < 4.0)
     rainbow (3.1.1)
     rake (13.0.6)
     rbi (0.1.13)
@@ -183,7 +181,6 @@ DEPENDENCIES
   pry
   pry-byebug
   rack
-  rack-utf8_sanitizer
   redis (~> 5.2.0)
   rubocop
   rubocop-performance

--- a/config.ru
+++ b/config.ru
@@ -7,6 +7,9 @@
 #     $ thin -e dev -R config.ru -p 3000 start
 #     $ tail -f /var/log/system.log
 
+# Ensure immediate flushing of stdout to improve real-time logging visibility.
+# This is particularly useful in development and production environments where
+# timely log output is crucial for monitoring and debugging purposes.
 $stdout.sync = true
 
 ENV['RACK_ENV'] ||= 'prod'
@@ -39,11 +42,12 @@ if Otto.env?(:dev)
   # DEV: Run webapps with extra logging and reloading
   apps.each_pair do |path, app|
     map(path) do
+      OT.ld "[app] Attaching #{app} at #{path}"
       use Rack::CommonLogger
       use Rack::Reloader, 1
 
-      use Rack::HandleInvalidPercentEncoding
       use Rack::HandleInvalidUTF8
+      use Rack::HandleInvalidPercentEncoding
 
       app.option[:public] = PUBLIC_DIR
       app.add_static_path '/favicon.ico'
@@ -55,8 +59,8 @@ if Otto.env?(:dev)
 else
   # PROD: run webapps the bare minimum additional middleware
   apps.each_pair do |path, app|
-    use Rack::HandleInvalidPercentEncoding
     use Rack::HandleInvalidUTF8
+    use Rack::HandleInvalidPercentEncoding
 
     app.option[:public] = PUBLIC_DIR
     map(path) { run app }

--- a/config.ru
+++ b/config.ru
@@ -17,6 +17,7 @@ $LOAD_PATH.unshift(File.join(ENV.fetch('APP_ROOT', nil), 'app'))
 
 require_relative 'lib/onetime'
 require_relative 'lib/middleware/handle_invalid_percent_encoding'
+require_relative 'lib/middleware/handle_invalid_utf8'
 
 PUBLIC_DIR = "#{ENV.fetch('APP_ROOT', nil)}/public/web".freeze
 APP_DIR = "#{ENV.fetch('APP_ROOT', nil)}/lib/onetime/app".freeze
@@ -41,7 +42,9 @@ if Otto.env?(:dev)
       use Rack::CommonLogger
       use Rack::Reloader, 1
 
+      # TODO: We actually only need to run this logic for the API app.
       use Rack::HandleInvalidPercentEncoding
+      use Rack::HandleInvalidUTF8
 
       app.option[:public] = PUBLIC_DIR
       app.add_static_path '/favicon.ico'
@@ -54,6 +57,7 @@ else
   # PROD: run webapps the bare minimum additional middleware
   apps.each_pair do |path, app|
     use Rack::HandleInvalidPercentEncoding
+    use Rack::HandleInvalidUTF8
 
     app.option[:public] = PUBLIC_DIR
     map(path) { run app }

--- a/config.ru
+++ b/config.ru
@@ -42,7 +42,6 @@ if Otto.env?(:dev)
       use Rack::CommonLogger
       use Rack::Reloader, 1
 
-      # TODO: We actually only need to run this logic for the API app.
       use Rack::HandleInvalidPercentEncoding
       use Rack::HandleInvalidUTF8
 

--- a/lib/middleware/handle_invalid_percent_encoding.rb
+++ b/lib/middleware/handle_invalid_percent_encoding.rb
@@ -10,7 +10,7 @@ require 'rack'
 # data in HTTP requests. Instead of attempting to guess or fix invalid encodings,
 # which could lead to silent but deadly data corruption, it:
 #
-# 1. Detects invalid percent-encoding early in the request processing.
+# 1. Detects invalid uri-encoding early in the request processing.
 # 2. Returns a 400 Bad Request with a clear error message.
 # 3. Logs the error for debugging and monitoring.
 #
@@ -31,12 +31,20 @@ class Rack::HandleInvalidPercentEncoding
 
   attr_reader :logger
 
-  def initialize(app, io: $stdout)
+  def initialize(app, io: $stdout, check_enabled: nil)
     @app = app
     @logger = Logger.new(io)
+    @check_enabled = check_enabled
   end
 
   def call(env)
+    request_uri = env['REQUEST_URI']
+
+    logger.debug "[handle-invalid-uri-encoding] Checking #{request_uri}"
+
+    # If the route doesn't include the AppSettings module, we can't
+    # determine if the app wants to check for invalid percent encoding.
+    return @app.call(env) unless check_enabled?(@app)
 
     # The instantiated request object isn't available until later in the
     # middleware chain so we need to create our own instance here in order
@@ -62,12 +70,27 @@ class Rack::HandleInvalidPercentEncoding
     end
   end
 
+  # NOTE: This check is specific to Onetime and Otto apps. We'll want to
+  # find a more generic way to determine if the app/route level settings.
+  # One example would be to check in config.ru and not `use` middleware
+  # for apps that don't have the settings enabled.
+  #
+  def check_enabled?(app)
+    return true if @check_enabled
+    return false unless defined?(Otto) && app.is_a?(Otto)
+    name, route = app.route_definitions.first
+    has_settings = route.klass.include?(Onetime::App::AppSettings)
+    setting_enabled = route.klass.check_uri_encoding
+    logger.debug "[handle-invalid-uri-encoding] #{name} has settings: #{has_settings}, enabled: #{setting_enabled}"
+    return has_settings && setting_enabled
+  end
+
   def handle_exception(env, exception)
     rack_input = env['rack.input']&.read || ''
     errmsg = exception.message
 
     message = "`#{errmsg}` in one of the following params: #{rack_input}"
-    logger.info "[handle-invalid-percent-encoding] #{message}"
+    logger.error "[handle-invalid-uri-encoding] #{message}"
 
     status = 400
     body   = { error: 'Bad Request', message: errmsg }.to_json

--- a/lib/middleware/handle_invalid_utf8.rb
+++ b/lib/middleware/handle_invalid_utf8.rb
@@ -9,28 +9,54 @@ require 'rack/utf8_sanitizer'
 # Handles invalid UTF8 characters in request URI and headers by
 # raising an exception and returning a 400 Bad Request response.
 #
-class Rack::HandleInvalidUTF8 < Rack::UTF8Sanitizer
+class Rack::HandleInvalidUTF8
   @default_content_type = 'application/json'
   @default_charset      = 'utf-8'
+  @default_exception    = Encoding::InvalidByteSequenceError
+  @input_sources        = %w[
+    SCRIPT_NAME
+    REQUEST_PATH
+    REQUEST_URI
+    PATH_INFO
+    QUERY_STRING
+    HTTP_REFERER
+    ORIGINAL_FULLPATH
+    ORIGINAL_SCRIPT_NAME
+    SERVER_NAME
+    HTTP_USER_AGENT
+
+    # Body content
+    rack.input
+  ]
 
   class << self
-    attr_reader :default_content_type, :default_charset
+    attr_reader :default_content_type,
+                :default_charset,
+                :default_exception,
+                :input_sources
   end
 
   attr_reader :logger
 
-  def initialize(app, options = {}, io: $stdout)
-    options[:strategy] = :exception
-    super(app, options)
+  def initialize(app, io: $stdout)
+    @app = app
     @logger = Logger.new(io)
   end
 
   def call(env)
+    shallow_copy = env.dup
 
-    sanitize(env.dup)
+    # We duplicate the environment to avoid modifying the original
+    # since all we want to do is kick the tires and see what shakes
+    # out. We don't want to change the environment and continue; we
+    # want to raise an exception early so we can return a 400 Bad
+    # Request and a descriptive error message.
+    self.class.input_sources.each do |key|
+      next unless shallow_copy.key?(key)
+      check_and_raise_for_invalid_utf8(shallow_copy[key], key)
+    end
 
-  rescue Rack::UTF8Sanitizer::NullByteInString,
-         Encoding::InvalidByteSequenceError,
+  rescue Encoding::InvalidByteSequenceError,
          Encoding::CompatibilityError,
          Encoding::UndefinedConversionError => e
 
@@ -41,6 +67,40 @@ class Rack::HandleInvalidUTF8 < Rack::UTF8Sanitizer
   end
 
   private
+
+  # Validates that the input is valid UTF-8 and raises an exception if it's not.
+  #
+  # This method handles different input types (String, StringIO, IO) and checks
+  # if the content is valid UTF-8. If the input is not valid UTF-8, it raises an exception.
+  #
+  # @param input [String, StringIO, IO, nil] The input to be validated
+  # @param key [String] The environment key being validated. Used for exception message.
+  # @return [nil] if the input is valid UTF-8
+  # @raise [StandardError] if the input contains invalid UTF-8 characters
+  #   The exact exception class is determined by self.class.default_exception
+  #
+  # @example
+  #   check_and_raise_for_invalid_utf8("Hello, world!", "QUERY_STRING") # => nil
+  #   check_and_raise_for_invalid_utf8(StringIO.new("\xFF"), "rack.input") # raises an exception
+  #   check_and_raise_for_invalid_utf8(nil, "SOME_KEY") # => nil (empty string is valid UTF-8)
+
+  def check_and_raise_for_invalid_utf8(input, key)
+    # If the string is frozen, we need to dup it before modifying
+    input = input.dup if input.frozen?
+
+    testcase = case input
+        when String
+          input
+        when StringIO, IO
+          input.read
+        else
+          '' # includes nil
+        end
+
+    testcase.force_encoding('UTF-8')
+    return if testcase.valid_encoding?
+    raise self.class.default_exception, "Invalid UTF-8 detected in env['#{key}']"
+  end
 
   def handle_exception(env, exception)
     message = "Invalid UTF-8 or null byte detected: #{exception.message}"

--- a/lib/middleware/handle_invalid_utf8.rb
+++ b/lib/middleware/handle_invalid_utf8.rb
@@ -1,0 +1,60 @@
+require 'pry-byebug'
+require 'json'
+require 'logger'
+require 'rack'
+require 'rack/utf8_sanitizer'
+
+# Rack::HandleInvalidUTF8
+#
+# Handles invalid UTF8 characters in request URI and headers by
+# raising an exception and returning a 400 Bad Request response.
+#
+class Rack::HandleInvalidUTF8 < Rack::UTF8Sanitizer
+  @default_content_type = 'application/json'
+  @default_charset      = 'utf-8'
+
+  class << self
+    attr_reader :default_content_type, :default_charset
+  end
+
+  attr_reader :logger
+
+  def initialize(app, options = {}, io: $stdout)
+    options[:strategy] = :exception
+    super(app, options)
+    @logger = Logger.new(io)
+  end
+
+  def call(env)
+
+    sanitize(env.dup)
+
+  rescue Rack::UTF8Sanitizer::NullByteInString,
+         Encoding::InvalidByteSequenceError,
+         Encoding::CompatibilityError,
+         Encoding::UndefinedConversionError => e
+
+    return handle_exception(env, e)
+  else
+
+    @app.call(env)
+  end
+
+  private
+
+  def handle_exception(env, exception)
+    message = "Invalid UTF-8 or null byte detected: #{exception.message}"
+    logger.info "[handle-invalid-utf8] #{message}"
+
+    status = 400
+    body = { error: 'Bad Request', message: message }.to_json
+
+    cls = self.class
+    headers = {
+      'Content-Type': "#{cls.default_content_type}; charset=#{cls.default_charset}",
+      'Content-Length': body.bytesize.to_s
+    }
+
+    [status, headers, [body]]
+  end
+end

--- a/lib/middleware/handle_invalid_utf8.rb
+++ b/lib/middleware/handle_invalid_utf8.rb
@@ -1,4 +1,4 @@
-require 'pry-byebug'
+
 require 'json'
 require 'logger'
 require 'rack'

--- a/lib/onetime/app/api.rb
+++ b/lib/onetime/app/api.rb
@@ -1,9 +1,14 @@
 
 require_relative 'api/base'
+require_relative 'base'  # app/base.rb
 
 class Onetime::App
   class API
+    include AppSettings
     include Onetime::App::API::Base
+
+    @check_utf8 = true
+    @check_uri_encoding = true
 
     def status
       authorized(true) do

--- a/lib/onetime/app/api/base.rb
+++ b/lib/onetime/app/api/base.rb
@@ -1,4 +1,5 @@
-require_relative '../helpers'  # app/helpers.rb
+# Ensure no conflicts with Onetime::App::API::Base methods
+require_relative '../helpers'   # app/helpers.rb
 
 
 class Onetime::App

--- a/lib/onetime/app/api/base.rb
+++ b/lib/onetime/app/api/base.rb
@@ -1,7 +1,9 @@
-require 'onetime/app/helpers'
+require_relative '../helpers'  # app/helpers.rb
+
 
 class Onetime::App
   class API
+
     module Base
       include Onetime::App::Helpers
 

--- a/lib/onetime/app/base.rb
+++ b/lib/onetime/app/base.rb
@@ -1,0 +1,33 @@
+class Onetime::App
+  #
+  # AppSettings module provides configuration options for UTF-8 and URI
+  # encoding middleware checks.
+  #
+  # This module is designed to be included in Onetime::App subclasses.
+  #
+  module AppSettings
+    # Default settings for UTF-8 and URI encoding checks
+    @check_utf8 = nil
+    @check_uri_encoding = nil
+
+    # When this module is included in a class, it extends that class
+    # with ClassMethods and sets up the initial configuration
+    #
+    # @param base [Class] The class including this module
+    def self.included(base)
+      base.extend(ClassMethods)
+      base.instance_variable_set(:@check_utf8, @check_utf8)
+      base.instance_variable_set(:@check_uri_encoding, @check_uri_encoding)
+    end
+
+    # ClassMethods module provides class-level accessor methods
+    # for configuring UTF-8 and URI encoding checks
+    module ClassMethods
+      # @!attribute [rw] check_utf8
+      #   @return [Boolean] Whether to check for valid UTF-8 encoding
+      # @!attribute [rw] check_uri_encoding
+      #   @return [Boolean] Whether to check for valid URI encoding
+      attr_accessor :check_utf8, :check_uri_encoding
+    end
+  end
+end

--- a/lib/onetime/app/web/base.rb
+++ b/lib/onetime/app/web/base.rb
@@ -1,4 +1,4 @@
-require 'onetime/app/helpers'
+require_relative '../helpers'  # app/helpers.rb
 
 module Onetime
   class App

--- a/try/06_handle_invalid_percent_encoding_try.rb
+++ b/try/06_handle_invalid_percent_encoding_try.rb
@@ -25,11 +25,10 @@ require 'rack'
 
 require_relative '../lib/middleware/handle_invalid_percent_encoding'
 
-# NOTE ABOUT LAMBDAS: We wrap associative arrays in lambdas to
-# ensure that identical values are used in each test. What you
-# see is what you get. There's no dark magic or any further
+# NOTE: We wrap associative arrays in lambdas to ensure that
+# identical values are used in each test. What you see is
+# what you get. There's no dark magic or any further
 # complications. It's just a robust way to keep things DRY.
-
 
 # URL-encoded data with multiple parameters.
 @env_url_encoded_multiple = lambda {{
@@ -68,7 +67,7 @@ require_relative '../lib/middleware/handle_invalid_percent_encoding'
 # Demonstrate how the HandleInvalidPercentEncoding
 # middleware can resolve these issues.
 @app = lambda { |env| [200, {'Content-Type' => 'text/plain'}, ['OK']] }
-@middleware = Rack::HandleInvalidPercentEncoding.new(@app)
+@middleware = Rack::HandleInvalidPercentEncoding.new(@app, check_enabled: true)
 
 
 ## Can handle URL-encoded data with multiple parameters
@@ -152,17 +151,17 @@ status, headers, body = @middleware.call(env)
 #=> "Status: 200, Body: OK"
 
 
-## Middleware sets correct content type in error response
+## Middleware sets correct content type in error response (always json)
 env = @env_url_encoded_multiple.call
 env['HTTP_ACCEPT'] = 'application/xml'
 status, headers, body = @middleware.call(env)
 "Content-Type: #{headers[:'Content-Type']}"
-#=> "Content-Type: application/xml; charset=utf-8"
+#=> "Content-Type: application/json; charset=utf-8"
 
 
 ## Middleware logs error message
 io = StringIO.new
-middleware_with_custom_logger = Rack::HandleInvalidPercentEncoding.new(@app, io: io)
+middleware_with_custom_logger = Rack::HandleInvalidPercentEncoding.new(@app, io: io, check_enabled: true)
 env = @env_url_encoded_multiple.call
 middleware_with_custom_logger.call(env)
 io.rewind

--- a/try/06_handle_invalid_percent_encoding_try.rb
+++ b/try/06_handle_invalid_percent_encoding_try.rb
@@ -22,6 +22,7 @@
 
 require 'json'
 require 'rack'
+
 require_relative '../lib/middleware/handle_invalid_percent_encoding'
 
 # NOTE ABOUT LAMBDAS: We wrap associative arrays in lambdas to

--- a/try/06_handle_invalid_percent_encoding_try.rb
+++ b/try/06_handle_invalid_percent_encoding_try.rb
@@ -166,7 +166,7 @@ env = @env_url_encoded_multiple.call
 middleware_with_custom_logger.call(env)
 io.rewind
 log_message = io.read
-log_message.include?("[handle-invalid-percent-encoding] `invalid %-encoding (value2%)` in one of the following params:")
+log_message.include?("[handle-invalid-uri-encoding] `invalid %-encoding (value2%)` in one of the following params:")
 #=> true
 
 

--- a/try/07_handle_invalid_utf8_try.rb
+++ b/try/07_handle_invalid_utf8_try.rb
@@ -98,7 +98,7 @@ status, headers, body = @middleware.call(env)
 
 ## Middleware logs error message
 io = StringIO.new
-middleware_with_custom_logger = Rack::HandleInvalidUTF8.new(@app, io: io)
+middleware_with_custom_logger = Rack::HandleInvalidUTF8.new(@app, io: io, check_enabled: true)
 env = @env_invalid_utf8_header.call
 middleware_with_custom_logger.call(env)
 io.rewind

--- a/try/07_handle_invalid_utf8_try.rb
+++ b/try/07_handle_invalid_utf8_try.rb
@@ -1,0 +1,122 @@
+# encoding: utf-8
+# frozen_string_literal: true
+
+# These tryouts test the Rack::HandleInvalidUTF8 middleware,
+# focusing on scenarios involving invalid UTF-8 characters in
+# different types of HTTP requests.
+#
+# We're testing various scenarios, including:
+# 1. Requests with invalid UTF-8 in headers
+# 2. Requests with invalid UTF-8 in the body
+# 3. Requests with null bytes
+# 4. Requests with valid UTF-8
+# 5. Different content types (JSON, form-urlencoded, multipart)
+#
+# These tests aim to ensure that the middleware correctly handles
+# invalid UTF-8 input, logs appropriate messages, and returns
+# proper responses.
+
+require 'json'
+require 'rack'
+require 'stringio'
+
+require_relative '../lib/middleware/handle_invalid_utf8'
+
+# Helper method to create invalid UTF-8 string
+def invalid_utf8
+  "\xFF\xFE\xFD"
+end
+
+# Helper method to create a string with a null byte
+def null_byte_string
+  "hello\x00world"
+end
+
+# Valid UTF-8 request
+@env_valid_utf8 = lambda {{
+  'REQUEST_METHOD' => 'GET',
+  'HTTP_USER_AGENT' => 'ValidAgent',
+  'rack.input' => StringIO.new
+}}
+
+# Request with invalid UTF-8 in header
+@env_invalid_utf8_header = lambda {{
+  'REQUEST_METHOD' => 'GET',
+  'HTTP_USER_AGENT' => "Invalid#{invalid_utf8}Agent",
+  'rack.input' => StringIO.new
+}}
+
+# Request with invalid UTF-8 in body
+@env_invalid_utf8_body = lambda {{
+  'REQUEST_METHOD' => 'POST',
+  'CONTENT_TYPE' => 'application/json',
+  'rack.input' => StringIO.new("{\"key\":\"Invalid#{invalid_utf8}Value\"}")
+}}
+
+# Request with null byte in body
+@env_null_byte = lambda {{
+  'REQUEST_METHOD' => 'POST',
+  'CONTENT_TYPE' => 'application/json',
+  'rack.input' => StringIO.new("{\"key\":\"#{null_byte_string}\"}")
+}}
+
+# Set up the middleware
+@app = lambda { |env| [200, {'Content-Type' => 'text/plain'}, ['OK']] }
+@middleware = Rack::HandleInvalidUTF8.new(@app)
+
+## Middleware allows valid UTF-8 request to pass through
+env = @env_valid_utf8.call
+status, headers, body = @middleware.call(env)
+"Status: #{status}, Body: #{body.first}"
+#=> "Status: 200, Body: OK"
+
+## Middleware handles invalid UTF-8 in header
+env = @env_invalid_utf8_header.call
+status, headers, body = @middleware.call(env)
+response = JSON.parse(body.first)
+"Status: #{status}, Error: #{response['error']}, Message: #{response['message'].include?('Invalid UTF-8')}"
+#=> "Status: 400, Error: Bad Request, Message: true"
+
+## Middleware handles invalid UTF-8 in body
+env = @env_invalid_utf8_body.call
+status, headers, body = @middleware.call(env)
+response = JSON.parse(body.first)
+"Status: #{status}, Error: #{response['error']}, Message: #{response['message'].include?('Invalid UTF-8')}"
+#=> "Status: 400, Error: Bad Request, Message: true"
+
+## Middleware handles null byte in body
+env = @env_null_byte.call
+status, headers, body = @middleware.call(env)
+"Status: #{status}, Message: #{body.first}"
+#=> "Status: 200, Message: OK"
+
+## Middleware sets correct content type in error response
+env = @env_invalid_utf8_header.call
+status, headers, body = @middleware.call(env)
+"Content-Type: #{headers[:'Content-Type']}"
+#=> "Content-Type: application/json; charset=utf-8"
+
+## Middleware logs error message
+io = StringIO.new
+middleware_with_custom_logger = Rack::HandleInvalidUTF8.new(@app, io: io)
+env = @env_invalid_utf8_header.call
+middleware_with_custom_logger.call(env)
+io.rewind
+log_message = io.read
+log_message.include?("[handle-invalid-utf8] Invalid UTF-8 or null byte detected:")
+#=> true
+
+## Middleware allows requests with valid UTF-8 to pass through
+output = []
+input_string = '{"key":"validValue🌈"}'.force_encoding('UTF-8')
+output << "Input encoding: #{input_string.encoding}"
+env = {
+  'REQUEST_METHOD' => 'POST',
+  'CONTENT_TYPE' => 'application/json',
+  'rack.input' => StringIO.new(input_string)
+}
+output << "StringIO encoding: #{env['rack.input'].string.encoding}"
+status, headers, body = @middleware.call(env)
+output << "Response: #{status}, #{body.first}, encoding: #{body.first.encoding}"
+"Status: #{status}, Body: #{body.first}, #{output.join('++++')}"
+#=> "Status: 200, Body: OK"

--- a/try/07_handle_invalid_utf8_try.rb
+++ b/try/07_handle_invalid_utf8_try.rb
@@ -107,16 +107,11 @@ log_message.include?("[handle-invalid-utf8] Invalid UTF-8 or null byte detected:
 #=> true
 
 ## Middleware allows requests with valid UTF-8 to pass through
-output = []
-input_string = '{"key":"validValue🌈"}'.force_encoding('UTF-8')
-output << "Input encoding: #{input_string.encoding}"
 env = {
   'REQUEST_METHOD' => 'POST',
   'CONTENT_TYPE' => 'application/json',
-  'rack.input' => StringIO.new(input_string)
+  'rack.input' => StringIO.new('{"key":"validValue🌈"}')  # Valid UTF-8 with emoji
 }
-output << "StringIO encoding: #{env['rack.input'].string.encoding}"
 status, headers, body = @middleware.call(env)
-output << "Response: #{status}, #{body.first}, encoding: #{body.first.encoding}"
-"Status: #{status}, Body: #{body.first}, #{output.join('++++')}"
+"Status: #{status}, Body: #{body.first}"
 #=> "Status: 200, Body: OK"

--- a/try/07_handle_invalid_utf8_try.rb
+++ b/try/07_handle_invalid_utf8_try.rb
@@ -62,7 +62,7 @@ end
 
 # Set up the middleware
 @app = lambda { |env| [200, {'Content-Type' => 'text/plain'}, ['OK']] }
-@middleware = Rack::HandleInvalidUTF8.new(@app)
+@middleware = Rack::HandleInvalidUTF8.new(@app, check_enabled: true)
 
 ## Middleware allows valid UTF-8 request to pass through
 env = @env_valid_utf8.call

--- a/try/10_utils_try.rb
+++ b/try/10_utils_try.rb
@@ -1,5 +1,21 @@
 # frozen_string_literal: true
 
+# These tryouts test the functionality of the Onetime::Utils module.
+# The Utils module provides various utility functions used throughout
+# the Onetime application.
+#
+# We're testing various aspects of the Utils module, including:
+# 1. Generation of random strands
+# 2. Email address obfuscation
+#
+# These tests aim to ensure that the utility functions work correctly,
+# which is crucial for various operations in the Onetime application,
+# such as generating unique identifiers and protecting user privacy.
+#
+# The tryouts simulate different scenarios of using the Utils module
+# without needing to run the full application, allowing for targeted
+# testing of these specific functionalities.
+
 require_relative '../lib/onetime'
 
 # Familia.debug = true

--- a/try/11_entropy_try.rb
+++ b/try/11_entropy_try.rb
@@ -1,5 +1,18 @@
 # frozen_string_literal: true
 
+# These tryouts test the functionality of the OT::Entropy module.
+# The Entropy module is responsible for generating and managing
+# random values used throughout the Onetime application.
+#
+# We're testing various aspects of the Entropy module, including:
+# 1. Generating and clearing entropy values
+# 2. Counting available entropy values
+# 3. Popping values from the entropy pool
+#
+# These tests aim to ensure that the entropy generation and management
+# in the Onetime application works correctly, which is crucial for
+# maintaining security and unpredictability in various operations.
+
 require_relative '../lib/onetime'
 
 # Use the default config file for tests

--- a/try/15_config_try.rb
+++ b/try/15_config_try.rb
@@ -1,5 +1,17 @@
 # frozen_string_literal: true
 
+# These tryouts test the configuration functionality of the Onetime application.
+# The Config module is responsible for loading and managing application settings.
+#
+# We're testing various aspects of the configuration, including:
+# 1. Loading and accessing config files
+# 2. Verifying basic configuration structure
+# 3. Checking specific configuration options (e.g., authentication, email settings)
+# 4. Testing utility methods for config key mapping and file existence
+#
+# These tests aim to ensure that the application can correctly load and use
+# its configuration, which is crucial for proper operation and customization.
+
 require_relative '../lib/onetime'
 
 # Use the default config file for tests

--- a/try/17_mail_validation.rb
+++ b/try/17_mail_validation.rb
@@ -1,8 +1,21 @@
 # frozen_string_literal: true
 
-require 'digest'
+# These tryouts test the email validation functionality using the Truemail gem.
+# Email validation is crucial for ensuring that user-provided email addresses
+# are valid and potentially deliverable.
+#
+# We're testing various aspects of email validation, including:
+# 1. Configuration of Truemail settings
+# 2. Validation of various email formats (valid, invalid, edge cases)
+# 3. Different validation methods (regex, MX, SMTP)
+#
+# These tests aim to ensure that the application can accurately validate
+# email addresses, which is important for user registration and communication.
 
+require 'digest'
 require 'dotenv'
+require 'truemail'
+
 Dotenv.load('.env')
 
 # Relys on environment variables:

--- a/try/20_metadata_try.rb
+++ b/try/20_metadata_try.rb
@@ -1,5 +1,19 @@
 # frozen_string_literal: true
 
+# These tryouts test the Onetime::Metadata class functionality.
+# The Metadata class is responsible for managing metadata associated
+# with secrets in the Onetime application.
+#
+# We're testing various aspects of the Metadata class, including:
+# 1. Creation and initialization of Metadata objects
+# 2. Consistency of Redis keys and secret keys
+# 3. Saving and destroying Metadata objects
+# 4. Checking existence of Metadata in the database
+#
+# These tests aim to ensure that metadata can be correctly created,
+# stored, and managed, which is crucial for maintaining information
+# about secrets in the application.
+
 require_relative '../lib/onetime'
 
 # Use the default config file for tests

--- a/try/21_secret_try.rb
+++ b/try/21_secret_try.rb
@@ -1,6 +1,19 @@
 # frozen_string_literal: true
 
+# These tryouts test the Onetime::Secret class functionality.
+# The Secret class is responsible for managing secrets in the
+# Onetime application.
 #
+# We're testing various aspects of the Secret class, including:
+# 1. Creation of Secret objects
+# 2. Consistency of Redis keys
+# 3. Spawning secret pairs (metadata and secret)
+# 4. Saving, loading, and destroying secrets
+# 5. Managing secret states (viewed, received)
+#
+# These tests aim to ensure that secrets can be correctly created,
+# stored, and managed throughout their lifecycle in the application.
+
 require_relative '../lib/onetime'
 
 # Use the default config file for tests

--- a/try/22_value_encryption_try.rb
+++ b/try/22_value_encryption_try.rb
@@ -1,5 +1,23 @@
 # frozen_string_literal: true
 
+# These tryouts test the encryption and decryption functionality
+# of the Onetime::Secret class.
+#
+# We're testing various aspects of secret handling, including:
+# 1. Storing a value
+# 2. Encrypting a value
+# 3. Decrypting a value
+# 4. Behavior when decrypting without prior encryption
+# 5. Behavior when the global secret is changed
+#
+# These tests aim to ensure that the secret handling mechanism
+# in the Onetime application works correctly and securely, which
+# is crucial for the core functionality of the service.
+#
+# The tryouts simulate different scenarios of secret handling
+# without needing to run the full application, allowing for
+# targeted testing of this specific functionality.
+
 require_relative '../lib/onetime'
 
 # Use the default config file for tests

--- a/try/23_app_settings_try.rb
+++ b/try/23_app_settings_try.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+# These tryouts test the functionality of the AppSettings module in the Onetime::App class.
+# The AppSettings module provides configuration options for UTF-8 and URI encoding
+# middleware checks.
+#
+# We're testing various aspects of the AppSettings module, including:
+# 1. Default values for check_utf8 and check_uri_encoding
+# 2. Setting and getting check_utf8 and check_uri_encoding values
+# 3. Independence of settings between different classes
+# 4. Behavior when including the module in multiple classes
+#
+# These tests aim to ensure that the AppSettings module correctly manages
+# configuration options for UTF-8 and URI encoding checks, which is crucial
+# for properly handling incoming requests in the Onetime application.
+#
+# The tryouts simulate different scenarios of using the AppSettings module
+# without needing to run the full application, allowing for targeted testing
+# of this specific functionality.
+
+require_relative '../lib/onetime'
+
+# Use the default config file for tests
+OT::Config.path = File.join(__dir__, '..', 'etc', 'config.test')
+OT.boot!
+
+class TestApp
+  include Onetime::App::AppSettings
+end
+
+## Default values for check_utf8 and check_uri_encoding are nil
+TestApp.check_utf8
+#=> nil
+
+TestApp.check_uri_encoding
+#=> nil
+
+## Can set and get check_utf8
+TestApp.check_utf8 = true
+TestApp.check_utf8
+#=> true
+
+## Can set and get check_uri_encoding
+TestApp.check_uri_encoding = false
+TestApp.check_uri_encoding
+#=> false
+
+## Settings are independent for different classes
+class AnotherTestApp
+  include Onetime::App::AppSettings
+end
+
+AnotherTestApp.check_utf8
+#=> nil
+
+AnotherTestApp.check_uri_encoding
+#=> nil
+
+## Can set different values for different classes
+AnotherTestApp.check_utf8 = false
+AnotherTestApp.check_uri_encoding = true
+
+TestApp.check_utf8
+#=> true
+
+TestApp.check_uri_encoding
+#=> false
+
+AnotherTestApp.check_utf8
+#=> false
+
+AnotherTestApp.check_uri_encoding
+#=> true

--- a/try/23_passphrase_try.rb
+++ b/try/23_passphrase_try.rb
@@ -1,5 +1,17 @@
 # frozen_string_literal: true
 
+# These tryouts test the functionality of passphrase handling in the OneTime application.
+# Specifically, they focus on:
+#
+# 1. Storing a plaintext passphrase
+# 2. Storing and verifying a one-way encrypted passphrase
+#
+# These tests aim to ensure that passphrases are correctly stored and verified,
+# which is crucial for maintaining the security of secrets in the application.
+#
+# The tryouts use the Onetime::Secret class to demonstrate passphrase-related operations,
+# allowing for targeted testing of these specific scenarios without needing to run the full application.
+
 require_relative '../lib/onetime'
 
 # Use the default config file for tests

--- a/try/25_customer_try.rb
+++ b/try/25_customer_try.rb
@@ -1,5 +1,22 @@
 # frozen_string_literal: true
 
+# These tryouts test the customer model functionality in the OneTime application.
+# They cover various aspects of customer management, including:
+#
+# 1. Customer creation and initialization
+# 2. Customer attributes (planid, custid, role, etc.)
+# 3. Customer states (pending, verified, active)
+# 4. Timestamp handling (created, updated, last_login)
+# 5. Customer destruction process
+#
+# These tests aim to verify the correct behavior of the OT::Customer class,
+# which is essential for managing user accounts in the application.
+#
+# The tryouts simulate different customer scenarios and test the OT::Customer class's
+# behavior without needing to run the full application, allowing for targeted testing
+# of these specific scenarios.
+
+
 require_relative '../lib/onetime'
 
 # Load the app

--- a/try/30_session_try.rb
+++ b/try/30_session_try.rb
@@ -16,9 +16,7 @@
 # behavior without needing to run the full application, allowing for targeted testing
 # of these specific features.
 
-
 require_relative '../lib/onetime'
-require 'pry-byebug';
 
 # Use the default config file for tests
 OT::Config.path = File.join(__dir__, '..', 'etc', 'config.test')

--- a/try/30_session_try.rb
+++ b/try/30_session_try.rb
@@ -1,5 +1,22 @@
 # frozen_string_literal: true
 
+# These tryouts test the session management functionality in the OneTime application.
+# They cover various aspects of session handling, including:
+#
+# 1. Session creation and initialization
+# 2. Session identifiers and attributes
+# 3. Form field management within sessions
+# 4. Authentication status and auth disabling
+# 5. Session reloading and replacement
+#
+# These tests aim to verify the correct behavior of the OT::Session class,
+# which is crucial for maintaining user state and security in the application.
+#
+# The tryouts simulate different session scenarios and test the OT::Session class's
+# behavior without needing to run the full application, allowing for targeted testing
+# of these specific features.
+
+
 require_relative '../lib/onetime'
 require 'pry-byebug';
 

--- a/try/35_ratelimit_try.rb
+++ b/try/35_ratelimit_try.rb
@@ -1,5 +1,21 @@
 # frozen_string_literal: true
 
+# These tryouts test the rate limiting functionality in the OneTime application.
+# They cover various aspects of rate limiting, including:
+#
+# 1. Defining and registering rate limit events
+# 2. Creating and managing rate limiters
+# 3. Checking if limits are exceeded
+# 4. Handling exceptions when limits are exceeded
+#
+# These tests aim to verify the correct behavior of the OT::RateLimit class,
+# which is essential for preventing abuse and ensuring fair usage of the application.
+#
+# The tryouts simulate different rate limiting scenarios and test the OT::RateLimit class's
+# behavior without needing to run the full application, allowing for targeted testing
+# of these specific features.
+
+
 require_relative '../lib/onetime'
 
 # Use the default config file for tests

--- a/try/40_email_template_try.rb
+++ b/try/40_email_template_try.rb
@@ -1,5 +1,18 @@
 # frozen_string_literal: true
 
+# These tryouts test the email template functionality in the OneTime application.
+# They cover various aspects of email template handling, including:
+#
+# 1. Creating email views for different purposes (Welcome, SecretLink)
+# 2. Rendering email templates
+# 3. Handling different locales (English, Spanish)
+# 4. Verifying email subject lines
+#
+# These tests aim to ensure that email templates are correctly generated and localized,
+# which is crucial for effective communication with users in the application.
+#
+# The tryouts use the OT::Email classes
+
 require_relative '../lib/onetime'
 
 # Use the default config file for tests

--- a/try/50_subdomain_try.rb
+++ b/try/50_subdomain_try.rb
@@ -1,5 +1,21 @@
 # frozen_string_literal: true
 
+# These tryouts test the subdomain functionality in the OneTime application.
+# They cover various aspects of subdomain management, including:
+#
+# 1. Creating and normalizing subdomains
+# 2. Checking subdomain existence and ownership
+# 3. Mapping subdomains to customer IDs
+# 4. Destroying subdomains
+#
+# These tests aim to verify the correct behavior of the Onetime::Subdomain class,
+# which is essential for managing custom subdomains in the application.
+#
+# The tryouts simulate different subdomain scenarios and test the Onetime::Subdomain class's
+# behavior without needing to interact with actual DNS, allowing for targeted testing
+# of these specific features.
+
+
 require_relative '../lib/onetime'
 
 # Use the default config file for tests

--- a/try/60_logic_base_try.rb
+++ b/try/60_logic_base_try.rb
@@ -1,5 +1,21 @@
 # frozen_string_literal: true
 
+# These tryouts test the base logic of the Onetime application,
+# specifically focusing on the CreateAccount functionality.
+#
+# We're testing various aspects of the CreateAccount logic, including:
+# 1. Instance creation
+# 2. Email validation
+#
+# These tests aim to ensure that the basic account creation logic
+# in the Onetime application works correctly, which is crucial for
+# user onboarding and management.
+#
+# The tryouts simulate different scenarios of using the CreateAccount
+# logic without needing to run the full application, allowing for
+# targeted testing of this specific functionality.
+
+
 require_relative '../lib/onetime'
 
 # Load the app

--- a/try/61_logic_destroy_account_try.rb
+++ b/try/61_logic_destroy_account_try.rb
@@ -1,5 +1,20 @@
 # frozen_string_literal: true
 
+# These tryouts test the account destruction functionality in the OneTime application.
+# They cover various aspects of the account destruction process, including:
+#
+# 1. Validating user input for account destruction
+# 2. Handling password confirmation
+# 3. Rate limiting destruction attempts
+# 4. Processing account destruction
+# 5. Verifying the state of destroyed accounts
+#
+# These tests aim to ensure that the account destruction process is secure, properly validated,
+# and correctly updates the user's account state.
+#
+# The tryouts use the OT::Logic::DestroyAccount class to simulate different account destruction
+# scenarios, allowing for targeted testing of this critical functionality without affecting real user accounts.
+
 require_relative '../lib/onetime'
 
 # Load the app

--- a/try/68_receive_feedback_try.rb
+++ b/try/68_receive_feedback_try.rb
@@ -1,5 +1,20 @@
 # frozen_string_literal: true
 
+# These tryouts test the feedback receiving functionality in the OneTime application.
+# They cover various aspects of handling user feedback, including:
+#
+# 1. Creating and processing feedback instances
+# 2. Validating feedback input
+# 3. Handling anonymous feedback attempts
+# 4. Storing and retrieving recent feedback
+# 5. Preventing duplicate feedback submissions
+#
+# These tests aim to ensure that user feedback is properly received, validated, and stored,
+# which is important for gathering user input and improving the application.
+#
+# The tryouts use the OT::Logic::ReceiveFeedback class to simulate different feedback submission
+# scenarios, allowing for targeted testing of this feature without affecting the actual feedback database.
+
 require_relative '../lib/onetime'
 
 # Load the app


### PR DESCRIPTION
### **User description**
The changes introduce a new middleware `Rack::HandleInvalidUTF8` to handle invalid UTF-8 characters in HTTP requests. This middleware checks various parts of the request environment for invalid UTF-8 sequences and raises an exception if any are found, returning a 400 Bad Request response. Additionally, the existing `Rack::HandleInvalidPercentEncoding` middleware is enhanced to handle exceptions more gracefully and log errors.

Key changes include:
- Addition of `lib/middleware/handle_invalid_utf8.rb` to define the new middleware.
- Extensive tests in `try/07_handle_invalid_utf8_try.rb` to validate the new middleware's functionality.
- Enhancements to `lib/middleware/handle_invalid_percent_encoding.rb` to improve error handling and logging.
- Introduction of `lib/onetime/app/base.rb` to provide configuration options for UTF-8 and URI encoding checks.
- Updates to `config.ru` to include the new middleware in the middleware stack.
- Addition of inline descriptions in tryout files.
- Modifications to `lib/onetime/app/api.rb` and `lib/onetime/app/api/base.rb` to include the new settings and improve relative path requires.
- Enabling `Performance/Size` cop in `.rubocop.yml` for better code quality.


___

### **PR Type**
Enhancement, Tests, Documentation


___

### **Description**
- Added `Rack::HandleInvalidUTF8` middleware to handle invalid UTF-8 characters in HTTP requests.
- Enhanced `Rack::HandleInvalidPercentEncoding` middleware for better error handling and logging.
- Introduced `AppSettings` module for configuring UTF-8 and URI encoding checks.
- Updated tests to cover new middleware functionalities and configurations.
- Added detailed descriptions to various tryout files for better documentation.
- Enabled `Performance/Size` cop in `.rubocop.yml` for improved code quality.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>7 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>config.ru</strong><dd><code>Add UTF-8 handling middleware and improve logging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

config.ru

<li>Added <code>Rack::HandleInvalidUTF8</code> middleware to handle invalid UTF-8 <br>characters.<br> <li> Ensured immediate flushing of stdout for real-time logging.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/465/files#diff-5fe74a7aca8668f86d1251d17e23b3ac9c55504d8d78698a8168a9cae87b350c">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>handle_invalid_percent_encoding.rb</strong><dd><code>Improve error handling and logging in percent encoding middleware</code></dd></summary>
<hr>

lib/middleware/handle_invalid_percent_encoding.rb

<li>Enhanced to handle exceptions more gracefully.<br> <li> Added logging improvements.<br> <li> Introduced <code>check_enabled?</code> method for route-specific checks.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/465/files#diff-186ddf7c022c5c0c286d2889669f397a09edd53097d61654bb2b60d0bb59918d">+48/-18</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>handle_invalid_utf8.rb</strong><dd><code>Add middleware to handle invalid UTF-8 characters</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/middleware/handle_invalid_utf8.rb

<li>Introduced new middleware to handle invalid UTF-8 characters.<br> <li> Added logging and error handling for invalid UTF-8 sequences.<br> <li> Implemented route-specific checks for UTF-8 validation.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/465/files#diff-ff177e1d3458bb844370a5b9d0ff715d612973932079a41ee94db91cb16b59ab">+143/-0</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>api.rb</strong><dd><code>Integrate AppSettings module for encoding checks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/onetime/app/api.rb

<li>Included <code>AppSettings</code> module for UTF-8 and URI encoding checks.<br> <li> Set default values for <code>check_utf8</code> and <code>check_uri_encoding</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/465/files#diff-bdbb5abe24f1c64c6b25a9d424d9f3634a0e9bfeaac3ede7e7382a8668d53cf6">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>base.rb</strong><dd><code>Update relative path requires in API base</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/onetime/app/api/base.rb

- Updated relative path requires for better maintainability.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/465/files#diff-d373c9db90dbcb4a66720f177566ef4757dcce10a3b3e79ba7df31e1f82b86c7">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>base.rb</strong><dd><code>Add AppSettings module for encoding middleware configuration</code></dd></summary>
<hr>

lib/onetime/app/base.rb

<li>Added <code>AppSettings</code> module for configuration of encoding checks.<br> <li> Provided class-level accessors for <code>check_utf8</code> and <code>check_uri_encoding</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/465/files#diff-4d0c25879ce8b50d4302d25f63aa03598062b3c1d4851714d7bfaa5d2fe3ab99">+33/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>base.rb</strong><dd><code>Update relative path requires in web base</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/onetime/app/web/base.rb

- Updated relative path requires for better maintainability.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/465/files#diff-d7b676502f4b13ea234bd52fafffd227dd09e034ca33ddd243de1e2ff6f8c783">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>06_handle_invalid_percent_encoding_try.rb</strong><dd><code>Update tests for percent encoding middleware</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

try/06_handle_invalid_percent_encoding_try.rb

<li>Updated tests to reflect changes in percent encoding middleware.<br> <li> Ensured middleware sets correct content type in error responses.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/465/files#diff-68a25ff225a0678713ff12c57872b42908108f8b03873659a46ba9a010c1a6a2">+9/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>07_handle_invalid_utf8_try.rb</strong><dd><code>Add tests for UTF-8 handling middleware</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

try/07_handle_invalid_utf8_try.rb

<li>Added tests for the new UTF-8 handling middleware.<br> <li> Covered various scenarios including invalid UTF-8 in headers and body.<br> <br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/465/files#diff-3ff9d145a6530540a58c9a3e358d5d518939cb3298a6efb942d0e81ca668418b">+117/-0</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>23_app_settings_try.rb</strong><dd><code>Add tests for AppSettings module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

try/23_app_settings_try.rb

<li>Added tests for AppSettings module.<br> <li> Covered default values and setting/getting configurations.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/465/files#diff-a9bdd042db98659fb2c9bb2b335157c2d900c1305897f51c4b4bfdd7c8efb70a">+73/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>16 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>10_utils_try.rb</strong><dd><code>Document utility function tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

try/10_utils_try.rb

- Added detailed descriptions for utility function tests.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/465/files#diff-272b5cdfe2196d7a3c41e3e5e3594b2c36f809bd81f9485409e9b34450ebdb15">+16/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>11_entropy_try.rb</strong><dd><code>Document entropy module tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

try/11_entropy_try.rb

- Added detailed descriptions for entropy module tests.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/465/files#diff-2db3de43e8fa8eb49801a18da1e64b94442a3336b1fe6ef334dca04834aa78d7">+13/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>15_config_try.rb</strong><dd><code>Document configuration tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

try/15_config_try.rb

- Added detailed descriptions for configuration tests.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/465/files#diff-531774a8ed986276366d01a8c95c7d5b5dad5f5aebda3ae14053fc32a38d11ff">+12/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>17_mail_validation.rb</strong><dd><code>Document email validation tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

try/17_mail_validation.rb

- Added detailed descriptions for email validation tests.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/465/files#diff-e73aadf6ae31bcf0c1b731051b094c04b92eff032a5062e94eeff7bed9095c6f">+14/-1</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>20_metadata_try.rb</strong><dd><code>Document metadata class tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

try/20_metadata_try.rb

- Added detailed descriptions for metadata class tests.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/465/files#diff-af34fec6bbbd1d98e7bb35c15db9daa2b79b7d923492df56ebf0a5a2004f5a77">+14/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>21_secret_try.rb</strong><dd><code>Document secret class tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

try/21_secret_try.rb

- Added detailed descriptions for secret class tests.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/465/files#diff-575a2576e0f54a1bc1b9c9ebe6cf4b40a3fcc44d25c476d5676a70cba2727ef1">+13/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>22_value_encryption_try.rb</strong><dd><code>Document value encryption tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

try/22_value_encryption_try.rb

- Added detailed descriptions for value encryption tests.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/465/files#diff-f440e03abcc6406354eb312f61c769bd85d880c0444f1021736d555f26b9e3b9">+18/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>23_passphrase_try.rb</strong><dd><code>Document passphrase handling tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

try/23_passphrase_try.rb

- Added detailed descriptions for passphrase handling tests.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/465/files#diff-b4b2bb2afa80540fd0aaa54637fb7e9c8b87f254b457f97f2fb5100c1e9e4593">+12/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>25_customer_try.rb</strong><dd><code>Document customer model tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

try/25_customer_try.rb

- Added detailed descriptions for customer model tests.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/465/files#diff-16609ea0076a3e7dbd94e39d6f4a338dbeec4a0999d09bd178a9185b08579c94">+17/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>30_session_try.rb</strong><dd><code>Document session management tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

try/30_session_try.rb

- Added detailed descriptions for session management tests.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/465/files#diff-9d10ecb8fa97955fb99596e9dc0de6ebf131b52f003798cc3bbaa0891fedeca3">+17/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>35_ratelimit_try.rb</strong><dd><code>Document rate limiting tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

try/35_ratelimit_try.rb

- Added detailed descriptions for rate limiting tests.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/465/files#diff-81711f71f4849a24e88b47b7113c30f878d46fd74c884a97036cd3284aaeed8a">+16/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>40_email_template_try.rb</strong><dd><code>Document email template tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

try/40_email_template_try.rb

- Added detailed descriptions for email template tests.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/465/files#diff-af5dc0e0a6ac752a05be8a07ef56dc3e2bfa3c1d5ad09f813d30ae745da307aa">+13/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>50_subdomain_try.rb</strong><dd><code>Document subdomain functionality tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

try/50_subdomain_try.rb

- Added detailed descriptions for subdomain functionality tests.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/465/files#diff-f6a0360b27ab81036d93b65bf6bcf931d51f9d17660722eb2dc7bfb5034bb7b3">+16/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>60_logic_base_try.rb</strong><dd><code>Document base logic tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

try/60_logic_base_try.rb

- Added detailed descriptions for base logic tests.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/465/files#diff-092b1b13531b688c43c14f2933a2102bfe24969e514a404e05b58d4468f7f54d">+16/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>61_logic_destroy_account_try.rb</strong><dd><code>Document account destruction tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

try/61_logic_destroy_account_try.rb

- Added detailed descriptions for account destruction tests.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/465/files#diff-e4acbac3c81b20d6197e016f6112234c78c22b685ef32a057ee75a1b3d0f24d5">+15/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>68_receive_feedback_try.rb</strong><dd><code>Document feedback receiving tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

try/68_receive_feedback_try.rb

- Added detailed descriptions for feedback receiving tests.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/465/files#diff-9ff98054266f568f1221910763d2013cdd0b2fe2104f085293fbb1b1d82bb74f">+15/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>.rubocop.yml</strong><dd><code>Enable Performance/Size cop in RuboCop configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.rubocop.yml

- Enabled `Performance/Size` cop for better code quality.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/465/files#diff-4f894049af3375c2bd4e608f546f8d4a0eed95464efcdea850993200db9fef5c">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

