### PR TITLE
Add coupon and promotion code CLI commands and enable promo codes at checkout

### DIFF
--- a/apps/web/billing/cli/billing_command.rb
+++ b/apps/web/billing/cli/billing_command.rb
@@ -61,6 +61,11 @@ module Onetime
             bin/ots billing payment-links show      Show payment link details
             bin/ots billing payment-links archive   Archive payment link
 
+          Coupons & Promotion Codes:
+            bin/ots billing coupons                  List all Stripe coupons
+            bin/ots billing coupons --valid-only     List only currently redeemable coupons
+            bin/ots billing coupon validate <CODE>   Check if a code is currently valid
+
           Catalog & Sync:
             bin/ots billing catalog            Manage plan catalog
             bin/ots billing catalog validate   Validate catalog YAML and Stripe consistency

--- a/apps/web/billing/cli/coupon_command.rb
+++ b/apps/web/billing/cli/coupon_command.rb
@@ -1,0 +1,42 @@
+# apps/web/billing/cli/coupon_command.rb
+#
+# frozen_string_literal: true
+
+require_relative 'helpers'
+
+module Onetime
+  module CLI
+    # Parent help command for `billing coupon` subcommands.
+    # Use `billing coupons` (plural) to list all coupons.
+    class BillingCouponCommand < Command
+      include BillingHelpers
+
+      desc 'Inspect or validate a single coupon / promotion code'
+
+      def call(**)
+        puts <<~HELP
+          Coupon Commands:
+
+            bin/ots billing coupons                  List all Stripe coupons
+            bin/ots billing coupon validate <CODE>   Check if a code is currently valid
+
+          Examples:
+            # List all coupons with their promo codes
+            bin/ots billing coupons
+
+            # Only show coupons currently redeemable
+            bin/ots billing coupons --valid-only
+
+            # Validate a promotion code customers can type at checkout
+            bin/ots billing coupon validate WELCOME20
+
+            # Validate by coupon ID
+            bin/ots billing coupon validate cou_abc123
+
+        HELP
+      end
+    end
+  end
+end
+
+Onetime::CLI.register 'billing coupon', Onetime::CLI::BillingCouponCommand

--- a/apps/web/billing/cli/coupon_validate_command.rb
+++ b/apps/web/billing/cli/coupon_validate_command.rb
@@ -1,0 +1,200 @@
+# apps/web/billing/cli/coupon_validate_command.rb
+#
+# frozen_string_literal: true
+
+require_relative 'helpers'
+
+module Onetime
+  module CLI
+    # Validate a coupon or promotion code and show its details.
+    #
+    # Accepts either:
+    #   - a promotion code string customers type at checkout (e.g. WELCOME20)
+    #   - a Stripe coupon ID (e.g. WELCOME20 if used as the coupon ID, or
+    #     a custom/auto-generated coupon ID like a3F9bC2D)
+    #
+    # The promotion code lookup is case-sensitive (Stripe stores codes
+    # case-sensitively but matches case-insensitively at checkout).
+    class BillingCouponValidateCommand < Command
+      include BillingHelpers
+
+      desc 'Check whether a coupon or promotion code is currently valid'
+
+      argument :code,
+        required: true,
+        desc: 'Promotion code string (e.g. WELCOME20) or coupon ID (cou_xxx)'
+
+      def call(code:, **)
+        boot_application!
+
+        return unless stripe_configured?
+
+        coupon, promo_code = resolve_code(code)
+
+        unless coupon
+          puts "✗ No matching promotion code or coupon found for: #{code}"
+          puts
+          puts 'Hints:'
+          puts '  - Promotion codes are case-sensitive when looked up via the API'
+          puts '  - Make sure the code exists in the same Stripe mode (test vs live)'
+          puts '    as your STRIPE_API_KEY'
+          exit_with_status(1)
+          return
+        end
+
+        print_summary(coupon, promo_code)
+        print_restrictions(coupon, promo_code)
+        print_validity(coupon, promo_code)
+      rescue Stripe::StripeError => ex
+        puts format_stripe_error('Failed to validate code', ex)
+        exit_with_status(1)
+      end
+
+      private
+
+      # Look up the input as either a promotion code or a coupon ID.
+      #
+      # Strategy:
+      #   1. Try Stripe::PromotionCode.list(code:) — matches the customer-facing
+      #      string. Returns the most recent active match.
+      #   2. Fall back to Stripe::Coupon.retrieve(code) for direct coupon ID
+      #      lookups (works for both auto-generated and custom coupon IDs).
+      #
+      # @return [Array(Stripe::Coupon, Stripe::PromotionCode|nil)]
+      def resolve_code(code)
+        # Promotion codes are limited to a-zA-Z0-9, so anything Stripe-shaped
+        # works either as a promo code or a coupon ID.
+        codes = Stripe::PromotionCode.list(code: code, limit: 5)
+        if codes.data.any?
+          # Prefer active codes when there are multiple matches.
+          promo_code = codes.data.find(&:active) || codes.data.first
+          return [promo_code.coupon, promo_code]
+        end
+
+        coupon = Stripe::Coupon.retrieve(code)
+        [coupon, nil]
+      rescue Stripe::InvalidRequestError
+        [nil, nil]
+      end
+
+      def print_summary(coupon, promo_code)
+        puts 'Coupon details:'
+        puts "  Coupon ID:    #{coupon.id}"
+        puts "  Name:         #{coupon.name || '(none)'}"
+        puts "  Discount:     #{format_discount(coupon)}"
+        puts "  Duration:     #{format_duration(coupon)}"
+        puts "  Created:      #{format_timestamp(coupon.created)}"
+        puts "  Redeemed:     #{redemption_summary(coupon)}"
+        puts
+
+        if promo_code
+          puts 'Promotion code:'
+          puts "  Code:         #{promo_code.code}"
+          puts "  ID:           #{promo_code.id}"
+          puts "  Active:       #{promo_code.active ? 'yes' : 'no'}"
+          if promo_code.expires_at
+            puts "  Expires at:   #{format_timestamp(promo_code.expires_at)}"
+          end
+          if promo_code.max_redemptions
+            puts "  Redeemed:     #{promo_code.times_redeemed}/#{promo_code.max_redemptions}"
+          end
+          if promo_code.customer
+            puts "  Customer:     #{promo_code.customer} (restricted to this customer)"
+          end
+          puts
+        end
+      end
+
+      def print_restrictions(coupon, promo_code)
+        restrictions = []
+
+        if coupon.amount_off && coupon.currency
+          restrictions << "Coupon is denominated in #{coupon.currency.upcase} — only " \
+                          'applies to checkouts in that currency.'
+        end
+        if coupon.applies_to&.products&.any?
+          restrictions << "Coupon limited to products: #{coupon.applies_to.products.join(', ')}"
+        end
+        if coupon.redeem_by
+          restrictions << "Coupon redemption deadline: #{format_timestamp(coupon.redeem_by)}"
+        end
+
+        restrictions_for_promo_code(promo_code, restrictions) if promo_code
+
+        return if restrictions.empty?
+
+        puts 'Restrictions:'
+        restrictions.each { |r| puts "  - #{r}" }
+        puts
+      end
+
+      def restrictions_for_promo_code(promo_code, restrictions)
+        if promo_code.restrictions&.first_time_transaction
+          restrictions << 'Only valid on a customer\'s first transaction'
+        end
+        if (min = promo_code.restrictions&.minimum_amount)
+          min_currency = promo_code.restrictions.minimum_amount_currency
+          restrictions << "Minimum order amount: #{format_amount(min, min_currency)}"
+        end
+      end
+
+      # rubocop:disable Metrics/CyclomaticComplexity
+      def print_validity(coupon, promo_code)
+        # When a promotion code is present, both it and the coupon must be valid.
+        problems = []
+
+        problems << 'Coupon is not valid (likely max redemptions reached or redeem_by passed)' unless coupon.valid
+        problems << 'Promotion code is not active' if promo_code && !promo_code.active
+        if promo_code&.expires_at && promo_code.expires_at < Time.now.to_i
+          problems << "Promotion code expired at #{format_timestamp(promo_code.expires_at)}"
+        end
+        if promo_code&.max_redemptions && promo_code.times_redeemed >= promo_code.max_redemptions
+          problems << 'Promotion code has reached its max redemptions'
+        end
+
+        if problems.empty?
+          puts '✓ Code is currently valid and can be applied at checkout'
+        else
+          puts '✗ Code is NOT currently valid:'
+          problems.each { |p| puts "  - #{p}" }
+          exit_with_status(1)
+        end
+      end
+      # rubocop:enable Metrics/CyclomaticComplexity
+
+      def format_discount(coupon)
+        if coupon.percent_off
+          "#{format('%g', coupon.percent_off)}% off"
+        elsif coupon.amount_off
+          "#{format_amount(coupon.amount_off, coupon.currency)} off"
+        else
+          'N/A'
+        end
+      end
+
+      def format_duration(coupon)
+        case coupon.duration
+        when 'once'      then 'once'
+        when 'forever'   then 'forever'
+        when 'repeating' then "repeating (#{coupon.duration_in_months} month(s))"
+        else coupon.duration.to_s
+        end
+      end
+
+      def redemption_summary(coupon)
+        if coupon.max_redemptions
+          "#{coupon.times_redeemed} / #{coupon.max_redemptions}"
+        else
+          "#{coupon.times_redeemed} (no max)"
+        end
+      end
+
+      # CLI exit helper that respects the no-exit pattern under tests.
+      def exit_with_status(status)
+        exit(status) unless ENV['RACK_ENV'] == 'test'
+      end
+    end
+  end
+end
+
+Onetime::CLI.register 'billing coupon validate', Onetime::CLI::BillingCouponValidateCommand

--- a/apps/web/billing/cli/coupons_command.rb
+++ b/apps/web/billing/cli/coupons_command.rb
@@ -1,0 +1,125 @@
+# apps/web/billing/cli/coupons_command.rb
+#
+# frozen_string_literal: true
+
+require_relative 'helpers'
+
+module Onetime
+  module CLI
+    # List Stripe coupons (with attached promotion codes)
+    class BillingCouponsCommand < Command
+      include BillingHelpers
+
+      desc 'List Stripe coupons and their promotion codes'
+
+      option :limit, type: :integer, default: 100, desc: 'Maximum coupons to return'
+      option :valid_only,
+        type: :boolean,
+        default: false,
+        desc: 'Only show coupons currently redeemable (valid=true)'
+
+      def call(limit: 100, valid_only: false, **)
+        boot_application!
+
+        return unless stripe_configured?
+
+        puts 'Fetching coupons from Stripe...'
+        coupons = Stripe::Coupon.list(limit: limit)
+        coupons = coupons.data
+        coupons = coupons.select(&:valid) if valid_only
+
+        if coupons.empty?
+          puts 'No coupons found'
+          return
+        end
+
+        puts format(
+          '%-22s %-20s %-12s %-12s %-12s %-7s %s',
+          'COUPON ID',
+          'NAME',
+          'DISCOUNT',
+          'DURATION',
+          'REDEEMED',
+          'VALID',
+          'PROMO CODES',
+        )
+        puts '-' * 110
+
+        coupons.each do |coupon|
+          puts format_coupon_row(coupon)
+        end
+
+        puts "\nTotal: #{coupons.size} coupon(s)"
+        puts "\nUse 'bin/ots billing coupon validate <CODE>' to inspect a code in detail."
+      rescue Stripe::StripeError => ex
+        puts format_stripe_error('Failed to list coupons', ex)
+      end
+
+      private
+
+      def format_coupon_row(coupon)
+        name        = coupon.name || coupon.id
+        discount    = format_discount(coupon)
+        duration    = format_duration(coupon)
+        redeemed    = redemption_summary(coupon)
+        valid_str   = coupon.valid ? 'yes' : 'no'
+        promo_codes = lookup_promotion_codes(coupon.id)
+
+        format(
+          '%-22s %-20s %-12s %-12s %-12s %-7s %s',
+          coupon.id[0..21],
+          name[0..19],
+          discount[0..11],
+          duration[0..11],
+          redeemed[0..11],
+          valid_str,
+          promo_codes[0..40],
+        )
+      end
+
+      def format_discount(coupon)
+        if coupon.percent_off
+          "#{format('%g', coupon.percent_off)}% off"
+        elsif coupon.amount_off
+          "#{format_amount(coupon.amount_off, coupon.currency)} off"
+        else
+          'N/A'
+        end
+      end
+
+      def format_duration(coupon)
+        case coupon.duration
+        when 'repeating'
+          "#{coupon.duration_in_months}mo"
+        else
+          coupon.duration.to_s
+        end
+      end
+
+      def redemption_summary(coupon)
+        if coupon.max_redemptions
+          "#{coupon.times_redeemed}/#{coupon.max_redemptions}"
+        else
+          coupon.times_redeemed.to_s
+        end
+      end
+
+      # Look up promotion codes attached to this coupon.
+      # Returns a compact comma-separated string of the customer-facing codes,
+      # or '(none)' if there are no active promotion codes.
+      def lookup_promotion_codes(coupon_id)
+        codes = Stripe::PromotionCode.list(coupon: coupon_id, limit: 10)
+        return '(none)' if codes.data.empty?
+
+        active = codes.data.select(&:active).map(&:code)
+        return '(none active)' if active.empty?
+
+        active.join(', ')
+      rescue Stripe::StripeError
+        '?'
+      end
+    end
+  end
+end
+
+Onetime::CLI.register 'billing coupons', Onetime::CLI::BillingCouponsCommand

--- a/apps/web/billing/cli/coupons_command.rb
+++ b/apps/web/billing/cli/coupons_command.rb
@@ -33,6 +33,14 @@ module Onetime
           return
         end
 
+        # Batch-fetch active promotion codes once and group by coupon ID, so we
+        # avoid one Stripe API call per coupon (N+1).
+        #
+        # NOTE: Stripe caps a single list page at 100. If there are more than
+        # 100 active promotion codes in this account, this command will only
+        # show the first page. Add pagination here if that limit becomes real.
+        promo_codes_by_coupon = group_promotion_codes_by_coupon
+
         puts format(
           '%-22s %-20s %-12s %-12s %-12s %-7s %s',
           'COUPON ID',
@@ -46,7 +54,7 @@ module Onetime
         puts '-' * 110
 
         coupons.each do |coupon|
-          puts format_coupon_row(coupon)
+          puts format_coupon_row(coupon, promo_codes_by_coupon)
         end
 
         puts "\nTotal: #{coupons.size} coupon(s)"
@@ -57,13 +65,13 @@ module Onetime
 
       private
 
-      def format_coupon_row(coupon)
+      def format_coupon_row(coupon, promo_codes_by_coupon)
         name        = coupon.name || coupon.id
         discount    = format_discount(coupon)
         duration    = format_duration(coupon)
         redeemed    = redemption_summary(coupon)
         valid_str   = coupon.valid ? 'yes' : 'no'
-        promo_codes = lookup_promotion_codes(coupon.id)
+        promo_codes = promo_codes_for(coupon.id, promo_codes_by_coupon)
 
         format(
           '%-22s %-20s %-12s %-12s %-12s %-7s %s',
@@ -104,19 +112,20 @@ module Onetime
         end
       end
 
-      # Look up promotion codes attached to this coupon.
-      # Returns a compact comma-separated string of the customer-facing codes,
-      # or '(none)' if there are no active promotion codes.
-      def lookup_promotion_codes(coupon_id)
-        codes = Stripe::PromotionCode.list(coupon: coupon_id, limit: 10)
-        return '(none)' if codes.data.empty?
+      # Fetch active promotion codes in a single API call and return them
+      # grouped by their underlying coupon ID. Any error here propagates up
+      # to the command's top-level rescue so the user sees a real message
+      # rather than silent fallback values.
+      def group_promotion_codes_by_coupon
+        codes = Stripe::PromotionCode.list(active: true, limit: 100).data
+        codes.group_by { |pc| pc.coupon.is_a?(String) ? pc.coupon : pc.coupon.id }
+      end
 
-        active = codes.data.select(&:active).map(&:code)
-        return '(none active)' if active.empty?
+      def promo_codes_for(coupon_id, promo_codes_by_coupon)
+        codes = promo_codes_by_coupon[coupon_id]
+        return '(none active)' if codes.nil? || codes.empty?
 
-        active.join(', ')
-      rescue Stripe::StripeError
-        '?'
+        codes.map(&:code).join(', ')
       end
     end
   end

--- a/apps/web/billing/controllers/billing.rb
+++ b/apps/web/billing/controllers/billing.rb
@@ -118,6 +118,10 @@ module Billing
           customer_email: org.billing_email || cust.email,
           client_reference_id: org.objid,
           locale: req.env['rack.locale']&.first || 'auto',
+          # Show the "Add promotion code" field on the Stripe-hosted checkout.
+          # Promotion codes must first be created in the Stripe Dashboard
+          # (Products → Coupons → Promotion codes).
+          allow_promotion_codes: true,
           subscription_data: {
             metadata: {
               orgid: org.objid,

--- a/apps/web/billing/controllers/plans.rb
+++ b/apps/web/billing/controllers/plans.rb
@@ -106,6 +106,11 @@ module Billing
           #
           automatic_tax: { enabled: true },
           tax_id_collection: { enabled: true },  # EU B2B VAT reverse charge
+
+          # Show the "Add promotion code" field on the Stripe-hosted checkout.
+          # Promotion codes must first be created in the Stripe Dashboard
+          # (Products → Coupons → Promotion codes).
+          allow_promotion_codes: true,
         }
 
         # Customer handling for authenticated users

--- a/apps/web/billing/docs/cli-usage.md
+++ b/apps/web/billing/docs/cli-usage.md
@@ -23,6 +23,8 @@ bin/ots billing                 # Show help
 bin/ots billing plans           # List cached plans
 bin/ots billing products        # List Stripe products
 bin/ots billing prices          # List Stripe prices
+bin/ots billing coupons         # List Stripe coupons
+bin/ots billing coupon validate # Check if a coupon/promo code is currently valid
 bin/ots billing sync            # Sync from Stripe to cache
 bin/ots billing validate        # Validate product metadata
 ```
@@ -1341,6 +1343,116 @@ bin/ots billing refunds create --charge ch_ABC123xyz --reason fraudulent --yes
 
 ---
 
+### `bin/ots billing coupons`
+
+List all Stripe coupons along with any active promotion codes attached
+to each. Useful for auditing what discount codes exist and whether they
+are currently redeemable.
+
+**Options:**
+- `--limit INTEGER` - Maximum coupons to return (default: 100)
+- `--valid-only` - Show only coupons where `valid=true` (not expired,
+  redemption cap not reached)
+
+**Examples:**
+```bash
+# List every coupon, plus active promo codes attached
+bin/ots billing coupons
+
+# Only show coupons currently redeemable
+bin/ots billing coupons --valid-only
+
+# Larger fetch
+bin/ots billing coupons --limit 250
+```
+
+**Output:**
+```
+COUPON ID              NAME                 DISCOUNT     DURATION     REDEEMED     VALID   PROMO CODES
+--------------------------------------------------------------------------------------------------------------
+WELCOME20              Welcome 20%          20% off      once         12           yes     WELCOME20
+SAVE10                 Save $10             CAD 10.00 of repeating    3/100        yes     SAVE10, SAVE10SUMMER
+LEGACY_LOYALTY         Loyalty 50% off      50% off      forever      87           yes     (none)
+
+Total: 3 coupon(s)
+```
+
+**Column meanings:**
+- `DISCOUNT` — percent off (any currency) or amount off (single-currency)
+- `DURATION` — `once`, `forever`, or `NNmo` for repeating coupons
+- `REDEEMED` — `times_redeemed` or `times_redeemed/max_redemptions`
+- `VALID` — Stripe's `valid` flag (the coupon can still be applied)
+- `PROMO CODES` — comma-separated list of active promotion codes that
+  resolve to this coupon at checkout
+
+---
+
+### `bin/ots billing coupon validate <CODE>`
+
+Look up a coupon or promotion code and report whether it would currently
+apply at checkout, along with all discount, duration, and restriction
+details. The argument can be either the customer-facing promotion code
+string (e.g. `WELCOME20`) or a Stripe coupon ID.
+
+**Arguments:**
+- `code` - The promotion code string or coupon ID to validate
+
+**Examples:**
+```bash
+# Validate a customer-facing promotion code
+bin/ots billing coupon validate WELCOME20
+
+# Validate a coupon by its Stripe ID
+bin/ots billing coupon validate cou_abc123
+```
+
+**Output (valid):**
+```
+Coupon details:
+  Coupon ID:    WELCOME20
+  Name:         Welcome 20%
+  Discount:     20% off
+  Duration:     once
+  Created:      2025-11-12 10:00:00 UTC
+  Redeemed:     12 (no max)
+
+Promotion code:
+  Code:         WELCOME20
+  ID:           promo_1Q...
+  Active:       yes
+
+✓ Code is currently valid and can be applied at checkout
+```
+
+**Output (invalid):**
+```
+Coupon details:
+  Coupon ID:    EXPIRED_OFFER
+  ...
+✗ Code is NOT currently valid:
+  - Coupon is not valid (likely max redemptions reached or redeem_by passed)
+  - Promotion code expired at 2025-04-01 00:00:00 UTC
+```
+
+**What it checks:**
+- Coupon's own `valid` flag (covers `redeem_by` and `max_redemptions`)
+- Promotion code's `active` flag and `expires_at`
+- Promotion-code-specific `max_redemptions`
+- Promotion-code restrictions (first-time customer, minimum order amount)
+
+**Exit code:**
+- `0` if the code is currently valid
+- `1` if the code is invalid, expired, or not found — useful for scripting
+
+**Notes:**
+- Promotion code lookup uses Stripe's API which is case-sensitive. At
+  the customer-facing checkout Stripe matches case-insensitively, but
+  the API lookup here must use the exact stored casing.
+- Test-mode and live-mode codes are entirely separate. Make sure your
+  `STRIPE_API_KEY` matches the environment where the code was created.
+
+---
+
 ### `bin/ots billing test trigger-webhook`
 
 Trigger test webhook events for development/testing. **Requires Stripe CLI.**
@@ -1805,6 +1917,8 @@ bin/ots billing payment-links create \
 | `billing refunds` | List refunds | `--charge`, `--limit` |
 | `billing refunds create` | Create refund | `--charge`, `--amount`, `--reason`, `--yes` |
 | `billing payment-methods set-default` | Set default payment method | `--customer` |
+| `billing coupons` | List Stripe coupons with promo codes | `--valid-only`, `--limit` |
+| `billing coupon validate` | Check if a coupon/promo code is currently valid | - |
 | `billing events` | View recent events | `--type`, `--limit` |
 | `billing test create-customer` | Create test customer with card | `--with-card` |
 | `billing test trigger-webhook` | Trigger test webhook event | `--subscription`, `--customer` |

--- a/apps/web/billing/docs/stripe-configuration.md
+++ b/apps/web/billing/docs/stripe-configuration.md
@@ -84,6 +84,33 @@ stripe listen --forward-to localhost:3000/billing/webhook
 stripe trigger checkout.session.completed
 ```
 
+## Promotion Codes
+
+Stripe Checkout Sessions created by this application enable
+`allow_promotion_codes: true`, which renders an "Add promotion code" field
+on the Stripe-hosted checkout page during both initial signup
+(`GET /billing/plans/:product/:interval`) and existing-org upgrades
+(`POST /billing/org/:extid/checkout`).
+
+For the field to be useful, promotion codes must first be created in the
+Stripe Dashboard:
+
+1. **Create a coupon:** [Stripe Dashboard → Products → Coupons](https://dashboard.stripe.com/coupons)
+   - Set the discount (percent off or amount off)
+   - Set duration (once, repeating, or forever)
+   - Optionally restrict to specific products
+2. **Create a promotion code** for the coupon
+   - Promotion codes are customer-facing strings (e.g., `WELCOME20`) that
+     customers enter at checkout
+   - One coupon can have many promotion codes
+3. Customers enter the promotion code on the Stripe-hosted checkout page —
+   no extra UI work is required on our side.
+
+**Note on currency:** Amount-off coupons are denominated in a single currency
+and only apply to checkouts in that currency. Percent-off coupons work across
+currencies. See `apps/web/billing/lib/currency_migration_service.rb` for how
+incompatible coupons are surfaced during currency migrations.
+
 ## Regional Setup
 
 For multi-region deployments, create separate products per region with `region` metadata:

--- a/apps/web/billing/spec/controllers/billing_controller_spec.rb
+++ b/apps/web/billing/spec/controllers/billing_controller_spec.rb
@@ -279,26 +279,6 @@ RSpec.describe 'Billing::Controllers::BillingController', :integration, :stripe_
       )
     end
 
-    it 'allows promotion codes on the checkout session' do
-      mock_session = build_checkout_session(
-        'url' => 'https://checkout.stripe.com/c/pay/cs_test_promo',
-        'id' => 'cs_test_promo'
-      )
-      allow(Stripe::Checkout::Session).to receive(:create).and_return(mock_session)
-
-      post "/billing/api/org/#{organization.extid}/checkout", {
-        product: product,
-        interval: interval,
-      }.to_json, { 'CONTENT_TYPE' => 'application/json', 'HTTP_X_CSRF_TOKEN' => csrf_token }
-
-      expect(last_response.status).to eq(200)
-
-      expect(Stripe::Checkout::Session).to have_received(:create).with(
-        hash_including(allow_promotion_codes: true),
-        anything
-      )
-    end
-
     it 'returns 400 when product is missing' do
       post "/billing/api/org/#{organization.extid}/checkout", {
         interval: interval,

--- a/apps/web/billing/spec/controllers/billing_controller_spec.rb
+++ b/apps/web/billing/spec/controllers/billing_controller_spec.rb
@@ -272,8 +272,29 @@ RSpec.describe 'Billing::Controllers::BillingController', :integration, :stripe_
       expect(Stripe::Checkout::Session).to have_received(:create).with(
         hash_including(
           mode: 'subscription',
-          client_reference_id: organization.objid
+          client_reference_id: organization.objid,
+          allow_promotion_codes: true
         ),
+        anything
+      )
+    end
+
+    it 'allows promotion codes on the checkout session' do
+      mock_session = build_checkout_session(
+        'url' => 'https://checkout.stripe.com/c/pay/cs_test_promo',
+        'id' => 'cs_test_promo'
+      )
+      allow(Stripe::Checkout::Session).to receive(:create).and_return(mock_session)
+
+      post "/billing/api/org/#{organization.extid}/checkout", {
+        product: product,
+        interval: interval,
+      }.to_json, { 'CONTENT_TYPE' => 'application/json', 'HTTP_X_CSRF_TOKEN' => csrf_token }
+
+      expect(last_response.status).to eq(200)
+
+      expect(Stripe::Checkout::Session).to have_received(:create).with(
+        hash_including(allow_promotion_codes: true),
         anything
       )
     end

--- a/apps/web/billing/spec/controllers/plans_controller_spec.rb
+++ b/apps/web/billing/spec/controllers/plans_controller_spec.rb
@@ -68,6 +68,17 @@ RSpec.describe 'Billing::Controllers::Plans', :integration, :stripe_sandbox_api,
       expect(last_response.location).to match(%r{\Ahttps://checkout\.stripe\.com/})
     end
 
+    it 'enables promotion codes on the checkout session', :vcr do
+      get "/billing/plans/#{product}/#{interval}"
+
+      expect(last_response.status).to eq(302)
+
+      session_id = last_response.location.match(%r{/pay/([^?]+)})[1]
+      session    = Stripe::Checkout::Session.retrieve(session_id)
+
+      expect(session.allow_promotion_codes).to eq(true)
+    end
+
     it 'creates checkout session with correct plan', :vcr do
       get "/billing/plans/#{product}/#{interval}"
 

--- a/apps/web/billing/spec/support/shared_contexts/with_stubbed_checkout.rb
+++ b/apps/web/billing/spec/support/shared_contexts/with_stubbed_checkout.rb
@@ -167,6 +167,7 @@ RSpec.shared_context 'with_stubbed_checkout' do
         'customer' => params[:customer],
         'client_reference_id' => params[:client_reference_id],
         'locale' => params[:locale],
+        'allow_promotion_codes' => params[:allow_promotion_codes],
         'subscription_data' => subscription_data,
         'subscription' => subscription_obj,
         'line_items' => params[:line_items]&.map { |li| li.transform_keys(&:to_s) },

--- a/apps/web/billing/spec/support/stripe_mock_factory.rb
+++ b/apps/web/billing/spec/support/stripe_mock_factory.rb
@@ -40,6 +40,7 @@ module StripeMockFactory
       'cancel_url' => 'https://example.com/cancel',
       'subscription' => nil,
       'automatic_tax' => { 'enabled' => true, 'liability' => { 'type' => 'self' }, 'status' => nil },
+      'allow_promotion_codes' => true,
       'metadata' => {},
       'customer_details' => nil,
       'client_reference_id' => nil


### PR DESCRIPTION
## Summary

Add comprehensive CLI tooling for managing Stripe coupons and promotion codes, and enable the promotion code field on Stripe-hosted checkout pages.

### Changes

**CLI Commands:**
- `bin/ots billing coupons` — List all Stripe coupons with attached active promotion codes, filterable by validity
- `bin/ots billing coupon validate <CODE>` — Validate a coupon or promotion code and report whether it's currently redeemable, including discount details, restrictions, and validity checks
- `bin/ots billing coupon` — Parent help command for coupon subcommands

**Checkout Integration:**
- Enable `allow_promotion_codes: true` on Stripe Checkout Sessions in both signup flow (`/billing/plans/:product/:interval`) and upgrade flow (`/billing/org/:extid/checkout`)
- This renders an "Add promotion code" field on the Stripe-hosted checkout page

**Documentation:**
- Added comprehensive CLI usage documentation for both commands with examples and output samples
- Added "Promotion Codes" section to stripe-configuration.md explaining how to create coupons and promotion codes in the Stripe Dashboard
- Updated billing command help text to reference new coupon commands

### Implementation Details

The `coupon validate` command:
- Accepts either a customer-facing promotion code string (e.g., `WELCOME20`) or a Stripe coupon ID
- Performs dual lookup: first tries promotion code API, falls back to coupon retrieval
- Reports comprehensive details: discount type/amount, duration, redemption counts, restrictions
- Checks validity across both coupon and promotion code (if present)
- Returns exit code 0 for valid codes, 1 for invalid/expired codes (useful for scripting)

The `coupons` command:
- Lists all coupons in a compact table format
- Shows discount, duration, redemption status, validity flag, and attached promotion codes
- Supports `--valid-only` flag to filter to currently redeemable coupons
- Supports `--limit` option for pagination

## Test Plan

Added test coverage for promotion code enablement:
- `billing_controller_spec.rb`: Tests that `allow_promotion_codes: true` is passed to Stripe API in upgrade flow
- `plans_controller_spec.rb`: Tests that promotion codes are enabled in signup flow and verifies the session property

CLI commands are tested via manual verification (not automated in this diff) but follow established patterns in the codebase using the `BillingHelpers` mixin for Stripe error handling and formatting utilities.

https://claude.ai/code/session_01ETZsCQDZnQyAS6DCTVphGs