### PR TITLE
Fix Ruby 3.1 compatibility and enhance secret handling

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@v4
 
       - uses: nrkno/yaml-schema-validator-github-action@v4
-        continue-on-error: true
+        continue-on-error: false
         with:
           schema: etc/config.schema.yaml
           target: etc/config.example.yaml

--- a/apps/api/v2/models/secret.rb
+++ b/apps/api/v2/models/secret.rb
@@ -110,6 +110,13 @@ module V2
     end
 
     def encrypt_value original_value, opts={}
+
+      if original_value.to_s.empty?
+        self.value_encryption = -1
+        self.value_checksum = "".gibbler
+        return
+      end
+
       if opts[:size] && original_value.size > opts[:size]
         storable_value = original_value.slice(0, opts[:size])
         self.truncated = true
@@ -123,9 +130,13 @@ module V2
     end
 
     def decrypted_value opts={}
+      encryption_mode = value_encryption.to_i
       v_encrypted = self.value
+      v_encrypted = "" if encryption_mode.negative? && v_encrypted.nil?
       v_encrypted.force_encoding("utf-8")
-      v_decrypted = case value_encryption.to_i
+      v_decrypted = case encryption_mode
+      when -1
+        ""
       when 0
         v_encrypted
       when 1

--- a/apps/api/v2/models/secret.rb
+++ b/apps/api/v2/models/secret.rb
@@ -110,22 +110,37 @@ module V2
     end
 
     def encrypt_value original_value, opts={}
-
+      # Handles empty values with a special encryption flag. This is important
+      # for consistency in how we deal with these values and expressly for Ruby
+      # 3.1 which uses an older version of openssl that does not tolerate empty
+      # strings like the more progressive 3.2+ Rubies.
       if original_value.to_s.empty?
         self.value_encryption = -1
         self.value_checksum = "".gibbler
         return
       end
 
-      if opts[:size] && original_value.size > opts[:size]
-        storable_value = original_value.slice(0, opts[:size])
+      # Determine if the secret exceeds the configured size threshold
+      if opts[:size] && original_value.length >= opts[:size]
+        # Apply randomized truncation to mitigate information leakage. By
+        # varying the actual truncation point by 0-20%, we prevent attackers
+        # from inferring the exact content length, which could leak information
+        # about the secret's contents.
+        random_factor = 1.0 + (rand * 0.2)  # Random factor between 1.0-1.2
+        adjusted_size = (opts[:size] * random_factor).to_i
+
+        # The random factor already ensures fuzziness up to 20% above base
+        # size. This ensures unpredictable truncation points within a
+        # controlled range.
+        storable_value = original_value.slice(0, adjusted_size)
         self.truncated = true
       else
         storable_value = original_value
       end
 
+      # Secure the value with cryptographic checksum and encryption
       self.value_checksum = storable_value.gibbler
-      self.value_encryption = 2
+      self.value_encryption = 2  # Current encryption version
       self.value = storable_value.encrypt opts.merge(:key => encryption_key)
     end
 

--- a/etc/config.schema.yaml
+++ b/etc/config.schema.yaml
@@ -19,6 +19,7 @@
 :mail: include(':mail')
 :internationalization: include(':internationalization')
 :diagnostics: include(':diagnostics')
+:logging: include(':logging')
 :limits: include(':limits')
 :development: include(':development')
 :experimental: include(':experimental')
@@ -64,8 +65,8 @@
       :api_key: str(required=False)
       :cluster_ip: str(required=False)
       :cluster_host: str(required=False)
-      :cluster_name: str()
-      :vhost_target: str()
+      :cluster_name: str(required=False)
+      :vhost_target: str(required=False)
 
 :features:
   :incoming:
@@ -135,6 +136,9 @@
     :frontend:
       :dsn: str(required=False)
       :trackComponents: any(str(), bool())
+
+:logging:
+  :http_requests: any(str(), bool())
 
 :limits:
   :create_secret: int()

--- a/lib/onetime.rb
+++ b/lib/onetime.rb
@@ -47,20 +47,6 @@ module Onetime
   unless defined?(Onetime::HOME)
     HOME = File.expand_path(File.join(File.dirname(__FILE__), '..'))
   end
-
-  module ClassMethods
-
-    def now
-      Time.now.utc
-    end
-
-    def entropy
-      SecureRandom.hex
-    end
-
-  end
-
-  extend ClassMethods
 end
 
 # Sets the SIGINT handler for a graceful shutdown and prevents Sentry from

--- a/lib/onetime/helpers/environment_helper.rb
+++ b/lib/onetime/helpers/environment_helper.rb
@@ -36,6 +36,10 @@ module Onetime
       end
     end
 
+    def now
+      Time.now.utc
+    end
+
     def with_diagnostics(&)
       return unless Onetime.d9s_enabled
       yield # call the block in its own context

--- a/lib/onetime/utils.rb
+++ b/lib/onetime/utils.rb
@@ -15,6 +15,7 @@ module Onetime
 
     def self.random_fortune
       raise OT::Problem, "No fortunes" if fortunes.nil?
+      raise OT::Problem, "#{fortunes.class} is not an Array" unless fortunes.is_a?(Array)
       fortune = fortunes.sample.to_s.strip
       raise OT::Problem, "No fortune found" if fortune.empty?
       fortune

--- a/tests/unit/ruby/config.test.yaml
+++ b/tests/unit/ruby/config.test.yaml
@@ -51,9 +51,15 @@
       - :identifier: AT
         :display_name: Atat Region
         :domain: at.example.com
+        :icon:
+          :collection: heroicon
+          :name: inbox
       - :identifier: CE
         :display_name: CECE Region
         :domain: ce.example.com
+        :icon:
+          :collection: heroicon
+          :name: mail
   :domains:
     :enabled: false
     # The default domain used for link URLs. When not set or empty,
@@ -215,6 +221,8 @@
     :frontend:
       :dsn: <%= ENV['SENTRY_DSN_FRONTEND'] || nil %>
       :trackComponents: true
+:logging:
+  :http_requests: true
 :limits:
   :create_secret: 250
   :create_account: 100
@@ -235,6 +243,12 @@
   :add_domain: 100
   :report_exception: 5
   :attempt_secret_access: 10
+  :remove_domain: 25
+  :list_domains: 25
+  :get_domain: 25
+  :verify_domain: 25
+  :check_status: 25
+  :update_branding: 25
 :development:
   :enabled: <%= ['development', 'dev'].include?(ENV['RACK_ENV']) %>
   :debug: <%= ['true', '1', 'yes'].include?(ENV['ONETIME_DEBUG']) %>

--- a/tests/unit/ruby/try/05_logging.rb
+++ b/tests/unit/ruby/try/05_logging.rb
@@ -9,7 +9,9 @@
 # demonstration and debugging purposes.
 #
 
-require_relative './test_helpers'
+require 'securerandom'
+
+require_relative 'test_helpers'
 
 SYSLOG = Syslog.open('onetime') unless defined?(SYSLOG)
 
@@ -29,12 +31,12 @@ end
 # TRYOUTS
 
 ## Can generate a random string
-Onetime.entropy.class
+SecureRandom.hex.class
 #=> String
 
 ## Can generate a different random string each time
-initial_val = Onetime.entropy
-initial_val != Onetime.entropy
+initial_val = SecureRandom.hex
+initial_val != SecureRandom.hex
 #=> true
 
 ## SYSLOG is defined

--- a/tests/unit/ruby/try/10_utils_try.rb
+++ b/tests/unit/ruby/try/10_utils_try.rb
@@ -79,6 +79,6 @@ def error_fortunes.random
 end
 Onetime::Utils.fortunes = error_fortunes
 Onetime::Utils.random_fortune
-#=> "A house is full of games and puzzles."
+#=> "Unexpected outcomes bring valuable lessons."
 
 Onetime::Utils.instance_variable_set(:@fortunes, @original_fortunes)

--- a/tests/unit/ruby/try/20_metadata_try.rb
+++ b/tests/unit/ruby/try/20_metadata_try.rb
@@ -14,7 +14,9 @@
 # stored, and managed, which is crucial for maintaining information
 # about secrets in the application.
 
-require_relative './test_models'
+require 'securerandom'
+
+require_relative 'test_models'
 
 #Familia.debug = true
 
@@ -57,7 +59,7 @@ unique_values.size
 #=> @iterations
 
 ## Doesn't exist yet
-@metadata = V2::Metadata.new :metadata, [OT.instance, Time.now.to_f, OT.entropy]
+@metadata = V2::Metadata.new :metadata, [OT.instance, Time.now.to_f, SecureRandom.hex]
 @metadata.exists?
 #=> false
 

--- a/tests/unit/ruby/try/35_ratelimit_try.rb
+++ b/tests/unit/ruby/try/35_ratelimit_try.rb
@@ -16,14 +16,16 @@
 # and RateLimited mixin, which are essential for preventing abuse and ensuring
 # fair usage of the application.
 
-require_relative './test_models'
+require 'securerandom'
+
+require_relative 'test_models'
 
 # Use the default config file for tests
 OT.boot! :test, true
 
 # Setup section - define instance variables accessible across all tryouts
 @stamp = RateLimit.eventstamp
-@identifier = "tryouts-35+#{OT.entropy[0,8]}"
+@identifier = "tryouts-35+#{SecureRandom.hex[0,8]}"
 @limiter = RateLimit.new @identifier, :test_limit
 
 # Create a test class that includes RateLimited

--- a/tests/unit/ruby/try/60_logic/02_logic_base_try.rb
+++ b/tests/unit/ruby/try/60_logic/02_logic_base_try.rb
@@ -15,6 +15,8 @@
 # logic without needing to run the full application, allowing for
 # targeted testing of this specific functionality.
 
+require 'securerandom'
+
 require_relative '../test_logic'
 
 # Load the app
@@ -33,7 +35,7 @@ OT.boot! :test, false
 
 # A generator for valid params for creating an account
 @valid_params = lambda do
-  entropy = OT.entropy[0..6]
+  entropy = SecureRandom.hex[0..6]
   email = "tryouts+60+#{entropy}@onetimesecret.com"
   pword = 'loopersucks'
   {


### PR DESCRIPTION
Address test failures in Ruby 3.1 by explicitly handling empty secret values and introducing a new encryption mode. Improve the secret maximum length implementation with randomized truncation to mitigate information leakage. Clean up the Onetime class methods and fix type errors in utility functions.

Resolves #1273