### PR TITLE
Generate base plan entries and add --force to materialize

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -75,7 +75,7 @@ gem 'truemail'
 # ORMs and database drivers
 # NOTE: We install both db drivers for the OCI images so that users can choose
 # which database to use at runtime via environment variable without rebuilding.
-gem 'familia', '~> 2.9'
+gem 'familia', '~> 2.9.1'
 gem 'pg', '~> 1.6'
 gem 'sequel', '~> 5.0'
 gem 'sqlite3', '~> 2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -128,7 +128,7 @@ GEM
       tzinfo
     faker (3.6.1)
       i18n (>= 1.8.11, < 2)
-    familia (2.9.0)
+    familia (2.9.1)
       concurrent-ruby (~> 1.3)
       connection_pool (>= 2.4, < 4.0)
       csv (~> 3.3)
@@ -622,7 +622,7 @@ DEPENDENCIES
   dry-cli (~> 1.2)
   encryptor (= 1.1.3)
   faker (~> 3.2)
-  familia (~> 2.9)
+  familia (~> 2.9.1)
   fastimage (~> 2.4)
   htmlbeautifier
   httparty

--- a/apps/web/billing/cli/plans_materialize_command.rb
+++ b/apps/web/billing/cli/plans_materialize_command.rb
@@ -38,6 +38,11 @@ module Onetime
         default: false,
         desc: 'Only materialize orgs where entitlements are stale vs current plan'
 
+      option :force,
+        type: :boolean,
+        default: false,
+        desc: 'Force re-materialization even if entitlements are up to date'
+
       option :run,
         type: :boolean,
         default: false,
@@ -55,7 +60,7 @@ module Onetime
         aliases: ['h'],
         desc: 'Show help message'
 
-      def call(all: false, plan: nil, stale: false, run: false, verbose: false, help: false, **)
+      def call(all: false, plan: nil, stale: false, force: false, run: false, verbose: false, help: false, **)
         return show_usage_help if help
 
         boot_application!
@@ -77,7 +82,7 @@ module Onetime
           return
         end
 
-        print_mode_banner(dry_run, all, plan, stale)
+        print_mode_banner(dry_run, all, plan, stale, force)
 
         stats             = { total: 0, materialized: 0, skipped_no_plan: 0, skipped_up_to_date: 0, skipped_plan_filter: 0, errors: [] }
         progress_interval = [total / 10, 1].max
@@ -88,7 +93,7 @@ module Onetime
         plans_cache = ::Billing::Plan.list_plans.to_h { |p| [p.plan_id, p] }
 
         Onetime::Organization.instances.each_record(batch_size: 100) do |org|
-          process_org(org, stats, total, dry_run, verbose, stale, plan, progress_interval, plans_cache)
+          process_org(org, stats, total, dry_run, verbose, stale, force, plan, progress_interval, plans_cache)
         end
 
         print_results(stats, dry_run, verbose)
@@ -103,7 +108,8 @@ module Onetime
         org.planid.to_s != plan_filter
       end
 
-      def skip_for_stale_filter?(org, stale_only, plans_cache)
+      def skip_for_stale_filter?(org, stale_only, force, plans_cache)
+        return false if force
         return false unless stale_only
         return false unless org.entitlements_materialized?
 
@@ -113,13 +119,14 @@ module Onetime
         !org.entitlements_stale?(plan)
       end
 
-      def print_mode_banner(dry_run, all, plan, stale)
+      def print_mode_banner(dry_run, all, plan, stale, force)
         scope  = if all
                   'all organizations'
                 else
                   "organizations on plan '#{plan}'"
                 end
         scope += ' (stale only)' if stale
+        scope += ' (force)' if force
 
         if dry_run
           puts "\nDRY RUN MODE - No changes will be made"
@@ -132,7 +139,7 @@ module Onetime
       end
 
       # rubocop:disable Metrics/PerceivedComplexity
-      def process_org(org, stats, total, dry_run, verbose, stale_only, plan_filter, progress_interval, plans_cache)
+      def process_org(org, stats, total, dry_run, verbose, stale_only, force, plan_filter, progress_interval, plans_cache)
         stats[:total] += 1
         idx            = stats[:total]
 
@@ -149,7 +156,7 @@ module Onetime
           return
         end
 
-        if skip_for_stale_filter?(org, stale_only, plans_cache)
+        if skip_for_stale_filter?(org, stale_only, force, plans_cache)
           stats[:skipped_up_to_date] += 1
           puts "  [#{idx}/#{total}] Skipping (up to date): #{org.extid}" if verbose
           print_progress(idx, total, verbose, progress_interval)
@@ -165,7 +172,7 @@ module Onetime
           return
         end
 
-        if !stale_only && org.entitlements_materialized? && !org.entitlements_stale?(plan)
+        if !force && !stale_only && org.entitlements_materialized? && !org.entitlements_stale?(plan)
           stats[:skipped_up_to_date] += 1
           puts "  [#{idx}/#{total}] Skipping (up to date): #{org.extid}" if verbose
           print_progress(idx, total, verbose, progress_interval)
@@ -254,6 +261,7 @@ module Onetime
             --all                 Materialize all organizations (migration mode)
             --plan=<plan_id>      Materialize only organizations on this plan
             --stale               Only materialize orgs where entitlements are stale
+            --force               Force re-materialization even if up to date
             --run                 Execute materialization (default is dry-run)
             --verbose, -v         Show detailed progress for each organization
             --help, -h            Show this help message
@@ -270,6 +278,9 @@ module Onetime
 
             # Only update stale orgs (efficient for large deployments)
             bin/ots billing plans materialize --all --stale --run
+
+            # Force re-materialize all orgs (ignore up-to-date checks)
+            bin/ots billing plans materialize --all --force --run
 
           Notes:
             - Command is idempotent (safe to run multiple times)

--- a/apps/web/billing/models/plan.rb
+++ b/apps/web/billing/models/plan.rb
@@ -284,6 +284,13 @@ module Billing
           return 0
         end
 
+        # PHASE 1b: Generate base plan entries (no interval suffix)
+        # These alias entries allow orgs to use canonical plan_ids (e.g., 'identity_plus_v1')
+        # while preserving interval-suffixed entries for checkout pricing lookup.
+        base_entries = generate_base_plan_entries(plan_data_list)
+        plan_data_list.concat(base_entries)
+        OT.li "[Plan.refresh_from_stripe] Generated #{base_entries.size} base plan entries"
+
         progress&.call("Upserting #{plan_data_list.size} plans...")
 
         # PHASE 2: Upsert all plans (NO clear_cache!)
@@ -837,6 +844,37 @@ module Billing
 
         OT.li "[Plan.prune_stale_plans] Pruned #{pruned_count} stale plans" if pruned_count.positive?
         pruned_count
+      end
+
+      # Generate base plan entries (no interval suffix) from interval-suffixed plans
+      #
+      # Creates alias entries keyed by base plan_id (e.g., 'identity_plus_v1') that
+      # mirror the entitlements/limits of the interval-suffixed entries. This allows
+      # org.planid to use the canonical no-suffix format while preserving interval-
+      # suffixed entries for checkout (PlanResolver needs them for pricing lookup).
+      #
+      # @param plan_data_list [Array<Hash>] Plan data with interval-suffixed plan_ids
+      # @return [Array<Hash>] Additional base plan entries to upsert
+      def generate_base_plan_entries(plan_data_list)
+        base_entries = {}
+
+        plan_data_list.each do |plan_data|
+          plan_id      = plan_data[:plan_id]
+          base_plan_id = plan_id.sub(/_(month|year)ly\z/, '')
+
+          # Skip if this is already a base entry (no suffix stripped)
+          next if base_plan_id == plan_id
+
+          # Use first encountered entry as template (monthly/yearly have same entitlements)
+          next if base_entries.key?(base_plan_id)
+
+          base_entries[base_plan_id] = plan_data.merge(
+            plan_id: base_plan_id,
+            interval: nil,
+          )
+        end
+
+        base_entries.values
       end
 
       # Get plan by tier, interval, and region

--- a/apps/web/billing/spec/cli/plans_materialize_command_spec.rb
+++ b/apps/web/billing/spec/cli/plans_materialize_command_spec.rb
@@ -1,0 +1,120 @@
+# apps/web/billing/spec/cli/plans_materialize_command_spec.rb
+#
+# frozen_string_literal: true
+
+# Specs for `bin/ots billing plans materialize`.
+#
+# Tests the --force option which re-materializes entitlements
+# even when they are already up to date.
+#
+# Run: pnpm run test:rspec apps/web/billing/spec/cli/plans_materialize_command_spec.rb
+
+require_relative '../support/billing_spec_helper'
+require 'onetime/cli'
+require_relative '../../cli/plans_materialize_command'
+
+RSpec.describe 'Billing Plans Materialize CLI', :billing_cli do
+  subject(:command) { Onetime::CLI::BillingPlansMaterializeCommand.new }
+
+  def run_command(**kwargs)
+    old_stdout = $stdout
+    $stdout    = StringIO.new
+    command.call(**kwargs)
+    $stdout.string
+  ensure
+    $stdout = old_stdout
+  end
+
+  before do
+    allow(command).to receive(:boot_application!)
+  end
+
+  describe '--help' do
+    it 'documents the --force option' do
+      output = run_command(help: true)
+
+      expect(output).to include('--force')
+      expect(output).to include('Force re-materialization')
+    end
+  end
+
+  describe '--force option' do
+    let(:mock_org) { instance_double(Onetime::Organization) }
+    let(:mock_plan) { instance_double(Billing::Plan) }
+    let(:mock_instances) { instance_double(Familia::SortedSet) }
+    let(:mock_entitlements) { double('entitlements') }
+
+    before do
+      allow(Onetime::Organization).to receive(:instances).and_return(mock_instances)
+      allow(mock_instances).to receive(:element_count).and_return(1)
+      allow(mock_instances).to receive(:each_record).and_yield(mock_org)
+
+      allow(mock_org).to receive(:extid).and_return('org_test123')
+      allow(mock_org).to receive(:planid).and_return('test_plan_v1')
+
+      allow(mock_plan).to receive(:plan_id).and_return('test_plan_v1')
+      allow(mock_plan).to receive(:entitlements).and_return(mock_entitlements)
+      allow(mock_entitlements).to receive(:size).and_return(5)
+
+      allow(Billing::Plan).to receive(:list_plans).and_return([mock_plan])
+    end
+
+    context 'when org is already up to date' do
+      before do
+        allow(mock_org).to receive(:entitlements_materialized?).and_return(true)
+        allow(mock_org).to receive(:entitlements_stale?).and_return(false)
+      end
+
+      it 'skips the org without --force (dry run)' do
+        output = run_command(all: true, run: false)
+
+        # Stats show 1 skipped, 0 materialized
+        expect(output).to include('Skipped (up to date):')
+        expect(output).to match(/Skipped \(up to date\):\s+1/)
+        expect(output).to match(/Materialized:\s+0/)
+        expect(output).not_to include('Would materialize')
+      end
+
+      it 'processes the org with --force (dry run)' do
+        output = run_command(all: true, force: true, run: false)
+
+        expect(output).to include('Would materialize')
+        expect(output).to include('org_test123')
+        # Stats show 1 materialized, 0 skipped
+        expect(output).to match(/Materialized:\s+1/)
+        expect(output).to match(/Skipped \(up to date\):\s+0/)
+      end
+
+      it 'materializes the org with --force --run' do
+        allow(mock_org).to receive(:materialize_entitlements_from_plan)
+
+        output = run_command(all: true, force: true, run: true)
+
+        expect(mock_org).to have_received(:materialize_entitlements_from_plan).with(mock_plan)
+        expect(output).to include('Materialized:')
+      end
+
+      it 'shows (force) in the scope banner' do
+        output = run_command(all: true, force: true, run: false)
+
+        expect(output).to include('(force)')
+      end
+    end
+
+    context 'when using --stale with --force' do
+      before do
+        allow(mock_org).to receive(:entitlements_materialized?).and_return(true)
+        allow(mock_org).to receive(:entitlements_stale?).and_return(false)
+      end
+
+      it '--force overrides --stale skip logic' do
+        output = run_command(all: true, stale: true, force: true, run: false)
+
+        expect(output).to include('Would materialize')
+        # Stats show 1 materialized, 0 skipped
+        expect(output).to match(/Materialized:\s+1/)
+        expect(output).to match(/Skipped \(up to date\):\s+0/)
+      end
+    end
+  end
+end

--- a/apps/web/billing/spec/models/plan_upsert_spec.rb
+++ b/apps/web/billing/spec/models/plan_upsert_spec.rb
@@ -1486,3 +1486,73 @@ RSpec.describe 'Billing::Plan.send(:collect_stripe_plans) validation', type: :bi
     end
   end
 end
+
+RSpec.describe 'Billing::Plan.generate_base_plan_entries', type: :billing do
+  describe 'base plan entry generation' do
+    let(:monthly_plan_data) do
+      {
+        plan_id: 'identity_plus_v1_monthly',
+        interval: 'month',
+        entitlements: %w[create_secrets custom_domains],
+        limits: { teams: 1 },
+        name: 'Identity Plus',
+      }
+    end
+
+    let(:yearly_plan_data) do
+      {
+        plan_id: 'identity_plus_v1_yearly',
+        interval: 'year',
+        entitlements: %w[create_secrets custom_domains],
+        limits: { teams: 1 },
+        name: 'Identity Plus',
+      }
+    end
+
+    let(:team_monthly_data) do
+      {
+        plan_id: 'team_plus_v1_monthly',
+        interval: 'month',
+        entitlements: %w[create_secrets custom_domains manage_teams],
+        limits: { teams: 5 },
+        name: 'Team Plus',
+      }
+    end
+
+    it 'generates base entries from interval-suffixed plans' do
+      plan_data_list = [monthly_plan_data, yearly_plan_data]
+      result = Billing::Plan.send(:generate_base_plan_entries, plan_data_list)
+
+      expect(result.size).to eq(1)
+      expect(result.first[:plan_id]).to eq('identity_plus_v1')
+      expect(result.first[:interval]).to be_nil
+      expect(result.first[:entitlements]).to eq(%w[create_secrets custom_domains])
+    end
+
+    it 'generates one base entry per unique base plan_id' do
+      plan_data_list = [monthly_plan_data, yearly_plan_data, team_monthly_data]
+      result = Billing::Plan.send(:generate_base_plan_entries, plan_data_list)
+
+      expect(result.size).to eq(2)
+      plan_ids = result.map { |p| p[:plan_id] }
+      expect(plan_ids).to contain_exactly('identity_plus_v1', 'team_plus_v1')
+    end
+
+    it 'skips entries that already lack interval suffix' do
+      base_only = { plan_id: 'free_v1', interval: nil, entitlements: [] }
+      plan_data_list = [monthly_plan_data, base_only]
+      result = Billing::Plan.send(:generate_base_plan_entries, plan_data_list)
+
+      expect(result.size).to eq(1)
+      expect(result.first[:plan_id]).to eq('identity_plus_v1')
+    end
+
+    it 'uses first encountered entry as template' do
+      plan_data_list = [monthly_plan_data, yearly_plan_data]
+      result = Billing::Plan.send(:generate_base_plan_entries, plan_data_list)
+
+      # Should use monthly (first encountered) as template
+      expect(result.first[:name]).to eq('Identity Plus')
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Preparatory changes for Phase 3 (#3135) that enable orgs to use canonical plan IDs while preserving checkout compatibility.

- **Familia v2.9.1**: Bumps dependency for pipeline fix.

- **Base plan entry generation**: During `catalog pull` or `plans --refresh`, creates no-suffix cache entries (e.g., `identity_plus_v1`) alongside the interval-suffixed ones (`identity_plus_v1_monthly`, `identity_plus_v1_yearly`). All three share the same entitlements/limits, allowing `org.planid` to use canonical IDs while `PlanResolver` still finds interval-suffixed entries for checkout.

- **`--force` option for materialize**: Bypasses "up to date" checks so all orgs get re-materialized regardless of existing `materialized_entitlements_at` timestamp. Useful after plan definition changes or to force a full refresh.

## Test plan

- [x] 117 plan specs pass (existing + 4 new for `generate_base_plan_entries`)
- [x] 6 new specs for `--force` behavior in dry-run and execute modes
- [ ] Run `bin/ots billing catalog pull` and verify base entries appear
- [x] Run `bin/ots billing plans materialize --all --force --run` and verify 0 "Skipped (up to date)"

Part of #3135