### PR TITLE
Fix default value for recipients in metadata view

### DIFF
--- a/lib/onetime/app/web/views.rb
+++ b/lib/onetime/app/web/views.rb
@@ -136,7 +136,15 @@ module Onetime
           self[:metadata_shortkey] = metadata.shortkey
           self[:secret_key] = metadata.secret_key
           self[:secret_shortkey] = metadata.secret_shortkey
-          self[:recipients] = metadata.recipients # default is an empty str
+
+          # Default the recipients to an empty string. When a Familia::Horreum
+          # object is loaded, the fields that have no values (or that don't
+          # exist in the redis hash yet) will have a value of "" (empty string).
+          # But for a newly instantiated object, the fields will have a value
+          # of nil. Later on, we rely on being able to check for emptiness
+          # like: `self[:recipients].empty?`.
+          self[:recipients] = metadata.recipients.to_s
+
           self[:display_feedback] = false
           self[:no_cache] = true
           # Metadata now lives twice as long as the original secret.


### PR DESCRIPTION
### **User description**
Set the default value for the recipients field in the metadata view to an empty string. This ensures consistency when loading a newly instantiated object and allows for checking if the field is empty later on.

Fixes #568


___

### **PR Type**
bug_fix


___

### **Description**
- Set the default value for the `recipients` field in the metadata view to an empty string to ensure consistency.
- Convert `metadata.recipients` to a string to handle cases where the field is `nil`.
- Added comments to clarify the logic behind setting the default value.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>views.rb</strong><dd><code>Fix default value handling for recipients in metadata view</code></dd></summary>
<hr>

lib/onetime/app/web/views.rb

<li>Set default value for <code>recipients</code> to an empty string.<br> <li> Convert <code>metadata.recipients</code> to string to ensure consistency.<br> <li> Added comments explaining the default value logic.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/571/files#diff-c495d1517c1d5e94130b53e37f7941f93f293744d246ece12dc2066f8bb153f0">+9/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

