### PR TITLE
Add experimental Ruby 3.4 support

### DIFF
--- a/.github/workflows/.docker-build-publish-reusable.yml
+++ b/.github/workflows/.docker-build-publish-reusable.yml
@@ -22,7 +22,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/.docker-build-publish-reusable.yml
+++ b/.github/workflows/.docker-build-publish-reusable.yml
@@ -22,7 +22,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-24
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/Fly.io.yml
+++ b/.github/workflows/Fly.io.yml
@@ -28,7 +28,7 @@ on:
 jobs:
   deploy:
     name: Deploy
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24
     environment: Fly.io
     steps:
       # Step 1: Check this out

--- a/.github/workflows/Fly.io.yml
+++ b/.github/workflows/Fly.io.yml
@@ -28,7 +28,7 @@ on:
 jobs:
   deploy:
     name: Deploy
-    runs-on: ubuntu-24
+    runs-on: ubuntu-24.04
     environment: Fly.io
     steps:
       # Step 1: Check this out

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -47,7 +47,7 @@ on:
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
-    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-24' }}
+    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-24.04' }}
     timeout-minutes: ${{ (matrix.language == 'swift' && 120) || 360 }}
     permissions:
       security-events: write

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -47,7 +47,7 @@ on:
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
-    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
+    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-24' }}
     timeout-minutes: ${{ (matrix.language == 'swift' && 120) || 360 }}
     permissions:
       security-events: write

--- a/.github/workflows/housekeeping.yml
+++ b/.github/workflows/housekeeping.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   stale:
 
-    runs-on: ubuntu-24
+    runs-on: ubuntu-24.04
     permissions:
       issues: write
       pull-requests: write

--- a/.github/workflows/housekeeping.yml
+++ b/.github/workflows/housekeeping.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   stale:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24
     permissions:
       issues: write
       pull-requests: write

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -42,6 +42,7 @@ on:
 
 jobs:
   build:
+    #
     # Can also be set to `self-hosted` if worker is running. Possible
     # issue when switching (or trying to run a mix of github-hosted
     # and self-hosted). All workflows in the repo stopped being queued

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -42,7 +42,6 @@ on:
 
 jobs:
   build:
-    #
     # Can also be set to `self-hosted` if worker is running. Possible
     # issue when switching (or trying to run a mix of github-hosted
     # and self-hosted). All workflows in the repo stopped being queued
@@ -57,7 +56,7 @@ jobs:
     #
     # https://github.com/rubygems/rubygems/blob/master/CHANGELOG.md#breaking-changes
     #
-    runs-on: ubuntu-24
+    runs-on: ubuntu-24.04
 
     strategy:
       matrix:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -72,10 +72,12 @@ jobs:
           - ruby: '3.1'
 
           - ruby: '3.0'
+            continue-on-error: true
             bundler: latest
             rubygems: '3.5.23'
 
           - ruby: '2.7'
+            continue-on-error: true
             bundler: '2.4.22'
             rubygems: '3.2.3'
 

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -61,17 +61,15 @@ jobs:
     strategy:
       matrix:
         include:
+          - ruby: '3.4'
+            continue-on-error: true
+            experimental: true
+
           - ruby: '3.3'
-            bundler: latest
-            rubygems: latest
 
           - ruby: '3.2'
-            bundler: latest
-            rubygems: latest
 
           - ruby: '3.1'
-            bundler: latest
-            rubygems: latest
 
           - ruby: '3.0'
             bundler: latest
@@ -103,10 +101,11 @@ jobs:
 
       - name: Set up Ruby ${{ matrix.ruby }}
         uses: ruby/setup-ruby@v1
+        continue-on-error: ${{ matrix.continue-on-error || false }}
         with:
           ruby-version: ${{ matrix.ruby }}
-          rubygems: ${{ matrix.rubygems }}
-          bundler: ${{ matrix.bundler }}
+          rubygems: ${{ matrix.rubygems || 'latest' }}
+          bundler: ${{ matrix.bundler || 'latest' }}
           # When the following is true, also run "bundle install",
           # and cache the result automatically. Ran into an issue
           # with the caching and multiple ruby version? See commit
@@ -120,21 +119,22 @@ jobs:
           detached: true
 
       - name: Install dependencies (bundler ${{ matrix.bundler }})
+        continue-on-error: ${{ matrix.continue-on-error || false }}
         run: |
           bundle config path vendor/bundle
           bundle install --jobs 4 --retry 3
 
       - name: Run tryouts
-        continue-on-error: false
+        continue-on-error: ${{ matrix.continue-on-error || false }}
         run: |
           bundle exec try -vf
 
       - name: Typecheck with Sorbet
-        continue-on-error: true
+        continue-on-error: ${{ matrix.continue-on-error || true }}
         run: |
           bundle exec srb tc
 
       - name: Rubocop
-        continue-on-error: true
+        continue-on-error: ${{ matrix.continue-on-error || true }}
         run: |
           bundle exec rubocop --config .rubocop.yml --format json --fail-level warning

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -56,7 +56,7 @@ jobs:
     #
     # https://github.com/rubygems/rubygems/blob/master/CHANGELOG.md#breaking-changes
     #
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24
 
     strategy:
       matrix:

--- a/.github/workflows/vue.yml
+++ b/.github/workflows/vue.yml
@@ -43,7 +43,7 @@ on:
         default: false
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/vue.yml
+++ b/.github/workflows/vue.yml
@@ -43,7 +43,7 @@ on:
         default: false
 jobs:
   test:
-    runs-on: ubuntu-24
+    runs-on: ubuntu-24.04
 
     steps:
     - uses: actions/checkout@v4

--- a/docs/api/POSTMAN.md
+++ b/docs/api/POSTMAN.md
@@ -102,7 +102,7 @@ on:
 
 jobs:
   sync:
-  runs-on: ubuntu-latest
+  runs-on: ubuntu-24
   steps:
     - uses: actions/checkout@v2
     - name: Sync Collection

--- a/docs/api/POSTMAN.md
+++ b/docs/api/POSTMAN.md
@@ -102,7 +102,7 @@ on:
 
 jobs:
   sync:
-  runs-on: ubuntu-24
+  runs-on: ubuntu-24.04
   steps:
     - uses: actions/checkout@v2
     - name: Sync Collection

--- a/tests/README.md
+++ b/tests/README.md
@@ -83,7 +83,7 @@ jobs:
   test:
     name: Run Playwright Tests
     timeout-minutes: 60
-    runs-on: ubuntu-24
+    runs-on: ubuntu-24.04
 
     steps:
     - name: Checkout code

--- a/tests/README.md
+++ b/tests/README.md
@@ -83,7 +83,7 @@ jobs:
   test:
     name: Run Playwright Tests
     timeout-minutes: 60
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24
 
     steps:
     - name: Checkout code

--- a/tests/integration/web/README.md
+++ b/tests/integration/web/README.md
@@ -68,7 +68,7 @@ on:
 jobs:
   test:
     timeout-minutes: 60
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4

--- a/tests/integration/web/README.md
+++ b/tests/integration/web/README.md
@@ -68,7 +68,7 @@ on:
 jobs:
   test:
     timeout-minutes: 60
-    runs-on: ubuntu-24
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4


### PR DESCRIPTION
### **User description**
Introduce support for Ruby 3.4 in the CI configuration, allowing for experimental testing while maintaining compatibility with earlier versions. Adjust error handling for various steps to accommodate the new version.


___

### **PR Type**
Enhancement


___

### **Description**
- Added experimental support for Ruby 3.4 in the CI pipeline with the following changes:
  * New test matrix entry for Ruby 3.4 marked as experimental
  * Added continue-on-error handling for experimental versions
- Simplified Ruby version configurations:
  * Made bundler and rubygems 'latest' by default for Ruby 3.1-3.3
  * Maintained specific version requirements for Ruby 3.0
- Unified error handling across test steps (tryouts, Sorbet, Rubocop) to respect experimental status



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ruby.yml</strong><dd><code>Add experimental Ruby 3.4 support in CI workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ruby.yml

<li>Added experimental Ruby 3.4 support to the test matrix<br> <li> Simplified Ruby version configurations by making bundler/rubygems <br>'latest' by default<br> <li> Added continue-on-error flag for experimental Ruby versions<br> <li> Unified error handling across different test steps<br>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/913/files#diff-ce0dee93a528f6c7648f4cd671a3ec7be6a80f976c88f3aa1c322b7a80828fba">+11/-11</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information