### PR TITLE
Remove original_size field and improve keyboard event handling

### DIFF
--- a/apps/api/v2/logic/secrets/reveal_secret.rb
+++ b/apps/api/v2/logic/secrets/reveal_secret.rb
@@ -8,7 +8,7 @@ module V2::Logic
     class RevealSecret < V2::Logic::Base
       attr_reader :key, :passphrase, :continue, :share_domain
       attr_reader :secret, :show_secret, :secret_value, :is_truncated,
-                  :original_size, :verification, :correct_passphrase,
+                  :verification, :correct_passphrase,
                   :display_lines, :one_liner, :is_owner, :has_passphrase,
                   :secret_key
 
@@ -40,7 +40,6 @@ module V2::Logic
           # the encrypted string.
           @secret_value = secret.can_decrypt? ? secret.decrypted_value : secret.value
           @is_truncated = secret.truncated?
-          @original_size = secret.original_size
 
           if verification
             if owner.nil? || owner.anonymous? || owner.verified?

--- a/apps/api/v2/logic/secrets/show_secret.rb
+++ b/apps/api/v2/logic/secrets/show_secret.rb
@@ -6,7 +6,7 @@ module V2::Logic
     class ShowSecret < V2::Logic::Base
       attr_reader :key, :passphrase, :continue
       attr_reader :secret, :show_secret, :secret_value, :is_truncated,
-                  :original_size, :verification, :correct_passphrase,
+                  :verification, :correct_passphrase,
                   :display_lines, :one_liner, :is_owner, :has_passphrase,
                   :secret_key, :share_domain
 
@@ -35,7 +35,6 @@ module V2::Logic
           # the encrypted string.
           @secret_value = secret.can_decrypt? ? secret.decrypted_value : secret.value
           @is_truncated = secret.truncated?
-          @original_size = secret.original_size
 
           if verification
             if cust.anonymous? || (cust.custid == owner.custid && !owner.verified?)

--- a/apps/api/v2/models/secret.rb
+++ b/apps/api/v2/models/secret.rb
@@ -16,7 +16,6 @@ module V2
     field :state
     field :value
     field :metadata_key
-    field :original_size
     field :value_checksum
     field :value_encryption
     field :lifespan
@@ -45,7 +44,6 @@ module V2
       :state,
       { secret_ttl: ->(m) { m.lifespan } },
       :lifespan,
-      :original_size,
       { shortkey: ->(m) { m.key.slice(0, 8) } },
       { has_passphrase: ->(m) { m.has_passphrase? } },
       { verification: ->(m) { m.verification? } },
@@ -119,7 +117,6 @@ module V2
         storable_value = original_value
       end
 
-      self.original_size = original_value.size
       self.value_checksum = storable_value.gibbler
       self.value_encryption = 2
       self.value = storable_value.encrypt opts.merge(:key => encryption_key)
@@ -224,7 +221,7 @@ module V2
       # happens in Logic::RevealSecret.process which prepares the secret value
       # to be included in the response and then calls this method att the end.
       # It's at that point that `Logic::RevealSecret.success_data` is called
-      # which means if we were to clear out say -- original_size -- it would
+      # which means if we were to clear out say -- state -- it would
       # be null in the API's JSON response. Not a huge deal in that case, but
       # we validate response data in the UI now and this would raise an error.
       @value = nil

--- a/src/components/CustomDomainPreview.vue
+++ b/src/components/CustomDomainPreview.vue
@@ -18,8 +18,8 @@
    * @see {@link useDropdown} For dropdown behavior implementation
    * @see {@link useDomainDropdown} For domain selection implementation
    */
-  import OIcon from '@/components/icons/OIcon.vue';
   import FancyIcon from '@/components/ctas/FancyIcon.vue';
+  import OIcon from '@/components/icons/OIcon.vue';
   import { useDomainDropdown } from '@/composables/useDomainDropdown';
   import { useDropdown } from '@/composables/useDropdown';
   import { WindowService } from '@/services/window.service';
@@ -33,6 +33,7 @@
       withDomainDropdown?: boolean;
     }>(),
     {
+      availableDomains: undefined,
       initialDomain: '',
       withDomainDropdown: false,
     }
@@ -59,8 +60,9 @@
     close();
   });
 
-  // Keyboard navigation
+  // Keyboard navigation for Space key
   onKeyStroke('Space', (e) => {
+    // This is already checking for button focus, which is correct
     if (document.activeElement === buttonRef.value) {
       e.preventDefault();
       isOpen.value = !isOpen.value;
@@ -69,7 +71,12 @@
 
   // Arrow key navigation
   onKeyStroke(['ArrowDown', 'ArrowUp'], (e) => {
+    // Only handle arrow keys when the component is focused or dropdown is open
     if (!props.availableDomains?.length) return;
+
+    // Check if either the button is focused or the dropdown is open
+    const isComponentFocused = document.activeElement === buttonRef.value || isOpen.value;
+    if (!isComponentFocused) return;
 
     e.preventDefault();
     if (!isOpen.value) {
@@ -88,7 +95,9 @@
 
   // Enter to select highlighted item
   onKeyStroke('Enter', (e) => {
-    if (isOpen.value && activeIndex.value >= 0) {
+    // Only handle when dropdown is open and component is focused
+    const isComponentFocused = document.activeElement === buttonRef.value || isOpen.value;
+    if (isOpen.value && activeIndex.value >= 0 && isComponentFocused) {
       e.preventDefault();
       const domain = props.availableDomains?.[activeIndex.value];
       if (domain) selectDomain(domain);
@@ -96,7 +105,9 @@
   });
 
   onKeyStroke('Escape', () => {
-    if (isOpen.value) {
+    // Only handle when dropdown is open and component is focused
+    const isComponentFocused = document.activeElement === buttonRef.value || isOpen.value;
+    if (isOpen.value && isComponentFocused) {
       close();
       buttonRef.value?.focus();
     }

--- a/src/components/secrets/canonical/SecretDisplayCase.vue
+++ b/src/components/secrets/canonical/SecretDisplayCase.vue
@@ -142,7 +142,7 @@ const closeTruncatedWarning = (event: Event) => {
             <span aria-hidden="true">&times;</span>
           </button>
           <strong>{{ $t('web.COMMON.warning') }}</strong>
-          {{ $t('web.shared.secret_was_truncated') }} {{ record.original_size }}.
+          {{ $t('web.shared.secret_was_truncated') }}
         </div>
       </div>
     </template>

--- a/src/schemas/models/secret.ts
+++ b/src/schemas/models/secret.ts
@@ -42,7 +42,6 @@ export const secretSchema = createModelSchema({
   ...secretBaseSchema.shape,
   secret_ttl: transforms.fromString.number,
   lifespan: transforms.fromString.number,
-  original_size: z.string(),
 }).strip();
 
 // Details schema with explicit typing

--- a/tests/unit/ruby/try/00_middleware/11_detect_host_try.rb
+++ b/tests/unit/ruby/try/00_middleware/11_detect_host_try.rb
@@ -18,6 +18,8 @@ require 'middleware/detect_host'
 # Capture log output for verification
 @log_output = StringIO.new
 @app = ->(env) { [200, {}, ['OK']] }
+@original_value = OT.debug?
+OT.debug = true  # log messages are only avalable in debug mode
 @middleware = Rack::DetectHost.new(@app, io: @log_output)
 
 ## X-Forwarded-Host takes precedence over Host header
@@ -81,3 +83,8 @@ env = {'HTTP_HOST' => 'example.com'}
 status, _, body = @middleware.call(env)
 [status, body]
 #=> [200, ['OK']]
+
+
+
+# Put everything back the way we found it
+OT.debug = @original_value

--- a/tests/unit/vue/fixtures/metadata.fixture.ts
+++ b/tests/unit/vue/fixtures/metadata.fixture.ts
@@ -246,7 +246,6 @@ export const mockSecretRecord: Secret = {
   secret_ttl: 86400,
   // Schema expects number, not string
   lifespan: 86400,
-  original_size: '42 bytes',
 };
 
 export const mockBurnedSecretRecord: Secret | null = null;
@@ -264,7 +263,6 @@ export const mockReceivedSecretRecord: Secret = {
   secret_value: 'received test secret',
   secret_ttl: 86400,
   lifespan: 86400,
-  original_size: '42 bytes',
 };
 
 export const mockOrphanedSecretRecord: Secret = {
@@ -281,7 +279,6 @@ export const mockOrphanedSecretRecord: Secret = {
   // Schema now expects number, not null
   secret_ttl: 0,
   lifespan: 0,
-  original_size: '42 bytes',
 };
 
 export const mockReceivedSecretRecord1: Secret = {
@@ -297,7 +294,6 @@ export const mockReceivedSecretRecord1: Secret = {
   secret_value: 'received-test-secret-1',
   secret_ttl: 3600, // 1 hour
   lifespan: 3600,
-  original_size: '42 bytes',
 };
 
 export const mockReceivedSecretRecord2: Secret = {
@@ -313,7 +309,6 @@ export const mockReceivedSecretRecord2: Secret = {
   secret_value: 'received-test-secret-2',
   secret_ttl: 7200, // 2 hours
   lifespan: 7200,
-  original_size: '42 bytes',
 };
 
 export const mockNotReceivedSecretRecord1: Secret = {
@@ -329,7 +324,6 @@ export const mockNotReceivedSecretRecord1: Secret = {
   secret_value: 'not-received-test-secret-1',
   secret_ttl: 1800, // 30 minutes
   lifespan: 1800,
-  original_size: '42 bytes',
 };
 
 export const mockSecretResponse = {


### PR DESCRIPTION
Remove the `original_size` field from the Secret model and related components to address security concerns. Update API responses, validation schemas, and frontend components accordingly. Additionally, enhance keyboard event handling in the domain preview component to ensure proper focus management, allowing users to navigate without interference.

Fixes #1254