### PR TITLE
Fix intermittent i18n test failures

### DIFF
--- a/lib/onetime/app/web/views/base.rb
+++ b/lib/onetime/app/web/views/base.rb
@@ -233,13 +233,20 @@ module Onetime
         add_message(msg, 'error')
       end
 
-      class << self
-        # pagename must stay here while we use i18n method above. It populates
-        # the i18n[:web][:pagename] hash with the locale translations, provided
-        # the view being used has a matching name in the locales file.
-        def pagename
-          @pagename ||= self.name.split('::').last.downcase.to_sym
-        end
+      # NOTE: There's some speculation that setting a class instance variable
+      # inside the class method could present a race condition in between the
+      # check for nil and running the expression to set it. It's possible but
+      # every thread will produce the same result. Winning by technicality is
+      # one thing but the reality of software development is another. Process
+      # is more important than clever design. Instead, a safer practice is to
+      # set the class instance variable here in the class definition.
+      @pagename = self.name.split('::').last.downcase.to_sym
+
+      # pagename must stay here while we use i18n method above. It populates
+      # the i18n[:web][:pagename] hash with the locale translations, provided
+      # the view being used has a matching name in the locales file.
+      def self.pagename
+        @pagename
       end
 
     end

--- a/support/smtp_test
+++ b/support/smtp_test
@@ -45,7 +45,7 @@ MAIL
 mailer = Net::SMTP.new(smtp_host, smtp_port)
 mailer.enable_starttls
 
-puts "Using account #{smtp_username} on host #{smtp_host}"
+puts "Using account #{smtp_username} on host #{smtp_host} (destination: #{to_email})"
 
 begin
   mailer.start(smtp_host, smtp_username, smtp_password, :login) do |smtp|

--- a/tests/unit/ruby/rspec/onetime/app/web/views/base_spec.rb
+++ b/tests/unit/ruby/rspec/onetime/app/web/views/base_spec.rb
@@ -9,6 +9,11 @@ RSpec.describe Onetime::App::View do
   include_context "view_test_context"
 
   before(:each) do
+    allow(OT).to receive(:default_locale).and_return('en')
+    allow(OT).to receive(:fallback_locale).and_return('en')
+    allow(OT).to receive(:supported_locales).and_return(['en'])
+    allow(OT).to receive(:i18n_enabled).and_return(true)
+
     allow(OT).to receive(:locales).and_return({
       'en' => {
         web: {


### PR DESCRIPTION
### **User description**
- Make sure the test mocks are reset properly 
- Clean up the pagename method to eliminate a potential race condition by setting the class instance variable directly in the class definition. 

Additionally, improve logging output to include the destination email.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fixed potential race condition in `pagename` method by setting class instance variable directly.

- Enhanced i18n test setup with additional mocks for locale configurations.

- Improved logging in SMTP test to include destination email.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>base.rb</strong><dd><code>Refactor `pagename` to prevent race condition</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/onetime/app/web/views/base.rb

<li>Refactored <code>pagename</code> method to avoid potential race condition.<br> <li> Added explanatory comments about the change.


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/1154/files#diff-a5d4e462fd47bbc94ac209ba3bdad2ef72c7bdb5948808941a06805e38e59836">+14/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>base_spec.rb</strong><dd><code>Add i18n configuration mocks for tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/unit/ruby/rspec/onetime/app/web/views/base_spec.rb

<li>Added mocks for default, fallback, and supported locales.<br> <li> Enabled i18n configuration for tests.


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/1154/files#diff-c00c46884737f42e8822ac377cc39f4cf50f8074f2e30b92cb7ca9112bb065bf">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>smtp_test</strong><dd><code>Improve SMTP logging with destination email</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

support/smtp_test

- Enhanced logging to include destination email in SMTP output.


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/1154/files#diff-0c1a59a00ecee6e321377158f1ffa7ea72fc4888195826765b1fe6b6f76daf7d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>