### PR TITLE
Add default TTL for secrets

### DIFF
--- a/etc/config.example.yaml
+++ b/etc/config.example.yaml
@@ -55,12 +55,11 @@
   :secret_options:
     # Default Time-To-Live (TTL) for secrets in seconds
     # This value is used if no specific TTL is provided when creating a secret
-    :default_ttl: <%= ENV['DEFAULT_TTL'] || '604800' %>  # 7 days in seconds
+    :default_ttl: <%= ENV['DEFAULT_TTL'] || nil %>
     # Available TTL options for secret creation (in seconds)
     # These options will be presented to users when they create a new secret
-    # Format: Array of integers representing seconds
-    # Default: 5 minutes, 30 minutes, 1 hour, 4 hours, 12 hours, 1 day, 3 days, 1 week, 2 weeks
-    :ttl_options: <%= (ENV['TTL_OPTIONS'] || '300 1800 3600 14400 43200 86400 259200 604800 1209600') %>
+    # Format: String of integers representing seconds
+    :ttl_options: <%= (ENV['TTL_OPTIONS'] || nil) %>
 :redis:
   :uri: <%= ENV['REDIS_URL'] || 'redis://CHANGEME@127.0.0.1:6379/0' %>
 :colonels:

--- a/etc/config.example.yaml
+++ b/etc/config.example.yaml
@@ -51,6 +51,16 @@
     :host: <%= ENV['SUPPORT_HOST'] || nil %>
   :regions:
     :enabled: false
+  # Configuration options for secret management
+  :secret_options:
+    # Default Time-To-Live (TTL) for secrets in seconds
+    # This value is used if no specific TTL is provided when creating a secret
+    :default_ttl: <%= ENV['DEFAULT_TTL'] || '604800' %>  # 7 days in seconds
+    # Available TTL options for secret creation (in seconds)
+    # These options will be presented to users when they create a new secret
+    # Format: Array of integers representing seconds
+    # Default: 5 minutes, 30 minutes, 1 hour, 4 hours, 12 hours, 1 day, 3 days, 1 week, 2 weeks
+    :ttl_options: <%= (ENV['TTL_OPTIONS'] || '300 1800 3600 14400 43200 86400 259200 604800 1209600') %>
 :redis:
   :uri: <%= ENV['REDIS_URL'] || 'redis://CHANGEME@127.0.0.1:6379/0' %>
 :colonels:

--- a/etc/config.schema.yaml
+++ b/etc/config.schema.yaml
@@ -32,6 +32,8 @@
   :regions:
     :enabled: bool()
     :default: str(required=False)
+  :secret_options: include(':secret_options')
+
 :domains:
   :enabled: any()
   :default: str(required=False)
@@ -51,6 +53,10 @@
 :authenticity:
   :type: str()
   :secret_key: str()
+
+:secret_options:
+  :default_ttl: str()
+  :ttl_options: any(str(), list(str()))
 
 :plans:
   :enabled: any()

--- a/lib/onetime.rb
+++ b/lib/onetime.rb
@@ -164,6 +164,7 @@ module Onetime
         OT.li "mail: smtp=#{OT.conf[:emailer][:host]}:#{OT.conf[:emailer][:port]}, from=#{OT.conf[:emailer][:from]}, mode=#{OT.conf[:emailer][:mode]}"
       end
       OT.li "locales: #{@locales.keys.join(', ')}"
+      OT.li "secret options: #{OT.conf.dig(:site, :secret_options)}"
       OT.li "rate limits: #{OT::RateLimit.events.map { |k,v| "#{k}=#{v}" }.join(', ')}"
     end
 

--- a/lib/onetime/app/web/views/base.rb
+++ b/lib/onetime/app/web/views/base.rb
@@ -22,8 +22,10 @@ module Onetime
         supported_locales = OT.conf.fetch(:locales, []).map(&:to_s)
 
         # TODO: Make better use of fetch/dig to avoid nil checks. Esp important
-        # across release versions where the config may change.
+        # across release versions where the config may change and existing
+        # installs may not have had a chance to update theirs yet.
         site = OT.conf.fetch(:site, {})
+        secret_options = site.fetch(:secret_options, {})
         domains = site.fetch(:domains, {})
         authentication = site.fetch(:authentication, {})
         support_host = site.dig(:support, :host) # defaults to nil
@@ -93,6 +95,7 @@ module Onetime
 
         self[:jsvars] << jsvar(:incoming_recipient, incoming_recipient)
         self[:jsvars] << jsvar(:support_host, support_host)
+        self[:jsvars] << jsvar(:secret_options, secret_options)
         self[:jsvars] << jsvar(:frontend_host, frontend_host)
         self[:jsvars] << jsvar(:authenticated, authenticated)
         self[:jsvars] << jsvar(:site_host, site[:host])

--- a/lib/onetime/config.rb
+++ b/lib/onetime/config.rb
@@ -73,6 +73,23 @@ module Onetime
         conf[:site][:regions] = { enabled: false }
       end
 
+      unless conf[:site]&.key?(:secret_options)
+        conf[:site][:secret_options] = {
+          default_ttl: 7.days,
+          ttl_options: [
+            5.minutes,      # 300
+            30.minutes,     # 1800
+            1.hour,         # 3600
+            4.hours,        # 14400
+            12.hours,       # 43200
+            1.day,          # 86400
+            3.days,         # 259200
+            1.week,         # 604800
+            2.weeks         # 1209600
+          ]
+        }
+      end
+
       # Disable all authentication sub-features when main feature is off for
       # consistency, security, and to prevent unexpected behavior. Ensures clean
       # config state.
@@ -94,6 +111,13 @@ module Onetime
         unless klass.api_key
           raise OT::Problem, "No `site.domains.cluster` api key (#{klass.api_key})"
         end
+      end
+
+      # if conf[:site][:secret_options] is a string, split it by spaces where any
+      # number of spaces or newlines is considered one delimiter to allow for
+      # flexible formatting.
+      if OT.conf.dig(:site, :secret_options).is_a?(String)
+        conf[:site][:secret_options] = OT.conf.dig(:site, :secret_options).split(/\s+/)
       end
 
       if OT.conf.dig(:site, :plans, :enabled).to_s == "true"

--- a/lib/onetime/config.rb
+++ b/lib/onetime/config.rb
@@ -1,4 +1,3 @@
-
 module Onetime
   module Config
     extend self
@@ -23,7 +22,9 @@ module Onetime
 
       parsed_template = ERB.new(File.read(path))
 
-      YAML.load(parsed_template.result)
+      c = YAML.load(parsed_template.result)
+      p [:plop, c.dig(:site, :secret_options)]
+      c
     rescue StandardError => e
       OT.le "Error loading config: #{path}"
       OT.le

--- a/lib/onetime/config.rb
+++ b/lib/onetime/config.rb
@@ -22,9 +22,7 @@ module Onetime
 
       parsed_template = ERB.new(File.read(path))
 
-      c = YAML.load(parsed_template.result)
-      p [:plop, c.dig(:site, :secret_options)]
-      c
+      YAML.load(parsed_template.result)
     rescue StandardError => e
       OT.le "Error loading config: #{path}"
       OT.le
@@ -121,6 +119,11 @@ module Onetime
       if ttl_options.is_a?(String)
         conf[:site][:secret_options][:ttl_options] = ttl_options.split(/\s+/)
       end
+      ttl_options = OT.conf.dig(:site, :secret_options, :ttl_options)
+      if ttl_options.is_a?(Array)
+        conf[:site][:secret_options][:ttl_options] = ttl_options.map(&:to_i)
+      end
+
       if default_ttl.is_a?(String)
         conf[:site][:secret_options][:default_ttl] = default_ttl.to_i
       end

--- a/lib/onetime/config.rb
+++ b/lib/onetime/config.rb
@@ -74,21 +74,20 @@ module Onetime
       end
 
       unless conf[:site]&.key?(:secret_options)
-        conf[:site][:secret_options] = {
-          default_ttl: 7.days,
-          ttl_options: [
-            5.minutes,      # 300
-            30.minutes,     # 1800
-            1.hour,         # 3600
-            4.hours,        # 14400
-            12.hours,       # 43200
-            1.day,          # 86400
-            3.days,         # 259200
-            1.week,         # 604800
-            2.weeks         # 1209600
-          ]
-        }
+        conf[:site][:secret_options] = {}
       end
+      conf[:site][:secret_options][:default_ttl] ||= 7.days
+      conf[:site][:secret_options][:ttl_options] ||= [
+        5.minutes,      # 300 seconds
+        30.minutes,     # 1800
+        1.hour,         # 3600
+        4.hours,        # 14400
+        12.hours,       # 43200
+        1.day,          # 86400
+        3.days,         # 259200
+        1.week,         # 604800
+        2.weeks         # 1209600
+      ]
 
       # Disable all authentication sub-features when main feature is off for
       # consistency, security, and to prevent unexpected behavior. Ensures clean
@@ -113,11 +112,16 @@ module Onetime
         end
       end
 
-      # if conf[:site][:secret_options] is a string, split it by spaces where any
-      # number of spaces or newlines is considered one delimiter to allow for
-      # flexible formatting.
-      if OT.conf.dig(:site, :secret_options).is_a?(String)
-        conf[:site][:secret_options] = OT.conf.dig(:site, :secret_options).split(/\s+/)
+      ttl_options = OT.conf.dig(:site, :secret_options, :ttl_options)
+      default_ttl = OT.conf.dig(:site, :secret_options, :default_ttl)
+
+      # if the ttl_options setting is a string, we want to split it into an
+      # array of integers.
+      if ttl_options.is_a?(String)
+        conf[:site][:secret_options][:ttl_options] = ttl_options.split(/\s+/)
+      end
+      if default_ttl.is_a?(String)
+        conf[:site][:secret_options][:default_ttl] = default_ttl.to_i
       end
 
       if OT.conf.dig(:site, :plans, :enabled).to_s == "true"

--- a/src/components/layout/DefaultFooter.vue
+++ b/src/components/layout/DefaultFooter.vue
@@ -80,12 +80,15 @@
         </div>
       </div>
 
-      <div class="flex flex-col sm:flex-row justify-between items-center pt-4 border-t border-gray-200 dark:border-gray-700">
+      <div class="flex flex-col sm:flex-row justify-between items-center pt-4
+                  border-t border-gray-200 dark:border-gray-700">
         <div v-if="displayVersion"
-             class="text-sm text-center sm:text-left text-gray-500 dark:text-gray-400 mb-4 sm:mb-0 order-2 sm:order-1">
+             class="text-sm text-center sm:text-left mb-4 sm:mb-0 order-2 sm:order-1
+                  text-gray-500 dark:text-gray-400">
           &copy; {{ new Date().getFullYear() }} OnetimeSecret.com - v{{ onetimeVersion }}
         </div>
-        <div class="flex items-center space-x-4 mb-4 sm:mb-0 order-1 sm:order-2">
+        <div v-if="displayToggles"
+             class="flex items-center space-x-4 mb-4 sm:mb-0 order-1 sm:order-2">
           <FeedbackToggle v-if="displayFeedback && authentication.enabled" />
           <ThemeToggle />
           <div class="relative z-50"
@@ -98,10 +101,6 @@
     </div>
   </footer>
 </template>
-
-
-
-
 
 <script setup lang="ts">
 import { ref } from 'vue';
@@ -116,12 +115,14 @@ export interface Props extends DefaultProps {
   displayFeedback?: boolean
   displayLinks?: boolean
   displayVersion?: boolean
+  displayToggles?: boolean
 }
 
 withDefaults(defineProps<Props>(), {
   displayFeedback: true,
   displayLinks: true,
   displayVersion: true,
+  displayToggles: true,
 });
 
 const isLanguageMenuOpen = ref(false);

--- a/src/components/secrets/form/SecretFormPrivacyOptions.vue
+++ b/src/components/secrets/form/SecretFormPrivacyOptions.vue
@@ -106,7 +106,7 @@ const showPassphrase = ref(false);
 const currentPassphrase = ref('');
 
 const selectedLifetime = ref(secretOptions.value?.default_ttl?.toString() || 604800); // Default to 7 days if not set
-console.log('Initial selectedLifetime:', selectedLifetime.value);
+console.debug('Initial selectedLifetime:', selectedLifetime.value);
 
 const lifetimeOptions = computed(() => {
   const options = secretOptions.value?.ttl_options;
@@ -122,6 +122,7 @@ const lifetimeOptions = computed(() => {
 
     return option;
   });
+  console.debug('Mapped lifetime options:', mappedOptions);
   return mappedOptions;
 });
 
@@ -131,7 +132,7 @@ const lifetimeOptions = computed(() => {
  * @returns {string} - The formatted duration string.
  */
 const formatDuration = (seconds: number): string => {
-  console.log('Formatting duration for seconds:', seconds);
+  console.debug('Formatting duration for seconds:', seconds);
   const units = [
     { key: 'day', seconds: 86400 },
     { key: 'hour', seconds: 3600 },
@@ -143,20 +144,20 @@ const formatDuration = (seconds: number): string => {
     const quotient = Math.floor(seconds / unit.seconds);
     if (quotient >= 1) {
       const result = t('web.UNITS.ttl.duration', { count: quotient, unit: t(`web.UNITS.ttl.time.${unit.key}`, quotient) });
-      console.log('Formatted duration:', result);
+      console.debug('Formatted duration:', result);
       return result;
     }
   }
 
   const result = t('web.UNITS.ttl.duration', { count: seconds, unit: t('web.UNITS.ttl.time.second', seconds) });
-  console.log('Formatted duration:', result);
+  console.debug('Formatted duration:', result);
   return result;
 };
 
 const filteredLifetimeOptions = computed(() => {
-  console.log('Computing filteredLifetimeOptions');
+  console.debug('Computing filteredLifetimeOptions');
   const planTtl = plan.value?.options?.ttl || 0;
-  console.log('Plan TTL:', planTtl);
+  console.debug('Plan TTL:', planTtl);
   if (!Array.isArray(lifetimeOptions.value)) {
     console.warn('lifetimeOptions is not an array:', lifetimeOptions.value);
     return [];
@@ -164,14 +165,12 @@ const filteredLifetimeOptions = computed(() => {
   const filtered = lifetimeOptions.value.filter(option => {
     const optionValue = parseFloat(option.value);
     const isValid = !isNaN(optionValue) && optionValue <= planTtl;
-    console.log('Filtering option:', option, 'Is valid:', isValid);
+    console.debug('Filtering option:', option, 'Is valid:', isValid);
     return isValid;
   });
-  console.log('Final filteredLifetimeOptions:', filtered);
+  console.debug('Final filteredLifetimeOptions:', filtered);
   return filtered;
 });
-
-
 
 const togglePassphrase = () => {
   showPassphrase.value = !showPassphrase.value;

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -2,8 +2,6 @@
 import { createI18n } from 'vue-i18n';
 import en from '@/locales/en.json' assert { type: 'json' };
 
-
-
 /**
  * This setup accomplishes the following:
  *
@@ -36,10 +34,10 @@ const i18n = createI18n<{ message: typeof en }, SupportedLocale>({
 export default i18n;
 
 async function loadLocaleMessages(locale: string): Promise<MessageSchema | null> {
-  console.log(`Attempting to load locale: ${locale}`);
+  console.debug(`Attempting to load locale: ${locale}`);
   try {
     const messages = await import(`@/locales/${locale}.json`);
-    console.log(`Successfully loaded locale: ${locale}`);
+    console.debug(`Successfully loaded locale: ${locale}`);
     return messages.default;
   } catch (error) {
     console.error(`Failed to load locale: ${locale}`, error);
@@ -49,21 +47,20 @@ async function loadLocaleMessages(locale: string): Promise<MessageSchema | null>
 
 export async function setLanguage(lang: string): Promise<void> {
   if (i18n.global.locale === lang) {
-    console.log(`Language is already set to ${lang}. No change needed.`);
+    console.debug(`Language is already set to ${lang}. No change needed.`);
     return;
   }
 
-  console.log(`Setting language to: ${lang}`);
   if (lang === 'en') {
     i18n.global.locale = 'en';
-    console.log(`Language set to: ${lang}`);
+    console.debug(`Language set to: ${lang}`);
     return;
   }
   const messages = await loadLocaleMessages(lang);
   if (messages) {
     i18n.global.setLocaleMessage(lang, messages);
     i18n.global.locale = lang;
-    console.log(`Language set to: ${lang}`);
+    console.debug(`Language set to: ${lang}`);
   } else {
     console.log(`Failed to set language to: ${lang}. Falling back to default.`);
   }

--- a/src/layouts/DefaultLayout.vue
+++ b/src/layouts/DefaultLayout.vue
@@ -31,6 +31,7 @@ export interface Props extends BaseProps {
   displayMasthead?: boolean
   displayNavigation?: boolean
   displayVersion?: boolean
+  displayToggles?: boolean
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -39,6 +40,7 @@ const props = withDefaults(defineProps<Props>(), {
   displayMasthead: true,
   displayNavigation: true,
   displayVersion: true,
+  displayToggles: true,
 })
 
 </script>

--- a/src/layouts/WideLayout.vue
+++ b/src/layouts/WideLayout.vue
@@ -31,6 +31,7 @@ export interface Props extends BaseProps {
   displayMasthead?: boolean
   displayNavigation?: boolean
   displayVersion?: boolean
+  displayToggles?: boolean
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -39,6 +40,7 @@ const props = withDefaults(defineProps<Props>(), {
   displayMasthead: true,
   displayNavigation: true,
   displayVersion: true,
+  displayToggles: true,
 });
 
 </script>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -65,6 +65,23 @@
       "button_send_feedback": "Send Feedback",
       "verification_sent_to": "A verification was sent to"
     },
+    "UNITS": {
+      "ttl": {
+        "duration": "{count} {unit}",
+        "time": {
+          "day": "day | days",
+          "hour": "hour | hours",
+          "minute": "minute | minutes",
+          "second": "second | seconds"
+        },
+        "noOptionsAvailable": "---"
+      }
+    },
+    "secrets": {
+      "privacyOptions": "Privacy Options",
+      "selectDuration": "Select duration",
+      "expiresIn": "Expires in {duration}"
+    },
     "homepage": {
       "tagline1": "Paste a password, secret message or private link below.",
       "tagline2": "Keep sensitive info out of your email and chat logs.",

--- a/src/main.ts
+++ b/src/main.ts
@@ -51,7 +51,6 @@ async function initializeApp() {
 
   // Get the initial locale and use it to set the language
   const initialLocale = languageStore.initializeCurrentLocale(navigator.language);
-  console.log('Initial locale:', initialLocale);
 
   // Set language before mounting the app
   // This ensures correct translations are available for the initial render
@@ -93,7 +92,7 @@ async function initializeApp() {
 // Start the application initialization process
 initializeApp();
 
-// http://patorjk.com/software/taag/#p=display&f=Tmplr&t=ONETIME
+// Created with http://patorjk.com/software/taag/#p=display&f=Tmplr&t=ONETIME
 const notice = `
 ┏┓┳┓┏┓┏┳┓┳┳┳┓┏┓
 ┃┃┃┃┣  ┃ ┃┃┃┃┣
@@ -101,4 +100,4 @@ const notice = `
 
 `;
 
-console.debug(notice);
+console.log(notice);

--- a/src/router/auth.ts
+++ b/src/router/auth.ts
@@ -18,7 +18,8 @@ const routes: Array<RouteRecordRaw> = [
         displayNavigation: false,
         displayLinks: false,
         displayFeedback: false,
-        displayVersion: false,
+        displayVersion: true,
+        displayToggles: true,
       },
     },
     beforeEnter: (to, from, next) => {

--- a/src/types/onetime.d.ts
+++ b/src/types/onetime.d.ts
@@ -43,6 +43,16 @@ export interface ColonelCustomer {
   stamp: string;
 }
 
+export interface SecretOptions {
+  // Default Time-To-Live (TTL) for secrets in seconds
+  default_ttl: number; // Default: 604800 (7 days in seconds)
+
+  // Available TTL options for secret creation (in seconds)
+  // These options will be presented to users when they create a new secret
+  // Format: Array of integers representing seconds
+  ttl_options: number[]; // Default: [300, 1800, 3600, 14400, 43200, 86400, 259200, 604800, 1209600]
+}
+
 export interface PlanOptions {
   ttl: number;
   size: number;

--- a/src/types/window.d.ts
+++ b/src/types/window.d.ts
@@ -40,7 +40,7 @@
  * IDEs.
  */
 
-import { AuthenticationSettings, Customer, Plan, Metadata, AvailablePlans } from './onetime';
+import { AuthenticationSettings, Customer, Plan, Metadata, AvailablePlans, SecretOptions } from './onetime';
 import type Stripe from 'stripe';
 
 declare global {
@@ -74,6 +74,7 @@ declare global {
     stripe_subscriptions?: Stripe.Subscriptions[];
     form_fields?: { [key: string]: string };
     authentication: AuthenticationSettings;
+    secret_options: SecretOptions | undefined | null;
 
     available_plans: AvailablePlans;
     support_host?: string;

--- a/tests/unit/ruby/config.test.yaml
+++ b/tests/unit/ruby/config.test.yaml
@@ -38,6 +38,15 @@
     :secret_key: <%= ENV['AUTHENTICITY_SECRET_KEY'] || 'your-secret-key' %>
   :plans:
     :enabled: false
+  :secret_options:
+    # Default Time-To-Live (TTL) for secrets in seconds
+    # This value is used if no specific TTL is provided when creating a secret
+    :default_ttl: <%= ENV['DEFAULT_TTL'] || '604800' %>  # 7 days in seconds
+    # Available TTL options for secret creation (in seconds)
+    # These options will be presented to users when they create a new secret
+    # Format: Array of integers representing seconds
+    # Default: 5 minutes, 30 minutes, 1 hour, 4 hours, 12 hours, 1 day, 3 days, 1 week, 2 weeks
+    :ttl_options: <%= (ENV['TTL_OPTIONS'] || '300 1800 3600 14400 43200 86400 259200 604800 1209600') %>
 :redis:
   :uri: 'redis://CHANGEME@127.0.0.1:6379/0'
   :config: ./try/redis.conf

--- a/tests/unit/ruby/config.test.yaml
+++ b/tests/unit/ruby/config.test.yaml
@@ -39,9 +39,9 @@
   :plans:
     :enabled: false
   :secret_options:
-    :default_ttl: <%= ENV['DEFAULT_TTL'] || '604800' %>  # 7 days in seconds
+    :default_ttl: <%= ENV['DEFAULT_TTL'] || '43200' %>  # 7 days in seconds
     # Default: 5 minutes, 30 minutes, 1 hour, 4 hours, 12 hours, 1 day, 3 days, 1 week, 2 weeks
-    :ttl_options: <%= (ENV['TTL_OPTIONS'] || '300 1800 3600 14400 43200 86400 259200 604800 1209600') %>
+    :ttl_options: <%= (ENV['TTL_OPTIONS'] || '1800 43200 604800') %>
 :redis:
   :uri: 'redis://CHANGEME@127.0.0.1:6379/0'
   :config: ./try/redis.conf

--- a/tests/unit/ruby/config.test.yaml
+++ b/tests/unit/ruby/config.test.yaml
@@ -39,12 +39,7 @@
   :plans:
     :enabled: false
   :secret_options:
-    # Default Time-To-Live (TTL) for secrets in seconds
-    # This value is used if no specific TTL is provided when creating a secret
     :default_ttl: <%= ENV['DEFAULT_TTL'] || '604800' %>  # 7 days in seconds
-    # Available TTL options for secret creation (in seconds)
-    # These options will be presented to users when they create a new secret
-    # Format: Array of integers representing seconds
     # Default: 5 minutes, 30 minutes, 1 hour, 4 hours, 12 hours, 1 day, 3 days, 1 week, 2 weeks
     :ttl_options: <%= (ENV['TTL_OPTIONS'] || '300 1800 3600 14400 43200 86400 259200 604800 1209600') %>
 :redis:

--- a/tests/unit/ruby/try/16_config_secret_options_try.rb
+++ b/tests/unit/ruby/try/16_config_secret_options_try.rb
@@ -27,25 +27,25 @@ OT.conf[:site][:secret_options].key? :ttl_options
 
 ## Default TTL is 604800 (7 days) when ENV['DEFAULT_TTL'] is not set
 ENV['DEFAULT_TTL'] = nil
-OT::Config.load
+OT.boot! :test
 OT.conf[:site][:secret_options][:default_ttl]
-#=> 604800
+#=> 43200
 
 ## Default TTL is updated when ENV['DEFAULT_TTL'] is provided
 ENV['DEFAULT_TTL'] = '3600'
-OT::Config.load
+OT.boot! :test
 OT.conf[:site][:secret_options][:default_ttl]
 #=> 3600
 
 ## TTL options are an array of integers when ENV['TTL_OPTIONS'] is not set
 ENV['TTL_OPTIONS'] = nil
-OT::Config.load
+OT.boot! :test
 OT.conf[:site][:secret_options][:ttl_options]
-#=> [300, 1800, 3600, 14400, 43200, 86400, 259200, 604800, 1209600]
+#=> [1800, 43200, 604800]
 
 ## TTL options are updated when ENV['TTL_OPTIONS'] is provided
 ENV['TTL_OPTIONS'] = '300 3600 86400'
-OT::Config.load
+OT.boot! :test
 OT.conf[:site][:secret_options][:ttl_options]
 #=> [300, 3600, 86400]
 

--- a/tests/unit/ruby/try/16_config_secret_options_try.rb
+++ b/tests/unit/ruby/try/16_config_secret_options_try.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+# These tryouts test the secret_options configuration of the Onetime application.
+# We're testing various aspects of the secret_options configuration, including:
+# 1. Loading and accessing the secret_options configuration
+# 2. Verifying the structure of secret_options
+# 3. Checking specific configuration options (e.g., default_ttl, ttl_options)
+# 4. Testing the behavior with different environment variable settings
+
+require 'onetime'
+
+# Use the default config file for tests
+OT::Config.path = File.join(__dir__, '..', 'config.test.yaml')
+OT.boot! :test
+
+## Config has secret_options
+OT.conf[:site].key? :secret_options
+#=> true
+
+## secret_options has default_ttl
+OT.conf[:site][:secret_options].key? :default_ttl
+#=> true
+
+## secret_options has ttl_options
+OT.conf[:site][:secret_options].key? :ttl_options
+#=> true
+
+## Default TTL is 604800 (7 days) when ENV['DEFAULT_TTL'] is not set
+ENV['DEFAULT_TTL'] = nil
+OT::Config.load
+OT.conf[:site][:secret_options][:default_ttl]
+#=> 604800
+
+## Default TTL is updated when ENV['DEFAULT_TTL'] is provided
+ENV['DEFAULT_TTL'] = '3600'
+OT::Config.load
+OT.conf[:site][:secret_options][:default_ttl]
+#=> 3600
+
+## TTL options are an array of integers when ENV['TTL_OPTIONS'] is not set
+ENV['TTL_OPTIONS'] = nil
+OT::Config.load
+OT.conf[:site][:secret_options][:ttl_options]
+#=> [300, 1800, 3600, 14400, 43200, 86400, 259200, 604800, 1209600]
+
+## TTL options are updated when ENV['TTL_OPTIONS'] is provided
+ENV['TTL_OPTIONS'] = '300 3600 86400'
+OT::Config.load
+OT.conf[:site][:secret_options][:ttl_options]
+#=> [300, 3600, 86400]
+
+# Clean up environment variables after tests
+ENV['DEFAULT_TTL'] = nil
+ENV['TTL_OPTIONS'] = nil


### PR DESCRIPTION
### **User description**
This pull request introduces a new feature to set a default TTL (Time-To-Live) for secrets. The default TTL is set to 7 days, but users still have the option to set a different TTL when creating a new secret.

Supports setting the default via env var, like: `DEFAULT_TTL=1800 bundle exec thin -e dev -R config.ru -p 7143 -a 0.0.0.0 start`

The changes include:

- Adding a new configuration option `:secret_options` in the YAML configuration file to specify the default TTL and available TTL options.
- Updating the frontend to receive the `secret_options` and display the default TTL and available options when creating a new secret.
- Updating the config schema to include the new `secret_options` setting.
- Setting baseline defaults for secret TTL options in the code, allowing for fallback values and consistent handling of TTL values.
- Adding internationalization (i18n) strings for secret TTL options, enabling dynamic localization of time duration units.

Also includes:
- Adding a new `displayToggles` prop to layout components, allowing for conditional rendering of toggle components.
- Tidying up console logging for better readability.

Addresses #646


___

### **PR Type**
enhancement, documentation


___

### **Description**
- Introduced a new feature to set default and available TTL (Time-To-Live) options for secrets.
- Updated configuration files to include `secret_options` for managing secret TTL settings.
- Enhanced frontend components to utilize secret options and display TTL options dynamically.
- Improved internationalization support for TTL duration labels.
- Added documentation and examples for configuring secret options.
- Ensured backward compatibility with existing installations.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>9 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>onetime.rb</strong><dd><code>Display secret options in print banner</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/onetime.rb

- Added display of `secret_options` in the print banner.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/747/files#diff-fdca55a2ee0875c33af04f1ecd5140eee8528d6756a21ab4837f579da61f0d37">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>base.rb</strong><dd><code>Include secret options in web view initialization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/onetime/app/web/views/base.rb

<li>Fetched <code>secret_options</code> from configuration.<br> <li> Added <code>secret_options</code> to JavaScript variables.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/747/files#diff-a5d4e462fd47bbc94ac209ba3bdad2ef72c7bdb5948808941a06805e38e59836">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>config.rb</strong><dd><code>Configure default and available TTL options for secrets</code>&nbsp; &nbsp; </dd></summary>
<hr>

lib/onetime/config.rb

<li>Added default and available TTL options for secrets.<br> <li> Ensured string TTL options are converted to integers.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/747/files#diff-ef8528e98ccc09f9e1104d5942cdc820a1a35defc502edebe5a19eecb07dc8e5">+28/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>DefaultFooter.vue</strong><dd><code>Add displayToggles prop to DefaultFooter component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/layout/DefaultFooter.vue

- Added `displayToggles` prop for conditional rendering.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/747/files#diff-4598e3c5371f2a24b52ce3544f4e1dbbc0564c34ce7cce1ef8246b27cc68ba73">+8/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>SecretFormPrivacyOptions.vue</strong><dd><code>Integrate secret TTL options in Privacy Options form</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/secrets/form/SecretFormPrivacyOptions.vue

<li>Integrated secret options for TTL in the form.<br> <li> Added i18n support for duration labels.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/747/files#diff-19f51ba8fd39bdda62451f3e2ca6e48322799ceb9ce42aa31218de856bd4823c">+78/-25</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>DefaultLayout.vue</strong><dd><code>Add displayToggles prop to DefaultLayout component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/layouts/DefaultLayout.vue

- Added `displayToggles` prop for layout customization.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/747/files#diff-75d0be1e1d17ff942ae3edfebee8f65524e01039ab9ef3a8e7328213e1818bf4">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>WideLayout.vue</strong><dd><code>Add displayToggles prop to WideLayout component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/layouts/WideLayout.vue

- Added `displayToggles` prop for layout customization.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/747/files#diff-df926daa68b6017d2c7d45bca66c4d837920fdb9d13264cb621626635f4555e9">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>i18n.ts</strong><dd><code>Use debug logs for i18n locale loading</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/i18n.ts

- Replaced console logs with debug logs for i18n loading.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/747/files#diff-8159012c4a3152e6527d42d99106692a73d39150ffeabf43dc868ec5c1d764b3">+5/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>auth.ts</strong><dd><code>Enable version and toggles display in auth routes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/router/auth.ts

- Enabled `displayVersion` and `displayToggles` in auth routes.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/747/files#diff-4a2c6d2e051d3f275b881bcfdf18f2c8f24bbf61d5a27b63d8b439c2a9df776b">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Miscellaneous</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>main.ts</strong><dd><code>Clean up initial locale logging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main.ts

- Removed console log for initial locale.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/747/files#diff-4fab5baaca5c14d2de62d8d2fceef376ddddcc8e9509d86cfa5643f51b89ce3d">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>onetime.d.ts</strong><dd><code>Define SecretOptions interface for secret configuration</code>&nbsp; &nbsp; </dd></summary>
<hr>

src/types/onetime.d.ts

- Added `SecretOptions` interface for secret configuration.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/747/files#diff-4151e09ea08485a70b7ed005ebaca5e68877649b8c3e095f967f7ee7b93f5a7d">+10/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>window.d.ts</strong><dd><code>Extend global window interface with SecretOptions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/types/window.d.ts

- Included `SecretOptions` in global window interface.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/747/files#diff-045fb887144d0411250117ed9a5d44645e05e3b889ef669f76c773ba65139571">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>config.example.yaml</strong><dd><code>Add secret options example to configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

etc/config.example.yaml

- Added example configuration for `secret_options`.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/747/files#diff-623a3725e34c66751e28979fce3f78929e9c476779cea0463cde7ea59a3ffcfb">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>config.schema.yaml</strong><dd><code>Update config schema with secret options</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

etc/config.schema.yaml

- Updated schema to include `secret_options`.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/747/files#diff-7dd86676853db6bba4b1700dc6a04ffdbbc8514e4d8925effbbe70a8add0150a">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>en.json</strong><dd><code>Add i18n strings for TTL options</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/locales/en.json

- Added i18n strings for TTL duration and options.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/747/files#diff-b1791c7a47875ce85f2f1e57ef6c25a9b993660f9bcc840d8f21daac6161b5a0">+17/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>config.test.yaml</strong><dd><code>Add test configuration for secret options</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/unit/ruby/config.test.yaml

- Added test configuration for `secret_options`.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/747/files#diff-03d45dad5fa2973b945cc673a987097627eca77ee846aa81336c21f58300193a">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information