### PR TITLE
Add explicit read permissions to GitHub workflow files

### DIFF
--- a/.github/workflows/Fly.io.yml
+++ b/.github/workflows/Fly.io.yml
@@ -28,6 +28,9 @@ on:
       - 'feature/*'
       - 'wip/*'
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     name: Deploy

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -40,6 +40,9 @@ on:
         required: false
         default: false
 
+permissions:
+  contents: read
+
 jobs:
   build:
     timeout-minutes: 15 # prevent hung jobs

--- a/.github/workflows/vue.yml
+++ b/.github/workflows/vue.yml
@@ -41,6 +41,10 @@ on:
         description: 'Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)'
         required: false
         default: false
+
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
Introduce explicit read permissions for contents in the GitHub workflow files to enhance security and control over access.