### PR TITLE
feat(dx): Add Git JSON merge driver for locale files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+# Semantic 3-way merge for locale JSON files
+# Automatically resolves non-conflicting changes (different keys on each branch)
+# Falls back to standard conflict markers for same-key modifications
+#
+# Setup required (one-time per developer):
+#   git config merge.json.driver "npx git-json-merge %A %O %B"
+#   git config merge.json.name "Custom 3-way merge driver for JSON files"
+#
+# See CONTRIBUTING.md for details
+
+src/locales/**/*.json merge=json

--- a/README.md
+++ b/README.md
@@ -165,6 +165,19 @@ pnpm run dev
 For complete setup with dependencies:
 [Docker Compose repo](https://github.com/onetimesecret/docker-compose/)
 
+### Git JSON Merge Driver (Recommended)
+
+This repository uses a custom merge driver for locale JSON files to automatically resolve conflicts:
+
+1. Install dependencies: `pnpm install`
+2. Configure Git (one-time setup):
+   ```bash
+   git config merge.json.driver "npx git-json-merge %A %O %B"
+   git config merge.json.name "Custom 3-way merge driver for JSON files"
+   ```
+
+The driver automatically resolves conflicts when multiple branches modify different keys in the same locale file. If a conflict cannot be resolved automatically (e.g., same key modified on both sides), Git falls back to standard conflict markers.
+
 ## Support
 
 - **Issues**: [GitHub Issues](https://github.com/onetimesecret/onetimesecret/issues)

--- a/changelog.d/20251128_123619_delano_2015_json_merge_driver_main.rst
+++ b/changelog.d/20251128_123619_delano_2015_json_merge_driver_main.rst
@@ -1,0 +1,12 @@
+.. A new scriv changelog fragment.
+
+Added
+-----
+
+- Git JSON merge driver for automated locale file conflict resolution. Semantic 3-way merging automatically resolves non-conflicting changes in ``src/locales/**/*.json`` files, preserving keys added on different branches without manual conflict resolution.
+- ``.gitattributes`` configuration for locale JSON files to enable the custom merge driver.
+
+Documentation
+-------------
+
+- Added Git JSON merge driver setup instructions to README.md Development section.

--- a/package.json
+++ b/package.json
@@ -122,6 +122,7 @@
     "eslint-plugin-import": "2.31.0",
     "eslint-plugin-tailwindcss": "3.18.2",
     "eslint-plugin-vue": "10.4.0",
+    "git-json-merge": "^1.0.0",
     "globals": "16.1.0",
     "happy-dom": "20.0.10",
     "jiti": "2.4.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -192,6 +192,9 @@ importers:
       eslint-plugin-vue:
         specifier: 10.4.0
         version: 10.4.0(@typescript-eslint/parser@8.32.1(eslint@9.35.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.35.0(jiti@2.4.2))(vue-eslint-parser@10.2.0(eslint@9.35.0(jiti@2.4.2)))
+      git-json-merge:
+        specifier: ^1.0.0
+        version: 1.0.0
       globals:
         specifier: 16.1.0
         version: 16.1.0
@@ -1595,6 +1598,9 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  adiff@0.2.13:
+    resolution: {integrity: sha512-EeKiARTSOy/Tah9RXE83g/PmW1gLQdRKTYiX6c1+OWjzWaJPqbECKvSVB1kejSPQSYJJah0JhuTUsU3CerEH6Q==}
+
   agent-base@6.0.2:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
@@ -1939,6 +1945,10 @@ packages:
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
+
+  detect-indent@6.1.0:
+    resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
+    engines: {node: '>=8'}
 
   didyoumean@1.2.2:
     resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
@@ -2350,6 +2360,11 @@ packages:
 
   get-tsconfig@4.10.0:
     resolution: {integrity: sha512-kGzZ3LWWQcGIAmg6iWvXn0ei6WDtV26wzHRMwDSzmAbcXrTEXxHy6IehI6/4eT6VRKyMP1eF1VqwrVUmE/LR7A==}
+
+  git-json-merge@1.0.0:
+    resolution: {integrity: sha512-bugFzAfvFMrFEEEMWGXVCyJxRNcWICyziOCMIbAJjQmvlLDNaiLxtxy0W1H4aFyLIHU4KBWpqNAhtnZibl7g9g==}
+    engines: {node: '>=6'}
+    hasBin: true
 
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
@@ -3959,6 +3974,9 @@ packages:
       utf-8-validate:
         optional: true
 
+  xdiff@0.2.11:
+    resolution: {integrity: sha512-724yjHkwZyON3AqfmlEDLKPHJS0y3kxK8/oHtMu3qfDrESAGymv1QiKk5htK49fSMirRZmeAg2ocudWsiVvr8g==}
+
   xml-name-validator@4.0.0:
     resolution: {integrity: sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==}
     engines: {node: '>=12'}
@@ -5276,6 +5294,8 @@ snapshots:
 
   acorn@8.15.0: {}
 
+  adiff@0.2.13: {}
+
   agent-base@6.0.2:
     dependencies:
       debug: 4.4.0
@@ -5645,6 +5665,8 @@ snapshots:
       object-keys: 1.1.1
 
   delayed-stream@1.0.0: {}
+
+  detect-indent@6.1.0: {}
 
   didyoumean@1.2.2: {}
 
@@ -6189,6 +6211,11 @@ snapshots:
   get-tsconfig@4.10.0:
     dependencies:
       resolve-pkg-maps: 1.0.0
+
+  git-json-merge@1.0.0:
+    dependencies:
+      detect-indent: 6.1.0
+      xdiff: 0.2.11
 
   glob-parent@5.1.2:
     dependencies:
@@ -7905,6 +7932,10 @@ snapshots:
       strip-ansi: 7.1.0
 
   ws@8.18.1: {}
+
+  xdiff@0.2.11:
+    dependencies:
+      adiff: 0.2.13
 
   xml-name-validator@4.0.0: {}
 


### PR DESCRIPTION
Closes #2015 

## Summary

- Adds `git-json-merge` as devDependency for semantic 3-way JSON merging
- Creates `.gitattributes` with `src/locales/**/*.json merge=json` pattern
- Documents setup instructions in README.md Development section

This eliminates manual conflict resolution for the 510+ locale files when multiple branches modify different keys in the same JSON file.

## Developer Setup (One-time)

After pulling this change, run:
```bash
pnpm install
git config merge.json.driver "npx git-json-merge %A %O %B"
git config merge.json.name "Custom 3-way merge driver for JSON files"
```

## How It Works

**Before (manual resolution required):**
```json
<<<<<<< HEAD
  "welcome": "Welcome!",
  "goodbye": "Farewell"
=======
  "welcome": "Welcome!",
  "hello": "Hello there"
>>>>>>> feature-branch
```

**After (automatic resolution):**
```json
  "welcome": "Welcome!",
  "goodbye": "Farewell",
  "hello": "Hello there"
```

## Test Plan

- [x] Verified merge driver installed correctly
- [x] Tested semantic merge with conflicting JSON keys on different branches
- [x] Confirmed fallback to standard conflict markers for same-key modifications

Related: #2015

🤖 Generated with [Claude Code](https://claude.com/claude-code)