### PR TITLE
Add bin wrappers for frontend, scheduler, and Stripe webhooks

### DIFF
--- a/Procfile.dev.example
+++ b/Procfile.dev.example
@@ -1,8 +1,10 @@
 # Procfile.dev
 
 # Use the port if set otherwise default to 3000
-backend: bundle exec bin/server -p ${PORT:-3000} etc/examples/puma.example.rb
+backend: bin/backend -p ${PORT:-3000} etc/examples/puma.example.rb
 
-frontend: pnpm run dev
+frontend: bin/frontend
 
-worker: bundle exec bin/worker
+worker: bin/worker
+
+scheduler: bin/scheduler

--- a/bin/backend
+++ b/bin/backend
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# bin/server
+# bin/backend
 
 # Ensure ONETIME_DEBUG is exported so it's available to the
 # bundle process and the subsequent ruby process.

--- a/bin/frontend
+++ b/bin/frontend
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+#
+# bin/frontend
+
+if [ -f .env.sh ]; then
+  source .env.sh
+fi
+
+pnpm run dev "$@"

--- a/bin/frontend
+++ b/bin/frontend
@@ -2,6 +2,8 @@
 #
 # bin/frontend
 
+set -euo pipefail
+
 if [ -f .env.sh ]; then
   source .env.sh
 fi

--- a/bin/scheduler
+++ b/bin/scheduler
@@ -2,6 +2,8 @@
 #
 # bin/scheduler
 
+set -euo pipefail
+
 if [ -f .env.sh ]; then
   source .env.sh
 fi

--- a/bin/scheduler
+++ b/bin/scheduler
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+#
+# bin/scheduler
+
+if [ -f .env.sh ]; then
+  source .env.sh
+fi
+
+bundle exec bin/ots scheduler "$@"

--- a/bin/stripe-dev-webhook
+++ b/bin/stripe-dev-webhook
@@ -15,18 +15,19 @@
 #   2. Parsed from etc/config.yaml site.host (if readable)
 #   3. Default: localhost:3000
 
-set -e
+set -euo pipefail
 
 if [ -f .env.sh ]; then
   source .env.sh
 fi
 
 # Resolve the host
-if [ -n "$HOST" ]; then
+if [ -n "${HOST:-}" ]; then
   WEBHOOK_HOST="$HOST"
 elif [ -f etc/config.yaml ]; then
   # Extract site.host from config (handles simple YAML, not ERB)
-  WEBHOOK_HOST=$(grep -A1 '^site:' etc/config.yaml | grep 'host:' | sed 's/.*host:[[:space:]]*//' | tr -d "'" | tr -d '"')
+  # Uses awk to find host: within the site: block, robust to comments/spacing
+  WEBHOOK_HOST=$(awk '/^site:/,/^[^ ]/ { if (/^[[:space:]]+host:/) { sub(/.*host:[[:space:]]*/, ""); gsub(/['\''"]/, ""); print; exit } }' etc/config.yaml)
 fi
 
 # Fall back to default

--- a/bin/stripe-dev-webhook
+++ b/bin/stripe-dev-webhook
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+#
+# bin/stripe-dev-webhook
+#
+# Forwards Stripe webhook events to your local development server.
+# Requires: stripe CLI (brew install stripe/stripe-cli/stripe)
+#
+# Usage examples:
+#   HOST=dev.onetime.dev bin/stripe-dev-webhook
+#   bin/stripe-dev-webhook                           # uses config or localhost:3000
+#   bin/stripe-dev-webhook --events payment_intent.* # filter events
+#
+# Host resolution order:
+#   1. HOST environment variable
+#   2. Parsed from etc/config.yaml site.host (if readable)
+#   3. Default: localhost:3000
+
+set -e
+
+if [ -f .env.sh ]; then
+  source .env.sh
+fi
+
+# Resolve the host
+if [ -n "$HOST" ]; then
+  WEBHOOK_HOST="$HOST"
+elif [ -f etc/config.yaml ]; then
+  # Extract site.host from config (handles simple YAML, not ERB)
+  WEBHOOK_HOST=$(grep -A1 '^site:' etc/config.yaml | grep 'host:' | sed 's/.*host:[[:space:]]*//' | tr -d "'" | tr -d '"')
+fi
+
+# Fall back to default
+WEBHOOK_HOST="${WEBHOOK_HOST:-localhost:3000}"
+
+# Determine protocol (assume https unless localhost)
+if [[ "$WEBHOOK_HOST" == localhost* ]] || [[ "$WEBHOOK_HOST" == 127.0.0.1* ]]; then
+  WEBHOOK_URL="http://${WEBHOOK_HOST}/billing/webhook"
+else
+  WEBHOOK_URL="https://${WEBHOOK_HOST}/billing/webhook"
+fi
+
+echo "Forwarding Stripe webhooks to: $WEBHOOK_URL"
+exec stripe listen --forward-to "$WEBHOOK_URL" "$@"


### PR DESCRIPTION
## Summary

Standardizes development scripts by adding thin wrappers that handle environment setup consistently. Each wrapper sources `.env.sh` before delegating to the underlying command, eliminating the need for `bundle exec` prefixes in the Procfile.

**New scripts:**
- `bin/frontend` — wraps `pnpm run dev`
- `bin/scheduler` — wraps `bin/ots scheduler`
- `bin/stripe-dev-webhook` — forwards Stripe events with auto-host detection from `$HOST`, config, or localhost default

**Updates:**
- `Procfile.dev.example` now uses the wrappers and includes the scheduler process
- `bin/backend` comment header fixed (was still referencing `bin/server`)

## Test plan

- [x] `bin/frontend` starts Vite dev server
- [x] `bin/scheduler` starts rufus scheduler
- [x] `bin/stripe-dev-webhook` connects to Stripe CLI and shows correct webhook URL
- [ ] `HOST=example.com bin/stripe-dev-webhook` uses custom host with https