### PR TITLE
Fix version metadata for non-tag CI builds

### DIFF
--- a/.github/workflows/build-and-publish-oci-images.yml
+++ b/.github/workflows/build-and-publish-oci-images.yml
@@ -100,9 +100,23 @@ jobs:
           echo "short_sha=${SHORT_SHA}" >> $GITHUB_OUTPUT
           echo "Commit hash recorded: ${SHORT_SHA}"
 
-      - name: Update package.json version from tag
-        if: startsWith(github.ref, 'refs/tags/v')
-        run: ./.github/scripts/update-version.sh
+      - name: Compute and set package.json version
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_VERSION_TAG: ${{ inputs.version_tag }}
+          SHORT_SHA: ${{ steps.commit.outputs.short_sha }}
+        run: |
+          if [[ "$GITHUB_REF" =~ ^refs/tags/v ]]; then
+            # Tag build: script auto-detects version from GITHUB_REF
+            ./.github/scripts/update-version.sh
+          elif [[ "$EVENT_NAME" == "workflow_dispatch" ]] && [[ -n "$INPUT_VERSION_TAG" ]]; then
+            ./.github/scripts/update-version.sh "$INPUT_VERSION_TAG"
+          elif [[ "$EVENT_NAME" == "schedule" ]]; then
+            ./.github/scripts/update-version.sh "0.0.0-nightly.$(date -u +%Y%m%d)"
+          else
+            BRANCH_SLUG=$(echo "${GITHUB_REF#refs/heads/}" | sed 's|/|-|g')
+            ./.github/scripts/update-version.sh "0.0.0-${BRANCH_SLUG}.${SHORT_SHA}"
+          fi
 
       - name: Compute version and tags
         id: version


### PR DESCRIPTION
## Summary

Non-tag CI builds (nightly, manual dispatch, branch pushes) were shipping with the `0.0.0-rc0` placeholder version baked into the container image. Only tag pushes called `update-version.sh`, so every other build path left `package.json` untouched. Since `lib/onetime/version.rb` reads version exclusively from `package.json`, the `/health` endpoint, webhook User-Agent headers, and entrypoint messages all reported `0.0.0-rc0` — making it impossible to distinguish builds without checking the commit hash.

The fix removes the `if: startsWith(github.ref, 'refs/tags/v')` guard and computes a meaningful version for every build path before the Docker build context is created:

- **Tag push**: unchanged (script auto-detects from `GITHUB_REF`)
- **Manual dispatch with `version_tag`**: uses the provided value directly
- **Nightly schedule**: `0.0.0-nightly.YYYYMMDD`
- **Other** (branch builds, manual dispatch without tag): `0.0.0-{branch-slug}.{short-sha}`

All version strings are valid semver and pass the existing regex validation in `update-version.sh`.

## Test plan

- [ ] Trigger a manual dispatch **with** `version_tag` set (e.g. `0.25.0-beta.1`) — verify the image's `/health` endpoint reports that version
- [ ] Trigger a manual dispatch **without** `version_tag` — verify version contains branch slug and short SHA
- [ ] Verify next nightly build reports `0.0.0-nightly.YYYYMMDD` format
- [ ] Verify a tag push (e.g. `v0.25.0-rc1`) still works as before