### PR TITLE
[#2779] Fix JSON encoding and case sensitivity in repair scripts

### DIFF
--- a/scripts/upgrades/v0.24.5/repair_display_domain_indexes.rb
+++ b/scripts/upgrades/v0.24.5/repair_display_domain_indexes.rb
@@ -81,6 +81,7 @@ end
 # but sorted set members are raw strings. This handles both.
 def normalize_value(raw)
   return nil if raw.nil?
+  return raw unless raw.is_a?(String) # Non-strings already normalized
   return raw if raw.empty?
 
   # Try parsing as JSON first (handles '"abc123"' -> 'abc123')
@@ -100,13 +101,14 @@ end
 # Try to find a value in a hash index, checking multiple key variants.
 # Returns [key_used, value] or [nil, nil] if not found.
 def hget_flexible(redis, hash_key, display_domain)
+  domain_str = display_domain.to_s
   # Try exact case first
-  value = redis.hget(hash_key, display_domain)
-  return [display_domain, value] if value
+  value = redis.hget(hash_key, domain_str)
+  return [domain_str, value] if value
 
   # Try lowercase
-  lower = display_domain.downcase
-  if lower != display_domain
+  lower = domain_str.downcase
+  if lower != domain_str
     value = redis.hget(hash_key, lower)
     return [lower, value] if value
   end

--- a/scripts/upgrades/v0.24.5/validate_display_domains_index.rb
+++ b/scripts/upgrades/v0.24.5/validate_display_domains_index.rb
@@ -39,6 +39,7 @@ end
 # but sorted set members are raw strings. This handles both.
 def normalize_value(raw)
   return nil if raw.nil?
+  return raw unless raw.is_a?(String) # Non-strings already normalized
   return raw if raw.empty?
 
   JSON.parse(raw)
@@ -55,13 +56,14 @@ end
 # Try to find a value in a hash index, checking multiple key variants.
 # Returns [key_used, value] or [nil, nil] if not found.
 def hget_flexible(redis, hash_key, display_domain)
+  domain_str = display_domain.to_s
   # Try exact case first
-  value = redis.hget(hash_key, display_domain)
-  return [display_domain, value] if value
+  value = redis.hget(hash_key, domain_str)
+  return [domain_str, value] if value
 
   # Try lowercase
-  lower = display_domain.downcase
-  if lower != display_domain
+  lower = domain_str.downcase
+  if lower != domain_str
     value = redis.hget(hash_key, lower)
     return [lower, value] if value
   end


### PR DESCRIPTION
Closes #2779

## Summary

- Add `normalize_value()` helper to parse JSON-encoded values from Familia HashKey fields
- Add `values_match()` to compare values after normalizing both sides
- Add `hget_flexible()` to try exact case then lowercase when looking up index keys
- Fix double-encoding bug in `repair_display_domain_indexes.rb`
- Update `validate_display_domains_index.rb` with same helpers for consistency

## Test plan

- [ ] Run `ruby scripts/upgrades/v0.24.5/repair_display_domain_indexes.rb --verbose` in dry-run mode
- [ ] Run `ruby scripts/upgrades/v0.24.5/validate_display_domains_index.rb` 
- [ ] Verify both scripts now report consistent results
- [ ] Test with `--execute` on staging if mismatches are found