### PR TITLE
Set 14-day Sentry event retention for compliance

### DIFF
--- a/docs/runbooks/sentry-retention-policy.md
+++ b/docs/runbooks/sentry-retention-policy.md
@@ -1,0 +1,35 @@
+# Sentry Retention Policy Runbook
+
+## Overview
+
+Sentry self-hosted defaults to 90-day event retention. For data minimization compliance, we limit retention to 14 days.
+
+## Configuration
+
+In the Sentry self-hosted `.env`:
+
+```bash
+SENTRY_EVENT_RETENTION_DAYS=14
+```
+
+Restart Sentry services after changing.
+
+## Known Issue
+
+ClickHouse may not honor the retention setting ([getsentry/self-hosted#3421](https://github.com/getsentry/self-hosted/issues/3421)). Verify cleanup is occurring.
+
+## Verification
+
+Check ClickHouse table sizes:
+
+```bash
+docker exec -it sentry-clickhouse clickhouse-client --query \
+  "SELECT table, formatReadableSize(sum(bytes)) as size \
+   FROM system.parts GROUP BY table ORDER BY sum(bytes) DESC"
+```
+
+Monitor disk usage over 2+ weeks to confirm purging.
+
+## Compliance
+
+This implements data minimization — debugging data should not be retained longer than necessary for its purpose.

--- a/docs/runbooks/sentry-retention-policy.md
+++ b/docs/runbooks/sentry-retention-policy.md
@@ -12,7 +12,7 @@ In the Sentry self-hosted `.env`:
 SENTRY_EVENT_RETENTION_DAYS=14
 ```
 
-Restart Sentry services after changing.
+Apply the changes by recreating the containers (e.g., `docker compose up -d`).
 
 ## Known Issue
 
@@ -24,11 +24,11 @@ Check ClickHouse table sizes:
 
 ```bash
 docker exec -it sentry-clickhouse clickhouse-client --query \
-  "SELECT table, formatReadableSize(sum(bytes)) as size \
-   FROM system.parts GROUP BY table ORDER BY sum(bytes) DESC"
+  "SELECT table, formatReadableSize(sum(bytes_on_disk)) as size \
+   FROM system.parts WHERE active GROUP BY table ORDER BY sum(bytes_on_disk) DESC"
 ```
 
-Monitor disk usage over 2+ weeks to confirm purging.
+Monitor disk usage and verify the oldest data partitions to confirm purging.
 
 ## Compliance
 


### PR DESCRIPTION
Adds a runbook documenting the `SENTRY_EVENT_RETENTION_DAYS=14` configuration for Sentry self-hosted, the known ClickHouse limitation (getsentry/self-hosted#3421), and post-deployment verification steps. Implements data minimization per compliance requirements.

NOTE: We have run our self-hosted sentry with 14-day retention from the get-go. The doc this PR adds is for visibility while we work through a number of logging/diagnostics tickets.

Closes #2969