### PR TITLE
Fix LICENSE link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ See `docker-compose.yml` for available profiles (simple vs full stack) and `dock
 
 ## Community & Support
 
-[Latest Release](https://github.com/onetimesecret/onetimesecret/releases/latest) · [Docker Hub](https://hub.docker.com/r/onetimesecret/onetimesecret) · [Build Status](https://github.com/onetimesecret/onetimesecret/actions) · [License](LICENSE)
+[Latest Release](https://github.com/onetimesecret/onetimesecret/releases/latest) · [Docker Hub](https://hub.docker.com/r/onetimesecret/onetimesecret) · [Build Status](https://github.com/onetimesecret/onetimesecret/actions) · [License](LICENSE.txt)
 
 - [Report an issue](https://github.com/onetimesecret/onetimesecret/issues)
 - [Security Statement](./SECURITY.md)


### PR DESCRIPTION
## Summary

Update the LICENSE link in the README from `LICENSE` to `LICENSE.txt` to match the actual filename in the repository.

## Related Issues

<!-- Keywords that auto-close issues when merged: Fixes, Closes, Resolves -->
<!-- Example: Fixes #123 -->

## Test Plan

N/A - This is a documentation link fix. The change can be verified by confirming the link in the rendered README correctly points to the LICENSE.txt file.

https://claude.ai/code/session_01ACup8DAAGChNAcmPv9dsgn