### PR TITLE
Update domain settings to prefer CNAME records

### DIFF
--- a/lib/onetime/models/custom_domain.rb
+++ b/lib/onetime/models/custom_domain.rb
@@ -69,6 +69,7 @@ class Onetime::CustomDomain < Familia::Horreum
     :trd,
     :tld,
     :sld,
+    { :is_apex => ->(obj) { obj.apex? } },
     :_original_value,
     :txt_validation_host,
     :txt_validation_value,
@@ -165,6 +166,18 @@ class Onetime::CustomDomain < Familia::Horreum
         multi.zrem(customer.custom_domains.rediskey, self.display_domain)
       end
     end
+  end
+
+  # Checks if the domain is an apex domain.
+  # An apex domain is a domain without any subdomains.
+  #
+  # Note: A subdomain can include nested subdomains (e.g., b.a.example.com),
+  # whereas TRD (Transit Routing Domain) refers to the part directly before
+  # the SLD.
+  #
+  # @return [Boolean] true if the domain is an apex domain, false otherwise
+  def apex?
+    subdomain.empty?
   end
 
   # Generates a host and value pair for a TXT record.

--- a/src/components/VerifyDomainDetails.vue
+++ b/src/components/VerifyDomainDetails.vue
@@ -1,10 +1,11 @@
-<!-- _onetime-challenge-domainid -> 7709715a6411631ce1d447428d8a70  -->
-<!-- _onetime-challenge-domainid.status -> cd94fec5a98fd33a0d70d069acaae9  -->
+
 <template>
   <div class="max-w-2xl mx-auto p-6 bg-white dark:bg-gray-800 rounded-xl shadow-lg">
 
-    <!--<h2 class="text-2xl font-bold mb-4 text-gray-800 dark:text-white">Card Title</h2>
-    <p class="text-lg mb-6 text-gray-600 dark:text-gray-300">Intro text for this card</p>-->
+    <h2 class="text-2xl font-bold mb-4 text-gray-800 dark:text-white">Domain Verification Steps</h2>
+    <p class="text-lg mb-6 text-gray-600 dark:text-gray-300">Follow these steps to verify domain ownership and elevate your online presence:</p>
+
+
 
     <ol class="space-y-6 mb-8">
       <li class="bg-gray-50 dark:bg-gray-700 p-4 rounded-lg">
@@ -22,7 +23,8 @@
         </div>
 
       </li>
-      <li class="bg-gray-50 dark:bg-gray-700 p-4 rounded-lg">
+      <li v-if="domain?.is_apex"
+          class="bg-gray-50 dark:bg-gray-700 p-4 rounded-lg">
         <h3 class="font-semibold text-lg mb-2 text-gray-800 dark:text-white">2. Create the A record</h3>
 
         <div class="space-y-2">
@@ -34,7 +36,29 @@
           <DetailField label="Value"
                        :value="cluster?.cluster_ip" />
         </div>
+      </li>
+      <li v-else
+          class="bg-gray-50 dark:bg-gray-700 p-4 rounded-lg">
+        <h3 class="font-semibold text-lg mb-2 text-gray-800 dark:text-white">2. Create the CNAME record</h3>
 
+        <div class="space-y-2">
+          <DetailField v-if="domain?.is_apex"
+                       label="Type"
+                       value="A" />
+          <DetailField v-else
+                       label="Type"
+                       value="CNAME" />
+
+          <DetailField label="Host"
+                       :value="domain?.trd ? domain.trd : '@'"
+                       :appendix="`.${domain?.base_domain}`" />
+          <DetailField v-if="domain?.is_apex"
+                       label="Value"
+                       :value="cluster?.cluster_ip" />
+          <DetailField v-else
+                       label="Value"
+                       :value="cluster?.vhost_target" />
+        </div>
       </li>
       <li class="bg-gray-50 dark:bg-gray-700 p-4 rounded-lg">
         <h3 class="font-semibold text-lg mb-2 text-gray-800 dark:text-white">3. Wait for propagation</h3>
@@ -62,7 +86,7 @@
             class="h-5 w-5 text-brandcomp-700 mr-2 mt-0.5 flex-shrink-0"
             aria-hidden="true" />
       <p class="text-sm text-gray-500 dark:text-gray-400">
-        It may take a few minutes for your SSL certificate to take effect once you've pointed your DNS A record.
+        It may take a few minutes for your SSL certificate to take effect.
       </p>
     </div>
   </div>

--- a/src/types/onetime.d.ts
+++ b/src/types/onetime.d.ts
@@ -114,6 +114,7 @@ export interface CustomDomain extends BaseApiRecord {
   display_domain: string;
   base_domain: string;
   subdomain: string;
+  is_apex: boolean;
   trd: string;
   tld: string;
   sld: string;

--- a/src/views/account/AccountDomainVerify.vue
+++ b/src/views/account/AccountDomainVerify.vue
@@ -1,4 +1,3 @@
-
 <template>
   <div class="">
 
@@ -6,28 +5,39 @@
 
     <h1 class="text-3xl font-bold mb-6 text-gray-900 dark:text-white">Verify your domain</h1>
 
-    <DomainVerificationInfo
-      v-if="domain?.vhost?.last_monitored_unix"
-      :domain="domain"
-      mode="table"
-    />
-    <p v-else class="text-lg mb-6 text-gray-600 dark:text-gray-300">
+    <DomainVerificationInfo v-if="domain?.vhost?.last_monitored_unix"
+                            :domain="domain"
+                            mode="table" />
+    <p v-else
+       class="text-lg mb-6 text-gray-600 dark:text-gray-300">
       Before we can activate links for
       <span class=" bg-white dark:bg-gray-800  text-brand-600 dark:text-brand-400">{{ domain?.display_domain }}</span>,
       you'll need to complete these steps.
     </p>
 
-    <MoreInfoText textColor="text-brandcomp-800 dark:text-gray-100" bgColor="bg-white dark:bg-gray-800">
-      <div class="px-6 py-6">
+    <MoreInfoText textColor="text-brandcomp-800 dark:text-gray-100"
+                  bgColor="bg-white dark:bg-gray-800">
+      <div class="px-6 py-6 prose">
         <div class="max-w-xl text-base text-gray-600 dark:text-gray-300">
           <p>
-            In order to connect your domain, you'll need to have a DNS A record that points
-            <span class="font-bold bg-white dark:bg-gray-800 px-2 text-brand-600 dark:text-brand-400">{{ domain?.display_domain }}</span> at <span
-                  :title="cluster?.cluster_name?? ''" class="bg-white dark:bg-gray-800 px-2">{{ cluster?.cluster_ip }}</span>. If you already have an A record for
-            that
-            address, please change it to point at <span :title="cluster?.cluster_name?? ''" class="bg-white dark:bg-gray-800 px-2">{{ cluster?.cluster_ip }}</span>
+            In order to connect your domain, you'll need to have a CNAME record in your DNS that points
+            <span
+                  class="font-bold bg-white dark:bg-gray-800 px-2 text-brand-600 dark:text-brand-400">{{ domain?.display_domain }}</span>
+            at <span :title="cluster?.cluster_name ?? ''"
+                  class="bg-white dark:bg-gray-800 px-2">{{ cluster?.vhost_target }}</span>. If you already have
+            a CNAME record for that address, please change it to point at
+            <span :title="cluster?.cluster_name ?? ''"
+                  class="bg-white dark:bg-gray-800 px-2">{{ cluster?.vhost_target }}</span>
             and remove any other A, AAAA,
             or CNAME records for that exact address.
+          </p>
+          <p v-if="domain?.is_apex"
+             class="bg-yellow-100 border-l-4 border-yellow-500 text-yellow-700 p-4">
+            <!-- Disclaimer for apex domains -->
+            <strong>Important:</strong> Please note that for apex domains (e.g., <span
+                  class="font-bold bg-white dark:bg-gray-800 px-2 text-brand-600 dark:text-brand-400">{{ domain?.display_domain }}</span>),
+            a CNAME record is not allowed.
+            Instead, you'll need to create an A record. Details on how to do this are provided further down the page.
           </p>
         </div>
         <div class="mt-4 text-sm">
@@ -39,14 +49,13 @@
       </div>
     </MoreInfoText>
 
-    <VerifyDomainDetails
-      v-if="domain && cluster"
-      :domain="domain"
-      :cluster="cluster"
-      :withVerifyCTA="allowVerifyCTA"
-      @domainVerify="handleDomainVerify"
-    />
-    <p v-else class="text-gray-600 dark:text-gray-400">Loading domain information...</p>
+    <VerifyDomainDetails v-if="domain && cluster"
+                         :domain="domain"
+                         :cluster="cluster"
+                         :withVerifyCTA="allowVerifyCTA"
+                         @domainVerify="handleDomainVerify" />
+    <p v-else
+       class="text-gray-600 dark:text-gray-400">Loading domain information...</p>
 
   </div>
 </template>
@@ -61,12 +70,11 @@ import DomainVerificationInfo from '@/components/DomainVerificationInfo.vue';
 import DashboardTabNav from '@/components/dashboard/DashboardTabNav.vue';
 
 
-
 const route = useRoute();
 const domain = ref<CustomDomain | null>(null);
 const cluster = ref<CustomDomainCluster | null>(null);
 
-console.log("VerifyDomain.ts", route.params.domain );
+console.debug("VerifyDomain.ts", route.params.domain);
 
 const fetchDomain = async (): Promise<void> => {
   const domainName: string = route.params.domain as string;
@@ -106,24 +114,21 @@ const fetchDomain = async (): Promise<void> => {
     }
   } catch (error) {
     console.error('Error fetching domain:', error);
-    // Handle error (e.g., show error message to user)
   }
 };
 
 const allowVerifyCTA = ref(false);
 
 const handleDomainVerify = async (data: CustomDomainApiResponse) => {
-  console.log('Domain verified: refreshing domain info', data);
-
+  console.debug('Domain verified: refreshing domain info', data);
   await fetchDomain();
 };
 
 
 onMounted(() => {
-  console.log('AccountDomainVerify component mounted');
-  console.log('Domain parameter:', route.params.domain);
+  console.debug('AccountDomainVerify component mounted');
+  console.debug('Domain parameter:', route.params.domain);
   fetchDomain();
-
 });
 
 </script>


### PR DESCRIPTION
### **User description**
We are updating our domain settings instructions to recommend using CNAME records instead of A records. This change will provide more flexibility and easier management for our users when configuring their custom domains. The pull request includes the following changes:

- Added apex domain check to CustomDomain model

- Updated domain verification to prefer CNAME records

- Replaced A record instructions with CNAME for easier integration

- Added conditional logic to handle apex domains with A records

- Improved user instructions and readability of verification steps

Fixes #773


___

### **PR Type**
Documentation, Enhancement


___

### **Description**
- Updated domain settings instructions to recommend using CNAME records instead of A records for better flexibility and management.
- Added a method to check if a domain is an apex domain and included an `is_apex` boolean flag in the `CustomDomain` model.
- Enhanced domain verification steps to prefer CNAME records, with conditional logic for handling apex domains.
- Improved user instructions and readability of domain verification steps, including a disclaimer for apex domains.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>custom_domain.rb</strong><dd><code>Add apex domain check and flag in CustomDomain model</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/onetime/models/custom_domain.rb

<li>Added a method to check if a domain is an apex domain.<br> <li> Included <code>is_apex</code> boolean flag in safe dump fields.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/797/files#diff-96ec102155ead1bc098be94a8beb0038951284ed58a35e54fe5360b1cb9e7a37">+13/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>VerifyDomainDetails.vue</strong><dd><code>Update domain verification to prefer CNAME records</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/VerifyDomainDetails.vue

<li>Updated domain verification steps to prefer CNAME records.<br> <li> Added conditional logic for apex domains.<br> <li> Improved user instructions for domain verification.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/797/files#diff-a5cf5437728036256a2bda42d1ee62714fc989585bde2064850416f6f3b4bd13">+30/-6</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>onetime.d.ts</strong><dd><code>Add is_apex property to CustomDomain interface</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/types/onetime.d.ts

- Added `is_apex` boolean property to `CustomDomain` interface.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/797/files#diff-4151e09ea08485a70b7ed005ebaca5e68877649b8c3e095f967f7ee7b93f5a7d">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AccountDomainVerify.vue</strong><dd><code>Update domain verification instructions for CNAME usage</code>&nbsp; &nbsp; </dd></summary>
<hr>

src/views/account/AccountDomainVerify.vue

<li>Changed instructions to use CNAME records instead of A records.<br> <li> Added disclaimer for apex domains.<br> <li> Improved readability of domain verification instructions.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/797/files#diff-a99eec767a55e12c6e0a525b5fa1b047168b7ef84945382f29023339f1dbcd22">+35/-30</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information