### PR TITLE
[#3120] Simplify plan validation: fail-closed, remove legacy detection

### DIFF
--- a/apps/web/billing/models/plan.rb
+++ b/apps/web/billing/models/plan.rb
@@ -193,7 +193,7 @@ module Billing
         missing  = REQUIRED_PRODUCT_METADATA - keys
 
         if missing.any?
-          OT.lw '[Plan.validate_product_metadata] Stripe product not managed by catalog',
+          OT.lw '[Plan.validate_product_metadata] Stripe product missing required metadata',
             {
               product_id: product.id,
               product_name: product.name,

--- a/apps/web/billing/models/plan.rb
+++ b/apps/web/billing/models/plan.rb
@@ -185,24 +185,36 @@ module Billing
 
       # Validate product has all required metadata for plan creation
       #
+      # Checks both key presence AND non-blank values for all required fields.
+      # Returns hash with :missing (keys not present) and :blank (keys with empty values).
+      #
       # @param product [Stripe::Product] The Stripe product
-      # @return [Array<String>] List of missing keys (empty if valid)
+      # @return [Hash] { missing: [...], blank: [...] } — both empty if valid
       def validate_product_metadata(product)
         metadata = product.metadata || {}
         keys     = metadata.keys.map(&:to_s)
         missing  = REQUIRED_PRODUCT_METADATA - keys
 
-        if missing.any?
-          OT.lw '[Plan.validate_product_metadata] Stripe product missing required metadata',
+        # Check present keys for blank values
+        blank = (REQUIRED_PRODUCT_METADATA - missing).select do |key|
+          metadata[key].to_s.strip.empty?
+        end
+
+        problems = []
+        problems << "missing: #{missing.join(', ')}" if missing.any?
+        problems << "blank: #{blank.join(', ')}" if blank.any?
+
+        if problems.any?
+          OT.lw '[Plan.validate_product_metadata] Stripe product invalid metadata',
             {
               product_id: product.id,
               product_name: product.name,
-              missing_keys: missing.join(', '),
+              problems: problems.join('; '),
               hint: 'Add metadata via Stripe Dashboard or `bin/ots billing products update`',
             }
         end
 
-        missing
+        { missing: missing, blank: blank }
       end
 
       # Check if product is a valid OTS product with all required metadata
@@ -212,8 +224,8 @@ module Billing
       def valid_ots_product?(product)
         return false unless product.metadata && product.metadata[Metadata::FIELD_APP] == Metadata::APP_NAME
 
-        missing = validate_product_metadata(product)
-        missing.empty?
+        result = validate_product_metadata(product)
+        result[:missing].empty? && result[:blank].empty?
       end
 
       # Check whether a Stripe product belongs to the configured region
@@ -527,23 +539,20 @@ module Billing
       # @return [Hash] Plan data ready for persistence
       # @raise [Onetime::ConfigError] If required metadata is missing or blank
       def extract_plan_data(product, price)
-        # Fail-closed: raise on missing required metadata
-        missing = validate_product_metadata(product)
-        if missing.any?
+        # Fail-closed: raise on missing or blank required metadata
+        result   = validate_product_metadata(product)
+        problems = []
+        problems << "missing: #{result[:missing].join(', ')}" if result[:missing].any?
+        problems << "blank: #{result[:blank].join(', ')}" if result[:blank].any?
+        if problems.any?
           raise Onetime::ConfigError,
-            "missing metadata for Stripe product #{product.id} (#{product.name}): #{missing.join(', ')}"
+            "invalid metadata for Stripe product #{product.id} (#{product.name}): #{problems.join('; ')}"
         end
 
-        interval = price.recurring.interval # 'month' or 'year'
-        tier     = product.metadata[Metadata::FIELD_TIER]
-        region   = product.metadata[Metadata::FIELD_REGION]
-
-        # Defense-in-depth: reject present-but-blank plan_id
+        interval     = price.recurring.interval # 'month' or 'year'
+        tier         = product.metadata[Metadata::FIELD_TIER]
+        region       = product.metadata[Metadata::FIELD_REGION]
         base_plan_id = product.metadata[Metadata::FIELD_PLAN_ID]
-        if base_plan_id.to_s.strip.empty?
-          raise Onetime::ConfigError,
-            "blank plan_id metadata for Stripe product #{product.id} (#{product.name})"
-        end
         plan_id      = "#{base_plan_id}_#{interval}ly"
 
         # Extract entitlements from product metadata

--- a/apps/web/billing/models/plan.rb
+++ b/apps/web/billing/models/plan.rb
@@ -183,11 +183,6 @@ module Billing
       # Note: 'interval' comes from the price object, not product metadata
       REQUIRED_PRODUCT_METADATA = [Metadata::FIELD_PLAN_ID, Metadata::FIELD_TIER, Metadata::FIELD_REGION].freeze
 
-      # Legacy field name variants for plan_id seen on older Stripe products.
-      # When one of these is present without `plan_id`, surface a migration
-      # hint instead of silently deriving plan identity from `tier`.
-      LEGACY_PLAN_ID_FIELDS = %w[planid plan].freeze
-
       # Validate product has all required metadata for plan creation
       #
       # @param product [Stripe::Product] The Stripe product
@@ -198,21 +193,12 @@ module Billing
         missing  = REQUIRED_PRODUCT_METADATA - keys
 
         if missing.any?
-          legacy_field = if missing.include?(Metadata::FIELD_PLAN_ID)
-                           LEGACY_PLAN_ID_FIELDS.find { |f| keys.include?(f) }
-                         end
-          hint = if legacy_field
-                   "rename Stripe metadata key '#{legacy_field}' to 'plan_id'"
-                 else
-                   'Add metadata via Stripe Dashboard or `bin/ots billing products update`'
-                 end
           OT.lw '[Plan.validate_product_metadata] Stripe product not managed by catalog',
             {
               product_id: product.id,
               product_name: product.name,
               missing_keys: missing.join(', '),
-              legacy_plan_id_field: legacy_field,
-              hint: hint,
+              hint: 'Add metadata via Stripe Dashboard or `bin/ots billing products update`',
             }
         end
 
@@ -514,7 +500,6 @@ module Billing
                 }
               next
             end
-            next if plan_data.nil? # Skip if metadata validation failed
 
             plan_data_list << plan_data
 
@@ -534,34 +519,32 @@ module Billing
 
       # Extracts plan data from Stripe product and price objects
       #
-      # @param product [Stripe::Product] Stripe product object
+      # Callers must validate product with valid_ots_product? before calling.
+      # Raises ConfigError on invalid input (missing or blank required metadata).
+      #
+      # @param product [Stripe::Product] Stripe product object (already validated)
       # @param price [Stripe::Price] Stripe price object
-      # @return [Hash, nil] Plan data ready for persistence, or nil if validation fails
+      # @return [Hash] Plan data ready for persistence
+      # @raise [Onetime::ConfigError] If required metadata is missing or blank
       def extract_plan_data(product, price)
-        # Early return if missing required metadata
+        # Fail-closed: raise on missing required metadata
         missing = validate_product_metadata(product)
         if missing.any?
-          OT.le '[Plan.extract_plan_data] Cannot extract plan data - missing metadata',
-            {
-              product_id: product.id,
-              missing_keys: missing,
-            }
-          return nil
+          raise Onetime::ConfigError,
+            "missing metadata for Stripe product #{product.id} (#{product.name}): #{missing.join(', ')}"
         end
 
         interval = price.recurring.interval # 'month' or 'year'
         tier     = product.metadata[Metadata::FIELD_TIER]
         region   = product.metadata[Metadata::FIELD_REGION]
 
-        # plan_id is required metadata (validated above). Defense-in-depth:
-        # raise rather than silently building "tier_monthly" when the key is
-        # present but blank — key-presence validation alone won't catch that.
+        # Defense-in-depth: reject present-but-blank plan_id
         base_plan_id = product.metadata[Metadata::FIELD_PLAN_ID]
-        if base_plan_id.nil? || base_plan_id.to_s.strip.empty?
+        if base_plan_id.to_s.strip.empty?
           raise Onetime::ConfigError,
-                "missing plan_id metadata for Stripe product #{product.id} (#{product.name})"
+            "blank plan_id metadata for Stripe product #{product.id} (#{product.name})"
         end
-        plan_id = "#{base_plan_id}_#{interval}ly"
+        plan_id      = "#{base_plan_id}_#{interval}ly"
 
         # Extract entitlements from product metadata
         entitlements_str = product.metadata[Metadata::FIELD_ENTITLEMENTS] || ''

--- a/apps/web/billing/operations/webhook_handlers/catalog_updated.rb
+++ b/apps/web/billing/operations/webhook_handlers/catalog_updated.rb
@@ -169,8 +169,8 @@ module Billing
           # Fetch fresh from Stripe - webhook payload is a snapshot and may be stale
           product = fetch_with_retry { Stripe::Product.retrieve(product_id) }
 
-          # Only sync OTS products (filter by app metadata)
-          return unless product.metadata['app'] == 'onetimesecret'
+          # Only sync valid OTS products (app metadata + required fields)
+          return unless Billing::Plan.valid_ots_product?(product)
 
           # Skip products from a different region when regional isolation is configured
           return unless Billing::Plan.correct_region?(product)
@@ -209,8 +209,8 @@ module Billing
           price   = fetch_with_retry { Stripe::Price.retrieve(price_id) }
           product = fetch_with_retry { Stripe::Product.retrieve(price.product) }
 
-          # Only sync OTS products
-          return unless product.metadata['app'] == 'onetimesecret'
+          # Only sync valid OTS products (app metadata + required fields)
+          return unless Billing::Plan.valid_ots_product?(product)
 
           # Skip products from a different region when regional isolation is configured
           return unless Billing::Plan.correct_region?(product)

--- a/apps/web/billing/operations/webhook_handlers/catalog_updated.rb
+++ b/apps/web/billing/operations/webhook_handlers/catalog_updated.rb
@@ -60,6 +60,14 @@ module Billing
           :success
         rescue Billing::CircuitOpenError => ex
           schedule_circuit_retry(ex)
+        rescue Onetime::ConfigError => ex
+          billing_logger.warn '[CatalogUpdated] Skipping product with invalid metadata',
+            {
+              error: ex.message,
+              event_type: @event.type,
+              object_id: @data_object.id,
+            }
+          :success
         rescue StandardError => ex
           billing_logger.error '[CatalogUpdated] Sync failed',
             {

--- a/apps/web/billing/spec/operations/process_webhook_event/catalog_updates_spec.rb
+++ b/apps/web/billing/spec/operations/process_webhook_event/catalog_updates_spec.rb
@@ -16,12 +16,12 @@ RSpec.describe 'ProcessWebhookEvent: catalog updates', :integration, :process_we
   let(:created_customers) { [] }
   let(:created_organizations) { [] }
 
-  # OTS product with proper metadata
+  # OTS product with proper metadata (all required fields for valid_ots_product?)
   let(:ots_product) do
     build_stripe_product(
       id: 'prod_ots_123',
       name: 'Identity Plus',
-      metadata: { 'app' => 'onetimesecret', 'tier' => 'identity_plus', 'region' => 'v1' }
+      metadata: { 'app' => 'onetimesecret', 'plan_id' => 'identity_plus_v1', 'tier' => 'identity_plus', 'region' => 'global' }
     )
   end
 
@@ -174,7 +174,7 @@ RSpec.describe 'ProcessWebhookEvent: catalog updates', :integration, :process_we
         build_stripe_product(
           id: 'prod_ca_999',
           name: 'Identity Plus CA',
-          metadata: { 'app' => 'onetimesecret', 'tier' => 'identity_plus', 'region' => 'CA' }
+          metadata: { 'app' => 'onetimesecret', 'plan_id' => 'identity_plus_v1', 'tier' => 'identity_plus', 'region' => 'CA' }
         )
       end
       let(:event) { build_stripe_event(type: 'product.updated', data_object: ca_product) }
@@ -264,7 +264,7 @@ RSpec.describe 'ProcessWebhookEvent: catalog updates', :integration, :process_we
         build_stripe_product(
           id: 'prod_ca_999',
           name: 'Identity Plus CA',
-          metadata: { 'app' => 'onetimesecret', 'tier' => 'identity_plus', 'region' => 'CA' }
+          metadata: { 'app' => 'onetimesecret', 'plan_id' => 'identity_plus_v1', 'tier' => 'identity_plus', 'region' => 'CA' }
         )
       end
       let(:ca_price) do

--- a/apps/web/billing/try/models/plan_extract_try.rb
+++ b/apps/web/billing/try/models/plan_extract_try.rb
@@ -8,9 +8,8 @@ require_relative '../../../../../try/support/test_helpers'
 #
 # Covers Phase 1 of the entitlement-resolution consolidation (#3120):
 # - plan_id is required on Stripe product metadata
-# - extract_plan_data no longer falls back to `tier` when plan_id is absent
-# - validate_product_metadata surfaces legacy field-name variants
-#   (`planid`, `plan`) so they get migrated rather than silently mis-resolved.
+# - extract_plan_data raises ConfigError on invalid input (fail-closed)
+# - validate_product_metadata reports missing required fields
 
 require 'apps/web/billing/models/plan'
 
@@ -56,23 +55,19 @@ product = MockProductForExtract.new(
 Billing::Plan.validate_product_metadata(product)
 #=> []
 
-## validate_product_metadata still reports plan_id as missing even when legacy `planid` is present
-product = MockProductForExtract.new(
-  id: 'prod_legacy',
-  name: 'Legacy field name',
-  metadata: { 'planid' => 'identity_plus_v1', 'tier' => 'single_team', 'region' => 'global' },
-)
-Billing::Plan.validate_product_metadata(product)
-#=> ["plan_id"]
-
-## extract_plan_data returns nil (not a tier-derived plan_id) when plan_id key is absent
+## extract_plan_data raises ConfigError when plan_id key is absent (fail-closed)
 product = MockProductForExtract.new(
   id: 'prod_missing',
   name: 'Missing plan_id',
   metadata: { 'tier' => 'single_team', 'region' => 'global' },
 )
-Billing::Plan.extract_plan_data(product, build_price)
-#=> nil
+begin
+  Billing::Plan.extract_plan_data(product, build_price)
+  :no_raise
+rescue Onetime::ConfigError => ex
+  ex.message.include?('missing metadata') ? :raised : :wrong_message
+end
+#=> :raised
 
 ## extract_plan_data raises ConfigError when plan_id key is present but blank
 product = MockProductForExtract.new(
@@ -84,7 +79,7 @@ begin
   Billing::Plan.extract_plan_data(product, build_price)
   :no_raise
 rescue Onetime::ConfigError => ex
-  ex.message.include?('missing plan_id metadata') ? :raised : :wrong_message
+  ex.message.include?('blank plan_id') ? :raised : :wrong_message
 end
 #=> :raised
 

--- a/apps/web/billing/try/models/plan_extract_try.rb
+++ b/apps/web/billing/try/models/plan_extract_try.rb
@@ -44,16 +44,16 @@ product = MockProductForExtract.new(
   metadata: { 'tier' => 'single_team', 'region' => 'global' },
 )
 Billing::Plan.validate_product_metadata(product)
-#=> ["plan_id"]
+#=> {:missing=>["plan_id"], :blank=>[]}
 
-## validate_product_metadata returns empty array when all required fields present
+## validate_product_metadata returns empty hash arrays when all required fields present
 product = MockProductForExtract.new(
   id: 'prod_ok',
   name: 'Complete',
   metadata: { 'plan_id' => 'identity_plus_v1', 'tier' => 'single_team', 'region' => 'global' },
 )
 Billing::Plan.validate_product_metadata(product)
-#=> []
+#=> {:missing=>[], :blank=>[]}
 
 ## extract_plan_data raises ConfigError when plan_id key is absent (fail-closed)
 product = MockProductForExtract.new(
@@ -65,7 +65,7 @@ begin
   Billing::Plan.extract_plan_data(product, build_price)
   :no_raise
 rescue Onetime::ConfigError => ex
-  ex.message.include?('missing metadata') ? :raised : :wrong_message
+  ex.message.include?('missing: plan_id') ? :raised : :wrong_message
 end
 #=> :raised
 
@@ -79,7 +79,7 @@ begin
   Billing::Plan.extract_plan_data(product, build_price)
   :no_raise
 rescue Onetime::ConfigError => ex
-  ex.message.include?('blank plan_id') ? :raised : :wrong_message
+  ex.message.include?('blank: plan_id') ? :raised : :wrong_message
 end
 #=> :raised
 


### PR DESCRIPTION
## Summary

Phase 1 of entitlement-resolution consolidation. Simplifies plan validation by adopting a fail-closed approach and removing legacy field detection.

- `extract_plan_data()` now raises `ConfigError` on missing/blank required metadata instead of returning `nil`
- Removed `LEGACY_PLAN_ID_FIELDS` constant that detected old field names (`planid`, `plan`)
- Webhook handlers now use `Billing::Plan.valid_ots_product?(product)` for stricter validation

## Breaking change

Products missing required metadata fields (`plan_id`, `tier`, `region`) will now raise errors instead of being silently skipped. Stripe catalog metadata migration must be complete before deploying.

## Test plan

- [ ] Existing plan validation tests pass with updated fixtures
- [ ] Catalog webhook handling rejects products with incomplete metadata
- [ ] Products with complete metadata are processed normally