### PR TITLE
Fix rate limiter for secret access and update Docker workflow tags

### DIFF
--- a/.github/workflows/.docker-build-publish-reusable.yml
+++ b/.github/workflows/.docker-build-publish-reusable.yml
@@ -31,12 +31,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Record commit hash and display version info
-        run: |
-          git rev-parse --short HEAD > .commit_hash.txt
-          echo Commit hash recorded
-          head -4 .commit_hash.txt package.json
-
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3.2.0
         with:
@@ -75,6 +69,12 @@ jobs:
             ${{ github.repository }}${{ inputs.image-suffix }}
           flavor: |
             latest=${{ !contains(github.ref, '-rc') }}
+
+      - name: Record commit hash and display version info
+        run: |
+          echo "${GITHUB_SHA:0:7}" > .commit_hash.txt
+          echo Commit hash recorded
+          head -4 .commit_hash.txt package.json
 
       - name: Build and push Docker image
         id: build-and-push

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -32,7 +32,7 @@ jobs:
       image_tags: |
         type=ref,event=branch
         type=ref,event=tag
-        type=raw,value=next,enable=${{ contains(github.ref, '-rc') }}
+        type=raw,value=next,enable=${{ contains(github.ref, '-rc') || contains(github.ref, 'develop') }}
     secrets: inherit
 
   build-and-publish-lite:
@@ -44,5 +44,5 @@ jobs:
       image_tags: |
         type=ref,event=branch
         type=ref,event=tag
-        type=raw,value=next,enable=${{ contains(github.ref, '-rc') }}
+        type=raw,value=next,enable=${{ contains(github.ref, '-rc') || contains(github.ref, 'develop') }}
     secrets: inherit

--- a/etc/config.example.yaml
+++ b/etc/config.example.yaml
@@ -240,6 +240,7 @@
   :get_domain: 100
   :verify_domain: 25
   :report_exception: 50
+  :attempt_secret_access: 10
 :development:
   # Enabling development mode here directs the application to expect
   # a vite server to be running on port 5173 and will attempt to

--- a/tests/unit/ruby/config.test.yaml
+++ b/tests/unit/ruby/config.test.yaml
@@ -184,6 +184,7 @@
   :generate_apitoken: 3
   :add_domain: 100
   :report_exception: 5
+  :attempt_secret_access: 10
 :development:
   :enabled: <%= ['development', 'dev'].include?(ENV['RACK_ENV']) %>
   :debug: <%= ['true', '1', 'yes'].include?(ENV['ONETIME_DEBUG']) %>


### PR DESCRIPTION
### **User description**
Introduce a new rate limit for secret access to enhance security and update Docker workflow to include the develop branch in tag generation.


___

### **PR Type**
Enhancement, Configuration changes, Tests


___

### **Description**
- Introduced a new rate limit for secret access attempts to enhance security and prevent abuse.
- Updated the secret burning logic to apply rate limiting consistently.
- Modified Docker workflow to include the 'develop' branch in tag generation for the 'next' tag.
- Adjusted commit hash recording method to use GitHub SHA for improved CI/CD workflow.
- Added configuration and test cases for the new `attempt_secret_access` rate limit.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>burn_secret.rb</strong><dd><code>Implement rate limiting and improve secret access control</code></dd></summary>
<hr>

lib/onetime/logic/secrets/burn_secret.rb

<li>Introduced rate limiting for secret access attempts.<br> <li> Corrected logic for passphrase handling.<br> <li> Enhanced access control for secret burning.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/874/files#diff-b9498cb579b8288b771dde78cd921d5abee7e814ed44d9b5d82734ca100b971b">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.docker-build-publish-reusable.yml</strong><dd><code>Update Docker workflow for tag generation and commit hash</code></dd></summary>
<hr>

.github/workflows/.docker-build-publish-reusable.yml

<li>Modified commit hash recording to use GitHub SHA.<br> <li> Adjusted Docker workflow for improved tag generation.<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/874/files#diff-9e66b11579c984baff1f71d75a2390c0c08f91a6e58ab892125350b098bbbaa2">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>docker-publish.yml</strong><dd><code>Enhance Docker publish workflow for branch inclusion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/docker-publish.yml

- Included 'develop' branch in 'next' tag generation.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/874/files#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>config.example.yaml</strong><dd><code>Add rate limit configuration for secret access attempts</code>&nbsp; &nbsp; </dd></summary>
<hr>

etc/config.example.yaml

- Added configuration for `attempt_secret_access` rate limit.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/874/files#diff-623a3725e34c66751e28979fce3f78929e9c476779cea0463cde7ea59a3ffcfb">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config.test.yaml</strong><dd><code>Update test configuration for new rate limit</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/unit/ruby/config.test.yaml

- Added test configuration for `attempt_secret_access` rate limit.



</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/874/files#diff-03d45dad5fa2973b945cc673a987097627eca77ee846aa81336c21f58300193a">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information