### PR TITLE
Remove unnecessary favicon and social preview image tags

### DIFF
--- a/apps/web/core/templates/partials/head-base.rue
+++ b/apps/web/core/templates/partials/head-base.rue
@@ -26,11 +26,6 @@
 
   <!-- Modern favicon strategy -->
   <link nonce="{{app.nonce}}" rel="icon" href="/favicon.ico" sizes="32x32">
-  <link nonce="{{app.nonce}}" rel="icon" type="image/svg+xml" href="/img/favicon.svg">
-  <!--<link nonce="{{app.nonce}}" rel="apple-touch-icon" href="/apple-touch-icon.png">-->
-  <link nonce="{{app.nonce}}" rel="mask-icon" href="/safari-pinned-tab.svg" color="#dc4a22">
-
-
 
   {{#if no_cache}}
     <meta http-equiv="pragma" content="no-cache">

--- a/apps/web/core/templates/partials/head.rue
+++ b/apps/web/core/templates/partials/head.rue
@@ -7,7 +7,6 @@
   <meta property="og:url" content="{{baseuri}}">
   <meta property="og:title" content="{{page_title}}">
   <meta property="og:description" content="{{description}}">
-  <meta property="og:image" content="{{baseuri}}/img/social-preview.png">
 
   <!-- Twitter Card meta tags -->
   <meta name="twitter:card" content="summary_large_image">
@@ -15,5 +14,4 @@
   <meta property="twitter:url" content="{{baseuri}}">
   <meta name="twitter:title" content="{{page_title}}">
   <meta name="twitter:description" content="{{description}}">
-  <meta name="twitter:image" content="{{baseuri}}/img/social-preview.png">
 </template>


### PR DESCRIPTION
## Summary

Cleans up redundant meta tags from the HTML head templates:

- Removes SVG favicon and Safari pinned-tab icon references from `head-base.rue`, keeping only the standard `favicon.ico`
- Removes Open Graph and Twitter Card image meta tags from `head.rue` that referenced a `social-preview.png`

These assets are either unused or handled elsewhere. Net effect: 7 fewer lines of template markup and fewer unnecessary resource hints for browsers.

## Test plan

- [ ] Verify favicon still renders correctly via `favicon.ico`
- [ ] Confirm no broken link warnings in browser dev tools