### PR TITLE
Add 60 seconds minimum to default TTL options

### DIFF
--- a/lib/onetime/config.rb
+++ b/lib/onetime/config.rb
@@ -93,6 +93,7 @@ module Onetime
       end
       conf[:site][:secret_options][:default_ttl] ||= 7.days
       conf[:site][:secret_options][:ttl_options] ||= [
+        60.seconds,     # 60 seconds (was missing from v0.20.5)
         5.minutes,      # 300 seconds
         30.minutes,     # 1800
         1.hour,         # 3600


### PR DESCRIPTION
### **User description**
Update the default TTL options to include a minimum of 60 seconds, addressing the removal of the hardcoded minimum in the previous release.

---

In release v0.20.5, a fix for the ttl logic removed a hardcoded min of
60 seconds that was buried in the validation logic. Now the logic is
based on the configured (or default) ttl options. The default hardcoded
values don't include 60 seconds so instances running this release had a
minimum of 5 minutes (unless they were explicitly configured otherwise).

https://github.com/onetimesecret/onetimesecret/releases/tag/v0.20.5


___

### **PR Type**
Enhancement


___

### **Description**
- Added a 60-second minimum to default TTL options.

- Updated configuration to ensure consistent TTL behavior.

- Addressed missing 60-second option from v0.20.5 release.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config.rb</strong><dd><code>Add 60-second option to TTL configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/onetime/config.rb

<li>Added <code>60.seconds</code> to the <code>ttl_options</code> array.<br> <li> Ensured the minimum TTL aligns with previous expectations.<br> <li> Commented the addition to clarify its purpose.


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/1210/files#diff-ef8528e98ccc09f9e1104d5942cdc820a1a35defc502edebe5a19eecb07dc8e5">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>