### PR TITLE
Eliminate support host setting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,7 +31,6 @@ STDOUT_SYNC=true
 ONETIME_DEBUG="false"
 RACK_ENV=production
 
-SUPPORT_HOST=
 COLONEL="CHANGEME@EXAMPLE.com"
 
 # Authentication settings

--- a/apps/web/frontend/views/serializers/config_serializer.rb
+++ b/apps/web/frontend/views/serializers/config_serializer.rb
@@ -25,7 +25,6 @@ module Frontend
 
         output[:ui]             = site.dig(:interface, :ui)
         output[:authentication] = site.fetch(:authentication, nil)
-        output[:support_host]   = site.dig(:support, :host)
         output[:secret_options] = site[:secret_options]
         output[:site_host]      = site[:host]
         regions                 = site[:regions] || {}
@@ -77,7 +76,6 @@ module Frontend
             regions_enabled: nil,
             secret_options: nil,
             site_host: nil,
-            support_host: nil,
             ui: nil,
           }
         end

--- a/etc/README.md
+++ b/etc/README.md
@@ -4,23 +4,21 @@ This directory contains configuration files and processing logic for the applica
 
 ## Directory Structure
 
-- **Configuration Data**: YAML files defining application behavior
-- **Processing Logic**: Ruby code that transforms configuration into runtime state
-- **Validation**: JSON Schema ensuring configuration correctness
+- `etc/` - **Configuration Data**: YAML files defining application behavior.
+- `etc/init.d` - **Processing Logic**: Ruby code that transforms configuration into runtime state.
+- `etc/defaults` - **Default Config Files**: Used as the starting point for new installs.
+- `etc/examples` - **Example Snippets**: Individual sections of the configuration demonstrating specific features.
 
 ## Files
 
-### Core Configuration
-- `examples/config.example.yaml` - Template with example values
+### Core/Static Configuration
+- `defaults/config.defaults.yaml` - Template with example values
 - `config.yaml` - Main application configuration
 - `config.schema.json` - Validation schema and defaults
 
-### System Configuration
+### System/Dynamic Configuration
 - `system_settings.example.yaml` - Default system settings
-- `redis.conf` - Redis server configuration
 
-### Application Data
-- `fortunes` - Messages used in signup verification process
 
 ## Configuration Schema
 
@@ -46,4 +44,4 @@ JSON::Validator.validate!(schema, config, insert_defaults: true)
 import schema from '../etc/config.schema.json'
 ```
 
-The Ruby backend uses the schema at startup for validation and default application. The Vue frontend references it for API interactions and the Colonel administrative interface.
+The Ruby backend uses the schema at startup to validate the static configuration (config.yaml) and to apply default values where needed. The Vue frontend references it for API interactions and the Colonel administrative interface.

--- a/etc/defaults/system_settings.defaults.yaml
+++ b/etc/defaults/system_settings.defaults.yaml
@@ -1,3 +1,4 @@
+---
 user_interface:
   # Controls whether the web interface is enabled
   # When false, only a basic explanation page is shown

--- a/src/components/modals/settings/JurisdictionInfo.vue
+++ b/src/components/modals/settings/JurisdictionInfo.vue
@@ -4,7 +4,6 @@ import OIcon from '@/components/icons/OIcon.vue';
 
 defineProps<{
   jurisdiction: Jurisdiction;
-  supportHost?: string;
 }>();
 </script>
 
@@ -37,13 +36,13 @@ defineProps<{
 
       <p class="m-0 text-center text-gray-600 dark:text-gray-300 sm:text-left">
         {{ $t('to-understand-the-specific-regulations-and-prote') }}
-        <a
-          :href="`${supportHost}/docs`"
+        <RouterLink
+          to="/docs"
           class="font-medium text-brand-600 hover:text-brand-500 dark:text-brand-400 dark:hover:text-brand-300"
           target="_blank"
           rel="noopener noreferrer">
           {{ $t('review-our-documentation') }}
-        </a>
+        </RouterLink>
         or
         <RouterLink
           to="/feedback"

--- a/src/components/modals/settings/JurisdictionTab.vue
+++ b/src/components/modals/settings/JurisdictionTab.vue
@@ -8,7 +8,6 @@ import JurisdictionInfo from './JurisdictionInfo.vue';
 import JurisdictionList from './JurisdictionList.vue';
 
 const cust = WindowService.get('cust');
-const supportHost = WindowService.get('support_host');
 
 const jurisdictionStore = useJurisdictionStore();
 const currentJurisdiction = computed(() => jurisdictionStore.getCurrentJurisdiction);
@@ -73,7 +72,6 @@ const customerId = computed(() => cust?.custid);
           <JurisdictionInfo
             v-if="currentJurisdiction"
             :jurisdiction="currentJurisdiction"
-            :support-host="supportHost"
           />
         </div>
       </div>

--- a/src/components/secrets/metadata/MetadataFAQ.vue
+++ b/src/components/secrets/metadata/MetadataFAQ.vue
@@ -2,9 +2,6 @@
 
 <script setup lang="ts">
   import { Metadata, MetadataDetails } from '@/schemas/models';
-  import { WindowService } from '@/services/window.service';
-
-  const windowProps = WindowService.getMultiple(['support_host']);
 
   interface Props {
     record: Metadata;
@@ -119,17 +116,16 @@
     <div class="mt-6 text-xs">
       <p
         >{{ $t('web.private.have-more-questions-visit-our') }}
-        <a
-          :href="`${windowProps.support_host}/docs`"
+        <RouterLink
+          to="/docs"
           class="text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300 hover:underline"
-          >documentation</a
+          >documentation</RouterLink
         >
         or
-        <a
-          href="/feedback"
+        <RouterLink
+          to="/feedback"
           class="text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300 hover:underline"
-          >{{ $t('web.private.send-feedback') }}</a
-        >.
+          >{{ $t('web.private.send-feedback') }}</RouterLink>.
       </p>
     </div>
   </div>

--- a/src/types/declarations/window.d.ts
+++ b/src/types/declarations/window.d.ts
@@ -116,7 +116,6 @@ export interface OnetimeWindow {
   secret_options: SecretOptions;
 
   available_plans: AvailablePlans;
-  support_host?: string;
 
   plan: Plan;
   is_paid: boolean;

--- a/tests/unit/ruby/config.test.yaml
+++ b/tests/unit/ruby/config.test.yaml
@@ -70,8 +70,6 @@
     # application itself is responsible for handling multiple domains.
     :cluster:
       :type: <%= ENV['CLUSTER_TYPE'] || nil %>
-  :support:
-    :host: <%= ENV['SUPPORT_HOST'] || nil %>
 :redis:
   :uri: <%= ENV['REDIS_URL'] || 'redis://CHANGEME@127.0.0.1:2121/0' %>
   :dbs:

--- a/tests/unit/ruby/rspec/apps/web/frontend/views/base_json_spec.rb
+++ b/tests/unit/ruby/rspec/apps/web/frontend/views/base_json_spec.rb
@@ -69,7 +69,6 @@ RSpec.xdescribe Frontend::Views::BaseView, "JSON Output" do
             },
             plans: { enabled: authenticated_json["plans_enabled"] },
             secret_options: authenticated_json["secret_options"],
-            support: { host: authenticated_json["support_host"] },
           },
           development: {
             enabled: true,
@@ -204,7 +203,6 @@ RSpec.xdescribe Frontend::Views::BaseView, "JSON Output" do
               },
               plans: { enabled: not_authenticated_json["plans_enabled"] },
               secret_options: not_authenticated_json["secret_options"],
-              support: { host: not_authenticated_json["support_host"] },
             },
             development: {
               enabled: true,

--- a/tests/unit/ruby/rspec/support/window-authenticated-1187.json
+++ b/tests/unit/ruby/rspec/support/window-authenticated-1187.json
@@ -68,7 +68,6 @@
     "ttl_options": [60, 300, 1800, 3600, 14400, 43200, 86400, 259200, 604800, 1209600, 2592000]
   },
   "site_host": "dev.onetime.dev",
-  "support_host": "https://docs.onetime.dev",
   "ui": { "enabled": false },
   "canonical_domain": "dev.onetime.dev",
   "display_domain": "dev.onetime.dev",

--- a/tests/unit/ruby/rspec/support/window-authenticated-develop.json
+++ b/tests/unit/ruby/rspec/support/window-authenticated-develop.json
@@ -76,7 +76,6 @@
   "i18n_enabled": true,
   "d9s_enabled": false,
   "incoming_recipient": null,
-  "support_host": "https://docs.onetime.dev",
   "secret_options": {
     "default_ttl": 604800.0,
     "ttl_options": [60, 300, 1800, 3600, 14400, 43200, 86400, 259200, 604800, 1209600, 2592000]

--- a/tests/unit/ruby/rspec/support/window-notauthenticated-1187.json
+++ b/tests/unit/ruby/rspec/support/window-notauthenticated-1187.json
@@ -50,7 +50,6 @@
     "ttl_options": [60, 300, 1800, 3600, 14400, 43200, 86400, 259200, 604800, 1209600, 2592000]
   },
   "site_host": "dev.onetime.dev",
-  "support_host": "https://docs.onetime.dev",
   "ui": { "enabled": false },
   "canonical_domain": "dev.onetime.dev",
   "display_domain": "dev.onetime.dev",

--- a/tests/unit/ruby/rspec/support/window-notauthenticated-develop.json
+++ b/tests/unit/ruby/rspec/support/window-notauthenticated-develop.json
@@ -58,7 +58,6 @@
   "i18n_enabled": true,
   "d9s_enabled": false,
   "incoming_recipient": null,
-  "support_host": "https://docs.onetime.dev",
   "secret_options": {
     "default_ttl": 604800.0,
     "ttl_options": [60, 300, 1800, 3600, 14400, 43200, 86400, 259200, 604800, 1209600, 2592000]

--- a/tests/unit/vue/fixtures/window.fixture.ts
+++ b/tests/unit/vue/fixtures/window.fixture.ts
@@ -39,7 +39,6 @@ export const stateFixture: OnetimeWindow = {
     ttl_options: [60, 3600, 86400, 604800, 1209600, 2592000],
   },
   available_plans: {},
-  support_host: 'https://docs.onetime.co',
   plan: {
     identifier: 'anonymous',
     planid: 'anonymous',


### PR DESCRIPTION
The settings has been... eliminated.

It was a stop-gap measure for linking to a documentation site in a way that wasn't specific to onetimesecret.com. Since the footer links are now configurable (along with similar new functionality), support_host is no longer needed. And that is why it has been fully... eliminated.

Fixes #1461.