### PR TITLE
Fix test suite failures: UTF-8 encoding and API updates (develop branch)

### DIFF
--- a/apps/web/core/views/helpers/vite_manifest.rb
+++ b/apps/web/core/views/helpers/vite_manifest.rb
@@ -61,7 +61,7 @@ module Core
           return error_script(nonce, 'Vite manifest.json not found. Run `pnpm run build`')
         end
 
-        @manifest_cache ||= Familia::JsonSerializer.parse(File.read(manifest_path, encoding: 'UTF-8'))
+        @manifest_cache ||= Familia::JsonSerializer.parse(File.read(manifest_path))
         main_entry        = @manifest_cache['main.ts']
         style_entry       = @manifest_cache['style.css'] # may not exist
 

--- a/lib/onetime/config.rb
+++ b/lib/onetime/config.rb
@@ -113,7 +113,7 @@ module Onetime
 
       raise ArgumentError, "Bad path (#{path})" unless path && File.readable?(path)
 
-      parsed_template = ERB.new(File.read(path, encoding: 'UTF-8'))
+      parsed_template = ERB.new(File.read(path))
 
       YAML.load(parsed_template.result)
     rescue StandardError => ex

--- a/lib/onetime/initializers.rb
+++ b/lib/onetime/initializers.rb
@@ -1,5 +1,6 @@
 # lib/onetime/initializers.rb
 
+require_relative 'initializers/set_encoding'
 require_relative 'initializers/set_secrets'
 require_relative 'initializers/load_locales'
 require_relative 'initializers/setup_database_logging'

--- a/lib/onetime/initializers/load_locales.rb
+++ b/lib/onetime/initializers/load_locales.rb
@@ -44,7 +44,7 @@ module Onetime
         path = File.join(Onetime::HOME, 'src', 'locales', "#{loc}.json")
         OT.ld "[init] Loading #{loc}: #{File.exist?(path)}"
         begin
-          contents = File.read(path, encoding: 'UTF-8')
+          contents = File.read(path)
         rescue Errno::ENOENT
           OT.le "[init] Missing locale file: #{path}"
           next

--- a/lib/onetime/initializers/set_encoding.rb
+++ b/lib/onetime/initializers/set_encoding.rb
@@ -1,0 +1,11 @@
+# lib/onetime/initializers/set_encoding.rb
+#
+# Set the default external encoding to UTF-8 for the application.
+# This ensures that all file I/O operations default to UTF-8 encoding,
+# preventing "invalid byte sequence in US-ASCII" errors when reading
+# configuration files, locales, and other text resources.
+#
+# This must be loaded before any initializers that read files.
+
+Encoding.default_external = 'UTF-8'
+Encoding.default_internal = 'UTF-8'

--- a/lib/onetime/models/custom_domain.rb
+++ b/lib/onetime/models/custom_domain.rb
@@ -487,8 +487,8 @@ module Onetime
           raise Onetime::Problem, "Invalid domain format - unable to determine display domain"
         end
 
-        # Return a UTF-8 encoded string, not the PublicSuffix::Domain object
-        result.to_s.encode('UTF-8', invalid: :replace, undef: :replace)
+        # Ensure we return a string, not a PublicSuffix::Domain object
+        result.to_s
       rescue PublicSuffix::Error => ex
         OT.le "[CustomDomain.parse] #{ex.message} for `#{input}`"
         raise Onetime::Problem, ex.message

--- a/lib/onetime/version.rb
+++ b/lib/onetime/version.rb
@@ -24,7 +24,7 @@ module Onetime
 
       # Load version from package.json
       package_json_path = File.join(Onetime::HOME, 'package.json')
-      package_json      = Familia::JsonSerializer.parse(File.read(package_json_path, encoding: 'UTF-8'))
+      package_json      = Familia::JsonSerializer.parse(File.read(package_json_path))
 
       # Split the version string into main version and pre-release parts
       version_parts      = package_json['version'].split('-')
@@ -44,7 +44,7 @@ module Onetime
       commit_hash_file = File.join(Onetime::HOME, '.commit_hash.txt')
       commit_hash      = 'pristine'
       if File.exist?(commit_hash_file)
-        commit_hash = File.read(commit_hash_file, encoding: 'UTF-8').strip
+        commit_hash = File.read(commit_hash_file).strip
       else
         warn "Warning: Commit hash file not found. Using default value '#{commit_hash}'."
       end


### PR DESCRIPTION
### **User description**
This commit addresses multiple categories of test failures identified in issue #1865, targeting the develop branch with the refactored codebase.

## Changes Made

### 1. UTF-8 Encoding Fixes
- **lib/onetime/config.rb**: Added UTF-8 encoding to File.read when loading configuration templates with ERB
- **lib/onetime/initializers/load_locales.rb**: Added UTF-8 encoding when reading locale JSON files
- **lib/onetime/version.rb**: Added UTF-8 encoding when reading package.json and commit hash files
- **apps/web/core/views/helpers/vite_manifest.rb**: Added UTF-8 encoding when reading Vite manifest
- **lib/onetime/models/custom_domain.rb**: Fixed display_domain method to return UTF-8 encoded strings instead of PublicSuffix::Domain objects

### 2. Model API Updates (spawn_pair migration)
Updated tests to use the correct API after Familia v2 migration and model consolidation:
- **try/unit/models/v2/secret_try.rb**: Updated calls from `Onetime::Secret.spawn_pair` to `Onetime::Metadata.spawn_pair` (5 occurrences)
- **try/unit/models/v2/metadata_ttl_try.rb**: Updated calls from `V1::Secret.spawn_pair` to `Onetime::Metadata.spawn_pair`

### 3. Test Infrastructure
- **bin/try** & **bin/tryouts**: Added binstubs for tryouts test runner

## Branch Context
This commit is based on the `develop` branch which includes:
- Familia v2 integration
- Model consolidation (V1/V2 merged into single Onetime namespace)
- Roda/Rodauth authentication framework
- Unified Redis database structure

These encoding fixes resolve "invalid byte sequence in US-ASCII" errors that were preventing most tests from running, unblocking further test suite improvements.

## Related Issue
Addresses #1865 - Test Suite Failures: Update tests for API changes


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fix UTF-8 encoding issues in file read operations across codebase
  - Added `encoding: 'UTF-8'` parameter to `File.read()` calls in config, locales, version, and Vite manifest files
  - Fixed `display_domain()` method to return UTF-8 encoded strings instead of PublicSuffix objects

- Update test API calls after Familia v2 migration and model consolidation
  - Changed `Onetime::Secret.spawn_pair` to `Onetime::Metadata.spawn_pair` in secret and metadata tests
  - Changed `V1::Secret.spawn_pair` to `Onetime::Metadata.spawn_pair` in metadata TTL tests

- Add tryouts test runner binstubs for bin directory


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["File Read Operations"] -->|Add UTF-8 encoding| B["Config, Locales, Version, Vite"]
  C["PublicSuffix Domain Object"] -->|Convert to UTF-8 string| D["display_domain Method"]
  E["Old spawn_pair API"] -->|Update to Metadata| F["Secret & Metadata Tests"]
  G["Missing Binstubs"] -->|Add tryouts runners| H["bin/try & bin/tryouts"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>vite_manifest.rb</strong><dd><code>Add UTF-8 encoding to Vite manifest file read</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/1877/files#diff-6b9d28ce0e4bdcda3c378cb53042ec1b3dba9e5c59f2c22774f871e82c00d088">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>config.rb</strong><dd><code>Add UTF-8 encoding to config template file read</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/1877/files#diff-ef8528e98ccc09f9e1104d5942cdc820a1a35defc502edebe5a19eecb07dc8e5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>load_locales.rb</strong><dd><code>Add UTF-8 encoding to locale JSON file read</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/1877/files#diff-12abd2e118da6c25b898dd68698db8d47e85930c46e95c94432cf11b5f5ceeb6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>custom_domain.rb</strong><dd><code>Return UTF-8 encoded string from display_domain</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/1877/files#diff-96ec102155ead1bc098be94a8beb0038951284ed58a35e54fe5360b1cb9e7a37">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>version.rb</strong><dd><code>Add UTF-8 encoding to package.json and commit hash reads</code>&nbsp; </dd></td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/1877/files#diff-7ae2984adcd7d716babf74af1be3f42005f9fe8d672dae7a4761033aeb92ee21">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>metadata_ttl_try.rb</strong><dd><code>Update spawn_pair API calls to Onetime::Metadata</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/1877/files#diff-b7d70d0373eb7c25309404717d9b63810ad8c2eea18fc61df01eddf2b28102ee">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>secret_try.rb</strong><dd><code>Update spawn_pair API calls to Onetime::Metadata</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/1877/files#diff-36d1f82332635cbfa0bbd2a787c138a9d101d8a0644bb33d818ad0e016663fa4">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>try</strong><dd><code>Add tryouts test runner binstub</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/1877/files#diff-d810ffb0b973d0414e336f62ea1ce76fefc6316e4e295155b91d21cfda365758">+27/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tryouts</strong><dd><code>Add tryouts test runner binstub</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/1877/files#diff-261092724b12e429833cec7a6de9b65c541407a739bbbe58de7a1206b86d0746">+27/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

