### PR TITLE
Update cluster_host setting and UI components

### DIFF
--- a/etc/config.schema.yaml
+++ b/etc/config.schema.yaml
@@ -42,8 +42,8 @@
   :cluster:
     :type: str(required=False)
     :api_key: str(required=False)
-    :cluster_ip: str(required=False)   # either
-    :cluster_host: str(required=False) # or
+    :cluster_ip: str(required=False)
+    :cluster_host: str(required=False)
     :cluster_name: str()
     :vhost_target: str()
 

--- a/lib/onetime/cluster.rb
+++ b/lib/onetime/cluster.rb
@@ -17,16 +17,18 @@ module Onetime
       @api_key = nil
       @cluster_ip = nil
       @cluster_name = nil
+      @cluster_host = nil
       @vhost_target = nil
 
       module ClassMethods
-        attr_accessor :type, :api_key, :cluster_ip, :cluster_name, :vhost_target
+        attr_accessor :type, :api_key, :cluster_ip, :cluster_name, :cluster_host, :vhost_target
 
         def cluster_safe_dump
           {
             type: Features.type,
             cluster_ip: Features.cluster_ip,
             cluster_name: Features.cluster_name,
+            cluster_host: Features.cluster_host,
             vhost_target: Features.vhost_target
           }
         end

--- a/lib/onetime/config.rb
+++ b/lib/onetime/config.rb
@@ -104,6 +104,7 @@ module Onetime
         klass.api_key = cluster[:api_key]
         klass.cluster_ip = cluster[:cluster_ip]
         klass.cluster_name = cluster[:cluster_name]
+        klass.cluster_host = cluster[:cluster_host]
         klass.vhost_target = cluster[:vhost_target]
         OT.ld "Domains config: #{cluster}"
         unless klass.api_key

--- a/lib/onetime/version.rb
+++ b/lib/onetime/version.rb
@@ -14,7 +14,8 @@ module Onetime
     end
 
     def self.inspect
-      '%s (%s)' % [to_s, @version[:BUILD]]
+      build = @version[:BUILD].to_s
+      build.empty? ? to_s : "#{to_s} (#{build})"
     end
 
     def self.load_config
@@ -40,11 +41,11 @@ module Onetime
     def self.get_build_info
       # Get the commit hash from .commit_hash.txt
       commit_hash_file = File.join(OT::HOME, '.commit_hash.txt')
-      commit_hash = 'unknown'
+      commit_hash = 'pristine'
       if File.exist?(commit_hash_file)
         commit_hash = File.read(commit_hash_file).strip
       else
-        $stderr.puts "Warning: Commit hash file not found. Using default value 'unknown'."
+        $stderr.puts "Warning: Commit hash file not found. Using default value '#{commit_hash}'."
       end
       commit_hash
     end

--- a/src/components/FeedbackForm.vue
+++ b/src/components/FeedbackForm.vue
@@ -3,7 +3,7 @@
     <!-- Feedback Form -->
     <div class="bg-white dark:bg-gray-800 shadow-md rounded-lg overflow-hidden">
       <div class="p-6">
-        <h2 class="text-xl font-semibold mb-4 text-gray-800 dark:text-gray-200">Submit Your Feedback</h2>
+
         <form @submit.prevent="submitForm"
               class="space-y-4">
           <input type="hidden"
@@ -13,40 +13,42 @@
                  name="shrimp"
                  :value="csrfStore.shrimp" />
 
-          <div class="flex flex-col sm:flex-row gap-4">
+          <div class="flex flex-col gap-4">
             <div class="flex-grow">
               <label for="feedback-message"
                      class="sr-only">Your feedback</label>
-              <input id="feedback-message"
-                     v-model="feedbackMessage"
-                     type="text"
-                     name="msg"
-                     class="w-full px-4 py-2 border border-gray-300 rounded-md
+              <textarea
+                id="feedback-message"
+                v-model="feedbackMessage"
+                name="msg"
+                rows="3"
+                class="w-full px-4 py-2 border border-gray-300 rounded-md resize-y
                   focus:border-brand-500 focus:ring-2 focus:ring-brand-500 focus:outline-none
                   dark:bg-gray-700 dark:border-gray-600 dark:text-gray-200"
-                     autocomplete="off"
-                     :placeholder="$t('web.COMMON.feedback_text')"
-                     aria-label="Enter your feedback">
+                :placeholder="$t('web.COMMON.feedback_text')"
+                aria-label="Enter your feedback"></textarea>
               <input type="hidden"
                      name="tz"
                      :value="userTimezone" />
               <input type="hidden"
                      name="version"
                      :value="ot_version" />
-
             </div>
-            <button type="submit"
-                    :disabled="isSubmitting"
-                    :class="[
-                      'px-6 py-2 font-medium text-white transition duration-150 ease-in-out rounded-md',
-                      showRedButton
-                        ? 'bg-brand-600 hover:bg-brand-700 focus:ring-brand-500'
-                        : 'bg-gray-500 hover:bg-gray-600 focus:ring-gray-400',
-                      isSubmitting ? 'opacity-50 cursor-not-allowed' : ''
-                    ]"
-                    aria-label="Send feedback">
-              {{ isSubmitting ? 'Sending...' : $t('web.COMMON.button_send_feedback') }}
-            </button>
+
+            <div class="flex justify-end">
+              <button type="submit"
+                      :disabled="isSubmitting"
+                      :class="[
+                        'px-6 py-2 font-medium text-white transition duration-150 ease-in-out rounded-md w-full sm:w-auto',
+                        showRedButton
+                          ? 'bg-brand-600 hover:bg-brand-700 focus:ring-brand-500'
+                          : 'bg-gray-500 hover:bg-gray-600 focus:ring-gray-400',
+                        isSubmitting ? 'opacity-50 cursor-not-allowed' : ''
+                      ]"
+                      aria-label="Send feedback">
+                {{ isSubmitting ? 'Sending...' : $t('web.COMMON.button_send_feedback') }}
+              </button>
+            </div>
           </div>
 
           <AltchaChallenge v-if="!cust" />

--- a/src/components/FeedbackForm.vue
+++ b/src/components/FeedbackForm.vue
@@ -60,7 +60,7 @@
 
       <div class="bg-gray-50 dark:bg-gray-700 px-6 py-4">
         <h3 class="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-          Information included with your feedback:
+          When you submit feedback, we'll see:
         </h3>
         <ul class="space-y-2 text-sm text-gray-600 dark:text-gray-400">
           <li v-if="cust"

--- a/src/components/FeedbackModalForm.vue
+++ b/src/components/FeedbackModalForm.vue
@@ -65,7 +65,7 @@
          class="mt-4 text-green-600 dark:text-green-400">{{ success }}</div>
 
     <div class="mt-6 text-sm text-gray-500 dark:text-gray-400">
-      <h3 class="font-medium text-lg mb-2 text-gray-500">Information included with your feedback:</h3>
+      <h3 class="font-medium text-lg mb-2 text-gray-500">When you submit feedback, we'll see:</h3>
       <ul class="space-y-1">
         <li v-if="cust">• Customer ID: {{ cust?.custid }}</li>
         <li>• Timezone: {{ userTimezone }}</li>

--- a/src/components/FeedbackToggle.vue
+++ b/src/components/FeedbackToggle.vue
@@ -5,7 +5,7 @@
                px-3 py-1.5
                text-sm font-medium
                bg-gray-200 dark:bg-gray-700
-               text-gray-600 dark:text-gray-300
+               text-gray-700 dark:text-gray-300
                hover:bg-slate-50 dark:hover:bg-slate-900
                focus:outline-none focus:ring-2 focus:ring-brand-500 focus:ring-offset-2
                dark:focus:ring-brand-400
@@ -14,7 +14,8 @@
 
       <span class="inline">Feedback</span>
       <svg xmlns="http://www.w3.org/2000/svg"
-           class="h-4 w-4 text-gray-500 transition-colors group-hover:text-brand-500 dark:text-gray-400 dark:group-hover:text-brand-400"
+           class="h-4 w-4 text-gray-500 dark:text-gray-300 group-hover:text-brand-500
+                  dark:group-hover:text-brand-400 transition-colors"
            fill="none"
            viewBox="0 0 24 24"
            stroke="currentColor">
@@ -24,6 +25,7 @@
               d="M7 8h10M7 12h4m1 8l-4-4H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-3l-4 4z" />
       </svg>
     </button>
+
     <Teleport to="body">
       <Transition enter-active-class="transition ease-out duration-200"
                   enter-from-class="opacity-0 translate-y-1"
@@ -42,16 +44,16 @@
 
 
 <script setup lang="ts">
-import { ref } from 'vue'
-import FeedbackModal from './modals/FeedbackModal.vue'
+import { ref } from 'vue';
+import FeedbackModal from './modals/FeedbackModal.vue';
 
-const isFeedbackModalOpen = ref(false)
+const isFeedbackModalOpen = ref(false);
 
 const toggleFeedbackModal = () => {
-  isFeedbackModalOpen.value = true
-}
+  isFeedbackModalOpen.value = true;
+};
 
 const closeFeedbackModal = () => {
-  isFeedbackModalOpen.value = false
-}
+  isFeedbackModalOpen.value = false;
+};
 </script>

--- a/src/components/JurisdictionFooterNotice.vue
+++ b/src/components/JurisdictionFooterNotice.vue
@@ -1,8 +1,9 @@
 <template>
   <div ref="dropdownRef"
        class="relative inline-flex items-center space-x-2 px-3 py-1 rounded-full
-           bg-gray-100 text-base font-medium text-gray-700 shadow-sm
-           dark:bg-gray-800 dark:text-gray-300
+           bg-gray-100 text-base font-medium shadow-sm
+           text-gray-500 dark:text-gray-400
+           dark:bg-gray-800
            transition-all duration-100 ease-in-out hover:shadow-md">
     <span class="sr-only">Current jurisdiction:</span>
     <button @click="toggleDropdown"
@@ -46,7 +47,7 @@
 
         <!-- List Title -->
         <li
-            class="px-3 py-2 text-xs font-semibold font-brand text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+            class="px-3 py-2 text-xs font-semibold font-brand text-gray-700 dark:text-gray-100 uppercase tracking-wider">
           Regions
         </li>
 
@@ -54,8 +55,9 @@
         <li v-for="jurisdiction in jurisdictions"
             :key="jurisdiction.identifier"
             class="relative py-2 pl-3 pr-9 cursor-default select-none font-brand text-base
+                  text-gray-700 dark:text-gray-50
                  hover:bg-brand-100 dark:hover:bg-brand-600 transition-colors duration-200"
-            :class="{ 'bg-brand-50 dark:bg-brand-500': currentJurisdiction.identifier === jurisdiction.identifier }"
+            :class="{ 'bg-brand-50 dark:bg-brandcompdim-900': currentJurisdiction.identifier === jurisdiction.identifier }"
             role="option"
             :aria-selected="currentJurisdiction.identifier === jurisdiction.identifier">
           <a :href="`https://${jurisdiction.domain}/signup`"
@@ -74,7 +76,7 @@
             </span>
             <span v-if="currentJurisdiction.identifier === jurisdiction.identifier"
                   class="absolute inset-y-0 right-0 flex items-center pr-4 text-brand-600
-                   dark:text-brand-300">
+                   dark:text-brand-400">
               <svg class="h-5 w-5"
                    xmlns="http://www.w3.org/2000/svg"
                    viewBox="0 0 20 20"

--- a/src/components/JurisdictionFooterNotice.vue
+++ b/src/components/JurisdictionFooterNotice.vue
@@ -56,7 +56,7 @@
             :key="jurisdiction.identifier"
             class="relative py-2 pl-3 pr-9 cursor-default select-none font-brand text-base
                   text-gray-700 dark:text-gray-50
-                 hover:bg-brand-100 dark:hover:bg-brand-600 transition-colors duration-200"
+                 hover:bg-brand-100 dark:hover:bg-brandcompdim-800 transition-colors duration-200"
             :class="{ 'bg-brand-50 dark:bg-brandcompdim-900': currentJurisdiction.identifier === jurisdiction.identifier }"
             role="option"
             :aria-selected="currentJurisdiction.identifier === jurisdiction.identifier">

--- a/src/components/VerifyDomainDetails.vue
+++ b/src/components/VerifyDomainDetails.vue
@@ -57,7 +57,7 @@
                        :value="cluster?.cluster_ip" />
           <DetailField v-else
                        label="Value"
-                       :value="cluster?.vhost_target" />
+                       :value="cluster?.cluster_host" />
         </div>
       </li>
       <li class="bg-gray-50 dark:bg-gray-700 p-4 rounded-lg">

--- a/src/components/layout/DefaultFooter.vue
+++ b/src/components/layout/DefaultFooter.vue
@@ -1,7 +1,7 @@
 <template>
   <footer class="
     w-full min-w-[320px]
-    py-8
+    py-16
     bg-gray-100 dark:bg-gray-800
     transition-all duration-300"
           aria-label="Site footer">
@@ -9,7 +9,7 @@
       <FooterLinkLists v-if="displayLinks"
                        v-bind="$props" />
 
-      <div class="flex flex-col space-y-6 pt-6 mt-6">
+      <div class="flex flex-col space-y-6 mt-6">
         <div class="
           flex
           items-center justify-between
@@ -19,14 +19,14 @@
           <JurisdictionFooterNotice v-if="regionsEnabled && regions" />
 
           <ThemeToggle class="
-            text-gray-600 dark:text-gray-300
+            text-gray-500 dark:text-gray-400
             hover:text-gray-800 dark:hover:text-gray-100
             transition-colors duration-200"
                        aria-label="Toggle dark mode" />
 
           <FeedbackToggle v-if="displayFeedback && authentication.enabled"
                           class="
-            text-gray-600 dark:text-gray-300
+            text-gray-500 dark:text-gray-400
             hover:text-gray-800 dark:hover:text-gray-100
             transition-colors duration-200"
                           aria-label="Provide feedback" />
@@ -36,9 +36,9 @@
              class="
           w-full
           text-sm text-center
-          text-gray-600 dark:text-gray-300">
+          text-gray-500 dark:text-gray-400">
           &copy; {{ new Date().getFullYear() }} {{ companyName }}.
-          All rights reserved.
+
         </div>
       </div>
     </div>

--- a/src/components/layout/DefaultFooter.vue
+++ b/src/components/layout/DefaultFooter.vue
@@ -9,13 +9,26 @@
       <FooterLinkLists v-if="displayLinks"
                        v-bind="$props" />
 
-      <div class="flex flex-col space-y-6 mt-6">
-        <div class="
-          flex
-          items-center justify-between
-          w-full
-          max-w-[400px]
-          mx-auto">
+      <div class="
+        flex flex-col-reverse
+        justify-between items-center
+        mt-6
+        space-y-6 space-y-reverse md:space-y-0
+        md:flex-row">
+        <div v-if="displayVersion"
+             class="
+          w-full md:w-auto
+          text-sm text-center md:text-left
+          text-gray-500 dark:text-gray-400">
+          &copy; {{ new Date().getFullYear() }} {{ companyName }}.
+        </div>
+
+        <div v-if="displayToggles"
+             class="
+          flex flex-wrap
+          items-center justify-center md:justify-end
+          w-full md:w-auto
+          space-x-4">
           <JurisdictionFooterNotice v-if="regionsEnabled && regions" />
 
           <ThemeToggle class="
@@ -30,15 +43,6 @@
             hover:text-gray-800 dark:hover:text-gray-100
             transition-colors duration-200"
                           aria-label="Provide feedback" />
-        </div>
-
-        <div v-if="displayVersion"
-             class="
-          w-full
-          text-sm text-center
-          text-gray-500 dark:text-gray-400">
-          &copy; {{ new Date().getFullYear() }} {{ companyName }}.
-
         </div>
       </div>
     </div>
@@ -69,5 +73,5 @@ withDefaults(defineProps<Props>(), {
 });
 
 const { regions_enabled: regionsEnabled, regions } = useWindowProps(['regions_enabled', 'regions']);
-const companyName = ref('Onetime Secret');
+const companyName = ref('OnetimeSecret.com');
 </script>

--- a/src/components/layout/DefaultFooter.vue
+++ b/src/components/layout/DefaultFooter.vue
@@ -9,27 +9,13 @@
       <FooterLinkLists v-if="displayLinks"
                        v-bind="$props" />
 
-      <div class="
-        flex flex-col-reverse
-        justify-between items-center
-        pt-6 mt-6
-        space-y-6 space-y-reverse md:space-y-0
-        md:flex-row">
-        <div v-if="displayVersion"
-             class="
-          w-full md:w-auto
-          text-sm text-center md:text-left
-          text-gray-600 dark:text-gray-300">
-          &copy; {{ new Date().getFullYear() }} {{ companyName }}.
-          <span class="hidden md:inline">All rights reserved.</span>
-        </div>
-
-        <div v-if="displayToggles"
-             class="
-          flex flex-wrap
-          items-center justify-center md:justify-end
-          w-full md:w-auto
-          space-x-4">
+      <div class="flex flex-col space-y-6 pt-6 mt-6">
+        <div class="
+          flex
+          items-center justify-between
+          w-full
+          max-w-[400px]
+          mx-auto">
           <JurisdictionFooterNotice v-if="regionsEnabled && regions" />
 
           <ThemeToggle class="
@@ -45,17 +31,22 @@
             transition-colors duration-200"
                           aria-label="Provide feedback" />
         </div>
+
+        <div v-if="displayVersion"
+             class="
+          w-full
+          text-sm text-center
+          text-gray-600 dark:text-gray-300">
+          &copy; {{ new Date().getFullYear() }} {{ companyName }}.
+          All rights reserved.
+        </div>
       </div>
     </div>
   </footer>
 </template>
 
-
-
-
-
 <script setup lang="ts">
-import { ref } from 'vue'
+import { ref } from 'vue';
 import type { Props as DefaultProps } from '@/layouts/DefaultLayout.vue';
 import FeedbackToggle from '@/components/FeedbackToggle.vue';
 import ThemeToggle from '@/components/ThemeToggle.vue';
@@ -64,10 +55,10 @@ import JurisdictionFooterNotice from '@/components/JurisdictionFooterNotice.vue'
 import { useWindowProps } from '@/composables/useWindowProps';
 
 export interface Props extends DefaultProps {
-  displayFeedback?: boolean
-  displayLinks?: boolean
-  displayVersion?: boolean
-  displayToggles?: boolean
+  displayFeedback?: boolean;
+  displayLinks?: boolean;
+  displayVersion?: boolean;
+  displayToggles?: boolean;
 }
 
 withDefaults(defineProps<Props>(), {
@@ -77,6 +68,6 @@ withDefaults(defineProps<Props>(), {
   displayToggles: true,
 });
 
-const { regions_enabled: regionsEnabled, regions } = useWindowProps(['regions_enabled', 'regions'])
+const { regions_enabled: regionsEnabled, regions } = useWindowProps(['regions_enabled', 'regions']);
 const companyName = ref('Onetime Secret');
 </script>

--- a/src/components/layout/DefaultHeader.vue
+++ b/src/components/layout/DefaultHeader.vue
@@ -1,5 +1,5 @@
 <template>
-  <header class="bg-white dark:bg-gray-900 ">
+  <header class="bg-white dark:bg-gray-900">
     <div class="container mx-auto px-4 py-4 min-w-[320px] max-w-2xl">
       <div v-if="displayMasthead"
            class="w-full">
@@ -9,10 +9,12 @@
                          class="flex items-center">
               <img id="logo"
                    src="@/assets/img/onetime-logo-v3-xl.svg"
-                   class="rounded-md w-12 h-12 sm:w-16 sm:h-16"
+                   class="w-12 h-12 sm:w-16 sm:h-16 rounded-md"
                    aria-label="Onetime Secret"
                    alt="Logo">
-              <span class="ml-2 text-xl font-brand font-bold text-gray-800 dark:text-white">Onetime Secret</span>
+              <span class="ml-2 text-xl font-bold font-brand text-gray-800 dark:text-white">
+                Onetime Secret
+              </span>
             </router-link>
           </div>
 
@@ -23,7 +25,7 @@
                              :colonel="colonel" />
               <a href="#"
                  @click="openSettingsModal"
-                 class="text-gray-600 dark:text-gray-300 hover:text-gray-800 dark:hover:text-white transition-colors duration-200"
+                 class="text-gray-600 hover:text-gray-800 dark:text-gray-300 dark:hover:text-white transition-colors duration-200"
                  title="Your Account">{{ $t('web.COMMON.header_settings') }}</a>
 
               <SettingsModal :is-open="isSettingsModalOpen"
@@ -31,7 +33,7 @@
 
               <span class="text-gray-400">|</span>
               <router-link to="/logout"
-                           class="text-gray-600 dark:text-gray-300 hover:text-gray-800 dark:hover:text-white transition-colors duration-200"
+                           class="text-gray-600 hover:text-gray-800 dark:text-gray-300 dark:hover:text-white transition-colors duration-200"
                            title="Log out of Onetime Secret">{{ $t('web.COMMON.header_logout') }}</router-link>
             </template>
 
@@ -40,20 +42,20 @@
                 <router-link v-if="authentication.signup"
                              to="/signup"
                              title="Signup - Individual and Business plans"
-                             class="font-bold text-gray-600 dark:text-gray-300 hover:text-gray-800 dark:hover:text-white transition-colors duration-200">
+                             class="font-bold text-gray-600 hover:text-gray-800 dark:text-gray-300 dark:hover:text-white transition-colors duration-200">
                   {{ $t('web.COMMON.header_create_account') }}
                 </router-link>
                 <span class="text-gray-400">|</span>
                 <router-link to="/about"
                              title="About Onetime Secret"
-                             class="text-gray-600 dark:text-gray-300 hover:text-gray-800 dark:hover:text-white transition-colors duration-200">
+                             class="text-gray-600 hover:text-gray-800 dark:text-gray-300 dark:hover:text-white transition-colors duration-200">
                   {{ $t('web.COMMON.header_about') }}
                 </router-link>
                 <span class="text-gray-400">|</span>
                 <router-link v-if="authentication.signin"
                              to="/signin"
                              title="Log in to Onetime Secret"
-                             class="text-gray-600 dark:text-gray-300 hover:text-gray-800 dark:hover:text-white transition-colors duration-200">
+                             class="text-gray-600 hover:text-gray-800 dark:text-gray-300 dark:hover:text-white transition-colors duration-200">
                   {{ $t('web.COMMON.header_sign_in') }}
                 </router-link>
               </template>
@@ -61,7 +63,7 @@
               <router-link v-else
                            to="/about"
                            title="About Onetime Secret"
-                           class="text-gray-600 dark:text-gray-300 hover:text-gray-800 dark:hover:text-white transition-colors duration-200">
+                           class="text-gray-600 hover:text-gray-800 dark:text-gray-300 dark:hover:text-white transition-colors duration-200">
                 {{ $t('web.COMMON.header_about') }}
               </router-link>
             </template>
@@ -72,6 +74,8 @@
   </header>
 </template>
 
+
+
 <script setup lang="ts">
 import HeaderUserNav from '@/components/layout/HeaderUserNav.vue';
 import SettingsModal from '@/components/modals/SettingsModal.vue';
@@ -81,8 +85,8 @@ import { computed, ref } from 'vue';
 
 // Define the props for this layout, extending the BaseLayout props
 export interface Props extends BaseProps {
-  displayMasthead?: boolean
-  displayNavigation?: boolean
+  displayMasthead?: boolean;
+  displayNavigation?: boolean;
 }
 
 const props = withDefaults(defineProps<Props>(), {

--- a/src/components/layout/FooterLinkLists.vue
+++ b/src/components/layout/FooterLinkLists.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="">
-    <div class="grid grid-cols-2 md:grid-cols-3 gap-8 mb-8 py-5 pl-4 sm:pl-8 md:pl-16">
+    <div class="grid grid-cols-2 md:grid-cols-3 gap-8 mb-8 py-6 pl-4 sm:pl-8 md:pl-16">
 
       <!-- Company links -->
       <div class="space-y-4">

--- a/src/components/layout/FooterLinkLists.vue
+++ b/src/components/layout/FooterLinkLists.vue
@@ -5,20 +5,20 @@
       <!-- Company links -->
       <div class="space-y-4">
         <h3 class="font-semibold text-gray-800 dark:text-gray-200 text-xl">Company</h3>
-        <ul class="space-y-2">
+        <ul class="prose dark:prose-invert font-brand space-y-2">
           <li>
             <router-link to="/about"
-                        class="text-gray-600 dark:text-gray-300 hover:text-brand-500 dark:hover:text-brand-400 transition-colors duration-300 text-base"
+                        class="text-gray-600 dark:text-gray-400 hover:text-brand-500 dark:hover:text-brand-400 transition-colors duration-300 text-xl md:text-lg"
                         aria-label="Learn about our company">About</router-link>
           </li>
           <li v-if="plansEnabled && authentication.enabled">
             <router-link to="/pricing"
-                        class="text-gray-600 dark:text-gray-300 hover:text-brand-500 dark:hover:text-brand-400 transition-colors duration-300 text-base"
+                        class="text-gray-600 dark:text-gray-400 hover:text-brand-500 dark:hover:text-brand-400 transition-colors duration-300 text-xl md:text-lg"
                         aria-label="View our subscription pricing">Pricing</router-link>
           </li>
           <li v-if="supportHost">
             <a :href="`${supportHost}/blog`"
-              class="text-gray-600 dark:text-gray-300 hover:text-brand-500 dark:hover:text-brand-400 transition-colors duration-300 text-base"
+              class="text-gray-600 dark:text-gray-400 hover:text-brand-500 dark:hover:text-brand-400 transition-colors duration-300 text-xl md:text-lg"
               aria-label="Read our latest blog posts"
               target="_blank"
               rel="noopener noreferrer">Blog</a>
@@ -29,10 +29,10 @@
       <!-- Resources links -->
       <div class="space-y-4">
         <h3 class="font-semibold text-gray-800 dark:text-gray-200 text-xl">Resources</h3>
-        <ul class="space-y-2">
+        <ul class="prose dark:prose-invert font-brand space-y-2">
           <li>
             <a href="https://github.com/onetimesecret/onetimesecret"
-              class="text-gray-600 dark:text-gray-300 hover:text-brand-500 dark:hover:text-brand-400 transition-colors duration-300 text-base"
+              class="text-gray-600 dark:text-gray-400 hover:text-brand-500 dark:hover:text-brand-400 transition-colors duration-300 text-xl md:text-lg"
               aria-label="View our source code on GitHub"
               target="_blank"
               rel="noopener noreferrer">GitHub</a>
@@ -40,20 +40,20 @@
           <li v-if="supportHost">
             <a :href="`${supportHost}/docs`"
               aria-label="Access our documentation"
-              class="text-gray-600 dark:text-gray-300 hover:text-brand-500 dark:hover:text-brand-400 transition-colors duration-300 text-base"
+              class="text-gray-600 dark:text-gray-400 hover:text-brand-500 dark:hover:text-brand-400 transition-colors duration-300 text-xl md:text-lg"
               target="_blank"
               rel="noopener noreferrer">Docs</a>
           </li>
           <li v-if="supportHost">
             <a :href="`${supportHost}/docs/rest-api`"
               aria-label="Explore our API documentation"
-              class="text-gray-600 dark:text-gray-300 hover:text-brand-500 dark:hover:text-brand-400 transition-colors duration-300 text-base"
+              class="text-gray-600 dark:text-gray-400 hover:text-brand-500 dark:hover:text-brand-400 transition-colors duration-300 text-xl md:text-lg"
               target="_blank"
               rel="noopener noreferrer">API</a>
           </li>
           <li>
             <a href="https://status.onetimesecret.com/"
-              class="text-gray-600 dark:text-gray-300 hover:text-brand-500 dark:hover:text-brand-400 transition-colors duration-300 text-base"
+              class="text-gray-600 dark:text-gray-400 hover:text-brand-500 dark:hover:text-brand-400 transition-colors duration-300 text-xl md:text-lg"
               aria-label="Check our service status"
               target="_blank"
               rel="noopener noreferrer">Status</a>
@@ -64,20 +64,20 @@
       <!-- Legal links -->
       <div class="space-y-4 col-span-2 md:col-span-1">
         <h3 class="font-semibold text-gray-800 dark:text-gray-200 text-xl">Legals</h3>
-        <ul class="space-y-2">
+        <ul class="prose dark:prose-invert font-brand space-y-2">
           <li>
             <router-link to="/info/privacy"
-                        class="text-gray-600 dark:text-gray-300 hover:text-brand-500 dark:hover:text-brand-400 transition-colors duration-300 text-base"
+                        class="text-gray-600 dark:text-gray-400 hover:text-brand-500 dark:hover:text-brand-400 transition-colors duration-300 text-xl md:text-lg"
                         aria-label="Read our Privacy Policy">Privacy</router-link>
           </li>
           <li>
             <router-link to="/info/terms"
-                        class="text-gray-600 dark:text-gray-300 hover:text-brand-500 dark:hover:text-brand-400 transition-colors duration-300 text-base"
+                        class="text-gray-600 dark:text-gray-400 hover:text-brand-500 dark:hover:text-brand-400 transition-colors duration-300 text-xl md:text-lg"
                         aria-label="View our Terms and Conditions">Terms</router-link>
           </li>
           <li>
             <router-link to="/info/security"
-                        class="text-gray-600 dark:text-gray-300 hover:text-brand-500 dark:hover:text-brand-400 transition-colors duration-300 text-base"
+                        class="text-gray-600 dark:text-gray-400 hover:text-brand-500 dark:hover:text-brand-400 transition-colors duration-300 text-xl md:text-lg"
                         aria-label="Learn about our security measures">Security</router-link>
           </li>
         </ul>

--- a/src/components/modals/FeedbackModal.vue
+++ b/src/components/modals/FeedbackModal.vue
@@ -8,7 +8,7 @@
       <div class="bg-white dark:bg-gray-800 p-6 rounded-lg w-full max-w-md max-h-[90vh] overflow-y-auto shadow-xl">
         <div class="flex justify-between items-center mb-6">
           <h2 id="feedback-modal-title" class="text-2xl font-semibold text-gray-900 dark:text-white">
-            Provide Feedback
+            Share your feedback
           </h2>
           <button @click="close"
                   class="text-gray-400 hover:text-gray-500 dark:hover:text-white transition-colors"

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -68,7 +68,11 @@ export function createAppRouter() {
         name: 'NotFound',
         component: NotFound
       }
-    ]
+    ],
+    scrollBehavior() {
+      // always scroll to top
+      return { top: 0 }
+    },
   })
 
   // Set up router guards for authentication and locale settings

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -69,9 +69,13 @@ export function createAppRouter() {
         component: NotFound
       }
     ],
-    scrollBehavior() {
+    scrollBehavior(to, from, savedPosition) {
       // always scroll to top
-      return { top: 0 }
+      if (savedPosition) {
+        return savedPosition
+      } else {
+        return { top: 0 }
+      }
     },
   })
 

--- a/src/types/onetime.d.ts
+++ b/src/types/onetime.d.ts
@@ -132,6 +132,7 @@ export interface CustomDomainCluster extends BaseApiRecord {
   type: string;
   cluster_ip: string;
   cluster_name: string;
+  cluster_host: string;
   vhost_target: string;
 }
 

--- a/src/views/Feedback.vue
+++ b/src/views/Feedback.vue
@@ -2,7 +2,7 @@
   <section class="mb-8">
     <h3 class="text-2xl font-semibold mb-4 text-gray-900 dark:text-gray-100"
         aria-label="Feedback Form">
-      Give us your feedback
+      Share your feedback
     </h3>
 
     <FeedbackForm :showRedButton="true" />
@@ -10,7 +10,7 @@
     <!-- Founder's Message -->
     <div class="bg-white dark:bg-gray-800 shadow-md rounded-lg overflow-hidden my-4">
       <div class="p-6">
-        <h2 class="text-xl font-semibold mb-4 text-gray-800 dark:text-gray-200">A Note from Delano, Founder of Onetime
+        <h2 class="text-xl font-semibold mb-4 text-gray-800 dark:text-gray-200">A note from Delano, founder of Onetime
           Secret</h2>
         <div class="space-y-3 text-gray-600 dark:text-gray-400">
           <p>
@@ -30,7 +30,6 @@
         </div>
       </div>
     </div>
-
 
   </section>
 

--- a/src/views/Homepage.vue
+++ b/src/views/Homepage.vue
@@ -1,10 +1,10 @@
 <template>
   <div class="container mx-auto py-1 min-w-[320px] max-w-2xl">
     <HomepageTaglines v-if="!authenticated"
-                      class="mb-8" />
+                      class="mb-6" />
 
     <HomepagePlansCTA v-if="authenticationSettings.signup"
-                      class="mb-8" />
+                      class="mb-6" />
 
     <SecretForm class="mb-8"
                 :withRecipient="false"

--- a/src/views/Homepage.vue
+++ b/src/views/Homepage.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="container mx-auto py-6 min-w-[320px] max-w-2xl">
+  <div class="container mx-auto py-1 min-w-[320px] max-w-2xl">
     <HomepageTaglines v-if="!authenticated"
                       class="mb-8" />
 

--- a/src/views/account/AccountDomainVerify.vue
+++ b/src/views/account/AccountDomainVerify.vue
@@ -24,10 +24,10 @@
             <span
                   class="font-bold bg-white dark:bg-gray-800 px-2 text-brand-600 dark:text-brand-400">{{ domain?.display_domain }}</span>
             at <span :title="cluster?.cluster_name ?? ''"
-                  class="bg-white dark:bg-gray-800 px-2">{{ cluster?.vhost_target }}</span>. If you already have
+                  class="bg-white dark:bg-gray-800 px-2">{{ cluster?.cluster_host }}</span>. If you already have
             a CNAME record for that address, please change it to point at
             <span :title="cluster?.cluster_name ?? ''"
-                  class="bg-white dark:bg-gray-800 px-2">{{ cluster?.vhost_target }}</span>
+                  class="bg-white dark:bg-gray-800 px-2">{{ cluster?.cluster_host }}</span>
             and remove any other A, AAAA,
             or CNAME records for that exact address.
           </p>


### PR DESCRIPTION
### **User description**
This pull request updates the `cluster_host` setting in the configuration schema and model attributes. It also enables the use of `cluster_host` in UI components for CNAME records. Additionally, it ensures the integration of `cluster_host` in domain verification views. 

This update also improves the usability and consistency of the feedback form by replacing the input with a textarea. It also standardizes the wording across feedback components. The pull request fixes the Vue Router scroll behavior to ensure that pages scroll to the top on navigation for a consistent user experience. There are also several minor adjustments for visual consistency, including raising the content slightly higher on the page, dimming the default toggle and dropdown text, matching the footer links styles with v0.18.2, and dimming the footer text to match v0.18.2.


___

### **PR Type**
enhancement, bug_fix


___

### **Description**
- Added `cluster_host` attribute to various components and configurations to enhance domain verification and UI components.
- Updated feedback forms to use textarea for better usability and standardized text across components.
- Improved visual consistency across UI components, including footer and feedback sections.
- Fixed Vue Router scroll behavior to ensure pages scroll to the top on navigation.
- Enhanced version handling by updating the default commit hash and improving build info display.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>16 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>cluster.rb</strong><dd><code>Add `cluster_host` attribute to Features module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/onetime/cluster.rb

<li>Added <code>cluster_host</code> attribute to the <code>Features</code> module.<br> <li> Included <code>cluster_host</code> in the <code>cluster_safe_dump</code> method.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/799/files#diff-699445e5aa7c37708799c15fee27d4a5d42d0373deac593f6c2eb586e1ffde1c">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>config.rb</strong><dd><code>Integrate `cluster_host` in configuration loading</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/onetime/config.rb

- Set `cluster_host` in the configuration loading process.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/799/files#diff-ef8528e98ccc09f9e1104d5942cdc820a1a35defc502edebe5a19eecb07dc8e5">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>version.rb</strong><dd><code>Improve version handling for build info</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/onetime/version.rb

<li>Updated <code>inspect</code> method to handle empty build info.<br> <li> Changed default commit hash value to 'pristine'.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/799/files#diff-7ae2984adcd7d716babf74af1be3f42005f9fe8d672dae7a4761033aeb92ee21">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>FeedbackForm.vue</strong><dd><code>Update FeedbackForm to use textarea</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/FeedbackForm.vue

<li>Replaced input with textarea for feedback message.<br> <li> Adjusted button styling and layout.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/799/files#diff-ce24f5e417a46920e988e991f8ae55a9bc06733369fa32b9ec76cdc79bd806bc">+25/-23</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>FeedbackModalForm.vue</strong><dd><code>Standardize feedback information text</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/FeedbackModalForm.vue

- Standardized feedback information text.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/799/files#diff-1b91927b2b0c81d34519b6ef1408e6fe77891aa2f6542261ed827ac712b60aaf">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>FeedbackToggle.vue</strong><dd><code>Improve FeedbackToggle styling and script consistency</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/FeedbackToggle.vue

<li>Adjusted text color for better visual hierarchy.<br> <li> Added semicolons for consistency in script.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/799/files#diff-67b4e71c240f2e19ae77229be0119e67b12627b571ea2e74424b552d0dda35b6">+11/-9</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>JurisdictionFooterNotice.vue</strong><dd><code>Enhance JurisdictionFooterNotice styling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/JurisdictionFooterNotice.vue

- Updated text and hover colors for better contrast.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/799/files#diff-82ac2a41a11c1278731d836454bd4e2b455d8e7ecb10d65d40f3042cb3c27107">+8/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>VerifyDomainDetails.vue</strong><dd><code>Use `cluster_host` in VerifyDomainDetails</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/VerifyDomainDetails.vue

<li>Changed value display to use <code>cluster_host</code> instead of <code>vhost_target</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/799/files#diff-a5cf5437728036256a2bda42d1ee62714fc989585bde2064850416f6f3b4bd13">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>DefaultFooter.vue</strong><dd><code>Update DefaultFooter layout and styling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/layout/DefaultFooter.vue

<li>Increased footer padding for better layout.<br> <li> Adjusted text color for consistency.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/799/files#diff-4598e3c5371f2a24b52ce3544f4e1dbbc0564c34ce7cce1ef8246b27cc68ba73">+12/-17</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>FooterLinkLists.vue</strong><dd><code>Enhance FooterLinkLists layout and styling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/layout/FooterLinkLists.vue

- Increased padding and adjusted text size for links.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/799/files#diff-c16a5d5ad9b267906145047be1569ce3a4a5ea9c96552c2bd336a6a9faeaa566">+14/-14</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>FeedbackModal.vue</strong><dd><code>Standardize FeedbackModal title text</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/modals/FeedbackModal.vue

- Standardized modal title text.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/799/files#diff-839ebc6ca1b264cd71c76b2f36a6bbf3d1038d7e357cff6a572db67f923cf087">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>Feedback.vue</strong><dd><code>Standardize Feedback view title text</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/views/Feedback.vue

- Standardized feedback section title text.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/799/files#diff-1dd1556f5f413581ce25096891596f83f2964f33b60d737dc59f72ae58323058">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>Homepage.vue</strong><dd><code>Improve Homepage layout consistency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/views/Homepage.vue

- Adjusted padding for better layout consistency.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/799/files#diff-336b5d303e4c5db8a8e68e3036ce9981c2d570da62e1b4a7ab4c43eb31925354">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>AccountDomainVerify.vue</strong><dd><code>Update domain verification instructions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/views/account/AccountDomainVerify.vue

- Updated CNAME record instructions to use `cluster_host`.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/799/files#diff-a99eec767a55e12c6e0a525b5fa1b047168b7ef84945382f29023339f1dbcd22">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>onetime.d.ts</strong><dd><code>Update TypeScript definitions for cluster_host</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/types/onetime.d.ts

- Added `cluster_host` to `CustomDomainCluster` interface.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/799/files#diff-4151e09ea08485a70b7ed005ebaca5e68877649b8c3e095f967f7ee7b93f5a7d">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>config.schema.yaml</strong><dd><code>Update configuration schema with cluster_host</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

etc/config.schema.yaml

- Added `cluster_host` to the configuration schema.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/799/files#diff-7dd86676853db6bba4b1700dc6a04ffdbbc8514e4d8925effbbe70a8add0150a">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Fix Vue Router scroll behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/router/index.ts

- Fixed Vue Router scroll behavior to scroll to top on navigation.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/799/files#diff-ed3eadd8a0891daf6ad6d6fabe767371981e5626c8ee467e694455fcbbb63710">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information