### PR TITLE
Normalize SSL config checks to use != false instead of raw truthiness

### DIFF
--- a/apps/api/v1/logic/helpers/uris.rb
+++ b/apps/api/v1/logic/helpers/uris.rb
@@ -19,7 +19,7 @@ module V1
       end
 
       def base_scheme
-        Onetime.conf['site']['ssl'] ? 'https://' : 'http://'
+        Onetime.conf.dig('site', 'ssl') != false ? 'https://' : 'http://'
       end
 
       def server_port

--- a/apps/api/v2/logic/helpers/uris.rb
+++ b/apps/api/v2/logic/helpers/uris.rb
@@ -19,7 +19,7 @@ module V2
       end
 
       def base_scheme
-        Onetime.conf['site']['ssl'] ? 'https://' : 'http://'
+        Onetime.conf.dig('site', 'ssl') != false ? 'https://' : 'http://'
       end
 
       def server_port

--- a/apps/web/billing/controllers/base.rb
+++ b/apps/web/billing/controllers/base.rb
@@ -85,7 +85,7 @@ module Billing
             }
         else
           uri.host ||= OT.conf['site']['host']
-          if (OT.conf['site']['ssl']) && (uri.scheme.nil? || uri.scheme != 'https')
+          if (OT.conf.dig('site', 'ssl') != false) && (uri.scheme.nil? || uri.scheme != 'https')
             uri.scheme = 'https'
           end
           uri        = nil unless uri.is_a?(URI::HTTP)

--- a/apps/web/billing/controllers/billing.rb
+++ b/apps/web/billing/controllers/billing.rb
@@ -995,7 +995,7 @@ module Billing
         # @return [String] Base URL, e.g. "https://example.com"
         def billing_base_url
           site_host = Onetime.conf['site']['host']
-          is_secure = Onetime.conf['site']['ssl']
+          is_secure = Onetime.conf.dig('site', 'ssl') != false
           protocol  = is_secure ? 'https' : 'http'
           "#{protocol}://#{site_host}"
         end

--- a/apps/web/billing/controllers/plans.rb
+++ b/apps/web/billing/controllers/plans.rb
@@ -76,7 +76,7 @@ module Billing
 
         # Build checkout session parameters
         site_host = Onetime.conf['site']['host']
-        is_secure = Onetime.conf['site']['ssl']
+        is_secure = Onetime.conf.dig('site', 'ssl') != false
         protocol  = is_secure ? 'https' : 'http'
 
         success_url = "#{protocol}://#{site_host}/billing/welcome?session_id={CHECKOUT_SESSION_ID}"
@@ -240,7 +240,7 @@ module Billing
         end
 
         site_host  = Onetime.conf['site']['host']
-        is_secure  = Onetime.conf['site']['ssl']
+        is_secure  = Onetime.conf.dig('site', 'ssl') != false
         protocol   = is_secure ? 'https' : 'http'
 
         # Return to billing overview for the specific organization

--- a/apps/web/core/controllers/base.rb
+++ b/apps/web/core/controllers/base.rb
@@ -69,7 +69,7 @@ module Core
           # Set a default host if the host is missing
           uri.host ||= OT.conf['site']['host']
           # Ensure the scheme is HTTPS if SSL is enabled in the configuration
-          if (OT.conf['site']['ssl']) && (uri.scheme.nil? || uri.scheme != 'https')
+          if (OT.conf.dig('site', 'ssl') != false) && (uri.scheme.nil? || uri.scheme != 'https')
             uri.scheme = 'https'
           end
           # Set uri to nil if it is not an HTTP or HTTPS URI

--- a/apps/web/core/controllers/welcome.rb
+++ b/apps/web/core/controllers/welcome.rb
@@ -157,7 +157,7 @@ module Core
         customer_id = cust.stripe_customer_id
 
         site_host   = Onetime.conf['site']['host']
-        is_secure   = Onetime.conf['site']['ssl']
+        is_secure   = Onetime.conf.dig('site', 'ssl') != false
         return_url  = "#{is_secure ? 'https' : 'http'}://#{site_host}/account"
 
         # Create a Stripe Customer Portal session

--- a/apps/web/core/views/helpers/initialize_view_vars.rb
+++ b/apps/web/core/views/helpers/initialize_view_vars.rb
@@ -177,7 +177,7 @@ module Core
 
         # URI helpers for templates
         site_host            = safe_site['host']
-        base_scheme          = safe_site['ssl'] ? 'https://' : 'http://'
+        base_scheme          = safe_site['ssl'] != false ? 'https://' : 'http://'
         baseuri              = base_scheme + site_host
 
         # Return all view variables as a hash


### PR DESCRIPTION
The site.ssl config value is typed as any() in the schema, meaning it could be a string or hash (both truthy). Using != false ensures only an explicit false disables SSL, matching the pattern already used in mail views.


