### PR TITLE
Remove Vue production Vite asset caching

### DIFF
--- a/lib/onetime/app/web/views/view_helpers.rb
+++ b/lib/onetime/app/web/views/view_helpers.rb
@@ -81,27 +81,27 @@ module Onetime
           assets = []
 
           # Add CSS files directly referenced in the manifest
-          css_files = manifest.values.select { |v| v['file'].end_with?('.css') }
+          css_files = @manifest_cache.values.select { |v| v['file'].end_with?('.css') }
           assets << css_files.map do |css|
             %(<link rel="stylesheet" href="/dist/#{css['file']}">)
           end
 
           # Add CSS files referenced in the 'css' key of manifest entries
-          css_linked_files = manifest.values.flat_map { |v| v['css'] || [] }
+          css_linked_files = @manifest_cache.values.flat_map { |v| v['css'] || [] }
           assets << css_linked_files.map do |css_file|
             %(<link rel="stylesheet" href="/dist/#{css_file}">)
           end
 
           # Add JS files
-          js_files = manifest.values.select { |v| v['file'].end_with?('.js') }
+          js_files = @manifest_cache.values.select { |v| v['file'].end_with?('.js') }
           assets << js_files.map do |js|
             %(<script type="module" src="/dist/#{js['file']}"></script>)
           end
 
           # Add preload directives for imported modules
-          import_files = manifest.values.flat_map { |v| v['imports'] || [] }.uniq
+          import_files = @manifest_cache.values.flat_map { |v| v['imports'] || [] }.uniq
           preload_links = import_files.map do |import_file|
-            %(<link rel="modulepreload" href="/dist/#{manifest[import_file]['file']}">)
+            %(<link rel="modulepreload" href="/dist/#{@manifest_cache[import_file]['file']}">)
           end
           assets << preload_links
 

--- a/lib/onetime/app/web/views/view_helpers.rb
+++ b/lib/onetime/app/web/views/view_helpers.rb
@@ -72,7 +72,11 @@ module Onetime
             return '<script>console.warn("Vite manifest not found. Run `pnpm run build`")</script>'
           end
 
-          manifest = JSON.parse(File.read(manifest_path))
+          # Cache the contents of the manifest file to avoid unnecessary I/O
+          # on every request. The manifest file is only updated when the assets
+          # are rebuilt, so it's safe to cache the contents for the lifetime of
+          # the application process.
+          @manifest_cache ||= JSON.parse(File.read(manifest_path))
 
           assets = []
 


### PR DESCRIPTION
### **User description**
This pull request removes the caching mechanism from the `vite_assets` helper, which is now only executed on full page loads. The call to the caching method has been eliminated, and inline documentation has been added for future reference. Testing has confirmed that the production build functions correctly without caching assets. This change may impact load times for returning users, but it ensures that assets are always up-to-date. Documentation has been updated accordingly.

Fixes #671


___

### **PR Type**
enhancement, documentation


___

### **Description**
- Removed the caching mechanism from the `vite_assets` helper, ensuring that assets are always up-to-date by executing on full page loads.
- Introduced inline documentation for the `cached_method` to clarify its usage and purpose.
- Implemented caching for the contents of the Vite manifest file to minimize unnecessary I/O operations, enhancing performance.
- Updated the logic for handling CSS and JS assets, including adding preload directives for imported modules.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>view_helpers.rb</strong><dd><code>Refactor and document asset handling in view helpers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/onetime/app/web/views/view_helpers.rb

<li>Removed caching mechanism from <code>vite_assets</code> helper.<br> <li> Added inline documentation for <code>cached_method</code>.<br> <li> Cached manifest file contents to reduce I/O operations.<br> <li> Updated logic for handling CSS and JS assets.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/672/files#diff-233cf1a6b7cdcfc60e58c1687029d3f9e77cf37caba5ebdd6d366c10baf9660b">+63/-42</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information