### PR TITLE
Enhance domains CLI with sorting, limiting, and vhost display

### DIFF
--- a/apps/api/domains/cli/helpers.rb
+++ b/apps/api/domains/cli/helpers.rb
@@ -65,6 +65,20 @@ module Onetime
         domain
       end
 
+      # Load domain by name, extid, or objid
+      def load_domain(identifier)
+        # Try display_domain first, then extid, then objid
+        domain   = Onetime::CustomDomain.load_by_display_domain(identifier)
+        domain ||= Onetime::CustomDomain.find_by_extid(identifier)
+        domain ||= Onetime::CustomDomain.find_by_identifier(identifier)
+
+        unless domain
+          puts "Error: Domain '#{identifier}' not found"
+          return nil
+        end
+        domain
+      end
+
       def load_organization(org_id, silent: false)
         org = Onetime::Organization.load(org_id)
         unless org

--- a/apps/api/domains/cli/info_command.rb
+++ b/apps/api/domains/cli/info_command.rb
@@ -12,16 +12,16 @@ module Onetime
 
       desc 'Show detailed information about a domain'
 
-      argument :domain_name, type: :string, required: true, desc: 'Domain name'
+      argument :identifier, type: :string, required: true, desc: 'Domain name, extid, or objid'
 
-      def call(domain_name:, **)
+      def call(identifier:, **)
         boot_application!
 
-        domain = load_domain_by_name(domain_name)
+        domain = load_domain(identifier)
         return unless domain
 
         puts '=' * 80
-        puts "Domain Information: #{domain_name}"
+        puts "Domain Information: #{domain.display_domain}"
         puts '=' * 80
         puts
 
@@ -69,12 +69,23 @@ module Onetime
         puts "  Validation Record:    #{domain.validation_record || 'N/A'}"
         puts
 
-        # Vhost configuration
-        puts 'Configuration:'
-        puts "  Vhost:                #{domain.vhost || 'N/A'}"
+        # Branding configuration
+        puts 'Brand Settings:'
         puts "  Allow Public Home:    #{domain.allow_public_homepage? || 'false'}"
         puts "  Allow Public API:     #{domain.allow_public_api? || 'false'}"
         puts "  Apex Domain:          #{domain.apex? || 'false'}"
+        puts
+
+        # Vhost (Approximated) details
+        puts 'Vhost (Approximated):'
+        vhost_data = domain.parse_vhost
+        if vhost_data.nil? || vhost_data.empty?
+          puts '  (not set)'
+        else
+          vhost_data.each do |key, value|
+            puts format('  %-20s %s', "#{key}:", value.to_s)
+          end
+        end
         puts
 
         # Timestamps
@@ -96,3 +107,4 @@ module Onetime
 end
 
 Onetime::CLI.register 'domains info', Onetime::CLI::DomainsInfoCommand
+Onetime::CLI.register 'domains show', Onetime::CLI::DomainsInfoCommand

--- a/apps/api/domains/cli/list_command.rb
+++ b/apps/api/domains/cli/list_command.rb
@@ -64,13 +64,13 @@ module Onetime
                sort: 'domain', desc: false, limit: nil, vhost: false, **)
         boot_application!
 
-        all_domain_ids = Onetime::CustomDomain.instances.all
-        all_domains    = all_domain_ids.map do |did|
-          Onetime::CustomDomain.find_by_identifier(did)
-        end.compact
+        # Batch load all domains using Familia v2.9.0's each_record
+        all_domains = []
+        Onetime::CustomDomain.instances.each_record { |domain| all_domains << domain }
 
         # Resolve org_extid to org_id if provided
         resolved_org_id = resolve_org_filter(org_id, org_extid)
+        return if resolved_org_id == :not_found
 
         # Apply filters
         filtered_domains = apply_filters(
@@ -80,6 +80,9 @@ module Onetime
           verified: verified,
           unverified: unverified,
         )
+
+        # Pre-load organizations to avoid N+1 queries during sort/display
+        @org_cache = preload_organizations(filtered_domains)
 
         # Apply sorting
         sorted_domains = sort_domains(filtered_domains, sort, desc)
@@ -106,14 +109,37 @@ module Onetime
 
         org = Onetime::Organization.find_by_extid(org_extid)
         unless org
-          puts "Warning: Organization with extid '#{org_extid}' not found"
-          return nil
+          puts "Error: Organization with extid '#{org_extid}' not found"
+          exit 1
         end
         org.org_id
       end
 
+      def preload_organizations(domains)
+        org_ids = domains.map(&:org_id).compact.uniq
+        cache   = {}
+        org_ids.each do |oid|
+          next if oid.to_s.empty?
+
+          cache[oid] ||= Onetime::Organization.load(oid)
+        end
+        cache
+      end
+
+      def cached_org_info(domain)
+        return '(orphaned)' if domain.org_id.to_s.empty?
+
+        org = @org_cache&.[](domain.org_id)
+        return "(org: #{domain.org_id})" unless org
+
+        org.display_name || org.org_id
+      end
+
       def sort_domains(domains, sort_field, descending)
-        sort_field = 'domain' unless SORT_FIELDS.include?(sort_field)
+        unless SORT_FIELDS.include?(sort_field)
+          puts "Warning: Invalid sort field '#{sort_field}', using 'domain'"
+          sort_field = 'domain'
+        end
 
         sorted = domains.sort_by do |d|
           case sort_field
@@ -124,7 +150,7 @@ module Onetime
           when 'updated'
             d.updated.to_i
           when 'org'
-            get_organization_info(d).downcase
+            cached_org_info(d).downcase
           when 'status'
             d.verification_state.to_s
           end
@@ -162,27 +188,31 @@ module Onetime
         end
       end
 
+      def truncate(str, max_len)
+        str.to_s[0, max_len]
+      end
+
       def format_domain_row_extended(domain, show_vhost: false)
-        org_info = get_organization_info(domain)
+        org_info = cached_org_info(domain)
         status   = domain.verification_state || 'unknown'
-        verified = domain.verified.to_s == 'true' ? 'yes' : 'no'
+        verified = domain.verified == true || domain.verified.to_s == 'true' ? 'yes' : 'no'
 
         if show_vhost
           vhost_json = format_vhost_json(domain)
           format(
             '%-40s %-25s %-12s %-8s  %s',
-            domain.display_domain[0..39],
-            org_info[0..24],
-            status[0..11],
+            truncate(domain.display_domain, 40),
+            truncate(org_info, 25),
+            truncate(status, 12),
             verified,
             vhost_json,
           )
         else
           format(
             '%-40s %-30s %-12s %-10s',
-            domain.display_domain[0..39],
-            org_info[0..29],
-            status[0..11],
+            truncate(domain.display_domain, 40),
+            truncate(org_info, 30),
+            truncate(status, 12),
             verified,
           )
         end
@@ -192,10 +222,10 @@ module Onetime
         vhost_data = domain.parse_vhost
         return '-' if vhost_data.nil? || vhost_data.empty?
 
-        # Compact JSON representation
         JSON.generate(vhost_data)
       rescue StandardError => ex
-        "(error: #{ex.message[0..20]})"
+        OT.le("Vhost JSON error for #{domain.domainid}: #{ex.message}")
+        "(error: #{truncate(ex.message, 50)})"
       end
 
       def display_duplicate_group(display_domain, domains, show_vhost: false)
@@ -218,8 +248,8 @@ module Onetime
           )
         end
         domains.each_with_index do |domain, idx|
-          org_info = get_organization_info(domain)
-          puts format('  [%d] %-37s %-30s', idx + 1, domain.domainid[0..36], org_info)
+          org_info = cached_org_info(domain)
+          puts format('  [%d] %-37s %-30s', idx + 1, truncate(domain.domainid, 37), org_info)
         end
       end
     end

--- a/apps/api/domains/cli/list_command.rb
+++ b/apps/api/domains/cli/list_command.rb
@@ -2,6 +2,7 @@
 #
 # frozen_string_literal: true
 
+require 'json'
 require_relative 'helpers'
 
 module Onetime
@@ -9,6 +10,8 @@ module Onetime
     # Main domains command (list all)
     class DomainsListCommand < Command
       include DomainsHelpers
+
+      SORT_FIELDS = %w[domain created updated org status].freeze
 
       desc 'List all custom domains with organization info'
 
@@ -20,7 +23,12 @@ module Onetime
       option :org_id,
         type: :string,
         default: nil,
-        desc: 'Filter by organization ID'
+        desc: 'Filter by organization ID (internal)'
+
+      option :org_extid,
+        type: :string,
+        default: nil,
+        desc: 'Filter by organization external ID'
 
       option :verified,
         type: :boolean,
@@ -32,7 +40,28 @@ module Onetime
         default: false,
         desc: 'Filter for unverified domains only'
 
-      def call(orphaned: false, org_id: nil, verified: false, unverified: false, **)
+      option :sort,
+        type: :string,
+        default: 'domain',
+        desc: "Sort by field: #{SORT_FIELDS.join(', ')}"
+
+      option :desc,
+        type: :boolean,
+        default: false,
+        desc: 'Sort descending (default: ascending)'
+
+      option :limit,
+        type: :integer,
+        default: nil,
+        desc: 'Limit number of results'
+
+      option :vhost,
+        type: :boolean,
+        default: false,
+        desc: 'Include vhost details as JSON'
+
+      def call(orphaned: false, org_id: nil, org_extid: nil, verified: false, unverified: false,
+               sort: 'domain', desc: false, limit: nil, vhost: false, **)
         boot_application!
 
         all_domain_ids = Onetime::CustomDomain.instances.all
@@ -40,49 +69,161 @@ module Onetime
           Onetime::CustomDomain.find_by_identifier(did)
         end.compact
 
+        # Resolve org_extid to org_id if provided
+        resolved_org_id = resolve_org_filter(org_id, org_extid)
+
         # Apply filters
         filtered_domains = apply_filters(
           all_domains,
           orphaned: orphaned,
-          org_id: org_id,
+          org_id: resolved_org_id,
           verified: verified,
           unverified: unverified,
         )
 
-        puts format('%d custom domains', filtered_domains.size)
-        return if filtered_domains.empty?
+        # Apply sorting
+        sorted_domains = sort_domains(filtered_domains, sort, desc)
 
-        # Display header
+        # Apply limit
+        sorted_domains = sorted_domains.first(limit) if limit
+
+        puts format(
+          '%d custom domains%s',
+          sorted_domains.size,
+          limit ? " (limited from #{filtered_domains.size})" : '',
+        )
+        return if sorted_domains.empty?
+
+        display_domains_table(sorted_domains, show_vhost: vhost)
+      end
+
+      private
+
+      def resolve_org_filter(org_id, org_extid)
+        return org_id if org_id
+
+        return nil unless org_extid
+
+        org = Onetime::Organization.find_by_extid(org_extid)
+        unless org
+          puts "Warning: Organization with extid '#{org_extid}' not found"
+          return nil
+        end
+        org.org_id
+      end
+
+      def sort_domains(domains, sort_field, descending)
+        sort_field = 'domain' unless SORT_FIELDS.include?(sort_field)
+
+        sorted = domains.sort_by do |d|
+          case sort_field
+          when 'domain'
+            d.display_domain.to_s.downcase
+          when 'created'
+            d.created.to_i
+          when 'updated'
+            d.updated.to_i
+          when 'org'
+            get_organization_info(d).downcase
+          when 'status'
+            d.verification_state.to_s
+          end
+        end
+
+        descending ? sorted.reverse : sorted
+      end
+
+      def display_domains_table(domains, show_vhost: false)
         puts
-        puts format('%-40s %-30s %-12s %-10s', 'Domain', 'Organization', 'Status', 'Verified')
-        puts '-' * 95
+        if show_vhost
+          puts format('%-40s %-25s %-12s %-8s  %s', 'Domain', 'Organization', 'Status', 'Verified', 'Vhost')
+          puts '-' * 120
+        else
+          puts format('%-40s %-30s %-12s %-10s', 'Domain', 'Organization', 'Status', 'Verified')
+          puts '-' * 95
+        end
 
         # Group by display_domain for deduplication
-        grouped_domains = filtered_domains.group_by(&:display_domain)
+        grouped_domains = domains.group_by(&:display_domain)
+        # Preserve sort order by iterating in original order
+        seen            = Set.new
+        domains.each do |domain|
+          dd = domain.display_domain
+          next if seen.include?(dd)
 
-        grouped_domains.sort.each do |display_domain, domains|
-          if domains.size == 1
-            domain = domains.first
-            puts format_domain_row(domain)
+          seen << dd
+          group = grouped_domains[dd]
+
+          if group.size == 1
+            puts format_domain_row_extended(domain, show_vhost: show_vhost)
           else
-            # Multiple records for same domain (duplicates)
-            puts format(
-              '%-40s %-30s %-12s %-10s',
-              "#{display_domain} (#{domains.size} records)",
-              'DUPLICATES',
-              'CHECK',
-              '?',
-            )
-            domains.each_with_index do |domain, idx|
-              org_info = get_organization_info(domain)
-              puts format('  [%d] %-37s %-30s', idx + 1, domain.domainid[0..36], org_info)
-            end
+            display_duplicate_group(dd, group, show_vhost: show_vhost)
           end
+        end
+      end
+
+      def format_domain_row_extended(domain, show_vhost: false)
+        org_info = get_organization_info(domain)
+        status   = domain.verification_state || 'unknown'
+        verified = domain.verified.to_s == 'true' ? 'yes' : 'no'
+
+        if show_vhost
+          vhost_json = format_vhost_json(domain)
+          format(
+            '%-40s %-25s %-12s %-8s  %s',
+            domain.display_domain[0..39],
+            org_info[0..24],
+            status[0..11],
+            verified,
+            vhost_json,
+          )
+        else
+          format(
+            '%-40s %-30s %-12s %-10s',
+            domain.display_domain[0..39],
+            org_info[0..29],
+            status[0..11],
+            verified,
+          )
+        end
+      end
+
+      def format_vhost_json(domain)
+        vhost_data = domain.parse_vhost
+        return '-' if vhost_data.nil? || vhost_data.empty?
+
+        # Compact JSON representation
+        JSON.generate(vhost_data)
+      rescue StandardError => ex
+        "(error: #{ex.message[0..20]})"
+      end
+
+      def display_duplicate_group(display_domain, domains, show_vhost: false)
+        if show_vhost
+          puts format(
+            '%-40s %-25s %-12s %-8s  %s',
+            "#{display_domain} (#{domains.size} records)",
+            'DUPLICATES',
+            'CHECK',
+            '?',
+            '-',
+          )
+        else
+          puts format(
+            '%-40s %-30s %-12s %-10s',
+            "#{display_domain} (#{domains.size} records)",
+            'DUPLICATES',
+            'CHECK',
+            '?',
+          )
+        end
+        domains.each_with_index do |domain, idx|
+          org_info = get_organization_info(domain)
+          puts format('  [%d] %-37s %-30s', idx + 1, domain.domainid[0..36], org_info)
         end
       end
     end
   end
 end
 
-Onetime::CLI.register 'domains', Onetime::CLI::DomainsListCommand
-Onetime::CLI.register 'domain', Onetime::CLI::DomainsListCommand
+Onetime::CLI.register 'domains list', Onetime::CLI::DomainsListCommand

--- a/lib/onetime/cli/domains_command.rb
+++ b/lib/onetime/cli/domains_command.rb
@@ -2,13 +2,14 @@
 #
 # frozen_string_literal: true
 
-# CLI command for managing custom domain records. Shows count and usage when
-# invoked without a subcommand.
+# CLI command for managing custom domain records. Shows subcommands when
+# invoked without arguments.
 #
 # Usage:
-#   bin/ots domains                             # Show count and usage
-#   bin/ots domains doctor secrets.example.com  # Check single domain
-#   bin/ots domains doctor --all                # Check all domains
+#   bin/ots domains              # Show subcommands
+#   bin/ots domains list         # List all domains with filtering options
+#   bin/ots domains info DOMAIN  # Show domain details
+#   bin/ots domains doctor --all # Check all domains
 #
 
 module Onetime
@@ -24,22 +25,7 @@ module Onetime
 
         puts format('%d custom domains (%d in display_domains index)', domain_count, index_count)
         puts
-        puts 'Usage:'
-        puts '  bin/ots domains doctor secrets.example.com  # Check single domain'
-        puts '  bin/ots domains doctor --all                # Check all domains'
-        puts '  bin/ots domains doctor --org EXTID          # Check domains for one org'
-        puts '  bin/ots domains doctor --all --repair       # Auto-repair issues'
-        puts '  bin/ots domains doctor --all --json         # JSON output'
-        puts
-        puts 'Integrity checks:'
-        puts '  1. org_id points to existing organization (CRITICAL)'
-        puts '  2. display_domain field is not empty (HIGH)'
-        puts '  3. display_domain_index entries are valid (HIGH)'
-        puts '  4. display_domains hash entries are valid (MEDIUM)'
-        puts '  5. Domain is in org.domains sorted set (MEDIUM)'
-        puts '  6. org.domains entries have valid domain objects (MEDIUM)'
-        puts '  7. verification_state is coherent (WARNING)'
-        puts '  8. txt_validation_value format is valid (LOW)'
+        puts 'Run bin/ots domains -h for available subcommands'
       end
     end
 

--- a/spec/cli/domains_command_spec.rb
+++ b/spec/cli/domains_command_spec.rb
@@ -37,6 +37,7 @@ RSpec.describe 'Domains Command', type: :cli do
       txt_validation_value: 'v=lettermint',
       validation_record: 'TXT',
       vhost: 'example.com',
+      parse_vhost: { 'host' => 'example.com' },
       allow_public_homepage?: false,
       allow_public_api?: false,
       apex?: true,
@@ -80,7 +81,9 @@ RSpec.describe 'Domains Command', type: :cli do
     end
 
     it 'handles non-existent domain' do
-      allow(Onetime::CustomDomain).to receive(:load_by_display_domain).and_return(nil)
+      allow(Onetime::CustomDomain).to receive(:load_by_display_domain).with('notfound.com').and_return(nil)
+      allow(Onetime::CustomDomain).to receive(:find_by_extid).with('notfound.com').and_return(nil)
+      allow(Onetime::CustomDomain).to receive(:find_by_identifier).with('notfound.com').and_return(nil)
 
       output = run_cli_command_quietly('domains', 'info', 'notfound.com')
       expect(output[:stdout]).to include('not found')


### PR DESCRIPTION
Closes #3145

## Summary
- Add `--sort`, `--desc`, `--limit`, `--vhost`, `--org-extid` options to `domains list`
- Update `domains info/show` to accept name, extid, or objid
- Restructure base `domains` command to show subcommands (matches `customers`/`org` pattern)

## Test plan
- [ ] `bin/ots domains -h` shows subcommands
- [ ] `bin/ots domains list -h` shows all filter options
- [ ] `bin/ots domains list --sort=updated --desc --limit 5` works
- [ ] `bin/ots domains list --vhost` shows JSON column
- [ ] `bin/ots domains info <extid>` resolves domain