### PR TITLE
Consolidate email normalization into OT::Utils.normalize_email

### DIFF
--- a/apps/api/invite/logic/invites/accept_invite.rb
+++ b/apps/api/invite/logic/invites/accept_invite.rb
@@ -92,7 +92,7 @@ module InviteAPI::Logic
       protected
 
       def normalize_email(email)
-        email.to_s.strip.downcase
+        OT::Utils.normalize_email(email)
       end
     end
   end

--- a/apps/api/organizations/cli/add_member_command.rb
+++ b/apps/api/organizations/cli/add_member_command.rb
@@ -96,7 +96,7 @@ module Onetime
       end
 
       def find_customer!(email)
-        customer = Onetime::Customer.find_by_email(email.to_s.strip.unicode_normalize(:nfc).downcase(:fold))
+        customer = Onetime::Customer.find_by_email(OT::Utils.normalize_email(email))
         unless customer
           puts "Error: Customer not found with email: #{email}"
           puts '  The customer must have an existing account before being added to an organization.'

--- a/apps/web/auth/config/base.rb
+++ b/apps/web/auth/config/base.rb
@@ -55,7 +55,7 @@ module Auth::Config::Base
     # Uses NFC normalization for consistent Unicode representation and :fold
     # for proper case folding of international characters.
     auth.normalize_login do |login|
-      login.to_s.strip.unicode_normalize(:nfc).downcase(:fold)
+      OT::Utils.normalize_email(login)
     end
 
     # Session configuration

--- a/apps/web/auth/config/hooks/omniauth.rb
+++ b/apps/web/auth/config/hooks/omniauth.rb
@@ -25,7 +25,7 @@ module Auth::Config::Hooks
       # - IdPs may return emails with different casing than stored
       # Uses NFC normalization and :fold for international email addresses.
       auth.account_from_omniauth do
-        normalized_email = omniauth_email.to_s.strip.unicode_normalize(:nfc).downcase(:fold)
+        normalized_email = OT::Utils.normalize_email(omniauth_email)
         _account_from_login(normalized_email)
       end
 

--- a/apps/web/auth/migrations/007_normalize_customer_emails.rb
+++ b/apps/web/auth/migrations/007_normalize_customer_emails.rb
@@ -100,7 +100,7 @@ Sequel.migration do
         duplicates = []
 
         entries.each do |email, objid_json|
-          lowercase_email = email.to_s.unicode_normalize(:nfc).downcase(:fold)
+          lowercase_email = OT::Utils.normalize_email(email)
 
           if email == lowercase_email
             stats[:skipped_already_lower] += 1

--- a/apps/web/auth/operations/accept_invitation.rb
+++ b/apps/web/auth/operations/accept_invitation.rb
@@ -114,7 +114,7 @@ module Auth
       end
 
       def normalize_email(email)
-        email.to_s.strip.downcase
+        OT::Utils.normalize_email(email)
       end
     end
   end

--- a/apps/web/auth/spec/config/base_normalize_login_spec.rb
+++ b/apps/web/auth/spec/config/base_normalize_login_spec.rb
@@ -22,8 +22,9 @@
 require 'rspec'
 
 RSpec.describe 'Auth::Config::Base normalize_login' do
-  # Simulates the normalize_login logic from auth/config/base.rb:
-  #   login.to_s.strip.unicode_normalize(:nfc).downcase(:fold)
+  # Simulates the normalize_login logic from auth/config/base.rb.
+  # Canonical implementation: OT::Utils.normalize_email
+  # Inlined here to test the specific chain the Rodauth hook uses.
   def normalize_login(login)
     login.to_s.strip.unicode_normalize(:nfc).downcase(:fold)
   end

--- a/apps/web/auth/spec/config/hooks/omniauth_spec.rb
+++ b/apps/web/auth/spec/config/hooks/omniauth_spec.rb
@@ -34,8 +34,9 @@ RSpec.describe 'OmniAuth hooks' do
     #
     # The method normalizes the IdP-provided email before account lookup.
 
-    # Simulates the email normalization logic from the _account_from_omniauth hook
-    # Uses NFC normalization and :fold for proper Unicode case folding
+    # Simulates the email normalization logic from the _account_from_omniauth hook.
+    # Canonical implementation: OT::Utils.normalize_email
+    # Inlined here to test the specific chain the OmniAuth hook uses.
     def normalize_email(omniauth_email)
       omniauth_email.to_s.strip.unicode_normalize(:nfc).downcase(:fold)
     end

--- a/lib/onetime/cli/customers/show_command.rb
+++ b/lib/onetime/cli/customers/show_command.rb
@@ -36,7 +36,7 @@ module Onetime
         boot_application!
 
         # Normalize email for lookup: strip, NFC normalize, case-fold
-        normalized = identifier.to_s.strip.unicode_normalize(:nfc).downcase(:fold)
+        normalized = OT::Utils.normalize_email(identifier)
 
         if normalized.empty?
           error_exit('Identifier is required', json: json)

--- a/lib/onetime/models/customer.rb
+++ b/lib/onetime/models/customer.rb
@@ -247,7 +247,7 @@ module Onetime
         # store emails consistently lowercase. Uses NFC normalization for
         # consistent Unicode representation and :fold for proper case folding
         # of international characters.
-        email = email.to_s.strip.unicode_normalize(:nfc).downcase(:fold)
+        email = OT::Utils.normalize_email(email)
 
         loggable_email = OT::Utils.obscure_email(email)
         raise Familia::Problem, 'email is required' if email.empty?

--- a/lib/onetime/models/customer/features/colonel_assignment.rb
+++ b/lib/onetime/models/customer/features/colonel_assignment.rb
@@ -28,7 +28,7 @@ module Onetime
         def colonel?(email)
           return false if email.nil? || email.empty?
 
-          normalized = email.to_s.strip.unicode_normalize(:nfc).downcase(:fold)
+          normalized = OT::Utils.normalize_email(email)
           colonels_list.include?(normalized)
         end
 
@@ -43,7 +43,7 @@ module Onetime
 
           raw_list
             .flat_map { |entry| entry.to_s.split(',') }
-            .map { |col| col.to_s.strip.unicode_normalize(:nfc).downcase(:fold) }
+            .map { |col| OT::Utils.normalize_email(col) }
             .compact
             .reject(&:empty?)
         end

--- a/lib/onetime/models/organization_membership.rb
+++ b/lib/onetime/models/organization_membership.rb
@@ -125,7 +125,7 @@ module Onetime
     def org_email_key
       return nil unless organization_objid && invited_email
 
-      "#{organization_objid}:#{invited_email.to_s.downcase}"
+      "#{organization_objid}:#{OT::Utils.normalize_email(invited_email)}"
     end
 
     # Key for finding active memberships by org + customer
@@ -221,7 +221,8 @@ module Onetime
       raise Onetime::Problem, 'Invitation declined' if status == 'declined'
 
       emails_match = invited_email.nil? ||
-                     customer.email.to_s.downcase == invited_email.to_s.downcase
+                     OT::Utils.normalize_email(customer.email) ==
+                     OT::Utils.normalize_email(invited_email)
       raise Onetime::Problem, 'Email mismatch' unless emails_match
 
       # Capture values from staged model before activation destroys it
@@ -388,7 +389,7 @@ module Onetime
       # @return [OrganizationMembership] the created invitation (UUID-keyed staged model)
       # @raise [Onetime::Problem] if invitation already exists for this email
       def create_invitation!(organization:, email:, inviter:, role: 'member')
-        email = email.to_s.strip.downcase
+        email = OT::Utils.normalize_email(email)
 
         # Check for existing pending invitation
         existing = find_by_org_email(organization.objid, email)
@@ -435,7 +436,7 @@ module Onetime
       def find_by_org_email(org_objid, email)
         return nil if org_objid.nil? || email.nil?
 
-        key   = "#{org_objid}:#{email.to_s.strip.downcase}"
+        key   = "#{org_objid}:#{OT::Utils.normalize_email(email)}"
         objid = org_email_lookup[key]
         return nil unless objid
 

--- a/lib/onetime/utils/email_hash.rb
+++ b/lib/onetime/utils/email_hash.rb
@@ -75,6 +75,13 @@ module Onetime
 
       # Normalize email for consistent hashing
       #
+      # Uses NFC normalization for consistent Unicode representation
+      # and :fold for proper case folding of international characters,
+      # matching Customer.create! normalization.
+      #
+      # Parallel copy kept here to avoid load-order dependency on Utils.
+      # @see OT::Utils.normalize_email (canonical public version in Strings)
+      #
       # @param email [String] Raw email address
       # @return [String] Normalized email (lowercase, trimmed)
       #

--- a/lib/onetime/utils/strings.rb
+++ b/lib/onetime/utils/strings.rb
@@ -104,6 +104,17 @@ module Onetime
       #
       # @note Uses Mail::Address for parsing, avoiding hand-rolled parsing
       #   edge cases while keeping the code short and auditable.
+      # Normalize an email address for consistent storage and comparison.
+      #
+      # @param email [String] Raw email address
+      # @return [String] Normalized email (NFC, case-folded, stripped)
+      #
+      # @see Onetime::Utils::EmailHash.normalize_email (private, parallel copy
+      #   kept to avoid load-order dependency)
+      def normalize_email(email)
+        email.to_s.strip.unicode_normalize(:nfc).downcase(:fold)
+      end
+
       def obscure_email(text)
         return text if text.nil? || text.empty?
 

--- a/try/unit/cli/customers/show_try.rb
+++ b/try/unit/cli/customers/show_try.rb
@@ -41,8 +41,8 @@ OT.info "Cleaned Redis for fresh test run"
 # -------------------------------------------------------------------
 
 def show_customer_cli(identifier:, full: false, json: false)
-  # Normalize email for lookup: strip, NFC normalize, case-fold
-  normalized = identifier.to_s.strip.unicode_normalize(:nfc).downcase(:fold)
+  # Normalize email for lookup via canonical method
+  normalized = OT::Utils.normalize_email(identifier)
 
   if normalized.empty?
     return { success: false, error: 'Identifier is required' }

--- a/try/unit/cli/organizations/add_member_email_normalization_try.rb
+++ b/try/unit/cli/organizations/add_member_email_normalization_try.rb
@@ -5,11 +5,11 @@
 # Tests for email normalization consistency in add_member_command.rb
 #
 # Issue: The CLI command was using `email.to_s.strip.downcase` but the model
-# uses `unicode_normalize(:nfc).downcase(:fold)` for storage. Without matching
-# normalization, lookups for internationalized emails could fail.
+# uses `OT::Utils.normalize_email` (NFC + case fold) for storage. Without
+# matching normalization, lookups for internationalized emails could fail.
 #
-# The fix ensures the CLI uses the same normalization chain:
-#   email.to_s.strip.unicode_normalize(:nfc).downcase(:fold)
+# The fix ensures the CLI uses the canonical normalization:
+#   OT::Utils.normalize_email(email)
 #
 # This test verifies:
 # 1. Email lookup works with unicode characters (e.g., "MULLER@example.com" finds "muller@example.com")
@@ -28,7 +28,8 @@ OT.info "Cleaned Redis for fresh test run"
 
 @test_id = SecureRandom.hex(6)
 
-# Helper to normalize email the same way the CLI command does (after fix)
+# Helper to normalize email the same way the CLI command does (after fix).
+# Inlined here deliberately to test that the chain matches OT::Utils.normalize_email.
 def cli_normalize_email(email)
   email.to_s.strip.unicode_normalize(:nfc).downcase(:fold)
 end
@@ -173,21 +174,20 @@ result
 #=> true
 
 ## Demonstrate the old bug: simple downcase fails for German sharp S
-# Without unicode_normalize(:nfc).downcase(:fold), lookups could fail
+# Without OT::Utils.normalize_email, lookups could fail
 # when CLI and model use different normalization
 old_style_normalize = ->(e) { e.to_s.strip.downcase }  # Old CLI behavior
-new_style_normalize = ->(e) { e.to_s.strip.unicode_normalize(:nfc).downcase(:fold) }  # Fixed CLI behavior
 
 # For basic ASCII, both produce the same result
 ascii_test = "TEST@EXAMPLE.COM"
-old_style_normalize.call(ascii_test) == new_style_normalize.call(ascii_test)
+old_style_normalize.call(ascii_test) == OT::Utils.normalize_email(ascii_test)
 #=> true
 
 ## Demonstrate consistency: CLI and model normalize to same value
 email_input = "MULLER_#{@test_id}@EXAMPLE.COM"
-# Simulate what model stores after normalization
-model_stored = email_input.to_s.strip.unicode_normalize(:nfc).downcase(:fold)
-# Simulate what CLI normalizes for lookup
+# What model stores via canonical normalization
+model_stored = OT::Utils.normalize_email(email_input)
+# What CLI normalizes for lookup
 cli_lookup = cli_normalize_email(email_input)
 model_stored == cli_lookup
 #=> true
@@ -195,7 +195,6 @@ model_stored == cli_lookup
 ## check_pending_invitation also uses correct normalization (add_member_command.rb:210)
 # The same normalization is used in find_by_org_email for invitation lookup
 # This ensures consistent behavior between member lookup and invitation lookup
-org_email_normalize = ->(e) { e.to_s.strip.unicode_normalize(:nfc).downcase(:fold) }
 test_email = "INVITATION_#{@test_id}@EXAMPLE.COM"
-org_email_normalize.call(test_email) == cli_normalize_email(test_email)
+OT::Utils.normalize_email(test_email) == cli_normalize_email(test_email)
 #=> true

--- a/try/unit/cli/organizations/add_member_try.rb
+++ b/try/unit/cli/organizations/add_member_try.rb
@@ -72,9 +72,9 @@ def add_member_cli(org:, email:, role: 'member', default_org: false, dry_run: fa
     return { success: false, error: "Organization not found: #{org}" }
   end
 
-  # Find customer - normalize email to lowercase for consistent Redis lookup
-  # (Customer emails are stored lowercase via Customer.create! normalization)
-  normalized_email = email.to_s.strip.unicode_normalize(:nfc).downcase(:fold)
+  # Find customer - normalize email for consistent Redis lookup
+  # (Customer emails are stored normalized via Customer.create!)
+  normalized_email = OT::Utils.normalize_email(email)
   customer = Onetime::Customer.find_by_email(normalized_email)
   unless customer
     return { success: false, error: "Customer not found: #{email}" }


### PR DESCRIPTION
## Summary

- Add `OT::Utils.normalize_email` as canonical public method in `Utils::Strings`, replacing 16 inline copies of `to_s.strip.unicode_normalize(:nfc).downcase(:fold)` across 12 production files
- Fix bug in `accept_invitation.rb` and `accept_invite.rb` where weaker `.strip.downcase` normalizer (missing NFC + `:fold`) could reject Unicode email matches during invitation acceptance
- `EmailHash` keeps its private copy to avoid load-order dependency, with cross-reference comment

Closes #2910

## Test plan

- [ ] `bundle exec try --agent` — full suite passes (5633/5634, pre-existing unrelated failure)
- [ ] `bundle exec try --agent try/unit/utils/` — 164/164 pass
- [ ] `bundle exec try --agent try/unit/billing/email_hash_try.rb` — EmailHash works independently
- [ ] Verify only 2 production copies of raw pattern remain: `grep -r 'unicode_normalize(:nfc).downcase(:fold)' lib/ apps/` → `strings.rb` + `email_hash.rb`
- [ ] Verify divergent normalizers removed: `grep -r '\.strip\.downcase' apps/web/auth/operations/ apps/api/invite/` → 0 hits