### PR TITLE
Use Valkey in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,11 +58,9 @@ jobs:
         ruby: ['3.4', '3.5']
         continue-on-error: [false]
 
-    # Make redis available for running the tryouts
     services:
       redis:
-        image: redis:7.4-bookworm@sha256:b52fce7a50c718c6836eef354f19428a9c9a6802379da6eb8a23853152e23f89
-        # Set health checks to wait until redis has started
+        image: ghcr.io/valkey-io/valkey:8.1.3-bookworm@sha256:93381a084ce82085bf2fb78f97661301577eee0df04fef64a6d14a743b858328
         options: >-
           --health-cmd "redis-cli ping"
           --health-interval 10s

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,8 @@ name: CI
 # "rel/", pull requests on main/develop/feature/* branches, and manual dispatch.
 #
 # The workflow has jobs for:
-# - Ruby testing (RSpec and tryouts) across multiple Ruby versions
+# - Ruby RSpec testing across multiple Ruby versions
+# - Ruby tryouts testing across multiple Ruby versions
 # - TypeScript testing (Vitest) and validation (linting, type-checking)
 #
 # This workflow ensures comprehensive testing across the full stack.
@@ -36,7 +37,7 @@ permissions:
   contents: read
 
 jobs:
-  test-ruby:
+  test-ruby-rspec:
     timeout-minutes: 15 # prevent hung jobs
 
     # Can also be set to `self-hosted` if worker is running. Possible
@@ -67,10 +68,6 @@ jobs:
           --health-timeout 3s
           --health-retries 5
         ports:
-          # https://docs.github.com/en/actions/using-containerized-services/creating-redis-service-containers#running-jobs-in-containers
-          # Maps port 6379 on service container to 2121 on the host to
-          # match the port we use in dev which helps us avoid clobbering
-          # our dev redis instances.
           - 2121:6379
 
     steps:
@@ -82,7 +79,6 @@ jobs:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
 
-      # Add Node.js setup to Ruby job
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -123,15 +119,66 @@ jobs:
       - name: Generate job summary
         if: always()
         run: |
-          echo "## Test Results" >> $GITHUB_STEP_SUMMARY
+          echo "## RSpec Results" >> $GITHUB_STEP_SUMMARY
           echo "$(bundle exec rspec \
             --dry-run \
             --format documentation \
             $(find ./spec -name '*_spec.rb' ! -name 'spec_helper.rb'))" >> $GITHUB_STEP_SUMMARY
           echo "Total tests: $(jq '.summary.example_count' tmp/rspec_results.json)" >> $GITHUB_STEP_SUMMARY
 
-      - name: Run tryouts
+  test-ruby-tryouts:
+    timeout-minutes: 15 # prevent hung jobs
+    runs-on: ubuntu-24.04
+
+    strategy:
+      fail-fast: true
+      matrix:
+        ruby: ['3.4', '3.5']
+        continue-on-error: [false]
+
+    services:
+      redis:
+        image: ghcr.io/valkey-io/valkey:8.1.3-bookworm@sha256:93381a084ce82085bf2fb78f97661301577eee0df04fef64a6d14a743b858328
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 3s
+          --health-retries 5
+        ports:
+          - 2121:6379
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: latest
+
+      - name: Install frontend dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build assets
+        run: pnpm run build
+
+      - name: Install dependencies (bundler ${{ matrix.bundler }})
         continue-on-error: ${{ matrix.continue-on-error }}
+        run: |
+          bundle config path vendor/bundle
+          bundle install --jobs 4 --retry 3
+
+      - name: Run tryouts
         env:
           REDIS_URL: 'redis://127.0.0.1:2121/0'
         run: |


### PR DESCRIPTION
### **User description**
* Changed the Redis service image to `ghcr.io/valkey-io/valkey:8.1.3-bookworm` for improved compatibility and performance.
* Split the `test-ruby` job into two distinct jobs: `test-ruby-rspec` for RSpec testing and `test-ruby-tryouts` for tryouts testing, improving job organization and clarity.


___

### **PR Type**
Enhancement


___

### **Description**
- Switch from Redis to Valkey service image for CI

- Split Ruby testing into parallel RSpec and tryouts jobs

- Update service configuration and health checks


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Single Ruby Test Job"] --> B["RSpec Job"]
  A --> C["Tryouts Job"]
  D["Redis Service"] --> E["Valkey Service"]
  B --> F["Parallel Execution"]
  C --> F
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ci.yml</strong><dd><code>Switch to Valkey and parallelize Ruby tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ci.yml

<ul><li>Replace Redis service with Valkey image <br><code>ghcr.io/valkey-io/valkey:8.1.3-bookworm</code><br> <li> Split <code>test-ruby</code> job into separate <code>test-ruby-rspec</code> and <br><code>test-ruby-tryouts</code> jobs<br> <li> Update job comments and summary generation for clarity<br> <li> Maintain same Ruby version matrix and service configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/1587/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f">+57/-12</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

