### PR TITLE
Fix branded homepage links and custom domain branding

### DIFF
--- a/apps/api/v1/logic/secrets/burn_secret.rb
+++ b/apps/api/v1/logic/secrets/burn_secret.rb
@@ -55,6 +55,15 @@ module V1::Logic
         # Get base receipt attributes
         attributes = receipt.safe_dump
 
+        # Resolve the domain for URL generation: use the custom domain
+        # the secret was created on when available, otherwise canonical.
+        domain = if domains_enabled && !receipt.share_domain.to_s.empty?
+                   receipt.share_domain
+                 else
+                   site_host
+                 end
+        domain_uri = [base_scheme, domain].join
+
         # Add required URL fields
         attributes.merge!({
           # secret_state: 'burned',
@@ -64,9 +73,9 @@ module V1::Logic
           share_path: build_path(:secret, receipt.secret_key),
           burn_path: build_path(:receipt, receipt.key, 'burn'),
           metadata_path: build_path(:receipt, receipt.key), # maintain public API
-          share_url: build_url(baseuri, build_path(:secret, receipt.secret_key)),
-          metadata_url: build_url(baseuri, build_path(:receipt, receipt.key)), # maintain public API
-          burn_url: build_url(baseuri, build_path(:receipt, receipt.key, 'burn')),
+          share_url: build_url(domain_uri, build_path(:secret, receipt.secret_key)),
+          metadata_url: build_url(domain_uri, build_path(:receipt, receipt.key)), # maintain public API
+          burn_url: build_url(domain_uri, build_path(:receipt, receipt.key, 'burn')),
         })
 
         {

--- a/apps/api/v1/logic/secrets/show_receipt.rb
+++ b/apps/api/v1/logic/secrets/show_receipt.rb
@@ -232,9 +232,9 @@ module V1::Logic
         @receipt_path = build_path(:receipt, receipt_key)
         @metadata_path = @receipt_path # maintain public API
         @share_url = build_url(share_domain, @share_path)
-        @receipt_url = build_url(baseuri, @receipt_path)
+        @receipt_url = build_url(share_domain, @receipt_path)
         @metadata_url = @receipt_url # maintain public API
-        @burn_url = build_url(baseuri, @burn_path)
+        @burn_url = build_url(share_domain, @burn_path)
         @display_lines = calculate_display_lines
       end
 

--- a/apps/api/v2/logic/secrets/burn_secret.rb
+++ b/apps/api/v2/logic/secrets/burn_secret.rb
@@ -83,6 +83,15 @@ module V2::Logic
         # Get base receipt attributes
         attributes = receipt.safe_dump
 
+        # Resolve the domain for URL generation: use the custom domain
+        # the secret was created on when available, otherwise canonical.
+        domain     = if domains_enabled && !receipt.share_domain.to_s.empty?
+                   receipt.share_domain
+                 else
+                   site_host
+                 end
+        domain_uri = [base_scheme, domain].join
+
         # Add required URL fields
         attributes.merge!(
           {
@@ -94,10 +103,10 @@ module V2::Logic
             burn_path: build_path(:receipt, receipt.identifier, 'burn'),
             receipt_path: build_path(:receipt, receipt.identifier),
             metadata_path: build_path(:receipt, receipt.identifier), # maintain public API
-            share_url: build_url(baseuri, build_path(:secret, receipt.secret_identifier)),
-            receipt_url: build_url(baseuri, build_path(:receipt, receipt.identifier)),
-            metadata_url: build_url(baseuri, build_path(:receipt, receipt.identifier)), # maintain public API
-            burn_url: build_url(baseuri, build_path(:receipt, receipt.identifier, 'burn')),
+            share_url: build_url(domain_uri, build_path(:secret, receipt.secret_identifier)),
+            receipt_url: build_url(domain_uri, build_path(:receipt, receipt.identifier)),
+            metadata_url: build_url(domain_uri, build_path(:receipt, receipt.identifier)), # maintain public API
+            burn_url: build_url(domain_uri, build_path(:receipt, receipt.identifier, 'burn')),
           },
         )
 

--- a/apps/api/v2/logic/secrets/show_receipt.rb
+++ b/apps/api/v2/logic/secrets/show_receipt.rb
@@ -271,9 +271,9 @@ module V2::Logic
         @receipt_path  = build_path(:receipt, receipt_identifier)
         @metadata_path = @receipt_path # maintain public API
         @share_url     = build_url(share_domain, @share_path)
-        @receipt_url   = build_url(baseuri, @receipt_path)
+        @receipt_url   = build_url(share_domain, @receipt_path)
         @metadata_url  = @receipt_url # maintain public API
-        @burn_url      = build_url(baseuri, @burn_path)
+        @burn_url      = build_url(share_domain, @burn_path)
         @display_lines = calculate_display_lines
       end
 

--- a/src/apps/secret/layouts/SecretLayout.vue
+++ b/src/apps/secret/layouts/SecretLayout.vue
@@ -10,8 +10,8 @@
   import OrganizationContextBar from '@/apps/workspace/components/navigation/OrganizationContextBar.vue';
   import WorkspaceFooter from '@/apps/workspace/components/layout/WorkspaceFooter.vue';
   import ManagementHeader from '@/shared/components/layout/ManagementHeader.vue';
+  import BrandedHeader from '@/apps/secret/components/layout/BrandedHeader.vue';
   import TransactionalFooter from '@/shared/components/layout/TransactionalFooter.vue';
-  import TransactionalHeader from '@/shared/components/layout/TransactionalHeader.vue';
   import BaseLayout from '@/shared/layouts/BaseLayout.vue';
   import { useBootstrapStore } from '@/shared/stores/bootstrapStore';
   import { useDomainsStore, useReceiptListStore } from '@/shared/stores';
@@ -60,8 +60,9 @@
       <ManagementHeader v-if="authenticated" v-bind="props">
         <OrganizationContextBar />
       </ManagementHeader>
-      <!-- Guest: TransactionalHeader (simpler) -->
-      <TransactionalHeader v-else v-bind="props" />
+      <!-- Guest: BrandedHeader switches to BrandedMastHead on custom domains,
+           preventing the canonical OTS logo/nav from leaking -->
+      <BrandedHeader v-else v-bind="props" />
     </template>
 
     <template #main>

--- a/src/apps/secret/routes/receipt.ts
+++ b/src/apps/secret/routes/receipt.ts
@@ -30,9 +30,12 @@ const withValidatedReceiptKey = {
     const domainStrategy = bootstrapStore.domain_strategy as string;
 
     if (domainStrategy === 'custom') {
+      // Only show masthead if the custom domain has its own logo;
+      // otherwise hide it to avoid displaying the canonical OTS logo.
+      const hasDomainLogo = !!bootstrapStore.domain_logo;
       to.meta.layoutProps = {
         ...to.meta.layoutProps,
-        displayMasthead: true,
+        displayMasthead: hasDomainLogo,
         displayNavigation: false,
         displayFooterLinks: false,
         displayFeedback: false,

--- a/src/apps/workspace/components/dashboard/DomainsTableDomainCell.vue
+++ b/src/apps/workspace/components/dashboard/DomainsTableDomainCell.vue
@@ -3,7 +3,6 @@
 <script setup lang="ts">
   import { useI18n } from 'vue-i18n';
   import DomainVerificationInfo from '@/apps/workspace/components/domains/DomainVerificationInfo.vue';
-  import { useDomainStatus } from '@/shared/composables/useDomainStatus';
   import type { CustomDomain } from '@/schemas/models/domain';
   import { formatDistanceToNow } from 'date-fns';
 
@@ -15,22 +14,13 @@ const { t } = useI18n();
   }
 
   const props = defineProps<Props>();
-
-  const status = useDomainStatus(props.domain);
 </script>
 
 <template>
   <div class="flex flex-col space-y-2">
     <div class="flex items-center space-x-2">
       <router-link
-        v-if="status.isActive.value"
         :to="{ name: 'DomainBrand', params: { orgid: props.orgid, extid: domain.extid } }"
-        class="font-brand text-lg text-brandcomp-600 hover:text-brandcomp-700 dark:text-brandcomp-400 dark:hover:text-brandcomp-300">
-        {{ domain.display_domain }}
-      </router-link>
-      <router-link
-        v-else
-        :to="{ name: 'DomainVerify', params: { orgid: props.orgid, extid: domain.extid } }"
         class="font-brand text-lg text-brandcomp-600 hover:text-brandcomp-700 dark:text-brandcomp-400 dark:hover:text-brandcomp-300">
         {{ domain.display_domain }}
       </router-link>

--- a/src/router/guards.routes.ts
+++ b/src/router/guards.routes.ts
@@ -24,12 +24,15 @@ export async function setupRouterGuards(router: Router): Promise<void> {
     const hasDomainLogo = !!bootstrapStore.domain_logo;
     const existing = (to.meta.layoutProps ?? {}) as Record<string, unknown>;
 
+    // Guard overrides win over route-defined static defaults.
+    // Per-route beforeEnter guards run AFTER beforeEach and can
+    // still override these values for route-specific needs.
     to.meta.layoutProps = {
+      ...existing,
       displayMasthead: hasDomainLogo,
       displayNavigation: false,
       displayFooterLinks: false,
       displayFeedback: false,
-      ...existing,
     };
 
     return true;

--- a/src/router/public.routes.ts
+++ b/src/router/public.routes.ts
@@ -80,7 +80,7 @@ function getLayoutPropsForMode(componentMode: string, domainStrategy: string) {
       ...layoutProps,
       displayMasthead: false, // Logo goes in page content for centered experience
       displayNavigation: false,
-      displayFooterLinks: true, // Keep Terms/Privacy links
+      displayFooterLinks: false,
       displayFeedback: false,
       displayVersion: false,
       displayPoweredBy: true, // Show "Powered by Onetime Secret"

--- a/src/shared/stores/receiptStore.ts
+++ b/src/shared/stores/receiptStore.ts
@@ -177,12 +177,14 @@ export const useReceiptStore = defineStore('receipt', () => {
 
   /**
    * Resets store state to initial values.
-   * Clears record, details, API mode, and initialization status.
+   * apiMode is intentionally preserved: it's set by the consuming
+   * composable based on auth state, and resetting it here causes a
+   * race condition when Vue processes new component setup before
+   * old component unmount.
    */
   function $reset() {
     record.value = null;
     details.value = null;
-    apiMode.value = 'authenticated';
     _initialized.value = false;
   }
 

--- a/src/tests/apps/secret/components/layout/BrandedHeader.spec.ts
+++ b/src/tests/apps/secret/components/layout/BrandedHeader.spec.ts
@@ -1,0 +1,252 @@
+// src/tests/apps/secret/components/layout/BrandedHeader.spec.ts
+//
+// Tests for BrandedHeader — the component that switches between
+// BrandedMastHead (custom domains) and MastHead (canonical domain)
+// based on productIdentity.isCustom.
+
+import { mount, VueWrapper } from '@vue/test-utils';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createI18n } from 'vue-i18n';
+import { createTestingPinia } from '@pinia/testing';
+import BrandedHeader from '@/apps/secret/components/layout/BrandedHeader.vue';
+import { nextTick } from 'vue';
+
+// Track which component renders
+const brandedMastHeadSpy = vi.fn();
+const mastHeadSpy = vi.fn();
+
+// Mock BrandedMastHead
+vi.mock('@/apps/secret/components/layout/BrandedMastHead.vue', () => ({
+  default: {
+    name: 'BrandedMastHead',
+    template: '<div class="branded-masthead" :data-headertext="headertext" :data-subtext="subtext" />',
+    props: ['headertext', 'subtext', 'displayMasthead', 'displayNavigation'],
+    setup() {
+      brandedMastHeadSpy();
+    },
+  },
+}));
+
+// Mock MastHead
+vi.mock('@/shared/components/layout/MastHead.vue', () => ({
+  default: {
+    name: 'MastHead',
+    template: '<div class="standard-masthead" />',
+    props: ['displayMasthead', 'displayNavigation', 'colonel'],
+    setup() {
+      mastHeadSpy();
+    },
+  },
+}));
+
+// Mock vue-router
+vi.mock('vue-router', () => ({
+  RouterLink: {
+    template: '<a :href="to"><slot /></a>',
+    props: ['to'],
+  },
+  useRoute: vi.fn(() => ({ path: '/', query: {}, params: {} })),
+  useRouter: vi.fn(() => ({ push: vi.fn() })),
+}));
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: {
+    en: {
+      web: {
+        homepage: {
+          create_a_secure_link: 'Create a Secure Link',
+          secure_links: 'Secure Links',
+          send_sensitive_information_that_can_only_be_viewed_once:
+            'Send sensitive information that can only be viewed once',
+          a_trusted_way_to_share_sensitive_information_etc:
+            'A trusted way to share sensitive information',
+          one_time_secret_literal: 'Onetime Secret',
+        },
+        layout: {
+          brand_logo: 'Brand Logo',
+        },
+        shared: {
+          pre_reveal_default: 'Click to reveal',
+          post_reveal_default: 'Secret has been revealed',
+        },
+        COMMON: {
+          tagline: 'Keep passwords out of your email & chat logs',
+        },
+      },
+    },
+  },
+});
+
+describe('BrandedHeader', () => {
+  let wrapper: VueWrapper;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    if (wrapper) {
+      wrapper.unmount();
+    }
+  });
+
+  const mountComponent = (
+    props: Record<string, unknown> = {},
+    storeOverrides: {
+      domain_strategy?: string;
+      domain_logo?: string | null;
+      domain_branding?: Record<string, unknown>;
+    } = {}
+  ) => {
+    const pinia = createTestingPinia({
+      createSpy: vi.fn,
+      stubActions: false,
+      initialState: {
+        bootstrap: {
+          domain_strategy: storeOverrides.domain_strategy ?? 'canonical',
+          domain_logo: storeOverrides.domain_logo ?? null,
+          domains_enabled: storeOverrides.domain_strategy === 'custom',
+          display_domain: storeOverrides.domain_strategy === 'custom'
+            ? 'secrets.acme.com'
+            : 'onetimesecret.com',
+          site_host: 'onetimesecret.com',
+          canonical_domain: 'onetimesecret.com',
+          domain_id: storeOverrides.domain_strategy === 'custom' ? 'cd_acme' : '',
+          domain_branding: storeOverrides.domain_branding ?? {
+            primary_color: '#36454F',
+            corner_style: 'rounded',
+            font_family: 'sans',
+            button_text_light: true,
+            allow_public_homepage: false,
+          },
+          ui: {
+            header: {
+              navigation: { enabled: true },
+              branding: {
+                logo: { url: 'DefaultLogo.vue', alt: 'Onetime Secret' },
+                site_name: 'Onetime Secret',
+              },
+            },
+          },
+        },
+      },
+    });
+
+    return mount(BrandedHeader, {
+      props: {
+        displayMasthead: true,
+        displayNavigation: false,
+        ...props,
+      },
+      global: {
+        plugins: [i18n, pinia],
+        stubs: {
+          RouterLink: {
+            template: '<a :href="to"><slot /></a>',
+            props: ['to'],
+          },
+        },
+      },
+    });
+  };
+
+  describe('Component switching based on domain strategy', () => {
+    it('renders MastHead on canonical domain', async () => {
+      wrapper = mountComponent({}, {
+        domain_strategy: 'canonical',
+        domain_logo: null,
+      });
+
+      await nextTick();
+      expect(wrapper.find('.standard-masthead').exists()).toBe(true);
+      expect(wrapper.find('.branded-masthead').exists()).toBe(false);
+      expect(mastHeadSpy).toHaveBeenCalled();
+      expect(brandedMastHeadSpy).not.toHaveBeenCalled();
+    });
+
+    it('renders BrandedMastHead on custom domain', async () => {
+      wrapper = mountComponent({}, {
+        domain_strategy: 'custom',
+        domain_logo: 'https://cdn.example.com/logo.png',
+      });
+
+      await nextTick();
+      expect(wrapper.find('.branded-masthead').exists()).toBe(true);
+      expect(wrapper.find('.standard-masthead').exists()).toBe(false);
+      expect(brandedMastHeadSpy).toHaveBeenCalled();
+      expect(mastHeadSpy).not.toHaveBeenCalled();
+    });
+
+    it('renders BrandedMastHead on custom domain even without logo', async () => {
+      // Key scenario: custom domain with no uploaded logo
+      // BrandedHeader should still use BrandedMastHead (NOT MastHead)
+      // because the switching is based on domain_strategy, not domain_logo
+      wrapper = mountComponent({}, {
+        domain_strategy: 'custom',
+        domain_logo: null,
+      });
+
+      await nextTick();
+      expect(wrapper.find('.branded-masthead').exists()).toBe(true);
+      expect(wrapper.find('.standard-masthead').exists()).toBe(false);
+    });
+  });
+
+  describe('Header text on custom domains', () => {
+    it('shows "Secure Links" when allow_public_homepage is false', async () => {
+      wrapper = mountComponent({}, {
+        domain_strategy: 'custom',
+        domain_logo: 'https://cdn.example.com/logo.png',
+        domain_branding: {
+          primary_color: '#ff4400',
+          corner_style: 'square',
+          font_family: 'sans',
+          button_text_light: false,
+          allow_public_homepage: false,
+        },
+      });
+
+      await nextTick();
+      const branded = wrapper.find('.branded-masthead');
+      expect(branded.attributes('data-headertext')).toBe('Secure Links');
+      expect(branded.attributes('data-subtext')).toBe(
+        'A trusted way to share sensitive information'
+      );
+    });
+
+    it('shows "Create a Secure Link" when allow_public_homepage is true', async () => {
+      wrapper = mountComponent({}, {
+        domain_strategy: 'custom',
+        domain_logo: 'https://cdn.example.com/logo.png',
+        domain_branding: {
+          primary_color: '#ff4400',
+          corner_style: 'square',
+          font_family: 'sans',
+          button_text_light: false,
+          allow_public_homepage: true,
+        },
+      });
+
+      await nextTick();
+      const branded = wrapper.find('.branded-masthead');
+      expect(branded.attributes('data-headertext')).toBe('Create a Secure Link');
+    });
+  });
+
+  describe('Masthead visibility', () => {
+    it('hides header content when displayMasthead is false', async () => {
+      wrapper = mountComponent({
+        displayMasthead: false,
+      }, {
+        domain_strategy: 'canonical',
+      });
+
+      await nextTick();
+      // The outer header exists but inner content is hidden via v-if
+      expect(wrapper.find('.standard-masthead').exists()).toBe(false);
+      expect(wrapper.find('.branded-masthead').exists()).toBe(false);
+    });
+  });
+});

--- a/src/tests/router/guards.routes.spec.ts
+++ b/src/tests/router/guards.routes.spec.ts
@@ -104,8 +104,8 @@ describe('Router Guards', () => {
   it('should redirect authenticated users from auth routes', async () => {
     setupRouterGuards(router);
 
-    // Index 1: main guard (index 0 is the feature-check guard)
-    const guard = vi.mocked(router.beforeEach).mock.calls[1][0] as AuthGuard;
+    // Index 2: main guard (index 0 is custom-domain guard, index 1 is feature-check guard)
+    const guard = vi.mocked(router.beforeEach).mock.calls[2][0] as AuthGuard;
     const to: RouteLocationNormalized = {
       meta: { isAuthRoute: true },
       query: {},
@@ -129,8 +129,8 @@ describe('Router Guards', () => {
   it('should handle root path redirect for authenticated users', async () => {
     setupRouterGuards(router);
 
-    // Index 1: main guard (index 0 is the feature-check guard)
-    const guard = vi.mocked(router.beforeEach).mock.calls[1][0] as AuthGuard;
+    // Index 2: main guard (index 0 is custom-domain guard, index 1 is feature-check guard)
+    const guard = vi.mocked(router.beforeEach).mock.calls[2][0] as AuthGuard;
     const to: RouteLocationNormalized = {
       path: '/',
       query: {},
@@ -159,7 +159,7 @@ describe('Router Guards', () => {
       });
 
       setupRouterGuards(router);
-      const guard = vi.mocked(router.beforeEach).mock.calls[0][0] as FeatureGuard;
+      const guard = vi.mocked(router.beforeEach).mock.calls[1][0] as FeatureGuard;
       const to = {
         meta: { requiresFeature: 'signup' as const, isAuthRoute: true },
         path: '/signup',
@@ -183,7 +183,7 @@ describe('Router Guards', () => {
       });
 
       setupRouterGuards(router);
-      const guard = vi.mocked(router.beforeEach).mock.calls[0][0] as FeatureGuard;
+      const guard = vi.mocked(router.beforeEach).mock.calls[1][0] as FeatureGuard;
       const to = {
         meta: { requiresFeature: 'signup' as const, isAuthRoute: true },
         path: '/signup',
@@ -207,7 +207,7 @@ describe('Router Guards', () => {
       });
 
       setupRouterGuards(router);
-      const guard = vi.mocked(router.beforeEach).mock.calls[0][0] as FeatureGuard;
+      const guard = vi.mocked(router.beforeEach).mock.calls[1][0] as FeatureGuard;
       const to = {
         meta: { requiresFeature: 'signin' as const, isAuthRoute: true },
         path: '/signin',
@@ -231,7 +231,7 @@ describe('Router Guards', () => {
       });
 
       setupRouterGuards(router);
-      const guard = vi.mocked(router.beforeEach).mock.calls[0][0] as FeatureGuard;
+      const guard = vi.mocked(router.beforeEach).mock.calls[1][0] as FeatureGuard;
       const to = {
         meta: { requiresFeature: 'signup' as const, isAuthRoute: true },
         path: '/signup',
@@ -255,7 +255,7 @@ describe('Router Guards', () => {
       });
 
       setupRouterGuards(router);
-      const guard = vi.mocked(router.beforeEach).mock.calls[0][0] as FeatureGuard;
+      const guard = vi.mocked(router.beforeEach).mock.calls[1][0] as FeatureGuard;
       const to = {
         meta: { requiresFeature: 'signin' as const, isAuthRoute: true },
         path: '/mfa-verify',
@@ -279,7 +279,7 @@ describe('Router Guards', () => {
       });
 
       setupRouterGuards(router);
-      const guard = vi.mocked(router.beforeEach).mock.calls[0][0] as FeatureGuard;
+      const guard = vi.mocked(router.beforeEach).mock.calls[1][0] as FeatureGuard;
       const to = {
         meta: { requiresFeature: 'signin' as const, isAuthRoute: true },
         path: '/reset-password',
@@ -303,7 +303,7 @@ describe('Router Guards', () => {
       });
 
       setupRouterGuards(router);
-      const guard = vi.mocked(router.beforeEach).mock.calls[0][0] as FeatureGuard;
+      const guard = vi.mocked(router.beforeEach).mock.calls[1][0] as FeatureGuard;
       const to = {
         meta: { requiresFeature: 'signin' as const, isAuthRoute: true },
         path: '/email-login',
@@ -327,7 +327,7 @@ describe('Router Guards', () => {
       });
 
       setupRouterGuards(router);
-      const guard = vi.mocked(router.beforeEach).mock.calls[0][0] as FeatureGuard;
+      const guard = vi.mocked(router.beforeEach).mock.calls[1][0] as FeatureGuard;
       const to = {
         meta: { requiresFeature: 'signin' as const, isAuthRoute: true },
         path: '/forgot',
@@ -351,7 +351,7 @@ describe('Router Guards', () => {
       });
 
       setupRouterGuards(router);
-      const guard = vi.mocked(router.beforeEach).mock.calls[0][0] as FeatureGuard;
+      const guard = vi.mocked(router.beforeEach).mock.calls[1][0] as FeatureGuard;
       const to = {
         meta: { requiresFeature: 'signin' as const, isAuthRoute: true },
         path: '/mfa-verify',
@@ -375,7 +375,7 @@ describe('Router Guards', () => {
       });
 
       setupRouterGuards(router);
-      const guard = vi.mocked(router.beforeEach).mock.calls[0][0] as FeatureGuard;
+      const guard = vi.mocked(router.beforeEach).mock.calls[1][0] as FeatureGuard;
       const to = {
         meta: { requiresFeature: 'signin' as const, isAuthRoute: true },
         path: '/email-login',
@@ -399,7 +399,7 @@ describe('Router Guards', () => {
       });
 
       setupRouterGuards(router);
-      const guard = vi.mocked(router.beforeEach).mock.calls[0][0] as FeatureGuard;
+      const guard = vi.mocked(router.beforeEach).mock.calls[1][0] as FeatureGuard;
       const to = {
         meta: { requiresFeature: 'signup' as const, isAuthRoute: true },
         path: '/signup/professional',
@@ -418,7 +418,7 @@ describe('Router Guards', () => {
 
     it('should not redirect routes without requiresFeature', () => {
       setupRouterGuards(router);
-      const guard = vi.mocked(router.beforeEach).mock.calls[0][0] as FeatureGuard;
+      const guard = vi.mocked(router.beforeEach).mock.calls[1][0] as FeatureGuard;
       const to = {
         meta: {},
         path: '/some-page',

--- a/src/tests/shared/components/layout/MastHead.customDomain.spec.ts
+++ b/src/tests/shared/components/layout/MastHead.customDomain.spec.ts
@@ -1,0 +1,503 @@
+// src/tests/shared/components/layout/MastHead.customDomain.spec.ts
+//
+// Tests for MastHead logo/brand behavior on custom domains.
+// Covers the interaction between domain_strategy, domain_logo,
+// and how the component decides which logo to render.
+
+import { mount, VueWrapper } from '@vue/test-utils';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createI18n } from 'vue-i18n';
+import { createTestingPinia } from '@pinia/testing';
+import MastHead from '@/shared/components/layout/MastHead.vue';
+import { nextTick } from 'vue';
+import { useAuthStore } from '@/shared/stores/authStore';
+
+// Mock DefaultLogo component
+vi.mock('@/shared/components/logos/DefaultLogo.vue', () => ({
+  default: {
+    name: 'DefaultLogo',
+    template: `<div class="default-logo" :data-size="size" :data-show-site-name="showSiteName">
+      <span class="logo-icon" />
+      <span v-if="showSiteName" class="site-name">{{ siteName }}</span>
+    </div>`,
+    props: ['url', 'alt', 'href', 'size', 'showSiteName', 'siteName', 'ariaLabel', 'isColonelArea', 'isUserPresent'],
+  },
+}));
+
+// Mock UserMenu component
+vi.mock('@/shared/components/navigation/UserMenu.vue', () => ({
+  default: {
+    name: 'UserMenu',
+    template: '<div class="user-menu" :data-email="email" />',
+    props: ['cust', 'email', 'colonel', 'awaitingMfa'],
+  },
+}));
+
+// Mock router
+vi.mock('vue-router', () => ({
+  RouterLink: {
+    template: '<a :href="to"><slot /></a>',
+    props: ['to'],
+  },
+}));
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: {
+    en: {
+      web: {
+        homepage: {
+          one_time_secret_literal: 'Onetime Secret',
+          signup_individual_and_business_plans: 'Sign up',
+          log_in_to_onetime_secret: 'Log in',
+        },
+        layout: {
+          main_navigation: 'Main Navigation',
+        },
+        COMMON: {
+          header_create_account: 'Create Account',
+          header_sign_in: 'Sign In',
+        },
+      },
+    },
+  },
+});
+
+describe('MastHead — Custom Domain Logo Behavior', () => {
+  let wrapper: VueWrapper;
+
+  const mockCustomer = {
+    custid: '123',
+    email: 'test@example.com',
+    extid: 'ext_123',
+    objid: 'obj_123',
+    role: 'customer',
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    if (wrapper) {
+      wrapper.unmount();
+    }
+  });
+
+  const mountComponent = (
+    props: Record<string, unknown> = {},
+    storeState: {
+      authenticated?: boolean;
+      awaiting_mfa?: boolean;
+      email?: string | null;
+      cust?: typeof mockCustomer | null;
+      domain_logo?: string | null;
+      domain_strategy?: string;
+      display_domain?: string;
+      domain_id?: string;
+    } = {}
+  ) => {
+    const pinia = createTestingPinia({
+      createSpy: vi.fn,
+      stubActions: false,
+      initialState: {
+        bootstrap: {
+          authenticated: storeState.authenticated ?? false,
+          awaiting_mfa: storeState.awaiting_mfa ?? false,
+          email: storeState.email ?? null,
+          cust: storeState.cust ?? null,
+          domain_logo: storeState.domain_logo ?? null,
+          domain_strategy: storeState.domain_strategy ?? 'canonical',
+          display_domain: storeState.display_domain ?? 'onetimesecret.com',
+          domain_id: storeState.domain_id ?? '',
+          ui: {
+            header: {
+              navigation: { enabled: true },
+              branding: {
+                logo: { url: 'DefaultLogo.vue', alt: 'Onetime Secret' },
+                site_name: 'Onetime Secret',
+              },
+            },
+          },
+          authentication: {
+            enabled: true,
+            signin: true,
+            signup: true,
+          },
+        },
+      },
+    });
+
+    const authStore = useAuthStore(pinia);
+    const hasAuthenticatedCustomer = storeState.authenticated && storeState.cust;
+    const hasMfaPendingEmail = storeState.awaiting_mfa && storeState.email;
+    (authStore as unknown as { isUserPresent: boolean }).isUserPresent =
+      !!(hasAuthenticatedCustomer || hasMfaPendingEmail);
+
+    return mount(MastHead, {
+      props: {
+        displayMasthead: true,
+        displayNavigation: true,
+        ...props,
+      },
+      global: {
+        plugins: [i18n, pinia],
+        stubs: {
+          RouterLink: {
+            template: '<a :href="to"><slot /></a>',
+            props: ['to'],
+          },
+        },
+      },
+    });
+  };
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // CANONICAL DOMAIN — Default OTS Logo
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  describe('Canonical domain (domain_strategy="canonical")', () => {
+    it('renders DefaultLogo component when no custom domain logo', async () => {
+      wrapper = mountComponent({}, {
+        authenticated: false,
+        domain_strategy: 'canonical',
+        domain_logo: null,
+      });
+
+      await nextTick();
+      const logo = wrapper.find('.default-logo');
+      expect(logo.exists()).toBe(true);
+    });
+
+    it('shows site name on canonical domain', async () => {
+      wrapper = mountComponent({}, {
+        authenticated: false,
+        domain_strategy: 'canonical',
+        domain_logo: null,
+      });
+
+      await nextTick();
+      const logo = wrapper.find('.default-logo');
+      expect(logo.attributes('data-show-site-name')).toBe('true');
+    });
+
+    it('uses 64px logo for unauthenticated users on canonical domain', async () => {
+      wrapper = mountComponent({}, {
+        authenticated: false,
+        domain_strategy: 'canonical',
+        domain_logo: null,
+      });
+
+      await nextTick();
+      const logo = wrapper.find('.default-logo');
+      expect(logo.attributes('data-size')).toBe('64');
+    });
+
+    it('uses 40px logo for authenticated users on canonical domain', async () => {
+      wrapper = mountComponent({}, {
+        authenticated: true,
+        cust: mockCustomer,
+        email: mockCustomer.email,
+        domain_strategy: 'canonical',
+        domain_logo: null,
+      });
+
+      await nextTick();
+      const logo = wrapper.find('.default-logo');
+      expect(logo.attributes('data-size')).toBe('40');
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // CUSTOM DOMAIN WITH LOGO — Custom brand logo
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  describe('Custom domain with logo (domain_strategy="custom", domain_logo set)', () => {
+    const customLogoUrl = 'https://cdn.example.com/logos/acme-logo.png';
+
+    it('renders img element instead of DefaultLogo when domain_logo is set', async () => {
+      wrapper = mountComponent({}, {
+        authenticated: false,
+        domain_strategy: 'custom',
+        domain_logo: customLogoUrl,
+        display_domain: 'secrets.acme.com',
+        domain_id: 'cd_acme',
+      });
+
+      await nextTick();
+      // Should NOT render DefaultLogo component
+      const defaultLogo = wrapper.find('.default-logo');
+      expect(defaultLogo.exists()).toBe(false);
+
+      // Should render img element with custom logo
+      const img = wrapper.find('img#logo');
+      expect(img.exists()).toBe(true);
+      expect(img.attributes('src')).toBe(customLogoUrl);
+    });
+
+    it('uses 80px size for custom domain logo', async () => {
+      wrapper = mountComponent({}, {
+        authenticated: false,
+        domain_strategy: 'custom',
+        domain_logo: customLogoUrl,
+      });
+
+      await nextTick();
+      const img = wrapper.find('img#logo');
+      expect(img.exists()).toBe(true);
+      expect(img.attributes('height')).toBe('80');
+      expect(img.attributes('width')).toBe('80');
+    });
+
+    it('applies size-20 class to custom domain logo', async () => {
+      wrapper = mountComponent({}, {
+        authenticated: false,
+        domain_strategy: 'custom',
+        domain_logo: customLogoUrl,
+      });
+
+      await nextTick();
+      const img = wrapper.find('img#logo');
+      expect(img.exists()).toBe(true);
+      expect(img.classes()).toContain('size-20');
+    });
+
+    it('hides site name when custom domain logo is present', async () => {
+      wrapper = mountComponent({}, {
+        authenticated: false,
+        domain_strategy: 'custom',
+        domain_logo: customLogoUrl,
+      });
+
+      await nextTick();
+      // Site name should not appear next to custom domain logo by default
+      const siteName = wrapper.find('span.font-brand.text-lg');
+      expect(siteName.exists()).toBe(false);
+    });
+
+    it('uses 80px size regardless of auth state for custom domain', async () => {
+      wrapper = mountComponent({}, {
+        authenticated: true,
+        cust: mockCustomer,
+        email: mockCustomer.email,
+        domain_strategy: 'custom',
+        domain_logo: customLogoUrl,
+      });
+
+      await nextTick();
+      const img = wrapper.find('img#logo');
+      expect(img.exists()).toBe(true);
+      expect(img.attributes('height')).toBe('80');
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // CUSTOM DOMAIN WITHOUT LOGO — The bug scenario
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  describe('Custom domain without logo (domain_strategy="custom", domain_logo=null)', () => {
+    it('falls back to DefaultLogo when custom domain has no uploaded logo', async () => {
+      wrapper = mountComponent({}, {
+        authenticated: false,
+        domain_strategy: 'custom',
+        domain_logo: null,
+        display_domain: 'secrets.acme.com',
+        domain_id: 'cd_acme',
+      });
+
+      await nextTick();
+      // When domain_logo is null, MastHead falls back to the configured logo URL
+      // which defaults to 'DefaultLogo.vue' — this renders the OTS logo
+      const defaultLogo = wrapper.find('.default-logo');
+      expect(defaultLogo.exists()).toBe(true);
+    });
+
+    it('shows OTS site name when custom domain has no logo', async () => {
+      wrapper = mountComponent({}, {
+        authenticated: false,
+        domain_strategy: 'custom',
+        domain_logo: null,
+        display_domain: 'secrets.acme.com',
+      });
+
+      await nextTick();
+      // Without domain_logo, the site name logic does NOT suppress the name
+      // This means the OTS site name "Onetime Secret" appears on a custom domain
+      const logo = wrapper.find('.default-logo');
+      expect(logo.exists()).toBe(true);
+      expect(logo.attributes('data-show-site-name')).toBe('true');
+    });
+
+    it('uses standard sizing (not 80px) when no custom logo is set', async () => {
+      wrapper = mountComponent({}, {
+        authenticated: false,
+        domain_strategy: 'custom',
+        domain_logo: null,
+      });
+
+      await nextTick();
+      const logo = wrapper.find('.default-logo');
+      expect(logo.exists()).toBe(true);
+      // Should use 64px (unauthenticated default), NOT 80px (custom domain logo size)
+      expect(logo.attributes('data-size')).toBe('64');
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // LOGO CONFIGURATION PRIORITY
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  describe('Logo configuration priority: props > domain_logo > config > default', () => {
+    it('props override domain_logo when both are provided', async () => {
+      wrapper = mountComponent({
+        logo: {
+          url: '/custom-override.png',
+          alt: 'Override Logo',
+          size: 48,
+          isUserPresent: false,
+        },
+      }, {
+        authenticated: false,
+        domain_strategy: 'custom',
+        domain_logo: 'https://cdn.example.com/domain-logo.png',
+      });
+
+      await nextTick();
+      // The img should use the prop override URL, not the domain_logo
+      const img = wrapper.find('img#logo');
+      expect(img.exists()).toBe(true);
+      expect(img.attributes('src')).toBe('/custom-override.png');
+      expect(img.attributes('height')).toBe('48');
+    });
+
+    it('domain_logo takes priority over header config logo URL', async () => {
+      wrapper = mountComponent({}, {
+        authenticated: false,
+        domain_strategy: 'custom',
+        domain_logo: 'https://cdn.example.com/domain-logo.png',
+      });
+
+      await nextTick();
+      // Should use domain_logo, not the header config default
+      const img = wrapper.find('img#logo');
+      expect(img.exists()).toBe(true);
+      expect(img.attributes('src')).toBe('https://cdn.example.com/domain-logo.png');
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // ACCESSIBILITY ON CUSTOM DOMAINS
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  describe('Accessibility on custom domains', () => {
+    it('custom domain logo has alt text', async () => {
+      wrapper = mountComponent({}, {
+        authenticated: false,
+        domain_strategy: 'custom',
+        domain_logo: 'https://cdn.example.com/logo.png',
+      });
+
+      await nextTick();
+      const img = wrapper.find('img#logo');
+      expect(img.exists()).toBe(true);
+      expect(img.attributes('alt')).toBeTruthy();
+    });
+
+    it('custom domain logo link has aria-label', async () => {
+      wrapper = mountComponent({}, {
+        authenticated: false,
+        domain_strategy: 'custom',
+        domain_logo: 'https://cdn.example.com/logo.png',
+      });
+
+      await nextTick();
+      const logoLink = wrapper.find('a[aria-label]');
+      expect(logoLink.exists()).toBe(true);
+    });
+
+    it('navigation has proper aria-label on custom domains', async () => {
+      wrapper = mountComponent({}, {
+        authenticated: true,
+        cust: mockCustomer,
+        email: mockCustomer.email,
+        domain_strategy: 'custom',
+        domain_logo: 'https://cdn.example.com/logo.png',
+      });
+
+      await nextTick();
+      const nav = wrapper.find('nav[role="navigation"]');
+      expect(nav.attributes('aria-label')).toBe('Main Navigation');
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // BUG DOCUMENTATION: Default logo leaks on custom domains
+  //
+  // MastHead's logo logic is driven by `domain_logo` (URL or null), not
+  // `domain_strategy`. When domain_strategy='custom' but domain_logo is null
+  // (e.g., customer hasn't uploaded a logo), MastHead renders the OTS default
+  // logo with "Onetime Secret" branding — which is wrong for custom domains.
+  //
+  // Leak routes: /incoming, /feedback, /help, /pricing — these use
+  // TransactionalHeader → MastHead directly, with no domain-aware switching.
+  //
+  // Non-leaking routes: homepage (BrandedHeader switches), reveal (hides
+  // masthead entirely), receipt (beforeEnter guard patches props).
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  describe('Bug: MastHead ignores domain_strategy when domain_logo is null', () => {
+    it('shows OTS default logo on custom domain when no logo uploaded (current behavior)', async () => {
+      // This documents the bug: a customer on secrets.acme.com sees the
+      // Onetime Secret logo because MastHead only checks domain_logo, not domain_strategy
+      wrapper = mountComponent({}, {
+        authenticated: false,
+        domain_strategy: 'custom',
+        domain_logo: null,
+        display_domain: 'secrets.acme.com',
+        domain_id: 'cd_acme',
+      });
+
+      await nextTick();
+
+      // BUG: DefaultLogo renders even though we're on a custom domain
+      const defaultLogo = wrapper.find('.default-logo');
+      expect(defaultLogo.exists()).toBe(true);
+
+      // BUG: "Onetime Secret" site name shows on another company's domain
+      expect(defaultLogo.attributes('data-show-site-name')).toBe('true');
+    });
+
+    it('does not suppress auth navigation on custom domain (correct: auth nav should remain)', async () => {
+      // Even on custom domains, sign in/sign up links should still appear
+      // if authentication is enabled — this is NOT a bug
+      wrapper = mountComponent({}, {
+        authenticated: false,
+        domain_strategy: 'custom',
+        domain_logo: null,
+      });
+
+      await nextTick();
+      const html = wrapper.html();
+      expect(html).toContain('Sign In');
+      expect(html).toContain('Create Account');
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // EXPECTED BEHAVIOR AFTER FIX (these should pass once the fix lands)
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  describe.todo('Expected: MastHead should be domain_strategy-aware', () => {
+    // Once fixed, MastHead should check domain_strategy='custom' and:
+    // 1. If domain_logo is set → show custom logo (already works)
+    // 2. If domain_logo is null → hide logo entirely or show a neutral placeholder
+    //    (NOT the OTS default logo with "Onetime Secret" branding)
+    //
+    // Test stubs for when the fix is implemented:
+
+    // it('hides DefaultLogo when domain_strategy=custom and no domain_logo', ...)
+    // it('does not show "Onetime Secret" site name on custom domain', ...)
+    // it('shows neutral placeholder when custom domain has no logo', ...)
+  });
+});

--- a/src/tests/shared/components/layout/TransactionalHeader.customDomain.spec.ts
+++ b/src/tests/shared/components/layout/TransactionalHeader.customDomain.spec.ts
@@ -1,0 +1,177 @@
+// src/tests/shared/components/layout/TransactionalHeader.customDomain.spec.ts
+//
+// Tests documenting that TransactionalHeader has no domain-aware branching.
+// It always renders MastHead directly, which means on custom domains it
+// will show the default OTS logo when domain_logo is null.
+//
+// Contrast with BrandedHeader.vue which switches between BrandedMastHead
+// (custom) and MastHead (canonical) based on productIdentity.isCustom.
+
+import { mount, VueWrapper } from '@vue/test-utils';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createI18n } from 'vue-i18n';
+import { createTestingPinia } from '@pinia/testing';
+import TransactionalHeader from '@/shared/components/layout/TransactionalHeader.vue';
+import { nextTick } from 'vue';
+
+// Mock MastHead to track rendering and capture props
+const mastHeadProps = vi.fn();
+vi.mock('@/shared/components/layout/MastHead.vue', () => ({
+  default: {
+    name: 'MastHead',
+    template: '<div class="masthead" :data-display-masthead="displayMasthead" />',
+    props: ['displayMasthead', 'displayNavigation', 'colonel', 'logo'],
+    setup(props: Record<string, unknown>) {
+      mastHeadProps(props);
+    },
+  },
+}));
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: { en: {} },
+});
+
+describe('TransactionalHeader — Custom Domain Leak Vector', () => {
+  let wrapper: VueWrapper;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    if (wrapper) {
+      wrapper.unmount();
+    }
+  });
+
+  const mountComponent = (
+    props: Record<string, unknown> = {},
+    storeState: {
+      domain_strategy?: string;
+      domain_logo?: string | null;
+    } = {}
+  ) => {
+    const pinia = createTestingPinia({
+      createSpy: vi.fn,
+      stubActions: false,
+      initialState: {
+        bootstrap: {
+          authenticated: false,
+          domain_strategy: storeState.domain_strategy ?? 'canonical',
+          domain_logo: storeState.domain_logo ?? null,
+          ui: {
+            header: {
+              navigation: { enabled: true },
+              branding: {
+                logo: { url: 'DefaultLogo.vue', alt: 'Onetime Secret' },
+                site_name: 'Onetime Secret',
+              },
+            },
+          },
+          authentication: { enabled: true, signin: true, signup: true },
+        },
+      },
+    });
+
+    return mount(TransactionalHeader, {
+      props: {
+        displayMasthead: true,
+        displayNavigation: true,
+        ...props,
+      },
+      global: {
+        plugins: [i18n, pinia],
+      },
+    });
+  };
+
+  it('always renders MastHead regardless of domain_strategy', async () => {
+    // TransactionalHeader has no domain-aware branching — it always uses MastHead
+    wrapper = mountComponent({}, {
+      domain_strategy: 'custom',
+      domain_logo: null,
+    });
+
+    await nextTick();
+    expect(wrapper.find('.masthead').exists()).toBe(true);
+    expect(mastHeadProps).toHaveBeenCalled();
+  });
+
+  it('renders MastHead on canonical domain (expected behavior)', async () => {
+    wrapper = mountComponent({}, {
+      domain_strategy: 'canonical',
+      domain_logo: null,
+    });
+
+    await nextTick();
+    expect(wrapper.find('.masthead').exists()).toBe(true);
+  });
+
+  it('renders MastHead on custom domain with logo (works but shows default OTS chrome)', async () => {
+    // When domain_logo is set, MastHead renders the custom logo correctly.
+    // But the surrounding TransactionalHeader still uses the OTS layout/style.
+    wrapper = mountComponent({}, {
+      domain_strategy: 'custom',
+      domain_logo: 'https://cdn.example.com/acme-logo.png',
+    });
+
+    await nextTick();
+    expect(wrapper.find('.masthead').exists()).toBe(true);
+  });
+
+  it('does not pass domain-aware props to MastHead', async () => {
+    // TransactionalHeader passes layout props but NOT domain context.
+    // MastHead has to derive domain awareness from bootstrap store directly.
+    wrapper = mountComponent({
+      displayMasthead: true,
+      displayNavigation: false,
+    }, {
+      domain_strategy: 'custom',
+    });
+
+    await nextTick();
+    // MastHead receives layout props, but nothing domain-specific
+    const lastCall = mastHeadProps.mock.calls[0]?.[0];
+    expect(lastCall).toBeDefined();
+    expect(lastCall.displayNavigation).toBe(false);
+    // No logo prop override — MastHead uses its own fallback chain
+    expect(lastCall.logo).toBeUndefined();
+  });
+
+  it('hides MastHead when displayMasthead is false', async () => {
+    wrapper = mountComponent({
+      displayMasthead: false,
+    }, {
+      domain_strategy: 'custom',
+    });
+
+    await nextTick();
+    // v-if="displayMasthead" prevents MastHead from rendering
+    expect(wrapper.find('.masthead').exists()).toBe(false);
+  });
+
+  // This documents the leak: routes using TransactionalHeader on custom domains
+  // include /incoming, /feedback, /help, /pricing — they all show the OTS logo
+  // because TransactionalHeader → MastHead → DefaultLogo fallback chain
+  // doesn't check domain_strategy.
+  describe('Leak documentation: routes affected', () => {
+    it('would show default OTS logo on /incoming for custom domain guests', async () => {
+      // SecretLayout uses TransactionalHeader for unauthenticated users
+      // On a custom domain with no logo, this shows the OTS default logo
+      wrapper = mountComponent({}, {
+        domain_strategy: 'custom',
+        domain_logo: null,
+      });
+
+      await nextTick();
+      // MastHead renders — it will show DefaultLogo via its internal fallback
+      expect(wrapper.find('.masthead').exists()).toBe(true);
+      // The only way to prevent this is either:
+      // 1. Make TransactionalHeader domain-aware (like BrandedHeader)
+      // 2. Make MastHead check domain_strategy and suppress default logo
+      // 3. Use route beforeEnter guards to set displayMasthead=false
+    });
+  });
+});

--- a/src/tests/stores/receiptStore.spec.ts
+++ b/src/tests/stores/receiptStore.spec.ts
@@ -438,10 +438,10 @@ describe('receiptStore', () => {
       expect(store.apiMode).toBe('authenticated');
     });
 
-    it('$reset resets apiMode to authenticated', () => {
+    it('$reset preserves apiMode (avoids race condition on re-navigation)', () => {
       store.setApiMode('public');
       store.$reset();
-      expect(store.apiMode).toBe('authenticated');
+      expect(store.apiMode).toBe('public');
     });
 
     it('persists apiMode across multiple operations', async () => {

--- a/try/unit/models/v2/secret_try.rb
+++ b/try/unit/models/v2/secret_try.rb
@@ -80,9 +80,10 @@ receipt.destroy!
 
 ## Can set receipt to previewed state
 receipt, secret = Onetime::Receipt.spawn_pair 'anon', 3600, 'test secret'
+now = Familia.now.to_i
 receipt.previewed!
-[receipt.previewed, receipt.state]
-#=> [Familia.now.to_i, 'previewed']
+[receipt.previewed.between?(now, now + 1), receipt.state]
+#=> [true, 'previewed']
 
 # NOTE: The received method has been removed from the Secret model.
 # The secret no longer keeps a reference to the receipt.


### PR DESCRIPTION
## Summary

- Fix share domain URLs for guest users and receipt/burn flows on custom domains
- Hide footer links on branded homepage to avoid linking back to the main site
- Add centralized custom domain layout guard in router
- Simplify domain table cell to always link to brand settings
- Fix custom domain branding in SecretLayout guest path

## Test plan

- [ ] Verify branded homepage on custom domain hides footer links
- [ ] Verify receipt/burn URLs use share_domain on custom domains
- [ ] Verify guest users on custom domains see correct branding
- [ ] Verify domain table cell links to brand settings
- [ ] Run `pnpm test` — all frontend tests pass
- [ ] Run `pnpm run type-check` — no type errors