### PR TITLE
Fix email template localization and improve locale handling

### DIFF
--- a/lib/onetime/app/api/v1/base.rb
+++ b/lib/onetime/app/api/v1/base.rb
@@ -142,7 +142,8 @@ module Onetime::App
         # Set default locale if the current one is not supported
         locale = locales.first unless OT.locales.key?(locale)
 
-        # Set locale in the request environment
+        # Set locale in the request environment. This behaviour is different
+        # than v2 API which checks if we have the translation before setting.
         req.env['ots.locale'] = @locale = locale
         req.env['ots.locales'] = locales
       end

--- a/lib/onetime/app/api/v2/base.rb
+++ b/lib/onetime/app/api/v2/base.rb
@@ -114,6 +114,32 @@ module Onetime::App
         end
       end
 
+      def check_locale!(locale = nil)
+        locale ||= req.params[:locale]
+        locale ||= cust.locale if cust&.locale
+        locale ||= (req.env['rack.locale'] || []).first
+
+        have_translations = locale && OT.locales.has_key?(locale)
+        lmsg = format(
+          '[check_locale!] class=%s locale=%s cust=%s req=%s t=%s',
+          self.class.name,
+          locale,
+          cust&.locale,
+          req.params.keys,
+          have_translations,
+        )
+        OT.ld lmsg
+
+        # Set the locale in the request environment if it is
+        # valid, otherwise use the default locale.
+        req.env['ots.locale'] = have_translations ? locale : OT.default_locale
+
+        # Important! This sets the locale for the current request which
+        # gets passed through to the logic class along with sess, cust.
+        # Without it, emails will be sent in the default locale.
+        @locale = req.env['ots.locale']
+      end
+
       def json hsh
         res.header['Content-Type'] = "application/json; charset=utf-8"
         res.body = hsh.to_json

--- a/lib/onetime/app/app_helpers.rb
+++ b/lib/onetime/app/app_helpers.rb
@@ -177,7 +177,8 @@ module Onetime::App
 
       have_translations = locale && OT.locales.has_key?(locale)
       OT.ld format(
-        '[check_locale!] locale=%s cust=%s req=%s t=%s',
+        '[check_locale!] class=%s locale=%s cust=%s req=%s t=%s',
+        self.class.name,
         locale,
         cust&.locale,
         req.params.keys,

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "test:watch:coverage": "pnpm test:base --coverage",
     "test:watch:ui": "pnpm test:base --ui --open",
     "test:watch": "pnpm test:base --ui --no-open",
-    "test": "pnpm test:base run",
+    "test": "pnpm test:base run --printConsoleTrace",
     "test:chrome:inspect": "pnpm test:base --inspect-brk --no-file-parallelism",
     "type-check:base": "vue-tsc --noEmit",
     "type-check": "pnpm run type-check:base",

--- a/src/plugins/axios/interceptors.ts
+++ b/src/plugins/axios/interceptors.ts
@@ -1,5 +1,6 @@
 // src/plugins/axios/interceptors.ts
 import type { ApiErrorResponse } from '@/schemas/api';
+import { useLanguageStore } from '@/stores';
 import { useCsrfStore } from '@/stores/csrfStore';
 import type { AxiosError, AxiosResponse, InternalAxiosRequestConfig } from 'axios';
 
@@ -36,6 +37,7 @@ const isValidShrimp = (shrimp: unknown): shrimp is string =>
  */
 export const requestInterceptor = (config: InternalAxiosRequestConfig) => {
   const csrfStore = useCsrfStore();
+  const languageStore = useLanguageStore();
 
   // console.debug('[debug] Request config:', {
   //   url: config.url,
@@ -46,6 +48,7 @@ export const requestInterceptor = (config: InternalAxiosRequestConfig) => {
   // Set CSRF token in headers
   config.headers = config.headers || {};
   config.headers['O-Shrimp'] = csrfStore.shrimp;
+  config.headers['Accept-Language'] = languageStore.getCurrentLocale;
 
   return config;
 };

--- a/src/plugins/core/appInitializer.ts
+++ b/src/plugins/core/appInitializer.ts
@@ -1,6 +1,6 @@
 // src/plugins/core/appInitializer.ts
 
-import i18n from '@/i18n';
+import { getI18n } from '@/i18n';
 import { createAppRouter } from '@/router';
 import { loggingService } from '@/services/logging.service';
 import { WindowService } from '@/services/window.service';
@@ -39,6 +39,7 @@ export const AppInitializer: Plugin<AppInitializerOptions> = {
  * We separate this from the main plugin to interface for testing purposes.
  */
 function initializeApp(app: App, options: AppInitializerOptions = {}) {
+  const i18n = getI18n();
   const diagnostics = WindowService.get('diagnostics');
   const d9sEnabled = WindowService.get('d9s_enabled');
   const displayDomain = WindowService.get('display_domain');

--- a/src/plugins/core/appInitializer.ts
+++ b/src/plugins/core/appInitializer.ts
@@ -1,6 +1,6 @@
 // src/plugins/core/appInitializer.ts
 
-import { getI18n } from '@/i18n';
+import i18n from '@/i18n';
 import { createAppRouter } from '@/router';
 import { loggingService } from '@/services/logging.service';
 import { WindowService } from '@/services/window.service';
@@ -39,7 +39,6 @@ export const AppInitializer: Plugin<AppInitializerOptions> = {
  * We separate this from the main plugin to interface for testing purposes.
  */
 function initializeApp(app: App, options: AppInitializerOptions = {}) {
-  const i18n = getI18n();
   const diagnostics = WindowService.get('diagnostics');
   const d9sEnabled = WindowService.get('d9s_enabled');
   const displayDomain = WindowService.get('display_domain');

--- a/src/services/window.service.ts
+++ b/src/services/window.service.ts
@@ -1,6 +1,8 @@
 // src/services/window.service.ts
 import type { OnetimeWindow } from '@/types/declarations/window';
 
+const STATE_KEY = '__ONETIME_STATE__';
+
 /**
  * Service for accessing typed window properties defined in window.d.ts.
  * Provides type-safe access to server-injected window properties with
@@ -16,10 +18,20 @@ export const WindowService = {
    * @returns The typed window property value
    */
   get<K extends keyof OnetimeWindow>(key: K): OnetimeWindow[K] {
-    if (!window.__ONETIME_STATE__) {
-      throw `[WindowService] State is not set (${key})`;
+    const state = this.getState();
+    return state[key];
+  },
+
+  getState(): OnetimeWindow {
+    if (typeof window === 'undefined') {
+      throw new Error('[WindowService] Window is not defined');
     }
-    return (window.__ONETIME_STATE__ as OnetimeWindow)[key];
+
+    if (!window[STATE_KEY]) {
+      throw new Error('[WindowService] State is not set');
+    }
+
+    return window[STATE_KEY] as OnetimeWindow;
   },
 
   /**

--- a/src/stores/languageStore.ts
+++ b/src/stores/languageStore.ts
@@ -1,6 +1,6 @@
 // src/stores/languageStore.ts
 
-import { getSetGlobalLocale } from '@/i18n';
+import { setGlobalLocale } from '@/i18n';
 import type { PiniaPluginOptions } from '@/plugins/pinia/types';
 import { localeSchema } from '@/schemas/i18n/locale';
 import { WindowService } from '@/services/window.service';
@@ -52,7 +52,7 @@ export const useLanguageStore = defineStore('language', () => {
       () => currentLocale.value,
       async (newLocale) => {
         if (newLocale) {
-          await getSetGlobalLocale()(newLocale);
+          await setGlobalLocale(newLocale);
         }
       }
     );
@@ -113,7 +113,6 @@ export const useLanguageStore = defineStore('language', () => {
       throw new Error(`Unsupported locale: ${validatedLocale}`);
     }
 
-    const setGlobalLocale = getSetGlobalLocale();
     await setGlobalLocale(validatedLocale); // via i18n
     setCurrentLocale(validatedLocale); // save to session storage
     await $api.post('/api/v2/account/update-locale', { locale: validatedLocale });

--- a/src/stores/secretStore.ts
+++ b/src/stores/secretStore.ts
@@ -1,10 +1,6 @@
 // src/stores/secretStore.ts
 import { PiniaPluginOptions } from '@/plugins/pinia';
-import {
-  ConcealDataResponse,
-  responseSchemas,
-  type SecretResponse,
-} from '@/schemas/api';
+import { ConcealDataResponse, responseSchemas, type SecretResponse } from '@/schemas/api';
 import { type Secret, type SecretDetails } from '@/schemas/models/secret';
 import { loggingService } from '@/services/logging.service';
 import { AxiosInstance } from 'axios';
@@ -40,6 +36,7 @@ export type SecretStore = {
 /* eslint-disable max-lines-per-function */
 export const useSecretStore = defineStore('secrets', () => {
   const $api = inject('api') as AxiosInstance;
+
   // State
   const record = ref<Secret | null>(null);
   const details = ref<SecretDetails | null>(null);
@@ -53,8 +50,7 @@ export const useSecretStore = defineStore('secrets', () => {
   function init(options?: StoreOptions) {
     if (_initialized.value) return { isInitialized };
 
-    if (options?.api)
-      loggingService.warn('API instance provided in options, ignoring.');
+    if (options?.api) loggingService.warn('API instance provided in options, ignoring.');
 
     _initialized.value = true;
 
@@ -96,18 +92,14 @@ export const useSecretStore = defineStore('secrets', () => {
    * and composable validation. This is an open question. Response validation
    * should remain the responsibility of this store.
    */
-  async function conceal(
-    payload: ConcealPayload
-  ): Promise<ConcealDataResponse> {
+  async function conceal(payload: ConcealPayload): Promise<ConcealDataResponse> {
     const response = await $api.post('/api/v2/secret/conceal', {
       secret: payload,
     });
     return response.data;
   }
 
-  async function generate(
-    payload: GeneratePayload
-  ): Promise<ConcealDataResponse> {
+  async function generate(payload: GeneratePayload): Promise<ConcealDataResponse> {
     const response = await $api.post('/api/v2/secret/generate', {
       secret: payload,
     });
@@ -125,13 +117,10 @@ export const useSecretStore = defineStore('secrets', () => {
    * @returns Validated secret response
    */
   async function reveal(secretKey: string, passphrase?: string) {
-    const response = await $api.post<SecretResponse>(
-      `/api/v2/secret/${secretKey}/reveal`,
-      {
-        passphrase,
-        continue: true,
-      }
-    );
+    const response = await $api.post<SecretResponse>(`/api/v2/secret/${secretKey}/reveal`, {
+      passphrase,
+      continue: true,
+    });
 
     const validated = responseSchemas.secret.parse(response.data);
     record.value = validated.record;

--- a/tests/unit/vue/setupWindow.ts
+++ b/tests/unit/vue/setupWindow.ts
@@ -18,6 +18,12 @@ export function setupWindowState(state = stateFixture) {
   return windowMockWithState;
 }
 
+export function setupEmptyWindowState() {
+  const windowMockWithState = setupWindowState({});
+  console.debug('setupEmptyWindowState', windowMockWithState);
+  Object.defineProperties(window, Object.getOwnPropertyDescriptors(windowMockWithState));
+}
+
 export function setupWindowMedia(query = '(prefers-color-scheme: dark)') {
   window.matchMedia = vi.fn().mockImplementation((query) => ({
     matches: query === '(prefers-color-scheme: dark)', // we start dark


### PR DESCRIPTION
### **User description**
Enhance the email template system to properly respect user locale preferences by implementing locale propagation from the frontend to the email service. Refactor the language store to include computed properties for accept languages and update axios interceptors to set the Accept-Language header. Improve error handling in the WindowService and ensure locale validation in the API. Add tests for multi-language email templates and document the new locale handling process.

Changes include: 
- Implemented Accept-Language header support in API requests
- Added new locale checking functionality in API base class
- Created getBrowserAcceptLanguage method to handle browser language preferences
- Added new tests for language headers and locale handling
- Updated window service with better state management
- Improved code formatting and simplified imports
- Added console trace printing for tests
- Added better logging for locale checking

Fixes #1143


___

### **PR Type**
Enhancement, Bug fix, Tests


___

### **Description**
- Implemented locale propagation for email templates.
  - Added `Accept-Language` header support in API requests.
  - Enhanced locale validation and fallback mechanisms.

- Refactored `languageStore` to include computed properties for locale handling.
  - Introduced `acceptLanguages` and `acceptLanguageHeader` for browser language preferences.

- Improved error handling and state management in `WindowService`.

- Added comprehensive tests for multi-language email templates.
  - Verified `Accept-Language` header formatting and locale selection.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>base.rb</strong><dd><code>Updated locale handling comments for v1 API</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/1144/files#diff-35281666a48e0506e8731c2c66f2e737a7c710703a490d84567dac881920a44f">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>base.rb</strong><dd><code>Added locale validation and propagation for v2 API</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/1144/files#diff-9b3facfbb18222e5d02ae1ee676ab1f3ab8d16d3302b1c98a2ecedc8e2fd55d1">+26/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>app_helpers.rb</strong><dd><code>Enhanced locale logging with class context</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/1144/files#diff-b52a605e9a9b24e685322c8a830d32741cc544c0b25cf40df915c9ad3c56692b">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>interceptors.ts</strong><dd><code>Added `Accept-Language` header to Axios requests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/1144/files#diff-d77dbd4570834f25af6431856b58d64031ddc66460109d1d283a9e33f1ade42a">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>window.service.ts</strong><dd><code>Improved state management and error handling in `WindowService`</code></dd></td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/1144/files#diff-8b47c994863180b0f8a7d639b3c39ca95bfe9a1b28aaa46cc269f08ac4835efb">+15/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>languageStore.ts</strong><dd><code>Refactored `languageStore` to support browser language preferences</code></dd></td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/1144/files#diff-cb09d89af8b2e093c5ae552fb8cc1f4d49c5b71f2e2300eb0880a389683a555d">+10/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Formatting</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>secretStore.ts</strong><dd><code>Minor formatting and logging improvements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/1144/files#diff-2262823bd85dd60bc245f2e4c00404f15ba38fa66dedb5baac004657f0f869b2">+9/-20</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>setupWindow.ts</strong><dd><code>Added utility for setting up empty window state in tests</code>&nbsp; </dd></td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/1144/files#diff-1d75d31268815eda74bacbfa9de43e13822a252ae94964e6d1c08445cb0e3614">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>languageStore.spec.ts</strong><dd><code>Added tests for `Accept-Language` header and locale handling</code></dd></td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/1144/files#diff-f4d63b8f14e8c07569291ae31cb110e2f587f141e9defc66a4fd7bd1f52b57dc">+48/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>package.json</strong><dd><code>Updated test script to include console trace printing</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/1144/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>