### PR TITLE
Prep for Familia upgrade: various small bug fixes, enhancements, and configuration changes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,8 +35,8 @@ default_install_hook_types:
   - post-commit
   - post-checkout
   - post-merge
-# default_stages:
-#   - pre-commit
+default_stages:
+   - pre-commit
 #   - prepare-commit-msg
 
 fail_fast: true
@@ -70,6 +70,7 @@ repos:
     rev: v1.64.1  # Use the ref you want to point at
     hooks:
       - id: rubocop
+        stages: [pre-commit]
         name: rubocop
         description: Enforce the community Ruby Style Guide with RuboCop
         entry: "bundle exec rubocop --config .rubocop.yml --format json --fail-level warning"
@@ -93,6 +94,7 @@ repos:
     rev: v8.56.0  # Use the latest version
     hooks:
       - id: eslint
+        stages: [pre-commit]
         files: \.(js|ts|vue)$
         types: [file]
         additional_dependencies:

--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,11 @@ gem 'yajl-ruby'
 gem 'mustache'
 
 gem 'drydock'
-gem 'familia', '~> 0.10.2'
+if ENV['USE_LOCAL_WIP']
+  gem 'familia', path: '~/Projects/opensource/d/familia'
+else
+  gem 'familia', '~> 0.10.2'
+end
 gem 'gibbler'
 gem 'otto', '~> 1.1.0.pre.alpha1'
 gem 'redis', '~> 5.2.0'

--- a/lib/onetime.rb
+++ b/lib/onetime.rb
@@ -132,7 +132,7 @@ module Onetime
     end
 
     def print_banner
-      info "---  ONETIME #{OT.mode} v#{OT::VERSION}  #{'---' * 12}"
+      info "---  ONETIME #{OT.mode} v#{OT::VERSION.inspect}  #{'---' * 10}"
       info "Sysinfo: #{@sysinfo.platform} (#{RUBY_VERSION})"
       info "Config: #{OT::Config.path}"
       info "Redis:  #{Familia.uri.serverid}" # doesn't print the password

--- a/lib/onetime.rb
+++ b/lib/onetime.rb
@@ -20,10 +20,12 @@ require 'familia'
 require 'storable'
 require 'sysinfo'
 
+
 require_relative 'onetime/core_ext'
 
 
-Familia.apiversion = nil
+Familia.debug = false
+#Familia.apiversion = nil
 
 # Onetime is the core of the Onetime Secret application.
 # It contains the core classes and modules that make up

--- a/lib/onetime/app/web/views/base.rb
+++ b/lib/onetime/app/web/views/base.rb
@@ -87,7 +87,7 @@ module Onetime
         # on-the-fly and in the time zone of the user.
         self[:jsvars] << jsvar(:customer_since, epochdom(cust.created))
 
-        self[:jsvars] << jsvar(:ot_version, OT::VERSION)
+        self[:jsvars] << jsvar(:ot_version, OT::VERSION.to_s)
         self[:jsvars] << jsvar(:ruby_version, "#{OT.sysinfo.vm}-#{OT.sysinfo.ruby.join}")
 
         plans = Onetime::Plan.plans.transform_values do |plan|

--- a/lib/onetime/app/web/views/helpers.rb
+++ b/lib/onetime/app/web/views/helpers.rb
@@ -34,8 +34,10 @@ module Onetime
                     value.to_json
                   when 'NilClass'
                     'null'
-                  else
+                  when 'Boolean', 'FalseClass', 'TrueClass'
                     value
+                  else
+                    "console.error('#{name} is an unhandled type (#{value.class})')"
                   end
           { name: name, value: value }
         end

--- a/lib/onetime/config.rb
+++ b/lib/onetime/config.rb
@@ -118,12 +118,18 @@ module Onetime
       development[:frontend_host] ||= ''  # make sure this is set
 
       sentry = conf[:services][:sentry]
-      if ::Otto.env?(:dev) && sentry && sentry[:enabled]
-        OT.ld "Setting up Sentry #{sentry}..."
+
+      if sentry&.dig(:enabled)
+        OT.info "Setting up Sentry #{sentry}..."
+        dsn = sentry&.dig(:dsn)
+
+        unless dsn
+          OT.le "No DSN"
+        end
 
         require 'sentry-ruby'
+        require 'stackprof'
 
-        dsn = sentry[:dsn]
         OT.info "[sentry-init] Initializing with DSN: #{dsn[0..10]}..."
         Sentry.init do |config|
           config.dsn = sentry[:dsn]

--- a/lib/onetime/core_ext.rb
+++ b/lib/onetime/core_ext.rb
@@ -147,13 +147,6 @@ module Rack
   end
 end
 
-class Numeric
-  def square ; self * self ; end
-  def fineround(len=6.0)
-    v = (self * (10.0**len)).round / (10.0**len)
-    v.zero? ? 0 : v
-  end
-end
 
 class Array
   def sum ; self.inject(0){|a,x| next if x.nil? || a.nil?; x+a} ; end

--- a/lib/onetime/models/customer.rb
+++ b/lib/onetime/models/customer.rb
@@ -49,7 +49,7 @@ class Onetime::Customer < Familia::HashKey
     # the object has been initialized and `super` called in RedisObject.
     # Long story short: we set these two instance vars do that the
     # identifier method can produce a valid identifier string. But,
-    # we're relying on CustomDomain.create to duplicate the effort
+    # we're relying on Customer.create to duplicate the effort
     # and set the same values in the way that will persist them to
     # redis. Hopefully I do'nt find myself reading this comment in
     # 5 years and wondering why I can't just call `super` man.
@@ -208,7 +208,7 @@ class Onetime::Customer < Familia::HashKey
   def metadata_list
     if @metadata_list.nil?
       el = [prefix, identifier, :metadata]
-      el.unshift Familia.apiversion unless Familia.apiversion.nil?
+      #el.unshift Familia.apiversion unless Familia.apiversion.nil?
       @metadata_list = Familia::SortedSet.new Familia.join(el), :db => db
     end
     @metadata_list
@@ -225,7 +225,7 @@ class Onetime::Customer < Familia::HashKey
   def custom_domains_list
     if @custom_domains_list.nil?
       el = [prefix, identifier, :custom_domain]
-      el.unshift Familia.apiversion unless Familia.apiversion.nil?
+      #el.unshift Familia.apiversion unless Familia.apiversion.nil?
       @custom_domains_list = Familia::SortedSet.new Familia.join(el), :db => db
     end
     @custom_domains_list

--- a/lib/onetime/models/session.rb
+++ b/lib/onetime/models/session.rb
@@ -80,6 +80,10 @@ class Onetime::Session < Familia::HashKey
     @external_identifier
   end
 
+  def short_identifier
+    identifier[0, 12]
+  end
+
   def stale?
     self[:stale].to_s == 'true'
   end

--- a/lib/onetime/version.rb
+++ b/lib/onetime/version.rb
@@ -6,7 +6,7 @@ module Onetime
     end
 
     def self.to_s
-      to_a[0..-2].join('.')
+      to_a.join('.')
     end
 
     def self.inspect

--- a/try/20_metadata_try.rb
+++ b/try/20_metadata_try.rb
@@ -15,10 +15,12 @@
 # about secrets in the application.
 
 require_relative '../lib/onetime'
+#Familia.debug = true
 
 # Use the default config file for tests
 OT::Config.path = File.join(__dir__, '..', 'etc', 'config.test')
 OT.boot!
+
 
 ## Keys are consistent for Metadata
 @metadata = Onetime::Metadata.new :metadata, :entropy

--- a/try/61_logic_destroy_account_try.rb
+++ b/try/61_logic_destroy_account_try.rb
@@ -155,7 +155,7 @@ post_destroy_passphrase = if Onetime.debug
 else
   cust.passphrase
 end
-
+puts [cust.role, cust.verified, post_destroy_passphrase]
 [cust.role, cust.verified, post_destroy_passphrase]
 #=> ['user_deleted_self', 'false', '']
 


### PR DESCRIPTION
### **User description**
The changes include multiple updates across different files:

1. **Bug Fixes and Enhancements in `lib/onetime/models/customer.rb`:**
   - Corrected a typo in a comment from `CustomDomain.create` to `Customer.create`.
   - Commented out lines that prepend `Familia.apiversion` to element lists in `metadata_list` and `custom_domains_list` methods.

2. **Configuration Changes in `.pre-commit-config.yaml`:**
   - Enabled `default_stages` for pre-commit hooks.
   - Added `stages: [pre-commit]` for `rubocop` and `eslint` hooks to ensure they run during pre-commit.

3. **Enhancements in `lib/onetime.rb`:**
   - Set `Familia.debug` to `false`.
   - Commented out the line setting `Familia.apiversion` to `nil`.
   - Adjusted the `print_banner` method to use `OT::VERSION.inspect` for better readability.

4. **Enhancements in `lib/onetime/config.rb`:**
   - Improved Sentry setup logic to check for the presence of DSN and log an error if it's missing.
   - Added `stackprof` requirement for profiling.

5. **Enhancements in `lib/onetime/app/web/views/base.rb`:**
   - Converted `OT::VERSION` to a string in JavaScript variables.

6. **Enhancements in `lib/onetime/app/web/views/helpers.rb`:**
   - Added handling for Boolean types in the `jsvar` method.
   - Added error logging for unhandled types.

7. **Configuration Changes in `try/20_metadata_try.rb`:**
   - Added a commented-out line to enable `Familia.debug`.

8. **Code Cleanup in `lib/onetime/core_ext.rb`:**
   - Removed the `Numeric` class extensions (`square` and `fineround` methods).

9. **Configuration Changes in `Gemfile`:**
   - Added conditional logic to use a local path for the `familia` gem if `USE_LOCAL_WIP` environment variable is set.

10. **Debugging Enhancement in `try/61_logic_destroy_account_try.rb`:**
    - Added a `puts` statement to print customer role, verification status, and post-destroy passphrase.

11. **Enhancements in `lib/onetime/models/session.rb`:**
    - Added a `short_identifier` method to return the first 12 characters of the identifier.

12. **Bug Fix in `lib/onetime/version.rb`:**
    - Modified the `to_s` method to join all elements of the version array.


___

### **PR Type**
Enhancement, Bug fix, Configuration changes


___

### **Description**
- Disabled `Familia.debug` and improved banner readability in `lib/onetime.rb`.
- Enhanced JavaScript variable handling by converting `OT::VERSION` to a string in `lib/onetime/app/web/views/base.rb`.
- Improved `jsvar` method with Boolean handling and error logging in `lib/onetime/app/web/views/helpers.rb`.
- Enhanced Sentry setup logic and added profiling requirement in `lib/onetime/config.rb`.
- Removed unused `Numeric` class extensions in `lib/onetime/core_ext.rb`.
- Corrected a typo and commented out unused code in `lib/onetime/models/customer.rb`.
- Added a method for shorter session identifiers in `lib/onetime/models/session.rb`.
- Updated version string representation in `lib/onetime/version.rb`.
- Enabled pre-commit stages for hooks in `.pre-commit-config.yaml`.
- Added conditional logic for local gem path in `Gemfile`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>onetime.rb</strong><dd><code>Disable debugging and improve banner readability</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/onetime.rb

<li>Disabled <code>Familia.debug</code> by setting it to <code>false</code>.<br> <li> Updated <code>print_banner</code> method for better readability using <br><code>OT::VERSION.inspect</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/542/files#diff-fdca55a2ee0875c33af04f1ecd5140eee8528d6756a21ab4837f579da61f0d37">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>base.rb</strong><dd><code>Convert OT::VERSION to string in JavaScript</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/onetime/app/web/views/base.rb

- Converted `OT::VERSION` to a string in JavaScript variables.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/542/files#diff-a5d4e462fd47bbc94ac209ba3bdad2ef72c7bdb5948808941a06805e38e59836">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>helpers.rb</strong><dd><code>Enhance jsvar method with Boolean handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/onetime/app/web/views/helpers.rb

<li>Added handling for Boolean types in <code>jsvar</code> method.<br> <li> Added error logging for unhandled types.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/542/files#diff-cad8735c3aaa432544ecd6de035ffc048c11e9a843ec350a3efd2e0f01a1d187">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>config.rb</strong><dd><code>Improve Sentry setup and add profiling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/onetime/config.rb

<li>Improved Sentry setup logic to check for DSN presence.<br> <li> Added error logging if DSN is missing.<br> <li> Required <code>stackprof</code> for profiling.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/542/files#diff-ef8528e98ccc09f9e1104d5942cdc820a1a35defc502edebe5a19eecb07dc8e5">+9/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>session.rb</strong><dd><code>Add method for shorter session identifier</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/onetime/models/session.rb

<li>Added a method <code>short_identifier</code> to return a shorter session <br>identifier.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/542/files#diff-f167d5124650c0199a0cb49863434a87e3ab36b20d677d99c336d23c48de4536">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>version.rb</strong><dd><code>Update version string representation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/onetime/version.rb

- Updated `to_s` method to include all version components.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/542/files#diff-7ae2984adcd7d716babf74af1be3f42005f9fe8d672dae7a4761033aeb92ee21">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Code cleanup</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>core_ext.rb</strong><dd><code>Remove unused Numeric class extensions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/onetime/core_ext.rb

<li>Removed unused <code>Numeric</code> class extensions (<code>square</code> and <code>fineround</code> <br>methods).<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/542/files#diff-aa450c9fb76a4c838d31988984fec446f60e15e00df14206e353447161243be5">+0/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>customer.rb</strong><dd><code>Fix typo and comment out unused code</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/onetime/models/customer.rb

<li>Corrected a typo in a comment from <code>CustomDomain.create</code> to <br><code>Customer.create</code>.<br> <li> Commented out lines that prepend <code>Familia.apiversion</code> to element lists.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/542/files#diff-dd6fa4b42f949f8bd49271fd4f0359f44d6afc4e24ce5e16b9064c71bac40dd0">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>20_metadata_try.rb</strong><dd><code>Comment out debug line in metadata try</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

try/20_metadata_try.rb

- Commented out line to enable `Familia.debug`.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/542/files#diff-af34fec6bbbd1d98e7bb35c15db9daa2b79b7d923492df56ebf0a5a2004f5a77">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>.pre-commit-config.yaml</strong><dd><code>Enable pre-commit stages for hooks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.pre-commit-config.yaml

<li>Enabled <code>default_stages</code> for pre-commit hooks.<br> <li> Added <code>stages: [pre-commit]</code> for <code>rubocop</code> and <code>eslint</code> hooks.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/542/files#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>Gemfile</strong><dd><code>Add conditional logic for local gem path</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Gemfile

<li>Added conditional logic to use a local path for the <code>familia</code> gem if <br><code>USE_LOCAL_WIP</code> environment variable is set.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/542/files#diff-d09ea66f8227784ff4393d88a19836f321c915ae10031d16c93d67e6283ab55f">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Debugging enhancement</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>61_logic_destroy_account_try.rb</strong><dd><code>Add debugging output for account destruction</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

try/61_logic_destroy_account_try.rb

- Added a `puts` statement for debugging.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/542/files#diff-e4acbac3c81b20d6197e016f6112234c78c22b685ef32a057ee75a1b3d0f24d5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

