### PR TITLE
[#1638] Fix tooltip text for logout and settings icons

### DIFF
--- a/src/components/layout/MastHead.vue
+++ b/src/components/layout/MastHead.vue
@@ -179,7 +179,7 @@ import { shallowRef } from 'vue';
               class="size-5"
               collection="material-symbols"
               name="settings-outline"
-              :aria-label="t('web.COMMON.header_settings')" />
+              aria-hidden="true" />
           </button>
 
           <SettingsModal
@@ -203,7 +203,7 @@ import { shallowRef } from 'vue';
               class="size-5"
               collection="heroicons"
               name="arrow-right-on-rectangle-solid"
-              :aria-label="t('web.COMMON.header_logout')" />
+              aria-hidden="true" />
           </router-link>
         </template>
 

--- a/src/components/layout/MastHead.vue
+++ b/src/components/layout/MastHead.vue
@@ -173,11 +173,13 @@ import { shallowRef } from 'vue';
             @click="openSettingsModal"
             class="text-xl text-gray-600 transition-colors duration-200
               hover:text-gray-800 dark:text-gray-300 dark:hover:text-white"
-            :aria-label="t('web.COMMON.header_settings')">
+            :aria-label="t('web.COMMON.header_settings')"
+            :title="t('web.COMMON.header_settings')">
             <OIcon
               class="size-5"
               collection="material-symbols"
-              name="settings-outline" />
+              name="settings-outline"
+              :aria-label="t('web.COMMON.header_settings')" />
           </button>
 
           <SettingsModal
@@ -200,7 +202,8 @@ import { shallowRef } from 'vue';
             <OIcon
               class="size-5"
               collection="heroicons"
-              name="arrow-right-on-rectangle-solid" />
+              name="arrow-right-on-rectangle-solid"
+              :aria-label="t('web.COMMON.header_logout')" />
           </router-link>
         </template>
 


### PR DESCRIPTION
### **User description**
## Summary
- Fixed tooltip text for logout and settings icons in header navigation
- Icons now show proper localized text ("Logout", "Settings") instead of technical class names
- Added aria-label props to OIcon components using existing i18n translation keys

## Changes
- Updated `src/components/layout/MastHead.vue` to pass aria-label props to OIcon components
- Logout icon now shows "Logout" instead of "heroicons-arrow-right-on-rectangle-solid icon"
- Settings icon now shows "Settings" instead of "material-symbols-settings-outline icon"

## Test plan
- [x] Build completes successfully
- [x] Linting passes
- [x] TypeScript type checking passes
- [ ] Manual testing: Hover over logout and settings icons to verify proper tooltip text

Resolves #1638

🤖 Generated with [Claude Code](https://claude.ai/code)


___

### **PR Type**
Bug fix


___

### **Description**
- Fix tooltip text for logout and settings icons

- Add proper aria-label props to OIcon components

- Replace technical class names with localized text


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Header Icons"] --> B["Add aria-label props"]
  B --> C["Settings Icon"]
  B --> D["Logout Icon"]
  C --> E["Show 'Settings' tooltip"]
  D --> F["Show 'Logout' tooltip"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>MastHead.vue</strong><dd><code>Fix icon tooltip accessibility and text</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/layout/MastHead.vue

<ul><li>Add <code>aria-label</code> props to settings and logout <code>OIcon</code> components<br> <li> Add <code>title</code> attribute to settings button for tooltip consistency<br> <li> Use i18n translation keys for proper localized tooltip text</ul>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/1736/files#diff-d98415312a507910e8bd55a8d7a0a3db1a2492b66d5b7672773251c18de1e84c">+6/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

