### PR TITLE
Bump API docs deployment via Bump.sh hub

### DIFF
--- a/.github/workflows/bump-api-docs.yml
+++ b/.github/workflows/bump-api-docs.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Deploy API documentation
-        uses: bump-sh/github-action@v1
+        uses: bump-sh/github-action@8545e8c657d27de6f55da875473fa493da78bc4f # v1
         with:
           hub: ${{ vars.BUMP_HUB_ID }}
           token: ${{ secrets.BUMP_TOKEN }}
@@ -53,7 +53,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Comment pull request with API diff
-        uses: bump-sh/github-action@v1
+        uses: bump-sh/github-action@8545e8c657d27de6f55da875473fa493da78bc4f # v1
         with:
           hub: ${{ vars.BUMP_HUB_ID }}
           token: ${{ secrets.BUMP_TOKEN }}


### PR DESCRIPTION
## Summary

- Adds `bump-api-docs.yml` workflow that deploys all four OpenAPI specs (`v1`, `v2`, `v3`, `internal`) to a Bump.sh hub on merge to main, and posts API diffs on PRs
- Updates `openapi-generation.yml` file references from the old `*-openapi.json` naming to `openapi.*.json`

Depends on the branch that generates the spec files to `docs/api/`.

Closes #2703