### PR TITLE
Use new --exclude-pattern argument for pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -78,14 +78,15 @@ repos:
         args: ['--branch', 'develop', '--branch', 'rel/.*']
 
   # Commit message issue tracking integration
-  - repo: https://github.com/avilaton/add-msg-issue-prefix-hook
-    rev: v0.0.13
+  - repo: https://github.com/delano/add-msg-issue-prefix-hook
+    rev: v0.0.14-fork
     hooks:
       - id: add-msg-issue-prefix
         stages: [prepare-commit-msg]
         description: Automatically prefix commits with issue numbers
         args:
           - '--default='
+          - '--exclude-pattern=^(dependabot|renovate)/'
           - '--pattern=(i18n(?=/)|([a-zA-Z0-9]{0,10}-?[0-9]{1,5}))'
           - '--template=[#{}]'
 


### PR DESCRIPTION
### **User description**
Avoids choking on claude code web automaticly named branches.

Examples:
claude/investigate-cors-csp-issues-011CUqK156JKVDtxNkCKY9uR -> [#ISSUES-011]
claude/dynamic-page-titles-011CUpQfcCC8Mk9XBEVYwHQ2 -> [#TITLES-011]


___

### **PR Type**
Enhancement


___

### **Description**
- Update add-msg-issue-prefix-hook to fork version with exclude-pattern support

- Add exclude-pattern argument to skip dependabot and renovate branches

- Prevents false issue number extraction from automated branch names

- Repository source changed from avilaton to delano fork


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["add-msg-issue-prefix-hook"] -->|"Update to fork v0.0.14"| B["Exclude pattern support"]
  B -->|"Skip dependabot/renovate"| C["Cleaner commit messages"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.pre-commit-config.yaml</strong><dd><code>Add exclude-pattern for automated branch handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.pre-commit-config.yaml

<ul><li>Updated hook repository from avilaton to delano fork version<br> <li> Bumped version from v0.0.13 to v0.0.14-fork<br> <li> Added <code>--exclude-pattern=^(dependabot|renovate)/</code> argument to skip <br>automated branch prefixes<br> <li> Prevents false issue number extraction from Claude Code Web and <br>dependency bot branch names</ul>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/1869/files#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

