### PR TITLE
Associate git commits with Sentry releases

### DIFF
--- a/.github/workflows/build-and-publish-oci-images.yml
+++ b/.github/workflows/build-and-publish-oci-images.yml
@@ -248,7 +248,31 @@ jobs:
             *.args.VERSION=${{ steps.version.outputs.version }}
             *.args.COMMIT_HASH=${{ steps.commit.outputs.short_sha }}
 
-      - name: Create Sentry release with source maps (frontend)
+      - name: Create Sentry release and associate commits
+        if: github.event_name != 'pull_request'
+        continue-on-error: true
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_URL: ${{ secrets.SENTRY_URL }}
+          SENTRY_PROJECTS: ${{ secrets.SENTRY_PROJECTS }}
+          SENTRY_RELEASE: ${{ steps.commit.outputs.short_sha }}
+        run: |
+          if [ -z "$SENTRY_AUTH_TOKEN" ] || [ -z "$SENTRY_PROJECTS" ]; then
+            echo "SENTRY_AUTH_TOKEN or SENTRY_PROJECTS not set, skipping Sentry release"
+            exit 0
+          fi
+          # Build --project flags from space-separated list
+          PROJECT_FLAGS=""
+          for proj in $SENTRY_PROJECTS; do
+            PROJECT_FLAGS="$PROJECT_FLAGS --project $proj"
+          done
+          echo "Creating release $SENTRY_RELEASE for projects: $SENTRY_PROJECTS"
+          npx @sentry/cli releases new "$SENTRY_RELEASE" $PROJECT_FLAGS
+          npx @sentry/cli releases set-commits "$SENTRY_RELEASE" --auto $PROJECT_FLAGS
+          npx @sentry/cli releases finalize "$SENTRY_RELEASE" $PROJECT_FLAGS
+
+      - name: Upload frontend sourcemaps to Sentry
         if: github.event_name != 'pull_request'
         continue-on-error: true
         env:
@@ -258,34 +282,14 @@ jobs:
           SENTRY_RELEASE: ${{ steps.commit.outputs.short_sha }}
         run: |
           if [ -z "$SENTRY_AUTH_TOKEN" ]; then
-            echo "SENTRY_AUTH_TOKEN not set, skipping Sentry release"
+            echo "SENTRY_AUTH_TOKEN not set, skipping sourcemaps upload"
             exit 0
           fi
-          npx @sentry/cli releases new "$SENTRY_RELEASE"
-          npx @sentry/cli releases set-commits "$SENTRY_RELEASE" --auto
           npx @sentry/cli sourcemaps upload ./public/web/dist \
             --release="$SENTRY_RELEASE" \
+            --project=frontend \
             --dist=frontend \
             --url-prefix='~/dist'
-          npx @sentry/cli releases finalize "$SENTRY_RELEASE"
-
-      - name: Associate commits with Sentry release (backend)
-        if: github.event_name != 'pull_request'
-        continue-on-error: true
-        env:
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
-          SENTRY_URL: ${{ secrets.SENTRY_URL }}
-          SENTRY_PROJECT: ${{ secrets.SENTRY_BACKEND_PROJECT }}
-          SENTRY_RELEASE: ${{ steps.commit.outputs.short_sha }}
-        run: |
-          if [ -z "$SENTRY_AUTH_TOKEN" ] || [ -z "$SENTRY_PROJECT" ]; then
-            echo "SENTRY_AUTH_TOKEN or SENTRY_BACKEND_PROJECT not set, skipping"
-            exit 0
-          fi
-          npx @sentry/cli releases new "$SENTRY_RELEASE" --project "$SENTRY_PROJECT"
-          npx @sentry/cli releases set-commits "$SENTRY_RELEASE" --auto --project "$SENTRY_PROJECT"
-          npx @sentry/cli releases finalize "$SENTRY_RELEASE" --project "$SENTRY_PROJECT"
 
       - name: Create Sentry deploy notification
         if: github.event_name != 'pull_request' && startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/build-and-publish-oci-images.yml
+++ b/.github/workflows/build-and-publish-oci-images.yml
@@ -24,6 +24,16 @@ name: Build and Publish OCI Images
 #   ACTIONS_RUNNER_DEBUG=true  Enable runner diagnostic logging
 #   Set in Settings → Secrets and variables → Actions → Variables
 #
+# Sentry Integration (Repository Secrets):
+#   SENTRY_AUTH_TOKEN  API token with project:releases and org:read scopes
+#   SENTRY_ORG         Organization slug (e.g., "onetimesecret")
+#   SENTRY_URL         Sentry instance URL (omit for sentry.io)
+#   SENTRY_PROJECTS    Space-separated project slugs (e.g., "frontend backend workers")
+#
+#   These enable: release creation, commit association, sourcemap upload,
+#   and deploy notifications. All Sentry steps use continue-on-error so
+#   missing secrets won't fail the build.
+#
 
 on:
   push:

--- a/.github/workflows/build-and-publish-oci-images.yml
+++ b/.github/workflows/build-and-publish-oci-images.yml
@@ -90,6 +90,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.source_branch || github.ref }}
+          fetch-depth: 0
 
       - name: Generate commit hash
         id: commit
@@ -267,6 +268,39 @@ jobs:
             --dist=frontend \
             --url-prefix='~/dist'
           npx @sentry/cli releases finalize "$SENTRY_RELEASE"
+
+      - name: Associate commits with Sentry release (backend)
+        if: github.event_name != 'pull_request'
+        continue-on-error: true
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_URL: ${{ secrets.SENTRY_URL }}
+          SENTRY_PROJECT: ${{ secrets.SENTRY_BACKEND_PROJECT }}
+          SENTRY_RELEASE: ${{ steps.commit.outputs.short_sha }}
+        run: |
+          if [ -z "$SENTRY_AUTH_TOKEN" ] || [ -z "$SENTRY_PROJECT" ]; then
+            echo "SENTRY_AUTH_TOKEN or SENTRY_BACKEND_PROJECT not set, skipping"
+            exit 0
+          fi
+          npx @sentry/cli releases new "$SENTRY_RELEASE" --project "$SENTRY_PROJECT"
+          npx @sentry/cli releases set-commits "$SENTRY_RELEASE" --auto --project "$SENTRY_PROJECT"
+          npx @sentry/cli releases finalize "$SENTRY_RELEASE" --project "$SENTRY_PROJECT"
+
+      - name: Create Sentry deploy notification
+        if: github.event_name != 'pull_request' && startsWith(github.ref, 'refs/tags/v')
+        continue-on-error: true
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_URL: ${{ secrets.SENTRY_URL }}
+          SENTRY_RELEASE: ${{ steps.commit.outputs.short_sha }}
+        run: |
+          if [ -z "$SENTRY_AUTH_TOKEN" ]; then
+            echo "SENTRY_AUTH_TOKEN not set, skipping deploy notification"
+            exit 0
+          fi
+          npx @sentry/cli releases deploys "$SENTRY_RELEASE" new -e production
 
       - name: Audit — verify image version
         if: success()

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -181,7 +181,7 @@ repos:
         stages: [post-commit, post-checkout, post-merge]
         name: Record commit hash
         description: Log current commit hash for build reference
-        entry: "sh -c 'git rev-parse --short HEAD > .commit_hash.txt; echo Commit hash recorded; head -4 .commit_hash.txt package.json'"
+        entry: "sh -c 'git rev-parse --short=7 HEAD > .commit_hash.txt; echo Commit hash recorded; head -4 .commit_hash.txt package.json'"
         language: system
         always_run: true
         pass_filenames: false

--- a/docs/architecture/build-architecture.md
+++ b/docs/architecture/build-architecture.md
@@ -258,7 +258,7 @@ podman build -f Dockerfile \
   --build-context base=container-image://ots-base:local \
   --build-arg VERSION=dev \
   --build-arg ALLOW_DEV_VERSION=true \
-  --build-arg COMMIT_HASH=$(git rev-parse --short HEAD) \
+  --build-arg COMMIT_HASH=$(git rev-parse --short=7 HEAD) \
   --tag onetimesecret:local .
 podman rmi ots-base:local                                 # cleanup base
 

--- a/lib/onetime/initializers/setup_diagnostics.rb
+++ b/lib/onetime/initializers/setup_diagnostics.rb
@@ -151,8 +151,7 @@ module Onetime
 
         # Resolves the Sentry release identifier with fallback chain:
         # 1. SENTRY_RELEASE env var (explicit override, e.g., production deploy)
-        # 2. .commit_hash.txt file (baked into Docker image by CI)
-        # 3. OT::VERSION.details (local development fallback)
+        # 2. OT::VERSION.get_build_info (reads .commit_hash.txt or git, returns 'dev' fallback)
         #
         # @return [String] The release identifier for Sentry
         def resolve_sentry_release
@@ -160,16 +159,8 @@ module Onetime
           env_release = ENV.fetch('SENTRY_RELEASE', '').strip
           return env_release unless env_release.empty?
 
-          # Check for .commit_hash.txt (CI bakes this into Docker image)
-          commit_hash_file = File.join(Onetime::HOME, '.commit_hash.txt')
-          if File.exist?(commit_hash_file)
-            file_content = File.read(commit_hash_file).strip
-            # Use file content if it's a real commit hash (not a fallback value)
-            return file_content unless file_content.empty? || %w[dev pristine].include?(file_content)
-          end
-
-          # Fall back to version details for local development
-          OT::VERSION.details
+          # Delegate to VERSION which handles .commit_hash.txt and git fallback
+          OT::VERSION.get_build_info
         end
 
         class << self

--- a/lib/onetime/initializers/setup_diagnostics.rb
+++ b/lib/onetime/initializers/setup_diagnostics.rb
@@ -67,7 +67,13 @@ module Onetime
         Sentry.init do |config|
           config.dsn         = dsn
           config.environment = OT.env
-          config.release     = OT::VERSION.details
+
+          # Determine Sentry release identifier. Priority:
+          # 1. SENTRY_RELEASE env var (explicit override)
+          # 2. .commit_hash.txt file (baked into Docker image by CI)
+          # 3. OT::VERSION.details fallback (local development)
+          # This ensures frontend and backend report the same release identifier.
+          config.release = resolve_sentry_release
 
           # Add contextual tags for filtering without fragmenting environments.
           # site_host identifies the deployment; jurisdiction is optional.
@@ -141,6 +147,29 @@ module Onetime
           else
             backend_dsn
           end
+        end
+
+        # Resolves the Sentry release identifier with fallback chain:
+        # 1. SENTRY_RELEASE env var (explicit override, e.g., production deploy)
+        # 2. .commit_hash.txt file (baked into Docker image by CI)
+        # 3. OT::VERSION.details (local development fallback)
+        #
+        # @return [String] The release identifier for Sentry
+        def resolve_sentry_release
+          # Check env var first (allows explicit override)
+          env_release = ENV.fetch('SENTRY_RELEASE', '').strip
+          return env_release unless env_release.empty?
+
+          # Check for .commit_hash.txt (CI bakes this into Docker image)
+          commit_hash_file = File.join(Onetime::HOME, '.commit_hash.txt')
+          if File.exist?(commit_hash_file)
+            file_content = File.read(commit_hash_file).strip
+            # Use file content if it's a real commit hash (not a fallback value)
+            return file_content unless file_content.empty? || %w[dev pristine].include?(file_content)
+          end
+
+          # Fall back to version details for local development
+          OT::VERSION.details
         end
 
         class << self

--- a/lib/onetime/version.rb
+++ b/lib/onetime/version.rb
@@ -62,7 +62,7 @@ module Onetime
 
       # If no valid hash from file, try git directly (works in local development)
       if commit_hash.nil? || commit_hash.empty?
-        commit_hash = `git rev-parse --short HEAD 2>/dev/null`.strip
+        commit_hash = `git rev-parse --short=7 HEAD 2>/dev/null`.strip
         commit_hash = nil if commit_hash.empty? || !$?.success?
       end
 

--- a/spec/unit/onetime/initializers/setup_diagnostics_spec.rb
+++ b/spec/unit/onetime/initializers/setup_diagnostics_spec.rb
@@ -410,12 +410,9 @@ RSpec.describe Onetime::Initializers::SetupDiagnostics do
       expect(mock_config.release).to eq('abc1234')
     end
 
-    it "uses OT::VERSION.details when SENTRY_RELEASE is not set and no .commit_hash.txt" do
+    it "uses OT::VERSION.get_build_info when SENTRY_RELEASE is not set" do
       ENV.delete('SENTRY_RELEASE')
-      # Stub File.exist? to return false for commit_hash.txt to test VERSION.details fallback
-      commit_hash_path = File.join(Onetime::HOME, '.commit_hash.txt')
-      allow(File).to receive(:exist?).and_call_original
-      allow(File).to receive(:exist?).with(commit_hash_path).and_return(false)
+      allow(OT::VERSION).to receive(:get_build_info).and_return('abc1234')
       setup_diagnostics_config
 
       expect(Kernel).to receive(:require).with('sentry-ruby').ordered
@@ -424,15 +421,12 @@ RSpec.describe Onetime::Initializers::SetupDiagnostics do
 
       execute_diagnostics_initializer
 
-      expect(mock_config.release).to eq(OT::VERSION.details)
+      expect(mock_config.release).to eq('abc1234')
     end
 
-    it "uses OT::VERSION.details when SENTRY_RELEASE is empty string and no .commit_hash.txt" do
+    it "uses OT::VERSION.get_build_info when SENTRY_RELEASE is empty string" do
       ENV['SENTRY_RELEASE'] = ''
-      # Stub File.exist? to return false for commit_hash.txt to test VERSION.details fallback
-      commit_hash_path = File.join(Onetime::HOME, '.commit_hash.txt')
-      allow(File).to receive(:exist?).and_call_original
-      allow(File).to receive(:exist?).with(commit_hash_path).and_return(false)
+      allow(OT::VERSION).to receive(:get_build_info).and_return('def5678')
       setup_diagnostics_config
 
       expect(Kernel).to receive(:require).with('sentry-ruby').ordered
@@ -441,15 +435,12 @@ RSpec.describe Onetime::Initializers::SetupDiagnostics do
 
       execute_diagnostics_initializer
 
-      expect(mock_config.release).to eq(OT::VERSION.details)
+      expect(mock_config.release).to eq('def5678')
     end
 
-    it "uses OT::VERSION.details when SENTRY_RELEASE is whitespace only and no .commit_hash.txt" do
+    it "uses OT::VERSION.get_build_info when SENTRY_RELEASE is whitespace only" do
       ENV['SENTRY_RELEASE'] = '   '
-      # Stub File.exist? to return false for commit_hash.txt to test VERSION.details fallback
-      commit_hash_path = File.join(Onetime::HOME, '.commit_hash.txt')
-      allow(File).to receive(:exist?).and_call_original
-      allow(File).to receive(:exist?).with(commit_hash_path).and_return(false)
+      allow(OT::VERSION).to receive(:get_build_info).and_return('ghi9012')
       setup_diagnostics_config
 
       expect(Kernel).to receive(:require).with('sentry-ruby').ordered
@@ -458,7 +449,7 @@ RSpec.describe Onetime::Initializers::SetupDiagnostics do
 
       execute_diagnostics_initializer
 
-      expect(mock_config.release).to eq(OT::VERSION.details)
+      expect(mock_config.release).to eq('ghi9012')
     end
 
     it "trims whitespace from SENTRY_RELEASE value" do
@@ -500,31 +491,13 @@ RSpec.describe Onetime::Initializers::SetupDiagnostics do
       expect(mock_config.release).to eq('a1b2c3d')
     end
 
-    context "with .commit_hash.txt file fallback" do
-      let(:commit_hash_path) { File.join(Onetime::HOME, '.commit_hash.txt') }
-
+    context "with OT::VERSION.get_build_info fallback" do
       before do
         ENV.delete('SENTRY_RELEASE')
-        @original_file_exists = File.exist?(commit_hash_path)
-        @original_content = File.read(commit_hash_path) if @original_file_exists
       end
 
-      after do
-        if @original_file_exists
-          File.write(commit_hash_path, @original_content)
-        elsif File.exist?(commit_hash_path)
-          # Only delete if we created it during the test
-          # File.delete(commit_hash_path)
-        end
-      end
-
-      it "uses .commit_hash.txt when SENTRY_RELEASE env var is not set" do
-        # Skip if file doesn't exist (we don't want to create files in tests)
-        skip "No .commit_hash.txt file present" unless File.exist?(commit_hash_path)
-
-        file_content = File.read(commit_hash_path).strip
-        skip "File contains dev/pristine fallback" if %w[dev pristine].include?(file_content) || file_content.empty?
-
+      it "uses OT::VERSION.get_build_info when SENTRY_RELEASE env var is not set" do
+        allow(OT::VERSION).to receive(:get_build_info).and_return('abc1234')
         setup_diagnostics_config
 
         expect(Kernel).to receive(:require).with('sentry-ruby').ordered
@@ -533,11 +506,26 @@ RSpec.describe Onetime::Initializers::SetupDiagnostics do
 
         execute_diagnostics_initializer
 
-        expect(mock_config.release).to eq(file_content)
+        expect(mock_config.release).to eq('abc1234')
       end
 
-      it "SENTRY_RELEASE env var takes precedence over .commit_hash.txt" do
+      it "falls back to 'dev' when no commit hash is available" do
+        allow(OT::VERSION).to receive(:get_build_info).and_return('dev')
+        setup_diagnostics_config
+
+        expect(Kernel).to receive(:require).with('sentry-ruby').ordered
+        expect(Kernel).to receive(:require).with('stackprof').ordered
+        expect(Sentry).to receive(:init).and_yield(mock_config)
+
+        execute_diagnostics_initializer
+
+        expect(mock_config.release).to eq('dev')
+      end
+
+      it "SENTRY_RELEASE env var takes precedence over get_build_info" do
         ENV['SENTRY_RELEASE'] = 'env-override'
+        # Should not be called when env var is set
+        expect(OT::VERSION).not_to receive(:get_build_info)
         setup_diagnostics_config
 
         expect(Kernel).to receive(:require).with('sentry-ruby').ordered

--- a/spec/unit/onetime/initializers/setup_diagnostics_spec.rb
+++ b/spec/unit/onetime/initializers/setup_diagnostics_spec.rb
@@ -193,7 +193,10 @@ RSpec.describe Onetime::Initializers::SetupDiagnostics do
       # Verify the config using our mock config object
       expect(mock_config.dsn).to eq("https://example-dsn@sentry.io/12345")
       expect(mock_config.environment).to eq(OT.env)
-      expect(mock_config.release).to eq(OT::VERSION.details)
+      # Release follows priority: ENV['SENTRY_RELEASE'] > .commit_hash.txt > OT::VERSION.details
+      # In test environment, .commit_hash.txt typically exists with the commit hash
+      expect(mock_config.release).to be_a(String)
+      expect(mock_config.release).not_to be_empty
       expect(mock_config.breadcrumbs_logger).to eq([:sentry_logger])
       expect(mock_config.traces_sample_rate).to eq(0.1)
       expect(mock_config.profiles_sample_rate).to eq(0.1)
@@ -363,6 +366,191 @@ RSpec.describe Onetime::Initializers::SetupDiagnostics do
   # via execute() is more reliable and still validates the core functionality.
   # The boot! process is tested in boot_part2_spec.rb with proper setup.
 
+  # Tests for SENTRY_RELEASE environment variable override (GitHub #2971)
+  # When SENTRY_RELEASE is set (e.g., by CI), it should be used instead of
+  # OT::VERSION.details to ensure frontend and backend report the same release.
+  describe "SENTRY_RELEASE environment variable override" do
+    before do
+      # Store original env value to restore later
+      @original_sentry_release = ENV.fetch('SENTRY_RELEASE', nil)
+    end
+
+    after do
+      # Restore original env value
+      if @original_sentry_release.nil?
+        ENV.delete('SENTRY_RELEASE')
+      else
+        ENV['SENTRY_RELEASE'] = @original_sentry_release
+      end
+    end
+
+    def setup_diagnostics_config
+      config = loaded_config.dup
+      config['diagnostics'] = {
+        'enabled' => true,
+        'sentry' => {
+          'backend' => { 'dsn' => "https://example-dsn@sentry.io/12345" },
+          'frontend' => { 'dsn' => nil }
+        }
+      }
+      config['site'] = { 'host' => "test.example.com" }
+      Onetime.instance_variable_set(:@conf, config)
+    end
+
+    it "uses SENTRY_RELEASE env var when set" do
+      ENV['SENTRY_RELEASE'] = 'abc1234'
+      setup_diagnostics_config
+
+      expect(Kernel).to receive(:require).with('sentry-ruby').ordered
+      expect(Kernel).to receive(:require).with('stackprof').ordered
+      expect(Sentry).to receive(:init).and_yield(mock_config)
+
+      execute_diagnostics_initializer
+
+      expect(mock_config.release).to eq('abc1234')
+    end
+
+    it "uses OT::VERSION.details when SENTRY_RELEASE is not set and no .commit_hash.txt" do
+      ENV.delete('SENTRY_RELEASE')
+      # Stub File.exist? to return false for commit_hash.txt to test VERSION.details fallback
+      commit_hash_path = File.join(Onetime::HOME, '.commit_hash.txt')
+      allow(File).to receive(:exist?).and_call_original
+      allow(File).to receive(:exist?).with(commit_hash_path).and_return(false)
+      setup_diagnostics_config
+
+      expect(Kernel).to receive(:require).with('sentry-ruby').ordered
+      expect(Kernel).to receive(:require).with('stackprof').ordered
+      expect(Sentry).to receive(:init).and_yield(mock_config)
+
+      execute_diagnostics_initializer
+
+      expect(mock_config.release).to eq(OT::VERSION.details)
+    end
+
+    it "uses OT::VERSION.details when SENTRY_RELEASE is empty string and no .commit_hash.txt" do
+      ENV['SENTRY_RELEASE'] = ''
+      # Stub File.exist? to return false for commit_hash.txt to test VERSION.details fallback
+      commit_hash_path = File.join(Onetime::HOME, '.commit_hash.txt')
+      allow(File).to receive(:exist?).and_call_original
+      allow(File).to receive(:exist?).with(commit_hash_path).and_return(false)
+      setup_diagnostics_config
+
+      expect(Kernel).to receive(:require).with('sentry-ruby').ordered
+      expect(Kernel).to receive(:require).with('stackprof').ordered
+      expect(Sentry).to receive(:init).and_yield(mock_config)
+
+      execute_diagnostics_initializer
+
+      expect(mock_config.release).to eq(OT::VERSION.details)
+    end
+
+    it "uses OT::VERSION.details when SENTRY_RELEASE is whitespace only and no .commit_hash.txt" do
+      ENV['SENTRY_RELEASE'] = '   '
+      # Stub File.exist? to return false for commit_hash.txt to test VERSION.details fallback
+      commit_hash_path = File.join(Onetime::HOME, '.commit_hash.txt')
+      allow(File).to receive(:exist?).and_call_original
+      allow(File).to receive(:exist?).with(commit_hash_path).and_return(false)
+      setup_diagnostics_config
+
+      expect(Kernel).to receive(:require).with('sentry-ruby').ordered
+      expect(Kernel).to receive(:require).with('stackprof').ordered
+      expect(Sentry).to receive(:init).and_yield(mock_config)
+
+      execute_diagnostics_initializer
+
+      expect(mock_config.release).to eq(OT::VERSION.details)
+    end
+
+    it "trims whitespace from SENTRY_RELEASE value" do
+      ENV['SENTRY_RELEASE'] = '  def5678  '
+      setup_diagnostics_config
+
+      expect(Kernel).to receive(:require).with('sentry-ruby').ordered
+      expect(Kernel).to receive(:require).with('stackprof').ordered
+      expect(Sentry).to receive(:init).and_yield(mock_config)
+
+      execute_diagnostics_initializer
+
+      expect(mock_config.release).to eq('def5678')
+    end
+
+    it "accepts version-style SENTRY_RELEASE values" do
+      ENV['SENTRY_RELEASE'] = 'v0.24.2'
+      setup_diagnostics_config
+
+      expect(Kernel).to receive(:require).with('sentry-ruby').ordered
+      expect(Kernel).to receive(:require).with('stackprof').ordered
+      expect(Sentry).to receive(:init).and_yield(mock_config)
+
+      execute_diagnostics_initializer
+
+      expect(mock_config.release).to eq('v0.24.2')
+    end
+
+    it "accepts commit hash style SENTRY_RELEASE values" do
+      ENV['SENTRY_RELEASE'] = 'a1b2c3d'
+      setup_diagnostics_config
+
+      expect(Kernel).to receive(:require).with('sentry-ruby').ordered
+      expect(Kernel).to receive(:require).with('stackprof').ordered
+      expect(Sentry).to receive(:init).and_yield(mock_config)
+
+      execute_diagnostics_initializer
+
+      expect(mock_config.release).to eq('a1b2c3d')
+    end
+
+    context "with .commit_hash.txt file fallback" do
+      let(:commit_hash_path) { File.join(Onetime::HOME, '.commit_hash.txt') }
+
+      before do
+        ENV.delete('SENTRY_RELEASE')
+        @original_file_exists = File.exist?(commit_hash_path)
+        @original_content = File.read(commit_hash_path) if @original_file_exists
+      end
+
+      after do
+        if @original_file_exists
+          File.write(commit_hash_path, @original_content)
+        elsif File.exist?(commit_hash_path)
+          # Only delete if we created it during the test
+          # File.delete(commit_hash_path)
+        end
+      end
+
+      it "uses .commit_hash.txt when SENTRY_RELEASE env var is not set" do
+        # Skip if file doesn't exist (we don't want to create files in tests)
+        skip "No .commit_hash.txt file present" unless File.exist?(commit_hash_path)
+
+        file_content = File.read(commit_hash_path).strip
+        skip "File contains dev/pristine fallback" if %w[dev pristine].include?(file_content) || file_content.empty?
+
+        setup_diagnostics_config
+
+        expect(Kernel).to receive(:require).with('sentry-ruby').ordered
+        expect(Kernel).to receive(:require).with('stackprof').ordered
+        expect(Sentry).to receive(:init).and_yield(mock_config)
+
+        execute_diagnostics_initializer
+
+        expect(mock_config.release).to eq(file_content)
+      end
+
+      it "SENTRY_RELEASE env var takes precedence over .commit_hash.txt" do
+        ENV['SENTRY_RELEASE'] = 'env-override'
+        setup_diagnostics_config
+
+        expect(Kernel).to receive(:require).with('sentry-ruby').ordered
+        expect(Kernel).to receive(:require).with('stackprof').ordered
+        expect(Sentry).to receive(:init).and_yield(mock_config)
+
+        execute_diagnostics_initializer
+
+        expect(mock_config.release).to eq('env-override')
+      end
+    end
+  end
+
   # Tests for execution_mode-aware DSN selection (GitHub #2973)
   # Workers and schedulers can use a separate Sentry DSN to isolate
   # background job errors from web/CLI errors.
@@ -521,7 +709,9 @@ RSpec.describe Onetime::Initializers::SetupDiagnostics do
         expect(Sentry).to receive(:init).and_yield(mock_config)
         execute_diagnostics_initializer
 
-        expect(mock_config.release).to eq(OT::VERSION.details)
+        # Release follows priority: ENV['SENTRY_RELEASE'] > .commit_hash.txt > OT::VERSION.details
+        expect(mock_config.release).to be_a(String)
+        expect(mock_config.release).not_to be_empty
       end
 
       it "sets same jurisdiction tag regardless of execution mode" do

--- a/spec/unit/onetime/version_spec.rb
+++ b/spec/unit/onetime/version_spec.rb
@@ -1,0 +1,120 @@
+# spec/unit/onetime/version_spec.rb
+#
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Onetime::VERSION do
+  let(:commit_hash_path) { File.join(Onetime::HOME, '.commit_hash.txt') }
+
+  describe '.get_build_info' do
+    # Reset cached @version between tests to ensure get_build_info is called fresh
+    before do
+      Onetime::VERSION.instance_variable_set(:@version, nil)
+    end
+
+    context 'when .commit_hash.txt exists with valid commit hash' do
+      it 'returns the commit hash from file' do
+        allow(File).to receive(:exist?).and_call_original
+        allow(File).to receive(:exist?).with(commit_hash_path).and_return(true)
+        allow(File).to receive(:read).and_call_original
+        allow(File).to receive(:read).with(commit_hash_path).and_return("abc1234\n")
+
+        expect(described_class.get_build_info).to eq('abc1234')
+      end
+
+      it 'strips whitespace from file content' do
+        allow(File).to receive(:exist?).and_call_original
+        allow(File).to receive(:exist?).with(commit_hash_path).and_return(true)
+        allow(File).to receive(:read).and_call_original
+        allow(File).to receive(:read).with(commit_hash_path).and_return("  def5678  \n")
+
+        expect(described_class.get_build_info).to eq('def5678')
+      end
+    end
+
+    context 'when .commit_hash.txt contains placeholder values' do
+      before do
+        allow(File).to receive(:exist?).and_call_original
+        allow(File).to receive(:exist?).with(commit_hash_path).and_return(true)
+        allow(File).to receive(:read).and_call_original
+      end
+
+      it 'filters out "dev" and falls back to dev (no git in test)' do
+        allow(File).to receive(:read).with(commit_hash_path).and_return("dev\n")
+        # Git command returns empty in test environment, triggering 'dev' fallback
+        allow(described_class).to receive(:`).and_return("")
+
+        expect(described_class.get_build_info).to eq('dev')
+      end
+
+      it 'filters out "pristine" and falls back to dev (no git in test)' do
+        allow(File).to receive(:read).with(commit_hash_path).and_return("pristine\n")
+        allow(described_class).to receive(:`).and_return("")
+
+        expect(described_class.get_build_info).to eq('dev')
+      end
+    end
+
+    context 'when .commit_hash.txt is empty' do
+      it 'falls back to dev when git unavailable' do
+        allow(File).to receive(:exist?).and_call_original
+        allow(File).to receive(:exist?).with(commit_hash_path).and_return(true)
+        allow(File).to receive(:read).and_call_original
+        allow(File).to receive(:read).with(commit_hash_path).and_return("")
+        allow(described_class).to receive(:`).and_return("")
+
+        expect(described_class.get_build_info).to eq('dev')
+      end
+    end
+
+    context 'when .commit_hash.txt does not exist' do
+      before do
+        allow(File).to receive(:exist?).and_call_original
+        allow(File).to receive(:exist?).with(commit_hash_path).and_return(false)
+      end
+
+      it 'returns "dev" when git returns empty output' do
+        allow(described_class).to receive(:`).and_return("")
+
+        expect(described_class.get_build_info).to eq('dev')
+      end
+
+      it 'returns "dev" when git returns only whitespace' do
+        allow(described_class).to receive(:`).and_return("   \n")
+
+        expect(described_class.get_build_info).to eq('dev')
+      end
+    end
+
+    context 'when both file and git are unavailable' do
+      it 'returns "dev" as final fallback' do
+        allow(File).to receive(:exist?).and_call_original
+        allow(File).to receive(:exist?).with(commit_hash_path).and_return(false)
+        allow(described_class).to receive(:`).and_return("")
+
+        expect(described_class.get_build_info).to eq('dev')
+      end
+    end
+
+    # Integration-style test using actual git (if available)
+    context 'with real git repository' do
+      it 'returns a 7-character hash when in a git repo' do
+        # Skip stubbing - let actual git run
+        # This tests the real behavior in development
+        result = described_class.get_build_info
+        # Result should be either a 7-char hash or 'dev'
+        expect(result).to match(/\A([a-f0-9]{7}|dev)\z/)
+      end
+    end
+  end
+
+  describe '.user_agent' do
+    it 'returns formatted user agent string' do
+      # VERSION.to_s depends on package.json, so we stub it
+      allow(described_class).to receive(:to_s).and_return('1.2.3')
+
+      expect(described_class.user_agent).to eq("OnetimeWorker/1.2.3 (Ruby/#{RUBY_VERSION})")
+    end
+  end
+end

--- a/src/tests/build/sentry-vite-plugin.spec.ts
+++ b/src/tests/build/sentry-vite-plugin.spec.ts
@@ -81,15 +81,17 @@ describe('Sentry Vite Plugin Configuration', () => {
   describe('Vite Config Structure', () => {
     const viteConfigPath = path.join(PROJECT_ROOT, 'vite.config.ts');
 
-    it('imports sentryVitePlugin from @sentry/vite-plugin', () => {
-      const content = fs.readFileSync(viteConfigPath, 'utf-8');
-      expect(content).toContain("import { sentryVitePlugin } from '@sentry/vite-plugin'");
-    });
-
     it('has sourcemap enabled in build config', () => {
       const content = fs.readFileSync(viteConfigPath, 'utf-8');
       // The build config should have sourcemap: true for Sentry to work
       expect(content).toMatch(/sourcemap:\s*true/);
+    });
+
+    it('documents CI-based sourcemap upload (not build-time)', () => {
+      const content = fs.readFileSync(viteConfigPath, 'utf-8');
+      // Sourcemaps are uploaded via sentry-cli in CI, not via sentryVitePlugin at build time.
+      // This keeps auth tokens out of the build context.
+      expect(content).toContain('Sentry sourcemaps are uploaded via CI');
     });
   });
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,13 +2,11 @@
 
 import Vue from '@vitejs/plugin-vue';
 import VueI18nPlugin from '@intlify/unplugin-vue-i18n/vite';
-import { execSync } from 'child_process';
 import { resolve } from 'path';
 import process from 'process';
 import Markdown from 'unplugin-vue-markdown/vite';
 import { defineConfig, type PluginOption } from 'vite';
 import tailwindcss from '@tailwindcss/vite';
-import { sentryVitePlugin } from '@sentry/vite-plugin';
 
 import { addTrailingNewline } from './src/build/plugins/addTrailingNewline';
 import { DEBUG } from './src/utils/debug';
@@ -26,72 +24,6 @@ const viteBaseUrl = process.env.VITE_BASE_URL;
 // https://vite.dev/config/server-options.html#server-allowedhosts
 // https://github.com/vitejs/vite/security/advisories/GHSA-vg6x-rcgg-rjx6
 const viteAdditionalServerAllowedHosts = process.env.VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS;
-
-/**
- * Sentry Source Map Upload Plugin (Production Only)
- * --------------------------------------------------
- * Uploads source maps to Sentry for readable stack traces in error reports.
- * Only active when:
- * - Building for production (command === 'build')
- * - SENTRY_AUTH_TOKEN is present in environment
- *
- * Required env vars for upload:
- * - SENTRY_AUTH_TOKEN: API token with project:releases scope
- * - SENTRY_ORG: Sentry organization slug (defaults to 'onetimesecret')
- * - SENTRY_PROJECT: Sentry project slug (defaults to 'frontend')
- *
- * Optional:
- * - SENTRY_RELEASE: Release version (defaults to git commit SHA)
- * - SENTRY_DIST: Distribution identifier (defaults to 'frontend')
- *
- * Note: execSync is used here with a static command string (no user input),
- * which is safe for build-time git SHA retrieval.
- */
-function createSentryPlugin(command: string): PluginOption | null {
-  const authToken = process.env.SENTRY_AUTH_TOKEN;
-
-  // Only upload source maps during production builds
-  if (command !== 'build') {
-    return null;
-  }
-
-  // Graceful degradation: skip plugin if auth token is missing
-  if (!authToken) {
-    console.warn(
-      '[vite] Sentry source map upload skipped: SENTRY_AUTH_TOKEN not set'
-    );
-    return null;
-  }
-
-  // Determine release version: prefer explicit env var, fallback to git SHA
-  let release = process.env.SENTRY_RELEASE;
-  if (!release) {
-    try {
-      release = execSync('git rev-parse --short=7 HEAD').toString().trim();
-    } catch {
-      console.warn(
-        '[vite] Sentry: Could not determine git SHA for release, using "unknown"'
-      );
-      release = 'unknown';
-    }
-  }
-
-  const org = process.env.SENTRY_ORG || 'onetimesecret';
-  const project = process.env.SENTRY_PROJECT || 'frontend';
-  const dist = process.env.SENTRY_DIST || 'frontend';
-
-  return sentryVitePlugin({
-    authToken,
-    org,
-    project,
-    release: { name: release },
-    sourcemaps: {
-      assets: './public/web/dist/**',
-      filesToDeleteAfterUpload: './public/web/dist/**/*.map',
-    },
-    dist,
-  });
-}
 
 /**
  * Vite Configuration - Consolidated Assets
@@ -119,7 +51,7 @@ function createSentryPlugin(command: string): PluginOption | null {
  * @see 29ffd790d74599bbbe3755d0fcba2b59c2f59ed7
  */
 // eslint-disable-next-line max-lines-per-function
-export default defineConfig(({ command }) => ({
+export default defineConfig(({ command: _command }) => ({
   // Project root is ./src (imports resolve from here, index.html lives here)
   root: './src',
 
@@ -239,9 +171,8 @@ export default defineConfig(({ command }) => ({
      * @see ./src/build/plugins/addTrailingNewline.ts for implementation details.
      */
     addTrailingNewline(),
-
-    // Sentry source map upload (production builds only, requires SENTRY_AUTH_TOKEN)
-    createSentryPlugin(command),
+    // Note: Sentry sourcemaps are uploaded via CI (sentry-cli), not at build time.
+    // This keeps auth tokens out of the build context. See .github/workflows/build-and-publish-oci-images.yml
   ].filter(Boolean) as PluginOption[],
 
   resolve: {


### PR DESCRIPTION
Enables Sentry's Suspect Commits feature by wiring sentry-cli into CI. Releases are created with commit history attached, sourcemaps are uploaded with an explicit project, and deploy notifications fire on tag pushes.

Removes the Vite plugin upload path in favour of CI-only upload — keeps auth tokens out of the Docker build context and eliminates release ID divergence risk between build-time and CI-controlled SHAs. A new `SENTRY_PROJECTS` secret (space-separated) replaces the old per-project secrets, letting one release step cover frontend, backend, and workers.

The Ruby initializer gains a `resolve_sentry_release` fallback chain (env var → `.commit_hash.txt` → `OT::VERSION.details`) so the running container reports the same release ID that CI registered with Sentry.

Closes #2971