### PR TITLE
[#578] Update custom share domains logic

### DIFF
--- a/lib/onetime/app/api/v1/endpoints.rb
+++ b/lib/onetime/app/api/v1/endpoints.rb
@@ -104,7 +104,9 @@ class Onetime::App
         logic.raise_concerns
         logic.process
         if logic.show_secret
-          json :value => logic.secret_value, :secret_key => req.params[:key]
+          json :value => logic.secret_value,
+               :secret_key => req.params[:key],
+               :share_domain => logic.share_domain
 
           # Immediately mark the secret as viewed, so that it
           # can't be shown again. If there's a network failure
@@ -233,7 +235,8 @@ class Onetime::App
           :updated => hsh['updated']&.to_i,
           :created => hsh['created']&.to_i,
           :received => hsh['received']&.to_i, # empty fields become 0
-          :recipient => recipient
+          :recipient => recipient,
+          :share_domain => hsh['share_domain']
         }
         if ret[:state] == 'received'
           ret.delete :secret_ttl

--- a/lib/onetime/logic/secrets.rb
+++ b/lib/onetime/logic/secrets.rb
@@ -120,7 +120,7 @@ module Onetime::Logic
     end
 
     class ShowSecret < OT::Logic::Base
-      attr_reader :key, :passphrase, :continue
+      attr_reader :key, :passphrase, :continue, :share_domain
       attr_reader :secret, :show_secret, :secret_value, :truncated, :original_size, :verification, :correct_passphrase
       def process_params
         @key = params[:key].to_s
@@ -136,6 +136,8 @@ module Onetime::Logic
         @correct_passphrase = !secret.has_passphrase? || secret.passphrase?(passphrase)
         @show_secret = secret.viewable? && correct_passphrase && continue
         @verification = secret.verification.to_s == "true"
+        @share_domain = secret.share_domain
+
         owner = secret.load_customer
 
         if show_secret

--- a/lib/onetime/logic/secrets.rb
+++ b/lib/onetime/logic/secrets.rb
@@ -76,12 +76,12 @@ module Onetime::Logic
 
           # Is the custom domain is nil, it either doesn't exist in the system
           # or it doesn't exist in the system for this customer.
-          raise_form_error "Unknown share domain" if custom_domain.nil?
+          raise_form_error "Unknown share domain (#{@share_domain})" if @custom_domain.nil?
 
           # We should never get here in theory since the domain won't load unless
           # the domain+custid matches. However, due to bugs and unofrseen circumstances
           # we may get here in practice.
-          raise_form_error "Invalid share domain" unless custom_domain.owner?(cust)
+          raise_form_error "Invalid share domain (#{@share_domain})" unless @custom_domain.owner?(@cust)
         end
       end
 

--- a/templates/web/docs/api.html
+++ b/templates/web/docs/api.html
@@ -6,20 +6,20 @@
 
     <nav>
       <ul class="flex space-x-4">
-        <li><a href="/docs/api" class="text-brand font-semibold dark:text-brand-100">Overview</a></li>
-        <li><a href="/docs/api/secrets" class="text-gray-600 hover:text-brand dark:text-gray-300 dark:hover:text-brand-100">Secrets</a></li>
-        <li><a href="/docs/api/libs" class="text-gray-600 hover:text-brand dark:text-gray-300 dark:hover:text-brand-100">Client Libraries</a></li>
+        <li><a href="/docs/api" class="text-brand underline font-semibold dark:text-brand-100">Overview</a></li>
+        <li><a href="/docs/api/secrets" class="text-gray-600 underline hover:text-brand dark:text-gray-300 dark:hover:text-brand-100">Secrets</a></li>
+        <li><a href="/docs/api/libs" class="text-gray-600 underline hover:text-brand dark:text-gray-300 dark:hover:text-brand-100">Client Libraries</a></li>
       </ul>
     </nav>
 
-    <p class="text-center">
-      <em class="text-lg">BETA API - updated 2022-01-14 (<a href="#feedback" class="text-brand hover:underline dark:text-brand-100">Have a question?</a>)</em>
+    <p class="justify-normal">
+      <em class="text-md">Updated: 2024-06-09</em>
     </p>
 
     <div class="space-y-8">
       <section>
         <h3 class="text-2xl font-semibold border-b pb-2 mb-4 text-gray-800 dark:text-gray-200">Base URI</h3>
-        <span class="text-sm text-gray-600 dark:text-gray-400 block mb-2">{{baseuri}}/api</span>
+        <span class="text-sm text-gray-600 dark:text-gray-600 mb-4 bg-yellow-200">{{baseuri}}/api</span>
 
         <p class="text-gray-800 dark:text-gray-200">
           All API access is over HTTPS and starts with <code class="bg-gray-200 dark:bg-gray-700 px-1 py-0.5 rounded">/api</code>. All responses are JSON.
@@ -41,7 +41,7 @@
 
       <section>
         <h3 class="text-2xl font-semibold border-b pb-2 mb-4 text-gray-800 dark:text-gray-200">System Status</h3>
-        <span class="text-sm text-gray-600 dark:text-gray-400 block mb-2">GET {{baseuri}}/api/v1/status</span>
+        <span class="text-sm text-gray-600 dark:text-gray-600 mb-4 bg-yellow-200">GET {{baseuri}}/api/v1/status</span>
 
         <p class="text-gray-800 dark:text-gray-200 mb-4">Current status of the system.</p>
 
@@ -50,16 +50,14 @@
           <em class="text-gray-600 dark:text-gray-400">None</em>
         </div>
 
-        <pre class="bg-gray-100 dark:bg-gray-800 p-4 rounded-lg overflow-x-auto text-sm mb-4">
-$ curl -u 'USERNAME:APITOKEN' {{baseuri}}/api/v1/status</pre>
+        <pre class="bg-gray-100 dark:bg-gray-800 p-4 rounded-lg overflow-x-auto text-sm mb-4">$ curl -u 'USERNAME:APITOKEN' {{baseuri}}/api/v1/status</pre>
 
-        <pre class="bg-gray-100 dark:bg-gray-800 p-4 rounded-lg overflow-x-auto text-sm mb-4">
-{"status":"nominal"}</pre>
+        <pre class="bg-gray-100 dark:bg-gray-800 p-4 rounded-lg overflow-x-auto text-sm mb-4">{"status":"nominal"}</pre>
 
         <div>
           <strong class="block mb-2 font-semibold">Attributes</strong>
           <ul class="list-disc pl-5 space-y-1 text-gray-800 dark:text-gray-200">
-            <li><span class="font-medium">status</span>: The current system status. One of: nominal, offline.</li>
+            <li><span class="font-bold">status</span>: The current system status. One of: nominal, offline.</li>
           </ul>
         </div>
       </section>

--- a/templates/web/docs/api/libs.html
+++ b/templates/web/docs/api/libs.html
@@ -6,14 +6,14 @@
 
     <nav>
       <ul class="flex space-x-4">
-        <li><a href="/docs/api" class="text-gray-600 hover:text-brand dark:text-gray-300 dark:hover:text-brand-100">Overview</a></li>
-        <li><a href="/docs/api/secrets" class="text-gray-600 hover:text-brand dark:text-gray-300 dark:hover:text-brand-100">Secrets</a></li>
-        <li><a href="/docs/api/libs" class="text-brand font-semibold dark:text-brand-100">Client Libraries</a></li>
+        <li><a href="/docs/api" class="text-gray-600 underline hover:text-brand dark:text-gray-300 dark:hover:text-brand-100">Overview</a></li>
+        <li><a href="/docs/api/secrets" class="text-gray-600 underline hover:text-brand dark:text-gray-300 dark:hover:text-brand-100">Secrets</a></li>
+        <li><a href="/docs/api/libs" class="text-brand underline font-semibold dark:text-brand-100">Client Libraries</a></li>
       </ul>
     </nav>
 
-    <p class="text-center">
-      <em class="text-lg">BETA API - updated 2022-01-14 (<a href="/feedback" class="text-brand hover:underline dark:text-brand-100">Have a question?</a>)</em>
+    <p class="justify-normal">
+      <em class="text-md">Updated: 2024-06-09</em>
     </p>
 
     <div class="space-y-8">

--- a/templates/web/docs/api/secrets.html
+++ b/templates/web/docs/api/secrets.html
@@ -2,22 +2,24 @@
 
 <div class="container mx-auto p-4 max-w-2xl">
   <div id="documentation" class="space-y-8">
-    <h2 class="text-3xl font-bold text-brand dark:text-brand-100">Creating &amp; Reading Secrets</h2>
+    <h2 class="text-3xl font-bold text-brand dark:text-brand-100">Secrets API</h2>
 
     <nav>
       <ul class="flex space-x-4">
-        <li><a href="/docs/api" class="text-gray-600 hover:text-brand dark:text-gray-300 dark:hover:text-brand-100">Overview</a></li>
-        <li><a href="/docs/api/secrets" class="text-brand font-semibold dark:text-brand-100">Secrets</a></li>
-        <li><a href="/docs/api/libs" class="text-gray-600 hover:text-brand dark:text-gray-300 dark:hover:text-brand-100">Client Libraries</a></li>
+        <li><a href="/docs/api" class="text-gray-600 underline hover:text-brand dark:text-gray-300 dark:hover:text-brand-100">Overview</a></li>
+        <li><a href="/docs/api/secrets" class="text-brand underline font-semibold dark:text-brand-100">Secrets</a></li>
+        <li><a href="/docs/api/libs" class="text-gray-600 underline hover:text-brand dark:text-gray-300 dark:hover:text-brand-100">Client Libraries</a></li>
       </ul>
     </nav>
 
-    <p class="text-center text-lg italic">BETA API - updated 2022-01-14 (<a href="#feedback" class="text-brand hover:underline dark:text-brand-100">Have a question?</a>)</p>
+    <p class="justify-normal">
+      <em class="text-md">Updated: 2024-09-02</em>
+    </p>
 
     <div id="topicContent" class="space-y-8">
       <section>
         <h3 class="text-2xl font-semibold border-b pb-2 mb-4 text-gray-800 dark:text-gray-200">Create a Secret</h3>
-        <p class="text-sm text-gray-600 dark:text-gray-400 mb-4">POST {{baseuri}}/api/v1/share</p>
+        <span class="text-sm text-gray-600 dark:text-gray-600 mb-4 bg-yellow-200">POST {{baseuri}}/api/v1/share</span>
 
         <p class="mb-4">Use this method to store a secret value.</p>
 
@@ -25,26 +27,28 @@
           <div>
             <h4 class="font-semibold mb-2">Query Params</h4>
             <ul class="list-disc pl-5">
-              <li><span class="font-medium">secret</span>: the secret value which is encrypted before being stored. There is a maximum length based on your plan that is enforced (1k-10k).</li>
-              <li><span class="font-medium">passphrase</span>: a string that the recipient must know to view the secret. This value is also used to encrypt the secret and is bcrypted before being stored so we only have this value in transit.</li>
-              <li><span class="font-medium">ttl</span>: the maximum amount of time, in seconds, that the secret should survive (i.e. time-to-live). Once this time expires, the secret will be deleted and not recoverable.</li>
-              <li><span class="font-medium">recipient</span>: an email address. We will send a friendly email containing the secret link (NOT the secret itself).</li>
+              <li><span class="font-bold">secret</span>: the secret value which is encrypted before being stored. There is a maximum length based on your plan that is enforced (1k-10k).</li>
+              <li><span class="font-bold">passphrase</span>: a string that the recipient must know to view the secret. This value is also used to encrypt the secret and is bcrypted before being stored so we only have this value in transit.</li>
+              <li><span class="font-bold">ttl</span>: the maximum amount of time, in seconds, that the secret should survive (i.e. time-to-live). Once this time expires, the secret will be deleted and not recoverable.</li>
+              <li><span class="font-bold">recipient</span>: an email address. We will send a friendly email containing the secret link (NOT the secret itself).</li>
+              <li><span class="font-bold">share_domain</span>: the custom domain to use when generating the secret link. If not provided, the default domain is used (e.g. {{ site_host }}).</li>
             </ul>
           </div>
 
           <div>
             <h4 class="font-semibold mb-2">Attributes</h4>
             <ul class="list-disc pl-5 ">
-              <li><span class="font-medium">custid</span>: this is you :]</li>
-              <li><span class="font-medium">metadata_key</span>: the unique key for the metadata. DO NOT share this.</li>
-              <li><span class="font-medium">secret_key</span>: the unique key for the secret you create. This is key that you can share.</li>
-              <li><span class="font-medium">ttl</span>: The time-to-live (in seconds) that was specified (i.e. not the time remaining)</li>
-              <li><span class="font-medium">metadata_ttl</span>: The remaining time (in seconds) that the metadata has left to live.</li>
-              <li><span class="font-medium">secret_ttl</span>: The remaining time (in seconds) that the secret has left to live.</li>
-              <li><span class="font-medium">recipient</span>: if a recipient was specified, this is an obfuscated version of the email address.</li>
-              <li><span class="font-medium">created</span>: Time the secret was created in unix time (UTC)</li>
-              <li><span class="font-medium">updated</span>: ditto, but the time it was last updated.</li>
-              <li><span class="font-medium">passphrase_required</span>: If a passphrase was provided when the secret was created, this will be true. Otherwise false, obviously.</li>
+              <li><span class="font-bold">custid</span>: the email address associated to the credentials being used</li>
+              <li><span class="font-bold">metadata_key</span>: the unique key for the metadata. DO NOT share this.</li>
+              <li><span class="font-bold">secret_key</span>: the unique key for the secret you create. This is key that you can share.</li>
+              <li><span class="font-bold">ttl</span>: The time-to-live (in seconds) that was specified (i.e. not the time remaining)</li>
+              <li><span class="font-bold">metadata_ttl</span>: The remaining time (in seconds) that the metadata has left to live.</li>
+              <li><span class="font-bold">secret_ttl</span>: The remaining time (in seconds) that the secret has left to live.</li>
+              <li><span class="font-bold">recipient</span>: if a recipient was specified, this is an obfuscated version of the email address.</li>
+              <li><span class="font-bold">created</span>: Time the secret was created in unix time (UTC)</li>
+              <li><span class="font-bold">updated</span>: ditto, but the time it was last updated.</li>
+              <li><span class="font-bold">passphrase_required</span>: If a passphrase was provided when the secret was created, this will be true. Otherwise false, of course.</li>
+              <li><span class="font-bold">share_domain</span>: the custom domain to use when generating the secret link. Otherwise nil.</li>
             </ul>
           </div>
         </div>
@@ -68,22 +72,20 @@ $ curl -X POST -u 'USERNAME:APITOKEN' -d 'secret=SECRET&ttl=NUMBER_IN_SECONDS' {
 
       <section>
           <h3 class="text-2xl font-semibold mb-2 text-brand dark:text-brand-100 border-b border-gray-300 dark:border-gray-700 pb-2">Generate a Secret</h3>
-    <span class="text-sm text-gray-600 dark:text-gray-400 mb-4 block">POST {{baseuri}}/api/v1/generate</span>
+    <span class="text-sm text-gray-600 dark:text-gray-600 mb-4 bg-yellow-200">POST {{baseuri}}/api/v1/generate</span>
 
     <p class="mb-4">Generate a short, unique secret. This is useful for temporary passwords, Onetime pads, salts, etc.</p>
 
     <div class="mb-6">
       <strong class="block mb-2 font-semibold">Query Params</strong>
       <ul class="list-disc pl-5 space-y-2">
-        <li><span class="font-medium">passphrase</span>: a string that the recipient must know to view the secret. This value is also used to encrypt the secret and is bcrypted before being stored so we only have this value in transit.</li>
-        <li><span class="font-medium">ttl</span>: the maximum amount of time, in seconds, that the secret should survive (i.e. time-to-live). Once this time expires, the secret will be deleted and not recoverable.</li>
-        <li><span class="font-medium">recipient</span>: an email address. We will send a friendly email containing the secret link (NOT the secret itself).</li>
+        <li><span class="font-bold">passphrase</span>: a string that the recipient must know to view the secret. This value is also used to encrypt the secret and is bcrypted before being stored so we only have this value in transit.</li>
+        <li><span class="font-bold">ttl</span>: the maximum amount of time, in seconds, that the secret should survive (i.e. time-to-live). Once this time expires, the secret will be deleted and not recoverable.</li>
+        <li><span class="font-bold">recipient</span>: an email address. We will send a friendly email containing the secret link (NOT the secret itself).</li>
       </ul>
     </div>
 
-    <pre class="bg-gray-100 dark:bg-gray-800 p-4 rounded-lg overflow-x-auto mb-4">
-    $ curl -X POST -u 'USERNAME:APITOKEN' -d 'ttl=NUMBER_IN_SECONDS' {{baseuri}}/api/v1/generate
-    </pre>
+    <pre class="bg-gray-100 dark:bg-gray-800 p-4 rounded-lg overflow-x-auto mb-4">$ curl -X POST -u 'USERNAME:APITOKEN' -d 'ttl=NUMBER_IN_SECONDS' {{baseuri}}/api/v1/generate</pre>
 
     <pre class="bg-gray-100 dark:bg-gray-800 p-4 rounded-lg overflow-x-auto mb-6">
     {
@@ -94,8 +96,7 @@ $ curl -X POST -u 'USERNAME:APITOKEN' -d 'secret=SECRET&ttl=NUMBER_IN_SECONDS' {
       "ttl":"3600",
       "updated":"1324174095",
       "created":"1324174095"
-    }
-    </pre>
+    }</pre>
 
     <div class="mb-8">
       <strong class="block mb-2 font-semibold">Attributes</strong>
@@ -105,34 +106,32 @@ $ curl -X POST -u 'USERNAME:APITOKEN' -d 'secret=SECRET&ttl=NUMBER_IN_SECONDS' {
   <section>
 
     <h3 class="text-2xl font-semibold mb-2 text-brand dark:text-brand-100 border-b border-gray-300 dark:border-gray-700 pb-2">Retrieve a Secret</h3>
-    <span class="text-sm text-gray-600 dark:text-gray-400 mb-4 block">POST {{baseuri}}/api/v1/secret/SECRET_KEY</span>
+    <span class="text-sm text-gray-600 dark:text-gray-600 mb-4 bg-yellow-200">POST {{baseuri}}/api/v1/secret/SECRET_KEY</span>
 
     <div class="mb-6">
       <strong class="block mb-2 font-semibold">Query Params</strong>
       <ul class="list-disc pl-5 space-y-2">
-        <li><span class="font-medium">SECRET_KEY</span>: the unique key for this secret.</li>
-        <li><span class="font-medium">passphrase</span> (if required): the passphrase is required only if the secret was create with one.</li>
+        <li><span class="font-bold">SECRET_KEY</span>: the unique key for this secret.</li>
+        <li><span class="font-bold">passphrase</span> (if required): the passphrase is required only if the secret was create with one.</li>
       </ul>
     </div>
 
     <div class="mb-6">
       <strong class="block mb-2 font-semibold">Attributes</strong>
       <ul class="list-disc pl-5 space-y-2">
-        <li><span class="font-medium">secret_key</span>: the unique key for the secret you create. This is key that you can share.</li>
-        <li><span class="font-medium">value</span>: The actual secret. It should go without saying, but this will only be available one time.</li>
+        <li><span class="font-bold">secret_key</span>: the unique key for the secret you create. This is key that you can share.</li>
+        <li><span class="font-bold">value</span>: The actual secret. It should go without saying, but this will only be available one time.</li>
       </ul>
     </div>
 
     <strong class="block mb-2 font-semibold">Example:</strong>
 
-    <pre class="bg-gray-100 dark:bg-gray-800 p-4 rounded-lg overflow-x-auto">
-    $ curl -X POST -u 'USERNAME:APITOKEN' {{baseuri}}/api/v1/secret/SECRET_KEY
-    </pre>
+    <pre class="bg-gray-100 dark:bg-gray-800 p-4 rounded-lg overflow-x-auto">$ curl -X POST -u 'USERNAME:APITOKEN' {{baseuri}}/api/v1/secret/SECRET_KEY</pre>
   </section>
   <section class="space-y-6">
   <div>
     <h3 class="text-2xl font-semibold text-brand dark:text-brand-100 border-b border-gray-300 dark:border-gray-700 pb-2">Retrieve Metadata</h3>
-    <span class="text-sm text-gray-600 dark:text-gray-400 block mt-1">POST {{baseuri}}/api/v1/private/METADATA_KEY</span>
+    <span class="text-sm text-gray-600 dark:text-gray-600 mb-4 bg-yellow-200">POST {{baseuri}}/api/v1/private/METADATA_KEY</span>
   </div>
 
   <p class="text-gray-800 dark:text-gray-200">
@@ -143,24 +142,24 @@ $ curl -X POST -u 'USERNAME:APITOKEN' -d 'secret=SECRET&ttl=NUMBER_IN_SECONDS' {
     <div>
       <h4 class="font-semibold mb-2 text-gray-700 dark:text-gray-300">Query Params</h4>
       <ul class="list-disc pl-5 space-y-1">
-        <li><span class="font-medium">METADATA_KEY</span>: the unique key for this metadata.</li>
+        <li><span class="font-bold">METADATA_KEY</span>: the unique key for this metadata.</li>
       </ul>
     </div>
 
     <div>
       <h4 class="font-semibold mb-2 text-gray-700 dark:text-gray-300">Attributes</h4>
       <ul class="list-disc pl-5 space-y-1">
-        <li><span class="font-medium">custid</span>: this is you :]</li>
-        <li><span class="font-medium">metadata_key</span>: the unique key for the metadata. DO NOT share this.</li>
-        <li><span class="font-medium">secret_key</span>: the unique key for the secret you created. This is key that you can share.</li>
-        <li><span class="font-medium">ttl</span>: The time-to-live that was specified (i.e. not the time remaining)</li>
-        <li><span class="font-medium">metadata_ttl</span>: The remaining time (in seconds) that the metadata has left to live.</li>
-        <li><span class="font-medium">secret_ttl</span>: The remaining time (in seconds) that the secret has left to live.</li>
-        <li><span class="font-medium">recipient</span>: if a recipient was specified, this is an obfuscated version of the email address.</li>
-        <li><span class="font-medium">created</span>: Time the metadata was created in unix time (UTC)</li>
-        <li><span class="font-medium">updated</span>: ditto, but the time it was last updated.</li>
-        <li><span class="font-medium">received</span>: Time the secret was received.</li>
-        <li><span class="font-medium">passphrase_required</span>: If a passphrase was provided when the secret was created, this will be true. Otherwise false, obviously.</li>
+        <li><span class="font-bold">custid</span>: this is you :]</li>
+        <li><span class="font-bold">metadata_key</span>: the unique key for the metadata. DO NOT share this.</li>
+        <li><span class="font-bold">secret_key</span>: the unique key for the secret you created. This is key that you can share.</li>
+        <li><span class="font-bold">ttl</span>: The time-to-live that was specified (i.e. not the time remaining)</li>
+        <li><span class="font-bold">metadata_ttl</span>: The remaining time (in seconds) that the metadata has left to live.</li>
+        <li><span class="font-bold">secret_ttl</span>: The remaining time (in seconds) that the secret has left to live.</li>
+        <li><span class="font-bold">recipient</span>: if a recipient was specified, this is an obfuscated version of the email address.</li>
+        <li><span class="font-bold">created</span>: Time the metadata was created in unix time (UTC)</li>
+        <li><span class="font-bold">updated</span>: ditto, but the time it was last updated.</li>
+        <li><span class="font-bold">received</span>: Time the secret was received.</li>
+        <li><span class="font-bold">passphrase_required</span>: If a passphrase was provided when the secret was created, this will be true. Otherwise false, obviously.</li>
       </ul>
     </div>
   </div>
@@ -175,7 +174,7 @@ $ curl -X POST -u 'USERNAME:APITOKEN' {{baseuri}}/api/v1/private/METADATA_KEY</p
     <section class="space-y-6">
   <div>
     <h3 class="text-2xl font-semibold text-brand dark:text-brand-100 border-b border-gray-300 dark:border-gray-700 pb-2">Burn a secret</h3>
-    <span class="text-sm text-gray-600 dark:text-gray-400 block mt-1">POST {{baseuri}}/api/v1/private/METADATA_KEY/burn</span>
+    <span class="text-sm text-gray-600 dark:text-gray-600 mb-4 bg-yellow-200">POST {{baseuri}}/api/v1/private/METADATA_KEY/burn</span>
   </div>
 
   <p class="text-gray-800 dark:text-gray-200">
@@ -209,7 +208,7 @@ $ curl -X POST -u 'USERNAME:APITOKEN' {{baseuri}}/api/v1/private/METADATA_KEY/bu
     <section class="space-y-6">
   <div>
     <h3 class="text-2xl font-semibold text-brand dark:text-brand-100 border-b border-gray-300 dark:border-gray-600 pb-2">Retrieve Recent Metadata</h3>
-    <span class="text-sm text-gray-600 dark:text-gray-400 block mt-1">GET {{baseuri}}/api/v1/private/recent</span>
+    <span class="text-sm text-gray-600 dark:text-gray-600 mb-4 bg-yellow-200">GET {{baseuri}}/api/v1/private/recent</span>
   </div>
 
   <p class="text-gray-800 dark:text-gray-200">

--- a/templates/web/docs/api/secrets.html
+++ b/templates/web/docs/api/secrets.html
@@ -48,7 +48,7 @@
               <li><span class="font-bold">created</span>: Time the secret was created in unix time (UTC)</li>
               <li><span class="font-bold">updated</span>: ditto, but the time it was last updated.</li>
               <li><span class="font-bold">passphrase_required</span>: If a passphrase was provided when the secret was created, this will be true. Otherwise false, of course.</li>
-              <li><span class="font-bold">share_domain</span>: the custom domain to use when generating the secret link. Otherwise nil.</li>
+              <li><span class="font-bold">share_domain</span>: the custom domain to use when generating the secret link. Otherwise "".</li>
             </ul>
           </div>
         </div>

--- a/try/29_customer_domains_try.rb
+++ b/try/29_customer_domains_try.rb
@@ -52,6 +52,32 @@ custom_domain = OT::CustomDomain.load(@valid_domain, @cust.custid)
 @cust.custom_domains.first
 #=> @valid_domain
 
+## A custom domain has an owner (via model instance)
+custom_domain = OT::CustomDomain.create(@valid_domain, @cust.custid)
+custom_domain.owner?(@cust)
+#=> true
+
+## A custom domain has an owner (via email string)
+custom_domain = OT::CustomDomain.create(@valid_domain, @cust.custid)
+custom_domain.owner?(@cust.custid)
+#=> true
+
+## A custom domain has an owner (nil)
+custom_domain = OT::CustomDomain.create(@valid_domain, @cust.custid)
+custom_domain.owner?(nil)
+#=> false
+
+## A custom domain has an owner (via different email string)
+custom_domain = OT::CustomDomain.create(@valid_domain, @cust.custid)
+custom_domain.owner?('anothercustomer@onetimesecret.com')
+#=> false
+
+## A custom domain has an owner (via different customer)
+cust = OT::Customer.create('anothercustomer@onetimesecret.com')
+custom_domain = OT::CustomDomain.create(@valid_domain, @cust.custid)
+custom_domain.owner?(cust)
+#=> false
+
 ## A customer's custom_domain list updates when a new domain is added
 custom_domain = @cust.custom_domains_list.first
 [custom_domain.class, custom_domain.display_domain]


### PR DESCRIPTION
### **User description**
* Skip default share domains to avoid unnecessary processing
* Ensure share domains belong to the correct customer
* Added relevant tests to confirm domain ownership logic
* Informative logging for domain validation steps and errors


___

### **PR Type**
Enhancement, Documentation


___

### **Description**
- Added `share_domain` attribute to API responses and logic classes to support custom domain usage.
- Enhanced domain validation logic to skip default domains and ensure correct customer ownership.
- Implemented new methods for domain ownership verification and default domain identification.
- Updated API documentation to include `share_domain` and improved readability with visual enhancements.
- Added tests to verify custom domain ownership logic and scenarios.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>endpoints.rb</strong><dd><code>Add `share_domain` to API JSON responses</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/onetime/app/api/v1/endpoints.rb

<li>Added <code>share_domain</code> to JSON responses for better context.<br> <li> Enhanced logic to include <code>share_domain</code> in secret metadata.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/634/files#diff-e17d694dc40e7bbeafa40181fe082407e5cc75e1a0401e73965b47cdeaa9d23e">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>secrets.rb</strong><dd><code>Improve domain validation and error handling logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/onetime/logic/secrets.rb

<li>Introduced <code>custom_domain</code> attribute for domain validation.<br> <li> Added checks for default and invalid share domains.<br> <li> Enhanced error handling for domain ownership.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/634/files#diff-9fcca108e9a4ed7df3fb68ff5d0f83e2888bfbd3273021bf978197292b1a818e">+24/-4</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>custom_domain.rb</strong><dd><code>Enhance custom domain ownership and validation methods</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/onetime/models/custom_domain.rb

<li>Implemented <code>owner?</code> method to verify domain ownership.<br> <li> Added <code>default_domain?</code> method to identify default domains.<br> <li> Improved error messages for domain loading.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/634/files#diff-96ec102155ead1bc098be94a8beb0038951284ed58a35e54fe5360b1cb9e7a37">+12/-4</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>29_customer_domains_try.rb</strong><dd><code>Add tests for custom domain ownership logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

try/29_customer_domains_try.rb

<li>Added tests for custom domain ownership verification.<br> <li> Included scenarios for different ownership checks.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/634/files#diff-7bb4b13206db3e75551eb69b5f28ea2cbf552b919e2623969a4ebe3a389642aa">+26/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>api.html</strong><dd><code>Update API documentation for clarity and new attributes</code>&nbsp; &nbsp; </dd></summary>
<hr>

templates/web/docs/api.html

<li>Updated API documentation with <code>share_domain</code> attribute.<br> <li> Improved visual elements for better readability.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/634/files#diff-64cb8ec4dd0bb63429f08aa242eba3b95b64b0d5743a554a366a67675a624fc7">+10/-12</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>libs.html</strong><dd><code>Improve navigation and update documentation date</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

templates/web/docs/api/libs.html

<li>Enhanced navigation links with underlining.<br> <li> Updated last modified date for documentation.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/634/files#diff-ccb6b2b64da38acb663079d3f55c659425fbb76a9e0d62c8b2eaa9688827f4d6">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>secrets.html</strong><dd><code>Update Secrets API documentation with new attributes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

templates/web/docs/api/secrets.html

<li>Added <code>share_domain</code> to API attributes.<br> <li> Enhanced text formatting for emphasis.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/634/files#diff-05bebb20343039fd5c36688edcc0e521052e8d29a361b6dca4f8cd23f648fad0">+51/-52</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

