### PR TITLE
Address Sentry URL scrubbing security review feedback

### DIFF
--- a/lib/onetime/initializers/setup_diagnostics.rb
+++ b/lib/onetime/initializers/setup_diagnostics.rb
@@ -84,12 +84,6 @@ module Onetime
             # Return nil if the event would cause errors in processing.
             return nil if event.nil?
 
-            # If there is no request object, we can't scrub URLs, but we should
-            # still allow the event to pass through (e.g. for background jobs).
-            if event.request.nil?
-              return event
-            end
-
             # Scrub sensitive URL paths and query parameters from event data.
             # This covers both event.request.url and custom context set via
             # scope.set_context('request', ...) in error handling middleware.
@@ -162,7 +156,7 @@ module Onetime
             scrubbed_url = scrub_url(original_url)
             if scrubbed_url != original_url
               event.request.url = scrubbed_url
-              OT.ld "[sentry] Scrubbed request.url -> #{scrubbed_url}"
+              OT.ld "[sentry] Scrubbed request.url"
             end
           end
 
@@ -180,8 +174,12 @@ module Onetime
 
           event
         rescue StandardError => ex
-          # Never let scrubbing errors prevent event capture
+          # Fail-closed: redact URLs on error to prevent leaking sensitive data
           OT.ld "[sentry] URL scrubbing failed: #{ex.class} - #{ex.message}"
+          event.request.url = '[SCRUBBING_FAILED]' if event.request&.url
+          if event.contexts.is_a?(Hash) && event.contexts['request'].is_a?(Hash)
+            event.contexts['request']['url'] = '[SCRUBBING_FAILED]'
+          end
           event
         end
 
@@ -207,8 +205,8 @@ module Onetime
           scrubbed = scrub_sensitive_paths(url)
           scrub_sensitive_query_params(scrubbed)
         rescue StandardError
-          # Return original URL if scrubbing fails
-          url
+          # Fail-closed: return redacted placeholder to prevent leaking sensitive data
+          '[SCRUBBING_FAILED]'
         end
 
         # Pattern for identifier paths - matches segments >= MIN_IDENTIFIER_LENGTH chars

--- a/lib/onetime/initializers/setup_diagnostics.rb
+++ b/lib/onetime/initializers/setup_diagnostics.rb
@@ -175,9 +175,12 @@ module Onetime
           event
         rescue StandardError => ex
           # Fail-closed: redact URLs on error to prevent leaking sensitive data
-          OT.ld "[sentry] URL scrubbing failed: #{ex.class} - #{ex.message}"
+          # Note: intentionally not logging ex.message as it may contain URL fragments
+          OT.ld "[sentry] URL scrubbing failed: #{ex.class}"
           event.request.url = '[SCRUBBING_FAILED]' if event.request&.url
-          if event.contexts.is_a?(Hash) && event.contexts['request'].is_a?(Hash)
+          if event.contexts.is_a?(Hash) &&
+             event.contexts['request'].is_a?(Hash) &&
+             event.contexts['request']['url']
             event.contexts['request']['url'] = '[SCRUBBING_FAILED]'
           end
           event

--- a/spec/unit/onetime/initializers/sentry_url_scrubbing_spec.rb
+++ b/spec/unit/onetime/initializers/sentry_url_scrubbing_spec.rb
@@ -378,5 +378,28 @@ RSpec.describe Onetime::Initializers::SetupDiagnostics do
 
       expect(result.request.url).to eq('https://example.com/api/v1/status')
     end
+
+    it 'scrubs context URLs when request is nil (non-HTTP events)' do
+      identifier = 'a' * 25
+      contexts = { 'request' => { 'url' => "https://example.com/secret/#{identifier}" } }
+      event = mock_event_class.new(request: nil, contexts: contexts)
+
+      result = described_class.scrub_event_urls(event)
+
+      expect(result.contexts['request']['url']).to eq('https://example.com/secret/[REDACTED]')
+    end
+  end
+
+  describe '.scrub_url fail-closed behavior' do
+    it 'returns [SCRUBBING_FAILED] when scrubbing raises an error' do
+      # Force an error by passing an object that will fail string operations
+      bad_input = Object.new
+      def bad_input.nil?; false; end
+      def bad_input.empty?; false; end
+      def bad_input.include?(_); raise StandardError, 'forced error'; end
+
+      result = described_class.scrub_url(bad_input)
+      expect(result).to eq('[SCRUBBING_FAILED]')
+    end
   end
 end

--- a/spec/unit/onetime/initializers/sentry_url_scrubbing_spec.rb
+++ b/spec/unit/onetime/initializers/sentry_url_scrubbing_spec.rb
@@ -396,6 +396,21 @@ RSpec.describe Onetime::Initializers::SetupDiagnostics do
       result = described_class.scrub_event_urls(event)
 
       expect(result.request.url).to eq('[SCRUBBING_FAILED]')
+      expect(result.contexts['request']['url']).to eq('[SCRUBBING_FAILED]')
+    end
+
+    it 'does not inject url key into contexts when scrubbing fails' do
+      allow(described_class).to receive(:scrub_url).and_raise(StandardError, 'unexpected failure')
+
+      # Context with request hash but no url key
+      event = mock_event_class.new(
+        request: mock_request_class.new(url: 'https://example.com/secret/abc', headers: {}),
+        contexts: { 'request' => { 'method' => 'GET' } }
+      )
+      result = described_class.scrub_event_urls(event)
+
+      expect(result.request.url).to eq('[SCRUBBING_FAILED]')
+      expect(result.contexts['request']).not_to have_key('url')
     end
   end
 

--- a/spec/unit/onetime/initializers/sentry_url_scrubbing_spec.rb
+++ b/spec/unit/onetime/initializers/sentry_url_scrubbing_spec.rb
@@ -388,17 +388,29 @@ RSpec.describe Onetime::Initializers::SetupDiagnostics do
 
       expect(result.contexts['request']['url']).to eq('https://example.com/secret/[REDACTED]')
     end
+
+    it 'redacts URLs when scrubbing raises an unexpected error' do
+      allow(described_class).to receive(:scrub_url).and_raise(StandardError, 'unexpected failure')
+
+      event = build_event(url: 'https://example.com/secret/abc123')
+      result = described_class.scrub_event_urls(event)
+
+      expect(result.request.url).to eq('[SCRUBBING_FAILED]')
+    end
   end
 
   describe '.scrub_url fail-closed behavior' do
-    it 'returns [SCRUBBING_FAILED] when scrubbing raises an error' do
-      # Force an error by passing an object that will fail string operations
-      bad_input = Object.new
-      def bad_input.nil?; false; end
-      def bad_input.empty?; false; end
-      def bad_input.include?(_); raise StandardError, 'forced error'; end
+    it 'returns [SCRUBBING_FAILED] when path scrubbing raises an error' do
+      allow(described_class).to receive(:scrub_sensitive_paths).and_raise(StandardError, 'regex failure')
 
-      result = described_class.scrub_url(bad_input)
+      result = described_class.scrub_url('https://example.com/secret/abc123')
+      expect(result).to eq('[SCRUBBING_FAILED]')
+    end
+
+    it 'returns [SCRUBBING_FAILED] when query param scrubbing raises an error' do
+      allow(described_class).to receive(:scrub_sensitive_query_params).and_raise(StandardError, 'split failure')
+
+      result = described_class.scrub_url('https://example.com/api?key=secret')
       expect(result).to eq('[SCRUBBING_FAILED]')
     end
   end


### PR DESCRIPTION
## Summary

Addresses security review feedback from PR #2976 on the Sentry URL scrubbing implementation.

**Fixes:**
- Remove early return when `event.request.nil?` — was preventing context URL scrubbing for non-HTTP events
- Stop logging scrubbed URLs — could leak data if scrubbing pattern is incomplete
- Fail-closed on scrubbing errors — return `[SCRUBBING_FAILED]` instead of original URL

## Test plan

- [x] Existing 52 tests pass
- [x] Added test for context URL scrubbing when request is nil
- [x] Added test for fail-closed behavior on scrub_url error

Relates to #2963