### PR TITLE
[#2967] Add request context to V1 API Sentry capture_error

### DIFF
--- a/apps/api/v1/controllers/helpers.rb
+++ b/apps/api/v1/controllers/helpers.rb
@@ -344,31 +344,78 @@ module V1
     # Available levels are :fatal, :error, :warning, :log, :info,
     # and :debug. The Sentry default, if not specified, is :error.
     #
-    def capture_error(error, level = :error, &)
+    def capture_error(error, level = :error, &block)
       return unless OT.d9s_enabled # diagnostics are disabled by default
 
-      # Capture more detailed debugging information when Sentry errors occur
-      begin
-        # Log request headers before attempting to send to Sentry
-        if defined?(req) && req.respond_to?(:env)
-          headers = req.env.select { |k, _v| k.start_with?('HTTP_') rescue false } # rubocop:disable Style/RescueModifier
-          OT.ld "[capture_error] Request headers: #{headers.inspect}"
+      # Log request headers before attempting to send to Sentry
+      if defined?(req) && req.respond_to?(:env)
+        headers = req.env.select { |k, _v| k.start_with?('HTTP_') rescue false } # rubocop:disable Style/RescueModifier
+        OT.ld "[capture_error] Request headers: #{headers.inspect}"
+      end
+
+      # Capture exception with request context for debugging in Sentry
+      Sentry.capture_exception(error, level: level) do |scope|
+        # Add searchable tags
+        scope.set_tags(
+          service: 'api',
+          endpoint: req&.path_info || 'unknown',
+        )
+
+        # Add request context (URLs scrubbed by before_send hook)
+        if defined?(req) && req.respond_to?(:url)
+          scope.set_context(
+            'request',
+            {
+              url: req.url,
+              method: req.request_method,
+              ip: req.ip,
+            },
+          )
         end
 
-        # Try Sentry exception reporting
-        Sentry.capture_exception(error, level: level, &)
-      rescue NoMethodError => ex
-        raise unless ex.message.include?('start_with?')
+        # Add customer/session context with truncated IDs for privacy
+        if defined?(cust) && cust && !cust.anonymous?
+          scope.set_context(
+            'customer',
+            {
+              custid: truncate_id(cust.custid),
+              role: cust.role,
+            },
+          )
+        end
 
-        # Continue execution - don't let a Sentry error break the app
-        OT.le "[capture_error] Sentry error with nil value in start_with? check: #{ex.message}"
-        OT.ld ex.backtrace.join("\n")
+        if defined?(sess) && sess.respond_to?(:sessid)
+          scope.set_context(
+            'session',
+            {
+              sessid: truncate_id(sess.sessid),
+            },
+          )
+        end
 
-      # Re-raise any other NoMethodError that isn't related to start_with?
-      rescue StandardError => ex
-        OT.le "[capture_error] #{ex.class}: #{ex.message}"
-        OT.ld ex.backtrace.join("\n")
+        # Allow caller to add additional context via block
+        block&.call(scope)
       end
+    rescue NoMethodError => ex
+      raise unless ex.message.include?('start_with?')
+
+      # Continue execution - don't let a Sentry error break the app
+      OT.le "[capture_error] Sentry error with nil value in start_with? check: #{ex.message}"
+      OT.ld ex.backtrace.join("\n")
+    rescue StandardError => ex
+      OT.le "[capture_error] #{ex.class}: #{ex.message}"
+      OT.ld ex.backtrace.join("\n")
+    end
+
+    # Truncates an ID string for privacy while keeping it useful for debugging.
+    # Shows first 8 characters followed by ellipsis.
+    # @param id [String, nil] ID to truncate
+    # @return [String] Truncated ID or 'unknown' if nil/empty
+    def truncate_id(id)
+      return 'unknown' if id.nil? || id.to_s.empty?
+
+      id_str = id.to_s
+      id_str.length <= 8 ? id_str : "#{id_str[0, 8]}..."
     end
 
     def capture_message(message, level = :log, &)

--- a/apps/api/v1/controllers/helpers.rb
+++ b/apps/api/v1/controllers/helpers.rb
@@ -355,10 +355,10 @@ module V1
 
       # Capture exception with request context for debugging in Sentry
       Sentry.capture_exception(error, level: level) do |scope|
-        # Add searchable tags
+        # Add searchable tags (guard req to avoid NameError if not defined)
         scope.set_tags(
           service: 'api',
-          endpoint: req&.path_info || 'unknown',
+          endpoint: (defined?(req) && req&.path_info) || 'unknown',
         )
 
         # Add request context (URLs scrubbed by before_send hook)
@@ -417,6 +417,7 @@ module V1
       id_str = id.to_s
       id_str.length <= 8 ? id_str : "#{id_str[0, 8]}..."
     end
+    private :truncate_id
 
     def capture_message(message, level = :log, &)
       return unless OT.d9s_enabled # diagnostics are disabled by default

--- a/apps/api/v1/spec/controllers/helpers_sentry_spec.rb
+++ b/apps/api/v1/spec/controllers/helpers_sentry_spec.rb
@@ -207,27 +207,82 @@ RSpec.describe V1::ControllerHelpers do
       end
 
       context 'when request object is nil' do
-        # Note: In production, req is always defined in controller context via Otto.
-        # Testing the nil case reveals that the implementation uses `defined?(req)`
-        # which returns true for attr_readers even when they return nil.
-        # A safer implementation would use `req&.path_info || 'unknown'`.
-        # This edge case is unlikely in production but noted here for completeness.
-        #
-        # The tests below are skipped because they require implementation changes
-        # to handle nil requests gracefully within the scope block.
+        # When @req attr_reader is defined but returns nil, the implementation
+        # uses safe navigation (req&.path_info) to avoid NoMethodError and
+        # falls back to 'unknown' for the endpoint tag.
 
         let(:controller_without_request) do
           controller_class.new
         end
 
-        it 'would ideally handle nil request gracefully', skip: 'Requires safe navigation fix: req&.path_info' do
+        before do
           allow(Sentry).to receive(:capture_exception).and_yield(mock_scope)
+        end
 
+        it 'sets endpoint tag to unknown when request is nil' do
           expect(mock_scope).to receive(:set_tags).with(
             hash_including(endpoint: 'unknown')
           )
 
           controller_without_request.capture_error(test_error)
+        end
+
+        it 'does not set request context when request is nil' do
+          expect(mock_scope).not_to receive(:set_context).with('request', anything)
+
+          controller_without_request.capture_error(test_error)
+        end
+      end
+
+      context 'when req is not defined (NameError prevention)' do
+        # Test that capture_error works when called from a context where
+        # the `req` method doesn't exist at all (would raise NameError).
+        # The implementation guards with `defined?(req)` checks.
+
+        let(:minimal_controller_class) do
+          Class.new do
+            include V1::ControllerHelpers
+            # Intentionally omit req, cust, sess attr_readers
+          end
+        end
+
+        let(:minimal_controller) { minimal_controller_class.new }
+
+        before do
+          allow(Sentry).to receive(:capture_exception).and_yield(mock_scope)
+        end
+
+        it 'does not raise NameError when req is undefined' do
+          expect { minimal_controller.capture_error(test_error) }.not_to raise_error
+        end
+
+        it 'sets endpoint to unknown when req is undefined' do
+          expect(mock_scope).to receive(:set_tags).with(
+            hash_including(
+              service: 'api',
+              endpoint: 'unknown'
+            )
+          )
+
+          minimal_controller.capture_error(test_error)
+        end
+
+        it 'does not set request context when req is undefined' do
+          expect(mock_scope).not_to receive(:set_context).with('request', anything)
+
+          minimal_controller.capture_error(test_error)
+        end
+
+        it 'does not set customer context when cust is undefined' do
+          expect(mock_scope).not_to receive(:set_context).with('customer', anything)
+
+          minimal_controller.capture_error(test_error)
+        end
+
+        it 'does not set session context when sess is undefined' do
+          expect(mock_scope).not_to receive(:set_context).with('session', anything)
+
+          minimal_controller.capture_error(test_error)
         end
       end
 
@@ -390,8 +445,15 @@ RSpec.describe V1::ControllerHelpers do
     end
   end
 
-  describe '#truncate_id' do
+  describe '#truncate_id (private)' do
     let(:controller_instance) { controller_class.new }
+
+    # Verify truncate_id is private to prevent exposure as a controller action.
+    # Otto maps public methods to routes, so helper methods must be private.
+    it 'is a private method (not exposed as controller action)' do
+      expect(controller_instance.public_methods).not_to include(:truncate_id)
+      expect(controller_instance.private_methods).to include(:truncate_id)
+    end
 
     it 'returns unknown for nil id' do
       expect(controller_instance.send(:truncate_id, nil)).to eq('unknown')

--- a/apps/api/v1/spec/controllers/helpers_sentry_spec.rb
+++ b/apps/api/v1/spec/controllers/helpers_sentry_spec.rb
@@ -1,0 +1,417 @@
+# apps/api/v1/spec/controllers/helpers_sentry_spec.rb
+#
+# frozen_string_literal: true
+
+require_relative '../../application'
+require_relative File.join(Onetime::HOME, 'spec', 'spec_helper')
+require 'v1/controllers'
+
+# Tests for Sentry error capture with request context in V1 API helpers.
+# See: apps/api/v1/controllers/helpers.rb - capture_error method
+#
+# The capture_error method adds request context when capturing exceptions to
+# Sentry, enabling better debugging of API errors. It sets:
+# - Tags: service='api', endpoint=<request path>
+# - Context 'request': url, method, ip
+# - Context 'customer': custid (truncated), role (when authenticated)
+# - Context 'session': sessid (truncated)
+#
+# Reference: apps/web/core/middleware/error_handling.rb for similar pattern
+RSpec.describe V1::ControllerHelpers do
+  # Create a test class that includes the helpers module
+  let(:controller_class) do
+    Class.new do
+      include V1::ControllerHelpers
+
+      attr_reader :req, :cust, :sess
+
+      def initialize(request: nil, customer: nil, session: nil)
+        @req = request
+        @cust = customer
+        @sess = session
+      end
+    end
+  end
+
+  # Use plain double to avoid strict method checking - the actual request
+  # object comes from Otto which extends Rack::Request
+  let(:mock_request) do
+    double(
+      'Request',
+      url: 'https://example.com/api/v1/secrets',
+      request_method: 'POST',
+      ip: '192.168.1.100',
+      path_info: '/api/v1/secrets',
+      env: {
+        'HTTP_USER_AGENT' => 'TestAgent/1.0',
+        'HTTP_X_FORWARDED_FOR' => '10.0.0.1',
+      }
+    )
+  end
+
+  let(:mock_customer) do
+    double(
+      'Customer',
+      custid: 'cust_abc123def456',
+      role: :unlimited,
+      anonymous?: false
+    )
+  end
+
+  let(:mock_session) do
+    double(
+      'Session',
+      sessid: 'sess_xyz789abc012'
+    )
+  end
+
+  let(:controller) { controller_class.new(request: mock_request) }
+  let(:test_error) { StandardError.new('Test error message') }
+
+  # Mock Sentry scope object that captures all set_context and set_tags calls
+  let(:mock_scope) do
+    scope = double('Sentry::Scope')
+    allow(scope).to receive(:set_context)
+    allow(scope).to receive(:set_tags)
+    allow(scope).to receive(:set_tag)
+    scope
+  end
+
+  before do
+    # Define a minimal Sentry constant if it doesn't exist
+    unless defined?(Sentry)
+      stub_const('Sentry', Module.new do
+        def self.capture_exception(error, **options, &block)
+          # Default stub
+        end
+
+        def self.capture_message(message, **options, &block)
+          # Default stub
+        end
+      end)
+    end
+  end
+
+  describe '#capture_error' do
+    context 'when diagnostics are enabled (OT.d9s_enabled is true)' do
+      before do
+        allow(OT).to receive(:d9s_enabled).and_return(true)
+        allow(OT).to receive(:ld) # Suppress debug logging
+      end
+
+      it 'calls Sentry.capture_exception with the error and level' do
+        expect(Sentry).to receive(:capture_exception)
+          .with(test_error, hash_including(level: :error))
+
+        controller.capture_error(test_error)
+      end
+
+      it 'calls Sentry.capture_exception with custom level' do
+        expect(Sentry).to receive(:capture_exception)
+          .with(test_error, hash_including(level: :warning))
+
+        controller.capture_error(test_error, :warning)
+      end
+
+      context 'scope configuration' do
+        before do
+          allow(Sentry).to receive(:capture_exception).and_yield(mock_scope)
+        end
+
+        it 'sets service and endpoint tags' do
+          expect(mock_scope).to receive(:set_tags).with(
+            hash_including(
+              service: 'api',
+              endpoint: '/api/v1/secrets'
+            )
+          )
+
+          controller.capture_error(test_error)
+        end
+
+        it 'sets request context with url, method, and ip' do
+          expect(mock_scope).to receive(:set_context).with(
+            'request',
+            hash_including(
+              url: 'https://example.com/api/v1/secrets',
+              method: 'POST',
+              ip: '192.168.1.100'
+            )
+          )
+
+          controller.capture_error(test_error)
+        end
+      end
+
+      context 'with authenticated customer' do
+        let(:controller_with_customer) do
+          controller_class.new(request: mock_request, customer: mock_customer)
+        end
+
+        before do
+          allow(Sentry).to receive(:capture_exception).and_yield(mock_scope)
+        end
+
+        it 'sets customer context with truncated custid and role' do
+          expect(mock_scope).to receive(:set_context).with(
+            'customer',
+            hash_including(
+              custid: 'cust_abc...', # truncated to 8 chars + ...
+              role: :unlimited
+            )
+          )
+
+          controller_with_customer.capture_error(test_error)
+        end
+      end
+
+      context 'with anonymous customer' do
+        let(:anonymous_customer) do
+          double('Customer', custid: 'anon_123', anonymous?: true)
+        end
+
+        let(:controller_with_anon) do
+          controller_class.new(request: mock_request, customer: anonymous_customer)
+        end
+
+        before do
+          allow(Sentry).to receive(:capture_exception).and_yield(mock_scope)
+        end
+
+        it 'does not set customer context for anonymous users' do
+          expect(mock_scope).not_to receive(:set_context).with('customer', anything)
+
+          controller_with_anon.capture_error(test_error)
+        end
+      end
+
+      context 'with session' do
+        let(:controller_with_session) do
+          controller_class.new(request: mock_request, session: mock_session)
+        end
+
+        before do
+          allow(Sentry).to receive(:capture_exception).and_yield(mock_scope)
+        end
+
+        it 'sets session context with truncated sessid' do
+          expect(mock_scope).to receive(:set_context).with(
+            'session',
+            hash_including(
+              sessid: 'sess_xyz...' # truncated to 8 chars + ...
+            )
+          )
+
+          controller_with_session.capture_error(test_error)
+        end
+      end
+
+      context 'when request object is nil' do
+        # Note: In production, req is always defined in controller context via Otto.
+        # Testing the nil case reveals that the implementation uses `defined?(req)`
+        # which returns true for attr_readers even when they return nil.
+        # A safer implementation would use `req&.path_info || 'unknown'`.
+        # This edge case is unlikely in production but noted here for completeness.
+        #
+        # The tests below are skipped because they require implementation changes
+        # to handle nil requests gracefully within the scope block.
+
+        let(:controller_without_request) do
+          controller_class.new
+        end
+
+        it 'would ideally handle nil request gracefully', skip: 'Requires safe navigation fix: req&.path_info' do
+          allow(Sentry).to receive(:capture_exception).and_yield(mock_scope)
+
+          expect(mock_scope).to receive(:set_tags).with(
+            hash_including(endpoint: 'unknown')
+          )
+
+          controller_without_request.capture_error(test_error)
+        end
+      end
+
+      context 'with caller-provided block' do
+        before do
+          allow(Sentry).to receive(:capture_exception).and_yield(mock_scope)
+        end
+
+        it 'yields scope to caller block for additional context' do
+          block_called = false
+
+          controller.capture_error(test_error) do |scope|
+            block_called = true
+            expect(scope).to eq(mock_scope)
+          end
+
+          expect(block_called).to be true
+        end
+      end
+    end
+
+    context 'when diagnostics are disabled (OT.d9s_enabled is false)' do
+      before do
+        allow(OT).to receive(:d9s_enabled).and_return(false)
+      end
+
+      it 'does not call Sentry.capture_exception' do
+        expect(Sentry).not_to receive(:capture_exception)
+
+        controller.capture_error(test_error)
+      end
+
+      it 'returns early without processing' do
+        result = controller.capture_error(test_error)
+        expect(result).to be_nil
+      end
+    end
+
+    context 'when Sentry raises an error' do
+      before do
+        allow(OT).to receive(:d9s_enabled).and_return(true)
+        allow(OT).to receive(:ld) # Suppress debug logging
+        allow(OT).to receive(:le) # Suppress error logging
+      end
+
+      it 'catches NoMethodError related to start_with? and continues' do
+        error = NoMethodError.new("undefined method `start_with?' for nil:NilClass")
+        allow(Sentry).to receive(:capture_exception).and_raise(error)
+
+        expect { controller.capture_error(test_error) }.not_to raise_error
+      end
+
+      it 're-raises NoMethodError not related to start_with?' do
+        error = NoMethodError.new("undefined method `foo' for nil:NilClass")
+        allow(Sentry).to receive(:capture_exception).and_raise(error)
+
+        expect { controller.capture_error(test_error) }.to raise_error(NoMethodError)
+      end
+
+      it 'catches general StandardError and continues' do
+        allow(Sentry).to receive(:capture_exception).and_raise(StandardError, 'Sentry network error')
+
+        expect { controller.capture_error(test_error) }.not_to raise_error
+      end
+
+      it 'logs errors when Sentry fails' do
+        allow(Sentry).to receive(:capture_exception).and_raise(StandardError, 'Sentry failed')
+
+        expect(OT).to receive(:le).with(/capture_error.*StandardError.*Sentry failed/)
+
+        controller.capture_error(test_error)
+      end
+    end
+
+    context 'with different error levels' do
+      before do
+        allow(OT).to receive(:d9s_enabled).and_return(true)
+        allow(OT).to receive(:ld)
+      end
+
+      %i[fatal error warning log info debug].each do |level|
+        it "accepts #{level} as a valid error level" do
+          expect(Sentry).to receive(:capture_exception)
+            .with(test_error, hash_including(level: level))
+
+          controller.capture_error(test_error, level)
+        end
+      end
+
+      it 'defaults to :error level when no level specified' do
+        expect(Sentry).to receive(:capture_exception)
+          .with(test_error, hash_including(level: :error))
+
+        controller.capture_error(test_error)
+      end
+    end
+  end
+
+  describe '#capture_message' do
+    let(:test_message) { 'Form validation failed' }
+
+    context 'when diagnostics are enabled' do
+      before do
+        allow(OT).to receive(:d9s_enabled).and_return(true)
+      end
+
+      it 'calls Sentry.capture_message with the message' do
+        expect(Sentry).to receive(:capture_message)
+          .with(test_message, hash_including(level: :log))
+
+        controller.capture_message(test_message)
+      end
+
+      it 'accepts custom level parameter' do
+        expect(Sentry).to receive(:capture_message)
+          .with(test_message, hash_including(level: :error))
+
+        controller.capture_message(test_message, :error)
+      end
+
+      it 'passes block to Sentry.capture_message' do
+        expect(Sentry).to receive(:capture_message) do |msg, **opts, &block|
+          expect(msg).to eq(test_message)
+          expect(block).not_to be_nil
+        end
+
+        controller.capture_message(test_message) { |_scope| }
+      end
+    end
+
+    context 'when diagnostics are disabled' do
+      before do
+        allow(OT).to receive(:d9s_enabled).and_return(false)
+      end
+
+      it 'does not call Sentry.capture_message' do
+        expect(Sentry).not_to receive(:capture_message)
+
+        controller.capture_message(test_message)
+      end
+    end
+
+    context 'when Sentry raises an error' do
+      before do
+        allow(OT).to receive(:d9s_enabled).and_return(true)
+        allow(OT).to receive(:le)
+        allow(OT).to receive(:ld)
+        allow(Sentry).to receive(:capture_message).and_raise(StandardError, 'Sentry unavailable')
+      end
+
+      it 'catches the error and continues' do
+        expect { controller.capture_message(test_message) }.not_to raise_error
+      end
+
+      it 'logs the error' do
+        expect(OT).to receive(:le).with(/capture_message.*StandardError.*Sentry unavailable/)
+
+        controller.capture_message(test_message)
+      end
+    end
+  end
+
+  describe '#truncate_id' do
+    let(:controller_instance) { controller_class.new }
+
+    it 'returns unknown for nil id' do
+      expect(controller_instance.send(:truncate_id, nil)).to eq('unknown')
+    end
+
+    it 'returns unknown for empty string' do
+      expect(controller_instance.send(:truncate_id, '')).to eq('unknown')
+    end
+
+    it 'returns full id when 8 characters or less' do
+      expect(controller_instance.send(:truncate_id, 'abc123')).to eq('abc123')
+      expect(controller_instance.send(:truncate_id, '12345678')).to eq('12345678')
+    end
+
+    it 'truncates id to first 8 characters with ellipsis' do
+      expect(controller_instance.send(:truncate_id, 'cust_abc123def456')).to eq('cust_abc...')
+    end
+
+    it 'handles non-string ids by converting to string' do
+      expect(controller_instance.send(:truncate_id, 12345678901234)).to eq('12345678...')
+    end
+  end
+end

--- a/apps/web/core/spec/views/base_spec.rb
+++ b/apps/web/core/spec/views/base_spec.rb
@@ -182,12 +182,14 @@ RSpec.describe Core::Views::BaseView do
 
       it 'sets diagnostic variables when enabled and DSN provided' do
         vars = subject.serialized_data
-        expect(vars['diagnostics']).to eq({
-          'sentry' => {
-            'dsn' => 'https://test-dsn@sentry.example.com/1',
-          },
-        },
-                                         )
+        expect(vars['diagnostics']['sentry']['dsn']).to eq('https://test-dsn@sentry.example.com/1')
+        expect(vars['diagnostics']['sentry']).to include(
+          'environment' => 'testing',
+          'logErrors' => true,
+          'maxBreadcrumbs' => 5,
+          'sampleRate' => 1.0,
+          'trackComponents' => true,
+        )
         expect(vars['d9s_enabled']).to be true
       end
     end
@@ -210,12 +212,14 @@ RSpec.describe Core::Views::BaseView do
       it 'sets diagnostic to disabled when DSN not provided' do
         vars = subject.serialized_data
         expect(vars['d9s_enabled']).to be false
-        expect(vars['diagnostics']).to eq({
-          'sentry' => {
-            'dsn' => nil,
-          },
-        },
-                                         )
+        expect(vars['diagnostics']['sentry']['dsn']).to be_nil
+        expect(vars['diagnostics']['sentry']).to include(
+          'environment' => 'testing',
+          'logErrors' => true,
+          'maxBreadcrumbs' => 5,
+          'sampleRate' => 1.0,
+          'trackComponents' => true,
+        )
       end
     end
   end

--- a/spec/support/shared_contexts/view_test_context.rb
+++ b/spec/support/shared_contexts/view_test_context.rb
@@ -113,7 +113,9 @@ RSpec.shared_context 'view_test_context' do
     allow(OT).to receive(:conf).and_return(config)
     allow(OT).to receive(:d9s_enabled).and_return(false)
     allow(OT).to receive(:default_locale).and_return('en')
-    allow(Onetime).to receive(:with_diagnostics).and_yield(config['diagnostics'])
+    # Use block implementation instead of and_yield to avoid
+    # RSpec 4.x arity checking issues on x86_64-linux
+    allow(Onetime).to receive(:with_diagnostics) { |&block| block&.call }
 
     allow(OT).to receive(:locales).and_return({
       'en' => {


### PR DESCRIPTION
Closes #2967

## Summary

- Add scope block to `capture_error` with tags and context for Sentry debugging
- Tags (searchable): `service='api'`, `endpoint=path_info`
- Request context: `url`, `method`, `ip` (URLs already scrubbed by `before_send` hook)
- Customer context: truncated `custid`, `role` (authenticated users only)
- Session context: truncated `sessid`
- Add `truncate_id` helper (first 8 chars + `...`)
- Use method-level rescues to reduce nesting

## Test plan

- [x] RSpec tests pass (33 examples)
- [ ] Deploy to staging and trigger an API error
- [ ] Verify Sentry event has `service:api` tag and request/customer/session context