### PR TITLE
[#510] Fix for ViewAccount logic

### DIFF
--- a/lib/onetime/app/web/account.rb
+++ b/lib/onetime/app/web/account.rb
@@ -323,10 +323,13 @@ module Onetime
         logic = OT::Logic::Account::ViewAccount.new sess, cust, req.params, locale
         logic.raise_concerns
         logic.process
-        subscriptions = [logic.stripe_subscription].compact
+
         view = Onetime::App::Views::Account.new req, sess, cust, locale
-        view[:jsvars] << view.jsvar(:stripe_customer, logic.stripe_customer)
-        view[:jsvars] << view.jsvar(:stripe_subscriptions, subscriptions)
+        if view[:plans_enabled]
+          subscriptions = [logic.stripe_subscription].compact
+          view[:jsvars] << view.jsvar(:stripe_customer, logic.stripe_customer)
+          view[:jsvars] << view.jsvar(:stripe_subscriptions, subscriptions)
+        end
 
         res.body = view.render
       end

--- a/lib/onetime/config.rb
+++ b/lib/onetime/config.rb
@@ -8,7 +8,17 @@ module Onetime
     UTILITY_PATHS = %w[~/.onetime /etc/onetime ./etc].freeze
     attr_reader :env, :base, :bootstrap
 
-    def load(path = self.path)
+    # Load a YAML configuration file, allowing for ERB templating within the file.
+    # This reads the file at the given path, processes any embedded Ruby (ERB) code,
+    # and then parses the result as YAML.
+    #
+    # @param path [String] (optional the path to the YAML configuration file
+    # @return [Hash] the parsed YAML data
+    #
+    def load(path=nil)
+      path ||= self.path
+
+      raise ArgumentError, "Missing config file" if path.nil?
       raise ArgumentError, "Bad path (#{path})" unless File.readable?(path)
 
       YAML.load(ERB.new(File.read(path)).result)
@@ -20,7 +30,8 @@ module Onetime
               "Error loading config: #{path}"
             end
       OT.le msg
-      OT.le e.message, e.backtrace.join("\n")
+      OT.le e.message
+      OT.ld e.backtrace.join("\n")
       Kernel.exit(1)
     end
 


### PR DESCRIPTION
### **User description**
- Added check for `plans_enabled`
- Don't attempt to load Stripe custom info when plans are disabled.
(Otherwise we're in for a `Stripe::AuthenticationError` since there's
most likely no Stripe API key configured.)


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Added a check for `plans_enabled` before loading and processing Stripe customer and subscription data to prevent errors when plans are disabled.
- Enhanced configuration loading with better error handling and detailed documentation.
- Prevented the addition of Stripe-related JavaScript variables when plans are disabled.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>account.rb</strong><dd><code>Conditional loading of Stripe data based on plan status</code>&nbsp; &nbsp; </dd></summary>
<hr>

lib/onetime/app/web/account.rb

<li>Added a check for <code>plans_enabled</code> before loading Stripe customer and <br>subscription data.<br> <li> Prevented the addition of Stripe-related JavaScript variables when <br>plans are disabled.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/535/files#diff-5bbe0d38a554c9ad4195c7d8320f2e23a950ff4a1fce7a5c7ffb2943dcf53b9a">+6/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>account.rb</strong><dd><code>Conditional processing of Stripe data based on plan status</code></dd></summary>
<hr>

lib/onetime/logic/account.rb

<li>Added a check for <code>plans_enabled</code> before processing Stripe customer and <br>subscription data.<br> <li> Ensured customer fields are updated only when plans are enabled.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/535/files#diff-3e2fa30ebf99ea545f099c1425c716253c06fd1d4fc4df7ecdc8abc4d462b748">+30/-25</a>&nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config.rb</strong><dd><code>Enhanced configuration loading with better error handling</code></dd></summary>
<hr>

lib/onetime/config.rb

<li>Added detailed documentation for the <code>load</code> method.<br> <li> Improved error handling and logging for configuration loading.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/535/files#diff-ef8528e98ccc09f9e1104d5942cdc820a1a35defc502edebe5a19eecb07dc8e5">+13/-2</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

