### PR TITLE
fix: .env.example and support/smtp_test.rb uses `FROM_EMAIL`, but the actual app appears to use 'FROM'

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,7 +30,7 @@ FRONTEND_HOST=
 VITE_API_BASE_URL=
 
 ##
-# SMTP Testing (see bin/smtp_test.rb)
+# SMTP Testing (see support/smtp_test.rb)
 #
 SMTP_HOST=
 SMTP_PORT=

--- a/etc/config.example.yaml
+++ b/etc/config.example.yaml
@@ -113,7 +113,7 @@
   # Production Settings (for reference)
   # ----------------------------------
   :mode: <%= ENV['EMAILER_MODE'] || 'smtp' %>
-  :from: <%= ENV['FROM'] || 'CHANGEME@example.com' %>
+  :from: <%= ENV['FROM_EMAIL'] || ENV['FROM'] || 'CHANGEME@example.com' %>
   :fromname: <%= ENV['FROMNAME'] || 'Support' %>
   :host: <%= ENV['SMTP_HOST'] || 'smtp.provider.com' %>
   :port: <%= ENV['SMTP_PORT'] || 587 %>

--- a/tests/unit/ruby/config.test.yaml
+++ b/tests/unit/ruby/config.test.yaml
@@ -73,7 +73,7 @@
   - 'CHANGEME@EXAMPLE.com'
 :emailer:
   :mode: <%= ENV['EMAILER_MODE'] || 'smtp' %>
-  :from: <%= ENV['FROM'] || 'tests@example.com' %>
+  :from: <%= ENV['FROM_EMAIL'] || ENV['FROM_EMAIL'] || 'tests@example.com' %>
   :fromname: <%= ENV['FROMNAME'] || 'Jan' %>
   :host: <%= ENV['SMTP_HOST'] || 'localhost' %>
   :port: <%= ENV['SMTP_PORT'] || 587 %>


### PR DESCRIPTION
This was originally brought up to me here: https://github.com/onetimesecret/helm-chart/issues/27#issuecomment-2626250674

@delano could you back port this into a patch for v0.18.X this way i can update the help chart with v0.18.X as well? Alternatively, we can just force everyone to use v0.19.X but given it was just released I'm unclear on how stable it is so will differ to you on this.