### PR TITLE
Fix domain strategy chooser to use full hostname

### DIFF
--- a/lib/onetime/logic/secrets/base_secret_action.rb
+++ b/lib/onetime/logic/secrets/base_secret_action.rb
@@ -230,7 +230,7 @@ module Onetime::Logic
         end
 
         unless domain_record.owner?(@cust)
-          raise_form_error "Unauthorized domain access: #{share_domain}"
+          OT.li "[validate_domain_perm]: #{share_domain} non-owner [#{cust.custid}]"
         end
       end
     end

--- a/lib/onetime/middleware/domain_strategy.rb
+++ b/lib/onetime/middleware/domain_strategy.rb
@@ -117,7 +117,7 @@ module Onetime
           when ->(d) { peer_of?(d, canonical_domain) }     then :canonical
           when ->(d) { parent_of?(d, canonical_domain)}    then :canonical
           when ->(d) { subdomain_of?(d, canonical_domain)} then :subdomain
-          when ->(d) { known_custom_domain?(d.domain)}     then :custom
+          when ->(d) { known_custom_domain?(d.name)}       then :custom
           else
             nil
           end

--- a/src/components/secrets/branded/SecretConfirmationForm.vue
+++ b/src/components/secrets/branded/SecretConfirmationForm.vue
@@ -1,24 +1,28 @@
 <script setup lang="ts">
 import { Secret, SecretDetails, brandSettingschema } from '@/schemas/models';
-import { useSecretStore } from '@/stores/secretStore';
 import { useProductIdentity } from '@/stores/identityStore';
 import { ref, computed } from 'vue';
-
 import BaseSecretDisplay from './BaseSecretDisplay.vue';
+
 
 interface Props {
   secretKey: string;
   record: Secret | null;
   details: SecretDetails | null;
   domainId: string;
+  isSubmitting: boolean;
+  error: unknown;
 }
 
 const props = defineProps<Props>();
-const emit = defineEmits(['secret-loaded']);
-const secretStore = useSecretStore();
+
+const emit = defineEmits(['user-confirmed']);
+// const useSecret = useSecret();
 const passphrase = ref('');
-const isSubmitting = ref(false);
-const error = ref('');
+
+const submitForm = async () => {
+  emit('user-confirmed', passphrase);
+};
 
 const productIdentity = useProductIdentity();
 const brandSettings = productIdentity.brand; // Not reactive
@@ -26,32 +30,6 @@ const defaultBranding = brandSettingschema.parse({});
 const safeBrandSettings = computed(() =>
   brandSettings ? brandSettingschema.parse(brandSettings) : defaultBranding
 );
-
-const submitForm = async () => {
-  if (isSubmitting.value) return;
-
-  isSubmitting.value = true;
-  try {
-    const response = await secretStore.reveal(props.secretKey, passphrase.value);
-    // Announce success to screen readers
-    const announcement = document.createElement('div');
-    announcement.setAttribute('role', 'status');
-    announcement.setAttribute('aria-live', 'polite');
-    announcement.textContent = 'Secret revealed successfully';
-    document.body.appendChild(announcement);
-    setTimeout(() => announcement.remove(), 1000);
-
-    // Emit the secret-loaded event with the response data
-    emit('secret-loaded', {
-      record: response.record,
-      details: response.details
-    });
-  } catch (err) {
-    error.value = err instanceof Error ? err.message : 'Failed to reveal secret';
-  } finally {
-    isSubmitting.value = false;
-  }
-};
 
 const hasImageError = ref(false);
 
@@ -74,126 +52,110 @@ const logoImage = ref<string>(`/imagine/${props.domainId}/logo.png`);
 </script>
 
 <template>
-  <BaseSecretDisplay
-    default-title="You have a message"
-    :domain-branding="safeBrandSettings"
-    :instructions="brandSettings?.instructions_pre_reveal">
+  <BaseSecretDisplay default-title="You have a message"
+                     :domain-branding="safeBrandSettings"
+                     :instructions="brandSettings?.instructions_pre_reveal">
     <template #logo>
-        <div class="relative mx-auto sm:mx-0">
+      <div class="relative mx-auto sm:mx-0">
         <div :class="[cornerStyle, 'size-14 sm:size-16 overflow-hidden']">
           <!-- Background container with matching corner style -->
-          <div
-            :class="[
+          <div :class="[
               cornerStyle,
               'absolute inset-0 flex items-center justify-center bg-gray-100 dark:bg-gray-700',
               { 'hidden': logoImage && !hasImageError }
             ]">
-              <!-- Default lock icon -->
-              <svg
-                v-if="!logoImage || hasImageError"
-                class="size-8 text-gray-400 dark:text-gray-500"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                aria-hidden="true">
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"
-                />
-              </svg>
-            </div>
-
-            <!-- Logo -->
-            <img
-              v-if="logoImage && !hasImageError"
-              :src="logoImage"
-              alt="Brand logo"
-              class="size-full object-contain"
-              :class="cornerStyle"
-              @error="handleImageError"
-            />
+            <!-- Default lock icon -->
+            <svg v-if="!logoImage || hasImageError"
+                 class="size-8 text-gray-400 dark:text-gray-500"
+                 viewBox="0 0 24 24"
+                 fill="none"
+                 stroke="currentColor"
+                 aria-hidden="true">
+              <path stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
+            </svg>
           </div>
+
+          <!-- Logo -->
+          <img v-if="logoImage && !hasImageError"
+               :src="logoImage"
+               alt="Brand logo"
+               class="size-full object-contain"
+               :class="cornerStyle"
+               @error="handleImageError" />
         </div>
-      </template>
+      </div>
+    </template>
 
     <template #content>
-      <div
-        class="flex items-center text-gray-400 dark:text-gray-500"
-        role="status"
-        aria-label="Content status">
-        <svg
-          class="mr-2 size-5"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          aria-hidden="true">
-          <path
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-            d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7A9.97 9.97 0 014.02 8.971m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21"
-          />
+      <div class="flex items-center text-gray-400 dark:text-gray-500"
+           role="status"
+           aria-label="Content status">
+        <svg class="mr-2 size-5"
+             viewBox="0 0 24 24"
+             fill="none"
+             stroke="currentColor"
+             aria-hidden="true">
+          <path stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7A9.97 9.97 0 014.02 8.971m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21" />
         </svg>
         <span class="text-sm">Content hidden</span>
       </div>
     </template>
 
     <template #action-button>
-      <form @submit.prevent="submitForm" aria-label="Secret access form">
+      <form @submit.prevent="submitForm"
+            aria-label="Secret access form">
         <!-- Error Message -->
-        <div
-          v-if="error"
-          class="mb-4 rounded-md bg-red-50 p-4 text-sm text-red-700 dark:bg-red-900/50 dark:text-red-200"
-          role="alert">
+        <div v-if="error"
+             class="mb-4 rounded-md bg-red-50 p-4 text-sm text-red-700 dark:bg-red-900/50 dark:text-red-200"
+             role="alert">
           {{ error }}
         </div>
 
         <!-- Passphrase Input -->
-        <div
-          v-if="record?.has_passphrase"
-          class="mb-4 space-y-2">
-          <label
-            :for="'passphrase-' + secretKey"
-            class="sr-only">
+        <div v-if="record?.has_passphrase"
+             class="mb-4 space-y-2">
+          <label :for="'passphrase-' + secretKey"
+                 class="sr-only">
             {{ $t('web.COMMON.enter_passphrase_here') }}
           </label>
-          <input
-            v-model="passphrase"
-            :id="'passphrase-' + secretKey"
-            type="password"
-            name="passphrase"
-            :class="{
+          <input v-model="passphrase"
+                 :id="'passphrase-' + secretKey"
+                 type="password"
+                 name="passphrase"
+                 :class="{
               'rounded-lg': brandSettings?.corner_style === 'rounded',
               'rounded-2xl': brandSettings?.corner_style === 'pill',
               'rounded-none': brandSettings?.corner_style === 'square',
               'w-full border border-gray-300 px-4 py-2 focus:outline-none focus:ring-2 focus:ring-offset-2 dark:border-gray-600 dark:bg-gray-700 dark:text-white': true
             }"
-            autocomplete="current-password"
-            :aria-label="$t('web.COMMON.enter_passphrase_here')"
-            :placeholder="$t('web.COMMON.enter_passphrase_here')"
-            aria-required="true"
-          />
+                 autocomplete="current-password"
+                 :aria-label="$t('web.COMMON.enter_passphrase_here')"
+                 :placeholder="$t('web.COMMON.enter_passphrase_here')"
+                 aria-required="true" />
         </div>
 
         <!-- Submit Button -->
-        <button
-          type="submit"
-          :disabled="isSubmitting"
-          :class="{
+        <button type="submit"
+                :disabled="isSubmitting"
+                :class="{
             'rounded-lg': brandSettings?.corner_style === 'rounded',
             'rounded-full': brandSettings?.corner_style === 'pill',
             'rounded-none': brandSettings?.corner_style === 'square',
             [`font-${brandSettings?.font_family}`]: true,
             'w-full py-3 text-base font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50 sm:text-lg': true
           }"
-          :style="{
-            backgroundColor: brandSettings?.primary_color || 'var(--tw-color-brand-500)',
-            color: brandSettings?.button_text_light ? '#ffffff' : '#000000',
+                :style="{
+            backgroundColor: brandSettings?.primary_color ?? '#dc4a22',
+            color: brandSettings?.button_text_light ? '#ffffff' : '#222222',
           }"
-          class="focus:outline-none focus:ring-2 focus:ring-brand-500 focus:ring-offset-2"
-          aria-live="polite">
+                class="focus:outline-none focus:ring-2 focus:ring-brand-500 focus:ring-offset-2"
+                aria-live="polite">
           <span class="sr-only">{{ isSubmitting ? 'Submitting...' : 'Click to continue' }}</span>
           {{ isSubmitting ? $t('web.COMMON.submitting') : $t('web.COMMON.click_to_continue') }}
         </button>
@@ -215,5 +177,4 @@ const logoImage = ref<string>(`/imagine/${props.domainId}/logo.png`);
   outline: 2px solid currentColor;
   outline-offset: 2px;
 }
-
 </style>

--- a/src/components/secrets/canonical/SecretDisplayCase.vue
+++ b/src/components/secrets/canonical/SecretDisplayCase.vue
@@ -218,8 +218,7 @@ const closeTruncatedWarning = (event: Event) => {
             <span aria-hidden="true">&times;</span>
           </button>
           <p>
-            Once you've finished viewing the secret, feel free to navigate away from this page or
-            close the window.
+            Once you've finished viewing the secret, feel free to close the window.
           </p>
         </div>
         <div v-else>

--- a/src/composables/useAsyncHandler.ts
+++ b/src/composables/useAsyncHandler.ts
@@ -1,6 +1,11 @@
 // src/composables/useAsyncHandler.ts
 import type { ApplicationError } from '@/schemas/errors';
-import { classifyError, createError, errorGuards, wrapError } from '@/schemas/errors';
+import {
+  classifyError,
+  createError,
+  errorGuards,
+  wrapError,
+} from '@/schemas/errors';
 import { loggingService } from '@/services/logging.service';
 import type {} from '@/stores/notificationsStore';
 import type { NotificationSeverity } from '@/types/ui/notifications';

--- a/src/composables/useDomainsManager.ts
+++ b/src/composables/useDomainsManager.ts
@@ -36,7 +36,9 @@ export function useDomainsManager() {
   const error = ref<ApplicationError | null>(null); // Add local error state
 
   const defaultAsyncHandlerOptions: AsyncHandlerOptions = {
-    notify: (message, severity) => notifications.show(message, severity),
+    notify: (message, severity) => {
+      notifications.show(message, severity);
+    },
     setLoading: (loading) => (isLoading.value = loading),
     onError: (err) => (error.value = err),
   };
@@ -75,7 +77,10 @@ export function useDomainsManager() {
   const verifyDomain = async (domainName: string) =>
     wrap(async () => {
       const result = await store.verifyDomain(domainName);
-      notifications.show('Domain verification initiated successfully', 'success');
+      notifications.show(
+        'Domain verification initiated successfully',
+        'success'
+      );
       return result;
     });
 
@@ -104,7 +109,10 @@ export function useDomainsManager() {
     });
 
   const confirmDelete = async (domainId: string): Promise<string | null> => {
-    console.debug('[useDomainsManager] Confirming delete for domain:', domainId);
+    console.debug(
+      '[useDomainsManager] Confirming delete for domain:',
+      domainId
+    );
 
     try {
       const confirmed = await showConfirmDialog({

--- a/src/composables/useSecret.ts
+++ b/src/composables/useSecret.ts
@@ -2,13 +2,10 @@
 
 import { useSecretStore } from '@/stores/secretStore';
 import { storeToRefs } from 'pinia';
-import { reactive, ref } from 'vue';
-import { useNotificationsStore } from '@/stores/notificationsStore';
-import { NotificationSeverity } from '@/types/ui/notifications';
+import { reactive } from 'vue';
 import { AsyncHandlerOptions, useAsyncHandler } from './useAsyncHandler';
-import { ApplicationError } from '@/schemas/errors';
 
-export function useSecret(secretKey: string) {
+export function useSecret(secretKey: string, options?: AsyncHandlerOptions) {
   const store = useSecretStore();
   const { record, details } = storeToRefs(store);
 
@@ -19,15 +16,17 @@ export function useSecret(secretKey: string) {
     passphrase: '',
   });
 
-  const notifications = useNotificationsStore();
-  const isLoading = ref(false);
-  const error = ref<ApplicationError | null>(null);
-
   const defaultAsyncHandlerOptions: AsyncHandlerOptions = {
-    notify: (message, severity) =>
-      notifications.show(message, severity as NotificationSeverity),
-    setLoading: (loading) => (isLoading.value = loading),
-    onError: (err) => (error.value = err),
+    notify: (message, severity) => {
+      if (severity === 'error') {
+        state.error = message;
+      } else {
+        state.success = message;
+      }
+    },
+    setLoading: (loading) => (state.isLoading = loading),
+    onError: () => (state.success = ''),
+    ...options,
   };
 
   const { wrap } = useAsyncHandler(defaultAsyncHandlerOptions);

--- a/src/schemas/errors/classifier.ts
+++ b/src/schemas/errors/classifier.ts
@@ -49,15 +49,27 @@ export const errorClassifier = {
   },
 
   classifyHttp(error: HttpErrorLike): ApplicationError {
+    if (!error.response) {
+      return wrapError(
+        error.message || 'Network Error',
+        'technical',
+        'error',
+        error as Error,
+        error.status // there may not be a status
+      );
+    }
+
     const status = error.status || error.response?.status;
     const type = status ? this.getTypeFromStatus(status) : 'technical';
+    const details = error.response?.data || {};
 
     return wrapError(
-      error.message || 'HTTP Error',
+      details.message || error.message || 'HTTP Error',
       type,
       'error',
       error as Error,
-      status
+      status,
+      details // include the response payload
     );
   },
 

--- a/src/views/secrets/branded/ShowSecret.vue
+++ b/src/views/secrets/branded/ShowSecret.vue
@@ -54,7 +54,7 @@
     </template>
 
     <!-- Confirmation slot -->
-    <template #confirmation="{ secretKey, record, details }">
+    <template #confirmation="{ secretKey, record, details, error, isLoading, onConfirm }">
       <div
         :class="{
           'rounded-lg': brandSettings?.corner_style === 'rounded',
@@ -67,7 +67,10 @@
                                 :record="record"
                                 :details="details"
                                 :domain-id="domainId"
-                                :display-powered-by="true" />
+                                :error="error"
+                                :is-submitting="isLoading"
+                                :display-powered-by="true"
+                                @user-confirmed="onConfirm" />
       </div>
     </template>
 

--- a/tests/unit/ruby/try/50_middleware/20_domain_strategy_try.rb
+++ b/tests/unit/ruby/try/50_middleware/20_domain_strategy_try.rb
@@ -50,6 +50,13 @@ custom_domain = Onetime::CustomDomain.create(@canonical_domain, @customer_id)
 @chooser.choose_strategy(custom_domain.display_domain, @canonical_domain)
 #=> :canonical
 
+## parent_of? matches parent to child relationship (configured onetimesecret.com)
+custom_domain = Onetime::CustomDomain.create('fr.example.com', @customer_id)
+@delete_domains << custom_domain
+@chooser.known_custom_domain?(custom_domain.display_domain)
+#=> true
+
+
 # Teardown
 @delete_domains.map { |d|
   OT.ld "Deleting custom domain: #{d}"

--- a/tests/unit/ruby/try/50_middleware/21_domain_strategy_multiple_canonical_try.rb
+++ b/tests/unit/ruby/try/50_middleware/21_domain_strategy_multiple_canonical_try.rb
@@ -6,7 +6,7 @@ require 'onetime/middleware/domain_strategy'
 OT::Config.path = File.join(Onetime::HOME, 'tests', 'unit', 'ruby', 'config.test.yaml')
 OT.boot! :test
 
-@canonical_domain = 'eu.onetimesecret.com'
+@canonical_domain = 'eu.example.com'
 @parser = Onetime::DomainStrategy::Parser
 @chooser = Onetime::DomainStrategy::Chooserator
 
@@ -16,21 +16,21 @@ OT.boot! :test
 #=> :canonical
 
 ## Valid subdomain passes validation
-@chooser.choose_strategy('onetimesecret.com', @canonical_domain)
-#=> nil
+@chooser.choose_strategy('example.com', @canonical_domain)
+#=> :canonical
 
 ## Domain with consecutive dots fails validation
-@chooser.choose_strategy('us.onetimesecret.com', @canonical_domain)
+@chooser.choose_strategy('us.example.com', @canonical_domain)
 #=> :canonical
 
 ## Valid subdomain passes validation
-@chooser.choose_strategy('onetimesecret.com', 'onetimesecret.com')
+@chooser.choose_strategy('example.com', 'example.com')
 #=> :canonical
 
 ## Valid subdomain passes validation
-@chooser.choose_strategy('eu.onetimesecret.com', 'onetimesecret.com')
+@chooser.choose_strategy('eu.example.com', 'example.com')
 #=> :subdomain
 
 ## Valid subdomain passes validation
-@chooser.choose_strategy('onetimesecret.com', 'eu.onetimesecret.com')
-#=> nil
+@chooser.choose_strategy('example.com', 'eu.example.com')
+#=> :canonical

--- a/tests/unit/ruby/try/50_middleware/22_domain_strategy_chooserator_try.rb
+++ b/tests/unit/ruby/try/50_middleware/22_domain_strategy_chooserator_try.rb
@@ -1,4 +1,5 @@
-# tryouts/domain_strategy_chooserator_tryouts.rb
+# tests/unit/ruby/try/50_middleware/22_domain_strategy_chooserator_try.rb
+
 require 'onetime'
 require 'middleware/detect_host'
 require 'onetime/middleware/domain_strategy'
@@ -55,17 +56,17 @@ Onetime::DomainStrategy::Chooserator.parent_of?(
 )
 #=> true
 
-## parent_of? matches parent to child relationship (configured eu.onetimesecret.com)
+## parent_of? matches parent to child relationship (configured eu.example.com)
 Onetime::DomainStrategy::Chooserator.parent_of?(
-  PublicSuffix.parse('onetimesecret.com'),
-  PublicSuffix.parse('eu.onetimesecret.com')
+  PublicSuffix.parse('example.com'),
+  PublicSuffix.parse('eu.example.com')
 )
 #=> true
 
-## parent_of? matches parent to child relationship (configured onetimesecret.com)
+## parent_of? matches parent to child relationship (configured example.com)
 Onetime::DomainStrategy::Chooserator.subdomain_of?(
-  PublicSuffix.parse('eu.onetimesecret.com'),
-  PublicSuffix.parse('onetimesecret.com')
+  PublicSuffix.parse('eu.example.com'),
+  PublicSuffix.parse('example.com')
 )
 #=> true
 


### PR DESCRIPTION
### **User description**
Correct the method used to check for known custom domains by switching from `domain` to `name`, ensuring the full hostname is utilized. Update related tests and examples to reflect the changes.


___

### **PR Type**
Bug fix, Enhancement, Tests


___

### **Description**
- Fix `choose_strategy` to use full hostname via `name` instead of `domain`.

- Simplify and enhance `SecretConfirmationForm` with better error handling and submission flow.

- Improve HTTP error classification by including response payload details.

- Update and expand tests for domain strategy logic and custom domain handling.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>SecretConfirmationForm.vue</strong><dd><code>Simplify secret confirmation form and improve submission logic</code></dd></td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/979/files#diff-0a22567781b397eef11c23726cc20e5e903302e968c85708eea5c70c47bd23ba">+75/-114</a></td>

</tr>

<tr>
  <td><strong>ShowSecret.vue</strong><dd><code>Add error and loading state handling to branded secret view</code></dd></td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/979/files#diff-48ce6313e95742eee5c2835a493bd0edadf3d43d4cfe4709464fbb11966b7220">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>useAsyncHandler.ts</strong><dd><code>Adjust error handling and notification logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/979/files#diff-646c1b297c495b241182b0b9e876bc4565d668b0733df23dfacafebb53fe85ba">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>useDomainsManager.ts</strong><dd><code>Refactor domain manager for better notifications and error handling</code></dd></td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/979/files#diff-40d16b8f1e1d2d771a393f1bcc379830c486db8e2fbad56f8cc371b1841c47ab">+11/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>useSecret.ts</strong><dd><code>Refactor secret composable for improved state management</code>&nbsp; </dd></td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/979/files#diff-c3cc9bd018b1280714e4f8b02b37199532808e531eea32cd5e3b8983f93f55b8">+13/-12</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Formatting</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>SecretDisplayCase.vue</strong><dd><code>Minor text adjustment in secret display case</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/979/files#diff-dc7e0bc55a4d1015b6321500c6ff7fce0b47482a8ada748cefa67deb2ca78494">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Error handling</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>base_secret_action.rb</strong><dd><code>Log unauthorized domain access instead of raising error</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/979/files#diff-859c644b87b7f82e1a2438049bce6f15cd6c6a70d2bee4bf3617a0347b7f6709">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>domain_strategy.rb</strong><dd><code>Fix domain strategy chooser to use full hostname</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/979/files#diff-8d8cf87f3bc1a5fb5031bdc58113b69c17b0215be65e308c77f91e52e1423a06">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>classifier.ts</strong><dd><code>Enhance HTTP error classification with response payload details</code></dd></td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/979/files#diff-01bc1e04d6be09e151ecdee70b76f647c485f9cec594da15f626025f6f632edd">+14/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>20_domain_strategy_try.rb</strong><dd><code>Add tests for known custom domain with full hostname</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/979/files#diff-abf0c2768fe15dec163dd0355b5db709aa9b164c33e6eb9c3fbeb7cca8d21a5d">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>21_domain_strategy_multiple_canonical_try.rb</strong><dd><code>Update tests for multiple canonical domain strategies</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/979/files#diff-1e3a50b042d9a4b19eb191d3d7bfad4e94267b17877401ecfc73ac11aba2faab">+8/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>22_domain_strategy_chooserator_try.rb</strong><dd><code>Update chooserator tests for parent-child domain relationships</code></dd></td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/979/files#diff-3bfe7fc5e5b99ca90b8ec0ed52d5bf6d1d9acf080d3a0ead52e21eb6f289d8f3">+8/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any question about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>