### PR TITLE
Add IP-based access control middleware

### DIFF
--- a/docs/access_control/overview.md
+++ b/docs/access_control/overview.md
@@ -47,7 +47,7 @@ access_control:
   enabled: true
 
   trigger:
-    header: 'X-Access-Control-Trigger'
+    header: 'O-Access-Control-Trigger'
     secret: '<STRONG_RANDOM_SECRET>'  # openssl rand -base64 32
 
   allowed_cidrs:
@@ -98,7 +98,7 @@ example.com {
     # Homepage access control
     @homepage path /
     handle @homepage {
-        header_up X-Access-Control-Trigger "your-shared-secret-here"
+        header_up O-Access-Control-Trigger "your-shared-secret-here"
         reverse_proxy localhost:3000
     }
 
@@ -116,7 +116,7 @@ server {
 
     location / {
         # Set trigger header for homepage
-        proxy_set_header X-Access-Control-Trigger "your-shared-secret-here";
+        proxy_set_header O-Access-Control-Trigger "your-shared-secret-here";
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_pass http://localhost:3000;
     }
@@ -137,7 +137,7 @@ frontend https_frontend
 
     # Set trigger header for homepage
     acl is_homepage path -i /
-    http-request set-header X-Access-Control-Trigger "your-shared-secret-here" if is_homepage
+    http-request set-header O-Access-Control-Trigger "your-shared-secret-here" if is_homepage
 
     default_backend app_backend
 
@@ -258,12 +258,12 @@ end
 
 ```bash
 # Test with internal IP (should allow)
-curl -H "X-Access-Control-Trigger: your-secret" \
+curl -H "O-Access-Control-Trigger: your-secret" \
      -H "X-Forwarded-For: 10.0.0.1" \
      http://localhost:3000/
 
 # Test with external IP (should restrict)
-curl -H "X-Access-Control-Trigger: your-secret" \
+curl -H "O-Access-Control-Trigger: your-secret" \
      -H "X-Forwarded-For: 203.0.113.1" \
      http://localhost:3000/
 
@@ -272,7 +272,7 @@ curl -H "X-Forwarded-For: 203.0.113.1" \
      http://localhost:3000/
 
 # Check mode header in response (for debugging)
-curl -v -H "X-Access-Control-Trigger: your-secret" \
+curl -v -H "O-Access-Control-Trigger: your-secret" \
         -H "X-Forwarded-For: 10.0.0.1" \
         http://localhost:3000/ 2>&1 | grep -i x-access-mode
 ```
@@ -382,7 +382,7 @@ curl -v http://localhost:3000/ 2>&1 | grep -i forward
 example.com {
     @homepage path /
     handle @homepage {
-        header_up X-Access-Control-Trigger "shared-secret-123"
+        header_up O-Access-Control-Trigger "shared-secret-123"
         reverse_proxy localhost:3000
     }
     reverse_proxy localhost:3000
@@ -424,14 +424,14 @@ example.com {
     # Protected routes - require internal IP
     @protected path /admin /dashboard
     handle @protected {
-        header_up X-Access-Control-Trigger "admin-secret"
+        header_up O-Access-Control-Trigger "admin-secret"
         reverse_proxy localhost:3000
     }
 
     # API routes - different secret
     @api path /api/*
     handle @api {
-        header_up X-Access-Control-Trigger "api-secret"
+        header_up O-Access-Control-Trigger "api-secret"
         reverse_proxy localhost:3000
     }
 

--- a/etc/examples/access_control.example.yaml
+++ b/etc/examples/access_control.example.yaml
@@ -23,7 +23,7 @@
 # example.com {
 #     @homepage path /
 #     handle @homepage {
-#         header_up X-Access-Control-Trigger "your-shared-secret"
+#         header_up O-Access-Control-Trigger "your-shared-secret"
 #         reverse_proxy localhost:3000
 #     }
 #     reverse_proxy localhost:3000
@@ -34,7 +34,7 @@
 #
 # ```
 # location / {
-#     proxy_set_header X-Access-Control-Trigger "your-shared-secret";
+#     proxy_set_header O-Access-Control-Trigger "your-shared-secret";
 #     proxy_pass http://localhost:3000;
 # }
 # ```
@@ -70,7 +70,7 @@ access_control:
     # Header name that reverse proxy will set
     # Standard practice: Use 'X-' prefix for custom headers
     #
-    header: <%= ENV['ACCESS_CONTROL_TRIGGER_HEADER'] || 'X-Access-Control-Trigger' %>
+    header: <%= ENV['ACCESS_CONTROL_TRIGGER_HEADER'] || 'O-Access-Control-Trigger' %>
 
     # Shared secret between infrastructure and application
     #
@@ -83,6 +83,33 @@ access_control:
     # Generate with: openssl rand -base64 32
     #
     secret: <%= ENV['ACCESS_CONTROL_TRIGGER_SECRET'] %>
+
+  # Trusted Proxy Depth
+  #
+  # ⚠️  CRITICAL SECURITY SETTING
+  #
+  # Number of trusted proxies in your infrastructure chain. This determines
+  # how X-Forwarded-For header is interpreted to prevent IP spoofing.
+  #
+  # DEFAULT: 0 (X-Forwarded-For IGNORED, uses REMOTE_ADDR only)
+  #
+  # Only set > 0 when ALL these conditions are met:
+  # 1. Application is behind a trusted reverse proxy
+  # 2. Direct access to application is BLOCKED by firewall
+  # 3. Proxy strips/overrides client-provided X-Forwarded-For
+  #
+  # Values:
+  # - 0: Ignore X-Forwarded-For, use REMOTE_ADDR (SAFEST, DEFAULT)
+  # - 1: Trust 1 proxy (use rightmost IP in X-Forwarded-For)
+  # - 2: Trust 2 proxies (use 2nd rightmost IP)
+  #
+  # Example without firewall protection (VULNERABLE):
+  #   curl -H "X-Forwarded-For: 10.0.0.1" http://app:3000/
+  #   # Attacker spoofs internal IP, bypasses allowlist
+  #
+  # See security documentation for firewall configuration examples.
+  #
+  trusted_proxy_depth: <%= ENV['TRUSTED_PROXY_DEPTH'] || '0' %>
 
   # IP Allowlist
   #
@@ -153,6 +180,9 @@ access_control:
 # export ACCESS_CONTROL_TRIGGER_HEADER="O-Access-Control-Trigger"
 # export ACCESS_CONTROL_TRIGGER_SECRET="$(openssl rand -base64 32)"
 #
+# # Trusted proxy depth (IMPORTANT FOR SECURITY)
+# export TRUSTED_PROXY_DEPTH=1  # Only if behind reverse proxy with firewall
+#
 # # IP allowlist (comma-separated CIDRs, no limit)
 # # Single CIDR:
 # export ALLOWED_CIDRS="10.0.0.0/8"
@@ -165,3 +195,37 @@ access_control:
 # export ACCESS_CONTROL_MODE_HEADER="O-Access-Mode"
 # export ACCESS_MODE_ALLOW="normal"
 # export ACCESS_MODE_DENY="protected"
+#
+# Firewall Configuration Examples
+#
+# ⚠️  CRITICAL: Block direct access to application when using trusted_proxy_depth > 0
+#
+# UFW (Ubuntu):
+# ```bash
+# # Allow only from reverse proxy
+# sudo ufw allow from 10.0.1.100 to any port 3000 proto tcp
+# sudo ufw deny 3000
+# ```
+#
+# iptables:
+# ```bash
+# # Allow only from reverse proxy at 10.0.1.100
+# iptables -A INPUT -p tcp -s 10.0.1.100 --dport 3000 -j ACCEPT
+# iptables -A INPUT -p tcp --dport 3000 -j DROP
+# ```
+#
+# Docker network isolation:
+# ```yaml
+# services:
+#   app:
+#     networks:
+#       - internal  # Not exposed to internet
+#   proxy:
+#     networks:
+#       - internal
+#       - external
+# networks:
+#   internal:
+#     internal: true
+#   external:
+# ```


### PR DESCRIPTION
Resolves #1992

## Summary

Implements optional IP-based access control middleware that allows reverse proxies to signal restricted access modes to the application. The middleware checks client IPs against configurable CIDR allowlists and sets header signals that the application can use to enforce access policies.

This is a purely additive feature - disabled by default, requires explicit configuration, and doesn't modify any existing code paths. The middleware never blocks requests directly; it only sets headers that application code can choose to respect.

## What Changed

Added a new middleware component with comprehensive test coverage and documentation:

- **New middleware** (`lib/onetime/middleware/access_control.rb`): IP allowlist checking with IPv4/IPv6 CIDR support, trigger-based activation via shared secret header, timing-attack resistant secret comparison
- **Test suite** (`try/middleware/access_control_try.rb`): 18 test cases covering disabled states, IP matching, CIDR ranges, X-Forwarded-For handling, trigger validation, and fail-safe behavior
- **Documentation** (`docs/access_control/overview.md`): Architecture diagrams, configuration guide, reverse proxy examples (Caddy, Nginx, HAProxy), security model, and troubleshooting
- **Config template** (`etc/examples/access_control.example.yaml`): Optional template with comma-separated CIDR notation, environment variable expansion, and sensible defaults

## Architecture

The middleware implements a signal-based model where infrastructure signals access mode but doesn't enforce policy:

1. Reverse proxy sets trigger header with shared secret when restricted mode needed
2. Middleware validates trigger + checks client IP against allowlist
3. Sets `O-Access-Mode` header for application to inspect
4. Application code decides whether to enforce restrictions

This separation keeps infrastructure concerns (IP checking) separate from business logic (what restrictions mean), and ensures fail-safe behavior - missing triggers or misconfigurations result in normal operation rather than denied access.

## Security Considerations

**Trusted infrastructure assumption**: The middleware relies on a trusted reverse proxy to set the trigger header with the correct shared secret. This is appropriate for environments where the proxy is under the same administrative control as the application.

**Timing-safe comparison**: Uses constant-time comparison for secret validation to prevent timing attacks.

**IP spoofing mitigation**: Only respects X-Forwarded-For when explicitly configured, and assumes the reverse proxy has been configured to strip/override client-provided headers.

**Fail-safe defaults**: Feature is disabled unless explicitly configured. Invalid configurations or missing triggers result in passthrough (no restriction signal), which is safer than accidentally blocking legitimate traffic.

## Review Focus

- **Security model**: Verify the trust boundary assumptions about reverse proxy configuration make sense for typical deployments
- **Configuration safety**: Confirm defaults don't accidentally enable restrictions (feature should be explicitly opt-in)
- **Header naming**: Check that `O-` prefix aligns with project conventions for custom headers
- **Documentation**: Validate reverse proxy examples match real-world setups
- **Test coverage**: Review edge cases in test suite (empty allowlists, IPv6, timing attacks, mixed CIDR notation)

## Testing

All changes covered by 18 tryouts test cases:
```bash
bundle exec try --agent try/middleware/access_control_try.rb
```

No existing tests modified - this is purely additive functionality.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)