### PR TITLE
Replace `<a>` tags with `<router-link>` for improved SPA routing

### DIFF
--- a/lib/onetime/app/web/views/view_helpers.rb
+++ b/lib/onetime/app/web/views/view_helpers.rb
@@ -13,7 +13,11 @@ module Onetime
         def jsvar(name, value)
           value = case value.class.to_s
                   when 'String', 'Gibbler::Digest', 'Symbol', 'Integer', 'Float'
-                    "'#{Rack::Utils.escape_html(value)}'"
+                    if value.to_s.match?(/\A(https?):\/\/[^\s\/$.?#].[^\s]*\z/)
+                      "'#{value}'" # escaping URLs really kills the vibe
+                    else
+                      "'#{Rack::Utils.escape_html(value)}'"
+                    end
                   when 'Array', 'Hash'
                     value.to_json
                   when 'NilClass'

--- a/src/App.vue
+++ b/src/App.vue
@@ -67,7 +67,6 @@ const layoutProps = computed(() => {
     authentication: authentication.value,
     colonel: false,
     cust: cust.value,
-    shrimp: shrimp.value,
     onetimeVersion: ot_version.value,
     supportHost: support_host.value,
     plansEnabled: plans_enabled.value,

--- a/src/components/account/AccountDeleteButtonWithModalForm.vue
+++ b/src/components/account/AccountDeleteButtonWithModalForm.vue
@@ -46,8 +46,8 @@ const closeDeleteModal = () => {
   <p class="dark:text-gray-300 mb-4">Please be advised:</p>
   <ul class="dark:text-gray-300 mb-4 list-disc list-inside">
     <li><span class="font-bold">Secrets will remain active until they expire.</span></li>
-    <li>Any secrets you wish to remove, <a href="#"
-         class="underline">burn them before continuing</a>.</li>
+    <li>Any secrets you wish to remove, <span
+         class="underline">burn them before continuing</span>.</li>
     <li>Deleting your account is <span class="italic">permanent and non-reversible.</span></li>
   </ul>
   <button @click="openDeleteModal"

--- a/src/components/ctas/HomepagePlansCTA.vue
+++ b/src/components/ctas/HomepagePlansCTA.vue
@@ -22,12 +22,12 @@
           </span>
         </div>
         <div class="flex w-full sm:w-auto font-brand">
-          <a href="/pricing"
-             class="w-full sm:w-auto inline-flex items-center justify-center px-6 py-4 sm:py-2 md:px-4
-             md:py-1 text-xl sm:text-base md:text-xs font-semibold text-brand-500 bg-white
-             hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-brand-500
-             rounded-md border border-brand-500 transition duration-150 animate-throb
-             dark:text-white dark:bg-brand-500 dark:hover:bg-brand-600">
+          <router-link to="/pricing"
+                       class="w-full sm:w-auto inline-flex items-center justify-center px-6 py-4 sm:py-2 md:px-4
+              md:py-1 text-xl sm:text-base md:text-xs font-semibold text-brand-500 bg-white
+              hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-brand-500
+              rounded-md border border-brand-500 transition duration-150 animate-throb
+              dark:text-white dark:bg-brand-500 dark:hover:bg-brand-600">
             <span class="sm:hidden">Now with custom domains</span>
             <span class="hidden sm:inline">{{ $t('web.homepage.explore_premium_plans') }}</span>
             <svg class="ml-2 w-5 h-5 md:w-4 md:h-4"
@@ -42,7 +42,7 @@
                     stroke-width="2"
                     d="M9 5l7 7-7 7"></path>
             </svg>
-          </a>
+          </router-link>
         </div>
       </div>
     </div>
@@ -50,8 +50,6 @@
 </template>
 
 <script setup lang="ts">
-
-
 </script>
 
 <style scoped>
@@ -65,6 +63,7 @@
   50% {
     transform: scale(1.05);
   }
+
 }
 
 .animate-throb {

--- a/src/components/ctas/plans_homepage_cta_initial.html
+++ b/src/components/ctas/plans_homepage_cta_initial.html
@@ -23,17 +23,17 @@
           {{i18n.page.cta_feature3}}
         </li>
       </ul>
-      <a href="/pricing" class="font-brand inline-flex items-center px-6 py-3 bg-brand-600 text-white font-semibold rounded-md hover:bg-brand-700 transition duration-300">
+      <router-link :to="/pricing" class="font-brand inline-flex items-center px-6 py-3 bg-brand-600 text-white font-semibold rounded-md hover:bg-brand-700 transition duration-300">
         {{i18n.page.explore_premium_plans}}
         <svg class="ml-2 w-4 h-4" fill="none" stroke="currentColor" height="20" width="20" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
         </svg>
-      </a>
+      </router-link>
     </div>
     <div class="w-full md:w-1/3 md:border-l md:border-gray-200 dark:md:border-gray-700 md:pl-8 mt-20 md:mt-20">
       <p class="text-gray-600 dark:text-gray-300 mb-4">{{i18n.page.need_free_account}}</p>
 
-      <a href="/signup" class="font-brand inline-block w-full text-base text-center px-6 py-3 bg-gray-100 dark:bg-gray-700 text-gray-800 dark:text-white font-semibold rounded-md hover:bg-gray-200 dark:hover:bg-gray-600 transition duration-300">
+      <router-link :to="/signup" class="font-brand inline-block w-full text-base text-center px-6 py-3 bg-gray-100 dark:bg-gray-700 text-gray-800 dark:text-white font-semibold rounded-md hover:bg-gray-200 dark:hover:bg-gray-600 transition duration-300">
         {{i18n.page.sign_up_free}}
       </a>
 

--- a/src/components/ctas/plans_homepage_cta_red.html
+++ b/src/components/ctas/plans_homepage_cta_red.html
@@ -30,12 +30,12 @@
       </ul>
     </div>
     <div class="w-full md:w-1/3 flex flex-col items-center md:items-end">
-      <a href="/pricing" class="w-full md:w-auto mb-3 px-6 py-3 bg-white text-brand-600 font-semibold rounded-md hover:bg-opacity-90 transition duration-300 text-center" aria-describedby="bannerTitle">
+      <router-link :to="/pricing" class="w-full md:w-auto mb-3 px-6 py-3 bg-white text-brand-600 font-semibold rounded-md hover:bg-opacity-90 transition duration-300 text-center" aria-describedby="bannerTitle">
         {{i18n.page.explore_premium_plans}}
-      </a>
-      <a href="/signup" class="w-full md:w-auto px-6 py-3 bg-brand-700 text-white font-semibold rounded-md hover:bg-brand-800 transition duration-300 text-center" aria-describedby="bannerTitle">
+      </router-link>
+      <router-link :to="/signup" class="w-full md:w-auto px-6 py-3 bg-brand-700 text-white font-semibold rounded-md hover:bg-brand-800 transition duration-300 text-center" aria-describedby="bannerTitle">
         {{i18n.page.sign_up_free}}
-      </a>
+      </router-link>
     </div>
   </div>
 </section>

--- a/src/components/secrets/SecretMetadataTable.vue
+++ b/src/components/secrets/SecretMetadataTable.vue
@@ -28,7 +28,7 @@ defineProps<Props>();
           </ul>
           <p v-else class="text-gray-600 dark:text-gray-400 italic">
             Go on then.
-              <a href="/" class="text-brand-500 hover:underline">{{ $t('web.COMMON.share_a_secret') }}!</a>
+              <router-link to="/" class="text-brand-500 hover:underline">{{ $t('web.COMMON.share_a_secret') }}</router-link>!
           </p>
         </section>
 
@@ -53,7 +53,7 @@ defineProps<Props>();
           </h3>
           <p class="text-gray-600 dark:text-gray-400 italic">
             Go on then.
-            <a href="/" class="text-brand-500 hover:underline">{{ $t('web.COMMON.share_a_secret') }}!</a>
+            <router-link to="/" class="text-brand-500 hover:underline">{{ $t('web.COMMON.share_a_secret') }}</router-link>!
           </p>
         </section>
       </template>

--- a/src/layouts/BaseLayout.vue
+++ b/src/layouts/BaseLayout.vue
@@ -99,7 +99,9 @@ withDefaults(defineProps<Props>(), {
           </template>
 
           <template v-if="plansEnabled">
-            <a href="/pricing" aria-label="Onetime Secret Subscription Pricing" class="text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-gray-100">Pricing</a> |
+            <router-link to="/pricing" aria-label="Onetime Secret Subscription Pricing" class="text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-gray-100">
+              Pricing
+            </router-link> |
           </template>
 
           <a href="https://github.com/onetimesecret/onetimesecret" aria-label="View source code on GitHub" class="text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-gray-100" rel="noopener noreferrer">GitHub</a> |
@@ -108,14 +110,17 @@ withDefaults(defineProps<Props>(), {
             <a :href="`${supportHost}/docs/rest-api`" aria-label="Our documentation site (in beta)" class="text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-gray-100" rel="noopener noreferrer">API</a> |
             <a :href="`${supportHost}/docs`" aria-label="Our documentation site (in beta)" class="text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-gray-100" rel="noopener noreferrer">Docs</a>
           </template>
-          <template v-else>
-            <a href="/docs/api" aria-label="API Documentation" class="text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-gray-100" rel="noopener noreferrer">API</a>
-          </template>
         </div>
         <div v-if="displayLinks" class="prose dark:prose-invert text-base font-brand">
-          <a href="/info/privacy" aria-label="Read our Privacy Policy" class="text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-gray-100">Privacy</a> |
-          <a href="/info/terms" aria-label="Read our Terms and Conditions" class="text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-gray-100">Terms</a> |
-          <a href="/info/security" aria-label="View security information" class="text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-gray-100">Security</a> |
+          <router-link to="/info/privacy" aria-label="Read our Privacy Policy" class="text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-gray-100">
+            Privacy
+          </router-link> |
+          <router-link to="/info/terms" aria-label="Read our Terms and Conditions" class="text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-gray-100">
+            Terms
+          </router-link> |
+          <router-link to="/info/security" aria-label="View security information" class="text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-gray-100">
+            Security
+          </router-link> |
           <a href="https://status.onetimesecret.com/" aria-label="Check service status" class="text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-gray-100" rel="noopener noreferrer">Status</a> |
           <a :href="`${supportHost}/about`" aria-label="About Onetime Secret" class="text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-gray-100">About</a>
         </div>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -212,15 +212,20 @@ const routes: Array<RouteRecordRaw> = [
     component: () => import('@/views/auth/Signin.vue'),
   },
   {
-    path: '/signup/:planCode',
-    name: 'Sign Up',
-    component: () => import('@/views/auth/Signup.vue'),
-    props: true,
-  },
-  {
     path: '/signup',
-    name: 'Sign Up',
-    component: () => import('@/views/auth/Signup.vue'),
+    children: [
+      {
+        path: '',
+        name: 'Sign Up',
+        component: () => import('@/views/auth/Signup.vue'),
+      },
+      {
+        path: ':planCode',
+        name: 'Sign Up with Plan',
+        component: () => import('@/views/auth/Signup.vue'),
+        props: true,
+      },
+    ],
   },
   {
     path: '/about',

--- a/src/views/About.vue
+++ b/src/views/About.vue
@@ -127,7 +127,7 @@ onMounted(() => {
       and we don't keep access logs beyond the minimum necessary. This means that in most cases, we
       simply don't have any data to provide in response to such requests. For more details, please
       review our
-      <a href="/info/privacy">privacy policy</a>.
+      <router-link to="/info/privacy">privacy policy</router-link>.
     </p>
 
     <h4>Why should I trust you?</h4>

--- a/src/views/auth/PasswordReset.vue
+++ b/src/views/auth/PasswordReset.vue
@@ -103,7 +103,9 @@ const props = withDefaults(defineProps<Props>(), {
   <!--{{/verified}}-->
 
   <div class="text-center mt-6">
-    <a href="/signin"
-       class="text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-300">Back to Sign-in</a>
+    <router-link to="/signin"
+                 class="text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-300">
+      Back to Sign-in
+    </router-link>
   </div>
 </template>

--- a/src/views/auth/Signin.vue
+++ b/src/views/auth/Signin.vue
@@ -18,18 +18,18 @@ import SignInForm from '@/components/auth/SignInForm.vue';
     <div class="text-center">
       <ul class="space-y-2">
         <li>
-          <a href="/signup"
-             class="text-sm text-gray-600 dark:text-gray-400 hover:underline transition duration-300 ease-in-out"
-             aria-label="Sign Up">
+          <router-link to="/signup"
+                       class="text-sm text-gray-600 dark:text-gray-400 hover:underline transition duration-300 ease-in-out"
+                       aria-label="Sign Up">
             {{ $t('web.login.need_an_account') }}
-          </a>
+          </router-link>
         </li>
         <li>
-          <a href="/forgot"
-             class="text-sm text-gray-600 dark:text-gray-400 hover:underline transition duration-300 ease-in-out"
-             aria-label="Forgot Password">
+          <router-link to="/forgot"
+                       class="text-sm text-gray-600 dark:text-gray-400 hover:underline transition duration-300 ease-in-out"
+                       aria-label="Forgot Password">
             {{ $t('web.login.forgot_your_password') }}
-          </a>
+          </router-link>
         </li>
       </ul>
     </div>

--- a/src/views/auth/Signup.vue
+++ b/src/views/auth/Signup.vue
@@ -2,10 +2,12 @@
 <script setup lang="ts">
 import PlansElevateCta from '@/components/ctas/PlansElevateCta.vue';
 import SignUpForm from '@/components/auth/SignUpForm.vue';
+import { useWindowProp } from '@/composables/useWindowProps';
 
 const currentPlanId = 'basic';
 const availablePlans = window.available_plans;
 const defaultPlan = availablePlans[currentPlanId];
+const supportHost = useWindowProp('support_host');
 
 </script>
 
@@ -17,20 +19,18 @@ const defaultPlan = availablePlans[currentPlanId];
       <ul class="list-disc pl-6 text-gray-700 dark:text-gray-300">
         <li>secrets that live up to <span class="font-bold text-brand-600 dark:text-brand-400">{{defaultPlan.options.ttl/3600/24}} days</span>.</li>
         <li v-if="defaultPlan.options.email">to send secret links via <span class="font-bold text-brand-600 dark:text-brand-400">email</span>.</li>
-        <li v-if="defaultPlan.options.api">access to the <a href="/docs/api" class="font-bold text-brand-600 dark:text-brand-400 hover:underline">API</a>.</li>
+        <li v-if="defaultPlan.options.api">access to the <a :href="`${supportHost}/docs/rest-api`" class="font-bold text-brand-600 dark:text-brand-400 hover:underline">API</a>.</li>
       </ul>
     </section>
 
-    <!--{{^hide_cta}}-->
-      <PlansElevateCta />
-    <!--{{/hide_cta}}-->
+    <PlansElevateCta />
 
     <SignUpForm :planid="currentPlanId" />
 
     <div class="mt-6 text-center">
-      <a href="/signin" class="text-sm text-gray-600 dark:text-gray-400 hover:underline">
+      <router-link to="/signin" class="text-sm text-gray-600 dark:text-gray-400 hover:underline">
         Already have an account? <strong class="font-medium text-gray-900 dark:text-gray-200">Sign In</strong>
-      </a>
+      </router-link>
     </div>
   </div>
 </template>

--- a/src/views/auth/Signup.vue
+++ b/src/views/auth/Signup.vue
@@ -1,25 +1,17 @@
 <!-- eslint-disable vue/multi-word-component-names -->
-<script setup lang="ts">
-import PlansElevateCta from '@/components/ctas/PlansElevateCta.vue';
-import SignUpForm from '@/components/auth/SignUpForm.vue';
-import { useWindowProp } from '@/composables/useWindowProps';
-
-const currentPlanId = 'basic';
-const availablePlans = window.available_plans;
-const defaultPlan = availablePlans[currentPlanId];
-const supportHost = useWindowProp('support_host');
-
-</script>
 
 <template>
   <div>
     <section class="mb-8">
       <h1 class="font-semibold mb-6 text-gray-900 dark:text-gray-100">Signup</h1>
-      <h3 class=" font-semibold mb- text-gray-900 dark:text-gray-100">Our basic plan is free! You get:</h3>
+      <h3 class=" font-semibold mb- text-gray-900 dark:text-gray-100">
+        Our {{ currentPlan.options.name }} plan! You get:
+      </h3>
+
       <ul class="list-disc pl-6 text-gray-700 dark:text-gray-300">
-        <li>secrets that live up to <span class="font-bold text-brand-600 dark:text-brand-400">{{defaultPlan.options.ttl/3600/24}} days</span>.</li>
-        <li v-if="defaultPlan.options.email">to send secret links via <span class="font-bold text-brand-600 dark:text-brand-400">email</span>.</li>
-        <li v-if="defaultPlan.options.api">access to the <a :href="`${supportHost}/docs/rest-api`" class="font-bold text-brand-600 dark:text-brand-400 hover:underline">API</a>.</li>
+        <li>secrets that live up to <span class="font-bold text-brand-600 dark:text-brand-400">{{currentPlan.options.ttl/3600/24}} days</span>.</li>
+        <li v-if="currentPlan.options.email">to send secret links via <span class="font-bold text-brand-600 dark:text-brand-400">email</span>.</li>
+        <li v-if="currentPlan.options.api">access to the <a :href="`${supportHost}/docs/rest-api`" class="font-bold text-brand-600 dark:text-brand-400 hover:underline">API</a>.</li>
       </ul>
     </section>
 
@@ -34,3 +26,22 @@ const supportHost = useWindowProp('support_host');
     </div>
   </div>
 </template>
+
+<script setup lang="ts">
+import PlansElevateCta from '@/components/ctas/PlansElevateCta.vue';
+import SignUpForm from '@/components/auth/SignUpForm.vue';
+import { useWindowProp } from '@/composables/useWindowProps';
+
+// This prop is passed from vue-router b/c the route has `prop: true`.
+interface Props {
+  planCode: string
+}
+
+const props = defineProps<Props>()
+
+const currentPlanId = props.planCode || 'basic';
+const availablePlans = window.available_plans;
+const currentPlan = availablePlans[currentPlanId];
+const supportHost = useWindowProp('support_host');
+
+</script>

--- a/src/views/pricing/PricingDual.vue
+++ b/src/views/pricing/PricingDual.vue
@@ -168,10 +168,10 @@
             </p>
           </div>
           <div class="mt-8 lg:mt-0 lg:ml-10 flex flex-col space-y-4">
-            <a href="/signup/basic"
-               class="font-brand inline-flex items-center justify-center px-5 py-3 border border-transparent text-base font-medium rounded-md text-white bg-brandcomp-500 hover:bg-brandcomp-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-brandcomp-500 transition-colors duration-200">
+            <router-link to="/signup/basic"
+                         class="font-brand inline-flex items-center justify-center px-5 py-3 border border-transparent text-base font-medium rounded-md text-white bg-brandcomp-500 hover:bg-brandcomp-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-brandcomp-500 transition-colors duration-200">
               Get Started for Free
-            </a>
+            </router-link>
             <a href="https://github.com/onetimesecret/onetimesecret"
                ref="noopener noreferrer"
                class="font-brand inline-flex items-center justify-center px-5 py-3 border border-gray-300 dark:border-gray-600 text-base font-medium rounded-md text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-brandcomp-500 transition-colors duration-200">
@@ -181,8 +181,6 @@
         </div>
       </div>
     </div>
-
-
 
   </div>
 </template>


### PR DESCRIPTION
### **User description**
This pull request replaces all `<a>` tags with `<router-link>` components to enhance internal site navigation consistency and performance within the Vue.js application. Additionally, it removes an unused property from `layoutProps` to clean up the state and includes minor styling adjustments for better visual alignment. These changes ensure that internal navigation is handled more effectively with Vue Router.


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Replaced all `<a>` tags with `<router-link>` components to enhance internal site navigation consistency and performance within the Vue.js application.
- Removed an unused `shrimp` property from `layoutProps` to clean up the state.
- Made minor styling adjustments for better visual alignment.
- Improved internal navigation handling with Vue Router.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>11 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>plans_homepage_cta_initial.html</strong><dd><code>Replace `<a>` tags with `<router-link>` for SPA routing</code>&nbsp; &nbsp; </dd></summary>
<hr>

src/components/ctas/plans_homepage_cta_initial.html

<li>Replaced <code><a></code> tags with <code><router-link></code> for SPA routing.<br> <li> Improved internal navigation consistency.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/663/files#diff-dc5f344d0284399f4ce5a766c6e37fa71228d5ff355edbe48fcdfc1f0e5ee8aa">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>plans_homepage_cta_red.html</strong><dd><code>Update links to use `<router-link>` for SPA routing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/ctas/plans_homepage_cta_red.html

<li>Replaced <code><a></code> tags with <code><router-link></code> for SPA routing.<br> <li> Enhanced internal navigation consistency.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/663/files#diff-474b4c890a48252438cc232652dec44066802d767d41cab23634898d1ea04e2a">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>AccountDeleteButtonWithModalForm.vue</strong><dd><code>Replace `<a>` with `<span>` for non-link text</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/account/AccountDeleteButtonWithModalForm.vue

- Changed `<a>` tag to `<span>` for non-link text.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/663/files#diff-e89a87179ada1bb6b802719aa084f7a7757b521f4addc6dd74a6ac429717716d">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>HomepagePlansCTA.vue</strong><dd><code>Use `<router-link>` for internal navigation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/ctas/HomepagePlansCTA.vue

<li>Replaced <code><a></code> tags with <code><router-link></code> for SPA routing.<br> <li> Improved internal navigation consistency.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/663/files#diff-721b252786140aac1f9143091901210b5917413e2748db18127761bf321877d8">+8/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>SecretMetadataTable.vue</strong><dd><code>Update links to `<router-link>` for SPA routing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/secrets/SecretMetadataTable.vue

<li>Replaced <code><a></code> tags with <code><router-link></code> for SPA routing.<br> <li> Enhanced internal navigation consistency.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/663/files#diff-ccce4d4e195dd5dab4b9777ce327c1770ecd688a68cf466a1841e6294aa006d6">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>BaseLayout.vue</strong><dd><code>Convert links to `<router-link>` for SPA routing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/layouts/BaseLayout.vue

<li>Replaced <code><a></code> tags with <code><router-link></code> for SPA routing.<br> <li> Improved internal navigation consistency.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/663/files#diff-a6b055169c496bd5bf6ec5e987e50b954ea4fa7517de7310676f07c60fe2b99e">+12/-7</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>About.vue</strong><dd><code>Use `<router-link>` for privacy policy link</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/views/About.vue

- Replaced `<a>` tag with `<router-link>` for SPA routing.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/663/files#diff-f22b56f87d5f2203c7eaa1f77720806fdba70f1a31eeb6e58090fe34f0d8a71e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>PasswordReset.vue</strong><dd><code>Update sign-in link to `<router-link>`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/views/auth/PasswordReset.vue

- Replaced `<a>` tag with `<router-link>` for SPA routing.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/663/files#diff-eddad8cec1037cb17d4c4785884d708491a8326a846e0dbfab65279a89f9e49c">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>Signin.vue</strong><dd><code>Convert sign-up and forgot password links to `<router-link>`</code></dd></summary>
<hr>

src/views/auth/Signin.vue

- Replaced `<a>` tags with `<router-link>` for SPA routing.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/663/files#diff-e1ac6403d23a844d2b27c3d914115fcdd0a72be080e4ddf9c2d699c6e9e37793">+8/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>Signup.vue</strong><dd><code>Update links to `<router-link>` and dynamic API link</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/views/auth/Signup.vue

<li>Replaced <code><a></code> tag with <code><router-link></code> for sign-in link.<br> <li> Updated API link to use dynamic <code>supportHost</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/663/files#diff-263e50f3866eac0dd44f029f81b35d7824e4fd506cc93f3421f01c8875565f19">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>PricingDual.vue</strong><dd><code>Use `<router-link>` for sign-up link</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/views/pricing/PricingDual.vue

- Replaced `<a>` tag with `<router-link>` for sign-up link.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/663/files#diff-ae1b4a5ad33a91212298b6c16770a9bc55322f0ba37962941648e63878c711c8">+3/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>App.vue</strong><dd><code>Remove unused `shrimp` property from layoutProps</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/App.vue

- Removed unused `shrimp` property from `layoutProps`.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/663/files#diff-7a7a37b12ee1265d7e27577ec286120d2cbc0940908635e264a2be44ccb9a8a0">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information