### PR TITLE
[#2972] Add distributed tracing across Web → RabbitMQ → Workers

### DIFF
--- a/apps/web/billing/workers/billing_worker.rb
+++ b/apps/web/billing/workers/billing_worker.rb
@@ -92,50 +92,52 @@ module Billing
       def work_with_params(msg, delivery_info, metadata)
         store_envelope(delivery_info, metadata)
 
-        data = parse_message(msg)
-        return unless data # parse_message handles reject on error
+        with_trace_context do
+          data = parse_message(msg)
+          return unless data # parse_message handles reject on error
 
-        # Handle ping test messages (from: bin/ots queue ping)
-        if data[:event_type] == 'ping.test'
-          log_info 'Received ping test', event_type: data[:event_type], event_id: data[:event_id]
-          return ack!
+          # Handle ping test messages (from: bin/ots queue ping)
+          if data[:event_type] == 'ping.test'
+            log_info 'Received ping test', event_type: data[:event_type], event_id: data[:event_id]
+            return ack!
+          end
+
+          # Atomic idempotency claim: only one worker can claim a message
+          unless claim_for_processing(message_id)
+            log_info "Skipping duplicate message: #{message_id}"
+            return ack!
+          end
+
+          log_debug "Processing billing event: #{data[:event_type]} (metadata: #{message_metadata})"
+
+          # Reconstruct Stripe event from raw payload
+          event = reconstruct_stripe_event(data)
+          return reject! unless event
+
+          # Delegate to operation with retry logic
+          result = nil
+          with_retry(max_retries: 3, base_delay: 2.0) do
+            result = process_event(event, data)
+          end
+
+          # Handle circuit retry scheduling - don't mark as success if queued for retry
+          if result == :queued
+            log_info "Billing event queued for circuit retry: #{data[:event_type]}", event_id: data[:event_id]
+          else
+            # Mark event as successfully processed in tracking record
+            mark_event_success(data[:event_id])
+            log_info "Billing event processed: #{data[:event_type]}", event_id: data[:event_id]
+          end
+
+          ack!
+        rescue StandardError => ex
+          log_error 'Unexpected error processing billing event', ex
+
+          # Mark event as failed in tracking record
+          mark_event_failed(data[:event_id], ex) if data
+
+          reject! # Send to DLQ
         end
-
-        # Atomic idempotency claim: only one worker can claim a message
-        unless claim_for_processing(message_id)
-          log_info "Skipping duplicate message: #{message_id}"
-          return ack!
-        end
-
-        log_debug "Processing billing event: #{data[:event_type]} (metadata: #{message_metadata})"
-
-        # Reconstruct Stripe event from raw payload
-        event = reconstruct_stripe_event(data)
-        return reject! unless event
-
-        # Delegate to operation with retry logic
-        result = nil
-        with_retry(max_retries: 3, base_delay: 2.0) do
-          result = process_event(event, data)
-        end
-
-        # Handle circuit retry scheduling - don't mark as success if queued for retry
-        if result == :queued
-          log_info "Billing event queued for circuit retry: #{data[:event_type]}", event_id: data[:event_id]
-        else
-          # Mark event as successfully processed in tracking record
-          mark_event_success(data[:event_id])
-          log_info "Billing event processed: #{data[:event_type]}", event_id: data[:event_id]
-        end
-
-        ack!
-      rescue StandardError => ex
-        log_error 'Unexpected error processing billing event', ex
-
-        # Mark event as failed in tracking record
-        mark_event_failed(data[:event_id], ex) if data
-
-        reject! # Send to DLQ
       end
 
       private

--- a/apps/web/billing/workers/billing_worker.rb
+++ b/apps/web/billing/workers/billing_worker.rb
@@ -93,54 +93,52 @@ module Billing
         store_envelope(delivery_info, metadata)
 
         data = nil
-        begin
-          with_trace_context do
-            data = parse_message(msg)
-            return unless data # parse_message handles reject on error
+        with_trace_context do
+          data = parse_message(msg)
+          return unless data # parse_message handles reject on error
 
-            # Handle ping test messages (from: bin/ots queue ping)
-            if data[:event_type] == 'ping.test'
-              log_info 'Received ping test', event_type: data[:event_type], event_id: data[:event_id]
-              return ack!
-            end
-
-            # Atomic idempotency claim: only one worker can claim a message
-            unless claim_for_processing(message_id)
-              log_info "Skipping duplicate message: #{message_id}"
-              return ack!
-            end
-
-            log_debug "Processing billing event: #{data[:event_type]} (metadata: #{message_metadata})"
-
-            # Reconstruct Stripe event from raw payload
-            event = reconstruct_stripe_event(data)
-            return reject! unless event
-
-            # Delegate to operation with retry logic
-            result = nil
-            with_retry(max_retries: 3, base_delay: 2.0) do
-              result = process_event(event, data)
-            end
-
-            # Handle circuit retry scheduling - don't mark as success if queued for retry
-            if result == :queued
-              log_info "Billing event queued for circuit retry: #{data[:event_type]}", event_id: data[:event_id]
-            else
-              # Mark event as successfully processed in tracking record
-              mark_event_success(data[:event_id])
-              log_info "Billing event processed: #{data[:event_type]}", event_id: data[:event_id]
-            end
-
-            ack!
+          # Handle ping test messages (from: bin/ots queue ping)
+          if data[:event_type] == 'ping.test'
+            log_info 'Received ping test', event_type: data[:event_type], event_id: data[:event_id]
+            return ack!
           end
-        rescue StandardError => ex
-          log_error 'Unexpected error processing billing event', ex
 
-          # Mark event as failed in tracking record
-          mark_event_failed(data[:event_id], ex) if data
+          # Atomic idempotency claim: only one worker can claim a message
+          unless claim_for_processing(message_id)
+            log_info "Skipping duplicate message: #{message_id}"
+            return ack!
+          end
 
-          reject! # Send to DLQ
+          log_debug "Processing billing event: #{data[:event_type]} (metadata: #{message_metadata})"
+
+          # Reconstruct Stripe event from raw payload
+          event = reconstruct_stripe_event(data)
+          return reject! unless event
+
+          # Delegate to operation with retry logic
+          result = nil
+          with_retry(max_retries: 3, base_delay: 2.0) do
+            result = process_event(event, data)
+          end
+
+          # Handle circuit retry scheduling - don't mark as success if queued for retry
+          if result == :queued
+            log_info "Billing event queued for circuit retry: #{data[:event_type]}", event_id: data[:event_id]
+          else
+            # Mark event as successfully processed in tracking record
+            mark_event_success(data[:event_id])
+            log_info "Billing event processed: #{data[:event_type]}", event_id: data[:event_id]
+          end
+
+          ack!
         end
+      rescue StandardError => ex
+        log_error 'Unexpected error processing billing event', ex
+
+        # Mark event as failed in tracking record
+        mark_event_failed(data[:event_id], ex) if data
+
+        reject! # Send to DLQ
       end
 
       private

--- a/apps/web/billing/workers/billing_worker.rb
+++ b/apps/web/billing/workers/billing_worker.rb
@@ -92,44 +92,47 @@ module Billing
       def work_with_params(msg, delivery_info, metadata)
         store_envelope(delivery_info, metadata)
 
-        with_trace_context do
-          data = parse_message(msg)
-          return unless data # parse_message handles reject on error
+        data = nil
+        begin
+          with_trace_context do
+            data = parse_message(msg)
+            return unless data # parse_message handles reject on error
 
-          # Handle ping test messages (from: bin/ots queue ping)
-          if data[:event_type] == 'ping.test'
-            log_info 'Received ping test', event_type: data[:event_type], event_id: data[:event_id]
-            return ack!
+            # Handle ping test messages (from: bin/ots queue ping)
+            if data[:event_type] == 'ping.test'
+              log_info 'Received ping test', event_type: data[:event_type], event_id: data[:event_id]
+              return ack!
+            end
+
+            # Atomic idempotency claim: only one worker can claim a message
+            unless claim_for_processing(message_id)
+              log_info "Skipping duplicate message: #{message_id}"
+              return ack!
+            end
+
+            log_debug "Processing billing event: #{data[:event_type]} (metadata: #{message_metadata})"
+
+            # Reconstruct Stripe event from raw payload
+            event = reconstruct_stripe_event(data)
+            return reject! unless event
+
+            # Delegate to operation with retry logic
+            result = nil
+            with_retry(max_retries: 3, base_delay: 2.0) do
+              result = process_event(event, data)
+            end
+
+            # Handle circuit retry scheduling - don't mark as success if queued for retry
+            if result == :queued
+              log_info "Billing event queued for circuit retry: #{data[:event_type]}", event_id: data[:event_id]
+            else
+              # Mark event as successfully processed in tracking record
+              mark_event_success(data[:event_id])
+              log_info "Billing event processed: #{data[:event_type]}", event_id: data[:event_id]
+            end
+
+            ack!
           end
-
-          # Atomic idempotency claim: only one worker can claim a message
-          unless claim_for_processing(message_id)
-            log_info "Skipping duplicate message: #{message_id}"
-            return ack!
-          end
-
-          log_debug "Processing billing event: #{data[:event_type]} (metadata: #{message_metadata})"
-
-          # Reconstruct Stripe event from raw payload
-          event = reconstruct_stripe_event(data)
-          return reject! unless event
-
-          # Delegate to operation with retry logic
-          result = nil
-          with_retry(max_retries: 3, base_delay: 2.0) do
-            result = process_event(event, data)
-          end
-
-          # Handle circuit retry scheduling - don't mark as success if queued for retry
-          if result == :queued
-            log_info "Billing event queued for circuit retry: #{data[:event_type]}", event_id: data[:event_id]
-          else
-            # Mark event as successfully processed in tracking record
-            mark_event_success(data[:event_id])
-            log_info "Billing event processed: #{data[:event_type]}", event_id: data[:event_id]
-          end
-
-          ack!
         rescue StandardError => ex
           log_error 'Unexpected error processing billing event', ex
 

--- a/lib/onetime/jobs/publisher.rb
+++ b/lib/onetime/jobs/publisher.rb
@@ -5,6 +5,7 @@
 require 'securerandom'
 require 'time'
 require_relative 'queues/config'
+require_relative 'trace_propagation'
 
 module Onetime
   module Jobs
@@ -339,13 +340,19 @@ module Onetime
 
         message_id = SecureRandom.uuid
 
+        # Capture Sentry trace context BEFORE any async operations.
+        # New threads lose Sentry context, so extract headers in the request thread.
+        trace_headers = TracePropagation.extract_trace_headers
+
         $rmq_channel_pool.with do |channel|
           channel.default_exchange.publish(
             payload.to_json,
             routing_key: queue_name,
             persistent: true,
             message_id: message_id,
-            headers: { 'x-schema-version' => QueueConfig::CURRENT_SCHEMA_VERSION },
+            headers: {
+              'x-schema-version' => QueueConfig::CURRENT_SCHEMA_VERSION,
+            }.merge(trace_headers),
             **,
           )
         end

--- a/lib/onetime/jobs/trace_propagation.rb
+++ b/lib/onetime/jobs/trace_propagation.rb
@@ -1,0 +1,129 @@
+# lib/onetime/jobs/trace_propagation.rb
+#
+# frozen_string_literal: true
+
+module Onetime
+  module Jobs
+    # Sentry distributed tracing utilities for RabbitMQ message propagation.
+    #
+    # Enables trace context to flow from web requests to background workers,
+    # linking errors and performance data in Sentry.
+    #
+    # Publisher side (web request):
+    #   headers = TracePropagation.extract_trace_headers
+    #   channel.publish(payload, headers: headers.merge(other_headers))
+    #
+    # Worker side (background job):
+    #   trace_headers = TracePropagation.parse_trace_headers(metadata)
+    #   TracePropagation.continue_trace(trace_headers, name: 'queue.process') do
+    #     # process message - errors will be linked to originating request
+    #   end
+    #
+    module TracePropagation
+      # Standard Sentry trace header names
+      SENTRY_TRACE_HEADER = 'sentry-trace'
+      BAGGAGE_HEADER      = 'baggage'
+
+      class << self
+        # Extract current Sentry trace headers for outgoing messages.
+        #
+        # Should be called from the request thread before any async fallback,
+        # as new threads lose Sentry context.
+        #
+        # @return [Hash<String, String>] Trace headers to include in message,
+        #   or empty hash if Sentry not configured or no active trace
+        def extract_trace_headers
+          return {} unless sentry_available?
+          return {} unless Sentry.get_current_scope&.get_span
+
+          Sentry.get_trace_propagation_headers || {}
+        rescue StandardError => ex
+          # Don't let tracing failures break message publishing
+          log_trace_error('extract_trace_headers', ex)
+          {}
+        end
+
+        # Parse trace headers from incoming message metadata.
+        #
+        # Handles nil gracefully for backwards compatibility with messages
+        # published before trace propagation was implemented.
+        #
+        # @param metadata [Bunny::MessageProperties, nil] AMQP message properties
+        # @return [Hash<String, String>] Trace headers or empty hash
+        def parse_trace_headers(metadata)
+          return {} unless metadata
+
+          headers = metadata.headers
+          return {} unless headers.is_a?(Hash)
+
+          result                      = {}
+          result[SENTRY_TRACE_HEADER] = headers[SENTRY_TRACE_HEADER] if headers[SENTRY_TRACE_HEADER]
+          result[BAGGAGE_HEADER]      = headers[BAGGAGE_HEADER] if headers[BAGGAGE_HEADER]
+          result
+        rescue StandardError => ex
+          log_trace_error('parse_trace_headers', ex)
+          {}
+        end
+
+        # Continue a trace from parsed headers and wrap processing in a transaction.
+        #
+        # If no trace headers are present, creates a new root transaction.
+        # If Sentry is not available, yields without creating a transaction.
+        #
+        # @param trace_headers [Hash<String, String>] Headers from parse_trace_headers
+        # @param name [String] Transaction name (e.g., 'queue.process')
+        # @param op [String] Span operation (e.g., 'queue.process')
+        # @yield Block to execute within the transaction
+        # @return Result of the block
+        def continue_trace(trace_headers, name:, op: 'queue.process')
+          unless sentry_available?
+            return yield if block_given?
+
+            return nil
+          end
+
+          # Sentry.continue_trace returns a transaction or nil
+          transaction = Sentry.continue_trace(trace_headers, name: name, op: op)
+
+          unless transaction
+            # No trace context - still yield but without transaction wrapping
+            return yield if block_given?
+
+            return nil
+          end
+
+          # Set the transaction as the current span
+          Sentry.get_current_scope.set_span(transaction)
+
+          begin
+            result = yield if block_given?
+            transaction.set_status('ok')
+            result
+          rescue StandardError
+            transaction.set_status('internal_error')
+            raise
+          ensure
+            transaction.finish
+          end
+        end
+
+        private
+
+        # Check if Sentry is available and initialized
+        # @return [Boolean]
+        def sentry_available?
+          defined?(Sentry) && Sentry.initialized?
+        end
+
+        # Log trace-related errors without breaking the main flow
+        # @param operation [String] Which operation failed
+        # @param error [StandardError] The error that occurred
+        def log_trace_error(operation, error)
+          return unless defined?(OT)
+
+          OT.ld "[trace_propagation] #{operation} failed: #{error.class} - #{error.message}"
+        end
+      end
+    end
+  end
+end

--- a/lib/onetime/jobs/trace_propagation.rb
+++ b/lib/onetime/jobs/trace_propagation.rb
@@ -70,6 +70,10 @@ module Onetime
         # If no trace headers are present, creates a new root transaction.
         # If Sentry is not available, yields without creating a transaction.
         #
+        # Uses Sentry.with_scope to ensure the transaction is set on a LOCAL scope,
+        # preventing span leakage in multi-threaded workers. Sets status to 'ok'
+        # before yielding to handle non-local returns (e.g., `return ack!`).
+        #
         # @param trace_headers [Hash<String, String>] Headers from parse_trace_headers
         # @param name [String] Transaction name (e.g., 'queue.process')
         # @param op [String] Span operation (e.g., 'queue.process')
@@ -82,28 +86,29 @@ module Onetime
             return nil
           end
 
-          # Sentry.continue_trace returns a transaction or nil
-          transaction = Sentry.continue_trace(trace_headers, name: name, op: op)
+          Sentry.with_scope do |scope|
+            transaction = Sentry.continue_trace(trace_headers, name: name, op: op)
 
-          unless transaction
-            # No trace context - still yield but without transaction wrapping
-            return yield if block_given?
+            unless transaction
+              return yield if block_given?
 
-            return nil
-          end
+              return nil
+            end
 
-          # Set the transaction as the current span
-          Sentry.get_current_scope.set_span(transaction)
+            # Set transaction on LOCAL scope (not global)
+            scope.set_span(transaction)
 
-          begin
-            result = yield if block_given?
+            # Default to 'ok' to handle non-local returns (e.g. 'return' in block)
             transaction.set_status('ok')
-            result
-          rescue StandardError
-            transaction.set_status('internal_error')
-            raise
-          ensure
-            transaction.finish
+
+            begin
+              yield if block_given?
+            rescue StandardError
+              transaction.set_status('internal_error')
+              raise
+            ensure
+              transaction.finish
+            end
           end
         end
 

--- a/lib/onetime/jobs/workers/base_worker.rb
+++ b/lib/onetime/jobs/workers/base_worker.rb
@@ -5,6 +5,7 @@
 require 'sneakers'
 require 'json'
 require_relative '../../utils/retry_helper'
+require_relative '../trace_propagation'
 
 module Onetime
   module Jobs
@@ -66,6 +67,38 @@ module Onetime
           def store_envelope(delivery_info, metadata)
             @delivery_info = delivery_info
             @metadata      = metadata
+          end
+
+          # Extract Sentry trace headers from message metadata.
+          #
+          # Returns empty hash if no trace headers present (backwards compatible
+          # with messages published before trace propagation was implemented).
+          #
+          # @return [Hash<String, String>] Trace headers or empty hash
+          def extract_trace_headers
+            Onetime::Jobs::TracePropagation.parse_trace_headers(@metadata)
+          end
+
+          # Continue Sentry trace from message headers and wrap processing.
+          #
+          # Links worker errors and performance data to the originating web
+          # request in Sentry. Creates a new transaction if trace headers are
+          # absent. Safe to call even if Sentry is not configured.
+          #
+          # @param name [String] Transaction name (default: "rabbitmq.WorkerClass")
+          # @param op [String] Span operation (default: 'queue.process')
+          # @yield Block to execute within the transaction
+          # @return Result of the block
+          def with_trace_context(name: nil, op: 'queue.process', &)
+            trace_headers    = extract_trace_headers
+            transaction_name = name || "rabbitmq.#{worker_name}"
+
+            Onetime::Jobs::TracePropagation.continue_trace(
+              trace_headers,
+              name: transaction_name,
+              op: op,
+              &
+            )
           end
 
           # Parse and validate message payload

--- a/lib/onetime/jobs/workers/dns_record_check_worker.rb
+++ b/lib/onetime/jobs/workers/dns_record_check_worker.rb
@@ -88,92 +88,94 @@ module Onetime
         def work_with_params(msg, delivery_info, metadata)
           store_envelope(delivery_info, metadata)
 
-          data = parse_message(msg)
-          return unless data # parse_message handles reject on error
+          with_trace_context do
+            data = parse_message(msg)
+            return unless data # parse_message handles reject on error
 
-          # Handle ping test messages (from: bin/ots queue ping)
-          if data[:domain_id] == 'ping.test'
-            log_info 'Received ping test', domain_id: data[:domain_id]
-            return ack!
-          end
+            # Handle ping test messages (from: bin/ots queue ping)
+            if data[:domain_id] == 'ping.test'
+              log_info 'Received ping test', domain_id: data[:domain_id]
+              return ack!
+            end
 
-          # Atomic idempotency claim: only one worker can claim a message
-          unless claim_for_processing(message_id)
-            log_info "Skipping duplicate message: #{message_id}"
-            return ack!
-          end
+            # Atomic idempotency claim: only one worker can claim a message
+            unless claim_for_processing(message_id)
+              log_info "Skipping duplicate message: #{message_id}"
+              return ack!
+            end
 
-          domain_id = data[:domain_id]
-          log_debug "Checking DNS records: #{domain_id} (metadata: #{message_metadata})"
+            domain_id = data[:domain_id]
+            log_debug "Checking DNS records: #{domain_id} (metadata: #{message_metadata})"
 
-          # Load the mailer config for this domain
-          mailer_config = Onetime::CustomDomain::MailerConfig.find_by_domain_id(domain_id)
-          unless mailer_config
-            log_error "MailerConfig not found for domain_id: #{domain_id}", message_id: message_id, metadata: message_metadata
-            return ack! # Don't retry -- config won't appear on its own
-          end
+            # Load the mailer config for this domain
+            mailer_config = Onetime::CustomDomain::MailerConfig.find_by_domain_id(domain_id)
+            unless mailer_config
+              log_error "MailerConfig not found for domain_id: #{domain_id}", message_id: message_id, metadata: message_metadata
+              return ack! # Don't retry -- config won't appear on its own
+            end
 
-          # Mark job as processing
-          mailer_config.dns_check_status = JobLifecycle::PROCESSING
-          mailer_config.save_fields(:dns_check_status)
+            # Mark job as processing
+            mailer_config.dns_check_status = JobLifecycle::PROCESSING
+            mailer_config.save_fields(:dns_check_status)
 
-          # Load the sender strategy for DNS lookups (no credentials needed)
-          provider = mailer_config.effective_provider
-          strategy = Onetime::Mail::SenderStrategies.for_provider(provider)
+            # Load the sender strategy for DNS lookups (no credentials needed)
+            provider = mailer_config.effective_provider
+            strategy = Onetime::Mail::SenderStrategies.for_provider(provider)
 
-          # Perform DNS lookups with retry (DNS can be transiently flaky)
-          result = nil
-          with_retry(max_retries: 1, base_delay: 2.0) do
-            result = strategy.check_dns_records(mailer_config, credentials: {})
-          end
+            # Perform DNS lookups with retry (DNS can be transiently flaky)
+            result = nil
+            with_retry(max_retries: 1, base_delay: 2.0) do
+              result = strategy.check_dns_records(mailer_config, credentials: {})
+            end
 
-          # Persist the raw fact-finding results.
-          # dns_check_results is a jsonkey (own Redis key), so use value= directly.
-          # dns_check_completed_at and updated are scalar fields — save_fields handles those.
-          mailer_config.dns_check_results.value = result[:records]
+            # Persist the raw fact-finding results.
+            # dns_check_results is a jsonkey (own Redis key), so use value= directly.
+            # dns_check_completed_at and updated are scalar fields — save_fields handles those.
+            mailer_config.dns_check_results.value = result[:records]
 
-          # Compute dns_verified outcome: true if all records have value_matches=true
-          records                    = result[:records] || []
-          all_matched                = records.all? { |r| r['value_matches'] == true || r[:value_matches] == true }
-          mailer_config.dns_verified = all_matched
+            # Compute dns_verified outcome: true if all records have value_matches=true
+            records                    = result[:records] || []
+            all_matched                = records.all? { |r| r['value_matches'] == true || r[:value_matches] == true }
+            mailer_config.dns_verified = all_matched
 
-          # Mark job as completed
-          mailer_config.dns_check_status       = JobLifecycle::COMPLETED
-          mailer_config.dns_check_completed_at = Familia.now.to_i
-          mailer_config.updated                = Familia.now.to_i
-          mailer_config.save_fields(:dns_check_status, :dns_verified, :dns_check_completed_at, :updated)
-
-          # Refresh from Redis so we see the validation worker's latest status, not our
-          # in-memory copy which was loaded before that worker ran.
-          mailer_config.refresh!
-
-          # Update stored verification_status if both jobs are now complete
-          if mailer_config.jobs_completed?
-            final_status = mailer_config.update_verification_status!
-            log_info "DNS record check complete (final): #{domain_id}",
-              record_count: records.size,
-              dns_verified: all_matched,
-              verification_status: final_status
-          else
-            log_info "DNS record check complete: #{domain_id}",
-              record_count: records.size,
-              dns_verified: all_matched,
-              provider_check_status: mailer_config.provider_check_status
-          end
-
-          ack!
-        rescue StandardError => ex
-          # Mark job as failed before sending to DLQ
-          if mailer_config
-            mailer_config.dns_check_status       = JobLifecycle::FAILED
+            # Mark job as completed
+            mailer_config.dns_check_status       = JobLifecycle::COMPLETED
             mailer_config.dns_check_completed_at = Familia.now.to_i
-            mailer_config.last_error             = ex.message
             mailer_config.updated                = Familia.now.to_i
-            mailer_config.save_fields(:dns_check_status, :dns_check_completed_at, :last_error, :updated)
-          end
+            mailer_config.save_fields(:dns_check_status, :dns_verified, :dns_check_completed_at, :updated)
 
-          log_error 'Unexpected error checking DNS records', ex
-          reject! # Send to DLQ
+            # Refresh from Redis so we see the validation worker's latest status, not our
+            # in-memory copy which was loaded before that worker ran.
+            mailer_config.refresh!
+
+            # Update stored verification_status if both jobs are now complete
+            if mailer_config.jobs_completed?
+              final_status = mailer_config.update_verification_status!
+              log_info "DNS record check complete (final): #{domain_id}",
+                record_count: records.size,
+                dns_verified: all_matched,
+                verification_status: final_status
+            else
+              log_info "DNS record check complete: #{domain_id}",
+                record_count: records.size,
+                dns_verified: all_matched,
+                provider_check_status: mailer_config.provider_check_status
+            end
+
+            ack!
+          rescue StandardError => ex
+            # Mark job as failed before sending to DLQ
+            if mailer_config
+              mailer_config.dns_check_status       = JobLifecycle::FAILED
+              mailer_config.dns_check_completed_at = Familia.now.to_i
+              mailer_config.last_error             = ex.message
+              mailer_config.updated                = Familia.now.to_i
+              mailer_config.save_fields(:dns_check_status, :dns_check_completed_at, :last_error, :updated)
+            end
+
+            log_error 'Unexpected error checking DNS records', ex
+            reject! # Send to DLQ
+          end
         end
       end
     end

--- a/lib/onetime/jobs/workers/dns_record_check_worker.rb
+++ b/lib/onetime/jobs/workers/dns_record_check_worker.rb
@@ -90,96 +90,94 @@ module Onetime
 
           data          = nil
           mailer_config = nil
-          begin
-            with_trace_context do
-              data = parse_message(msg)
-              return unless data # parse_message handles reject on error
+          with_trace_context do
+            data = parse_message(msg)
+            return unless data # parse_message handles reject on error
 
-              # Handle ping test messages (from: bin/ots queue ping)
-              if data[:domain_id] == 'ping.test'
-                log_info 'Received ping test', domain_id: data[:domain_id]
-                return ack!
-              end
-
-              # Atomic idempotency claim: only one worker can claim a message
-              unless claim_for_processing(message_id)
-                log_info "Skipping duplicate message: #{message_id}"
-                return ack!
-              end
-
-              domain_id = data[:domain_id]
-              log_debug "Checking DNS records: #{domain_id} (metadata: #{message_metadata})"
-
-              # Load the mailer config for this domain
-              mailer_config = Onetime::CustomDomain::MailerConfig.find_by_domain_id(domain_id)
-              unless mailer_config
-                log_error "MailerConfig not found for domain_id: #{domain_id}", message_id: message_id, metadata: message_metadata
-                return ack! # Don't retry -- config won't appear on its own
-              end
-
-              # Mark job as processing
-              mailer_config.dns_check_status = JobLifecycle::PROCESSING
-              mailer_config.save_fields(:dns_check_status)
-
-              # Load the sender strategy for DNS lookups (no credentials needed)
-              provider = mailer_config.effective_provider
-              strategy = Onetime::Mail::SenderStrategies.for_provider(provider)
-
-              # Perform DNS lookups with retry (DNS can be transiently flaky)
-              result = nil
-              with_retry(max_retries: 1, base_delay: 2.0) do
-                result = strategy.check_dns_records(mailer_config, credentials: {})
-              end
-
-              # Persist the raw fact-finding results.
-              # dns_check_results is a jsonkey (own Redis key), so use value= directly.
-              # dns_check_completed_at and updated are scalar fields — save_fields handles those.
-              mailer_config.dns_check_results.value = result[:records]
-
-              # Compute dns_verified outcome: true if all records have value_matches=true
-              records                    = result[:records] || []
-              all_matched                = records.all? { |r| r['value_matches'] == true || r[:value_matches] == true }
-              mailer_config.dns_verified = all_matched
-
-              # Mark job as completed
-              mailer_config.dns_check_status       = JobLifecycle::COMPLETED
-              mailer_config.dns_check_completed_at = Familia.now.to_i
-              mailer_config.updated                = Familia.now.to_i
-              mailer_config.save_fields(:dns_check_status, :dns_verified, :dns_check_completed_at, :updated)
-
-              # Refresh from Redis so we see the validation worker's latest status, not our
-              # in-memory copy which was loaded before that worker ran.
-              mailer_config.refresh!
-
-              # Update stored verification_status if both jobs are now complete
-              if mailer_config.jobs_completed?
-                final_status = mailer_config.update_verification_status!
-                log_info "DNS record check complete (final): #{domain_id}",
-                  record_count: records.size,
-                  dns_verified: all_matched,
-                  verification_status: final_status
-              else
-                log_info "DNS record check complete: #{domain_id}",
-                  record_count: records.size,
-                  dns_verified: all_matched,
-                  provider_check_status: mailer_config.provider_check_status
-              end
-
-              ack!
-            end
-          rescue StandardError => ex
-            # Mark job as failed before sending to DLQ
-            if mailer_config
-              mailer_config.dns_check_status       = JobLifecycle::FAILED
-              mailer_config.dns_check_completed_at = Familia.now.to_i
-              mailer_config.last_error             = ex.message
-              mailer_config.updated                = Familia.now.to_i
-              mailer_config.save_fields(:dns_check_status, :dns_check_completed_at, :last_error, :updated)
+            # Handle ping test messages (from: bin/ots queue ping)
+            if data[:domain_id] == 'ping.test'
+              log_info 'Received ping test', domain_id: data[:domain_id]
+              return ack!
             end
 
-            log_error 'Unexpected error checking DNS records', ex
-            reject! # Send to DLQ
+            # Atomic idempotency claim: only one worker can claim a message
+            unless claim_for_processing(message_id)
+              log_info "Skipping duplicate message: #{message_id}"
+              return ack!
+            end
+
+            domain_id = data[:domain_id]
+            log_debug "Checking DNS records: #{domain_id} (metadata: #{message_metadata})"
+
+            # Load the mailer config for this domain
+            mailer_config = Onetime::CustomDomain::MailerConfig.find_by_domain_id(domain_id)
+            unless mailer_config
+              log_error "MailerConfig not found for domain_id: #{domain_id}", message_id: message_id, metadata: message_metadata
+              return ack! # Don't retry -- config won't appear on its own
+            end
+
+            # Mark job as processing
+            mailer_config.dns_check_status = JobLifecycle::PROCESSING
+            mailer_config.save_fields(:dns_check_status)
+
+            # Load the sender strategy for DNS lookups (no credentials needed)
+            provider = mailer_config.effective_provider
+            strategy = Onetime::Mail::SenderStrategies.for_provider(provider)
+
+            # Perform DNS lookups with retry (DNS can be transiently flaky)
+            result = nil
+            with_retry(max_retries: 1, base_delay: 2.0) do
+              result = strategy.check_dns_records(mailer_config, credentials: {})
+            end
+
+            # Persist the raw fact-finding results.
+            # dns_check_results is a jsonkey (own Redis key), so use value= directly.
+            # dns_check_completed_at and updated are scalar fields — save_fields handles those.
+            mailer_config.dns_check_results.value = result[:records]
+
+            # Compute dns_verified outcome: true if all records have value_matches=true
+            records                    = result[:records] || []
+            all_matched                = records.all? { |r| r['value_matches'] == true || r[:value_matches] == true }
+            mailer_config.dns_verified = all_matched
+
+            # Mark job as completed
+            mailer_config.dns_check_status       = JobLifecycle::COMPLETED
+            mailer_config.dns_check_completed_at = Familia.now.to_i
+            mailer_config.updated                = Familia.now.to_i
+            mailer_config.save_fields(:dns_check_status, :dns_verified, :dns_check_completed_at, :updated)
+
+            # Refresh from Redis so we see the validation worker's latest status, not our
+            # in-memory copy which was loaded before that worker ran.
+            mailer_config.refresh!
+
+            # Update stored verification_status if both jobs are now complete
+            if mailer_config.jobs_completed?
+              final_status = mailer_config.update_verification_status!
+              log_info "DNS record check complete (final): #{domain_id}",
+                record_count: records.size,
+                dns_verified: all_matched,
+                verification_status: final_status
+            else
+              log_info "DNS record check complete: #{domain_id}",
+                record_count: records.size,
+                dns_verified: all_matched,
+                provider_check_status: mailer_config.provider_check_status
+            end
+
+            ack!
           end
+        rescue StandardError => ex
+          # Mark job as failed before sending to DLQ
+          if mailer_config
+            mailer_config.dns_check_status       = JobLifecycle::FAILED
+            mailer_config.dns_check_completed_at = Familia.now.to_i
+            mailer_config.last_error             = ex.message
+            mailer_config.updated                = Familia.now.to_i
+            mailer_config.save_fields(:dns_check_status, :dns_check_completed_at, :last_error, :updated)
+          end
+
+          log_error 'Unexpected error checking DNS records', ex
+          reject! # Send to DLQ
         end
       end
     end

--- a/lib/onetime/jobs/workers/dns_record_check_worker.rb
+++ b/lib/onetime/jobs/workers/dns_record_check_worker.rb
@@ -88,81 +88,85 @@ module Onetime
         def work_with_params(msg, delivery_info, metadata)
           store_envelope(delivery_info, metadata)
 
-          with_trace_context do
-            data = parse_message(msg)
-            return unless data # parse_message handles reject on error
+          data          = nil
+          mailer_config = nil
+          begin
+            with_trace_context do
+              data = parse_message(msg)
+              return unless data # parse_message handles reject on error
 
-            # Handle ping test messages (from: bin/ots queue ping)
-            if data[:domain_id] == 'ping.test'
-              log_info 'Received ping test', domain_id: data[:domain_id]
-              return ack!
+              # Handle ping test messages (from: bin/ots queue ping)
+              if data[:domain_id] == 'ping.test'
+                log_info 'Received ping test', domain_id: data[:domain_id]
+                return ack!
+              end
+
+              # Atomic idempotency claim: only one worker can claim a message
+              unless claim_for_processing(message_id)
+                log_info "Skipping duplicate message: #{message_id}"
+                return ack!
+              end
+
+              domain_id = data[:domain_id]
+              log_debug "Checking DNS records: #{domain_id} (metadata: #{message_metadata})"
+
+              # Load the mailer config for this domain
+              mailer_config = Onetime::CustomDomain::MailerConfig.find_by_domain_id(domain_id)
+              unless mailer_config
+                log_error "MailerConfig not found for domain_id: #{domain_id}", message_id: message_id, metadata: message_metadata
+                return ack! # Don't retry -- config won't appear on its own
+              end
+
+              # Mark job as processing
+              mailer_config.dns_check_status = JobLifecycle::PROCESSING
+              mailer_config.save_fields(:dns_check_status)
+
+              # Load the sender strategy for DNS lookups (no credentials needed)
+              provider = mailer_config.effective_provider
+              strategy = Onetime::Mail::SenderStrategies.for_provider(provider)
+
+              # Perform DNS lookups with retry (DNS can be transiently flaky)
+              result = nil
+              with_retry(max_retries: 1, base_delay: 2.0) do
+                result = strategy.check_dns_records(mailer_config, credentials: {})
+              end
+
+              # Persist the raw fact-finding results.
+              # dns_check_results is a jsonkey (own Redis key), so use value= directly.
+              # dns_check_completed_at and updated are scalar fields — save_fields handles those.
+              mailer_config.dns_check_results.value = result[:records]
+
+              # Compute dns_verified outcome: true if all records have value_matches=true
+              records                    = result[:records] || []
+              all_matched                = records.all? { |r| r['value_matches'] == true || r[:value_matches] == true }
+              mailer_config.dns_verified = all_matched
+
+              # Mark job as completed
+              mailer_config.dns_check_status       = JobLifecycle::COMPLETED
+              mailer_config.dns_check_completed_at = Familia.now.to_i
+              mailer_config.updated                = Familia.now.to_i
+              mailer_config.save_fields(:dns_check_status, :dns_verified, :dns_check_completed_at, :updated)
+
+              # Refresh from Redis so we see the validation worker's latest status, not our
+              # in-memory copy which was loaded before that worker ran.
+              mailer_config.refresh!
+
+              # Update stored verification_status if both jobs are now complete
+              if mailer_config.jobs_completed?
+                final_status = mailer_config.update_verification_status!
+                log_info "DNS record check complete (final): #{domain_id}",
+                  record_count: records.size,
+                  dns_verified: all_matched,
+                  verification_status: final_status
+              else
+                log_info "DNS record check complete: #{domain_id}",
+                  record_count: records.size,
+                  dns_verified: all_matched,
+                  provider_check_status: mailer_config.provider_check_status
+              end
+
+              ack!
             end
-
-            # Atomic idempotency claim: only one worker can claim a message
-            unless claim_for_processing(message_id)
-              log_info "Skipping duplicate message: #{message_id}"
-              return ack!
-            end
-
-            domain_id = data[:domain_id]
-            log_debug "Checking DNS records: #{domain_id} (metadata: #{message_metadata})"
-
-            # Load the mailer config for this domain
-            mailer_config = Onetime::CustomDomain::MailerConfig.find_by_domain_id(domain_id)
-            unless mailer_config
-              log_error "MailerConfig not found for domain_id: #{domain_id}", message_id: message_id, metadata: message_metadata
-              return ack! # Don't retry -- config won't appear on its own
-            end
-
-            # Mark job as processing
-            mailer_config.dns_check_status = JobLifecycle::PROCESSING
-            mailer_config.save_fields(:dns_check_status)
-
-            # Load the sender strategy for DNS lookups (no credentials needed)
-            provider = mailer_config.effective_provider
-            strategy = Onetime::Mail::SenderStrategies.for_provider(provider)
-
-            # Perform DNS lookups with retry (DNS can be transiently flaky)
-            result = nil
-            with_retry(max_retries: 1, base_delay: 2.0) do
-              result = strategy.check_dns_records(mailer_config, credentials: {})
-            end
-
-            # Persist the raw fact-finding results.
-            # dns_check_results is a jsonkey (own Redis key), so use value= directly.
-            # dns_check_completed_at and updated are scalar fields — save_fields handles those.
-            mailer_config.dns_check_results.value = result[:records]
-
-            # Compute dns_verified outcome: true if all records have value_matches=true
-            records                    = result[:records] || []
-            all_matched                = records.all? { |r| r['value_matches'] == true || r[:value_matches] == true }
-            mailer_config.dns_verified = all_matched
-
-            # Mark job as completed
-            mailer_config.dns_check_status       = JobLifecycle::COMPLETED
-            mailer_config.dns_check_completed_at = Familia.now.to_i
-            mailer_config.updated                = Familia.now.to_i
-            mailer_config.save_fields(:dns_check_status, :dns_verified, :dns_check_completed_at, :updated)
-
-            # Refresh from Redis so we see the validation worker's latest status, not our
-            # in-memory copy which was loaded before that worker ran.
-            mailer_config.refresh!
-
-            # Update stored verification_status if both jobs are now complete
-            if mailer_config.jobs_completed?
-              final_status = mailer_config.update_verification_status!
-              log_info "DNS record check complete (final): #{domain_id}",
-                record_count: records.size,
-                dns_verified: all_matched,
-                verification_status: final_status
-            else
-              log_info "DNS record check complete: #{domain_id}",
-                record_count: records.size,
-                dns_verified: all_matched,
-                provider_check_status: mailer_config.provider_check_status
-            end
-
-            ack!
           rescue StandardError => ex
             # Mark job as failed before sending to DLQ
             if mailer_config

--- a/lib/onetime/jobs/workers/domain_validation_worker.rb
+++ b/lib/onetime/jobs/workers/domain_validation_worker.rb
@@ -117,146 +117,151 @@ module Onetime
         def work_with_params(msg, delivery_info, metadata)
           store_envelope(delivery_info, metadata)
 
-          with_trace_context do
-            data = parse_message(msg)
-            return unless data # parse_message handles reject on error
+          data          = nil
+          mailer_config = nil
+          domain_id     = nil
+          begin
+            with_trace_context do
+              data = parse_message(msg)
+              return unless data # parse_message handles reject on error
 
-            # Handle ping test messages (from: bin/ots queue ping)
-            if data[:domain_id] == 'ping.test'
-              log_info 'Received ping test', domain_id: data[:domain_id]
-              return ack!
-            end
+              # Handle ping test messages (from: bin/ots queue ping)
+              if data[:domain_id] == 'ping.test'
+                log_info 'Received ping test', domain_id: data[:domain_id]
+                return ack!
+              end
 
-            # Atomic idempotency claim: only one worker can claim a message
-            unless claim_for_processing(message_id)
-              log_info "Skipping duplicate message: #{message_id}"
-              return ack!
-            end
+              # Atomic idempotency claim: only one worker can claim a message
+              unless claim_for_processing(message_id)
+                log_info "Skipping duplicate message: #{message_id}"
+                return ack!
+              end
 
-            domain_id    = data[:domain_id]
-            bypass_cache = data[:bypass_cache] || false  # Backward compat for in-flight messages
-            log_debug "Validating sender domain DNS: #{domain_id} (bypass_cache: #{bypass_cache}, metadata: #{message_metadata})"
+              domain_id    = data[:domain_id]
+              bypass_cache = data[:bypass_cache] || false  # Backward compat for in-flight messages
+              log_debug "Validating sender domain DNS: #{domain_id} (bypass_cache: #{bypass_cache}, metadata: #{message_metadata})"
 
-            # Load the mailer config for this domain
-            mailer_config = Onetime::CustomDomain::MailerConfig.find_by_domain_id(domain_id)
-            unless mailer_config
-              log_error "MailerConfig not found for domain_id: #{domain_id}", message_id: message_id, metadata: message_metadata
-              return ack! # Don't retry -- config won't appear on its own
-            end
+              # Load the mailer config for this domain
+              mailer_config = Onetime::CustomDomain::MailerConfig.find_by_domain_id(domain_id)
+              unless mailer_config
+                log_error "MailerConfig not found for domain_id: #{domain_id}", message_id: message_id, metadata: message_metadata
+                return ack! # Don't retry -- config won't appear on its own
+              end
 
-            # Mark job as processing
-            mailer_config.provider_check_status = JobLifecycle::PROCESSING
-            mailer_config.save_fields(:provider_check_status)
+              # Mark job as processing
+              mailer_config.provider_check_status = JobLifecycle::PROCESSING
+              mailer_config.save_fields(:provider_check_status)
 
-            # Delegate to operation with retry logic (DNS can be transiently flaky)
-            # Don't retry rate limits - they won't clear for ~60 minutes
-            result = nil
-            with_retry(
-              max_retries: 2,
-              base_delay: 2.0,
-              retriable: ->(ex) { !ex.is_a?(Onetime::LimitExceeded) },
-            ) do
-              # persist: false because this worker controls verification_status
-              # through update_verification_status! after BOTH workers complete.
-              # The operation would otherwise set verification_status='verified'
-              # based on DNS alone, before the provider API check runs.
-              result = Onetime::Operations::ValidateSenderDomain.new(
-                mailer_config: mailer_config,
-                persist: false,
+              # Delegate to operation with retry logic (DNS can be transiently flaky)
+              # Don't retry rate limits - they won't clear for ~60 minutes
+              result = nil
+              with_retry(
+                max_retries: 2,
+                base_delay: 2.0,
+                retriable: ->(ex) { !ex.is_a?(Onetime::LimitExceeded) },
+              ) do
+                # persist: false because this worker controls verification_status
+                # through update_verification_status! after BOTH workers complete.
+                # The operation would otherwise set verification_status='verified'
+                # based on DNS alone, before the provider API check runs.
+                result = Onetime::Operations::ValidateSenderDomain.new(
+                  mailer_config: mailer_config,
+                  persist: false,
+                  bypass_cache: bypass_cache,
+                ).call
+                # Re-raise so with_retry can retry transient DNS failures.
+                # ValidateSenderDomain#call rescues internally and returns a
+                # Result — without this, with_retry never sees an exception.
+                raise result.error if result.error
+              end
+
+              log_info "Sender domain validation complete: #{domain_id}",
+                status: result.verification_status,
+                all_verified: result.all_verified,
+                persisted: result.persisted,
                 bypass_cache: bypass_cache,
-              ).call
-              # Re-raise so with_retry can retry transient DNS failures.
-              # ValidateSenderDomain#call rescues internally and returns a
-              # Result — without this, with_retry never sees an exception.
-              raise result.error if result.error
-            end
+                error: result.error
 
-            log_info "Sender domain validation complete: #{domain_id}",
-              status: result.verification_status,
-              all_verified: result.all_verified,
-              persisted: result.persisted,
-              bypass_cache: bypass_cache,
-              error: result.error
+              # Provider-level verification: ask the provider API if the domain is verified.
+              # This complements the DNS validation above.
+              provider_api_verified = nil
+              begin
+                provider = mailer_config.effective_provider
+                if provider && provider != 'smtp'
+                  require 'onetime/mail/sender_strategies'
+                  sender_strategy = Onetime::Mail::SenderStrategies.for_provider(provider)
+                  creds           = Onetime::Mail::Mailer.provider_credentials(provider)
 
-            # Provider-level verification: ask the provider API if the domain is verified.
-            # This complements the DNS validation above.
-            provider_api_verified = nil
-            begin
-              provider = mailer_config.effective_provider
-              if provider && provider != 'smtp'
-                require 'onetime/mail/sender_strategies'
-                sender_strategy = Onetime::Mail::SenderStrategies.for_provider(provider)
-                creds           = Onetime::Mail::Mailer.provider_credentials(provider)
-
-                if creds && !creds.empty?
-                  provider_result       = sender_strategy.check_provider_verification_status(mailer_config, credentials: creds)
-                  provider_api_verified = provider_result[:verified]
-                  log_info "Provider verification check: #{domain_id}",
-                    provider: provider,
-                    verified: provider_result[:verified],
-                    status: provider_result[:status]
-                else
-                  log_debug "Skipping provider check: no credentials for #{provider}"
+                  if creds && !creds.empty?
+                    provider_result       = sender_strategy.check_provider_verification_status(mailer_config, credentials: creds)
+                    provider_api_verified = provider_result[:verified]
+                    log_info "Provider verification check: #{domain_id}",
+                      provider: provider,
+                      verified: provider_result[:verified],
+                      status: provider_result[:status]
+                  else
+                    log_debug "Skipping provider check: no credentials for #{provider}"
+                  end
                 end
+
+                # Set provider_verified from provider API check when available.
+                # Fall back to DNS result only when no provider credentials exist
+                # (degraded mode - better than leaving nil).
+                mailer_config.provider_verified = if provider_api_verified.nil?
+                                                    result.all_verified
+                                                  else
+                                                    provider_api_verified
+                                                  end
+
+                # Record provider status when verification fails so UI can explain why
+                mailer_config.last_error = provider_api_verified == false && provider_result ? "Provider status: #{provider_result[:status]}" : nil
+
+                # Persist the provider's current domain status back into provider_dns_data
+                # so the UI can surface it (e.g. 'verified', 'pending_verification').
+                if provider_result
+                  current_provider_data                 = mailer_config.provider_dns_data.value || {}
+                  provider_records                      = provider_result.dig(:details, :dns_records) || []
+                  mailer_config.provider_dns_data.value = current_provider_data.merge(
+                    'status' => provider_result[:status],
+                    'dns_records' => provider_records,
+                    'raw_provider_response' => provider_result[:details],
+                  )
+                end
+
+                mailer_config.provider_check_status       = JobLifecycle::COMPLETED
+                mailer_config.provider_check_completed_at = Familia.now.to_i
+                mailer_config.updated                     = Familia.now.to_i
+                mailer_config.save_fields(:provider_verified, :provider_check_status, :provider_check_completed_at, :last_error, :updated)
+              rescue StandardError => ex
+                # Provider check failure should not fail the overall worker
+                log_error "Provider verification check failed for #{domain_id}", ex
+                # Mark as completed (not failed - the worker itself didn't crash)
+                # but don't set provider_verified since we couldn't determine it
+                mailer_config.provider_check_status       = JobLifecycle::COMPLETED
+                mailer_config.provider_check_completed_at = Familia.now.to_i
+                mailer_config.updated                     = Familia.now.to_i
+                mailer_config.save_fields(:provider_check_status, :provider_check_completed_at, :updated)
               end
 
-              # Set provider_verified from provider API check when available.
-              # Fall back to DNS result only when no provider credentials exist
-              # (degraded mode - better than leaving nil).
-              mailer_config.provider_verified = if provider_api_verified.nil?
-                                                  result.all_verified
-                                                else
-                                                  provider_api_verified
-                                                end
+              # Refresh from Redis so we see the DNS worker's latest status, not our
+              # in-memory copy which was loaded before that worker ran.
+              mailer_config.refresh!
 
-              # Record provider status when verification fails so UI can explain why
-              mailer_config.last_error = provider_api_verified == false && provider_result ? "Provider status: #{provider_result[:status]}" : nil
-
-              # Persist the provider's current domain status back into provider_dns_data
-              # so the UI can surface it (e.g. 'verified', 'pending_verification').
-              if provider_result
-                current_provider_data                 = mailer_config.provider_dns_data.value || {}
-                provider_records                      = provider_result.dig(:details, :dns_records) || []
-                mailer_config.provider_dns_data.value = current_provider_data.merge(
-                  'status' => provider_result[:status],
-                  'dns_records' => provider_records,
-                  'raw_provider_response' => provider_result[:details],
-                )
+              # Update stored verification_status if both jobs are now complete
+              if mailer_config.jobs_completed?
+                final_status = mailer_config.update_verification_status!
+                log_info "Domain validation final determination: #{domain_id}",
+                  verification_status: final_status,
+                  dns_verified: mailer_config.dns_verified,
+                  provider_verified: mailer_config.provider_verified
+              else
+                log_info "Domain validation awaiting DNS check: #{domain_id}",
+                  provider_verified: mailer_config.provider_verified,
+                  dns_check_status: mailer_config.dns_check_status
               end
 
-              mailer_config.provider_check_status       = JobLifecycle::COMPLETED
-              mailer_config.provider_check_completed_at = Familia.now.to_i
-              mailer_config.updated                     = Familia.now.to_i
-              mailer_config.save_fields(:provider_verified, :provider_check_status, :provider_check_completed_at, :last_error, :updated)
-            rescue StandardError => ex
-              # Provider check failure should not fail the overall worker
-              log_error "Provider verification check failed for #{domain_id}", ex
-              # Mark as completed (not failed - the worker itself didn't crash)
-              # but don't set provider_verified since we couldn't determine it
-              mailer_config.provider_check_status       = JobLifecycle::COMPLETED
-              mailer_config.provider_check_completed_at = Familia.now.to_i
-              mailer_config.updated                     = Familia.now.to_i
-              mailer_config.save_fields(:provider_check_status, :provider_check_completed_at, :updated)
+              ack!
             end
-
-            # Refresh from Redis so we see the DNS worker's latest status, not our
-            # in-memory copy which was loaded before that worker ran.
-            mailer_config.refresh!
-
-            # Update stored verification_status if both jobs are now complete
-            if mailer_config.jobs_completed?
-              final_status = mailer_config.update_verification_status!
-              log_info "Domain validation final determination: #{domain_id}",
-                verification_status: final_status,
-                dns_verified: mailer_config.dns_verified,
-                provider_verified: mailer_config.provider_verified
-            else
-              log_info "Domain validation awaiting DNS check: #{domain_id}",
-                provider_verified: mailer_config.provider_verified,
-                dns_check_status: mailer_config.dns_check_status
-            end
-
-            ack!
           rescue Onetime::LimitExceeded => ex
             # Rate limited - ack the message (don't retry or DLQ)
             # User can manually re-trigger after the rate limit window

--- a/lib/onetime/jobs/workers/domain_validation_worker.rb
+++ b/lib/onetime/jobs/workers/domain_validation_worker.rb
@@ -120,179 +120,177 @@ module Onetime
           data          = nil
           mailer_config = nil
           domain_id     = nil
-          begin
-            with_trace_context do
-              data = parse_message(msg)
-              return unless data # parse_message handles reject on error
+          with_trace_context do
+            data = parse_message(msg)
+            return unless data # parse_message handles reject on error
 
-              # Handle ping test messages (from: bin/ots queue ping)
-              if data[:domain_id] == 'ping.test'
-                log_info 'Received ping test', domain_id: data[:domain_id]
-                return ack!
-              end
-
-              # Atomic idempotency claim: only one worker can claim a message
-              unless claim_for_processing(message_id)
-                log_info "Skipping duplicate message: #{message_id}"
-                return ack!
-              end
-
-              domain_id    = data[:domain_id]
-              bypass_cache = data[:bypass_cache] || false  # Backward compat for in-flight messages
-              log_debug "Validating sender domain DNS: #{domain_id} (bypass_cache: #{bypass_cache}, metadata: #{message_metadata})"
-
-              # Load the mailer config for this domain
-              mailer_config = Onetime::CustomDomain::MailerConfig.find_by_domain_id(domain_id)
-              unless mailer_config
-                log_error "MailerConfig not found for domain_id: #{domain_id}", message_id: message_id, metadata: message_metadata
-                return ack! # Don't retry -- config won't appear on its own
-              end
-
-              # Mark job as processing
-              mailer_config.provider_check_status = JobLifecycle::PROCESSING
-              mailer_config.save_fields(:provider_check_status)
-
-              # Delegate to operation with retry logic (DNS can be transiently flaky)
-              # Don't retry rate limits - they won't clear for ~60 minutes
-              result = nil
-              with_retry(
-                max_retries: 2,
-                base_delay: 2.0,
-                retriable: ->(ex) { !ex.is_a?(Onetime::LimitExceeded) },
-              ) do
-                # persist: false because this worker controls verification_status
-                # through update_verification_status! after BOTH workers complete.
-                # The operation would otherwise set verification_status='verified'
-                # based on DNS alone, before the provider API check runs.
-                result = Onetime::Operations::ValidateSenderDomain.new(
-                  mailer_config: mailer_config,
-                  persist: false,
-                  bypass_cache: bypass_cache,
-                ).call
-                # Re-raise so with_retry can retry transient DNS failures.
-                # ValidateSenderDomain#call rescues internally and returns a
-                # Result — without this, with_retry never sees an exception.
-                raise result.error if result.error
-              end
-
-              log_info "Sender domain validation complete: #{domain_id}",
-                status: result.verification_status,
-                all_verified: result.all_verified,
-                persisted: result.persisted,
-                bypass_cache: bypass_cache,
-                error: result.error
-
-              # Provider-level verification: ask the provider API if the domain is verified.
-              # This complements the DNS validation above.
-              provider_api_verified = nil
-              begin
-                provider = mailer_config.effective_provider
-                if provider && provider != 'smtp'
-                  require 'onetime/mail/sender_strategies'
-                  sender_strategy = Onetime::Mail::SenderStrategies.for_provider(provider)
-                  creds           = Onetime::Mail::Mailer.provider_credentials(provider)
-
-                  if creds && !creds.empty?
-                    provider_result       = sender_strategy.check_provider_verification_status(mailer_config, credentials: creds)
-                    provider_api_verified = provider_result[:verified]
-                    log_info "Provider verification check: #{domain_id}",
-                      provider: provider,
-                      verified: provider_result[:verified],
-                      status: provider_result[:status]
-                  else
-                    log_debug "Skipping provider check: no credentials for #{provider}"
-                  end
-                end
-
-                # Set provider_verified from provider API check when available.
-                # Fall back to DNS result only when no provider credentials exist
-                # (degraded mode - better than leaving nil).
-                mailer_config.provider_verified = if provider_api_verified.nil?
-                                                    result.all_verified
-                                                  else
-                                                    provider_api_verified
-                                                  end
-
-                # Record provider status when verification fails so UI can explain why
-                mailer_config.last_error = provider_api_verified == false && provider_result ? "Provider status: #{provider_result[:status]}" : nil
-
-                # Persist the provider's current domain status back into provider_dns_data
-                # so the UI can surface it (e.g. 'verified', 'pending_verification').
-                if provider_result
-                  current_provider_data                 = mailer_config.provider_dns_data.value || {}
-                  provider_records                      = provider_result.dig(:details, :dns_records) || []
-                  mailer_config.provider_dns_data.value = current_provider_data.merge(
-                    'status' => provider_result[:status],
-                    'dns_records' => provider_records,
-                    'raw_provider_response' => provider_result[:details],
-                  )
-                end
-
-                mailer_config.provider_check_status       = JobLifecycle::COMPLETED
-                mailer_config.provider_check_completed_at = Familia.now.to_i
-                mailer_config.updated                     = Familia.now.to_i
-                mailer_config.save_fields(:provider_verified, :provider_check_status, :provider_check_completed_at, :last_error, :updated)
-              rescue StandardError => ex
-                # Provider check failure should not fail the overall worker
-                log_error "Provider verification check failed for #{domain_id}", ex
-                # Mark as completed (not failed - the worker itself didn't crash)
-                # but don't set provider_verified since we couldn't determine it
-                mailer_config.provider_check_status       = JobLifecycle::COMPLETED
-                mailer_config.provider_check_completed_at = Familia.now.to_i
-                mailer_config.updated                     = Familia.now.to_i
-                mailer_config.save_fields(:provider_check_status, :provider_check_completed_at, :updated)
-              end
-
-              # Refresh from Redis so we see the DNS worker's latest status, not our
-              # in-memory copy which was loaded before that worker ran.
-              mailer_config.refresh!
-
-              # Update stored verification_status if both jobs are now complete
-              if mailer_config.jobs_completed?
-                final_status = mailer_config.update_verification_status!
-                log_info "Domain validation final determination: #{domain_id}",
-                  verification_status: final_status,
-                  dns_verified: mailer_config.dns_verified,
-                  provider_verified: mailer_config.provider_verified
-              else
-                log_info "Domain validation awaiting DNS check: #{domain_id}",
-                  provider_verified: mailer_config.provider_verified,
-                  dns_check_status: mailer_config.dns_check_status
-              end
-
-              ack!
+            # Handle ping test messages (from: bin/ots queue ping)
+            if data[:domain_id] == 'ping.test'
+              log_info 'Received ping test', domain_id: data[:domain_id]
+              return ack!
             end
-          rescue Onetime::LimitExceeded => ex
-            # Rate limited - ack the message (don't retry or DLQ)
-            # User can manually re-trigger after the rate limit window
-            # Mark as completed (not failed) but without setting provider_verified
-            if mailer_config
+
+            # Atomic idempotency claim: only one worker can claim a message
+            unless claim_for_processing(message_id)
+              log_info "Skipping duplicate message: #{message_id}"
+              return ack!
+            end
+
+            domain_id    = data[:domain_id]
+            bypass_cache = data[:bypass_cache] || false  # Backward compat for in-flight messages
+            log_debug "Validating sender domain DNS: #{domain_id} (bypass_cache: #{bypass_cache}, metadata: #{message_metadata})"
+
+            # Load the mailer config for this domain
+            mailer_config = Onetime::CustomDomain::MailerConfig.find_by_domain_id(domain_id)
+            unless mailer_config
+              log_error "MailerConfig not found for domain_id: #{domain_id}", message_id: message_id, metadata: message_metadata
+              return ack! # Don't retry -- config won't appear on its own
+            end
+
+            # Mark job as processing
+            mailer_config.provider_check_status = JobLifecycle::PROCESSING
+            mailer_config.save_fields(:provider_check_status)
+
+            # Delegate to operation with retry logic (DNS can be transiently flaky)
+            # Don't retry rate limits - they won't clear for ~60 minutes
+            result = nil
+            with_retry(
+              max_retries: 2,
+              base_delay: 2.0,
+              retriable: ->(ex) { !ex.is_a?(Onetime::LimitExceeded) },
+            ) do
+              # persist: false because this worker controls verification_status
+              # through update_verification_status! after BOTH workers complete.
+              # The operation would otherwise set verification_status='verified'
+              # based on DNS alone, before the provider API check runs.
+              result = Onetime::Operations::ValidateSenderDomain.new(
+                mailer_config: mailer_config,
+                persist: false,
+                bypass_cache: bypass_cache,
+              ).call
+              # Re-raise so with_retry can retry transient DNS failures.
+              # ValidateSenderDomain#call rescues internally and returns a
+              # Result — without this, with_retry never sees an exception.
+              raise result.error if result.error
+            end
+
+            log_info "Sender domain validation complete: #{domain_id}",
+              status: result.verification_status,
+              all_verified: result.all_verified,
+              persisted: result.persisted,
+              bypass_cache: bypass_cache,
+              error: result.error
+
+            # Provider-level verification: ask the provider API if the domain is verified.
+            # This complements the DNS validation above.
+            provider_api_verified = nil
+            begin
+              provider = mailer_config.effective_provider
+              if provider && provider != 'smtp'
+                require 'onetime/mail/sender_strategies'
+                sender_strategy = Onetime::Mail::SenderStrategies.for_provider(provider)
+                creds           = Onetime::Mail::Mailer.provider_credentials(provider)
+
+                if creds && !creds.empty?
+                  provider_result       = sender_strategy.check_provider_verification_status(mailer_config, credentials: creds)
+                  provider_api_verified = provider_result[:verified]
+                  log_info "Provider verification check: #{domain_id}",
+                    provider: provider,
+                    verified: provider_result[:verified],
+                    status: provider_result[:status]
+                else
+                  log_debug "Skipping provider check: no credentials for #{provider}"
+                end
+              end
+
+              # Set provider_verified from provider API check when available.
+              # Fall back to DNS result only when no provider credentials exist
+              # (degraded mode - better than leaving nil).
+              mailer_config.provider_verified = if provider_api_verified.nil?
+                                                  result.all_verified
+                                                else
+                                                  provider_api_verified
+                                                end
+
+              # Record provider status when verification fails so UI can explain why
+              mailer_config.last_error = provider_api_verified == false && provider_result ? "Provider status: #{provider_result[:status]}" : nil
+
+              # Persist the provider's current domain status back into provider_dns_data
+              # so the UI can surface it (e.g. 'verified', 'pending_verification').
+              if provider_result
+                current_provider_data                 = mailer_config.provider_dns_data.value || {}
+                provider_records                      = provider_result.dig(:details, :dns_records) || []
+                mailer_config.provider_dns_data.value = current_provider_data.merge(
+                  'status' => provider_result[:status],
+                  'dns_records' => provider_records,
+                  'raw_provider_response' => provider_result[:details],
+                )
+              end
+
               mailer_config.provider_check_status       = JobLifecycle::COMPLETED
               mailer_config.provider_check_completed_at = Familia.now.to_i
-              mailer_config.last_error                  = "Rate limited: retry after #{ex.retry_after}s"
               mailer_config.updated                     = Familia.now.to_i
-              mailer_config.save_fields(:provider_check_status, :provider_check_completed_at, :last_error, :updated)
-            end
-
-            log_info 'Sender domain validation rate limited',
-              domain_id: domain_id,
-              retry_after: ex.retry_after,
-              attempts: ex.attempts,
-              max_attempts: ex.max_attempts
-            ack!
-          rescue StandardError => ex
-            # Mark job as failed before sending to DLQ
-            if mailer_config
-              mailer_config.provider_check_status       = JobLifecycle::FAILED
+              mailer_config.save_fields(:provider_verified, :provider_check_status, :provider_check_completed_at, :last_error, :updated)
+            rescue StandardError => ex
+              # Provider check failure should not fail the overall worker
+              log_error "Provider verification check failed for #{domain_id}", ex
+              # Mark as completed (not failed - the worker itself didn't crash)
+              # but don't set provider_verified since we couldn't determine it
+              mailer_config.provider_check_status       = JobLifecycle::COMPLETED
               mailer_config.provider_check_completed_at = Familia.now.to_i
-              mailer_config.last_error                  = ex.message
               mailer_config.updated                     = Familia.now.to_i
-              mailer_config.save_fields(:provider_check_status, :provider_check_completed_at, :last_error, :updated)
+              mailer_config.save_fields(:provider_check_status, :provider_check_completed_at, :updated)
             end
 
-            log_error 'Unexpected error validating sender domain', ex
-            reject! # Send to DLQ
+            # Refresh from Redis so we see the DNS worker's latest status, not our
+            # in-memory copy which was loaded before that worker ran.
+            mailer_config.refresh!
+
+            # Update stored verification_status if both jobs are now complete
+            if mailer_config.jobs_completed?
+              final_status = mailer_config.update_verification_status!
+              log_info "Domain validation final determination: #{domain_id}",
+                verification_status: final_status,
+                dns_verified: mailer_config.dns_verified,
+                provider_verified: mailer_config.provider_verified
+            else
+              log_info "Domain validation awaiting DNS check: #{domain_id}",
+                provider_verified: mailer_config.provider_verified,
+                dns_check_status: mailer_config.dns_check_status
+            end
+
+            ack!
           end
+        rescue Onetime::LimitExceeded => ex
+          # Rate limited - ack the message (don't retry or DLQ)
+          # User can manually re-trigger after the rate limit window
+          # Mark as completed (not failed) but without setting provider_verified
+          if mailer_config
+            mailer_config.provider_check_status       = JobLifecycle::COMPLETED
+            mailer_config.provider_check_completed_at = Familia.now.to_i
+            mailer_config.last_error                  = "Rate limited: retry after #{ex.retry_after}s"
+            mailer_config.updated                     = Familia.now.to_i
+            mailer_config.save_fields(:provider_check_status, :provider_check_completed_at, :last_error, :updated)
+          end
+
+          log_info 'Sender domain validation rate limited',
+            domain_id: domain_id,
+            retry_after: ex.retry_after,
+            attempts: ex.attempts,
+            max_attempts: ex.max_attempts
+          ack!
+        rescue StandardError => ex
+          # Mark job as failed before sending to DLQ
+          if mailer_config
+            mailer_config.provider_check_status       = JobLifecycle::FAILED
+            mailer_config.provider_check_completed_at = Familia.now.to_i
+            mailer_config.last_error                  = ex.message
+            mailer_config.updated                     = Familia.now.to_i
+            mailer_config.save_fields(:provider_check_status, :provider_check_completed_at, :last_error, :updated)
+          end
+
+          log_error 'Unexpected error validating sender domain', ex
+          reject! # Send to DLQ
         end
         # rubocop:enable Metrics/PerceivedComplexity
       end

--- a/lib/onetime/jobs/workers/domain_validation_worker.rb
+++ b/lib/onetime/jobs/workers/domain_validation_worker.rb
@@ -117,175 +117,177 @@ module Onetime
         def work_with_params(msg, delivery_info, metadata)
           store_envelope(delivery_info, metadata)
 
-          data = parse_message(msg)
-          return unless data # parse_message handles reject on error
+          with_trace_context do
+            data = parse_message(msg)
+            return unless data # parse_message handles reject on error
 
-          # Handle ping test messages (from: bin/ots queue ping)
-          if data[:domain_id] == 'ping.test'
-            log_info 'Received ping test', domain_id: data[:domain_id]
-            return ack!
-          end
+            # Handle ping test messages (from: bin/ots queue ping)
+            if data[:domain_id] == 'ping.test'
+              log_info 'Received ping test', domain_id: data[:domain_id]
+              return ack!
+            end
 
-          # Atomic idempotency claim: only one worker can claim a message
-          unless claim_for_processing(message_id)
-            log_info "Skipping duplicate message: #{message_id}"
-            return ack!
-          end
+            # Atomic idempotency claim: only one worker can claim a message
+            unless claim_for_processing(message_id)
+              log_info "Skipping duplicate message: #{message_id}"
+              return ack!
+            end
 
-          domain_id    = data[:domain_id]
-          bypass_cache = data[:bypass_cache] || false  # Backward compat for in-flight messages
-          log_debug "Validating sender domain DNS: #{domain_id} (bypass_cache: #{bypass_cache}, metadata: #{message_metadata})"
+            domain_id    = data[:domain_id]
+            bypass_cache = data[:bypass_cache] || false  # Backward compat for in-flight messages
+            log_debug "Validating sender domain DNS: #{domain_id} (bypass_cache: #{bypass_cache}, metadata: #{message_metadata})"
 
-          # Load the mailer config for this domain
-          mailer_config = Onetime::CustomDomain::MailerConfig.find_by_domain_id(domain_id)
-          unless mailer_config
-            log_error "MailerConfig not found for domain_id: #{domain_id}", message_id: message_id, metadata: message_metadata
-            return ack! # Don't retry -- config won't appear on its own
-          end
+            # Load the mailer config for this domain
+            mailer_config = Onetime::CustomDomain::MailerConfig.find_by_domain_id(domain_id)
+            unless mailer_config
+              log_error "MailerConfig not found for domain_id: #{domain_id}", message_id: message_id, metadata: message_metadata
+              return ack! # Don't retry -- config won't appear on its own
+            end
 
-          # Mark job as processing
-          mailer_config.provider_check_status = JobLifecycle::PROCESSING
-          mailer_config.save_fields(:provider_check_status)
+            # Mark job as processing
+            mailer_config.provider_check_status = JobLifecycle::PROCESSING
+            mailer_config.save_fields(:provider_check_status)
 
-          # Delegate to operation with retry logic (DNS can be transiently flaky)
-          # Don't retry rate limits - they won't clear for ~60 minutes
-          result = nil
-          with_retry(
-            max_retries: 2,
-            base_delay: 2.0,
-            retriable: ->(ex) { !ex.is_a?(Onetime::LimitExceeded) },
-          ) do
-            # persist: false because this worker controls verification_status
-            # through update_verification_status! after BOTH workers complete.
-            # The operation would otherwise set verification_status='verified'
-            # based on DNS alone, before the provider API check runs.
-            result = Onetime::Operations::ValidateSenderDomain.new(
-              mailer_config: mailer_config,
-              persist: false,
+            # Delegate to operation with retry logic (DNS can be transiently flaky)
+            # Don't retry rate limits - they won't clear for ~60 minutes
+            result = nil
+            with_retry(
+              max_retries: 2,
+              base_delay: 2.0,
+              retriable: ->(ex) { !ex.is_a?(Onetime::LimitExceeded) },
+            ) do
+              # persist: false because this worker controls verification_status
+              # through update_verification_status! after BOTH workers complete.
+              # The operation would otherwise set verification_status='verified'
+              # based on DNS alone, before the provider API check runs.
+              result = Onetime::Operations::ValidateSenderDomain.new(
+                mailer_config: mailer_config,
+                persist: false,
+                bypass_cache: bypass_cache,
+              ).call
+              # Re-raise so with_retry can retry transient DNS failures.
+              # ValidateSenderDomain#call rescues internally and returns a
+              # Result — without this, with_retry never sees an exception.
+              raise result.error if result.error
+            end
+
+            log_info "Sender domain validation complete: #{domain_id}",
+              status: result.verification_status,
+              all_verified: result.all_verified,
+              persisted: result.persisted,
               bypass_cache: bypass_cache,
-            ).call
-            # Re-raise so with_retry can retry transient DNS failures.
-            # ValidateSenderDomain#call rescues internally and returns a
-            # Result — without this, with_retry never sees an exception.
-            raise result.error if result.error
-          end
+              error: result.error
 
-          log_info "Sender domain validation complete: #{domain_id}",
-            status: result.verification_status,
-            all_verified: result.all_verified,
-            persisted: result.persisted,
-            bypass_cache: bypass_cache,
-            error: result.error
+            # Provider-level verification: ask the provider API if the domain is verified.
+            # This complements the DNS validation above.
+            provider_api_verified = nil
+            begin
+              provider = mailer_config.effective_provider
+              if provider && provider != 'smtp'
+                require 'onetime/mail/sender_strategies'
+                sender_strategy = Onetime::Mail::SenderStrategies.for_provider(provider)
+                creds           = Onetime::Mail::Mailer.provider_credentials(provider)
 
-          # Provider-level verification: ask the provider API if the domain is verified.
-          # This complements the DNS validation above.
-          provider_api_verified = nil
-          begin
-            provider = mailer_config.effective_provider
-            if provider && provider != 'smtp'
-              require 'onetime/mail/sender_strategies'
-              sender_strategy = Onetime::Mail::SenderStrategies.for_provider(provider)
-              creds           = Onetime::Mail::Mailer.provider_credentials(provider)
-
-              if creds && !creds.empty?
-                provider_result       = sender_strategy.check_provider_verification_status(mailer_config, credentials: creds)
-                provider_api_verified = provider_result[:verified]
-                log_info "Provider verification check: #{domain_id}",
-                  provider: provider,
-                  verified: provider_result[:verified],
-                  status: provider_result[:status]
-              else
-                log_debug "Skipping provider check: no credentials for #{provider}"
+                if creds && !creds.empty?
+                  provider_result       = sender_strategy.check_provider_verification_status(mailer_config, credentials: creds)
+                  provider_api_verified = provider_result[:verified]
+                  log_info "Provider verification check: #{domain_id}",
+                    provider: provider,
+                    verified: provider_result[:verified],
+                    status: provider_result[:status]
+                else
+                  log_debug "Skipping provider check: no credentials for #{provider}"
+                end
               end
+
+              # Set provider_verified from provider API check when available.
+              # Fall back to DNS result only when no provider credentials exist
+              # (degraded mode - better than leaving nil).
+              mailer_config.provider_verified = if provider_api_verified.nil?
+                                                  result.all_verified
+                                                else
+                                                  provider_api_verified
+                                                end
+
+              # Record provider status when verification fails so UI can explain why
+              mailer_config.last_error = provider_api_verified == false && provider_result ? "Provider status: #{provider_result[:status]}" : nil
+
+              # Persist the provider's current domain status back into provider_dns_data
+              # so the UI can surface it (e.g. 'verified', 'pending_verification').
+              if provider_result
+                current_provider_data                 = mailer_config.provider_dns_data.value || {}
+                provider_records                      = provider_result.dig(:details, :dns_records) || []
+                mailer_config.provider_dns_data.value = current_provider_data.merge(
+                  'status' => provider_result[:status],
+                  'dns_records' => provider_records,
+                  'raw_provider_response' => provider_result[:details],
+                )
+              end
+
+              mailer_config.provider_check_status       = JobLifecycle::COMPLETED
+              mailer_config.provider_check_completed_at = Familia.now.to_i
+              mailer_config.updated                     = Familia.now.to_i
+              mailer_config.save_fields(:provider_verified, :provider_check_status, :provider_check_completed_at, :last_error, :updated)
+            rescue StandardError => ex
+              # Provider check failure should not fail the overall worker
+              log_error "Provider verification check failed for #{domain_id}", ex
+              # Mark as completed (not failed - the worker itself didn't crash)
+              # but don't set provider_verified since we couldn't determine it
+              mailer_config.provider_check_status       = JobLifecycle::COMPLETED
+              mailer_config.provider_check_completed_at = Familia.now.to_i
+              mailer_config.updated                     = Familia.now.to_i
+              mailer_config.save_fields(:provider_check_status, :provider_check_completed_at, :updated)
             end
 
-            # Set provider_verified from provider API check when available.
-            # Fall back to DNS result only when no provider credentials exist
-            # (degraded mode - better than leaving nil).
-            mailer_config.provider_verified = if provider_api_verified.nil?
-                                                result.all_verified
-                                              else
-                                                provider_api_verified
-                                              end
+            # Refresh from Redis so we see the DNS worker's latest status, not our
+            # in-memory copy which was loaded before that worker ran.
+            mailer_config.refresh!
 
-            # Record provider status when verification fails so UI can explain why
-            mailer_config.last_error = provider_api_verified == false && provider_result ? "Provider status: #{provider_result[:status]}" : nil
-
-            # Persist the provider's current domain status back into provider_dns_data
-            # so the UI can surface it (e.g. 'verified', 'pending_verification').
-            if provider_result
-              current_provider_data                 = mailer_config.provider_dns_data.value || {}
-              provider_records                      = provider_result.dig(:details, :dns_records) || []
-              mailer_config.provider_dns_data.value = current_provider_data.merge(
-                'status' => provider_result[:status],
-                'dns_records' => provider_records,
-                'raw_provider_response' => provider_result[:details],
-              )
+            # Update stored verification_status if both jobs are now complete
+            if mailer_config.jobs_completed?
+              final_status = mailer_config.update_verification_status!
+              log_info "Domain validation final determination: #{domain_id}",
+                verification_status: final_status,
+                dns_verified: mailer_config.dns_verified,
+                provider_verified: mailer_config.provider_verified
+            else
+              log_info "Domain validation awaiting DNS check: #{domain_id}",
+                provider_verified: mailer_config.provider_verified,
+                dns_check_status: mailer_config.dns_check_status
             end
 
-            mailer_config.provider_check_status       = JobLifecycle::COMPLETED
-            mailer_config.provider_check_completed_at = Familia.now.to_i
-            mailer_config.updated                     = Familia.now.to_i
-            mailer_config.save_fields(:provider_verified, :provider_check_status, :provider_check_completed_at, :last_error, :updated)
+            ack!
+          rescue Onetime::LimitExceeded => ex
+            # Rate limited - ack the message (don't retry or DLQ)
+            # User can manually re-trigger after the rate limit window
+            # Mark as completed (not failed) but without setting provider_verified
+            if mailer_config
+              mailer_config.provider_check_status       = JobLifecycle::COMPLETED
+              mailer_config.provider_check_completed_at = Familia.now.to_i
+              mailer_config.last_error                  = "Rate limited: retry after #{ex.retry_after}s"
+              mailer_config.updated                     = Familia.now.to_i
+              mailer_config.save_fields(:provider_check_status, :provider_check_completed_at, :last_error, :updated)
+            end
+
+            log_info 'Sender domain validation rate limited',
+              domain_id: domain_id,
+              retry_after: ex.retry_after,
+              attempts: ex.attempts,
+              max_attempts: ex.max_attempts
+            ack!
           rescue StandardError => ex
-            # Provider check failure should not fail the overall worker
-            log_error "Provider verification check failed for #{domain_id}", ex
-            # Mark as completed (not failed - the worker itself didn't crash)
-            # but don't set provider_verified since we couldn't determine it
-            mailer_config.provider_check_status       = JobLifecycle::COMPLETED
-            mailer_config.provider_check_completed_at = Familia.now.to_i
-            mailer_config.updated                     = Familia.now.to_i
-            mailer_config.save_fields(:provider_check_status, :provider_check_completed_at, :updated)
+            # Mark job as failed before sending to DLQ
+            if mailer_config
+              mailer_config.provider_check_status       = JobLifecycle::FAILED
+              mailer_config.provider_check_completed_at = Familia.now.to_i
+              mailer_config.last_error                  = ex.message
+              mailer_config.updated                     = Familia.now.to_i
+              mailer_config.save_fields(:provider_check_status, :provider_check_completed_at, :last_error, :updated)
+            end
+
+            log_error 'Unexpected error validating sender domain', ex
+            reject! # Send to DLQ
           end
-
-          # Refresh from Redis so we see the DNS worker's latest status, not our
-          # in-memory copy which was loaded before that worker ran.
-          mailer_config.refresh!
-
-          # Update stored verification_status if both jobs are now complete
-          if mailer_config.jobs_completed?
-            final_status = mailer_config.update_verification_status!
-            log_info "Domain validation final determination: #{domain_id}",
-              verification_status: final_status,
-              dns_verified: mailer_config.dns_verified,
-              provider_verified: mailer_config.provider_verified
-          else
-            log_info "Domain validation awaiting DNS check: #{domain_id}",
-              provider_verified: mailer_config.provider_verified,
-              dns_check_status: mailer_config.dns_check_status
-          end
-
-          ack!
-        rescue Onetime::LimitExceeded => ex
-          # Rate limited - ack the message (don't retry or DLQ)
-          # User can manually re-trigger after the rate limit window
-          # Mark as completed (not failed) but without setting provider_verified
-          if mailer_config
-            mailer_config.provider_check_status       = JobLifecycle::COMPLETED
-            mailer_config.provider_check_completed_at = Familia.now.to_i
-            mailer_config.last_error                  = "Rate limited: retry after #{ex.retry_after}s"
-            mailer_config.updated                     = Familia.now.to_i
-            mailer_config.save_fields(:provider_check_status, :provider_check_completed_at, :last_error, :updated)
-          end
-
-          log_info 'Sender domain validation rate limited',
-            domain_id: domain_id,
-            retry_after: ex.retry_after,
-            attempts: ex.attempts,
-            max_attempts: ex.max_attempts
-          ack!
-        rescue StandardError => ex
-          # Mark job as failed before sending to DLQ
-          if mailer_config
-            mailer_config.provider_check_status       = JobLifecycle::FAILED
-            mailer_config.provider_check_completed_at = Familia.now.to_i
-            mailer_config.last_error                  = ex.message
-            mailer_config.updated                     = Familia.now.to_i
-            mailer_config.save_fields(:provider_check_status, :provider_check_completed_at, :last_error, :updated)
-          end
-
-          log_error 'Unexpected error validating sender domain', ex
-          reject! # Send to DLQ
         end
         # rubocop:enable Metrics/PerceivedComplexity
       end

--- a/lib/onetime/jobs/workers/email_worker.rb
+++ b/lib/onetime/jobs/workers/email_worker.rb
@@ -55,50 +55,48 @@ module Onetime
           store_envelope(delivery_info, metadata)
 
           data = nil
-          begin
-            with_trace_context do
-              data = parse_message(msg)
-              return unless data # parse_message handles reject on error
+          with_trace_context do
+            data = parse_message(msg)
+            return unless data # parse_message handles reject on error
 
-              # Handle ping test messages (from: bin/ots queue ping)
-              if ping_test?(data)
-                log_info 'Received ping test', template: data[:template], ping_id: data.dig(:data, :ping_id)
-                return ack!
-              end
-
-              # Atomic idempotency claim: only one worker can claim a message
-              unless claim_for_processing(message_id)
-                log_info "Skipping duplicate message: #{message_id}"
-                return ack!
-              end
-
-              log_debug "Processing email: #{data[:template]} (metadata: #{message_metadata})"
-
-              # Only skip retries for non-transient DeliveryErrors (auth failure, permanent rejection).
-              # Plain StandardErrors and transient DeliveryErrors are retriable.
-              retriable = ->(ex) { !ex.is_a?(Onetime::Mail::DeliveryError) || ex.transient? }
-
-              with_retry(max_retries: 3, base_delay: 2.0, retriable: retriable) do
-                deliver_email(data)
-              end
-
-              log_info "Email delivered: #{data[:template]}"
-              update_delivery_status(data, 'sent')
-              ack!
+            # Handle ping test messages (from: bin/ots queue ping)
+            if ping_test?(data)
+              log_info 'Received ping test', template: data[:template], ping_id: data.dig(:data, :ping_id)
+              return ack!
             end
-          rescue Onetime::Mail::DeliveryError => ex
-            if ex.transient?
-              log_error 'Transient delivery error (retries exhausted)', ex
-            else
-              log_error 'Non-transient delivery error, skipping to DLQ', ex
+
+            # Atomic idempotency claim: only one worker can claim a message
+            unless claim_for_processing(message_id)
+              log_info "Skipping duplicate message: #{message_id}"
+              return ack!
             end
-            update_delivery_status(data, 'failed')
-            reject! # Send to DLQ
-          rescue StandardError => ex
-            log_error 'Unexpected error delivering email', ex
-            update_delivery_status(data, 'failed')
-            reject! # Send to DLQ
+
+            log_debug "Processing email: #{data[:template]} (metadata: #{message_metadata})"
+
+            # Only skip retries for non-transient DeliveryErrors (auth failure, permanent rejection).
+            # Plain StandardErrors and transient DeliveryErrors are retriable.
+            retriable = ->(ex) { !ex.is_a?(Onetime::Mail::DeliveryError) || ex.transient? }
+
+            with_retry(max_retries: 3, base_delay: 2.0, retriable: retriable) do
+              deliver_email(data)
+            end
+
+            log_info "Email delivered: #{data[:template]}"
+            update_delivery_status(data, 'sent')
+            ack!
           end
+        rescue Onetime::Mail::DeliveryError => ex
+          if ex.transient?
+            log_error 'Transient delivery error (retries exhausted)', ex
+          else
+            log_error 'Non-transient delivery error, skipping to DLQ', ex
+          end
+          update_delivery_status(data, 'failed')
+          reject! # Send to DLQ
+        rescue StandardError => ex
+          log_error 'Unexpected error delivering email', ex
+          update_delivery_status(data, 'failed')
+          reject! # Send to DLQ
         end
 
         # Templates that support delivery status tracking on the customer model

--- a/lib/onetime/jobs/workers/email_worker.rb
+++ b/lib/onetime/jobs/workers/email_worker.rb
@@ -54,35 +54,38 @@ module Onetime
         def work_with_params(msg, delivery_info, metadata)
           store_envelope(delivery_info, metadata)
 
-          with_trace_context do
-            data = parse_message(msg)
-            return unless data # parse_message handles reject on error
+          data = nil
+          begin
+            with_trace_context do
+              data = parse_message(msg)
+              return unless data # parse_message handles reject on error
 
-            # Handle ping test messages (from: bin/ots queue ping)
-            if ping_test?(data)
-              log_info 'Received ping test', template: data[:template], ping_id: data.dig(:data, :ping_id)
-              return ack!
+              # Handle ping test messages (from: bin/ots queue ping)
+              if ping_test?(data)
+                log_info 'Received ping test', template: data[:template], ping_id: data.dig(:data, :ping_id)
+                return ack!
+              end
+
+              # Atomic idempotency claim: only one worker can claim a message
+              unless claim_for_processing(message_id)
+                log_info "Skipping duplicate message: #{message_id}"
+                return ack!
+              end
+
+              log_debug "Processing email: #{data[:template]} (metadata: #{message_metadata})"
+
+              # Only skip retries for non-transient DeliveryErrors (auth failure, permanent rejection).
+              # Plain StandardErrors and transient DeliveryErrors are retriable.
+              retriable = ->(ex) { !ex.is_a?(Onetime::Mail::DeliveryError) || ex.transient? }
+
+              with_retry(max_retries: 3, base_delay: 2.0, retriable: retriable) do
+                deliver_email(data)
+              end
+
+              log_info "Email delivered: #{data[:template]}"
+              update_delivery_status(data, 'sent')
+              ack!
             end
-
-            # Atomic idempotency claim: only one worker can claim a message
-            unless claim_for_processing(message_id)
-              log_info "Skipping duplicate message: #{message_id}"
-              return ack!
-            end
-
-            log_debug "Processing email: #{data[:template]} (metadata: #{message_metadata})"
-
-            # Only skip retries for non-transient DeliveryErrors (auth failure, permanent rejection).
-            # Plain StandardErrors and transient DeliveryErrors are retriable.
-            retriable = ->(ex) { !ex.is_a?(Onetime::Mail::DeliveryError) || ex.transient? }
-
-            with_retry(max_retries: 3, base_delay: 2.0, retriable: retriable) do
-              deliver_email(data)
-            end
-
-            log_info "Email delivered: #{data[:template]}"
-            update_delivery_status(data, 'sent')
-            ack!
           rescue Onetime::Mail::DeliveryError => ex
             if ex.transient?
               log_error 'Transient delivery error (retries exhausted)', ex

--- a/lib/onetime/jobs/workers/email_worker.rb
+++ b/lib/onetime/jobs/workers/email_worker.rb
@@ -54,46 +54,48 @@ module Onetime
         def work_with_params(msg, delivery_info, metadata)
           store_envelope(delivery_info, metadata)
 
-          data = parse_message(msg)
-          return unless data # parse_message handles reject on error
+          with_trace_context do
+            data = parse_message(msg)
+            return unless data # parse_message handles reject on error
 
-          # Handle ping test messages (from: bin/ots queue ping)
-          if ping_test?(data)
-            log_info 'Received ping test', template: data[:template], ping_id: data.dig(:data, :ping_id)
-            return ack!
+            # Handle ping test messages (from: bin/ots queue ping)
+            if ping_test?(data)
+              log_info 'Received ping test', template: data[:template], ping_id: data.dig(:data, :ping_id)
+              return ack!
+            end
+
+            # Atomic idempotency claim: only one worker can claim a message
+            unless claim_for_processing(message_id)
+              log_info "Skipping duplicate message: #{message_id}"
+              return ack!
+            end
+
+            log_debug "Processing email: #{data[:template]} (metadata: #{message_metadata})"
+
+            # Only skip retries for non-transient DeliveryErrors (auth failure, permanent rejection).
+            # Plain StandardErrors and transient DeliveryErrors are retriable.
+            retriable = ->(ex) { !ex.is_a?(Onetime::Mail::DeliveryError) || ex.transient? }
+
+            with_retry(max_retries: 3, base_delay: 2.0, retriable: retriable) do
+              deliver_email(data)
+            end
+
+            log_info "Email delivered: #{data[:template]}"
+            update_delivery_status(data, 'sent')
+            ack!
+          rescue Onetime::Mail::DeliveryError => ex
+            if ex.transient?
+              log_error 'Transient delivery error (retries exhausted)', ex
+            else
+              log_error 'Non-transient delivery error, skipping to DLQ', ex
+            end
+            update_delivery_status(data, 'failed')
+            reject! # Send to DLQ
+          rescue StandardError => ex
+            log_error 'Unexpected error delivering email', ex
+            update_delivery_status(data, 'failed')
+            reject! # Send to DLQ
           end
-
-          # Atomic idempotency claim: only one worker can claim a message
-          unless claim_for_processing(message_id)
-            log_info "Skipping duplicate message: #{message_id}"
-            return ack!
-          end
-
-          log_debug "Processing email: #{data[:template]} (metadata: #{message_metadata})"
-
-          # Only skip retries for non-transient DeliveryErrors (auth failure, permanent rejection).
-          # Plain StandardErrors and transient DeliveryErrors are retriable.
-          retriable = ->(ex) { !ex.is_a?(Onetime::Mail::DeliveryError) || ex.transient? }
-
-          with_retry(max_retries: 3, base_delay: 2.0, retriable: retriable) do
-            deliver_email(data)
-          end
-
-          log_info "Email delivered: #{data[:template]}"
-          update_delivery_status(data, 'sent')
-          ack!
-        rescue Onetime::Mail::DeliveryError => ex
-          if ex.transient?
-            log_error 'Transient delivery error (retries exhausted)', ex
-          else
-            log_error 'Non-transient delivery error, skipping to DLQ', ex
-          end
-          update_delivery_status(data, 'failed')
-          reject! # Send to DLQ
-        rescue StandardError => ex
-          log_error 'Unexpected error delivering email', ex
-          update_delivery_status(data, 'failed')
-          reject! # Send to DLQ
         end
 
         # Templates that support delivery status tracking on the customer model

--- a/lib/onetime/jobs/workers/notification_worker.rb
+++ b/lib/onetime/jobs/workers/notification_worker.rb
@@ -49,35 +49,37 @@ module Onetime
         def work_with_params(msg, delivery_info, metadata)
           store_envelope(delivery_info, metadata)
 
-          with_trace_context do
-            data = parse_message(msg)
-            return unless data # parse_message handles reject on error
+          begin
+            with_trace_context do
+              data = parse_message(msg)
+              return unless data # parse_message handles reject on error
 
-            # Handle ping test messages (from: bin/ots queue ping)
-            if data[:type] == 'ping.test'
-              log_info 'Received ping test', type: data[:type], ping_id: data.dig(:data, :ping_id)
-              return ack!
+              # Handle ping test messages (from: bin/ots queue ping)
+              if data[:type] == 'ping.test'
+                log_info 'Received ping test', type: data[:type], ping_id: data.dig(:data, :ping_id)
+                return ack!
+              end
+
+              # Atomic idempotency claim: only one worker can claim a message
+              unless claim_for_processing(message_id)
+                log_info "Skipping duplicate message: #{message_id}"
+                return ack!
+              end
+
+              log_debug "Processing notification: #{data[:type]} (metadata: #{message_metadata})"
+
+              # Delegate to operation with retry logic
+              with_retry(max_retries: 2, base_delay: 1.0) do
+                operation = Onetime::Operations::DispatchNotification.new(
+                  data: data,
+                  context: { source_message_id: message_id },
+                )
+                operation.call
+              end
+
+              log_info "Notification dispatched: #{data[:type]}", channels: data[:channels]
+              ack!
             end
-
-            # Atomic idempotency claim: only one worker can claim a message
-            unless claim_for_processing(message_id)
-              log_info "Skipping duplicate message: #{message_id}"
-              return ack!
-            end
-
-            log_debug "Processing notification: #{data[:type]} (metadata: #{message_metadata})"
-
-            # Delegate to operation with retry logic
-            with_retry(max_retries: 2, base_delay: 1.0) do
-              operation = Onetime::Operations::DispatchNotification.new(
-                data: data,
-                context: { source_message_id: message_id },
-              )
-              operation.call
-            end
-
-            log_info "Notification dispatched: #{data[:type]}", channels: data[:channels]
-            ack!
           rescue StandardError => ex
             log_error 'Unexpected error processing notification', ex
             reject! # Send to DLQ

--- a/lib/onetime/jobs/workers/notification_worker.rb
+++ b/lib/onetime/jobs/workers/notification_worker.rb
@@ -49,37 +49,39 @@ module Onetime
         def work_with_params(msg, delivery_info, metadata)
           store_envelope(delivery_info, metadata)
 
-          data = parse_message(msg)
-          return unless data # parse_message handles reject on error
+          with_trace_context do
+            data = parse_message(msg)
+            return unless data # parse_message handles reject on error
 
-          # Handle ping test messages (from: bin/ots queue ping)
-          if data[:type] == 'ping.test'
-            log_info 'Received ping test', type: data[:type], ping_id: data.dig(:data, :ping_id)
-            return ack!
+            # Handle ping test messages (from: bin/ots queue ping)
+            if data[:type] == 'ping.test'
+              log_info 'Received ping test', type: data[:type], ping_id: data.dig(:data, :ping_id)
+              return ack!
+            end
+
+            # Atomic idempotency claim: only one worker can claim a message
+            unless claim_for_processing(message_id)
+              log_info "Skipping duplicate message: #{message_id}"
+              return ack!
+            end
+
+            log_debug "Processing notification: #{data[:type]} (metadata: #{message_metadata})"
+
+            # Delegate to operation with retry logic
+            with_retry(max_retries: 2, base_delay: 1.0) do
+              operation = Onetime::Operations::DispatchNotification.new(
+                data: data,
+                context: { source_message_id: message_id },
+              )
+              operation.call
+            end
+
+            log_info "Notification dispatched: #{data[:type]}", channels: data[:channels]
+            ack!
+          rescue StandardError => ex
+            log_error 'Unexpected error processing notification', ex
+            reject! # Send to DLQ
           end
-
-          # Atomic idempotency claim: only one worker can claim a message
-          unless claim_for_processing(message_id)
-            log_info "Skipping duplicate message: #{message_id}"
-            return ack!
-          end
-
-          log_debug "Processing notification: #{data[:type]} (metadata: #{message_metadata})"
-
-          # Delegate to operation with retry logic
-          with_retry(max_retries: 2, base_delay: 1.0) do
-            operation = Onetime::Operations::DispatchNotification.new(
-              data: data,
-              context: { source_message_id: message_id },
-            )
-            operation.call
-          end
-
-          log_info "Notification dispatched: #{data[:type]}", channels: data[:channels]
-          ack!
-        rescue StandardError => ex
-          log_error 'Unexpected error processing notification', ex
-          reject! # Send to DLQ
         end
       end
     end

--- a/lib/onetime/jobs/workers/notification_worker.rb
+++ b/lib/onetime/jobs/workers/notification_worker.rb
@@ -49,41 +49,39 @@ module Onetime
         def work_with_params(msg, delivery_info, metadata)
           store_envelope(delivery_info, metadata)
 
-          begin
-            with_trace_context do
-              data = parse_message(msg)
-              return unless data # parse_message handles reject on error
+          with_trace_context do
+            data = parse_message(msg)
+            return unless data # parse_message handles reject on error
 
-              # Handle ping test messages (from: bin/ots queue ping)
-              if data[:type] == 'ping.test'
-                log_info 'Received ping test', type: data[:type], ping_id: data.dig(:data, :ping_id)
-                return ack!
-              end
-
-              # Atomic idempotency claim: only one worker can claim a message
-              unless claim_for_processing(message_id)
-                log_info "Skipping duplicate message: #{message_id}"
-                return ack!
-              end
-
-              log_debug "Processing notification: #{data[:type]} (metadata: #{message_metadata})"
-
-              # Delegate to operation with retry logic
-              with_retry(max_retries: 2, base_delay: 1.0) do
-                operation = Onetime::Operations::DispatchNotification.new(
-                  data: data,
-                  context: { source_message_id: message_id },
-                )
-                operation.call
-              end
-
-              log_info "Notification dispatched: #{data[:type]}", channels: data[:channels]
-              ack!
+            # Handle ping test messages (from: bin/ots queue ping)
+            if data[:type] == 'ping.test'
+              log_info 'Received ping test', type: data[:type], ping_id: data.dig(:data, :ping_id)
+              return ack!
             end
-          rescue StandardError => ex
-            log_error 'Unexpected error processing notification', ex
-            reject! # Send to DLQ
+
+            # Atomic idempotency claim: only one worker can claim a message
+            unless claim_for_processing(message_id)
+              log_info "Skipping duplicate message: #{message_id}"
+              return ack!
+            end
+
+            log_debug "Processing notification: #{data[:type]} (metadata: #{message_metadata})"
+
+            # Delegate to operation with retry logic
+            with_retry(max_retries: 2, base_delay: 1.0) do
+              operation = Onetime::Operations::DispatchNotification.new(
+                data: data,
+                context: { source_message_id: message_id },
+              )
+              operation.call
+            end
+
+            log_info "Notification dispatched: #{data[:type]}", channels: data[:channels]
+            ack!
           end
+        rescue StandardError => ex
+          log_error 'Unexpected error processing notification', ex
+          reject! # Send to DLQ
         end
       end
     end

--- a/lib/onetime/jobs/workers/transient_worker.rb
+++ b/lib/onetime/jobs/workers/transient_worker.rb
@@ -33,21 +33,23 @@ module Onetime
         def work_with_params(msg, delivery_info, metadata)
           store_envelope(delivery_info, metadata)
 
-          with_trace_context do
-            data = parse_message(msg)
-            return unless data
+          begin
+            with_trace_context do
+              data = parse_message(msg)
+              return unless data
 
-            # Skip idempotency for transient messages - they're fire-and-forget
-            action = data[:action]&.to_sym
+              # Skip idempotency for transient messages - they're fire-and-forget
+              action = data[:action]&.to_sym
 
-            case action
-            when :ping
-              handle_ping(data)
-            else
-              log_info "Unknown transient action: #{action}", data: data
+              case action
+              when :ping
+                handle_ping(data)
+              else
+                log_info "Unknown transient action: #{action}", data: data
+              end
+
+              ack!
             end
-
-            ack!
           rescue StandardError => ex
             log_error 'Error processing transient message', ex
             ack! # Don't reject transient messages - just ack and move on

--- a/lib/onetime/jobs/workers/transient_worker.rb
+++ b/lib/onetime/jobs/workers/transient_worker.rb
@@ -33,27 +33,25 @@ module Onetime
         def work_with_params(msg, delivery_info, metadata)
           store_envelope(delivery_info, metadata)
 
-          begin
-            with_trace_context do
-              data = parse_message(msg)
-              return unless data
+          with_trace_context do
+            data = parse_message(msg)
+            return unless data
 
-              # Skip idempotency for transient messages - they're fire-and-forget
-              action = data[:action]&.to_sym
+            # Skip idempotency for transient messages - they're fire-and-forget
+            action = data[:action]&.to_sym
 
-              case action
-              when :ping
-                handle_ping(data)
-              else
-                log_info "Unknown transient action: #{action}", data: data
-              end
-
-              ack!
+            case action
+            when :ping
+              handle_ping(data)
+            else
+              log_info "Unknown transient action: #{action}", data: data
             end
-          rescue StandardError => ex
-            log_error 'Error processing transient message', ex
-            ack! # Don't reject transient messages - just ack and move on
+
+            ack!
           end
+        rescue StandardError => ex
+          log_error 'Error processing transient message', ex
+          ack! # Don't reject transient messages - just ack and move on
         end
 
         private

--- a/lib/onetime/jobs/workers/transient_worker.rb
+++ b/lib/onetime/jobs/workers/transient_worker.rb
@@ -33,23 +33,25 @@ module Onetime
         def work_with_params(msg, delivery_info, metadata)
           store_envelope(delivery_info, metadata)
 
-          data = parse_message(msg)
-          return unless data
+          with_trace_context do
+            data = parse_message(msg)
+            return unless data
 
-          # Skip idempotency for transient messages - they're fire-and-forget
-          action = data[:action]&.to_sym
+            # Skip idempotency for transient messages - they're fire-and-forget
+            action = data[:action]&.to_sym
 
-          case action
-          when :ping
-            handle_ping(data)
-          else
-            log_info "Unknown transient action: #{action}", data: data
+            case action
+            when :ping
+              handle_ping(data)
+            else
+              log_info "Unknown transient action: #{action}", data: data
+            end
+
+            ack!
+          rescue StandardError => ex
+            log_error 'Error processing transient message', ex
+            ack! # Don't reject transient messages - just ack and move on
           end
-
-          ack!
-        rescue StandardError => ex
-          log_error 'Error processing transient message', ex
-          ack! # Don't reject transient messages - just ack and move on
         end
 
         private

--- a/spec/integration/all/jobs/workers/base_worker_spec.rb
+++ b/spec/integration/all/jobs/workers/base_worker_spec.rb
@@ -513,6 +513,223 @@ RSpec.describe Onetime::Jobs::Workers::BaseWorker, type: :integration do
     end
   end
 
+  # ==========================================================================
+  # Sentry Distributed Tracing Tests
+  # ==========================================================================
+  # These tests verify that workers correctly extract and continue Sentry
+  # traces from incoming messages, enabling distributed tracing across
+  # RabbitMQ message boundaries.
+  # ==========================================================================
+
+  describe '#extract_trace_headers' do
+    context 'when metadata contains trace headers' do
+      let(:metadata_with_trace) do
+        MetadataStub.new(
+          message_id: 'msg-trace-123',
+          headers: {
+            'x-schema-version' => 1,
+            'sentry-trace' => '00-abcd1234-5678ef90-01',
+            'baggage' => 'sentry-environment=production'
+          }
+        )
+      end
+
+      before do
+        worker.store_envelope(delivery_info, metadata_with_trace)
+      end
+
+      it 'extracts sentry-trace header' do
+        result = worker.extract_trace_headers
+
+        expect(result['sentry-trace']).to eq('00-abcd1234-5678ef90-01')
+      end
+
+      it 'extracts baggage header' do
+        result = worker.extract_trace_headers
+
+        expect(result['baggage']).to eq('sentry-environment=production')
+      end
+    end
+
+    context 'when metadata lacks trace headers' do
+      it 'returns empty hash' do
+        result = worker.extract_trace_headers
+
+        expect(result).to eq({})
+      end
+    end
+
+    context 'when metadata is nil' do
+      before do
+        worker.metadata = nil
+      end
+
+      it 'returns empty hash without raising' do
+        expect { worker.extract_trace_headers }.not_to raise_error
+        expect(worker.extract_trace_headers).to eq({})
+      end
+    end
+  end
+
+  describe '#with_trace_context' do
+    # Stub Sentry if not defined
+    before do
+      unless defined?(Sentry)
+        stub_const('Sentry', Module.new do
+          def self.initialized?
+            false
+          end
+
+          def self.get_current_scope
+            nil
+          end
+
+          def self.continue_trace(headers, name:, op:)
+            nil
+          end
+        end)
+      end
+    end
+
+    context 'when Sentry is not initialized' do
+      before do
+        allow(Sentry).to receive(:initialized?).and_return(false)
+      end
+
+      it 'yields to the block' do
+        block_called = false
+
+        worker.with_trace_context do
+          block_called = true
+        end
+
+        expect(block_called).to be true
+      end
+
+      it 'returns the result of the block' do
+        result = worker.with_trace_context do
+          'worker result'
+        end
+
+        expect(result).to eq('worker result')
+      end
+    end
+
+    context 'when Sentry is initialized' do
+      let(:mock_transaction) { instance_double('Sentry::Transaction') }
+      let(:mock_scope) { instance_double('Sentry::Scope') }
+
+      let(:metadata_with_trace) do
+        MetadataStub.new(
+          message_id: 'msg-trace-456',
+          headers: {
+            'x-schema-version' => 1,
+            'sentry-trace' => '00-trace123-span456-01',
+            'baggage' => 'sentry-environment=test'
+          }
+        )
+      end
+
+      before do
+        worker.store_envelope(delivery_info, metadata_with_trace)
+        allow(Sentry).to receive(:initialized?).and_return(true)
+        allow(Sentry).to receive(:continue_trace).and_return(mock_transaction)
+        allow(Sentry).to receive(:get_current_scope).and_return(mock_scope)
+        allow(mock_scope).to receive(:set_span)
+        allow(mock_transaction).to receive(:set_status)
+        allow(mock_transaction).to receive(:finish)
+      end
+
+      it 'calls Sentry.continue_trace with extracted headers' do
+        expected_headers = {
+          'sentry-trace' => '00-trace123-span456-01',
+          'baggage' => 'sentry-environment=test'
+        }
+
+        expect(Sentry).to receive(:continue_trace).with(
+          expected_headers,
+          name: 'rabbitmq.EmailWorker',
+          op: 'queue.process'
+        ).and_return(mock_transaction)
+
+        worker.with_trace_context {}
+      end
+
+      it 'uses default transaction name based on worker name' do
+        expect(Sentry).to receive(:continue_trace).with(
+          anything,
+          hash_including(name: 'rabbitmq.EmailWorker')
+        ).and_return(mock_transaction)
+
+        worker.with_trace_context {}
+      end
+
+      it 'allows custom transaction name' do
+        expect(Sentry).to receive(:continue_trace).with(
+          anything,
+          hash_including(name: 'custom.operation.name')
+        ).and_return(mock_transaction)
+
+        worker.with_trace_context(name: 'custom.operation.name') {}
+      end
+
+      it 'allows custom op parameter' do
+        expect(Sentry).to receive(:continue_trace).with(
+          anything,
+          hash_including(op: 'custom.op')
+        ).and_return(mock_transaction)
+
+        worker.with_trace_context(op: 'custom.op') {}
+      end
+
+      it 'yields to the block' do
+        block_called = false
+
+        worker.with_trace_context do
+          block_called = true
+        end
+
+        expect(block_called).to be true
+      end
+
+      it 'returns the result of the block' do
+        result = worker.with_trace_context do
+          'traced result'
+        end
+
+        expect(result).to eq('traced result')
+      end
+    end
+
+    context 'when message has no trace headers (backwards compatibility)' do
+      before do
+        # Default metadata has no trace headers
+        allow(Sentry).to receive(:initialized?).and_return(true)
+        allow(Sentry).to receive(:continue_trace).and_return(nil)
+      end
+
+      it 'still yields to the block' do
+        block_called = false
+
+        worker.with_trace_context do
+          block_called = true
+        end
+
+        expect(block_called).to be true
+      end
+
+      it 'calls continue_trace with empty headers' do
+        expect(Sentry).to receive(:continue_trace).with(
+          {},
+          name: 'rabbitmq.EmailWorker',
+          op: 'queue.process'
+        ).and_return(nil)
+
+        worker.with_trace_context {}
+      end
+    end
+  end
+
   describe 'race condition handling (concurrent idempotency)' do
     # This test verifies that claim_for_processing prevents race conditions.
     #

--- a/spec/integration/all/jobs/workers/base_worker_spec.rb
+++ b/spec/integration/all/jobs/workers/base_worker_spec.rb
@@ -584,6 +584,10 @@ RSpec.describe Onetime::Jobs::Workers::BaseWorker, type: :integration do
             nil
           end
 
+          def self.with_scope
+            yield nil if block_given?
+          end
+
           def self.continue_trace(headers, name:, op:)
             nil
           end
@@ -633,8 +637,8 @@ RSpec.describe Onetime::Jobs::Workers::BaseWorker, type: :integration do
       before do
         worker.store_envelope(delivery_info, metadata_with_trace)
         allow(Sentry).to receive(:initialized?).and_return(true)
+        allow(Sentry).to receive(:with_scope).and_yield(mock_scope)
         allow(Sentry).to receive(:continue_trace).and_return(mock_transaction)
-        allow(Sentry).to receive(:get_current_scope).and_return(mock_scope)
         allow(mock_scope).to receive(:set_span)
         allow(mock_transaction).to receive(:set_status)
         allow(mock_transaction).to receive(:finish)
@@ -702,9 +706,12 @@ RSpec.describe Onetime::Jobs::Workers::BaseWorker, type: :integration do
     end
 
     context 'when message has no trace headers (backwards compatibility)' do
+      let(:mock_scope) { instance_double('Sentry::Scope') }
+
       before do
         # Default metadata has no trace headers
         allow(Sentry).to receive(:initialized?).and_return(true)
+        allow(Sentry).to receive(:with_scope).and_yield(mock_scope)
         allow(Sentry).to receive(:continue_trace).and_return(nil)
       end
 

--- a/spec/unit/onetime/jobs/publisher_spec.rb
+++ b/spec/unit/onetime/jobs/publisher_spec.rb
@@ -69,6 +69,157 @@ RSpec.describe Onetime::Jobs::Publisher do
     end
   end
 
+  # ==========================================================================
+  # Sentry Distributed Tracing Tests
+  # ==========================================================================
+  # These tests verify that Sentry trace headers are correctly extracted
+  # from the current request context and included in published messages
+  # for distributed tracing across RabbitMQ message boundaries.
+  # ==========================================================================
+
+  describe 'trace header propagation' do
+    subject(:publisher) { described_class.new }
+
+    let(:mock_channel) { instance_double(Bunny::Channel) }
+    let(:mock_exchange) { instance_double(Bunny::Exchange) }
+    let(:mock_channel_pool) { instance_double(ConnectionPool) }
+
+    before do
+      allow(mock_channel_pool).to receive(:with).and_yield(mock_channel)
+      allow(mock_channel).to receive(:default_exchange).and_return(mock_exchange)
+      allow(mock_exchange).to receive(:publish)
+      $rmq_channel_pool = mock_channel_pool
+
+      # Stub Sentry module for tests if not defined
+      unless defined?(Sentry)
+        stub_const('Sentry', Module.new do
+          def self.initialized?
+            false
+          end
+
+          def self.get_current_scope
+            nil
+          end
+
+          def self.get_trace_propagation_headers
+            nil
+          end
+        end)
+      end
+    end
+
+    after do
+      $rmq_channel_pool = nil
+    end
+
+    context 'when Sentry has active trace context' do
+      let(:trace_headers) do
+        {
+          'sentry-trace' => '00-abcd1234-5678ef90-01',
+          'baggage' => 'sentry-environment=production,sentry-release=1.0.0'
+        }
+      end
+
+      before do
+        allow(Onetime::Jobs::TracePropagation).to receive(:extract_trace_headers).and_return(trace_headers)
+      end
+
+      it 'includes sentry-trace header in published message headers' do
+        publisher.publish('test.queue', { data: 'test' })
+
+        expect(mock_exchange).to have_received(:publish) do |_payload, options|
+          expect(options[:headers]['sentry-trace']).to eq('00-abcd1234-5678ef90-01')
+        end
+      end
+
+      it 'includes baggage header in published message headers' do
+        publisher.publish('test.queue', { data: 'test' })
+
+        expect(mock_exchange).to have_received(:publish) do |_payload, options|
+          expect(options[:headers]['baggage']).to eq('sentry-environment=production,sentry-release=1.0.0')
+        end
+      end
+
+      it 'merges trace headers with schema version header' do
+        publisher.publish('test.queue', { data: 'test' })
+
+        expect(mock_exchange).to have_received(:publish) do |_payload, options|
+          headers = options[:headers]
+          expect(headers['x-schema-version']).to eq(Onetime::Jobs::QueueConfig::CURRENT_SCHEMA_VERSION)
+          expect(headers['sentry-trace']).not_to be_nil
+          expect(headers['baggage']).not_to be_nil
+        end
+      end
+
+      it 'propagates trace headers via enqueue_email' do
+        publisher.enqueue_email(:secret_link, { secret_key: 'abc' })
+
+        expect(mock_exchange).to have_received(:publish) do |_payload, options|
+          expect(options[:headers]['sentry-trace']).to eq('00-abcd1234-5678ef90-01')
+        end
+      end
+
+      it 'propagates trace headers via schedule_email' do
+        publisher.schedule_email(:secret_link, { secret_key: 'abc' }, delay_seconds: 60)
+
+        expect(mock_exchange).to have_received(:publish) do |_payload, options|
+          expect(options[:headers]['sentry-trace']).to eq('00-abcd1234-5678ef90-01')
+        end
+      end
+
+      it 'propagates trace headers via enqueue_email_raw' do
+        raw_email = { to: 'test@example.com', from: 'noreply@example.com', subject: 'Test', body: 'Hello' }
+        publisher.enqueue_email_raw(raw_email)
+
+        expect(mock_exchange).to have_received(:publish) do |_payload, options|
+          expect(options[:headers]['sentry-trace']).to eq('00-abcd1234-5678ef90-01')
+        end
+      end
+    end
+
+    context 'when Sentry has no active trace context' do
+      before do
+        allow(Onetime::Jobs::TracePropagation).to receive(:extract_trace_headers).and_return({})
+      end
+
+      it 'publishes message without trace headers' do
+        publisher.publish('test.queue', { data: 'test' })
+
+        expect(mock_exchange).to have_received(:publish) do |_payload, options|
+          expect(options[:headers]).not_to have_key('sentry-trace')
+          expect(options[:headers]).not_to have_key('baggage')
+        end
+      end
+
+      it 'still includes schema version header' do
+        publisher.publish('test.queue', { data: 'test' })
+
+        expect(mock_exchange).to have_received(:publish) do |_payload, options|
+          expect(options[:headers]['x-schema-version']).to eq(Onetime::Jobs::QueueConfig::CURRENT_SCHEMA_VERSION)
+        end
+      end
+    end
+
+    context 'when Sentry is not initialized' do
+      before do
+        allow(Sentry).to receive(:initialized?).and_return(false)
+        # Let the actual module handle this - it should return empty hash
+        allow(Onetime::Jobs::TracePropagation).to receive(:extract_trace_headers).and_call_original
+      end
+
+      it 'publishes message successfully without trace headers' do
+        expect {
+          publisher.publish('test.queue', { data: 'test' })
+        }.not_to raise_error
+
+        expect(mock_exchange).to have_received(:publish) do |_payload, options|
+          # Schema version should still be present
+          expect(options[:headers]['x-schema-version']).not_to be_nil
+        end
+      end
+    end
+  end
+
   describe '#enqueue_email without RabbitMQ' do
     subject(:publisher) { described_class.new }
 

--- a/spec/unit/onetime/jobs/trace_propagation_spec.rb
+++ b/spec/unit/onetime/jobs/trace_propagation_spec.rb
@@ -1,0 +1,482 @@
+# spec/unit/onetime/jobs/trace_propagation_spec.rb
+#
+# frozen_string_literal: true
+
+# Purpose:
+#   Tests for the TracePropagation module that enables Sentry distributed tracing
+#   across RabbitMQ message boundaries. This module provides utilities for:
+#   - Extracting trace headers from the current Sentry transaction (publisher side)
+#   - Parsing trace headers from incoming messages (worker side)
+#   - Properly continuing traces in background workers
+#
+# The TracePropagation module is designed to work with Sentry's continue_trace API
+# to link asynchronous job execution back to the originating HTTP request.
+#
+# Test Categories:
+#   - extract_trace_headers: Publisher-side header generation
+#   - parse_trace_headers: Worker-side header extraction from message metadata
+#   - continue_trace: Worker-side trace continuation with transaction wrapping
+#
+# Setup Requirements:
+#   - Sentry mocking (no real DSN needed)
+#   - AMQP metadata stubs for worker tests
+#
+
+require 'spec_helper'
+require 'support/amqp_stubs'
+require 'onetime/jobs/trace_propagation'
+
+RSpec.describe Onetime::Jobs::TracePropagation do
+  # Define a minimal Sentry stub for tests that need it.
+  # Some tests use hide_const('Sentry') to simulate Sentry being unavailable.
+  before do
+    unless defined?(Sentry)
+      stub_const('Sentry', Module.new do
+        def self.initialized?
+          false
+        end
+
+        def self.get_current_scope
+          nil
+        end
+
+        def self.get_trace_propagation_headers
+          nil
+        end
+
+        def self.continue_trace(headers, name:, op:)
+          nil
+        end
+      end)
+    end
+  end
+
+  describe '.extract_trace_headers' do
+    context 'when Sentry is initialized with an active span' do
+      before do
+        allow(Sentry).to receive(:initialized?).and_return(true)
+      end
+
+      it 'returns trace headers from Sentry' do
+        mock_scope = instance_double('Sentry::Scope')
+        mock_span = instance_double('Sentry::Span')
+        expected_headers = {
+          'sentry-trace' => '00-abcd1234-5678ef90-01',
+          'baggage' => 'sentry-environment=production,sentry-release=1.0.0'
+        }
+
+        allow(Sentry).to receive(:get_current_scope).and_return(mock_scope)
+        allow(mock_scope).to receive(:get_span).and_return(mock_span)
+        allow(Sentry).to receive(:get_trace_propagation_headers).and_return(expected_headers)
+
+        headers = described_class.extract_trace_headers
+
+        expect(headers).to eq(expected_headers)
+      end
+
+      it 'returns empty hash when get_trace_propagation_headers returns nil' do
+        mock_scope = instance_double('Sentry::Scope')
+        mock_span = instance_double('Sentry::Span')
+
+        allow(Sentry).to receive(:get_current_scope).and_return(mock_scope)
+        allow(mock_scope).to receive(:get_span).and_return(mock_span)
+        allow(Sentry).to receive(:get_trace_propagation_headers).and_return(nil)
+
+        headers = described_class.extract_trace_headers
+
+        expect(headers).to eq({})
+      end
+
+      it 'returns empty hash when no active span' do
+        mock_scope = instance_double('Sentry::Scope')
+
+        allow(Sentry).to receive(:get_current_scope).and_return(mock_scope)
+        allow(mock_scope).to receive(:get_span).and_return(nil)
+
+        headers = described_class.extract_trace_headers
+
+        expect(headers).to eq({})
+      end
+
+      it 'returns empty hash when scope is nil' do
+        allow(Sentry).to receive(:get_current_scope).and_return(nil)
+
+        headers = described_class.extract_trace_headers
+
+        expect(headers).to eq({})
+      end
+    end
+
+    context 'when Sentry is not initialized' do
+      before do
+        allow(Sentry).to receive(:initialized?).and_return(false)
+      end
+
+      it 'returns empty hash' do
+        headers = described_class.extract_trace_headers
+
+        expect(headers).to eq({})
+      end
+
+      it 'does not call any Sentry scope methods' do
+        expect(Sentry).not_to receive(:get_current_scope)
+        expect(Sentry).not_to receive(:get_trace_propagation_headers)
+
+        described_class.extract_trace_headers
+      end
+    end
+
+    context 'when Sentry is not defined' do
+      before do
+        hide_const('Sentry')
+      end
+
+      it 'returns empty hash without raising' do
+        headers = described_class.extract_trace_headers
+
+        expect(headers).to eq({})
+      end
+    end
+
+    context 'when an error occurs during extraction' do
+      before do
+        allow(Sentry).to receive(:initialized?).and_return(true)
+        allow(Sentry).to receive(:get_current_scope).and_raise(StandardError.new('Sentry internal error'))
+      end
+
+      it 'returns empty hash and does not propagate the error' do
+        expect {
+          headers = described_class.extract_trace_headers
+          expect(headers).to eq({})
+        }.not_to raise_error
+      end
+    end
+  end
+
+  describe '.parse_trace_headers' do
+    let(:metadata_with_trace) do
+      MetadataStub.new(
+        message_id: 'msg-123',
+        headers: {
+          'x-schema-version' => 1,
+          'sentry-trace' => '00-abcd1234-5678ef90-01',
+          'baggage' => 'sentry-environment=production'
+        }
+      )
+    end
+
+    let(:metadata_without_trace) do
+      MetadataStub.new(
+        message_id: 'msg-456',
+        headers: {
+          'x-schema-version' => 1
+        }
+      )
+    end
+
+    let(:metadata_with_nil_headers) do
+      MetadataStub.new(
+        message_id: 'msg-789',
+        headers: nil
+      )
+    end
+
+    context 'when metadata contains trace headers' do
+      it 'extracts sentry-trace header' do
+        result = described_class.parse_trace_headers(metadata_with_trace)
+
+        expect(result['sentry-trace']).to eq('00-abcd1234-5678ef90-01')
+      end
+
+      it 'extracts baggage header' do
+        result = described_class.parse_trace_headers(metadata_with_trace)
+
+        expect(result['baggage']).to eq('sentry-environment=production')
+      end
+
+      it 'returns hash with both headers' do
+        result = described_class.parse_trace_headers(metadata_with_trace)
+
+        expect(result).to eq({
+          'sentry-trace' => '00-abcd1234-5678ef90-01',
+          'baggage' => 'sentry-environment=production'
+        })
+      end
+    end
+
+    context 'when metadata lacks trace headers' do
+      it 'returns empty hash' do
+        result = described_class.parse_trace_headers(metadata_without_trace)
+
+        expect(result).to eq({})
+      end
+    end
+
+    context 'when metadata headers are nil' do
+      it 'returns empty hash' do
+        result = described_class.parse_trace_headers(metadata_with_nil_headers)
+
+        expect(result).to eq({})
+      end
+    end
+
+    context 'when metadata is nil' do
+      it 'returns empty hash' do
+        result = described_class.parse_trace_headers(nil)
+
+        expect(result).to eq({})
+      end
+    end
+
+    context 'when only sentry-trace is present (no baggage)' do
+      let(:metadata_trace_only) do
+        MetadataStub.new(
+          message_id: 'msg-abc',
+          headers: {
+            'sentry-trace' => '00-trace123-span456-01'
+          }
+        )
+      end
+
+      it 'returns hash with only sentry-trace' do
+        result = described_class.parse_trace_headers(metadata_trace_only)
+
+        expect(result).to eq({ 'sentry-trace' => '00-trace123-span456-01' })
+      end
+    end
+
+    context 'when only baggage is present (edge case)' do
+      let(:metadata_baggage_only) do
+        MetadataStub.new(
+          message_id: 'msg-xyz',
+          headers: {
+            'baggage' => 'sentry-environment=staging'
+          }
+        )
+      end
+
+      it 'returns hash with only baggage' do
+        result = described_class.parse_trace_headers(metadata_baggage_only)
+
+        expect(result).to eq({ 'baggage' => 'sentry-environment=staging' })
+      end
+    end
+
+    context 'when headers is not a Hash' do
+      let(:metadata_invalid_headers) do
+        MetadataStub.new(
+          message_id: 'msg-invalid',
+          headers: 'not-a-hash'
+        )
+      end
+
+      it 'returns empty hash' do
+        result = described_class.parse_trace_headers(metadata_invalid_headers)
+
+        expect(result).to eq({})
+      end
+    end
+  end
+
+  describe '.continue_trace' do
+    let(:trace_headers) do
+      {
+        'sentry-trace' => '00-abcd1234-5678ef90-01',
+        'baggage' => 'sentry-environment=production'
+      }
+    end
+
+    context 'when Sentry is initialized' do
+      before do
+        allow(Sentry).to receive(:initialized?).and_return(true)
+      end
+
+      context 'when continue_trace returns a transaction' do
+        let(:mock_transaction) { instance_double('Sentry::Transaction') }
+        let(:mock_scope) { instance_double('Sentry::Scope') }
+
+        before do
+          allow(Sentry).to receive(:continue_trace).and_return(mock_transaction)
+          allow(Sentry).to receive(:get_current_scope).and_return(mock_scope)
+          allow(mock_scope).to receive(:set_span)
+          allow(mock_transaction).to receive(:set_status)
+          allow(mock_transaction).to receive(:finish)
+        end
+
+        it 'calls Sentry.continue_trace with headers, name, and op' do
+          expect(Sentry).to receive(:continue_trace).with(
+            trace_headers,
+            name: 'email.worker.process',
+            op: 'queue.process'
+          ).and_return(mock_transaction)
+
+          described_class.continue_trace(trace_headers, name: 'email.worker.process') {}
+        end
+
+        it 'sets the transaction as the current span' do
+          expect(mock_scope).to receive(:set_span).with(mock_transaction)
+
+          described_class.continue_trace(trace_headers, name: 'test.operation') {}
+        end
+
+        it 'yields to the block' do
+          block_called = false
+          described_class.continue_trace(trace_headers, name: 'test') do
+            block_called = true
+          end
+
+          expect(block_called).to be true
+        end
+
+        it 'returns the result of the block' do
+          result = described_class.continue_trace(trace_headers, name: 'test') do
+            'block result'
+          end
+
+          expect(result).to eq('block result')
+        end
+
+        it 'sets transaction status to ok on success' do
+          expect(mock_transaction).to receive(:set_status).with('ok')
+
+          described_class.continue_trace(trace_headers, name: 'test') {}
+        end
+
+        it 'finishes the transaction' do
+          expect(mock_transaction).to receive(:finish)
+
+          described_class.continue_trace(trace_headers, name: 'test') {}
+        end
+
+        it 'accepts custom op parameter' do
+          expect(Sentry).to receive(:continue_trace).with(
+            trace_headers,
+            name: 'custom.operation',
+            op: 'custom.op'
+          ).and_return(mock_transaction)
+
+          described_class.continue_trace(trace_headers, name: 'custom.operation', op: 'custom.op') {}
+        end
+
+        context 'when block raises an error' do
+          it 'sets transaction status to internal_error' do
+            expect(mock_transaction).to receive(:set_status).with('internal_error')
+
+            expect {
+              described_class.continue_trace(trace_headers, name: 'test') do
+                raise StandardError, 'Processing failed'
+              end
+            }.to raise_error(StandardError, 'Processing failed')
+          end
+
+          it 'finishes the transaction before re-raising' do
+            expect(mock_transaction).to receive(:finish)
+
+            expect {
+              described_class.continue_trace(trace_headers, name: 'test') do
+                raise StandardError, 'Processing failed'
+              end
+            }.to raise_error(StandardError)
+          end
+
+          it 're-raises the original error' do
+            expect {
+              described_class.continue_trace(trace_headers, name: 'test') do
+                raise StandardError, 'Original error'
+              end
+            }.to raise_error(StandardError, 'Original error')
+          end
+        end
+      end
+
+      context 'when continue_trace returns nil (no trace context)' do
+        before do
+          allow(Sentry).to receive(:continue_trace).and_return(nil)
+        end
+
+        it 'still yields to the block' do
+          block_called = false
+          described_class.continue_trace(trace_headers, name: 'test') do
+            block_called = true
+          end
+
+          expect(block_called).to be true
+        end
+
+        it 'returns the result of the block' do
+          result = described_class.continue_trace(trace_headers, name: 'test') do
+            'result without transaction'
+          end
+
+          expect(result).to eq('result without transaction')
+        end
+      end
+    end
+
+    context 'when Sentry is not initialized' do
+      before do
+        allow(Sentry).to receive(:initialized?).and_return(false)
+      end
+
+      it 'does not call Sentry.continue_trace' do
+        expect(Sentry).not_to receive(:continue_trace)
+
+        described_class.continue_trace(trace_headers, name: 'test') {}
+      end
+
+      it 'still yields to the block' do
+        block_called = false
+        described_class.continue_trace(trace_headers, name: 'test') do
+          block_called = true
+        end
+
+        expect(block_called).to be true
+      end
+
+      it 'returns the result of the block' do
+        result = described_class.continue_trace(trace_headers, name: 'test') do
+          'fallback result'
+        end
+
+        expect(result).to eq('fallback result')
+      end
+    end
+
+    context 'when no block is given' do
+      before do
+        allow(Sentry).to receive(:initialized?).and_return(false)
+      end
+
+      it 'returns nil' do
+        result = described_class.continue_trace(trace_headers, name: 'test')
+
+        expect(result).to be_nil
+      end
+    end
+
+    context 'when Sentry is not defined' do
+      before do
+        hide_const('Sentry')
+      end
+
+      it 'yields to the block without error' do
+        block_called = false
+        described_class.continue_trace(trace_headers, name: 'test') do
+          block_called = true
+        end
+
+        expect(block_called).to be true
+      end
+    end
+  end
+
+  describe 'header key constants' do
+    it 'defines SENTRY_TRACE_HEADER' do
+      expect(described_class::SENTRY_TRACE_HEADER).to eq('sentry-trace')
+    end
+
+    it 'defines BAGGAGE_HEADER' do
+      expect(described_class::BAGGAGE_HEADER).to eq('baggage')
+    end
+  end
+end

--- a/spec/unit/onetime/jobs/trace_propagation_spec.rb
+++ b/spec/unit/onetime/jobs/trace_propagation_spec.rb
@@ -47,6 +47,10 @@ RSpec.describe Onetime::Jobs::TracePropagation do
         def self.continue_trace(headers, name:, op:)
           nil
         end
+
+        def self.with_scope
+          yield nil if block_given?
+        end
       end)
     end
   end
@@ -296,8 +300,8 @@ RSpec.describe Onetime::Jobs::TracePropagation do
         let(:mock_scope) { instance_double('Sentry::Scope') }
 
         before do
+          allow(Sentry).to receive(:with_scope).and_yield(mock_scope)
           allow(Sentry).to receive(:continue_trace).and_return(mock_transaction)
-          allow(Sentry).to receive(:get_current_scope).and_return(mock_scope)
           allow(mock_scope).to receive(:set_span)
           allow(mock_transaction).to receive(:set_status)
           allow(mock_transaction).to receive(:finish)
@@ -390,7 +394,10 @@ RSpec.describe Onetime::Jobs::TracePropagation do
       end
 
       context 'when continue_trace returns nil (no trace context)' do
+        let(:mock_scope) { instance_double('Sentry::Scope') }
+
         before do
+          allow(Sentry).to receive(:with_scope).and_yield(mock_scope)
           allow(Sentry).to receive(:continue_trace).and_return(nil)
         end
 


### PR DESCRIPTION
## Problem

Worker errors and performance data are isolated in Sentry — they cannot be linked to the originating web request. Debugging production issues requires manually correlating timestamps across logs.

## Solution

Propagate Sentry trace context (`sentry-trace`, `baggage`) through RabbitMQ message headers:

1. **Publisher side:** Extract trace headers before publishing to queue
2. **Worker side:** Continue trace from message metadata with `Sentry.continue_trace`
3. **Result:** Worker errors linked to originating request with full waterfall view in Sentry Performance

## Changes

**New:**
- `TracePropagation` module — extract/parse/continue Sentry traces across async boundaries
- `BaseWorker` additions — `with_trace_context` helper wraps processing in Sentry transaction

**Modified:**
- `Publisher#publish` — embeds trace headers in AMQP message metadata
- All 6 workers wrapped in trace context: EmailWorker, BillingWorker, NotificationWorker, DomainValidationWorker, DNSRecordCheckWorker, TransientWorker

## Testing

- 36 unit tests for TracePropagation (mocked Sentry)
- 9 publisher tests for header injection
- 16 BaseWorker integration tests for trace continuation
- All 439 job specs pass

## Backwards Compatible

- Gracefully handles messages without trace headers (creates new root transaction)
- Sentry tracing optional — workers function normally if Sentry not configured
- No breaking changes to message format or worker behavior

Closes #2972