### PR TITLE
Use RabbitMQ policies for DLQ TTL instead of queue arguments

### DIFF
--- a/changelog.d/20260219_005212_delano_2529_dlq_policies.rst
+++ b/changelog.d/20260219_005212_delano_2529_dlq_policies.rst
@@ -1,0 +1,38 @@
+.. A new scriv changelog fragment.
+
+Changed
+-------
+
+- DLQ message TTL is now managed via a RabbitMQ policy (``dlq-ttl``) rather
+  than queue arguments. Policies are mutable at runtime; queue arguments are
+  not, and caused ``PRECONDITION_FAILED`` errors on worker startup when TTL
+  config changed. PR #2529
+
+- ``bin/ots queue init`` now applies the ``dlq-ttl`` policy as step 4 via the
+  Management API. ``bin/ots queue status`` reports active DLQ policies.
+
+**Upgrading existing installs** (environments with DLQ queues declared before
+this release):
+
+.. code-block:: bash
+
+   # Check DLQ message counts — any messages are failed jobs already dead-lettered
+   bin/ots queue status
+
+   # Stop workers, then delete and recreate all queues (destroys DLQ messages)
+   bin/ots queue reset --force
+
+   # Recreate infrastructure and apply the dlq-ttl policy
+   bin/ots queue init
+
+   # Restart workers and verify
+   bin/ots queue status
+
+If DLQ messages must be preserved, drain them before resetting (requeue or
+archive via the Management UI), then proceed with the reset.
+
+AI Assistance
+-------------
+
+- Claude assisted with debugging CI test failures in the DLQ policy filter
+  and nil/empty-array return value semantics for the Management API client.

--- a/lib/onetime/cli/queue/init_command.rb
+++ b/lib/onetime/cli/queue/init_command.rb
@@ -27,12 +27,15 @@ require 'json'
 require 'uri'
 require_relative '../../jobs/queues/config'
 require_relative '../../jobs/queues/declarator'
+require_relative 'rabbitmq_helpers'
 
 module Onetime
   module CLI
     module Queue
       class InitCommand < Command
         desc 'Initialize RabbitMQ vhost, exchanges, and queues'
+
+        include Onetime::CLI::Queue::RabbitMQHelpers
 
         option :force,
           type: :boolean,
@@ -93,45 +96,6 @@ module Onetime
         end
 
         private
-
-        # Mask credentials in AMQP URL using URI parsing for robustness
-        # Handles passwords containing special characters like : or @
-        def mask_amqp_credentials(url)
-          uri = URI.parse(url)
-          return url unless uri.userinfo
-
-          masked_uri          = uri.dup
-          masked_uri.userinfo = '***:***'
-          masked_uri.to_s
-        rescue URI::InvalidURIError
-          # Fallback for malformed URLs
-          url.gsub(%r{//[^@]*@}, '//***:***@')
-        end
-
-        def parse_amqp_url(url)
-          uri      = URI.parse(url)
-          raw_path = uri.path&.sub(%r{^/}, '')
-          vhost    = raw_path.nil? || raw_path.empty? ? '/' : raw_path
-          {
-            host: uri.host || 'localhost',
-            port: uri.port || 5672,
-            user: uri.user || 'guest',
-            password: uri.password || 'guest',
-            vhost: vhost,
-            scheme: uri.scheme || 'amqp',
-          }
-        end
-
-        def management_url
-          ENV.fetch('RABBITMQ_MANAGEMENT_URL', 'http://localhost:15672')
-        end
-
-        def management_credentials
-          # Try to get from RABBITMQ_URL first, fall back to defaults
-          amqp_url = ENV.fetch('RABBITMQ_URL', 'amqp://guest:guest@localhost:5672')
-          parsed   = parse_amqp_url(amqp_url)
-          [parsed[:user], parsed[:password]]
-        end
 
         def create_vhost(parsed)
           vhost = parsed[:vhost]
@@ -249,20 +213,21 @@ module Onetime
 
           puts 'Applying DLQ policies via Management API...'
 
+          encoded_vhost = URI.encode_www_form_component(vhost)
+          user, pw      = management_credentials
+          base_uri      = URI.parse(management_url)
+
+          http              = Net::HTTP.new(base_uri.host, base_uri.port)
+          http.use_ssl      = base_uri.scheme == 'https'
+          http.open_timeout = 5
+          http.read_timeout = 10
+
           Onetime::Jobs::QueueConfig::DLQ_POLICIES.each do |policy|
-            policy_name   = policy[:name]
-            encoded_vhost = URI.encode_www_form_component(vhost)
-            encoded_name  = URI.encode_www_form_component(policy_name)
+            policy_name  = policy[:name]
+            encoded_name = URI.encode_www_form_component(policy_name)
+            path         = "/api/policies/#{encoded_vhost}/#{encoded_name}"
 
-            uri      = URI.parse("#{management_url}/api/policies/#{encoded_vhost}/#{encoded_name}")
-            user, pw = management_credentials
-
-            http              = Net::HTTP.new(uri.host, uri.port)
-            http.use_ssl      = uri.scheme == 'https'
-            http.open_timeout = 5
-            http.read_timeout = 10
-
-            request                 = Net::HTTP::Put.new(uri.path)
+            request                 = Net::HTTP::Put.new(path)
             request.basic_auth(user, pw)
             request['Content-Type'] = 'application/json'
             request.body            = JSON.generate(

--- a/lib/onetime/cli/queue/rabbitmq_helpers.rb
+++ b/lib/onetime/cli/queue/rabbitmq_helpers.rb
@@ -1,0 +1,60 @@
+# lib/onetime/cli/queue/rabbitmq_helpers.rb
+#
+# frozen_string_literal: true
+
+require 'uri'
+
+module Onetime
+  module CLI
+    module Queue
+      # Shared helpers for CLI commands that interact with RabbitMQ.
+      #
+      # Include this module in any Command class that needs to parse AMQP URLs,
+      # build management API URLs, or mask credentials in output.
+      module RabbitMQHelpers
+        # Parse an AMQP URL into its component parts.
+        #
+        # Returns a hash with keys: :host, :port, :user, :password, :vhost, :scheme
+        def parse_amqp_url(url)
+          uri      = URI.parse(url)
+          raw_path = uri.path&.sub(%r{^/}, '')
+          vhost    = raw_path.nil? || raw_path.empty? ? '/' : raw_path
+          {
+            host: uri.host || 'localhost',
+            port: uri.port || 5672,
+            user: uri.user || 'guest',
+            password: uri.password || 'guest',
+            vhost: vhost,
+            scheme: uri.scheme || 'amqp',
+          }
+        end
+
+        # Base URL for the RabbitMQ Management HTTP API.
+        def management_url
+          ENV.fetch('RABBITMQ_MANAGEMENT_URL', 'http://localhost:15672')
+        end
+
+        # Returns [user, password] extracted from RABBITMQ_URL.
+        def management_credentials
+          amqp_url = ENV.fetch('RABBITMQ_URL', 'amqp://guest:guest@localhost:5672')
+          parsed   = parse_amqp_url(amqp_url)
+          [parsed[:user], parsed[:password]]
+        end
+
+        # Mask credentials in AMQP URL using URI parsing for robustness.
+        # Handles passwords containing special characters like : or @
+        def mask_amqp_credentials(url)
+          uri = URI.parse(url)
+          return url unless uri.userinfo
+
+          masked_uri          = uri.dup
+          masked_uri.userinfo = '***:***'
+          masked_uri.to_s
+        rescue URI::InvalidURIError
+          # Fallback for malformed URLs
+          url.gsub(%r{//[^@]*@}, '//***:***@')
+        end
+      end
+    end
+  end
+end

--- a/lib/onetime/cli/queue/status_command.rb
+++ b/lib/onetime/cli/queue/status_command.rb
@@ -220,10 +220,10 @@ module Onetime
 
           response = http.request(request)
 
-          return [] unless response.code.to_i == 200
+          return nil unless response.code.to_i == 200
 
           policies = JSON.parse(response.body)
-          policies.select { |p| p['pattern']&.include?('dlq') }
+          policies.select { |p| p['pattern']&.start_with?('dlq', '^dlq') }
         rescue StandardError
           # Management API unavailable or error — not critical for status
           nil

--- a/lib/onetime/cli/queue/status_command.rb
+++ b/lib/onetime/cli/queue/status_command.rb
@@ -220,10 +220,10 @@ module Onetime
 
           response = http.request(request)
 
-          return nil unless response.code.to_i == 200
+          return [] unless response.code.to_i == 200
 
           policies = JSON.parse(response.body)
-          policies.select { |p| p['pattern']&.match?(/^dlq\./) }
+          policies.select { |p| p['pattern']&.include?('dlq') }
         rescue StandardError
           # Management API unavailable or error — not critical for status
           nil

--- a/lib/onetime/jobs/queues/config.rb
+++ b/lib/onetime/jobs/queues/config.rb
@@ -79,21 +79,31 @@ module Onetime
       DEAD_LETTER_CONFIG = {
         'dlx.email.message' => {
           queue: 'dlq.email.message',
-          arguments: { 'x-message-ttl' => DLQ_MESSAGE_TTL },
+          arguments: {},
         },
         'dlx.notifications.alert' => {
           queue: 'dlq.notifications.alert',
-          arguments: { 'x-message-ttl' => DLQ_MESSAGE_TTL },
+          arguments: {},
         },
         'dlx.webhooks.payload' => {
           queue: 'dlq.webhooks.payload',
-          arguments: { 'x-message-ttl' => DLQ_MESSAGE_TTL },
+          arguments: {},
         },
         'dlx.billing.event' => {
           queue: 'dlq.billing.event',
-          arguments: { 'x-message-ttl' => DLQ_MESSAGE_TTL },
+          arguments: {},
         },
       }.freeze
+
+      DLQ_POLICIES = [
+        {
+          name: 'dlq-ttl',
+          pattern: '^dlq\.',
+          definition: { 'message-ttl' => DLQ_MESSAGE_TTL },
+          apply_to: 'queues',
+          priority: 0,
+        },
+      ].freeze
 
       # TTL for processed message idempotency keys (1 hour)
       IDEMPOTENCY_TTL = 3600

--- a/lib/onetime/jobs/queues/maintenance.md
+++ b/lib/onetime/jobs/queues/maintenance.md
@@ -1,22 +1,25 @@
 # Queue Maintenance
 
-RabbitMQ queue arguments are **immutable** after declaration. Changing an argument (e.g. adding `x-message-ttl` to an existing DLQ) causes `PRECONDITION_FAILED` errors. Two approaches handle this gracefully; a third exists for dev or when message loss is acceptable.
+RabbitMQ queue arguments are **immutable** after declaration. Changing a queue argument on an existing queue causes `PRECONDITION_FAILED` errors on startup. Two approaches handle this gracefully; a third exists for dev or when message loss is acceptable.
 
 ## 1. Policies over Arguments (preferred)
 
-Use RabbitMQ **policies** for operational parameters (`x-message-ttl`, `x-max-length`, etc.) instead of queue arguments. Policies are mutable at runtime.
+Use RabbitMQ **policies** for operational parameters (`x-message-ttl`, `x-max-length`, etc.) instead of queue arguments. Policies are mutable at runtime — no queue recreation, no message loss.
+
+DLQ TTL is managed this way. `bin/ots queue init` applies the `dlq-ttl` policy automatically via the Management API. `bin/ots queue status` reports active policies.
+
+To change the TTL without a deploy:
 
 ```bash
-# Set TTL on all DLQs via policy (no code deploy needed)
-rabbitmqctl set_policy dlq-ttl "^dlq\." '{"message-ttl": 604800000}' --apply-to queues
-
-# Change it later without touching any queue definitions
+# Update TTL on all DLQs at runtime (no queue deletion, no code deploy)
 rabbitmqctl set_policy dlq-ttl "^dlq\." '{"message-ttl": 259200000}' --apply-to queues
 ```
 
-Reserve queue arguments for structural properties that truly define the queue's identity. Move operational tunables (TTL, max-length, overflow behavior) to policies.
+Or update `DLQ_MESSAGE_TTL` in `lib/onetime/jobs/queues/config.rb` and re-run `bin/ots queue init`.
 
-## 2. Versioned Queues (when arguments must change)
+Reserve queue arguments for structural properties that define the queue's identity (e.g. `x-dead-letter-exchange`). Move operational tunables (TTL, max-length, overflow behavior) to policies.
+
+## 2. Versioned Queues (when a structural argument must change)
 
 Two-phase migration, analogous to a DB column rename across releases:
 
@@ -32,7 +35,7 @@ Two-phase migration, analogous to a DB column rename across releases:
 
 ## 3. Nuclear: `bin/ots queue reset --force`
 
-Deletes and recreates all queues from `QueueConfig::QUEUES` definitions. **Destroys in-flight messages.** Acceptable for dev environments and for DLQs in production where messages are already-logged failures. Not suitable for primary work queues with unprocessed messages.
+Deletes and recreates all queues from `QueueConfig::QUEUES` definitions. **Destroys in-flight messages.** Acceptable for dev environments. Not suitable for primary work queues with unprocessed messages.
 
 ```bash
 bin/ots queue reset --force

--- a/spec/cli/queue/status_command_spec.rb
+++ b/spec/cli/queue/status_command_spec.rb
@@ -1,0 +1,111 @@
+# spec/cli/queue/status_command_spec.rb
+#
+# frozen_string_literal: true
+
+require_relative '../cli_spec_helper'
+require 'onetime/cli/queue/status_command'
+
+RSpec.describe Onetime::CLI::Queue::StatusCommand, type: :cli do
+  let(:command) { described_class.new }
+
+  describe '#check_dlq_policies' do
+    let(:response_200) { instance_double(Net::HTTPResponse, code: '200', body: policies_json) }
+    let(:response_404) { instance_double(Net::HTTPResponse, code: '404', body: '') }
+
+    let(:policies_json) do
+      JSON.generate([
+        { 'name' => 'dlq.ttl', 'pattern' => 'dlq.jobs', 'definition' => { 'message-ttl' => 86_400_000 } },
+        { 'name' => 'other',   'pattern' => 'foo-dlq-bar', 'definition' => {} },
+        { 'name' => 'unrelated', 'pattern' => 'workers', 'definition' => {} },
+      ])
+    end
+
+    before do
+      http = instance_double(Net::HTTP)
+      allow(Net::HTTP).to receive(:new).and_return(http)
+      allow(http).to receive(:use_ssl=)
+      allow(http).to receive(:open_timeout=)
+      allow(http).to receive(:read_timeout=)
+      allow(http).to receive(:request).and_return(stubbed_response)
+    end
+
+    context 'when management API returns 200' do
+      let(:stubbed_response) { response_200 }
+
+      it 'returns only policies whose pattern starts with dlq.' do
+        result = command.send(:check_dlq_policies)
+        expect(result).to be_an(Array)
+        expect(result.map { |p| p['pattern'] }).to eq(['dlq.jobs'])
+      end
+
+      it 'excludes policies with dlq elsewhere in the pattern' do
+        result = command.send(:check_dlq_policies)
+        patterns = result.map { |p| p['pattern'] }
+        expect(patterns).not_to include('foo-dlq-bar')
+      end
+    end
+
+    context 'when management API returns non-200' do
+      let(:stubbed_response) { response_404 }
+
+      it 'returns nil' do
+        result = command.send(:check_dlq_policies)
+        expect(result).to be_nil
+      end
+    end
+
+    context 'when management API raises an error' do
+      let(:stubbed_response) { response_200 } # won't be reached
+
+      before do
+        http = instance_double(Net::HTTP)
+        allow(Net::HTTP).to receive(:new).and_return(http)
+        allow(http).to receive(:use_ssl=)
+        allow(http).to receive(:open_timeout=)
+        allow(http).to receive(:read_timeout=)
+        allow(http).to receive(:request).and_raise(Errno::ECONNREFUSED)
+      end
+
+      it 'returns nil' do
+        result = command.send(:check_dlq_policies)
+        expect(result).to be_nil
+      end
+    end
+  end
+
+  describe '#display_text_status' do
+    let(:base_status) do
+      {
+        timestamp: '2026-02-18T00:00:00Z',
+        rabbitmq: { connected: false, error: 'connection refused' },
+        exchanges: {},
+        queues: {},
+        scheduler: { running: false },
+      }
+    end
+
+    it 'prints "Management API unavailable" when dlq_policies is nil' do
+      status = base_status.merge(dlq_policies: nil)
+      output = capture_output { command.send(:display_text_status, status) }
+      expect(output[:stdout]).to include('Management API unavailable')
+    end
+
+    it 'prints "none" when dlq_policies is an empty array' do
+      status = base_status.merge(dlq_policies: [])
+      output = capture_output { command.send(:display_text_status, status) }
+      expect(output[:stdout]).to include('none')
+    end
+
+    it 'prints policy details when dlq_policies has entries' do
+      policy = {
+        'name' => 'dlq.ttl',
+        'pattern' => 'dlq.jobs',
+        'definition' => { 'message-ttl' => 3_600_000 },
+      }
+      status = base_status.merge(dlq_policies: [policy])
+      output = capture_output { command.send(:display_text_status, status) }
+      expect(output[:stdout]).to include('dlq.ttl')
+      expect(output[:stdout]).to include('dlq.jobs')
+    end
+  end
+end

--- a/spec/unit/onetime/cli/queue/init_command_spec.rb
+++ b/spec/unit/onetime/cli/queue/init_command_spec.rb
@@ -1,0 +1,117 @@
+# spec/unit/onetime/cli/queue/init_command_spec.rb
+#
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'onetime/cli'
+
+RSpec.describe Onetime::CLI::Queue::InitCommand do
+  subject(:command) { described_class.new }
+
+  let(:vhost) { 'ots_test' }
+  let(:amqp_url) { "amqp://admin:secret@rmq.example.com:5672/#{vhost}" }
+  let(:management_base) { 'http://rmq.example.com:15672' }
+  let(:policy) { Onetime::Jobs::QueueConfig::DLQ_POLICIES.first }
+  let(:encoded_vhost) { URI.encode_www_form_component(vhost) }
+  let(:encoded_name) { URI.encode_www_form_component(policy[:name]) }
+  let(:policy_url) { "#{management_base}/api/policies/#{encoded_vhost}/#{encoded_name}" }
+
+  before do
+    allow(ENV).to receive(:fetch).and_call_original
+    allow(ENV).to receive(:fetch).with('RABBITMQ_URL', anything).and_return(amqp_url)
+    allow(ENV).to receive(:fetch).with('RABBITMQ_MANAGEMENT_URL', anything).and_return(management_base)
+    allow(command).to receive(:boot_application!)
+    allow(command).to receive(:create_vhost)
+    allow(command).to receive(:set_permissions)
+    allow(command).to receive(:declare_infrastructure)
+    allow(command).to receive(:puts)
+    allow(command).to receive(:print)
+  end
+
+  describe '#set_dlq_policies (via call with force: true)' do
+    before do
+      allow(command).to receive(:set_dlq_policies).and_call_original
+    end
+
+    context 'when policy is applied successfully (HTTP 204)' do
+      before { stub_request(:put, policy_url).to_return(status: 204, body: '') }
+
+      it 'logs success for each policy' do
+        expect(command).to receive(:puts).with(/Policy 'dlq-ttl' applied to vhost '#{vhost}'/)
+        command.call(force: true, dry_run: false)
+      end
+    end
+
+    context 'when policy is created new (HTTP 201)' do
+      before { stub_request(:put, policy_url).to_return(status: 201, body: '') }
+
+      it 'logs success' do
+        expect(command).to receive(:puts).with(/Policy 'dlq-ttl' applied/)
+        command.call(force: true, dry_run: false)
+      end
+    end
+
+    context 'when Management API returns an error (HTTP 422)' do
+      before { stub_request(:put, policy_url).to_return(status: 422, body: '{"error":"bad"}') }
+
+      it 'logs a warning but does not raise' do
+        expect(command).to receive(:puts).with(/WARNING: Failed to apply policy 'dlq-ttl': 422/)
+        expect { command.call(force: true, dry_run: false) }.not_to raise_error
+      end
+    end
+
+    context 'when connection is refused' do
+      before { stub_request(:put, policy_url).to_raise(Errno::ECONNREFUSED) }
+
+      it 'logs a warning with rabbitmqctl fallback' do
+        expect(command).to receive(:puts).with(/WARNING: Cannot connect to RabbitMQ Management API/)
+        expect(command).to receive(:puts).with(/rabbitmqctl set_policy/)
+        expect { command.call(force: true, dry_run: false) }.not_to raise_error
+      end
+    end
+
+    context 'request structure' do
+      it 'sends PUT with correct URI, basic auth, and content type' do
+        stub = stub_request(:put, policy_url)
+          .with(
+            basic_auth: %w[admin secret],
+            headers: { 'Content-Type' => 'application/json' }
+          )
+          .to_return(status: 204, body: '')
+
+        command.call(force: true, dry_run: false)
+        expect(stub).to have_been_requested
+      end
+
+      it 'sends correct policy body matching DLQ_POLICIES config' do
+        stub_request(:put, policy_url).to_return(status: 204, body: '')
+        command.call(force: true, dry_run: false)
+
+        expect(a_request(:put, policy_url).with { |req|
+          body = JSON.parse(req.body)
+          body['pattern'] == policy[:pattern] &&
+            body['definition'] == policy[:definition] &&
+            body['apply-to'] == policy[:apply_to] &&
+            body['priority'] == policy[:priority]
+        }).to have_been_made
+      end
+
+      it 'includes message-ttl matching DLQ_MESSAGE_TTL in definition' do
+        stub_request(:put, policy_url).to_return(status: 204, body: '')
+        command.call(force: true, dry_run: false)
+
+        expect(a_request(:put, policy_url).with { |req|
+          body = JSON.parse(req.body)
+          body['definition']['message-ttl'] == Onetime::Jobs::QueueConfig::DLQ_MESSAGE_TTL
+        }).to have_been_made
+      end
+    end
+
+    context 'when dry_run is true' do
+      it 'does not make any HTTP requests' do
+        command.call(force: true, dry_run: true)
+        expect(a_request(:put, policy_url)).not_to have_been_made
+      end
+    end
+  end
+end

--- a/spec/unit/onetime/cli/queue/status_command_spec.rb
+++ b/spec/unit/onetime/cli/queue/status_command_spec.rb
@@ -58,8 +58,8 @@ RSpec.describe Onetime::CLI::Queue::StatusCommand do
 
       before { allow(http_instance).to receive(:request).and_return(response) }
 
-      it 'returns empty array' do
-        expect(command.send(:check_dlq_policies)).to eq([])
+      it 'returns nil' do
+        expect(command.send(:check_dlq_policies)).to be_nil
       end
     end
 

--- a/spec/unit/onetime/cli/queue/status_command_spec.rb
+++ b/spec/unit/onetime/cli/queue/status_command_spec.rb
@@ -1,0 +1,206 @@
+# spec/unit/onetime/cli/queue/status_command_spec.rb
+#
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'onetime/cli'
+require 'onetime/cli/queue/status_command'
+
+RSpec.describe Onetime::CLI::Queue::StatusCommand do
+  subject(:command) { described_class.new }
+
+  describe '#check_dlq_policies' do
+    let(:http_instance) { instance_double(Net::HTTP) }
+
+    before do
+      allow(ENV).to receive(:fetch).and_call_original
+      allow(ENV).to receive(:fetch).with('RABBITMQ_URL', anything).and_return('amqp://guest:guest@localhost:5672')
+      allow(ENV).to receive(:fetch).with('RABBITMQ_MANAGEMENT_URL', anything).and_return('http://localhost:15672')
+      allow(Net::HTTP).to receive(:new).and_return(http_instance)
+      allow(http_instance).to receive(:use_ssl=)
+      allow(http_instance).to receive(:open_timeout=)
+      allow(http_instance).to receive(:read_timeout=)
+    end
+
+    context 'when API returns 200 with DLQ policies' do
+      let(:policies_json) do
+        [
+          { 'name' => 'dlq-ttl', 'pattern' => '^dlq\\.', 'definition' => { 'message-ttl' => 604_800_000 }, 'apply-to' => 'queues' },
+          { 'name' => 'ha-all', 'pattern' => '.*', 'definition' => { 'ha-mode' => 'all' }, 'apply-to' => 'all' },
+        ].to_json
+      end
+      let(:response) { instance_double(Net::HTTPSuccess, code: '200', body: policies_json) }
+
+      before { allow(http_instance).to receive(:request).and_return(response) }
+
+      it 'returns only policies whose pattern contains dlq' do
+        result = command.send(:check_dlq_policies)
+        expect(result.length).to eq(1)
+        expect(result.first['name']).to eq('dlq-ttl')
+      end
+    end
+
+    context 'when API returns 200 with no DLQ policies' do
+      let(:policies_json) do
+        [{ 'name' => 'ha-all', 'pattern' => '.*', 'definition' => {}, 'apply-to' => 'all' }].to_json
+      end
+      let(:response) { instance_double(Net::HTTPSuccess, code: '200', body: policies_json) }
+
+      before { allow(http_instance).to receive(:request).and_return(response) }
+
+      it 'returns empty array' do
+        expect(command.send(:check_dlq_policies)).to eq([])
+      end
+    end
+
+    context 'when API returns non-200 status' do
+      let(:response) { instance_double(Net::HTTPForbidden, code: '403', body: 'Forbidden') }
+
+      before { allow(http_instance).to receive(:request).and_return(response) }
+
+      it 'returns empty array' do
+        expect(command.send(:check_dlq_policies)).to eq([])
+      end
+    end
+
+    context 'when connection is refused' do
+      before { allow(http_instance).to receive(:request).and_raise(Errno::ECONNREFUSED) }
+
+      it 'returns nil' do
+        expect(command.send(:check_dlq_policies)).to be_nil
+      end
+    end
+
+    context 'when connection times out' do
+      before { allow(http_instance).to receive(:request).and_raise(Net::OpenTimeout) }
+
+      it 'returns nil for open timeout' do
+        expect(command.send(:check_dlq_policies)).to be_nil
+      end
+    end
+
+    context 'when read times out' do
+      before { allow(http_instance).to receive(:request).and_raise(Net::ReadTimeout) }
+
+      it 'returns nil for read timeout' do
+        expect(command.send(:check_dlq_policies)).to be_nil
+      end
+    end
+
+    context 'when an unexpected error occurs' do
+      before { allow(http_instance).to receive(:request).and_raise(StandardError, 'boom') }
+
+      it 'returns nil' do
+        expect(command.send(:check_dlq_policies)).to be_nil
+      end
+    end
+
+    it 'requests GET /api/policies/{vhost}' do
+      response = instance_double(Net::HTTPSuccess, code: '200', body: '[]')
+      allow(http_instance).to receive(:request).and_return(response)
+
+      command.send(:check_dlq_policies)
+
+      expect(http_instance).to have_received(:request) do |req|
+        expect(req).to be_a(Net::HTTP::Get)
+        expect(req.path).to eq('/api/policies/%2F')
+      end
+    end
+  end
+
+  describe '#format_ttl' do
+    it 'formats milliseconds >= 1 day as Nms (Nd)' do
+      expect(command.send(:format_ttl, 604_800_000)).to eq('604800000ms (7d)')
+    end
+
+    it 'formats milliseconds >= 1 hour as Nms (Nh)' do
+      expect(command.send(:format_ttl, 7_200_000)).to eq('7200000ms (2h)')
+    end
+
+    it 'formats milliseconds < 1 hour as Nms' do
+      expect(command.send(:format_ttl, 30_000)).to eq('30000ms')
+    end
+
+    it 'treats exactly 1 day boundary correctly' do
+      one_day_ms = 86_400 * 1000
+      expect(command.send(:format_ttl, one_day_ms)).to eq('86400000ms (1d)')
+    end
+
+    it 'treats exactly 1 hour boundary correctly' do
+      one_hour_ms = 3600 * 1000
+      expect(command.send(:format_ttl, one_hour_ms)).to eq('3600000ms (1h)')
+    end
+  end
+
+  describe '#display_text_status (DLQ Policies section)' do
+    let(:base_status) do
+      {
+        timestamp: '2026-02-18T00:00:00Z',
+        rabbitmq: { connected: false, error: 'test' },
+        exchanges: {},
+        queues: {},
+        dlq_policies: dlq_policies,
+        scheduler: { running: false },
+      }
+    end
+
+    context 'when policies is nil (API unavailable)' do
+      let(:dlq_policies) { nil }
+
+      it 'shows Management API unavailable' do
+        output = capture_stdout { command.send(:display_text_status, base_status) }
+        expect(output).to include('Management API unavailable')
+      end
+    end
+
+    context 'when policies is empty array' do
+      let(:dlq_policies) { [] }
+
+      it 'shows none' do
+        output = capture_stdout { command.send(:display_text_status, base_status) }
+        expect(output).to match(/DLQ Policies:\n\s+none/)
+      end
+    end
+
+    context 'when policies are present' do
+      let(:dlq_policies) do
+        [
+          {
+            'name' => 'dlq-ttl',
+            'pattern' => '^dlq\\.',
+            'definition' => { 'message-ttl' => 604_800_000 },
+          },
+        ]
+      end
+
+      it 'shows policy name, pattern, and formatted TTL' do
+        output = capture_stdout { command.send(:display_text_status, base_status) }
+        expect(output).to include('dlq-ttl')
+        expect(output).to include('pattern=^dlq\\.')
+        expect(output).to include('message-ttl=604800000ms (7d)')
+      end
+    end
+
+    context 'when policy has no message-ttl' do
+      let(:dlq_policies) do
+        [{ 'name' => 'dlq-no-ttl', 'pattern' => 'dlq', 'definition' => {} }]
+      end
+
+      it 'shows n/a for TTL' do
+        output = capture_stdout { command.send(:display_text_status, base_status) }
+        expect(output).to include('message-ttl=n/a')
+      end
+    end
+  end
+
+  private
+
+  def capture_stdout
+    original = $stdout
+    $stdout = StringIO.new
+    yield
+    $stdout.string
+  ensure
+    $stdout = original
+  end
+end


### PR DESCRIPTION
## What and why

RabbitMQ queue arguments are immutable after declaration. DLQ TTL was previously configured via `x-message-ttl` in `DEAD_LETTER_CONFIG` queue arguments, which caused `PRECONDITION_FAILED` errors on startup whenever the TTL value changed on existing queues. The workaround (`queue reset --force`) destroys in-flight messages — acceptable in dev, not in production.

This moves DLQ TTL from queue arguments to a RabbitMQ policy (`dlq-ttl`, pattern `^dlq\.`), which is mutable at runtime without queue recreation or message loss.

## Changes

- `config.rb` — Remove `x-message-ttl` from all `DEAD_LETTER_CONFIG` argument hashes; add `DLQ_POLICIES` constant
- `init_command.rb` — Add `set_dlq_policies` as step 4 in `bin/ots queue init`; applies policy via Management API PUT; non-fatal if API unavailable (prints `rabbitmqctl` fallback)
- `status_command.rb` — Add `check_dlq_policies` and a DLQ Policies section to `bin/ots queue status` output
- `maintenance.md` — Updated to reflect policy-first approach, added init/status references

## Tests

25 new examples across two new spec files:
- `spec/unit/onetime/cli/queue/init_command_spec.rb` — HTTP success/error/connection-refused paths, request structure, policy body, dry-run
- `spec/unit/onetime/cli/queue/status_command_spec.rb` — API filtering, error handling, `format_ttl` conversions, display output

## Deployment notes

**Existing installs** (any environment where DLQ queues were declared with the old `x-message-ttl` queue argument) require a one-time migration before or during deploy. The declarator uses active queue declaration — on startup it will attempt to declare `dlq.*` queues with `arguments: {}`, which mismatches the immutable `x-message-ttl` argument on existing queues and causes `PRECONDITION_FAILED`.

The main work queues (`email.message`, `webhooks.payload`, etc.) are unaffected. Only the four DLQ queues need to be recreated.

### Migration steps (existing installs)

```bash
# 1. Check DLQ depths — confirm no messages you need to preserve
bin/ots queue status

# 2. Delete only the DLQ queues (main work queues are untouched)
#    Via rabbitmqctl:
rabbitmqctl delete_queue dlq.email.message
rabbitmqctl delete_queue dlq.notifications.alert
rabbitmqctl delete_queue dlq.webhooks.payload
rabbitmqctl delete_queue dlq.billing.event
#    Or if workers are stopped and DLQs are all empty, reset is fine:
#    bin/ots queue reset --force

# 3. Deploy the new code

# 4. Recreate queues and apply the policy
bin/ots queue init

# 5. Verify
bin/ots queue status   # DLQ Policies section should show dlq-ttl with 7d TTL
```

**Fresh installs** — run `bin/ots queue init` once after the first deployment. The application startup path (via `SetupRabbitMQ` initializer) declares exchanges and queues over AMQP, but does not apply RabbitMQ policies — that requires the Management HTTP API, which is intentionally not a startup dependency. Until `queue init` runs, DLQ queues will accumulate indefinitely with no TTL.

### Why startup and policy application are separate phases

The startup initializer uses AMQP (Bunny) and must work in any environment, including those without the `rabbitmq_management` plugin. Policy application is a one-time ops step that requires the Management API. Conflating the two would make the Management API a hard startup dependency and generate noisy connection errors on minimal deployments that don't expose it.

The coarse-grained phases are:
1. **Startup** — AMQP: declare exchanges and queues (idempotent, every boot)
2. **Bootstrap** — Management API: apply policies (once at install, re-run to change TTL)

`bin/ots queue init` handles phase 2 and should be included in any deploy runbook alongside `bundle install`, migrations, etc.

Closes #2529