### PR TITLE
Clean up rate limiting implementation by removing redundant Redis key

### DIFF
--- a/lib/onetime/models/rate_limit.rb
+++ b/lib/onetime/models/rate_limit.rb
@@ -36,10 +36,7 @@ class Onetime::RateLimit < Familia::Horreum
   ttl 20.minutes
 
   prefix :limiter
-
-  string :counter, :quantize => [20.minutes, '%H:%M'], :ttl => 20.minutes
-
-  def_delegators :@counter, :value=, :to_i, :to_s
+  suffix :counter
 
   # limiter:cryt61zzviouw9bhxju71wv64q4yba3:get_page:0240
   identifier [:external_identifier, :event, :timeblock]
@@ -55,7 +52,6 @@ class Onetime::RateLimit < Familia::Horreum
   # @param event [Symbol] the type of event being limited
   # @return [Onetime::RateLimit]
   def init
-    self.counter.value = "0" unless exists?
     update_expiration
   end
 

--- a/lib/onetime/models/rate_limit.rb
+++ b/lib/onetime/models/rate_limit.rb
@@ -78,6 +78,10 @@ class Onetime::RateLimit < Familia::Horreum
     get
   end
 
+  def to_s
+    get
+  end
+
   # Increment the counter and raise OT::LimitExceeded if limit is exceeded
   # @return [Integer] the new count
   # @raise [OT::LimitExceeded] if the limit is exceeded

--- a/lib/onetime/models/rate_limit.rb
+++ b/lib/onetime/models/rate_limit.rb
@@ -52,6 +52,7 @@ class Onetime::RateLimit < Familia::Horreum
   # @param event [Symbol] the type of event being limited
   # @return [Onetime::RateLimit]
   def init
+    redis.setnx(rediskey, 0) # nx = set if not exists
     update_expiration
   end
 

--- a/tests/unit/ruby/try/35_ratelimit_try.rb
+++ b/tests/unit/ruby/try/35_ratelimit_try.rb
@@ -60,7 +60,7 @@ OT::RateLimit.event_limit(:unknown_event)
 
 ## Creates limiter with proper Redis key format
 [@limiter.class, @limiter.rediskey]
-#=> [Onetime::RateLimit, "limiter:#{@identifier}:test_limit:#{@stamp}:object"]
+#=> [Onetime::RateLimit, "limiter:#{@identifier}:test_limit:#{@stamp}:counter"]
 
 ## Can get the external identifier of the limiter
 pp [:identifier, @limiter.identifier, @identifier]
@@ -81,25 +81,19 @@ p @limiter.incr!
 #=> true
 
 ## Redis relation key has proper TTL (should be around 1200 seconds / 20 minutes)
-ttl = @limiter.counter.realttl
-p [:ttl, ttl, @limiter.counter.realttl, @limiter.counter.class.ttl]
+ttl = @limiter.realttl
+p [:ttl, ttl, @limiter.realttl, @limiter.class.ttl]
 (ttl > 1100 && ttl <= 1200)
 #=> true
 
 ## Redis relation key is updated when parent is updated
-before_ttl = @limiter.counter.realttl
+before_ttl = @limiter.realttl
 p [:before, before_ttl]
 @limiter.update_expiration(ttl: 5)
-after_ttl = @limiter.counter.realttl
+after_ttl = @limiter.realttl
 p [:after, after_ttl]
 [before_ttl, after_ttl]
 #=> [1200, 5]
-
-## Supports string operations from Familia::String
-@limiter.clear
-@limiter.value = "5"
-[@limiter.to_i, @limiter.to_s]
-#=> [5, "5"]
 
 ## Can track multiple increments
 @limiter.clear


### PR DESCRIPTION
### **User description**
Eliminate the unused object key in the RateLimit model and simplify the counter implementation. Update tests to ensure the functionality remains intact while reducing Redis memory usage. Fixes #1000


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Removed redundant Redis `object` key creation in `RateLimit`.

- Simplified implementation by using `suffix :counter`.

- Updated tests to reflect the new Redis key structure.

- Eliminated unnecessary delegated string operations.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rate_limit.rb</strong><dd><code>Simplified Redis key handling in RateLimit</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/onetime/models/rate_limit.rb

<li>Removed <code>string :counter</code> and replaced with <code>suffix :counter</code>.<br> <li> Eliminated initialization of <code>counter.value</code> in <code>init</code>.<br> <li> Removed delegated string operations for <code>counter</code>.


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/1005/files#diff-23457e37ba1aa905bbc1ea50c7fd0d5310e527a013d18d04d3b1d68df59d3059">+1/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>35_ratelimit_try.rb</strong><dd><code>Updated tests for new RateLimit Redis key structure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/unit/ruby/try/35_ratelimit_try.rb

<li>Updated tests to validate new Redis key format.<br> <li> Removed tests for unused string operations.<br> <li> Adjusted TTL-related tests to align with new implementation.


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/1005/files#diff-3cf3885f5a3e6351090331ff0fe35d223cc3179005a48626a16d8ef727f52c31">+5/-11</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any question about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>