### PR TITLE
Fix #3094: Standardize plan ID interval format to month/year

### DIFF
--- a/lib/onetime/mail/views/feedback_email.rb
+++ b/lib/onetime/mail/views/feedback_email.rb
@@ -100,6 +100,10 @@ module Onetime
           fetch_optional(:version)
         end
 
+        def baseuri
+          data[:baseuri] || site_baseuri
+        end
+
         private
 
         # Optional metadata may arrive as symbol keys (in-process callers) or

--- a/src/tests/apps/secret/support/Pricing.spec.ts
+++ b/src/tests/apps/secret/support/Pricing.spec.ts
@@ -296,7 +296,7 @@ describe('Pricing.vue', () => {
 
     it('includes product and interval for paid plans', async () => {
       const paidPlan = createMockPlan({
-        id: 'identity_plus_v1_monthly',
+        id: 'identity_plus_v1_month',
         tier: 'single_team',
         interval: 'month',
       });
@@ -306,13 +306,13 @@ describe('Pricing.vue', () => {
 
       const signupLink = wrapper.find('[data-testid="signup-link"]');
       expect(signupLink.attributes('href')).toBe(
-        '/signup?product=identity_plus_v1&interval=monthly'
+        '/signup?product=identity_plus_v1&interval=month'
       );
     });
 
     it('encodes special characters in product name', async () => {
       const planWithSpecialChars = createMockPlan({
-        id: 'plan_with+special&chars_monthly',
+        id: 'plan_with+special&chars_month',
         tier: 'single_team',
         interval: 'month',
       });
@@ -327,17 +327,17 @@ describe('Pricing.vue', () => {
 
     it('uses yearly interval string for year plans', async () => {
       const yearlyPlan = createMockPlan({
-        id: 'identity_plus_v1_yearly',
+        id: 'identity_plus_v1_year',
         tier: 'single_team',
         interval: 'year',
       });
 
       mockListPlans.mockResolvedValueOnce({ plans: [yearlyPlan] });
-      mockRouteParamsValue = { interval: 'yearly' };
+      mockRouteParamsValue = { interval: 'year' };
       await mountComponent();
 
       const signupLink = wrapper.find('[data-testid="signup-link"]');
-      expect(signupLink.attributes('href')).toContain('interval=yearly');
+      expect(signupLink.attributes('href')).toContain('interval=year');
     });
   });
 
@@ -348,9 +348,9 @@ describe('Pricing.vue', () => {
     // Note: Testing through the component's rendered signup URLs
     // since the function is internal to the component
 
-    it('removes _monthly suffix', async () => {
+    it('removes _month suffix', async () => {
       const plan = createMockPlan({
-        id: 'identity_plus_v1_monthly',
+        id: 'identity_plus_v1_month',
         tier: 'single_team',
         interval: 'month',
       });
@@ -360,23 +360,23 @@ describe('Pricing.vue', () => {
 
       const signupLink = wrapper.find('[data-testid="signup-link"]');
       expect(signupLink.attributes('href')).toContain('product=identity_plus_v1');
-      expect(signupLink.attributes('href')).not.toContain('product=identity_plus_v1_monthly');
+      expect(signupLink.attributes('href')).not.toContain('product=identity_plus_v1_month');
     });
 
-    it('removes _yearly suffix', async () => {
+    it('removes _year suffix', async () => {
       const plan = createMockPlan({
-        id: 'team_plus_v1_yearly',
+        id: 'team_plus_v1_year',
         tier: 'single_team',
         interval: 'year',
       });
 
       mockListPlans.mockResolvedValueOnce({ plans: [plan] });
-      mockRouteParamsValue = { interval: 'yearly' };
+      mockRouteParamsValue = { interval: 'year' };
       await mountComponent();
 
       const signupLink = wrapper.find('[data-testid="signup-link"]');
       expect(signupLink.attributes('href')).toContain('product=team_plus_v1');
-      expect(signupLink.attributes('href')).not.toContain('product=team_plus_v1_yearly');
+      expect(signupLink.attributes('href')).not.toContain('product=team_plus_v1_year');
     });
 
     it('handles plans without interval suffix', async () => {

--- a/src/tests/services/billing.service.spec.ts
+++ b/src/tests/services/billing.service.spec.ts
@@ -304,7 +304,7 @@ describe('BillingService', () => {
 
       const result = await BillingService.createCheckoutSession(
         'org_abc',
-        { id: 'identity_plus_v1_monthly', interval: 'month' }
+        { id: 'identity_plus_v1_month', interval: 'month' }
       );
 
       expect(mockPost).toHaveBeenCalledWith(
@@ -325,7 +325,7 @@ describe('BillingService', () => {
 
       const result = await BillingService.createCheckoutSession(
         'org_abc',
-        { id: 'identity_plus_v1_yearly', interval: 'year' }
+        { id: 'identity_plus_v1_year', interval: 'year' }
       );
 
       expect(mockPost).toHaveBeenCalledWith(

--- a/src/tests/types/billing-legacy.spec.ts
+++ b/src/tests/types/billing-legacy.spec.ts
@@ -191,18 +191,18 @@ describe('Legacy Plan Utilities', () => {
         expect(getPlanDisplayName(undefined as unknown as string)).toBe('Free');
       });
 
-      it('unknown plan falls back to Title Case conversion', () => {
-        // Should strip version/interval suffix and convert to Title Case
-        expect(getPlanDisplayName('some_plan_v1_monthly')).toBe('Some Plan');
-        expect(getPlanDisplayName('custom_enterprise_v2_yearly')).toBe('Custom Enterprise');
+      it('unknown plan returns plan ID as-is for debugging visibility', () => {
+        // Unknown plans are logged and returned as-is (no Title Case conversion)
+        expect(getPlanDisplayName('some_plan_v1_month')).toBe('some_plan_v1_month');
+        expect(getPlanDisplayName('custom_enterprise_v2_year')).toBe('custom_enterprise_v2_year');
       });
     });
 
     describe('pattern matching order', () => {
       // Verifies that more specific patterns match before general ones
       it('"identity_plus" matches before "identity"', () => {
-        expect(getPlanDisplayName('identity_plus_v1_monthly')).toBe('Identity Plus');
-        expect(getPlanDisplayName('identity_plus_v2_yearly')).toBe('Identity Plus');
+        expect(getPlanDisplayName('identity_plus_v1_month')).toBe('Identity Plus');
+        expect(getPlanDisplayName('identity_plus_v1_year')).toBe('Identity Plus');
       });
 
       it('"identity" exact match shows Early Supporter suffix', () => {
@@ -212,7 +212,7 @@ describe('Legacy Plan Utilities', () => {
 
       it('free pattern takes precedence', () => {
         expect(getPlanDisplayName('free_v1')).toBe('Free');
-        expect(getPlanDisplayName('free_v2_monthly')).toBe('Free');
+        expect(getPlanDisplayName('free_v1_month')).toBe('Free');
       });
     });
   });


### PR DESCRIPTION
## Summary

Standardizes plan ID interval suffixes to use Stripe's native format (`_month`/`_year`) instead of the derived `_monthly`/`_yearly`. This eliminates a translation layer and makes plan IDs consistent with Stripe price intervals.

- Change plan ID suffix from `_monthly`/`_yearly` to `_month`/`_year`
- Update `normalizePlanId()` to handle both old and new formats during transition
- Replace regex-based plan display name lookup with exact mapping table

## Stacked on

This PR targets `fix/3089-remove-silent-tier-fallback` (#3097).

## Test plan

- [x] TypeScript types updated with backwards-compatible normalization
- [x] Ruby plan construction uses new format
- [x] Billing service specs updated