### PR TITLE
Refactor email masking with Mail gem and improved TLD handling

### DIFF
--- a/lib/onetime/utils/strings.rb
+++ b/lib/onetime/utils/strings.rb
@@ -124,13 +124,13 @@ module Onetime
       # @param raw [String] Raw email address to mask
       # @return [String] Masked email address, or original if parsing fails
       def mask_email_address(raw)
-        addr = Mail::Address.new(raw)
+        addr = ::Mail::Address.new(raw)
         return raw unless addr.local && addr.domain
 
         local  = mask_string_head(addr.local, EMAIL_MASK_MIN_LOCAL)
         domain = mask_domain(addr.domain)
         "#{local}@#{domain}"
-      rescue Mail::Field::ParseError
+      rescue ::Mail::Field::ParseError
         raw
       end
 

--- a/lib/onetime/utils/strings.rb
+++ b/lib/onetime/utils/strings.rb
@@ -2,6 +2,8 @@
 #
 # frozen_string_literal: true
 
+require 'mail'
+
 module Onetime
   module Utils
     module Strings
@@ -60,33 +62,51 @@ module Onetime
         Array.new(len) { chars[SecureRandom.random_number(charset_size)] }.join
       end
 
+      # Configuration constants for email masking
+      EMAIL_MASK_MIN_LOCAL = 2    # chars to keep at start of local part
+      EMAIL_MASK_CHAR      = '*'  # masking character
+      EMAIL_MASK_LENGTH    = 3    # number of mask characters
+
+      # RFC 5321/5322-compliant email pattern for matching
+      # Supports: local-part@domain where local-part allows dots, plus, etc.
+      # This pattern is intentionally permissive to catch edge cases while
+      # Mail::Address handles validation during parsing.
+      EMAIL_PATTERN = /
+        \b
+        [A-Z0-9._%+'-]+   # local part: alphanumeric, dots, plus, etc.
+        @
+        [A-Z0-9.-]+       # domain: alphanumeric, dots, hyphens
+        \.
+        [A-Z]{2,}         # TLD: at least 2 letters
+        \b
+      /ix.freeze
+
       # Obscures email addresses by replacing most characters with asterisks
-      # while preserving the first few and last characters of both the local
-      # and domain parts for partial readability.
+      # while preserving a minimal prefix for partial readability. Uses the
+      # mail gem's Address parser for robust email handling.
       #
       # @param text [String] Text containing email addresses to obscure
-      # @return [String] Text with email addresses obscured in the format:
-      #   "ab*****c@d*****com" where visible characters are preserved from
-      #   the beginning and end of each part
+      # @return [String] Text with email addresses masked
       #
-      # @example
-      #   obscure_email("Contact tom@myspace.com for help")
-      #   # => "Contact to*****e@m******.com for help"
+      # @example Basic usage
+      #   obscure_email("Contact tom@myspace.com please")
+      #   # => "Contact to***@m***.com please"
       #
-      # @note The method uses a regex to identify email patterns and replaces
-      #   the middle portions with asterisks while keeping structural elements
-      #   visible for context.
+      # @example Short local part
+      #   obscure_email("a@example.org")
+      #   # => "a@e***.org"
+      #
+      # @example Subdomain handling
+      #   obscure_email("user@mail.example.co.uk")
+      #   # => "us***@m***.co.uk"
+      #
+      # @note Uses Mail::Address for parsing, avoiding hand-rolled parsing
+      #   edge cases while keeping the code short and auditable.
       def obscure_email(text)
-        email_pattern = /\b([A-Z0-9]{1,2})([A-Z0-9._%-]*)([A-Z0-9])?@([A-Z0-9])([A-Z0-9.-]+)(\.[A-Z]{2,4}\b)/i
+        return text if text.nil? || text.empty?
 
-        text.gsub(email_pattern) do |_match|
-          local_start  = ::Regexp.last_match(1)
-          _            = ::Regexp.last_match(2)
-          local_end    = ::Regexp.last_match(3)
-          domain_start = ::Regexp.last_match(4)
-          _            = ::Regexp.last_match(5)
-          domain_end   = ::Regexp.last_match(6)
-          "#{local_start}*****#{local_end}@#{domain_start}*****#{domain_end}"
+        text.gsub(EMAIL_PATTERN) do |raw|
+          mask_email_address(raw)
         end
       end
 
@@ -95,6 +115,64 @@ module Onetime
       # @return [Boolean] true if value one of the TRUTHY_VALUES (case-insensitive)
       def yes?(value)
         !value.to_s.empty? && TRUTHY_VALUES.include?(value.to_s.downcase)
+      end
+
+      private
+
+      # Masks a single email address string
+      # @param raw [String] Raw email address to mask
+      # @return [String] Masked email address, or original if parsing fails
+      def mask_email_address(raw)
+        addr = Mail::Address.new(raw)
+        return raw unless addr.local && addr.domain
+
+        local  = mask_string_head(addr.local, EMAIL_MASK_MIN_LOCAL)
+        domain = mask_domain(addr.domain)
+        "#{local}@#{domain}"
+      rescue Mail::Field::ParseError
+        raw
+      end
+
+      # Splits domain and masks the host portion, preserving TLD
+      # @param domain [String] Full domain (e.g., "mail.example.co.uk")
+      # @return [String] Masked domain (e.g., "m***.co.uk")
+      def mask_domain(domain)
+        parts = domain.split('.')
+        return domain if parts.size < 2
+
+        # Extract TLD - handle country-code TLDs like .co.uk, .com.au
+        # Strategy: take last part, then extend if it's a 2-letter ccTLD
+        tld_parts = [parts.pop]
+
+        # Extend for country-code TLDs (e.g., .co.uk, .com.au, .org.uk)
+        # Only extend if the current TLD is 2 chars (country code) and there's more
+        if tld_parts.first.length == 2 && parts.any? && parts.last.length <= 3
+          tld_parts.unshift(parts.pop)
+        end
+
+        # If we consumed everything, restore one part as host
+        if parts.empty? && tld_parts.size > 1
+          parts.push(tld_parts.shift)
+        end
+
+        host = parts.join('.')
+        tld  = tld_parts.join('.')
+
+        return tld if host.empty?
+
+        masked_host = mask_string_head(host, 1)
+        "#{masked_host}.#{tld}"
+      end
+
+      # Masks a string keeping only the first N characters visible
+      # @param str [String] String to mask
+      # @param keep_head [Integer] Number of leading characters to preserve
+      # @return [String] Masked string
+      def mask_string_head(str, keep_head)
+        return str if str.nil? || str.length <= keep_head
+
+        visible = str[0, keep_head]
+        "#{visible}#{EMAIL_MASK_CHAR * EMAIL_MASK_LENGTH}"
       end
     end
   end

--- a/lib/onetime/utils/strings.rb
+++ b/lib/onetime/utils/strings.rb
@@ -80,7 +80,7 @@ module Onetime
         \.
         [A-Z]{2,}         # TLD: at least 2 letters
         \b
-      /ix.freeze
+      /ix
 
       # Obscures email addresses by replacing most characters with asterisks
       # while preserving a minimal prefix for partial readability. Uses the

--- a/try/unit/logic/secrets/generate_secret_try.rb
+++ b/try/unit/logic/secrets/generate_secret_try.rb
@@ -57,7 +57,7 @@ logic = Logic::Secrets::ConcealSecret.new @strategy_result_with_cust, {'secret' 
   logic.recipient,
   logic.recipient_safe,
 ]
-#=> ['test secret value', 'testpass123', 7200, ['recipient@example.com'], ["re*****@e*****.com"]]
+#=> ['test secret value', 'testpass123', 7200, ['recipient@example.com'], ["re***@e***.com"]]
 
 # ShowSecret Tests
 

--- a/try/unit/utils/utils_try.rb
+++ b/try/unit/utils/utils_try.rb
@@ -39,25 +39,65 @@ Onetime::Utils.strand.size
 Onetime::Utils.strand(20).size
 #=> 20
 
-## Obscure email address (6 or more chars)
+## Obscure email address (standard email)
 Onetime::Utils.obscure_email('tryouts@onetimesecret.com')
-#=> 'tr*****@o*****.com'
+#=> 'tr***@o***.com'
 
-## Obscure email address (4 or more chars)
+## Obscure email address (4 chars local)
 Onetime::Utils.obscure_email('dave@onetimesecret.com')
-#=> 'da*****@o*****.com'
+#=> 'da***@o***.com'
 
-## Obscure email address (less than 4 chars)
+## Obscure email address (2 chars local - at MIN_LOCAL threshold)
 Onetime::Utils.obscure_email('dm@onetimesecret.com')
-#=> 'dm*****@o*****.com'
+#=> 'dm@o***.com'
 
-## Obscure email address (single char)
+## Obscure email address (single char local - below MIN_LOCAL)
 Onetime::Utils.obscure_email('r@onetimesecret.com')
-#=> 'r*****@o*****.com'
+#=> 'r@o***.com'
 
-## Obscure email address (Long)
+## Obscure email address (long local and domain)
 Onetime::Utils.obscure_email('readyreadyreadyready@onetimesecretonetimesecretonetimesecret.com')
-#=> 're*****@o*****.com'
+#=> 're***@o***.com'
+
+## Obscure email in sentence context
+Onetime::Utils.obscure_email('Contact tom@myspace.com please')
+#=> 'Contact to***@m***.com please'
+
+## Obscure email with country-code TLD (.co.uk)
+Onetime::Utils.obscure_email('user@example.co.uk')
+#=> 'us***@e***.co.uk'
+
+## Obscure email with subdomain
+Onetime::Utils.obscure_email('admin@mail.example.org')
+#=> 'ad***@m***.org'
+
+## Obscure multiple emails in text
+Onetime::Utils.obscure_email('From: alice@foo.com To: bob@bar.org')
+#=> 'From: al***@f***.com To: bo***@b***.org'
+
+## Obscure email with plus addressing
+Onetime::Utils.obscure_email('user+tag@example.com')
+#=> 'us***@e***.com'
+
+## Obscure email with dots in local part
+Onetime::Utils.obscure_email('first.last@example.com')
+#=> 'fi***@e***.com'
+
+## Handle nil input gracefully
+Onetime::Utils.obscure_email(nil)
+#=> nil
+
+## Handle empty string gracefully
+Onetime::Utils.obscure_email('')
+#=> ''
+
+## Handle text without email addresses
+Onetime::Utils.obscure_email('No email here')
+#=> 'No email here'
+
+## Handle complex TLD (.com.au)
+Onetime::Utils.obscure_email('user@domain.com.au')
+#=> 'us***@d***.com.au'
 
 ## random_fortune returns a string
 ## Create a mock fortunes collection


### PR DESCRIPTION
### **User description**
## Summary

Refactors the `obscure_email` method to use the `mail` gem for robust email parsing and introduces improved handling for country-code TLDs (e.g., `.co.uk`, `.com.au`). The new implementation is more maintainable, auditable, and handles edge cases better while reducing the masking from 5 asterisks to 3 for improved readability.

## Changes

- **Added `mail` gem dependency** for RFC 5321/5322-compliant email parsing
- **Simplified email masking logic** by extracting helper methods:
  - `mask_email_address`: Parses and masks individual email addresses
  - `mask_domain`: Intelligently handles domain masking with TLD preservation
  - `mask_string_head`: Generic string masking utility
- **Improved TLD detection** with support for multi-part TLDs (`.co.uk`, `.com.au`, `.org.uk`)
- **Reduced mask length** from 5 to 3 asterisks for better readability while maintaining obfuscation
- **Enhanced robustness** with graceful fallback to original text on parse errors
- **Added nil/empty input handling** to prevent errors on edge cases
- **Updated documentation** with clearer examples and rationale

## Test Plan

- All existing test cases updated to reflect new 3-asterisk masking format
- Added comprehensive test cases covering:
  - Standard emails
  - Short local parts (1-2 characters)
  - Long local and domain parts
  - Country-code TLDs (`.co.uk`, `.com.au`)
  - Subdomains
  - Plus addressing (`user+tag@example.com`)
  - Dots in local part (`first.last@example.com`)
  - Multiple emails in text
  - Nil and empty string inputs
  - Text without email addresses

All test cases in `try/unit/utils/utils_try.rb` pass with expected outputs.

https://claude.ai/code/session_01Cztb62JSezi63SjMXtgxJW


___

### **PR Type**
Enhancement


___

### **Description**
- Refactored email masking to use Mail gem for RFC-compliant parsing

- Improved TLD handling for country-code domains (.co.uk, .com.au)

- Reduced mask length from 5 to 3 asterisks for readability

- Added helper methods for modular, maintainable email masking logic

- Enhanced robustness with nil/empty input handling and graceful error fallback

- Expanded test coverage for edge cases and complex email formats


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Email Text Input"] --> B["EMAIL_PATTERN Regex Match"]
  B --> C["mask_email_address"]
  C --> D["Mail::Address Parser"]
  D --> E["mask_string_head<br/>Local Part"]
  D --> F["mask_domain<br/>Domain Part"]
  E --> G["Masked Email<br/>local***@domain"]
  F --> G
  G --> H["Output Text<br/>with Masked Emails"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>strings.rb</strong><dd><code>Implement Mail gem-based email masking with TLD support</code>&nbsp; &nbsp; </dd></summary>
<hr>

lib/onetime/utils/strings.rb

<ul><li>Added <code>mail</code> gem dependency for RFC 5321/5322-compliant email parsing<br> <li> Introduced configuration constants for mask length (3 asterisks) and <br>visible characters (2 minimum)<br> <li> Replaced hand-rolled regex with improved <code>EMAIL_PATTERN</code> supporting <br>dots, plus addressing, and hyphens<br> <li> Refactored <code>obscure_email</code> method to use new helper methods and handle <br>nil/empty inputs<br> <li> Added three private helper methods: <code>mask_email_address</code>, <code>mask_domain</code>, <br>and <code>mask_string_head</code><br> <li> Implemented intelligent TLD detection supporting multi-part <br>country-code TLDs (.co.uk, .com.au, .org.uk)</ul>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/2469/files#diff-dc6717ddeca3b9ca55ac589c2993a0c1ae6ae8da3d4dd8dc3fd7c921736e4264">+99/-21</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>utils_try.rb</strong><dd><code>Update email masking tests with new format and edge cases</code></dd></summary>
<hr>

try/unit/utils/utils_try.rb

<ul><li>Updated all existing email masking test cases to reflect new <br>3-asterisk format (from 5 asterisks)<br> <li> Added comprehensive test cases for edge cases: short local parts (1-2 <br>chars), long addresses, country-code TLDs<br> <li> Added tests for advanced email formats: plus addressing, dots in local <br>part, subdomains<br> <li> Added tests for nil and empty string inputs to verify graceful <br>handling<br> <li> Added test for text without email addresses to ensure non-email text <br>passes through unchanged<br> <li> Added test for complex multi-part TLD (.com.au) handling</ul>


</details>


  </td>
  <td><a href="https://github.com/onetimesecret/onetimesecret/pull/2469/files#diff-a5c83694cfe1d5953c7cb781a33e7a0913213ec7a4dfa9a6117f1a2f1bd3e6c9">+50/-10</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

