### PR TITLE
Fix middleware initialization argument error

### DIFF
--- a/lib/onetime/application/middleware_stack.rb
+++ b/lib/onetime/application/middleware_stack.rb
@@ -141,11 +141,10 @@ module Onetime
           # Locale detection middleware (after session, before domain strategy)
           # Sets env['otto.locale'] based on URL param, session, Accept-Language header
           logger.debug 'Setting up Locale detection middleware'
-          builder.use Otto::Locale::Middleware, {
+          builder.use Otto::Locale::Middleware,
             available_locales: build_available_locales,
             default_locale: OT.default_locale,
-            debug: OT.debug?,
-          }
+            debug: OT.debug?
 
           # Domain strategy middleware (after identity)
           builder.use Onetime::Middleware::DomainStrategy, application_context: application_context


### PR DESCRIPTION
### **User description**
The application was failing to start with: ArgumentError: wrong number
of arguments (given 2, expected 1; required keywords: available_locales,
default_locale)

Root cause: When passing a hash literal `{ key: value }` as the second
argument to `builder.use`, Rack 3 passes it as a positional argument.
However, Otto::Locale::Middleware#initialize expects keyword arguments
(available_locales:, default_locale:, debug:).

Solution: Remove the curly braces and pass keyword arguments directly to
builder.use. Rack will then properly forward them as keyword arguments
to the middleware's initialize method.

This aligns with the middleware signature in Otto gem: def
initialize(app, available_locales:, default_locale:, debug: false)


___

### **PR Type**
Bug fix


___

### **Description**
- Fix Rack 3 middleware initialization argument error

- Remove hash literal braces from Otto::Locale::Middleware configuration

- Pass keyword arguments directly to builder.use method

- Align with middleware signature expecting keyword arguments


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Hash literal syntax<br/>builder.use Middleware, {...}"] -->|"Remove braces"| B["Keyword arguments<br/>builder.use Middleware,<br/>key: value"]
  B -->|"Rack 3 forwards correctly"| C["Middleware receives<br/>keyword arguments"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>middleware_stack.rb</strong><dd><code>Remove hash braces from middleware configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/onetime/application/middleware_stack.rb

<ul><li>Removed curly braces from Otto::Locale::Middleware configuration hash<br> <li> Changed from hash literal <code>{ key: value }</code> to direct keyword arguments<br> <li> Maintains all three configuration parameters: available_locales, <br>default_locale, debug<br> <li> Fixes ArgumentError caused by Rack 3 treating hash literals as <br>positional arguments</ul>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/1902/files#diff-39c89444fb1c6c4a615078088e77161ee2a40098f36544065b594de370379e30">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

