### PR TITLE
Make bundle install optional in entrypoint.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -99,9 +99,6 @@ RUN set -eux && \
 RUN gem update --system
 RUN gem install bundler
 
-# Install the entrypoint script
-COPY ./bin/entrypoint.sh .
-
 
 ##
 # ENVIRONMENT LAYER
@@ -129,9 +126,10 @@ RUN mkdir -p "$ONETIME_HOME/{log,tmp}"
 
 WORKDIR $CODE_ROOT
 
-COPY Gemfile ./
+COPY Gemfile Gemfile.lock ./
 
-# Install the dependencies into the base image
+# Install the dependencies into the environment image
+RUN bundle config set --local without 'development test'
 RUN bundle install
 RUN bundle update --bundler
 
@@ -145,7 +143,7 @@ RUN bundle update --bundler
 FROM app_env
 ARG CODE_ROOT
 
-LABEL Name=onetimesecret Version=0.13.0
+LABEL Name=onetimesecret Version=0.15.0
 LABEL maintainer "Onetime Secret <docker-maint@onetimesecret.com>"
 LABEL org.opencontainers.image.description "Onetime Secret is a web application to share sensitive information securely and temporarily. This image contains the application and its dependencies."
 
@@ -176,7 +174,5 @@ RUN cp --preserve --no-clobber \
 # 3. Using the CMD instruction in the Dockerfile provides a fallback
 # command, which can be useful if no specific command is set in the
 # Docker Compose configuration.
-
-# TODO: Add ENTRYPOINT for max flexibility?
 
 CMD ["bin/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -63,6 +63,23 @@ Building and running locally.
       onetimesecret/onetimesecret:latest
 ```
 
+#### Optional Bundle Install
+
+By default, the `bundle install` command is not run when starting the container. If you want it to run at startup (e.g., to re-install new dependencies added to the Gemfile without rebuilding the image), you can set the `BUNDLE_INSTALL` environment variable to `true`. Here's how you can do this:
+
+```bash
+$ docker run -p 3000:3000 -d --name onetimesecret \
+    -e BUNDLE_INSTALL=true \
+    -e REDIS_URL=$REDIS_URL \
+    -e COLONEL=$COLONEL \
+    -e HOST=$HOST \
+    -e SSL=$SSL \
+    onetimesecret/onetimesecret:latest
+```
+
+This will cause the container to run bundle install each time it starts up. Note that this may increase the startup time of your container.
+
+
 #### Multi-platform builds
 
 Docker's buildx command is a powerful tool that allows you to create Docker images for multiple platforms simultaneously. Use buildx to build a Docker image that can run on both amd64 (standard Intel/AMD CPUs) and arm64 (ARM CPUs, like those in the Apple M1 chip) platforms.

--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -1,6 +1,6 @@
-#!/bin/sh
+#!/bin/bash
 
-#
+##
 # ONETIME ENTRYPOINT SCRIPT - 2024-05-18
 #
 #   Usage:
@@ -14,7 +14,6 @@
 #           onetime:
 #             extends: onetime-config
 #        -->  command: ["onetime", "-h", "0.0.0.0", "-p", "3000"]
-#
 #
 
 # Stop at the first sign of trouble
@@ -41,7 +40,13 @@ unset datestamp location basename
 
 # Run bundler again so that new dependencies added to the
 # Gemfile are installed at up time (i.e. avoids a rebuild).
->&2 bundle install
+# Check if BUNDLE_INSTALL is set to "true" (case-insensitive)
+if [[ "${BUNDLE_INSTALL,,}" == "true" ]]; then
+  >&2 echo "Running bundle install..."
+  >&2 bundle install
+else
+  >&2 echo "Skipping bundle install. Use BUNDLE_INSTALL=true to run it."
+fi
 
 if [ -d "/mnt/public" ]; then
   # By default the static web assets are available at /mnt/public/web


### PR DESCRIPTION
### **User description**
Currently, `bundle install` is always run in `bin/entrypoint.sh`. This can be time-consuming and unnecessary if dependencies haven't changed. This pull request introduces the `BUNDLE_INSTALL` environment variable and modifies `bin/entrypoint.sh` to check for this variable. The `bundle install` command will only run if the variable is set to "true" (case-insensitive). Logging has been added to indicate whether the command was run or skipped. The documentation has also been updated to explain this new option.

Fixes #473


___

### **PR Type**
Enhancement, Documentation


___

### **Description**
- Introduced `BUNDLE_INSTALL` environment variable to make `bundle install` optional in `bin/entrypoint.sh`.
- Updated shebang in `bin/entrypoint.sh` to use bash instead of sh.
- Configured Bundler in Dockerfile to skip development and test groups.
- Updated application version from 0.13.0 to 0.15.0 in Dockerfile.
- Added documentation for the new `BUNDLE_INSTALL` option in README.md.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>entrypoint.sh</strong><dd><code>Make `bundle install` optional based on environment variable</code></dd></summary>
<hr>

bin/entrypoint.sh

<li>Added conditional check for <code>BUNDLE_INSTALL</code> environment variable.<br> <li> Updated shebang to use bash instead of sh.<br> <li> Added logging to indicate whether <code>bundle install</code> was run or skipped.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/475/files#diff-75312155067f723f6e9c86dd316e4d83a9c88fb8be09889c355e39e03fb5ab6c">+9/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>Dockerfile</strong><dd><code>Update Dockerfile for optimized dependency management</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Dockerfile

<li>Updated to copy both <code>Gemfile</code> and <code>Gemfile.lock</code>.<br> <li> Configured Bundler to skip development and test groups.<br> <li> Updated application version from 0.13.0 to 0.15.0.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/475/files#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557">+4/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Document optional `BUNDLE_INSTALL` environment variable</code>&nbsp; &nbsp; </dd></summary>
<hr>

README.md

<li>Added documentation for the optional <code>BUNDLE_INSTALL</code> environment <br>variable.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/475/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+17/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

