### PR TITLE
Update to familia 2.3.3 for AAD fixes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -75,7 +75,7 @@ gem 'truemail'
 # ORMs and database drivers
 # NOTE: We install both db drivers for the OCI images so that users can choose
 # which database to use at runtime via environment variable without rebuilding.
-gem 'familia', '2.3.2'
+gem 'familia', '2.3.3'
 gem 'pg', '~> 1.6'
 gem 'sequel', '~> 5.0'
 gem 'sqlite3', '~> 2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -129,7 +129,7 @@ GEM
     facets (3.1.0)
     faker (3.6.1)
       i18n (>= 1.8.11, < 2)
-    familia (2.3.2)
+    familia (2.3.3)
       concurrent-ruby (~> 1.3)
       connection_pool (>= 2.4, < 4.0)
       csv (~> 3.3)
@@ -629,7 +629,7 @@ DEPENDENCIES
   dry-cli (~> 1.2)
   encryptor (= 1.1.3)
   faker (~> 3.2)
-  familia (= 2.3.2)
+  familia (= 2.3.3)
   fastimage (~> 2.4)
   htmlbeautifier
   httparty


### PR DESCRIPTION
Bumps familia gem from 2.3.2 to 2.3.3, which includes fixes for AAD (additional authenticated data) handling in encrypted fields.

Relates to #FAMILIA-233