### PR TITLE
Bake Sentry release into frontend bundle at build time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -133,6 +133,15 @@ RUN set -eux && \
       fi ; \
     fi
 
+# Generate build metadata BEFORE build so getSentryRelease() can read it.
+# COMMIT_HASH is passed as a build arg from CI (GitHub Actions).
+# The .commit_hash.txt file is read by vite.config.ts to bake the release
+# version into the frontend bundle, ensuring sourcemaps match errors.
+RUN set -eux && \
+    mkdir -p /tmp/build-meta && \
+    echo "${COMMIT_HASH:-dev}" > .commit_hash.txt && \
+    echo "${COMMIT_HASH:-dev}" > /tmp/build-meta/commit_hash.txt
+
 # Build application and generate schema
 RUN set -eux && \
     pnpm run build && \
@@ -140,12 +149,6 @@ RUN set -eux && \
     pnpm prune --prod && \
     rm -rf node_modules ~/.npm ~/.pnpm-store && \
     npm uninstall -g pnpm
-
-# Generate build metadata.
-# COMMIT_HASH is passed as a build arg from CI (GitHub Actions).
-RUN set -eux && \
-    mkdir -p /tmp/build-meta && \
-    echo "${COMMIT_HASH:-dev}" > /tmp/build-meta/commit_hash.txt
 
 ##
 # FINAL-S6: Production image with S6 overlay for multi-process supervision

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -94,6 +94,7 @@ export default [
       globals: {
         ...globals.browser,
         process: true, // Allow process global for environment variables
+        __SENTRY_RELEASE__: true, // Build-time injected by Vite define
       },
       parser: parserTs,
       parserOptions: {

--- a/src/plugins/core/enableDiagnostics.ts
+++ b/src/plugins/core/enableDiagnostics.ts
@@ -5,6 +5,15 @@ import { initDiagnostics } from '@/services/diagnostics.service';
 import type { DiagnosticsConfig } from '@/types/diagnostics';
 import type { RouteMeta } from '@/types/router';
 import { DEBUG } from '@/utils/debug';
+
+/**
+ * Build-time Sentry release version, injected by Vite define.
+ * Matches the commit hash used for sourcemap uploads, ensuring
+ * frontend errors can be correlated with the correct sourcemaps.
+ *
+ * @see vite.config.ts getSentryRelease()
+ */
+declare const __SENTRY_RELEASE__: string;
 import { collectValuesToRedact, scrubUrlWithValues } from './diagnostics/urlScrubbing';
 // Re-export scrubbing utilities from dependency-free module for backward compatibility
 export {
@@ -310,7 +319,13 @@ export function createDiagnostics(options: EnableDiagnosticsOptions): Plugin {
 
     // Scrub sensitive URLs from breadcrumbs at capture time
     beforeBreadcrumb: createBeforeBreadcrumbHandler(router),
-    ...config.sentry, // includes dsn, environment, release, etc.
+    ...config.sentry, // includes dsn, environment, etc.
+
+    // Build-time release takes precedence over backend config.
+    // This ensures frontend errors match the sourcemaps uploaded during this build,
+    // which is critical for CDN caching and rolling deploys where the backend
+    // might be running a newer release than the cached frontend bundle.
+    release: __SENTRY_RELEASE__,
   };
 
   console.debug('[EnableDiagnostics] sentryOptions:', sentryOptions);

--- a/src/plugins/core/enableDiagnostics.ts
+++ b/src/plugins/core/enableDiagnostics.ts
@@ -5,15 +5,6 @@ import { initDiagnostics } from '@/services/diagnostics.service';
 import type { DiagnosticsConfig } from '@/types/diagnostics';
 import type { RouteMeta } from '@/types/router';
 import { DEBUG } from '@/utils/debug';
-
-/**
- * Build-time Sentry release version, injected by Vite define.
- * Matches the commit hash used for sourcemap uploads, ensuring
- * frontend errors can be correlated with the correct sourcemaps.
- *
- * @see vite.config.ts getSentryRelease()
- */
-declare const __SENTRY_RELEASE__: string;
 import { collectValuesToRedact, scrubUrlWithValues } from './diagnostics/urlScrubbing';
 // Re-export scrubbing utilities from dependency-free module for backward compatibility
 export {

--- a/src/tests/build/sentry-vite-plugin.spec.ts
+++ b/src/tests/build/sentry-vite-plugin.spec.ts
@@ -199,6 +199,67 @@ describe('getSentryRelease() Single Source of Truth', () => {
       expect(content).toContain('@see vite.config.ts getSentryRelease()');
     });
   });
+
+  describe('ESLint Configuration', () => {
+    const eslintConfigPath = path.join(PROJECT_ROOT, 'eslint.config.ts');
+
+    it('__SENTRY_RELEASE__ is declared in ESLint globals', () => {
+      const content = fs.readFileSync(eslintConfigPath, 'utf-8');
+      expect(content).toContain('__SENTRY_RELEASE__: true');
+    });
+
+    it('ESLint globals comment explains build-time injection', () => {
+      const content = fs.readFileSync(eslintConfigPath, 'utf-8');
+      // Verify the comment explains the build-time injection
+      expect(content).toMatch(/__SENTRY_RELEASE__:.*Build-time.*Vite define/i);
+    });
+  });
+
+  describe('Test Environment Setup', () => {
+    const setupEnvPath = path.join(PROJECT_ROOT, 'src/tests/setup-env.ts');
+
+    it('__SENTRY_RELEASE__ is mocked in test setup', () => {
+      const content = fs.readFileSync(setupEnvPath, 'utf-8');
+      expect(content).toContain('__SENTRY_RELEASE__');
+      expect(content).toContain('test-release');
+    });
+
+    it('test setup references vite.config.ts getSentryRelease()', () => {
+      const content = fs.readFileSync(setupEnvPath, 'utf-8');
+      expect(content).toContain('@see vite.config.ts getSentryRelease()');
+    });
+  });
+});
+
+describe('__SENTRY_RELEASE__ Usage in enableDiagnostics', () => {
+  const enableDiagnosticsPath = path.join(
+    PROJECT_ROOT,
+    'src/plugins/core/enableDiagnostics.ts'
+  );
+
+  it('uses __SENTRY_RELEASE__ for the release property', () => {
+    const content = fs.readFileSync(enableDiagnosticsPath, 'utf-8');
+    expect(content).toContain('release: __SENTRY_RELEASE__');
+  });
+
+  it('__SENTRY_RELEASE__ is placed after config spread to take precedence', () => {
+    const content = fs.readFileSync(enableDiagnosticsPath, 'utf-8');
+    // The spread of config.sentry should come before release: __SENTRY_RELEASE__
+    // This ensures build-time release overrides backend-provided release
+    const configSpreadIndex = content.indexOf('...config.sentry');
+    const releaseIndex = content.indexOf('release: __SENTRY_RELEASE__');
+
+    expect(configSpreadIndex).toBeGreaterThan(-1);
+    expect(releaseIndex).toBeGreaterThan(-1);
+    expect(releaseIndex).toBeGreaterThan(configSpreadIndex);
+  });
+
+  it('has comment explaining CDN caching and rolling deploys', () => {
+    const content = fs.readFileSync(enableDiagnosticsPath, 'utf-8');
+    // Verify the comment explains why build-time release takes precedence
+    expect(content).toContain('Build-time release takes precedence');
+    expect(content).toContain('CDN caching');
+  });
 });
 
 describe('Sentry Plugin Behavior Specification', () => {

--- a/src/tests/build/sentry-vite-plugin.spec.ts
+++ b/src/tests/build/sentry-vite-plugin.spec.ts
@@ -153,7 +153,7 @@ describe('getSentryRelease() Single Source of Truth', () => {
 
     it('getSentryRelease uses git rev-parse as third fallback', () => {
       const content = fs.readFileSync(viteConfigPath, 'utf-8');
-      expect(content).toContain("execSync('git rev-parse --short=7 HEAD')");
+      expect(content).toContain("execSync('git rev-parse --short=7 HEAD', { timeout: 5000 })");
     });
 
     it('getSentryRelease returns "dev" as final fallback', () => {

--- a/src/tests/build/sentry-vite-plugin.spec.ts
+++ b/src/tests/build/sentry-vite-plugin.spec.ts
@@ -4,17 +4,20 @@
  * Tests for Sentry Vite Plugin Configuration
  *
  * Issue: #2959 - Upload source maps to Sentry for readable stacktraces
+ * Issue: #2999 - Bake Sentry release into frontend bundle at build time
  *
  * These tests verify the build configuration for Sentry source map uploads:
  * - Environment variable documentation is complete
  * - No credentials are hardcoded in config files
  * - Plugin configuration follows graceful degradation pattern
+ * - getSentryRelease() is the single source of truth for release version
  *
  * Run:
  *   pnpm test src/tests/build/sentry-vite-plugin.spec.ts
  */
 
 import { describe, it, expect } from 'vitest';
+import { execSync } from 'child_process';
 import fs from 'fs';
 import path from 'path';
 
@@ -106,6 +109,94 @@ describe('Sentry Vite Plugin Configuration', () => {
     it('generates manifest for asset tracking', () => {
       const content = fs.readFileSync(viteConfigPath, 'utf-8');
       expect(content).toMatch(/manifest:\s*true/);
+    });
+  });
+});
+
+describe('getSentryRelease() Single Source of Truth', () => {
+  /**
+   * Issue: #2999 - getSentryRelease() consolidates release version logic
+   *
+   * The function is used by Vite define to inject the release version:
+   *   { __SENTRY_RELEASE__: JSON.stringify(getSentryRelease()) }
+   *
+   * Note: Sourcemap uploads now use sentry-cli in CI (not the Vite plugin).
+   *
+   * Fallback chain (documented in vite.config.ts):
+   * 1. SENTRY_RELEASE env var (explicit CI/CD override)
+   * 2. .commit_hash.txt file (Docker builds, pre-commit hook)
+   * 3. git rev-parse --short=7 HEAD (local development)
+   * 4. 'dev' (environments without git)
+   */
+
+  describe('Configuration Structure', () => {
+    const viteConfigPath = path.join(PROJECT_ROOT, 'vite.config.ts');
+
+    it('defines getSentryRelease() function', () => {
+      const content = fs.readFileSync(viteConfigPath, 'utf-8');
+      expect(content).toContain('function getSentryRelease(): string');
+    });
+
+    it('getSentryRelease checks SENTRY_RELEASE env var first', () => {
+      const content = fs.readFileSync(viteConfigPath, 'utf-8');
+      // Verify the function checks process.env.SENTRY_RELEASE
+      expect(content).toMatch(/const envRelease = process\.env\.SENTRY_RELEASE/);
+      expect(content).toMatch(/if \(envRelease\)/);
+    });
+
+    it('getSentryRelease checks .commit_hash.txt file second', () => {
+      const content = fs.readFileSync(viteConfigPath, 'utf-8');
+      expect(content).toContain(".commit_hash.txt'");
+      expect(content).toContain('existsSync(commitHashPath)');
+      expect(content).toContain('readFileSync(commitHashPath');
+    });
+
+    it('getSentryRelease uses git rev-parse as third fallback', () => {
+      const content = fs.readFileSync(viteConfigPath, 'utf-8');
+      expect(content).toContain("execSync('git rev-parse --short=7 HEAD')");
+    });
+
+    it('getSentryRelease returns "dev" as final fallback', () => {
+      const content = fs.readFileSync(viteConfigPath, 'utf-8');
+      expect(content).toMatch(/return 'dev'/);
+    });
+
+    it('__SENTRY_RELEASE__ define uses getSentryRelease()', () => {
+      const content = fs.readFileSync(viteConfigPath, 'utf-8');
+      expect(content).toContain('__SENTRY_RELEASE__: JSON.stringify(getSentryRelease())');
+    });
+  });
+
+  describe('Runtime Behavior Verification', () => {
+    it('git rev-parse returns valid short hash in test environment', () => {
+      // This verifies git is available in the test environment
+      // and the command pattern used by getSentryRelease() works
+      // Note: execSync with static command string is safe (no user input)
+      const hash = execSync('git rev-parse --short=7 HEAD').toString().trim();
+      expect(hash).toMatch(/^[a-f0-9]{7}$/);
+    });
+
+    it('git rev-parse command matches getSentryRelease() implementation', () => {
+      // The exact command from getSentryRelease()
+      // Note: execSync with static command string is safe (no user input)
+      const hash = execSync('git rev-parse --short=7 HEAD').toString().trim();
+      expect(hash.length).toBe(7);
+      expect(hash).not.toBe('dev');
+    });
+  });
+
+  describe('Type Safety', () => {
+    const viteEnvDtsPath = path.join(PROJECT_ROOT, 'src/types/declarations/vite-env.d.ts');
+
+    it('__SENTRY_RELEASE__ is declared as global const', () => {
+      const content = fs.readFileSync(viteEnvDtsPath, 'utf-8');
+      expect(content).toContain('declare global');
+      expect(content).toContain('const __SENTRY_RELEASE__: string');
+    });
+
+    it('declaration references getSentryRelease() in comments', () => {
+      const content = fs.readFileSync(viteEnvDtsPath, 'utf-8');
+      expect(content).toContain('@see vite.config.ts getSentryRelease()');
     });
   });
 });

--- a/src/tests/setup-env.ts
+++ b/src/tests/setup-env.ts
@@ -26,6 +26,12 @@ if (typeof process !== 'undefined') {
   authenticated: false,
 };
 
+// Mock __SENTRY_RELEASE__ global that Vite defines at build time
+// This value is replaced by the actual git commit hash during production builds
+// @see vite.config.ts getSentryRelease()
+// @see src/types/declarations/vite-env.d.ts
+(globalThis as Record<string, unknown>).__SENTRY_RELEASE__ = 'test-release';
+
 // Mock localStorage for tests
 const localStorageMock = {
   getItem: () => null,

--- a/src/types/declarations/vite-env.d.ts
+++ b/src/types/declarations/vite-env.d.ts
@@ -46,6 +46,22 @@ interface ImportMetaEnv {
 }
 
 /**
+ * Build-time constants injected by Vite define.
+ * These must be in a `declare global` block because this file
+ * is a module (has imports/exports).
+ */
+declare global {
+  /**
+   * Sentry release version baked at build time.
+   * Matches the commit hash used for sourcemap uploads, ensuring
+   * frontend errors can be correlated with the correct sourcemaps.
+   *
+   * @see vite.config.ts getSentryRelease()
+   */
+  const __SENTRY_RELEASE__: string;
+}
+
+/**
  * This part tells TypeScript how to understand .vue files.
  * It's like teaching TypeScript a new language (Vue).
  */

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -22,17 +22,31 @@ import Inspector from 'vite-plugin-vue-inspector';
 const viteBaseUrl = process.env.VITE_BASE_URL;
 
 /**
- * Sentry Release Version - Baked into Frontend Bundle
- * ----------------------------------------------------
- * Reads the commit hash from .commit_hash.txt (created by pre-commit hook
- * and baked into Docker images). This ensures frontend errors are tagged
- * with the exact release that was compiled, matching sourcemap uploads.
+ * Sentry Release Version - Single Source of Truth
+ * ------------------------------------------------
+ * Determines the release version for both:
+ * - Build-time injection into frontend bundle (__SENTRY_RELEASE__)
+ * - Sentry sourcemap upload tagging
  *
- * Falls back to 'dev' for local development without the pre-commit hook.
+ * Fallback chain:
+ * 1. SENTRY_RELEASE env var (explicit override for CI/CD)
+ * 2. .commit_hash.txt file (created by pre-commit hook, baked into Docker)
+ * 3. git rev-parse (local development with git available)
+ * 4. 'dev' (local development without git)
+ *
+ * Note: execSync is used here with a static command string (no user input),
+ * which is safe for build-time git SHA retrieval.
  *
  * @see PR #2995 for backend release tracking
  */
 function getSentryRelease(): string {
+  // 1. Explicit environment variable takes precedence
+  const envRelease = process.env.SENTRY_RELEASE;
+  if (envRelease) {
+    return envRelease;
+  }
+
+  // 2. Pre-generated commit hash file (Docker builds, CI artifacts)
   const commitHashPath = resolve(process.cwd(), '.commit_hash.txt');
   if (existsSync(commitHashPath)) {
     const hash = readFileSync(commitHashPath, 'utf-8').trim();
@@ -40,7 +54,14 @@ function getSentryRelease(): string {
       return hash;
     }
   }
-  return 'dev';
+
+  // 3. Git SHA for local development
+  try {
+    return execSync('git rev-parse --short=7 HEAD').toString().trim();
+  } catch {
+    // 4. Final fallback for environments without git
+    return 'dev';
+  }
 }
 
 // server.allowedHosts - Multiple hosts can be separated by commas.

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -55,9 +55,9 @@ function getSentryRelease(): string {
     }
   }
 
-  // 3. Git SHA for local development
+  // 3. Git SHA for local development (5s timeout prevents hanging builds)
   try {
-    return execSync('git rev-parse --short=7 HEAD').toString().trim();
+    return execSync('git rev-parse --short=7 HEAD', { timeout: 5000 }).toString().trim();
   } catch {
     // 4. Final fallback for environments without git
     return 'dev';

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,6 +2,8 @@
 
 import Vue from '@vitejs/plugin-vue';
 import VueI18nPlugin from '@intlify/unplugin-vue-i18n/vite';
+import { execSync } from 'child_process';
+import { existsSync, readFileSync } from 'fs';
 import { resolve } from 'path';
 import process from 'process';
 import Markdown from 'unplugin-vue-markdown/vite';
@@ -18,6 +20,28 @@ import Inspector from 'vite-plugin-vue-inspector';
 // available here to prevent accidental exposure of sensitive
 // environment variables to the client-side code.
 const viteBaseUrl = process.env.VITE_BASE_URL;
+
+/**
+ * Sentry Release Version - Baked into Frontend Bundle
+ * ----------------------------------------------------
+ * Reads the commit hash from .commit_hash.txt (created by pre-commit hook
+ * and baked into Docker images). This ensures frontend errors are tagged
+ * with the exact release that was compiled, matching sourcemap uploads.
+ *
+ * Falls back to 'dev' for local development without the pre-commit hook.
+ *
+ * @see PR #2995 for backend release tracking
+ */
+function getSentryRelease(): string {
+  const commitHashPath = resolve(process.cwd(), '.commit_hash.txt');
+  if (existsSync(commitHashPath)) {
+    const hash = readFileSync(commitHashPath, 'utf-8').trim();
+    if (hash) {
+      return hash;
+    }
+  }
+  return 'dev';
+}
 
 // server.allowedHosts - Multiple hosts can be separated by commas.
 //
@@ -321,5 +345,8 @@ export default defineConfig(({ command: _command }) => ({
     // vue-i18n (intlify) feature flags — Rollup auto-replaced these but
     // Rolldown requires explicit definition to avoid ReferenceError at runtime
     __INTLIFY_PROD_DEVTOOLS__: false,
+    // Sentry release version baked at build time to match sourcemap uploads.
+    // Falls back to 'dev' when .commit_hash.txt doesn't exist (local development).
+    __SENTRY_RELEASE__: JSON.stringify(getSentryRelease()),
   },
 }));


### PR DESCRIPTION
## Summary

- Read `.commit_hash.txt` in `vite.config.ts` via new `getSentryRelease()` function
- Inject as `__SENTRY_RELEASE__` compile-time constant (falls back to `'dev'`)
- Use in `enableDiagnostics.ts` for `BrowserClient` release option

This ensures frontend errors are tagged with the exact release that was compiled, matching the sourcemaps uploaded by CI. Build-time injection is more robust than runtime config for CDN caching and rolling deploys.

Closes #2999
Related to #2971

## Test plan

- [ ] `pnpm build` succeeds
- [ ] Verify release is baked into bundle: `grep -o '44d632c' public/web/dist/assets/main.*.js`
- [ ] Local dev without `.commit_hash.txt` uses `'dev'` fallback
- [ ] After deploy, confirm frontend errors in Sentry show the correct release and stack traces are de-obfuscated