### PR TITLE
[#3027] Remove vestigial ots:migration_needed:db_0 setnx flag

### DIFF
--- a/changelog.d/20260417_120000_delano_3027_remove_vestigial_setnx_flag.rst
+++ b/changelog.d/20260417_120000_delano_3027_remove_vestigial_setnx_flag.rst
@@ -1,0 +1,6 @@
+.. A new scriv changelog fragment.
+
+Removed
+-------
+
+- Dropped the vestigial ``ots:migration_needed:db_0`` SETNX write from the connection pool initializer. The flag was never read and its name misled operators grepping Redis — actual migrations run through ``bin/ots migrate`` and ``Familia::Migration::Base``, which are independent of this key. Removes one Redis round-trip per boot. (#3027)

--- a/lib/onetime/initializers/setup_connection_pool.rb
+++ b/lib/onetime/initializers/setup_connection_pool.rb
@@ -92,11 +92,6 @@ module Onetime
         level: :debug,
       )
 
-      # Optional: Single migration flag for entire DB 0
-      dbkey      = Familia.join(%w[ots migration_needed db_0])
-      first_time = database_pool.with { |conn| conn.setnx(dbkey, '1') } # Direct pool usage for setup
-      OT.ld "[init] Connect database: Setting #{dbkey} to '1' (already set? #{!first_time})"
-
       # Set runtime state
       Onetime::Runtime.update_infrastructure(database_pool: database_pool)
       end


### PR DESCRIPTION
## Summary

- Deletes the 4-line block in `lib/onetime/initializers/setup_connection_pool.rb` that wrote `ots:migration_needed:db_0` via `SETNX` on every boot. The return value was never acted on, the key was never read anywhere in the repo, and its name misled operators grepping Redis for pending migrations.
- Real migration gating lives in `bin/ots migrate` and `Familia::Migration::Base`, which are independent of this key and untouched.
- Removes one Redis round-trip per boot.

Closes #3027.

## Verification

- `git grep 'migration_needed:db_0'` → no readers (only the writer being removed).
- Other `migration_needed` hits (`lib/onetime/cli/migrate_redis_data_command.rb`, `scripts/check-migration-status.sh`, `spec/cli/migrate_command_spec.rb`, `migrations/2025-07-27/`) use a different key shape (`ots:migration_needed:<model>:db_<n>`) or are unrelated method-name collisions.
- No tests asserted on the removed SETNX or log line; no spec/tryout exercises the initializer directly.
- `database_pool` (defined upstream, consumed by `Onetime::Runtime.update_infrastructure` downstream) is preserved.

## Out of scope

- Existing `ots:migration_needed:db_0` key in production Redis is left to age out (no TTL, negligible disk cost).
- Familia migration framework — untouched.

## Test plan

- [ ] CI green
- [ ] Boot the app locally and confirm the initializer log block still prints `✅ DATABASE: Connected …` and the `[init]` setnx line is gone
- [ ] `bin/ots migrate --help` still dispatches correctly (sanity check that migration machinery is unaffected)