### PR TITLE
Clarify prefix for custom domain class

### DIFF
--- a/lib/onetime/models/custom_domain.rb
+++ b/lib/onetime/models/custom_domain.rb
@@ -30,7 +30,7 @@ class Onetime::CustomDomain < Familia::Horreum
   include Gibbler::Complex
 
   db 6
-  prefix :custom_domain
+  prefix :customdomain
 
   feature :safe_dump
 

--- a/try/29_customer_domains_try.rb
+++ b/try/29_customer_domains_try.rb
@@ -65,3 +65,27 @@ custom_domain = @cust.custom_domains_list.first
 ## A customer's custom_domain list is empty again after removing a domain
 @cust.custom_domains.empty?
 #=> true
+
+## CustomDomain uses the correct Redis database
+OT::CustomDomain.db
+#=> 6
+
+## CustomDomain has the correct prefix
+OT::CustomDomain.prefix
+#=> :customdomain
+
+## CustomDomain.values is a Familia::SortedSet
+OT::CustomDomain.values.class
+#=> Familia::SortedSet
+
+## CustomDomain.owners is a Familia::HashKey
+OT::CustomDomain.owners.class
+#=> Familia::HashKey
+
+## CustomDomain.values Redis key is correctly prefixed
+OT::CustomDomain.values.rediskey
+#=> "customdomain:values"
+
+## CustomDomain.owners Redis key is correctly prefixed
+OT::CustomDomain.owners.rediskey
+#=> "customdomain:owners"


### PR DESCRIPTION
The prefix for the custom domain class has been changed from `custom_domain` to `customdomain` to match live production data. This pull request includes updates to tests to confirm the correct database index is used, the proper prefix is applied to Redis keys, and the correct data types for `values` and `owners` are used.