### PR TITLE
Fix nil domain_strategy causing custom domain permission check to always fail

### DIFF
--- a/apps/api/v1/controllers/base.rb
+++ b/apps/api/v1/controllers/base.rb
@@ -93,6 +93,20 @@ module V1
       end
     end
 
+    # Applies domain context from the DomainStrategy middleware to a logic
+    # object. The middleware sets env['onetime.domain_strategy'] and
+    # env['onetime.display_domain'] for every request. V1 logic objects
+    # declare these as attr_accessor but don't receive a strategy_result
+    # (unlike the main Logic::Base), so we bridge the gap here.
+    #
+    # Must be called after construction but before raise_concerns, since
+    # validate_share_domain -> custom_domain? reads domain_strategy.
+    def apply_domain_context(logic)
+      logic.domain_strategy = req.env['onetime.domain_strategy']
+      logic.display_domain  = req.env['onetime.display_domain']
+      logic
+    end
+
     def json hsh
       res.headers['content-type'] = "application/json; charset=utf-8"
       res.body = hsh.to_json

--- a/apps/api/v1/controllers/index.rb
+++ b/apps/api/v1/controllers/index.rb
@@ -67,6 +67,7 @@ module V1
           return if check_rate_limit!(:create_secret, V1_RATE_LIMIT_MAX_CREATES) == :limited
 
           logic = V1::Logic::Secrets::ConcealSecret.new sess, cust, req.params, locale
+          apply_domain_context(logic)
           logic.raise_concerns
           logic.process
           if req.get?
@@ -86,6 +87,7 @@ module V1
           return if check_rate_limit!(:create_secret, V1_RATE_LIMIT_MAX_CREATES) == :limited
 
           logic = V1::Logic::Secrets::GenerateSecret.new sess, cust, req.params, locale
+          apply_domain_context(logic)
           logic.raise_concerns
           logic.process
           if req.get?
@@ -107,6 +109,7 @@ module V1
           return otto_not_found unless valid_identifier?(req.params['key'])
 
           logic = V1::Logic::Secrets::ShowReceipt.new sess, cust, req.params, locale
+          apply_domain_context(logic)
           logic.raise_concerns
           logic.process
           # Reuse data already loaded/decrypted in logic.process rather than
@@ -132,6 +135,7 @@ module V1
       def show_receipt_recent
         authorized(false) do
           logic = V1::Logic::Secrets::ShowReceiptList.new sess, cust, req.params, locale
+          apply_domain_context(logic)
           logic.raise_concerns
           logic.process
           recent_receipts = logic.receipts.collect { |md|
@@ -151,6 +155,7 @@ module V1
 
           req.params['continue'] = 'true'
           logic = V1::Logic::Secrets::ShowSecret.new sess, cust, req.params, locale
+          apply_domain_context(logic)
           logic.raise_concerns
           logic.process
           if logic.show_secret
@@ -170,6 +175,7 @@ module V1
 
           req.params['continue'] = 'true'
           logic = V1::Logic::Secrets::BurnSecret.new sess, cust, req.params, locale
+          apply_domain_context(logic)
           logic.raise_concerns
           logic.process
           if logic.greenlighted
@@ -186,6 +192,7 @@ module V1
           return if check_rate_limit!(:create_secret, V1_RATE_LIMIT_MAX_CREATES) == :limited
 
           logic = V1::Logic::Secrets::ConcealSecret.new sess, cust, req.params, locale
+          apply_domain_context(logic)
           logic.raise_concerns
           logic.process
           if req.get?

--- a/apps/api/v1/spec/controllers/anonymous_access_spec.rb
+++ b/apps/api/v1/spec/controllers/anonymous_access_spec.rb
@@ -236,6 +236,8 @@ RSpec.describe V1::Controllers::Index, 'anonymous access paths' do
 
       before do
         allow(V1::Logic::Secrets::ConcealSecret).to receive(:new).and_return(logic)
+        allow(logic).to receive(:domain_strategy=)
+        allow(logic).to receive(:display_domain=)
         allow(logic).to receive(:raise_concerns)
         allow(logic).to receive(:process)
         allow(logic).to receive(:secret).and_return(secret)
@@ -261,6 +263,8 @@ RSpec.describe V1::Controllers::Index, 'anonymous access paths' do
 
       before do
         allow(V1::Logic::Secrets::GenerateSecret).to receive(:new).and_return(logic)
+        allow(logic).to receive(:domain_strategy=)
+        allow(logic).to receive(:display_domain=)
         allow(logic).to receive(:raise_concerns)
         allow(logic).to receive(:process)
         allow(logic).to receive(:secret).and_return(secret)
@@ -287,6 +291,8 @@ RSpec.describe V1::Controllers::Index, 'anonymous access paths' do
 
       before do
         allow(V1::Logic::Secrets::ConcealSecret).to receive(:new).and_return(logic)
+        allow(logic).to receive(:domain_strategy=)
+        allow(logic).to receive(:display_domain=)
         allow(logic).to receive(:raise_concerns)
         allow(logic).to receive(:process)
         allow(logic).to receive(:secret).and_return(secret)
@@ -307,6 +313,8 @@ RSpec.describe V1::Controllers::Index, 'anonymous access paths' do
       before do
         allow(request).to receive(:params).and_return({ 'key' => 'secret_abc' })
         allow(V1::Logic::Secrets::ShowSecret).to receive(:new).and_return(logic)
+        allow(logic).to receive(:domain_strategy=)
+        allow(logic).to receive(:display_domain=)
         allow(logic).to receive(:raise_concerns)
         allow(logic).to receive(:process)
         allow(logic).to receive(:show_secret).and_return(false)
@@ -330,6 +338,8 @@ RSpec.describe V1::Controllers::Index, 'anonymous access paths' do
       before do
         allow(request).to receive(:params).and_return({ 'key' => 'rcpt_key' })
         allow(V1::Logic::Secrets::ShowReceipt).to receive(:new).and_return(logic)
+        allow(logic).to receive(:domain_strategy=)
+        allow(logic).to receive(:display_domain=)
         allow(logic).to receive(:raise_concerns)
         allow(logic).to receive(:process)
         allow(logic).to receive(:show_secret).and_return(false)

--- a/apps/api/v1/spec/controllers/index_spec.rb
+++ b/apps/api/v1/spec/controllers/index_spec.rb
@@ -62,6 +62,8 @@ RSpec.describe V1::Controllers::Index, type: :request do
       allow(V1::Logic::Secrets::ShowSecret).to receive(:new)
         .with(session, customer, secret_params, 'en')
         .and_return(logic)
+      allow(logic).to receive(:domain_strategy=)
+      allow(logic).to receive(:display_domain=)
       allow(logic).to receive(:raise_concerns)
       allow(logic).to receive(:process)
     end
@@ -117,6 +119,8 @@ RSpec.describe V1::Controllers::Index, type: :request do
       allow(V1::Logic::Secrets::ConcealSecret).to receive(:new)
         .with(session, customer, request.params, 'en')
         .and_return(logic)
+      allow(logic).to receive(:domain_strategy=)
+      allow(logic).to receive(:display_domain=)
       allow(logic).to receive(:raise_concerns)
       allow(logic).to receive(:process)
       allow(logic).to receive(:secret).and_return(secret)
@@ -191,6 +195,8 @@ RSpec.describe V1::Controllers::Index, type: :request do
       allow(V1::Logic::Secrets::ConcealSecret).to receive(:new)
         .with(session, customer, request.params, 'en')
         .and_return(logic)
+      allow(logic).to receive(:domain_strategy=)
+      allow(logic).to receive(:display_domain=)
       allow(logic).to receive(:raise_concerns)
       allow(logic).to receive(:process)
       allow(logic).to receive(:secret).and_return(secret)
@@ -239,6 +245,8 @@ RSpec.describe V1::Controllers::Index, type: :request do
       allow(V1::Logic::Secrets::GenerateSecret).to receive(:new)
         .with(session, customer, request.params, 'en')
         .and_return(logic)
+      allow(logic).to receive(:domain_strategy=)
+      allow(logic).to receive(:display_domain=)
       allow(logic).to receive(:raise_concerns)
       allow(logic).to receive(:process)
       allow(logic).to receive(:secret).and_return(secret)
@@ -292,6 +300,8 @@ RSpec.describe V1::Controllers::Index, type: :request do
       allow(V1::Logic::Secrets::ShowSecret).to receive(:new)
         .with(session, customer, secret_params, 'en')
         .and_return(logic)
+      allow(logic).to receive(:domain_strategy=)
+      allow(logic).to receive(:display_domain=)
       allow(logic).to receive(:raise_concerns)
       allow(logic).to receive(:process)
       # show_secret is false when passphrase is wrong — same controller path as
@@ -321,6 +331,8 @@ RSpec.describe V1::Controllers::Index, type: :request do
       allow(V1::Logic::Secrets::BurnSecret).to receive(:new)
         .with(session, customer, burn_params, 'en')
         .and_return(logic)
+      allow(logic).to receive(:domain_strategy=)
+      allow(logic).to receive(:display_domain=)
       allow(logic).to receive(:raise_concerns)
       allow(logic).to receive(:process)
       allow(logic).to receive(:receipt).and_return(receipt)
@@ -399,6 +411,8 @@ RSpec.describe V1::Controllers::Index, type: :request do
       before do
         logic = instance_double(V1::Logic::Secrets::ConcealSecret)
         allow(V1::Logic::Secrets::ConcealSecret).to receive(:new).and_return(logic)
+        allow(logic).to receive(:domain_strategy=)
+        allow(logic).to receive(:display_domain=)
         allow(logic).to receive(:raise_concerns)
         allow(logic).to receive(:process)
         allow(logic).to receive(:secret).and_return(
@@ -416,6 +430,8 @@ RSpec.describe V1::Controllers::Index, type: :request do
       before do
         logic = instance_double(V1::Logic::Secrets::GenerateSecret)
         allow(V1::Logic::Secrets::GenerateSecret).to receive(:new).and_return(logic)
+        allow(logic).to receive(:domain_strategy=)
+        allow(logic).to receive(:display_domain=)
         allow(logic).to receive(:raise_concerns)
         allow(logic).to receive(:process)
         allow(logic).to receive(:secret).and_return(
@@ -435,6 +451,8 @@ RSpec.describe V1::Controllers::Index, type: :request do
       before do
         logic = instance_double(V1::Logic::Secrets::ConcealSecret)
         allow(V1::Logic::Secrets::ConcealSecret).to receive(:new).and_return(logic)
+        allow(logic).to receive(:domain_strategy=)
+        allow(logic).to receive(:display_domain=)
         allow(logic).to receive(:raise_concerns)
         allow(logic).to receive(:process)
         allow(logic).to receive(:secret).and_return(
@@ -455,6 +473,8 @@ RSpec.describe V1::Controllers::Index, type: :request do
         allow(request).to receive(:params).and_return({'key' => secret_key})
         logic = instance_double(V1::Logic::Secrets::ShowSecret)
         allow(V1::Logic::Secrets::ShowSecret).to receive(:new).and_return(logic)
+        allow(logic).to receive(:domain_strategy=)
+        allow(logic).to receive(:display_domain=)
         allow(logic).to receive(:raise_concerns)
         allow(logic).to receive(:process)
         allow(logic).to receive(:show_secret).and_return(true)

--- a/apps/api/v1/spec/controllers/show_receipt_recent_spec.rb
+++ b/apps/api/v1/spec/controllers/show_receipt_recent_spec.rb
@@ -63,6 +63,8 @@ RSpec.describe V1::Controllers::Index, '#show_receipt_recent' do
       allow(V1::Logic::Secrets::ShowReceiptList).to receive(:new)
         .with(session, customer, request.params, 'en')
         .and_return(logic)
+      allow(logic).to receive(:domain_strategy=)
+      allow(logic).to receive(:display_domain=)
       allow(logic).to receive(:raise_concerns)
       allow(logic).to receive(:process)
     end

--- a/lib/onetime/logic/base.rb
+++ b/lib/onetime/logic/base.rb
@@ -66,6 +66,9 @@ module Onetime
         # Extract organization and team context from StrategyResult metadata
         extract_organization_context(strategy_result)
 
+        # Extract domain context from StrategyResult metadata
+        extract_domain_context(strategy_result)
+
         @processed_params ||= {} # TODO: Remove
         process_settings
 
@@ -189,6 +192,13 @@ module Onetime
 
       def custom_domain?
         domain_strategy.to_s == 'custom'
+      end
+
+      def extract_domain_context(strategy_result)
+        return unless strategy_result
+
+        @domain_strategy = strategy_result.metadata[:domain_strategy]
+        @display_domain  = strategy_result.metadata[:display_domain]
       end
 
       # Session message helpers for user feedback

--- a/try/unit/api/v2/secrets/validate_domain_permissions_try.rb
+++ b/try/unit/api/v2/secrets/validate_domain_permissions_try.rb
@@ -36,9 +36,16 @@ def set_public_homepage(domain, enabled)
 end
 
 # Helper to create a mock ConcealSecret logic instance for testing
-def create_test_logic(customer, share_domain_value: nil, domain_strategy: nil)
+#
+# Passes domain_strategy and display_domain through metadata so that
+# Logic::Base#initialize -> extract_domain_context exercises the real
+# init chain (instead of setting attributes after construction).
+def create_test_logic(customer, share_domain_value: nil, domain_strategy: nil, display_domain: nil)
   sess = MockSession.new
-  strategy_result = MockStrategyResult.new(session: sess, user: customer)
+  metadata = {}
+  metadata[:domain_strategy] = domain_strategy if domain_strategy
+  metadata[:display_domain]  = display_domain  if display_domain
+  strategy_result = MockStrategyResult.new(session: sess, user: customer, metadata: metadata)
   params = {
     'secret' => {
       'secret' => 'test secret',
@@ -46,14 +53,12 @@ def create_test_logic(customer, share_domain_value: nil, domain_strategy: nil)
       'share_domain' => share_domain_value
     }
   }
-  logic = V2::Logic::Secrets::ConcealSecret.new(strategy_result, params, 'en')
-  logic.domain_strategy = domain_strategy if domain_strategy
-  logic
+  V2::Logic::Secrets::ConcealSecret.new(strategy_result, params, 'en')
 end
 
 ## Domain owner can access their own domain from canonical domain
+# No domain_strategy in metadata -> canonical domain (domain_strategy is nil)
 logic = create_test_logic(@owner, share_domain_value: @domain.display_domain)
-logic.domain_strategy = nil # canonical domain (not custom)
 begin
   # Call validate_domain_access which internally calls validate_domain_permissions
   logic.send(:validate_domain_access, @domain.display_domain)
@@ -64,8 +69,8 @@ end
 #=> :success
 
 ## Non-owner on canonical domain raises FormError matching domain permission message
+# No domain_strategy in metadata -> canonical domain (domain_strategy is nil)
 logic = create_test_logic(@other, share_domain_value: @domain.display_domain)
-logic.domain_strategy = nil # canonical domain (not custom)
 begin
   logic.send(:validate_domain_access, @domain.display_domain)
   :success
@@ -75,8 +80,8 @@ end
 #=~> /You do not have permission to use domain:/
 
 ## Error message includes the actual domain name
+# No domain_strategy in metadata -> canonical domain (domain_strategy is nil)
 logic = create_test_logic(@other, share_domain_value: @domain.display_domain)
-logic.domain_strategy = nil # canonical domain
 begin
   logic.send(:validate_domain_access, @domain.display_domain)
   :success
@@ -87,9 +92,10 @@ end
 
 ## Non-owner on custom domain with public sharing enabled is allowed
 set_public_homepage(@domain, true)
-logic = create_test_logic(@other, share_domain_value: @domain.display_domain)
-logic.domain_strategy = 'custom' # accessing FROM a custom domain
-logic.display_domain = @domain.display_domain
+logic = create_test_logic(@other,
+  share_domain_value: @domain.display_domain,
+  domain_strategy: :custom,
+  display_domain: @domain.display_domain)
 begin
   logic.send(:validate_domain_access, @domain.display_domain)
   :success
@@ -100,9 +106,10 @@ end
 
 ## Non-owner on custom domain with public sharing disabled is rejected
 set_public_homepage(@domain, false)
-logic = create_test_logic(@other, share_domain_value: @domain.display_domain)
-logic.domain_strategy = 'custom' # accessing FROM a custom domain
-logic.display_domain = @domain.display_domain
+logic = create_test_logic(@other,
+  share_domain_value: @domain.display_domain,
+  domain_strategy: :custom,
+  display_domain: @domain.display_domain)
 begin
   logic.send(:validate_domain_access, @domain.display_domain)
   :success
@@ -112,9 +119,9 @@ end
 #=~> /Public sharing disabled for domain:/
 
 ## Owner can always access their domain regardless of public sharing setting
+# No domain_strategy in metadata -> canonical domain (domain_strategy is nil)
 set_public_homepage(@domain, false)
 logic = create_test_logic(@owner, share_domain_value: @domain.display_domain)
-logic.domain_strategy = nil # canonical domain
 begin
   logic.send(:validate_domain_access, @domain.display_domain)
   :success


### PR DESCRIPTION
## Summary

`Logic::Base#initialize` never extracted `domain_strategy` from `strategy_result.metadata`, so `custom_domain?` always returned `false` — silently bypassing the `allow_public_homepage` permission branch for visitors on branded domains.

- **V2 fix**: Added `extract_domain_context()` in `Logic::Base#initialize`, mirroring the existing `extract_organization_context` pattern
- **V1 bridge**: Added `apply_domain_context()` helper in V1 `ControllerBase` since V1 logic objects don't receive StrategyResult — reads from `req.env` instead, applied at all 7 endpoint call sites
- **Tests**: Refactored to pass domain context through metadata instead of manual setters, exercising the real init chain that was previously bypassed

### Behavioral change

Custom domains with `allow_public_homepage: false` will now correctly reject anonymous secret creation. Previously this setting was silently ignored because the permission check never activated.

## Test plan

- [x] Domain permission tryouts pass (6/6 scenarios: owner access, non-owner rejection, public sharing on/off, error messages)
- [x] V1 controller specs pass (117/117)
- [x] Full unit tryouts pass (2538/2538, 0 regressions)
- [ ] Manual: verify anonymous secret creation on a custom domain with public sharing disabled is rejected
- [ ] Manual: verify anonymous secret creation on a custom domain with public sharing enabled succeeds

Closes #2763