### PR TITLE
[#3120] Add CatalogValidationError and fail-closed accumulation

### DIFF
--- a/apps/web/billing/cli/helpers.rb
+++ b/apps/web/billing/cli/helpers.rb
@@ -10,9 +10,6 @@ module Onetime
   module CLI
     # Base module for billing command helpers
     module BillingHelpers
-      # Use constants from Billing::Metadata module to avoid magic strings
-      REQUIRED_METADATA_FIELDS = ::Billing::Metadata::REQUIRED_FIELDS
-
       # Retry configuration for Stripe API calls
       MAX_STRIPE_RETRIES      = 3
       STRIPE_RETRY_BASE_DELAY = 2 # seconds
@@ -191,22 +188,6 @@ module Onetime
 
         dollars = amount_cents.to_f / 100
         "#{currency&.upcase || 'CAD'} #{format('%.2f', dollars)}"
-      end
-
-      def validate_product_metadata(product)
-        errors = []
-
-        REQUIRED_METADATA_FIELDS.each do |field|
-          unless product.metadata[field]
-            errors << "Missing required metadata field: #{field}"
-          end
-        end
-
-        unless product.metadata[Billing::Metadata::FIELD_APP] == Billing::Metadata::APP_NAME
-          errors << "Invalid app metadata (should be '#{Billing::Metadata::APP_NAME}')"
-        end
-
-        errors
       end
 
       def prompt_for_metadata

--- a/apps/web/billing/cli/plans_validate_command.rb
+++ b/apps/web/billing/cli/plans_validate_command.rb
@@ -120,24 +120,18 @@ module Onetime
           }
         end
 
-        # Validate required metadata
-        validate_product_metadata(product, errors)
-
-        # Check plan_id uniqueness (detect duplicates)
-        validate_plan_id_uniqueness(product, errors)
-      end
-
-      def validate_product_metadata(product, errors)
-        required_fields = %w[app plan_id tier region]
-        missing_fields  = required_fields.reject { |field| product.metadata[field] }
-
-        if missing_fields.any?
+        # Validate required metadata using canonical method
+        result = Billing::Plan.validate_product_metadata(product)
+        if result[:missing].any? || result[:blank].any?
+          problems = []
+          problems << "missing: #{result[:missing].join(', ')}" if result[:missing].any?
+          problems << "blank: #{result[:blank].join(', ')}" if result[:blank].any?
           errors << {
             product_id: product.id,
             plan_id: product.metadata['plan_id'] || 'unknown',
-            type: :missing_metadata,
-            message: 'Missing required metadata',
-            details: "Required metadata fields missing: #{missing_fields.join(', ')}",
+            type: :invalid_metadata,
+            message: 'Invalid product metadata',
+            details: problems.join('; '),
             resolution: [
               "Update product metadata: bin/ots billing products update #{product.id}",
               "See: #{stripe_dashboard_url(:product, product.id)}",
@@ -145,17 +139,8 @@ module Onetime
           }
         end
 
-        # Validate app field value
-        return unless product.metadata['app'] && product.metadata['app'] != 'onetimesecret'
-
-        errors << {
-          product_id: product.id,
-          plan_id: product.metadata['plan_id'] || 'unknown',
-          type: :invalid_app_metadata,
-          message: 'Invalid app metadata',
-          details: "Expected 'onetimesecret', got '#{product.metadata['app']}'",
-          resolution: ['Update app metadata to onetimesecret'],
-        }
+        # Check plan_id uniqueness (detect duplicates)
+        validate_plan_id_uniqueness(product, errors)
       end
 
       def validate_plan_id_uniqueness(product, errors)

--- a/apps/web/billing/cli/products_validate_command.rb
+++ b/apps/web/billing/cli/products_validate_command.rb
@@ -68,34 +68,22 @@ module Onetime
       private
 
       def validate_product(product, errors, warnings)
-        required_fields = %w[app plan_id tier region]
-        missing_fields  = required_fields.reject { |field| product.metadata[field] }
-
-        if missing_fields.any?
+        # Validate required metadata using canonical method
+        result = Billing::Plan.validate_product_metadata(product)
+        if result[:missing].any? || result[:blank].any?
+          problems = []
+          problems << "missing: #{result[:missing].join(', ')}" if result[:missing].any?
+          problems << "blank: #{result[:blank].join(', ')}" if result[:blank].any?
           errors << {
             product_id: product.id,
-            type: :missing_metadata,
-            message: 'Missing required metadata',
-            details: "Required fields missing: #{missing_fields.join(', ')}",
+            type: :invalid_metadata,
+            message: 'Invalid product metadata',
+            details: problems.join('; '),
             resolution: [
               "Update metadata: bin/ots billing products update #{product.id}",
               'Or archive if not needed',
               "See: #{stripe_dashboard_url(:product, product.id)}",
             ],
-          }
-        end
-
-        # Detect legacy/typo field name variants for plan_id
-        detect_plan_id_variants(product, warnings)
-
-        # Check for duplicate plan_ids (will be detected across all products)
-        # Individual validation just ensures plan_id exists
-        unless product.metadata['plan_id']
-          warnings << {
-            product_id: product.id,
-            type: :missing_plan_id,
-            message: 'Missing plan_id',
-            details: 'Product metadata missing plan_id field',
           }
         end
 
@@ -151,32 +139,6 @@ module Onetime
             details: "Expected integer or 'unlimited', got '#{value}'",
           }
         end
-      end
-
-      # Detect legacy or typo field name variants for plan_id
-      #
-      # @param product [Stripe::Product] The Stripe product
-      # @param warnings [Array] Warnings collection to append to
-      def detect_plan_id_variants(product, warnings)
-        metadata = product.metadata || {}
-
-        if metadata['planid']
-          warnings << {
-            product_id: product.id,
-            type: :field_variant,
-            message: "Found 'planid', expected 'plan_id'",
-            details: 'Metadata uses wrong field name (missing underscore)',
-          }
-        end
-
-        return unless metadata['plan']
-
-        warnings << {
-          product_id: product.id,
-          type: :field_variant,
-          message: "Found legacy 'plan' field, expected 'plan_id'",
-          details: 'Metadata uses deprecated field name',
-        }
       end
 
       # Check all metadata keys against canonical Metadata::FIELD_* constants

--- a/apps/web/billing/errors.rb
+++ b/apps/web/billing/errors.rb
@@ -44,6 +44,33 @@ module Billing
     end
   end
 
+  # CatalogValidationError - Raised when Stripe products fail metadata validation
+  #
+  # This error indicates managed products (app=onetimesecret) have invalid or
+  # missing required metadata. The sync aborts before upsert/prune to prevent
+  # data loss from silent skips being mistaken for legitimate deletions.
+  #
+  # All validation failures are accumulated so operators can fix everything
+  # in one pass rather than fix-one-rerun-fix-one.
+  #
+  # @example Handling validation failures
+  #   begin
+  #     Billing::Plan.refresh_from_stripe
+  #   rescue Billing::CatalogValidationError => e
+  #     e.errors.each { |err| puts "#{err[:product_id]}: #{err[:error]}" }
+  #   end
+  #
+  class CatalogValidationError < OpsProblem
+    attr_reader :errors
+
+    # @param message [String] Summary message
+    # @param errors [Array<Hash>] List of validation failures with :product_id, :price_id, :error
+    def initialize(message, errors: [])
+      @errors = errors
+      super(message)
+    end
+  end
+
   # Raised when the Stripe circuit breaker is open.
   #
   # The circuit breaker opens after consecutive Stripe API failures to prevent

--- a/apps/web/billing/metadata.rb
+++ b/apps/web/billing/metadata.rb
@@ -68,13 +68,12 @@ module Billing
       FIELD_IS_POPULAR => 'is_popular',        # Special handling: boolean
     }.freeze
 
-    # All required metadata fields
+    # Required metadata fields for plan creation (app check is separate gate)
+    # These fields must be present AND non-blank for a product to be valid.
     REQUIRED_FIELDS = [
-      FIELD_APP,
+      FIELD_PLAN_ID,
       FIELD_TIER,
-      FIELD_ENTITLEMENTS,
-      FIELD_TENANCY,
-      FIELD_CREATED,
+      FIELD_REGION,
     ].freeze
 
     # Plan IDs that represent free/unpaid tiers
@@ -128,7 +127,7 @@ module Billing
       jurisdiction = OT.conf&.dig('features', 'regions', 'current_jurisdiction')
       if jurisdiction.to_s.strip.empty?
         raise Onetime::ConfigError,
-              'features.regions.enabled is true but features.regions.current_jurisdiction is not set'
+          'features.regions.enabled is true but features.regions.current_jurisdiction is not set'
       end
 
       jurisdiction

--- a/apps/web/billing/models/plan.rb
+++ b/apps/web/billing/models/plan.rb
@@ -217,15 +217,16 @@ module Billing
         { missing: missing, blank: blank }
       end
 
-      # Check if product is a valid OTS product with all required metadata
+      # Check if product belongs to OTS (app=onetimesecret in metadata)
+      #
+      # This only checks ownership, not validity. Products belonging to OTS may
+      # still have invalid metadata; callers should use extract_plan_data for
+      # fail-closed validation.
       #
       # @param product [Stripe::Product] The Stripe product
-      # @return [Boolean] true if valid OTS product
+      # @return [Boolean] true if product has app=onetimesecret metadata
       def valid_ots_product?(product)
-        return false unless product.metadata && product.metadata[Metadata::FIELD_APP] == Metadata::APP_NAME
-
-        result = validate_product_metadata(product)
-        result[:missing].empty? && result[:blank].empty?
+        product.metadata && product.metadata[Metadata::FIELD_APP] == Metadata::APP_NAME
       end
 
       # Check whether a Stripe product belongs to the configured region
@@ -443,6 +444,7 @@ module Billing
       # @param progress [Proc, nil] Optional progress callback
       # @return [Array<Hash>] Array of plan data hashes ready for persistence
       # @raise [Stripe::StripeError] If any Stripe API call fails
+      # @raise [Billing::CatalogValidationError] If any managed products have invalid metadata
       def collect_stripe_plans(progress: nil)
         # Ensure Stripe API key is configured (required for console/CLI usage
         # where StripeSetup initializer may not have run)
@@ -457,6 +459,7 @@ module Billing
         )
 
         plan_data_list     = []
+        validation_errors  = []
         products_processed = 0
 
         progress&.call('Fetching products from Stripe...')
@@ -504,12 +507,18 @@ module Billing
             begin
               plan_data = extract_plan_data(product, price)
             rescue Onetime::ConfigError => ex
-              OT.le '[Plan.collect_stripe_plans] Skipping product with bad metadata',
+              OT.le '[Plan.collect_stripe_plans] Product failed validation',
                 {
                   product_id: product.id,
                   stripe_price_id: price.id,
                   error: ex.message,
                 }
+              validation_errors << {
+                product_id: product.id,
+                price_id: price.id,
+                product_name: product.name,
+                error: ex.message,
+              }
               next
             end
 
@@ -524,6 +533,20 @@ module Billing
         end
 
         OT.li "[Plan.collect_stripe_plans] Collected #{plan_data_list.size} plans from Stripe"
+
+        # Fail-closed: abort before returning if any managed products had invalid metadata
+        if validation_errors.any?
+          OT.le '[Plan.collect_stripe_plans] Aborting due to validation failures',
+            {
+              error_count: validation_errors.size,
+              valid_count: plan_data_list.size,
+            }
+          raise Billing::CatalogValidationError.new(
+            "#{validation_errors.size} Stripe products failed metadata validation",
+            errors: validation_errors,
+          )
+        end
+
         plan_data_list
       end
 

--- a/apps/web/billing/models/plan.rb
+++ b/apps/web/billing/models/plan.rb
@@ -488,6 +488,28 @@ module Billing
             next
           end
 
+          # Validate product metadata once before fetching prices (avoid redundant
+          # API calls and duplicate error entries for products with multiple prices)
+          result = validate_product_metadata(product)
+          if result[:missing].any? || result[:blank].any?
+            problems = []
+            problems << "missing: #{result[:missing].join(', ')}" if result[:missing].any?
+            problems << "blank: #{result[:blank].join(', ')}" if result[:blank].any?
+            OT.le '[Plan.collect_stripe_plans] Product failed metadata validation',
+              {
+                product_id: product.id,
+                product_name: product.name,
+                problems: problems.join('; '),
+              }
+            validation_errors << {
+              product_id: product.id,
+              price_id: nil,
+              product_name: product.name,
+              error: "invalid metadata: #{problems.join('; ')}",
+            }
+            next
+          end
+
           # Fetch all active prices for this product
           prices = Stripe::Price.list(
             {
@@ -501,24 +523,8 @@ module Billing
             # Skip non-recurring prices
             next unless price.type == 'recurring'
 
-            begin
-              plan_data = extract_plan_data(product, price)
-            rescue Onetime::ConfigError => ex
-              OT.le '[Plan.collect_stripe_plans] Product failed validation',
-                {
-                  product_id: product.id,
-                  stripe_price_id: price.id,
-                  error: ex.message,
-                }
-              validation_errors << {
-                product_id: product.id,
-                price_id: price.id,
-                product_name: product.name,
-                error: ex.message,
-              }
-              next
-            end
-
+            # Product metadata already validated above; extract_plan_data won't fail
+            plan_data = extract_plan_data(product, price)
             plan_data_list << plan_data
 
             OT.ld "[Plan.collect_stripe_plans] Collected plan: #{plan_data[:plan_id]}",

--- a/apps/web/billing/models/plan.rb
+++ b/apps/web/billing/models/plan.rb
@@ -179,10 +179,6 @@ module Billing
     end
 
     module ClassMethods
-      # Required metadata keys for OTS products (app check is separate)
-      # Note: 'interval' comes from the price object, not product metadata
-      REQUIRED_PRODUCT_METADATA = [Metadata::FIELD_PLAN_ID, Metadata::FIELD_TIER, Metadata::FIELD_REGION].freeze
-
       # Validate product has all required metadata for plan creation
       #
       # Checks both key presence AND non-blank values for all required fields.
@@ -191,12 +187,13 @@ module Billing
       # @param product [Stripe::Product] The Stripe product
       # @return [Hash] { missing: [...], blank: [...] } — both empty if valid
       def validate_product_metadata(product)
+        required = Metadata::REQUIRED_FIELDS
         metadata = product.metadata || {}
         keys     = metadata.keys.map(&:to_s)
-        missing  = REQUIRED_PRODUCT_METADATA - keys
+        missing  = required - keys
 
         # Check present keys for blank values
-        blank = (REQUIRED_PRODUCT_METADATA - missing).select do |key|
+        blank = (required - missing).select do |key|
           metadata[key].to_s.strip.empty?
         end
 

--- a/apps/web/billing/spec/fixtures/vcr_cassettes/Billing_Controllers_BillingController/GET/returns_list_of_available_plans.yml
+++ b/apps/web/billing/spec/fixtures/vcr_cassettes/Billing_Controllers_BillingController/GET/returns_list_of_available_plans.yml
@@ -16128,4 +16128,78 @@ http_interactions:
           "url": "/v1/prices"
         }
   recorded_at: Mon, 16 Feb 2026 12:13:57 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/prices?active=true&limit=100&product=prod_TzPUnsAuFSbODB
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/18.4.2 AIAgent/claude_code
+      Authorization:
+      - "<STRIPE_API_KEY>"
+      Stripe-Version:
+      - "<STRIPE_VERSION>"
+      X-Stripe-Client-User-Agent:
+      - '{"bindings_version":"18.4.2","lang":"ruby","lang_version":"3.4.9 p82 (2026-03-11)","platform":"arm64-darwin25","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Tundra.local 25.4.0 Darwin Kernel Version 25.4.0: Thu Mar 19 19:31:17 PDT
+        2026; root:xnu-12377.101.15~1/RELEASE_ARM64_T6020 arm64","hostname":"Tundra.local","ai_agent":"claude_code"}'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 18 May 2026 01:36:13 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '114'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        upgrade-insecure-requests
+      Vary:
+      - Origin
+      Www-Authenticate:
+      - Bearer realm="Stripe"
+      X-Robots-Tag:
+      - none
+      X-Wc:
+      - '383'
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Stripe-Version:
+      - "<STRIPE_VERSION>"
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "error": {
+            "message": "Invalid API Key provided: sk_test_mock",
+            "type": "invalid_request_error"
+          }
+        }
+  recorded_at: Mon, 18 May 2026 01:36:12 GMT
 recorded_with: VCR 6.4.0

--- a/apps/web/billing/spec/models/plan_upsert_spec.rb
+++ b/apps/web/billing/spec/models/plan_upsert_spec.rb
@@ -1273,3 +1273,216 @@ RSpec.describe 'Orphaned plan hash regression (cross-region bug)', type: :billin
     end
   end
 end
+
+# ==============================================================================
+# SECTION 4: Plan.collect_stripe_plans fail-closed validation (#3120 Phase 1)
+# ==============================================================================
+
+RSpec.describe 'Billing::Plan.send(:collect_stripe_plans) validation', type: :billing do
+  include PlanUpsertTestHelpers
+
+  # Mock Stripe objects for testing
+  let(:valid_metadata) do
+    {
+      'app' => 'onetimesecret',
+      'plan_id' => 'identity_plus_v1',
+      'tier' => 'identity',
+      'region' => 'US',
+    }
+  end
+
+  let(:invalid_metadata_missing_plan_id) do
+    {
+      'app' => 'onetimesecret',
+      'tier' => 'identity',
+      'region' => 'US',
+    }
+  end
+
+  let(:invalid_metadata_blank_plan_id) do
+    {
+      'app' => 'onetimesecret',
+      'plan_id' => '   ',
+      'tier' => 'identity',
+      'region' => 'US',
+    }
+  end
+
+  def build_mock_product(id:, name:, metadata:)
+    Stripe::StripeObject.construct_from({
+      id: id,
+      name: name,
+      description: "Description for #{name}",
+      metadata: metadata,
+      active: true,
+      marketing_features: [],
+      updated: Time.now.to_i,
+    })
+  end
+
+  def build_mock_price(id:, product_id:, interval: 'month')
+    Stripe::Price.construct_from({
+      id: id,
+      product: product_id,
+      type: 'recurring',
+      currency: 'cad',
+      unit_amount: 2900,
+      active: true,
+      billing_scheme: 'per_unit',
+      nickname: nil,
+      recurring: { interval: interval },
+    })
+  end
+
+  def mock_product_list(*products)
+    list = instance_double(Stripe::ListObject)
+    stub = allow(list).to receive(:auto_paging_each)
+    products.flatten.each { |p| stub = stub.and_yield(p) }
+    list
+  end
+
+  def mock_price_list(*prices)
+    list = instance_double(Stripe::ListObject)
+    stub = allow(list).to receive(:auto_paging_each)
+    prices.flatten.each { |p| stub = stub.and_yield(p) }
+    list
+  end
+
+  before do
+    allow(Billing::Plan).to receive(:ensure_stripe_configured!)
+    # Allow all regions to pass through (no regional isolation in tests)
+    allow(OT.billing_config).to receive(:region).and_return(nil)
+  end
+
+  # --------------------------------------------------------------------------
+  # Single product with bad metadata
+  # --------------------------------------------------------------------------
+
+  describe 'single product with bad metadata' do
+    let(:bad_product) { build_mock_product(id: 'prod_bad', name: 'Bad Product', metadata: invalid_metadata_missing_plan_id) }
+    let(:price) { build_mock_price(id: 'price_bad', product_id: 'prod_bad') }
+
+    before do
+      allow(Stripe::Product).to receive(:list).and_return(mock_product_list(bad_product))
+      allow(Stripe::Price).to receive(:list).and_return(mock_price_list(price))
+    end
+
+    it 'raises CatalogValidationError with one error' do
+      expect { Billing::Plan.send(:collect_stripe_plans) }
+        .to raise_error(Billing::CatalogValidationError) do |e|
+          expect(e.errors.size).to eq(1)
+          expect(e.errors.first[:product_id]).to eq('prod_bad')
+          expect(e.errors.first[:error]).to include('missing metadata')
+        end
+    end
+  end
+
+  # --------------------------------------------------------------------------
+  # Multiple products with bad metadata
+  # --------------------------------------------------------------------------
+
+  describe 'multiple products with bad metadata' do
+    let(:bad_product1) { build_mock_product(id: 'prod_bad1', name: 'Bad Product 1', metadata: invalid_metadata_missing_plan_id) }
+    let(:bad_product2) { build_mock_product(id: 'prod_bad2', name: 'Bad Product 2', metadata: invalid_metadata_blank_plan_id) }
+    let(:price1) { build_mock_price(id: 'price_bad1', product_id: 'prod_bad1') }
+    let(:price2) { build_mock_price(id: 'price_bad2', product_id: 'prod_bad2') }
+
+    before do
+      product_list = instance_double(Stripe::ListObject)
+      allow(product_list).to receive(:auto_paging_each).and_yield(bad_product1).and_yield(bad_product2)
+      allow(Stripe::Product).to receive(:list).and_return(product_list)
+
+      allow(Stripe::Price).to receive(:list).with(hash_including(product: 'prod_bad1')).and_return(mock_price_list(price1))
+      allow(Stripe::Price).to receive(:list).with(hash_including(product: 'prod_bad2')).and_return(mock_price_list(price2))
+    end
+
+    it 'accumulates all errors before raising' do
+      expect { Billing::Plan.send(:collect_stripe_plans) }
+        .to raise_error(Billing::CatalogValidationError) do |e|
+          expect(e.errors.size).to eq(2)
+          product_ids = e.errors.map { |err| err[:product_id] }
+          expect(product_ids).to contain_exactly('prod_bad1', 'prod_bad2')
+        end
+    end
+  end
+
+  # --------------------------------------------------------------------------
+  # Mix of good and bad products
+  # --------------------------------------------------------------------------
+
+  describe 'mix of good and bad products' do
+    let(:good_product) { build_mock_product(id: 'prod_good', name: 'Good Product', metadata: valid_metadata) }
+    let(:bad_product) { build_mock_product(id: 'prod_bad', name: 'Bad Product', metadata: invalid_metadata_missing_plan_id) }
+    let(:good_price) { build_mock_price(id: 'price_good', product_id: 'prod_good') }
+    let(:bad_price) { build_mock_price(id: 'price_bad', product_id: 'prod_bad') }
+
+    before do
+      product_list = instance_double(Stripe::ListObject)
+      allow(product_list).to receive(:auto_paging_each).and_yield(good_product).and_yield(bad_product)
+      allow(Stripe::Product).to receive(:list).and_return(product_list)
+
+      allow(Stripe::Price).to receive(:list).with(hash_including(product: 'prod_good')).and_return(mock_price_list(good_price))
+      allow(Stripe::Price).to receive(:list).with(hash_including(product: 'prod_bad')).and_return(mock_price_list(bad_price))
+    end
+
+    it 'collects valid plans then raises with bad ones' do
+      expect { Billing::Plan.send(:collect_stripe_plans) }
+        .to raise_error(Billing::CatalogValidationError) do |e|
+          expect(e.errors.size).to eq(1)
+          expect(e.errors.first[:product_id]).to eq('prod_bad')
+        end
+    end
+  end
+
+  # --------------------------------------------------------------------------
+  # All products valid
+  # --------------------------------------------------------------------------
+
+  describe 'all products valid' do
+    let(:good_product1) { build_mock_product(id: 'prod_good1', name: 'Good Product 1', metadata: valid_metadata) }
+    let(:good_product2) { build_mock_product(id: 'prod_good2', name: 'Good Product 2', metadata: valid_metadata.merge('plan_id' => 'team_plus_v1')) }
+    let(:price1) { build_mock_price(id: 'price_good1', product_id: 'prod_good1') }
+    let(:price2) { build_mock_price(id: 'price_good2', product_id: 'prod_good2') }
+
+    before do
+      product_list = instance_double(Stripe::ListObject)
+      allow(product_list).to receive(:auto_paging_each).and_yield(good_product1).and_yield(good_product2)
+      allow(Stripe::Product).to receive(:list).and_return(product_list)
+
+      allow(Stripe::Price).to receive(:list).with(hash_including(product: 'prod_good1')).and_return(mock_price_list(price1))
+      allow(Stripe::Price).to receive(:list).with(hash_including(product: 'prod_good2')).and_return(mock_price_list(price2))
+    end
+
+    it 'returns plan_data_list without raising' do
+      result = Billing::Plan.send(:collect_stripe_plans)
+      expect(result).to be_an(Array)
+      expect(result.size).to eq(2)
+      plan_ids = result.map { |d| d[:plan_id] }
+      expect(plan_ids).to contain_exactly('identity_plus_v1_monthly', 'team_plus_v1_monthly')
+    end
+  end
+
+  # --------------------------------------------------------------------------
+  # Products skipped for valid reasons (wrong app, wrong region)
+  # --------------------------------------------------------------------------
+
+  describe 'products skipped for valid reasons do not trigger validation error' do
+    let(:other_app_product) { build_mock_product(id: 'prod_other', name: 'Other App', metadata: { 'app' => 'other_app' }) }
+    let(:good_product) { build_mock_product(id: 'prod_good', name: 'Good Product', metadata: valid_metadata) }
+    let(:good_price) { build_mock_price(id: 'price_good', product_id: 'prod_good') }
+
+    before do
+      product_list = instance_double(Stripe::ListObject)
+      allow(product_list).to receive(:auto_paging_each).and_yield(other_app_product).and_yield(good_product)
+      allow(Stripe::Product).to receive(:list).and_return(product_list)
+
+      allow(Stripe::Price).to receive(:list).with(hash_including(product: 'prod_good')).and_return(mock_price_list(good_price))
+    end
+
+    it 'skips non-OTS products without error' do
+      result = Billing::Plan.send(:collect_stripe_plans)
+      expect(result.size).to eq(1)
+      expect(result.first[:plan_id]).to eq('identity_plus_v1_monthly')
+    end
+  end
+end

--- a/apps/web/billing/spec/models/plan_upsert_spec.rb
+++ b/apps/web/billing/spec/models/plan_upsert_spec.rb
@@ -1372,7 +1372,7 @@ RSpec.describe 'Billing::Plan.send(:collect_stripe_plans) validation', type: :bi
         .to raise_error(Billing::CatalogValidationError) do |e|
           expect(e.errors.size).to eq(1)
           expect(e.errors.first[:product_id]).to eq('prod_bad')
-          expect(e.errors.first[:error]).to include('missing metadata')
+          expect(e.errors.first[:error]).to include('missing: plan_id')
         end
     end
   end

--- a/apps/web/billing/try/cli/helpers_try.rb
+++ b/apps/web/billing/try/cli/helpers_try.rb
@@ -124,32 +124,3 @@ result, elapsed = helper.measure_api_time do
 end
 elapsed >= 10
 #=> true
-
-## Test: validate_product_metadata detects missing fields
-helper  = @helper_class.new
-# Mock a product with minimal metadata
-product = MockProduct.new(metadata: { 'app' => 'onetimesecret' })
-errors  = helper.validate_product_metadata(product)
-errors.any? { |e| e.include?('Missing required') }
-#=> true
-
-## Test: validate_product_metadata accepts valid app
-helper  = @helper_class.new
-product = MockProduct.new(metadata: {
-  'app' => 'onetimesecret',
-  'plan_id' => 'test_v1',
-  'tier' => 'basic',
-  'region' => 'global',
-  'entitlements' => 'test',
-  'tenancy' => 'single',
-})
-errors  = helper.validate_product_metadata(product)
-errors.none? { |e| e.include?('Invalid app metadata') }
-#=> true
-
-## Test: validate_product_metadata rejects wrong app
-helper  = @helper_class.new
-product = MockProduct.new(metadata: { 'app' => 'wrong_app' })
-errors  = helper.validate_product_metadata(product)
-errors.any? { |e| e.include?('Invalid app metadata') }
-#=> true

--- a/apps/web/billing/try/models/plan_extract_try.rb
+++ b/apps/web/billing/try/models/plan_extract_try.rb
@@ -33,8 +33,8 @@ def build_price(interval: 'month')
   )
 end
 
-## REQUIRED_PRODUCT_METADATA now includes plan_id
-Billing::Plan::ClassMethods::REQUIRED_PRODUCT_METADATA.include?('plan_id')
+## Metadata::REQUIRED_FIELDS includes plan_id (canonical source)
+Billing::Metadata::REQUIRED_FIELDS.include?('plan_id')
 #=> true
 
 ## validate_product_metadata reports plan_id as missing when absent


### PR DESCRIPTION
> **Stacked on**: #3136

## Summary

Phase 1 continuation: implements fail-closed validation during Stripe catalog sync. Instead of silently skipping products with invalid metadata (which could be mistaken for legitimate deletions), this accumulates all failures and raises a single `CatalogValidationError` with details.

Changes:
- New `CatalogValidationError` exception that collects validation failure details (product_id, price_id, error)
- `collect_stripe_plans` now accumulates errors and raises after processing all products
- `valid_ots_product?` simplified to ownership check only (full validation happens during collection)

## Test plan

- [x] 6 test scenarios covering error accumulation behavior
- [ ] Single bad product raises with 1 error
- [ ] Multiple bad products accumulates all errors  
- [ ] Mixed good/bad products processes valid ones, raises with bad
- [ ] All valid products succeeds without raising
- [ ] Skipped products (wrong app/region) don't trigger error