### PR TITLE
fix: when AUTH_DISABLED is true, the colonels map is undefined

### DIFF
--- a/lib/onetime/helpers/initialization_helper.rb
+++ b/lib/onetime/helpers/initialization_helper.rb
@@ -77,7 +77,7 @@ module Onetime
       site_config = OT.conf.fetch(:site) # if :site is missing we got real problems
       email_config = OT.conf.fetch(:emailer, {})
       redis_info = Familia.redis.info
-      colonels = site_config.dig(:authentication, :colonels)
+      colonels = site_config.dig(:authentication, :colonels) || []
 
       OT.li "---  ONETIME #{OT.mode} v#{OT::VERSION.inspect}  #{'---' * 3}"
       OT.li "system: #{@sysinfo.platform} (#{RUBY_ENGINE} #{RUBY_VERSION} in #{OT.env})"


### PR DESCRIPTION
### **User description**
Since 0.21.4, when running OTS with AUTH_DISABLED = true, the app won't start, and gives the error below: 

```
ots-1    | [Wed May  7 19:30:44 UTC 2025] INFO: Running entrypoint.sh...
ots-1    | INFO: Skipping bundle install. Use BUNDLE_INSTALL=true to run it.
ots-1    | Starting Thin server on port 3000
ots-1    | I(1746646245): Registering 3 application(s)
ots-1    | I(1746646245):   V1::Application for /api/v1
ots-1    | I(1746646245):   V2::Application for /api/v2
ots-1    | I(1746646245):   Core::Application for /
ots-1    | E(1746646245): Unexpected error `undefined method 'empty?' for false` (NoMethodError)
ots-1    | I(1746646245): ---  ONETIME app v0.21.4 (1745871764)  ---------
ots-1    | I(1746646245): system: ruby-unix-linux-unknown (ruby 3.4.3 in production)
ots-1    | I(1746646245): config: /app/etc/config.yaml
ots-1    | I(1746646245): redis: 8.0.0 (redis://redis:6379/0)
ots-1    | I(1746646245): familia: v1.1.0-rc1
ots-1    | I(1746646245): i18n: false
ots-1    | I(1746646245): diagnotics: false
ots-1 exited with code 99
```

This is because the `:colonels` field is not defined with `AUTH_DISABLED` is true. 

Fixed by setting a default value of `[]` for `colonels`.


___

### **PR Type**
Bug fix


___

### **Description**
- Fixes crash when `AUTH_DISABLED` is true by defaulting `colonels` to empty array

- Ensures `colonels` variable is always defined in log banner


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>initialization_helper.rb</strong><dd><code>Default colonels to empty array to prevent errors</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/onetime/helpers/initialization_helper.rb

<li>Sets <code>colonels</code> to empty array if not present in config<br> <li> Prevents NoMethodError when <code>AUTH_DISABLED</code> is true


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/1382/files#diff-8140c9cc0a5f92269ab47e67156f02251b8192f1a9087846641d8ae5a7258153">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>