### PR TITLE
Add domain verification requirement toggle for custom domains

### DIFF
--- a/apps/api/v1/logic/secrets/base_secret_action.rb
+++ b/apps/api/v1/logic/secrets/base_secret_action.rb
@@ -437,7 +437,7 @@ module V1::Logic
       # @raise [FormError] If require_verified is on and the domain is not
       #   yet verified
       def validate_domain_verification(domain_record)
-        return unless OT.conf.dig('features', 'domains', 'require_verified')
+        return unless OT.conf.dig('features', 'domains', 'require_verified').to_s == 'true'
         return if domain_record.verified.to_s == 'true'
 
         OT.li "[validate_domain_verif]: #{share_domain} unverified [#{cust&.custid}]"

--- a/apps/api/v1/logic/secrets/base_secret_action.rb
+++ b/apps/api/v1/logic/secrets/base_secret_action.rb
@@ -422,9 +422,26 @@ module V1::Logic
             custom_domain?:  #{custom_domain?}
             allow_public?:   #{domain_record.allow_public_homepage?}
             owner?:          #{domain_record.owner?(@cust)}
+            verified?:       #{domain_record.verified}
         DEBUG
 
         validate_domain_permissions(domain_record)
+        validate_domain_verification(domain_record)
+      end
+
+      # Rejects secret creation against an unverified custom share_domain when
+      # the features.domains.require_verified toggle is on. Canonical domains
+      # are filtered out earlier in process_share_domain via default_domain?.
+      #
+      # @param domain_record [CustomDomain] The domain record to check
+      # @raise [FormError] If require_verified is on and the domain is not
+      #   yet verified
+      def validate_domain_verification(domain_record)
+        return unless OT.conf.dig('features', 'domains', 'require_verified')
+        return if domain_record.verified.to_s == 'true'
+
+        OT.li "[validate_domain_verif]: #{share_domain} unverified [#{cust&.custid}]"
+        raise_form_error "Custom domain is not verified: #{share_domain}"
       end
 
       # Validates domain permissions based on context and configuration.

--- a/apps/api/v2/logic/secrets/base_secret_action.rb
+++ b/apps/api/v2/logic/secrets/base_secret_action.rb
@@ -373,6 +373,29 @@ module V2::Logic
           }
 
         validate_domain_permissions(domain_record)
+        validate_domain_verification(domain_record)
+      end
+
+      # Rejects secret creation against an unverified custom share_domain when
+      # the features.domains.require_verified toggle is on. Canonical domains
+      # are filtered out earlier in process_share_domain via default_domain?.
+      #
+      # @param domain_record [CustomDomain] The domain record to check
+      # @raise [FormError] If require_verified is on and the domain is not
+      #   yet verified
+      def validate_domain_verification(domain_record)
+        return unless OT.conf.dig('features', 'domains', 'require_verified')
+        return if domain_record.verified.to_s == 'true'
+
+        secret_logger.warn 'Unverified custom share_domain rejected',
+          {
+            domain: share_domain,
+            user_id: @cust&.objid,
+            action: 'validate_domain_verification',
+            result: :unverified,
+          }
+        raise_form_error "Custom domain is not verified: #{share_domain}",
+          field: 'share_domain', error_type: 'domain_unverified'
       end
 
       # Validates domain permissions based on context and configuration.

--- a/apps/api/v2/logic/secrets/base_secret_action.rb
+++ b/apps/api/v2/logic/secrets/base_secret_action.rb
@@ -384,7 +384,7 @@ module V2::Logic
       # @raise [FormError] If require_verified is on and the domain is not
       #   yet verified
       def validate_domain_verification(domain_record)
-        return unless OT.conf.dig('features', 'domains', 'require_verified')
+        return unless OT.conf.dig('features', 'domains', 'require_verified').to_s == 'true'
         return if domain_record.verified.to_s == 'true'
 
         secret_logger.warn 'Unverified custom share_domain rejected',

--- a/etc/config.schema.yaml
+++ b/etc/config.schema.yaml
@@ -82,6 +82,7 @@ features:
     jurisdictions: list(include('jurisdiction'), required=False)
   domains:
     enabled: any()
+    require_verified: any(str(), bool(), required=False)
     default: str(required=False)
     validation_strategy: str(required=False)
     strict_strategy: bool(required=False)

--- a/etc/defaults/config.defaults.yaml
+++ b/etc/defaults/config.defaults.yaml
@@ -371,6 +371,10 @@ features:
       - <%= ENV['INCOMING_RECIPIENT_4']&.split(',') %>
   domains:
     enabled: <%= ENV['DOMAINS_ENABLED'] == 'true' || false %>
+    # When true, secret creation rejects an unverified custom share_domain
+    # with a form error. When false (default), creation is allowed regardless
+    # of the domain's verification status. Canonical domains are unaffected.
+    require_verified: <%= ENV['DOMAINS_REQUIRE_VERIFIED'] == 'true' || false %>
     # The default domain used for link URLs. When not set or empty,
     # site.host is used.
     default: <%= ENV['DEFAULT_DOMAIN'] || nil %>

--- a/lib/onetime/config.rb
+++ b/lib/onetime/config.rb
@@ -82,7 +82,14 @@ module Onetime
         },
         'features' => {
           'regions' => { 'enabled' => false },
-          'domains' => { 'enabled' => false },
+          'domains' => {
+            'enabled' => false,
+            # When true, secret creation against an unverified custom
+            # share_domain raises a form error. When false (default),
+            # creation is allowed regardless of the domain's verification
+            # status. Canonical domains are unaffected.
+            'require_verified' => false,
+          },
           'incoming' => {
             'enabled' => false,
             'memo_max_length' => 50,

--- a/lib/onetime/mail/views/feedback_email.rb
+++ b/lib/onetime/mail/views/feedback_email.rb
@@ -21,6 +21,10 @@ module Onetime
       #   user_id:          Submitter identifier shown in the email body (extid for
       #                     authenticated users, 'anon:<prefix>' for anonymous).
       #                     Defaults to 'anonymous' when not supplied.
+      #   tz:               Submitter timezone string. Defaults to '' when not
+      #                     supplied.
+      #   version:          App version string shown in the email body. Defaults
+      #                     to '' when not supplied.
       #   baseuri:          Override site base URI
       #
       class FeedbackEmail < Base
@@ -76,6 +80,14 @@ module Onetime
           data[:user_id] || 'anonymous'
         end
 
+        def tz
+          data[:tz] || ''
+        end
+
+        def version
+          data[:version] || ''
+        end
+
         def baseuri
           data[:baseuri] || site_baseuri
         end
@@ -89,6 +101,8 @@ module Onetime
             display_domain: display_domain,
             domain_strategy: domain_strategy,
             user_id: user_id,
+            tz: tz,
+            version: version,
             baseuri: baseuri,
           )
           TemplateContext.new(computed_data, locale).get_binding

--- a/lib/onetime/mail/views/feedback_email.rb
+++ b/lib/onetime/mail/views/feedback_email.rb
@@ -18,6 +18,9 @@ module Onetime
       #
       # Optional data:
       #   domain_strategy:  How the domain was determined (e.g., 'custom', 'default')
+      #   user_id:          Submitter identifier shown in the email body (extid for
+      #                     authenticated users, 'anon:<prefix>' for anonymous).
+      #                     Defaults to 'anonymous' when not supplied.
       #   baseuri:          Override site base URI
       #
       class FeedbackEmail < Base
@@ -66,6 +69,13 @@ module Onetime
           data[:domain_strategy] || 'default'
         end
 
+        # Submitter identifier shown in the email body. Falls back to 'anonymous'
+        # so the template never sees a nil/missing local (the .erb references
+        # this unconditionally).
+        def user_id
+          data[:user_id] || 'anonymous'
+        end
+
         def baseuri
           data[:baseuri] || site_baseuri
         end
@@ -78,6 +88,7 @@ module Onetime
             message: message,
             display_domain: display_domain,
             domain_strategy: domain_strategy,
+            user_id: user_id,
             baseuri: baseuri,
           )
           TemplateContext.new(computed_data, locale).get_binding

--- a/spec/integration/all/config/after_load_spec.rb
+++ b/spec/integration/all/config/after_load_spec.rb
@@ -316,7 +316,9 @@ RSpec.describe "Onetime boot configuration process", type: :integration do
       processed_config = Onetime::Config.after_load(config)
 
       # Domains config moved from site.domains to features.domains
-      expect(processed_config['features']['domains']).to eq({ 'enabled' => false })
+      expect(processed_config['features']['domains']).to eq(
+        { 'enabled' => false, 'require_verified' => false }
+      )
     end
 
     it 'does not add billing configuration when not present' do

--- a/src/schemas/contracts/config/config.ts
+++ b/src/schemas/contracts/config/config.ts
@@ -299,8 +299,9 @@ export const apiFeaturesSchema = z.object({
   domains: z
     .object({
       enabled: booleanOrString,
+      require_verified: booleanOrString.optional(),
       default: z.string().nullable().optional(),
-      strategy: z.string().nullable().optional(),
+      validation_strategy: z.string().nullable().optional(),
     })
     .nullable()
     .optional(),

--- a/src/schemas/contracts/config/public.ts
+++ b/src/schemas/contracts/config/public.ts
@@ -163,26 +163,50 @@ const regionsSchema = z.object({
 });
 
 /**
- * Schema for the :cluster section within :domains (proxy configuration)
+ * Schema for the :approximated section within :domains
+ *
+ * Approximated proxy configuration (used by the 'approximated' validation
+ * strategy). All fields default to nil in the Ruby YAML when env vars are
+ * unset, so every key is optional/nullable here.
  */
-const clusterSchema = z
+const approximatedSchema = z
   .object({
-    type: z.string().optional(),
-    //  api_key: z.string().optional(),
-    proxy_ip: z.string().optional(),
-    proxy_host: z.string().optional(),
-    proxy_name: z.string(),
-    vhost_target: z.string(),
+    api_key: z.string().nullable().optional(),
+    proxy_ip: z.string().nullable().optional(),
+    proxy_host: z.string().nullable().optional(),
+    proxy_name: z.string().nullable().optional(),
+    vhost_target: z.string().nullable().optional(),
+  })
+  .strip();
+
+/**
+ * Schema for the :acme section within :domains
+ *
+ * Internal ACME endpoint configuration (used by the 'caddy_on_demand'
+ * validation strategy).
+ */
+const acmeSchema = z
+  .object({
+    enabled: z.boolean(),
+    listen_address: z.string().optional(),
+    port: z.union([z.string(), z.number()]).optional(),
   })
   .strip();
 
 /**
  * Schema for the :domains section
+ *
+ * Mirrors `features.domains` in etc/defaults/config.defaults.yaml. The
+ * bootstrap payload is the raw Ruby hash (see ConfigSerializer), so any
+ * rename here must be applied on the Ruby side as well.
  */
 const domainsSchema = z.object({
   enabled: z.boolean(),
-  default: z.string().optional(),
-  cluster: clusterSchema,
+  require_verified: z.boolean().optional(),
+  default: z.string().nullable().optional(),
+  validation_strategy: z.string().optional(),
+  approximated: approximatedSchema.optional(),
+  acme: acmeSchema.optional(),
 });
 
 /**

--- a/src/schemas/contracts/config/section/features.ts
+++ b/src/schemas/contracts/config/section/features.ts
@@ -74,12 +74,19 @@ const featuresDomainsAcmeSchema = z.object({
 
 /**
  * Domains feature configuration
+ *
+ * Field names mirror `features.domains` in etc/defaults/config.defaults.yaml.
+ * The bootstrap payload is the raw Ruby hash (see ConfigSerializer), so any
+ * rename here must be applied on the Ruby side as well.
  */
 const featuresDomainsSchema = z.object({
   enabled: z.boolean().default(false),
+  require_verified: z.boolean().default(false),
   default: nullableString,
-  strategy: z.enum(['passthrough', 'approximated', 'caddy_on_demand']).default('passthrough'),
-  cluster: featuresDomainsProxySchema.optional(),
+  validation_strategy: z
+    .enum(['passthrough', 'approximated', 'caddy_on_demand'])
+    .default('passthrough'),
+  approximated: featuresDomainsProxySchema.optional(),
   acme: featuresDomainsAcmeSchema.optional(),
 });
 

--- a/try/unit/api/v2/secrets/validate_domain_verification_try.rb
+++ b/try/unit/api/v2/secrets/validate_domain_verification_try.rb
@@ -1,0 +1,146 @@
+# try/unit/api/v2/secrets/validate_domain_verification_try.rb
+#
+# frozen_string_literal: true
+
+# Tests for V2::Logic::Secrets::BaseSecretAction#validate_domain_verification.
+#
+# Behavior gated by features.domains.require_verified:
+# - When the toggle is off (default), unverified custom share_domains are
+#   accepted (preserves pre-fix behavior).
+# - When the toggle is on, secret creation against an unverified custom
+#   share_domain raises Onetime::FormError. This applies to owners too —
+#   the verification check is about domain state, not authorization.
+# - Verified domains are always allowed regardless of the toggle.
+# - Canonical domains are filtered out earlier in process_share_domain
+#   (default_domain?), so the verification check never runs for them.
+
+require_relative '../../../../support/test_helpers'
+
+OT.boot! :test, false
+
+require 'v2/logic'
+
+@timestamp = Familia.now.to_i
+
+@owner_email = generate_unique_test_email("verif_owner")
+@owner = Onetime::Customer.create!(email: @owner_email)
+@org   = Onetime::Organization.create!("DomainVerif Org #{@timestamp}", @owner, "orgverif_#{@timestamp}@test.com")
+@domain = Onetime::CustomDomain.create!("verif-#{@timestamp}.example.com", @org.objid)
+
+# Build a logic instance the same way validate_domain_permissions_try does.
+def create_test_logic(customer, share_domain_value: nil, domain_strategy: nil, display_domain: nil)
+  sess = MockSession.new
+  metadata = {}
+  metadata[:domain_strategy] = domain_strategy if domain_strategy
+  metadata[:display_domain]  = display_domain  if display_domain
+  auth_method = customer.nil? ? 'anonymous' : 'basic'
+  strategy_result = MockStrategyResult.new(session: sess, user: customer, auth_method: auth_method, metadata: metadata)
+  params = {
+    'secret' => {
+      'secret' => 'test secret',
+      'ttl' => '3600',
+      'share_domain' => share_domain_value
+    }
+  }
+  V2::Logic::Secrets::ConcealSecret.new(strategy_result, params, 'en')
+end
+
+# Mutate the require_verified flag in-process. Config is frozen outside of
+# test mode; OT.boot! :test, false leaves it mutable for tryouts.
+def set_require_verified(value)
+  OT.conf['features'] ||= {}
+  OT.conf['features']['domains'] ||= {}
+  OT.conf['features']['domains']['require_verified'] = value
+end
+
+@original_require_verified = OT.conf.dig('features', 'domains', 'require_verified')
+
+## Toggle off + unverified domain: owner is allowed (default behavior unchanged)
+set_require_verified(false)
+@domain.verified = 'false'
+@domain.save
+logic = create_test_logic(@owner, share_domain_value: @domain.display_domain)
+begin
+  logic.send(:validate_domain_access, @domain.display_domain)
+  :success
+rescue Onetime::FormError => e
+  e.message
+end
+#=> :success
+
+## Toggle on + unverified domain: owner is rejected
+set_require_verified(true)
+@domain.verified = 'false'
+@domain.save
+logic = create_test_logic(@owner, share_domain_value: @domain.display_domain)
+begin
+  logic.send(:validate_domain_access, @domain.display_domain)
+  :success
+rescue Onetime::FormError => e
+  e.message
+end
+#=~> /Custom domain is not verified:/
+
+## Toggle on + unverified domain: error message includes the domain name
+set_require_verified(true)
+@domain.verified = 'false'
+@domain.save
+logic = create_test_logic(@owner, share_domain_value: @domain.display_domain)
+begin
+  logic.send(:validate_domain_access, @domain.display_domain)
+  :success
+rescue Onetime::FormError => e
+  e.message.include?('verif-')
+end
+#=> true
+
+## Toggle on + verified domain: owner is allowed
+set_require_verified(true)
+@domain.verified = 'true'
+@domain.save
+logic = create_test_logic(@owner, share_domain_value: @domain.display_domain)
+begin
+  logic.send(:validate_domain_access, @domain.display_domain)
+  :success
+rescue Onetime::FormError => e
+  e.message
+end
+#=> :success
+
+## Toggle on + verified domain on custom-domain context: allowed
+set_require_verified(true)
+@domain.verified = 'true'
+@domain.save
+logic = create_test_logic(@owner,
+  share_domain_value: @domain.display_domain,
+  domain_strategy: :custom,
+  display_domain: @domain.display_domain)
+begin
+  logic.send(:validate_domain_access, @domain.display_domain)
+  :success
+rescue Onetime::FormError => e
+  e.message
+end
+#=> :success
+
+## Toggle on + unverified domain on custom-domain context: rejected
+set_require_verified(true)
+@domain.verified = 'false'
+@domain.save
+logic = create_test_logic(@owner,
+  share_domain_value: @domain.display_domain,
+  domain_strategy: :custom,
+  display_domain: @domain.display_domain)
+begin
+  logic.send(:validate_domain_access, @domain.display_domain)
+  :success
+rescue Onetime::FormError => e
+  e.message
+end
+#=~> /Custom domain is not verified:/
+
+# Teardown
+set_require_verified(@original_require_verified)
+@domain.destroy!
+@org.destroy!
+@owner.destroy!


### PR DESCRIPTION
## Summary

Adds a new `features.domains.require_verified` configuration toggle that enforces domain verification checks during secret creation. When enabled, attempting to create a secret with an unverified custom domain raises a form error. This provides operators with control over whether unverified domains are allowed while maintaining backward compatibility (disabled by default).

## Changes

### Core Logic
- Added `validate_domain_verification()` method to both V1 and V2 `BaseSecretAction` classes that checks the toggle and domain verification status
- Integrated verification validation into the `validate_domain_access()` flow for both API versions
- Canonical/default domains are unaffected (filtered earlier in the process)

### Configuration
- Added `require_verified` boolean field to `features.domains` configuration across all schema files:
  - `lib/onetime/config.rb` (Ruby defaults)
  - `etc/defaults/config.defaults.yaml` (YAML template)
  - `src/schemas/contracts/config/` (TypeScript schemas)
  - `etc/config.schema.yaml` (YAML schema validation)
- Added environment variable support: `DOMAINS_REQUIRE_VERIFIED`
- Defaults to `false` to preserve existing behavior

### Schema Improvements
- Renamed `cluster` → `approximated` and `strategy` → `validation_strategy` in domain configuration schemas for clarity
- Updated TypeScript schemas to properly handle nullable/optional fields
- Added comprehensive documentation comments explaining the configuration purpose

## Test Plan

Added comprehensive tryout tests in `try/unit/api/v2/secrets/validate_domain_verification_try.rb` covering:
- Toggle off + unverified domain: owner allowed (backward compatibility)
- Toggle on + unverified domain: owner rejected with appropriate error message
- Toggle on + verified domain: owner allowed
- Custom domain context scenarios with both verified and unverified domains

The tests verify both the feature flag behavior and error messaging.

https://claude.ai/code/session_018FNLx6HLbPENyCjV6zfLx3