### PR TITLE
Remove sysinfo dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,6 @@ gem 'familia', '~> 1.2.0'
 gem 'gibbler'
 gem 'otto', '~> 1.1.0.pre.alpha4'
 gem 'storable'
-gem 'sysinfo'
 gem 'tty-table', '~> 0.12.0'
 gem 'uri-redis', '~> 1.3.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -315,7 +315,6 @@ DEPENDENCIES
   storable
   stringio (~> 3.1.6)
   stripe
-  sysinfo
   syslog (~> 0.3.0)
   thin
   truemail

--- a/apps/web/core/views/serializers/system_serializer.rb
+++ b/apps/web/core/views/serializers/system_serializer.rb
@@ -19,11 +19,7 @@ module Core
 
         output[:ot_version] = OT::VERSION.to_s
         output[:ot_version_long] = OT::VERSION.inspect
-        output[:ruby_version] = if OT.sysinfo.nil?
-          RUBY_VERSION.to_s
-        else
-           "#{OT.sysinfo.vm}-#{OT.sysinfo.ruby.join}"
-        end
+        output[:ruby_version] = RUBY_VERSION.to_s
 
         output[:shrimp] = view_vars[:shrimp]
         output[:nonce] = view_vars[:nonce]

--- a/lib/onetime/boot.rb
+++ b/lib/onetime/boot.rb
@@ -1,16 +1,13 @@
 # lib/onetime/boot.rb
 
-require 'sysinfo'
-
 require_relative 'initializers'
 
 module Onetime
   module Initializers
-    @sysinfo = nil
     @conf = nil
     @ready = nil
 
-    attr_reader :conf, :instance, :sysinfo
+    attr_reader :conf, :instance
 
     # Boot reads and interprets the configuration and applies it to the
     # relevant features and services. Must be called after applications
@@ -38,12 +35,10 @@ module Onetime
       # doesn't get enabled even after loading config.
       OT.d9s_enabled = false
 
-      @sysinfo ||= SysInfo.new.freeze
-
       # Sets a unique SHA hash every time this process starts. In a multi-
       # threaded environment (e.g. with Puma), this could different for
       # each thread.
-      @instance ||= [OT.sysinfo.hostname, OT.sysinfo.user, Process.pid, OT::VERSION.to_s, OT.now.to_i].gibbler.freeze
+      @instance ||= [Process.pid, OT::VERSION.to_s, OT.now.to_i].gibbler.freeze
 
       # Normalize environment variables prior to loading the YAML config
       OT::Config.before_load

--- a/lib/onetime/initializers/print_log_banner.rb
+++ b/lib/onetime/initializers/print_log_banner.rb
@@ -80,7 +80,7 @@ module Onetime
     # Builds system information section rows
     def build_system_section(redis_info)
       system_rows = [
-        ['System', "#{@sysinfo.platform} (#{RUBY_ENGINE} #{RUBY_VERSION} in #{OT.env})"],
+        ['System', "#{RUBY_ENGINE} #{RUBY_VERSION} in #{OT.env}"],
         ['Config', OT::Config.path],
         ['Redis', "#{redis_info['redis_version']} (#{Familia.uri.serverid})"],
         ['Familia', "v#{Familia::VERSION}"],

--- a/spec/apps/web/views/base_json_spec.rb
+++ b/spec/apps/web/views/base_json_spec.rb
@@ -98,11 +98,6 @@ RSpec.xdescribe Core::Views::BaseView, "JSON Output" do
         # Mock version info - Use double instead of OpenStruct
         allow(OT).to receive(:global_banner).and_return(nil)
 
-        sysinfo_mock = double('SysInfo')
-        allow(sysinfo_mock).to receive(:vm).and_return('ruby')
-        allow(sysinfo_mock).to receive(:ruby).and_return(['341'])
-        allow(OT).to receive(:sysinfo).and_return(sysinfo_mock)
-
         allow(OT).to receive(:VERSION).and_return("0.20.4 ()")
 
         # For plans
@@ -236,11 +231,6 @@ RSpec.xdescribe Core::Views::BaseView, "JSON Output" do
 
         # Mock version info - Use double instead of OpenStruct
         allow(OT).to receive(:global_banner).and_return(nil)
-
-        sysinfo_mock = double('SysInfo')
-        allow(sysinfo_mock).to receive(:vm).and_return('ruby')
-        allow(sysinfo_mock).to receive(:ruby).and_return(['341'])
-        allow(OT).to receive(:sysinfo).and_return(sysinfo_mock)
 
         allow(OT).to receive(:VERSION).and_return("0.20.4 (plop)")
 

--- a/spec/apps/web/views/base_spec.rb
+++ b/spec/apps/web/views/base_spec.rb
@@ -13,7 +13,6 @@ RSpec.describe Core::Views::BaseView do
 
   before(:all) do
     OT::Plan.load_plans!
-    @sysinfo ||= SysInfo.new.freeze
 
     described_class.use_serializers(
       Core::Views::ConfigSerializer,

--- a/spec/onetime/config/after_load_spec.rb
+++ b/spec/onetime/config/after_load_spec.rb
@@ -25,7 +25,6 @@ RSpec.describe "Onetime boot configuration process" do
     @original_mode = Onetime.mode
     @original_env = Onetime.env
     @original_emailer = Onetime.instance_variable_get(:@emailer)
-    @original_sysinfo = Onetime.instance_variable_get(:@sysinfo)
     @original_instance = Onetime.instance_variable_get(:@instance)
     @original_d9s_enabled = Onetime.d9s_enabled
 
@@ -77,7 +76,6 @@ RSpec.describe "Onetime boot configuration process" do
     Onetime.env = @original_env
     Onetime.instance_variable_set(:@conf, nil)
     Onetime.instance_variable_set(:@emailer, @original_emailer)
-    Onetime.instance_variable_set(:@sysinfo, @original_sysinfo)
     Onetime.instance_variable_set(:@instance, @original_instance)
     Onetime.d9s_enabled = @original_d9s_enabled
 
@@ -133,10 +131,7 @@ RSpec.describe "Onetime boot configuration process" do
         expect(Onetime).to have_received(:connect_databases)
       end
 
-      it 'initializes system info' do
-        Onetime.boot!(:test)
-        expect(Onetime.sysinfo).not_to be_nil
-      end
+
 
       it 'generates a unique instance identifier' do
         Onetime.boot!(:test)

--- a/spec/onetime/initializers/boot_part1_spec.rb
+++ b/spec/onetime/initializers/boot_part1_spec.rb
@@ -29,7 +29,6 @@ RSpec.describe "Onetime::Config during Onetime.boot!" do
     Onetime.instance_variable_set(:@fallback_locale, nil)
     Onetime.instance_variable_set(:@locales, nil)
     Onetime.instance_variable_set(:@instance, nil)
-    Onetime.instance_variable_set(:@sysinfo, nil)
     Onetime.instance_variable_set(:@emailer, nil)
     Onetime.instance_variable_set(:@global_secret, nil)
     Onetime.instance_variable_set(:@global_banner, nil) # Reset global_banner state
@@ -40,11 +39,6 @@ RSpec.describe "Onetime::Config during Onetime.boot!" do
     allow(OT::Config).to receive(:after_load).and_call_original
 
     allow(Familia).to receive(:uri=)
-
-    # There are testcases in the other boot test files that confirm sysinfo
-    # is frozen after being set. Here we mock it up.
-    sysinfo_double = instance_double(SysInfo, hostname: 'testhost', user: 'testuser', platform: 'testplatform').as_null_object
-    allow(Onetime).to receive(:sysinfo).and_return(sysinfo_double)
 
     allow(Gibbler).to receive(:secret).and_return(nil)
     allow(Gibbler).to receive(:secret=)
@@ -359,11 +353,6 @@ RSpec.describe "Onetime::Config during Onetime.boot!" do
         expect(Onetime.locales.keys).to eq(['en']) # Only default locale 'en' should be loaded
         expect(Onetime.fallback_locale).to be_nil
       end
-    end
-
-    it "initializes Onetime.sysinfo and freezes it" do
-      Onetime.boot!(:test)
-      expect(Onetime.sysinfo.hostname).to eq('testhost') # Check if it's the mocked one
     end
 
     it "initializes Onetime.instance and freezes it" do

--- a/spec/onetime/initializers/boot_part2_spec.rb
+++ b/spec/onetime/initializers/boot_part2_spec.rb
@@ -34,7 +34,6 @@ RSpec.describe "Onetime global state after boot" do
     Onetime.instance_variable_set(:@locale, nil)
     Onetime.instance_variable_set(:@locales, nil)
     Onetime.instance_variable_set(:@instance, nil)
-    Onetime.instance_variable_set(:@sysinfo, nil)
     Onetime.instance_variable_set(:@global_banner, nil)
     OT::Utils.instance_variable_set(:@fortunes, nil)
 
@@ -120,15 +119,7 @@ RSpec.describe "Onetime global state after boot" do
     end
 
     context "regarding system information" do
-      it "initializes and freezes Onetime.sysinfo" do
-        Onetime.boot!(:test)
 
-        expect(Onetime.sysinfo).not_to be_nil
-        expect(Onetime.sysinfo).to be_frozen
-
-        version = Onetime.sysinfo.ruby.join('.')
-        expect(version).to eq(RUBY_VERSION)
-      end
 
       it "initializes and freezes Onetime.instance" do
         Onetime.boot!(:test)


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Remove sysinfo dependency from codebase

- Simplify Ruby version reporting to use RUBY_VERSION

- Update instance identifier generation logic

- Clean up test mocks and system information handling


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["sysinfo dependency"] -- "removed" --> B["RUBY_VERSION constant"]
  C["system serializer"] -- "simplified" --> D["direct Ruby version"]
  E["boot process"] -- "updated" --> F["streamlined instance ID"]
  G["test mocks"] -- "cleaned up" --> H["simplified test setup"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>system_serializer.rb</strong><dd><code>Simplify Ruby version serialization logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/1580/files#diff-d86a4dd15d890e7dc830cde7412375302c09146f4f735bc4e7c2d2ae9c7c12dc">+1/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>boot.rb</strong><dd><code>Remove sysinfo initialization and dependency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/1580/files#diff-65e08ff06f3b888e6ee7b0c7df20e80d0ffb98792a6f6db4d9b6001e32516284">+2/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>print_log_banner.rb</strong><dd><code>Update system information display format</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/1580/files#diff-922654988f91aa736c5c182a6659a93e261e91510368718309560aa959dc7b9a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>base_json_spec.rb</strong><dd><code>Remove sysinfo mocks from tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/1580/files#diff-5864a57b6c2bb76f12cbae40be865b2e0e3dad232256841dd76daff1c9e2d33d">+0/-10</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>base_spec.rb</strong><dd><code>Clean up sysinfo test initialization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/1580/files#diff-1b24b3e9a8d0ce09c98067e469cbf1912779c5242bfd51b795f8116e37427f9a">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>after_load_spec.rb</strong><dd><code>Remove sysinfo state management from tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/1580/files#diff-a1c69b1bb9fbafb8dfc824791857a274b0b0f0530b8bc7c1e6cf6ee90d8a5c24">+1/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>boot_part1_spec.rb</strong><dd><code>Remove sysinfo test cases and mocks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/1580/files#diff-cf987e9f1d2a592fbcd5bc62235ebcb9cbbe6448594cdae7ef2a728a8ef0b05a">+0/-11</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>boot_part2_spec.rb</strong><dd><code>Clean up sysinfo-related test specifications</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/1580/files#diff-e0cf6123372e56948e942208465176567f909aab512990f3cbdaea84f01f397b">+0/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Dependencies</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>Gemfile</strong><dd><code>Remove sysinfo gem dependency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/1580/files#diff-d09ea66f8227784ff4393d88a19836f321c915ae10031d16c93d67e6283ab55f">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

