### PR TITLE
Fix CSRF token generation against detached session on anonymous routes

### DIFF
--- a/src/apps/session/components/SignInForm.vue
+++ b/src/apps/session/components/SignInForm.vue
@@ -43,7 +43,14 @@ const handleSubmit = async () => {
   isSubmitting.value = true;
   try {
     clearErrors();
-    await bootstrapStore.refresh();
+    // Best-effort token refresh: proceed with the existing CSRF token on failure.
+    // Plain try/catch (not useAsyncHandler) because this is intentionally non-fatal —
+    // Sentry reports and user notifications would fire for a non-event.
+    try {
+      await bootstrapStore.refresh();
+    } catch (refreshError) {
+      console.warn('[SignInForm] Bootstrap refresh failed, proceeding with current token:', refreshError);
+    }
     await login(email.value, password.value, rememberMe.value);
     // Navigation handled by useAuth composable
   } finally {

--- a/src/apps/session/components/SignInForm.vue
+++ b/src/apps/session/components/SignInForm.vue
@@ -36,11 +36,19 @@ const togglePasswordVisibility = () => {
   showPassword.value = !showPassword.value;
 };
 
+const isSubmitting = ref(false);
+
 const handleSubmit = async () => {
-  clearErrors();
-  await bootstrapStore.refresh();
-  await login(email.value, password.value, rememberMe.value);
-  // Navigation handled by useAuth composable
+  if (isSubmitting.value) return;
+  isSubmitting.value = true;
+  try {
+    clearErrors();
+    await bootstrapStore.refresh();
+    await login(email.value, password.value, rememberMe.value);
+    // Navigation handled by useAuth composable
+  } finally {
+    isSubmitting.value = false;
+  }
 };
 </script>
 
@@ -78,7 +86,7 @@ const handleSubmit = async () => {
           type="email"
           autocomplete="email"
           required
-          :disabled="isLoading"
+          :disabled="isSubmitting || isLoading"
           :aria-invalid="error && !lockoutStatus ? 'true' : undefined"
           :aria-describedby="error && !lockoutStatus ? 'signin-error' : undefined"
           class="block w-full appearance-none rounded-md
@@ -108,7 +116,7 @@ const handleSubmit = async () => {
             name="password"
             autocomplete="current-password"
             required
-            :disabled="isLoading"
+            :disabled="isSubmitting || isLoading"
             :aria-invalid="error && !lockoutStatus ? 'true' : undefined"
             :aria-describedby="error && !lockoutStatus ? 'signin-error' : undefined"
             class="block w-full appearance-none rounded-md
@@ -125,7 +133,7 @@ const handleSubmit = async () => {
           <button
             type="button"
             @click="togglePasswordVisibility"
-            :disabled="isLoading"
+            :disabled="isSubmitting || isLoading"
             :aria-label="showPassword ? t('web.COMMON.hide_password') : t('web.COMMON.show_password')"
             class="absolute inset-y-0 right-0 z-10 flex items-center pr-3 text-sm leading-5 disabled:opacity-50">
             <OIcon
@@ -146,7 +154,7 @@ const handleSubmit = async () => {
           id="remember-me"
           name="remember-me"
           type="checkbox"
-          :disabled="isLoading"
+          :disabled="isSubmitting || isLoading"
           aria-describedby="remember-me-description"
           class="size-4 rounded border-gray-300
                       text-brand-600
@@ -177,7 +185,7 @@ const handleSubmit = async () => {
     <div class="mt-5">
       <button
         type="submit"
-        :disabled="isLoading"
+        :disabled="isSubmitting || isLoading"
         class="group relative flex w-full justify-center
                      rounded-md
                      border border-transparent
@@ -187,12 +195,12 @@ const handleSubmit = async () => {
                      focus:outline-none focus:ring-2 focus:ring-brand-500 focus:ring-offset-2
                      disabled:cursor-not-allowed disabled:opacity-50
                      dark:bg-brand-600 dark:hover:bg-brand-700 dark:focus:ring-offset-gray-800">
-        <span v-if="isLoading">{{ t('web.COMMON.processing') || 'Processing...' }}</span>
+        <span v-if="isSubmitting || isLoading">{{ t('web.COMMON.processing') || 'Processing...' }}</span>
         <span v-else>{{ t('web.login.button_sign_in') }}</span>
       </button>
       <!-- Loading state announcement (screen reader only) -->
       <div
-        v-if="isLoading"
+        v-if="isSubmitting || isLoading"
         aria-live="polite"
         aria-atomic="true"
         class="sr-only">

--- a/src/apps/session/components/SignInForm.vue
+++ b/src/apps/session/components/SignInForm.vue
@@ -5,6 +5,7 @@
 import LockoutAlert from '@/apps/session/components/LockoutAlert.vue';
 import OIcon from '@/shared/components/icons/OIcon.vue';
 import { useAuth } from '@/shared/composables/useAuth';
+import { useBootstrapStore } from '@/shared/stores/bootstrapStore';
 import { ref } from 'vue';
 import { useRoute } from 'vue-router';
 
@@ -21,6 +22,7 @@ withDefaults(defineProps<Props>(), {
   locale: 'en',
 })
 
+const bootstrapStore = useBootstrapStore();
 const { login, isLoading, error, lockoutStatus, clearErrors } = useAuth();
 
 // Prefill email from query param (e.g., from invitation flow)
@@ -36,6 +38,7 @@ const togglePasswordVisibility = () => {
 
 const handleSubmit = async () => {
   clearErrors();
+  await bootstrapStore.refresh();
   await login(email.value, password.value, rememberMe.value);
   // Navigation handled by useAuth composable
 };

--- a/src/apps/session/components/SignUpForm.vue
+++ b/src/apps/session/components/SignUpForm.vue
@@ -37,11 +37,19 @@ const togglePasswordVisibility = () => {
   showPassword.value = !showPassword.value;
 };
 
+const isSubmitting = ref(false);
+
 const handleSubmit = async () => {
-  clearErrors();
-  await bootstrapStore.refresh();
-  await signup(email.value, password.value, termsAgreed.value);
-  // Navigation handled by useAuth composable
+  if (isSubmitting.value) return;
+  isSubmitting.value = true;
+  try {
+    clearErrors();
+    await bootstrapStore.refresh();
+    await signup(email.value, password.value, termsAgreed.value);
+    // Navigation handled by useAuth composable
+  } finally {
+    isSubmitting.value = false;
+  }
 };
 </script>
 
@@ -120,7 +128,7 @@ const handleSubmit = async () => {
           type="email"
           autocomplete="email"
           required
-          :disabled="isLoading"
+          :disabled="isSubmitting || isLoading"
           focus
           tabindex="0"
           :aria-invalid="fieldError && fieldError[0] === 'login' ? 'true' : undefined"
@@ -152,7 +160,7 @@ const handleSubmit = async () => {
             name="password"
             autocomplete="new-password"
             required
-            :disabled="isLoading"
+            :disabled="isSubmitting || isLoading"
             tabindex="0"
             :aria-invalid="fieldError && fieldError[0] === 'password' ? 'true' : undefined"
             :aria-describedby="fieldError && fieldError[0] === 'password' ? 'password-error' : 'password-requirements'"
@@ -170,7 +178,7 @@ const handleSubmit = async () => {
           <button
             type="button"
             @click="togglePasswordVisibility"
-            :disabled="isLoading"
+            :disabled="isSubmitting || isLoading"
             :aria-label="showPassword ? t('web.COMMON.hide_password') : t('web.COMMON.show_password')"
             class="absolute inset-y-0 right-0 z-10 flex items-center pr-3 text-sm leading-5 disabled:opacity-50">
             <OIcon
@@ -196,7 +204,7 @@ const handleSubmit = async () => {
           name="agree"
           type="checkbox"
           required
-          :disabled="isLoading"
+          :disabled="isSubmitting || isLoading"
           tabindex="0"
           class="size-4 rounded border-gray-300
                       text-brand-600
@@ -230,7 +238,7 @@ const handleSubmit = async () => {
     <div class="mt-5">
       <button
         type="submit"
-        :disabled="isLoading"
+        :disabled="isSubmitting || isLoading"
         class="group relative flex w-full justify-center
                      rounded-md
                      border border-transparent
@@ -240,12 +248,12 @@ const handleSubmit = async () => {
                      focus:outline-none focus:ring-2 focus:ring-brand-500 focus:ring-offset-2
                      disabled:cursor-not-allowed disabled:opacity-50
                      dark:bg-brand-600 dark:hover:bg-brand-700 dark:focus:ring-offset-gray-800">
-        <span v-if="isLoading">{{ t('web.COMMON.processing') || 'Processing...' }}</span>
+        <span v-if="isSubmitting || isLoading">{{ t('web.COMMON.processing') || 'Processing...' }}</span>
         <span v-else>{{ t('web.COMMON.button_create_account') }}</span>
       </button>
       <!-- Loading state announcement (screen reader only) -->
       <div
-        v-if="isLoading"
+        v-if="isSubmitting || isLoading"
         aria-live="polite"
         aria-atomic="true"
         class="sr-only">

--- a/src/apps/session/components/SignUpForm.vue
+++ b/src/apps/session/components/SignUpForm.vue
@@ -44,7 +44,14 @@ const handleSubmit = async () => {
   isSubmitting.value = true;
   try {
     clearErrors();
-    await bootstrapStore.refresh();
+    // Best-effort token refresh: proceed with the existing CSRF token on failure.
+    // Plain try/catch (not useAsyncHandler) because this is intentionally non-fatal —
+    // Sentry reports and user notifications would fire for a non-event.
+    try {
+      await bootstrapStore.refresh();
+    } catch (refreshError) {
+      console.warn('[SignUpForm] Bootstrap refresh failed, proceeding with current token:', refreshError);
+    }
     await signup(email.value, password.value, termsAgreed.value);
     // Navigation handled by useAuth composable
   } finally {

--- a/src/apps/session/components/SignUpForm.vue
+++ b/src/apps/session/components/SignUpForm.vue
@@ -4,6 +4,7 @@
   import { useI18n } from 'vue-i18n';
 import OIcon from '@/shared/components/icons/OIcon.vue';
 import { useAuth } from '@/shared/composables/useAuth';
+import { useBootstrapStore } from '@/shared/stores/bootstrapStore';
 import { Jurisdiction } from '@/schemas/models';
 import { ref } from 'vue';
 import { useRoute } from 'vue-router';
@@ -20,6 +21,7 @@ withDefaults(defineProps<Props>(), {
 })
 
 const route = useRoute();
+const bootstrapStore = useBootstrapStore();
 const { signup, isLoading, error, fieldError, clearErrors } = useAuth();
 
 const { t } = useI18n();
@@ -37,6 +39,7 @@ const togglePasswordVisibility = () => {
 
 const handleSubmit = async () => {
   clearErrors();
+  await bootstrapStore.refresh();
   await signup(email.value, password.value, termsAgreed.value);
   // Navigation handled by useAuth composable
 };

--- a/src/shared/stores/csrfStore.ts
+++ b/src/shared/stores/csrfStore.ts
@@ -93,6 +93,13 @@ export const useCsrfStore = defineStore('csrf', () => {
     }
   });
 
+  // Sync CSRF token when bootstrap refreshes (e.g., native fetch bypasses axios)
+  watch(bootstrapShrimp, (newShrimp) => {
+    if (newShrimp && _initialized.value) {
+      shrimp.value = newShrimp;
+    }
+  });
+
   function updateShrimp(newShrimp: string) {
     shrimp.value = newShrimp;
   }


### PR DESCRIPTION
## Summary

Fixes #2501 — CSRF tokens on anonymous routes (signup, login, verify) were generated against a throwaway `{}` hash from `NoAuthStrategy` instead of `env['rack.session']`. The token never reached Redis, so every POST on these routes got a 403 from `Rack::Protection::AuthenticityToken`.

The core fix is a one-variable swap in `InitializeViewVars`: use `req.env['rack.session']` for CSRF generation instead of the strategy-resolved `sess`. Supporting changes harden the token flow end-to-end.

**What changed:**
- `InitializeViewVars` generates CSRF tokens from `rack.session` instead of the detached strategy session
- `CsrfResponseHeader` returns per-request masked tokens instead of raw `session[:csrf]` (BREACH mitigation)
- `csrfStore` watches `bootstrapStore.shrimp` reactively so native-fetch refreshes propagate
- `SignUpForm` and `SignInForm` call `bootstrapStore.refresh()` before submit (matching existing `VerifyAccount.vue` pattern)

**6 files, 141 additions, 18 deletions. No breaking changes.**

## Test plan

- [x] 5 new Vitest tests for csrfStore watcher behavior (init gate, empty value guard, consecutive updates, reset/re-init cycle)
- [x] Existing test suite passes (2130 pass, 12 pre-existing i18n flakes)
- [x] Type-check clean, ESLint clean, RuboCop clean
- [ ] Manual: Submit signup form on fresh anonymous session — should succeed (was 403)
- [ ] Manual: Click email verification link — should succeed (was 403)
- [ ] Manual: Submit login form on anonymous session — should succeed
- [ ] Manual: Verify authenticated routes still work (dashboard, account, etc.)
- [ ] Manual: Inspect `X-CSRF-Token` response header — value should differ between requests