### PR TITLE
Fix middleware app setting checks

### DIFF
--- a/lib/middleware/handle_invalid_percent_encoding.rb
+++ b/lib/middleware/handle_invalid_percent_encoding.rb
@@ -80,9 +80,9 @@ class Rack::HandleInvalidPercentEncoding
     return false unless defined?(Otto) && app.is_a?(Otto)
     name, route = app.route_definitions.first
     has_settings = route.klass.include?(Onetime::App::AppSettings)
-    setting_enabled = route.klass.check_uri_encoding
+    setting_enabled = has_settings && route.klass.check_uri_encoding
     logger.debug "[handle-invalid-uri-encoding] #{name} has settings: #{has_settings}, enabled: #{setting_enabled}"
-    return has_settings && setting_enabled
+    return setting_enabled
   end
 
   def handle_exception(env, exception)

--- a/lib/middleware/handle_invalid_utf8.rb
+++ b/lib/middleware/handle_invalid_utf8.rb
@@ -85,9 +85,9 @@ class Rack::HandleInvalidUTF8
     return false unless defined?(Otto) && app.is_a?(Otto)
     name, route = app.route_definitions.first
     has_settings = route.klass.include?(Onetime::App::AppSettings)
-    setting_enabled = route.klass.check_utf8
+    setting_enabled = has_settings && route.klass.check_utf8
     logger.debug "[handle-invalid-utf8] #{name} has settings: #{has_settings}, enabled: #{setting_enabled}"
-    return has_settings && setting_enabled
+    return setting_enabled
   end
 
   # Validates that the input is valid UTF-8 and raises an exception if it's not.

--- a/lib/onetime/app/colonel.rb
+++ b/lib/onetime/app/colonel.rb
@@ -1,7 +1,9 @@
 require_relative 'web/base'
+require_relative 'base'  # app/base.rb
 
 class Onetime::App
   class Colonel
+    include AppSettings
     include OT::App::Base
 
     def index

--- a/lib/onetime/app/web.rb
+++ b/lib/onetime/app/web.rb
@@ -1,9 +1,11 @@
 
 require_relative 'web/base'
 require_relative 'web/views'
+require_relative 'base'  # app/base.rb
 
 module Onetime
   class App
+    include AppSettings
     include Base
     require 'onetime/app/web/info'
     require 'onetime/app/web/account'


### PR DESCRIPTION
### **User description**
A change has been made to how middleware checks for Otto app settings to determine if percent encoding and UTF-8 validation should be applied. Previously, the check returned true if the app had settings defined, but this allowed validation to be applied even if the specific setting was disabled. The changes now only return true if both the app has settings AND the relevant setting is explicitly enabled, avoiding unnecessary validation.

Include new AppSettings in web, colonel apps


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fixed middleware checks for Otto app settings to ensure percent encoding and UTF-8 validation are only applied if the relevant settings are explicitly enabled.
- Included `AppSettings` module in both Colonel and Web apps.
- Added necessary require statements for `base.rb` in Colonel and Web apps.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>handle_invalid_percent_encoding.rb</strong><dd><code>Fix middleware check for URI encoding settings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/middleware/handle_invalid_percent_encoding.rb

<li>Modified the <code>check_enabled?</code> method to ensure that <code>setting_enabled</code> is <br>only true if <code>has_settings</code> is true.<br> <li> Simplified the return statement to only check <code>setting_enabled</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/468/files#diff-186ddf7c022c5c0c286d2889669f397a09edd53097d61654bb2b60d0bb59918d">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>handle_invalid_utf8.rb</strong><dd><code>Fix middleware check for UTF-8 settings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/middleware/handle_invalid_utf8.rb

<li>Modified the <code>check_enabled?</code> method to ensure that <code>setting_enabled</code> is <br>only true if <code>has_settings</code> is true.<br> <li> Simplified the return statement to only check <code>setting_enabled</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/468/files#diff-ff177e1d3458bb844370a5b9d0ff715d612973932079a41ee94db91cb16b59ab">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>colonel.rb</strong><dd><code>Include AppSettings in Colonel app</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/onetime/app/colonel.rb

<li>Included <code>AppSettings</code> module in <code>Colonel</code> class.<br> <li> Added a require statement for <code>base.rb</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/468/files#diff-387b2bc5e35d0294050dc40433968851b7a1370d19d03e612c86775e1b324344">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>web.rb</strong><dd><code>Include AppSettings in Web app</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/onetime/app/web.rb

<li>Included <code>AppSettings</code> module in <code>Web</code> class.<br> <li> Added a require statement for <code>base.rb</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/468/files#diff-ad61619aa6345b131c7c89cc1eb5e0f8e26d22a5da1942ba59aa67df05daf2f0">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

