### PR TITLE
Add globalSetup to generate locale files before i18n tests

### DIFF
--- a/src/tests/globalSetup.ts
+++ b/src/tests/globalSetup.ts
@@ -1,0 +1,31 @@
+// src/tests/globalSetup.ts
+
+/**
+ * Vitest globalSetup: runs once before all test files.
+ *
+ * Generates the merged locale files in generated/locales/ that
+ * i18n tests depend on (key-validation, locale-consistency,
+ * naming-convention, security-messages).
+ */
+
+import { execSync } from 'child_process';
+import { existsSync } from 'fs';
+import { resolve } from 'path';
+
+export function setup() {
+  const generatedLocale = resolve(
+    process.cwd(),
+    'generated/locales/en.json'
+  );
+
+  if (!existsSync(generatedLocale)) {
+    console.log(
+      '[globalSetup] Generating locale files for i18n tests...'
+    );
+    execSync('pnpm run locales:sync', {
+      cwd: process.cwd(),
+      stdio: 'pipe',
+    });
+    console.log('[globalSetup] Locale files generated.');
+  }
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -29,6 +29,7 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   plugins: [vue()],
   test: {
+    globalSetup: ['src/tests/globalSetup.ts'],
     globals: true,
     environment: 'jsdom',
     include: ['src/tests/**/*.spec.ts', 'src/**/*.spec.vue'],


### PR DESCRIPTION
## Summary

Add a Vitest `globalSetup` hook that automatically generates merged locale files before running i18n-related tests. This ensures that the `generated/locales/` directory is populated with the required locale files that tests depend on (key-validation, locale-consistency, naming-convention, security-messages).

## Changes

- Created `src/tests/globalSetup.ts` that runs once before all test files
- Checks if `generated/locales/en.json` exists; if not, executes `pnpm run locales:sync`
- Updated `vitest.config.ts` to register the globalSetup hook

## Related Issues

<!-- Keywords that auto-close issues when merged: Fixes, Closes, Resolves -->
<!-- Example: Fixes #123 -->

## Test Plan

The globalSetup hook will be automatically executed by Vitest before running any tests. Existing i18n tests (key-validation, locale-consistency, naming-convention, security-messages) will now have the required locale files available without manual setup.

https://claude.ai/code/session_012Qi3hdeGg7oYkjK3WgkhTj