### PR TITLE
Generate build file earlier and improve metadata handling

### DIFF
--- a/.github/workflows/.docker-build-publish-reusable.yml
+++ b/.github/workflows/.docker-build-publish-reusable.yml
@@ -31,6 +31,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      # Generate .commit_hash.txt in the build context. This guarantees the file
+      # is created before the build context is submitted.
+      - name: Generate commit hash
+        run: |
+          echo "${GITHUB_SHA:0:7}" > .commit_hash.txt
+          echo Commit hash recorded
+          head -4 .commit_hash.txt package.json
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3.3.0
         with:
@@ -69,12 +77,6 @@ jobs:
             ${{ github.repository }}${{ inputs.image-suffix }}
           flavor: |
             latest=${{ !contains(github.ref, '-rc') }}
-
-      - name: Record commit hash and display version info
-        run: |
-          echo "${GITHUB_SHA:0:7}" > .commit_hash.txt
-          echo Commit hash recorded
-          head -4 .commit_hash.txt package.json
 
       - name: Build and push Docker image
         id: build-and-push

--- a/Dockerfile
+++ b/Dockerfile
@@ -183,8 +183,8 @@ RUN VERSION=$(node -p "require('./package.json').version") \
     && mkdir -p /tmp/build-meta \
     && echo "VERSION=$VERSION" > /tmp/build-meta/version_env \
     && if [ ! -f /tmp/build-meta/commit_hash.txt ]; then \
-          echo "dev" > /tmp/build-meta/commit_hash.txt; \
-        fi
+      date -u +%s > /tmp/build-meta/commit_hash.txt; \
+    fi
 
 ##
 # APPLICATION LAYER (FINAL)

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # check=error=true
 
 ##
-# ONETIME SECRET - DOCKER IMAGE - 2024-10-10
+# ONETIME SECRET - DOCKER IMAGE - 2025-01-15
 #
 # For detailed instructions on building, running, and deploying this Docker image,
 # please refer to our comprehensive Docker guide:
@@ -91,11 +91,11 @@
 #
 # Installs system packages, updates RubyGems, and prepares the
 # application's package management dependencies using a Debian
-# Ruby 3.3 base image.
+# Ruby 3 base image.
 #
 ARG CODE_ROOT=/app
 ARG ONETIME_HOME=/opt/onetime
-ARG VERSION=0.0.0
+ARG VERSION
 
 FROM docker.io/library/ruby:3.4-slim-bookworm AS base
 
@@ -176,8 +176,15 @@ RUN set -eux \
   && pnpm run build-only \
   && pnpm prune --prod \
   && rm -rf node_modules \
-  && npm uninstall -g pnpm \
-  && touch .commit_hash.txt  # avoid ignorable error later on
+  && npm uninstall -g pnpm
+
+# Create both version and commit hash files while we can
+RUN VERSION=$(node -p "require('./package.json').version") \
+    && mkdir -p /tmp/build-meta \
+    && echo "VERSION=$VERSION" > /tmp/build-meta/version_env \
+    && if [ ! -f /tmp/build-meta/commit_hash.txt ]; then \
+          echo "dev" > /tmp/build-meta/commit_hash.txt; \
+        fi
 
 ##
 # APPLICATION LAYER (FINAL)
@@ -193,16 +200,29 @@ COPY --from=build /usr/local/bundle /usr/local/bundle
 COPY --from=build $CODE_ROOT/public $CODE_ROOT/public
 COPY --from=build $CODE_ROOT/templates $CODE_ROOT/templates
 COPY --from=build $CODE_ROOT/src $CODE_ROOT/src
-COPY --from=build $CODE_ROOT/.commit_hash.txt $CODE_ROOT/
 COPY bin $CODE_ROOT/bin
 COPY etc $CODE_ROOT/etc
 COPY lib $CODE_ROOT/lib
 COPY migrate $CODE_ROOT/migrate
 COPY package.json config.ru Gemfile Gemfile.lock $CODE_ROOT/
 
-LABEL Name=onetimesecret Version=$VERSION
-LABEL maintainer="Onetime Secret <docker-maint@onetimesecret.com>"
-LABEL org.opencontainers.image.description="Onetime Secret is a web application to share sensitive information securely and temporarily. This image contains the application and its dependencies."
+# Copy build stage metadata files
+COPY --from=build /tmp/build-meta/commit_hash.txt $CODE_ROOT/.commit_hash.txt
+COPY --from=build /tmp/build-meta/version_env /tmp/
+
+RUN . /tmp/version_env \
+    && echo "Version: $VERSION" \
+    && echo "LABEL Name=onetimesecret Version=$VERSION" >> /tmp/docker-labels \
+    && echo "LABEL Maintainer=\"Onetime Secret <docker-maint@onetimesecret.com>\"" >> /tmp/docker-labels \
+    && cat /tmp/docker-labels >> Dockerfile \
+    && rm /tmp/version_env /tmp/docker-labels
+
+# OCI Labels using extracted version
+LABEL org.opencontainers.image.version="${VERSION}" \
+      org.opencontainers.image.title="Onetime Secret" \
+      org.opencontainers.image.description="Onetime Secret is a web application to share sensitive information securely and temporarily." \
+      org.opencontainers.image.source="https://github.com/onetimesecret/onetimesecret" \
+      org.opencontainers.image.licenses="MIT"
 
 # See: https://fly.io/docs/rails/cookbooks/deploy/
 ENV RUBY_YJIT_ENABLE=1


### PR DESCRIPTION
### **User description**
Generate the commit hash earlier in the build process and implement an alternate strategy for managing build metadata, ensuring that version and commit information are correctly recorded and utilized.


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Generate `.commit_hash.txt` earlier in the build process.

- Implement a new strategy for managing build metadata.

- Update Dockerfile to handle version and commit hash files.

- Add OCI-compliant labels for Docker image metadata.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.docker-build-publish-reusable.yml</strong><dd><code>Generate commit hash earlier in workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/.docker-build-publish-reusable.yml

<li>Added a step to generate <code>.commit_hash.txt</code> earlier in the workflow.<br> <li> Removed redundant commit hash generation step before Docker build.


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/971/files#diff-9e66b11579c984baff1f71d75a2390c0c08f91a6e58ab892125350b098bbbaa2">+8/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Dockerfile</strong><dd><code>Enhance Dockerfile metadata handling and labeling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Dockerfile

<li>Updated metadata handling to create version and commit hash files.<br> <li> Added OCI-compliant labels for Docker image metadata.<br> <li> Removed hardcoded default version and improved metadata management.<br> <li> Adjusted build and application layers for better metadata handling.


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/971/files#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557">+29/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information