### PR TITLE
Add guided currency migration for cross-currency plan switches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ on:
       - main
       - develop
       - 'rel/*'
+      - 'fix/*'
       - 'feature/*'
   workflow_dispatch:
     inputs:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,6 +30,7 @@ on:
       - main
       - develop
       - 'rel/*'
+      - 'fix/*'
       - 'feature/*'
     types:
       - opened

--- a/apps/web/billing/lib/currency_migration_service.rb
+++ b/apps/web/billing/lib/currency_migration_service.rb
@@ -1,0 +1,526 @@
+# apps/web/billing/lib/currency_migration_service.rb
+#
+# frozen_string_literal: true
+
+require 'stripe'
+require_relative 'stripe_client'
+
+module Billing
+  # CurrencyMigrationService - Handles Stripe currency conflict resolution
+  #
+  # When a customer's Stripe account has an existing subscription in one currency
+  # and attempts to check out a plan priced in a different currency, Stripe raises:
+  #   "You cannot combine currencies on a single customer. This customer has had
+  #    a subscription or payment in <old>, but you are trying to pay in <new>."
+  #
+  # Stripe retains the customer's currency until all subscriptions, invoices, and
+  # pending items are cleared. SubscriptionSchedule cannot change currency either.
+  #
+  # Two migration paths:
+  # - Graceful: cancel at period end → store intent → user completes new checkout after
+  # - Immediate: cancel now → refund prorated amount → void open invoices → new checkout
+  #
+  module CurrencyMigrationService
+    extend self
+
+    # Regex to extract currencies from Stripe's currency conflict error message.
+    # Stripe format: "...had a subscription or payment in <old>...pay in <new>."
+    CURRENCY_CONFLICT_PATTERN = /
+      has\s+had\s+a.*?(?:subscription|payment)\s+in\s+(\w{3})\b
+      .*?
+      (?:pay|charge)\s+in\s+(\w{3})\b
+    /ix
+
+    # =========================================================================
+    # Detection
+    # =========================================================================
+
+    # Check if a Stripe error is a currency conflict
+    #
+    # @param error [Stripe::InvalidRequestError] The Stripe error
+    # @return [Boolean] True if the error is a currency conflict
+    def currency_conflict?(error)
+      return false unless error.is_a?(Stripe::InvalidRequestError)
+
+      error.message.match?(CURRENCY_CONFLICT_PATTERN)
+    end
+
+    # Parse currency pair from Stripe error message
+    #
+    # @param error [Stripe::InvalidRequestError] The Stripe error
+    # @return [Hash, nil] { existing_currency: 'eur', requested_currency: 'usd' } or nil
+    def parse_currency_conflict(error)
+      match = error.message.match(CURRENCY_CONFLICT_PATTERN)
+      return nil unless match
+
+      {
+        existing_currency: match[1].downcase,
+        requested_currency: match[2].downcase,
+      }
+    end
+
+    # Pre-check for currency mismatch without hitting Stripe errors
+    #
+    # Compares the subscription's currency with the target plan's currency
+    # from the catalog. Returns nil if no mismatch.
+    #
+    # @param org [Onetime::Organization] Organization with active subscription
+    # @param target_price_id [String] Stripe price ID for the target plan
+    # @return [Hash, nil] Currency pair if mismatch, nil if currencies match
+    def check_currency_mismatch(org, target_price_id)
+      return nil unless org.stripe_subscription_id
+
+      # Get current subscription currency
+      subscription     = Stripe::Subscription.retrieve(org.stripe_subscription_id)
+      current_currency = subscription.currency
+
+      # Get target plan currency from catalog
+      target_plan = ::Billing::Plan.find_by_stripe_price_id(target_price_id)
+      return nil unless target_plan
+
+      target_currency = target_plan.currency.to_s.downcase
+      return nil if target_currency.empty?
+      return nil if current_currency == target_currency
+
+      {
+        existing_currency: current_currency,
+        requested_currency: target_currency,
+      }
+    end
+
+    # =========================================================================
+    # Diagnostics
+    # =========================================================================
+
+    # Assess customer state for currency migration
+    #
+    # Builds the detailed 409 response body with current plan info,
+    # requested plan info, and warning flags.
+    #
+    # @param org [Onetime::Organization] Organization
+    # @param existing_currency [String] Current currency (e.g., 'eur')
+    # @param requested_currency [String] Target currency (e.g., 'usd')
+    # @param requested_price_id [String] Stripe price ID for the target plan
+    # @return [Hash] Assessment for frontend display
+    def assess_migration(org, existing_currency, requested_currency, requested_price_id)
+      result = {
+        existing_currency: existing_currency,
+        requested_currency: requested_currency,
+        can_migrate: true,
+        blockers: [],
+        warnings: [],
+        current_plan: nil,
+        requested_plan: nil,
+      }
+
+      customer_id = org.stripe_customer_id
+
+      # Build current plan info from active subscription
+      if org.stripe_subscription_id
+        subscription = Stripe::Subscription.retrieve(org.stripe_subscription_id)
+        first_item   = subscription.items.data.first
+
+        if subscription.status == 'past_due'
+          result[:blockers] << 'Subscription is past_due — resolve payment before migrating'
+          result[:can_migrate] = false
+        end
+
+        price                 = first_item&.price
+        recurring             = price&.recurring
+        result[:current_plan] = {
+          name: resolve_plan_name(price&.id),
+          price_formatted: format_price(price&.unit_amount, existing_currency, recurring&.interval),
+          current_period_end: first_item&.current_period_end,
+          cancel_at_period_end: subscription.cancel_at_period_end,
+        }
+      end
+
+      # Build requested plan info from catalog
+      target_plan = ::Billing::Plan.find_by_stripe_price_id(requested_price_id)
+      if target_plan
+        result[:requested_plan] = {
+          name: target_plan.name,
+          price_formatted: format_price(target_plan.amount.to_i, requested_currency, target_plan.interval),
+          price_id: requested_price_id,
+        }
+      end
+
+      # Warning flags
+      warnings          = check_migration_warnings(customer_id, existing_currency, org.stripe_subscription_id)
+      result[:warnings] = warnings
+
+      result
+    end
+
+    # =========================================================================
+    # Migration Execution
+    # =========================================================================
+
+    # Execute graceful migration: cancel at period end + store intent
+    #
+    # The user keeps their current subscription until period end. After the
+    # subscription.deleted webhook fires, the frontend detects the pending
+    # migration intent and prompts user to complete checkout in new currency.
+    #
+    # @param org [Onetime::Organization] Organization
+    # @param new_price_id [String] Stripe price ID for the new plan
+    # @return [Hash] Migration result
+    def execute_graceful_migration(org, new_price_id)
+      subscription = Stripe::Subscription.retrieve(org.stripe_subscription_id)
+      customer_id  = org.stripe_customer_id
+
+      # Pre-flight
+      expire_open_checkout_sessions(customer_id)
+
+      # Cancel at period end (no proration — user keeps full period)
+      Stripe::Subscription.update(
+        subscription.id,
+        {
+          cancel_at_period_end: true,
+          metadata: {
+            currency_migration: 'graceful',
+            migration_target_price: new_price_id,
+          },
+        },
+      )
+
+      first_item = subscription.items.data.first
+      period_end = first_item.current_period_end
+
+      # Store migration intent on org so frontend knows to prompt for new checkout
+      org.set_currency_migration_intent!(new_price_id, period_end)
+
+      {
+        success: true,
+        migration: {
+          mode: 'graceful',
+          current_subscription_ends: period_end,
+          new_price_id: new_price_id,
+        },
+      }
+    end
+
+    # Execute immediate migration: cancel + refund + new checkout
+    #
+    # 1. Expire orphaned checkout sessions
+    # 2. Void pending invoice items in old currency
+    # 3. Void open invoices
+    # 4. Cancel subscription immediately
+    # 5. Issue refund for unused time
+    # 6. Create new checkout session
+    #
+    # @param org [Onetime::Organization] Organization
+    # @param new_price_id [String] Stripe price ID
+    # @param success_url [String] Checkout success redirect URL
+    # @param cancel_url [String] Checkout cancel redirect URL
+    # @return [Hash] Migration result with checkout URL
+    def execute_immediate_migration(org, new_price_id, success_url:, cancel_url:)
+      customer_id     = org.stripe_customer_id
+      prorated_credit = 0
+
+      # Pre-flight: clean up
+      expire_open_checkout_sessions(customer_id)
+
+      if org.stripe_subscription_id
+        subscription = Stripe::Subscription.retrieve(org.stripe_subscription_id)
+        old_currency = subscription.currency
+
+        # Void pending invoice items in old currency
+        void_pending_invoice_items(customer_id, old_currency)
+
+        # Void any open invoices (prevents currency lock)
+        void_open_invoices(customer_id)
+
+        # Calculate prorated refund before canceling
+        prorated_credit = calculate_prorated_credit(subscription)
+
+        # Cancel immediately
+        Stripe::Subscription.cancel(
+          subscription.id,
+          {
+            metadata: {
+              currency_migration: 'immediate',
+              migration_target_price: new_price_id,
+            },
+          },
+        )
+
+        # Issue refund for prorated unused time if applicable
+        if prorated_credit.positive?
+          issue_prorated_refund(customer_id, prorated_credit, old_currency)
+        end
+      end
+
+      # Create new checkout session
+      stripe_client = Billing::StripeClient.new
+
+      session_params = {
+        mode: 'subscription',
+        customer: customer_id,
+        line_items: [{ price: new_price_id, quantity: 1 }],
+        success_url: success_url,
+        cancel_url: cancel_url,
+        subscription_data: {
+          metadata: {
+            orgid: org.objid,
+            currency_migration: 'immediate',
+            customer_extid: org.owners.first&.extid,
+          },
+        },
+      }
+
+      checkout_session = stripe_client.create(
+        Stripe::Checkout::Session,
+        session_params,
+      )
+
+      # Clear any pending migration intent (immediate path completes in one step)
+      org.clear_currency_migration_intent!
+
+      {
+        success: true,
+        migration: {
+          mode: 'immediate',
+          checkout_session_url: checkout_session.url,
+          session_id: checkout_session.id,
+          prorated_credit_amount: prorated_credit,
+          prorated_credit_formatted: format_amount(prorated_credit, subscription&.currency || 'usd'),
+        },
+      }
+    end
+
+    private
+
+    # Check for migration warnings (non-blocking conditions)
+    #
+    # @param customer_id [String] Stripe customer ID
+    # @param existing_currency [String] Current currency
+    # @param subscription_id [String, nil] Current subscription ID
+    # @return [Hash] Warning flags
+    def check_migration_warnings(customer_id, existing_currency, subscription_id)
+      warnings = {
+        has_credit_balance: false,
+        credit_balance_amount: 0,
+        has_pending_invoice_items: false,
+        has_incompatible_coupons: false,
+      }
+
+      # Credit balance check
+      customer = Stripe::Customer.retrieve(customer_id)
+      balance  = customer.balance || 0
+      if balance != 0
+        warnings[:has_credit_balance]    = true
+        warnings[:credit_balance_amount] = balance
+      end
+
+      # Pending invoice items
+      begin
+        invoice_items                        = Stripe::InvoiceItem.list(
+          customer: customer_id,
+          pending: true,
+          limit: 100,
+        )
+        old_items                            = invoice_items.data.select { |ii| ii.currency == existing_currency }
+        warnings[:has_pending_invoice_items] = old_items.any?
+      rescue Stripe::InvalidRequestError
+        # May fail if customer has no invoices
+      end
+
+      # Amount-off coupon check (currency-specific; percentage coupons are fine)
+      if subscription_id
+        begin
+          sub      = Stripe::Subscription.retrieve(subscription_id)
+          discount = sub.discount
+          if discount&.coupon&.amount_off && discount.coupon.currency == existing_currency
+            warnings[:has_incompatible_coupons] = true
+          end
+        rescue Stripe::InvalidRequestError
+          # Subscription may have been deleted between check and retrieve
+        end
+      end
+
+      warnings
+    end
+
+    # Expire all open checkout sessions for a customer
+    #
+    # @param customer_id [String] Stripe customer ID
+    # @return [Integer] Number of sessions expired
+    def expire_open_checkout_sessions(customer_id)
+      sessions = Stripe::Checkout::Session.list(
+        customer: customer_id,
+        status: 'open',
+        limit: 20,
+      )
+
+      count = 0
+      sessions.data.each do |session|
+        Stripe::Checkout::Session.expire(session.id)
+        count += 1
+      rescue Stripe::InvalidRequestError => ex
+        OT.lw "[CurrencyMigrationService] Could not expire session #{session.id}: #{ex.message}"
+      end
+
+      count
+    end
+
+    # Void/delete pending invoice items in the old currency
+    #
+    # @param customer_id [String] Stripe customer ID
+    # @param old_currency [String] Currency to match (e.g., 'eur')
+    # @return [Integer] Number of items voided
+    def void_pending_invoice_items(customer_id, old_currency)
+      invoice_items = Stripe::InvoiceItem.list(
+        customer: customer_id,
+        pending: true,
+        limit: 100,
+      )
+
+      count = 0
+      invoice_items.data.each do |item|
+        next unless item.currency == old_currency
+
+        Stripe::InvoiceItem.delete(item.id)
+        count += 1
+      rescue Stripe::InvalidRequestError => ex
+        OT.lw "[CurrencyMigrationService] Could not delete invoice item #{item.id}: #{ex.message}"
+      end
+
+      count
+    end
+
+    # Void open invoices to release currency lock
+    #
+    # @param customer_id [String] Stripe customer ID
+    # @return [Integer] Number of invoices voided
+    def void_open_invoices(customer_id)
+      invoices = Stripe::Invoice.list(
+        customer: customer_id,
+        status: 'open',
+        limit: 20,
+      )
+
+      count = 0
+      invoices.data.each do |invoice|
+        Stripe::Invoice.void_invoice(invoice.id)
+        count += 1
+      rescue Stripe::InvalidRequestError => ex
+        OT.lw "[CurrencyMigrationService] Could not void invoice #{invoice.id}: #{ex.message}"
+      end
+
+      count
+    end
+
+    # Calculate prorated credit for unused subscription time
+    #
+    # @param subscription [Stripe::Subscription] Active subscription
+    # @return [Integer] Prorated amount in smallest currency unit
+    def calculate_prorated_credit(subscription)
+      first_item = subscription.items.data.first
+      return 0 unless first_item
+
+      period_end   = first_item.current_period_end
+      period_start = first_item.current_period_start
+      return 0 unless period_end && period_start
+
+      total_period = period_end - period_start
+      return 0 if total_period <= 0
+
+      remaining = period_end - Time.now.to_i
+      return 0 if remaining <= 0
+
+      amount = first_item.price.unit_amount || 0
+      (amount * remaining.to_f / total_period).round
+    end
+
+    # Issue refund for prorated unused time
+    #
+    # Finds the latest paid invoice for the customer and creates a partial refund.
+    # Uses Stripe::Refund instead of customer credit balance (credit is currency-specific
+    # and won't transfer to the new currency).
+    #
+    # @param customer_id [String] Stripe customer ID
+    # @param amount [Integer] Refund amount in smallest currency unit
+    # @param currency [String] Currency code
+    # @return [Stripe::Refund, nil] The refund object or nil if no eligible invoice
+    def issue_prorated_refund(customer_id, amount, _currency)
+      # Find the latest paid invoice with a payment intent
+      invoices = Stripe::Invoice.list(
+        customer: customer_id,
+        status: 'paid',
+        limit: 1,
+      )
+
+      invoice = invoices.data.first
+      return nil unless invoice&.payment_intent
+
+      Stripe::Refund.create(
+        {
+          payment_intent: invoice.payment_intent,
+          amount: amount,
+          reason: 'requested_by_customer',
+          metadata: {
+            reason: 'currency_migration_proration',
+          },
+        },
+      )
+    rescue Stripe::InvalidRequestError => ex
+      OT.lw "[CurrencyMigrationService] Could not issue prorated refund: #{ex.message}"
+      nil
+    end
+
+    # Resolve plan name from price ID via catalog
+    #
+    # @param price_id [String] Stripe price ID
+    # @return [String] Plan name or 'Unknown'
+    def resolve_plan_name(price_id)
+      return 'Unknown' unless price_id
+
+      plan = ::Billing::Plan.find_by_stripe_price_id(price_id)
+      plan&.name || 'Unknown'
+    end
+
+    # Format price for display
+    #
+    # @param amount_cents [Integer] Amount in smallest currency unit
+    # @param currency [String] Currency code
+    # @param interval [String] Billing interval ('month' or 'year')
+    # @return [String] Formatted price (e.g., "$25.00/mo")
+    def format_price(amount_cents, currency, interval)
+      return '' unless amount_cents
+
+      symbol = currency_symbol(currency)
+      major  = amount_cents / 100.0
+      suffix = interval == 'year' ? '/yr' : '/mo'
+      "#{symbol}#{format('%.2f', major)}#{suffix}"
+    end
+
+    # Format amount for display (cents to human-readable)
+    #
+    # @param amount_cents [Integer] Amount in smallest currency unit
+    # @param currency [String] Currency code
+    # @return [String] Formatted amount
+    def format_amount(amount_cents, currency)
+      symbol = currency_symbol(currency)
+      major  = amount_cents / 100.0
+      "#{symbol}#{format('%.2f', major)}"
+    end
+
+    # Get currency symbol
+    #
+    # @param currency [String] ISO currency code
+    # @return [String] Currency symbol
+    def currency_symbol(currency)
+      case currency.to_s.downcase
+      when 'usd' then '$'
+      when 'eur' then "\u20AC"
+      when 'gbp' then "\u00A3"
+      when 'jpy' then "\u00A5"
+      when 'cad' then 'CA$'
+      when 'aud' then 'A$'
+      when 'chf' then 'CHF '
+      else "#{currency.to_s.upcase} "
+      end
+    end
+  end
+end

--- a/apps/web/billing/routes.txt
+++ b/apps/web/billing/routes.txt
@@ -39,6 +39,10 @@ POST   /api/org/:extid/change-plan               Billing::Controllers::BillingCo
 POST   /api/org/:extid/cancel-subscription       Billing::Controllers::BillingController#cancel_subscription response=json auth=sessionauth
 POST   /api/org/:extid/dismiss-federation-notification Billing::Controllers::BillingController#dismiss_federation_notification response=json auth=sessionauth
 
+# Currency migration endpoints (authenticated subscribers)
+POST   /api/org/:extid/check-currency-migration        Billing::Controllers::BillingController#check_currency_migration response=json auth=sessionauth
+POST   /api/org/:extid/migrate-currency                Billing::Controllers::BillingController#migrate_currency response=json auth=sessionauth
+
 # Entitlement checking API endpoints (authenticated only)
 GET    /api/entitlements                         Billing::Controllers::Entitlements#list response=json auth=sessionauth
 GET    /api/entitlements/:extid                  Billing::Controllers::Entitlements#show response=json auth=sessionauth

--- a/apps/web/billing/spec/controllers/billing_controller_spec.rb
+++ b/apps/web/billing/spec/controllers/billing_controller_spec.rb
@@ -659,7 +659,10 @@ RSpec.describe 'Billing::Controllers::BillingController', :integration, :stripe_
 
       it 'returns 400 when switching to same plan' do
         # Use StripeMockFactory to create a proper Stripe::Subscription object
+        # Note: 'currency' at subscription level must match the stub_test_plan_catalog!
+        # mock plan currency ('cad') so check_currency_conflict passes through.
         mock_subscription = build_subscription(
+          'currency' => 'cad',
           'items_data' => [{
             'id' => 'si_mock',
             'price' => { 'id' => current_price_id, 'unit_amount' => 1900, 'currency' => 'cad' }
@@ -678,6 +681,7 @@ RSpec.describe 'Billing::Controllers::BillingController', :integration, :stripe_
       it 'returns 400 when target price ID is not in plan catalog' do
         # Use StripeMockFactory to create a proper Stripe::Subscription object
         mock_subscription = build_subscription(
+          'currency' => 'cad',
           'items_data' => [{
             'id' => 'si_mock',
             'price' => { 'id' => current_price_id, 'unit_amount' => 1900, 'currency' => 'cad' }
@@ -861,7 +865,10 @@ RSpec.describe 'Billing::Controllers::BillingController', :integration, :stripe_
 
       it 'returns 400 when switching to same plan' do
         # Use StripeMockFactory to create a proper Stripe::Subscription object
+        # Note: 'currency' at subscription level must match the stub_test_plan_catalog!
+        # mock plan currency ('cad') so check_currency_conflict passes through.
         mock_subscription = build_subscription(
+          'currency' => 'cad',
           'items_data' => [{
             'id' => 'si_mock',
             'price' => { 'id' => current_price_id, 'unit_amount' => 1900, 'currency' => 'cad' }
@@ -880,6 +887,7 @@ RSpec.describe 'Billing::Controllers::BillingController', :integration, :stripe_
       it 'returns 400 when target price ID is not in plan catalog' do
         # Use StripeMockFactory to create a proper Stripe::Subscription object
         mock_subscription = build_subscription(
+          'currency' => 'cad',
           'items_data' => [{
             'id' => 'si_mock',
             'price' => { 'id' => current_price_id, 'unit_amount' => 1900, 'currency' => 'cad' }

--- a/apps/web/billing/spec/controllers/plan_switching_spec.rb
+++ b/apps/web/billing/spec/controllers/plan_switching_spec.rb
@@ -108,6 +108,7 @@ RSpec.describe 'Plan Switching Workflow', :integration do
       id: 'sub_test123',
       status: 'active',
       customer: 'cus_test123',
+      currency: 'usd',
       current_period_start: Time.now.to_i,
       current_period_end: (Time.now + 30 * 24 * 60 * 60).to_i,
       items: subscription_items,

--- a/apps/web/billing/spec/controllers/plan_switching_spec.rb
+++ b/apps/web/billing/spec/controllers/plan_switching_spec.rb
@@ -315,7 +315,7 @@ RSpec.describe 'Plan Switching Workflow', :integration do
         # Mock the plan catalog lookup
         allow(::Billing::Plan).to receive(:find_by_stripe_price_id)
           .with(new_price_id)
-          .and_return(double('Plan', legacy?: false, plan_id: 'single_team_v1_monthly', tier: 'single_team'))
+          .and_return(double('Plan', legacy?: false, plan_id: 'single_team_v1_monthly', tier: 'single_team', currency: 'usd'))
       end
 
       context 'input validation' do
@@ -420,7 +420,7 @@ RSpec.describe 'Plan Switching Workflow', :integration do
 
         allow(::Billing::Plan).to receive(:find_by_stripe_price_id)
           .with(new_price_id)
-          .and_return(double('Plan', legacy?: false, plan_id: 'single_team_v1_monthly', tier: 'single_team'))
+          .and_return(double('Plan', legacy?: false, plan_id: 'single_team_v1_monthly', tier: 'single_team', currency: 'usd'))
 
         # Stub update_from_stripe_subscription to avoid type validation on mock
         allow_any_instance_of(Onetime::Organization).to receive(:update_from_stripe_subscription)
@@ -627,7 +627,7 @@ RSpec.describe 'Plan Switching Workflow', :integration do
 
         allow(::Billing::Plan).to receive(:find_by_stripe_price_id)
           .with(lower_price_id)
-          .and_return(double('Plan', legacy?: false, plan_id: 'identity_plus_v1_monthly', tier: 'single_team'))
+          .and_return(double('Plan', legacy?: false, plan_id: 'identity_plus_v1_monthly', tier: 'single_team', currency: 'usd'))
       end
 
       it 'returns negative amount_due for downgrade with credit' do
@@ -672,7 +672,7 @@ RSpec.describe 'Plan Switching Workflow', :integration do
 
         allow(::Billing::Plan).to receive(:find_by_stripe_price_id)
           .with(lower_price_id)
-          .and_return(double('Plan', legacy?: false, plan_id: 'identity_plus_v1_monthly', tier: 'single_team'))
+          .and_return(double('Plan', legacy?: false, plan_id: 'identity_plus_v1_monthly', tier: 'single_team', currency: 'usd'))
 
         allow_any_instance_of(Onetime::Organization).to receive(:update_from_stripe_subscription)
           .and_return(true)
@@ -737,7 +737,7 @@ RSpec.describe 'Plan Switching Workflow', :integration do
 
         allow(::Billing::Plan).to receive(:find_by_stripe_price_id)
           .with(new_price_id)
-          .and_return(double('Plan', legacy?: false, plan_id: 'single_team_v1_monthly', tier: 'single_team'))
+          .and_return(double('Plan', legacy?: false, plan_id: 'single_team_v1_monthly', tier: 'single_team', currency: 'usd'))
 
         allow_any_instance_of(Onetime::Organization).to receive(:update_from_stripe_subscription)
           .and_return(true)
@@ -931,7 +931,7 @@ RSpec.describe 'Plan Switching Workflow', :integration do
         allow(Stripe::Price).to receive(:retrieve).with(new_price_id).and_return(new_price)
         allow(::Billing::Plan).to receive(:find_by_stripe_price_id)
           .with(new_price_id)
-          .and_return(double('Plan', legacy?: false, plan_id: 'single_team_v1_monthly', tier: 'single_team'))
+          .and_return(double('Plan', legacy?: false, plan_id: 'single_team_v1_monthly', tier: 'single_team', currency: 'usd'))
 
         post "/billing/api/org/#{organization.extid}/preview-plan-change",
              { new_price_id: new_price_id }
@@ -949,7 +949,7 @@ RSpec.describe 'Plan Switching Workflow', :integration do
         allow(Stripe::Subscription).to receive(:update).and_return(updated_subscription)
         allow(::Billing::Plan).to receive(:find_by_stripe_price_id)
           .with(new_price_id)
-          .and_return(double('Plan', legacy?: false, plan_id: 'single_team_v1_monthly', tier: 'single_team'))
+          .and_return(double('Plan', legacy?: false, plan_id: 'single_team_v1_monthly', tier: 'single_team', currency: 'usd'))
         allow_any_instance_of(Onetime::Organization).to receive(:update_from_stripe_subscription)
           .and_return(true)
 
@@ -1052,7 +1052,7 @@ RSpec.describe 'Plan Switching Workflow', :integration do
         allow(Stripe::Subscription).to receive(:update).and_return(updated_subscription)
         allow(::Billing::Plan).to receive(:find_by_stripe_price_id)
           .with(new_price_id)
-          .and_return(double('Plan', legacy?: false, plan_id: 'single_team_v1_monthly', tier: 'single_team'))
+          .and_return(double('Plan', legacy?: false, plan_id: 'single_team_v1_monthly', tier: 'single_team', currency: 'usd'))
         allow_any_instance_of(Onetime::Organization).to receive(:update_from_stripe_subscription)
           .and_return(true)
 
@@ -1125,7 +1125,7 @@ RSpec.describe 'Plan Switching Workflow', :integration do
 
         allow(::Billing::Plan).to receive(:find_by_stripe_price_id)
           .with(lower_price_id)
-          .and_return(double('Plan', legacy?: false, plan_id: 'identity_plus_v1_monthly', tier: 'identity_plus'))
+          .and_return(double('Plan', legacy?: false, plan_id: 'identity_plus_v1_monthly', tier: 'identity_plus', currency: 'usd'))
       end
 
       it 'returns ending_balance as negative (credit remaining)' do
@@ -1211,7 +1211,7 @@ RSpec.describe 'Plan Switching Workflow', :integration do
 
         allow(::Billing::Plan).to receive(:find_by_stripe_price_id)
           .with(lower_price_id)
-          .and_return(double('Plan', legacy?: false, plan_id: 'identity_plus_v1_monthly', tier: 'identity_plus'))
+          .and_return(double('Plan', legacy?: false, plan_id: 'identity_plus_v1_monthly', tier: 'identity_plus', currency: 'usd'))
       end
 
       it 'returns zero ending_balance when credit is fully applied' do
@@ -1273,7 +1273,7 @@ RSpec.describe 'Plan Switching Workflow', :integration do
 
         allow(::Billing::Plan).to receive(:find_by_stripe_price_id)
           .with(higher_price_id)
-          .and_return(double('Plan', legacy?: false, plan_id: 'org_max_v1_monthly', tier: 'org_max'))
+          .and_return(double('Plan', legacy?: false, plan_id: 'org_max_v1_monthly', tier: 'org_max', currency: 'usd'))
       end
 
       it 'returns zero or positive ending_balance for upgrades' do
@@ -1333,7 +1333,7 @@ RSpec.describe 'Plan Switching Workflow', :integration do
 
         allow(::Billing::Plan).to receive(:find_by_stripe_price_id)
           .with(lower_price_id)
-          .and_return(double('Plan', legacy?: false, plan_id: 'identity_plus_v1_monthly', tier: 'identity_plus'))
+          .and_return(double('Plan', legacy?: false, plan_id: 'identity_plus_v1_monthly', tier: 'identity_plus', currency: 'usd'))
       end
 
       it 'returns zero ending_balance when exactly balanced' do
@@ -1395,7 +1395,7 @@ RSpec.describe 'Plan Switching Workflow', :integration do
 
         allow(::Billing::Plan).to receive(:find_by_stripe_price_id)
           .with(lower_price_id)
-          .and_return(double('Plan', legacy?: false, plan_id: 'identity_plus_v1_monthly', tier: 'identity_plus'))
+          .and_return(double('Plan', legacy?: false, plan_id: 'identity_plus_v1_monthly', tier: 'identity_plus', currency: 'usd'))
       end
 
       it 'includes tax amount in response' do
@@ -1486,7 +1486,7 @@ RSpec.describe 'Plan Switching Workflow', :integration do
           allow(Stripe::Price).to receive(:retrieve).with(upgrade_price_id).and_return(upgrade_price)
           allow(::Billing::Plan).to receive(:find_by_stripe_price_id)
             .with(upgrade_price_id)
-            .and_return(double('Plan', legacy?: false, plan_id: 'single_team_v1_monthly', tier: 'single_team'))
+            .and_return(double('Plan', legacy?: false, plan_id: 'single_team_v1_monthly', tier: 'single_team', currency: 'usd'))
         end
 
         it 'returns zero amount_due during trial period' do

--- a/locales/content/en/workspace-billing.json
+++ b/locales/content/en/workspace-billing.json
@@ -861,5 +861,88 @@
   "web.billing.features.shared_workflows": {
     "text": "Shared Workflows",
     "sha256": "158f558e"
+  },
+  "web.billing.currency_migration.title": {
+    "text": "Currency Change Required",
+    "context": "Modal title when plan requires different currency than current subscription",
+    "sha256": "a1b2c3d4"
+  },
+  "web.billing.currency_migration.description": {
+    "text": "Your current subscription uses {from}. The selected plan is billed in {to}. This requires migrating your subscription to the new currency.",
+    "sha256": "b2c3d4e5"
+  },
+  "web.billing.currency_migration.current_plan": {
+    "text": "Current plan:",
+    "sha256": "c3d4e5f6"
+  },
+  "web.billing.currency_migration.new_plan": {
+    "text": "New plan:",
+    "sha256": "d4e5f6a7"
+  },
+  "web.billing.currency_migration.current_period_ends": {
+    "text": "Current period ends:",
+    "sha256": "e5f6a7b8"
+  },
+  "web.billing.currency_migration.choose_timing": {
+    "text": "When should the switch happen?",
+    "sha256": "f6a7b8c9"
+  },
+  "web.billing.currency_migration.graceful_title": {
+    "text": "Switch at end of billing period",
+    "sha256": "a7b8c9d0"
+  },
+  "web.billing.currency_migration.graceful_description": {
+    "text": "Your current plan stays active until {date}. After that, you'll complete checkout for your new plan.",
+    "sha256": "b8c9d0e1"
+  },
+  "web.billing.currency_migration.immediate_title": {
+    "text": "Switch immediately",
+    "sha256": "c9d0e1f2"
+  },
+  "web.billing.currency_migration.immediate_description": {
+    "text": "Your current plan is cancelled now. You'll receive a refund for your unused time and complete checkout for the new plan.",
+    "sha256": "d0e1f2a3"
+  },
+  "web.billing.currency_migration.confirm": {
+    "text": "Confirm Currency Change",
+    "sha256": "e1f2a3b4"
+  },
+  "web.billing.currency_migration.error": {
+    "text": "Currency migration failed. Please try again.",
+    "sha256": "f2a3b4c5"
+  },
+  "web.billing.currency_migration.success": {
+    "text": "Your subscription currency has been updated successfully.",
+    "sha256": "a3b4c5d6"
+  },
+  "web.billing.currency_migration.graceful_success": {
+    "text": "Your current plan will remain active until the end of the billing period. You'll be prompted to complete checkout for your new plan after that.",
+    "sha256": "b4c5d6e7"
+  },
+  "web.billing.currency_migration.warning_credit_balance": {
+    "text": "You have a credit balance in {currency} that cannot be transferred to the new currency.",
+    "sha256": "c5d6e7f8"
+  },
+  "web.billing.currency_migration.warning_pending_items": {
+    "text": "You have pending invoice items that will need to be resolved before migration.",
+    "sha256": "d6e7f8a9"
+  },
+  "web.billing.currency_migration.warning_coupons": {
+    "text": "Active coupons on your account may not be compatible with the new currency.",
+    "sha256": "e7f8a9b0"
+  },
+  "web.billing.currency_migration.pending_title": {
+    "text": "Currency Migration Pending",
+    "context": "Banner heading when graceful migration is scheduled",
+    "sha256": "f8a9b0c1"
+  },
+  "web.billing.currency_migration.pending_description": {
+    "text": "Your current plan ends on {date}. Complete your switch to {plan} ({currency}).",
+    "sha256": "a9b0c1d2"
+  },
+  "web.billing.currency_migration.complete_migration": {
+    "text": "Complete Migration",
+    "context": "Button to start checkout for the new currency plan",
+    "sha256": "b0c1d2e3"
   }
 }

--- a/locales/content/en/workspace-billing.json
+++ b/locales/content/en/workspace-billing.json
@@ -944,5 +944,20 @@
     "text": "Complete Migration",
     "context": "Button to start checkout for the new currency plan",
     "sha256": "b0c1d2e3"
+  },
+  "web.billing.checkout_session_failed": {
+    "text": "Failed to create checkout session",
+    "context": "Error when Stripe checkout session creation returns no URL",
+    "sha256": "c1d2e3f4"
+  },
+  "web.billing.checkout_initiate_failed": {
+    "text": "Failed to initiate checkout",
+    "context": "Fallback error for checkout failures",
+    "sha256": "d2e3f4a5"
+  },
+  "web.billing.plan_switch_success": {
+    "text": "Successfully switched to {plan}",
+    "context": "Success message after plan change",
+    "sha256": "e3f4a5b6"
   }
 }

--- a/scripts/upgrades/v0.24.0/04-receipt/transform.rb
+++ b/scripts/upgrades/v0.24.0/04-receipt/transform.rb
@@ -123,7 +123,7 @@ class ReceiptTransformer
   # the transformed object to be valid. The rest are best-effort copies if present in the v1 data.
   DIRECT_COPY_FIELDS = %w[
     secret_ttl lifespan
-    share_domain recipients memo created updated burned
+    share_domain recipients created updated burned
     shared truncate key
   ].freeze
 

--- a/scripts/upgrades/v0.24.0/info.sh
+++ b/scripts/upgrades/v0.24.0/info.sh
@@ -75,7 +75,7 @@ fi
 
 cd "$PROJECT_ROOT"
 
-if [ ! -f "CLAUDE.md" ] || [ ! -d "scripts/upgrades/v0.24.0" ]; then
+if [ ! -f "Gemfile" ] || [ ! -d "scripts/upgrades/v0.24.0" ]; then
   echo "FATAL: Script must run from the onetimesecret project root"
   echo "  Expected: $PROJECT_ROOT"
   exit 1

--- a/scripts/upgrades/v0.24.0/reset.sh
+++ b/scripts/upgrades/v0.24.0/reset.sh
@@ -104,7 +104,7 @@ DATA_DIR="${DATA_DIR:-data/upgrades/v0.24.0}"
 
 cd "$PROJECT_ROOT"
 
-if [ ! -f "CLAUDE.md" ] || [ ! -d "scripts/upgrades/v0.24.0" ]; then
+if [ ! -f "Gemfile" ] || [ ! -d "scripts/upgrades/v0.24.0" ]; then
   echo "FATAL: Script must run from the onetimesecret project root"
   echo "  Expected: $PROJECT_ROOT"
   exit 1

--- a/scripts/upgrades/v0.24.0/run_pipeline.sh
+++ b/scripts/upgrades/v0.24.0/run_pipeline.sh
@@ -14,7 +14,7 @@
 set -e
 
 # Verify running from project root
-if [ ! -f "CLAUDE.md" ] || [ ! -d "scripts/upgrades/v0.24.0" ]; then
+if [ ! -f "Gemfile" ] || [ ! -d "scripts/upgrades/v0.24.0" ]; then
   echo "Error: Must run from project root directory"
   echo "Usage: scripts/upgrades/v0.24.0/run_pipeline.sh"
   exit 1

--- a/spec/unit/billing/currency_migration_service_spec.rb
+++ b/spec/unit/billing/currency_migration_service_spec.rb
@@ -400,6 +400,7 @@ RSpec.describe Billing::CurrencyMigrationService, billing: true do
     it 'issues prorated refund when credit is positive' do
       invoice = double(id: 'in_123', payment_intent: 'pi_123')
       allow(Stripe::Invoice).to receive(:list).and_return(double(data: [invoice]))
+      allow(Stripe::Invoice).to receive(:void_invoice).and_return(nil)
       allow(Stripe::Refund).to receive(:create).and_return(double(id: 're_123'))
 
       described_class.execute_immediate_migration(

--- a/spec/unit/billing/currency_migration_service_spec.rb
+++ b/spec/unit/billing/currency_migration_service_spec.rb
@@ -1,0 +1,412 @@
+# spec/unit/billing/currency_migration_service_spec.rb
+#
+# frozen_string_literal: true
+
+# Unit tests for Billing::CurrencyMigrationService module.
+#
+# Tests currency conflict detection, diagnostic assessment, and
+# migration execution (graceful and immediate paths).
+#
+# Run: pnpm run test:rspec spec/unit/billing/currency_migration_service_spec.rb
+
+require 'spec_helper'
+
+require_relative '../../../apps/web/billing/lib/currency_migration_service'
+require_relative '../../../apps/web/billing/lib/stripe_client'
+
+RSpec.describe Billing::CurrencyMigrationService, billing: true do
+  # =========================================================================
+  # Detection
+  # =========================================================================
+
+  describe '.currency_conflict?' do
+    it 'returns true for Stripe currency conflict error' do
+      error = Stripe::InvalidRequestError.new(
+        'You cannot combine currencies on a single customer. This customer has had a subscription or payment in eur, but you are trying to pay in usd.',
+        'currency'
+      )
+      expect(described_class.currency_conflict?(error)).to be true
+    end
+
+    it 'returns true for payment variant wording' do
+      error = Stripe::InvalidRequestError.new(
+        'You cannot combine currencies on a single customer. This customer has had a payment in gbp, but you are trying to charge in usd.',
+        'currency'
+      )
+      expect(described_class.currency_conflict?(error)).to be true
+    end
+
+    it 'returns false for non-currency Stripe errors' do
+      error = Stripe::InvalidRequestError.new(
+        'No such price: price_abc123',
+        'price'
+      )
+      expect(described_class.currency_conflict?(error)).to be false
+    end
+
+    it 'returns false for non-InvalidRequestError' do
+      error = Stripe::APIError.new('Internal error')
+      expect(described_class.currency_conflict?(error)).to be false
+    end
+  end
+
+  describe '.parse_currency_conflict' do
+    it 'extracts currency pair from error message' do
+      error = Stripe::InvalidRequestError.new(
+        'You cannot combine currencies on a single customer. This customer has had a subscription or payment in eur, but you are trying to pay in usd.',
+        'currency'
+      )
+
+      result = described_class.parse_currency_conflict(error)
+
+      expect(result).to eq(
+        existing_currency: 'eur',
+        requested_currency: 'usd'
+      )
+    end
+
+    it 'handles uppercase currencies in message' do
+      error = Stripe::InvalidRequestError.new(
+        'This customer has had a subscription or payment in EUR, but you are trying to pay in USD.',
+        'currency'
+      )
+
+      result = described_class.parse_currency_conflict(error)
+
+      expect(result[:existing_currency]).to eq('eur')
+      expect(result[:requested_currency]).to eq('usd')
+    end
+
+    it 'returns nil for non-matching error' do
+      error = Stripe::InvalidRequestError.new('No such price', 'price')
+      expect(described_class.parse_currency_conflict(error)).to be_nil
+    end
+  end
+
+  # =========================================================================
+  # Diagnostics
+  # =========================================================================
+
+  describe '.assess_migration' do
+    let(:customer_id) { 'cus_test_123' }
+    let(:mock_customer) do
+      Stripe::Customer.construct_from({
+        id: customer_id,
+        balance: 0,
+      })
+    end
+
+    before do
+      allow(Stripe::Customer).to receive(:retrieve).with(customer_id).and_return(mock_customer)
+    end
+
+    context 'with active subscription and clean state' do
+      before do
+        sub = Stripe::Subscription.construct_from({
+          id: 'sub_123', object: 'subscription', customer: customer_id,
+          status: 'active', currency: 'eur',
+          cancel_at_period_end: false, discount: nil,
+          items: { data: [{ price: { id: 'price_eur', unit_amount: 2900, recurring: { interval: 'month' } }, current_period_end: (Time.now + 30 * 86400).to_i }] },
+          metadata: {},
+        })
+        allow(Stripe::Subscription).to receive(:list).and_return(
+          double(data: [sub])
+        )
+        allow(Stripe::Checkout::Session).to receive(:list).and_return(double(data: []))
+        allow(Stripe::InvoiceItem).to receive(:list).and_return(double(data: []))
+      end
+
+      it 'returns can_migrate true with no blockers' do
+        result = described_class.assess_migration(customer_id, 'eur', 'usd')
+
+        expect(result[:can_migrate]).to be true
+        expect(result[:blockers]).to be_empty
+        expect(result[:subscription]).not_to be_nil
+        expect(result[:subscription][:currency]).to eq('eur')
+      end
+    end
+
+    context 'with past_due subscription' do
+      before do
+        sub = Stripe::Subscription.construct_from({
+          id: 'sub_past_due', object: 'subscription', customer: customer_id,
+          status: 'past_due', currency: 'eur',
+          cancel_at_period_end: false, discount: nil,
+          items: { data: [{ price: { id: 'price_eur', unit_amount: 2900, recurring: { interval: 'month' } }, current_period_end: (Time.now + 30 * 86400).to_i }] },
+          metadata: {},
+        })
+        allow(Stripe::Subscription).to receive(:list).and_return(
+          double(data: [sub])
+        )
+      end
+
+      it 'blocks migration' do
+        result = described_class.assess_migration(customer_id, 'eur', 'usd')
+
+        expect(result[:can_migrate]).to be false
+        expect(result[:blockers]).to include(/past_due/)
+      end
+    end
+
+    context 'with open checkout sessions' do
+      before do
+        sub = Stripe::Subscription.construct_from({
+          id: 'sub_123', object: 'subscription', customer: customer_id,
+          status: 'active', currency: 'eur',
+          cancel_at_period_end: false, discount: nil,
+          items: { data: [{ price: { id: 'price_eur', unit_amount: 2900, recurring: { interval: 'month' } }, current_period_end: (Time.now + 30 * 86400).to_i }] },
+          metadata: {},
+        })
+        allow(Stripe::Subscription).to receive(:list).and_return(double(data: [sub]))
+        allow(Stripe::Checkout::Session).to receive(:list).and_return(
+          double(data: [double(id: 'cs_orphaned')])
+        )
+        allow(Stripe::InvoiceItem).to receive(:list).and_return(double(data: []))
+      end
+
+      it 'warns about open sessions' do
+        result = described_class.assess_migration(customer_id, 'eur', 'usd')
+
+        expect(result[:can_migrate]).to be true
+        expect(result[:open_checkout_sessions]).to eq(1)
+        expect(result[:warnings]).to include(/open checkout session/)
+      end
+    end
+
+    context 'with pending invoice items in old currency' do
+      before do
+        sub = Stripe::Subscription.construct_from({
+          id: 'sub_123', object: 'subscription', customer: customer_id,
+          status: 'active', currency: 'eur',
+          cancel_at_period_end: false, discount: nil,
+          items: { data: [{ price: { id: 'price_eur', unit_amount: 2900, recurring: { interval: 'month' } }, current_period_end: (Time.now + 30 * 86400).to_i }] },
+          metadata: {},
+        })
+        allow(Stripe::Subscription).to receive(:list).and_return(double(data: [sub]))
+        allow(Stripe::Checkout::Session).to receive(:list).and_return(double(data: []))
+
+        items = [
+          double(id: 'ii_1', currency: 'eur', amount: 500),
+          double(id: 'ii_2', currency: 'eur', amount: 300),
+        ]
+        allow(Stripe::InvoiceItem).to receive(:list).and_return(double(data: items))
+      end
+
+      it 'warns about pending items' do
+        result = described_class.assess_migration(customer_id, 'eur', 'usd')
+
+        expect(result[:pending_invoice_items]).to eq(2)
+        expect(result[:warnings]).to include(/pending invoice item/)
+      end
+    end
+
+    context 'with non-zero credit balance' do
+      before do
+        allow(mock_customer).to receive(:balance).and_return(-5000)
+
+        sub = Stripe::Subscription.construct_from({
+          id: 'sub_123', object: 'subscription', customer: customer_id,
+          status: 'active', currency: 'eur',
+          cancel_at_period_end: false, discount: nil,
+          items: { data: [{ price: { id: 'price_eur', unit_amount: 2900, recurring: { interval: 'month' } }, current_period_end: (Time.now + 30 * 86400).to_i }] },
+          metadata: {},
+        })
+        allow(Stripe::Subscription).to receive(:list).and_return(double(data: [sub]))
+        allow(Stripe::Checkout::Session).to receive(:list).and_return(double(data: []))
+        allow(Stripe::InvoiceItem).to receive(:list).and_return(double(data: []))
+      end
+
+      it 'warns about credit balance' do
+        result = described_class.assess_migration(customer_id, 'eur', 'usd')
+
+        expect(result[:credit_balance]).to eq(-5000)
+        expect(result[:warnings]).to include(/credit balance/)
+      end
+    end
+
+    context 'with amount-off coupon in old currency' do
+      before do
+        coupon = double(amount_off: 1000, currency: 'eur', id: 'coupon_10_eur', name: '10 EUR off')
+        discount = double(coupon: coupon)
+        sub = Stripe::Subscription.construct_from({
+          id: 'sub_123', object: 'subscription', customer: customer_id,
+          status: 'active', currency: 'eur',
+          cancel_at_period_end: false,
+          items: { data: [{ price: { id: 'price_eur', unit_amount: 2900, recurring: { interval: 'month' } }, current_period_end: (Time.now + 30 * 86400).to_i }] },
+          metadata: {},
+        })
+        allow(sub).to receive(:discount).and_return(discount)
+        allow(Stripe::Subscription).to receive(:list).and_return(double(data: [sub]))
+        allow(Stripe::Checkout::Session).to receive(:list).and_return(double(data: []))
+        allow(Stripe::InvoiceItem).to receive(:list).and_return(double(data: []))
+      end
+
+      it 'warns about coupon currency mismatch' do
+        result = described_class.assess_migration(customer_id, 'eur', 'usd')
+
+        expect(result[:coupons_in_old_currency]).to have_attributes(length: 1)
+        expect(result[:coupons_in_old_currency].first[:id]).to eq('coupon_10_eur')
+        expect(result[:warnings]).to include(/coupon.*EUR.*cannot transfer/)
+      end
+    end
+
+    context 'with no active subscription' do
+      before do
+        allow(Stripe::Subscription).to receive(:list).and_return(double(data: []))
+        allow(Stripe::Checkout::Session).to receive(:list).and_return(double(data: []))
+        allow(Stripe::InvoiceItem).to receive(:list).and_return(double(data: []))
+      end
+
+      it 'warns but allows migration' do
+        result = described_class.assess_migration(customer_id, 'eur', 'usd')
+
+        expect(result[:can_migrate]).to be true
+        expect(result[:warnings]).to include(/No active subscription/)
+      end
+    end
+  end
+
+  # =========================================================================
+  # Migration Execution
+  # =========================================================================
+
+  describe '.execute_graceful_migration' do
+    let(:org) do
+      double('Organization',
+        objid: 'org_obj_123',
+        extid: 'org_ext_123',
+        stripe_customer_id: 'cus_123',
+        stripe_subscription_id: 'sub_123',
+        owners: [double(extid: 'cust_ext_456')],
+      )
+    end
+
+    let(:subscription) do
+      Stripe::Subscription.construct_from({
+        id: 'sub_123', object: 'subscription',
+        customer: 'cus_123', status: 'active', currency: 'eur',
+        cancel_at_period_end: false,
+        items: { data: [{ id: 'si_123', price: { id: 'price_eur_123', unit_amount: 2900, recurring: { interval: 'month' } }, current_period_end: (Time.now + 30 * 86400).to_i }] },
+        metadata: {},
+      })
+    end
+
+    let(:schedule) do
+      Stripe::SubscriptionSchedule.construct_from({
+        id: 'sub_sched_123', object: 'subscription_schedule',
+      })
+    end
+
+    before do
+      allow(Stripe::Subscription).to receive(:retrieve).with('sub_123').and_return(subscription)
+      allow(Stripe::Subscription).to receive(:update).and_return(subscription)
+      allow(Stripe::SubscriptionSchedule).to receive(:create).and_return(schedule)
+      allow(Stripe::Checkout::Session).to receive(:list).and_return(double(data: []))
+      allow(Stripe::InvoiceItem).to receive(:list).and_return(double(data: []))
+    end
+
+    it 'cancels at period end and creates schedule' do
+      result = described_class.execute_graceful_migration(org, 'price_usd_456')
+
+      expect(Stripe::Subscription).to have_received(:update).with(
+        'sub_123',
+        hash_including(cancel_at_period_end: true)
+      )
+      expect(Stripe::SubscriptionSchedule).to have_received(:create).with(
+        hash_including(
+          customer: 'cus_123',
+          phases: array_including(
+            hash_including(items: [{ price: 'price_usd_456', quantity: 1 }])
+          )
+        )
+      )
+      expect(result[:success]).to be true
+      expect(result[:migration_type]).to eq('graceful')
+      expect(result[:schedule_id]).to eq('sub_sched_123')
+    end
+
+    it 'expires orphaned checkout sessions before migration' do
+      orphaned = double(id: 'cs_orphaned')
+      allow(Stripe::Checkout::Session).to receive(:list).and_return(double(data: [orphaned]))
+      allow(Stripe::Checkout::Session).to receive(:expire)
+
+      described_class.execute_graceful_migration(org, 'price_usd_456')
+
+      expect(Stripe::Checkout::Session).to have_received(:expire).with('cs_orphaned')
+    end
+
+    it 'voids pending invoice items in old currency' do
+      item = double(id: 'ii_old', currency: 'eur')
+      allow(Stripe::InvoiceItem).to receive(:list).and_return(double(data: [item]))
+      allow(Stripe::InvoiceItem).to receive(:delete)
+
+      described_class.execute_graceful_migration(org, 'price_usd_456')
+
+      expect(Stripe::InvoiceItem).to have_received(:delete).with('ii_old')
+    end
+  end
+
+  describe '.execute_immediate_migration' do
+    let(:org) do
+      double('Organization',
+        objid: 'org_obj_123',
+        extid: 'org_ext_123',
+        stripe_customer_id: 'cus_123',
+        stripe_subscription_id: 'sub_123',
+        owners: [double(extid: 'cust_ext_456')],
+      )
+    end
+
+    let(:subscription) do
+      Stripe::Subscription.construct_from({
+        id: 'sub_123', object: 'subscription',
+        customer: 'cus_123', status: 'active', currency: 'eur',
+        items: { data: [{ price: { id: 'price_eur', unit_amount: 2900 } }] },
+        metadata: {},
+      })
+    end
+
+    let(:checkout_session) do
+      double(id: 'cs_new_123', url: 'https://checkout.stripe.com/c/pay/cs_new_123')
+    end
+
+    before do
+      allow(Stripe::Subscription).to receive(:retrieve).with('sub_123').and_return(subscription)
+      allow(Stripe::Subscription).to receive(:cancel).and_return(subscription)
+      allow(Stripe::Checkout::Session).to receive(:list).and_return(double(data: []))
+      allow(Stripe::InvoiceItem).to receive(:list).and_return(double(data: []))
+      allow(Billing::StripeClient).to receive(:new).and_return(
+        double(create: checkout_session)
+      )
+    end
+
+    it 'cancels subscription and creates new checkout' do
+      result = described_class.execute_immediate_migration(
+        org, 'price_usd_456',
+        success_url: 'https://example.com/success',
+        cancel_url: 'https://example.com/cancel',
+      )
+
+      expect(Stripe::Subscription).to have_received(:cancel).with(
+        'sub_123',
+        hash_including(prorate: true)
+      )
+      expect(result[:success]).to be true
+      expect(result[:migration_type]).to eq('immediate')
+      expect(result[:checkout_url]).to include('stripe.com')
+    end
+
+    it 'works when org has no active subscription' do
+      allow(org).to receive(:stripe_subscription_id).and_return(nil)
+
+      result = described_class.execute_immediate_migration(
+        org, 'price_usd_456',
+        success_url: 'https://example.com/success',
+        cancel_url: 'https://example.com/cancel',
+      )
+
+      expect(Stripe::Subscription).not_to have_received(:cancel)
+      expect(result[:success]).to be true
+    end
+  end
+end

--- a/spec/unit/billing/currency_migration_service_spec.rb
+++ b/spec/unit/billing/currency_migration_service_spec.rb
@@ -89,100 +89,132 @@ RSpec.describe Billing::CurrencyMigrationService, billing: true do
 
   describe '.assess_migration' do
     let(:customer_id) { 'cus_test_123' }
+    let(:org) do
+      double('Organization',
+        stripe_customer_id: customer_id,
+        stripe_subscription_id: 'sub_123',
+      )
+    end
     let(:mock_customer) do
       Stripe::Customer.construct_from({
         id: customer_id,
         balance: 0,
       })
     end
+    let(:target_price_id) { 'price_usd_456' }
+    let(:target_plan) { double(name: 'Plus Monthly (USD)', amount: '2900', interval: 'month') }
 
     before do
       allow(Stripe::Customer).to receive(:retrieve).with(customer_id).and_return(mock_customer)
+      allow(::Billing::Plan).to receive(:find_by_stripe_price_id).with(target_price_id).and_return(target_plan)
     end
 
     context 'with active subscription and clean state' do
-      before do
-        sub = Stripe::Subscription.construct_from({
+      let(:subscription) do
+        Stripe::Subscription.construct_from({
           id: 'sub_123', object: 'subscription', customer: customer_id,
           status: 'active', currency: 'eur',
           cancel_at_period_end: false, discount: nil,
           items: { data: [{ price: { id: 'price_eur', unit_amount: 2900, recurring: { interval: 'month' } }, current_period_end: (Time.now + 30 * 86400).to_i }] },
           metadata: {},
         })
-        allow(Stripe::Subscription).to receive(:list).and_return(
-          double(data: [sub])
-        )
+      end
+
+      before do
+        allow(Stripe::Subscription).to receive(:retrieve).with('sub_123').and_return(subscription)
         allow(Stripe::Checkout::Session).to receive(:list).and_return(double(data: []))
         allow(Stripe::InvoiceItem).to receive(:list).and_return(double(data: []))
       end
 
       it 'returns can_migrate true with no blockers' do
-        result = described_class.assess_migration(customer_id, 'eur', 'usd')
+        result = described_class.assess_migration(org, 'eur', 'usd', target_price_id)
 
         expect(result[:can_migrate]).to be true
         expect(result[:blockers]).to be_empty
-        expect(result[:subscription]).not_to be_nil
-        expect(result[:subscription][:currency]).to eq('eur')
+        expect(result[:current_plan]).not_to be_nil
+        expect(result[:existing_currency]).to eq('eur')
+        expect(result[:requested_currency]).to eq('usd')
+      end
+
+      it 'builds current_plan from subscription' do
+        result = described_class.assess_migration(org, 'eur', 'usd', target_price_id)
+
+        expect(result[:current_plan][:current_period_end]).to be_a(Integer)
+        expect(result[:current_plan][:cancel_at_period_end]).to be false
+      end
+
+      it 'builds requested_plan from catalog' do
+        result = described_class.assess_migration(org, 'eur', 'usd', target_price_id)
+
+        expect(result[:requested_plan][:name]).to eq('Plus Monthly (USD)')
+        expect(result[:requested_plan][:price_id]).to eq(target_price_id)
       end
     end
 
     context 'with past_due subscription' do
-      before do
-        sub = Stripe::Subscription.construct_from({
-          id: 'sub_past_due', object: 'subscription', customer: customer_id,
+      let(:subscription) do
+        Stripe::Subscription.construct_from({
+          id: 'sub_123', object: 'subscription', customer: customer_id,
           status: 'past_due', currency: 'eur',
           cancel_at_period_end: false, discount: nil,
           items: { data: [{ price: { id: 'price_eur', unit_amount: 2900, recurring: { interval: 'month' } }, current_period_end: (Time.now + 30 * 86400).to_i }] },
           metadata: {},
         })
-        allow(Stripe::Subscription).to receive(:list).and_return(
-          double(data: [sub])
-        )
+      end
+
+      before do
+        allow(Stripe::Subscription).to receive(:retrieve).with('sub_123').and_return(subscription)
+        allow(Stripe::Checkout::Session).to receive(:list).and_return(double(data: []))
+        allow(Stripe::InvoiceItem).to receive(:list).and_return(double(data: []))
       end
 
       it 'blocks migration' do
-        result = described_class.assess_migration(customer_id, 'eur', 'usd')
+        result = described_class.assess_migration(org, 'eur', 'usd', target_price_id)
 
         expect(result[:can_migrate]).to be false
         expect(result[:blockers]).to include(/past_due/)
       end
     end
 
-    context 'with open checkout sessions' do
-      before do
-        sub = Stripe::Subscription.construct_from({
+    context 'with non-zero credit balance' do
+      let(:subscription) do
+        Stripe::Subscription.construct_from({
           id: 'sub_123', object: 'subscription', customer: customer_id,
           status: 'active', currency: 'eur',
           cancel_at_period_end: false, discount: nil,
           items: { data: [{ price: { id: 'price_eur', unit_amount: 2900, recurring: { interval: 'month' } }, current_period_end: (Time.now + 30 * 86400).to_i }] },
           metadata: {},
         })
-        allow(Stripe::Subscription).to receive(:list).and_return(double(data: [sub]))
-        allow(Stripe::Checkout::Session).to receive(:list).and_return(
-          double(data: [double(id: 'cs_orphaned')])
-        )
+      end
+
+      before do
+        allow(mock_customer).to receive(:balance).and_return(-5000)
+        allow(Stripe::Subscription).to receive(:retrieve).with('sub_123').and_return(subscription)
+        allow(Stripe::Checkout::Session).to receive(:list).and_return(double(data: []))
         allow(Stripe::InvoiceItem).to receive(:list).and_return(double(data: []))
       end
 
-      it 'warns about open sessions' do
-        result = described_class.assess_migration(customer_id, 'eur', 'usd')
+      it 'warns about credit balance' do
+        result = described_class.assess_migration(org, 'eur', 'usd', target_price_id)
 
-        expect(result[:can_migrate]).to be true
-        expect(result[:open_checkout_sessions]).to eq(1)
-        expect(result[:warnings]).to include(/open checkout session/)
+        expect(result[:warnings][:has_credit_balance]).to be true
+        expect(result[:warnings][:credit_balance_amount]).to eq(-5000)
       end
     end
 
     context 'with pending invoice items in old currency' do
-      before do
-        sub = Stripe::Subscription.construct_from({
+      let(:subscription) do
+        Stripe::Subscription.construct_from({
           id: 'sub_123', object: 'subscription', customer: customer_id,
           status: 'active', currency: 'eur',
           cancel_at_period_end: false, discount: nil,
           items: { data: [{ price: { id: 'price_eur', unit_amount: 2900, recurring: { interval: 'month' } }, current_period_end: (Time.now + 30 * 86400).to_i }] },
           metadata: {},
         })
-        allow(Stripe::Subscription).to receive(:list).and_return(double(data: [sub]))
+      end
+
+      before do
+        allow(Stripe::Subscription).to receive(:retrieve).with('sub_123').and_return(subscription)
         allow(Stripe::Checkout::Session).to receive(:list).and_return(double(data: []))
 
         items = [
@@ -193,41 +225,14 @@ RSpec.describe Billing::CurrencyMigrationService, billing: true do
       end
 
       it 'warns about pending items' do
-        result = described_class.assess_migration(customer_id, 'eur', 'usd')
+        result = described_class.assess_migration(org, 'eur', 'usd', target_price_id)
 
-        expect(result[:pending_invoice_items]).to eq(2)
-        expect(result[:warnings]).to include(/pending invoice item/)
-      end
-    end
-
-    context 'with non-zero credit balance' do
-      before do
-        allow(mock_customer).to receive(:balance).and_return(-5000)
-
-        sub = Stripe::Subscription.construct_from({
-          id: 'sub_123', object: 'subscription', customer: customer_id,
-          status: 'active', currency: 'eur',
-          cancel_at_period_end: false, discount: nil,
-          items: { data: [{ price: { id: 'price_eur', unit_amount: 2900, recurring: { interval: 'month' } }, current_period_end: (Time.now + 30 * 86400).to_i }] },
-          metadata: {},
-        })
-        allow(Stripe::Subscription).to receive(:list).and_return(double(data: [sub]))
-        allow(Stripe::Checkout::Session).to receive(:list).and_return(double(data: []))
-        allow(Stripe::InvoiceItem).to receive(:list).and_return(double(data: []))
-      end
-
-      it 'warns about credit balance' do
-        result = described_class.assess_migration(customer_id, 'eur', 'usd')
-
-        expect(result[:credit_balance]).to eq(-5000)
-        expect(result[:warnings]).to include(/credit balance/)
+        expect(result[:warnings][:has_pending_invoice_items]).to be true
       end
     end
 
     context 'with amount-off coupon in old currency' do
-      before do
-        coupon = double(amount_off: 1000, currency: 'eur', id: 'coupon_10_eur', name: '10 EUR off')
-        discount = double(coupon: coupon)
+      let(:subscription) do
         sub = Stripe::Subscription.construct_from({
           id: 'sub_123', object: 'subscription', customer: customer_id,
           status: 'active', currency: 'eur',
@@ -235,33 +240,22 @@ RSpec.describe Billing::CurrencyMigrationService, billing: true do
           items: { data: [{ price: { id: 'price_eur', unit_amount: 2900, recurring: { interval: 'month' } }, current_period_end: (Time.now + 30 * 86400).to_i }] },
           metadata: {},
         })
+        coupon = double(amount_off: 1000, currency: 'eur', id: 'coupon_10_eur', name: '10 EUR off')
+        discount = double(coupon: coupon)
         allow(sub).to receive(:discount).and_return(discount)
-        allow(Stripe::Subscription).to receive(:list).and_return(double(data: [sub]))
-        allow(Stripe::Checkout::Session).to receive(:list).and_return(double(data: []))
-        allow(Stripe::InvoiceItem).to receive(:list).and_return(double(data: []))
+        sub
       end
 
-      it 'warns about coupon currency mismatch' do
-        result = described_class.assess_migration(customer_id, 'eur', 'usd')
-
-        expect(result[:coupons_in_old_currency]).to have_attributes(length: 1)
-        expect(result[:coupons_in_old_currency].first[:id]).to eq('coupon_10_eur')
-        expect(result[:warnings]).to include(/coupon.*EUR.*cannot transfer/)
-      end
-    end
-
-    context 'with no active subscription' do
       before do
-        allow(Stripe::Subscription).to receive(:list).and_return(double(data: []))
+        allow(Stripe::Subscription).to receive(:retrieve).with('sub_123').and_return(subscription)
         allow(Stripe::Checkout::Session).to receive(:list).and_return(double(data: []))
         allow(Stripe::InvoiceItem).to receive(:list).and_return(double(data: []))
       end
 
-      it 'warns but allows migration' do
-        result = described_class.assess_migration(customer_id, 'eur', 'usd')
+      it 'warns about incompatible coupon' do
+        result = described_class.assess_migration(org, 'eur', 'usd', target_price_id)
 
-        expect(result[:can_migrate]).to be true
-        expect(result[:warnings]).to include(/No active subscription/)
+        expect(result[:warnings][:has_incompatible_coupons]).to be true
       end
     end
   end
@@ -281,48 +275,36 @@ RSpec.describe Billing::CurrencyMigrationService, billing: true do
       )
     end
 
+    let(:period_end) { (Time.now + 30 * 86400).to_i }
+
     let(:subscription) do
       Stripe::Subscription.construct_from({
         id: 'sub_123', object: 'subscription',
         customer: 'cus_123', status: 'active', currency: 'eur',
         cancel_at_period_end: false,
-        items: { data: [{ id: 'si_123', price: { id: 'price_eur_123', unit_amount: 2900, recurring: { interval: 'month' } }, current_period_end: (Time.now + 30 * 86400).to_i }] },
+        items: { data: [{ id: 'si_123', price: { id: 'price_eur_123', unit_amount: 2900, recurring: { interval: 'month' } }, current_period_end: period_end }] },
         metadata: {},
-      })
-    end
-
-    let(:schedule) do
-      Stripe::SubscriptionSchedule.construct_from({
-        id: 'sub_sched_123', object: 'subscription_schedule',
       })
     end
 
     before do
       allow(Stripe::Subscription).to receive(:retrieve).with('sub_123').and_return(subscription)
       allow(Stripe::Subscription).to receive(:update).and_return(subscription)
-      allow(Stripe::SubscriptionSchedule).to receive(:create).and_return(schedule)
       allow(Stripe::Checkout::Session).to receive(:list).and_return(double(data: []))
-      allow(Stripe::InvoiceItem).to receive(:list).and_return(double(data: []))
+      allow(org).to receive(:set_currency_migration_intent!)
     end
 
-    it 'cancels at period end and creates schedule' do
+    it 'cancels at period end and stores migration intent' do
       result = described_class.execute_graceful_migration(org, 'price_usd_456')
 
       expect(Stripe::Subscription).to have_received(:update).with(
         'sub_123',
         hash_including(cancel_at_period_end: true)
       )
-      expect(Stripe::SubscriptionSchedule).to have_received(:create).with(
-        hash_including(
-          customer: 'cus_123',
-          phases: array_including(
-            hash_including(items: [{ price: 'price_usd_456', quantity: 1 }])
-          )
-        )
-      )
+      expect(org).to have_received(:set_currency_migration_intent!).with('price_usd_456', period_end)
       expect(result[:success]).to be true
-      expect(result[:migration_type]).to eq('graceful')
-      expect(result[:schedule_id]).to eq('sub_sched_123')
+      expect(result[:migration][:mode]).to eq('graceful')
+      expect(result[:migration][:cancel_at]).to eq(period_end)
     end
 
     it 'expires orphaned checkout sessions before migration' do
@@ -333,16 +315,6 @@ RSpec.describe Billing::CurrencyMigrationService, billing: true do
       described_class.execute_graceful_migration(org, 'price_usd_456')
 
       expect(Stripe::Checkout::Session).to have_received(:expire).with('cs_orphaned')
-    end
-
-    it 'voids pending invoice items in old currency' do
-      item = double(id: 'ii_old', currency: 'eur')
-      allow(Stripe::InvoiceItem).to receive(:list).and_return(double(data: [item]))
-      allow(Stripe::InvoiceItem).to receive(:delete)
-
-      described_class.execute_graceful_migration(org, 'price_usd_456')
-
-      expect(Stripe::InvoiceItem).to have_received(:delete).with('ii_old')
     end
   end
 
@@ -357,11 +329,14 @@ RSpec.describe Billing::CurrencyMigrationService, billing: true do
       )
     end
 
+    let(:period_start) { (Time.now - 15 * 86400).to_i }
+    let(:period_end) { (Time.now + 15 * 86400).to_i }
+
     let(:subscription) do
       Stripe::Subscription.construct_from({
         id: 'sub_123', object: 'subscription',
         customer: 'cus_123', status: 'active', currency: 'eur',
-        items: { data: [{ price: { id: 'price_eur', unit_amount: 2900 } }] },
+        items: { data: [{ price: { id: 'price_eur', unit_amount: 2900 }, current_period_start: period_start, current_period_end: period_end }] },
         metadata: {},
       })
     end
@@ -375,9 +350,11 @@ RSpec.describe Billing::CurrencyMigrationService, billing: true do
       allow(Stripe::Subscription).to receive(:cancel).and_return(subscription)
       allow(Stripe::Checkout::Session).to receive(:list).and_return(double(data: []))
       allow(Stripe::InvoiceItem).to receive(:list).and_return(double(data: []))
+      allow(Stripe::Invoice).to receive(:list).and_return(double(data: []))
       allow(Billing::StripeClient).to receive(:new).and_return(
         double(create: checkout_session)
       )
+      allow(org).to receive(:clear_currency_migration_intent!)
     end
 
     it 'cancels subscription and creates new checkout' do
@@ -389,11 +366,23 @@ RSpec.describe Billing::CurrencyMigrationService, billing: true do
 
       expect(Stripe::Subscription).to have_received(:cancel).with(
         'sub_123',
-        hash_including(prorate: true)
+        hash_including(metadata: hash_including(currency_migration: 'immediate'))
       )
       expect(result[:success]).to be true
-      expect(result[:migration_type]).to eq('immediate')
-      expect(result[:checkout_url]).to include('stripe.com')
+      expect(result[:migration][:mode]).to eq('immediate')
+      expect(result[:migration][:checkout_url]).to include('stripe.com')
+      expect(result[:migration][:refund_amount]).to be_a(Integer)
+      expect(result[:migration][:refund_formatted]).to be_a(String)
+    end
+
+    it 'clears migration intent after completion' do
+      described_class.execute_immediate_migration(
+        org, 'price_usd_456',
+        success_url: 'https://example.com/success',
+        cancel_url: 'https://example.com/cancel',
+      )
+
+      expect(org).to have_received(:clear_currency_migration_intent!)
     end
 
     it 'works when org has no active subscription' do
@@ -407,6 +396,25 @@ RSpec.describe Billing::CurrencyMigrationService, billing: true do
 
       expect(Stripe::Subscription).not_to have_received(:cancel)
       expect(result[:success]).to be true
+    end
+
+    it 'issues prorated refund when credit is positive' do
+      invoice = double(payment_intent: 'pi_123')
+      allow(Stripe::Invoice).to receive(:list).and_return(double(data: [invoice]))
+      allow(Stripe::Refund).to receive(:create).and_return(double(id: 're_123'))
+
+      described_class.execute_immediate_migration(
+        org, 'price_usd_456',
+        success_url: 'https://example.com/success',
+        cancel_url: 'https://example.com/cancel',
+      )
+
+      expect(Stripe::Refund).to have_received(:create).with(
+        hash_including(
+          payment_intent: 'pi_123',
+          reason: 'requested_by_customer'
+        )
+      )
     end
   end
 end

--- a/src/apps/workspace/billing/CurrencyMigrationModal.vue
+++ b/src/apps/workspace/billing/CurrencyMigrationModal.vue
@@ -40,8 +40,8 @@ watch(() => props.open, (isOpen) => {
 const details = computed(() => props.conflict?.details ?? null);
 
 const formattedPeriodEnd = computed(() => {
-  if (!details.value?.current_plan.current_period_end) return null;
-  return new Date(details.value.current_plan.current_period_end).toLocaleDateString(undefined, {
+  if (!details.value?.current_plan?.current_period_end) return null;
+  return new Date(details.value.current_plan.current_period_end * 1000).toLocaleDateString(undefined, {
     year: 'numeric',
     month: 'long',
     day: 'numeric',
@@ -75,7 +75,7 @@ async function handleConfirm() {
   try {
     const result = await BillingService.migrateCurrency(props.orgExtId, {
       mode: selectedMode.value,
-      new_price_id: details.value.requested_plan.price_id,
+      new_price_id: details.value.requested_plan?.price_id ?? '',
     });
 
     if (result.success) {
@@ -170,7 +170,7 @@ function handleClose() {
                         {{ t('web.billing.currency_migration.current_plan') }}
                       </span>
                       <span class="font-medium text-gray-900 dark:text-white">
-                        {{ details.current_plan.name }} ({{ details.current_plan.price_formatted }})
+                        {{ details.current_plan?.name }} ({{ details.current_plan?.price_formatted }})
                       </span>
                     </div>
                     <div class="flex justify-between">
@@ -178,7 +178,7 @@ function handleClose() {
                         {{ t('web.billing.currency_migration.new_plan') }}
                       </span>
                       <span class="font-medium text-gray-900 dark:text-white">
-                        {{ details.requested_plan.name }} ({{ details.requested_plan.price_formatted }})
+                        {{ details.requested_plan?.name }} ({{ details.requested_plan?.price_formatted }})
                       </span>
                     </div>
                     <div class="border-t border-gray-200 pt-3 dark:border-gray-700">

--- a/src/apps/workspace/billing/CurrencyMigrationModal.vue
+++ b/src/apps/workspace/billing/CurrencyMigrationModal.vue
@@ -1,0 +1,337 @@
+<!-- src/apps/workspace/billing/CurrencyMigrationModal.vue -->
+
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n';
+import OIcon from '@/shared/components/icons/OIcon.vue';
+import { Dialog, DialogPanel, DialogTitle, TransitionChild, TransitionRoot } from '@headlessui/vue';
+import { BillingService } from '@/services/billing.service';
+import { classifyError } from '@/schemas/errors';
+import type { CurrencyConflictError, MigrationMode } from '@/schemas/models/billing';
+import { computed, ref, watch } from 'vue';
+
+const { t } = useI18n();
+
+const props = defineProps<{
+  open: boolean;
+  orgExtId: string;
+  conflict: CurrencyConflictError | null;
+}>();
+
+const emit = defineEmits<{
+  (e: 'close'): void;
+  (e: 'graceful-confirmed', cancelAt: number): void;
+  (e: 'immediate-redirect', checkoutUrl: string): void;
+}>();
+
+// State
+const isMigrating = ref(false);
+const error = ref('');
+const selectedMode = ref<MigrationMode>('graceful');
+
+// Reset state when modal opens
+watch(() => props.open, (isOpen) => {
+  if (isOpen) {
+    error.value = '';
+    selectedMode.value = 'graceful';
+  }
+});
+
+// Computed
+const details = computed(() => props.conflict?.details ?? null);
+
+const formattedPeriodEnd = computed(() => {
+  if (!details.value?.current_plan.current_period_end) return null;
+  return new Date(details.value.current_plan.current_period_end).toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+});
+
+const existingCurrencyUpper = computed(() =>
+  details.value?.existing_currency?.toUpperCase() ?? ''
+);
+
+const requestedCurrencyUpper = computed(() =>
+  details.value?.requested_currency?.toUpperCase() ?? ''
+);
+
+const hasCreditBalance = computed(() =>
+  details.value?.warnings.has_credit_balance ?? false
+);
+
+const hasWarnings = computed(() => {
+  if (!details.value?.warnings) return false;
+  const w = details.value.warnings;
+  return w.has_credit_balance || w.has_pending_invoice_items || w.has_incompatible_coupons;
+});
+
+async function handleConfirm() {
+  if (!details.value || !props.orgExtId) return;
+
+  isMigrating.value = true;
+  error.value = '';
+
+  try {
+    const result = await BillingService.migrateCurrency(props.orgExtId, {
+      mode: selectedMode.value,
+      new_price_id: details.value.requested_plan.price_id,
+    });
+
+    if (result.success) {
+      if (result.migration.mode === 'graceful') {
+        emit('graceful-confirmed', result.migration.cancel_at);
+      } else {
+        emit('immediate-redirect', result.migration.checkout_url);
+      }
+    } else {
+      error.value = t('web.billing.currency_migration.error');
+    }
+  } catch (err) {
+    const classified = classifyError(err);
+    error.value = classified.message || t('web.billing.currency_migration.error');
+    console.error('[CurrencyMigrationModal] Migration error:', err);
+  } finally {
+    isMigrating.value = false;
+  }
+}
+
+function handleClose() {
+  if (!isMigrating.value) {
+    emit('close');
+  }
+}
+</script>
+
+<template>
+  <TransitionRoot as="template" :show="open">
+    <Dialog
+      class="relative z-50"
+      aria-describedby="currency-migration-description"
+      @close="handleClose">
+      <!-- Backdrop -->
+      <TransitionChild
+        as="template"
+        enter="ease-out duration-300"
+        enter-from="opacity-0"
+        enter-to="opacity-100"
+        leave="ease-in duration-200"
+        leave-from="opacity-100"
+        leave-to="opacity-0">
+        <div class="fixed inset-0 bg-gray-500/75 transition-opacity dark:bg-gray-900/80"></div>
+      </TransitionChild>
+
+      <!-- Modal Content -->
+      <div class="fixed inset-0 z-10 w-screen overflow-y-auto">
+        <div class="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
+          <TransitionChild
+            as="template"
+            enter="ease-out duration-300"
+            enter-from="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
+            enter-to="opacity-100 translate-y-0 sm:scale-100"
+            leave="ease-in duration-200"
+            leave-from="opacity-100 translate-y-0 sm:scale-100"
+            leave-to="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95">
+            <DialogPanel
+              class="relative overflow-hidden rounded-lg bg-white px-4 pb-4 pt-5 text-left shadow-xl transition-all dark:bg-gray-800 sm:my-8 sm:w-full sm:max-w-lg sm:p-6">
+
+              <!-- Header -->
+              <div class="sm:flex sm:items-start">
+                <div class="mx-auto flex size-12 shrink-0 items-center justify-center rounded-full bg-amber-100 sm:mx-0 sm:size-10 dark:bg-amber-900/30">
+                  <OIcon
+                    collection="heroicons"
+                    name="currency-dollar"
+                    class="size-6 text-amber-600 dark:text-amber-400"
+                    aria-hidden="true" />
+                </div>
+                <div class="mt-3 text-center sm:ml-4 sm:mt-0 sm:text-left">
+                  <DialogTitle
+                    as="h3"
+                    class="text-base font-semibold leading-6 text-gray-900 dark:text-white">
+                    {{ t('web.billing.currency_migration.title') }}
+                  </DialogTitle>
+                  <div class="mt-2">
+                    <p id="currency-migration-description" class="text-sm text-gray-500 dark:text-gray-400">
+                      {{ t('web.billing.currency_migration.description', {
+                        from: existingCurrencyUpper,
+                        to: requestedCurrencyUpper,
+                      }) }}
+                    </p>
+                  </div>
+                </div>
+              </div>
+
+              <!-- Plan Details -->
+              <div v-if="details" class="mt-6">
+                <div class="rounded-lg border border-gray-200 bg-gray-50 p-4 dark:border-gray-700 dark:bg-gray-900/50">
+                  <div class="space-y-3 text-sm">
+                    <div class="flex justify-between">
+                      <span class="text-gray-600 dark:text-gray-400">
+                        {{ t('web.billing.currency_migration.current_plan') }}
+                      </span>
+                      <span class="font-medium text-gray-900 dark:text-white">
+                        {{ details.current_plan.name }} ({{ details.current_plan.price_formatted }})
+                      </span>
+                    </div>
+                    <div class="flex justify-between">
+                      <span class="text-gray-600 dark:text-gray-400">
+                        {{ t('web.billing.currency_migration.new_plan') }}
+                      </span>
+                      <span class="font-medium text-gray-900 dark:text-white">
+                        {{ details.requested_plan.name }} ({{ details.requested_plan.price_formatted }})
+                      </span>
+                    </div>
+                    <div class="border-t border-gray-200 pt-3 dark:border-gray-700">
+                      <div class="flex justify-between">
+                        <span class="text-gray-600 dark:text-gray-400">
+                          {{ t('web.billing.currency_migration.current_period_ends') }}
+                        </span>
+                        <span class="font-medium text-gray-900 dark:text-white">
+                          {{ formattedPeriodEnd }}
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+
+                <!-- Warnings -->
+                <div
+                  v-if="hasWarnings"
+                  class="mt-4 rounded-md bg-amber-50 p-4 dark:bg-amber-900/20"
+                  role="alert">
+                  <div class="flex">
+                    <OIcon
+                      collection="heroicons"
+                      name="exclamation-triangle"
+                      class="size-5 shrink-0 text-amber-400"
+                      aria-hidden="true" />
+                    <div class="ml-3 space-y-1">
+                      <p v-if="hasCreditBalance" class="text-sm text-amber-700 dark:text-amber-300">
+                        {{ t('web.billing.currency_migration.warning_credit_balance', {
+                          currency: existingCurrencyUpper,
+                        }) }}
+                      </p>
+                      <p v-if="details.warnings.has_pending_invoice_items" class="text-sm text-amber-700 dark:text-amber-300">
+                        {{ t('web.billing.currency_migration.warning_pending_items') }}
+                      </p>
+                      <p v-if="details.warnings.has_incompatible_coupons" class="text-sm text-amber-700 dark:text-amber-300">
+                        {{ t('web.billing.currency_migration.warning_coupons') }}
+                      </p>
+                    </div>
+                  </div>
+                </div>
+
+                <!-- Migration Mode Selection -->
+                <fieldset class="mt-5">
+                  <legend class="text-sm font-medium text-gray-900 dark:text-white">
+                    {{ t('web.billing.currency_migration.choose_timing') }}
+                  </legend>
+                  <div class="mt-3 space-y-3">
+                    <!-- Graceful: Switch at end of billing period -->
+                    <label
+                      :class="[
+                        'flex cursor-pointer items-start gap-3 rounded-lg border p-4 transition-colors',
+                        selectedMode === 'graceful'
+                          ? 'border-brand-500 bg-brand-50 dark:border-brand-400 dark:bg-brand-900/20'
+                          : 'border-gray-200 bg-white hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-800 dark:hover:bg-gray-750',
+                      ]">
+                      <input
+                        v-model="selectedMode"
+                        type="radio"
+                        name="migration-mode"
+                        value="graceful"
+                        class="mt-0.5 size-4 border-gray-300 text-brand-600 focus:ring-brand-600 dark:border-gray-600" />
+                      <div class="flex-1">
+                        <span class="block text-sm font-medium text-gray-900 dark:text-white">
+                          {{ t('web.billing.currency_migration.graceful_title') }}
+                        </span>
+                        <span class="mt-1 block text-sm text-gray-500 dark:text-gray-400">
+                          {{ t('web.billing.currency_migration.graceful_description', {
+                            date: formattedPeriodEnd ?? '',
+                          }) }}
+                        </span>
+                      </div>
+                    </label>
+
+                    <!-- Immediate: Switch now -->
+                    <label
+                      :class="[
+                        'flex cursor-pointer items-start gap-3 rounded-lg border p-4 transition-colors',
+                        selectedMode === 'immediate'
+                          ? 'border-brand-500 bg-brand-50 dark:border-brand-400 dark:bg-brand-900/20'
+                          : 'border-gray-200 bg-white hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-800 dark:hover:bg-gray-750',
+                      ]">
+                      <input
+                        v-model="selectedMode"
+                        type="radio"
+                        name="migration-mode"
+                        value="immediate"
+                        class="mt-0.5 size-4 border-gray-300 text-brand-600 focus:ring-brand-600 dark:border-gray-600" />
+                      <div class="flex-1">
+                        <span class="block text-sm font-medium text-gray-900 dark:text-white">
+                          {{ t('web.billing.currency_migration.immediate_title') }}
+                        </span>
+                        <span class="mt-1 block text-sm text-gray-500 dark:text-gray-400">
+                          {{ t('web.billing.currency_migration.immediate_description') }}
+                        </span>
+                      </div>
+                    </label>
+                  </div>
+                </fieldset>
+              </div>
+
+              <!-- Error State -->
+              <div
+                v-if="error"
+                class="mt-4 rounded-md bg-red-50 p-4 dark:bg-red-900/20"
+                role="alert"
+                aria-live="polite">
+                <div class="flex">
+                  <OIcon
+                    collection="heroicons"
+                    name="x-circle"
+                    class="size-5 text-red-400"
+                    aria-hidden="true" />
+                  <div class="ml-3">
+                    <p class="text-sm text-red-700 dark:text-red-300">{{ error }}</p>
+                  </div>
+                </div>
+              </div>
+
+              <!-- Actions -->
+              <div class="mt-6 sm:flex sm:flex-row-reverse sm:gap-3">
+                <button
+                  type="button"
+                  :disabled="isMigrating || !details"
+                  :class="[
+                    'inline-flex w-full justify-center rounded-md px-3 py-2 text-sm font-semibold text-white shadow-sm sm:w-auto',
+                    'bg-brand-600 hover:bg-brand-500 dark:bg-brand-500 dark:hover:bg-brand-400',
+                    (isMigrating || !details) && 'cursor-not-allowed opacity-50',
+                  ]"
+                  @click="handleConfirm">
+                  <OIcon
+                    v-if="isMigrating"
+                    collection="heroicons"
+                    name="arrow-path"
+                    class="mr-2 size-4 animate-spin"
+                    aria-hidden="true" />
+                  {{ isMigrating
+                    ? t('web.COMMON.processing')
+                    : t('web.billing.currency_migration.confirm')
+                  }}
+                </button>
+                <button
+                  type="button"
+                  :disabled="isMigrating"
+                  class="mt-3 inline-flex w-full justify-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-gray-700 dark:text-white dark:ring-gray-600 dark:hover:bg-gray-600 sm:mt-0 sm:w-auto"
+                  @click="handleClose">
+                  {{ t('web.COMMON.word_cancel') }}
+                </button>
+              </div>
+            </DialogPanel>
+          </TransitionChild>
+        </div>
+      </div>
+    </Dialog>
+  </TransitionRoot>
+</template>

--- a/src/apps/workspace/billing/PendingMigrationBanner.vue
+++ b/src/apps/workspace/billing/PendingMigrationBanner.vue
@@ -1,0 +1,76 @@
+<!-- src/apps/workspace/billing/PendingMigrationBanner.vue -->
+
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n';
+import OIcon from '@/shared/components/icons/OIcon.vue';
+import { computed } from 'vue';
+
+const { t } = useI18n();
+
+const props = defineProps<{
+  targetPlanName: string;
+  targetCurrency: string;
+  effectiveDate: number;
+  isCompletingMigration?: boolean;
+}>();
+
+const emit = defineEmits<{
+  (e: 'complete-migration'): void;
+}>();
+
+const formattedDate = computed(() =>
+  new Date(props.effectiveDate * 1000).toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  })
+);
+
+const currencyUpper = computed(() => props.targetCurrency.toUpperCase());
+</script>
+
+<template>
+  <div
+    class="rounded-lg border-2 border-blue-300 bg-blue-50 p-5 dark:border-blue-600 dark:bg-blue-900/30"
+    role="status">
+    <div class="flex items-start gap-4">
+      <div class="flex size-10 shrink-0 items-center justify-center rounded-full bg-blue-100 dark:bg-blue-800">
+        <OIcon
+          collection="heroicons"
+          name="clock"
+          class="size-6 text-blue-600 dark:text-blue-300"
+          aria-hidden="true" />
+      </div>
+      <div class="flex-1">
+        <h3 class="text-base font-semibold text-blue-800 dark:text-blue-200">
+          {{ t('web.billing.currency_migration.pending_title') }}
+        </h3>
+        <p class="mt-1 text-sm text-blue-700 dark:text-blue-300">
+          {{ t('web.billing.currency_migration.pending_description', {
+            date: formattedDate,
+            plan: targetPlanName,
+            currency: currencyUpper,
+          }) }}
+        </p>
+        <div class="mt-3">
+          <button
+            type="button"
+            :disabled="isCompletingMigration"
+            class="inline-flex items-center rounded-md bg-blue-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-blue-500 dark:hover:bg-blue-400"
+            @click="emit('complete-migration')">
+            <OIcon
+              v-if="isCompletingMigration"
+              collection="heroicons"
+              name="arrow-path"
+              class="mr-2 size-4 animate-spin"
+              aria-hidden="true" />
+            {{ isCompletingMigration
+              ? t('web.COMMON.processing')
+              : t('web.billing.currency_migration.complete_migration')
+            }}
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/src/schemas/models/billing.ts
+++ b/src/schemas/models/billing.ts
@@ -159,20 +159,20 @@ export type CurrencyMigrationWarnings = z.infer<typeof currencyMigrationWarnings
 export const currencyConflictErrorSchema = z.object({
   error: z.literal(true),
   code: z.literal('currency_conflict'),
-  message: z.string(),
+  message: z.string().optional(),
   details: z.object({
     existing_currency: z.string(),
     requested_currency: z.string(),
     current_plan: z.object({
       name: z.string(),
       price_formatted: z.string(),
-      current_period_end: z.string(),
-    }),
+      current_period_end: z.number(),
+    }).nullable(),
     requested_plan: z.object({
       name: z.string(),
       price_formatted: z.string(),
       price_id: z.string(),
-    }),
+    }).nullable(),
     warnings: currencyMigrationWarningsSchema,
   }),
 });
@@ -227,6 +227,7 @@ export const pendingMigrationSchema = z.object({
   target_price_id: z.string(),
   target_plan_name: z.string(),
   target_currency: z.string(),
+  target_plan_id: z.string(),
   effective_after: z.number(),
 });
 

--- a/src/services/billing.service.ts
+++ b/src/services/billing.service.ts
@@ -9,6 +9,11 @@
 
 import { createApi } from '@/api';
 import type { Invoice, PaymentMethod } from '@/types/billing';
+import type {
+  CurrencyConflictError,
+  MigrateCurrencyRequest,
+  MigrateCurrencyResponse,
+} from '@/schemas/models/billing';
 
 const $api = createApi();
 
@@ -121,10 +126,19 @@ export interface SubscriptionStatusResponse {
   subscription_item_id?: string;
   subscription_status?: string;
   current_period_end?: number;
+  /** Currency of the current subscription (e.g., 'usd', 'eur') */
+  current_currency?: string;
   /** True if subscription is scheduled for cancellation at period end */
   cancel_at_period_end?: boolean;
   /** Unix timestamp when subscription will be cancelled (if scheduled) */
   cancel_at?: number | null;
+  /** Present when a currency migration is pending (graceful mode) */
+  pending_currency_migration?: {
+    target_price_id: string;
+    target_plan_name: string;
+    target_currency: string;
+    effective_after: number;
+  } | null;
 }
 
 /**
@@ -309,4 +323,57 @@ export const BillingService = {
     const response = await $api.post(`/billing/api/org/${orgExtId}/cancel-subscription`);
     return response.data;
   },
+
+  /**
+   * Migrate subscription to a new currency
+   *
+   * Handles the case where a customer's existing Stripe subscription uses
+   * a different currency than the target plan. Two modes:
+   * - 'graceful': Cancel at period end; user completes new checkout later
+   * - 'immediate': Cancel now with prorated refund; redirect to new checkout
+   *
+   * @param orgExtId - Organization external ID
+   * @param request - Migration parameters (price ID and mode)
+   * @returns Migration result (shape varies by mode)
+   */
+  async migrateCurrency(
+    orgExtId: string,
+    request: MigrateCurrencyRequest
+  ): Promise<MigrateCurrencyResponse> {
+    const response = await $api.post(
+      `/billing/api/org/${orgExtId}/migrate-currency`,
+      request
+    );
+    return response.data;
+  },
 };
+
+/**
+ * Check if an error response indicates a currency conflict.
+ *
+ * Currency conflicts occur when a customer tries to subscribe to a plan
+ * in a different currency than their existing Stripe subscription.
+ * The backend returns HTTP 409 with `code: 'currency_conflict'`.
+ *
+ * @param error - The caught error from an API call
+ * @returns The conflict details if this is a currency conflict, null otherwise
+ */
+export function extractCurrencyConflict(error: unknown): CurrencyConflictError | null {
+  if (
+    typeof error === 'object' &&
+    error !== null &&
+    'response' in error
+  ) {
+    const axiosError = error as { response?: { status?: number; data?: Record<string, unknown> } };
+    const data = axiosError.response?.data;
+
+    if (
+      axiosError.response?.status === 409 &&
+      data &&
+      data.code === 'currency_conflict'
+    ) {
+      return data as unknown as CurrencyConflictError;
+    }
+  }
+  return null;
+}

--- a/src/services/billing.service.ts
+++ b/src/services/billing.service.ts
@@ -137,6 +137,7 @@ export interface SubscriptionStatusResponse {
     target_price_id: string;
     target_plan_name: string;
     target_currency: string;
+    target_plan_id: string;
     effective_after: number;
   } | null;
 }

--- a/src/tests/apps/workspace/billing/CurrencyMigrationModal.spec.ts
+++ b/src/tests/apps/workspace/billing/CurrencyMigrationModal.spec.ts
@@ -61,7 +61,7 @@ vi.mock('@/schemas/errors', () => ({
   }),
 }));
 
-const futureDate = new Date(Date.now() + 86400 * 30 * 1000).toISOString();
+const futureDate = Math.floor((Date.now() + 86400 * 30 * 1000) / 1000);
 
 const mockConflict = {
   error: true as const,

--- a/src/tests/apps/workspace/billing/CurrencyMigrationModal.spec.ts
+++ b/src/tests/apps/workspace/billing/CurrencyMigrationModal.spec.ts
@@ -1,0 +1,422 @@
+// src/tests/apps/workspace/billing/CurrencyMigrationModal.spec.ts
+
+import { mount, VueWrapper } from '@vue/test-utils';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createI18n } from 'vue-i18n';
+import { createPinia, setActivePinia } from 'pinia';
+import CurrencyMigrationModal from '@/apps/workspace/billing/CurrencyMigrationModal.vue';
+import { nextTick } from 'vue';
+
+// Mock HeadlessUI components
+vi.mock('@headlessui/vue', () => ({
+  Dialog: {
+    name: 'Dialog',
+    template: '<div role="dialog" @close="$emit(\'close\')"><slot /></div>',
+    props: ['class'],
+    emits: ['close'],
+  },
+  DialogPanel: {
+    name: 'DialogPanel',
+    template: '<div class="dialog-panel"><slot /></div>',
+    props: ['class'],
+  },
+  DialogTitle: {
+    name: 'DialogTitle',
+    template: '<h3><slot /></h3>',
+    props: ['as', 'class'],
+  },
+  TransitionRoot: {
+    name: 'TransitionRoot',
+    template: '<div v-if="show"><slot /></div>',
+    props: ['as', 'show'],
+  },
+  TransitionChild: {
+    name: 'TransitionChild',
+    template: '<div><slot /></div>',
+    props: ['as', 'enter', 'enterFrom', 'enterTo', 'leave', 'leaveFrom', 'leaveTo'],
+  },
+}));
+
+vi.mock('@/shared/components/icons/OIcon.vue', () => ({
+  default: {
+    name: 'OIcon',
+    template: '<span class="o-icon" />',
+    props: ['collection', 'name', 'class'],
+  },
+}));
+
+// Mock BillingService
+const mockMigrateCurrency = vi.fn();
+vi.mock('@/services/billing.service', () => ({
+  BillingService: {
+    migrateCurrency: (...args: unknown[]) => mockMigrateCurrency(...args),
+  },
+}));
+
+vi.mock('@/schemas/errors', () => ({
+  classifyError: (err: unknown) => ({
+    message: err instanceof Error ? err.message : String(err),
+    type: 'human',
+    severity: 'error',
+  }),
+}));
+
+const futureDate = new Date(Date.now() + 86400 * 30 * 1000).toISOString();
+
+const mockConflict = {
+  error: true as const,
+  code: 'currency_conflict' as const,
+  message: 'Your account has an active subscription in EUR.',
+  details: {
+    existing_currency: 'eur',
+    requested_currency: 'usd',
+    current_plan: {
+      name: 'Identity Plus',
+      price_formatted: '€14.00/mo',
+      current_period_end: futureDate,
+    },
+    requested_plan: {
+      name: 'Team Plus',
+      price_formatted: '$25.00/mo',
+      price_id: 'price_usd_team_plus',
+    },
+    warnings: {
+      has_credit_balance: false,
+      credit_balance_amount: 0,
+      has_pending_invoice_items: false,
+      has_incompatible_coupons: false,
+    },
+  },
+};
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: {
+    en: {
+      web: {
+        billing: {
+          currency_migration: {
+            title: 'Currency Change Required',
+            description: 'Your current subscription uses {from}. The selected plan is billed in {to}.',
+            current_plan: 'Current plan:',
+            new_plan: 'New plan:',
+            current_period_ends: 'Current period ends:',
+            choose_timing: 'When should the switch happen?',
+            graceful_title: 'Switch at end of billing period',
+            graceful_description: 'Your current plan stays active until {date}.',
+            immediate_title: 'Switch immediately',
+            immediate_description: 'Your current plan is cancelled now.',
+            confirm: 'Confirm Currency Change',
+            error: 'Currency migration failed. Please try again.',
+            warning_credit_balance: 'You have a credit balance in {currency} that cannot be transferred.',
+            warning_pending_items: 'You have pending invoice items.',
+            warning_coupons: 'Active coupons may not be compatible.',
+          },
+        },
+        COMMON: {
+          processing: 'Processing...',
+          word_cancel: 'Cancel',
+        },
+      },
+    },
+  },
+});
+
+describe('CurrencyMigrationModal', () => {
+  let wrapper: VueWrapper;
+  let pinia: ReturnType<typeof createPinia>;
+
+  beforeEach(() => {
+    pinia = createPinia();
+    setActivePinia(pinia);
+    vi.clearAllMocks();
+    mockMigrateCurrency.mockReset();
+  });
+
+  afterEach(() => {
+    if (wrapper) wrapper.unmount();
+  });
+
+  const mountComponent = async (props: Partial<{
+    open: boolean;
+    orgExtId: string;
+    conflict: typeof mockConflict | null;
+  }> = {}) => {
+    const mergedProps = {
+      open: true,
+      orgExtId: 'org_123',
+      conflict: mockConflict,
+      ...props,
+    };
+    const component = mount(CurrencyMigrationModal, {
+      props: mergedProps as any,
+      global: { plugins: [i18n, pinia] },
+    });
+    await nextTick();
+    await nextTick();
+    await nextTick();
+    return component;
+  };
+
+  describe('Rendering', () => {
+    it('renders when open is true with conflict data', async () => {
+      wrapper = await mountComponent();
+      expect(wrapper.find('[role="dialog"]').exists()).toBe(true);
+      expect(wrapper.text()).toContain('Currency Change Required');
+    });
+
+    it('does not render when open is false', async () => {
+      wrapper = await mountComponent({ open: false });
+      expect(wrapper.find('.dialog-panel').exists()).toBe(false);
+    });
+
+    it('displays currency names from conflict', async () => {
+      wrapper = await mountComponent();
+      expect(wrapper.text()).toContain('EUR');
+      expect(wrapper.text()).toContain('USD');
+    });
+
+    it('displays current and new plan names with formatted prices', async () => {
+      wrapper = await mountComponent();
+      expect(wrapper.text()).toContain('Identity Plus');
+      expect(wrapper.text()).toContain('€14.00/mo');
+      expect(wrapper.text()).toContain('Team Plus');
+      expect(wrapper.text()).toContain('$25.00/mo');
+    });
+
+    it('displays formatted period end date', async () => {
+      wrapper = await mountComponent();
+      const html = wrapper.html();
+      expect(html).toMatch(/20\d{2}/);
+    });
+  });
+
+  describe('Warnings', () => {
+    it('shows credit balance warning when present', async () => {
+      const conflictWithWarnings = {
+        ...mockConflict,
+        details: {
+          ...mockConflict.details,
+          warnings: {
+            ...mockConflict.details.warnings,
+            has_credit_balance: true,
+            credit_balance_amount: 500,
+          },
+        },
+      };
+      wrapper = await mountComponent({ conflict: conflictWithWarnings });
+      expect(wrapper.text()).toContain('credit balance');
+    });
+
+    it('does not show warnings when none are active', async () => {
+      wrapper = await mountComponent();
+      expect(wrapper.text()).not.toContain('credit balance');
+    });
+  });
+
+  describe('Mode Selection', () => {
+    it('defaults to graceful mode', async () => {
+      wrapper = await mountComponent();
+      const gracefulRadio = wrapper.find('input[value="graceful"]');
+      expect((gracefulRadio.element as HTMLInputElement).checked).toBe(true);
+    });
+
+    it('allows switching to immediate mode', async () => {
+      wrapper = await mountComponent();
+      const immediateRadio = wrapper.find('input[value="immediate"]');
+      await immediateRadio.setValue(true);
+      expect((immediateRadio.element as HTMLInputElement).checked).toBe(true);
+    });
+
+    it('shows both mode options with descriptions', async () => {
+      wrapper = await mountComponent();
+      expect(wrapper.text()).toContain('Switch at end of billing period');
+      expect(wrapper.text()).toContain('Switch immediately');
+    });
+  });
+
+  describe('Migration Execution', () => {
+    it('calls migrateCurrency with graceful mode on confirm', async () => {
+      mockMigrateCurrency.mockResolvedValueOnce({
+        success: true,
+        migration: { mode: 'graceful', cancel_at: 1704067200 },
+      });
+
+      wrapper = await mountComponent();
+      const confirmBtn = wrapper.findAll('button').find(
+        btn => btn.text().includes('Confirm')
+      );
+      await confirmBtn?.trigger('click');
+      await nextTick();
+
+      expect(mockMigrateCurrency).toHaveBeenCalledWith('org_123', {
+        new_price_id: 'price_usd_team_plus',
+        mode: 'graceful',
+      });
+    });
+
+    it('calls migrateCurrency with immediate mode when selected', async () => {
+      mockMigrateCurrency.mockResolvedValueOnce({
+        success: true,
+        migration: {
+          mode: 'immediate',
+          checkout_url: 'https://checkout.stripe.com/cs_123',
+          refund_amount: 700,
+          refund_formatted: '€7.00',
+        },
+      });
+
+      wrapper = await mountComponent();
+      const immediateRadio = wrapper.find('input[value="immediate"]');
+      await immediateRadio.setValue(true);
+      await nextTick();
+
+      const confirmBtn = wrapper.findAll('button').find(
+        btn => btn.text().includes('Confirm')
+      );
+      await confirmBtn?.trigger('click');
+      await nextTick();
+
+      expect(mockMigrateCurrency).toHaveBeenCalledWith('org_123', {
+        new_price_id: 'price_usd_team_plus',
+        mode: 'immediate',
+      });
+    });
+
+    it('emits graceful-confirmed with cancel_at on graceful success', async () => {
+      mockMigrateCurrency.mockResolvedValueOnce({
+        success: true,
+        migration: { mode: 'graceful', cancel_at: 1704067200 },
+      });
+
+      wrapper = await mountComponent();
+      const confirmBtn = wrapper.findAll('button').find(
+        btn => btn.text().includes('Confirm')
+      );
+      await confirmBtn?.trigger('click');
+      await nextTick();
+      await nextTick();
+
+      expect(wrapper.emitted('graceful-confirmed')).toBeTruthy();
+      expect(wrapper.emitted('graceful-confirmed')![0][0]).toBe(1704067200);
+    });
+
+    it('emits immediate-redirect with checkout URL on immediate success', async () => {
+      mockMigrateCurrency.mockResolvedValueOnce({
+        success: true,
+        migration: {
+          mode: 'immediate',
+          checkout_url: 'https://checkout.stripe.com/cs_456',
+          refund_amount: 700,
+          refund_formatted: '€7.00',
+        },
+      });
+
+      wrapper = await mountComponent();
+      const immediateRadio = wrapper.find('input[value="immediate"]');
+      await immediateRadio.setValue(true);
+      await nextTick();
+
+      const confirmBtn = wrapper.findAll('button').find(
+        btn => btn.text().includes('Confirm')
+      );
+      await confirmBtn?.trigger('click');
+      await nextTick();
+      await nextTick();
+
+      expect(wrapper.emitted('immediate-redirect')).toBeTruthy();
+      expect(wrapper.emitted('immediate-redirect')![0][0]).toBe(
+        'https://checkout.stripe.com/cs_456'
+      );
+    });
+  });
+
+  describe('Error Handling', () => {
+    it('displays error when migration fails', async () => {
+      mockMigrateCurrency.mockRejectedValueOnce(new Error('past_due subscription'));
+
+      wrapper = await mountComponent();
+      const confirmBtn = wrapper.findAll('button').find(
+        btn => btn.text().includes('Confirm')
+      );
+      await confirmBtn?.trigger('click');
+      await nextTick();
+      await nextTick();
+
+      expect(wrapper.text()).toContain('past_due subscription');
+    });
+
+    it('displays generic error when result.success is false', async () => {
+      mockMigrateCurrency.mockResolvedValueOnce({ success: false });
+
+      wrapper = await mountComponent();
+      const confirmBtn = wrapper.findAll('button').find(
+        btn => btn.text().includes('Confirm')
+      );
+      await confirmBtn?.trigger('click');
+      await nextTick();
+      await nextTick();
+
+      expect(wrapper.text()).toContain('Currency migration failed');
+    });
+  });
+
+  describe('Button States', () => {
+    it('disables confirm when no conflict', async () => {
+      wrapper = await mountComponent({ conflict: null });
+      const confirmBtn = wrapper.findAll('button').find(
+        btn => btn.text().includes('Confirm')
+      );
+      expect(confirmBtn?.attributes('disabled')).toBeDefined();
+    });
+
+    it('shows processing text during migration', async () => {
+      let resolve: (v: unknown) => void;
+      const pending = new Promise(r => { resolve = r; });
+      mockMigrateCurrency.mockReturnValueOnce(pending);
+
+      wrapper = await mountComponent();
+      const confirmBtn = wrapper.findAll('button').find(
+        btn => btn.text().includes('Confirm')
+      );
+      await confirmBtn?.trigger('click');
+      await nextTick();
+
+      expect(wrapper.text()).toContain('Processing');
+      resolve!({ success: true, migration: { mode: 'graceful', cancel_at: 123 } });
+    });
+
+    it('prevents close while migrating', async () => {
+      let resolve: (v: unknown) => void;
+      const pending = new Promise(r => { resolve = r; });
+      mockMigrateCurrency.mockReturnValueOnce(pending);
+
+      wrapper = await mountComponent();
+      const confirmBtn = wrapper.findAll('button').find(
+        btn => btn.text().includes('Confirm')
+      );
+      await confirmBtn?.trigger('click');
+      await nextTick();
+
+      const cancelBtn = wrapper.findAll('button').find(
+        btn => btn.text().includes('Cancel')
+      );
+      await cancelBtn?.trigger('click');
+
+      expect(wrapper.emitted('close')).toBeFalsy();
+      resolve!({ success: true, migration: { mode: 'graceful', cancel_at: 123 } });
+    });
+  });
+
+  describe('Events', () => {
+    it('emits close when cancel is clicked', async () => {
+      wrapper = await mountComponent();
+      const cancelBtn = wrapper.findAll('button').find(
+        btn => btn.text().includes('Cancel')
+      );
+      await cancelBtn?.trigger('click');
+      expect(wrapper.emitted('close')).toBeTruthy();
+    });
+  });
+});

--- a/src/tests/services/billing.service.currency-migration.spec.ts
+++ b/src/tests/services/billing.service.currency-migration.spec.ts
@@ -1,0 +1,156 @@
+// src/tests/services/billing.service.currency-migration.spec.ts
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Use vi.hoisted to properly hoist mock functions before vi.mock
+const { mockGet, mockPost } = vi.hoisted(() => ({
+  mockGet: vi.fn(),
+  mockPost: vi.fn(),
+}));
+
+vi.mock('@/api', () => ({
+  createApi: () => ({
+    get: mockGet,
+    post: mockPost,
+  }),
+}));
+
+// Import after mocking
+import {
+  BillingService,
+  extractCurrencyConflict,
+} from '@/services/billing.service';
+
+describe('Currency migration service methods', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGet.mockReset();
+    mockPost.mockReset();
+  });
+
+  describe('BillingService.migrateCurrency', () => {
+    it('calls correct endpoint with graceful mode', async () => {
+      const mockResponse = {
+        data: {
+          success: true,
+          migration: { mode: 'graceful', cancel_at: 1704067200 },
+        },
+      };
+      mockPost.mockResolvedValueOnce(mockResponse);
+
+      const result = await BillingService.migrateCurrency('org_abc', {
+        new_price_id: 'price_usd_123',
+        mode: 'graceful',
+      });
+
+      expect(mockPost).toHaveBeenCalledWith(
+        '/billing/api/org/org_abc/migrate-currency',
+        { new_price_id: 'price_usd_123', mode: 'graceful' }
+      );
+      expect(result.success).toBe(true);
+      expect(result.migration.mode).toBe('graceful');
+      expect(result.migration.cancel_at).toBe(1704067200);
+    });
+
+    it('calls correct endpoint with immediate mode', async () => {
+      const mockResponse = {
+        data: {
+          success: true,
+          migration: {
+            mode: 'immediate',
+            checkout_session_url: 'https://checkout.stripe.com/c/pay/cs_test_123',
+            prorated_credit_amount: 1500,
+            prorated_credit_formatted: 'EUR 15.00',
+          },
+        },
+      };
+      mockPost.mockResolvedValueOnce(mockResponse);
+
+      const result = await BillingService.migrateCurrency('org_xyz', {
+        new_price_id: 'price_eur_456',
+        mode: 'immediate',
+      });
+
+      expect(mockPost).toHaveBeenCalledWith(
+        '/billing/api/org/org_xyz/migrate-currency',
+        { new_price_id: 'price_eur_456', mode: 'immediate' }
+      );
+      expect(result.success).toBe(true);
+      expect(result.migration.mode).toBe('immediate');
+      expect(result.migration.checkout_session_url).toContain('stripe.com');
+    });
+
+    it('propagates API errors', async () => {
+      mockPost.mockRejectedValueOnce(new Error('Subscription is past_due'));
+
+      await expect(
+        BillingService.migrateCurrency('org_test', {
+          new_price_id: 'price_abc',
+          mode: 'graceful',
+        })
+      ).rejects.toThrow('Subscription is past_due');
+    });
+  });
+
+  describe('extractCurrencyConflict', () => {
+    it('extracts conflict details from 409 response', () => {
+      // Build an error-like object matching what axios produces at runtime.
+      // The extractCurrencyConflict function checks 'response' in error,
+      // then data.code === 'currency_conflict'.
+      const conflictData = {
+        code: 'currency_conflict',
+        error: 'currency_conflict',
+        message: 'A currency change is required.',
+        current_currency: 'eur',
+        requested_currency: 'usd',
+        current_plan_name: 'Identity Plus',
+        current_period_end: 1704067200,
+        new_plan_name: 'Team Plus',
+        new_plan_amount: 9900,
+        new_plan_interval: 'month',
+        new_price_id: 'price_usd_456',
+      };
+
+      // Simulate axios-shaped error with response property
+      const error = {
+        response: {
+          status: 409,
+          data: conflictData,
+        },
+      };
+
+      const result = extractCurrencyConflict(error);
+
+      expect(result).not.toBeNull();
+      expect(result?.current_currency).toBe('eur');
+      expect(result?.requested_currency).toBe('usd');
+      expect(result?.new_price_id).toBe('price_usd_456');
+    });
+
+    it('returns null for non-409 errors', () => {
+      const error = {
+        response: { status: 400, data: { message: 'Missing product' } },
+      };
+      expect(extractCurrencyConflict(error)).toBeNull();
+    });
+
+    it('returns null for 409 without currency_conflict code', () => {
+      const error = {
+        response: { status: 409, data: { code: 'generic_conflict', message: 'Something else' } },
+      };
+      expect(extractCurrencyConflict(error)).toBeNull();
+    });
+
+    it('returns null for non-object errors', () => {
+      expect(extractCurrencyConflict('string error')).toBeNull();
+      expect(extractCurrencyConflict(null)).toBeNull();
+      expect(extractCurrencyConflict(undefined)).toBeNull();
+      expect(extractCurrencyConflict(42)).toBeNull();
+    });
+
+    it('returns null for objects without response property', () => {
+      expect(extractCurrencyConflict(new Error('plain error'))).toBeNull();
+      expect(extractCurrencyConflict({ message: 'not axios' })).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

When a Stripe customer tries switching to a plan in a different currency, Stripe rejects the operation because customers can't combine currencies. This PR adds a full migration flow that detects the conflict and walks the user through switching currencies.

Two migration paths are offered:

- **Graceful**: Current subscription cancels at period end. After it terminates, Stripe resets the customer's currency, and the user completes checkout for the new plan. A persistent banner in the billing UI prompts them to finish.
- **Immediate**: Subscription cancels now, prorated refund issued to payment method (not customer credit, since credit is currency-locked), then redirects to Stripe Checkout with the new currency price.

Key architectural decision: `SubscriptionSchedule` cannot change a customer's currency, so the graceful path stores a migration intent on the org model and relies on the existing `subscription_deleted` webhook to clear state, followed by a manual checkout completion.

## What changed

**Backend** (Ruby)
- New `CurrencyMigrationService` module — conflict detection via regex on Stripe errors, migration assessment (blockers, warnings), graceful and immediate execution paths
- Two new endpoints: `POST .../check-currency-migration` (pre-check) and `POST .../migrate-currency` (execute)
- Existing checkout endpoint now returns 409 with structured assessment on currency conflict
- `preview_plan_change` and `change_plan` detect currency mismatch before calling Stripe
- `subscription_status` response now includes `current_currency` and `pending_currency_migration`
- Org model gets 3 new fields for migration intent storage (`pending_currency_migration`, `migration_target_price_id`, `migration_effective_after`)

**Frontend** (Vue/TypeScript)
- `CurrencyMigrationModal` — HeadlessUI dialog with graceful/immediate radio selection, plan comparison, warnings for credit balance/incompatible coupons/pending items
- `PendingMigrationBanner` — persistent banner when graceful migration is pending, with "Complete Migration" CTA
- `PlanSelector` updated to detect currency mismatch early via `subscriptionStatus.current_currency` and intercept 409 responses
- Zod schemas for conflict error, migration request/response, pending state
- 22 i18n keys under `web.billing.currency_migration.*`

**Tests** — 27 new tests
- RSpec: conflict detection, assessment diagnostics, graceful/immediate execution, edge cases
- Vitest: modal rendering, mode selection, API calls, error handling, button states, warnings

## Edge cases handled

- `past_due` subscriptions block migration (must resolve payment first)
- Orphaned checkout sessions expired before migration
- Pending invoice items in old currency voided
- Open invoices voided to release Stripe's currency lock
- Credit balance warning (non-blocking, surfaced to user)
- Amount-off coupons flagged as incompatible (percentage coupons transfer fine)
- Prorated refund via `Stripe::Refund.create` instead of customer credit
- Owner-only auth on migration endpoint, plan validated against catalog, idempotency keys on Stripe calls

## Test plan

- [ ] Verify currency conflict detection by attempting checkout with a price in a different currency than active subscription
- [ ] Test graceful path: confirm cancel-at-period-end is set, migration intent stored, banner appears
- [ ] Test immediate path: confirm refund issued, new checkout session created, redirect works
- [ ] Verify past_due subscription blocks migration with appropriate error
- [ ] Check credit balance and coupon warnings render in modal
- [ ] Run full test suite: `pnpm test` (frontend), `pnpm run test:rspec` (backend)