### PR TITLE
Enable dismissable Global Broadcast functionality with persistent user preferences

### DIFF
--- a/apps/api/v2/controllers/secrets.rb
+++ b/apps/api/v2/controllers/secrets.rb
@@ -31,6 +31,20 @@ module V2
         )
       end
 
+      def generate_secret_options
+        # Return a response for an HTTP OPTIONS request
+        headers = {
+          "Content-Type" => "application/json",
+          "Allow" => "GET, POST, OPTIONS",
+          "Access-Control-Allow-Origin" => "*",
+          "Access-Control-Allow-Methods" => "GET, POST, OPTIONS",
+          "Access-Control-Allow-Headers" => "Content-Type, Authorization",
+          "Access-Control-Max-Age" => "86400",
+
+        }
+        [200, headers, {}]
+      end
+
       def burn_secret
         process_action(
           V2::Logic::Secrets::BurnSecret,

--- a/apps/api/v2/routes
+++ b/apps/api/v2/routes
@@ -30,6 +30,8 @@ GET    /secret/:key/status                        V2::Controllers::Secrets#get_s
 POST   /secret/status                             V2::Controllers::Secrets#list_secret_status
 POST   /secret/:key/reveal                        V2::Controllers::Secrets#reveal_secret
 
+OPTIONS /secret/generate                          V2::Controllers::Secrets#generate_secret_options
+OPTIONS /secret/conceal                           V2::Controllers::Secrets#generate_secret_options
 POST   /secret/generate                           V2::Controllers::Secrets#generate_secret
 POST   /secret/conceal                            V2::Controllers::Secrets#conceal_secret
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "onetimesecret",
-  "version": "0.21.5",
+  "version": "0.21.7",
   "description": "",
   "type": "module",
   "scripts": {

--- a/src/App.vue
+++ b/src/App.vue
@@ -25,6 +25,7 @@
     displayVersion: true,
     displayPoweredBy: false, // used in only a few places
     displayToggles: true,
+    displayGlobalBroadcast: true, // will only display if one exists (need to restart backend when changes)
   };
 
   // Bring the layout and route together

--- a/src/components/CopyButton.vue
+++ b/src/components/CopyButton.vue
@@ -1,43 +1,44 @@
 <!-- src/components/CopyButton.vue -->
 
 <script setup lang="ts">
-import OIcon from '@/components/icons/OIcon.vue';
-import { ref, onBeforeUnmount } from 'vue';
-import { useI18n } from 'vue-i18n';
-const { t } = useI18n();
+  import OIcon from '@/components/icons/OIcon.vue';
+  import { ref, onBeforeUnmount } from 'vue';
+  import { useI18n } from 'vue-i18n';
+  const { t } = useI18n();
 
-interface Props {
-  text: string;
-  interval?: number;
-}
+  interface Props {
+    text: string;
+    interval?: number;
+  }
 
-const props = withDefaults(defineProps<Props>(), {
-  text: '',
-  interval: 2000
-});
-
-const copied = ref(false);
-const showTooltip = ref(false);
-let tooltipTimeout: number | null = null;
-const ariaLabel = copied.value ? t('web.STATUS.copied') : t('web.LABELS.copy_to_clipboard');
-
-const copyToClipboard = () => {
-  navigator.clipboard.writeText(props.text).then(() => {
-    copied.value = true;
-    showTooltip.value = true;
-
-    if (tooltipTimeout) clearTimeout(tooltipTimeout);
-
-    setTimeout(() => {
-      copied.value = false;
-      showTooltip.value = false;
-    }, props.interval);
+  const props = withDefaults(defineProps<Props>(), {
+    text: '',
+    interval: 2000,
   });
-};
 
-onBeforeUnmount(() => {
-  if (tooltipTimeout) clearTimeout(tooltipTimeout);
-});
+  const copied = ref(false);
+  const showTooltip = ref(false);
+  const ariaLabel = copied.value ? t('web.STATUS.copied') : t('web.LABELS.copy_to_clipboard');
+
+  let tooltipTimeout: number | null = null;
+
+  const copyToClipboard = () => {
+    navigator.clipboard.writeText(props.text).then(() => {
+      copied.value = true;
+      showTooltip.value = true;
+
+      if (tooltipTimeout) clearTimeout(tooltipTimeout);
+
+      setTimeout(() => {
+        copied.value = false;
+        showTooltip.value = false;
+      }, props.interval);
+    });
+  };
+
+  onBeforeUnmount(() => {
+    if (tooltipTimeout) clearTimeout(tooltipTimeout);
+  });
 </script>
 
 <template>
@@ -49,25 +50,25 @@ onBeforeUnmount(() => {
       class="text-gray-600 hover:text-gray-900 focus:outline-none dark:text-gray-400 dark:hover:text-white"
       :aria-label="ariaLabel">
       <OIcon
-              collection="material-symbols"
-              :name="copied ? 'check' : 'content-copy-outline'"
-              class="size-5" />
+        collection="material-symbols"
+        :name="copied ? 'check' : 'content-copy-outline'"
+        class="size-5" />
     </button>
     <!-- prettier-ignore-attribute class -->
-      <div
-        v-if="showTooltip"
-        class="absolute right-4 top-4 flex items-center gap-2 rounded-md
+    <div
+      v-if="showTooltip"
+      class="absolute right-4 top-4 flex items-center gap-2 rounded-md
         bg-slate-900 px-3.5 py-2 text-sm text-white shadow-lg transition-all duration-300
         dark:bg-slate-700"
-        :class="{
-          'translate-y-1 opacity-0': !showTooltip,
-          'translate-y-0 opacity-100': showTooltip,
-        }">
-        <OIcon
-          collection="material-symbols"
-          name="check-circle-outline"
-          class="size-4 text-green-400" />
-        {{ ariaLabel }}
-      </div>
+      :class="{
+        'translate-y-1 opacity-0': !showTooltip,
+        'translate-y-0 opacity-100': showTooltip,
+      }">
+      <OIcon
+        collection="material-symbols"
+        name="check-circle-outline"
+        class="size-4 text-green-400" />
+      {{ ariaLabel }}
+    </div>
   </div>
 </template>

--- a/src/components/CopyButton.vue
+++ b/src/components/CopyButton.vue
@@ -1,6 +1,7 @@
 <!-- src/components/CopyButton.vue -->
 
 <script setup lang="ts">
+import OIcon from '@/components/icons/OIcon.vue';
 import { ref, onBeforeUnmount } from 'vue';
 import { useI18n } from 'vue-i18n';
 const { t } = useI18n();
@@ -47,39 +48,26 @@ onBeforeUnmount(() => {
       @mouseleave="showTooltip = false"
       class="text-gray-600 hover:text-gray-900 focus:outline-none dark:text-gray-400 dark:hover:text-white"
       :aria-label="ariaLabel">
-      <svg
-        v-if="!copied"
-        class="size-5"
-        fill="none"
-        stroke="currentColor"
-        viewBox="0 0 24 24"
-        xmlns="http://www.w3.org/2000/svg">
-        <path
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"
-        />
-      </svg>
-      <svg
-        v-else
-        class="size-5 text-green-500"
-        fill="none"
-        stroke="currentColor"
-        viewBox="0 0 24 24"
-        xmlns="http://www.w3.org/2000/svg">
-        <path
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          d="M5 13l4 4L19 7"
-        />
-      </svg>
+      <OIcon
+              collection="material-symbols"
+              :name="copied ? 'check' : 'content-copy-outline'"
+              class="size-5" />
     </button>
-    <div
-      v-if="showTooltip"
-      class="absolute bottom-full left-1/2 z-10 -translate-x-1/2 -translate-y-2 rounded-md bg-gray-900 px-2 py-1 text-sm text-white">
-      {{ ariaLabel }}
-    </div>
+    <!-- prettier-ignore-attribute class -->
+      <div
+        v-if="showTooltip"
+        class="absolute right-4 top-4 flex items-center gap-2 rounded-md
+        bg-slate-900 px-3.5 py-2 text-sm text-white shadow-lg transition-all duration-300
+        dark:bg-slate-700"
+        :class="{
+          'translate-y-1 opacity-0': !showTooltip,
+          'translate-y-0 opacity-100': showTooltip,
+        }">
+        <OIcon
+          collection="material-symbols"
+          name="check-circle-outline"
+          class="size-4 text-green-400" />
+        {{ ariaLabel }}
+      </div>
   </div>
 </template>

--- a/src/components/CopyButton.vue
+++ b/src/components/CopyButton.vue
@@ -2,23 +2,26 @@
 
 <script setup lang="ts">
   import OIcon from '@/components/icons/OIcon.vue';
-  import { ref, onBeforeUnmount } from 'vue';
+  import { ref, computed, onBeforeUnmount } from 'vue';
   import { useI18n } from 'vue-i18n';
   const { t } = useI18n();
 
   interface Props {
     text: string;
     interval?: number;
+    tooltip?: string | undefined;
   }
 
   const props = withDefaults(defineProps<Props>(), {
     text: '',
     interval: 2000,
+    tooltip: undefined,
   });
 
   const copied = ref(false);
   const showTooltip = ref(false);
   const ariaLabel = copied.value ? t('web.STATUS.copied') : t('web.LABELS.copy_to_clipboard');
+  const tooltipText = computed(() => props.tooltip ? props.tooltip : ariaLabel);
 
   let tooltipTimeout: number | null = null;
 
@@ -57,18 +60,18 @@
     <!-- prettier-ignore-attribute class -->
     <div
       v-if="showTooltip"
-      class="absolute right-4 top-4 flex items-center gap-2 rounded-md
+      class="absolute bottom-1/2 right-full mr-2 z-50 flex items-center gap-2 rounded-md
         bg-slate-900 px-3.5 py-2 text-sm text-white shadow-lg transition-all duration-300
         dark:bg-slate-700"
       :class="{
-        'translate-y-1 opacity-0': !showTooltip,
-        'translate-y-0 opacity-100': showTooltip,
+        'translate-x-1 opacity-0': !showTooltip,
+        'translate-x-0 opacity-100': showTooltip,
       }">
       <OIcon
         collection="material-symbols"
         name="check-circle-outline"
         class="size-4 text-green-400" />
-      {{ ariaLabel }}
+      {{ tooltipText }}
     </div>
   </div>
 </template>

--- a/src/components/GlobalBroadcast.vue
+++ b/src/components/GlobalBroadcast.vue
@@ -1,77 +1,119 @@
-<!--
-  On importing components: import GlobalBroadcast as a default import, not a named import.
-
-  `import { GlobalBroadcast } from '~/components/GlobalBroadcast.vue';` -- Incorrect ❌
-  `import GlobalBroadcast from '~/components/GlobalBroadcast.vue';` -- Correct ✅
--->
+<!-- src/components/GlobalBroadcast.vue -->
 
 <script setup lang="ts">
-import MovingGlobules from '@/components/MovingGlobules.vue';
-import OIcon from '@/components/icons/OIcon.vue';
-import DOMPurify from 'dompurify';
-import { computed } from 'vue';
+  import MovingGlobules from '@/components/MovingGlobules.vue';
+  import OIcon from '@/components/icons/OIcon.vue';
+  import DOMPurify from 'dompurify';
+  import { computed } from 'vue';
+  import { useDismissableBanner } from '@/composables/useDismissableBanner';
 
-// TypeScript with Composition API
-//
-// Note that default values for mutable reference types (like arrays or
-// objects) should be wrapped in functions to avoid accidental
-// modification and external side effects. This ensures each component
-// instance gets its own copy of the default value.
-//
-// See: https://vuejs.org/guide/typescript/composition-api.html#props-default-values
+  export interface Props {
+    content: string | null; // Can contain HTML
+    show: boolean;
+    bannerId?: string; // Unique identifier for this banner
+    expirationDays?: number; // Days until banner reappears after dismissal
+  }
 
-export interface Props {
-  content: string | null; // Can contain HTML
-  show: boolean;
-}
-const props = withDefaults(defineProps<Props>(), {
-  content: "Welcome to the Global Broadcast!",
-  show: false,
-});
+  // TypeScript with Composition API
+  //
+  // Note that default values for mutable reference types (like arrays or
+  // objects) should be wrapped in functions to avoid accidental
+  // modification and external side effects. This ensures each component
+  // instance gets its own copy of the default value.
+  //
+  // See: https://vuejs.org/guide/typescript/composition-api.html#props-default-values
+  const props = withDefaults(defineProps<Props>(), {
+    content: 'Welcome to the Global Broadcast!',
+    show: false,
+    bannerId: 'global-broadcast',
+    expirationDays: 0, // Default to permanent dismissal
+  });
 
-// Function to decode HTML entities
-function decodeHTMLEntities(html: string) {
-  const txt = document.createElement('textarea');
-  txt.innerHTML = html;
-  return txt.value;
-}
+  // Use our composable to handle dismissal state
+  const { isVisible, dismiss } = useDismissableBanner(props.bannerId, props.expirationDays);
 
-// Computed property for decoded and sanitized content
-const sanitizedContent = computed(() => {
-  const decodedContent = decodeHTMLEntities(props.content ?? '');
-  const sanitizeConfig = {
-    ALLOWED_TAGS: ['a'],
-    ALLOWED_ATTR: ['href', 'target', 'rel', 'class']
-  };
-  return DOMPurify.sanitize(decodedContent, sanitizeConfig);
-});
+  // Function to decode HTML entities
+  function decodeHTMLEntities(html: string) {
+    const txt = document.createElement('textarea');
+    txt.innerHTML = html;
+    return txt.value;
+  }
 
+  // Computed property for decoded and sanitized content
+  const sanitizedContent = computed(() => {
+    const decodedContent = decodeHTMLEntities(props.content ?? '');
+    const sanitizeConfig = {
+      ALLOWED_TAGS: ['a'],
+      ALLOWED_ATTR: ['href', 'target', 'rel', 'class'],
+    };
+    return DOMPurify.sanitize(decodedContent, sanitizeConfig);
+  });
+
+  // Should show banner only if (1) parent says to show it AND (2) user hasn't dismissed it
+  const shouldShow = computed(() => props.show && isVisible.value);
 </script>
 
 <template>
   <div
-    v-if="show"
+    v-if="shouldShow"
     class="relative isolate flex items-center gap-x-6 overflow-hidden bg-gray-50 px-6 py-2.5 dark:bg-gray-900 sm:px-3.5 sm:before:flex-1">
     <div
       class="absolute left-[max(-7rem,calc(50%-52rem))] top-1/2 -z-10 -translate-y-1/2 transform-gpu blur-2xl"
       aria-hidden="true">
       <div
         class="aspect-[577/310] w-[36.0625rem] bg-gradient-to-r from-[#dc4a22] to-[#fcf4e8] opacity-30"
-        style="clip-path: polygon(74.8% 41.9%, 97.2% 73.2%, 100% 34.9%, 92.5% 0.4%, 87.5% 0%, 75% 28.6%, 58.5% 54.6%, 50.1% 56.8%, 46.9% 44%, 48.3% 17.4%, 24.7% 53.9%, 0% 27.9%, 11.9% 74.2%, 24.9% 54.1%, 68.6% 100%, 74.8% 41.9%)"></div>
+        style="
+          clip-path: polygon(
+            74.8% 41.9%,
+            97.2% 73.2%,
+            100% 34.9%,
+            92.5% 0.4%,
+            87.5% 0%,
+            75% 28.6%,
+            58.5% 54.6%,
+            50.1% 56.8%,
+            46.9% 44%,
+            48.3% 17.4%,
+            24.7% 53.9%,
+            0% 27.9%,
+            11.9% 74.2%,
+            24.9% 54.1%,
+            68.6% 100%,
+            74.8% 41.9%
+          );
+        "></div>
     </div>
     <MovingGlobules
       from-colour="#23b5dd"
       to-colour="#dc4a22"
       speed="10s"
       :interval="1000"
-      :scale="2"
-    />
+      :scale="2" />
     <div
       class="absolute left-[max(45rem,calc(50%+8rem))] top-1/2 -z-10 -translate-y-1/2 transform-gpu blur-2xl"
       aria-hidden="true">
       <div
         class="aspect-[577/310] w-[36.0625rem] bg-gradient-to-r from-[#dc4a22] to-[#fcf4e8] opacity-30"
-        style="clip-path: polygon(74.8% 41.9%, 97.2% 73.2%, 100% 34.9%, 92.5% 0.4%, 87.5% 0%, 75% 28.6%, 58.5% 54.6%, 50.1% 56.8%, 46.9% 44%, 48.3% 17.4%, 24.7% 53.9%, 0% 27.9%, 11.9% 74.2%, 24.9% 54.1%, 68.6% 100%, 74.8% 41.9%)"></div>
+        style="
+          clip-path: polygon(
+            74.8% 41.9%,
+            97.2% 73.2%,
+            100% 34.9%,
+            92.5% 0.4%,
+            87.5% 0%,
+            75% 28.6%,
+            58.5% 54.6%,
+            50.1% 56.8%,
+            46.9% 44%,
+            48.3% 17.4%,
+            24.7% 53.9%,
+            0% 27.9%,
+            11.9% 74.2%,
+            24.9% 54.1%,
+            68.6% 100%,
+            74.8% 41.9%
+          );
+        "></div>
     </div>
     <div class="font-brand text-base leading-6 text-gray-900 dark:text-gray-100">
       <div class="relative flex items-center space-x-3">
@@ -85,8 +127,7 @@ const sanitizedContent = computed(() => {
             stroke-linecap="round"
             stroke-linejoin="round"
             stroke-width="2"
-            d="M11 5.882V19.24a1.76 1.76 0 01-3.417.592l-2.147-6.15M18 13a3 3 0 100-6M5.436 13.683A4.001 4.001 0 017 6h1.832c4.1 0 7.625-1.234 9.168-3v14c-1.543-1.766-5.067-3-9.168-3H7a3.988 3.988 0 01-1.564-.317z"
-          />
+            d="M11 5.882V19.24a1.76 1.76 0 01-3.417.592l-2.147-6.15M18 13a3 3 0 100-6M5.436 13.683A4.001 4.001 0 017 6h1.832c4.1 0 7.625-1.234 9.168-3v14c-1.543-1.766-5.067-3-9.168-3H7a3.988 3.988 0 01-1.564-.317z" />
         </svg>
         <span v-html="sanitizedContent"></span>
       </div>
@@ -94,14 +135,14 @@ const sanitizedContent = computed(() => {
     <div class="flex flex-1 justify-end">
       <button
         type="button"
+        @click="dismiss"
         class="-m-3 p-3 focus-visible:outline-offset-[-4px]">
         <span class="sr-only">{{ $t('web.LABELS.dismiss') }}</span>
         <OIcon
-          collection="heroicons-solid"
-          name="xmarkicon"
+          collection="heroicons"
+          name="x-mark-16-solid"
           class="size-5 text-gray-900 dark:text-gray-100"
-          aria-hidden="true"
-        />
+          aria-hidden="true" />
       </button>
     </div>
   </div>

--- a/src/components/GlobalBroadcast.vue
+++ b/src/components/GlobalBroadcast.vue
@@ -30,6 +30,7 @@
   });
 
   // Use our composable to handle dismissal state with content-based ID generation
+  // The banner ID will be generated asynchronously based on content
   const { isVisible, dismiss } = useDismissableBanner({
     prefix: 'gb', // gb for global-broadcast
     content: props.content

--- a/src/components/GlobalBroadcast.vue
+++ b/src/components/GlobalBroadcast.vue
@@ -29,16 +29,11 @@
     expirationDays: 0, // Default to permanent dismissal
   });
 
-  // Generate a unique ID for this banner based on content to ensure new banners are shown
-  const internalBannerId = computed(() => {
-    // Use the first 10 chars of content as part of ID so new content always shows
-    const contentPrefix = props.content ?
-      props.content.substring(0, 10).replace(/[^a-z0-9]/gi, '') : 'default';
-    return `gb-${contentPrefix}`; // gb for global-broadcast
-  });
-
-  // Use our composable to handle dismissal state
-  const { isVisible, dismiss } = useDismissableBanner(internalBannerId.value, props.expirationDays);
+  // Use our composable to handle dismissal state with content-based ID generation
+  const { isVisible, dismiss } = useDismissableBanner({
+    prefix: 'gb', // gb for global-broadcast
+    content: props.content
+  }, props.expirationDays);
 
   // Function to decode HTML entities
   function decodeHTMLEntities(html: string) {

--- a/src/components/GlobalBroadcast.vue
+++ b/src/components/GlobalBroadcast.vue
@@ -10,7 +10,7 @@
   export interface Props {
     content: string | null; // Can contain HTML
     show: boolean;
-    bannerId?: string; // Unique identifier for this banner
+
     expirationDays?: number; // Days until banner reappears after dismissal
   }
 
@@ -25,12 +25,20 @@
   const props = withDefaults(defineProps<Props>(), {
     content: 'Welcome to the Global Broadcast!',
     show: false,
-    bannerId: 'global-broadcast',
+
     expirationDays: 0, // Default to permanent dismissal
   });
 
+  // Generate a unique ID for this banner based on content to ensure new banners are shown
+  const internalBannerId = computed(() => {
+    // Use the first 10 chars of content as part of ID so new content always shows
+    const contentPrefix = props.content ?
+      props.content.substring(0, 10).replace(/[^a-z0-9]/gi, '') : 'default';
+    return `gb-${contentPrefix}`; // gb for global-broadcast
+  });
+
   // Use our composable to handle dismissal state
-  const { isVisible, dismiss } = useDismissableBanner(props.bannerId, props.expirationDays);
+  const { isVisible, dismiss } = useDismissableBanner(internalBannerId.value, props.expirationDays);
 
   // Function to decode HTML entities
   function decodeHTMLEntities(html: string) {

--- a/src/components/icons/HeroiconsSprites.vue
+++ b/src/components/icons/HeroiconsSprites.vue
@@ -10,6 +10,7 @@
 <template>
   <svg style="display: block">
     <defs>
+      <symbol viewBox="0 0 16 16" id="heroicons-x-mark-16-solid"><path fill="currentColor" d="M5.28 4.22a.75.75 0 0 0-1.06 1.06L6.94 8l-2.72 2.72a.75.75 0 1 0 1.06 1.06L8 9.06l2.72 2.72a.75.75 0 1 0 1.06-1.06L9.06 8l2.72-2.72a.75.75 0 0 0-1.06-1.06L8 6.94z" /></symbol>
       <symbol
         viewBox="0 0 16 16"
         id="heroicons-arrow-path">

--- a/src/components/layout/MicroFooter.vue
+++ b/src/components/layout/MicroFooter.vue
@@ -1,12 +1,14 @@
-<!-- src/components/layout/DefaultFooter.vue -->
+<!-- src/components/layout/MicroFooter.vue -->
 
 <script setup lang="ts">
   import type { LayoutProps } from '@/types/ui/layouts';
+  import { WindowService } from '@/services/window.service';
   import FooterControls from '@/components/layout/SecretFooterControls.vue';
   import FooterAttribution from '@/components/layout/SecretFooterAttribution.vue';
 
   withDefaults(defineProps<LayoutProps>(), {});
 
+  const siteHost = WindowService.get('site_host');
 </script>
 <template>
   <footer

--- a/src/components/layout/MicroFooter.vue
+++ b/src/components/layout/MicroFooter.vue
@@ -1,0 +1,25 @@
+<!-- src/components/layout/DefaultFooter.vue -->
+
+<script setup lang="ts">
+  import type { LayoutProps } from '@/types/ui/layouts';
+  import FooterControls from '@/components/layout/SecretFooterControls.vue';
+  import FooterAttribution from '@/components/layout/SecretFooterAttribution.vue';
+
+  withDefaults(defineProps<LayoutProps>(), {});
+
+</script>
+<template>
+  <footer
+    class="w-full min-w-[320px] bg-gray-100 py-8 transition-colors duration-300 dark:bg-gray-800"
+    :aria-label="$t('site-footer')">
+    <div class="flex flex-col items-center space-y-8 py-8">
+      <div class="flex items-center justify-center">
+        <FooterControls :show-language="true" />
+      </div>
+      <FooterAttribution
+        :site-host="siteHost"
+        :show-nav="false"
+        :show-terms="false" />
+    </div>
+  </footer>
+</template>

--- a/src/components/layout/QuietFooter.vue
+++ b/src/components/layout/QuietFooter.vue
@@ -55,7 +55,8 @@
             :aria-label="$t('toggle-dark-mode')" />
           <LanguageToggle
             v-if="windowProps.i18n_enabled"
-            :compact="true" />
+            :compact="true"
+            max-height="max-h-dvh" />
           <FeedbackToggle
             v-if="displayFeedback && windowProps.authentication?.enabled"
             class="text-gray-500 transition-colors duration-200 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-100"

--- a/src/components/secrets/metadata/BurnButtonForm.vue
+++ b/src/components/secrets/metadata/BurnButtonForm.vue
@@ -44,11 +44,11 @@
         v-if="!showConfirmation"
         type="button"
         @click="showConfirmation = true"
-        class="group flex w-full items-center justify-center gap-3 rounded-lg bg-gradient-to-r
-        from-brand-500 to-brand-600 px-6 py-3 text-base
-        font-medium text-white shadow-sm transition-all duration-200
-        hover:from-brand-600 hover:to-brand-700 hover:shadow
-        focus:outline-none focus:ring-2 focus:ring-brand-500 focus:ring-offset-2
+        class="group flex w-full items-center justify-center gap-3 rounded-lg bg-gradient-to-b
+        from-yellow-300 to-yellow-500 px-6 py-3 text-base
+        font-medium text-gray-900 shadow-sm transition-all duration-200
+        hover:from-yellow-400 hover:to-yellow-500 hover:shadow
+        focus:outline-none focus:ring-2 focus:ring-yellow-400 focus:ring-offset-2
         disabled:opacity-70 dark:focus:ring-offset-gray-900"
         :disabled="isLoading"
         :aria-label="$t('web.COMMON.burn_this_secret_aria')"
@@ -105,7 +105,7 @@
               :placeholder="$t('web.COMMON.enter_passphrase_here')"
               class="w-full rounded-lg border border-gray-300
                 bg-white p-4 py-2.5 text-gray-900 shadow-sm
-                focus:border-transparent focus:ring-2 focus:ring-brand-500
+                focus:border-transparent focus:ring-2 focus:ring-yellow-400
                 dark:border-gray-600 dark:bg-gray-700 dark:text-white" />
           </div>
         </div>
@@ -116,9 +116,9 @@
             type="button"
             @click="showConfirmation = false"
             class="over:bg-gray-50 ark:border-gray-600 rounded-lg border border-gray-300 bg-white
-              px-4 py-2.5 text-base font-medium text-gray-700
+              px-4 py-2.5 text-base font-medium text-gray-900
               transition-colors duration-200 focus:outline-none focus:ring-2
-              focus:ring-brand-500 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600">
+              focus:ring-yellow-400 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600">
             {{ $t('web.LABELS.cancel') }}
           </button>
           <!-- prettier-ignore-attribute class -->
@@ -126,15 +126,15 @@
             type="submit"
             @click="burn"
             :disabled="isLoading"
-            class="flex items-center gap-2 rounded-lg
-              bg-gradient-to-r from-brand-500 to-brand-600 px-4 py-2.5
-              text-base font-medium text-white shadow-sm transition-all duration-200
-              hover:from-brand-600 hover:to-brand-700 hover:shadow
-              focus:outline-none focus:ring-2 focus:ring-brand-500 disabled:opacity-50">
+            class="group flex items-center gap-2 rounded-lg
+              bg-gradient-to-r from-yellow-400 to-yellow-500 px-4 py-2.5
+              text-base font-medium text-gray-900 shadow-sm transition-all duration-200
+              hover:from-yellow-400 hover:to-yellow-500 hover:shadow
+              focus:outline-none focus:ring-2 focus:ring-yellow-400 disabled:opacity-50">
             <OIcon
               collection="material-symbols"
               name="local-fire-department-rounded"
-              class="size-4" />
+              class="size-4 transition-all group-hover:rotate-12 group-hover:scale-125" />
             <span>{{ $t('web.COMMON.confirm_burn') }}</span>
           </button>
         </div>

--- a/src/components/secrets/metadata/SecretLink.vue
+++ b/src/components/secrets/metadata/SecretLink.vue
@@ -2,10 +2,9 @@
 
 <script setup lang="ts">
   import OIcon from '@/components/icons/OIcon.vue';
+  import CopyButton from '@/components/CopyButton.vue';
   import type { Metadata, MetadataDetails } from '@/schemas/models';
-  import { ref, computed } from 'vue';
-  import { useI18n } from 'vue-i18n';
-  const { t } = useI18n();
+  import { ref } from 'vue';
 
   interface Props {
     record: Metadata;
@@ -15,37 +14,7 @@
 
   defineProps<Props>();
 
-  const copied = ref(false);
-  const showToast = ref(false);
   const linkInput = ref<HTMLInputElement>();
-  const buttonText = computed(() =>
-    copied.value ? t('web.STATUS.copied') : t('web.LABELS.copy_to_clipboard')
-  );
-
-  const copyToClipboard = async () => {
-    if (!linkInput.value) return;
-
-    try {
-      await navigator.clipboard.writeText(linkInput.value.value);
-      copied.value = true;
-      showToast.value = true;
-
-      // Reset copy icon
-      setTimeout(() => {
-        copied.value = false;
-      }, 2000);
-
-      // Hide toast
-      setTimeout(() => {
-        showToast.value = false;
-      }, 1500);
-    } catch (err) {
-      console.error('Failed to copy text: ', err);
-
-      linkInput.value.select();
-      document.execCommand('copy'); // fallback for older browsers
-    }
-  };
 </script>
 
 <template>
@@ -136,23 +105,9 @@
         </div>
 
         <div class="ml-4 shrink-0">
-          <!-- prettier-ignore-attribute class -->
-          <button
-            @click="copyToClipboard"
-            class="inline-flex items-center justify-center rounded-md p-2.5
-              text-gray-500 transition-all duration-200
-              hover:bg-gray-100 hover:text-brand-600
-              focus:outline-none focus:ring-2 focus:ring-brand-500 focus:ring-offset-2
-              dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-brand-400"
-            :class="{
-              'bg-green-50 text-green-500 dark:bg-green-900/30 dark:text-green-400': copied,
-            }">
-            <OIcon
-              collection="material-symbols"
-              :name="copied ? 'check' : 'content-copy-outline'"
-              class="size-5" />
-            <span class="sr-only">{{ buttonText }}</span>
-          </button>
+          <CopyButton
+                class="ml-auto transition-transform hover:scale-105"
+                :text="record.share_url" />
         </div>
       </div>
 
@@ -171,24 +126,6 @@
             {{ $t('web.COMMON.share_link_securely') }}
           </span>
         </div>
-      </div>
-
-      <!-- Copy Feedback Toast with Enhanced Design -->
-      <!-- prettier-ignore-attribute class -->
-      <div
-        v-if="showToast"
-        class="absolute right-4 top-4 flex items-center gap-2 rounded-md
-        bg-slate-900 px-3.5 py-2 text-sm text-white shadow-lg transition-all duration-300
-        dark:bg-slate-700"
-        :class="{
-          'translate-y-1 opacity-0': !showToast,
-          'translate-y-0 opacity-100': showToast,
-        }">
-        <OIcon
-          collection="material-symbols"
-          name="check-circle-outline"
-          class="size-4 text-green-400" />
-        {{ $t('web.COMMON.copied_to_clipboard') }}
       </div>
     </div>
   </div>

--- a/src/components/secrets/metadata/SecretLink.vue
+++ b/src/components/secrets/metadata/SecretLink.vue
@@ -130,15 +130,9 @@
             :value="record.share_url"
             class="w-full resize-none rounded-md
               border-0 bg-slate-50 px-3 py-2.5 font-mono text-sm text-gray-900
-              focus:ring-1 focus:ring-brand-500
+              focus:ring-1 focus:ring-green-500
               dark:bg-slate-900 dark:text-gray-100 sm:text-base"
             :aria-label="$t('secret-link')"></textarea>
-
-          <!-- Focus effect overlay -->
-          <!-- prettier-ignore-attribute class -->
-          <div
-            class="pointer-events-none absolute inset-0 rounded-md
-              border border-transparent group-focus-within/link:border-brand-500"></div>
         </div>
 
         <div class="ml-4 shrink-0">

--- a/src/components/secrets/metadata/SecretLink.vue
+++ b/src/components/secrets/metadata/SecretLink.vue
@@ -57,11 +57,13 @@
     </h1>
 
     <!-- Passphrase Indicator -->
+    <!-- prettier-ignore-attribute class -->
     <div
       v-if="details?.has_passphrase"
       class="flex items-center gap-2 rounded-full
         border border-amber-100 bg-amber-50 px-2 py-1
-        text-sm font-medium text-amber-600 shadow-sm transition-transform dark:border-amber-800/50 dark:bg-amber-900/30 dark:text-amber-400">
+        text-sm font-medium text-amber-600 shadow-sm transition-transform
+        dark:border-amber-800/50 dark:bg-amber-900/30 dark:text-amber-400">
       <OIcon
         collection="mdi"
         name="lock"
@@ -69,8 +71,11 @@
       {{ $t('web.LABELS.passphrase_protected') }}
     </div>
 
+    <!-- prettier-ignore-attribute class -->
     <div
-      class="group relative overflow-hidden rounded-lg border-gray-200 bg-white shadow-md dark:border-gray-700 dark:bg-gray-800">
+      class="group relative overflow-hidden rounded-lg
+        border-gray-200 bg-white shadow-md
+        dark:border-gray-700 dark:bg-gray-800">
       <!-- Momentum Indicator - Enhanced Animation -->
       <div class="absolute left-0 top-0 h-1.5 w-full overflow-hidden">
         <div
@@ -99,15 +104,16 @@
       </div>
 
       <!-- Subsequent Message -->
+      <!-- prettier-ignore-attribute class -->
       <div
-        class="mb-1 flex items-center gap-2 px-5 pt-4 font-mono text-sm tracking-wide text-gray-500">
+        class="mb-1 flex items-center gap-2 px-5 pt-4
+          font-mono text-sm tracking-wide text-gray-500">
         <OIcon
           collection="material-symbols"
           name="key-vertical"
           class="size-4 transition-transform duration-300 group-hover:rotate-12"
           aria-hidden="true" />
-        <span
-          class="transition-colors group-hover:text-brand-500 dark:group-hover:text-brand-400">
+        <span class="transition-colors group-hover:text-brand-500 dark:group-hover:text-brand-400">
           {{ record.secret_shortkey }}
         </span>
       </div>
@@ -122,20 +128,28 @@
             ref="linkInput"
             readonly
             :value="record.share_url"
-            class="w-full resize-none rounded-md border-0 bg-slate-50 px-3 py-2.5 font-mono text-sm text-gray-900 focus:ring-1 focus:ring-brand-500 dark:bg-slate-900 dark:text-gray-100 sm:text-base"
+            class="w-full resize-none rounded-md
+              border-0 bg-slate-50 px-3 py-2.5 font-mono text-sm text-gray-900
+              focus:ring-1 focus:ring-brand-500
+              dark:bg-slate-900 dark:text-gray-100 sm:text-base"
             :aria-label="$t('secret-link')"></textarea>
 
           <!-- Focus effect overlay -->
           <!-- prettier-ignore-attribute class -->
           <div
-            class="pointer-events-none absolute inset-0 rounded-md border border-transparent group-focus-within/link:border-brand-500"></div>
+            class="pointer-events-none absolute inset-0 rounded-md
+              border border-transparent group-focus-within/link:border-brand-500"></div>
         </div>
 
         <div class="ml-4 shrink-0">
           <!-- prettier-ignore-attribute class -->
           <button
             @click="copyToClipboard"
-            class="inline-flex items-center justify-center rounded-md p-2.5 text-gray-500 transition-all duration-200 hover:bg-gray-100 hover:text-brand-600 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:ring-offset-2 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-brand-400"
+            class="inline-flex items-center justify-center rounded-md p-2.5
+              text-gray-500 transition-all duration-200
+              hover:bg-gray-100 hover:text-brand-600
+              focus:outline-none focus:ring-2 focus:ring-brand-500 focus:ring-offset-2
+              dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-brand-400"
             :class="{
               'bg-green-50 text-green-500 dark:bg-green-900/30 dark:text-green-400': copied,
             }">
@@ -170,7 +184,8 @@
       <div
         v-if="showToast"
         class="absolute right-4 top-4 flex items-center gap-2 rounded-md
-        bg-slate-900 px-3.5 py-2 text-sm text-white shadow-lg transition-all duration-300 dark:bg-slate-700"
+        bg-slate-900 px-3.5 py-2 text-sm text-white shadow-lg transition-all duration-300
+        dark:bg-slate-700"
         :class="{
           'translate-y-1 opacity-0': !showToast,
           'translate-y-0 opacity-100': showToast,

--- a/src/composables/useDismissableBanner.ts
+++ b/src/composables/useDismissableBanner.ts
@@ -1,0 +1,99 @@
+// useDismissableBanner.ts
+
+/**
+ * <script setup lang="ts">
+ * import { useDismissableBanner } from '@/composables/useDismissableBanner'
+ *
+ * // Banner that never reappears once dismissed
+ * const { isVisible: isAnnouncementVisible, dismiss: dismissAnnouncement } =
+ *   useDismissableBanner('announcement')
+ *
+ * // Banner that reappears after 7 days
+ * const { isVisible: isPromoVisible, dismiss: dismissPromo } =
+ *   useDismissableBanner('promo', 7)
+ * </script>
+ *
+ * <template>
+ *   <!-- Permanent dismissal banner -->
+ *   <div v-if="isAnnouncementVisible">
+ *     <p>Important announcement that you only need to see once!</p>
+ *     <button @click="dismissAnnouncement">
+ *       X
+ *     </button>
+ *   </div>
+ *
+ *   <!-- Time-limited dismissal banner -->
+ *   <div v-if="isPromoVisible">
+ *     <button @click="dismissPromo">Dismiss</button>
+ *   </div>
+ * </template>
+ */
+import { ref, computed } from 'vue';
+
+interface BannerState {
+  dismissed: boolean;
+  timestamp: string | null;
+}
+
+/**
+ * Composable for managing dismissable banners with optional expiration
+ * @param bannerId - Unique identifier for the banner
+ * @param expirationDays - Optional number of days until the banner reappears (0 for never)
+ * @returns Object with isVisible state and dismiss function
+ */
+export function useDismissableBanner(bannerId: string, expirationDays: number = 0) {
+  // Initialize state from localStorage or with defaults
+  const getStoredState = (): BannerState => {
+    const stored = localStorage.getItem(`banner-${bannerId}`);
+    if (stored) {
+      try {
+        const parsedState = JSON.parse(stored);
+        // Basic validation to ensure it's at least an object with expected keys,
+        // though a more robust validation (e.g., with Zod) could be used here.
+        if (typeof parsedState === 'object' && parsedState !== null &&
+            'dismissed' in parsedState && 'timestamp' in parsedState) {
+          return parsedState as BannerState;
+        }
+        // If the structure is not what we expect, treat as invalid.
+        console.warn(`Invalid banner state structure for ${bannerId}:`, parsedState);
+        return { dismissed: false, timestamp: null };
+      } catch (error) {
+        // If JSON parsing fails, log the error and return default state.
+        console.warn(`Failed to parse banner state for ${bannerId} from localStorage:`, error);
+        return { dismissed: false, timestamp: null };
+      }
+    }
+    return { dismissed: false, timestamp: null };
+  };
+
+  // Create reactive state
+  const bannerState = ref<BannerState>(getStoredState());
+
+  // Computed property to determine if banner should be visible
+  const isVisible = computed(() => {
+    if (!bannerState.value.dismissed) return true;
+    if (expirationDays === 0) return false; // Never show again if expiration is 0
+
+    const dismissedTime = bannerState.value.timestamp
+      ? new Date(bannerState.value.timestamp).getTime()
+      : 0;
+    const currentTime = new Date().getTime();
+    const daysPassed = (currentTime - dismissedTime) / (1000 * 60 * 60 * 24);
+
+    return daysPassed > expirationDays;
+  });
+
+  // Function to dismiss the banner
+  const dismiss = () => {
+    bannerState.value = {
+      dismissed: true,
+      timestamp: new Date().toISOString(),
+    };
+    localStorage.setItem(`banner-${bannerId}`, JSON.stringify(bannerState.value));
+  };
+
+  return {
+    isVisible,
+    dismiss,
+  };
+}

--- a/src/composables/useHash.ts
+++ b/src/composables/useHash.ts
@@ -1,0 +1,51 @@
+// composables/useHash.ts
+
+import { ref, Ref } from 'vue';
+
+/**
+ * Supported hash algorithms that can be used with Web Crypto API
+ */
+export type HashAlgorithm = 'SHA-1' | 'SHA-256' | 'SHA-384' | 'SHA-512';
+
+/**
+ * Composable for generating cryptographic hashes using the Web Crypto API
+ * @returns Object containing hash generation method and status values
+ */
+export function useHash() {
+  const isHashing: Ref<boolean> = ref(false);
+  const error: Ref<string | null> = ref(null);
+
+  /**
+   * Generates a cryptographic hash of the provided message
+   * @param message - The input string to be hashed
+   * @param algorithm - The hashing algorithm to use (default: 'SHA-256')
+   * @returns A promise resolving to the hexadecimal hash string, or null if an error occurs
+   */
+  const generateHash = async (
+    message: string,
+    algorithm: HashAlgorithm = 'SHA-256'
+  ): Promise<string | null> => {
+    isHashing.value = true;
+    error.value = null;
+
+    try {
+      const msgUint8 = new TextEncoder().encode(message);
+      const hashBuffer = await crypto.subtle.digest(algorithm, msgUint8);
+      const hashArray = Array.from(new Uint8Array(hashBuffer));
+      const hashHex = hashArray.map((b) => b.toString(16).padStart(2, '0')).join('');
+
+      return hashHex;
+    } catch (err: unknown) {
+      error.value = err instanceof Error ? err.message : String(err);
+      return null;
+    } finally {
+      isHashing.value = false;
+    }
+  };
+
+  return {
+    generateHash,
+    isHashing,
+    error,
+  };
+}

--- a/src/layouts/BaseLayout.vue
+++ b/src/layouts/BaseLayout.vue
@@ -20,14 +20,6 @@
     return !!globalBanner;
   });
 
-  // Generate a unique ID for this banner based on content to ensure new banners are shown
-  const bannerContentId = computed(() => {
-    // Use the first 10 chars of content as part of ID so new content always shows
-    const contentPrefix = globalBanner ?
-      globalBanner.substring(0, 10).replace(/[^a-z0-9]/gi, '') : '';
-    return `global-banner-${contentPrefix}`;
-  });
-
   // Compute primary color styles based on brand color or prop
   const primaryColorClass = computed(() => {
     const currentColor = identityStore.primaryColor;
@@ -53,7 +45,7 @@
       v-if="displayGlobalBroadcast"
       :show="hasGlobalBanner"
       :content="globalBanner"
-      :banner-id="bannerContentId"
+      :key="globalBanner"
       :expiration-days="7" />
 
     <!-- Rest of the owl -->

--- a/src/layouts/BaseLayout.vue
+++ b/src/layouts/BaseLayout.vue
@@ -20,6 +20,14 @@
     return !!globalBanner;
   });
 
+  // Generate a unique ID for this banner based on content to ensure new banners are shown
+  const bannerContentId = computed(() => {
+    // Use the first 10 chars of content as part of ID so new content always shows
+    const contentPrefix = globalBanner ?
+      globalBanner.substring(0, 10).replace(/[^a-z0-9]/gi, '') : '';
+    return `global-banner-${contentPrefix}`;
+  });
+
   // Compute primary color styles based on brand color or prop
   const primaryColorClass = computed(() => {
     const currentColor = identityStore.primaryColor;
@@ -44,17 +52,14 @@
     <GlobalBroadcast
       v-if="displayGlobalBroadcast"
       :show="hasGlobalBanner"
-      :content="globalBanner" />
+      :content="globalBanner"
+      :banner-id="bannerContentId"
+      :expiration-days="7" />
 
-    <!-- Header content, Ramos territory -->
+    <!-- Rest of the owl -->
     <slot name="header"></slot>
-
-    <!-- Main page content, only in Japan -->
     <slot name="main"></slot>
-
-    <!-- Footer content, Haaland maybe? -->
     <slot name="footer"></slot>
-
     <slot name="status">
       <div id="status-messages"></div>
     </slot>

--- a/src/layouts/BaseLayout.vue
+++ b/src/layouts/BaseLayout.vue
@@ -11,6 +11,10 @@
   defineProps<LayoutProps>();
 
   const globalBanner = WindowService.get('global_banner') ?? null;
+
+  // Component key cannot be null or undefined
+  const globalBroadcastKey = globalBanner ? 'global_broadcast' : 'n/a';
+
   const identityStore = useProductIdentity();
 
   // If there's a global banner set (in redis), this will be true. The actual
@@ -45,7 +49,7 @@
       v-if="displayGlobalBroadcast"
       :show="hasGlobalBanner"
       :content="globalBanner"
-      :key="globalBanner"
+      :key="globalBroadcastKey"
       :expiration-days="7" />
 
     <!-- Rest of the owl -->

--- a/src/views/HomepageContainer.vue
+++ b/src/views/HomepageContainer.vue
@@ -13,7 +13,7 @@
 
   // Simple approach: use direct component with transition
   const currentComponent = computed(() => {
-    return isCustom.value ? BrandedHomepage : Homepage;
+    return isCustom ? BrandedHomepage : Homepage;
   });
 </script>
 

--- a/src/views/HomepageContainer.vue
+++ b/src/views/HomepageContainer.vue
@@ -11,14 +11,39 @@
 
   const { isCustom, displayDomain, siteHost } = useProductIdentity();
 
+  // Simple approach: use direct component with transition
   const currentComponent = computed(() => {
-    return isCustom ? BrandedHomepage : Homepage;
+    return isCustom.value ? BrandedHomepage : Homepage;
   });
 </script>
 
 <template>
-  <Component
-    :is="currentComponent"
-    :display-domain="displayDomain"
-    :site-host="siteHost" />
+  <div class="homepage-container">
+    <Transition name="homepage-fade" mode="out-in">
+      <Component
+        :key="isCustom ? 'branded' : 'standard'"
+        :is="currentComponent"
+        :display-domain="displayDomain"
+        :site-host="siteHost" />
+    </Transition>
+  </div>
 </template>
+
+<style scoped>
+.homepage-container {
+  /* Ensure container has a minimum height to prevent layout shifts */
+  min-height: 500px;
+  position: relative;
+}
+
+/* Transition definitions */
+.homepage-fade-enter-active,
+.homepage-fade-leave-active {
+  transition: opacity 0.25s ease;
+}
+
+.homepage-fade-enter-from,
+.homepage-fade-leave-to {
+  opacity: 0;
+}
+</style>

--- a/src/views/secrets/BurnSecret.vue
+++ b/src/views/secrets/BurnSecret.vue
@@ -1,6 +1,7 @@
 <!-- src/views/secrets/BurnSecret.vue -->
 
 <script setup lang="ts">
+  import OIcon from '@/components/icons/OIcon.vue';
   import { useMetadata } from '@/composables/useMetadata';
   import { onMounted } from 'vue';
 
@@ -31,10 +32,14 @@
     </div>
 
     <!-- Destroyed/Invalid State -->
+    <!-- prettier-ignore-attribute class -->
     <div
       v-else-if="!record || record?.is_destroyed"
       role="alert"
-      class="space-y-4 rounded-lg border-l-4 border-red-500 bg-red-50 p-5 shadow-sm dark:border-red-600 dark:bg-red-900/30">
+      class="space-y-4 rounded-lg
+        border-l-4 border-red-500
+        bg-red-50 p-5 shadow-sm
+        dark:border-red-600 dark:bg-red-900/30">
       <!-- Status Message -->
       <div class="flex items-center space-x-3">
         <svg
@@ -60,16 +65,28 @@
 
       <!-- Action Buttons -->
       <div class="flex flex-col gap-3 sm:flex-row">
+        <!-- prettier-ignore-attribute class -->
         <a
           v-if="record?.metadata_path"
           :href="record.metadata_path"
-          class="flex-1 rounded-lg bg-white px-4 py-2.5 text-center font-brand font-medium text-gray-700 shadow-sm transition hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-red-500 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
+          class="flex-1 rounded-lg
+            bg-white px-4 py-2.5 text-center font-brand font-medium
+            text-gray-700 shadow-sm transition
+            hover:bg-gray-50
+            focus:outline-none focus:ring-2 focus:ring-red-500 dark:bg-gray-800
+            dark:text-gray-200 dark:hover:bg-gray-700"
           :aria-label="$t('back-to-details')">
           {{ $t('back-to-details') }}
         </a>
+        <!-- prettier-ignore-attribute class -->
         <router-link
           to="/"
-          class="flex-1 rounded-lg bg-red-600 px-4 py-2.5 text-center font-brand font-medium text-white shadow-sm transition hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 dark:bg-red-700 dark:hover:bg-red-600">
+          class="flex-1 rounded-lg
+            bg-red-600 px-4 py-2.5 text-center font-brand font-medium
+            text-white shadow-sm transition
+            hover:bg-red-700
+            focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2
+            dark:bg-red-700 dark:hover:bg-red-600">
           {{ $t('web.LABELS.create_new_secret') }}
         </router-link>
       </div>
@@ -97,32 +114,32 @@
             class="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-300">
             {{ $t('web.COMMON.enter_passphrase_here') }}
           </label>
+          <!-- prettier-ignore-attribute class -->
           <input
             type="password"
             v-model="passphrase"
             id="passField"
-            class="w-full rounded-md border border-gray-300 bg-white px-3 py-2 focus:outline-none focus:ring-2 focus:ring-brand-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200"
+            class="w-full rounded-md
+              border border-gray-300 bg-white px-3 py-2
+              focus:outline-none focus:ring-2 focus:ring-brand-500
+              dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200"
             :aria-describedby="details?.has_passphrase ? 'password-hint' : undefined" />
         </div>
+        <!-- prettier-ignore-attribute class -->
         <button
           type="submit"
           :disabled="isLoading"
-          class="flex w-full items-center justify-center rounded-md bg-yellow-400 px-4 py-2 text-gray-800 transition duration-200 hover:bg-yellow-300 focus:outline-none focus:ring-2 focus:ring-yellow-400 focus:ring-offset-2 dark:focus:ring-offset-gray-800"
+          class="flex w-full items-center justify-center rounded-md
+            bg-yellow-400 px-4 py-2 text-gray-800 transition duration-200
+            hover:bg-yellow-300
+            focus:outline-none focus:ring-2 focus:ring-yellow-400 focus:ring-offset-2
+            dark:focus:ring-offset-gray-800"
           aria-describedby="burn-action-description">
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            class="mr-2 size-5"
-            viewBox="0 0 20 20"
-            fill="currentColor"
-            width="20"
-            height="20"
-            aria-hidden="true"
-            role="img">
-            <path
-              fill-rule="evenodd"
-              d="M12.395 2.553a1 1 0 00-1.45-.385c-.345.23-.614.558-.822.88-.214.33-.403.713-.57 1.116-.334.804-.614 1.768-.84 2.734a31.365 31.365 0 00-.613 3.58 2.64 2.64 0 01-.945-1.067c-.328-.68-.398-1.534-.398-2.654A1 1 0 005.05 6.05 6.981 6.981 0 003 11a7 7 0 1011.95-4.95c-.592-.591-.98-.985-1.348-1.467-.363-.476-.724-1.063-1.207-2.03zM12.12 15.12A3 3 0 017 13s.879.5 2.5.5c0-1 .5-4 1.25-4.5.5 1 .786 1.293 1.371 1.879A2.99 2.99 0 0113 13a2.99 2.99 0 01-.879 2.121z"
-              clip-rule="evenodd" />
-          </svg>
+          <OIcon
+            collection=""
+            name="heroicons-fire-20-solid"
+            class="mr-1 size-5 transition-all group-hover:rotate-12 group-hover:scale-125"
+            aria-hidden="true" />
           {{ $t('web.COMMON.word_confirm') }}: {{ $t('web.COMMON.burn_this_secret') }}
         </button>
         <!-- prettier-ignore-attribute class -->

--- a/src/views/secrets/BurnSecret.vue
+++ b/src/views/secrets/BurnSecret.vue
@@ -129,9 +129,9 @@
         <button
           type="submit"
           :disabled="isLoading"
-          class="flex w-full items-center justify-center rounded-md
-            bg-yellow-400 px-4 py-2 text-gray-800 transition duration-200
-            hover:bg-yellow-300
+          class="group flex w-full items-center justify-center rounded-md
+            bg-yellow-400 px-4 py-2 text-gray-800  duration-200
+            hover:bg-yellow-500
             focus:outline-none focus:ring-2 focus:ring-yellow-400 focus:ring-offset-2
             dark:focus:ring-offset-gray-800"
           aria-describedby="burn-action-description">

--- a/src/views/secrets/BurnSecret.vue
+++ b/src/views/secrets/BurnSecret.vue
@@ -42,16 +42,10 @@
         dark:border-red-600 dark:bg-red-900/30">
       <!-- Status Message -->
       <div class="flex items-center space-x-3">
-        <svg
-          class="size-6 text-red-500 dark:text-red-400"
-          fill="currentColor"
-          viewBox="0 0 20 20"
-          aria-hidden="true"
-          role="img">
-          <path
-            fill-rule="evenodd"
-            d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" />
-        </svg>
+        <OIcon
+          collection="heroicons"
+          name="exclamation-circle-16-solid"
+          class="size-6 text-red-500 dark:text-red-400" />
         <p class="text-base font-medium text-red-800 dark:text-red-200">
           <template v-if="record?.is_received">
             {{ $t('viewed-on-record-received', [record?.received]) }}
@@ -66,18 +60,18 @@
       <!-- Action Buttons -->
       <div class="flex flex-col gap-3 sm:flex-row">
         <!-- prettier-ignore-attribute class -->
-        <a
+        <router-link
           v-if="record?.metadata_path"
-          :href="record.metadata_path"
+          :to="{ name: 'Receipt link', params: { metadataKey: record.identifier } }"
           class="flex-1 rounded-lg
             bg-white px-4 py-2.5 text-center font-brand font-medium
             text-gray-700 shadow-sm transition
-            hover:bg-gray-50
-            focus:outline-none focus:ring-2 focus:ring-red-500 dark:bg-gray-800
-            dark:text-gray-200 dark:hover:bg-gray-700"
+            hover:bg-gray-200
+            focus:outline-none focus:ring-2 focus:ring-red-500 dark:bg-gray-700
+            dark:text-gray-200 dark:hover:bg-gray-600"
           :aria-label="$t('back-to-details')">
           {{ $t('back-to-details') }}
-        </a>
+        </router-link>
         <!-- prettier-ignore-attribute class -->
         <router-link
           to="/"

--- a/src/views/secrets/ShowMetadata.vue
+++ b/src/views/secrets/ShowMetadata.vue
@@ -115,7 +115,6 @@
           dark:border-slate-800/50 dark:from-slate-900 dark:to-slate-950 dark:shadow-slate-900/30">
           <!-- Secret Link Header -->
           <section
-
             class="relative transition-transform duration-300 hover:scale-[1.01]"
             aria-labelledby="secret-header">
             <SecretLink
@@ -123,7 +122,7 @@
               :record="record"
               :details="details"
               :is-initial-view="!record.is_viewed"
-              class="rounded-lg focus-within:ring-2 focus-within:ring-brand-500" />
+            />
           </section>
 
           <!-- Recipients Section -->

--- a/tests/unit/vue/composables/useDismissableBanner.spec.ts
+++ b/tests/unit/vue/composables/useDismissableBanner.spec.ts
@@ -1,0 +1,254 @@
+// tests/unit/vue/composables/useDismissableBanner.spec.ts
+
+import { useDismissableBanner } from '@/composables/useDismissableBanner';
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+
+describe('useDismissableBanner', () => {
+  const BANNER_ID_PERMANENT = 'test-permanent-banner';
+  const BANNER_ID_TEMPORARY = 'test-temporary-banner';
+  const EXPIRATION_DAYS = 7;
+
+  beforeEach(() => {
+    // Clear localStorage before each test
+    localStorage.clear();
+    // Use fake timers to control time-based logic
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    // Restore real timers after each test
+    vi.useRealTimers();
+  });
+
+  it('should be visible by default when no prior state exists', () => {
+    const { isVisible } = useDismissableBanner('new-banner-default');
+    expect(isVisible.value).toBe(true);
+  });
+
+  describe('Permanent Dismissal (expirationDays = 0 or not provided)', () => {
+    it('should dismiss banner permanently and store state when expirationDays is 0', () => {
+      const { isVisible, dismiss } = useDismissableBanner(BANNER_ID_PERMANENT, 0);
+      expect(isVisible.value).toBe(true); // Initially visible
+
+      dismiss();
+      expect(isVisible.value).toBe(false); // Should be hidden after dismissal
+
+      // Verify localStorage state
+      const storedState = JSON.parse(localStorage.getItem(`banner-${BANNER_ID_PERMANENT}`) || '{}');
+      expect(storedState.dismissed).toBe(true);
+      expect(storedState.timestamp).toBeTypeOf('string'); // Timestamp should be set
+
+      // Re-initialize composable to check for persistence from localStorage
+      const { isVisible: isVisibleAfterReinit } = useDismissableBanner(BANNER_ID_PERMANENT, 0);
+      expect(isVisibleAfterReinit.value).toBe(false); // Should remain hidden
+    });
+
+    it('should dismiss banner permanently and store state when expirationDays is not provided (defaults to 0)', () => {
+      const { isVisible, dismiss } = useDismissableBanner(BANNER_ID_PERMANENT); // No expirationDays argument
+      expect(isVisible.value).toBe(true);
+
+      dismiss();
+      expect(isVisible.value).toBe(false);
+
+      const storedState = JSON.parse(localStorage.getItem(`banner-${BANNER_ID_PERMANENT}`) || '{}');
+      expect(storedState.dismissed).toBe(true);
+      expect(storedState.timestamp).toBeTypeOf('string');
+
+      const { isVisible: isVisibleAfterReinit } = useDismissableBanner(BANNER_ID_PERMANENT);
+      expect(isVisibleAfterReinit.value).toBe(false);
+    });
+
+    it('should remain dismissed permanently even after significant time has passed', () => {
+      const { isVisible, dismiss } = useDismissableBanner(BANNER_ID_PERMANENT, 0);
+      dismiss();
+      expect(isVisible.value).toBe(false);
+
+      // Advance time well beyond any possible temporary expiration (e.g., 10 years)
+      vi.advanceTimersByTime(1000 * 60 * 60 * 24 * 365 * 10);
+
+      const { isVisible: isVisibleAfterTime } = useDismissableBanner(BANNER_ID_PERMANENT, 0);
+      expect(isVisibleAfterTime.value).toBe(false); // Should still be hidden
+    });
+  });
+
+  describe('Temporary Dismissal (expirationDays > 0)', () => {
+    const MOCK_CURRENT_DATE_STR = '2024-01-01T12:00:00.000Z';
+
+    beforeEach(() => {
+      // Set a consistent "current" time for these tests
+      vi.setSystemTime(new Date(MOCK_CURRENT_DATE_STR));
+    });
+
+    it('should dismiss banner temporarily and store state with timestamp', () => {
+      const { isVisible, dismiss } = useDismissableBanner(BANNER_ID_TEMPORARY, EXPIRATION_DAYS);
+      expect(isVisible.value).toBe(true);
+
+      dismiss();
+      expect(isVisible.value).toBe(false);
+
+      const storedState = JSON.parse(localStorage.getItem(`banner-${BANNER_ID_TEMPORARY}`) || '{}');
+      expect(storedState.dismissed).toBe(true);
+      expect(storedState.timestamp).toBe(MOCK_CURRENT_DATE_STR); // Timestamp of dismissal
+
+      const { isVisible: isVisibleAfterReinit } = useDismissableBanner(
+        BANNER_ID_TEMPORARY,
+        EXPIRATION_DAYS
+      );
+      expect(isVisibleAfterReinit.value).toBe(false); // Should remain hidden
+    });
+
+    it('should remain hidden if re-initialized before expiration period', () => {
+      const { dismiss } = useDismissableBanner(BANNER_ID_TEMPORARY, EXPIRATION_DAYS);
+      dismiss();
+
+      // Advance time, but by less than the expiration period
+      vi.advanceTimersByTime(1000 * 60 * 60 * 24 * (EXPIRATION_DAYS - 1)); // e.g., 6 days for 7-day expiry
+
+      const { isVisible: isVisibleBeforeExpiration } = useDismissableBanner(
+        BANNER_ID_TEMPORARY,
+        EXPIRATION_DAYS
+      );
+      expect(isVisibleBeforeExpiration.value).toBe(false); // Should still be hidden
+    });
+
+    it('should become visible again if re-initialized after expiration period', () => {
+      const { dismiss } = useDismissableBanner(BANNER_ID_TEMPORARY, EXPIRATION_DAYS);
+      dismiss(); // Dismissed at MOCK_CURRENT_DATE_STR
+
+      // Confirm it's dismissed immediately after
+      const { isVisible: isVisibleInitially } = useDismissableBanner(
+        BANNER_ID_TEMPORARY,
+        EXPIRATION_DAYS
+      );
+      expect(isVisibleInitially.value).toBe(false);
+
+      // Advance time by exactly expirationDays + 1 millisecond
+      vi.advanceTimersByTime(1000 * 60 * 60 * 24 * EXPIRATION_DAYS + 1);
+
+      const { isVisible: isVisibleAfterExpiration } = useDismissableBanner(
+        BANNER_ID_TEMPORARY,
+        EXPIRATION_DAYS
+      );
+      expect(isVisibleAfterExpiration.value).toBe(true); // Should now be visible
+    });
+
+    it('should be visible if initialized with a stored timestamp older than expiration period', () => {
+      const dismissedDate = new Date(MOCK_CURRENT_DATE_STR);
+      // Set dismissal timestamp to be (EXPIRATION_DAYS + 1 day) in the past
+      dismissedDate.setDate(dismissedDate.getDate() - (EXPIRATION_DAYS + 1));
+
+      localStorage.setItem(
+        `banner-${BANNER_ID_TEMPORARY}`,
+        JSON.stringify({
+          dismissed: true,
+          timestamp: dismissedDate.toISOString(),
+        })
+      );
+
+      // Current time is MOCK_CURRENT_DATE_STR
+      const { isVisible } = useDismissableBanner(BANNER_ID_TEMPORARY, EXPIRATION_DAYS);
+      expect(isVisible.value).toBe(true); // Should be visible as it's expired
+    });
+
+    it('should remain hidden if initialized with a stored timestamp within expiration period', () => {
+      const dismissedDate = new Date(MOCK_CURRENT_DATE_STR);
+      // Set dismissal timestamp to be 1 day in the past
+      dismissedDate.setDate(dismissedDate.getDate() - 1);
+
+      localStorage.setItem(
+        `banner-${BANNER_ID_TEMPORARY}`,
+        JSON.stringify({
+          dismissed: true,
+          timestamp: dismissedDate.toISOString(),
+        })
+      );
+
+      // Current time is MOCK_CURRENT_DATE_STR, expiry is 7 days
+      const { isVisible } = useDismissableBanner(BANNER_ID_TEMPORARY, EXPIRATION_DAYS);
+      expect(isVisible.value).toBe(false); // Should be hidden, still within 7 days
+    });
+  });
+
+  it('should handle multiple banner instances independently', () => {
+    const banner1Id = 'multi-banner-1'; // Permanent
+    const banner2Id = 'multi-banner-2'; // Temporary (5 days)
+    const banner3Id = 'multi-banner-3'; // Permanent (default)
+
+    vi.setSystemTime(new Date('2024-01-01T00:00:00.000Z'));
+
+    const banner1 = useDismissableBanner(banner1Id, 0);
+    const banner2 = useDismissableBanner(banner2Id, 5);
+    const banner3 = useDismissableBanner(banner3Id);
+
+    expect(banner1.isVisible.value, 'banner1 initial').toBe(true);
+    expect(banner2.isVisible.value, 'banner2 initial').toBe(true);
+    expect(banner3.isVisible.value, 'banner3 initial').toBe(true);
+
+    banner1.dismiss();
+    expect(banner1.isVisible.value, 'banner1 after dismiss').toBe(false);
+    expect(banner2.isVisible.value, 'banner2 after banner1 dismiss').toBe(true);
+    expect(banner3.isVisible.value, 'banner3 after banner1 dismiss').toBe(true);
+
+    banner2.dismiss();
+    expect(banner1.isVisible.value, 'banner1 after banner2 dismiss').toBe(false);
+    expect(banner2.isVisible.value, 'banner2 after dismiss').toBe(false);
+    expect(banner3.isVisible.value, 'banner3 after banner2 dismiss').toBe(true);
+
+    // Re-initialize to confirm localStorage isolation before time passes
+    const banner1Reinit = useDismissableBanner(banner1Id, 0);
+    const banner2Reinit = useDismissableBanner(banner2Id, 5);
+    const banner3Reinit = useDismissableBanner(banner3Id); // Never dismissed this one yet
+
+    expect(banner1Reinit.isVisible.value, 'banner1 reinit').toBe(false);
+    expect(banner2Reinit.isVisible.value, 'banner2 reinit').toBe(false);
+    expect(banner3Reinit.isVisible.value, 'banner3 reinit').toBe(true);
+
+    banner3Reinit.dismiss(); // Now dismiss banner3
+    expect(banner3Reinit.isVisible.value, 'banner3 after its dismiss').toBe(false);
+
+    // Advance time by 6 days (banner2 was 5 day expiry)
+    vi.advanceTimersByTime(1000 * 60 * 60 * 24 * 6);
+
+    const banner1AfterTime = useDismissableBanner(banner1Id, 0);
+    const banner2AfterTime = useDismissableBanner(banner2Id, 5);
+    const banner3AfterTime = useDismissableBanner(banner3Id);
+
+    expect(banner1AfterTime.isVisible.value, 'banner1 after 6 days').toBe(false); // Permanent
+    expect(banner2AfterTime.isVisible.value, 'banner2 after 6 days (expired)').toBe(true); // Temporary, expired
+    expect(banner3AfterTime.isVisible.value, 'banner3 after 6 days').toBe(false); // Permanent
+  });
+
+  it('should handle invalid or missing localStorage data gracefully', () => {
+    // Case 1: Malformed JSON in localStorage
+    localStorage.setItem('banner-bad-json', 'this is not valid json {');
+    const { isVisible: isVisibleBadJson, dismiss: dismissBadJson } =
+      useDismissableBanner('bad-json');
+    // Should default to visible if localStorage parsing fails
+    expect(isVisibleBadJson.value).toBe(true);
+    // Dismissal should still work and overwrite the bad data
+    dismissBadJson();
+    expect(isVisibleBadJson.value).toBe(false);
+    expect(JSON.parse(localStorage.getItem('banner-bad-json') || '{}').dismissed).toBe(true);
+
+    // Case 2: Item exists, dismissed is true, but timestamp is null (e.g. old/corrupted data)
+    // For temporary banners, this should effectively mean it's expired because (currentTime - 0) > expirationDays.
+    localStorage.setItem(
+      `banner-${BANNER_ID_TEMPORARY}`,
+      JSON.stringify({ dismissed: true, timestamp: null })
+    );
+    const { isVisible: isVisibleNoTimestampTemp } = useDismissableBanner(
+      BANNER_ID_TEMPORARY,
+      EXPIRATION_DAYS
+    );
+    expect(isVisibleNoTimestampTemp.value).toBe(true);
+
+    // Case 3: Item exists, dismissed is true, timestamp is null, but it's a permanent banner
+    // Should remain dismissed because expirationDays === 0 check takes precedence.
+    localStorage.setItem(
+      `banner-${BANNER_ID_PERMANENT}`,
+      JSON.stringify({ dismissed: true, timestamp: null })
+    );
+    const { isVisible: isVisibleNoTimestampPerm } = useDismissableBanner(BANNER_ID_PERMANENT, 0);
+    expect(isVisibleNoTimestampPerm.value).toBe(false);
+  });
+});

--- a/tests/unit/vue/composables/useHash.spec.ts
+++ b/tests/unit/vue/composables/useHash.spec.ts
@@ -1,0 +1,297 @@
+// tests/unit/vue/composables/useHash.spec.ts
+/**
+ * Unit tests for useHash composable
+ *
+ * These tests verify that the useHash composable correctly:
+ * - Generates cryptographic hashes with different algorithms
+ * - Manages state during hash generation (isHashing, error)
+ * - Handles edge cases like empty strings, errors, and large inputs
+ */
+
+import { useHash, type HashAlgorithm } from '@/composables/useHash';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+describe('useHash', () => {
+  const originalSubtleDigest = crypto.subtle.digest;
+
+  beforeEach(() => {
+    // No need to store full crypto object as it has only getters
+  });
+
+  afterEach(() => {
+    // Restore original subtle.digest implementation
+    Object.defineProperty(crypto.subtle, 'digest', {
+      value: originalSubtleDigest,
+      configurable: true,
+    });
+  });
+
+  it('should generate SHA-256 hash correctly', async () => {
+    const { generateHash, isHashing, error } = useHash();
+    const input = 'test message';
+
+    // Known SHA-256 hash of 'test message'
+    const expectedHash = '3f0a377ba0a4a460ecb616f6507ce0d8cfa3e704025d4fda3ed0c5ca05468728';
+
+    const result = await generateHash(input);
+
+    expect(result).toBe(expectedHash);
+    expect(isHashing.value).toBe(false);
+    expect(error.value).toBeNull();
+  });
+
+  it('should set isHashing to true during hash generation', async () => {
+    const { generateHash, isHashing } = useHash();
+
+    // Mock subtle.digest to delay completion
+    const mockDigest = vi.fn().mockImplementation(() => {
+      return new Promise((resolve) => {
+        setTimeout(() => {
+          // Create a mock hash buffer
+          const buffer = new ArrayBuffer(32);
+          const view = new Uint8Array(buffer);
+          for (let i = 0; i < 32; i++) {
+            view[i] = i;
+          }
+          resolve(buffer);
+        }, 10);
+      });
+    });
+
+    // Replace crypto.subtle.digest with our mock implementation
+    Object.defineProperty(crypto.subtle, 'digest', {
+      value: mockDigest,
+      configurable: true,
+    });
+
+    // Start hash generation but don't await it yet
+    const hashPromise = generateHash('test');
+
+    // isHashing should be true while the promise is pending
+    expect(isHashing.value).toBe(true);
+
+    // Wait for hash to complete
+    await hashPromise;
+
+    // isHashing should be false after completion
+    expect(isHashing.value).toBe(false);
+    expect(mockDigest).toHaveBeenCalledWith('SHA-256', expect.any(Object));
+  });
+
+  it('should support different hash algorithms', async () => {
+    const { generateHash } = useHash();
+    const input = 'test message';
+
+    // Mock the digest function for different algorithms
+    const mockDigest = vi.fn().mockImplementation((algorithm) => {
+      const mockHashResults = {
+        'SHA-1': new Uint8Array([1, 2, 3, 4, 5]),
+        'SHA-256': new Uint8Array([6, 7, 8, 9, 10]),
+        'SHA-384': new Uint8Array([11, 12, 13, 14, 15]),
+        'SHA-512': new Uint8Array([16, 17, 18, 19, 20])
+      };
+
+      return Promise.resolve(mockHashResults[algorithm as keyof typeof mockHashResults].buffer);
+    });
+
+    // Replace crypto.subtle.digest with our mock implementation
+    Object.defineProperty(crypto.subtle, 'digest', {
+      value: mockDigest,
+      configurable: true,
+    });
+
+    await generateHash(input, 'SHA-1');
+    expect(mockDigest).toHaveBeenCalledWith('SHA-1', expect.any(Object));
+
+    await generateHash(input, 'SHA-256');
+    expect(mockDigest).toHaveBeenCalledWith('SHA-256', expect.any(Object));
+
+    await generateHash(input, 'SHA-384');
+    expect(mockDigest).toHaveBeenCalledWith('SHA-384', expect.any(Object));
+
+    await generateHash(input, 'SHA-512');
+    expect(mockDigest).toHaveBeenCalledWith('SHA-512', expect.any(Object));
+  });
+
+  it('should reject invalid hash algorithms', async () => {
+    const { generateHash, error } = useHash();
+
+    // @ts-expect-error - Testing invalid algorithm which TypeScript would normally prevent
+    const result = await generateHash('test', 'INVALID-ALGORITHM' as HashAlgorithm);
+
+    expect(result).toBeNull();
+    expect(error.value).not.toBeNull();
+    expect(error.value).toContain('algorithm');
+  });
+
+  it('should handle errors during hash generation', async () => {
+    const { generateHash, error } = useHash();
+
+    // Mock crypto.subtle.digest to throw an error
+    const mockError = new Error('Crypto operation failed');
+    Object.defineProperty(crypto.subtle, 'digest', {
+      value: vi.fn().mockRejectedValue(mockError),
+      configurable: true,
+    });
+
+    const result = await generateHash('test');
+
+    expect(result).toBeNull();
+    expect(error.value).toBe('Crypto operation failed');
+  });
+
+  it('should handle non-Error objects thrown during hash generation', async () => {
+    const { generateHash, error } = useHash();
+
+    // Mock crypto.subtle.digest to throw a non-Error object
+    Object.defineProperty(crypto.subtle, 'digest', {
+      value: vi.fn().mockRejectedValue('String error message'),
+      configurable: true,
+    });
+
+    const result = await generateHash('test');
+
+    expect(result).toBeNull();
+    expect(error.value).toBe('String error message');
+  });
+
+  it('should generate consistent hash for the same input', async () => {
+    const { generateHash } = useHash();
+    const input = 'consistent input';
+
+    const hash1 = await generateHash(input);
+    const hash2 = await generateHash(input);
+
+    expect(hash1).toBe(hash2);
+  });
+
+  it('should generate different hashes for different inputs', async () => {
+    const { generateHash } = useHash();
+
+    const hash1 = await generateHash('input1');
+    const hash2 = await generateHash('input2');
+
+    expect(hash1).not.toBe(hash2);
+    expect(hash1?.length).toBe(64); // SHA-256 output should be 64 hex chars
+    expect(hash2?.length).toBe(64);
+  });
+
+  it('should convert empty string input correctly', async () => {
+    const { generateHash } = useHash();
+
+    // SHA-256 hash of empty string
+    const emptyStringHash = 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855';
+
+    const result = await generateHash('');
+
+    expect(result).toBe(emptyStringHash);
+  });
+
+  it('should handle null and undefined inputs', async () => {
+    const { generateHash } = useHash();
+
+    // Define known values for comparison
+    const emptyStringHash = await generateHash('');
+    const nullStringHash = await generateHash('null');
+
+    // @ts-expect-error - Testing null input which TypeScript would normally prevent
+    const nullResult = await generateHash(null);
+    // Implementation treats null as "null" string
+    expect(nullResult).not.toBeNull();
+    expect(nullResult?.length).toBe(64); // Valid SHA-256 hash
+    expect(nullResult).toBe(nullStringHash); // Should match hash of "null" string
+    expect(nullResult).not.toBe(emptyStringHash); // Should not match empty string hash
+
+    // @ts-expect-error - Testing undefined input which TypeScript would normally prevent
+    const undefinedResult = await generateHash(undefined);
+    // Implementation treats undefined as empty string
+    expect(undefinedResult).toBe(emptyStringHash); // Should match empty string hash
+    expect(undefinedResult).not.toBe(nullResult); // Should not match null result
+  });
+
+  it('should handle very large input strings', async () => {
+    const { generateHash } = useHash();
+
+    // Create a large string (1MB+)
+    const largeString = 'x'.repeat(1024 * 1024 + 100); // Just over 1MB
+
+    const result = await generateHash(largeString);
+
+    // We just check that it returns a valid hash (64 hex chars for SHA-256)
+    expect(result).not.toBeNull();
+    expect(result?.length).toBe(64);
+  });
+
+  it('should properly handle Unicode characters', async () => {
+    const { generateHash } = useHash();
+    const unicodeInput = '👋 Hello, 世界!';
+
+    // First hash with Unicode characters
+    const hash1 = await generateHash(unicodeInput);
+
+    // Verify the hash is not null and has the expected length for SHA-256 (64 hex chars)
+    expect(hash1).not.toBeNull();
+    expect(hash1?.length).toBe(64);
+
+    // Generate the hash again with the same input
+    const hash2 = await generateHash(unicodeInput);
+
+    // Verify the hashes match
+    expect(hash1).toBe(hash2);
+  });
+
+  it('should maintain proper error state between multiple calls', async () => {
+    const { generateHash, error, isHashing } = useHash();
+
+    // Mock crypto.subtle.digest to throw an error
+    Object.defineProperty(crypto.subtle, 'digest', {
+      value: vi.fn().mockRejectedValue(new Error('First error')),
+      configurable: true,
+    });
+
+    const result1 = await generateHash('test');
+    expect(result1).toBeNull();
+    expect(error.value).toBe('First error');
+    expect(isHashing.value).toBe(false);
+
+    // Change the mock to succeed
+    Object.defineProperty(crypto.subtle, 'digest', {
+      value: vi.fn().mockImplementation(() => {
+        const buffer = new ArrayBuffer(32);
+        const view = new Uint8Array(buffer);
+        for (let i = 0; i < 32; i++) {
+          view[i] = i;
+        }
+        return Promise.resolve(buffer);
+      }),
+      configurable: true,
+    });
+
+    const result2 = await generateHash('test');
+    expect(result2).not.toBeNull();
+    expect(error.value).toBeNull(); // Error should be cleared after successful call
+    expect(isHashing.value).toBe(false);
+  });
+
+  it('should handle concurrent hash operations correctly', async () => {
+    const { generateHash, isHashing } = useHash();
+
+    // Create multiple hash operations without awaiting them
+    const hashPromise1 = generateHash('data1');
+    const hashPromise2 = generateHash('data2');
+
+    // isHashing should be true while operations are in progress
+    expect(isHashing.value).toBe(true);
+
+    // Complete all hash operations
+    const [result1, result2] = await Promise.all([hashPromise1, hashPromise2]);
+
+    // Verify results
+    expect(result1).not.toBeNull();
+    expect(result2).not.toBeNull();
+    expect(result1).not.toBe(result2);
+
+    // isHashing should be false when all complete
+    expect(isHashing.value).toBe(false);
+  });
+});


### PR DESCRIPTION


## PR Description
This PR introduces a new dismissable global broadcast banner feature that allows site-wide announcements to be shown to users, with the following key improvements:

### Features Added
- Implemented dismissable banner system with localStorage persistence
- Created `useDismissableBanner` composable for reusable banner management
- Added `useHash` composable for content-based banner ID generation using Web Crypto API
- Set 7-day expiration for dismissed broadcasts (configurable)
- Added comprehensive unit tests for new composables
- Updated `GlobalBroadcast.vue` to use the new dismissable banner system
- Added sanitization of HTML content in global broadcasts

### Technical Improvements
- Replaced inline SVGs with `OIcon` component for better maintainability
- Created `MicroFooter` component for smaller footprint UI elements
- Updated CopyButton styling and functionality
- Enhanced burn button and metadata display on secret pages
- Fixed router-link behavior in BurnSecret inactive state

### Code Quality
- Added comprehensive unit tests for useHash and useDismissableBanner
- Improved code organization by moving ID generation to appropriate composables
- Applied consistent formatting throughout modified components

### Bug Fixes
- Fixed language toggle height when not logged in
- Fixed focus effects on metadata page
- Fixed metadata display edge case for standalone burn page

### Versioning
- Version bump to v0.21.7

The banner system now respects user preferences without requiring server-side state management.