### PR TITLE
Skip Claude code review on fork PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -23,7 +23,17 @@ jobs:
     #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
     # if: ${{ !startsWith(github.head_ref, 'deps/') }}
     runs-on: ubuntu-latest
-    # Skip bot-created PRs (renovate, dependabot, etc.) - they show as 'name[bot]' in github.actor
+    # Run only when ALL of the following are true:
+    #   1. Author is not a bot (renovate, dependabot, etc. surface as 'name[bot]' in github.actor).
+    #   2. PR head is not from a fork. Fork PRs run without access to repository
+    #      secrets, so CLAUDE_CODE_OAUTH_TOKEN is empty and the action would fail.
+    #      External contributions should be reviewed manually or via a maintainer-triggered
+    #      workflow that runs against the merged ref.
+    #   3. The event is one of:
+    #        - a freshly opened PR (always reviewed on open),
+    #        - a 'claude-review' label being added (manual trigger), or
+    #        - a push to a PR that already carries the 'claude-review' label
+    #          (so subsequent commits keep getting reviewed without re-labeling).
     if: ${{
       !endsWith(github.actor, '[bot]') &&
       !github.event.pull_request.head.repo.fork &&

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -26,6 +26,7 @@ jobs:
     # Skip bot-created PRs (renovate, dependabot, etc.) - they show as 'name[bot]' in github.actor
     if: ${{
       !endsWith(github.actor, '[bot]') &&
+      !github.event.pull_request.head.repo.fork &&
       (
         (github.event.action == 'opened') ||
         (github.event.action == 'labeled' && github.event.label.name == 'claude-review') ||


### PR DESCRIPTION
## Summary
- Add `!github.event.pull_request.head.repo.fork` guard to the `claude-review` job so PRs from forks are skipped instead of failing on a missing `CLAUDE_CODE_OAUTH_TOKEN` (forks don't get access to repo secrets).
- Document each `if:` condition inline so the intent of the bot, fork, and event-type guards is obvious to future maintainers.

## Test plan
- [ ] Open a same-repo PR targeting one of the watched bases (`main`, `develop`, `feature/*`, etc.) and confirm the `claude-review` job runs as before.
- [ ] Open a fork PR against the same base and confirm the `claude-review` job is skipped (not failed).
- [ ] Apply the `claude-review` label to an existing same-repo PR and confirm the job re-runs.
- [ ] Confirm bot-authored PRs (renovate/dependabot) continue to be skipped.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DN28FYari5NmW1DhHpxnhw)_