### PR TITLE
Backport latest OCI build workflows to rel/0.22

### DIFF
--- a/.github/workflows/.build-and-publish-oci-images-reusable.yml
+++ b/.github/workflows/.build-and-publish-oci-images-reusable.yml
@@ -1,0 +1,114 @@
+# .github/workflows/.build-and-publish-oci-images-reusable.yml
+
+name: Docker Build and Publish (Reusable)
+
+on:
+  workflow_call:
+    inputs:
+      image-suffix:
+        required: false
+        type: string
+        default: ''
+      dockerfile:
+        required: false
+        type: string
+        default: 'Dockerfile'
+      image_tags:
+        required: false
+        type: string
+        default: ''
+
+env:
+  REGISTRY: ghcr.io
+  RACK_ENV: production
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+
+    if: github.repository == 'onetimesecret/onetimesecret'
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+
+      # Generate .commit_hash.txt in the build context. This guarantees the file
+      # is created before the build context is submitted.
+      - name: Generate commit hash
+        run: |
+          echo "${GITHUB_SHA:0:7}" > .commit_hash.txt
+          echo Commit hash recorded
+          head -4 .commit_hash.txt package.json
+
+      - name: Update package.json version from tag
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: ./bin/update-version.sh
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
+        with:
+          platforms: arm64
+
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+        with:
+          platforms: linux/amd64,linux/arm64
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get Version
+        id: package_version
+        run: echo "version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
+        env:
+          DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          tags: |
+            ${{ inputs.image_tags != '' && inputs.image_tags || format('type=ref,event=branch') }}
+          images: |
+            ${{ env.REGISTRY }}/${{ github.repository }}${{ inputs.image-suffix }}
+            ${{ github.repository }}${{ inputs.image-suffix }}
+          flavor: |
+            latest=${{ !contains(github.ref, '-rc') }}
+          labels: |
+            org.opencontainers.image.title=Onetime Secret
+            org.opencontainers.image.description=Onetime Secret is a web application to share sensitive information securely and temporarily.
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.licenses=MIT
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ steps.package_version.outputs.version }}
+
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@14487ce63c7a62a4a324b0bfb37086795e31c6c1 # v6.16.0
+        with:
+          context: .
+          file: ${{ inputs.dockerfile }}
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          annotations: ${{ steps.meta.outputs.annotations }}
+          platforms: linux/amd64,linux/arm64
+          build-args: |
+            VERSION=${{ steps.package_version.outputs.version }}
+            GITHUB_SHA=${{ github.sha }}

--- a/.github/workflows/.docker-build-publish-reusable.yml
+++ b/.github/workflows/.docker-build-publish-reusable.yml
@@ -17,6 +17,14 @@ on:
         required: false
         type: string
         default: ''
+      debug_enabled:
+        required: false
+        type: boolean
+        default: false
+      platforms:
+        required: false
+        type: string
+        default: 'linux/amd64,linux/arm64'
 
 env:
   REGISTRY: ghcr.io
@@ -52,7 +60,7 @@ jobs:
       - name: Setup Docker buildx
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
         with:
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ inputs.platforms }}
 
       - name: Login to Docker Hub
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
@@ -104,7 +112,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           annotations: ${{ steps.meta.outputs.annotations }}
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ inputs.platforms }}
           build-args: |
             VERSION=${{ steps.package_version.outputs.version }}
             GITHUB_SHA=${{ github.sha }}

--- a/.github/workflows/build-and-publish-oci-images.yml
+++ b/.github/workflows/build-and-publish-oci-images.yml
@@ -1,0 +1,54 @@
+# .github/workflows/build-and-publish-oci-images.yml
+
+name: Build and Publish OCI Images
+
+#
+# OCI image tagging strategy:
+#
+# Release tags (v1.0.0):        {version}, latest
+# Release candidates (v1.0.0-rc1): {version}, next
+# Branches (feature/x):         {branch-name}
+#
+# This ensures stable releases are tagged as 'latest' while release candidates
+# are tagged as 'next' for early testing. Branch builds get descriptive tags.
+#
+
+on:
+  push:
+    tags: ['v*']
+  pull_request:
+    types: [closed]
+    branches: ['develop', 'feature/*', 'rel/*']
+    # Don't deploy on PRs from forks
+    paths-ignore:
+      - '**'
+
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-publish-main:
+    uses: ./.github/workflows/.build-and-publish-oci-images-reusable.yml
+    with:
+      image-suffix: ''
+      dockerfile: 'Dockerfile'
+      image_tags: |
+        type=ref,event=branch
+        type=ref,event=tag
+        type=raw,value=next,enable=${{ contains(github.ref, '-rc') || contains(github.ref, 'develop') }}
+    secrets: inherit
+
+  build-and-publish-lite:
+    needs: [build-and-publish-main]
+    uses: ./.github/workflows/.docker-build-publish-reusable.yml
+    with:
+      image-suffix: '-lite'
+      dockerfile: 'Dockerfile-lite'
+      image_tags: |
+        type=ref,event=branch
+        type=ref,event=tag
+        type=raw,value=next,enable=${{ contains(github.ref, '-rc') || contains(github.ref, 'develop') }}
+    secrets: inherit

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -24,6 +24,21 @@ on:
       - '**'
 
   workflow_dispatch:
+    inputs:
+      debug_enabled:
+        type: boolean
+        description: 'Enable debug mode for build troubleshooting'
+        required: false
+        default: false
+      platforms:
+        type: choice
+        description: 'Target platforms'
+        required: false
+        default: 'linux/amd64,linux/arm64'
+        options:
+          - 'linux/amd64,linux/arm64'
+          - 'linux/amd64'
+          - 'linux/arm64'
 
 permissions:
   contents: read
@@ -39,6 +54,8 @@ jobs:
         type=ref,event=branch
         type=ref,event=tag
         type=raw,value=next,enable=${{ contains(github.ref, '-rc') || contains(github.ref, 'develop') }}
+      debug_enabled: ${{ inputs.debug_enabled || false }}
+      platforms: ${{ inputs.platforms || 'linux/amd64,linux/arm64' }}
     secrets: inherit
 
   build-and-publish-lite:
@@ -51,4 +68,6 @@ jobs:
         type=ref,event=branch
         type=ref,event=tag
         type=raw,value=next,enable=${{ contains(github.ref, '-rc') || contains(github.ref, 'develop') }}
+      debug_enabled: ${{ inputs.debug_enabled || false }}
+      platforms: ${{ inputs.platforms || 'linux/amd64,linux/arm64' }}
     secrets: inherit

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "@babel/helpers": "7.27.1",
     "@codemirror/lang-json": "6.0.1",
     "@codemirror/lang-yaml": "6.1.2",
+    "@codemirror/state": "^6.5.2",
     "@codemirror/theme-one-dark": "6.1.2",
     "@codemirror/view": "6.37.1",
     "@headlessui/vue": "1.7.23",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@codemirror/lang-yaml':
         specifier: 6.1.2
         version: 6.1.2
+      '@codemirror/state':
+        specifier: ^6.5.2
+        version: 6.5.2
       '@codemirror/theme-one-dark':
         specifier: 6.1.2
         version: 6.1.2
@@ -103,7 +106,7 @@ importers:
         version: 3.5.13(typescript@5.8.3)
       vue-codemirror6:
         specifier: 1.3.15
-        version: 1.3.15(prettier@3.5.3)(typescript@5.8.3)(vue@3.5.13(typescript@5.8.3))
+        version: 1.3.15(jiti@2.4.2)(prettier@3.5.3)(typescript@5.8.3)(vue@3.5.13(typescript@5.8.3))
       vue-i18n:
         specifier: 11.1.3
         version: 11.1.3(vue@3.5.13(typescript@5.8.3))
@@ -6748,7 +6751,7 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
 
-  onetimesecret@file:(prettier@3.5.3)(typescript@5.8.3):
+  onetimesecret@file:(jiti@2.4.2)(prettier@3.5.3)(typescript@5.8.3):
     dependencies:
       '@babel/helpers': 7.27.1
       '@codemirror/lang-json': 6.0.1
@@ -6770,6 +6773,7 @@ snapshots:
       codemirror: 6.0.1
       date-fns: 4.1.0
       dompurify: 3.2.6
+      eslint: 9.35.0(jiti@2.4.2)
       focus-trap: 7.6.4
       focus-trap-vue: 4.0.3(focus-trap@7.6.4)(vue@3.5.13(typescript@5.8.3))
       highlight.js: 11.11.1
@@ -6780,7 +6784,7 @@ snapshots:
       pnpm: 10.10.0
       stripe: 17.7.0
       vue: 3.5.13(typescript@5.8.3)
-      vue-codemirror6: 1.3.15(prettier@3.5.3)(typescript@5.8.3)(vue@3.5.13(typescript@5.8.3))
+      vue-codemirror6: 1.3.15(jiti@2.4.2)(prettier@3.5.3)(typescript@5.8.3)(vue@3.5.13(typescript@5.8.3))
       vue-i18n: 11.1.3(vue@3.5.13(typescript@5.8.3))
       zod: 3.24.3
       zod-validation-error: 3.4.0(zod@3.24.3)
@@ -6792,11 +6796,13 @@ snapshots:
       - drauu
       - fuse.js
       - idb-keyval
+      - jiti
       - jwt-decode
       - nprogress
       - prettier
       - qrcode
       - sortablejs
+      - supports-color
       - typescript
       - universal-cookie
 
@@ -7623,7 +7629,7 @@ snapshots:
 
   vscode-uri@3.1.0: {}
 
-  vue-codemirror6@1.3.15(prettier@3.5.3)(typescript@5.8.3)(vue@3.5.13(typescript@5.8.3)):
+  vue-codemirror6@1.3.15(jiti@2.4.2)(prettier@3.5.3)(typescript@5.8.3)(vue@3.5.13(typescript@5.8.3)):
     dependencies:
       '@codemirror/commands': 6.8.1
       '@codemirror/language': 6.11.0
@@ -7633,7 +7639,7 @@ snapshots:
       codemirror: 6.0.1
       style-mod: 4.1.2
       vue: 3.5.13(typescript@5.8.3)
-      vue-codemirror6: onetimesecret@file:(prettier@3.5.3)(typescript@5.8.3)
+      vue-codemirror6: onetimesecret@file:(jiti@2.4.2)(prettier@3.5.3)(typescript@5.8.3)
       vue-demi: 0.14.10(vue@3.5.13(typescript@5.8.3))
     transitivePeerDependencies:
       - '@vue/composition-api'
@@ -7643,11 +7649,13 @@ snapshots:
       - drauu
       - fuse.js
       - idb-keyval
+      - jiti
       - jwt-decode
       - nprogress
       - prettier
       - qrcode
       - sortablejs
+      - supports-color
       - typescript
       - universal-cookie
 


### PR DESCRIPTION
### **User description**
- **Add explicit @codemirror/state dep**
- **Update workflow_dispatch settings in docker workflows**
- **Backport latest OCI build workflows to rel/0.22**


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Add explicit `@codemirror/state` dependency to fix build issues

- Enhance Docker workflows with manual dispatch controls

- Enable platform selection and debug mode options

- Update workflow inputs for better CI flexibility


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["package.json"] -- "adds dependency" --> B["@codemirror/state"]
  C["docker workflows"] -- "adds inputs" --> D["debug_enabled & platforms"]
  D -- "enables" --> E["manual workflow dispatch"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Add explicit CodeMirror state dependency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

package.json

<ul><li>Add explicit <code>@codemirror/state</code> dependency version ^6.5.2<br> <li> Fix missing CodeMirror state dependency for Vite build</ul>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/1710/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pnpm-lock.yaml</strong><dd><code>Update lockfile with new dependencies</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pnpm-lock.yaml

<ul><li>Update lockfile with new <code>@codemirror/state</code> dependency<br> <li> Reflect dependency resolution changes in snapshots<br> <li> Add transitive dependencies for jiti and supports-color</ul>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/1710/files#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bb">+13/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.docker-build-publish-reusable.yml</strong><dd><code>Add configurable debug and platform inputs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/.docker-build-publish-reusable.yml

<ul><li>Add <code>debug_enabled</code> boolean input parameter<br> <li> Add <code>platforms</code> string input with default multi-arch support<br> <li> Make platform configuration dynamic via inputs</ul>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/1710/files#diff-9e66b11579c984baff1f71d75a2390c0c08f91a6e58ab892125350b098bbbaa2">+10/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>docker-publish.yml</strong><dd><code>Enable manual workflow dispatch with options</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/docker-publish.yml

<ul><li>Add workflow_dispatch inputs for debug mode and platform selection<br> <li> Provide choice options for single or multi-platform builds<br> <li> Pass input parameters to reusable workflow calls</ul>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/1710/files#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98">+19/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

