### PR TITLE
Pin syslog gem to version 0.2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,7 +64,7 @@ gem 'stringio', '~> 3.1.1'
 # Including them explicitly ensures they are part of the application's
 # dependencies and silences the warnings.
 gem 'base64'
-gem 'syslog'
+gem 'syslog', '~> 0.2.0'
 
 # As of Ruby 3.5, these are no longer in the standard library
 gem 'fiddle'   # Fiddle library for handling dynamic libraries (required by reline)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -197,7 +197,7 @@ GEM
     sysinfo (0.10.0)
       drydock (< 1.0)
       storable (~> 0.10)
-    syslog (0.1.2)
+    syslog (0.2.0)
     tapioca (0.16.4)
       bundler (>= 2.2.25)
       netrc (>= 0.11.0)
@@ -277,7 +277,7 @@ DEPENDENCIES
   stringio (~> 3.1.1)
   stripe
   sysinfo
-  syslog
+  syslog (~> 0.2.0)
   tapioca
   thin
   truemail
@@ -288,4 +288,4 @@ RUBY VERSION
    ruby 3.3.5p100
 
 BUNDLED WITH
-   2.5.16
+   2.6.3


### PR DESCRIPTION
### **User description**
Update the syslog gem to version 0.2.0 to resolve native extension build failures on ARM64 architecture. This change addresses compatibility issues encountered with the previous version.

https://github.com/onetimesecret/onetimesecret/actions/runs/12923565047


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Pin `syslog` gem to version 0.2.0 to resolve build failures.

- Address GCC compiler segmentation fault on ARM64 architecture.

- Ensure compatibility with Ruby 3.4.0 and ARM64 environments.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Gemfile</strong><dd><code>Pin `syslog` gem to version 0.2.0</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Gemfile

<li>Updated <code>syslog</code> gem to version 0.2.0.<br> <li> Added version constraint to ensure compatibility.<br> <li> Addressed build failures on ARM64 architecture.


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/1012/files#diff-d09ea66f8227784ff4393d88a19836f321c915ae10031d16c93d67e6283ab55f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any question about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>