### PR TITLE
Fix free tier TTL: align DEFAULT_FREE_TTL with free_v1 plan (14 days)

### DIFF
--- a/lib/onetime/models/features/with_entitlements.rb
+++ b/lib/onetime/models/features/with_entitlements.rb
@@ -57,10 +57,15 @@ module Onetime
         MAX_TTL = 365 * 24 * 60 * 60
 
         # Default TTL values (in seconds)
-        # Free tier max: 7 days. Paid plans or billing-disabled get 30 days.
+        # Free tier max: 14 days. Paid plans or billing-disabled get 30 days.
         # This also serves as the entitlement gate threshold — requests above
         # this value require the 'extended_default_expiration' entitlement.
-        DEFAULT_FREE_TTL = 604_800  # 7 days
+        #
+        # MUST match `free_v1.limits.secret_lifetime` in etc/billing.yaml so
+        # that a billing-enabled org with an empty planid (cache miss /
+        # unassigned) gets the same 14-day ceiling as the canonical free_v1
+        # plan. See #3111 for the drift bug this constant previously caused.
+        DEFAULT_FREE_TTL = 1_209_600  # 14 days
 
         # Full entitlement set for standalone mode
         # When billing is disabled or plan cache is empty, users get full access
@@ -123,9 +128,10 @@ module Onetime
         # Results are memoized at class level for consistent behavior and performance.
         #
         # Environment variables:
-        #   PLAN_TTL_ANONYMOUS - Maximum secret TTL for anonymous/free tier users (default: 604800 = 7 days)
+        #   PLAN_TTL_ANONYMOUS - Maximum secret TTL for anonymous/free tier users (default: 1209600 = 14 days)
         #
         # @see https://github.com/onetimesecret/onetimesecret/issues/2390
+        # @see https://github.com/onetimesecret/onetimesecret/issues/3111
         def self.free_tier_limits
           @free_tier_limits ||= {
             'organizations.max' => 5,

--- a/spec/integration/api/v2/secret_ttl_entitlement_spec.rb
+++ b/spec/integration/api/v2/secret_ttl_entitlement_spec.rb
@@ -174,6 +174,59 @@ RSpec.describe 'API V2 Secret TTL Entitlement Gate', type: :integration, billing
         expect { logic.process_params }.not_to raise_error
       end
     end
+
+    # Regression suite for #3111 — DEFAULT_FREE_TTL drifted from the
+    # free_v1 plan's 14-day secret_lifetime, so users on the free tier
+    # were being told they could only set 7 days even though the plan
+    # promises 14. These tests pin the customer-facing contract: any
+    # request from 7 days + 1 second up to and including 14 days from a
+    # free_v1 org with no extended_default_expiration entitlement must
+    # succeed without an EntitlementRequired surprise.
+    context '#3111 regression: free_v1 ceiling is 14 days, not 7 (no customer annoyance)' do
+      let(:org) do
+        mock_organization(
+          planid: 'free_v1',
+          entitlements: %w[create_secrets api_access],
+          secret_lifetime: FREE_TTL,
+        )
+      end
+
+      it 'accepts a TTL of exactly 14 days without raising' do
+        logic = create_logic(logic_class, params: conceal_params(14 * 24 * 60 * 60), org: org)
+        expect { logic.process_params }.not_to raise_error
+        expect(logic.ttl).to eq(14 * 24 * 60 * 60)
+      end
+
+      it 'accepts a TTL of 10 days (above legacy 7-day cap, within new 14-day cap)' do
+        ten_days = 10 * 24 * 60 * 60
+        logic = create_logic(logic_class, params: conceal_params(ten_days), org: org)
+        expect { logic.process_params }.not_to raise_error
+        expect(logic.ttl).to eq(ten_days)
+      end
+
+      it 'accepts a TTL of 7 days + 1 second (used to fail with #3111)' do
+        # Before the fix, this would clamp to 7 days and could trigger the
+        # entitlement gate. After the fix, 7d+1s is well below the 14d
+        # ceiling and goes through cleanly.
+        ttl = 604_800 + 1
+        logic = create_logic(logic_class, params: conceal_params(ttl), org: org)
+        expect { logic.process_params }.not_to raise_error
+        expect(logic.ttl).to eq(ttl)
+      end
+
+      it 'still rejects a TTL of 14 days + 1 second (new boundary enforced)' do
+        ttl = (14 * 24 * 60 * 60) + 1
+        logic = create_logic(logic_class, params: conceal_params(ttl), org: org)
+        expect { logic.process_params }.to raise_error(Onetime::EntitlementRequired)
+      end
+
+      it 'FREE_TTL constant resolves to 14 days' do
+        # Guards against future regressions where someone reverts the
+        # constant; this spec relies on FREE_TTL pointing at 14 days.
+        expect(FREE_TTL).to eq(14 * 24 * 60 * 60)
+        expect(FREE_TTL).to eq(1_209_600)
+      end
+    end
   end
 
   describe V2::Logic::Secrets::ConcealSecret do

--- a/spec/unit/onetime/models/features/with_entitlements_ttl_env_spec.rb
+++ b/spec/unit/onetime/models/features/with_entitlements_ttl_env_spec.rb
@@ -459,11 +459,11 @@ RSpec.describe Onetime::Models::Features::WithEntitlements do
     context 'FREE_TIER_LIMITS constant (resolved at load time)' do
       it 'secret_lifetime.max equals 14 days' do
         # The legacy constant is captured from free_tier_limits at class
-        # load. The class loaded before this spec ran, so we re-resolve
-        # to confirm the current state matches DEFAULT_FREE_TTL.
-        described_class.reset_free_tier_limits!
-        ENV.delete('PLAN_TTL_ANONYMOUS')
-        limits = described_class.free_tier_limits
+        # load. We verify the constant directly to ensure legacy callers
+        # receive the correct 14-day default. Unlike the memoized method,
+        # the constant is frozen and immutable, so this pins the load-time
+        # contract for backwards-compat consumers.
+        limits = described_class::FREE_TIER_LIMITS
         expect(limits['secret_lifetime.max']).to eq(described_class::DEFAULT_FREE_TTL)
         expect(limits['secret_lifetime.max']).to eq(1_209_600)
       end

--- a/spec/unit/onetime/models/features/with_entitlements_ttl_env_spec.rb
+++ b/spec/unit/onetime/models/features/with_entitlements_ttl_env_spec.rb
@@ -3,6 +3,8 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require 'erb'
+require 'yaml'
 
 # Unit tests for WithEntitlements TTL Environment Variable Support
 #
@@ -12,6 +14,7 @@ require 'spec_helper'
 #
 # This provides upgrade continuity with PR #2393 from main branch.
 # @see https://github.com/onetimesecret/onetimesecret/issues/2390
+# @see https://github.com/onetimesecret/onetimesecret/issues/3111
 #
 RSpec.describe Onetime::Models::Features::WithEntitlements do
   describe '.parse_ttl_env' do
@@ -159,9 +162,13 @@ RSpec.describe Onetime::Models::Features::WithEntitlements do
     end
 
     context 'when PLAN_TTL_ANONYMOUS is not set' do
-      it 'returns default secret_lifetime.max of 7 days' do
+      it 'returns default secret_lifetime.max of 14 days (matches free_v1 plan)' do
+        # See #3111: the constant must match `free_v1.limits.secret_lifetime`
+        # in etc/billing.yaml (1_209_600) so that empty-planid orgs get the
+        # same 14-day ceiling as the canonical free_v1 plan.
         limits = described_class.free_tier_limits
-        expect(limits['secret_lifetime.max']).to eq(604_800)
+        expect(limits['secret_lifetime.max']).to eq(1_209_600)
+        expect(limits['secret_lifetime.max']).to eq(14 * 24 * 60 * 60)
       end
 
       it 'returns default organization limits' do
@@ -199,9 +206,10 @@ RSpec.describe Onetime::Models::Features::WithEntitlements do
     context 'when PLAN_TTL_ANONYMOUS is invalid' do
       before { ENV['PLAN_TTL_ANONYMOUS'] = 'invalid' }
 
-      it 'falls back to default value' do
+      it 'falls back to DEFAULT_FREE_TTL (14 days)' do
         limits = described_class.free_tier_limits
-        expect(limits['secret_lifetime.max']).to eq(604_800)
+        expect(limits['secret_lifetime.max']).to eq(described_class::DEFAULT_FREE_TTL)
+        expect(limits['secret_lifetime.max']).to eq(1_209_600)
       end
     end
 
@@ -252,9 +260,43 @@ RSpec.describe Onetime::Models::Features::WithEntitlements do
   end
 
   describe 'DEFAULT_FREE_TTL constant' do
-    it 'equals 7 days in seconds' do
-      expect(described_class::DEFAULT_FREE_TTL).to eq(7 * 24 * 60 * 60)
-      expect(described_class::DEFAULT_FREE_TTL).to eq(604_800)
+    it 'equals 14 days in seconds (matches free_v1 plan)' do
+      # Regression test for #3111. The constant must match
+      # `free_v1.limits.secret_lifetime` in etc/billing.yaml so that the
+      # FREE_TIER_LIMITS fallback (used when planid is empty or cache miss)
+      # does not silently impose a stricter ceiling than the canonical
+      # free_v1 plan documented in the catalog.
+      expect(described_class::DEFAULT_FREE_TTL).to eq(14 * 24 * 60 * 60)
+      expect(described_class::DEFAULT_FREE_TTL).to eq(1_209_600)
+    end
+
+    it 'is positive' do
+      expect(described_class::DEFAULT_FREE_TTL).to be > 0
+    end
+
+    it 'is less than MAX_TTL (365 days)' do
+      expect(described_class::DEFAULT_FREE_TTL).to be < described_class::MAX_TTL
+    end
+
+    it 'is not the legacy 7-day value (regression guard for #3111)' do
+      # If this assertion ever fails, someone has reverted DEFAULT_FREE_TTL
+      # back to 604_800. That value drifts from `free_v1` in etc/billing.yaml
+      # and silently caps free-tier users at 7 days instead of 14.
+      expect(described_class::DEFAULT_FREE_TTL).not_to eq(604_800)
+    end
+
+    it 'matches the secret_lifetime declared by free_v1 in billing.example.yaml' do
+      # The example billing YAML is the documentation source-of-truth for
+      # the free tier ceiling. If this drifts, FREE_TIER_LIMITS will silently
+      # disagree with what operators read in the catalog file.
+      yaml_path = File.expand_path('../../../../../etc/examples/billing.example.yaml', __dir__)
+      raw = File.read(yaml_path)
+      processed = ERB.new(raw).result
+      config = YAML.safe_load(processed, aliases: true)
+      free_v1_lifetime = config.dig('plans', 'free_v1', 'limits', 'secret_lifetime')
+
+      expect(free_v1_lifetime).to be_a(Integer)
+      expect(described_class::DEFAULT_FREE_TTL).to eq(free_v1_lifetime)
     end
   end
 
@@ -288,8 +330,15 @@ RSpec.describe Onetime::Models::Features::WithEntitlements do
     end
 
     context 'when PLAN_TTL_ANONYMOUS is not set' do
-      it 'limit_for returns default 7 days for secret_lifetime' do
-        expect(org.limit_for('secret_lifetime')).to eq(604_800)
+      it 'limit_for returns default 14 days for secret_lifetime (#3111)' do
+        expect(org.limit_for('secret_lifetime')).to eq(1_209_600)
+        expect(org.limit_for('secret_lifetime')).to eq(described_class::DEFAULT_FREE_TTL)
+      end
+
+      it 'limit_for does NOT return the legacy 7-day cap' do
+        # Customer-annoyance regression test: a billing-enabled empty-planid
+        # org must not get the buggy 7-day cap from before #3111.
+        expect(org.limit_for('secret_lifetime')).not_to eq(604_800)
       end
     end
 
@@ -306,6 +355,134 @@ RSpec.describe Onetime::Models::Features::WithEntitlements do
 
       it 'limit_for clamps to zero' do
         expect(org.limit_for('secret_lifetime')).to eq(0)
+      end
+    end
+
+    context 'when PLAN_TTL_ANONYMOUS explicitly downgrades to legacy 7 days' do
+      # Operators who want the old 7-day cap can still opt in via env var.
+      # This protects deployments that intentionally relied on the legacy
+      # constant value before #3111 was filed.
+      before { ENV['PLAN_TTL_ANONYMOUS'] = '604800' }
+
+      it 'limit_for honors the operator override' do
+        expect(org.limit_for('secret_lifetime')).to eq(604_800)
+      end
+    end
+
+    context 'when PLAN_TTL_ANONYMOUS matches the new default exactly' do
+      before { ENV['PLAN_TTL_ANONYMOUS'] = '1209600' }
+
+      it 'limit_for returns 14 days (idempotent override)' do
+        expect(org.limit_for('secret_lifetime')).to eq(1_209_600)
+        expect(org.limit_for('secret_lifetime')).to eq(described_class::DEFAULT_FREE_TTL)
+      end
+    end
+
+    context 'symbol vs string resource keys (#3111 edge case)' do
+      # The limit_for path flattens both symbol and string resource names
+      # to "secret_lifetime.max". Both forms must agree for callers like
+      # BaseSecretAction (string) and colonel test mode (symbol).
+      it 'returns 14 days for the string form' do
+        expect(org.limit_for('secret_lifetime')).to eq(1_209_600)
+      end
+
+      it 'returns 14 days for the symbol form' do
+        expect(org.limit_for(:secret_lifetime)).to eq(1_209_600)
+      end
+
+      it 'returns the same value regardless of key form' do
+        expect(org.limit_for(:secret_lifetime)).to eq(org.limit_for('secret_lifetime'))
+      end
+    end
+  end
+
+  # Regression suite for #3111: DEFAULT_FREE_TTL drifted from the canonical
+  # `free_v1` plan in etc/billing.yaml, so a billing-enabled org with no
+  # planid (or a cache-miss planid) was getting a stricter 7-day ceiling
+  # than the published free_v1 14-day limit. These tests pin down the
+  # contract so the drift cannot silently return.
+  describe '#3111 regression: free tier TTL parity with free_v1' do
+    let(:test_class) do
+      Class.new do
+        include Onetime::Models::Features::WithEntitlements
+
+        attr_accessor :planid
+
+        def initialize(planid = nil)
+          @planid = planid
+        end
+
+        def billing_enabled?
+          true
+        end
+      end
+    end
+
+    before do
+      described_class.reset_free_tier_limits!
+    end
+
+    after do
+      ENV.delete('PLAN_TTL_ANONYMOUS')
+      described_class.reset_free_tier_limits!
+    end
+
+    context 'when planid is empty string (billing enabled, no plan assigned)' do
+      let(:org) { test_class.new('') }
+
+      it 'limit_for returns 14 days, not the legacy 7 days' do
+        expect(org.limit_for('secret_lifetime')).to eq(1_209_600)
+      end
+    end
+
+    context 'when planid is nil (billing enabled, unset)' do
+      let(:org) { test_class.new(nil) }
+
+      it 'limit_for returns 14 days, not the legacy 7 days' do
+        expect(org.limit_for('secret_lifetime')).to eq(1_209_600)
+      end
+    end
+
+    context 'when planid points to a missing plan (cache miss fallback)' do
+      let(:org) { test_class.new('definitely_not_a_real_plan_id') }
+
+      it 'limit_for returns 14 days via FREE_TIER_LIMITS fallback' do
+        # When the plan cache misses, limit_for falls through to
+        # free_tier_limit_for. With #3111 fixed, that fallback yields 14
+        # days, matching the canonical free_v1 plan rather than the
+        # legacy 7-day constant.
+        allow(OT).to receive(:lw) # suppress expected fallback warning
+        expect(org.limit_for('secret_lifetime')).to eq(1_209_600)
+      end
+    end
+
+    context 'FREE_TIER_LIMITS constant (resolved at load time)' do
+      it 'secret_lifetime.max equals 14 days' do
+        # The legacy constant is captured from free_tier_limits at class
+        # load. The class loaded before this spec ran, so we re-resolve
+        # to confirm the current state matches DEFAULT_FREE_TTL.
+        described_class.reset_free_tier_limits!
+        ENV.delete('PLAN_TTL_ANONYMOUS')
+        limits = described_class.free_tier_limits
+        expect(limits['secret_lifetime.max']).to eq(described_class::DEFAULT_FREE_TTL)
+        expect(limits['secret_lifetime.max']).to eq(1_209_600)
+      end
+    end
+
+    describe 'boundary semantics around the 14-day ceiling' do
+      let(:org) { test_class.new(nil) }
+
+      it 'returns exactly 1_209_600 at the boundary' do
+        expect(org.limit_for('secret_lifetime')).to eq(1_209_600)
+      end
+
+      it 'is strictly greater than the old 7-day value (no off-by-one)' do
+        expect(org.limit_for('secret_lifetime')).to be > 604_800
+      end
+
+      it 'is exactly twice the old 7-day value' do
+        # Documents the intent: free_v1 is "2 weeks" — twice 1 week.
+        expect(org.limit_for('secret_lifetime')).to eq(2 * 604_800)
       end
     end
   end

--- a/try/unit/models/organization_entitlements_try.rb
+++ b/try/unit/models/organization_entitlements_try.rb
@@ -93,8 +93,9 @@ OT.boot! :test
 #=> 0
 
 ## SaaS empty planid: limit_for('secret_lifetime') returns DEFAULT_FREE_TTL absent env override
+## (14 days, matching free_v1 plan in billing.yaml; see #3111)
 @org.limit_for('secret_lifetime')
-#=> 604_800
+#=> 1_209_600
 
 ## SAAS PLAN CACHE MISS TEST: billing enabled but plan not in cache returns FREE tier (graceful degradation)
 @org.planid = "nonexistent_plan_#{@timestamp}"


### PR DESCRIPTION
## Summary

[#3111](https://github.com/onetimesecret/onetimesecret/issues/3111)

The `DEFAULT_FREE_TTL` constant was set to 604,800 seconds (7 days), but the canonical `free_v1` plan in `etc/billing.yaml` specifies 1,209,600 seconds (14 days) for `secret_lifetime`. This drift caused billing-enabled organizations with no assigned plan (or cache misses) to silently receive a stricter 7-day ceiling instead of the documented 14-day free tier limit.

**Changes:**
- Updated `DEFAULT_FREE_TTL` from 604,800 (7 days) to 1,209,600 (14 days) in `lib/onetime/models/features/with_entitlements.rb`
- Added documentation explaining the constant must match the `free_v1` plan to prevent future drift
- Updated all related test expectations and added comprehensive regression tests to prevent this issue from recurring

## Related Issues

Fixes #3111

## Test Plan

Added extensive regression test suite covering:
- `DEFAULT_FREE_TTL` constant validation (14 days, matches `free_v1` plan, not legacy 7-day value)
- Free tier limits with various planid states (empty, nil, missing plan)
- Symbol vs. string resource key handling
- Boundary semantics around the 14-day ceiling
- Integration tests confirming free_v1 organizations accept TTLs up to 14 days without entitlement errors
- Operator override capability via `PLAN_TTL_ANONYMOUS` environment variable

All existing tests updated to reflect the new 14-day default. CI passes with full test coverage.

https://claude.ai/code/session_01Dao9yeztSxkxGp2h6AWktN