### PR TITLE
[#2530] Add DlqEmailConsumerJob: scheduled auth email replay from DLQ

### DIFF
--- a/changelog.d/20260218_193610_delano_2530_dlq_consumer_auth_emails.rst
+++ b/changelog.d/20260218_193610_delano_2530_dlq_consumer_auth_emails.rst
@@ -1,0 +1,17 @@
+Added
+-----
+
+- New ``DlqEmailConsumerJob`` scheduled job replays auth-critical emails from
+  the dead-letter queue (``dlq.email.message``) on a 5-minute cycle. Raw
+  Rodauth emails (password reset, verify account, email change) are always
+  replayed; templated auth emails are replayed only if the underlying Rodauth
+  key is still valid; non-auth emails (secret links, expiration warnings) are
+  discarded as stale. Enabled by default; set
+  ``JOBS_DLQ_CONSUMER_ENABLED=false`` to disable. PR #2530
+
+AI Assistance
+-------------
+
+- Claude assisted with implementation of ``DlqEmailConsumerJob``, including
+  idempotency design, token expiry validation, channel management, and
+  tryout test coverage.

--- a/etc/config.schema.yaml
+++ b/etc/config.schema.yaml
@@ -17,6 +17,7 @@ features: include('features')
 redis: include('redis')
 emailer: include('emailer')
 mail: include('mail')
+jobs: include('jobs', required=False)
 billing: include('billing')
 internationalization: include('internationalization')
 diagnostics: include('diagnostics')
@@ -135,6 +136,18 @@ mail:
     email_pattern: str(required=False)
     smtp_error_body_pattern: str(required=False)
     logger: map()
+
+jobs:
+  enabled: any(bool(), str())
+  rabbitmq_url: str(required=False)
+  channel_pool_size: any(str(), int(), required=False)
+  fallback_to_sync: any(bool(), str(), required=False)
+  workers: map(required=False)
+  scheduler: map(required=False)
+  plan_cache_refresh_enabled: any(bool(), str(), required=False)
+  catalog_retry_enabled: any(bool(), str(), required=False)
+  dlq_consumer_enabled: any(bool(), str(), required=False)
+  expiration_warnings: map(required=False)
 
 billing:
   enabled: any()

--- a/etc/defaults/config.defaults.yaml
+++ b/etc/defaults/config.defaults.yaml
@@ -560,6 +560,12 @@ jobs:
   # Runs every 2 minutes when enabled; skips if circuit is still open.
   catalog_retry_enabled: <%= ENV['JOBS_CATALOG_RETRY_ENABLED'] == 'true' || false %>
 
+  # DLQ Email Consumer Job
+  # Processes failed email messages from the dead-letter queue.
+  # Runs on a schedule to inspect DLQ messages and re-publish recoverable
+  # failures or log permanent failures for investigation.
+  dlq_consumer_enabled: <%= ENV['JOBS_DLQ_CONSUMER_ENABLED'] == 'true' || false %>
+
   # Expiration warning emails
   # Send email notifications before secrets expire to warn recipients
   expiration_warnings:

--- a/etc/defaults/config.defaults.yaml
+++ b/etc/defaults/config.defaults.yaml
@@ -564,7 +564,7 @@ jobs:
   # Processes failed email messages from the dead-letter queue.
   # Runs on a schedule to inspect DLQ messages and re-publish recoverable
   # failures or log permanent failures for investigation.
-  dlq_consumer_enabled: <%= ENV['JOBS_DLQ_CONSUMER_ENABLED'] == 'true' || false %>
+  dlq_consumer_enabled: <%= ENV['JOBS_DLQ_CONSUMER_ENABLED'] != 'false' %>
 
   # Expiration warning emails
   # Send email notifications before secrets expire to warn recipients

--- a/lib/onetime/jobs/scheduled/dlq_email_consumer_job.rb
+++ b/lib/onetime/jobs/scheduled/dlq_email_consumer_job.rb
@@ -1,0 +1,266 @@
+# lib/onetime/jobs/scheduled/dlq_email_consumer_job.rb
+#
+# frozen_string_literal: true
+
+require_relative '../scheduled_job'
+require_relative '../queues/config'
+
+module Onetime
+  module Jobs
+    module Scheduled
+      # Consumes messages from the email DLQ and replays auth-critical
+      # emails whose tokens are still valid.
+      #
+      # Non-auth emails (secret_link, expiration_warning, etc.) are discarded
+      # because they are time-sensitive and stale by the time they reach the
+      # DLQ. Auth emails (password reset, verification, email change) are
+      # replayed if the underlying token hasn't expired, because the user
+      # is actively waiting for that email.
+      #
+      # Raw emails (Rodauth's password reset, verify account, email auth)
+      # are always replayed since they are auth-critical by definition and
+      # their token lifecycle is managed by Rodauth internally.
+      #
+      # Configuration:
+      #   jobs:
+      #     dlq_consumer_enabled: true
+      #
+      # Schedule: every 5 minutes, first_in: 30s
+      #
+      # rubocop:disable Style/GlobalVars
+      class DlqEmailConsumerJob < ScheduledJob
+        DLQ_NAME   = 'dlq.email.message'
+        BATCH_SIZE = 50
+
+        # Auth templates whose DLQ messages are worth replaying.
+        # Maps template name to config for token extraction and deadline lookup.
+        #
+        # token_field:      key in the `data` hash holding the auth token
+        # table:            Sequel table to query for deadline
+        # key_column:       column containing the token value
+        # deadline_column:  column with expiry timestamp (nil = row presence check)
+        #
+        AUTH_TEMPLATES = {
+          'email_change_confirmation' => {
+            token_field: 'confirmation_token',
+            table: :account_login_change_keys,
+            key_column: :key,
+            deadline_column: :deadline,
+          },
+          'password_reset' => {
+            token_field: 'account_id',
+            table: :account_password_reset_keys,
+            key_column: :id,
+            deadline_column: :deadline,
+          },
+          'verify_account' => {
+            token_field: 'verify_key',
+            table: :account_verification_keys,
+            key_column: :key,
+            deadline_column: nil,
+          },
+        }.freeze
+
+        class << self
+          def schedule(scheduler)
+            return unless enabled?
+
+            scheduler_logger.info '[DlqEmailConsumerJob] Scheduling DLQ email consumer'
+
+            every(scheduler, '5m', first_in: '30s') do
+              consume_dlq_batch
+            end
+          end
+
+          private
+
+          def enabled?
+            OT.conf.dig('jobs', 'dlq_consumer_enabled') == true
+          end
+
+          def consume_dlq_batch
+            conn, channel, own_connection = acquire_channel
+            return unless channel
+
+            queue     = channel.queue(DLQ_NAME, durable: true, passive: true)
+            available = queue.message_count
+
+            if available == 0
+              scheduler_logger.debug '[DlqEmailConsumerJob] DLQ empty'
+              return
+            end
+
+            to_process = [available, BATCH_SIZE].min
+            results    = { replayed: 0, discarded_non_auth: 0, discarded_expired: 0, errors: 0 }
+
+            to_process.times do
+              delivery_info, properties, payload = queue.pop(manual_ack: true)
+              break unless delivery_info
+
+              process_message(channel, delivery_info, properties, payload, results)
+            end
+
+            scheduler_logger.info '[DlqEmailConsumerJob] Batch complete: ' \
+                                  "replayed=#{results[:replayed]} " \
+                                  "discarded_non_auth=#{results[:discarded_non_auth]} " \
+                                  "discarded_expired=#{results[:discarded_expired]} " \
+                                  "errors=#{results[:errors]}"
+          rescue Bunny::NotFound
+            scheduler_logger.debug "[DlqEmailConsumerJob] Queue #{DLQ_NAME} not declared yet"
+          ensure
+            channel&.close if channel&.open?
+            conn&.close if own_connection
+          end
+
+          # Use the shared RabbitMQ connection ($rmq_conn) to create a dedicated
+          # channel. A dedicated channel (not from $rmq_channel_pool) is used
+          # because passive queue declarations and manual_ack operations can
+          # trigger channel-level exceptions that would corrupt a pooled channel.
+          # Falls back to a standalone connection if the shared one is unavailable.
+          #
+          # @return [Array(Bunny::Session, Bunny::Channel, Boolean)]
+          #   connection, channel, and whether we own the connection (must close it)
+          def acquire_channel
+            if $rmq_conn&.open?
+              [$rmq_conn, $rmq_conn.create_channel, false]
+            else
+              url  = OT.conf.dig('jobs', 'rabbitmq_url') ||
+                     ENV.fetch('RABBITMQ_URL', 'amqp://localhost:5672')
+              conn = Bunny.new(url)
+              conn.start
+              [conn, conn.create_channel, true]
+            end
+          rescue Bunny::TCPConnectionFailed, Bunny::ConnectionTimeout => ex
+            scheduler_logger.error "[DlqEmailConsumerJob] Connection failed: #{ex.message}"
+            [nil, nil, false]
+          end
+
+          def process_message(channel, delivery_info, properties, payload, results)
+            data = JSON.parse(payload, symbolize_names: false)
+
+            # Raw Rodauth emails (password reset, verify account, email auth)
+            # are always auth-critical. They have no template field; Rodauth
+            # manages their token lifecycle internally.
+            if data['raw'] == true
+              replay_message(channel, delivery_info, properties, payload, results)
+              return
+            end
+
+            template = data['template']
+
+            unless template && AUTH_TEMPLATES.key?(template)
+              channel.nack(delivery_info.delivery_tag, false, false)
+              results[:discarded_non_auth] += 1
+              return
+            end
+
+            # Auth template: check if the token is still valid
+            config = AUTH_TEMPLATES[template]
+            token  = data.dig('data', config[:token_field])
+
+            unless token
+              # No token in payload, can't verify validity
+              channel.nack(delivery_info.delivery_tag, false, false)
+              results[:discarded_expired] += 1
+              return
+            end
+
+            if token_expired?(config, token)
+              channel.nack(delivery_info.delivery_tag, false, false)
+              results[:discarded_expired] += 1
+              return
+            end
+
+            replay_message(channel, delivery_info, properties, payload, results)
+          rescue JSON::ParserError => ex
+            scheduler_logger.error "[DlqEmailConsumerJob] Invalid JSON: #{ex.message}"
+            channel.nack(delivery_info.delivery_tag, false, false)
+            results[:errors] += 1
+          rescue StandardError => ex
+            scheduler_logger.error "[DlqEmailConsumerJob] Error processing message: #{ex.message}"
+            channel.nack(delivery_info.delivery_tag, false, true)
+            results[:errors] += 1
+          end
+
+          # Check whether the auth token has expired by querying the deadline table.
+          #
+          # @return [Boolean] true if expired or not found
+          def token_expired?(config, token)
+            db = Auth::Database.connection
+            return false unless db
+
+            dataset = db[config[:table]].where(config[:key_column] => token)
+
+            if config[:deadline_column]
+              row = dataset.select(config[:deadline_column]).first
+              return true unless row
+
+              row[config[:deadline_column]] <= Time.now
+            else
+              # No deadline column (verify_account): row presence = still valid
+              dataset.none?
+            end
+          rescue StandardError => ex
+            scheduler_logger.error "[DlqEmailConsumerJob] Deadline check failed: #{ex.message}"
+            false # On error, allow replay (err on the side of delivery)
+          end
+
+          def replay_message(channel, delivery_info, properties, payload, results)
+            message_id = properties.message_id
+
+            # Idempotency: skip if already replayed
+            if message_id && !claim_for_replay(message_id)
+              channel.ack(delivery_info.delivery_tag)
+              return
+            end
+
+            original_queue = extract_original_queue(properties.headers)
+            unless original_queue
+              scheduler_logger.warn '[DlqEmailConsumerJob] No original queue in x-death headers'
+              channel.nack(delivery_info.delivery_tag, false, false)
+              results[:errors] += 1
+              return
+            end
+
+            channel.default_exchange.publish(
+              payload,
+              routing_key: original_queue,
+              persistent: true,
+              message_id: message_id,
+              content_type: properties.content_type,
+              headers: clean_headers(properties.headers),
+            )
+
+            channel.ack(delivery_info.delivery_tag)
+            results[:replayed] += 1
+          end
+
+          # Idempotency claim via Redis SET NX
+          # @return [Boolean] true if claimed (first time), false if already seen
+          def claim_for_replay(message_id)
+            Familia.dbclient.set(
+              "dlq:replayed:#{message_id}",
+              '1',
+              nx: true,
+              ex: QueueConfig::IDEMPOTENCY_TTL,
+            )
+          end
+
+          def extract_original_queue(headers)
+            return nil unless headers
+
+            death = headers['x-death']&.first
+            death&.fetch('queue', nil)
+          end
+
+          def clean_headers(headers)
+            return {} unless headers
+
+            headers.reject { |k, _| k.start_with?('x-death', 'x-first-death') }
+          end
+        end
+      end
+      # rubocop:enable Style/GlobalVars
+    end
+  end
+end

--- a/lib/onetime/jobs/scheduled/dlq_email_consumer_job.rb
+++ b/lib/onetime/jobs/scheduled/dlq_email_consumer_job.rb
@@ -178,7 +178,7 @@ module Onetime
             results[:errors] += 1
           rescue StandardError => ex
             scheduler_logger.error "[DlqEmailConsumerJob] Error processing message: #{ex.message}"
-            channel.nack(delivery_info.delivery_tag, false, true)
+            channel.nack(delivery_info.delivery_tag, false, false)
             results[:errors] += 1
           end
 
@@ -195,7 +195,7 @@ module Onetime
               row = dataset.select(config[:deadline_column]).first
               return true unless row
 
-              row[config[:deadline_column]] <= Time.now
+              row[config[:deadline_column]] <= Time.now.utc
             else
               # No deadline column (verify_account): row presence = still valid
               dataset.none?

--- a/try/jobs/dlq_email_consumer_job_try.rb
+++ b/try/jobs/dlq_email_consumer_job_try.rb
@@ -294,6 +294,18 @@ call_private(:process_message, ch, di, props, payload, results)
 results[:errors]
 #=> 1
 
+## process_message nacks with requeue=false when original queue not found in x-death headers
+ch = MockChannel.new
+di = MockDeliveryInfo.new(delivery_tag: 'tag-no-xdeath-nack')
+msg_id = "no-xdeath-nack-#{SecureRandom.hex(4)}"
+track_key("dlq:replayed:#{msg_id}")
+props = MockProperties.new(message_id: msg_id, headers: nil)
+payload = JSON.generate({ 'raw' => true, 'email' => { 'to' => 'u@e.com' } })
+results = fresh_results
+call_private(:process_message, ch, di, props, payload, results)
+ch.nacks.first[:requeue]
+#=> false
+
 ## process_message strips x-death headers from replayed message
 ch = MockChannel.new
 di = MockDeliveryInfo.new(delivery_tag: 'tag-strip')

--- a/try/jobs/dlq_email_consumer_job_try.rb
+++ b/try/jobs/dlq_email_consumer_job_try.rb
@@ -1,0 +1,325 @@
+# try/jobs/dlq_email_consumer_job_try.rb
+#
+# frozen_string_literal: true
+
+# Tests the DlqEmailConsumerJob scheduled job logic.
+#
+# Covers:
+#   - AUTH_TEMPLATES constant structure
+#   - Config flag gating (enabled?)
+#   - Header extraction and cleaning (extract_original_queue, clean_headers)
+#   - Idempotency (claim_for_replay) via Redis SET NX
+#   - Message routing: raw, auth template, non-auth template
+#   - Expired token discard logic
+#   - Duplicate message_id skip
+#
+# Does NOT require RabbitMQ — uses mock channel/delivery/properties objects.
+
+require_relative '../support/test_helpers'
+
+OT.boot! :test, false
+
+require_relative '../../lib/onetime/jobs/scheduled/dlq_email_consumer_job'
+
+@job = Onetime::Jobs::Scheduled::DlqEmailConsumerJob
+
+# Mock objects for process_message tests.
+# These simulate the Bunny objects without requiring a real RabbitMQ connection.
+
+MockDeliveryInfo = Data.define(:delivery_tag)
+
+MockProperties = Data.define(:message_id, :headers, :content_type) do
+  def initialize(message_id: nil, headers: nil, content_type: 'application/json')
+    super
+  end
+end
+
+# Records channel operations (ack, nack, publish) for assertion.
+class MockChannel
+  attr_reader :acks, :nacks, :publishes
+
+  def initialize
+    @acks = []
+    @nacks = []
+    @publishes = []
+    @exchange = MockExchange.new(@publishes)
+  end
+
+  def ack(delivery_tag)
+    @acks << delivery_tag
+  end
+
+  def nack(delivery_tag, multiple, requeue)
+    @nacks << { tag: delivery_tag, multiple: multiple, requeue: requeue }
+  end
+
+  def default_exchange
+    @exchange
+  end
+end
+
+class MockExchange
+  def initialize(publishes)
+    @publishes = publishes
+  end
+
+  def publish(payload, **opts)
+    @publishes << { payload: payload, **opts }
+  end
+end
+
+# Helper to call private class methods on the job
+def call_private(method, *args)
+  @job.send(method, *args)
+end
+
+# Helper to build a results hash
+def fresh_results
+  { replayed: 0, discarded_non_auth: 0, discarded_expired: 0, errors: 0 }
+end
+
+# Cleanup idempotency keys we create during testing
+@cleanup_keys = []
+
+def track_key(key)
+  @cleanup_keys << key
+  key
+end
+
+# TRYOUTS
+
+## AUTH_TEMPLATES contains email_change_confirmation
+@job::AUTH_TEMPLATES.key?('email_change_confirmation')
+#=> true
+
+## AUTH_TEMPLATES contains password_reset
+@job::AUTH_TEMPLATES.key?('password_reset')
+#=> true
+
+## AUTH_TEMPLATES contains verify_account
+@job::AUTH_TEMPLATES.key?('verify_account')
+#=> true
+
+## AUTH_TEMPLATES does not contain secret_link
+@job::AUTH_TEMPLATES.key?('secret_link')
+#=> false
+
+## AUTH_TEMPLATES does not contain incoming_secret
+@job::AUTH_TEMPLATES.key?('incoming_secret')
+#=> false
+
+## AUTH_TEMPLATES email_change_confirmation has expected token_field
+@job::AUTH_TEMPLATES['email_change_confirmation'][:token_field]
+#=> 'confirmation_token'
+
+## AUTH_TEMPLATES verify_account has nil deadline_column (presence check)
+@job::AUTH_TEMPLATES['verify_account'][:deadline_column]
+#=> nil
+
+## BATCH_SIZE is 50
+@job::BATCH_SIZE
+#=> 50
+
+## DLQ_NAME is dlq.email.message
+@job::DLQ_NAME
+#=> 'dlq.email.message'
+
+## enabled? returns false in test config (dlq_consumer_enabled not set to true)
+call_private(:enabled?)
+#=> false
+
+## enabled? checks jobs.dlq_consumer_enabled config path
+OT.conf.dig('jobs', 'dlq_consumer_enabled') == true
+#=> false
+
+## extract_original_queue returns queue from x-death headers
+headers = { 'x-death' => [{ 'queue' => 'email.message.send', 'reason' => 'rejected' }] }
+call_private(:extract_original_queue, headers)
+#=> 'email.message.send'
+
+## extract_original_queue returns nil when headers are nil
+call_private(:extract_original_queue, nil)
+#=> nil
+
+## extract_original_queue returns nil when x-death is missing
+call_private(:extract_original_queue, { 'some-other' => 'header' })
+#=> nil
+
+## extract_original_queue returns nil when x-death is empty
+call_private(:extract_original_queue, { 'x-death' => [] })
+#=> nil
+
+## clean_headers strips x-death and x-first-death headers
+headers = {
+  'x-death' => [{ 'queue' => 'q' }],
+  'x-first-death-exchange' => 'dlx.email.message',
+  'x-first-death-queue' => 'email.message.send',
+  'x-first-death-reason' => 'rejected',
+  'content-type' => 'application/json',
+  'x-schema-version' => 1,
+}
+cleaned = call_private(:clean_headers, headers)
+[cleaned.key?('x-death'), cleaned.key?('x-first-death-exchange'), cleaned.key?('content-type'), cleaned.key?('x-schema-version')]
+#=> [false, false, true, true]
+
+## clean_headers returns empty hash when headers are nil
+call_private(:clean_headers, nil)
+#=> {}
+
+## claim_for_replay returns true on first claim
+key_id = "test-idem-#{SecureRandom.hex(4)}"
+track_key("dlq:replayed:#{key_id}")
+call_private(:claim_for_replay, key_id)
+#=> true
+
+## claim_for_replay returns false on duplicate claim
+key_id2 = "test-idem-dup-#{SecureRandom.hex(4)}"
+track_key("dlq:replayed:#{key_id2}")
+call_private(:claim_for_replay, key_id2)
+call_private(:claim_for_replay, key_id2)
+#=> false
+
+## process_message discards non-auth template (secret_link)
+ch = MockChannel.new
+di = MockDeliveryInfo.new(delivery_tag: 'tag-non-auth')
+props = MockProperties.new
+payload = JSON.generate({ 'template' => 'secret_link', 'data' => { 'secret_key' => 'abc' } })
+results = fresh_results
+call_private(:process_message, ch, di, props, payload, results)
+results[:discarded_non_auth]
+#=> 1
+
+## process_message nacks non-auth template without requeue
+ch = MockChannel.new
+di = MockDeliveryInfo.new(delivery_tag: 'tag-nack-check')
+props = MockProperties.new
+payload = JSON.generate({ 'template' => 'incoming_secret', 'data' => {} })
+results = fresh_results
+call_private(:process_message, ch, di, props, payload, results)
+ch.nacks.first[:requeue]
+#=> false
+
+## process_message discards auth template with missing token
+ch = MockChannel.new
+di = MockDeliveryInfo.new(delivery_tag: 'tag-no-token')
+props = MockProperties.new
+payload = JSON.generate({ 'template' => 'password_reset', 'data' => {} })
+results = fresh_results
+call_private(:process_message, ch, di, props, payload, results)
+results[:discarded_expired]
+#=> 1
+
+## process_message replays raw email (Rodauth auth email)
+ch = MockChannel.new
+di = MockDeliveryInfo.new(delivery_tag: 'tag-raw')
+msg_id = "raw-replay-#{SecureRandom.hex(4)}"
+track_key("dlq:replayed:#{msg_id}")
+headers = { 'x-death' => [{ 'queue' => 'email.message.send' }] }
+props = MockProperties.new(message_id: msg_id, headers: headers)
+payload = JSON.generate({ 'raw' => true, 'email' => { 'to' => 'user@example.com', 'from' => 'noreply@example.com', 'subject' => 'Reset', 'body' => 'Click here' } })
+results = fresh_results
+call_private(:process_message, ch, di, props, payload, results)
+results[:replayed]
+#=> 1
+
+## process_message acks raw email after replay
+ch = MockChannel.new
+di = MockDeliveryInfo.new(delivery_tag: 'tag-raw-ack')
+msg_id = "raw-ack-#{SecureRandom.hex(4)}"
+track_key("dlq:replayed:#{msg_id}")
+headers = { 'x-death' => [{ 'queue' => 'email.message.send' }] }
+props = MockProperties.new(message_id: msg_id, headers: headers)
+payload = JSON.generate({ 'raw' => true, 'email' => { 'to' => 'u@e.com' } })
+results = fresh_results
+call_private(:process_message, ch, di, props, payload, results)
+ch.acks.include?('tag-raw-ack')
+#=> true
+
+## process_message publishes replay to original queue
+ch = MockChannel.new
+di = MockDeliveryInfo.new(delivery_tag: 'tag-raw-pub')
+msg_id = "raw-pub-#{SecureRandom.hex(4)}"
+track_key("dlq:replayed:#{msg_id}")
+headers = { 'x-death' => [{ 'queue' => 'email.message.send' }] }
+props = MockProperties.new(message_id: msg_id, headers: headers)
+payload = JSON.generate({ 'raw' => true, 'email' => { 'to' => 'u@e.com' } })
+results = fresh_results
+call_private(:process_message, ch, di, props, payload, results)
+ch.publishes.first[:routing_key]
+#=> 'email.message.send'
+
+## process_message skips replay when message_id already claimed (idempotency)
+ch = MockChannel.new
+di = MockDeliveryInfo.new(delivery_tag: 'tag-dup')
+msg_id = "dup-check-#{SecureRandom.hex(4)}"
+track_key("dlq:replayed:#{msg_id}")
+headers = { 'x-death' => [{ 'queue' => 'email.message.send' }] }
+props = MockProperties.new(message_id: msg_id, headers: headers)
+payload = JSON.generate({ 'raw' => true, 'email' => { 'to' => 'u@e.com' } })
+# First call claims
+call_private(:process_message, ch, MockDeliveryInfo.new(delivery_tag: 'tag-first'), props, payload, fresh_results)
+# Second call with same message_id should skip
+results = fresh_results
+call_private(:process_message, ch, di, props, payload, results)
+[results[:replayed], ch.acks.include?('tag-dup')]
+#=> [0, true]
+
+## process_message counts error for invalid JSON
+ch = MockChannel.new
+di = MockDeliveryInfo.new(delivery_tag: 'tag-bad-json')
+props = MockProperties.new
+results = fresh_results
+call_private(:process_message, ch, di, props, 'not-valid-json{', results)
+results[:errors]
+#=> 1
+
+## process_message nacks invalid JSON without requeue
+ch = MockChannel.new
+di = MockDeliveryInfo.new(delivery_tag: 'tag-bad-json2')
+props = MockProperties.new
+results = fresh_results
+call_private(:process_message, ch, di, props, '{bad', results)
+ch.nacks.first[:requeue]
+#=> false
+
+## process_message errors on missing x-death headers for raw replay
+ch = MockChannel.new
+di = MockDeliveryInfo.new(delivery_tag: 'tag-no-xdeath')
+msg_id = "no-xdeath-#{SecureRandom.hex(4)}"
+track_key("dlq:replayed:#{msg_id}")
+props = MockProperties.new(message_id: msg_id, headers: nil)
+payload = JSON.generate({ 'raw' => true, 'email' => { 'to' => 'u@e.com' } })
+results = fresh_results
+call_private(:process_message, ch, di, props, payload, results)
+results[:errors]
+#=> 1
+
+## process_message strips x-death headers from replayed message
+ch = MockChannel.new
+di = MockDeliveryInfo.new(delivery_tag: 'tag-strip')
+msg_id = "strip-#{SecureRandom.hex(4)}"
+track_key("dlq:replayed:#{msg_id}")
+headers = {
+  'x-death' => [{ 'queue' => 'email.message.send' }],
+  'x-first-death-reason' => 'rejected',
+  'x-schema-version' => 1,
+}
+props = MockProperties.new(message_id: msg_id, headers: headers)
+payload = JSON.generate({ 'raw' => true, 'email' => { 'to' => 'u@e.com' } })
+results = fresh_results
+call_private(:process_message, ch, di, props, payload, results)
+published_headers = ch.publishes.first[:headers]
+[published_headers.key?('x-death'), published_headers.key?('x-first-death-reason'), published_headers.key?('x-schema-version')]
+#=> [false, false, true]
+
+## token_expired? returns false when Auth::Database.connection is nil
+# This happens when full auth mode is not enabled (simple mode)
+config = @job::AUTH_TEMPLATES['password_reset']
+call_private(:token_expired?, config, 'some-token-value')
+#=> false
+
+# TEARDOWN
+
+@cleanup_keys.each do |key|
+  Familia.dbclient.del(key)
+end


### PR DESCRIPTION
#2530 

## What

Adds a scheduled job that consumes the `dlq.email.message` dead-letter queue and replays auth-critical emails whose tokens are still valid.

The core problem: when an email delivery worker fails and a message ends up in the DLQ, auth emails (password reset, verify account, email change) are still actionable if the user's token hasn't expired — the user is actively waiting for that email. Non-auth emails (secret links, expiration warnings) are stale by the time they hit the DLQ and not worth replaying.

## How it works

The job runs every 5 minutes and processes up to 50 messages per batch. For each message:

- **Raw Rodauth emails** (no `template` field) are always replayed — Rodauth manages their token lifecycle internally
- **Auth-templated emails** (`email_change_confirmation`, `password_reset`, `verify_account`) are replayed only if the corresponding Rodauth key table confirms the token is still live
- **Everything else** (`secret_link`, `expiration_warning`, etc.) is discarded without requeue

Idempotency is handled via Redis SET NX on `message_id`, preventing double-replay if the scheduler fires while a previous run is still in progress. x-death and x-first-death headers are stripped before republishing to prevent RabbitMQ from immediately re-routing to the DLQ.

A dedicated channel (not from the shared pool) is used for each batch to avoid corrupting pool state with manual_ack and passive queue declarations. Falls back to a standalone connection if `$rmq_conn` is unavailable.

Token expiry is checked against UTC (`Time.now.utc`) to match how Rodauth stores deadlines. On generic processing errors, messages are nacked without requeue to prevent poison pill loops.

## Configuration

Enabled by default. The job handles missing queues gracefully (`Bunny::NotFound` caught, empty queue short-circuits), so running on deployments without a DLQ configured is safe.

```yaml
# etc/defaults/config.defaults.yaml
jobs:
  dlq_consumer_enabled: <%= ENV['JOBS_DLQ_CONSUMER_ENABLED'] != 'false' %>
```

Set `JOBS_DLQ_CONSUMER_ENABLED=false` to disable explicitly.

## Files

- `lib/onetime/jobs/scheduled/dlq_email_consumer_job.rb` — job implementation
- `try/jobs/dlq_email_consumer_job_try.rb` — tryouts covering constants, config gating, header extraction, idempotency, all message routing branches, and error paths (no RabbitMQ required)
- `etc/config.schema.yaml` + `etc/defaults/config.defaults.yaml` — schema and default for `dlq_consumer_enabled`

🤖 Generated with [Claude Code](https://claude.com/claude-code)