### PR TITLE
Global Banner Communication Enhancements and updated verification

### DIFF
--- a/lib/onetime.rb
+++ b/lib/onetime.rb
@@ -45,7 +45,7 @@ module Onetime
 
   module ClassMethods
     attr_accessor :mode
-    attr_reader :conf, :locales, :instance, :sysinfo, :emailer, :global_secret
+    attr_reader :conf, :locales, :instance, :sysinfo, :emailer, :global_secret, :global_banner
     attr_writer :debug
 
     def debug
@@ -84,7 +84,8 @@ module Onetime
       load_fortunes
       load_plans
       connect_databases
-      print_banner unless mode?(:test)
+      check_global_banner
+      print_log_banner unless mode?(:test)
 
       @conf # return the config
 
@@ -143,7 +144,17 @@ module Onetime
       OT::Utils.fortunes ||= File.readlines(File.join(Onetime::HOME, 'etc', 'fortunes'))
     end
 
-    def print_banner
+    def check_global_banner
+      @global_banner = Familia.redis(0).get('global_banner')
+      if global_banner
+        OT.li "Global banner: #{OT.global_banner}"
+      else
+        OT.li "No global banner set."
+      end
+
+    end
+
+    def print_log_banner
       redis_info = Familia.redis.info
       OT.li "---  ONETIME #{OT.mode} v#{OT::VERSION.inspect}  #{'---' * 3}"
       OT.li "system: #{@sysinfo.platform} (ruby #{RUBY_VERSION})"

--- a/lib/onetime/app/web/views/base.rb
+++ b/lib/onetime/app/web/views/base.rb
@@ -54,6 +54,9 @@ module Onetime
 
         self[:jsvars] = []
 
+        # Add the global site banner if there is one
+        self[:jsvars] << jsvar(:global_banner, OT.global_banner) if OT.global_banner
+
         # Pass the authentication flag settings to the frontends.
         self[:jsvars] << jsvar(:authentication, authentication)
         self[:jsvars] << jsvar(:shrimp, sess.add_shrimp) if sess

--- a/lib/onetime/cluster.rb
+++ b/lib/onetime/cluster.rb
@@ -53,6 +53,11 @@ module Onetime
       # @param records [Array<Hash>] An array of hashes representing DNS records to check.
       #   Each hash should contain keys like 'type', 'name', and 'value'.
       #
+      # The data list is returned back to you with injected fields for 'match' and
+      # 'actual_values'. The 'match' field will be true if there is any record/value
+      # that matches the 'match_against' field, regardless of how many other
+      # records/values there may be for that address.
+      #
       # @return [HTTParty::Response] The response from the API call.
       #
       # @example
@@ -63,8 +68,37 @@ module Onetime
       #   ]
       #   response = Approximated.check_records(api_key, records)
       #
+      # @response example
+      # {
+      #   "records": [
+      #     {
+      #         "actual_values": [
+      #             "93.184.216.34"
+      #         ],
+      #         "match": false,
+      #         "address": "example.com",
+      #         "match_against": "12.345.678.90",
+      #         "type": "a"
+      #     }
+      #   ]
+      # }
+      #
       def self.check_records_exist(api_key, records)
         post('/dns/check-records-exist',
+          headers: { 'api-key' => api_key },
+          body: { records: records }.to_json)
+      end
+
+      # Checks the existence of the DNS records and whether the values match exactly.
+      #
+      # The inputs and outputs are the same as `check_records_exist`.
+      #
+      # The 'match' field will only be true if there is exactly one DNS
+      # record/value for each address, and it must exactly match the
+      # 'match_against' value you've set.
+      #
+      def self.check_records_match_exactly(api_key, records)
+        post('/dns/check-records-match-exactly',
           headers: { 'api-key' => api_key },
           body: { records: records }.to_json)
       end

--- a/lib/onetime/cluster.rb
+++ b/lib/onetime/cluster.rb
@@ -169,10 +169,16 @@ module Onetime
         response
       end
 
-      # Retrieves a virtual host by its incoming address.
+      # Retrieves the virtual host by the incoming address.
       #
-      # @param api_key [String] The API key for authenticating with the Approximated API.
-      # @param incoming_address [String] The incoming address of the virtual host to retrieve.
+      # @param api_key [String] The API key for authenticating with the API.
+      # @param incoming_address [String] The incoming address to search for the virtual host.
+      # @param force [Boolean] Whether to force check the virtual host.
+      #
+      # re: force-check, setting to true will have it check again before
+      # responding. This may take up to 30 seconds if the domain DNS is
+      # not pointed yet, and is rate limited to minimize accidentally
+      # DDOSing your application.
       #
       # @return [HTTParty::Response] The response from the API call.
       #
@@ -181,7 +187,8 @@ module Onetime
       #   incoming_address = 'custom.example.com'
       #   response = Approximated.get_vhost_by_incoming_address(api_key, incoming_address)
       #
-      # @raise [HTTParty::ResponseError] If the API returns a 404 (Virtual Host not found) or 401 (Invalid API key) error.
+      # @raise [HTTParty::ResponseError] If the API returns a 404 (Virtual
+      #        Host not found) or 401 (Invalid API key) error.
       #
       #  {
       #  "data" => {
@@ -204,9 +211,12 @@ module Onetime
       #    "user_message" => "..."
       #  }
       #}
-      def self.get_vhost_by_incoming_address(api_key, incoming_address)
-        response = get("/vhosts/by/incoming/#{incoming_address}",
-          headers: { 'api-key' => api_key })
+      #
+      def self.get_vhost_by_incoming_address(api_key, incoming_address, force = false)
+        url_path = "/vhosts/by/incoming/#{incoming_address}"
+        url_path += '/force-check' if force
+
+        response = get(url_path, headers: { 'api-key' => api_key })
 
         case response.code
         when 404

--- a/lib/onetime/cluster.rb
+++ b/lib/onetime/cluster.rb
@@ -63,8 +63,8 @@ module Onetime
       # @example
       #   api_key = 'your_api_key_here'
       #   records = [
-      #     { type: 'A', name: 'example.com', value: '192.0.2.1' },
-      #     { type: 'MX', name: 'example.com', value: 'mail.example.com' }
+      #     { type: 'A', address: 'example.com', match_against: '192.0.2.1' },
+      #     { type: 'MX', address: 'example.com', match_against: 'mail.example.com' }
       #   ]
       #   response = Approximated.check_records(api_key, records)
       #

--- a/lib/onetime/logic/domains.rb
+++ b/lib/onetime/logic/domains.rb
@@ -262,7 +262,7 @@ module Onetime::Logic
           custom_domain.verified! found_match  # save immediately
         else
           msg = payload['message']
-          OT.le "[VerifyDomain.verify_txt_record] %s %s [%i]"  % [display_domain, res.code, code]
+          OT.le "[VerifyDomain.verify_txt_record] %s %s [%i]"  % [display_domain, res.code, msg]
         end
 
       end

--- a/lib/onetime/logic/domains.rb
+++ b/lib/onetime/logic/domains.rb
@@ -210,6 +210,11 @@ module Onetime::Logic
         # sense running the get logic more than we need to.
         limit_action :verify_domain
 
+        if OT::Cluster::Features.api_key.to_s.empty?
+          OT.le "[VerifyDomain.raise_concerns] Approximated API key not set"
+          raise_form_error "Communications error"
+        end
+
         super
       end
 
@@ -217,20 +222,49 @@ module Onetime::Logic
         super
 
         refresh_vhost
+        verify_txt_record
       end
 
       def refresh_vhost
         api_key = OT::Cluster::Features.api_key
-        if api_key.to_s.empty?
-          return OT.info "[VerifyDomain.refresh_vhost] Approximated API key not set"
-        end
+
         res = OT::Cluster::Approximated.get_vhost_by_incoming_address(api_key, display_domain)
-        payload = res.parsed_response
-        OT.info "[VerifyDomain.refresh_vhost] %s" % payload
-        OT.ld ""
-        custom_domain.vhost = payload['data'].to_json
-        custom_domain.updated = OT.now.to_i
-        custom_domain.save
+        if res.code == 200
+          payload = res.parsed_response
+          OT.info "[VerifyDomain.refresh_vhost] %s" % payload
+
+          custom_domain.vhost = payload['data'].to_json
+          custom_domain.updated = OT.now.to_i
+          custom_domain.resolving = (payload.dig('data', 'is_resolving') || false).to_s
+          custom_domain.save
+        else
+          msg = payload['message']
+          OT.le "[VerifyDomain.refresh_vhost] %s %s [%i]"  % [display_domain, res.code, code]
+        end
+      end
+
+      def verify_txt_record
+        api_key = OT::Cluster::Features.api_key
+        records = [{
+          type: 'TXT',
+          address: custom_domain.validation_record,
+          match_against: custom_domain.txt_validation_value
+        }]
+        OT.info "[VerifyDomain.verify_txt_record] %s" % records
+        res = OT::Cluster::Approximated.check_records_match_exactly(api_key, records)
+        if res.code == 200
+          payload = res.parsed_response
+          match_records = payload.dig('records')
+          found_match = match_records.any? { |record| record['match'] == true }
+          OT.info "[VerifyDomain.verify_txt_record] %s (matched:%s)" % [match_records, found_match]
+
+          # Check if any record has match: true
+          custom_domain.verified! found_match  # save immediately
+        else
+          msg = payload['message']
+          OT.le "[VerifyDomain.verify_txt_record] %s %s [%i]"  % [display_domain, res.code, code]
+        end
+
       end
     end
   end

--- a/lib/onetime/models/custom_domain.rb
+++ b/lib/onetime/models/custom_domain.rb
@@ -53,7 +53,8 @@ class Onetime::CustomDomain < Familia::Horreum
   field :txt_validation_value
   field :status
   field :vhost
-  field :verified
+  field :verified # the txt record matches?
+  field :resolving # there's a valid A or CNAME record?
   field :created
   field :updated
   field :_original_value
@@ -212,6 +213,17 @@ class Onetime::CustomDomain < Familia::Horreum
     # These can now be displayed to the customer for them
     # to continue the validation process.
     [record_host, record_value]
+  end
+
+  # The fully qualified domain name for the TXT record.
+  #
+  # Used to validate the domain ownership by the customer
+  # via the Approximated check_records API.
+  #
+  # e.g. `_onetime-challenge-domainid.froogle.com`
+  #
+  def validation_record
+    [txt_validation_host, base_domain].join('.')
   end
 
   module ClassMethods

--- a/package.json
+++ b/package.json
@@ -36,8 +36,10 @@
   "dependencies": {
     "@headlessui/vue": "^1.7.23",
     "@intlify/core": "^9.14.1",
+    "@types/dompurify": "^3.0.5",
     "altcha": "^1.0.0",
     "axios": "^1.7.7",
+    "dompurify": "^3.1.7",
     "pinia": "^2.2.4",
     "pnpm": "^9.12.0",
     "stripe": "^17.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,12 +14,18 @@ importers:
       '@intlify/core':
         specifier: ^9.14.1
         version: 9.14.1
+      '@types/dompurify':
+        specifier: ^3.0.5
+        version: 3.0.5
       altcha:
         specifier: ^1.0.0
         version: 1.0.0
       axios:
         specifier: ^1.7.7
         version: 1.7.7
+      dompurify:
+        specifier: ^3.1.7
+        version: 3.1.7
       pinia:
         specifier: ^2.2.4
         version: 2.2.4(typescript@5.6.2)(vue@3.5.11(typescript@5.6.2))
@@ -625,6 +631,9 @@ packages:
   '@tsconfig/node22@22.0.0':
     resolution: {integrity: sha512-twLQ77zevtxobBOD4ToAtVmuYrpeYUh3qh+TEp+08IWhpsrIflVHqQ1F1CiPxQGL7doCdBIOOCF+1Tm833faNg==}
 
+  '@types/dompurify@3.0.5':
+    resolution: {integrity: sha512-1Wg0g3BtQF7sSb27fJQAKck1HECM6zV1EB66j8JH9i3LCjYabJa0FSdiSgsD5K/RbrsR0SiraKacLB+T8ZVYAg==}
+
   '@types/estree@1.0.6':
     resolution: {integrity: sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==}
 
@@ -642,6 +651,9 @@ packages:
 
   '@types/node@22.7.4':
     resolution: {integrity: sha512-y+NPi1rFzDs1NdQHHToqeiX2TIS79SWEAw9GYhkkx8bD0ChpfqC+n2j5OXOCpzfojBEBt6DnEnnG9MY0zk1XLg==}
+
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
   '@types/web-bluetooth@0.0.20':
     resolution: {integrity: sha512-g9gZnnXVq7gM7v3tJCWV/qw7w+KeOlSHAhgF9RytFyifW6AF61hdT2ucrYhPq9hLs5JIryeupHV3qGk95dH9ow==}
@@ -1163,6 +1175,9 @@ packages:
   domhandler@4.3.1:
     resolution: {integrity: sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==}
     engines: {node: '>= 4'}
+
+  dompurify@3.1.7:
+    resolution: {integrity: sha512-VaTstWtsneJY8xzy7DekmYWEOZcmzIe3Qb3zPd4STve1OBTa+e+WmS1ITQec1fZYXI3HCsOZZiSMpG6oxoWMWQ==}
 
   domutils@2.8.0:
     resolution: {integrity: sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==}
@@ -2906,6 +2921,10 @@ snapshots:
 
   '@tsconfig/node22@22.0.0': {}
 
+  '@types/dompurify@3.0.5':
+    dependencies:
+      '@types/trusted-types': 2.0.7
+
   '@types/estree@1.0.6': {}
 
   '@types/linkify-it@5.0.0': {}
@@ -2924,6 +2943,8 @@ snapshots:
   '@types/node@22.7.4':
     dependencies:
       undici-types: 6.19.8
+
+  '@types/trusted-types@2.0.7': {}
 
   '@types/web-bluetooth@0.0.20': {}
 
@@ -3537,6 +3558,8 @@ snapshots:
   domhandler@4.3.1:
     dependencies:
       domelementtype: 2.3.0
+
+  dompurify@3.1.7: {}
 
   domutils@2.8.0:
     dependencies:

--- a/src/App.vue
+++ b/src/App.vue
@@ -34,6 +34,7 @@ const {
   ot_version,
   plans_enabled,
   support_host,
+  global_banner,
 } = useWindowProps([
   'authenticated',
   'authentication',
@@ -41,6 +42,7 @@ const {
   'ot_version',
   'plans_enabled',
   'support_host',
+  'global_banner',
 ]);
 
 // Layout Switching: In the script section, the layout computed property
@@ -65,6 +67,8 @@ const layoutProps = computed(() => {
     plansEnabled: plans_enabled.value,
     defaultLocale: locale.value,
     isDefaultLocale: true,
+    hasGlobalBanner: !!global_banner.value, // not null or undefined
+    globalBanner: global_banner.value,
   };
 
   // Merge with route.meta.layoutProps if they exist

--- a/src/components/GlobalBroadcast.vue
+++ b/src/components/GlobalBroadcast.vue
@@ -8,6 +8,8 @@
 <script setup lang="ts">
 import { Icon } from '@iconify/vue';
 import MovingGlobules from '@/components/MovingGlobules.vue';
+import DOMPurify from 'dompurify';
+import { computed } from 'vue';
 
 // TypeScript with Composition API
 //
@@ -20,22 +22,37 @@ import MovingGlobules from '@/components/MovingGlobules.vue';
 
 
 export interface Props {
-  content: string;
+  content: string; // Can contain HTML
   show: boolean;
 }
-
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const props = withDefaults(defineProps<Props>(), {
   content: "Welcome to the Global Broadcast!",
   show: false,
-})
+});
+
+
+// Function to decode HTML entities
+function decodeHTMLEntities(html: string) {
+  const txt = document.createElement('textarea');
+  txt.innerHTML = html;
+  return txt.value;
+}
+
+// Computed property for decoded and sanitized content
+const sanitizedContent = computed(() => {
+  const decodedContent = decodeHTMLEntities(props.content);
+  const sanitizeConfig = {
+    ALLOWED_TAGS: ['a'],
+    ALLOWED_ATTR: ['href', 'target', 'rel', 'class']
+  };
+  return DOMPurify.sanitize(decodedContent, sanitizeConfig);
+});
 
 </script>
 
 <template>
-
   <div v-if="show"
-       class="relative isolate flex items-center gap-x-6 overflow-hidden bg-gray-50  dark:bg-gray-900 px-6 py-2.5 sm:px-3.5 sm:before:flex-1">
+       class="relative isolate flex items-center gap-x-6 overflow-hidden bg-gray-50 dark:bg-gray-900 px-6 py-2.5 sm:px-3.5 sm:before:flex-1">
     <div class="absolute left-[max(-7rem,calc(50%-52rem))] top-1/2 -z-10 -translate-y-1/2 transform-gpu blur-2xl"
          aria-hidden="true">
       <div class="aspect-[577/310] w-[36.0625rem] bg-gradient-to-r from-[#dc4a22] to-[#fcf4e8] opacity-30"
@@ -51,29 +68,25 @@ const props = withDefaults(defineProps<Props>(), {
       <div class="aspect-[577/310] w-[36.0625rem] bg-gradient-to-r from-[#dc4a22] to-[#fcf4e8] opacity-30"
            style="clip-path: polygon(74.8% 41.9%, 97.2% 73.2%, 100% 34.9%, 92.5% 0.4%, 87.5% 0%, 75% 28.6%, 58.5% 54.6%, 50.1% 56.8%, 46.9% 44%, 48.3% 17.4%, 24.7% 53.9%, 0% 27.9%, 11.9% 74.2%, 24.9% 54.1%, 68.6% 100%, 74.8% 41.9%)" />
     </div>
-    <p class="text-sm leading-6 text-gray-900 dark:text-gray-100">
-      <a href="#">
-        <strong class="font-semibold"></strong>
-
-        <div class="text-base font-brand leading-6 text-gray-900 dark:text-gray-100">
-          <div class="relative flex items-center space-x-3">
-            <svg class="h-6 w-6 opacity-60" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5.882V19.24a1.76 1.76 0 01-3.417.592l-2.147-6.15M18 13a3 3 0 100-6M5.436 13.683A4.001 4.001 0 017 6h1.832c4.1 0 7.625-1.234 9.168-3v14c-1.543-1.766-5.067-3-9.168-3H7a3.988 3.988 0 01-1.564-.317z" />
-            </svg>
-            <a href="#">
-              {{ content }}
-            </a>
-          </div>
-        </div>
-
-        <!--&nbsp;<span aria-hidden="true">&rarr;</span>-->
-      </a>
-    </p>
+    <div class="text-base font-brand leading-6 text-gray-900 dark:text-gray-100">
+      <div class="relative flex items-center space-x-3">
+        <svg class="h-6 w-6 opacity-60"
+             xmlns="http://www.w3.org/2000/svg"
+             fill="none"
+             viewBox="0 0 24 24"
+             stroke="currentColor">
+          <path stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M11 5.882V19.24a1.76 1.76 0 01-3.417.592l-2.147-6.15M18 13a3 3 0 100-6M5.436 13.683A4.001 4.001 0 017 6h1.832c4.1 0 7.625-1.234 9.168-3v14c-1.543-1.766-5.067-3-9.168-3H7a3.988 3.988 0 01-1.564-.317z" />
+        </svg>
+        <span v-html="sanitizedContent"></span>
+      </div>
+    </div>
     <div class="flex flex-1 justify-end">
       <button type="button"
               class="-m-3 p-3 focus-visible:outline-offset-[-4px]">
         <span class="sr-only">Dismiss</span>
-
         <Icon icon="heroicons-solid:xmarkicon"
               class="h-5 w-5 text-gray-900 dark:text-gray-100"
               aria-hidden="true" />

--- a/src/components/layout/FooterLinkLists.vue
+++ b/src/components/layout/FooterLinkLists.vue
@@ -17,7 +17,7 @@
                         aria-label="View our subscription pricing">Pricing</router-link>
           </li>
           <li v-if="supportHost">
-            <a :href="`${supportHost}/blog`"
+            <a :href="`https://blog.onetimesecret.com`"
               class="text-gray-600 dark:text-gray-400 hover:text-brand-500 dark:hover:text-brand-400 transition-colors duration-300 text-xl md:text-lg"
               aria-label="Read our latest blog posts"
               target="_blank"

--- a/src/layouts/BaseLayout.vue
+++ b/src/layouts/BaseLayout.vue
@@ -6,7 +6,7 @@
     <div class="w-full h-1 bg-brand-500 fixed top-0 left-0 z-50"></div>
 
     <!-- Good morning Vietnam -->
-    <GlobalBroadcast :show="false" content="" />
+    <GlobalBroadcast :show="hasGlobalBanner" :content="globalBanner" />
 
     <!-- Header content, Ramos territory -->
     <slot name="header"></slot>
@@ -32,12 +32,16 @@ export interface Props {
   onetimeVersion: string
   plansEnabled?: boolean
   supportHost?: string
+  hasGlobalBanner: boolean
+  globalBanner?: string
 }
 
 withDefaults(defineProps<Props>(), {
   authenticated: false,
   colonel: false,
   plansEnabled: false,
+  hasGlobalBanner: false,
+  globalBanner: '',
 })
 
 </script>

--- a/src/types/window.d.ts
+++ b/src/types/window.d.ts
@@ -105,5 +105,9 @@ declare global {
     // Used by the pre-Vue colour mode detection to go inert once
     // the Vue app takes control over the UI. See index.html.
     enjoyTheVue: boolean;
+
+    // When present, the global banner is displayed at the top of the
+    // page. NOTE: Can contain HTML.
+    global_banner?: string;
   }
 }


### PR DESCRIPTION
### **User description**
This pull request introduces a new method to verify if DNS records match exactly and expands unit tests to cover the new functionality. It also adds a resolving field and a validation method to track valid DNS TXT records and aid in domain ownership checks. Additionally, the pull request expands the VerifyDomain logic to match TXT records as well, improves error handling and diagnostics in domain verification routines, and enhances global_banner support by introducing DOMPurify to sanitize HTML content in banners and improving the frontend to show global banners across the application from a redis key. The pull request includes file changes to package.json, index.html, main.ts, layout.ts, CustomDomain.rb, Onetime.rb, and various dependency updates.


___

### **PR Type**
enhancement, tests


___

### **Description**
- Introduced exact DNS record match verification functionality, enhancing domain verification processes.
- Added global banner support across the application, including backend retrieval and frontend display.
- Integrated DOMPurify to sanitize HTML content in global banners, improving security.
- Expanded unit tests to cover new DNS record match functionality.
- Updated dependencies to include DOMPurify and its TypeScript types.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>10 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>onetime.rb</strong><dd><code>Add global banner support and logging improvements.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/onetime.rb

<li>Added <code>global_banner</code> attribute to class methods.<br> <li> Introduced <code>check_global_banner</code> method to retrieve and log global <br>banners.<br> <li> Modified <code>print_banner</code> to <code>print_log_banner</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/800/files#diff-fdca55a2ee0875c33af04f1ecd5140eee8528d6756a21ab4837f579da61f0d37">+14/-3</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>base.rb</strong><dd><code>Integrate global banner into web view variables.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/onetime/app/web/views/base.rb

- Added global banner to JavaScript variables.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/800/files#diff-a5d4e462fd47bbc94ac209ba3bdad2ef72c7bdb5948808941a06805e38e59836">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>cluster.rb</strong><dd><code>Add exact DNS record match verification method.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/onetime/cluster.rb

<li>Added <code>check_records_match_exactly</code> method for DNS record verification.<br> <li> Enhanced documentation for DNS record checking methods.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/800/files#diff-699445e5aa7c37708799c15fee27d4a5d42d0373deac593f6c2eb586e1ffde1c">+53/-9</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>domains.rb</strong><dd><code>Enhance domain verification with TXT record checks.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/onetime/logic/domains.rb

<li>Added <code>verify_txt_record</code> method for TXT record validation.<br> <li> Improved error handling in domain verification.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/800/files#diff-4d3fe2c37de0a04b7a3b15b07c751afb9952b185405911db90990192ba63ffd4">+43/-9</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>custom_domain.rb</strong><dd><code>Add DNS resolving field and validation method.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/onetime/models/custom_domain.rb

<li>Added <code>resolving</code> field to track DNS record status.<br> <li> Introduced <code>validation_record</code> method for domain ownership validation.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/800/files#diff-96ec102155ead1bc098be94a8beb0038951284ed58a35e54fe5360b1cb9e7a37">+13/-1</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>App.vue</strong><dd><code>Integrate global banner into Vue application.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/App.vue

<li>Added <code>global_banner</code> to window properties.<br> <li> Integrated global banner into layout properties.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/800/files#diff-7a7a37b12ee1265d7e27577ec286120d2cbc0940908635e264a2be44ccb9a8a0">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>GlobalBroadcast.vue</strong><dd><code>Sanitize HTML content in global broadcast component.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/GlobalBroadcast.vue

<li>Added DOMPurify for HTML content sanitization.<br> <li> Enhanced global broadcast component with sanitized content.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/800/files#diff-8de770fb4edc8b6ec4439f0f25c0f4c0ed83132b0fe19b2e7f80ce548f70c2fc">+38/-25</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>FooterLinkLists.vue</strong><dd><code>Fix blog link URL in footer.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/layout/FooterLinkLists.vue

- Updated blog link to a fixed URL.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/800/files#diff-c16a5d5ad9b267906145047be1569ce3a4a5ea9c96552c2bd336a6a9faeaa566">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>BaseLayout.vue</strong><dd><code>Display global banner in base layout.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/layouts/BaseLayout.vue

- Integrated global banner into base layout.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/800/files#diff-a6b055169c496bd5bf6ec5e987e50b954ea4fa7517de7310676f07c60fe2b99e">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>window.d.ts</strong><dd><code>Extend window interface with global banner property.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/types/window.d.ts

- Added `global_banner` to window interface.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/800/files#diff-045fb887144d0411250117ed9a5d44645e05e3b889ef669f76c773ba65139571">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>72_approximated.rb</strong><dd><code>Expand unit tests for DNS record match functionality.</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/unit/ruby/try/72_approximated.rb

<li>Added tests for <code>check_records_match_exactly</code> method.<br> <li> Updated test cases for DNS record verification.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/800/files#diff-712727a00f686936499d36b1467581759bd5d34776f1745d643447703453d98f">+46/-4</a>&nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Dependencies</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Add DOMPurify dependencies for HTML sanitization.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

package.json

- Added `dompurify` and `@types/dompurify` dependencies.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/800/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>pnpm-lock.yaml</strong><dd><code>Update lockfile with DOMPurify dependencies.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pnpm-lock.yaml

- Updated lockfile with new dependencies.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/800/files#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bb">+23/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information