### PR TITLE
[#629] Shift anonymous sess check to improve readability

### DIFF
--- a/lib/onetime.rb
+++ b/lib/onetime.rb
@@ -195,12 +195,16 @@ module Onetime
     end
 
     def stdout(prefix, msg)
+      return if STDOUT.closed?
+
       stamp = Time.now.to_i
       logline = "%s(%s): %s" % [prefix, stamp, msg]
       STDOUT.puts(logline)
     end
 
     def stderr(prefix, msg)
+      return if STDERR.closed?
+
       stamp = Time.now.to_i
       logline = "%s(%s): %s" % [prefix, stamp, msg]
       STDERR.puts(logline)

--- a/lib/onetime/app/api/v1/base.rb
+++ b/lib/onetime/app/api/v1/base.rb
@@ -66,12 +66,18 @@ class Onetime::App
           # proceed.
           else
 
-            if allow_anonymous
-              @cust = OT::Customer.anonymous
-              @sess = OT::Session.new req.client_ipaddress, cust.custid
-              OT.info "[authorized] Anonymous session via #{req.client_ipaddress} (new session #{sess.sessid})"
-            else
+            unless allow_anonymous
               raise OT::Unauthorized, "No session or credentials"
+            end
+
+            @cust = OT::Customer.anonymous
+            @sess = OT::Session.new req.client_ipaddress, cust.custid
+
+            if OT.debug?
+              ip_address = req.client_ipaddress.to_s
+              session_id = sess.sessid.to_s
+              message = "[authorized] Anonymous session via #{ip_address} (new session #{session_id})"
+              OT.ld message
             end
 
           end


### PR DESCRIPTION
### **User description**
Enhanced readability by changing `if` to `unless` for anonymous session
check.
Added debug logging for anonymous session creation to capture IP and
session ID.
This aids in debugging and tracking anonymous sessions.

Related to #614.

Signed-off-by: delano <delano@onetimesecret.com>


___

### **PR Type**
enhancement, bug fix


___

### **Description**
- Added checks to prevent logging to closed STDOUT and STDERR, improving error handling.
- Enhanced readability by changing `if` to `unless` for anonymous session checks.
- Introduced debug logging for anonymous session creation, capturing IP and session ID for better tracking and debugging.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>onetime.rb</strong><dd><code>Add checks for closed STDOUT and STDERR in logging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/onetime.rb

- Added checks to prevent logging to closed STDOUT and STDERR.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/633/files#diff-fdca55a2ee0875c33af04f1ecd5140eee8528d6756a21ab4837f579da61f0d37">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>base.rb</strong><dd><code>Improve readability and logging for anonymous sessions</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/onetime/app/api/v1/base.rb

<li>Changed <code>if</code> to <code>unless</code> for anonymous session check.<br> <li> Added debug logging for anonymous session creation.<br> <li> Captured IP and session ID for debugging.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/633/files#diff-35281666a48e0506e8731c2c66f2e737a7c710703a490d84567dac881920a44f">+11/-5</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

