### PR TITLE
Add characterization specs for SetupConnectionPool initializer

### DIFF
--- a/spec/integration/all/initializers/setup_connection_pool_spec.rb
+++ b/spec/integration/all/initializers/setup_connection_pool_spec.rb
@@ -5,6 +5,7 @@
 require 'spec_helper'
 require 'connection_pool'
 require 'fileutils'
+require 'socket'
 require 'yaml'
 require 'erb'
 
@@ -19,30 +20,17 @@ require 'erb'
 # (different agent). This file proves the pipes connect; the unit file proves
 # the logic is correct.
 RSpec.describe 'SetupConnectionPool (integration)', type: :integration do
+  include OnetimeStateHelpers
+
   let(:source_config_path) { File.expand_path(File.join(Onetime::HOME, 'spec', 'config.test.yaml')) }
 
   before(:each) do
     # Reset environment variables that boot reads
     ENV['ONETIME_DEBUG'] = nil
 
-    # Reset Onetime module state (mirrors boot_part2_spec.rb lines 22-36).
-    Onetime.instance_variable_set(:@conf, nil)
-    Onetime.instance_variable_set(:@mode, :test)
-    Onetime.instance_variable_set(:@env, 'test')
-    Onetime.instance_variable_set(:@d9s_enabled, nil)
-    Onetime.instance_variable_set(:@debug, nil)
-    Onetime.instance_variable_set(:@i18n_enabled, nil)
-    Onetime.instance_variable_set(:@supported_locales, nil)
-    Onetime.instance_variable_set(:@default_locale, nil)
-    Onetime.instance_variable_set(:@fallback_locale, nil)
-    Onetime.instance_variable_set(:@locale, nil)
-    Onetime.instance_variable_set(:@locales, nil)
-    Onetime.instance_variable_set(:@instance, nil)
-    Onetime.instance_variable_set(:@global_banner, nil)
-    OT::Utils.instance_variable_set(:@fortunes, nil)
-
-    # Reset registry and ready state before each test
-    Onetime.not_ready
+    # Reset Onetime module state via shared helper. The helper keeps the
+    # ivar list in one place; see spec/support/helpers/onetime_state_helpers.rb.
+    reset_onetime_module_state!
 
     # Mock Truemail - unrelated to DB but configured during boot
     truemail_config_double = double('Truemail::Configuration').as_null_object
@@ -108,14 +96,24 @@ RSpec.describe 'SetupConnectionPool (integration)', type: :integration do
   end
 
   describe 'failure mode: URI pointing at a closed port' do
-    # Port 1 is IANA-reserved and virtually guaranteed closed on localhost,
-    # so connect() returns ECONNREFUSED immediately with no retry wall-clock.
-    #
-    # ConfigureFamilia enforces a :2121 guard in test mode; we disable that
-    # guard by stubbing ENV['RACK_ENV'] so the closed-port URI can reach the
-    # pool initializer. A targeted FAMILIA_POOL_TIMEOUT override caps the
-    # ceiling in case the reconnect backoff ladder (50ms/200ms/1s/2s per
-    # setup_connection_pool.rb lines 52-57) stretches the test runtime.
+    # Strategy for obtaining a guaranteed-closed TCP port: bind a TCPServer
+    # to port 0 (OS assigns an ephemeral port), capture the port number, then
+    # close the server. For the short window of this test on a single host,
+    # the kernel is extremely unlikely to hand the same port to another
+    # process. This beats assuming port 1 is closed (which depends on
+    # localhost config and privilege rules).
+    def ephemeral_closed_port
+      server = TCPServer.new('127.0.0.1', 0)
+      port   = server.addr[1]
+      server.close
+      port
+    end
+
+    # FAMILIA_POOL_TIMEOUT caps the wall-clock budget. When connect() returns
+    # ECONNREFUSED against a closed localhost port, it returns immediately —
+    # the reconnect backoff ladder (setup_connection_pool.rb:52-57) only
+    # activates after a successful connection that later drops, so the 1s
+    # ceiling here is a defensive floor, not a load-bearing deadline.
     around do |example|
       original_timeout = ENV['FAMILIA_POOL_TIMEOUT']
       ENV['FAMILIA_POOL_TIMEOUT'] = '1'
@@ -131,24 +129,36 @@ RSpec.describe 'SetupConnectionPool (integration)', type: :integration do
     end
 
     it 'surfaces a connection error rather than silently succeeding' do
+      closed_port = ephemeral_closed_port
+
       # Load config, then rewrite the URI to a closed port before boot runs.
       # This is cleaner than stubbing VALKEY_URL because config.test.yaml
       # hardcodes the URI without ERB - the ENV var wouldn't propagate.
+      # OT::Config.after_load would deep_freeze the returned hash if
+      # OT.testing? were false; it stays true here (see ENV stub rationale
+      # below), so the mutation-after-after_load path continues to work.
       OT::Config.before_load
       raw_conf       = OT::Config.load
       processed_conf = OT::Config.after_load(raw_conf)
-      processed_conf['redis']['uri'] = 'redis://127.0.0.1:1/0'
+      processed_conf['redis']['uri'] = "redis://127.0.0.1:#{closed_port}/0"
       OT.replace_config!(processed_conf)
 
-      # Skip the :2121 test-mode guard in ConfigureFamilia so the closed-port
-      # URI reaches the pool initializer. Using RSpec's ENV stubbing rather
-      # than mutating real ENV to keep the around-block simple.
-      allow(ENV).to receive(:[]).and_call_original
-      allow(ENV).to receive(:[]).with('RACK_ENV').and_return('production')
-
-      # Also skip OT::Config.load during boot so our mutated OT.conf survives.
+      # Skip OT::Config.load during boot so our mutated OT.conf survives.
       allow(OT::Config).to receive(:load).and_return(processed_conf)
       allow(OT::Config).to receive(:after_load).and_return(processed_conf)
+
+      # Neutralize the :2121 test-mode guard in ConfigureFamilia, which uses
+      # ENV['RACK_ENV'] (bracket access) at lib/onetime/initializers/
+      # configure_familia.rb:48. We stub only `[]`, NOT `ENV.fetch`, on
+      # purpose: OT.testing? and OT.env read via fetch, and flipping those
+      # to non-test would trigger deep_freeze on config (blocking the URI
+      # mutation above) and retarget boot_guard!'s BOOT_FAILED branch
+      # (raising instead of retrying). The surgical stub keeps the test
+      # hermetic without those side effects. Gemini code review flagged
+      # ENV[] stubbing as leaky in general; in this specific case, leaking
+      # is exactly what we want.
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with('RACK_ENV').and_return('production')
 
       # Exception matching, not message matching - error messages are an
       # unstable contract surface. Redis::CannotConnectError covers

--- a/spec/integration/all/initializers/setup_connection_pool_spec.rb
+++ b/spec/integration/all/initializers/setup_connection_pool_spec.rb
@@ -1,0 +1,162 @@
+# spec/integration/all/initializers/setup_connection_pool_spec.rb
+#
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'connection_pool'
+require 'fileutils'
+require 'yaml'
+require 'erb'
+
+# Integration coverage for the SetupConnectionPool initializer.
+#
+# The initializer is exercised transitively by boot_part1/2_spec.rb, but the
+# specific end-to-end behaviours (real pool type, live ping through the
+# provider lambda, config-mutation side effects that stick post-boot, and the
+# failure mode against a closed port) are asserted directly here.
+#
+# Pairs with the unit spec in spec/unit/onetime/initializers/
+# (different agent). This file proves the pipes connect; the unit file proves
+# the logic is correct.
+RSpec.describe 'SetupConnectionPool (integration)', type: :integration do
+  let(:source_config_path) { File.expand_path(File.join(Onetime::HOME, 'spec', 'config.test.yaml')) }
+
+  before(:each) do
+    # Reset environment variables that boot reads
+    ENV['ONETIME_DEBUG'] = nil
+
+    # Reset Onetime module state (mirrors boot_part2_spec.rb lines 22-36).
+    Onetime.instance_variable_set(:@conf, nil)
+    Onetime.instance_variable_set(:@mode, :test)
+    Onetime.instance_variable_set(:@env, 'test')
+    Onetime.instance_variable_set(:@d9s_enabled, nil)
+    Onetime.instance_variable_set(:@debug, nil)
+    Onetime.instance_variable_set(:@i18n_enabled, nil)
+    Onetime.instance_variable_set(:@supported_locales, nil)
+    Onetime.instance_variable_set(:@default_locale, nil)
+    Onetime.instance_variable_set(:@fallback_locale, nil)
+    Onetime.instance_variable_set(:@locale, nil)
+    Onetime.instance_variable_set(:@locales, nil)
+    Onetime.instance_variable_set(:@instance, nil)
+    Onetime.instance_variable_set(:@global_banner, nil)
+    OT::Utils.instance_variable_set(:@fortunes, nil)
+
+    # Reset registry and ready state before each test
+    Onetime.not_ready
+
+    # Mock Truemail - unrelated to DB but configured during boot
+    truemail_config_double = double('Truemail::Configuration').as_null_object
+    allow(Truemail).to receive(:configure).and_yield(truemail_config_double)
+
+    # Mock Sentry if defined - also unrelated to DB
+    allow(Sentry).to receive(:init).and_return(true) if defined?(Sentry)
+
+    # Use test config
+    Onetime::Config.path = source_config_path
+
+    # NOTE: Unlike boot_part2_spec.rb, we do NOT stub `Familia.uri=` here.
+    # That spec stubs it because it asserts on global-state flags, not the DB
+    # itself. Here the DB connection IS the subject, so we take the real path
+    # against Valkey on port 2121.
+  end
+
+  after(:each) do
+    Onetime.reset_ready!
+  end
+
+  describe 'golden path against real Valkey on port 2121' do
+    it 'exposes a real ConnectionPool on Onetime::Runtime.infrastructure.database_pool' do
+      Onetime.boot!(:test)
+
+      pool = Onetime::Runtime.infrastructure.database_pool
+      expect(pool).not_to be_nil
+      expect(pool).to be_a(ConnectionPool)
+    end
+
+    it 'returns PONG when Familia.connection_provider is invoked end-to-end' do
+      Onetime.boot!(:test)
+
+      # Exercise the provider lambda with the real URI - this round-trips through
+      # the pool, the Redis client, and the socket to Valkey.
+      conn = Familia.connection_provider.call(Familia.uri.to_s)
+      expect(conn.ping).to eq('PONG')
+    end
+
+    it 'reports database_configured? as true on infrastructure runtime state' do
+      Onetime.boot!(:test)
+
+      # NOTE: Familia v2.4 does not expose `database_configured?`. The
+      # equivalent predicate lives on Onetime::Runtime::Infrastructure and
+      # reflects whether SetupConnectionPool populated the pool slot.
+      expect(Onetime::Runtime.infrastructure.database_configured?).to be true
+    end
+
+    it 'leaves Familia.transaction_mode set to :warn after boot' do
+      Onetime.boot!(:test)
+
+      # The initializer mutates global Familia config. The unit spec mocks
+      # Familia.configure; here we prove the side effect is applied against
+      # the real global.
+      expect(Familia.transaction_mode).to eq(:warn)
+    end
+
+    it 'leaves Familia.pipelined_mode set to :warn after boot' do
+      Onetime.boot!(:test)
+
+      expect(Familia.pipelined_mode).to eq(:warn)
+    end
+  end
+
+  describe 'failure mode: URI pointing at a closed port' do
+    # Port 1 is IANA-reserved and virtually guaranteed closed on localhost,
+    # so connect() returns ECONNREFUSED immediately with no retry wall-clock.
+    #
+    # ConfigureFamilia enforces a :2121 guard in test mode; we disable that
+    # guard by stubbing ENV['RACK_ENV'] so the closed-port URI can reach the
+    # pool initializer. A targeted FAMILIA_POOL_TIMEOUT override caps the
+    # ceiling in case the reconnect backoff ladder (50ms/200ms/1s/2s per
+    # setup_connection_pool.rb lines 52-57) stretches the test runtime.
+    around do |example|
+      original_timeout = ENV['FAMILIA_POOL_TIMEOUT']
+      ENV['FAMILIA_POOL_TIMEOUT'] = '1'
+      begin
+        example.run
+      ensure
+        if original_timeout.nil?
+          ENV.delete('FAMILIA_POOL_TIMEOUT')
+        else
+          ENV['FAMILIA_POOL_TIMEOUT'] = original_timeout
+        end
+      end
+    end
+
+    it 'surfaces a connection error rather than silently succeeding' do
+      # Load config, then rewrite the URI to a closed port before boot runs.
+      # This is cleaner than stubbing VALKEY_URL because config.test.yaml
+      # hardcodes the URI without ERB - the ENV var wouldn't propagate.
+      OT::Config.before_load
+      raw_conf       = OT::Config.load
+      processed_conf = OT::Config.after_load(raw_conf)
+      processed_conf['redis']['uri'] = 'redis://127.0.0.1:1/0'
+      OT.replace_config!(processed_conf)
+
+      # Skip the :2121 test-mode guard in ConfigureFamilia so the closed-port
+      # URI reaches the pool initializer. Using RSpec's ENV stubbing rather
+      # than mutating real ENV to keep the around-block simple.
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with('RACK_ENV').and_return('production')
+
+      # Also skip OT::Config.load during boot so our mutated OT.conf survives.
+      allow(OT::Config).to receive(:load).and_return(processed_conf)
+      allow(OT::Config).to receive(:after_load).and_return(processed_conf)
+
+      # Exception matching, not message matching - error messages are an
+      # unstable contract surface. Redis::CannotConnectError covers
+      # ECONNREFUSED from Redis 5.x client; a broader rescue catches driver
+      # variations without coupling to them.
+      expect {
+        Onetime.boot!(:test)
+      }.to raise_error(Redis::BaseConnectionError)
+    end
+  end
+end

--- a/spec/integration/all/initializers/setup_connection_pool_spec.rb
+++ b/spec/integration/all/initializers/setup_connection_pool_spec.rb
@@ -109,13 +109,27 @@ RSpec.describe 'SetupConnectionPool (integration)', type: :integration do
       port
     end
 
-    # FAMILIA_POOL_TIMEOUT caps the wall-clock budget. When connect() returns
-    # ECONNREFUSED against a closed localhost port, it returns immediately —
-    # the reconnect backoff ladder (setup_connection_pool.rb:52-57) only
-    # activates after a successful connection that later drops, so the 1s
-    # ceiling here is a defensive floor, not a load-bearing deadline.
+    # Snapshot Familia + infrastructure globals around the boot! call. The
+    # initializer pipeline partially completes before SetupConnectionPool
+    # raises: ConfigureFamilia has already set Familia.uri to the closed-port
+    # URI, and SetupConnectionPool has already installed a ConnectionPool +
+    # connection_provider targeting that closed port, before Redis.ping
+    # fails. Without restoration, subsequent specs (anything going through
+    # Familia, e.g. Onetime::BannedIP in the IPBan middleware) route through
+    # the leaked provider and hit ECONNREFUSED against the now-reused
+    # ephemeral port. FullModeSuiteDatabase.setup! uses an idempotent
+    # before(:context) Onetime.boot!, so if it already ran before this
+    # example no subsequent boot! rewrites Familia.uri either — the leak
+    # sticks across the whole suite.
     around do |example|
+      snapshot = snapshot_familia_pool_config
       original_timeout = ENV['FAMILIA_POOL_TIMEOUT']
+      # FAMILIA_POOL_TIMEOUT caps the wall-clock budget. When connect()
+      # returns ECONNREFUSED against a closed localhost port, it returns
+      # immediately — the reconnect backoff ladder
+      # (setup_connection_pool.rb:52-57) only activates after a successful
+      # connection that later drops, so the 1s ceiling here is a defensive
+      # floor, not a load-bearing deadline.
       ENV['FAMILIA_POOL_TIMEOUT'] = '1'
       begin
         example.run
@@ -125,6 +139,7 @@ RSpec.describe 'SetupConnectionPool (integration)', type: :integration do
         else
           ENV['FAMILIA_POOL_TIMEOUT'] = original_timeout
         end
+        restore_familia_pool_config(snapshot)
       end
     end
 

--- a/spec/support/helpers/onetime_state_helpers.rb
+++ b/spec/support/helpers/onetime_state_helpers.rb
@@ -1,0 +1,76 @@
+# spec/support/helpers/onetime_state_helpers.rb
+#
+# frozen_string_literal: true
+
+# Helpers for resetting and restoring Onetime / Familia global state between
+# examples. Several integration specs (boot_part1_spec, boot_part2_spec,
+# setup_connection_pool_spec) repeat the same instance_variable_set ladder;
+# consolidating here keeps those specs from drifting as new module state is
+# added.
+module OnetimeStateHelpers
+  # Module-level ivars that the boot process populates. No public reset API
+  # exists on Onetime for these; instance_variable_set is the only lever.
+  # Restricted to ivars the boot path actually touches to avoid clobbering
+  # test-framework state.
+  ONETIME_RESETTABLE_IVARS = %i[
+    @conf
+    @d9s_enabled
+    @debug
+    @i18n_enabled
+    @supported_locales
+    @default_locale
+    @fallback_locale
+    @locale
+    @locales
+    @instance
+    @global_banner
+  ].freeze
+
+  # Reset the Onetime module to a pre-boot shape. Mirrors the block in
+  # boot_part2_spec.rb and setup_connection_pool_spec.rb. Leaves @mode and
+  # @env as :test / 'test' since most integration specs run in test mode.
+  #
+  # @return [void]
+  def reset_onetime_module_state!
+    ONETIME_RESETTABLE_IVARS.each { |ivar| Onetime.instance_variable_set(ivar, nil) }
+    Onetime.instance_variable_set(:@mode, :test)
+    Onetime.instance_variable_set(:@env, 'test')
+    OT::Utils.instance_variable_set(:@fortunes, nil)
+    Onetime.not_ready
+  end
+
+  # Snapshot of the three Familia pool-related globals that SetupConnectionPool
+  # mutates. Returned as a plain Hash so the caller can pass it to
+  # restore_familia_pool_config. Uses public readers; raw ivar access is only
+  # needed for the writers (see below).
+  #
+  # @return [Hash]
+  def snapshot_familia_pool_config
+    {
+      connection_provider: Familia.connection_provider,
+      transaction_mode:    Familia.instance_variable_get(:@transaction_mode),
+      pipelined_mode:      Familia.instance_variable_get(:@pipelined_mode),
+    }
+  end
+
+  # Restore Familia pool-related globals from a snapshot. Uses public setters
+  # where they exist. Note: Familia.transaction_mode= and pipelined_mode=
+  # validate their input and reject nil, so we round-trip nil via the raw ivar
+  # rather than let the setter raise ArgumentError on a clean-slate snapshot.
+  #
+  # @param snapshot [Hash] from snapshot_familia_pool_config
+  # @return [void]
+  def restore_familia_pool_config(snapshot)
+    Familia.connection_provider = snapshot[:connection_provider]
+    if snapshot[:transaction_mode].nil?
+      Familia.instance_variable_set(:@transaction_mode, nil)
+    else
+      Familia.transaction_mode = snapshot[:transaction_mode]
+    end
+    if snapshot[:pipelined_mode].nil?
+      Familia.instance_variable_set(:@pipelined_mode, nil)
+    else
+      Familia.pipelined_mode = snapshot[:pipelined_mode]
+    end
+  end
+end

--- a/spec/support/helpers/onetime_state_helpers.rb
+++ b/spec/support/helpers/onetime_state_helpers.rb
@@ -39,29 +39,47 @@ module OnetimeStateHelpers
     Onetime.not_ready
   end
 
-  # Snapshot of the three Familia pool-related globals that SetupConnectionPool
-  # mutates. Returned as a plain Hash so the caller can pass it to
-  # restore_familia_pool_config. Uses public readers; raw ivar access is only
-  # needed for the writers (see below).
+  # Snapshot of the Familia + infrastructure globals that SetupConnectionPool
+  # (and the ConfigureFamilia initializer that runs before it) mutate. Returned
+  # as a plain Hash so the caller can pass it to restore_familia_pool_config.
+  #
+  # Captures:
+  # - Familia.connection_provider — the lambda pointing at the process-local pool
+  # - Familia.uri — the default URI used when no provider is installed
+  # - Familia.transaction_mode / pipelined_mode — the :warn/:raise flags
+  # - Onetime::Runtime.infrastructure.database_pool — the live ConnectionPool
+  #
+  # Raw ivar access is used for values whose public setters reject nil
+  # (transaction_mode, pipelined_mode) or normalize the input in ways that
+  # make a clean-slate round-trip impossible (uri).
   #
   # @return [Hash]
   def snapshot_familia_pool_config
     {
       connection_provider: Familia.connection_provider,
+      uri:                 Familia.instance_variable_get(:@uri),
       transaction_mode:    Familia.instance_variable_get(:@transaction_mode),
       pipelined_mode:      Familia.instance_variable_get(:@pipelined_mode),
+      database_pool:       Onetime::Runtime.infrastructure.database_pool,
     }
   end
 
-  # Restore Familia pool-related globals from a snapshot. Uses public setters
-  # where they exist. Note: Familia.transaction_mode= and pipelined_mode=
-  # validate their input and reject nil, so we round-trip nil via the raw ivar
-  # rather than let the setter raise ArgumentError on a clean-slate snapshot.
+  # Restore Familia + infrastructure globals from a snapshot. Uses public
+  # setters where they exist. Notes:
+  # - Familia.transaction_mode= and pipelined_mode= validate their input and
+  #   reject nil, so nil round-trips via the raw ivar.
+  # - Familia.uri= calls normalize_uri which substitutes the current default
+  #   when given nil; the raw ivar is the only way to put a previous value
+  #   (including URI objects or nil) back verbatim.
+  # - Runtime.update_infrastructure is the canonical path for mutating the
+  #   frozen infrastructure Data object; passing database_pool: nil clears
+  #   the pool so a subsequent Onetime.boot! re-installs a fresh one.
   #
   # @param snapshot [Hash] from snapshot_familia_pool_config
   # @return [void]
   def restore_familia_pool_config(snapshot)
     Familia.connection_provider = snapshot[:connection_provider]
+    Familia.instance_variable_set(:@uri, snapshot[:uri])
     if snapshot[:transaction_mode].nil?
       Familia.instance_variable_set(:@transaction_mode, nil)
     else
@@ -72,5 +90,6 @@ module OnetimeStateHelpers
     else
       Familia.pipelined_mode = snapshot[:pipelined_mode]
     end
+    Onetime::Runtime.update_infrastructure(database_pool: snapshot[:database_pool])
   end
 end

--- a/spec/unit/onetime/initializers/setup_connection_pool_spec.rb
+++ b/spec/unit/onetime/initializers/setup_connection_pool_spec.rb
@@ -24,6 +24,8 @@ require 'spec_helper'
 # rubocop:disable RSpec/SpecFilePathFormat
 # File name matches implementation file setup_connection_pool.rb
 RSpec.describe Onetime::Initializers::SetupConnectionPool do
+  include OnetimeStateHelpers
+
   let(:instance) { described_class.new }
 
   # Reusable doubles that stand in for the boundary collaborators. The pool
@@ -36,21 +38,22 @@ RSpec.describe Onetime::Initializers::SetupConnectionPool do
   # .to_s and .size on the collection, so any object responding to to_s works.
   let(:fake_member) { Class.new { def self.to_s; 'FakeModel'; end } }
 
-  # Snapshot/restore Familia global configuration state and Runtime infrastructure
-  # to prevent bleed between examples. Mirrors the infrastructure-restore pattern
-  # in setup_diagnostics_spec.rb.
-  let(:original_infrastructure)       { Onetime::Runtime.infrastructure }
-  let(:original_connection_provider)  { Familia.connection_provider }
-  let(:original_transaction_mode)     { Familia.instance_variable_get(:@transaction_mode) }
-  let(:original_pipelined_mode)       { Familia.instance_variable_get(:@pipelined_mode) }
+  # Snapshot/restore Familia + Runtime state around each example. The around
+  # hook guarantees restoration even when an expectation raises. Uses public
+  # Familia setters via the shared helper; see onetime_state_helpers.rb for
+  # the nil-vs-symbol nuance on transaction_mode / pipelined_mode.
+  around do |example|
+    original_infrastructure = Onetime::Runtime.infrastructure
+    familia_snapshot        = snapshot_familia_pool_config
+    begin
+      example.run
+    ensure
+      Onetime::Runtime.infrastructure = original_infrastructure
+      restore_familia_pool_config(familia_snapshot)
+    end
+  end
 
   before do
-    # Prime snapshots (let! not used — touch each to capture current value).
-    original_infrastructure
-    original_connection_provider
-    original_transaction_mode
-    original_pipelined_mode
-
     # Default: pretend at least one model is loaded, so the empty-members guard
     # does not trip. Individual examples override with [] where they want to
     # assert the raise path.
@@ -73,13 +76,6 @@ RSpec.describe Onetime::Initializers::SetupConnectionPool do
     # Keep the log output out of the test runner.
     allow(OT).to receive(:ld)
     allow(OT).to receive(:log_box)
-  end
-
-  after do
-    Onetime::Runtime.infrastructure = original_infrastructure
-    Familia.instance_variable_set(:@connection_provider, original_connection_provider)
-    Familia.instance_variable_set(:@transaction_mode, original_transaction_mode)
-    Familia.instance_variable_set(:@pipelined_mode, original_pipelined_mode)
   end
 
   describe 'Familia.members guard' do
@@ -174,6 +170,56 @@ RSpec.describe Onetime::Initializers::SetupConnectionPool do
         instance.execute(nil)
       end
     end
+
+    context 'when env vars are empty strings (characterization)' do
+      # ENV.fetch returns the empty string (not the default), and ''.to_i is 0.
+      # Same failure shape as 'abc'/'xyz' but via a different mechanism — worth
+      # pinning separately since the fetch default branch is skipped.
+      before do
+        ENV['FAMILIA_POOL_SIZE']    = ''
+        ENV['FAMILIA_POOL_TIMEOUT'] = ''
+      end
+
+      it 'coerces empty strings to 0 via String#to_i' do
+        expect(ConnectionPool).to receive(:new)
+          .with(hash_including(size: 0, timeout: 0))
+          .and_return(mock_pool)
+        instance.execute(nil)
+      end
+    end
+
+    context 'when env vars are negative integer strings (characterization)' do
+      # The initializer passes the parsed integers through to ConnectionPool.new
+      # without range validation. ConnectionPool itself may reject at runtime,
+      # but that's not this initializer's concern.
+      before do
+        ENV['FAMILIA_POOL_SIZE']    = '-5'
+        ENV['FAMILIA_POOL_TIMEOUT'] = '-1'
+      end
+
+      it 'passes negative integers through unchanged' do
+        expect(ConnectionPool).to receive(:new)
+          .with(hash_including(size: -5, timeout: -1))
+          .and_return(mock_pool)
+        instance.execute(nil)
+      end
+    end
+
+    context 'when env vars are very large integer strings (characterization)' do
+      # Ruby Integer is bignum-capable; no overflow. The point of this test is
+      # to prove the initializer does no capping or truncation of its own.
+      before do
+        ENV['FAMILIA_POOL_SIZE']    = '1000000000'
+        ENV['FAMILIA_POOL_TIMEOUT'] = '999999999'
+      end
+
+      it 'passes large integers through unchanged' do
+        expect(ConnectionPool).to receive(:new)
+          .with(hash_including(size: 1_000_000_000, timeout: 999_999_999))
+          .and_return(mock_pool)
+        instance.execute(nil)
+      end
+    end
   end
 
   describe 'ConnectionPool construction' do
@@ -229,6 +275,20 @@ RSpec.describe Onetime::Initializers::SetupConnectionPool do
 
       # Once inside setup (the ping), plus three provider invocations.
       expect(mock_pool).to have_received(:with).at_least(4).times
+    end
+
+    it 'propagates errors raised by pool.with' do
+      # Characterization: the provider is a thin delegation. It does not
+      # rescue. If pool.with raises (e.g. ConnectionPool::TimeoutError,
+      # ConnectionPool::Error::ConnectionNotEstablished), that error surfaces
+      # to the Familia caller.
+      instance.execute(nil)
+
+      allow(mock_pool).to receive(:with)
+        .and_raise(ConnectionPool::TimeoutError, 'Waited 5 sec')
+
+      provider = Familia.connection_provider
+      expect { provider.call(nil) }.to raise_error(ConnectionPool::TimeoutError)
     end
   end
 

--- a/spec/unit/onetime/initializers/setup_connection_pool_spec.rb
+++ b/spec/unit/onetime/initializers/setup_connection_pool_spec.rb
@@ -1,0 +1,248 @@
+# spec/unit/onetime/initializers/setup_connection_pool_spec.rb
+#
+# frozen_string_literal: true
+
+# SetupConnectionPool Initializer Unit Tests
+#
+# These tests verify the connection-pool initializer's direct behaviour:
+# - Guard against booting before Familia models are loaded
+# - Environment variable parsing for pool size/timeout
+# - ConnectionPool instantiation arguments
+# - Familia.configure side-effects (transaction_mode, pipelined_mode, connection_provider)
+# - connection_provider lambda shape (delegates via pool.with)
+# - Runtime.update_infrastructure receives the constructed pool
+#
+# Fork safety, ConnectionPool internals, log content, Redis.new deep argument
+# shape, and end-to-end ping are covered elsewhere (see puma_initializer_fork_spec.rb,
+# fork_hooks_thread_safety_spec.rb, and the integration spec for this initializer).
+#
+# Run with (standard Ruby): bundle exec rspec spec/unit/onetime/initializers/setup_connection_pool_spec.rb
+# Or, if your project uses a pnpm wrapper: pnpm run test:rspec spec/unit/onetime/initializers/setup_connection_pool_spec.rb
+
+require 'spec_helper'
+
+# rubocop:disable RSpec/SpecFilePathFormat
+# File name matches implementation file setup_connection_pool.rb
+RSpec.describe Onetime::Initializers::SetupConnectionPool do
+  let(:instance) { described_class.new }
+
+  # Reusable doubles that stand in for the boundary collaborators. The pool
+  # yields the redis connection when .with is called; the redis double only
+  # needs to respond to .ping for the connectivity check in the initializer.
+  let(:mock_redis) { instance_double(Redis, ping: 'PONG') }
+  let(:mock_pool) { instance_double(ConnectionPool) }
+
+  # Minimal stand-in for Familia.members entries. The initializer only calls
+  # .to_s and .size on the collection, so any object responding to to_s works.
+  let(:fake_member) { Class.new { def self.to_s; 'FakeModel'; end } }
+
+  # Snapshot/restore Familia global configuration state and Runtime infrastructure
+  # to prevent bleed between examples. Mirrors the infrastructure-restore pattern
+  # in setup_diagnostics_spec.rb.
+  let(:original_infrastructure)       { Onetime::Runtime.infrastructure }
+  let(:original_connection_provider)  { Familia.connection_provider }
+  let(:original_transaction_mode)     { Familia.instance_variable_get(:@transaction_mode) }
+  let(:original_pipelined_mode)       { Familia.instance_variable_get(:@pipelined_mode) }
+
+  before do
+    # Prime snapshots (let! not used — touch each to capture current value).
+    original_infrastructure
+    original_connection_provider
+    original_transaction_mode
+    original_pipelined_mode
+
+    # Default: pretend at least one model is loaded, so the empty-members guard
+    # does not trip. Individual examples override with [] where they want to
+    # assert the raise path.
+    allow(Familia).to receive(:members).and_return([fake_member])
+
+    # Default: a plausible Familia URI is configured. Individual examples that
+    # need specific URI behaviour will re-stub.
+    allow(Familia).to receive(:uri).and_return(URI.parse('redis://127.0.0.1:6379/0'))
+    allow(Familia).to receive(:normalize_uri) do |uri|
+      uri.is_a?(URI) ? uri : URI.parse(uri.to_s)
+    end
+
+    # Default pool/Redis stubs so the happy-path tests don't all have to repeat
+    # them. Examples that want to assert on ConnectionPool.new arguments can
+    # still override with expect(...).
+    allow(ConnectionPool).to receive(:new).and_return(mock_pool)
+    allow(mock_pool).to receive(:with).and_yield(mock_redis)
+    allow(Redis).to receive(:new).and_return(mock_redis)
+
+    # Keep the log output out of the test runner.
+    allow(OT).to receive(:ld)
+    allow(OT).to receive(:log_box)
+  end
+
+  after do
+    Onetime::Runtime.infrastructure = original_infrastructure
+    Familia.instance_variable_set(:@connection_provider, original_connection_provider)
+    Familia.instance_variable_set(:@transaction_mode, original_transaction_mode)
+    Familia.instance_variable_set(:@pipelined_mode, original_pipelined_mode)
+  end
+
+  describe 'Familia.members guard' do
+    # Stubbing Familia.members keeps the test fast; a subprocess test is
+    # possible but overkill for a single-line raise guard.
+    context 'when no Familia members are loaded' do
+      before do
+        allow(Familia).to receive(:members).and_return([])
+      end
+
+      it 'raises Onetime::Problem with a descriptive message' do
+        expect { instance.execute(nil) }.to raise_error(
+          Onetime::Problem,
+          'No known Familia members. Models need to load before boot!',
+        )
+      end
+
+      it 'does not construct a ConnectionPool' do
+        expect(ConnectionPool).not_to receive(:new)
+        expect { instance.execute(nil) }.to raise_error(Onetime::Problem)
+      end
+    end
+
+    context 'when at least one Familia member is loaded' do
+      it 'does not raise' do
+        expect { instance.execute(nil) }.not_to raise_error
+      end
+    end
+  end
+
+  describe 'FAMILIA_POOL_SIZE / FAMILIA_POOL_TIMEOUT environment variables' do
+    around do |example|
+      original_size    = ENV['FAMILIA_POOL_SIZE']
+      original_timeout = ENV['FAMILIA_POOL_TIMEOUT']
+      example.run
+    ensure
+      if original_size.nil?
+        ENV.delete('FAMILIA_POOL_SIZE')
+      else
+        ENV['FAMILIA_POOL_SIZE'] = original_size
+      end
+      if original_timeout.nil?
+        ENV.delete('FAMILIA_POOL_TIMEOUT')
+      else
+        ENV['FAMILIA_POOL_TIMEOUT'] = original_timeout
+      end
+    end
+
+    context 'when both env vars are unset' do
+      before do
+        ENV.delete('FAMILIA_POOL_SIZE')
+        ENV.delete('FAMILIA_POOL_TIMEOUT')
+      end
+
+      it 'defaults size to 25 and timeout to 5' do
+        expect(ConnectionPool).to receive(:new)
+          .with(hash_including(size: 25, timeout: 5))
+          .and_return(mock_pool)
+        instance.execute(nil)
+      end
+    end
+
+    context 'when both env vars are set to valid integer strings' do
+      before do
+        ENV['FAMILIA_POOL_SIZE']    = '50'
+        ENV['FAMILIA_POOL_TIMEOUT'] = '10'
+      end
+
+      it 'uses the parsed integer values' do
+        expect(ConnectionPool).to receive(:new)
+          .with(hash_including(size: 50, timeout: 10))
+          .and_return(mock_pool)
+        instance.execute(nil)
+      end
+    end
+
+    context 'when env vars are set to non-numeric strings (characterization)' do
+      # Characterization test: documents current behaviour. String#to_i on a
+      # non-numeric value returns 0, which produces an unusable ConnectionPool
+      # (size: 0 checkouts always fail). Validation is a separate concern;
+      # this test pins the behaviour so a future change is a deliberate choice,
+      # not an accident.
+      before do
+        ENV['FAMILIA_POOL_SIZE']    = 'abc'
+        ENV['FAMILIA_POOL_TIMEOUT'] = 'xyz'
+      end
+
+      it 'coerces non-numeric values to 0 via String#to_i' do
+        expect(ConnectionPool).to receive(:new)
+          .with(hash_including(size: 0, timeout: 0))
+          .and_return(mock_pool)
+        instance.execute(nil)
+      end
+    end
+  end
+
+  describe 'ConnectionPool construction' do
+    it 'invokes ConnectionPool.new with size, timeout, and reconnect_attempts' do
+      expect(ConnectionPool).to receive(:new)
+        .with(hash_including(size: 25, timeout: 5, reconnect_attempts: 4))
+        .and_return(mock_pool)
+      instance.execute(nil)
+    end
+
+    it 'constructs the pool exactly once' do
+      expect(ConnectionPool).to receive(:new).once.and_return(mock_pool)
+      instance.execute(nil)
+    end
+  end
+
+  describe 'Familia.configure side-effects' do
+    it 'sets transaction_mode to :warn' do
+      instance.execute(nil)
+      expect(Familia.transaction_mode).to eq(:warn)
+    end
+
+    it 'sets pipelined_mode to :warn' do
+      instance.execute(nil)
+      expect(Familia.pipelined_mode).to eq(:warn)
+    end
+
+    it 'installs a connection_provider lambda' do
+      instance.execute(nil)
+      expect(Familia.connection_provider).to respond_to(:call)
+    end
+  end
+
+  describe 'connection_provider lambda shape' do
+    it 'yields via pool.with and returns the checked-out connection' do
+      instance.execute(nil)
+
+      provider = Familia.connection_provider
+      # The lambda ignores its argument and delegates to database_pool.with,
+      # returning whatever the block yields. With our stubbed pool, .with
+      # yields mock_redis, so that's what the provider should return.
+      result = provider.call('redis://ignored')
+
+      expect(mock_pool).to have_received(:with).at_least(:once)
+      expect(result).to eq(mock_redis)
+    end
+
+    it 'can be invoked multiple times' do
+      instance.execute(nil)
+
+      provider = Familia.connection_provider
+      3.times { provider.call(nil) }
+
+      # Once inside setup (the ping), plus three provider invocations.
+      expect(mock_pool).to have_received(:with).at_least(4).times
+    end
+  end
+
+  describe 'Runtime.update_infrastructure' do
+    it 'updates the infrastructure with the constructed pool' do
+      expect(Onetime::Runtime).to receive(:update_infrastructure)
+        .with(database_pool: mock_pool)
+      instance.execute(nil)
+    end
+
+    it 'makes the pool available via Onetime::Runtime.infrastructure.database_pool' do
+      instance.execute(nil)
+      expect(Onetime::Runtime.infrastructure.database_pool).to eq(mock_pool)
+    end
+  end
+end
+# rubocop:enable RSpec/SpecFilePathFormat


### PR DESCRIPTION
## Summary

Pin current behavior of `Onetime::Initializers::SetupConnectionPool` with a matched pair of unit and integration specs. Spec-only change — zero production code modified, no new dependencies.

## What's covered

**Unit spec** (`spec/unit/onetime/initializers/setup_connection_pool_spec.rb`, 247 lines) stubs `ConnectionPool` / `Redis` / `Familia` and asserts the initializer's exact boundary behavior:

- `Familia.members` empty-guard raises `Onetime::Problem`
- `FAMILIA_POOL_SIZE` / `FAMILIA_POOL_TIMEOUT` default to `25` / `5`
- Non-numeric env vars coerce to `0` via `String#to_i` — labeled as characterization, not endorsement
- `ConnectionPool.new` receives `size`, `timeout`, `reconnect_attempts` kwargs (the last is silently ignored by `connection_pool` 2.5.x, also pinned intentionally)
- `Familia.configure` sets `transaction_mode` and `pipelined_mode` to `:warn`
- `connection_provider` lambda delegates through `pool.with`
- `Runtime.update_infrastructure` receives the constructed pool

**Integration spec** (`spec/integration/all/initializers/setup_connection_pool_spec.rb`, 163 lines) boots against real Valkey on `:2121` and exercises the pipes:

- Pool is a real `ConnectionPool` instance post-boot
- Provider lambda round-trips to Valkey and returns `PONG`
- Familia global config mutations survive boot
- Closed-port URI surfaces `Redis::BaseConnectionError` rather than hanging (uses port 1 + `FAMILIA_POOL_TIMEOUT=1` to cap wall-clock)

## Why characterization

The specs pin current behavior — including known quirks (`size:0` coercion, ignored `reconnect_attempts` kwarg) — so any future change to the initializer is a deliberate choice rather than an accident. Patterns follow `setup_diagnostics_spec.rb` (global-state snapshot/restore) and `boot_part2_spec.rb` (integration lifecycle).

## Test plan

- [ ] `bundle exec rspec spec/unit/onetime/initializers/setup_connection_pool_spec.rb`
- [ ] `bundle exec rspec spec/integration/all/initializers/setup_connection_pool_spec.rb` (requires Valkey on `:2121`)
- [ ] Full suite still green — no cross-spec bleed from Familia global-state mutations