### PR TITLE
Refactor region configuration to use features.regions structure

### DIFF
--- a/apps/web/billing/metadata.rb
+++ b/apps/web/billing/metadata.rb
@@ -110,5 +110,26 @@ module Billing
     def self.normalize_limit(value)
       unlimited?(value) ? Float::INFINITY : value.to_i
     end
+
+    # Resolve the deployment's current region for Stripe customer metadata.
+    #
+    # Returns the configured jurisdiction (e.g., 'EU', 'US') when regions are
+    # enabled, or 'global' when regions are disabled. Raises ConfigError if
+    # regions are enabled but no jurisdiction is set — that's a deployment
+    # misconfiguration that must be corrected, not silently defaulted.
+    #
+    # @return [String] Region jurisdiction code, or 'global' if regions disabled
+    # @raise [Onetime::ConfigError] If regions enabled but jurisdiction missing
+    def self.current_region
+      return 'global' unless OT.conf&.dig('features', 'regions', 'enabled')
+
+      jurisdiction = OT.conf&.dig('features', 'regions', 'current_jurisdiction')
+      if jurisdiction.to_s.strip.empty?
+        raise Onetime::ConfigError,
+              'features.regions.enabled is true but features.regions.current_jurisdiction is not set'
+      end
+
+      jurisdiction
+    end
   end
 end

--- a/apps/web/billing/metadata.rb
+++ b/apps/web/billing/metadata.rb
@@ -121,7 +121,9 @@ module Billing
     # @return [String] Region jurisdiction code, or 'global' if regions disabled
     # @raise [Onetime::ConfigError] If regions enabled but jurisdiction missing
     def self.current_region
-      return 'global' unless OT.conf&.dig('features', 'regions', 'enabled')
+      # Compare against the string 'true' so a YAML-supplied string like
+      # "false" (which is truthy in Ruby) doesn't get treated as enabled.
+      return 'global' unless OT.conf&.dig('features', 'regions', 'enabled').to_s == 'true'
 
       jurisdiction = OT.conf&.dig('features', 'regions', 'current_jurisdiction')
       if jurisdiction.to_s.strip.empty?

--- a/apps/web/billing/operations/webhook_handlers/checkout_completed.rb
+++ b/apps/web/billing/operations/webhook_handlers/checkout_completed.rb
@@ -4,6 +4,7 @@
 
 require_relative 'base_handler'
 require 'onetime/utils/email_hash'
+require_relative '../../metadata'
 require_relative '../../../auth/operations/create_default_workspace'
 
 module Billing
@@ -197,7 +198,7 @@ module Billing
             merged_metadata   = existing_metadata.merge(
               'email_hash' => email_hash,
               'email_hash_created_at' => Time.now.to_i.to_s,
-              'region' => OT.conf.dig('site', 'region') || 'default',
+              'region' => Billing::Metadata.current_region,
             )
             Stripe::Customer.update(stripe_customer_id, metadata: merged_metadata)
 

--- a/apps/web/billing/operations/webhook_handlers/subscription_federation.rb
+++ b/apps/web/billing/operations/webhook_handlers/subscription_federation.rb
@@ -3,6 +3,7 @@
 # frozen_string_literal: true
 
 require 'onetime/utils/email_hash'
+require_relative '../../metadata'
 require_relative '../../models/pending_federated_subscription'
 require_relative '../apply_subscription_to_org'
 
@@ -170,7 +171,7 @@ module Billing
           stripe_customer_id = subscription.customer
           return if stripe_customer_id.to_s.empty?
 
-          local_region = OT.conf.dig('site', 'region') || 'unknown'
+          local_region = Billing::Metadata.current_region
           plan_id      = org.planid || 'unresolved'
           event_type   = first_federation ? 'initial' : 'update'
 

--- a/apps/web/billing/spec/operations/process_webhook_event/federation/subscription_federation_spec.rb
+++ b/apps/web/billing/spec/operations/process_webhook_event/federation/subscription_federation_spec.rb
@@ -526,7 +526,7 @@ RSpec.describe 'ProcessWebhookEvent: Subscription Federation', :integration, :pr
       before do
         # Mock OT.conf for region lookup
         allow(OT).to receive(:conf).and_return({
-          'site' => { 'region' => 'EU' },
+          'features' => { 'regions' => { 'enabled' => true, 'current_jurisdiction' => 'EU' } },
         })
       end
 
@@ -579,7 +579,7 @@ RSpec.describe 'ProcessWebhookEvent: Subscription Federation', :integration, :pr
 
     describe 'Stripe API error handling' do
       before do
-        allow(OT).to receive(:conf).and_return({ 'site' => { 'region' => 'EU' } })
+        allow(OT).to receive(:conf).and_return({ 'features' => { 'regions' => { 'enabled' => true, 'current_jurisdiction' => 'EU' } } })
 
         # Simulate Stripe API error on update
         allow(Stripe::Customer).to receive(:update)
@@ -644,7 +644,7 @@ RSpec.describe 'ProcessWebhookEvent: Subscription Federation', :integration, :pr
       end
 
       before do
-        allow(OT).to receive(:conf).and_return({ 'site' => { 'region' => 'EU' } })
+        allow(OT).to receive(:conf).and_return({ 'features' => { 'regions' => { 'enabled' => true, 'current_jurisdiction' => 'EU' } } })
       end
 
       it 'uses "unresolved" when org has no planid' do
@@ -660,7 +660,7 @@ RSpec.describe 'ProcessWebhookEvent: Subscription Federation', :integration, :pr
     describe 'idempotency (last-write-wins)' do
       before do
         allow(OT).to receive(:conf).and_return({
-          'site' => { 'region' => 'EU' },
+          'features' => { 'regions' => { 'enabled' => true, 'current_jurisdiction' => 'EU' } },
         })
       end
 
@@ -675,19 +675,34 @@ RSpec.describe 'ProcessWebhookEvent: Subscription Federation', :integration, :pr
       end
     end
 
-    describe 'region config missing' do
+    describe 'regions feature disabled' do
       before do
-        # OT.conf returns empty hash — no site/region key
+        # OT.conf returns empty hash — features.regions.enabled is falsy
         allow(OT).to receive(:conf).and_return({})
       end
 
-      it 'falls back to "unknown" when site region is not configured' do
+      it 'falls back to "global" when regions feature is disabled' do
         expect(Stripe::Customer).to receive(:update).with(
           stripe_customer_id,
-          metadata: hash_including('last_federation_region' => 'unknown')
+          metadata: hash_including('last_federation_region' => 'global')
         )
 
         handler.send(:record_federation_note, subscription, federated_org, true)
+      end
+    end
+
+    describe 'regions enabled but jurisdiction missing' do
+      before do
+        allow(OT).to receive(:conf).and_return({
+          'features' => { 'regions' => { 'enabled' => true, 'current_jurisdiction' => nil } },
+        })
+      end
+
+      it 'raises ConfigError to surface the misconfiguration' do
+        expect(Stripe::Customer).not_to receive(:update)
+        expect {
+          handler.send(:record_federation_note, subscription, federated_org, true)
+        }.to raise_error(Onetime::ConfigError, /current_jurisdiction/)
       end
     end
   end

--- a/lib/onetime/cli/migrations/backfill_stripe_email_hash_command.rb
+++ b/lib/onetime/cli/migrations/backfill_stripe_email_hash_command.rb
@@ -16,6 +16,7 @@
 # @see https://github.com/onetimesecret/onetimesecret/issues/2471
 
 require 'onetime/utils/email_hash'
+require 'billing/metadata'
 
 module Onetime
   module CLI
@@ -168,12 +169,11 @@ module Onetime
       end
 
       def update_stripe_customer(org, customer, email_hash, idx, total_orgs, dry_run, verbose)
-        region          = OT.conf.dig('site', 'region') || 'default'
         merged_metadata = customer.metadata.to_h.merge(
           'email_hash' => email_hash,
           'email_hash_created_at' => Time.now.to_i.to_s,
           'email_hash_migrated' => 'true',
-          'region' => region,
+          'region' => Billing::Metadata.current_region,
         )
 
         if dry_run


### PR DESCRIPTION
## Summary

Centralizes region/jurisdiction configuration handling by introducing a `Billing::Metadata.current_region` method that encapsulates the new configuration structure. Updates all references from the legacy `site.region` path to the new `features.regions` structure with explicit `enabled` flag and `current_jurisdiction` field.

### Changes

- **New method**: `Billing::Metadata.current_region` — resolves the deployment's current region for Stripe metadata
  - Returns `'global'` when regions feature is disabled
  - Returns the configured jurisdiction (e.g., `'EU'`, `'US'`) when enabled
  - Raises `ConfigError` if regions are enabled but `current_jurisdiction` is not set (prevents silent misconfiguration)

- **Updated configuration structure**: 
  - Old: `OT.conf['site']['region']`
  - New: `OT.conf['features']['regions']['enabled']` and `OT.conf['features']['regions']['current_jurisdiction']`

- **Updated callers**:
  - `subscription_federation.rb`: Uses `current_region` for federation notes
  - `checkout_completed.rb`: Uses `current_region` for Stripe customer metadata
  - `backfill_stripe_email_hash_command.rb`: Uses `current_region` for migration

- **Updated tests**: All test mocks now use the new configuration structure and verify both the enabled/disabled and missing jurisdiction scenarios

## Related Issues

<!-- Add issue number if applicable -->

## Test Plan

Existing test suite updated to cover:
- Regions enabled with valid jurisdiction → uses jurisdiction value
- Regions disabled → falls back to `'global'`
- Regions enabled but jurisdiction missing → raises `ConfigError`

All webhook handler and federation tests pass with new configuration structure.

https://claude.ai/code/session_01TYXTJettSJsoD2a8AS9Nh6