### PR TITLE
Fix logic class namespace and update incoming UI with Tailwind CSS

### DIFF
--- a/etc/config.example
+++ b/etc/config.example
@@ -66,6 +66,10 @@
   :pass: <%= ENV['SMTP_PASSWORD'] || 'CHANGEME' %>
   :auth: <%= ENV['SMTP_AUTH'] || 'login' %>
   :tls: <%= ENV['SMTP_TLS'] || true %>
+:incoming:
+  :enabled: false
+  :email: CHANGEME@example.com
+  :passphrase: abacus
 :mail:
   :truemail:
     # Available validation types: :regex, :mx, :mx_blacklist, :smtp

--- a/lib/onetime/app/web/endpoints.rb
+++ b/lib/onetime/app/web/endpoints.rb
@@ -123,7 +123,7 @@ module Onetime
     def create_incoming
       publically(req.request_path) do
         if OT.conf[:incoming] && OT.conf[:incoming][:enabled]
-          logic = OT::Logic::CreateIncoming.new sess, cust, req.params, locale
+          logic = OT::Logic::Incoming::CreateIncoming.new sess, cust, req.params, locale
           logic.raise_concerns
           logic.process
           req.params.clear

--- a/templates/web/incoming.html
+++ b/templates/web/incoming.html
@@ -1,23 +1,24 @@
 {{>partial/header}}
+
 <div class="container mx-auto p-4 max-w-2xl">
   {{^actionable_visitor}}
-  <div class="jumbotron">
-    <h2 class="intro">Return to <a href="{{subdomain.homepage}}">{{subdomain.company_domain}}</a></h2>
+  <div class="bg-white dark:bg-gray-800 shadow-md rounded-lg p-6">
+    <h2 class="text-2xl font-bold mb-4 dark:text-white">Return to <a href="{{subdomain.homepage}}" class="text-brand-600 hover:text-brand-800 dark:text-brand-400 dark:hover:text-brand-300">{{subdomain.company_domain}}</a></h2>
   </div>
   {{/actionable_visitor}}
 
-  {{#actionable_visitor}}
-  <div class="jumbotron">
+  {{>partial/session_messages}}
 
+  {{#actionable_visitor}}
+  <div class="bg-white dark:bg-gray-800 shadow-md rounded-lg p-6">
     {{^authenticated}}
-    <h1 class="">{{i18n.page.tagline1}}</h1>
-    <p class="lead">{{i18n.page.tagline2}}</p>
+    <h1 class="text-3xl font-bold mb-2 dark:text-white">{{i18n.page.tagline1}}</h1>
+    <p class="text-xl text-gray-600 dark:text-gray-300 mb-6">{{i18n.page.tagline2}}</p>
     {{/authenticated}}
 
     {{>partial/create_incoming_form}}
 
   </div>
-
   {{/actionable_visitor}}
 </div>
 {{>partial/footer}}

--- a/templates/web/partial/create_incoming_form.html
+++ b/templates/web/partial/create_incoming_form.html
@@ -1,53 +1,56 @@
 {{>partial/session_messages}}
 
-<form id="createSecret" method="post" autocomplete="off" action="/incoming" class="form-horizontal">
-  {{{add_shrimp}}}
-  <fieldset>
-    <div class="text-input">
-      <textarea rows="7" class="btn-block" name="secret" autocomplete="off" placeholder="{{i18n.page.incoming_secret_placeholder}}"></textarea>
-      <div class="chars-display lightest"></div>
-    </div>
-    <div class="well options-box">
-      <div class="title">{{i18n.page.incoming_secret_options}}</div>
 
-      <div class="control-group">
-        <label class="control-label lighter" for="ticketnoField">{{i18n.page.incoming_ticket_number}}:</label>
-        <div class="controls">
-          <input class="input-block-level" type="text" name="ticketno" id="ticketnoField" value="" placeholder="{{i18n.page.incoming_ticket_number_hint}}" autocomplete="off" />
+    <form id="createSecret" method="post" autocomplete="off" action="/incoming" class="space-y-6">
+      {{{add_shrimp}}}
+      <div>
+        <textarea rows="7" class="w-full px-3 py-2 text-gray-700 dark:text-gray-300 border rounded-lg focus:outline-none dark:bg-gray-700 dark:border-gray-600 focus:ring-brandcomp-500 focus:border-brandcomp-500 " name="secret" autocomplete="off" placeholder="{{i18n.page.incoming_secret_placeholder}}"></textarea>
+        <div class="text-sm text-gray-500 dark:text-gray-400 mt-1">
+          <span class="chars-display">{{plan.options.size}}</span> remaining
         </div>
       </div>
 
-      <div class="control-group">
-        <label class="control-label lighter" for="recipientField">{{i18n.page.incoming_recipient_address}}:</label>
-        <div class="controls" style="margin-top: 5px">
-          {{incoming_recipient}}
+      <div class="bg-gray-50 dark:bg-gray-700 p-4 rounded-lg">
+        <h3 class="text-lg font-medium text-gray-900 dark:text-white mb-4">{{i18n.page.incoming_secret_options}}</h3>
+
+        <div class="space-y-4">
+          <div>
+            <label for="ticketnoField" class="block text-sm font-medium text-gray-700 dark:text-gray-300">{{i18n.page.incoming_ticket_number}}:</label>
+            <input type="text" name="ticketno" id="ticketnoField" class="mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:ring-brandcomp-500 focus:border-brandcomp-500 sm:text-sm dark:bg-gray-600 dark:border-gray-500 dark:text-white" placeholder="{{i18n.page.incoming_ticket_number_hint}}" autocomplete="off" />
+          </div>
+
+          <div>
+            <label for="recipientField" class="block text-sm font-medium text-gray-700 dark:text-gray-300">{{i18n.page.incoming_recipient_address}}:</label>
+            <div class="mt-1 text-sm text-gray-900 dark:text-gray-100">{{incoming_recipient}}</div>
+          </div>
         </div>
       </div>
-    </div>
 
-    <button class="create btn btn-large btn-block btn-custom" type="submit" name="kind" value="share" >{{i18n.page.incoming_button_create}}</button>
-  </fieldset>
-</form>
-<script type="text/javascript">
-$('#createSecret textarea').on('keyup', function () {
-  var max = {{plan.options.size}};
-  var len = $(this).val().length;
-  var obj = $('#createSecret .chars-display');
-  if (len > max && obj.hasClass('lightest')) {
-    obj.removeClass('lightest');
-    obj.addClass('warning-text');
-  } else if (len <= max && obj.hasClass('warning-text')) {
-    obj.removeClass('warning-text');
-    obj.addClass('lightest');
-  }
-  var char = max - len;
-  obj.text(char);
-  var sub = $('#createSecret .generate');
-  if (len > 0 && !sub.attr('disabled')) {
-    sub.attr('disabled', true);
-  }
-  if (len == 0) {
-    sub.attr('disabled', false);
-  }
-});
-</script>
+      <button type="submit" name="kind" value="share" class="w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-brand-600 hover:bg-brand-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-brand-500 dark:bg-brand-500 dark:hover:bg-brand-600 dark:focus:ring-offset-gray-800">
+        {{i18n.page.incoming_button_create}}
+      </button>
+    </form>
+
+    <script>
+      document.querySelector('#createSecret textarea').addEventListener('keyup', function () {
+        const max = {{plan.options.size}};
+        const len = this.value.length;
+        const obj = document.querySelector('#createSecret .chars-display');
+        if (len > max && obj.classList.contains('text-gray-500')) {
+          obj.classList.remove('text-gray-500', 'dark:text-gray-400');
+          obj.classList.add('text-red-500', 'dark:text-red-400');
+        } else if (len <= max && obj.classList.contains('text-red-500')) {
+          obj.classList.remove('text-red-500', 'dark:text-red-400');
+          obj.classList.add('text-gray-500', 'dark:text-gray-400');
+        }
+        const char = max - len;
+        obj.textContent = char;
+        const sub = document.querySelector('#createSecret .generate');
+        if (len > 0 && !sub.disabled) {
+          sub.disabled = true;
+        }
+        if (len == 0) {
+          sub.disabled = false;
+        }
+      });
+    </script>


### PR DESCRIPTION
### **User description**
This pull request addresses the issue with the logic class namespace for the `/incoming` endpoint by updating the reference in `endpoints.rb`. Additionally, the UI for the incoming feature has been modernized using Tailwind CSS, enhancing design and responsiveness. This includes improved dark mode support, consistent styling, and the replacement of legacy forms with Tailwind equivalents. Default settings for the incoming feature have also been added to the example configuration file.


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Fixed the namespace for the `CreateIncoming` logic class in `endpoints.rb`.
- Updated the incoming page UI using Tailwind CSS for improved design, responsiveness, and dark mode support.
- Refactored the create incoming form to use Tailwind CSS, enhancing styling and accessibility.
- Added default settings for the incoming feature to the example configuration file.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>endpoints.rb</strong><dd><code>Fix namespace for CreateIncoming logic class</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/onetime/app/web/endpoints.rb

<li>Fixed the namespace for the <code>CreateIncoming</code> logic class.<br> <li> Updated the logic instantiation to use the correct namespace.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/640/files#diff-af994e57bc4e93e5ab35c66f8e34d46f7da088568060d2b46781ec06a7df17c2">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>incoming.html</strong><dd><code>Modernize incoming page UI with Tailwind CSS</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

templates/web/incoming.html

<li>Updated UI with Tailwind CSS for improved styling.<br> <li> Enhanced dark mode support.<br> <li> Replaced legacy HTML structures with Tailwind equivalents.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/640/files#diff-e699b9398e4bc8f35245e23cf58169697219ef46a1801db4e5ee9c3e51249043">+8/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>create_incoming_form.html</strong><dd><code>Refactor create incoming form with Tailwind CSS</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

templates/web/partial/create_incoming_form.html

<li>Refactored form styling using Tailwind CSS.<br> <li> Improved form accessibility and responsiveness.<br> <li> Updated JavaScript for character count display.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/640/files#diff-70a75d91689b04cb7f4076a8c5570ea556b1d8174c915d7265531fcc9d870d0f">+47/-44</a>&nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config.example</strong><dd><code>Add default incoming feature settings to config</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

etc/config.example

<li>Added default settings for the incoming feature.<br> <li> Included <code>enabled</code>, <code>email</code>, and <code>passphrase</code> configurations.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/640/files#diff-71a1275087d5064b1db195a61a706a791f3904ffc96941f57e43d62f10b202e1">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

