### PR TITLE
Fix: lazy require rackup in server command

### DIFF
--- a/lib/onetime/cli/server_command.rb
+++ b/lib/onetime/cli/server_command.rb
@@ -22,8 +22,6 @@
 # @see https://github.com/macournoyer/thin/blob/v2.0.1/lib/thin/rackup/handler.rb
 #
 
-require 'rackup'
-
 module Onetime
   module CLI
     class ServerCommand < DelayBootCommand
@@ -46,6 +44,9 @@ module Onetime
 
       def call(config_file: nil, server: 'puma', port: 7143, environment: 'development',
                threads: '2:4', workers: 0, bind: '127.0.0.1', **)
+        # Lazy require - rackup is in development group, not available in production containers
+        require 'rackup'
+
         has_options = port != 7143 || threads != '2:4' || workers != 0 || bind != '127.0.0.1'
 
         if config_file && has_options

--- a/spec/cli/server_command_spec.rb
+++ b/spec/cli/server_command_spec.rb
@@ -3,6 +3,7 @@
 # frozen_string_literal: true
 
 require_relative 'cli_spec_helper'
+require 'rackup'
 
 RSpec.describe 'Server Command', type: :cli do
   let(:rack_app) { double('RackApp') }


### PR DESCRIPTION
### **User description**
## Summary
- Move `require 'rackup'` from top-level to inside `call()` method
- Fixes `cannot load such file -- rackup (LoadError)` when running `bin/ots jobs worker` in production containers

## Problem
`rackup` is in the `development` Gemfile group, excluded from production images via `BUNDLE_WITHOUT="development:test:optional"`. The CLI was loading `server_command.rb` at boot time, which unconditionally required `rackup`, causing jobs commands to fail.

## Solution
Lazy load `rackup` only when `bin/ots server` actually runs. This allows other CLI commands to work in production containers where `rackup` isn't installed.


___

### **PR Type**
Bug fix


___

### **Description**
- Move `require 'rackup'` from module level to inside `call()` method

- Fixes LoadError when running non-server CLI commands in production

- Allows lazy loading of development-only dependency at runtime


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CLI Boot"] --> B{"Server Command?"}
  B -->|No| C["Other Commands Work"]
  B -->|Yes| D["Load rackup"]
  D --> E["Start Server"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>server_command.rb</strong><dd><code>Lazy load rackup in server command call method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/onetime/cli/server_command.rb

<ul><li>Removed top-level <code>require 'rackup'</code> statement from module scope<br> <li> Added lazy <code>require 'rackup'</code> inside <code>call()</code> method with explanatory <br>comment<br> <li> Prevents LoadError for production containers where rackup is excluded</ul>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/2156/files#diff-ad356e5281a2013278be2da764aef130eee5d9e723b460b7faf0974411601704">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

