### PR TITLE
Update Docker image tagging strategy

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,5 +1,16 @@
 name: Docker Build and Publish
 
+#
+# Docker image tagging strategy:
+#
+# Release tags (v1.0.0):        {version}, latest
+# Release candidates (v1.0.0-rc1): {version}, next
+# Branches (feature/x):         {branch-name}
+#
+# This ensures stable releases are tagged as 'latest' while release candidates
+# are tagged as 'next' for early testing. Branch builds get descriptive tags.
+#
+
 on:
   push:
     tags: [ "v*" ]
@@ -13,39 +24,27 @@ permissions:
   packages: write
 
 jobs:
-  set-image-tags:
-    runs-on: ubuntu-latest
-    outputs:
-      image_tags: ${{ steps.set-tags.outputs.image_tags }}
-    steps:
-      - name: Set Image tags
-        id: set-tags
-        run: |
-
-          if [[ ${{ github.ref }} =~ ^refs/tags/v.*-rc[0-9]+$ ]]; then
-            echo "image_tags=type=raw,value=next,enable=true" >> $GITHUB_OUTPUT
-            echo "image_tags=type=ref,event=tag" >> $GITHUB_OUTPUT
-          elif [[ ${{ github.ref }} =~ ^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "image_tags=type=raw,value=latest,enable=true" >> $GITHUB_OUTPUT
-            echo "image_tags=type=ref,event=tag" >> $GITHUB_OUTPUT
-          else
-            echo "image_tags=type=ref,event=branch" >> $GITHUB_OUTPUT
-          fi
-
   build-and-publish-main:
-    needs: set-image-tags
     uses: ./.github/workflows/.docker-build-publish-reusable.yml
     with:
       image-suffix: ''
       dockerfile: 'Dockerfile'
-      image_tags: ${{ needs.set-image-tags.outputs.image_tags }}
+      image_tags: |
+        type=ref,event=branch
+        type=ref,event=tag
+        type=raw,value=next,enable=${{ contains(github.ref, '-rc') }}
+        flavor=latest=${{ !contains(github.ref, '-rc') }}
     secrets: inherit
 
   build-and-publish-lite:
-    needs: [set-image-tags, build-and-publish-main]
+    needs: [build-and-publish-main]
     uses: ./.github/workflows/.docker-build-publish-reusable.yml
     with:
       image-suffix: '-lite'
       dockerfile: 'Dockerfile-lite'
-      image_tags: ${{ needs.set-image-tags.outputs.image_tags }}
+      image_tags: |
+        type=ref,event=branch
+        type=ref,event=tag
+        type=raw,value=next,enable=${{ contains(github.ref, '-rc') }}
+        flavor=latest=${{ !contains(github.ref, '-rc') }}
     secrets: inherit


### PR DESCRIPTION
### **User description**
This pull request updates the Docker image tagging strategy in the `.github/workflows/docker-publish.yml` file. The new strategy ensures that stable releases are tagged as 'latest', release candidates are tagged as 'next' for early testing, and branch builds get descriptive tags. This improves the organization and clarity of the Docker image tags.


___

### **PR Type**
enhancement, configuration changes


___

### **Description**
- Updated the Docker image tagging strategy to improve clarity and organization.
- Removed the separate `set-image-tags` job and integrated its logic directly into the build jobs.
- Simplified the image tagging logic using inline expressions, ensuring stable releases are tagged as 'latest' and release candidates as 'next'.
- Added comments to document the new tagging strategy.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>docker-publish.yml</strong><dd><code>Update and simplify Docker image tagging strategy</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/docker-publish.yml

<li>Added comments to explain the Docker image tagging strategy.<br> <li> Removed the <code>set-image-tags</code> job and integrated its logic directly into <br>the <code>build-and-publish-main</code> and <code>build-and-publish-lite</code> jobs.<br> <li> Simplified the image tagging logic using inline expressions.<br> <li> Ensured stable releases are tagged as 'latest' and release candidates <br>as 'next'.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/806/files#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98">+22/-23</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information