### PR TITLE
Consolidate OCI labels and deploy builds to Fly

### DIFF
--- a/.github/workflows/.docker-build-publish-reusable.yml
+++ b/.github/workflows/.docker-build-publish-reusable.yml
@@ -77,6 +77,16 @@ jobs:
             ${{ github.repository }}${{ inputs.image-suffix }}
           flavor: |
             latest=${{ !contains(github.ref, '-rc') }}
+          annotations: |
+            org.opencontainers.image.description=Onetime Secret is a web application to share sensitive information securely and temporarily.
+          labels: |
+            org.opencontainers.image.title=Onetime Secret
+            org.opencontainers.image.description=Onetime Secret is a web application to share sensitive information securely and temporarily.
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.licenses=MIT
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ fromJSON(steps.meta.outputs.json).version }}
+            org.opencontainers.image.created=${{ fromJSON(steps.meta.outputs.json).created }}
 
       - name: Build and push Docker image
         id: build-and-push
@@ -87,6 +97,8 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          provenance: false
           annotations: ${{ steps.meta.outputs.annotations }}
           platforms: linux/amd64,linux/arm64
+          build-args: |
+            VERSION=${{ steps.meta.outputs.version }}
+            GITHUB_SHA=${{ github.sha }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -208,21 +208,6 @@ COPY package.json config.ru Gemfile Gemfile.lock $CODE_ROOT/
 
 # Copy build stage metadata files
 COPY --from=build /tmp/build-meta/commit_hash.txt $CODE_ROOT/.commit_hash.txt
-COPY --from=build /tmp/build-meta/version_env /tmp/
-
-RUN . /tmp/version_env \
-    && echo "Version: $VERSION" \
-    && echo "LABEL Name=onetimesecret Version=$VERSION" >> /tmp/docker-labels \
-    && echo "LABEL Maintainer=\"Onetime Secret <docker-maint@onetimesecret.com>\"" >> /tmp/docker-labels \
-    && cat /tmp/docker-labels >> Dockerfile \
-    && rm /tmp/version_env /tmp/docker-labels
-
-# OCI Labels using extracted version
-LABEL org.opencontainers.image.version="${VERSION}" \
-      org.opencontainers.image.title="Onetime Secret" \
-      org.opencontainers.image.description="Onetime Secret is a web application to share sensitive information securely and temporarily." \
-      org.opencontainers.image.source="https://github.com/onetimesecret/onetimesecret" \
-      org.opencontainers.image.licenses="MIT"
 
 # See: https://fly.io/docs/rails/cookbooks/deploy/
 ENV RUBY_YJIT_ENABLE=1

--- a/fly.toml
+++ b/fly.toml
@@ -24,8 +24,8 @@ app = 'ots-staging-ui'
 primary_region = 'ams'
 
 [build]
-image = 'ghcr.io/onetimesecret/onetimesecret:v0.19.0-RC0'
-# dockerfile = 'Dockerfile' # builds the current local state (incl etc/config)
+#image = 'ghcr.io/onetimesecret/onetimesecret:v0.19.0-RC0'
+dockerfile = 'Dockerfile' # builds the current local state (incl etc/config)
 
 [[vm]]
 size = 'shared-cpu-1x'


### PR DESCRIPTION
### **User description**
Consolidate OCI labels in the GitHub workflow and update the Fly configuration to deploy the current builds.


___

### **PR Type**
Enhancement, Configuration changes


___

### **Description**
- Consolidated OCI labels in GitHub workflow for consistency.

- Updated Fly configuration to deploy builds using Dockerfile.

- Added annotations and labels for OCI compliance in workflows.

- Removed redundant OCI label definitions from Dockerfile.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.docker-build-publish-reusable.yml</strong><dd><code>Update GitHub workflow for OCI labels and build arguments</code></dd></summary>
<hr>

.github/workflows/.docker-build-publish-reusable.yml

<li>Added OCI annotations and labels for Docker images.<br> <li> Introduced build arguments for version and Git SHA.<br> <li> Enhanced Docker build and push workflow configuration.


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/972/files#diff-9e66b11579c984baff1f71d75a2390c0c08f91a6e58ab892125350b098bbbaa2">+13/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Dockerfile</strong><dd><code>Simplify Dockerfile by removing redundant OCI labels</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Dockerfile

<li>Removed redundant OCI label definitions.<br> <li> Simplified Dockerfile by eliminating inline label creation.


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/972/files#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557">+0/-15</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>fly.toml</strong><dd><code>Update Fly configuration to use Dockerfile</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

fly.toml

<li>Switched Fly configuration to use Dockerfile for builds.<br> <li> Commented out specific image reference for flexibility.


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/972/files#diff-660f7078dc0b381a350960eae8f3e924e739994dd8657dcc0d270a28c6ff8a38">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information