### PR TITLE
Branded pages: prioritize domain branding locale in the frontend

### DIFF
--- a/apps/web/core/views/serializers/domain_serializer.rb
+++ b/apps/web/core/views/serializers/domain_serializer.rb
@@ -43,6 +43,7 @@ module Core
           output[:domain_logo] = (custom_domain&.logo&.hgetall || {}).to_h
 
           domain_locale = output[:domain_branding].fetch('locale', nil)
+          output[:domain_locale] = domain_locale
         end
 
         # There's no custom domain list when the feature is disabled

--- a/apps/web/core/views/serializers/i18n_serializer.rb
+++ b/apps/web/core/views/serializers/i18n_serializer.rb
@@ -41,7 +41,7 @@ module Core
         end
       end
 
-      SerializerRegistry.register(self)
+      SerializerRegistry.register(self, ['DomainSerializer'])
     end
   end
 end

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,38 +1,40 @@
 <!-- src/App.vue -->
 <script setup lang="ts">
-import StatusBar from '@/components/StatusBar.vue';
-import CarbonSprites from '@/components/icons/CarbonSprites.vue';
-import FontAwesome6Sprites from '@/components/icons/FontAwesome6Sprites.vue';
-import HeroiconsSprites from '@/components/icons/HeroiconsSprites.vue';
-import MdiSprites from '@/components/icons/MdiSprites.vue';
-import MaterialSymbolsSprites from '@/components/icons/MaterialSymbolsSprites.vue';
-import TablerSprites from '@/components/icons/TablerSprites.vue';
-import PhosphorSprites from '@/components/icons/PhosphorSprites.vue';
-import QuietLayout from '@/layouts/QuietLayout.vue';
-import type { LayoutProps } from '@/types/ui/layouts';
-import { computed } from 'vue';
-import { useI18n } from 'vue-i18n';
-import { useRoute } from 'vue-router';
+  import CarbonSprites from '@/components/icons/CarbonSprites.vue';
+  import FontAwesome6Sprites from '@/components/icons/FontAwesome6Sprites.vue';
+  import HeroiconsSprites from '@/components/icons/HeroiconsSprites.vue';
+  import MaterialSymbolsSprites from '@/components/icons/MaterialSymbolsSprites.vue';
+  import MdiSprites from '@/components/icons/MdiSprites.vue';
+  import PhosphorSprites from '@/components/icons/PhosphorSprites.vue';
+  import TablerSprites from '@/components/icons/TablerSprites.vue';
+  import StatusBar from '@/components/StatusBar.vue';
+  import QuietLayout from '@/layouts/QuietLayout.vue';
+  import type { LayoutProps } from '@/types/ui/layouts';
+  import { computed } from 'vue';
+  import { useI18n } from 'vue-i18n';
+  import { useRoute } from 'vue-router';
 
-const { locale } = useI18n();
-const route = useRoute();
+  const { locale } = useI18n();
+  const route = useRoute();
 
-const defaultProps: LayoutProps = {
-  displayMasthead: true,
-  displayNavigation: true,
-  displayLinks: true,
-  displayFeedback: true,
-  displayVersion: true,
-  displayPoweredBy: false, // used in only a few places
-  displayToggles: true,
-};
+  const defaultProps: LayoutProps = {
+    displayMasthead: true,
+    displayNavigation: true,
+    displayLinks: true,
+    displayFeedback: true,
+    displayVersion: true,
+    displayPoweredBy: false, // used in only a few places
+    displayToggles: true,
+  };
 
-// Bring the layout and route together
-const layout = computed(() => { return route.meta.layout || QuietLayout });
-const layoutProps = computed(() => ({
-  ...defaultProps,
-  ...(route.meta.layoutProps ?? {})
-}));
+  // Bring the layout and route together
+  const layout = computed(() => {
+    return route.meta.layout || QuietLayout;
+  });
+  const layoutProps = computed(() => ({
+    ...defaultProps,
+    ...(route.meta.layoutProps ?? {}),
+  }));
 </script>
 <!--
 /**
@@ -54,19 +56,24 @@ const layoutProps = computed(() => ({
 -->
 <template>
   <!-- Dynamic layout selection based on route.meta.layout -->
-  <component :is="layout"
-             :lang="locale"
-             v-bind="layoutProps">
+  <component
+    :is="layout"
+    :lang="locale"
+    v-bind="layoutProps">
     <!-- Router view with forced component recreation on route changes -->
-    <router-view v-slot="{ Component }"
-                 class="rounded-md">
-      <component :is="Component"
-                 :key="$route.fullPath" />
+    <router-view
+      v-slot="{ Component }"
+      class="rounded-md">
+      <component
+        :is="Component"
+        :key="$route.fullPath" />
     </router-view>
 
     <StatusBar position="bottom" />
 
-    <div id="sprites" class="hidden">
+    <div
+      id="sprites"
+      class="hidden">
       <HeroiconsSprites />
       <CarbonSprites />
       <FontAwesome6Sprites />

--- a/src/components/layout/BrandedMastHead.vue
+++ b/src/components/layout/BrandedMastHead.vue
@@ -1,7 +1,7 @@
 <!-- src/components/layout/Masthead.vue -->
 <script setup lang="ts">
-  import type { LayoutProps } from '@/types/ui/layouts';
   import { useProductIdentity } from '@/stores/identityStore';
+  import type { LayoutProps } from '@/types/ui/layouts';
   import { ref } from 'vue';
 
   const productIdentity = useProductIdentity();
@@ -25,8 +25,8 @@
 </script>
 
 <template>
-  <div class="bg-white dark:bg-gray-900 py-8 transition-colors duration-200">
-    <div class="container mx-auto px-4 max-w-2xl">
+  <div class="bg-white py-8 transition-colors duration-200 dark:bg-gray-900">
+    <div class="container mx-auto max-w-2xl px-4">
       <div class="flex flex-col items-center gap-8">
         <!-- Logo Section -->
         <div
@@ -37,7 +37,7 @@
             <div
               :class="[
                 productIdentity.cornerClass,
-                'flex size-16 items-center justify-center overflow-hidden bg-gray-100 dark:bg-gray-800 transition-all duration-200',
+                'flex size-16 items-center justify-center overflow-hidden bg-gray-100 transition-all duration-200 dark:bg-gray-800',
               ]">
               <img
                 v-if="productIdentity.logoUri && !imageError"
@@ -65,19 +65,19 @@
 
         <!-- Content Section -->
         <div
-          class="text-center space-y-3"
+          class="space-y-3 text-center"
           :class="[
             productIdentity.fontFamilyClass,
             productIdentity.cornerClass,
           ]">
           <h1
-            class="text-2xl sm:text-3xl font-medium text-gray-900 dark:text-gray-100"
+            class="text-2xl font-medium text-gray-900 dark:text-gray-100 sm:text-3xl"
             :class="productIdentity.fontFamilyClass">
-            {{ $t(headertext) }}
+            {{ headertext }}
           </h1>
           <p
-            class="text-sm sm:text-base text-gray-600 dark:text-gray-300 max-w-md mx-auto">
-            {{ $t(subtext) }}
+            class="mx-auto max-w-md text-sm text-gray-600 dark:text-gray-300 sm:text-base">
+            {{ subtext }}
           </p>
         </div>
       </div>

--- a/src/components/layout/QuietFooter.vue
+++ b/src/components/layout/QuietFooter.vue
@@ -1,23 +1,25 @@
 <!-- src/components/layout/DefaultFooter.vue -->
 
 <script setup lang="ts">
-  import FooterLinkLists from '@/components/layout/FooterLinkLists.vue';
   import FeedbackToggle from '@/components/FeedbackToggle.vue';
   import JurisdictionToggle from '@/components/JurisdictionToggle.vue';
+  import LanguageToggle from '@/components/LanguageToggle.vue';
+  import FooterLinkLists from '@/components/layout/FooterLinkLists.vue';
   import ThemeToggle from '@/components/ThemeToggle.vue';
+  import { WindowService } from '@/services/window.service';
   import { useProductIdentity } from '@/stores/identityStore';
   import type { LayoutProps } from '@/types/ui/layouts';
-  import { WindowService } from '@/services/window.service';
   import { ref } from 'vue';
-
-  import LanguageToggle from '@/components/LanguageToggle.vue';
 
   const productIdentity = useProductIdentity();
 
   withDefaults(defineProps<LayoutProps>(), {});
 
   const windowProps = WindowService.getMultiple([
-    'regions_enabled', 'regions', 'authentication', 'i18n_enabled',
+    'regions_enabled',
+    'regions',
+    'authentication',
+    'i18n_enabled',
   ]);
 
   const companyName = ref('OnetimeSecret.com');
@@ -31,7 +33,8 @@
       class="container mx-auto max-w-2xl px-4">
       <FooterLinkLists
         v-if="displayLinks"
-        v-bind="$props" />
+        v-bind="$props"
+      />
 
       <div
         class="mt-6 flex flex-col-reverse items-center justify-between space-y-6 space-y-reverse md:flex-row md:space-y-0">
@@ -50,7 +53,9 @@
           <ThemeToggle
             class="text-gray-500 transition-colors duration-200 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-100"
             :aria-label="$t('toggle-dark-mode')" />
-          <LanguageToggle v-if="windowProps.i18n_enabled" :compact="true" />
+          <LanguageToggle
+            v-if="windowProps.i18n_enabled"
+            :compact="true" />
           <FeedbackToggle
             v-if="displayFeedback && windowProps.authentication?.enabled"
             class="text-gray-500 transition-colors duration-200 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-100"
@@ -69,22 +74,26 @@
           <ThemeToggle
             class="text-gray-500 transition-colors duration-200 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-100"
             :aria-label="$t('toggle-dark-mode')" />
-          <LanguageToggle v-if="windowProps.i18n_enabled" :compact="true" />
+          <LanguageToggle
+            v-if="windowProps.i18n_enabled"
+            :compact="true" />
         </div>
 
         <!-- Links Section -->
         <div class="text-sm text-gray-500 dark:text-gray-400">
           <router-link
             to="/info/terms"
-            class="transition-colors duration-200 hover:text-gray-800 dark:hover:text-gray-100 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:ring-offset-2">
+            class="transition-colors duration-200 hover:text-gray-800 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:ring-offset-2 dark:hover:text-gray-100">
             {{ $t('terms') }}
           </router-link>
           <span
             class="mx-2 select-none"
-            aria-hidden="true">·</span>
+            aria-hidden="true">
+            ·
+          </span>
           <router-link
             to="/info/privacy"
-            class="transition-colors duration-200 hover:text-gray-800 dark:hover:text-gray-100 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:ring-offset-2">
+            class="transition-colors duration-200 hover:text-gray-800 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:ring-offset-2 dark:hover:text-gray-100">
             {{ $t('privacy') }}
           </router-link>
         </div>

--- a/src/components/layout/QuietHeader.vue
+++ b/src/components/layout/QuietHeader.vue
@@ -1,8 +1,10 @@
+<!-- src/components/layout/QuietHeader.vue -->
+
 <script setup lang="ts">
-  import type { LayoutProps } from '@/types/ui/layouts';
-  import { useProductIdentity } from '@/stores/identityStore';
-  import MastHead from '@/components/layout/MastHead.vue';
   import BrandedMasthead from '@/components/layout/BrandedMastHead.vue';
+  import MastHead from '@/components/layout/MastHead.vue';
+  import { useProductIdentity } from '@/stores/identityStore';
+  import type { LayoutProps } from '@/types/ui/layouts';
   import { computed } from 'vue';
   import { useI18n } from 'vue-i18n';
   const { t } = useI18n();
@@ -26,19 +28,18 @@
 
 <template>
   <header class="bg-white dark:bg-gray-900">
-
     <div
       v-if="displayMasthead"
       class="container mx-auto min-w-[320px] max-w-2xl p-4">
-
       <BrandedMasthead
         v-if="productIdentity.isCustom"
         :headertext="headertext"
         :subtext="subtext"
-        v-bind="props"/>
+        v-bind="props" />
 
-      <MastHead v-else v-bind="props" />
+      <MastHead
+        v-else
+        v-bind="props" />
     </div>
-
   </header>
 </template>

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -20,10 +20,11 @@ type GlobalComposer = Composer<{}, {}, {}, Locale>;
 /**
  * The list of supported locales comes directly from etc/config.yaml.
  */
+const domainBranding = WindowService.get('domain_branding');
 const supportedLocales = WindowService.get('supported_locales') || [];
 const fallbackLocale = WindowService.get('fallback_locale') || {};
 const defaultLocale = WindowService.get('default_locale') || 'en';
-const displayLocale = WindowService.get('locale');
+const displayLocale = domainBranding.locale ?? WindowService.get('locale');
 
 /**
  * Creates a completely independent i18n instance with its own locale state and message

--- a/src/layouts/BaseLayout.vue
+++ b/src/layouts/BaseLayout.vue
@@ -1,46 +1,50 @@
 <!-- src/layouts/BaseLayout.vue -->
 
 <script setup lang="ts">
-import GlobalBroadcast from '@/components/GlobalBroadcast.vue';
-import { WindowService } from '@/services/window.service';
-import { useProductIdentity } from '@/stores/identityStore';
-import type { LayoutProps } from '@/types/ui/layouts';
-import { isColorValue } from '@/utils/color-utils';
-import { computed, defineProps } from 'vue';
+  import GlobalBroadcast from '@/components/GlobalBroadcast.vue';
+  import { WindowService } from '@/services/window.service';
+  import { useProductIdentity } from '@/stores/identityStore';
+  import type { LayoutProps } from '@/types/ui/layouts';
+  import { isColorValue } from '@/utils/color-utils';
+  import { computed, defineProps } from 'vue';
 
-defineProps<LayoutProps>();
+  defineProps<LayoutProps>();
 
-const globalBanner = WindowService.get('global_banner') ?? null;
-const identityStore = useProductIdentity();
+  const globalBanner = WindowService.get('global_banner') ?? null;
+  const identityStore = useProductIdentity();
 
-// If there's a global banner set (in redis), this will be true. The actual
-// content may not show if the feature is by displayGlobalBroadcast=false.
-// For example, custom branded pages have the feature disabled altogether.
-const hasGlobalBanner = computed(() => { return !!globalBanner });
+  // If there's a global banner set (in redis), this will be true. The actual
+  // content may not show if the feature is by displayGlobalBroadcast=false.
+  // For example, custom branded pages have the feature disabled altogether.
+  const hasGlobalBanner = computed(() => {
+    return !!globalBanner;
+  });
 
-// Compute primary color styles based on brand color or prop
-const primaryColorClass = computed(() => {
-  const currentColor = identityStore.primaryColor;
-  return !isColorValue(currentColor) ? currentColor : '';
-});
+  // Compute primary color styles based on brand color or prop
+  const primaryColorClass = computed(() => {
+    const currentColor = identityStore.primaryColor;
+    return !isColorValue(currentColor) ? currentColor : '';
+  });
 
-const primaryColorStyle = computed(() => {
-  const currentColor = identityStore.primaryColor;
-  return isColorValue(currentColor) ? { backgroundColor: currentColor } : {};
-});
+  const primaryColorStyle = computed(() => {
+    const currentColor = identityStore.primaryColor;
+    return isColorValue(currentColor) ? { backgroundColor: currentColor } : {};
+  });
 </script>
 
 <template>
   <div>
     <!-- All along the watch tower -->
-    <div class="fixed left-0 top-0 z-50 h-1 w-full"
-         :class="primaryColorClass"
-         :style="primaryColorStyle"></div>
+    <div
+      class="fixed left-0 top-0 z-50 h-1 w-full"
+      :class="primaryColorClass"
+      :style="primaryColorStyle"></div>
 
     <!-- Good morning Vietnam -->
-    <GlobalBroadcast v-if="displayGlobalBroadcast"
-                     :show="hasGlobalBanner"
-                     :content="globalBanner" />
+    <GlobalBroadcast
+      v-if="displayGlobalBroadcast"
+      :show="hasGlobalBanner"
+      :content="globalBanner" />
 
     <!-- Header content, Ramos territory -->
     <slot name="header"></slot>

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,8 +2,8 @@
 
 // Ensures modulepreload works in all browsers, improving
 // performance by preloading modules.
-import 'vite/modulepreload-polyfill';
 import { createApp } from 'vue';
+import 'vite/modulepreload-polyfill';
 import App from './App.vue';
 import './assets/style.css';
 import { AppInitializer } from './plugins/core/appInitializer';

--- a/src/plugins/core/appInitializer.ts
+++ b/src/plugins/core/appInitializer.ts
@@ -1,17 +1,17 @@
 // src/plugins/core/appInitializer.ts
 
+import { createApi } from '@/api';
 import i18n from '@/i18n';
 import { createAppRouter } from '@/router';
 import { loggingService } from '@/services/logging.service';
 import { WindowService } from '@/services/window.service';
-import { createApi } from '@/api';
 import { AxiosInstance } from 'axios';
 import { createPinia } from 'pinia';
 import { App, Plugin } from 'vue';
-import { autoInitPlugin } from '../pinia/autoInitPlugin';
 
 import { createDiagnostics } from './enableDiagnostics';
 import { createErrorBoundary } from './globalErrorBoundary';
+import { autoInitPlugin } from '../pinia/autoInitPlugin';
 
 interface AppInitializerOptions {
   api?: AxiosInstance;
@@ -38,6 +38,7 @@ export const AppInitializer: Plugin<AppInitializerOptions> = {
  *
  * We separate this from the main plugin to interface for testing purposes.
  */
+/*eslint max-statements: ["error", 20]*/
 function initializeApp(app: App, options: AppInitializerOptions = {}) {
   const diagnostics = WindowService.get('diagnostics');
   const d9sEnabled = WindowService.get('d9s_enabled');

--- a/src/views/BrandedHomepage.vue
+++ b/src/views/BrandedHomepage.vue
@@ -1,3 +1,5 @@
+<!-- src/views/BrandedHomepage.vue -->
+
 <script setup lang="ts">
   import SecretForm from '@/components/secrets/form/SecretForm.vue';
   import { useProductIdentity } from '@/stores/identityStore';

--- a/src/views/HomepageContainer.vue
+++ b/src/views/HomepageContainer.vue
@@ -17,7 +17,8 @@
 </script>
 
 <template>
-  <Component :is="currentComponent"
-             :display-domain="displayDomain"
-             :site-host="siteHost" />
+  <Component
+    :is="currentComponent"
+    :display-domain="displayDomain"
+    :site-host="siteHost" />
 </template>


### PR DESCRIPTION
Enhance the handling of locales for branded pages by prioritizing the domain branding locale over the default locale. This change addresses a bug introduced in v0.20.0, ensuring that the correct locale is used in the frontend without requiring serializers to reload custom domain records. Additional adjustments include formatting improvements and updates to the i18n serializer dependency.

Fixes #1283