### PR TITLE
Remove conditional check for main repository in Docker build workflow

### DIFF
--- a/.github/workflows/.docker-build-publish-reusable.yml
+++ b/.github/workflows/.docker-build-publish-reusable.yml
@@ -29,20 +29,6 @@ jobs:
       packages: write
 
     steps:
-      - name: Debug Repository Info
-        run: |
-          echo "Event Name: ${{ github.event_name }}"
-          echo "Repository: ${{ github.repository }}"
-          echo "Actor: ${{ github.actor }}"
-          echo "Ref: ${{ github.ref }}"
-
-      - name: Debug PR Info
-        if: github.event_name == 'pull_request'
-        run: |
-          echo "PR Number: ${{ github.event.number }}"
-          echo "PR Source: ${{ github.event.pull_request.head.label }}"
-          echo "PR Target: ${{ github.event.pull_request.base.label }}"
-
       - name: Checkout repository
         uses: actions/checkout@v4
 

--- a/.github/workflows/.docker-build-publish-reusable.yml
+++ b/.github/workflows/.docker-build-publish-reusable.yml
@@ -23,11 +23,26 @@ env:
 jobs:
   build:
     runs-on: ubuntu-24.04
+
     permissions:
       contents: read
       packages: write
 
     steps:
+      - name: Debug Repository Info
+        run: |
+          echo "Event Name: ${{ github.event_name }}"
+          echo "Repository: ${{ github.repository }}"
+          echo "Actor: ${{ github.actor }}"
+          echo "Ref: ${{ github.ref }}"
+
+      - name: Debug PR Info
+        if: github.event_name == 'pull_request'
+        run: |
+          echo "PR Number: ${{ github.event.number }}"
+          echo "PR Source: ${{ github.event.pull_request.head.label }}"
+          echo "PR Target: ${{ github.event.pull_request.base.label }}"
+
       - name: Checkout repository
         uses: actions/checkout@v4
 

--- a/.github/workflows/.docker-build-publish-reusable.yml
+++ b/.github/workflows/.docker-build-publish-reusable.yml
@@ -23,8 +23,6 @@ env:
 jobs:
   build:
     runs-on: ubuntu-24.04
-    # Only run this job on the main repository
-    if: github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/.docker-build-publish-reusable.yml
+++ b/.github/workflows/.docker-build-publish-reusable.yml
@@ -24,6 +24,8 @@ jobs:
   build:
     runs-on: ubuntu-24.04
 
+    if: github.repository == 'onetimesecret/onetimesecret'
+
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/Fly.io.yml
+++ b/.github/workflows/Fly.io.yml
@@ -38,6 +38,20 @@ jobs:
     environment: Fly.io
 
     steps:
+      - name: Debug Repository Info
+        run: |
+          echo "Event Name: ${{ github.event_name }}"
+          echo "Repository: ${{ github.repository }}"
+          echo "Actor: ${{ github.actor }}"
+          echo "Ref: ${{ github.ref }}"
+
+      - name: Debug PR Info
+        if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+        run: |
+          echo "PR Number: ${{ github.event.number }}"
+          echo "PR Source: ${{ github.event.pull_request.head.label }}"
+          echo "PR Target: ${{ github.event.pull_request.base.label }}"
+
       # Step 1: Check this out
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/Fly.io.yml
+++ b/.github/workflows/Fly.io.yml
@@ -36,6 +36,7 @@ jobs:
     name: Deploy
     runs-on: ubuntu-24.04
     environment: Fly.io
+    if: github.repository == 'onetimesecret/onetimesecret'
 
     steps:
       - name: Debug Repository Info
@@ -46,7 +47,7 @@ jobs:
           echo "Ref: ${{ github.ref }}"
 
       - name: Debug PR Info
-        if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+        if: github.event_name == 'pull_request'
         run: |
           echo "PR Number: ${{ github.event.number }}"
           echo "PR Source: ${{ github.event.pull_request.head.label }}"

--- a/.github/workflows/Fly.io.yml
+++ b/.github/workflows/Fly.io.yml
@@ -36,8 +36,7 @@ jobs:
     name: Deploy
     runs-on: ubuntu-24.04
     environment: Fly.io
-    # Only run this job on the main repository
-    if: github.event.pull_request.head.repo.full_name == github.repository
+
     steps:
       # Step 1: Check this out
       - name: Checkout repository


### PR DESCRIPTION
### **User description**
Eliminate the conditional check that restricted the Docker build workflow to the main repository, allowing it to run in other contexts.


___

### **PR Type**
enhancement


___

### **Description**
- Removed conditional check restricting Docker build to main repository.

- Enabled Docker build workflow to run in other contexts.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.docker-build-publish-reusable.yml</strong><dd><code>Removed conditional check in Docker build workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/.docker-build-publish-reusable.yml

<li>Removed conditional check for main repository in Docker build job.<br> <li> Simplified workflow to allow execution in broader contexts.


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/1042/files#diff-9e66b11579c984baff1f71d75a2390c0c08f91a6e58ab892125350b098bbbaa2">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>