### PR TITLE
Add continue-on-error for type-check and test jobs, use GitHub SHA for commit hash

### DIFF
--- a/.github/workflows/Fly.io.yml
+++ b/.github/workflows/Fly.io.yml
@@ -38,7 +38,7 @@ jobs:
       # Step 2: Always leave a note
       - name: Record commit hash and display version info
         run: |
-          git rev-parse --short HEAD > .commit_hash.txt
+          echo ${GITHUB_SHA::7} > .commit_hash.txt
           echo Commit hash recorded
           head -4 .commit_hash.txt package.json
 
@@ -54,6 +54,5 @@ jobs:
           # Generate a long-lived token for reliable automated deployments
           # Command: flyctl tokens create deploy -x 13140h (valid 18 months)
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
-
 # Fortune: As this code vanishes into the ether, so too shall your
 # secrets be whispered once and forgotten.

--- a/.github/workflows/vue.yml
+++ b/.github/workflows/vue.yml
@@ -46,23 +46,25 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Use Node.js
-      uses: actions/setup-node@v4
-      with:
-        node-version: '18'
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
 
-    - name: Install pnpm
-      uses: pnpm/action-setup@v4
-      with:
-        version: 9
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
 
-    - name: Install dependencies
-      run: pnpm install
+      - name: Install dependencies
+        run: pnpm install
 
-    - name: Run type check
-      run: pnpm run type-check
+      - name: Run type check
+        run: pnpm run type-check
+        continue-on-error: true
 
-    - name: Run tests
-      run: pnpm test
+      - name: Run tests
+        run: pnpm test
+        continue-on-error: true


### PR DESCRIPTION
### **User description**
Implement continue-on-error for type-check and test jobs to improve workflow resilience. Replace the use of `git rev-parse` with the GitHub SHA environment variable for better compatibility in the deployment process.

Most of the Vue tests we wrote for the `feature/branding` branch are failing with the change to the stores over the past week (replacing the pinia plugins with Vue style dependency injection for example). We've spent so much time on paying down tech debt and investing in the frontend architecture over the past couple months, we're switching gears to get the v0.19 release out the door. 

___

### **PR Type**
Enhancement, Configuration changes


___

### **Description**
- Replaced `git rev-parse` with `GITHUB_SHA` for commit hash recording.

- Added `continue-on-error` to type-check and test steps in workflows.

- Improved workflow resilience and compatibility for CI/CD processes.

- Minor formatting adjustments in workflow YAML files.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Fly.io.yml</strong><dd><code>Use `GITHUB_SHA` for commit hash in Fly.io workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/Fly.io.yml

<li>Replaced <code>git rev-parse</code> with <code>GITHUB_SHA</code> for commit hash recording.<br> <li> Simplified commit hash recording process for deployment.


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/945/files#diff-a8afa2dfe8238ff037dafaab912212e96aae8c164b4e0225837a5258d82a9959">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>vue.yml</strong><dd><code>Add error resilience and formatting to Vue workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/vue.yml

<li>Added <code>continue-on-error</code> for type-check and test steps.<br> <li> Improved workflow resilience by allowing non-critical errors.<br> <li> Adjusted formatting for better readability.


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/945/files#diff-c5d401e588c34e31052f1b0c43179b5bc943d595859afbe9f21ecc35fa84620a">+17/-15</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information