### PR TITLE
SSO settings alignment

### DIFF
--- a/apps/web/billing/cli/diagnose_command.rb
+++ b/apps/web/billing/cli/diagnose_command.rb
@@ -23,7 +23,7 @@ module Onetime
 
       desc 'Diagnose entitlement resolution for a user or organization'
 
-      argument :email, required: false, desc: 'Customer email address (omit when using --org)'
+      argument :email, required: false, desc: 'Customer email address (required unless --org is provided)'
 
       option :org,
         type: :string,
@@ -44,8 +44,11 @@ module Onetime
         boot_application!
 
         if email.to_s.empty? && org.to_s.empty?
-          puts 'ERROR: provide a customer email argument or --org <extid>'
-          return
+          warn "'ots billing diagnose' was called with no arguments"
+          warn ''
+          warn 'Usage: ots billing diagnose EMAIL [OPTIONS]'
+          warn '   or: ots billing diagnose --org EXTID [OPTIONS]'
+          exit 1
         end
 
         target = org.to_s.empty? ? email : "org=#{org}"

--- a/apps/web/billing/cli/diagnose_command.rb
+++ b/apps/web/billing/cli/diagnose_command.rb
@@ -6,7 +6,7 @@ require_relative 'helpers'
 
 module Onetime
   module CLI
-    # Diagnose entitlement resolution for a specific user
+    # Diagnose entitlement resolution for a specific user or organization
     #
     # Walks the full chain: email → customer → org → planid → plan cache →
     # billing.yaml fallback → entitlements. Reports the first break point found.
@@ -14,14 +14,21 @@ module Onetime
     # Usage:
     #   bin/ots billing diagnose user@example.com
     #   bin/ots billing diagnose user@example.com --entitlement custom_mail_sender
+    #   bin/ots billing diagnose --org on8q30gih2uxu2cw77jzh7caq07
+    #   bin/ots billing diagnose --org on8q30gih2uxu2cw77jzh7caq07 --entitlement manage_sso
     #   bin/ots billing diagnose user@example.com --verbose
     #
     class BillingDiagnoseCommand < Command
       include BillingHelpers
 
-      desc 'Diagnose entitlement resolution for a user'
+      desc 'Diagnose entitlement resolution for a user or organization'
 
-      argument :email, required: true, desc: 'Customer email address'
+      argument :email, required: false, desc: 'Customer email address (omit when using --org)'
+
+      option :org,
+        type: :string,
+        default: nil,
+        desc: 'Organization extid (e.g., on8q30gih2uxu2cw77jzh7caq07); bypasses email lookup'
 
       option :entitlement,
         type: :string,
@@ -33,24 +40,38 @@ module Onetime
         default: false,
         desc: 'Show all resolution details even when passing'
 
-      def call(email:, entitlement: nil, verbose: false, **)
-        require_sudo
+      def call(email: nil, org: nil, entitlement: nil, verbose: false, **)
         boot_application!
 
-        puts "Diagnosing: #{email}"
+        if email.to_s.empty? && org.to_s.empty?
+          puts 'ERROR: provide a customer email argument or --org <extid>'
+          return
+        end
+
+        target = org.to_s.empty? ? email : "org=#{org}"
+        puts "Diagnosing: #{target}"
         puts '=' * 70
         puts
 
         # Step 1: Billing enabled?
         billing_on = check_billing_enabled(verbose)
 
-        # Step 2: Customer lookup
-        customer = check_customer(email)
-        return unless customer
+        # Step 2 & 3: Customer + Organization lookup
+        # When --org is given, resolve the org first and derive the customer
+        # from its owner_id. Otherwise walk email → customer → default org.
+        if org.to_s.empty?
+          customer = check_customer(email)
+          return unless customer
 
-        # Step 3: Organization lookup
-        org = check_organization(customer)
-        return unless org
+          resolved_org = check_organization(customer)
+          return unless resolved_org
+        else
+          resolved_org = check_organization_by_extid(org)
+          return unless resolved_org
+
+          check_customer_for_org(resolved_org)
+        end
+        org = resolved_org
 
         # Step 4: Plan assignment
         planid = check_planid(org, verbose)
@@ -186,6 +207,59 @@ module Onetime
         puts
 
         org
+      end
+
+      def check_organization_by_extid(extid)
+        puts 'ORGANIZATION'
+        puts '-' * 70
+
+        org = Onetime::Organization.find_by_extid(extid)
+        unless org
+          puts "  NOT FOUND: No organization with extid '#{extid}'"
+          puts
+          return nil
+        end
+
+        puts "  Org ID:       #{org.objid}"
+        puts "  ExtID:        #{org.extid}" if org.respond_to?(:extid)
+        puts "  Display Name: #{org.display_name}" if org.respond_to?(:display_name)
+        puts "  Is Default:   #{org.is_default}"
+
+        stripe_cust = org.respond_to?(:stripe_customer_id) ? org.stripe_customer_id : nil
+        stripe_sub  = org.respond_to?(:stripe_subscription_id) ? org.stripe_subscription_id : nil
+        puts "  Stripe Customer:     #{stripe_cust.to_s.empty? ? '(none)' : stripe_cust}"
+        puts "  Stripe Subscription: #{stripe_sub.to_s.empty? ? '(none)' : stripe_sub}"
+        puts
+
+        org
+      end
+
+      def check_customer_for_org(org)
+        puts 'CUSTOMER (resolved from org.owner_id)'
+        puts '-' * 70
+
+        owner_id = org.respond_to?(:owner_id) ? org.owner_id : nil
+        if owner_id.to_s.empty?
+          puts '  (none) — org has no owner_id set'
+          puts
+          return nil
+        end
+
+        customer = Onetime::Customer.load(owner_id)
+
+        unless customer
+          puts "  NOT FOUND: owner_id=#{owner_id} did not resolve to a customer"
+          puts
+          return nil
+        end
+
+        puts "  Email:    #{customer.email || customer.custid}"
+        puts "  Role:     #{customer.role}"
+        puts "  Verified: #{customer.verified}"
+        puts "  ExtID:    #{customer.extid}"
+        puts
+
+        customer
       end
 
       def check_planid(org, _verbose)

--- a/apps/web/billing/cli/diagnose_command.rb
+++ b/apps/web/billing/cli/diagnose_command.rb
@@ -72,7 +72,7 @@ module Onetime
           resolved_org = check_organization_by_extid(org)
           return unless resolved_org
 
-          check_customer_for_org(resolved_org)
+          _customer = check_customer_for_org(resolved_org)
         end
         org = resolved_org
 
@@ -224,8 +224,8 @@ module Onetime
         end
 
         puts "  Org ID:       #{org.objid}"
-        puts "  ExtID:        #{org.extid}" if org.respond_to?(:extid)
-        puts "  Display Name: #{org.display_name}" if org.respond_to?(:display_name)
+        puts "  ExtID:        #{org.extid}"
+        puts "  Display Name: #{org.display_name}"
         puts "  Is Default:   #{org.is_default}"
 
         stripe_cust = org.respond_to?(:stripe_customer_id) ? org.stripe_customer_id : nil
@@ -308,8 +308,7 @@ module Onetime
           puts '  Source: Redis plan cache'
           puts "  Key:    billing_plan:#{planid}:entitlements"
           puts "  Count:  #{ents.size}"
-          product_id = plan.respond_to?(:stripe_product_id) ? plan.stripe_product_id : nil
-          puts "  Stripe Product: #{product_id.to_s.empty? ? '(none)' : product_id}"
+          puts "  Stripe Product: #{plan.stripe_product_id.to_s.empty? ? '(none)' : plan.stripe_product_id}"
           if verbose && plan.respond_to?(:tier)
             puts "  Tier:   #{plan.tier}"
           end

--- a/apps/web/billing/cli/diagnose_command.rb
+++ b/apps/web/billing/cli/diagnose_command.rb
@@ -301,10 +301,12 @@ module Onetime
         # Try Redis cache
         plan = ::Billing::Plan.load(planid)
         if plan
-          ents = plan.entitlements.to_a
+          ents       = plan.entitlements.to_a
           puts '  Source: Redis plan cache'
           puts "  Key:    billing_plan:#{planid}:entitlements"
           puts "  Count:  #{ents.size}"
+          product_id = plan.respond_to?(:stripe_product_id) ? plan.stripe_product_id : nil
+          puts "  Stripe Product: #{product_id.to_s.empty? ? '(none)' : product_id}"
           if verbose && plan.respond_to?(:tier)
             puts "  Tier:   #{plan.tier}"
           end

--- a/apps/web/billing/cli/helpers.rb
+++ b/apps/web/billing/cli/helpers.rb
@@ -108,6 +108,7 @@ module Onetime
       end
 
       def format_product_row(product)
+        plan_id               = product.metadata[Billing::Metadata::FIELD_PLAN_ID] || 'N/A'
         tier                  = product.metadata[Billing::Metadata::FIELD_TIER] || 'N/A'
         tenancy               = product.metadata[Billing::Metadata::FIELD_TENANCY] || 'N/A'
         region                = product.metadata[Billing::Metadata::FIELD_REGION] || 'N/A'
@@ -117,9 +118,10 @@ module Onetime
         active                = product.active ? 'yes' : 'no'
 
         format(
-          '%-30s %-30s %-12s %-12s %-10s %-8s %-10s %s',
+          '%-30s %-30s %-25s %-12s %-12s %-10s %-8s %-10s %s',
           product.id,
           product.name[0..29],
+          plan_id[0..24],
           tier[0..11],
           tenancy[0..11],
           region[0..9],

--- a/apps/web/billing/cli/products_command.rb
+++ b/apps/web/billing/cli/products_command.rb
@@ -48,9 +48,10 @@ module Onetime
         end
 
         puts format(
-          '%-30s %-30s %-12s %-12s %-10s %-8s %-10s %s',
+          '%-30s %-30s %-25s %-12s %-12s %-10s %-8s %-10s %s',
           'ID',
           'NAME',
+          'PLAN_ID',
           'TIER',
           'TENANCY',
           'REGION',
@@ -58,7 +59,7 @@ module Onetime
           'SHOW',
           'ACTIVE',
         )
-        puts '-' * 125
+        puts '-' * 150
 
         products.data.each do |product|
           puts format_product_row(product)

--- a/etc/examples/billing.example.yaml
+++ b/etc/examples/billing.example.yaml
@@ -34,7 +34,6 @@
 # ```
 
 schema_version: "1.0"
-app_identifier: "exampleapplication"  # Used in Stripe metadata['app'] matching
 
 # It doesn't make sense to have an enabled flag for turning the billing functionality
 # on. If the billing.yaml config file exists, we assume it is enabled. Ah, but what if
@@ -43,6 +42,7 @@ enabled: <%= ENV['BILLING_ENABLED'] != 'false' %>
 stripe_key: <%= ENV['STRIPE_API_KEY'] || 'nostripekey' %>
 webhook_signing_secret: <%= ENV['STRIPE_WEBHOOK_SIGNING_SECRET'] || 'nosigningsecret' %>
 stripe_api_version: "2025-12-15.clover"
+currency: <%= ENV['BILLING_CURRENCY'] || 'cad' %>
 
 # Product Matching Configuration
 #
@@ -58,8 +58,8 @@ stripe_api_version: "2025-12-15.clover"
 #
 # match_fields: Reserved for future composite-key matching. Not read at runtime;
 #   regional isolation is driven solely by the region field above.
+app_identifier: "exampleapplication"  # Used in Stripe metadata['app'] matching
 region: <%= ENV['JURISDICTION'] || nil %>
-currency: <%= ENV['BILLING_CURRENCY'] || 'cad' %>
 match_fields:
   - plan_id
   - region
@@ -189,49 +189,9 @@ plans:
     # Then do a bin/ots billing catalog pull --clear.
     prices: []
 
-  # Legacy Plan - Grandfathered customers only
-  # No longer offered but remains active for existing subscriptions.
-  # Set show_on_plans_page: false to hide from the public plans UI.
-  legacy_plan_v1:
-    name: "Legacy Plan (Legacy)"
-    tier: single_team
-    tenancy: multi
-    region: <%= ENV['JURISDICTION'] || nil %>
-    display_order: null
-    show_on_plans_page: false
-    legacy: true
-    # stripe_product_id: prod_XXXXXXXXXXXX  # Bind directly when auto-matching fails
-    grandfathered_until: "2028-01-31"  # Auto-downgraded after this date
-    description: "Original plan, grandfathered for existing customers"
-
-    entitlements:
-      - create_secrets
-      - view_receipt
-      - custom_domains
-      - custom_branding
-      - custom_privacy_defaults
-      - homepage_secrets
-      - incoming_secrets
-      - custom_mail_sender
-      - api_access
-
-    features:
-      - web.billing.features.custom_branding
-      - web.billing.features.homepage_secrets
-      - web.billing.features.api_access
-
-    limits:
-      organizations: 1
-      members_per_team: 5
-      custom_domains: -1       # unlimited
-      secret_lifetime: 2592000 # 30 days in seconds
-      secrets_per_day: -1      # unlimited
-
-    prices: []  # Preserved in Stripe; no new subscriptions
-
   # Example Paid Tier - Individual account
   identity_plus_v1:
-    name: "Identity Plus"
+    name: "Identity Plus (<%= ENV['JURISDICTION'] || nil %>)"
     tier: single_account
     plan_name_label: web.billing.plans.individual_account
     tenancy: multi
@@ -267,21 +227,24 @@ plans:
       secret_lifetime: 1209600 # 14 days in seconds
       secrets_per_day: -1      # unlimited
 
+    # Changes to prices requires a full catalog push && catalog pull. If a price is
+    # updated/deleted/archived through the Stripe dashboard, the pull command must
+    # include the --clear flag to properly updated the cache.
     prices:
-      - interval: month
-        amount: 900   # $9.00
-      - interval: year
-        amount: 9000  # $90.00
         # Complimentary price for pro-bono accounts (see #2657)
         # Used by: bin/ots migrations migrate-probono-accounts --price-id <id>
       - interval: month
         amount: 0
         metadata:
           complimentary: "true"
+      - interval: month
+        amount: 900   # $9.00
+      - interval: year
+        amount: 9000  # $90.00
 
   # # Team Plan - Uncomment to enable team subscriptions
   # team_plus_v1:
-  #   name: "Team Plus"
+  #   name: "Team Plus (<%= ENV['JURISDICTION'] || nil %>)"
   #   tier: single_team
   #   plan_name_label: web.billing.plans.team_account
   #   tenancy: multi

--- a/lib/onetime/domain_validation/features.rb
+++ b/lib/onetime/domain_validation/features.rb
@@ -95,9 +95,9 @@ module Onetime
           target     = approx_config['vhost_target']
           has_key    = !approx_config['api_key'].to_s.empty?
 
-          OT.info "[DomainValidation::Features] Loading config: strategy=#{strategy} " \
-                  "vhost_target=#{target.inspect} api_key_present=#{has_key} " \
-                  "proxy_host=#{approx_config['proxy_host'].inspect}"
+          OT.ld "[DomainValidation::Features] Loading config: strategy=#{strategy} " \
+                "vhost_target=#{target.inspect} api_key_present=#{has_key} " \
+                "proxy_host=#{approx_config['proxy_host'].inspect}"
 
           configure(
             strategy_name: strategy,

--- a/lib/onetime/initializers/setup_loggers.rb
+++ b/lib/onetime/initializers/setup_loggers.rb
@@ -138,7 +138,11 @@ module Onetime
       #   BACKTRACE_LINES - Max backtrace lines to include (default: 3 in prod, unlimited in dev)
       #
       def build_formatter(config)
-        base_formatter = config['formatter']&.to_sym || :color
+        base_formatter = if OT.mode?(:cli)
+                           :color  # Human-readable for CLI
+                         else
+                           config['formatter']&.to_sym || :color
+                         end
         max_lines      = backtrace_limit
 
         # In development/test, use standard formatter with full backtraces
@@ -248,7 +252,9 @@ module Onetime
         overrides = cached_loggers.filter_map do |name, logger|
           "#{name}=#{logger.level}" if logger.level != default
         end
-        warn " default=#{default}, overrides: #{overrides.any? ? overrides.join(', ') : '(none)'}"
+        if Onetime.debug?
+          warn " default=#{default}, overrides2: #{overrides.any? ? overrides.join(', ') : '(none)'}"
+        end
       end
     end
   end

--- a/lib/onetime/initializers/setup_loggers.rb
+++ b/lib/onetime/initializers/setup_loggers.rb
@@ -253,7 +253,7 @@ module Onetime
           "#{name}=#{logger.level}" if logger.level != default
         end
         if Onetime.debug?
-          warn " default=#{default}, overrides2: #{overrides.any? ? overrides.join(', ') : '(none)'}"
+          warn " default=#{default}, overrides: #{overrides.any? ? overrides.join(', ') : '(none)'}"
         end
       end
     end

--- a/locales/content/en/workspace-billing.json
+++ b/locales/content/en/workspace-billing.json
@@ -319,6 +319,10 @@
     "text": "Handoff Workflows",
     "content_hash": "07202af3"
   },
+  "web.billing.features.manage_sso": {
+    "text": "SSO",
+    "content_hash": null
+  },
   "web.billing.plans.title": {
     "text": "Select a Plan",
     "content_hash": "79506c82"

--- a/try/unit/cli/billing_diagnose_try.rb
+++ b/try/unit/cli/billing_diagnose_try.rb
@@ -49,8 +49,8 @@ end
 @help_out.include?('ots billing diagnose')
 #=> true
 
-## --help shows EMAIL argument as required
-@help_out.include?('REQUIRED Customer email address')
+## --help shows EMAIL argument with conditional requirement note
+@help_out.include?('Customer email address (required unless --org is provided)')
 #=> true
 
 ## --help shows --entitlement option


### PR DESCRIPTION
Closes #3058 

Follow-up to #3057 SSO settings alignment. Small operability and copy improvements on top of the SSO work already merged to `main`.

## Changes

- **CLI `diagnose`** (`apps/web/billing/cli/diagnose_command.rb`): accept `extid` for org lookup; surface the Stripe Product ID alongside the plan in output.
- **CLI `products`** (`apps/web/billing/cli/products_command.rb`): include plan ID in listings so operators can map plans to products at a glance.
- **CLI logging**: switch to the color formatter when running CLI commands; drop boot-time chatter from `OT.info` to `OT.ld` in `setup_loggers.rb`.
- **SSO locales** (`locales/content/en/workspace-billing.json`): add the SSO entries that were missing from workspace-billing copy.
- **Example config** (`etc/examples/billing.example.yaml`): tidy section ordering and trim legacy boilerplate for readability.
- **Bootstrap features validation** (`lib/onetime/domain_validation/features.rb`): minor tweak to the validation message/path.

No schema changes, no API contract changes. CLI output format changes are additive (extra fields), but anything parsing the diagnose output by column should be re-checked.

## Test plan

- [x] `bin/billing diagnose <extid>` — returns the org and shows Stripe Product ID
- [x] `bin/billing products` — output includes plan ID column
- [x] App boots without the previously-noisy info lines
- [x] Workspace billing UI shows translated SSO strings