### PR TITLE
Fix colonel config path and enhance logging

### DIFF
--- a/apps/api/v1/logic/authentication/authenticate_session.rb
+++ b/apps/api/v1/logic/authentication/authenticate_session.rb
@@ -58,7 +58,7 @@ module V1::Logic
           sess.save
           cust.save
 
-          colonels = OT.conf.dig(:authentication, :colonels) || []
+          colonels = OT.conf.dig(:site, :authentication, :colonels) || []
           if colonels.member?(cust.custid)
             cust.role = :colonel
           else

--- a/apps/api/v2/logic/feedback.rb
+++ b/apps/api/v2/logic/feedback.rb
@@ -52,6 +52,7 @@ module V2
 
         begin
           configured_colonels = OT.conf.dig(:site, :authentication, :colonels) || []
+          OT.ld "[configured_colonels] #{configured_colonels.inspect}"
 
           first_colonel = nil
           configured_colonels.each do |colonel_email|

--- a/lib/onetime/helpers/initialization_helper.rb
+++ b/lib/onetime/helpers/initialization_helper.rb
@@ -77,16 +77,22 @@ module Onetime
       site_config = OT.conf.fetch(:site) # if :site is missing we got real problems
       email_config = OT.conf.fetch(:emailer, {})
       redis_info = Familia.redis.info
+      colonels = site_config.dig(:authentication, :colonels)
 
       OT.li "---  ONETIME #{OT.mode} v#{OT::VERSION.inspect}  #{'---' * 3}"
       OT.li "system: #{@sysinfo.platform} (#{RUBY_ENGINE} #{RUBY_VERSION} in #{OT.env})"
       OT.li "config: #{OT::Config.path}"
       OT.li "redis: #{redis_info['redis_version']} (#{Familia.uri.serverid})"
       OT.li "familia: v#{Familia::VERSION}"
-      OT.li "colonels: #{site_config.dig(:authentication, :colonels).join(', ')}"
       OT.li "i18n: #{OT.i18n_enabled}"
       OT.li "locales: #{@locales.keys.join(', ')}" if OT.i18n_enabled
       OT.li "diagnotics: #{OT.d9s_enabled}"
+
+      if colonels.empty?
+        OT.lw "colonels: No colonels configured"
+      else
+        OT.li "colonels: #{colonels.join(', ')}"
+      end
 
       if site_config.dig(:plans, :enabled)
         OT.li "plans: #{OT::Plan.plans.keys}"

--- a/lib/onetime/helpers/initialization_helper.rb
+++ b/lib/onetime/helpers/initialization_helper.rb
@@ -83,7 +83,7 @@ module Onetime
       OT.li "config: #{OT::Config.path}"
       OT.li "redis: #{redis_info['redis_version']} (#{Familia.uri.serverid})"
       OT.li "familia: v#{Familia::VERSION}"
-      OT.li "colonels: #{OT.conf.fetch(:colonels, []).join(', ')}"
+      OT.li "colonels: #{site_config.dig(:authentication, :colonels).join(', ')}"
       OT.li "i18n: #{OT.i18n_enabled}"
       OT.li "locales: #{@locales.keys.join(', ')}" if OT.i18n_enabled
       OT.li "diagnotics: #{OT.d9s_enabled}"


### PR DESCRIPTION
Correct the configuration path for colonels and improve logging to aid in debugging during startup. This change ensures accurate retrieval of colonel information and provides visibility into the configured colonels in the logs.