### PR TITLE
Improve footer layout and responsiveness

### DIFF
--- a/src/components/layout/DefaultFooter.vue
+++ b/src/components/layout/DefaultFooter.vue
@@ -3,13 +3,27 @@
     <div class="container mx-auto px-4 max-w-2xl">
       <FooterLinkLists v-if="displayLinks" v-bind="$props" />
 
-      <div class="flex flex-col-reverse sm:flex-row justify-between items-center pt-6 mt-6">
-        <div v-if="displayVersion" class="text-sm text-center sm:text-left w-full sm:w-auto mt-4 sm:mt-0 text-gray-600 dark:text-gray-300 order-2 sm:order-1">
+      <div class="
+        flex flex-col-reverse
+        justify-between items-center
+        pt-6 mt-6
+        space-y-6 space-y-reverse md:space-y-0
+        md:flex-row">
+        <div v-if="displayVersion"
+             class="
+          w-full md:w-auto
+          text-sm text-center md:text-left
+          text-gray-600 dark:text-gray-300">
           &copy; {{ new Date().getFullYear() }} {{ companyName }}.
           <span class="hidden md:inline">All rights reserved.</span>
         </div>
 
-        <div v-if="displayToggles" class="flex flex-wrap items-center justify-center sm:justify-end space-x-4 w-full sm:w-auto order-1 sm:order-2">
+        <div v-if="displayToggles"
+             class="
+          flex flex-wrap
+          items-center justify-center md:justify-end
+          w-full md:w-auto
+          space-x-4">
           <JurisdictionFooterNotice v-if="regionsEnabled && regions" />
 
           <ThemeToggle
@@ -26,6 +40,10 @@
     </div>
   </footer>
 </template>
+
+
+
+
 
 <script setup lang="ts">
 import { ref } from 'vue'


### PR DESCRIPTION
### **User description**
Refactors footer markup for clearer structure and readability. Aligns item order and spacing for varied screen sizes. This pull request addresses issue #775 by improving the footer layout and responsiveness on mobile devices. The changes include simplifying the footer signature layout, using a stacked or condensed version of the signature for smaller screens, ensuring proper spacing and alignment of elements within the footer, and maintaining brand identity while optimizing for readability. The footer signature will now appear less cluttered on extra small (xs) and small (sm) screen sizes in Tailwind CSS. The changes have been implemented and tested for xs and sm screen sizes, while ensuring consistency with the overall design on larger screen sizes.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Refactored the footer layout in `DefaultFooter.vue` to improve responsiveness on mobile devices.
- Adjusted flexbox properties and spacing to ensure the footer signature is less cluttered on extra small (xs) and small (sm) screen sizes.
- Ensured consistent design and readability across all screen sizes while maintaining brand identity.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DefaultFooter.vue</strong><dd><code>Refactor footer layout for better mobile responsiveness</code>&nbsp; &nbsp; </dd></summary>
<hr>

src/components/layout/DefaultFooter.vue

<li>Refactored footer layout for improved responsiveness.<br> <li> Adjusted flexbox properties for better alignment on small screens.<br> <li> Enhanced spacing and order of elements for clarity.<br> <li> Ensured consistent design across different screen sizes.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/778/files#diff-4598e3c5371f2a24b52ce3544f4e1dbbc0564c34ce7cce1ef8246b27cc68ba73">+21/-3</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information