### PR TITLE
Fix for TTL above 7 days 

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -73,6 +73,18 @@ DEFAULT_DOMAIN=
 I18N_ENABLED=false
 I18N_DEFAULT_LOCALE=en
 
+# Secret TTL Configuration
+# Default TTL when creating secrets (in seconds)
+DEFAULT_TTL=
+# Available TTL options shown to users (space-separated seconds)
+# Example: '1800 43200 86400 604800' for 30m, 12h, 24h, 7d
+TTL_OPTIONS=
+# Plan TTL limits - max TTL allowed per plan (in seconds)
+# These override the default hardcoded values
+PLAN_TTL_ANONYMOUS=    # Default: 604800 (7 days)
+PLAN_TTL_BASIC=        # Default: 1209600 (14 days)
+PLAN_TTL_IDENTITY=     # Default: 2592000 (30 days)
+
 # Security settings
 AUTHENTICITY_TYPE=altcha
 AUTHENTICITY_SECRET_KEY='<REPLACE_WITH_STRONG_HMAC_KEY>'

--- a/.env.example
+++ b/.env.example
@@ -80,7 +80,7 @@ DEFAULT_TTL=
 # Example: '1800 43200 86400 604800' for 30m, 12h, 24h, 7d
 TTL_OPTIONS=
 # Plan TTL limits - max TTL allowed per plan (in seconds)
-# These override the default hardcoded values
+# These override the default hardcoded values (max: 31536000 = 365 days)
 PLAN_TTL_ANONYMOUS=    # Default: 604800 (7 days)
 PLAN_TTL_BASIC=        # Default: 1209600 (14 days)
 PLAN_TTL_IDENTITY=     # Default: 2592000 (30 days)

--- a/etc/defaults/config.defaults.yaml
+++ b/etc/defaults/config.defaults.yaml
@@ -140,6 +140,20 @@ site:
         receipt: <%= ENV['API_GUEST_RECEIPT'] != 'false' %>
         burn: <%= ENV['API_GUEST_BURN'] != 'false' %>
   # Configuration options for secret management
+  #
+  # NOTE: TTL limits are enforced at two levels:
+  #   1. Config level (below): DEFAULT_TTL and TTL_OPTIONS control what's shown to users
+  #   2. Plan level: Each plan has a max TTL that caps the actual value
+  #
+  # Plan TTL limits can be overridden via environment variables:
+  #   - PLAN_TTL_ANONYMOUS: Max TTL for anonymous users (default: 604800 = 7 days)
+  #   - PLAN_TTL_BASIC: Max TTL for basic plan users (default: 1209600 = 14 days)
+  #   - PLAN_TTL_IDENTITY: Max TTL for identity plan users (default: 2592000 = 30 days)
+  #
+  # To allow 30-day TTL for anonymous users in Docker:
+  #   TTL_OPTIONS='604800 1209600 2592000'  # 7d, 14d, 30d options
+  #   PLAN_TTL_ANONYMOUS=2592000             # Allow anonymous up to 30 days
+  #
   secret_options:
     # Default Time-To-Live (TTL) for secrets in seconds
     # This value is used if no specific TTL is provided when creating a secret

--- a/etc/defaults/config.defaults.yaml
+++ b/etc/defaults/config.defaults.yaml
@@ -149,6 +149,7 @@ site:
   #   - PLAN_TTL_ANONYMOUS: Max TTL for anonymous users (default: 604800 = 7 days)
   #   - PLAN_TTL_BASIC: Max TTL for basic plan users (default: 1209600 = 14 days)
   #   - PLAN_TTL_IDENTITY: Max TTL for identity plan users (default: 2592000 = 30 days)
+  #   - Maximum allowed value: 31536000 (365 days) to prevent resource exhaustion
   #
   # To allow 30-day TTL for anonymous users in Docker:
   #   TTL_OPTIONS='604800 1209600 2592000'  # 7d, 14d, 30d options

--- a/lib/onetime/plan.rb
+++ b/lib/onetime/plan.rb
@@ -70,16 +70,22 @@ module Onetime
         add_plan :identity, 35, 0, ttl: identity_ttl, size: 10_000_000, api: true, name: 'Identity', email: true, custom_domains: true, dark_mode: true
       end
 
+      # Maximum allowed TTL to prevent resource exhaustion (1 year)
+      MAX_TTL = 365.days
+
       # Parse TTL from environment variable, returning default if not set or invalid.
+      # Values are clamped to MAX_TTL (365 days) to prevent resource exhaustion.
       # @param env_var [String] Name of the environment variable
       # @param default [Integer] Default TTL in seconds
-      # @return [Integer] TTL value in seconds
+      # @return [Integer] TTL value in seconds (capped at MAX_TTL)
       def parse_ttl_env(env_var, default)
         value = ENV[env_var]
         return default if value.nil? || value.empty?
 
         parsed = value.to_i
-        parsed.positive? ? parsed : default
+        return default unless parsed.positive?
+
+        [parsed, MAX_TTL].min
       end
     end
 

--- a/lib/onetime/plan.rb
+++ b/lib/onetime/plan.rb
@@ -75,6 +75,7 @@ module Onetime
 
       # Parse TTL from environment variable, returning default if not set or invalid.
       # Values are clamped to MAX_TTL (365 days) to prevent resource exhaustion.
+      # Uses strict integer parsing - rejects partial matches like "123abc".
       # @param env_var [String] Name of the environment variable
       # @param default [Integer] Default TTL in seconds
       # @return [Integer] TTL value in seconds (capped at MAX_TTL)
@@ -82,10 +83,13 @@ module Onetime
         value = ENV[env_var]
         return default if value.nil? || value.empty?
 
-        parsed = value.to_i
+        parsed = Integer(value, 10)
         return default unless parsed.positive?
 
         [parsed, MAX_TTL].min
+      rescue ArgumentError
+        # Invalid integer format (e.g., "123abc", "abc", "12.5")
+        default
       end
     end
 

--- a/tests/unit/ruby/try/16_plan_ttl_env_try.rb
+++ b/tests/unit/ruby/try/16_plan_ttl_env_try.rb
@@ -10,6 +10,8 @@
 # 4. Valid positive integer parsing
 # 5. Capping at MAX_TTL for oversized values
 # 6. Default value for non-numeric strings
+# 7. Strict parsing rejects partial matches (e.g., "123abc")
+# 8. Strict parsing rejects decimal numbers (e.g., "3600.5")
 
 require_relative './test_helpers'
 
@@ -78,10 +80,20 @@ ENV['TEST_TTL'] = 'abc123'
 OT::Plan.parse_ttl_env('TEST_TTL', 1000)
 #=> 1000
 
-## Parses string with trailing text (Ruby to_i behavior)
+## Returns default for string with trailing text (strict parsing rejects partial matches)
 ENV['TEST_TTL'] = '123abc'
 OT::Plan.parse_ttl_env('TEST_TTL', 1000)
-#=> 123
+#=> 1000
+
+## Returns default for decimal numbers (strict integer parsing)
+ENV['TEST_TTL'] = '3600.5'
+OT::Plan.parse_ttl_env('TEST_TTL', 1000)
+#=> 1000
+
+## Handles values with leading/trailing whitespace (Integer() strips whitespace)
+ENV['TEST_TTL'] = '  3600  '
+OT::Plan.parse_ttl_env('TEST_TTL', 1000)
+#=> 3600
 
 ## Plan TTL env vars work for anonymous plan
 ENV['PLAN_TTL_ANONYMOUS'] = '1209600'

--- a/tests/unit/ruby/try/16_plan_ttl_env_try.rb
+++ b/tests/unit/ruby/try/16_plan_ttl_env_try.rb
@@ -1,0 +1,105 @@
+# tests/unit/ruby/try/16_plan_ttl_env_try.rb
+
+# These tryouts test the Plan.parse_ttl_env method which allows
+# plan TTL limits to be configured via environment variables.
+#
+# Test cases cover:
+# 1. Default value when env var is not set
+# 2. Default value for empty string
+# 3. Default value for non-positive values (0, negative)
+# 4. Valid positive integer parsing
+# 5. Capping at MAX_TTL for oversized values
+# 6. Default value for non-numeric strings
+
+require_relative './test_helpers'
+
+# Use the default config file for tests
+OT.boot! :test, false
+
+# Store original env values to restore later
+ORIGINAL_TEST_TTL = ENV['TEST_TTL']
+
+## MAX_TTL is defined as 365 days
+OT::Plan::MAX_TTL
+#=> 31536000
+
+## Returns default when env var is not set (nil)
+ENV.delete('TEST_TTL')
+OT::Plan.parse_ttl_env('TEST_TTL', 1000)
+#=> 1000
+
+## Returns default for empty string
+ENV['TEST_TTL'] = ''
+OT::Plan.parse_ttl_env('TEST_TTL', 1000)
+#=> 1000
+
+## Returns default for zero value
+ENV['TEST_TTL'] = '0'
+OT::Plan.parse_ttl_env('TEST_TTL', 1000)
+#=> 1000
+
+## Returns default for negative value
+ENV['TEST_TTL'] = '-100'
+OT::Plan.parse_ttl_env('TEST_TTL', 1000)
+#=> 1000
+
+## Returns parsed value for valid positive integer
+ENV['TEST_TTL'] = '2592000'
+OT::Plan.parse_ttl_env('TEST_TTL', 1000)
+#=> 2592000
+
+## Returns parsed value for small valid integer
+ENV['TEST_TTL'] = '3600'
+OT::Plan.parse_ttl_env('TEST_TTL', 1000)
+#=> 3600
+
+## Caps at MAX_TTL for oversized values
+ENV['TEST_TTL'] = '99999999999'
+OT::Plan.parse_ttl_env('TEST_TTL', 1000)
+#=> 31536000
+
+## Caps at MAX_TTL for value just over MAX_TTL
+ENV['TEST_TTL'] = '31536001'
+OT::Plan.parse_ttl_env('TEST_TTL', 1000)
+#=> 31536000
+
+## Returns exactly MAX_TTL when set to MAX_TTL
+ENV['TEST_TTL'] = '31536000'
+OT::Plan.parse_ttl_env('TEST_TTL', 1000)
+#=> 31536000
+
+## Returns default for non-numeric string (to_i returns 0)
+ENV['TEST_TTL'] = 'invalid'
+OT::Plan.parse_ttl_env('TEST_TTL', 1000)
+#=> 1000
+
+## Returns default for string with leading text
+ENV['TEST_TTL'] = 'abc123'
+OT::Plan.parse_ttl_env('TEST_TTL', 1000)
+#=> 1000
+
+## Parses string with trailing text (Ruby to_i behavior)
+ENV['TEST_TTL'] = '123abc'
+OT::Plan.parse_ttl_env('TEST_TTL', 1000)
+#=> 123
+
+## Plan TTL env vars work for anonymous plan
+ENV['PLAN_TTL_ANONYMOUS'] = '1209600'
+OT::Plan.load_plans!
+OT::Plan.plan(:anonymous).options[:ttl]
+#=> 1209600
+
+## Plan TTL env vars are capped at MAX_TTL
+ENV['PLAN_TTL_ANONYMOUS'] = '99999999999'
+OT::Plan.load_plans!
+OT::Plan.plan(:anonymous).options[:ttl]
+#=> 31536000
+
+# Clean up environment variables after tests
+ENV['TEST_TTL'] = ORIGINAL_TEST_TTL
+ENV.delete('PLAN_TTL_ANONYMOUS')
+ENV.delete('PLAN_TTL_BASIC')
+ENV.delete('PLAN_TTL_IDENTITY')
+
+# Reload plans with default values
+OT::Plan.load_plans!


### PR DESCRIPTION
### **User description**
Fixes #2390 - Docker deployments could not set TTL above 7 days even when TTL_OPTIONS included longer durations because plan TTL limits were hardcoded.

Added environment variable overrides for plan TTL limits:
- PLAN_TTL_ANONYMOUS (default: 604800 = 7 days)
- PLAN_TTL_BASIC (default: 1209600 = 14 days)
- PLAN_TTL_IDENTITY (default: 2592000 = 30 days)

To allow 30-day TTL for anonymous users in Docker:
  TTL_OPTIONS='604800 1209600 2592000'
  PLAN_TTL_ANONYMOUS=2592000


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Allow plan TTL limits to be configured via environment variables

- Add PLAN_TTL_ANONYMOUS, PLAN_TTL_BASIC, PLAN_TTL_IDENTITY overrides

- Enable Docker deployments to set TTL above 7 days without code changes

- Document TTL configuration with examples and defaults


___

### Diagram Walkthrough


```mermaid
flowchart LR
  ENV["Environment Variables<br/>PLAN_TTL_*"] -- "parse_ttl_env()" --> PARSER["TTL Parser<br/>with defaults"]
  PARSER -- "anonymous_ttl<br/>basic_ttl<br/>identity_ttl" --> PLANS["Plan Configuration<br/>load_plans!"]
  PLANS --> RESULT["Flexible TTL Limits<br/>per plan"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>plan.rb</strong><dd><code>Make plan TTL limits environment-configurable</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/onetime/plan.rb

<ul><li>Extract hardcoded TTL values into environment variable overrides<br> <li> Add <code>parse_ttl_env()</code> method to safely parse TTL from ENV with defaults<br> <li> Use parsed TTL values when defining anonymous, basic, and identity <br>plans<br> <li> Add documentation comments explaining the configuration approach</ul>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/2393/files#diff-c16aaf64e8113cc0a26e0f0cce4f1765fc639caec85f4eae5c80a15a71a1cff7">+22/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.env.example</strong><dd><code>Document TTL configuration environment variables</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.env.example

<ul><li>Add new section for Secret TTL Configuration<br> <li> Document DEFAULT_TTL and TTL_OPTIONS with examples<br> <li> Add PLAN_TTL_ANONYMOUS, PLAN_TTL_BASIC, PLAN_TTL_IDENTITY with <br>defaults<br> <li> Include usage example for setting 30-day TTL for anonymous users</ul>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/2393/files#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8c">+12/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>config.defaults.yaml</strong><dd><code>Document TTL configuration architecture and overrides</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

etc/defaults/config.defaults.yaml

<ul><li>Add comprehensive documentation about two-level TTL enforcement<br> <li> Explain relationship between config-level and plan-level TTL limits<br> <li> Document environment variable overrides with default values<br> <li> Provide Docker example for enabling 30-day TTL for anonymous users</ul>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/2393/files#diff-29ced24d2eddd11c1376069f7683c996901bc66574de55125d817b95b9060c91">+14/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

