### PR TITLE
Fix secret reveal functionality and improve error handling

### DIFF
--- a/lib/onetime/app/api/v2/routes
+++ b/lib/onetime/app/api/v2/routes
@@ -15,7 +15,7 @@ GET    /private/recent                       Onetime::App::APIV2::Secrets#list_m
 POST   /private/:key/burn                    Onetime::App::APIV2::Secrets#burn_secret
 GET    /private/:key                         Onetime::App::APIV2::Secrets#get_metadata
 GET    /secret/:key                          Onetime::App::APIV2::Secrets#get_secret
-POST   /secret/:key                          Onetime::App::APIV2::Secrets#get_secret
+POST   /secret/:key                          Onetime::App::APIV2::Secrets#reveal_secret
 
 POST   /secret/conceal                       Onetime::App::APIV2::Secrets#conceal_secret
 

--- a/lib/onetime/app/api/v2/secrets.rb
+++ b/lib/onetime/app/api/v2/secrets.rb
@@ -38,6 +38,10 @@ class Onetime::App::APIV2
       retrieve_records(OT::Logic::Secrets::ShowSecret, allow_anonymous: true)
     end
 
+    def reveal_secret
+      retrieve_records(OT::Logic::Secrets::RevealSecret, allow_anonymous: true)
+    end
+
     def list_metadata
       retrieve_records(OT::Logic::Secrets::ShowMetadataList)
     end

--- a/lib/onetime/logic/secrets.rb
+++ b/lib/onetime/logic/secrets.rb
@@ -2,6 +2,7 @@
 require_relative 'base'
 require_relative 'secrets/burn_secret'
 require_relative 'secrets/conceal_secret'
+require_relative 'secrets/reveal_secret'
 require_relative 'secrets/show_metadata'
 require_relative 'secrets/show_metadata_list'
 require_relative 'secrets/show_secret'

--- a/lib/onetime/logic/secrets/reveal_secret.rb
+++ b/lib/onetime/logic/secrets/reveal_secret.rb
@@ -1,0 +1,129 @@
+
+
+
+module Onetime::Logic
+  module Secrets
+
+    # Very similar logic to ShowSecret, but with a few key differences
+    # as required by the v2 API. The v1 API uses the original ShowSecret.
+    class RevealSecret < OT::Logic::Base
+      attr_reader :key, :passphrase, :continue, :share_domain
+      attr_reader :secret, :show_secret, :secret_value, :is_truncated,
+                  :original_size, :verification, :correct_passphrase,
+                  :display_lines, :one_liner, :is_owner, :has_passphrase,
+                  :secret_key
+
+      def process_params
+        @key = params[:key].to_s
+        @secret = Onetime::Secret.load key
+        @passphrase = params[:passphrase].to_s
+        @continue = params[:continue].to_s == 'true'
+
+      end
+
+      def raise_concerns
+        limit_action :show_secret
+        raise OT::MissingSecret if secret.nil? || !secret.viewable?
+      end
+
+      def process
+        @correct_passphrase = secret.has_passphrase? && secret.passphrase?(passphrase)
+        @show_secret = secret.viewable? && (correct_passphrase || !secret.has_passphrase?) && continue
+        @verification = secret.verification.to_s == "true"
+        @secret_key = @secret.key
+        @secret_shortkey = @secret.shortkey
+
+        owner = secret.load_customer
+
+        if show_secret
+          # If we can't decrypt that's great! We just set secret_value to
+          # the encrypted string.
+          @secret_value = secret.can_decrypt? ? secret.decrypted_value : secret.value
+          @is_truncated = secret.truncated?
+          @original_size = secret.original_size
+
+          if verification
+            if cust.anonymous? || (cust.custid == owner.custid && !owner.verified?)
+              owner.verified! "true"
+              sess.destroy!
+              secret.received!
+            else
+              raise_form_error "You can't verify an account when you're already logged in."
+            end
+          else
+
+            owner.increment_field :secrets_shared unless cust.anonymous?
+            OT::Customer.global.increment_field :secrets_shared
+
+            secret.received!
+
+            OT::Logic.stathat_count("Viewed Secrets", 1)
+          end
+
+        elsif secret.has_passphrase? && !correct_passphrase
+          limit_action :failed_passphrase if secret.has_passphrase?
+          message = OT.locales.dig(locale, :web, :COMMON, :error_passphrase) || 'Incorrect passphrase'
+          raise_form_error message
+        end
+
+        domain = if domains_enabled
+                  if secret.share_domain.to_s.empty?
+                    site_host
+                  else
+                    secret.share_domain
+                  end
+                else
+                  site_host
+                end
+
+        @share_domain = [base_scheme, domain].join
+        @is_owner = @secret.owner?(cust)
+        @has_passphrase = @secret.has_passphrase?
+        @display_lines = calculate_display_lines
+        @one_liner = one_liner
+      end
+
+      def success_data
+        ret = {
+          record: {
+            key: @secret_key,
+            secret_key: @secret_key,
+            secret_shortkey: @secret_shortkey,
+            is_truncated: @is_truncated,
+            original_size: @original_size,
+            verification: @verification,
+            share_domain: @share_domain,
+            is_owner: @is_owner,
+            has_passphrase: @has_passphrase
+          },
+          details: {
+            continue: @continue,
+            show_secret: @show_secret,
+            correct_passphrase: @correct_passphrase,
+            display_lines: @display_lines,
+            one_liner: @one_liner
+          }
+        }
+
+        # Add the secret_value only if the secret is viewable
+        if show_secret && secret_value
+          ret[:record][:secret_value] = secret_value
+        end
+
+        ret
+      end
+
+      def calculate_display_lines
+        v = secret_value.to_s
+        ret = ((80+v.size)/80) + (v.scan(/\n/).size) + 3
+        ret = ret > 30 ? 30 : ret
+      end
+
+      def one_liner
+        return if secret_value.to_s.empty? # return nil when the value is empty
+        secret_value.to_s.scan(/\n/).size.zero?
+      end
+    end
+
+  end
+end

--- a/src/views/secrets/ShowSecret.vue
+++ b/src/views/secrets/ShowSecret.vue
@@ -31,12 +31,11 @@
         <div class="">
           <BasicFormAlerts :success="success"
                            :error="error" />
-
-          <p v-if="details.verification && !details.has_passphrase"
+          <p v-if="details.verification && !record.has_passphrase"
              class="text-md text-gray-600 dark:text-gray-400">
             {{ $t('web.COMMON.click_to_verify') }}
           </p>
-          <h2 v-if="details.has_passphrase"
+          <h2 v-if="record.has_passphrase"
               class="text-xl font-bold text-gray-800 dark:text-gray-200">
             {{ $t('web.shared.requires_passphrase') }}
           </h2>
@@ -49,11 +48,13 @@
             <input name="continue"
                    type="hidden"
                    value="true" />
-            <input v-if="details.has_passphrase"
+            <input v-if="record.has_passphrase"
                    type="password"
                    v-model="passphrase"
                    name="passphrase"
                    class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-500 dark:bg-gray-700 dark:border-gray-600 dark:text-white"
+                   autocomplete="switch"
+                   aria-label="Secret Passphrase"
                    :placeholder="$t('web.COMMON.enter_passphrase_here')" />
             <button type="submit"
                     :disabled="isSubmitting"
@@ -133,7 +134,8 @@ const {
     finalDetails.value = data.details
   },
   onError: (data) => {
-    console.error('Error fetching secret:', data)
+    console.debug('Error fetching secret:', data.message)
+    throw new Error(data.message);
   },
 })
 

--- a/try/63_logic_secrets_reveal_secret_try.rb
+++ b/try/63_logic_secrets_reveal_secret_try.rb
@@ -1,0 +1,318 @@
+# frozen_string_literal: true
+
+# These tryouts test the RevealSecret logic functionality in the OneTime application,
+# with a focus on the initialization process and its arguments.
+# They cover:
+#
+# 1. Creating and initializing a RevealSecret logic with various arguments
+# 2. Testing the visibility of different elements based on metadata state and user authentication
+# 3. Verifying the correct generation of URIs and paths
+# 4. Checking the handling of secret values and their display properties
+#
+# These tests ensure that the RevealSecret logic correctly handles different scenarios
+# and properly initializes based on the provided arguments.
+
+require_relative '../lib/onetime'
+
+# Use the default config file for tests
+OT::Config.path = File.join(__dir__, '..', 'etc', 'config.test.yaml')
+OT.boot!
+
+@email = "tryouts+#{Time.now.to_i}@onetimesecret.com"
+@cust = OT::Customer.create @email
+
+# Define a lambda to create and return a new metadata instance
+@create_metadata = lambda {
+  metadata = OT::Metadata.create
+  secret = OT::Secret.create(value: "This is a secret message")
+  metadata.secret_key = secret.key
+  metadata.save
+  metadata
+}
+
+# Use the lambda to create a metadata instance
+@metadata = @create_metadata.call
+
+# Mock request object
+class MockRequest
+  attr_reader :env
+  def initialize
+    @env = {'ots.locale' => 'en'}
+  end
+end
+
+# Mock session object
+class MockSession
+  def authenticated?
+    true
+  end
+  def add_shrimp
+    "mock_shrimp"
+  end
+  def get_error_messages
+    []
+  end
+  def get_info_messages
+    []
+  end
+  def get_form_fields!
+    {}
+  end
+  def event_incr!(event)
+    "mock_event: #{event}"
+  end
+end
+
+@sess = MockSession.new
+
+## Can create a RevealSecret logic with all arguments
+params = {}
+logic = Onetime::Logic::Secrets::RevealSecret.new(@sess, @cust, params, 'en')
+[logic.sess, logic.cust, logic.params, logic.locale]
+#=> [@sess, @cust, {}, 'en']
+
+## Correctly sets basic success_data
+params = {}
+logic = Onetime::Logic::Secrets::RevealSecret.new(@sess, @cust, params, 'en')
+res = logic.success_data
+res.keys
+[:record, :details]
+#=> [:record, :details]
+
+## Has some essential settings
+params = {}
+logic = Onetime::Logic::Secrets::RevealSecret.new(@sess, @cust, params, 'en')
+[logic.site[:host], logic.authentication[:enabled], logic.domains_enabled]
+#=> ["127.0.0.1:3000", true, false]
+
+## Raises an exception when there's no metadata (no metadata param)
+params = {}
+logic = Onetime::Logic::Secrets::RevealSecret.new(@sess, @cust, params, 'en')
+logic.process_params
+begin
+  logic.raise_concerns
+rescue Onetime::MissingSecret
+  true
+end
+#=> true
+
+## Raises an exception when there's no metadata (invalid metadata param)
+params = {
+  key: 'bogus'
+}
+logic = Onetime::Logic::Secrets::RevealSecret.new(@sess, @cust, params, 'en')
+logic.process_params
+begin
+  logic.raise_concerns
+rescue Onetime::MissingSecret
+  true
+end
+#=> true
+
+## Raises an exception when there's no secret
+params = {
+  key: @metadata.key
+}
+logic = Onetime::Logic::Secrets::RevealSecret.new(@sess, @cust, params, 'en')
+begin
+  logic.raise_concerns
+rescue Onetime::MissingSecret
+  true
+end
+#=> true
+
+## Raises an exception when there's no viewable secret
+metadata = @create_metadata.call
+secret = metadata.load_secret
+secret.received!
+params = {
+  key: metadata.secret_key
+}
+logic = Onetime::Logic::Secrets::RevealSecret.new(@sess, @cust, params, 'en')
+begin
+  logic.raise_concerns
+rescue Onetime::MissingSecret
+  true
+end
+#=> true
+
+## Share domain is site.host by default (same as metadata)
+metadata = @create_metadata.call
+params = {
+  key: metadata.secret_key
+}
+@this_logic = Onetime::Logic::Secrets::RevealSecret.new(@sess, @cust, params, 'en')
+@this_logic.process
+@this_logic.share_domain
+#=> "https://127.0.0.1:3000"
+
+## Share domain is still site.host even when the secret has it set if domains is disabled
+metadata = @create_metadata.call
+secret = metadata.load_secret
+secret.share_domain! "example.com"
+params = {
+  key: metadata.secret_key
+}
+@this_logic = Onetime::Logic::Secrets::RevealSecret.new(@sess, @cust, params, 'en')
+@this_logic.process
+[@this_logic.share_domain, @this_logic.domains_enabled]
+#=> ["https://127.0.0.1:3000", false]
+
+## Share domain is processed correctly when the secret has it set
+metadata = @create_metadata.call
+secret = metadata.load_secret
+secret.share_domain! "example.com"
+params = {
+  key: metadata.secret_key
+}
+@this_logic = Onetime::Logic::Secrets::RevealSecret.new(@sess, @cust, params, 'en')
+@this_logic.instance_variable_set(:@domains_enabled, true)
+@this_logic.process
+[@this_logic.share_domain, @this_logic.domains_enabled]
+#=> ["https://example.com", true]
+
+## Sets locale correctly
+logic = Onetime::Logic::Secrets::RevealSecret.new(@sess, @cust, {}, 'es')
+logic.locale
+#=> 'es'
+
+## Falls back to nil locale if not provided
+logic = Onetime::Logic::Secrets::RevealSecret.new(@sess, @cust, {}, nil)
+logic.locale
+#=> nil
+
+## Asking the logic about whether the secret value is a single line returns nil when no secret
+logic = Onetime::Logic::Secrets::RevealSecret.new(@sess, @cust, {}, 'en')
+logic.one_liner
+#=> nil
+
+## Cannot determine if secret is a one-liner when the logic.show_secret is false, even if the secret itself is viewable
+metadata = @create_metadata.call
+params = {
+  key: metadata.secret_key
+}
+logic = Onetime::Logic::Secrets::RevealSecret.new(@sess, @cust, params, 'en')
+logic.raise_concerns
+logic.process
+[logic.secret.viewable?, logic.show_secret, logic.one_liner, logic.secret.can_decrypt?]
+#=> [true, false, nil, true]
+
+## Correctly determines if secret is a one-liner once we've confirmed to
+## continue (even though viewable? now reports false b/c logic.process has
+## been run successfully and can never be run again -- as far as its concerned
+## the secret has been received).
+metadata = @create_metadata.call
+params = {
+  key: metadata.secret_key,
+  continue: true
+}
+logic = Onetime::Logic::Secrets::RevealSecret.new(@sess, @cust, params, 'en')
+logic.raise_concerns
+logic.process
+[logic.secret.viewable?, logic.show_secret, logic.one_liner, logic.secret.can_decrypt?]
+#=> [false, true, true, true]
+
+## Correctly determines if secret is a one-liner if the secret is readable
+metadata = @create_metadata.call
+secret = metadata.load_secret
+params = {
+  key: metadata.secret_key
+}
+logic = Onetime::Logic::Secrets::RevealSecret.new(@sess, @cust, params, 'en')
+secret.received!
+logic.process
+[secret.viewable?, logic.one_liner]
+#=> [false, nil]
+
+## Correctly determines if secret is NOT a one-liner (see note above
+## about why logic.secret.viewable? reports false after running process).
+metadata = OT::Metadata.create
+secret = OT::Secret.create value: "Line 1\nLine 2\nLine 3\nLine4\nLine5\nLine6"
+metadata.secret_key = secret.key
+metadata.save
+params = {
+  key: metadata.secret_key,
+  continue: true
+}
+logic = Onetime::Logic::Secrets::RevealSecret.new(@sess, @cust, params, 'en')
+logic.process
+[logic.secret.viewable?, logic.one_liner]
+#=> [false, false]
+
+## Correctly determines display lines for multi-line secrets
+metadata = OT::Metadata.create
+secret = OT::Secret.create value: "Line 1\nLine 2\nLine 3\nLine4\nLine5\nLine6"
+metadata.secret_key = secret.key
+metadata.save
+params = {
+  key: metadata.secret_key,
+  continue: true
+}
+logic = Onetime::Logic::Secrets::RevealSecret.new(@sess, @cust, params, 'en')
+logic.process
+logic.display_lines
+#=> 9
+
+## Correctly handles a secret without a passphrase
+metadata = @create_metadata.call
+secret = metadata.load_secret
+params = {
+  key: metadata.secret_key,
+  continue: true
+}
+logic = Onetime::Logic::Secrets::RevealSecret.new(@sess, @cust, params, 'en')
+logic.process
+[logic.secret.has_passphrase?, logic.correct_passphrase, logic.show_secret]
+#=> [false, false, true]
+
+## Correctly handles a secret with an incorrect passphrase
+metadata = @create_metadata.call
+secret = metadata.load_secret
+secret.update_passphrase('correct_pass')
+params = {
+  key: metadata.secret_key,
+  passphrase: 'wrong_pass',
+  continue: true
+}
+logic = Onetime::Logic::Secrets::RevealSecret.new(@sess, @cust, params, 'en')
+begin
+  logic.process
+rescue OT::FormError => e
+  [logic.secret.has_passphrase?, logic.correct_passphrase, logic.show_secret, e.message]
+end
+#=> [true, false, false, "Double check that passphrase"]
+
+## Correctly handles a secret with an incorrect passphrase (bogus locale)
+metadata = @create_metadata.call
+secret = metadata.load_secret
+secret.update_passphrase('correct_pass')
+params = {
+  key: metadata.secret_key,
+  passphrase: 'wrong_pass',
+  continue: true
+}
+logic = Onetime::Logic::Secrets::RevealSecret.new(@sess, @cust, params, 'BOGUS')
+begin
+  logic.process
+rescue OT::FormError => e
+  [logic.secret.has_passphrase?, logic.correct_passphrase, logic.show_secret, e.message]
+end
+#=> [true, false, false, "Incorrect passphrase"]
+
+## Correctly handles a secret with a correct passphrase
+metadata = @create_metadata.call
+secret = metadata.load_secret
+secret.update_passphrase('correct_pass')
+params = {
+  key: metadata.secret_key,
+  passphrase: 'correct_pass',
+  continue: true
+}
+logic = Onetime::Logic::Secrets::RevealSecret.new(@sess, @cust, params, 'en')
+logic.process
+[logic.secret.has_passphrase?, logic.correct_passphrase, logic.show_secret]
+#=> [true, true, true]
+
+# Teardown
+@metadata.destroy!
+@cust.destroy!


### PR DESCRIPTION
### **User description**
This pull request implements the `RevealSecret` logic to address the issue where users were unable to view shared secrets after an update. The new logic is optimized for the v2 API and closely resembles the previous `ShowSecret` method. Additionally, the conditional logic for displaying the passphrase form has been corrected, enhancing accessibility with appropriate `aria-label` attributes and improved error handling for better debugging. Expanded log messages now include fetched secret details to assist in troubleshooting.

Fixes #706 #707


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Implemented `RevealSecret` logic to address issues with viewing shared secrets, optimized for the v2 API.
- Added `reveal_secret` method in API to handle secret revealing.
- Updated Vue component to correct conditional logic for passphrase form display and enhance accessibility.
- Improved error handling by adding exception throwing and expanded log messages.
- Updated routing to use `reveal_secret` for POST requests.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>secrets.rb</strong><dd><code>Add reveal_secret method for v2 API secret handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/onetime/app/api/v2/secrets.rb

<li>Added <code>reveal_secret</code> method to handle secret revealing.<br> <li> Utilizes <code>OT::Logic::Secrets::RevealSecret</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/708/files#diff-2ede8eb43c8d4603c04a98ab034c90ac990b9d7c6e4be159e9dd3e3e0884fe39">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>secrets.rb</strong><dd><code>Include RevealSecret logic in secrets module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/onetime/logic/secrets.rb

- Added `require_relative 'secrets/reveal_secret'`.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/708/files#diff-9fcca108e9a4ed7df3fb68ff5d0f83e2888bfbd3273021bf978197292b1a818e">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>reveal_secret.rb</strong><dd><code>Implement RevealSecret class for secret revealing logic</code>&nbsp; &nbsp; </dd></summary>
<hr>

lib/onetime/logic/secrets/reveal_secret.rb

<li>Implemented <code>RevealSecret</code> class for secret revealing logic.<br> <li> Handles passphrase verification and secret viewing.<br> <li> Includes error handling and success data preparation.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/708/files#diff-3b7269d3163de7512cb51c91c2aa54ad761463237b8f61e491d2bdbb01dde3a6">+129/-0</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>routes</strong><dd><code>Update route to use reveal_secret for POST requests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/onetime/app/api/v2/routes

- Changed POST route to use `reveal_secret`.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/708/files#diff-bd9a507e01229e0b1b12525dbf35f2935dc60845c14e1bccccc4630f68295c12">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ShowSecret.vue</strong><dd><code>Update passphrase form logic and error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/views/secrets/ShowSecret.vue

<li>Updated conditional logic for passphrase form display.<br> <li> Enhanced accessibility with <code>aria-label</code>.<br> <li> Improved error handling with exception throwing.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/708/files#diff-5580ff34fd4acf1c0905aca412cddcbec9c9a22ef0bda308dc62f5bb98bf286c">+7/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information