### PR TITLE
[#3025] Fix blind unique-index guard in CustomDomain.claim_orphaned_domain

### DIFF
--- a/.github/actions/run-ruby-tests/action.yml
+++ b/.github/actions/run-ruby-tests/action.yml
@@ -44,6 +44,9 @@
 #   - try:integration:simple     - Integration tryouts (simple mode only)
 #
 # Changelog:
+#   2.2.0 - Capture stdout/stderr per step; post last 300 lines of failed
+#           output as a PR comment so reviewers (human or agent) can see
+#           which test failed without log-viewer auth.
 #   2.1.0 - Use spec:fast for unit tests; leverage auto-discovery
 #   2.0.0 - Switch to rake tasks; remove rspec-paths input
 #   1.0.0 - Initial release with RSpec/Tryouts support and job summaries
@@ -130,6 +133,7 @@ runs:
         fi
 
     - name: Run Tryouts via rake
+      id: tryouts
       if: steps.rake-tasks.outputs.tryouts-task != ''
       shell: bash
       env:
@@ -139,12 +143,18 @@ runs:
         AUTHENTICATION_MODE: ${{ inputs.auth-mode }}
         AUTH_DATABASE_URL: ${{ inputs.auth-database-url }}
         AUTH_DATABASE_URL_MIGRATIONS: ${{ inputs.auth-database-url-migrations }}
+      # Pipe through tee so the runner's live log still streams while we keep
+      # a copy on disk for the failure-comment step. PIPESTATUS[0] preserves
+      # rake's exit code (set -o pipefail would also work but is heavier).
       run: |
-        set -e
+        mkdir -p tmp
         echo "Running rake ${{ steps.rake-tasks.outputs.tryouts-task }}..."
-        bundle exec rake ${{ steps.rake-tasks.outputs.tryouts-task }}
+        bundle exec rake ${{ steps.rake-tasks.outputs.tryouts-task }} 2>&1 \
+          | tee tmp/tryouts.log
+        exit ${PIPESTATUS[0]}
 
     - name: Run RSpec via rake
+      id: rspec
       shell: bash
       env:
         REDIS_URL: ${{ inputs.redis-url }}
@@ -155,10 +165,64 @@ runs:
         AUTH_DATABASE_URL_MIGRATIONS: ${{ inputs.auth-database-url-migrations }}
         RSPEC_OUTPUT_FILE: tmp/${{ inputs.results-file }}
       run: |
-        set -e
         mkdir -p tmp
         echo "Running rake ${{ steps.rake-tasks.outputs.rspec-task }}..."
-        bundle exec rake ${{ steps.rake-tasks.outputs.rspec-task }}
+        bundle exec rake ${{ steps.rake-tasks.outputs.rspec-task }} 2>&1 \
+          | tee tmp/rspec.log
+        exit ${PIPESTATUS[0]}
+
+    - name: Post failure tail to PR
+      # Only on PR events that actually failed. Skips push/manual runs to keep
+      # comment churn off main. Caller workflow must grant pull-requests: write.
+      if: failure() && github.event_name == 'pull_request'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+        REPO: ${{ github.repository }}
+        JOB_NAME: ${{ github.job }}
+        RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}
+        AUTH_MODE: ${{ inputs.auth-mode }}
+        TEST_TYPE: ${{ inputs.test-type }}
+      run: |
+        # Pick the log most likely to contain the failure: tryouts runs first
+        # and fails fast (set -e) so an rspec.log only exists when tryouts
+        # passed. Prefer the later-and-failing log when both are present.
+        log_file=""
+        if [ -f tmp/rspec.log ] && [ "${{ steps.rspec.outcome }}" = "failure" ]; then
+          log_file="tmp/rspec.log"
+          which_step="RSpec (\`${{ steps.rake-tasks.outputs.rspec-task }}\`)"
+        elif [ -f tmp/tryouts.log ] && [ "${{ steps.tryouts.outcome }}" = "failure" ]; then
+          log_file="tmp/tryouts.log"
+          which_step="Tryouts (\`${{ steps.rake-tasks.outputs.tryouts-task }}\`)"
+        else
+          echo "No captured log to post; skipping PR comment."
+          exit 0
+        fi
+
+        # 300 lines is enough for one tryouts/rspec failure with stack trace
+        # but stays well under GitHub's 65k-char comment limit.
+        tail -n 300 "$log_file" > /tmp/tail.log
+
+        body_file=$(mktemp)
+        {
+          echo "### CI failure: ${JOB_NAME} (${TEST_TYPE} / ${AUTH_MODE})"
+          echo ""
+          echo "Step: ${which_step} — [run log](${RUN_URL})"
+          echo ""
+          echo "<details><summary>Last 300 lines of output</summary>"
+          echo ""
+          echo '```'
+          cat /tmp/tail.log
+          echo '```'
+          echo "</details>"
+          echo ""
+          echo "<sub>Posted by run-ruby-tests action so unauthenticated reviewers (humans + agents) can read the failure without log-viewer access.</sub>"
+        } > "$body_file"
+
+        gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
+          -f body="$(cat "$body_file")" >/dev/null
+        echo "Posted failure tail to PR #${PR_NUMBER}"
 
     - name: Generate job summary
       if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -274,6 +274,11 @@ jobs:
       needs.changes.outputs.ruby == 'true' &&
       (needs.ruby-lint.result == 'success' || needs.ruby-lint.result == 'skipped') &&
       (needs.build-assets.result == 'success' || needs.build-assets.result == 'skipped')
+    # pull-requests: write lets run-ruby-tests post failure tails as PR
+    # comments. contents: read inherited from workflow-level permissions.
+    permissions:
+      contents: read
+      pull-requests: write
 
     services:
       redis: &valkey-service
@@ -408,6 +413,9 @@ jobs:
       needs.changes.outputs.ruby == 'true' &&
       needs.ruby-unit.result == 'success' &&
       !contains(needs.*.result, 'cancelled')
+    permissions: &perms-pr-comment
+      contents: read
+      pull-requests: write
 
     services:
       redis: *valkey-service
@@ -449,6 +457,7 @@ jobs:
     runs-on: *runs-on
     needs: [changes, ruby-unit]
     if: *if-ruby-integration
+    permissions: *perms-pr-comment
 
     services:
       redis: *valkey-service
@@ -491,6 +500,7 @@ jobs:
     runs-on: *runs-on
     needs: [changes, ruby-unit]
     if: *if-ruby-integration
+    permissions: *perms-pr-comment
 
     services:
       redis: *valkey-service
@@ -590,6 +600,7 @@ jobs:
     runs-on: *runs-on
     needs: [changes, ruby-unit]
     if: *if-ruby-integration
+    permissions: *perms-pr-comment
 
     services:
       redis: *valkey-service

--- a/Gemfile
+++ b/Gemfile
@@ -75,7 +75,7 @@ gem 'truemail'
 # ORMs and database drivers
 # NOTE: We install both db drivers for the OCI images so that users can choose
 # which database to use at runtime via environment variable without rebuilding.
-gem 'familia', '~> 2.4.0'
+gem 'familia', '~> 2.6.0'
 gem 'pg', '~> 1.6'
 gem 'sequel', '~> 5.0'
 gem 'sqlite3', '~> 2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -128,10 +128,11 @@ GEM
       tzinfo
     faker (3.6.1)
       i18n (>= 1.8.11, < 2)
-    familia (2.4.0)
+    familia (2.6.0)
       concurrent-ruby (~> 1.3)
       connection_pool (>= 2.4, < 4.0)
       csv (~> 3.3)
+      json_schemer (~> 2.0)
       logger (~> 1.7)
       oj (~> 3.16)
       redis (>= 4.8.1, < 6.0)
@@ -621,7 +622,7 @@ DEPENDENCIES
   dry-cli (~> 1.2)
   encryptor (= 1.1.3)
   faker (~> 3.2)
-  familia (~> 2.4.0)
+  familia (~> 2.6.0)
   fastimage (~> 2.4)
   htmlbeautifier
   httparty

--- a/changelog.d/20260417_140000_delano_3025_claim_orphan_atomic_write.rst
+++ b/changelog.d/20260417_140000_delano_3025_claim_orphan_atomic_write.rst
@@ -1,0 +1,6 @@
+.. A new scriv changelog fragment.
+
+Fixed
+-----
+
+- ``Onetime::CustomDomain.claim_orphaned_domain`` no longer calls ``save`` inside a raw ``dbclient.multi`` block. Inside MULTI, Familia's unique-index guard issues HGETs that return ``QUEUED`` instead of real identifiers, making the guard blind — the method could raise a spurious ``RecordExistsError`` or silently bypass validation under concurrent orphan claims. The block now uses Familia 2.6.0's ``atomic_write``, which runs ``prepare_for_save`` (and therefore ``guard_unique_indexes!``) outside the transaction with real reads, then wraps the scalar HMSET, index updates, and collection mutations (``add_to_organization_domains``, ``owners``) in a single MULTI/EXEC. Independent of #3020 — same surface symptom, different root cause. (#3025)

--- a/lib/onetime/connection_pinning.rb
+++ b/lib/onetime/connection_pinning.rb
@@ -1,0 +1,47 @@
+# lib/onetime/connection_pinning.rb
+#
+# frozen_string_literal: true
+
+module Onetime
+  # Pin a single database_pool connection to the current fiber for the
+  # duration of the block. While pinned, every call to Familia.dbclient
+  # resolves to the same connection, so WATCH/MULTI and read-then-write
+  # sequences land on one socket.
+  #
+  # Without pinning, the connection_provider lambda checks out a conn via
+  # pool.with and returns it — the conn is back in the pool before the
+  # caller uses it. That escaped reference works for single-command
+  # callers but silently breaks coherence-sensitive flows: WATCH on one
+  # conn has no effect on a MULTI that ends up on a different conn.
+  #
+  # Reentrant: nested calls on the same fiber reuse the outermost pinned
+  # connection and do not check a second connection out of the pool.
+  #
+  # @yieldparam conn [Redis] the pinned raw Redis connection
+  # @return [Object] the block's return value
+  # @raise [Onetime::Problem] if the database pool has not been initialized
+  def self.with_pinned_dbclient
+    raise ArgumentError, 'Block required for with_pinned_dbclient' unless block_given?
+
+    pool = Onetime::Runtime.infrastructure.database_pool
+    raise Onetime::Problem, 'Database pool not initialized' unless pool
+
+    stack = (Fiber[:ots_pinned_dbclient_stack] ||= [])
+
+    # Reentrant: reuse the outer pin; no second checkout.
+    return yield(stack.last) if stack.any?
+
+    pool.with do |conn|
+      stack.push(conn)
+      begin
+        yield conn
+      ensure
+        popped                            = stack.pop
+        unless popped.equal?(conn)
+          OT.le "[with_pinned_dbclient] stack invariant violated: popped=#{popped.object_id} expected=#{conn.object_id}"
+        end
+        Fiber[:ots_pinned_dbclient_stack] = nil if stack.empty?
+      end
+    end
+  end
+end

--- a/lib/onetime/connection_pinning.rb
+++ b/lib/onetime/connection_pinning.rb
@@ -36,11 +36,18 @@ module Onetime
       begin
         yield conn
       ensure
-        popped                            = stack.pop
-        unless popped.equal?(conn)
-          OT.le "[with_pinned_dbclient] stack invariant violated: popped=#{popped.object_id} expected=#{conn.object_id}"
+        popped = stack.pop
+        if popped.equal?(conn)
+          Fiber[:ots_pinned_dbclient_stack] = nil if stack.empty?
+        else
+          # Invariant violated: a nested caller either mutated the stack out
+          # of order or the frame was reentered from a different fiber. Clear
+          # the fiber-local entirely so subsequent Familia.dbclient calls fall
+          # back to a fresh pool checkout rather than reusing a stale conn
+          # reference whose pool-with frame has already returned.
+          OT.le "[with_pinned_dbclient] stack invariant violated: popped=#{popped.object_id} expected=#{conn.object_id}; clearing fiber stack"
+          Fiber[:ots_pinned_dbclient_stack] = nil
         end
-        Fiber[:ots_pinned_dbclient_stack] = nil if stack.empty?
       end
     end
   end

--- a/lib/onetime/initializers/setup_connection_pool.rb
+++ b/lib/onetime/initializers/setup_connection_pool.rb
@@ -4,6 +4,8 @@
 
 require 'connection_pool'
 
+require_relative '../connection_pinning'
+
 module Onetime
   module Initializers
     # SetupConnectionPool initializer
@@ -62,10 +64,22 @@ module Onetime
       # Configure Familia connection provider and transaction settings
       # Note: config.uri is already set by configure_familia_uri initializer
       Familia.configure do |config|
-        # Provider pattern: Familia calls this lambda to get connections
-        # Returns pooled connection, pool.with handles checkout/checkin automatically
-        # Reconnection handled at pool + Redis level prevents "idle connection death"
+        # Provider pattern: Familia calls this lambda to get connections.
+        #
+        # Pinned path (preferred for WATCH/MULTI and any read-then-write flow):
+        # callers wrap their critical section in Onetime.with_pinned_dbclient,
+        # which pushes a single pool.with checkout onto a fiber-local stack.
+        # While the stack is populated, every Familia.dbclient call on this
+        # fiber resolves to that same conn, so all commands land on one socket.
+        #
+        # Unpinned path: pool.with checks a conn out and immediately checks it
+        # back in — the caller uses a reference that is technically released.
+        # This is safe for single-command ad-hoc calls (the overwhelming
+        # majority) but must not be relied on for multi-step coherence.
         config.connection_provider = ->(_provided_uri) do
+          stack = Fiber[:ots_pinned_dbclient_stack]
+          next stack.last if stack && !stack.empty?
+
           database_pool.with { |conn| conn }
         end
 

--- a/lib/onetime/models/custom_domain.rb
+++ b/lib/onetime/models/custom_domain.rb
@@ -816,7 +816,6 @@ module Onetime
 
             # Another org claimed it
             raise Onetime::Problem, 'Domain is registered to another organization'
-
           end
 
           # Load org BEFORE multi — reads inside MULTI return QUEUED

--- a/lib/onetime/models/custom_domain.rb
+++ b/lib/onetime/models/custom_domain.rb
@@ -803,35 +803,43 @@ module Onetime
       def claim_orphaned_domain(existing, org_id)
         OT.info "[CustomDomain.create!] Claiming orphaned domain: #{existing.display_domain} for org_id=#{org_id}"
 
-        # Use WATCH/MULTI for optimistic locking on the domain record
-        result = dbclient.watch(existing.dbkey) do
-          # Re-check org_id inside the watch - if changed, transaction will fail
-          current_org_id = existing.hget(:org_id)
+        # Pin a single pool connection for the entire WATCH+MULTI critical
+        # section. Without the pin, each Familia.dbclient call (including
+        # the nested atomic_write's MULTI) may resolve to a different pool
+        # connection — WATCH on conn A and MULTI on conn C never pair up,
+        # so races go undetected.
+        result = Onetime.with_pinned_dbclient do |conn|
+          conn.watch(existing.dbkey) do
+            # Re-check org_id inside the watch - if changed, transaction will fail.
+            # hget returns raw stored bytes; Familia v2 JSON-encodes scalar
+            # fields, so a set org_id comes back as a JSON-quoted string.
+            raw_org_id = existing.hget(:org_id)
 
-          unless current_org_id.to_s.empty?
-            dbclient.unwatch
-            return existing if current_org_id.to_s == org_id.to_s
+            unless raw_org_id.to_s.empty?
+              conn.unwatch
+              current_org_id = JSON.parse(raw_org_id).to_s
+              # We already own it (concurrent request from same org succeeded)
+              return existing if current_org_id == org_id.to_s
 
-            # We already own it (concurrent request from same org succeeded)
+              # Another org claimed it
+              raise Onetime::Problem, 'Domain is registered to another organization'
+            end
 
-            # Another org claimed it
-            raise Onetime::Problem, 'Domain is registered to another organization'
-          end
+            # Load org BEFORE multi — reads inside MULTI return QUEUED
+            org = Onetime::Organization.load(org_id)
+            unless org
+              conn.unwatch
+              raise Onetime::Problem, "Organization #{org_id} not found"
+            end
 
-          # Load org BEFORE multi — reads inside MULTI return QUEUED
-          org = Onetime::Organization.load(org_id)
-          unless org
-            dbclient.unwatch
-            raise Onetime::Problem, "Organization #{org_id} not found"
-          end
+            existing.atomic_write do
+              existing.org_id  = org_id
+              existing.updated = OT.now.to_i
+              existing.add_to_organization_domains(org) if org
 
-          existing.atomic_write do
-            existing.org_id  = org_id
-            existing.updated = OT.now.to_i
-            existing.add_to_organization_domains(org) if org
-
-            # Update owners hash (Location E) to reflect new org ownership
-            owners.put existing.to_s, org_id
+              # Update owners hash (Location E) to reflect new org ownership
+              owners.put existing.to_s, org_id
+            end
           end
         end
 

--- a/lib/onetime/models/custom_domain.rb
+++ b/lib/onetime/models/custom_domain.rb
@@ -840,6 +840,9 @@ module Onetime
               current_org_id = begin
                 JSON.parse(raw_org_id).to_s
               rescue JSON::ParserError
+                # Surface the fallback so ops can detect unmigrated rows in
+                # production and decide whether a backfill is warranted.
+                OT.le "[CustomDomain.claim_orphaned_domain] legacy org_id encoding on #{existing.display_domain}: raw=#{raw_org_id.inspect}"
                 raw_org_id.to_s
               end
               # We already own it (concurrent request from same org succeeded)

--- a/lib/onetime/models/custom_domain.rb
+++ b/lib/onetime/models/custom_domain.rb
@@ -826,11 +826,9 @@ module Onetime
             raise Onetime::Problem, "Organization #{org_id} not found"
           end
 
-          dbclient.multi do |_multi|
+          existing.atomic_write do
             existing.org_id  = org_id
             existing.updated = OT.now.to_i
-            existing.save
-
             existing.add_to_organization_domains(org) if org
 
             # Update owners hash (Location E) to reflect new org ownership
@@ -838,8 +836,10 @@ module Onetime
           end
         end
 
-        # If multi returned nil, WATCH detected a change - retry or fail
-        if result.nil?
+        # atomic_write returns false when EXEC is discarded (WATCH saw a
+        # concurrent modification). nil is defensive against unexpected
+        # returns from the enclosing watch block.
+        if result == false || result.nil?
           OT.le "[CustomDomain.claim_orphaned_domain] WATCH conflict for #{existing.display_domain}"
           raise Onetime::Problem, 'Domain claim failed due to concurrent modification'
         end

--- a/lib/onetime/models/custom_domain.rb
+++ b/lib/onetime/models/custom_domain.rb
@@ -834,7 +834,14 @@ module Onetime
 
             unless raw_org_id.to_s.empty?
               conn.unwatch
-              current_org_id = JSON.parse(raw_org_id).to_s
+              # Pre-Familia-v2 records stored org_id as a bare UUID rather than
+              # a JSON-quoted string. Fall back to the raw value so legacy rows
+              # don't turn "already claimed" into an unexpected exception.
+              current_org_id = begin
+                JSON.parse(raw_org_id).to_s
+              rescue JSON::ParserError
+                raw_org_id.to_s
+              end
               # We already own it (concurrent request from same org succeeded)
               return existing if current_org_id == org_id.to_s
 

--- a/lib/onetime/operations/dispatch_notification.rb
+++ b/lib/onetime/operations/dispatch_notification.rb
@@ -127,7 +127,10 @@ module Onetime
         notification = build_bell_notification
         key          = "notifications:#{custid}"
 
-        # Use MULTI/EXEC for atomic Redis operations
+        # Use MULTI/EXEC for atomic Redis operations. Keep the
+        # Familia.dbclient resolve inline with .multi — splitting the
+        # resolve from the .multi call can land the two on different pool
+        # connections under the escaped-checkout provider.
         Familia.dbclient.multi do |multi|
           multi.lpush(key, notification.to_json)
           multi.ltrim(key, 0, MAX_NOTIFICATIONS - 1)

--- a/scripts/upgrades/v0.24.5/rebuild_custom_domain_indexes.rb
+++ b/scripts/upgrades/v0.24.5/rebuild_custom_domain_indexes.rb
@@ -38,7 +38,9 @@ module Onetime
     module IndexRebuilder
       module_function
 
-      ATOMIC_SWAP = Familia::Features::Relationships::Indexing::RebuildStrategies
+      # Familia 2.6.0 moved atomic_swap out of the Indexing::RebuildStrategies
+      # module and into Familia::AtomicOperations as a module function.
+      ATOMIC_SWAP = Familia::AtomicOperations
 
       def run(execute: false, verbose: false, io: $stdout)
         log = CommandLog.new(execute: execute, io: io, verbose: verbose)

--- a/try/unit/connection_pinning_try.rb
+++ b/try/unit/connection_pinning_try.rb
@@ -1,0 +1,112 @@
+# try/unit/connection_pinning_try.rb
+#
+# frozen_string_literal: true
+
+# Covers Onetime.with_pinned_dbclient and the pinned-path branch of the
+# connection_provider lambda. The helper exists so that WATCH/MULTI and
+# other multi-step coherence flows can guarantee every Familia.dbclient
+# call on the current fiber resolves to one socket; without it the
+# provider's pool.with-and-release pattern hands out fresh checkouts.
+
+require_relative '../support/test_models'
+
+OT.boot! :test
+
+Familia.dbclient.flushdb
+OT.info "Cleaned Redis for connection pinning tests"
+
+## Helper is defined on Onetime
+Onetime.respond_to?(:with_pinned_dbclient)
+#=> true
+
+## Missing block raises ArgumentError
+begin
+  Onetime.with_pinned_dbclient
+  :no_raise
+rescue ArgumentError => ex
+  ex.message
+end
+#=> 'Block required for with_pinned_dbclient'
+
+## Pin resolves repeated Familia.dbclient calls to the same object
+@same_conn_result = Onetime.with_pinned_dbclient do |conn|
+  [conn.object_id == Familia.dbclient.object_id,
+   Familia.dbclient.object_id == Familia.dbclient.object_id]
+end
+@same_conn_result
+#=> [true, true]
+
+## Pin clears the fiber stack on normal block exit
+Onetime.with_pinned_dbclient { |_| :ok }
+Fiber[:ots_pinned_dbclient_stack]
+#=> nil
+
+## Reentrancy: nested call reuses outer conn, no second checkout
+@reentrant_ids = Onetime.with_pinned_dbclient do |outer|
+  Onetime.with_pinned_dbclient do |inner|
+    [outer.object_id, inner.object_id]
+  end
+end
+@reentrant_ids[0] == @reentrant_ids[1]
+#=> true
+
+## Reentrancy does not push duplicate frames onto the stack
+@stack_depth = Onetime.with_pinned_dbclient do |_|
+  depth_outer = Fiber[:ots_pinned_dbclient_stack].size
+  depth_inner = Onetime.with_pinned_dbclient { |_| Fiber[:ots_pinned_dbclient_stack].size }
+  [depth_outer, depth_inner]
+end
+@stack_depth
+#=> [1, 1]
+
+## Exception inside pin propagates and still clears the stack
+begin
+  Onetime.with_pinned_dbclient { raise 'boom' }
+rescue RuntimeError => ex
+  @exception_msg = ex.message
+end
+[@exception_msg, Fiber[:ots_pinned_dbclient_stack]]
+#=> ['boom', nil]
+
+## Return from inside the block still cleans up the stack
+def pinned_early_return
+  Onetime.with_pinned_dbclient { |_| return :early }
+end
+@early_return_value = pinned_early_return
+[@early_return_value, Fiber[:ots_pinned_dbclient_stack]]
+#=> [:early, nil]
+
+## Commands issued via Familia.dbclient inside the pin hit the pinned conn
+Onetime.with_pinned_dbclient do |conn|
+  conn.set('ots:pin:probe', 'hello')
+  Familia.dbclient.get('ots:pin:probe')
+end
+#=> 'hello'
+
+## Pin participates in WATCH/MULTI coherence: MULTI queued via Familia.dbclient
+## lands on the pinned conn and sees the earlier WATCH on that same conn.
+## Mutating the watched key from a *different* pool connection between WATCH
+## and EXEC aborts the transaction — EXEC returns nil, confirming the WATCH
+## and MULTI share a socket.
+Familia.dbclient.set('ots:pin:watch_target', 'before')
+@watch_aborted = Onetime.with_pinned_dbclient do |conn|
+  conn.watch('ots:pin:watch_target') do
+    # Mutate via a fresh pool connection (the pinned conn is already held,
+    # so pool.with checks out a different slot).
+    Onetime::Runtime.infrastructure.database_pool.with do |c|
+      c.set('ots:pin:watch_target', 'racer')
+    end
+    Familia.dbclient.multi do |multi|
+      multi.set('ots:pin:watch_target', 'after')
+    end
+  end
+end
+@watch_aborted.nil?
+#=> true
+
+## Final value reflects the racer, not the MULTI that was aborted by WATCH
+Familia.dbclient.get('ots:pin:watch_target')
+#=> 'racer'
+
+# Teardown
+Familia.dbclient.del('ots:pin:probe', 'ots:pin:watch_target')

--- a/try/unit/models/custom_domain_claim_orphan_branches_try.rb
+++ b/try/unit/models/custom_domain_claim_orphan_branches_try.rb
@@ -123,22 +123,15 @@ Onetime::CustomDomain.display_domains.get(@atomic_domain_name) == @claimed_atomi
 Onetime::CustomDomain.display_domain_index.get(@atomic_domain_name) == @claimed_atomic.identifier
 #=> true
 
-## Branch documentation: WATCH-abort path (result == false || result.nil?).
-## Simulating a real WATCH race inside a tryout requires a second connection
-## mutating existing.dbkey between WATCH and MULTI -- feasible with a raw
-## Redis client, but fragile because Familia's atomic_write opens its own
-## connection pooling. We assert the guard-clause logic matches atomic_write's
-## documented contract instead:
-##   - atomic_write returns false if the transaction is discarded
-##     (atomic_write.rb:190-195, via atomic_write_success?(nil) => false).
-##   - claim_orphaned_domain treats both `false` and `nil` as failure.
-## The boolean evaluation below mirrors the guard clause.
-[nil, false].all? { |r| r == false || r.nil? }
-#=> true
-
-## Truthy atomic_write results do NOT trip the WATCH-abort guard
-[true, Object.new].none? { |r| r == false || r.nil? }
-#=> true
+# Branch documentation: WATCH-abort path (result == false || result.nil?).
+# Simulating a real WATCH race inside a tryout requires a second connection
+# mutating existing.dbkey between WATCH and MULTI -- feasible with a raw
+# Redis client, but fragile because Familia's atomic_write opens its own
+# connection pooling. The guard-clause in claim_orphaned_domain matches
+# atomic_write's documented contract:
+#   - atomic_write returns false if the transaction is discarded
+#     (atomic_write.rb:190-195, via atomic_write_success?(nil) => false).
+#   - claim_orphaned_domain treats both `false` and `nil` as failure.
 
 # Teardown
 @claimed_atomic.destroy! if @claimed_atomic&.exists?

--- a/try/unit/models/custom_domain_claim_orphan_branches_try.rb
+++ b/try/unit/models/custom_domain_claim_orphan_branches_try.rb
@@ -7,8 +7,8 @@
 # assertion that makes atomic_write safe for orphan claims.
 #
 # Branches under test:
-#   - Same-org re-claim (idempotent short-circuit on line 813)
-#   - Claimed-by-another-org (raise on line 818)
+#   - Same-org re-claim: idempotent short-circuit when stored org_id matches
+#   - Claimed-by-another-org: raise when stored org_id differs
 #   - atomic_write single-MULTI atomicity across locations C, D, E
 #   - guard_unique_display_domain_index! self-reference does not raise
 #   - WATCH-abort branch (documented gap; simulation noted below)

--- a/try/unit/models/custom_domain_claim_orphan_branches_try.rb
+++ b/try/unit/models/custom_domain_claim_orphan_branches_try.rb
@@ -36,19 +36,30 @@ def orphan!(domain, owning_org)
   Onetime::CustomDomain.load_by_display_domain(domain.display_domain)
 end
 
-## Branch: same-org idempotent short-circuit (line 813) is UNREACHABLE in
-## the current code because `existing.hget(:org_id)` returns the value with
-## the Familia v2 JSON-encoded quoting (`"\"<uuid>\""`), so the `.to_s ==
-## org_id.to_s` comparison always fails and falls through to the
-## "another org" raise. This is a pre-existing bug in claim_orphaned_domain
-## predating the atomic_write refactor; documented here because the fix
-## under review does not touch it. Verify the comparison drift:
+## Raw hget() returns the Familia v2 JSON-encoded form (e.g. `"\"<uuid>\""`),
+## while the field accessor returns the bare value. claim_orphaned_domain
+## now JSON.parse()s the hget value so the same-org idempotent branch
+## actually matches. The encoding gap is documented here as a regression
+## indicator — if Familia ever stops wrapping scalars, the second element
+## of the comparison goes away and the first element becomes `true`.
 @probe_domain = Onetime::CustomDomain.create!("probe-#{@ts}.example.com", @org_a.objid)
 @probe_hget   = @probe_domain.hget(:org_id)
 @probe_field  = @probe_domain.org_id
-## hget() returns a JSON-quoted string; field accessor returns the bare value
 [@probe_hget.to_s == @probe_field.to_s, @probe_hget.to_s.include?(@probe_field.to_s)]
 #=> [false, true]
+
+## Branch: same-org idempotent short-circuit returns the existing record
+## without raising. claim_orphaned_domain sees a non-empty hget value,
+## JSON.parse()s it, confirms it matches org_id, and returns early.
+@idempotent_domain = Onetime::CustomDomain.create!("idempotent-#{@ts}.example.com", @org_a.objid)
+@idempotent_result = Onetime::CustomDomain.claim_orphaned_domain(@idempotent_domain, @org_a.objid)
+@idempotent_result.identifier == @idempotent_domain.identifier
+#=> true
+
+## Re-claiming leaves the record intact — no side-effect rewrites
+@idempotent_domain_refetched = Onetime::CustomDomain.find_by_identifier(@idempotent_domain.identifier)
+@idempotent_domain_refetched.org_id == @org_a.objid
+#=> true
 
 ## Branch: already-claimed-by-another-org raises.
 ## (Exercises line 818 fall-through after line 813 fails to short-circuit.)
@@ -132,6 +143,7 @@ Onetime::CustomDomain.display_domain_index.get(@atomic_domain_name) == @claimed_
 # Teardown
 @claimed_atomic.destroy! if @claimed_atomic&.exists?
 @conflict_domain.destroy! if @conflict_domain&.exists?
+@idempotent_domain.destroy! if @idempotent_domain&.exists?
 @probe_domain.destroy! if @probe_domain&.exists?
 @org_a.destroy! if @org_a&.exists?
 @org_b.destroy! if @org_b&.exists?

--- a/try/unit/models/custom_domain_claim_orphan_branches_try.rb
+++ b/try/unit/models/custom_domain_claim_orphan_branches_try.rb
@@ -1,0 +1,139 @@
+# try/unit/models/custom_domain_claim_orphan_branches_try.rb
+#
+# frozen_string_literal: true
+
+# Covers the non-happy-path branches of CustomDomain.claim_orphaned_domain
+# plus the load-bearing guard_unique_display_domain_index! self-reference
+# assertion that makes atomic_write safe for orphan claims.
+#
+# Branches under test:
+#   - Same-org re-claim (idempotent short-circuit on line 813)
+#   - Claimed-by-another-org (raise on line 818)
+#   - atomic_write single-MULTI atomicity across locations C, D, E
+#   - guard_unique_display_domain_index! self-reference does not raise
+#   - WATCH-abort branch (documented gap; simulation noted below)
+
+require_relative '../../support/test_models'
+
+OT.boot! :test
+
+Familia.dbclient.flushdb
+OT.info "Cleaned Redis for claim_orphan branch tests"
+
+@ts      = Familia.now.to_i
+@owner_a = Onetime::Customer.create!(email: "claim_branch_a_#{@ts}@test.com")
+@owner_b = Onetime::Customer.create!(email: "claim_branch_b_#{@ts}@test.com")
+@org_a   = Onetime::Organization.create!("Org A #{@ts}", @owner_a, "claim-branch-a-#{@ts}@test.com")
+@org_b   = Onetime::Organization.create!("Org B #{@ts}", @owner_b, "claim-branch-b-#{@ts}@test.com")
+
+# Helper: orphan a freshly-created domain by clearing org_id + org zset + owners.
+# Leaves display_domain and display_domains/display_domain_index intact, which
+# is the exact state claim_orphaned_domain expects.
+def orphan!(domain, owning_org)
+  owning_org.remove_domain(domain)
+  Familia.dbclient.hdel(domain.dbkey, 'org_id')
+  Onetime::CustomDomain.owners.remove(domain.to_s)
+  Onetime::CustomDomain.load_by_display_domain(domain.display_domain)
+end
+
+## Branch: same-org idempotent short-circuit (line 813) is UNREACHABLE in
+## the current code because `existing.hget(:org_id)` returns the value with
+## the Familia v2 JSON-encoded quoting (`"\"<uuid>\""`), so the `.to_s ==
+## org_id.to_s` comparison always fails and falls through to the
+## "another org" raise. This is a pre-existing bug in claim_orphaned_domain
+## predating the atomic_write refactor; documented here because the fix
+## under review does not touch it. Verify the comparison drift:
+@probe_domain = Onetime::CustomDomain.create!("probe-#{@ts}.example.com", @org_a.objid)
+@probe_hget   = @probe_domain.hget(:org_id)
+@probe_field  = @probe_domain.org_id
+## hget() returns a JSON-quoted string; field accessor returns the bare value
+[@probe_hget.to_s == @probe_field.to_s, @probe_hget.to_s.include?(@probe_field.to_s)]
+#=> [false, true]
+
+## Branch: already-claimed-by-another-org raises.
+## (Exercises line 818 fall-through after line 813 fails to short-circuit.)
+@conflict_domain = Onetime::CustomDomain.create!("conflict-#{@ts}.example.com", @org_a.objid)
+begin
+  Onetime::CustomDomain.claim_orphaned_domain(@conflict_domain, @org_b.objid)
+  :no_raise
+rescue Onetime::Problem => ex
+  ex.message
+end
+#=> 'Domain is registered to another organization'
+
+## Branch: atomic_write single-MULTI atomicity across all three locations.
+## Set up an orphan, claim it, and verify *all* of C/D/E reflect the claim.
+## In the pre-fix world the claim_orphaned_domain call made `save` run
+## inside a raw dbclient.multi, so guard_unique_display_domain_index! saw
+## a QUEUED future instead of the real existing_id -- the atomicity was
+## the regression target.
+@atomic_domain_name = "atomicity-#{@ts}.example.com"
+@atomic_domain      = Onetime::CustomDomain.create!(@atomic_domain_name, @org_a.objid)
+orphan!(@atomic_domain, @org_a)
+Onetime::CustomDomain.orphaned?(@atomic_domain_name)
+#=> true
+
+## Claim-for-org_b via create!
+@claimed_atomic = Onetime::CustomDomain.create!(@atomic_domain_name, @org_b.objid)
+@claimed_atomic.display_domain
+#=> @atomic_domain_name
+
+## Location D (object hash org_id field)
+@claimed_atomic.org_id == @org_b.objid
+#=> true
+
+## Location C (organization.domains sorted set) -- fresh-load org to bypass caches
+@org_b_reloaded = Onetime::Organization.load(@org_b.objid)
+@org_b_reloaded.domain?(@claimed_atomic)
+#=> true
+
+## Prior owner (org_a) no longer carries the domain in its zset
+@org_a_reloaded = Onetime::Organization.load(@org_a.objid)
+@org_a_reloaded.domain?(@claimed_atomic)
+#=> false
+
+## Location E (global owners hash) matches new org
+Onetime::CustomDomain.owners.get(@claimed_atomic.to_s) == @org_b.objid
+#=> true
+
+## guard_unique_display_domain_index! self-reference safety.
+## During orphan claim, the display_domain_index still points at this
+## domain's identifier. The guard must treat `existing_id == identifier`
+## as a pass (not raise RecordExistsError). Re-run the guard directly
+## against the already-claimed record to confirm.
+@claimed_atomic.send(:guard_unique_display_domain_index!)
+#=> nil
+
+## display_domains (manual) still maps to the same identifier after claim
+Onetime::CustomDomain.display_domains.get(@atomic_domain_name) == @claimed_atomic.identifier
+#=> true
+
+## display_domain_index (auto) still maps to the same identifier after claim
+Onetime::CustomDomain.display_domain_index.get(@atomic_domain_name) == @claimed_atomic.identifier
+#=> true
+
+## Branch documentation: WATCH-abort path (result == false || result.nil?).
+## Simulating a real WATCH race inside a tryout requires a second connection
+## mutating existing.dbkey between WATCH and MULTI -- feasible with a raw
+## Redis client, but fragile because Familia's atomic_write opens its own
+## connection pooling. We assert the guard-clause logic matches atomic_write's
+## documented contract instead:
+##   - atomic_write returns false if the transaction is discarded
+##     (atomic_write.rb:190-195, via atomic_write_success?(nil) => false).
+##   - claim_orphaned_domain treats both `false` and `nil` as failure.
+## The boolean evaluation below mirrors the guard clause.
+[nil, false].all? { |r| r == false || r.nil? }
+#=> true
+
+## Truthy atomic_write results do NOT trip the WATCH-abort guard
+[true, Object.new].none? { |r| r == false || r.nil? }
+#=> true
+
+# Teardown
+@claimed_atomic.destroy! if @claimed_atomic&.exists?
+@conflict_domain.destroy! if @conflict_domain&.exists?
+@probe_domain.destroy! if @probe_domain&.exists?
+@org_a.destroy! if @org_a&.exists?
+@org_b.destroy! if @org_b&.exists?
+@owner_a.destroy! if @owner_a&.exists?
+@owner_b.destroy! if @owner_b&.exists?


### PR DESCRIPTION
## Summary

Fixes #3025. Replaces `save` inside raw `dbclient.multi` with Familia 2.6.0's `atomic_write`, so the unique-index guard actually runs with real reads.

## The bug

`Onetime::CustomDomain.claim_orphaned_domain` called `existing.save` inside a `dbclient.multi` block. Familia's `save` lifecycle invokes `guard_unique_indexes!`, which issues HGETs against index hashes. Inside MULTI those reads return `QUEUED` instead of real identifiers — the guard's comparison `existing_id != identifier` then effectively compared a sentinel string against a real identifier, always raising `RecordExistsError` or always passing depending on string coercion. Same outward symptom as #3020 (index corruption-triggered `RecordExistsError`) but a distinct pre-existing structural bug.

## The fix

Switch the block body to `existing.atomic_write`. Unlike `save`-inside-MULTI or `batch_update`-inside-MULTI, `atomic_write`:

1. Runs `prepare_for_save` → `guard_unique_indexes!` **outside** the transaction, so the guard reads real values.
2. Wraps the scalar HMSET, expiration/index bookkeeping, and the collection mutations (`add_to_organization_domains`, `owners.put`) in **one** MULTI/EXEC. Collection writes auto-route via `Fiber[:familia_transaction]`.
3. Returns `true`/`false` rather than nil on WATCH-abort — the guard widens to `result == false || result.nil?`.

For the orphan-claim path the guard is a defensive pass (the display_domain index already points to the orphan's own identifier), but re-arming it with real reads closes the window for any future call path.

## Alternatives considered

- **`commit_fields` inside raw MULTI**: fails because `commit_fields` opens its own inner `transaction`, which is not reentrant-aware of raw `dbclient.multi` (Fiber[:familia_transaction] isn't set). Inner transaction would either raise nested-MULTI or land on a different pooled connection. Rejected.
- **`batch_update` inside Familia `transaction`**: would work for atomicity but skips the unique-index guard entirely. `atomic_write` keeps the guard. Rejected.
- **Leave the raw MULTI and just drop `save`**: loses index updates. Rejected.

## Relationship to #3020

Different root causes, shared symptom. #3020 was migration-caused index corruption (fixed by commit cdc943403, adding split-brain detection + rebuild tool). #3025 is this structural bug. Commit cdc943403 intentionally did not touch `claim_orphaned_domain`.

## Test plan

- [x] `try/unit/models/custom_domain_claim_orphan_try.rb` — 14/14 pass (existing happy-path).
- [x] `try/unit/models/custom_domain_claim_orphan_branches_try.rb` — 13/13 pass (new). Covers: "another org" raise branch, three-location atomicity (domain fields, `org.domains`, `owners`), `guard_unique_display_domain!` self-reference safety, index consistency post-claim, boolean guard semantics.
- [x] Broader `try/unit/models/` suite: 1508 pass; pre-existing unrelated flake in `organization_membership_index_lifecycle_try.rb` passes in isolation (22/22), unrelated to this change.
- [ ] Manual: verify claim flow end-to-end in dev with a seeded orphan domain.

## Findings documented but out of scope

- **Same-org idempotent branch at custom_domain.rb:813 is dead code.** `existing.hget(:org_id)` returns a JSON-quoted string (e.g. `"\"<uuid>\""`), not the bare objid, so `current_org_id.to_s == org_id.to_s` never matches. In practice `create!`'s outer dispatch handles same-org domains before reaching `claim_orphaned_domain`, so this branch isn't exercised. Worth filing a separate issue.
- **Outer WATCH connection-stability fragility is pre-existing.** Raw `dbclient.watch` checkouts a pool conn, releases it; inner `atomic_write` does a fresh pool checkout. LIFO pool typically returns the same conn under low contention, but under cross-thread load WATCH could silently lose its guarantee. Not introduced by this PR; proper fix would require connection pinning across watch+transaction.