### PR TITLE
Use setTag instead of setExtras for searchable Sentry fields (#2964)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,8 +7,8 @@
 #   1. Install pre-commit:
 #       $ pip install pre-commit
 #
-#   2. Install git hooks:
-#       $ pre-commit install
+#   2. Install all git hooks:
+#       $ pre-commit install && pre-commit install --hook-type pre-push -c .pre-push-config.yaml
 #
 # Usage:
 #   Hooks run automatically on 'git commit'
@@ -52,9 +52,8 @@ default_language_version:
   ruby: system
   node: system
 
-# Allow all hooks to run even if one (or more fails). This avoids
-# the commit->fail->fix->commit->fail->fix->commit routine.
-fail_fast: false
+# Stop on first failure for fast feedback during commits
+fail_fast: true
 
 # Ignore generated and dependency directories
 exclude: '^$'

--- a/.pre-push-config.yaml
+++ b/.pre-push-config.yaml
@@ -4,8 +4,8 @@
 # Quality control checks that run before code is pushed to remote repositories
 #
 # Setup:
-#   1. Install the pre-push hook:
-#       $ pre-commit install --hook-type pre-push
+#   1. Install all hooks (run from .pre-commit-config.yaml instructions):
+#       $ pre-commit install && pre-commit install --hook-type pre-push -c .pre-push-config.yaml
 #
 #   2. Install required dependencies:
 #       - Ruby + Rubocop
@@ -37,16 +37,16 @@
 # Note: These intensive checks run before pushing to catch issues early
 # but allow faster local development with lighter pre-commit hooks.
 
-fail_fast: true
+# Run all checks to see complete picture before pushing
+fail_fast: false
 
 # Skip generated/dependency directories
 exclude: '^(vendor|node_modules|dist|build)/'
 
 default_install_hook_types:
   - pre-push
-  - push
 
-default_stages: [push]
+default_stages: [pre-push]
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -90,7 +90,7 @@ repos:
   - repo: local
     hooks:
       - id: pnpm-lint
-        stages: [push]
+        stages: [pre-push]
         name: pnpm lint
         entry: pnpm run lint
         language: system
@@ -102,7 +102,7 @@ repos:
   - repo: local
     hooks:
       - id: typescript-check-full
-        stages: [push]
+        stages: [pre-push]
         name: TypeScript Type Check
         entry: pnpm run type-check
         language: system

--- a/src/plugins/core/enableDiagnostics.ts
+++ b/src/plugins/core/enableDiagnostics.ts
@@ -447,6 +447,10 @@ export function createDiagnostics(options: EnableDiagnosticsOptions): Plugin {
   const scope = new Scope();
   scope.setClient(client);
 
+  // Set default service tag for all events from this frontend app
+  // @see https://github.com/onetimesecret/onetimesecret/issues/2964
+  scope.setTag('service', 'web');
+
   // Initialize the Sentry client. This is equivalent to calling
   // Sentry.init() with the options provided above.
   client.init(); // after setting the client on the scope

--- a/src/plugins/core/globalErrorBoundary.ts
+++ b/src/plugins/core/globalErrorBoundary.ts
@@ -59,7 +59,6 @@ export function createErrorBoundary(options: ErrorBoundaryOptions = {}): Plugin 
             componentInfo: info,
             errorType: classifiedError.type,
             errorSeverity: classifiedError.severity,
-            service: 'web',
           };
 
           // Add jurisdiction if regions are configured (optional field)

--- a/src/plugins/core/globalErrorBoundary.ts
+++ b/src/plugins/core/globalErrorBoundary.ts
@@ -4,6 +4,7 @@ import { AsyncHandlerOptions } from '@/shared/composables/useAsyncHandler';
 import { classifyError, errorGuards } from '@/schemas/errors';
 import { captureException, isDiagnosticsEnabled } from '@/services/diagnostics.service';
 import { loggingService } from '@/services/logging.service';
+import { useBootstrapStore } from '@/shared/stores/bootstrapStore';
 import type { App, Plugin } from 'vue';
 
 interface ErrorBoundaryOptions extends AsyncHandlerOptions {
@@ -50,11 +51,33 @@ export function createErrorBoundary(options: ErrorBoundaryOptions = {}): Plugin 
         // Send to Sentry via diagnostics service
         if (isDiagnosticsEnabled()) {
           console.debug('[GlobalErrorBoundary] Sending to Sentry');
-          captureException(normalizedError, {
+
+          // Extract searchable tags from bootstrap store
+          // Note: useBootstrapStore() is safe here because Pinia is installed before this plugin
+          const bootstrap = useBootstrapStore();
+          const context: Record<string, unknown> = {
             componentInfo: info,
             errorType: classifiedError.type,
             errorSeverity: classifiedError.severity,
-          });
+            service: 'web',
+          };
+
+          // Add jurisdiction if regions are configured (optional field)
+          if (bootstrap.regions?.current_jurisdiction) {
+            context.jurisdiction = bootstrap.regions.current_jurisdiction;
+          }
+
+          // Add planid from organization if present (organization is optional)
+          if (bootstrap.organization?.planid) {
+            context.planid = bootstrap.organization.planid;
+          }
+
+          // Add role from customer if present (cust is nullable)
+          if (bootstrap.cust?.role) {
+            context.role = bootstrap.cust.role;
+          }
+
+          captureException(normalizedError, context);
         } else {
           console.debug('[GlobalErrorBoundary] Sentry not initialized');
         }

--- a/src/services/diagnostics.service.ts
+++ b/src/services/diagnostics.service.ts
@@ -26,6 +26,7 @@ let diagnosticsClient: DiagnosticsClient | null = null;
  *
  * Tags:
  * - errorType: human, security, technical (from error classification)
+ * - errorSeverity: error severity level (from error classification)
  * - schema: Zod schema name (lowercase)
  * - service: web, api
  * - jurisdiction: region code from bootstrap.regions.current_jurisdiction
@@ -34,8 +35,8 @@ let diagnosticsClient: DiagnosticsClient | null = null;
  *
  * @see https://github.com/onetimesecret/onetimesecret/issues/2964
  */
-const TAG_FIELDS = ['errorType', 'schema', 'service', 'jurisdiction', 'planid', 'role'] as const;
-type TagField = (typeof TAG_FIELDS)[number];
+const TAG_FIELDS = ['errorType', 'errorSeverity', 'schema', 'service', 'jurisdiction', 'planid', 'role'] as const;
+type _TagField = (typeof TAG_FIELDS)[number]; // Used for documentation; lookup via Set<string>
 
 /**
  * Extracts tag fields from context and applies them to the scope.
@@ -51,11 +52,15 @@ function applyTagsFromContext(
 ): Record<string, unknown> {
   const extras: Record<string, unknown> = {};
 
+  const tagFieldsSet = new Set<string>(TAG_FIELDS);
   for (const [key, value] of Object.entries(context)) {
-    if (TAG_FIELDS.includes(key as TagField) && value !== undefined && value !== null) {
-      // Tags must be strings and normalized to lowercase
-      const tagValue = String(value).toLowerCase();
-      eventScope.setTag(key, tagValue);
+    if (tagFieldsSet.has(key)) {
+      // Tag fields are handled exclusively - set if valid, skip if null/undefined
+      if (value !== undefined && value !== null) {
+        // Tags must be strings and normalized to lowercase
+        const tagValue = String(value).toLowerCase();
+        eventScope.setTag(key, tagValue);
+      }
     } else {
       extras[key] = value;
     }

--- a/src/services/diagnostics.service.ts
+++ b/src/services/diagnostics.service.ts
@@ -20,6 +20,51 @@ interface DiagnosticsClient {
 let diagnosticsClient: DiagnosticsClient | null = null;
 
 /**
+ * Tag fields that should be indexed in Sentry for searchability.
+ * These are extracted from context and set via setTag() instead of setExtras().
+ * All tag values are normalized to lowercase for consistent querying.
+ *
+ * Tags:
+ * - errorType: human, security, technical (from error classification)
+ * - schema: Zod schema name (lowercase)
+ * - service: web, api
+ * - jurisdiction: region code from bootstrap.regions.current_jurisdiction
+ * - planid: plan identifier from bootstrap.organization.planid
+ * - role: customer, colonel, recipient, user_deleted_self from bootstrap.cust.role
+ *
+ * @see https://github.com/onetimesecret/onetimesecret/issues/2964
+ */
+const TAG_FIELDS = ['errorType', 'schema', 'service', 'jurisdiction', 'planid', 'role'] as const;
+type TagField = (typeof TAG_FIELDS)[number];
+
+/**
+ * Extracts tag fields from context and applies them to the scope.
+ * Returns the remaining context fields for use with setExtras().
+ *
+ * @param context - The context object containing tags and extras
+ * @param eventScope - The Sentry scope to apply tags to
+ * @returns The remaining context fields (non-tag fields)
+ */
+function applyTagsFromContext(
+  context: Record<string, unknown>,
+  eventScope: Scope
+): Record<string, unknown> {
+  const extras: Record<string, unknown> = {};
+
+  for (const [key, value] of Object.entries(context)) {
+    if (TAG_FIELDS.includes(key as TagField) && value !== undefined && value !== null) {
+      // Tags must be strings and normalized to lowercase
+      const tagValue = String(value).toLowerCase();
+      eventScope.setTag(key, tagValue);
+    } else {
+      extras[key] = value;
+    }
+  }
+
+  return extras;
+}
+
+/**
  * Initialize the diagnostics service with Sentry client and scope.
  * Called once during app startup from enableDiagnostics plugin.
  */
@@ -38,6 +83,9 @@ export function isDiagnosticsEnabled(): boolean {
  * Capture an exception to Sentry with optional context.
  * Falls back to console.error if Sentry is not initialized.
  *
+ * Tag fields (errorType, schema, service, jurisdiction, planid, role) are
+ * extracted and set via setTag() for Sentry indexing. Remaining fields use setExtras().
+ *
  * @param error - The error to capture
  * @param context - Optional extra context to attach to the event
  *
@@ -45,7 +93,10 @@ export function isDiagnosticsEnabled(): boolean {
  * ```typescript
  * captureException(new Error('Schema validation failed'), {
  *   schema: 'SecretResponse',
- *   issues: zodError.issues,
+ *   errorType: 'technical',
+ *   service: 'web',
+ *   jurisdiction: 'eu',
+ *   issues: zodError.issues, // goes to extras
  * });
  * ```
  */
@@ -58,7 +109,10 @@ export function captureException(
     const eventScope = baseScope.clone();
 
     if (context) {
-      eventScope.setExtras(context);
+      const extras = applyTagsFromContext(context, eventScope);
+      if (Object.keys(extras).length > 0) {
+        eventScope.setExtras(extras);
+      }
     }
 
     client.captureException(error, undefined, eventScope);
@@ -74,6 +128,9 @@ export function captureException(
 /**
  * Capture a message to Sentry with optional context.
  * Useful for non-exception events that should be tracked.
+ *
+ * Tag fields (errorType, schema, service, jurisdiction, planid, role) are
+ * extracted and set via setTag() for Sentry indexing. Remaining fields use setExtras().
  */
 export function captureMessage(
   message: string,
@@ -84,7 +141,10 @@ export function captureMessage(
     const eventScope = baseScope.clone();
 
     if (context) {
-      eventScope.setExtras(context);
+      const extras = applyTagsFromContext(context, eventScope);
+      if (Object.keys(extras).length > 0) {
+        eventScope.setExtras(extras);
+      }
     }
 
     client.captureMessage(message, undefined, undefined, eventScope);

--- a/src/shared/composables/README.md
+++ b/src/shared/composables/README.md
@@ -76,7 +76,6 @@ export function useMyFeature() {
 | `log` | `(error: ApplicationError) => void \| false` | Error logging | loggingService.error |
 | `setLoading` | `(isLoading: boolean) => void` | Loading state | noop |
 | `onError` | `(error: ApplicationError) => void` | Pre-throw callback | undefined |
-| `sentry` | `SentryInstance` | Error tracking | Auto-injected |
 
 ### Auth-Specific Pattern
 

--- a/src/shared/composables/useAsyncHandler.ts
+++ b/src/shared/composables/useAsyncHandler.ts
@@ -121,6 +121,47 @@ export function useAsyncHandler(options: AsyncHandlerOptions = {}) {
   };
 
   /**
+   * Safely invokes the onError callback, logging any callback errors
+   */
+  function handleErrorCallback(classifiedError: ApplicationError): void {
+    if (!handlers.onError) return;
+    try {
+      handlers.onError(classifiedError);
+    } catch (callbackError) {
+      handlers.log?.(classifyError(callbackError as Error));
+    }
+  }
+
+  /**
+   * Notifies the user with appropriate message based on error type
+   */
+  function notifyUser(classifiedError: ApplicationError): void {
+    if (!handlers.notify) return;
+    const isHuman = errorGuards.isOfHumanInterest(classifiedError);
+    const message = isHuman ? classifiedError.message : t('web.COMMON.unexpected_error');
+    handlers.notify(message, classifiedError.severity);
+  }
+
+  /**
+   * Logs technical errors and sends to Sentry with context tags
+   */
+  function logTechnicalError(error: unknown, classifiedError: ApplicationError): void {
+    if (errorGuards.isOfHumanInterest(classifiedError)) return;
+
+    handlers.log?.(classifiedError);
+
+    if (isDiagnosticsEnabled()) {
+      captureException(error instanceof Error ? error : new Error(String(error)), {
+        errorType: classifiedError.type,
+        service: 'web',
+        jurisdiction: bootstrap.regions?.current_jurisdiction,
+        planid: bootstrap.organization?.planid,
+        role: bootstrap.cust?.role,
+      });
+    }
+  }
+
+  /**
    * Wraps an async operation with consistent error handling
    *
    * Key features:
@@ -149,38 +190,9 @@ export function useAsyncHandler(options: AsyncHandlerOptions = {}) {
     } catch (error) {
       const classifiedError = classifyError(error as Error);
 
-      // Call onError callback before  everything else
-      if (handlers.onError) {
-        try {
-          handlers.onError(classifiedError);
-        } catch (callbackError) {
-          // Log but don't throw callback errors
-          handlers.log?.(classifyError(callbackError as Error));
-        }
-      }
-
-      // Always notify the user, but use a generic message for technical/security errors
-      if (handlers.notify) {
-        const isHuman = errorGuards.isOfHumanInterest(classifiedError);
-        const message = isHuman ? classifiedError.message : t('web.COMMON.unexpected_error');
-        handlers.notify(message, classifiedError.severity);
-      }
-
-      // Only log technical and security errors
-      if (!errorGuards.isOfHumanInterest(classifiedError)) {
-        handlers.log?.(classifiedError);
-
-        // Send to Sentry via centralized diagnostics service with searchable tags
-        if (isDiagnosticsEnabled()) {
-          captureException(error instanceof Error ? error : new Error(String(error)), {
-            errorType: classifiedError.type,
-            service: 'web',
-            jurisdiction: bootstrap.regions?.current_jurisdiction,
-            planid: bootstrap.organization?.planid,
-            role: bootstrap.cust?.role,
-          });
-        }
-      }
+      handleErrorCallback(classifiedError);
+      notifyUser(classifiedError);
+      logTechnicalError(error, classifiedError);
 
       return undefined;
     } finally {

--- a/src/shared/composables/useAsyncHandler.ts
+++ b/src/shared/composables/useAsyncHandler.ts
@@ -1,12 +1,12 @@
 // src/shared/composables/useAsyncHandler.ts
 
-import { SENTRY_KEY, SentryInstance } from '@/plugins/core/enableDiagnostics';
 import type { ApplicationError } from '@/schemas/errors';
 import { classifyError, createError, errorGuards, wrapError } from '@/schemas/errors';
+import { captureException, isDiagnosticsEnabled } from '@/services/diagnostics.service';
 import { loggingService } from '@/services/logging.service';
 import type {} from '@/shared/stores/notificationsStore';
+import { useBootstrapStore } from '@/shared/stores/bootstrapStore';
 import type { NotificationSeverity } from '@/types/ui/notifications';
-import { inject } from 'vue';
 import { useI18n } from 'vue-i18n';
 
 export interface AsyncHandlerOptions {
@@ -18,10 +18,6 @@ export interface AsyncHandlerOptions {
    * Optional error logging implementation
    */
   log?: ((error: ApplicationError) => void) | false;
-  /**
-   * Optional Sentry error tracking client
-   */
-  sentry?: SentryInstance;
   /**
    * Optional loading state handler
    */
@@ -90,7 +86,6 @@ export { createError, errorGuards, wrapError }; // Re-export for convenience
  * ```
  */
 export function useAsyncHandler(options: AsyncHandlerOptions = {}) {
-  const sentry = inject(SENTRY_KEY, null) as SentryInstance | null;
 
   // useAsyncHandler is called during component setup (synchronously), so we put
   // useI18n() here to execute in the correct context. The t function it returns
@@ -100,6 +95,9 @@ export function useAsyncHandler(options: AsyncHandlerOptions = {}) {
   // be called synchronously at the top level of setup() or another composable
   // and not never inside callbacks, async functions, or event handlers.
   const { t } = useI18n();
+
+  // Capture bootstrap store for Sentry context tags (jurisdiction, planid, role)
+  const bootstrap = useBootstrapStore();
 
   // Default implementations that will be used if no options provided
   const handlers = {
@@ -172,8 +170,15 @@ export function useAsyncHandler(options: AsyncHandlerOptions = {}) {
       if (!errorGuards.isOfHumanInterest(classifiedError)) {
         handlers.log?.(classifiedError);
 
-        if (sentry) {
-          sentry.scope.captureException(error);
+        // Send to Sentry via centralized diagnostics service with searchable tags
+        if (isDiagnosticsEnabled()) {
+          captureException(error instanceof Error ? error : new Error(String(error)), {
+            errorType: classifiedError.type,
+            service: 'web',
+            jurisdiction: bootstrap.regions?.current_jurisdiction,
+            planid: bootstrap.organization?.planid,
+            role: bootstrap.cust?.role,
+          });
         }
       }
 

--- a/src/tests/services/diagnostics.service.spec.ts
+++ b/src/tests/services/diagnostics.service.spec.ts
@@ -445,9 +445,9 @@ describe('diagnostics.service', () => {
         expect(clonedScope.setTag).toHaveBeenCalledWith('schema', 'secretresponse');
         expect(clonedScope.setTag).toHaveBeenCalledTimes(1);
 
-        // null value should go to extras (not filtered out)
-        const extrasArg = clonedScope.setExtras.mock.calls[0][0];
-        expect(extrasArg).toHaveProperty('errorType', null);
+        // Tag fields with null values are skipped, not moved to extras
+        // Since there are no non-tag fields, setExtras should not be called
+        expect(clonedScope.setExtras).not.toHaveBeenCalled();
       });
 
       it('does not call setTag for undefined tag values', async () => {
@@ -468,9 +468,9 @@ describe('diagnostics.service', () => {
         expect(clonedScope.setTag).toHaveBeenCalledWith('schema', 'secretresponse');
         expect(clonedScope.setTag).toHaveBeenCalledTimes(1);
 
-        // undefined value should go to extras (not filtered out)
-        const extrasArg = clonedScope.setExtras.mock.calls[0][0];
-        expect(extrasArg).toHaveProperty('errorType', undefined);
+        // Tag fields with undefined values are skipped, not moved to extras
+        // Since there are no non-tag fields, setExtras should not be called
+        expect(clonedScope.setExtras).not.toHaveBeenCalled();
       });
 
       it('sets empty string tag values (does not skip them)', async () => {
@@ -607,10 +607,9 @@ describe('diagnostics.service', () => {
         expect(clonedScope.setTag).toHaveBeenCalledWith('service', 'web');
         expect(clonedScope.setTag).toHaveBeenCalledTimes(1);
 
-        // null/undefined values should go to extras
-        const extrasArg = clonedScope.setExtras.mock.calls[0][0];
-        expect(extrasArg).toHaveProperty('errorType', null);
-        expect(extrasArg).toHaveProperty('schema', undefined);
+        // Tag fields with null/undefined values are skipped, not moved to extras
+        // Since there are no non-tag fields, setExtras should not be called
+        expect(clonedScope.setExtras).not.toHaveBeenCalled();
       });
     });
 

--- a/src/tests/services/diagnostics.service.spec.ts
+++ b/src/tests/services/diagnostics.service.spec.ts
@@ -4,10 +4,12 @@
  * Tests for diagnostics.service.ts (Sentry integration layer)
  *
  * Issue: #2790 - PR review fixes
+ * Issue: #2964 - Sentry setTag vs setExtras separation
  *
  * Covers initialization, captureException, captureMessage, console
- * fallback when Sentry is unavailable, and context isolation between
- * successive captures (validates the Scope.clone() fix from Issue 4).
+ * fallback when Sentry is unavailable, context isolation between
+ * successive captures (validates the Scope.clone() fix from Issue 4),
+ * and tag/extras separation for Sentry indexing.
  *
  * Run:
  *   pnpm test src/tests/services/diagnostics.service.spec.ts
@@ -19,16 +21,25 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 // Mock Scope class that tracks method calls and supports clone()
 // ---------------------------------------------------------------------------
 function createMockScope() {
-  const scope: Record<string, ReturnType<typeof vi.fn>> & { _extras: Record<string, unknown> } = {
+  const scope: Record<string, ReturnType<typeof vi.fn>> & {
+    _extras: Record<string, unknown>;
+    _tags: Record<string, string>;
+  } = {
     _extras: {},
+    _tags: {},
     setExtras: vi.fn(function (this: typeof scope, extras: Record<string, unknown>) {
       Object.assign(this._extras, extras);
       return this;
     }),
+    setTag: vi.fn(function (this: typeof scope, key: string, value: string) {
+      this._tags[key] = value;
+      return this;
+    }),
     clone: vi.fn(function (this: typeof scope) {
       const cloned = createMockScope();
-      // Simulate copying existing extras from the base scope
+      // Simulate copying existing extras and tags from the base scope
       cloned._extras = { ...this._extras };
+      cloned._tags = { ...this._tags };
       return cloned;
     }),
     captureException: vi.fn(),
@@ -116,14 +127,15 @@ describe('diagnostics.service', () => {
       initDiagnostics(client as never, baseScope as never);
 
       const error = new Error('test error');
-      const context = { schema: 'TestSchema', count: 42 };
+      // Use non-tag fields to test basic functionality
+      const context = { count: 42, detail: 'info' };
 
       captureException(error, context);
 
       // Should clone the base scope
       expect(baseScope.clone).toHaveBeenCalledOnce();
 
-      // The cloned scope should receive the extras
+      // The cloned scope should receive the extras (non-tag fields)
       const clonedScope = baseScope.clone.mock.results[0].value;
       expect(clonedScope.setExtras).toHaveBeenCalledWith(context);
 
@@ -181,7 +193,8 @@ describe('diagnostics.service', () => {
 
       initDiagnostics(client as never, baseScope as never);
 
-      const context = { source: 'test' };
+      // Use non-tag fields to test basic functionality
+      const context = { source: 'test', detail: 'info' };
       captureMessage('test message', context);
 
       expect(baseScope.clone).toHaveBeenCalledOnce();
@@ -267,6 +280,367 @@ describe('diagnostics.service', () => {
       const secondClonedScope = baseScope.clone.mock.results[1].value;
       expect(secondClonedScope.setExtras).not.toHaveBeenCalled();
       expect(baseScope.setExtras).not.toHaveBeenCalled();
+    });
+  });
+
+  // ========================================================================
+  // Tag extraction (Issue #2964: Sentry setTag vs setExtras separation)
+  // ========================================================================
+  describe('tag extraction', () => {
+    // Tag fields: errorType, schema, service, jurisdiction, planid, role
+    // These should be extracted and set via setTag() with lowercase values
+
+    describe('captureException', () => {
+      it('extracts errorType as tag with lowercase value', async () => {
+        const { initDiagnostics, captureException } = await importFresh();
+        const client = createMockClient();
+        const baseScope = createMockScope();
+
+        initDiagnostics(client as never, baseScope as never);
+
+        captureException(new Error('test'), { errorType: 'TECHNICAL' });
+
+        const clonedScope = baseScope.clone.mock.results[0].value;
+        expect(clonedScope.setTag).toHaveBeenCalledWith('errorType', 'technical');
+      });
+
+      it('extracts schema as tag with lowercase value', async () => {
+        const { initDiagnostics, captureException } = await importFresh();
+        const client = createMockClient();
+        const baseScope = createMockScope();
+
+        initDiagnostics(client as never, baseScope as never);
+
+        captureException(new Error('test'), { schema: 'SecretResponse' });
+
+        const clonedScope = baseScope.clone.mock.results[0].value;
+        expect(clonedScope.setTag).toHaveBeenCalledWith('schema', 'secretresponse');
+      });
+
+      it('extracts service as tag with lowercase value', async () => {
+        const { initDiagnostics, captureException } = await importFresh();
+        const client = createMockClient();
+        const baseScope = createMockScope();
+
+        initDiagnostics(client as never, baseScope as never);
+
+        captureException(new Error('test'), { service: 'WEB' });
+
+        const clonedScope = baseScope.clone.mock.results[0].value;
+        expect(clonedScope.setTag).toHaveBeenCalledWith('service', 'web');
+      });
+
+      it('extracts jurisdiction as tag with lowercase value', async () => {
+        const { initDiagnostics, captureException } = await importFresh();
+        const client = createMockClient();
+        const baseScope = createMockScope();
+
+        initDiagnostics(client as never, baseScope as never);
+
+        captureException(new Error('test'), { jurisdiction: 'EU' });
+
+        const clonedScope = baseScope.clone.mock.results[0].value;
+        expect(clonedScope.setTag).toHaveBeenCalledWith('jurisdiction', 'eu');
+      });
+
+      it('extracts planid as tag with lowercase value', async () => {
+        const { initDiagnostics, captureException } = await importFresh();
+        const client = createMockClient();
+        const baseScope = createMockScope();
+
+        initDiagnostics(client as never, baseScope as never);
+
+        captureException(new Error('test'), { planid: 'ENTERPRISE_V2' });
+
+        const clonedScope = baseScope.clone.mock.results[0].value;
+        expect(clonedScope.setTag).toHaveBeenCalledWith('planid', 'enterprise_v2');
+      });
+
+      it('extracts role as tag with lowercase value', async () => {
+        const { initDiagnostics, captureException } = await importFresh();
+        const client = createMockClient();
+        const baseScope = createMockScope();
+
+        initDiagnostics(client as never, baseScope as never);
+
+        captureException(new Error('test'), { role: 'CUSTOMER' });
+
+        const clonedScope = baseScope.clone.mock.results[0].value;
+        expect(clonedScope.setTag).toHaveBeenCalledWith('role', 'customer');
+      });
+
+      it('extracts all 6 tag fields when present', async () => {
+        const { initDiagnostics, captureException } = await importFresh();
+        const client = createMockClient();
+        const baseScope = createMockScope();
+
+        initDiagnostics(client as never, baseScope as never);
+
+        captureException(new Error('test'), {
+          errorType: 'HUMAN',
+          schema: 'UserResponse',
+          service: 'API',
+          jurisdiction: 'US',
+          planid: 'PRO',
+          role: 'COLONEL',
+        });
+
+        const clonedScope = baseScope.clone.mock.results[0].value;
+        expect(clonedScope.setTag).toHaveBeenCalledWith('errorType', 'human');
+        expect(clonedScope.setTag).toHaveBeenCalledWith('schema', 'userresponse');
+        expect(clonedScope.setTag).toHaveBeenCalledWith('service', 'api');
+        expect(clonedScope.setTag).toHaveBeenCalledWith('jurisdiction', 'us');
+        expect(clonedScope.setTag).toHaveBeenCalledWith('planid', 'pro');
+        expect(clonedScope.setTag).toHaveBeenCalledWith('role', 'colonel');
+        expect(clonedScope.setTag).toHaveBeenCalledTimes(6);
+      });
+
+      it('separates tag fields from non-tag fields correctly', async () => {
+        const { initDiagnostics, captureException } = await importFresh();
+        const client = createMockClient();
+        const baseScope = createMockScope();
+
+        initDiagnostics(client as never, baseScope as never);
+
+        captureException(new Error('test'), {
+          errorType: 'SECURITY',
+          schema: 'SecretResponse',
+          issues: [{ path: 'field', message: 'invalid' }],
+          userId: '12345',
+          timestamp: Date.now(),
+        });
+
+        const clonedScope = baseScope.clone.mock.results[0].value;
+
+        // Tag fields should be set via setTag
+        expect(clonedScope.setTag).toHaveBeenCalledWith('errorType', 'security');
+        expect(clonedScope.setTag).toHaveBeenCalledWith('schema', 'secretresponse');
+        expect(clonedScope.setTag).toHaveBeenCalledTimes(2);
+
+        // Non-tag fields should be set via setExtras
+        expect(clonedScope.setExtras).toHaveBeenCalledTimes(1);
+        const extrasArg = clonedScope.setExtras.mock.calls[0][0];
+        expect(extrasArg).toHaveProperty('issues');
+        expect(extrasArg).toHaveProperty('userId', '12345');
+        expect(extrasArg).toHaveProperty('timestamp');
+        expect(extrasArg).not.toHaveProperty('errorType');
+        expect(extrasArg).not.toHaveProperty('schema');
+      });
+
+      it('does not call setTag for null tag values', async () => {
+        const { initDiagnostics, captureException } = await importFresh();
+        const client = createMockClient();
+        const baseScope = createMockScope();
+
+        initDiagnostics(client as never, baseScope as never);
+
+        captureException(new Error('test'), {
+          errorType: null,
+          schema: 'SecretResponse',
+        });
+
+        const clonedScope = baseScope.clone.mock.results[0].value;
+
+        // Only schema should be set as a tag
+        expect(clonedScope.setTag).toHaveBeenCalledWith('schema', 'secretresponse');
+        expect(clonedScope.setTag).toHaveBeenCalledTimes(1);
+
+        // null value should go to extras (not filtered out)
+        const extrasArg = clonedScope.setExtras.mock.calls[0][0];
+        expect(extrasArg).toHaveProperty('errorType', null);
+      });
+
+      it('does not call setTag for undefined tag values', async () => {
+        const { initDiagnostics, captureException } = await importFresh();
+        const client = createMockClient();
+        const baseScope = createMockScope();
+
+        initDiagnostics(client as never, baseScope as never);
+
+        captureException(new Error('test'), {
+          errorType: undefined,
+          schema: 'SecretResponse',
+        });
+
+        const clonedScope = baseScope.clone.mock.results[0].value;
+
+        // Only schema should be set as a tag
+        expect(clonedScope.setTag).toHaveBeenCalledWith('schema', 'secretresponse');
+        expect(clonedScope.setTag).toHaveBeenCalledTimes(1);
+
+        // undefined value should go to extras (not filtered out)
+        const extrasArg = clonedScope.setExtras.mock.calls[0][0];
+        expect(extrasArg).toHaveProperty('errorType', undefined);
+      });
+
+      it('sets empty string tag values (does not skip them)', async () => {
+        const { initDiagnostics, captureException } = await importFresh();
+        const client = createMockClient();
+        const baseScope = createMockScope();
+
+        initDiagnostics(client as never, baseScope as never);
+
+        captureException(new Error('test'), {
+          errorType: '',
+          schema: 'SecretResponse',
+        });
+
+        const clonedScope = baseScope.clone.mock.results[0].value;
+
+        // Empty string is a valid value, should be set as tag
+        expect(clonedScope.setTag).toHaveBeenCalledWith('errorType', '');
+        expect(clonedScope.setTag).toHaveBeenCalledWith('schema', 'secretresponse');
+        expect(clonedScope.setTag).toHaveBeenCalledTimes(2);
+      });
+
+      it('context with only non-tag fields calls setExtras only', async () => {
+        const { initDiagnostics, captureException } = await importFresh();
+        const client = createMockClient();
+        const baseScope = createMockScope();
+
+        initDiagnostics(client as never, baseScope as never);
+
+        captureException(new Error('test'), {
+          userId: '12345',
+          action: 'create',
+          payload: { data: 'test' },
+        });
+
+        const clonedScope = baseScope.clone.mock.results[0].value;
+
+        expect(clonedScope.setTag).not.toHaveBeenCalled();
+        expect(clonedScope.setExtras).toHaveBeenCalledWith({
+          userId: '12345',
+          action: 'create',
+          payload: { data: 'test' },
+        });
+      });
+
+      it('context with only tag fields does not call setExtras', async () => {
+        const { initDiagnostics, captureException } = await importFresh();
+        const client = createMockClient();
+        const baseScope = createMockScope();
+
+        initDiagnostics(client as never, baseScope as never);
+
+        captureException(new Error('test'), {
+          errorType: 'technical',
+          schema: 'SecretResponse',
+          service: 'web',
+          jurisdiction: 'eu',
+          planid: 'basic',
+          role: 'customer',
+        });
+
+        const clonedScope = baseScope.clone.mock.results[0].value;
+
+        expect(clonedScope.setTag).toHaveBeenCalledTimes(6);
+        expect(clonedScope.setExtras).not.toHaveBeenCalled();
+      });
+
+      it('converts non-string tag values to strings', async () => {
+        const { initDiagnostics, captureException } = await importFresh();
+        const client = createMockClient();
+        const baseScope = createMockScope();
+
+        initDiagnostics(client as never, baseScope as never);
+
+        // Pass a number (which will be stringified)
+        captureException(new Error('test'), {
+          errorType: 123 as unknown as string,
+        });
+
+        const clonedScope = baseScope.clone.mock.results[0].value;
+        expect(clonedScope.setTag).toHaveBeenCalledWith('errorType', '123');
+      });
+    });
+
+    describe('captureMessage', () => {
+      it('extracts tag fields the same way as captureException', async () => {
+        const { initDiagnostics, captureMessage } = await importFresh();
+        const client = createMockClient();
+        const baseScope = createMockScope();
+
+        initDiagnostics(client as never, baseScope as never);
+
+        captureMessage('test message', {
+          errorType: 'HUMAN',
+          schema: 'UserResponse',
+          service: 'API',
+          jurisdiction: 'US',
+          planid: 'PRO',
+          role: 'COLONEL',
+          customField: 'value',
+        });
+
+        const clonedScope = baseScope.clone.mock.results[0].value;
+
+        // All 6 tag fields should be extracted
+        expect(clonedScope.setTag).toHaveBeenCalledWith('errorType', 'human');
+        expect(clonedScope.setTag).toHaveBeenCalledWith('schema', 'userresponse');
+        expect(clonedScope.setTag).toHaveBeenCalledWith('service', 'api');
+        expect(clonedScope.setTag).toHaveBeenCalledWith('jurisdiction', 'us');
+        expect(clonedScope.setTag).toHaveBeenCalledWith('planid', 'pro');
+        expect(clonedScope.setTag).toHaveBeenCalledWith('role', 'colonel');
+        expect(clonedScope.setTag).toHaveBeenCalledTimes(6);
+
+        // Non-tag field should go to extras
+        expect(clonedScope.setExtras).toHaveBeenCalledWith({ customField: 'value' });
+      });
+
+      it('handles null/undefined tag values correctly', async () => {
+        const { initDiagnostics, captureMessage } = await importFresh();
+        const client = createMockClient();
+        const baseScope = createMockScope();
+
+        initDiagnostics(client as never, baseScope as never);
+
+        captureMessage('test message', {
+          errorType: null,
+          schema: undefined,
+          service: 'web',
+        });
+
+        const clonedScope = baseScope.clone.mock.results[0].value;
+
+        // Only service should be set as a tag
+        expect(clonedScope.setTag).toHaveBeenCalledWith('service', 'web');
+        expect(clonedScope.setTag).toHaveBeenCalledTimes(1);
+
+        // null/undefined values should go to extras
+        const extrasArg = clonedScope.setExtras.mock.calls[0][0];
+        expect(extrasArg).toHaveProperty('errorType', null);
+        expect(extrasArg).toHaveProperty('schema', undefined);
+      });
+    });
+
+    describe('tag isolation between calls', () => {
+      it('tags from one call do not leak to the next', async () => {
+        const { initDiagnostics, captureException } = await importFresh();
+        const client = createMockClient();
+        const baseScope = createMockScope();
+
+        initDiagnostics(client as never, baseScope as never);
+
+        // First call with tags
+        captureException(new Error('first'), {
+          errorType: 'security',
+          schema: 'SecretResponse',
+        });
+
+        // Second call without tags
+        captureException(new Error('second'), {
+          customField: 'value',
+        });
+
+        const secondClonedScope = baseScope.clone.mock.results[1].value;
+
+        // Second call should not have any tags set
+        expect(secondClonedScope.setTag).not.toHaveBeenCalled();
+
+        // Base scope should never have setTag called directly
+        expect(baseScope.setTag).not.toHaveBeenCalled();
+      });
     });
   });
 });


### PR DESCRIPTION
## Summary

Refactors Sentry error reporting to use `setTag()` for fields that need to be searchable in Sentry dashboards. Tags are indexed by Sentry's backend, while extras are not—this means we can now filter and query errors by:

- `service` (web vs api)
- `errorType` (error classification)  
- `jurisdiction` (user's data region)
- `planid` (subscription tier)
- `role` (user role)
- `schema` (validation schema that failed)

All tag values are normalized to lowercase for consistent querying.

## Changes

**Core refactor in `diagnostics.service.ts`**: New `applyTagsFromContext()` function extracts tag-eligible fields from context and applies them via `scope.setTag()`. Non-tag fields continue to use `setExtras()` as before.

**Global tagging in `enableDiagnostics.ts`**: Sets `service: 'web'` on all frontend events.

**Error boundary integration**: `globalErrorBoundary.ts` now passes bootstrap context (jurisdiction, planid, role) through the diagnostics service.

**Simplified `useAsyncHandler.ts`**: Removed direct Sentry injection pattern, now delegates to centralized `captureException()` with context.

## Test plan

- [x] 388 new test lines covering tag extraction, normalization, and edge cases
- [x] Tests for null/undefined handling, type coercion, and tag isolation between calls
- [ ] Verify tagged errors appear correctly in Sentry dashboard