### PR TITLE
Fix Jumpy Dark Mode Issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@typescript-eslint/eslint-plugin": "^7.16.1",
     "@typescript-eslint/parser": "^7.16.1",
     "@vitejs/plugin-vue": "^5.0.5",
+    "@vue/runtime-core": "^3.4.38",
     "autoprefixer": "^10.4.19",
     "eslint": "^8.57.0",
     "eslint-plugin-vue": "^9.27.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,6 +54,9 @@ importers:
       '@vitejs/plugin-vue':
         specifier: ^5.0.5
         version: 5.0.5(vite@5.3.4(@types/node@20.14.11)(terser@5.31.3))(vue@3.4.32(typescript@5.5.3))
+      '@vue/runtime-core':
+        specifier: ^3.4.38
+        version: 3.4.38
       autoprefixer:
         specifier: ^10.4.19
         version: 10.4.19(postcss@8.4.39)
@@ -594,8 +597,14 @@ packages:
   '@vue/reactivity@3.4.32':
     resolution: {integrity: sha512-1P7QvghAzhSIWmiNmh4MNkLVjr2QTNDcFv2sKmytEWhR6t7BZzNicgm5ENER4uU++wbWxgRh/pSEYgdI3MDcvg==}
 
+  '@vue/reactivity@3.4.38':
+    resolution: {integrity: sha512-4vl4wMMVniLsSYYeldAKzbk72+D3hUnkw9z8lDeJacTxAkXeDAP1uE9xr2+aKIN0ipOL8EG2GPouVTH6yF7Gnw==}
+
   '@vue/runtime-core@3.4.32':
     resolution: {integrity: sha512-FxT2dTHUs1Hki8Ui/B1Hu339mx4H5kRJooqrNM32tGUHBPStJxwMzLIRbeGO/B1NMplU4Pg9fwOqrJtrOzkdfA==}
+
+  '@vue/runtime-core@3.4.38':
+    resolution: {integrity: sha512-21z3wA99EABtuf+O3IhdxP0iHgkBs1vuoCAsCKLVJPEjpVqvblwBnTj42vzHRlWDCyxu9ptDm7sI2ZMcWrQqlA==}
 
   '@vue/runtime-dom@3.4.32':
     resolution: {integrity: sha512-Xz9G+ZViRyPFQtRBCPFkhMzKn454ihCPMKUiacNaUhuTIXvyfkAq8l89IZ/kegFVyw/7KkJGRGqYdEZrf27Xsg==}
@@ -610,6 +619,9 @@ packages:
 
   '@vue/shared@3.4.32':
     resolution: {integrity: sha512-ep4mF1IVnX/pYaNwxwOpJHyBtOMKWoKZMbnUyd+z0udqIxLUh7YCCd/JfDna8aUrmnG9SFORyIq2HzEATRrQsg==}
+
+  '@vue/shared@3.4.38':
+    resolution: {integrity: sha512-q0xCiLkuWWQLzVrecPb0RMsNWyxICOjPrcrwxTUEHb1fsnvni4dcuyG7RT/Ie7VPTvnjzIaWzRMUBsrqNj/hhw==}
 
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -2191,10 +2203,19 @@ snapshots:
     dependencies:
       '@vue/shared': 3.4.32
 
+  '@vue/reactivity@3.4.38':
+    dependencies:
+      '@vue/shared': 3.4.38
+
   '@vue/runtime-core@3.4.32':
     dependencies:
       '@vue/reactivity': 3.4.32
       '@vue/shared': 3.4.32
+
+  '@vue/runtime-core@3.4.38':
+    dependencies:
+      '@vue/reactivity': 3.4.38
+      '@vue/shared': 3.4.38
 
   '@vue/runtime-dom@3.4.32':
     dependencies:
@@ -2212,6 +2233,8 @@ snapshots:
   '@vue/shared@3.4.31': {}
 
   '@vue/shared@3.4.32': {}
+
+  '@vue/shared@3.4.38': {}
 
   acorn-jsx@5.3.2(acorn@8.12.1):
     dependencies:

--- a/src/components/ThemeToggle.vue
+++ b/src/components/ThemeToggle.vue
@@ -1,46 +1,47 @@
+
+<script setup lang="ts">
+import { ref, onMounted, watch } from 'vue'
+
+const isDarkMode = ref(false)
+
+const toggleDarkMode = () => {
+  isDarkMode.value = !isDarkMode.value
+  localStorage.setItem('darkMode', isDarkMode.value.toString())
+  updateDarkMode()
+}
+
+const updateDarkMode = () => {
+  if (isDarkMode.value) {
+    document.documentElement.classList.add('dark')
+  } else {
+    document.documentElement.classList.remove('dark')
+  }
+}
+
+const detectSystemPreference = () => {
+  return window.matchMedia('(prefers-color-scheme: dark)').matches
+}
+
+onMounted(() => {
+  const storedPreference = localStorage.getItem('darkMode')
+  if (storedPreference !== null) {
+    isDarkMode.value = storedPreference === 'true'
+  } else {
+    isDarkMode.value = detectSystemPreference()
+  }
+  updateDarkMode()
+})
+
+watch(isDarkMode, updateDarkMode)
+</script>
+
 <template>
-  <button @click="toggleDarkMode" class="p-2 rounded-md hover:bg-gray-200 dark:hover:bg-gray-700">
-    <svg v-if="isDarkMode" class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+  <button @click="toggleDarkMode" aria-label="Toggle dark mode" :aria-pressed="isDarkMode" class="p-2 rounded-md hover:bg-gray-200 dark:hover:bg-gray-700">
+    <svg v-if="isDarkMode" aria-hidden="true" class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"></path>
     </svg>
-    <svg v-else class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+    <svg v-else aria-hidden="true" class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"></path>
     </svg>
   </button>
 </template>
-
-<script>
-import { ref, onMounted, watch } from 'vue'
-
-export default {
-  setup() {
-    const isDarkMode = ref(false)
-
-    const toggleDarkMode = () => {
-      isDarkMode.value = !isDarkMode.value
-      localStorage.setItem('darkMode', isDarkMode.value)
-      updateDarkMode()
-    }
-
-    const updateDarkMode = () => {
-      if (isDarkMode.value) {
-        document.documentElement.classList.add('dark')
-      } else {
-        document.documentElement.classList.remove('dark')
-      }
-    }
-
-    onMounted(() => {
-      isDarkMode.value = localStorage.getItem('darkMode') === 'true'
-      updateDarkMode()
-    })
-
-    watch(isDarkMode, updateDarkMode)
-
-    return {
-      isDarkMode,
-      toggleDarkMode
-    }
-  }
-}
-</script>

--- a/src/main.ts
+++ b/src/main.ts
@@ -49,8 +49,8 @@ const DefaultApp = {
 }
 
 const app = createApp(DefaultApp)
-app.use(router)
-app.mount('#app')
+app.use(router);
+app.mount('#app');
 
 
 /**

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,9 +1,9 @@
-import GlobalBroadcast from '@/components/GlobalBroadcast.vue'
-import ThemeToggle from '@/components/ThemeToggle.vue'
-import router from '@/router'
-import { createApp, ref } from 'vue'
+import GlobalBroadcast from '@/components/GlobalBroadcast.vue';
+import ThemeToggle from '@/components/ThemeToggle.vue';
+import router from '@/router';
+import { createApp, ref } from 'vue';
 
-import './style.css'
+import './style.css';
 
 
 /**
@@ -48,7 +48,7 @@ const DefaultApp = {
   template: '<div id="app"><router-view></router-view></div>'
 }
 
-const app = createApp(DefaultApp)
+const app = createApp(DefaultApp);
 app.use(router);
 app.mount('#app');
 
@@ -66,7 +66,7 @@ const broadcastApp = createApp(GlobalBroadcast, {
   content: 'This is a global broadcast',
   show: showBanner.value,
 })
-broadcastApp.mount('#broadcast')
+broadcastApp.mount('#broadcast');
 
 const themeToggleElement = document.querySelector('#theme-toggle');
 if (themeToggleElement) {

--- a/templates/web/partial/footer.html
+++ b/templates/web/partial/footer.html
@@ -72,7 +72,7 @@
     </div>
   {{/display_links}}
 
-  {{>partial/footer_magic}}
+  {{>partial/footer_outro}}
 
   </footer>
 </div>

--- a/templates/web/partial/footer_magic.html
+++ b/templates/web/partial/footer_magic.html
@@ -1,9 +1,0 @@
-    <div class="text-gray-400 dark:text-gray-500 mt-4 pt-4">
-      v{{ot_version}}
-    </div>
-
-    {{#authenticated}}
-    <div class="mt-2 text-slate-400">
-      <span id="theme-toggle"></span>
-    </div>
-    {{/authenticated}}

--- a/templates/web/partial/footer_outro.html
+++ b/templates/web/partial/footer_outro.html
@@ -1,0 +1,10 @@
+    <div class="text-gray-400 dark:text-gray-500 mt-4 pt-4">
+      v{{ot_version}}
+    </div>
+
+    <!-- Dark mode toggle in the bottom left corner -->
+    <div class="fixed bottom-4 left-4 z-50">
+      <div class="mt-2 text-slate-300">
+        <span id="theme-toggle"></span>
+      </div>
+    </div>

--- a/templates/web/partial/plans_homepage_cta.html
+++ b/templates/web/partial/plans_homepage_cta.html
@@ -1,11 +1,5 @@
 <section class="max-w-4xl mx-auto my-12 bg-white dark:bg-gray-800 rounded-lg shadow-md overflow-hidden transition-colors duration-300">
   <div class="p-8 flex flex-col md:flex-row items-start justify-between relative">
-    <!-- Dark mode toggle -->
-    <button id="darkModeToggle" class="absolute top-4 right-4 p-2 rounded-full bg-gray-200 dark:bg-gray-700 text-gray-800 dark:text-gray-200 focus:outline-none">
-      <svg class="w-5 h-5" fill="none" stroke="currentColor" height="20" width="20" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"></path>
-      </svg>
-    </button>
 
     <div class="w-full md:w-2/3 md:pr-8">
       <h2 class="text-3xl font-bold text-gray-800 dark:text-white mb-4 flex items-center">
@@ -46,20 +40,3 @@
     </div>
   </div>
 </section>
-
-<script>
-  // Dark mode toggle functionality
-  const darkModeToggle = document.getElementById('darkModeToggle');
-  const htmlElement = document.documentElement;
-
-  darkModeToggle.addEventListener('click', () => {
-    htmlElement.classList.toggle('dark');
-    localStorage.setItem('darkMode', htmlElement.classList.contains('dark'));
-  });
-
-  // Check for user's preference
-  if (localStorage.getItem('darkMode') === 'true' ||
-      (window.matchMedia('(prefers-color-scheme: dark)').matches && !localStorage.getItem('darkMode'))) {
-    htmlElement.classList.add('dark');
-  }
-</script>

--- a/templates/web/partial/quiet_footer.html
+++ b/templates/web/partial/quiet_footer.html
@@ -1,7 +1,7 @@
 
 <div class="container mx-auto p-4 max-w-2xl">
   <footer class="text-sm text-center space-y-2">
-    {{>partial/footer_magic}}
+    {{>partial/footer_outro}}
   </footer>
 </div>
 

--- a/templates/web/signup.html
+++ b/templates/web/signup.html
@@ -14,9 +14,6 @@
       {{#default_plan.api}}
         <li>access to the <a href="/docs/api" class="font-bold text-brand-600 dark:text-brand-400 hover:underline">API</a>.</li>
       {{/default_plan.api}}
-      {{#default_plan.dark_mode}}
-        <li>also <span class="italic">dark mode</span>.</li>
-      {{/default_plan.dark_mode}}
     </ul>
   </section>
 


### PR DESCRIPTION
### **User description**
Addresses #575

This pull request fixes the jumpy behavior of the dark mode setting. It includes the following changes:

- Introduced a fixed position for the dark mode toggle in the footer
- Removed redundant dark mode toggle script from the plans_homepage_cta

These changes optimize the dark mode toggle implementation and ensure a consistent dark mode setting across all pages, providing a seamless user experience.


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Introduced a fixed position for the dark mode toggle in the footer, ensuring consistent placement across pages.
- Removed redundant dark mode toggle script from the homepage CTA to streamline the implementation.
- Renamed `footer_magic` to `footer_outro` for clarity and updated references.
- Simplified the dark mode feature explanation in the signup page.
- Added `@vue/runtime-core` to the project dependencies for improved Vue integration.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>footer.html</strong><dd><code>Rename footer partial for clarity</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

templates/web/partial/footer.html

- Renamed `footer_magic` to `footer_outro`.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/582/files#diff-a7a0327390e7c1c0d4080cadd05246d9b4e5c08624d7b4cd1251d1f8fdf82268">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>footer_magic.html</strong><dd><code>Remove deprecated footer partial</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

templates/web/partial/footer_magic.html

- Removed the `footer_magic` partial.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/582/files#diff-eee3a0aa73ec238b736c233a867ea54f1f6f143d38f7d917118c7546ca700045">+0/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>footer_outro.html</strong><dd><code>Add new footer partial with fixed dark mode toggle</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

templates/web/partial/footer_outro.html

<li>Added new <code>footer_outro</code> partial.<br> <li> Positioned dark mode toggle in the bottom left corner.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/582/files#diff-fd42dc49ac1b39c6a17b8b7b255dd6e9d9308f76bba9f640d97ffdb34937a81b">+10/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>plans_homepage_cta.html</strong><dd><code>Remove redundant dark mode toggle from homepage CTA</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

templates/web/partial/plans_homepage_cta.html

- Removed dark mode toggle button and script.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/582/files#diff-1eededcc774f85434d6c64d730f34ea90d4c1dc5539c252c209b474c5c6c21cb">+0/-23</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>quiet_footer.html</strong><dd><code>Update quiet footer to use new partial</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

templates/web/partial/quiet_footer.html

- Updated to use `footer_outro` instead of `footer_magic`.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/582/files#diff-3739b948436179b135cd914a3edd3b9d87e69183b05d3460523f2e07420193b3">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>signup.html</strong><dd><code>Simplify dark mode explanation in signup page</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

templates/web/signup.html

- Removed dark mode feature explanation.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/582/files#diff-f025f26faafa2485b2b393a44579c99a63e8eb962f497f8ab6017d6602cf57ba">+0/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Formatting</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>main.ts</strong><dd><code>Code formatting improvements in main.ts</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main.ts

- Added semicolons for consistency.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/582/files#diff-4fab5baaca5c14d2de62d8d2fceef376ddddcc8e9509d86cfa5643f51b89ce3d">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Dependencies</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Add Vue runtime-core dependency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

package.json

- Added `@vue/runtime-core` dependency.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/582/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>pnpm-lock.yaml</strong><dd><code>Update lock file with new Vue dependency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pnpm-lock.yaml

- Updated lock file to include `@vue/runtime-core`.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/582/files#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bb">+23/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

