### PR TITLE
Update Session ID Generation Method

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -151,7 +151,7 @@ GEM
     timeout (0.4.1)
     truemail (3.3.1)
       simpleidn (~> 0.2.1)
-    tryouts (2.4.0)
+    tryouts (2.4.1)
       sysinfo (~> 0.10)
     unicode-display_width (2.5.0)
     uri-redis (1.3.0)

--- a/lib/onetime/app/helpers.rb
+++ b/lib/onetime/app/helpers.rb
@@ -98,7 +98,7 @@ class Onetime::App
       error_response "An unexpected error occurred :["
 
     ensure
-      @sess ||= OT::Session.new :failover
+      @sess ||= OT::Session.new :failover, :anon
       @cust ||= OT::Customer.anonymous
     end
 

--- a/lib/onetime/models/mixins/rate_limited.rb
+++ b/lib/onetime/models/mixins/rate_limited.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-
-
 module Onetime::Models
   module RateLimited
     def event_incr! event
@@ -9,11 +7,14 @@ module Onetime::Models
       # track of the event count. e.g. sess.external_identifier.
       OT::RateLimit.incr! external_identifier, event
     end
+
     def event_clear! event
       OT::RateLimit.clear! external_identifier, event
     end
+
     def external_identifier
-      raise RuntimeError, "TODO: #{self.class}.external_identifier"
+      OT.ld "[external_identifier] #{self.class}##{id}"
+      raise RuntimeError, "TODO: Implement #{self.class}.external_identifier"
     end
   end
 end

--- a/lib/onetime/models/modules/rate_limit.rb
+++ b/lib/onetime/models/modules/rate_limit.rb
@@ -2,43 +2,61 @@
 
 class Onetime::RateLimit < Familia::String
   DEFAULT_LIMIT = 25 unless defined?(OT::RateLimit::DEFAULT_LIMIT)
+
   ttl 20.minutes
+
   def initialize identifier, event
     super [:limiter, identifier, event, self.class.eventstamp], db: 2
   end
+
   alias_method :count, :to_i
+
   class << self
     attr_reader :events
+  end
+
+  module ClassMethods
     def incr! identifier, event
+      OT.ld "RateLimit.incr! #{identifier} #{event}"
       lmtr = new identifier, event
       count = lmtr.increment
       lmtr.update_expiration
-      OT.ld [:limit, event, identifier, count].inspect
+
+      OT.ld ['[RateLimit.incr!]', event, identifier, count].inspect
+
       if exceeded?(event, count)
         raise OT::LimitExceeded.new(identifier, event, count)
       end
+
       count
     end
     alias_method :increment!, :incr!
+
     def clear! identifier, event
       lmtr = new identifier, event
       ret = lmtr.clear
       OT.ld [:clear, event, identifier, ret].inspect
       ret
     end
+
     def exceeded? event, count
       (count) > (events[event] || DEFAULT_LIMIT)
     end
+
     def register_event event, count
       (@events ||= {})[event] = count
     end
+
     def register_events events
       (@events ||= {}).merge! events
     end
+
     def eventstamp
       now = OT.now.to_i
       rounded = now - (now % self.ttl)
       Time.at(rounded).utc.strftime('%H%M')
     end
   end
+
+  extend ClassMethods
 end

--- a/lib/onetime/models/session.rb
+++ b/lib/onetime/models/session.rb
@@ -18,8 +18,10 @@ class Onetime::Session < Familia::HashKey
   # be anonymous and the customer will be anonymous.
   attr_accessor :disable_auth
 
-  def initialize ipaddress=nil, useragent=nil, custid=nil
-    @ipaddress, @custid, @useragent = ipaddress, custid, useragent  # must be nil or have values!
+  def initialize ipaddress, custid, useragent=nil
+    @ipaddress = ipaddress
+    @custid = custid
+    @useragent = useragent
     @entropy = [ipaddress, custid, useragent]
     OT.ld "[Session.initialize] Initialized session #{self} with entropy: #{@entropy}"
     @sessid = "anon"
@@ -167,13 +169,13 @@ class Onetime::Session < Familia::HashKey
     end
 
     def exists? sessid
-      sess = new
+      sess = new nil, nil
       sess.sessid = sessid
       sess.exists?
     end
 
     def load sessid
-      sess = new
+      sess = new nil, nil
       sess.sessid = sessid
       sess.exists? ? (add(sess); sess) : nil  # make sure this sess is in the values set
     end

--- a/lib/onetime/models/session.rb
+++ b/lib/onetime/models/session.rb
@@ -21,10 +21,14 @@ class Onetime::Session < Familia::HashKey
     @custid = custid
     @useragent = useragent
 
-    # Setting the session ID to nil ensures we can't persist this instance
+    # Defaulting the session ID to nil ensures we can't persist this instance
     # to redis until one is set (see `RedisHash#check_identifier!`). This is
     # important b/c we don't want to be colliding a default session ID and risk
     # leaking session data (e.g. across anonymous users).
+    #
+    # This is the distinction between .new and .create. .new is a new session
+    # that hasn't been saved to redis yet. .create is a new session that has
+    # been saved to redis.
     @sessid = nil
 
     @disable_auth = false

--- a/try/30_session_try.rb
+++ b/try/30_session_try.rb
@@ -28,10 +28,24 @@ OT.boot!
 
 @sess = OT::Session.create @ipaddress, @custid, @useragent
 
+## Sessions have a NIL session ID when _new_ is called
+sess = OT::Session.new @ipaddress, @custid, @useragent
+sessid = sess.sessid
+[sessid.class, sessid]
+#=> [NilClass, nil]
+
 ## Sessions have a session ID when _create_ is called
 sessid = @sess.sessid
 [sessid.class, (48..52).include?(sessid.length)]
 #=> [String, true]
+
+## Sessions have a unique session ID when _create_ is called the same arguments
+@sess = OT::Session.create @ipaddress, @custid, @useragent
+sess = OT::Session.create @ipaddress, @custid, @useragent
+sessid1 = @sess.sessid
+sessid2 = sess.sessid
+[sessid1.eql?(sessid2), sessid1.eql?(''), sessid1.class, sessid2.class, sessid2.to_i(36).positive?, sessid2.to_i(36).positive?]
+#=> [false, false, String, String, true, true]
 
 ## Sessions have an identifier
 identifier = @sess.identifier

--- a/try/30_session_try.rb
+++ b/try/30_session_try.rb
@@ -26,10 +26,9 @@ OT.boot!
 @useragent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_2_5) AppleWebKit/237.36 (KHTML, like Gecko) Chrome/10.0.95 Safari/237.36'
 @custid = 'tryouts'
 
-# NOTE: create and initialize have transposed arguments 😩
 @sess = OT::Session.create @ipaddress, @custid, @useragent
 
-## Sessions have a session ID when created
+## Sessions have a session ID when _create_ is called
 sessid = @sess.sessid
 [sessid.class, sessid.length > 50]
 #=> [String, true]
@@ -50,8 +49,8 @@ ipaddress = @sess.ipaddress
 #=> [String, @ipaddress]
 
 ## Sessions don't get unique IDs when instantiated
-s1 = OT::Session.new
-s2 = OT::Session.new
+s1 = OT::Session.new '255.255.255.255', :anon
+s2 = OT::Session.new '255.255.255.255', :anon
 s1.sessid.eql?(s2.sessid)
 #=> true
 

--- a/try/30_session_try.rb
+++ b/try/30_session_try.rb
@@ -30,12 +30,12 @@ OT.boot!
 
 ## Sessions have a session ID when _create_ is called
 sessid = @sess.sessid
-[sessid.class, sessid.length > 50]
+[sessid.class, (48..52).include?(sessid.length)]
 #=> [String, true]
 
 ## Sessions have an identifier
 identifier = @sess.identifier
-[identifier.class, identifier.length > 50]
+[identifier.class, (48..52).include?(identifier.length)]
 #=> [String, true]
 
 ## Sessions have a short identifier
@@ -128,7 +128,7 @@ sess.sessid.eql?(@sess.sessid)
 
 ## Can generate a session ID
 sid = OT::Session.generate_id
-[sid.class, sid.length > 50]
+[sid.class, (48..52).include?(sid.length)]
 #=> [String, true]
 
 ## Can update fields

--- a/try/31_session_extended_try.rb
+++ b/try/31_session_extended_try.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require 'benchmark'
+
+require_relative '../lib/onetime'
+
+# Use the default config file for tests
+OT::Config.path = File.join(__dir__, '..', 'etc', 'config.test')
+OT.boot!
+
+@ipaddress = '10.0.0.254'
+@useragent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_2_5) AppleWebKit/237.36 (KHTML, like Gecko) Chrome/10.0.95 Safari/237.36'
+@custid = 'tryouts'
+@session_ids = 1000.times.map { OT::Session.create(@ipaddress, @custid, @useragent).sessid }
+
+
+## Generate a large set of session IDs and check for duplicates
+[@session_ids.uniq.length, @session_ids.length]
+#=> [1000, 1000]
+
+## Verify that the distribution of characters in the IDs is uniform
+char_counts = @session_ids.join.chars.group_by(&:itself).transform_values(&:count)
+std_dev = Math.sqrt(char_counts.values.sum { |count| (count - char_counts.values.sum.to_f / char_counts.length) ** 2 } / char_counts.length)
+[std_dev < 50, char_counts.length > 30]  # Adjust these thresholds as needed
+#=> [true, true]
+
+## Check that the length of all generated IDs is consistent
+## and within an acceptable range (e.g. [50, 49, 48])
+lengths = @session_ids.map(&:length).uniq
+min_length, max_length = 47, 53  # Adjust these values based on your implementation
+puts lengths
+lengths.all? { |length| length.between?(min_length, max_length) }
+#=> true
+
+## Ensure IDs don't contain any predictable patterns
+first_chars = @session_ids.map { |id| id[0, 3] }
+last_chars = @session_ids.map { |id| id[-3, 3] }
+[first_chars.uniq.length > 100, last_chars.uniq.length > 100]  # Adjust thresholds as needed
+#=> [true, true]
+
+## Add timing tests to verify that ID generation is consistent and reasonably fast
+times = 10.times.map { Benchmark.realtime { OT::Session.create(@ipaddress, @custid, @useragent) } }
+[times.max < 0.01, times.min > 0]  # Adjust the max time (0.01 seconds) as needed
+#=> [true, true]
+
+## Implement collision resistance tests (generating IDs with similar inputs)
+similar_inputs = [
+  ['10.0.0.1', 'user1', 'Chrome'],
+  ['10.0.0.2', 'user1', 'Chrome'],
+  ['10.0.0.1', 'user2', 'Chrome'],
+  ['10.0.0.1', 'user1', 'Firefox']
+]
+similar_ids = similar_inputs.map { |ip, cust, ua| OT::Session.create(ip, cust, ua).sessid }
+similar_ids.uniq.length == similar_ids.length
+#=> true
+
+## Test ID generation with various input combinations
+varied_inputs = [
+  ['192.168.1.1', 'customer1', 'Safari'],
+  ['8.8.8.8', 'customer2', 'Edge'],
+  ['172.16.0.1', 'customer3', 'Opera'],
+  ['::1', 'customer4', 'Brave']
+]
+varied_ids = varied_inputs.map { |ip, cust, ua| OT::Session.create(ip, cust, ua).sessid }
+varied_ids.uniq.length == varied_ids.length
+#=> true
+
+## Verify that IDs are URL-safe and don't contain any special characters
+url_unsafe_chars = /[^a-zA-Z0-9-_]/
+@session_ids.any? { |id| id =~ url_unsafe_chars }
+#=> false
+
+## Check that IDs are case-insensitive (if applicable to our system)
+downcase_ids = @session_ids.map(&:downcase)
+upcase_ids = @session_ids.map(&:upcase)
+[downcase_ids == @session_ids, upcase_ids == @session_ids]
+#=> [true, false]  # Adjust based on your case-sensitivity requirements
+
+## Test ID generation across different Ruby versions (simulate by calling the method multiple times)
+ruby_version_ids = 3.times.map { OT::Session.create(@ipaddress, @custid, @useragent).sessid }
+ruby_version_ids.uniq.length == ruby_version_ids.length
+#=> true

--- a/try/60_logic_base_try.rb
+++ b/try/60_logic_base_try.rb
@@ -26,7 +26,7 @@ OT.boot! :app
 @now = DateTime.now
 @from_address = OT.conf.dig(:emailer, :from)
 @email_address = 'tryouts@onetimesecret.com'
-@sess = OT::Session.new
+@sess = OT::Session.new '255.255.255.255', :anon
 @cust = OT::Customer.new @email_address
 @sess.event_clear! :send_feedback
 @params = {}
@@ -74,7 +74,7 @@ end
 #=> true
 
 ## Can create account and it's not verified by default.
-sess = OT::Session.new
+sess = OT::Session.new '255.255.255.255', :anon
 cust = OT::Customer.new
 logic = OT::Logic::CreateAccount.new sess, cust, @valid_params.call, 'en'
 logic.raise_concerns
@@ -83,7 +83,7 @@ logic.process
 #=> [false, 'false', false]
 
 ## Can create account and have it auto-verified.
-sess = OT::Session.new
+sess = OT::Session.new '255.255.255.255', :anon
 cust = OT::Customer.new
 OT.conf[:site][:authentication][:autoverify] = true # force the config to be true
 logic = OT::Logic::CreateAccount.new sess, cust, @valid_params.call, 'en'

--- a/try/60_logic_base_try.rb
+++ b/try/60_logic_base_try.rb
@@ -74,20 +74,20 @@ end
 #=> true
 
 ## Can create account and it's not verified by default.
-sess = OT::Session.new '255.255.255.255', :anon
+sess = OT::Session.create '255.255.255.255', :anon
 cust = OT::Customer.new
 logic = OT::Logic::CreateAccount.new sess, cust, @valid_params.call, 'en'
 logic.raise_concerns
 logic.process
-[logic.autoverify, logic.cust.verified, OT.conf[:site][:authentication][:autoverify]]
+[logic.autoverify, logic.cust.verified, OT.conf.dig(:site, :authentication, :autoverify)]
 #=> [false, 'false', false]
 
 ## Can create account and have it auto-verified.
-sess = OT::Session.new '255.255.255.255', :anon
+sess = OT::Session.create '255.255.255.255', :anon
 cust = OT::Customer.new
 OT.conf[:site][:authentication][:autoverify] = true # force the config to be true
 logic = OT::Logic::CreateAccount.new sess, cust, @valid_params.call, 'en'
 logic.raise_concerns
 logic.process
-[logic.autoverify, logic.cust.verified, OT.conf[:site][:authentication][:autoverify]]
+[logic.autoverify, logic.cust.verified, OT.conf.dig(:site, :authentication, :autoverify)]
 #=> [true, 'true', true]

--- a/try/61_logic_destroy_account_try.rb
+++ b/try/61_logic_destroy_account_try.rb
@@ -24,7 +24,7 @@ OT.boot! :app
 # Setup some variables for these tryouts
 @email_address = 'changeme@example.com'
 @now = DateTime.now
-@sess = OT::Session.new
+@sess = OT::Session.new '255.255.255.255', :anon
 @sess.event_clear! :destroy_account
 @cust = OT::Customer.new @email_address
 @sess.event_clear! :send_feedback

--- a/try/61_logic_destroy_account_try.rb
+++ b/try/61_logic_destroy_account_try.rb
@@ -128,7 +128,7 @@ last_error = nil
 end
 @sess.event_clear! :destroy_account
 last_error
-#=> [OT::LimitExceeded, '[limit-exceeded] 9b8yjehe955u8l6kicd1jz90xqj8nz for destroy_account (6)']
+#=> [OT::LimitExceeded, '[limit-exceeded] lk2oqnz198o3p7vm0mptqvpeqanjzae for destroy_account (6)']
 
 ## Attempt to process the request without calling raise_concerns first
 password_guess = @params[:currentp]

--- a/try/68_receive_feedback_try.rb
+++ b/try/68_receive_feedback_try.rb
@@ -25,7 +25,7 @@ OT.boot! :app
 @now = DateTime.now
 @model_class = OT::Feedback
 @email_address = "tryouts+#{@now}@onetimesecret.com"
-@sess = OT::Session.new
+@sess = OT::Session.new '255.255.255.255', :anon
 @cust = OT::Customer.new @email_address
 @sess.event_clear! :send_feedback
 @params = {
@@ -87,7 +87,7 @@ count_after - count_before
 ## Sending populates the Feedback model's sorted set key in redis
 count_before = @model_class.recent.count
 email_address = "tryouts2+#{@now}@onetimesecret.com"
-sess = OT::Session.new
+sess = OT::Session.new '255.255.255.255', :anon
 cust = OT::Customer.new email_address
 obj = OT::Logic::ReceiveFeedback.new sess, cust, { msg: 'Some feedback' }
 obj.process
@@ -97,7 +97,7 @@ count_after - count_before
 
 ## Sending feedback as an anonymous user raises a concern
 cust = OT::Customer.anonymous
-sess = OT::Session.new 'id123', 'tryouts', cust
+sess = OT::Session.new 'id123', cust, "tryouts"
 params = { msg: 'This is a test feedback' }
 obj = OT::Logic::ReceiveFeedback.new sess, cust, params
 sess.event_clear! :send_feedback


### PR DESCRIPTION
### **User description**
(To be merged after #484, #492)

We are updating the `generate_id` method in the `Session` model to improve the security and uniqueness of our session identifiers. The current implementation uses SHA512 and base-36 encoding, but we are implementing a more robust solution.

### Changes Made

- Increased debug logging around session creation
- Fixed session initialize signature
- Changed the order of arguments to match `Session.create`
- Made IP address and custid required in session initialize
- Updated tryouts gem to version 2.4.1
- Set `Session.sessid` to `nil` by default to prevent collision of default session IDs and potential data leakage
- Refactored session ID generation to remove entropy parameter and switch to SHA256 hashing
- Limited external ID in `61_logic_destroy_account_try`


___

### **PR Type**
Enhancement, Tests, Configuration changes


___

### **Description**
- Enhanced session ID generation by removing entropy parameter and switching to SHA256 hashing.
- Added `autoverify` configuration and logic to account creation process.
- Updated session initialization to set `sessid` to `nil` by default.
- Improved logging for session creation and rate limiting.
- Updated tests to reflect changes in session ID generation and account creation logic.
- Updated configuration files to include `autoverify` option and new default DNS servers.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>7 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>helpers.rb</strong><dd><code>Ensure anonymous session handling in helpers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/onetime/app/helpers.rb

<li>Added <code>:anon</code> argument to <code>OT::Session.new</code> to ensure anonymous session <br>handling.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/498/files#diff-e94d14dd7ae26375167811c7ec80077c552df686cbd9b62877e36f299e28725a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>account.rb</strong><dd><code>Add autoverify handling in account creation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/onetime/app/web/account.rb

<li>Added conditional logic to handle <code>autoverify</code> in account creation.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/498/files#diff-5bbe0d38a554c9ad4195c7d8320f2e23a950ff4a1fce7a5c7ffb2943dcf53b9a">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>logic.rb</strong><dd><code>Enhance account creation with autoverify and roles</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/onetime/logic.rb

<li>Added <code>autoverify</code> and <code>customer_role</code> attributes.<br> <li> Updated account creation logic to handle <code>autoverify</code> and customer <br>roles.<br> <li> Added logging and email verification logic.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/498/files#diff-7392bb117f086b438ba32efa5d5e1d5e4a4d504535adf17f59d5347f2e927b80">+40/-15</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>base.rb</strong><dd><code>Ensure plan method returns a value</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/onetime/logic/base.rb

- Added a return statement to the `plan` method.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/498/files#diff-e1e6d4ed0dad20172f914c28eaa0751f6e5143b8c50452966f3efc045c1496be">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rate_limited.rb</strong><dd><code>Add logging to external_identifier method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/onetime/models/mixins/rate_limited.rb

- Added logging to `external_identifier` method.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/498/files#diff-6a72107d924abf24fc0756e2474fc51e26bc831e1c3198c3972d80446f3c879b">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rate_limit.rb</strong><dd><code>Refactor and add logging to rate limit methods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/onetime/models/modules/rate_limit.rb

<li>Added logging and refactored rate limit methods.<br> <li> Extended with <code>ClassMethods</code> module.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/498/files#diff-fb536f571449716a1dbcdc6241fe566c67c9a9ed320e6eed7b6bd0cf19d50765">+19/-1</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>session.rb</strong><dd><code>Refactor session ID generation and external identifier</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/onetime/models/session.rb

<li>Removed <code>entropy</code> parameter from session ID generation.<br> <li> Switched to SHA256 hashing for session ID.<br> <li> Set <code>sessid</code> to <code>nil</code> by default.<br> <li> Updated <code>external_identifier</code> method to use IP address and customer ID.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/498/files#diff-f167d5124650c0199a0cb49863434a87e3ab36b20d677d99c336d23c48de4536">+42/-20</a>&nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>15_config_try.rb</strong><dd><code>Add autoverify configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

try/15_config_try.rb

- Added configuration for `autoverify`.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/498/files#diff-531774a8ed986276366d01a8c95c7d5b5dad5f5aebda3ae14053fc32a38d11ff">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>ruby.yml</strong><dd><code>Add verbose failure output to tryouts command</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ruby.yml

- Added `-f` flag to tryouts command for verbose failure output.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/498/files#diff-ce0dee93a528f6c7648f4cd671a3ec7be6a80f976c88f3aa1c322b7a80828fba">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>config.example</strong><dd><code>Add autoverify option and update DNS servers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

etc/config.example

<li>Added <code>autoverify</code> configuration option.<br> <li> Updated default DNS servers.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/498/files#diff-71a1275087d5064b1db195a61a706a791f3904ffc96941f57e43d62f10b202e1">+9/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>config.test</strong><dd><code>Add autoverify option and update DNS servers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

etc/config.test

<li>Added <code>autoverify</code> configuration option.<br> <li> Updated default DNS servers.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/498/files#diff-0f6b7badb142361613206170cb041a7748fc0ff8fd5057171ce4d8407ccab9ca">+9/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>30_session_try.rb</strong><dd><code>Update session tests for new ID generation logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

try/30_session_try.rb

- Updated session tests to reflect new session ID generation logic.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/498/files#diff-9d10ecb8fa97955fb99596e9dc0de6ebf131b52f003798cc3bbaa0891fedeca3">+6/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>40_email_template_try.rb</strong><dd><code>Update email template tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

try/40_email_template_try.rb

- Updated email template tests to use new mail classes.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/498/files#diff-af5dc0e0a6ac752a05be8a07ef56dc3e2bfa3c1d5ad09f813d30ae745da307aa">+13/-16</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>60_logic_base_try.rb</strong><dd><code>Add tests for account creation with autoverify</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

try/60_logic_base_try.rb

- Added tests for account creation with and without autoverify.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/498/files#diff-092b1b13531b688c43c14f2933a2102bfe24969e514a404e05b58d4468f7f54d">+39/-3</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>61_logic_destroy_account_try.rb</strong><dd><code>Update destroy account tests for new session initialization</code></dd></summary>
<hr>

try/61_logic_destroy_account_try.rb

- Updated destroy account tests to use new session initialization.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/498/files#diff-e4acbac3c81b20d6197e016f6112234c78c22b685ef32a057ee75a1b3d0f24d5">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>68_receive_feedback_try.rb</strong><dd><code>Update feedback tests for new session initialization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

try/68_receive_feedback_try.rb

- Updated feedback tests to use new session initialization.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/498/files#diff-9ff98054266f568f1221910763d2013cdd0b2fe2104f085293fbb1b1d82bb74f">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

