### PR TITLE
Grant admin role full menu visibility on custom domains

### DIFF
--- a/src/shared/components/navigation/UserMenu.vue
+++ b/src/shared/components/navigation/UserMenu.vue
@@ -67,9 +67,9 @@ const userRole = computed(() =>
   organizationStore.currentOrganization?.current_user_role || null
 );
 
-// Only restrict when we have a confirmed non-owner role
-// If org hasn't loaded yet (null role), show full menu to avoid blocking navigation
-const isCustomDomainNonOwner = computed(() => isCustom && !!userRole.value && userRole.value !== 'owner');
+// Only restrict members on custom domains — admins see the full menu like owners.
+// If org hasn't loaded yet (null role), show full menu to avoid blocking navigation.
+const isCustomDomainMember = computed(() => isCustom && !!userRole.value && userRole.value === 'member');
 
 const isOpen = ref(false);
 const menuRef = ref<HTMLElement | null>(null);
@@ -104,25 +104,25 @@ const menuItems = computed<MenuItem[]>(() => [
     variant: 'caution' as const, condition: () => props.awaitingMfa },
   { id: 'dashboard', to: '/dashboard', label: t('web.TITLES.dashboard'),
     icon: { collection: 'heroicons', name: 'shield-check-solid' },
-    condition: () => !props.awaitingMfa && !isCustomDomainNonOwner.value },
+    condition: () => !props.awaitingMfa && !isCustomDomainMember.value },
   { id: 'recent', to: '/recent', label: t('web.TITLES.recent'),
     icon: { collection: 'heroicons', name: 'clock' },
-    condition: () => !props.awaitingMfa && !isCustomDomainNonOwner.value },
+    condition: () => !props.awaitingMfa && !isCustomDomainMember.value },
   { id: 'billing', to: '/billing', label: t('web.navigation.billing'),
     icon: { collection: 'heroicons', name: 'credit-card' },
-    condition: () => !props.awaitingMfa && !!billing_enabled.value && !isCustomDomainNonOwner.value },
+    condition: () => !props.awaitingMfa && !!billing_enabled.value && !isCustomDomainMember.value },
   { id: 'account', to: '/account', label: t('web.TITLES.account'),
     icon: { collection: 'heroicons', name: 'cog-6-tooth-solid' },
     condition: () => !props.awaitingMfa },
   { id: 'colonel', to: '/colonel', label: t('web.colonel.admin'),
     icon: { collection: 'mdi', name: 'star' },
-    condition: () => !props.awaitingMfa && props.colonel && !isCustomDomainNonOwner.value },
+    condition: () => !props.awaitingMfa && props.colonel && !isCustomDomainMember.value },
   {
     id: 'test-plan',
     label: t('web.colonel.testPlanMode'),
     icon: { collection: 'heroicons', name: 'beaker' },
     variant: isTestModeActive.value ? 'caution' : 'default',
-    condition: () => !props.awaitingMfa && props.colonel && !isCustomDomainNonOwner.value,
+    condition: () => !props.awaitingMfa && props.colonel && !isCustomDomainMember.value,
     onClick: openPlanTestModal,
   },
   {
@@ -137,7 +137,7 @@ const menuItems = computed<MenuItem[]>(() => [
     to: '/feedback',
     label: t('web.TITLES.feedback'),
     icon: { collection: 'heroicons', name: 'chat-bubble-bottom-center-text' },
-    condition: () => !props.awaitingMfa && !isCustomDomainNonOwner.value,
+    condition: () => !props.awaitingMfa && !isCustomDomainMember.value,
   },
   {
     id: 'logout',

--- a/src/tests/shared/components/navigation/UserMenu.spec.ts
+++ b/src/tests/shared/components/navigation/UserMenu.spec.ts
@@ -620,18 +620,19 @@ describe('UserMenu', () => {
         };
       });
 
-      it('should see only account, help, and logout', async () => {
-        wrapper = mountComponent();
-        const menuTexts = await getVisibleMenuItemTexts();
-
-        expectMenuContains(menuTexts, ['account', 'help', 'logout']);
-      });
-
-      it('should NOT see dashboard, recent, billing, colonel, or feedback', async () => {
+      it('should see full menu (same as owner on custom domain)', async () => {
         wrapper = mountComponent({ colonel: true }, { billing_enabled: true });
         const menuTexts = await getVisibleMenuItemTexts();
 
-        expectMenuNotContains(menuTexts, ['dashboard', 'recent', 'billing', 'colonel', 'feedback']);
+        // Admin sees all items, same as owner
+        expectMenuContains(menuTexts, ['dashboard', 'recent', 'billing', 'account', 'colonel', 'help', 'feedback', 'logout']);
+      });
+
+      it('should see test plan mode when colonel', async () => {
+        wrapper = mountComponent({ colonel: true });
+        const menuTexts = await getVisibleMenuItemTexts();
+
+        expectMenuContains(menuTexts, ['test plan']);
       });
     });
 


### PR DESCRIPTION
## Summary

Followup to #2889. The role gate in `UserMenu.vue` used `role !== 'owner'` to restrict menu items on custom domains, which collapsed admin down to member-level visibility. Since admin conventionally sits between owner and member in privilege, it should see the expanded menu.

- Renamed `isCustomDomainNonOwner` → `isCustomDomainMember` and changed gate from `!== 'owner'` to `=== 'member'`
- Updated tests so admin expects full menu (dashboard, recent, billing, colonel, feedback) matching owner

No behavioral change for members (still restricted) or canonical site users.

## Test plan

- [x] All 36 UserMenu tests pass
- [x] Admin on custom domain sees full menu (new assertion)
- [x] Admin sees test plan mode when colonel (new test)
- [x] Member on custom domain still sees minimal set
- [x] Owner unchanged, canonical site unchanged
- [x] Null org edge case: fail-open preserved
- [x] MFA precedence over role restrictions preserved

Closes https://github.com/onetimesecret/onetimesecret/issues/2889#issuecomment-4196943068