### PR TITLE
Consolidate email validation into shared module

### DIFF
--- a/apps/api/domains/logic/incoming_config/base.rb
+++ b/apps/api/domains/logic/incoming_config/base.rb
@@ -2,7 +2,6 @@
 #
 # frozen_string_literal: true
 
-require 'onetime/models/custom_domain/incoming_config'
 require 'onetime/application/authorization_policies'
 
 module DomainsAPI

--- a/apps/api/domains/logic/incoming_config/delete_incoming_config.rb
+++ b/apps/api/domains/logic/incoming_config/delete_incoming_config.rb
@@ -2,7 +2,6 @@
 #
 # frozen_string_literal: true
 
-require 'onetime/models/custom_domain/incoming_config'
 require_relative 'base'
 require_relative 'serializers'
 

--- a/apps/api/domains/logic/incoming_config/get_incoming_config.rb
+++ b/apps/api/domains/logic/incoming_config/get_incoming_config.rb
@@ -2,7 +2,6 @@
 #
 # frozen_string_literal: true
 
-require 'onetime/models/custom_domain/incoming_config'
 require_relative 'base'
 require_relative 'serializers'
 

--- a/apps/api/domains/logic/incoming_config/put_incoming_config.rb
+++ b/apps/api/domains/logic/incoming_config/put_incoming_config.rb
@@ -55,10 +55,10 @@ module DomainsAPI
             raise_form_error("Maximum #{max} recipients allowed", field: :recipients, error_type: :invalid)
           end
 
-          # Validate recipient emails
+          # Validate recipient emails with Truemail (write path — admin config)
           @recipients.each do |r|
-            unless r[:email].match?(/\A[^@\s]+@[^@\s]+\.[^@\s]+\z/)
-              raise_form_error("Invalid email format: #{r[:email]}", field: :recipients, error_type: :invalid)
+            unless valid_email?(r[:email])
+              raise_form_error("Invalid email: #{r[:email]}", field: :recipients, error_type: :invalid)
             end
           end
 

--- a/apps/api/domains/logic/incoming_config/put_incoming_config.rb
+++ b/apps/api/domains/logic/incoming_config/put_incoming_config.rb
@@ -2,7 +2,6 @@
 #
 # frozen_string_literal: true
 
-require 'onetime/models/custom_domain/incoming_config'
 require_relative 'base'
 require_relative 'serializers'
 

--- a/apps/api/incoming/logic/create_incoming_secret.rb
+++ b/apps/api/incoming/logic/create_incoming_secret.rb
@@ -2,8 +2,8 @@
 #
 # frozen_string_literal: true
 
-require 'lib/onetime/jobs/publisher'
-require 'lib/onetime/incoming/recipient_resolver'
+require 'onetime/jobs/publisher'
+require 'onetime/incoming/recipient_resolver'
 
 require_relative 'base'
 

--- a/apps/api/incoming/logic/create_incoming_secret.rb
+++ b/apps/api/incoming/logic/create_incoming_secret.rb
@@ -87,7 +87,11 @@ module Incoming
           raise_form_error 'Invalid recipient'
         end
 
-        unless recipient_email.to_s.match?(/\A[\w+\-.]+@[a-z\d-]+(\.[a-z\d-]+)*\.[a-z]+\z/i)
+        # Corruption guard: email was validated at config time, this catches
+        # data corruption or misconfigured storage. Uses Truemail :regex mode
+        # (no DNS) since this runs on every incoming secret creation.
+        # Flow: POST /api/incoming/secret -> resolve_recipient_and_config -> here
+        unless Truemail.validate(recipient_email.to_s, with: :regex).result.valid?
           OT.le "[IncomingSecret] Lookup returned invalid email for hash: #{@recipient_hash}"
           raise_form_error 'Invalid recipient configuration'
         end

--- a/apps/api/incoming/logic/create_incoming_secret.rb
+++ b/apps/api/incoming/logic/create_incoming_secret.rb
@@ -2,9 +2,10 @@
 #
 # frozen_string_literal: true
 
+require 'lib/onetime/jobs/publisher'
+require 'lib/onetime/incoming/recipient_resolver'
+
 require_relative 'base'
-require_relative '../../../../lib/onetime/jobs/publisher'
-require_relative '../../../../lib/onetime/incoming/recipient_resolver'
 
 module Incoming
   module Logic

--- a/apps/api/organizations/logic/invitations/create_invitation.rb
+++ b/apps/api/organizations/logic/invitations/create_invitation.rb
@@ -147,11 +147,6 @@ module OrganizationAPI::Logic
         )
         membership&.admin?
       end
-
-      # Basic email validation
-      def valid_email?(email)
-        email =~ /\A[^@\s]+@[^@\s]+\.[^@\s]+\z/
-      end
     end
   end
 end

--- a/apps/api/v1/logic/base.rb
+++ b/apps/api/v1/logic/base.rb
@@ -63,24 +63,6 @@ module V1
         end
       end
 
-      # V1-specific email validation [#2621]
-      #
-      # v0.23.4 used basic format validation only. v0.24 introduced Truemail
-      # with stricter DNS MX + SMTP verification, rejecting disposable email
-      # addresses that previously succeeded. V1 preserves the old format-only
-      # check via a standalone RFC 5321 regex — no Truemail dependency, no
-      # DNS lookups, no SMTP probes.
-      V1_EMAIL_REGEX = /\A[a-zA-Z0-9.!\#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*\z/
-
-      def v1_valid_email?(email_field)
-        valid = V1_EMAIL_REGEX.match?(email_field.to_s)
-        OT.ld "[v1_valid_email?] valid=#{valid}"
-        valid
-      rescue StandardError => e
-        OT.le "V1 email validation error: #{e.message}"
-        false
-      end
-
       def success_data
         raise NotImplementedError
       end

--- a/apps/api/v1/logic/secrets/base_secret_action.rb
+++ b/apps/api/v1/logic/secrets/base_secret_action.rb
@@ -61,11 +61,6 @@ module V1::Logic
       # maxLength: 10000 documented in the OpenAPI definition.
       V1_MAX_SECRET_SIZE = 10_000
 
-      # Basic email shape check for parsing recipient input. Only used
-      # to extract email-shaped tokens from free-text input; actual
-      # validation is done by Truemail in validate_recipient.
-      EMAIL_REGEX = /\b[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}\b/
-
       attr_reader :passphrase, :secret_value, :kind, :ttl, :recipient, :recipient_safe, :greenlighted
       attr_reader :receipt, :secret, :share_domain, :custom_domain, :payload, :default_expiration
 
@@ -200,12 +195,12 @@ module V1::Logic
         @passphrase = payload['passphrase'].to_s
       end
 
+      # Sanitizes but does not validate as an email address.
       def process_recipient
         payload['recipient'] = [payload['recipient']].flatten.compact.uniq # force a list
         @recipient = payload['recipient'].collect { |email_address|
           next if email_address.to_s.empty?
           sanitized_email = sanitize_email(email_address)
-          sanitized_email.scan(EMAIL_REGEX).uniq.first
         }.compact.uniq
         @recipient_safe = recipient.collect { |r| OT::Utils.obscure_email(r) }
       end

--- a/apps/api/v2/logic/secrets/base_secret_action.rb
+++ b/apps/api/v2/logic/secrets/base_secret_action.rb
@@ -9,9 +9,6 @@ module V2::Logic
     class BaseSecretAction < V2::Logic::Base
       include Onetime::LoggerMethods
 
-      # Email validation regex - defined once to avoid recompilation on every call
-      EMAIL_REGEX = /\b[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}\b/
-
       attr_reader :passphrase,
         :secret_value,
         :kind,
@@ -138,28 +135,32 @@ module V2::Logic
         raise NotImplementedError, 'You must implement process_secret'
       end
 
+      # Our passphrase contract: presence determines intent.
+      #   - Param key missing → no passphrase protection (nil)
+      #   - Param key present → use value as-is (including empty string)
+      #
+      # We honour exactly what is included with the request without guessing.
+      # It's the, "if it fits, I sits" design model.
+      #
+      # UX concerns (e.g. preventing accidental empty-passphrase secrets) are
+      # the client's responsibility. The API layer remains value-neutral.
       def process_passphrase
-        # API Contract: Key presence determines intent.
-        #   - Key missing → no passphrase protection (nil)
-        #   - Key present → use value as-is (including empty string)
-        #
-        # The backend honors exactly what the client sends without guessing intent.
-        # "If you send this key, I use its value" - predictable and explicit.
-        #
-        # UX concerns (e.g., preventing accidental empty-passphrase secrets) are
-        # the client's responsibility. The API layer remains value-neutral.
         @passphrase = payload.key?('passphrase') ? payload['passphrase'].to_s : nil
       end
 
+      # Our recipient contract: always a list of sanitized strings.
+      #
+      # Sanitization keeps trash out but does not validate as an email address.
+      #
       def process_recipient
-        payload['recipient'] = [payload['recipient']].flatten.compact.uniq # force a list
-        @recipient           = payload['recipient'].collect do |email_address|
+        # Make sure we're dealing with a list.
+        recipient_list  = [payload['recipient']].flatten.compact.uniq
+        @recipient      = recipient_list.collect do |email_address|
           next if email_address.to_s.empty?
 
-          sanitized_email = sanitize_email(email_address)
-          sanitized_email.scan(EMAIL_REGEX).uniq.first
+          sanitize_email(email_address)
         end.compact.uniq
-        @recipient_safe      = recipient.collect { |r| OT::Utils.obscure_email(r) }
+        @recipient_safe = recipient.collect { |r| OT::Utils.obscure_email(r) }
       end
 
       # Capture the selected domain the link is meant for, as long as it's
@@ -197,12 +198,25 @@ module V2::Logic
         @share_domain = potential_domain
       end
 
+      # Check each individual recipient email address using
+      # the centralized Truemail-based validation. Depending
+      # on the configuration, this could be a regex, mx, or
+      # full smtp level check.
       def validate_recipient
         return if recipient.empty?
 
-        raise_form_error 'An account is required to send emails.', field: 'recipient', error_type: 'requires_account' if anonymous_user?
-        recipient.each do |recip|
-          raise_form_error "Undeliverable email address: #{recip}", field: 'recipient', error_type: 'invalid_email' unless valid_email?(recip)
+        if anonymous_user?
+          raise_form_error 'An account is required to send emails.',
+            field: 'recipient',
+            error_type: 'requires_account'
+        end
+
+        recipient.each do |email_address|
+          next if valid_email?(email_address)
+
+          raise_form_error "Undeliverable email address: #{email_address}",
+            field: 'recipient',
+            error_type: 'invalid_email'
         end
       end
 

--- a/apps/web/auth/config/hooks/account.rb
+++ b/apps/web/auth/config/hooks/account.rb
@@ -48,6 +48,11 @@ module Auth::Config::Hooks
         end
       end
 
+      # When this is part of a regular user signup flow, we'll have already
+      # called Truemail.validate on this address in the CreateAccount logic,
+      # but we call it here as a defensive in depth regardless. It's easier
+      # to call it twice than to try to keep track of the state through
+      # multiple codepaths.
       auth.login_valid_email? do |email|
         validator = Truemail.validate(email)
         is_valid  = super(email) && validator.result.valid?

--- a/docs/architecture/email-validation.md
+++ b/docs/architecture/email-validation.md
@@ -1,0 +1,56 @@
+# docs/architecture/email-validation.md
+---
+
+# Email Validation
+
+## Flow
+
+All email inputs follow the same path:
+
+```
+sanitize_email(input) → valid_email?(email) [Truemail.validate]
+```
+
+Sanitization strips HTML, prevents header injection (`\r\n`), lowercases. Validation calls Truemail with the configured validation type (regex, mx, or smtp).
+
+## Signup vs Recipient vs Incoming
+
+|                  | Signup                            | Recipient                 | Incoming (config)         | Incoming (create)         |
+| ---------------- | --------------------------------- | ------------------------- | ------------------------- | ------------------------- |
+| Sanitization     | `sanitize_email`                  | `sanitize_email`          | `sanitize_email`          | none (hash lookup)        |
+| Validation       | `valid_email?` (Truemail)         | `valid_email?` (Truemail) | `valid_email?` (Truemail) | Truemail `:regex` only    |
+| Domain allowlist | `allowed_signup_domain?`          | none                      | none                      | none                      |
+| Truemail calls   | 2x (CreateAccount + Rodauth hook) | 1x                        | 1x                        | 1x (corruption guard)     |
+
+The duplicate Truemail call at signup is defense in depth: the Rodauth hook validates independently of the API logic class.
+
+Incoming has two phases: config-time (admin adds recipients, full validation) and create-time (submitter provides hash, regex-only corruption guard). The create-time check uses `:regex` mode (no DNS) since it runs on every submission.
+
+## When to Use BASIC_FORMAT
+
+`EmailFormat::BASIC_FORMAT` is a fallback for contexts where Truemail cannot run:
+
+1. **Model-layer validation** -- Truemail may not be configured
+2. **Pre-boot code** -- runs before `configure_truemail.rb` executes
+
+CLI commands boot the application, so they use Truemail. The no-boot subclass (`Onetime::CLI::BaseBoot`) is an explicit opt-out for commands that need to run without full initialization.
+
+## Entry Points
+
+- `Onetime::Logic::Base#valid_email?` -- shared Truemail wrapper
+- `Onetime::Logic::Base#sanitize_email` -- input sanitization (via `InputSanitizers`)
+- `Onetime::Utils::EmailFormat::BASIC_FORMAT` -- regex for model/pre-boot contexts
+- `AccountAPI::Logic::Account::CreateAccount#allowed_signup_domain?` -- signup domain allowlist
+- `V2::Logic::Secrets::BaseSecretAction#validate_recipient` -- recipient validation
+- `DomainsAPI::Logic::IncomingConfig::PutIncomingConfig` -- incoming recipient config (full Truemail)
+- `Incoming::Logic::CreateIncomingSecret#raise_concerns` -- incoming secret creation (`:regex` corruption guard)
+
+## Configuration
+
+Truemail reads from `OT.conf['mail']['truemail']`. Common settings:
+
+- `verifier_email` -- required, used as MAIL FROM in SMTP checks
+- `default_validation_type` -- `:regex`, `:mx`, or `:smtp`
+- `validation_type_for` -- per-domain overrides (hash of domain => type)
+
+Runtime state is tracked in `Onetime::Runtime.email.truemail_configured`.

--- a/docs/architecture/email-validation.md
+++ b/docs/architecture/email-validation.md
@@ -22,18 +22,25 @@ Sanitization strips HTML, prevents header injection (`\r\n`), lowercases. Valida
 | Domain allowlist | `allowed_signup_domain?`          | none                      | none                      | none                      |
 | Truemail calls   | 2x (CreateAccount + Rodauth hook) | 1x                        | 1x                        | 1x (corruption guard)     |
 
-The duplicate Truemail call at signup is defense in depth: the Rodauth hook validates independently of the API logic class.
+The duplicate Truemail call at signup is defense in depth: the Rodauth hook validates independently since there's no guarantee of which codepath is calling it.
 
 Incoming has two phases: config-time (admin adds recipients, full validation) and create-time (submitter provides hash, regex-only corruption guard). The create-time check uses `:regex` mode (no DNS) since it runs on every submission.
 
-## When to Use BASIC_FORMAT
+### Choosing a Validation Method
 
-`EmailFormat::BASIC_FORMAT` is a fallback for contexts where Truemail cannot run:
+| Context | Method |
+| ------- | ------ |
+| Signup, invitation, share boundaries | `Logic::Base#valid_email?` (full Truemail) |
+| Corruption guards in booted contexts | `Truemail.validate(email, with: :regex).result.valid?` |
+| Model-layer or pre-boot code | `EmailFormat::BASIC_FORMAT` regex |
 
-1. **Model-layer validation** -- Truemail may not be configured
-2. **Pre-boot code** -- runs before `configure_truemail.rb` executes
+**Full Truemail** (`valid_email?`) for user-input boundaries -- validates format, MX records, optionally SMTP depending on config.
 
-CLI commands boot the application, so they use Truemail. The no-boot subclass (`Onetime::CLI::BaseBoot`) is an explicit opt-out for commands that need to run without full initialization.
+**Truemail `:regex` mode** for corruption guards -- format-only, no DNS, fast enough to run on every request. Use when the email was already validated at config time.
+
+**BASIC_FORMAT** in pre-boot code (code that runs before `configure_truemail.rb` executes).
+
+CLI commands boot the application, so they use Truemail. Unless subclassed from `Onetime::CLI::DelayBootCommand` in which case you know what you doing.
 
 ## Entry Points
 

--- a/lib/onetime/cli.rb
+++ b/lib/onetime/cli.rb
@@ -41,6 +41,12 @@ module Onetime
       def debug?
         OT.debug?
       end
+
+      def valid_email?(email)
+        return false if email.nil? || email.to_s.empty?
+
+        Truemail.validate(email.to_s).result.valid?
+      end
     end
 
     # Command class that delays boot (for commands that handle boot themselves)

--- a/lib/onetime/cli.rb
+++ b/lib/onetime/cli.rb
@@ -120,6 +120,7 @@ require_relative 'cli/email/test_command'
 require_relative 'cli/email/templates_command'
 require_relative 'cli/email/preview_command'
 require_relative 'cli/email/config_command'
+require_relative 'cli/email/validate_command'
 
 # Load diagnostics CLI commands
 require_relative 'cli/diagnostics'

--- a/lib/onetime/cli/apitoken_command.rb
+++ b/lib/onetime/cli/apitoken_command.rb
@@ -243,12 +243,6 @@ module Onetime
         SecureRandom.alphanumeric(20)
       end
 
-      def valid_email?(email)
-        return false if email.nil? || email.empty?
-
-        email.match?(/\A[^@\s]+@[^@\s]+\.[^@\s]+\z/)
-      end
-
       def base_uri
         host = OT.conf&.dig('site', 'host')
         return 'https://localhost:3000' unless host

--- a/lib/onetime/cli/customers/create_command.rb
+++ b/lib/onetime/cli/customers/create_command.rb
@@ -183,14 +183,6 @@ module Onetime
         # 20 characters = ~119 bits entropy (log2(62^20))
         SecureRandom.alphanumeric(20)
       end
-
-      # Basic email validation
-      def valid_email?(email)
-        return false if email.nil? || email.empty?
-
-        # Simple regex for email validation
-        email.match?(/\A[^@\s]+@[^@\s]+\.[^@\s]+\z/)
-      end
     end
 
     register 'customers create', CustomersCreateCommand

--- a/lib/onetime/cli/email/test_command.rb
+++ b/lib/onetime/cli/email/test_command.rb
@@ -8,9 +8,13 @@
 #   ots email test --to user@example.com
 #   ots email test --to user@example.com --dry-run
 #   ots email test --to user@example.com --format json
+#   ots email test --to user@example.com --enqueue
 #
 # Sends by default (no --execute flag needed). Use --dry-run to preview.
 # Bypasses templates — sends a plain-text diagnostic email directly.
+#
+# With --enqueue, sends via the background worker queue instead of direct
+# delivery. Tests that RabbitMQ is running and workers are processing messages.
 
 require 'json'
 require 'socket'
@@ -37,7 +41,12 @@ module Onetime
           aliases: ['f'],
           desc: 'Output format: text or json'
 
-        def call(to:, dry_run: false, format: 'text', **)
+        option :enqueue,
+          type: :boolean,
+          default: false,
+          desc: 'Enqueue via background worker instead of direct send'
+
+        def call(to:, dry_run: false, format: 'text', enqueue: false, **)
           boot_application!
 
           provider  = Onetime::Mail::Mailer.send(:determine_provider)
@@ -52,12 +61,18 @@ module Onetime
           }
 
           if format == 'json'
-            output_json(email, provider, hostname, dry_run)
+            output_json(email, provider, hostname, dry_run, enqueue: enqueue)
           else
-            output_text(email, provider, hostname, dry_run)
+            output_text(email, provider, hostname, dry_run, enqueue: enqueue)
           end
 
-          deliver!(email) unless dry_run
+          return if dry_run
+
+          if enqueue
+            enqueue!(email)
+          else
+            deliver!(email)
+          end
         rescue StandardError => ex
           warn "Error: #{ex.message}"
           exit 1
@@ -80,7 +95,47 @@ module Onetime
           exit 1
         end
 
-        def output_text(email, provider, hostname, dry_run)
+        def enqueue!(email)
+          require_relative '../../../onetime/jobs/publisher'
+
+          start      = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+          # Convert to raw email format expected by Publisher
+          raw_email  = {
+            to: email[:to],
+            from: email[:from],
+            subject: email[:subject],
+            body: email[:text_body],
+          }
+          queued     = Onetime::Jobs::Publisher.enqueue_email_raw(raw_email, fallback: :raise)
+          elapsed    = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start
+
+          puts
+          if queued
+            puts format('Status:    ENQUEUED (%.2fs)', elapsed)
+            puts 'Queue:     email.message.send'
+            puts
+            puts 'Check worker logs for delivery confirmation.'
+          else
+            # Fallback used (jobs disabled), message was sent synchronously
+            puts format('Status:    SENT SYNC (%.2fs) - jobs disabled', elapsed)
+          end
+        rescue Onetime::Mail::DeliveryError => ex
+          elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start
+          $stderr.puts
+          warn format('Status:    FAILED (%.2fs)', elapsed)
+          warn "Error:     #{ex.message}"
+          warn
+          warn 'Ensure RabbitMQ is running and bin/ots worker is active.'
+          exit 1
+        rescue StandardError => ex
+          elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start
+          $stderr.puts
+          warn format('Status:    FAILED (%.2fs)', elapsed)
+          warn "Error:     #{ex.message}"
+          exit 1
+        end
+
+        def output_text(email, provider, hostname, dry_run, enqueue: false)
           puts format('Provider:  %s', provider)
           puts format('Host:      %s', hostname)
           puts format('To:        %s', email[:to])
@@ -91,11 +146,20 @@ module Onetime
           puts email[:text_body]
           puts
           if dry_run
-            puts 'Mode: DRY RUN (omit --dry-run to send)'
+            mode = enqueue ? 'DRY RUN (would enqueue to worker)' : 'DRY RUN (omit --dry-run to send)'
+            puts "Mode: #{mode}"
+          elsif enqueue
+            puts 'Mode: ENQUEUE (via background worker)'
           end
         end
 
-        def output_json(email, provider, hostname, dry_run)
+        def output_json(email, provider, hostname, dry_run, enqueue: false)
+          mode = if dry_run
+            enqueue ? 'dry_run_enqueue' : 'dry_run'
+          else
+            enqueue ? 'enqueue' : 'live'
+          end
+
           result = {
             provider: provider,
             host: hostname,
@@ -103,7 +167,7 @@ module Onetime
             from: email[:from],
             subject: email[:subject],
             text_body: email[:text_body],
-            mode: dry_run ? 'dry_run' : 'live',
+            mode: mode,
           }
           puts JSON.pretty_generate(result)
         end

--- a/lib/onetime/cli/email/validate_command.rb
+++ b/lib/onetime/cli/email/validate_command.rb
@@ -1,0 +1,221 @@
+# lib/onetime/cli/email/validate_command.rb
+#
+# frozen_string_literal: true
+
+# CLI command for validating email addresses using Truemail.
+#
+# Usage:
+#   bin/ots email validate user@example.com          # MX validation (default)
+#   bin/ots email validate user@example.com --regex  # Format-only validation
+#   bin/ots email validate user@example.com --smtp   # Full SMTP validation
+#   bin/ots email validate user@example.com --json   # JSON output
+#
+# Useful for debugging email delivery issues and testing allowlist/denylist.
+
+require 'json'
+
+module Onetime
+  module CLI
+    module Email
+      class ValidateCommand < Command
+        desc 'Validate an email address using Truemail'
+
+        argument :email, type: :string, required: true, desc: 'Email address to validate'
+
+        option :mx,
+          type: :boolean,
+          default: false,
+          desc: 'Use MX record validation (default when no mode specified)'
+
+        option :regex,
+          type: :boolean,
+          default: false,
+          desc: 'Use format-only (regex) validation'
+
+        option :smtp,
+          type: :boolean,
+          default: false,
+          desc: 'Use full SMTP validation'
+
+        option :json,
+          type: :boolean,
+          default: false,
+          aliases: ['j'],
+          desc: 'Output as JSON'
+
+        # Validation modes in priority order
+        MODES = [:smtp, :mx, :regex].freeze
+
+        def call(email:, mx: false, regex: false, smtp: false, json: false, **)
+          boot_application!
+
+          unless Onetime::Runtime.email.configured?
+            warn 'Error: Truemail not configured.'
+            warn 'Add mail.truemail section to config with verifier_email.'
+            exit 1
+          end
+
+          mode = determine_mode(smtp, mx, regex)
+
+          begin
+            result = Truemail.validate(email, with: mode)
+          rescue StandardError => ex
+            warn "Error: Validation failed - #{ex.message}"
+            exit 1
+          end
+
+          if json
+            output_json(result, mode)
+          else
+            output_text(result, mode)
+          end
+
+          exit(result.result.valid? ? 0 : 1)
+        end
+
+        private
+
+        def determine_mode(smtp, mx, regex)
+          return :smtp if smtp
+          return :regex if regex
+          return :mx if mx
+
+          # Default to MX when no flag specified
+          :mx
+        end
+
+        def output_json(validator, mode)
+          r                   = validator.result
+          output              = {
+            email: r.email,
+            valid: r.valid?,
+            mode: mode.to_s,
+            domain: r.domain,
+            mail_servers: r.mail_servers,
+            errors: r.errors,
+            configuration: extract_list_config,
+          }
+          output[:smtp_debug] = format_smtp_debug(r.smtp_debug) if r.smtp_debug
+          puts JSON.pretty_generate(output)
+        end
+
+        def output_text(validator, mode)
+          r      = validator.result
+          status = r.valid? ? 'VALID' : 'INVALID'
+
+          puts format('Email:     %s', r.email)
+          puts format('Status:    %s', status)
+          puts format('Mode:      %s', mode)
+          puts format('Domain:    %s', r.domain) if r.domain && !r.domain.empty?
+
+          if r.mail_servers&.any?
+            puts format('MX:        %s', r.mail_servers.join(', '))
+          end
+
+          if r.errors&.any?
+            puts
+            puts 'Errors:'
+            r.errors.each do |key, message|
+              puts format('  %s: %s', key, message)
+            end
+          end
+
+          print_list_match(r)
+          print_smtp_debug(r.smtp_debug) if r.smtp_debug
+          print_config_summary
+        end
+
+        def print_list_match(result)
+          # Check if email/domain matches configured lists
+          config = Truemail.configuration
+          email  = result.email.to_s.downcase
+          domain = result.domain.to_s.downcase
+
+          matches = []
+
+          if config.whitelisted_emails&.map(&:downcase)&.include?(email)
+            matches << 'allowlist (email)'
+          end
+          if config.blacklisted_emails&.map(&:downcase)&.include?(email)
+            matches << 'denylist (email)'
+          end
+          if config.whitelisted_domains&.map(&:downcase)&.include?(domain)
+            matches << 'allowlist (domain)'
+          end
+          if config.blacklisted_domains&.map(&:downcase)&.include?(domain)
+            matches << 'denylist (domain)'
+          end
+
+          return if matches.empty?
+
+          puts
+          puts format('Lists:     %s', matches.join(', '))
+        end
+
+        def print_smtp_debug(debug)
+          return unless debug&.any?
+
+          puts
+          puts 'SMTP Debug:'
+          debug.each do |entry|
+            puts format('  %s:%s', entry.host, entry.port)
+            puts format('    connection: %s', entry.connection ? 'ok' : 'failed')
+            puts format('    response: %s', entry.response_body) if entry.response_body
+            puts format('    errors: %s', entry.errors.inspect) if entry.errors&.any?
+          end
+        end
+
+        def format_smtp_debug(debug)
+          return [] unless debug&.any?
+
+          debug.map do |entry|
+            {
+              host: entry.host,
+              port: entry.port,
+              connection: entry.connection,
+              response_body: entry.response_body,
+              errors: entry.errors,
+            }
+          end
+        end
+
+        def print_config_summary
+          config    = Truemail.configuration
+          has_lists = [
+            config.whitelisted_emails,
+            config.blacklisted_emails,
+            config.whitelisted_domains,
+            config.blacklisted_domains,
+          ].any? { |l| l&.any? }
+
+          return unless has_lists
+
+          puts
+          puts 'Configured lists:'
+          print_list('  allowlist emails', config.whitelisted_emails)
+          print_list('  denylist emails', config.blacklisted_emails)
+          print_list('  allowlist domains', config.whitelisted_domains)
+          print_list('  denylist domains', config.blacklisted_domains)
+        end
+
+        def print_list(label, items)
+          return unless items&.any?
+
+          puts format('%s: %s', label, items.join(', '))
+        end
+
+        def extract_list_config
+          config = Truemail.configuration
+          {
+            whitelisted_emails: config.whitelisted_emails || [],
+            blacklisted_emails: config.blacklisted_emails || [],
+            whitelisted_domains: config.whitelisted_domains || [],
+            blacklisted_domains: config.blacklisted_domains || [],
+          }
+        end
+      end
+    end
+
+    register 'email validate', Email::ValidateCommand
+  end
+end

--- a/lib/onetime/models/custom_domain/incoming_config.rb
+++ b/lib/onetime/models/custom_domain/incoming_config.rb
@@ -107,7 +107,7 @@ module Onetime
       # @return [Array<Hash>] Array of {hash:, name:} hashes
       # @raise [Onetime::Problem] if site.secret is not configured
       def public_recipients
-        site_secret = ensure_site_secret
+        site_secret = self.class.ensure_site_secret
 
         recipients.map do |r|
           { hash: self.class.hash_email(r[:email], site_secret), name: r[:name] }
@@ -120,7 +120,7 @@ module Onetime
       # @return [String, nil] Email address if found, nil otherwise
       # @raise [Onetime::Problem] if site.secret is not configured
       def lookup_recipient_email(hash)
-        site_secret = ensure_site_secret
+        site_secret = self.class.ensure_site_secret
 
         recipients.find do |r|
           self.class.hash_email(r[:email], site_secret) == hash

--- a/lib/onetime/models/custom_domain/incoming_config.rb
+++ b/lib/onetime/models/custom_domain/incoming_config.rb
@@ -338,15 +338,16 @@ module Onetime
 
         # Get site secret or raise if not configured.
         #
+        # Reads from config on each call (no caching) to ensure tests and
+        # runtime config changes are reflected immediately.
+        #
         # @return [String] The site secret
         # @raise [Onetime::Problem] if site.secret is not configured
         def ensure_site_secret
-          return @site_secret unless @site_secret.to_s.empty?
+          site_secret = OT.conf.dig('site', 'secret')
+          raise Onetime::Problem, 'site.secret must be configured' if site_secret.to_s.empty?
 
-          @site_secret = OT.conf.dig('site', 'secret')
-          raise Onetime::Problem, 'site.secret must be configured' if @site_secret.to_s.empty?
-
-          @site_secret
+          site_secret
         end
       end
     end

--- a/lib/onetime/models/custom_domain/incoming_config.rb
+++ b/lib/onetime/models/custom_domain/incoming_config.rb
@@ -3,7 +3,7 @@
 # frozen_string_literal: true
 
 require 'digest/sha2'
-require 'onetime/security/input_sanitizers'
+require_relative '../../security/input_sanitizers'
 
 #
 # CustomDomain::IncomingConfig - Per-domain incoming secrets recipient storage

--- a/lib/onetime/models/custom_domain/incoming_config.rb
+++ b/lib/onetime/models/custom_domain/incoming_config.rb
@@ -3,6 +3,7 @@
 # frozen_string_literal: true
 
 require 'digest/sha2'
+require 'onetime/security/input_sanitizers'
 
 #
 # CustomDomain::IncomingConfig - Per-domain incoming secrets recipient storage

--- a/lib/onetime/models/custom_domain/incoming_config.rb
+++ b/lib/onetime/models/custom_domain/incoming_config.rb
@@ -25,6 +25,7 @@ module Onetime
   class CustomDomain < Familia::Horreum
     class IncomingConfig < Familia::Horreum
       include Familia::Features::Autoloader
+      include Onetime::Security::InputSanitizers
 
       SCHEMA = 'models/domain-incoming-config'
 
@@ -90,11 +91,11 @@ module Onetime
 
       # Set the list of recipients.
       #
-      # @param recipients_array [Array<Hash>] Array of {email:, name:} hashes
+      # @param recipients_list [Array<Hash>] Array of {email:, name:} hashes
       # @return [void]
       # @raise [Onetime::Problem] if validation fails
-      def recipients=(recipients_array)
-        normalized = normalize_recipients(recipients_array)
+      def recipients=(recipients_list)
+        normalized = normalize_recipients(recipients_list)
         validate_recipients!(normalized)
 
         self.recipients_json = JSON.generate(normalized)
@@ -106,10 +107,10 @@ module Onetime
       # @return [Array<Hash>] Array of {hash:, name:} hashes
       # @raise [Onetime::Problem] if site.secret is not configured
       def public_recipients
-        site_secret = require_site_secret
+        site_secret = ensure_site_secret
 
         recipients.map do |r|
-          { hash: hash_email(r[:email], site_secret), name: r[:name] }
+          { hash: self.class.hash_email(r[:email], site_secret), name: r[:name] }
         end
       end
 
@@ -119,10 +120,10 @@ module Onetime
       # @return [String, nil] Email address if found, nil otherwise
       # @raise [Onetime::Problem] if site.secret is not configured
       def lookup_recipient_email(hash)
-        site_secret = require_site_secret
+        site_secret = ensure_site_secret
 
         recipients.find do |r|
-          hash_email(r[:email], site_secret) == hash
+          self.class.hash_email(r[:email], site_secret) == hash
         end&.dig(:email)
       end
 
@@ -136,10 +137,10 @@ module Onetime
         current = recipients
         raise Onetime::Problem, "Maximum #{MAX_RECIPIENTS} recipients allowed" if current.size >= MAX_RECIPIENTS
 
-        normalized_email = email.to_s.strip.downcase
-        raise Onetime::Problem, 'Recipient email already exists' if current.any? { |r| r[:email] == normalized_email }
+        normalized_email = sanitize_email(email)
+        raise Onetime::Problem, 'Recipient email already exists' if current.any? { it[:email] == normalized_email }
 
-        current << { email: normalized_email, name: name.to_s.strip }
+        current << { email: normalized_email, name: sanitize_plain_text(name) }
         self.recipients = current
       end
 
@@ -149,11 +150,11 @@ module Onetime
       # @return [void]
       # @raise [Onetime::Problem] if recipient not found
       def remove_recipient(email:)
-        normalized_email = email.to_s.strip.downcase
+        normalized_email = sanitize_email(email)
         current          = recipients
         initial_size     = current.size
 
-        current.reject! { |r| r[:email] == normalized_email }
+        current.reject! { it[:email] == normalized_email }
 
         raise Onetime::Problem, 'Recipient not found' if current.size == initial_size
 
@@ -202,6 +203,49 @@ module Onetime
       # @return [Boolean] true if no validation errors
       def valid?
         validation_errors.empty?
+      end
+
+      private
+
+      # Normalize recipients array.
+      #
+      # @param recipients_list [Array] Raw recipients input
+      # @return [Array<Hash>] Normalized recipients with symbolized keys
+      def normalize_recipients(recipients_list)
+        Array(recipients_list).map do |r|
+          next nil unless r.is_a?(Hash)
+
+          email = sanitize_email(r[:email] || r['email'])
+          name  = sanitize_plain_text(r[:name] || r['name'])
+
+          next nil if email.empty?
+
+          { email: email, name: name.empty? ? email.split('@').first : name }
+        end.compact
+      end
+
+      # Validate recipients array.
+      #
+      # Flow: PUT /api/domains/:id/incoming/config -> PutIncomingConfig ->
+      #       IncomingConfig#recipients= -> normalize_recipients -> here
+      #
+      # Uses format-only regex (not Truemail) to avoid DNS latency on config
+      # saves. Truemail validation happens at secret-creation time via the
+      # logic layer.
+      #
+      # @param recipients_list [Array<Hash>] Normalized recipients
+      # @raise [Onetime::Problem] if validation fails
+      def validate_recipients!(recipients_list)
+        raise Onetime::Problem, "Maximum #{MAX_RECIPIENTS} recipients allowed" if recipients_list.size > MAX_RECIPIENTS
+
+        emails = recipients_list.map { it[:email] }
+        raise Onetime::Problem, 'Duplicate recipient emails not allowed' if emails.uniq.size != emails.size
+
+        recipients_list.each do |r|
+          unless r[:email].match?(OT::Utils::EmailFormat::BASIC_FORMAT)
+            raise Onetime::Problem, "Invalid email format: #{r[:email]}"
+          end
+        end
       end
 
       class << self
@@ -281,69 +325,28 @@ module Onetime
         def count
           instances.size
         end
-      end
 
-      private
-
-      # Normalize recipients array.
-      #
-      # @param recipients_array [Array] Raw recipients input
-      # @return [Array<Hash>] Normalized recipients with symbolized keys
-      def normalize_recipients(recipients_array)
-        Array(recipients_array).map do |r|
-          next nil unless r.is_a?(Hash)
-
-          email = (r[:email] || r['email']).to_s.strip.downcase
-          name  = (r[:name] || r['name']).to_s.strip
-
-          next nil if email.empty?
-
-          { email: email, name: name.empty? ? email.split('@').first : name }
-        end.compact
-      end
-
-      # Validate recipients array.
-      #
-      # Flow: PUT /api/domains/:id/incoming/config -> PutIncomingConfig ->
-      #       IncomingConfig#recipients= -> normalize_recipients -> here
-      #
-      # Uses format-only regex (not Truemail) to avoid DNS latency on config
-      # saves. Truemail validation happens at secret-creation time via the
-      # logic layer.
-      #
-      # @param recipients_array [Array<Hash>] Normalized recipients
-      # @raise [Onetime::Problem] if validation fails
-      def validate_recipients!(recipients_array)
-        raise Onetime::Problem, "Maximum #{MAX_RECIPIENTS} recipients allowed" if recipients_array.size > MAX_RECIPIENTS
-
-        emails = recipients_array.map { |r| r[:email] }
-        raise Onetime::Problem, 'Duplicate recipient emails not allowed' if emails.uniq.size != emails.size
-
-        recipients_array.each do |r|
-          unless r[:email].match?(OT::Utils::EmailFormat::BASIC_FORMAT)
-            raise Onetime::Problem, "Invalid email format: #{r[:email]}"
-          end
+        # Compute SHA256 hash of email with site secret.
+        #
+        # @param email [String] Email address to hash
+        # @param secret [String] Site secret for hashing
+        # @return [String] Hex-encoded SHA256 hash
+        def hash_email(email, secret)
+          Digest::SHA256.hexdigest("#{email}:#{secret}")
         end
-      end
 
-      # Compute SHA256 hash of email with site secret.
-      #
-      # @param email [String] Email address to hash
-      # @param secret [String] Site secret for hashing
-      # @return [String] Hex-encoded SHA256 hash
-      def hash_email(email, secret)
-        Digest::SHA256.hexdigest("#{email}:#{secret}")
-      end
+        # Get site secret or raise if not configured.
+        #
+        # @return [String] The site secret
+        # @raise [Onetime::Problem] if site.secret is not configured
+        def ensure_site_secret
+          return @site_secret unless @site_secret.nil?
 
-      # Get site secret or raise if not configured.
-      #
-      # @return [String] The site secret
-      # @raise [Onetime::Problem] if site.secret is not configured
-      def require_site_secret
-        site_secret = OT.conf.dig('site', 'secret')
-        raise Onetime::Problem, 'site.secret must be configured' if site_secret.to_s.empty?
+          @site_secret = OT.conf.dig('site', 'secret')
+          raise Onetime::Problem, 'site.secret must be configured' if @site_secret.to_s.empty?
 
-        site_secret
+          @site_secret
+        end
       end
     end
   end

--- a/lib/onetime/models/custom_domain/incoming_config.rb
+++ b/lib/onetime/models/custom_domain/incoming_config.rb
@@ -304,6 +304,13 @@ module Onetime
 
       # Validate recipients array.
       #
+      # Flow: PUT /api/domains/:id/incoming/config -> PutIncomingConfig ->
+      #       IncomingConfig#recipients= -> normalize_recipients -> here
+      #
+      # Uses format-only regex (not Truemail) to avoid DNS latency on config
+      # saves. Truemail validation happens at secret-creation time via the
+      # logic layer.
+      #
       # @param recipients_array [Array<Hash>] Normalized recipients
       # @raise [Onetime::Problem] if validation fails
       def validate_recipients!(recipients_array)
@@ -313,7 +320,7 @@ module Onetime
         raise Onetime::Problem, 'Duplicate recipient emails not allowed' if emails.uniq.size != emails.size
 
         recipients_array.each do |r|
-          unless r[:email].match?(/\A[^@\s]+@[^@\s]+\.[^@\s]+\z/)
+          unless r[:email].match?(OT::Utils::EmailFormat::BASIC_FORMAT)
             raise Onetime::Problem, "Invalid email format: #{r[:email]}"
           end
         end

--- a/lib/onetime/models/custom_domain/incoming_config.rb
+++ b/lib/onetime/models/custom_domain/incoming_config.rb
@@ -340,7 +340,7 @@ module Onetime
         # @return [String] The site secret
         # @raise [Onetime::Problem] if site.secret is not configured
         def ensure_site_secret
-          return @site_secret unless @site_secret.nil?
+          return @site_secret unless @site_secret.to_s.empty?
 
           @site_secret = OT.conf.dig('site', 'secret')
           raise Onetime::Problem, 'site.secret must be configured' if @site_secret.to_s.empty?

--- a/lib/onetime/security/input_sanitizers.rb
+++ b/lib/onetime/security/input_sanitizers.rb
@@ -90,7 +90,10 @@ module Onetime
         max_length ? result.slice(0, max_length) : result
       end
 
-      # Sanitize email addresses
+      # Sanitize strings that we area treating as email addresses.
+      #
+      # NOTE: This is not a validator. It treats the input as a string that
+      # is presumed to be an email address.
       #
       # Strips HTML tags (defense-in-depth), lowercases, trims whitespace,
       # and removes newlines to prevent email header injection attacks.

--- a/lib/onetime/utils.rb
+++ b/lib/onetime/utils.rb
@@ -5,6 +5,7 @@
 require 'pathname'
 
 require_relative 'utils/domain_parser'
+require_relative 'utils/email_format'
 require_relative 'utils/enumerables'
 require_relative 'utils/retry_helper'
 require_relative 'utils/strings'

--- a/lib/onetime/utils/email_format.rb
+++ b/lib/onetime/utils/email_format.rb
@@ -1,0 +1,35 @@
+# lib/onetime/utils/email_format.rb
+#
+# frozen_string_literal: true
+
+module Onetime
+  module Utils
+    # EmailFormat - Basic email format validation for model layer
+    #
+    # Provides format-only validation without DNS/SMTP probes. Use for
+    # model-layer validation where Truemail may not be configured (CLI,
+    # console, tests).
+    #
+    # For user-input validation at signup/invitation/share boundaries,
+    # use Truemail via Logic::Base#valid_email? instead.
+    #
+    # For corruption guards in booted contexts, use Truemail :regex mode:
+    #   Truemail.validate(email, with: :regex).result.valid?
+    #
+    module EmailFormat
+      # Basic 3-part format check: local@domain.tld
+      # Rejects obvious malformations without DNS lookups.
+      BASIC_FORMAT = /\A[^@\s]+@[^@\s]+\.[^@\s]+\z/
+
+      class << self
+        # Check basic email format (no DNS, no Truemail dependency)
+        #
+        # @param email [String] Email address to validate
+        # @return [Boolean] True if format matches
+        def valid_format?(email)
+          BASIC_FORMAT.match?(email.to_s)
+        end
+      end
+    end
+  end
+end

--- a/lib/onetime/utils/email_format.rb
+++ b/lib/onetime/utils/email_format.rb
@@ -4,13 +4,13 @@
 
 module Onetime
   module Utils
-    # EmailFormat - Basic email format validation for model layer
+    # EmailFormat - Basic email format check for model layer
     #
-    # Provides format-only validation without DNS/SMTP probes. Use for
-    # model-layer validation where Truemail may not be configured (CLI,
-    # console, tests).
+    # Provides format-only checking without DNS/SMTP probes. Use for
+    # model-layer where Truemail may not be configured (prior to full
+    # application boot).
     #
-    # For user-input validation at signup/invitation/share boundaries,
+    # For validation at signup/invitation/share boundaries,
     # use Truemail via Logic::Base#valid_email? instead.
     #
     # For corruption guards in booted contexts, use Truemail :regex mode:
@@ -19,7 +19,7 @@ module Onetime
     module EmailFormat
       # Basic 3-part format check: local@domain.tld
       # Rejects obvious malformations without DNS lookups.
-      BASIC_FORMAT = /\A[^@\s]+@[^@\s]+\.[^@\s]+\z/
+      BASIC_FORMAT = /\A[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\z/
 
       class << self
         # Check basic email format (no DNS, no Truemail dependency)

--- a/spec/cli/email_validate_command_spec.rb
+++ b/spec/cli/email_validate_command_spec.rb
@@ -1,0 +1,488 @@
+# spec/cli/email_validate_command_spec.rb
+#
+# frozen_string_literal: true
+
+# Tests for: bin/ots email validate <email_address> [--mx|--regex|--smtp]
+#
+# Validates email addresses using Truemail with configurable validation modes.
+# Default mode is :mx (DNS lookup). Other modes: :regex (format only), :smtp (full check).
+
+require_relative 'cli_spec_helper'
+
+RSpec.describe 'Email Validate Command', type: :cli do
+  # Mock Truemail validation result structure
+  # Note: mail_servers is required by output_text method
+  let(:valid_result) do
+    double('TruemailResult',
+      valid?: true,
+      email: 'user@example.com',
+      domain: 'example.com',
+      mail_servers: ['mx.example.com'],
+      validation_type: :mx,
+      errors: {},
+      smtp_debug: nil
+    )
+  end
+
+  let(:invalid_format_result) do
+    double('TruemailResult',
+      valid?: false,
+      email: 'invalid-email',
+      domain: nil,
+      mail_servers: [],
+      validation_type: :regex,
+      errors: { regex: 'email does not match the regex pattern' },
+      smtp_debug: nil
+    )
+  end
+
+  let(:invalid_mx_result) do
+    double('TruemailResult',
+      valid?: false,
+      email: 'user@nonexistent-domain-xyz.test',
+      domain: 'nonexistent-domain-xyz.test',
+      mail_servers: [],
+      validation_type: :mx,
+      errors: { mx: 'target host(s) not found' },
+      smtp_debug: nil
+    )
+  end
+
+  # SMTP debug entries are objects with host, port, connection, response_body, errors
+  let(:smtp_debug_entry) do
+    double('SmtpDebugEntry',
+      host: 'mx.example.com',
+      port: 25,
+      connection: false,
+      response_body: 'Connection refused',
+      errors: { connection: 'refused' }
+    )
+  end
+
+  let(:invalid_smtp_result) do
+    double('TruemailResult',
+      valid?: false,
+      email: 'bounce@example.com',
+      domain: 'example.com',
+      mail_servers: ['mx.example.com'],
+      validation_type: :smtp,
+      errors: { smtp: 'smtp error' },
+      smtp_debug: [smtp_debug_entry]
+    )
+  end
+
+  let(:validator_double) do
+    double('TruemailValidator', result: valid_result, as_json: { 'result' => 'valid' })
+  end
+
+  let(:email_runtime) do
+    double('EmailRuntime', configured?: true, truemail_configured: true)
+  end
+
+  let(:truemail_config) do
+    double('TruemailConfig',
+      whitelisted_emails: [],
+      blacklisted_emails: [],
+      whitelisted_domains: [],
+      blacklisted_domains: []
+    )
+  end
+
+  before do
+    # Mock Runtime.email.configured? to allow command to proceed
+    allow(Onetime::Runtime).to receive(:email).and_return(email_runtime)
+
+    # Mock Truemail.validate to avoid real DNS/SMTP lookups in tests
+    allow(Truemail).to receive(:validate).and_return(validator_double)
+
+    # Mock Truemail.configuration for list matching tests
+    allow(Truemail).to receive(:configuration).and_return(truemail_config)
+  end
+
+  describe 'with valid email format (--regex mode)' do
+    let(:regex_result) do
+      double('TruemailResult',
+        valid?: true,
+        email: 'user@example.com',
+        domain: 'example.com',
+        mail_servers: [],
+        validation_type: :regex,
+        errors: {},
+        smtp_debug: nil
+      )
+    end
+
+    before do
+      allow(Truemail).to receive(:validate)
+        .with('user@example.com', with: :regex)
+        .and_return(double('Validator', result: regex_result, as_json: {}))
+    end
+
+    it 'validates successfully with --regex flag' do
+      output = run_cli_command_quietly('email', 'validate', 'user@example.com', '--regex')
+      expect(output[:stdout]).to match(/valid/i)
+      expect(output[:stdout]).to include('regex')
+      expect(last_exit_code).to eq(0)
+    end
+  end
+
+  describe 'with invalid email format' do
+    before do
+      allow(Truemail).to receive(:validate)
+        .with('invalid-email', with: :regex)
+        .and_return(double('Validator', result: invalid_format_result, as_json: {}))
+    end
+
+    it 'fails validation for email missing @' do
+      output = run_cli_command_quietly('email', 'validate', 'invalid-email', '--regex')
+      expect(output[:stdout]).to match(/invalid/i)
+      expect(last_exit_code).to eq(1)
+    end
+  end
+
+  describe 'with email missing domain part' do
+    let(:no_domain_result) do
+      double('TruemailResult',
+        valid?: false,
+        email: 'user@',
+        domain: nil,
+        mail_servers: [],
+        validation_type: :regex,
+        errors: { regex: 'email does not match the regex pattern' },
+        smtp_debug: nil
+      )
+    end
+
+    before do
+      allow(Truemail).to receive(:validate)
+        .with('user@', with: :regex)
+        .and_return(double('Validator', result: no_domain_result, as_json: {}))
+    end
+
+    it 'fails validation for email without domain' do
+      output = run_cli_command_quietly('email', 'validate', 'user@', '--regex')
+      expect(output[:stdout]).to match(/invalid/i)
+      expect(last_exit_code).to eq(1)
+    end
+  end
+
+  describe 'with email missing local part' do
+    let(:no_local_result) do
+      double('TruemailResult',
+        valid?: false,
+        email: '@example.com',
+        domain: 'example.com',
+        mail_servers: [],
+        validation_type: :regex,
+        errors: { regex: 'email does not match the regex pattern' },
+        smtp_debug: nil
+      )
+    end
+
+    before do
+      allow(Truemail).to receive(:validate)
+        .with('@example.com', with: :regex)
+        .and_return(double('Validator', result: no_local_result, as_json: {}))
+    end
+
+    it 'fails validation for email without local part' do
+      output = run_cli_command_quietly('email', 'validate', '@example.com', '--regex')
+      expect(output[:stdout]).to match(/invalid/i)
+      expect(last_exit_code).to eq(1)
+    end
+  end
+
+  describe 'MX validation (--mx mode, default)' do
+    context 'when domain has valid MX records' do
+      let(:mx_valid_result) do
+        double('TruemailResult',
+          valid?: true,
+          email: 'user@gmail.com',
+          domain: 'gmail.com',
+          mail_servers: ['alt1.gmail-smtp-in.l.google.com'],
+          validation_type: :mx,
+          errors: {},
+          smtp_debug: nil
+        )
+      end
+
+      before do
+        allow(Truemail).to receive(:validate)
+          .with('user@gmail.com', with: :mx)
+          .and_return(double('Validator', result: mx_valid_result, as_json: {}))
+      end
+
+      it 'validates successfully with MX records' do
+        output = run_cli_command_quietly('email', 'validate', 'user@gmail.com', '--mx')
+        expect(output[:stdout]).to match(/valid/i)
+        expect(output[:stdout]).to include('mx')
+        expect(last_exit_code).to eq(0)
+      end
+
+      it 'uses MX mode by default (no flag)' do
+        # Default mode should be :mx
+        allow(Truemail).to receive(:validate)
+          .with('user@gmail.com', with: :mx)
+          .and_return(double('Validator', result: mx_valid_result, as_json: {}))
+
+        output = run_cli_command_quietly('email', 'validate', 'user@gmail.com')
+        expect(output[:stdout]).to match(/valid/i)
+        expect(last_exit_code).to eq(0)
+      end
+    end
+
+    context 'when domain has no MX records' do
+      before do
+        allow(Truemail).to receive(:validate)
+          .with('user@nonexistent-domain-xyz.test', with: :mx)
+          .and_return(double('Validator', result: invalid_mx_result, as_json: {}))
+      end
+
+      it 'fails validation with MX error' do
+        output = run_cli_command_quietly('email', 'validate', 'user@nonexistent-domain-xyz.test', '--mx')
+        expect(output[:stdout]).to match(/invalid/i)
+        expect(last_exit_code).to eq(1)
+      end
+    end
+  end
+
+  describe 'SMTP validation (--smtp mode)' do
+    context 'when SMTP check succeeds' do
+      let(:smtp_success_entry) do
+        double('SmtpDebugEntry',
+          host: 'mail.example.com',
+          port: 25,
+          connection: true,
+          response_body: '220 mail.example.com ESMTP',
+          errors: {}
+        )
+      end
+
+      let(:smtp_valid_result) do
+        double('TruemailResult',
+          valid?: true,
+          email: 'real-user@example.com',
+          domain: 'example.com',
+          mail_servers: ['mx.example.com'],
+          validation_type: :smtp,
+          errors: {},
+          smtp_debug: [smtp_success_entry]
+        )
+      end
+
+      before do
+        allow(Truemail).to receive(:validate)
+          .with('real-user@example.com', with: :smtp)
+          .and_return(double('Validator', result: smtp_valid_result, as_json: {}))
+      end
+
+      it 'validates successfully with SMTP verification' do
+        output = run_cli_command_quietly('email', 'validate', 'real-user@example.com', '--smtp')
+        expect(output[:stdout]).to match(/valid/i)
+        expect(output[:stdout]).to include('smtp')
+        expect(last_exit_code).to eq(0)
+      end
+    end
+
+    context 'when SMTP check fails' do
+      before do
+        allow(Truemail).to receive(:validate)
+          .with('bounce@example.com', with: :smtp)
+          .and_return(double('Validator', result: invalid_smtp_result, as_json: {}))
+      end
+
+      it 'fails validation with SMTP error' do
+        output = run_cli_command_quietly('email', 'validate', 'bounce@example.com', '--smtp')
+        expect(output[:stdout]).to match(/invalid/i)
+        expect(last_exit_code).to eq(1)
+      end
+    end
+  end
+
+  describe 'option parsing' do
+    it 'accepts --regex option' do
+      expect(Truemail).to receive(:validate).with('test@example.com', with: :regex)
+        .and_return(double('Validator', result: valid_result, as_json: {}))
+
+      run_cli_command_quietly('email', 'validate', 'test@example.com', '--regex')
+    end
+
+    it 'accepts --mx option' do
+      expect(Truemail).to receive(:validate).with('test@example.com', with: :mx)
+        .and_return(double('Validator', result: valid_result, as_json: {}))
+
+      run_cli_command_quietly('email', 'validate', 'test@example.com', '--mx')
+    end
+
+    it 'accepts --smtp option' do
+      expect(Truemail).to receive(:validate).with('test@example.com', with: :smtp)
+        .and_return(double('Validator', result: valid_result, as_json: {}))
+
+      run_cli_command_quietly('email', 'validate', 'test@example.com', '--smtp')
+    end
+  end
+
+  describe 'output format' do
+    let(:detailed_result) do
+      double('TruemailResult',
+        valid?: true,
+        email: 'user@example.com',
+        domain: 'example.com',
+        mail_servers: ['mx.example.com'],
+        validation_type: :mx,
+        errors: {},
+        smtp_debug: nil
+      )
+    end
+
+    before do
+      allow(Truemail).to receive(:validate)
+        .and_return(double('Validator', result: detailed_result, as_json: {
+          'email' => 'user@example.com',
+          'domain' => 'example.com',
+          'validation_type' => 'mx',
+          'success' => true
+        }))
+    end
+
+    it 'includes email address in output' do
+      output = run_cli_command_quietly('email', 'validate', 'user@example.com', '--mx')
+      expect(output[:stdout]).to include('user@example.com')
+    end
+
+    it 'includes validation mode in output' do
+      output = run_cli_command_quietly('email', 'validate', 'user@example.com', '--mx')
+      expect(output[:stdout]).to include('mx')
+    end
+
+    it 'includes valid/invalid status in output' do
+      output = run_cli_command_quietly('email', 'validate', 'user@example.com', '--mx')
+      expect(output[:stdout]).to match(/valid|success/i)
+    end
+  end
+
+  describe 'suppression and allowlist matching' do
+    context 'when email matches allowlist' do
+      let(:allowlisted_result) do
+        double('TruemailResult',
+          valid?: true,
+          email: 'vip@trusted-domain.com',
+          domain: 'trusted-domain.com',
+          mail_servers: ['mx.trusted-domain.com'],
+          validation_type: :mx,
+          errors: {},
+          smtp_debug: nil
+        )
+      end
+
+      before do
+        # Mock Truemail configuration with allowlist
+        # Implementation uses whitelisted_* and blacklisted_* (Truemail's terminology)
+        allow(Truemail).to receive(:configuration).and_return(
+          double('Config',
+            whitelisted_emails: [],
+            blacklisted_emails: [],
+            whitelisted_domains: ['trusted-domain.com'],
+            blacklisted_domains: []
+          )
+        )
+        allow(Truemail).to receive(:validate)
+          .with('vip@trusted-domain.com', with: :mx)
+          .and_return(double('Validator', result: allowlisted_result, as_json: {}))
+      end
+
+      it 'reports allowlist match when verbose' do
+        # Note: Actual allowlist reporting depends on implementation
+        output = run_cli_command_quietly('email', 'validate', 'vip@trusted-domain.com', '--mx')
+        expect(output[:stdout]).to match(/valid/i)
+        expect(last_exit_code).to eq(0)
+      end
+    end
+
+    context 'when email matches denylist' do
+      let(:denylisted_result) do
+        double('TruemailResult',
+          valid?: false,
+          email: 'spammer@blocked-domain.com',
+          domain: 'blocked-domain.com',
+          mail_servers: [],
+          validation_type: :mx,
+          errors: { blacklist: 'domain is in the blacklist' },
+          smtp_debug: nil
+        )
+      end
+
+      before do
+        allow(Truemail).to receive(:validate)
+          .with('spammer@blocked-domain.com', with: :mx)
+          .and_return(double('Validator', result: denylisted_result, as_json: {}))
+      end
+
+      it 'fails validation for denylisted domain' do
+        output = run_cli_command_quietly('email', 'validate', 'spammer@blocked-domain.com', '--mx')
+        expect(output[:stdout]).to match(/invalid/i)
+        expect(last_exit_code).to eq(1)
+      end
+    end
+  end
+
+  describe 'error handling' do
+    context 'when no email argument provided' do
+      it 'displays usage error' do
+        output = run_cli_command_quietly('email', 'validate')
+        # Dry::CLI raises ArgumentError for missing required argument
+        expect(last_exit_code).to eq(1)
+      end
+    end
+
+    context 'when Truemail raises an error' do
+      before do
+        allow(Truemail).to receive(:validate).and_raise(StandardError, 'DNS timeout')
+      end
+
+      it 'handles validation errors gracefully' do
+        output = run_cli_command_quietly('email', 'validate', 'user@example.com', '--mx')
+        expect(output[:stderr]).to include('Error')
+        expect(last_exit_code).to eq(1)
+      end
+    end
+  end
+
+  describe 'JSON output format' do
+    let(:json_result) do
+      double('TruemailResult',
+        valid?: true,
+        email: 'user@example.com',
+        domain: 'example.com',
+        mail_servers: ['mx.example.com'],
+        validation_type: :mx,
+        errors: {},
+        smtp_debug: nil
+      )
+    end
+
+    before do
+      allow(Truemail).to receive(:validate)
+        .and_return(double('Validator',
+          result: json_result,
+          as_json: {
+            'email' => 'user@example.com',
+            'domain' => 'example.com',
+            'validation_type' => 'mx',
+            'success' => true,
+            'errors' => {}
+          }
+        ))
+    end
+
+    it 'outputs valid JSON with --format json flag' do
+      output = run_cli_command_quietly('email', 'validate', 'user@example.com', '--format', 'json')
+
+      # Attempt to parse as JSON
+      if output[:stdout].include?('{')
+        json_str = output[:stdout][output[:stdout].index('{')..]
+        expect { JSON.parse(json_str) }.not_to raise_error
+      end
+    end
+  end
+end

--- a/try/features/incoming/incoming_config_model_try.rb
+++ b/try/features/incoming/incoming_config_model_try.rb
@@ -15,7 +15,6 @@
 require_relative '../../support/test_models'
 OT.boot! :test, false
 
-require 'onetime/models/custom_domain/incoming_config'
 
 IncomingConfig = Onetime::CustomDomain::IncomingConfig
 
@@ -28,24 +27,33 @@ IncomingConfig = Onetime::CustomDomain::IncomingConfig
 @test_org = Onetime::Organization.create!("Incoming Model Test #{@ts}", @test_cust, "org_incoming_#{@ts}@test.com")
 @test_domain = Onetime::CustomDomain.create!("incoming-model-#{@ts}-#{@entropy}.example.com", @test_org.objid)
 
-# Store original site.secret for restoration
-@original_site_secret = OT.conf.dig('site', 'secret')
+# Helper to simulate missing site.secret by stubbing ensure_site_secret.
+# OT.conf is frozen, so we stub the class method instead of mutating config.
+def with_missing_site_secret
+  klass = IncomingConfig
+  original_secret = klass.instance_variable_get(:@site_secret)
+  original_method = klass.method(:ensure_site_secret)
 
-# Helper to modify site.secret temporarily
-def with_site_secret(value)
-  original = OT.conf.dig('site', 'secret')
-  if value.nil?
-    OT.conf['site'].delete('secret')
-  else
-    OT.conf['site']['secret'] = value
+  klass.instance_variable_set(:@site_secret, nil)
+  klass.define_singleton_method(:ensure_site_secret) do
+    raise Onetime::Problem, 'site.secret must be configured'
   end
+
   yield
 ensure
-  if original.nil?
-    OT.conf['site'].delete('secret')
-  else
-    OT.conf['site']['secret'] = original
-  end
+  klass.define_singleton_method(:ensure_site_secret, original_method)
+  klass.instance_variable_set(:@site_secret, original_secret)
+end
+
+# Helper to simulate whitespace-only site.secret
+def with_whitespace_site_secret
+  klass = IncomingConfig
+  original_secret = klass.instance_variable_get(:@site_secret)
+
+  klass.instance_variable_set(:@site_secret, '   ')
+  yield
+ensure
+  klass.instance_variable_set(:@site_secret, original_secret)
 end
 
 # --- EMAIL HASHING CONSISTENCY (Review Item 1) ---
@@ -101,7 +109,7 @@ config.recipients = [{ email: 'test@example.com', name: 'Test' }]
 config.save
 result = nil
 begin
-  with_site_secret(nil) do
+  with_missing_site_secret do
     config.public_recipients
     result = 'did_not_raise'
   end
@@ -121,7 +129,7 @@ config.recipients = [{ email: 'test@example.com', name: 'Test' }]
 config.save
 result = nil
 begin
-  with_site_secret('   ') do
+  with_whitespace_site_secret do
     config.public_recipients
     result = 'did_not_raise'
   end
@@ -140,7 +148,7 @@ config.recipients = [{ email: 'test@example.com', name: 'Test' }]
 config.save
 result = nil
 begin
-  with_site_secret(nil) do
+  with_missing_site_secret do
     config.lookup_recipient_email('any_hash')
     result = 'did_not_raise'
   end
@@ -159,7 +167,7 @@ config.recipients = [{ email: 'test@example.com', name: 'Test' }]
 config.save
 result = nil
 begin
-  with_site_secret('   ') do
+  with_whitespace_site_secret do
     result = config.lookup_recipient_email('any_hash')
   end
 rescue OT::Problem

--- a/try/features/incoming/incoming_config_schema_separation_try.rb
+++ b/try/features/incoming/incoming_config_schema_separation_try.rb
@@ -19,7 +19,6 @@
 require_relative '../../support/test_models'
 OT.boot! :test, false
 
-require 'onetime/models/custom_domain/incoming_config'
 
 IncomingConfig = Onetime::CustomDomain::IncomingConfig
 

--- a/try/features/incoming/incoming_config_timestamp_try.rb
+++ b/try/features/incoming/incoming_config_timestamp_try.rb
@@ -18,7 +18,6 @@
 require_relative '../../support/test_models'
 OT.boot! :test, false
 
-require 'onetime/models/custom_domain/incoming_config'
 
 IncomingConfig = Onetime::CustomDomain::IncomingConfig
 

--- a/try/features/incoming/incoming_enabled_toggle_try.rb
+++ b/try/features/incoming/incoming_enabled_toggle_try.rb
@@ -26,7 +26,6 @@ require 'apps/api/incoming/logic/incoming'
 
 OT.boot! :test, false
 
-require 'onetime/models/custom_domain/incoming_config'
 require_relative '../../../lib/onetime/incoming/recipient_resolver'
 
 IncomingConfig = Onetime::CustomDomain::IncomingConfig

--- a/try/features/incoming/incoming_timestamp_update_try.rb
+++ b/try/features/incoming/incoming_timestamp_update_try.rb
@@ -17,7 +17,6 @@ require_relative '../../support/test_logic'
 
 OT.boot! :test, false
 
-require 'onetime/models/custom_domain/incoming_config'
 
 IncomingConfig = Onetime::CustomDomain::IncomingConfig
 

--- a/try/features/incoming/put_incoming_config_recipients_try.rb
+++ b/try/features/incoming/put_incoming_config_recipients_try.rb
@@ -40,7 +40,6 @@ enable_incoming_feature
 require 'apps/api/domains/logic/base'
 require 'apps/api/domains/logic/incoming_config/base'
 require 'apps/api/domains/logic/incoming_config/put_incoming_config'
-require 'onetime/models/custom_domain/incoming_config'
 
 IncomingConfig = Onetime::CustomDomain::IncomingConfig
 PutIncomingConfig = DomainsAPI::Logic::IncomingConfig::PutIncomingConfig

--- a/try/unit/cli/email/validate_command_try.rb
+++ b/try/unit/cli/email/validate_command_try.rb
@@ -1,0 +1,82 @@
+# try/unit/cli/email/validate_command_try.rb
+#
+# frozen_string_literal: true
+
+# Tests for Onetime::CLI::Email::ValidateCommand class.
+#
+# Tests private helper methods: determine_mode
+# Full integration tests with Truemail mocking are in spec/cli/email_validate_command_spec.rb
+
+require_relative '../../../support/test_helpers'
+
+OT.boot! :test, false
+
+require 'onetime/cli'
+
+@cmd = Onetime::CLI::Email::ValidateCommand.new
+
+# TRYOUTS
+
+## ValidateCommand class exists
+defined?(Onetime::CLI::Email::ValidateCommand)
+#=> "constant"
+
+## ValidateCommand inherits from Command
+Onetime::CLI::Email::ValidateCommand.superclass
+#=> Onetime::CLI::Command
+
+## MODES constant contains expected validation types
+Onetime::CLI::Email::ValidateCommand::MODES
+#=> [:smtp, :mx, :regex]
+
+## determine_mode returns :smtp when smtp flag is true
+@cmd.send(:determine_mode, true, false, false)
+#=> :smtp
+
+## determine_mode returns :regex when regex flag is true (smtp false)
+@cmd.send(:determine_mode, false, false, true)
+#=> :regex
+
+## determine_mode returns :mx when mx flag is true (others false)
+@cmd.send(:determine_mode, false, true, false)
+#=> :mx
+
+## determine_mode defaults to :mx when no flags set
+@cmd.send(:determine_mode, false, false, false)
+#=> :mx
+
+## determine_mode prioritizes smtp over mx and regex
+@cmd.send(:determine_mode, true, true, true)
+#=> :smtp
+
+## determine_mode prioritizes regex over mx when smtp false
+@cmd.send(:determine_mode, false, true, true)
+#=> :regex
+
+## extract_list_config returns hash with expected keys
+config_mock = Struct.new(
+  :whitelisted_emails, :blacklisted_emails,
+  :whitelisted_domains, :blacklisted_domains
+).new([], [], [], [])
+allow_truemail_config = -> { config_mock }
+Truemail.define_singleton_method(:configuration, &allow_truemail_config)
+
+result = @cmd.send(:extract_list_config)
+result.keys.sort
+#=> [:blacklisted_domains, :blacklisted_emails, :whitelisted_domains, :whitelisted_emails]
+
+## extract_list_config returns arrays for all values
+result = @cmd.send(:extract_list_config)
+result.values.all? { |v| v.is_a?(Array) }
+#=> true
+
+## extract_list_config preserves configured values
+config_mock = Struct.new(
+  :whitelisted_emails, :blacklisted_emails,
+  :whitelisted_domains, :blacklisted_domains
+).new(['allowed@test.com'], ['blocked@test.com'], ['trusted.com'], ['spam.com'])
+Truemail.define_singleton_method(:configuration) { config_mock }
+
+result = @cmd.send(:extract_list_config)
+[result[:whitelisted_emails], result[:blacklisted_domains]]
+#=> [["allowed@test.com"], ["spam.com"]]

--- a/try/unit/cli/email/validate_command_try.rb
+++ b/try/unit/cli/email/validate_command_try.rb
@@ -15,6 +15,9 @@ require 'onetime/cli'
 
 @cmd = Onetime::CLI::Email::ValidateCommand.new
 
+# Save original Truemail.configuration method for restoration later
+@original_truemail_configuration = Truemail.method(:configuration)
+
 # TRYOUTS
 
 ## ValidateCommand class exists
@@ -80,3 +83,8 @@ Truemail.define_singleton_method(:configuration) { config_mock }
 result = @cmd.send(:extract_list_config)
 [result[:whitelisted_emails], result[:blacklisted_domains]]
 #=> [["allowed@test.com"], ["spam.com"]]
+
+## Restore original Truemail.configuration
+Truemail.define_singleton_method(:configuration, @original_truemail_configuration)
+true
+#=> true

--- a/try/unit/controllers/homepage_bypass_header_try.rb
+++ b/try/unit/controllers/homepage_bypass_header_try.rb
@@ -46,35 +46,10 @@ def create_mock_request(headers = {})
 end
 
 # -------------------------------------------------------------------
-# SETUP: Mock OT.conf for testing
+# NOTE: Tests call header_matches_mode? with explicit arguments.
+# No need to mock OT.conf since the method takes header_name and
+# expected_mode as parameters directly.
 # -------------------------------------------------------------------
-
-## Create a test config that we can modify
-@test_config = {
-  'site' => {
-    'interface' => {
-      'ui' => {
-        'homepage' => {
-          'mode' => 'protected',
-          'request_header' => 'O-Homepage-Mode'
-        }
-      }
-    }
-  }
-}
-
-## Stub OT.conf to return our test config
-def OT.conf
-  @test_config_override || super
-end
-
-def OT.conf=(config)
-  @test_config_override = config
-end
-
-OT.conf = @test_config
-OT.conf.dig('site', 'interface', 'ui', 'homepage', 'mode')
-#=> 'protected'
 
 # -------------------------------------------------------------------
 # TEST: Method returns true when header matches
@@ -137,75 +112,53 @@ OT.conf.dig('site', 'interface', 'ui', 'homepage', 'mode')
 # -------------------------------------------------------------------
 
 ## Configure with header containing underscores
-@test_config['site']['interface']['ui']['homepage']['request_header'] = 'X_Custom_Header'
-OT.conf = @test_config
 @req_underscore = create_mock_request('X-Custom-Header' => 'protected')
 @controller7 = TestController.new(@req_underscore, nil)
 @controller7.send(:header_matches_mode?, 'X_Custom_Header', 'protected')
 #=> true
 
 ## Configure with header already in HTTP_ format
-@test_config['site']['interface']['ui']['homepage']['request_header'] = 'HTTP_X_BYPASS'
-OT.conf = @test_config
 @req_http_prefix = create_mock_request('X-Bypass' => 'protected')
 @controller8 = TestController.new(@req_http_prefix, nil)
 @controller8.send(:header_matches_mode?, 'HTTP_X_BYPASS', 'protected')
 #=> true
 
 # -------------------------------------------------------------------
-# TEST: Method returns nil when mode is not configured
+# TEST: Method returns false when mode is nil
 # -------------------------------------------------------------------
 
 ## With nil mode value (should return false since header doesn't match nil)
-@test_config['site']['interface']['ui']['homepage']['mode'] = nil
-OT.conf = @test_config
 @req_no_mode = create_mock_request('O-Homepage-Mode' => 'protected')
 @controller9 = TestController.new(@req_no_mode, nil)
 @controller9.send(:header_matches_mode?, 'O-Homepage-Mode', nil)
 #=> false
 
 # -------------------------------------------------------------------
-# TEST: Method returns nil when mode is different
+# TEST: Method returns false when mode doesn't match header value
 # -------------------------------------------------------------------
 
 ## With different expected mode value
-@test_config['site']['interface']['ui']['homepage']['mode'] = 'some-other-mode'
-OT.conf = @test_config
 @req_other_mode = create_mock_request('O-Homepage-Mode' => 'protected')
 @controller10 = TestController.new(@req_other_mode, nil)
 @controller10.send(:header_matches_mode?, 'O-Homepage-Mode', 'some-other-mode')
 #=> false
 
 # -------------------------------------------------------------------
-# TEST: Method returns nil when request_header is not configured
+# TEST: Method returns false when header name is nil
 # -------------------------------------------------------------------
 
 ## With nil header name (should return false)
-@test_config['site']['interface']['ui']['homepage']['mode'] = 'protected'
-@test_config['site']['interface']['ui']['homepage']['request_header'] = nil
-OT.conf = @test_config
 @req_no_header_config = create_mock_request('O-Homepage-Mode' => 'protected')
 @controller11 = TestController.new(@req_no_header_config, nil)
 @controller11.send(:header_matches_mode?, nil, 'protected')
 #=> false
 
 # -------------------------------------------------------------------
-# TEST: Method returns nil when request_header is empty string
+# TEST: Method returns false when header name is empty string
 # -------------------------------------------------------------------
 
 ## With empty header name (should return false)
-@test_config['site']['interface']['ui']['homepage']['request_header'] = ''
-OT.conf = @test_config
 @req_empty_header_config = create_mock_request('O-Homepage-Mode' => 'protected')
 @controller12 = TestController.new(@req_empty_header_config, nil)
 @controller12.send(:header_matches_mode?, '', 'protected')
 #=> false
-
-# -------------------------------------------------------------------
-# TEARDOWN: Remove config override
-# -------------------------------------------------------------------
-
-## Remove the test config override
-OT.instance_variable_set(:@test_config_override, nil)
-true
-#=> true


### PR DESCRIPTION
Closes #3101. Revisits choices made on #2621. 

## Summary

- Extract `OT::Utils::EmailFormat` module with `BASIC_FORMAT` constant for model-layer validation
- Remove duplicate `valid_email?` definitions from V1 API, CLI commands, and organization invitations
- Centralize Truemail-backed `valid_email?` in CLI base module
- Differentiate validation tiers: Truemail full-validate at input boundaries, `:regex` mode as corruption guards, `BASIC_FORMAT` at model layer

## Test plan

- [x] CLI email validation still works: `bin/ots apitoken list <email>`
- [ ] Incoming config recipient validation accepts valid emails
- [ ] Organization invitations validate email format
- [ ] V1 API endpoints that accepted emails still work