### PR TITLE
Refactor WithEntitlements to idiomatic Familia Feature pattern

### DIFF
--- a/lib/onetime/models/features/with_entitlements.rb
+++ b/lib/onetime/models/features/with_entitlements.rb
@@ -152,7 +152,11 @@ module Onetime
 
         def self.included(base)
           OT.ld "[features] #{base}: #{name}"
+          base.extend ClassMethods
           base.include InstanceMethods
+        end
+
+        module ClassMethods
         end
 
         module InstanceMethods

--- a/lib/onetime/models/features/with_entitlements.rb
+++ b/lib/onetime/models/features/with_entitlements.rb
@@ -90,66 +90,6 @@ module Onetime
           homepage_secrets
         ].freeze
 
-        # Parse TTL value from environment variable with strict validation
-        #
-        # Uses Integer() for strict parsing to reject malformed values like "123abc".
-        # Applies bounds validation: minimum 0, maximum MAX_TTL (365 days).
-        #
-        # @param env_var [String] Environment variable name
-        # @param default [Integer] Default value if env var is not set or invalid
-        # @return [Integer] Validated TTL value in seconds (0 to MAX_TTL)
-        #
-        # @example
-        #   parse_ttl_env('PLAN_TTL_ANONYMOUS', 604_800)  # => 604800 (or env value)
-        def self.parse_ttl_env(env_var, default)
-          raw = ENV.fetch(env_var, nil)
-          return default if raw.nil? || raw.strip.empty?
-
-          begin
-            value = Integer(raw.strip, 10) # Strict integer parsing, base 10
-            # Apply bounds: clamp between 0 and MAX_TTL (365 days)
-            value.clamp(0, MAX_TTL)
-          rescue ArgumentError
-            OT.lw "[WithEntitlements] Invalid #{env_var} value, using default",
-              {
-                env_var: env_var,
-                default: default,
-              }
-            default
-          end
-        end
-
-        # FREE tier default limits when cache is unavailable
-        #
-        # The secret_lifetime.max value can be overridden via PLAN_TTL_ANONYMOUS
-        # environment variable for Docker/self-hosted deployments.
-        # This provides upgrade continuity with PR #2393 from main branch.
-        #
-        # Results are memoized at class level for consistent behavior and performance.
-        #
-        # Environment variables:
-        #   PLAN_TTL_ANONYMOUS - Maximum secret TTL for anonymous/free tier users (default: 1209600 = 14 days)
-        #
-        # @see https://github.com/onetimesecret/onetimesecret/issues/2390
-        # @see https://github.com/onetimesecret/onetimesecret/issues/3111
-        def self.free_tier_limits
-          @free_tier_limits ||= {
-            'organizations.max' => 5,
-            'teams.max' => 0,
-            'members_per_team.max' => 0,
-            'secret_lifetime.max' => parse_ttl_env('PLAN_TTL_ANONYMOUS', DEFAULT_FREE_TTL),
-          }.freeze
-        end
-
-        # Reset memoized free_tier_limits (for testing)
-        def self.reset_free_tier_limits!
-          @free_tier_limits = nil
-        end
-
-        # Legacy constant for backward compatibility
-        # @deprecated Use free_tier_limits method instead
-        FREE_TIER_LIMITS = free_tier_limits
-
         def self.included(base)
           OT.ld "[features] #{base}: #{name}"
           base.extend ClassMethods
@@ -157,6 +97,53 @@ module Onetime
         end
 
         module ClassMethods
+          # Parse TTL value from environment variable with strict validation
+          #
+          # Uses Integer() for strict parsing to reject malformed values like "123abc".
+          # Applies bounds validation: minimum 0, maximum MAX_TTL (365 days).
+          #
+          # @param env_var [String] Environment variable name
+          # @param default [Integer] Default value if env var is not set or invalid
+          # @return [Integer] Validated TTL value in seconds (0 to MAX_TTL)
+          #
+          # @example
+          #   Organization.parse_ttl_env('PLAN_TTL_ANONYMOUS', 604_800)
+          def parse_ttl_env(env_var, default)
+            raw = ENV.fetch(env_var, nil)
+            return default if raw.nil? || raw.strip.empty?
+
+            begin
+              value = Integer(raw.strip, 10)
+              value.clamp(0, MAX_TTL)
+            rescue ArgumentError
+              OT.lw "[WithEntitlements] Invalid #{env_var} value, using default",
+                { env_var: env_var, default: default }
+              default
+            end
+          end
+
+          # FREE tier default limits when cache is unavailable
+          #
+          # The secret_lifetime.max value can be overridden via PLAN_TTL_ANONYMOUS
+          # environment variable for Docker/self-hosted deployments.
+          #
+          # Results are memoized at class level for consistent behavior.
+          #
+          # @see https://github.com/onetimesecret/onetimesecret/issues/2390
+          # @see https://github.com/onetimesecret/onetimesecret/issues/3111
+          def free_tier_limits
+            @free_tier_limits ||= {
+              'organizations.max' => 5,
+              'teams.max' => 0,
+              'members_per_team.max' => 0,
+              'secret_lifetime.max' => parse_ttl_env('PLAN_TTL_ANONYMOUS', DEFAULT_FREE_TTL),
+            }.freeze
+          end
+
+          # Reset memoized free_tier_limits (for testing)
+          def reset_free_tier_limits!
+            @free_tier_limits = nil
+          end
         end
 
         module InstanceMethods
@@ -289,10 +276,10 @@ module Onetime
           #
           # Fallback hierarchy:
           # 1. If billing disabled (standalone mode) -> Float::INFINITY (unlimited)
-          # 2. If no planid set -> FREE_TIER_LIMITS
+          # 2. If no planid set -> free_tier_limits
           # 3. If plan found in cache -> plan.limits
           # 4. If plan not in cache, try billing.yaml config fallback
-          # 5. Final fallback -> FREE_TIER_LIMITS (conservative defaults)
+          # 5. Final fallback -> free_tier_limits (conservative defaults)
           #
           # @example
           #   org.limit_for('teams')            # => 1
@@ -471,13 +458,10 @@ module Onetime
 
           # Get FREE tier limit for a resource key
           #
-          # Uses WithEntitlements.free_tier_limits to support runtime
-          # environment variable overrides (e.g., PLAN_TTL_ANONYMOUS).
-          #
           # @param key [String] Flattened limit key (e.g., "teams.max")
           # @return [Numeric] Limit value, defaults to 0 for unknown keys
           def free_tier_limit_for(key)
-            val = WithEntitlements.free_tier_limits[key]
+            val = self.class.free_tier_limits[key]
             return 0 if val.nil?
 
             val

--- a/spec/unit/onetime/models/features/with_entitlements_ttl_env_spec.rb
+++ b/spec/unit/onetime/models/features/with_entitlements_ttl_env_spec.rb
@@ -17,6 +17,27 @@ require 'yaml'
 # @see https://github.com/onetimesecret/onetimesecret/issues/3111
 #
 RSpec.describe Onetime::Models::Features::WithEntitlements do
+  # Test class that includes the feature, giving us access to ClassMethods
+  let(:test_class) do
+    Class.new do
+      include Onetime::Models::Features::WithEntitlements
+
+      attr_accessor :planid
+
+      def initialize(planid = nil)
+        @planid = planid
+      end
+
+      def billing_enabled?
+        true
+      end
+
+      def extid
+        'test-org-extid'
+      end
+    end
+  end
+
   describe '.parse_ttl_env' do
     let(:default_value) { 604_800 } # 7 days
 
@@ -26,7 +47,7 @@ RSpec.describe Onetime::Models::Features::WithEntitlements do
 
     context 'when environment variable is not set' do
       it 'returns the default value' do
-        result = described_class.parse_ttl_env('TEST_TTL_VAR', default_value)
+        result = test_class.parse_ttl_env('TEST_TTL_VAR', default_value)
         expect(result).to eq(default_value)
       end
     end
@@ -35,7 +56,7 @@ RSpec.describe Onetime::Models::Features::WithEntitlements do
       before { ENV['TEST_TTL_VAR'] = '' }
 
       it 'returns the default value' do
-        result = described_class.parse_ttl_env('TEST_TTL_VAR', default_value)
+        result = test_class.parse_ttl_env('TEST_TTL_VAR', default_value)
         expect(result).to eq(default_value)
       end
     end
@@ -44,7 +65,7 @@ RSpec.describe Onetime::Models::Features::WithEntitlements do
       before { ENV['TEST_TTL_VAR'] = '   ' }
 
       it 'returns the default value' do
-        result = described_class.parse_ttl_env('TEST_TTL_VAR', default_value)
+        result = test_class.parse_ttl_env('TEST_TTL_VAR', default_value)
         expect(result).to eq(default_value)
       end
     end
@@ -53,7 +74,7 @@ RSpec.describe Onetime::Models::Features::WithEntitlements do
       before { ENV['TEST_TTL_VAR'] = '2592000' } # 30 days
 
       it 'returns the parsed integer value' do
-        result = described_class.parse_ttl_env('TEST_TTL_VAR', default_value)
+        result = test_class.parse_ttl_env('TEST_TTL_VAR', default_value)
         expect(result).to eq(2_592_000)
       end
     end
@@ -62,7 +83,7 @@ RSpec.describe Onetime::Models::Features::WithEntitlements do
       before { ENV['TEST_TTL_VAR'] = '  1209600  ' } # 14 days with whitespace
 
       it 'returns the parsed integer value after trimming' do
-        result = described_class.parse_ttl_env('TEST_TTL_VAR', default_value)
+        result = test_class.parse_ttl_env('TEST_TTL_VAR', default_value)
         expect(result).to eq(1_209_600)
       end
     end
@@ -71,7 +92,7 @@ RSpec.describe Onetime::Models::Features::WithEntitlements do
       before { ENV['TEST_TTL_VAR'] = '999999999' } # Way more than 365 days
 
       it 'caps the value at MAX_TTL (365 days)' do
-        result = described_class.parse_ttl_env('TEST_TTL_VAR', default_value)
+        result = test_class.parse_ttl_env('TEST_TTL_VAR', default_value)
         expect(result).to eq(described_class::MAX_TTL)
         expect(result).to eq(365 * 24 * 60 * 60)
       end
@@ -81,7 +102,7 @@ RSpec.describe Onetime::Models::Features::WithEntitlements do
       before { ENV['TEST_TTL_VAR'] = (365 * 24 * 60 * 60).to_s }
 
       it 'returns the MAX_TTL value' do
-        result = described_class.parse_ttl_env('TEST_TTL_VAR', default_value)
+        result = test_class.parse_ttl_env('TEST_TTL_VAR', default_value)
         expect(result).to eq(described_class::MAX_TTL)
       end
     end
@@ -90,7 +111,7 @@ RSpec.describe Onetime::Models::Features::WithEntitlements do
       before { ENV['TEST_TTL_VAR'] = '123abc' }
 
       it 'returns the default value' do
-        result = described_class.parse_ttl_env('TEST_TTL_VAR', default_value)
+        result = test_class.parse_ttl_env('TEST_TTL_VAR', default_value)
         expect(result).to eq(default_value)
       end
 
@@ -99,7 +120,7 @@ RSpec.describe Onetime::Models::Features::WithEntitlements do
           '[WithEntitlements] Invalid TEST_TTL_VAR value, using default',
           hash_including(env_var: 'TEST_TTL_VAR', default: default_value)
         )
-        described_class.parse_ttl_env('TEST_TTL_VAR', default_value)
+        test_class.parse_ttl_env('TEST_TTL_VAR', default_value)
       end
     end
 
@@ -107,7 +128,7 @@ RSpec.describe Onetime::Models::Features::WithEntitlements do
       before { ENV['TEST_TTL_VAR'] = '604800.5' }
 
       it 'returns the default value (strict integer parsing)' do
-        result = described_class.parse_ttl_env('TEST_TTL_VAR', default_value)
+        result = test_class.parse_ttl_env('TEST_TTL_VAR', default_value)
         expect(result).to eq(default_value)
       end
     end
@@ -116,7 +137,7 @@ RSpec.describe Onetime::Models::Features::WithEntitlements do
       before { ENV['TEST_TTL_VAR'] = '-100' }
 
       it 'clamps to zero (lower bound)' do
-        result = described_class.parse_ttl_env('TEST_TTL_VAR', default_value)
+        result = test_class.parse_ttl_env('TEST_TTL_VAR', default_value)
         expect(result).to eq(0)
       end
     end
@@ -125,7 +146,7 @@ RSpec.describe Onetime::Models::Features::WithEntitlements do
       before { ENV['TEST_TTL_VAR'] = '0' }
 
       it 'returns zero' do
-        result = described_class.parse_ttl_env('TEST_TTL_VAR', default_value)
+        result = test_class.parse_ttl_env('TEST_TTL_VAR', default_value)
         expect(result).to eq(0)
       end
     end
@@ -134,7 +155,7 @@ RSpec.describe Onetime::Models::Features::WithEntitlements do
       before { ENV['TEST_TTL_VAR'] = '0x1234' }
 
       it 'returns the default value (base 10 only rejects hex)' do
-        result = described_class.parse_ttl_env('TEST_TTL_VAR', default_value)
+        result = test_class.parse_ttl_env('TEST_TTL_VAR', default_value)
         expect(result).to eq(default_value)
       end
     end
@@ -144,7 +165,7 @@ RSpec.describe Onetime::Models::Features::WithEntitlements do
 
       it 'parses as base 10 (leading zero ignored)' do
         # Integer('0777', 10) parses as 777 in base 10, not octal
-        result = described_class.parse_ttl_env('TEST_TTL_VAR', default_value)
+        result = test_class.parse_ttl_env('TEST_TTL_VAR', default_value)
         expect(result).to eq(777)
       end
     end
@@ -153,12 +174,12 @@ RSpec.describe Onetime::Models::Features::WithEntitlements do
   describe '.free_tier_limits' do
     before do
       # Reset memoization before each test
-      described_class.reset_free_tier_limits!
+      test_class.reset_free_tier_limits!
     end
 
     after do
       ENV.delete('PLAN_TTL_ANONYMOUS')
-      described_class.reset_free_tier_limits!
+      test_class.reset_free_tier_limits!
     end
 
     context 'when PLAN_TTL_ANONYMOUS is not set' do
@@ -166,13 +187,13 @@ RSpec.describe Onetime::Models::Features::WithEntitlements do
         # See #3111: the constant must match `free_v1.limits.secret_lifetime`
         # in etc/billing.yaml (1_209_600) so that empty-planid orgs get the
         # same 14-day ceiling as the canonical free_v1 plan.
-        limits = described_class.free_tier_limits
+        limits = test_class.free_tier_limits
         expect(limits['secret_lifetime.max']).to eq(1_209_600)
         expect(limits['secret_lifetime.max']).to eq(14 * 24 * 60 * 60)
       end
 
       it 'returns default organization limits' do
-        limits = described_class.free_tier_limits
+        limits = test_class.free_tier_limits
         expect(limits['organizations.max']).to eq(5)
         expect(limits['teams.max']).to eq(0)
         expect(limits['members_per_team.max']).to eq(0)
@@ -183,12 +204,12 @@ RSpec.describe Onetime::Models::Features::WithEntitlements do
       before { ENV['PLAN_TTL_ANONYMOUS'] = '2592000' }
 
       it 'returns overridden secret_lifetime.max' do
-        limits = described_class.free_tier_limits
+        limits = test_class.free_tier_limits
         expect(limits['secret_lifetime.max']).to eq(2_592_000)
       end
 
       it 'does not affect other limits' do
-        limits = described_class.free_tier_limits
+        limits = test_class.free_tier_limits
         expect(limits['organizations.max']).to eq(5)
         expect(limits['teams.max']).to eq(0)
       end
@@ -198,7 +219,7 @@ RSpec.describe Onetime::Models::Features::WithEntitlements do
       before { ENV['PLAN_TTL_ANONYMOUS'] = '999999999' }
 
       it 'caps secret_lifetime.max at MAX_TTL' do
-        limits = described_class.free_tier_limits
+        limits = test_class.free_tier_limits
         expect(limits['secret_lifetime.max']).to eq(described_class::MAX_TTL)
       end
     end
@@ -207,7 +228,7 @@ RSpec.describe Onetime::Models::Features::WithEntitlements do
       before { ENV['PLAN_TTL_ANONYMOUS'] = 'invalid' }
 
       it 'falls back to DEFAULT_FREE_TTL (14 days)' do
-        limits = described_class.free_tier_limits
+        limits = test_class.free_tier_limits
         expect(limits['secret_lifetime.max']).to eq(described_class::DEFAULT_FREE_TTL)
         expect(limits['secret_lifetime.max']).to eq(1_209_600)
       end
@@ -215,40 +236,25 @@ RSpec.describe Onetime::Models::Features::WithEntitlements do
 
     context 'memoization behavior' do
       it 'returns the same frozen hash on subsequent calls' do
-        first_call = described_class.free_tier_limits
-        second_call = described_class.free_tier_limits
+        first_call = test_class.free_tier_limits
+        second_call = test_class.free_tier_limits
         expect(first_call).to be(second_call)
         expect(first_call).to be_frozen
       end
 
       it 'can be reset for testing' do
         ENV['PLAN_TTL_ANONYMOUS'] = '1000'
-        first_limits = described_class.free_tier_limits
+        first_limits = test_class.free_tier_limits
         expect(first_limits['secret_lifetime.max']).to eq(1000)
 
         ENV['PLAN_TTL_ANONYMOUS'] = '2000'
         # Without reset, should return memoized value
-        expect(described_class.free_tier_limits['secret_lifetime.max']).to eq(1000)
+        expect(test_class.free_tier_limits['secret_lifetime.max']).to eq(1000)
 
         # After reset, should pick up new value
-        described_class.reset_free_tier_limits!
-        expect(described_class.free_tier_limits['secret_lifetime.max']).to eq(2000)
+        test_class.reset_free_tier_limits!
+        expect(test_class.free_tier_limits['secret_lifetime.max']).to eq(2000)
       end
-    end
-  end
-
-  describe 'FREE_TIER_LIMITS constant' do
-    it 'is frozen' do
-      expect(described_class::FREE_TIER_LIMITS).to be_frozen
-    end
-
-    it 'contains expected keys' do
-      expect(described_class::FREE_TIER_LIMITS.keys).to include(
-        'organizations.max',
-        'teams.max',
-        'members_per_team.max',
-        'secret_lifetime.max'
-      )
     end
   end
 
@@ -263,7 +269,7 @@ RSpec.describe Onetime::Models::Features::WithEntitlements do
     it 'equals 14 days in seconds (matches free_v1 plan)' do
       # Regression test for #3111. The constant must match
       # `free_v1.limits.secret_lifetime` in etc/billing.yaml so that the
-      # FREE_TIER_LIMITS fallback (used when planid is empty or cache miss)
+      # free_tier_limits fallback (used when planid is empty or cache miss)
       # does not silently impose a stricter ceiling than the canonical
       # free_v1 plan documented in the catalog.
       expect(described_class::DEFAULT_FREE_TTL).to eq(14 * 24 * 60 * 60)
@@ -287,7 +293,7 @@ RSpec.describe Onetime::Models::Features::WithEntitlements do
 
     it 'matches the secret_lifetime declared by free_v1 in billing.example.yaml' do
       # The example billing YAML is the documentation source-of-truth for
-      # the free tier ceiling. If this drifts, FREE_TIER_LIMITS will silently
+      # the free tier ceiling. If this drifts, free_tier_limits will silently
       # disagree with what operators read in the catalog file.
       yaml_path = File.expand_path('../../../../../etc/examples/billing.example.yaml', __dir__)
       raw = File.read(yaml_path)
@@ -301,36 +307,15 @@ RSpec.describe Onetime::Models::Features::WithEntitlements do
   end
 
   describe 'integration with limit_for' do
-    # Mock class that includes WithEntitlements
-    let(:test_class) do
-      Class.new do
-        include Onetime::Models::Features::WithEntitlements
-
-        attr_accessor :planid
-
-        def initialize(planid = nil)
-          @planid = planid
-        end
-
-        def billing_enabled?
-          true
-        end
-
-        def extid
-          'test-org-extid'
-        end
-      end
-    end
-
     let(:org) { test_class.new(nil) } # No plan = free tier
 
     before do
-      described_class.reset_free_tier_limits!
+      test_class.reset_free_tier_limits!
     end
 
     after do
       ENV.delete('PLAN_TTL_ANONYMOUS')
-      described_class.reset_free_tier_limits!
+      test_class.reset_free_tier_limits!
     end
 
     context 'when PLAN_TTL_ANONYMOUS is not set' do
@@ -406,33 +391,13 @@ RSpec.describe Onetime::Models::Features::WithEntitlements do
   # than the published free_v1 14-day limit. These tests pin down the
   # contract so the drift cannot silently return.
   describe '#3111 regression: free tier TTL parity with free_v1', billing: true do
-    let(:test_class) do
-      Class.new do
-        include Onetime::Models::Features::WithEntitlements
-
-        attr_accessor :planid
-
-        def initialize(planid = nil)
-          @planid = planid
-        end
-
-        def billing_enabled?
-          true
-        end
-
-        def extid
-          'test-org-extid'
-        end
-      end
-    end
-
     before do
-      described_class.reset_free_tier_limits!
+      test_class.reset_free_tier_limits!
     end
 
     after do
       ENV.delete('PLAN_TTL_ANONYMOUS')
-      described_class.reset_free_tier_limits!
+      test_class.reset_free_tier_limits!
     end
 
     context 'when planid is empty string (billing enabled, no plan assigned)' do
@@ -462,19 +427,6 @@ RSpec.describe Onetime::Models::Features::WithEntitlements do
           Billing::PlanCacheMissError,
           /Plan not found in cache or config/
         )
-      end
-    end
-
-    context 'FREE_TIER_LIMITS constant (resolved at load time)' do
-      it 'secret_lifetime.max equals 14 days' do
-        # The legacy constant is captured from free_tier_limits at class
-        # load. We verify the constant directly to ensure legacy callers
-        # receive the correct 14-day default. Unlike the memoized method,
-        # the constant is frozen and immutable, so this pins the load-time
-        # contract for backwards-compat consumers.
-        limits = described_class::FREE_TIER_LIMITS
-        expect(limits['secret_lifetime.max']).to eq(described_class::DEFAULT_FREE_TTL)
-        expect(limits['secret_lifetime.max']).to eq(1_209_600)
       end
     end
 


### PR DESCRIPTION
Restructures `WithEntitlements` to match the idiomatic Familia Feature module pattern used by `WithCustomDomains` and others.

- Moves `parse_ttl_env`, `free_tier_limits`, and `reset_free_tier_limits!` from module-level `self.` methods into `ClassMethods`, so they are available on including classes (e.g. `Organization.free_tier_limits`)
- Removes the deprecated `FREE_TIER_LIMITS` constant
- Updates `free_tier_limit_for` to call through the class (`self.class.free_tier_limits`) instead of the module directly
- Rewrites spec to use a test class that includes the feature rather than calling methods on the module itself

Relates to #3134