### PR TITLE
Add NormalizeContentType middleware for malformed Content-Type headers

### DIFF
--- a/lib/onetime/application/middleware_stack.rb
+++ b/lib/onetime/application/middleware_stack.rb
@@ -12,6 +12,7 @@ require_relative '../session'
 require_relative '../middleware/ip_ban'
 require_relative '../middleware/health_access_control'
 require_relative '../middleware/csrf_response_header'
+require_relative '../middleware/normalize_content_type'
 require 'otto'
 
 module Onetime
@@ -158,6 +159,11 @@ module Onetime
           require 'middleware/request_id'
           builder.use Rack::RequestId, generator: -> { Familia.generate_trace_id }
 
+          # Recover a parseable Content-Type for clients that send malformed
+          # or duplicate Content-Type headers (e.g. legacy PHP clients that
+          # set text/html before application/x-www-form-urlencoded). See
+          # Onetime::Middleware::NormalizeContentType for the rationale.
+          builder.use Onetime::Middleware::NormalizeContentType
           builder.use Rack::Parser, parsers: @parsers
           # Add session middleware early in the stack (before other middleware)
           session_config = Onetime.session_config

--- a/lib/onetime/middleware/normalize_content_type.rb
+++ b/lib/onetime/middleware/normalize_content_type.rb
@@ -82,18 +82,17 @@ module Onetime
       end
 
       def read_sample(body)
-        body.rewind
+        body.rewind if body.respond_to?(:rewind)
         body.read(SNIFF_BYTES)
       ensure
         body.rewind if body.respond_to?(:rewind)
       end
 
       def sniff(sample)
-        stripped = sample.byteslice(0, SNIFF_BYTES).to_s.lstrip
+        stripped = sample.lstrip
         return nil if stripped.empty?
 
-        first = stripped[0]
-        return JSON_TYPE if first == '{' || first == '['
+        return JSON_TYPE if stripped.start_with?('{', '[')
         return FORM_TYPE if stripped.match?(FORM_PREFIX_RE)
 
         nil
@@ -104,7 +103,7 @@ module Onetime
 
         # Compare against the bare media type, ignoring parameters
         # like charset=utf-8.
-        media_type = value.split(';', 2).first.to_s.strip.downcase
+        media_type = value.split(';', 2).first&.strip&.downcase
         PARSEABLE_TYPES.include?(media_type)
       end
     end

--- a/lib/onetime/middleware/normalize_content_type.rb
+++ b/lib/onetime/middleware/normalize_content_type.rb
@@ -1,0 +1,112 @@
+# lib/onetime/middleware/normalize_content_type.rb
+#
+# frozen_string_literal: true
+
+module Onetime
+  module Middleware
+    # NormalizeContentType
+    #
+    # Recovers a parseable Content-Type for request body parsing when the
+    # client sends a malformed or duplicate Content-Type header.
+    #
+    # Some HTTP clients (notably the OneTimeSecret PHP client at
+    # onetime-api.php) send two Content-Type headers in sequence:
+    #
+    #     Content-Type: text/html; charset=utf-8
+    #     Content-type: application/x-www-form-urlencoded
+    #
+    # HTTP servers handle duplicate Content-Type values inconsistently:
+    # some keep the first, some keep the last, some join with `,`. When
+    # an unparseable value (text/html) reaches Rack::Parser, the body is
+    # not parsed and downstream params are empty — which surfaces in the
+    # V1 API as a misleading 404 "You did not provide anything to share".
+    #
+    # This middleware runs before Rack::Parser and:
+    #
+    #   1. If CONTENT_TYPE is a comma-joined list, picks the first member
+    #      that is parseable (application/json or
+    #      application/x-www-form-urlencoded).
+    #
+    #   2. For POST/PUT/PATCH with an unparseable CONTENT_TYPE, sniffs a
+    #      small prefix of the body. If it unambiguously looks like JSON
+    #      or form-urlencoded data, rewrites CONTENT_TYPE to match. The
+    #      body is rewound after sniffing so downstream consumers see it
+    #      unchanged.
+    #
+    # Multipart and other recognized body types are left alone.
+    class NormalizeContentType
+      JSON_TYPE = 'application/json'
+      FORM_TYPE = 'application/x-www-form-urlencoded'
+      PARSEABLE_TYPES = [JSON_TYPE, FORM_TYPE].freeze
+      BODY_METHODS = %w[POST PUT PATCH].freeze
+      SNIFF_BYTES = 256
+
+      # Conservative form-data signature: a token, then `=`. Matches the
+      # `key=value&key2=value2` shape without false-positiving on prose
+      # or HTML/XML.
+      FORM_PREFIX_RE = /\A[A-Za-z_][\w.\-\[\]%+]*=/
+
+      def initialize(app)
+        @app = app
+      end
+
+      def call(env)
+        normalize_joined_content_type(env)
+        sniff_body_content_type(env) if BODY_METHODS.include?(env['REQUEST_METHOD'])
+
+        @app.call(env)
+      end
+
+      private
+
+      def normalize_joined_content_type(env)
+        raw = env['CONTENT_TYPE']
+        return unless raw.is_a?(String) && raw.include?(',')
+
+        parts = raw.split(',').map(&:strip).reject(&:empty?)
+        preferred = parts.find { |part| parseable_type?(part) }
+        env['CONTENT_TYPE'] = preferred if preferred
+      end
+
+      def sniff_body_content_type(env)
+        return if parseable_type?(env['CONTENT_TYPE'])
+
+        body = env['rack.input']
+        return unless body.respond_to?(:read) && body.respond_to?(:rewind)
+
+        sample = read_sample(body)
+        return if sample.nil? || sample.empty?
+
+        sniffed = sniff(sample)
+        env['CONTENT_TYPE'] = sniffed if sniffed
+      end
+
+      def read_sample(body)
+        body.rewind
+        body.read(SNIFF_BYTES)
+      ensure
+        body.rewind if body.respond_to?(:rewind)
+      end
+
+      def sniff(sample)
+        stripped = sample.byteslice(0, SNIFF_BYTES).to_s.lstrip
+        return nil if stripped.empty?
+
+        first = stripped[0]
+        return JSON_TYPE if first == '{' || first == '['
+        return FORM_TYPE if stripped.match?(FORM_PREFIX_RE)
+
+        nil
+      end
+
+      def parseable_type?(value)
+        return false unless value.is_a?(String)
+
+        # Compare against the bare media type, ignoring parameters
+        # like charset=utf-8.
+        media_type = value.split(';', 2).first.to_s.strip.downcase
+        PARSEABLE_TYPES.include?(media_type)
+      end
+    end
+  end
+end

--- a/spec/unit/onetime/middleware/normalize_content_type_spec.rb
+++ b/spec/unit/onetime/middleware/normalize_content_type_spec.rb
@@ -1,0 +1,191 @@
+# spec/unit/onetime/middleware/normalize_content_type_spec.rb
+#
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'stringio'
+require 'onetime/middleware/normalize_content_type'
+
+RSpec.describe Onetime::Middleware::NormalizeContentType do
+  let(:downstream) do
+    lambda { |env|
+      [200, { 'content-type' => 'text/plain' }, [env['CONTENT_TYPE'].to_s]]
+    }
+  end
+
+  let(:middleware) { described_class.new(downstream) }
+
+  def env_for(method:, content_type:, body: '')
+    {
+      'REQUEST_METHOD' => method,
+      'CONTENT_TYPE' => content_type,
+      'rack.input' => StringIO.new(body),
+    }
+  end
+
+  describe 'comma-joined Content-Type values' do
+    it 'prefers application/x-www-form-urlencoded when both are joined' do
+      env = env_for(
+        method: 'POST',
+        content_type: 'text/html; charset=utf-8, application/x-www-form-urlencoded',
+        body: 'secret=hi&ttl=60',
+      )
+
+      middleware.call(env)
+
+      expect(env['CONTENT_TYPE']).to eq('application/x-www-form-urlencoded')
+    end
+
+    it 'prefers application/json when joined with an unparseable type' do
+      env = env_for(
+        method: 'POST',
+        content_type: 'text/html, application/json; charset=utf-8',
+        body: '{"secret":"hi"}',
+      )
+
+      middleware.call(env)
+
+      expect(env['CONTENT_TYPE']).to eq('application/json; charset=utf-8')
+    end
+
+    it 'leaves the value alone when no joined part is parseable' do
+      env = env_for(
+        method: 'POST',
+        content_type: 'text/html; charset=utf-8, text/plain',
+        body: 'plain text body',
+      )
+
+      middleware.call(env)
+
+      # Body did not look like JSON or form data, so no override.
+      expect(env['CONTENT_TYPE']).to eq('text/html; charset=utf-8, text/plain')
+    end
+  end
+
+  describe 'body sniffing for unparseable Content-Type' do
+    it 'rewrites text/html to form-urlencoded when body looks form-encoded' do
+      env = env_for(
+        method: 'POST',
+        content_type: 'text/html; charset=utf-8',
+        body: 'secret=hello-world&ttl=3600',
+      )
+
+      middleware.call(env)
+
+      expect(env['CONTENT_TYPE']).to eq('application/x-www-form-urlencoded')
+    end
+
+    it 'rewrites text/html to JSON when body looks like a JSON object' do
+      env = env_for(
+        method: 'POST',
+        content_type: 'text/html; charset=utf-8',
+        body: '  {"secret":"hi"}',
+      )
+
+      middleware.call(env)
+
+      expect(env['CONTENT_TYPE']).to eq('application/json')
+    end
+
+    it 'rewrites text/html to JSON when body looks like a JSON array' do
+      env = env_for(
+        method: 'POST',
+        content_type: 'text/html',
+        body: '[1, 2, 3]',
+      )
+
+      middleware.call(env)
+
+      expect(env['CONTENT_TYPE']).to eq('application/json')
+    end
+
+    it 'leaves CONTENT_TYPE alone when the body does not look parseable' do
+      env = env_for(
+        method: 'POST',
+        content_type: 'text/html; charset=utf-8',
+        body: '<html><body>not parseable</body></html>',
+      )
+
+      middleware.call(env)
+
+      expect(env['CONTENT_TYPE']).to eq('text/html; charset=utf-8')
+    end
+
+    it 'rewinds the body so downstream can read it' do
+      body_io = StringIO.new('secret=hi')
+      env = {
+        'REQUEST_METHOD' => 'POST',
+        'CONTENT_TYPE' => 'text/html',
+        'rack.input' => body_io,
+      }
+
+      middleware.call(env)
+
+      expect(body_io.read).to eq('secret=hi')
+    end
+
+    it 'does not modify CONTENT_TYPE for GET requests even with form-shaped body' do
+      env = env_for(
+        method: 'GET',
+        content_type: 'text/html',
+        body: 'foo=bar',
+      )
+
+      middleware.call(env)
+
+      expect(env['CONTENT_TYPE']).to eq('text/html')
+    end
+
+    it 'does not touch already-parseable Content-Type' do
+      env = env_for(
+        method: 'POST',
+        content_type: 'application/json; charset=utf-8',
+        body: 'not really json but we trust the header',
+      )
+
+      middleware.call(env)
+
+      expect(env['CONTENT_TYPE']).to eq('application/json; charset=utf-8')
+    end
+
+    it 'leaves multipart/form-data alone' do
+      env = env_for(
+        method: 'POST',
+        content_type: 'multipart/form-data; boundary=----abc',
+        body: '------abc\r\nContent-Disposition: form-data; name="x"\r\n\r\nhi\r\n------abc--',
+      )
+
+      middleware.call(env)
+
+      expect(env['CONTENT_TYPE']).to eq('multipart/form-data; boundary=----abc')
+    end
+
+    it 'tolerates a missing Content-Type header' do
+      env = {
+        'REQUEST_METHOD' => 'POST',
+        'rack.input' => StringIO.new('secret=hi'),
+      }
+
+      expect { middleware.call(env) }.not_to raise_error
+      expect(env['CONTENT_TYPE']).to eq('application/x-www-form-urlencoded')
+    end
+
+    it 'tolerates an empty body' do
+      env = env_for(
+        method: 'POST',
+        content_type: 'text/html',
+        body: '',
+      )
+
+      expect { middleware.call(env) }.not_to raise_error
+      expect(env['CONTENT_TYPE']).to eq('text/html')
+    end
+  end
+
+  describe 'integration with Rack::Parser parser registry' do
+    it 'matches the parseable types Rack::Parser is configured for' do
+      parsers = Onetime::Application::MiddlewareStack.instance_variable_get(:@parsers)
+      expect(parsers.keys).to include('application/json', 'application/x-www-form-urlencoded')
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds a new `NormalizeContentType` middleware that recovers a parseable Content-Type header for request body parsing when clients send malformed or duplicate Content-Type headers.

This addresses [#3067](https://github.com/onetimesecret/onetimesecret/issues/3067), where some HTTP clients (notably the legacy OneTimeSecret PHP client) send multiple Content-Type headers in sequence (`text/html; charset=utf-8` first, `application/x-www-form-urlencoded` second). After integrating Rack::Parser in afc519b26, requests in this shape stop parsing the body, causing V1 POSTs (`/api/v1/share`, `/generate`, `/create`) to return 404 `"You did not provide anything to share"`.

The middleware:
1. Detects comma-joined Content-Type values (some servers join duplicates with `,`) and selects the first parseable type (`application/json` or `application/x-www-form-urlencoded`).
2. For POST/PUT/PATCH requests with an unparseable Content-Type, sniffs up to 256 bytes of the request body. If it unambiguously looks like JSON (`{` / `[`) or form-urlencoded (`token=…`), rewrites `CONTENT_TYPE` accordingly.
3. Leaves multipart and other recognized types untouched; never sniffs GET/DELETE/HEAD bodies.
4. Rewinds the body after sniffing so downstream consumers see it unchanged.

## Related Issues

Fixes #3067

## Test Plan

Added unit tests in `spec/unit/onetime/middleware/normalize_content_type_spec.rb` covering:
- Comma-joined Content-Type with preference for the parseable member
- Body sniffing for JSON objects, JSON arrays, and form-urlencoded data
- Already-parseable and multipart Content-Types left untouched
- Edge cases: missing header, empty body, GET requests
- Body rewind after sniffing

https://claude.ai/code/session_01HLjF66F7rkKAW3VS9kSxUA