### PR TITLE
Update Redis connection management and refine model database configurations

### DIFF
--- a/etc/config.example.yaml
+++ b/etc/config.example.yaml
@@ -1,4 +1,3 @@
----
 :site:
   :host: <%= ENV['HOST'] || 'localhost:3000' %>
   :domains:
@@ -64,6 +63,17 @@
     :ttl_options: <%= (ENV['TTL_OPTIONS'] || nil) %>
 :redis:
   :uri: <%= ENV['REDIS_URL'] || 'redis://CHANGEME@127.0.0.1:6379/0' %>
+  #
+  :dbs:
+    :session: 1
+    :splittest: 1
+    :custom_domain: 6
+    :customer: 6
+    :subdomain: 6
+    :metadata: 7
+    :email_receipt: 8
+    :secret: 8
+  :ttls:
 :colonels:
   # Email addresses listed below will be granted automatic
   # administrative privileges upon account creation. These

--- a/lib/onetime/models/custom_domain.rb
+++ b/lib/onetime/models/custom_domain.rb
@@ -36,7 +36,6 @@ class Onetime::CustomDomain < Familia::Horreum
   MAX_SUBDOMAIN_DEPTH = 10 # e.g., a.b.c.d.e.f.g.h.i.j.example.com
   MAX_TOTAL_LENGTH = 253   # RFC 1034 section 3.1
 
-  db 6
   prefix :customdomain
 
   feature :safe_dump

--- a/lib/onetime/models/customer.rb
+++ b/lib/onetime/models/customer.rb
@@ -6,7 +6,6 @@ class Onetime::Customer < Familia::Horreum
   feature :safe_dump
   feature :expiration
 
-  db 6
   prefix :customer
 
   @global = nil

--- a/lib/onetime/models/email_receipt.rb
+++ b/lib/onetime/models/email_receipt.rb
@@ -5,7 +5,6 @@ class Onetime::EmailReceipt < Familia::Horreum
   feature :safe_dump
   feature :expiration
 
-  db 8
   ttl 14.days
 
   prefix :secret

--- a/lib/onetime/models/metadata.rb
+++ b/lib/onetime/models/metadata.rb
@@ -6,7 +6,6 @@ module Onetime
     feature :safe_dump
     feature :expiration
 
-    db 7
     ttl 14.days
     prefix :metadata
 

--- a/lib/onetime/models/secret.rb
+++ b/lib/onetime/models/secret.rb
@@ -6,7 +6,6 @@ module Onetime
     feature :safe_dump
     feature :expiration
 
-    db 8
     ttl 7.days # default only, can be overridden at create time
     prefix :secret
 

--- a/lib/onetime/models/session.rb
+++ b/lib/onetime/models/session.rb
@@ -7,7 +7,6 @@ class Onetime::Session < Familia::Horreum
   feature :safe_dump
   feature :expiration
 
-  db 1
   ttl 20.minutes
   prefix :session
 

--- a/lib/onetime/models/stripe_event.rb
+++ b/lib/onetime/models/stripe_event.rb
@@ -4,7 +4,6 @@ class Onetime::StripeEvent < Familia::Horreum
   feature :safe_dump
   feature :expiration
 
-  db 10
   ttl 5.years
   prefix :stripeevent
 

--- a/lib/onetime/models/subdomain.rb
+++ b/lib/onetime/models/subdomain.rb
@@ -13,8 +13,6 @@ class Onetime::Subdomain < Familia::Horreum
 
   feature :safe_dump
 
-  db 6
-
   prefix :customer
   identifier :custid
   suffix :subdomain

--- a/lib/refinements/horreum_refinements.rb
+++ b/lib/refinements/horreum_refinements.rb
@@ -1,0 +1,27 @@
+# lib/familia/horreum/string_refinements.rb
+module Familia
+  module HorreumRefinements
+    refine Horreum do
+      # Converts the class name into a symbol that can be used to look up
+      # configuration values. This is particularly useful when mapping
+      # database numbers to specific models in the configuration.
+      #
+      # @example Using in database configuration
+      #   # In onetime.rb
+      #   def connect_databases
+      #     # Config has db numbers like: db_session: 0, db_secret: 1
+      #     Onetime::Session.db = OT.conf["db_#{Onetime::Session.to_sym}"]
+      #     # => looks up 'db_session' in config
+      #   end
+      #
+      # @return [Symbol] The underscored class name as a symbol
+      def to_sym
+        name.split('::').last
+            .gsub(/([A-Z]+)([A-Z][a-z])/, '\1_\2')
+            .gsub(/([a-z\d])([A-Z])/, '\1_\2')
+            .downcase
+            .to_sym
+      end
+    end
+  end
+end

--- a/lib/refinements/horreum_refinements.rb
+++ b/lib/refinements/horreum_refinements.rb
@@ -1,7 +1,8 @@
-# lib/familia/horreum/string_refinements.rb
+
+
 module Familia
   module HorreumRefinements
-    refine Horreum do
+    refine Familia::Horreum.singleton_class do
       # Converts the class name into a symbol that can be used to look up
       # configuration values. This is particularly useful when mapping
       # database numbers to specific models in the configuration.

--- a/lib/refinements/stripe_refinements.rb
+++ b/lib/refinements/stripe_refinements.rb
@@ -1,0 +1,107 @@
+# rubocop:disable
+
+require 'stripe' # ensures Stripe namespace is loaded
+
+module Onetime::StripeRefinements
+  refine Stripe::Subscription do
+    extend Familia::Features::SafeDump::ClassMethods
+
+    # Safe fields for Stripe Subscription object
+    set_safe_dump_fields [
+      :id,
+      :status,
+      :current_period_start,
+      :current_period_end,
+      :cancel_at_period_end,
+      :canceled_at,
+      :created,
+      :days_until_due,
+      :trial_start,
+      :trial_end,
+      :livemode,
+
+      { :items => lambda { |sub|
+        sub.items.data.map do |item|
+          {
+            price_id: item.price.id,
+            price_nickname: item.price.nickname,
+            quantity: item.quantity
+          }
+        end
+      }},
+
+      { :current_period_remaining => lambda { |sub|
+        (Time.at(sub.current_period_end) - Time.now).to_i
+      }},
+
+      { :on_trial => lambda { |sub|
+        sub.trial_end && Time.now < Time.at(sub.trial_end)
+      }},
+
+      { :plan => lambda { |sub|
+        sub.plan ? {
+          id: sub.plan.id,
+          nickname: sub.plan.nickname,
+          amount: sub.plan.amount,
+          interval: sub.plan.interval,
+          interval_count: sub.plan.interval_count
+        } : nil
+      }}
+    ]
+  end
+
+  refine Stripe::Customer do
+    @safe_dump_fields = []
+    @safe_dump_field_map = {}
+    extend Familia::Features::SafeDump::ClassMethods
+
+    def safe_dump
+      self.class.safe_dump_field_map.transform_values do |callable|
+        transformed_value = callable.call(self)
+
+        # If the value is a ancestor of SafeDump we can call safe_dump
+        # on it, otherwise we'll just return the value as-is.
+        if transformed_value.is_a?(SafeDump)
+          transformed_value.safe_dump
+        else
+          transformed_value
+        end
+      end
+    end
+
+
+    # Safe fields for Stripe Customer object
+    @safe_dump_fields = [
+      :id,
+      :email,
+      :name,
+      :phone,
+      :created,
+      :livemode,
+      :tax_exempt,
+      :preferred_locales,
+      :currency,
+
+      { :address => lambda { |cust|
+        cust.address ? {
+          city: cust.address.city,
+          country: cust.address.country,
+          line1: cust.address.line1,
+          line2: cust.address.line2,
+          postal_code: cust.address.postal_code,
+          state: cust.address.state
+        } : nil
+      }},
+
+      { :has_payment_method => lambda { |cust|
+        !cust.default_source.nil?
+      }},
+
+      { :metadata => lambda { |cust|
+        # Only include safe metadata fields
+        safe_metadata_keys = [:public_note, :preferred_language]
+        cust.metadata_list.select { |k, _| safe_metadata_keys.include?(k.to_sym) }
+      }}
+    ]
+  end
+end

--- a/tests/unit/ruby/config.test.yaml
+++ b/tests/unit/ruby/config.test.yaml
@@ -1,4 +1,3 @@
----
 :site:
   :host: '127.0.0.1:3000'
   :domains:
@@ -45,6 +44,15 @@
 :redis:
   :uri: 'redis://CHANGEME@127.0.0.1:6379/0'
   :config: ./try/redis.conf
+  :dbs:
+    :metadata: 7
+    :secret: 8
+    :session: 1
+    :customer: 6
+    :splittest: 1
+    :email_receipt: 8
+    :subdomain: 6
+    :custom_domain: 6
 :colonels:
   - 'CHANGEME@EXAMPLE.com'
 :emailer:

--- a/tests/unit/ruby/try/20_metadata_try.rb
+++ b/tests/unit/ruby/try/20_metadata_try.rb
@@ -25,13 +25,13 @@ OT.boot! :test
 
 ## Can create a Metadata
 m = Onetime::Metadata.new :private
-[m.class, m.db, m.secret_key]
+[m.class, m.redis.connection[:db], m.secret_key]
 #=> [Onetime::Metadata, 7, nil]
 
 ## Can explicitly set the secret key
 m = Onetime::Metadata.new :private
 m.secret_key = 'hihi'
-[m.class, m.db, m.secret_key]
+[m.class, m.redis.connection[:db], m.secret_key]
 #=> [Onetime::Metadata, 7, 'hihi']
 
 ## Keys are always unique for Metadata

--- a/tests/unit/ruby/try/21_secret_try.rb
+++ b/tests/unit/ruby/try/21_secret_try.rb
@@ -25,7 +25,7 @@ OT.boot! :test
 
 ## Can create Secret
 s = Onetime::Secret.new :private
-[s.class, s.db, s.metadata_key]
+[s.class, s.redis.connection[:db], s.metadata_key]
 #=> [Onetime::Secret, 8, nil]
 
 ## Keys are always unique for Secrets

--- a/tests/unit/ruby/try/29_customer_domains_try.rb
+++ b/tests/unit/ruby/try/29_customer_domains_try.rb
@@ -93,7 +93,7 @@ custom_domain = @cust.custom_domains_list.first
 #=> true
 
 ## CustomDomain uses the correct Redis database
-OT::CustomDomain.db
+OT::CustomDomain.redis.connection[:db]
 #=> 6
 
 ## CustomDomain has the correct prefix

--- a/tests/unit/ruby/try/60_logic/40_logic_domains_try.rb
+++ b/tests/unit/ruby/try/60_logic/40_logic_domains_try.rb
@@ -17,7 +17,7 @@ OT.boot! :test
 
 # Setup common test variables
 @now = DateTime.now
-@email = 'test@onetimesecret.com'
+@email = "test+#{Time.now.to_i}@onetimesecret.com"
 @sess = OT::Session.new '255.255.255.255', 'anon'
 @cust = OT::Customer.new @email
 @cust.save
@@ -25,11 +25,10 @@ OT.boot! :test
 @custom_domain = OT::CustomDomain.create @domain_input, @cust.custid
 @cust.add_custom_domain @custom_domain
 
-
 # ListDomains Tests
 
 ## Add a test domain to the customer
-@cust.add_domain(@domain_input)
+@cust.add_custom_domain(@domain_input)
 
 # Test domain listing
 logic = OT::Logic::Domains::ListDomains.new @sess, @cust


### PR DESCRIPTION
### **User description**
Enhance Redis connection handling by implementing model-specific database configurations. This change replaces static database access with a dynamic mapping of models to their respective Redis databases, improving connection management and clarity. Additionally, introduce refinements for Horreum and Stripe objects to facilitate safer data handling and configuration lookups.

Related to #766


___

### **PR Type**
enhancement, configuration changes


___

### **Description**
- Implemented model-specific Redis database connections to improve connection management and clarity.
- Removed static database index assignments from model classes.
- Added `HorreumRefinements` for class name to symbol conversion for configuration lookups.
- Introduced safe dump capabilities for Stripe objects with defined safe fields.
- Updated tests to reflect changes in Redis connection handling and added timestamp to test emails to prevent conflicts.
- Updated configuration files to include model-specific Redis database settings.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>onetime.rb</strong><dd><code>Implement model-specific Redis database connections</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/onetime.rb

<li>Added <code>HorreumRefinements</code> for class name to symbol conversion.<br> <li> Updated Redis connection logic to use model-specific database <br>configuration.<br> <li> Improved logging for database connections.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/824/files#diff-fdca55a2ee0875c33af04f1ecd5140eee8528d6756a21ab4837f579da61f0d37">+18/-7</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>horreum_refinements.rb</strong><dd><code>Add HorreumRefinements for class name conversion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/refinements/horreum_refinements.rb

- Added refinement for converting class names to symbols.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/824/files#diff-80bd9aa5bdb6f410c71426213f64bdc148910efe7be4ccc7de73463d58347570">+28/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>stripe_refinements.rb</strong><dd><code>Add safe dump refinements for Stripe objects</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/refinements/stripe_refinements.rb

<li>Added safe dump capabilities for Stripe objects.<br> <li> Defined safe fields for Stripe Subscription and Customer.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/824/files#diff-fb8a58810db38f825df88c58ac29ce6ca16ebecf76eebce236530e3ceae78daf">+107/-0</a>&nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>10 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>custom_domain.rb</strong><dd><code>Remove static Redis database index for CustomDomain</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/onetime/models/custom_domain.rb

- Removed static database index assignment.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/824/files#diff-96ec102155ead1bc098be94a8beb0038951284ed58a35e54fe5360b1cb9e7a37">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>customer.rb</strong><dd><code>Remove static Redis database index for Customer</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/onetime/models/customer.rb

- Removed static database index assignment.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/824/files#diff-dd6fa4b42f949f8bd49271fd4f0359f44d6afc4e24ce5e16b9064c71bac40dd0">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>email_receipt.rb</strong><dd><code>Remove static Redis database index for EmailReceipt</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/onetime/models/email_receipt.rb

- Removed static database index assignment.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/824/files#diff-59d92245e044462ee2878c13c0768e9926b8f328276fc11b3b0907f4cb507f2e">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>metadata.rb</strong><dd><code>Remove static Redis database index for Metadata</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/onetime/models/metadata.rb

- Removed static database index assignment.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/824/files#diff-37c1391c13ede3383947f3799790fdd1cce1e9c6793c28caaed3aa4caa53a1fb">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>secret.rb</strong><dd><code>Remove static Redis database index for Secret</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/onetime/models/secret.rb

- Removed static database index assignment.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/824/files#diff-dc6c15bf06b485edaff44c409b33490b677eb464e874ba3103949b9c699bf9d9">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>session.rb</strong><dd><code>Remove static Redis database index for Session</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/onetime/models/session.rb

- Removed static database index assignment.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/824/files#diff-f167d5124650c0199a0cb49863434a87e3ab36b20d677d99c336d23c48de4536">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>stripe_event.rb</strong><dd><code>Remove static Redis database index for StripeEvent</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/onetime/models/stripe_event.rb

- Removed static database index assignment.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/824/files#diff-ff307070f312fbb351000c2a1b59b4b676f1250afc745e59ee8d28994559a946">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>subdomain.rb</strong><dd><code>Remove static Redis database index for Subdomain</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/onetime/models/subdomain.rb

- Removed static database index assignment.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/824/files#diff-fceacf80da5c08c887374ba449901fa8402a49105d424a7b82dabccda0d39e8e">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>config.example.yaml</strong><dd><code>Add model-specific Redis database configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

etc/config.example.yaml

- Added model-specific Redis database configuration.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/824/files#diff-623a3725e34c66751e28979fce3f78929e9c476779cea0463cde7ea59a3ffcfb">+11/-1</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>config.test.yaml</strong><dd><code>Add model-specific Redis database configuration for tests</code></dd></summary>
<hr>

tests/unit/ruby/config.test.yaml

- Added model-specific Redis database configuration.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/824/files#diff-03d45dad5fa2973b945cc673a987097627eca77ee846aa81336c21f58300193a">+9/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>20_metadata_try.rb</strong><dd><code>Update Metadata test for Redis connection handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/unit/ruby/try/20_metadata_try.rb

- Updated test to use `redis.connection[:db]` for database index.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/824/files#diff-c191ad2d44d7aec12c5ebd208dfb75e6579c7353de396777ffdc7ff0a3c17b64">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>21_secret_try.rb</strong><dd><code>Update Secret test for Redis connection handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/unit/ruby/try/21_secret_try.rb

- Updated test to use `redis.connection[:db]` for database index.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/824/files#diff-417673ed2a03f3c2106cb1bf92046d5923698e77a94c974a3752d10d5f2e621e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>29_customer_domains_try.rb</strong><dd><code>Update CustomDomain test for Redis connection handling</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/unit/ruby/try/29_customer_domains_try.rb

- Updated test to use `redis.connection[:db]` for database index.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/824/files#diff-133cfacf9d346744413a9f5f099ccf0a47340a33ef0168a9bc62e944991abd39">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>40_logic_domains_try.rb</strong><dd><code>Update domain logic test email handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/unit/ruby/try/60_logic/40_logic_domains_try.rb

- Updated test email to include timestamp to prevent conflicts.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/824/files#diff-f379c8848e0fe9d073d58e51abad33ffb0c7f23f72ef15bab6bcd574ddb57c78">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information