### PR TITLE
Fix: Regenerate pnpm-lock.yaml

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7033,7 +7033,7 @@ snapshots:
       '@codemirror/lang-yaml': 6.1.2
       '@codemirror/theme-one-dark': 6.1.2
       '@headlessui/vue': 1.7.23(vue@3.5.13(typescript@5.8.3))
-      '@intlify/core': 11.1.3
+      '@intlify/core': 11.1.5
       '@prettier/plugin-ruby': 4.0.4(prettier@3.5.3)
       '@sentry/browser': 9.17.0
       '@sentry/core': 9.17.0
@@ -7046,7 +7046,7 @@ snapshots:
       client: link:@vitejs/plugin-vue/client
       codemirror: 6.0.1
       date-fns: 4.1.0
-      dompurify: 3.2.5
+      dompurify: 3.2.6
       focus-trap: 7.6.4
       focus-trap-vue: 4.0.3(focus-trap@7.6.4)(vue@3.5.13(typescript@5.8.3))
       highlight.js: 11.11.1


### PR DESCRIPTION
Fixed by:
- Running `pnpm install --no-frozen-lockfile` to regenerate the lockfile
- Committing the updated `pnpm-lock.yaml`

The lockfile now correctly resolves `@intlify/core` to version `11.1.5`, matching the `package.json` declaration. This will allow the Docker build to proceed without the dependency resolution error.