### PR TITLE
Consolidate Zod v4 schemas for YAML config files

### DIFF
--- a/.github/workflows/openapi-generation.yml
+++ b/.github/workflows/openapi-generation.yml
@@ -21,7 +21,7 @@ on:
       - develop
     paths:
       - 'src/schemas/**/*.ts'
-      - 'apps/api/*/routes'
+      - 'apps/api/*/routes.txt'
       - 'src/scripts/openapi/**/*.ts'
   pull_request:
     branches:
@@ -29,7 +29,7 @@ on:
       - main
     paths:
       - 'src/schemas/**/*.ts'
-      - 'apps/api/*/routes'
+      - 'apps/api/*/routes.txt'
       - 'src/scripts/openapi/**/*.ts'
   workflow_dispatch:
     inputs:

--- a/docs/api/account-openapi.json
+++ b/docs/api/account-openapi.json
@@ -94,7 +94,15 @@
             "description": "Custom metadata key-value pairs"
           }
         },
-        "required": ["id", "email", "name", "created", "currency", "balance", "metadata"]
+        "required": [
+          "id",
+          "email",
+          "name",
+          "created",
+          "currency",
+          "balance",
+          "metadata"
+        ]
       },
       "StripeSubscription": {
         "type": "object",
@@ -172,23 +180,41 @@
                           "properties": {
                             "interval": {
                               "type": "string",
-                              "enum": ["day", "week", "month", "year"]
+                              "enum": [
+                                "day",
+                                "week",
+                                "month",
+                                "year"
+                              ]
                             },
                             "interval_count": {
                               "type": "number"
                             }
                           },
-                          "required": ["interval", "interval_count"]
+                          "required": [
+                            "interval",
+                            "interval_count"
+                          ]
                         }
                       },
-                      "required": ["id", "currency", "unit_amount", "recurring"]
+                      "required": [
+                        "id",
+                        "currency",
+                        "unit_amount",
+                        "recurring"
+                      ]
                     }
                   },
-                  "required": ["id", "price"]
+                  "required": [
+                    "id",
+                    "price"
+                  ]
                 }
               }
             },
-            "required": ["data"],
+            "required": [
+              "data"
+            ],
             "description": "Subscription line items"
           },
           "metadata": {
@@ -237,7 +263,12 @@
               },
               "role": {
                 "type": "string",
-                "enum": ["customer", "colonel", "recipient", "user_deleted_self"]
+                "enum": [
+                  "customer",
+                  "colonel",
+                  "recipient",
+                  "user_deleted_self"
+                ]
               },
               "email": {
                 "type": "string",
@@ -343,7 +374,11 @@
             }
           }
         },
-        "required": ["cust", "stripe_customer", "stripe_subscriptions"]
+        "required": [
+          "cust",
+          "stripe_customer",
+          "stripe_subscriptions"
+        ]
       },
       "ApiToken": {
         "type": "object",
@@ -356,7 +391,9 @@
             "nullable": true
           }
         },
-        "required": ["apitoken"]
+        "required": [
+          "apitoken"
+        ]
       },
       "CheckAuthDetails": {
         "type": "object",
@@ -365,7 +402,9 @@
             "type": "boolean"
           }
         },
-        "required": ["authenticated"]
+        "required": [
+          "authenticated"
+        ]
       },
       "ColonelInfo": {
         "type": "object",
@@ -400,7 +439,12 @@
                   "type": "string"
                 }
               },
-              "required": ["custid", "colonel", "verified", "stamp"]
+              "required": [
+                "custid",
+                "colonel",
+                "verified",
+                "stamp"
+              ]
             },
             "default": []
           },
@@ -418,7 +462,10 @@
                   "type": "string"
                 }
               },
-              "required": ["msg", "stamp"]
+              "required": [
+                "msg",
+                "stamp"
+              ]
             },
             "default": []
           },
@@ -436,7 +483,10 @@
                   "type": "string"
                 }
               },
-              "required": ["msg", "stamp"]
+              "required": [
+                "msg",
+                "stamp"
+              ]
             },
             "default": []
           },
@@ -455,7 +505,10 @@
                   "type": "string"
                 }
               },
-              "required": ["msg", "stamp"]
+              "required": [
+                "msg",
+                "stamp"
+              ]
             },
             "default": null
           },
@@ -521,7 +574,9 @@
             }
           }
         },
-        "required": ["counts"]
+        "required": [
+          "counts"
+        ]
       },
       "ColonelStats": {
         "type": "object",
@@ -560,7 +615,9 @@
             }
           }
         },
-        "required": ["counts"]
+        "required": [
+          "counts"
+        ]
       },
       "ErrorResponse": {
         "type": "object",
@@ -572,7 +629,9 @@
             "type": "string"
           }
         },
-        "required": ["message"]
+        "required": [
+          "message"
+        ]
       },
       "ChangePasswordRequest": {
         "type": "object",
@@ -588,7 +647,11 @@
             "type": "string"
           }
         },
-        "required": ["current_password", "new_password", "confirm_password"]
+        "required": [
+          "current_password",
+          "new_password",
+          "confirm_password"
+        ]
       },
       "UpdateLocaleRequest": {
         "type": "object",
@@ -599,7 +662,9 @@
             "description": "Language code (e.g., en, es, fr)"
           }
         },
-        "required": ["locale"]
+        "required": [
+          "locale"
+        ]
       }
     },
     "parameters": {}
@@ -609,7 +674,9 @@
       "post": {
         "summary": "Destroy account",
         "description": "Permanently delete the user account and all associated data. This action cannot be undone.",
-        "tags": ["account"],
+        "tags": [
+          "account"
+        ],
         "security": [
           {
             "SessionAuth": []
@@ -635,7 +702,9 @@
       "post": {
         "summary": "Change password",
         "description": "Update the account password. Requires current password verification.",
-        "tags": ["account"],
+        "tags": [
+          "account"
+        ],
         "security": [
           {
             "SessionAuth": []
@@ -670,8 +739,12 @@
       "post": {
         "summary": "Update locale preference",
         "description": "Change the user's language preference for the interface.",
-        "tags": ["account"],
-        "security": [{}],
+        "tags": [
+          "account"
+        ],
+        "security": [
+          {}
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -695,7 +768,9 @@
       "post": {
         "summary": "Generate API token",
         "description": "Generate a new API token for programmatic access. Previous token will be invalidated.",
-        "tags": ["account"],
+        "tags": [
+          "account"
+        ],
         "security": [
           {
             "SessionAuth": []
@@ -720,7 +795,9 @@
                       "nullable": true
                     }
                   },
-                  "required": ["apitoken"]
+                  "required": [
+                    "apitoken"
+                  ]
                 }
               }
             }
@@ -735,7 +812,9 @@
       "get": {
         "summary": "Get account details",
         "description": "Retrieve complete account information including Stripe subscription data if applicable.",
-        "tags": ["account"],
+        "tags": [
+          "account"
+        ],
         "security": [
           {
             "SessionAuth": []
@@ -757,255 +836,6 @@
           },
           "401": {
             "description": "Unauthorized - Authentication required"
-          }
-        }
-      }
-    },
-    "/api/colonel/info": {
-      "get": {
-        "summary": "Get colonel dashboard info",
-        "description": "Retrieve comprehensive dashboard information for administrators. Requires colonel role.",
-        "tags": ["account", "colonel"],
-        "security": [
-          {
-            "SessionAuth": []
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Colonel info retrieved successfully",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "recent_customers": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "custid": {
-                            "type": "string"
-                          },
-                          "colonel": {
-                            "type": "boolean"
-                          },
-                          "secrets_created": {
-                            "type": "number",
-                            "nullable": true
-                          },
-                          "secrets_shared": {
-                            "type": "number",
-                            "nullable": true
-                          },
-                          "emails_sent": {
-                            "type": "number",
-                            "nullable": true
-                          },
-                          "verified": {
-                            "type": "boolean"
-                          },
-                          "stamp": {
-                            "type": "string"
-                          }
-                        },
-                        "required": ["custid", "colonel", "verified", "stamp"]
-                      },
-                      "default": []
-                    },
-                    "today_feedback": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "msg": {
-                            "type": "string",
-                            "minLength": 1,
-                            "maxLength": 1500
-                          },
-                          "stamp": {
-                            "type": "string"
-                          }
-                        },
-                        "required": ["msg", "stamp"]
-                      },
-                      "default": []
-                    },
-                    "yesterday_feedback": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "msg": {
-                            "type": "string",
-                            "minLength": 1,
-                            "maxLength": 1500
-                          },
-                          "stamp": {
-                            "type": "string"
-                          }
-                        },
-                        "required": ["msg", "stamp"]
-                      },
-                      "default": []
-                    },
-                    "older_feedback": {
-                      "type": "array",
-                      "nullable": true,
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "msg": {
-                            "type": "string",
-                            "minLength": 1,
-                            "maxLength": 1500
-                          },
-                          "stamp": {
-                            "type": "string"
-                          }
-                        },
-                        "required": ["msg", "stamp"]
-                      },
-                      "default": null
-                    },
-                    "dbclient_info": {
-                      "type": "string",
-                      "default": ""
-                    },
-                    "billing_enabled": {
-                      "type": "boolean",
-                      "default": false
-                    },
-                    "counts": {
-                      "type": "object",
-                      "properties": {
-                        "customer_count": {
-                          "type": "number",
-                          "nullable": true
-                        },
-                        "emails_sent": {
-                          "type": "number",
-                          "nullable": true
-                        },
-                        "feedback_count": {
-                          "type": "number",
-                          "nullable": true
-                        },
-                        "metadata_count": {
-                          "type": "number",
-                          "nullable": true
-                        },
-                        "older_feedback_count": {
-                          "type": "number",
-                          "nullable": true
-                        },
-                        "recent_customer_count": {
-                          "type": "number",
-                          "nullable": true
-                        },
-                        "secret_count": {
-                          "type": "number",
-                          "nullable": true
-                        },
-                        "secrets_created": {
-                          "type": "number",
-                          "nullable": true
-                        },
-                        "secrets_shared": {
-                          "type": "number",
-                          "nullable": true
-                        },
-                        "session_count": {
-                          "type": "number",
-                          "nullable": true
-                        },
-                        "today_feedback_count": {
-                          "type": "number",
-                          "nullable": true
-                        },
-                        "yesterday_feedback_count": {
-                          "type": "number",
-                          "nullable": true
-                        }
-                      }
-                    }
-                  },
-                  "required": ["counts"]
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized - Authentication required"
-          },
-          "403": {
-            "description": "Forbidden - Insufficient permissions"
-          }
-        }
-      }
-    },
-    "/api/colonel/stats": {
-      "get": {
-        "summary": "Get colonel statistics",
-        "description": "Retrieve system-wide statistics for administrators. Requires colonel role.",
-        "tags": ["account", "colonel"],
-        "security": [
-          {
-            "SessionAuth": []
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Colonel stats retrieved successfully",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "counts": {
-                      "type": "object",
-                      "properties": {
-                        "customer_count": {
-                          "type": "number",
-                          "nullable": true
-                        },
-                        "emails_sent": {
-                          "type": "number",
-                          "nullable": true
-                        },
-                        "metadata_count": {
-                          "type": "number",
-                          "nullable": true
-                        },
-                        "secret_count": {
-                          "type": "number",
-                          "nullable": true
-                        },
-                        "secrets_created": {
-                          "type": "number",
-                          "nullable": true
-                        },
-                        "secrets_shared": {
-                          "type": "number",
-                          "nullable": true
-                        },
-                        "session_count": {
-                          "type": "number",
-                          "nullable": true
-                        }
-                      }
-                    }
-                  },
-                  "required": ["counts"]
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized - Authentication required"
-          },
-          "403": {
-            "description": "Forbidden - Insufficient permissions"
           }
         }
       }

--- a/src/schemas/api/account/endpoints/colonel.ts
+++ b/src/schemas/api/account/endpoints/colonel.ts
@@ -1,259 +1,29 @@
-// src/schemas/api/endpoints/colonel.ts
+// src/schemas/api/account/endpoints/colonel.ts
+
+/**
+ * Colonel (Admin) API Endpoint Schemas
+ *
+ * This file contains schemas for the colonel/admin API endpoints.
+ * Config-related schemas are imported from @/schemas/config/config.ts
+ */
 
 import { feedbackSchema } from '@/schemas/models';
 import { transforms } from '@/schemas/transforms';
-import { z } from 'zod';
+import { z } from 'zod/v4';
 
-// Common types
-// More flexible type validation that can handle missing values
-const booleanOrString = z.union([z.boolean(), z.string()]).optional();
-const numberOrString = z.union([z.string(), z.number()]).optional();
+// Import system settings schemas from config
+import {
+  systemSettingsSchema,
+  systemSettingsDetailsSchema,
+} from '@/schemas/config/config';
 
-const interfaceSchema = z.object({
-  ui: z
-    .object({
-      enabled: booleanOrString.optional(),
-      header: z
-        .object({
-          enabled: booleanOrString.optional(),
-          branding: z
-            .object({
-              logo: z
-                .object({
-                  url: z.string().optional(),
-                  alt: z.string().optional(),
-                  link_to: z.string().optional(),
-                })
-                .optional(),
-              site_name: z.string().optional(),
-            })
-            .optional(),
-          navigation: z
-            .object({
-              enabled: booleanOrString.optional(),
-            })
-            .optional(),
-        })
-        .optional(),
-      footer_links: z
-        .object({
-          enabled: booleanOrString.optional(),
-          groups: z
-            .array(
-              z.object({
-                name: z.string().optional(),
-                i18n_key: z.string().optional(),
-                links: z
-                  .array(
-                    z.object({
-                      text: z.string().nullable().optional(),
-                      i18n_key: z.string().nullable().optional(),
-                      url: z.string().nullable().optional(),
-                      external: z.boolean().nullable().optional(),
-                      icon: z.string().nullable().optional(),
-                      visible: z.boolean().nullable().optional(),
-                    })
-                  )
-                  .optional(),
-              })
-            )
-            .optional(),
-        })
-        .optional(),
-    })
-    .optional(),
-  api: z
-    .object({
-      enabled: booleanOrString.optional(),
-    })
-    .optional(),
-});
+// Re-export for backward compatibility
+export { systemSettingsSchema, systemSettingsDetailsSchema };
+export type SystemSettingsDetails = z.infer<typeof systemSettingsDetailsSchema>;
 
-// Secret options
-const secretOptionsSchema = z.object({
-  default_ttl: numberOrString.optional(),
-  ttl_options: z.union([z.string(), z.array(z.number())]).optional(),
-  passphrase: z
-    .object({
-      required: booleanOrString.optional(),
-      minimum_length: numberOrString.optional(),
-      maximum_length: numberOrString.optional(),
-      enforce_complexity: booleanOrString.optional(),
-    })
-    .nullable()
-    .optional(),
-  password_generation: z
-    .object({
-      default_length: numberOrString.optional(),
-      character_sets: z
-        .object({
-          uppercase: booleanOrString.optional(),
-          lowercase: booleanOrString.optional(),
-          numbers: booleanOrString.optional(),
-          symbols: booleanOrString.optional(),
-          exclude_ambiguous: booleanOrString.optional(),
-        })
-        .nullable()
-        .optional(),
-    })
-    .nullable()
-    .optional(),
-});
-
-// Emailer schema (SMTP settings)
-const emailerSchema = z.object({
-  mode: z.string().nullable().optional(),
-  region: z.string().nullable().optional(),
-  from: z.string().nullable().optional(),
-  from_name: z.string().nullable().optional(),
-  reply_to: z.string().nullable().optional(),
-  host: z.string().nullable().optional(),
-  port: numberOrString.nullable().optional(),
-  user: z.string().nullable().optional(),
-  pass: z.string().nullable().optional(), // Should be masked by backend
-  auth: z.string().nullable().optional(),
-  tls: z.union([z.boolean(), z.string()]).nullable().optional(),
-});
-
-// Mail schema (TrueMail validation)
-const mailSchema = z.object({
-  truemail: z
-    .object({
-      default_validation_type: z.string().optional(),
-      verifier_email: z.string().optional(),
-      verifier_domain: z.string().optional(),
-      allowed_domains_only: z.boolean().optional(),
-      dns: z.array(z.string()).optional(),
-      smtp_fail_fast: z.boolean().optional(),
-      smtp_safe_check: z.boolean().optional(),
-      not_rfc_mx_lookup_flow: z.boolean().optional(),
-      logger: z
-        .object({
-          tracking_event: z.any().optional(),
-          stdout: z.any().optional(),
-        })
-        .optional(),
-    })
-    .optional(),
-});
-
-// Diagnostics schema
-const diagnosticsSchema = z.object({
-  enabled: booleanOrString.nullable().optional(),
-  redis_uri: z.string().nullable().optional(),
-  sentry: z
-    .object({
-      defaults: z
-        .object({
-          dsn: z.string().nullable().optional(),
-          sampleRate: z.union([z.string(), z.number()]).nullable().optional(),
-          maxBreadcrumbs: z.union([z.string(), z.number()]).nullable().optional(),
-          logErrors: booleanOrString.nullable().optional(),
-        })
-        .nullable()
-        .optional(),
-      backend: z
-        .object({
-          dsn: z.string().nullable().optional(),
-          sampleRate: z.union([z.string(), z.number()]).nullable().optional(),
-          maxBreadcrumbs: z.union([z.string(), z.number()]).nullable().optional(),
-          logErrors: booleanOrString.nullable().optional(),
-        })
-        .nullable()
-        .optional(),
-      frontend: z
-        .object({
-          dsn: z.string().nullable().optional(),
-          sampleRate: z.union([z.string(), z.number()]).nullable().optional(),
-          maxBreadcrumbs: z.union([z.string(), z.number()]).nullable().optional(),
-          logErrors: booleanOrString.nullable().optional(),
-          trackComponents: booleanOrString.nullable().optional(),
-        })
-        .nullable()
-        .optional(),
-    })
-    .nullable()
-    .optional(),
-});
-
-// Authentication schema
-const authenticationSchema = z.object({
-  enabled: booleanOrString.optional(),
-  signup: booleanOrString.optional(),
-  signin: booleanOrString.optional(),
-  autoverify: booleanOrString.optional(),
-  required: booleanOrString.optional(),
-  colonels: z.array(z.string()).nullable().optional(),
-  allowed_signup_domains: z.array(z.string()).nullable().optional(),
-});
-
-// Logging schema
-const loggingSchema = z.object({
-  default_level: z.string().nullable().optional(),
-  formatter: z.string().nullable().optional(),
-  loggers: z.record(z.string()).nullable().optional(),
-  http: z
-    .object({
-      enabled: booleanOrString.optional(),
-      level: z.string().nullable().optional(),
-      capture: z.string().nullable().optional(),
-      slow_request_ms: numberOrString.optional(),
-      ignore_paths: z.array(z.string()).nullable().optional(),
-    })
-    .nullable()
-    .optional(),
-});
-
-// Billing schema (when enabled)
-const billingSchema = z.object({
-  enabled: booleanOrString.optional(),
-  stripe_key: z.string().nullable().optional(), // Masked by backend
-  webhook_signing_secret: z.string().nullable().optional(), // Masked by backend
-  stripe_api_version: z.string().nullable().optional(),
-  capabilities: z.record(z.any()).nullable().optional(),
-});
-
-// Features schema
-const featuresSchema = z.object({
-  regions: z
-    .object({
-      enabled: booleanOrString.optional(),
-      current_jurisdiction: z.string().nullable().optional(),
-      jurisdictions: z.array(z.any()).nullable().optional(),
-    })
-    .nullable()
-    .optional(),
-  domains: z
-    .object({
-      enabled: booleanOrString.optional(),
-      default: z.string().nullable().optional(),
-      strategy: z.string().nullable().optional(),
-    })
-    .nullable()
-    .optional(),
-});
-
-/**
- * SystemSettingsSchema defines the top-level structure of the settings.
- * Each section references deeper schemas defined elsewhere.
- * Using .optional() to handle partial settings data during initialization.
- */
-export const systemSettingsSchema = z.object({
-  interface: interfaceSchema.nullable().optional(),
-  secret_options: secretOptionsSchema.nullable().optional(),
-  authentication: authenticationSchema.nullable().optional(),
-  emailer: emailerSchema.nullable().optional(),
-  mail: mailSchema.nullable().optional(),
-  diagnostics: diagnosticsSchema.nullable().optional(),
-  logging: loggingSchema.nullable().optional(),
-  billing: billingSchema.nullable().optional(),
-  features: featuresSchema.nullable().optional(),
-});
-
-export const systemSettingsDetailsSchema = systemSettingsSchema.extend({
-  // This extension allows for additional fields in the future without breaking changes
-  // All fields are optional with defaults to handle missing data
-});
+// ============================================================================
+// Colonel API Response Schemas
+// ============================================================================
 
 /**
  * An abridged customer record used in the recent list.
@@ -463,10 +233,6 @@ export const customDomainsDetailsSchema = z.object({
 });
 
 /**
- // Raw API data structures before transformation
- // These represent the API shape that will be transformed by input schemas
- */
-/**
  * Lightweight stats schema for dashboard display
  */
 export const colonelStatsDetailsSchema = z.object({
@@ -504,10 +270,12 @@ export const colonelInfoDetailsSchema = z.object({
   }),
 });
 
-// Export types
+// ============================================================================
+// Type Exports
+// ============================================================================
+
 export type ColonelStatsDetails = z.infer<typeof colonelStatsDetailsSchema>;
 export type ColonelInfoDetails = z.infer<typeof colonelInfoDetailsSchema>;
-export type SystemSettingsDetails = z.infer<typeof systemSettingsDetailsSchema>;
 export type RecentCustomer = z.infer<typeof recentCustomerSchema>;
 export type ColonelUser = z.infer<typeof colonelUserSchema>;
 export type ColonelUsersDetails = z.infer<typeof colonelUsersDetailsSchema>;

--- a/src/schemas/config/auth.ts
+++ b/src/schemas/config/auth.ts
@@ -1,0 +1,102 @@
+// src/schemas/config/auth.ts
+
+/**
+ * Authentication Configuration Schema
+ *
+ * Zod v4 schema for etc/defaults/auth.defaults.yaml
+ *
+ * Purpose:
+ * - Type-safe validation of authentication configuration
+ * - Runtime validation for YAML parsing
+ * - TypeScript type inference for auth config usage
+ */
+
+import { z } from 'zod/v4';
+import { nullableString } from './shared/primitives';
+
+/**
+ * Authentication mode
+ */
+const authModeSchema = z.enum(['basic', 'advanced']);
+
+/**
+ * Session configuration (shared between basic and advanced modes)
+ */
+const sessionConfigSchema = z.object({
+  secret: nullableString,
+  expire_after: z.number().int().positive().default(86400), // 24 hours
+  key: z.string().default('onetime.session'),
+  secure: z.boolean().default(true),
+  same_site: z.enum(['strict', 'lax', 'none']).default('strict'),
+});
+
+/**
+ * Basic mode settings (Redis-only authentication)
+ */
+const basicModeSchema = z.object({
+  password_hash_cost: z.number().int().positive().optional(),
+  session_timeout: z.number().int().positive().optional(),
+});
+
+/**
+ * Advanced mode settings (Rodauth-based application)
+ */
+const advancedModeSchema = z.object({
+  /**
+   * Application database connection URL
+   *
+   * SQLite paths:
+   *   - 'sqlite://:memory:' - In-memory, no persistence (dev/test only)
+   *   - 'sqlite://data/auth.db' - Relative path
+   *   - 'sqlite:///data/auth.db' - Absolute path
+   */
+  database_url: z.string().default('sqlite://data/auth.db'),
+
+  /**
+   * Migrations connection (PostgreSQL, MySQL, MS SQL Server only)
+   *
+   * Used at deployment time to run all Rodauth migrations
+   */
+  database_url_migrations: nullableString,
+
+  /**
+   * Service URL for internal requests
+   */
+  service_url: z.string().optional(),
+});
+
+/**
+ * Complete authentication configuration schema
+ *
+ * Matches the structure from etc/defaults/auth.defaults.yaml
+ */
+const authConfigSchema = z.object({
+  mode: authModeSchema.default('basic'),
+  session: sessionConfigSchema.optional(),
+  basic: basicModeSchema.optional(),
+  advanced: advancedModeSchema.optional(),
+});
+
+export type AuthMode = z.infer<typeof authModeSchema>;
+export type SessionConfig = z.infer<typeof sessionConfigSchema>;
+export type BasicModeConfig = z.infer<typeof basicModeSchema>;
+export type AdvancedModeConfig = z.infer<typeof advancedModeSchema>;
+export type AuthConfig = z.infer<typeof authConfigSchema>;
+
+export {
+  authConfigSchema,
+  authModeSchema,
+  sessionConfigSchema,
+  basicModeSchema,
+  advancedModeSchema,
+};
+
+/**
+ * Type guard: Check if auth config is valid
+ *
+ * @param data - Unknown data to validate
+ * @returns True if data matches AuthConfig schema
+ */
+export function isAuthConfig(data: unknown): data is AuthConfig {
+  return authConfigSchema.safeParse(data).success;
+}

--- a/src/schemas/config/billing-plans.ts
+++ b/src/schemas/config/billing-plans.ts
@@ -20,7 +20,7 @@
  * ```
  */
 
-import { z } from 'zod';
+import { z } from 'zod/v4';
 
 /**
  * Schema Version

--- a/src/schemas/config/billing.ts
+++ b/src/schemas/config/billing.ts
@@ -18,7 +18,7 @@
  * ```
  */
 
-import { z } from 'zod';
+import { z } from 'zod/v4';
 
 /**
  * Capability Category

--- a/src/schemas/config/config.ts
+++ b/src/schemas/config/config.ts
@@ -1,0 +1,444 @@
+// src/schemas/config/config.ts
+
+/**
+ * Application Configuration Schema
+ *
+ * Consolidated Zod v4 schemas for config.defaults.yaml
+ *
+ * This schema supports two use cases:
+ * 1. API Response Parsing - flexible schemas that accept string/boolean unions
+ *    for values that may come as strings from environment variables
+ * 2. Config File Validation - strict schemas matching YAML structure
+ *
+ * The API response schemas use booleanOrString/numberOrString for flexibility
+ * when parsing backend responses that may have coerced values.
+ */
+
+import { z } from 'zod/v4';
+
+import { siteSchema, siteAuthenticationSchema, passphraseSchema, passwordGenerationSchema } from './section/site';
+import { storageSchema, redisSchema } from './section/storage';
+import { emailerSchema, mailSchema, mailConnectionSchema, mailValidationSchema } from './section/mail';
+import { diagnosticsSchema } from './section/diagnostics';
+import { featuresSchema } from './section/features';
+import { capabilitiesSchema } from './section/capabilities';
+import { i18nSchema } from './section/i18n';
+import { developmentSchema } from './section/development';
+import { experimentalSchema } from './section/experimental';
+import { userInterfaceSchema, apiSchema } from './section/ui';
+import { limitsSchema } from './section/limits';
+import { secretOptionsSchema } from './section/secret_options';
+
+// ============================================================================
+// Flexible Type Helpers (for API response parsing)
+// ============================================================================
+
+/**
+ * Flexible boolean that accepts boolean or string ("true"/"false")
+ * Used when parsing API responses where env vars may be stringified
+ */
+export const booleanOrString = z.union([z.boolean(), z.string()]).optional();
+
+/**
+ * Flexible number that accepts number or string
+ * Used when parsing API responses where env vars may be stringified
+ */
+export const numberOrString = z.union([z.string(), z.number()]).optional();
+
+// ============================================================================
+// API Response Schemas (flexible, for parsing backend responses)
+// ============================================================================
+
+/**
+ * Interface schema for API responses
+ * More permissive than config file schema to handle string coercion
+ */
+export const apiInterfaceSchema = z.object({
+  ui: z
+    .object({
+      enabled: booleanOrString,
+      header: z
+        .object({
+          enabled: booleanOrString,
+          branding: z
+            .object({
+              logo: z
+                .object({
+                  url: z.string().optional(),
+                  alt: z.string().optional(),
+                  href: z.string().optional(),
+                  link_to: z.string().optional(), // Legacy field
+                })
+                .optional(),
+              site_name: z.string().optional(),
+            })
+            .optional(),
+          navigation: z
+            .object({
+              enabled: booleanOrString,
+            })
+            .optional(),
+        })
+        .optional(),
+      footer_links: z
+        .object({
+          enabled: booleanOrString,
+          groups: z
+            .array(
+              z.object({
+                name: z.string().optional(),
+                i18n_key: z.string().optional(),
+                links: z
+                  .array(
+                    z.object({
+                      text: z.string().nullable().optional(),
+                      i18n_key: z.string().nullable().optional(),
+                      url: z.string().nullable().optional(),
+                      external: z.boolean().nullable().optional(),
+                      icon: z.string().nullable().optional(),
+                      visible: z.boolean().nullable().optional(),
+                    })
+                  )
+                  .optional(),
+              })
+            )
+            .optional(),
+        })
+        .optional(),
+    })
+    .optional(),
+  api: z
+    .object({
+      enabled: booleanOrString,
+    })
+    .optional(),
+});
+
+/**
+ * Secret options schema for API responses
+ */
+export const apiSecretOptionsSchema = z.object({
+  default_ttl: numberOrString,
+  ttl_options: z.union([z.string(), z.array(z.number())]).optional(),
+  passphrase: z
+    .object({
+      required: booleanOrString,
+      minimum_length: numberOrString,
+      maximum_length: numberOrString,
+      enforce_complexity: booleanOrString,
+    })
+    .nullable()
+    .optional(),
+  password_generation: z
+    .object({
+      default_length: numberOrString,
+      character_sets: z
+        .object({
+          uppercase: booleanOrString,
+          lowercase: booleanOrString,
+          numbers: booleanOrString,
+          symbols: booleanOrString,
+          exclude_ambiguous: booleanOrString,
+        })
+        .nullable()
+        .optional(),
+    })
+    .nullable()
+    .optional(),
+});
+
+/**
+ * Emailer schema for API responses
+ */
+export const apiEmailerSchema = z.object({
+  mode: z.string().nullable().optional(),
+  region: z.string().nullable().optional(),
+  from: z.string().nullable().optional(),
+  from_name: z.string().nullable().optional(),
+  reply_to: z.string().nullable().optional(),
+  host: z.string().nullable().optional(),
+  port: numberOrString.nullable(),
+  user: z.string().nullable().optional(),
+  pass: z.string().nullable().optional(),
+  auth: z.string().nullable().optional(),
+  tls: z.union([z.boolean(), z.string()]).nullable().optional(),
+});
+
+/**
+ * Mail schema for API responses
+ */
+export const apiMailSchema = z.object({
+  truemail: z
+    .object({
+      default_validation_type: z.string().optional(),
+      verifier_email: z.string().optional(),
+      verifier_domain: z.string().optional(),
+      allowed_domains_only: z.boolean().optional(),
+      dns: z.array(z.string()).optional(),
+      smtp_fail_fast: z.boolean().optional(),
+      smtp_safe_check: z.boolean().optional(),
+      not_rfc_mx_lookup_flow: z.boolean().optional(),
+      logger: z
+        .object({
+          tracking_event: z.any().optional(),
+          stdout: z.any().optional(),
+        })
+        .optional(),
+    })
+    .optional(),
+});
+
+/**
+ * Diagnostics schema for API responses
+ */
+export const apiDiagnosticsSchema = z.object({
+  enabled: booleanOrString.nullable(),
+  redis_uri: z.string().nullable().optional(),
+  sentry: z
+    .object({
+      defaults: z
+        .object({
+          dsn: z.string().nullable().optional(),
+          sampleRate: z.union([z.string(), z.number()]).nullable().optional(),
+          maxBreadcrumbs: z.union([z.string(), z.number()]).nullable().optional(),
+          logErrors: booleanOrString.nullable(),
+        })
+        .nullable()
+        .optional(),
+      backend: z
+        .object({
+          dsn: z.string().nullable().optional(),
+          sampleRate: z.union([z.string(), z.number()]).nullable().optional(),
+          maxBreadcrumbs: z.union([z.string(), z.number()]).nullable().optional(),
+          logErrors: booleanOrString.nullable(),
+        })
+        .nullable()
+        .optional(),
+      frontend: z
+        .object({
+          dsn: z.string().nullable().optional(),
+          sampleRate: z.union([z.string(), z.number()]).nullable().optional(),
+          maxBreadcrumbs: z.union([z.string(), z.number()]).nullable().optional(),
+          logErrors: booleanOrString.nullable(),
+          trackComponents: booleanOrString.nullable(),
+        })
+        .nullable()
+        .optional(),
+    })
+    .nullable()
+    .optional(),
+});
+
+/**
+ * Authentication schema for API responses
+ */
+export const apiAuthenticationSchema = z.object({
+  enabled: booleanOrString,
+  signup: booleanOrString,
+  signin: booleanOrString,
+  autoverify: booleanOrString,
+  required: booleanOrString,
+  colonels: z.array(z.string()).nullable().optional(),
+  allowed_signup_domains: z.array(z.string()).nullable().optional(),
+});
+
+/**
+ * Logging schema for API responses
+ */
+export const apiLoggingSchema = z.object({
+  default_level: z.string().nullable().optional(),
+  formatter: z.string().nullable().optional(),
+  loggers: z.record(z.string(), z.string()).nullable().optional(),
+  http: z
+    .object({
+      enabled: booleanOrString,
+      level: z.string().nullable().optional(),
+      capture: z.string().nullable().optional(),
+      slow_request_ms: numberOrString,
+      ignore_paths: z.array(z.string()).nullable().optional(),
+    })
+    .nullable()
+    .optional(),
+});
+
+/**
+ * Billing schema for API responses
+ */
+export const apiBillingSchema = z.object({
+  enabled: booleanOrString,
+  stripe_key: z.string().nullable().optional(),
+  webhook_signing_secret: z.string().nullable().optional(),
+  stripe_api_version: z.string().nullable().optional(),
+  capabilities: z.record(z.string(), z.any()).nullable().optional(),
+});
+
+/**
+ * Features schema for API responses
+ */
+export const apiFeaturesSchema = z.object({
+  regions: z
+    .object({
+      enabled: booleanOrString,
+      current_jurisdiction: z.string().nullable().optional(),
+      jurisdictions: z.array(z.any()).nullable().optional(),
+    })
+    .nullable()
+    .optional(),
+  incoming: z
+    .object({
+      enabled: booleanOrString,
+      memo_max_length: numberOrString,
+      default_ttl: numberOrString,
+    })
+    .nullable()
+    .optional(),
+  domains: z
+    .object({
+      enabled: booleanOrString,
+      default: z.string().nullable().optional(),
+      strategy: z.string().nullable().optional(),
+    })
+    .nullable()
+    .optional(),
+});
+
+/**
+ * System settings schema for API responses (colonel endpoint)
+ * This is the flexible schema used when parsing backend responses
+ */
+export const systemSettingsSchema = z.object({
+  interface: apiInterfaceSchema.nullable().optional(),
+  secret_options: apiSecretOptionsSchema.nullable().optional(),
+  authentication: apiAuthenticationSchema.nullable().optional(),
+  emailer: apiEmailerSchema.nullable().optional(),
+  mail: apiMailSchema.nullable().optional(),
+  diagnostics: apiDiagnosticsSchema.nullable().optional(),
+  logging: apiLoggingSchema.nullable().optional(),
+  billing: apiBillingSchema.nullable().optional(),
+  features: apiFeaturesSchema.nullable().optional(),
+});
+
+export const systemSettingsDetailsSchema = systemSettingsSchema.extend({});
+
+// ============================================================================
+// Config File Schemas (strict, for YAML validation)
+// ============================================================================
+
+/**
+ * Combined mail schema for static config
+ */
+const staticMailSchema = z.object({
+  connection: mailConnectionSchema,
+  validation: z.object({
+    defaults: mailValidationSchema.optional(),
+  }),
+});
+
+/**
+ * Mutable mail validation schema
+ */
+const mutableMailSchema = z.object({
+  validation: z.object({
+    recipients: mailValidationSchema.optional(),
+    accounts: mailValidationSchema.optional(),
+  }),
+});
+
+/**
+ * Simple logging schema for static config
+ */
+const simpleLoggingSchema = z.object({
+  http_requests: z.boolean().default(true),
+});
+
+/**
+ * Static configuration schema
+ * Matches the structure from config.defaults.yaml for application startup
+ */
+export const staticConfigSchema = z.object({
+  site: siteSchema,
+  features: featuresSchema.optional(),
+  redis: redisSchema.optional(),
+  emailer: emailerSchema.optional(),
+  mail: mailSchema.optional(),
+  internationalization: i18nSchema.optional(),
+  diagnostics: diagnosticsSchema.optional(),
+  development: developmentSchema.optional(),
+  experimental: experimentalSchema.optional(),
+});
+
+/**
+ * Mutable configuration schema
+ * Settings that can be changed at runtime without restart
+ */
+export const mutableConfigSchema = z.object({
+  ui: userInterfaceSchema.optional(),
+  api: apiSchema.optional(),
+  secret_options: secretOptionsSchema.optional(),
+  mail: mutableMailSchema.optional(),
+  features: featuresSchema.optional(),
+  limits: limitsSchema.optional(),
+});
+
+/**
+ * Runtime configuration schema
+ * Combines static and mutable config; static takes precedence
+ */
+export const runtimeConfigSchema = z.object({
+  ...mutableConfigSchema.shape,
+  ...staticConfigSchema.shape,
+});
+
+/**
+ * Legacy static config schema for backward compatibility
+ */
+export const legacyStaticConfigSchema = z.object({
+  site: siteSchema,
+  storage: storageSchema.optional(),
+  features: featuresSchema.optional(),
+  capabilities: capabilitiesSchema.optional(),
+  mail: staticMailSchema.optional(),
+  logging: simpleLoggingSchema.optional(),
+  i18n: i18nSchema.optional(),
+  development: developmentSchema.optional(),
+  experimental: experimentalSchema.optional(),
+  diagnostics: diagnosticsSchema.optional(),
+});
+
+// ============================================================================
+// Type Exports
+// ============================================================================
+
+export type StaticConfig = z.infer<typeof staticConfigSchema>;
+export type MutableConfig = z.infer<typeof mutableConfigSchema>;
+export type RuntimeConfig = z.infer<typeof runtimeConfigSchema>;
+export type LegacyStaticConfig = z.infer<typeof legacyStaticConfigSchema>;
+export type SystemSettings = z.infer<typeof systemSettingsSchema>;
+export type SystemSettingsDetails = z.infer<typeof systemSettingsDetailsSchema>;
+
+// Re-export section schemas for direct access
+export {
+  siteSchema,
+  siteAuthenticationSchema,
+  passphraseSchema,
+  passwordGenerationSchema,
+  storageSchema,
+  redisSchema,
+  emailerSchema,
+  mailSchema,
+  mailConnectionSchema,
+  mailValidationSchema,
+  diagnosticsSchema,
+  featuresSchema,
+  capabilitiesSchema,
+  i18nSchema,
+  developmentSchema,
+  experimentalSchema,
+  userInterfaceSchema,
+  apiSchema,
+  limitsSchema,
+  secretOptionsSchema,
+};
+
+// Aliases for backward compatibility
+export { staticMailSchema, mutableMailSchema, simpleLoggingSchema as loggingSchema };

--- a/src/schemas/config/index.ts
+++ b/src/schemas/config/index.ts
@@ -3,28 +3,143 @@
 /**
  * Configuration Schemas
  *
- * Zod schemas for application configuration files (YAML/JSON)
+ * Zod v4 schemas for application configuration files (YAML/JSON)
  *
  * Purpose:
  * - Type-safe validation of configuration files
  * - Runtime validation for config parsing
  * - TypeScript type inference for configuration usage
  * - Integration between backend YAML configs and frontend
+ *
+ * Structure:
+ * - shared/: Common primitives and user type definitions
+ * - section/: Individual configuration section schemas
+ * - config.ts: Main config schemas (static, mutable, runtime, API response)
+ * - auth.ts: Authentication configuration (auth.defaults.yaml)
+ * - logging.ts: Logging configuration (logging.defaults.yaml)
+ * - billing.ts: Billing configuration (billing.yaml)
+ * - billing-plans.ts: Plan catalog configuration (billing-plans.yaml)
  */
 
-export * from './billing';
-export * from './billing-plans';
+// ============================================================================
+// Shared Primitives
+// ============================================================================
+export { nullableString, ValidKeys } from './shared';
 
-// Billing configuration types
+// ============================================================================
+// Section Schemas
+// ============================================================================
+export * from './section';
+
+// ============================================================================
+// Main Configuration (config.defaults.yaml)
+// ============================================================================
+export {
+  // Type helpers
+  booleanOrString,
+  numberOrString,
+  // API response schemas (flexible)
+  apiInterfaceSchema,
+  apiSecretOptionsSchema,
+  apiEmailerSchema,
+  apiMailSchema,
+  apiDiagnosticsSchema,
+  apiAuthenticationSchema,
+  apiLoggingSchema,
+  apiBillingSchema,
+  apiFeaturesSchema,
+  systemSettingsSchema,
+  systemSettingsDetailsSchema,
+  // Config file schemas (strict)
+  staticConfigSchema,
+  mutableConfigSchema,
+  runtimeConfigSchema,
+  legacyStaticConfigSchema,
+  // Section re-exports
+  siteSchema,
+  siteAuthenticationSchema,
+  passphraseSchema,
+  passwordGenerationSchema,
+  storageSchema,
+  redisSchema,
+  emailerSchema,
+  mailSchema,
+  mailConnectionSchema,
+  mailValidationSchema,
+  diagnosticsSchema,
+  featuresSchema,
+  capabilitiesSchema,
+  i18nSchema,
+  developmentSchema,
+  experimentalSchema,
+  userInterfaceSchema,
+  apiSchema,
+  limitsSchema,
+  secretOptionsSchema,
+  loggingSchema,
+} from './config';
+
 export type {
-  BillingConfig,
-  CapabilityCategory,
-  CapabilityDefinition,
-  CapabilityId,
-} from './billing';
+  StaticConfig,
+  MutableConfig,
+  RuntimeConfig,
+  LegacyStaticConfig,
+  SystemSettings,
+  SystemSettingsDetails,
+} from './config';
 
+// Backward compatibility aliases
+export type MutableConfigDetails = import('./config').MutableConfig;
+
+// ============================================================================
+// Authentication Configuration (auth.defaults.yaml)
+// ============================================================================
+export {
+  authConfigSchema,
+  authModeSchema,
+  sessionConfigSchema,
+  basicModeSchema,
+  advancedModeSchema,
+  isAuthConfig,
+} from './auth';
+
+export type {
+  AuthConfig,
+  AuthMode,
+  SessionConfig,
+  BasicModeConfig,
+  AdvancedModeConfig,
+} from './auth';
+
+// ============================================================================
+// Logging Configuration (logging.defaults.yaml)
+// ============================================================================
+export {
+  loggingConfigSchema,
+  logLevelSchema,
+  formatterSchema,
+  httpCaptureSchema,
+  loggersSchema,
+  httpLoggingSchema,
+  isLoggingConfig,
+} from './logging';
+
+export type {
+  LoggingConfig,
+  LogLevel,
+  Formatter,
+  HttpCapture,
+  Loggers,
+  HttpLogging,
+} from './logging';
+
+// ============================================================================
+// Billing Configuration (billing.yaml)
+// ============================================================================
 export {
   BillingConfigSchema,
+  CapabilityCategorySchema,
+  CapabilityDefinitionSchema,
   getAllCapabilityIds,
   getCapabilitiesByCategory,
   getCapabilityById,
@@ -32,7 +147,44 @@ export {
   isBillingConfig,
 } from './billing';
 
-// Plan catalog types
+export type {
+  BillingConfig,
+  CapabilityCategory,
+  CapabilityDefinition,
+  CapabilityId,
+} from './billing';
+
+// ============================================================================
+// Plan Catalog Configuration (billing-plans.yaml)
+// ============================================================================
+export {
+  CATALOG_SCHEMA_VERSION,
+  BillingTierSchema,
+  TenancyTypeSchema,
+  BillingIntervalSchema,
+  CurrencyCodeSchema,
+  LimitValueSchema,
+  PlanLimitsSchema,
+  PlanPriceSchema,
+  PlanDefinitionSchema,
+  LegacyPlanDefinitionSchema,
+  MetadataFieldSchema,
+  StripeMetadataSchemaDefinition,
+  ValidationRulesSchema,
+  PlanCatalogSchema,
+  formatLimitValue,
+  getIncompletePlans,
+  getPlanById,
+  getPlanPrice,
+  getPlansByTier,
+  getPlansSortedByDisplayOrder,
+  getStripePlans,
+  isPlanCatalog,
+  limitValueToNumber,
+  planHasCapability,
+  shouldCreateStripeProduct,
+} from './billing-plans';
+
 export type {
   BillingInterval,
   BillingTier,
@@ -44,23 +196,7 @@ export type {
   PlanId,
   PlanLimits,
   PlanPrice,
-  StripeMetadataSchemaDefinition,
+  StripeMetadataSchemaDefinition as StripeMetadataSchema,
   TenancyType,
   ValidationRules,
-} from './billing-plans';
-
-export {
-  CATALOG_SCHEMA_VERSION,
-  formatLimitValue,
-  getIncompletePlans,
-  getPlanById,
-  getPlanPrice,
-  getPlansByTier,
-  getPlansSortedByDisplayOrder,
-  getStripePlans,
-  isPlanCatalog,
-  limitValueToNumber,
-  PlanCatalogSchema,
-  planHasCapability,
-  shouldCreateStripeProduct,
 } from './billing-plans';

--- a/src/schemas/config/logging.ts
+++ b/src/schemas/config/logging.ts
@@ -1,0 +1,118 @@
+// src/schemas/config/logging.ts
+
+/**
+ * Logging Configuration Schema
+ *
+ * Zod v4 schema for etc/defaults/logging.defaults.yaml
+ *
+ * Purpose:
+ * - Type-safe validation of logging configuration
+ * - Runtime validation for YAML parsing
+ * - TypeScript type inference for logging config usage
+ *
+ * Strategic categories for debugging and operational instrumentation:
+ *   Auth     - Authentication/authorization flows
+ *   Session  - Session lifecycle management
+ *   HTTP     - HTTP requests, responses, and middleware
+ *   Familia  - Redis operations via Familia ORM
+ *   Otto     - Otto framework operations
+ *   Rhales   - Rhales template rendering
+ *   Sequel   - Database queries and operations
+ *   Secret   - Core business value (create/view/burn)
+ *   App      - Default fallback for application-level logging
+ */
+
+import { z } from 'zod/v4';
+import { nullableString } from './shared/primitives';
+
+/**
+ * Log level enum
+ */
+const logLevelSchema = z.enum(['trace', 'debug', 'info', 'warn', 'error', 'fatal']);
+
+/**
+ * Output formatter enum
+ */
+const formatterSchema = z.enum(['color', 'json', 'default']);
+
+/**
+ * HTTP capture mode
+ */
+const httpCaptureSchema = z.enum(['minimal', 'standard', 'debug']);
+
+/**
+ * Named logger levels
+ * Each category can be configured independently
+ */
+const loggersSchema = z.object({
+  App: logLevelSchema.default('info'),
+  Auth: logLevelSchema.default('info'),
+  Billing: logLevelSchema.default('info'),
+  Boot: logLevelSchema.default('info'),
+  Familia: logLevelSchema.default('warn'),
+  HTTP: logLevelSchema.default('warn'),
+  Otto: logLevelSchema.default('warn'),
+  Rhales: logLevelSchema.default('error'),
+  Secret: logLevelSchema.default('info'),
+  Sequel: logLevelSchema.default('warn'),
+  Session: logLevelSchema.default('info'),
+}).catchall(logLevelSchema);
+
+/**
+ * HTTP request logging configuration
+ */
+const httpLoggingSchema = z.object({
+  enabled: z.boolean().default(true),
+  level: nullableString,
+  capture: httpCaptureSchema.default('standard'),
+  slow_request_ms: z.number().int().positive().default(1000),
+  ignore_paths: z.array(z.string()).default([
+    '/api/v1/status',
+    '/api/v2/status',
+    '/api/v3/status',
+    '/health',
+    '/healthcheck',
+    '/favicon.ico',
+    '/_vite/*',
+    '/assets/*',
+    '/dist/*',
+  ]),
+});
+
+/**
+ * Complete logging configuration schema
+ *
+ * Matches the structure from etc/defaults/logging.defaults.yaml
+ */
+const loggingConfigSchema = z.object({
+  default_level: logLevelSchema.default('info'),
+  formatter: formatterSchema.default('color'),
+  loggers: loggersSchema.optional(),
+  http: httpLoggingSchema.optional(),
+});
+
+export type LogLevel = z.infer<typeof logLevelSchema>;
+export type Formatter = z.infer<typeof formatterSchema>;
+export type HttpCapture = z.infer<typeof httpCaptureSchema>;
+export type Loggers = z.infer<typeof loggersSchema>;
+export type HttpLogging = z.infer<typeof httpLoggingSchema>;
+export type LoggingConfig = z.infer<typeof loggingConfigSchema>;
+
+export {
+  loggingConfigSchema,
+  logLevelSchema,
+  formatterSchema,
+  httpCaptureSchema,
+  loggersSchema,
+  httpLoggingSchema,
+};
+
+/**
+ * Type guard: Check if logging config is valid
+ *
+ * @param data - Unknown data to validate
+ * @returns True if data matches LoggingConfig schema
+ */
+export function isLoggingConfig(data: unknown): data is LoggingConfig {
+  return loggingConfigSchema.safeParse(data).success;
+}

--- a/src/schemas/config/section/capabilities.ts
+++ b/src/schemas/config/section/capabilities.ts
@@ -1,0 +1,30 @@
+// src/schemas/config/section/capabilities.ts
+
+/**
+ * Capabilities Configuration Schema
+ *
+ * Defines feature flags for different user types.
+ * Previously these flags were defined in Onetime::Plan.load_plans!
+ */
+
+import { z } from 'zod/v4';
+import { ValidKeys as UserTypeKeys } from '../shared/user_types';
+
+/**
+ * Capability flags for a user type
+ */
+const capabilityFlagsSchema = z.object({
+  api: z.boolean(),
+  email: z.boolean(),
+  custom_domains: z.boolean(),
+});
+
+/**
+ * Capabilities schema - maps user types to their capability flags
+ *
+ * @see Zod v4 note about using enums for record keys:
+ *  https://zod.dev/api?id=records
+ */
+const capabilitiesSchema = z.record(UserTypeKeys, capabilityFlagsSchema);
+
+export { capabilitiesSchema, capabilityFlagsSchema };

--- a/src/schemas/config/section/development.ts
+++ b/src/schemas/config/section/development.ts
@@ -1,0 +1,20 @@
+// src/schemas/config/section/development.ts
+
+/**
+ * Development Configuration Schema
+ *
+ * Maps to the `development:` section in config.defaults.yaml
+ */
+
+import { z } from 'zod/v4';
+
+/**
+ * Development mode configuration
+ */
+const developmentSchema = z.object({
+  enabled: z.boolean().default(false),
+  debug: z.boolean().default(false),
+  frontend_host: z.string().default('http://localhost:5173'),
+});
+
+export { developmentSchema };

--- a/src/schemas/config/section/diagnostics.ts
+++ b/src/schemas/config/section/diagnostics.ts
@@ -1,0 +1,57 @@
+// src/schemas/config/section/diagnostics.ts
+
+/**
+ * Diagnostics Configuration Schema
+ *
+ * Maps to the `diagnostics:` section in config.defaults.yaml
+ */
+
+import { z } from 'zod/v4';
+import { nullableString } from '../shared/primitives';
+
+/**
+ * Sentry defaults configuration
+ */
+const diagnosticsSentryDefaultsSchema = z.object({
+  dsn: nullableString,
+  sampleRate: z.union([z.string(), z.number()]).optional(),
+  maxBreadcrumbs: z.union([z.string(), z.number()]).optional(),
+  logErrors: z.boolean().default(true),
+});
+
+/**
+ * Sentry backend configuration
+ */
+const diagnosticsSentryBackendSchema = diagnosticsSentryDefaultsSchema.extend({});
+
+/**
+ * Sentry frontend configuration
+ */
+const diagnosticsSentryFrontendSchema = diagnosticsSentryDefaultsSchema.extend({
+  trackComponents: z.boolean().default(true),
+});
+
+/**
+ * Sentry configuration
+ */
+const diagnosticsSentrySchema = z.object({
+  defaults: diagnosticsSentryDefaultsSchema.optional(),
+  backend: diagnosticsSentryBackendSchema.optional(),
+  frontend: diagnosticsSentryFrontendSchema.optional(),
+});
+
+/**
+ * Complete diagnostics schema
+ */
+const diagnosticsSchema = z.object({
+  enabled: z.boolean().default(false),
+  sentry: diagnosticsSentrySchema.optional(),
+});
+
+export {
+  diagnosticsSchema,
+  diagnosticsSentrySchema,
+  diagnosticsSentryDefaultsSchema,
+  diagnosticsSentryBackendSchema,
+  diagnosticsSentryFrontendSchema,
+};

--- a/src/schemas/config/section/experimental.ts
+++ b/src/schemas/config/section/experimental.ts
@@ -1,0 +1,46 @@
+// src/schemas/config/section/experimental.ts
+
+/**
+ * Experimental Configuration Schema
+ *
+ * Maps to the `experimental:` section in config.defaults.yaml
+ */
+
+import { z } from 'zod/v4';
+
+/**
+ * Middleware configuration
+ */
+const middlewareSchema = z.object({
+  static_files: z.boolean().default(true),
+  utf8_sanitizer: z.boolean().default(true),
+  authenticity_token: z.boolean().default(true),
+  http_origin: z.boolean().default(false),
+  escaped_params: z.boolean().default(false),
+  xss_header: z.boolean().default(false),
+  frame_options: z.boolean().default(false),
+  path_traversal: z.boolean().default(false),
+  cookie_tossing: z.boolean().default(false),
+  ip_spoofing: z.boolean().default(false),
+  strict_transport: z.boolean().default(false),
+});
+
+/**
+ * Content Security Policy configuration
+ */
+const cspSchema = z.object({
+  enabled: z.boolean().default(false),
+});
+
+/**
+ * Experimental features configuration
+ */
+const experimentalSchema = z.object({
+  allow_nil_global_secret: z.boolean().default(false),
+  rotated_secrets: z.array(z.string()).default([]),
+  freeze_app: z.boolean().default(false),
+  middleware: middlewareSchema.optional(),
+  csp: cspSchema.optional(),
+});
+
+export { experimentalSchema, middlewareSchema, cspSchema };

--- a/src/schemas/config/section/features.ts
+++ b/src/schemas/config/section/features.ts
@@ -1,0 +1,102 @@
+// src/schemas/config/section/features.ts
+
+/**
+ * Features Configuration Schema
+ *
+ * Maps to the `features:` section in config.defaults.yaml
+ */
+
+import { z } from 'zod/v4';
+import { nullableString } from '../shared/primitives';
+
+/**
+ * Incoming secrets recipient configuration
+ */
+const incomingRecipientSchema = z.tuple([z.string(), z.string().optional()]).nullable();
+
+/**
+ * Incoming secrets feature configuration
+ */
+const featuresIncomingSchema = z.object({
+  enabled: z.boolean().default(false),
+  memo_max_length: z.number().int().positive().default(50),
+  default_ttl: z.number().int().positive().default(604800),
+  default_passphrase: z.string().nullable().optional(),
+  recipients: z.array(incomingRecipientSchema).optional(),
+});
+
+/**
+ * Region jurisdiction icon configuration
+ */
+const featuresRegionJurisdictionIconSchema = z.object({
+  collection: z.string().optional(),
+  name: z.string().optional(),
+});
+
+/**
+ * Region jurisdiction configuration
+ */
+const featuresRegionJurisdictionSchema = z.object({
+  identifier: z.string().optional(),
+  display_name: z.string().optional(),
+  domain: z.string().optional(),
+  icon: featuresRegionJurisdictionIconSchema.optional(),
+});
+
+/**
+ * Regions feature configuration
+ */
+const featuresRegionsSchema = z.object({
+  enabled: z.boolean().default(false),
+  current_jurisdiction: nullableString,
+  jurisdictions: z.array(featuresRegionJurisdictionSchema).optional(),
+});
+
+/**
+ * Domain cluster configuration (for approximated strategy)
+ */
+const featuresDomainsClusterSchema = z.object({
+  api_key: nullableString,
+  cluster_ip: nullableString,
+  cluster_host: nullableString,
+  cluster_name: nullableString,
+  vhost_target: nullableString,
+});
+
+/**
+ * ACME endpoint configuration (for caddy_on_demand strategy)
+ */
+const featuresDomainsAcmeSchema = z.object({
+  enabled: z.boolean().default(false),
+  listen_address: z.string().default('127.0.0.1'),
+  port: z.string().default('12020'),
+});
+
+/**
+ * Domains feature configuration
+ */
+const featuresDomainsSchema = z.object({
+  enabled: z.boolean().default(false),
+  default: nullableString,
+  strategy: z.enum(['passthrough', 'approximated', 'caddy_on_demand']).default('passthrough'),
+  cluster: featuresDomainsClusterSchema.optional(),
+  acme: featuresDomainsAcmeSchema.optional(),
+});
+
+/**
+ * Complete features schema
+ */
+const featuresSchema = z.object({
+  regions: featuresRegionsSchema.optional(),
+  incoming: featuresIncomingSchema.optional(),
+  domains: featuresDomainsSchema.optional(),
+});
+
+export {
+  featuresSchema,
+  featuresRegionsSchema,
+  featuresIncomingSchema,
+  featuresDomainsSchema,
+  featuresDomainsClusterSchema,
+  featuresDomainsAcmeSchema,
+};

--- a/src/schemas/config/section/i18n.ts
+++ b/src/schemas/config/section/i18n.ts
@@ -1,0 +1,22 @@
+// src/schemas/config/section/i18n.ts
+
+/**
+ * Internationalization Configuration Schema
+ *
+ * Maps to the `internationalization:` section in config.defaults.yaml
+ */
+
+import { z } from 'zod/v4';
+
+/**
+ * i18n configuration schema
+ */
+const i18nSchema = z.object({
+  enabled: z.boolean().default(false),
+  default_locale: z.string().default('en'),
+  fallback_locale: z.record(z.string(), z.union([z.array(z.string()), z.string()])),
+  locales: z.array(z.string()).default([]),
+  incomplete: z.array(z.string()).default([]),
+});
+
+export { i18nSchema };

--- a/src/schemas/config/section/index.ts
+++ b/src/schemas/config/section/index.ts
@@ -1,0 +1,21 @@
+// src/schemas/config/section/index.ts
+
+/**
+ * Configuration Section Schemas
+ *
+ * Individual schema modules for each configuration section.
+ * These are composed into static, mutable, and runtime configs.
+ */
+
+export * from './capabilities';
+export * from './development';
+export * from './diagnostics';
+export * from './experimental';
+export * from './features';
+export * from './i18n';
+export * from './limits';
+export * from './mail';
+export * from './secret_options';
+export * from './site';
+export * from './storage';
+export * from './ui';

--- a/src/schemas/config/section/limits.ts
+++ b/src/schemas/config/section/limits.ts
@@ -1,0 +1,85 @@
+// src/schemas/config/section/limits.ts
+
+/**
+ * Rate Limits Configuration Schema
+ *
+ * Rate limit values are optional numeric limits (requests per time window).
+ * Unknown rate limits are automatically handled via catchall for backward compatibility.
+ */
+
+import { z } from 'zod/v4';
+
+const RATE_LIMIT_KEYS = [
+  // Core authentication and account operations
+  'create_account',
+  'update_account',
+  'destroy_account',
+  'authenticate_session',
+  'destroy_session',
+  'show_account',
+
+  // Secret operations
+  'create_secret',
+  'show_secret',
+  'show_metadata',
+  'burn_secret',
+  'attempt_secret_access',
+  'failed_passphrase',
+
+  // Domain operations
+  'add_domain',
+  'remove_domain',
+  'list_domains',
+  'get_domain',
+  'verify_domain',
+  'get_domain_brand',
+  'get_domain_logo',
+  'remove_domain_logo',
+  'update_domain_brand',
+
+  // Communication and feedback
+  'email_recipient',
+  'send_feedback',
+
+  // Password reset operations
+  'forgot_password_request',
+  'forgot_password_reset',
+
+  // Dashboard and UI operations
+  'dashboard',
+  'get_page',
+  'get_image',
+
+  // API and system operations
+  'generate_apitoken',
+  'check_status',
+  'report_exception',
+  'update_branding',
+  'update_mutable_config',
+  'view_colonel',
+  'external_redirect',
+
+  // Payment operations
+  'stripe_webhook',
+] as const;
+
+const rateLimitValue = z.number().optional();
+
+const createRateLimitFields = () => {
+  const fields: Record<string, typeof rateLimitValue> = {};
+
+  RATE_LIMIT_KEYS.forEach((key) => {
+    fields[key] = rateLimitValue;
+  });
+
+  return fields;
+};
+
+/**
+ * Rate limits schema with known keys and catchall for unknown keys
+ */
+const limitsSchema = z.object(createRateLimitFields()).catchall(rateLimitValue);
+
+export type RateLimitKey = (typeof RATE_LIMIT_KEYS)[number] | string;
+export type RateLimits = z.infer<typeof limitsSchema>;
+export { RATE_LIMIT_KEYS, limitsSchema };

--- a/src/schemas/config/section/mail.ts
+++ b/src/schemas/config/section/mail.ts
@@ -1,0 +1,123 @@
+// src/schemas/config/section/mail.ts
+
+/**
+ * Mail Configuration Schema
+ *
+ * Maps to the `emailer:` and `mail:` sections in config.defaults.yaml
+ */
+
+import { z } from 'zod/v4';
+import { nullableString } from '../shared/primitives';
+
+/**
+ * Emailer (SMTP) configuration
+ */
+const emailerSchema = z.object({
+  mode: z.string().default('smtp'),
+  region: z.string().optional(),
+  from: z.string().default('CHANGEME@example.com'),
+  from_name: z.string().default('Support'),
+  reply_to: nullableString,
+  host: z.string().default('smtp.provider.com'),
+  port: z.number().int().positive().default(587),
+  user: nullableString,
+  pass: nullableString,
+  auth: nullableString, // 'login', 'plain', etc.
+  tls: z.boolean().nullable().optional(),
+});
+
+/**
+ * Truemail logger configuration
+ */
+const truemailLoggerSchema = z.object({
+  tracking_event: z.string().default(':error'),
+  stdout: z.boolean().default(true),
+  log_absolute_path: z.string().optional(),
+});
+
+/**
+ * Truemail validation configuration
+ */
+const truemailSchema = z.object({
+  default_validation_type: z.string().default(':regex'),
+  verifier_email: z.string().default('CHANGEME@example.com'),
+  verifier_domain: z.string().optional(),
+  connection_timeout: z.number().optional(),
+  response_timeout: z.number().optional(),
+  connection_attempts: z.number().optional(),
+  validation_type_for: z.record(z.string(), z.string()).optional(),
+  allowed_domains_only: z.boolean().default(false),
+  allowed_emails: z.array(z.string()).optional(),
+  blocked_emails: z.array(z.string()).optional(),
+  allowed_domains: z.array(z.string()).optional(),
+  blocked_domains: z.array(z.string()).optional(),
+  blocked_mx_ip_addresses: z.array(z.string()).optional(),
+  dns: z.array(z.string()).default(['1.1.1.1', '8.8.4.4', '208.67.220.220']),
+  smtp_port: z.number().int().positive().optional(),
+  smtp_fail_fast: z.boolean().default(false),
+  smtp_safe_check: z.boolean().default(true),
+  not_rfc_mx_lookup_flow: z.boolean().default(false),
+  email_pattern: z.string().optional(),
+  smtp_error_body_pattern: z.string().optional(),
+  logger: truemailLoggerSchema.optional(),
+});
+
+/**
+ * Mail validation configuration
+ */
+const mailSchema = z.object({
+  truemail: truemailSchema.optional(),
+});
+
+/**
+ * Combined mail connection schema (for static config)
+ */
+const mailConnectionSchema = z.object({
+  mode: z.string().default('smtp'),
+  auth: z.string().default('login'),
+  region: z.string().optional(),
+  from: z.string().default('noreply@example.com'),
+  fromname: z.string().default('OneTimeSecret'),
+  host: z.string().optional(),
+  port: z.number().optional(),
+  user: nullableString,
+  pass: nullableString,
+  tls: z.boolean().nullable().optional(),
+});
+
+/**
+ * Mail validation schema (for static config)
+ */
+const mailValidationSchema = z.object({
+  default_validation_type: z.string().default('mx'),
+  verifier_email: z.string().default('example@onetimesecret.dev'),
+  verifier_domain: z.string().default('onetimesecret.dev'),
+  connection_timeout: z.number().optional(),
+  response_timeout: z.number().optional(),
+  connection_attempts: z.number().optional(),
+  validation_type_for: z.record(z.string(), z.union([z.string(), z.any()])).optional(),
+  allowed_domains_only: z.boolean().optional(),
+  allowed_emails: z.array(z.string()).optional(),
+  blocked_emails: z.array(z.string()).optional(),
+  allowed_domains: z.array(z.string()).optional(),
+  blocked_domains: z.array(z.string()).optional(),
+  blocked_mx_ip_addresses: z.array(z.string()).optional(),
+  dns: z.array(z.string()).optional(),
+  smtp_port: z.number().optional(),
+  smtp_fail_fast: z.boolean().optional(),
+  smtp_safe_check: z.boolean().optional(),
+  not_rfc_mx_lookup_flow: z.boolean().optional(),
+  logger: z.object({
+    tracking_event: z.string().default('all'),
+    stdout: z.boolean().default(true),
+    log_absolute_path: z.string().optional(),
+  }).optional(),
+});
+
+export {
+  emailerSchema,
+  mailSchema,
+  truemailSchema,
+  mailConnectionSchema,
+  mailValidationSchema,
+};

--- a/src/schemas/config/section/secret_options.ts
+++ b/src/schemas/config/section/secret_options.ts
@@ -1,0 +1,57 @@
+// src/schemas/config/section/secret_options.ts
+
+/**
+ * Secret Options Configuration Schema
+ *
+ * Defines TTL and size limits for different user types.
+ * Previously defined in Onetime::Plan.load_plans!
+ */
+
+import { z } from 'zod/v4';
+import { ValidKeys as UserTypeKeys } from '../shared/user_types';
+
+/**
+ * Secret option boundaries for a user type
+ */
+const secretOptionBoundariesSchema = z.object({
+  /**
+   * Default Time-To-Live (TTL) for secrets in seconds
+   * @default 604800 (7 days)
+   */
+  default_ttl: z.number().int().positive().nullable().default(604800),
+
+  /**
+   * Available TTL options for secret creation (in seconds)
+   * @min 60 - One minute
+   * @max 2592000 - 30 days
+   * @default [300, 1800, 3600, 14400, 43200, 86400, 259200, 604800, 1209600, 2592000]
+   */
+  ttl_options: z
+    .array(z.number().int().positive().min(60).max(2592000))
+    .nullable()
+    .default([300, 1800, 3600, 14400, 43200, 86400, 259200, 604800, 1209600, 2592000]),
+
+  /**
+   * Maximum secret size in bytes
+   * @max 10485760 (10MB)
+   * @default 102400 (100KB)
+   */
+  size: z
+    .number()
+    .int()
+    .positive()
+    .min(1)
+    .max(10485760)
+    .nullable()
+    .default(102400),
+});
+
+/**
+ * Secret options schema - maps user types to their boundaries
+ *
+ * @see Zod v4 note about using enums for record keys:
+ *  https://zod.dev/api?id=records
+ */
+const secretOptionsSchema = z.record(UserTypeKeys, secretOptionBoundariesSchema);
+
+export { secretOptionsSchema, secretOptionBoundariesSchema };

--- a/src/schemas/config/section/site.ts
+++ b/src/schemas/config/section/site.ts
@@ -1,0 +1,86 @@
+// src/schemas/config/section/site.ts
+
+/**
+ * Site Configuration Schema
+ *
+ * Maps to the `site:` section in config.defaults.yaml
+ */
+
+import { z } from 'zod/v4';
+
+/**
+ * Authentication settings within site configuration
+ */
+const siteAuthenticationSchema = z.object({
+  enabled: z.boolean().default(true),
+  signup: z.boolean().default(true),
+  signin: z.boolean().default(true),
+  autoverify: z.boolean().default(false),
+  required: z.boolean().default(false),
+  colonels: z.array(z.string()).default([]),
+  allowed_signup_domains: z.array(z.string()).default([]),
+});
+
+/**
+ * Support configuration
+ */
+const siteSupportSchema = z.object({
+  host: z.string().nullable().optional(),
+});
+
+/**
+ * Secret options - passphrase settings
+ */
+const passphraseSchema = z.object({
+  required: z.boolean().default(false),
+  minimum_length: z.number().int().positive().default(8),
+  maximum_length: z.number().int().positive().default(128),
+  enforce_complexity: z.boolean().default(false),
+});
+
+/**
+ * Secret options - password generation settings
+ */
+const passwordGenerationCharacterSetsSchema = z.object({
+  uppercase: z.boolean().default(true),
+  lowercase: z.boolean().default(true),
+  numbers: z.boolean().default(true),
+  symbols: z.boolean().default(true),
+  exclude_ambiguous: z.boolean().default(true),
+});
+
+const passwordGenerationSchema = z.object({
+  default_length: z.number().int().positive().default(12),
+  character_sets: passwordGenerationCharacterSetsSchema,
+});
+
+/**
+ * Secret options configuration
+ */
+const siteSecretOptionsSchema = z.object({
+  default_ttl: z.number().int().positive().nullable().optional(),
+  ttl_options: z.string().nullable().optional(), // Raw string from env, parsed elsewhere
+  passphrase: passphraseSchema,
+  password_generation: passwordGenerationSchema,
+});
+
+/**
+ * Complete site schema matching config.defaults.yaml site: section
+ */
+const siteSchema = z.object({
+  host: z.string().default('localhost:3000'),
+  ssl: z.boolean().default(false),
+  secret: z.string().nullable().optional(),
+  interface: z.any().optional(), // Defined in ui.ts for mutable config
+  secret_options: siteSecretOptionsSchema.optional(),
+  authentication: siteAuthenticationSchema.optional(),
+  support: siteSupportSchema.optional(),
+});
+
+export {
+  siteSchema,
+  siteAuthenticationSchema,
+  siteSecretOptionsSchema,
+  passphraseSchema,
+  passwordGenerationSchema,
+};

--- a/src/schemas/config/section/storage.ts
+++ b/src/schemas/config/section/storage.ts
@@ -1,0 +1,45 @@
+// src/schemas/config/section/storage.ts
+
+/**
+ * Storage Configuration Schema
+ *
+ * Maps to the `redis:` section in config.defaults.yaml
+ */
+
+import { z } from 'zod/v4';
+
+/**
+ * Redis database mapping
+ * Maps database names to their Redis database numbers (0-15)
+ */
+const redisDbsSchema = z.object({
+  session: z.number().int().min(0).max(15).default(0),
+  custom_domain: z.number().int().min(0).max(15).default(0),
+  customdomain: z.number().int().min(0).max(15).default(0), // Alias
+  customer: z.number().int().min(0).max(15).default(0),
+  metadata: z.number().int().min(0).max(15).default(0),
+  secret: z.number().int().min(0).max(15).default(0),
+  feedback: z.number().int().min(0).max(15).default(0),
+});
+
+/**
+ * Redis/Valkey connection configuration
+ */
+const redisSchema = z.object({
+  uri: z.string().default('redis://127.0.0.1:6379'),
+  dbs: redisDbsSchema.optional(),
+});
+
+/**
+ * Storage schema (wraps redis for consistency with historical schema)
+ */
+const storageSchema = z.object({
+  db: z.object({
+    connection: z.object({
+      url: z.string().default('redis://localhost:6379'),
+    }),
+    database_mapping: z.record(z.string(), z.number().nullable()).optional(),
+  }).optional(),
+});
+
+export { redisSchema, redisDbsSchema, storageSchema };

--- a/src/schemas/config/section/ui.ts
+++ b/src/schemas/config/section/ui.ts
@@ -1,0 +1,117 @@
+// src/schemas/config/section/ui.ts
+
+/**
+ * User Interface Configuration Schema
+ *
+ * Maps to the `site.interface:` section in config.defaults.yaml
+ */
+
+import { z } from 'zod/v4';
+import { nullableString } from '../shared/primitives';
+
+/**
+ * Logo configuration
+ */
+const userInterfaceLogoSchema = z.object({
+  url: z.string().optional(),
+  alt: z.string().optional(),
+  href: z.string().optional(),
+});
+
+/**
+ * Header branding configuration
+ */
+const userInterfaceHeaderBrandingSchema = z.object({
+  logo: userInterfaceLogoSchema.optional(),
+  site_name: z.string().optional(),
+});
+
+/**
+ * Header navigation configuration
+ */
+const userInterfaceHeaderNavigationSchema = z.object({
+  enabled: z.boolean().optional(),
+});
+
+/**
+ * Homepage mode configuration (CIDR-based or header-based)
+ */
+const userInterfaceHomepageSchema = z.object({
+  mode: z.string().nullable().optional(),
+  matching_cidrs: z.array(z.string()).default([]),
+  mode_header: z.string().default('O-Homepage-Mode'),
+  trusted_proxy_depth: z.number().int().nonnegative().default(1),
+  trusted_ip_header: z.string().default('X-Forwarded-For'),
+});
+
+/**
+ * Header configuration
+ */
+const userInterfaceHeaderSchema = z.object({
+  enabled: z.boolean().default(true),
+  branding: userInterfaceHeaderBrandingSchema.optional(),
+  navigation: userInterfaceHeaderNavigationSchema.optional(),
+});
+
+/**
+ * Footer link item
+ */
+const userInterfaceFooterLinkSchema = z.object({
+  text: z.string().optional(),
+  i18n_key: z.string().optional(),
+  url: nullableString,
+  external: z.boolean().optional(),
+  icon: z.string().optional(),
+});
+
+/**
+ * Footer link group
+ */
+const userInterfaceFooterGroupSchema = z.object({
+  name: z.string().optional(),
+  i18n_key: z.string().optional(),
+  links: z.array(userInterfaceFooterLinkSchema).optional(),
+});
+
+/**
+ * Footer links configuration
+ */
+const userInterfaceFooterLinksSchema = z.object({
+  enabled: z.boolean().default(false),
+  groups: z.array(userInterfaceFooterGroupSchema).optional(),
+});
+
+/**
+ * UI configuration schema
+ */
+const uiSchema = z.object({
+  enabled: z.boolean().default(true),
+  homepage: userInterfaceHomepageSchema.optional(),
+  header: userInterfaceHeaderSchema.optional(),
+  footer_links: userInterfaceFooterLinksSchema.optional(),
+});
+
+/**
+ * API configuration schema
+ */
+const apiSchema = z.object({
+  enabled: z.boolean().default(true),
+});
+
+/**
+ * Combined interface schema (ui + api)
+ */
+const userInterfaceSchema = z.object({
+  ui: uiSchema.optional(),
+  api: apiSchema.optional(),
+});
+
+export {
+  userInterfaceSchema,
+  uiSchema,
+  apiSchema,
+  userInterfaceLogoSchema,
+  userInterfaceHeaderSchema,
+  userInterfaceFooterLinksSchema,
+  userInterfaceHomepageSchema,
+};

--- a/src/schemas/config/shared/index.ts
+++ b/src/schemas/config/shared/index.ts
@@ -1,0 +1,4 @@
+// src/schemas/config/shared/index.ts
+
+export { nullableString } from './primitives';
+export { ValidKeys } from './user_types';

--- a/src/schemas/config/shared/primitives.ts
+++ b/src/schemas/config/shared/primitives.ts
@@ -1,0 +1,7 @@
+// src/schemas/config/shared/primitives.ts
+
+import { z } from 'zod/v4';
+
+const nullableString = z.string().nullable().optional();
+
+export { nullableString };

--- a/src/schemas/config/shared/user_types.ts
+++ b/src/schemas/config/shared/user_types.ts
@@ -1,0 +1,18 @@
+// src/schemas/config/shared/user_types.ts
+
+/**
+ * User Types
+ *
+ * @see capabilities.ts, secret_options.ts
+ *
+ * NOTE: "User" types is the correct nomenclature vs "Profile" because it's
+ * at the user-level that authentication happens. It was less clear when the
+ * possible keys were anonymous, basic, identity (which is how they were
+ * distinguished in onetime/plan.rb).
+ */
+
+import { z } from 'zod/v4';
+
+const ValidKeys = z.enum(['anonymous', 'authenticated', 'standard', 'enhanced']);
+
+export { ValidKeys };

--- a/src/scripts/openapi/otto-routes-parser.ts
+++ b/src/scripts/openapi/otto-routes-parser.ts
@@ -98,7 +98,7 @@ export function parseRoutesFile(filePath: string): ParsedRoutes {
  * Parse all Otto routes for a specific API
  */
 export function parseApiRoutes(apiName: string): ParsedRoutes {
-  const routesPath = join(process.cwd(), 'apps', 'api', apiName, 'routes');
+  const routesPath = join(process.cwd(), 'apps', 'api', apiName, 'routes.txt');
   return parseRoutesFile(routesPath);
 }
 
@@ -200,12 +200,12 @@ export function discoverApiNames(): string[] {
     // Read all directories in apps/api/
     const entries = readdirSync(apiDir, { withFileTypes: true });
 
-    // Filter for directories that contain a 'routes' file
+    // Filter for directories that contain a 'routes.txt' file
     const apiNames = entries
       .filter(entry => entry.isDirectory())
       .map(entry => entry.name)
       .filter(name => {
-        const routesPath = join(apiDir, name, 'routes');
+        const routesPath = join(apiDir, name, 'routes.txt');
         return existsSync(routesPath);
       });
 


### PR DESCRIPTION
## Summary

- Consolidate scattered Zod schemas for YAML config files into a proper structure in `src/schemas/config/`
- Add schemas for `auth.defaults.yaml` and `logging.defaults.yaml`
- Update colonel.ts to import from config schemas instead of redefining
- Update all Zod imports to use `zod/v4`

## Changes

### New Files
- `config.ts` - Main config schemas (API response + config file validation)
- `auth.ts` - Schema for `etc/defaults/auth.defaults.yaml`
- `logging.ts` - Schema for `etc/defaults/logging.defaults.yaml`
- `section/` - Individual section schemas (site, ui, features, mail, storage, diagnostics, etc.)
- `shared/` - Common primitives (nullableString, ValidKeys)

### Modified Files
- `colonel.ts` - Now imports `systemSettingsSchema` from config instead of redefining (~230 lines removed)
- `billing.ts`, `billing-plans.ts` - Updated to use `zod/v4` imports
- `index.ts` - Updated exports for new structure

### Removed Files
- `static.ts`, `mutable.ts`, `runtime.ts` - Consolidated into `config.ts`

## Test plan

- [x] TypeScript type-check passes for schema files
- [ ] Manual verification that colonel admin panel still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)