### PR TITLE
[#PR-1963] Clean up PR #1963 follow-up: Remove obsolete tests and fix docs

### DIFF
--- a/src/stores/domainsStore.ts
+++ b/src/stores/domainsStore.ts
@@ -187,9 +187,9 @@ export const useDomainsStore = defineStore('domains', () => {
   }
 
   /**
-   * Update brand settings for a domain and update the full domain record in store
+   * Update brand settings for a domain via PUT /:extid/brand endpoint
    *
-   * Unlike updateBrandSettings() which only updates brand settings,
+   * Unlike updateBrandSettings() which returns only brand settings,
    * this function returns the full domain object and updates store state.
    */
   async function updateDomainBrand(extid: string, brandUpdate: UpdateDomainBrandRequest) {

--- a/src/tests/stores/domainsStore.spec.ts
+++ b/src/tests/stores/domainsStore.spec.ts
@@ -261,40 +261,20 @@ describe('domainsStore', () => {
     });
   });
 
-  describe.skip('State Management', () => {
-    it('should update domain in place when it exists', async () => {
-      const domain = mockDomains['domain-1'];
-      const updatedDomain = {
-        ...domain,
-        brand: mockCustomBranding,
-      };
-
-      store.domains = [domain];
-
-      axiosMock.onPut(`/api/domains/${domain.extid}`).reply(200, {
-        record: updatedDomain,
-      });
-
-      await store.updateDomain(updatedDomain);
-      expect(store.domains).toHaveLength(1);
-      expect(store.domains[0]).toEqual(updatedDomain);
-    });
-
-    it('should add domain when updating non-existent domain', async () => {
-      const newDomain = mockDomains['domain-2'];
-
-      axiosMock.onPut(`/api/domains/${newDomain.extid}`).reply(200, {
-        record: newDomain,
-      });
-
-      await store.updateDomain(newDomain);
-      expect(store.domains).toContainEqual(newDomain);
-    });
-
+  describe('State Management', () => {
     it('should prevent duplicate refreshes when initialized', async () => {
-      store.initialized = true;
+      // First call initializes the store
+      axiosMock.onGet('/api/domains').reply(200, {
+        records: Object.values(mockDomains),
+        count: Object.keys(mockDomains).length,
+      });
+
       await store.refreshRecords();
-      expect(axiosMock.history.get).toHaveLength(0);
+      expect(axiosMock.history.get).toHaveLength(1);
+
+      // Second call should skip fetching because store is initialized
+      await store.refreshRecords();
+      expect(axiosMock.history.get).toHaveLength(1); // Still 1, not 2
     });
   });
 });


### PR DESCRIPTION
Addresses review feedback from PR #1963:

1. Remove obsolete updateDomain tests (lines 264-292)
   - Tests referenced non-existent updateDomain() function
   - Function was never part of DomainsAPI migration
   - Store correctly uses updateDomainBrand() with PUT /:extid/brand

2. Fix inconsistent documentation in domainsStore.ts:191-193
   - Clarify updateDomainBrand() calls PUT /:extid/brand endpoint
   - Distinguish from updateBrandSettings() which returns different type

3. Fix remaining State Management test
   - Test now properly validates duplicate refresh prevention
   - Uses actual API mock instead of setting internal state directly

Test results: All 11 tests passing (1 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
