### PR TITLE
[#843] Removes legacy Array core extensions

### DIFF
--- a/lib/onetime/core_ext.rb
+++ b/lib/onetime/core_ext.rb
@@ -1,4 +1,3 @@
-# rubocop:disable all
 
 
 module QuantizeTime
@@ -11,6 +10,7 @@ module QuantizeTime
   end
 end
 
+
 module QuantizeInteger
   def quantize quantum
     stamp = self === Integer ? self : to_i
@@ -21,13 +21,16 @@ module QuantizeInteger
   end
 end
 
+
 class Time
   include QuantizeTime
 end
 
+
 class Integer
   include QuantizeInteger
 end
+
 
 class String
   def plural(int=1)
@@ -56,80 +59,5 @@ module Rack
          "X-Cascade" => "pass"},
        [body]]
     end
-  end
-end
-
-
-class Array
-  def sum
-    self.compact.inject(0) { |a, x| a + (x.is_a?(Numeric) ? x : 0) }
-  end
-
-  def mean
-    return 0 if self.empty?
-    self.sum.to_f / self.size
-  end
-
-  def median
-    return nil if self.empty?
-    sorted = self.sort
-    mid = self.size / 2
-    if self.size.even?
-      sorted[mid - 1, 2].mean
-    else
-      sorted[mid].to_f
-    end
-  end
-
-  def histogram
-    self.sort.each_with_object(Hash.new(0)) { |x, a| a[x] += 1 }
-  end
-
-  def mode
-    map = self.histogram
-    max = map.values.max
-    map.filter_map { |k, v| k if v == max }
-  end
-
-  def squares
-    self.filter_map { |x| x.is_a?(Numeric) ? x**2 : nil }.sum
-  end
-
-  def variance
-    return 0 if self.empty?
-    self.squares.to_f / self.size - self.mean**2
-  end
-
-  def deviation
-    Math.sqrt(self.variance)
-  end
-  alias_method :sd, :deviation
-
-  def permute
-    self.dup.permute!
-  end
-
-  def permute!
-    (1...self.size).each do |i|
-      j = rand(i + 1)
-      self[i], self[j] = self[j], self[i] if i != j
-    end
-    self
-  end
-
-  def sample(n = 1)
-    Array.new(n) { self[rand(self.size)] }
-  end
-
-  def random
-    self.sample(1).first
-  end
-
-  def percentile(perc)
-    self.sort[percentile_index(perc)]
-  end
-
-  def percentile_index(perc)
-    [(perc * self.length).ceil - 1, 0].max
   end
 end


### PR DESCRIPTION
Cleans up core extensions by removing unnecessary Array method additions while
preserving essential functionality in QuantizeTime, QuantizeInteger, and String
classes.

- Removes statistical methods (mean, median, mode, variance, etc.)
- Removes array manipulation methods (permute, sample, random)
- Removes unnecessary rubocop disable directive

Resolves #843