### PR TITLE
Correct OCI label generation

### DIFF
--- a/.github/workflows/.docker-build-publish-reusable.yml
+++ b/.github/workflows/.docker-build-publish-reusable.yml
@@ -63,6 +63,10 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Get Version
+        id: package_version
+        run: echo "version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
+
       - name: Extract Docker metadata
         id: meta
         uses: docker/metadata-action@369eb591f429131d6889c46b94e711f089e6ca96 # v5.6.1
@@ -77,16 +81,13 @@ jobs:
             ${{ github.repository }}${{ inputs.image-suffix }}
           flavor: |
             latest=${{ !contains(github.ref, '-rc') }}
-          annotations: |
-            org.opencontainers.image.description=Onetime Secret is a web application to share sensitive information securely and temporarily.
           labels: |
             org.opencontainers.image.title=Onetime Secret
             org.opencontainers.image.description=Onetime Secret is a web application to share sensitive information securely and temporarily.
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
             org.opencontainers.image.licenses=MIT
             org.opencontainers.image.revision=${{ github.sha }}
-            org.opencontainers.image.version=${{ fromJSON(steps.meta.outputs.json).version }}
-            org.opencontainers.image.created=${{ fromJSON(steps.meta.outputs.json).created }}
+            org.opencontainers.image.version=${{ steps.package_version.outputs.version }}
 
       - name: Build and push Docker image
         id: build-and-push
@@ -100,5 +101,5 @@ jobs:
           annotations: ${{ steps.meta.outputs.annotations }}
           platforms: linux/amd64,linux/arm64
           build-args: |
-            VERSION=${{ steps.meta.outputs.version }}
+            VERSION=${{ steps.package_version.outputs.version }}
             GITHUB_SHA=${{ github.sha }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -192,6 +192,7 @@ RUN VERSION=$(node -p "require('./package.json').version") \
 FROM ruby:3.4-slim-bookworm AS final
 ARG CODE_ROOT
 ARG VERSION
+LABEL org.opencontainers.image.version=$VERSION
 
 WORKDIR $CODE_ROOT
 


### PR DESCRIPTION
### **User description**
Update the Docker workflow to correctly generate and use the version label from the package.json file, ensuring accurate metadata in the Docker image.


___

### **PR Type**
Enhancement


___

### **Description**
- Corrected OCI label generation in Docker workflows.

- Extracted version from `package.json` for accurate metadata.

- Updated Dockerfile to include OCI version label.

- Improved metadata annotations for Docker images.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.docker-build-publish-reusable.yml</strong><dd><code>Update Docker workflow for accurate OCI labels</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/.docker-build-publish-reusable.yml

<li>Added a step to extract version from <code>package.json</code>.<br> <li> Updated OCI labels to use the extracted version.<br> <li> Removed redundant metadata annotations.<br> <li> Adjusted build arguments to use the new version extraction.


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/973/files#diff-9e66b11579c984baff1f71d75a2390c0c08f91a6e58ab892125350b098bbbaa2">+6/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Dockerfile</strong><dd><code>Add OCI version label in Dockerfile</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Dockerfile

- Added OCI version label using the `VERSION` argument.


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/973/files#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information