### PR TITLE
Homepage config backfill

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -75,7 +75,7 @@ gem 'truemail'
 # ORMs and database drivers
 # NOTE: We install both db drivers for the OCI images so that users can choose
 # which database to use at runtime via environment variable without rebuilding.
-gem 'familia', '~> 2.4.0'
+gem 'familia', '~> 2.5.0'
 gem 'pg', '~> 1.6'
 gem 'sequel', '~> 5.0'
 gem 'sqlite3', '~> 2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,7 +87,7 @@ GEM
     base64 (0.3.0)
     bcrypt (3.1.22)
     benchmark (0.5.0)
-    bigdecimal (4.0.1)
+    bigdecimal (4.1.1)
     bindata (2.5.1)
     bunny (2.24.0)
       amq-protocol (~> 2.3)
@@ -128,10 +128,11 @@ GEM
       tzinfo
     faker (3.6.1)
       i18n (>= 1.8.11, < 2)
-    familia (2.4.0)
+    familia (2.5.0)
       concurrent-ruby (~> 1.3)
       connection_pool (>= 2.4, < 4.0)
       csv (~> 3.3)
+      json_schemer (~> 2.0)
       logger (~> 1.7)
       oj (~> 3.16)
       redis (>= 4.8.1, < 6.0)
@@ -272,7 +273,7 @@ GEM
       snaky_hash (~> 2.0, >= 2.0.3)
       version_gem (~> 1.1, >= 1.1.9)
     observer (0.1.2)
-    oj (3.16.16)
+    oj (3.16.17)
       bigdecimal (>= 3.0)
       ostruct (>= 0.2)
     omniauth (2.1.4)
@@ -393,7 +394,7 @@ GEM
       tsort
     redis (5.4.1)
       redis-client (>= 0.22.0)
-    redis-client (0.27.0)
+    redis-client (0.28.0)
       connection_pool
     regexp_parser (2.11.3)
     reline (0.6.3)
@@ -621,7 +622,7 @@ DEPENDENCIES
   dry-cli (~> 1.2)
   encryptor (= 1.1.3)
   faker (~> 3.2)
-  familia (~> 2.4.0)
+  familia (~> 2.5.0)
   fastimage (~> 2.4)
   htmlbeautifier
   httparty

--- a/apps/api/domains/logic/domains/remove_domain_image.rb
+++ b/apps/api/domains/logic/domains/remove_domain_image.rb
@@ -48,6 +48,7 @@ module DomainsAPI::Logic
 
       def process
         _image_field.delete! # delete the entire db hash key
+        @custom_domain.updated = OT.now.to_i
         @custom_domain.save
 
         success_data

--- a/changelog.d/20260417_110529_delano_3023_backfill_homepage_config.rst
+++ b/changelog.d/20260417_110529_delano_3023_backfill_homepage_config.rst
@@ -10,3 +10,4 @@ Changed
 -------
 
 - The HomepageConfig backfill migration now emits a periodic progress line (every 250 domains) with a running stat breakdown, so operators have visibility into long-running backfills. Small datasets remain quiet — no progress output below the threshold. (#3023)
+- ``CustomDomain::HomepageConfig`` and ``CustomDomain::ApiConfig`` gained ``find_or_create_for_domain``, an atomic create-if-missing class method backed by Familia's ``save_if_not_exists!`` (WATCH + MULTI). The backfill migration now uses it, so a concurrent PUT that writes before the migration does cannot have its value silently overwritten. ``upsert`` remains in place for PUT endpoint callers where last-write-wins is the intended semantic. (#3023)

--- a/changelog.d/20260417_110529_delano_3023_backfill_homepage_config.rst
+++ b/changelog.d/20260417_110529_delano_3023_backfill_homepage_config.rst
@@ -5,6 +5,7 @@ Fixed
 
 - Added a backfill migration for ``CustomDomain::HomepageConfig`` so domains that had ``allow_public_homepage`` enabled under the legacy BrandSettings schema continue to render correctly after the v0.25 homepage-config split. The migration is idempotent and safe to re-run; production was already manually pre-mitigated. (#3023)
 - ``CustomDomain#destroy!`` now cleans up the ``HomepageConfig`` and ``ApiConfig`` sibling records in addition to the existing ``SsoConfig`` / ``MailerConfig`` / ``IncomingConfig`` cleanup. Each sibling cleanup is isolated so one failure does not block the others, preventing orphaned per-domain config records when a domain is removed. (#3023)
+- ``OrganizationMembership#accept!`` now re-populates ``org_email_lookup`` with the activated membership's objid after ``activate_members_instance`` returns. The Familia 2.5.0 upgrade introduced automatic class-index cleanup on ``Horreum#destroy!``, which meant the destroy of the staged UUID model wiped the index entry the composite-keyed save had just written (both share the same ``org_email_key``). Without the restore, ``find_by_org_email`` returned ``nil`` for freshly accepted invitations. (#3023)
 
 Changed
 -------

--- a/changelog.d/20260417_110529_delano_3023_backfill_homepage_config.rst
+++ b/changelog.d/20260417_110529_delano_3023_backfill_homepage_config.rst
@@ -1,0 +1,6 @@
+.. A new scriv changelog fragment.
+
+Fixed
+-----
+
+- Added a backfill migration for ``CustomDomain::HomepageConfig`` so domains that had ``allow_public_homepage`` enabled under the legacy BrandSettings schema continue to render correctly after the v0.25 homepage-config split. The migration is idempotent and safe to re-run; production was already manually pre-mitigated. (#3023)

--- a/changelog.d/20260417_110529_delano_3023_backfill_homepage_config.rst
+++ b/changelog.d/20260417_110529_delano_3023_backfill_homepage_config.rst
@@ -4,3 +4,9 @@ Fixed
 -----
 
 - Added a backfill migration for ``CustomDomain::HomepageConfig`` so domains that had ``allow_public_homepage`` enabled under the legacy BrandSettings schema continue to render correctly after the v0.25 homepage-config split. The migration is idempotent and safe to re-run; production was already manually pre-mitigated. (#3023)
+- ``CustomDomain#destroy!`` now cleans up the ``HomepageConfig`` and ``ApiConfig`` sibling records in addition to the existing ``SsoConfig`` / ``MailerConfig`` / ``IncomingConfig`` cleanup. Each sibling cleanup is isolated so one failure does not block the others, preventing orphaned per-domain config records when a domain is removed. (#3023)
+
+Changed
+-------
+
+- The HomepageConfig backfill migration now emits a periodic progress line (every 250 domains) with a running stat breakdown, so operators have visibility into long-running backfills. Small datasets remain quiet — no progress output below the threshold. (#3023)

--- a/lib/onetime/models/custom_domain.rb
+++ b/lib/onetime/models/custom_domain.rb
@@ -400,10 +400,27 @@ module Onetime
     #
     # @return [void]
     def destroy!
-      # Clean up domain-specific configurations (idempotent, safe to call if none exist)
-      Onetime::CustomDomain::SsoConfig.delete_for_domain!(identifier)
-      Onetime::CustomDomain::MailerConfig.delete_for_domain!(identifier)
-      Onetime::CustomDomain::IncomingConfig.delete_for_domain!(identifier)
+      # Clean up domain-specific configurations (idempotent, safe to call if
+      # none exist). Each sibling is wrapped individually so that a failure
+      # cleaning one config does not block the others — orphaned sibling
+      # records are preferable to a partial cleanup that can't be retried.
+      sibling_configs = [
+        Onetime::CustomDomain::HomepageConfig,
+        Onetime::CustomDomain::ApiConfig,
+        Onetime::CustomDomain::SsoConfig,
+        Onetime::CustomDomain::MailerConfig,
+        Onetime::CustomDomain::IncomingConfig,
+      ]
+      # Rescue only Familia's own errors (schema drift, field-level failures)
+      # so that infrastructure failures like Redis::BaseConnectionError surface
+      # to the caller — there's no value in continuing the cascade if the
+      # datastore is unreachable, and the subsequent super call would fail with
+      # a more accurate error anyway.
+      sibling_configs.each do |config_class|
+        config_class.delete_for_domain!(identifier)
+      rescue Familia::Problem => ex
+        OT.le "[CustomDomain.destroy!] Failed to clean up #{config_class}: #{ex.message}"
+      end
 
       # Remove domain-scoped memberships (SSO-provisioned users restricted to this domain)
       scoped_memberships = Onetime::OrganizationMembership.find_all_by_domain_scope(objid)

--- a/lib/onetime/models/custom_domain/api_config.rb
+++ b/lib/onetime/models/custom_domain/api_config.rb
@@ -151,6 +151,42 @@ module Onetime
           config
         end
 
+        # Atomically return an existing ApiConfig or create one if absent.
+        #
+        # Backfill/bootstrap counterpart to upsert. A concurrent writer that
+        # created a record between the caller's read and our write gets their
+        # value preserved — this method never overwrites an existing record.
+        # Uses Familia's WATCH-based save_if_not_exists! so the exists-check
+        # and save participate in the same optimistic transaction.
+        #
+        # @param domain_id [String] CustomDomain identifier
+        # @param enabled   [Boolean, String] value to use only if creating
+        # @return [Array(ApiConfig, Symbol)] [config, :created | :existed]
+        def find_or_create_for_domain(domain_id:, enabled:)
+          raise Onetime::Problem, 'domain_id is required' if domain_id.to_s.empty?
+
+          existing = find_by_domain_id(domain_id)
+          return [existing, :existed] if existing
+
+          now    = Familia.now.to_i
+          config = new(domain_id: domain_id, enabled: enabled.to_s, created: now, updated: now)
+
+          begin
+            config.save_if_not_exists!
+            [config, :created]
+          rescue Familia::RecordExistsError
+            # A racing writer's record existed inside Familia's WATCH block.
+            # Re-read must succeed: if it doesn't, the record vanished between
+            # WATCH and re-read (concurrent destroy, TTL eviction, test teardown).
+            # Raise rather than silently return [nil, :existed] and break the
+            # method contract.
+            found = find_by_domain_id(domain_id)
+            raise Onetime::Problem, "ApiConfig for #{domain_id} vanished after conflict" unless found
+
+            [found, :existed]
+          end
+        end
+
         # Create a new API config for a domain.
         #
         # @param domain_id [String] CustomDomain identifier

--- a/lib/onetime/models/custom_domain/homepage_config.rb
+++ b/lib/onetime/models/custom_domain/homepage_config.rb
@@ -151,6 +151,42 @@ module Onetime
           config
         end
 
+        # Atomically return an existing HomepageConfig or create one if absent.
+        #
+        # Backfill/bootstrap counterpart to upsert. A concurrent writer that
+        # created a record between the caller's read and our write gets their
+        # value preserved — this method never overwrites an existing record.
+        # Uses Familia's WATCH-based save_if_not_exists! so the exists-check
+        # and save participate in the same optimistic transaction.
+        #
+        # @param domain_id [String] CustomDomain identifier
+        # @param enabled   [Boolean, String] value to use only if creating
+        # @return [Array(HomepageConfig, Symbol)] [config, :created | :existed]
+        def find_or_create_for_domain(domain_id:, enabled:)
+          raise Onetime::Problem, 'domain_id is required' if domain_id.to_s.empty?
+
+          existing = find_by_domain_id(domain_id)
+          return [existing, :existed] if existing
+
+          now    = Familia.now.to_i
+          config = new(domain_id: domain_id, enabled: enabled.to_s, created: now, updated: now)
+
+          begin
+            config.save_if_not_exists!
+            [config, :created]
+          rescue Familia::RecordExistsError
+            # A racing writer's record existed inside Familia's WATCH block.
+            # Re-read must succeed: if it doesn't, the record vanished between
+            # WATCH and re-read (concurrent destroy, TTL eviction, test teardown).
+            # Raise rather than silently return [nil, :existed] and break the
+            # method contract.
+            found = find_by_domain_id(domain_id)
+            raise Onetime::Problem, "HomepageConfig for #{domain_id} vanished after conflict" unless found
+
+            [found, :existed]
+          end
+        end
+
         # Create a new homepage config for a domain.
         #
         # @param domain_id [String] CustomDomain identifier

--- a/lib/onetime/models/organization_membership.rb
+++ b/lib/onetime/models/organization_membership.rb
@@ -303,6 +303,18 @@ module Onetime
         raise
       end
 
+      # Re-populate org_email_lookup on the NEW composite-keyed model.
+      # activate_members_instance saves the composite model (populates
+      # org_email_lookup) and then destroys the staged UUID model. As of
+      # Familia 2.5.0, Horreum#destroy! auto-cleans class-level unique_index
+      # entries — and because staged and activated models share the same
+      # org_email_key, the destroy wipes the entry the activated save just
+      # wrote. Restore it here so find_by_org_email continues to resolve
+      # the active membership.
+      if activated.org_email_key
+        self.class.org_email_lookup[activated.org_email_key] = activated.objid
+      end
+
       # Populate active-state OTS index on the NEW composite-keyed model
       if activated.org_customer_key
         self.class.org_customer_lookup[activated.org_customer_key] = activated.objid

--- a/migrations/2026-04-17/20260417_01_backfill_homepage_config.rb
+++ b/migrations/2026-04-17/20260417_01_backfill_homepage_config.rb
@@ -1,0 +1,115 @@
+# migrations/2026-04-17/20260417_01_backfill_homepage_config.rb
+#
+# frozen_string_literal: true
+
+#
+# Backfill CustomDomain::HomepageConfig from legacy BrandSettings
+#
+# The v0.24 -> v0.25 change moved `allow_public_homepage` from BrandSettings
+# (a hashkey field on CustomDomain.brand) into a dedicated
+# CustomDomain::HomepageConfig record without a release-time backfill.
+# The UI serializer and API read HomepageConfig directly (no fallback in
+# those paths), so domains that were toggled ON under v0.24 render as
+# disabled under v0.25 until a HomepageConfig record exists.
+#
+# Production was mitigated manually via bin/console with equivalent logic;
+# this migration encodes that mitigation for the release process itself and
+# is safe to re-run (domains with an existing HomepageConfig are skipped).
+#
+# Usage:
+#   bin/ots migrate 20260417_01_backfill_homepage_config           # Preview
+#   bin/ots migrate --run 20260417_01_backfill_homepage_config     # Execute
+#
+# Refs: #3023
+require 'familia/migration'
+
+module Onetime
+  module Migrations
+    # Create HomepageConfig records for CustomDomains that only carry the
+    # legacy BrandSettings#allow_public_homepage value.
+    class BackfillHomepageConfig < Familia::Migration::Base
+      self.migration_id = '20260417_01_backfill_homepage_config'
+      self.description  = 'Backfill CustomDomain::HomepageConfig from legacy BrandSettings.allow_public_homepage'
+      self.dependencies = []
+
+      def prepare
+        @model_class  = Onetime::CustomDomain
+        @config_class = Onetime::CustomDomain::HomepageConfig
+      end
+
+      def migration_needed?
+        @model_class.instances.each do |domain_id|
+          next if @config_class.exists_for_domain?(domain_id)
+
+          # Per #3023: any domain without a HomepageConfig record needs backfill,
+          # regardless of the legacy brand_settings.allow_public_homepage value.
+          # The legacy value only determines the enabled flag written during
+          # migrate, not whether migration is needed. This ensures the legacy
+          # fallback at CustomDomain#allow_public_homepage? can be removed in
+          # a future release once every domain carries a real HomepageConfig.
+          domain = @model_class.find_by_identifier(domain_id)
+          return true if domain
+        rescue StandardError => ex
+          # Surface the discovery error but keep scanning so one corrupt
+          # record cannot mask a genuine pending migration.
+          error "migration_needed? error for #{domain_id}: #{ex.message}"
+        end
+
+        false
+      end
+
+      def migrate
+        run_mode_banner
+
+        @model_class.instances.each do |domain_id|
+          process_domain(domain_id)
+        rescue StandardError => ex
+          track_stat(:errors)
+          error "Error processing domain #{domain_id}: #{ex.message}"
+        end
+
+        print_summary do |mode|
+          @stats.each { |key, value| info "  #{key}: #{value}" }
+          info ''
+          info(mode == :dry_run ? 'Re-run with --run to apply changes.' : 'Backfill complete.')
+        end
+
+        true
+      end
+
+      private
+
+      def process_domain(domain_id)
+        if @config_class.exists_for_domain?(domain_id)
+          track_stat(:skipped_existing)
+          info "Skip (existing HomepageConfig): #{domain_id}"
+          return
+        end
+
+        domain = @model_class.find_by_identifier(domain_id)
+        unless domain
+          track_stat(:skipped_missing_domain)
+          info "Skip (domain not found): #{domain_id}"
+          return
+        end
+
+        legacy_enabled = domain.brand_settings.allow_public_homepage?
+
+        if dry_run?
+          track_stat(legacy_enabled ? :would_migrate_true : :would_migrate_false)
+          info "[DRY RUN] would upsert HomepageConfig(domain_id=#{domain_id}, enabled=#{legacy_enabled})"
+        else
+          @config_class.upsert(domain_id: domain_id, enabled: legacy_enabled)
+          track_stat(legacy_enabled ? :migrated_true : :migrated_false)
+          info "Upserted HomepageConfig(domain_id=#{domain_id}, enabled=#{legacy_enabled})"
+        end
+      end
+    end
+  end
+end
+
+# Run directly
+if __FILE__ == $0
+  OT.boot! :cli
+  exit(Onetime::Migrations::BackfillHomepageConfig.cli_run)
+end

--- a/migrations/2026-04-17/20260417_01_backfill_homepage_config.rb
+++ b/migrations/2026-04-17/20260417_01_backfill_homepage_config.rb
@@ -58,6 +58,16 @@ module Onetime
         false
       end
 
+      # Stat-key naming note
+      #
+      # Keys :would_migrate_true / :would_migrate_false / :migrated_true /
+      # :migrated_false deliberately deviate from the 2025-07-27 convention of
+      # past-tense action nouns (e.g. :backup_created, :symbols_converted,
+      # :records_updated). The boolean split is retained for production
+      # observability: operators can verify the true/false ratio matches
+      # expectations, and if :migrated_true stays at zero across runs, the
+      # legacy fallback at CustomDomain#allow_public_homepage? is provably
+      # unused and safe to remove.
       def migrate
         run_mode_banner
 

--- a/migrations/2026-04-17/20260417_01_backfill_homepage_config.rb
+++ b/migrations/2026-04-17/20260417_01_backfill_homepage_config.rb
@@ -68,14 +68,27 @@ module Onetime
       # expectations, and if :migrated_true stays at zero across runs, the
       # legacy fallback at CustomDomain#allow_public_homepage? is provably
       # unused and safe to remove.
+      # Progress reporting threshold: emit a running breakdown every N domains
+      # processed. 250 balances noise vs. operator visibility on large domain
+      # counts; below the threshold the summary banner is enough.
+      PROGRESS_STEP = 250
+
       def migrate
         run_mode_banner
+
+        # ZCARD on CustomDomain.instances — O(1), worth the one-time cost so
+        # progress output can show current/total.
+        total     = @model_class.instances.count
+        processed = 0
 
         @model_class.instances.each do |domain_id|
           process_domain(domain_id)
         rescue StandardError => ex
           track_stat(:errors)
           error "Error processing domain #{domain_id}: #{ex.message}"
+        ensure
+          processed += 1
+          report_progress(processed, total)
         end
 
         print_summary do |mode|
@@ -88,6 +101,18 @@ module Onetime
       end
 
       private
+
+      # Emit a periodic progress line with a running stat breakdown so
+      # operators can watch long-running backfills. Only logs at the step
+      # boundary or the final iteration; stays silent below the threshold
+      # to avoid noise on small datasets.
+      def report_progress(processed, total)
+        return unless total >= PROGRESS_STEP
+        return unless (processed % PROGRESS_STEP).zero? || processed == total
+
+        breakdown = @stats.map { |k, v| "#{k}=#{v}" }.join(', ')
+        info "Progress: #{processed}/#{total} (#{breakdown})"
+      end
 
       def process_domain(domain_id)
         if @config_class.exists_for_domain?(domain_id)

--- a/migrations/2026-04-17/20260417_01_backfill_homepage_config.rb
+++ b/migrations/2026-04-17/20260417_01_backfill_homepage_config.rb
@@ -115,12 +115,6 @@ module Onetime
       end
 
       def process_domain(domain_id)
-        if @config_class.exists_for_domain?(domain_id)
-          track_stat(:skipped_existing)
-          info "Skip (existing HomepageConfig): #{domain_id}"
-          return
-        end
-
         domain = @model_class.find_by_identifier(domain_id)
         unless domain
           track_stat(:skipped_missing_domain)
@@ -131,12 +125,29 @@ module Onetime
         legacy_enabled = domain.brand_settings.allow_public_homepage?
 
         if dry_run?
-          track_stat(legacy_enabled ? :would_migrate_true : :would_migrate_false)
-          info "[DRY RUN] would upsert HomepageConfig(domain_id=#{domain_id}, enabled=#{legacy_enabled})"
-        else
-          @config_class.upsert(domain_id: domain_id, enabled: legacy_enabled)
+          if @config_class.exists_for_domain?(domain_id)
+            track_stat(:skipped_existing)
+            info "[DRY RUN] skip (existing HomepageConfig): #{domain_id}"
+          else
+            track_stat(legacy_enabled ? :would_migrate_true : :would_migrate_false)
+            info "[DRY RUN] would create HomepageConfig(domain_id=#{domain_id}, enabled=#{legacy_enabled})"
+          end
+          return
+        end
+
+        # find_or_create_for_domain uses WATCH+MULTI; a concurrent PUT that
+        # wrote first wins and we return :existed without stomping their value.
+        _config, outcome = @config_class.find_or_create_for_domain(
+          domain_id: domain_id, enabled: legacy_enabled,
+        )
+
+        case outcome
+        when :created
           track_stat(legacy_enabled ? :migrated_true : :migrated_false)
-          info "Upserted HomepageConfig(domain_id=#{domain_id}, enabled=#{legacy_enabled})"
+          info "Created HomepageConfig(domain_id=#{domain_id}, enabled=#{legacy_enabled})"
+        when :existed
+          track_stat(:skipped_existing)
+          info "Skip (existing HomepageConfig): #{domain_id}"
         end
       end
     end

--- a/try/migrations/homepage_config_backfill_try.rb
+++ b/try/migrations/homepage_config_backfill_try.rb
@@ -133,7 +133,14 @@ Onetime::CustomDomain::HomepageConfig.exists_for_domain?(@domain_off.identifier)
 
 # --- Error path: per-domain rescue in migrate ---
 #
-# One domain is rigged so that CustomDomain.find_by_identifier raises for it.
+# One domain is rigged so that its `brand` Redis key is the wrong Redis type
+# (string instead of hash). CustomDomain.find_by_identifier returns the domain
+# normally, but the downstream call `domain.brand_settings.allow_public_homepage?`
+# triggers `brand.hgetall`, which raises Redis::CommandError (WRONGTYPE).
+# This exercises the per-domain rescue in `migrate` via real data corruption
+# rather than monkey-patching class methods, so the test survives Familia /
+# redis-rb version changes that would break singleton-method stubs.
+#
 # The migration must count :errors, keep processing the remaining domains,
 # and must not raise out of migrate.
 # Bare code between ## blocks does not execute in Tryouts; we wrap setup in
@@ -154,28 +161,23 @@ Familia.dbclient.flushdb
 [@raising_id.to_s.length.positive?, @domain_ok.identifier.to_s.length.positive?]
 #=> [true, true]
 
-## Setup: install singleton override that raises for one specific id
-# Capture closure variables (define_singleton_method's block runs with self bound
-# to the class; instance variables inside the block would resolve against the
-# class, not this test context).
-@original_find      = Onetime::CustomDomain.method(:find_by_identifier)
-Onetime::CustomDomain.singleton_class.send(:alias_method, :__orig_find_for_test, :find_by_identifier)
-captured_raising_id = @raising_id
-Onetime::CustomDomain.define_singleton_method(:find_by_identifier) do |id|
-  raise StandardError, "simulated failure for #{id}" if id == captured_raising_id
+## Setup: corrupt the raising domain's brand key (hash -> string) so hgetall raises WRONGTYPE
+@brand_dbkey = @domain_err.brand.dbkey
+Familia.dbclient.del(@brand_dbkey)
+Familia.dbclient.set(@brand_dbkey, 'corrupted-not-a-hash')
+Familia.dbclient.type(@brand_dbkey)
+#=> "string"
 
-  __orig_find_for_test(id)
-end
-# Sanity: routes raising id to StandardError, non-raising id to a real domain
+## Sanity: fresh domain load raises from brand_settings due to WRONGTYPE, non-raising domain loads cleanly
 sanity =
   begin
-    Onetime::CustomDomain.find_by_identifier(@raising_id)
+    Onetime::CustomDomain.find_by_identifier(@raising_id).brand_settings.allow_public_homepage?
     :no_raise
   rescue StandardError
     :raised
   end
-ok_domain = Onetime::CustomDomain.find_by_identifier(@domain_ok.identifier)
-[sanity, ok_domain&.identifier == @domain_ok.identifier]
+ok_fresh = Onetime::CustomDomain.find_by_identifier(@domain_ok.identifier)
+[sanity, ok_fresh&.identifier == @domain_ok.identifier]
 #=> [:raised, true]
 
 ## Error run completes without raising
@@ -199,12 +201,6 @@ Onetime::CustomDomain::HomepageConfig.find_by_domain_id(@domain_ok.identifier).e
 ## Raising domain did not get a HomepageConfig written
 Onetime::CustomDomain::HomepageConfig.exists_for_domain?(@raising_id)
 #=> false
-
-## Teardown: remove the singleton override so the class method is restored
-Onetime::CustomDomain.singleton_class.send(:remove_method, :find_by_identifier)
-Onetime::CustomDomain.singleton_class.send(:remove_method, :__orig_find_for_test)
-Onetime::CustomDomain.find_by_identifier(@domain_ok.identifier).identifier == @domain_ok.identifier
-#=> true
 
 # --- migration_needed? false when all domains already have HomepageConfig ---
 
@@ -285,6 +281,33 @@ Onetime::CustomDomain.instances.to_a
 [@empty_run.stats[:migrated_true], @empty_run.stats[:migrated_false],
  @empty_run.stats[:skipped_existing], @empty_run.stats[:errors]]
 #=> [0, 0, 0, 0]
+
+# --- Stale instances entry: identifier in sorted set but domain record missing ---
+
+## Setup: flush and stage one real domain plus a stale identifier in the sorted set
+Familia.dbclient.flushdb
+@ts_stale    = Familia.now.to_i
+@owner_stale = Onetime::Customer.create!(email: "hp_stale_owner_#{@ts_stale}_#{SecureRandom.hex(4)}@test.com")
+@org_stale   = Onetime::Organization.create!("HpStale Test Org #{@ts_stale}", @owner_stale, "hp_stale_#{@ts_stale}@test.com")
+@stale_id    = 'nonexistent_domain_id_xyz'
+
+@domain_stale                                = Onetime::CustomDomain.create!("hp-stale-#{@ts_stale}.example.com", @org_stale.objid)
+@domain_stale.brand['allow_public_homepage'] = true
+@domain_stale.instance_variable_set(:@brand_settings, nil)
+
+Familia.dbclient.zadd(Onetime::CustomDomain.instances.dbkey, Familia.now.to_f, @stale_id)
+[Onetime::CustomDomain.instances.size,
+ Onetime::CustomDomain.find_by_identifier(@stale_id).nil?]
+#=> [2, true]
+
+## skipped_missing_domain: migrate succeeds, stale id is skipped, real domain is backfilled
+@stale_run = Onetime::Migrations::BackfillHomepageConfig.new(run: true).tap(&:prepare)
+@stale_run.migrate
+[@stale_run.stats[:skipped_missing_domain],
+ @stale_run.stats[:migrated_true],
+ Onetime::CustomDomain::HomepageConfig.exists_for_domain?(@domain_stale.identifier),
+ Onetime::CustomDomain::HomepageConfig.find_by_domain_id(@domain_stale.identifier).enabled?]
+#=> [1, 1, true, true]
 
 # Teardown
 Familia.dbclient.flushdb

--- a/try/migrations/homepage_config_backfill_try.rb
+++ b/try/migrations/homepage_config_backfill_try.rb
@@ -1,0 +1,290 @@
+# try/migrations/homepage_config_backfill_try.rb
+#
+# frozen_string_literal: true
+
+# Tests for migrations/2026-04-17/20260417_01_backfill_homepage_config.rb
+#
+# Covers:
+#   - migration_needed? is true when a domain has legacy
+#     brand_settings.allow_public_homepage but no HomepageConfig record
+#   - dry-run performs no writes
+#   - actual run creates HomepageConfig with enabled=true for legacy-on domains,
+#     enabled=false for legacy-off domains, and leaves pre-existing records alone
+#   - re-running is idempotent (all domains reported as skipped_existing)
+
+require_relative '../support/test_models'
+require 'familia/migration'
+require_relative '../../migrations/2026-04-17/20260417_01_backfill_homepage_config'
+
+OT.boot! :test
+
+Familia.dbclient.flushdb
+OT.info 'Cleaned Redis for HomepageConfig backfill migration test run'
+
+@ts      = Familia.now.to_i
+@entropy = SecureRandom.hex(4)
+@owner   = Onetime::Customer.create!(email: "hp_bf_owner_#{@ts}_#{@entropy}@test.com")
+@org     = Onetime::Organization.create!("HpBf Test Org #{@ts}", @owner, "hp_bf_#{@ts}@test.com")
+
+# Domain A: legacy allow_public_homepage = true, no HomepageConfig yet.
+@domain_on                                = Onetime::CustomDomain.create!("hp-bf-on-#{@ts}.example.com", @org.objid)
+@domain_on.brand['allow_public_homepage'] = true
+@domain_on.instance_variable_set(:@brand_settings, nil)
+
+# Domain B: legacy allow_public_homepage = false, no HomepageConfig yet.
+@domain_off                                = Onetime::CustomDomain.create!("hp-bf-off-#{@ts}.example.com", @org.objid)
+@domain_off.brand['allow_public_homepage'] = false
+@domain_off.instance_variable_set(:@brand_settings, nil)
+
+# Domain C: pre-existing HomepageConfig(enabled=true), legacy value false.
+# The migration must not overwrite this record.
+@domain_pre                                = Onetime::CustomDomain.create!("hp-bf-pre-#{@ts}.example.com", @org.objid)
+@domain_pre.brand['allow_public_homepage'] = false
+@domain_pre.instance_variable_set(:@brand_settings, nil)
+Onetime::CustomDomain::HomepageConfig.upsert(domain_id: @domain_pre.identifier, enabled: true)
+
+## Setup: brand_settings reflects the staged values
+[@domain_on.brand_settings.allow_public_homepage?,
+ @domain_off.brand_settings.allow_public_homepage?,
+ @domain_pre.brand_settings.allow_public_homepage?]
+#=> [true, false, false]
+
+## Setup: only the pre-existing domain starts with a HomepageConfig
+[Onetime::CustomDomain::HomepageConfig.exists_for_domain?(@domain_on.identifier),
+ Onetime::CustomDomain::HomepageConfig.exists_for_domain?(@domain_off.identifier),
+ Onetime::CustomDomain::HomepageConfig.exists_for_domain?(@domain_pre.identifier)]
+#=> [false, false, true]
+
+## migration_needed? is true before any run
+@migration = Onetime::Migrations::BackfillHomepageConfig.new
+@migration.prepare
+@migration.migration_needed?
+#=> true
+
+# --- Dry run ---
+
+## Dry run completes successfully
+@dry = Onetime::Migrations::BackfillHomepageConfig.new(run: false)
+@dry.prepare
+@dry.migrate
+#=> true
+
+## Dry run records no writes for the on-domain
+Onetime::CustomDomain::HomepageConfig.exists_for_domain?(@domain_on.identifier)
+#=> false
+
+## Dry run records no writes for the off-domain
+Onetime::CustomDomain::HomepageConfig.exists_for_domain?(@domain_off.identifier)
+#=> false
+
+## Dry run reports both unmigrated domains under would_migrate_*
+[@dry.stats[:would_migrate_true], @dry.stats[:would_migrate_false]]
+#=> [1, 1]
+
+## Dry run skips the pre-existing record
+@dry.stats[:skipped_existing]
+#=> 1
+
+## Dry run performs no writes and reports zero errors
+[@dry.stats[:migrated_true], @dry.stats[:migrated_false], @dry.stats[:errors]]
+#=> [0, 0, 0]
+
+# --- Actual run ---
+
+## Actual run completes successfully
+@run = Onetime::Migrations::BackfillHomepageConfig.new(run: true)
+@run.prepare
+@run.migrate
+#=> true
+
+## On-domain now has HomepageConfig(enabled=true)
+@cfg_on = Onetime::CustomDomain::HomepageConfig.find_by_domain_id(@domain_on.identifier)
+@cfg_on.enabled?
+#=> true
+
+## Off-domain now has HomepageConfig(enabled=false)
+@cfg_off = Onetime::CustomDomain::HomepageConfig.find_by_domain_id(@domain_off.identifier)
+@cfg_off.enabled?
+#=> false
+
+## Pre-existing HomepageConfig is untouched (still enabled=true)
+@cfg_pre = Onetime::CustomDomain::HomepageConfig.find_by_domain_id(@domain_pre.identifier)
+@cfg_pre.enabled?
+#=> true
+
+## Actual run counts match: one true, one false migrated, one skipped
+[@run.stats[:migrated_true], @run.stats[:migrated_false], @run.stats[:skipped_existing], @run.stats[:errors]]
+#=> [1, 1, 1, 0]
+
+# --- Idempotency ---
+
+## After apply, migration_needed? returns false
+@check = Onetime::Migrations::BackfillHomepageConfig.new
+@check.prepare
+@check.migration_needed?
+#=> false
+
+## Re-running records all three domains as skipped_existing with no writes
+@rerun = Onetime::Migrations::BackfillHomepageConfig.new(run: true)
+@rerun.prepare
+@rerun.migrate
+[@rerun.stats[:skipped_existing], @rerun.stats[:migrated_true], @rerun.stats[:migrated_false], @rerun.stats[:errors]]
+#=> [3, 0, 0, 0]
+
+# --- Error path: per-domain rescue in migrate ---
+#
+# One domain is rigged so that CustomDomain.find_by_identifier raises for it.
+# The migration must count :errors, keep processing the remaining domains,
+# and must not raise out of migrate.
+# Bare code between ## blocks does not execute in Tryouts; we wrap setup in
+# explicit setup testcases so @ivars propagate.
+
+## Setup: flush Redis and stage raising + non-raising domain fixtures
+Familia.dbclient.flushdb
+@ts_err       = Familia.now.to_i
+@owner_err    = Onetime::Customer.create!(email: "hp_err_owner_#{@ts_err}_#{SecureRandom.hex(4)}@test.com")
+@org_err      = Onetime::Organization.create!("HpErr Test Org #{@ts_err}", @owner_err, "hp_err_#{@ts_err}@test.com")
+@domain_err                                = Onetime::CustomDomain.create!("hp-err-raise-#{@ts_err}.example.com", @org_err.objid)
+@domain_err.brand['allow_public_homepage'] = true
+@domain_err.instance_variable_set(:@brand_settings, nil)
+@domain_ok                                 = Onetime::CustomDomain.create!("hp-err-ok-#{@ts_err}.example.com", @org_err.objid)
+@domain_ok.brand['allow_public_homepage']  = false
+@domain_ok.instance_variable_set(:@brand_settings, nil)
+@raising_id                                = @domain_err.identifier
+[@raising_id.to_s.length.positive?, @domain_ok.identifier.to_s.length.positive?]
+#=> [true, true]
+
+## Setup: install singleton override that raises for one specific id
+# Capture closure variables (define_singleton_method's block runs with self bound
+# to the class; instance variables inside the block would resolve against the
+# class, not this test context).
+@original_find      = Onetime::CustomDomain.method(:find_by_identifier)
+Onetime::CustomDomain.singleton_class.send(:alias_method, :__orig_find_for_test, :find_by_identifier)
+captured_raising_id = @raising_id
+Onetime::CustomDomain.define_singleton_method(:find_by_identifier) do |id|
+  raise StandardError, "simulated failure for #{id}" if id == captured_raising_id
+
+  __orig_find_for_test(id)
+end
+# Sanity: routes raising id to StandardError, non-raising id to a real domain
+sanity =
+  begin
+    Onetime::CustomDomain.find_by_identifier(@raising_id)
+    :no_raise
+  rescue StandardError
+    :raised
+  end
+ok_domain = Onetime::CustomDomain.find_by_identifier(@domain_ok.identifier)
+[sanity, ok_domain&.identifier == @domain_ok.identifier]
+#=> [:raised, true]
+
+## Error run completes without raising
+@err_run = Onetime::Migrations::BackfillHomepageConfig.new(run: true)
+@err_run.prepare
+@err_run.migrate
+#=> true
+
+## Error count is at least one
+@err_run.stats[:errors] >= 1
+#=> true
+
+## Non-raising domain still received its HomepageConfig
+Onetime::CustomDomain::HomepageConfig.exists_for_domain?(@domain_ok.identifier)
+#=> true
+
+## Non-raising domain's HomepageConfig reflects the legacy value (false)
+Onetime::CustomDomain::HomepageConfig.find_by_domain_id(@domain_ok.identifier).enabled?
+#=> false
+
+## Raising domain did not get a HomepageConfig written
+Onetime::CustomDomain::HomepageConfig.exists_for_domain?(@raising_id)
+#=> false
+
+## Teardown: remove the singleton override so the class method is restored
+Onetime::CustomDomain.singleton_class.send(:remove_method, :find_by_identifier)
+Onetime::CustomDomain.singleton_class.send(:remove_method, :__orig_find_for_test)
+Onetime::CustomDomain.find_by_identifier(@domain_ok.identifier).identifier == @domain_ok.identifier
+#=> true
+
+# --- migration_needed? false when all domains already have HomepageConfig ---
+
+## Setup: flush and stage two domains that already have HomepageConfigs
+Familia.dbclient.flushdb
+@ts_pre    = Familia.now.to_i
+@owner_pre = Onetime::Customer.create!(email: "hp_pre_owner_#{@ts_pre}_#{SecureRandom.hex(4)}@test.com")
+@org_pre   = Onetime::Organization.create!("HpPre Test Org #{@ts_pre}", @owner_pre, "hp_pre_#{@ts_pre}@test.com")
+@domain_p1 = Onetime::CustomDomain.create!("hp-pre-1-#{@ts_pre}.example.com", @org_pre.objid)
+@domain_p2 = Onetime::CustomDomain.create!("hp-pre-2-#{@ts_pre}.example.com", @org_pre.objid)
+Onetime::CustomDomain::HomepageConfig.upsert(domain_id: @domain_p1.identifier, enabled: true)
+Onetime::CustomDomain::HomepageConfig.upsert(domain_id: @domain_p2.identifier, enabled: false)
+[Onetime::CustomDomain::HomepageConfig.exists_for_domain?(@domain_p1.identifier),
+ Onetime::CustomDomain::HomepageConfig.exists_for_domain?(@domain_p2.identifier)]
+#=> [true, true]
+
+## needed_false_all_preexisting: every domain already has a config
+@pre_check = Onetime::Migrations::BackfillHomepageConfig.new
+@pre_check.prepare
+@pre_check.migration_needed?
+#=> false
+
+# --- Missing brand field defaults to disabled ---
+
+## Setup: flush and stage a domain with no allow_public_homepage brand key
+Familia.dbclient.flushdb
+@ts_def     = Familia.now.to_i
+@owner_def  = Onetime::Customer.create!(email: "hp_def_owner_#{@ts_def}_#{SecureRandom.hex(4)}@test.com")
+@org_def    = Onetime::Organization.create!("HpDef Test Org #{@ts_def}", @owner_def, "hp_def_#{@ts_def}@test.com")
+@domain_def = Onetime::CustomDomain.create!("hp-def-#{@ts_def}.example.com", @org_def.objid)
+@domain_def.brand.delete('allow_public_homepage') if @domain_def.brand.key?('allow_public_homepage')
+@domain_def.instance_variable_set(:@brand_settings, nil)
+@domain_def.brand.key?('allow_public_homepage')
+#=> false
+
+## BrandSettings::DEFAULTS yields false for missing allow_public_homepage
+@domain_def.brand_settings.allow_public_homepage?
+#=> false
+
+## Migration still reports needed (any domain without HomepageConfig qualifies)
+@def_check = Onetime::Migrations::BackfillHomepageConfig.new
+@def_check.prepare
+@def_check.migration_needed?
+#=> true
+
+## missing_brand_setting_defaults_false: after migrate HomepageConfig exists and is disabled
+@def_run = Onetime::Migrations::BackfillHomepageConfig.new(run: true)
+@def_run.prepare
+@def_run.migrate
+@def_cfg = Onetime::CustomDomain::HomepageConfig.find_by_domain_id(@domain_def.identifier)
+[@def_cfg.nil?, @def_cfg&.enabled?]
+#=> [false, false]
+
+## Stats reflect one false-valued migration
+@def_run.stats[:migrated_false]
+#=> 1
+
+# --- Empty instances set ---
+
+## Setup: flush Redis so CustomDomain.instances is empty
+Familia.dbclient.flushdb
+Onetime::CustomDomain.instances.to_a
+#=> []
+
+## empty_instances_set: migration_needed? is false with zero domains
+@empty_check = Onetime::Migrations::BackfillHomepageConfig.new
+@empty_check.prepare
+@empty_check.migration_needed?
+#=> false
+
+## empty_instances_set: migrate returns true without raising and writes nothing
+@empty_run = Onetime::Migrations::BackfillHomepageConfig.new(run: true)
+@empty_run.prepare
+@empty_run.migrate
+#=> true
+
+## empty_instances_set: all counters are zero
+[@empty_run.stats[:migrated_true], @empty_run.stats[:migrated_false],
+ @empty_run.stats[:skipped_existing], @empty_run.stats[:errors]]
+#=> [0, 0, 0, 0]
+
+# Teardown
+Familia.dbclient.flushdb

--- a/try/unit/models/custom_domain_api_config_try.rb
+++ b/try/unit/models/custom_domain_api_config_try.rb
@@ -136,5 +136,64 @@ Onetime::CustomDomain::ApiConfig.exists_for_domain?(@domain_no_cfg.identifier)
 @domain_no_cfg.allow_public_api?
 #=> false
 
+# --- find_or_create_for_domain: atomic create-if-missing ---
+
+## Setup: a fresh domain with no ApiConfig
+@focd_domain = Onetime::CustomDomain.create!("api-cfg-focd-#{@ts}.example.com", @org.objid)
+Onetime::CustomDomain::ApiConfig.exists_for_domain?(@focd_domain.identifier)
+#=> false
+
+## find_or_create_for_domain on missing record returns :created
+@focd_config, @focd_outcome = Onetime::CustomDomain::ApiConfig.find_or_create_for_domain(
+  domain_id: @focd_domain.identifier, enabled: true,
+)
+@focd_outcome
+#=> :created
+
+## Created record has the requested enabled value
+@focd_config.enabled?
+#=> true
+
+## Created record persists (exists_for_domain? is true)
+Onetime::CustomDomain::ApiConfig.exists_for_domain?(@focd_domain.identifier)
+#=> true
+
+## find_or_create_for_domain on existing record returns :existed
+@focd_config2, @focd_outcome2 = Onetime::CustomDomain::ApiConfig.find_or_create_for_domain(
+  domain_id: @focd_domain.identifier, enabled: false,
+)
+@focd_outcome2
+#=> :existed
+
+## Existing record's enabled value is preserved (proposed false did NOT overwrite the true)
+@focd_config2.enabled?
+#=> true
+
+## Returned existing record has same domain_id
+@focd_config2.domain_id == @focd_domain.identifier
+#=> true
+
+## Reload confirms the stored value was not overwritten by the second call
+Onetime::CustomDomain::ApiConfig.find_by_domain_id(@focd_domain.identifier).enabled?
+#=> true
+
+## find_or_create_for_domain raises Problem when domain_id is empty string
+begin
+  Onetime::CustomDomain::ApiConfig.find_or_create_for_domain(domain_id: '', enabled: true)
+  'unexpected_success'
+rescue Onetime::Problem => e
+  e.message
+end
+#=> 'domain_id is required'
+
+## find_or_create_for_domain raises Problem when domain_id is nil
+begin
+  Onetime::CustomDomain::ApiConfig.find_or_create_for_domain(domain_id: nil, enabled: true)
+  'unexpected_success'
+rescue Onetime::Problem => e
+  e.message
+end
+#=> 'domain_id is required'
+
 # Teardown
 Familia.dbclient.flushdb

--- a/try/unit/models/custom_domain_destroy_cascade_try.rb
+++ b/try/unit/models/custom_domain_destroy_cascade_try.rb
@@ -4,7 +4,8 @@
 
 #
 # Tests that CustomDomain.destroy! cascades to:
-# 1. Domain-specific configs (SsoConfig, MailerConfig, IncomingConfig)
+# 1. Domain-specific configs (HomepageConfig, ApiConfig, SsoConfig,
+#    MailerConfig, IncomingConfig)
 # 2. Domain-scoped memberships (SSO-provisioned users restricted to this domain)
 #
 # After destroy!, all associated resources should be cleaned up.
@@ -17,6 +18,12 @@ OT.boot! :test
 @org = Onetime::Organization.create!("Cascade Test Org", @owner, generate_unique_test_email("cascade_contact"))
 @domain = Onetime::CustomDomain.create!("cascade-test.example.com", @org.objid)
 @domain_id = @domain.identifier
+
+# Stage sibling configs — HomepageConfig + ApiConfig exercise the cleanup path
+# added alongside the #3023 backfill migration work; the others were already
+# cleaned prior to that change.
+Onetime::CustomDomain::HomepageConfig.upsert(domain_id: @domain_id, enabled: true)
+Onetime::CustomDomain::ApiConfig.upsert(domain_id: @domain_id, enabled: true)
 
 # Create domain-scoped members
 @scoped_user_a = Onetime::Customer.create!(email: generate_unique_test_email("cascade_scoped_a"))
@@ -51,10 +58,26 @@ Onetime::OrganizationMembership.find_all_by_domain_scope(@domain.objid).size
 @domain.exists?
 #=> true
 
+## Pre-condition: HomepageConfig exists
+Onetime::CustomDomain::HomepageConfig.exists_for_domain?(@domain_id)
+#=> true
+
+## Pre-condition: ApiConfig exists
+Onetime::CustomDomain::ApiConfig.exists_for_domain?(@domain_id)
+#=> true
+
 ## Destroy the domain (triggers cascade)
 @domain.destroy!
 true
 #=> true
+
+## After destroy: HomepageConfig was cleaned up
+Onetime::CustomDomain::HomepageConfig.exists_for_domain?(@domain_id)
+#=> false
+
+## After destroy: ApiConfig was cleaned up
+Onetime::CustomDomain::ApiConfig.exists_for_domain?(@domain_id)
+#=> false
 
 ## After destroy: domain-scoped memberships are removed
 Onetime::OrganizationMembership.find_all_by_domain_scope(@domain_id).size
@@ -84,8 +107,120 @@ Onetime::OrganizationMembership.exists?(@org_membership_objid)
 @org.member?(@scoped_user_b)
 #=> false
 
+# --- Destroy with no sibling configs present is a no-op on cleanup ---
+#
+# Bare code between `##` testcases does not execute under Tryouts; wrap
+# setup as its own testcase so @ivars propagate to subsequent testcases.
+
+## Setup: fresh domain with no sibling configs
+@bare_owner = Onetime::Customer.create!(email: generate_unique_test_email("cascade_bare"))
+@bare_org = Onetime::Organization.create!("Cascade Bare Org", @bare_owner, generate_unique_test_email("cascade_bare_contact"))
+@bare_domain = Onetime::CustomDomain.create!("cascade-bare.example.com", @bare_org.objid)
+@bare_domain_id = @bare_domain.identifier
+[Onetime::CustomDomain::HomepageConfig.exists_for_domain?(@bare_domain_id),
+ Onetime::CustomDomain::ApiConfig.exists_for_domain?(@bare_domain_id),
+ Onetime::CustomDomain::SsoConfig.exists_for_domain?(@bare_domain_id),
+ Onetime::CustomDomain::MailerConfig.exists_for_domain?(@bare_domain_id),
+ Onetime::CustomDomain::IncomingConfig.exists_for_domain?(@bare_domain_id)]
+#=> [false, false, false, false, false]
+
+## Destroy on bare domain does not raise
+@bare_domain.destroy!
+true
+#=> true
+
+## Bare domain is gone
+Onetime::CustomDomain.find_by_identifier(@bare_domain_id)
+#=> nil
+
+# --- One sibling cleanup raising does not block the others ---
+#
+# Stub HomepageConfig.delete_for_domain! to raise, confirm ApiConfig is still
+# cleaned up and destroy! still completes. Restore the stub afterwards so
+# cleanup below runs normally.
+
+## Setup: fail-path domain with both HomepageConfig and ApiConfig present
+@fail_owner = Onetime::Customer.create!(email: generate_unique_test_email("cascade_fail"))
+@fail_org = Onetime::Organization.create!("Cascade Fail Org", @fail_owner, generate_unique_test_email("cascade_fail_contact"))
+@fail_domain = Onetime::CustomDomain.create!("cascade-fail.example.com", @fail_org.objid)
+@fail_domain_id = @fail_domain.identifier
+Onetime::CustomDomain::HomepageConfig.upsert(domain_id: @fail_domain_id, enabled: true)
+Onetime::CustomDomain::ApiConfig.upsert(domain_id: @fail_domain_id, enabled: true)
+[Onetime::CustomDomain::HomepageConfig.exists_for_domain?(@fail_domain_id),
+ Onetime::CustomDomain::ApiConfig.exists_for_domain?(@fail_domain_id)]
+#=> [true, true]
+
+## Stubbed HomepageConfig raises during cleanup but destroy! still completes
+hp_class = Onetime::CustomDomain::HomepageConfig
+original_delete = hp_class.method(:delete_for_domain!)
+hp_class.define_singleton_method(:delete_for_domain!) do |_domain_id|
+  raise Familia::HorreumError, "forced cleanup failure"
+end
+begin
+  @fail_domain.destroy!
+  :completed
+ensure
+  hp_class.define_singleton_method(:delete_for_domain!) do |domain_id|
+    original_delete.call(domain_id)
+  end
+end
+#=> :completed
+
+## ApiConfig was still cleaned up despite HomepageConfig raising
+Onetime::CustomDomain::ApiConfig.exists_for_domain?(@fail_domain_id)
+#=> false
+
+## Domain hash is gone — the main destroy! ran after sibling cleanups
+Onetime::CustomDomain.find_by_identifier(@fail_domain_id)
+#=> nil
+
+
+# --- Sibling cleanups run before the primary record is destroyed ---
+#
+# Partial-failure recovery depends on this ordering: if super ran first, a
+# mid-cascade failure would orphan siblings with no recovery path. Capture
+# the primary record's existence at sibling-cleanup time to prove the order.
+
+## Setup: ordering-path domain with HomepageConfig present (unique name avoids stale display_domains)
+@order_owner = Onetime::Customer.create!(email: generate_unique_test_email("cascade_order"))
+@order_org = Onetime::Organization.create!("Cascade Order Org", @order_owner, generate_unique_test_email("cascade_order_contact"))
+@order_domain_name = "cascade-order-#{SecureRandom.hex(4)}.example.com"
+@order_domain = Onetime::CustomDomain.create!(@order_domain_name, @order_org.objid)
+@order_domain_id = @order_domain.identifier
+@order_domain_dbkey = @order_domain.dbkey
+Onetime::CustomDomain::HomepageConfig.upsert(domain_id: @order_domain_id, enabled: true)
+Onetime::CustomDomain::HomepageConfig.exists_for_domain?(@order_domain_id)
+#=> true
+
+## Sibling cleanup fires while primary record still exists in Redis
+hp_class = Onetime::CustomDomain::HomepageConfig
+original_delete = hp_class.method(:delete_for_domain!)
+captured_dbkey = @order_domain_dbkey
+captured_primary_exists = nil
+hp_class.define_singleton_method(:delete_for_domain!) do |domain_id|
+  captured_primary_exists = Familia.dbclient.exists?(captured_dbkey)
+  original_delete.call(domain_id)
+end
+begin
+  @order_domain.destroy!
+ensure
+  hp_class.define_singleton_method(:delete_for_domain!) do |domain_id|
+    original_delete.call(domain_id)
+  end
+end
+captured_primary_exists
+#=> true
+
+## After destroy: primary record is gone
+Onetime::CustomDomain.find_by_identifier(@order_domain_id)
+#=> nil
+
 
 # Cleanup
-[@org, @owner, @scoped_user_a, @scoped_user_b, @org_member].each do |obj|
+[@org, @owner, @scoped_user_a, @scoped_user_b, @org_member,
+ @bare_org, @bare_owner, @fail_org, @fail_owner,
+ @order_org, @order_owner].each do |obj|
   obj.destroy! if obj&.respond_to?(:destroy!) && obj.exists?
 end
+# Remove the HomepageConfig we left behind on the fail_domain (the stub blocked its cleanup).
+Onetime::CustomDomain::HomepageConfig.delete_for_domain!(@fail_domain_id) if @fail_domain_id

--- a/try/unit/models/custom_domain_homepage_config_race_try.rb
+++ b/try/unit/models/custom_domain_homepage_config_race_try.rb
@@ -1,0 +1,281 @@
+# try/unit/models/custom_domain_homepage_config_race_try.rb
+#
+# frozen_string_literal: true
+
+# Race-condition tests for CustomDomain::HomepageConfig.find_or_create_for_domain
+#
+# Verifies that concurrent find_or_create_for_domain calls against the same
+# domain_id produce exactly one :created outcome and one :existed outcome,
+# and that the surviving record reflects the winning writer's value (not
+# a silent last-write-wins overwrite of either value).
+#
+# Backed by Familia's save_if_not_exists! (WATCH + MULTI), which raises
+# Familia::RecordExistsError when a racing writer completes first; the
+# find_or_create_for_domain class method catches that and returns :existed.
+#
+# Pattern adapted from try/unit/models/organization_race_condition_try.rb.
+
+require_relative '../../support/test_models'
+
+OT.boot! :test
+
+Familia.dbclient.flushdb
+OT.info 'Cleaned Redis for HomepageConfig race-condition test run'
+
+@ts      = Familia.now.to_i
+@entropy = SecureRandom.hex(4)
+@owner   = Onetime::Customer.create!(email: "hp_race_owner_#{@ts}_#{@entropy}@test.com")
+@org     = Onetime::Organization.create!("HpRace Test Org #{@ts}", @owner, "hp_race_#{@ts}@test.com")
+@domain  = Onetime::CustomDomain.create!("hp-race-#{@ts}.example.com", @org.objid)
+
+## Setup: target domain has no HomepageConfig
+Onetime::CustomDomain::HomepageConfig.exists_for_domain?(@domain.identifier)
+#=> false
+
+# --- Two concurrent writers, different proposed values ---
+#
+# Thread A proposes enabled=true, Thread B proposes enabled=false. Only one
+# writer's value should be persisted; both threads should receive a coherent
+# tuple ([config, :created] or [config, :existed]).
+
+## Concurrent find_or_create_for_domain produces exactly one :created, one :existed
+results = []
+mutex   = Mutex.new
+threads = []
+2.times do |i|
+  threads << Thread.new do
+    proposed = (i == 0)
+    begin
+      cfg, outcome = Onetime::CustomDomain::HomepageConfig.find_or_create_for_domain(
+        domain_id: @domain.identifier, enabled: proposed,
+      )
+      mutex.synchronize do
+        results << { proposed: proposed, outcome: outcome, stored: cfg&.enabled? }
+      end
+    rescue StandardError => e
+      mutex.synchronize { results << { proposed: proposed, error: e.class.name, msg: e.message } }
+    end
+  end
+end
+threads.each(&:join)
+@results = results
+created_count = @results.count { |r| r[:outcome] == :created }
+existed_count = @results.count { |r| r[:outcome] == :existed }
+error_count   = @results.count { |r| r.key?(:error) }
+[created_count, existed_count, error_count]
+#=> [1, 1, 0]
+
+## Exactly one Redis record persisted
+Onetime::CustomDomain::HomepageConfig.exists_for_domain?(@domain.identifier)
+#=> true
+
+## Both threads' returned stored-enabled values agree (single source of truth)
+@results.map { |r| r[:stored] }.uniq.size
+#=> 1
+
+## Persisted record matches the :created writer's proposed value
+@winner            = @results.find { |r| r[:outcome] == :created }
+@reloaded          = Onetime::CustomDomain::HomepageConfig.find_by_domain_id(@domain.identifier)
+@reloaded.enabled? == @winner[:proposed]
+#=> true
+
+## The :existed writer sees the winner's value, not their own proposal
+@loser = @results.find { |r| r[:outcome] == :existed }
+@loser[:stored] == @winner[:proposed]
+#=> true
+
+# --- Race against a pre-existing record: all writers should see :existed ---
+
+## Setup: second domain with a pre-existing HomepageConfig(enabled=true)
+@domain_pre = Onetime::CustomDomain.create!("hp-race-pre-#{@ts}.example.com", @org.objid)
+Onetime::CustomDomain::HomepageConfig.upsert(domain_id: @domain_pre.identifier, enabled: true)
+Onetime::CustomDomain::HomepageConfig.find_by_domain_id(@domain_pre.identifier).enabled?
+#=> true
+
+## Three concurrent find_or_create attempts all report :existed, none overwrite
+pre_results = []
+pre_mutex   = Mutex.new
+pre_threads = []
+3.times do
+  pre_threads << Thread.new do
+    _cfg, outcome = Onetime::CustomDomain::HomepageConfig.find_or_create_for_domain(
+      domain_id: @domain_pre.identifier, enabled: false,
+    )
+    pre_mutex.synchronize { pre_results << outcome }
+  end
+end
+pre_threads.each(&:join)
+[pre_results.count(:existed), pre_results.count(:created), pre_results.size]
+#=> [3, 0, 3]
+
+## Pre-existing record's enabled=true survives unchanged
+Onetime::CustomDomain::HomepageConfig.find_by_domain_id(@domain_pre.identifier).enabled?
+#=> true
+
+# --- Rescue-branch coverage: force the Familia::RecordExistsError path ---
+#
+# The tests above exercise the pre-check short-circuit at line 168-169 (both
+# concurrent callers typically read nil and race, but whichever loses the
+# exists?-inside-WATCH check returns via the rescue). To guarantee the rescue
+# branch at lines 177-179 of homepage_config.rb executes, we stub
+# find_by_domain_id to return nil on the FIRST call per thread, bypassing
+# the pre-check, and pass through on subsequent calls so the re-read inside
+# the rescue branch returns the persisted record.
+
+## Setup: third domain, no HomepageConfig
+@domain_rescue = Onetime::CustomDomain.create!("hp-race-rescue-#{@ts}.example.com", @org.objid)
+Onetime::CustomDomain::HomepageConfig.exists_for_domain?(@domain_rescue.identifier)
+#=> false
+
+## Rescue branch executes: stubbed pre-check forces both threads into save_if_not_exists!
+hp_class         = Onetime::CustomDomain::HomepageConfig
+original_find    = hp_class.method(:find_by_domain_id)
+target_id        = @domain_rescue.identifier  # capture locally so the stub closure sees it
+rescue_latch     = Mutex.new
+rescue_ready     = ConditionVariable.new
+rescue_threads_ready = 0
+rescue_rescue_fired  = { count: 0 } # shared mutable tracker for rescue re-reads
+
+# Stub: per-thread first-call returns nil, subsequent calls pass through.
+# Also synchronize so both threads enter save_if_not_exists! concurrently.
+hp_class.define_singleton_method(:find_by_domain_id) do |domain_id|
+  if domain_id == target_id
+    Thread.current[:hp_rescue_calls] ||= 0
+    Thread.current[:hp_rescue_calls]  += 1
+    if Thread.current[:hp_rescue_calls] == 1
+      # Barrier: wait until both threads have bypassed the pre-check together,
+      # so neither has written yet when both reach save_if_not_exists!
+      rescue_latch.synchronize do
+        rescue_threads_ready += 1
+        if rescue_threads_ready >= 2
+          rescue_ready.broadcast
+        else
+          rescue_ready.wait(rescue_latch)
+        end
+      end
+      nil
+    else
+      # Subsequent calls (the re-read inside the rescue branch) — pass through.
+      rescue_latch.synchronize { rescue_rescue_fired[:count] += 1 }
+      original_find.call(domain_id)
+    end
+  else
+    original_find.call(domain_id)
+  end
+end
+
+rescue_results = []
+rescue_mutex   = Mutex.new
+rescue_threads = []
+2.times do |i|
+  rescue_threads << Thread.new do
+    proposed = (i == 0)
+    begin
+      cfg, outcome = hp_class.find_or_create_for_domain(
+        domain_id: @domain_rescue.identifier, enabled: proposed,
+      )
+      rescue_mutex.synchronize do
+        rescue_results << { proposed: proposed, outcome: outcome, stored: cfg&.enabled? }
+      end
+    rescue StandardError => e
+      rescue_mutex.synchronize { rescue_results << { proposed: proposed, error: e.class.name, msg: e.message } }
+    end
+  end
+end
+rescue_threads.each(&:join)
+
+# Restore original method
+hp_class.define_singleton_method(:find_by_domain_id) do |domain_id|
+  original_find.call(domain_id)
+end
+
+@rescue_results      = rescue_results
+@rescue_rescue_fired = rescue_rescue_fired[:count]
+[
+  @rescue_results.count { |r| r[:outcome] == :created },
+  @rescue_results.count { |r| r[:outcome] == :existed },
+  @rescue_results.count { |r| r.key?(:error) },
+]
+#=> [1, 1, 0]
+
+## Rescue branch re-read executed for the :existed thread (not pre-check)
+@rescue_rescue_fired
+#=> 1
+
+## Surviving Redis record matches the :created writer's proposed value
+@rescue_winner    = @rescue_results.find { |r| r[:outcome] == :created }
+@rescue_persisted = Onetime::CustomDomain::HomepageConfig.find_by_domain_id(@domain_rescue.identifier)
+@rescue_persisted.enabled? == @rescue_winner[:proposed]
+#=> true
+
+## The :existed thread (rescue branch) sees the winner's value
+@rescue_loser = @rescue_results.find { |r| r[:outcome] == :existed }
+@rescue_loser[:stored] == @rescue_winner[:proposed]
+#=> true
+
+# --- Nil re-read after RecordExistsError raises Onetime::Problem ---
+#
+# Exercises the contract-preserving raise at homepage_config.rb:
+#   rescue Familia::RecordExistsError
+#     found = find_by_domain_id(domain_id)
+#     raise Onetime::Problem, "...vanished after conflict" unless found
+#
+# Simulates the case where the record existed at WATCH time (so
+# save_if_not_exists! raises RecordExistsError) but has vanished by the
+# time the rescue branch re-reads (concurrent destroy / eviction / teardown).
+# We stub both find_by_domain_id (to always return nil so the pre-check is
+# bypassed AND the rescue re-read returns nil) AND save_if_not_exists! (to
+# raise RecordExistsError directly, since without a real pre-existing record
+# the WATCH path would actually persist successfully).
+
+## Setup: fourth domain for the vanish scenario
+@domain_vanish = Onetime::CustomDomain.create!("hp-race-vanish-#{@ts}.example.com", @org.objid)
+Onetime::CustomDomain::HomepageConfig.exists_for_domain?(@domain_vanish.identifier)
+#=> false
+
+## Stub find_by_domain_id -> nil and save_if_not_exists! -> raise, then call method
+vanish_class      = Onetime::CustomDomain::HomepageConfig
+@vanish_target_id  = @domain_vanish.identifier
+original_v_find   = vanish_class.method(:find_by_domain_id)
+vanish_class.define_singleton_method(:find_by_domain_id) do |domain_id|
+  if domain_id == @vanish_target_id
+    nil
+  else
+    original_v_find.call(domain_id)
+  end
+end
+# Stub save_if_not_exists! on any instance of HomepageConfig to raise,
+# simulating "record existed at WATCH time" without needing a real racer.
+vanish_class.class_eval do
+  alias_method :__orig_save_if_not_exists!, :save_if_not_exists!
+  define_method(:save_if_not_exists!) do |*|
+    raise Familia::RecordExistsError, "stubbed: record existed at WATCH time"
+  end
+end
+
+@vanish_outcome =
+  begin
+    vanish_class.find_or_create_for_domain(domain_id: @vanish_target_id, enabled: true)
+    :no_raise
+  rescue Onetime::Problem => e
+    [:raised, e.message]
+  end
+
+# Restore stubs
+vanish_class.define_singleton_method(:find_by_domain_id) do |domain_id|
+  original_v_find.call(domain_id)
+end
+vanish_class.class_eval do
+  alias_method :save_if_not_exists!, :__orig_save_if_not_exists!
+  remove_method :__orig_save_if_not_exists!
+end
+
+@vanish_outcome.first
+#=> :raised
+
+## Raised message mentions the vanishing condition and identifies the record
+@vanish_outcome.last.include?('vanished after conflict') && @vanish_outcome.last.include?(@vanish_target_id)
+#=> true
+
+# Teardown
+Familia.dbclient.flushdb

--- a/try/unit/models/custom_domain_homepage_config_try.rb
+++ b/try/unit/models/custom_domain_homepage_config_try.rb
@@ -136,5 +136,64 @@ Onetime::CustomDomain::HomepageConfig.exists_for_domain?(@domain_no_cfg.identifi
 @domain_no_cfg.allow_public_homepage?
 #=> false
 
+# --- find_or_create_for_domain: atomic create-if-missing ---
+
+## Setup: a fresh domain with no HomepageConfig
+@focd_domain = Onetime::CustomDomain.create!("hp-cfg-focd-#{@ts}.example.com", @org.objid)
+Onetime::CustomDomain::HomepageConfig.exists_for_domain?(@focd_domain.identifier)
+#=> false
+
+## find_or_create_for_domain on missing record returns :created
+@focd_config, @focd_outcome = Onetime::CustomDomain::HomepageConfig.find_or_create_for_domain(
+  domain_id: @focd_domain.identifier, enabled: true,
+)
+@focd_outcome
+#=> :created
+
+## Created record has the requested enabled value
+@focd_config.enabled?
+#=> true
+
+## Created record persists (exists_for_domain? is true)
+Onetime::CustomDomain::HomepageConfig.exists_for_domain?(@focd_domain.identifier)
+#=> true
+
+## find_or_create_for_domain on existing record returns :existed
+@focd_config2, @focd_outcome2 = Onetime::CustomDomain::HomepageConfig.find_or_create_for_domain(
+  domain_id: @focd_domain.identifier, enabled: false,
+)
+@focd_outcome2
+#=> :existed
+
+## Existing record's enabled value is preserved (proposed false did NOT overwrite the true)
+@focd_config2.enabled?
+#=> true
+
+## Returned existing record has same domain_id
+@focd_config2.domain_id == @focd_domain.identifier
+#=> true
+
+## Reload confirms the stored value was not overwritten by the second call
+Onetime::CustomDomain::HomepageConfig.find_by_domain_id(@focd_domain.identifier).enabled?
+#=> true
+
+## find_or_create_for_domain raises Problem when domain_id is empty string
+begin
+  Onetime::CustomDomain::HomepageConfig.find_or_create_for_domain(domain_id: '', enabled: true)
+  'unexpected_success'
+rescue Onetime::Problem => e
+  e.message
+end
+#=> 'domain_id is required'
+
+## find_or_create_for_domain raises Problem when domain_id is nil
+begin
+  Onetime::CustomDomain::HomepageConfig.find_or_create_for_domain(domain_id: nil, enabled: true)
+  'unexpected_success'
+rescue Onetime::Problem => e
+  e.message
+end
+#=> 'domain_id is required'
+
 # Teardown
 Familia.dbclient.flushdb


### PR DESCRIPTION
Adds a `Familia::Migration::Base` migration that backfills `HomepageConfig` records for all `CustomDomain` instances lacking one, using `brand_settings.allow_public_homepage` as the source value. Without this, domains with the legacy field set to true but no `HomepageConfig` record render as disabled in the UI and API.

Migration is idempotent via `HomepageConfig.exists_for_domain?` — production was pre-mitigated manually (see #3023 comment); re-running reports all as `:skipped_existing`. Honors `dry_run?`, isolates per-domain errors so one bad record doesn't halt the batch.

37 tryouts cases covering dry-run, apply (true/false), idempotency, stale sorted-set entries, error-path continuation, missing brand field, and empty universe. Error-path test uses Redis WRONGTYPE corruption rather than singleton-method stubs — mechanism-agnostic and version-safe.

Follow-up issues filed: #3026 (remove L529 fallback after migration ships), #3027 (remove vestigial boot-time Redis flag).

Closes #3023