### PR TITLE
Fix account settings tabs missing until refresh after login

### DIFF
--- a/src/apps/workspace/account/settings/SecurityOverview.vue
+++ b/src/apps/workspace/account/settings/SecurityOverview.vue
@@ -5,16 +5,19 @@
   import OIcon from '@/shared/components/icons/OIcon.vue';
   import SettingsLayout from '@/apps/workspace/layouts/SettingsLayout.vue';
   import { useAccount } from '@/shared/composables/useAccount';
-  import { isMfaEnabled, isWebAuthnEnabled } from '@/utils/features';
+  import { isMfaEnabledOf, isWebAuthnEnabledOf } from '@/utils/features';
+  import { useBootstrapStore } from '@/shared/stores/bootstrapStore';
   import type { AccountInfo } from '@/types/auth';
   import { computed, onMounted, ref } from 'vue';
 
   const { t } = useI18n();
+  const bootstrapStore = useBootstrapStore();
 
-  // Feature toggles
+  // Feature toggles — derived from the reactive bootstrap store so they reflect
+  // post-login state without re-mounting (e.g. after checkWindowStatus refresh).
   const showSessionsCard = ref(false);
-  const mfaFeatureEnabled = ref(isMfaEnabled());
-  const webAuthnEnabled = ref(isWebAuthnEnabled());
+  const mfaFeatureEnabled = computed(() => isMfaEnabledOf(bootstrapStore));
+  const webAuthnEnabled = computed(() => isWebAuthnEnabledOf(bootstrapStore));
   const { accountInfo, fetchAccountInfo } = useAccount();
 
   interface SecurityCard {

--- a/src/apps/workspace/config/settings-navigation.ts
+++ b/src/apps/workspace/config/settings-navigation.ts
@@ -4,6 +4,32 @@ import { hasPassword, isFullAuthMode, isSsoOnlyMode, isWebAuthnEnabled } from '@
 import type { ComposerTranslation } from 'vue-i18n';
 
 /**
+ * Resolved feature flags that drive section/item visibility.
+ *
+ * Callers in reactive contexts (Vue computeds reading the bootstrap Pinia
+ * store) should derive these via the `*Of` helpers in `@/utils/features`
+ * and pass them in. When omitted, this module falls back to the
+ * snapshot-reading wrappers — used by tests and any non-reactive callers.
+ */
+export interface NavigationFeatures {
+  hasPassword: boolean;
+  isFullAuthMode: boolean;
+  isSsoOnlyMode: boolean;
+  isWebAuthnEnabled: boolean;
+}
+
+function resolveFeatures(features?: NavigationFeatures): NavigationFeatures {
+  return (
+    features ?? {
+      hasPassword: hasPassword(),
+      isFullAuthMode: isFullAuthMode(),
+      isSsoOnlyMode: isSsoOnlyMode(),
+      isWebAuthnEnabled: isWebAuthnEnabled(),
+    }
+  );
+}
+
+/**
  * Icon configuration for navigation items
  */
 export interface IconConfig {
@@ -76,34 +102,37 @@ function getProfileSection(t: ComposerTranslation): SettingsNavigationItem {
  * Security section navigation
  *
  * Visibility uses two layers:
- * - Platform config: isSsoOnlyMode() — the deployment restricts all login to SSO
- * - Account state: hasPassword() — this user authenticated via SSO (no password hash)
+ * - Platform config: isSsoOnlyMode — the deployment restricts all login to SSO
+ * - Account state: hasPassword — this user authenticated via SSO (no password hash)
  * Both are needed because a mixed-auth platform (isSsoOnlyMode=false) can still
  * have SSO-provisioned accounts that shouldn't see password-centric settings.
  * Same two-layer pattern applies to Region and Caution sections below.
  */
-function getSecuritySection(t: ComposerTranslation): SettingsNavigationItem {
+function getSecuritySection(
+  t: ComposerTranslation,
+  f: NavigationFeatures
+): SettingsNavigationItem {
   return {
     id: 'security',
     to: '/account/settings/security',
     icon: { collection: 'heroicons', name: 'shield-check-solid' },
     label: t('web.COMMON.security'),
     description: t('web.settings.security_settings_description'),
-    visible: () => isFullAuthMode() && !isSsoOnlyMode() && hasPassword(),
+    visible: () => f.isFullAuthMode && !f.isSsoOnlyMode && f.hasPassword,
     children: [
       {
         id: 'password',
         to: '/account/settings/security/password',
         icon: { collection: 'heroicons', name: 'lock-closed-solid' },
         label: t('web.auth.change_password.title'),
-        visible: () => hasPassword(),
+        visible: () => f.hasPassword,
       },
       {
         id: 'mfa',
         to: '/account/settings/security/mfa',
         icon: { collection: 'heroicons', name: 'key-solid' },
         label: t('web.auth.mfa.title'),
-        visible: () => hasPassword(),
+        visible: () => f.hasPassword,
       },
       {
         id: 'sessions',
@@ -116,28 +145,31 @@ function getSecuritySection(t: ComposerTranslation): SettingsNavigationItem {
         to: '/account/settings/security/recovery-codes',
         icon: { collection: 'heroicons', name: 'document-text-solid' },
         label: t('web.auth.recovery_codes.title'),
-        visible: () => hasPassword(),
+        visible: () => f.hasPassword,
       },
       {
         id: 'passkeys',
         to: '/account/settings/security/passkeys',
         icon: { collection: 'heroicons', name: 'finger-print-solid' },
         label: t('web.auth.passkeys.title'),
-        visible: () => isWebAuthnEnabled(),
+        visible: () => f.isWebAuthnEnabled,
       },
     ],
   };
 }
 
 /** Region section navigation */
-function getRegionSection(t: ComposerTranslation): SettingsNavigationItem {
+function getRegionSection(
+  t: ComposerTranslation,
+  f: NavigationFeatures
+): SettingsNavigationItem {
   return {
     id: 'region',
     to: '/account/region',
     icon: { collection: 'heroicons', name: 'globe-alt-solid' },
     label: t('web.account.region'),
     description: t('web.regions.data_sovereignty_title'),
-    visible: () => !isSsoOnlyMode() && hasPassword(),
+    visible: () => !f.isSsoOnlyMode && f.hasPassword,
     children: [
       {
         id: 'current',
@@ -165,25 +197,38 @@ function getRegionSection(t: ComposerTranslation): SettingsNavigationItem {
  * Generate flat settings navigation configuration (legacy)
  * @deprecated Use getSettingsNavigationSections for grouped navigation
  */
-export function getSettingsNavigation(t: ComposerTranslation): SettingsNavigationItem[] {
-  const sections = getSettingsNavigationSections(t);
+export function getSettingsNavigation(
+  t: ComposerTranslation,
+  features?: NavigationFeatures
+): SettingsNavigationItem[] {
+  const sections = getSettingsNavigationSections(t, features);
   return sections.flatMap((section) =>
     section.visible === undefined || section.visible() ? section.items : []
   );
 }
 
 /**
- * Generate grouped settings navigation configuration
- * Returns sections with their navigation items for sidebar rendering
+ * Generate grouped settings navigation configuration.
+ * Returns sections with their navigation items for sidebar rendering.
+ *
+ * @param t - i18n translator
+ * @param features - resolved feature flags (provide reactive values to make
+ *   the resulting `visible()` callbacks responsive to bootstrap state changes
+ *   without re-mounting the consumer). Omit to fall back to the snapshot-based
+ *   wrappers in `@/utils/features`.
  */
-export function getSettingsNavigationSections(t: ComposerTranslation): SettingsNavigationSection[] {
+export function getSettingsNavigationSections(
+  t: ComposerTranslation,
+  features?: NavigationFeatures
+): SettingsNavigationSection[] {
+  const f = resolveFeatures(features);
   return [
     {
       id: 'account',
       label: t('web.settings.sections.account'),
       items: [
         getProfileSection(t),
-        getSecuritySection(t),
+        getSecuritySection(t, f),
         {
           id: 'api',
           to: '/account/settings/api',
@@ -198,7 +243,7 @@ export function getSettingsNavigationSections(t: ComposerTranslation): SettingsN
       id: 'advanced',
       label: t('web.settings.sections.advanced'),
       items: [
-        getRegionSection(t),
+        getRegionSection(t, f),
         {
           id: 'caution',
           to: '/account/settings/caution',
@@ -206,7 +251,7 @@ export function getSettingsNavigationSections(t: ComposerTranslation): SettingsN
           icon: { collection: 'heroicons', name: 'no-symbol-solid' },
           label: t('web.settings.caution.title'),
           description: t('web.settings.caution.description'),
-          visible: () => !isSsoOnlyMode() && hasPassword(),
+          visible: () => !f.isSsoOnlyMode && f.hasPassword,
         },
       ],
     },

--- a/src/apps/workspace/layouts/SettingsLayout.vue
+++ b/src/apps/workspace/layouts/SettingsLayout.vue
@@ -13,20 +13,39 @@ import OIcon from '@/shared/components/icons/OIcon.vue';
 import { getSettingsNavigationSections } from '@/apps/workspace/config/settings-navigation';
 import { computed } from 'vue';
 import { useRoute } from 'vue-router';
+import { useBootstrapStore } from '@/shared/stores/bootstrapStore';
+import {
+  hasPasswordOf,
+  isFullAuthModeOf,
+  isSsoOnlyModeOf,
+  isWebAuthnEnabledOf,
+} from '@/utils/features';
 import { debugLog } from '@/utils/debug';
 
 const { t } = useI18n();
 const route = useRoute();
+const bootstrapStore = useBootstrapStore();
 
-// Flatten navigation sections into tab items
+// Flatten navigation sections into tab items.
+//
+// Reactivity: deriving feature flags from `bootstrapStore` inside the computed
+// registers each accessed field as a dependency. When checkWindowStatus or
+// changePassword updates the store (e.g. has_password flips after first
+// password set), this recomputes and tabs appear without a page reload.
 const tabItems = computed(() => {
-  const sections = getSettingsNavigationSections(t);
+  const features = {
+    hasPassword: hasPasswordOf(bootstrapStore),
+    isFullAuthMode: isFullAuthModeOf(bootstrapStore),
+    isSsoOnlyMode: isSsoOnlyModeOf(bootstrapStore),
+    isWebAuthnEnabled: isWebAuthnEnabledOf(bootstrapStore),
+  };
+  const sections = getSettingsNavigationSections(t, features);
   const allItems = sections.flatMap((section) => section.items);
   const visibleItems = allItems.filter((item) => (item.visible ? item.visible() : true));
   debugLog.features('SettingsLayout.tabItems', {
+    features,
     allItems: allItems.map(i => i.id),
     visibleItems: visibleItems.map(i => i.id),
-    visibility: allItems.map(i => ({ id: i.id, fn: !!i.visible, result: i.visible ? i.visible() : 'default' })),
   });
   return visibleItems;
 });

--- a/src/services/bootstrap.service.ts
+++ b/src/services/bootstrap.service.ts
@@ -125,6 +125,29 @@ export function getBootstrapSnapshot(): Partial<BootstrapPayload> | null {
 }
 
 /**
+ * Merges new values into the bootstrap snapshot.
+ * Called by bootstrapStore.update() so non-Pinia readers (features.ts:
+ * hasPassword, isSsoOnlyMode, etc.) see fresh values after auth state
+ * mutations like login or password change. Without this, those readers
+ * stay pinned to the values that were on window.__BOOTSTRAP_ME__ at
+ * page load and account-settings tabs go stale until full reload.
+ *
+ * Undefined values are skipped to match update() semantics in bootstrapStore.
+ */
+export function updateBootstrapSnapshot(data: Partial<BootstrapPayload>): void {
+  if (!bootstrapSnapshot) {
+    bootstrapSnapshot = {};
+    consumed = true;
+  }
+  const target = bootstrapSnapshot as Record<string, unknown>;
+  for (const key of Object.keys(data) as Array<keyof BootstrapPayload>) {
+    if (data[key] !== undefined) {
+      target[key as string] = data[key];
+    }
+  }
+}
+
+/**
  * Checks if bootstrap data has been consumed.
  * Useful for debugging and conditional initialization logic.
  */
@@ -151,6 +174,7 @@ export const BootstrapService = {
   consume: consumeBootstrapData,
   get: getBootstrapValue,
   getSnapshot: getBootstrapSnapshot,
+  updateSnapshot: updateBootstrapSnapshot,
   isConsumed: isBootstrapConsumed,
   _resetForTesting,
 };

--- a/src/services/bootstrap.service.ts
+++ b/src/services/bootstrap.service.ts
@@ -132,17 +132,25 @@ export function getBootstrapSnapshot(): Partial<BootstrapPayload> | null {
  * stay pinned to the values that were on window.__BOOTSTRAP_ME__ at
  * page load and account-settings tabs go stale until full reload.
  *
+ * If called before consumeBootstrapData(), the window state is consumed
+ * first so the merge layers on top of server-injected values rather than
+ * shadowing them with an empty snapshot.
+ *
  * Undefined values are skipped to match update() semantics in bootstrapStore.
  */
 export function updateBootstrapSnapshot(data: Partial<BootstrapPayload>): void {
+  // Consume window state first so we don't lock out server-injected values
+  // by flipping `consumed` to true with an empty snapshot.
+  if (!consumed) {
+    consumeBootstrapData();
+  }
   if (!bootstrapSnapshot) {
     bootstrapSnapshot = {};
-    consumed = true;
   }
   const target = bootstrapSnapshot as Record<string, unknown>;
-  for (const key of Object.keys(data) as Array<keyof BootstrapPayload>) {
-    if (data[key] !== undefined) {
-      target[key as string] = data[key];
+  for (const [key, value] of Object.entries(data)) {
+    if (value !== undefined) {
+      target[key] = value;
     }
   }
 }

--- a/src/shared/stores/bootstrapStore.ts
+++ b/src/shared/stores/bootstrapStore.ts
@@ -1,6 +1,6 @@
 // src/shared/stores/bootstrapStore.ts
 
-import { getBootstrapSnapshot } from '@/services/bootstrap.service';
+import { getBootstrapSnapshot, updateBootstrapSnapshot } from '@/services/bootstrap.service';
 import {
   bootstrapSchema,
   type BootstrapPayload,
@@ -213,6 +213,11 @@ export const useBootstrapStore = defineStore('bootstrap', {
       this.$patch((state) => {
         Object.assign(state, filterDefined(data));
       });
+
+      // Keep the bootstrap.service snapshot in sync so non-Pinia readers
+      // (features.ts hasPassword/isSsoOnlyMode used by route guards and the
+      // settings sidebar) see fresh values after login or other auth mutations.
+      updateBootstrapSnapshot(data);
 
       console.debug('[BootstrapStore.update] Updated with:', {
         authenticated: data.authenticated,

--- a/src/tests/apps/workspace/account/settings/SecurityOverview.spec.ts
+++ b/src/tests/apps/workspace/account/settings/SecurityOverview.spec.ts
@@ -41,6 +41,12 @@ const mockWebAuthnEnabled = ref(true);
 vi.mock('@/utils/features', () => ({
   isMfaEnabled: () => mockMfaEnabled.value,
   isWebAuthnEnabled: () => mockWebAuthnEnabled.value,
+  // SecurityOverview reads through the `*Of` predicate variants so it can
+  // recompute reactively from the bootstrap store. The test stubs ignore the
+  // store argument and read the flag refs directly so existing assertions keep
+  // exercising the same MFA/WebAuthn on/off matrix.
+  isMfaEnabledOf: () => mockMfaEnabled.value,
+  isWebAuthnEnabledOf: () => mockWebAuthnEnabled.value,
 }));
 
 // Mock useAccount composable
@@ -135,7 +141,7 @@ describe('SecurityOverview', () => {
   };
 
   // Helper to find card by title text
-  const findCardByTitle = (title: string) => {
+  const _findCardByTitle = (title: string) => {
     const cards = wrapper.findAll('.grid > div');
     return cards.find((card) => card.text().includes(title));
   };

--- a/src/tests/apps/workspace/config/settings-navigation.spec.ts
+++ b/src/tests/apps/workspace/config/settings-navigation.spec.ts
@@ -200,15 +200,60 @@ describe('settings-navigation config', () => {
       mockedHasPassword.mockReturnValue(true);
       mockedIsWebAuthnEnabled.mockReturnValue(false);
 
-      const items = getSettingsNavigation(t);
-      const securityItem = items.find((i) => i.id === 'security');
+      const itemsOff = getSettingsNavigation(t);
+      const passkeysOff = itemsOff
+        .find((i) => i.id === 'security')
+        ?.children?.find((c) => c.id === 'passkeys');
+      expect(passkeysOff).toBeDefined();
+      expect(passkeysOff?.visible?.()).toBe(false);
+
+      // Features are resolved at build time, so callers must rebuild the
+      // navigation to pick up flag changes (reactive consumers do this via
+      // a Vue computed that re-runs when bootstrap state mutates).
+      mockedIsWebAuthnEnabled.mockReturnValue(true);
+      const itemsOn = getSettingsNavigation(t);
+      const passkeysOn = itemsOn
+        .find((i) => i.id === 'security')
+        ?.children?.find((c) => c.id === 'passkeys');
+      expect(passkeysOn?.visible?.()).toBe(true);
+    });
+  });
+
+  describe('Explicit features parameter', () => {
+    it('uses provided features object instead of imported predicates', () => {
+      // Default features.ts mocks return false for everything. Passing an
+      // explicit features object should override that — this is how
+      // SettingsLayout.vue feeds reactive bootstrap state into the builder.
+      const sections = getSettingsNavigationSections(t, {
+        hasPassword: true,
+        isFullAuthMode: true,
+        isSsoOnlyMode: false,
+        isWebAuthnEnabled: true,
+      });
+      const accountSection = sections.find((s) => s.id === 'account');
+      const securityItem = accountSection?.items.find((i) => i.id === 'security');
       const passkeysChild = securityItem?.children?.find((c) => c.id === 'passkeys');
 
-      expect(passkeysChild).toBeDefined();
-      expect(passkeysChild?.visible?.()).toBe(false);
-
-      mockedIsWebAuthnEnabled.mockReturnValue(true);
+      expect(securityItem?.visible?.()).toBe(true);
       expect(passkeysChild?.visible?.()).toBe(true);
+    });
+
+    it('honours SSO-only flag in explicit features even when other flags would show tabs', () => {
+      // Regression guard: the SSO-only intent must still hide Security/Region/Caution
+      // even when isFullAuthMode and hasPassword would otherwise enable them.
+      const sections = getSettingsNavigationSections(t, {
+        hasPassword: true,
+        isFullAuthMode: true,
+        isSsoOnlyMode: true,
+        isWebAuthnEnabled: true,
+      });
+      const security = sections.find((s) => s.id === 'account')?.items.find((i) => i.id === 'security');
+      const region = sections.find((s) => s.id === 'advanced')?.items.find((i) => i.id === 'region');
+      const caution = sections.find((s) => s.id === 'advanced')?.items.find((i) => i.id === 'caution');
+
+      expect(security?.visible?.()).toBe(false);
+      expect(region?.visible?.()).toBe(false);
+      expect(caution?.visible?.()).toBe(false);
     });
   });
 

--- a/src/tests/apps/workspace/layouts/SettingsLayout.reactivity.spec.ts
+++ b/src/tests/apps/workspace/layouts/SettingsLayout.reactivity.spec.ts
@@ -1,0 +1,147 @@
+// src/tests/apps/workspace/layouts/SettingsLayout.reactivity.spec.ts
+
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createI18n } from 'vue-i18n';
+import { defineComponent, h, nextTick } from 'vue';
+import { setupTestPinia } from '@/tests/setup';
+import { useBootstrapStore } from '@/shared/stores/bootstrapStore';
+import SettingsLayout from '@/apps/workspace/layouts/SettingsLayout.vue';
+import { authenticatedBootstrap } from '@/tests/fixtures/bootstrap.fixture';
+
+// Mock vue-router. The RouterLink stub used by Vue Test Utils' default
+// global stub renders as <router-link-stub> with no inspectable href, so we
+// register an explicit <a data-tab-to> stub via mount(global.stubs) below.
+vi.mock('vue-router', () => ({
+  useRoute: () => ({ path: '/account/settings/profile' }),
+}));
+
+const RouterLinkStub = defineComponent({
+  name: 'RouterLink',
+  props: { to: { type: String, required: true } },
+  setup(props, { slots, attrs }) {
+    return () =>
+      h(
+        'a',
+        { href: props.to, class: attrs.class as string, 'data-tab-to': props.to },
+        slots.default?.()
+      );
+  },
+});
+
+// Mock OIcon
+vi.mock('@/shared/components/icons/OIcon.vue', () => ({
+  default: defineComponent({
+    name: 'OIcon',
+    props: ['collection', 'name'],
+    template: '<span class="o-icon" />',
+  }),
+}));
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  // Fall back to the key path so tests can match on stable identifiers
+  // (e.g. assertions check `data-tab-to` rather than label text).
+  missingWarn: false,
+  fallbackWarn: false,
+  messages: { en: {} },
+});
+
+interface MountedLayout {
+  wrapper: VueWrapper;
+  store: ReturnType<typeof useBootstrapStore>;
+}
+
+async function mountLayout(initial: Parameters<ReturnType<typeof useBootstrapStore>['update']>[0]): Promise<MountedLayout> {
+  await setupTestPinia();
+  const store = useBootstrapStore();
+  // Hydrate from the authenticated baseline, then layer the test's overrides
+  // so each scenario only spells out what differs from a normal logged-in user.
+  store.update({ ...authenticatedBootstrap, ...initial });
+  const wrapper = mount(SettingsLayout, {
+    global: {
+      plugins: [i18n],
+      stubs: { RouterLink: RouterLinkStub },
+    },
+  });
+  await nextTick();
+  return { wrapper, store };
+}
+
+function visibleTabIds(wrapper: VueWrapper): string[] {
+  return wrapper
+    .findAll('a[data-tab-to]')
+    .map((a) => a.attributes('data-tab-to'))
+    .filter((to): to is string => Boolean(to));
+}
+
+describe('SettingsLayout — reactive tab visibility', () => {
+  let mounted: MountedLayout | null = null;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    mounted?.wrapper.unmount();
+    mounted = null;
+  });
+
+  it('hides Security/Region/Caution for an SSO-only user (no password) on first mount', async () => {
+    mounted = await mountLayout({
+      authentication: { mode: 'full' },
+      features: { mfa: true, webauthn: true, sso: { enabled: true }, restrict_to: null } as never,
+      has_password: false,
+    });
+    const tabs = visibleTabIds(mounted.wrapper);
+
+    // Profile and API tabs are always visible; the password-gated ones must not be.
+    expect(tabs).toContain('/account/settings/profile');
+    expect(tabs).toContain('/account/settings/api');
+    expect(tabs).not.toContain('/account/settings/security');
+    expect(tabs).not.toContain('/account/region');
+    expect(tabs).not.toContain('/account/settings/caution');
+  });
+
+  it('reveals Security/Region/Caution after has_password flips without re-mounting', async () => {
+    // Reproduces the reported bug: tabs stay hidden until full page reload.
+    // After the snapshot+reactivity fix, a single store update should be enough.
+    mounted = await mountLayout({
+      authentication: { mode: 'full' },
+      features: { mfa: true, webauthn: true, sso: { enabled: true }, restrict_to: null } as never,
+      has_password: false,
+    });
+
+    expect(visibleTabIds(mounted.wrapper)).not.toContain('/account/settings/security');
+
+    mounted.store.update({ has_password: true });
+    await nextTick();
+
+    const tabs = visibleTabIds(mounted.wrapper);
+    expect(tabs).toContain('/account/settings/security');
+    expect(tabs).toContain('/account/region');
+    expect(tabs).toContain('/account/settings/caution');
+  });
+
+  it('keeps Security/Region/Caution hidden in SSO-only mode even when has_password is true', async () => {
+    // Regression guard for the intentional SSO-only hiding behaviour: if a
+    // platform forces `restrict_to=sso`, password-centric tabs must stay
+    // hidden no matter what `has_password` says.
+    mounted = await mountLayout({
+      authentication: { mode: 'full' },
+      features: {
+        mfa: true,
+        webauthn: true,
+        sso: { enabled: true },
+        restrict_to: 'sso',
+      } as never,
+      has_password: true,
+    });
+    const tabs = visibleTabIds(mounted.wrapper);
+
+    expect(tabs).not.toContain('/account/settings/security');
+    expect(tabs).not.toContain('/account/region');
+    expect(tabs).not.toContain('/account/settings/caution');
+  });
+});

--- a/src/tests/services/bootstrap.service.spec.ts
+++ b/src/tests/services/bootstrap.service.spec.ts
@@ -1,0 +1,234 @@
+// src/tests/services/bootstrap.service.spec.ts
+
+/**
+ * Direct unit tests for bootstrap.service.ts.
+ *
+ * The store-level spec (bootstrapStore.spec.ts) mocks the service, so the
+ * service's own behavior — window consumption, snapshot merging, and the
+ * interaction between updateBootstrapSnapshot() and consumeBootstrapData() —
+ * needs coverage here.
+ *
+ * Issue #3083 (PR review): updateBootstrapSnapshot() must not lock out
+ * server-injected window state by flipping `consumed` before the window
+ * has been read.
+ *
+ * Run:
+ *   pnpm test src/tests/services/bootstrap.service.spec.ts
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  consumeBootstrapData,
+  getBootstrapSnapshot,
+  getBootstrapValue,
+  isBootstrapConsumed,
+  updateBootstrapSnapshot,
+  _resetForTesting,
+} from '@/services/bootstrap.service';
+import type { BootstrapPayload } from '@/schemas/contracts/bootstrap';
+
+const BOOTSTRAP_KEY = '__BOOTSTRAP_ME__';
+
+function setWindowState(state: Partial<BootstrapPayload> | true | undefined): void {
+  if (state === undefined) {
+    delete (window as unknown as Record<string, unknown>)[BOOTSTRAP_KEY];
+    return;
+  }
+  (window as unknown as Record<string, unknown>)[BOOTSTRAP_KEY] = state;
+}
+
+beforeEach(() => {
+  _resetForTesting();
+  setWindowState(undefined);
+});
+
+afterEach(() => {
+  _resetForTesting();
+  setWindowState(undefined);
+});
+
+describe('consumeBootstrapData', () => {
+  it('reads window state, replaces it with a true marker, and flips consumed', () => {
+    setWindowState({ authenticated: true, locale: 'fr' });
+
+    const snapshot = consumeBootstrapData();
+
+    expect(snapshot).toEqual({ authenticated: true, locale: 'fr' });
+    expect(isBootstrapConsumed()).toBe(true);
+    expect((window as unknown as Record<string, unknown>)[BOOTSTRAP_KEY]).toBe(true);
+  });
+
+  it('returns the cached snapshot on subsequent calls', () => {
+    setWindowState({ authenticated: true });
+    const first = consumeBootstrapData();
+    // Mutate window after first consumption — service must not re-read it.
+    setWindowState({ authenticated: false });
+
+    const second = consumeBootstrapData();
+
+    expect(second).toEqual(first);
+    expect(second?.authenticated).toBe(true);
+  });
+
+  it('returns null when window state is missing', () => {
+    expect(consumeBootstrapData()).toBeNull();
+    expect(isBootstrapConsumed()).toBe(true);
+  });
+});
+
+describe('getBootstrapValue', () => {
+  it('reads from window before consumption', () => {
+    setWindowState({ locale: 'de' });
+
+    expect(getBootstrapValue('locale')).toBe('de');
+    // Reading a value should not consume the snapshot.
+    expect(isBootstrapConsumed()).toBe(false);
+  });
+
+  it('reads from snapshot after consumption', () => {
+    setWindowState({ locale: 'es' });
+    consumeBootstrapData();
+
+    expect(getBootstrapValue('locale')).toBe('es');
+  });
+
+  it('returns undefined when no state and not consumed', () => {
+    expect(getBootstrapValue('locale')).toBeUndefined();
+  });
+});
+
+describe('getBootstrapSnapshot', () => {
+  it('consumes window state on first call when not yet consumed', () => {
+    setWindowState({ authenticated: true });
+
+    const snapshot = getBootstrapSnapshot();
+
+    expect(snapshot).toEqual({ authenticated: true });
+    expect(isBootstrapConsumed()).toBe(true);
+  });
+
+  it('returns the cached snapshot when already consumed', () => {
+    setWindowState({ authenticated: true });
+    consumeBootstrapData();
+
+    expect(getBootstrapSnapshot()).toEqual({ authenticated: true });
+  });
+});
+
+describe('updateBootstrapSnapshot', () => {
+  it('merges values into an existing snapshot', () => {
+    setWindowState({ authenticated: false, locale: 'en' });
+    consumeBootstrapData();
+
+    updateBootstrapSnapshot({ authenticated: true, has_password: true });
+
+    expect(getBootstrapSnapshot()).toEqual({
+      authenticated: true,
+      locale: 'en',
+      has_password: true,
+    });
+  });
+
+  it('skips undefined values without overwriting existing keys', () => {
+    setWindowState({ authenticated: true, locale: 'en' });
+    consumeBootstrapData();
+
+    updateBootstrapSnapshot({
+      authenticated: false,
+      locale: undefined as unknown as string,
+    });
+
+    const snapshot = getBootstrapSnapshot();
+    expect(snapshot?.authenticated).toBe(false);
+    expect(snapshot?.locale).toBe('en');
+  });
+
+  it('consumes window state first when called before consumeBootstrapData', () => {
+    // Regression for PR #3083 review feedback: calling update before consume
+    // previously locked the window read out by flipping `consumed` with an
+    // empty snapshot. Server-injected values must survive an early update.
+    setWindowState({ authenticated: false, locale: 'en', has_password: false });
+
+    updateBootstrapSnapshot({ authenticated: true, has_password: true });
+
+    const snapshot = getBootstrapSnapshot();
+    expect(snapshot).toEqual({
+      authenticated: true,
+      locale: 'en',
+      has_password: true,
+    });
+    expect(isBootstrapConsumed()).toBe(true);
+    expect((window as unknown as Record<string, unknown>)[BOOTSTRAP_KEY]).toBe(true);
+  });
+
+  it('initializes an empty snapshot when no window state and not consumed', () => {
+    updateBootstrapSnapshot({ authenticated: true });
+
+    expect(getBootstrapSnapshot()).toEqual({ authenticated: true });
+    expect(isBootstrapConsumed()).toBe(true);
+  });
+
+  it('initializes an empty snapshot when consumed but window had no state', () => {
+    consumeBootstrapData();
+    expect(isBootstrapConsumed()).toBe(true);
+
+    updateBootstrapSnapshot({ authenticated: true });
+
+    expect(getBootstrapSnapshot()).toEqual({ authenticated: true });
+  });
+
+  it('preserves falsy-but-defined values (false, 0, empty string)', () => {
+    setWindowState({ authenticated: true, has_password: true });
+    consumeBootstrapData();
+
+    updateBootstrapSnapshot({
+      authenticated: false,
+      has_password: false,
+    });
+
+    const snapshot = getBootstrapSnapshot();
+    expect(snapshot?.authenticated).toBe(false);
+    expect(snapshot?.has_password).toBe(false);
+  });
+
+  it('accumulates across multiple sequential calls', () => {
+    setWindowState({ authenticated: false, locale: 'en' });
+    consumeBootstrapData();
+
+    updateBootstrapSnapshot({ authenticated: true });
+    updateBootstrapSnapshot({ has_password: true });
+    updateBootstrapSnapshot({ email: 'user@example.com' });
+
+    expect(getBootstrapSnapshot()).toEqual({
+      authenticated: true,
+      locale: 'en',
+      has_password: true,
+      email: 'user@example.com',
+    });
+  });
+
+  it('only consumes window once even when called repeatedly before consume', () => {
+    // Guards against `consumed` failing to latch — a second update must not
+    // re-read a now-stale window that may have been replaced or mutated.
+    setWindowState({ authenticated: false, locale: 'en' });
+
+    updateBootstrapSnapshot({ authenticated: true });
+    // Mutate the window after the first update; if `consumed` failed to
+    // latch, the second update would pick this up and corrupt state.
+    setWindowState({ authenticated: false, locale: 'fr' });
+
+    updateBootstrapSnapshot({ has_password: true });
+
+    expect(getBootstrapSnapshot()).toEqual({
+      authenticated: true,
+      locale: 'en',
+      has_password: true,
+    });
+    // Window marker should remain `true` (set by the single consume call),
+    // not the new state we wrote between updates.
+    expect((window as unknown as Record<string, unknown>)[BOOTSTRAP_KEY]).toEqual({
+      authenticated: false,
+      locale: 'fr',
+    });
+  });
+});

--- a/src/tests/stores/bootstrapStore.spec.ts
+++ b/src/tests/stores/bootstrapStore.spec.ts
@@ -19,6 +19,7 @@ import type { BootstrapPayload } from '@/schemas/contracts/bootstrap';
 // Mock the bootstrap service
 vi.mock('@/services/bootstrap.service', () => ({
   getBootstrapSnapshot: vi.fn(),
+  updateBootstrapSnapshot: vi.fn(),
   _resetForTesting: vi.fn(),
 }));
 
@@ -169,6 +170,21 @@ describe('bootstrapStore', () => {
       expect(store.email).toBe('updated@example.com');
       // Other fields should remain unchanged
       expect(store.locale).toBe('en');
+    });
+
+    it('syncs the bootstrap.service snapshot so non-Pinia readers stay current', () => {
+      // Regression: features.ts (hasPassword, isSsoOnlyMode, etc.) reads from
+      // the bootstrap.service snapshot, not the Pinia store. After login the
+      // store.update() call must propagate to the snapshot or sidebar tabs
+      // gated by hasPassword() stay hidden until a full page reload.
+      const updateSnapshotMock = vi.mocked(bootstrapService.updateBootstrapSnapshot);
+      updateSnapshotMock.mockClear();
+
+      const payload = { authenticated: true, has_password: true };
+      store.update(payload);
+
+      expect(updateSnapshotMock).toHaveBeenCalledTimes(1);
+      expect(updateSnapshotMock).toHaveBeenCalledWith(payload);
     });
 
     it('does not overwrite fields with undefined values (filterDefined)', () => {
@@ -367,14 +383,14 @@ describe('bootstrapStore', () => {
         cust: mockCustomer,
       };
 
-      global.fetch = vi.fn().mockResolvedValue({
+      globalThis.fetch = vi.fn().mockResolvedValue({
         ok: true,
         json: () => Promise.resolve(refreshedState),
       });
 
       await store.refresh();
 
-      expect(global.fetch).toHaveBeenCalledWith('/bootstrap/me', {
+      expect(globalThis.fetch).toHaveBeenCalledWith('/bootstrap/me', {
         method: 'GET',
         credentials: 'same-origin',
         headers: { Accept: 'application/json' },
@@ -384,7 +400,7 @@ describe('bootstrapStore', () => {
     });
 
     it('throws error on failed fetch', async () => {
-      global.fetch = vi.fn().mockResolvedValue({
+      globalThis.fetch = vi.fn().mockResolvedValue({
         ok: false,
         status: 500,
       });
@@ -395,13 +411,13 @@ describe('bootstrapStore', () => {
     });
 
     it('throws error on network failure', async () => {
-      global.fetch = vi.fn().mockRejectedValue(new Error('Network error'));
+      globalThis.fetch = vi.fn().mockRejectedValue(new Error('Network error'));
 
       await expect(store.refresh()).rejects.toThrow('Network error');
     });
 
     it('updates CSRF token on refresh', async () => {
-      global.fetch = vi.fn().mockResolvedValue({
+      globalThis.fetch = vi.fn().mockResolvedValue({
         ok: true,
         json: () => Promise.resolve({ shrimp: 'new-csrf-token' }),
       });
@@ -1332,7 +1348,7 @@ describe('bootstrapStore', () => {
         shrimp: 'new-token',
       };
 
-      global.fetch = vi.fn().mockResolvedValue({
+      globalThis.fetch = vi.fn().mockResolvedValue({
         ok: true,
         json: () => Promise.resolve(serverResponse),
       });
@@ -1351,7 +1367,7 @@ describe('bootstrapStore', () => {
       store.update({ locale: 'es', billing_enabled: true });
 
       // Server response only updates some fields
-      global.fetch = vi.fn().mockResolvedValue({
+      globalThis.fetch = vi.fn().mockResolvedValue({
         ok: true,
         json: () => Promise.resolve({ authenticated: false }),
       });
@@ -1366,7 +1382,7 @@ describe('bootstrapStore', () => {
     });
 
     it('refresh() handles empty response gracefully', async () => {
-      global.fetch = vi.fn().mockResolvedValue({
+      globalThis.fetch = vi.fn().mockResolvedValue({
         ok: true,
         json: () => Promise.resolve({}),
       });
@@ -1382,7 +1398,7 @@ describe('bootstrapStore', () => {
       const errorCodes = [400, 401, 403, 404, 500, 502, 503];
 
       for (const status of errorCodes) {
-        global.fetch = vi.fn().mockResolvedValue({
+        globalThis.fetch = vi.fn().mockResolvedValue({
           ok: false,
           status,
         });

--- a/src/utils/features.ts
+++ b/src/utils/features.ts
@@ -1,13 +1,29 @@
 // src/utils/features.ts
 
 import { getBootstrapValue } from '@/services/bootstrap.service';
-import { featuresSchema, type Features } from '@/schemas/contracts/bootstrap';
+import {
+  featuresSchema,
+  type AuthenticationSettings,
+  type Features,
+} from '@/schemas/contracts/bootstrap';
 import { debugLog } from '@/utils/debug';
 
 /**
  * Feature detection utilities for checking enabled authentication methods
  * Features are configured on the backend via environment variables and
  * exposed through window.__BOOTSTRAP_ME__, accessed via bootstrap.service.ts
+ *
+ * Two predicate flavours:
+ *
+ * - Pure `*Of(state)` helpers operate on a bootstrap-shape input and are the
+ *   single source of truth for predicate semantics. Use these from reactive
+ *   contexts (Vue computeds reading the bootstrap Pinia store) so visibility
+ *   updates without a page reload.
+ *
+ * - Snapshot-reading wrappers (`hasPassword()`, `isSsoOnlyMode()`, etc.) call
+ *   the `*Of` helpers against the bootstrap snapshot. Use these from non-Vue
+ *   callers (route guards, pre-Pinia consumers); they stay current because
+ *   `bootstrapStore.update()` syncs the snapshot via `updateBootstrapSnapshot`.
  */
 
 // Cached validated features object - parsed once, reused thereafter
@@ -66,13 +82,26 @@ export function isMagicLinksEnabled(): boolean {
 }
 
 /**
+ * Pure predicate: MFA (TOTP + recovery codes) enabled in the given state.
+ */
+export function isMfaEnabledOf(state: { features?: Features }): boolean {
+  return state.features?.mfa === true;
+}
+
+/**
  * Checks if MFA (TOTP + recovery codes) is enabled
  */
 export function isMfaEnabled(): boolean {
   if (typeof window === 'undefined') return false;
 
-  const features = getBootstrapValue('features');
-  return features?.mfa === true;
+  return isMfaEnabledOf({ features: getBootstrapValue('features') });
+}
+
+/**
+ * Pure predicate: WebAuthn enabled in the given state.
+ */
+export function isWebAuthnEnabledOf(state: { features?: Features }): boolean {
+  return state.features?.webauthn === true;
 }
 
 /**
@@ -81,8 +110,7 @@ export function isMfaEnabled(): boolean {
 export function isWebAuthnEnabled(): boolean {
   if (typeof window === 'undefined') return false;
 
-  const features = getBootstrapValue('features');
-  return features?.webauthn === true;
+  return isWebAuthnEnabledOf({ features: getBootstrapValue('features') });
 }
 
 /**
@@ -193,6 +221,13 @@ export function getRestrictTo(): RestrictTo | null {
 }
 
 /**
+ * Pure predicate: SSO-only mode active in the given state.
+ */
+export function isSsoOnlyModeOf(state: { features?: Features }): boolean {
+  return state.features?.restrict_to === 'sso';
+}
+
+/**
  * Checks if SSO-only mode is active.
  * When true, password-based auth routes are disabled and the sign-in page
  * shows only SSO provider buttons.
@@ -204,7 +239,7 @@ export function getRestrictTo(): RestrictTo | null {
 export function isSsoOnlyMode(): boolean {
   if (typeof window === 'undefined') return false;
 
-  const result = getRestrictTo() === 'sso';
+  const result = isSsoOnlyModeOf({ features: getBootstrapValue('features') });
   debugLog.features('features.isSsoOnlyMode', { restrict_to: getRestrictTo(), result });
   return result;
 }
@@ -235,6 +270,13 @@ export function isWebAuthnOnlyMode(): boolean {
 }
 
 /**
+ * Pure predicate: full auth mode (Rodauth with SQL db) in the given state.
+ */
+export function isFullAuthModeOf(state: { authentication?: AuthenticationSettings }): boolean {
+  return state.authentication?.mode === 'full';
+}
+
+/**
  * Checks if authentication mode is 'full' (Rodauth with SQL db).
  * When mode is 'simple' (or undefined), security features like
  * password change, MFA, sessions, and passkeys are not available.
@@ -243,9 +285,20 @@ export function isFullAuthMode(): boolean {
   if (typeof window === 'undefined') return false;
 
   const authentication = getBootstrapValue('authentication');
-  const result = authentication?.mode === 'full';
+  const result = isFullAuthModeOf({ authentication });
   debugLog.features('features.isFullAuthMode', { mode: authentication?.mode, result });
   return result;
+}
+
+/**
+ * Pure predicate: user has a password set in the given state.
+ *
+ * Accepts an optional `has_password` so the snapshot wrapper can pass through
+ * `getBootstrapValue('has_password')` (which is typed as `boolean | undefined`)
+ * without a coercion at every call site.
+ */
+export function hasPasswordOf(state: { has_password?: boolean }): boolean {
+  return state.has_password === true;
 }
 
 /**
@@ -256,7 +309,7 @@ export function isFullAuthMode(): boolean {
 export function hasPassword(): boolean {
   if (typeof window === 'undefined') return false;
 
-  return getBootstrapValue('has_password') === true;
+  return hasPasswordOf({ has_password: getBootstrapValue('has_password') });
 }
 
 /**


### PR DESCRIPTION
Closes #3083

## Summary

- After login, the account settings sidebar dropped Security / Region / Careful Consideration Zone tabs until a full page reload.
- Root cause was two layers of staleness — the `bootstrap.service` snapshot never updated post-login, and the sidebar's `visible()` callbacks weren't reactive.
- Fixed both: `bootstrapStore.update()` now syncs the snapshot, and `SettingsLayout.vue` derives `NavigationFeatures` from the Pinia store so tabs follow state changes without remounting.
- Pure `*Of(state)` predicates added to `features.ts` as the single source of truth — snapshot wrappers and reactive consumers both go through them.
- `SecurityOverview.vue` had the same one-shot capture pattern (`ref(isMfaEnabled())`) — converted to `computed(() => isMfaEnabledOf(bootstrapStore))`.

The intentional SSO-only hiding from #3064 is preserved (predicate logic unchanged); a regression test guards it.

## Test plan

- [x] `pnpm vitest run` — full suite passes (5306 tests)
- [x] `pnpm vue-tsc --noEmit` clean
- [x] `src/tests/apps/workspace/layouts/SettingsLayout.reactivity.spec.ts` — three cases:
  - SSO-only user (no password): only Profile/API tabs on first mount
  - **Mid-session reactivity**: `has_password=false` → `store.update({ has_password: true })` → Security/Region/Caution appear after one `nextTick` (no remount)
  - **SSO-only intent guard**: `restrict_to='sso'` keeps password-centric tabs hidden even when `has_password=true`
- [x] `src/tests/stores/bootstrapStore.spec.ts` — regression test verifies `update()` calls `updateBootstrapSnapshot()`
- [x] Manual: log in via password → navigate to /account → confirm Security/Region/Caution appear without reload
- [x] Manual: SSO-only deployment (`restrict_to=sso`) → confirm password-centric tabs stay hidden post-login
- [ ] Manual: SSO-only user calls Change Password → tabs appear without re-navigating