### PR TITLE
[#1903] Disable Caddy active health checks to prevent HTTP/2 PRI errors

### DIFF
--- a/etc/examples/Caddyfile-example
+++ b/etc/examples/Caddyfile-example
@@ -262,28 +262,36 @@
 			# Active health checking
 			#
 			# @see https://caddyserver.com/docs/caddyfile/directives/reverse_proxy#active-health-checks
-			health_uri /api/v2/status
+			#
+			# DISABLED: Health checks were causing HTTP/2 (PRI method) requests to Puma
+			# which doesn't support HTTP/2. Caddy's health check client may attempt
+			# protocol negotiation independently of the transport settings.
+			#
+			# TODO: Re-enable with explicit HTTP/1.1 constraint once Caddy supports
+			# per-health-check transport configuration.
+			#
+			# health_uri /api/v2/status
+			# health_body nominal
+			# health_interval 20s
+			# health_passes 2
+			# health_fails 2
+			# health_timeout 5s
 
-			# Substring or regular expression to match
-			health_body nominal
-
-			# How often to check (default: 30s)
-			health_interval 20s
-
-			# Consecutive checks to mark healthy/unhealthy (default: 1)
-			health_passes 2
-			health_fails 2
-
-			# How long to wait before marking down (default: 5s)
-			health_timeout 5s
-
-			# Passive health checks
+			# Passive health checks (ENABLED)
 			#
 			# @see https://caddyserver.com/docs/caddyfile/directives/reverse_proxy#passive-health-checks
+			#
+			# Passive health checks monitor actual traffic and don't make separate
+			# HTTP requests, so they don't suffer from the HTTP/2 protocol issue
+			# that affects active health checks.
 
 			# How long to remember a failed request; a duration > 0 enables
 			# passive health checking. (default: 30s)
 			fail_duration 30s
+
+			# Maximum number of unhealthy requests to tolerate before marking
+			# the backend as down (optional, uses default if not specified)
+			# unhealthy_request_count 3
 
 			transport http {
 				# Internet → Caddy → Puma


### PR DESCRIPTION
### **User description**
Caddy's active health check client was making HTTP/2 requests (PRI method)
to Puma despite `transport http { versions 1.1 }` configuration. Puma does
not support HTTP/2 and logs "Unsupported HTTP method used: PRI" errors.

Root cause: Active health checks may attempt protocol negotiation independently
of the main reverse_proxy transport settings, causing them to try HTTP/2 even
when the transport block specifies HTTP/1.1 only.

Changes:
- Disabled active health checks (health_uri, health_body, etc.)
- Enhanced passive health checks with additional documentation
- Added TODO to re-enable active checks once per-health-check transport
  configuration is supported in Caddy

Passive health checks remain enabled and monitor actual traffic without
making separate HTTP requests, so they don't trigger the HTTP/2 issue.

Related: #1903, previous fix in a939d72 added explicit http:// scheme


___

### **PR Type**
Bug fix


___

### **Description**
- Disabled active health checks causing HTTP/2 PRI errors to Puma

- Enhanced passive health checks with detailed documentation

- Added TODO for re-enabling active checks with per-check transport config

- Clarified that passive checks don't trigger HTTP/2 protocol issues


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Active Health Checks<br/>HTTP/2 PRI requests"] -->|DISABLED| B["Passive Health Checks<br/>Monitor actual traffic"]
  B -->|No separate requests| C["Avoid HTTP/2 issue<br/>with Puma"]
  D["TODO: Per-check<br/>transport config"] -.->|Future re-enable| A
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Caddyfile-example</strong><dd><code>Disable active health checks, enhance passive checks documentation</code></dd></summary>
<hr>

etc/examples/Caddyfile-example

<ul><li>Commented out all active health check directives (health_uri, <br>health_body, health_interval, health_passes, health_fails, <br>health_timeout)<br> <li> Added detailed explanation of why active checks were disabled (HTTP/2 <br>PRI method incompatibility with Puma)<br> <li> Added TODO comment for re-enabling active checks once Caddy supports <br>per-health-check transport configuration<br> <li> Enhanced passive health checks section with documentation explaining <br>they don't make separate HTTP requests<br> <li> Added optional commented example for <code>unhealthy_request_count</code> parameter</ul>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/1908/files#diff-411a1ed20b76c328d653a3be2bc1ffe87f1acb3721fbea1dee9b726d685150e4">+24/-16</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

