### PR TITLE
[#1217] Fix argument check in container entrypoint script

### DIFF
--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -81,7 +81,10 @@ fi
 # Run the command configured for the docker compose service
 # in the docker-compose.yaml file, or a default if none is
 # provided. See Dockerfile for more details.
-if [ -z "$@" ]; then
+#
+# Check if no arguments were provided to the script
+# (e.g. running container without command override).
+if [ $# -eq 0 ]; then
   PORT="${PORT:-3000}" # explicit default
 
   # Choose server based on SERVER_TYPE environment variable


### PR DESCRIPTION
### **User description**
#1217


___

### **PR Type**
Bug fix, Documentation


___

### **Description**
- Fixed argument check in Docker entrypoint script for reliability.

- Replaced `-z "$@"` with `if [ $# -eq 0 ]` for accurate argument detection.

- Added comments explaining the new argument check logic.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>entrypoint.sh</strong><dd><code>Fix and document argument check in entrypoint script</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

bin/entrypoint.sh

<li>Replaced unreliable argument check <code>-z "$@"</code> with <code>if [ $# -eq 0 ]</code>.<br> <li> Added comments to explain the purpose of the new condition.<br> <li> Improved script reliability and clarity for handling arguments.


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/1231/files#diff-75312155067f723f6e9c86dd316e4d83a9c88fb8be09889c355e39e03fb5ab6c">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>