### PR TITLE
Increase TTL for EmailReceipt and StripeEvent

### DIFF
--- a/lib/onetime/models/email_receipt.rb
+++ b/lib/onetime/models/email_receipt.rb
@@ -6,7 +6,7 @@ class Onetime::EmailReceipt < Familia::Horreum
   feature :expiration
 
   db 8
-  ttl 30.days
+  ttl 14.days
 
   prefix :secret
   identifier :secretid
@@ -47,7 +47,7 @@ class Onetime::EmailReceipt < Familia::Horreum
     # fobj is a familia object
     def add fobj
       self.values.add OT.now.to_i, fobj.identifier
-      self.values.remrangebyscore 0, OT.now.to_i-2.days
+      self.values.remrangebyscore 0, OT.now.to_i-14.days # keep 14 days of email activity
     end
 
     def all

--- a/try/44_email_receipt_try.rb
+++ b/try/44_email_receipt_try.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+# These tryouts cover various aspects of the EmailReceipt model, including:
+#
+# 1. Checking the correct prefix, suffix, and identifier
+# 2. Verifying the rediskey format
+# 3. Creating a new EmailReceipt
+# 4. Checking the fields of a new EmailReceipt
+# 5. Verifying existence in Redis
+# 6. Testing class methods like `all` and `recent`
+# 7. Checking if the EmailReceipt is added to the values sorted set
+# 8. Testing the destruction process
+
+require_relative '../lib/onetime'
+
+# Load the app
+OT::Config.path = File.join(__dir__, '..', 'etc', 'config.test')
+OT.boot! :app
+
+# Setup some variables for these tryouts
+@now = Time.now.strftime("%Y%m%d%H%M%S")
+@email_address = "tryouts+#{@now}@onetimesecret.com"
+@cust = OT::Customer.new @email_address
+
+# TRYOUTS
+#
+
+# Setup for EmailReceipt tryouts
+@secretid = "secret#{@now}"
+@email_receipt = OT::EmailReceipt.new(secretid: @secretid, custid: @email_address)
+
+## EmailReceipt has the correct prefix (method missing in Familia v1.0.0-rc7)
+@email_receipt.prefix
+##=> :secret
+
+## EmailReceipt has the correct suffix
+@email_receipt.suffix
+#=> :email
+
+## EmailReceipt uses secretid as identifier
+@email_receipt.identifier
+#=> @secretid
+
+## EmailReceipt has the correct rediskey format
+@email_receipt.rediskey
+#=> "secret:#{@secretid}:email"
+
+## Can create a new EmailReceipt
+@new_receipt = OT::EmailReceipt.create(@email_address, @secretid, "Test message")
+@new_receipt.class
+#=> OT::EmailReceipt
+
+## New EmailReceipt has correct custid
+@new_receipt.custid
+#=> @email_address
+
+## New EmailReceipt has correct secretid
+@new_receipt.secretid
+#=> @secretid
+
+## New EmailReceipt has correct message_response
+@new_receipt.message_response
+#=> "Test message"
+
+## New EmailReceipt exists in Redis
+@new_receipt.exists?
+#=> true
+
+## Can retrieve all EmailReceipts
+OT::EmailReceipt.all.class
+#=> Array
+
+## Can retrieve recent EmailReceipts
+OT::EmailReceipt.recent.class
+#=> Array
+
+## EmailReceipt is added to values sorted set
+OT::EmailReceipt.values.member?(@new_receipt.identifier)
+#=> true
+
+## Can destroy EmailReceipt
+@new_receipt.destroy!
+@new_receipt.exists?
+#=> false
+
+## Destroyed EmailReceipt is removed from values sorted set
+OT::EmailReceipt.values.member?(@new_receipt.identifier)
+#=> false

--- a/try/75_stripe_event_try.rb
+++ b/try/75_stripe_event_try.rb
@@ -1,0 +1,108 @@
+# File: 26_stripe_event_try.rb
+
+# frozen_string_literal: true
+
+# These tryouts test the StripeEvent model functionality in the OneTime application.
+# They cover various aspects of Stripe event management, including:
+#
+# 1. StripeEvent creation and initialization
+# 2. StripeEvent attributes (custid, eventid, message_response, etc.)
+# 3. Redis key format and storage
+# 4. Class methods for retrieving and managing events
+# 5. Destruction process
+#
+# These tests aim to verify the correct behavior of the OT::StripeEvent class,
+# which is essential for managing Stripe-related events in the application.
+
+require_relative '../lib/onetime'
+require_relative '../lib/onetime/models/stripe_event'
+
+# Load the app
+OT::Config.path = File.join(__dir__, '..', 'etc', 'config.test')
+OT.boot! :app
+
+# Setup
+def setup
+  @now = Time.now.strftime("%Y%m%d%H%M%S")
+  @custid = "customer_#{@now}"
+  @eventid = "evt_#{@now}"
+
+  @message_response = "Test message response"
+  @stripe_event = OT::StripeEvent.new(eventid: @eventid, custid: @custid, message_response: @message_response)
+end
+
+# Teardown
+def teardown
+  @stripe_event.destroy! if @stripe_event && @stripe_event.exists?
+end
+
+# TRYOUTS
+
+setup
+
+## New instance of StripeEvent has the correct prefix
+@stripe_event.prefix
+##=> :stripe
+
+## New instance of StripeEvent has the correct suffix
+@stripe_event.suffix
+#=> :object
+
+## New instance of StripeEvent has the correct identifier
+@stripe_event.identifier
+#=> @eventid
+
+## New instance of StripeEvent has the correct rediskey format
+@stripe_event.rediskey
+#=> "stripeevent:#{@eventid}:object"
+
+## New instance of StripeEvent has the correct custid
+@stripe_event.custid
+#=> @custid
+
+## New instance of StripeEvent has the correct message_response
+@stripe_event.message_response
+#=> @message_response
+
+## Can create a new StripeEvent
+p [@eventid, @custid, @message_response]
+@new_event = OT::StripeEvent.new(eventid: @eventid, custid: @custid, message_response: @message_response)
+@new_event.class
+#=> OT::StripeEvent
+
+## New StripeEvent doesn't exist in Redis yet
+@new_event.exists?
+#=> false
+
+## New StripeEvent doesn't exist in Redis yet
+@new_event.save
+@new_event.exists?
+#=> true
+
+## Can retrieve all StripeEvents
+OT::StripeEvent.all.class
+#=> Array
+
+## Can retrieve recent StripeEvents
+OT::StripeEvent.recent.class
+#=> Array
+
+## StripeEvent is not added to values sorted set automatically (when created using new + save)
+OT::StripeEvent.values.member?(@new_event.identifier)
+#=> false
+
+## StripeEvent is added to values sorted set
+OT::StripeEvent.add @new_event
+OT::StripeEvent.values.member?(@new_event.identifier)
+#=> true
+
+## Can destroy StripeEvent
+@new_event.destroy!
+@new_event.exists?
+#=> false
+
+## Destroyed StripeEvent is removed from values sorted set
+OT::StripeEvent.values.member?(@new_event.identifier)
+#=> false
+
+teardown


### PR DESCRIPTION
### **User description**
This pull request increases the TTL (time to live) for the EmailReceipt and StripeEvent models in the OneTime application.

For the EmailReceipt model, the TTL is adjusted from 30 days to 14 days to ensure data consistency across the application. The `add` method in the EmailReceipt model is also updated to remove records older than 14 days. Comprehensive tests are added to cover various aspects of the new TTL behavior and email receipt model functionalities.

For the StripeEvent model, the TTL is set to 5 years. The identifier field is changed to eventid for better clarity. The removal of old events is modified to match the 5-year TTL. New fields are added for more detailed event tracking. An automated test file is included to verify the functionality of the StripeEvent model.

These changes improve the management of email receipts and Stripe events in the OneTime application, ensuring that the data is retained for the appropriate duration.

For #559


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Adjusted the TTL for the EmailReceipt model from 30 days to 14 days, ensuring data consistency and updated the `add` method to remove records older than 14 days.
- Set the TTL for the StripeEvent model to 5 years, changed the identifier to `eventid`, and added new fields for more detailed event tracking.
- Added comprehensive tests for the EmailReceipt model, covering creation, existence, and destruction functionalities.
- Added comprehensive tests for the StripeEvent model, covering creation, existence, and destruction functionalities.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>email_receipt.rb</strong><dd><code>Adjust TTL and cleanup logic for EmailReceipt model</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/onetime/models/email_receipt.rb

<li>Reduced TTL from 30 days to 14 days for email receipts.<br> <li> Updated <code>add</code> method to remove records older than 14 days.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/563/files#diff-59d92245e044462ee2878c13c0768e9926b8f328276fc11b3b0907f4cb507f2e">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>stripe_event.rb</strong><dd><code>Update TTL and fields for StripeEvent model</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/onetime/models/stripe_event.rb

<li>Set TTL to 5 years for Stripe events.<br> <li> Changed identifier from <code>secretid</code> to <code>eventid</code>.<br> <li> Added new fields for detailed event tracking.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/563/files#diff-ff307070f312fbb351000c2a1b59b4b676f1250afc745e59ee8d28994559a946">+13/-12</a>&nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>44_email_receipt_try.rb</strong><dd><code>Add comprehensive tests for EmailReceipt model</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

try/44_email_receipt_try.rb

<li>Added tests for EmailReceipt model functionalities.<br> <li> Verified creation, existence, and destruction of EmailReceipts.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/563/files#diff-a9b3d2364a84b84a3acd0b772f497647ced1ccc1fcf93f384e630744c28a4392">+88/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>75_stripe_event_try.rb</strong><dd><code>Add comprehensive tests for StripeEvent model</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

try/75_stripe_event_try.rb

<li>Added tests for StripeEvent model functionalities.<br> <li> Verified creation, existence, and destruction of StripeEvents.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/563/files#diff-af71c1fbb570b7d220afc482b8fab261907ec394379ab39bf1d029c8e7eef4f1">+108/-0</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

