### PR TITLE
API v1 Refinements and Domain Strategy Cleanup

### DIFF
--- a/lib/middleware/detect_host.rb
+++ b/lib/middleware/detect_host.rb
@@ -79,14 +79,14 @@ module Rack
         'X-Forwarded-Host',   # Common proxy header (AWS ALB, nginx)
         'X-Original-Host',    # Various proxy services
         'Forwarded',          # RFC 7239 standard (host parameter)
-        'Host'                # Default HTTP host header
+        'Host',               # Default HTTP host header
       ]
 
       INVALID_HOSTS = [
         'localhost',
         'localhost.localdomain',
         '127.0.0.1',
-        '::1'
+        '::1',
       ].freeze
 
       IP_PATTERN = /\A(\d{1,3}\.){3}\d{1,3}\z|\A[0-9a-fA-F:]+\z/
@@ -118,16 +118,16 @@ module Rack
 
         if self.class.valid_host?(host)
           detected_host = host
-          logger.debug("[DetectHost] #{host} via #{header_key}")
+          logger.info("[DetectHost] #{host} via #{header_key}")
           break # stop on first valid host
         else
-          logger.debug("[DetectHost] Invalid host detected from #{header_key}: #{host}")
+          logger.warn("[DetectHost] Invalid host detected from #{header_key}: #{host}")
         end
       end
 
       # Log indication if no valid host found in debug mode
       unless detected_host
-        logger.debug("[DetectHost] No valid host detected in request")
+        logger.warn("[DetectHost] No valid host detected in request")
       end
 
       # e.g. env['rack.detected_host'] = 'example.com'

--- a/lib/middleware/detect_host.rb
+++ b/lib/middleware/detect_host.rb
@@ -118,16 +118,16 @@ module Rack
 
         if self.class.valid_host?(host)
           detected_host = host
-          logger.info("[DetectHost] #{host} via #{header_key}")
+          logger.debug("[DetectHost] #{host} via #{header_key}")
           break # stop on first valid host
         else
-          logger.warn("[DetectHost] Invalid host detected from #{header_key}: #{host}")
+          logger.debug("[DetectHost] Invalid host detected from #{header_key}: #{host}")
         end
       end
 
       # Log indication if no valid host found in debug mode
       unless detected_host
-        logger.warn("[DetectHost] No valid host detected in request")
+        logger.debug("[DetectHost] No valid host detected in request")
       end
 
       # e.g. env['rack.detected_host'] = 'example.com'

--- a/lib/onetime/app/api/v1/endpoints.rb
+++ b/lib/onetime/app/api/v1/endpoints.rb
@@ -34,8 +34,7 @@ module Onetime::App
 
     def share
       authorized(true) do
-        req.params[:kind] = :share
-        logic = OT::Logic::Secrets::ConcealSecret.new sess, cust, req.params, locale
+        logic = OT::Logic::Secrets::ConcealSecret.new sess, cust, {secret: req.params}, locale
         logic.raise_concerns
         logic.process
         if req.get?
@@ -51,8 +50,7 @@ module Onetime::App
 
     def generate
       authorized(true) do
-        req.params[:kind] = :generate
-        logic = OT::Logic::Secrets::ConcealSecret.new sess, cust, req.params, locale
+        logic = OT::Logic::Secrets::GenerateSecret.new sess, cust, {secret: req.params}, locale
         logic.raise_concerns
         logic.process
         if req.get?

--- a/lib/onetime/app/web/views/base.rb
+++ b/lib/onetime/app/web/views/base.rb
@@ -24,7 +24,8 @@ module Onetime
         is_default_locale = OT.conf[:locales].first.to_s == locale
         supported_locales = OT.conf.fetch(:locales, []).map(&:to_s)
 
-        # TODO: This only needs to happen once at boot time.
+        # TODO: The normalizing only needs to happen once at boot time. And canonicalDomain
+        # should fully replace siteHost in the frontend.
         @canonical_domain = Onetime::DomainStrategy.normalize_canonical_domain(site) # can be nil
         @domain_strategy = req.env['onetime.domain_strategy'] # never nil
         @display_domain = req.env['onetime.display_domain'] # can be nil

--- a/lib/onetime/logic/secrets/reveal_secret.rb
+++ b/lib/onetime/logic/secrets/reveal_secret.rb
@@ -83,6 +83,7 @@ module Onetime::Logic
       end
 
       def success_data
+        return nil unless secret
         ret = {
           record: secret.safe_dump,
           details: {

--- a/lib/onetime/logic/secrets/show_secret.rb
+++ b/lib/onetime/logic/secrets/show_secret.rb
@@ -59,6 +59,7 @@ module Onetime::Logic
           limit_action :failed_passphrase
         end
 
+        @has_passphrase = @secret.has_passphrase?
         @display_lines = calculate_display_lines
         @is_owner = secret.owner?(cust)
         @one_liner = one_liner

--- a/lib/onetime/logic/secrets/show_secret.rb
+++ b/lib/onetime/logic/secrets/show_secret.rb
@@ -59,7 +59,7 @@ module Onetime::Logic
           limit_action :failed_passphrase
         end
 
-        @has_passphrase = @secret.has_passphrase?
+        @has_passphrase = secret.has_passphrase?
         @display_lines = calculate_display_lines
         @is_owner = secret.owner?(cust)
         @one_liner = one_liner
@@ -68,6 +68,7 @@ module Onetime::Logic
       end
 
       def success_data
+        return nil unless secret
         ret = {
           record: secret.safe_dump,
           details: {

--- a/lib/onetime/middleware/domain_strategy.rb
+++ b/lib/onetime/middleware/domain_strategy.rb
@@ -39,7 +39,7 @@ module Onetime
 
       if domains_enabled?
         display_domain = env[Rack::DetectHost.result_field_name]
-        domain_strategy = process_domain(display_domain) # canonical, custom, etc
+        domain_strategy = process_domain(display_domain).value # canonical, custom, etc
       end
 
       env['onetime.display_domain'] = display_domain
@@ -73,7 +73,7 @@ module Onetime
       normalized = Normalizer.normalize(host)
       return State.new(STATES[:invalid]) unless normalized
 
-      determine_state(normalized).value # we ignore the host here
+      determine_state(normalized)
     end
 
     # Determines the state of the normalized host.

--- a/lib/onetime/models/secret.rb
+++ b/lib/onetime/models/secret.rb
@@ -185,8 +185,12 @@ module Onetime
     end
 
     def viewed!
+      # A guard to prevent regressing (e.g. from :burned back to :viewed)
+      return unless state?(:new)
       # The secret link has been accessed but the secret has not been consumed yet
-      self.state = 'viewed'
+      @state = 'viewed'
+      # NOTE: calling save re-creates all fields so if you're relying on
+      # has_field? to be false, it will start returning true after a save.
       save update_expiration: false
     end
 

--- a/src/components/layout/QuietHeader.vue
+++ b/src/components/layout/QuietHeader.vue
@@ -3,7 +3,7 @@
   import { useProductIdentity } from '@/stores/identityStore';
   import MastHead from '@/components/layout/MastHead.vue';
   import BrandedMasthead from '@/components/layout/BrandedMastHead.vue';
-import { computed } from 'vue';
+  import { computed } from 'vue';
   const productIdentity = useProductIdentity();
 
   const props = withDefaults(defineProps<LayoutProps>(), {
@@ -27,12 +27,13 @@ import { computed } from 'vue';
     <div
       v-if="displayMasthead"
       class="container mx-auto min-w-[320px] max-w-2xl p-4">
-      <MastHead v-if="productIdentity.isCanonical" v-bind="props" />
+
       <BrandedMasthead
-        v-else
+        v-if="productIdentity.isCustom"
         :headertext="headertext"
         :subtext="subtext"
         v-bind="props"/>
+      <MastHead v-else v-bind="props" />
     </div>
 
   </header>

--- a/src/router/metadata.routes.ts
+++ b/src/router/metadata.routes.ts
@@ -24,15 +24,11 @@ const validateMetadataKey = (key: string | string[]): key is string =>
  */
 const withValidatedMetadataKey = {
   beforeEnter: (to: RouteLocationNormalized) => {
-    const windowProps = WindowService.getMultiple([
-      'domain_id',
-      'domain_branding',
-      'domain_strategy',
-      'display_domain',
-    ]);
+    // Use window service directly rather than the identity store
+    // since the routes start before the pinia stores.
+    const domainStrategy = WindowService.get('domain_strategy') as string;
 
-    if (windowProps.domain_strategy === 'canonical') {
-    } else {
+    if (domainStrategy === 'custom') {
       to.meta.layoutProps = {
         ...to.meta.layoutProps,
         displayMasthead: true,

--- a/src/router/public.routes.ts
+++ b/src/router/public.routes.ts
@@ -15,7 +15,6 @@ const routes: Array<RouteRecordRaw> = [
   {
     path: '/',
     name: 'Home',
-    // component: HomepageContainer,
     components: {
       default: HomepageContainer,
       header: QuietHeader,
@@ -37,15 +36,9 @@ const routes: Array<RouteRecordRaw> = [
     beforeEnter: async (to) => {
       // Use window service directly rather than the identity store
       // since the routes start before the pinia stores.
-      const windowProps = WindowService.getMultiple([
-        'domain_id',
-        'domain_branding',
-        'domain_strategy',
-        'display_domain',
-      ]);
+      const domainStrategy = WindowService.get('domain_strategy') as string;
 
-      if (windowProps.domain_strategy === 'canonical') {
-      } else {
+      if (domainStrategy === 'custom') {
         to.meta.layoutProps = {
           ...to.meta.layoutProps,
           displayMasthead: true,

--- a/src/stores/identityStore.ts
+++ b/src/stores/identityStore.ts
@@ -15,6 +15,8 @@ interface IdentityState {
   domainsEnabled: boolean;
   /** Current domain being served */
   displayDomain: string;
+  /** Site host for this application */
+  siteHost: string;
   /** System's primary domain */
   canonicalDomain: string;
   /** Database ID of custom domain if applicable */
@@ -45,6 +47,7 @@ const getInitialState = (): IdentityState => {
     domainStrategy,
     domainsEnabled: WindowService.get('domains_enabled'),
     displayDomain: WindowService.get('display_domain'),
+    siteHost: WindowService.get('site_host'),
     canonicalDomain: WindowService.get('canonical_domain'),
     domainId: WindowService.get('domain_id'),
     brand,

--- a/src/stores/identityStore.ts
+++ b/src/stores/identityStore.ts
@@ -1,5 +1,8 @@
 // stores/productIdentity.ts
-import { brandSettingschema, type BrandSettings } from '@/schemas/models/domain/brand';
+import {
+  brandSettingschema,
+  type BrandSettings,
+} from '@/schemas/models/domain/brand';
 import { WindowService } from '@/services/window.service';
 import { defineStore } from 'pinia';
 import { computed, reactive, toRefs } from 'vue';
@@ -33,7 +36,8 @@ interface IdentityState {
  * Ensures color values conform to brand schema requirements
  */
 const primaryColorValidator = brandSettingschema.shape.primary_color;
-const allowPublicHomepageValidator = brandSettingschema.shape.allow_public_homepage;
+const allowPublicHomepageValidator =
+  brandSettingschema.shape.allow_public_homepage;
 
 /**
  * Creates initial identity state from window service values
@@ -55,7 +59,9 @@ const getInitialState = (): IdentityState => {
       domainStrategy === 'custom' && brand?.primary_color
         ? primaryColorValidator.parse(brand.primary_color)
         : defaultPrimaryColor,
-    allowPublicHomepage: allowPublicHomepageValidator.parse(brand?.allow_public_homepage),
+    allowPublicHomepage: allowPublicHomepageValidator.parse(
+      brand?.allow_public_homepage
+    ),
   };
 };
 
@@ -80,7 +86,9 @@ export const useProductIdentity = defineStore('productIdentity', () => {
   const isSubdomain = computed(() => state.domainStrategy === 'subdomain');
 
   /** Display name for current domain context */
-  const displayName = computed(() => state.brand?.description || state.displayDomain);
+  const displayName = computed(
+    () => state.brand?.description || state.displayDomain
+  );
 
   const logoUri = computed(() => {
     const template = '/imagine/:custom_domain_id/:image_type.:image_ext';
@@ -118,12 +126,14 @@ export const useProductIdentity = defineStore('productIdentity', () => {
 
   const preRevealInstructions = computed(
     () =>
-      state.brand?.instructions_pre_reveal?.trim() || t('web.shared.pre_reveal_default')
+      state.brand?.instructions_pre_reveal?.trim() ||
+      t('web.shared.pre_reveal_default')
   );
 
   const postRevealInstructions = computed(
     () =>
-      state.brand?.instructions_post_reveal?.trim() || t('web.shared.post_reveal_default')
+      state.brand?.instructions_post_reveal?.trim() ||
+      t('web.shared.post_reveal_default')
   );
 
   /** Resets state to initial values from window service */

--- a/src/views/HomepageContainer.vue
+++ b/src/views/HomepageContainer.vue
@@ -1,6 +1,6 @@
 <!-- src/views/HomepageContainer.vue -->
 <script setup lang="ts">
-  import { WindowService } from '@/services/window.service';
+  import { useProductIdentity } from '@/stores/identityStore';
   import { computed } from 'vue';
 
   import BrandedHomepage from './BrandedHomepage.vue';
@@ -9,13 +9,10 @@
   interface Props {}
   defineProps<Props>();
 
-  const domainStrategy = WindowService.get('domain_strategy');
-  const displayDomain = WindowService.get('display_domain');
-  const siteHost = WindowService.get('site_host');
+  const { isCustom, displayDomain, siteHost } = useProductIdentity();
 
   const currentComponent = computed(() => {
-    console.debug('[HomepageContainer] meta=', domainStrategy);
-    return domainStrategy === 'canonical' ? Homepage : BrandedHomepage;
+    return isCustom ? BrandedHomepage : Homepage;
   });
 </script>
 

--- a/tests/unit/ruby/try/19_safe_dump_try.rb
+++ b/tests/unit/ruby/try/19_safe_dump_try.rb
@@ -17,12 +17,12 @@ Familia::Features::SafeDump.safe_dump_fields
 
 ## Implementing models like Customer can define safe dump fields
 Onetime::Customer.safe_dump_fields
-#=> [:custid, :role, :verified, :last_login, :locale, :updated, :created, :stripe_customer_id, :stripe_subscription_id, :stripe_checkout_email, :plan, :secrets_created, :secrets_burned, :secrets_shared, :emails_sent, :active]
+#=> [:identifier, :custid, :role, :verified, :last_login, :locale, :updated, :created, :stripe_customer_id, :stripe_subscription_id, :stripe_checkout_email, :plan, :secrets_created, :secrets_burned, :secrets_shared, :emails_sent, :active]
 
 ## Implementing models like Customer can safely dump their fields
 cust = Onetime::Customer.new
 cust.safe_dump
-#=> {:custid=>"anon", :role=>"customer", :verified=>nil, :last_login=>nil, :locale=>"", :updated=>nil, :created=>nil, :stripe_customer_id=>nil, :stripe_subscription_id=>nil, :stripe_checkout_email=>nil, :plan=>{:planid=>nil, :source=>"parts_unknown"}, :secrets_created=>"0", :secrets_burned=>"0", :secrets_shared=>"0", :emails_sent=>"0", :active=>false}
+#=> {:identifier=>"anon", :custid=>"anon", :role=>"customer", :verified=>nil, :last_login=>nil, :locale=>"", :updated=>nil, :created=>nil, :stripe_customer_id=>nil, :stripe_subscription_id=>nil, :stripe_checkout_email=>nil, :plan=>{:planid=>nil, :source=>"parts_unknown"}, :secrets_created=>"0", :secrets_burned=>"0", :secrets_shared=>"0", :emails_sent=>"0", :active=>false}
 
 ## Implementing models like Customer do have other fields
 ## that are by default considered not safe to dump.

--- a/tests/unit/ruby/try/42_web_template_vuepoint_try.rb
+++ b/tests/unit/ruby/try/42_web_template_vuepoint_try.rb
@@ -67,17 +67,17 @@ view = OT::App::Views::VuePoint.new(@req, @sess, @cust, 'en', @metadata)
 
 ## Sets authentication status correctly
 view = OT::App::Views::VuePoint.new(@req, @sess, @cust, 'en', @metadata)
-authenticated_value = view[:jsvars].find { |key, value| key[:name] == :authenticated }
+authenticated_value = view[:jsvars][:authenticated]
 authenticated_value
-#=> {:name=>:authenticated, :value=>true}
+#=> true
 
 ## Handles unauthenticated user correctly
 unauthenticated_sess = MockSession.new
 def unauthenticated_sess.authenticated?; false; end
 view = OT::App::Views::VuePoint.new(@req, unauthenticated_sess, OT::Customer.anonymous, 'en', @metadata)
-authenticated_value = view[:jsvars].find { |key, value| key[:name] == :authenticated }
+authenticated_value = view[:jsvars][:authenticated]
 authenticated_value
-#=> {:name=>:authenticated, :value=>false}
+#=> false
 
 ## Sets locale correctly
 view = OT::App::Views::VuePoint.new(@req, @sess, @cust, 'es', @metadata)

--- a/tests/unit/ruby/try/60_logic/03_logic_secrets_try.rb
+++ b/tests/unit/ruby/try/60_logic/03_logic_secrets_try.rb
@@ -46,7 +46,7 @@ secret.generate_id
   ttl: '7200',
   recipient: 'recipient@example.com'
 }
-logic = OT::Logic::Secrets::ConcealSecret.new @sess, @cust, @secret_params
+logic = OT::Logic::Secrets::ConcealSecret.new @sess, @cust, {secret: @secret_params}
 [
   logic.secret_value,
   logic.passphrase,

--- a/tests/unit/ruby/try/60_logic/22_logic_secrets_show_secret_try.rb
+++ b/tests/unit/ruby/try/60_logic/22_logic_secrets_show_secret_try.rb
@@ -71,12 +71,22 @@ logic = Onetime::Logic::Secrets::ShowSecret.new(@sess, @cust, params, 'en')
 [logic.sess, logic.cust, logic.params, logic.locale]
 #=> [@sess, @cust, {}, 'en']
 
-## Correctly sets basic success_data
+## success_data returns nil when no secret
 params = {}
 logic = Onetime::Logic::Secrets::ShowSecret.new(@sess, @cust, params, 'en')
-res = logic.success_data
-res.keys
-[:record, :details]
+logic.success_data
+#=> nil
+
+
+## success_data returns correct structure when secret is viewable
+metadata = @create_metadata.call
+secret = metadata.load_secret
+params = {
+  key: metadata.secret_key
+}
+logic = Onetime::Logic::Secrets::ShowSecret.new(@sess, @cust, params, 'en')
+ret = logic.success_data
+ret.keys
 #=> [:record, :details]
 
 ## Has some essential settings
@@ -139,9 +149,7 @@ end
 ## Display domain is nil by default (previously called share_domain, that defaulted to site_host)
 metadata = @create_metadata.call
 params = {
-  secret: {
-    key: metadata.secret_key
-  }
+  key: metadata.secret_key
 }
 this_logic = Onetime::Logic::Secrets::ShowSecret.new(@sess, @cust, params, 'en')
 this_logic.process

--- a/tests/unit/ruby/try/60_logic/22_logic_secrets_show_secret_try.rb
+++ b/tests/unit/ruby/try/60_logic/22_logic_secrets_show_secret_try.rb
@@ -77,7 +77,6 @@ logic = Onetime::Logic::Secrets::ShowSecret.new(@sess, @cust, params, 'en')
 logic.success_data
 #=> nil
 
-
 ## success_data returns correct structure when secret is viewable
 metadata = @create_metadata.call
 secret = metadata.load_secret
@@ -195,7 +194,7 @@ logic = Onetime::Logic::Secrets::ShowSecret.new(@sess, @cust, params, 'en')
 logic.raise_concerns
 logic.process
 [logic.secret.viewable?, logic.show_secret, logic.one_liner, logic.secret.can_decrypt?]
-#=> [false, true, true, true]
+#=> [false, true, true, false]
 
 ## Correctly determines if secret is a one-liner if the secret is readable
 metadata = @create_metadata.call

--- a/tests/unit/ruby/try/60_logic/22_logic_secrets_show_secret_try.rb
+++ b/tests/unit/ruby/try/60_logic/22_logic_secrets_show_secret_try.rb
@@ -139,37 +139,14 @@ end
 ## Share domain is site.host by default (same as metadata)
 metadata = @create_metadata.call
 params = {
-  key: metadata.secret_key
+  secret: {
+    key: metadata.secret_key
+  }
 }
-@this_logic = Onetime::Logic::Secrets::ShowSecret.new(@sess, @cust, params, 'en')
-@this_logic.process
-@this_logic.share_domain
-#=> "https://127.0.0.1:3000"
-
-## Share domain is still site.host even when the secret has it set if domains is disabled
-metadata = @create_metadata.call
-secret = metadata.load_secret
-secret.share_domain! "example.com"
-params = {
-  key: metadata.secret_key
-}
-@this_logic = Onetime::Logic::Secrets::ShowSecret.new(@sess, @cust, params, 'en')
-@this_logic.process
-[@this_logic.share_domain, @this_logic.domains_enabled]
-#=> ["https://127.0.0.1:3000", false]
-
-## Share domain is processed correctly when the secret has it set
-metadata = @create_metadata.call
-secret = metadata.load_secret
-secret.share_domain! "example.com"
-params = {
-  key: metadata.secret_key
-}
-@this_logic = Onetime::Logic::Secrets::ShowSecret.new(@sess, @cust, params, 'en')
-@this_logic.instance_variable_set(:@domains_enabled, true)
-@this_logic.process
-[@this_logic.share_domain, @this_logic.domains_enabled]
-#=> ["https://example.com", true]
+this_logic = Onetime::Logic::Secrets::ShowSecret.new(@sess, @cust, params, 'en')
+this_logic.process
+this_logic.display_domain
+#=> nil
 
 ## Sets locale correctly
 logic = Onetime::Logic::Secrets::ShowSecret.new(@sess, @cust, {}, 'es')

--- a/tests/unit/ruby/try/60_logic/22_logic_secrets_show_secret_try.rb
+++ b/tests/unit/ruby/try/60_logic/22_logic_secrets_show_secret_try.rb
@@ -136,7 +136,7 @@ rescue Onetime::MissingSecret
 end
 #=> true
 
-## Share domain is site.host by default (same as metadata)
+## Display domain is nil by default (previously called share_domain, that defaulted to site_host)
 metadata = @create_metadata.call
 params = {
   secret: {

--- a/tests/unit/ruby/try/60_logic/23_logic_secrets_reveal_secret_try.rb
+++ b/tests/unit/ruby/try/60_logic/23_logic_secrets_reveal_secret_try.rb
@@ -71,12 +71,21 @@ logic = Onetime::Logic::Secrets::RevealSecret.new(@sess, @cust, params, 'en')
 [logic.sess, logic.cust, logic.params, logic.locale]
 #=> [@sess, @cust, {}, 'en']
 
-## Correctly sets basic success_data
+## success_data returns nil when no secret
 params = {}
 logic = Onetime::Logic::Secrets::RevealSecret.new(@sess, @cust, params, 'en')
-res = logic.success_data
-res.keys
-[:record, :details]
+logic.success_data
+#=> nil
+
+## success_data returns correct structure when secret is viewable
+metadata = @create_metadata.call
+secret = metadata.load_secret
+params = {
+  key: metadata.secret_key
+}
+logic = Onetime::Logic::Secrets::RevealSecret.new(@sess, @cust, params, 'en')
+ret = logic.success_data
+ret.keys
 #=> [:record, :details]
 
 ## Has some essential settings
@@ -210,7 +219,7 @@ logic = Onetime::Logic::Secrets::RevealSecret.new(@sess, @cust, params, 'en')
 logic.raise_concerns
 logic.process
 [logic.secret.viewable?, logic.show_secret, logic.one_liner, logic.secret.can_decrypt?]
-#=> [false, true, true, true]
+#=> [false, true, true, false]
 
 ## Correctly determines if secret is a one-liner if the secret is readable
 metadata = @create_metadata.call

--- a/tests/unit/ruby/try/90_routes_smoketest_try.rb
+++ b/tests/unit/ruby/try/90_routes_smoketest_try.rb
@@ -34,7 +34,7 @@ response = @mock_request.get('/dashboard')
 ## Can access the about page
 response = @mock_request.get('/about')
 response.status
-#=> 404
+#=> 200
 
 
 # API Routes

--- a/tests/unit/ruby/try/91_authentication_routes_try.rb
+++ b/tests/unit/ruby/try/91_authentication_routes_try.rb
@@ -128,7 +128,7 @@ response = @mock_request.post('/api/v2/secret/conceal')
 content = JSON.parse(response.body)
 message = content.delete('message')
 [response.status, message]
-#=> [400, "You did not provide anything to share"]
+#=> [422, "You did not provide anything to share"]
 
 ## Can post to a bogus endpoint and get a 404
 response = @mock_request.post('/api/v2/generate2')


### PR DESCRIPTION
### **User description**
Changes:
- Stricter secret state management:
  - Added receivable? check for secrets
  - Improved viewed! and received! state transitions
  - Prevent state regression from burned back to viewed
  - Clear sensitive fields on secret destruction

- Domain strategy improvements:
  - Improved host detection logging
  - Added siteHost to identity store
  - Simplified domain strategy logic in routes, flipping the logic gates for clarity (making canonical the else case).

- API v1 refinements:
  - Added proper secret param nesting
  - Fixed error status code for missing share content (400->422)

- Test updates:
  - Updated success_data tests to handle nil cases
  - Fixed can_decrypt? expectations
  - Added test coverage for new secret states
  - Updated domain strategy tests

Alternate resolution for #974


___

### **PR Type**
Enhancement, Bug fix, Tests


___

### **Description**
- Introduced bifurcated logic classes for API v1 and v2.

- Improved secret state management and security handling.

- Updated domain strategy logic and related components.

- Enhanced test coverage for new and existing functionalities.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>8 files</summary><table>
<tr>
  <td><strong>QuietHeader.vue</strong><dd><code>Adjusted masthead rendering logic based on domain strategy.</code></dd></td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/975/files#diff-6d2210943db05772fe5993f3e6ce221c2ac705ed9c2f3ff2659fe0be4d983b98">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>HomepageContainer.vue</strong><dd><code>Simplified domain strategy handling for homepage rendering.</code></dd></td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/975/files#diff-3da2ecfdf38ac5dc41db6d55f0d52c3a7312e97dc77d136ddf3b61309e54c235">+3/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>detect_host.rb</strong><dd><code>Improved logging for host detection and invalid host warnings.</code></dd></td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/975/files#diff-ce7e6afdc47abdd4dff10acab378d1b2ae415fee42871c9737cfd9627f9bde95">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>domain_strategy.rb</strong><dd><code>Refined domain strategy processing and state determination.</code></dd></td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/975/files#diff-8d8cf87f3bc1a5fb5031bdc58113b69c17b0215be65e308c77f91e52e1423a06">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>secret.rb</strong><dd><code>Improved secret state transitions and added receivable logic.</code></dd></td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/975/files#diff-dc6c15bf06b485edaff44c409b33490b677eb464e874ba3103949b9c699bf9d9">+21/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>metadata.routes.ts</strong><dd><code>Simplified domain strategy handling in route guards.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/975/files#diff-9227bda50545aa858388ca86d03458c1536cf520b543c96280370419450436f2">+4/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>public.routes.ts</strong><dd><code>Simplified domain strategy handling in public routes.</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/975/files#diff-a985431b279ab325689cbf3a84286e7ed88863fec6ed258955dc6a63d35fc5a2">+2/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>identityStore.ts</strong><dd><code>Enhanced identity store with additional fields and validations.</code></dd></td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/975/files#diff-55467110c1149898245c7b0995e50dcda83f5391b70ae529ab6e3dd8fa3dfac7">+19/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>endpoints.rb</strong><dd><code>Updated parameter handling for secret conceal and generate endpoints.</code></dd></td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/975/files#diff-e17d694dc40e7bbeafa40181fe082407e5cc75e1a0401e73965b47cdeaa9d23e">+2/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>reveal_secret.rb</strong><dd><code>Added guard to prevent null secret in success data.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/975/files#diff-3b7269d3163de7512cb51c91c2aa54ad761463237b8f61e491d2bdbb01dde3a6">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>show_secret.rb</strong><dd><code>Enhanced secret handling with guards and success data validation.</code></dd></td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/975/files#diff-bfb942ea4f0fa88ed76fd1d2d680eefb4b3a8fa389d0b375ded4d8f459aec423">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>base.rb</strong><dd><code>Added comments for canonical domain normalization improvements.</code></dd></td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/975/files#diff-a5d4e462fd47bbc94ac209ba3bdad2ef72c7bdb5948808941a06805e38e59836">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>7 files</summary><table>
<tr>
  <td><strong>19_safe_dump_try.rb</strong><dd><code>Updated tests for safe dump fields in customer model.</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/975/files#diff-14547df01e43118af5f5d7b21af53cef2c89684002383146f748392b2b3860c2">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>42_web_template_vuepoint_try.rb</strong><dd><code>Adjusted tests for VuePoint authentication and locale handling.</code></dd></td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/975/files#diff-ff095953cef36601684b3c9e3dca1269a4bc2e9fa37bfec6bf8622dbe5d2586c">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>03_logic_secrets_try.rb</strong><dd><code>Updated tests for secret conceal logic with new parameter structure.</code></dd></td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/975/files#diff-a4c56bc9365fe5d818822009e83d7a2875fc2e5a01ef4b4a71ec96f95889ef30">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>22_logic_secrets_show_secret_try.rb</strong><dd><code>Enhanced tests for show secret logic and success data validation.</code></dd></td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/975/files#diff-9466dc3b5be1d24f6b33ad1c3777428c132e56f40d6e462832413959b3a95df3">+19/-35</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>23_logic_secrets_reveal_secret_try.rb</strong><dd><code>Enhanced tests for reveal secret logic and success data validation.</code></dd></td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/975/files#diff-caa3b1c5de6f81be4978df6aaf7d61314f3b4bcc6bbe17a50bf9ba7f2c4d07fe">+14/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>90_routes_smoketest_try.rb</strong><dd><code>Fixed test for about page accessibility.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/975/files#diff-9714947eb455100ed9ec9894f9abb37986b559ae6243ae89533c9aaca75cdc36">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>91_authentication_routes_try.rb</strong><dd><code>Updated API share endpoint test for new status code.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/975/files#diff-36354ff662bf61e3402a98370080f94d0dc8018fb90fa062084da9aa8d5e89e2">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any question about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>