### PR TITLE
Replace blocking Redis KEYS with non-blocking SCAN in Colonel API

### DIFF
--- a/apps/api/colonel/logic/colonel/get_colonel_info.rb
+++ b/apps/api/colonel/logic/colonel/get_colonel_info.rb
@@ -82,8 +82,9 @@ module ColonelAPI
         private :process_customers
 
         def process_statistics
-          @metadata_count  = Onetime::Metadata.new.dbclient.keys('metadata*:object').count
-          @secret_count    = Onetime::Secret.new.dbclient.keys('secret*:object').count
+          # Use O(1) ZCARD-based count via Familia instances instead of O(N) blocking KEYS
+          @metadata_count  = Onetime::Metadata.count
+          @secret_count    = Onetime::Secret.count
           # TODO: Re-enable global statistics when Customer.global is implemented
           # @secrets_created = Onetime::Customer.global.secrets_created.to_s
           # @secrets_shared  = Onetime::Customer.global.secrets_shared.to_s

--- a/apps/api/colonel/logic/colonel/get_database_metrics.rb
+++ b/apps/api/colonel/logic/colonel/get_database_metrics.rb
@@ -70,9 +70,10 @@ module ColonelAPI
               total_keys: total_keys,
               memory_stats: memory_stats,
               model_counts: {
+                # All model counts use O(1) ZCARD-based count via Familia instances
                 customers: Onetime::Customer.count,
-                secrets: Onetime::Secret.new.dbclient.keys('secret*:object').count,
-                metadata: Onetime::Metadata.new.dbclient.keys('metadata*:object').count,
+                secrets: Onetime::Secret.count,
+                metadata: Onetime::Metadata.count,
               },
             },
           }


### PR DESCRIPTION
### **User description**
## Summary

Fixes #2211 - replaces 9 blocking Redis `KEYS` operations in the Colonel admin API with non-blocking alternatives to prevent Redis lock-up under load.

## Changes

The Colonel API used `dbclient.keys('pattern')` calls which are O(N) and block Redis during execution. With a growing database, this caused admin panel timeouts and risked production degradation.

**Count operations** (`get_colonel_info.rb`, `get_database_metrics.rb`):
- Replaced `dbclient.keys('secret*:object').count` with `Onetime::Secret.count`
- These use Familia's O(1) ZCARD-based counting instead of scanning the keyspace

**Iteration operations** (4 files):
- `list_users.rb`: Extracted KEYS from the per-user loop (was O(N*M)) into a single SCAN pass that builds an owner_id→count index
- `export_usage.rb`, `get_user_details.rb`, `list_secrets.rb`: Replaced KEYS with cursor-based SCAN iteration

All SCAN implementations include a 10K item memory bound to prevent OOM on large datasets.

## Testing

- Verified no `.keys('pattern')` calls remain in colonel logic
- QA reviewed all 6 files for correctness and Ruby 3.4 compatibility
- Existing colonel tryouts pass (2/2)

## Notes for Reviewers

The `list_secrets.rb` pagination is still in-memory (loads up to 10K secrets, then slices). A comment notes that true cursor-based pagination could be a future enhancement, but this is acceptable for an admin-only endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Replace 9 blocking Redis KEYS operations with non-blocking SCAN

- Use O(1) ZCARD-based counting via Familia model methods

- Extract SCAN operations from loops to prevent O(N*M) complexity

- Implement 10K item memory bounds to prevent OOM on large datasets


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Blocking KEYS<br/>O(N) operations"] -->|"Replace with"| B["Non-blocking SCAN<br/>Cursor-based iteration"]
  C["Model.count<br/>O(1) ZCARD"] -->|"Use for"| D["Statistics & Metrics"]
  E["SCAN in loops<br/>O(N*M) complexity"] -->|"Extract to"| F["Single SCAN pass<br/>with index"]
  B -->|"Add memory bound"| G["10K item limit<br/>OOM prevention"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>get_colonel_info.rb</strong><dd><code>Replace KEYS with O(1) model count methods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/api/colonel/logic/colonel/get_colonel_info.rb

<ul><li>Replace blocking KEYS calls with O(1) model count methods<br> <li> Use <code>Onetime::Metadata.count</code> and <code>Onetime::Secret.count</code> instead of <br>dbclient.keys<br> <li> Add comment explaining ZCARD-based counting via Familia instances</ul>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/2280/files#diff-f30196a369703132eec6538efa2a64d2b40aa8665c0e153944daf8d077717163">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>get_database_metrics.rb</strong><dd><code>Replace KEYS with O(1) model counts</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/api/colonel/logic/colonel/get_database_metrics.rb

<ul><li>Replace two blocking KEYS calls with O(1) model count methods<br> <li> Use <code>Onetime::Secret.count</code> and <code>Onetime::Metadata.count</code><br> <li> Add clarifying comment about ZCARD-based counting</ul>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/2280/files#diff-69c6eea277205339db3cec10c2d097ef701635e32136ba4c66a9772f01cd4553">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>export_usage.rb</strong><dd><code>Replace KEYS with cursor-based SCAN iteration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/api/colonel/logic/colonel/export_usage.rb

<ul><li>Extract blocking KEYS operation into private <br><code>scan_secrets_in_date_range</code> method<br> <li> Implement cursor-based SCAN iteration with 10K item memory bound<br> <li> Filter secrets by date range during SCAN iteration instead of <br>post-processing</ul>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/2280/files#diff-d73aa46f019fd282b4b8da3b57844bb4ae0a1765c409e0f88b24b68627a422d0">+31/-10</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>get_user_details.rb</strong><dd><code>Replace KEYS with SCAN-based methods for user data</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/api/colonel/logic/colonel/get_user_details.rb

<ul><li>Extract two blocking KEYS operations into private methods <br><code>scan_user_secrets</code> and <code>scan_user_metadata</code><br> <li> Implement cursor-based SCAN iteration for both secrets and metadata<br> <li> Add 10K item memory bounds to prevent OOM on large datasets</ul>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/2280/files#diff-45438cb48510a1b08c9f33987153820faa6710e92f0ad4b2609d761eb74167e4">+71/-33</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>list_secrets.rb</strong><dd><code>Replace KEYS with SCAN-based pagination</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/api/colonel/logic/colonel/list_secrets.rb

<ul><li>Extract blocking KEYS operation into private <code>scan_secrets_paginated</code> <br>method<br> <li> Implement cursor-based SCAN iteration with in-memory pagination<br> <li> Add 10K item memory bound and sort by created timestamp<br> <li> Include comment noting future cursor-based pagination enhancement</ul>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/2280/files#diff-cfbe547673b9797532f74221701ab157e3f0c224245f06c1d4270a6f1a29d7b4">+54/-29</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>list_users.rb</strong><dd><code>Extract SCAN from loop to build owner index</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/api/colonel/logic/colonel/list_users.rb

<ul><li>Extract KEYS operation from per-user loop into private <br><code>build_secrets_count_by_owner</code> method<br> <li> Build owner_id to secret count index using single SCAN pass<br> <li> Eliminate O(N*M) complexity by scanning once instead of per-user<br> <li> Add 10K item memory bound to prevent OOM</ul>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/2280/files#diff-dd59ce2fbfe151afef7e8c0dfa2aa461b671ba25190809cf8b8bd9e785608423">+33/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

