### PR TITLE
Disable Docker renovate updates for onetimesecret image

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -56,6 +56,11 @@
     {
       "matchPackageNames": ["rack"],
       "recreateWhen": "never"
+    },
+    {
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["ghcr.io/onetimesecret/onetimesecret"],
+      "enabled": false
     }
   ],
 


### PR DESCRIPTION
Disable automatic updates for the onetimesecret Docker image in the Renovate configuration.