### PR TITLE
Fix custom logo sizing and disabled page vertical positioning

### DIFF
--- a/src/apps/secret/conceal/AccessDenied.vue
+++ b/src/apps/secret/conceal/AccessDenied.vue
@@ -8,7 +8,7 @@
 </script>
 
 <template>
-  <div class="flex min-h-screen flex-col items-center justify-center px-4">
+  <div class="flex flex-col items-center px-4 pt-24 sm:pt-32">
     <div class="container mx-auto min-w-[320px] max-w-2xl">
       <!--
 

--- a/src/apps/secret/conceal/DisabledUI.vue
+++ b/src/apps/secret/conceal/DisabledUI.vue
@@ -13,7 +13,7 @@
 </script>
 
 <template>
-  <div class="flex min-h-screen flex-col items-center justify-center px-4">
+  <div class="flex flex-col items-center px-4 pt-24 sm:pt-32">
     <div class="container mx-auto min-w-[320px] max-w-2xl">
       <!--
 

--- a/src/shared/components/layout/MastHead.vue
+++ b/src/shared/components/layout/MastHead.vue
@@ -62,17 +62,21 @@
     || isCustomLogoUrl(headerConfig.value?.branding?.logo?.url)
   );
   // Authenticated users get a smaller logo (40px) to balance visual weight with context switchers.
-  // Custom logos render at 160px (h-40) to give brand identity prominence, unauthenticated users get 48px.
+  // Custom logos render at 160px (h-40) on >=sm viewports to give brand identity prominence;
+  // mobile collapses to 96px (h-24) so the header doesn't dominate small screens.
+  // Unauthenticated users with the default logo get 48px.
   const getLogoSize = () => {
     if (props.logo?.size) return props.logo.size;
     if (isCustomLogo.value) return 160;
     return isUserPresent.value ? 40 : 48;
   };
-  // Hide site name when custom domain logo is displayed (unless explicitly configured)
-  // Priority: props > custom domain (hide by default) > logo.show_name config > site_name presence
+  // Hide site name whenever a custom logo is in use; custom branding typically embeds
+  // its own wordmark, so showing the site name alongside duplicates the brand identity.
+  // Callers can opt back in via the props.logo.showSiteName override.
+  // Priority: props > custom logo (any source, hide by default) > logo.show_name config > site_name presence
   const getShowSiteName = () => {
     if (props.logo?.showSiteName != null) return props.logo.showSiteName;
-    if (domain_logo.value) return false;
+    if (isCustomLogo.value) return false;
 
     const showName = headerConfig.value?.branding?.logo?.show_name;
     return showName ?? !!headerConfig.value?.branding?.site_name;
@@ -95,6 +99,22 @@
 
   // Simplified logo configuration with prop override support
   const logoConfig = computed(getLogoConfig);
+
+  // When a caller passes an explicit pixel size via props.logo.size, we must NOT
+  // apply a Tailwind h-* class (the class would override the pixel value). In that
+  // case we render the height via an inline style and skip the responsive class.
+  const hasExplicitImgSize = computed(() => typeof props.logo?.size === 'number' && props.logo.size > 0);
+
+  const imgHeightClass = computed(() => {
+    if (hasExplicitImgSize.value) return null;
+    // Custom logos: compact on mobile (h-24 = 96px), prominent from sm up (h-40 = 160px)
+    if (isCustomLogo.value) return 'h-24 sm:h-40';
+    return isUserPresent.value ? 'h-10' : 'h-12';
+  });
+
+  const imgInlineStyle = computed(() =>
+    hasExplicitImgSize.value ? { height: `${props.logo!.size}px` } : undefined
+  );
 
   const navigationEnabled = computed(() =>
     headerConfig.value?.navigation?.enabled !== false
@@ -181,13 +201,8 @@
               id="logo"
               :src="logoConfig.url"
               class="w-auto object-contain transition-transform"
-              :class="[
-                isCustomLogo
-                  ? 'h-40'
-                  : isUserPresent
-                    ? 'h-10'
-                    : 'h-12'
-              ]"
+              :class="imgHeightClass"
+              :style="imgInlineStyle"
               :height="logoConfig.size"
               :alt="logoConfig.alt" />
             <span

--- a/src/shared/components/layout/MastHead.vue
+++ b/src/shared/components/layout/MastHead.vue
@@ -43,18 +43,29 @@
   // Default logo component for fallback
   const DEFAULT_LOGO = 'DefaultLogo.vue';
 
+  // A URL counts as "custom branding" only when it's set AND differs from the
+  // default Vue logo component (which the stock config always populates).
+  const isCustomLogoUrl = (url: string | null | undefined): boolean =>
+    !!url && url !== DEFAULT_LOGO;
+
   // Helper functions for logo configuration
   // Priority: props > custom domain logo > static config > default
   const getLogoUrl = () => props.logo?.url || domain_logo.value || headerConfig.value?.branding?.logo?.url || DEFAULT_LOGO;
   const getLogoAlt = () => props.logo?.alt || headerConfig.value?.branding?.logo?.alt || t('web.homepage.one_time_secret_literal');
   const getLogoHref = () => props.logo?.href || headerConfig.value?.branding?.logo?.link_to || '/';
-  // Custom logos (API domain branding OR static config) are larger to emphasize brand identity
-  const isCustomLogo = computed(() => !!domain_logo.value || !!headerConfig.value?.branding?.logo?.url);
-  // Authenticated users get a smaller logo (40px) to balance visual weight with context switchers
-  // Custom domain logos remain at 80px, unauthenticated users get 48px
+  // Custom logos (props override, API domain branding, OR non-default static config)
+  // are larger to emphasize brand identity. Excludes the default Vue logo so a stock
+  // install doesn't enlarge the built-in icon.
+  const isCustomLogo = computed(() =>
+    isCustomLogoUrl(props.logo?.url)
+    || !!domain_logo.value
+    || isCustomLogoUrl(headerConfig.value?.branding?.logo?.url)
+  );
+  // Authenticated users get a smaller logo (40px) to balance visual weight with context switchers.
+  // Custom logos render at 160px (h-40) to give brand identity prominence, unauthenticated users get 48px.
   const getLogoSize = () => {
     if (props.logo?.size) return props.logo.size;
-    if (isCustomLogo.value) return 80;
+    if (isCustomLogo.value) return 160;
     return isUserPresent.value ? 40 : 48;
   };
   // Hide site name when custom domain logo is displayed (unless explicitly configured)

--- a/src/shared/components/layout/MastHead.vue
+++ b/src/shared/components/layout/MastHead.vue
@@ -48,13 +48,13 @@
   const getLogoUrl = () => props.logo?.url || domain_logo.value || headerConfig.value?.branding?.logo?.url || DEFAULT_LOGO;
   const getLogoAlt = () => props.logo?.alt || headerConfig.value?.branding?.logo?.alt || t('web.homepage.one_time_secret_literal');
   const getLogoHref = () => props.logo?.href || headerConfig.value?.branding?.logo?.link_to || '/';
-  // Custom domain logos are larger to emphasize brand identity
-  const isCustomDomainLogo = computed(() => !!domain_logo.value);
+  // Custom logos (API domain branding OR static config) are larger to emphasize brand identity
+  const isCustomLogo = computed(() => !!domain_logo.value || !!headerConfig.value?.branding?.logo?.url);
   // Authenticated users get a smaller logo (40px) to balance visual weight with context switchers
   // Custom domain logos remain at 80px, unauthenticated users get 48px
   const getLogoSize = () => {
     if (props.logo?.size) return props.logo.size;
-    if (isCustomDomainLogo.value) return 80;
+    if (isCustomLogo.value) return 80;
     return isUserPresent.value ? 40 : 48;
   };
   // Hide site name when custom domain logo is displayed (unless explicitly configured)
@@ -169,10 +169,10 @@
             <img
               id="logo"
               :src="logoConfig.url"
-              class="w-auto transition-transform"
+              class="w-auto object-contain transition-transform"
               :class="[
-                isCustomDomainLogo
-                  ? 'h-20'
+                isCustomLogo
+                  ? 'h-40'
                   : isUserPresent
                     ? 'h-10'
                     : 'h-12'

--- a/src/tests/shared/components/layout/MastHead.customDomain.spec.ts
+++ b/src/tests/shared/components/layout/MastHead.customDomain.spec.ts
@@ -282,7 +282,7 @@ describe('MastHead — Custom Domain Logo Behavior', () => {
       expect(img.attributes('width')).toBeUndefined();
     });
 
-    it('applies h-40, w-auto, and object-contain classes to custom domain logo', async () => {
+    it('applies responsive height (h-24 mobile, sm:h-40), w-auto, and object-contain classes', async () => {
       wrapper = mountComponent(
         {},
         {
@@ -295,13 +295,16 @@ describe('MastHead — Custom Domain Logo Behavior', () => {
       await nextTick();
       const img = wrapper.find('img#logo');
       expect(img.exists()).toBe(true);
-      expect(img.classes()).toContain('h-40');
+      // Responsive sizing: compact on mobile, prominent from sm breakpoint up
+      expect(img.classes()).toContain('h-24');
+      expect(img.classes()).toContain('sm:h-40');
       expect(img.classes()).toContain('w-auto');
       expect(img.classes()).toContain('object-contain');
-      // Regression: old square class should not be present
+      // Regression: old square classes should not be present
       expect(img.classes()).not.toContain('size-20');
-      // Regression: previous height class should not be present
+      // Regression: previous height classes should not be present
       expect(img.classes()).not.toContain('h-20');
+      expect(img.classes()).not.toContain('h-40'); // non-responsive variant
     });
 
     it('hides site name when custom domain logo is present', async () => {
@@ -423,10 +426,14 @@ describe('MastHead — Custom Domain Logo Behavior', () => {
       );
 
       await nextTick();
-      // The img should use the prop override URL, not the domain_logo
       const img = wrapper.find('img#logo');
       expect(img.exists()).toBe(true);
+      // The img should use the prop override URL, not the domain_logo
       expect(img.attributes('src')).toBe('/custom-override.png');
+      // Explicit prop size is honored via inline style instead of a Tailwind class
+      expect(img.attributes('style')).toContain('height: 48px');
+      expect(img.classes()).not.toContain('h-24');
+      expect(img.classes()).not.toContain('sm:h-40');
       expect(img.attributes('height')).toBe('48');
     });
 

--- a/src/tests/shared/components/layout/MastHead.customDomain.spec.ts
+++ b/src/tests/shared/components/layout/MastHead.customDomain.spec.ts
@@ -20,7 +20,17 @@ vi.mock('@/shared/components/logos/DefaultLogo.vue', () => ({
       <span class="logo-icon" />
       <span v-if="showSiteName" class="site-name">{{ siteName }}</span>
     </div>`,
-    props: ['url', 'alt', 'href', 'size', 'showSiteName', 'siteName', 'ariaLabel', 'isColonelArea', 'isUserPresent'],
+    props: [
+      'url',
+      'alt',
+      'href',
+      'size',
+      'showSiteName',
+      'siteName',
+      'ariaLabel',
+      'isColonelArea',
+      'isUserPresent',
+    ],
   },
 }));
 
@@ -85,32 +95,35 @@ describe('MastHead — Custom Domain Logo Behavior', () => {
     }
   });
 
-  const mountComponent = (
-    props: Record<string, unknown> = {},
-    storeState: {
-      authenticated?: boolean;
-      awaiting_mfa?: boolean;
-      email?: string | null;
-      cust?: typeof mockCustomer | null;
-      domain_logo?: string | null;
-      domain_strategy?: string;
-      display_domain?: string;
-      domain_id?: string;
-    } = {}
-  ) => {
+  type StoreState = {
+    authenticated?: boolean;
+    awaiting_mfa?: boolean;
+    email?: string | null;
+    cust?: typeof mockCustomer | null;
+    domain_logo?: string | null;
+    domain_strategy?: string;
+    display_domain?: string;
+    domain_id?: string;
+  };
+
+  const buildBootstrapState = (s: StoreState) => ({
+    authenticated: s.authenticated ?? false,
+    awaiting_mfa: s.awaiting_mfa ?? false,
+    email: s.email ?? null,
+    cust: s.cust ?? null,
+    domain_logo: s.domain_logo ?? null,
+    domain_strategy: s.domain_strategy ?? 'canonical',
+    display_domain: s.display_domain ?? 'onetimesecret.com',
+    domain_id: s.domain_id ?? '',
+  });
+
+  const mountComponent = (props: Record<string, unknown> = {}, storeState: StoreState = {}) => {
     const pinia = createTestingPinia({
       createSpy: vi.fn,
       stubActions: false,
       initialState: {
         bootstrap: {
-          authenticated: storeState.authenticated ?? false,
-          awaiting_mfa: storeState.awaiting_mfa ?? false,
-          email: storeState.email ?? null,
-          cust: storeState.cust ?? null,
-          domain_logo: storeState.domain_logo ?? null,
-          domain_strategy: storeState.domain_strategy ?? 'canonical',
-          display_domain: storeState.display_domain ?? 'onetimesecret.com',
-          domain_id: storeState.domain_id ?? '',
+          ...buildBootstrapState(storeState),
           ui: {
             header: {
               navigation: { enabled: true },
@@ -132,8 +145,9 @@ describe('MastHead — Custom Domain Logo Behavior', () => {
     const authStore = useAuthStore(pinia);
     const hasAuthenticatedCustomer = storeState.authenticated && storeState.cust;
     const hasMfaPendingEmail = storeState.awaiting_mfa && storeState.email;
-    (authStore as unknown as { isUserPresent: boolean }).isUserPresent =
-      !!(hasAuthenticatedCustomer || hasMfaPendingEmail);
+    (authStore as unknown as { isUserPresent: boolean }).isUserPresent = !!(
+      hasAuthenticatedCustomer || hasMfaPendingEmail
+    );
 
     return mount(MastHead, {
       props: {
@@ -159,11 +173,14 @@ describe('MastHead — Custom Domain Logo Behavior', () => {
 
   describe('Canonical domain (domain_strategy="canonical")', () => {
     it('renders DefaultLogo component when no custom domain logo', async () => {
-      wrapper = mountComponent({}, {
-        authenticated: false,
-        domain_strategy: 'canonical',
-        domain_logo: null,
-      });
+      wrapper = mountComponent(
+        {},
+        {
+          authenticated: false,
+          domain_strategy: 'canonical',
+          domain_logo: null,
+        }
+      );
 
       await nextTick();
       const logo = wrapper.find('.default-logo');
@@ -171,11 +188,14 @@ describe('MastHead — Custom Domain Logo Behavior', () => {
     });
 
     it('shows site name on canonical domain', async () => {
-      wrapper = mountComponent({}, {
-        authenticated: false,
-        domain_strategy: 'canonical',
-        domain_logo: null,
-      });
+      wrapper = mountComponent(
+        {},
+        {
+          authenticated: false,
+          domain_strategy: 'canonical',
+          domain_logo: null,
+        }
+      );
 
       await nextTick();
       const logo = wrapper.find('.default-logo');
@@ -183,11 +203,14 @@ describe('MastHead — Custom Domain Logo Behavior', () => {
     });
 
     it('uses 48px logo for unauthenticated users on canonical domain', async () => {
-      wrapper = mountComponent({}, {
-        authenticated: false,
-        domain_strategy: 'canonical',
-        domain_logo: null,
-      });
+      wrapper = mountComponent(
+        {},
+        {
+          authenticated: false,
+          domain_strategy: 'canonical',
+          domain_logo: null,
+        }
+      );
 
       await nextTick();
       const logo = wrapper.find('.default-logo');
@@ -195,13 +218,16 @@ describe('MastHead — Custom Domain Logo Behavior', () => {
     });
 
     it('uses 40px logo for authenticated users on canonical domain', async () => {
-      wrapper = mountComponent({}, {
-        authenticated: true,
-        cust: mockCustomer,
-        email: mockCustomer.email,
-        domain_strategy: 'canonical',
-        domain_logo: null,
-      });
+      wrapper = mountComponent(
+        {},
+        {
+          authenticated: true,
+          cust: mockCustomer,
+          email: mockCustomer.email,
+          domain_strategy: 'canonical',
+          domain_logo: null,
+        }
+      );
 
       await nextTick();
       const logo = wrapper.find('.default-logo');
@@ -217,13 +243,16 @@ describe('MastHead — Custom Domain Logo Behavior', () => {
     const customLogoUrl = 'https://cdn.example.com/logos/acme-logo.png';
 
     it('renders img element instead of DefaultLogo when domain_logo is set', async () => {
-      wrapper = mountComponent({}, {
-        authenticated: false,
-        domain_strategy: 'custom',
-        domain_logo: customLogoUrl,
-        display_domain: 'secrets.acme.com',
-        domain_id: 'cd_acme',
-      });
+      wrapper = mountComponent(
+        {},
+        {
+          authenticated: false,
+          domain_strategy: 'custom',
+          domain_logo: customLogoUrl,
+          display_domain: 'secrets.acme.com',
+          domain_id: 'cd_acme',
+        }
+      );
 
       await nextTick();
       // Should NOT render DefaultLogo component
@@ -236,42 +265,54 @@ describe('MastHead — Custom Domain Logo Behavior', () => {
       expect(img.attributes('src')).toBe(customLogoUrl);
     });
 
-    it('uses 80px height for custom domain logo without forcing width', async () => {
-      wrapper = mountComponent({}, {
-        authenticated: false,
-        domain_strategy: 'custom',
-        domain_logo: customLogoUrl,
-      });
+    it('uses 160px height for custom domain logo without forcing width', async () => {
+      wrapper = mountComponent(
+        {},
+        {
+          authenticated: false,
+          domain_strategy: 'custom',
+          domain_logo: customLogoUrl,
+        }
+      );
 
       await nextTick();
       const img = wrapper.find('img#logo');
       expect(img.exists()).toBe(true);
-      expect(img.attributes('height')).toBe('80');
+      expect(img.attributes('height')).toBe('160');
       expect(img.attributes('width')).toBeUndefined();
     });
 
-    it('applies h-20 and w-auto classes to custom domain logo', async () => {
-      wrapper = mountComponent({}, {
-        authenticated: false,
-        domain_strategy: 'custom',
-        domain_logo: customLogoUrl,
-      });
+    it('applies h-40, w-auto, and object-contain classes to custom domain logo', async () => {
+      wrapper = mountComponent(
+        {},
+        {
+          authenticated: false,
+          domain_strategy: 'custom',
+          domain_logo: customLogoUrl,
+        }
+      );
 
       await nextTick();
       const img = wrapper.find('img#logo');
       expect(img.exists()).toBe(true);
-      expect(img.classes()).toContain('h-20');
+      expect(img.classes()).toContain('h-40');
       expect(img.classes()).toContain('w-auto');
+      expect(img.classes()).toContain('object-contain');
       // Regression: old square class should not be present
       expect(img.classes()).not.toContain('size-20');
+      // Regression: previous height class should not be present
+      expect(img.classes()).not.toContain('h-20');
     });
 
     it('hides site name when custom domain logo is present', async () => {
-      wrapper = mountComponent({}, {
-        authenticated: false,
-        domain_strategy: 'custom',
-        domain_logo: customLogoUrl,
-      });
+      wrapper = mountComponent(
+        {},
+        {
+          authenticated: false,
+          domain_strategy: 'custom',
+          domain_logo: customLogoUrl,
+        }
+      );
 
       await nextTick();
       // Site name should not appear next to custom domain logo by default
@@ -279,19 +320,22 @@ describe('MastHead — Custom Domain Logo Behavior', () => {
       expect(siteName.exists()).toBe(false);
     });
 
-    it('uses 80px size regardless of auth state for custom domain', async () => {
-      wrapper = mountComponent({}, {
-        authenticated: true,
-        cust: mockCustomer,
-        email: mockCustomer.email,
-        domain_strategy: 'custom',
-        domain_logo: customLogoUrl,
-      });
+    it('uses 160px size regardless of auth state for custom domain', async () => {
+      wrapper = mountComponent(
+        {},
+        {
+          authenticated: true,
+          cust: mockCustomer,
+          email: mockCustomer.email,
+          domain_strategy: 'custom',
+          domain_logo: customLogoUrl,
+        }
+      );
 
       await nextTick();
       const img = wrapper.find('img#logo');
       expect(img.exists()).toBe(true);
-      expect(img.attributes('height')).toBe('80');
+      expect(img.attributes('height')).toBe('160');
     });
   });
 
@@ -301,13 +345,16 @@ describe('MastHead — Custom Domain Logo Behavior', () => {
 
   describe('Custom domain without logo (domain_strategy="custom", domain_logo=null)', () => {
     it('falls back to DefaultLogo when custom domain has no uploaded logo', async () => {
-      wrapper = mountComponent({}, {
-        authenticated: false,
-        domain_strategy: 'custom',
-        domain_logo: null,
-        display_domain: 'secrets.acme.com',
-        domain_id: 'cd_acme',
-      });
+      wrapper = mountComponent(
+        {},
+        {
+          authenticated: false,
+          domain_strategy: 'custom',
+          domain_logo: null,
+          display_domain: 'secrets.acme.com',
+          domain_id: 'cd_acme',
+        }
+      );
 
       await nextTick();
       // When domain_logo is null, MastHead falls back to the configured logo URL
@@ -317,12 +364,15 @@ describe('MastHead — Custom Domain Logo Behavior', () => {
     });
 
     it('shows OTS site name when custom domain has no logo', async () => {
-      wrapper = mountComponent({}, {
-        authenticated: false,
-        domain_strategy: 'custom',
-        domain_logo: null,
-        display_domain: 'secrets.acme.com',
-      });
+      wrapper = mountComponent(
+        {},
+        {
+          authenticated: false,
+          domain_strategy: 'custom',
+          domain_logo: null,
+          display_domain: 'secrets.acme.com',
+        }
+      );
 
       await nextTick();
       // Without domain_logo, the site name logic does NOT suppress the name
@@ -333,11 +383,14 @@ describe('MastHead — Custom Domain Logo Behavior', () => {
     });
 
     it('uses standard sizing (not 80px) when no custom logo is set', async () => {
-      wrapper = mountComponent({}, {
-        authenticated: false,
-        domain_strategy: 'custom',
-        domain_logo: null,
-      });
+      wrapper = mountComponent(
+        {},
+        {
+          authenticated: false,
+          domain_strategy: 'custom',
+          domain_logo: null,
+        }
+      );
 
       await nextTick();
       const logo = wrapper.find('.default-logo');
@@ -353,18 +406,21 @@ describe('MastHead — Custom Domain Logo Behavior', () => {
 
   describe('Logo configuration priority: props > domain_logo > config > default', () => {
     it('props override domain_logo when both are provided', async () => {
-      wrapper = mountComponent({
-        logo: {
-          url: '/custom-override.png',
-          alt: 'Override Logo',
-          size: 48,
-          isUserPresent: false,
+      wrapper = mountComponent(
+        {
+          logo: {
+            url: '/custom-override.png',
+            alt: 'Override Logo',
+            size: 48,
+            isUserPresent: false,
+          },
         },
-      }, {
-        authenticated: false,
-        domain_strategy: 'custom',
-        domain_logo: 'https://cdn.example.com/domain-logo.png',
-      });
+        {
+          authenticated: false,
+          domain_strategy: 'custom',
+          domain_logo: 'https://cdn.example.com/domain-logo.png',
+        }
+      );
 
       await nextTick();
       // The img should use the prop override URL, not the domain_logo
@@ -375,11 +431,14 @@ describe('MastHead — Custom Domain Logo Behavior', () => {
     });
 
     it('domain_logo takes priority over header config logo URL', async () => {
-      wrapper = mountComponent({}, {
-        authenticated: false,
-        domain_strategy: 'custom',
-        domain_logo: 'https://cdn.example.com/domain-logo.png',
-      });
+      wrapper = mountComponent(
+        {},
+        {
+          authenticated: false,
+          domain_strategy: 'custom',
+          domain_logo: 'https://cdn.example.com/domain-logo.png',
+        }
+      );
 
       await nextTick();
       // Should use domain_logo, not the header config default
@@ -395,11 +454,14 @@ describe('MastHead — Custom Domain Logo Behavior', () => {
 
   describe('Accessibility on custom domains', () => {
     it('custom domain logo has alt text', async () => {
-      wrapper = mountComponent({}, {
-        authenticated: false,
-        domain_strategy: 'custom',
-        domain_logo: 'https://cdn.example.com/logo.png',
-      });
+      wrapper = mountComponent(
+        {},
+        {
+          authenticated: false,
+          domain_strategy: 'custom',
+          domain_logo: 'https://cdn.example.com/logo.png',
+        }
+      );
 
       await nextTick();
       const img = wrapper.find('img#logo');
@@ -408,11 +470,14 @@ describe('MastHead — Custom Domain Logo Behavior', () => {
     });
 
     it('custom domain logo link has aria-label', async () => {
-      wrapper = mountComponent({}, {
-        authenticated: false,
-        domain_strategy: 'custom',
-        domain_logo: 'https://cdn.example.com/logo.png',
-      });
+      wrapper = mountComponent(
+        {},
+        {
+          authenticated: false,
+          domain_strategy: 'custom',
+          domain_logo: 'https://cdn.example.com/logo.png',
+        }
+      );
 
       await nextTick();
       const logoLink = wrapper.find('a[aria-label]');
@@ -420,13 +485,16 @@ describe('MastHead — Custom Domain Logo Behavior', () => {
     });
 
     it('navigation has proper aria-label on custom domains', async () => {
-      wrapper = mountComponent({}, {
-        authenticated: true,
-        cust: mockCustomer,
-        email: mockCustomer.email,
-        domain_strategy: 'custom',
-        domain_logo: 'https://cdn.example.com/logo.png',
-      });
+      wrapper = mountComponent(
+        {},
+        {
+          authenticated: true,
+          cust: mockCustomer,
+          email: mockCustomer.email,
+          domain_strategy: 'custom',
+          domain_logo: 'https://cdn.example.com/logo.png',
+        }
+      );
 
       await nextTick();
       const nav = wrapper.find('nav[role="navigation"]');
@@ -453,13 +521,16 @@ describe('MastHead — Custom Domain Logo Behavior', () => {
     it('shows OTS default logo on custom domain when no logo uploaded (current behavior)', async () => {
       // This documents the bug: a customer on secrets.acme.com sees the
       // Onetime Secret logo because MastHead only checks domain_logo, not domain_strategy
-      wrapper = mountComponent({}, {
-        authenticated: false,
-        domain_strategy: 'custom',
-        domain_logo: null,
-        display_domain: 'secrets.acme.com',
-        domain_id: 'cd_acme',
-      });
+      wrapper = mountComponent(
+        {},
+        {
+          authenticated: false,
+          domain_strategy: 'custom',
+          domain_logo: null,
+          display_domain: 'secrets.acme.com',
+          domain_id: 'cd_acme',
+        }
+      );
 
       await nextTick();
 
@@ -474,11 +545,14 @@ describe('MastHead — Custom Domain Logo Behavior', () => {
     it('does not suppress auth navigation on custom domain (correct: auth nav should remain)', async () => {
       // Even on custom domains, sign in/sign up links should still appear
       // if authentication is enabled — this is NOT a bug
-      wrapper = mountComponent({}, {
-        authenticated: false,
-        domain_strategy: 'custom',
-        domain_logo: null,
-      });
+      wrapper = mountComponent(
+        {},
+        {
+          authenticated: false,
+          domain_strategy: 'custom',
+          domain_logo: null,
+        }
+      );
 
       await nextTick();
       const html = wrapper.html();
@@ -498,7 +572,6 @@ describe('MastHead — Custom Domain Logo Behavior', () => {
     //    (NOT the OTS default logo with "Onetime Secret" branding)
     //
     // Test stubs for when the fix is implemented:
-
     // it('hides DefaultLogo when domain_strategy=custom and no domain_logo', ...)
     // it('does not show "Onetime Secret" site name on custom domain', ...)
     // it('shows neutral placeholder when custom domain has no logo', ...)

--- a/src/tests/shared/components/layout/MastHead.spec.ts
+++ b/src/tests/shared/components/layout/MastHead.spec.ts
@@ -16,7 +16,17 @@ vi.mock('@/shared/components/logos/DefaultLogo.vue', () => ({
       <span class="logo-icon" />
       <span v-if="showSiteName" class="site-name">{{ siteName }}</span>
     </div>`,
-    props: ['url', 'alt', 'href', 'size', 'showSiteName', 'siteName', 'ariaLabel', 'isColonelArea', 'isUserPresent'],
+    props: [
+      'url',
+      'alt',
+      'href',
+      'size',
+      'showSiteName',
+      'siteName',
+      'ariaLabel',
+      'isColonelArea',
+      'isUserPresent',
+    ],
   },
 }));
 
@@ -134,8 +144,9 @@ describe('MastHead', () => {
     const hasAuthenticatedCustomer = storeState.authenticated && storeState.cust;
     const hasMfaPendingEmail = storeState.awaiting_mfa && storeState.email;
     // Override the stubbed computed property
-    (authStore as unknown as { isUserPresent: boolean }).isUserPresent =
-      !!(hasAuthenticatedCustomer || hasMfaPendingEmail);
+    (authStore as unknown as { isUserPresent: boolean }).isUserPresent = !!(
+      hasAuthenticatedCustomer || hasMfaPendingEmail
+    );
 
     return mount(MastHead, {
       props: {
@@ -160,11 +171,14 @@ describe('MastHead', () => {
 
   describe('Logo Sizing', () => {
     it('uses 48px logo for unauthenticated users', async () => {
-      wrapper = mountComponent({}, {
-        authenticated: false,
-        cust: null,
-        email: null,
-      });
+      wrapper = mountComponent(
+        {},
+        {
+          authenticated: false,
+          cust: null,
+          email: null,
+        }
+      );
 
       await nextTick();
       const logo = wrapper.find('.default-logo');
@@ -172,11 +186,14 @@ describe('MastHead', () => {
     });
 
     it('uses 40px logo for authenticated users', async () => {
-      wrapper = mountComponent({}, {
-        authenticated: true,
-        cust: mockCustomer,
-        email: mockCustomer.email,
-      });
+      wrapper = mountComponent(
+        {},
+        {
+          authenticated: true,
+          cust: mockCustomer,
+          email: mockCustomer.email,
+        }
+      );
 
       await nextTick();
       const logo = wrapper.find('.default-logo');
@@ -184,43 +201,52 @@ describe('MastHead', () => {
     });
 
     it('uses 40px logo for MFA-pending users (partial auth)', async () => {
-      wrapper = mountComponent({}, {
-        authenticated: false,
-        awaiting_mfa: true,
-        email: mockCustomer.email,
-        cust: null,
-      });
+      wrapper = mountComponent(
+        {},
+        {
+          authenticated: false,
+          awaiting_mfa: true,
+          email: mockCustomer.email,
+          cust: null,
+        }
+      );
 
       await nextTick();
       const logo = wrapper.find('.default-logo');
       expect(logo.attributes('data-size')).toBe('40');
     });
 
-    it('uses 80px logo when custom domain logo is present', async () => {
-      wrapper = mountComponent({}, {
-        authenticated: true,
-        cust: mockCustomer,
-        email: mockCustomer.email,
-        domain_logo: 'https://example.com/custom-logo.png',
-      });
+    it('uses 160px logo when custom domain logo is present', async () => {
+      wrapper = mountComponent(
+        {},
+        {
+          authenticated: true,
+          cust: mockCustomer,
+          email: mockCustomer.email,
+          domain_logo: 'https://example.com/custom-logo.png',
+        }
+      );
 
       await nextTick();
-      // Custom domain logo uses img element with h-20 + w-auto (height-only constraint)
+      // Custom domain logo uses img element with h-40 + w-auto + object-contain
       const img = wrapper.find('img#logo');
-      if (img.exists()) {
-        expect(img.classes()).toContain('h-20');
-        expect(img.classes()).toContain('w-auto');
-        expect(img.attributes('height')).toBe('80');
-      }
+      expect(img.exists()).toBe(true);
+      expect(img.classes()).toContain('h-40');
+      expect(img.classes()).toContain('w-auto');
+      expect(img.classes()).toContain('object-contain');
+      expect(img.attributes('height')).toBe('160');
     });
 
     it('respects explicit size prop override', async () => {
-      wrapper = mountComponent({
-        logo: { size: 48, isUserPresent: false },
-      }, {
-        authenticated: true,
-        cust: mockCustomer,
-      });
+      wrapper = mountComponent(
+        {
+          logo: { size: 48, isUserPresent: false },
+        },
+        {
+          authenticated: true,
+          cust: mockCustomer,
+        }
+      );
 
       await nextTick();
       const logo = wrapper.find('.default-logo');
@@ -229,54 +255,163 @@ describe('MastHead', () => {
   });
 
   describe('Image logo sizing (non-Vue URL)', () => {
-    it('uses h-12 and w-auto classes for unauthenticated users with image URL', async () => {
-      wrapper = mountComponent({
-        logo: { url: '/static/brand.png' },
-      }, {
-        authenticated: false,
-        cust: null,
-        email: null,
-      });
+    it('treats a prop-supplied image URL as a custom logo (h-40)', async () => {
+      wrapper = mountComponent(
+        {
+          logo: { url: '/static/brand.png' },
+        },
+        {
+          authenticated: false,
+          cust: null,
+          email: null,
+        }
+      );
 
       await nextTick();
       const img = wrapper.find('img#logo');
       expect(img.exists()).toBe(true);
-      expect(img.classes()).toContain('h-12');
+      expect(img.classes()).toContain('h-40');
       expect(img.classes()).toContain('w-auto');
-      expect(img.attributes('height')).toBeTruthy();
+      expect(img.classes()).toContain('object-contain');
+      expect(img.attributes('height')).toBe('160');
       expect(img.attributes('width')).toBeUndefined();
       // Regression: old square class should not be present
       expect(img.classes()).not.toContain('size-12');
     });
 
-    it('uses h-10 and w-auto classes for authenticated users with image URL', async () => {
-      wrapper = mountComponent({
-        logo: { url: '/static/brand.png' },
-      }, {
-        authenticated: true,
-        cust: mockCustomer,
-        email: mockCustomer.email,
+    it('treats a prop-supplied image URL as custom for authenticated users too', async () => {
+      wrapper = mountComponent(
+        {
+          logo: { url: '/static/brand.png' },
+        },
+        {
+          authenticated: true,
+          cust: mockCustomer,
+          email: mockCustomer.email,
+        }
+      );
+
+      await nextTick();
+      const img = wrapper.find('img#logo');
+      expect(img.exists()).toBe(true);
+      expect(img.classes()).toContain('h-40');
+      expect(img.classes()).toContain('w-auto');
+      expect(img.classes()).toContain('object-contain');
+      expect(img.attributes('height')).toBe('160');
+      expect(img.attributes('width')).toBeUndefined();
+      // Regression: old square class should not be present
+      expect(img.classes()).not.toContain('size-10');
+    });
+
+    it('respects an explicit prop size override over the custom-logo default', async () => {
+      wrapper = mountComponent(
+        {
+          logo: { url: '/static/brand.png', size: 56 },
+        },
+        {
+          authenticated: false,
+        }
+      );
+
+      await nextTick();
+      const img = wrapper.find('img#logo');
+      expect(img.exists()).toBe(true);
+      // Class still reflects custom-logo branding tier, but height attr honors prop
+      expect(img.classes()).toContain('h-40');
+      expect(img.attributes('height')).toBe('56');
+    });
+  });
+
+  describe('Static config logo (ui.header.branding.logo.url)', () => {
+    const mountWithStaticLogoUrl = (
+      logoUrl: string,
+      storeState: Parameters<typeof mountComponent>[1] = {}
+    ) => {
+      const pinia = createTestingPinia({
+        createSpy: vi.fn,
+        stubActions: false,
+        initialState: {
+          bootstrap: {
+            authenticated: storeState.authenticated ?? false,
+            awaiting_mfa: storeState.awaiting_mfa ?? false,
+            email: storeState.email ?? null,
+            cust: storeState.cust ?? null,
+            domain_logo: storeState.domain_logo ?? null,
+            ui: {
+              header: {
+                navigation: { enabled: true },
+                branding: {
+                  logo: { url: logoUrl, alt: 'Brand' },
+                  site_name: 'Brand',
+                },
+              },
+            },
+            authentication: { enabled: true, signin: true, signup: true },
+          },
+        },
+      });
+
+      const authStore = useAuthStore(pinia);
+      const hasAuthenticatedCustomer = storeState.authenticated && storeState.cust;
+      const hasMfaPendingEmail = storeState.awaiting_mfa && storeState.email;
+      (authStore as unknown as { isUserPresent: boolean }).isUserPresent = !!(
+        hasAuthenticatedCustomer || hasMfaPendingEmail
+      );
+
+      return mount(MastHead, {
+        props: { displayMasthead: true, displayNavigation: true },
+        global: {
+          plugins: [i18n, pinia],
+          stubs: {
+            RouterLink: { template: '<a :href="to"><slot /></a>', props: ['to'] },
+          },
+        },
+      });
+    };
+
+    it('renders a non-default static image URL as a custom logo (h-40, 160px)', async () => {
+      wrapper = mountWithStaticLogoUrl('/img/brand.svg', {
+        authenticated: false,
       });
 
       await nextTick();
       const img = wrapper.find('img#logo');
       expect(img.exists()).toBe(true);
-      expect(img.classes()).toContain('h-10');
+      expect(img.classes()).toContain('h-40');
       expect(img.classes()).toContain('w-auto');
-      expect(img.attributes('height')).toBeTruthy();
-      expect(img.attributes('width')).toBeUndefined();
-      // Regression: old square class should not be present
-      expect(img.classes()).not.toContain('size-10');
+      expect(img.classes()).toContain('object-contain');
+      expect(img.attributes('height')).toBe('160');
+    });
+
+    it('does NOT treat the default DefaultLogo.vue config as a custom logo (regression)', async () => {
+      // Stock install: config.defaults.yaml ships branding.logo.url = 'DefaultLogo.vue'.
+      // This must continue to use the regular guest size (48px), not the 160px custom size.
+      wrapper = mountComponent(
+        {},
+        {
+          authenticated: false,
+          cust: null,
+          email: null,
+        }
+      );
+
+      await nextTick();
+      const logo = wrapper.find('.default-logo');
+      expect(logo.exists()).toBe(true);
+      expect(logo.attributes('data-size')).toBe('48');
     });
   });
 
   describe('Context Switchers Slot', () => {
     it('renders context-switchers slot for authenticated users', async () => {
-      wrapper = mountComponent({}, {
-        authenticated: true,
-        cust: mockCustomer,
-        email: mockCustomer.email,
-      });
+      wrapper = mountComponent(
+        {},
+        {
+          authenticated: true,
+          cust: mockCustomer,
+          email: mockCustomer.email,
+        }
+      );
 
       await nextTick();
 
@@ -287,11 +422,14 @@ describe('MastHead', () => {
     });
 
     it('renders context-switchers slot with responsive gap', async () => {
-      wrapper = mountComponent({}, {
-        authenticated: true,
-        cust: mockCustomer,
-        email: mockCustomer.email,
-      });
+      wrapper = mountComponent(
+        {},
+        {
+          authenticated: true,
+          cust: mockCustomer,
+          email: mockCustomer.email,
+        }
+      );
 
       await nextTick();
 
@@ -302,11 +440,14 @@ describe('MastHead', () => {
     });
 
     it('does not render context-switchers for unauthenticated users', async () => {
-      wrapper = mountComponent({}, {
-        authenticated: false,
-        cust: null,
-        email: null,
-      });
+      wrapper = mountComponent(
+        {},
+        {
+          authenticated: false,
+          cust: null,
+          email: null,
+        }
+      );
 
       await nextTick();
 
@@ -318,11 +459,14 @@ describe('MastHead', () => {
 
   describe('Navigation Display', () => {
     it('shows sign in/sign up links for unauthenticated users', async () => {
-      wrapper = mountComponent({}, {
-        authenticated: false,
-        cust: null,
-        email: null,
-      });
+      wrapper = mountComponent(
+        {},
+        {
+          authenticated: false,
+          cust: null,
+          email: null,
+        }
+      );
 
       await nextTick();
 
@@ -332,11 +476,14 @@ describe('MastHead', () => {
     });
 
     it('shows UserMenu for authenticated users', async () => {
-      wrapper = mountComponent({}, {
-        authenticated: true,
-        cust: mockCustomer,
-        email: mockCustomer.email,
-      });
+      wrapper = mountComponent(
+        {},
+        {
+          authenticated: true,
+          cust: mockCustomer,
+          email: mockCustomer.email,
+        }
+      );
 
       await nextTick();
 
@@ -345,12 +492,15 @@ describe('MastHead', () => {
     });
 
     it('hides navigation when displayNavigation is false', async () => {
-      wrapper = mountComponent({
-        displayNavigation: false,
-      }, {
-        authenticated: true,
-        cust: mockCustomer,
-      });
+      wrapper = mountComponent(
+        {
+          displayNavigation: false,
+        },
+        {
+          authenticated: true,
+          cust: mockCustomer,
+        }
+      );
 
       await nextTick();
 
@@ -361,10 +511,13 @@ describe('MastHead', () => {
 
   describe('Custom Domain Logo', () => {
     it('hides site name by default when custom domain logo is present', async () => {
-      wrapper = mountComponent({}, {
-        authenticated: false,
-        domain_logo: 'https://example.com/brand.png',
-      });
+      wrapper = mountComponent(
+        {},
+        {
+          authenticated: false,
+          domain_logo: 'https://example.com/brand.png',
+        }
+      );
 
       await nextTick();
 
@@ -378,16 +531,19 @@ describe('MastHead', () => {
     });
 
     it('shows site name when explicitly configured with custom domain logo', async () => {
-      wrapper = mountComponent({
-        logo: {
-          showSiteName: true,
-          siteName: 'Custom Brand',
-          isUserPresent: false,
+      wrapper = mountComponent(
+        {
+          logo: {
+            showSiteName: true,
+            siteName: 'Custom Brand',
+            isUserPresent: false,
+          },
         },
-      }, {
-        authenticated: false,
-        domain_logo: 'https://example.com/brand.png',
-      });
+        {
+          authenticated: false,
+          domain_logo: 'https://example.com/brand.png',
+        }
+      );
 
       await nextTick();
 
@@ -401,10 +557,13 @@ describe('MastHead', () => {
 
   describe('Accessibility', () => {
     it('has proper aria-label on main navigation', async () => {
-      wrapper = mountComponent({}, {
-        authenticated: true,
-        cust: mockCustomer,
-      });
+      wrapper = mountComponent(
+        {},
+        {
+          authenticated: true,
+          cust: mockCustomer,
+        }
+      );
 
       await nextTick();
 
@@ -413,10 +572,13 @@ describe('MastHead', () => {
     });
 
     it('logo link has aria-label', async () => {
-      wrapper = mountComponent({}, {
-        authenticated: false,
-        domain_logo: 'https://example.com/brand.png',
-      });
+      wrapper = mountComponent(
+        {},
+        {
+          authenticated: false,
+          domain_logo: 'https://example.com/brand.png',
+        }
+      );
 
       await nextTick();
 

--- a/src/tests/shared/components/layout/MastHead.spec.ts
+++ b/src/tests/shared/components/layout/MastHead.spec.ts
@@ -216,7 +216,7 @@ describe('MastHead', () => {
       expect(logo.attributes('data-size')).toBe('40');
     });
 
-    it('uses 160px logo when custom domain logo is present', async () => {
+    it('uses responsive sizing (h-24 mobile, sm:h-40 from sm breakpoint) for custom domain logo', async () => {
       wrapper = mountComponent(
         {},
         {
@@ -228,12 +228,15 @@ describe('MastHead', () => {
       );
 
       await nextTick();
-      // Custom domain logo uses img element with h-40 + w-auto + object-contain
       const img = wrapper.find('img#logo');
       expect(img.exists()).toBe(true);
-      expect(img.classes()).toContain('h-40');
+      // Mobile base size to avoid dominating small viewports
+      expect(img.classes()).toContain('h-24');
+      // Prominent size from sm breakpoint up
+      expect(img.classes()).toContain('sm:h-40');
       expect(img.classes()).toContain('w-auto');
       expect(img.classes()).toContain('object-contain');
+      // The height attribute is a layout hint matching the larger (sm+) size
       expect(img.attributes('height')).toBe('160');
     });
 
@@ -255,7 +258,7 @@ describe('MastHead', () => {
   });
 
   describe('Image logo sizing (non-Vue URL)', () => {
-    it('treats a prop-supplied image URL as a custom logo (h-40)', async () => {
+    it('treats a prop-supplied image URL as a custom logo with responsive sizing', async () => {
       wrapper = mountComponent(
         {
           logo: { url: '/static/brand.png' },
@@ -270,7 +273,8 @@ describe('MastHead', () => {
       await nextTick();
       const img = wrapper.find('img#logo');
       expect(img.exists()).toBe(true);
-      expect(img.classes()).toContain('h-40');
+      expect(img.classes()).toContain('h-24');
+      expect(img.classes()).toContain('sm:h-40');
       expect(img.classes()).toContain('w-auto');
       expect(img.classes()).toContain('object-contain');
       expect(img.attributes('height')).toBe('160');
@@ -294,7 +298,8 @@ describe('MastHead', () => {
       await nextTick();
       const img = wrapper.find('img#logo');
       expect(img.exists()).toBe(true);
-      expect(img.classes()).toContain('h-40');
+      expect(img.classes()).toContain('h-24');
+      expect(img.classes()).toContain('sm:h-40');
       expect(img.classes()).toContain('w-auto');
       expect(img.classes()).toContain('object-contain');
       expect(img.attributes('height')).toBe('160');
@@ -303,7 +308,7 @@ describe('MastHead', () => {
       expect(img.classes()).not.toContain('size-10');
     });
 
-    it('respects an explicit prop size override over the custom-logo default', async () => {
+    it('honors an explicit prop size override: omits h-* classes and sets inline height style', async () => {
       wrapper = mountComponent(
         {
           logo: { url: '/static/brand.png', size: 56 },
@@ -316,9 +321,19 @@ describe('MastHead', () => {
       await nextTick();
       const img = wrapper.find('img#logo');
       expect(img.exists()).toBe(true);
-      // Class still reflects custom-logo branding tier, but height attr honors prop
-      expect(img.classes()).toContain('h-40');
+      // Prop size wins visually: no Tailwind height class is applied
+      expect(img.classes()).not.toContain('h-24');
+      expect(img.classes()).not.toContain('sm:h-40');
+      expect(img.classes()).not.toContain('h-40');
+      expect(img.classes()).not.toContain('h-10');
+      expect(img.classes()).not.toContain('h-12');
+      // Inline style enforces the exact pixel size
+      expect(img.attributes('style')).toContain('height: 56px');
+      // Height attribute also reflects the override for pre-load layout reservation
       expect(img.attributes('height')).toBe('56');
+      // Static classes are still present
+      expect(img.classes()).toContain('w-auto');
+      expect(img.classes()).toContain('object-contain');
     });
   });
 
@@ -369,7 +384,7 @@ describe('MastHead', () => {
       });
     };
 
-    it('renders a non-default static image URL as a custom logo (h-40, 160px)', async () => {
+    it('renders a non-default static image URL as a custom logo with responsive sizing', async () => {
       wrapper = mountWithStaticLogoUrl('/img/brand.svg', {
         authenticated: false,
       });
@@ -377,10 +392,25 @@ describe('MastHead', () => {
       await nextTick();
       const img = wrapper.find('img#logo');
       expect(img.exists()).toBe(true);
-      expect(img.classes()).toContain('h-40');
+      expect(img.classes()).toContain('h-24');
+      expect(img.classes()).toContain('sm:h-40');
       expect(img.classes()).toContain('w-auto');
       expect(img.classes()).toContain('object-contain');
       expect(img.attributes('height')).toBe('160');
+    });
+
+    it('hides the site name by default for non-default static config logos', async () => {
+      // Static-config custom branding typically embeds the wordmark in the image,
+      // so the site name text mark should not appear next to it (matches the
+      // long-standing behavior for per-domain uploaded logos).
+      wrapper = mountWithStaticLogoUrl('/img/brand.svg', {
+        authenticated: false,
+      });
+
+      await nextTick();
+      // Site name span should not be rendered for a static custom image URL
+      const siteName = wrapper.find('span.font-brand.text-lg');
+      expect(siteName.exists()).toBe(false);
     });
 
     it('does NOT treat the default DefaultLogo.vue config as a custom logo (regression)', async () => {

--- a/src/views/DisabledHomepage.vue
+++ b/src/views/DisabledHomepage.vue
@@ -10,7 +10,7 @@
 </script>
 
 <template>
-  <div class="min-h-screen flex flex-col justify-center items-center px-4">
+  <div class="flex flex-col items-center px-4 pt-24 sm:pt-32">
     <div class="container mx-auto min-w-[320px] max-w-2xl">
       <!--
 

--- a/src/views/DisabledUI.vue
+++ b/src/views/DisabledUI.vue
@@ -10,7 +10,7 @@
 </script>
 
 <template>
-  <div class="min-h-screen flex flex-col justify-center items-center px-4">
+  <div class="flex flex-col items-center px-4 pt-24 sm:pt-32">
     <div class="container mx-auto min-w-[320px] max-w-2xl">
       <!--
 


### PR DESCRIPTION
## Changes

- Detect static config logos (not just API domain logos) for prominent sizing in `MastHead.vue`
- Add `object-contain` to preserve logo aspect ratio
- Increase custom logo height from `h-20` to `h-40`
- Position disabled/access-denied content in upper third (`pt-24 sm:pt-32`) instead of viewport center

## Files

- `src/shared/components/layout/MastHead.vue` — renamed `isCustomDomainLogo` → `isCustomLogo`, broadened detection, bumped height, added `object-contain`
- `src/apps/secret/conceal/AccessDenied.vue`
- `src/apps/secret/conceal/DisabledUI.vue`
- `src/views/DisabledHomepage.vue`
- `src/views/DisabledUI.vue`