### PR TITLE
fix: use uuid checkout idempotency keys

### DIFF
--- a/apps/web/billing/controllers/billing.rb
+++ b/apps/web/billing/controllers/billing.rb
@@ -5,6 +5,7 @@
 # rubocop:disable Metrics/ClassLength
 
 require 'stripe'
+require 'securerandom'
 
 require_relative 'base'
 require_relative '../lib/stripe_client'
@@ -139,34 +140,15 @@ module Billing
           return json_error('Billing service temporarily unavailable', status: 503)
         end
 
-        # Create Stripe Checkout Session with idempotency
-        # Generate deterministic idempotency key to prevent duplicate sessions
+        # Create Stripe Checkout Session.
+        #
+        # Checkout sessions are ephemeral pre-payment URLs, not the subscription
+        # mutation itself. Stripe recommends creating a new Checkout Session for
+        # each pay attempt, so we intentionally use a fresh UUID here instead of
+        # a deterministic key. Subscription mutations keep their deterministic
+        # idempotency elsewhere.
         stripe_client = Billing::StripeClient.new
-
-        # ==========================================================================
-        # IDEMPOTENCY KEY - CRITICAL FOR PREVENTING DUPLICATE CHECKOUTS
-        # ==========================================================================
-        #
-        # Stripe caches checkout sessions by idempotency key. If you see
-        # "You're all done here" on the checkout page, it means Stripe returned
-        # a cached (already-completed) session instead of creating a new one.
-        #
-        # KEY BEHAVIOR DIFFERENCE:
-        #   - TEST MODE (sk_test_*): Minute granularity - allows rapid iteration
-        #   - LIVE MODE (sk_live_*): Daily granularity - prevents accidental duplicates
-        #
-        # If stuck in test mode: wait 1 minute, or try a different plan tier.
-        #
-        # SHA256 produces 64 hex chars, well within Stripe's 255 char limit.
-        # ==========================================================================
-        time_component  = if Stripe.api_key&.start_with?('sk_test_')
-                           Time.now.strftime('%Y-%m-%dT%H:%M') # Minute granularity for test
-                         else
-                           Time.now.to_date.iso8601 # Daily for production
-                         end
-        idempotency_key = Digest::SHA256.hexdigest(
-          "checkout:#{org.objid}:#{plan.plan_id}:#{time_component}",
-        )
+        idempotency_key = SecureRandom.uuid
 
         checkout_session = stripe_client.create(
           Stripe::Checkout::Session,

--- a/apps/web/billing/controllers/plans.rb
+++ b/apps/web/billing/controllers/plans.rb
@@ -4,6 +4,7 @@
 
 require_relative 'base'
 require 'stripe'
+require 'securerandom'
 
 module Billing
   module Controllers
@@ -19,7 +20,7 @@ module Billing
       #
       # - Automatic Tax: Stripe Tax for EU VAT, Canadian GST/HST, etc.
       # - VAT ID Collection: EU B2B customers can enter VAT for reverse charge
-      # - Idempotency Key: Per-customer, per-plan, per-minute to prevent duplicates
+      # - Idempotency Key: Fresh UUID per session attempt
       # - Nested JSON Metadata: Grouped debug info per Stripe best practices
       # - Customer Reuse: Returning subscribers use existing Stripe Customer ID
       #
@@ -150,9 +151,11 @@ module Billing
           },
         }
 
-        # Create Stripe Checkout Session with idempotency key
-        # Key granularity: per-customer, per-plan, per-minute (prevents duplicates on retry)
-        idempotency_key  = "checkout_#{cust.extid}_#{plan.plan_id}_#{Time.now.to_i / 60}"
+        # Checkout Sessions should be recreated on each pay attempt. We use a
+        # fresh UUID here so minor parameter drift cannot collide with a stale
+        # cached session. Deterministic idempotency is reserved for actual
+        # subscription mutations, not pre-payment URLs.
+        idempotency_key  = SecureRandom.uuid
         checkout_session = Stripe::Checkout::Session.create(
           session_params,
           { idempotency_key: idempotency_key },

--- a/apps/web/billing/spec/controllers/billing_controller_spec.rb
+++ b/apps/web/billing/spec/controllers/billing_controller_spec.rb
@@ -369,7 +369,7 @@ RSpec.describe 'Billing::Controllers::BillingController', :integration, :stripe_
       )
     end
 
-    it 'uses idempotency key to prevent duplicates' do
+    it 'uses a UUID idempotency key for each checkout session attempt' do
       # Mock Stripe checkout session creation
       mock_session = build_checkout_session(
         'url' => 'https://checkout.stripe.com/c/pay/cs_test_idempotent',
@@ -387,12 +387,41 @@ RSpec.describe 'Billing::Controllers::BillingController', :integration, :stripe_
         expect(last_response.status).to eq(200)
       end
 
-      # Verify idempotency key was used in both requests
-      # The key is a SHA256 hash (64 hex chars) of checkout:<org_id>:<plan_id>:<time>
+      # Verify each request gets a fresh UUID so Stripe creates a new session
+      # instead of returning a stale cached checkout URL.
       expect(Stripe::Checkout::Session).to have_received(:create).twice.with(
         anything,
-        hash_including(idempotency_key: a_string_matching(/^[a-f0-9]{64}$/))
+        hash_including(
+          idempotency_key: a_string_matching(
+            /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+          ),
+        ),
       )
+    end
+
+    it 'generates a different idempotency key for each checkout request' do
+      mock_session = build_checkout_session(
+        'url' => 'https://checkout.stripe.com/c/pay/cs_test_unique',
+        'id' => 'cs_test_unique'
+      )
+      request_keys = []
+
+      allow(Stripe::Checkout::Session).to receive(:create) do |_params, opts|
+        request_keys << opts[:idempotency_key]
+        mock_session
+      end
+
+      2.times do
+        post "/billing/api/org/#{organization.extid}/checkout", {
+          product: product,
+          interval: interval,
+        }.to_json, { 'CONTENT_TYPE' => 'application/json' }
+
+        expect(last_response.status).to eq(200)
+      end
+
+      expect(request_keys.size).to eq(2)
+      expect(request_keys.first).not_to eq(request_keys.last)
     end
 
     it 'returns 403 when customer is not organization owner' do

--- a/apps/web/billing/spec/controllers/plans_controller_spec.rb
+++ b/apps/web/billing/spec/controllers/plans_controller_spec.rb
@@ -121,6 +121,28 @@ RSpec.describe 'Billing::Controllers::Plans', :integration, :stripe_sandbox_api,
       expect(last_response.location).to include('/signup')
     end
 
+    it 'uses a fresh UUID idempotency key for each checkout redirect request', :vcr do
+      request_keys = []
+
+      allow(Stripe::Checkout::Session).to receive(:create).and_wrap_original do |original, params, opts|
+        request_keys << opts[:idempotency_key]
+        original.call(params, opts)
+      end
+
+      2.times do
+        get "/billing/plans/#{product}/#{interval}"
+
+        expect(last_response.status).to eq(302)
+        expect(last_response.location).to match(%r{\Ahttps://checkout\.stripe\.com/})
+      end
+
+      expect(request_keys.size).to eq(2)
+      expect(request_keys).to all(
+        match(/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/),
+      )
+      expect(request_keys.first).not_to eq(request_keys.last)
+    end
+
     it 'uses yearly interval parameter', :vcr do
       get "/billing/plans/#{product}/yearly"
 


### PR DESCRIPTION
Closes #2605

## Summary
- switch both checkout-session creation paths to `SecureRandom.uuid`
- keep deterministic idempotency for actual subscription mutations / plan changes untouched
- update checkout controller specs to expect per-request UUID session keys instead of deterministic hashes

## Why
Stripe recommends creating a new Checkout Session for each payment attempt. The old deterministic checkout keys were appropriate for mutation deduplication, but too sticky for ephemeral pre-payment URLs and could collide when session parameters drifted.

## Verification
- `ruby -c apps/web/billing/controllers/billing.rb`
- `ruby -c apps/web/billing/controllers/plans.rb`
- `ruby -c apps/web/billing/spec/controllers/billing_controller_spec.rb`
- `ruby -c apps/web/billing/spec/controllers/plans_controller_spec.rb`

## Local blocker
Full `bundle exec rspec` is currently blocked in this shell because the repo bundle resolves against Ruby `< 4.0`, while this machine is on Ruby `4.0.1` and does not yet have the repo's compatible Ruby toolchain installed.
