### PR TITLE
Drop pretty-format-json from pre-push hooks

### DIFF
--- a/.pre-push-config.yaml
+++ b/.pre-push-config.yaml
@@ -65,11 +65,6 @@ repos:
         name: Validate JSON files
         files: \.json$
 
-      - id: pretty-format-json
-        name: Format JSON files
-        args: ['--autofix', '--no-sort-keys']
-        files: \.json$
-
       - id: mixed-line-ending
         name: Check line endings
         args: [--fix=lf]


### PR DESCRIPTION
## Summary

`pretty-format-json` from `pre-commit/pre-commit-hooks` calls `json.dumps()` with the default `ensure_ascii=True`, which rewrites every non-ASCII character as `\uXXXX`. Combined with `--autofix`, it mangled 580 locale files across 29 languages on the first push to a remote that was significantly behind (the locale files entered the diff range only because that remote was missing recent merges). There is no flag to disable the ASCII escaping.

`check-json` is retained for parseability validation; only the destructive autofix is removed.

### Why now, after a year of the hook being in place

The hook config has existed for ~a year, but the client-side wrapper at `.git/hooks/pre-push` was last installed on Apr 17 2026 (per file mtime). Before that the wrapper was absent or stale, so `git push` never invoked the chain. Pushes to `origin` since Apr 17 had small diffs that did not sweep up locale churn; the recent push to a remote behind by many commits did.

## Test plan

- [ ] `pre-commit run --config .pre-push-config.yaml check-json --all-files` passes
- [ ] `git push` to a remote with a large diff containing locale JSON files no longer modifies the working tree