### PR TITLE
Fix null locale configuration and improve i18n handling

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,14 +64,16 @@ gem 'syslog', '~> 0.2.0'
 
 # As of Ruby 3.5, these are no longer in the standard library
 gem 'fiddle'   # Fiddle library for handling dynamic libraries (required by reline)
+gem 'irb'      # IRB
 gem 'logger'   # Logger library for logging messages (required by truemail)
 gem 'ostruct'  # OpenStruct library for creating data objects (required by json)
 gem 'rdoc'     # IRB
+gem 'reline'
 
 # Third-party services
 gem 'sendgrid-ruby'
-gem 'stripe', require: false
 gem "sentry-ruby", require: false
+gem 'stripe', require: false
 
 gem 'stackprof', require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,6 +81,11 @@ GEM
       csv
       mini_mime (>= 1.0.0)
       multi_xml (>= 0.5.2)
+    io-console (0.8.0)
+    irb (1.15.1)
+      pp (>= 0.6.0)
+      rdoc (>= 4.0.0)
+      reline (>= 0.4.2)
     json (2.8.2)
     language_server-protocol (3.17.0.3)
     logger (1.6.5)
@@ -114,6 +119,9 @@ GEM
     parser (3.3.6.0)
       ast (~> 2.4.1)
       racc
+    pp (0.6.2)
+      prettyprint
+    prettyprint (0.2.0)
     prism (1.3.0)
     pry (0.14.2)
       coderay (~> 1.1)
@@ -143,6 +151,8 @@ GEM
     redis-client (0.22.2)
       connection_pool
     regexp_parser (2.9.2)
+    reline (0.6.0)
+      io-console (~> 0.5)
     rexml (3.3.9)
     rubocop (1.68.0)
       json (~> 2.3)
@@ -244,6 +254,7 @@ DEPENDENCIES
   fiddle
   gibbler
   httparty
+  irb
   logger
   mail
   multi_json
@@ -259,6 +270,7 @@ DEPENDENCIES
   rack-proxy
   rdoc
   redis (~> 5.3.0)
+  reline
   rspec!
   rspec-core!
   rspec-expectations!

--- a/lib/onetime.rb
+++ b/lib/onetime.rb
@@ -241,9 +241,38 @@ module Onetime
       end
     end
 
+    # We always load locales regardless of whether internationalization
+    # is enabled. When it's disabled, we just limit the locales to
+    # english. Otherwise we would have to text strings to use.
     def load_locales
-      return unless OT.i18n_enabled
+      i18n = OT.conf.fetch(:internationalization, {})
+      OT.i18n_enabled = i18n[:enabled] || false
 
+      OT.ld "Parsing through i18n locales..."
+
+      # Load the locales from the config in both the current and
+      # legacy locations. If the locales are not set in the config,
+      # we fallback to english.
+      locales_list = i18n.fetch(:locales, nil) || OT.conf.fetch(:locales, ['en']).map(&:to_s)
+
+      if OT.i18n_enabled
+        # First look for the default locale in the i18n config, then
+        # legacy the locales config approach of using the first one.
+        OT.supported_locales = locales_list
+        OT.default_locale = i18n.fetch(:default_locale, locales_list.first) || 'en'
+        OT.fallback_locale = i18n.fetch(:fallback_locale, nil)
+
+        unless locales_list.include?(OT.default_locale)
+          OT.le "Default locale #{OT.default_locale} not in locales_list #{locales_list}"
+          OT.i18n_enabled = false
+        end
+      else
+        OT.default_locale = 'en'
+        OT.supported_locales = [OT.default_locale]
+        OT.fallback_locale = nil
+      end
+
+      # Iterate over the list of supported locales, to load their JSON
       confs = OT.supported_locales.collect do |loc|
         path = File.join(Onetime::HOME, 'src', 'locales', "#{loc}.json")
         OT.ld "Loading #{loc}: #{File.exist?(path)}"
@@ -258,19 +287,20 @@ module Onetime
       end
 
       # Convert the zipped array to a hash
-      locales = confs.compact.to_h
+      locales_defs = confs.compact.to_h
 
-      default_locale_def = locales.fetch(OT.default_locale, {})
+      default_locale_def = locales_defs.fetch(OT.default_locale, {})
 
       # Here we overlay each locale on top of the default just
       # in case there are keys that haven't been translated.
       # That way, at least the default language will display.
-      locales.each do |key, locale|
+      locales_defs.each do |key, locale|
         next if OT.default_locale == locale
-        locales[key] = OT::Utils.deep_merge(default_locale_def, locale)
+        locales_defs[key] = OT::Utils.deep_merge(default_locale_def, locale)
       end
 
-      @locales = locales
+      @locales = locales_defs || {}
+
     end
 
     def stdout(prefix, msg)

--- a/lib/onetime.rb
+++ b/lib/onetime.rb
@@ -295,7 +295,7 @@ module Onetime
       # in case there are keys that haven't been translated.
       # That way, at least the default language will display.
       locales_defs.each do |key, locale|
-        next if OT.default_locale == locale
+        next if OT.default_locale == key
         locales_defs[key] = OT::Utils.deep_merge(default_locale_def, locale)
       end
 

--- a/lib/onetime/app/web/views/base.rb
+++ b/lib/onetime/app/web/views/base.rb
@@ -206,8 +206,8 @@ module Onetime
         @i18n ||= {
           locale: self.locale,
           default: OT.default_locale,
-          page: messages[:web].fetch(pagename, {}),
-          COMMON: messages[:web][:COMMON],
+          page: messages.dig(:web, pagename),
+          COMMON: messages.dig(:web, :COMMON),
         }
       end
 

--- a/lib/onetime/config.rb
+++ b/lib/onetime/config.rb
@@ -205,29 +205,6 @@ module Onetime
         OT.li "[sentry-init] Status: #{Sentry.initialized? ? 'OK' : 'Failed'}"
       end
 
-      i18n = OT.conf.fetch(:internationalization, {})
-      OT.i18n_enabled = i18n[:enabled] || false
-
-      if OT.i18n_enabled
-        OT.ld "Setting up i18n..."
-
-        # Load the locales from the config in both the current and
-        # legacy locations. If the locales are not set in the config,
-        # we fallback to english.
-        locales = i18n.fetch(:locales, nil) || OT.conf.fetch(:locales, ['en']).map(&:to_s)
-
-         # First look for the default locale in the i18n config, then
-         # legacy the locales config approach of using the first one.
-        OT.supported_locales = locales
-        OT.default_locale = i18n.fetch(:default_locale, locales.first) || 'en'
-        OT.fallback_locale = i18n.fetch(:fallback_locale, nil)
-
-        unless locales.include?(OT.default_locale)
-          OT.le "Default locale #{OT.default_locale} not in locales #{locales}"
-          OT.i18n_enabled = false
-        end
-      end
-
       # Make sure these are set
       development = conf[:development]
       development[:enabled] ||= false

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "podman:run": "podman run --rm -it onetimesecret",
     "preview:local": "vite preview --config vite.config.local.ts",
     "preview": "vite preview",
+    "rspec": "bundle exec rspec --format documentation",
     "test:base": "vitest --typecheck",
     "test:coverage": "pnpm test:base run --coverage",
     "test:watch:coverage": "pnpm test:base --coverage",

--- a/src/components/layout/DefaultFooter.vue
+++ b/src/components/layout/DefaultFooter.vue
@@ -19,7 +19,7 @@ withDefaults(defineProps<LayoutProps>(), {
 });
 
 const windowProps = WindowService.getMultiple([
-  'regions_enabled', 'regions', 'authentication'
+  'regions_enabled', 'regions', 'authentication', 'i18n_enabled',
 ]);
 
 const companyName = ref('OnetimeSecret.com');
@@ -73,7 +73,7 @@ const companyName = ref('OnetimeSecret.com');
             :aria-label="$t('toggle-dark-mode')"
           />
 
-          <LanguageToggle :compact="true" />
+          <LanguageToggle v-if="windowProps.i18n_enabled" :compact="true" />
 
           <FeedbackToggle
             v-if="displayFeedback && windowProps.authentication?.enabled"

--- a/src/components/layout/QuietFooter.vue
+++ b/src/components/layout/QuietFooter.vue
@@ -16,7 +16,9 @@
 
   withDefaults(defineProps<LayoutProps>(), {});
 
-  const windowProps = WindowService.getMultiple(['regions_enabled', 'regions', 'authentication']);
+  const windowProps = WindowService.getMultiple([
+    'regions_enabled', 'regions', 'authentication', 'i18n_enabled',
+  ]);
 
   const companyName = ref('OnetimeSecret.com');
 </script>
@@ -48,7 +50,7 @@
           <ThemeToggle
             class="text-gray-500 transition-colors duration-200 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-100"
             :aria-label="$t('toggle-dark-mode')" />
-          <LanguageToggle :compact="true" />
+          <LanguageToggle v-if="windowProps.i18n_enabled" :compact="true" />
           <FeedbackToggle
             v-if="displayFeedback && windowProps.authentication?.enabled"
             class="text-gray-500 transition-colors duration-200 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-100"
@@ -67,7 +69,7 @@
           <ThemeToggle
             class="text-gray-500 transition-colors duration-200 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-100"
             :aria-label="$t('toggle-dark-mode')" />
-          <LanguageToggle :compact="true" />
+          <LanguageToggle v-if="windowProps.i18n_enabled" :compact="true" />
         </div>
 
         <!-- Links Section -->

--- a/src/components/layout/SecretFooterControls.vue
+++ b/src/components/layout/SecretFooterControls.vue
@@ -3,17 +3,22 @@
 <script setup lang="ts">
   import ThemeToggle from '@/components/ThemeToggle.vue';
   import LanguageToggle from '@/components/LanguageToggle.vue';
+import { WindowService } from '@/services/window.service';
 
   defineProps<{
     showLanguage?: boolean;
   }>();
+
+  const windowProps = WindowService.getMultiple([
+    'i18n_enabled',
+  ]);
 </script>
 
 <template>
   <div class="flex justify-center pt-16">
     <ThemeToggle />
     <LanguageToggle
-      v-if="showLanguage"
+      v-if="windowProps.i18n_enabled && showLanguage"
       :compact="true" />
   </div>
 </template>

--- a/src/components/modals/SettingsModal.vue
+++ b/src/components/modals/SettingsModal.vue
@@ -7,7 +7,9 @@
   import GeneralTab from './settings/GeneralTab.vue';
   import JurisdictionTab from './settings/JurisdictionTab.vue';
 
-  const regionsEnabled = WindowService.get('regions_enabled');
+  const windowProps = WindowService.getMultiple([
+    'regions_enabled', 'i18n_enabled',
+  ]);
 
   interface Tab {
     id: string;
@@ -31,7 +33,7 @@
       { id: 'general', label: t('general') }
     ];
 
-    if (regionsEnabled) {
+    if (windowProps.regions_enabled) {
       tabsList.push({ id: 'data-region', label: t('data-region') });
     }
 
@@ -210,7 +212,7 @@
                   :aria-labelledby="'tab-button-data-region'"
                   tabindex="0"
                   class="space-y-8">
-                  <JurisdictionTab v-if="regionsEnabled" />
+                  <JurisdictionTab v-if="windowProps.regions_enabled" />
                 </div>
               </template>
 

--- a/src/components/modals/settings/GeneralTab.vue
+++ b/src/components/modals/settings/GeneralTab.vue
@@ -2,6 +2,7 @@
 import LanguageToggle from '@/components/LanguageToggle.vue';
 import ThemeToggle from '@/components/ThemeToggle.vue';
 import OIcon from '@/components/icons/OIcon.vue';
+import { WindowService } from '@/services/window.service';
 import { ref } from 'vue';
 
 const isLoading = ref(false);
@@ -14,6 +15,10 @@ const emit = defineEmits<{
 const handleMenuToggled = () => {
   emit('menuToggled');
 };
+
+const windowProps = WindowService.getMultiple([
+  'i18n_enabled',
+]);
 
 const handleThemeChange = async (isDark: boolean) => {
   isLoading.value = true;
@@ -31,7 +36,7 @@ const handleThemeChange = async (isDark: boolean) => {
 <template>
   <div class="mx-auto max-w-3xl space-y-8 p-4 sm:p-6">
     <section
-      role="region"
+      role="theme"
       aria-labelledby="appearance-heading"
       class="space-y-4">
       <h3
@@ -67,7 +72,8 @@ const handleThemeChange = async (isDark: boolean) => {
       aria-hidden="true"></div>
 
     <section
-      role="region"
+      v-if="windowProps.i18n_enabled"
+      role="language"
       aria-labelledby="language-heading"
       class="space-y-4">
       <h3

--- a/src/views/dashboard/DashboardDomainBrand.vue
+++ b/src/views/dashboard/DashboardDomainBrand.vue
@@ -16,6 +16,7 @@ import { detectPlatform } from '@/utils';
 import { computed, onMounted, ref, watch } from 'vue';
 import { onBeforeRouteLeave } from 'vue-router';
 import { useI18n } from 'vue-i18n';
+import { WindowService } from '@/services/window.service';
 
 const { t } = useI18n();
 
@@ -49,6 +50,8 @@ const browserType = ref<'safari' | 'edge'>(detectPlatform());
 const toggleBrowser = () => {
   browserType.value = browserType.value === 'safari' ? 'edge' : 'safari';
 };
+
+const windowProps = WindowService.getMultiple(['i18n_enabled']);
 
 // Add loading guard
 watch(() => isLoading.value, (loading) => {
@@ -98,7 +101,8 @@ onBeforeRouteLeave((to, from, next) => {
           </template>
 
           <template #language-button>
-            <LanguageSelector v-model="brandSettings.locale"
+            <LanguageSelector v-if="windowProps.i18n_enabled"
+                              v-model="brandSettings.locale"
                               :previewI18n="previewI18n"
                               @update:model-value="(value) => brandSettings.locale = value" />
           </template>

--- a/tests/unit/ruby/rspec/config/i18n_spec.rb
+++ b/tests/unit/ruby/rspec/config/i18n_spec.rb
@@ -43,11 +43,112 @@ RSpec.describe "Internationalization config" do
       end
 
       context 'when internationalization is disabled' do
+        let(:original_state) do
+           {
+             i18n_enabled: described_class.i18n_enabled,
+             locales: described_class.instance_variable_get(:@locales),
+             default_locale: described_class.default_locale,
+             supported_locales: described_class.supported_locales
+           }
+         end
 
+         before do
+           # Setup disabled internationalization state
+           described_class.i18n_enabled = false
+           described_class.default_locale = 'en'
+           described_class.supported_locales = ['en']
+
+           # Simulate loading only English locale
+           en_locale = {'greeting': 'Hello'}
+           described_class.instance_variable_set(:@locales, {'en' => en_locale})
+         end
+
+         after do
+           # Restore original state
+           described_class.i18n_enabled = original_state[:i18n_enabled]
+           described_class.instance_variable_set(:@locales, original_state[:locales])
+           described_class.default_locale = original_state[:default_locale]
+           described_class.supported_locales = original_state[:supported_locales]
+         end
+
+         it 'returns only English locale' do
+           expect(described_class.locales).to include('en')
+           expect(described_class.locales.keys.length).to eq(1)
+         end
+
+         it 'has English as default locale' do
+           expect(described_class.default_locale).to eq('en')
+         end
+
+         it 'only has English in supported locales' do
+           expect(described_class.supported_locales).to eq(['en'])
+         end
+
+         it 'accesses locale content correctly' do
+           expect(described_class.locales['en'][:greeting]).to eq('Hello')
+         end
+      end
+
+      context 'when internationalization is enabled' do
+        let(:original_state) do
+          {
+            i18n_enabled: described_class.i18n_enabled,
+            locales: described_class.instance_variable_get(:@locales),
+            default_locale: described_class.default_locale,
+            supported_locales: described_class.supported_locales,
+            fallback_locale: described_class.fallback_locale
+          }
+        end
+
+        before do
+          # Setup enabled internationalization state
+          described_class.i18n_enabled = true
+          described_class.default_locale = 'fr_FR'
+          described_class.supported_locales = ['en', 'fr_FR', 'de_AT']
+          described_class.fallback_locale = {'fr-CA': ['fr_CA', 'fr_FR', 'en'], 'default': ['en']}
+
+          # Simulate loading multiple locales
+          test_locales = {
+            'en' => {greeting: 'Hello'},
+            'fr_FR' => {greeting: 'Bonjour'},
+            'de_AT' => {greeting: 'Grüß Gott'}
+          }
+          described_class.instance_variable_set(:@locales, test_locales)
+        end
+
+        after do
+          # Restore original state
+          described_class.i18n_enabled = original_state[:i18n_enabled]
+          described_class.instance_variable_set(:@locales, original_state[:locales])
+          described_class.default_locale = original_state[:default_locale]
+          described_class.supported_locales = original_state[:supported_locales]
+          described_class.fallback_locale = original_state[:fallback_locale]
+        end
+
+        it 'returns all configured locales' do
+          expect(described_class.locales.keys).to contain_exactly('en', 'fr_FR', 'de_AT')
+        end
+
+        it 'uses French as default locale' do
+          expect(described_class.default_locale).to eq('fr_FR')
+        end
+
+        it 'includes all locales in supported locales' do
+          expect(described_class.supported_locales).to eq(['en', 'fr_FR', 'de_AT'])
+        end
+
+        it 'accesses specific locale content correctly' do
+          expect(described_class.locales['fr_FR'][:greeting]).to eq('Bonjour')
+          expect(described_class.locales['de_AT'][:greeting]).to eq('Grüß Gott')
+        end
+
+        it 'respects configured fallback locales' do
+          expect(described_class.fallback_locale[:'fr-CA']).to eq(['fr_CA', 'fr_FR', 'en'])
+          expect(described_class.fallback_locale[:default]).to eq(['en'])
+        end
       end
 
     end
-
   end
 
   describe Onetime::App::WebHelpers do

--- a/tests/unit/ruby/rspec/config/i18n_spec.rb
+++ b/tests/unit/ruby/rspec/config/i18n_spec.rb
@@ -1,0 +1,106 @@
+# tests/unit/ruby/rspec/config/i18n_spec.rb
+
+require_relative '../spec_helper'
+
+RSpec.describe Onetime do
+  describe '.locales' do
+    context 'when internationalization is disabled' do
+      before do
+        # Save original state to restore after test
+        @original_i18n_enabled = described_class.i18n_enabled
+        @original_locales = described_class.instance_variable_get(:@locales)
+
+        # Simulate disabled internationalization
+        described_class.i18n_enabled = false
+        described_class.remove_instance_variable(:@locales) if described_class.instance_variable_defined?(:@locales)
+      end
+
+      after do
+        # Restore original state
+        described_class.i18n_enabled = @original_i18n_enabled
+        described_class.instance_variable_set(:@locales, @original_locales)
+      end
+
+      it 'should return a hash even when internationalization is disabled' do
+        # This test fails currently because OT.locales returns nil
+        expect(described_class.locales).to be_a(Hash)
+      end
+
+      it 'should not raise error when checking if locale exists' do
+        expect { described_class.locales.has_key?('en') }.not_to raise_error
+      end
+    end
+
+    context 'when internationalization is enabled' do
+      before do
+        # Save original state to restore after test
+        @original_i18n_enabled = described_class.i18n_enabled
+        @original_locales = described_class.instance_variable_get(:@locales)
+        @original_default_locale = described_class.default_locale
+
+        # Simulate enabled internationalization
+        described_class.i18n_enabled = true
+        described_class.instance_variable_set(:@locales, {'en' => {}})
+        described_class.default_locale = 'en'
+      end
+
+      after do
+        # Restore original state
+        described_class.i18n_enabled = @original_i18n_enabled
+        described_class.instance_variable_set(:@locales, @original_locales)
+        described_class.default_locale = @original_default_locale
+      end
+
+      it 'should return the configured locales' do
+        expect(described_class.locales).to eq({'en' => {}})
+      end
+
+      it 'should check if locale exists without error' do
+        expect(described_class.locales.has_key?('en')).to be true
+      end
+    end
+  end
+
+  describe '#check_locale!' do
+    let(:req) { double('request', params: {}, env: {}) }
+    let(:cust) { double('customer', locale: nil) }
+    let(:helper) do
+      Class.new do
+        include Onetime::App::WebHelpers
+        attr_accessor :req, :cust
+
+        def initialize(req, cust)
+          @req = req
+          @cust = cust
+        end
+      end.new(req, cust)
+    end
+
+    context 'when OT.locales is nil' do
+      before do
+        @original_i18n_enabled = Onetime.i18n_enabled
+        @original_locales = Onetime.instance_variable_get(:@locales)
+        @original_default_locale = Onetime.default_locale
+
+        Onetime.i18n_enabled = false
+        Onetime.remove_instance_variable(:@locales) if Onetime.instance_variable_defined?(:@locales)
+        Onetime.default_locale = 'en'
+      end
+
+      after do
+        Onetime.i18n_enabled = @original_i18n_enabled
+        Onetime.instance_variable_set(:@locales, @original_locales)
+        Onetime.default_locale = @original_default_locale
+      end
+
+      it 'should not raise error when checking locale' do
+        expect { helper.check_locale! }.not_to raise_error
+      end
+
+      it 'should set default locale when locales is nil' do
+        helper.check_locale!
+        expect(req.env['ots.locale']).to eq('en')
+      end
+    end
+  end
+end

--- a/tests/unit/ruby/rspec/onetime/app/web/views/base_spec.rb
+++ b/tests/unit/ruby/rspec/onetime/app/web/views/base_spec.rb
@@ -1,5 +1,7 @@
 # tests/unit/ruby/rspec/onetime/app/web/views/base_spec.rb
 
+# e.g. pnpm run rspec tests/unit/ruby/rspec/onetime/app/web/views/base_spec.rb
+
 require_relative '../../../../spec_helper'
 
 RSpec.describe Onetime::App::View do


### PR DESCRIPTION
### **User description**
Addressed a production error related to locale configuration by adding null safety checks and improving the i18n configuration logic. Updated tests to cover new behavior and ensure proper handling of nil values and disabled i18n settings. Enhanced UI components to conditionally display language options based on the i18n configuration. Additionally, resolved Ruby 3.5 warnings related to the reline gem.

Fixes #1142


___

### **PR Type**
Bug fix, Enhancement, Tests


___

### **Description**
- Added null safety checks for locale configurations.

- Enhanced i18n configuration logic and fallback handling.

- Updated UI components to respect `i18n_enabled` setting.

- Introduced new RSpec tests for i18n configuration and locale handling.

- Resolved Ruby 3.5 warnings by adding necessary gems.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>7 files</summary><table>
<tr>
  <td><strong>DefaultFooter.vue</strong><dd><code>Add conditional display for language toggle based on `i18n_enabled`</code></dd></td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/1145/files#diff-4598e3c5371f2a24b52ce3544f4e1dbbc0564c34ce7cce1ef8246b27cc68ba73">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>QuietFooter.vue</strong><dd><code>Add conditional language toggle visibility based on `i18n_enabled`</code></dd></td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/1145/files#diff-9631bfd5b99d081348c0b643cbc1ea86e88dadd908862d5d87edc1aa64067197">+5/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>SecretFooterControls.vue</strong><dd><code>Update language toggle visibility to depend on `i18n_enabled`</code></dd></td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/1145/files#diff-425d7c04d20386717a8e8b2e06d94ef3212be213d269d35fa757c777bb1ff44d">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>SettingsModal.vue</strong><dd><code>Refactor settings modal to use `windowProps` for i18n checks</code></dd></td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/1145/files#diff-d8255684797884d12df5774abf8b8b6a9b9a2ea7716fbb6cfb419fcd3b89da85">+5/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>GeneralTab.vue</strong><dd><code>Add conditional rendering for language section based on <code>i18n_enabled</code></code></dd></td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/1145/files#diff-278cb8a0b988241fb478120b01746ad59394815c2a42c98dfe1ead23ae540d91">+8/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>DashboardDomainBrand.vue</strong><dd><code>Add conditional language selector visibility based on `i18n_enabled`</code></dd></td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/1145/files#diff-fd7c800a7b7b505b512ebee0e7306dde6cc836d6270fadd397b249ffd30891a5">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>config.rb</strong><dd><code>Remove redundant i18n configuration logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/1145/files#diff-ef8528e98ccc09f9e1104d5942cdc820a1a35defc502edebe5a19eecb07dc8e5">+0/-23</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>onetime.rb</strong><dd><code>Refactor locale loading logic with enhanced null safety and fallbacks</code></dd></td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/1145/files#diff-fdca55a2ee0875c33af04f1ecd5140eee8528d6756a21ab4837f579da61f0d37">+36/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>i18n_spec.rb</strong><dd><code>Add RSpec tests for i18n configuration and locale handling</code></dd></td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/1145/files#diff-146ef537a77b2bd78822667854f438fc30a10481847bc065d91d6ba50b82f974">+101/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Dependencies</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>Gemfile</strong><dd><code>Add missing gems to resolve Ruby 3.5 warnings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/1145/files#diff-d09ea66f8227784ff4393d88a19836f321c915ae10031d16c93d67e6283ab55f">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>package.json</strong><dd><code>Add RSpec script for running tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/1145/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>