### PR TITLE
Remove debug console logging from auth state management

### DIFF
--- a/src/plugins/pinia/autoInitPlugin.ts
+++ b/src/plugins/pinia/autoInitPlugin.ts
@@ -107,16 +107,7 @@ import type { PiniaPluginOptions } from './types';
 export function autoInitPlugin(options: PiniaPluginOptions = {}) {
   return ({ store }: PiniaPluginContext) => {
     if (typeof store.init === 'function') {
-      if (import.meta.env.DEV) {
-        console.group('🔌 Pinia autoInitPlugin');
-        console.log('Initializing store:', store.$id);
-        console.log('Timestamp:', new Date().toISOString());
-      }
       store.init(options);
-      if (import.meta.env.DEV) {
-        console.log('Store initialized');
-        console.groupEnd();
-      }
     }
   };
 }

--- a/src/router/guards.routes.ts
+++ b/src/router/guards.routes.ts
@@ -13,60 +13,36 @@ export async function setupRouterGuards(router: Router): Promise<void> {
   let currentTitle: string | null = null;
 
   router.beforeEach(async (to: RouteLocationNormalized) => {
-    console.group('🛣️ Router Guard: beforeEach');
-    console.log('Navigating to:', to.path);
-    console.log('Route name:', to.name);
-    console.log('Timestamp:', new Date().toISOString());
-
     const authStore = useAuthStore();
     const languageStore = useLanguageStore();
-
-    console.log('Auth store state:', {
-      isAuthenticated: authStore.isAuthenticated,
-      isInitialized: authStore.isInitialized,
-      needsCheck: authStore.needsCheck,
-    });
 
     processQueryParams(to.query as Record<string, string>);
 
     if (to.name === 'NotFound') {
-      console.log('Route is NotFound, allowing');
-      console.groupEnd();
       return true;
     }
 
     // Handle MFA requirement checks
     const mfaRedirect = handleMfaAccess(to, authStore.isAuthenticated);
     if (mfaRedirect) {
-      console.log('MFA redirect required:', mfaRedirect);
-      console.groupEnd();
       return mfaRedirect;
     }
 
     // Handle root path redirect
     if (to.path === '/') {
-      const redirect = authStore.isAuthenticated ? { name: 'Dashboard' } : true;
-      console.log('Root path redirect:', redirect);
-      console.groupEnd();
-      return redirect;
+      return authStore.isAuthenticated ? { name: 'Dashboard' } : true;
     }
 
     // Redirect authenticated users away from auth routes
     if (isAuthRoute(to) && authStore.isAuthenticated) {
-      console.log('Auth route with authenticated user, redirecting to Dashboard');
-      console.groupEnd();
       return { name: 'Dashboard' };
     }
 
     // Validate authentication for protected routes
     if (requiresAuthentication(to)) {
-      console.log('Route requires authentication, validating...');
       const isAuthenticated = await validateAuthentication(authStore, to);
-      console.log('Validation result:', isAuthenticated);
 
       if (!isAuthenticated) {
-        console.warn('❌ Authentication failed, redirecting to signin');
-        console.groupEnd();
         return redirectToSignIn(to);
       }
 
@@ -76,8 +52,6 @@ export async function setupRouterGuards(router: Router): Promise<void> {
       }
     }
 
-    console.log('✅ Navigation allowed');
-    console.groupEnd();
     return true; // Always return true for non-auth routes
   });
 
@@ -187,43 +161,16 @@ async function validateAuthentication(
   store: AuthValidator, // tried AuthStore, etc
   route: RouteLocationNormalized
 ): Promise<boolean> {
-  if (import.meta.env.DEV) {
-    console.group('🔍 validateAuthentication');
-    console.log('Route requires auth:', requiresAuthentication(route));
-    console.log('Store needsCheck:', store.needsCheck);
-    console.log('Store isAuthenticated:', store.isAuthenticated);
-  }
-
   if (!requiresAuthentication(route)) {
-    if (import.meta.env.DEV) {
-      console.log('Route does not require auth, returning true');
-      console.groupEnd();
-    }
     return true;
   }
 
   if (store.needsCheck) {
-    if (import.meta.env.DEV) {
-      console.log('Needs check, calling checkWindowStatus...');
-    }
     const authStatus = await store.checkWindowStatus();
-    if (import.meta.env.DEV) {
-      console.log('checkWindowStatus returned:', authStatus);
-    }
-    const result = authStatus ?? false;
-    if (import.meta.env.DEV) {
-      console.log('Final result (after coalescing):', result);
-      console.groupEnd();
-    }
-    return result;
+    return authStatus ?? false;
   }
 
-  const result = store.isAuthenticated ?? false;
-  if (import.meta.env.DEV) {
-    console.log('Using cached auth state:', result);
-    console.groupEnd();
-  }
-  return result;
+  return store.isAuthenticated ?? false;
 }
 
 /**

--- a/src/services/window.service.ts
+++ b/src/services/window.service.ts
@@ -20,14 +20,7 @@ export const WindowService = {
    */
   get<K extends keyof OnetimeWindow>(key: K): OnetimeWindow[K] {
     const state = this.getState();
-    const value = state[key];
-
-    // Only log for auth-related keys to avoid spam
-    if (import.meta.env.DEV && (key === 'authenticated' || key === 'awaiting_mfa')) {
-      console.log(`🪟 WindowService.get('${String(key)}'):`, value);
-    }
-
-    return value;
+    return state[key];
   },
 
   getState(): OnetimeWindow {

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -113,13 +113,7 @@ export const useAuthStore = defineStore('auth', () => {
   // Actions
 
   function init(options?: StoreOptions) {
-    console.group('🔐 Auth State Initialization');
-    console.log('Timestamp:', new Date().toISOString());
-    console.log('Already initialized:', _initialized.value);
-
     if (_initialized.value) {
-      console.log('⚠️ Skipping - already initialized');
-      console.groupEnd();
       return { needsCheck, isInitialized };
     }
 
@@ -128,10 +122,6 @@ export const useAuthStore = defineStore('auth', () => {
     const inputValue = WindowService.get('authenticated');
     const hadValidSession = WindowService.get('had_valid_session');
     const storedAuthState = sessionStorage.getItem('ots_auth_state');
-
-    console.log('Window state authenticated:', inputValue);
-    console.log('Window state had_valid_session:', hadValidSession);
-    console.log('Stored auth state (sessionStorage):', storedAuthState);
 
     // Detect if this might be an error page masquerading as unauthenticated:
     // - Window says authenticated = false
@@ -142,8 +132,6 @@ export const useAuthStore = defineStore('auth', () => {
     // The server sets had_valid_session by checking the session cookie on its side.
     if (inputValue === false && hadValidSession === true && storedAuthState === 'true') {
       // Likely a server error page, preserve the stored auth state
-      console.warn('⚠️ Preserving auth state despite server showing unauthenticated');
-      console.log('Reason: Server confirms valid session existed (had_valid_session=true)');
       loggingService.warn(
         'Window state shows unauthenticated but server had valid session - ' +
         'likely server error page, preserving auth state'
@@ -153,36 +141,19 @@ export const useAuthStore = defineStore('auth', () => {
       // Normal flow: trust window state
       // Regardless of what the value is, if it isn't exactly true, it's false.
       // i.e. unlimited ways to fail, only one way to succeed.
-      if (import.meta.env.DEV) {
-        console.log('✅ Using server auth state (normal flow)');
-      }
       isAuthenticated.value = inputValue === true;
-    }
-
-    if (import.meta.env.DEV) {
-      console.log('Final isAuthenticated value:', isAuthenticated.value);
     }
 
     // Store auth state for error recovery
     if (isAuthenticated.value) {
-      if (import.meta.env.DEV) {
-        console.log('📝 Storing auth state in sessionStorage');
-      }
       sessionStorage.setItem('ots_auth_state', 'true');
       lastCheckTime.value = Date.now();
       $scheduleNextCheck();
     } else {
-      if (import.meta.env.DEV) {
-        console.log('📝 Removing auth state from sessionStorage');
-      }
       sessionStorage.removeItem('ots_auth_state');
     }
 
     _initialized.value = true;
-    if (import.meta.env.DEV) {
-      console.log('Initialization complete');
-      console.groupEnd();
-    }
     return { needsCheck, isInitialized };
   }
 
@@ -295,12 +266,6 @@ export const useAuthStore = defineStore('auth', () => {
    * is cleared and the store is returned to its default state.
    */
   async function logout() {
-    if (import.meta.env.DEV) {
-      console.group('🚪 logout called');
-      console.log('Timestamp:', new Date().toISOString());
-      console.log('Stack trace:', new Error().stack);
-    }
-
     await $stopAuthCheck();
 
     $reset();
@@ -313,11 +278,6 @@ export const useAuthStore = defineStore('auth', () => {
 
     // Clear all session storage;
     sessionStorage.clear();
-
-    if (import.meta.env.DEV) {
-      console.log('Logout complete');
-      console.groupEnd();
-    }
 
     // Remove any and all lingering store state
     // context.pinia.state.value = {};
@@ -335,23 +295,12 @@ export const useAuthStore = defineStore('auth', () => {
   }
 
   function $reset() {
-    if (import.meta.env.DEV) {
-      console.group('🔄 $reset called');
-      console.log('Timestamp:', new Date().toISOString());
-      console.log('Stack trace:', new Error().stack);
-    }
-
     isAuthenticated.value = null;
     authCheckTimer.value = null;
     failureCount.value = null;
     lastCheckTime.value = null;
     _initialized.value = false;
     sessionStorage.removeItem('ots_auth_state');
-
-    if (import.meta.env.DEV) {
-      console.log('Reset complete');
-      console.groupEnd();
-    }
   }
 
   /**
@@ -360,43 +309,21 @@ export const useAuthStore = defineStore('auth', () => {
    * @param value - The authentication state to set
    */
   async function setAuthenticated(value: boolean) {
-    if (import.meta.env.DEV) {
-      console.group('📝 setAuthenticated called');
-      console.log('Setting authenticated:', value);
-      console.log('Current value:', isAuthenticated.value);
-    }
-
     isAuthenticated.value = value;
 
     // Update sessionStorage for error recovery
     if (value) {
-      if (import.meta.env.DEV) {
-        console.log('📝 Storing in sessionStorage: true');
-      }
       sessionStorage.setItem('ots_auth_state', 'true');
-      if (import.meta.env.DEV) {
-        console.log('Fetching fresh window state...');
-      }
       // Fetch fresh window state immediately to get customer data
       await checkWindowStatus();
     } else {
-      if (import.meta.env.DEV) {
-        console.log('📝 Removing from sessionStorage');
-      }
       sessionStorage.removeItem('ots_auth_state');
       await $stopAuthCheck();
     }
 
     // Sync window state flag
     if (window.__ONETIME_STATE__) {
-      if (import.meta.env.DEV) {
-        console.log('Syncing window.__ONETIME_STATE__.authenticated:', value);
-      }
       window.__ONETIME_STATE__.authenticated = value;
-    }
-
-    if (import.meta.env.DEV) {
-      console.groupEnd();
     }
   }
 
@@ -427,6 +354,5 @@ export const useAuthStore = defineStore('auth', () => {
 });
 
 const deleteCookie = (name: string) => {
-  console.debug('Deleting cookie:', name);
   document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;`;
 };


### PR DESCRIPTION
Cleaned up verbose console logging added during PR #1972 development:
- authStore.ts: Removed console groups/logs from init, logout, reset, and setAuthenticated
- router/guards.routes.ts: Removed beforeEach navigation logging and validation tracing
- plugins/pinia/autoInitPlugin.ts: Removed store initialization logging
- services/window.service.ts: Removed auth-related property access logging

All core functionality and error recovery logic preserved. Tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
