### PR TITLE
Add test coverage for chain_length == trusted_proxy_depth scenario

### DIFF
--- a/tests/unit/ruby/rspec/onetime/helpers/homepage_mode_helpers_spec.rb
+++ b/tests/unit/ruby/rspec/onetime/helpers/homepage_mode_helpers_spec.rb
@@ -568,6 +568,15 @@ RSpec.describe Onetime::Helpers::HomepageModeHelpers do
         result = test_instance.send(:extract_ip_from_header, 'X-Forwarded-For', 1)
         expect(result).to eq('203.0.113.0')
       end
+
+      it 'handles single IP in chain (common case with 1 proxy)' do
+        # Chain: client -> proxy1
+        # X-Forwarded-For: client_ip (proxy doesn't add itself)
+        # This is the normal case: chain_length == trusted_proxy_depth
+        mock_req.env['HTTP_X_FORWARDED_FOR'] = '203.0.113.0'
+        result = test_instance.send(:extract_ip_from_header, 'X-Forwarded-For', 1)
+        expect(result).to eq('203.0.113.0')
+      end
     end
 
     context 'with trusted_proxy_depth of 2' do


### PR DESCRIPTION
Added test case documenting the common scenario where the X-Forwarded-For chain length exactly equals the trusted_proxy_depth. This is the normal case when using a single reverse proxy.

SCENARIO:
- Client → Proxy (trusted_proxy_depth = 1)
- X-Forwarded-For contains only: client_ip
- Chain length: 1, Proxy depth: 1 (equal)

EXPECTED BEHAVIOR:
The code correctly extracts the client IP in this case. The log message "Chain shorter than proxy depth" is slightly misleading when they're equal, but the extraction logic is correct.

This is what's happening in production logs:
- REMOTE_ADDR: 127.0.0.6 (the proxy)
- X-Forwarded-For: B.180.169.0 (the client)
- trusted_proxy_depth: 1
- Result: Correctly extracts B.180.169.0 as client IP ✓

TEST RESULTS:
✅ 111 examples, 0 failures (+1 new test)

The proxy configuration is working correctly. The "no mode applied" result is because client IP doesn't match any of the configured CIDRs, not because of incorrect proxy depth handling.