### PR TITLE
Improve Page Refresh Handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ data/
 Caddyfile
 .prompts/
 /etc/caddy
+node_modules/

--- a/lib/onetime/app/helpers.rb
+++ b/lib/onetime/app/helpers.rb
@@ -127,14 +127,20 @@ class Onetime::App
       @check_shrimp_ran = true
       return unless req.post? || req.put? || req.delete?
       attempted_shrimp = req.params[:shrimp]
+      shrimp = (sess.shrimp || '[noshrimp]').clone
 
-      ### NOTE: MUST FAIL WHEN NO SHRIMP OTHERWISE YOU CAN
-      ### JUST SUBMIT A FORM WITHOUT ANY SHRIMP WHATSOEVER.
-      unless sess.shrimp?(attempted_shrimp) || ignoreshrimp
-        shrimp = (sess.shrimp || '[noshrimp]').clone
-        sess.clear_shrimp!  # assume the shrimp is being tampered with
+      if sess.shrimp?(attempted_shrimp) || ignoreshrimp
+        OT.ld "GOOD SHRIMP for #{cust.custid}@#{req.path}: #{attempted_shrimp.shorten(10)}"
+        # Regardless of the outcome, we clear the shrimp from the session
+        # to prevent replay attacks. A new shrimp is generated on the
+        # next page load.
+        sess.clear_shrimp!
+      else
+        ### NOTE: MUST FAIL WHEN NO SHRIMP OTHERWISE YOU CAN
+        ### JUST SUBMIT A FORM WITHOUT ANY SHRIMP WHATSOEVER.
         ex = OT::BadShrimp.new(req.path, cust.custid, attempted_shrimp, shrimp)
-        OT.ld "BAD SHRIMP for #{cust.custid}@#{req.path}: #{attempted_shrimp}"
+        OT.ld "BAD SHRIMP for #{cust.custid}@#{req.path}: #{attempted_shrimp.shorten(10)}"
+        sess.clear_shrimp!
         raise ex
       end
     end

--- a/lib/onetime/app/web.rb
+++ b/lib/onetime/app/web.rb
@@ -35,6 +35,7 @@ module Onetime
 
     def dashboard
       authenticated do
+        no_cache!
         logic = OT::Logic::Dashboard.new sess, cust, req.params, locale
         logic.raise_concerns
         logic.process

--- a/lib/onetime/app/web/account.rb
+++ b/lib/onetime/app/web/account.rb
@@ -43,7 +43,6 @@ module Onetime
 
     def forgot
       publically do
-        no_cache!
         if req.params[:key]
           secret = OT::Secret.load req.params[:key]
           if secret.nil? || secret.verification.to_s != 'true'
@@ -62,7 +61,6 @@ module Onetime
 
     def request_reset
       publically do
-        no_cache!
         if req.params[:key]
           logic = OT::Logic::ResetPassword.new sess, cust, req.params, locale
           logic.raise_concerns
@@ -83,8 +81,6 @@ module Onetime
 
     def signup
       publically do
-        no_cache!
-
         # If a plan has been selected, the next onboarding step is the actual signup
         if OT::Plan.plan?(req.params[:planid])
           sess.set_error_message "You're already signed up" if sess.authenticated?
@@ -110,7 +106,6 @@ module Onetime
     def create_account
       publically() do
         deny_agents!
-        no_cache!
         logic = OT::Logic::CreateAccount.new sess, cust, req.params, locale
         logic.raise_concerns
         logic.process
@@ -128,7 +123,6 @@ module Onetime
 
     def authenticate # rubocop:disable Metrics/AbcSize
       publically do
-        no_cache!
         logic = OT::Logic::AuthenticateSession.new sess, cust, req.params, locale
         view = Onetime::App::Views::Login.new req, sess, cust, locale
         if sess.authenticated?
@@ -157,7 +151,6 @@ module Onetime
 
     def logout
       authenticated do
-        no_cache!
         logic = OT::Logic::DestroySession.new sess, cust, req.params, locale
         logic.raise_concerns
         logic.process
@@ -167,7 +160,6 @@ module Onetime
 
     def account
       authenticated do
-        no_cache!
         logic = OT::Logic::ViewAccount.new sess, cust, req.params, locale
         logic.raise_concerns
         logic.process
@@ -195,7 +187,6 @@ module Onetime
     end
     def update_subdomain
       authenticated('/account') do
-        no_cache!
         logic = OT::Logic::UpdateSubdomain.new sess, cust, req.params, locale
         logic.raise_concerns
         logic.process

--- a/lib/onetime/app/web/account.rb
+++ b/lib/onetime/app/web/account.rb
@@ -123,6 +123,10 @@ module Onetime
 
     def authenticate # rubocop:disable Metrics/AbcSize
       publically do
+        # If the request is halted, say for example rate limited, we don't want to
+        # allow the browser to refresh and re-submit the form with the login
+        # credentials.
+        no_cache!
         logic = OT::Logic::AuthenticateSession.new sess, cust, req.params, locale
         view = Onetime::App::Views::Login.new req, sess, cust, locale
         if sess.authenticated?

--- a/lib/onetime/app/web/account.rb
+++ b/lib/onetime/app/web/account.rb
@@ -43,6 +43,7 @@ module Onetime
 
     def forgot
       publically do
+        no_cache!
         if req.params[:key]
           secret = OT::Secret.load req.params[:key]
           if secret.nil? || secret.verification.to_s != 'true'
@@ -61,6 +62,7 @@ module Onetime
 
     def request_reset
       publically do
+        no_cache!
         if req.params[:key]
           logic = OT::Logic::ResetPassword.new sess, cust, req.params, locale
           logic.raise_concerns
@@ -81,6 +83,8 @@ module Onetime
 
     def signup
       publically do
+        no_cache!
+
         # If a plan has been selected, the next onboarding step is the actual signup
         if OT::Plan.plan?(req.params[:planid])
           sess.set_error_message "You're already signed up" if sess.authenticated?
@@ -106,6 +110,7 @@ module Onetime
     def create_account
       publically() do
         deny_agents!
+        no_cache!
         logic = OT::Logic::CreateAccount.new sess, cust, req.params, locale
         logic.raise_concerns
         logic.process
@@ -123,6 +128,7 @@ module Onetime
 
     def authenticate # rubocop:disable Metrics/AbcSize
       publically do
+        no_cache!
         logic = OT::Logic::AuthenticateSession.new sess, cust, req.params, locale
         view = Onetime::App::Views::Login.new req, sess, cust, locale
         if sess.authenticated?
@@ -151,6 +157,7 @@ module Onetime
 
     def logout
       authenticated do
+        no_cache!
         logic = OT::Logic::DestroySession.new sess, cust, req.params, locale
         logic.raise_concerns
         logic.process
@@ -160,6 +167,7 @@ module Onetime
 
     def account
       authenticated do
+        no_cache!
         logic = OT::Logic::ViewAccount.new sess, cust, req.params, locale
         logic.raise_concerns
         logic.process
@@ -187,6 +195,7 @@ module Onetime
     end
     def update_subdomain
       authenticated('/account') do
+        no_cache!
         logic = OT::Logic::UpdateSubdomain.new sess, cust, req.params, locale
         logic.raise_concerns
         logic.process

--- a/lib/onetime/app/web/base.rb
+++ b/lib/onetime/app/web/base.rb
@@ -19,6 +19,7 @@ module Onetime
 
       def authenticated redirect=nil
         carefully(redirect) do
+          no_cache!
           check_session!     # 1. Load or create the session, load customer (or anon)
           check_locale!      # 2. Check the request for the desired locale
           check_shrimp!      # 3. Check the shrimp for POST,PUT,DELETE (after session)

--- a/lib/onetime/logic.rb
+++ b/lib/onetime/logic.rb
@@ -35,9 +35,9 @@ module Onetime
       def process_params
         @planid = params[:planid].to_s
         @custid = params[:u].to_s.downcase.strip
-        @password = params[:p].to_s
-        @password2 = params[:p2].to_s
-        @skill = params[:skill].to_s # Hidden field, shouldn't have a value
+        @password = self.class.normalize_password(params[:p])
+        @password2 = self.class.normalize_password(params[:p2])
+        @skill = params[:skill].to_s.strip.slice(0,60) # Hidden field, shouldn't have a value
       end
       def raise_concerns
         limit_action :create_account
@@ -98,7 +98,7 @@ module Onetime
       attr_reader :session_ttl
       def process_params
         @potential_custid = params[:u].to_s.downcase.strip
-        @passwd = params[:p]
+        @passwd = self.class.normalize_password(params[:p])
         #@stay = params[:stay].to_s == "true"
         @stay = true # Keep sessions alive by default
         @session_ttl = (stay ? 30.days : 20.minutes).to_i
@@ -243,8 +243,8 @@ module Onetime
       attr_reader :secret
       def process_params
         @secret = OT::Secret.load params[:key].to_s
-        @newp = params[:newp].to_s
-        @newp2 = params[:newp2].to_s
+        @newp = self.class.normalize_password(params[:newp])
+        @newp2 = self.class.normalize_password(params[:newp2])
       end
       def raise_concerns
         raise OT::MissingSecret if secret.nil?
@@ -316,10 +316,10 @@ module Onetime
     class UpdateAccount < OT::Logic::Base
       attr_reader :modified
       def process_params
-        @currentp = params[:currentp].to_s.strip.slice(0,60)
-        @newp = params[:newp].to_s.strip.slice(0,60)
-        @newp2 = params[:newp2].to_s.strip.slice(0,60)
-        @passgen_token = params[:passgen_token].to_s.strip.slice(0,60)
+        @currentp = self.class.normalize_password(params[:currentp])
+        @newp = self.class.normalize_password(params[:newp])
+        @newp2 = self.class.normalize_password(params[:newp2])
+        @passgen_token = self.class.normalize_password(params[:passgen_token], 60)
       end
       def raise_concerns
         @modified ||= []
@@ -361,10 +361,10 @@ module Onetime
       attr_reader :raised_concerns_was_called
 
       def process_params
-        unless params.nil?
-          @currentp = params[:currentp].to_s.strip.slice(0,60)
-        end
+        return if params.nil?
+        @currentp = self.class.normalize_password(params[:currentp])
       end
+
       def raise_concerns
         @raised_concerns_was_called = true
 

--- a/lib/onetime/logic/base.rb
+++ b/lib/onetime/logic/base.rb
@@ -63,6 +63,14 @@ module Onetime
 
         sess.event_incr! event
       end
+
+      module ClassMethods
+        def normalize_password(password, max_length = 128)
+          password.to_s.strip.slice(0, max_length)
+        end
+      end
+
+      extend ClassMethods
     end
 
     module ClassMethods

--- a/lib/onetime/models/session.rb
+++ b/lib/onetime/models/session.rb
@@ -94,11 +94,8 @@ class Onetime::Session < Familia::HashKey
   end
 
   def add_shrimp
-    ret = self.shrimp
-    if ret.to_s.empty?
-      ret = self.shrimp = self.class.generate_id(sessid, custid, :shrimp)
-    end
-    ret
+    self.shrimp ||= self.class.generate_id(sessid, custid, :shrimp)
+    self.shrimp
   end
 
   def clear_shrimp!


### PR DESCRIPTION
### **User description**
This pull request aims to enhance the handling of page refreshes on the /account page to ensure a smoother user experience and maintain data integrity. The following changes have been made:

- Use `no_cache!` for all authenticated endpoints
- Replace sessid on successful login to improve login security
- Improve shrimp validation security and logging
- Standardize password handling

These changes address the issues described in Issue #503 and provide a more robust mechanism to handle page refreshes. The implemented solution includes a state management system to preserve user data during refreshes, appropriate checks to prevent duplicate submissions or unintended data modifications, and proper error handling and user feedback for refresh scenarios. Additionally, server-side checks have been implemented to validate request authenticity and prevent unintended actions, and the existing `check_shrimp!` method has been utilized to enhance security measures during page refreshes.


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Enhanced shrimp validation security by clearing shrimp from the session after validation and adding logging for comparisons.
- Added `no_cache!` to various endpoints to prevent caching issues and form resubmission.
- Standardized password handling across multiple logic classes to improve security and consistency.
- Improved session security by replacing the session ID on successful login and creating a new session.
- Added a method to normalize passwords.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>helpers.rb</strong><dd><code>Enhance shrimp validation security and logging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/onetime/app/helpers.rb

<li>Improved shrimp validation logic to prevent replay attacks.<br> <li> Added logging for both good and bad shrimp comparisons.<br> <li> Ensured shrimp is cleared from the session after validation.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/504/files#diff-e94d14dd7ae26375167811c7ec80077c552df686cbd9b62877e36f299e28725a">+13/-7</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>web.rb</strong><dd><code>Prevent caching issues on dashboard endpoint</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/onetime/app/web.rb

<li>Added <code>no_cache!</code> to the dashboard endpoint to prevent caching issues.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/504/files#diff-ad61619aa6345b131c7c89cc1eb5e0f8e26d22a5da1942ba59aa67df05daf2f0">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>account.rb</strong><dd><code>Prevent form resubmission on authentication</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/onetime/app/web/account.rb

<li>Added <code>no_cache!</code> to the authenticate method to prevent form <br>resubmission.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/504/files#diff-5bbe0d38a554c9ad4195c7d8320f2e23a950ff4a1fce7a5c7ffb2943dcf53b9a">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>base.rb</strong><dd><code>Prevent caching issues for authenticated endpoints</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/onetime/app/web/base.rb

<li>Added <code>no_cache!</code> to the authenticated method to prevent caching issues.<br> <br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/504/files#diff-d7b676502f4b13ea234bd52fafffd227dd09e034ca33ddd243de1e2ff6f8c783">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>logic.rb</strong><dd><code>Standardize password handling and improve session security</code></dd></summary>
<hr>

lib/onetime/logic.rb

<li>Standardized password handling across multiple logic classes.<br> <li> Replaced session ID on successful login to improve security.<br> <li> Added new session creation logic on successful authentication.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/504/files#diff-7392bb117f086b438ba32efa5d5e1d5e4a4d504535adf17f59d5347f2e927b80">+26/-16</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>base.rb</strong><dd><code>Add password normalization method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/onetime/logic/base.rb

- Added a method to normalize passwords.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/504/files#diff-e1e6d4ed0dad20172f914c28eaa0751f6e5143b8c50452966f3efc045c1496be">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>session.rb</strong><dd><code>Simplify shrimp addition logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/onetime/models/session.rb

- Simplified shrimp addition logic.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/504/files#diff-f167d5124650c0199a0cb49863434a87e3ab36b20d677d99c336d23c48de4536">+2/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

