### PR TITLE
Fix default domain handling in link generation

### DIFF
--- a/lib/onetime/app/web/views.rb
+++ b/lib/onetime/app/web/views.rb
@@ -161,7 +161,9 @@ module Onetime
           else
             '%d days' % ttl.in_days
           end
+
           secret = metadata.load_secret
+
           if secret.nil?
             self[:is_received] = metadata.state?(:received)
             self[:is_burned] = metadata.state?(:burned)
@@ -228,7 +230,11 @@ module Onetime
           self[:show_recipients] = self[:show_metadata] && !self[:recipients].empty?
 
           domain = if self[:domains_enabled]
-            metadata.share_domain || site_host
+            if metadata.share_domain.to_s.empty?
+              site_host
+            else
+              metadata.share_domain
+            end
           else
             site_host
           end

--- a/lib/onetime/logic/secrets.rb
+++ b/lib/onetime/logic/secrets.rb
@@ -43,8 +43,8 @@ module Onetime::Logic
         # most basic of checks, then whatever this is never had a whisker's
         # chance in a lion's den of being a custom domain anyway.
         potential_domain = params[:share_domain].to_s
-        if potential_domain && OT::CustomDomain.valid?(potential_domain)
 
+        if potential_domain && OT::CustomDomain.valid?(potential_domain)
           # If the given domain is the same as the site's host domain, then
           # we simply skip the share domain stuff altogether.
           if OT::CustomDomain.default_domain?(potential_domain)
@@ -190,14 +190,17 @@ module Onetime::Logic
     class ShowMetadata < OT::Logic::Base
       attr_reader :key
       attr_reader :metadata, :secret, :show_secret
+
       def process_params
         @key = params[:key].to_s
         @metadata = Onetime::Metadata.load key
       end
+
       def raise_concerns
         limit_action :show_metadata
         raise OT::MissingSecret if metadata.nil?
       end
+
       def process
         @secret = @metadata.load_secret
       end

--- a/try/45_web_template_private_try.rb
+++ b/try/45_web_template_private_try.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+# These tryouts test the Private view functionality in the OneTime application,
+# with a focus on the initialization process and its arguments.
+# They cover:
+#
+# 1. Creating and initializing a Private view with various arguments
+# 2. Testing the visibility of different elements based on metadata state and user authentication
+# 3. Verifying the correct generation of URIs and paths
+# 4. Checking the handling of secret values and their display properties
+#
+# These tests ensure that the Private view correctly handles different scenarios
+# and properly initializes based on the provided arguments.
+
+require_relative '../lib/onetime'
+
+# Use the default config file for tests
+OT::Config.path = File.join(__dir__, '..', 'etc', 'config.test')
+OT.boot!
+
+@email = 'tryouts+41@onetimesecret.com'
+@cust = OT::Customer.create @email
+@metadata = OT::Metadata.create
+@secret = OT::Secret.create value: "This is a secret message"
+@metadata.secret_key = @secret.key
+@metadata.save
+
+# Mock request object
+class MockRequest
+  attr_reader :env
+  def initialize
+    @env = {'ots.locale' => 'en'}
+  end
+end
+
+# Mock session object
+class MockSession
+  def authenticated?
+    true
+  end
+  def add_shrimp
+    "mock_shrimp"
+  end
+  def get_error_messages
+    []
+  end
+  def get_info_messages
+    []
+  end
+  def get_form_fields!
+    {}
+  end
+end
+
+@req = MockRequest.new
+@sess = MockSession.new
+
+## Can create a Private view with all arguments
+view = OT::App::Views::Private.new(@req, @sess, @cust, 'en', @metadata)
+[view.req, view.sess, view.cust, view.locale]
+#=> [@req, @sess, @cust, 'en']
+
+## Correctly sets basic properties
+view = OT::App::Views::Private.new(@req, @sess, @cust, 'en', @metadata)
+[view[:title], view[:body_class], view[:metadata_key]]
+#=> ["You saved a secret", :generate, @metadata.key]
+
+## Sets authentication status correctly
+view = OT::App::Views::Private.new(@req, @sess, @cust, 'en', @metadata)
+view[:authenticated]
+#=> true
+
+## Handles unauthenticated user correctly
+unauthenticated_sess = MockSession.new
+def unauthenticated_sess.authenticated?; false; end
+view = OT::App::Views::Private.new(@req, unauthenticated_sess, OT::Customer.anonymous, 'en', @metadata)
+view[:authenticated]
+#=> false
+
+## Generates correct share URI
+@this_view = OT::App::Views::Private.new(@req, @sess, @cust, 'en', @metadata)
+@this_view.share_uri
+#=> "#{@this_view.baseuri}/secret/#{@secret.key}"
+
+## Sets locale correctly
+view = OT::App::Views::Private.new(@req, @sess, @cust, 'es', @metadata)
+view.locale
+#=> 'es'
+
+## Falls back to default locale if not provided
+view = OT::App::Views::Private.new(@req, @sess, @cust, nil, @metadata)
+view.locale
+#=> 'en'
+
+## Correctly sets expiration stamp
+@metadata.ttl = 2.days
+view = OT::App::Views::Private.new(@req, @sess, @cust, 'en', @metadata)
+view[:expiration_stamp]
+#=> "2 days"
+
+## Shows secret link when appropriate
+view = OT::App::Views::Private.new(@req, @sess, @cust, 'en', @metadata)
+view[:show_secret_link]
+#=> true
+
+## Hides secret link when metadata is in received state
+@metadata.received!
+view = OT::App::Views::Private.new(@req, @sess, @cust, 'en', @metadata)
+view[:show_secret_link]
+#=> false
+
+## Correctly determines if secret is a one-liner
+view = OT::App::Views::Private.new(@req, @sess, @cust, 'en', @metadata)
+view.one_liner
+#=> true
+
+## Correctly determines display lines for multi-line secrets
+metadata = OT::Metadata.create
+secret = OT::Secret.create value: "Line 1\nLine 2\nLine 3\nLine4\nLine5\nLine6"
+metadata.secret_key = secret.key
+metadata.save
+view = OT::App::Views::Private.new(@req, @sess, @cust, 'en', metadata)
+view.display_lines
+#=> 7
+
+# Teardown
+@secret.destroy!
+@metadata.destroy!
+@cust.destroy!


### PR DESCRIPTION
### **User description**
This pull request addresses the issue of links being generated without the default domain. It ensures that the default domain is used when the `share_domain` parameter is empty, improving the consistency of parameter processing in the metadata logic. Comprehensive tests for the Private view initialization, URIs, and state handling have also been included to verify the correct functionality. This change eliminates the need for manual domain addition by users, streamlining the link-sharing process.

Fixes #639


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fixed the handling of default domains in link generation by ensuring the default domain is used when `share_domain` is empty.
- Improved consistency in parameter processing within the metadata logic.
- Added comprehensive tests for the Private view, including initialization, URI generation, and state handling.
- Verified the correct handling and display of secret values in various scenarios.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>views.rb</strong><dd><code>Fix default domain handling in link generation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/onetime/app/web/views.rb

<li>Added logic to ensure the default domain is used when <code>share_domain</code> is <br>empty.<br> <li> Improved consistency in parameter processing.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/641/files#diff-c495d1517c1d5e94130b53e37f7941f93f293744d246ece12dc2066f8bb153f0">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>secrets.rb</strong><dd><code>Improve domain validation and formatting consistency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/onetime/logic/secrets.rb

<li>Adjusted domain validation logic for <code>share_domain</code>.<br> <li> Ensured consistent formatting and spacing.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/641/files#diff-9fcca108e9a4ed7df3fb68ff5d0f83e2888bfbd3273021bf978197292b1a818e">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>45_web_template_private_try.rb</strong><dd><code>Add tests for Private view functionality and initialization</code></dd></summary>
<hr>

try/45_web_template_private_try.rb

<li>Added comprehensive tests for Private view initialization.<br> <li> Tested URI generation and metadata state handling.<br> <li> Verified secret handling and display properties.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/641/files#diff-b032172a29ac8f815fbb28d317439de825a8d094242ef9df8b81a0162c334daa">+129/-0</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

