### PR TITLE
Remove external dependency from vite build

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -225,7 +225,6 @@ export default defineConfig({
       input: {
         main: 'src/main.ts',
       },
-      external: ['altcha'],
       output: {
         // Enforce single chunk output
         inlineDynamicImports: true,


### PR DESCRIPTION
When a module is external, Vite doesn't bundle it and expects the
browser to resolve it at runtime. The error occurs because the browser
is trying to import it as a bare module specifier, but browsers require
relative or absolute paths.
