### PR TITLE
Add URL scrubbing to Sentry before_send hook

### DIFF
--- a/lib/onetime/initializers/setup_diagnostics.rb
+++ b/lib/onetime/initializers/setup_diagnostics.rb
@@ -79,13 +79,20 @@ module Onetime
           # of sampled transactions.
           config.profiles_sample_rate = 0.1
 
-          # Add a before_send to filter out problematic events that might cause errors
+          # Add a before_send to filter out problematic events and scrub sensitive URLs
           config.before_send = ->(event, _hint) do
-            # Return nil if the event would cause errors in processing
-            if event.nil? || event.request.nil? || event.request.headers.nil?
+            # Return nil if the event would cause errors in processing.
+            # Don't filter on nil headers - background jobs and non-HTTP contexts
+            # may legitimately have nil headers but still have useful event data.
+            if event.nil? || event.request.nil?
               OT.ld '[init] Sentry: Filtering out event with nil components'
               return nil
             end
+
+            # Scrub sensitive URL paths and query parameters from event data.
+            # This covers both event.request.url and custom context set via
+            # scope.set_context('request', ...) in error handling middleware.
+            Onetime::Initializers::SetupDiagnostics.scrub_event_urls(event)
 
             # Return the event if it passes validation
             event
@@ -96,6 +103,184 @@ module Onetime
 
         # Set runtime state
         Onetime::Runtime.update_infrastructure(d9s_enabled: true)
+      end
+
+      class << self
+        # Distinguishes a verifiable identifier segment from a named path segment
+        # (e.g. `/secret/IDENTIFIER` vs `/receipt/recent`).
+        #
+        # A base-36 verifiable identifier is always exactly 62 characters
+        # (320 bits: 256-bit random + 64-bit HMAC tag), encoded with [0-9a-z].
+        # Named segments are never this length, so length alone is a reliable
+        # discriminant.
+        #
+        # Use {Familia::VerifiableIdentifier.plausible_identifier?} at route-matching
+        # time - it checks length and character set without performing HMAC verification:
+        #
+        #   segment = request.path.split('/').last
+        #   if Familia::VerifiableIdentifier.plausible_identifier?(segment)
+        #     # route to resource handler
+        #   else
+        #     # route to named action
+        #   end
+        #
+        # Use {Familia::VerifiableIdentifier.verified_identifier?} after routing, when
+        # the identifier is about to authorize an operation. It runs the plausibility
+        # check first, then verifies the embedded HMAC tag.
+        #
+        # For framework routers that require a pattern:
+        #
+        #   ID_LEN = Familia::SecureIdentifier.min_length_for_bits(320, 36) # => 62
+        #   /\A[0-9a-z]{#{ID_LEN}}\z/
+        #
+        # Legacy v0.23 identifiers were 31 chars (base36). The minimum length check
+        # (MIN_IDENTIFIER_LENGTH = 20) allows both formats while filtering out
+        # named paths like "burn" or "recent".
+        #
+        # @see src/router/index.ts for frontend scrubbing via route metadata
+
+        # Identifier length for v0.24+ VerifiableIdentifier (320 bits in base-36)
+        IDENTIFIER_LENGTH = 62
+
+        # Minimum identifier length to distinguish from named path segments.
+        # Legacy v0.23 identifiers are 31 chars; this allows both old and new.
+        MIN_IDENTIFIER_LENGTH = 20
+
+        # Scrub sensitive data from URLs in Sentry events
+        #
+        # Handles two URL locations:
+        # 1. event.request.url - Standard Sentry request data
+        # 2. event.contexts['request']['url'] - Custom context set by error middleware
+        #
+        # @param event [Sentry::Event] The event to scrub
+        # @return [Sentry::Event] The scrubbed event
+        def scrub_event_urls(event)
+          # Scrub standard request URL
+          if event.request&.url
+            original_url = event.request.url
+            scrubbed_url = scrub_url(original_url)
+            if scrubbed_url != original_url
+              event.request.url = scrubbed_url
+              OT.ld "[sentry] Scrubbed request.url: #{original_url} -> #{scrubbed_url}"
+            end
+          end
+
+          # Scrub custom request context URL (set via scope.set_context in error middleware)
+          if event.contexts.is_a?(Hash) &&
+             event.contexts['request'].is_a?(Hash) &&
+             event.contexts['request']['url']
+            original_url = event.contexts['request']['url']
+            scrubbed_url = scrub_url(original_url)
+            if scrubbed_url != original_url
+              event.contexts['request']['url'] = scrubbed_url
+              OT.ld "[sentry] Scrubbed contexts.request.url: #{original_url} -> #{scrubbed_url}"
+            end
+          end
+
+          event
+        rescue StandardError => ex
+          # Never let scrubbing errors prevent event capture
+          OT.ld "[sentry] URL scrubbing failed: #{ex.class} - #{ex.message}"
+          event
+        end
+
+        # Scrub sensitive path segments and query parameters from a URL
+        #
+        # Identifier paths (use MIN_IDENTIFIER_LENGTH discriminant):
+        # - /secret/:identifier, /receipt/:identifier - v0.24 (62 chars) or v0.23 (31 chars)
+        # - /private/:identifier, /metadata/:identifier - legacy aliases
+        # - /incoming/:identifier - incoming secret submissions
+        #
+        # Auth token paths (variable length, scrub any segment):
+        # - /forgot/:key, /auth/reset-password/:key, /account/email/confirm/:token
+        # - /l/:shortcode - short links (variable length)
+        #
+        # Admin paths:
+        # - /colonel/* - admin paths need full debugging context; scrub multi-segment
+        #
+        # @param url [String, nil] The URL to scrub
+        # @return [String, nil] The scrubbed URL or original if nil/malformed
+        def scrub_url(url)
+          return url if url.nil? || url.empty?
+
+          scrubbed = scrub_sensitive_paths(url)
+          scrub_sensitive_query_params(scrubbed)
+        rescue StandardError
+          # Return original URL if scrubbing fails
+          url
+        end
+
+        # Pattern for identifier paths - matches segments >= MIN_IDENTIFIER_LENGTH chars
+        # that look like base-36 identifiers (lowercase alphanumeric).
+        # This avoids false positives on named paths like /receipt/recent.
+        IDENTIFIER_PATH_PATTERN = %r{
+          (/(?:secret|receipt|private|metadata|incoming)/)([0-9a-z]{#{MIN_IDENTIFIER_LENGTH},})
+        }x
+
+        # Pattern for auth token and shortcode paths - these have variable-length
+        # tokens that should always be scrubbed regardless of length.
+        AUTH_TOKEN_PATH_PATTERN = %r{
+          (/(?:forgot|l)/)[^/?#]+                    |  # Password reset, shortcodes
+          (/auth/reset-password/)[^/?#]+            |  # Auth reset password
+          (/account/email/confirm/)[^/?#]+             # Email confirmation token
+        }x
+
+        # Pattern for colonel admin paths - multi-segment scrubbing
+        COLONEL_PATH_PATTERN = %r{(/colonel/)[^/?#]+(?:/[^/?#]+)*}x
+
+        # Query parameter names that contain sensitive data
+        SENSITIVE_QUERY_PARAMS = %w[key secret token passphrase].freeze
+
+        private
+
+        def scrub_sensitive_paths(url)
+          result = url
+
+          # Scrub identifier paths (only if segment looks like an identifier)
+          result = result.gsub(IDENTIFIER_PATH_PATTERN) do
+            prefix = ::Regexp.last_match(1)
+            "#{prefix}[REDACTED]"
+          end
+
+          # Scrub auth token paths (always scrub regardless of length)
+          result = result.gsub(AUTH_TOKEN_PATH_PATTERN) do
+            prefix = ::Regexp.last_match(1) ||
+                     ::Regexp.last_match(2) ||
+                     ::Regexp.last_match(3)
+            "#{prefix}[REDACTED]"
+          end
+
+          # Scrub colonel admin paths
+          result = result.gsub(COLONEL_PATH_PATTERN) do
+            prefix = ::Regexp.last_match(1)
+            "#{prefix}[REDACTED]"
+          end
+
+          result
+        end
+
+        def scrub_sensitive_query_params(url)
+          return url unless url.include?('?')
+
+          uri_part, query_string = url.split('?', 2)
+          return url if query_string.nil? || query_string.empty?
+
+          # Handle fragment if present
+          query_part, fragment = query_string.split('#', 2)
+
+          scrubbed_params = query_part.split('&').map do |param|
+            key, _value = param.split('=', 2)
+            if key && SENSITIVE_QUERY_PARAMS.include?(key.downcase)
+              "#{key}=[REDACTED]"
+            else
+              param
+            end
+          end
+
+          result   = "#{uri_part}?#{scrubbed_params.join('&')}"
+          result  += "##{fragment}" if fragment
+          result
+        end
       end
     end
   end

--- a/lib/onetime/initializers/setup_diagnostics.rb
+++ b/lib/onetime/initializers/setup_diagnostics.rb
@@ -82,11 +82,12 @@ module Onetime
           # Add a before_send to filter out problematic events and scrub sensitive URLs
           config.before_send = ->(event, _hint) do
             # Return nil if the event would cause errors in processing.
-            # Don't filter on nil headers - background jobs and non-HTTP contexts
-            # may legitimately have nil headers but still have useful event data.
-            if event.nil? || event.request.nil?
-              OT.ld '[init] Sentry: Filtering out event with nil components'
-              return nil
+            return nil if event.nil?
+
+            # If there is no request object, we can't scrub URLs, but we should
+            # still allow the event to pass through (e.g. for background jobs).
+            if event.request.nil?
+              return event
             end
 
             # Scrub sensitive URL paths and query parameters from event data.
@@ -161,7 +162,7 @@ module Onetime
             scrubbed_url = scrub_url(original_url)
             if scrubbed_url != original_url
               event.request.url = scrubbed_url
-              OT.ld "[sentry] Scrubbed request.url: #{original_url} -> #{scrubbed_url}"
+              OT.ld "[sentry] Scrubbed request.url -> #{scrubbed_url}"
             end
           end
 
@@ -173,7 +174,7 @@ module Onetime
             scrubbed_url = scrub_url(original_url)
             if scrubbed_url != original_url
               event.contexts['request']['url'] = scrubbed_url
-              OT.ld "[sentry] Scrubbed contexts.request.url: #{original_url} -> #{scrubbed_url}"
+              OT.ld "[sentry] Scrubbed contexts.request.url"
             end
           end
 
@@ -268,7 +269,7 @@ module Onetime
           # Handle fragment if present
           query_part, fragment = query_string.split('#', 2)
 
-          scrubbed_params = query_part.split('&').map do |param|
+          scrubbed_params = query_part.split('&', -1).map do |param|
             key, _value = param.split('=', 2)
             if key && SENSITIVE_QUERY_PARAMS.include?(key.downcase)
               "#{key}=[REDACTED]"

--- a/spec/unit/onetime/initializers/sentry_url_scrubbing_spec.rb
+++ b/spec/unit/onetime/initializers/sentry_url_scrubbing_spec.rb
@@ -1,0 +1,382 @@
+# spec/unit/onetime/initializers/sentry_url_scrubbing_spec.rb
+#
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'onetime/initializers/setup_diagnostics'
+
+# Tests for URL scrubbing functionality in the Sentry before_send hook.
+# The scrubbing ensures sensitive data (secret keys, tokens, etc.) are not
+# sent to Sentry in error reports.
+#
+# This test file exercises the production code in SetupDiagnostics directly
+# to ensure the scrubbing logic works as expected.
+
+RSpec.describe Onetime::Initializers::SetupDiagnostics do
+  # Helper to call the private scrub_url method on production code
+  def scrub_url(url)
+    described_class.send(:scrub_url, url)
+  end
+
+  # Helper to call the private scrub_sensitive_paths method
+  def scrub_sensitive_paths(url)
+    described_class.send(:scrub_sensitive_paths, url)
+  end
+
+  # Helper to call the private scrub_sensitive_query_params method
+  def scrub_sensitive_query_params(url)
+    described_class.send(:scrub_sensitive_query_params, url)
+  end
+
+  # Generate a 20+ char base-36 identifier for testing (minimum length for scrubbing)
+  let(:short_identifier) { 'abc123def456xyz789ab' } # exactly 20 chars
+  let(:long_identifier) { 'a' * 62 } # realistic 62-char identifier
+
+  describe '.scrub_url' do
+    context 'with sensitive identifier paths (>= 20 chars, base-36)' do
+      it 'scrubs /secret/:key paths with valid identifier' do
+        result = scrub_url("https://example.com/secret/#{short_identifier}")
+        expect(result).to eq('https://example.com/secret/[REDACTED]')
+      end
+
+      it 'scrubs /receipt/:key paths with valid identifier' do
+        result = scrub_url("https://example.com/receipt/#{short_identifier}")
+        expect(result).to eq('https://example.com/receipt/[REDACTED]')
+      end
+
+      it 'scrubs /private/:key paths with valid identifier' do
+        result = scrub_url("https://example.com/private/#{short_identifier}")
+        expect(result).to eq('https://example.com/private/[REDACTED]')
+      end
+
+      it 'scrubs /metadata/:key paths with valid identifier' do
+        result = scrub_url("https://example.com/metadata/#{short_identifier}")
+        expect(result).to eq('https://example.com/metadata/[REDACTED]')
+      end
+
+      it 'scrubs /incoming/:key paths with valid identifier' do
+        result = scrub_url("https://example.com/incoming/#{short_identifier}")
+        expect(result).to eq('https://example.com/incoming/[REDACTED]')
+      end
+    end
+
+    context 'with admin and auth token paths (always scrubbed)' do
+      it 'scrubs /colonel/:path paths' do
+        result = scrub_url('https://example.com/colonel/admin_path')
+        expect(result).to eq('https://example.com/colonel/[REDACTED]')
+      end
+
+      it 'scrubs /l/:shortcode paths' do
+        result = scrub_url('https://example.com/l/shortcode123')
+        expect(result).to eq('https://example.com/l/[REDACTED]')
+      end
+
+      it 'scrubs /forgot/:token paths' do
+        result = scrub_url('https://example.com/forgot/reset_token')
+        expect(result).to eq('https://example.com/forgot/[REDACTED]')
+      end
+
+      it 'scrubs /auth/reset-password/:token paths' do
+        result = scrub_url('https://example.com/auth/reset-password/token123')
+        expect(result).to eq('https://example.com/auth/reset-password/[REDACTED]')
+      end
+
+      it 'scrubs /account/email/confirm/:token paths' do
+        result = scrub_url('https://example.com/account/email/confirm/confirm_token')
+        expect(result).to eq('https://example.com/account/email/confirm/[REDACTED]')
+      end
+    end
+
+    context 'with 62-char base-36 identifiers (realistic secret keys)' do
+      # Generate a realistic 62-character identifier (base-36 format)
+      let(:identifier_62) { 'a' * 62 }
+
+      it 'scrubs /secret/:id with 62-char identifier' do
+        expect(identifier_62.length).to eq(62)
+        result = scrub_url("https://example.com/secret/#{identifier_62}")
+        expect(result).to eq('https://example.com/secret/[REDACTED]')
+      end
+
+      it 'scrubs /receipt/:id with 62-char identifier' do
+        result = scrub_url("https://example.com/receipt/#{identifier_62}")
+        expect(result).to eq('https://example.com/receipt/[REDACTED]')
+      end
+
+      it 'scrubs /private/:id with 62-char identifier' do
+        result = scrub_url("https://example.com/private/#{identifier_62}")
+        expect(result).to eq('https://example.com/private/[REDACTED]')
+      end
+
+      it 'scrubs /metadata/:id with 62-char identifier' do
+        result = scrub_url("https://example.com/metadata/#{identifier_62}")
+        expect(result).to eq('https://example.com/metadata/[REDACTED]')
+      end
+    end
+
+    context 'with named path segments (should NOT be scrubbed)' do
+      # These are legitimate named routes, not secret identifiers.
+      # The identifier-length discriminant (MIN_IDENTIFIER_LENGTH = 20) ensures
+      # short named paths like "recent" or "burn" are preserved for debugging.
+
+      it 'preserves /receipt/recent (named path, not identifier)' do
+        result = scrub_url('https://example.com/receipt/recent')
+        expect(result).to eq('https://example.com/receipt/recent')
+      end
+
+      it 'preserves /private/recent (named path, not identifier)' do
+        result = scrub_url('https://example.com/private/recent')
+        expect(result).to eq('https://example.com/private/recent')
+      end
+
+      it 'preserves /secret/burn (named path, not identifier)' do
+        result = scrub_url('https://example.com/secret/burn')
+        expect(result).to eq('https://example.com/secret/burn')
+      end
+
+      it 'preserves /incoming/new (named path, not identifier)' do
+        result = scrub_url('https://example.com/incoming/new')
+        expect(result).to eq('https://example.com/incoming/new')
+      end
+
+      it 'preserves /metadata/info (named path, not identifier)' do
+        result = scrub_url('https://example.com/metadata/info')
+        expect(result).to eq('https://example.com/metadata/info')
+      end
+    end
+
+    context 'paths that should NOT be scrubbed' do
+      it 'preserves /api/v1/status' do
+        result = scrub_url('https://example.com/api/v1/status')
+        expect(result).to eq('https://example.com/api/v1/status')
+      end
+
+      it 'preserves /health' do
+        result = scrub_url('https://example.com/health')
+        expect(result).to eq('https://example.com/health')
+      end
+
+      it 'preserves /dashboard' do
+        result = scrub_url('https://example.com/dashboard')
+        expect(result).to eq('https://example.com/dashboard')
+      end
+
+      it 'preserves /api/v2/secrets (plural endpoint, not a key path)' do
+        result = scrub_url('https://example.com/api/v2/secrets')
+        expect(result).to eq('https://example.com/api/v2/secrets')
+      end
+
+      it 'preserves root path' do
+        result = scrub_url('https://example.com/')
+        expect(result).to eq('https://example.com/')
+      end
+
+      it 'preserves /api/v1/info' do
+        result = scrub_url('https://example.com/api/v1/info')
+        expect(result).to eq('https://example.com/api/v1/info')
+      end
+
+      it 'does not scrub partial matches (e.g., /secrets vs /secret)' do
+        result = scrub_url('https://example.com/secrets/list')
+        expect(result).to eq('https://example.com/secrets/list')
+      end
+
+      it 'does not scrub paths with prefix match only' do
+        result = scrub_url('https://example.com/secretive/page')
+        expect(result).to eq('https://example.com/secretive/page')
+      end
+    end
+  end
+
+  describe '.scrub_sensitive_query_params' do
+    # Production code uses string manipulation, not URI encoding
+    # Output should be ?key=[REDACTED], NOT ?key=%5BREDACTED%5D
+
+    it 'scrubs ?key=value parameter without URI encoding' do
+      result = scrub_url('https://example.com/page?key=secret123')
+      expect(result).to eq('https://example.com/page?key=[REDACTED]')
+    end
+
+    it 'scrubs ?secret=value parameter' do
+      result = scrub_url('https://example.com/page?secret=abc')
+      expect(result).to eq('https://example.com/page?secret=[REDACTED]')
+    end
+
+    it 'scrubs ?token=value parameter' do
+      result = scrub_url('https://example.com/page?token=xyz')
+      expect(result).to eq('https://example.com/page?token=[REDACTED]')
+    end
+
+    it 'scrubs ?passphrase=value parameter' do
+      result = scrub_url('https://example.com/page?passphrase=hidden')
+      expect(result).to eq('https://example.com/page?passphrase=[REDACTED]')
+    end
+
+    it 'preserves non-sensitive query parameters' do
+      result = scrub_url('https://example.com/page?other=value')
+      expect(result).to eq('https://example.com/page?other=value')
+    end
+
+    it 'scrubs sensitive params while preserving others' do
+      result = scrub_url('https://example.com/page?secret=abc&other=value&token=xyz')
+      expect(result).to eq('https://example.com/page?secret=[REDACTED]&other=value&token=[REDACTED]')
+    end
+
+    it 'handles case-insensitive param names' do
+      result = scrub_url('https://example.com/page?KEY=value&TOKEN=abc')
+      expect(result).to eq('https://example.com/page?KEY=[REDACTED]&TOKEN=[REDACTED]')
+    end
+
+    it 'preserves fragment identifiers' do
+      result = scrub_url('https://example.com/page?key=secret#section')
+      expect(result).to eq('https://example.com/page?key=[REDACTED]#section')
+    end
+  end
+
+  describe 'combined path and query scrubbing' do
+    it 'scrubs both sensitive path AND query params' do
+      # Use a 20+ char identifier to ensure path scrubbing triggers
+      result = scrub_url("https://example.com/secret/#{short_identifier}?key=token456&other=keep")
+      expect(result).to eq('https://example.com/secret/[REDACTED]?key=[REDACTED]&other=keep')
+    end
+
+    it 'scrubs nested sensitive paths with query params' do
+      result = scrub_url('https://example.com/auth/reset-password/token123?secret=value')
+      expect(result).to eq('https://example.com/auth/reset-password/[REDACTED]?secret=[REDACTED]')
+    end
+
+    it 'scrubs query params even when path is not sensitive' do
+      result = scrub_url('https://example.com/secret/short?key=sensitive&other=keep')
+      expect(result).to eq('https://example.com/secret/short?key=[REDACTED]&other=keep')
+    end
+  end
+
+  describe 'edge cases' do
+    context 'nil and empty values' do
+      it 'handles nil URL gracefully' do
+        result = scrub_url(nil)
+        expect(result).to be_nil
+      end
+
+      it 'handles empty string URL gracefully' do
+        result = scrub_url('')
+        expect(result).to eq('')
+      end
+    end
+
+    context 'malformed URLs' do
+      it 'returns malformed URL unchanged (graceful degradation)' do
+        malformed = 'not-a-valid-url::://'
+        result = scrub_url(malformed)
+        expect(result).to eq(malformed)
+      end
+
+      it 'handles URL with only protocol' do
+        result = scrub_url('https://')
+        expect(result).to eq('https://')
+      end
+
+      it 'handles relative paths with valid identifiers' do
+        result = scrub_url("/secret/#{short_identifier}")
+        expect(result).to eq('/secret/[REDACTED]')
+      end
+
+      it 'handles relative paths with short segments (not scrubbed)' do
+        result = scrub_url('/secret/abc123')
+        expect(result).to eq('/secret/abc123')
+      end
+    end
+
+    context 'special characters in paths' do
+      it 'handles URL-encoded characters in secret keys with valid identifier length' do
+        # 20 chars with URL-encoded space: abc%20 takes 6 chars but decodes to 4
+        result = scrub_url("https://example.com/secret/#{short_identifier}")
+        expect(result).to eq('https://example.com/secret/[REDACTED]')
+      end
+
+      it 'handles paths with trailing slashes' do
+        # The regex matches up to but not including the trailing slash
+        result = scrub_url("https://example.com/secret/#{short_identifier}/")
+        expect(result).to include('/secret/[REDACTED]')
+      end
+    end
+
+    context 'colonel path with multiple segments' do
+      it 'scrubs colonel paths with nested segments' do
+        result = scrub_url('https://example.com/colonel/admin/users/list')
+        expect(result).to eq('https://example.com/colonel/[REDACTED]')
+      end
+    end
+  end
+
+  describe '.scrub_event_urls' do
+    # Mock structures that mirror Sentry's event/request objects
+    let(:mock_request_class) do
+      Struct.new(:url, :headers, keyword_init: true)
+    end
+
+    let(:mock_event_class) do
+      Class.new do
+        attr_accessor :request, :contexts
+
+        def initialize(request: nil, contexts: nil)
+          @request = request
+          @contexts = contexts || {}
+        end
+      end
+    end
+
+    def build_event(url:, context_url: nil)
+      request = mock_request_class.new(url: url, headers: { 'User-Agent' => 'test' })
+      contexts = {}
+      contexts['request'] = { 'url' => context_url || url } if context_url || url
+      mock_event_class.new(request: request, contexts: contexts)
+    end
+
+    it 'scrubs URLs in both request and contexts' do
+      # Use a 20+ char identifier to ensure scrubbing triggers
+      identifier = 'a' * 25
+      event = build_event(
+        url: "https://example.com/secret/#{identifier}",
+        context_url: "https://example.com/secret/#{identifier}"
+      )
+
+      result = described_class.scrub_event_urls(event)
+
+      expect(result.request.url).to eq('https://example.com/secret/[REDACTED]')
+      expect(result.contexts['request']['url']).to eq('https://example.com/secret/[REDACTED]')
+    end
+
+    it 'handles event with nil request URL gracefully' do
+      event = mock_event_class.new(
+        request: mock_request_class.new(url: nil, headers: {}),
+        contexts: {}
+      )
+
+      expect { described_class.scrub_event_urls(event) }.not_to raise_error
+    end
+
+    it 'handles event with nil contexts gracefully' do
+      identifier = 'a' * 25
+      request = mock_request_class.new(url: "https://example.com/secret/#{identifier}", headers: {})
+      event = mock_event_class.new(request: request, contexts: nil)
+
+      expect { described_class.scrub_event_urls(event) }.not_to raise_error
+    end
+
+    it 'handles event with non-hash contexts gracefully' do
+      identifier = 'a' * 25
+      request = mock_request_class.new(url: "https://example.com/secret/#{identifier}", headers: {})
+      event = mock_event_class.new(request: request, contexts: 'not a hash')
+
+      result = described_class.scrub_event_urls(event)
+      expect(result.request.url).to eq('https://example.com/secret/[REDACTED]')
+    end
+
+    it 'preserves non-sensitive URLs unchanged' do
+      event = build_event(url: 'https://example.com/api/v1/status')
+      result = described_class.scrub_event_urls(event)
+
+      expect(result.request.url).to eq('https://example.com/api/v1/status')
+    end
+  end
+end

--- a/spec/unit/onetime/initializers/setup_diagnostics_spec.rb
+++ b/spec/unit/onetime/initializers/setup_diagnostics_spec.rb
@@ -8,8 +8,8 @@ require 'spec_helper'
 MockConfig = Struct.new(:dsn, :environment, :release, :breadcrumbs_logger,
                        :traces_sample_rate, :profiles_sample_rate, :before_send,
                        keyword_init: true) unless defined?(MockConfig)
-EventStruct = Struct.new(:request, keyword_init: true) unless defined?(EventStruct)
-RequestStruct = Struct.new(:headers, keyword_init: true) unless defined?(RequestStruct)
+EventStruct = Struct.new(:request, :contexts, keyword_init: true) unless defined?(EventStruct)
+RequestStruct = Struct.new(:headers, :url, keyword_init: true) unless defined?(RequestStruct)
 
 RSpec.describe Onetime::Initializers::SetupDiagnostics do
   let(:source_config_path) { File.expand_path(File.join(Onetime::HOME, 'spec', 'config.test.yaml')) }
@@ -237,15 +237,23 @@ RSpec.describe Onetime::Initializers::SetupDiagnostics do
       invalid_event = EventStruct.new(request: nil)
       expect(before_send_proc.call(invalid_event, {})).to be_nil
 
-      # Test event with request but nil headers
-      invalid_event2 = EventStruct.new(request: RequestStruct.new(headers: nil))
-      expect(before_send_proc.call(invalid_event2, {})).to be_nil
+      # Test event with request but nil headers - should pass through
+      # (background jobs and non-HTTP contexts may have nil headers)
+      event_nil_headers = EventStruct.new(
+        request: RequestStruct.new(headers: nil, url: 'https://example.com/api/status'),
+        contexts: {}
+      )
+      result = before_send_proc.call(event_nil_headers, {})
+      expect(result).not_to be_nil
+      expect(result.request.url).to eq('https://example.com/api/status')
 
-      # Test valid event
+      # Test valid event with headers
       valid_event = EventStruct.new(
         request: RequestStruct.new(
-          headers: { "User-Agent" => "test" }
-        )
+          headers: { "User-Agent" => "test" },
+          url: 'https://example.com/api/status'
+        ),
+        contexts: {}
       )
       expect(before_send_proc.call(valid_event, {})).to eq(valid_event)
     end

--- a/spec/unit/onetime/initializers/setup_diagnostics_spec.rb
+++ b/spec/unit/onetime/initializers/setup_diagnostics_spec.rb
@@ -233,9 +233,9 @@ RSpec.describe Onetime::Initializers::SetupDiagnostics do
       # Test nil event
       expect(before_send_proc.call(nil, {})).to be_nil
 
-      # Test event with nil request
-      invalid_event = EventStruct.new(request: nil)
-      expect(before_send_proc.call(invalid_event, {})).to be_nil
+      # Test event with nil request - should pass through for background jobs/CLI
+      event_nil_request = EventStruct.new(request: nil)
+      expect(before_send_proc.call(event_nil_request, {})).to eq(event_nil_request)
 
       # Test event with request but nil headers - should pass through
       # (background jobs and non-HTTP contexts may have nil headers)


### PR DESCRIPTION
Scrubs secret identifiers and auth tokens from request URLs before events reach Sentry. Covers `event.request.url` and custom context set via `scope.set_context()`, which bypasses `send_default_pii`.

Uses identifier length (`MIN_IDENTIFIER_LENGTH=20`) to distinguish verifiable identifier segments from named path segments — avoids false positives on routes like `/receipt/recent`.

Part of a security-critical trio with #2961 and #2962.

Closes #2963