### PR TITLE
Remove deprecated subscription plans

### DIFF
--- a/bin/ots
+++ b/bin/ots
@@ -49,8 +49,10 @@ class OT::CLI::Definition
   end
   alias_command :build, :version
 
-  usage 'ots migrate MIGRATION_SCRIPT'
+  # In OT::CLI::Definition in bin/ots
+  usage 'ots migrate MIGRATION_SCRIPT [--run]'
   about 'Run a migration script from the migrate/ directory'
+  option :r, :run, "Actually apply changes (default is dry run mode)"
   command migrate: OT::CLI
 
   usage 'ots move-keys SOURCEDB TARGETDB [filter]'

--- a/lib/onetime/cli.rb
+++ b/lib/onetime/cli.rb
@@ -19,7 +19,8 @@ module Onetime
       migration_file = argv.first
 
       unless migration_file
-        puts "Usage: ots migrate MIGRATION_SCRIPT"
+        puts "Usage: ots migrate MIGRATION_SCRIPT [--run]"
+        puts "  --run    Actually apply changes (default is dry run mode)"
         puts "\nAvailable migrations:"
         Dir[File.join(Onetime::HOME, 'migrate', '*.rb')].each do |file|
           puts "  - #{File.basename(file)}"
@@ -38,7 +39,10 @@ module Onetime
         require_relative "../../migrate/#{migration_file}"
 
         # Run the migration
-        success = Onetime::Migration.run
+        migration = Onetime::Migration.new
+        # Pass options to the migration
+        migration.options[:run] = option.run
+        success = migration.migrate
         puts success ? "\nMigration completed successfully" : "\nMigration failed"
         exit(success ? 0 : 1)
       rescue LoadError => e

--- a/lib/onetime/cli.rb
+++ b/lib/onetime/cli.rb
@@ -38,11 +38,8 @@ module Onetime
         # Load the migration script
         require_relative "../../migrate/#{migration_file}"
 
-        # Run the migration
-        migration = Onetime::Migration.new
-        # Pass options to the migration
-        migration.options[:run] = option.run
-        success = migration.migrate
+        # Run the migration with options
+        success = Onetime::Migration.run(run: option.run)
         puts success ? "\nMigration completed successfully" : "\nMigration failed"
         exit(success ? 0 : 1)
       rescue LoadError => e

--- a/lib/onetime/migration.rb
+++ b/lib/onetime/migration.rb
@@ -1,6 +1,14 @@
+# lib/onetime/migration.rb
+
 module Onetime
   # Base class for all migrations
   class BaseMigration
+    attr_accessor :options
+
+    def initialize
+      @options = {}
+    end
+
     def self.run
       new.migrate
     end

--- a/lib/onetime/migration.rb
+++ b/lib/onetime/migration.rb
@@ -4,27 +4,95 @@ module Onetime
   # Base class for all migrations
   class BaseMigration
     attr_accessor :options
+    attr_reader :stats
 
     def initialize
       @options = {}
+      @stats = Hash.new(0)
     end
 
-    def self.run
-      new.migrate
+    def self.run(options = {})
+      migration = new
+      migration.options = options
+      migration.migrate
     end
 
     def migrate
       raise NotImplementedError, "#{self.class} must implement #migrate"
     end
 
+    # Core run mode methods
+
+    def dry_run?
+      !options[:run]
+    end
+
+    def actual_run?
+      options[:run]
+    end
+
+    def run_mode_banner
+      header("Running in #{dry_run? ? 'DRY RUN' : 'ACTUAL RUN'} mode")
+      info("#{dry_run? ? 'No changes will be made' : 'Changes WILL be applied to the database'}")
+      separator
+    end
+
+    def execute_if_actual_run
+      if actual_run?
+        yield
+        true
+      else
+        false
+      end
+    end
+
+    def track_stat(key, increment = 1)
+      @stats[key] += increment
+    end
+
+    # Logging and output methods
+
+    def header(message)
+      OT.li(message.upcase)
+    end
+
+    def info(message)
+      OT.li(message)
+    end
+
+    def debug(message)
+      OT.ld(message)
+    end
+
+    def separator
+      OT.li("------------------------------------------------------------")
+    end
+
+    def progress(current, total, message = "Processing", step = 100)
+      if current % step == 0 || current == total
+        OT.li "#{message} #{current}/#{total}..."
+      end
+    end
+
+    # Summary methods
+
+    def print_summary
+      separator
+      if dry_run?
+        header("DRY RUN SUMMARY")
+        # Always show this message to make it clear how to run for real
+        yield(:dry_run) if block_given?
+        info("To make actual changes, run with the --run option")
+      else
+        header("ACTUAL RUN SUMMARY")
+        yield(:actual_run) if block_given?
+      end
+    end
+
     protected
 
     def redis
       @redis ||= Familia.redis(6)
-    end
-
-    def log(message)
-      puts message
     end
   end
 end

--- a/lib/onetime/plan.rb
+++ b/lib/onetime/plan.rb
@@ -20,7 +20,6 @@ module Onetime
       # circular dependency issues. Plans are loaded very early
       # ans technically aren't models in the traditional sense.
       #
-      # TODO: Doublecheck directly including works as expected. i.e. without subclassing Familia::Horreum.
       self.class.include Familia::Features::SafeDump
     end
 
@@ -62,22 +61,6 @@ module Onetime
         add_plan :anonymous, 0, 0, ttl: 7.days, size: 100_000, api: false, name: 'Anonymous'
         add_plan :basic, 0, 0, ttl: 14.days, size: 1_000_000, api: true, name: 'Basic Plan', email: true, custom_domains: false, dark_mode: true
         add_plan :identity, 35, 0, ttl: 30.days, size: 10_000_000, api: true, name: 'Identity', email: true, custom_domains: true, dark_mode: true
-
-        # Deprecated / to be removed in future versions
-        add_plan :personal_v1, 5.0, 1, ttl: 14.days, size: 1_000_000, api: false, name: 'Personal'
-        add_plan :personal_v2, 10.0, 0.5, ttl: 30.days, size: 1_000_000, api: true, name: 'Personal'
-        add_plan :personal_v3, 5.0, 0, ttl: 14.days, size: 1_000_000, api: true, name: 'Personal'
-        add_plan :professional_v1, 30.0, 0.50, ttl: 30.days, size: 1_000_000, api: true, cname: true,
-                                               name: 'Professional'
-        add_plan :professional_v2, 30.0, 0.333333, ttl: 30.days, size: 1_000_000, api: true, cname: true,
-                                                   name: 'Professional'
-        add_plan :agency_v1, 100.0, 0.25, ttl: 30.days, size: 1_000_000, api: true, private: true,
-                                          name: 'Agency'
-        add_plan :agency_v2, 75.0, 0.33333333, ttl: 30.days, size: 1_000_000, api: true, private: true,                                               name: 'Agency'
-        add_plan :basic_v1, 10.0, 0.5, ttl: 30.days, size: 1_000_000, api: true, name: 'Basic'
-        add_plan :individual_v1, 0, 0, ttl: 14.days, size: 1_000_000, api: true, name: 'Individual'
-        add_plan :nonprofit_v1, 0, 0, ttl: 30.days, size: 1_000_000, api: true, cname: true,
-                                      name: 'Non Profit'
       end
     end
 

--- a/migrate/1002_planid_audit.rb
+++ b/migrate/1002_planid_audit.rb
@@ -1,0 +1,101 @@
+#!/usr/bin/env ruby
+# migrate/1002_planid_audit.rb
+
+base_path = File.expand_path File.join(File.dirname(__FILE__), '..')
+$:.unshift File.join(base_path, 'lib')
+
+require 'onetime'
+require 'onetime/migration'
+
+# Set of valid plan IDs
+VALID_PLANS = ['anonymous', 'basic', 'identity'].freeze
+
+module Onetime
+  class Migration < BaseMigration
+    def migrate
+      deprecated_count = 0
+      empty_count = 0
+      total_keys_count = 0
+      loops_count = 0
+      deprecated_customers = []
+      empty_planid_customers = []
+
+      # Use Redis scan for non-blocking iteration over customer keys
+      cursor = "0"
+      pattern = "customer:*:object"
+      batch_size = 1000
+      redis = Familia.redis(6)
+
+      OT.li "Starting scan of customer records..."
+
+      loop do
+        loops_count += 1
+
+        cursor, keys = redis.scan(cursor, match: pattern, count: batch_size)
+
+        keys.each do |key|
+          total_keys_count += 1
+
+          # Extract customer ID from key
+          custid = key.split(':')[1] rescue nil
+          next unless custid
+
+          keytype = redis.type(key)
+          OT.ld "Customer ID: #{custid} (#{key})"
+          OT.ld "Key type: #{keytype}"
+
+          # Get planid directly from Redis hash
+          planid = redis.hget(key, 'planid')
+
+          # Handle empty planid case
+          if planid.nil? || planid.strip.empty?
+            empty_count += 1
+            empty_planid_customers << { custid: custid }
+            OT.ld "Customer #{custid} has empty planid"
+            next
+          end
+
+          # Check if plan is deprecated
+          unless VALID_PLANS.include?(Onetime::Plan.normalize(planid))
+            deprecated_count += 1
+            deprecated_customers << { custid: custid, planid: planid }
+
+            # Print progress for large datasets
+            OT.li "Found #{deprecated_count} deprecated plans..." if deprecated_count % batch_size == 0
+          end
+        end
+
+        # Exit loop when scan is complete
+        break if cursor == "0"
+      end
+
+      OT.li "Total keys scanned: #{total_keys_count} in #{loops_count} loops"
+
+      # Report empty planid customers
+      if empty_planid_customers.empty?
+        OT.li "No customers found with empty plan IDs."
+      else
+        OT.li "Found #{empty_count} customers with empty plan IDs"
+        empty_planid_customers.each do |customer|
+          OT.ld "Customer ID: #{customer[:custid]}"
+        end
+      end
+
+      # Report deprecated plan customers
+      if deprecated_customers.empty?
+        OT.li "No customers found on deprecated plans."
+      else
+        OT.li "Found #{deprecated_count} customers on deprecated plans:"
+        deprecated_customers.each do |customer|
+          OT.ld "Customer ID: #{customer[:custid]}, Plan ID: #{customer[:planid]}"
+        end
+      end
+    end
+  end
+end
+
+# If this script is run directly
+if __FILE__ == $0
+  OT.boot! :cli
+  exit(Onetime::Migration.run ? 0 : 1)
+end

--- a/migrate/1002_planid_audit.rb
+++ b/migrate/1002_planid_audit.rb
@@ -56,7 +56,7 @@ module Onetime
             execute_if_actual_run do
               redis_client.hset(key, 'planid', 'basic')
               track_stat(:changed_customers)
-              debug "Updated customer #{custid} to 'basic' plan"
+              info "Updated customer #{custid} to 'basic' plan"
             end
 
             next
@@ -74,7 +74,7 @@ module Onetime
             execute_if_actual_run do
               redis_client.hset(key, 'planid', 'basic')
               track_stat(:changed_customers)
-              debug "Updated customer #{custid} from '#{planid}' to 'basic' plan"
+              info "Updated customer #{custid} from '#{planid}' to 'basic' plan"
             end
 
             # Print progress for large datasets


### PR DESCRIPTION
### **User description**
Audit and remove deprecated subscription plans from the codebase. Introduce a dry-run mode for migrations to ensure safer execution. Implement a script to track and update customer records with deprecated or empty plan IDs to the active 'basic' plan. Enhance logging for better visibility of changes during migrations.

Fixes #1002


___

### **PR Type**
Enhancement, Bug fix, Tests


___

### **Description**
- Removed deprecated subscription plans from `lib/onetime/plan.rb`.

- Introduced a dry-run mode for safer database migrations.

- Added a migration script to audit and update customer records.

- Enhanced logging and progress tracking for migration processes.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cli.rb</strong><dd><code>Add dry-run mode support to CLI migrations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/onetime/cli.rb

<li>Updated CLI to support <code>--run</code> flag for migrations.<br> <li> Enhanced usage instructions for migration commands.<br> <li> Integrated dry-run mode into migration execution.


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/1208/files#diff-682e856ca4b6e4f9b379fa54b0f348a75da65b5f589f9da4b23de0f49cd6d1bb">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>migration.rb</strong><dd><code>Enhance migration system with dry-run and logging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/onetime/migration.rb

<li>Introduced dry-run and actual-run modes for migrations.<br> <li> Added detailed logging and progress tracking methods.<br> <li> Implemented statistics tracking for migration operations.


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/1208/files#diff-8f1e3f53593e716b1d4984717d8344dda1b759a332f401640bace9cb722d0cba">+82/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>1002_planid_audit.rb</strong><dd><code>Add migration script for auditing and updating plan IDs</code>&nbsp; &nbsp; </dd></summary>
<hr>

migrate/1002_planid_audit.rb

<li>Added a migration script to audit customer records.<br> <li> Updated empty or deprecated plan IDs to the <code>basic</code> plan.<br> <li> Included dry-run mode for safe execution.<br> <li> Logged detailed statistics and progress during execution.


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/1208/files#diff-aab53283735259bd167652b7f81bd800c3e3a41cbceed3201acd190a814b26be">+140/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ots</strong><dd><code>Update CLI migration command with `--run` option</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

bin/ots

<li>Updated migration command to include <code>--run</code> option.<br> <li> Enhanced CLI help text for migration commands.


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/1208/files#diff-f760b4e89ed099696292fc69306124cbec19b6c57ac9be1f5ff22bc4b887171b">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>plan.rb</strong><dd><code>Remove deprecated subscription plans</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/onetime/plan.rb

<li>Removed definitions for deprecated subscription plans.<br> <li> Retained only active plans: <code>anonymous</code>, <code>basic</code>, and <code>identity</code>.


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/1208/files#diff-c16aaf64e8113cc0a26e0f0cce4f1765fc639caec85f4eae5c80a15a71a1cff7">+0/-17</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>