### PR TITLE
[#2025-01] Catch up Postman Collection with API definition

### DIFF
--- a/docs/api/collections/Onetime Secret - API Definition.json
+++ b/docs/api/collections/Onetime Secret - API Definition.json
@@ -2766,6 +2766,1212 @@
 				}
 			],
 			"id": "80334c15-6b9d-4a71-a4e2-8f78debc591d"
+		},
+		{
+			"name": "/incoming",
+			"id": "797f11ac-de49-4b44-8cd5-2cfd6d7ad9e3",
+			"protocolProfileBehavior": {
+				"disableBodyPruning": true
+			},
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/x-www-form-urlencoded"
+					},
+					{
+						"key": "Accept",
+						"value": "application/json"
+					}
+				],
+				"body": {
+					"mode": "urlencoded",
+					"urlencoded": [
+						{
+							"description": "(Required) The secret value to be stored",
+							"key": "secret",
+							"value": "<string>"
+						},
+						{
+							"description": "(Required) A valid ticket number",
+							"key": "ticketno",
+							"value": "<string>"
+						},
+						{
+							"description": "Email addresses of recipients",
+							"key": "recipient",
+							"value": "<email>"
+						},
+						{
+							"description": "Email addresses of recipients",
+							"key": "recipient",
+							"value": "<email>"
+						}
+					]
+				},
+				"url": {
+					"raw": "{{baseUrl}}/incoming",
+					"host": [
+						"{{baseUrl}}"
+					],
+					"path": [
+						"incoming"
+					]
+				}
+			},
+			"response": [
+				{
+					"id": "6422da29-95f7-488c-a8aa-56927883f89d",
+					"name": "Successful response",
+					"originalRequest": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/x-www-form-urlencoded"
+							},
+							{
+								"key": "Accept",
+								"value": "application/json"
+							},
+							{
+								"description": "Added as a part of security scheme: basic",
+								"key": "Authorization",
+								"value": "Basic <credentials>"
+							}
+						],
+						"body": {
+							"mode": "urlencoded",
+							"urlencoded": [
+								{
+									"description": "(Required) The secret value to be stored",
+									"key": "secret",
+									"value": "<string>"
+								},
+								{
+									"description": "(Required) A valid ticket number",
+									"key": "ticketno",
+									"value": "<string>"
+								},
+								{
+									"description": "Email addresses of recipients",
+									"key": "recipient",
+									"value": "<email>"
+								},
+								{
+									"description": "Email addresses of recipients",
+									"key": "recipient",
+									"value": "<email>"
+								}
+							]
+						},
+						"url": {
+							"raw": "{{baseUrl}}/incoming",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"incoming"
+							]
+						}
+					},
+					"status": "OK",
+					"code": 200,
+					"_postman_previewlanguage": "json",
+					"header": [
+						{
+							"key": "Content-Type",
+							"value": "application/json"
+						}
+					],
+					"cookie": [],
+					"body": "{\n  \"success\": false,\n  \"status\": -89120553.52957888\n}"
+				},
+				{
+					"id": "67494da8-416e-40fa-bed0-f4dd58c0e71c",
+					"name": "Bad request",
+					"originalRequest": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/x-www-form-urlencoded"
+							},
+							{
+								"key": "Accept",
+								"value": "application/json"
+							},
+							{
+								"description": "Added as a part of security scheme: basic",
+								"key": "Authorization",
+								"value": "Basic <credentials>"
+							}
+						],
+						"body": {
+							"mode": "urlencoded",
+							"urlencoded": [
+								{
+									"description": "(Required) The secret value to be stored",
+									"key": "secret",
+									"value": "<string>"
+								},
+								{
+									"description": "(Required) A valid ticket number",
+									"key": "ticketno",
+									"value": "<string>"
+								},
+								{
+									"description": "Email addresses of recipients",
+									"key": "recipient",
+									"value": "<email>"
+								},
+								{
+									"description": "Email addresses of recipients",
+									"key": "recipient",
+									"value": "<email>"
+								}
+							]
+						},
+						"url": {
+							"raw": "{{baseUrl}}/incoming",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"incoming"
+							]
+						}
+					},
+					"status": "Bad Request",
+					"code": 400,
+					"_postman_previewlanguage": "json",
+					"header": [
+						{
+							"key": "Content-Type",
+							"value": "application/json"
+						}
+					],
+					"cookie": [],
+					"body": "{\n  \"value\": \"reference #/components/schemas/ErrorResponse not found in the OpenAPI spec\"\n}"
+				}
+			]
+		},
+		{
+			"name": "/signup",
+			"id": "efdc23da-8d13-4eff-810d-c4370f8c17d8",
+			"protocolProfileBehavior": {
+				"disableBodyPruning": true
+			},
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/x-www-form-urlencoded"
+					},
+					{
+						"key": "Accept",
+						"value": "application/json"
+					}
+				],
+				"body": {
+					"mode": "urlencoded",
+					"urlencoded": [
+						{
+							"description": "(Required) User's email address (used as username)",
+							"key": "u",
+							"value": "<email>"
+						},
+						{
+							"description": "(Required) User's password",
+							"key": "p",
+							"value": "<string>"
+						},
+						{
+							"description": "(Required) Password confirmation",
+							"key": "p2",
+							"value": "<string>"
+						},
+						{
+							"description": "(Required) ID of the selected plan",
+							"key": "planid",
+							"value": "<string>"
+						},
+						{
+							"description": "Hidden field for bot detection (should be empty)",
+							"key": "skill",
+							"value": "<string>"
+						}
+					]
+				},
+				"url": {
+					"raw": "{{baseUrl}}/signup",
+					"host": [
+						"{{baseUrl}}"
+					],
+					"path": [
+						"signup"
+					]
+				}
+			},
+			"response": [
+				{
+					"id": "431e10b7-ce58-40a2-869e-82b6bae3feea",
+					"name": "Successful response",
+					"originalRequest": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/x-www-form-urlencoded"
+							},
+							{
+								"key": "Accept",
+								"value": "application/json"
+							},
+							{
+								"description": "Added as a part of security scheme: basic",
+								"key": "Authorization",
+								"value": "Basic <credentials>"
+							}
+						],
+						"body": {
+							"mode": "urlencoded",
+							"urlencoded": [
+								{
+									"description": "(Required) User's email address (used as username)",
+									"key": "u",
+									"value": "<email>"
+								},
+								{
+									"description": "(Required) User's password",
+									"key": "p",
+									"value": "<string>"
+								},
+								{
+									"description": "(Required) Password confirmation",
+									"key": "p2",
+									"value": "<string>"
+								},
+								{
+									"description": "(Required) ID of the selected plan",
+									"key": "planid",
+									"value": "<string>"
+								},
+								{
+									"description": "Hidden field for bot detection (should be empty)",
+									"key": "skill",
+									"value": "<string>"
+								}
+							]
+						},
+						"url": {
+							"raw": "{{baseUrl}}/signup",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"signup"
+							]
+						}
+					},
+					"status": "OK",
+					"code": 200,
+					"_postman_previewlanguage": "json",
+					"header": [
+						{
+							"key": "Content-Type",
+							"value": "application/json"
+						}
+					],
+					"cookie": [],
+					"body": "{\n  \"success\": false,\n  \"status\": -89120553.52957888\n}"
+				},
+				{
+					"id": "acfedec4-6824-4ae8-93d9-b9e4584ba4ff",
+					"name": "Bad request",
+					"originalRequest": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/x-www-form-urlencoded"
+							},
+							{
+								"key": "Accept",
+								"value": "application/json"
+							},
+							{
+								"description": "Added as a part of security scheme: basic",
+								"key": "Authorization",
+								"value": "Basic <credentials>"
+							}
+						],
+						"body": {
+							"mode": "urlencoded",
+							"urlencoded": [
+								{
+									"description": "(Required) User's email address (used as username)",
+									"key": "u",
+									"value": "<email>"
+								},
+								{
+									"description": "(Required) User's password",
+									"key": "p",
+									"value": "<string>"
+								},
+								{
+									"description": "(Required) Password confirmation",
+									"key": "p2",
+									"value": "<string>"
+								},
+								{
+									"description": "(Required) ID of the selected plan",
+									"key": "planid",
+									"value": "<string>"
+								},
+								{
+									"description": "Hidden field for bot detection (should be empty)",
+									"key": "skill",
+									"value": "<string>"
+								}
+							]
+						},
+						"url": {
+							"raw": "{{baseUrl}}/signup",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"signup"
+							]
+						}
+					},
+					"status": "Bad Request",
+					"code": 400,
+					"_postman_previewlanguage": "json",
+					"header": [
+						{
+							"key": "Content-Type",
+							"value": "application/json"
+						}
+					],
+					"cookie": [],
+					"body": "{\n  \"value\": \"reference #/components/schemas/ErrorResponse not found in the OpenAPI spec\"\n}"
+				}
+			]
+		},
+		{
+			"name": "/signin",
+			"id": "c7866c0c-39d9-4a1b-b12e-0205a4a0994a",
+			"protocolProfileBehavior": {
+				"disableBodyPruning": true
+			},
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/x-www-form-urlencoded"
+					},
+					{
+						"key": "Accept",
+						"value": "application/json"
+					}
+				],
+				"body": {
+					"mode": "urlencoded",
+					"urlencoded": [
+						{
+							"description": "(Required) User's email address",
+							"key": "u",
+							"value": "<email>"
+						},
+						{
+							"description": "(Required) User's password",
+							"key": "p",
+							"value": "<string>"
+						}
+					]
+				},
+				"url": {
+					"raw": "{{baseUrl}}/signin",
+					"host": [
+						"{{baseUrl}}"
+					],
+					"path": [
+						"signin"
+					]
+				}
+			},
+			"response": [
+				{
+					"id": "786b23b3-b466-4fa0-a367-a606c2f822b7",
+					"name": "Successful response",
+					"originalRequest": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/x-www-form-urlencoded"
+							},
+							{
+								"key": "Accept",
+								"value": "application/json"
+							},
+							{
+								"description": "Added as a part of security scheme: basic",
+								"key": "Authorization",
+								"value": "Basic <credentials>"
+							}
+						],
+						"body": {
+							"mode": "urlencoded",
+							"urlencoded": [
+								{
+									"description": "(Required) User's email address",
+									"key": "u",
+									"value": "<email>"
+								},
+								{
+									"description": "(Required) User's password",
+									"key": "p",
+									"value": "<string>"
+								}
+							]
+						},
+						"url": {
+							"raw": "{{baseUrl}}/signin",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"signin"
+							]
+						}
+					},
+					"status": "OK",
+					"code": 200,
+					"_postman_previewlanguage": "json",
+					"header": [
+						{
+							"key": "Content-Type",
+							"value": "application/json"
+						}
+					],
+					"cookie": [],
+					"body": "{\n  \"success\": false,\n  \"status\": -89120553.52957888\n}"
+				},
+				{
+					"id": "32298325-1fd8-4515-8197-cbeeec27c7e6",
+					"name": "Bad request",
+					"originalRequest": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/x-www-form-urlencoded"
+							},
+							{
+								"key": "Accept",
+								"value": "application/json"
+							},
+							{
+								"description": "Added as a part of security scheme: basic",
+								"key": "Authorization",
+								"value": "Basic <credentials>"
+							}
+						],
+						"body": {
+							"mode": "urlencoded",
+							"urlencoded": [
+								{
+									"description": "(Required) User's email address",
+									"key": "u",
+									"value": "<email>"
+								},
+								{
+									"description": "(Required) User's password",
+									"key": "p",
+									"value": "<string>"
+								}
+							]
+						},
+						"url": {
+							"raw": "{{baseUrl}}/signin",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"signin"
+							]
+						}
+					},
+					"status": "Bad Request",
+					"code": 400,
+					"_postman_previewlanguage": "json",
+					"header": [
+						{
+							"key": "Content-Type",
+							"value": "application/json"
+						}
+					],
+					"cookie": [],
+					"body": "{\n  \"value\": \"reference #/components/schemas/ErrorResponse not found in the OpenAPI spec\"\n}"
+				}
+			]
+		},
+		{
+			"name": "/welcome/stripe/webhook",
+			"id": "7871d337-8107-4aec-8fe1-dd3124f8ac9e",
+			"protocolProfileBehavior": {
+				"disableBodyPruning": true
+			},
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Stripe-Signature",
+						"value": "<string>",
+						"description": "(Required) Stripe webhook signature"
+					},
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					},
+					{
+						"key": "Accept",
+						"value": "application/json"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n  \"payload\": {}\n}",
+					"options": {
+						"raw": {
+							"headerFamily": "json",
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "{{baseUrl}}/welcome/stripe/webhook",
+					"host": [
+						"{{baseUrl}}"
+					],
+					"path": [
+						"welcome",
+						"stripe",
+						"webhook"
+					]
+				}
+			},
+			"response": [
+				{
+					"id": "760c206f-4861-43d4-9920-7ffa94a71d30",
+					"name": "Successful response",
+					"originalRequest": {
+						"method": "POST",
+						"header": [
+							{
+								"description": "(Required) Stripe webhook signature",
+								"key": "Stripe-Signature",
+								"value": "<string>"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "Accept",
+								"value": "application/json"
+							},
+							{
+								"description": "Added as a part of security scheme: basic",
+								"key": "Authorization",
+								"value": "Basic <credentials>"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"payload\": {}\n}",
+							"options": {
+								"raw": {
+									"headerFamily": "json",
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseUrl}}/welcome/stripe/webhook",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"welcome",
+								"stripe",
+								"webhook"
+							]
+						}
+					},
+					"status": "OK",
+					"code": 200,
+					"_postman_previewlanguage": "json",
+					"header": [
+						{
+							"key": "Content-Type",
+							"value": "application/json"
+						}
+					],
+					"cookie": [],
+					"body": "{\n  \"welcome\": \"<string>\"\n}"
+				},
+				{
+					"id": "57ec5fc0-d635-4b77-aa1f-53926b831840",
+					"name": "Bad request",
+					"originalRequest": {
+						"method": "POST",
+						"header": [
+							{
+								"description": "(Required) Stripe webhook signature",
+								"key": "Stripe-Signature",
+								"value": "<string>"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "Accept",
+								"value": "application/json"
+							},
+							{
+								"description": "Added as a part of security scheme: basic",
+								"key": "Authorization",
+								"value": "Basic <credentials>"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"payload\": {}\n}",
+							"options": {
+								"raw": {
+									"headerFamily": "json",
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseUrl}}/welcome/stripe/webhook",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"welcome",
+								"stripe",
+								"webhook"
+							]
+						}
+					},
+					"status": "Bad Request",
+					"code": 400,
+					"_postman_previewlanguage": "json",
+					"header": [
+						{
+							"key": "Content-Type",
+							"value": "application/json"
+						}
+					],
+					"cookie": [],
+					"body": "{\n  \"value\": \"reference #/components/schemas/ErrorResponse not found in the OpenAPI spec\"\n}"
+				}
+			]
+		},
+		{
+			"name": "/feedback",
+			"id": "607f3e0b-9e0c-4da0-b808-956ce876cb8d",
+			"protocolProfileBehavior": {
+				"disableBodyPruning": true
+			},
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/x-www-form-urlencoded"
+					},
+					{
+						"key": "Accept",
+						"value": "application/json"
+					}
+				],
+				"body": {
+					"mode": "urlencoded",
+					"urlencoded": [
+						{
+							"description": "(Required) Feedback message",
+							"key": "msg",
+							"value": "<string>"
+						},
+						{
+							"description": "Authenticity payload for spam prevention",
+							"key": "authenticity_payload",
+							"value": "<string>"
+						}
+					]
+				},
+				"url": {
+					"raw": "{{baseUrl}}/feedback",
+					"host": [
+						"{{baseUrl}}"
+					],
+					"path": [
+						"feedback"
+					]
+				}
+			},
+			"response": [
+				{
+					"id": "3cdf53ed-7321-448e-828c-bb66da60acb4",
+					"name": "Successful response",
+					"originalRequest": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/x-www-form-urlencoded"
+							},
+							{
+								"key": "Accept",
+								"value": "application/json"
+							},
+							{
+								"description": "Added as a part of security scheme: basic",
+								"key": "Authorization",
+								"value": "Basic <credentials>"
+							}
+						],
+						"body": {
+							"mode": "urlencoded",
+							"urlencoded": [
+								{
+									"description": "(Required) Feedback message",
+									"key": "msg",
+									"value": "<string>"
+								},
+								{
+									"description": "Authenticity payload for spam prevention",
+									"key": "authenticity_payload",
+									"value": "<string>"
+								}
+							]
+						},
+						"url": {
+							"raw": "{{baseUrl}}/feedback",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"feedback"
+							]
+						}
+					},
+					"status": "OK",
+					"code": 200,
+					"_postman_previewlanguage": "json",
+					"header": [
+						{
+							"key": "Content-Type",
+							"value": "application/json"
+						}
+					],
+					"cookie": [],
+					"body": "{\n  \"success\": false,\n  \"status\": -89120553.52957888\n}"
+				},
+				{
+					"id": "ec760503-63e3-4697-98e8-68dbfada0cbb",
+					"name": "Bad request",
+					"originalRequest": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/x-www-form-urlencoded"
+							},
+							{
+								"key": "Accept",
+								"value": "application/json"
+							},
+							{
+								"description": "Added as a part of security scheme: basic",
+								"key": "Authorization",
+								"value": "Basic <credentials>"
+							}
+						],
+						"body": {
+							"mode": "urlencoded",
+							"urlencoded": [
+								{
+									"description": "(Required) Feedback message",
+									"key": "msg",
+									"value": "<string>"
+								},
+								{
+									"description": "Authenticity payload for spam prevention",
+									"key": "authenticity_payload",
+									"value": "<string>"
+								}
+							]
+						},
+						"url": {
+							"raw": "{{baseUrl}}/feedback",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"feedback"
+							]
+						}
+					},
+					"status": "Bad Request",
+					"code": 400,
+					"_postman_previewlanguage": "json",
+					"header": [
+						{
+							"key": "Content-Type",
+							"value": "application/json"
+						}
+					],
+					"cookie": [],
+					"body": "{\n  \"value\": \"reference #/components/schemas/ErrorResponse not found in the OpenAPI spec\"\n}"
+				}
+			]
+		},
+		{
+			"name": "/forgot",
+			"id": "0d050cf3-4097-4583-90b5-a7410d609a4a",
+			"protocolProfileBehavior": {
+				"disableBodyPruning": true
+			},
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/x-www-form-urlencoded"
+					},
+					{
+						"key": "Accept",
+						"value": "application/json"
+					}
+				],
+				"body": {
+					"mode": "urlencoded",
+					"urlencoded": [
+						{
+							"description": "(Required) User's email address",
+							"key": "u",
+							"value": "<email>"
+						}
+					]
+				},
+				"url": {
+					"raw": "{{baseUrl}}/forgot",
+					"host": [
+						"{{baseUrl}}"
+					],
+					"path": [
+						"forgot"
+					]
+				}
+			},
+			"response": [
+				{
+					"id": "6e4009ee-5ed8-49b3-9bb4-afacb043a0ed",
+					"name": "Successful response",
+					"originalRequest": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/x-www-form-urlencoded"
+							},
+							{
+								"key": "Accept",
+								"value": "application/json"
+							},
+							{
+								"description": "Added as a part of security scheme: basic",
+								"key": "Authorization",
+								"value": "Basic <credentials>"
+							}
+						],
+						"body": {
+							"mode": "urlencoded",
+							"urlencoded": [
+								{
+									"description": "(Required) User's email address",
+									"key": "u",
+									"value": "<email>"
+								}
+							]
+						},
+						"url": {
+							"raw": "{{baseUrl}}/forgot",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"forgot"
+							]
+						}
+					},
+					"status": "OK",
+					"code": 200,
+					"_postman_previewlanguage": "json",
+					"header": [
+						{
+							"key": "Content-Type",
+							"value": "application/json"
+						}
+					],
+					"cookie": [],
+					"body": "{\n  \"success\": false,\n  \"status\": -89120553.52957888\n}"
+				},
+				{
+					"id": "c2d9551d-7955-4740-bf43-d83809290a68",
+					"name": "Bad request",
+					"originalRequest": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/x-www-form-urlencoded"
+							},
+							{
+								"key": "Accept",
+								"value": "application/json"
+							},
+							{
+								"description": "Added as a part of security scheme: basic",
+								"key": "Authorization",
+								"value": "Basic <credentials>"
+							}
+						],
+						"body": {
+							"mode": "urlencoded",
+							"urlencoded": [
+								{
+									"description": "(Required) User's email address",
+									"key": "u",
+									"value": "<email>"
+								}
+							]
+						},
+						"url": {
+							"raw": "{{baseUrl}}/forgot",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"forgot"
+							]
+						}
+					},
+					"status": "Bad Request",
+					"code": 400,
+					"_postman_previewlanguage": "json",
+					"header": [
+						{
+							"key": "Content-Type",
+							"value": "application/json"
+						}
+					],
+					"cookie": [],
+					"body": "{\n  \"value\": \"reference #/components/schemas/ErrorResponse not found in the OpenAPI spec\"\n}"
+				}
+			]
+		},
+		{
+			"name": "/forgot/:key",
+			"id": "5846254e-82ee-4fbe-9270-7c4b599d94e9",
+			"protocolProfileBehavior": {
+				"disableBodyPruning": true
+			},
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/x-www-form-urlencoded"
+					},
+					{
+						"key": "Accept",
+						"value": "application/json"
+					}
+				],
+				"body": {
+					"mode": "urlencoded",
+					"urlencoded": [
+						{
+							"description": "(Required) New password",
+							"key": "newp",
+							"value": "<string>"
+						},
+						{
+							"description": "(Required) New password confirmation",
+							"key": "newp2",
+							"value": "<string>"
+						}
+					]
+				},
+				"url": {
+					"raw": "{{baseUrl}}/forgot/:key",
+					"host": [
+						"{{baseUrl}}"
+					],
+					"path": [
+						"forgot",
+						":key"
+					],
+					"variable": [
+						{
+							"key": "key",
+							"value": "<string>",
+							"description": "(Required) Reset password key"
+						}
+					]
+				}
+			},
+			"response": [
+				{
+					"id": "0ba895b2-ff03-44ab-969d-babd3f2505f0",
+					"name": "Successful response",
+					"originalRequest": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/x-www-form-urlencoded"
+							},
+							{
+								"key": "Accept",
+								"value": "application/json"
+							},
+							{
+								"description": "Added as a part of security scheme: basic",
+								"key": "Authorization",
+								"value": "Basic <credentials>"
+							}
+						],
+						"body": {
+							"mode": "urlencoded",
+							"urlencoded": [
+								{
+									"description": "(Required) New password",
+									"key": "newp",
+									"value": "<string>"
+								},
+								{
+									"description": "(Required) New password confirmation",
+									"key": "newp2",
+									"value": "<string>"
+								}
+							]
+						},
+						"url": {
+							"raw": "{{baseUrl}}/forgot/:key",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"forgot",
+								":key"
+							],
+							"variable": [
+								{
+									"key": "key"
+								}
+							]
+						}
+					},
+					"status": "OK",
+					"code": 200,
+					"_postman_previewlanguage": "json",
+					"header": [
+						{
+							"key": "Content-Type",
+							"value": "application/json"
+						}
+					],
+					"cookie": [],
+					"body": "{\n  \"success\": false,\n  \"status\": -89120553.52957888\n}"
+				},
+				{
+					"id": "1fdce71f-2d8c-4fc1-af34-8162824bc16b",
+					"name": "Bad request",
+					"originalRequest": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/x-www-form-urlencoded"
+							},
+							{
+								"key": "Accept",
+								"value": "application/json"
+							},
+							{
+								"description": "Added as a part of security scheme: basic",
+								"key": "Authorization",
+								"value": "Basic <credentials>"
+							}
+						],
+						"body": {
+							"mode": "urlencoded",
+							"urlencoded": [
+								{
+									"description": "(Required) New password",
+									"key": "newp",
+									"value": "<string>"
+								},
+								{
+									"description": "(Required) New password confirmation",
+									"key": "newp2",
+									"value": "<string>"
+								}
+							]
+						},
+						"url": {
+							"raw": "{{baseUrl}}/forgot/:key",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"forgot",
+								":key"
+							],
+							"variable": [
+								{
+									"key": "key"
+								}
+							]
+						}
+					},
+					"status": "Bad Request",
+					"code": 400,
+					"_postman_previewlanguage": "json",
+					"header": [
+						{
+							"key": "Content-Type",
+							"value": "application/json"
+						}
+					],
+					"cookie": [],
+					"body": "{\n  \"value\": \"reference #/components/schemas/ErrorResponse not found in the OpenAPI spec\"\n}"
+				}
+			]
 		}
 	],
 	"auth": {
@@ -2820,7 +4026,7 @@
 			"id": "d8af7d7f-579d-4635-9826-8bcc99f39ffe",
 			"key": "baseUrl",
 			"value": "https://onetimesecret.com/api",
-			"type": "any"
+			"type": "string"
 		},
 		{
 			"id": "47f92be2-6ee1-44d6-a425-18271217d0da",


### PR DESCRIPTION
### **User description**
These are updates to the API Collection that's created by Postman from the OpenAPI definition. Specifically the 2024-10-09 version.


___

### **PR Type**
Documentation


___

### **Description**
- Updated Postman collection to align with the latest API definition.

- Added new endpoints: `/incoming`, `/signup`, `/signin`, `/welcome/stripe/webhook`, `/feedback`, `/forgot`, and `/forgot/:key`.

- Included detailed request and response structures for each endpoint.

- Changed variable type for `baseUrl` from `any` to `string`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Onetime Secret - API Definition.json</strong><dd><code>Updated Postman collection with new API endpoints</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/api/collections/Onetime Secret - API Definition.json

<li>Added new API endpoints with request and response details.<br> <li> Updated <code>baseUrl</code> variable type from <code>any</code> to <code>string</code>.<br> <li> Enhanced documentation for endpoints with descriptions and parameters.<br> <li> Included examples for successful and bad request responses.


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/1036/files#diff-8975288e5a5e3d617e37fcd9d1efe170786b803ad48e0be0f3633ce8c7795577">+1207/-1</a></td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>