### PR TITLE
Fix banner display suppression in test mode

### DIFF
--- a/lib/onetime/boot.rb
+++ b/lib/onetime/boot.rb
@@ -67,7 +67,7 @@ module Onetime
         check_global_banner
       end
 
-      print_log_banner if $stdout.tty? && !mode?(:test) && !mode?(:cli)
+      print_log_banner if $stdout.tty? && !mode?(:test) && !mode?(:cli) && ENV['RACK_ENV'] != 'test'
 
       @ready = true
 

--- a/lib/onetime/boot.rb
+++ b/lib/onetime/boot.rb
@@ -67,7 +67,7 @@ module Onetime
         check_global_banner
       end
 
-      print_log_banner if $stdout.tty? && !mode?(:test) && !mode?(:cli) && ENV['RACK_ENV'] != 'test'
+      print_log_banner if $stdout.tty? && !mode?(:test) && !mode?(:cli)
 
       @ready = true
 

--- a/lib/onetime/class_methods.rb
+++ b/lib/onetime/class_methods.rb
@@ -9,7 +9,7 @@
 module Onetime
   module ClassMethods
     @env   = nil
-    @mode  = :app
+    @mode  ||= :app
     @debug = nil
 
     attr_accessor :mode, :env

--- a/spec/onetime/initializers/boot_part1_spec.rb
+++ b/spec/onetime/initializers/boot_part1_spec.rb
@@ -419,16 +419,18 @@ RSpec.describe "Onetime::Config during Onetime.boot!" do
 
         # Set RACK_ENV to non-test value to allow banner display
         original_rack_env = ENV['RACK_ENV']
-        ENV['RACK_ENV'] = 'development'
+        begin
+          ENV['RACK_ENV'] = 'development'
 
-        # OT.li is already stubbed by config_spec_helper.rb
-        # Familia.dbclient.serverid is stubbed in the main before(:each)
+          # OT.li is already stubbed by config_spec_helper.rb
+          # Familia.dbclient.serverid is stubbed in the main before(:each)
 
-        Onetime.boot!(:app) # Use a non-test mode like :app
-        expect(Onetime).to have_received(:print_log_banner).at_least(:once)
-
-        # Restore original RACK_ENV
-        ENV['RACK_ENV'] = original_rack_env
+          Onetime.boot!(:app) # Use a non-test mode like :app
+          expect(Onetime).to have_received(:print_log_banner).at_least(:once)
+        ensure
+          # Restore original RACK_ENV
+          ENV['RACK_ENV'] = original_rack_env
+        end
       end
     end
   end

--- a/spec/onetime/initializers/boot_part1_spec.rb
+++ b/spec/onetime/initializers/boot_part1_spec.rb
@@ -417,11 +417,18 @@ RSpec.describe "Onetime::Config during Onetime.boot!" do
         # Mock $stdout.tty? to return true for this test
         allow($stdout).to receive(:tty?).and_return(true)
 
+        # Set RACK_ENV to non-test value to allow banner display
+        original_rack_env = ENV['RACK_ENV']
+        ENV['RACK_ENV'] = 'development'
+
         # OT.li is already stubbed by config_spec_helper.rb
         # Familia.dbclient.serverid is stubbed in the main before(:each)
 
         Onetime.boot!(:app) # Use a non-test mode like :app
         expect(Onetime).to have_received(:print_log_banner).at_least(:once)
+
+        # Restore original RACK_ENV
+        ENV['RACK_ENV'] = original_rack_env
       end
     end
   end

--- a/spec/onetime/initializers/boot_part2_spec.rb
+++ b/spec/onetime/initializers/boot_part2_spec.rb
@@ -191,7 +191,14 @@ RSpec.describe "Onetime global state after boot" do
         # Mock $stdout.tty? to return true for this test
         allow($stdout).to receive(:tty?).and_return(true)
 
+        # Set RACK_ENV to non-test value to allow banner display
+        original_rack_env = ENV['RACK_ENV']
+        ENV['RACK_ENV'] = 'development'
+
         Onetime.boot!(:development)
+
+        # Restore original RACK_ENV
+        ENV['RACK_ENV'] = original_rack_env
       end
     end
 

--- a/spec/onetime/initializers/boot_part2_spec.rb
+++ b/spec/onetime/initializers/boot_part2_spec.rb
@@ -193,12 +193,14 @@ RSpec.describe "Onetime global state after boot" do
 
         # Set RACK_ENV to non-test value to allow banner display
         original_rack_env = ENV['RACK_ENV']
-        ENV['RACK_ENV'] = 'development'
+        begin
+          ENV['RACK_ENV'] = 'development'
 
-        Onetime.boot!(:development)
-
-        # Restore original RACK_ENV
-        ENV['RACK_ENV'] = original_rack_env
+          Onetime.boot!(:development)
+        ensure
+          # Restore original RACK_ENV
+          ENV['RACK_ENV'] = original_rack_env
+        end
       end
     end
 

--- a/try/90_routes_smoketest_try.rb
+++ b/try/90_routes_smoketest_try.rb
@@ -8,6 +8,7 @@
 
 require_relative 'test_helpers'
 
+ENV['RACK_ENV'] = 'test'  # Set before boot to ensure consistency
 OT.boot! :test, false
 
 require 'rack'


### PR DESCRIPTION
### **User description**
## Summary

Fixes an issue where the application banner was showing during test execution, causing visual clutter in test output. The banner should only display in interactive development mode, not during automated testing.

## Changes

- Enhanced banner suppression logic in `lib/onetime/boot.rb` to check `RACK_ENV != 'test'` in addition to existing mode checks
- Fixed mode initialization in `lib/onetime/class_methods.rb` to use `||=` to prevent overwriting existing mode values
- Updated RSpec tests to properly set `RACK_ENV` during banner display tests to ensure consistent behavior
- Added explicit `RACK_ENV = 'test'` setting in tryouts smoketest to ensure proper test environment

## Test plan

- [x] Run existing RSpec tests to ensure banner logic works correctly
- [x] Run tryouts to confirm banner no longer appears in test output
- [x] Verify banner still displays in development mode

🤖 Generated with [Claude Code](https://claude.ai/code)


___

### **PR Type**
Bug fix


___

### **Description**
- Enhanced banner suppression logic to check `RACK_ENV != 'test'`

- Fixed mode initialization to prevent overwriting existing values

- Updated RSpec tests to properly set `RACK_ENV` during testing

- Added explicit `RACK_ENV = 'test'` in tryouts smoketest


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Test Environment"] --> B["Set RACK_ENV=test"]
  B --> C["Enhanced Banner Logic"]
  C --> D["Banner Suppressed"]
  E["Mode Initialization"] --> F["Prevent Overwrite"]
  F --> G["Consistent Mode"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>boot.rb</strong><dd><code>Enhanced banner suppression with RACK_ENV check</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/onetime/boot.rb

<ul><li>Added <code>ENV['RACK_ENV'] != 'test'</code> check to banner display condition<br> <li> Enhanced banner suppression logic for test environments</ul>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/1738/files#diff-65e08ff06f3b888e6ee7b0c7df20e80d0ffb98792a6f6db4d9b6001e32516284">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>class_methods.rb</strong><dd><code>Fixed mode initialization to prevent overwrite</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/onetime/class_methods.rb

<ul><li>Changed <code>@mode = :app</code> to <code>@mode ||= :app</code><br> <li> Prevents overwriting existing mode values during initialization</ul>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/1738/files#diff-96c0184bc5c0ae5763fd2fe6a56456ccf8be330d2218d461342b36ba7f0f953d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>boot_part1_spec.rb</strong><dd><code>Updated RSpec test with RACK_ENV handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

spec/onetime/initializers/boot_part1_spec.rb

<ul><li>Added <code>RACK_ENV</code> manipulation in banner display test<br> <li> Sets environment to 'development' during test execution<br> <li> Restores original <code>RACK_ENV</code> after test completion</ul>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/1738/files#diff-cf987e9f1d2a592fbcd5bc62235ebcb9cbbe6448594cdae7ef2a728a8ef0b05a">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>boot_part2_spec.rb</strong><dd><code>Updated RSpec test with RACK_ENV handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

spec/onetime/initializers/boot_part2_spec.rb

<ul><li>Added <code>RACK_ENV</code> manipulation in banner display test<br> <li> Sets environment to 'development' during test execution<br> <li> Restores original <code>RACK_ENV</code> after test completion</ul>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/1738/files#diff-e0cf6123372e56948e942208465176567f909aab512990f3cbdaea84f01f397b">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>90_routes_smoketest_try.rb</strong><dd><code>Set RACK_ENV in tryouts smoketest</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

try/90_routes_smoketest_try.rb

<ul><li>Added <code>ENV['RACK_ENV'] = 'test'</code> before <code>OT.boot!</code> call<br> <li> Ensures consistent test environment setup</ul>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/1738/files#diff-bc8e40368eddbddb261c61b0a6ef15e1bc87b8ee24ffd338609e9d21fafdfa50">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

