### PR TITLE
Re-enable multi-arch builds for linux/arm64

### DIFF
--- a/.github/workflows/build-and-publish-oci-images.yml
+++ b/.github/workflows/build-and-publish-oci-images.yml
@@ -68,12 +68,11 @@ on:
         type: choice
         description: 'Target platforms'
         required: false
-        # default: 'linux/amd64,linux/arm64'
-        default: 'linux/amd64'
+        default: 'linux/amd64,linux/arm64'
         options:
           - ''
-          - 'linux/amd64'
           - 'linux/amd64,linux/arm64'
+          - 'linux/amd64'
           - 'linux/arm64'
 
 permissions:
@@ -188,7 +187,7 @@ jobs:
       - name: Setup Docker buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
         with:
-          platforms: ${{ inputs.platforms || 'linux/amd64' }}
+          platforms: ${{ inputs.platforms || 'linux/amd64,linux/arm64' }}
 
       - name: Login to Docker Hub
         if: github.event_name != 'pull_request' && (inputs.registry_target || 'public') != 'custom'
@@ -219,7 +218,7 @@ jobs:
           IMAGE_TAG: ${{ steps.version.outputs.image_tag }}
           COMMIT_HASH: ${{ steps.commit.outputs.short_sha }}
           EXTRA_TAGS: ${{ steps.version.outputs.extra_tags }}
-          PLATFORMS: ${{ inputs.platforms || 'linux/amd64' }}
+          PLATFORMS: ${{ inputs.platforms || 'linux/amd64,linux/arm64' }}
           REGISTRY_MODE: ${{ inputs.registry_target || 'public' }}
           CUSTOM_REGISTRY: ${{ secrets.CUSTOM_REGISTRY_HOST }}
         run: |
@@ -237,7 +236,7 @@ jobs:
           IMAGE_TAG: ${{ steps.version.outputs.image_tag }}
           COMMIT_HASH: ${{ steps.commit.outputs.short_sha }}
           EXTRA_TAGS: ${{ steps.version.outputs.extra_tags }}
-          PLATFORMS: ${{ inputs.platforms || 'linux/amd64' }}
+          PLATFORMS: ${{ inputs.platforms || 'linux/amd64,linux/arm64' }}
           REGISTRY_MODE: ${{ inputs.registry_target || 'public' }}
           CUSTOM_REGISTRY: ${{ secrets.CUSTOM_REGISTRY_HOST }}
         with:
@@ -282,7 +281,7 @@ jobs:
 
       - name: Output build summary
         env:
-          BUILD_PLATFORMS: ${{ inputs.platforms || 'linux/amd64' }}
+          BUILD_PLATFORMS: ${{ inputs.platforms || 'linux/amd64,linux/arm64' }}
           BUILD_VERSION: ${{ steps.version.outputs.version }}
           BUILD_IMAGE_TAG: ${{ steps.version.outputs.image_tag }}
           BUILD_COMMIT: ${{ steps.commit.outputs.short_sha }}


### PR DESCRIPTION
Closes #2954

## Summary

- Restores `linux/amd64,linux/arm64` as the default platform across the OCI build workflow
- arm64 was temporarily disabled in cb85fc142 during active development on #2309 for quicker feedback cycles and was not re-enabled after that work wrapped up
- Updates five locations in the workflow where the platform fallback defaulted to `linux/amd64` only: the `workflow_dispatch` input default, `setup-buildx-action`, the audit step, the bake step, and the build summary step
- The QEMU setup step already had `platforms: arm64` throughout and needed no change

## Test plan

- [ ] Trigger a manual workflow dispatch and confirm both `linux/amd64` and `linux/arm64` manifests are published
- [ ] Verify the next release tag produces a multi-arch image inspectable via `docker manifest inspect`