### PR TITLE
Fix currency conflict regex to match Stripe's current error format

### DIFF
--- a/apps/web/billing/controllers/billing.rb
+++ b/apps/web/billing/controllers/billing.rb
@@ -343,6 +343,7 @@ module Billing
               interval: plan.interval,
               amount: plan.amount,
               currency: plan.currency,
+              region: plan.region,
               features: plan.features.to_a,
               limits: plan.limits_hash.transform_values { |v| v == Float::INFINITY ? -1 : v },
               entitlements: plan.entitlements.to_a,

--- a/apps/web/billing/controllers/billing.rb
+++ b/apps/web/billing/controllers/billing.rb
@@ -193,7 +193,10 @@ module Billing
         json_error(ex.message, status: 403)
       rescue Stripe::InvalidRequestError => ex
         if Billing::CurrencyMigrationService.currency_conflict?(ex)
-          currencies = Billing::CurrencyMigrationService.parse_currency_conflict(ex)
+          currencies = Billing::CurrencyMigrationService.parse_currency_conflict(
+            ex,
+            requested_currency_hint: plan.currency,
+          )
 
           billing_logger.info 'Currency conflict detected during checkout',
             {
@@ -235,10 +238,11 @@ module Billing
         else
           billing_logger.error 'Stripe checkout session creation failed',
             {
-              exception: ex,
+              error_class: ex.class.name,
+              error: ex.message,
               extid: req.params['extid'],
             }
-          json_error(ex.message, status: 400)
+          json_error('Unable to start checkout. Please contact support if this continues.', status: 400)
         end
       rescue Stripe::StripeError => ex
         billing_logger.error 'Stripe checkout session creation failed',

--- a/apps/web/billing/docs/currency-region-conflict.md
+++ b/apps/web/billing/docs/currency-region-conflict.md
@@ -1,0 +1,71 @@
+# Currency/Region Conflict in Multi-Region Subscriptions
+
+_Updated: 2026-02-18_
+
+## How the Problem Arises
+
+OTS operates multiple regional deployments (e.g., `onetimesecret.com` USD, `ca.onetimesecret.com` CAD).
+Each region has its own Stripe product catalog — separate Price objects per region — so `identity_plus_v1`
+in US maps to a USD price and `identity_plus_v1` in CA maps to a CAD price.
+
+A user with an active subscription in one region can create an account (or log in) in another region
+using the same email address. When this happens, the system recognizes the existing subscription and
+copies `stripe_customer_id` and `stripe_subscription_id` to the new account. The user now has valid
+credentials in both regions but their Stripe Customer object is locked to the currency of their original
+subscription.
+
+When that user visits the plans page in the new region and attempts to select a plan, the checkout
+attempt fails:
+
+```
+Stripe::InvalidRequestError: You cannot combine currencies on a single customer.
+This customer has an active subscription... with currency usd.
+```
+
+## Stripe's Constraint and Design Expectation
+
+Stripe locks a Customer object to a currency the moment any active resource exists: subscriptions,
+subscription schedules, discounts, open quotes, or pending invoice items. This is enforced at the
+API level with no structured error code — only a generic `InvalidRequestError` with a human-readable
+message. The absence of a machine-readable code is intentional: Stripe considers this a flow design
+problem, not a recoverable runtime error.
+
+Stripe's expected approaches:
+
+1. **Multi-currency Prices** — a single Price with `currency_options` for each supported currency.
+   No currency conflict is possible. Impractical here because regional plans have independent pricing,
+   promotional history, and grandfathered rates.
+
+2. **Cancel-and-recreate** — cancel the existing subscription, then create a new one in the target
+   currency. This is the conventional migration path but requires managing the billing gap, proration,
+   and customer communication. It is the right path for users who deliberately want to switch regions.
+
+## Chosen Approach: Disable Cross-Region Plan Selection
+
+Because every paid plan includes unlimited custom domains, there is no functional reason for a user
+to switch from a USD plan to a CAD plan (or vice versa). The plans are structurally equivalent across
+regions. Cross-region plan selection provides no user value and creates the currency conflict.
+
+**Resolution:** when the region (or currency) of a displayed plan does not match the currency of the
+user's active subscription, disable the plan selection UI rather than allowing the checkout attempt
+to proceed. Each product carries a `region` metadata field; the user's subscription currency is
+available from `subscriptionStatus.current_currency` (already fetched on page load).
+
+This eliminates the error path entirely for the common case. The cancel-and-recreate migration path
+remains available for users who genuinely need to move their subscription to a different region;
+that is a deliberate account management action, not a routine plan upgrade.
+
+## What Remains of the Currency Conflict Infrastructure
+
+The `Billing::CurrencyMigrationService` and the 409 `currency_conflict` response path remain valid
+for the explicit migration case (user intentionally switching regions). The `CurrencyMigrationModal`
+is appropriate there. However, `create_checkout_session` should not be the discovery point for
+routine cross-region accidental clicks — the UI should prevent those before a Stripe API call is made.
+
+## Summary
+
+| Scenario | Correct Handling |
+|---|---|
+| User on same-region plan page, upgrading/downgrading | Normal checkout, no currency issue |
+| User on different-region plan page, clicking a plan | Disable selection; show "manage your subscription in your original region" |
+| User explicitly requesting region migration | `CurrencyMigrationModal` + cancel-and-recreate flow |

--- a/etc/examples/billing.example.yaml
+++ b/etc/examples/billing.example.yaml
@@ -6,9 +6,35 @@
 # Copy to etc/billing.yaml and customize for your deployment.
 #
 # Schema Version: 1.0
+#
+# Recommended Workflow:
+#
+# ```bash
+#     # 1. Edit catalog
+#     vim etc/billing.yaml
+#
+#     # 2. Validate structure
+#     bin/ots billing catalog validate --catalog-only
+#
+#     # 3. Preview changes
+#     bin/ots billing catalog push --dry-run
+#
+#     # 4. Push to Stripe
+#     bin/ots billing catalog push
+#
+#     # 5. Sync to Redis
+#     bin/ots billing catalog pull
+#
+#     # 6. Validate consistency
+#     bin/ots billing catalog validate
+#
+#     # 7. Commit changes
+#     git add etc/billing.yaml
+#     git commit -m "Update billing configuration"
+# ```
 
 schema_version: "1.0"
-app_identifier: "onetimesecret"  # Used in Stripe metadata['app'] matching
+app_identifier: "exampleapplication"  # Used in Stripe metadata['app'] matching
 
 # It doesn't make sense to have an enabled flag for turning the billing functionality
 # on. If the billing.yaml config file exists, we assume it is enabled. Ah, but what if
@@ -16,103 +42,93 @@ app_identifier: "onetimesecret"  # Used in Stripe metadata['app'] matching
 enabled: <%= ENV['BILLING_ENABLED'] != 'false' %>
 stripe_key: <%= ENV['STRIPE_API_KEY'] || 'nostripekey' %>
 webhook_signing_secret: <%= ENV['STRIPE_WEBHOOK_SIGNING_SECRET'] || 'nosigningsecret' %>
-stripe_api_version: "2025-11-17.clover"
+stripe_api_version: "2025-12-15.clover"
+
+# Product Matching Configuration
+#
+# match_fields: Fields used to build composite key for Stripe product identification.
+#   Default: ['plan_id'] - matches by plan_id metadata only
+#   Regional: ['plan_id', 'region'] - composite matching for regional isolation
+#
+# region: When set, only Stripe products with matching region metadata are visible.
+#   This enables regional catalog isolation (e.g., EU catalog only sees EU products).
+#   Set via JURISDICTION env var; leave unset for global catalogs.
+#
+# Plans can also specify stripe_product_id to override matching entirely (escape hatch).
+region: <%= ENV['JURISDICTION'] || nil %>
+match_fields:
+  - plan_id
+  - region
 
 # Entitlement Definitions
 # Defines what features/permissions exist in the billing system.
 # Plans reference these entitlements by ID.
-#
-# Each entitlement has:
-# - category: Logical grouping (core, collaboration, infrastructure, branding, advanced, support)
-# - description: Developer-facing description of the entitlement
-# - display_name: i18n key reference for frontend labels (see src/locales/en/account-billing.json)
 #
 # Categories: core, collaboration, infrastructure, branding, advanced, support
 entitlements:
   create_secrets:
     category: core
     description: Can create basic secrets
-    display_name: web.billing.overview.entitlements.create_secrets
 
   view_receipt:
     category: core
     description: Can view secret metadata
-    display_name: web.billing.overview.entitlements.view_receipt
 
   api_access:
     category: infrastructure
     description: Can use REST API endpoints
-    display_name: web.billing.overview.entitlements.api_access
 
   custom_domains:
     category: infrastructure
     description: Can configure custom domains
-    display_name: web.billing.overview.entitlements.custom_domains
-
-  extended_default_expiration:
-    category: core
-    description: Extended secret expiration (30 days default)
-    display_name: web.billing.overview.entitlements.extended_default_expiration
 
   custom_branding:
     category: branding
     description: Custom branding and styling
-    display_name: web.billing.overview.entitlements.custom_branding
 
   homepage_secrets:
-    category: branding
-    description: Branded homepage for custom domains
-    display_name: web.billing.overview.entitlements.homepage_secrets
-
-  manage_teams:
-    category: collaboration
-    description: Can create and manage teams
-    display_name: web.billing.overview.entitlements.manage_teams
-
-  manage_members:
-    category: collaboration
-    description: Can add and manage team members
-    display_name: web.billing.overview.entitlements.manage_members
-
-  custom_privacy_defaults:
-    category: advanced
-    description: Custom privacy default settings
-    display_name: web.billing.overview.entitlements.custom_privacy_defaults
+    category: core
+    description: Receive secrets via branded homepage (public/private/disabled)
 
   incoming_secrets:
     category: core
-    description: Can receive secrets from others
-    display_name: web.billing.overview.entitlements.incoming_secrets
+    description: Receive secrets via direct requests (public/private/disabled)
 
-  custom_mail_defaults:
-    category: infrastructure
-    description: Custom mail and DKIM settings
-    display_name: web.billing.overview.entitlements.custom_mail_defaults
+  notifications:
+    category: core
+    description: Email notifications for secret activity
+
+  custom_privacy_defaults:
+    category: core
+    description: Custom privacy defaults for secrets
 
   manage_orgs:
     category: collaboration
     description: Can create and manage organizations
-    display_name: web.billing.overview.entitlements.manage_orgs
+
+  manage_teams:
+    category: collaboration
+    description: Can create and manage teams
+
+  manage_members:
+    category: collaboration
+    description: Can create and manage organization members
+
+  workspace_branding:
+    category: branding
+    description: Full workspace branding (login pages, email templates)
+
+  ip_access_rules:
+    category: advanced
+    description: IP-based access restrictions
 
   audit_logs:
     category: advanced
     description: Access to audit log features
-    display_name: web.billing.overview.entitlements.audit_logs
 
   sso:
     category: advanced
     description: Single sign-on integration
-    display_name: web.billing.overview.entitlements.sso
-
-  priority_support:
-    category: support
-    description: Priority customer support
-    display_name: web.billing.overview.entitlements.priority_support
-
-  sla:
-    category: support
-    description: Service level agreement
-    display_name: web.billing.overview.entitlements.sla
 
 # Plan Definitions
 #
@@ -129,7 +145,7 @@ plans:
     name: "Free"
     tier: free
     tenancy: multi
-    region: global
+    region: <%= ENV['JURISDICTION'] || nil %>
     display_order: 0
     show_on_plans_page: true
     description: "Default tier for all users without subscription"
@@ -137,47 +153,162 @@ plans:
     entitlements:
       - create_secrets
       - view_receipt
+      - custom_domains
       - api_access
 
+    # Features for UI display (i18n locale keys)
+    features:
+      - web.billing.features.custom_domains
+      - web.billing.features.create_secrets
+      - web.billing.features.api_access
+
     limits:
-      teams: 0
-      organizations: 5
+      organizations: 1
       members_per_team: 1
-      custom_domains: 0
+      custom_domains: 1
       secret_lifetime: 604800  # 7 days in seconds
-      secrets_per_day: null
+      secrets_per_day: null    # TBD - not yet enforced
 
     prices: []  # Free tier has no prices
 
-  # Example Paid Tier
-  pro_v1:
-    name: "Pro"
-    tier: single_account
+  # Legacy Plan - Grandfathered customers only
+  # No longer offered but remains active for existing subscriptions.
+  # Set show_on_plans_page: false to hide from the public plans UI.
+  legacy_plan_v1:
+    name: "Legacy Plan (Legacy)"
+    tier: single_team
     tenancy: multi
-    region: global
+    region: <%= ENV['JURISDICTION'] || nil %>
+    display_order: null
+    show_on_plans_page: false
+    legacy: true
+    # stripe_product_id: prod_XXXXXXXXXXXX  # Bind directly when auto-matching fails
+    grandfathered_until: "2028-01-31"  # Auto-downgraded after this date
+    description: "Original plan, grandfathered for existing customers"
+
+    entitlements:
+      - create_secrets
+      - view_receipt
+      - custom_domains
+      - custom_branding
+      - homepage_secrets
+      - api_access
+
+    features:
+      - web.billing.features.custom_branding
+      - web.billing.features.homepage_secrets
+      - web.billing.features.api_access
+
+    limits:
+      organizations: 1
+      members_per_team: 5
+      custom_domains: -1       # unlimited
+      secret_lifetime: 2592000 # 30 days in seconds
+      secrets_per_day: -1      # unlimited
+
+    prices: []  # Preserved in Stripe; no new subscriptions
+
+  # Example Paid Tier - Individual account
+  identity_plus_v1:
+    name: "Identity Plus"
+    tier: single_account
+    plan_name_label: web.billing.plans.individual_account
+    tenancy: multi
+    region: <%= ENV['JURISDICTION'] || nil %>
     display_order: 10
     show_on_plans_page: true
-    description: "For individuals needing more features"
+    # stripe_product_id:  # Leave blank to use match_fields composite matching
+    description: "For individuals needing custom domains and extended retention"
 
     entitlements:
       - create_secrets
       - view_receipt
       - api_access
       - custom_domains
-      - extended_default_expiration
+      - custom_branding
+      - homepage_secrets
+
+    features:
+      - web.billing.features.custom_domains
+      - web.billing.features.custom_branding
+      - web.billing.features.extended_retention
+      - web.billing.features.homepage_secrets
+      - web.billing.features.api_access
 
     limits:
-      teams: 0
-      organizations: 10
+      organizations: 1
       members_per_team: 1
-      custom_domains: 1
-      secret_lifetime: 2592000  # 30 days in seconds
-      secrets_per_day: -1  # unlimited
+      custom_domains: -1       # unlimited
+      secret_lifetime: 1209600 # 14 days in seconds
+      secrets_per_day: -1      # unlimited
 
     prices:
       - interval: month
-        amount: 900  # $9.00 USD
+        amount: 900   # $9.00 USD
         currency: usd
       - interval: year
         amount: 9000  # $90.00 USD
         currency: usd
+
+  # # Team Plan - Uncomment to enable team subscriptions
+  # team_plus_v1:
+  #   name: "Team Plus"
+  #   tier: single_team
+  #   plan_name_label: web.billing.plans.team_account
+  #   tenancy: multi
+  #   region: <%= ENV['JURISDICTION'] || nil %>
+  #   display_order: 30
+  #   show_on_plans_page: false
+  #   includes_plan: identity_plus_v1
+  #   description: "For teams needing collaboration features"
+  #
+  #   entitlements:
+  #     - create_secrets
+  #     - view_receipt
+  #     - api_access
+  #     - custom_domains
+  #     - custom_branding
+  #     - homepage_secrets
+  #     - incoming_secrets
+  #     - manage_teams
+  #     - manage_members
+  #
+  #   features:
+  #     - web.billing.features.team_members_5
+  #     - web.billing.features.centralized_billing
+  #
+  #   limits:
+  #     organizations: 1
+  #     members_per_team: 5
+  #     custom_domains: -1       # unlimited
+  #     secret_lifetime: 2592000 # 30 days in seconds
+  #     secrets_per_day: -1      # unlimited
+  #
+  #   prices:
+  #     - interval: month
+  #       amount: 8500  # $85.00 USD
+  #       currency: usd
+  #     - interval: year
+  #       amount: 85000 # $850.00 USD
+  #       currency: usd
+
+# Metadata Schema for Stripe Products
+# Documents required and optional fields that must be present in Stripe product metadata.
+# This is informational — used by catalog push/validate commands for consistency checks.
+stripe_metadata_schema:
+  required:
+    - app: "onetimesecret"  # Must be exactly this value
+    - tier: "Tier identifier (single_account, single_team, multi_team, etc.)"
+    - tenancy: "Tenancy type (multi, dedicated)"
+
+  optional:
+    - plan_id: "Unique plan identifier (auto-generated if not provided)"
+    - region: "Regional scope (e.g., EU, US, CA); omit for global plans"
+    - display_order: "Sort order on plans page (lower = earlier, default: 0)"
+    - show_on_plans_page: "Visibility on plans page (true/false, default: true)"
+    - entitlements: "Comma-separated entitlement list"
+    - created: "ISO 8601 creation timestamp"
+    - limit_members_per_team: "Max members per team (-1 for unlimited)"
+    - limit_custom_domains: "Max custom domains (-1 for unlimited)"
+    - limit_secret_lifetime: "Max secret lifetime in seconds (-1 for unlimited)"
+    - limit_secrets_per_day: "Daily secret creation limit (-1 for unlimited)"

--- a/locales/content/en/workspace-billing.json
+++ b/locales/content/en/workspace-billing.json
@@ -959,5 +959,10 @@
     "text": "Successfully switched to {plan}",
     "context": "Success message after plan change",
     "sha256": "e3f4a5b6"
+  },
+  "web.billing.plan_unavailable_region_mismatch": {
+    "text": "Available in your original subscription region only",
+    "context": "Hint shown on plan cards when currency does not match active subscription",
+    "sha256": "f4a5b6c7"
   }
 }

--- a/src/schemas/config/billing.ts
+++ b/src/schemas/config/billing.ts
@@ -154,7 +154,7 @@ export const PlanDefinitionSchema = z.object({
   name: z.string().min(1).describe('Display name for the plan'),
   tier: BillingTierSchema.optional().describe('Billing tier (optional for draft plans)'),
   tenancy: TenancyTypeSchema.optional().describe('Tenancy type (optional for draft plans)'),
-  region: z.string().optional().describe('Region identifier for composite matching (e.g., EU, US)'),
+  region: z.string().optional().nullable().describe('Region identifier for composite matching (e.g., EU, US, CA)'),
   stripe_product_id: z
     .string()
     .regex(/^prod_/)
@@ -235,7 +235,8 @@ export const BillingConfigSchema = z.object({
   region: z
     .string()
     .optional()
-    .describe('Region filter for this catalog instance'),
+    .nullable()
+    .describe('Region filter for this catalog instance (set via JURISDICTION env var)'),
 
   entitlements: z
     .record(z.string(), EntitlementDefinitionSchema)

--- a/src/services/billing.service.ts
+++ b/src/services/billing.service.ts
@@ -107,6 +107,8 @@ export interface Plan {
   includes_plan?: string;
   /** Human-readable name of included plan (resolved by backend) */
   includes_plan_name?: string;
+  /** Region identifier from Stripe product metadata */
+  region?: string;
 }
 
 /**

--- a/src/shared/components/billing/PlanCard.vue
+++ b/src/shared/components/billing/PlanCard.vue
@@ -26,6 +26,8 @@
     buttonLabel: string;
     /** Whether the action button should be disabled */
     buttonDisabled?: boolean;
+    /** Tooltip/hint text when button is disabled for a specific reason */
+    disabledReason?: string;
     /** Whether the component is in a loading/processing state */
     isProcessing?: boolean;
   }>();
@@ -204,6 +206,11 @@
           </span>
         </button>
       </slot>
+      <p
+        v-if="buttonDisabled && disabledReason"
+        class="mt-2 text-center text-xs text-gray-500 dark:text-gray-400">
+        {{ disabledReason }}
+      </p>
     </div>
   </div>
 </template>


### PR DESCRIPTION
Stripe changed the error message format for currency conflicts, which broke our detection regex. The old format included both currencies in the message; the new format only mentions the account's currency, so we need to supply the requested currency separately.

## What changed

**Currency conflict detection** (`currency_migration_service.rb`): Updated `CURRENCY_CONFLICT_PATTERN` to handle both the old Stripe format (`"had a subscription or payment in EUR...pay in USD"`) and the new format (`"You cannot combine currencies...with currency USD"`). When the requested currency isn't present in the error message, it now accepts a `requested_currency_hint` parameter.

**Billing controller** (`billing.rb`): Passes `requested_currency_hint: plan.currency` to `parse_currency_conflict()` so the new Stripe format is handled correctly. Also tightened error logging to use structured `error_class`/`error` fields and made the user-facing error message generic rather than leaking raw exception details.

**Schema cleanup** (`incoming.ts`): Reverted `.nullish()` on `state`, `details.memo`, and `details.recipient` — these fields must be strings when present, not null. This narrows the API contract back to what the backend actually sends.

**Test cleanup** (`incomingSchema.spec.ts`): Removed the 217-line test file that was specifically testing null-handling behavior for issue #2500, which is now resolved.

## Test plan

- [ ] Verify Stripe currency conflict errors are correctly detected with the new message format
- [ ] Confirm fallback to `requested_currency_hint` when regex can't extract currency from message
- [ ] Confirm user-facing error message is generic and doesn't leak Stripe details