### PR TITLE
Fix passphrase privacy settings

### DIFF
--- a/src/components/SecretForm.vue
+++ b/src/components/SecretForm.vue
@@ -59,6 +59,7 @@ const togglePassphrase = () => {
                 :type="showPassphrase ? 'text' : 'password'"
                 id="currentPassphrase"
                 v-model="currentPassphrase"
+                name="passphrase"
                 autocomplete="unique-passphrase"
                 placeholder="A word or passphrase that's difficult to guess"
                 class="w-full p-2 border rounded dark:bg-gray-700 dark:border-gray-600 pr-10"


### PR DESCRIPTION
### **User description**
Fixes issue #525

The passphrase privacy settings were being dismissed after a recent update. This pull request fixes the issue by adding the missing `name="passphrase"` attribute to the input field. Now, the passphrase will be properly set and the generated URL will only be accessible with the correct passphrase.


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed issue #525 where passphrase privacy settings were being dismissed.
- Added the missing `name="passphrase"` attribute to the input field in `SecretForm.vue`.
- Ensured the passphrase is properly set and the generated URL is only accessible with the correct passphrase.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SecretForm.vue</strong><dd><code>Fix passphrase input field by adding missing attribute</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/SecretForm.vue

- Added `name="passphrase"` attribute to the passphrase input field.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/527/files#diff-7151733f1c20c5466825cd712d35893c192b4a6891e84cf95075944d6a04f591">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

