### PR TITLE
Add net-imap gem dependency to address vulnerability

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,9 +40,7 @@ gem 'storable'
 gem 'sysinfo'
 gem 'uri-redis', '~> 1.3.0'
 
-
 gem 'redis', '~> 5.4.0'
-
 
 gem 'bcrypt'
 gem 'encryptor', '= 1.1.3'
@@ -50,7 +48,7 @@ gem 'encryptor', '= 1.1.3'
 gem 'httparty'
 
 gem 'mail'
-
+gem 'net-imap', '~> 0.5.7'
 gem "fastimage", "~> 2.4"
 
 gem 'psych', '~> 5.2.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -117,7 +117,7 @@ GEM
     multi_xml (0.7.1)
       bigdecimal (~> 3.1)
     mustache (1.1.1)
-    net-imap (0.5.6)
+    net-imap (0.5.7)
       date
       net-protocol
     net-pop (0.1.2)
@@ -266,6 +266,7 @@ DEPENDENCIES
   mail
   multi_json
   mustache
+  net-imap (~> 0.5.7)
   ostruct
   otto (~> 1.1.0.pre.alpha4)
   pry


### PR DESCRIPTION
Introduce the net-imap gem to resolve a potential DoS vulnerability related to memory exhaustion. Update the gem version to 0.5.7 for improved security.