### PR TITLE
Upgrade sentry-ruby to 6.5.0 with strict trace continuation integration

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -472,7 +472,7 @@ GEM
       concurrent-ruby (~> 1.0)
     sendgrid-ruby (6.7.0)
       ruby_http_client (~> 3.4)
-    sentry-ruby (6.4.1)
+    sentry-ruby (6.5.0)
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
       logger

--- a/etc/config.schema.yaml
+++ b/etc/config.schema.yaml
@@ -171,12 +171,12 @@ diagnostics:
       sampleRate: any(str(), num())
       maxBreadcrumbs: any(str(), int())
       logErrors: any(str(), bool())
+      org_id: str(required=False)
     backend:
       dsn: str(required=False)
     frontend:
       dsn: str(required=False)
       trackComponents: any(str(), bool())
-    org_id: str(required=False)
 
 logging:
   http_requests: any(str(), bool())

--- a/etc/config.schema.yaml
+++ b/etc/config.schema.yaml
@@ -176,6 +176,7 @@ diagnostics:
     frontend:
       dsn: str(required=False)
       trackComponents: any(str(), bool())
+    org_id: str(required=False)
 
 logging:
   http_requests: any(str(), bool())

--- a/etc/defaults/config.defaults.yaml
+++ b/etc/defaults/config.defaults.yaml
@@ -825,11 +825,21 @@ diagnostics:
     # `sampleRate` - Percentage of events to sample (0.0 to 1.0)
     # `maxBreadcrumbs` - Maximum number of breadcrumbs to capture
     # `logErrors` - Whether to log errors to console
+    # `org_id` - Sentry organization ID. When set, the Ruby SDK enables
+    #   strict trace continuation (sentry-ruby 6.5+): incoming distributed
+    #   traces are only continued if their sentry-org_id baggage matches
+    #   this value, which prevents a third-party service instrumented by
+    #   Sentry under a different org from polluting our traces. Self-hosted
+    #   Sentry DSNs cannot be parsed for org_id, so it must be set
+    #   explicitly here. Leave nil to keep strict mode off and continue all
+    #   inbound traces regardless of their org. The value propagates to
+    #   each peer (backend/frontend/workers) via apply_defaults_to_peers.
     defaults:
       dsn: <%= ENV['SENTRY_DSN'] || nil %>
       sampleRate: <%= ENV['SENTRY_SAMPLE_RATE'] || '0.10' %>
       maxBreadcrumbs: <%= ENV['SENTRY_MAX_BREADCRUMBS'] || 5 %>
       logErrors: <%= ENV['SENTRY_LOG_ERRORS'] != 'false' %>
+      org_id: <%= ENV['SENTRY_ORG_ID'] || nil %>
     # Ruby backend-specific Sentry configuration
     #
     # `dsn` - Backend-specific Sentry DSN
@@ -853,14 +863,6 @@ diagnostics:
     # `dsn` - Workers-specific Sentry DSN
     workers:
       dsn: <%= ENV['SENTRY_DSN_WORKERS'] || nil %>
-    # Sentry organization ID. When set, the SDK enables strict trace
-    # continuation (sentry-ruby 6.5+): incoming distributed traces are only
-    # continued if their sentry-org_id baggage matches this value, which
-    # prevents a third-party service instrumented by Sentry under a different
-    # org from polluting our traces. Self-hosted Sentry DSNs cannot be parsed
-    # for org_id, so it must be set explicitly here. Leave nil to keep strict
-    # mode off and continue all inbound traces regardless of their org.
-    org_id: <%= ENV['SENTRY_ORG_ID'] || nil %>
 development:
   # Development Mode Configuration
   #

--- a/etc/defaults/config.defaults.yaml
+++ b/etc/defaults/config.defaults.yaml
@@ -853,6 +853,14 @@ diagnostics:
     # `dsn` - Workers-specific Sentry DSN
     workers:
       dsn: <%= ENV['SENTRY_DSN_WORKERS'] || nil %>
+    # Sentry organization ID. When set, the SDK enables strict trace
+    # continuation (sentry-ruby 6.5+): incoming distributed traces are only
+    # continued if their sentry-org_id baggage matches this value, which
+    # prevents a third-party service instrumented by Sentry under a different
+    # org from polluting our traces. Self-hosted Sentry DSNs cannot be parsed
+    # for org_id, so it must be set explicitly here. Leave nil to keep strict
+    # mode off and continue all inbound traces regardless of their org.
+    org_id: <%= ENV['SENTRY_ORG_ID'] || nil %>
 development:
   # Development Mode Configuration
   #

--- a/lib/onetime/initializers/setup_diagnostics.rb
+++ b/lib/onetime/initializers/setup_diagnostics.rb
@@ -68,6 +68,19 @@ module Onetime
           config.dsn         = dsn
           config.environment = OT.env
 
+          # Strict trace continuation (sentry-ruby 6.5+) — when an org_id is
+          # configured, refuse to continue distributed traces whose
+          # sentry-org_id baggage doesn't match. Defends against a third-party
+          # service (instrumented by Sentry under a different org) injecting
+          # trace context into our request path. org_id must be set explicitly
+          # for self-hosted Sentry because DSN-based parsing only works for the
+          # SaaS ingest hostnames. When org_id is nil, strict mode is left off
+          # so inbound requests carrying any sentry-org_id baggage (e.g. from a
+          # browser running sentry-javascript) still stitch into the trace.
+          sentry_org_id                    = OT.conf.dig('diagnostics', 'sentry', 'org_id')
+          config.org_id                    = sentry_org_id
+          config.strict_trace_continuation = !sentry_org_id.nil?
+
           # Determine Sentry release identifier. Priority:
           # 1. SENTRY_RELEASE env var (explicit override)
           # 2. .commit_hash.txt file (baked into Docker image by CI)

--- a/lib/onetime/initializers/setup_diagnostics.rb
+++ b/lib/onetime/initializers/setup_diagnostics.rb
@@ -74,12 +74,17 @@ module Onetime
           # service (instrumented by Sentry under a different org) injecting
           # trace context into our request path. org_id must be set explicitly
           # for self-hosted Sentry because DSN-based parsing only works for the
-          # SaaS ingest hostnames. When org_id is nil, strict mode is left off
-          # so inbound requests carrying any sentry-org_id baggage (e.g. from a
-          # browser running sentry-javascript) still stitch into the trace.
-          sentry_org_id                    = OT.conf.dig('diagnostics', 'sentry', 'org_id')
+          # SaaS ingest hostnames. When org_id is blank, strict mode is left
+          # off so inbound requests carrying any sentry-org_id baggage (e.g.
+          # from a browser running sentry-javascript) still stitch into the
+          # trace. The value is sourced from the `defaults` block of the
+          # diagnostics.sentry config and propagated into each peer hash by
+          # Onetime::Config#apply_defaults_to_peers; reading from `backend`
+          # is correct for any execution mode because the same value lives
+          # on every peer.
+          sentry_org_id                    = OT.conf.dig('diagnostics', 'sentry', 'backend', 'org_id')
           config.org_id                    = sentry_org_id
-          config.strict_trace_continuation = !sentry_org_id.nil?
+          config.strict_trace_continuation = !sentry_org_id.to_s.strip.empty?
 
           # Determine Sentry release identifier. Priority:
           # 1. SENTRY_RELEASE env var (explicit override)

--- a/spec/unit/onetime/config_spec.rb
+++ b/spec/unit/onetime/config_spec.rb
@@ -90,6 +90,50 @@ RSpec.describe Onetime::Config do
           expect(sentry_config['defaults']).to eq(original)
         end
       end
+
+      # Contract relied on by Onetime::Initializers::SetupDiagnostics, which
+      # reads diagnostics.sentry.backend.org_id (and equivalently workers/
+      # frontend) at runtime. If this propagation ever regresses, strict
+      # trace continuation silently turns off — this is the bug fixed in
+      # commit af8bd0243 / PR #3007.
+      context 'sentry org_id propagation contract' do
+        let(:sentry_with_org_id) do
+          {
+            'defaults' => {
+              'org_id' => 'org-abc-123',
+              'environment' => 'test',
+            },
+            'backend'  => { 'dsn' => 'backend-dsn' },
+            'frontend' => { 'dsn' => 'frontend-dsn' },
+            'workers'  => { 'dsn' => 'workers-dsn' },
+          }
+        end
+
+        it 'propagates org_id from defaults to every peer hash' do
+          result = described_class.apply_defaults_to_peers(sentry_with_org_id)
+
+          expect(result['backend']['org_id']).to  eq('org-abc-123')
+          expect(result['frontend']['org_id']).to eq('org-abc-123')
+          expect(result['workers']['org_id']).to  eq('org-abc-123')
+        end
+
+        it 'lets a peer override org_id from defaults' do
+          sentry_with_org_id['workers']['org_id'] = 'org-workers-override'
+          result = described_class.apply_defaults_to_peers(sentry_with_org_id)
+
+          expect(result['backend']['org_id']).to eq('org-abc-123')
+          expect(result['workers']['org_id']).to eq('org-workers-override')
+        end
+
+        it 'leaves org_id absent on peers when defaults omit it' do
+          sentry_with_org_id['defaults'].delete('org_id')
+          result = described_class.apply_defaults_to_peers(sentry_with_org_id)
+
+          expect(result['backend']).not_to have_key('org_id')
+          expect(result['frontend']).not_to have_key('org_id')
+          expect(result['workers']).not_to have_key('org_id')
+        end
+      end
   end
 
   describe '#apply_defaults' do

--- a/spec/unit/onetime/initializers/setup_diagnostics_spec.rb
+++ b/spec/unit/onetime/initializers/setup_diagnostics_spec.rb
@@ -7,6 +7,7 @@ require 'spec_helper'
 # Create top-level Struct definitions to prevent "already initialized constant" warnings
 MockConfig = Struct.new(:dsn, :environment, :release, :breadcrumbs_logger,
                        :traces_sample_rate, :profiles_sample_rate, :before_send,
+                       :org_id, :strict_trace_continuation,
                        keyword_init: true) unless defined?(MockConfig)
 EventStruct = Struct.new(:request, :contexts, keyword_init: true) unless defined?(EventStruct)
 RequestStruct = Struct.new(:headers, :url, keyword_init: true) unless defined?(RequestStruct)
@@ -57,6 +58,8 @@ RSpec.describe Onetime::Initializers::SetupDiagnostics do
     mock_config.traces_sample_rate = nil
     mock_config.profiles_sample_rate = nil
     mock_config.before_send = nil
+    mock_config.org_id = nil
+    mock_config.strict_trace_continuation = nil
 
     # Stub Kernel.require to avoid loading the real gem
     allow(Kernel).to receive(:require).and_call_original
@@ -208,6 +211,51 @@ RSpec.describe Onetime::Initializers::SetupDiagnostics do
       expect(mock_config.traces_sample_rate).to eq(0.1)
       expect(mock_config.profiles_sample_rate).to eq(0.1)
       expect(mock_config.before_send).to be_a(Proc)
+    end
+
+    it "enables strict_trace_continuation and sets org_id when org_id is configured" do
+      config = loaded_config.dup
+      config['diagnostics'] = {
+        'enabled' => true,
+        'sentry' => {
+          'org_id' => 'test-org-123',
+          'backend' => { 'dsn' => "https://example-dsn@sentry.io/12345" },
+          'frontend' => { 'dsn' => nil }
+        }
+      }
+      config['site'] = { 'host' => "test.example.com" }
+
+      expect(Kernel).to receive(:require).with('sentry-ruby').ordered
+      expect(Kernel).to receive(:require).with('stackprof').ordered
+      expect(Sentry).to receive(:init).and_yield(mock_config)
+
+      Onetime.instance_variable_set(:@conf, config)
+      execute_diagnostics_initializer
+
+      expect(mock_config.org_id).to eq('test-org-123')
+      expect(mock_config.strict_trace_continuation).to eq(true)
+    end
+
+    it "leaves strict_trace_continuation off and org_id nil when org_id is not configured" do
+      config = loaded_config.dup
+      config['diagnostics'] = {
+        'enabled' => true,
+        'sentry' => {
+          'backend' => { 'dsn' => "https://example-dsn@sentry.io/12345" },
+          'frontend' => { 'dsn' => nil }
+        }
+      }
+      config['site'] = { 'host' => "test.example.com" }
+
+      expect(Kernel).to receive(:require).with('sentry-ruby').ordered
+      expect(Kernel).to receive(:require).with('stackprof').ordered
+      expect(Sentry).to receive(:init).and_yield(mock_config)
+
+      Onetime.instance_variable_set(:@conf, config)
+      execute_diagnostics_initializer
+
+      expect(mock_config.org_id).to be_nil
+      expect(mock_config.strict_trace_continuation).to eq(false)
     end
   end
 

--- a/spec/unit/onetime/initializers/setup_diagnostics_spec.rb
+++ b/spec/unit/onetime/initializers/setup_diagnostics_spec.rb
@@ -213,14 +213,21 @@ RSpec.describe Onetime::Initializers::SetupDiagnostics do
       expect(mock_config.before_send).to be_a(Proc)
     end
 
+    # The org_id field is declared in diagnostics.sentry.defaults in the
+    # YAML schema and propagated into each peer hash (backend/frontend/
+    # workers) by Onetime::Config#apply_defaults_to_peers at config load
+    # time. These tests inject the post-normalization shape directly so
+    # they accurately reflect the runtime state the initializer reads.
     it "enables strict_trace_continuation and sets org_id when org_id is configured" do
       config = loaded_config.dup
       config['diagnostics'] = {
         'enabled' => true,
         'sentry' => {
-          'org_id' => 'test-org-123',
-          'backend' => { 'dsn' => "https://example-dsn@sentry.io/12345" },
-          'frontend' => { 'dsn' => nil }
+          'backend' => {
+            'dsn' => "https://example-dsn@sentry.io/12345",
+            'org_id' => 'test-org-123'
+          },
+          'frontend' => { 'dsn' => nil, 'org_id' => 'test-org-123' }
         }
       }
       config['site'] = { 'host' => "test.example.com" }
@@ -255,6 +262,30 @@ RSpec.describe Onetime::Initializers::SetupDiagnostics do
       execute_diagnostics_initializer
 
       expect(mock_config.org_id).to be_nil
+      expect(mock_config.strict_trace_continuation).to eq(false)
+    end
+
+    it "treats blank org_id (empty or whitespace) as unset for strict_trace_continuation" do
+      config = loaded_config.dup
+      config['diagnostics'] = {
+        'enabled' => true,
+        'sentry' => {
+          'backend' => {
+            'dsn' => "https://example-dsn@sentry.io/12345",
+            'org_id' => '   '
+          },
+          'frontend' => { 'dsn' => nil }
+        }
+      }
+      config['site'] = { 'host' => "test.example.com" }
+
+      expect(Kernel).to receive(:require).with('sentry-ruby').ordered
+      expect(Kernel).to receive(:require).with('stackprof').ordered
+      expect(Sentry).to receive(:init).and_yield(mock_config)
+
+      Onetime.instance_variable_set(:@conf, config)
+      execute_diagnostics_initializer
+
       expect(mock_config.strict_trace_continuation).to eq(false)
     end
   end


### PR DESCRIPTION
Bumps sentry-ruby from 6.4.1 to 6.5.0 and integrates the new `org_id` and `strict_trace_continuation` config options added in this release.

When `SENTRY_ORG_ID` is set, the SDK now refuses to continue distributed traces whose `sentry-org_id` baggage doesn't match — defending against a third-party Sentry-instrumented service injecting trace context into OTS. When `org_id` is nil, strict mode stays off so inbound traces from the sentry-javascript frontend still stitch correctly. Config schema and defaults are updated to document and expose the new field.

Also picks up the upstream Scope#dup event-processor copy fix and HTTP 413 transport handling, both of which are no-ops for OTS's current usage but correctness improvements in the SDK.

Closes #3001