### PR TITLE
Fix validation error on secret reveal and enhance domain strategy middleware documentation

### DIFF
--- a/lib/onetime/middleware/domain_strategy.rb
+++ b/lib/onetime/middleware/domain_strategy.rb
@@ -109,8 +109,8 @@ module Onetime
         # @param request_domain [String] The domain associated to the current request
         # @param canonical_domain [PublicSuffix::Domain, String] The canonical domain.
         def choose_strategy(request_domain, canonical_domain)
-          canonical_domain = PublicSuffix.parse(canonical_domain) unless canonical_domain.is_a?(PublicSuffix::Domain)
-          request_domain = PublicSuffix.parse(request_domain)
+          canonical_domain = Parser.parse(canonical_domain) unless canonical_domain.is_a?(PublicSuffix::Domain)
+          request_domain = Parser.parse(request_domain)
 
           case request_domain
           when ->(d) { equal_to?(d, canonical_domain) }    then :canonical

--- a/lib/onetime/models/secret.rb
+++ b/lib/onetime/models/secret.rb
@@ -209,10 +209,18 @@ module Onetime
       # the secret is viewable. If we don't change the state here, the secret
       # will still be viewable b/c (state?(:new) || state?(:viewed) == true).
       @state = 'received'
+      # We clear the value and passphrase_temp immediately so that the secret
+      # payload is not recoverable from this instance of the secret; however,
+      # we shouldn't clear arbitrary fields here b/c there are valid reasons
+      # to be able to call secret.safe_dump for example. This is exactly what
+      # happens in Logic::RevealSecret.process which prepares the secret value
+      # to be included in the response and then calls this method att the end.
+      # It's at that point that `Logic::RevealSecret.success_data` is called
+      # which means if we were to clear out say -- original_size -- it would
+      # be null in the API's JSON response. Not a huge deal in that case, but
+      # we validate response data in the UI now and this would raise an error.
       @value = nil
       @passphrase_temp = nil
-      @metadata_key = nil
-      @original_size = nil
       self.destroy!
     end
 


### PR DESCRIPTION
### **User description**
Address a validation error encountered during secret reveal and improve the documentation for the domain strategy middleware to clarify its functionality and design philosophy.


___

### **PR Type**
Bug fix, Documentation


___

### **Description**
- Fixed validation error in `received!` method of `Secret` model.

- Enhanced documentation for `DomainStrategy` middleware:
  - Detailed domain classification strategies and design philosophy.
  - Explained implementation steps and tradeoffs.

- Improved domain parsing logic in `choose_strategy` method.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>domain_strategy.rb</strong><dd><code>Enhanced documentation and improved domain parsing logic</code>&nbsp; </dd></summary>
<hr>

lib/onetime/middleware/domain_strategy.rb

<li>Expanded and clarified documentation for domain classification <br>strategies.<br> <li> Added implementation details and design philosophy for middleware.<br> <li> Updated domain parsing logic to use <code>PublicSuffix.parse</code>.


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/978/files#diff-8d8cf87f3bc1a5fb5031bdc58113b69c17b0215be65e308c77f91e52e1423a06">+45/-11</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>secret.rb</strong><dd><code>Fixed validation and clarified state handling in `received!`</code></dd></summary>
<hr>

lib/onetime/models/secret.rb

<li>Fixed validation error in <code>received!</code> method.<br> <li> Added comments to clarify state handling and field clearing logic.<br> <li> Ensured secret payload is cleared without affecting valid fields.


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/978/files#diff-dc6c15bf06b485edaff44c409b33490b677eb464e874ba3103949b9c699bf9d9">+10/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any question about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>