### PR TITLE
Fix CSRF token refresh on form submission errors

### DIFF
--- a/apps/api/base_json_api.rb
+++ b/apps/api/base_json_api.rb
@@ -41,11 +41,6 @@ class BaseJSONAPI < Onetime::Application::Base
   # Common middleware for all JSON APIs
   use Rack::JSONBodyParser
 
-  # CSRF Response Header
-  # Note: CSRF validation is handled by common Security middleware with
-  # allow_if to skip /api/* routes. This just adds the response header.
-  use Onetime::Middleware::CsrfResponseHeader
-
   # Warmup block placeholder for future initialization
   warmup { nil }
 

--- a/apps/api/v1/application.rb
+++ b/apps/api/v1/application.rb
@@ -39,9 +39,6 @@ module V1
     # V1-specific middleware (universal middleware in MiddlewareStack)
     use Rack::JSONBodyParser
 
-    # CSRF Response Header
-    use Onetime::Middleware::CsrfResponseHeader
-
     warmup do
     end
 

--- a/apps/api/v2/application.rb
+++ b/apps/api/v2/application.rb
@@ -31,11 +31,6 @@ module V2
     # V2-specific middleware (universal middleware in MiddlewareStack)
     use Rack::JSONBodyParser # TODO: Remove since we pass: builder.use Rack::Parser, parsers: @parsers
 
-    # CSRF Response Header
-    # Note: CSRF validation is handled by common Security middleware with
-    # allow_if to skip /api/* routes. This just adds the response header.
-    use Onetime::Middleware::CsrfResponseHeader
-
     # Warmup block placeholder for future initialization
     warmup { nil }
 

--- a/apps/api/v2/spec/application_spec.rb
+++ b/apps/api/v2/spec/application_spec.rb
@@ -18,12 +18,12 @@ RSpec.describe V2::Application do
       expect(middleware_classes).to include(Rack::JSONBodyParser)
     end
 
-    it 'includes CsrfResponseHeader middleware' do
+    it 'does not include CsrfResponseHeader (moved to shared MiddlewareStack)' do
       middleware_classes = described_class.middleware.map do |middleware_spec|
         middleware_spec.first
       end
 
-      expect(middleware_classes).to include(Onetime::Middleware::CsrfResponseHeader)
+      expect(middleware_classes).not_to include(Onetime::Middleware::CsrfResponseHeader)
     end
   end
 end

--- a/apps/web/auth/application.rb
+++ b/apps/web/auth/application.rb
@@ -26,11 +26,6 @@ module Auth
     # Auth app specific middleware (common middleware is in MiddlewareStack)
     use Rack::JSONBodyParser  # Parse JSON request bodies for Rodauth
 
-    # CSRF Response Header
-    # Note: CSRF validation is handled by common Security middleware with
-    # allow_if to skip JSON requests. Rodauth json feature disables CSRF internally.
-    use Onetime::Middleware::CsrfResponseHeader
-
     Onetime.development? do
       # Development configuration if needed
     end

--- a/apps/web/billing/application.rb
+++ b/apps/web/billing/application.rb
@@ -44,11 +44,6 @@ module Billing
       !Onetime.billing_config.enabled?
     end
 
-    # CSRF Response Header
-    # Note: CSRF validation is handled by common Security middleware with
-    # allow_if to skip webhook endpoints. This just adds the response header.
-    use Onetime::Middleware::CsrfResponseHeader
-
     warmup do
       # Warmup is for preloading and preparing the router
       # Actual initialization logic is in initializers/

--- a/apps/web/core/application.rb
+++ b/apps/web/core/application.rb
@@ -38,11 +38,6 @@ module Core
     # Initialize request context (nonce, locale) before other processing
     use Core::Middleware::RequestSetup
 
-    # CSRF Response Header
-    # Note: CSRF validation is handled by common Security middleware with
-    # allow_if to skip JSON/API requests. This just adds the response header.
-    use Onetime::Middleware::CsrfResponseHeader
-
     # Simplified error handling for Vue SPA - serves entry points
     # Must come after security but before router to catch all downstream errors
     use Core::Middleware::ErrorHandling

--- a/lib/onetime/application/middleware_stack.rb
+++ b/lib/onetime/application/middleware_stack.rb
@@ -11,6 +11,7 @@ require 'rack/utf8_sanitizer'
 require_relative '../session'
 require_relative '../middleware/ip_ban'
 require_relative '../middleware/health_access_control'
+require_relative '../middleware/csrf_response_header'
 require 'otto'
 
 module Onetime
@@ -190,6 +191,11 @@ module Onetime
             # Position Sentry middleware early to capture exceptions throughout the stack
             builder.use Sentry::Rack::CaptureExceptions
           end
+
+          # CSRF Response Header - MUST be before Security middleware so that
+          # 403 responses from AuthenticityToken also get a fresh masked token.
+          logger.debug 'Setting up CSRF Response Header middleware'
+          builder.use Onetime::Middleware::CsrfResponseHeader
 
           # Security Middleware Configuration
           # Configures security-related middleware components based on application settings

--- a/locales/content/en/session-auth-extended.json
+++ b/locales/content/en/session-auth-extended.json
@@ -154,6 +154,10 @@
     "text": "Invalid or missing login link",
     "sha256": "d726c0da"
   },
+  "web.auth.magicLink.sessionExpired": {
+    "text": "Your session has expired. Please refresh the page and try again.",
+    "sha256": "a7c3e901"
+  },
   "web.auth.magicLink.loginFailed": {
     "text": "Login failed. Please try again.",
     "sha256": "c95b4875"

--- a/src/shared/composables/useFormSubmission.ts
+++ b/src/shared/composables/useFormSubmission.ts
@@ -67,9 +67,16 @@ export function useFormSubmission<ResponseSchema extends z.ZodType>(
         method: 'POST',
         headers: {
           'Content-Type': 'application/x-www-form-urlencoded',
+          'X-CSRF-Token': csrfStore.shrimp,
         },
         body: urlSearchParams.toString(),
       });
+
+      // Refresh CSRF token from response header (mirrors Axios interceptor behavior)
+      const responseShrimp = response.headers.get('x-csrf-token');
+      if (responseShrimp && responseShrimp.length > 0) {
+        csrfStore.updateShrimp(responseShrimp);
+      }
 
       let jsonData: z.infer<ResponseSchema>;
       try {

--- a/src/shared/composables/useFormSubmission.ts
+++ b/src/shared/composables/useFormSubmission.ts
@@ -72,7 +72,8 @@ export function useFormSubmission<ResponseSchema extends z.ZodType>(
         body: urlSearchParams.toString(),
       });
 
-      // Refresh CSRF token from response header (mirrors Axios interceptor behavior)
+      // Refresh CSRF token from response header first; the JSON body's shrimp
+      // field takes precedence below as the primary CSRF token path.
       const responseShrimp = response.headers.get('x-csrf-token');
       if (responseShrimp && responseShrimp.length > 0) {
         csrfStore.updateShrimp(responseShrimp);

--- a/src/tests/composables/useFormSubmission.spec.ts
+++ b/src/tests/composables/useFormSubmission.spec.ts
@@ -1,0 +1,167 @@
+// src/tests/composables/useFormSubmission.spec.ts
+
+import { useFormSubmission } from '@/shared/composables/useFormSubmission';
+import { useCsrfStore } from '@/shared/stores/csrfStore';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+
+/**
+ * Creates a mock Response with configurable headers and JSON body.
+ */
+function createMockResponse(
+  body: Record<string, unknown>,
+  options: { status?: number; headers?: Record<string, string> } = {}
+): Response {
+  const { status = 200, headers = {} } = options;
+  const headersObj = new Headers(headers);
+  headersObj.set('content-type', 'application/json');
+
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: headersObj,
+    json: () => Promise.resolve(body),
+  } as Response;
+}
+
+describe('useFormSubmission', () => {
+  let csrfStore: ReturnType<typeof useCsrfStore>;
+  const testUrl = '/api/v2/test';
+  const testSchema = z.object({ message: z.string() }).passthrough();
+
+  beforeEach(() => {
+    csrfStore = useCsrfStore();
+    csrfStore.init();
+    csrfStore.updateShrimp('initial-shrimp-token');
+
+    // Reset fetch mock before each test
+    vi.mocked(global.fetch).mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  /**
+   * Helper to create a composable instance with standard options.
+   */
+  function createSubmission(overrides: Record<string, unknown> = {}) {
+    return useFormSubmission({
+      url: testUrl,
+      successMessage: 'Done',
+      schema: testSchema,
+      getFormData: () => new URLSearchParams({ field: 'value' }),
+      ...overrides,
+    });
+  }
+
+  describe('CSRF token in request', () => {
+    it('sends CSRF token in X-CSRF-Token header', async () => {
+      vi.mocked(global.fetch).mockResolvedValue(
+        createMockResponse({ message: 'ok' }, {
+          headers: { 'x-csrf-token': 'new-token' },
+        })
+      );
+
+      const { submitForm } = createSubmission();
+      await submitForm();
+
+      const [, fetchInit] = vi.mocked(global.fetch).mock.calls[0];
+      const headers = fetchInit?.headers as Record<string, string>;
+      expect(headers['X-CSRF-Token']).toBe('initial-shrimp-token');
+    });
+
+    it('sends shrimp in form body', async () => {
+      vi.mocked(global.fetch).mockResolvedValue(
+        createMockResponse({ message: 'ok' })
+      );
+
+      const { submitForm } = createSubmission();
+      await submitForm();
+
+      const [, fetchInit] = vi.mocked(global.fetch).mock.calls[0];
+      const body = new URLSearchParams(fetchInit?.body as string);
+      expect(body.get('shrimp')).toBe('initial-shrimp-token');
+    });
+  });
+
+  describe('CSRF token refresh from response header', () => {
+    it('updates CSRF token from success response header', async () => {
+      vi.mocked(global.fetch).mockResolvedValue(
+        createMockResponse({ message: 'ok' }, {
+          headers: { 'x-csrf-token': 'refreshed-token' },
+        })
+      );
+
+      const { submitForm } = createSubmission();
+      await submitForm();
+
+      expect(csrfStore.shrimp).toBe('refreshed-token');
+    });
+
+    it('updates CSRF token from error response header', async () => {
+      vi.mocked(global.fetch).mockResolvedValue(
+        createMockResponse(
+          { message: 'Bad request' },
+          { status: 400, headers: { 'x-csrf-token': 'error-refreshed-token' } }
+        )
+      );
+
+      const { submitForm } = createSubmission();
+      await submitForm();
+
+      expect(csrfStore.shrimp).toBe('error-refreshed-token');
+    });
+
+    it('handles missing x-csrf-token header gracefully', async () => {
+      vi.mocked(global.fetch).mockResolvedValue(
+        createMockResponse({ message: 'ok' })
+      );
+
+      const { submitForm } = createSubmission();
+      await submitForm();
+
+      // Token stays at initial value when no header present
+      expect(csrfStore.shrimp).toBe('initial-shrimp-token');
+    });
+  });
+
+  describe('backward compatibility: shrimp in JSON body', () => {
+    it('updates shrimp from JSON response body', async () => {
+      const responseSchema = z.object({
+        message: z.string(),
+        shrimp: z.string(),
+      });
+
+      vi.mocked(global.fetch).mockResolvedValue(
+        createMockResponse({ message: 'ok', shrimp: 'body-shrimp-token' })
+      );
+
+      const { submitForm } = createSubmission({ schema: responseSchema });
+      await submitForm();
+
+      // JSON body shrimp overwrites header shrimp (it runs after)
+      expect(csrfStore.shrimp).toBe('body-shrimp-token');
+    });
+
+    it('header token is applied even when JSON body also has shrimp', async () => {
+      const responseSchema = z.object({
+        message: z.string(),
+        shrimp: z.string(),
+      });
+
+      vi.mocked(global.fetch).mockResolvedValue(
+        createMockResponse(
+          { message: 'ok', shrimp: 'body-token' },
+          { headers: { 'x-csrf-token': 'header-token' } }
+        )
+      );
+
+      const { submitForm } = createSubmission({ schema: responseSchema });
+      await submitForm();
+
+      // Body shrimp runs after header refresh, so body wins
+      expect(csrfStore.shrimp).toBe('body-token');
+    });
+  });
+});

--- a/src/tests/composables/useMagicLink.spec.ts
+++ b/src/tests/composables/useMagicLink.spec.ts
@@ -1,0 +1,121 @@
+// src/tests/composables/useMagicLink.spec.ts
+
+import { useMagicLink } from '@/shared/composables/useMagicLink';
+import { useCsrfStore } from '@/shared/stores/csrfStore';
+import { setupTestPinia, type TestPiniaSetup } from '@/tests/setup';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+  }),
+}));
+
+describe('useMagicLink', () => {
+  let setup: TestPiniaSetup;
+  let csrfStore: ReturnType<typeof useCsrfStore>;
+
+  beforeEach(async () => {
+    setup = await setupTestPinia({ stubActions: false });
+    csrfStore = useCsrfStore();
+    csrfStore.shrimp = 'test-shrimp';
+  });
+
+  afterEach(() => {
+    setup.axiosMock?.reset();
+    vi.restoreAllMocks();
+  });
+
+  describe('requestMagicLink', () => {
+    it('returns true and sets sent on success', async () => {
+      setup.axiosMock?.onPost('/auth/email-login-request').reply(200, {
+        success: 'Link sent',
+      });
+
+      const { requestMagicLink, sent, error } = useMagicLink();
+      const result = await requestMagicLink('user@example.com');
+
+      expect(result).toBe(true);
+      expect(sent.value).toBe(true);
+      expect(error.value).toBeNull();
+    });
+
+    it('returns false and sets error on server error response', async () => {
+      setup.axiosMock?.onPost('/auth/email-login-request').reply(200, {
+        error: 'Account not found',
+        'field-error': ['login', 'Not found'],
+      });
+
+      const { requestMagicLink, sent, error, fieldError } = useMagicLink();
+      const result = await requestMagicLink('bad@example.com');
+
+      expect(result).toBe(false);
+      expect(sent.value).toBe(false);
+      expect(error.value).toBe('Account not found');
+      expect(fieldError.value).toEqual(['login', 'Not found']);
+    });
+
+    it('retries transparently on 403 and succeeds', async () => {
+      let callCount = 0;
+      setup.axiosMock?.onPost('/auth/email-login-request').reply(() => {
+        callCount++;
+        if (callCount === 1) {
+          return [403, { error: 'Forbidden' }];
+        }
+        return [200, { success: 'Link sent' }];
+      });
+
+      const { requestMagicLink, sent, error } = useMagicLink();
+      const result = await requestMagicLink('user@example.com');
+
+      expect(callCount).toBe(2);
+      expect(result).toBe(true);
+      expect(sent.value).toBe(true);
+      expect(error.value).toBeNull();
+    });
+
+    it('shows sessionExpired when 403 retry also fails', async () => {
+      setup.axiosMock?.onPost('/auth/email-login-request').reply(403, {
+        error: 'Forbidden',
+      });
+
+      const { requestMagicLink, sent, error } = useMagicLink();
+      const result = await requestMagicLink('user@example.com');
+
+      expect(result).toBe(false);
+      expect(sent.value).toBe(false);
+      expect(error.value).toBe('web.auth.magicLink.sessionExpired');
+    });
+
+    it('returns false with networkError on network failure', async () => {
+      setup.axiosMock?.onPost('/auth/email-login-request').networkError();
+
+      const { requestMagicLink, error } = useMagicLink();
+      const result = await requestMagicLink('user@example.com');
+
+      expect(result).toBe(false);
+      expect(error.value).toBe('web.auth.magicLink.networkError');
+    });
+
+    it('does not retry on non-403 HTTP errors', async () => {
+      let callCount = 0;
+      setup.axiosMock?.onPost('/auth/email-login-request').reply(() => {
+        callCount++;
+        return [500, { error: 'Internal Server Error' }];
+      });
+
+      const { requestMagicLink, error } = useMagicLink();
+      const result = await requestMagicLink('user@example.com');
+
+      expect(callCount).toBe(1);
+      expect(result).toBe(false);
+      expect(error.value).toBe('Internal Server Error');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

When a request fails CSRF validation (403), the frontend couldn't recover because the error response didn't include a fresh token. Users would get stuck with expired tokens and see confusing rejection errors instead of actual form feedback.

This fixes the problem in two layers:

- **Backend**: Moved `CsrfResponseHeader` middleware before the Security middleware in the shared stack, so 403 responses now include a fresh `X-CSRF-Token` header. This also consolidates the middleware from 6 per-app registrations into one shared location.
- **Frontend**: `useFormSubmission` now sends and reads CSRF tokens via headers (matching the existing Axios interceptor pattern). `useMagicLink` retries once on 403, so the Axios error interceptor can refresh the token transparently before the retry succeeds.

## Changes

- Consolidated `CsrfResponseHeader` middleware into `MiddlewareStack` (removed from 6 app files)
- `useFormSubmission.ts` sends `X-CSRF-Token` header and refreshes from response headers on both success and error
- `useMagicLink.ts` extracts API call into helper, adds single-retry on 403 with `sessionExpired` fallback
- Added `web.auth.magicLink.sessionExpired` locale key

## Test plan

- [x] Integration test: 403 responses include `X-CSRF-Token` header
- [x] `useFormSubmission.spec.ts`: token in request, refresh from headers, backward compat with shrimp in body
- [x] `useMagicLink.spec.ts`: success, server errors, 403 retry success, retry failure, network errors, non-403 no-retry
- [ ] Manual: trigger CSRF expiry during magic link flow, verify transparent retry