### PR TITLE
Add backend verification trigger from DNS widget

### DIFF
--- a/apps/api/domains/logic/domains/verify_domain.rb
+++ b/apps/api/domains/logic/domains/verify_domain.rb
@@ -22,8 +22,17 @@ module DomainsAPI::Logic
       end
 
       # Refresh the domain status (SSL, resolving, etc.)
+      # If the vhost doesn't exist in Approximated, try to create it first.
       def refresh_status(strategy)
         result = strategy.check_status(custom_domain)
+
+        # Check if vhost not found (404) - the strategy returns this as a message
+        if vhost_not_found?(result)
+          OT.info "[VerifyDomain.refresh_status] Vhost not found for #{display_domain}, attempting to create"
+          ensure_vhost_exists(strategy)
+          # Re-check status after creating vhost
+          result = strategy.check_status(custom_domain)
+        end
 
         OT.info "[VerifyDomain.refresh_status] #{display_domain} -> #{result[:ready]}"
 
@@ -39,6 +48,35 @@ module DomainsAPI::Logic
         custom_domain.save
       rescue StandardError => ex
         OT.le "[VerifyDomain.refresh_status] Error: #{ex.message}"
+      end
+
+      # Check if the result indicates vhost was not found (404 from Approximated)
+      def vhost_not_found?(result)
+        return false unless result.is_a?(Hash)
+
+        message = result[:message].to_s
+        message.include?('Could not find Virtual Host')
+      end
+
+      # Ensure the vhost exists in Approximated, creating it if necessary.
+      # This handles cases where the initial vhost creation failed during domain addition.
+      def ensure_vhost_exists(strategy)
+        result = strategy.request_certificate(custom_domain)
+
+        if %w[requested success].include?(result[:status])
+          OT.info "[VerifyDomain.ensure_vhost_exists] Created vhost for #{display_domain}"
+
+          # Store the vhost data if returned
+          if result[:data]
+            custom_domain.vhost   = result[:data].to_json
+            custom_domain.updated = OT.now.to_i
+            custom_domain.save
+          end
+        else
+          OT.le "[VerifyDomain.ensure_vhost_exists] Failed to create vhost: #{result[:message]}"
+        end
+      rescue StandardError => ex
+        OT.le "[VerifyDomain.ensure_vhost_exists] Error: #{ex.message}"
       end
 
       # Validate domain ownership via TXT record

--- a/lib/onetime/domain_validation/approximated_strategy.rb
+++ b/lib/onetime/domain_validation/approximated_strategy.rb
@@ -92,14 +92,20 @@ module Onetime
         api_key      = Features.api_key
         vhost_target = Features.vhost_target
 
+        OT.ld "[ApproximatedStrategy.request_certificate] domain=#{custom_domain.display_domain} " \
+              "vhost_target=#{vhost_target.inspect} api_key_present=#{!api_key.to_s.empty?}"
+
         if api_key.to_s.empty?
           return { status: 'error', message: 'Approximated API key not configured' }
         end
 
         if vhost_target.to_s.empty?
-          OT.le '[ApproximatedStrategy] vhost_target not configured (set APPROXIMATED_VHOST_TARGET)'
+          OT.le '[ApproximatedStrategy] vhost_target not configured (set features.domains.approximated.vhost_target)'
           return { status: 'error', message: 'Approximated vhost_target not configured' }
         end
+
+        OT.ld '[ApproximatedStrategy.request_certificate] Creating vhost: ' \
+              "incoming=#{custom_domain.display_domain} target=#{vhost_target} port=443"
 
         res = client.create_vhost(
           api_key,
@@ -134,6 +140,9 @@ module Onetime
       #
       def check_status(custom_domain)
         api_key = Features.api_key
+
+        OT.ld "[ApproximatedStrategy.check_status] domain=#{custom_domain.display_domain} " \
+              "api_key_present=#{!api_key.to_s.empty?}"
 
         if api_key.to_s.empty?
           return { ready: false, message: 'Approximated API key not configured' }

--- a/lib/onetime/domain_validation/approximated_strategy.rb
+++ b/lib/onetime/domain_validation/approximated_strategy.rb
@@ -114,7 +114,8 @@ module Onetime
           '443',
         )
 
-        if res.code == 200
+        # 200 = existing vhost returned, 201 = new vhost created
+        if [200, 201].include?(res.code)
           payload = res.parsed_response
           {
             status: 'requested',

--- a/lib/onetime/domain_validation/approximated_strategy.rb
+++ b/lib/onetime/domain_validation/approximated_strategy.rb
@@ -96,6 +96,11 @@ module Onetime
           return { status: 'error', message: 'Approximated API key not configured' }
         end
 
+        if vhost_target.to_s.empty?
+          OT.le '[ApproximatedStrategy] vhost_target not configured (set APPROXIMATED_VHOST_TARGET)'
+          return { status: 'error', message: 'Approximated vhost_target not configured' }
+        end
+
         res = client.create_vhost(
           api_key,
           custom_domain.display_domain,

--- a/lib/onetime/domain_validation/features.rb
+++ b/lib/onetime/domain_validation/features.rb
@@ -91,13 +91,21 @@ module Onetime
           domains_config = config.dig('features', 'domains') || {}
           approx_config  = domains_config['approximated'] || {}
 
+          strategy   = domains_config['validation_strategy'] || 'passthrough'
+          target     = approx_config['vhost_target']
+          has_key    = !approx_config['api_key'].to_s.empty?
+
+          OT.info "[DomainValidation::Features] Loading config: strategy=#{strategy} " \
+                  "vhost_target=#{target.inspect} api_key_present=#{has_key} " \
+                  "proxy_host=#{approx_config['proxy_host'].inspect}"
+
           configure(
-            strategy_name: domains_config['validation_strategy'] || 'passthrough',
+            strategy_name: strategy,
             api_key: approx_config['api_key'],
             proxy_ip: approx_config['proxy_ip'],
             proxy_host: approx_config['proxy_host'],
             proxy_name: approx_config['proxy_name'],
-            vhost_target: approx_config['vhost_target'],
+            vhost_target: target,
           )
         end
 

--- a/src/apps/secret/conceal/IncomingSuccess.vue
+++ b/src/apps/secret/conceal/IncomingSuccess.vue
@@ -31,13 +31,13 @@
     try {
       await navigator.clipboard.writeText(receiptKey.value);
       copied.value = true;
-      notifications.show('Reference ID copied to clipboard', 'success');
+      notifications.show('Reference ID copied to clipboard', 'success', 'top');
 
       setTimeout(() => {
         copied.value = false;
       }, 2000);
     } catch {
-      notifications.show('Failed to copy reference ID', 'error');
+      notifications.show('Failed to copy reference ID', 'error', 'top');
     }
   };
 </script>

--- a/src/apps/workspace/domains/DomainVerify.vue
+++ b/src/apps/workspace/domains/DomainVerify.vue
@@ -95,9 +95,15 @@
 
   // On mount: fetch domain then verify if showing widget
   onMounted(async () => {
-    await fetchDomain();
-    if (showDnsWidget.value) {
-      await triggerVerification();
+    try {
+      await fetchDomain();
+      if (showDnsWidget.value) {
+        await triggerVerification();
+      }
+    } catch (err: unknown) {
+      // Errors from fetchDomain are handled by useDomainsManager
+      // This catch is a safety net for any unexpected errors
+      console.error('Failed to initialize domain verification:', err);
     }
   });
 </script>

--- a/src/shared/components/ui/EmailObfuscator.vue
+++ b/src/shared/components/ui/EmailObfuscator.vue
@@ -31,10 +31,10 @@ const handleClick = async () => {
   // Copy email to clipboard
   try {
     await navigator.clipboard.writeText(deobfuscatedEmail);
-    notifications.show(t('web.COMMON.email_address_copied_to_clipboard'), 'success');
+    notifications.show(t('web.COMMON.email_address_copied_to_clipboard'), 'success', 'top');
   } catch (err) {
     console.error('Failed to copy email: ', err);
-    notifications.show(t('web.COMMON.unexpected_error'), 'error');
+    notifications.show(t('web.COMMON.unexpected_error'), 'error', 'top');
   }
 
 };

--- a/src/shared/composables/useDomain.ts
+++ b/src/shared/composables/useDomain.ts
@@ -42,7 +42,7 @@ export function useDomain(domainId?: string) {
   const details = ref<any>(null);
 
   const defaultAsyncHandlerOptions: AsyncHandlerOptions = {
-    notify: (message, severity) => notifications.show(message, severity),
+    notify: (message, severity) => notifications.show(message, severity, 'top'),
     setLoading: (loading) => (isLoading.value = loading),
     onError: (err) => {
       if (err.code === 404 || err.code === 422 || err.code === 403) {
@@ -75,7 +75,7 @@ export function useDomain(domainId?: string) {
     wrap(async () => {
       if (!domainId) return;
       await store.verifyDomain(domainId);
-      notifications.show(t('web.domains.domain_verification_initiated_successfully'), 'success');
+      notifications.show(t('web.domains.domain_verification_initiated_successfully'), 'success', 'top');
       await initialize();
     });
 
@@ -83,7 +83,7 @@ export function useDomain(domainId?: string) {
     wrap(async () => {
       if (!domainId) return;
       await store.deleteDomain(domainId);
-      notifications.show(t('web.domains.domain_removed_successfully'), 'success');
+      notifications.show(t('web.domains.domain_removed_successfully'), 'success', 'top');
       router.push({ name: 'Domains' });
     });
 

--- a/src/shared/composables/useDomainsManager.ts
+++ b/src/shared/composables/useDomainsManager.ts
@@ -46,7 +46,7 @@ export function useDomainsManager() {
 
   const defaultAsyncHandlerOptions: AsyncHandlerOptions = {
     notify: (message, severity) => {
-      notifications.show(message, severity);
+      notifications.show(message, severity, 'top');
     },
     setLoading: (loading) => (isLoading.value = loading),
     onError: (err) => {
@@ -60,7 +60,7 @@ export function useDomainsManager() {
       // These should surface to the user, not redirect to NotFound
       error.value = err;
       if (err.message) {
-        notifications.show(err.message, 'error');
+        notifications.show(err.message, 'error', 'top');
       }
     },
   };
@@ -97,13 +97,13 @@ export function useDomainsManager() {
   const verifyDomain = async (extid: string) =>
     wrap(async () => {
       const result = await store.verifyDomain(extid);
-      notifications.show(t('web.domains.domain_verification_initiated_successfully'), 'success');
+      notifications.show(t('web.domains.domain_verification_initiated_successfully'), 'success', 'top');
       return result;
     });
 
   const handleDomainExistsError = async (domain: string, errorMessage: string) => {
     if (errorMessage.includes('already registered in your organization')) {
-      notifications.show(t('web.domains.domain_already_in_organization'), 'warning');
+      notifications.show(t('web.domains.domain_already_in_organization'), 'warning', 'top');
       await store.fetchList();
       const existingDomain = store.records?.find(d => d.display_domain === domain);
       if (existingDomain && orgid.value) {
@@ -117,7 +117,7 @@ export function useDomainsManager() {
       return null;
     }
     if (errorMessage.includes('registered to another organization')) {
-      notifications.show(t('web.domains.domain_in_other_organization'), 'error');
+      notifications.show(t('web.domains.domain_in_other_organization'), 'error', 'top');
       return null;
     }
     return undefined; // Signal to re-throw
@@ -151,7 +151,7 @@ export function useDomainsManager() {
         const { record, details } = result;
         const isReclaimed = record.updated.getTime() > record.created.getTime();
         const message = isReclaimed ? 'web.domains.domain_claimed_successfully' : 'web.domains.domain_added_successfully';
-        notifications.show(t(message), 'success');
+        notifications.show(t(message), 'success', 'top');
 
         updateDomainContextAfterAdd(record, details);
 
@@ -173,7 +173,7 @@ export function useDomainsManager() {
 
   const deleteDomain = async (domainId: string) => {
     await store.deleteDomain(domainId);
-    notifications.show(t('web.domains.domain_removed_successfully'), 'success');
+    notifications.show(t('web.domains.domain_removed_successfully'), 'success', 'top');
   };
 
   /**

--- a/src/shared/composables/useIncomingSecret.ts
+++ b/src/shared/composables/useIncomingSecret.ts
@@ -76,7 +76,7 @@ export function useIncomingSecret(options?: IncomingSecretOptions) {
 
   // Form submission: shows user notifications
   const submitHandlerOptions: AsyncHandlerOptions = {
-    notify: (message, severity) => notifications.show(message, severity),
+    notify: (message, severity) => notifications.show(message, severity, 'top'),
     setLoading: (loading) => (isSubmitting.value = loading),
   };
 

--- a/src/shared/composables/useMembersManager.ts
+++ b/src/shared/composables/useMembersManager.ts
@@ -63,7 +63,7 @@ export function useMembersManager() {
   // Async handler configuration
   const defaultAsyncHandlerOptions: AsyncHandlerOptions = {
     notify: (message, severity) => {
-      notifications.show(message, severity);
+      notifications.show(message, severity, 'top');
     },
     setLoading: (loading) => (isLoading.value = loading),
     onError: (err) => {
@@ -137,7 +137,8 @@ export function useMembersManager() {
       if (!canChangeRole(member)) {
         notifications.show(
           t('web.organizations.members.insufficient_permissions'),
-          'error'
+          'error',
+          'top'
         );
         return undefined;
       }
@@ -145,7 +146,8 @@ export function useMembersManager() {
       if (newRole === 'owner') {
         notifications.show(
           t('web.organizations.members.cannot_change_own_role'),
-          'error'
+          'error',
+          'top'
         );
         return undefined;
       }
@@ -155,7 +157,8 @@ export function useMembersManager() {
 
       notifications.show(
         t('web.organizations.members.role_updated'),
-        'success'
+        'success',
+        'top'
       );
 
       return result;
@@ -177,12 +180,14 @@ export function useMembersManager() {
         if (member.role === 'owner') {
           notifications.show(
             t('web.organizations.members.cannot_remove_owner'),
-            'error'
+            'error',
+            'top'
           );
         } else {
           notifications.show(
             t('web.organizations.members.insufficient_permissions'),
-            'error'
+            'error',
+            'top'
           );
         }
         return undefined;
@@ -192,7 +197,8 @@ export function useMembersManager() {
 
       notifications.show(
         t('web.organizations.members.member_removed'),
-        'success'
+        'success',
+        'top'
       );
 
       return true;

--- a/src/shared/composables/useReceipt.ts
+++ b/src/shared/composables/useReceipt.ts
@@ -50,7 +50,7 @@ export function useReceipt(receiptIdentifier: string, options?: ReceiptOptions) 
   // );
 
   const defaultAsyncHandlerOptions: AsyncHandlerOptions = {
-    notify: (message, severity) => notifications.show(message, severity as NotificationSeverity),
+    notify: (message, severity) => notifications.show(message, severity as NotificationSeverity, 'top'),
     setLoading: (loading) => (isLoading.value = loading),
     onError: (err) => (error.value = err),
   };

--- a/src/shared/composables/useReceiptList.ts
+++ b/src/shared/composables/useReceiptList.ts
@@ -27,7 +27,7 @@ export function useReceiptList() {
   const error = ref<ApplicationError | null>(null);
 
   const defaultAsyncHandlerOptions: AsyncHandlerOptions = {
-    notify: (message, severity) => notifications.show(message, severity),
+    notify: (message, severity) => notifications.show(message, severity, 'top'),
     setLoading: (loading) => (isLoading.value = loading),
     onError: (err) => (error.value = err),
   };

--- a/src/shared/composables/useRecentSecrets.ts
+++ b/src/shared/composables/useRecentSecrets.ts
@@ -321,7 +321,7 @@ export function useRecentSecrets(): UseRecentSecretsReturn {
   const error = ref<ApplicationError | null>(null);
 
   const defaultAsyncHandlerOptions: AsyncHandlerOptions = {
-    notify: (message, severity) => notifications.show(message, severity),
+    notify: (message, severity) => notifications.show(message, severity, 'top'),
     setLoading: (loading) => (isLoading.value = loading),
     onError: (err) => (error.value = err),
   };

--- a/src/shared/composables/useSecretConcealer.ts
+++ b/src/shared/composables/useSecretConcealer.ts
@@ -57,7 +57,7 @@ export function useSecretConcealer(options?: SecretConcealerOptions) {
   const { form, validation, operations } = useSecretForm();
 
   const asyncHandlerOptions: AsyncHandlerOptions = {
-    notify: (message, severity) => notifications.show(message, severity),
+    notify: (message, severity) => notifications.show(message, severity, 'top'),
     setLoading: (loading) => (isSubmitting.value = loading),
   };
 

--- a/src/shared/composables/useSystemSettings.ts
+++ b/src/shared/composables/useSystemSettings.ts
@@ -41,7 +41,7 @@ export function useSystemSettings() {
 
   // AsyncHandler setup
   const defaultOptions: AsyncHandlerOptions = {
-    notify: (message, severity) => notifications.show(message, severity),
+    notify: (message, severity) => notifications.show(message, severity, 'top'),
     setLoading: (loading) => (isSaving.value = loading),
     onError: (err) => {
       errorMessage.value = err.message || t('web.colonel.errorSavingConfig');
@@ -245,7 +245,7 @@ export function useSystemSettings() {
         modifiedSections.value.delete(currentSection);
 
         saveSuccess.value = true;
-        notifications.show(t('web.colonel.sectionSaved', { section: sectionLabel }), 'success');
+        notifications.show(t('web.colonel.sectionSaved', { section: sectionLabel }), 'success', 'top');
       } catch (error) {
         // The wrap function will handle notifications.show for errors
         throw error;

--- a/src/shared/stores/notificationsStore.ts
+++ b/src/shared/stores/notificationsStore.ts
@@ -102,7 +102,7 @@ export const useNotificationsStore = defineStore('notifications', () => {
    *
    * @param msg - Notification message text
    * @param sev - Message severity: 'success' | 'error' | 'info'
-   * @param pos - Optional display position, defaults to 'bottom'
+   * @param pos - Optional display position, defaults to 'top'
    *
    * @example Error Notification
    * ```ts
@@ -117,7 +117,7 @@ export const useNotificationsStore = defineStore('notifications', () => {
   function show(msg: string, sev: NotificationSeverity, pos?: NotificationPosition) {
     message.value = msg;
     severity.value = sev;
-    position.value = pos || 'bottom';
+    position.value = pos || 'top';
     isVisible.value = true;
 
     setTimeout(() => {
@@ -148,7 +148,7 @@ export const useNotificationsStore = defineStore('notifications', () => {
     message.value = '';
     severity.value = null;
     isVisible.value = false;
-    position.value = 'bottom';
+    position.value = 'top';
     _initialized.value = false;
   }
 

--- a/src/tests/apps/workspace/domains/DomainVerify.spec.ts
+++ b/src/tests/apps/workspace/domains/DomainVerify.spec.ts
@@ -1,0 +1,472 @@
+// src/tests/apps/workspace/domains/DomainVerify.spec.ts
+
+import { mount, flushPromises } from '@vue/test-utils';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createI18n } from 'vue-i18n';
+import { createPinia, setActivePinia } from 'pinia';
+import DomainVerify from '@/apps/workspace/domains/DomainVerify.vue';
+import { ref } from 'vue';
+
+// Mock route params
+const mockRouteParams = { extid: 'dm-test-extid' };
+
+vi.mock('vue-router', () => ({
+  useRoute: () => ({
+    params: mockRouteParams,
+  }),
+}));
+
+// Mock child components
+vi.mock('@/apps/workspace/components/domains/DnsWidget.vue', () => ({
+  default: {
+    name: 'DnsWidget',
+    template: '<div class="dns-widget" data-testid="dns-widget"><slot /></div>',
+    props: ['domain', 'targetAddress', 'isApex', 'txtValidationHost', 'txtValidationValue', 'trd'],
+    emits: ['records-verified'],
+  },
+}));
+
+vi.mock('@/apps/workspace/components/domains/DomainVerificationInfo.vue', () => ({
+  default: {
+    name: 'DomainVerificationInfo',
+    template: '<div class="domain-verification-info" data-testid="domain-verification-info" />',
+    props: ['domain', 'mode'],
+  },
+}));
+
+vi.mock('@/shared/components/ui/MoreInfoText.vue', () => ({
+  default: {
+    name: 'MoreInfoText',
+    template: '<div class="more-info-text"><slot /></div>',
+    props: ['textColor', 'bgColor'],
+  },
+}));
+
+vi.mock('@/apps/workspace/components/domains/VerifyDomainDetails.vue', () => ({
+  default: {
+    name: 'VerifyDomainDetails',
+    template: '<div class="verify-domain-details" data-testid="verify-domain-details" />',
+    props: ['domain', 'cluster', 'withVerifyCTA'],
+    emits: ['domain-verify'],
+  },
+}));
+
+vi.mock('@/shared/components/forms/BasicFormAlerts.vue', () => ({
+  default: {
+    name: 'BasicFormAlerts',
+    template: '<div class="basic-form-alerts" data-testid="basic-form-alerts">{{ errors?.join(", ") }}</div>',
+    props: ['success', 'error', 'errors'],
+  },
+}));
+
+// Mock useDomainsManager
+const mockGetDomain = vi.fn();
+const mockVerifyDomain = vi.fn();
+const mockIsLoading = ref(false);
+const mockError = ref(null);
+
+vi.mock('@/shared/composables/useDomainsManager', () => ({
+  useDomainsManager: () => ({
+    getDomain: mockGetDomain,
+    verifyDomain: mockVerifyDomain,
+    isLoading: mockIsLoading,
+    error: mockError,
+  }),
+}));
+
+// i18n setup
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: {
+    en: {
+      web: {
+        domains: {
+          verify_your_domain: 'Verify Your Domain',
+          before_we_can_activate_links_for: 'Before we can activate links for',
+          youll_need_to_complete_these_steps: "you'll need to complete these steps",
+          configure_dns_records: 'Configure DNS Records',
+          dns_widget_description: 'Use this widget to configure your DNS records',
+          verify_domain: 'Verify Domain',
+          loading_domain_information: 'Loading domain information...',
+          domain_verification_initiated_successfully: 'Domain verification initiated successfully',
+          in_order_to_connect_your_domain_youll_need_to_ha: 'In order to connect your domain, you\'ll need to have',
+          if_you_already_have_a_cname_record_for_that_addr: 'If you already have a CNAME record for that address',
+          and_remove_any_other_a_aaaa_or_cname_records_for: 'and remove any other A, AAAA, or CNAME records for',
+          please_note_that_for_apex_domains: 'Please note that for apex domains',
+          a_cname_record_is_not_allowed_instead_youll_need: 'a CNAME record is not allowed. Instead, you\'ll need',
+        },
+        COMMON: {
+          processing: 'Processing...',
+          important: 'Important',
+        },
+      },
+    },
+  },
+});
+
+// Test fixtures
+const createMockDomain = (overrides = {}) => ({
+  extid: 'dm-test-extid',
+  display_domain: 'test.example.com',
+  is_apex: false,
+  vhost: { last_monitored_unix: 0 },
+  txt_validation_host: '_challenge.test',
+  txt_validation_value: 'verify123',
+  trd: 'test',
+  ...overrides,
+});
+
+const createMockCluster = (overrides = {}) => ({
+  validation_strategy: 'approximated',
+  proxy_host: 'proxy.example.com',
+  proxy_ip: '192.168.1.1',
+  proxy_name: 'Proxy Server',
+  ...overrides,
+});
+
+describe('DomainVerify', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+
+    // Default mock responses
+    mockGetDomain.mockResolvedValue({
+      domain: createMockDomain(),
+      cluster: createMockCluster(),
+      canVerify: true,
+    });
+    mockVerifyDomain.mockResolvedValue({ success: true });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const mountComponent = async () => {
+    const wrapper = mount(DomainVerify, {
+      global: {
+        plugins: [i18n, createPinia()],
+        stubs: {
+          RouterLink: { template: '<a><slot /></a>' },
+        },
+      },
+    });
+    await flushPromises();
+    return wrapper;
+  };
+
+  describe('mount and auto-verification', () => {
+    it('fetches domain data on mount', async () => {
+      await mountComponent();
+
+      expect(mockGetDomain).toHaveBeenCalledWith('dm-test-extid');
+    });
+
+    it('auto-triggers verification on mount when showDnsWidget is true', async () => {
+      mockGetDomain.mockResolvedValue({
+        domain: createMockDomain({ vhost: { last_monitored_unix: 0 } }),
+        cluster: createMockCluster({ validation_strategy: 'approximated' }),
+        canVerify: true,
+      });
+
+      await mountComponent();
+
+      expect(mockVerifyDomain).toHaveBeenCalledWith('dm-test-extid');
+    });
+
+    it('does NOT auto-trigger verification when domain is already verified', async () => {
+      mockGetDomain.mockResolvedValue({
+        domain: createMockDomain({ vhost: { last_monitored_unix: 1704067200 } }),
+        cluster: createMockCluster(),
+        canVerify: true,
+      });
+
+      await mountComponent();
+
+      expect(mockVerifyDomain).not.toHaveBeenCalled();
+    });
+
+    it('does NOT auto-trigger verification when validation_strategy is not approximated', async () => {
+      mockGetDomain.mockResolvedValue({
+        domain: createMockDomain(),
+        cluster: createMockCluster({ validation_strategy: 'manual' }),
+        canVerify: true,
+      });
+
+      await mountComponent();
+
+      expect(mockVerifyDomain).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('DNS widget event handling', () => {
+    it('triggers backend verification when @records-verified fires', async () => {
+      const wrapper = await mountComponent();
+      vi.clearAllMocks(); // Clear auto-verification call
+
+      // Advance time past cooldown to allow verification
+      vi.advanceTimersByTime(11000);
+
+      const dnsWidget = wrapper.findComponent({ name: 'DnsWidget' });
+      await dnsWidget.vm.$emit('records-verified');
+      await flushPromises();
+
+      expect(mockVerifyDomain).toHaveBeenCalledWith('dm-test-extid');
+    });
+
+    it('refreshes domain data after successful widget verification', async () => {
+      const wrapper = await mountComponent();
+      vi.clearAllMocks();
+
+      // Advance time past cooldown to allow verification
+      vi.advanceTimersByTime(11000);
+
+      const dnsWidget = wrapper.findComponent({ name: 'DnsWidget' });
+      await dnsWidget.vm.$emit('records-verified');
+      await flushPromises();
+
+      // getDomain called once after verification
+      expect(mockGetDomain).toHaveBeenCalledWith('dm-test-extid');
+    });
+  });
+
+  describe('manual verify button', () => {
+    it('renders verify button when DNS widget is shown', async () => {
+      const wrapper = await mountComponent();
+
+      const button = wrapper.find('button[type="button"]');
+      expect(button.exists()).toBe(true);
+      expect(button.text()).toContain('Verify Domain');
+    });
+
+    it('triggers verification on button click', async () => {
+      const wrapper = await mountComponent();
+      vi.clearAllMocks();
+
+      // Advance time past cooldown
+      vi.advanceTimersByTime(11000);
+
+      const button = wrapper.find('button[type="button"]');
+      await button.trigger('click');
+      await flushPromises();
+
+      expect(mockVerifyDomain).toHaveBeenCalledWith('dm-test-extid');
+    });
+
+    it('button is disabled during verification', async () => {
+      // Make verifyDomain hang to simulate in-progress state
+      mockVerifyDomain.mockImplementation(() => new Promise(() => {}));
+
+      const wrapper = await mountComponent();
+
+      const button = wrapper.find('button[type="button"]');
+      expect(button.attributes('disabled')).toBeDefined();
+    });
+
+    it('button shows processing text during verification', async () => {
+      mockVerifyDomain.mockImplementation(() => new Promise(() => {}));
+
+      const wrapper = await mountComponent();
+
+      const button = wrapper.find('button[type="button"]');
+      expect(button.text()).toContain('Processing...');
+    });
+
+    it('button re-enables after verification completes', async () => {
+      mockVerifyDomain.mockResolvedValue({ success: true });
+
+      const wrapper = await mountComponent();
+      await flushPromises();
+
+      // Advance time past cooldown
+      vi.advanceTimersByTime(11000);
+
+      const button = wrapper.find('button[type="button"]');
+      expect(button.attributes('disabled')).toBeUndefined();
+    });
+  });
+
+  describe('rate limiting', () => {
+    it('prevents rapid verification attempts within cooldown period', async () => {
+      const wrapper = await mountComponent();
+      vi.clearAllMocks();
+
+      // First click (should be rate-limited since auto-verification just happened)
+      const button = wrapper.find('button[type="button"]');
+      await button.trigger('click');
+      await flushPromises();
+
+      expect(mockVerifyDomain).not.toHaveBeenCalled();
+    });
+
+    it('allows verification after cooldown period expires', async () => {
+      const wrapper = await mountComponent();
+      vi.clearAllMocks();
+
+      // Advance time past the 10-second cooldown
+      vi.advanceTimersByTime(11000);
+
+      const button = wrapper.find('button[type="button"]');
+      await button.trigger('click');
+      await flushPromises();
+
+      expect(mockVerifyDomain).toHaveBeenCalledWith('dm-test-extid');
+    });
+  });
+
+  describe('error handling', () => {
+    it('displays error message after failed verification', async () => {
+      mockVerifyDomain.mockRejectedValue(new Error('Verification failed'));
+
+      const wrapper = await mountComponent();
+      await flushPromises();
+
+      const alerts = wrapper.find('[data-testid="basic-form-alerts"]');
+      expect(alerts.exists()).toBe(true);
+      expect(alerts.text()).toContain('Verification failed');
+    });
+
+    it('clears error before new verification attempt', async () => {
+      // First call fails
+      mockVerifyDomain.mockRejectedValueOnce(new Error('First error'));
+      // Second call succeeds
+      mockVerifyDomain.mockResolvedValueOnce({ success: true });
+
+      const wrapper = await mountComponent();
+      await flushPromises();
+
+      // Error should be shown
+      expect(wrapper.find('[data-testid="basic-form-alerts"]').exists()).toBe(true);
+
+      // Advance time and retry
+      vi.advanceTimersByTime(11000);
+      const button = wrapper.find('button[type="button"]');
+      await button.trigger('click');
+      await flushPromises();
+
+      // Error should be cleared on new attempt (even if we can't verify final state easily)
+      expect(mockVerifyDomain).toHaveBeenCalledTimes(2);
+    });
+
+    it('handles error objects with message property', async () => {
+      mockVerifyDomain.mockRejectedValue({ message: 'API error message' });
+
+      const wrapper = await mountComponent();
+      await flushPromises();
+
+      const alerts = wrapper.find('[data-testid="basic-form-alerts"]');
+      expect(alerts.text()).toContain('API error message');
+    });
+
+    it('handles non-Error objects gracefully', async () => {
+      mockVerifyDomain.mockRejectedValue('String error');
+
+      const wrapper = await mountComponent();
+      await flushPromises();
+
+      const alerts = wrapper.find('[data-testid="basic-form-alerts"]');
+      expect(alerts.text()).toContain('String error');
+    });
+  });
+
+  describe('conditional rendering', () => {
+    it('shows DnsWidget when domain unverified + approximated strategy', async () => {
+      mockGetDomain.mockResolvedValue({
+        domain: createMockDomain({ vhost: { last_monitored_unix: 0 } }),
+        cluster: createMockCluster({ validation_strategy: 'approximated' }),
+        canVerify: true,
+      });
+
+      const wrapper = await mountComponent();
+
+      expect(wrapper.find('[data-testid="dns-widget"]').exists()).toBe(true);
+      expect(wrapper.find('[data-testid="verify-domain-details"]').exists()).toBe(false);
+    });
+
+    it('shows VerifyDomainDetails when domain unverified + non-approximated', async () => {
+      mockGetDomain.mockResolvedValue({
+        domain: createMockDomain({ vhost: { last_monitored_unix: 0 } }),
+        cluster: createMockCluster({ validation_strategy: 'manual' }),
+        canVerify: true,
+      });
+
+      const wrapper = await mountComponent();
+
+      expect(wrapper.find('[data-testid="dns-widget"]').exists()).toBe(false);
+      expect(wrapper.find('[data-testid="verify-domain-details"]').exists()).toBe(true);
+    });
+
+    it('shows DomainVerificationInfo when domain is verified', async () => {
+      mockGetDomain.mockResolvedValue({
+        domain: createMockDomain({ vhost: { last_monitored_unix: 1704067200 } }),
+        cluster: createMockCluster(),
+        canVerify: true,
+      });
+
+      const wrapper = await mountComponent();
+
+      expect(wrapper.find('[data-testid="domain-verification-info"]').exists()).toBe(true);
+      expect(wrapper.find('[data-testid="dns-widget"]').exists()).toBe(false);
+    });
+
+    it('shows loading message when domain is null', async () => {
+      mockGetDomain.mockResolvedValue(null);
+
+      const wrapper = await mountComponent();
+
+      expect(wrapper.text()).toContain('Loading domain information...');
+    });
+  });
+
+  describe('DNS target address computation', () => {
+    it('returns proxy_ip for apex domains', async () => {
+      mockGetDomain.mockResolvedValue({
+        domain: createMockDomain({ is_apex: true }),
+        cluster: createMockCluster({ proxy_ip: '10.0.0.1', proxy_host: 'proxy.test.com' }),
+        canVerify: true,
+      });
+
+      const wrapper = await mountComponent();
+
+      const dnsWidget = wrapper.findComponent({ name: 'DnsWidget' });
+      expect(dnsWidget.props('targetAddress')).toBe('10.0.0.1');
+    });
+
+    it('returns proxy_host for non-apex domains', async () => {
+      mockGetDomain.mockResolvedValue({
+        domain: createMockDomain({ is_apex: false }),
+        cluster: createMockCluster({ proxy_ip: '10.0.0.1', proxy_host: 'proxy.test.com' }),
+        canVerify: true,
+      });
+
+      const wrapper = await mountComponent();
+
+      const dnsWidget = wrapper.findComponent({ name: 'DnsWidget' });
+      expect(dnsWidget.props('targetAddress')).toBe('proxy.test.com');
+    });
+  });
+
+  describe('accessibility', () => {
+    it('button has aria-busy attribute during verification', async () => {
+      mockVerifyDomain.mockImplementation(() => new Promise(() => {}));
+
+      const wrapper = await mountComponent();
+
+      const button = wrapper.find('button[type="button"]');
+      expect(button.attributes('aria-busy')).toBe('true');
+    });
+
+    it('error alerts have aria-live attribute', async () => {
+      mockVerifyDomain.mockRejectedValue(new Error('Test error'));
+
+      const wrapper = await mountComponent();
+      await flushPromises();
+
+      const alerts = wrapper.find('[data-testid="basic-form-alerts"]');
+      // The parent div with aria-live is in the actual component
+      expect(alerts.exists()).toBe(true);
+    });
+  });
+});

--- a/src/tests/composables/useDomainsManager.spec.ts
+++ b/src/tests/composables/useDomainsManager.spec.ts
@@ -189,7 +189,8 @@ describe('useDomainsManager', () => {
         });
         expect(mockDependencies.notificationsStore.show).toHaveBeenCalledWith(
           'Domain added successfully',
-          'success'
+          'success',
+          'top'
         );
       });
 
@@ -294,7 +295,8 @@ describe('useDomainsManager', () => {
         expect(mockDependencies.domainsStore.deleteDomain).toHaveBeenCalledWith('domain-1');
         expect(mockDependencies.notificationsStore.show).toHaveBeenCalledWith(
           'Domain removed successfully',
-          'success'
+          'success',
+          'top'
         );
       });
 

--- a/src/tests/composables/useReceipt.spec.ts
+++ b/src/tests/composables/useReceipt.spec.ts
@@ -229,7 +229,7 @@ describe('useReceipt', () => {
       // Verify
       expect(store.fetch).toHaveBeenCalledWith('test-key');
       expect(isLoading.value).toBe(false);
-      expect(notifications.show).toHaveBeenCalledWith('web.COMMON.unexpected_error', 'error');
+      expect(notifications.show).toHaveBeenCalledWith('web.COMMON.unexpected_error', 'error', 'top');
       expect(error.value).toBeDefined();
       expect(error.value?.type).toBe('technical');
       expect(error.value?.severity).toBe('error');
@@ -267,7 +267,8 @@ describe('useReceipt', () => {
       });
       expect(notifications.show).toHaveBeenCalledWith(
         'Secret not found or has been burned',
-        'error'
+        'error',
+        'top'
       );
     });
   });
@@ -330,15 +331,12 @@ describe('useReceipt', () => {
 
       // Verify
       expect(store.burn).not.toHaveBeenCalled();
-      console.log(error.value);
-      console.log(error.value?.original);
-      debugger;
       expect(error.value).toMatchObject({
         message: 'Cannot burn this secret',
         type: 'human',
         severity: 'error',
       });
-      expect(notifications.show).toHaveBeenCalledWith('Cannot burn this secret', 'error');
+      expect(notifications.show).toHaveBeenCalledWith('Cannot burn this secret', 'error', 'top');
     });
   });
 

--- a/src/views/incoming/IncomingSuccessView.vue
+++ b/src/views/incoming/IncomingSuccessView.vue
@@ -25,13 +25,13 @@
     try {
       await navigator.clipboard.writeText(metadataKey.value);
       copied.value = true;
-      notifications.show('Reference ID copied to clipboard', 'success');
+      notifications.show('Reference ID copied to clipboard', 'success', 'top');
 
       setTimeout(() => {
         copied.value = false;
       }, 2000);
     } catch {
-      notifications.show('Failed to copy reference ID', 'error');
+      notifications.show('Failed to copy reference ID', 'error', 'top');
     }
   };
 </script>


### PR DESCRIPTION
### **User description**
## Summary
- Auto-trigger backend verification on page load when DNS widget is shown
- Trigger verification when DNS widget reports records verified (client-side)
- Add manual "Verify Domain" button for user-initiated retry
- Track verification state locally (avoids shared loading state issues from composable)
- Display errors inline; success notification via existing toast system

## Test plan
- [x] Navigate to domain verify page with approximated strategy → verification auto-triggers on load
- [x] Use DNS widget to configure records → when widget shows success, verification triggers again
- [x] Click "Verify Domain" button → manual verification works, shows loading spinner
- [x] Verify button disabled during verification, re-enables after
- [ ] Error displays inline if verification fails
- [ ] Domain status updates after each successful verification


___

### **PR Type**
Enhancement


___

### **Description**
- Auto-trigger backend verification on page load when DNS widget is shown

- Trigger verification when DNS widget reports records verified client-side

- Add manual "Verify Domain" button for user-initiated retry

- Track verification state locally with error display via BasicFormAlerts


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Page Load"] --> B["Fetch Domain"]
  B --> C{"Show DNS Widget?"}
  C -->|Yes| D["Auto-trigger Verification"]
  C -->|No| E["Display Info"]
  F["DNS Widget Success"] --> D
  G["Manual Button Click"] --> D
  D --> H["Call verifyDomain API"]
  H --> I{"Success?"}
  I -->|Yes| J["Refresh Domain Data"]
  I -->|No| K["Display Error Alert"]
  J --> L["Update UI"]
  K --> L
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DomainVerify.vue</strong><dd><code>Add backend verification trigger and manual button</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/apps/workspace/domains/DomainVerify.vue

<ul><li>Import <code>BasicFormAlerts</code> component for error display<br> <li> Add <code>verifyDomain</code> method from <code>useDomainsManager</code> composable<br> <li> Add <code>verificationInProgress</code> and <code>verificationError</code> reactive refs for <br>state tracking<br> <li> Implement <code>triggerVerification</code> function that calls backend API and <br>refreshes domain data<br> <li> Update <code>onMounted</code> hook to auto-trigger verification when DNS widget is <br>shown<br> <li> Update <code>handleDnsRecordsVerified</code> to call <code>triggerVerification</code> instead of <br>just refreshing<br> <li> Add manual "Verify Domain" button with loading spinner and disabled <br>state during verification<br> <li> Display inline error alerts using <code>BasicFormAlerts</code> component with <br><code>aria-live</code> attribute<br> <li> Add <code>aria-busy</code> attribute to button for accessibility</ul>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/2435/files#diff-6fd34fd303013c4c34bb39a5d5a3d340f7740f2d4b68213e40c20f818a397a34">+67/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

