### PR TITLE
Fix custom domain relation handling

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,7 @@ gem 'public_suffix'
 gem 'thin'
 
 gem 'drydock'
-gem 'familia', '~> 1.0.0.pre.rc6'
+gem 'familia', '~> 1.0.0.pre.rc7'
 
 gem 'gibbler'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,7 +23,7 @@ GEM
     encryptor (1.1.3)
     erubi (1.13.0)
     eventmachine (1.2.7)
-    familia (1.0.0.pre.rc6)
+    familia (1.0.0.pre.rc7)
       redis (>= 4.8.1, < 6.0)
       uri-redis (~> 1.3)
     gibbler (1.0.0)
@@ -172,7 +172,7 @@ DEPENDENCIES
   dotenv
   drydock
   encryptor (= 1.1.3)
-  familia (~> 1.0.0.pre.rc6)
+  familia (~> 1.0.0.pre.rc7)
   gibbler
   httparty
   mail

--- a/lib/onetime/logic/domains.rb
+++ b/lib/onetime/logic/domains.rb
@@ -146,6 +146,8 @@ module Onetime::Logic
 
       def process
         OT.ld "[ListDomains] Processing #{@cust.custom_domains.length}"
+        OT.info "[ListDomains] Processing #{@cust.custom_domains.rediskey}"
+
         @custom_domains = @cust.custom_domains_list.map { |cd| cd.safe_dump }
       end
 

--- a/lib/onetime/models/customer.rb
+++ b/lib/onetime/models/customer.rb
@@ -14,7 +14,7 @@ class Onetime::Customer < Familia::Horreum
   class_sorted_set :values, key: 'onetime:customers'
   class_hashkey :domains, key: 'onetime:customers:domains'
 
-  sorted_set :custom_domains
+  sorted_set :custom_domains, suffix: 'custom_domain'
   sorted_set :metadata
 
   identifier :custid


### PR DESCRIPTION
### **User description**
This pull request fixes an issue with the handling of custom domain relations. The 'familia' gem dependency version has been updated to rc7. A suffix has been introduced for the 'custom_domains' sorted set in the customer model to ensure correct handling. This change matches the 'customer:CUSTID:custom_domain' keys in production. Additionally, logging has been added for 'custom_domains.rediskey'.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Introduced a suffix for the `custom_domains` sorted set in the customer model to ensure correct handling and match production keys.
- Added logging for `custom_domains.rediskey` to improve traceability of domain processing.
- Updated the 'familia' gem dependency version to rc7 to incorporate the latest fixes and improvements.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>domains.rb</strong><dd><code>Add logging for custom domain processing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/onetime/logic/domains.rb

- Added logging for `custom_domains.rediskey`.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/556/files#diff-4d3fe2c37de0a04b7a3b15b07c751afb9952b185405911db90990192ba63ffd4">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>customer.rb</strong><dd><code>Add suffix to custom_domains sorted set</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/onetime/models/customer.rb

- Introduced a suffix for `custom_domains` sorted set.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/556/files#diff-dd6fa4b42f949f8bd49271fd4f0359f44d6afc4e24ce5e16b9064c71bac40dd0">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Gemfile</strong><dd><code>Update 'familia' gem dependency version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Gemfile

- Updated 'familia' gem dependency version to rc7.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/556/files#diff-d09ea66f8227784ff4393d88a19836f321c915ae10031d16c93d67e6283ab55f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

