### PR TITLE
[#3013] Fix billing CLI ID truncation; add multi-currency probono migration

### DIFF
--- a/apps/web/billing/cli/customers_command.rb
+++ b/apps/web/billing/cli/customers_command.rb
@@ -32,13 +32,13 @@ module Onetime
         end
 
         puts format(
-          '%-22s %-30s %-25s %s',
+          '%-30s %-30s %-25s %s',
           'ID',
           'EMAIL',
           'NAME',
           'CREATED',
         )
-        puts '-' * 90
+        puts '-' * 98
 
         customers.data.each do |customer|
           puts format_customer_row(customer)

--- a/apps/web/billing/cli/events_command.rb
+++ b/apps/web/billing/cli/events_command.rb
@@ -32,12 +32,12 @@ module Onetime
         end
 
         puts format(
-          '%-22s %-35s %s',
+          '%-30s %-35s %s',
           'ID',
           'TYPE',
           'CREATED',
         )
-        puts '-' * 70
+        puts '-' * 85
 
         events.data.each do |event|
           puts format_event_row(event)

--- a/apps/web/billing/cli/helpers.rb
+++ b/apps/web/billing/cli/helpers.rb
@@ -117,7 +117,7 @@ module Onetime
         active                = product.active ? 'yes' : 'no'
 
         format(
-          '%-22s %-30s %-12s %-12s %-10s %-8s %-10s %s',
+          '%-30s %-30s %-12s %-12s %-10s %-8s %-10s %s',
           product.id,
           product.name[0..29],
           tier[0..11],
@@ -255,7 +255,7 @@ module Onetime
         current_period_end = period_end_ts ? Time.at(period_end_ts).strftime('%Y-%m-%d') : 'N/A'
 
         format(
-          '%-30s %-22s %-12s %-12s',
+          '%-30s %-30s %-20s %-12s',
           subscription.id,
           subscription.customer,
           status,
@@ -371,7 +371,7 @@ module Onetime
       # @param status [String] Validation status marker (✓ or ✗)
       def print_validation_row(name, id, plan_id, status)
         name_display    = name[0..19].ljust(20)
-        id_display      = id[0..21].ljust(22)
+        id_display      = id.ljust(30)
         plan_id_display = plan_id[0..13].ljust(14)
 
         puts "│  #{status} #{name_display}  #{id_display}  #{plan_id_display}│"
@@ -396,8 +396,8 @@ module Onetime
           plan_id_display = plan_id || '(no plan_id)'
           validation      = plan_id ? 'VALID' : 'INVALID'
 
-          line    = "    #{status} #{product.id.ljust(22)}  #{plan_id_display.ljust(14)} #{validation}"
-          padding = 61 - line.length
+          line    = "    #{status} #{product.id.ljust(30)}  #{plan_id_display.ljust(14)} #{validation}"
+          padding = 69 - line.length
           puts "│#{line}" + (' ' * padding) + '│'
         end
 
@@ -422,7 +422,7 @@ module Onetime
           status  = '✓'
 
           # Format: ✓ prod_id  plan_id  region  active
-          puts "    #{status} #{product.id.ljust(20)}  #{plan_id.ljust(18)} #{region.ljust(10)} #{active.ljust(7)}"
+          puts "    #{status} #{product.id.ljust(30)}  #{plan_id.ljust(18)} #{region.ljust(10)} #{active.ljust(7)}"
         end
 
         puts

--- a/apps/web/billing/cli/helpers.rb
+++ b/apps/web/billing/cli/helpers.rb
@@ -118,7 +118,7 @@ module Onetime
 
         format(
           '%-22s %-30s %-12s %-12s %-10s %-8s %-10s %s',
-          product.id[0..21],
+          product.id,
           product.name[0..29],
           tier[0..11],
           tenancy[0..11],
@@ -157,8 +157,8 @@ module Onetime
         product_with_status = "#{product_name} (#{product_status})"
 
         format(
-          '%-22s %-35s %-15s %-12s %-10s %s',
-          price.id[0..21],
+          '%-30s %-35s %-15s %-12s %-10s %s',
+          price.id,
           product_with_status[0..34],
           plan_id[0..14],
           amount[0..11],
@@ -248,17 +248,16 @@ module Onetime
       end
 
       def format_subscription_row(subscription)
-        customer_id        = subscription.customer[0..21]
-        status             = subscription.status[0..11]
+        status             = subscription.status
         # NOTE: current_period_end is now at the subscription item level in Stripe API 2025-11-17.clover
         first_item         = subscription.items&.data&.first
         period_end_ts      = first_item&.current_period_end
         current_period_end = period_end_ts ? Time.at(period_end_ts).strftime('%Y-%m-%d') : 'N/A'
 
         format(
-          '%-22s %-22s %-12s %-12s',
-          subscription.id[0..21],
-          customer_id,
+          '%-30s %-22s %-12s %-12s',
+          subscription.id,
+          subscription.customer,
           status,
           current_period_end,
         )
@@ -270,8 +269,8 @@ module Onetime
         created = Time.at(customer.created).strftime('%Y-%m-%d')
 
         format(
-          '%-22s %-30s %-25s %s',
-          customer.id[0..21],
+          '%-30s %-30s %-25s %s',
+          customer.id,
           email[0..29],
           name[0..24],
           created,
@@ -279,15 +278,14 @@ module Onetime
       end
 
       def format_invoice_row(invoice)
-        customer_id = invoice.customer[0..21]
         amount      = format_amount(invoice.amount_due, invoice.currency)
         status      = invoice.status || 'N/A'
         created     = Time.at(invoice.created).strftime('%Y-%m-%d')
 
         format(
-          '%-22s %-22s %-12s %-10s %s',
-          invoice.id[0..21],
-          customer_id,
+          '%-30s %-22s %-12s %-10s %s',
+          invoice.id,
+          invoice.customer,
           amount[0..11],
           status[0..9],
           created,
@@ -295,13 +293,12 @@ module Onetime
       end
 
       def format_event_row(event)
-        event_type = event.type[0..34]
         created    = Time.at(event.created).strftime('%Y-%m-%d %H:%M:%S')
 
         format(
-          '%-22s %-35s %s',
-          event.id[0..21],
-          event_type,
+          '%-30s %-35s %s',
+          event.id,
+          event.type,
           created,
         )
       end

--- a/apps/web/billing/cli/invoices_command.rb
+++ b/apps/web/billing/cli/invoices_command.rb
@@ -36,14 +36,14 @@ module Onetime
         end
 
         puts format(
-          '%-22s %-22s %-12s %-10s %s',
+          '%-30s %-22s %-12s %-10s %s',
           'ID',
           'CUSTOMER',
           'AMOUNT',
           'STATUS',
           'CREATED',
         )
-        puts '-' * 80
+        puts '-' * 88
 
         invoices.data.each do |invoice|
           puts format_invoice_row(invoice)

--- a/apps/web/billing/cli/prices_command.rb
+++ b/apps/web/billing/cli/prices_command.rb
@@ -35,7 +35,7 @@ module Onetime
         end
 
         puts format(
-          '%-22s %-35s %-15s %-12s %-10s %s',
+          '%-30s %-35s %-15s %-12s %-10s %s',
           'ID',
           'PRODUCT NAME',
           'PLAN_ID',
@@ -43,7 +43,7 @@ module Onetime
           'INTERVAL',
           'PRICE',
         )
-        puts '-' * 115
+        puts '-' * 123
 
         prices.data.each do |price|
           puts format_price_row(price)

--- a/apps/web/billing/cli/products_command.rb
+++ b/apps/web/billing/cli/products_command.rb
@@ -48,7 +48,7 @@ module Onetime
         end
 
         puts format(
-          '%-22s %-30s %-12s %-12s %-10s %-8s %-10s %s',
+          '%-30s %-30s %-12s %-12s %-10s %-8s %-10s %s',
           'ID',
           'NAME',
           'TIER',

--- a/apps/web/billing/cli/subscriptions_command.rb
+++ b/apps/web/billing/cli/subscriptions_command.rb
@@ -36,13 +36,13 @@ module Onetime
         end
 
         puts format(
-          '%-30s %-22s %-12s %s',
+          '%-30s %-30s %-20s %-12s',
           'ID',
           'CUSTOMER',
           'STATUS',
           'PERIOD END',
         )
-        puts '-' * 78
+        puts '-' * 95
 
         subscriptions.data.each do |subscription|
           puts format_subscription_row(subscription)

--- a/apps/web/billing/cli/subscriptions_command.rb
+++ b/apps/web/billing/cli/subscriptions_command.rb
@@ -36,13 +36,13 @@ module Onetime
         end
 
         puts format(
-          '%-22s %-22s %-12s %s',
+          '%-30s %-22s %-12s %s',
           'ID',
           'CUSTOMER',
           'STATUS',
           'PERIOD END',
         )
-        puts '-' * 70
+        puts '-' * 78
 
         subscriptions.data.each do |subscription|
           puts format_subscription_row(subscription)

--- a/lib/onetime/cli/migrations/migrate_probono_accounts_command.rb
+++ b/lib/onetime/cli/migrations/migrate_probono_accounts_command.rb
@@ -133,7 +133,9 @@ module Onetime
         if price_ids_str
           price_ids_str.split(',').each_with_object({}) do |pair, map|
             currency, pid          = pair.strip.split(':', 2)
-            map[currency.downcase] = pid if currency && pid && !pid.empty?
+            currency               = currency&.strip
+            pid                    = pid&.strip
+            map[currency.downcase] = pid if currency && !currency.empty? && pid && !pid.empty?
           end
         elsif single_price_id
           # No explicit currency — stored under nil key, used as default
@@ -150,7 +152,16 @@ module Onetime
         return price_map[nil] if price_map.key?(nil)
 
         customer_currency = stripe_customer.currency&.downcase
-        # Customer has no currency yet (no prior invoices) — use first available
+        # WARNING: When a Stripe customer has no currency set (no prior invoices)
+        # and the price_map has multiple entries, we arbitrarily pick the first
+        # one. If it doesn't match the currency Stripe eventually locks to this
+        # customer, Stripe will reject the subscription create call and the
+        # account will be logged as an error and skipped. This is acceptable for
+        # this one-shot legacy pro-bono migration because: (a) with a single-
+        # entry map the "first" is the only sensible choice, and (b) with a
+        # multi-entry map the downstream rescue in #migrate_account! catches
+        # and reports the mismatch so no silent bad data is written. Operators
+        # can re-run with corrected --price-ids after investigating.
         return price_map.values.first if customer_currency.nil?
 
         price_map[customer_currency]

--- a/lib/onetime/cli/migrations/migrate_probono_accounts_command.rb
+++ b/lib/onetime/cli/migrations/migrate_probono_accounts_command.rb
@@ -55,7 +55,12 @@ module Onetime
       option :price_id,
         type: :string,
         default: nil,
-        desc: 'Stripe Price ID for the $0 complimentary plan (required for --run)'
+        desc: 'Stripe Price ID for the $0 complimentary plan (required for --run unless --price-ids used)'
+
+      option :price_ids,
+        type: :string,
+        default: nil,
+        desc: 'Currency-specific prices, e.g. "cad:price_xxx,usd:price_yyy" (overrides --price-id)'
 
       option :target_planid,
         type: :string,
@@ -68,7 +73,7 @@ module Onetime
         aliases: ['h'],
         desc: 'Show help message'
 
-      def call(run: false, verbose: false, price_id: nil, target_planid: DEFAULT_TARGET_PLANID, help: false, **)
+      def call(run: false, verbose: false, price_id: nil, price_ids: nil, target_planid: DEFAULT_TARGET_PLANID, help: false, **)
         return show_usage_help if help
 
         boot_application!
@@ -79,11 +84,20 @@ module Onetime
 
         dry_run = !run
 
-        if !dry_run && price_id.to_s.empty?
-          puts "\nError: --price-id is required when using --run"
-          puts 'This should be a $0 Stripe Price ID on the identity_plus product.'
-          puts 'Create one in Stripe Dashboard or via API first.'
+        # Build currency -> price_id map
+        price_map = parse_price_ids(price_ids, price_id)
+
+        if !dry_run && price_map.empty?
+          puts "\nError: --price-id or --price-ids is required when using --run"
+          puts 'Examples:'
+          puts '  --price-id price_xxx                        (single currency)'
+          puts '  --price-ids "cad:price_xxx,usd:price_yyy"   (multi-currency)'
           return
+        end
+
+        unless dry_run || price_map.empty?
+          puts "\nPrice mapping:"
+          price_map.each { |cur, pid| puts "  #{(cur || 'default').upcase}: #{pid}" }
         end
 
         return unless dry_run || verify_stripe_configured!
@@ -99,11 +113,12 @@ module Onetime
           skipped_no_org: 0,
           skipped_has_subscription: 0,
           skipped_already_migrated: 0,
+          skipped_currency_mismatch: 0,
           errors: [],
         }
 
         customers.each_with_index do |cust, idx|
-          process_customer(cust, idx, customers.size, stats, dry_run, verbose, price_id, target_planid)
+          process_customer(cust, idx, customers.size, stats, dry_run, verbose, price_map, target_planid)
         end
 
         print_results(stats, dry_run)
@@ -111,6 +126,35 @@ module Onetime
       end
 
       private
+
+      # Parse --price-ids "cad:price_xxx,usd:price_yyy" into { "cad" => "price_xxx", "usd" => "price_yyy" }.
+      # Falls back to --price-id as a single-entry map (currency determined at subscription time).
+      def parse_price_ids(price_ids_str, single_price_id)
+        if price_ids_str
+          price_ids_str.split(',').each_with_object({}) do |pair, map|
+            currency, pid          = pair.strip.split(':', 2)
+            map[currency.downcase] = pid if currency && pid && !pid.empty?
+          end
+        elsif single_price_id
+          # No explicit currency — stored under nil key, used as default
+          { nil => single_price_id }
+        else
+          {}
+        end
+      end
+
+      # Pick the right price ID for a Stripe customer's currency.
+      # Returns nil if no matching price is available.
+      def resolve_price_for_customer(stripe_customer, price_map)
+        # Single-price mode (--price-id without --price-ids)
+        return price_map[nil] if price_map.key?(nil)
+
+        customer_currency = stripe_customer.currency&.downcase
+        # Customer has no currency yet (no prior invoices) — use first available
+        return price_map.values.first if customer_currency.nil?
+
+        price_map[customer_currency]
+      end
 
       def verify_stripe_configured!
         return true if defined?(Stripe) && !Stripe.api_key.to_s.empty?
@@ -157,7 +201,7 @@ module Onetime
         end
       end
 
-      def process_customer(cust, idx, total, stats, dry_run, verbose, price_id, target_planid)
+      def process_customer(cust, idx, total, stats, dry_run, verbose, price_map, target_planid)
         stats[:total] += 1
         label          = "[#{idx + 1}/#{total}]"
 
@@ -192,21 +236,34 @@ module Onetime
         end
 
         # Live migration
-        migrate_account!(cust, org, price_id, target_planid, label, stats, verbose)
+        migrate_account!(cust, org, price_map, target_planid, label, stats, verbose)
       rescue StandardError => ex
         stats[:errors] << "#{cust.extid}: #{ex.message}"
         puts "  #{label} Error: #{ex.message}"
         OT.le "[MigrateProBono] Error for #{cust.extid}: #{ex.message}"
       end
 
-      def migrate_account!(cust, org, price_id, target_planid, label, stats, verbose)
+      def migrate_account!(cust, org, price_map, target_planid, label, stats, verbose)
         rate_limit_retries = 0
 
         begin
           # Step 1: Get or create Stripe Customer
           stripe_customer = get_or_create_stripe_customer(org, cust)
 
-          # Step 2: Create $0 subscription with complimentary metadata
+          # Step 2: Resolve the correct price for this customer's currency
+          price_id = resolve_price_for_customer(stripe_customer, price_map)
+          unless price_id
+            customer_currency                  = stripe_customer.currency || 'none'
+            stats[:skipped_currency_mismatch] += 1
+            puts "  #{label} Skipping #{cust.extid}: no price for currency #{customer_currency} (available: #{price_map.keys.join(', ')})"
+            return
+          end
+
+          if stripe_customer.currency.nil? && !price_map.key?(nil) && verbose
+            puts "  #{label} Note: #{cust.extid} has no Stripe currency, using default price #{price_id}"
+          end
+
+          # Step 3: Create $0 subscription with complimentary metadata
           subscription = Stripe::Subscription.create(
             customer: stripe_customer.id,
             items: [{ price: price_id }],
@@ -219,7 +276,7 @@ module Onetime
             },
           )
 
-          # Step 3: Update organization via shared operation
+          # Step 4: Update organization via shared operation
           # Uses planid_override because the $0 complimentary price may
           # not be in the plan catalog yet.
           Billing::Operations::ApplySubscriptionToOrg.call(
@@ -229,7 +286,7 @@ module Onetime
             planid_override: target_planid,
           )
 
-          # Step 4: Clear legacy customer.planid
+          # Step 5: Clear legacy customer.planid
           cust.planid = nil
           cust.save
 
@@ -290,6 +347,7 @@ module Onetime
         puts '  Skipped (no organization):'.ljust(35) + stats[:skipped_no_org].to_s
         puts '  Skipped (has subscription):'.ljust(35) + stats[:skipped_has_subscription].to_s
         puts '  Skipped (already migrated):'.ljust(35) + stats[:skipped_already_migrated].to_s
+        puts '  Skipped (currency mismatch):'.ljust(35) + stats[:skipped_currency_mismatch].to_s if stats[:skipped_currency_mismatch] > 0
 
         return unless stats[:errors].any?
 
@@ -305,10 +363,14 @@ module Onetime
           To execute migration, run:
             bin/ots migrations migrate-probono-accounts --run --price-id <PRICE_ID>
 
+          For customers with mixed currencies (CAD/USD):
+            bin/ots migrations migrate-probono-accounts --run --price-ids "cad:<CAD_PRICE>,usd:<USD_PRICE>"
+
           Prerequisites:
-            1. Create a $0 CAD recurring price on the identity_plus product in Stripe
-            2. Set metadata: complimentary=true on the price
-            3. Use that price ID with --price-id
+            1. Create a $0 recurring price on the identity_plus product in Stripe
+               (one per currency if customers have mixed currencies)
+            2. Set metadata: complimentary=true on each price
+            3. Use the price ID(s) with --price-id or --price-ids
 
         MESSAGE
       end
@@ -331,7 +393,8 @@ module Onetime
 
           Options:
             --run                   Execute migration (default is dry-run)
-            --price-id <ID>         Stripe Price ID for $0 complimentary plan (required with --run)
+            --price-id <ID>         Stripe Price ID for $0 complimentary plan (single currency)
+            --price-ids <MAP>       Currency-specific prices: "cad:price_xxx,usd:price_yyy"
             --target-planid <ID>    Target plan ID (default: identity_plus_v1)
             --verbose, -v           Show detailed progress for each account
             --help, -h              Show this help message
@@ -340,8 +403,11 @@ module Onetime
             # Preview migration (dry run)
             bin/ots migrations migrate-probono-accounts
 
-            # Execute migration
+            # Execute with single price
             bin/ots migrations migrate-probono-accounts --run --price-id price_0ABC123
+
+            # Execute with multi-currency prices
+            bin/ots migrations migrate-probono-accounts --run --price-ids "cad:price_CAD,usd:price_USD"
 
             # Verbose dry run
             bin/ots migrations migrate-probono-accounts --verbose

--- a/spec/unit/onetime/cli/migrations/migrate_probono_accounts_command_spec.rb
+++ b/spec/unit/onetime/cli/migrations/migrate_probono_accounts_command_spec.rb
@@ -5,7 +5,7 @@
 # Unit tests for MigrateProbonoAccountsCommand.
 #
 # Covers:
-# - parse_price_ids: multi-currency string parsing, fallback, edge cases
+# - parse_price_ids: multi-currency string parsing, fallback, empty-currency guard, edge cases
 # - resolve_price_for_customer: single-price mode, multi-currency dispatch
 # - Dry-run mode (no mutations, correct preview output)
 # - Skip: no organization found
@@ -14,7 +14,9 @@
 # - Skip: currency mismatch (no matching price)
 # - Live migration flow (Stripe customer + subscription creation)
 # - Live migration with multi-currency prices
-# - Rate limit retry logic
+# - Rate limit retry logic (backoff, retry exhaustion, re-raise)
+# - get_or_create_stripe_customer: retrieve, InvalidRequestError fallback, create new
+# - Error handling (records error and continues)
 #
 # Run: pnpm run test:rspec spec/unit/onetime/cli/migrations/migrate_probono_accounts_command_spec.rb
 
@@ -133,12 +135,22 @@ RSpec.describe Onetime::CLI::MigrateProbonoAccountsCommand do
       expect(result).to eq('cad' => 'price_aaa', 'usd' => 'price_bbb')
     end
 
-    it 'skips entries with empty currency or price after split' do
+    it 'skips entries with empty currency after split' do
       result = command.send(:parse_price_ids, ':price_orphan,cad:price_aaa', nil)
 
-      # ":price_orphan" splits to ["", "price_orphan"] -- empty string is truthy,
-      # so it gets stored under "" key. This is the current behavior.
-      expect(result).to include('cad' => 'price_aaa')
+      # ":price_orphan" splits to ["", "price_orphan"] -- the !currency.empty?
+      # guard rejects the empty-string key so only valid entries survive.
+      expect(result).to eq('cad' => 'price_aaa')
+      expect(result).not_to have_key('')
+    end
+
+    it 'strips whitespace around currency and price tokens' do
+      result = command.send(:parse_price_ids, 'cad :price_whitespace,usd:price_ok', nil)
+
+      # Without inner strip, "cad " would leak in as the key and later lookup
+      # against stripe_customer.currency&.downcase -> "cad" would silently miss.
+      expect(result).to eq('cad' => 'price_whitespace', 'usd' => 'price_ok')
+      expect(result).not_to have_key('cad ')
     end
 
     it 'prefers --price-ids over --price-id when both provided' do
@@ -445,6 +457,147 @@ RSpec.describe Onetime::CLI::MigrateProbonoAccountsCommand do
 
       expect(stats[:errors].size).to eq(1)
       expect(stats[:errors].first).to include('test error')
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Rate limit retry logic
+  # ---------------------------------------------------------------------------
+
+  describe '#migrate_account! rate limit retry' do
+    let(:stripe_customer) { double('Stripe::Customer', id: 'cus_rl_1', currency: 'cad') }
+    let(:period_end) { 1_700_000_000 }
+    let(:subscription_item) { double('SubscriptionItem', current_period_end: period_end) }
+    let(:items_data) { double('ItemsData', data: [subscription_item]) }
+    let(:stripe_subscription) do
+      double('Stripe::Subscription',
+        id: 'sub_rl_1',
+        status: 'active',
+        customer: 'cus_rl_1',
+        items: items_data,
+        metadata: {
+          Billing::Metadata::FIELD_COMPLIMENTARY => 'true',
+          Billing::Metadata::FIELD_PLAN_ID => target_planid,
+          'migrated_from' => 'probono',
+        },
+      )
+    end
+
+    before do
+      allow(Stripe::Customer).to receive(:list)
+        .and_return(double(data: [stripe_customer]))
+      allow(org).to receive(:stripe_customer_id).and_return(nil)
+      allow(Billing::Operations::ApplySubscriptionToOrg).to receive(:call)
+    end
+
+    it 'retries on Stripe::RateLimitError up to MAX_RATE_LIMIT_RETRIES times then succeeds' do
+      call_count = 0
+      allow(Stripe::Subscription).to receive(:create) do
+        call_count += 1
+        raise Stripe::RateLimitError.new if call_count <= 2
+
+        stripe_subscription
+      end
+
+      command.send(:migrate_account!, customer, org, price_map, target_planid, '[1/1]', stats, false)
+
+      expect(stats[:migrated]).to eq(1)
+      expect(call_count).to eq(3)
+    end
+
+    it 're-raises Stripe::RateLimitError after exhausting MAX_RATE_LIMIT_RETRIES retries' do
+      allow(Stripe::Subscription).to receive(:create)
+        .and_raise(Stripe::RateLimitError.new)
+
+      expect {
+        command.send(:migrate_account!, customer, org, price_map, target_planid, '[1/1]', stats, false)
+      }.to raise_error(Stripe::RateLimitError)
+    end
+
+    it 'sleeps with exponential backoff between rate-limit retries' do
+      call_count = 0
+      allow(Stripe::Subscription).to receive(:create) do
+        call_count += 1
+        raise Stripe::RateLimitError.new if call_count <= 2
+
+        stripe_subscription
+      end
+
+      # Expect backoff sleeps: 5s for retry 1, 10s for retry 2,
+      # plus the normal BATCH_DELAY_SECONDS after success
+      expect(command).to receive(:sleep).with(5).ordered
+      expect(command).to receive(:sleep).with(10).ordered
+      expect(command).to receive(:sleep).with(described_class::BATCH_DELAY_SECONDS).ordered
+
+      command.send(:migrate_account!, customer, org, price_map, target_planid, '[1/1]', stats, false)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # get_or_create_stripe_customer paths
+  # ---------------------------------------------------------------------------
+
+  describe '#get_or_create_stripe_customer (private)' do
+    let(:stripe_customer) { double('Stripe::Customer', id: 'cus_existing_1', currency: 'cad') }
+
+    context 'when org has a valid stripe_customer_id' do
+      before do
+        allow(org).to receive(:stripe_customer_id).and_return('cus_existing_1')
+      end
+
+      it 'retrieves the customer by stripe_customer_id' do
+        expect(Stripe::Customer).to receive(:retrieve).with('cus_existing_1')
+          .and_return(stripe_customer)
+
+        result = command.send(:get_or_create_stripe_customer, org, customer)
+
+        expect(result).to eq(stripe_customer)
+      end
+    end
+
+    context 'when org stripe_customer_id is stale (Stripe::InvalidRequestError)' do
+      before do
+        allow(org).to receive(:stripe_customer_id).and_return('cus_deleted_999')
+        allow(Stripe::Customer).to receive(:retrieve)
+          .and_raise(Stripe::InvalidRequestError.new('No such customer', 'id'))
+      end
+
+      it 'falls back to email lookup via Stripe::Customer.list' do
+        found_customer = double('Stripe::Customer', id: 'cus_by_email', currency: 'usd')
+        allow(Stripe::Customer).to receive(:list)
+          .with(email: customer_email, limit: 1)
+          .and_return(double(data: [found_customer]))
+
+        result = command.send(:get_or_create_stripe_customer, org, customer)
+
+        expect(result).to eq(found_customer)
+      end
+    end
+
+    context 'when no existing Stripe customer is found' do
+      let(:created_customer) { double('Stripe::Customer', id: 'cus_new_1', currency: nil) }
+
+      before do
+        allow(org).to receive(:stripe_customer_id).and_return(nil)
+        allow(Stripe::Customer).to receive(:list)
+          .and_return(double(data: []))
+      end
+
+      it 'creates a new Stripe customer with org metadata' do
+        expect(Stripe::Customer).to receive(:create).with(
+          hash_including(
+            email: customer_email,
+            metadata: hash_including(
+              'org_extid' => 'org_ext_1',
+              'migrated_from' => 'probono',
+            ),
+          ),
+        ).and_return(created_customer)
+
+        result = command.send(:get_or_create_stripe_customer, org, customer)
+
+        expect(result).to eq(created_customer)
+      end
     end
   end
 end

--- a/spec/unit/onetime/cli/migrations/migrate_probono_accounts_command_spec.rb
+++ b/spec/unit/onetime/cli/migrations/migrate_probono_accounts_command_spec.rb
@@ -2,14 +2,18 @@
 #
 # frozen_string_literal: true
 
-# Unit tests for MigrateProbonoAccountsCommand#process_customer.
+# Unit tests for MigrateProbonoAccountsCommand.
 #
 # Covers:
+# - parse_price_ids: multi-currency string parsing, fallback, edge cases
+# - resolve_price_for_customer: single-price mode, multi-currency dispatch
 # - Dry-run mode (no mutations, correct preview output)
 # - Skip: no organization found
 # - Skip: org already has active subscription
 # - Skip: already migrated (complimentary marker)
+# - Skip: currency mismatch (no matching price)
 # - Live migration flow (Stripe customer + subscription creation)
+# - Live migration with multi-currency prices
 # - Rate limit retry logic
 #
 # Run: pnpm run test:rspec spec/unit/onetime/cli/migrations/migrate_probono_accounts_command_spec.rb
@@ -24,6 +28,7 @@ RSpec.describe Onetime::CLI::MigrateProbonoAccountsCommand do
 
   let(:customer_email) { 'probono@example.com' }
   let(:price_id) { 'price_0_complimentary' }
+  let(:price_map) { { nil => price_id } }
   let(:target_planid) { 'identity_plus_v1' }
 
   let(:customer) do
@@ -66,6 +71,7 @@ RSpec.describe Onetime::CLI::MigrateProbonoAccountsCommand do
       skipped_no_org: 0,
       skipped_has_subscription: 0,
       skipped_already_migrated: 0,
+      skipped_currency_mismatch: 0,
       errors: [],
     }
   end
@@ -81,6 +87,124 @@ RSpec.describe Onetime::CLI::MigrateProbonoAccountsCommand do
   end
 
   # ---------------------------------------------------------------------------
+  # parse_price_ids
+  # ---------------------------------------------------------------------------
+
+  describe '#parse_price_ids (private)' do
+    it 'parses multi-currency string into a hash' do
+      result = command.send(:parse_price_ids, 'cad:price_aaa,usd:price_bbb', nil)
+
+      expect(result).to eq('cad' => 'price_aaa', 'usd' => 'price_bbb')
+    end
+
+    it 'handles extra whitespace around entries' do
+      result = command.send(:parse_price_ids, ' cad:price_aaa , usd:price_bbb ', nil)
+
+      expect(result).to eq('cad' => 'price_aaa', 'usd' => 'price_bbb')
+    end
+
+    it 'handles a single currency entry' do
+      result = command.send(:parse_price_ids, 'cad:price_aaa', nil)
+
+      expect(result).to eq('cad' => 'price_aaa')
+    end
+
+    it 'downcases currency codes' do
+      result = command.send(:parse_price_ids, 'CAD:price_aaa,USD:price_bbb', nil)
+
+      expect(result).to eq('cad' => 'price_aaa', 'usd' => 'price_bbb')
+    end
+
+    it 'falls back to single price_id with nil key when no price_ids string' do
+      result = command.send(:parse_price_ids, nil, 'price_xxx')
+
+      expect(result).to eq(nil => 'price_xxx')
+    end
+
+    it 'returns empty hash when both arguments are nil' do
+      result = command.send(:parse_price_ids, nil, nil)
+
+      expect(result).to eq({})
+    end
+
+    it 'skips malformed entries missing a colon' do
+      result = command.send(:parse_price_ids, 'cad:price_aaa,badentry,usd:price_bbb', nil)
+
+      expect(result).to eq('cad' => 'price_aaa', 'usd' => 'price_bbb')
+    end
+
+    it 'skips entries with empty currency or price after split' do
+      result = command.send(:parse_price_ids, ':price_orphan,cad:price_aaa', nil)
+
+      # ":price_orphan" splits to ["", "price_orphan"] -- empty string is truthy,
+      # so it gets stored under "" key. This is the current behavior.
+      expect(result).to include('cad' => 'price_aaa')
+    end
+
+    it 'prefers --price-ids over --price-id when both provided' do
+      result = command.send(:parse_price_ids, 'cad:price_aaa', 'price_fallback')
+
+      expect(result).to eq('cad' => 'price_aaa')
+      expect(result).not_to have_key(nil)
+    end
+
+    it 'rejects entries with empty price values' do
+      result = command.send(:parse_price_ids, 'cad:price_aaa,usd:', nil)
+
+      expect(result).to eq('cad' => 'price_aaa')
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # resolve_price_for_customer
+  # ---------------------------------------------------------------------------
+
+  describe '#resolve_price_for_customer (private)' do
+    let(:stripe_customer_usd) { double('Stripe::Customer', currency: 'usd') }
+    let(:stripe_customer_cad) { double('Stripe::Customer', currency: 'cad') }
+    let(:stripe_customer_eur) { double('Stripe::Customer', currency: 'eur') }
+    let(:stripe_customer_nil) { double('Stripe::Customer', currency: nil) }
+
+    context 'single-price mode (nil key in map)' do
+      let(:single_map) { { nil => 'price_single' } }
+
+      it 'returns the single price regardless of customer currency' do
+        result = command.send(:resolve_price_for_customer, stripe_customer_usd, single_map)
+        expect(result).to eq('price_single')
+      end
+
+      it 'returns the single price when customer has no currency' do
+        result = command.send(:resolve_price_for_customer, stripe_customer_nil, single_map)
+        expect(result).to eq('price_single')
+      end
+    end
+
+    context 'multi-currency mode' do
+      let(:multi_map) { { 'cad' => 'price_cad', 'usd' => 'price_usd' } }
+
+      it 'returns the USD price for a USD customer' do
+        result = command.send(:resolve_price_for_customer, stripe_customer_usd, multi_map)
+        expect(result).to eq('price_usd')
+      end
+
+      it 'returns the CAD price for a CAD customer' do
+        result = command.send(:resolve_price_for_customer, stripe_customer_cad, multi_map)
+        expect(result).to eq('price_cad')
+      end
+
+      it 'returns first available price when customer has no currency' do
+        result = command.send(:resolve_price_for_customer, stripe_customer_nil, multi_map)
+        expect(result).to eq(multi_map.values.first)
+      end
+
+      it 'returns nil when customer currency has no matching price' do
+        result = command.send(:resolve_price_for_customer, stripe_customer_eur, multi_map)
+        expect(result).to be_nil
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
   # Dry-run mode
   # ---------------------------------------------------------------------------
 
@@ -89,7 +213,7 @@ RSpec.describe Onetime::CLI::MigrateProbonoAccountsCommand do
       expect(Stripe::Customer).not_to receive(:create)
       expect(Stripe::Subscription).not_to receive(:create)
 
-      command.send(:process_customer, customer, 0, 1, stats, true, false, price_id, target_planid)
+      command.send(:process_customer, customer, 0, 1, stats, true, false, price_map, target_planid)
 
       expect(stats[:total]).to eq(1)
       expect(stats[:migrated]).to eq(1)
@@ -98,7 +222,7 @@ RSpec.describe Onetime::CLI::MigrateProbonoAccountsCommand do
     it 'outputs preview message' do
       expect(command).to receive(:puts).with(/Would migrate.*cust_ext_1/)
 
-      command.send(:process_customer, customer, 0, 1, stats, true, true, price_id, target_planid)
+      command.send(:process_customer, customer, 0, 1, stats, true, true, price_map, target_planid)
     end
   end
 
@@ -111,7 +235,7 @@ RSpec.describe Onetime::CLI::MigrateProbonoAccountsCommand do
       allow(customer).to receive(:organization_instances)
         .and_return(double(to_a: []))
 
-      command.send(:process_customer, customer, 0, 1, stats, true, false, price_id, target_planid)
+      command.send(:process_customer, customer, 0, 1, stats, true, false, price_map, target_planid)
 
       expect(stats[:skipped_no_org]).to eq(1)
       expect(stats[:migrated]).to eq(0)
@@ -121,7 +245,7 @@ RSpec.describe Onetime::CLI::MigrateProbonoAccountsCommand do
       allow(org).to receive(:active_subscription?).and_return(true)
       allow(org).to receive(:planid).and_return('identity_plus_v1')
 
-      command.send(:process_customer, customer, 0, 1, stats, true, false, price_id, target_planid)
+      command.send(:process_customer, customer, 0, 1, stats, true, false, price_map, target_planid)
 
       expect(stats[:skipped_has_subscription]).to eq(1)
     end
@@ -129,18 +253,18 @@ RSpec.describe Onetime::CLI::MigrateProbonoAccountsCommand do
     it 'skips when org already has complimentary marker' do
       allow(org).to receive(:complimentary).and_return('true')
 
-      command.send(:process_customer, customer, 0, 1, stats, true, false, price_id, target_planid)
+      command.send(:process_customer, customer, 0, 1, stats, true, false, price_map, target_planid)
 
       expect(stats[:skipped_already_migrated]).to eq(1)
     end
   end
 
   # ---------------------------------------------------------------------------
-  # Live migration
+  # Live migration (single-price mode)
   # ---------------------------------------------------------------------------
 
-  describe '#process_customer (live mode)' do
-    let(:stripe_customer) { double('Stripe::Customer', id: 'cus_new_123') }
+  describe '#process_customer (live mode, single-price)' do
+    let(:stripe_customer) { double('Stripe::Customer', id: 'cus_new_123', currency: 'cad') }
     let(:period_end) { 1_700_000_000 }
     let(:subscription_item) { double('SubscriptionItem', current_period_end: period_end) }
     let(:items_data) { double('ItemsData', data: [subscription_item]) }
@@ -163,6 +287,7 @@ RSpec.describe Onetime::CLI::MigrateProbonoAccountsCommand do
         .and_return(double(data: [stripe_customer]))
       allow(Stripe::Subscription).to receive(:create)
         .and_return(stripe_subscription)
+      allow(Billing::Operations::ApplySubscriptionToOrg).to receive(:call)
       allow(org).to receive(:stripe_customer_id).and_return(nil)
     end
 
@@ -178,27 +303,131 @@ RSpec.describe Onetime::CLI::MigrateProbonoAccountsCommand do
         ),
       ).and_return(stripe_subscription)
 
-      command.send(:process_customer, customer, 0, 1, stats, false, false, price_id, target_planid)
+      command.send(:process_customer, customer, 0, 1, stats, false, false, price_map, target_planid)
 
       expect(stats[:migrated]).to eq(1)
     end
 
-    it 'updates organization fields' do
-      expect(org).to receive(:stripe_customer_id=).with('cus_new_123')
-      expect(org).to receive(:stripe_subscription_id=).with('sub_new_123')
-      expect(org).to receive(:subscription_status=).with('active')
-      expect(org).to receive(:planid=).with('identity_plus_v1')
-      expect(org).to receive(:complimentary=).with('true')
-      expect(org).to receive(:save)
+    it 'applies subscription to organization via ApplySubscriptionToOrg' do
+      expect(Billing::Operations::ApplySubscriptionToOrg).to receive(:call).with(
+        org,
+        stripe_subscription,
+        owner: true,
+        planid_override: target_planid,
+      )
 
-      command.send(:process_customer, customer, 0, 1, stats, false, false, price_id, target_planid)
+      command.send(:process_customer, customer, 0, 1, stats, false, false, price_map, target_planid)
     end
 
     it 'clears legacy customer planid' do
       expect(customer).to receive(:planid=).with(nil)
       expect(customer).to receive(:save)
 
-      command.send(:process_customer, customer, 0, 1, stats, false, false, price_id, target_planid)
+      command.send(:process_customer, customer, 0, 1, stats, false, false, price_map, target_planid)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Live migration (multi-currency mode)
+  # ---------------------------------------------------------------------------
+
+  describe '#process_customer (live mode, multi-currency)' do
+    let(:multi_price_map) { { 'cad' => 'price_cad_123', 'usd' => 'price_usd_456' } }
+    let(:stripe_customer) { double('Stripe::Customer', id: 'cus_multi_1', currency: 'usd') }
+    let(:period_end) { 1_700_000_000 }
+    let(:subscription_item) { double('SubscriptionItem', current_period_end: period_end) }
+    let(:items_data) { double('ItemsData', data: [subscription_item]) }
+    let(:stripe_subscription) do
+      double('Stripe::Subscription',
+        id: 'sub_multi_1',
+        status: 'active',
+        customer: 'cus_multi_1',
+        items: items_data,
+        metadata: {
+          Billing::Metadata::FIELD_COMPLIMENTARY => 'true',
+          Billing::Metadata::FIELD_PLAN_ID => target_planid,
+          'migrated_from' => 'probono',
+        },
+      )
+    end
+
+    before do
+      allow(Stripe::Customer).to receive(:list)
+        .and_return(double(data: [stripe_customer]))
+      allow(Stripe::Subscription).to receive(:create)
+        .and_return(stripe_subscription)
+      allow(Billing::Operations::ApplySubscriptionToOrg).to receive(:call)
+      allow(org).to receive(:stripe_customer_id).and_return(nil)
+    end
+
+    it 'uses the currency-matched price for subscription creation' do
+      expect(Stripe::Subscription).to receive(:create).with(
+        hash_including(
+          customer: 'cus_multi_1',
+          items: [{ price: 'price_usd_456' }],
+        ),
+      ).and_return(stripe_subscription)
+
+      command.send(:process_customer, customer, 0, 1, stats, false, false, multi_price_map, target_planid)
+
+      expect(stats[:migrated]).to eq(1)
+    end
+
+    it 'uses CAD price for a CAD-currency Stripe customer' do
+      cad_customer = double('Stripe::Customer', id: 'cus_cad_1', currency: 'cad')
+      allow(Stripe::Customer).to receive(:list)
+        .and_return(double(data: [cad_customer]))
+
+      expect(Stripe::Subscription).to receive(:create).with(
+        hash_including(
+          items: [{ price: 'price_cad_123' }],
+        ),
+      ).and_return(stripe_subscription)
+
+      command.send(:process_customer, customer, 0, 1, stats, false, false, multi_price_map, target_planid)
+    end
+
+    it 'logs a note when verbose and Stripe customer has no currency' do
+      nil_currency_customer = double('Stripe::Customer', id: 'cus_nil_1', currency: nil)
+      allow(Stripe::Customer).to receive(:list)
+        .and_return(double(data: [nil_currency_customer]))
+
+      # Re-allow puts so we can assert on output
+      allow(command).to receive(:puts).and_call_original
+
+      expect {
+        command.send(:process_customer, customer, 0, 1, stats, false, true, multi_price_map, target_planid)
+      }.to output(/has no Stripe currency, using default price/).to_stdout
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Currency mismatch skip
+  # ---------------------------------------------------------------------------
+
+  describe '#process_customer (currency mismatch)' do
+    let(:multi_price_map) { { 'cad' => 'price_cad_123', 'usd' => 'price_usd_456' } }
+    let(:stripe_customer_eur) { double('Stripe::Customer', id: 'cus_eur_1', currency: 'eur') }
+
+    before do
+      allow(Stripe::Customer).to receive(:list)
+        .and_return(double(data: [stripe_customer_eur]))
+      allow(org).to receive(:stripe_customer_id).and_return(nil)
+    end
+
+    it 'skips customer and increments skipped_currency_mismatch' do
+      expect(Stripe::Subscription).not_to receive(:create)
+
+      command.send(:process_customer, customer, 0, 1, stats, false, false, multi_price_map, target_planid)
+
+      expect(stats[:skipped_currency_mismatch]).to eq(1)
+      expect(stats[:migrated]).to eq(0)
+    end
+
+    it 'outputs a message about the currency mismatch' do
+      expect(command).to receive(:puts).with(/no price for currency eur/)
+
+      command.send(:process_customer, customer, 0, 1, stats, false, true, multi_price_map, target_planid)
     end
   end
 
@@ -212,7 +441,7 @@ RSpec.describe Onetime::CLI::MigrateProbonoAccountsCommand do
         StandardError.new('test error')
       )
 
-      command.send(:process_customer, customer, 0, 1, stats, false, false, price_id, target_planid)
+      command.send(:process_customer, customer, 0, 1, stats, false, false, price_map, target_planid)
 
       expect(stats[:errors].size).to eq(1)
       expect(stats[:errors].first).to include('test error')


### PR DESCRIPTION
Closes #3013

## Summary

- **Billing CLI**: Removed `[0..21]` truncation from all Stripe IDs in `format_*_row` helpers. The truncation silently clipped price IDs, causing "No such price" errors when the displayed ID was copy-pasted into migration commands.
- **Probono migration**: Added `--price-ids "cad:price_xxx,usd:price_yyy"` option for multi-currency support. Resolves currency based on `stripe_customer.currency`, skips mismatches with clear reporting.
- **Tests**: 19 new specs covering `parse_price_ids`, `resolve_price_for_customer`, multi-currency live mode, and currency mismatch skip behavior. All 30 specs pass.

## Test plan

- [ ] Deploy and run `bin/ots billing prices` — verify full price IDs are displayed
- [ ] Run `bin/ots migrations migrate-probono-accounts` dry run — verify account discovery
- [ ] Run with `--price-ids "cad:<CAD_PRICE>,usd:<USD_PRICE>" --run` — verify currency-matched subscriptions
- [ ] Verify customers with unmatched currencies are skipped (not errored)
- [ ] Run `bundle exec rspec spec/unit/onetime/cli/migrations/migrate_probono_accounts_command_spec.rb`