### PR TITLE
Fix worker vhost parsing from RABBITMQ_URL

### DIFF
--- a/spec/cli/jobs/worker_command_spec.rb
+++ b/spec/cli/jobs/worker_command_spec.rb
@@ -8,118 +8,135 @@ require 'onetime/cli/jobs/worker_command'
 RSpec.describe Onetime::CLI::Jobs::WorkerCommand, type: :cli do
   let(:command) { described_class.new }
 
-  describe '#extract_vhost_from_url (private)' do
-    # Use send to test private method - it's a pure function with clear inputs/outputs
-    def extract_vhost(url)
-      command.send(:extract_vhost_from_url, url)
+  describe 'Sneakers vhost configuration' do
+    # Track the config passed to Sneakers.configure
+    let(:captured_config) { {} }
+
+    before do
+      # Mock Sneakers.configure to capture the config hash
+      allow(Sneakers).to receive(:configure) do |config|
+        captured_config.merge!(config)
+      end
+
+      # Mock the logger to avoid nil errors
+      mock_logger = double('Logger', level: Logger::INFO)
+      allow(mock_logger).to receive(:level=)
+      allow(Sneakers).to receive(:logger).and_return(mock_logger)
     end
 
-    context 'with standard AMQP URLs' do
-      it 'extracts vhost from path' do
-        expect(extract_vhost('amqp://host/myvhost')).to eq('myvhost')
-      end
-
-      it 'extracts vhost from amqps URL' do
-        expect(extract_vhost('amqps://user:pass@host:5671/production')).to eq('production')
-      end
-
-      it 'handles vhost with credentials in URL' do
-        expect(extract_vhost('amqp://guest:guest@localhost:5672/testvhost')).to eq('testvhost')
-      end
-    end
-
-    context 'with URL-encoded vhosts' do
-      it 'decodes URL-encoded vhost names' do
-        expect(extract_vhost('amqp://host/my%20vhost')).to eq('my vhost')
-      end
-
-      it 'decodes percent-encoded slashes' do
-        expect(extract_vhost('amqp://host/%2Fproduction')).to eq('/production')
-      end
-
-      it 'decodes complex encoded vhost' do
-        expect(extract_vhost('amqp://host/ns%3Aproduction')).to eq('ns:production')
-      end
-
-      it 'preserves literal + characters (not form-decoded to space)' do
-        expect(extract_vhost('amqp://host/my+vhost')).to eq('my+vhost')
-      end
-    end
-
-    context 'with empty or missing path' do
-      it 'returns "/" for empty path' do
-        expect(extract_vhost('amqp://host/')).to eq('/')
-      end
-
-      it 'returns "/" for URL without path' do
-        expect(extract_vhost('amqp://host')).to eq('/')
-      end
-
-      it 'returns "/" for URL with only port' do
-        expect(extract_vhost('amqp://host:5672')).to eq('/')
-      end
-    end
-
-    context 'with invalid URIs' do
-      it 'returns "/" for malformed URI' do
-        expect(extract_vhost('not-a-valid-uri://[')).to eq('/')
-      end
-
-      it 'returns "/" for empty string' do
-        expect(extract_vhost('')).to eq('/')
-      end
-    end
-
-    context 'with multi-segment paths' do
-      # AMQP URLs should only have single-segment vhost names
-      # but we handle whatever URI.parse gives us
-      it 'extracts first segment as vhost' do
-        # URI.parse('/path/to/vhost').path returns '/path/to/vhost'
-        # After removing leading slash: 'path/to/vhost'
-        expect(extract_vhost('amqp://host/path/to/vhost')).to eq('path/to/vhost')
-      end
-    end
-
-    context 'with real-world Northflank-style URLs' do
-      it 'handles Northflank addon URL format' do
-        url = 'amqps://4ef062f27f30f2ec:secretpass@rabbit.northflank.com:5671/4ef062f27f30f2ec'
-        expect(extract_vhost(url)).to eq('4ef062f27f30f2ec')
-      end
-    end
-  end
-
-  describe 'RABBITMQ_VHOST environment variable precedence' do
     around do |example|
-      # Save original env
+      # Save and restore environment
       original_url = ENV['RABBITMQ_URL']
       original_vhost = ENV['RABBITMQ_VHOST']
       example.run
     ensure
-      # Restore original env
       ENV['RABBITMQ_URL'] = original_url
-      ENV['RABBITMQ_VHOST'] = original_vhost
+      if original_vhost.nil?
+        ENV.delete('RABBITMQ_VHOST')
+      else
+        ENV['RABBITMQ_VHOST'] = original_vhost
+      end
     end
 
-    it 'uses RABBITMQ_VHOST when explicitly set' do
-      ENV['RABBITMQ_URL'] = 'amqp://host/url-vhost'
-      ENV['RABBITMQ_VHOST'] = 'override-vhost'
+    context 'when RABBITMQ_VHOST is explicitly set' do
+      it 'includes vhost in Sneakers config' do
+        ENV['RABBITMQ_URL'] = 'amqp://host/url-vhost'
+        ENV['RABBITMQ_VHOST'] = 'override-vhost'
 
-      # The actual vhost selection happens in configure_kicks
-      # We test the logic directly here
-      url = ENV.fetch('RABBITMQ_URL')
-      vhost = ENV.fetch('RABBITMQ_VHOST') { command.send(:extract_vhost_from_url, url) }
+        command.send(:configure_kicks,
+          concurrency: 10,
+          daemonize: false,
+          environment: 'test',
+          log_level: 'info'
+        )
 
-      expect(vhost).to eq('override-vhost')
+        expect(captured_config[:vhost]).to eq('override-vhost')
+      end
+
+      it 'overrides vhost from URL with env var value' do
+        ENV['RABBITMQ_URL'] = 'amqps://user:pass@host:5671/production'
+        ENV['RABBITMQ_VHOST'] = 'staging'
+
+        command.send(:configure_kicks,
+          concurrency: 10,
+          daemonize: false,
+          environment: 'test',
+          log_level: 'info'
+        )
+
+        expect(captured_config[:vhost]).to eq('staging')
+        expect(captured_config[:amqp]).to eq('amqps://user:pass@host:5671/production')
+      end
     end
 
-    it 'extracts from URL when RABBITMQ_VHOST not set' do
-      ENV['RABBITMQ_URL'] = 'amqp://host/url-vhost'
-      ENV.delete('RABBITMQ_VHOST')
+    context 'when RABBITMQ_VHOST is not set' do
+      it 'omits vhost from config (lets Bunny parse from URL)' do
+        ENV['RABBITMQ_URL'] = 'amqp://host/url-vhost'
+        ENV.delete('RABBITMQ_VHOST')
 
-      url = ENV.fetch('RABBITMQ_URL')
-      vhost = ENV.fetch('RABBITMQ_VHOST') { command.send(:extract_vhost_from_url, url) }
+        command.send(:configure_kicks,
+          concurrency: 10,
+          daemonize: false,
+          environment: 'test',
+          log_level: 'info'
+        )
 
-      expect(vhost).to eq('url-vhost')
+        # vhost should NOT be in the config - Bunny will parse it from URL
+        expect(captured_config).not_to have_key(:vhost)
+      end
+
+      it 'passes AMQP URL unchanged for Bunny to parse' do
+        ENV['RABBITMQ_URL'] = 'amqps://4ef062f27f30f2ec:secret@rabbit.northflank.com:5671/4ef062f27f30f2ec'
+        ENV.delete('RABBITMQ_VHOST')
+
+        command.send(:configure_kicks,
+          concurrency: 10,
+          daemonize: false,
+          environment: 'test',
+          log_level: 'info'
+        )
+
+        expect(captured_config[:amqp]).to eq('amqps://4ef062f27f30f2ec:secret@rabbit.northflank.com:5671/4ef062f27f30f2ec')
+        expect(captured_config).not_to have_key(:vhost)
+      end
+    end
+
+    context 'with default RABBITMQ_URL' do
+      it 'uses localhost default when RABBITMQ_URL not set' do
+        ENV.delete('RABBITMQ_URL')
+        ENV.delete('RABBITMQ_VHOST')
+
+        command.send(:configure_kicks,
+          concurrency: 10,
+          daemonize: false,
+          environment: 'test',
+          log_level: 'info'
+        )
+
+        expect(captured_config[:amqp]).to eq('amqp://guest:guest@localhost:5672')
+      end
+    end
+
+    context 'other Sneakers configuration' do
+      it 'sets expected configuration values' do
+        ENV['RABBITMQ_URL'] = 'amqp://host/vhost'
+        ENV.delete('RABBITMQ_VHOST')
+
+        command.send(:configure_kicks,
+          concurrency: 5,
+          daemonize: true,
+          environment: 'production',
+          log_level: 'warn'
+        )
+
+        expect(captured_config[:threads]).to eq(5)
+        expect(captured_config[:daemonize]).to eq(true)
+        expect(captured_config[:env]).to eq('production')
+        expect(captured_config[:exchange]).to eq('')
+        expect(captured_config[:exchange_type]).to eq(:direct)
+        expect(captured_config[:durable]).to eq(true)
+        expect(captured_config[:ack]).to eq(true)
+      end
     end
   end
 end


### PR DESCRIPTION
### **User description**
Sneakers was overriding vhost with '/' default even when the URL contained the correct vhost. Now extracts vhost from URL path component (e.g., amqps://user:pass@host/myvhost -> 'myvhost').

RABBITMQ_VHOST env var still works as explicit override.


___

### **PR Type**
Bug fix


___

### **Description**
- Extracts vhost from RABBITMQ_URL path component instead of defaulting to '/'

- Adds `extract_vhost_from_url()` method to parse URI and decode vhost name

- Maintains RABBITMQ_VHOST env var as explicit override mechanism

- Handles edge cases with URL decoding and invalid URIs gracefully


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["RABBITMQ_URL<br/>amqps://user:pass@host/myvhost"] -->|extract_vhost_from_url| B["Parse URI path<br/>Decode component"]
  C["RABBITMQ_VHOST<br/>env var"] -->|explicit override| D["vhost config"]
  B -->|fallback to '/'| D
  D -->|Sneakers.configure| E["Worker initialized"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>worker_command.rb</strong><dd><code>Add vhost extraction from AMQP URL with override support</code>&nbsp; </dd></summary>
<hr>

lib/onetime/cli/jobs/worker_command.rb

<ul><li>Extracts <code>amqp_url</code> and <code>vhost</code> into variables before Sneakers <br>configuration<br> <li> Implements new <code>extract_vhost_from_url()</code> method to parse AMQP URL path <br>component<br> <li> Uses <code>ENV.fetch()</code> with block to prioritize RABBITMQ_VHOST override, <br>then URL extraction<br> <li> Handles URI parsing errors and empty paths by defaulting to '/' vhost</ul>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/2157/files#diff-fb8077016763147d0c7c3b64c471b304c59b188f806aac3e82e1329982bd7a96">+18/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

