### PR TITLE
Add Sentry context improvements for debugging

### DIFF
--- a/src/plugins/axios/interceptors.ts
+++ b/src/plugins/axios/interceptors.ts
@@ -3,14 +3,12 @@
 import {
   scrubSensitiveStrings,
   scrubUrlWithPatterns,
-} from '@/plugins/core/enableDiagnostics';
+} from '@/plugins/core/diagnostics/scrubbers';
 import { useLanguageStore } from '@/shared/stores';
 import { useCsrfStore } from '@/shared/stores/csrfStore';
 import { useOrganizationStore } from '@/shared/stores/organizationStore';
 import { addBreadcrumb } from '@sentry/vue';
 import type { AxiosError, AxiosResponse, InternalAxiosRequestConfig } from 'axios';
-
-import { scrubSensitiveStrings, scrubUrlWithPatterns } from '../core/enableDiagnostics';
 
 /**
  * CSRF Token Interceptors
@@ -128,7 +126,9 @@ export const errorInterceptor = (error: AxiosError) => {
 
   // Add Sentry breadcrumb for API debugging (#2965)
   // Scrub sensitive data from URL and error message before sending
-  // Note: method/url in data object aligns with Sentry's http breadcrumb schema
+  // Note: This complements breadcrumbsIntegration auto-capture (category 'xhr'/'fetch')
+  // by adding error-specific context (reason) under a distinct 'axios' category.
+  // The method/url in data object aligns with Sentry's http breadcrumb schema.
   const method = error.config?.method?.toUpperCase() ?? 'UNKNOWN';
   const url = error.config?.url ? scrubUrlWithPatterns(error.config.url) : 'unknown';
   addBreadcrumb({
@@ -137,7 +137,7 @@ export const errorInterceptor = (error: AxiosError) => {
     data: {
       method,
       url,
-      ...(error.response?.status && { status_code: error.response.status }),
+      ...(error.response?.status != null && { status_code: error.response.status }),
       reason: scrubSensitiveStrings(error.message),
     },
     level: 'error',
@@ -147,22 +147,6 @@ export const errorInterceptor = (error: AxiosError) => {
   if (isValidShrimp(responseShrimp)) {
     csrfStore.updateShrimp(responseShrimp);
   }
-
-  // Add Sentry breadcrumb for API error debugging
-  const scrubbedUrl = scrubUrlWithPatterns(error.config?.url ?? '');
-  const method = error.config?.method?.toUpperCase() || 'HTTP';
-  addBreadcrumb({
-    type: 'http',
-    category: 'http.client',
-    level: 'error',
-    message: `${method} ${scrubbedUrl}`,
-    data: {
-      url: scrubbedUrl,
-      method,
-      status_code: error.response?.status,
-      reason: scrubSensitiveStrings(error.message),
-    },
-  });
 
   return Promise.reject(error); // no gate keeping, just pass the error along
 };

--- a/src/plugins/axios/interceptors.ts
+++ b/src/plugins/axios/interceptors.ts
@@ -128,14 +128,16 @@ export const errorInterceptor = (error: AxiosError) => {
 
   // Add Sentry breadcrumb for API debugging (#2965)
   // Scrub sensitive data from URL and error message before sending
+  // Note: method/url in data object aligns with Sentry's http breadcrumb schema
   const method = error.config?.method?.toUpperCase() ?? 'UNKNOWN';
   const url = error.config?.url ? scrubUrlWithPatterns(error.config.url) : 'unknown';
   addBreadcrumb({
     type: 'http',
     category: 'axios',
-    message: `${method} ${url}`,
     data: {
-      status_code: error.response?.status,
+      method,
+      url,
+      ...(error.response?.status && { status_code: error.response.status }),
       reason: scrubSensitiveStrings(error.message),
     },
     level: 'error',

--- a/src/plugins/axios/interceptors.ts
+++ b/src/plugins/axios/interceptors.ts
@@ -1,10 +1,13 @@
 // src/plugins/axios/interceptors.ts
 
-import { addBreadcrumb } from '@sentry/browser';
-
+import {
+  scrubSensitiveStrings,
+  scrubUrlWithPatterns,
+} from '@/plugins/core/enableDiagnostics';
 import { useLanguageStore } from '@/shared/stores';
 import { useCsrfStore } from '@/shared/stores/csrfStore';
 import { useOrganizationStore } from '@/shared/stores/organizationStore';
+import { addBreadcrumb } from '@sentry/vue';
 import type { AxiosError, AxiosResponse, InternalAxiosRequestConfig } from 'axios';
 
 import { scrubSensitiveStrings, scrubUrlWithPatterns } from '../core/enableDiagnostics';
@@ -123,15 +126,20 @@ export const errorInterceptor = (error: AxiosError) => {
   // Read CSRF token from response header even in error cases
   const responseShrimp = error.response?.headers['x-csrf-token'];
 
-  // console.error('[errorInterceptor] ', {
-  //   url: error.config?.url,
-  //   method: error.config?.method,
-  //   status: error.response?.status,
-  //   hasShrimp: responseShrimp ? true : false,
-  //   shrimp: createLoggableShrimp(responseShrimp),
-  //   error: error.message,
-  //   name: error.name,
-  // });
+  // Add Sentry breadcrumb for API debugging (#2965)
+  // Scrub sensitive data from URL and error message before sending
+  const method = error.config?.method?.toUpperCase() ?? 'UNKNOWN';
+  const url = error.config?.url ? scrubUrlWithPatterns(error.config.url) : 'unknown';
+  addBreadcrumb({
+    type: 'http',
+    category: 'axios',
+    message: `${method} ${url}`,
+    data: {
+      status_code: error.response?.status,
+      reason: scrubSensitiveStrings(error.message),
+    },
+    level: 'error',
+  });
 
   // Update our local shrimp token if new one is provided
   if (isValidShrimp(responseShrimp)) {

--- a/src/plugins/axios/interceptors.ts
+++ b/src/plugins/axios/interceptors.ts
@@ -134,13 +134,14 @@ export const errorInterceptor = (error: AxiosError) => {
   addBreadcrumb({
     type: 'http',
     category: 'axios',
+    level: 'error',
+    message: `${method} ${url}`,
     data: {
       method,
       url,
       ...(error.response?.status != null && { status_code: error.response.status }),
       reason: scrubSensitiveStrings(error.message),
     },
-    level: 'error',
   });
 
   // Update our local shrimp token if new one is provided

--- a/src/plugins/core/diagnostics/scrubbers.ts
+++ b/src/plugins/core/diagnostics/scrubbers.ts
@@ -1,0 +1,96 @@
+// src/plugins/core/diagnostics/scrubbers.ts
+//
+// Dependency-free utilities for scrubbing sensitive data from strings and URLs.
+// Extracted from enableDiagnostics.ts to avoid pulling in Sentry/Vue dependencies.
+//
+// Used by:
+// - axios interceptors (breadcrumb scrubbing)
+// - Sentry beforeBreadcrumb handler
+// - Sentry beforeSend handler
+
+/**
+ * Pattern for known sensitive URL paths.
+ * Matches /secret/, /private/, /receipt/, /incoming/ followed by an identifier.
+ *
+ * @internal Exported for testing
+ */
+export const SENSITIVE_PATH_PATTERN =
+  /\/(secret|private|receipt|incoming)\/([a-zA-Z0-9]+)/gi;
+
+/**
+ * Fallback pattern for 62-character verifiable identifiers.
+ * These are base62-encoded IDs that could appear in unexpected paths.
+ *
+ * @internal Exported for testing
+ */
+export const VERIFIABLE_ID_PATTERN = /[0-9a-z]{62}/gi;
+
+/**
+ * Pattern for email addresses.
+ * Matches standard email formats like user@example.com.
+ *
+ * @internal Exported for testing
+ */
+export const EMAIL_PATTERN = /[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g;
+
+/**
+ * Scrubs sensitive data from arbitrary strings using regex patterns.
+ * Used for exception messages, standalone messages, and other text.
+ *
+ * Scrubs:
+ * - Email addresses -> [EMAIL REDACTED]
+ * - 62-char verifiable IDs -> [REDACTED]
+ * - Sensitive path patterns -> /type/[REDACTED]
+ *
+ * @param text - The string to scrub
+ * @returns The scrubbed string with sensitive data replaced
+ */
+export function scrubSensitiveStrings(text: string): string {
+  if (!text || typeof text !== 'string') {
+    return text;
+  }
+
+  let result = text;
+
+  // Scrub email addresses
+  result = result.replace(EMAIL_PATTERN, '[EMAIL REDACTED]');
+
+  // Scrub 62-char verifiable IDs
+  result = result.replace(VERIFIABLE_ID_PATTERN, '[REDACTED]');
+
+  // Scrub sensitive path patterns (in case exception message contains URLs/paths)
+  result = result.replace(SENSITIVE_PATH_PATTERN, '/$1/[REDACTED]');
+
+  return result;
+}
+
+/**
+ * Scrubs sensitive identifiers from a URL path using regex patterns.
+ * Used for HTTP breadcrumbs where we don't have route context.
+ *
+ * Scrubs:
+ * - Known sensitive paths (/secret/, /private/, /receipt/, /incoming/)
+ * - 62-char verifiable IDs
+ * - Email addresses in query strings (e.g., ?email=user@example.com)
+ *
+ * @param url - The URL string to scrub
+ * @returns The scrubbed URL with sensitive identifiers replaced by [REDACTED]
+ */
+export function scrubUrlWithPatterns(url: string): string {
+  if (!url || typeof url !== 'string') {
+    return url;
+  }
+
+  let result = url;
+
+  // First pass: scrub known sensitive path patterns
+  result = result.replace(SENSITIVE_PATH_PATTERN, '/$1/[REDACTED]');
+
+  // Second pass: scrub any remaining 62-char verifiable IDs
+  result = result.replace(VERIFIABLE_ID_PATTERN, '[REDACTED]');
+
+  // Third pass: scrub email addresses (e.g., in query params like ?email=user@example.com)
+  result = result.replace(EMAIL_PATTERN, '[EMAIL REDACTED]');
+
+  return result;
+}

--- a/src/plugins/core/enableDiagnostics.ts
+++ b/src/plugins/core/enableDiagnostics.ts
@@ -6,6 +6,14 @@ import type { DiagnosticsConfig } from '@/types/diagnostics';
 import type { RouteMeta } from '@/types/router';
 import { DEBUG } from '@/utils/debug';
 import { collectValuesToRedact, scrubUrlWithValues } from './diagnostics/urlScrubbing';
+// Re-export scrubbing utilities from dependency-free module for backward compatibility
+export {
+  EMAIL_PATTERN,
+  SENSITIVE_PATH_PATTERN,
+  VERIFIABLE_ID_PATTERN,
+  scrubSensitiveStrings,
+  scrubUrlWithPatterns,
+} from './diagnostics/scrubbers';
 import {
   BrowserClient,
   Scope,
@@ -23,83 +31,8 @@ import type { Router } from 'vue-router';
 
 export const SENTRY_KEY = Symbol('sentry');
 
-/**
- * Regex pattern for sensitive path segments in HTTP requests.
- * Matches: /secret/, /private/, /receipt/, /incoming/ followed by an identifier.
- * Does NOT include /colonel/ as those routes explicitly opt out of scrubbing.
- *
- * @internal Exported for testing
- */
-export const SENSITIVE_PATH_PATTERN = /\/(secret|private|receipt|incoming)\/([a-zA-Z0-9]+)/gi;
-
-/**
- * Fallback pattern for 62-character verifiable identifiers.
- * These are base62-encoded IDs that could appear in unexpected paths.
- *
- * @internal Exported for testing
- */
-export const VERIFIABLE_ID_PATTERN = /[0-9a-z]{62}/gi;
-
-/**
- * Pattern for email addresses.
- * Matches standard email formats like user@example.com.
- *
- * @internal Exported for testing
- */
-export const EMAIL_PATTERN = /[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g;
-
-/**
- * Scrubs sensitive data from arbitrary strings using regex patterns.
- * Used for exception messages, standalone messages, and other text.
- *
- * @param text - The string to scrub
- * @returns The scrubbed string with sensitive data replaced
- *
- * @internal Exported for testing
- */
-export function scrubSensitiveStrings(text: string): string {
-  if (!text || typeof text !== 'string') {
-    return text;
-  }
-
-  let result = text;
-
-  // Scrub email addresses
-  result = result.replace(EMAIL_PATTERN, '[EMAIL REDACTED]');
-
-  // Scrub 62-char verifiable IDs
-  result = result.replace(VERIFIABLE_ID_PATTERN, '[REDACTED]');
-
-  // Scrub sensitive path patterns (in case exception message contains URLs/paths)
-  result = result.replace(SENSITIVE_PATH_PATTERN, '/$1/[REDACTED]');
-
-  return result;
-}
-
-/**
- * Scrubs sensitive identifiers from a URL path using regex patterns.
- * Used for HTTP breadcrumbs where we don't have route context.
- *
- * @param url - The URL string to scrub
- * @returns The scrubbed URL with sensitive identifiers replaced by [REDACTED]
- *
- * @internal Exported for testing
- */
-export function scrubUrlWithPatterns(url: string): string {
-  if (!url || typeof url !== 'string') {
-    return url;
-  }
-
-  let result = url;
-
-  // First pass: scrub known sensitive path patterns
-  result = result.replace(SENSITIVE_PATH_PATTERN, '/$1/[REDACTED]');
-
-  // Second pass: scrub any remaining 62-char verifiable IDs
-  result = result.replace(VERIFIABLE_ID_PATTERN, '[REDACTED]');
-
-  return result;
-}
+// Import functions for local use (patterns are re-exported above for external consumers)
+import { scrubSensitiveStrings, scrubUrlWithPatterns } from './diagnostics/scrubbers';
 
 /**
  * Creates a Sentry beforeBreadcrumb handler that scrubs sensitive URLs at capture time.

--- a/src/plugins/core/globalErrorBoundary.ts
+++ b/src/plugins/core/globalErrorBoundary.ts
@@ -5,6 +5,7 @@ import { classifyError, errorGuards } from '@/schemas/errors';
 import { captureException, isDiagnosticsEnabled } from '@/services/diagnostics.service';
 import { loggingService } from '@/services/logging.service';
 import { useBootstrapStore } from '@/shared/stores/bootstrapStore';
+import type { VueComponentLike } from '@/types/ui/vue-internals';
 import type { App, Plugin } from 'vue';
 
 interface ErrorBoundaryOptions extends AsyncHandlerOptions {
@@ -20,8 +21,7 @@ interface ErrorBoundaryOptions extends AsyncHandlerOptions {
  */
 export function getComponentName(instance: unknown): string {
   if (!instance || typeof instance !== 'object') return 'unknown';
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const i = instance as any;
+  const i = instance as VueComponentLike;
   // Options API: $options.name
   // Script setup: $.type.name or $.type.__name (Vue 3 internal component type)
   // Guard i.$ for edge cases (SSR hydration errors, corrupted instances)

--- a/src/plugins/core/globalErrorBoundary.ts
+++ b/src/plugins/core/globalErrorBoundary.ts
@@ -14,8 +14,11 @@ interface ErrorBoundaryOptions extends AsyncHandlerOptions {
 /**
  * Extracts the Vue component name for Sentry context (#2966)
  * Works with both Options API ($options.name) and script setup ($.type.name/.__name)
+ *
+ * @param instance - Vue component instance (from error handler)
+ * @returns Component name or 'unknown' if not extractable
  */
-function getComponentName(instance: unknown): string {
+export function getComponentName(instance: unknown): string {
   if (!instance || typeof instance !== 'object') return 'unknown';
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const i = instance as any;

--- a/src/plugins/core/globalErrorBoundary.ts
+++ b/src/plugins/core/globalErrorBoundary.ts
@@ -13,17 +13,16 @@ interface ErrorBoundaryOptions extends AsyncHandlerOptions {
 
 /**
  * Extracts the Vue component name for Sentry context (#2966)
- * Works with both Options API ($options.name) and script setup (__name)
+ * Works with both Options API ($options.name) and script setup ($.type.name/.__name)
  */
 function getComponentName(instance: unknown): string {
   if (!instance || typeof instance !== 'object') return 'unknown';
-  const opts = (instance as Record<string, unknown>).$options;
-  if (opts && typeof opts === 'object' && typeof (opts as Record<string, unknown>).name === 'string') {
-    return (opts as Record<string, unknown>).name as string;
-  }
-  const name = (instance as Record<string, unknown>).__name;
-  if (typeof name === 'string') return name;
-  return 'unknown';
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const i = instance as any;
+  // Options API: $options.name
+  // Script setup: $.type.name or $.type.__name (Vue 3 internal component type)
+  // Guard i.$ for edge cases (SSR hydration errors, corrupted instances)
+  return i.$options?.name || i.$?.type?.name || i.$?.type?.__name || 'unknown';
 }
 
 /**

--- a/src/plugins/core/globalErrorBoundary.ts
+++ b/src/plugins/core/globalErrorBoundary.ts
@@ -12,6 +12,21 @@ interface ErrorBoundaryOptions extends AsyncHandlerOptions {
 }
 
 /**
+ * Extracts the Vue component name for Sentry context (#2966)
+ * Works with both Options API ($options.name) and script setup (__name)
+ */
+function getComponentName(instance: unknown): string {
+  if (!instance || typeof instance !== 'object') return 'unknown';
+  const opts = (instance as Record<string, unknown>).$options;
+  if (opts && typeof opts === 'object' && typeof (opts as Record<string, unknown>).name === 'string') {
+    return (opts as Record<string, unknown>).name as string;
+  }
+  const name = (instance as Record<string, unknown>).__name;
+  if (typeof name === 'string') return name;
+  return 'unknown';
+}
+
+/**
  * Creates a Vue plugin that provides global error handling
  *
  * @param {ErrorBoundaryOptions} options - Configuration options
@@ -56,6 +71,7 @@ export function createErrorBoundary(options: ErrorBoundaryOptions = {}): Plugin 
           // Note: useBootstrapStore() is safe here because Pinia is installed before this plugin
           const bootstrap = useBootstrapStore();
           const context: Record<string, unknown> = {
+            componentName: getComponentName(instance),
             componentInfo: info,
             errorType: classifiedError.type,
             errorSeverity: classifiedError.severity,

--- a/src/services/diagnostics.service.ts
+++ b/src/services/diagnostics.service.ts
@@ -25,6 +25,7 @@ let diagnosticsClient: DiagnosticsClient | null = null;
  * All tag values are normalized to lowercase for consistent querying.
  *
  * Tags:
+ * - componentName: Vue component name where error occurred (#2966)
  * - errorType: human, security, technical (from error classification)
  * - errorSeverity: error severity level (from error classification)
  * - schema: Zod schema name (lowercase)
@@ -35,7 +36,7 @@ let diagnosticsClient: DiagnosticsClient | null = null;
  *
  * @see https://github.com/onetimesecret/onetimesecret/issues/2964
  */
-const TAG_FIELDS = ['errorType', 'errorSeverity', 'schema', 'service', 'jurisdiction', 'planid', 'role'] as const;
+const TAG_FIELDS = ['componentName', 'errorType', 'errorSeverity', 'schema', 'service', 'jurisdiction', 'planid', 'role'] as const;
 type _TagField = (typeof TAG_FIELDS)[number]; // Used for documentation; lookup via Set<string>
 const TAG_FIELDS_SET = new Set<string>(TAG_FIELDS);
 

--- a/src/tests/plugins/axios/interceptors.spec.ts
+++ b/src/tests/plugins/axios/interceptors.spec.ts
@@ -130,13 +130,14 @@ describe('axios interceptors', () => {
         expect(mockAddBreadcrumb).toHaveBeenCalledWith({
           type: 'http',
           category: 'axios',
+          level: 'error',
+          message: 'POST /api/v3/secrets',
           data: {
             method: 'POST',
             url: '/api/v3/secrets',
             status_code: 500,
             reason: 'Internal Server Error',
           },
-          level: 'error',
         });
       });
 

--- a/src/tests/plugins/axios/interceptors.spec.ts
+++ b/src/tests/plugins/axios/interceptors.spec.ts
@@ -1,40 +1,37 @@
 // src/tests/plugins/axios/interceptors.spec.ts
+//
+// Integration tests for axios interceptors, specifically the Sentry
+// breadcrumb creation in the error interceptor.
+//
+// Issue: #2965 - Add Sentry breadcrumbs for API debugging
+//
+// Run:
+//   pnpm test src/tests/plugins/axios/interceptors.spec.ts
 
-/**
- * Tests for axios interceptors (src/plugins/axios/interceptors.ts)
- *
- * Covers:
- * - errorInterceptor breadcrumb functionality (Sentry integration)
- * - URL scrubbing for sensitive paths
- * - CSRF token preservation during errors
- *
- * Run:
- *   pnpm vitest run src/tests/plugins/axios/interceptors.spec.ts
- */
-
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-import axios, { type AxiosError, type AxiosResponse } from 'axios';
-import * as Sentry from '@sentry/browser';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { AxiosError, AxiosResponse, InternalAxiosRequestConfig } from 'axios';
 
 // ---------------------------------------------------------------------------
-// Mock setup - must be before imports that use these modules
+// Mocks - must use vi.hoisted() for variables used in vi.mock factories
 // ---------------------------------------------------------------------------
 
-vi.mock('@sentry/browser', () => ({
-  addBreadcrumb: vi.fn(),
+const { mockAddBreadcrumb, mockUpdateShrimp } = vi.hoisted(() => ({
+  mockAddBreadcrumb: vi.fn(),
+  mockUpdateShrimp: vi.fn(),
 }));
 
-// Mock the CSRF store - use a module-level object so we can spy on it
-const mockCsrfStore = {
-  shrimp: 'mock-csrf-token',
-  updateShrimp: vi.fn(),
-};
+vi.mock('@sentry/vue', () => ({
+  addBreadcrumb: mockAddBreadcrumb,
+}));
 
+// Mock Pinia stores
 vi.mock('@/shared/stores/csrfStore', () => ({
-  useCsrfStore: () => mockCsrfStore,
+  useCsrfStore: () => ({
+    shrimp: 'test-csrf-token',
+    updateShrimp: mockUpdateShrimp,
+  }),
 }));
 
-// Mock other stores used by requestInterceptor
 vi.mock('@/shared/stores', () => ({
   useLanguageStore: () => ({
     getCurrentLocale: 'en',
@@ -47,432 +44,220 @@ vi.mock('@/shared/stores/organizationStore', () => ({
   }),
 }));
 
-// ---------------------------------------------------------------------------
-// Import module under test AFTER mocks are set up
-// ---------------------------------------------------------------------------
-import { errorInterceptor, responseInterceptor, createLoggableShrimp } from '@/plugins/axios/interceptors';
+// Mock scrubbing functions with passthrough behavior for most tests
+// Actual scrubbing logic is tested in scrubbers.spec.ts
+vi.mock('@/plugins/core/diagnostics/scrubbers', () => ({
+  scrubSensitiveStrings: (str: string) => str,
+  scrubUrlWithPatterns: (url: string) => url,
+}));
 
 // ---------------------------------------------------------------------------
-// Helper: Create mock AxiosError objects
+// Import after mocks
 // ---------------------------------------------------------------------------
-function createMockAxiosError(options: {
-  url?: string;
-  method?: string;
-  status?: number;
-  message?: string;
-  responseHeaders?: Record<string, string>;
-}): AxiosError {
-  const { url, method, status, message = 'Request failed', responseHeaders = {} } = options;
 
-  const error = new axios.AxiosError(
-    message,
-    status?.toString() ?? 'ERR_UNKNOWN',
-    url !== undefined || method !== undefined
-      ? ({
-          url,
-          method,
-        } as any)
-      : undefined,
-    undefined,
-    status !== undefined
-      ? ({
-          status,
-          headers: responseHeaders,
+import {
+  errorInterceptor,
+  responseInterceptor,
+  createLoggableShrimp,
+} from '@/plugins/axios/interceptors';
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function createAxiosError(
+  overrides: Partial<{
+    message: string;
+    method: string;
+    url: string;
+    status: number;
+    responseHeaders: Record<string, string>;
+  }> = {}
+): AxiosError {
+  const config: InternalAxiosRequestConfig = {
+    method: overrides.method ?? 'get',
+    url: overrides.url ?? '/api/test',
+    headers: {} as InternalAxiosRequestConfig['headers'],
+  };
+
+  return {
+    name: 'AxiosError',
+    message: overrides.message ?? 'Request failed',
+    config,
+    isAxiosError: true,
+    toJSON: () => ({}),
+    response: overrides.status
+      ? {
+          status: overrides.status,
+          statusText: 'Error',
+          headers: overrides.responseHeaders ?? {},
+          config,
           data: {},
-        } as AxiosResponse)
-      : undefined
-  );
-
-  return error;
+        }
+      : undefined,
+  } as AxiosError;
 }
 
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
+
 describe('axios interceptors', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockCsrfStore.updateShrimp.mockClear();
   });
 
-  // ========================================================================
-  // errorInterceptor - Breadcrumb functionality
-  // ========================================================================
+  afterEach(() => {
+    vi.resetModules();
+  });
+
+  // ==========================================================================
+  // errorInterceptor
+  // ==========================================================================
   describe('errorInterceptor', () => {
-    describe('breadcrumb creation', () => {
-      it('adds a breadcrumb when error occurs', async () => {
-        const error = createMockAxiosError({
-          url: '/api/v3/users',
-          method: 'get',
+    describe('Sentry breadcrumb creation', () => {
+      it('creates breadcrumb with correct structure', async () => {
+        const error = createAxiosError({
+          method: 'post',
+          url: '/api/v3/secrets',
           status: 500,
           message: 'Internal Server Error',
         });
 
-        await expect(errorInterceptor(error)).rejects.toBe(error);
+        await expect(errorInterceptor(error)).rejects.toThrow();
 
-        expect(Sentry.addBreadcrumb).toHaveBeenCalledTimes(1);
-        expect(Sentry.addBreadcrumb).toHaveBeenCalledWith(
-          expect.objectContaining({
-            type: 'http',
-            category: 'http.client',
-            level: 'error',
-          })
-        );
-      });
-
-      it('includes correct data fields in breadcrumb', async () => {
-        const error = createMockAxiosError({
-          url: '/api/v3/colonel/admin',
-          method: 'post',
-          status: 403,
-          message: 'Forbidden',
-        });
-
-        await expect(errorInterceptor(error)).rejects.toBe(error);
-
-        expect(Sentry.addBreadcrumb).toHaveBeenCalledWith(
-          expect.objectContaining({
-            message: 'POST /api/v3/colonel/admin',
-            data: expect.objectContaining({
-              url: '/api/v3/colonel/admin',
-              method: 'POST',
-              status_code: 403,
-              reason: 'Forbidden',
-            }),
-          })
-        );
-      });
-    });
-
-    describe('URL scrubbing', () => {
-      it('scrubs /secret/ path identifiers', async () => {
-        const error = createMockAxiosError({
-          url: '/api/v3/secret/abc123def456',
-          method: 'get',
-          status: 404,
-        });
-
-        await expect(errorInterceptor(error)).rejects.toBe(error);
-
-        expect(Sentry.addBreadcrumb).toHaveBeenCalledWith(
-          expect.objectContaining({
-            message: 'GET /api/v3/secret/[REDACTED]',
-            data: expect.objectContaining({
-              url: '/api/v3/secret/[REDACTED]',
-            }),
-          })
-        );
-      });
-
-      it('scrubs /private/ path identifiers', async () => {
-        const error = createMockAxiosError({
-          url: '/api/v3/private/xyz789',
-          method: 'get',
-          status: 404,
-        });
-
-        await expect(errorInterceptor(error)).rejects.toBe(error);
-
-        expect(Sentry.addBreadcrumb).toHaveBeenCalledWith(
-          expect.objectContaining({
-            message: 'GET /api/v3/private/[REDACTED]',
-            data: expect.objectContaining({
-              url: '/api/v3/private/[REDACTED]',
-            }),
-          })
-        );
-      });
-
-      it('scrubs /receipt/ path identifiers', async () => {
-        const error = createMockAxiosError({
-          url: '/api/v3/receipt/receipt123',
-          method: 'get',
-          status: 404,
-        });
-
-        await expect(errorInterceptor(error)).rejects.toBe(error);
-
-        expect(Sentry.addBreadcrumb).toHaveBeenCalledWith(
-          expect.objectContaining({
-            message: 'GET /api/v3/receipt/[REDACTED]',
-            data: expect.objectContaining({
-              url: '/api/v3/receipt/[REDACTED]',
-            }),
-          })
-        );
-      });
-
-      it('scrubs /incoming/ path identifiers', async () => {
-        const error = createMockAxiosError({
-          url: '/api/v3/incoming/incoming456',
-          method: 'post',
-          status: 400,
-        });
-
-        await expect(errorInterceptor(error)).rejects.toBe(error);
-
-        expect(Sentry.addBreadcrumb).toHaveBeenCalledWith(
-          expect.objectContaining({
-            message: 'POST /api/v3/incoming/[REDACTED]',
-            data: expect.objectContaining({
-              url: '/api/v3/incoming/[REDACTED]',
-            }),
-          })
-        );
-      });
-
-      it('scrubs multiple sensitive segments in one URL', async () => {
-        const error = createMockAxiosError({
-          url: '/api/v3/secret/abc123/private/xyz789',
-          method: 'get',
-          status: 500,
-        });
-
-        await expect(errorInterceptor(error)).rejects.toBe(error);
-
-        expect(Sentry.addBreadcrumb).toHaveBeenCalledWith(
-          expect.objectContaining({
-            message: 'GET /api/v3/secret/[REDACTED]/private/[REDACTED]',
-            data: expect.objectContaining({
-              url: '/api/v3/secret/[REDACTED]/private/[REDACTED]',
-            }),
-          })
-        );
-      });
-
-      it('leaves non-sensitive URLs unchanged', async () => {
-        const error = createMockAxiosError({
-          url: '/api/v3/colonel/admin',
-          method: 'get',
-          status: 401,
-        });
-
-        await expect(errorInterceptor(error)).rejects.toBe(error);
-
-        expect(Sentry.addBreadcrumb).toHaveBeenCalledWith(
-          expect.objectContaining({
-            message: 'GET /api/v3/colonel/admin',
-            data: expect.objectContaining({
-              url: '/api/v3/colonel/admin',
-            }),
-          })
-        );
-      });
-    });
-
-    describe('method handling', () => {
-      it('uppercases method from lowercase', async () => {
-        const error = createMockAxiosError({
-          url: '/api/test',
-          method: 'get',
-          status: 500,
-        });
-
-        await expect(errorInterceptor(error)).rejects.toBe(error);
-
-        expect(Sentry.addBreadcrumb).toHaveBeenCalledWith(
-          expect.objectContaining({
-            message: 'GET /api/test',
-            data: expect.objectContaining({
-              method: 'GET',
-            }),
-          })
-        );
-      });
-
-      it('uppercases mixed case method', async () => {
-        const error = createMockAxiosError({
-          url: '/api/test',
-          method: 'PoSt',
-          status: 500,
-        });
-
-        await expect(errorInterceptor(error)).rejects.toBe(error);
-
-        expect(Sentry.addBreadcrumb).toHaveBeenCalledWith(
-          expect.objectContaining({
-            message: 'POST /api/test',
-            data: expect.objectContaining({
-              method: 'POST',
-            }),
-          })
-        );
-      });
-
-      it('defaults method to HTTP when undefined', async () => {
-        const error = createMockAxiosError({
-          url: '/api/test',
-          method: undefined,
-          status: 500,
-        });
-
-        await expect(errorInterceptor(error)).rejects.toBe(error);
-
-        expect(Sentry.addBreadcrumb).toHaveBeenCalledWith(
-          expect.objectContaining({
-            message: 'HTTP /api/test',
-            data: expect.objectContaining({
-              method: 'HTTP',
-            }),
-          })
-        );
-      });
-    });
-
-    describe('status code and reason capture', () => {
-      it('captures status code from response', async () => {
-        const error = createMockAxiosError({
-          url: '/api/test',
-          method: 'get',
-          status: 404,
-          message: 'Not Found',
-        });
-
-        await expect(errorInterceptor(error)).rejects.toBe(error);
-
-        expect(Sentry.addBreadcrumb).toHaveBeenCalledWith(
-          expect.objectContaining({
-            data: expect.objectContaining({
-              status_code: 404,
-              reason: 'Not Found',
-            }),
-          })
-        );
-      });
-
-      it('handles undefined status code when no response', async () => {
-        // Network error - no response
-        const error = createMockAxiosError({
-          url: '/api/test',
-          method: 'get',
-          status: undefined,
-          message: 'Network Error',
-        });
-
-        await expect(errorInterceptor(error)).rejects.toBe(error);
-
-        expect(Sentry.addBreadcrumb).toHaveBeenCalledWith(
-          expect.objectContaining({
-            data: expect.objectContaining({
-              status_code: undefined,
-              reason: 'Network Error',
-            }),
-          })
-        );
-      });
-    });
-
-    describe('graceful handling of edge cases', () => {
-      it('handles error with empty config gracefully', async () => {
-        const error = new axios.AxiosError('Request failed', 'ERR_UNKNOWN');
-        // error.config is undefined by default
-
-        await expect(errorInterceptor(error)).rejects.toBe(error);
-
-        // Should not crash, should add breadcrumb with defaults
-        expect(Sentry.addBreadcrumb).toHaveBeenCalledTimes(1);
-        expect(Sentry.addBreadcrumb).toHaveBeenCalledWith(
-          expect.objectContaining({
-            message: 'HTTP ',
-            data: expect.objectContaining({
-              url: '',
-              method: 'HTTP',
-            }),
-          })
-        );
-      });
-
-      it('handles error with null-like values gracefully', async () => {
-        const error = createMockAxiosError({
-          url: '',
-          method: '',
-          status: undefined,
-          message: 'Unknown error',
-        });
-
-        await expect(errorInterceptor(error)).rejects.toBe(error);
-
-        expect(Sentry.addBreadcrumb).toHaveBeenCalledTimes(1);
-        // Empty method string.toUpperCase() returns '' which is falsy,
-        // so || 'HTTP' kicks in - defaults to 'HTTP'
-        expect(Sentry.addBreadcrumb).toHaveBeenCalledWith(
-          expect.objectContaining({
-            type: 'http',
-            category: 'http.client',
-            level: 'error',
-            data: expect.objectContaining({
-              url: '',
-              method: 'HTTP',
-            }),
-          })
-        );
-      });
-    });
-
-    describe('CSRF token update on error', () => {
-      it('updates CSRF token from error response headers', async () => {
-        const error = createMockAxiosError({
-          url: '/api/test',
-          method: 'post',
-          status: 403,
-          responseHeaders: {
-            'x-csrf-token': 'new-csrf-token-from-error',
+        expect(mockAddBreadcrumb).toHaveBeenCalledOnce();
+        expect(mockAddBreadcrumb).toHaveBeenCalledWith({
+          type: 'http',
+          category: 'axios',
+          data: {
+            method: 'POST',
+            url: '/api/v3/secrets',
+            status_code: 500,
+            reason: 'Internal Server Error',
           },
+          level: 'error',
         });
+      });
+
+      it('uppercases HTTP method', async () => {
+        const error = createAxiosError({ method: 'delete' });
+
+        await expect(errorInterceptor(error)).rejects.toThrow();
+
+        const call = mockAddBreadcrumb.mock.calls[0][0];
+        expect(call.data.method).toBe('DELETE');
+      });
+
+      it('handles missing method gracefully', async () => {
+        const error = createAxiosError({});
+        error.config = undefined as unknown as InternalAxiosRequestConfig;
+
+        await expect(errorInterceptor(error)).rejects.toThrow();
+
+        const call = mockAddBreadcrumb.mock.calls[0][0];
+        expect(call.data.method).toBe('UNKNOWN');
+      });
+
+      it('handles missing URL gracefully', async () => {
+        const error = createAxiosError({});
+        error.config!.url = undefined;
+
+        await expect(errorInterceptor(error)).rejects.toThrow();
+
+        const call = mockAddBreadcrumb.mock.calls[0][0];
+        expect(call.data.url).toBe('unknown');
+      });
+
+      it('omits status_code when response is undefined (network error)', async () => {
+        const error = createAxiosError({ message: 'Network Error' });
+        // No response = network error
+
+        await expect(errorInterceptor(error)).rejects.toThrow();
+
+        const call = mockAddBreadcrumb.mock.calls[0][0];
+        expect(call.data).not.toHaveProperty('status_code');
+      });
+
+      it('includes status_code when response exists', async () => {
+        const error = createAxiosError({ status: 404 });
+
+        await expect(errorInterceptor(error)).rejects.toThrow();
+
+        const call = mockAddBreadcrumb.mock.calls[0][0];
+        expect(call.data.status_code).toBe(404);
+      });
+
+      it('always rejects with the original error', async () => {
+        const error = createAxiosError({ message: 'Test error' });
 
         await expect(errorInterceptor(error)).rejects.toBe(error);
+      });
+    });
 
-        expect(mockCsrfStore.updateShrimp).toHaveBeenCalledWith('new-csrf-token-from-error');
+    // Note: Scrubbing function behavior is tested in scrubbers.spec.ts
+    // These tests verify the interceptor calls scrubbing functions correctly
+    describe('breadcrumb scrubbing integration', () => {
+      it('passes URL through scrubUrlWithPatterns', async () => {
+        // With passthrough mock, URL should be unchanged
+        const error = createAxiosError({ url: '/api/v3/test' });
+
+        await expect(errorInterceptor(error)).rejects.toThrow();
+
+        const call = mockAddBreadcrumb.mock.calls[0][0];
+        expect(call.data.url).toBe('/api/v3/test');
+      });
+
+      it('passes error message through scrubSensitiveStrings', async () => {
+        // With passthrough mock, message should be unchanged
+        const error = createAxiosError({ message: 'Test error message' });
+
+        await expect(errorInterceptor(error)).rejects.toThrow();
+
+        const call = mockAddBreadcrumb.mock.calls[0][0];
+        expect(call.data.reason).toBe('Test error message');
+      });
+    });
+
+    describe('CSRF token handling', () => {
+      it('updates CSRF token from error response headers', async () => {
+        const error = createAxiosError({
+          status: 403,
+          responseHeaders: { 'x-csrf-token': 'new-token' },
+        });
+
+        await expect(errorInterceptor(error)).rejects.toThrow();
+
+        expect(mockUpdateShrimp).toHaveBeenCalledWith('new-token');
       });
 
       it('does not update CSRF token when header is missing', async () => {
-        const error = createMockAxiosError({
-          url: '/api/test',
-          method: 'post',
+        const error = createAxiosError({
           status: 500,
           responseHeaders: {},
         });
 
-        await expect(errorInterceptor(error)).rejects.toBe(error);
+        await expect(errorInterceptor(error)).rejects.toThrow();
 
-        expect(mockCsrfStore.updateShrimp).not.toHaveBeenCalled();
+        expect(mockUpdateShrimp).not.toHaveBeenCalled();
       });
 
       it('does not update CSRF token when header is empty string', async () => {
-        const error = createMockAxiosError({
-          url: '/api/test',
-          method: 'post',
+        const error = createAxiosError({
           status: 403,
-          responseHeaders: {
-            'x-csrf-token': '',
-          },
+          responseHeaders: { 'x-csrf-token': '' },
         });
 
-        await expect(errorInterceptor(error)).rejects.toBe(error);
+        await expect(errorInterceptor(error)).rejects.toThrow();
 
-        expect(mockCsrfStore.updateShrimp).not.toHaveBeenCalled();
-      });
-    });
-
-    describe('error propagation', () => {
-      it('rejects with the original error (no gate keeping)', async () => {
-        const error = createMockAxiosError({
-          url: '/api/test',
-          method: 'get',
-          status: 500,
-          message: 'Internal Server Error',
-        });
-
-        const rejection = errorInterceptor(error);
-
-        await expect(rejection).rejects.toBe(error);
+        expect(mockUpdateShrimp).not.toHaveBeenCalled();
       });
     });
   });
 
-  // ========================================================================
+  // ==========================================================================
   // responseInterceptor - CSRF token update
-  // ========================================================================
+  // ==========================================================================
   describe('responseInterceptor', () => {
     it('updates CSRF token from response headers', () => {
       const response = {
@@ -487,7 +272,7 @@ describe('axios interceptors', () => {
 
       const result = responseInterceptor(response);
 
-      expect(mockCsrfStore.updateShrimp).toHaveBeenCalledWith('new-csrf-token');
+      expect(mockUpdateShrimp).toHaveBeenCalledWith('new-csrf-token');
       expect(result).toBe(response);
     });
 
@@ -502,14 +287,14 @@ describe('axios interceptors', () => {
 
       const result = responseInterceptor(response);
 
-      expect(mockCsrfStore.updateShrimp).not.toHaveBeenCalled();
+      expect(mockUpdateShrimp).not.toHaveBeenCalled();
       expect(result).toBe(response);
     });
   });
 
-  // ========================================================================
+  // ==========================================================================
   // createLoggableShrimp - Token truncation for logging
-  // ========================================================================
+  // ==========================================================================
   describe('createLoggableShrimp', () => {
     it('truncates valid token to first 4 chars with ellipsis', () => {
       expect(createLoggableShrimp('abcdefghijklmnop')).toBe('abcd...');

--- a/src/tests/plugins/core/diagnostics/scrubbers.spec.ts
+++ b/src/tests/plugins/core/diagnostics/scrubbers.spec.ts
@@ -1,0 +1,136 @@
+// src/tests/plugins/core/diagnostics/scrubbers.spec.ts
+//
+// Tests for the scrubbing utilities in the dependency-free scrubbers module.
+//
+// Run:
+//   pnpm test src/tests/plugins/core/diagnostics/scrubbers.spec.ts
+
+import { describe, it, expect } from 'vitest';
+import {
+  scrubSensitiveStrings,
+  scrubUrlWithPatterns,
+  EMAIL_PATTERN,
+  SENSITIVE_PATH_PATTERN,
+  VERIFIABLE_ID_PATTERN,
+} from '@/plugins/core/diagnostics/scrubbers';
+
+describe('scrubbers', () => {
+  describe('scrubSensitiveStrings', () => {
+    it('scrubs email addresses', () => {
+      const text = 'User user@example.com reported an error';
+      expect(scrubSensitiveStrings(text)).toBe(
+        'User [EMAIL REDACTED] reported an error'
+      );
+    });
+
+    it('scrubs multiple email addresses', () => {
+      const text = 'From: alice@example.com To: bob@test.org';
+      expect(scrubSensitiveStrings(text)).toBe(
+        'From: [EMAIL REDACTED] To: [EMAIL REDACTED]'
+      );
+    });
+
+    it('scrubs 62-char verifiable IDs', () => {
+      const id62 = 'abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz';
+      const text = `Secret ID: ${id62}`;
+      expect(scrubSensitiveStrings(text)).toBe('Secret ID: [REDACTED]');
+    });
+
+    it('scrubs sensitive path patterns', () => {
+      const text = 'Error at /secret/abc123 endpoint';
+      expect(scrubSensitiveStrings(text)).toBe(
+        'Error at /secret/[REDACTED] endpoint'
+      );
+    });
+
+    it('handles null/undefined gracefully', () => {
+      expect(scrubSensitiveStrings(null as unknown as string)).toBe(null);
+      expect(scrubSensitiveStrings(undefined as unknown as string)).toBe(undefined);
+    });
+
+    it('handles empty string', () => {
+      expect(scrubSensitiveStrings('')).toBe('');
+    });
+  });
+
+  describe('scrubUrlWithPatterns', () => {
+    it('scrubs sensitive path patterns', () => {
+      expect(scrubUrlWithPatterns('/api/v3/secret/abc123')).toBe(
+        '/api/v3/secret/[REDACTED]'
+      );
+      expect(scrubUrlWithPatterns('/api/v3/private/xyz789')).toBe(
+        '/api/v3/private/[REDACTED]'
+      );
+      expect(scrubUrlWithPatterns('/api/v3/receipt/token123')).toBe(
+        '/api/v3/receipt/[REDACTED]'
+      );
+      expect(scrubUrlWithPatterns('/api/v3/incoming/data456')).toBe(
+        '/api/v3/incoming/[REDACTED]'
+      );
+    });
+
+    it('scrubs 62-char verifiable IDs', () => {
+      const id62 = 'abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz';
+      expect(scrubUrlWithPatterns(`/api/v3/unknown/${id62}`)).toBe(
+        '/api/v3/unknown/[REDACTED]'
+      );
+    });
+
+    it('scrubs email addresses in query params', () => {
+      expect(scrubUrlWithPatterns('/api/users?email=user@example.com')).toBe(
+        '/api/users?email=[EMAIL REDACTED]'
+      );
+    });
+
+    it('scrubs email addresses in path segments', () => {
+      expect(scrubUrlWithPatterns('/api/users/user@example.com/profile')).toBe(
+        '/api/users/[EMAIL REDACTED]/profile'
+      );
+    });
+
+    it('scrubs multiple emails in URL', () => {
+      expect(
+        scrubUrlWithPatterns('/api/share?from=alice@a.com&to=bob@b.com')
+      ).toBe('/api/share?from=[EMAIL REDACTED]&to=[EMAIL REDACTED]');
+    });
+
+    it('leaves non-sensitive URLs unchanged', () => {
+      expect(scrubUrlWithPatterns('/api/v3/colonel/status')).toBe(
+        '/api/v3/colonel/status'
+      );
+      expect(scrubUrlWithPatterns('/api/health')).toBe('/api/health');
+    });
+
+    it('handles null/undefined gracefully', () => {
+      expect(scrubUrlWithPatterns(null as unknown as string)).toBe(null);
+      expect(scrubUrlWithPatterns(undefined as unknown as string)).toBe(undefined);
+    });
+
+    it('handles empty string', () => {
+      expect(scrubUrlWithPatterns('')).toBe('');
+    });
+
+    it('preserves URL structure while scrubbing', () => {
+      const url = 'https://api.example.com/api/v3/secret/abc123?email=test@test.com';
+      const scrubbed = scrubUrlWithPatterns(url);
+      expect(scrubbed).toBe(
+        'https://api.example.com/api/v3/secret/[REDACTED]?email=[EMAIL REDACTED]'
+      );
+    });
+  });
+
+  describe('pattern exports', () => {
+    it('exports EMAIL_PATTERN', () => {
+      expect(EMAIL_PATTERN).toBeInstanceOf(RegExp);
+      expect('test@example.com'.match(EMAIL_PATTERN)).toBeTruthy();
+    });
+
+    it('exports SENSITIVE_PATH_PATTERN', () => {
+      expect(SENSITIVE_PATH_PATTERN).toBeInstanceOf(RegExp);
+    });
+
+    it('exports VERIFIABLE_ID_PATTERN', () => {
+      expect(VERIFIABLE_ID_PATTERN).toBeInstanceOf(RegExp);
+    });
+  });
+});

--- a/src/tests/plugins/core/globalErrorBoundary.spec.ts
+++ b/src/tests/plugins/core/globalErrorBoundary.spec.ts
@@ -1,0 +1,174 @@
+// src/tests/plugins/core/globalErrorBoundary.spec.ts
+//
+// Tests for globalErrorBoundary.ts - specifically the getComponentName() utility
+// that extracts Vue component names for Sentry context.
+//
+// Issue: #2966 - Add component name to Sentry context
+//
+// Run:
+//   pnpm test src/tests/plugins/core/globalErrorBoundary.spec.ts
+
+import { describe, it, expect } from 'vitest';
+import { getComponentName } from '@/plugins/core/globalErrorBoundary';
+
+describe('getComponentName', () => {
+  describe('null/invalid inputs', () => {
+    it('returns unknown for null instance', () => {
+      expect(getComponentName(null)).toBe('unknown');
+    });
+
+    it('returns unknown for undefined instance', () => {
+      expect(getComponentName(undefined)).toBe('unknown');
+    });
+
+    it('returns unknown for non-object (string)', () => {
+      expect(getComponentName('not an object')).toBe('unknown');
+    });
+
+    it('returns unknown for non-object (number)', () => {
+      expect(getComponentName(42)).toBe('unknown');
+    });
+
+    it('returns unknown for non-object (boolean)', () => {
+      expect(getComponentName(true)).toBe('unknown');
+    });
+
+    it('returns unknown for empty object', () => {
+      expect(getComponentName({})).toBe('unknown');
+    });
+  });
+
+  describe('Options API components', () => {
+    it('extracts name from $options.name', () => {
+      const instance = { $options: { name: 'TestComponent' } };
+      expect(getComponentName(instance)).toBe('TestComponent');
+    });
+
+    it('handles $options without name property', () => {
+      const instance = { $options: { props: ['value'] } };
+      expect(getComponentName(instance)).toBe('unknown');
+    });
+
+    it('handles $options.name as empty string', () => {
+      const instance = { $options: { name: '' } };
+      // Empty string is falsy, falls through to next check
+      expect(getComponentName(instance)).toBe('unknown');
+    });
+  });
+
+  describe('Script setup components ($.type.name)', () => {
+    it('extracts name from $.type.name', () => {
+      const instance = {
+        $: { type: { name: 'ScriptSetupComponent' } },
+      };
+      expect(getComponentName(instance)).toBe('ScriptSetupComponent');
+    });
+
+    it('prefers $options.name over $.type.name', () => {
+      const instance = {
+        $options: { name: 'OptionsName' },
+        $: { type: { name: 'TypeName' } },
+      };
+      expect(getComponentName(instance)).toBe('OptionsName');
+    });
+
+    it('handles $.type without name', () => {
+      const instance = {
+        $: { type: { props: {} } },
+      };
+      expect(getComponentName(instance)).toBe('unknown');
+    });
+  });
+
+  describe('Script setup components ($.type.__name)', () => {
+    it('extracts name from $.type.__name (Vue SFC compiled)', () => {
+      const instance = {
+        $: { type: { __name: 'CompiledSFCComponent' } },
+      };
+      expect(getComponentName(instance)).toBe('CompiledSFCComponent');
+    });
+
+    it('prefers $.type.name over $.type.__name', () => {
+      const instance = {
+        $: { type: { name: 'TypeName', __name: 'UnderscoreName' } },
+      };
+      expect(getComponentName(instance)).toBe('TypeName');
+    });
+
+    it('uses __name as final fallback', () => {
+      const instance = {
+        $options: {},
+        $: { type: { __name: 'FallbackName' } },
+      };
+      expect(getComponentName(instance)).toBe('FallbackName');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('handles instance with $ but no type', () => {
+      const instance = { $: {} };
+      expect(getComponentName(instance)).toBe('unknown');
+    });
+
+    it('handles instance with $ as null', () => {
+      const instance = { $: null };
+      expect(getComponentName(instance)).toBe('unknown');
+    });
+
+    it('handles instance with $options as null', () => {
+      const instance = { $options: null };
+      expect(getComponentName(instance)).toBe('unknown');
+    });
+
+    it('handles array instance (non-component)', () => {
+      expect(getComponentName(['not', 'a', 'component'])).toBe('unknown');
+    });
+
+    it('handles function instance (non-component)', () => {
+      expect(getComponentName(() => {})).toBe('unknown');
+    });
+  });
+
+  describe('realistic Vue component structures', () => {
+    it('extracts name from full Options API component instance', () => {
+      const instance = {
+        $options: {
+          name: 'SecretForm',
+          props: { value: String },
+          components: {},
+        },
+        $props: { value: 'test' },
+        $emit: () => {},
+      };
+      expect(getComponentName(instance)).toBe('SecretForm');
+    });
+
+    it('extracts name from full script setup component instance', () => {
+      const instance = {
+        $options: {},
+        $: {
+          type: {
+            __name: 'CreateSecret',
+            setup: () => {},
+            props: {},
+          },
+          props: {},
+          emit: () => {},
+        },
+      };
+      expect(getComponentName(instance)).toBe('CreateSecret');
+    });
+
+    it('extracts name from component with both API styles', () => {
+      // Some components may have both due to mixins or extending
+      const instance = {
+        $options: { name: 'MixedComponent' },
+        $: {
+          type: { __name: 'InternalName' },
+        },
+      };
+      // $options.name takes precedence
+      expect(getComponentName(instance)).toBe('MixedComponent');
+    });
+  });
+});

--- a/src/tests/plugins/core/globalErrorBoundary.spec.ts
+++ b/src/tests/plugins/core/globalErrorBoundary.spec.ts
@@ -9,6 +9,8 @@
 //   pnpm test src/tests/plugins/core/globalErrorBoundary.spec.ts
 
 import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { defineComponent, h } from 'vue';
 import { getComponentName } from '@/plugins/core/globalErrorBoundary';
 
 describe('getComponentName', () => {
@@ -169,6 +171,92 @@ describe('getComponentName', () => {
       };
       // $options.name takes precedence
       expect(getComponentName(instance)).toBe('MixedComponent');
+    });
+  });
+
+  describe('runtime validation with real Vue components', () => {
+    // These tests mount actual Vue components to validate our assumptions
+    // about Vue's internal instance structure are correct.
+
+    it('extracts name from mounted Options API component', () => {
+      const OptionsComponent = defineComponent({
+        name: 'OptionsApiTestComponent',
+        render() {
+          return h('div', 'test');
+        },
+      });
+
+      const wrapper = mount(OptionsComponent);
+      // vm is the component instance passed to errorHandler
+      const instance = wrapper.vm;
+
+      expect(getComponentName(instance)).toBe('OptionsApiTestComponent');
+      wrapper.unmount();
+    });
+
+    it('extracts name from mounted script setup style component', () => {
+      // Script setup components use $.type.__name internally
+      // We simulate this by defining a component without explicit name
+      // but Vue's internal structure should still be accessible
+      const ScriptSetupLike = defineComponent({
+        name: 'ScriptSetupTestComponent',
+        setup() {
+          return () => h('div', 'script setup');
+        },
+      });
+
+      const wrapper = mount(ScriptSetupLike);
+      const instance = wrapper.vm;
+
+      // Even script-setup-like components with defineComponent have $options.name
+      expect(getComponentName(instance)).toBe('ScriptSetupTestComponent');
+      wrapper.unmount();
+    });
+
+    it('extracts name from anonymous component via $.type.__name', () => {
+      // Anonymous components (no name in defineComponent) rely on $.type.__name
+      // which is set by the SFC compiler. We can test the fallback path.
+      const AnonymousComponent = defineComponent({
+        // No name property - simulates component without explicit name
+        render() {
+          return h('span', 'anonymous');
+        },
+      });
+
+      const wrapper = mount(AnonymousComponent);
+      const instance = wrapper.vm;
+
+      // Without a name, falls through to $.type.name or __name
+      // In test environment without SFC compilation, may return 'unknown'
+      const name = getComponentName(instance);
+
+      // Verify the function doesn't crash and returns a valid result
+      expect(typeof name).toBe('string');
+      wrapper.unmount();
+    });
+
+    it('validates Vue instance has expected structure', () => {
+      // This test documents the actual structure we rely on
+      const TestComponent = defineComponent({
+        name: 'StructureValidation',
+        render() {
+          return h('div');
+        },
+      });
+
+      const wrapper = mount(TestComponent);
+      const instance = wrapper.vm;
+
+      // Verify $options exists and has name (Options API path)
+      expect(instance.$options).toBeDefined();
+      expect(instance.$options.name).toBe('StructureValidation');
+
+      // Document existence of internal $ property (Script setup path)
+      // Note: $ may not be directly accessible on the public proxy in all scenarios
+      // but our type guards handle this safely
+      expect(typeof instance).toBe('object');
+
+      wrapper.unmount();
     });
   });
 });

--- a/src/tests/services/diagnostics.service.spec.ts
+++ b/src/tests/services/diagnostics.service.spec.ts
@@ -287,10 +287,37 @@ describe('diagnostics.service', () => {
   // Tag extraction (Issue #2964: Sentry setTag vs setExtras separation)
   // ========================================================================
   describe('tag extraction', () => {
-    // Tag fields: errorType, schema, service, jurisdiction, planid, role
+    // Tag fields: componentName, errorType, errorSeverity, schema, service,
+    //             jurisdiction, planid, role
     // These should be extracted and set via setTag() with lowercase values
 
     describe('captureException', () => {
+      it('extracts componentName as tag with lowercase value', async () => {
+        const { initDiagnostics, captureException } = await importFresh();
+        const client = createMockClient();
+        const baseScope = createMockScope();
+
+        initDiagnostics(client as never, baseScope as never);
+
+        captureException(new Error('test'), { componentName: 'SecretForm' });
+
+        const clonedScope = baseScope.clone.mock.results[0].value;
+        expect(clonedScope.setTag).toHaveBeenCalledWith('componentName', 'secretform');
+      });
+
+      it('extracts errorSeverity as tag with lowercase value', async () => {
+        const { initDiagnostics, captureException } = await importFresh();
+        const client = createMockClient();
+        const baseScope = createMockScope();
+
+        initDiagnostics(client as never, baseScope as never);
+
+        captureException(new Error('test'), { errorSeverity: 'ERROR' });
+
+        const clonedScope = baseScope.clone.mock.results[0].value;
+        expect(clonedScope.setTag).toHaveBeenCalledWith('errorSeverity', 'error');
+      });
+
       it('extracts errorType as tag with lowercase value', async () => {
         const { initDiagnostics, captureException } = await importFresh();
         const client = createMockClient();
@@ -369,7 +396,7 @@ describe('diagnostics.service', () => {
         expect(clonedScope.setTag).toHaveBeenCalledWith('role', 'customer');
       });
 
-      it('extracts all 6 tag fields when present', async () => {
+      it('extracts all 8 tag fields when present', async () => {
         const { initDiagnostics, captureException } = await importFresh();
         const client = createMockClient();
         const baseScope = createMockScope();
@@ -377,7 +404,9 @@ describe('diagnostics.service', () => {
         initDiagnostics(client as never, baseScope as never);
 
         captureException(new Error('test'), {
+          componentName: 'SecretForm',
           errorType: 'HUMAN',
+          errorSeverity: 'ERROR',
           schema: 'UserResponse',
           service: 'API',
           jurisdiction: 'US',
@@ -386,13 +415,15 @@ describe('diagnostics.service', () => {
         });
 
         const clonedScope = baseScope.clone.mock.results[0].value;
+        expect(clonedScope.setTag).toHaveBeenCalledWith('componentName', 'secretform');
         expect(clonedScope.setTag).toHaveBeenCalledWith('errorType', 'human');
+        expect(clonedScope.setTag).toHaveBeenCalledWith('errorSeverity', 'error');
         expect(clonedScope.setTag).toHaveBeenCalledWith('schema', 'userresponse');
         expect(clonedScope.setTag).toHaveBeenCalledWith('service', 'api');
         expect(clonedScope.setTag).toHaveBeenCalledWith('jurisdiction', 'us');
         expect(clonedScope.setTag).toHaveBeenCalledWith('planid', 'pro');
         expect(clonedScope.setTag).toHaveBeenCalledWith('role', 'colonel');
-        expect(clonedScope.setTag).toHaveBeenCalledTimes(6);
+        expect(clonedScope.setTag).toHaveBeenCalledTimes(8);
       });
 
       it('separates tag fields from non-tag fields correctly', async () => {
@@ -524,7 +555,9 @@ describe('diagnostics.service', () => {
         initDiagnostics(client as never, baseScope as never);
 
         captureException(new Error('test'), {
+          componentName: 'SecretForm',
           errorType: 'technical',
+          errorSeverity: 'warning',
           schema: 'SecretResponse',
           service: 'web',
           jurisdiction: 'eu',
@@ -534,7 +567,7 @@ describe('diagnostics.service', () => {
 
         const clonedScope = baseScope.clone.mock.results[0].value;
 
-        expect(clonedScope.setTag).toHaveBeenCalledTimes(6);
+        expect(clonedScope.setTag).toHaveBeenCalledTimes(8);
         expect(clonedScope.setExtras).not.toHaveBeenCalled();
       });
 
@@ -564,7 +597,9 @@ describe('diagnostics.service', () => {
         initDiagnostics(client as never, baseScope as never);
 
         captureMessage('test message', {
+          componentName: 'SecretForm',
           errorType: 'HUMAN',
+          errorSeverity: 'ERROR',
           schema: 'UserResponse',
           service: 'API',
           jurisdiction: 'US',
@@ -575,14 +610,16 @@ describe('diagnostics.service', () => {
 
         const clonedScope = baseScope.clone.mock.results[0].value;
 
-        // All 6 tag fields should be extracted
+        // All 8 tag fields should be extracted
+        expect(clonedScope.setTag).toHaveBeenCalledWith('componentName', 'secretform');
         expect(clonedScope.setTag).toHaveBeenCalledWith('errorType', 'human');
+        expect(clonedScope.setTag).toHaveBeenCalledWith('errorSeverity', 'error');
         expect(clonedScope.setTag).toHaveBeenCalledWith('schema', 'userresponse');
         expect(clonedScope.setTag).toHaveBeenCalledWith('service', 'api');
         expect(clonedScope.setTag).toHaveBeenCalledWith('jurisdiction', 'us');
         expect(clonedScope.setTag).toHaveBeenCalledWith('planid', 'pro');
         expect(clonedScope.setTag).toHaveBeenCalledWith('role', 'colonel');
-        expect(clonedScope.setTag).toHaveBeenCalledTimes(6);
+        expect(clonedScope.setTag).toHaveBeenCalledTimes(8);
 
         // Non-tag field should go to extras
         expect(clonedScope.setExtras).toHaveBeenCalledWith({ customField: 'value' });

--- a/src/types/ui/index.ts
+++ b/src/types/ui/index.ts
@@ -11,3 +11,4 @@ export * from './forms';
 export * from './layouts';
 export * from './local-receipt';
 export * from './notifications';
+export * from './vue-internals';

--- a/src/types/ui/vue-internals.ts
+++ b/src/types/ui/vue-internals.ts
@@ -1,0 +1,25 @@
+// src/types/ui/vue-internals.ts
+
+/**
+ * Minimal type for Vue component instance properties we access.
+ * These are Vue internals, not public API - structure may vary by version.
+ *
+ * Used by getComponentName() in globalErrorBoundary.ts to extract
+ * component names for Sentry context without using `any`.
+ *
+ * @see https://github.com/vuejs/core/blob/main/packages/runtime-core/src/component.ts
+ */
+export interface VueComponentLike {
+  /** Options API: component name from defineComponent({ name: '...' }) */
+  $options?: { name?: string };
+  /** Vue 3 internal instance, exposed on public proxy */
+  $?: {
+    /** Component type definition */
+    type?: {
+      /** Explicit name property */
+      name?: string;
+      /** SFC compiled name (set by vue-loader/vite-plugin-vue) */
+      __name?: string;
+    };
+  };
+}


### PR DESCRIPTION
## Summary

Quick wins from gap analysis to improve Sentry debugging context:

- **#2966**: Add Vue component name to error context - Extract `$options.name` or `__name` from component instance for searchability in Sentry
- **#2965**: Add Axios error breadcrumbs - Log HTTP method, scrubbed URL, status code, and sanitized error message before rejecting failed API requests

Note: #2970 (jurisdiction tag) was already merged via #2987.

## Test plan

- [ ] Type check passes (`pnpm type-check`)
- [ ] Trigger a Vue component error and verify `componentName` appears in Sentry context
- [ ] Trigger an API error and verify breadcrumb appears with scrubbed URL
- [ ] Verify sensitive data (secret keys, emails) are redacted from breadcrumb URLs

Closes #2965, closes #2966