### PR TITLE
[#525] Fix for passphrase (reprise)

### DIFF
--- a/src/components/SecretFormPrivacyOptions.vue
+++ b/src/components/SecretFormPrivacyOptions.vue
@@ -44,10 +44,13 @@ const togglePassphrase = () => {
     <div class="space-y-6 mt-4">
       <div class="flex flex-col md:flex-row md:space-x-4 space-y-6 md:space-y-0">
         <!-- Passphrase Field -->
-        <div v-if="props.withPassphrase" class="flex-1">
-          <label for="currentPassphrase" class="sr-only">Passphrase:</label>
+        <div v-if="props.withPassphrase"
+             class="flex-1">
+          <label for="currentPassphrase"
+                 class="sr-only">Passphrase:</label>
           <div class="relative">
-            <input :type="showPassphrase ? 'text' : 'password'" tabindex="3"
+            <input :type="showPassphrase ? 'text' : 'password'"
+                   tabindex="3"
                    id="currentPassphrase"
                    v-model="currentPassphrase"
                    name="passphrase"
@@ -58,20 +61,27 @@ const togglePassphrase = () => {
             <button type="button"
                     @click="togglePassphrase()"
                     class="absolute inset-y-0 right-0 flex items-center px-3 text-gray-500 dark:text-gray-300">
-              <Icon :icon="showPassphrase ? 'mdi:eye' : 'mdi:eye-off'" class="w-5 h-5" />
+              <Icon :icon="showPassphrase ? 'mdi:eye' : 'mdi:eye-off'"
+                    class="w-5 h-5" />
             </button>
           </div>
         </div>
 
         <!-- Lifetime Field -->
-        <div v-if="props.withExpiry" class="flex-1">
-          <label for="lifetime" class="sr-only">Lifetime:</label>
-          <select id="lifetime" tabindex="4"
+        <div v-if="props.withExpiry"
+             class="flex-1">
+          <label for="lifetime"
+                 class="sr-only">Lifetime:</label>
+          <select id="lifetime"
+                  tabindex="4"
                   name="ttl"
                   v-model="selectedLifetime"
                   class="w-full px-4 py-2 border border-gray-300 rounded-md focus:ring-brandcomp-500 focus:border-brandcomp-500 dark:bg-gray-700 dark:border-gray-600 dark:text-white">
-            <option value="" disabled>Select duration</option>
-            <option v-for="option in lifetimeOptions" :key="option.value" :value="option.value">
+            <option value=""
+                    disabled>Select duration</option>
+            <option v-for="option in lifetimeOptions"
+                    :key="option.value"
+                    :value="option.value">
               <span class="text-gray-500">Expires in</span> {{ option.label }}
             </option>
           </select>
@@ -79,11 +89,14 @@ const togglePassphrase = () => {
       </div>
 
       <!-- Recipient Field (if needed) -->
-      <div v-if="props.withRecipient" class="flex flex-col">
-        <label for="recipient" class="block font-brand text-sm font-medium text-gray-500 dark:text-gray-300 mb-2">
+      <div v-if="props.withRecipient"
+           class="flex flex-col">
+        <label for="recipient"
+               class="block font-brand text-sm font-medium text-gray-500 dark:text-gray-300 mb-2">
           Recipient Address
         </label>
-        <input type="email" tabindex="5"
+        <input type="email"
+               tabindex="5"
                id="recipient"
                name="recipient[]"
                placeholder="tom@myspace.com"

--- a/src/components/SecretFormPrivacyOptions.vue
+++ b/src/components/SecretFormPrivacyOptions.vue
@@ -53,6 +53,7 @@ const togglePassphrase = () => {
                    name="passphrase"
                    autocomplete="unique-passphrase"
                    placeholder="Enter a passphrase"
+                   aria-label="Passphrase"
                    class="w-full px-4 py-2 border border-gray-300 rounded-md focus:ring-brandcomp-500 focus:border-brandcomp-500 dark:bg-gray-700 dark:border-gray-600 dark:text-white">
             <button type="button"
                     @click="togglePassphrase()"

--- a/src/components/SecretFormPrivacyOptions.vue
+++ b/src/components/SecretFormPrivacyOptions.vue
@@ -50,6 +50,7 @@ const togglePassphrase = () => {
             <input :type="showPassphrase ? 'text' : 'password'" tabindex="3"
                    id="currentPassphrase"
                    v-model="currentPassphrase"
+                   name="passphrase"
                    autocomplete="unique-passphrase"
                    placeholder="Enter a passphrase"
                    class="w-full px-4 py-2 border border-gray-300 rounded-md focus:ring-brandcomp-500 focus:border-brandcomp-500 dark:bg-gray-700 dark:border-gray-600 dark:text-white">


### PR DESCRIPTION
### **User description**
The original e32669ae2cc623ab88b2a9dc0901249950fe84b7

#525 #532


___

### **PR Type**
Bug fix


___

### **Description**
- Added the `name` attribute to the passphrase input field in `SecretFormPrivacyOptions.vue` to ensure proper form handling and identification.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SecretFormPrivacyOptions.vue</strong><dd><code>Add `name` attribute to passphrase input field</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/SecretFormPrivacyOptions.vue

- Added `name` attribute to the passphrase input field.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/533/files#diff-b13a62345d0c72decb6eebfc48c1f8df48e49263eb38b8171170fe752187ca5d">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

