### PR TITLE
 Generate owner memberships during v0.24.5 migration and harden pipeline

### DIFF
--- a/scripts/upgrades/README.md
+++ b/scripts/upgrades/README.md
@@ -7,7 +7,7 @@ contains scripts to migrate data from the previous version.
 
 | Directory  | From   | To     | Description                      |
 | ---------- | ------ | ------ | -------------------------------- |
-| `v0.24.0/` | 0.23.x | 0.24.0 | Familia v1 to v2 data transforms |
+| `v0.24.5/` | 0.23.x | 0.24.5 | Familia v1 to v2 data transforms |
 
 ## Structure
 
@@ -22,10 +22,10 @@ Each upgrade directory contains:
 
 ```bash
 # Run all transforms for an upgrade
-./scripts/upgrades/v0.24.0/run_pipeline.sh
+./scripts/upgrades/v0.24.5/run_pipeline.sh
 
 # Run individual transforms
-ruby scripts/upgrades/v0.24.0/01-customer/transform.rb --help
+ruby scripts/upgrades/v0.24.5/01-customer/transform.rb --help
 ```
 
 ## Distinction from Migrations

--- a/scripts/upgrades/v0.24.5/01-customer/transform.rb
+++ b/scripts/upgrades/v0.24.5/01-customer/transform.rb
@@ -428,13 +428,23 @@ class CustomerTransformer
   def write_output(records)
     FileUtils.mkdir_p(@output_dir)
     output_file = File.join(@output_dir, 'customer_transformed.jsonl')
+    temp_file   = "#{output_file}.tmp"
 
-    File.open(output_file, 'w') do |f|
-      records.each do |record|
-        f.puts(JSON.generate(record))
-        @stats[:v2_records_written] += 1
+    begin
+      File.open(temp_file, 'w') do |f|
+        records.each do |record|
+          f.puts(JSON.generate(record))
+          @stats[:v2_records_written] += 1
+        end
       end
+      FileUtils.mv(temp_file, output_file)
+    rescue StandardError
+      # Ensure no partial output is promoted to the final filename.
+      # Any prior successful run's output remains at output_file.
+      FileUtils.rm_f(temp_file)
+      raise
     end
+
     puts "Wrote #{@stats[:v2_records_written]} transformed records to #{output_file}"
   end
 

--- a/scripts/upgrades/v0.24.5/01-customer/transform.rb
+++ b/scripts/upgrades/v0.24.5/01-customer/transform.rb
@@ -162,6 +162,16 @@ class CustomerTransformer
     @redis.close
   end
 
+  # Pipelining is opt-in via OTS_MIGRATION_PIPELINE. Any truthy value enables
+  # within-customer pipelining of RESTORE+HGETALL, HMSET+DUMP, and the
+  # counter SET+DUMP fan-out. DEL stays in `ensure` blocks unchanged so temp
+  # keys are cleaned up on every path. Memoized; ENV is read once.
+  def pipeline_enabled?
+    return @pipeline_enabled if defined?(@pipeline_enabled)
+    raw = ENV['OTS_MIGRATION_PIPELINE'].to_s.strip.downcase
+    @pipeline_enabled = !(raw.empty? || %w[0 false no off].include?(raw))
+  end
+
   def group_records_by_customer
     puts "Reading and grouping records from #{@input_file}..."
     groups = Hash.new { |h, k| h[k] = [] }
@@ -270,31 +280,62 @@ class CustomerTransformer
   # Extract counter fields from customer hash and emit as standalone JSONL records.
   # In v2, Familia class_counter fields are Redis String keys, not hash fields.
   def externalize_counters(v1_fields, objid, original_record)
-    records = []
+    pending = []
     COUNTER_FIELDS.each do |field|
       value = v1_fields[field].to_i
       next if value.zero?
 
-      # Create a proper Redis DUMP blob so load_keys.rb can RESTORE it
-      temp_key = "#{TEMP_KEY_PREFIX}ctr_#{SecureRandom.hex(4)}"
-      dump_b64 = begin
-        @redis.set(temp_key, value)
-        dump_data = @redis.dump(temp_key)
-        Base64.strict_encode64(dump_data)
-      ensure
-        @redis.del(temp_key)
-      end
-
-      records << {
-        key: "customer:#{objid}:#{field}",
-        type: 'string',
-        ttl_ms: -1,
-        db: original_record[:db],
-        dump: dump_b64,
-      }
-      @stats[:externalized_counters] += 1
+      pending << [field, value, "#{TEMP_KEY_PREFIX}ctr_#{SecureRandom.hex(4)}"]
     end
-    records
+    return [] if pending.empty?
+
+    if pipeline_enabled?
+      # Pipeline all SET+DUMP pairs for this customer's counters in one RTT,
+      # then DEL the temp keys in one RTT. For a customer with N non-zero
+      # counters this collapses 3N round trips into 2. The DEL pipeline lives
+      # in `ensure` so a transient failure mid-SET+DUMP does not leak temp keys
+      # for `cleanup_redis` to mop up later.
+      begin
+        results = @redis.pipelined do |pipe|
+          pending.each do |_field, value, temp_key|
+            pipe.set(temp_key, value)
+            pipe.dump(temp_key)
+          end
+        end
+        pending.each_with_index.map do |(field, _value, _temp_key), i|
+          dump_data = results[(i * 2) + 1]
+          @stats[:externalized_counters] += 1
+          {
+            key: "customer:#{objid}:#{field}",
+            type: 'string',
+            ttl_ms: -1,
+            db: original_record[:db],
+            dump: Base64.strict_encode64(dump_data),
+          }
+        end
+      ensure
+        @redis.pipelined { |pipe| pending.each { |_, _, tk| pipe.del(tk) } }
+      end
+    else
+      pending.map do |field, value, temp_key|
+        dump_b64 = begin
+          @redis.set(temp_key, value)
+          dump_data = @redis.dump(temp_key)
+          Base64.strict_encode64(dump_data)
+        ensure
+          @redis.del(temp_key)
+        end
+
+        @stats[:externalized_counters] += 1
+        {
+          key: "customer:#{objid}:#{field}",
+          type: 'string',
+          ttl_ms: -1,
+          db: original_record[:db],
+          dump: dump_b64,
+        }
+      end
+    end
   end
 
   def transform_customer_object(v1_record, v1_fields, objid, extid)
@@ -326,8 +367,18 @@ class CustomerTransformer
       v2_serialized = serialize_for_v2(v2_fields)
       # NOTE: hmset is deprecated, but redis-rb gem maps it to HMSET for older redis-server versions
       # For modern Redis, this would be `hset(temp_key, v2_serialized)`
-      @redis.hmset(temp_key, v2_serialized.to_a.flatten)
-      dump_data     = @redis.dump(temp_key)
+      hmset_args = v2_serialized.to_a.flatten
+      dump_data =
+        if pipeline_enabled?
+          _hmset_result, dumped = @redis.pipelined do |pipe|
+            pipe.hmset(temp_key, hmset_args)
+            pipe.dump(temp_key)
+          end
+          dumped
+        else
+          @redis.hmset(temp_key, hmset_args)
+          @redis.dump(temp_key)
+        end
       Base64.strict_encode64(dump_data)
     ensure
       @redis.del(temp_key)
@@ -370,8 +421,19 @@ class CustomerTransformer
     temp_key  = "#{TEMP_KEY_PREFIX}#{SecureRandom.hex(8)}"
     dump_data = Base64.strict_decode64(record[:dump])
     begin
-      @redis.restore(temp_key, 0, dump_data, replace: true)
-      @redis.hgetall(temp_key)
+      if pipeline_enabled?
+        # RESTORE then HGETALL on the same key in a single round trip; Redis
+        # processes pipelined commands in order, so HGETALL sees the just-
+        # restored hash. Saves one RTT per customer object decode.
+        _restore_result, fields = @redis.pipelined do |pipe|
+          pipe.restore(temp_key, 0, dump_data, replace: true)
+          pipe.hgetall(temp_key)
+        end
+        fields
+      else
+        @redis.restore(temp_key, 0, dump_data, replace: true)
+        @redis.hgetall(temp_key)
+      end
     rescue Redis::CommandError => ex
       raise "Restore failed for key #{record[:key]}: #{ex.message}"
     ensure

--- a/scripts/upgrades/v0.24.5/02-organization/create_indexes.rb
+++ b/scripts/upgrades/v0.24.5/02-organization/create_indexes.rb
@@ -45,12 +45,14 @@ class OrganizationIndexCreator
     @stats = {
       total_records: 0,
       object_records: 0,
+      membership_records: 0,
       indexes_written: 0,
       stripe_customer_indexes: 0,
       stripe_subscription_indexes: 0,
       stripe_checkout_email_indexes: 0,
       billing_email_indexes: 0,
       member_entries: 0,
+      org_customer_lookups: 0,
       skipped: 0,
       errors: [],
     }
@@ -113,12 +115,44 @@ class OrganizationIndexCreator
       # Skip GLOBAL singleton records (should not be indexed as organizations)
       next if record[:key]&.include?(':GLOBAL:') || record[:key]&.include?(':GLOBAL_STATS:')
 
-      @stats[:object_records] += 1
-
-      process_organization_record(record)
+      # Owner-membership records (emitted alongside orgs by generate.rb) need
+      # only the org_customer_lookup HSET. Routing is by explicit record_kind
+      # marker, not key shape, to keep the consumer/producer contract obvious.
+      if record[:record_kind] == 'organization_membership'
+        @stats[:membership_records] += 1
+        process_membership_record(record)
+      else
+        @stats[:object_records] += 1
+        process_organization_record(record)
+      end
     rescue JSON::ParserError => ex
       @stats[:errors] << { line: @stats[:total_records], error: ex.message }
     end
+  end
+
+  def process_membership_record(record)
+    membership_objid   = record[:objid]
+    organization_objid = record[:organization_objid]
+    customer_objid     = record[:customer_objid]
+
+    if [membership_objid, organization_objid, customer_objid].any? { |v| v.nil? || v.to_s.empty? }
+      @stats[:skipped] += 1
+      @stats[:errors] << { key: record[:key], error: 'Missing membership identifiers' }
+      return
+    end
+
+    # Composite key matches OrganizationMembership#org_customer_key:
+    #   "#{organization_objid}:#{customer_objid}"
+    # Index Redis key matches Familia class_hashkey shape:
+    #   "{prefix}:#{index_name}" -> "org_membership:org_customer_lookup"
+    # Value is JSON-quoted membership objid (Familia HashKey convention).
+    composite_key = "#{organization_objid}:#{customer_objid}"
+    add_command(
+      'HSET',
+      'org_membership:org_customer_lookup',
+      [composite_key, membership_objid.to_json],
+    )
+    @stats[:org_customer_lookups] += 1
   end
 
   def process_organization_record(record)
@@ -281,6 +315,7 @@ class OrganizationIndexCreator
     puts "Input file: #{@input_file}"
     puts "Total records: #{@stats[:total_records]}"
     puts "Object records: #{@stats[:object_records]}"
+    puts "Membership records: #{@stats[:membership_records]}"
     puts "Index commands generated: #{@stats[:indexes_written]}"
     puts
     puts 'Lookup Indexes:'
@@ -288,6 +323,7 @@ class OrganizationIndexCreator
     puts "  Stripe subscription indexes: #{@stats[:stripe_subscription_indexes]}"
     puts "  Stripe checkout email indexes: #{@stats[:stripe_checkout_email_indexes]}"
     puts "  Billing email indexes: #{@stats[:billing_email_indexes]}"
+    puts "  Membership org_customer lookups: #{@stats[:org_customer_lookups]}"
     puts
     puts 'Participation Indexes:'
     puts "  Member entries: #{@stats[:member_entries]}"
@@ -347,6 +383,7 @@ def parse_args(args)
           - organization:stripe_checkout_email_index (hash: email -> "org_objid")
           - organization:{org_objid}:members (sorted set: score=created, member=customer_objid)
           - customer:{owner_id}:participations (set: organization:{org_objid}:members)
+          - org_membership:org_customer_lookup (hash: "org:cust" -> "membership_objid")
       HELP
       exit 0
     else

--- a/scripts/upgrades/v0.24.5/02-organization/generate.rb
+++ b/scripts/upgrades/v0.24.5/02-organization/generate.rb
@@ -168,6 +168,16 @@ class OrganizationGenerator
     @redis.close
   end
 
+  # Pipelining is opt-in via OTS_MIGRATION_PIPELINE. Any truthy value enables
+  # within-record pipelining of RESTORE+HGETALL and HMSET+DUMP. DEL stays in
+  # `ensure` blocks unchanged so temp keys are cleaned up on every path.
+  # Memoized; ENV is read once.
+  def pipeline_enabled?
+    return @pipeline_enabled if defined?(@pipeline_enabled)
+    raw = ENV['OTS_MIGRATION_PIPELINE'].to_s.strip.downcase
+    @pipeline_enabled = !(raw.empty? || %w[0 false no off].include?(raw))
+  end
+
   def serialize_for_v2(fields, field_types = FIELD_TYPES)
     fields.each_with_object({}) do |(key, value), result|
       result[key] = if value == '' || value.nil?
@@ -283,8 +293,19 @@ class OrganizationGenerator
     dump_data = Base64.strict_decode64(record[:dump])
 
     begin
-      @redis.restore(temp_key, 0, dump_data, replace: true)
-      @redis.hgetall(temp_key)
+      if pipeline_enabled?
+        # RESTORE then HGETALL on the same key in a single round trip; Redis
+        # processes pipelined commands in order, so HGETALL sees the just-
+        # restored hash. Saves one RTT per customer object decode.
+        _restore_result, fields = @redis.pipelined do |pipe|
+          pipe.restore(temp_key, 0, dump_data, replace: true)
+          pipe.hgetall(temp_key)
+        end
+        fields
+      else
+        @redis.restore(temp_key, 0, dump_data, replace: true)
+        @redis.hgetall(temp_key)
+      end
     rescue Redis::CommandError => ex
       @stats[:errors] << { key: record[:key], error: "Restore failed: #{ex.message}" }
       nil
@@ -353,9 +374,19 @@ class OrganizationGenerator
     # Serialize values for Familia v2 JSON format before writing to Redis
     temp_key     = "#{TEMP_KEY_PREFIX}org_#{SecureRandom.hex(8)}"
     serialized   = serialize_for_v2(org_fields)
+    hmset_args   = serialized.to_a.flatten
     org_dump_b64 = begin
-      @redis.hmset(temp_key, serialized.to_a.flatten)
-      dump_data = @redis.dump(temp_key)
+      dump_data =
+        if pipeline_enabled?
+          _hmset_result, dumped = @redis.pipelined do |pipe|
+            pipe.hmset(temp_key, hmset_args)
+            pipe.dump(temp_key)
+          end
+          dumped
+        else
+          @redis.hmset(temp_key, hmset_args)
+          @redis.dump(temp_key)
+        end
       Base64.strict_encode64(dump_data)
     ensure
       @redis.del(temp_key)
@@ -414,9 +445,20 @@ class OrganizationGenerator
 
     temp_key   = "#{TEMP_KEY_PREFIX}mem_#{SecureRandom.hex(8)}"
     serialized = serialize_for_v2(membership_fields, MEMBERSHIP_FIELD_TYPES)
+    hmset_args = serialized.to_a.flatten
     dump_b64   = begin
-      @redis.hmset(temp_key, serialized.to_a.flatten)
-      Base64.strict_encode64(@redis.dump(temp_key))
+      dump_data =
+        if pipeline_enabled?
+          _hmset_result, dumped = @redis.pipelined do |pipe|
+            pipe.hmset(temp_key, hmset_args)
+            pipe.dump(temp_key)
+          end
+          dumped
+        else
+          @redis.hmset(temp_key, hmset_args)
+          @redis.dump(temp_key)
+        end
+      Base64.strict_encode64(dump_data)
     ensure
       @redis.del(temp_key)
     end

--- a/scripts/upgrades/v0.24.5/02-organization/generate.rb
+++ b/scripts/upgrades/v0.24.5/02-organization/generate.rb
@@ -18,7 +18,10 @@
 #
 # Input: data/upgrades/v0.24.5/customer/customer_transformed.jsonl (V2 customer records)
 # Output:
-#   - data/upgrades/v0.24.5/organization/organization_transformed.jsonl (V2 organization records)
+#   - data/upgrades/v0.24.5/organization/organization_transformed.jsonl
+#       Contains both organization:{org}:object records AND the
+#       org_membership:organization:{org}:customer:{cust}:org_membership:object
+#       records that record each customer as the owner of their org.
 #   - data/upgrades/v0.24.5/organization/customer_objid_to_org_objid.json (customer_objid -> org_objid)
 #   - data/upgrades/v0.24.5/organization/email_to_org_objid.json (email -> org_objid, for customdomain)
 
@@ -71,6 +74,21 @@ class OrganizationGenerator
     # _original_record removed: v1 data now stored as _original_object hashkey via RESTORE
   }.freeze
 
+  # Field type mappings for OrganizationMembership records.
+  # Owner memberships generated during migration only need a small subset of
+  # fields (see lib/onetime/models/organization_membership.rb). Pending-only
+  # fields (token, invited_email, invited_by, invited_at, resend_count,
+  # domain_scope_id) are intentionally omitted.
+  MEMBERSHIP_FIELD_TYPES = {
+    'objid'              => :string,
+    'organization_objid' => :string,
+    'customer_objid'     => :string,
+    'role'               => :string,
+    'status'             => :string,
+    'joined_at'          => :timestamp,
+    'updated_at'         => :timestamp,
+  }.freeze
+
   def initialize(input_file:, output_dir:, redis_url:, temp_db:, dry_run: false)
     @input_file = input_file
     @output_dir = output_dir
@@ -83,15 +101,17 @@ class OrganizationGenerator
       records_read: 0,          # Total lines read from JSONL (includes related records)
       customer_objects: 0,      # Customer :object records processed
       organizations_created: 0,
+      memberships_created: 0,
       stripe_customers: 0,
       stripe_subscriptions: 0,
       skipped: 0,
       errors: [],
     }
 
-    @customer_to_org = {}  # customer_objid -> org_objid
-    @email_to_org    = {}  # email -> org_objid
-    @org_records     = []  # Generated organization JSONL records
+    @customer_to_org    = {}  # customer_objid -> org_objid
+    @email_to_org       = {}  # email -> org_objid
+    @org_records        = []  # Generated organization JSONL records
+    @membership_records = []  # Generated OrganizationMembership JSONL records (owner per org)
   end
 
   def run
@@ -148,12 +168,12 @@ class OrganizationGenerator
     @redis.close
   end
 
-  def serialize_for_v2(fields)
+  def serialize_for_v2(fields, field_types = FIELD_TYPES)
     fields.each_with_object({}) do |(key, value), result|
       result[key] = if value == '' || value.nil?
                       'null'
                     else
-                      ruby_val = parse_to_ruby_type(key, value)
+                      ruby_val = parse_to_ruby_type(key, value, field_types)
                       Familia::JsonSerializer.dump(ruby_val)
                     end
     end
@@ -175,9 +195,9 @@ class OrganizationGenerator
     fields.transform_values { |v| deserialize_v2_value(v) }
   end
 
-  def parse_to_ruby_type(key, value)
-    field_type = FIELD_TYPES[key.to_s]
-    raise ArgumentError, "Unknown field '#{key}' not in FIELD_TYPES - add it to the mapping" unless field_type
+  def parse_to_ruby_type(key, value, field_types = FIELD_TYPES)
+    field_type = field_types[key.to_s]
+    raise ArgumentError, "Unknown field '#{key}' not in field types map - add it to the mapping" unless field_type
 
     case field_type
     when :string then value.to_s
@@ -242,6 +262,20 @@ class OrganizationGenerator
     @email_to_org[email] = org_record[:objid] if email && !email.empty?
 
     @stats[:organizations_created] += 1
+
+    # Generate the owner OrganizationMembership record alongside the org.
+    # Without this, OrganizationMembership.find_by_org_customer returns nil
+    # for every migrated owner and plan switching breaks (issue #3041).
+    membership_record = generate_owner_membership(
+      org_objid: org_record[:objid],
+      customer_objid: customer_objid,
+      created: org_record[:created],
+      db: customer_record[:db],
+    )
+    return unless membership_record
+
+    @membership_records << membership_record
+    @stats[:memberships_created] += 1
   end
 
   def restore_and_read_hash(record)
@@ -341,6 +375,69 @@ class OrganizationGenerator
     }
   end
 
+  # Build the OrganizationMembership record that records the V1 customer as
+  # the active owner of their generated organization.
+  #
+  # Familia builds through-model objids deterministically as a composite path
+  # (see Familia ThroughModelOperations.build_key):
+  #
+  #   {target.prefix}:{target.objid}:{participant.prefix}:{participant.objid}:{through.prefix}
+  #
+  # For OrganizationMembership that resolves to:
+  #
+  #   organization:{org_objid}:customer:{customer_objid}:org_membership
+  #
+  # The full Redis key is then dbkey(objid, suffix) = prefix:objid:suffix:
+  #
+  #   org_membership:organization:{org_objid}:customer:{customer_objid}:org_membership:object
+  #
+  # Using a UUIDv7 here would write the hash to a key that find_by_org_customer
+  # could never resolve back to; the lookup index value MUST equal the composite
+  # path so that load(objid) reconstructs the correct dbkey.
+  #
+  # Generated downstream by load_keys.rb via RESTORE. The lookup HSET that
+  # makes find_by_org_customer work is emitted by create_indexes.rb.
+  def generate_owner_membership(org_objid:, customer_objid:, created:, db:)
+    membership_objid = "organization:#{org_objid}:customer:#{customer_objid}:org_membership"
+    now              = Time.now.to_f
+    joined_at        = created.to_f.positive? ? created.to_f : now
+
+    membership_fields = {
+      'objid'              => membership_objid,
+      'organization_objid' => org_objid,
+      'customer_objid'     => customer_objid,
+      'role'               => 'owner',
+      'status'             => 'active',
+      'joined_at'          => joined_at.to_s,
+      'updated_at'         => now.to_s,
+    }
+
+    temp_key   = "#{TEMP_KEY_PREFIX}mem_#{SecureRandom.hex(8)}"
+    serialized = serialize_for_v2(membership_fields, MEMBERSHIP_FIELD_TYPES)
+    dump_b64   = begin
+      @redis.hmset(temp_key, serialized.to_a.flatten)
+      Base64.strict_encode64(@redis.dump(temp_key))
+    ensure
+      @redis.del(temp_key)
+    end
+
+    {
+      key: "org_membership:#{membership_objid}:object",
+      type: 'hash',
+      ttl_ms: -1,
+      db: db,
+      dump: dump_b64,
+      record_kind: 'organization_membership',
+      objid: membership_objid,
+      organization_objid: org_objid,
+      customer_objid: customer_objid,
+      role: 'owner',
+      status: 'active',
+      joined_at: joined_at,
+      created: created,
+    }
+  end
+
   # Generate deterministic org_objid from customer_objid and created timestamp
   # Uses UUIDv7 format with:
   #   - Timestamp from customer's created date (preserves chronological ordering)
@@ -398,14 +495,16 @@ class OrganizationGenerator
   def write_outputs
     FileUtils.mkdir_p(@output_dir)
 
-    # Write organization records JSONL
+    # Write organization + owner-membership records to a single JSONL.
+    # load_keys.rb iterates the file and RESTOREs each record by its :key,
+    # so co-locating memberships avoids changes to the loader.
     org_file = File.join(@output_dir, 'organization_transformed.jsonl')
     File.open(org_file, 'w') do |f|
-      @org_records.each do |record|
-        f.puts(JSON.generate(record))
-      end
+      @org_records.each { |record| f.puts(JSON.generate(record)) }
+      @membership_records.each { |record| f.puts(JSON.generate(record)) }
     end
     puts "Wrote #{@org_records.size} organization records to #{org_file}"
+    puts "Wrote #{@membership_records.size} owner-membership records to #{org_file}"
 
     # Write customer_objid -> org_objid lookup (debug/reference)
     customer_lookup_file = File.join(@output_dir, 'customer_objid_to_org_objid.json')
@@ -424,6 +523,7 @@ class OrganizationGenerator
     puts "Records read: #{@stats[:records_read]}"
     puts "Customer objects: #{@stats[:customer_objects]}"
     puts "Organizations created: #{@stats[:organizations_created]}"
+    puts "Owner memberships created: #{@stats[:memberships_created]}"
     puts "  With Stripe customer: #{@stats[:stripe_customers]}"
     puts "  With Stripe subscription: #{@stats[:stripe_subscriptions]}"
     puts "Skipped: #{@stats[:skipped]}"
@@ -468,7 +568,8 @@ def parse_args(args)
           --help              Show this help
 
         Output files:
-          organization_transformed.jsonl       - V2 organization records with DUMP data
+          organization_transformed.jsonl     - V2 organization records AND owner-
+                                               membership records (DUMP data)
           customer_objid_to_org_objid.json   - customer_objid -> org_objid mapping
           email_to_org_objid.json            - email -> org_objid (for customdomain)
 

--- a/scripts/upgrades/v0.24.5/02-organization/generate.rb
+++ b/scripts/upgrades/v0.24.5/02-organization/generate.rb
@@ -270,7 +270,7 @@ class OrganizationGenerator
       org_objid: org_record[:objid],
       customer_objid: customer_objid,
       created: org_record[:created],
-      db: customer_record[:db],
+      db: record[:db],
     )
     return unless membership_record
 

--- a/scripts/upgrades/v0.24.5/02-organization/spec.md
+++ b/scripts/upgrades/v0.24.5/02-organization/spec.md
@@ -49,6 +49,13 @@ Hash        organization:{objid}:urls                  New in V2
 Sorted Set  organization:{objid}:pending_invitations   New in V2
 JsonKey     organization:{objid}:caboose               New in V2
 JsonKey     organization:{objid}:_original_record    New in V2 (migration snapshot)
+Hash        org_membership:organization:{org}:customer:{cust}:org_membership:object
+                                                       New in V2 (owner membership;
+                                                       Familia prefix=org_membership,
+                                                       objid=composite path
+                                                       organization:{org}:customer:{cust}:org_membership
+                                                       matching Familia's
+                                                       ThroughModelOperations.build_key)
 
 INDEXES
 
@@ -62,6 +69,9 @@ Lookup Indexes
   organization:stripe_checkout_email_index  Hash    email -> "objid"
   organization:extid_lookup                 Hash    extid -> "objid"
   organization:objid_lookup                 Hash    objid -> "objid"
+  org_membership:org_customer_lookup        Hash    "org_objid:customer_objid" ->
+                                                    "membership_objid"
+                                                    (powers find_by_org_customer)
 
 Participation Indexes
   organization:{objid}:members    Sorted Set    Add customer objids with score=joined
@@ -70,12 +80,21 @@ Participation Indexes
 
 SCRIPTS
 
-1. generate.rb   - Creates organization records from transformed customer data
+1. generate.rb   - Creates organization records from transformed customer data,
+                   plus an owner OrganizationMembership record per organization.
+                   Both record types are written to the same JSONL output so
+                   load_keys.rb (which iterates by :key) loads them transparently.
                    Input:  exports/customer/customer_transformed.jsonl
                    Output: exports/organization/organization_transformed.jsonl
-                           exports/organization/customer_to_org_lookup.json
+                             - organization:{org_objid}:object records
+                             - org_membership:organization:{org}:customer:{cust}:org_membership:object records
+                           exports/organization/customer_objid_to_org_objid.json
+                           exports/organization/email_to_org_objid.json
 
-2. create_indexes.rb - Creates index commands from generated organizations
+2. create_indexes.rb - Creates index commands from generated records. For the
+                       org records, emits all instance/lookup/participation
+                       commands. For each membership record, emits one HSET
+                       on org_membership:org_customer_lookup.
                        Input:  exports/organization/organization_transformed.jsonl
                        Output: exports/organization/organization_indexes.jsonl
 
@@ -133,6 +152,13 @@ rebuild_indexes(v2_record):
 
   # Participation (add owner as first member)
   ZADD organization:{objid}:members created v2_record.owner_id
+  SADD customer:{owner_id}:participations organization:{objid}:members
+
+  # Owner membership lookup (powers OrganizationMembership.find_by_org_customer).
+  # membership_objid is the same composite path used as the through model's objid.
+  membership_objid = "organization:{objid}:customer:{owner_id}:org_membership"
+  HSET org_membership:org_customer_lookup
+       "{objid}:{owner_id}" json(membership_objid)
 
 VALIDATION CHECKLIST
 
@@ -148,6 +174,9 @@ VALIDATION CHECKLIST
 [ ] Added to organization:objid_lookup
 [ ] Stripe indexes populated if applicable
 [ ] Owner added to organization:{objid}:members
+[ ] Owner OrganizationMembership record created (role=owner, status=active)
+[ ] org_membership:org_customer_lookup populated for "{org_objid}:{owner_id}"
+[ ] customer:{owner_id}:participations contains organization:{org_objid}:members
 [ ] Migration status = 'completed'
 
 WARNINGS

--- a/scripts/upgrades/v0.24.5/02-organization/validate_instance_index.rb
+++ b/scripts/upgrades/v0.24.5/02-organization/validate_instance_index.rb
@@ -270,6 +270,11 @@ def parse_args(args)
     transformed_file: File.join(DEFAULT_DATA_DIR, 'organization/organization_transformed.jsonl'),
     indexes_file: File.join(DEFAULT_DATA_DIR, 'organization/organization_indexes.jsonl'),
     customer_file: File.join(DEFAULT_DATA_DIR, 'customer/customer_transformed.jsonl'),
+    # Accepted for symmetry with sibling validators (run_pipeline.sh passes
+    # --redis-url to every validator). This validator works exclusively on
+    # JSONL artifacts on disk; the value is currently unused but is recorded
+    # so callers don't fail when invoking with the standard flag set.
+    redis_url: ENV['VALKEY_URL'] || ENV.fetch('REDIS_URL', nil),
   }
 
   args.each do |arg|
@@ -280,6 +285,8 @@ def parse_args(args)
       options[:indexes_file] = Regexp.last_match(1)
     when /^--customer-file=(.+)$/
       options[:customer_file] = Regexp.last_match(1)
+    when /^--redis-url=(.+)$/
+      options[:redis_url] = Regexp.last_match(1)
     when '--help', '-h'
       puts <<~HELP
         Usage: ruby scripts/upgrades/v0.24.5/02-organization/validate_instance_index.rb [OPTIONS]
@@ -291,6 +298,8 @@ def parse_args(args)
           --transformed-file=FILE  Transformed JSONL (default: data/upgrades/v0.24.5/organization/organization_transformed.jsonl)
           --indexes-file=FILE      Indexes JSONL (default: data/upgrades/v0.24.5/organization/organization_indexes.jsonl)
           --customer-file=FILE     Customer transformed JSONL (default: data/upgrades/v0.24.5/customer/customer_transformed.jsonl)
+          --redis-url=URL          Accepted for parity with other validators; unused
+                                   (env: VALKEY_URL or REDIS_URL)
           --help                   Show this help
 
         Validates:

--- a/scripts/upgrades/v0.24.5/dump_keys.rb
+++ b/scripts/upgrades/v0.24.5/dump_keys.rb
@@ -7,6 +7,13 @@
 # Dumps Redis keys to JSONL format for migration, organized by model.
 # Each line: {"key": "...", "type": "...", "ttl_ms": ..., "dump": "<base64>", "created": ...}
 #
+# Default: execute (writes JSONL to disk). Pass --dry-run to preview.
+# This default is intentional: orchestrators (upgrade.sh, run_pipeline.sh) rely
+# on the run_pipeline.sh contract that pipeline scripts default to execute and
+# upgrade.sh's $DRY_RUN_FLAG ("--dry-run" when not executing) is forwarded here.
+# See run_pipeline.sh header for the full contract; flipping this default would
+# silently break upgrade.sh's dry-run propagation.
+#
 # Usage:
 #   ruby scripts/dump_keys.rb [OPTIONS]
 #

--- a/scripts/upgrades/v0.24.5/enrich_with_original_record.rb
+++ b/scripts/upgrades/v0.24.5/enrich_with_original_record.rb
@@ -27,8 +27,10 @@
 #   --input-dir=DIR    Input directory with dump/transformed files (default: data/upgrades/v0.24.5)
 #   --redis-url=URL    Redis URL for RESTORE operations (env: VALKEY_URL or REDIS_URL)
 #   --target-db=N      Target database number (default: 0)
-#   --dry-run          Preview without writing to Redis
+#   --execute          Perform Redis writes (default: dry-run, no writes)
 #   --help             Show this help
+#
+# Default behavior is DRY-RUN. Pass --execute to perform Redis RESTORE operations.
 #
 # Input:
 #   data/upgrades/v0.24.5/{model}/{model}_dump.jsonl        (v1 dump — source of RESTORE binaries)
@@ -95,7 +97,7 @@ class OriginalRecordRestorer
     },
   }.freeze
 
-  def initialize(input_dir:, redis_url:, target_db:, dry_run: false)
+  def initialize(input_dir:, redis_url:, target_db:, dry_run: true)
     @input_dir  = input_dir
     @redis_url  = redis_url
     @target_db  = target_db
@@ -369,7 +371,7 @@ def parse_args(args)
     input_dir: DEFAULT_DATA_DIR,
     redis_url: ENV['VALKEY_URL'] || ENV.fetch('REDIS_URL', nil),
     target_db: 0,
-    dry_run: false,
+    dry_run: true,
   }
 
   args.each do |arg|
@@ -380,19 +382,21 @@ def parse_args(args)
       options[:redis_url] = Regexp.last_match(1)
     when /^--target-db=(\d+)$/
       options[:target_db] = Regexp.last_match(1).to_i
-    when '--dry-run'
-      options[:dry_run] = true
+    when '--execute'
+      options[:dry_run] = false
     when '--help', '-h'
       puts <<~HELP
         Usage: ruby scripts/upgrades/v0.24.5/enrich_with_original_record.rb [OPTIONS]
 
         Restores original v1 records as _original_* Redis keys with 30-day TTL.
 
+        Default behavior is DRY-RUN (no Redis writes). Pass --execute to perform writes.
+
         Options:
           --input-dir=DIR    Input directory (default: data/upgrades/v0.24.5)
           --redis-url=URL    Redis URL for RESTORE (env: VALKEY_URL or REDIS_URL)
           --target-db=N      Target database number (default: 0)
-          --dry-run          Preview without writing to Redis
+          --execute          Perform Redis writes (default: dry-run, no writes)
           --help             Show this help
 
         Input files:

--- a/scripts/upgrades/v0.24.5/enrich_with_original_record.rb
+++ b/scripts/upgrades/v0.24.5/enrich_with_original_record.rb
@@ -32,6 +32,15 @@
 #
 # Default behavior is DRY-RUN. Pass --execute to perform Redis RESTORE operations.
 #
+# Default rationale: this script is a Phase 4 callee of upgrade.sh — NOT a
+# run_pipeline.sh (Phase 2) callee. The "must default to execute" contract
+# documented at run_pipeline.sh:12-20 applies only to Phase 2 transforms.
+# Phase 4 archives v1 dumps with a 30-day TTL and is the most consequential
+# write of any single phase; defaulting to dry-run preserves CLI safety when
+# operators run this script standalone. upgrade.sh:493-499 translates its
+# own --execute flag into this script's --execute (the $DRY_RUN_FLAG pattern
+# does not apply because the flag semantics are inverted).
+#
 # Input:
 #   data/upgrades/v0.24.5/{model}/{model}_dump.jsonl        (v1 dump — source of RESTORE binaries)
 #   data/upgrades/v0.24.5/{model}/{model}_transformed.jsonl (v2 records — source of v1→v2 mapping)

--- a/scripts/upgrades/v0.24.5/load_keys.rb
+++ b/scripts/upgrades/v0.24.5/load_keys.rb
@@ -144,7 +144,10 @@ class KeyLoader
       if File.exist?(transformed_file)
         load_transformed_records(model_name, transformed_file)
       else
-        puts "  No transformed file: #{transformed_file}"
+        msg = "Missing transformed file: #{transformed_file} (Phase 2 artifact). " \
+              'Re-run Phase 2, or pass --skip-records if loading indexes only is intentional.'
+        warn "  ERROR: #{msg}"
+        @stats[model_name][:errors] << { error: msg, file: transformed_file }
       end
     end
 
@@ -154,7 +157,10 @@ class KeyLoader
       if File.exist?(indexes_file)
         execute_index_commands(model_name, indexes_file)
       else
-        puts "  No indexes file: #{indexes_file}"
+        msg = "Missing indexes file: #{indexes_file} (Phase 2 artifact). " \
+              'Re-run Phase 2, or pass --skip-indexes if loading records only is intentional.'
+        warn "  ERROR: #{msg}"
+        @stats[model_name][:errors] << { error: msg, file: indexes_file }
       end
     end
 
@@ -443,12 +449,12 @@ def parse_args(args)
           --skip-records       Load only indexes (skip RESTORE operations)
           --help               Show this help
 
-        Models (loaded in dependency order):
-          customer       -> DB 6
-          organization   -> DB 6
-          customdomain   -> DB 6
-          receipt        -> DB 7
-          secret         -> DB 8
+        Models (loaded in dependency order, all into consolidated DB 0):
+          customer       -> DB 0
+          organization   -> DB 0
+          customdomain   -> DB 0
+          receipt        -> DB 0 (read from 'metadata' subdir)
+          secret         -> DB 0
 
         Input files per model (in subdirs):
           {model}_transformed.jsonl   Records to RESTORE (with dump blobs)

--- a/scripts/upgrades/v0.24.5/load_keys.rb
+++ b/scripts/upgrades/v0.24.5/load_keys.rb
@@ -174,7 +174,32 @@ class KeyLoader
     parts << 'records only' if @skip_indexes
     parts << 'indexes only' if @skip_records
     parts << 'full load' if parts.empty?
+    parts << "pipeline=#{pipeline_batch_size}" if pipeline_enabled?
     parts.join(', ')
+  end
+
+  # Pipelining is opt-in via OTS_MIGRATION_PIPELINE.
+  #   unset / 0 / false / no / off -> off (default; per-record round trips)
+  #   1 / true / yes / on          -> on, batch size 500
+  #   <positive integer>           -> on, that batch size
+  # Memoized per loader so we read ENV once at startup.
+  def pipeline_batch_size
+    return @pipeline_batch_size if defined?(@pipeline_batch_size)
+    raw = ENV['OTS_MIGRATION_PIPELINE'].to_s.strip.downcase
+    @pipeline_batch_size =
+      if raw.empty? || %w[0 false no off].include?(raw)
+        0
+      elsif (parsed = Integer(raw, exception: false)) && parsed > 0
+        parsed
+      elsif %w[1 true yes on].include?(raw)
+        500
+      else
+        0
+      end
+  end
+
+  def pipeline_enabled?
+    pipeline_batch_size > 0
   end
 
   def load_model(model_name, dir_name = nil)
@@ -225,11 +250,30 @@ class KeyLoader
     target_db = MODELS[model_name][:db]
     redis     = get_redis(target_db)
 
-    File.foreach(file_path) do |line|
-      record = JSON.parse(line, symbolize_names: true)
-      restore_record(model_name, redis, record)
-    rescue JSON::ParserError => ex
-      @stats[model_name][:errors] << { error: "JSON parse error: #{ex.message}" }
+    if pipeline_enabled?
+      puts "    Pipelining RESTORE in batches of #{pipeline_batch_size}"
+      batch = []
+      File.foreach(file_path) do |line|
+        record   = JSON.parse(line, symbolize_names: true)
+        prepared = prepare_record(model_name, record)
+        next unless prepared
+
+        batch << prepared
+        if batch.size >= pipeline_batch_size
+          flush_record_batch(model_name, redis, batch)
+          batch.clear
+        end
+      rescue JSON::ParserError => ex
+        @stats[model_name][:errors] << { error: "JSON parse error: #{ex.message}" }
+      end
+      flush_record_batch(model_name, redis, batch) unless batch.empty?
+    else
+      File.foreach(file_path) do |line|
+        record = JSON.parse(line, symbolize_names: true)
+        restore_record(model_name, redis, record)
+      rescue JSON::ParserError => ex
+        @stats[model_name][:errors] << { error: "JSON parse error: #{ex.message}" }
+      end
     end
 
     puts "    Records restored: #{@stats[model_name][:records_restored]}"
@@ -237,6 +281,26 @@ class KeyLoader
   end
 
   def restore_record(model_name, redis, record)
+    prepared = prepare_record(model_name, record)
+    return unless prepared
+
+    key, restore_ttl, dump_data = prepared
+    redis.restore(key, restore_ttl, dump_data, replace: true)
+    @record_keys << key
+    @stats[model_name][:records_restored] += 1
+  rescue Redis::CommandError => ex
+    fatal_if_hard_redis_error!(ex, model_name: model_name, key: key, op: 'RESTORE')
+    @stats[model_name][:records_skipped] += 1
+    @stats[model_name][:errors] << { key: key, error: "RESTORE failed: #{ex.message}" }
+  end
+
+  # Validate, decode, and produce a [key, restore_ttl, dump_data] triple ready
+  # for either single-record RESTORE or pipelined RESTORE. Per-record soft
+  # errors (missing fields, base64 decode) are recorded against @stats here so
+  # both code paths get identical error semantics. Returns nil for skip.
+  # In dry-run mode the key is counted as restored and nil is returned (no
+  # Redis work to do).
+  def prepare_record(model_name, record)
     key      = record[:key]
     dump_b64 = record[:dump]
     ttl_ms   = record[:ttl_ms]
@@ -244,34 +308,51 @@ class KeyLoader
     unless key && dump_b64
       @stats[model_name][:records_skipped] += 1
       @stats[model_name][:errors] << { key: key, error: 'Missing key or dump data' }
-      return
+      return nil
     end
 
     if @dry_run
       @record_keys << key
       @stats[model_name][:records_restored] += 1
-      return
+      return nil
     end
 
-    # Decode the dump blob
-    dump_data = Base64.strict_decode64(dump_b64)
+    begin
+      dump_data = Base64.strict_decode64(dump_b64)
+    rescue ArgumentError => ex
+      @stats[model_name][:records_skipped] += 1
+      @stats[model_name][:errors] << { key: key, error: "Base64 decode failed: #{ex.message}" }
+      return nil
+    end
 
-    # Determine TTL for RESTORE command
-    # -1 in source means no expiry -> use 0 in RESTORE
-    # Otherwise use the ttl_ms value directly
+    # -1 in source means no expiry -> use 0 in RESTORE; else use ttl_ms as-is.
     restore_ttl = ttl_ms == -1 ? 0 : ttl_ms.to_i
+    [key, restore_ttl, dump_data]
+  end
 
-    # RESTORE key ttl serialized-value REPLACE
-    redis.restore(key, restore_ttl, dump_data, replace: true)
-    @record_keys << key
-    @stats[model_name][:records_restored] += 1
-  rescue ArgumentError => ex
-    @stats[model_name][:records_skipped] += 1
-    @stats[model_name][:errors] << { key: key, error: "Base64 decode failed: #{ex.message}" }
-  rescue Redis::CommandError => ex
-    fatal_if_hard_redis_error!(ex, model_name: model_name, key: key, op: 'RESTORE')
-    @stats[model_name][:records_skipped] += 1
-    @stats[model_name][:errors] << { key: key, error: "RESTORE failed: #{ex.message}" }
+  def flush_record_batch(model_name, redis, prepared)
+    return if prepared.empty?
+
+    # exception: false -> per-command results; failed commands appear as
+    # Redis::CommandError instances at their slot in the result array. This
+    # preserves the per-key error granularity of the non-pipelined path.
+    results = redis.pipelined(exception: false) do |pipe|
+      prepared.each do |key, ttl, data|
+        pipe.restore(key, ttl, data, replace: true)
+      end
+    end
+
+    results.each_with_index do |result, idx|
+      key = prepared[idx][0]
+      if result.is_a?(Redis::CommandError)
+        fatal_if_hard_redis_error!(result, model_name: model_name, key: key, op: 'RESTORE')
+        @stats[model_name][:records_skipped] += 1
+        @stats[model_name][:errors] << { key: key, error: "RESTORE failed: #{result.message}" }
+      else
+        @record_keys << key
+        @stats[model_name][:records_restored] += 1
+      end
+    end
   end
 
   def execute_index_commands(model_name, file_path)
@@ -279,11 +360,30 @@ class KeyLoader
     target_db = MODELS[model_name][:db]
     redis     = get_redis(target_db)
 
-    File.foreach(file_path) do |line|
-      cmd = JSON.parse(line, symbolize_names: true)
-      execute_command(model_name, redis, cmd)
-    rescue JSON::ParserError => ex
-      @stats[model_name][:errors] << { error: "JSON parse error: #{ex.message}" }
+    if pipeline_enabled?
+      puts "    Pipelining index commands in batches of #{pipeline_batch_size}"
+      batch = []
+      File.foreach(file_path) do |line|
+        cmd      = JSON.parse(line, symbolize_names: true)
+        prepared = prepare_index_command(model_name, cmd)
+        next unless prepared
+
+        batch << prepared
+        if batch.size >= pipeline_batch_size
+          flush_index_batch(model_name, redis, batch)
+          batch.clear
+        end
+      rescue JSON::ParserError => ex
+        @stats[model_name][:errors] << { error: "JSON parse error: #{ex.message}" }
+      end
+      flush_index_batch(model_name, redis, batch) unless batch.empty?
+    else
+      File.foreach(file_path) do |line|
+        cmd = JSON.parse(line, symbolize_names: true)
+        execute_command(model_name, redis, cmd)
+      rescue JSON::ParserError => ex
+        @stats[model_name][:errors] << { error: "JSON parse error: #{ex.message}" }
+      end
     end
 
     puts "    Index commands executed: #{@stats[model_name][:indexes_executed]}"
@@ -291,41 +391,15 @@ class KeyLoader
   end
 
   def execute_command(model_name, redis, cmd)
-    command = cmd[:command]
-    key     = cmd[:key]
-    args    = cmd[:args]
+    prepared = prepare_index_command(model_name, cmd)
+    return unless prepared
 
-    unless VALID_COMMANDS.include?(command)
-      @stats[model_name][:indexes_skipped] += 1
-      @stats[model_name][:errors] << { key: key, error: "Unknown command: #{command}" }
-      return
-    end
-
-    unless key && args.is_a?(Array)
-      @stats[model_name][:indexes_skipped] += 1
-      @stats[model_name][:errors] << { key: key, error: 'Missing key or args' }
-      return
-    end
-
-    if @dry_run
-      @index_keys << key
-      @stats[model_name][:indexes_executed] += 1
-      return
-    end
-
+    command, key, args = prepared
     case command
-    when 'ZADD'
-      # args: [score, member] or [score, member, score, member, ...]
-      redis.zadd(key, *args)
-    when 'HSET'
-      # args: [field, value] or [field, value, field, value, ...]
-      redis.hset(key, *args)
-    when 'SADD'
-      # args: [member, ...]
-      redis.sadd(key, *args)
-    when 'INCRBY'
-      # args: [increment]
-      redis.incrby(key, args.first.to_i)
+    when 'ZADD'   then redis.zadd(key, *args)
+    when 'HSET'   then redis.hset(key, *args)
+    when 'SADD'   then redis.sadd(key, *args)
+    when 'INCRBY' then redis.incrby(key, args.first.to_i)
     end
 
     @index_keys << key
@@ -334,6 +408,63 @@ class KeyLoader
     fatal_if_hard_redis_error!(ex, model_name: model_name, key: key, op: command)
     @stats[model_name][:indexes_skipped] += 1
     @stats[model_name][:errors] << { key: key, command: command, error: ex.message }
+  end
+
+  # Validate an index command and produce a [command, key, args] triple ready
+  # for either single-shot or pipelined execution. Per-cmd soft errors are
+  # recorded here so both paths get identical error semantics. Returns nil
+  # for skip; in dry-run mode the key is counted as executed and nil returned.
+  def prepare_index_command(model_name, cmd)
+    command = cmd[:command]
+    key     = cmd[:key]
+    args    = cmd[:args]
+
+    unless VALID_COMMANDS.include?(command)
+      @stats[model_name][:indexes_skipped] += 1
+      @stats[model_name][:errors] << { key: key, error: "Unknown command: #{command}" }
+      return nil
+    end
+
+    unless key && args.is_a?(Array)
+      @stats[model_name][:indexes_skipped] += 1
+      @stats[model_name][:errors] << { key: key, error: 'Missing key or args' }
+      return nil
+    end
+
+    if @dry_run
+      @index_keys << key
+      @stats[model_name][:indexes_executed] += 1
+      return nil
+    end
+
+    [command, key, args]
+  end
+
+  def flush_index_batch(model_name, redis, prepared)
+    return if prepared.empty?
+
+    results = redis.pipelined(exception: false) do |pipe|
+      prepared.each do |command, key, args|
+        case command
+        when 'ZADD'   then pipe.zadd(key, *args)
+        when 'HSET'   then pipe.hset(key, *args)
+        when 'SADD'   then pipe.sadd(key, *args)
+        when 'INCRBY' then pipe.incrby(key, args.first.to_i)
+        end
+      end
+    end
+
+    results.each_with_index do |result, idx|
+      command, key, _args = prepared[idx]
+      if result.is_a?(Redis::CommandError)
+        fatal_if_hard_redis_error!(result, model_name: model_name, key: key, op: command)
+        @stats[model_name][:indexes_skipped] += 1
+        @stats[model_name][:errors] << { key: key, command: command, error: result.message }
+      else
+        @index_keys << key
+        @stats[model_name][:indexes_executed] += 1
+      end
+    end
   end
 
   def fatal_if_hard_redis_error!(ex, model_name:, key:, op:)

--- a/scripts/upgrades/v0.24.5/load_keys.rb
+++ b/scripts/upgrades/v0.24.5/load_keys.rb
@@ -4,6 +4,22 @@
 # Loads migrated data into Valkey/Redis from transformed JSONL files.
 # Processes both transformed records (RESTORE) and index commands (ZADD/HSET/etc).
 #
+# Default: execute (writes to Valkey/Redis). Pass --dry-run to preview.
+# This default is intentional: orchestrators (upgrade.sh, run_pipeline.sh) rely
+# on the run_pipeline.sh contract that pipeline scripts default to execute and
+# upgrade.sh's $DRY_RUN_FLAG ("--dry-run" when not executing) is forwarded here.
+# See run_pipeline.sh header for the full contract; flipping this default would
+# silently break upgrade.sh's dry-run propagation.
+#
+# Error handling: per-record soft errors (Base64 decode, JSON parse, single-key
+# Redis errors not in HARD_ERROR_PATTERNS) are collected to @stats[model][:errors]
+# and the run continues so all issues surface in one pass. HARD Redis errors
+# (WRONGTYPE, NOAUTH, READONLY, LOADING, CLUSTERDOWN, MISCONF, OOM, corrupt
+# DUMP payload) abort the run immediately with exit code 2 — these indicate
+# environment misconfiguration or structural data conflict where continuing
+# would compound damage or amount to retry-spam against a broken environment.
+# Exit codes: 0 clean, 1 soft errors only, 2 hard error fail-fast.
+#
 # Usage:
 #   ruby scripts/upgrades/v0.24.5/load_keys.rb [OPTIONS]
 #
@@ -41,6 +57,31 @@ class KeyLoader
   }.freeze
 
   VALID_COMMANDS = %w[ZADD HSET SADD INCRBY].freeze
+
+  # Redis errors that abort the run immediately. Continuing past these either
+  # compounds data corruption (WRONGTYPE: every subsequent same-keyspace write
+  # fails the same way), is impossible (NOAUTH, READONLY), or means the input
+  # itself is broken (DUMP payload checksum). See header for full rationale.
+  HARD_ERROR_PATTERNS = [
+    /\AWRONGTYPE/,
+    /\ANOAUTH/,
+    /\AREADONLY/,
+    /\ALOADING/,
+    /\ACLUSTERDOWN/,
+    /\AMISCONF/,
+    /\AOOM\b/,
+    /DUMP payload version or checksum/,
+  ].freeze
+
+  class HardLoadError < StandardError
+    attr_reader :model_name, :key, :original
+    def initialize(message, model_name:, key:, original:)
+      super(message)
+      @model_name = model_name
+      @key        = key
+      @original   = original
+    end
+  end
 
   def initialize(input_dir:, valkey_url:, model: nil, dry_run: false, skip_indexes: false, skip_records: false)
     @input_dir     = input_dir
@@ -87,6 +128,18 @@ class KeyLoader
 
     print_summary
     exit_with_status
+  rescue HardLoadError => ex
+    warn ''
+    warn "FATAL: hard error during #{ex.model_name} load — aborting before further damage."
+    warn "  key:   #{ex.key.inspect}"
+    warn "  error: #{ex.original.message}"
+    warn ''
+    warn 'Hard errors (WRONGTYPE, NOAUTH, READONLY, LOADING, CLUSTERDOWN, MISCONF,'
+    warn 'OOM, corrupt DUMP) indicate environment misconfiguration or structural'
+    warn 'data conflict where continuing would compound damage. Investigate the'
+    warn 'cause above, then re-run.'
+    print_summary
+    exit 2
   ensure
     close_connections
   end
@@ -216,6 +269,7 @@ class KeyLoader
     @stats[model_name][:records_skipped] += 1
     @stats[model_name][:errors] << { key: key, error: "Base64 decode failed: #{ex.message}" }
   rescue Redis::CommandError => ex
+    fatal_if_hard_redis_error!(ex, model_name: model_name, key: key, op: 'RESTORE')
     @stats[model_name][:records_skipped] += 1
     @stats[model_name][:errors] << { key: key, error: "RESTORE failed: #{ex.message}" }
   end
@@ -277,8 +331,17 @@ class KeyLoader
     @index_keys << key
     @stats[model_name][:indexes_executed] += 1
   rescue Redis::CommandError => ex
+    fatal_if_hard_redis_error!(ex, model_name: model_name, key: key, op: command)
     @stats[model_name][:indexes_skipped] += 1
     @stats[model_name][:errors] << { key: key, command: command, error: ex.message }
+  end
+
+  def fatal_if_hard_redis_error!(ex, model_name:, key:, op:)
+    return unless HARD_ERROR_PATTERNS.any? { |pattern| ex.message.match?(pattern) }
+    raise HardLoadError.new(
+      "#{op} failed on #{key.inspect} (#{model_name}): #{ex.message}",
+      model_name: model_name, key: key, original: ex,
+    )
   end
 
   def get_redis(db)

--- a/scripts/upgrades/v0.24.5/run_pipeline.sh
+++ b/scripts/upgrades/v0.24.5/run_pipeline.sh
@@ -112,7 +112,7 @@ phase_start=$SECONDS
 echo "=== Organization ============================================="
 ruby scripts/upgrades/v0.24.5/02-organization/generate.rb
 ruby scripts/upgrades/v0.24.5/02-organization/create_indexes.rb
-run_validator scripts/upgrades/v0.24.5/02-organization/validate_instance_index.rb
+run_validator scripts/upgrades/v0.24.5/02-organization/validate_instance_index.rb --redis-url="${VALKEY_URL:-$REDIS_URL}"
 echo "  Organization completed in $((SECONDS - phase_start))s"
 
 echo ""

--- a/scripts/upgrades/v0.24.5/run_pipeline.sh
+++ b/scripts/upgrades/v0.24.5/run_pipeline.sh
@@ -9,15 +9,20 @@
 # This lets the full pipeline complete so all issues surface in one run,
 # rather than fixing one model at a time and re-running.
 #
-# CONTRACT: All scripts invoked by this pipeline MUST default to execute
-# (i.e., run-with-side-effects without an explicit flag). The Phase 2
-# orchestration in upgrade.sh runs this script only when --execute is set,
-# so dry-run propagation is handled at the parent level. enrich_with_identifiers.rb
-# is the documented exception (defaults to dry-run for direct CLI safety,
-# cf. PR #2748); it is invoked here with an explicit --execute and guarded
-# against silent dry-run output below. If you add a callee that defaults
-# to dry-run, either flip its default or add a similar guard, or the
-# pipeline will silently no-op (see issue #3036).
+# CONTRACT: All scripts invoked by THIS PIPELINE (Phase 2 transforms) MUST
+# default to execute (i.e., run-with-side-effects without an explicit flag).
+# The Phase 2 orchestration in upgrade.sh runs this script only when --execute
+# is set, so dry-run propagation is handled at the parent level.
+# enrich_with_identifiers.rb is the documented exception (defaults to dry-run
+# for direct CLI safety, cf. PR #2748); it is invoked here with an explicit
+# --execute and guarded against silent dry-run output below. If you add a
+# callee that defaults to dry-run, either flip its default or add a similar
+# guard, or the pipeline will silently no-op (see issue #3036).
+#
+# Scope note: this contract applies to run_pipeline.sh (Phase 2) only.
+# Phase 4's enrich_with_original_record.rb is invoked directly by upgrade.sh
+# and intentionally defaults to dry-run for its own CLI-safety reasons; the
+# parent flag-translation lives at upgrade.sh:493-499.
 #
 # Usage: Run from project root:
 #   scripts/upgrades/v0.24.5/run_pipeline.sh
@@ -130,7 +135,7 @@ phase_start=$SECONDS
 echo "=== Receipt ============================================="
 ruby scripts/upgrades/v0.24.5/04-receipt/transform.rb
 ruby scripts/upgrades/v0.24.5/04-receipt/create_indexes.rb
-run_validator scripts/upgrades/v0.24.5/04-receipt/validate_instance_index.rb
+run_validator scripts/upgrades/v0.24.5/04-receipt/validate_instance_index.rb --redis-url="${VALKEY_URL:-$REDIS_URL}"
 echo "  Receipt completed in $((SECONDS - phase_start))s"
 
 echo ""
@@ -139,7 +144,7 @@ phase_start=$SECONDS
 echo "=== Secret ============================================="
 ruby scripts/upgrades/v0.24.5/05-secret/transform.rb
 ruby scripts/upgrades/v0.24.5/05-secret/create_indexes.rb
-run_validator scripts/upgrades/v0.24.5/05-secret/validate_instance_index.rb
+run_validator scripts/upgrades/v0.24.5/05-secret/validate_instance_index.rb --redis-url="${VALKEY_URL:-$REDIS_URL}"
 echo "  Secret completed in $((SECONDS - phase_start))s"
 
 echo ""

--- a/scripts/upgrades/v0.24.5/upgrade.sh
+++ b/scripts/upgrades/v0.24.5/upgrade.sh
@@ -490,10 +490,18 @@ if [ "$START_PHASE" -le 4 ]; then
 
   phase_start=$SECONDS
 
+  # enrich_with_original_record.rb defaults to dry-run; pass --execute when
+  # the operator has opted into a real upgrade. $DRY_RUN_FLAG (--dry-run) does
+  # not apply here since the script's flag semantics are inverted.
+  ENRICH_ORIGINAL_EXECUTE_FLAG=""
+  if $EXECUTE; then
+    ENRICH_ORIGINAL_EXECUTE_FLAG="--execute"
+  fi
+
   ruby scripts/upgrades/v0.24.5/enrich_with_original_record.rb \
     --redis-url="$TARGET_VALKEY_URL" \
     --input-dir="$DATA_DIR" \
-    $DRY_RUN_FLAG
+    $ENRICH_ORIGINAL_EXECUTE_FLAG
 
   echo ""
   echo "  Phase 4 completed in $((SECONDS - phase_start))s"

--- a/scripts/upgrades/v0.24.5/upgrade.sh
+++ b/scripts/upgrades/v0.24.5/upgrade.sh
@@ -441,10 +441,22 @@ if [ "$START_PHASE" -le 3 ]; then
   " "$TARGET_VALKEY_URL" "$REDIS_TIMEOUT" 2>/dev/null || echo "    (could not read keyspace)"
   echo ""
 
+  set +e
   ruby scripts/upgrades/v0.24.5/load_keys.rb \
     --valkey-url="$TARGET_VALKEY_URL" \
     --input-dir="$DATA_DIR" \
     $DRY_RUN_FLAG
+  load_keys_rc=$?
+  set -e
+
+  if [ "$load_keys_rc" -ne 0 ]; then
+    echo ""
+    echo "  FATAL: Phase 3 (load_keys.rb) failed with exit code $load_keys_rc"
+    echo "         Inspect output above; common causes are missing Phase 2 artifacts"
+    echo "         or RESTORE/index command errors against the target."
+    echo "         To resume after fixing: $0 --execute --start-phase=3"
+    exit "$load_keys_rc"
+  fi
 
   # Capture keyspace after load
   if $EXECUTE; then

--- a/scripts/upgrades/v0.24.5/validate_post_migration.rb
+++ b/scripts/upgrades/v0.24.5/validate_post_migration.rb
@@ -1,0 +1,593 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Post-migration end-to-end validator for the v0.24.5 OneTimeSecret upgrade.
+#
+# Runs AFTER load_keys.rb has restored transformed records and indexes into the
+# live Valkey/Redis dataset. Verifies the integrity of the v2 keyspace so an
+# operator can sign off (or know what's broken) in a single pass.
+#
+# DESIGN NOTES
+#
+# - The load-bearing check is the customer -> organization -> membership ->
+#   org_customer_lookup chain. PR #3041 fixed a bug where the loader silently
+#   produced organizations without their owner OrganizationMembership records,
+#   leaving find_by_org_customer broken for every migrated owner. This
+#   validator's primary job is to prove that chain is intact for a sample.
+#
+# - The customer_objid -> org_objid mapping is read from the JSONL artifact
+#   produced by 02-organization/generate.rb:
+#     data/upgrades/v0.24.5/organization/customer_objid_to_org_objid.json
+#   (NOTE: PR review brief referred to this as customer_org_map.json - the
+#   actual filename is customer_objid_to_org_objid.json.)
+#   If absent, we fall back to scanning organization:objid_lookup HKEYS and
+#   reading owner_id off each org hash. That fallback is O(orgs) per check
+#   and slow on 400k records - use --sample=N to bound it.
+#
+# - For the custom-domain exclusivity and owner-objects-exist checks we
+#   delegate to the existing sibling validators rather than reimplementing
+#   their logic. Their exit codes are rolled up into our own.
+#
+# - Familia v2 stores HashKey/HSET-index values JSON-encoded (e.g. an objid
+#   like "01h7..." is stored as "\"01h7...\""). All lookups in this script
+#   normalize HGET results through JSON.parse before comparing.
+#
+# Usage:
+#   ruby scripts/upgrades/v0.24.5/validate_post_migration.rb [OPTIONS]
+#
+# Options:
+#   --valkey-url=URL    Valkey/Redis URL (also --redis-url; env: VALKEY_URL or REDIS_URL)
+#   --sample=N          Customers/orgs to spot-check (default 100; 0 = all)
+#   --model=NAME        Restrict to one cohort: customer, organization,
+#                       membership (alias org_membership), customdomain,
+#                       receipt, secret
+#   --data-dir=DIR      Migration artifact directory (default: data/upgrades/v0.24.5)
+#   --verbose           Print every failing case, not just totals
+#   --help              Show this help
+#
+# Exit codes:
+#   0  All checks passed
+#   1  One or more validation checks failed
+#   2  Connection error or unrecoverable hard error
+
+require 'json'
+require 'redis'
+require 'rbconfig'
+require 'set'
+require 'uri'
+
+DEFAULT_DATA_DIR = 'data/upgrades/v0.24.5'
+SAMPLE_FAILURES_CAP = 50         # max failing cases retained per check
+SAMPLE_FAILURES_PRINT = 5        # printed by default; --verbose prints all
+
+VALID_MODELS = %w[customer organization membership org_membership customdomain receipt secret].freeze
+
+COHORTS = [
+  { label: 'customer',        scan: 'customer:*:object' },
+  { label: 'organization',    scan: 'organization:*:object' },
+  { label: 'org_membership',  scan: 'org_membership:*:object' },
+  { label: 'customdomain',    scan: 'custom_domain:*:object' },
+  { label: 'receipt',         scan: 'receipt:*:object' },
+  { label: 'secret',          scan: 'secret:*:object' },
+].freeze
+
+# Familia HashKey/HSET-index values are JSON-encoded ("\"objid\"").
+# Sorted-set members are raw. This handles both transparently.
+def normalize_indexed_value(raw)
+  return nil if raw.nil?
+  return raw unless raw.is_a?(String)
+  return raw if raw.empty?
+
+  JSON.parse(raw)
+rescue JSON::ParserError
+  raw
+end
+
+class CheckResult
+  STATUS = %i[pass fail skip].freeze
+
+  attr_reader :name, :status, :sample_size, :fail_count, :failures, :note
+
+  def initialize(name)
+    @name        = name
+    @status      = :pass
+    @sample_size = 0
+    @fail_count  = 0
+    @failures    = []
+    @note        = nil
+  end
+
+  def mark_pass(sample_size)
+    @sample_size = sample_size
+    @status = :pass
+  end
+
+  def mark_fail(sample_size, fail_count, failures)
+    @sample_size = sample_size
+    @fail_count  = fail_count
+    @failures    = failures
+    @status      = :fail
+  end
+
+  def mark_skip(note)
+    @note   = note
+    @status = :skip
+  end
+
+  def passed?; @status == :pass; end
+  def skipped?; @status == :skip; end
+end
+
+class PostMigrationValidator
+  def initialize(valkey_url:, sample:, model:, data_dir:, verbose:)
+    @valkey_url = valkey_url
+    @sample     = sample
+    @model      = model
+    @data_dir   = data_dir
+    @verbose    = verbose
+
+    @redis = nil
+    @cohort_counts = {}
+    @check_results = []
+  end
+
+  def run
+    connect_redis
+
+    cohort_population
+
+    selected = filter_for_model
+
+    selected.each do |check_id|
+      result = case check_id
+               when :customer_chain
+                 check_customer_to_membership_chain
+               when :org_indexes
+                 check_organization_indexes
+               when :domain_exclusivity
+                 check_via_external('Custom domain -> org exclusivity', 'validate_domain_org_exclusivity.rb')
+               when :owner_objects
+                 check_via_external('Owner customer objects exist',     'validate_owners_objects_exist.rb')
+               end
+      @check_results << result if result
+    end
+
+    print_summary
+    exit_code
+  ensure
+    @redis&.close
+  end
+
+  private
+
+  def connect_redis
+    uri = URI.parse(@valkey_url)
+    uri.path = '/0'
+    @redis = Redis.new(url: uri.to_s)
+    @redis.ping
+  rescue Redis::CannotConnectError, URI::InvalidURIError, Redis::CommandError => ex
+    warn "ERROR: Cannot connect to Valkey/Redis: #{ex.class}: #{ex.message}"
+    exit 2
+  end
+
+  def filter_for_model
+    return %i[customer_chain org_indexes domain_exclusivity owner_objects] unless @model
+
+    case @model
+    when 'customer'                       then %i[customer_chain]
+    when 'organization'                   then %i[org_indexes owner_objects]
+    when 'membership', 'org_membership'   then %i[customer_chain]
+    when 'customdomain'                   then %i[domain_exclusivity]
+    when 'receipt', 'secret'              then []
+    end
+  end
+
+  # ------------------------------------------------------------------
+  # Cohort population
+  # ------------------------------------------------------------------
+
+  def cohort_population
+    COHORTS.each do |cohort|
+      @cohort_counts[cohort[:label]] = scan_count(cohort[:scan])
+    end
+  end
+
+  def scan_count(pattern)
+    count = 0
+    cursor = '0'
+    loop do
+      cursor, keys = @redis.scan(cursor, match: pattern, count: 1000)
+      count += keys.size
+      break if cursor == '0'
+    end
+    count
+  end
+
+  # ------------------------------------------------------------------
+  # Check 1: customer -> org -> membership -> lookup chain
+  # ------------------------------------------------------------------
+
+  def check_customer_to_membership_chain
+    result = CheckResult.new('Customer -> Org -> Membership chain')
+
+    customer_keys = sample_keys('customer:*:object')
+    if customer_keys.empty?
+      result.mark_skip('no customer records found')
+      return result
+    end
+
+    customer_to_org = load_customer_to_org_map
+
+    failures = []
+    fail_count = 0
+
+    customer_keys.each do |customer_key|
+      customer_objid = customer_key.split(':')[1]
+
+      # Resolve org_objid via map artifact, with fallback scan if absent.
+      org_objid = customer_to_org[customer_objid]
+      org_objid ||= fallback_org_lookup(customer_objid)
+
+      unless org_objid
+        fail_count += 1
+        failures << { stage: 'customer->org', customer_objid: customer_objid, reason: 'no org_objid found via map or fallback' } if failures.size < SAMPLE_FAILURES_CAP
+        next
+      end
+
+      composite_field = "#{org_objid}:#{customer_objid}"
+      raw = @redis.hget('org_membership:org_customer_lookup', composite_field)
+      membership_objid = normalize_indexed_value(raw)
+
+      unless membership_objid
+        fail_count += 1
+        if failures.size < SAMPLE_FAILURES_CAP
+          failures << {
+            stage: 'lookup_hget',
+            customer_objid: customer_objid,
+            org_objid: org_objid,
+            composite_field: composite_field,
+            raw_value: raw.inspect,
+            reason: 'org_membership:org_customer_lookup HGET returned nil',
+          }
+        end
+        next
+      end
+
+      # The membership Redis key is org_membership:{membership_objid}:object
+      # where membership_objid is the composite path
+      # "organization:{org}:customer:{cust}:org_membership".
+      membership_key = "org_membership:#{membership_objid}:object"
+      unless @redis.exists(membership_key) > 0
+        fail_count += 1
+        if failures.size < SAMPLE_FAILURES_CAP
+          failures << {
+            stage: 'membership_object',
+            customer_objid: customer_objid,
+            org_objid: org_objid,
+            membership_objid: membership_objid,
+            membership_key: membership_key,
+            reason: 'membership object key does not exist',
+          }
+        end
+        next
+      end
+
+      # Verify the membership hash's stored ids match. Values are JSON-encoded.
+      stored_org  = normalize_indexed_value(@redis.hget(membership_key, 'organization_objid'))
+      stored_cust = normalize_indexed_value(@redis.hget(membership_key, 'customer_objid'))
+
+      if stored_org != org_objid || stored_cust != customer_objid
+        fail_count += 1
+        if failures.size < SAMPLE_FAILURES_CAP
+          failures << {
+            stage: 'membership_field_mismatch',
+            customer_objid: customer_objid,
+            org_objid: org_objid,
+            membership_objid: membership_objid,
+            stored_organization_objid: stored_org,
+            stored_customer_objid: stored_cust,
+            reason: 'membership object fields do not match expected ids',
+          }
+        end
+      end
+    end
+
+    if fail_count.zero?
+      result.mark_pass(customer_keys.size)
+    else
+      result.mark_fail(customer_keys.size, fail_count, failures)
+    end
+    result
+  end
+
+  def load_customer_to_org_map
+    map_file = File.join(@data_dir, 'organization', 'customer_objid_to_org_objid.json')
+    return {} unless File.exist?(map_file)
+
+    JSON.parse(File.read(map_file))
+  rescue JSON::ParserError, Errno::ENOENT
+    {}
+  end
+
+  # Slow-path: scan organization:objid_lookup, read each org hash's owner_id,
+  # build a reverse {customer_objid => org_objid}. Cached per run on first call.
+  def fallback_org_lookup(customer_objid)
+    @fallback_index ||= build_fallback_index
+    @fallback_index[customer_objid]
+  end
+
+  def build_fallback_index
+    warn 'NOTE: customer_objid_to_org_objid.json not found - falling back to ' \
+         'scanning organization:objid_lookup. This is O(orgs) and slow on large datasets.'
+    index = {}
+    org_objids = @redis.hkeys('organization:objid_lookup')
+    org_objids.each do |org_objid|
+      owner = normalize_indexed_value(@redis.hget("organization:#{org_objid}:object", 'owner_id'))
+      index[owner] = org_objid if owner
+    end
+    index
+  end
+
+  # ------------------------------------------------------------------
+  # Check 2: organization indexes resolve back
+  # ------------------------------------------------------------------
+
+  def check_organization_indexes
+    result = CheckResult.new('Organization lookup indexes')
+
+    org_keys = sample_keys('organization:*:object')
+    if org_keys.empty?
+      result.mark_skip('no organization records found')
+      return result
+    end
+
+    failures = []
+    fail_count = 0
+
+    org_keys.each do |org_key|
+      org_objid = org_key.split(':')[1]
+
+      org_fields = @redis.hgetall(org_key)
+      org_extid     = normalize_indexed_value(org_fields['extid'])
+      contact_email = normalize_indexed_value(org_fields['contact_email'])
+      billing_email = normalize_indexed_value(org_fields['billing_email'])
+
+      checks = [
+        ['organization:objid_lookup', org_objid,    org_objid, true],
+        ['organization:extid_lookup', org_extid,    org_objid, true],
+        ['organization:contact_email_index', contact_email, org_objid, false],
+        ['organization:billing_email_index', billing_email, org_objid, false],
+      ]
+
+      checks.each do |hkey, field, expected, required|
+        if field.nil? || field.to_s.empty?
+          if required
+            fail_count += 1
+            if failures.size < SAMPLE_FAILURES_CAP
+              failures << { stage: hkey, org_objid: org_objid, reason: 'lookup field missing on org hash' }
+            end
+          end
+          next
+        end
+
+        raw = @redis.hget(hkey, field.to_s)
+        actual = normalize_indexed_value(raw)
+        next if actual == expected
+
+        fail_count += 1
+        next unless failures.size < SAMPLE_FAILURES_CAP
+        failures << {
+          stage: hkey,
+          org_objid: org_objid,
+          field: field,
+          expected: expected,
+          actual: actual,
+          raw_value: raw.inspect,
+        }
+      end
+    end
+
+    if fail_count.zero?
+      result.mark_pass(org_keys.size)
+    else
+      result.mark_fail(org_keys.size, fail_count, failures)
+    end
+    result
+  end
+
+  # ------------------------------------------------------------------
+  # External validators
+  # ------------------------------------------------------------------
+
+  def check_via_external(name, script_basename)
+    result = CheckResult.new(name)
+    script_path = File.expand_path("../#{script_basename}", __FILE__)
+
+    unless File.exist?(script_path)
+      result.mark_skip("delegated validator missing: #{script_path}")
+      return result
+    end
+
+    cmd = [RbConfig.ruby, script_path, "--redis-url=#{@valkey_url}"]
+    puts "  -> delegating to #{script_basename}..."
+    success = system(*cmd)
+
+    if success
+      result.mark_pass(0)
+    else
+      child_exit = $?&.exitstatus || 1
+      if child_exit == 2
+        warn "WARN: #{script_basename} exited 2 (hard error) - propagating"
+      end
+      result.mark_fail(0, 0, [{ stage: 'delegated', script: script_basename, exit_code: child_exit }])
+    end
+    result
+  end
+
+  # ------------------------------------------------------------------
+  # Sampling
+  # ------------------------------------------------------------------
+
+  def sample_keys(pattern)
+    keys = []
+    cursor = '0'
+    loop do
+      cursor, batch = @redis.scan(cursor, match: pattern, count: 1000)
+      keys.concat(batch)
+      break if cursor == '0'
+    end
+
+    return keys if @sample.zero? || keys.size <= @sample
+
+    keys.sample(@sample)
+  end
+
+  # ------------------------------------------------------------------
+  # Reporting
+  # ------------------------------------------------------------------
+
+  def print_summary
+    puts
+    puts '=' * 60
+    puts 'POST-MIGRATION VALIDATION SUMMARY'
+    puts '=' * 60
+    puts
+    puts 'Cohort populations:'
+    label_w = COHORTS.map { |c| c[:label].size }.max
+    COHORTS.each do |cohort|
+      printf "  %-#{label_w + 1}s %s\n", "#{cohort[:label]}:", format_int(@cohort_counts[cohort[:label]])
+    end
+    puts
+
+    puts 'Checks:'
+    @check_results.each { |r| print_check(r) }
+    puts
+
+    failed = @check_results.count { |r| r.status == :fail }
+    skipped = @check_results.count(&:skipped?)
+    total = @check_results.size
+
+    if failed.zero?
+      puts "Result: #{total - skipped} checks passed, #{skipped} skipped, 0 failed."
+    else
+      puts "Result: #{failed} of #{total} checks failed (#{skipped} skipped)."
+    end
+  end
+
+  def print_check(result)
+    case result.status
+    when :pass
+      printf "  [PASS] %-44s (sample=%d, fail=0)\n", result.name, result.sample_size
+    when :skip
+      printf "  [SKIP] %-44s (%s)\n", result.name, result.note
+    when :fail
+      printf "  [FAIL] %-44s (sample=%d, fail=%d)\n", result.name, result.sample_size, result.fail_count
+      to_print = @verbose ? result.failures : result.failures.first(SAMPLE_FAILURES_PRINT)
+      to_print.each do |f|
+        puts "    - #{f.inspect}"
+      end
+      if !@verbose && result.failures.size > SAMPLE_FAILURES_PRINT
+        puts "    ... and #{result.failures.size - SAMPLE_FAILURES_PRINT} more (use --verbose to see all)"
+      end
+    end
+  end
+
+  def format_int(n)
+    return '0' if n.nil?
+
+    n.to_s.reverse.scan(/.{1,3}/).join(',').reverse
+  end
+
+  def exit_code
+    # Promote to exit 2 if any delegated validator hit a hard error (its
+    # failures carry exit_code: 2 per check_via_external). Otherwise exit 1
+    # for soft validation failures, 0 clean.
+    hard = @check_results.any? do |r|
+      r.status == :fail && r.failures.any? { |f| f.is_a?(Hash) && f[:exit_code] == 2 }
+    end
+    return 2 if hard
+
+    @check_results.any? { |r| r.status == :fail } ? 1 : 0
+  end
+end
+
+def parse_args(args)
+  options = {
+    valkey_url: ENV['VALKEY_URL'] || ENV.fetch('REDIS_URL', 'redis://localhost:6379'),
+    sample: 100,
+    model: nil,
+    data_dir: DEFAULT_DATA_DIR,
+    verbose: false,
+  }
+
+  args.each do |arg|
+    case arg
+    when /^--valkey-url=(.+)$/, /^--redis-url=(.+)$/
+      options[:valkey_url] = Regexp.last_match(1)
+    when /^--sample=(\d+)$/
+      options[:sample] = Regexp.last_match(1).to_i
+    when /^--model=(.+)$/
+      m = Regexp.last_match(1)
+      unless VALID_MODELS.include?(m)
+        warn "Invalid --model=#{m} (valid: #{VALID_MODELS.join(', ')})"
+        exit 1
+      end
+      options[:model] = m
+    when /^--data-dir=(.+)$/
+      options[:data_dir] = Regexp.last_match(1)
+    when '--verbose'
+      options[:verbose] = true
+    when '--help', '-h'
+      puts <<~HELP
+        Usage: ruby #{__FILE__} [OPTIONS]
+
+        Post-migration end-to-end validator for the v0.24.5 OneTimeSecret upgrade.
+        Verifies the customer -> organization -> membership -> lookup-index chain
+        and other key invariants in the live Valkey/Redis dataset after load_keys.rb.
+
+        Options:
+          --valkey-url=URL    Valkey/Redis URL (also --redis-url; env: VALKEY_URL or REDIS_URL)
+          --sample=N          Customers/orgs to spot-check (default 100; 0 = all)
+          --model=NAME        Restrict to one cohort:
+                                customer, organization,
+                                membership (alias org_membership),
+                                customdomain, receipt, secret
+          --data-dir=DIR      Migration artifact directory (default: #{DEFAULT_DATA_DIR})
+          --verbose           Print every failing case, not just the first #{SAMPLE_FAILURES_PRINT}
+          --help              Show this help
+
+        Exit codes:
+          0  All checks passed
+          1  One or more validation checks failed
+          2  Connection error or unrecoverable hard error
+
+        Checks:
+          1. Cohort population counts (customer/org/membership/customdomain/receipt/secret)
+          2. Customer -> Organization -> Membership chain (sample)
+          3. Organization lookup indexes resolve (sample)
+          4. Custom domain -> org exclusivity (delegates to validate_domain_org_exclusivity.rb)
+          5. Owner customer objects exist (delegates to validate_owners_objects_exist.rb)
+      HELP
+      exit 0
+    else
+      warn "Unknown option: #{arg}"
+      exit 1
+    end
+  end
+
+  options
+end
+
+if __FILE__ == $PROGRAM_NAME
+  options = parse_args(ARGV)
+
+  validator = PostMigrationValidator.new(
+    valkey_url: options[:valkey_url],
+    sample: options[:sample],
+    model: options[:model],
+    data_dir: options[:data_dir],
+    verbose: options[:verbose],
+  )
+
+  exit validator.run
+end

--- a/try/migrations/load_keys_try.rb
+++ b/try/migrations/load_keys_try.rb
@@ -1,0 +1,294 @@
+# try/migrations/load_keys_try.rb
+#
+# frozen_string_literal: true
+
+# Tests for scripts/upgrades/v0.24.5/load_keys.rb and its integration with
+# scripts/upgrades/v0.24.5/upgrade.sh (Phase 3).
+#
+# Regression context (#3041):
+#   1. A missing {model}_transformed.jsonl was logged but did not fail the
+#      script — load_keys.rb returned 0 even when an entire model's records
+#      were absent. Operators only learned about the gap from a keyspace
+#      diff after the fact.
+#   2. Help/banner/comments in load_keys.rb still mentioned legacy DBs 6/7/8
+#      after the consolidation onto DB 0. Misleading for anyone reading the
+#      help to understand the layout.
+#   3. upgrade.sh invoked load_keys.rb without an explicit `$?` check, so
+#      an exiting-1 loader could be masked by surrounding script structure.
+#
+# Post-fix contract:
+#   * Help text shows DB 0 for every model and contains no DB 6/7/8 mentions.
+#   * Missing transformed file is recorded as an error and load_keys.rb
+#     exits 1 (via the existing exit_with_status hook).
+#   * --skip-records suppresses the missing-records error path (operator
+#     opt-in for indexes-only loads).
+#   * upgrade.sh Phase 3 captures load_keys_rc and aborts with the same
+#     non-zero code, printing a FATAL line.
+#
+# Implementation notes:
+#   * Tests shell out via Open3. The contracts under test are CLI-shaped.
+#   * Help-text and missing-artifact cases are pure file IO (no Redis).
+#   * Happy-path / --skip-records / upgrade.sh propagation cases need a
+#     reachable test Redis. Tests skip gracefully if no Redis is available;
+#     the suite must never crash on a developer laptop without Redis.
+#   * Test Redis target defaults to redis://localhost:6379/15 (DB 15) and
+#     namespaces all writes under a tmp prefix for safe cleanup.
+
+require 'base64'
+require 'fileutils'
+require 'json'
+require 'open3'
+require 'tmpdir'
+require 'uri'
+
+PROJECT_ROOT     = File.expand_path('../..', __dir__).freeze
+LOAD_KEYS_SCRIPT = File.join(PROJECT_ROOT, 'scripts/upgrades/v0.24.5/load_keys.rb').freeze
+UPGRADE_SH       = File.join(PROJECT_ROOT, 'scripts/upgrades/v0.24.5/upgrade.sh').freeze
+
+TEST_VALKEY_URL = ENV['TEST_VALKEY_URL'] || ENV['VALKEY_URL'] || ENV['REDIS_URL'] || 'redis://localhost:6379/15'
+
+def redis_available?
+  return @redis_available unless @redis_available.nil?
+
+  require 'redis'
+  uri = URI.parse(TEST_VALKEY_URL)
+  uri.path = '/15'
+  client = Redis.new(url: uri.to_s, timeout: 1)
+  client.ping
+  client.close
+  @redis_available = true
+rescue LoadError, StandardError
+  @redis_available = false
+end
+
+# Stage every model subdir load_keys.rb expects to find. Files written depend
+# on the +files+ keyword: pass {transformed: true, indexes: true} to populate
+# both, or omit either to test the missing-artifact paths.
+#
+# +records+ is keyed by model name; values are arrays of record hashes that
+# get serialized as transformed JSONL. Index commands are a small fixed shape
+# unless +indexes+ is a Hash.
+def stage_input_dir(input_dir, files: {}, records: {})
+  layout = {
+    'customer'     => 'customer',
+    'organization' => 'organization',
+    'customdomain' => 'customdomain',
+    'receipt'      => 'metadata',
+    'secret'       => 'secret',
+  }
+
+  layout.each do |model, subdir|
+    dir = File.join(input_dir, subdir)
+    FileUtils.mkdir_p(dir)
+
+    if files[:transformed]
+      transformed_path = File.join(dir, "#{model}_transformed.jsonl")
+      lines = (records[model] || []).map { |r| JSON.generate(r) }
+      File.write(transformed_path, lines.join("\n") + (lines.empty? ? '' : "\n"))
+    end
+
+    if files[:indexes]
+      indexes_path = File.join(dir, "#{model}_indexes.jsonl")
+      File.write(indexes_path, '') # empty indexes file is valid input
+    end
+  end
+end
+
+def run_load_keys(args, env: {})
+  Open3.capture3(env, 'ruby', LOAD_KEYS_SCRIPT, *args, chdir: PROJECT_ROOT)
+end
+
+# Build a record whose `dump` is a real Redis SERIALIZE blob for an empty
+# hash — RESTORE accepts this on any DB without needing a prior dump. Only
+# used when Redis is available; the byte sequence comes from Redis itself.
+def hash_dump_blob(redis)
+  redis.del('__test_seed__')
+  redis.hset('__test_seed__', 'k', 'v')
+  blob = redis.dump('__test_seed__')
+  redis.del('__test_seed__')
+  blob
+end
+
+# ---- Help text contract (#3041) -----------------------------------------------
+
+## Setup: capture --help output once for reuse across assertions
+@help_stdout, _, @help_status = run_load_keys(['--help'])
+@help_status.success?
+#=> true
+
+## Help text mentions DB 0 (the consolidated target database)
+@help_stdout.match?(/\bDB 0\b/)
+#=> true
+
+## Help text contains zero references to legacy DBs 6, 7, or 8
+@help_stdout.match?(/\bDB\s*[678]\b/)
+#=> false
+
+## Help text enumerates all five models on DB 0
+%w[customer organization customdomain receipt secret].all? do |m|
+  @help_stdout.match?(/#{m}\s+->\s+DB 0/)
+end
+#=> true
+
+# ---- Missing transformed file fails loudly (#3041) ----------------------------
+
+## Setup: stage every model's subdir but write no transformed files.
+## Indexes files are present so the indexes path doesn't also error.
+## Use --model=customer so the run does not need Redis to surface the
+## missing-artifact error: load_keys.rb records the error before opening
+## any connection. The all-models case is covered when Redis is reachable.
+@missing_dir = Dir.mktmpdir('load_keys_missing_')
+stage_input_dir(@missing_dir, files: { indexes: true })
+@missing_stdout, @missing_stderr, @missing_status =
+  run_load_keys(["--input-dir=#{@missing_dir}", "--valkey-url=#{TEST_VALKEY_URL}",
+                 '--model=customer', '--skip-indexes', '--dry-run'])
+@missing_status.exitstatus
+#=> 1
+
+## Stderr names the model whose transformed file is missing
+@missing_stderr.match?(/Missing transformed file.*customer/)
+#=> true
+
+## When Redis is reachable, run with no --model and confirm every model's
+## missing transformed file is reported (no silent passes).
+if redis_available?
+  _, @all_missing_stderr, @all_missing_status =
+    run_load_keys(["--input-dir=#{@missing_dir}", "--valkey-url=#{TEST_VALKEY_URL}", '--dry-run'])
+end
+
+## Exit status is 1 across-the-board when Redis is reachable.
+redis_available? ? @all_missing_status.exitstatus : 1
+#=> 1
+
+## All five models report a missing transformed file (Redis-required check).
+if redis_available?
+  %w[customer organization customdomain receipt secret].all? do |m|
+    @all_missing_stderr.match?(/Missing transformed file.*#{m}/)
+  end
+else
+  true
+end
+#=> true
+
+# Teardown for missing-artifact case
+FileUtils.rm_rf(@missing_dir) if @missing_dir
+
+# ---- --skip-records bypasses the missing-records check (#3041) ----------------
+
+## Setup: index files only, no transformed JSONL anywhere. With --skip-records,
+## load_keys.rb should not record errors for absent transformed files.
+@skip_dir = Dir.mktmpdir('load_keys_skip_')
+stage_input_dir(@skip_dir, files: { indexes: true })
+
+## Skip gracefully if no Redis: --skip-records still opens connections to
+## execute (empty) index files, so we cannot run this case offline.
+@skip_stdout, @skip_stderr, @skip_status =
+  if redis_available?
+    run_load_keys(["--input-dir=#{@skip_dir}", "--valkey-url=#{TEST_VALKEY_URL}", '--skip-records'])
+  else
+    [nil, nil, nil]
+  end
+
+## Exits 0 when Redis is reachable; skipped otherwise (no false failure).
+redis_available? ? @skip_status.exitstatus : 0
+#=> 0
+
+## Stderr does not contain a "Missing transformed file" error in skip mode.
+redis_available? ? !@skip_stderr.include?('Missing transformed file') : true
+#=> true
+
+# Teardown for skip-records case
+FileUtils.rm_rf(@skip_dir) if @skip_dir
+
+# ---- Happy path: one customer, no indexes, --skip-indexes ---------------------
+
+## Setup: a single transformed customer record using a real Redis dump blob.
+## All other models keep empty transformed files so they don't error out.
+@happy_dir = Dir.mktmpdir('load_keys_happy_')
+
+if redis_available?
+  require 'redis'
+  uri = URI.parse(TEST_VALKEY_URL); uri.path = '/15'
+  @happy_redis = Redis.new(url: uri.to_s, timeout: 2)
+  @happy_redis.flushdb
+  @happy_blob   = hash_dump_blob(@happy_redis)
+  @happy_record = {
+    'key'    => 'tryouts:load_keys:customer:alice@example.com:object',
+    'type'   => 'hash',
+    'ttl_ms' => -1,
+    'db'     => 0,
+    'dump'   => Base64.strict_encode64(@happy_blob),
+  }
+  stage_input_dir(@happy_dir,
+                  files:   { transformed: true },
+                  records: { 'customer' => [@happy_record] })
+
+  uri15 = URI.parse(TEST_VALKEY_URL); uri15.path = '/15'
+  @happy_stdout, @happy_stderr, @happy_status =
+    run_load_keys(["--input-dir=#{@happy_dir}", "--valkey-url=#{uri15}",
+                   '--model=customer', '--skip-indexes'])
+end
+
+## Exits 0 when Redis is reachable; skipped otherwise.
+redis_available? ? @happy_status.exitstatus : 0
+#=> 0
+
+## Summary output reports the restored record count.
+redis_available? ? @happy_stdout.match?(/Records restored:\s+1/) : true
+#=> true
+
+## The record actually landed in the target DB.
+if redis_available?
+  exists = @happy_redis.exists?('tryouts:load_keys:customer:alice@example.com:object')
+  @happy_redis.del('tryouts:load_keys:customer:alice@example.com:object')
+  @happy_redis.flushdb
+  @happy_redis.close
+  exists
+else
+  true
+end
+#=> true
+
+# Teardown for happy path
+FileUtils.rm_rf(@happy_dir) if @happy_dir
+
+# ---- upgrade.sh propagates load_keys.rb non-zero exit (#3041) -----------------
+
+## upgrade.sh structurally captures the load_keys.rb return code (regression
+## guard: even if the bash flow is rewritten, this file-level check ensures
+## the exit-status propagation pattern stays in place).
+@upgrade_src = File.read(UPGRADE_SH)
+[@upgrade_src.match?(/load_keys_rc=\$\?/),
+ @upgrade_src.match?(/if\s*\[\s*"\$load_keys_rc"\s*-ne\s*0\s*\]/),
+ @upgrade_src.match?(/FATAL:\s+Phase\s+3\s+\(load_keys\.rb\)\s+failed/),
+ @upgrade_src.match?(/exit\s+"\$load_keys_rc"/)].all?
+#=> true
+
+## Functional check: invoking upgrade.sh with a deliberately-broken Phase 3
+## input (subdirs present, transformed files absent) propagates exit 1 and
+## prints the FATAL line. Skip when Redis is unavailable: upgrade.sh pings
+## source/target before reaching Phase 3 and would fail earlier on its own.
+if redis_available?
+  @propagate_dir = Dir.mktmpdir('load_keys_propagate_')
+  stage_input_dir(@propagate_dir, files: { indexes: true })
+
+  @propagate_stdout, @propagate_stderr, @propagate_status = Open3.capture3(
+    'bash', UPGRADE_SH,
+    '--execute', '--start-phase=3', '--skip-gates',
+    "--source-url=#{TEST_VALKEY_URL}",
+    "--target-url=#{TEST_VALKEY_URL}",
+    "--data-dir=#{@propagate_dir}",
+    chdir: PROJECT_ROOT
+  )
+end
+
+## upgrade.sh exits non-zero when load_keys.rb fails Phase 3.
+redis_available? ? (@propagate_status.exitstatus != 0) : true
+#=> true
+
+## upgrade.sh prints the FATAL line naming Phase 3 + load_keys.rb.
+redis_available? ? @propagate_stdout.include?('FATAL: Phase 3 (load_keys.rb) failed') : true
+#=> true
+
+# Teardown for propagation case
+FileUtils.rm_rf(@propagate_dir) if defined?(@propagate_dir) && @propagate_dir

--- a/try/migrations/organization_generation_try.rb
+++ b/try/migrations/organization_generation_try.rb
@@ -7,7 +7,7 @@
 #
 # Regression context (#3041): the v0.24.5 upgrade pipeline produced
 # Organization records but never emitted OrganizationMembership records, which
-# in turn left organization:org_customer_lookup empty. Customers appeared in
+# in turn left org_membership:org_customer_lookup empty. Customers appeared in
 # org.members ZSETs and customer.participations SETs, but model-level lookups
 # such as OrganizationMembership.find_by_org_customer returned nil. The
 # Organization-stage validator also lacked a --redis-url option, so
@@ -18,7 +18,7 @@
 #   1. generate.rb + create_indexes.rb + load_keys.rb (the production path)
 #      produce a discoverable OrganizationMembership for each org's owner with
 #      role='owner', status='active', and a positive joined_at.
-#   2. organization:org_customer_lookup HSET contains the expected
+#   2. org_membership:org_customer_lookup HSET contains the expected
 #      "org_objid:owner_id" -> membership_objid mapping.
 #   3. The owner is in org.members (ZSET) and the org collection key is in
 #      customer.participations (SET) — guards the existing behavior that the
@@ -257,9 +257,9 @@ end
 
 # --- Membership emission contract (#3041 fix) ---------------------------------
 
-## organization:org_customer_lookup HSET contains an entry for every (org, owner) pair
+## org_membership:org_customer_lookup HSET contains an entry for every (org, owner) pair
 @expected_lookup_keys = @org_records.map { |r| "#{r['objid']}:#{r['owner_id']}" }.sort
-@actual_lookup_keys   = @redis.hkeys('organization:org_customer_lookup').sort
+@actual_lookup_keys   = @redis.hkeys('org_membership:org_customer_lookup').sort
 (@expected_lookup_keys - @actual_lookup_keys).empty?
 #=> true
 
@@ -301,7 +301,7 @@ end
 # --- Idempotency: re-running create_indexes.rb + load_keys.rb is stable -------
 
 ## Snapshot membership state before the second pass
-@before_lookup_size = @redis.hlen('organization:org_customer_lookup')
+@before_lookup_size = @redis.hlen('org_membership:org_customer_lookup')
 @before_membership_objids = @org_records.map do |r|
   Onetime::OrganizationMembership.find_by_org_customer(r['objid'], r['owner_id']).objid
 end
@@ -317,7 +317,7 @@ run_load_keys(input_dir: @workdir).last.success?
 #=> true
 
 ## Lookup HSET size is unchanged (no duplicates)
-@redis.hlen('organization:org_customer_lookup') == @before_lookup_size
+@redis.hlen('org_membership:org_customer_lookup') == @before_lookup_size
 #=> true
 
 ## Each (org, owner) still resolves to the same membership objid

--- a/try/migrations/organization_generation_try.rb
+++ b/try/migrations/organization_generation_try.rb
@@ -1,0 +1,348 @@
+# try/migrations/organization_generation_try.rb
+#
+# frozen_string_literal: true
+
+# Tests for scripts/upgrades/v0.24.5/02-organization/{generate,create_indexes,
+# validate_instance_index}.rb plus the Organization stage of run_pipeline.sh.
+#
+# Regression context (#3041): the v0.24.5 upgrade pipeline produced
+# Organization records but never emitted OrganizationMembership records, which
+# in turn left organization:org_customer_lookup empty. Customers appeared in
+# org.members ZSETs and customer.participations SETs, but model-level lookups
+# such as OrganizationMembership.find_by_org_customer returned nil. The
+# Organization-stage validator also lacked a --redis-url option, so
+# run_pipeline.sh:115 invoked it without one (out of step with the customer
+# and customdomain validators on lines 106 and 124).
+#
+# What these tests lock in (post-fix contract):
+#   1. generate.rb + create_indexes.rb + load_keys.rb (the production path)
+#      produce a discoverable OrganizationMembership for each org's owner with
+#      role='owner', status='active', and a positive joined_at.
+#   2. organization:org_customer_lookup HSET contains the expected
+#      "org_objid:owner_id" -> membership_objid mapping.
+#   3. The owner is in org.members (ZSET) and the org collection key is in
+#      customer.participations (SET) — guards the existing behavior that the
+#      fix must not regress.
+#   4. Re-running the pipeline produces no duplicate memberships and leaves
+#      the lookup HSET stable.
+#   5. validate_instance_index.rb accepts --redis-url=... and exits 0 against
+#      the seeded fixture.
+#   6. run_pipeline.sh:115 invokes the org validator with --redis-url, mirroring
+#      the customer (:106) and customdomain (:124) calls.
+#   7. Snippet-A audit (sample N orgs, count missing memberships) reports zero
+#      gaps after the fix.
+#
+# Implementation notes:
+#   - Customer fixture records carry real Redis DUMP blobs of v2-serialized
+#     hashes — generate.rb RESTOREs and deserialize_v2_fields-decodes the
+#     contents. Fake bytes raise Redis::CommandError.
+#   - Index commands are applied via load_keys.rb (the production applier)
+#     rather than reimplemented; that's the same code path Prod-1's emitter
+#     output flows through in production.
+#   - Tests boot OT in-process to use OrganizationMembership.find_by_org_customer
+#     — the storage shape (additional JSONL records vs index commands vs both)
+#     is implementation detail; the contract is the model lookup.
+#   - If no test Redis is reachable on port 2121, the whole file exits 0
+#     cleanly so CI doesn't false-fail on missing infrastructure.
+
+require_relative '../support/test_helpers'
+
+require 'base64'
+require 'fileutils'
+require 'json'
+require 'open3'
+require 'redis'
+require 'securerandom'
+require 'tmpdir'
+require 'uri'
+
+PROJECT_ROOT  = File.expand_path('../..', __dir__).freeze
+ORG_DIR       = File.join(PROJECT_ROOT, 'scripts/upgrades/v0.24.5/02-organization').freeze
+GENERATE_RB   = File.join(ORG_DIR, 'generate.rb').freeze
+INDEXES_RB    = File.join(ORG_DIR, 'create_indexes.rb').freeze
+VALIDATOR_RB  = File.join(ORG_DIR, 'validate_instance_index.rb').freeze
+LOAD_KEYS_RB  = File.join(PROJECT_ROOT, 'scripts/upgrades/v0.24.5/load_keys.rb').freeze
+PIPELINE_SH   = File.join(PROJECT_ROOT, 'scripts/upgrades/v0.24.5/run_pipeline.sh').freeze
+
+TEST_REDIS_URL = ENV['VALKEY_URL'] || ENV['REDIS_URL'] || 'redis://127.0.0.1:2121/0'
+TEMP_DB        = 14  # generate/create_indexes use --temp-db for RESTORE staging
+                     # 15 is the script default; keep our value distinct to surface
+                     # accidental cross-talk between staging and target databases.
+
+# --- Fixture builders ---------------------------------------------------------
+
+# Stages a v2-serialized customer hash into Redis under a temp key, DUMPs it,
+# DELs the key, and returns the base64-encoded DUMP. Mirrors what 01-customer
+# transform.rb writes into customer_transformed.jsonl.
+def customer_dump_b64(redis, fields)
+  temp_key = "_test_customer_stage_#{SecureRandom.hex(6)}"
+  serialized = fields.transform_values { |v| v.nil? ? 'null' : JSON.generate(v) }
+  redis.hset(temp_key, serialized)
+  blob = redis.dump(temp_key)
+  redis.del(temp_key)
+  Base64.strict_encode64(blob)
+end
+
+# Builds a customer_transformed.jsonl record carrying a real DUMP blob.
+def customer_record(redis:, objid:, email:, created:, **extra_fields)
+  fields = {
+    'custid' => objid,
+    'email' => email,
+    'planid' => extra_fields[:planid] || 'free',
+    'created' => created.to_f,
+    'updated' => created.to_f,
+    'v1_custid' => email,
+  }
+  fields['stripe_customer_id'] = extra_fields[:stripe_customer_id] if extra_fields[:stripe_customer_id]
+
+  {
+    'key' => "customer:#{email}:object",
+    'type' => 'hash',
+    'ttl_ms' => -1,
+    'db' => 0,
+    'dump' => customer_dump_b64(redis, fields),
+    'objid' => objid,
+    'extid' => "ur#{SecureRandom.hex(12).rjust(25, '0')[0, 25]}",
+    'created' => created.to_f,
+  }
+end
+
+def write_jsonl(path, records)
+  FileUtils.mkdir_p(File.dirname(path))
+  File.open(path, 'w') { |f| records.each { |r| f.puts(JSON.generate(r)) } }
+end
+
+def read_jsonl(path)
+  File.foreach(path).map { |line| JSON.parse(line.chomp) }
+end
+
+# Shells out with VALKEY_URL/REDIS_URL pointing at the test Redis so any
+# script that picks them up via env (vs flag) hits the same database.
+def shell_out(*cmd)
+  env = { 'VALKEY_URL' => TEST_REDIS_URL, 'REDIS_URL' => TEST_REDIS_URL }
+  Open3.capture3(env, *cmd, chdir: PROJECT_ROOT)
+end
+
+def run_generate(input_file:, output_dir:)
+  shell_out('ruby', GENERATE_RB,
+            "--input-file=#{input_file}",
+            "--output-dir=#{output_dir}",
+            "--redis-url=#{TEST_REDIS_URL}",
+            "--temp-db=#{TEMP_DB}")
+end
+
+def run_create_indexes(input_file:, output_dir:)
+  shell_out('ruby', INDEXES_RB,
+            "--input-file=#{input_file}",
+            "--output-dir=#{output_dir}",
+            "--redis-url=#{TEST_REDIS_URL}",
+            "--temp-db=#{TEMP_DB}")
+end
+
+# Apply only the organization indexes JSONL via load_keys.rb. We skip the
+# RESTORE phase because:
+#   - the fixture has no on-disk customer_transformed.jsonl in the expected
+#     load_keys layout, only an inline path we pass to generate.rb, and
+#   - org.members ZSET / customer.participations SET / org_customer_lookup
+#     HSET are all populated from index commands, which is what we're testing.
+def run_load_keys(input_dir:)
+  shell_out('ruby', LOAD_KEYS_RB,
+            "--input-dir=#{input_dir}",
+            "--valkey-url=#{TEST_REDIS_URL}",
+            '--model=organization',
+            '--skip-records')
+end
+
+# --- Redis availability guard -------------------------------------------------
+
+def redis_reachable?(url)
+  client = Redis.new(url: url, timeout: 1.0)
+  client.ping == 'PONG'
+rescue StandardError
+  false
+ensure
+  client&.close
+end
+
+unless redis_reachable?(TEST_REDIS_URL)
+  warn "[organization_generation_try] Redis at #{TEST_REDIS_URL} not reachable — skipping."
+  exit 0
+end
+
+# --- Test setup ---------------------------------------------------------------
+
+OT.boot! :test
+
+@redis = Redis.new(url: TEST_REDIS_URL)
+@redis.flushdb
+# Also flush the temp DB used by generate/create_indexes for RESTORE staging,
+# in case a previous run left orphan keys in DB 14.
+temp_uri = URI.parse(TEST_REDIS_URL).tap { |u| u.path = "/#{TEMP_DB}" }
+Redis.new(url: temp_uri.to_s).then { |r| r.flushdb; r.close }
+
+@workdir   = Dir.mktmpdir('orggen_try_')
+@cust_dir  = File.join(@workdir, 'customer')
+@org_dir   = File.join(@workdir, 'organization')
+@cust_file = File.join(@cust_dir, 'customer_transformed.jsonl')
+@org_file  = File.join(@org_dir,  'organization_transformed.jsonl')
+@idx_file  = File.join(@org_dir,  'organization_indexes.jsonl')
+
+@ts        = Familia.now.to_i
+@records   = [
+  { objid: SecureRandom.uuid_v7, email: "alice_#{@ts}@orggentry.example", created: @ts - 300 },
+  { objid: SecureRandom.uuid_v7, email: "bob_#{@ts}@orggentry.example",   created: @ts - 200,
+    stripe_customer_id: 'cus_orggentry_bob' },
+  { objid: SecureRandom.uuid_v7, email: "carol_#{@ts}@orggentry.example", created: @ts - 100 },
+]
+
+write_jsonl(@cust_file, @records.map { |r| customer_record(redis: @redis, **r) })
+
+# --- Pipeline shape: validator must be invoked with --redis-url ---------------
+
+## run_pipeline.sh exists at the expected path
+File.exist?(PIPELINE_SH)
+#=> true
+
+## run_pipeline.sh invokes the org validator with --redis-url, like its peers
+@pipeline_src = File.read(PIPELINE_SH)
+@pipeline_src.match?(%r{02-organization/validate_instance_index\.rb.*--redis-url=}m)
+#=> true
+
+# --- generate.rb produces organization records --------------------------------
+
+## generate.rb runs successfully against the customer fixture
+@gen_stdout, @gen_stderr, @gen_status = run_generate(input_file: @cust_file, output_dir: @org_dir)
+[@gen_status.success?, File.exist?(@org_file)]
+#=> [true, true]
+
+## generate.rb emits one organization per customer object with required fields
+@org_records = read_jsonl(@org_file)
+[@org_records.size,
+ @org_records.all? { |r| r['key']&.match?(%r{\Aorganization:[0-9a-f-]{36}:object\z}) },
+ @org_records.all? { |r| r['objid'] && r['extid']&.start_with?('on') && r['owner_id'] && r['contact_email'] }]
+#=> [3, true, true]
+
+## owner_id values exactly match the customer objids the records came from
+expected_owners = @records.map { |r| r[:objid] }.sort
+@org_records.map { |r| r['owner_id'] }.sort == expected_owners
+#=> true
+
+# --- create_indexes.rb + load_keys.rb populates Redis state ------------------
+
+## create_indexes.rb runs successfully and writes the indexes JSONL
+@idx_stdout, @idx_stderr, @idx_status = run_create_indexes(input_file: @org_file, output_dir: @org_dir)
+[@idx_status.success?, File.exist?(@idx_file)]
+#=> [true, true]
+
+## load_keys.rb applies the indexes against the test Redis
+@load_stdout, @load_stderr, @load_status = run_load_keys(input_dir: @workdir)
+@load_status.success?
+#=> true
+
+## organization:instances ZSET contains all generated org_objids
+@org_objids = @org_records.map { |r| r['objid'] }
+(@org_objids - @redis.zrange('organization:instances', 0, -1)).empty?
+#=> true
+
+## For every org, the owner is present in organization:{org}:members (ZSET behavior)
+@org_records.all? { |r| @redis.zscore("organization:#{r['objid']}:members", r['owner_id']) }
+#=> true
+
+## For every org, customer:{owner}:participations contains the org's members key
+@org_records.all? do |r|
+  @redis.sismember("customer:#{r['owner_id']}:participations",
+                   "organization:#{r['objid']}:members")
+end
+#=> true
+
+# --- Membership emission contract (#3041 fix) ---------------------------------
+
+## organization:org_customer_lookup HSET contains an entry for every (org, owner) pair
+@expected_lookup_keys = @org_records.map { |r| "#{r['objid']}:#{r['owner_id']}" }.sort
+@actual_lookup_keys   = @redis.hkeys('organization:org_customer_lookup').sort
+(@expected_lookup_keys - @actual_lookup_keys).empty?
+#=> true
+
+## OrganizationMembership.find_by_org_customer returns a non-nil membership for every org/owner pair
+@memberships = @org_records.map do |r|
+  Onetime::OrganizationMembership.find_by_org_customer(r['objid'], r['owner_id'])
+end
+@memberships.none?(&:nil?)
+#=> true
+
+## Each membership has role='owner', status='active', and positive joined_at
+@memberships.map { |m| [m.role, m.status, m.joined_at.to_f.positive?] }.uniq
+#=> [["owner", "active", true]]
+
+## Each membership has organization_objid and customer_objid pointing at the right pair
+@memberships.zip(@org_records).all? do |m, r|
+  m.organization_objid == r['objid'] && m.customer_objid == r['owner_id']
+end
+#=> true
+
+# --- Snippet-A regression check (0429-upgrade-bugs.md) -----------------------
+
+## Sampled audit reports zero (org, owner) pairs missing OrganizationMembership
+@sampled_orgs = Onetime::Organization.instances.revrange(0, 19)
+@total_pairs   = 0
+@missing_pairs = 0
+@sampled_orgs.each do |org_objid|
+  member_objids = @redis.zrange("organization:#{org_objid}:members", 0, -1)
+  next if member_objids.empty?
+
+  member_objids.each do |cust_objid|
+    @total_pairs += 1
+    @missing_pairs += 1 if Onetime::OrganizationMembership.find_by_org_customer(org_objid, cust_objid).nil?
+  end
+end
+[@total_pairs.positive?, @missing_pairs]
+#=> [true, 0]
+
+# --- Idempotency: re-running create_indexes.rb + load_keys.rb is stable -------
+
+## Snapshot membership state before the second pass
+@before_lookup_size = @redis.hlen('organization:org_customer_lookup')
+@before_membership_objids = @org_records.map do |r|
+  Onetime::OrganizationMembership.find_by_org_customer(r['objid'], r['owner_id']).objid
+end
+@before_lookup_size
+#=> 3
+
+## Second create_indexes.rb pass succeeds
+run_create_indexes(input_file: @org_file, output_dir: @org_dir).last.success?
+#=> true
+
+## Second load_keys.rb pass succeeds
+run_load_keys(input_dir: @workdir).last.success?
+#=> true
+
+## Lookup HSET size is unchanged (no duplicates)
+@redis.hlen('organization:org_customer_lookup') == @before_lookup_size
+#=> true
+
+## Each (org, owner) still resolves to the same membership objid
+@after_membership_objids = @org_records.map do |r|
+  Onetime::OrganizationMembership.find_by_org_customer(r['objid'], r['owner_id']).objid
+end
+@after_membership_objids == @before_membership_objids
+#=> true
+
+# --- Validator CLI: --redis-url is accepted and the run exits 0 ---------------
+
+## validate_instance_index.rb --redis-url=... runs and exits 0
+@val_stdout, @val_stderr, @val_status = shell_out(
+  'ruby', VALIDATOR_RB,
+  "--transformed-file=#{@org_file}",
+  "--indexes-file=#{@idx_file}",
+  "--customer-file=#{@cust_file}",
+  "--redis-url=#{TEST_REDIS_URL}",
+)
+[@val_status.success?, @val_stderr.include?('Unknown option: --redis-url')]
+#=> [true, false]
+
+# --- Teardown ----------------------------------------------------------------
+
+@redis.flushdb
+@redis.close
+Redis.new(url: temp_uri.to_s).then { |r| r.flushdb; r.close }
+FileUtils.rm_rf(@workdir) if @workdir


### PR DESCRIPTION
Fixes #3041

This PR addresses missing `OrganizationMembership` records during the v0.24.5 data migration and improves the safety and resilience of the upgrade pipeline.

**Key Changes:**
* **Organization Memberships:** `generate.rb` now emits an `OrganizationMembership` record (role='owner') alongside each migrated organization. `create_indexes.rb` processes these to populate the `org_membership:org_customer_lookup` index, ensuring `OrganizationMembership.find_by_org_customer` resolves correctly for migrated owners.
* **Pipeline Hardening:**
  * `upgrade.sh` explicitly captures exit codes and aborts Phase 3 if `load_keys.rb` fails.
  * `load_keys.rb` logs explicit errors and exits non-zero when required Phase 2 artifacts are missing.
  * `enrich_with_original_record.rb` defaults to a safe dry-run mode and requires an explicit `--execute` flag to perform Redis writes.
  * `01-customer/transform.rb` implements atomic file writes via a temporary file to prevent partial data artifacts on failure.
* **Validation & Testing:**
  * Added `--redis-url` support to the organization `validate_instance_index.rb` script for CLI parity.
  * Introduced comprehensive tests (`try/migrations/`) for key loading and organization generation.
  * Updated `README.md` and `spec.md` to reflect accurate version numbers and consolidated DB schema changes.

