### PR TITLE
[#3011] Diagnostics and logging improvements for Sentry capture path

### DIFF
--- a/apps/api/v1/controllers/helpers.rb
+++ b/apps/api/v1/controllers/helpers.rb
@@ -356,7 +356,7 @@ module V1
 
       # Log request headers before attempting to send to Sentry
       if defined?(req) && req.respond_to?(:env)
-        headers = req.env.select { |k, _v| k.start_with?('HTTP_') rescue false } # rubocop:disable Style/RescueModifier
+        headers = Onetime::ErrorHandler.http_headers_from(req.env)
         OT.ld "[capture_error] Request headers: #{headers.inspect}"
       end
 

--- a/apps/api/v1/controllers/helpers.rb
+++ b/apps/api/v1/controllers/helpers.rb
@@ -345,7 +345,14 @@ module V1
     # and :debug. The Sentry default, if not specified, is :error.
     #
     def capture_error(error, level = :error, &block)
-      return unless OT.d9s_enabled # diagnostics are disabled by default
+      OT.ld "[sentry] api capture_error → decision exception=#{error.class} level=#{level} " \
+            "d9s_enabled=#{OT.d9s_enabled} sentry_defined=#{defined?(Sentry) ? true : false} " \
+            "sentry_initialized=#{(defined?(Sentry) && Sentry.initialized?) || false}"
+
+      unless OT.d9s_enabled # diagnostics are disabled by default
+        OT.ld '[sentry] api capture_error skipped — d9s_enabled=false'
+        return
+      end
 
       # Log request headers before attempting to send to Sentry
       if defined?(req) && req.respond_to?(:env)
@@ -354,7 +361,7 @@ module V1
       end
 
       # Capture exception with request context for debugging in Sentry
-      Sentry.capture_exception(error, level: level) do |scope|
+      event_id = Sentry.capture_exception(error, level: level) do |scope|
         # Add searchable tags (guard req to avoid NameError if not defined)
         scope.set_tags(
           service: 'api',
@@ -396,6 +403,7 @@ module V1
         # Allow caller to add additional context via block
         block&.call(scope)
       end
+      OT.ld "[sentry] api capture_error returned event_id=#{event_id.inspect} exception=#{error.class}"
     rescue NoMethodError => ex
       raise unless ex.message.include?('start_with?')
 

--- a/apps/api/v1/spec/controllers/helpers_sentry_spec.rb
+++ b/apps/api/v1/spec/controllers/helpers_sentry_spec.rb
@@ -78,7 +78,10 @@ RSpec.describe V1::ControllerHelpers do
   end
 
   before do
-    # Define a minimal Sentry constant if it doesn't exist
+    # Define a minimal Sentry constant if it doesn't exist.
+    # initialized? is required because capture_error's diagnostic log line
+    # (helpers.rb) interpolates `Sentry.initialized?` regardless of the
+    # d9s_enabled gate — evaluation happens before the early return.
     unless defined?(Sentry)
       stub_const('Sentry', Module.new do
         def self.capture_exception(error, **options, &block)
@@ -87,6 +90,10 @@ RSpec.describe V1::ControllerHelpers do
 
         def self.capture_message(message, **options, &block)
           # Default stub
+        end
+
+        def self.initialized?
+          true
         end
       end)
     end

--- a/apps/web/core/controllers/base.rb
+++ b/apps/web/core/controllers/base.rb
@@ -265,7 +265,18 @@ module Core
       # Available levels are :fatal, :error, :warning, :log, :info, and :debug.
       # The Sentry default, if not specified, is :error.
       def capture_error(error, level = :error, &)
-        return unless OT.d9s_enabled
+        http_logger.debug '[sentry] controller capture_error → decision',
+          {
+            exception_class: error.class.name,
+            level: level,
+            d9s_enabled: OT.d9s_enabled,
+            sentry_defined: defined?(Sentry) ? true : false,
+            sentry_initialized: (defined?(Sentry) && Sentry.initialized?) || false,
+          }
+        unless OT.d9s_enabled
+          http_logger.debug '[sentry] controller capture_error skipped — d9s_enabled=false'
+          return
+        end
 
         begin
           if defined?(req) && req.respond_to?(:env)
@@ -276,7 +287,12 @@ module Core
               }
           end
 
-          Sentry.capture_exception(error, level: level, &)
+          event_id = Sentry.capture_exception(error, level: level, &)
+          http_logger.debug '[sentry] controller capture_error returned',
+            {
+              event_id: event_id,
+              exception_class: error.class.name,
+            }
         rescue NoMethodError => ex
           raise unless ex.message.include?('start_with?')
 

--- a/apps/web/core/controllers/base.rb
+++ b/apps/web/core/controllers/base.rb
@@ -280,7 +280,7 @@ module Core
 
         begin
           if defined?(req) && req.respond_to?(:env)
-            headers = req.env.select { |k, _v| k.start_with?('HTTP_') rescue false } # rubocop:disable Style/RescueModifier
+            headers = Onetime::ErrorHandler.http_headers_from(req.env)
             http_logger.debug 'Capturing error to Sentry with request headers',
               {
                 headers: headers,

--- a/apps/web/core/middleware/error_handling.rb
+++ b/apps/web/core/middleware/error_handling.rb
@@ -84,7 +84,22 @@ module Core
           }
 
         # Track in Sentry if diagnostics enabled
-        capture_error(ex, env) if OT.d9s_enabled
+        http_logger.debug '[sentry] handle_error → capture decision',
+          {
+            exception_class: ex.class.name,
+            d9s_enabled: OT.d9s_enabled,
+            sentry_defined: defined?(Sentry) ? true : false,
+            sentry_initialized: (defined?(Sentry) && Sentry.initialized?) || false,
+            request_id: env['HTTP_X_REQUEST_ID'],
+          }
+        if OT.d9s_enabled
+          capture_error(ex, env)
+        else
+          http_logger.debug '[sentry] skipping capture — d9s_enabled=false',
+            {
+              request_id: env['HTTP_X_REQUEST_ID'],
+            }
+        end
 
         # Serve Vue entry point - let Vue show error UI
         serve_vue_entry_point(env, status: 500)
@@ -118,8 +133,23 @@ module Core
       end
 
       def capture_error(error, env)
-        return unless defined?(Sentry)
+        unless defined?(Sentry)
+          http_logger.debug '[sentry] capture_error aborted — Sentry constant not defined',
+            {
+              request_id: env && env['HTTP_X_REQUEST_ID'],
+            }
+          return
+        end
 
+        http_logger.debug '[sentry] capture_error → entering Sentry.with_scope',
+          {
+            exception_class: error.class.name,
+            exception_message: error.message,
+            sentry_initialized: Sentry.initialized?,
+            request_id: env && env['HTTP_X_REQUEST_ID'],
+          }
+
+        event_id = nil
         Sentry.with_scope do |scope|
           if env
             req = build_rack_request(env)
@@ -133,8 +163,15 @@ module Core
             )
           end
 
-          Sentry.capture_exception(error)
+          event_id = Sentry.capture_exception(error)
         end
+
+        http_logger.debug '[sentry] capture_error returned',
+          {
+            event_id: event_id,
+            exception_class: error.class.name,
+            request_id: env && env['HTTP_X_REQUEST_ID'],
+          }
       rescue StandardError => ex
         http_logger.error 'Sentry capture failed',
           {

--- a/lib/onetime/application/request_logger.rb
+++ b/lib/onetime/application/request_logger.rb
@@ -47,7 +47,28 @@ module Onetime
         level   = determine_level(status, duration_μs)
         payload = build_payload(request, status, duration_μs)
 
-        @logger.send(level, Familia::JsonSerializer.dump(payload))
+        @logger.send(level, Familia::JsonSerializer.dump(sanitize_for_json(payload)))
+      end
+
+      # Recursively coerce values into JSON-safe primitives so strict
+      # serialization never raises on unexpected objects (e.g., uploaded files,
+      # tempfiles, IO handles) that may appear under :debug capture mode.
+      # Logging must never break request processing.
+      def sanitize_for_json(value, depth = 0)
+        return '[TOO_DEEP]' if depth > 10
+
+        case value
+        when Hash
+          value.each_with_object({}) do |(k, v), result|
+            result[k.to_s] = sanitize_for_json(v, depth + 1)
+          end
+        when Array
+          value.map { |v| sanitize_for_json(v, depth + 1) }
+        when String, Integer, Float, TrueClass, FalseClass, NilClass
+          value
+        else
+          value.to_s
+        end
       end
 
       def build_payload(request, status, duration_μs)

--- a/lib/onetime/application/request_logger.rb
+++ b/lib/onetime/application/request_logger.rb
@@ -47,7 +47,7 @@ module Onetime
         level   = determine_level(status, duration_μs)
         payload = build_payload(request, status, duration_μs)
 
-        @logger.send(level, status, payload)
+        @logger.send(level, Familia::JsonSerializer.dump(payload))
       end
 
       def build_payload(request, status, duration_μs)
@@ -59,7 +59,12 @@ module Onetime
         payload[:request_id] = request.env['HTTP_X_REQUEST_ID'] if capture?(:request_id)
         payload[:ip]         = request.ip if capture?(:ip)
         payload[:params]     = redact_params(request.params) if capture?(:params)
-        payload[:session_id] = request.session.id if capture?(:session_id) && request.session.respond_to?(:id)
+        # Rack::Session::SessionId is not JSON-serializable under strict mode;
+        # prefer public_id (hex digest safe to log) and fall back to to_s.
+        if capture?(:session_id) && request.session.respond_to?(:id)
+          sid                  = request.session.id
+          payload[:session_id] = sid.respond_to?(:public_id) ? sid.public_id : sid.to_s
+        end
 
         if capture?(:headers)
           payload[:headers] = request.env.select { |k, _| k.start_with?('HTTP_') }

--- a/lib/onetime/cli/diagnostics/sentry/doctor_command.rb
+++ b/lib/onetime/cli/diagnostics/sentry/doctor_command.rb
@@ -8,13 +8,15 @@
 #
 # Usage:
 #   bin/ots diagnostics sentry doctor
+#   bin/ots diagnostics sentry doctor --send-event
 #
 # Checks:
 #   1. DIAGNOSTICS_ENABLED env var is 'true'
-#   2. DSN env vars are set (backend / frontend / fallback)
+#   2. DSN env vars are set (backend / frontend / workers / fallback)
 #   3. DSN format is valid (https://KEY@HOST/PROJECT_ID)
 #   4. Sentry host responds at /api/0/  (unauthenticated)
 #   5. Store endpoint accepts the DSN key (authenticated POST)
+#   6. (--send-event) sentry-ruby SDK raises → captures → delivers
 
 module Onetime
   module CLI
@@ -22,7 +24,18 @@ module Onetime
       class SentryDoctorCommand < DelayBootCommand
         desc 'Report Sentry configuration and connectivity health'
 
-        def call(**)
+        option :send_event,
+          type: :boolean,
+          default: false,
+          desc: 'Also raise/capture a test exception through sentry-ruby to verify SDK delivery'
+
+        TICK  = '[OK]  '
+        CROSS = '[FAIL]'
+        WARN  = '[WARN]'
+
+        DSN_TARGETS = %w[BACKEND FRONTEND WORKERS].freeze
+
+        def call(send_event: false, **)
           @issues = []
 
           puts
@@ -30,16 +43,13 @@ module Onetime
           puts '=' * 50
 
           check_env
-          check_backend_dsn
-          check_frontend_dsn
+          check_dsn(:backend)
+          check_dsn(:frontend)
+          send_live_events if send_event
 
           puts
           summarize
         end
-
-        TICK  = '[OK]  '
-        CROSS = '[FAIL]'
-        WARN  = '[WARN]'
 
         private
 
@@ -72,84 +82,43 @@ module Onetime
 
           ok 'DIAGNOSTICS_ENABLED', enabled
 
-          backend = ENV.fetch('SENTRY_DSN_BACKEND', nil)
-          if backend.to_s.strip.empty?
-            fallback = ENV.fetch('SENTRY_DSN', nil)
-            fail 'SENTRY_DSN_BACKEND', 'not set (no SENTRY_DSN fallback either)' if fallback.to_s.strip.empty?
+          DSN_TARGETS.each { |target| check_env_dsn(target) }
 
-            warn 'SENTRY_DSN_BACKEND', 'not set — using SENTRY_DSN fallback'
-
-          else
-            ok 'SENTRY_DSN_BACKEND', 'set'
-          end
-
-          frontend = ENV.fetch('SENTRY_DSN_FRONTEND', nil)
-          if frontend.to_s.strip.empty?
-            fallback = ENV.fetch('SENTRY_DSN', nil)
-            fail 'SENTRY_DSN_FRONTEND', 'not set (no SENTRY_DSN fallback either)' if fallback.to_s.strip.empty?
-
-            warn 'SENTRY_DSN_FRONTEND', 'not set — using SENTRY_DSN fallback'
-
-          else
-            ok 'SENTRY_DSN_FRONTEND', 'set'
-          end
-
-          workers = ENV.fetch('SENTRY_DSN_WORKERS', nil)
-          if workers.to_s.strip.empty?
-            fallback = ENV.fetch('SENTRY_DSN', nil)
-            fail 'SENTRY_DSN_WORKERS', 'not set (no SENTRY_DSN fallback either)' if fallback.to_s.strip.empty?
-
-            warn 'SENTRY_DSN_WORKERS', 'not set — using SENTRY_DSN fallback'
-
-          else
-            ok 'SENTRY_DSN_WORKERS', 'set'
-          end
-
-          sample_rate = ENV['SENTRY_SAMPLE_RATE'] || '0.10'
-          ok 'SENTRY_SAMPLE_RATE', sample_rate
+          ok 'SENTRY_SAMPLE_RATE', ENV['SENTRY_SAMPLE_RATE'] || '0.10'
 
           log_errors = ENV.fetch('SENTRY_LOG_ERRORS', nil)
           ok 'SENTRY_LOG_ERRORS', log_errors.nil? ? '(default: true)' : log_errors
         end
 
-        def check_backend_dsn
-          dsn = Diagnostics.backend_dsn
-          return if dsn.nil?
+        def check_env_dsn(target)
+          var = "SENTRY_DSN_#{target}"
+          val = ENV.fetch(var, nil)
 
-          puts
-          puts 'Backend DSN'
-          puts '-' * 50
+          if val.to_s.strip.empty?
+            fail var, 'not set (no SENTRY_DSN fallback either)' if ENV['SENTRY_DSN'].to_s.strip.empty?
 
-          parsed = Diagnostics.parse_dsn(dsn)
-          if parsed.nil?
-            fail 'DSN format', 'invalid — expected https://KEY@HOST/PROJECT_ID'
-            return
+            warn var, 'not set — using SENTRY_DSN fallback'
+
+          else
+            ok var, 'set'
           end
-
-          ok   'Key',        "#{parsed[:key][0..7]}..."
-          ok   'Host',       parsed[:host]
-          ok   'Project ID', parsed[:project_id]
-
-          probe_host(parsed[:host])
-          probe_store(parsed)
         end
 
-        def check_frontend_dsn
-          dsn = Diagnostics.frontend_dsn
+        def check_dsn(role)
+          dsn = role == :backend ? Diagnostics.backend_dsn : Diagnostics.frontend_dsn
           return if dsn.nil?
 
-          # Skip if it's the same DSN as backend (SENTRY_DSN fallback for both)
-          if dsn == Diagnostics.backend_dsn && ENV['SENTRY_DSN_FRONTEND'].to_s.strip.empty?
-            puts
-            puts 'Frontend DSN'
-            puts '-' * 50
-            warn 'Frontend DSN', 'same as backend (SENTRY_DSN fallback) — skipping duplicate probe'
+          label = "#{role.to_s.capitalize} DSN"
+          puts
+          puts label
+          puts '-' * 50
+
+          # Frontend falling back to SENTRY_DSN is identical to backend —
+          # no useful second probe, just note it and skip.
+          if role == :frontend && dsn == Diagnostics.backend_dsn && ENV['SENTRY_DSN_FRONTEND'].to_s.strip.empty?
+            warn label, 'same as backend (SENTRY_DSN fallback) — skipping duplicate probe'
             return
           end
-
-          puts
-          puts 'Frontend DSN'
-          puts '-' * 50
 
           parsed = Diagnostics.parse_dsn(dsn)
           if parsed.nil?
@@ -161,8 +130,7 @@ module Onetime
           ok 'Host',       parsed[:host]
           ok 'Project ID', parsed[:project_id]
 
-          # Skip connectivity re-probe if on same host as backend
-          backend_parsed = Diagnostics.parse_dsn(Diagnostics.backend_dsn)
+          backend_parsed = role == :frontend ? Diagnostics.parse_dsn(Diagnostics.backend_dsn) : nil
           if backend_parsed && backend_parsed[:host] == parsed[:host]
             ok 'API connectivity', 'same host as backend (already verified)'
           else
@@ -190,6 +158,59 @@ module Onetime
             detail = result[:error] ? "#{result[:status]} — #{result[:error]}" : result[:status].to_s
             fail 'Store endpoint', detail
           end
+        end
+
+        # Opt-in: initializes sentry-ruby with synchronous delivery, raises a
+        # test exception, captures it, and reports the event_id. Runs for
+        # backend and (if distinct) frontend DSNs.
+        def send_live_events
+          puts
+          puts 'Live SDK delivery'
+          puts '-' * 50
+
+          deliver_via_sdk(:backend, Diagnostics.backend_dsn)
+
+          frontend = Diagnostics.frontend_dsn
+          return if frontend.nil? || frontend == Diagnostics.backend_dsn
+
+          deliver_via_sdk(:frontend, frontend)
+        end
+
+        def deliver_via_sdk(role, dsn)
+          label = "#{role.to_s.capitalize} SDK delivery"
+          return if dsn.nil?
+
+          parsed = Diagnostics.parse_dsn(dsn)
+          unless parsed
+            fail label, 'invalid DSN'
+            return
+          end
+
+          require 'sentry-ruby'
+          Sentry.close if defined?(Sentry) && Sentry.initialized?
+
+          Sentry.init do |c|
+            c.dsn                       = dsn
+            c.environment               = 'cli-doctor'
+            c.release                   = defined?(OT::VERSION) ? OT::VERSION.details : 'cli'
+            c.traces_sample_rate        = 0.0
+            # Synchronous delivery — CLI exits cleanly after capture.
+            c.background_worker_threads = 0
+          end
+
+          begin
+            raise "[OTS doctor] Sentry delivery probe #{Time.now.utc.iso8601}"
+          rescue RuntimeError => ex
+            event    = Sentry.capture_exception(ex)
+            event_id = event&.event_id
+            fail label, 'capture_exception returned nil (dropped by before_send, sample rate, or rate limit)' unless event_id
+
+            ok label, "event_id=#{event_id} (project #{parsed[:project_id]})"
+          end
+        rescue StandardError => ex
+          fail label, ex.message
+        ensure
+          Sentry.close if defined?(Sentry) && Sentry.initialized?
         end
 
         def summarize

--- a/lib/onetime/cli/diagnostics/sentry/doctor_command.rb
+++ b/lib/onetime/cli/diagnostics/sentry/doctor_command.rb
@@ -2,6 +2,8 @@
 #
 # frozen_string_literal: true
 
+require 'time'
+
 # Report on the full Sentry configuration health without booting the
 # application. Reads environment variables directly so it works
 # before Redis/DB are available.
@@ -192,7 +194,16 @@ module Onetime
           Sentry.init do |c|
             c.dsn                       = dsn
             c.environment               = 'cli-doctor'
-            c.release                   = defined?(OT::VERSION) ? OT::VERSION.details : 'cli'
+            # Mirror SetupDiagnostics#resolve_sentry_release so doctor-originated
+            # events group under the same release as runtime events.
+            c.release                   = begin
+              env_release = ENV.fetch('SENTRY_RELEASE', '').strip
+              if env_release.empty?
+                defined?(OT::VERSION) ? OT::VERSION.get_build_info : 'cli'
+              else
+                env_release
+              end
+            end
             c.traces_sample_rate        = 0.0
             # Synchronous delivery — CLI exits cleanly after capture.
             c.background_worker_threads = 0

--- a/lib/onetime/error_handler.rb
+++ b/lib/onetime/error_handler.rb
@@ -47,6 +47,7 @@ module Onetime
             operation: operation,
           }
       end
+      nil
     end
 
     # Lua script for atomic INCR + EXPIRE (prevents race condition

--- a/lib/onetime/error_handler.rb
+++ b/lib/onetime/error_handler.rb
@@ -50,6 +50,36 @@ module Onetime
       nil
     end
 
+    # Rack env keys for headers that carry authentication credentials or
+    # session state. These are redacted from Sentry capture-decision debug
+    # logs because that logging runs exactly when operators enable debug
+    # mode in production to diagnose dropped events — the same conditions
+    # under which a leaked Basic Auth header would reach the log aggregator.
+    SENSITIVE_HEADER_KEYS = %w[
+      HTTP_AUTHORIZATION
+      HTTP_PROXY_AUTHORIZATION
+      HTTP_COOKIE
+      HTTP_X_API_KEY
+      HTTP_X_AUTH_TOKEN
+    ].freeze
+
+    # Filters a Rack env hash down to HTTP_* request headers suitable for
+    # debug logging, with sensitive headers replaced by "[FILTERED]". The
+    # `rescue false` guards against non-String keys — Rack's spec says keys
+    # are Strings, but this debug path must never raise.
+    #
+    # @param env [Hash] Rack request env
+    # @return [Hash] subset of env whose keys start with "HTTP_", with
+    #   sensitive values redacted
+    def self.http_headers_from(env)
+      return {} unless env.respond_to?(:select)
+
+      headers = env.select { |k, _v| k.start_with?('HTTP_') rescue false } # rubocop:disable Style/RescueModifier
+      headers.each_with_object({}) do |(k, v), result|
+        result[k] = SENSITIVE_HEADER_KEYS.include?(k) ? '[FILTERED]' : v
+      end
+    end
+
     # Lua script for atomic INCR + EXPIRE (prevents race condition
     # where a crash between the two commands leaves a permanent key).
     TRACK_ERROR_LUA = <<~LUA

--- a/lib/onetime/error_handler.rb
+++ b/lib/onetime/error_handler.rb
@@ -29,7 +29,24 @@ module Onetime
     rescue StandardError => ex
       log_error(operation, ex, context)
       track_error(operation) if trackable?
-      capture_error(operation, ex, context) if sentry_available?
+
+      sentry_ok = sentry_available?
+      app_logger.debug '[sentry] error_handler → capture decision',
+        {
+          operation: operation,
+          exception_class: ex.class.name,
+          sentry_defined: defined?(Sentry) ? true : false,
+          sentry_initialized: (defined?(Sentry) && Sentry.initialized?) || false,
+          sentry_available: sentry_ok,
+        }
+      if sentry_ok
+        capture_error(operation, ex, context)
+      else
+        app_logger.debug '[sentry] error_handler skipped — sentry_available=false',
+          {
+            operation: operation,
+          }
+      end
     end
 
     # Lua script for atomic INCR + EXPIRE (prevents race condition
@@ -75,11 +92,17 @@ module Onetime
 
       # Captures error in Sentry with context
       def capture_error(operation, ex, context)
-        Sentry.capture_exception(ex) do |scope|
+        event_id = Sentry.capture_exception(ex) do |scope|
           scope.set_context('error_handler', { operation: operation, **context })
           scope.set_level(:warning)
           scope.set_tags(operation: operation, error_handler: true)
         end
+        app_logger.debug '[sentry] error_handler capture_error returned',
+          {
+            operation: operation,
+            event_id: event_id,
+            exception_class: ex.class.name,
+          }
       rescue StandardError => ex
         # Don't let Sentry errors break the error handler itself
         app_logger.error 'error-handler: Failed to capture in Sentry',

--- a/lib/onetime/initializers/setup_diagnostics.rb
+++ b/lib/onetime/initializers/setup_diagnostics.rb
@@ -2,6 +2,8 @@
 #
 # frozen_string_literal: true
 
+require 'uri'
+
 module Onetime
   module Initializers
     # SetupDiagnostics initializer
@@ -55,9 +57,18 @@ module Onetime
           return
         end
 
-        # Safely log first part of DSN for debugging
-        dsn_preview = dsn ? "#{dsn[0..10]}..." : 'nil'
-        OT.boot_logger.info "[init] Sentry: Initializing with DSN: #{dsn_preview}"
+        # Safely log first part of DSN for debugging, plus the host and
+        # project id parsed out of the DSN path so multi-project setups
+        # can tell which Sentry project each boot is targeting. Project
+        # name isn't encoded in the DSN (Sentry only exposes the numeric
+        # project id), so host + id is the most specific identifier
+        # available without hitting the API.
+        dsn_preview              = "#{dsn[0..10]}..."
+        dsn_host, dsn_project_id = parse_sentry_dsn(dsn)
+        OT.boot_logger.info(
+          "[init] Sentry: Initializing project=#{dsn_project_id || 'unknown'} " \
+          "host=#{dsn_host || 'unknown'} dsn=#{dsn_preview}",
+        )
 
         # Only require Sentry if we have a DSN. We call explicitly
         # via Kernel to aid in testing.
@@ -142,6 +153,18 @@ module Onetime
       end
 
       private
+
+        # Parses a Sentry DSN to extract host and project id. A Sentry DSN
+        # has the shape "https://PUBLIC_KEY@HOST/PROJECT_ID"; the project id
+        # is the last path segment. Returns [host, project_id], either of
+        # which may be nil if the DSN is malformed.
+        def parse_sentry_dsn(dsn)
+          uri        = URI.parse(dsn)
+          project_id = uri.path.to_s.split('/').reject(&:empty?).last
+          [uri.host, project_id]
+        rescue URI::InvalidURIError
+          [nil, nil]
+        end
 
         # Selects the appropriate Sentry DSN based on execution mode.
         #

--- a/lib/onetime/initializers/setup_loggers.rb
+++ b/lib/onetime/initializers/setup_loggers.rb
@@ -57,6 +57,8 @@ module Onetime
         config               = load_logging_config
         Onetime.logging_conf = config
 
+        SemanticLogger.application = 'onetimesecret'
+
         configure_default_level(config)
         configure_appender(config)
 

--- a/try/unit/error_handler_try.rb
+++ b/try/unit/error_handler_try.rb
@@ -140,8 +140,69 @@ final_ttl = @redis.ttl(@test_key_4)
 [original_ttl > 604700, reduced_ttl <= 500, final_ttl <= 500 && final_ttl > 0]
 #=> [true, true, true]
 
+# -----------------------------------------------------------------------------
+# Gate-state methods (trackable? / sentry_available?) -- PR #3012 additions
+#
+# safe_execute's rescue branch emits debug logs describing whether Sentry is
+# available and whether tracking is possible. The branches pivot on two private
+# predicates. These tests cover the predicates directly (and confirm the
+# return-value invariant under the common "no Sentry" path).
+# -----------------------------------------------------------------------------
+
+## sentry_available? is a private class method
+# Cannot be called without .send(...) -- guards against accidental exposure.
+Onetime::ErrorHandler.respond_to?(:sentry_available?, true)
+#=> true
+
+## sentry_available? is NOT a public method
+Onetime::ErrorHandler.respond_to?(:sentry_available?)
+#=> false
+
+## sentry_available? returns a falsy value when Sentry is not defined or not initialized
+# The method is literally `defined?(Sentry) && Sentry.initialized?` -- `defined?`
+# returns nil for undefined constants and `nil && x` short-circuits to nil.
+# Whether Sentry is undefined (nil) or present-but-uninitialized (false), the
+# predicate must be falsy.
+result = Onetime::ErrorHandler.send(:sentry_available?)
+[!result, [nil, false].include?(result)]
+#=> [true, true]
+
+## sentry_available? output is consistent across calls (pure read)
+r1 = Onetime::ErrorHandler.send(:sentry_available?)
+r2 = Onetime::ErrorHandler.send(:sentry_available?)
+r1 == r2
+#=> true
+
+## trackable? is a private class method
+Onetime::ErrorHandler.respond_to?(:trackable?, true)
+#=> true
+
+## trackable? returns a Boolean reflecting Familia.dbclient availability
+# dbclient is present in the test environment (we've already used it above),
+# so trackable? must be true here.
+result = Onetime::ErrorHandler.send(:trackable?)
+[result.is_a?(TrueClass) || result.is_a?(FalseClass), !Familia.dbclient.nil?, result]
+#=> [true, true, true]
+
+## Regression -- safe_execute return value is nil even after the new debug-log
+## emission in the rescue branch (the log call must not leak through as the
+## method's return value).
+@test_key_5 = "errors:rodauth:debug_log_invariant:#{@test_date_str}"
+@redis.del(@test_key_5)
+return_value = Onetime::ErrorHandler.safe_execute('debug_log_invariant') do
+  raise ArgumentError, 'boom'
+end
+return_value
+#=> nil
+
+## Regression -- track_error still ran alongside the new debug log
+# Confirms the rescue branch is still executing its full sequence.
+@redis.get(@test_key_5).to_i
+#=> 1
+
 # Clean up test keys
 @redis.del(@test_key)
 @redis.del(@test_key_2)
 @redis.del(@test_key_3)
 @redis.del(@test_key_4)
+@redis.del(@test_key_5)

--- a/try/unit/error_handler_try.rb
+++ b/try/unit/error_handler_try.rb
@@ -200,9 +200,146 @@ return_value
 @redis.get(@test_key_5).to_i
 #=> 1
 
+# -----------------------------------------------------------------------------
+# Additional gate/branch coverage (PR #3012)
+#
+# - safe_execute rescues StandardError only (non-StandardError propagates).
+# - Context kwargs pass through to the error log without affecting the return.
+# - trackable? true path: track_error actually runs alongside the rescue.
+# - sentry_available? false path (current env): capture_error does NOT run
+#   and the rescue still returns nil.
+# - Success path: context kwargs do not alter block return value.
+# -----------------------------------------------------------------------------
+
+## safe_execute does NOT rescue non-StandardError exceptions
+# rescue StandardError means ScriptError/Interrupt/SystemExit are not caught.
+# A plain Exception subclass falls outside the rescue clause and propagates.
+class NonStandardBoom < Exception; end
+raised = nil
+begin
+  Onetime::ErrorHandler.safe_execute('non_standard_boom') do
+    raise NonStandardBoom, 'propagate me'
+  end
+rescue NonStandardBoom => ex
+  raised = ex
+end
+[raised.nil?, raised&.message]
+#=> [false, 'propagate me']
+
+## safe_execute returns nil and still invokes track_error under trackable?=true
+# With Familia.dbclient present (as throughout this file), the trackable? gate
+# evaluates to true -- so the counter must increment even when sentry_available?
+# is false in the test environment.
+@test_key_6 = "errors:rodauth:gate_trackable_true:#{@test_date_str}"
+@redis.del(@test_key_6)
+return_value = Onetime::ErrorHandler.safe_execute('gate_trackable_true') do
+  raise StandardError, 'kaboom'
+end
+[return_value, @redis.get(@test_key_6).to_i]
+#=> [nil, 1]
+
+## safe_execute passes context kwargs through (does not raise on arbitrary keys)
+# Proves the **context splat reaches log_error cleanly. Return value remains nil.
+@test_key_7 = "errors:rodauth:ctx_passthrough:#{@test_date_str}"
+@redis.del(@test_key_7)
+return_value = Onetime::ErrorHandler.safe_execute(
+  'ctx_passthrough',
+  account_id: 42,
+  customer_id: 'cust_abc',
+  arbitrary: { nested: true },
+) { raise StandardError, 'ctx' }
+[return_value, @redis.get(@test_key_7).to_i]
+#=> [nil, 1]
+
+## Success path preserves block return value regardless of context kwargs
+result = Onetime::ErrorHandler.safe_execute('success_with_ctx', account_id: 1, reason: 'test') do
+  { status: 'ok', n: 7 }
+end
+result
+#=> { status: 'ok', n: 7 }
+
+## Success path does NOT invoke track_error (no key created)
+# Proves the rescue branch is the only place tracking happens.
+@test_key_8 = "errors:rodauth:success_no_track:#{@test_date_str}"
+@redis.del(@test_key_8)
+_ = Onetime::ErrorHandler.safe_execute('success_no_track') { :ok }
+@redis.get(@test_key_8)
+#=> nil
+
+## sentry_available? is false in this env, so capture_error is skipped
+# When sentry_available? is false, the rescue emits the 'skipped' debug log and
+# returns nil WITHOUT going through capture_error. If capture_error had run
+# against an uninitialized Sentry, we'd have seen a NoMethodError bubble up.
+# (Confirmed by: safe_execute already returned nil in multiple prior cases.)
+sentry_ok = Onetime::ErrorHandler.send(:sentry_available?)
+# No exception propagated from the earlier rescues -- combined with sentry_ok
+# being falsy, we've exercised the else branch.
+[!sentry_ok, true]
+#=> [true, true]
+
+## Sequential safe_execute calls accumulate on the same daily counter key
+# Confirms the key shape is stable and that two failures bump the same key.
+@test_key_9 = "errors:rodauth:sequential_safe:#{@test_date_str}"
+@redis.del(@test_key_9)
+3.times do
+  Onetime::ErrorHandler.safe_execute('sequential_safe') { raise StandardError, 'x' }
+end
+@redis.get(@test_key_9).to_i
+#=> 3
+
+# -----------------------------------------------------------------------------
+# http_headers_from redaction (PR #3012)
+#
+# The debug logging path runs exactly when operators enable debug mode in
+# production to diagnose dropped Sentry events. Any Basic Auth, cookie, or
+# API-key header reaching the log aggregator is a credential-leak risk.
+# -----------------------------------------------------------------------------
+
+## http_headers_from redacts HTTP_AUTHORIZATION
+env = {
+  'HTTP_AUTHORIZATION' => 'Basic dXNlcjpwYXNz',
+  'HTTP_USER_AGENT'    => 'curl/8.0',
+  'REQUEST_METHOD'     => 'GET',
+}
+result = Onetime::ErrorHandler.http_headers_from(env)
+[result['HTTP_AUTHORIZATION'], result['HTTP_USER_AGENT'], result.key?('REQUEST_METHOD')]
+#=> ["[FILTERED]", "curl/8.0", false]
+
+## http_headers_from redacts HTTP_COOKIE and proxy/api-key variants
+env = {
+  'HTTP_COOKIE'              => 'sess=secret; csrf=abc',
+  'HTTP_PROXY_AUTHORIZATION' => 'Bearer xyz',
+  'HTTP_X_API_KEY'           => 'ak_live_123',
+  'HTTP_X_AUTH_TOKEN'        => 'tok_456',
+  'HTTP_ACCEPT'              => 'application/json',
+}
+result = Onetime::ErrorHandler.http_headers_from(env)
+[
+  result['HTTP_COOKIE'],
+  result['HTTP_PROXY_AUTHORIZATION'],
+  result['HTTP_X_API_KEY'],
+  result['HTTP_X_AUTH_TOKEN'],
+  result['HTTP_ACCEPT'],
+]
+#=> ["[FILTERED]", "[FILTERED]", "[FILTERED]", "[FILTERED]", "application/json"]
+
+## http_headers_from returns {} for non-Hash env
+Onetime::ErrorHandler.http_headers_from(nil)
+#=> {}
+
+## http_headers_from tolerates non-String keys without raising
+# Real Rack env is String-keyed, but the debug path must never crash.
+env = { :symbol_key => 'ignored', 'HTTP_HOST' => 'example.com', 42 => 'also ignored' }
+Onetime::ErrorHandler.http_headers_from(env)
+#=> {"HTTP_HOST"=>"example.com"}
+
 # Clean up test keys
 @redis.del(@test_key)
 @redis.del(@test_key_2)
 @redis.del(@test_key_3)
 @redis.del(@test_key_4)
 @redis.del(@test_key_5)
+@redis.del(@test_key_6)
+@redis.del(@test_key_7)
+@redis.del(@test_key_8)
+@redis.del(@test_key_9)

--- a/try/unit/request_logger_sanitization_try.rb
+++ b/try/unit/request_logger_sanitization_try.rb
@@ -1,0 +1,139 @@
+# try/unit/request_logger_sanitization_try.rb
+#
+# frozen_string_literal: true
+
+# These tryouts validate the #sanitize_for_json helper on
+# Onetime::Application::RequestLogger. The helper recursively coerces any
+# non-JSON-primitive value (e.g. Rack::Multipart::UploadedFile, Tempfile,
+# IO handles) to a String via to_s before the payload reaches
+# Familia::JsonSerializer.dump (Oj strict mode).
+#
+# Without this sanitization step, strict JSON serialization raises on
+# unexpected object types when running under :debug capture mode -- taking
+# the middleware (and the request) down with it.
+
+require_relative '../support/test_helpers'
+
+OT.boot! :test, false
+
+require 'familia/json_serializer'
+require_relative '../../lib/onetime/application/request_logger'
+
+# Minimal Rack app and config to instantiate RequestLogger.
+@app    = ->(_env) { [200, {}, ['']] }
+@config = { 'capture' => 'debug' }
+@logger = Onetime::Application::RequestLogger.new(@app, @config)
+
+# A simple class whose to_s yields a predictable marker. Stand-in for
+# arbitrary non-primitive objects like Tempfile, Pathname, custom wrappers.
+class SanitizeTargetObject
+  def to_s
+    'sanitize-target-object-string'
+  end
+end
+
+# Struct mimicking Rack::Multipart::UploadedFile for the common case that
+# motivated the fix: uploaded files surfacing in request.params.
+UploadLikeStruct = Struct.new(:filename, :type) do
+  def to_s
+    "upload(#{filename})"
+  end
+end
+
+## sanitize_for_json is defined as a private instance method on RequestLogger
+@logger.respond_to?(:sanitize_for_json, true)
+#=> true
+
+## sanitize_for_json is NOT exposed as a public method
+@logger.respond_to?(:sanitize_for_json)
+#=> false
+
+## String primitive passes through unchanged
+@logger.send(:sanitize_for_json, 'hello')
+#=> 'hello'
+
+## Integer primitive passes through unchanged
+@logger.send(:sanitize_for_json, 42)
+#=> 42
+
+## Float primitive passes through unchanged
+@logger.send(:sanitize_for_json, 3.14)
+#=> 3.14
+
+## true passes through unchanged
+@logger.send(:sanitize_for_json, true)
+#=> true
+
+## false passes through unchanged
+@logger.send(:sanitize_for_json, false)
+#=> false
+
+## nil passes through unchanged
+@logger.send(:sanitize_for_json, nil)
+#=> nil
+
+## Hash is recursively sanitized, remains a Hash with string keys
+input  = { 'a' => 1, 'b' => 'two' }
+result = @logger.send(:sanitize_for_json, input)
+[result.class, result['a'], result['b']]
+#=> [Hash, 1, 'two']
+
+## Symbol keys are stringified so Oj strict mode can serialize them
+result = @logger.send(:sanitize_for_json, { method: 'GET' })
+[result.keys, result['method']]
+#=> [['method'], 'GET']
+
+## Nested Hash values preserved as Hash, not flattened
+input  = { 'outer' => { 'inner' => 'value' } }
+result = @logger.send(:sanitize_for_json, input)
+[result['outer'].class, result['outer']['inner']]
+#=> [Hash, 'value']
+
+## Array is recursively sanitized and remains an Array
+result = @logger.send(:sanitize_for_json, ['a', 1, true, nil])
+[result.class, result]
+#=> [Array, ['a', 1, true, nil]]
+
+## Array of mixed primitives and non-primitives coerces only the non-primitives
+result = @logger.send(:sanitize_for_json, ['keep', SanitizeTargetObject.new, 7])
+result
+#=> ['keep', 'sanitize-target-object-string', 7]
+
+## Non-primitive object is coerced to its to_s output
+result = @logger.send(:sanitize_for_json, SanitizeTargetObject.new)
+result
+#=> 'sanitize-target-object-string'
+
+## An UploadedFile-like struct is coerced to a String
+upload = UploadLikeStruct.new('photo.png', 'image/png')
+result = @logger.send(:sanitize_for_json, upload)
+[result.class, result]
+#=> [String, 'upload(photo.png)']
+
+## After sanitization, Familia::JsonSerializer.dump does not raise on the upload
+upload     = UploadLikeStruct.new('report.pdf', 'application/pdf')
+sanitized  = @logger.send(:sanitize_for_json, { 'file' => upload })
+# Oj strict mode would raise on the raw struct; sanitized payload must serialize.
+json = Familia::JsonSerializer.dump(sanitized)
+json.include?('upload(report.pdf)')
+#=> true
+
+## Mixed realistic payload serializes successfully end-to-end
+upload  = UploadLikeStruct.new('resume.docx', 'application/octet-stream')
+payload = {
+  method: 'POST',
+  params: { 'file' => upload, 'name' => 'x' },
+  headers: { 'HTTP_HOST' => 'a.com' },
+}
+sanitized = @logger.send(:sanitize_for_json, payload)
+json      = Familia::JsonSerializer.dump(sanitized)
+parsed    = Familia::JsonSerializer.parse(json)
+[parsed['method'], parsed['params']['file'], parsed['params']['name'], parsed['headers']['HTTP_HOST']]
+#=> ['POST', 'upload(resume.docx)', 'x', 'a.com']
+
+## Deep recursion cuts off with [TOO_DEEP] marker (guard against cycles/huge trees)
+deep = { 'a' => { 'b' => { 'c' => { 'd' => { 'e' => { 'f' => { 'g' => { 'h' => { 'i' => { 'j' => { 'k' => 'too-deep' } } } } } } } } } } }
+result = @logger.send(:sanitize_for_json, deep)
+# After 10 levels, further recursion returns the sentinel string.
+Familia::JsonSerializer.dump(result).include?('TOO_DEEP')
+#=> true

--- a/try/unit/request_logger_sanitization_try.rb
+++ b/try/unit/request_logger_sanitization_try.rb
@@ -137,3 +137,113 @@ result = @logger.send(:sanitize_for_json, deep)
 # After 10 levels, further recursion returns the sentinel string.
 Familia::JsonSerializer.dump(result).include?('TOO_DEEP')
 #=> true
+
+# -----------------------------------------------------------------------------
+# Additional coverage (PR #3012): non-primitive coercion, mixed nesting, keys,
+# depth boundary, and mutation safety.
+# -----------------------------------------------------------------------------
+
+## IO-like object (StringIO) coerces to to_s output, not raising under strict JSON
+require 'stringio'
+io     = StringIO.new('hello')
+result = @logger.send(:sanitize_for_json, io)
+# StringIO#to_s returns the default Object inspect-like form -- what matters is
+# that it's a String (so Oj strict doesn't blow up). We only assert the class
+# and that JSON serialization succeeds.
+[result.class, Familia::JsonSerializer.dump({ 'io' => result }).class]
+#=> [String, String]
+
+## Rack::Session::SessionId-like object (no public_id; .to_s returns hex digest)
+# Mirrors the real-world cause: SessionId reaches the payload when capture=debug.
+class FakeSessionId
+  def to_s
+    'abcdef0123456789'
+  end
+end
+result = @logger.send(:sanitize_for_json, FakeSessionId.new)
+[result.class, result]
+#=> [String, 'abcdef0123456789']
+
+## Nested Array inside Hash inside Array recurses at each level
+input  = [{ 'list' => ['a', SanitizeTargetObject.new, 2] }]
+result = @logger.send(:sanitize_for_json, input)
+[result.class, result[0]['list']]
+#=> [Array, ['a', 'sanitize-target-object-string', 2]]
+
+## Hash inside Array inside Hash recurses (mixed Hash/Array structure)
+input  = { 'items' => [{ 'id' => 1, 'obj' => SanitizeTargetObject.new }] }
+result = @logger.send(:sanitize_for_json, input)
+[result['items'][0]['id'], result['items'][0]['obj']]
+#=> [1, 'sanitize-target-object-string']
+
+## Symbol keys are stringified recursively inside nested Hashes too
+input  = { outer: { inner: { deeper: 'ok' } } }
+result = @logger.send(:sanitize_for_json, input)
+[result.keys, result['outer'].keys, result['outer']['inner'].keys, result['outer']['inner']['deeper']]
+#=> [['outer'], ['inner'], ['deeper'], 'ok']
+
+## Numeric (Integer) keys are coerced to strings via k.to_s
+input  = { 1 => 'one', 2 => 'two' }
+result = @logger.send(:sanitize_for_json, input)
+[result.keys.sort, result['1'], result['2']]
+#=> [['1', '2'], 'one', 'two']
+
+## Mixed key types in one Hash all coerce to String keys
+input  = { :sym => 1, 'str' => 2, 42 => 3 }
+result = @logger.send(:sanitize_for_json, input)
+result.keys.sort
+#=> ['42', 'str', 'sym']
+
+## Array values also participate in depth counting
+# Build a structure that's 11 Array-levels deep. At depth > 10 the sentinel fires.
+deep_array = 'leaf'
+11.times { deep_array = [deep_array] }
+result = @logger.send(:sanitize_for_json, deep_array)
+Familia::JsonSerializer.dump(result).include?('TOO_DEEP')
+#=> true
+
+## Exactly at the depth cap (10 nested hashes), the leaf still serializes
+# Structure: depth 0 is root, depth 10 is the innermost 'k'. depth > 10 triggers sentinel.
+at_limit = { 'a' => { 'b' => { 'c' => { 'd' => { 'e' => { 'f' => { 'g' => { 'h' => { 'i' => { 'j' => 'leaf' } } } } } } } } } }
+result = @logger.send(:sanitize_for_json, at_limit)
+json   = Familia::JsonSerializer.dump(result)
+[json.include?('TOO_DEEP'), json.include?('leaf')]
+#=> [false, true]
+
+## Mixed Hash/Array nesting contributes equally to depth counting
+# 5 hashes wrapping 6 arrays = 11 levels; should trigger sentinel.
+mixed = 'leaf'
+6.times { mixed = [mixed] }
+5.times { mixed = { 'k' => mixed } }
+result = @logger.send(:sanitize_for_json, mixed)
+Familia::JsonSerializer.dump(result).include?('TOO_DEEP')
+#=> true
+
+## Original input Hash is not mutated by sanitization (returns a new structure)
+input  = { sym: 'v' }
+_      = @logger.send(:sanitize_for_json, input)
+# Keys on the original should still be Symbols; only the returned Hash is stringified.
+input.keys
+#=> [:sym]
+
+## Original input Array is not mutated by sanitization (returns a new Array)
+obj    = SanitizeTargetObject.new
+input  = [obj, 1]
+_      = @logger.send(:sanitize_for_json, input)
+# First element of the original array is still the raw object, not the stringification.
+input.first.equal?(obj)
+#=> true
+
+## Empty Hash round-trips to an empty Hash
+@logger.send(:sanitize_for_json, {})
+#=> {}
+
+## Empty Array round-trips to an empty Array
+@logger.send(:sanitize_for_json, [])
+#=> []
+
+## Symbol value (not key) is a non-primitive and coerces to its String form
+# Symbols are NOT listed in the primitive whenlist, so they go through value.to_s.
+result = @logger.send(:sanitize_for_json, :status_ok)
+[result.class, result]
+#=> [String, 'status_ok']

--- a/try/unit/sentry_doctor_release_try.rb
+++ b/try/unit/sentry_doctor_release_try.rb
@@ -1,0 +1,133 @@
+# try/unit/sentry_doctor_release_try.rb
+#
+# frozen_string_literal: true
+
+# These tryouts validate the Sentry release-resolution contract shared
+# between two call sites:
+#
+#   1. runtime  -- Onetime::Initializers::SetupDiagnostics#resolve_sentry_release
+#   2. CLI      -- Onetime::CLI::Diagnostics::SentryDoctorCommand#deliver_via_sdk
+#
+# Fix 2 brings the CLI site in line with the runtime site so that
+# doctor-originated events group under the same release as live events.
+#
+# Strategy:
+#   - Behavioral: replicate the documented resolution rules in a helper
+#     and assert the three input branches (env set / env unset / env blank).
+#   - Regression: string-match the CLI source to ensure it keeps using the
+#     same pattern rather than silently regressing back to a literal
+#     release string like 'cli'.
+#
+# The `deliver_via_sdk` method itself calls Sentry.init + network I/O and
+# cannot be exercised in a unit test.
+
+require_relative '../support/test_helpers'
+
+OT.boot! :test, false
+
+require 'onetime/version'
+
+# Helper mirroring Onetime::Initializers::SetupDiagnostics#resolve_sentry_release.
+# If the CLI site and runtime site agree, both will produce the value this
+# helper produces for the same ENV state.
+def resolve_release
+  env_release = ENV.fetch('SENTRY_RELEASE', '').strip
+  return env_release unless env_release.empty?
+
+  OT::VERSION.get_build_info
+end
+
+# Preserve the caller's ENV so teardown can restore it.
+@original_sentry_release = ENV['SENTRY_RELEASE']
+
+# Compute the build-info fallback once for equality checks below.
+@build_info_fallback = OT::VERSION.get_build_info
+
+# Path to the CLI source file we're guarding against regression.
+@doctor_source_path = File.expand_path(
+  '../../lib/onetime/cli/diagnostics/sentry/doctor_command.rb',
+  __dir__,
+)
+@doctor_source = File.read(@doctor_source_path)
+
+# -----------------------------------------------------------------------------
+# Behavioral equivalence tests
+# -----------------------------------------------------------------------------
+
+## With SENTRY_RELEASE set, resolver returns the env value
+ENV['SENTRY_RELEASE'] = 'v1.2.3'
+resolve_release
+#=> 'v1.2.3'
+
+## With SENTRY_RELEASE unset, resolver falls back to OT::VERSION.get_build_info
+ENV.delete('SENTRY_RELEASE')
+resolve_release
+#=> @build_info_fallback
+
+## With SENTRY_RELEASE set to empty string, resolver falls back (empty stripped)
+ENV['SENTRY_RELEASE'] = ''
+resolve_release
+#=> @build_info_fallback
+
+## With SENTRY_RELEASE set to whitespace only, resolver falls back (strip check)
+ENV['SENTRY_RELEASE'] = '   '
+resolve_release
+#=> @build_info_fallback
+
+## With SENTRY_RELEASE padded with surrounding whitespace, value is stripped
+ENV['SENTRY_RELEASE'] = "  v9.9.9\n"
+resolve_release
+#=> 'v9.9.9'
+
+## Explicit override survives even when value looks like a commit hash
+ENV['SENTRY_RELEASE'] = 'deadbee'
+resolve_release
+#=> 'deadbee'
+
+# -----------------------------------------------------------------------------
+# Source-level regression guards (proves CLI site keeps using the pattern)
+# -----------------------------------------------------------------------------
+
+## doctor_command.rb requires 'time' (Fix 3 -- ensures Time#iso8601 is available)
+@doctor_source.include?("require 'time'")
+#=> true
+
+## doctor_command.rb references SENTRY_RELEASE env var in deliver_via_sdk
+@doctor_source.include?("ENV.fetch('SENTRY_RELEASE'")
+#=> true
+
+## doctor_command.rb still uses OT::VERSION.get_build_info as fallback
+@doctor_source.include?('OT::VERSION.get_build_info')
+#=> true
+
+## doctor_command.rb strips the env value (prevents whitespace slip-through)
+@doctor_source.match?(/SENTRY_RELEASE['"]\s*,\s*['"]{2}\s*\)\s*\.strip/)
+#=> true
+
+## The release block lives inside the Sentry.init configuration
+# (We want to be sure the logic is applied to c.release, not dead code.)
+@doctor_source.match?(/c\.release\s*=.*SENTRY_RELEASE/m)
+#=> true
+
+## Fallback string 'cli' still exists as last-resort when OT::VERSION is undefined
+# This preserves the CLI's safety net (cli tools can load without Onetime boot).
+@doctor_source.include?("'cli'")
+#=> true
+
+## setup_diagnostics.rb still defines resolve_sentry_release (the runtime site
+## the CLI mirrors -- if this ever moves, CLI should move with it)
+setup_source = File.read(File.expand_path(
+  '../../lib/onetime/initializers/setup_diagnostics.rb',
+  __dir__,
+))
+setup_source.include?('def resolve_sentry_release')
+#=> true
+
+# -----------------------------------------------------------------------------
+# Teardown -- restore original ENV
+# -----------------------------------------------------------------------------
+if @original_sentry_release.nil?
+  ENV.delete('SENTRY_RELEASE')
+else
+  ENV['SENTRY_RELEASE'] = @original_sentry_release
+end

--- a/try/unit/sentry_doctor_release_try.rb
+++ b/try/unit/sentry_doctor_release_try.rb
@@ -37,6 +37,19 @@ def resolve_release
   OT::VERSION.get_build_info
 end
 
+# CLI-faithful helper that models the extra 'cli' fallback branch in
+# doctor_command.rb's deliver_via_sdk. Driven by a flag rather than mutating
+# the OT::VERSION constant so it can coexist with other tryouts in the shared
+# runner.
+def cli_resolve_release(version_defined: true)
+  env_release = ENV.fetch('SENTRY_RELEASE', '').strip
+  if env_release.empty?
+    version_defined ? OT::VERSION.get_build_info : 'cli'
+  else
+    env_release
+  end
+end
+
 # Preserve the caller's ENV so teardown can restore it.
 @original_sentry_release = ENV['SENTRY_RELEASE']
 
@@ -121,6 +134,76 @@ setup_source = File.read(File.expand_path(
   __dir__,
 ))
 setup_source.include?('def resolve_sentry_release')
+#=> true
+
+# -----------------------------------------------------------------------------
+# CLI-faithful release-resolver behavioral tests (PR #3012)
+#
+# The CLI site has an extra fallback the runtime site does not: when
+# OT::VERSION is not defined, the CLI returns the literal 'cli'. This preserves
+# a usable release identifier for CLI tools loaded outside a full Onetime boot.
+#
+# We model the exact CLI expression here -- including the `defined?(OT::VERSION)`
+# guard -- and drive it via a flag rather than mutating the constant (which
+# would leak into every subsequent test case in the shared runner).
+# -----------------------------------------------------------------------------
+
+## CLI resolver: SENTRY_RELEASE wins even when OT::VERSION is available
+ENV['SENTRY_RELEASE'] = 'v2.0.0'
+cli_resolve_release(version_defined: true)
+#=> 'v2.0.0'
+
+## CLI resolver: unset env + OT::VERSION defined -> get_build_info
+ENV.delete('SENTRY_RELEASE')
+cli_resolve_release(version_defined: true)
+#=> @build_info_fallback
+
+## CLI resolver: unset env + OT::VERSION undefined -> literal 'cli'
+# This is the CLI-only branch -- the runtime site would raise NameError here.
+ENV.delete('SENTRY_RELEASE')
+cli_resolve_release(version_defined: false)
+#=> 'cli'
+
+## CLI resolver: empty env + OT::VERSION undefined -> literal 'cli'
+ENV['SENTRY_RELEASE'] = ''
+cli_resolve_release(version_defined: false)
+#=> 'cli'
+
+## CLI resolver: whitespace-only env + OT::VERSION undefined -> 'cli'
+# Whitespace must be treated as empty (guards against "SENTRY_RELEASE= " slipping
+# through in CI scripts), and fallback must still resolve cleanly.
+ENV['SENTRY_RELEASE'] = "\t\n "
+cli_resolve_release(version_defined: false)
+#=> 'cli'
+
+## CLI resolver: explicit env overrides the 'cli' fallback branch entirely
+# Proves the branch order: env is checked first, so the OT::VERSION guard is
+# never reached when env is present.
+ENV['SENTRY_RELEASE'] = 'release-abc123'
+cli_resolve_release(version_defined: false)
+#=> 'release-abc123'
+
+# -----------------------------------------------------------------------------
+# Additional source-level guards against known regression paths
+# -----------------------------------------------------------------------------
+
+## deliver_via_sdk uses Sentry.init (not a hand-rolled HTTP envelope) for release tagging
+# The release identifier only reaches Sentry if it's attached via SDK config,
+# not via the HTTP fallback path.
+@doctor_source.match?(/def deliver_via_sdk.*Sentry\.init/m)
+#=> true
+
+## The 'cli' literal is co-located with OT::VERSION guard (not a stray string elsewhere)
+# Ensures the fallback lives on the same logical line as the defined? check.
+@doctor_source.match?(/defined\?\(OT::VERSION\).*?'cli'/m)
+#=> true
+
+## Time#iso8601 is actually called in the delivery probe (proves require 'time' is used)
+@doctor_source.include?('Time.now.utc.iso8601')
+#=> true
+
+## environment tag is set to 'cli-doctor' (so runtime and CLI events can be filtered apart in Sentry)
+@doctor_source.include?("c.environment               = 'cli-doctor'")
 #=> true
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
Closes #3011

## Summary

- **Observability plumbing for Sentry capture**: every explicit `Sentry.capture_*` call site now logs its decision (gate state, `Sentry.initialized?`, `d9s_enabled`) and the returned `event_id`. Lets us see, on the next dropped event, exactly which gate ate it.
- **`doctor --send-event`**: new opt-in that raises → captures → flushes through the real sentry-ruby SDK with synchronous delivery (`background_worker_threads: 0`), so SDK-layer failures (init blockers, `before_send`, sample rate, transport) become visible to the health check. Default off — `doctor` stays read-only unless you ask. Also collapses the three repeated DSN-env blocks and the near-duplicate backend/frontend DSN checks.
- **RequestLogger fixes**: emit the payload as a JSON string (was a Hash, which defeated downstream `message`-parsing log pipelines) and coerce `Rack::Session::SessionId` to `public_id`/`to_s` before serialization — the Hash form combined with `Familia::JsonSerializer` strict mode was crashing Puma on any session-bearing request.
- **Boot log**: Sentry init line now includes the parsed project id and host, not just a DSN prefix.
- **`SemanticLogger.application`**: set to `onetimesecret` at initializer time. Previously every JSON log line was stamped `"application": "Semantic Logger"` (the gem's default).

## Test plan

- [ ] `bin/ots diagnostics sentry doctor` runs unchanged (passive probes only)
- [ ] `bin/ots diagnostics sentry doctor --send-event` returns a real `event_id` and the event appears in the corresponding Sentry project under `environment=cli-doctor`
- [ ] Boot log shows `project=<id> host=<host>` on Sentry initialization
- [ ] JSON log output shows `"application": "onetimesecret"` on every line
- [ ] Requests carrying a session no longer produce `Familia::SerializerError: Failed to dump Rack::Session::SessionId Object to JSON in strict mode`
- [ ] Triggering an error with `DIAGNOSTICS_ENABLED=true` produces `[sentry] ... → decision` and `[sentry] ... capture_exception returned` debug lines, and the event reaches Sentry