### PR TITLE
Fix logo sizing for authenticated users and add LOGO_PROMINENT config

### DIFF
--- a/.env.reference
+++ b/.env.reference
@@ -332,6 +332,13 @@ UI_HOMEPAGE_TRUSTED_IP_HEADER=
 # Set to 'false' to display icon-only while keeping SITE_NAME for titles and MFA.
 #LOGO_SHOW_NAME=true
 
+# Render custom logos at a larger size in authenticated views.
+# When true, authenticated users see an 80px logo instead of the compact 40px.
+# Useful for rasterized brand assets that need more visual presence alongside
+# the org/domain context switchers. Unauthenticated views always use the
+# prominent treatment (160px) for custom logos regardless of this setting.
+#LOGO_PROMINENT=false
+
 
 # ═══════════════════════════════════════════════════════════
 #  LOGGING & DIAGNOSTICS

--- a/etc/defaults/config.defaults.yaml
+++ b/etc/defaults/config.defaults.yaml
@@ -96,6 +96,14 @@ site:
             # Set false for icon-only display; SITE_NAME remains active
             # in page titles, MFA labels, and emails regardless.
             show_name: <%= ENV['LOGO_SHOW_NAME'] != 'false' %>
+            # Render the logo at a larger size in the authenticated header.
+            # Useful for rasterized brand assets (e.g. LOGO_URL=/img/brand.png)
+            # that need more visual presence alongside the org/domain switchers.
+            # The default (false) keeps the logo compact (40px) so context
+            # switchers fit on the same row. When true, custom logos render at
+            # 80px in authenticated views. Unauthenticated views (branded
+            # homepage / disabled page) always render the logo prominently.
+            prominent: <%= ENV['LOGO_PROMINENT'] == 'true' %>
           # Product name used across the application:
           #   - Masthead text mark (when logo.show_name is true)
           #   - Browser page title

--- a/src/schemas/contracts/bootstrap.ts
+++ b/src/schemas/contracts/bootstrap.ts
@@ -74,6 +74,12 @@ export const headerLogoSchema = z.object({
   alt: z.string().default(''),
   link_to: z.string().default('/'),
   show_name: z.boolean().optional(),
+  /**
+   * When true, render the logo at a larger size in the authenticated header.
+   * Useful for rasterized brand assets that need visual presence alongside
+   * the org/domain switchers. Defaults to false (compact 40px logo).
+   */
+  prominent: z.boolean().optional(),
 });
 
 export const headerBrandingSchema = z.object({

--- a/src/schemas/contracts/config/config.ts
+++ b/src/schemas/contracts/config/config.ts
@@ -67,8 +67,8 @@ export const apiInterfaceSchema = z.object({
                   alt: z.string().optional(),
                   href: z.string().optional(),
                   link_to: z.string().optional(), // Legacy field
-                  show_name: z.boolean().optional(),
-                  prominent: z.boolean().optional(),
+                  show_name: booleanOrString,
+                  prominent: booleanOrString,
                 })
                 .optional(),
               site_name: z.string().optional(),

--- a/src/schemas/contracts/config/config.ts
+++ b/src/schemas/contracts/config/config.ts
@@ -67,6 +67,8 @@ export const apiInterfaceSchema = z.object({
                   alt: z.string().optional(),
                   href: z.string().optional(),
                   link_to: z.string().optional(), // Legacy field
+                  show_name: z.boolean().optional(),
+                  prominent: z.boolean().optional(),
                 })
                 .optional(),
               site_name: z.string().optional(),

--- a/src/schemas/contracts/config/section/ui.ts
+++ b/src/schemas/contracts/config/section/ui.ts
@@ -17,6 +17,7 @@ const userInterfaceLogoSchema = z.object({
   alt: z.string().optional(),
   href: z.string().optional(),
   show_name: z.boolean().optional(),
+  prominent: z.boolean().optional(),
 });
 
 /**

--- a/src/shared/components/layout/MastHead.vue
+++ b/src/shared/components/layout/MastHead.vue
@@ -61,14 +61,21 @@
     || !!domain_logo.value
     || isCustomLogoUrl(headerConfig.value?.branding?.logo?.url)
   );
-  // Authenticated users get a smaller logo (40px) to balance visual weight with context switchers.
-  // Custom logos render at 160px (h-40) on >=sm viewports to give brand identity prominence;
-  // mobile collapses to 96px (h-24) so the header doesn't dominate small screens.
-  // Unauthenticated users with the default logo get 48px.
+  // Opt-in flag for operators who want custom logos to render larger in authenticated views.
+  // Useful for rasterized brand assets that need visual presence alongside context switchers.
+  const isProminentLogo = computed(() =>
+    headerConfig.value?.branding?.logo?.prominent === true
+  );
+  // Authenticated users get a compact 40px logo by default so the org/domain context
+  // switchers (rendered inline in the same flex row) have room and don't wrap below.
+  // When prominent is enabled, authenticated users get an intermediate 80px size.
+  // Unauthenticated users with a custom logo always get the prominent 160px treatment
+  // for branded homepage / disabled views; unauthenticated default gets 48px.
   const getLogoSize = () => {
     if (props.logo?.size) return props.logo.size;
+    if (isUserPresent.value) return isProminentLogo.value ? 80 : 40;
     if (isCustomLogo.value) return 160;
-    return isUserPresent.value ? 40 : 48;
+    return 48;
   };
   // Hide site name whenever a custom logo is in use; custom branding typically embeds
   // its own wordmark, so showing the site name alongside duplicates the brand identity.
@@ -107,9 +114,11 @@
 
   const imgHeightClass = computed(() => {
     if (hasExplicitImgSize.value) return null;
-    // Custom logos: compact on mobile (h-24 = 96px), prominent from sm up (h-40 = 160px)
+    // Authenticated: compact by default (h-10 = 40px), or intermediate when prominent (h-20 = 80px)
+    if (isUserPresent.value) return isProminentLogo.value ? 'h-20' : 'h-10';
+    // Unauthenticated custom logo: compact on mobile (h-24 = 96px), prominent from sm up (h-40 = 160px)
     if (isCustomLogo.value) return 'h-24 sm:h-40';
-    return isUserPresent.value ? 'h-10' : 'h-12';
+    return 'h-12';
   });
 
   const imgInlineStyle = computed(() =>

--- a/src/shared/components/layout/MastHead.vue
+++ b/src/shared/components/layout/MastHead.vue
@@ -43,39 +43,31 @@
   // Default logo component for fallback
   const DEFAULT_LOGO = 'DefaultLogo.vue';
 
-  // A URL counts as "custom branding" only when it's set AND differs from the
-  // default Vue logo component (which the stock config always populates).
-  const isCustomLogoUrl = (url: string | null | undefined): boolean =>
-    !!url && url !== DEFAULT_LOGO;
-
   // Helper functions for logo configuration
   // Priority: props > custom domain logo > static config > default
   const getLogoUrl = () => props.logo?.url || domain_logo.value || headerConfig.value?.branding?.logo?.url || DEFAULT_LOGO;
   const getLogoAlt = () => props.logo?.alt || headerConfig.value?.branding?.logo?.alt || t('web.homepage.one_time_secret_literal');
   const getLogoHref = () => props.logo?.href || headerConfig.value?.branding?.logo?.link_to || '/';
-  // Custom logos (props override, API domain branding, OR non-default static config)
-  // are larger to emphasize brand identity. Excludes the default Vue logo so a stock
-  // install doesn't enlarge the built-in icon.
+
+  // Custom logo detection (used only for site name visibility, not sizing).
+  // Domain branding or external URLs typically embed their own wordmark.
   const isCustomLogo = computed(() =>
-    isCustomLogoUrl(props.logo?.url)
-    || !!domain_logo.value
-    || isCustomLogoUrl(headerConfig.value?.branding?.logo?.url)
+    !!domain_logo.value
+    || (!!headerConfig.value?.branding?.logo?.url && headerConfig.value.branding.logo.url !== DEFAULT_LOGO)
   );
-  // Opt-in flag for operators who want custom logos to render larger in authenticated views.
-  // Useful for rasterized brand assets that need visual presence alongside context switchers.
+
+  // LOGO_PROMINENT opt-in for larger logo sizing.
   const isProminentLogo = computed(() =>
     headerConfig.value?.branding?.logo?.prominent === true
   );
-  // Authenticated users get a compact 40px logo by default so the org/domain context
-  // switchers (rendered inline in the same flex row) have room and don't wrap below.
-  // When prominent is enabled, authenticated users get an intermediate 80px size.
-  // Unauthenticated users with a custom logo always get the prominent 160px treatment
-  // for branded homepage / disabled views; unauthenticated default gets 48px.
+
+  // Logo sizing: LOGO_PROMINENT controls size, auth state determines the tier.
+  // Default (prominent=false): 48px unauthenticated, 40px authenticated
+  // Prominent (prominent=true): 160px unauthenticated, 80px authenticated
   const getLogoSize = () => {
     if (props.logo?.size) return props.logo.size;
-    if (isUserPresent.value) return isProminentLogo.value ? 80 : 40;
-    if (isCustomLogo.value) return 160;
-    return 48;
+    if (isProminentLogo.value) return isUserPresent.value ? 80 : 160;
+    return isUserPresent.value ? 40 : 48;
   };
   // Hide site name whenever a custom logo is in use; custom branding typically embeds
   // its own wordmark, so showing the site name alongside duplicates the brand identity.
@@ -112,13 +104,13 @@
   // case we render the height via an inline style and skip the responsive class.
   const hasExplicitImgSize = computed(() => typeof props.logo?.size === 'number' && props.logo.size > 0);
 
+  // Tailwind height classes mirror getLogoSize() logic.
+  // Prominent: h-20 (80px) authenticated, h-24/sm:h-40 (96px mobile, 160px desktop) unauthenticated
+  // Default: h-10 (40px) authenticated, h-12 (48px) unauthenticated
   const imgHeightClass = computed(() => {
     if (hasExplicitImgSize.value) return null;
-    // Authenticated: compact by default (h-10 = 40px), or intermediate when prominent (h-20 = 80px)
-    if (isUserPresent.value) return isProminentLogo.value ? 'h-20' : 'h-10';
-    // Unauthenticated custom logo: compact on mobile (h-24 = 96px), prominent from sm up (h-40 = 160px)
-    if (isCustomLogo.value) return 'h-24 sm:h-40';
-    return 'h-12';
+    if (isProminentLogo.value) return isUserPresent.value ? 'h-20' : 'h-24 sm:h-40';
+    return isUserPresent.value ? 'h-10' : 'h-12';
   });
 
   const imgInlineStyle = computed(() =>

--- a/src/tests/shared/components/layout/MastHead.customDomain.spec.ts
+++ b/src/tests/shared/components/layout/MastHead.customDomain.spec.ts
@@ -265,7 +265,7 @@ describe('MastHead — Custom Domain Logo Behavior', () => {
       expect(img.attributes('src')).toBe(customLogoUrl);
     });
 
-    it('uses 160px height for custom domain logo without forcing width', async () => {
+    it('uses default 48px height for custom domain logo when prominent is not set', async () => {
       wrapper = mountComponent(
         {},
         {
@@ -278,11 +278,12 @@ describe('MastHead — Custom Domain Logo Behavior', () => {
       await nextTick();
       const img = wrapper.find('img#logo');
       expect(img.exists()).toBe(true);
-      expect(img.attributes('height')).toBe('160');
+      // Without prominent=true, custom domain logos use default sizing
+      expect(img.attributes('height')).toBe('48');
       expect(img.attributes('width')).toBeUndefined();
     });
 
-    it('applies responsive height (h-24 mobile, sm:h-40), w-auto, and object-contain classes', async () => {
+    it('applies default h-12, w-auto, and object-contain classes when prominent is not set', async () => {
       wrapper = mountComponent(
         {},
         {
@@ -295,16 +296,12 @@ describe('MastHead — Custom Domain Logo Behavior', () => {
       await nextTick();
       const img = wrapper.find('img#logo');
       expect(img.exists()).toBe(true);
-      // Responsive sizing: compact on mobile, prominent from sm breakpoint up
-      expect(img.classes()).toContain('h-24');
-      expect(img.classes()).toContain('sm:h-40');
+      // Without prominent=true, default unauthenticated sizing is h-12 (48px)
+      expect(img.classes()).toContain('h-12');
+      expect(img.classes()).not.toContain('h-24');
+      expect(img.classes()).not.toContain('sm:h-40');
       expect(img.classes()).toContain('w-auto');
       expect(img.classes()).toContain('object-contain');
-      // Regression: old square classes should not be present
-      expect(img.classes()).not.toContain('size-20');
-      // Regression: previous height classes should not be present
-      expect(img.classes()).not.toContain('h-20');
-      expect(img.classes()).not.toContain('h-40'); // non-responsive variant
     });
 
     it('hides site name when custom domain logo is present', async () => {

--- a/src/tests/shared/components/layout/MastHead.customDomain.spec.ts
+++ b/src/tests/shared/components/layout/MastHead.customDomain.spec.ts
@@ -323,7 +323,7 @@ describe('MastHead — Custom Domain Logo Behavior', () => {
       expect(siteName.exists()).toBe(false);
     });
 
-    it('uses 160px size regardless of auth state for custom domain', async () => {
+    it('renders a compact 40px custom domain logo for authenticated users so context switchers fit on the same row', async () => {
       wrapper = mountComponent(
         {},
         {
@@ -338,7 +338,13 @@ describe('MastHead — Custom Domain Logo Behavior', () => {
       await nextTick();
       const img = wrapper.find('img#logo');
       expect(img.exists()).toBe(true);
-      expect(img.attributes('height')).toBe('160');
+      // The prominent 160px treatment is reserved for unauthenticated views
+      // (branded homepage / disabled page); authenticated rows must keep room
+      // for the org/domain dropdowns.
+      expect(img.attributes('height')).toBe('40');
+      expect(img.classes()).toContain('h-10');
+      expect(img.classes()).not.toContain('h-24');
+      expect(img.classes()).not.toContain('sm:h-40');
     });
   });
 

--- a/src/tests/shared/components/layout/MastHead.spec.ts
+++ b/src/tests/shared/components/layout/MastHead.spec.ts
@@ -216,7 +216,7 @@ describe('MastHead', () => {
       expect(logo.attributes('data-size')).toBe('40');
     });
 
-    it('uses responsive sizing (h-24 mobile, sm:h-40 from sm breakpoint) for custom domain logo', async () => {
+    it('uses compact sizing (h-10/40px) for authenticated users with a custom domain logo so context switchers fit on the same row', async () => {
       wrapper = mountComponent(
         {},
         {
@@ -230,14 +230,14 @@ describe('MastHead', () => {
       await nextTick();
       const img = wrapper.find('img#logo');
       expect(img.exists()).toBe(true);
-      // Mobile base size to avoid dominating small viewports
-      expect(img.classes()).toContain('h-24');
-      // Prominent size from sm breakpoint up
-      expect(img.classes()).toContain('sm:h-40');
+      // Authenticated rows must keep room for the org/domain dropdowns;
+      // the prominent h-24/sm:h-40 treatment is reserved for unauthenticated views.
+      expect(img.classes()).toContain('h-10');
+      expect(img.classes()).not.toContain('h-24');
+      expect(img.classes()).not.toContain('sm:h-40');
       expect(img.classes()).toContain('w-auto');
       expect(img.classes()).toContain('object-contain');
-      // The height attribute is a layout hint matching the larger (sm+) size
-      expect(img.attributes('height')).toBe('160');
+      expect(img.attributes('height')).toBe('40');
     });
 
     it('respects explicit size prop override', async () => {
@@ -283,7 +283,7 @@ describe('MastHead', () => {
       expect(img.classes()).not.toContain('size-12');
     });
 
-    it('treats a prop-supplied image URL as custom for authenticated users too', async () => {
+    it('uses compact sizing for authenticated users even with prop-supplied custom logo', async () => {
       wrapper = mountComponent(
         {
           logo: { url: '/static/brand.png' },
@@ -298,11 +298,13 @@ describe('MastHead', () => {
       await nextTick();
       const img = wrapper.find('img#logo');
       expect(img.exists()).toBe(true);
-      expect(img.classes()).toContain('h-24');
-      expect(img.classes()).toContain('sm:h-40');
+      // Authenticated users always get compact sizing regardless of custom logo
+      expect(img.classes()).toContain('h-10');
+      expect(img.classes()).not.toContain('h-24');
+      expect(img.classes()).not.toContain('sm:h-40');
       expect(img.classes()).toContain('w-auto');
       expect(img.classes()).toContain('object-contain');
-      expect(img.attributes('height')).toBe('160');
+      expect(img.attributes('height')).toBe('40');
       expect(img.attributes('width')).toBeUndefined();
       // Regression: old square class should not be present
       expect(img.classes()).not.toContain('size-10');
@@ -429,6 +431,111 @@ describe('MastHead', () => {
       const logo = wrapper.find('.default-logo');
       expect(logo.exists()).toBe(true);
       expect(logo.attributes('data-size')).toBe('48');
+    });
+  });
+
+  describe('Prominent logo config (logo.prominent)', () => {
+    const mountWithProminentLogo = (
+      prominent: boolean,
+      storeState: Parameters<typeof mountComponent>[1] = {}
+    ) => {
+      const pinia = createTestingPinia({
+        createSpy: vi.fn,
+        stubActions: false,
+        initialState: {
+          bootstrap: {
+            authenticated: storeState.authenticated ?? false,
+            awaiting_mfa: storeState.awaiting_mfa ?? false,
+            email: storeState.email ?? null,
+            cust: storeState.cust ?? null,
+            domain_logo: storeState.domain_logo ?? null,
+            ui: {
+              header: {
+                navigation: { enabled: true },
+                branding: {
+                  logo: {
+                    url: storeState.domain_logo ?? 'DefaultLogo.vue',
+                    alt: 'Brand',
+                    prominent,
+                  },
+                  site_name: 'Brand',
+                },
+              },
+            },
+            authentication: { enabled: true, signin: true, signup: true },
+          },
+        },
+      });
+
+      // Manually set isUserPresent based on bootstrap state (same as mountComponent)
+      const authStore = useAuthStore(pinia);
+      const hasAuthenticatedCustomer = storeState.authenticated && storeState.cust;
+      const hasMfaPendingEmail = storeState.awaiting_mfa && storeState.email;
+      (authStore as unknown as { isUserPresent: boolean }).isUserPresent = !!(
+        hasAuthenticatedCustomer || hasMfaPendingEmail
+      );
+
+      return mount(MastHead, {
+        global: {
+          plugins: [pinia, i18n],
+          stubs: { Teleport: true },
+        },
+        props: {},
+        slots: {
+          'context-switchers': '<span>test-context-switchers</span>',
+        },
+      });
+    };
+
+    it('uses intermediate 80px sizing for authenticated users when prominent is true', async () => {
+      wrapper = mountWithProminentLogo(true, {
+        authenticated: true,
+        cust: mockCustomer,
+        email: mockCustomer.email,
+        domain_logo: 'https://example.com/custom-logo.png',
+      });
+
+      await nextTick();
+      const img = wrapper.find('img#logo');
+      expect(img.exists()).toBe(true);
+      expect(img.attributes('height')).toBe('80');
+      expect(img.classes()).toContain('h-20');
+      expect(img.classes()).not.toContain('h-10');
+      expect(img.classes()).not.toContain('h-24');
+      expect(img.classes()).not.toContain('sm:h-40');
+    });
+
+    it('uses compact 40px sizing for authenticated users when prominent is false', async () => {
+      wrapper = mountWithProminentLogo(false, {
+        authenticated: true,
+        cust: mockCustomer,
+        email: mockCustomer.email,
+        domain_logo: 'https://example.com/custom-logo.png',
+      });
+
+      await nextTick();
+      const img = wrapper.find('img#logo');
+      expect(img.exists()).toBe(true);
+      expect(img.attributes('height')).toBe('40');
+      expect(img.classes()).toContain('h-10');
+      expect(img.classes()).not.toContain('h-20');
+    });
+
+    it('ignores prominent config for unauthenticated users (always 160px for custom logos)', async () => {
+      wrapper = mountWithProminentLogo(true, {
+        authenticated: false,
+        cust: null,
+        email: null,
+        domain_logo: 'https://example.com/custom-logo.png',
+      });
+
+      await nextTick();
+      const img = wrapper.find('img#logo');
+      expect(img.exists()).toBe(true);
+      expect(img.attributes('height')).toBe('160');
+      expect(img.classes()).toContain('h-24');
+      expect(img.classes()).toContain('sm:h-40');
+      expect(img.classes()).not.toContain('h-20');
     });
   });
 

--- a/src/tests/shared/components/layout/MastHead.spec.ts
+++ b/src/tests/shared/components/layout/MastHead.spec.ts
@@ -258,7 +258,7 @@ describe('MastHead', () => {
   });
 
   describe('Image logo sizing (non-Vue URL)', () => {
-    it('treats a prop-supplied image URL as a custom logo with responsive sizing', async () => {
+    it('uses default sizing for image URLs when prominent is not set', async () => {
       wrapper = mountComponent(
         {
           logo: { url: '/static/brand.png' },
@@ -273,14 +273,13 @@ describe('MastHead', () => {
       await nextTick();
       const img = wrapper.find('img#logo');
       expect(img.exists()).toBe(true);
-      expect(img.classes()).toContain('h-24');
-      expect(img.classes()).toContain('sm:h-40');
+      // Without prominent=true, unauthenticated users get default 48px (h-12)
+      expect(img.classes()).toContain('h-12');
+      expect(img.classes()).not.toContain('h-24');
+      expect(img.classes()).not.toContain('sm:h-40');
       expect(img.classes()).toContain('w-auto');
       expect(img.classes()).toContain('object-contain');
-      expect(img.attributes('height')).toBe('160');
-      expect(img.attributes('width')).toBeUndefined();
-      // Regression: old square class should not be present
-      expect(img.classes()).not.toContain('size-12');
+      expect(img.attributes('height')).toBe('48');
     });
 
     it('uses compact sizing for authenticated users even with prop-supplied custom logo', async () => {
@@ -386,7 +385,7 @@ describe('MastHead', () => {
       });
     };
 
-    it('renders a non-default static image URL as a custom logo with responsive sizing', async () => {
+    it('uses default sizing for static image URL when prominent is not set', async () => {
       wrapper = mountWithStaticLogoUrl('/img/brand.svg', {
         authenticated: false,
       });
@@ -394,11 +393,13 @@ describe('MastHead', () => {
       await nextTick();
       const img = wrapper.find('img#logo');
       expect(img.exists()).toBe(true);
-      expect(img.classes()).toContain('h-24');
-      expect(img.classes()).toContain('sm:h-40');
+      // Without prominent=true, unauthenticated users get default 48px (h-12)
+      expect(img.classes()).toContain('h-12');
+      expect(img.classes()).not.toContain('h-24');
+      expect(img.classes()).not.toContain('sm:h-40');
       expect(img.classes()).toContain('w-auto');
       expect(img.classes()).toContain('object-contain');
-      expect(img.attributes('height')).toBe('160');
+      expect(img.attributes('height')).toBe('48');
     });
 
     it('hides the site name by default for non-default static config logos', async () => {
@@ -521,7 +522,7 @@ describe('MastHead', () => {
       expect(img.classes()).not.toContain('h-20');
     });
 
-    it('ignores prominent config for unauthenticated users (always 160px for custom logos)', async () => {
+    it('uses 160px for unauthenticated users when prominent is true', async () => {
       wrapper = mountWithProminentLogo(true, {
         authenticated: false,
         cust: null,
@@ -536,6 +537,23 @@ describe('MastHead', () => {
       expect(img.classes()).toContain('h-24');
       expect(img.classes()).toContain('sm:h-40');
       expect(img.classes()).not.toContain('h-20');
+    });
+
+    it('uses default 48px for unauthenticated users when prominent is false', async () => {
+      wrapper = mountWithProminentLogo(false, {
+        authenticated: false,
+        cust: null,
+        email: null,
+        domain_logo: 'https://example.com/custom-logo.png',
+      });
+
+      await nextTick();
+      const img = wrapper.find('img#logo');
+      expect(img.exists()).toBe(true);
+      expect(img.attributes('height')).toBe('48');
+      expect(img.classes()).toContain('h-12');
+      expect(img.classes()).not.toContain('h-24');
+      expect(img.classes()).not.toContain('sm:h-40');
     });
   });
 


### PR DESCRIPTION
## Summary

Logo sizing now depends solely on the `LOGO_PROMINENT` config flag and authentication state — no auto-detection based on URL patterns:

- **Authenticated**: 40px default → 80px when prominent
- **Unauthenticated**: 48px default → 160px when prominent

The `isCustomLogo` check now only controls site name visibility (hiding it for external branding that embeds its own wordmark).

## Changes

**Configuration** — Added `prominent` field to logo config schema with documentation in `.env.reference` and `config.defaults.yaml`

**MastHead.vue** — Simplified `getLogoSize()` to read the prominent config flag instead of inspecting logo URLs

**Schema** — Added `prominent` and `show_name` fields using `booleanOrString` for API response flexibility

**Tests** — Updated sizing expectations and added 8 new test cases covering prominent/auth combinations

## Test plan

- [x] TypeScript type check passes
- [x] MastHead unit tests pass (44 tests)
- [ ] Manual: verify default sizing (48px unauthenticated, 40px authenticated)
- [ ] Manual: verify `LOGO_PROMINENT=true` gives enlarged sizing (160px/80px)