### PR TITLE
feat(redis): Allow redis dbs to be defined from env vars

### DIFF
--- a/etc/config.example.yaml
+++ b/etc/config.example.yaml
@@ -76,17 +76,17 @@
   # Note: If using a Redis provider with single-database limitation (e.g., Upstash),
   # set all values to 0.
   :dbs:
-    :session: 1
-    :splittest: 1
-    :custom_domain: 6
-    :customer: 6
-    :subdomain: 6
-    :metadata: 7
-    :email_receipt: 8
-    :secret: 8
-    :rate_limit: 2
-    :feedback: 11
-    :exception_info: 12
+    :session: <%= ENV['REDIS_DBS_SESSION'] || 1 %>
+    :splittest: <%= ENV['REDIS_DBS_SPLITTEST'] || 1 %>
+    :custom_domain: <%= ENV['REDIS_DBS_CUSTOM_DOMAIN'] || 6 %>
+    :customer: <%= ENV['REDIS_DBS_CUSTOMER'] || 6 %>
+    :subdomain: <%= ENV['REDIS_DBS_SUBDOMAIN'] || 6 %>
+    :metadata: <%= ENV['REDIS_DBS_METADATA'] || 7 %>
+    :email_receipt: <%= ENV['REDIS_DBS_EMAIL_RECEIPT'] || 8 %>
+    :secret: <%= ENV['REDIS_DBS_SECRET'] || 8 %>
+    :rate_limit: <%= ENV['REDIS_DBS_RATE_LIMIT'] || 2 %>
+    :feedback: <%= ENV['REDIS_DBS_FEEDBACK'] || 11 %>
+    :exception_info: <%= ENV['REDIS_DBS_EXCEPTION_INFO'] || 12 %>
 :colonels:
   # Email addresses listed below will be granted automatic
   # administrative privileges upon account creation. These


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Allow Redis database mappings to be configured via environment variables.

- Updated `etc/config.example.yaml` to support dynamic Redis DB configuration.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config.example.yaml</strong><dd><code>Support environment variable-based Redis DB configuration</code></dd></summary>
<hr>

etc/config.example.yaml

<li>Replaced hardcoded Redis database mappings with environment <br>variable-based configuration.<br> <li> Added fallback values for each Redis database mapping.<br> <li> Enhanced flexibility for Redis database usage in different <br>environments.


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/1024/files#diff-623a3725e34c66751e28979fce3f78929e9c476779cea0463cde7ea59a3ffcfb">+11/-11</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>