### PR TITLE
Move Sequel logger SQL output from debug to trace level

### DIFF
--- a/apps/web/auth/database.rb
+++ b/apps/web/auth/database.rb
@@ -41,7 +41,7 @@ module Auth
       db = Sequel.connect(
         database_url,
         logger: Onetime.get_logger('Sequel'),
-        sql_log_level: :debug  # Log SQL statements at debug level instead of info
+        sql_log_level: :trace  # Log SQL statements at trace level for safety
       )
 
       db

--- a/bin/ots
+++ b/bin/ots
@@ -140,7 +140,7 @@ class OT::CLI::Definition
            DEBUG_SESSION=1   - Set Session logger to debug
            DEBUG_HTTP=1      - Set HTTP logger to debug
            DEBUG_SECRET=1    - Set Secret logger to debug
-           DEBUG_SEQUEL=1    - Set Sequel logger to debug
+           DEBUG_SEQUEL=1    - Set Sequel logger to debug (SQL at trace)
            DEBUG_APP=1       - Set App logger to debug
 
         EXTERNAL LIBRARY FLAGS
@@ -166,7 +166,7 @@ class OT::CLI::Definition
           LOG_LEVEL=warn bin/ots server
 
         Combine multiple approaches:
-          LOG_LEVEL=info DEBUG_AUTH=1 DEBUG_LOGGERS=Sequel:debug bin/ots server
+          LOG_LEVEL=info DEBUG_AUTH=1 DEBUG_LOGGERS=Sequel:trace bin/ots server
 
         Production with reduced noise:
           LOG_LEVEL=warn DEBUG_LOGGERS=Familia:info,Otto:info bin/ots server

--- a/docs/architecture/logging.md
+++ b/docs/architecture/logging.md
@@ -86,7 +86,7 @@ All logging goes through these operational categories:
 | `Otto` | Routing and request handling | Route matching, auth strategies |
 | `Rhales` | Rhales framework | Framework internals |
 | `Secret` | Secret lifecycle | Secret create, view, expire |
-| `Sequel` | Database operations | SQL queries, migrations |
+| `Sequel` | Database operations | SQL queries (at :trace), migrations |
 | `App` | General application | Fallback for uncategorized code |
 
 ### Usage Pattern

--- a/etc/defaults/logging.defaults.yaml
+++ b/etc/defaults/logging.defaults.yaml
@@ -50,7 +50,7 @@ loggers:
   Otto: warn      # Otto framework operations
   Rhales: error   # Rhales template rendering (suppress unescaped HTML warnings)
   Secret: info    # Secret lifecycle (create, view, burn)
-  Sequel: warn    # Database queries and operations
+  Sequel: warn    # Database queries and operations (SQL logged at :trace level)
   Session: info   # Session lifecycle (create, update, destroy)
 
 # HTTP request logging configuration

--- a/lib/onetime/initializers/setup_loggers.rb
+++ b/lib/onetime/initializers/setup_loggers.rb
@@ -177,7 +177,7 @@ module Onetime
     # - Familia: Redis ORM with SemanticLogger['Familia']
     # - Otto: Router framework with SemanticLogger['Otto']
     # - Rhales: Ruby SFC framework with SemanticLogger['Rhales']
-    # - Sequel: Database connections with SemanticLogger['Sequel']
+    # - Sequel: Database connections with SemanticLogger['Sequel'] (SQL at :trace)
     #
     # Note: Some libraries don't support custom loggers (e.g., standard Redis gem).
     # For those, we rely on our own logging within wrapper code.


### PR DESCRIPTION
### **User description**
This change aligns Sequel logging behavior with Familia's trace-level command logging, improving safety by preventing accidental exposure of table data during routine debugging.

Changes:
- Update sql_log_level from :debug to :trace in database.rb
- Update configuration comments and documentation
- Update bin/ots help text to clarify SQL logging at trace
- Update usage examples to show DEBUG_LOGGERS=Sequel:trace

Security benefit: SQL queries containing sensitive data (emails, IDs, etc.) no longer appear with DEBUG_SEQUEL=1. Trace level now required for SQL query output, making it an explicit opt-in operation.

Usage patterns:
- DEBUG_SEQUEL=1: Shows connection/migration info only (safe)
- DEBUG_LOGGERS=Sequel:trace: Shows SQL queries (explicit opt-in)


___

### **PR Type**
Enhancement, Documentation


___

### **Description**
- Move Sequel SQL logging from debug to trace level for improved security

- Prevent accidental exposure of sensitive data in SQL queries during routine debugging

- Update documentation and help text to reflect new trace-level SQL logging requirement

- Clarify usage patterns: DEBUG_SEQUEL=1 shows safe info only, DEBUG_LOGGERS=Sequel:trace shows SQL queries


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Sequel Logger Configuration"] -->|sql_log_level changed| B[":debug → :trace"]
  B -->|Security Improvement| C["SQL queries require explicit opt-in"]
  C -->|Usage Pattern| D["DEBUG_LOGGERS=Sequel:trace"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>database.rb</strong><dd><code>Update Sequel SQL log level to trace</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/web/auth/database.rb

<ul><li>Changed <code>sql_log_level</code> from <code>:debug</code> to <code>:trace</code> in Sequel connection <br>configuration<br> <li> Updated inline comment to clarify trace level is for safety purposes</ul>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/1886/files#diff-d5efa0b8a03bb83ac905e998ebdfa5f19fbd18e85c687e9a66198a1937825a71">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>setup_loggers.rb</strong><dd><code>Document Sequel trace-level SQL logging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/onetime/initializers/setup_loggers.rb

<ul><li>Updated documentation comment for Sequel logger configuration<br> <li> Added clarification that SQL queries are logged at <code>:trace</code> level</ul>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/1886/files#diff-5bc61170a251b2b5c31d4c8d03be7fc95341e5ce199b82da67ec4a92e95b22d3">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ots</strong><dd><code>Update CLI help text for Sequel trace logging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

bin/ots

<ul><li>Updated DEBUG_SEQUEL flag help text to indicate SQL is logged at trace <br>level<br> <li> Updated example command to use <code>DEBUG_LOGGERS=Sequel:trace</code> instead of <br><code>:debug</code><br> <li> Clarified that DEBUG_SEQUEL=1 only shows connection/migration info</ul>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/1886/files#diff-f760b4e89ed099696292fc69306124cbec19b6c57ac9be1f5ff22bc4b887171b">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>logging.md</strong><dd><code>Document Sequel trace-level SQL logging requirement</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/architecture/logging.md

<ul><li>Updated Sequel logger documentation to specify SQL queries are logged <br>at <code>:trace</code> level<br> <li> Clarified that migrations are still logged at standard levels</ul>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/1886/files#diff-8ff2c13b105f792454e4af780e43df2905b30922515fffcade66e95a48b71fa4">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>logging.defaults.yaml</strong><dd><code>Update Sequel logger configuration documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

etc/defaults/logging.defaults.yaml

<ul><li>Updated Sequel logger configuration comment to clarify SQL is logged <br>at <code>:trace</code> level<br> <li> Maintained <code>warn</code> as the default log level for Sequel logger itself</ul>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/1886/files#diff-7a322e387e6e26f9ac72ce5864e1ed0f620ab8a3a1ed97988d957969663be385">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

