### PR TITLE
Fix TTL handling and standardize anonymous identifiers

### DIFF
--- a/.prompts
+++ b/.prompts
@@ -1,0 +1,1 @@
+/Users/d/Projects/_/dotfiles/dotprompts

--- a/lib/onetime/app/api/v1/endpoints.rb
+++ b/lib/onetime/app/api/v1/endpoints.rb
@@ -35,7 +35,7 @@ class Onetime::App
           res.redirect app_path(logic.redirect_uri)
         else
           secret = logic.secret
-          json metadata_hsh(logic.metadata,
+          json self.class.metadata_hsh(logic.metadata,
                               :secret_ttl => secret.realttl,
                               :passphrase_required => secret && secret.has_passphrase?)
         end
@@ -52,7 +52,7 @@ class Onetime::App
           res.redirect app_path(logic.redirect_uri)
         else
           secret = logic.secret
-          json metadata_hsh(logic.metadata,
+          json self.class.metadata_hsh(logic.metadata,
                               :value => logic.secret_value,
                               :secret_ttl => secret.realttl,
                               :passphrase_required => secret && secret.has_passphrase?)
@@ -69,12 +69,12 @@ class Onetime::App
         secret = logic.metadata.load_secret
         if logic.show_secret
           secret_value = secret.can_decrypt? ? secret.decrypted_value : nil
-          json metadata_hsh(logic.metadata,
+          json self.class.metadata_hsh(logic.metadata,
                               :value => secret_value,
                               :secret_ttl => secret.realttl,
                               :passphrase_required => secret && secret.has_passphrase?)
         else
-          json metadata_hsh(logic.metadata,
+          json self.class.metadata_hsh(logic.metadata,
                               :secret_ttl => secret ? secret.realttl : nil,
                               :passphrase_required => secret && secret.has_passphrase?)
         end
@@ -89,7 +89,7 @@ class Onetime::App
         logic.process
         recent_metadata = logic.metadata.collect { |md|
           next if md.nil?
-          hash = metadata_hsh(md)
+          hash = self.class.metadata_hsh(md)
           hash.delete :secret_key   # Don't call md.delete, that will delete from redis
           hash
         }.compact
@@ -126,7 +126,7 @@ class Onetime::App
         logic.raise_concerns
         logic.process
         if logic.greenlighted
-          json :state           => metadata_hsh(logic.metadata),
+          json :state           => self.class.metadata_hsh(logic.metadata),
                :secret_shortkey => logic.metadata.secret_shortkey
         else
           secret_not_found_response
@@ -145,102 +145,104 @@ class Onetime::App
           res.redirect app_path(logic.redirect_uri)
         else
           secret = logic.secret
-          json metadata_hsh(logic.metadata,
+          json self.class.metadata_hsh(logic.metadata,
                               :secret_ttl => secret.realttl,
                               :passphrase_required => secret && secret.has_passphrase?)
         end
       end
     end
 
-    # Transforms metadata into a structured hash with enhanced information.
-    #
-    # This method processes a metadata object and optional parameters to create
-    # a comprehensive hash representation. It includes derived and calculated
-    # values, providing a rich snapshot of the metadata and associated secret
-    # state.
-    #
-    # @param md [Metadata] The metadata object to process
-    # @param opts [Hash] Optional parameters to influence the output
-    # @option opts [Integer, nil] :secret_ttl The actual TTL of the associated
-    #   secret, if available
-    #
-    # @return [Hash] A structured hash containing metadata and derived
-    #   information
-    #
-    # @note This method relies on the FlexibleHashAccess refinement for hash
-    #   key access.
-    #
-    # @example Basic usage
-    #   metadata = Metadata.new(key: 'abc123', custid: 'user@example.com')
-    #   result = metadata_hsh(metadata)
-    #   puts result[:custid] # => "user@example.com"
-    #
-    # @example With secret TTL provided
-    #   result = metadata_hsh(metadata, secret_ttl: 3600)
-    #   puts result[:secret_ttl] # => 3600
-    #
-    def metadata_hsh md, opts={}
-      hsh = md.refresh.to_h
-
-      # NOTE: This is a workaround for limitation in Familia where we can't add
-      # fields that clash with reserved keywords like ttl, db, etc. For the v1
-      # API, "ttl" is the requested value (i.e. the value of the ttl param when
-      # the secret was created). Although this is getting the value from a
-      # different field than the 0.16.x and earlier, it reads better (as in "the
-      # secret has a ttl of 123") vs an ambiguous field called just ttl. It's
-      # just confusing with the API response fields where `secret_ttl` is the
-      # real value.
+    module ClassMethods
+      # Transforms metadata into a structured hash with enhanced information.
       #
-      # Also note that the ttl used for metadata at creation time is secret_ttl*2
-      # so that the creator has time to keep retreiving them metadata after the
-      # secret itself has expired. Otherwise there'd be no record of whether the
-      # secret was seen or not.
-      metadata_ttl = (md.secret_ttl || 0).to_i
-
-      # Show the secret's actual real ttl as of now if we have it.
-      secret_realttl = opts[:secret_ttl] ? opts[:secret_ttl].to_i : nil
-
-      # md.realttl is a redis command method. This makes a call to the redis server
-      # to get the current value of the ttl for the metadata object. This is the
-      # actual time left before the metadata object is deleted from the redis server.
+      # This method processes a metadata object and optional parameters to create
+      # a comprehensive hash representation. It includes derived and calculated
+      # values, providing a rich snapshot of the metadata and associated secret
+      # state.
       #
-      # For the v1 API, this real value is what gets returned a "metadata_ttl". If
-      # you don't find that confusing, take another look through the code.
-      metadata_realttl = md.realttl.to_i
+      # @param md [Metadata] The metadata object to process
+      # @param opts [Hash] Optional parameters to influence the output
+      # @option opts [Integer, nil] :secret_ttl The actual TTL of the associated
+      #   secret, if available
+      #
+      # @return [Hash] A structured hash containing metadata and derived
+      #   information
+      #
+      # @note This method relies on the FlexibleHashAccess refinement for hash
+      #   key access.
+      #
+      # @example Basic usage
+      #   metadata = Metadata.new(key: 'abc123', custid: 'user@example.com')
+      #   result = API.metadata_hsh(metadata)
+      #   puts result[:custid] # => "user@example.com"
+      #
+      # @example With secret TTL provided
+      #   result = API.metadata_hsh(metadata, secret_ttl: 3600)
+      #   puts result[:secret_ttl] # => 3600
+      #
+      def metadata_hsh md, opts={}
+        hsh = md.to_h
 
-      recipient = [hsh['recipients']]
-                  .flatten
-                  .compact
-                  .reject(&:empty?)
-                  .uniq
+        # NOTE: This is a workaround for limitation in Familia where we can't add
+        # fields that clash with reserved keywords like ttl, db, etc. For the v1
+        # API, "ttl" is the requested value (i.e. the value of the ttl param when
+        # the secret was created). Although this is getting the value from a
+        # different field than the 0.16.x and earlier, it reads better (as in "the
+        # secret has a ttl of 123") vs an ambiguous field called just ttl. It's
+        # just confusing with the API response fields where `secret_ttl` is the
+        # real value.
+        #
+        # Also note that the ttl used for metadata at creation time is secret_ttl*2
+        # so that the creator has time to keep retreiving them metadata after the
+        # secret itself has expired. Otherwise there'd be no record of whether the
+        # secret was seen or not.
+        metadata_ttl = (md.secret_ttl || 0).to_i
 
-      ret = {
-        :custid => hsh['custid'],
-        :metadata_key => hsh['key'],
-        :secret_key => hsh['secret_key'],
-        :ttl => metadata_ttl, # static value from redis hash field
-        :metadata_ttl => metadata_realttl, # actual number of seconds left to live
-        :secret_ttl => secret_realttl, # ditto, actual number
-        :state => hsh['state'] || 'new',
-        :updated => hsh['updated'].to_i,
-        :created => hsh['created'].to_i,
-        :received => hsh['received'].to_i,
-        :recipient => recipient
-      }
-      if ret[:state] == 'received'
-        ret.delete :secret_ttl
-        ret.delete :secret_key
-      else
-        ret.delete :received
+        # Show the secret's actual real ttl as of now if we have it.
+        secret_realttl = opts[:secret_ttl] ? opts[:secret_ttl].to_i : nil
+
+        # md.realttl is a redis command method. This makes a call to the redis server
+        # to get the current value of the ttl for the metadata object. This is the
+        # actual time left before the metadata object is deleted from the redis server.
+        #
+        # For the v1 API, this real value is what gets returned a "metadata_ttl". If
+        # you don't find that confusing, take another look through the code.
+        metadata_realttl = md.realttl.to_i
+
+        recipient = [hsh['recipients']]
+                    .flatten
+                    .compact
+                    .reject(&:empty?)
+                    .uniq
+
+        ret = {
+          :custid => hsh['custid'],
+          :metadata_key => hsh['key'],
+          :secret_key => hsh['secret_key'],
+          :ttl => metadata_ttl, # static value from redis hash field
+          :metadata_ttl => metadata_realttl, # actual number of seconds left to live
+          :secret_ttl => secret_realttl, # ditto, actual number
+          :state => hsh['state'] || 'new',
+          :updated => hsh['updated'].to_i,
+          :created => hsh['created'].to_i,
+          :received => hsh['received'].to_i,
+          :recipient => recipient
+        }
+        if ret[:state] == 'received'
+          ret.delete :secret_ttl
+          ret.delete :secret_key
+        else
+          ret.delete :received
+        end
+        ret[:value] = opts[:value] if opts[:value]
+        if !opts[:passphrase_required].nil?
+          ret[:passphrase_required] = opts[:passphrase_required]
+        end
+        ret
       end
-      ret[:value] = opts[:value] if opts[:value]
-      if !opts[:passphrase_required].nil?
-        ret[:passphrase_required] = opts[:passphrase_required]
-      end
-      ret
     end
-    private :metadata_hsh
 
+    extend ClassMethods
   end
 end
 

--- a/lib/onetime/app/app_helpers.rb
+++ b/lib/onetime/app/app_helpers.rb
@@ -114,7 +114,7 @@ class Onetime::App
       error_response "An unexpected error occurred :["
 
     ensure
-      @sess ||= OT::Session.new :failover, :anon
+      @sess ||= OT::Session.new 'failover', 'anon'
       @cust ||= OT::Customer.anonymous
     end
 

--- a/lib/onetime/models/customer.rb
+++ b/lib/onetime/models/customer.rb
@@ -71,7 +71,7 @@ class Onetime::Customer < Familia::Horreum
   ]
 
   def init
-    self.custid ||= :anon
+    self.custid ||= 'anon'
     self.role ||= 'customer'
 
     # Initialze auto-increment fields. We do this since Redis
@@ -186,13 +186,18 @@ class Onetime::Customer < Familia::Horreum
     if anonymous?
       raise OT::Problem, "Anonymous customer has no external identifier"
     end
+    # Changing the type, order or value of the elements in this array will
+    # change the external identifier. This is used to identify customers
+    # primarily in logs and other external systems where the actual customer
+    # ID is not needed or otherwise not appropriate to use. Keeping the
+    # value consistent is generally preferred.
     elements = ['cust', role, custid]
     @external_identifier ||= elements.gibbler
     @external_identifier
   end
 
   def anonymous?
-    custid.to_s.to_sym.eql?(:anon)
+    custid.to_s.eql?('anon')
   end
 
   def obscure_email
@@ -369,7 +374,7 @@ class Onetime::Customer < Familia::Horreum
     end
 
     def anonymous
-      new(:anon).freeze
+      new('anon').freeze
     end
 
     def create custid, email=nil

--- a/lib/onetime/models/session.rb
+++ b/lib/onetime/models/session.rb
@@ -147,7 +147,7 @@ class Onetime::Session < Familia::Horreum
   end
 
   def anonymous?
-    disable_auth || sessid.to_s.to_sym == :anon || sessid.to_s.empty?
+    disable_auth || sessid.to_s == 'anon' || sessid.to_s.empty?
   end
 
   def load_customer

--- a/src/components/SecretContentInputArea.vue
+++ b/src/components/SecretContentInputArea.vue
@@ -177,10 +177,6 @@ onUnmounted(() => {
   within the dropdown element, and if so, it closes the dropdown. The Escape key
   functionality simply closes the dropdown when the key is pressed.
 
--->
-
-<!--
-
   TESTING:
   To test the readability and distinguishability of various characters,
   including commonly problematic ones, use the following command to generate

--- a/try/19_safe_dump_try.rb
+++ b/try/19_safe_dump_try.rb
@@ -22,7 +22,7 @@ Onetime::Customer.safe_dump_fields
 ## Implementing models like Customer can safely dump their fields
 cust = Onetime::Customer.new
 cust.safe_dump
-#=> {:custid=>:anon, :role=>"customer", :verified=>nil, :last_login=>nil, :updated=>nil, :created=>nil, :stripe_customer_id=>nil, :stripe_subscription_id=>nil, :stripe_checkout_email=>nil, :plan=>{:planid=>nil, :source=>"parts_unknown"}, :secrets_created=>"0", :secrets_burned=>"0", :secrets_shared=>"0", :emails_sent=>"0", :active=>false}
+#=> {:custid=>"anon", :role=>"customer", :verified=>nil, :last_login=>nil, :updated=>nil, :created=>nil, :stripe_customer_id=>nil, :stripe_subscription_id=>nil, :stripe_checkout_email=>nil, :plan=>{:planid=>nil, :source=>"parts_unknown"}, :secrets_created=>"0", :secrets_burned=>"0", :secrets_shared=>"0", :emails_sent=>"0", :active=>false}
 
 ## Implementing models like Customer do have other fields
 ## that are by default considered not safe to dump.
@@ -59,7 +59,7 @@ all_non_safe_fields = cust.instance_variables.map { |el|
 #
 #   class Customer
 #     def init
-#       self.custid ||= :anon
+#       self.custid ||= 'anon'
 #       self.role ||= 'customer'
 #
 #       # counter fields also added -- Aug 26

--- a/try/20_metadata_ttl_try.rb
+++ b/try/20_metadata_ttl_try.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+# These tryouts test the OT::App::API.metadata_hsh method functionality.
+# The metadata_hsh method is responsible for transforming metadata
+# into a structured hash with enhanced information.
+#
+# We're testing various aspects of the metadata_hsh method, including:
+# 1. Basic metadata transformation
+# 2. TTL handling (metadata_ttl, secret_ttl, and real TTL values)
+# 3. State-dependent field presence
+# 4. Optional parameter handling
+#
+# These tests aim to ensure that the metadata_hsh method correctly
+# processes metadata objects and produces the expected structured
+# hash output for the API response.
+
+require_relative '../lib/onetime'
+
+# Use the default config file for tests
+OT::Config.path = File.join(__dir__, '..', 'etc', 'config.test')
+OT.boot!
+
+# Setup
+@metadata, @secret = Onetime::Secret.spawn_pair 'anon', :tryouts
+@metadata.save
+@secret.save
+
+## Basic metadata transformation
+result = OT::App::API.metadata_hsh(@metadata)
+p [result[:custid], result[:metadata_key], result[:secret_key]]
+p [@metadata.custid, @metadata.key, @metadata.secret_key]
+[result[:custid], result[:metadata_key], result[:secret_key]]
+#=> [@metadata.custid, @metadata.key, @metadata.secret_key]
+
+## TTL handling - metadata_ttl is set to the real TTL value
+result = OT::App::API.metadata_hsh(@metadata)
+result[:metadata_ttl].is_a?(Integer) && result[:metadata_ttl] > 0
+#=> true
+
+## TTL handling - ttl is set to the static value from redis hash field
+@metadata.secret_ttl = 3600
+result = OT::App::API.metadata_hsh(@metadata)
+p result
+result[:ttl]
+#=> 3600
+
+## TTL handling - secret_ttl is nil when not provided
+result = OT::App::API.metadata_hsh(@metadata)
+result[:secret_ttl]
+#=> nil
+
+## TTL handling - secret_ttl is set when provided
+result = OT::App::API.metadata_hsh(@metadata, secret_ttl: 1800)
+result[:secret_ttl]
+#=> 1800
+
+## State-dependent field presence - 'new' state
+result = OT::App::API.metadata_hsh(@metadata)
+[result.key?(:secret_key), result.key?(:secret_ttl), result.key?(:received)]
+#=> [true, true, false]
+
+## State-dependent field presence - 'received' state
+@metadata.state = 'received'
+@metadata.save
+result = OT::App::API.metadata_hsh(@metadata)
+[result.key?(:secret_key), result.key?(:secret_ttl), result.key?(:received)]
+#=> [false, false, true]
+
+## Optional parameter handling - value
+result = OT::App::API.metadata_hsh(@metadata, value: 'test_value')
+result[:value]
+#=> 'test_value'
+
+## Optional parameter handling - passphrase_required (true)
+result = OT::App::API.metadata_hsh(@metadata, passphrase_required: true)
+result[:passphrase_required]
+#=> true
+
+## Optional parameter handling - passphrase_required (false)
+result = OT::App::API.metadata_hsh(@metadata, passphrase_required: false)
+result[:passphrase_required]
+#=> false
+
+# Teardown
+@metadata.destroy!
+@secret.destroy!

--- a/try/20_metadata_ttl_try.rb
+++ b/try/20_metadata_ttl_try.rb
@@ -81,6 +81,87 @@ result = OT::App::API.metadata_hsh(@metadata, passphrase_required: false)
 result[:passphrase_required]
 #=> false
 
+## Handling nil custid
+@metadata.custid = nil
+@metadata.save
+result = OT::App::API.metadata_hsh(@metadata)
+result[:custid]
+#=> ""
+
+## Handling nil secret_key
+@metadata.secret_key = nil
+@metadata.save
+result = OT::App::API.metadata_hsh(@metadata)
+result[:secret_key]
+#=> nil
+
+## Handling nil state
+@metadata.state = nil
+@metadata.save
+result = OT::App::API.metadata_hsh(@metadata)
+result[:state]
+#=> ''
+
+## Handling nil updated timestamp, is overridden when saved
+@metadata.updated = nil
+@metadata.save
+result = OT::App::API.metadata_hsh(@metadata)
+result[:created].positive?
+#=> true
+
+## Handling nil created timestamp, is overridden when saved
+@metadata.created = nil
+@metadata.save
+result = OT::App::API.metadata_hsh(@metadata)
+result[:created].positive?
+#=> true
+
+## Handling nil received timestamp
+@metadata.received = nil
+@metadata.state = 'received'
+@metadata.save
+result = OT::App::API.metadata_hsh(@metadata)
+result[:received]
+#=> 0
+
+## Handling nil recipients
+@metadata.recipients = nil
+@metadata.save
+result = OT::App::API.metadata_hsh(@metadata)
+result[:recipient]
+#=> []
+
+## Handling nil secret_ttl in metadata
+@metadata.secret_ttl = nil
+@metadata.save
+result = OT::App::API.metadata_hsh(@metadata)
+result[:ttl]
+#=> nil
+
+## Handling nil realttl
+class Onetime::Metadata
+  def realttl; nil; end
+end
+result = OT::App::API.metadata_hsh(@metadata)
+result[:metadata_ttl]
+#=> nil
+
+## Handling nil secret_ttl option
+result = OT::App::API.metadata_hsh(@metadata, secret_ttl: nil)
+result[:secret_ttl]
+#=> nil
+
+## Handling nil value option
+result = OT::App::API.metadata_hsh(@metadata, value: nil)
+result.key?(:value)
+#=> false
+
+## Handling nil passphrase_required option
+result = OT::App::API.metadata_hsh(@metadata, passphrase_required: nil)
+result.key?(:passphrase_required)
+#=> false
+
+
 # Teardown
 @metadata.destroy!
 @secret.destroy!

--- a/try/21_secret_try.rb
+++ b/try/21_secret_try.rb
@@ -47,7 +47,7 @@ unique_values.size
 #=> @iterations
 
 ## Generate a pair
-@metadata, @secret = Onetime::Secret.spawn_pair :anon, :tryouts
+@metadata, @secret = Onetime::Secret.spawn_pair 'anon', :tryouts
 [@metadata.nil?, @secret.nil?]
 #=> [false, false]
 
@@ -78,13 +78,13 @@ p [@secret.key, @metadata.secret_key]
 #=> true
 
 ## Can set private secret to viewed state
-metadata, secret = Onetime::Secret.spawn_pair :anon, :tryouts
+metadata, secret = Onetime::Secret.spawn_pair 'anon', :tryouts
 metadata.viewed!
 [metadata.viewed, metadata.state]
 #=> [Time.now.utc.to_i, 'viewed']
 
 ## Can set shared secret to viewed state
-metadata, secret = Onetime::Secret.spawn_pair :anon, :tryouts
+metadata, secret = Onetime::Secret.spawn_pair 'anon', :tryouts
 metadata.save && secret.save
 secret.received!
 metadata = secret.load_metadata

--- a/try/25_customer_try.rb
+++ b/try/25_customer_try.rb
@@ -49,7 +49,7 @@ p [:email, @email_address]
 ## Can "create" an anonymous user (more like simulate)
 @anonymous = OT::Customer.anonymous
 @anonymous.custid
-#=> :anon
+#=> 'anon'
 
 ## Anonymous is a Customer class
 @anonymous.class

--- a/try/30_session_try.rb
+++ b/try/30_session_try.rb
@@ -67,8 +67,8 @@ ipaddress = @sess.ipaddress
 #=> [String, @ipaddress]
 
 ## Sessions don't get unique IDs when instantiated
-s1 = OT::Session.new '255.255.255.255', :anon
-s2 = OT::Session.new '255.255.255.255', :anon
+s1 = OT::Session.new '255.255.255.255', 'anon'
+s2 = OT::Session.new '255.255.255.255', 'anon'
 # Don't call s1.sessid by accessor method b/c that will generate one
 s1.instance_variable_get(:@sessid).eql?(s2.instance_variable_get(:@sessid))
 #=> true

--- a/try/60_logic_base_try.rb
+++ b/try/60_logic_base_try.rb
@@ -26,7 +26,7 @@ OT.boot! :app
 @now = DateTime.now
 @from_address = OT.conf.dig(:emailer, :from)
 @email_address = 'tryouts@onetimesecret.com'
-@sess = OT::Session.new '255.255.255.255', :anon
+@sess = OT::Session.new '255.255.255.255', 'anon'
 @cust = OT::Customer.new @email_address
 @sess.event_clear! :send_feedback
 @params = {}
@@ -74,7 +74,7 @@ end
 #=> true
 
 ## Can create account and it's not verified by default.
-sess = OT::Session.create '255.255.255.255', :anon
+sess = OT::Session.create '255.255.255.255', 'anon'
 cust = OT::Customer.new
 logic = OT::Logic::Account::CreateAccount.new sess, cust, @valid_params.call, 'en'
 logic.raise_concerns
@@ -83,7 +83,7 @@ logic.process
 #=> [false, 'false', false]
 
 ## Can create account and have it auto-verified.
-sess = OT::Session.create '255.255.255.255', :anon
+sess = OT::Session.create '255.255.255.255', 'anon'
 cust = OT::Customer.new
 OT.conf[:site][:authentication][:autoverify] = true # force the config to be true
 logic = OT::Logic::Account::CreateAccount.new sess, cust, @valid_params.call, 'en'

--- a/try/64_logic_destroy_account_try.rb
+++ b/try/64_logic_destroy_account_try.rb
@@ -24,7 +24,7 @@ OT.boot! :app
 # Setup some variables for these tryouts
 @email_address = 'changeme@example.com'
 @now = DateTime.now
-@sess = OT::Session.new '255.255.255.255', :anon
+@sess = OT::Session.new '255.255.255.255', 'anon'
 @sess.event_clear! :destroy_account
 @cust = OT::Customer.new @email_address
 @sess.event_clear! :send_feedback
@@ -127,7 +127,7 @@ last_error = nil
 end
 @sess.event_clear! :destroy_account
 last_error
-#=> [OT::LimitExceeded, '[limit-exceeded] lk2oqnz198o3p7vm0mptqvpeqanjzae for destroy_account (6)']
+#=> [OT::LimitExceeded, '[limit-exceeded] 3ytjp10tjtosfj7ljcscmblz1sc6ds9 for destroy_account (6)']
 
 ## Attempt to process the request without calling raise_concerns first
 password_guess = @params[:confirmation]

--- a/try/68_receive_feedback_try.rb
+++ b/try/68_receive_feedback_try.rb
@@ -25,7 +25,7 @@ OT.boot! :app
 @now = DateTime.now
 @model_class = OT::Feedback
 @email_address = "tryouts+#{@now}@onetimesecret.com"
-@sess = OT::Session.new '255.255.255.255', :anon
+@sess = OT::Session.new '255.255.255.255', 'anon'
 @cust = OT::Customer.new @email_address
 @sess.event_clear! :send_feedback
 @params = {
@@ -87,7 +87,7 @@ count_after - count_before
 ## Sending populates the Feedback model's sorted set key in redis
 count_before = @model_class.recent.count
 email_address = "tryouts2+#{@now}@onetimesecret.com"
-sess = OT::Session.new '255.255.255.255', :anon
+sess = OT::Session.new '255.255.255.255', 'anon'
 cust = OT::Customer.new email_address
 obj = OT::Logic::Misc::ReceiveFeedback.new sess, cust, { msg: 'Some feedback' }
 obj.process


### PR DESCRIPTION
This pull request addresses the issue where the `ttl` attribute value was decreasing unexpectedly in the v1 API response, ensuring that `metadata_ttl` and `secret_ttl` accurately reflect the intended values. Additionally, it standardizes the use of the string 'anon' for identifying anonymous customers and sessions, enhancing code readability and consistency. Tests have been added to validate the functionality of the `metadata_hsh` method, particularly focusing on TTL handling and state-dependent field presence.

re: standardize anonymous identifiers, these changes also include an internal standardization on using the string 'anon' rather than the symbol :anon as default values when creating Session and Customer objects. This aligns with behaviour of redis objects where after a value has been sent to redis, it will remain a string forevermore. 

The reason this change is included in this PR is that in order to make the API.metadata_hsh (now) class-level method testable, we needed to remove the call to refresh prior to hashifying the metadata object: `hsh = md.refresh.to_h`. As a result, values passed when creating the metadata object remain the same values when we get here in the code. IOW, without the call to refresh, cases where a symbol may have been used at instantiation time (e.g. :anon), will now arrive here as a symbol without having been converted to a string by virtue of loading the object from redis just in time. It was a poor choice to call refresh there as the solution to a similar prob. That wrong has now been righted (note: I am talking to myself here). 

Fixes #627

## API Responses

### Example Before

```js
// Create secret
{
  "custid": "anon",
  "metadata_key": "116ytpk6nhnidorumr26csyzu49tbma",
  "secret_key": "5y9z715fhbd4rqq0ftcbm8dwb4922vd",
  "ttl": 600,
  "metadata_ttl": 600,
  "secret_ttl": 300,
  "state": "new",
  "updated": 1726360414,
  "created": 1726360414,
  "recipient": [],
  "passphrase_required": false
}

// Get metadata 1 of 2
{
  "custid": "anon",
  "metadata_key": "116ytpk6nhnidorumr26csyzu49tbma",
  "secret_key": "5y9z715fhbd4rqq0ftcbm8dwb4922vd",
  "ttl": 540,
  "metadata_ttl": 570,
  "secret_ttl": 270,
  "state": "viewed",
  "updated": 1726360423,
  "created": 1726360414,
  "recipient": [],
  "passphrase_required": false
}

// Get metadata 2 of 2
{
  "custid": "anon",
  "metadata_key": "116ytpk6nhnidorumr26csyzu49tbma",
  "secret_key": "5y9z715fhbd4rqq0ftcbm8dwb4922vd",
  "ttl": 520,
  "metadata_ttl": 560,
  "secret_ttl": 260,
  "state": "viewed",
  "updated": 1726360423,
  "created": 1726360414,
  "recipient": []
}
```

### Example after fix

```js
// Create secret
{
  "custid": "anon",
  "metadata_key": "60272upr3gegjxhovfk4zcoem19ziop",
  "secret_key": "1nnumkq7nolj8drfaxdxw4x36orb9f6",
  "ttl": 300,
  "metadata_ttl": 600,
  "secret_ttl": 300,
  "state": "new",
  "updated": 1726361634,
  "created": 1726361634,
  "recipient": [],
  "passphrase_required": false
}

// Get metadata 1 of 2
{
  "custid": "anon",
  "metadata_key": "60272upr3gegjxhovfk4zcoem19ziop",
  "secret_key": "1nnumkq7nolj8drfaxdxw4x36orb9f6",
  "ttl": 300,
  "metadata_ttl": 559,
  "secret_ttl": 259,
  "state": "new",
  "updated": 1726361634,
  "created": 1726361634,
  "recipient": [],
  "passphrase_required": false
}

// Get metadata 2 of 2
{
  "custid": "anon",
  "metadata_key": "60272upr3gegjxhovfk4zcoem19ziop",
  "secret_key": "1nnumkq7nolj8drfaxdxw4x36orb9f6",
  "ttl": 300,
  "metadata_ttl": 536,
  "secret_ttl": 236,
  "state": "viewed",
  "updated": 1726361675,
  "created": 1726361634,
  "recipient": [],
  "passphrase_required": false
}
```
      