### PR TITLE
Mask API key display and add missing locale entries

### DIFF
--- a/src/apps/workspace/components/account/APIKeyCard.vue
+++ b/src/apps/workspace/components/account/APIKeyCard.vue
@@ -3,7 +3,8 @@
 <script setup lang="ts">
   import { useI18n } from 'vue-i18n';
 import OIcon from '@/shared/components/icons/OIcon.vue';
-import { ref } from 'vue';
+import { maskSensitiveText } from '@/utils/format';
+import { ref, computed } from 'vue';
 
 const { t } = useI18n();
 
@@ -19,8 +20,11 @@ const props = withDefaults(defineProps<Props>(), {
 
 const copied = ref(false);
 
+// Mask the displayed token while keeping the full value for copying
+const maskedToken = computed(() => maskSensitiveText(props.apitoken ?? ''));
+
 const handleCopy = () => {
-  navigator.clipboard.writeText(props.apitoken)
+  navigator.clipboard.writeText(props.apitoken ?? '')
     .then(() => {
       copied.value = true;
       setTimeout(() => {
@@ -40,7 +44,7 @@ const handleCopy = () => {
     class="mb-4 rounded-lg border border-gray-200/60 bg-white/60 p-4 shadow-sm backdrop-blur-sm dark:border-gray-700/60 dark:bg-gray-800/60">
     <div class="font-mono text-sm text-gray-800 dark:text-gray-200">
       <div class="relative flex items-center overflow-x-auto rounded-md border border-gray-200 bg-gray-50 p-3 dark:border-gray-600 dark:bg-gray-900/50">
-        <span class="break-all pr-10">{{ apitoken }}</span>
+        <span class="break-all pr-10">{{ maskedToken }}</span>
         <button
           @click.stop="handleCopy"
           type="button"

--- a/src/sources/translations.json
+++ b/src/sources/translations.json
@@ -1,5 +1,16 @@
 [
   {
+    "name": "English",
+    "code": "en",
+    "translators": [
+      {
+        "name": "Onetime Secret",
+        "url": "https://github.com/onetimesecret",
+        "date": "Original"
+      }
+    ]
+  },
+  {
     "name": "Ukrainian",
     "code": "uk",
     "translators": [
@@ -121,7 +132,7 @@
   },
   {
     "name": "Chinese",
-    "code": "cn",
+    "code": "zh",
     "translators": [
       {
         "name": "Rayi_Yosoro",
@@ -264,6 +275,83 @@
         "name": "Duc Nguyen",
         "url": "https://fb.me/socthaovat",
         "date": "Nov, 2022"
+      }
+    ]
+  },
+  {
+    "name": "Esperanto",
+    "code": "eo",
+    "translators": [
+      {
+        "name": "Claude 3.5 Sonnet",
+        "url": "https://github.com/anthropics",
+        "date": "Mar, 2026"
+      }
+    ]
+  },
+  {
+    "name": "German (Austria)",
+    "code": "de_AT",
+    "translators": [
+      {
+        "name": "Claude 3.5 Sonnet",
+        "url": "https://github.com/anthropics",
+        "date": "Mar, 2026"
+      }
+    ]
+  },
+  {
+    "name": "French (Canada)",
+    "code": "fr_CA",
+    "translators": [
+      {
+        "name": "Claude 3.5 Sonnet",
+        "url": "https://github.com/anthropics",
+        "date": "Mar, 2026"
+      }
+    ]
+  },
+  {
+    "name": "French (France)",
+    "code": "fr_FR",
+    "translators": [
+      {
+        "name": "Claude 3.5 Sonnet",
+        "url": "https://github.com/anthropics",
+        "date": "Mar, 2026"
+      }
+    ]
+  },
+  {
+    "name": "Japanese",
+    "code": "ja",
+    "translators": [
+      {
+        "name": "Claude 3.5 Sonnet",
+        "url": "https://github.com/anthropics",
+        "date": "Mar, 2026"
+      }
+    ]
+  },
+  {
+    "name": "Korean",
+    "code": "ko",
+    "translators": [
+      {
+        "name": "Claude 3.5 Sonnet",
+        "url": "https://github.com/anthropics",
+        "date": "Mar, 2026"
+      }
+    ]
+  },
+  {
+    "name": "Māori",
+    "code": "mi_NZ",
+    "translators": [
+      {
+        "name": "Claude 3.5 Sonnet",
+        "url": "https://github.com/anthropics",
+        "date": "Mar, 2026"
       }
     ]
   }

--- a/src/utils/format/index.ts
+++ b/src/utils/format/index.ts
@@ -214,3 +214,38 @@ export const formatRelativeTime = (date: Date | undefined): string => {
   const days = Math.floor(diffInSeconds / 86400);
   return `${days} ${days === 1 ? 'day' : 'days'} ago`;
 };
+
+/**
+ * Mask sensitive text, showing only first and last few characters.
+ * Uses bullet character (•) for masking to match SSO config patterns.
+ *
+ * @param text - The text to mask
+ * @param visibleStart - Number of characters to show at start (default: 4)
+ * @param visibleEnd - Number of characters to show at end (default: 4)
+ * @returns Masked text like "abc1••••••••5xyz"
+ *
+ * @example
+ * maskSensitiveText('sk_live_abc123xyz789') // 'sk_l••••••••9789'
+ * maskSensitiveText('short') // '••••••••' (too short to show ends)
+ * maskSensitiveText('abcdefghij', 2, 2) // 'ab••••••ij'
+ */
+export const maskSensitiveText = (
+  text: string,
+  visibleStart = 4,
+  visibleEnd = 4,
+): string => {
+  if (!text) return '';
+
+  const minLength = visibleStart + visibleEnd + 4; // Need at least 4 masked chars
+
+  if (text.length < minLength) {
+    // Too short to show meaningful ends - just mask entirely
+    return '••••••••';
+  }
+
+  const start = text.slice(0, visibleStart);
+  const end = text.slice(-visibleEnd);
+  const maskedLength = Math.min(text.length - visibleStart - visibleEnd, 8);
+
+  return `${start}${'•'.repeat(maskedLength)}${end}`;
+};


### PR DESCRIPTION
Add maskSensitiveText utility for displaying sensitive tokens with first/last 4 characters visible and bullets in between. Apply to APIKeyCard so the token display is masked while copy still works with full value.

Add missing locale entries to translations.json: en, eo (Esperanto), de_AT, fr_CA, fr_FR, ja, ko, mi_NZ. Fix Chinese code from cn to zh (ISO 639-1).