### PR TITLE
Fix customer class relation key names

### DIFF
--- a/lib/onetime/models/customer.rb
+++ b/lib/onetime/models/customer.rb
@@ -11,8 +11,8 @@ class Onetime::Customer < Familia::Horreum
 
   @global = nil
 
-  class_sorted_set :values, key: 'onetime:customers'
-  class_hashkey :domains, key: 'onetime:customers:domains'
+  class_sorted_set :values, key: 'onetime:customer'
+  class_hashkey :domains, key: 'onetime:customers:domain'
 
   sorted_set :custom_domains, suffix: 'custom_domain'
   sorted_set :metadata

--- a/try/25_customer_try.rb
+++ b/try/25_customer_try.rb
@@ -139,3 +139,19 @@ ttl = @cust.ttl
 @cust.destroy_requested!
 @cust.verified?
 #=> false
+
+## Customer.values has the correct rediskey
+OT::Customer.values.rediskey
+#=> "onetime:customer"
+
+## Customer.domains has the correct rediskey
+OT::Customer.domains.rediskey
+#=> "onetime:customers:domain"
+
+## Customer.values is a Familia::SortedSet
+OT::Customer.values.class
+#=> Familia::SortedSet
+
+## Customer.domains is a Familia::HashKey
+OT::Customer.domains.class
+#=> Familia::HashKey


### PR DESCRIPTION
### **User description**
The Redis key names for the `values` and `domains` attributes in the customer class have been corrected. The `values` key has been changed to "onetime:customer" and the `domains` key has been changed to "onetime:customers:domain". Tests have been added to verify the correct Redis keys and classes.

For #560


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Corrected the Redis key names for the `values` and `domains` attributes in the `Onetime::Customer` class.
- Changed `values` key to "onetime:customer" and `domains` key to "onetime:customers:domain".
- Added tests to verify the correct Redis keys for `values` and `domains`.
- Confirmed `values` is a `Familia::SortedSet` and `domains` is a `Familia::HashKey`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>customer.rb</strong><dd><code>Fix Redis key names for customer attributes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/onetime/models/customer.rb

<li>Corrected Redis key for <code>values</code> attribute.<br> <li> Corrected Redis key for <code>domains</code> attribute.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/564/files#diff-dd6fa4b42f949f8bd49271fd4f0359f44d6afc4e24ce5e16b9064c71bac40dd0">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>25_customer_try.rb</strong><dd><code>Add tests for customer Redis keys and classes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

try/25_customer_try.rb

<li>Added tests for correct Redis keys for <code>values</code> and <code>domains</code>.<br> <li> Verified <code>values</code> is a <code>Familia::SortedSet</code>.<br> <li> Verified <code>domains</code> is a <code>Familia::HashKey</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/564/files#diff-16609ea0076a3e7dbd94e39d6f4a338dbeec4a0999d09bd178a9185b08579c94">+16/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

