### PR TITLE
Add caching for Vite manifest

### DIFF
--- a/lib/onetime/app/web/views/helpers.rb
+++ b/lib/onetime/app/web/views/helpers.rb
@@ -64,48 +64,66 @@ module Onetime
           [prefix, '.gravatar.com/avatar/', suffix].join
         end
 
+        def cached_method methname
+          rediskey = "template:global:#{methname}"
+          cache_object = Familia::String.new rediskey, ttl: 1.hour, db: 0
+          OT.ld "[cached_method] #{methname} #{cache_object.exists? ? 'hit' : 'miss'} #{rediskey}"
+          cached = cache_object.get
+          return cached if cached
+
+          # Existing logic to generate assets...
+          content = yield
+
+          # Cache the generated content
+          cache_object.set(content)
+
+          content
+        end
+
         def vite_assets
-          manifest_path = File.join(PUBLIC_DIR, 'dist', '.vite', 'manifest.json')
-          unless File.exist?(manifest_path)
-            OT.le "Vite manifest not found at #{manifest_path}. Run `pnpm run build`"
-            return '<script>console.warn("Vite manifest not found. Run `pnpm run build`")</script>'
+          cached_method :vite_assets do
+            manifest_path = File.join(PUBLIC_DIR, 'dist', '.vite', 'manifest.json')
+            unless File.exist?(manifest_path)
+              OT.le "Vite manifest not found at #{manifest_path}. Run `pnpm run build`"
+              return '<script>console.warn("Vite manifest not found. Run `pnpm run build`")</script>'
+            end
+
+            manifest = JSON.parse(File.read(manifest_path))
+
+            assets = []
+
+            # Add CSS files directly referenced in the manifest
+            css_files = manifest.values.select { |v| v['file'].end_with?('.css') }
+            assets << css_files.map do |css|
+              %(<link rel="stylesheet" href="/dist/#{css['file']}">)
+            end
+
+            # Add CSS files referenced in the 'css' key of manifest entries
+            css_linked_files = manifest.values.flat_map { |v| v['css'] || [] }
+            assets << css_linked_files.map do |css_file|
+              %(<link rel="stylesheet" href="/dist/#{css_file}">)
+            end
+
+            # Add JS files
+            js_files = manifest.values.select { |v| v['file'].end_with?('.js') }
+            assets << js_files.map do |js|
+              %(<script type="module" src="/dist/#{js['file']}"></script>)
+            end
+
+            # Add preload directives for imported modules
+            import_files = manifest.values.flat_map { |v| v['imports'] || [] }.uniq
+            preload_links = import_files.map do |import_file|
+              %(<link rel="modulepreload" href="/dist/#{manifest[import_file]['file']}">)
+            end
+            assets << preload_links
+
+            if assets.empty?
+              OT.le "No assets found in Vite manifest at #{manifest_path}"
+              return '<script>console.warn("No assets found in Vite manifest")</script>'
+            end
+
+            assets.flatten.compact.join("\n")
           end
-
-          manifest = JSON.parse(File.read(manifest_path))
-
-          assets = []
-
-          # Add CSS files directly referenced in the manifest
-          css_files = manifest.values.select { |v| v['file'].end_with?('.css') }
-          assets << css_files.map do |css|
-            %(<link rel="stylesheet" href="/dist/#{css['file']}">)
-          end
-
-          # Add CSS files referenced in the 'css' key of manifest entries
-          css_linked_files = manifest.values.flat_map { |v| v['css'] || [] }
-          assets << css_linked_files.map do |css_file|
-            %(<link rel="stylesheet" href="/dist/#{css_file}">)
-          end
-
-          # Add JS files
-          js_files = manifest.values.select { |v| v['file'].end_with?('.js') }
-          assets << js_files.map do |js|
-            %(<script type="module" src="/dist/#{js['file']}"></script>)
-          end
-
-          # Add preload directives for imported modules
-          import_files = manifest.values.flat_map { |v| v['imports'] || [] }.uniq
-          preload_links = import_files.map do |import_file|
-            %(<link rel="modulepreload" href="/dist/#{manifest[import_file]['file']}">)
-          end
-          assets << preload_links
-
-          if assets.empty?
-            OT.le "No assets found in Vite manifest at #{manifest_path}"
-            return '<script>console.warn("No assets found in Vite manifest")</script>'
-          end
-
-          assets.flatten.compact.join("\n")
         end
 
         def secure_request?

--- a/try/11_cached_method_try.rb
+++ b/try/11_cached_method_try.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+# These tryouts test the functionality of the cached_method in the Onetime::App::Views::Helpers module.
+# The cached_method provides a caching mechanism for method results using Redis.
+#
+# We're testing various aspects of the cached_method, including:
+# 1. Caching of method results
+# 2. Retrieval of cached results
+# 3. Expiration of cached results
+#
+# These tests aim to ensure that the caching mechanism works correctly,
+# which is crucial for improving performance in the Onetime application.
+#
+# The tryouts simulate different scenarios of using the cached_method
+# without needing to run the full application, allowing for targeted
+# testing of this specific functionality.
+
+require_relative '../lib/onetime'
+
+# Familia.debug = true
+
+# Use the default config file for tests
+OT::Config.path = File.join(__dir__, '..', 'etc', 'config.test')
+OT.boot!
+
+@num = rand(1000)
+
+class TestHelper
+  include Onetime::App::Views::Helpers
+  attr_reader :num
+
+  def initialize(num)
+    @num = num
+  end
+
+  def test_method
+    "This is a test result: #{num}"
+  end
+end
+
+@helper = TestHelper.new @num
+
+## First call should cache the result
+@result1 = @helper.cached_method(:test_method) { @helper.test_method }
+p [:start1, @num]
+@result1.class
+#=> String
+
+## Content is as expected
+p [:start2, @num]
+p @helper.num
+@numb = @num
+@result1
+#=> "This is a test result: #{@numb}"
+
+## Second call should return the cached result
+result2 = @helper.cached_method(:test_method) { @helper.test_method }
+result2 == @result1
+#=> true
+
+## Call with different method name should cache separately
+result3 = @helper.cached_method(:another_method) { "Another result: #{rand(100)}" }
+result3 == @result1
+#=> false
+
+## Manually expire the cache
+Familia::String.new("template:global:test_method", ttl: 1.hour, db: 0).del
+#=> 1
+
+## Call after expiration should generate a new result
+content = @helper.cached_method(:test_method) { @helper.test_method }
+p content
+p @result1
+content == @result1
+#=> true
+
+Familia::String.new("template:global:test_method", ttl: 1.hour, db: 0).del


### PR DESCRIPTION
### **User description**
This pull request introduces a caching mechanism for the Vite manifest in order to improve performance by reducing redundant asset generation. The `vite_assets` method in the Ruby app helper now uses the `cached_method` to cache and retrieve method results. Detailed tests have been added to validate the caching mechanism. This solution ensures that the Vite manifest file is not deleted during the build process and remains accessible for the Ruby app helper to parse and generate the appropriate `<script>` and `<link>` tags for server-rendered templates.

For #561


___

### **PR Type**
enhancement, tests


___

### **Description**
- Introduced a caching mechanism using `cached_method` to cache and retrieve results in the `vite_assets` method, improving performance by reducing redundant asset generation.
- Modified the `vite_assets` method to utilize the new caching mechanism, ensuring that assets are efficiently managed and served.
- Added comprehensive tests to validate the caching mechanism, including scenarios for caching, retrieval, and expiration of cached results.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>helpers.rb</strong><dd><code>Implement caching mechanism for Vite manifest assets</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/onetime/app/web/views/helpers.rb

<li>Introduced <code>cached_method</code> to cache and retrieve method results.<br> <li> Modified <code>vite_assets</code> to use <code>cached_method</code> for caching.<br> <li> Improved performance by reducing redundant asset generation.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/562/files#diff-cad8735c3aaa432544ecd6de035ffc048c11e9a843ec350a3efd2e0f01a1d187">+55/-37</a>&nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>11_cached_method_try.rb</strong><dd><code>Add tests for caching mechanism in helpers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

try/11_cached_method_try.rb

<li>Added tests for <code>cached_method</code> functionality.<br> <li> Tested caching, retrieval, and expiration of cached results.<br> <li> Ensured caching mechanism works correctly for performance improvement.<br> <br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/562/files#diff-4a74cf3125f6c425a6d65f7866cb2520c96c9cbad144d7700227bcac0dc280bc">+77/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

