### PR TITLE
Add logtide-ship log shipping tool and hivemind runner support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,7 @@ tsconfig.tsbuildinfo
 *.db
 !locales/db/*.sql
 !routes.txt
+!scripts/requirements-*.txt
 .overmind.sock
 Procfile.*
 !Procfile*.example

--- a/bin/dev
+++ b/bin/dev
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# bin/dev - Overmind Development Runner
+# bin/dev - Development Process Runner (overmind or hivemind)
 #
 # USAGE:
 #   $ bin/dev                       # Start with Procfile.dev
@@ -30,8 +30,14 @@
 #   Usage: Essential for 'binding.pry', 'debugger', or surgical restarts.
 # -----------------------------------------------------------------------------
 
-if ! command -v overmind >/dev/null 2>&1; then
-  echo "Error: Overmind not found. Install from https://github.com/DarthSim/overmind"
+if command -v overmind >/dev/null 2>&1; then
+  RUNNER="overmind"
+elif command -v hivemind >/dev/null 2>&1; then
+  RUNNER="hivemind"
+else
+  echo "Error: Neither overmind nor hivemind found."
+  echo "  Install overmind: https://github.com/DarthSim/overmind"
+  echo "  Install hivemind: https://github.com/DarthSim/hivemind"
   exit 1
 fi
 
@@ -77,4 +83,8 @@ fi
 # --port flag takes precedence over PORT env var, then falls back to 7143
 PORT="${PORT_OVERRIDE:-${PORT:-7143}}"
 
-exec env PORT="$PORT" overmind start -f "$PROCFILE" "${ARGS[@]}"
+if [[ "$RUNNER" == "overmind" ]]; then
+  exec env PORT="$PORT" overmind start -f "$PROCFILE" "${ARGS[@]}"
+else
+  exec env PORT="$PORT" hivemind "$PROCFILE" "${ARGS[@]}"
+fi

--- a/scripts/logtide-ship.py
+++ b/scripts/logtide-ship.py
@@ -110,7 +110,7 @@ def _mask_key(key: str) -> str:
     return f"{key[:4]}***{key[-3:]}"
 
 
-def _preflight(service: str, mode: LogMode) -> None:
+def _preflight(command: str, service: str, mode: LogMode) -> None:
     """Print startup banner and verify LogTide connectivity and auth.
 
     Sends an empty batch to the ingest endpoint. Exits on auth failure
@@ -118,8 +118,8 @@ def _preflight(service: str, mode: LogMode) -> None:
     connection errors but continues (server may come up later).
     """
     print(
-        f"[logtide-ship] url={LOGTIDE_URL} key={_mask_key(LOGTIDE_API_KEY)}"
-        f" mode={mode} service={service}",
+        f"[logtide-ship {command}] service={service} mode={mode}"
+        f" url={LOGTIDE_URL} key={_mask_key(LOGTIDE_API_KEY)}",
         file=sys.stderr,
     )
 
@@ -253,7 +253,7 @@ def _build_entry_json(raw: dict, service: str) -> dict:
     return {
         "time": raw.get("timestamp", _now()),     # SemanticLogger: ISO 8601
         "service": service,
-        "hostname": raw.get("host", ""),           # SemanticLogger: machine hostname
+        "hostname": raw.get("host", _HOSTNAME),    # SemanticLogger host, or machine fallback
         "level": raw.get("level", "info"),
         "message": json.dumps(raw),                # full JSON for pipeline parsing
     }
@@ -419,7 +419,7 @@ def _build_entry_metadata(raw: dict, service: str) -> dict:
     entry = {
         "time": raw.get("timestamp", _now()),
         "service": service,
-        "hostname": raw.get("host", ""),
+        "hostname": raw.get("host", _HOSTNAME),
         "level": raw.get("level", "info"),
         "message": raw.get("message", ""),
     }
@@ -434,6 +434,7 @@ def _build_entry_text(line: str, service: str) -> dict:
     return {
         "time": _now(),
         "service": service,
+        "hostname": _HOSTNAME,
         "level": detect_level(line),
         "message": line,
     }
@@ -523,7 +524,7 @@ def follow(service: str, *, opts: Global = Global()):
     service
         Service name attached to each log entry (e.g. "backend", "caddy-proxy").
     """
-    _preflight(service, opts.mode)
+    _preflight("follow", service, opts.mode)
 
     queue: Queue = Queue()
     thread = threading.Thread(
@@ -560,7 +561,7 @@ def batch(service: str, *, opts: Global = Global()):
     service
         Service name attached to each log entry (e.g. "backend", "caddy-proxy").
     """
-    _preflight(service, opts.mode)
+    _preflight("batch", service, opts.mode)
 
     lines = sys.stdin.read().splitlines()   # blocks until EOF
 

--- a/scripts/logtide-ship.py
+++ b/scripts/logtide-ship.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-
 # scripts/logtide-ship.py
 
 """logtide-ship - pipe stdin to LogTide
@@ -8,7 +7,7 @@ Reads log lines from stdin and ships them to a LogTide instance via the
 HTTP ingest API (/api/v1/ingest). Supports two subcommands:
 
     follow  - read stdin continuously, ship in batches (for long-running pipes)
-    batch   - read all of stdin, ship as a single batch (for one-shot imports)
+    batch   - read stdin to EOF, ship in batches (for one-shot imports)
 
 Four modes control how JSON log lines are handled:
 
@@ -275,8 +274,15 @@ _HOSTNAME = socket.gethostname()
 # Caddy duration parsing.  With `duration_format string` in the Caddyfile,
 # durations are Go time.Duration strings ("7.750ms", "250µs", "1.5s").
 # With the default `duration_format number`, they're float seconds.
-_GO_DURATION_RE = re.compile(r"^([\d.]+)(µs|us|ms|s)$")
-_DURATION_MULTIPLIERS = {"s": 1000, "ms": 1, "us": 0.001, "µs": 0.001}
+_GO_DURATION_RE = re.compile(r"^([\d.]+)(µs|us|ms|s|m|h)$")
+_DURATION_MULTIPLIERS = {
+    "h": 3600000,
+    "m": 60000,
+    "s": 1000,
+    "ms": 1,
+    "us": 0.001,
+    "µs": 0.001,
+}
 
 
 def _parse_caddy_ts(ts: int | float) -> str:
@@ -443,31 +449,56 @@ def _build_entry_text(line: str, service: str) -> dict:
 # -- HTTP transport ------------------------------------------------------
 
 
+_SEND_RETRIES = 2
+_SEND_BACKOFF = 0.5  # seconds, doubled each retry
+
+
+def _is_retryable(exc: Exception) -> bool:
+    """True for transient failures worth retrying (connection errors, 5xx)."""
+    if isinstance(exc, (httpx.ConnectError, httpx.ReadTimeout, httpx.WriteTimeout)):
+        return True
+    if isinstance(exc, httpx.HTTPStatusError) and exc.response.status_code >= 500:
+        return True
+    return False
+
+
 def _send_batch(client: httpx.Client, batch: list[dict]) -> None:
     """POST a batch of log entries to the LogTide ingest API.
 
-    Errors are logged to stderr rather than raised, so a transient LogTide
-    outage doesn't kill the pipeline — lines continue to be read from stdin.
+    Retries up to _SEND_RETRIES times on transient failures (connection
+    errors, 5xx). Non-retryable errors are logged and swallowed so a
+    LogTide outage doesn't kill the pipeline.
     """
-    try:
-        resp = client.post(
-            LOGTIDE_URL,
-            json={"logs": batch},
-            headers={"X-API-Key": LOGTIDE_API_KEY},
-            timeout=10,
-        )
-        if resp.status_code != 200:
-            # Include the first entry for context — helps identify which
-            # service/mode is producing entries the server rejects.
-            print(
-                f"[logtide-ship] {resp.status_code}: {resp.text}"
-                f" (batch_size={len(batch)},"
-                f" first={batch[0] if batch else 'empty'})",
-                file=sys.stderr,
+    delay = _SEND_BACKOFF
+    for attempt in range(_SEND_RETRIES + 1):
+        try:
+            resp = client.post(
+                LOGTIDE_URL,
+                json={"logs": batch},
+                headers={"X-API-Key": LOGTIDE_API_KEY},
+                timeout=10,
             )
-        resp.raise_for_status()
-    except httpx.HTTPError as e:
-        print(f"[logtide-ship] send failed: {e}", file=sys.stderr)
+            if resp.status_code != 200:
+                print(
+                    f"[logtide-ship] {resp.status_code}: {resp.text}"
+                    f" (batch_size={len(batch)},"
+                    f" first={batch[0] if batch else 'empty'})",
+                    file=sys.stderr,
+                )
+            resp.raise_for_status()
+            return
+        except httpx.HTTPError as e:
+            if _is_retryable(e) and attempt < _SEND_RETRIES:
+                print(
+                    f"[logtide-ship] transient error (attempt {attempt + 1}/"
+                    f"{_SEND_RETRIES + 1}): {e} — retrying in {delay}s",
+                    file=sys.stderr,
+                )
+                time.sleep(delay)
+                delay *= 2
+                continue
+            print(f"[logtide-ship] send failed: {e}", file=sys.stderr)
+            return
 
 
 def _shipper(queue: Queue, service: str, mode: LogMode):
@@ -526,7 +557,7 @@ def follow(service: str, *, opts: Global = Global()):
     """
     _preflight("follow", service, opts.mode)
 
-    queue: Queue = Queue()
+    queue: Queue = Queue(maxsize=10_000)
     thread = threading.Thread(
         target=_shipper, args=(queue, service, opts.mode), daemon=True
     )
@@ -550,11 +581,12 @@ def follow(service: str, *, opts: Global = Global()):
 
 @app.command
 def batch(service: str, *, opts: Global = Global()):
-    """Read all of stdin then ship to LogTide as a single batch.
+    """Read stdin to EOF and ship to LogTide in batches.
 
     Use for one-shot imports (``cat logfile | logtide-ship batch ...``).
-    Reads stdin to EOF before shipping, so do NOT use with ``tail -f``
-    or other never-ending streams — use ``follow`` for those.
+    Reads synchronously (no background thread) and ships each batch as
+    it fills, so memory stays bounded. Do NOT use with ``tail -f`` or
+    other never-ending streams — use ``follow`` for those.
 
     Parameters
     ----------
@@ -563,21 +595,23 @@ def batch(service: str, *, opts: Global = Global()):
     """
     _preflight("batch", service, opts.mode)
 
-    lines = sys.stdin.read().splitlines()   # blocks until EOF
-
-    if opts.verbose:
-        for line in lines:
-            sys.stdout.write(line + "\n")
-        sys.stdout.flush()
-
-    batch = [_build_entry(line, service, opts.mode) for line in lines if line]
-
-    if not batch:
-        return
+    entries: list[dict] = []
 
     with httpx.Client() as client:
-        for i in range(0, len(batch), BATCH_SIZE):
-            _send_batch(client, batch[i : i + BATCH_SIZE])
+        for line in sys.stdin:
+            line = line.rstrip("\n")
+            if opts.verbose:
+                sys.stdout.write(line + "\n")
+                sys.stdout.flush()
+            if not line:
+                continue
+            entries.append(_build_entry(line, service, opts.mode))
+            if len(entries) >= BATCH_SIZE:
+                _send_batch(client, entries)
+                entries = []
+
+        if entries:
+            _send_batch(client, entries)
 
 
 if __name__ == "__main__":

--- a/scripts/logtide-ship.py
+++ b/scripts/logtide-ship.py
@@ -7,11 +7,10 @@
 Reads log lines from stdin and ships them to a LogTide instance via the
 HTTP ingest API (/api/v1/ingest). Supports two subcommands:
 
-    stream  - read stdin continuously, ship in batches (for long-running pipes)
-    ingest  - read all of stdin, ship as a single batch (for one-shot imports)
+    follow  - read stdin continuously, ship in batches (for long-running pipes)
+    batch   - read all of stdin, ship as a single batch (for one-shot imports)
 
-Three modes control how JSON log lines (e.g. from SemanticLogger with
-LOG_FORMATTER=json) are handled:
+Four modes control how JSON log lines are handled:
 
     plain    - All input treated as text. ANSI codes stripped, log level
                guessed from message content. No JSON parsing. This is the
@@ -28,22 +27,33 @@ LOG_FORMATTER=json) are handled:
                the LogTide `message`, allowing a LogTide pipeline with a JSON
                parser step to extract and index all fields server-side.
 
+    caddy    - Caddy structured JSON access logs are parsed. Timestamps
+               (Unix epoch floats) are converted to ISO 8601. A readable
+               message is built from method, URI, status, size, and duration.
+               Request details (remote_ip, proto, TLS, user_agent) go into
+               LogTide `metadata`. Machine hostname is used since Caddy
+               doesn't include it in log output.
+
 Plain text lines always use the text path regardless of mode.
 
 Usage:
-    # Stream from a process manager (default --mode json)
-    LOG_FORMATTER=json bin/backend | python3 scripts/logtide-ship.py stream backend
+    # Follow a process manager (default --mode json)
+    LOG_FORMATTER=json bin/backend | python3 scripts/logtide-ship.py follow backend
 
-    # Ship existing log file with text-mode fallback
-    cat /var/log/app.log | python3 scripts/logtide-ship.py ingest backend --mode plain
+    # Batch-ship an existing log file with text-mode fallback
+    cat /var/log/app.log | python3 scripts/logtide-ship.py batch backend --mode plain
 
     # Use metadata mode for structured fields without pipeline parsing
-    LOG_FORMATTER=json bin/backend | python3 scripts/logtide-ship.py stream backend --mode metadata
+    LOG_FORMATTER=json bin/backend | python3 scripts/logtide-ship.py follow backend --mode metadata
+
+    # Follow Caddy access logs
+    tail -f /var/log/caddy/access.log | python3 scripts/logtide-ship.py follow caddy-proxy --mode caddy
 """
 
 import json
 import os
 import re
+import socket
 import sys
 import threading
 import time
@@ -55,7 +65,13 @@ from typing import Literal
 import httpx
 from cyclopts import App, Parameter
 
-# LogTide ingest endpoint and credentials (env vars take precedence)
+# -- Configuration -------------------------------------------------------
+#
+# LOGTIDE_URL     Full URL to the LogTide ingest endpoint.  The /api/v1/ingest
+#                 path accepts POST {"logs": [...]}.  Override via env var to
+#                 point at a remote instance.
+# LOGTIDE_API_KEY Passed as X-API-Key header.  The default "CHANGEME" is
+#                 intentionally invalid — preflight will catch it and exit.
 LOGTIDE_URL = os.environ.get("LOGTIDE_URL", "http://127.0.0.1:8080/api/v1/ingest")
 LOGTIDE_API_KEY = os.environ.get("LOGTIDE_API_KEY", "CHANGEME")
 
@@ -68,7 +84,7 @@ FLUSH_INTERVAL = 2.0
 app = App(name="logtide-ship", help="Ship logs to LogTide.")
 
 
-LogMode = Literal["plain", "metadata", "json"]
+LogMode = Literal["plain", "metadata", "json", "caddy"]
 
 
 @Parameter(name="*")
@@ -83,7 +99,77 @@ class Global:
     plain    -- treat all input as text (original behavior)
     metadata -- parse JSON, extract structured fields into metadata
     json     -- parse JSON, send full JSON as message for LogTide pipeline parsing
+    caddy    -- parse Caddy structured JSON access logs
     """
+
+
+def _mask_key(key: str) -> str:
+    """Mask API key for display, showing first 4 and last 3 characters."""
+    if len(key) <= 8:
+        return "***"
+    return f"{key[:4]}***{key[-3:]}"
+
+
+def _preflight(service: str, mode: LogMode) -> None:
+    """Print startup banner and verify LogTide connectivity and auth.
+
+    Sends an empty batch to the ingest endpoint. Exits on auth failure
+    (no point reading stdin if every batch will be rejected). Warns on
+    connection errors but continues (server may come up later).
+    """
+    print(
+        f"[logtide-ship] url={LOGTIDE_URL} key={_mask_key(LOGTIDE_API_KEY)}"
+        f" mode={mode} service={service}",
+        file=sys.stderr,
+    )
+
+    if LOGTIDE_API_KEY == "CHANGEME":
+        print(
+            "[logtide-ship] WARNING: using default API key 'CHANGEME'"
+            " — set LOGTIDE_API_KEY",
+            file=sys.stderr,
+        )
+
+    # Probe with an empty batch.  We only care about the status code:
+    #   200/400 → connected and authed (400 = server dislikes empty logs, fine)
+    #   401/403 → bad key, no point reading stdin — exit immediately
+    #   5xx     → server-side issue, warn but continue (may recover)
+    #   ConnectError → server unreachable, warn but continue (may start later)
+    try:
+        with httpx.Client() as client:
+            resp = client.post(
+                LOGTIDE_URL,
+                json={"logs": []},
+                headers={"X-API-Key": LOGTIDE_API_KEY},
+                timeout=5,
+            )
+        if resp.status_code in (401, 403):
+            print(
+                f"[logtide-ship] FATAL: authentication failed"
+                f" ({resp.status_code}). Check LOGTIDE_API_KEY.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        if resp.status_code >= 500:
+            print(
+                f"[logtide-ship] WARNING: server returned {resp.status_code}"
+                " — will retry with real batches",
+                file=sys.stderr,
+            )
+        else:
+            print("[logtide-ship] preflight OK", file=sys.stderr)
+    except httpx.ConnectError:
+        print(
+            f"[logtide-ship] WARNING: cannot reach {LOGTIDE_URL}"
+            " — will retry when batches are ready",
+            file=sys.stderr,
+        )
+    except httpx.HTTPError as e:
+        print(
+            f"[logtide-ship] WARNING: preflight failed: {e}"
+            " — continuing anyway",
+            file=sys.stderr,
+        )
 
 
 def detect_level(msg: str) -> str:
@@ -130,35 +216,192 @@ def _try_parse_json(line: str) -> dict | None:
         return None
 
 
-def _build_entry(line: str, service: str, mode: LogMode = "json") -> dict:
-    """Dispatch to the appropriate entry builder based on mode.
+# -- Entry builders ------------------------------------------------------
+#
+# Each mode has its own builder that maps source-specific fields to the
+# LogTide ingest schema:
+#
+#   { time, service, hostname, level, message, metadata? }
+#
+# _build_entry() dispatches based on mode.  Non-JSON lines always fall
+# through to the text path, so mixed-format streams (e.g. startup banners
+# interspersed with JSON) are handled gracefully.
 
-    For non-plain modes, attempts JSON parsing first. Falls through to
-    the text path if the line isn't valid JSON (e.g. plain text output,
-    startup banners, non-SemanticLogger lines mixed into the stream).
-    """
+
+def _build_entry(line: str, service: str, mode: LogMode = "json") -> dict:
+    """Dispatch to the appropriate entry builder based on mode."""
     if mode != "plain":
         raw = _try_parse_json(line)
         if raw:
+            if mode == "caddy":
+                return _build_entry_caddy(raw, service)
             if mode == "metadata":
                 return _build_entry_metadata(raw, service)
+            # mode == "json": send raw JSON as the message body
             return _build_entry_json(raw, service)
     return _build_entry_text(line, service)
 
 
 def _build_entry_json(raw: dict, service: str) -> dict:
-    """Send full JSON as message for LogTide pipeline parsing."""
+    """Send full JSON as message for LogTide pipeline parsing.
+
+    The entire raw JSON object is re-serialized into ``message`` so that
+    a LogTide pipeline step (e.g. a JSON parser) can extract and index
+    every field server-side.  Top-level ``timestamp``, ``host``, and
+    ``level`` are pulled out for LogTide's native fields.
+    """
     return {
-        "time": raw.get("timestamp", _now()),
+        "time": raw.get("timestamp", _now()),     # SemanticLogger: ISO 8601
         "service": service,
-        "hostname": raw.get("host", ""),
+        "hostname": raw.get("host", ""),           # SemanticLogger: machine hostname
         "level": raw.get("level", "info"),
-        "message": json.dumps(raw),
+        "message": json.dumps(raw),                # full JSON for pipeline parsing
     }
 
 
+def _fmt_bytes(n: int) -> str:
+    """Format byte count for log messages."""
+    if n < 1024:
+        return f"{n}B"
+    if n < 1024 * 1024:
+        return f"{n / 1024:.1f}kB"
+    return f"{n / (1024 * 1024):.1f}MB"
+
+
+# Caddy doesn't include machine hostname in its JSON output (request.host
+# is the HTTP Host header), so we resolve it once at import time.
+_HOSTNAME = socket.gethostname()
+
+# Caddy duration parsing.  With `duration_format string` in the Caddyfile,
+# durations are Go time.Duration strings ("7.750ms", "250µs", "1.5s").
+# With the default `duration_format number`, they're float seconds.
+_GO_DURATION_RE = re.compile(r"^([\d.]+)(µs|us|ms|s)$")
+_DURATION_MULTIPLIERS = {"s": 1000, "ms": 1, "us": 0.001, "µs": 0.001}
+
+
+def _parse_caddy_ts(ts: int | float) -> str:
+    """Convert Caddy timestamp to ISO 8601.
+
+    Handles both ``unix_seconds_float`` (default) and
+    ``unix_milli_float`` (common in production configs).
+    Values above 1e12 are treated as milliseconds.
+    """
+    if ts > 1e12:
+        ts = ts / 1000
+    return (
+        datetime.fromtimestamp(ts, tz=timezone.utc)
+        .strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3]
+        + "Z"
+    )
+
+
+def _parse_caddy_duration_ms(val: str | int | float) -> float:
+    """Parse Caddy duration to milliseconds.
+
+    Handles float seconds (``duration_format number``) and Go duration
+    strings like ``7.750292ms`` (``duration_format string``).
+    """
+    if isinstance(val, (int, float)):
+        return round(val * 1000, 2)
+    if isinstance(val, str):
+        m = _GO_DURATION_RE.match(val)
+        if m:
+            return round(float(m.group(1)) * _DURATION_MULTIPLIERS[m.group(2)], 2)
+    return 0
+
+
+def _build_entry_caddy(raw: dict, service: str) -> dict:
+    """Build entry from Caddy structured JSON access log.
+
+    Caddy logs use Unix epoch floats for timestamps and nest request
+    details under a ``request`` key. This builder extracts a readable
+    message (method, URI, status, size, duration) and populates metadata
+    with the structured fields LogTide can query.
+
+    Handles both default Caddy config and common overrides:
+    - ``time_format``: ``unix_seconds_float`` (default) or ``unix_milli_float``
+    - ``duration_format``: ``number`` (float seconds) or ``string`` (Go duration)
+    """
+    # -- Timestamp -----------------------------------------------------------
+    # Caddy's `ts` field format depends on the Caddyfile `time_format`:
+    #   unix_seconds_float (default) → 1646861401.524  (seconds)
+    #   unix_milli_float             → 1775975893020.3 (milliseconds)
+    # _parse_caddy_ts auto-detects based on magnitude (> 1e12 = millis).
+    ts = raw.get("ts")
+    if isinstance(ts, (int, float)):
+        time_str = _parse_caddy_ts(ts)
+    else:
+        time_str = _now()
+
+    # -- Human-readable message ----------------------------------------------
+    # Condenses the request into a single line:  "GET /api/users 200 13.8kB 74.01ms"
+    req = raw.get("request", {})
+    method = req.get("method", "")
+    uri = req.get("uri", "")
+    status = raw.get("status", 0)
+    size = raw.get("size", 0)             # response body bytes
+    duration_ms = _parse_caddy_duration_ms(raw.get("duration", 0))
+
+    message = f"{method} {uri} {status} {_fmt_bytes(size)} {duration_ms}ms"
+
+    # -- Metadata ------------------------------------------------------------
+    # Structured fields that LogTide can query/filter on.  Only included
+    # when present to keep payloads lean.
+    metadata: dict = {}
+    if req.get("remote_ip"):
+        metadata["remote_ip"] = req["remote_ip"]
+    # client_ip differs from remote_ip when behind a proxy (X-Forwarded-For)
+    if req.get("client_ip") and req["client_ip"] != req.get("remote_ip"):
+        metadata["client_ip"] = req["client_ip"]
+    if status:
+        metadata["status"] = status
+    if size:
+        metadata["size"] = size
+    if duration_ms:
+        metadata["duration_ms"] = duration_ms
+    if req.get("host"):
+        metadata["host"] = req["host"]    # HTTP Host header, not machine hostname
+    if req.get("proto"):
+        metadata["proto"] = req["proto"]  # e.g. "HTTP/2.0", "HTTP/3.0"
+    if raw.get("logger"):
+        metadata["logger"] = raw["logger"]  # e.g. "http.log.access.log0"
+
+    # TLS negotiated protocol (h2, h3, http/1.1)
+    tls = req.get("tls")
+    if isinstance(tls, dict) and tls.get("proto"):
+        metadata["tls_proto"] = tls["proto"]
+
+    # Caddy stores header values as arrays (HTTP allows repeated headers)
+    headers = req.get("headers", {})
+    ua = headers.get("User-Agent")
+    if isinstance(ua, list) and ua:
+        metadata["user_agent"] = ua[0]
+
+    entry = {
+        "time": time_str,
+        "service": service,
+        "hostname": _HOSTNAME,            # machine hostname (not in Caddy output)
+        "level": raw.get("level", "info"),
+        "message": message,
+    }
+    if metadata:
+        entry["metadata"] = metadata
+    return entry
+
+
 def _build_entry_metadata(raw: dict, service: str) -> dict:
-    """Extract structured fields into metadata dict."""
+    """Extract structured fields into metadata dict.
+
+    SemanticLogger JSON fields → LogTide mapping:
+      timestamp → time     (ISO 8601)
+      host      → hostname (machine hostname)
+      level     → level    (info/warn/error/debug/critical)
+      message   → message  (human-readable text)
+      name      → metadata.logger   (Ruby class/module name)
+      pid       → metadata.pid
+      thread    → metadata.thread
+      payload   → metadata.*        (app-specific key/value pairs, merged in)
+    """
     metadata = {
         k: v
         for k, v in {
@@ -168,6 +411,7 @@ def _build_entry_metadata(raw: dict, service: str) -> dict:
         }.items()
         if v is not None
     }
+    # SemanticLogger's payload is an arbitrary dict of app-specific data
     payload = raw.get("payload")
     if isinstance(payload, dict):
         metadata.update(payload)
@@ -195,6 +439,9 @@ def _build_entry_text(line: str, service: str) -> dict:
     }
 
 
+# -- HTTP transport ------------------------------------------------------
+
+
 def _send_batch(client: httpx.Client, batch: list[dict]) -> None:
     """POST a batch of log entries to the LogTide ingest API.
 
@@ -209,8 +456,12 @@ def _send_batch(client: httpx.Client, batch: list[dict]) -> None:
             timeout=10,
         )
         if resp.status_code != 200:
+            # Include the first entry for context — helps identify which
+            # service/mode is producing entries the server rejects.
             print(
-                f"[logtide-ship] {resp.status_code}: {resp.text} (batch_size={len(batch)}, first={batch[0] if batch else 'empty'})",
+                f"[logtide-ship] {resp.status_code}: {resp.text}"
+                f" (batch_size={len(batch)},"
+                f" first={batch[0] if batch else 'empty'})",
                 file=sys.stderr,
             )
         resp.raise_for_status()
@@ -221,9 +472,12 @@ def _send_batch(client: httpx.Client, batch: list[dict]) -> None:
 def _shipper(queue: Queue, service: str, mode: LogMode):
     """Background thread that drains the queue and ships batches to LogTide.
 
-    Runs in a loop reading lines from the queue, building entries, and
-    flushing when the batch is full or the flush interval elapses. Sending
-    None into the queue signals shutdown; any remaining entries are flushed
+    Runs in a daemon thread started by the ``follow`` command.  The main
+    thread reads stdin and pushes raw lines into the queue; this thread
+    builds LogTide entries and flushes them in batches.
+
+    Shutdown protocol: the main thread pushes ``None`` into the queue
+    (on EOF or KeyboardInterrupt).  Any remaining entries are flushed
     before the thread exits.
     """
     batch: list[dict] = []
@@ -233,12 +487,13 @@ def _shipper(queue: Queue, service: str, mode: LogMode):
         while True:
             try:
                 line = queue.get(timeout=0.5)
-                if line is None:
+                if line is None:        # shutdown sentinel
                     break
                 batch.append(_build_entry(line, service, mode))
             except Empty:
-                pass
+                pass                    # no new lines — check flush timer
 
+            # Flush on batch-full or time-elapsed, whichever comes first
             now = time.monotonic()
             if len(batch) >= BATCH_SIZE or (
                 batch and now - last_flush > FLUSH_INTERVAL
@@ -247,19 +502,29 @@ def _shipper(queue: Queue, service: str, mode: LogMode):
                 batch = []
                 last_flush = now
 
+        # Drain remainder after shutdown sentinel
         if batch:
             _send_batch(client, batch)
 
 
+# -- Subcommands ---------------------------------------------------------
+
+
 @app.command
-def stream(service: str, *, opts: Global = Global()):
+def follow(service: str, *, opts: Global = Global()):
     """Read stdin continuously and ship lines to LogTide in batches.
+
+    Use with long-running pipes (process managers, ``tail -f``).
+    Lines are queued and shipped by a background thread so stdin is
+    never blocked by HTTP latency.
 
     Parameters
     ----------
     service
-        Service name attached to each log entry.
+        Service name attached to each log entry (e.g. "backend", "caddy-proxy").
     """
+    _preflight(service, opts.mode)
+
     queue: Queue = Queue()
     thread = threading.Thread(
         target=_shipper, args=(queue, service, opts.mode), daemon=True
@@ -278,20 +543,26 @@ def stream(service: str, *, opts: Global = Global()):
     except KeyboardInterrupt:
         pass
     finally:
-        queue.put(None)
+        queue.put(None)             # signal shipper to flush and exit
         thread.join(timeout=5)
 
 
 @app.command
-def ingest(service: str, *, opts: Global = Global()):
+def batch(service: str, *, opts: Global = Global()):
     """Read all of stdin then ship to LogTide as a single batch.
+
+    Use for one-shot imports (``cat logfile | logtide-ship batch ...``).
+    Reads stdin to EOF before shipping, so do NOT use with ``tail -f``
+    or other never-ending streams — use ``follow`` for those.
 
     Parameters
     ----------
     service
-        Service name attached to each log entry.
+        Service name attached to each log entry (e.g. "backend", "caddy-proxy").
     """
-    lines = sys.stdin.read().splitlines()
+    _preflight(service, opts.mode)
+
+    lines = sys.stdin.read().splitlines()   # blocks until EOF
 
     if opts.verbose:
         for line in lines:
@@ -304,7 +575,6 @@ def ingest(service: str, *, opts: Global = Global()):
         return
 
     with httpx.Client() as client:
-        # Ship in chunks of BATCH_SIZE
         for i in range(0, len(batch), BATCH_SIZE):
             _send_batch(client, batch[i : i + BATCH_SIZE])
 

--- a/scripts/logtide-ship.py
+++ b/scripts/logtide-ship.py
@@ -47,7 +47,7 @@ _ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
 def _build_entry(line: str, service: str) -> dict:
     line = _ANSI_RE.sub("", line)
     return {
-        "time": datetime.now(timezone.utc).isoformat(),
+        "time": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z",
         "service": service,
         "level": detect_level(line),
         "message": line,
@@ -56,12 +56,15 @@ def _build_entry(line: str, service: str) -> dict:
 
 def _send_batch(client: httpx.Client, batch: list[dict]) -> None:
     try:
-        client.post(
+        resp = client.post(
             LOGTIDE_URL,
             json={"logs": batch},
             headers={"X-API-Key": API_KEY},
             timeout=10,
-        ).raise_for_status()
+        )
+        if resp.status_code != 200:
+            print(f"[logtide-ship] {resp.status_code}: {resp.text} (batch_size={len(batch)}, first={batch[0] if batch else 'empty'})", file=sys.stderr)
+        resp.raise_for_status()
     except httpx.HTTPError as e:
         print(f"[logtide-ship] send failed: {e}", file=sys.stderr)
 
@@ -113,6 +116,8 @@ def stream(service: str, *, opts: Global = Global()):
             if opts.verbose:
                 sys.stdout.write(line + "\n")
                 sys.stdout.flush()
+            if not line:
+                continue
             queue.put(line)
     except KeyboardInterrupt:
         pass
@@ -137,7 +142,7 @@ def ingest(service: str, *, opts: Global = Global()):
             sys.stdout.write(line + "\n")
         sys.stdout.flush()
 
-    batch = [_build_entry(line, service) for line in lines]
+    batch = [_build_entry(line, service) for line in lines if line]
 
     if not batch:
         return

--- a/scripts/logtide-ship.py
+++ b/scripts/logtide-ship.py
@@ -1,7 +1,10 @@
 #!/usr/bin/env python3
 
+# scripts/logtide-ship.py
+
 """logtide-ship - pipe stdin to LogTide"""
 
+import json
 import re
 import sys
 import threading
@@ -44,10 +47,58 @@ def detect_level(msg: str) -> str:
 _ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
 
 
+def _now() -> str:
+    return (
+        datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"
+    )
+
+
+def _try_parse_json(line: str) -> dict | None:
+    if not line.startswith("{"):
+        return None
+    try:
+        return json.loads(line)
+    except json.JSONDecodeError:
+        return None
+
+
 def _build_entry(line: str, service: str) -> dict:
+    raw = _try_parse_json(line)
+    if raw:
+        return _build_entry_from_json(raw, service)
+    return _build_entry_from_text(line, service)
+
+
+def _build_entry_from_json(raw: dict, service: str) -> dict:
+    metadata = {
+        k: v
+        for k, v in {
+            "logger": raw.get("name"),
+            "pid": raw.get("pid"),
+            "thread": raw.get("thread"),
+            "host": raw.get("host"),
+        }.items()
+        if v is not None
+    }
+    payload = raw.get("payload")
+    if isinstance(payload, dict):
+        metadata.update(payload)
+
+    entry = {
+        "time": raw.get("timestamp", _now()),
+        "service": service,
+        "level": raw.get("level", "info"),
+        "message": raw.get("message", ""),
+    }
+    if metadata:
+        entry["metadata"] = metadata
+    return entry
+
+
+def _build_entry_from_text(line: str, service: str) -> dict:
     line = _ANSI_RE.sub("", line)
     return {
-        "time": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z",
+        "time": _now(),
         "service": service,
         "level": detect_level(line),
         "message": line,
@@ -63,7 +114,10 @@ def _send_batch(client: httpx.Client, batch: list[dict]) -> None:
             timeout=10,
         )
         if resp.status_code != 200:
-            print(f"[logtide-ship] {resp.status_code}: {resp.text} (batch_size={len(batch)}, first={batch[0] if batch else 'empty'})", file=sys.stderr)
+            print(
+                f"[logtide-ship] {resp.status_code}: {resp.text} (batch_size={len(batch)}, first={batch[0] if batch else 'empty'})",
+                file=sys.stderr,
+            )
         resp.raise_for_status()
     except httpx.HTTPError as e:
         print(f"[logtide-ship] send failed: {e}", file=sys.stderr)

--- a/scripts/logtide-ship.py
+++ b/scripts/logtide-ship.py
@@ -198,13 +198,6 @@ class Global:
     """
 
 
-def _mask_key(key: str) -> str:
-    """Mask API key for display, showing first 4 and last 3 characters."""
-    if len(key) <= 8:
-        return "***"
-    return f"{key[:4]}***{key[-3:]}"
-
-
 def _preflight(command: str, service: str, mode: LogMode) -> None:
     """Print startup banner and verify LogTide connectivity and auth.
 
@@ -215,8 +208,8 @@ def _preflight(command: str, service: str, mode: LogMode) -> None:
     _validate_service(service)
     _validate_url(LOGTIDE_URL)
 
-    # Hoist masked key to a local to avoid CodeQL clear-text-logging false positive.
-    masked_key = _mask_key(LOGTIDE_API_KEY)
+    # Log boolean flags about the key rather than any derived form of it,
+    # to avoid CodeQL clear-text-logging flags on masked-secret output.
     _diag.info(
         "%s",
         _kv(
@@ -225,7 +218,8 @@ def _preflight(command: str, service: str, mode: LogMode) -> None:
             service=service,
             mode=mode,
             url=LOGTIDE_URL,
-            key=masked_key,
+            api_key_configured=LOGTIDE_API_KEY != "",
+            api_key_is_default=LOGTIDE_API_KEY == "CHANGEME",
         ),
     )
 

--- a/scripts/logtide-ship.py
+++ b/scripts/logtide-ship.py
@@ -50,6 +50,7 @@ Usage:
 """
 
 import json
+import logging
 import os
 import re
 import socket
@@ -59,10 +60,100 @@ import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from queue import Empty, Queue
-from typing import Literal
+from typing import Any, Literal
+from urllib.parse import urlparse
 
 import httpx
 from cyclopts import App, Parameter
+
+# -- Diagnostic logging --------------------------------------------------
+#
+# stdlib logging -> stderr with a logfmt-style suffix of key=value pairs.
+# Keeps diagnostics consistent (timestamp, level, subcommand context) while
+# avoiding any new deps. Payloads shipped to LogTide are unaffected.
+
+_LOG_LEVEL = os.environ.get("LOGTIDE_SHIP_LOG_LEVEL", "INFO").upper()
+
+_diag = logging.getLogger("logtide-ship")
+if not _diag.handlers:
+    _handler = logging.StreamHandler(sys.stderr)
+    _handler.setFormatter(
+        logging.Formatter("%(asctime)s %(levelname)s logtide-ship %(message)s")
+    )
+    _diag.addHandler(_handler)
+    _diag.propagate = False
+try:
+    _diag.setLevel(getattr(logging, _LOG_LEVEL, logging.INFO))
+except Exception:
+    _diag.setLevel(logging.INFO)
+
+
+# Control chars (0x00-0x1f, 0x7f) corrupt logfmt lines; escape them explicitly.
+_CTRL_ESCAPES = {"\n": "\\n", "\r": "\\r", "\t": "\\t"}
+_CTRL_RE = re.compile(r"[\x00-\x1f\x7f]")
+
+
+def _escape_ctrl(match: re.Match) -> str:
+    c = match.group(0)
+    return _CTRL_ESCAPES.get(c, f"\\x{ord(c):02x}")
+
+
+def _kv(**fields: Any) -> str:
+    """Format key=value pairs for logfmt-style diagnostic lines."""
+    parts = []
+    for k, v in fields.items():
+        if v is None:
+            continue
+        s = str(v)
+        has_ctrl = bool(_CTRL_RE.search(s))
+        needs_quote = has_ctrl or any(c in s for c in (" ", '"', "="))
+        if needs_quote:
+            s = s.replace("\\", "\\\\").replace('"', '\\"')
+            if has_ctrl:
+                s = _CTRL_RE.sub(_escape_ctrl, s)
+            s = '"' + s + '"'
+        parts.append(f"{k}={s}")
+    return " ".join(parts)
+
+
+def _snippet(text: str, limit: int = 200) -> str:
+    """Truncate arbitrary text for safe inclusion in a single log line."""
+    text = text.replace("\n", "\\n").replace("\r", "\\r")
+    if len(text) > limit:
+        return text[:limit] + "...<truncated>"
+    return text
+
+
+_SERVICE_RE = re.compile(r"[\x00-\x1f\x7f]")
+
+
+def _validate_service(service: str) -> None:
+    """Reject empty/oversized/control-char service names with a clear error."""
+    if not service or not service.strip():
+        _diag.error("%s", _kv(event="invalid_service", reason="empty"))
+        sys.exit(2)
+    if len(service) > 128:
+        _diag.error(
+            "%s", _kv(event="invalid_service", reason="too_long", length=len(service))
+        )
+        sys.exit(2)
+    if _SERVICE_RE.search(service):
+        _diag.error("%s", _kv(event="invalid_service", reason="control_chars"))
+        sys.exit(2)
+
+
+def _validate_url(url: str) -> None:
+    """Reject obviously malformed LOGTIDE_URL values."""
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        _diag.error(
+            "%s",
+            _kv(event="invalid_url", reason="bad_scheme", scheme=parsed.scheme or ""),
+        )
+        sys.exit(2)
+    if not parsed.netloc or not parsed.hostname:
+        _diag.error("%s", _kv(event="invalid_url", reason="missing_host", url=url))
+        sys.exit(2)
 
 # -- Configuration -------------------------------------------------------
 #
@@ -79,6 +170,11 @@ LOGTIDE_API_KEY = os.environ.get("LOGTIDE_API_KEY", "CHANGEME")
 # per-line HTTP overhead.
 BATCH_SIZE = 100
 FLUSH_INTERVAL = 2.0
+
+# Queue saturation reporting: emit queue_dropped every Nth drop to avoid flooding.
+_DROP_REPORT_INTERVAL = 1000
+_QUEUE_RECOVERY_THRESHOLD = 5_000
+_QUEUE_MAXSIZE = 10_000
 
 app = App(name="logtide-ship", help="Ship logs to LogTide.")
 
@@ -116,17 +212,31 @@ def _preflight(command: str, service: str, mode: LogMode) -> None:
     (no point reading stdin if every batch will be rejected). Warns on
     connection errors but continues (server may come up later).
     """
-    print(
-        f"[logtide-ship {command}] service={service} mode={mode}"
-        f" url={LOGTIDE_URL} key={_mask_key(LOGTIDE_API_KEY)}",
-        file=sys.stderr,
+    _validate_service(service)
+    _validate_url(LOGTIDE_URL)
+
+    # Hoist masked key to a local to avoid CodeQL clear-text-logging false positive.
+    masked_key = _mask_key(LOGTIDE_API_KEY)
+    _diag.info(
+        "%s",
+        _kv(
+            event="startup",
+            subcommand=command,
+            service=service,
+            mode=mode,
+            url=LOGTIDE_URL,
+            key=masked_key,
+        ),
     )
 
     if LOGTIDE_API_KEY == "CHANGEME":
-        print(
-            "[logtide-ship] WARNING: using default API key 'CHANGEME'"
-            " — set LOGTIDE_API_KEY",
-            file=sys.stderr,
+        _diag.warning(
+            "%s",
+            _kv(
+                event="default_api_key",
+                subcommand=command,
+                hint="set LOGTIDE_API_KEY",
+            ),
         )
 
     # Probe with an empty batch.  We only care about the status code:
@@ -143,31 +253,54 @@ def _preflight(command: str, service: str, mode: LogMode) -> None:
                 timeout=5,
             )
         if resp.status_code in (401, 403):
-            print(
-                f"[logtide-ship] FATAL: authentication failed"
-                f" ({resp.status_code}). Check LOGTIDE_API_KEY.",
-                file=sys.stderr,
+            _diag.error(
+                "%s",
+                _kv(
+                    event="preflight_auth_failed",
+                    subcommand=command,
+                    status=resp.status_code,
+                    body=_snippet(resp.text),
+                    hint="check LOGTIDE_API_KEY",
+                ),
             )
             sys.exit(1)
         if resp.status_code >= 500:
-            print(
-                f"[logtide-ship] WARNING: server returned {resp.status_code}"
-                " — will retry with real batches",
-                file=sys.stderr,
+            _diag.warning(
+                "%s",
+                _kv(
+                    event="preflight_server_error",
+                    subcommand=command,
+                    status=resp.status_code,
+                    body=_snippet(resp.text),
+                ),
             )
         else:
-            print("[logtide-ship] preflight OK", file=sys.stderr)
-    except httpx.ConnectError:
-        print(
-            f"[logtide-ship] WARNING: cannot reach {LOGTIDE_URL}"
-            " — will retry when batches are ready",
-            file=sys.stderr,
+            _diag.info(
+                "%s",
+                _kv(
+                    event="preflight_ok",
+                    subcommand=command,
+                    status=resp.status_code,
+                ),
+            )
+    except httpx.ConnectError as e:
+        _diag.warning(
+            "%s",
+            _kv(
+                event="preflight_unreachable",
+                subcommand=command,
+                url=LOGTIDE_URL,
+                error=str(e),
+            ),
         )
     except httpx.HTTPError as e:
-        print(
-            f"[logtide-ship] WARNING: preflight failed: {e}"
-            " — continuing anyway",
-            file=sys.stderr,
+        _diag.warning(
+            "%s",
+            _kv(
+                event="preflight_error",
+                subcommand=command,
+                error=str(e),
+            ),
         )
 
 
@@ -211,7 +344,15 @@ def _try_parse_json(line: str) -> dict | None:
         return None
     try:
         return json.loads(line)
-    except json.JSONDecodeError:
+    except json.JSONDecodeError as e:
+        _diag.debug(
+            "%s",
+            _kv(
+                event="json_parse_failed",
+                error=str(e),
+                line=_snippet(line, 120),
+            ),
+        )
         return None
 
 
@@ -479,25 +620,47 @@ def _send_batch(client: httpx.Client, batch: list[dict]) -> None:
                 timeout=10,
             )
             if resp.status_code != 200:
-                print(
-                    f"[logtide-ship] {resp.status_code}: {resp.text}"
-                    f" (batch_size={len(batch)},"
-                    f" first={batch[0] if batch else 'empty'})",
-                    file=sys.stderr,
+                _diag.warning(
+                    "%s",
+                    _kv(
+                        event="send_non_200",
+                        status=resp.status_code,
+                        attempt=attempt + 1,
+                        batch_size=len(batch),
+                        body=_snippet(resp.text),
+                    ),
                 )
             resp.raise_for_status()
             return
         except httpx.HTTPError as e:
             if _is_retryable(e) and attempt < _SEND_RETRIES:
-                print(
-                    f"[logtide-ship] transient error (attempt {attempt + 1}/"
-                    f"{_SEND_RETRIES + 1}): {e} — retrying in {delay}s",
-                    file=sys.stderr,
+                status = getattr(getattr(e, "response", None), "status_code", None)
+                _diag.warning(
+                    "%s",
+                    _kv(
+                        event="send_retry",
+                        attempt=attempt + 1,
+                        max_attempts=_SEND_RETRIES + 1,
+                        batch_size=len(batch),
+                        status=status,
+                        backoff=delay,
+                        error=str(e),
+                    ),
                 )
                 time.sleep(delay)
                 delay *= 2
                 continue
-            print(f"[logtide-ship] send failed: {e}", file=sys.stderr)
+            status = getattr(getattr(e, "response", None), "status_code", None)
+            _diag.error(
+                "%s",
+                _kv(
+                    event="send_failed",
+                    attempt=attempt + 1,
+                    batch_size=len(batch),
+                    status=status,
+                    error=str(e),
+                ),
+            )
             return
 
 
@@ -514,29 +677,46 @@ def _shipper(queue: Queue, service: str, mode: LogMode):
     """
     batch: list[dict] = []
     last_flush = time.monotonic()
+    exit_reason = "unknown"
 
-    with httpx.Client() as client:
-        while True:
-            try:
-                line = queue.get(timeout=0.5)
-                if line is None:        # shutdown sentinel
-                    break
-                batch.append(_build_entry(line, service, mode))
-            except Empty:
-                pass                    # no new lines — check flush timer
+    try:
+        with httpx.Client() as client:
+            while True:
+                try:
+                    line = queue.get(timeout=0.5)
+                    if line is None:        # shutdown sentinel
+                        exit_reason = "shutdown_sentinel"
+                        break
+                    batch.append(_build_entry(line, service, mode))
+                except Empty:
+                    pass                    # no new lines — check flush timer
 
-            # Flush on batch-full or time-elapsed, whichever comes first
-            now = time.monotonic()
-            if len(batch) >= BATCH_SIZE or (
-                batch and now - last_flush > FLUSH_INTERVAL
-            ):
+                # Flush on batch-full or time-elapsed, whichever comes first
+                now = time.monotonic()
+                if len(batch) >= BATCH_SIZE or (
+                    batch and now - last_flush > FLUSH_INTERVAL
+                ):
+                    _send_batch(client, batch)
+                    batch = []
+                    last_flush = now
+
+            # Drain remainder after shutdown sentinel
+            if batch:
+                _diag.debug(
+                    "%s", _kv(event="shipper_drain", remaining=len(batch))
+                )
                 _send_batch(client, batch)
-                batch = []
-                last_flush = now
-
-        # Drain remainder after shutdown sentinel
-        if batch:
-            _send_batch(client, batch)
+    except Exception as e:
+        exit_reason = f"exception:{type(e).__name__}"
+        _diag.error(
+            "%s",
+            _kv(event="shipper_crash", error=str(e), exc_type=type(e).__name__),
+        )
+        raise
+    finally:
+        _diag.info(
+            "%s", _kv(event="shipper_exit", reason=exit_reason)
+        )
 
 
 # -- Subcommands ---------------------------------------------------------
@@ -550,6 +730,14 @@ def follow(service: str, *, opts: Global = Global()):
     Lines are queued and shipped by a background thread so stdin is
     never blocked by HTTP latency.
 
+    Backpressure: the producer never blocks. When the queue is full,
+    the oldest queued line is evicted (drop-oldest) and the incoming
+    line takes its place. A ``queue_full`` warning is emitted once at
+    the start of a saturation episode; ``queue_dropped`` fires every
+    ``_DROP_REPORT_INTERVAL`` drops with the running total; when the
+    queue drains below ``_QUEUE_RECOVERY_THRESHOLD`` a
+    ``queue_recovered`` event reports the total drops for the episode.
+
     Parameters
     ----------
     service
@@ -557,12 +745,16 @@ def follow(service: str, *, opts: Global = Global()):
     """
     _preflight("follow", service, opts.mode)
 
-    queue: Queue = Queue(maxsize=10_000)
+    queue: Queue = Queue(maxsize=_QUEUE_MAXSIZE)
     thread = threading.Thread(
         target=_shipper, args=(queue, service, opts.mode), daemon=True
     )
     thread.start()
 
+    stop_reason = "eof"
+    backpressure_logged = False
+    dropped = 0                 # running total for current saturation episode
+    last_reported = 0           # last value of `dropped` we emitted
     try:
         for line in sys.stdin:
             line = line.rstrip("\n")
@@ -571,12 +763,70 @@ def follow(service: str, *, opts: Global = Global()):
                 sys.stdout.flush()
             if not line:
                 continue
-            queue.put(line)
+            # Non-blocking drop-oldest: on Full, evict the head and retry.
+            # If the retry still fails (racy shipper enqueue), drop the new line.
+            try:
+                queue.put_nowait(line)
+            except Exception:
+                if not backpressure_logged:
+                    _diag.warning(
+                        "%s",
+                        _kv(
+                            event="queue_full",
+                            qsize=queue.qsize(),
+                            maxsize=_QUEUE_MAXSIZE,
+                            action="drop_oldest",
+                        ),
+                    )
+                    backpressure_logged = True
+                try:
+                    queue.get_nowait()          # evict oldest
+                    queue.put_nowait(line)
+                except Exception:
+                    pass                        # lost the race; drop incoming
+                dropped += 1
+                if dropped - last_reported >= _DROP_REPORT_INTERVAL:
+                    _diag.warning(
+                        "%s",
+                        _kv(
+                            event="queue_dropped",
+                            count=dropped,
+                            qsize=queue.qsize(),
+                        ),
+                    )
+                    last_reported = dropped
+            else:
+                if backpressure_logged and queue.qsize() < _QUEUE_RECOVERY_THRESHOLD:
+                    _diag.info(
+                        "%s",
+                        _kv(
+                            event="queue_recovered",
+                            qsize=queue.qsize(),
+                            dropped_total=dropped,
+                        ),
+                    )
+                    backpressure_logged = False
+                    dropped = 0
+                    last_reported = 0
     except KeyboardInterrupt:
-        pass
+        stop_reason = "keyboard_interrupt"
+    except Exception as e:
+        stop_reason = f"exception:{type(e).__name__}"
+        _diag.error(
+            "%s",
+            _kv(event="reader_crash", error=str(e), exc_type=type(e).__name__),
+        )
+        raise
     finally:
+        _diag.info(
+            "%s", _kv(event="reader_exit", reason=stop_reason)
+        )
         queue.put(None)             # signal shipper to flush and exit
         thread.join(timeout=5)
+        if thread.is_alive():
+            _diag.warning(
+                "%s", _kv(event="shipper_join_timeout", seconds=5)
+            )
 
 
 @app.command

--- a/scripts/logtide-ship.py
+++ b/scripts/logtide-ship.py
@@ -2,9 +2,47 @@
 
 # scripts/logtide-ship.py
 
-"""logtide-ship - pipe stdin to LogTide"""
+"""logtide-ship - pipe stdin to LogTide
+
+Reads log lines from stdin and ships them to a LogTide instance via the
+HTTP ingest API (/api/v1/ingest). Supports two subcommands:
+
+    stream  - read stdin continuously, ship in batches (for long-running pipes)
+    ingest  - read all of stdin, ship as a single batch (for one-shot imports)
+
+Three modes control how JSON log lines (e.g. from SemanticLogger with
+LOG_FORMATTER=json) are handled:
+
+    plain    - All input treated as text. ANSI codes stripped, log level
+               guessed from message content. No JSON parsing. This is the
+               original behavior and works with any log formatter.
+
+    metadata - JSON lines are parsed. Level, timestamp, and hostname are
+               extracted into top-level LogTide fields. Structured fields
+               (logger name, pid, thread, SemanticLogger payload) are placed
+               in the LogTide `metadata` dict. Human-readable message is
+               preserved. Best when LogTide supports metadata queries.
+
+    json     - JSON lines are parsed. Level, timestamp, and hostname are
+               extracted into top-level fields. The full raw JSON is sent as
+               the LogTide `message`, allowing a LogTide pipeline with a JSON
+               parser step to extract and index all fields server-side.
+
+Plain text lines always use the text path regardless of mode.
+
+Usage:
+    # Stream from a process manager (default --mode json)
+    LOG_FORMATTER=json bin/backend | python3 scripts/logtide-ship.py stream backend
+
+    # Ship existing log file with text-mode fallback
+    cat /var/log/app.log | python3 scripts/logtide-ship.py ingest backend --mode plain
+
+    # Use metadata mode for structured fields without pipeline parsing
+    LOG_FORMATTER=json bin/backend | python3 scripts/logtide-ship.py stream backend --mode metadata
+"""
 
 import json
+import os
 import re
 import sys
 import threading
@@ -12,16 +50,25 @@ import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from queue import Empty, Queue
+from typing import Literal
 
 import httpx
 from cyclopts import App, Parameter
 
-LOGTIDE_URL = "http://127.0.0.1:8080/api/v1/ingest"
-API_KEY = "lp_b2d8d9a5aebf0566d7cdc52603a537bac511f9d8708bae0141b0ee28ea50851b"
+# LogTide ingest endpoint and credentials (env vars take precedence)
+LOGTIDE_URL = os.environ.get("LOGTIDE_URL", "http://127.0.0.1:8080/api/v1/ingest")
+LOGTIDE_API_KEY = os.environ.get("LOGTIDE_API_KEY", "CHANGEME")
+
+# Batching: flush when batch reaches this size or after this many seconds of
+# inactivity, whichever comes first. Keeps latency bounded while avoiding
+# per-line HTTP overhead.
 BATCH_SIZE = 100
 FLUSH_INTERVAL = 2.0
 
 app = App(name="logtide-ship", help="Ship logs to LogTide.")
+
+
+LogMode = Literal["plain", "metadata", "json"]
 
 
 @Parameter(name="*")
@@ -30,8 +77,22 @@ class Global:
     verbose: bool = False
     """Echo lines to stdout as well."""
 
+    mode: LogMode = "json"
+    """How to handle JSON log lines.
+
+    plain    -- treat all input as text (original behavior)
+    metadata -- parse JSON, extract structured fields into metadata
+    json     -- parse JSON, send full JSON as message for LogTide pipeline parsing
+    """
+
 
 def detect_level(msg: str) -> str:
+    """Guess LogTide level from message text. Used only for plain text input.
+
+    Maps to LogTide's level values (matching the syslog integration):
+    FATAL/CRIT -> critical, ERROR -> error, WARN -> warn, DEBUG -> debug,
+    everything else -> info.
+    """
     msg_upper = msg.upper()
     if any(x in msg_upper for x in ("FATAL", "CRIT")):
         return "critical"
@@ -44,6 +105,7 @@ def detect_level(msg: str) -> str:
     return "info"
 
 
+# Matches ANSI color/style escape sequences (e.g. from SemanticLogger :color formatter)
 _ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
 
 
@@ -54,6 +116,12 @@ def _now() -> str:
 
 
 def _try_parse_json(line: str) -> dict | None:
+    """Fast-path JSON detection: skip lines that don't start with '{'.
+
+    SemanticLogger JSON output always starts with '{'. Plain text, ANSI-colored
+    output, and blank lines never do, so the startswith check avoids calling
+    json.loads on every line.
+    """
     if not line.startswith("{"):
         return None
     try:
@@ -62,21 +130,41 @@ def _try_parse_json(line: str) -> dict | None:
         return None
 
 
-def _build_entry(line: str, service: str) -> dict:
-    raw = _try_parse_json(line)
-    if raw:
-        return _build_entry_from_json(raw, service)
-    return _build_entry_from_text(line, service)
+def _build_entry(line: str, service: str, mode: LogMode = "json") -> dict:
+    """Dispatch to the appropriate entry builder based on mode.
+
+    For non-plain modes, attempts JSON parsing first. Falls through to
+    the text path if the line isn't valid JSON (e.g. plain text output,
+    startup banners, non-SemanticLogger lines mixed into the stream).
+    """
+    if mode != "plain":
+        raw = _try_parse_json(line)
+        if raw:
+            if mode == "metadata":
+                return _build_entry_metadata(raw, service)
+            return _build_entry_json(raw, service)
+    return _build_entry_text(line, service)
 
 
-def _build_entry_from_json(raw: dict, service: str) -> dict:
+def _build_entry_json(raw: dict, service: str) -> dict:
+    """Send full JSON as message for LogTide pipeline parsing."""
+    return {
+        "time": raw.get("timestamp", _now()),
+        "service": service,
+        "hostname": raw.get("host", ""),
+        "level": raw.get("level", "info"),
+        "message": json.dumps(raw),
+    }
+
+
+def _build_entry_metadata(raw: dict, service: str) -> dict:
+    """Extract structured fields into metadata dict."""
     metadata = {
         k: v
         for k, v in {
             "logger": raw.get("name"),
             "pid": raw.get("pid"),
             "thread": raw.get("thread"),
-            "host": raw.get("host"),
         }.items()
         if v is not None
     }
@@ -87,6 +175,7 @@ def _build_entry_from_json(raw: dict, service: str) -> dict:
     entry = {
         "time": raw.get("timestamp", _now()),
         "service": service,
+        "hostname": raw.get("host", ""),
         "level": raw.get("level", "info"),
         "message": raw.get("message", ""),
     }
@@ -95,7 +184,8 @@ def _build_entry_from_json(raw: dict, service: str) -> dict:
     return entry
 
 
-def _build_entry_from_text(line: str, service: str) -> dict:
+def _build_entry_text(line: str, service: str) -> dict:
+    """Strip ANSI, guess level from text content."""
     line = _ANSI_RE.sub("", line)
     return {
         "time": _now(),
@@ -106,11 +196,16 @@ def _build_entry_from_text(line: str, service: str) -> dict:
 
 
 def _send_batch(client: httpx.Client, batch: list[dict]) -> None:
+    """POST a batch of log entries to the LogTide ingest API.
+
+    Errors are logged to stderr rather than raised, so a transient LogTide
+    outage doesn't kill the pipeline — lines continue to be read from stdin.
+    """
     try:
         resp = client.post(
             LOGTIDE_URL,
             json={"logs": batch},
-            headers={"X-API-Key": API_KEY},
+            headers={"X-API-Key": LOGTIDE_API_KEY},
             timeout=10,
         )
         if resp.status_code != 200:
@@ -123,7 +218,14 @@ def _send_batch(client: httpx.Client, batch: list[dict]) -> None:
         print(f"[logtide-ship] send failed: {e}", file=sys.stderr)
 
 
-def _shipper(queue: Queue, service: str):
+def _shipper(queue: Queue, service: str, mode: LogMode):
+    """Background thread that drains the queue and ships batches to LogTide.
+
+    Runs in a loop reading lines from the queue, building entries, and
+    flushing when the batch is full or the flush interval elapses. Sending
+    None into the queue signals shutdown; any remaining entries are flushed
+    before the thread exits.
+    """
     batch: list[dict] = []
     last_flush = time.monotonic()
 
@@ -133,7 +235,7 @@ def _shipper(queue: Queue, service: str):
                 line = queue.get(timeout=0.5)
                 if line is None:
                     break
-                batch.append(_build_entry(line, service))
+                batch.append(_build_entry(line, service, mode))
             except Empty:
                 pass
 
@@ -160,7 +262,7 @@ def stream(service: str, *, opts: Global = Global()):
     """
     queue: Queue = Queue()
     thread = threading.Thread(
-        target=_shipper, args=(queue, service), daemon=True
+        target=_shipper, args=(queue, service, opts.mode), daemon=True
     )
     thread.start()
 
@@ -196,7 +298,7 @@ def ingest(service: str, *, opts: Global = Global()):
             sys.stdout.write(line + "\n")
         sys.stdout.flush()
 
-    batch = [_build_entry(line, service) for line in lines if line]
+    batch = [_build_entry(line, service, opts.mode) for line in lines if line]
 
     if not batch:
         return

--- a/scripts/logtide-ship.py
+++ b/scripts/logtide-ship.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+
+"""logtide-ship - pipe stdin to LogTide"""
+
+import re
+import sys
+import threading
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from queue import Empty, Queue
+
+import httpx
+from cyclopts import App, Parameter
+
+LOGTIDE_URL = "http://127.0.0.1:8080/api/v1/ingest"
+API_KEY = "lp_b2d8d9a5aebf0566d7cdc52603a537bac511f9d8708bae0141b0ee28ea50851b"
+BATCH_SIZE = 100
+FLUSH_INTERVAL = 2.0
+
+app = App(name="logtide-ship", help="Ship logs to LogTide.")
+
+
+@Parameter(name="*")
+@dataclass
+class Global:
+    verbose: bool = False
+    """Echo lines to stdout as well."""
+
+
+def detect_level(msg: str) -> str:
+    msg_upper = msg.upper()
+    if any(x in msg_upper for x in ("FATAL", "CRIT")):
+        return "critical"
+    if "ERROR" in msg_upper:
+        return "error"
+    if "WARN" in msg_upper:
+        return "warn"
+    if "DEBUG" in msg_upper:
+        return "debug"
+    return "info"
+
+
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _build_entry(line: str, service: str) -> dict:
+    line = _ANSI_RE.sub("", line)
+    return {
+        "time": datetime.now(timezone.utc).isoformat(),
+        "service": service,
+        "level": detect_level(line),
+        "message": line,
+    }
+
+
+def _send_batch(client: httpx.Client, batch: list[dict]) -> None:
+    try:
+        client.post(
+            LOGTIDE_URL,
+            json={"logs": batch},
+            headers={"X-API-Key": API_KEY},
+            timeout=10,
+        ).raise_for_status()
+    except httpx.HTTPError as e:
+        print(f"[logtide-ship] send failed: {e}", file=sys.stderr)
+
+
+def _shipper(queue: Queue, service: str):
+    batch: list[dict] = []
+    last_flush = time.monotonic()
+
+    with httpx.Client() as client:
+        while True:
+            try:
+                line = queue.get(timeout=0.5)
+                if line is None:
+                    break
+                batch.append(_build_entry(line, service))
+            except Empty:
+                pass
+
+            now = time.monotonic()
+            if len(batch) >= BATCH_SIZE or (
+                batch and now - last_flush > FLUSH_INTERVAL
+            ):
+                _send_batch(client, batch)
+                batch = []
+                last_flush = now
+
+        if batch:
+            _send_batch(client, batch)
+
+
+@app.command
+def stream(service: str, *, opts: Global = Global()):
+    """Read stdin continuously and ship lines to LogTide in batches.
+
+    Parameters
+    ----------
+    service
+        Service name attached to each log entry.
+    """
+    queue: Queue = Queue()
+    thread = threading.Thread(
+        target=_shipper, args=(queue, service), daemon=True
+    )
+    thread.start()
+
+    try:
+        for line in sys.stdin:
+            line = line.rstrip("\n")
+            if opts.verbose:
+                sys.stdout.write(line + "\n")
+                sys.stdout.flush()
+            queue.put(line)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        queue.put(None)
+        thread.join(timeout=5)
+
+
+@app.command
+def ingest(service: str, *, opts: Global = Global()):
+    """Read all of stdin then ship to LogTide as a single batch.
+
+    Parameters
+    ----------
+    service
+        Service name attached to each log entry.
+    """
+    lines = sys.stdin.read().splitlines()
+
+    if opts.verbose:
+        for line in lines:
+            sys.stdout.write(line + "\n")
+        sys.stdout.flush()
+
+    batch = [_build_entry(line, service) for line in lines]
+
+    if not batch:
+        return
+
+    with httpx.Client() as client:
+        # Ship in chunks of BATCH_SIZE
+        for i in range(0, len(batch), BATCH_SIZE):
+            _send_batch(client, batch[i : i + BATCH_SIZE])
+
+
+if __name__ == "__main__":
+    app()

--- a/scripts/requirements-logtide.txt
+++ b/scripts/requirements-logtide.txt
@@ -1,0 +1,2 @@
+httpx>=0.27,<1
+cyclopts>=4,<5

--- a/scripts/tests/test_logtide_ship.py
+++ b/scripts/tests/test_logtide_ship.py
@@ -1,0 +1,909 @@
+# scripts/tests/test_logtide_ship.py
+
+"""Tests for scripts/logtide-ship.py.
+
+Run from repo root:
+    python3 -m pytest scripts/tests/test_logtide_ship.py -v
+
+Requirements: pytest, httpx. cyclopts is only required to import the module
+itself; if it's missing the entire module skips. respx is not used — we mock
+httpx via httpx.MockTransport + monkeypatching httpx.Client.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import logging
+import os
+import queue as queue_mod
+import re
+import socket
+import sys
+import threading
+import time
+from pathlib import Path
+
+import httpx
+import pytest
+
+# -- Module loader ------------------------------------------------------
+# logtide-ship.py has a hyphen, so we can't `import` it normally.
+
+_SCRIPT = Path(__file__).resolve().parents[1] / "logtide-ship.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("logtide_ship", _SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    try:
+        spec.loader.exec_module(mod)
+    except ModuleNotFoundError as e:
+        pytest.skip(f"logtide-ship dependency missing: {e}")
+    return mod
+
+
+ls = _load_module()
+
+
+# -- Helpers ------------------------------------------------------------
+
+
+ISO_Z_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$")
+
+
+class FakeTransport(httpx.BaseTransport):
+    """Records requests and returns scripted responses."""
+
+    def __init__(self, responses):
+        # responses: list of (status_code, body_dict) or callables
+        self.responses = list(responses)
+        self.requests = []
+
+    def handle_request(self, request):
+        self.requests.append(request)
+        if not self.responses:
+            return httpx.Response(200, json={"ok": True})
+        item = self.responses.pop(0)
+        if callable(item):
+            return item(request)
+        status, body = item
+        return httpx.Response(status, json=body)
+
+
+@pytest.fixture
+def diag_caplog(caplog):
+    """Capture logtide-ship diag logger. _diag has propagate=False, so
+    temporarily enable propagation for the duration of the test."""
+    prev = ls._diag.propagate
+    ls._diag.propagate = True
+    caplog.set_level(logging.DEBUG, logger="logtide-ship")
+    yield caplog
+    ls._diag.propagate = prev
+
+
+def _patched_client(monkeypatch, transport):
+    """Force httpx.Client() calls to use our transport."""
+    real_client = httpx.Client
+
+    def factory(*args, **kwargs):
+        kwargs["transport"] = transport
+        return real_client(*args, **kwargs)
+
+    monkeypatch.setattr(ls.httpx, "Client", factory)
+
+
+# -- _mask_key ----------------------------------------------------------
+
+
+class TestMaskKey:
+    def test_empty(self):
+        assert ls._mask_key("") == "***"
+
+    def test_short(self):
+        assert ls._mask_key("abcd") == "***"
+        assert ls._mask_key("abcdefgh") == "***"  # boundary: len==8
+
+    def test_long(self):
+        masked = ls._mask_key("sk-abcdef1234567890xyz")
+        assert masked == "sk-a***xyz"
+
+    def test_never_contains_full_key(self):
+        key = "supersecretapikey123456"
+        masked = ls._mask_key(key)
+        assert key not in masked
+        assert "secret" not in masked
+
+
+# -- detect_level -------------------------------------------------------
+
+
+class TestDetectLevel:
+    @pytest.mark.parametrize(
+        "msg,expected",
+        [
+            ("something FATAL happened", "critical"),
+            ("CRITical path", "critical"),
+            ("ERROR: boom", "error"),
+            ("a WARNing sign", "warn"),
+            ("DEBUG trace", "debug"),
+            ("all good", "info"),
+            ("", "info"),
+        ],
+    )
+    def test_levels(self, msg, expected):
+        assert ls.detect_level(msg) == expected
+
+
+# -- _now ---------------------------------------------------------------
+
+
+class TestNow:
+    def test_z_suffix(self):
+        s = ls._now()
+        assert ISO_Z_RE.match(s), s
+        assert s.endswith("Z")
+        assert "+00:00" not in s
+
+
+# -- Caddy duration parser ---------------------------------------------
+
+
+class TestCaddyDuration:
+    @pytest.mark.parametrize(
+        "val,expected",
+        [
+            ("100ms", 100.0),
+            ("1.5s", 1500.0),
+            ("2m", 120000.0),
+            ("1h", 3600000.0),
+            ("250µs", 0.25),
+            ("250us", 0.25),
+            ("7.750ms", 7.75),
+        ],
+    )
+    def test_go_duration_strings(self, val, expected):
+        assert ls._parse_caddy_duration_ms(val) == expected
+
+    def test_float_seconds(self):
+        # duration_format number → float seconds
+        assert ls._parse_caddy_duration_ms(0.074) == 74.0
+        assert ls._parse_caddy_duration_ms(1) == 1000.0
+
+    def test_malformed_returns_zero(self):
+        assert ls._parse_caddy_duration_ms("bogus") == 0
+        assert ls._parse_caddy_duration_ms("5xyz") == 0
+        assert ls._parse_caddy_duration_ms(None) == 0
+
+    def test_composite_not_supported_returns_zero(self):
+        # _GO_DURATION_RE is anchored and doesn't handle composite units.
+        # Documenting actual behavior: "1m30s" does not match.
+        assert ls._parse_caddy_duration_ms("1m30s") == 0
+
+
+# -- Caddy timestamp parser --------------------------------------------
+
+
+class TestCaddyTimestamp:
+    def test_unix_seconds_float(self):
+        # 2022-03-09 21:30:01.524 UTC-ish
+        out = ls._parse_caddy_ts(1646861401.524)
+        assert ISO_Z_RE.match(out)
+        assert out.startswith("2022-03-09T")
+
+    def test_unix_milli_float(self):
+        # > 1e12 → treated as millis
+        out = ls._parse_caddy_ts(1646861401524.0)
+        assert ISO_Z_RE.match(out)
+        assert out.startswith("2022-03-09T")
+
+    def test_both_forms_equivalent(self):
+        a = ls._parse_caddy_ts(1646861401.524)
+        b = ls._parse_caddy_ts(1646861401524.0)
+        assert a == b
+
+
+# -- Entry builders ----------------------------------------------------
+
+
+class TestBuildEntryText:
+    def test_strips_ansi(self):
+        line = "\x1b[31mERROR: boom\x1b[0m"
+        e = ls._build_entry_text(line, "svc")
+        assert e["message"] == "ERROR: boom"
+        assert e["level"] == "error"
+        assert e["service"] == "svc"
+        assert e["hostname"] == ls._HOSTNAME
+        assert ISO_Z_RE.match(e["time"])
+
+    def test_level_guess_info(self):
+        e = ls._build_entry_text("just a message", "svc")
+        assert e["level"] == "info"
+
+
+class TestBuildEntryJson:
+    def test_full_json_as_message(self):
+        raw = {
+            "timestamp": "2024-01-02T03:04:05.678Z",
+            "host": "box-1",
+            "level": "warn",
+            "message": "hi",
+            "name": "Onetime::App",
+        }
+        e = ls._build_entry_json(raw, "backend")
+        assert e["time"] == "2024-01-02T03:04:05.678Z"
+        assert e["hostname"] == "box-1"
+        assert e["level"] == "warn"
+        assert json.loads(e["message"]) == raw
+
+    def test_fallbacks(self):
+        e = ls._build_entry_json({}, "svc")
+        assert ISO_Z_RE.match(e["time"])
+        assert e["hostname"] == ls._HOSTNAME
+        assert e["level"] == "info"
+
+
+class TestBuildEntryMetadata:
+    def test_extracts_fields(self):
+        raw = {
+            "timestamp": "2024-01-02T03:04:05.678Z",
+            "host": "box-1",
+            "level": "error",
+            "message": "boom",
+            "name": "Onetime::Secret",
+            "pid": 1234,
+            "thread": "main",
+            "payload": {"user_id": "u_1", "secret_id": "s_1"},
+        }
+        e = ls._build_entry_metadata(raw, "backend")
+        assert e["message"] == "boom"
+        assert e["metadata"]["logger"] == "Onetime::Secret"
+        assert e["metadata"]["pid"] == 1234
+        assert e["metadata"]["thread"] == "main"
+        assert e["metadata"]["user_id"] == "u_1"
+        assert e["metadata"]["secret_id"] == "s_1"
+
+    def test_no_metadata_key_when_empty(self):
+        raw = {"message": "hi"}
+        e = ls._build_entry_metadata(raw, "svc")
+        assert "metadata" not in e
+        assert e["hostname"] == ls._HOSTNAME
+
+
+class TestBuildEntryCaddy:
+    @pytest.fixture
+    def sample(self):
+        return {
+            "level": "info",
+            "ts": 1646861401.524,
+            "logger": "http.log.access.log0",
+            "status": 200,
+            "size": 14131,
+            "duration": "7.750ms",
+            "request": {
+                "remote_ip": "10.0.0.1",
+                "client_ip": "203.0.113.7",
+                "proto": "HTTP/2.0",
+                "method": "GET",
+                "host": "example.com",
+                "uri": "/api/users",
+                "headers": {"User-Agent": ["Mozilla/5.0"]},
+                "tls": {"proto": "h2"},
+            },
+        }
+
+    def test_message_format(self, sample):
+        e = ls._build_entry_caddy(sample, "caddy")
+        assert e["message"] == "GET /api/users 200 13.8kB 7.75ms"
+        assert ISO_Z_RE.match(e["time"])
+        assert e["hostname"] == ls._HOSTNAME  # Caddy doesn't ship host
+
+    def test_metadata_populated(self, sample):
+        e = ls._build_entry_caddy(sample, "caddy")
+        md = e["metadata"]
+        assert md["remote_ip"] == "10.0.0.1"
+        assert md["client_ip"] == "203.0.113.7"
+        assert md["status"] == 200
+        assert md["size"] == 14131
+        assert md["duration_ms"] == 7.75
+        assert md["host"] == "example.com"
+        assert md["proto"] == "HTTP/2.0"
+        assert md["logger"] == "http.log.access.log0"
+        assert md["tls_proto"] == "h2"
+        assert md["user_agent"] == "Mozilla/5.0"
+
+    def test_client_ip_equals_remote_ip_omitted(self, sample):
+        sample["request"]["client_ip"] = sample["request"]["remote_ip"]
+        e = ls._build_entry_caddy(sample, "caddy")
+        assert "client_ip" not in e["metadata"]
+
+    def test_unix_milli_timestamp(self, sample):
+        sample["ts"] = 1646861401524.0
+        e = ls._build_entry_caddy(sample, "caddy")
+        assert e["time"].startswith("2022-03-09T")
+
+    def test_float_duration_seconds(self, sample):
+        sample["duration"] = 0.0775  # 77.5ms in float-seconds form
+        e = ls._build_entry_caddy(sample, "caddy")
+        assert e["metadata"]["duration_ms"] == 77.5
+
+    def test_missing_ts_uses_now(self, sample):
+        del sample["ts"]
+        e = ls._build_entry_caddy(sample, "caddy")
+        assert ISO_Z_RE.match(e["time"])
+
+
+# -- _build_entry dispatch ---------------------------------------------
+
+
+class TestBuildEntryDispatch:
+    def test_plain_mode_ignores_json(self):
+        line = '{"level":"warn","message":"hi"}'
+        e = ls._build_entry(line, "svc", mode="plain")
+        # plain always goes text path; raw line becomes the message
+        assert e["message"] == line
+        assert e["level"] == "warn"  # detect_level picks it up
+
+    def test_non_json_line_in_json_mode_falls_through(self):
+        e = ls._build_entry("plain startup banner", "svc", mode="json")
+        assert e["message"] == "plain startup banner"
+
+    def test_ansi_colored_line_in_metadata_mode(self):
+        # ANSI-colored text doesn't start with '{' → text path
+        line = "\x1b[31mERROR: boom\x1b[0m"
+        e = ls._build_entry(line, "svc", mode="metadata")
+        assert e["message"] == "ERROR: boom"
+        assert e["level"] == "error"
+
+    def test_semantic_logger_json_metadata_mode(self):
+        raw = {
+            "timestamp": "2024-01-02T03:04:05.678Z",
+            "host": "h",
+            "level": "info",
+            "message": "m",
+            "name": "L",
+        }
+        line = json.dumps(raw)
+        e = ls._build_entry(line, "svc", mode="metadata")
+        assert e["message"] == "m"
+        assert e["metadata"]["logger"] == "L"
+
+    def test_caddy_mode_routes_to_caddy_builder(self):
+        raw = {"ts": 1646861401.5, "request": {"method": "GET", "uri": "/"}, "status": 200}
+        line = json.dumps(raw)
+        e = ls._build_entry(line, "svc", mode="caddy")
+        assert "GET /" in e["message"]
+        assert e["time"].startswith("2022-")
+
+
+# -- _send_batch retry behavior ----------------------------------------
+
+
+class TestSendBatch:
+    def test_success_no_retry(self, monkeypatch):
+        t = FakeTransport([(200, {"ok": True})])
+        _patched_client(monkeypatch, t)
+        with httpx.Client() as c:
+            ls._send_batch(c, [{"message": "hi"}])
+        assert len(t.requests) == 1
+
+    def test_retries_on_500_then_succeeds(self, monkeypatch):
+        monkeypatch.setattr(ls.time, "sleep", lambda _s: None)
+        t = FakeTransport([(500, {"err": "boom"}), (200, {"ok": True})])
+        _patched_client(monkeypatch, t)
+        with httpx.Client() as c:
+            ls._send_batch(c, [{"message": "hi"}])
+        assert len(t.requests) == 2
+
+    def test_retries_exhausted_on_503(self, monkeypatch, capsys):
+        monkeypatch.setattr(ls.time, "sleep", lambda _s: None)
+        # 3 attempts total (1 initial + 2 retries) all 503
+        t = FakeTransport([(503, {}), (503, {}), (503, {})])
+        _patched_client(monkeypatch, t)
+        with httpx.Client() as c:
+            ls._send_batch(c, [{"message": "hi"}])
+        assert len(t.requests) == 3
+
+    def test_no_retry_on_401(self, monkeypatch):
+        monkeypatch.setattr(ls.time, "sleep", lambda _s: None)
+        t = FakeTransport([(401, {"err": "auth"}), (200, {"ok": True})])
+        _patched_client(monkeypatch, t)
+        with httpx.Client() as c:
+            ls._send_batch(c, [{"message": "hi"}])
+        # _send_batch swallows the HTTPStatusError but doesn't retry 4xx
+        assert len(t.requests) == 1
+
+    def test_sends_correct_headers_and_body(self, monkeypatch):
+        monkeypatch.setattr(ls, "LOGTIDE_API_KEY", "key-xyz")
+        monkeypatch.setattr(ls, "LOGTIDE_URL", "http://test.local/ingest")
+        t = FakeTransport([(200, {"ok": True})])
+        _patched_client(monkeypatch, t)
+        with httpx.Client() as c:
+            ls._send_batch(c, [{"message": "a"}, {"message": "b"}])
+        req = t.requests[0]
+        assert req.headers["X-API-Key"] == "key-xyz"
+        body = json.loads(req.content)
+        assert body == {"logs": [{"message": "a"}, {"message": "b"}]}
+
+
+# -- _preflight --------------------------------------------------------
+
+
+class TestPreflight:
+    def test_exits_on_401(self, monkeypatch):
+        t = FakeTransport([(401, {"err": "nope"})])
+        _patched_client(monkeypatch, t)
+        with pytest.raises(SystemExit) as exc:
+            ls._preflight("follow", "svc", "json")
+        assert exc.value.code == 1
+
+    def test_exits_on_403(self, monkeypatch):
+        t = FakeTransport([(403, {})])
+        _patched_client(monkeypatch, t)
+        with pytest.raises(SystemExit):
+            ls._preflight("follow", "svc", "json")
+
+    def test_success_on_200(self, monkeypatch, diag_caplog):
+        t = FakeTransport([(200, {"ok": True})])
+        _patched_client(monkeypatch, t)
+        ls._preflight("follow", "svc", "json")
+        msgs = " ".join(r.getMessage() for r in diag_caplog.records)
+        assert "event=preflight_ok" in msgs
+        assert "status=200" in msgs
+
+    def test_success_on_400_empty_logs_rejected(self, monkeypatch, diag_caplog):
+        # Some servers reject {"logs":[]} with 400 — still treated as auth OK
+        t = FakeTransport([(400, {"err": "empty"})])
+        _patched_client(monkeypatch, t)
+        ls._preflight("follow", "svc", "json")
+        msgs = " ".join(r.getMessage() for r in diag_caplog.records)
+        assert "event=preflight_ok" in msgs
+        assert "status=400" in msgs
+
+    def test_connection_error_warns_but_continues(self, monkeypatch, diag_caplog):
+        def boom(_req):
+            raise httpx.ConnectError("refused")
+
+        t = FakeTransport([boom])
+        _patched_client(monkeypatch, t)
+        ls._preflight("follow", "svc", "json")  # must not raise
+        msgs = " ".join(r.getMessage() for r in diag_caplog.records)
+        assert "event=preflight_unreachable" in msgs
+        assert "refused" in msgs
+
+    def test_5xx_warns_but_continues(self, monkeypatch, diag_caplog):
+        t = FakeTransport([(503, {})])
+        _patched_client(monkeypatch, t)
+        ls._preflight("follow", "svc", "json")
+        msgs = " ".join(r.getMessage() for r in diag_caplog.records)
+        assert "event=preflight_server_error" in msgs
+        assert "status=503" in msgs
+
+    def test_banner_masks_key(self, monkeypatch, diag_caplog, capfd):
+        monkeypatch.setattr(ls, "LOGTIDE_API_KEY", "supersecretapikey123456")
+        t = FakeTransport([(200, {"ok": True})])
+        _patched_client(monkeypatch, t)
+        ls._preflight("follow", "svc", "json")
+        msgs = " ".join(r.getMessage() for r in diag_caplog.records)
+        # Full secret must not appear in logged messages
+        assert "supersecretapikey123456" not in msgs
+        assert "supe***456" in msgs
+        # Also verify it never hits the raw stderr stream
+        err = capfd.readouterr().err
+        assert "supersecretapikey123456" not in err
+
+    def test_auth_failure_emits_event(self, monkeypatch, diag_caplog):
+        t = FakeTransport([(401, {"err": "nope"})])
+        _patched_client(monkeypatch, t)
+        with pytest.raises(SystemExit):
+            ls._preflight("follow", "svc", "json")
+        msgs = " ".join(r.getMessage() for r in diag_caplog.records)
+        assert "event=preflight_auth_failed" in msgs
+        assert "status=401" in msgs
+
+
+# -- follow / batch subcommands ----------------------------------------
+
+
+class TestFollow:
+    def test_skips_empty_lines_and_ships(self, monkeypatch):
+        monkeypatch.setattr(ls.time, "sleep", lambda _s: None)
+        t = FakeTransport([(200, {"ok": True})] * 10)
+        _patched_client(monkeypatch, t)
+        monkeypatch.setattr(ls, "_preflight", lambda *a, **k: None)
+
+        input_lines = "line one\n\n   \nline two\n"
+        monkeypatch.setattr(sys, "stdin", io.StringIO(input_lines))
+        # shorten flush interval so test isn't slow
+        monkeypatch.setattr(ls, "FLUSH_INTERVAL", 0.05)
+        monkeypatch.setattr(ls, "BATCH_SIZE", 100)
+
+        ls.follow("svc", opts=ls.Global(mode="plain"))
+
+        # All batches together should contain both non-empty lines; blank
+        # lines should never be queued/shipped.
+        all_logs = []
+        for req in t.requests:
+            body = json.loads(req.content)
+            all_logs.extend(body.get("logs", []))
+        messages = [e["message"] for e in all_logs]
+        assert "line one" in messages
+        assert "line two" in messages
+        assert "   " in messages  # whitespace-only is non-empty, not skipped
+        assert "" not in messages
+
+    def test_bounded_queue_constant(self):
+        # Document the maxsize contract — producer now uses drop-oldest
+        # when full, rather than blocking.
+        assert ls._QUEUE_MAXSIZE == 10_000
+        assert ls._QUEUE_RECOVERY_THRESHOLD == 5_000
+        assert ls._DROP_REPORT_INTERVAL == 1000
+
+
+class TestBatch:
+    def test_streams_stdin(self, monkeypatch):
+        """`batch` must iterate stdin, not call sys.stdin.read()."""
+        t = FakeTransport([(200, {"ok": True})] * 5)
+        _patched_client(monkeypatch, t)
+        monkeypatch.setattr(ls, "_preflight", lambda *a, **k: None)
+
+        class TrackingStdin(io.StringIO):
+            read_called = False
+
+            def read(self, *a, **k):
+                TrackingStdin.read_called = True
+                return super().read(*a, **k)
+
+        stdin = TrackingStdin("a\nb\n\nc\n")
+        monkeypatch.setattr(sys, "stdin", stdin)
+
+        ls.batch("svc", opts=ls.Global(mode="plain"))
+
+        assert TrackingStdin.read_called is False
+        all_logs = []
+        for req in t.requests:
+            all_logs.extend(json.loads(req.content)["logs"])
+        messages = [e["message"] for e in all_logs]
+        assert messages == ["a", "b", "c"]
+
+    def test_flushes_on_batch_size(self, monkeypatch):
+        t = FakeTransport([(200, {"ok": True})] * 10)
+        _patched_client(monkeypatch, t)
+        monkeypatch.setattr(ls, "_preflight", lambda *a, **k: None)
+        monkeypatch.setattr(ls, "BATCH_SIZE", 3)
+
+        stdin = io.StringIO("\n".join(f"line{i}" for i in range(7)) + "\n")
+        monkeypatch.setattr(sys, "stdin", stdin)
+        ls.batch("svc", opts=ls.Global(mode="plain"))
+
+        # 7 lines, batch size 3 → 3 batches (3, 3, 1)
+        batch_sizes = [len(json.loads(r.content)["logs"]) for r in t.requests]
+        assert batch_sizes == [3, 3, 1]
+
+    def test_hostname_fallback(self, monkeypatch):
+        """When source lacks host field, machine hostname is used."""
+        t = FakeTransport([(200, {"ok": True})])
+        _patched_client(monkeypatch, t)
+        monkeypatch.setattr(ls, "_preflight", lambda *a, **k: None)
+
+        raw = {"timestamp": "2024-01-01T00:00:00.000Z", "level": "info", "message": "x"}
+        stdin = io.StringIO(json.dumps(raw) + "\n")
+        monkeypatch.setattr(sys, "stdin", stdin)
+
+        ls.batch("svc", opts=ls.Global(mode="metadata"))
+
+        logs = json.loads(t.requests[0].content)["logs"]
+        assert logs[0]["hostname"] == socket.gethostname()
+
+
+# -- _validate_service -------------------------------------------------
+
+
+class TestValidateService:
+    def test_happy_path(self):
+        ls._validate_service("backend")  # no raise
+
+    def test_empty_exits(self, diag_caplog):
+        with pytest.raises(SystemExit) as exc:
+            ls._validate_service("")
+        assert exc.value.code == 2
+        assert any(
+            "event=invalid_service" in r.getMessage() and "reason=empty" in r.getMessage()
+            for r in diag_caplog.records
+        )
+
+    def test_whitespace_only_exits(self):
+        with pytest.raises(SystemExit):
+            ls._validate_service("   ")
+
+    def test_too_long_exits(self, diag_caplog):
+        with pytest.raises(SystemExit):
+            ls._validate_service("x" * 129)
+        assert any("reason=too_long" in r.getMessage() for r in diag_caplog.records)
+
+    def test_boundary_128_ok(self):
+        ls._validate_service("x" * 128)
+
+    def test_control_char_exits(self, diag_caplog):
+        with pytest.raises(SystemExit):
+            ls._validate_service("bad\x00name")
+        assert any("reason=control_chars" in r.getMessage() for r in diag_caplog.records)
+
+    def test_newline_rejected(self):
+        with pytest.raises(SystemExit):
+            ls._validate_service("bad\nname")
+
+
+# -- _validate_url -----------------------------------------------------
+
+
+class TestValidateUrl:
+    def test_happy_http(self):
+        ls._validate_url("http://x")
+
+    def test_happy_https_with_port_and_path(self):
+        ls._validate_url("https://x:8080/path")
+
+    def test_bare_token_exits(self, diag_caplog):
+        with pytest.raises(SystemExit) as exc:
+            ls._validate_url("foo")
+        assert exc.value.code == 2
+        msgs = " ".join(r.getMessage() for r in diag_caplog.records)
+        assert "event=invalid_url" in msgs
+
+    def test_ftp_scheme_exits(self, diag_caplog):
+        with pytest.raises(SystemExit):
+            ls._validate_url("ftp://x")
+        assert any("reason=bad_scheme" in r.getMessage() for r in diag_caplog.records)
+
+    def test_missing_host_exits(self, diag_caplog):
+        with pytest.raises(SystemExit):
+            ls._validate_url("http://")
+        assert any("reason=missing_host" in r.getMessage() for r in diag_caplog.records)
+
+    def test_preflight_invokes_url_validation(self, monkeypatch, diag_caplog):
+        monkeypatch.setattr(ls, "LOGTIDE_URL", "ftp://nope")
+        with pytest.raises(SystemExit):
+            ls._preflight("follow", "svc", "json")
+        assert any("event=invalid_url" in r.getMessage() for r in diag_caplog.records)
+
+
+# -- _kv logfmt helper --------------------------------------------------
+
+
+class TestKvHelper:
+    def test_plain_values(self):
+        assert ls._kv(a="1", b="2") == "a=1 b=2"
+
+    def test_none_skipped(self):
+        assert ls._kv(a="1", b=None, c="3") == "a=1 c=3"
+
+    def test_quotes_spaces(self):
+        assert ls._kv(msg="hello world") == 'msg="hello world"'
+
+    def test_quotes_equals(self):
+        assert ls._kv(x="a=b") == 'x="a=b"'
+
+    def test_escapes_embedded_quote(self):
+        out = ls._kv(x='say "hi"')
+        assert out == 'x="say \\"hi\\""'
+
+    def test_newline_passthrough(self):
+        # _kv now escapes control chars including \n and quotes the value.
+        out = ls._kv(x="line1\nline2")
+        assert out == 'x="line1\\nline2"'
+        # No actual newline survives into the logfmt output.
+        assert "\n" not in out
+
+    def test_control_char_newline_escaped(self):
+        out = ls._kv(x="a\nb")
+        assert out == 'x="a\\nb"'
+
+    def test_control_char_cr_escaped(self):
+        out = ls._kv(x="a\rb")
+        assert out == 'x="a\\rb"'
+
+    def test_control_char_tab_escaped(self):
+        out = ls._kv(x="a\tb")
+        assert out == 'x="a\\tb"'
+
+    def test_raw_low_control_char_hex_escaped(self):
+        out = ls._kv(x="a\x01b")
+        assert out == 'x="a\\x01b"'
+
+    def test_del_char_hex_escaped(self):
+        out = ls._kv(x="a\x7fb")
+        assert out == 'x="a\\x7fb"'
+
+    def test_no_double_escape_literal_backslash_n(self):
+        # Python source "foo\\n" is 4 chars: f, o, o, backslash, n (actually
+        # 5 with the 'n'). There is no control char and no space/quote/=,
+        # so _kv neither quotes nor backslash-doubles. Output stays literal.
+        out = ls._kv(x="foo\\n")
+        assert out == "x=foo\\n"
+        # And specifically: no real newline character survived.
+        assert "\n" not in out
+
+    def test_no_double_escape_when_control_and_backslash_coexist(self):
+        # Literal backslash+'n' AND a real newline in same value.
+        # Doubling runs first: "\\" -> "\\\\"; then ctrl escape turns \n into "\\n".
+        out = ls._kv(x="foo\\n\nbar")
+        assert out == 'x="foo\\\\n\\nbar"'
+
+    def test_space_regression_not_hex_escaped(self):
+        # Regression: space must NOT be treated as a control char.
+        assert ls._kv(msg="foo bar") == 'msg="foo bar"'
+        assert "\\x20" not in ls._kv(msg="foo bar")
+
+
+# -- follow queue_full backpressure ------------------------------------
+
+
+class TestFollowDropOldest:
+    """Follow's producer must never block. When the queue saturates it
+    evicts the oldest line (drop-oldest) and keeps accepting new input.
+    """
+
+    def _install_nondraining_shipper(self, monkeypatch):
+        """Install a _shipper stub that leaves whatever is in the queue
+        alone until it sees the shutdown sentinel — so drop-oldest is
+        the only way the queue can make room."""
+        def fake_shipper(q, *a, **k):
+            # Wait for shutdown sentinel only. Don't drain data items.
+            while True:
+                item = q.get()
+                if item is None:
+                    return
+                # Put it back — we want to observe retained items.
+                # But we can't easily "peek", so instead: drain *after*
+                # sentinel seen. Store items on the function itself.
+        # Simpler: no-op shipper that just blocks on sentinel.
+        def noop_shipper(q, *a, **k):
+            while q.get() is not None:
+                pass
+        monkeypatch.setattr(ls, "_shipper", noop_shipper)
+
+    def test_drop_oldest_keeps_newest(self, monkeypatch, diag_caplog):
+        monkeypatch.setattr(ls, "_preflight", lambda *a, **k: None)
+        monkeypatch.setattr(ls, "_QUEUE_MAXSIZE", 4)
+        monkeypatch.setattr(ls, "_DROP_REPORT_INTERVAL", 2)
+        # Disable recovery entirely for this test (threshold=0 means qsize
+        # can never go below it, so queue_recovered never fires).
+        monkeypatch.setattr(ls, "_QUEUE_RECOVERY_THRESHOLD", 0)
+
+        observed = {}
+
+        # Queue subclass that:
+        #  - still honors maxsize (so drop-oldest fires)
+        #  - lets the shutdown sentinel (None) bypass the bound so the
+        #    main thread's `queue.put(None)` never blocks
+        #  - captures a snapshot of retained data items when the sentinel
+        #    is observed, so we can verify newest-retained semantics
+        class SnapshotQueue(queue_mod.Queue):
+            def put(self, item, block=True, timeout=None):
+                if item is None:
+                    with self.mutex:
+                        observed["snapshot"] = [
+                            x for x in list(self.queue) if x is not None
+                        ]
+                    return  # swallow sentinel — shipper stub will just exit
+                return super().put(item, block=block, timeout=timeout)
+
+        monkeypatch.setattr(ls, "Queue", SnapshotQueue)
+
+        # Non-draining shipper: exits immediately. The queue will be
+        # abandoned (daemon thread dies with test), but the snapshot
+        # captured in SnapshotQueue.put is what we assert against.
+        def nondraining_shipper(q, *a, **k):
+            return
+
+        monkeypatch.setattr(ls, "_shipper", nondraining_shipper)
+
+        # Feed 4 (maxsize) + 3 (overflow).
+        n_max, overflow = 4, 3
+        lines = [f"line{i}" for i in range(n_max + overflow)]
+        stdin = io.StringIO("\n".join(lines) + "\n")
+        monkeypatch.setattr(sys, "stdin", stdin)
+
+        ls.follow("svc", opts=ls.Global(mode="plain"))
+
+        snapshot = observed.get("snapshot", [])
+        # Queue held maxsize data items; the oldest `overflow` were evicted.
+        assert len(snapshot) == n_max
+        assert snapshot == lines[overflow:], (
+            f"expected newest items retained, got {snapshot}"
+        )
+
+        msgs = [r.getMessage() for r in diag_caplog.records]
+        full = [m for m in msgs if "event=queue_full" in m]
+        dropped_events = [m for m in msgs if "event=queue_dropped" in m]
+
+        # queue_full fires exactly once per saturation episode.
+        assert len(full) == 1, full
+        assert "action=drop_oldest" in full[0]
+        # With _DROP_REPORT_INTERVAL=2 and 3 drops, queue_dropped fires
+        # at count=2 (count=3 is below the next threshold).
+        assert len(dropped_events) == 1
+        assert "count=2" in dropped_events[0]
+
+    def test_queue_recovered_resets_counters(self, monkeypatch, diag_caplog):
+        """After saturation, once qsize drops below the recovery threshold
+        and a new line is enqueued, queue_recovered reports dropped_total
+        and the warn-once flag resets."""
+        monkeypatch.setattr(ls, "_preflight", lambda *a, **k: None)
+        monkeypatch.setattr(ls, "_QUEUE_MAXSIZE", 3)
+        monkeypatch.setattr(ls, "_DROP_REPORT_INTERVAL", 1000)
+        monkeypatch.setattr(ls, "_QUEUE_RECOVERY_THRESHOLD", 2)
+
+        drain_event = threading.Event()
+
+        class RecoveryQueue(queue_mod.Queue):
+            """Queue that lets the shutdown sentinel bypass maxsize and
+            drains all data items when the test signals it's time."""
+
+            def put(self, item, block=True, timeout=None):
+                if item is None:
+                    return  # swallow sentinel; shipper stub exits on its own
+                return super().put(item, block=block, timeout=timeout)
+
+        monkeypatch.setattr(ls, "Queue", RecoveryQueue)
+
+        def draining_shipper(q, *a, **k):
+            drain_event.wait(timeout=5)
+            # Drain everything so qsize drops to 0 (below threshold=2).
+            while True:
+                try:
+                    q.get_nowait()
+                except queue_mod.Empty:
+                    return
+
+        monkeypatch.setattr(ls, "_shipper", draining_shipper)
+
+        # Stdin: yield 5 lines (3 fit, 2 dropped), then signal drain,
+        # then yield one more line that should trigger recovery.
+        class StagedStdin:
+            def __init__(self):
+                self.phase = 0
+
+            def __iter__(self):
+                return self
+
+            def __next__(self):
+                if self.phase < 5:
+                    self.phase += 1
+                    return f"burst{self.phase}\n"
+                if self.phase == 5:
+                    drain_event.set()
+                    # Give shipper a beat to drain before the next put.
+                    time.sleep(0.1)
+                    self.phase = 6
+                    return "post_recovery\n"
+                raise StopIteration
+
+        monkeypatch.setattr(sys, "stdin", StagedStdin())
+
+        ls.follow("svc", opts=ls.Global(mode="plain"))
+
+        msgs = [r.getMessage() for r in diag_caplog.records]
+        full = [m for m in msgs if "event=queue_full" in m]
+        recovered = [m for m in msgs if "event=queue_recovered" in m]
+        assert len(full) == 1, full
+        assert len(recovered) == 1, recovered
+        # 5 lines, maxsize 3 → 2 drops before recovery.
+        assert "dropped_total=2" in recovered[0]
+
+
+# -- send_retry structured event ---------------------------------------
+
+
+class TestSendRetryEvent:
+    def test_retry_event_logged(self, monkeypatch, diag_caplog):
+        monkeypatch.setattr(ls.time, "sleep", lambda _s: None)
+        t = FakeTransport([(500, {"err": "x"}), (200, {"ok": True})])
+        _patched_client(monkeypatch, t)
+        with httpx.Client() as c:
+            ls._send_batch(c, [{"message": "hi"}])
+        msgs = " ".join(r.getMessage() for r in diag_caplog.records)
+        assert "event=send_retry" in msgs
+        assert "status=500" in msgs

--- a/scripts/update-file-headers.rb
+++ b/scripts/update-file-headers.rb
@@ -242,7 +242,7 @@ class HeaderValidator
     idx = start
     while idx < lines.length
       line = lines[idx].strip
-      break unless line.empty? || (line.start_with?('#') && !line.start_with?('#!') && idx == start)
+      break unless line.empty? || (line.start_with?('#') && !line.start_with?('#!') && idx < start + 4)
 
       idx += 1
     end

--- a/scripts/update-file-headers.rb
+++ b/scripts/update-file-headers.rb
@@ -175,7 +175,7 @@ class HeaderValidator
 
   def fix_ruby_header(full_path, relative_path, lines)
     has_shebang = lines[0]&.start_with?('#!')
-    content_start = find_ruby_content_start(lines, has_shebang ? 1 : 0)
+    content_start = find_ruby_content_start(lines, relative_path, has_shebang ? 1 : 0)
     content = lines[content_start..].join
 
     prefix = has_shebang ? lines[0] : ''
@@ -184,17 +184,23 @@ class HeaderValidator
     @fixed << relative_path
   end
 
-  def find_ruby_content_start(lines, start = 0)
+  # Only consume lines that are part of the existing file-path header:
+  #   - the exact path-header line (`# <relative_path>`)
+  #   - an immediately following `#` separator line
+  #   - an immediately following `# frozen_string_literal: true`
+  #   - a single trailing blank line
+  # Any other leading comment (license, rubocop directive, author credit)
+  # is preserved as content.
+  def find_ruby_content_start(lines, relative_path, start = 0)
     idx = start
-    while idx < lines.length
-      line = lines[idx].strip
-      break unless line.empty? ||
-                   line == '#' ||
-                   line.start_with?('# frozen_string_literal') ||
-                   (line.start_with?('#') && !line.start_with?('##') && idx < start + 4)
+    header_line = "# #{relative_path}"
 
+    if lines[idx]&.strip == header_line
       idx += 1
+      idx += 1 if lines[idx]&.strip == '#'
+      idx += 1 if lines[idx]&.strip == '# frozen_string_literal: true'
     end
+    idx += 1 if lines[idx]&.strip == ''
     idx
   end
 
@@ -229,7 +235,7 @@ class HeaderValidator
 
   def fix_python_header(full_path, relative_path, lines)
     has_shebang = lines[0]&.start_with?('#!')
-    content_start = find_python_content_start(lines, has_shebang ? 1 : 0)
+    content_start = find_python_content_start(lines, relative_path, has_shebang ? 1 : 0)
     content = lines[content_start..].join
 
     prefix = has_shebang ? lines[0] : ''
@@ -238,14 +244,12 @@ class HeaderValidator
     @fixed << relative_path
   end
 
-  def find_python_content_start(lines, start = 0)
+  # Only consume the exact file-path header line plus one trailing blank.
+  # Preserves encoding cookies, license stubs, module docstrings.
+  def find_python_content_start(lines, relative_path, start = 0)
     idx = start
-    while idx < lines.length
-      line = lines[idx].strip
-      break unless line.empty? || (line.start_with?('#') && !line.start_with?('#!') && idx < start + 4)
-
-      idx += 1
-    end
+    idx += 1 if lines[idx]&.strip == "# #{relative_path}"
+    idx += 1 if lines[idx]&.strip == ''
     idx
   end
 

--- a/scripts/update-file-headers.rb
+++ b/scripts/update-file-headers.rb
@@ -3,7 +3,7 @@
 #
 # frozen_string_literal: true
 
-# Validates that all Ruby, TypeScript, and Vue files have correct header format
+# Validates that all Ruby, Python, TypeScript, and Vue files have correct header format
 #
 # Usage:
 #   ruby scripts/update-file-headers.rb
@@ -21,6 +21,9 @@
 #
 # TypeScript files:
 #   // path/to/file.ts
+#
+# Python files:
+#   # path/to/file.py
 #
 # Vue files:
 #   <!-- path/to/file.vue -->
@@ -46,6 +49,7 @@ class HeaderValidator
     puts
 
     validate_ruby_files
+    validate_python_files
     validate_typescript_files
     validate_vue_files
 
@@ -62,7 +66,7 @@ class HeaderValidator
         full_path = REPO_ROOT / path
         if full_path.directory?
           # Path is a directory - search within it
-          Dir.glob(File.join(path, '**/*.{rb,ts,vue}'), base: REPO_ROOT)
+          Dir.glob(File.join(path, '**/*.{rb,py,ts,vue}'), base: REPO_ROOT)
              .select { |f| File.fnmatch?(pattern, f, File::FNM_PATHNAME) }
         else
           # Path is a glob or file pattern
@@ -84,6 +88,20 @@ class HeaderValidator
 
       @files_found += 1
       validate_ruby_header(full_path, file_path)
+    end
+  end
+
+  def validate_python_files
+    puts 'Checking Python files...'
+
+    files_for_glob('**/*.py').each do |file_path|
+      next if skip_file?(file_path)
+
+      full_path = REPO_ROOT / file_path
+      next unless full_path.file?
+
+      @files_found += 1
+      validate_python_header(full_path, file_path)
     end
   end
 
@@ -119,35 +137,31 @@ class HeaderValidator
     lines = File.readlines(full_path)
     return if lines.empty?
 
-    # Skip files with shebangs
-    return if lines[0].start_with?('#!')
+    # Shebang files have the header after the shebang line
+    offset = lines[0].start_with?('#!') ? 1 : 0
 
-    # Expected header:
-    # Line 1: # path/to/file.rb
-    # Line 2: #
-    # Line 3: # frozen_string_literal: true
-    # Line 4: (blank)
+    # Expected header (at offset):
+    # # path/to/file.rb
+    # #
+    # # frozen_string_literal: true
+    # (blank)
 
     errors = []
 
-    # Check line 1: filename comment
-    unless lines[0]&.strip == "# #{relative_path}"
-      errors << "Line 1: Expected '# #{relative_path}', got: #{lines[0]&.strip.inspect}"
+    unless lines[offset]&.strip == "# #{relative_path}"
+      errors << "Line #{offset + 1}: Expected '# #{relative_path}', got: #{lines[offset]&.strip.inspect}"
     end
 
-    # Check line 2: empty comment
-    unless lines[1]&.strip == '#'
-      errors << "Line 2: Expected '#', got: #{lines[1]&.strip.inspect}"
+    unless lines[offset + 1]&.strip == '#'
+      errors << "Line #{offset + 2}: Expected '#', got: #{lines[offset + 1]&.strip.inspect}"
     end
 
-    # Check line 3: frozen pragma
-    unless lines[2]&.strip == '# frozen_string_literal: true'
-      errors << "Line 3: Expected '# frozen_string_literal: true', got: #{lines[2]&.strip.inspect}"
+    unless lines[offset + 2]&.strip == '# frozen_string_literal: true'
+      errors << "Line #{offset + 3}: Expected '# frozen_string_literal: true', got: #{lines[offset + 2]&.strip.inspect}"
     end
 
-    # Check line 4: blank line
-    unless lines[3]&.strip == ''
-      errors << "Line 4: Expected blank line, got: #{lines[3]&.strip.inspect}"
+    unless lines[offset + 3]&.strip == ''
+      errors << "Line #{offset + 4}: Expected blank line, got: #{lines[offset + 3]&.strip.inspect}"
     end
 
     if errors.any?
@@ -160,24 +174,75 @@ class HeaderValidator
   end
 
   def fix_ruby_header(full_path, relative_path, lines)
-    # Find where original content starts (skip existing header attempts)
-    content_start = find_ruby_content_start(lines)
+    has_shebang = lines[0]&.start_with?('#!')
+    content_start = find_ruby_content_start(lines, has_shebang ? 1 : 0)
     content = lines[content_start..].join
 
+    prefix = has_shebang ? lines[0] : ''
     new_header = "# #{relative_path}\n#\n# frozen_string_literal: true\n\n"
-    File.write(full_path, new_header + content)
+    File.write(full_path, prefix + new_header + content)
     @fixed << relative_path
   end
 
-  def find_ruby_content_start(lines)
-    # Skip lines that look like header comments or frozen_string_literal
-    idx = 0
+  def find_ruby_content_start(lines, start = 0)
+    idx = start
     while idx < lines.length
       line = lines[idx].strip
       break unless line.empty? ||
                    line == '#' ||
                    line.start_with?('# frozen_string_literal') ||
-                   (line.start_with?('#') && !line.start_with?('##') && idx < 4)
+                   (line.start_with?('#') && !line.start_with?('##') && idx < start + 4)
+
+      idx += 1
+    end
+    idx
+  end
+
+  def validate_python_header(full_path, relative_path)
+    lines = File.readlines(full_path)
+    return if lines.empty?
+
+    offset = lines[0].start_with?('#!') ? 1 : 0
+
+    # Expected header (at offset):
+    # # path/to/file.py
+    # (blank)
+
+    errors = []
+
+    unless lines[offset]&.strip == "# #{relative_path}"
+      errors << "Line #{offset + 1}: Expected '# #{relative_path}', got: #{lines[offset]&.strip.inspect}"
+    end
+
+    unless lines[offset + 1]&.strip == ''
+      errors << "Line #{offset + 2}: Expected blank line, got: #{lines[offset + 1]&.strip.inspect}"
+    end
+
+    if errors.any?
+      if @fix
+        fix_python_header(full_path, relative_path, lines)
+      else
+        @errors << { file: relative_path, issues: errors }
+      end
+    end
+  end
+
+  def fix_python_header(full_path, relative_path, lines)
+    has_shebang = lines[0]&.start_with?('#!')
+    content_start = find_python_content_start(lines, has_shebang ? 1 : 0)
+    content = lines[content_start..].join
+
+    prefix = has_shebang ? lines[0] : ''
+    new_header = "# #{relative_path}\n\n"
+    File.write(full_path, prefix + new_header + content)
+    @fixed << relative_path
+  end
+
+  def find_python_content_start(lines, start = 0)
+    idx = start
+    while idx < lines.length
+      line = lines[idx].strip
+      break unless line.empty? || (line.start_with?('#') && !line.start_with?('#!') && idx == start)
 
       idx += 1
     end
@@ -188,23 +253,20 @@ class HeaderValidator
     lines = File.readlines(full_path)
     return if lines.empty?
 
-    # Skip files with shebangs (executable scripts)
-    return if lines[0].start_with?('#!')
+    offset = lines[0].start_with?('#!') ? 1 : 0
 
-    # Expected header:
-    # Line 1: // path/to/file.ts
-    # Line 2: (blank)
+    # Expected header (at offset):
+    # // path/to/file.ts
+    # (blank)
 
     errors = []
 
-    # Check line 1: filename comment
-    unless lines[0]&.strip == "// #{relative_path}"
-      errors << "Line 1: Expected '// #{relative_path}', got: #{lines[0]&.strip.inspect}"
+    unless lines[offset]&.strip == "// #{relative_path}"
+      errors << "Line #{offset + 1}: Expected '// #{relative_path}', got: #{lines[offset]&.strip.inspect}"
     end
 
-    # Check line 2: blank line
-    unless lines[1]&.strip == ''
-      errors << "Line 2: Expected blank line, got: #{lines[1]&.strip.inspect}"
+    unless lines[offset + 1]&.strip == ''
+      errors << "Line #{offset + 2}: Expected blank line, got: #{lines[offset + 1]&.strip.inspect}"
     end
 
     if errors.any?
@@ -217,20 +279,21 @@ class HeaderValidator
   end
 
   def fix_typescript_header(full_path, relative_path, lines)
-    content_start = find_typescript_content_start(lines)
+    has_shebang = lines[0]&.start_with?('#!')
+    content_start = find_typescript_content_start(lines, has_shebang ? 1 : 0)
     content = lines[content_start..].join
 
+    prefix = has_shebang ? lines[0] : ''
     new_header = "// #{relative_path}\n\n"
-    File.write(full_path, new_header + content)
+    File.write(full_path, prefix + new_header + content)
     @fixed << relative_path
   end
 
-  def find_typescript_content_start(lines)
-    idx = 0
+  def find_typescript_content_start(lines, start = 0)
+    idx = start
     while idx < lines.length
       line = lines[idx].strip
-      # Skip empty lines and single-line path comments at the start
-      break unless line.empty? || (line.start_with?('//') && idx == 0)
+      break unless line.empty? || (line.start_with?('//') && idx == start)
 
       idx += 1
     end
@@ -241,20 +304,20 @@ class HeaderValidator
     lines = File.readlines(full_path)
     return if lines.empty?
 
-    # Expected header:
-    # Line 1: <!-- path/to/file.vue -->
-    # Line 2: (blank)
+    offset = lines[0].start_with?('#!') ? 1 : 0
+
+    # Expected header (at offset):
+    # <!-- path/to/file.vue -->
+    # (blank)
 
     errors = []
 
-    # Check line 1: filename comment
-    unless lines[0]&.strip == "<!-- #{relative_path} -->"
-      errors << "Line 1: Expected '<!-- #{relative_path} -->', got: #{lines[0]&.strip.inspect}"
+    unless lines[offset]&.strip == "<!-- #{relative_path} -->"
+      errors << "Line #{offset + 1}: Expected '<!-- #{relative_path} -->', got: #{lines[offset]&.strip.inspect}"
     end
 
-    # Check line 2: blank line
-    unless lines[1]&.strip == ''
-      errors << "Line 2: Expected blank line, got: #{lines[1]&.strip.inspect}"
+    unless lines[offset + 1]&.strip == ''
+      errors << "Line #{offset + 2}: Expected blank line, got: #{lines[offset + 1]&.strip.inspect}"
     end
 
     if errors.any?
@@ -267,20 +330,21 @@ class HeaderValidator
   end
 
   def fix_vue_header(full_path, relative_path, lines)
-    content_start = find_vue_content_start(lines)
+    has_shebang = lines[0]&.start_with?('#!')
+    content_start = find_vue_content_start(lines, has_shebang ? 1 : 0)
     content = lines[content_start..].join
 
+    prefix = has_shebang ? lines[0] : ''
     new_header = "<!-- #{relative_path} -->\n\n"
-    File.write(full_path, new_header + content)
+    File.write(full_path, prefix + new_header + content)
     @fixed << relative_path
   end
 
-  def find_vue_content_start(lines)
-    idx = 0
+  def find_vue_content_start(lines, start = 0)
+    idx = start
     while idx < lines.length
       line = lines[idx].strip
-      # Skip empty lines and HTML comment headers at the start
-      break unless line.empty? || (line.start_with?('<!--') && line.end_with?('-->') && idx == 0)
+      break unless line.empty? || (line.start_with?('<!--') && line.end_with?('-->') && idx == start)
 
       idx += 1
     end
@@ -291,7 +355,9 @@ class HeaderValidator
     path.include?('node_modules/') ||
       path.include?('.git/') ||
       path.include?('vendor/') ||
-      path.include?('tmp/')
+      path.include?('tmp/') ||
+      path.include?('__pycache__/') ||
+      path.include?('.venv/')
   end
 
   def report_results

--- a/try/scripts/update_file_headers_try.rb
+++ b/try/scripts/update_file_headers_try.rb
@@ -1,0 +1,196 @@
+# try/scripts/update_file_headers_try.rb
+#
+# frozen_string_literal: true
+
+# Tests for scripts/update-file-headers.rb --fix mode.
+#
+# The script hardcodes REPO_ROOT via __dir__ and calls exit, so we shell out
+# to it from an isolated tempdir. Fixtures are staged under the tempdir, the
+# script is copied into <tempdir>/scripts/ so its REPO_ROOT resolves there,
+# and we invoke it with --fix <relative_path> for each case.
+#
+# Verifies post-fix behavior for PR #2953 follow-ups: positional header
+# detection (Ruby + Python) preserves license stubs, rubocop directives,
+# encoding cookies, magic comments, and docstrings.
+
+require 'tmpdir'
+require 'fileutils'
+require 'open3'
+require 'pathname'
+
+SCRIPT_SRC = File.expand_path('../../scripts/update-file-headers.rb', __dir__)
+
+# Stage the script into a temp "repo" so REPO_ROOT = tmpdir.
+# Returns [tmpdir_path, script_path_in_tmpdir].
+def stage_repo
+  tmp = Dir.mktmpdir('uhdr_')
+  FileUtils.mkdir_p(File.join(tmp, 'scripts'))
+  script = File.join(tmp, 'scripts', 'update-file-headers.rb')
+  FileUtils.cp(SCRIPT_SRC, script)
+  [tmp, script]
+end
+
+def run_fix(tmpdir, script, relative_path)
+  Open3.capture3('ruby', script, '--fix', relative_path, chdir: tmpdir)
+end
+
+def run_check(tmpdir, script, relative_path)
+  Open3.capture3('ruby', script, relative_path, chdir: tmpdir)
+end
+
+def write_file(tmpdir, relpath, content)
+  full = File.join(tmpdir, relpath)
+  FileUtils.mkdir_p(File.dirname(full))
+  File.write(full, content)
+  full
+end
+
+def read_file(tmpdir, relpath)
+  File.read(File.join(tmpdir, relpath))
+end
+
+## Ruby file with frozen_string_literal magic comment is left intact
+@tmp, @script = stage_repo
+write_file(@tmp, 'lib/example.rb', <<~RB)
+  # lib/example.rb
+  # frozen_string_literal: true
+
+  class Example; end
+RB
+_, _, @status = run_fix(@tmp, @script, 'lib/example.rb')
+@out = read_file(@tmp, 'lib/example.rb')
+@out.include?('# frozen_string_literal: true') &&
+  @out.include?('class Example; end') &&
+  @out.start_with?("# lib/example.rb\n#\n# frozen_string_literal: true\n\n")
+#=> true
+
+## Ruby file with rubocop directives preserved
+@tmp, @script = stage_repo
+write_file(@tmp, 'lib/rubo.rb', <<~RB)
+  # lib/rubo.rb
+  # rubocop:disable Style/Documentation
+  # rubocop:disable Metrics/ClassLength
+
+  class Rubo; end
+RB
+run_fix(@tmp, @script, 'lib/rubo.rb')
+@out = read_file(@tmp, 'lib/rubo.rb')
+[@out.include?('rubocop:disable Style/Documentation'),
+ @out.include?('rubocop:disable Metrics/ClassLength'),
+ @out.start_with?("# lib/rubo.rb\n#\n# frozen_string_literal: true\n\n")]
+#=> [true, true, true]
+
+## Ruby file with a multi-line license stub is preserved below the header
+@tmp, @script = stage_repo
+write_file(@tmp, 'lib/lic.rb', <<~RB)
+  # lib/lic.rb
+  # Copyright 2026 Example Corp.
+  # Licensed under the MIT License.
+  # See LICENSE.txt for details.
+  # Author: J. Doe
+
+  module Lic; end
+RB
+run_fix(@tmp, @script, 'lib/lic.rb')
+@out = read_file(@tmp, 'lib/lic.rb')
+[@out.include?('Copyright 2026 Example Corp.'),
+ @out.include?('Licensed under the MIT License.'),
+ @out.include?('Author: J. Doe'),
+ @out.start_with?("# lib/lic.rb\n#\n# frozen_string_literal: true\n\n")]
+#=> [true, true, true, true]
+
+## Python file with encoding cookie is preserved
+@tmp, @script = stage_repo
+write_file(@tmp, 'py/enc.py', <<~PY)
+  # py/enc.py
+  # -*- coding: utf-8 -*-
+  x = 1
+PY
+run_fix(@tmp, @script, 'py/enc.py')
+@out = read_file(@tmp, 'py/enc.py')
+[@out.include?('# -*- coding: utf-8 -*-'),
+ @out.include?('x = 1'),
+ @out.start_with?("# py/enc.py\n\n")]
+#=> [true, true, true]
+
+## Python file with module docstring is preserved
+@tmp, @script = stage_repo
+write_file(@tmp, 'py/doc.py', <<~PY)
+  # py/doc.py
+  """Module docstring.
+
+  More details here.
+  """
+
+  def main():
+      pass
+PY
+run_fix(@tmp, @script, 'py/doc.py')
+@out = read_file(@tmp, 'py/doc.py')
+[@out.include?('"""Module docstring.'),
+ @out.include?('More details here.'),
+ @out.include?('def main():'),
+ @out.start_with?("# py/doc.py\n\n")]
+#=> [true, true, true, true]
+
+## Already-conformant Ruby file is a byte-identical no-op under --fix
+@tmp, @script = stage_repo
+@content = "# lib/ok.rb\n#\n# frozen_string_literal: true\n\nclass Ok; end\n"
+write_file(@tmp, 'lib/ok.rb', @content)
+run_fix(@tmp, @script, 'lib/ok.rb')
+read_file(@tmp, 'lib/ok.rb') == @content
+#=> true
+
+## Already-conformant Ruby file passes check mode
+@tmp, @script = stage_repo
+write_file(@tmp, 'lib/ok.rb', "# lib/ok.rb\n#\n# frozen_string_literal: true\n\nclass Ok; end\n")
+@stdout, _err, @status = run_check(@tmp, @script, 'lib/ok.rb')
+[@status.exitstatus, @stdout.include?('All file headers are valid')]
+#=> [0, true]
+
+## Ruby file with shebang keeps shebang on line 1, header on line 2
+@tmp, @script = stage_repo
+write_file(@tmp, 'bin/cli.rb', <<~RB)
+  #!/usr/bin/env ruby
+  # bin/cli.rb
+  # frozen_string_literal: true
+
+  puts 'hi'
+RB
+run_fix(@tmp, @script, 'bin/cli.rb')
+@out = read_file(@tmp, 'bin/cli.rb')
+[@out.start_with?("#!/usr/bin/env ruby\n# bin/cli.rb\n#\n# frozen_string_literal: true\n\n"),
+ @out.include?("puts 'hi'")]
+#=> [true, true]
+
+## File missing header entirely gets one added, content preserved
+@tmp, @script = stage_repo
+write_file(@tmp, 'lib/bare.rb', "class Bare\n  def foo; end\nend\n")
+run_fix(@tmp, @script, 'lib/bare.rb')
+@out = read_file(@tmp, 'lib/bare.rb')
+[@out.start_with?("# lib/bare.rb\n#\n# frozen_string_literal: true\n\n"),
+ @out.include?('class Bare'),
+ @out.include?('def foo; end')]
+#=> [true, true, true]
+
+## Caveat: stale wrong-path header is preserved as content (post-fix behavior)
+# After a rename, an old `# old/path.rb` header in a file whose actual path
+# is `new/path.rb` no longer matches the positional pattern, so the positional
+# matcher leaves it alone and it is preserved as content. The new correct
+# header is prepended above it.
+@tmp, @script = stage_repo
+write_file(@tmp, 'new/path.rb', <<~RB)
+  # old/path.rb
+  # frozen_string_literal: true
+
+  class Renamed; end
+RB
+run_fix(@tmp, @script, 'new/path.rb')
+@out = read_file(@tmp, 'new/path.rb')
+[@out.start_with?("# new/path.rb\n#\n# frozen_string_literal: true\n\n"),
+ @out.include?('# old/path.rb'),
+ @out.include?('class Renamed; end')]
+#=> [true, true, true]
+
+# Teardown
+FileUtils.remove_entry(@tmp) if @tmp && File.directory?(@tmp)


### PR DESCRIPTION
## Summary

- Adds `scripts/logtide-ship.py`, a stdin-to-LogTide HTTP ingest tool with four parsing modes (plain, metadata, json, caddy), batched shipping, structured diagnostic logging, preflight auth check, header/service/URL validators, and drop-oldest backpressure. Covered by `scripts/tests/test_logtide_ship.py` (~900 lines).
- Adds hivemind as an alternative process manager in `bin/dev` alongside the existing runner.
- Extends `scripts/update-file-headers.rb` to handle Python files and hashbang lines, with new Tryouts coverage in `try/scripts/update_file_headers_try.rb`.

## Test plan

- [ ] `python scripts/tests/test_logtide_ship.py` (or via pytest) passes
- [ ] `scripts/logtide-ship.py follow --mode plain` ships stdin lines to a local LogTide instance
- [ ] `scripts/logtide-ship.py follow --mode caddy` parses a Caddy access log line and converts Unix epoch timestamps correctly
- [ ] Preflight exits on 401/403 and warns on connection errors
- [ ] `bin/dev` starts successfully under hivemind
- [ ] `bundle exec try try/scripts/update_file_headers_try.rb --agent` passes