### PR TITLE
Fix CI test failures: API service field and YAML color quoting

### DIFF
--- a/apps/web/auth/docs/console-debugging.md
+++ b/apps/web/auth/docs/console-debugging.md
@@ -1,0 +1,47 @@
+# Auth DB: Console Debugging
+
+Connection is lazy — no DB call until first query. See `Auth::Database::LazyConnection` in `database.rb`.
+
+## Config
+
+```ruby
+Onetime.auth_config.full_enabled?   # false means DB is never connected
+Onetime.auth_config.database_url
+Onetime.auth_config.mode
+```
+
+## Connect and test
+
+```ruby
+db = Auth::Database.connection   # nil in simple mode
+Auth::Database.connected?        # has the lazy proxy connected yet?
+
+db.__connect__!                  # force TCP/socket connection (errors surface here)
+db.test_connection
+db[:accounts].count
+```
+
+## Inspect
+
+```ruby
+db.adapter_scheme   #=> :sqlite or :postgres
+db.opts             #=> connection hash
+db.tables
+db.views
+db.schema(:accounts)
+db.loggers          # SQL logging is :trace by default
+```
+
+## Multi-host PostgreSQL
+
+```ruby
+Auth::Database.parse_postgres_multihost_url(Onetime.auth_config.database_url)
+```
+
+## Reset
+
+```ruby
+Auth::Database.reset_connection!
+db = Auth::Database.connection
+db.__connect__!
+```

--- a/etc/defaults/config.defaults.yaml
+++ b/etc/defaults/config.defaults.yaml
@@ -312,7 +312,7 @@ site:
       enabled: <%= ENV['CSP_ENABLED'] == 'true' || false %>
 
 brand:
-  primary_color: <%= ENV['BRAND_PRIMARY_COLOR'] || nil %>
+  primary_color: <%= ENV['BRAND_PRIMARY_COLOR'] ? %Q("#{ENV['BRAND_PRIMARY_COLOR']}") : nil %>
   product_name: <%= ENV['BRAND_PRODUCT_NAME'] || nil %>
   product_domain: <%= ENV['BRAND_PRODUCT_DOMAIN'] || nil %>
   support_email: <%= ENV['BRAND_SUPPORT_EMAIL'] || nil %>

--- a/lib/onetime/jobs/console-debugging.md
+++ b/lib/onetime/jobs/console-debugging.md
@@ -1,0 +1,103 @@
+# RabbitMQ: Console Debugging
+
+Globals set by `SetupRabbitMQ` initializer (runs only when `jobs.enabled` is truthy):
+- `$rmq_conn` — `Bunny::Session`
+- `$rmq_channel_pool` — `ConnectionPool` of `Bunny::Channel`
+
+## Config
+
+```ruby
+OT.conf.dig('jobs', 'enabled')
+OT.conf.dig('jobs', 'rabbitmq_url')
+OT.conf.dig('jobs', 'channel_pool_size')
+```
+
+## Connection state
+
+```ruby
+$rmq_conn&.open?
+Onetime::Runtime.infrastructure.rabbitmq_configured?
+```
+
+## Manual connectivity test
+
+```ruby
+conn = Bunny.new(OT.conf.dig('jobs', 'rabbitmq_url'))
+conn.start
+conn.open?
+conn.close
+```
+
+## Inspect queues
+
+```ruby
+# Single queue
+$rmq_channel_pool.with do |ch|
+  q = ch.queue('email.message.send', passive: true)
+  q.message_count
+  q.consumer_count
+end
+
+# All queues — Bunny::NotFound closes the channel, so recreate it
+$rmq_channel_pool.with do |ch|
+  Onetime::Jobs::QueueConfig::QUEUES.each_key do |name|
+    q = ch.queue(name, passive: true)
+    puts "#{name}: #{q.message_count} msgs, #{q.consumer_count} consumers"
+  rescue Bunny::NotFound
+    puts "#{name}: NOT DECLARED"
+    ch = $rmq_conn.create_channel
+  end
+end
+```
+
+## Dead letter queues
+
+```ruby
+$rmq_channel_pool.with do |ch|
+  Onetime::Jobs::QueueConfig::DEAD_LETTER_CONFIG.each_value do |cfg|
+    q = ch.queue(cfg[:queue], passive: true)
+    puts "#{cfg[:queue]}: #{q.message_count} msgs"
+  rescue Bunny::NotFound
+    puts "#{cfg[:queue]}: NOT DECLARED"
+    ch = $rmq_conn.create_channel
+  end
+end
+```
+
+## Publish test message
+
+```ruby
+require 'onetime/jobs/publisher'
+Onetime::Jobs::Publisher.enqueue_email(:ping_test, { test: true })
+```
+
+## Re-declare topology
+
+```ruby
+$rmq_channel_pool.with { |ch| Onetime::Jobs::QueueDeclarator.declare_all(ch) }
+```
+
+## Reset connection
+
+```ruby
+$rmq_conn&.close
+$rmq_conn = nil
+$rmq_channel_pool = nil
+
+conn = Bunny.new(OT.conf.dig('jobs', 'rabbitmq_url'), heartbeat: 60)
+conn.start
+$rmq_conn = conn
+$rmq_channel_pool = ConnectionPool.new(size: 5, timeout: 5) { $rmq_conn.create_channel }
+```
+
+## CLI equivalents
+
+```
+bin/ots queue status                    # connection, exchanges, depths, scheduler
+bin/ots queue status -w 5               # watch mode
+bin/ots queue ping                      # test messages to all queues
+bin/ots queue ping -q email             # ping one queue
+bin/ots queue dlq list                  # DLQ message counts
+bin/ots queue dlq list billing.event    # specific DLQ
+bin/ots queue dlq replay billing.event  # replay back to origin
+```

--- a/try/system/routes_smoketest_try.rb
+++ b/try/system/routes_smoketest_try.rb
@@ -71,8 +71,9 @@ response = @mock_request.get('/api/v2/status')
 
 ## v2 API does not have an authcheck endpoint
 response = @mock_request.get('/api/v2/authcheck')
-[response.status, response.body]
-#=> [404, '{"error":"Not Found"}']
+content = Familia::JsonSerializer.parse(response.body)
+[response.status, content.key?('error'), content['error']]
+#=> [404, true, 'Not Found']
 
 ## Can access the API share endpoint
 # NOTE: Disabled pending Otto v2 migration for v1 API (#2128)
@@ -111,8 +112,8 @@ content = Familia::JsonSerializer.parse(response.body)
 response = @mock_request.post('/api/v2/humphrey/bogus', @api_auth)
 content = Familia::JsonSerializer.parse(response.body)
 has_msg = content.slice('error').eql?({'error' => 'Not Found'})
-[response.status, has_msg, content.keys.sort]
-#=> [404, true, ['error']]
+[response.status, has_msg, content.key?('error')]
+#=> [404, true, true]
 
 # API v2 Routes
 


### PR DESCRIPTION
## Summary

Fixes the 3 failing tests in the Ruby unit test CI job for PR #2491.

**Routes smoketest (2 failures):** The `267df86f` commit added a `service` key to API error responses but the test expectations still matched exact JSON body strings. Updated to assert error semantics (key presence + value) rather than exact shape, so the tests don't break if more fields are added later.

**Brand defaults (1 failure):** The ERB template `primary_color: <%= ENV['BRAND_PRIMARY_COLOR'] || nil %>` renders hex colors like `#00FF00` unquoted — YAML treats `#` as a comment delimiter, so the value silently becomes `nil`. Fixed by wrapping the ERB output in double quotes when the env var is set.

## Test plan
- [ ] CI Ruby unit tests pass (routes_smoketest_try.rb L75, L115)
- [ ] CI Ruby unit tests pass (brand_defaults_try.rb L71)
- [ ] `BRAND_PRIMARY_COLOR` env var works in config template
- [ ] Unset `BRAND_PRIMARY_COLOR` still produces `nil` (no empty string)