### PR TITLE
Clean up dashboard UX: remove stay-on-page toggle, gate dismiss button on auth

### DIFF
--- a/src/apps/secret/components/RecentSecretsTable.vue
+++ b/src/apps/secret/components/RecentSecretsTable.vue
@@ -154,7 +154,7 @@
           {{ t('web.LABELS.items_count', { count: records.length }) }}
         </span>
         <button
-          v-if="hasRecords"
+          v-if="hasRecords && !isAuthenticated"
           @click="dismissAllRecents"
           class="rounded p-1.5 text-gray-500 hover:bg-gray-100 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
           :aria-label="t('web.LABELS.dismiss')"

--- a/src/apps/workspace/components/forms/WorkspaceSecretForm.vue
+++ b/src/apps/workspace/components/forms/WorkspaceSecretForm.vue
@@ -402,34 +402,8 @@
                 </div>
               </div>
 
-              <!-- Submit Area with Stay on Page toggle (always right-aligned) -->
+              <!-- Submit Area (always right-aligned) -->
               <div class="ml-auto flex items-center gap-2.5">
-                <!-- Stay on Page Toggle (refined, compact) -->
-                <!-- Disabled when generating password since user must see the receipt to view the generated password -->
-                <button
-                  type="button"
-                  :disabled="isSubmitting || selectedAction === 'generate-password'"
-                  @click="localReceiptStore.toggleWorkspaceMode()"
-                  :title="selectedAction === 'generate-password'
-                    ? t('web.secrets.workspace_mode_disabled_for_generate')
-                    : t('web.secrets.workspace_mode_description')"
-                  class="inline-flex items-center gap-1 rounded px-2 py-1.5 text-xs
-                    font-medium ring-1 ring-inset transition-all
-                    focus:outline-none focus:ring-2 focus:ring-brand-500/50
-                    disabled:opacity-50 disabled:cursor-not-allowed"
-                  :class="
-                    localReceiptStore.workspaceMode && selectedAction !== 'generate-password'
-                      ? 'bg-brand-50/80 text-brand-600 ring-brand-500/25 hover:bg-brand-100/80 dark:bg-brand-900/20 dark:text-brand-400 dark:ring-brand-400/20 dark:hover:bg-brand-900/30'
-                      : 'bg-gray-50/80 text-gray-500 ring-gray-400/20 hover:bg-gray-100/80 hover:text-gray-600 dark:bg-gray-800/50 dark:text-gray-400 dark:ring-gray-600/20 dark:hover:bg-gray-700/50'
-                  ">
-                  <OIcon
-                    collection="mdi"
-                    :name="localReceiptStore.workspaceMode && selectedAction !== 'generate-password' ? 'pin' : 'pin-off'"
-                    class="size-3.5"
-                    aria-hidden="true" />
-                  <span>{{ t('web.secrets.workspace_mode') }}</span>
-                </button>
-
                 <!-- Submit Button -->
                 <SplitButton
                   :with-generate="true"

--- a/src/apps/workspace/dashboard/DashboardIndex.vue
+++ b/src/apps/workspace/dashboard/DashboardIndex.vue
@@ -68,6 +68,6 @@
 
     <RecentSecretsTable
       ref="recentSecretsTableRef"
-      :show-workspace-mode-toggle="false" />
+      :show-workspace-mode-toggle="true" />
   </div>
 </template>

--- a/src/shared/composables/useRecentSecrets.ts
+++ b/src/shared/composables/useRecentSecrets.ts
@@ -226,7 +226,9 @@ function useApiRecentSecrets(
   wrapSilent: <T>(operation: () => Promise<T>) => Promise<T | undefined>
 ) {
   const store = useReceiptListStore();
+  const localStore = useLocalReceiptStore();
   const { records: storeRecords, currentScope, scopeLabel } = storeToRefs(store);
+  const { workspaceMode } = storeToRefs(localStore);
 
   // Transform API records to unified format
   // Filter out records with missing secret_shortid to prevent broken share links
@@ -236,9 +238,6 @@ function useApiRecentSecrets(
   });
 
   const hasRecords = computed(() => records.value.length > 0);
-
-  // Workspace mode is not applicable for API source
-  const workspaceMode = computed(() => false);
 
   const fetch = async (options: FetchListOptions = {}) => {
     const wrapper = options.silent ? wrapSilent : wrap;
@@ -252,7 +251,7 @@ function useApiRecentSecrets(
   };
 
   const toggleWorkspaceMode = () => {
-    // No-op for API mode - workspace mode is a local-only feature
+    localStore.toggleWorkspaceMode();
   };
 
   const updateMemo = async (id: string, memo: string) => {

--- a/src/tests/apps/secret/components/RecentSecretsTable.spec.ts
+++ b/src/tests/apps/secret/components/RecentSecretsTable.spec.ts
@@ -278,7 +278,8 @@ describe('RecentSecretsTable', () => {
       expect(html).toContain('web.LABELS.items_count');
     });
 
-    it('renders dismiss button', async () => {
+    it('renders dismiss button when not authenticated', async () => {
+      mockIsAuthenticated.value = false;
       const wrapper = await mountComponent();
       await flushPromises();
 
@@ -286,7 +287,17 @@ describe('RecentSecretsTable', () => {
       expect(dismissButton.exists()).toBe(true);
     });
 
+    it('hides dismiss button when authenticated', async () => {
+      mockIsAuthenticated.value = true;
+      const wrapper = await mountComponent();
+      await flushPromises();
+
+      const dismissButton = wrapper.find('button[type="button"]');
+      expect(dismissButton.exists()).toBe(false);
+    });
+
     it('calls clear when dismiss button is clicked', async () => {
+      mockIsAuthenticated.value = false;
       const wrapper = await mountComponent();
       await flushPromises();
 

--- a/src/tests/composables/useRecentSecrets.spec.ts
+++ b/src/tests/composables/useRecentSecrets.spec.ts
@@ -436,17 +436,17 @@ describe('useRecentSecrets', () => {
       expect(workspaceMode.value).toBe(true);
     });
 
-    it('workspaceMode is always false in API mode', async () => {
+    it('workspaceMode reads from local store in API mode', async () => {
       vi.mocked(useAuthStore).mockReturnValue({
         isFullyAuthenticated: true,
       } as any);
 
-      mockWorkspaceMode.value = true; // This shouldn't matter in API mode
+      mockWorkspaceMode.value = true;
 
       const { workspaceMode } = useRecentSecrets();
       await nextTick();
 
-      expect(workspaceMode.value).toBe(false);
+      expect(workspaceMode.value).toBe(true);
     });
   });
 


### PR DESCRIPTION
## Summary
- Remove the stay-on-page (workspace mode) toggle from WorkspaceSecretForm — simplifies the submit area
- Gate the "dismiss all" button in RecentSecretsTable behind `!isAuthenticated` so authenticated users don't accidentally clear server-backed records
- Enable workspace mode toggle on DashboardIndex's RecentSecretsTable

## Test plan
- [x] Updated RecentSecretsTable tests for auth-gated dismiss behavior
- [ ] Verify dismiss button hidden when logged in, visible when anonymous
- [ ] Confirm workspace form submit area renders without pin toggle