### PR TITLE
Fix class attribute formatting in MastHead.vue

### DIFF
--- a/src/components/layout/MastHead.vue
+++ b/src/components/layout/MastHead.vue
@@ -130,8 +130,7 @@ import { shallowRef } from 'vue';
               :alt="logoConfig.alt" />
             <span
               v-if="logoConfig.showSiteName"
-              class="text-lg font-bold text-gray-800 d
-              ark:text-gray-100">
+              class="text-lg font-bold text-gray-800 dark:text-gray-100">
               {{ logoConfig.siteName }}
             </span>
           </a>


### PR DESCRIPTION
### **User description**
Fixed dark theme site name text colour not applying due to line break in middle of attribute.


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed dark theme site name text color not applying

- Removed line break in middle of class attribute

- Consolidated class attribute to single line


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["MastHead.vue<br/>class attribute"] -- "remove line break" --> B["Single line<br/>class attribute"]
  B -- "dark:text-gray-100<br/>now applies" --> C["Dark theme<br/>styling works"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>MastHead.vue</strong><dd><code>Fix class attribute line break formatting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/layout/MastHead.vue

<ul><li>Fixed class attribute split across two lines<br> <li> Consolidated <code>class="text-lg font-bold text-gray-800 </code><br><code>dark:text-gray-100"</code> to single line<br> <li> Resolves dark theme text color not applying to site name span element</ul>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/1840/files#diff-d98415312a507910e8bd55a8d7a0a3db1a2492b66d5b7672773251c18de1e84c">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

