### PR TITLE
Update otto gem to version 1.1.0.pre.alpha3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ gem 'truemail'
 
 gem 'addressable'
 
-gem 'rack'
+gem 'rack', '>= 2.2', '< 3.0'
 
 gem 'dotenv'
 gem 'multi_json'
@@ -35,7 +35,8 @@ gem 'familia', '~> 1.0.0.pre.rc7'
 
 gem 'gibbler'
 
-gem 'otto', '~> 1.1.0.pre.alpha1'
+gem 'otto', '~> 1.1.0.pre.alpha3'
+
 gem 'redis', '~> 5.2.0'
 gem 'storable'
 gem 'sysinfo'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,9 +56,9 @@ GEM
     net-smtp (0.5.0)
       net-protocol
     netrc (0.11.0)
-    otto (1.1.0.pre.alpha1)
-      addressable (>= 2.2.6)
-      rack (>= 1.2.1)
+    otto (1.1.0.pre.alpha3)
+      addressable (~> 2.2, < 3)
+      rack (~> 2.2, < 3.0)
     parallel (1.25.1)
     parser (3.3.3.0)
       ast (~> 2.4.1)
@@ -178,11 +178,11 @@ DEPENDENCIES
   mail
   multi_json
   mustache
-  otto (~> 1.1.0.pre.alpha1)
+  otto (~> 1.1.0.pre.alpha3)
   pry
   pry-byebug
   public_suffix
-  rack
+  rack (>= 2.2, < 3.0)
   redis (~> 5.2.0)
   rubocop
   rubocop-performance

--- a/lib/onetime/app/helpers.rb
+++ b/lib/onetime/app/helpers.rb
@@ -30,7 +30,7 @@ class Onetime::App
       # Determine the locale for the current request
       # We check get here to stop an infinite redirect loop.
       # Pages redirecting from a POST can get by with the same page once.
-      redirect = '/error' if req.get? && redirect.to_s == req.request_path
+      redirect = '/500' if req.get? && redirect.to_s == req.request_path
 
       unless res.header['Content-Language']
         res.header['Content-Language'] = req.env['ots.locale'] || req.env['rack.locale'] || OT.conf[:locales].first
@@ -45,8 +45,6 @@ class Onetime::App
         custref = cust.obscure_email
         OT.info "[carefully] #{sess.short_identifier} #{custref} at #{reqstr}"
       end
-
-      #OT.le "[carefully] steps #{sess.short_identifier} #{cust.obscure_email} #{req.current_absolute_uri} #{return_value}"
 
       return_value
 

--- a/lib/onetime/app/web.rb
+++ b/lib/onetime/app/web.rb
@@ -24,6 +24,10 @@ module Onetime
       end
     end
 
+    def basic_error
+      server_error 500, "Oops, something went wrong."
+    end
+
     def robots_txt
       publically do
         view = Onetime::App::Views::Meta::Robot.new req, sess, cust, locale

--- a/lib/onetime/app/web/base.rb
+++ b/lib/onetime/app/web/base.rb
@@ -118,10 +118,22 @@ module Onetime
         end
       end
 
-      def server_error
-        publically do
-          error_response "You found a bug. Let us know how it happened!"
-        end
+      def server_error status=500, message=nil
+        res.status = status
+        res['Content-Type'] = 'text/html'
+        res.body = <<-HTML
+        <!DOCTYPE html>
+        <html lang="en">
+        <head>
+            <meta charset="UTF-8">
+            <title>500 Internal Server Error</title>
+        </head>
+        <body>
+            <h1>500 - Internal Server Error</h1>
+            <p>Something went wrong on our end. Please try again later.</p>
+        </body>
+        </html>
+        HTML
       end
 
       def disabled_response path

--- a/lib/onetime/app/web/routes
+++ b/lib/onetime/app/web/routes
@@ -1,5 +1,7 @@
 
 GET   /                                          Onetime::App#index
+GET   /500                                       Onetime::App#basic_error
+
 POST  /share                                     Onetime::App#create_secret
 
 GET   /incoming                                  Onetime::App#incoming

--- a/lib/onetime/models/customer.rb
+++ b/lib/onetime/models/customer.rb
@@ -244,7 +244,8 @@ class Onetime::Customer < Familia::Horreum
   def metadata_list
     metadata.revmembers.collect do |key|
       obj = OT::Metadata.load(key)
-      obj
+    rescue OT::RecordNotFound => e
+      OT.le "[metadata_list] Error: #{e.message} (#{key} / #{self.custid})"
     end.compact
   end
 
@@ -253,7 +254,11 @@ class Onetime::Customer < Familia::Horreum
   end
 
   def custom_domains_list
-    custom_domains.revmembers.collect { |domain| OT::CustomDomain.load domain, self.custid }.compact
+    custom_domains.revmembers.collect do |domain|
+      OT::CustomDomain.load domain, self.custid
+    rescue OT::RecordNotFound => e
+      OT.le "[custom_domains_list] Error: #{e.message} (#{domain} / #{self.custid})"
+    end.compact
   end
 
   def add_custom_domain obj


### PR DESCRIPTION
### **User description**
This pull request updates the otto gem to version 1.1.0.pre.alpha3 to resolve a cascading domain not found error. The error was causing disruptions and issues related to domain resolution. The update includes several commits that handle error handling, introduce a basic error route, and update dependencies. The changes ensure that the cascading domain not found error no longer occurs and that domain resolution works as expected. The application has been thoroughly tested after the update. If the issue persists, further investigation or reaching out to the gem maintainers may be necessary.

Resolves #565


___

### **PR Type**
enhancement, bug fix


___

### **Description**
- Updated the `otto` gem to version `1.1.0.pre.alpha3` to resolve cascading domain not found errors.
- Changed redirect logic in `helpers.rb` to prevent infinite loops by redirecting GET requests to '/500'.
- Enhanced error handling by adding a new `basic_error` method and updating the `server_error` method to return a complete HTML response.
- Added error handling for `RecordNotFound` exceptions in `metadata_list` and `custom_domains_list` to prevent crashes and improve logging.
- Updated `Gemfile` to specify version constraints for `rack` and update the `otto` gem.
- Introduced a new route for '/500' to handle server errors more effectively.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>helpers.rb</strong><dd><code>Update redirect logic to prevent infinite loops</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/onetime/app/helpers.rb

<li>Changed redirect path from '/error' to '/500' for GET requests to <br>prevent infinite loops.<br> <li> Removed outdated commented code.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/566/files#diff-e94d14dd7ae26375167811c7ec80077c552df686cbd9b62877e36f299e28725a">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>customer.rb</strong><dd><code>Add error handling for metadata and domain lists</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/onetime/models/customer.rb

<li>Added error handling for <code>RecordNotFound</code> exceptions in <code>metadata_list</code> <br>and <code>custom_domains_list</code>.<br> <li> Improved logging for errors in metadata and domain lists.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/566/files#diff-dd6fa4b42f949f8bd49271fd4f0359f44d6afc4e24ce5e16b9064c71bac40dd0">+7/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>web.rb</strong><dd><code>Add basic error handling method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/onetime/app/web.rb

- Added a new method `basic_error` to handle basic error responses.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/566/files#diff-ad61619aa6345b131c7c89cc1eb5e0f8e26d22a5da1942ba59aa67df05daf2f0">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>base.rb</strong><dd><code>Enhance server error response with HTML content</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/onetime/app/web/base.rb

<li>Enhanced <code>server_error</code> method to return a complete HTML response.<br> <li> Updated error handling to provide a more informative error page.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/566/files#diff-d7b676502f4b13ea234bd52fafffd227dd09e034ca33ddd243de1e2ff6f8c783">+16/-4</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>routes</strong><dd><code>Add new route for server error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/onetime/app/web/routes

- Added a new route for '/500' to handle server errors.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/566/files#diff-0e07fc77a9a92355efaf5c55d933fc52ef5a0fe8527529790fe76190fd6339ae">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Gemfile</strong><dd><code>Update gem dependencies for otto and rack</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Gemfile

<li>Updated <code>otto</code> gem to version <code>1.1.0.pre.alpha3</code>.<br> <li> Specified version constraints for <code>rack</code> gem.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/566/files#diff-d09ea66f8227784ff4393d88a19836f321c915ae10031d16c93d67e6283ab55f">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

