### PR TITLE
Fix: API call via cURL doesn't propagate TTL properly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ pnpm-debug.log*
 
 .appendonlydir/
 .bundle/
+.rspec
 appendonlydir/
 data/
 node_modules/

--- a/Gemfile
+++ b/Gemfile
@@ -88,3 +88,11 @@ gem 'stackprof', require: false, group: :staging # bundle exec stackprof --text 
 gem 'stripe', require: false, group: :plans # bundle install --group plans
 gem 'tapioca', require: false, group: :development
 gem 'tryouts', require: false, group: :development
+
+group :test do
+  gem 'simplecov', require: false
+  gem 'rspec', git: "https://github.com/rspec/rspec"
+  %w[rspec-core rspec-expectations rspec-mocks rspec-support].each do |lib|
+    gem lib, git: "https://github.com/rspec/rspec", glob: "#{lib}/#{lib}.gemspec"
+  end
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,45 @@
+GIT
+  remote: https://github.com/rspec/rspec
+  revision: 5946b3c9aa61279bf52363bfde4d850810daaa3a
+  specs:
+    rspec (3.14.0.pre)
+      rspec-core (= 3.14.0.pre)
+      rspec-expectations (= 3.14.0.pre)
+      rspec-mocks (= 3.14.0.pre)
+
+GIT
+  remote: https://github.com/rspec/rspec
+  revision: 5946b3c9aa61279bf52363bfde4d850810daaa3a
+  glob: rspec-core/rspec-core.gemspec
+  specs:
+    rspec-core (3.14.0.pre)
+      rspec-support (= 3.14.0.pre)
+
+GIT
+  remote: https://github.com/rspec/rspec
+  revision: 5946b3c9aa61279bf52363bfde4d850810daaa3a
+  glob: rspec-expectations/rspec-expectations.gemspec
+  specs:
+    rspec-expectations (3.14.0.pre)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (= 3.14.0.pre)
+
+GIT
+  remote: https://github.com/rspec/rspec
+  revision: 5946b3c9aa61279bf52363bfde4d850810daaa3a
+  glob: rspec-mocks/rspec-mocks.gemspec
+  specs:
+    rspec-mocks (3.14.0.pre)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (= 3.14.0.pre)
+
+GIT
+  remote: https://github.com/rspec/rspec
+  revision: 5946b3c9aa61279bf52363bfde4d850810daaa3a
+  glob: rspec-support/rspec-support.gemspec
+  specs:
+    rspec-support (3.14.0.pre)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -19,6 +61,8 @@ GEM
     csv (3.3.0)
     daemons (1.4.1)
     date (3.4.0)
+    diff-lcs (1.5.1)
+    docile (1.4.1)
     dotenv (3.1.4)
     drydock (0.6.9)
     encryptor (1.1.3)
@@ -125,6 +169,12 @@ GEM
     sentry-ruby (5.21.0)
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.13.1)
+    simplecov_json_formatter (0.1.4)
     simpleidn (0.2.3)
     sorbet (0.5.11751)
       sorbet-static (= 0.5.11751)
@@ -208,11 +258,17 @@ DEPENDENCIES
   rack-proxy
   rdoc
   redis (~> 5.3.0)
+  rspec!
+  rspec-core!
+  rspec-expectations!
+  rspec-mocks!
+  rspec-support!
   rubocop
   rubocop-performance
   rubocop-thread_safety
   sendgrid-ruby
   sentry-ruby
+  simplecov
   sorbet
   sorbet-runtime
   spoom

--- a/lib/onetime/alias.rb
+++ b/lib/onetime/alias.rb
@@ -1,3 +1,4 @@
+# lib/onetime/alias.rb
 # typed: ignore
 
 # This file exists solely to define the OT = Onetime constant.

--- a/lib/onetime/logic/base.rb
+++ b/lib/onetime/logic/base.rb
@@ -4,6 +4,7 @@ require 'stathat'
 require 'timeout'
 
 require_relative 'logic_helpers'
+require_relative '../refinements/rack_refinements'
 
 module Onetime
   module Logic

--- a/lib/onetime/logic/secrets/base_secret_action.rb
+++ b/lib/onetime/logic/secrets/base_secret_action.rb
@@ -5,6 +5,7 @@ module Onetime::Logic
       attr_reader :passphrase, :secret_value, :kind, :ttl, :recipient, :recipient_safe, :greenlighted
       attr_reader :metadata, :secret, :share_domain, :custom_domain, :payload
       attr_accessor :token
+      using Onetime::RackRefinements
 
       # Process methods populate instance variables with the values. The
       # raise_concerns and process methods deal with the values in the instance

--- a/lib/onetime/refinements/rack_refinements.rb
+++ b/lib/onetime/refinements/rack_refinements.rb
@@ -22,11 +22,11 @@ module Onetime
         end
       end
 
-      def dig(key, *args)
-        OT.ld "[Hash#dig] key: #{key}, args: #{args}"
-        value = fetch(key, nil)
-        return value if args.empty? || value.nil?
-        value.dig(*args) if value.respond_to?(:dig)
+      def dig(key, *rest)
+        OT.ld "[Hash#dig] key: #{key}, rest: #{rest}"
+        value = fetch(key, nil)  # Explicitly pass nil as default
+        return value if rest.empty? || value.nil?
+        value.respond_to?(:dig) ? value.dig(*rest) : nil
       end
     end
   end

--- a/lib/onetime/refinements/rack_refinements.rb
+++ b/lib/onetime/refinements/rack_refinements.rb
@@ -8,18 +8,12 @@ module Onetime
         OT.ld "[Hash#fetch] key: #{key}, args: #{args}"
         string_key = key.to_s
         symbol_key = key.respond_to?(:to_sym) ? key.to_sym : nil
-
-        if key?(string_key)
-          super(string_key, *args)
-        elsif symbol_key && key?(symbol_key)
-          super(symbol_key, *args)
-        elsif block_given?
-          yield key
-        elsif args.any?
-          args.first
-        else
-          raise KeyError, "key not found: #{key.inspect}"
-        end
+        return super(string_key, *args) if key?(string_key)
+        return super(symbol_key, *args) if symbol_key && key?(symbol_key)
+        return yield(key) if block_given?
+        return args.first if args.length > 0
+        return nil if args == [nil]  # Handle explicit nil default
+        raise KeyError, "key not found: #{key.inspect}"
       end
 
       def dig(key, *rest)

--- a/lib/onetime/refinements/rack_refinements.rb
+++ b/lib/onetime/refinements/rack_refinements.rb
@@ -1,0 +1,32 @@
+# rubocop:disable
+
+# lives in lib/onetime/refinements
+
+module Onetime::RackRefinements
+  refine Hash do
+    def fetch(key, *args)
+      OT.ld "[Hash#fetch] key: #{key}, args: #{args}"
+      string_key = key.to_s
+      symbol_key = key.respond_to?(:to_sym) ? key.to_sym : nil
+
+      if key?(string_key)
+        super(string_key, *args)
+      elsif symbol_key && key?(symbol_key)
+        super(symbol_key, *args)
+      elsif block_given?
+        yield key
+      elsif args.any?
+        args.first
+      else
+        raise KeyError, "key not found: #{key.inspect}"
+      end
+    end
+
+    def dig(key, *args)
+      OT.ld "[Hash#dig] key: #{key}, args: #{args}"
+      value = fetch(key, nil)
+      return value if args.empty? || value.nil?
+      value.dig(*args) if value.respond_to?(:dig)
+    end
+  end
+end

--- a/lib/onetime/refinements/rack_refinements.rb
+++ b/lib/onetime/refinements/rack_refinements.rb
@@ -1,32 +1,33 @@
+# lib/onetime/refinements/rack_refinements.rb
 # rubocop:disable
 
-# lives in lib/onetime/refinements
+module Onetime
+  module RackRefinements
+    refine Hash do
+      def fetch(key, *args)
+        OT.ld "[Hash#fetch] key: #{key}, args: #{args}"
+        string_key = key.to_s
+        symbol_key = key.respond_to?(:to_sym) ? key.to_sym : nil
 
-module Onetime::RackRefinements
-  refine Hash do
-    def fetch(key, *args)
-      OT.ld "[Hash#fetch] key: #{key}, args: #{args}"
-      string_key = key.to_s
-      symbol_key = key.respond_to?(:to_sym) ? key.to_sym : nil
-
-      if key?(string_key)
-        super(string_key, *args)
-      elsif symbol_key && key?(symbol_key)
-        super(symbol_key, *args)
-      elsif block_given?
-        yield key
-      elsif args.any?
-        args.first
-      else
-        raise KeyError, "key not found: #{key.inspect}"
+        if key?(string_key)
+          super(string_key, *args)
+        elsif symbol_key && key?(symbol_key)
+          super(symbol_key, *args)
+        elsif block_given?
+          yield key
+        elsif args.any?
+          args.first
+        else
+          raise KeyError, "key not found: #{key.inspect}"
+        end
       end
-    end
 
-    def dig(key, *args)
-      OT.ld "[Hash#dig] key: #{key}, args: #{args}"
-      value = fetch(key, nil)
-      return value if args.empty? || value.nil?
-      value.dig(*args) if value.respond_to?(:dig)
+      def dig(key, *args)
+        OT.ld "[Hash#dig] key: #{key}, args: #{args}"
+        value = fetch(key, nil)
+        return value if args.empty? || value.nil?
+        value.dig(*args) if value.respond_to?(:dig)
+      end
     end
   end
 end

--- a/lib/onetime/refinements/rack_refinements.rb
+++ b/lib/onetime/refinements/rack_refinements.rb
@@ -5,7 +5,6 @@ module Onetime
   module RackRefinements
     refine Hash do
       def fetch(key, *args)
-        OT.ld "[Hash#fetch] key: #{key}, args: #{args}"
         string_key = key.to_s
         symbol_key = key.respond_to?(:to_sym) ? key.to_sym : nil
         return super(string_key, *args) if key?(string_key)
@@ -17,7 +16,6 @@ module Onetime
       end
 
       def dig(key, *rest)
-        OT.ld "[Hash#dig] key: #{key}, rest: #{rest}"
         value = fetch(key, nil)  # Explicitly pass nil as default
         return value if rest.empty? || value.nil?
         value.respond_to?(:dig) ? value.dig(*rest) : nil

--- a/tests/unit/ruby/rspec/onetime/logic/secrets/base_secret_action_spec.rb
+++ b/tests/unit/ruby/rspec/onetime/logic/secrets/base_secret_action_spec.rb
@@ -1,0 +1,109 @@
+# tests/unit/ruby/rspec/onetime/logic/secrets/base_secret_action_spec.rb
+
+RSpec.describe Onetime::Logic::Secrets::BaseSecretAction do
+  # Create test implementation class
+  class TestSecretAction < Onetime::Logic::Secrets::BaseSecretAction
+    def process_secret
+      @kind = :test
+      @secret_value = "test_secret"
+    end
+  end
+
+  let(:session) { double('Session', event_incr!: nil) }
+  let(:customer) { double('Customer',
+    anonymous?: false,
+    custid: 'cust123',
+    planid: 'anonymous'
+  ) }
+
+  let(:base_params) {{
+    secret: {
+      ttl: '7',
+      recipient: ['test@example.com'],
+      share_domain: 'example.com'
+    }
+  }}
+
+  subject { TestSecretAction.new(session, customer, base_params) }
+
+  before do
+    allow(Onetime::Plan).to receive(:plan).and_return(double('Plan',
+      paid?: false,
+      options: {size: 1024, ttl: 7.days}
+    ))
+    allow(Truemail).to receive(:validate).and_return(
+      double('Validator', result: double('Result', valid?: true), as_json: '{}')
+    )
+  end
+
+  describe '#process_ttl' do
+    it 'sets default TTL when none provided' do
+      subject.instance_variable_set(:@payload, {})
+      subject.send(:process_ttl)
+      expect(subject.ttl).to eq(7.days)
+    end
+
+    it 'enforces minimum TTL' do
+      subject.instance_variable_set(:@payload, {ttl: '30'}) # 30 seconds
+      subject.send(:process_ttl)
+      expect(subject.ttl).to eq(1.minute)
+    end
+
+    it 'enforces minimum TTL' do
+      subject.instance_variable_set(:@payload, {'ttl' => '30'}) # 30 seconds
+      subject.send(:process_ttl)
+      expect(subject.ttl).to eq(1.minute)
+    end
+  end
+
+  describe '#validate_recipient' do
+    context 'with valid recipient' do
+      it 'passes validation for valid email' do
+        subject.instance_variable_set(:@recipient, ['valid@example.com'])
+        expect { subject.send(:validate_recipient) }.not_to raise_error
+      end
+    end
+
+    context 'with invalid recipient' do
+      it 'raises error for anonymous user trying to send email' do
+        allow(customer).to receive(:anonymous?).and_return(true)
+        subject.instance_variable_set(:@recipient, ['test@example.com'])
+
+        expect { subject.send(:validate_recipient) }.to raise_error(
+          OT::FormError, /account is required/
+        )
+      end
+    end
+  end
+
+  describe '#valid_email?' do
+    let(:validator_result) { double('Result', valid?: true) }
+    let(:validator) { double('Validator', result: validator_result, as_json: '{}') }
+
+    it 'returns true for valid email' do
+      allow(Truemail).to receive(:validate).with('test@example.com').and_return(validator)
+      expect(subject.valid_email?('test@example.com')).to be true
+    end
+
+    it 'handles validation errors gracefully' do
+      allow(Truemail).to receive(:validate)
+        .with('test@example.com')
+        .and_raise(StandardError.new('Validation failed'))
+
+      # Ensure we can capture the logging
+      expect(OT).to receive(:le).with('Email validation error: Validation failed')
+      expect(OT).to receive(:le).with(kind_of(Array)) # for backtrace
+
+      expect(subject.valid_email?('test@example.com')).to be false
+    end
+
+    it 'returns false for invalid email format' do
+      allow(validator_result).to receive(:valid?).and_return(false)
+      allow(Truemail).to receive(:validate).with('invalid-email').and_return(validator)
+
+      expect(OT).to receive(:info).with(/Validator \(false\)/)
+
+      expect(subject.valid_email?('invalid-email')).to be false
+    end
+  end
+end

--- a/tests/unit/ruby/rspec/onetime/logic/secrets/show_secret_spec.rb
+++ b/tests/unit/ruby/rspec/onetime/logic/secrets/show_secret_spec.rb
@@ -1,0 +1,102 @@
+# tests/unit/ruby/rspec/onetime/refinements/logic/secrets/show_secret_spec.rb
+
+require_relative '../../../spec_helper.rb'
+
+
+RSpec.describe Onetime::Logic::Secrets::ShowSecret do
+  let(:session) { double('Session') }
+  let(:customer) { double('Customer', anonymous?: false, custid: 'cust123', increment_field: nil ) }
+  let(:owner) { double('Owner', custid: 'owner123', verified?: false, anonymous?: false, increment_field: nil ) }
+
+  let(:secret) do
+    double('Secret',
+      verification: 'false',
+      key: 'secret123',
+      state?: true,
+      owner?: false
+    )
+  end
+
+  let(:base_params) do
+    {
+      key: 'secret123',
+      passphrase: 'pass123',
+      continue: 'true'
+    }
+  end
+
+  subject { described_class.new(session, customer, base_params) }
+
+  before do
+    allow(Onetime::Secret).to receive(:load).with('secret123').and_return(secret)
+    allow(secret).to receive(:load_customer).and_return(owner)
+    allow(OT::Customer).to receive(:global).and_return(double('Global', increment_field: true))
+    allow(OT::Logic).to receive(:stathat_count)
+  end
+
+  describe '#process' do
+    context 'with valid secret' do
+      before do
+        allow(secret).to receive(:viewable?).and_return(true)
+        allow(secret).to receive(:has_passphrase?).and_return(false)
+        allow(secret).to receive(:passphrase?).and_return(true)
+        allow(secret).to receive(:can_decrypt?).and_return(true)
+        allow(secret).to receive(:decrypted_value).and_return('decoded_secret')
+        allow(secret).to receive(:truncated?).and_return(false)
+        allow(secret).to receive(:original_size).and_return(100)
+        allow(secret).to receive(:viewed!)
+        allow(secret).to receive(:received!)
+        allow(secret).to receive(:verification).and_return('false')
+      end
+
+      it 'processes valid secret viewing' do
+        subject.process
+
+        expect(subject.show_secret).to be true
+        expect(subject.secret_value).to eq('decoded_secret')
+        expect(subject.correct_passphrase).to be true
+      end
+    end
+
+    context 'with passphrase protected secret' do
+      before do
+        allow(secret).to receive(:viewable?).and_return(true)
+        allow(secret).to receive(:has_passphrase?).and_return(true)
+        allow(secret).to receive(:passphrase?).with('pass123').and_return(false)
+        allow(secret).to receive(:state?).and_return(true)
+        allow(secret).to receive(:truncated?).and_return(false)
+        allow(secret).to receive(:can_decrypt?).and_return(false)
+        allow(secret).to receive(:viewed!)
+      end
+
+      it 'handles incorrect passphrase' do
+        allow(secret).to receive(:passphrase?).with('pass123').and_return(false)
+
+        expect(subject).to receive(:limit_action).with(:failed_passphrase)
+        subject.process
+
+        expect(subject.correct_passphrase).to be false
+      end
+    end
+  end
+
+  describe '#success_data' do
+    before do
+      allow(secret).to receive(:safe_dump).and_return({key: 'secret123'})
+      subject.instance_variable_set(:@show_secret, true)
+      subject.instance_variable_set(:@is_owner, false)
+      subject.instance_variable_set(:@correct_passphrase, true)
+      subject.instance_variable_set(:@display_lines, 5)
+      subject.instance_variable_set(:@one_liner, true)
+      subject.instance_variable_set(:@secret_value, 'secret_content')
+    end
+
+    it 'returns formatted success data' do
+      result = subject.success_data
+
+      expect(result).to include(:record, :details)
+      expect(result[:record]).to include(:secret_value)
+      expect(result[:details][:show_secret]).to be true
+    end
+  end
+end

--- a/tests/unit/ruby/rspec/onetime/refinements/rack_refinements_spec.rb
+++ b/tests/unit/ruby/rspec/onetime/refinements/rack_refinements_spec.rb
@@ -69,8 +69,20 @@ RSpec.describe Onetime::RackRefinements do
         expect { fetch(test_hash, "missing") }.to raise_error(KeyError)
       end
 
-      it "handles nil keys" do
+      it "handles nil keys, by raising an error when no default provided" do
         expect { fetch(test_hash, nil) }.to raise_error(KeyError)
+      end
+
+      it "handles nil keys, by returning a default value when provided (nil)" do
+        expect(fetch(test_hash, nil, nil)).to eq(nil)
+      end
+
+      it "handles nil keys, by returning a default value when provided (empty hash)" do
+        expect(fetch(test_hash, nil, {})).to eq({})
+      end
+
+      it "handles nil keys, by returning a default value when provided (string)" do
+        expect(fetch(test_hash, nil, 'default')).to eq('default')
       end
     end
   end

--- a/tests/unit/ruby/rspec/onetime/refinements/rack_refinements_spec.rb
+++ b/tests/unit/ruby/rspec/onetime/refinements/rack_refinements_spec.rb
@@ -1,0 +1,73 @@
+# tests/unit/ruby/rspec/onetime/refinements/rack_refinements_spec.rb
+
+require_relative '../../spec_helper.rb'
+# require_relative "./hash_spec.rb"
+
+require 'onetime/refinements/rack_refinements'
+
+RSpec.describe Onetime::RackRefinements do
+  # Define module for testing scope
+  module RefineTest
+    using Onetime::RackRefinements
+
+    def self.fetch_with_refinements(hash, key, *args, &block)
+      hash.fetch(key, *args, &block)
+    end
+
+    def self.dig_with_refinements(hash, *keys)
+      hash.dig(*keys)
+    end
+  end
+
+  let(:test_hash) { {"string_key" => "value1", symbol_key: "value2"} }
+
+  shared_examples "hash access behavior" do |refined: false|
+    context "#fetch" do
+      if refined
+        def fetch_from(hash, *args, &block)
+          RefineTest.fetch_with_refinements(hash, *args, &block)
+        end
+      else
+        def fetch_from(hash, *args, &block)
+          hash.fetch(*args, &block)
+        end
+      end
+
+      it "retrieves string key values" do
+        expect(fetch_from(test_hash, "string_key")).to eq("value1")
+      end
+
+      it "retrieves symbol key values using string" do
+        if refined
+          expect(fetch_from(test_hash, "symbol_key")).to eq("value2")
+        else
+          expect { fetch_from(test_hash, "symbol_key") }.to raise_error(KeyError)
+        end
+      end
+
+      it "retrieves symbol key values using symbol" do
+        expect(fetch_from(test_hash, :symbol_key)).to eq("value2")
+      end
+
+      it "handles missing keys with default" do
+        expect(fetch_from(test_hash, "missing", "default")).to eq("default")
+      end
+
+      it "handles missing keys with block" do
+        expect(fetch_from(test_hash, "missing") { "block_value" }).to eq("block_value")
+      end
+
+      it "raises KeyError for missing keys" do
+        expect { fetch_from(test_hash, "missing") }.to raise_error(KeyError)
+      end
+    end
+  end
+
+  context "with refinements" do
+    include_examples "hash access behavior", refined: true
+  end
+
+  context "without refinements" do
+    include_examples "hash access behavior", refined: false
+  end
+end

--- a/tests/unit/ruby/rspec/onetime/refinements/rack_refinements_spec.rb
+++ b/tests/unit/ruby/rspec/onetime/refinements/rack_refinements_spec.rb
@@ -1,7 +1,6 @@
 # tests/unit/ruby/rspec/onetime/refinements/rack_refinements_spec.rb
 
 require_relative '../../spec_helper.rb'
-# require_relative "./hash_spec.rb"
 
 require 'onetime/refinements/rack_refinements'
 

--- a/tests/unit/ruby/rspec/spec_helper.rb
+++ b/tests/unit/ruby/rspec/spec_helper.rb
@@ -1,0 +1,61 @@
+# tests/unit/ruby/rspec/spec_helper.rb
+
+# This file sets up the RSpec testing environment for the OnetimeSecret project.
+# It includes necessary libraries, configures code coverage, and mocks essential components.
+
+require 'rspec'
+require 'simplecov'
+
+# Starts SimpleCov for code coverage analysis if the COVERAGE environment variable is set.
+SimpleCov.start if ENV['COVERAGE']
+
+# Adds the 'lib' directory to the load path to ensure that the Onetime library can be required.
+$LOAD_PATH.unshift File.expand_path('../../../../lib', __FILE__)
+
+begin
+  require 'onetime/refinements/rack_refinements'
+rescue LoadError => e
+  puts "Failed to load refinements: #{e.message}"
+  puts "Current directory: #{Dir.pwd}"
+  puts "Load path: #{$LOAD_PATH}"
+  exit
+end
+
+# Mocking the OT module to stub logging methods during tests.
+# This prevents actual logging and allows tests to run without external dependencies.
+module OT
+  class << self
+    # Stub method for logging to avoid cluttering test output.
+    # @param message [String] The message intended for logging.
+    def ld(message)
+      # Stub logging in test environment
+    end
+  end
+end
+
+# Configures RSpec with desired settings to tailor the testing environment.
+RSpec.configure do |config|
+  # Configures RSpec to include chain clauses in custom matcher descriptions for better readability.
+  config.expect_with :rspec do |expectations|
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+  end
+
+  # Sets RSpec as the mocking framework.
+  config.mock_with :rspec
+
+  # Applies shared context metadata to host groups, enhancing test organization.
+  # Will be default in RSpec 4       
+  config.shared_context_metadata_behavior = :apply_to_host_groups
+
+  # Disables RSpec's monkey patching to encourage the use of the RSpec DSL.
+  config.disable_monkey_patching!
+
+  # Suppresses Ruby warnings during test runs for a cleaner output.
+  config.warnings = false
+
+  # Orders test execution randomly to surface order dependencies and improve test reliability.
+  config.order = :random
+
+  # Seeds the random number generator based on RSpec's seed to allow reproducible test order.
+  Kernel.srand config.seed
+end

--- a/tests/unit/ruby/rspec/spec_helper.rb
+++ b/tests/unit/ruby/rspec/spec_helper.rb
@@ -28,7 +28,7 @@ module OT
     # Stub method for logging to avoid cluttering test output.
     # @param message [String] The message intended for logging.
     def ld(message)
-      # Stub logging in test environment
+      puts message
     end
   end
 end

--- a/tests/unit/ruby/rspec/spec_helper.rb
+++ b/tests/unit/ruby/rspec/spec_helper.rb
@@ -10,16 +10,28 @@ require 'simplecov'
 SimpleCov.start if ENV['COVERAGE']
 
 # Adds the 'lib' directory to the load path to ensure that the Onetime library can be required.
-$LOAD_PATH.unshift File.expand_path('../../../../lib', __FILE__)
+# Add lib directory to load path
+lib_path = File.expand_path('../../../../lib', __FILE__)
+$LOAD_PATH.unshift(lib_path) unless $LOAD_PATH.include?(lib_path)
+
+# Add spec directory to load path
+spec_path = File.expand_path('../..', __FILE__)
+$LOAD_PATH.unshift(spec_path) unless $LOAD_PATH.include?(spec_path)
 
 begin
+  require 'onetime'
+  require 'onetime/alias' # OT
   require 'onetime/refinements/rack_refinements'
+  require 'onetime/logic/secrets/show_secret'
 rescue LoadError => e
   puts "Failed to load refinements: #{e.message}"
   puts "Current directory: #{Dir.pwd}"
   puts "Load path: #{$LOAD_PATH}"
   exit
 end
+
+OT::Config.path = File.join(Onetime::HOME, 'tests', 'unit', 'ruby', 'config.test.yaml')
+OT.boot! :test
 
 # Mocking the OT module to stub logging methods during tests.
 # This prevents actual logging and allows tests to run without external dependencies.


### PR DESCRIPTION
### **User description**
Introduce Rack refinements to handle string/symbol key indifference for Hash#fetch and Hash#dig methods. Integrate RSpec and SimpleCov for testing and code coverage reporting. Add unit tests for the new refinements and ensure proper functionality of the fetch and dig methods. Update the load path in the spec helper for seamless testing.



Fixes #991


___

### **PR Type**
Bug fix, Tests, Enhancement


___

### **Description**
- Introduced `RackRefinements` to handle string/symbol key indifference in `Hash#fetch` and `Hash#dig`.

- Fixed TTL propagation issue in API calls by ensuring correct handling of TTL parameters.

- Added comprehensive RSpec tests for `RackRefinements`, `BaseSecretAction`, and `ShowSecret` logic.

- Integrated RSpec and SimpleCov for testing and code coverage reporting.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>alias.rb</strong><dd><code>Added file header comment for clarity.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/993/files#diff-4e31cf0599c335d2c5eabd6ef3003cb77f0b9d255e216d760e785e54a1d46aa6">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>base.rb</strong><dd><code>Added `RackRefinements` to base logic module.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/993/files#diff-e1e6d4ed0dad20172f914c28eaa0751f6e5143b8c50452966f3efc045c1496be">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>base_secret_action.rb</strong><dd><code>Applied `RackRefinements` to `BaseSecretAction` class.</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/993/files#diff-859c644b87b7f82e1a2438049bce6f15cd6c6a70d2bee4bf3617a0347b7f6709">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>rack_refinements.rb</strong><dd><code>Introduced <code>RackRefinements</code> for string/symbol key indifference in <br>hashes.</code></dd></td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/993/files#diff-238e69ef54f55dc62740fa14e23f2f3406556fcbb034cd108f31f013ccdc9e96">+25/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>base_secret_action_spec.rb</strong><dd><code>Added RSpec tests for `BaseSecretAction` logic.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/993/files#diff-e5cc6d93a9a2370995b2d7d6c9c21154c661e6e3b7b0a58045bf1c4e8698aefe">+109/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>show_secret_spec.rb</strong><dd><code>Added RSpec tests for `ShowSecret` logic.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/993/files#diff-d6b0dc17d0cb1d75313a322a91328192e3b9a4365962ad24a064e9d1ffe9db87">+102/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>rack_refinements_spec.rb</strong><dd><code>Added RSpec tests for `RackRefinements`.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/993/files#diff-30efce59f4cf0d008a47e7ed146cdf20c2952e8abdecf26664fe25470042a66d">+98/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>spec_helper.rb</strong><dd><code>Configured RSpec and SimpleCov for testing environment.</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/993/files#diff-49fb902d7004fcd0dafb3d1dcf26111d2cb468965efd274af9ac15f14ec05b8a">+73/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Dependencies</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>Gemfile</strong><dd><code>Added RSpec and SimpleCov dependencies for testing.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/993/files#diff-d09ea66f8227784ff4393d88a19836f321c915ae10031d16c93d67e6283ab55f">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any question about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>