### PR TITLE
Derive Sentry breadcrumb scrub patterns from API route metadata

### DIFF
--- a/apps/api/v1/routes.txt
+++ b/apps/api/v1/routes.txt
@@ -20,23 +20,23 @@ POST   /generate                             V1::Controllers::Index#generate    
 
 POST   /create                               V1::Controllers::Index#create      openapi_auth=basic,anonymous content=form response=default
 
-POST   /secret/:key                          V1::Controllers::Index#show_secret openapi_auth=basic,anonymous content=form response=default
+POST   /secret/:key                          V1::Controllers::Index#show_secret openapi_auth=basic,anonymous content=form response=default sensitive=true
 
 # Canonical receipt paths
 # NOTE: Specific sub-paths (burn) must precede the :key wildcard so
 # Otto's first-match-wins dynamic routing resolves them correctly.
 GET    /receipt/recent                       V1::Controllers::Index#show_receipt_recent openapi_auth=basic response=default
-POST   /receipt/:key/burn                    V1::Controllers::Index#burn_secret  openapi_auth=basic,anonymous content=form response=default
-GET    /receipt/:key                         V1::Controllers::Index#show_receipt openapi_auth=basic,anonymous response=default
-POST   /receipt/:key                         V1::Controllers::Index#show_receipt openapi_auth=basic,anonymous content=form response=default
+POST   /receipt/:key/burn                    V1::Controllers::Index#burn_secret  openapi_auth=basic,anonymous content=form response=default sensitive=true
+GET    /receipt/:key                         V1::Controllers::Index#show_receipt openapi_auth=basic,anonymous response=default sensitive=true
+POST   /receipt/:key                         V1::Controllers::Index#show_receipt openapi_auth=basic,anonymous content=form response=default sensitive=true
 
 # Legacy aliases — use /receipt/ paths instead
 GET    /private/recent                       V1::Controllers::Index#show_receipt_recent openapi_auth=basic response=default deprecated=true
-POST   /private/:key/burn                    V1::Controllers::Index#burn_secret  openapi_auth=basic,anonymous content=form response=default deprecated=true
-GET    /private/:key                         V1::Controllers::Index#show_receipt openapi_auth=basic,anonymous response=default deprecated=true
-POST   /private/:key                         V1::Controllers::Index#show_receipt openapi_auth=basic,anonymous content=form response=default deprecated=true
+POST   /private/:key/burn                    V1::Controllers::Index#burn_secret  openapi_auth=basic,anonymous content=form response=default deprecated=true sensitive=true
+GET    /private/:key                         V1::Controllers::Index#show_receipt openapi_auth=basic,anonymous response=default deprecated=true sensitive=true
+POST   /private/:key                         V1::Controllers::Index#show_receipt openapi_auth=basic,anonymous content=form response=default deprecated=true sensitive=true
 
 GET    /metadata/recent                      V1::Controllers::Index#show_receipt_recent openapi_auth=basic response=default deprecated=true
-POST   /metadata/:key/burn                   V1::Controllers::Index#burn_secret  openapi_auth=basic,anonymous content=form response=default deprecated=true
-GET    /metadata/:key                        V1::Controllers::Index#show_receipt openapi_auth=basic,anonymous response=default deprecated=true
-POST   /metadata/:key                        V1::Controllers::Index#show_receipt openapi_auth=basic,anonymous content=form response=default deprecated=true
+POST   /metadata/:key/burn                   V1::Controllers::Index#burn_secret  openapi_auth=basic,anonymous content=form response=default deprecated=true sensitive=true
+GET    /metadata/:key                        V1::Controllers::Index#show_receipt openapi_auth=basic,anonymous response=default deprecated=true sensitive=true
+POST   /metadata/:key                        V1::Controllers::Index#show_receipt openapi_auth=basic,anonymous content=form response=default deprecated=true sensitive=true

--- a/apps/api/v2/routes.txt
+++ b/apps/api/v2/routes.txt
@@ -7,31 +7,31 @@
 
 # Receipts (creator-facing secret metadata)
 GET    /receipt/recent                            V2::Logic::Secrets::ListReceipts response=json auth=basicauth
-POST   /receipt/:identifier/burn                  V2::Logic::Secrets::BurnSecret response=json auth=basicauth,noauth
-GET    /receipt/:identifier                       V2::Logic::Secrets::ShowReceipt response=json auth=basicauth,noauth
-PATCH  /receipt/:identifier                       V2::Logic::Secrets::UpdateReceipt response=json auth=basicauth,noauth
+POST   /receipt/:identifier/burn                  V2::Logic::Secrets::BurnSecret response=json auth=basicauth,noauth sensitive=true
+GET    /receipt/:identifier                       V2::Logic::Secrets::ShowReceipt response=json auth=basicauth,noauth sensitive=true
+PATCH  /receipt/:identifier                       V2::Logic::Secrets::UpdateReceipt response=json auth=basicauth,noauth sensitive=true
 
 # Legacy aliases — use /receipt/ paths instead
 GET    /private/recent                            V2::Logic::Secrets::ListReceipts response=json auth=basicauth deprecated=true
-POST   /private/:identifier/burn                  V2::Logic::Secrets::BurnSecret response=json auth=basicauth,noauth deprecated=true
-GET    /private/:identifier                       V2::Logic::Secrets::ShowReceipt response=json auth=basicauth,noauth deprecated=true
-PATCH  /private/:identifier                       V2::Logic::Secrets::UpdateReceipt response=json auth=basicauth,noauth deprecated=true
+POST   /private/:identifier/burn                  V2::Logic::Secrets::BurnSecret response=json auth=basicauth,noauth deprecated=true sensitive=true
+GET    /private/:identifier                       V2::Logic::Secrets::ShowReceipt response=json auth=basicauth,noauth deprecated=true sensitive=true
+PATCH  /private/:identifier                       V2::Logic::Secrets::UpdateReceipt response=json auth=basicauth,noauth deprecated=true sensitive=true
 
 # Secrets - Public (Anonymous allowed)
-GET    /secret/:identifier                        V2::Logic::Secrets::ShowSecret response=json auth=basicauth,noauth
-GET    /secret/:identifier/status                 V2::Logic::Secrets::ShowSecretStatus response=json auth=basicauth,noauth
+GET    /secret/:identifier                        V2::Logic::Secrets::ShowSecret response=json auth=basicauth,noauth sensitive=true
+GET    /secret/:identifier/status                 V2::Logic::Secrets::ShowSecretStatus response=json auth=basicauth,noauth sensitive=true
 POST   /secret/status                             V2::Logic::Secrets::ListSecretStatus response=json auth=basicauth,noauth
-POST   /secret/:identifier/reveal                 V2::Logic::Secrets::RevealSecret response=json auth=basicauth,noauth
+POST   /secret/:identifier/reveal                 V2::Logic::Secrets::RevealSecret response=json auth=basicauth,noauth sensitive=true
 POST   /secret/generate                           V2::Logic::Secrets::GenerateSecret response=json auth=basicauth,noauth
 POST   /secret/conceal                            V2::Logic::Secrets::ConcealSecret response=json auth=basicauth,noauth
 
 # Guest routes (anonymous access with GuestRouteGating)
 POST   /guest/secret/conceal                      V2::Logic::Secrets::ConcealSecret response=json auth=noauth
 POST   /guest/secret/generate                     V2::Logic::Secrets::GenerateSecret response=json auth=noauth
-GET    /guest/secret/:identifier                  V2::Logic::Secrets::ShowSecret response=json auth=noauth
-POST   /guest/secret/:identifier/reveal           V2::Logic::Secrets::RevealSecret response=json auth=noauth
-GET    /guest/receipt/:identifier                 V2::Logic::Secrets::ShowReceipt response=json auth=noauth
-POST   /guest/receipt/:identifier/burn            V2::Logic::Secrets::BurnSecret response=json auth=noauth
+GET    /guest/secret/:identifier                  V2::Logic::Secrets::ShowSecret response=json auth=noauth sensitive=true
+POST   /guest/secret/:identifier/reveal           V2::Logic::Secrets::RevealSecret response=json auth=noauth sensitive=true
+GET    /guest/receipt/:identifier                 V2::Logic::Secrets::ShowReceipt response=json auth=noauth sensitive=true
+POST   /guest/receipt/:identifier/burn            V2::Logic::Secrets::BurnSecret response=json auth=noauth sensitive=true
 
 # OPTIONS preflight for CORS (public)
 OPTIONS /secret/generate                          V2::Logic::Secrets::GenerateSecret response=json

--- a/apps/api/v3/routes.txt
+++ b/apps/api/v3/routes.txt
@@ -9,16 +9,16 @@
 
 # Secrets - Authenticated (require session)
 GET    /receipt/recent                            V3::Logic::Secrets::ListReceipts response=json auth=sessionauth
-GET    /receipt/:identifier                       V3::Logic::Secrets::ShowReceipt response=json auth=sessionauth
-PATCH  /receipt/:identifier                       V3::Logic::Secrets::UpdateReceipt response=json auth=sessionauth
-POST   /receipt/:identifier/burn                  V3::Logic::Secrets::BurnSecret response=json auth=sessionauth
+GET    /receipt/:identifier                       V3::Logic::Secrets::ShowReceipt response=json auth=sessionauth sensitive=true
+PATCH  /receipt/:identifier                       V3::Logic::Secrets::UpdateReceipt response=json auth=sessionauth sensitive=true
+POST   /receipt/:identifier/burn                  V3::Logic::Secrets::BurnSecret response=json auth=sessionauth sensitive=true
 POST   /secret/conceal                            V3::Logic::Secrets::ConcealSecret response=json auth=sessionauth
 POST   /secret/generate                           V3::Logic::Secrets::GenerateSecret response=json auth=sessionauth
-GET    /secret/:identifier                        V3::Logic::Secrets::ShowSecret response=json auth=sessionauth
-POST   /secret/:identifier/reveal                 V3::Logic::Secrets::RevealSecret response=json auth=sessionauth
+GET    /secret/:identifier                        V3::Logic::Secrets::ShowSecret response=json auth=sessionauth sensitive=true
+POST   /secret/:identifier/reveal                 V3::Logic::Secrets::RevealSecret response=json auth=sessionauth sensitive=true
 
 # Meta/Public endpoints (static information, no auth required)
-GET    /secret/:identifier/status                 V3::Logic::Secrets::ShowSecretStatus response=json auth=noauth
+GET    /secret/:identifier/status                 V3::Logic::Secrets::ShowSecretStatus response=json auth=noauth sensitive=true
 POST   /secret/status                             V3::Logic::Secrets::ListSecretStatus response=json auth=noauth
 
 # OPTIONS preflight for CORS (public)
@@ -28,10 +28,10 @@ OPTIONS /secret/conceal                           V3::Logic::Secrets::ConcealSec
 # Guest routes (anonymous access with GuestRouteGating)
 POST   /guest/secret/conceal                      V3::Logic::Secrets::ConcealSecret response=json auth=noauth
 POST   /guest/secret/generate                     V3::Logic::Secrets::GenerateSecret response=json auth=noauth
-GET    /guest/secret/:identifier                  V3::Logic::Secrets::ShowSecret response=json auth=noauth
-POST   /guest/secret/:identifier/reveal           V3::Logic::Secrets::RevealSecret response=json auth=noauth
-GET    /guest/receipt/:identifier                 V3::Logic::Secrets::ShowReceipt response=json auth=noauth
-POST   /guest/receipt/:identifier/burn            V3::Logic::Secrets::BurnSecret response=json auth=noauth
+GET    /guest/secret/:identifier                  V3::Logic::Secrets::ShowSecret response=json auth=noauth sensitive=true
+POST   /guest/secret/:identifier/reveal           V3::Logic::Secrets::RevealSecret response=json auth=noauth sensitive=true
+GET    /guest/receipt/:identifier                 V3::Logic::Secrets::ShowReceipt response=json auth=noauth sensitive=true
+POST   /guest/receipt/:identifier/burn            V3::Logic::Secrets::BurnSecret response=json auth=noauth sensitive=true
 POST   /guest/receipts                            V3::Logic::Secrets::ShowMultipleReceipts response=json auth=noauth
 
 # Meta/Public endpoints (static information uses class methods)

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "locales:hashes:dry-run": "python3 locales/scripts/add_hashes.py --dry-run",
     "locales:sync": "python3 locales/scripts/build/compile.py --all --merged",
     "openapi:generate": "tsx --tsconfig scripts/tsconfig.json scripts/openapi/generate-openapi.ts",
+    "generate:sentry-patterns": "tsx --tsconfig scripts/tsconfig.json scripts/generate-sentry-scrub-patterns.ts",
     "schemas:scan": "tsx --tsconfig scripts/tsconfig.json scripts/openapi/schema-scanner.ts",
     "schemas:json:generate": "tsx --tsconfig scripts/tsconfig.json scripts/json-schema/generate.ts",
     "schemas:json:generate:dry-run": "tsx --tsconfig scripts/tsconfig.json scripts/json-schema/generate.ts --dry-run",

--- a/scripts/generate-sentry-scrub-patterns.ts
+++ b/scripts/generate-sentry-scrub-patterns.ts
@@ -1,0 +1,247 @@
+#!/usr/bin/env tsx
+
+// scripts/generate-sentry-scrub-patterns.ts
+
+/**
+ * Sentry Scrub Patterns Generator
+ *
+ * Generates TypeScript patterns for scrubbing sensitive path segments from URLs.
+ * Reads Otto routes annotated with sensitive=true and produces regex patterns
+ * that the frontend can use to redact identifiers before sending to Sentry.
+ *
+ * Usage:
+ *   pnpm run generate:sentry-patterns              # Generate patterns
+ *   pnpm run generate:sentry-patterns -- --dry-run # Preview without writing
+ *   pnpm run generate:sentry-patterns -- --verbose # Show each sensitive route
+ */
+
+import { existsSync, mkdirSync, writeFileSync } from 'fs';
+import { dirname, join } from 'path';
+
+import { parseAllApiRoutes, type OttoRoute } from './openapi/otto-routes-parser';
+
+// =============================================================================
+// Configuration
+// =============================================================================
+
+const OUTPUT_DIR = join(process.cwd(), 'src', 'generated');
+const OUTPUT_FILE = join(OUTPUT_DIR, 'sentry-scrub-patterns.ts');
+const DRY_RUN = process.argv.includes('--dry-run');
+const VERBOSE = process.argv.includes('--verbose') || process.argv.includes('-v');
+
+/** Maps API directory name to its mount path prefix */
+const API_MOUNT_PATHS: Record<string, string> = {
+  v1: '/api/v1',
+  v2: '/api/v2',
+  v3: '/api/v3',
+  account: '/api/account',
+  colonel: '/api/colonel',
+  domains: '/api/domains',
+  organizations: '/api/organizations',
+  invite: '/api/invite',
+  incoming: '/api/incoming',
+};
+
+// =============================================================================
+// Pattern Generation
+// =============================================================================
+
+interface SensitiveRoute {
+  apiName: string;
+  method: string;
+  fullPath: string;
+  pathParams: string[];
+  route: OttoRoute;
+}
+
+/**
+ * Extract path parameters from a route path.
+ * Example: /secret/:identifier -> ['identifier']
+ */
+function getPathParams(path: string): string[] {
+  const params: string[] = [];
+  const matches = path.matchAll(/:(\w+)/g);
+  for (const match of matches) {
+    params.push(match[1]);
+  }
+  return params;
+}
+
+/**
+ * Convert a route path to a regex pattern string.
+ * Replaces :param with a capture group for alphanumeric identifiers.
+ *
+ * Example: /secret/:identifier -> \/secret\/([a-zA-Z0-9]+)
+ */
+function pathToRegexPattern(path: string): string {
+  // Escape forward slashes and replace :param with capture group
+  return path
+    .replace(/\//g, '\\/')
+    .replace(/:(\w+)/g, '([a-zA-Z0-9]+)');
+}
+
+/**
+ * Filter routes to only those marked as sensitive.
+ */
+function filterSensitiveRoutes(
+  allRoutes: Record<string, { routes: OttoRoute[] }>
+): SensitiveRoute[] {
+  const sensitiveRoutes: SensitiveRoute[] = [];
+
+  for (const [apiName, parsed] of Object.entries(allRoutes)) {
+    const mountPath = API_MOUNT_PATHS[apiName] || `/api/${apiName}`;
+
+    for (const route of parsed.routes) {
+      // Check if route is marked as sensitive
+      if (route.params.sensitive) {
+        const fullPath = mountPath + route.path;
+        sensitiveRoutes.push({
+          apiName,
+          method: route.method,
+          fullPath,
+          pathParams: getPathParams(route.path),
+          route,
+        });
+      }
+    }
+  }
+
+  return sensitiveRoutes;
+}
+
+/**
+ * Deduplicate patterns by their regex string.
+ * Multiple routes may produce the same pattern (e.g., GET and POST on same path).
+ */
+function deduplicatePatterns(routes: SensitiveRoute[]): Map<string, SensitiveRoute> {
+  const seen = new Map<string, SensitiveRoute>();
+
+  for (const route of routes) {
+    const pattern = pathToRegexPattern(route.fullPath);
+    if (!seen.has(pattern)) {
+      seen.set(pattern, route);
+    }
+  }
+
+  return seen;
+}
+
+/**
+ * Generate the TypeScript output file content.
+ */
+function generateOutput(patterns: Map<string, SensitiveRoute>): string {
+  const sortedPatterns = Array.from(patterns.entries()).sort((a, b) =>
+    a[1].fullPath.localeCompare(b[1].fullPath)
+  );
+
+  const patternLines = sortedPatterns.map(([pattern, route]) => {
+    const comment = `  // ${route.fullPath}`;
+    const regex = `  /${pattern}/gi,`;
+    return `${comment}\n${regex}`;
+  });
+
+  return `// Auto-generated from routes with sensitive=true metadata
+// Do not edit manually - regenerate with: pnpm run generate:sentry-patterns
+// Generated: ${new Date().toISOString()}
+
+/**
+ * Regex patterns for scrubbing sensitive path segments from URLs.
+ * Derived from Otto routes marked with sensitive=true.
+ *
+ * These patterns match API paths that contain sensitive identifiers
+ * (secret keys, receipt identifiers, etc.) and capture those identifiers
+ * for replacement with [REDACTED].
+ */
+export const SENSITIVE_PATH_PATTERNS: RegExp[] = [
+${patternLines.join('\n')}
+];
+
+/**
+ * Scrub sensitive identifiers from a URL path.
+ * Replaces captured groups with [REDACTED].
+ *
+ * @param url - The URL string to scrub
+ * @returns The scrubbed URL with sensitive identifiers replaced
+ *
+ * @example
+ * scrubSensitivePath('/api/v1/secret/abc123') // => '/api/v1/secret/[REDACTED]'
+ * scrubSensitivePath('/api/v3/receipt/xyz789/burn') // => '/api/v3/receipt/[REDACTED]/burn'
+ */
+export function scrubSensitivePath(url: string): string {
+  let result = url;
+  for (const pattern of SENSITIVE_PATH_PATTERNS) {
+    pattern.lastIndex = 0; // Reset global regex state
+    result = result.replace(pattern, (match, ...groups) => {
+      // Replace each captured group with [REDACTED]
+      let scrubbed = match;
+      for (const group of groups) {
+        if (typeof group === 'string') {
+          scrubbed = scrubbed.replace(group, '[REDACTED]');
+        }
+      }
+      return scrubbed;
+    });
+  }
+  return result;
+}
+`;
+}
+
+// =============================================================================
+// Main
+// =============================================================================
+
+function main(): void {
+  console.log('Generating Sentry scrub patterns from routes.txt...\n');
+
+  if (DRY_RUN) {
+    console.log('  [dry-run mode - no files will be written]\n');
+  }
+
+  // Parse all API routes
+  const allRoutes = parseAllApiRoutes();
+
+  // Filter to sensitive routes only
+  const sensitiveRoutes = filterSensitiveRoutes(allRoutes);
+
+  if (VERBOSE) {
+    console.log('\nSensitive routes found:');
+    for (const route of sensitiveRoutes) {
+      const params = route.pathParams.length > 0
+        ? ` (params: ${route.pathParams.join(', ')})`
+        : '';
+      console.log(`  ${route.method.padEnd(6)} ${route.fullPath}${params}`);
+    }
+  }
+
+  // Deduplicate patterns
+  const uniquePatterns = deduplicatePatterns(sensitiveRoutes);
+
+  // Generate output
+  const output = generateOutput(uniquePatterns);
+
+  if (DRY_RUN) {
+    console.log('\n--- Generated output (preview) ---\n');
+    console.log(output);
+    console.log('--- End preview ---\n');
+  } else {
+    // Ensure output directory exists
+    if (!existsSync(OUTPUT_DIR)) {
+      mkdirSync(OUTPUT_DIR, { recursive: true });
+      console.log(`Created directory: ${OUTPUT_DIR}`);
+    }
+
+    // Write the output file
+    writeFileSync(OUTPUT_FILE, output);
+    console.log(`\nWrote: ${OUTPUT_FILE}`);
+  }
+
+  // Summary
+  console.log('\nSummary');
+  console.log('-------------------');
+  console.log(`Total sensitive routes: ${sensitiveRoutes.length}`);
+  console.log(`Unique patterns:        ${uniquePatterns.size}`);
+  console.log(DRY_RUN ? '\nDry run complete. No files written.' : '\nPatterns generated.');
+}
+
+main();

--- a/scripts/generate-sentry-scrub-patterns.ts
+++ b/scripts/generate-sentry-scrub-patterns.ts
@@ -74,8 +74,11 @@ function getPathParams(path: string): string[] {
  * Example: /secret/:identifier -> \/secret\/([a-zA-Z0-9]+)
  */
 function pathToRegexPattern(path: string): string {
-  // Escape forward slashes and replace :param with capture group
+  // Escape regex special characters, then replace :param with capture group.
+  // Backslashes first (before they could be introduced by other escapes),
+  // then forward slashes, then parameter placeholders.
   return path
+    .replace(/\\/g, '\\\\')
     .replace(/\//g, '\\/')
     .replace(/:(\w+)/g, '([a-zA-Z0-9]+)');
 }
@@ -171,10 +174,11 @@ export function scrubSensitivePath(url: string): string {
   let result = url;
   for (const pattern of SENSITIVE_PATH_PATTERNS) {
     pattern.lastIndex = 0; // Reset global regex state
-    result = result.replace(pattern, (match, ...groups) => {
-      // Replace each captured group with [REDACTED]
+    result = result.replace(pattern, (match, ...args) => {
+      // args contains [p1, ..., pN, offset, originalString] — slice off last 2
+      const captureGroups = args.slice(0, -2);
       let scrubbed = match;
-      for (const group of groups) {
+      for (const group of captureGroups) {
         if (typeof group === 'string') {
           scrubbed = scrubbed.replace(group, '[REDACTED]');
         }

--- a/scripts/openapi/generate-openapi.ts
+++ b/scripts/openapi/generate-openapi.ts
@@ -593,10 +593,17 @@ function buildOperation(route: OttoRoute, apiName: string): Record<string, unkno
   // Emit custom route params as x-o-route-* extensions.
   // Reserved params (consumed by the generator for structural purposes)
   // are excluded — only domain-specific annotations pass through.
-  const RESERVED_PARAMS = new Set(['response', 'auth', 'content', 'csrf', 'deprecated']);
+  const RESERVED_PARAMS = new Set(['response', 'auth', 'content', 'csrf', 'deprecated', 'sensitive']);
   for (const [key, value] of Object.entries(route.params)) {
     if (RESERVED_PARAMS.has(key)) continue;
     operation[`x-otto-route-${key}`] = value;
+  }
+
+  // Emit sensitive param as x-sensitive extension for downstream consumers
+  if (route.params.sensitive) {
+    operation['x-sensitive'] = route.params.sensitive === 'true'
+      ? true
+      : route.params.sensitive.split(',');
   }
 
   // Add security

--- a/src/generated/sentry-scrub-patterns.ts
+++ b/src/generated/sentry-scrub-patterns.ts
@@ -1,0 +1,97 @@
+// Auto-generated from routes with sensitive=true metadata
+// Do not edit manually - regenerate with: pnpm run generate:sentry-patterns
+// Generated: 2026-04-15T07:09:11.966Z
+
+/**
+ * Regex patterns for scrubbing sensitive path segments from URLs.
+ * Derived from Otto routes marked with sensitive=true.
+ *
+ * These patterns match API paths that contain sensitive identifiers
+ * (secret keys, receipt identifiers, etc.) and capture those identifiers
+ * for replacement with [REDACTED].
+ */
+export const SENSITIVE_PATH_PATTERNS: RegExp[] = [
+  // /api/v1/metadata/:key
+  /\/api\/v1\/metadata\/([a-zA-Z0-9]+)/gi,
+  // /api/v1/metadata/:key/burn
+  /\/api\/v1\/metadata\/([a-zA-Z0-9]+)\/burn/gi,
+  // /api/v1/private/:key
+  /\/api\/v1\/private\/([a-zA-Z0-9]+)/gi,
+  // /api/v1/private/:key/burn
+  /\/api\/v1\/private\/([a-zA-Z0-9]+)\/burn/gi,
+  // /api/v1/receipt/:key
+  /\/api\/v1\/receipt\/([a-zA-Z0-9]+)/gi,
+  // /api/v1/receipt/:key/burn
+  /\/api\/v1\/receipt\/([a-zA-Z0-9]+)\/burn/gi,
+  // /api/v1/secret/:key
+  /\/api\/v1\/secret\/([a-zA-Z0-9]+)/gi,
+  // /api/v2/guest/receipt/:identifier
+  /\/api\/v2\/guest\/receipt\/([a-zA-Z0-9]+)/gi,
+  // /api/v2/guest/receipt/:identifier/burn
+  /\/api\/v2\/guest\/receipt\/([a-zA-Z0-9]+)\/burn/gi,
+  // /api/v2/guest/secret/:identifier
+  /\/api\/v2\/guest\/secret\/([a-zA-Z0-9]+)/gi,
+  // /api/v2/guest/secret/:identifier/reveal
+  /\/api\/v2\/guest\/secret\/([a-zA-Z0-9]+)\/reveal/gi,
+  // /api/v2/private/:identifier
+  /\/api\/v2\/private\/([a-zA-Z0-9]+)/gi,
+  // /api/v2/private/:identifier/burn
+  /\/api\/v2\/private\/([a-zA-Z0-9]+)\/burn/gi,
+  // /api/v2/receipt/:identifier
+  /\/api\/v2\/receipt\/([a-zA-Z0-9]+)/gi,
+  // /api/v2/receipt/:identifier/burn
+  /\/api\/v2\/receipt\/([a-zA-Z0-9]+)\/burn/gi,
+  // /api/v2/secret/:identifier
+  /\/api\/v2\/secret\/([a-zA-Z0-9]+)/gi,
+  // /api/v2/secret/:identifier/reveal
+  /\/api\/v2\/secret\/([a-zA-Z0-9]+)\/reveal/gi,
+  // /api/v2/secret/:identifier/status
+  /\/api\/v2\/secret\/([a-zA-Z0-9]+)\/status/gi,
+  // /api/v3/guest/receipt/:identifier
+  /\/api\/v3\/guest\/receipt\/([a-zA-Z0-9]+)/gi,
+  // /api/v3/guest/receipt/:identifier/burn
+  /\/api\/v3\/guest\/receipt\/([a-zA-Z0-9]+)\/burn/gi,
+  // /api/v3/guest/secret/:identifier
+  /\/api\/v3\/guest\/secret\/([a-zA-Z0-9]+)/gi,
+  // /api/v3/guest/secret/:identifier/reveal
+  /\/api\/v3\/guest\/secret\/([a-zA-Z0-9]+)\/reveal/gi,
+  // /api/v3/receipt/:identifier
+  /\/api\/v3\/receipt\/([a-zA-Z0-9]+)/gi,
+  // /api/v3/receipt/:identifier/burn
+  /\/api\/v3\/receipt\/([a-zA-Z0-9]+)\/burn/gi,
+  // /api/v3/secret/:identifier
+  /\/api\/v3\/secret\/([a-zA-Z0-9]+)/gi,
+  // /api/v3/secret/:identifier/reveal
+  /\/api\/v3\/secret\/([a-zA-Z0-9]+)\/reveal/gi,
+  // /api/v3/secret/:identifier/status
+  /\/api\/v3\/secret\/([a-zA-Z0-9]+)\/status/gi,
+];
+
+/**
+ * Scrub sensitive identifiers from a URL path.
+ * Replaces captured groups with [REDACTED].
+ *
+ * @param url - The URL string to scrub
+ * @returns The scrubbed URL with sensitive identifiers replaced
+ *
+ * @example
+ * scrubSensitivePath('/api/v1/secret/abc123') // => '/api/v1/secret/[REDACTED]'
+ * scrubSensitivePath('/api/v3/receipt/xyz789/burn') // => '/api/v3/receipt/[REDACTED]/burn'
+ */
+export function scrubSensitivePath(url: string): string {
+  let result = url;
+  for (const pattern of SENSITIVE_PATH_PATTERNS) {
+    pattern.lastIndex = 0; // Reset global regex state
+    result = result.replace(pattern, (match, ...groups) => {
+      // Replace each captured group with [REDACTED]
+      let scrubbed = match;
+      for (const group of groups) {
+        if (typeof group === 'string') {
+          scrubbed = scrubbed.replace(group, '[REDACTED]');
+        }
+      }
+      return scrubbed;
+    });
+  }
+  return result;
+}

--- a/src/generated/sentry-scrub-patterns.ts
+++ b/src/generated/sentry-scrub-patterns.ts
@@ -82,10 +82,11 @@ export function scrubSensitivePath(url: string): string {
   let result = url;
   for (const pattern of SENSITIVE_PATH_PATTERNS) {
     pattern.lastIndex = 0; // Reset global regex state
-    result = result.replace(pattern, (match, ...groups) => {
-      // Replace each captured group with [REDACTED]
+    result = result.replace(pattern, (match, ...args) => {
+      // args contains [p1, ..., pN, offset, originalString] — slice off last 2
+      const captureGroups = args.slice(0, -2);
       let scrubbed = match;
-      for (const group of groups) {
+      for (const group of captureGroups) {
         if (typeof group === 'string') {
           scrubbed = scrubbed.replace(group, '[REDACTED]');
         }

--- a/src/plugins/core/diagnostics/scrubbers.ts
+++ b/src/plugins/core/diagnostics/scrubbers.ts
@@ -8,8 +8,10 @@
 // - Sentry beforeBreadcrumb handler
 // - Sentry beforeSend handler
 
+import { scrubSensitivePath } from '@/generated/sentry-scrub-patterns';
+
 /**
- * Pattern for known sensitive URL paths.
+ * Legacy pattern for known sensitive URL paths.
  * Matches path segments that contain tokens or identifiers:
  * - /secret/, /private/, /receipt/, /incoming/ - core secret paths
  * - /invite/ - invitation tokens
@@ -18,6 +20,9 @@
  * Note: Some auth routes use query params instead of path params:
  * - /reset-password?key=... - handled by query param scrubbing
  * - /verify-account?token=... - handled by query param scrubbing
+ *
+ * @deprecated Use scrubSensitivePath() from generated patterns instead.
+ * Kept as fallback for paths not covered by route-derived patterns.
  *
  * @internal Exported for testing
  */
@@ -65,7 +70,10 @@ export function scrubSensitiveStrings(text: string): string {
   // Scrub 62-char verifiable IDs
   result = result.replace(VERIFIABLE_ID_PATTERN, '[REDACTED]');
 
-  // Scrub sensitive path patterns (in case exception message contains URLs/paths)
+  // Scrub sensitive path patterns using generated route-derived patterns
+  result = scrubSensitivePath(result);
+
+  // Fallback: scrub any remaining sensitive paths not covered by generated patterns
   result = result.replace(SENSITIVE_PATH_PATTERN, '/$1/[REDACTED]');
 
   return result;
@@ -90,13 +98,16 @@ export function scrubUrlWithPatterns(url: string): string {
 
   let result = url;
 
-  // First pass: scrub known sensitive path patterns
+  // First pass: scrub using generated route-derived patterns
+  result = scrubSensitivePath(result);
+
+  // Second pass: fallback for paths not covered by generated patterns
   result = result.replace(SENSITIVE_PATH_PATTERN, '/$1/[REDACTED]');
 
-  // Second pass: scrub any remaining 62-char verifiable IDs
+  // Third pass: scrub any remaining 62-char verifiable IDs
   result = result.replace(VERIFIABLE_ID_PATTERN, '[REDACTED]');
 
-  // Third pass: scrub email addresses (e.g., in query params like ?email=user@example.com)
+  // Fourth pass: scrub email addresses (e.g., in query params like ?email=user@example.com)
   result = result.replace(EMAIL_PATTERN, '[EMAIL REDACTED]');
 
   return result;

--- a/src/plugins/core/diagnostics/scrubbers.ts
+++ b/src/plugins/core/diagnostics/scrubbers.ts
@@ -11,19 +11,20 @@
 import { scrubSensitivePath } from '@/generated/sentry-scrub-patterns';
 
 /**
- * Legacy pattern for known sensitive URL paths.
- * Matches path segments that contain tokens or identifiers:
+ * Legacy fallback pattern for sensitive URL paths.
+ *
+ * Current approach uses deterministic route metadata (fail-safe, opt-out):
+ * - Frontend: src/routes/index.ts route definitions with scrub metadata
+ * - Backend: Otto routes with `sensitive=true` annotation, e.g.:
+ *   `GET /receipt/:identifier ... sensitive=true`
+ *
+ * This regex catches paths missed by route-derived patterns:
  * - /secret/, /private/, /receipt/, /incoming/ - core secret paths
  * - /invite/ - invitation tokens
- * - /account/email/confirm/ - email confirmation tokens (matched as /account/ then /confirm/)
+ * - /confirm/ - email confirmation tokens
  *
- * Note: Some auth routes use query params instead of path params:
- * - /reset-password?key=... - handled by query param scrubbing
- * - /verify-account?token=... - handled by query param scrubbing
- *
- * @deprecated Use scrubSensitivePath() from generated patterns instead.
- * Kept as fallback for paths not covered by route-derived patterns.
- *
+ * @see scrubSensitivePath - generated patterns from route metadata
+ * @see src/generated/sentry-scrub-patterns.ts - generated output
  * @internal Exported for testing
  */
 export const SENSITIVE_PATH_PATTERN =

--- a/src/tests/generated/sentry-scrub-patterns.spec.ts
+++ b/src/tests/generated/sentry-scrub-patterns.spec.ts
@@ -1,0 +1,273 @@
+// src/tests/generated/sentry-scrub-patterns.spec.ts
+//
+// Tests for the auto-generated Sentry scrub patterns.
+// These tests verify that scrubSensitivePath() correctly redacts sensitive
+// identifiers from API paths derived from route metadata.
+//
+// Run:
+//   pnpm test src/tests/generated/sentry-scrub-patterns.spec.ts
+
+import { describe, it, expect } from 'vitest';
+import {
+  scrubSensitivePath,
+  SENSITIVE_PATH_PATTERNS,
+} from '@/generated/sentry-scrub-patterns';
+
+describe('generated sentry-scrub-patterns', () => {
+  describe('SENSITIVE_PATH_PATTERNS', () => {
+    it('exports an array of RegExp patterns', () => {
+      expect(Array.isArray(SENSITIVE_PATH_PATTERNS)).toBe(true);
+      expect(SENSITIVE_PATH_PATTERNS.length).toBeGreaterThan(0);
+      SENSITIVE_PATH_PATTERNS.forEach((pattern) => {
+        expect(pattern).toBeInstanceOf(RegExp);
+      });
+    });
+
+    it('contains patterns for v1, v2, and v3 APIs', () => {
+      const patternStrings = SENSITIVE_PATH_PATTERNS.map((p) => p.source);
+      expect(patternStrings.some((s) => s.includes('api\\/v1'))).toBe(true);
+      expect(patternStrings.some((s) => s.includes('api\\/v2'))).toBe(true);
+      expect(patternStrings.some((s) => s.includes('api\\/v3'))).toBe(true);
+    });
+  });
+
+  describe('scrubSensitivePath', () => {
+    describe('v1 API paths', () => {
+      it('scrubs /api/v1/secret/:key', () => {
+        expect(scrubSensitivePath('/api/v1/secret/abc123')).toBe(
+          '/api/v1/secret/[REDACTED]'
+        );
+      });
+
+      it('scrubs /api/v1/metadata/:key', () => {
+        expect(scrubSensitivePath('/api/v1/metadata/xyz789')).toBe(
+          '/api/v1/metadata/[REDACTED]'
+        );
+      });
+
+      it('scrubs /api/v1/metadata/:key/burn', () => {
+        expect(scrubSensitivePath('/api/v1/metadata/abc123/burn')).toBe(
+          '/api/v1/metadata/[REDACTED]/burn'
+        );
+      });
+
+      it('scrubs /api/v1/private/:key', () => {
+        expect(scrubSensitivePath('/api/v1/private/secretkey')).toBe(
+          '/api/v1/private/[REDACTED]'
+        );
+      });
+
+      it('scrubs /api/v1/private/:key/burn', () => {
+        expect(scrubSensitivePath('/api/v1/private/secretkey/burn')).toBe(
+          '/api/v1/private/[REDACTED]/burn'
+        );
+      });
+
+      it('scrubs /api/v1/receipt/:key', () => {
+        expect(scrubSensitivePath('/api/v1/receipt/receipt123')).toBe(
+          '/api/v1/receipt/[REDACTED]'
+        );
+      });
+
+      it('scrubs /api/v1/receipt/:key/burn', () => {
+        expect(scrubSensitivePath('/api/v1/receipt/receipt123/burn')).toBe(
+          '/api/v1/receipt/[REDACTED]/burn'
+        );
+      });
+    });
+
+    describe('v2 API paths', () => {
+      it('scrubs /api/v2/secret/:identifier', () => {
+        expect(scrubSensitivePath('/api/v2/secret/identifier123')).toBe(
+          '/api/v2/secret/[REDACTED]'
+        );
+      });
+
+      it('scrubs /api/v2/secret/:identifier/reveal', () => {
+        expect(scrubSensitivePath('/api/v2/secret/identifier123/reveal')).toBe(
+          '/api/v2/secret/[REDACTED]/reveal'
+        );
+      });
+
+      it('scrubs /api/v2/secret/:identifier/status', () => {
+        expect(scrubSensitivePath('/api/v2/secret/identifier123/status')).toBe(
+          '/api/v2/secret/[REDACTED]/status'
+        );
+      });
+
+      it('scrubs /api/v2/private/:identifier', () => {
+        expect(scrubSensitivePath('/api/v2/private/privatekey')).toBe(
+          '/api/v2/private/[REDACTED]'
+        );
+      });
+
+      it('scrubs /api/v2/private/:identifier/burn', () => {
+        expect(scrubSensitivePath('/api/v2/private/privatekey/burn')).toBe(
+          '/api/v2/private/[REDACTED]/burn'
+        );
+      });
+
+      it('scrubs /api/v2/receipt/:identifier', () => {
+        expect(scrubSensitivePath('/api/v2/receipt/receipt456')).toBe(
+          '/api/v2/receipt/[REDACTED]'
+        );
+      });
+
+      it('scrubs /api/v2/receipt/:identifier/burn', () => {
+        expect(scrubSensitivePath('/api/v2/receipt/receipt456/burn')).toBe(
+          '/api/v2/receipt/[REDACTED]/burn'
+        );
+      });
+
+      it('scrubs /api/v2/guest/secret/:identifier', () => {
+        expect(scrubSensitivePath('/api/v2/guest/secret/guestsecret')).toBe(
+          '/api/v2/guest/secret/[REDACTED]'
+        );
+      });
+
+      it('scrubs /api/v2/guest/secret/:identifier/reveal', () => {
+        expect(
+          scrubSensitivePath('/api/v2/guest/secret/guestsecret/reveal')
+        ).toBe('/api/v2/guest/secret/[REDACTED]/reveal');
+      });
+
+      it('scrubs /api/v2/guest/receipt/:identifier', () => {
+        expect(scrubSensitivePath('/api/v2/guest/receipt/guestreceipt')).toBe(
+          '/api/v2/guest/receipt/[REDACTED]'
+        );
+      });
+
+      it('scrubs /api/v2/guest/receipt/:identifier/burn', () => {
+        expect(
+          scrubSensitivePath('/api/v2/guest/receipt/guestreceipt/burn')
+        ).toBe('/api/v2/guest/receipt/[REDACTED]/burn');
+      });
+    });
+
+    describe('v3 API paths', () => {
+      it('scrubs /api/v3/secret/:identifier', () => {
+        expect(scrubSensitivePath('/api/v3/secret/secret789')).toBe(
+          '/api/v3/secret/[REDACTED]'
+        );
+      });
+
+      it('scrubs /api/v3/secret/:identifier/reveal', () => {
+        expect(scrubSensitivePath('/api/v3/secret/secret789/reveal')).toBe(
+          '/api/v3/secret/[REDACTED]/reveal'
+        );
+      });
+
+      it('scrubs /api/v3/secret/:identifier/status', () => {
+        expect(scrubSensitivePath('/api/v3/secret/secret789/status')).toBe(
+          '/api/v3/secret/[REDACTED]/status'
+        );
+      });
+
+      it('scrubs /api/v3/receipt/:identifier', () => {
+        expect(scrubSensitivePath('/api/v3/receipt/receipt789')).toBe(
+          '/api/v3/receipt/[REDACTED]'
+        );
+      });
+
+      it('scrubs /api/v3/receipt/:identifier/burn', () => {
+        expect(scrubSensitivePath('/api/v3/receipt/receipt789/burn')).toBe(
+          '/api/v3/receipt/[REDACTED]/burn'
+        );
+      });
+
+      it('scrubs /api/v3/guest/secret/:identifier', () => {
+        expect(scrubSensitivePath('/api/v3/guest/secret/guestsecret3')).toBe(
+          '/api/v3/guest/secret/[REDACTED]'
+        );
+      });
+
+      it('scrubs /api/v3/guest/secret/:identifier/reveal', () => {
+        expect(
+          scrubSensitivePath('/api/v3/guest/secret/guestsecret3/reveal')
+        ).toBe('/api/v3/guest/secret/[REDACTED]/reveal');
+      });
+
+      it('scrubs /api/v3/guest/receipt/:identifier', () => {
+        expect(scrubSensitivePath('/api/v3/guest/receipt/guestreceipt3')).toBe(
+          '/api/v3/guest/receipt/[REDACTED]'
+        );
+      });
+
+      it('scrubs /api/v3/guest/receipt/:identifier/burn', () => {
+        expect(
+          scrubSensitivePath('/api/v3/guest/receipt/guestreceipt3/burn')
+        ).toBe('/api/v3/guest/receipt/[REDACTED]/burn');
+      });
+    });
+
+    describe('edge cases', () => {
+      it('handles empty string', () => {
+        expect(scrubSensitivePath('')).toBe('');
+      });
+
+      it('leaves non-sensitive paths unchanged', () => {
+        expect(scrubSensitivePath('/api/v3/colonel/status')).toBe(
+          '/api/v3/colonel/status'
+        );
+        expect(scrubSensitivePath('/api/health')).toBe('/api/health');
+        expect(scrubSensitivePath('/pricing')).toBe('/pricing');
+      });
+
+      it('handles full URLs with protocol and host', () => {
+        expect(
+          scrubSensitivePath('https://example.com/api/v3/secret/abc123')
+        ).toBe('https://example.com/api/v3/secret/[REDACTED]');
+      });
+
+      it('preserves query strings', () => {
+        expect(
+          scrubSensitivePath('/api/v3/secret/abc123?timestamp=12345')
+        ).toBe('/api/v3/secret/[REDACTED]?timestamp=12345');
+      });
+
+      it('handles alphanumeric identifiers', () => {
+        expect(scrubSensitivePath('/api/v3/secret/ABC123xyz')).toBe(
+          '/api/v3/secret/[REDACTED]'
+        );
+      });
+
+      it('handles very long identifiers', () => {
+        const longId = 'a'.repeat(100);
+        expect(scrubSensitivePath(`/api/v3/secret/${longId}`)).toBe(
+          '/api/v3/secret/[REDACTED]'
+        );
+      });
+
+      it('scrubs alphanumeric prefix before special characters', () => {
+        // Generated patterns match [a-zA-Z0-9]+ which stops at special chars
+        // So 'abc-123' matches 'abc' and scrubs it, leaving '-123'
+        const urlWithDash = '/api/v3/secret/abc-123';
+        expect(scrubSensitivePath(urlWithDash)).toBe('/api/v3/secret/[REDACTED]-123');
+      });
+
+      it('handles case-insensitive matching', () => {
+        expect(scrubSensitivePath('/API/V3/SECRET/abc123')).toBe(
+          '/API/V3/SECRET/[REDACTED]'
+        );
+      });
+
+      it('does not double-scrub already scrubbed paths', () => {
+        // If a path already contains [REDACTED], it should not be altered further
+        const alreadyScrubbed = '/api/v3/secret/[REDACTED]';
+        // The pattern won't match [REDACTED] since it contains brackets
+        expect(scrubSensitivePath(alreadyScrubbed)).toBe(alreadyScrubbed);
+      });
+    });
+
+    describe('multiple occurrences', () => {
+      it('scrubs multiple sensitive segments', () => {
+        // While unlikely in practice, test that the function handles multiple matches
+        const url =
+          '/api/v3/secret/abc123?redirect=/api/v2/secret/xyz789';
+        expect(scrubSensitivePath(url)).toBe(
+          '/api/v3/secret/[REDACTED]?redirect=/api/v2/secret/[REDACTED]'
+        );
+      });
+    });
+  });
+});

--- a/src/tests/generated/sentry-scrub-patterns.spec.ts
+++ b/src/tests/generated/sentry-scrub-patterns.spec.ts
@@ -270,4 +270,76 @@ describe('generated sentry-scrub-patterns', () => {
       });
     });
   });
+
+  describe('pathToRegexPattern backslash escaping', () => {
+    // Tests for the backslash escaping fix in scripts/generate-sentry-scrub-patterns.ts
+    // The pathToRegexPattern function must escape backslashes before other characters
+    // to prevent regex injection. These tests verify the expected pattern behavior.
+
+    /**
+     * Mimics pathToRegexPattern from the generator script.
+     * This allows testing the escaping logic in isolation.
+     */
+    function pathToRegexPattern(path: string): string {
+      return path
+        .replace(/\\/g, '\\\\')
+        .replace(/\//g, '\\/')
+        .replace(/:(\w+)/g, '([a-zA-Z0-9]+)');
+    }
+
+    it('escapes single backslash in path', () => {
+      // Defensive test: paths should not contain backslashes, but if they do,
+      // they must be properly escaped to avoid regex injection
+      const pattern = pathToRegexPattern('/api/v1/test\\path');
+      expect(pattern).toBe('\\/api\\/v1\\/test\\\\path');
+
+      // Verify the resulting pattern is valid regex
+      const regex = new RegExp(pattern);
+      expect(regex.test('/api/v1/test\\path')).toBe(true);
+    });
+
+    it('escapes multiple consecutive backslashes', () => {
+      const pattern = pathToRegexPattern('/api/v1/test\\\\double');
+      expect(pattern).toBe('\\/api\\/v1\\/test\\\\\\\\double');
+
+      const regex = new RegExp(pattern);
+      expect(regex.test('/api/v1/test\\\\double')).toBe(true);
+    });
+
+    it('escapes backslashes mixed with forward slashes', () => {
+      const pattern = pathToRegexPattern('/api/v1/a\\b/c\\d');
+      expect(pattern).toBe('\\/api\\/v1\\/a\\\\b\\/c\\\\d');
+
+      const regex = new RegExp(pattern);
+      expect(regex.test('/api/v1/a\\b/c\\d')).toBe(true);
+      expect(regex.test('/api/v1/aXb/cYd')).toBe(false);
+    });
+
+    it('escapes backslashes before parameter placeholders', () => {
+      // Backslash before :key is escaped, and :key is still converted to capture group
+      // because the parameter replacement regex matches any :word pattern
+      const pattern = pathToRegexPattern('/api/v1/test\\:key/:id');
+      expect(pattern).toBe('\\/api\\/v1\\/test\\\\([a-zA-Z0-9]+)\\/([a-zA-Z0-9]+)');
+
+      const regex = new RegExp(pattern);
+      expect(regex.test('/api/v1/test\\abc123/def456')).toBe(true);
+    });
+
+    it('handles path with only backslashes', () => {
+      const pattern = pathToRegexPattern('\\\\\\');
+      expect(pattern).toBe('\\\\\\\\\\\\');
+
+      const regex = new RegExp(pattern);
+      expect(regex.test('\\\\\\')).toBe(true);
+    });
+
+    it('handles normal paths without backslashes unchanged', () => {
+      // Regression test: ensure normal paths still work correctly
+      const pattern = pathToRegexPattern('/api/v1/secret/:key');
+      expect(pattern).toBe('\\/api\\/v1\\/secret\\/([a-zA-Z0-9]+)');
+
+      const regex = new RegExp(pattern, 'i');
+      expect(regex.test('/api/v1/secret/abc123')).toBe(true);
+    });
+  });
 });


### PR DESCRIPTION
Generates Sentry breadcrumb URL scrub patterns automatically from API route metadata rather than maintaining them by hand. A new script (`scripts/generate-sentry-scrub-patterns.ts`) parses route definitions across all API versions and emits typed patterns into `src/generated/sentry-scrub-patterns.ts`, which the diagnostics scrubber then consumes. Includes a test suite covering the generated patterns.

Also regenerates the route listing files for v1/v2/v3 as a side effect of the updated OpenAPI generation script.

Closes #2981