### PR TITLE
Extract billing catalog operations into composable service objects

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -337,6 +337,7 @@ Metrics/ClassLength:
   Max: 350
   Exclude:
     - 'apps/web/billing/cli/catalog_push_command.rb' # CLI command with self-contained sync logic
+    - 'apps/web/billing/operations/catalog/push.rb' # Operations class with self-contained sync logic
 
 # Offense count: non-0
 Metrics/MethodLength:

--- a/apps/web/billing/cli/catalog_pull_command.rb
+++ b/apps/web/billing/cli/catalog_pull_command.rb
@@ -3,6 +3,7 @@
 # frozen_string_literal: true
 
 require_relative 'helpers'
+require_relative '../operations/catalog/pull'
 
 module Onetime
   module CLI
@@ -19,46 +20,28 @@ module Onetime
 
       def call(clear: false, **)
         boot_application!
-
         return unless stripe_configured?
 
-        # Clear cache if requested
-        if clear
-          puts 'Clearing existing plan cache...'
-          Billing::Plan.clear_cache
-          puts '✓ Cache cleared'
-          puts
+        result = Billing::Operations::Catalog::Pull.call(
+          clear_cache: clear,
+          progress: method(:show_progress),
+        )
+
+        puts "\n"
+
+        if result.success
+          puts "Successfully pulled #{result.plans_synced} plan(s) from Stripe"
+          puts "Upserted #{result.config_plans_loaded} config-only plan(s)" if result.config_plans_loaded > 0
+          puts "\nTo view cached plans:"
+          puts '  bin/ots billing plans'
+        else
+          result.errors.each { |e| puts "Error: #{e}" }
+          exit 1
         end
-
-        puts 'Pulling from Stripe to Redis cache...'
-        puts
-
-        # Use retry wrapper for resilience against network errors
-        count = with_stripe_retry do
-          Billing::Plan.refresh_from_stripe(progress: method(:show_progress))
-        end
-
-        # Upsert config-only plans (free tier, etc.) after Stripe sync
-        config_count = Billing::Plan.upsert_config_only_plans
-
-        puts "\n\nSuccessfully pulled #{count} plan(s) from Stripe"
-        puts "Upserted #{config_count} config-only plan(s)" if config_count > 0
-        puts "\nTo view cached plans:"
-        puts '  bin/ots billing plans'
-      rescue Stripe::StripeError => ex
-        puts format_stripe_error('Pull failed', ex)
-        puts "\nTroubleshooting:"
-        puts '  - Verify STRIPE_API_KEY is set correctly'
-        puts '  - Check your internet connection'
-        puts '  - Verify Stripe account has access to products'
-      rescue StandardError => ex
-        puts "Error during pull: #{ex.message}"
-        puts ex.backtrace.first(5).join("\n") if OT.debug?
       end
 
       private
 
-      # Show progress during pull
       def show_progress(message)
         print "\r#{message}"
         $stdout.flush

--- a/apps/web/billing/cli/catalog_push_command.rb
+++ b/apps/web/billing/cli/catalog_push_command.rb
@@ -3,8 +3,7 @@
 # frozen_string_literal: true
 
 require_relative 'helpers'
-require_relative '../errors'
-require_relative '../config'
+require_relative '../operations/catalog/push'
 
 module Onetime
   module CLI
@@ -13,11 +12,6 @@ module Onetime
     # Syncs the YAML billing catalog to Stripe, creating or updating
     # products as needed. Prices are NEVER updated - only created when
     # all required fields are provided.
-    #
-    # All plans are synced including free tier. Free plans in Stripe enable:
-    # - Downgrade flows (manual or after subscription cancellation)
-    # - Targeted free/discounted plans for non-profits
-    # - Consistent plan metadata across all tiers
     #
     class BillingCatalogPushCommand < Command
       include BillingHelpers
@@ -45,590 +39,57 @@ module Onetime
 
       def call(dry_run: false, force: false, plan: nil, skip_prices: false, **)
         boot_application!
-
         return unless stripe_configured?
-
-        catalog = load_catalog
-        return unless catalog
-
-        app_identifier   = catalog['app_identifier'] || Billing::Metadata::APP_NAME
-        plans            = catalog['plans'] || {}
-        match_fields     = catalog['match_fields'] || ['plan_id']
-        region_filter    = catalog['region']
-        catalog_currency = (catalog['currency'] || 'cad').to_s.strip.downcase
-
-        if plans.empty?
-          puts 'No plans found in catalog'
-          return
-        end
-
-        # Filter to single plan if specified
-        if plan
-          unless plans.key?(plan)
-            puts "Plan '#{plan}' not found in catalog"
-            puts "\nAvailable plans: #{plans.keys.join(', ')}"
-            return
-          end
-          plans = { plan => plans[plan] }
-        end
 
         puts "Billing Catalog Push#{' (DRY RUN)' if dry_run}"
         puts '=' * 50
-        puts "App identifier: #{app_identifier}"
-        puts "Match fields: #{match_fields.join(', ')}"
-        puts "Catalog currency: #{catalog_currency}"
-        puts "Region filter: #{region_filter || '(none)'}"
-        puts "Plans to process: #{plans.keys.join(', ')}"
+
+        # Confirmation unless dry_run or --force
+        unless dry_run || force
+          print "\nProceed with catalog push? (y/n): "
+          response = $stdin.gets
+          return unless response&.chomp&.downcase == 'y'
+        end
+
+        result = Billing::Operations::Catalog::Push.call(
+          dry_run: dry_run,
+          plan_filter: plan,
+          skip_prices: skip_prices,
+          progress: method(:show_progress),
+        )
+
         puts
 
-        # Fetch existing products from Stripe
-        existing_products = fetch_existing_products(app_identifier, match_fields, region_filter, plans)
-        existing_prices   = fetch_existing_prices(existing_products)
-
-        # Analyze changes
-        changes = analyze_changes(plans, existing_products, existing_prices, skip_prices, match_fields, catalog_currency)
-
-        if changes[:products_to_create].empty? &&
-           changes[:products_to_update].empty? &&
-           changes[:prices_to_create].empty?
-          puts 'No changes needed - Stripe is in sync with catalog'
-          return
+        if result.success
+          display_success(result, dry_run)
+        else
+          result.errors.each { |e| puts "Error: #{e}" }
+          exit 1
         end
-
-        # Display changes
-        display_changes(changes, dry_run)
-
-        return if dry_run
-
-        # Confirm unless --force
-        unless force
-          print "\nProceed with these changes? (y/n): "
-          response = $stdin.gets
-          return unless response # Handle EOF/Ctrl+D gracefully
-          return unless response.chomp.downcase == 'y'
-        end
-
-        # Apply changes
-        apply_changes(changes, app_identifier)
-
-        puts "\nCatalog push complete!"
-        puts 'Run `bin/ots billing catalog pull` to sync to Redis cache'
       end
 
       private
 
-      def load_catalog
-        unless Billing::Config.config_exists?
-          puts "Catalog not found: #{Billing::Config.config_path}"
-          return nil
-        end
-
-        catalog = Billing::Config.safe_load_config
-        if catalog.empty?
-          puts 'Failed to load catalog (check logs for details)'
-          return nil
-        end
-
-        catalog
+      def show_progress(message)
+        puts message
       end
 
-      # Fetch existing products from Stripe, indexed by composite match key.
-      #
-      # Products are included if they match EITHER:
-      # 1. app metadata filter (standard matching), OR
-      # 2. explicit stripe_product_id override in catalog (legacy product support)
-      #
-      # Legacy products (via stripe_product_id override) may lack metadata fields
-      # required for composite key generation. These are stored by product ID
-      # prefixed with "__id__" so resolve_existing_product can find them.
-      #
-      # @param app_identifier [String] Filter to products with this app metadata
-      # @param match_fields [Array<String>] Fields to build composite match key (e.g., ['plan_id', 'region'])
-      # @param region_filter [String, nil] If set, only return products matching this region
-      # @param plans [Hash] Plan definitions from catalog (for stripe_product_id overrides)
-      # @return [Hash<String, Stripe::Product>] Products indexed by composite match key
-      def fetch_existing_products(app_identifier, match_fields, region_filter, plans = {})
-        products = {}
+      def display_success(result, dry_run)
+        prefix = dry_run ? '[DRY RUN] Would' : 'Completed:'
 
-        # Collect explicit stripe_product_id overrides from catalog
-        override_product_ids = plans.values
-          .map { |plan_def| plan_def['stripe_product_id'] }
-          .compact
-          .to_set
-
-        with_stripe_retry do
-          Stripe::Product.list(active: true, limit: 100).auto_paging_each do |product|
-            # Include if: app metadata matches OR product ID is an explicit override
-            has_app_match      = product.metadata['app'] == app_identifier
-            has_override_match = override_product_ids.include?(product.id)
-
-            next unless has_app_match || has_override_match
-
-            # Region filtering: skip products not matching our region context
-            # Skip region filter for explicit overrides (they need metadata bootstrapping)
-            if region_filter && !has_override_match && !Billing::RegionNormalizer.match?(product.metadata['region'], region_filter)
-              next
-            end
-
-            # Build composite match key from metadata fields
-            key = build_match_key_from_metadata(product.metadata, match_fields)
-
-            if key
-              products[key] = product
-            elsif has_override_match
-              # Legacy products may lack metadata for match key; store by product ID
-              # so resolve_existing_product can find them via .values search
-              products["__id__#{product.id}"] = product
-            end
-          end
+        if result.no_changes
+          puts 'No changes needed - Stripe is in sync with catalog'
+          return
         end
 
-        products
-      end
+        puts "#{prefix} create #{result.products_created} product(s)" if result.products_created > 0
+        puts "#{prefix} update #{result.products_updated} product(s)" if result.products_updated > 0
+        puts "#{prefix} create #{result.prices_created} price(s)" if result.prices_created > 0
 
-      # Build composite match key from product metadata.
-      #
-      # @param metadata [Hash] Stripe product metadata
-      # @param match_fields [Array<String>] Fields to include in key
-      # @return [String, nil] Composite key or nil if required fields missing
-      def build_match_key_from_metadata(metadata, match_fields)
-        values = match_fields.map { |f| metadata[f]&.to_s }
-        return nil if values.any?(&:nil?)
-
-        values.join('|')
-      end
-
-      # Build composite match key from local plan definition.
-      #
-      # @param plan_id [String] The plan identifier (YAML key)
-      # @param plan_def [Hash] Plan definition from catalog
-      # @param match_fields [Array<String>] Fields to include in key
-      # @return [String, nil] Composite key, or nil if any required field is missing
-      def build_match_key_from_plan(plan_id, plan_def, match_fields)
-        values = match_fields.map do |field|
-          field == 'plan_id' ? plan_id : plan_def[field]&.to_s
+        unless dry_run
+          puts "\nCatalog push complete!"
+          puts 'Run `bin/ots billing catalog pull` to sync to Redis cache'
         end
-        return nil if values.any?(&:nil?)
-
-        values.join('|')
-      end
-
-      def fetch_existing_prices(products)
-        prices      = {}
-        product_ids = products.values.map(&:id)
-
-        return prices if product_ids.empty?
-
-        with_stripe_retry do
-          Stripe::Price.list(active: true, limit: 100).auto_paging_each do |price|
-            next unless product_ids.include?(price.product)
-
-            # Find match key for this product (composite key like "plan_id|region")
-            match_key = products.find { |_k, p| p.id == price.product }&.first
-            next unless match_key
-
-            prices[match_key] ||= []
-            prices[match_key] << price
-          end
-        end
-
-        prices
-      end
-
-      def analyze_changes(plans, existing_products, existing_prices, skip_prices, match_fields, catalog_currency = 'cad')
-        changes = {
-          products_to_create: [],
-          products_to_update: [],
-          prices_to_create: [],
-        }
-
-        plans.each do |plan_id, plan_def|
-          # Resolve existing product: stripe_product_id override takes precedence
-          existing = resolve_existing_product(
-            plan_id, plan_def, existing_products, match_fields
-          )
-
-          # Build the match key for price lookups (composite key, not Stripe ID)
-          match_key = build_match_key_from_plan(plan_id, plan_def, match_fields)
-
-          if existing
-            # Check if product needs update
-            updates = detect_product_updates(plan_id, existing, plan_def, catalog_currency)
-            unless updates.empty?
-              changes[:products_to_update] << {
-                plan_id: plan_id,
-                product: existing,
-                updates: updates,
-                plan_def: plan_def,
-              }
-            end
-          elsif plan_def['legacy']
-            # Legacy plans are never created — they only exist for grandfathered
-            # customers. If the product wasn't found (e.g., filtered by region
-            # or stripe_product_id mismatch), skip entirely.
-            puts "  ⏭ #{plan_id}: skipping (legacy plan, product not found)"
-            next
-          else
-            # New product
-            changes[:products_to_create] << {
-              plan_id: plan_id,
-              plan_def: plan_def,
-            }
-          end
-
-          # Check prices unless skipped
-          next if skip_prices
-
-          price_changes = analyze_price_changes(
-            plan_id, plan_def, existing, existing_prices[match_key] || [], catalog_currency
-          )
-          changes[:prices_to_create].concat(price_changes)
-        end
-
-        changes
-      end
-
-      # Resolve existing Stripe product for a plan.
-      #
-      # Matching modes (mutually exclusive):
-      # 1. stripe_product_id override: Direct 1-to-1 binding to a specific Stripe product.
-      #    If specified, this is the ONLY product that can match - no fallback.
-      # 2. Composite match key lookup: Match by plan_id + region (or other configured fields).
-      #    Only used when NO stripe_product_id is specified.
-      #
-      # @param plan_id [String] The plan identifier
-      # @param plan_def [Hash] Plan definition from catalog
-      # @param existing_products [Hash] Products indexed by composite key
-      # @param match_fields [Array<String>] Fields used for matching
-      # @return [Stripe::Product, nil] Matched product or nil
-      def resolve_existing_product(plan_id, plan_def, existing_products, match_fields)
-        # Override: direct Stripe product ID binding (explicit 1-to-1 match)
-        if (override_id = plan_def['stripe_product_id'])
-          product = existing_products.values.find { |p| p.id == override_id }
-          if product
-            puts "  ℹ #{plan_id}: using stripe_product_id override (#{override_id})"
-            return product
-          else
-            # stripe_product_id is an explicit binding - do NOT fall through to composite matching.
-            # The product may exist in Stripe but be filtered out by region, or may not exist at all.
-            # Either way, treat this plan as having no existing product (will create new).
-            puts "  ⚠ #{plan_id}: stripe_product_id '#{override_id}' not found in fetched products"
-            puts '    (product may be filtered by region or not exist - will create new product)'
-            return nil
-          end
-        end
-
-        # Normal matching via composite key (only when no explicit override)
-        match_key = build_match_key_from_plan(plan_id, plan_def, match_fields)
-        existing_products[match_key]
-      end
-
-      def detect_product_updates(plan_id, existing, plan_def, catalog_currency = 'cad')
-        updates = {}
-
-        # Check name
-        if existing.name != plan_def['name']
-          updates[:name] = { from: existing.name, to: plan_def['name'] }
-        end
-
-        # Check marketing_features (i18n locale keys for UI display)
-        existing_features = existing.marketing_features&.map(&:name) || []
-        config_features   = plan_def['features'] || []
-        if existing_features.sort != config_features.sort
-          updates[:marketing_features] = { from: existing_features, to: config_features }
-        end
-
-        # Check metadata fields using registry from Billing::Metadata
-        metadata_fields = build_syncable_metadata(plan_id, plan_def, catalog_currency)
-
-        metadata_fields.each do |field, expected|
-          current = existing.metadata[field]
-          next if current.to_s == expected.to_s
-
-          updates[:"metadata_#{field}"] = { from: current, to: expected }
-        end
-
-        updates
-      end
-
-      # Build metadata fields for update detection from plan definition.
-      # Uses Billing::Metadata::SYNCABLE_FIELDS and LIMIT_FIELDS registries.
-      #
-      # Most fields are always included (even if empty) so that adding or
-      # removing a value is detected as a change. The exception is region:
-      # nil/blank region is intentionally omitted (not written as "") to
-      # avoid erasing existing Stripe metadata. See RegionNormalizer.
-      #
-      # @param plan_id [String] The plan identifier
-      # @param plan_def [Hash] Plan definition from catalog
-      # @return [Hash<String, String>] Metadata fields for comparison
-      def build_syncable_metadata(plan_id, plan_def, catalog_currency = 'cad')
-        metadata_fields                                   = {}
-        metadata_fields[Billing::Metadata::FIELD_PLAN_ID] = plan_id
-        limits                                            = plan_def['limits'] || {}
-
-        # Add all syncable fields from registry (always include for update detection)
-        Billing::Metadata::SYNCABLE_FIELDS.each do |field_name, yaml_key|
-          value = plan_def[yaml_key]
-
-          # Special handling for certain field types. Region returns nil
-          # for blank/missing values; the `if serialized` guard below
-          # ensures nil regions are omitted rather than written as "".
-          serialized = case field_name
-                       when Billing::Metadata::FIELD_ENTITLEMENTS
-                         (value || []).join(',')
-                       when Billing::Metadata::FIELD_IS_POPULAR
-                         (value == true).to_s
-                       when Billing::Metadata::FIELD_REGION
-                         Billing::RegionNormalizer.normalize(value)
-                       else
-                         value.to_s
-                       end
-
-          metadata_fields[field_name] = serialized if serialized
-        end
-
-        # Currency is top-level config, not per-plan — add explicitly
-        metadata_fields[Billing::Metadata::FIELD_CURRENCY] = catalog_currency
-
-        # Add all limit fields from registry (always include for update detection)
-        Billing::Metadata::LIMIT_FIELDS.each do |field_name, yaml_key|
-          metadata_fields[field_name] = limits[yaml_key].to_s
-        end
-
-        metadata_fields
-      end
-
-      def analyze_price_changes(plan_id, plan_def, existing_product, existing_prices, catalog_currency = 'cad')
-        changes        = []
-        catalog_prices = plan_def['prices'] || []
-
-        return changes if catalog_prices.empty?
-
-        # For new products, existing_product will be nil. We still analyze prices
-        # and set product_id to nil - it will be resolved in apply_changes after
-        # the product is created.
-        product_id = existing_product&.id
-
-        catalog_prices.each_with_index do |price_def, idx|
-          # Currency inherited from top-level config if not per-price
-          resolved_currency = (price_def['currency'] || catalog_currency).to_s.strip.downcase
-
-          # Validate all required fields are present
-          missing = []
-          missing << 'amount' unless price_def['amount']
-          missing << 'interval' unless price_def['interval']
-
-          unless missing.empty?
-            puts "  ⚠ #{plan_id} price[#{idx}]: skipping - missing #{missing.join(', ')}"
-            next
-          end
-
-          # Check if matching price exists (only for existing products)
-          if existing_product
-            matching = existing_prices.find do |p|
-              p.unit_amount == price_def['amount'] &&
-                p.currency == resolved_currency &&
-                p.recurring&.interval == price_def['interval']
-            end
-            next if matching # Price already exists
-          end
-
-          changes << {
-            plan_id: plan_id,
-            product_id: product_id, # Can be nil for new products
-            amount: price_def['amount'],
-            currency: resolved_currency,
-            interval: price_def['interval'],
-          }
-        end
-
-        changes
-      end
-
-      def display_changes(changes, dry_run)
-        prefix = dry_run ? '[DRY RUN] ' : ''
-
-        unless changes[:products_to_create].empty?
-          puts "#{prefix}Products to CREATE:"
-          changes[:products_to_create].each do |item|
-            puts "  + #{item[:plan_id]}: #{item[:plan_def]['name']}"
-          end
-          puts
-        end
-
-        unless changes[:products_to_update].empty?
-          puts "#{prefix}Products to UPDATE:"
-          changes[:products_to_update].each do |item|
-            puts "  ~ #{item[:plan_id]} (#{item[:product].id}):"
-            item[:updates].each do |field, change|
-              field_name = field.to_s.sub('metadata_', '')
-              puts "      #{field_name}: '#{change[:from]}' -> '#{change[:to]}'"
-            end
-          end
-          puts
-        end
-
-        return if changes[:prices_to_create].empty?
-
-        puts "#{prefix}Prices to CREATE:"
-        changes[:prices_to_create].each do |item|
-          amount_display = format_amount(item[:amount], item[:currency])
-          puts "  + #{item[:plan_id]}: #{amount_display}/#{item[:interval]}"
-        end
-        puts
-      end
-
-      def apply_changes(changes, app_identifier)
-        # Create new products first
-        new_products = {}
-        changes[:products_to_create].each do |item|
-          product                      = create_product(item[:plan_id], item[:plan_def], app_identifier)
-          new_products[item[:plan_id]] = product if product
-        end
-
-        # Update existing products
-        changes[:products_to_update].each do |item|
-          update_product(item[:product], item[:plan_def], item[:updates])
-        end
-
-        # Create prices (need product IDs for new products)
-        changes[:prices_to_create].each do |item|
-          product_id = item[:product_id] || new_products[item[:plan_id]]&.id
-          next unless product_id
-
-          create_price(product_id, item)
-        end
-      end
-
-      def create_product(plan_id, plan_def, app_identifier)
-        metadata = build_metadata(plan_id, plan_def, app_identifier)
-
-        # Build marketing_features from config features (i18n locale keys)
-        marketing_features = (plan_def['features'] || []).map { |f| { name: f } }
-
-        product = with_stripe_retry do
-          Stripe::Product.create(
-            name: plan_def['name'],
-            metadata: metadata,
-            marketing_features: marketing_features,
-          )
-        end
-
-        puts "  Created product: #{product.id} (#{plan_id})"
-        product
-      rescue Stripe::StripeError => ex
-        puts "  ERROR creating #{plan_id}: #{ex.message}"
-        nil
-      end
-
-      def update_product(existing, _plan_def, updates)
-        # Build update params
-        params = {}
-
-        if updates[:name]
-          params[:name] = updates[:name][:to]
-        end
-
-        # Update marketing_features (i18n locale keys for UI display)
-        if updates[:marketing_features]
-          params[:marketing_features] = updates[:marketing_features][:to].map { |f| { name: f } }
-        end
-
-        # Collect metadata updates
-        metadata_updates = {}
-        updates.each do |field, change|
-          next unless field.to_s.start_with?('metadata_')
-
-          key                   = field.to_s.sub('metadata_', '')
-          metadata_updates[key] = change[:to]
-        end
-
-        params[:metadata] = metadata_updates unless metadata_updates.empty?
-
-        return if params.empty?
-
-        with_stripe_retry do
-          Stripe::Product.update(existing.id, params)
-        end
-
-        puts "  Updated product: #{existing.id}"
-      rescue Stripe::StripeError => ex
-        puts "  ERROR updating #{existing.id}: #{ex.message}"
-      end
-
-      def create_price(product_id, price_def)
-        with_stripe_retry do
-          params = {
-            product: product_id,
-            unit_amount: price_def[:amount],
-            currency: price_def[:currency].downcase,
-            recurring: {
-              interval: price_def[:interval],
-            },
-          }
-
-          # Forward price-level metadata when defined in billing.yaml
-          params[:metadata] = price_def[:metadata] if price_def[:metadata]&.any?
-
-          Stripe::Price.create(params)
-        end
-
-        amount_display = format_amount(price_def[:amount], price_def[:currency])
-        puts "  Created price: #{amount_display}/#{price_def[:interval]} for #{price_def[:plan_id]}"
-      rescue Stripe::StripeError => ex
-        puts "  ERROR creating price: #{ex.message}"
-      end
-
-      # Build metadata for creating a new Stripe product.
-      # Uses Billing::Metadata registries for field definitions.
-      #
-      # Only includes fields with values (don't create empty metadata keys).
-      #
-      # @param plan_id [String] Plan identifier (YAML key)
-      # @param plan_def [Hash] Plan definition from catalog
-      # @param app_identifier [String] Application identifier
-      # @return [Hash<String, String>] Metadata for Stripe product
-      def build_metadata(plan_id, plan_def, app_identifier)
-        limits = plan_def['limits'] || {}
-
-        # Required fields (always present)
-        metadata = {
-          Billing::Metadata::FIELD_APP => app_identifier,
-          Billing::Metadata::FIELD_PLAN_ID => plan_id,
-          Billing::Metadata::FIELD_CREATED => Time.now.utc.iso8601,
-        }
-
-        # Add syncable fields from registry (only if value present for creation)
-        Billing::Metadata::SYNCABLE_FIELDS.each do |field_name, yaml_key|
-          value = plan_def[yaml_key]
-          next unless value
-
-          # Special handling for certain field types
-          serialized = case field_name
-                       when Billing::Metadata::FIELD_ENTITLEMENTS
-                         value.join(',')
-                       when Billing::Metadata::FIELD_IS_POPULAR
-                         value == true ? 'true' : nil
-                       when Billing::Metadata::FIELD_REGION
-                         Billing::RegionNormalizer.normalize(value)
-                       else
-                         value.to_s
-                       end
-
-          metadata[field_name] = serialized if serialized
-        end
-
-        # Currency is top-level config, not per-plan — add from catalog
-        metadata[Billing::Metadata::FIELD_CURRENCY] = OT.billing_config.currency
-
-        # Add limit fields from registry (only if value present)
-        Billing::Metadata::LIMIT_FIELDS.each do |field_name, yaml_key|
-          value                = limits[yaml_key]
-          metadata[field_name] = value.to_s if value
-        end
-
-        metadata
       end
     end
   end

--- a/apps/web/billing/cli/catalog_validate_command.rb
+++ b/apps/web/billing/cli/catalog_validate_command.rb
@@ -2,10 +2,8 @@
 #
 # frozen_string_literal: true
 
-require 'yaml'
-require 'json_schemer'
 require_relative 'helpers'
-require_relative '../config'
+require_relative '../operations/catalog/validate'
 
 module Onetime
   module CLI
@@ -27,222 +25,90 @@ module Onetime
       def call(strict: false, **)
         boot_application!
 
-        catalog_path = Billing::Config.config_path
-        schema_path  = File.join(Onetime::HOME, 'generated', 'schemas', 'config', 'billing.schema.json')
+        result = Billing::Operations::Catalog::Validate.call(
+          strict: strict,
+          progress: method(:show_progress),
+        )
 
-        unless File.exist?(catalog_path)
-          puts "❌ Error: Catalog file not found: #{catalog_path}"
-          return
-        end
-
-        unless File.exist?(schema_path)
-          puts "❌ Error: Schema file not found: #{schema_path}"
-          return
-        end
-
-        puts "Validating catalog structure: #{catalog_path}"
         puts
 
-        # Load catalog and schema
-        catalog = load_catalog(catalog_path)
-        return unless catalog
+        unless result.success
+          result.errors.each { |e| puts "Error: #{e}" }
+          exit 1
+        end
 
-        schema = load_schema(schema_path)
-        return unless schema
-
-        errors   = []
-        warnings = []
-
-        # Validate against JSON Schema
-        validate_with_schema(catalog, schema, errors)
-
-        # Additional semantic validations
-        validate_entitlements_references(catalog, errors, warnings)
-        validate_price_consistency(catalog, warnings)
-
-        # Report results
-        print_plan_summary(catalog, errors)
-        print_validation_results(errors, warnings, strict)
+        print_plan_summary(result.plan_summary)
+        print_validation_results(result.errors, result.warnings, strict, result.valid)
       end
 
       private
 
-      def load_catalog(path)
-        erb_template = ERB.new(File.read(path))
-        yaml_content = erb_template.result
-        YAML.safe_load(yaml_content, permitted_classes: [Symbol], symbolize_names: false)
-      rescue Psych::SyntaxError => ex
-        puts "❌ YAML syntax error: #{ex.message}"
-        nil
-      rescue StandardError => ex
-        puts "❌ Error loading catalog: #{ex.message}"
-        nil
+      def show_progress(message)
+        puts message
       end
 
-      def load_schema(path)
-        JSON.parse(File.read(path))
-      rescue JSON::ParserError => ex
-        puts "❌ JSON schema syntax error: #{ex.message}"
-        nil
-      rescue StandardError => ex
-        puts "❌ Error loading schema: #{ex.message}"
-        nil
-      end
-
-      def validate_with_schema(catalog, schema, errors)
-        schemer           = JSONSchemer.schema(schema)
-        validation_errors = schemer.validate(catalog).to_a
-
-        validation_errors.each do |error|
-          # Build human-readable error message
-          location = error['data_pointer'].empty? ? 'root' : error['data_pointer']
-          message  = error['error'] || error['type']
-          errors << "Schema validation: #{location}: #{message}"
-        end
-      end
-
-      def validate_entitlements_references(catalog, _errors, warnings)
-        # Load entitlements from billing.yaml
-        entitlements = Billing::Config.load_entitlements
-
-        return if entitlements.empty?
-
-        # Validate plan entitlement references (includes legacy plans with legacy: true flag)
-        plans = catalog['plans'] || {}
-        plans.each do |plan_id, plan_data|
-          plan_entitlements = plan_data['entitlements'] || []
-          is_legacy         = plan_data['legacy'] == true
-          label             = is_legacy ? "Legacy plan #{plan_id}" : "Plan #{plan_id}"
-
-          plan_entitlements.each do |ent_id|
-            unless entitlements.key?(ent_id)
-              warnings << "#{label}: references unknown entitlement '#{ent_id}'"
-            end
-          end
-        end
-
-        # Warn if deprecated legacy_plans section exists
-        if catalog['legacy_plans']&.any?
-          warnings << "DEPRECATED: legacy_plans section found. Move plans to 'plans' with legacy: true flag."
-        end
-      end
-
-      def validate_price_consistency(catalog, warnings)
-        plans = catalog['plans'] || {}
-
-        plans.each do |plan_id, plan_data|
-          prices = plan_data['prices'] || []
-
-          # Skip free tier
-          next if plan_data['tier'] == 'free'
-
-          # Warn if no prices defined for paid tier
-          if prices.empty?
-            warnings << "Plan #{plan_id}: No prices defined (expected for paid tier)"
-          end
-
-          # Check for both monthly and yearly pricing
-          intervals = prices.map { |p| p['interval'] }.uniq
-          if intervals.size == 1
-            missing = (%w[month year] - intervals).first
-            warnings << "Plan #{plan_id}: Missing #{missing}ly pricing (recommend both intervals)"
-          end
-
-          # Check for duplicate intervals
-          interval_counts = prices.group_by { |p| p['interval'] }.transform_values(&:count)
-          interval_counts.each do |interval, count|
-            if count > 1
-              warnings << "Plan #{plan_id}: Duplicate #{interval}ly prices (#{count} found)"
-            end
-          end
-        end
-      end
-
-      def print_validation_results(errors, warnings, strict)
-        puts
-
-        if errors.any?
-          puts '  ' + ('━' * 62)
-          puts "   ❌  VALIDATION FAILED: #{errors.size} error(s) found"
-          puts '  ' + ('━' * 62)
-          puts
-          errors.each { |error| puts "  ✗ #{error}" }
-          puts
-        elsif warnings.any? && strict
-          puts '  ' + ('━' * 62)
-          puts "   ❌  VALIDATION FAILED: #{warnings.size} warning(s) in strict mode"
-          puts '  ' + ('━' * 62)
-          puts
-          warnings.each { |warning| puts "  • #{warning}" }
-          puts
-        elsif warnings.any?
-          puts '  ' + ('━' * 62)
-          puts '   ✅  VALIDATION PASSED (warnings only)'
-          puts '  ' + ('━' * 62)
-          puts
-          puts "  ⚠️  #{warnings.size} warning(s):"
-          puts
-          warnings.each { |warning| puts "  • #{warning}" }
-          puts
-        else
-          puts '  ' + ('━' * 62)
-          puts '   ✅  VALIDATION PASSED'
-          puts '  ' + ('━' * 62)
-          puts
-        end
-
-        # Exit successfully if no errors, and either no warnings or not in strict mode
-        if errors.any? || (warnings.any? && strict)
-          exit 1
-        else
-          exit 0
-        end
-      end
-
-      def print_plan_summary(catalog, errors)
-        plans = catalog['plans'] || {}
-
-        # Categorize by validation status
-        valid         = []
-        invalid       = []
-        has_free_tier = false
-
-        plans.each do |plan_id, data|
-          has_errors = errors.any? { |e| e.start_with?("Plan #{plan_id}:") }
-
-          if has_errors
-            invalid << [plan_id, data]
-          else
-            valid << [plan_id, data]
-            has_free_tier = true if data['tier'] == 'free'
-          end
-        end
+      def print_plan_summary(summary)
+        valid   = summary[:valid] || []
+        invalid = summary[:invalid] || []
 
         puts
         if valid.any?
-          puts "┌─ VALID (#{valid.size}) " + ('─' * (67 - "VALID (#{valid.size}) ".length - 4))
-          valid.sort_by { |_id, data| -(data['display_order'] || 0) }.each do |plan_id, data|
-            marker = data['tier'] == 'free' ? '*' : ' '
-            puts "  #{marker} ✓ #{data['name'].ljust(20)} (#{plan_id})"
+          puts "VALID (#{valid.size}) " + ('-' * (60 - "VALID (#{valid.size}) ".length))
+          valid.sort_by { |p| -(p[:display_order] || 0) }.each do |plan|
+            marker = plan[:tier] == 'free' ? '*' : ' '
+            name   = (plan[:name] || plan[:id]).to_s
+            puts "  #{marker} #{name.ljust(20)} (#{plan[:id]})"
           end
-          puts ' ' * 67
-          puts '└' + ('─' * 67)
           puts if invalid.any?
         end
 
         if invalid.any?
-          puts "┌─ INVALID (#{invalid.size}) " + ('─' * (67 - "INVALID (#{invalid.size}) ".length - 4))
-          invalid.sort_by { |_id, data| -(data['display_order'] || 0) }.each do |plan_id, data|
-            puts "    ✗ #{data['name'] || plan_id} (#{plan_id})"
+          puts "INVALID (#{invalid.size}) " + ('-' * (60 - "INVALID (#{invalid.size}) ".length))
+          invalid.each do |plan|
+            name = (plan[:name] || plan[:id]).to_s
+            puts "    #{name} (#{plan[:id]})"
           end
-          puts ' ' * 67
-          puts '└' + ('─' * 67)
         end
 
-        if has_free_tier
+        if summary[:has_free_tier]
           puts
           puts '  * Free tier valid in catalog, does not have a Stripe product'
         end
+      end
+
+      def print_validation_results(errors, warnings, strict, valid)
+        puts
+        puts '-' * 62
+
+        if errors.any?
+          puts "VALIDATION FAILED: #{errors.size} error(s) found"
+          puts '-' * 62
+          puts
+          errors.each { |e| puts "  #{e}" }
+          puts
+          exit 1
+        elsif warnings.any? && strict
+          puts "VALIDATION FAILED: #{warnings.size} warning(s) in strict mode"
+          puts '-' * 62
+          puts
+          warnings.each { |w| puts "  #{w}" }
+          puts
+          exit 1
+        elsif warnings.any?
+          puts 'VALIDATION PASSED (warnings only)'
+          puts '-' * 62
+          puts
+          puts "  #{warnings.size} warning(s):"
+          puts
+          warnings.each { |w| puts "  #{w}" }
+          puts
+        else
+          puts 'VALIDATION PASSED'
+          puts '-' * 62
+          puts
+        end
+
+        exit(valid ? 0 : 1)
       end
     end
   end

--- a/apps/web/billing/cli/plans_command.rb
+++ b/apps/web/billing/cli/plans_command.rb
@@ -3,6 +3,7 @@
 # frozen_string_literal: true
 
 require_relative 'helpers'
+require_relative '../operations/catalog/pull'
 
 module Onetime
   module CLI
@@ -24,8 +25,8 @@ module Onetime
 
         if refresh
           puts 'Refreshing plans from Stripe...'
-          count = Billing::Plan.refresh_from_stripe
-          puts "Refreshed #{count} plan entries"
+          result = Billing::Operations::Catalog::Pull.call
+          puts "Refreshed #{result.plans_synced} plan entries"
           puts
         end
 

--- a/apps/web/billing/initializers/billing_catalog.rb
+++ b/apps/web/billing/initializers/billing_catalog.rb
@@ -4,6 +4,8 @@
 
 require_relative '../config'
 require_relative '../models/plan'
+require_relative '../operations/catalog/pull'
+require_relative '../operations/catalog/config_loader'
 
 module Billing
   module Initializers
@@ -31,16 +33,16 @@ module Billing
 
         Onetime.billing_logger.info 'Refreshing plan cache from Stripe'
         begin
-          Billing::Plan.refresh_from_stripe
-          Billing::Plan.upsert_config_only_plans
-          Onetime.billing_logger.info 'Plan cache refreshed successfully'
+          result = Billing::Operations::Catalog::Pull.call
+          Onetime.billing_logger.info 'Plan cache refreshed successfully',
+            { plans_synced: result.plans_synced, config_plans: result.config_plans_loaded }
         rescue StandardError => ex
           Onetime.billing_logger.warn 'Stripe sync failed, falling back to billing.yaml',
             { message: ex.message }
 
           # Fallback to local config when Stripe is unavailable
           begin
-            count = Billing::Plan.load_all_from_config
+            count = Billing::Operations::Catalog::ConfigLoader.load_all_from_config
             Onetime.billing_logger.info "Loaded #{count} plans from billing.yaml fallback"
           rescue StandardError => fallback_ex
             Onetime.billing_logger.error 'Fallback to billing.yaml also failed',

--- a/apps/web/billing/models/plan.rb
+++ b/apps/web/billing/models/plan.rb
@@ -9,6 +9,8 @@ require_relative '../metadata'
 require_relative '../config'
 require_relative '../region_normalizer'
 require_relative '../operations/catalog/pull'
+require_relative '../operations/catalog/config_loader'
+require_relative '../operations/catalog/plan_persister'
 
 module Billing
   unless defined?(RECORD_LIMIT)
@@ -313,105 +315,10 @@ module Billing
 
       # Upsert config-only plans (free tier, etc.) that have no Stripe prices
       #
-      # Called AFTER refresh_from_stripe to add plans with `prices: []` in billing.yaml.
-      # These plans are not synced from Stripe since they have no prices, but should
-      # still appear in the plan catalog for entitlement materialization and display
-      # on pricing pages.
-      #
-      # Since this runs after prune_stale_plans, config-only plans are upserted fresh
-      # each sync cycle with active=true, ensuring they persist in the catalog.
-      #
+      # @deprecated Use Billing::Operations::Catalog::ConfigLoader.upsert_config_only_plans
       # @return [Integer] Number of config-only plans upserted
       def upsert_config_only_plans
-        plans_hash = OT.billing_config.plans
-        return 0 if plans_hash.empty?
-
-        upserted_count = 0
-
-        plans_hash.each do |plan_key, plan_def|
-          prices = plan_def['prices'] || []
-
-          # Only process config-only plans (no prices)
-          next unless prices.empty?
-
-          # Config-only plans don't have interval variants - use plan_key as ID
-          plan_id = plan_key.to_s
-
-          # Skip if not configured to show on plans page
-          next unless plan_def['show_on_plans_page'] == true
-
-          # Resolve effective region: explicit plan region, or inherit from deployment
-          # Config-only plans (free tier) typically don't specify a region in YAML
-          # because they're universal — they inherit the deployment's region.
-          configured_region = OT.billing_config.region
-          plan_region       = Billing::RegionNormalizer.normalize(plan_def['region']) || configured_region
-
-          # Skip plans whose effective region doesn't match deployment
-          unless Billing::RegionNormalizer.match?(plan_region, configured_region)
-            OT.ld "[Plan.upsert_config_only_plans] Skipping config-only plan for region #{plan_region}: #{plan_key}"
-            next
-          end
-
-          # Extract plan attributes from config
-          tier               = plan_def['tier']
-          tenancy            = plan_def['tenancy'] || 'multi'
-          display_order      = plan_def['display_order'] || 0
-          entitlements_list  = plan_def['entitlements'] || []
-          features_list      = plan_def['features'] || []
-
-          # Convert limits to flattened format
-          limits_hash = (plan_def['limits'] || {}).transform_keys { |k| "#{k}.max" }
-          limits_hash = limits_hash.transform_values do |v|
-            v.nil? || v == -1 ? 'unlimited' : v.to_s
-          end
-
-          # Create or update Plan instance
-          plan = load(plan_id) || new(plan_id: plan_id)
-
-          plan.name               = plan_def['name']
-          plan.tier               = tier
-          plan.currency           = OT.billing_config.currency
-          plan.tenancy            = tenancy
-          plan.display_order      = display_order.to_s
-          plan.show_on_plans_page = 'true'
-          plan.description        = plan_def['description']
-          plan.stripe_product_id  = nil  # No Stripe product
-          plan.active             = 'true'
-          plan.plan_code          = plan_def['plan_code']
-          plan.plan_name_label    = plan_def['plan_name_label']
-          plan.includes_plan      = plan_def['includes_plan']
-          plan.is_popular         = (plan_def['is_popular'] == true).to_s
-          plan.region             = Billing::RegionNormalizer.normalize(plan_def['region']) || OT.billing_config.region
-          plan.last_synced_at     = Time.now.to_i.to_s
-
-          # Save scalar fields before writing collections (sets, hashkeys)
-          # which write directly to Redis and expect the parent to exist.
-          unless plan.save
-            OT.le "[Plan.upsert_config_only_plans] Save FAILED for config-only plan: #{plan_id}",
-              {
-                tier: tier,
-                tenancy: tenancy,
-              }
-            next
-          end
-
-          # Populate collections after save (these write directly to Redis)
-          plan.entitlements.clear
-          entitlements_list.each { |ent| plan.entitlements.add(ent) }
-
-          plan.features.clear
-          features_list.each { |feat| plan.features.add(feat) }
-
-          plan.limits.clear
-          limits_hash.each { |key, val| plan.limits[key] = val }
-
-          upserted_count += 1
-
-          OT.li "[Plan.upsert_config_only_plans] Upserted config-only plan: #{plan_id}"
-        end
-
-        OT.li "[Plan.upsert_config_only_plans] Upserted #{upserted_count} config-only plans"
-        upserted_count
+        Billing::Operations::Catalog::ConfigLoader.upsert_config_only_plans
       end
 
       # Extracts plan data from Stripe product and price objects
@@ -547,165 +454,20 @@ module Billing
 
       # Upsert single plan from Stripe data
       #
-      # Creates a new plan if it doesn't exist, or updates an existing one.
-      # This pattern avoids the empty catalog window that occurs with clear+rebuild.
-      #
+      # @deprecated Use Billing::Operations::Catalog::PlanPersister.upsert_from_stripe_data
       # @param plan_data [Hash] Plan data from extract_plan_data or webhook payload
       # @return [Plan] The upserted plan instance
       def upsert_from_stripe_data(plan_data)
-        plan_id = plan_data[:plan_id]
-
-        # Load existing or create new - handle missing entries gracefully
-        existing = begin
-          loaded = load(plan_id)
-          loaded if loaded&.exists?
-        rescue Familia::NoIdentifier
-          # Plan hash missing but instances entry persisted - treat as new
-          nil
-        end
-
-        # Check for stale update (out-of-order webhook delivery)
-        # Only skip if BOTH timestamps are valid (> 0) AND the Stripe product
-        # is the same. When stripe_product_id differs (cross-region replacement),
-        # bypass the stale check so the new product always wins.
-        # NOTE: nil == nil is true in Ruby — plans without a stripe_product_id
-        # (e.g., config-only plans created before this field existed) are treated
-        # as "same product", so the stale check still applies. This is the correct
-        # safe default, avoiding accidental overwrites when product provenance is
-        # unknown.
-        if existing && plan_data[:stripe_updated_at]
-          same_product     = existing.stripe_product_id == plan_data[:stripe_product_id]
-          incoming_updated = plan_data[:stripe_updated_at].to_i
-          existing_updated = existing.stripe_updated_at.to_i
-
-          if same_product && incoming_updated > 0 && existing_updated > 0 && incoming_updated <= existing_updated
-            OT.ld "[Plan.upsert_from_stripe_data] Skipping stale update for #{plan_id} " \
-                  "(same_product: #{same_product}, incoming: #{incoming_updated}, existing: #{existing_updated})"
-            return existing
-          end
-        end
-
-        plan = existing || new(plan_id: plan_id)
-
-        # Apply family-level scalar fields from plan_data
-        plan.stripe_product_id  = plan_data[:stripe_product_id]
-        plan.name               = plan_data[:name]
-        plan.tier               = plan_data[:tier]
-        plan.currency           = plan_data[:currency]
-        plan.region             = plan_data[:region]
-        plan.tenancy            = plan_data[:tenancy]
-        plan.display_order      = plan_data[:display_order]
-        plan.show_on_plans_page = plan_data[:show_on_plans_page]
-        plan.description        = plan_data[:description]
-        plan.plan_code          = plan_data[:plan_code]
-        plan.is_popular         = plan_data[:is_popular]
-        plan.plan_name_label    = plan_data[:plan_name_label]
-        plan.includes_plan      = plan_data[:includes_plan]
-        plan.active             = plan_data[:active]
-        plan.last_synced_at     = Time.now.to_i.to_s
-
-        # Store stripe_updated_at for future stale update comparison
-        plan.stripe_updated_at  = plan_data[:stripe_updated_at] || Time.now.to_i.to_s
-
-        # Save scalar fields before writing collections (sets, hashkeys)
-        # which write directly to Redis and expect the parent to exist.
-        unless plan.save
-          OT.le "[Plan.upsert_from_stripe_data] Save FAILED for plan: #{plan_id}",
-            {
-              existing: !existing.nil?,
-              region: plan_data[:region],
-              stripe_product_id: plan_data[:stripe_product_id],
-            }
-          return plan
-        end
-
-        # Populate collections after save (these write directly to Redis)
-        plan.entitlements.clear
-        plan_data[:entitlements]&.each { |ent| plan.entitlements.add(ent) }
-
-        plan.features.clear
-        plan_data[:features]&.each { |feat| plan.features.add(feat) }
-
-        plan.limits.clear
-        plan_data[:limits]&.each do |resource, value|
-          key              = "#{resource}.max"
-          val              = value == -1 ? 'unlimited' : value.to_s
-          plan.limits[key] = val
-        end
-
-        # Merge prices into hashkey (interval => JSON price data)
-        # For updates, merge new intervals with existing; for new plans, set all
-        plan_data[:prices]&.each do |interval, price_data|
-          plan.prices[interval.to_s] = price_data.to_json
-        end
-
-        # Clear memoization cache so prices_hash reflects new data
-        plan.instance_variable_set(:@prices_hash, nil)
-
-        # Store Stripe data snapshot for recovery
-        if plan_data[:stripe_snapshot]
-          plan.stripe_data_snapshot.value = plan_data[:stripe_snapshot].to_json
-        end
-
-        action = existing ? 'Updated' : 'Created'
-        OT.ld "[Plan.upsert_from_stripe_data] #{action} plan: #{plan_id}"
-
-        plan
+        Billing::Operations::Catalog::PlanPersister.upsert_from_stripe_data(plan_data)
       end
 
       # Remove plans not in current Stripe catalog
       #
-      # Uses soft-delete pattern - marks plans as inactive rather than destroying.
-      # Handles missing entries gracefully by removing orphaned instances entries.
-      #
+      # @deprecated Use Billing::Operations::Catalog::PlanPersister.prune_stale_plans
       # @param current_plan_ids [Array<String>] Plan IDs currently in Stripe catalog
       # @return [Integer] Number of plans marked stale or cleaned up
       def prune_stale_plans(current_plan_ids)
-        all_cached_ids = instances.to_a
-        stale_ids      = all_cached_ids - current_plan_ids
-        pruned_count   = 0
-
-        stale_ids.each do |plan_id|
-          plan = load(plan_id)
-
-          if plan&.exists?
-            # Plan exists in Redis - soft-delete by marking inactive
-            plan.active         = 'false'
-            plan.last_synced_at = Time.now.to_i.to_s
-            unless plan.save
-              OT.le "[Plan.prune_stale_plans] Save FAILED for stale plan: #{plan_id}",
-                {
-                  active: plan.active,
-                  last_synced_at: plan.last_synced_at,
-                  region: plan.region,
-                  stripe_product_id: plan.stripe_product_id,
-                }
-            end
-            OT.li "[Plan.prune_stale_plans] Marked stale: #{plan_id}"
-            pruned_count       += 1
-          else
-            # Plan hash missing - just remove orphaned instances entry
-            instances.remove(plan_id)
-            OT.ld "[Plan.prune_stale_plans] Removed orphaned entry: #{plan_id}"
-            pruned_count += 1
-          end
-        rescue Familia::NoIdentifier => _ex
-          # Object missing but load returned something invalid - clean up instances
-          instances.remove(plan_id)
-          OT.ld "[Plan.prune_stale_plans] Cleaned orphan entry: #{plan_id}"
-          pruned_count += 1
-        rescue StandardError => ex
-          # Always clean up orphan entry on unexpected errors to prevent stale references
-          instances.remove(plan_id)
-          OT.le '[Plan.prune_stale_plans] Error processing stale plan (cleaned orphan)',
-            {
-              plan_id: plan_id,
-              error: ex.message,
-            }
-        end
-
-        OT.li "[Plan.prune_stale_plans] Pruned #{pruned_count} stale plans" if pruned_count.positive?
-        pruned_count
+        Billing::Operations::Catalog::PlanPersister.prune_stale_plans(current_plan_ids)
       end
 
       # Get plan by tier, interval, and region
@@ -883,153 +645,18 @@ module Billing
 
       # Update the global catalog sync timestamp
       #
-      # Called after successful Stripe sync to record when the catalog
-      # was last refreshed. Stores Familia.now (Float) with JSON serialization
-      # to preserve type. TTL matches CATALOG_TTL so the staleness check
-      # in BillingCatalog initializer automatically triggers re-sync.
-      #
+      # @deprecated Use Billing::Operations::Catalog::PlanPersister.update_catalog_sync_timestamp
       def update_catalog_sync_timestamp
-        catalog_synced_at.value = Familia.now
+        Billing::Operations::Catalog::PlanPersister.update_catalog_sync_timestamp
       end
 
       # Load all plans from billing.yaml config into Redis cache
       #
-      # Bypasses Stripe API and loads plans directly from YAML configuration.
-      # Creates one Plan instance per family (e.g., "identity_plus_v1") with
-      # interval variants stored in the nested `prices` hashkey.
-      #
-      # Uses ConfigResolver to load from spec/billing.test.yaml in test environment.
-      #
+      # @deprecated Use Billing::Operations::Catalog::ConfigLoader.load_all_from_config
       # @param clear_first [Boolean] Whether to clear existing cache before loading (default: true)
       # @return [Integer] Number of plans loaded into Redis
       def load_all_from_config(clear_first: true)
-        plans_hash = OT.billing_config.plans
-        return 0 if plans_hash.empty?
-
-        # Clear existing cache if requested
-        clear_cache if clear_first
-
-        plans_count = 0
-
-        plans_hash.each do |plan_key, plan_def|
-          # Skip plans not matching the configured region
-          configured_region = OT.billing_config.region
-          plan_region       = Billing::RegionNormalizer.normalize(plan_def['region'])
-          unless Billing::RegionNormalizer.match?(plan_region, configured_region)
-            OT.ld "[Plan.load_all_from_config] Skipping plan for region #{plan_region}: #{plan_key}"
-            next
-          end
-
-          prices_list = plan_def['prices'] || []
-
-          # Skip plans without prices (e.g., free tier - handled by upsert_config_only_plans)
-          if prices_list.empty?
-            OT.ld "[Plan.load_all_from_config] Skipping plan without prices: #{plan_key}"
-            next
-          end
-
-          # Family-keyed: one Plan per plan_key with nested prices
-          plan_id = plan_key.to_s
-
-          # Extract family-level attributes
-          tier               = plan_def['tier']
-          region             = Billing::RegionNormalizer.normalize(plan_def['region']) || OT.billing_config.region
-          tenancy            = plan_def['tenancy'] || 'multi'
-          display_order      = plan_def['display_order'] || 0
-          show_on_plans_page = plan_def['show_on_plans_page'] == true
-          entitlements_list  = plan_def['entitlements'] || []
-          features_list      = plan_def['features'] || []
-
-          # Convert limits to flattened format (e.g., "teams" -> "teams.max")
-          limits_hash = (plan_def['limits'] || {}).transform_keys { |k| "#{k}.max" }
-          limits_hash = limits_hash.transform_values do |v|
-            v.nil? || v == -1 ? 'unlimited' : v.to_s
-          end
-
-          # Build nested prices hash from all intervals
-          prices_data = {}
-          prices_list.each do |price|
-            interval       = price['interval'].to_sym # :month or :year
-            plan_currency  = price['currency'] || OT.billing_config.currency
-
-            prices_data[interval] = {
-              stripe_price_id: price['price_id'],
-              amount: price['amount'].to_s,
-              currency: plan_currency,
-              billing_scheme: 'per_unit',
-              usage_type: 'licensed',
-              trial_period_days: nil,
-              nickname: nil,
-              active: 'true',
-            }
-          end
-
-          # Use first price's currency as family currency (they should match)
-          family_currency = prices_list.first['currency'] || OT.billing_config.currency
-
-          # Create Plan instance with family-level fields only
-          plan = new(
-            plan_id: plan_id,
-            stripe_product_id: nil,
-            name: plan_def['name'],
-            tier: tier,
-            currency: family_currency,
-            region: region,
-            tenancy: tenancy,
-            display_order: display_order.to_s,
-            show_on_plans_page: show_on_plans_page.to_s,
-            description: plan_def['description'],
-          )
-
-          # Populate additional family-level fields
-          plan.active          = 'true'
-          plan.plan_code       = plan_def['plan_code']
-          plan.is_popular      = (plan_def['is_popular'] == true).to_s
-          plan.plan_name_label = plan_def['plan_name_label']
-          plan.includes_plan   = plan_def['includes_plan']
-          plan.last_synced_at  = Time.now.to_i.to_s
-
-          # Save scalar fields before writing collections (sets, hashkeys)
-          # which write directly to Redis and expect the parent to exist.
-          unless plan.save
-            OT.le "[Plan.load_all_from_config] Save FAILED for plan: #{plan_id}"
-            next
-          end
-
-          # Populate collections after save (these write directly to Redis)
-          plan.entitlements.clear
-          entitlements_list.each { |ent| plan.entitlements.add(ent) }
-
-          plan.features.clear
-          features_list.each { |feat| plan.features.add(feat) }
-
-          plan.limits.clear
-          limits_hash.each { |key, val| plan.limits[key] = val }
-
-          # Populate prices hashkey with JSON per interval
-          plan.prices.clear
-          prices_data.each do |interval, price_data|
-            plan.prices[interval.to_s] = price_data.to_json
-          end
-
-          # No stripe_data_snapshot for config-based plans
-          plan.stripe_data_snapshot.value = nil
-
-          OT.ld "[Plan.load_all_from_config] Cached plan: #{plan_id}",
-            {
-              tier: tier,
-              intervals: prices_data.keys,
-              currency: family_currency,
-            }
-
-          plans_count += 1
-        end
-
-        # Rebuild price ID cache after loading
-        rebuild_stripe_price_id_cache
-
-        OT.li "[Plan.load_all_from_config] Cached #{plans_count} plans from config"
-        plans_count
+        Billing::Operations::Catalog::ConfigLoader.load_all_from_config(clear_first: clear_first)
       end
 
       # Load a single plan from billing.yaml config

--- a/apps/web/billing/models/plan.rb
+++ b/apps/web/billing/models/plan.rb
@@ -8,7 +8,7 @@ require 'stripe'
 require_relative '../metadata'
 require_relative '../config'
 require_relative '../region_normalizer'
-require_relative '../lib/stripe_circuit_breaker'
+require_relative '../operations/catalog/pull'
 
 module Billing
   unless defined?(RECORD_LIMIT)
@@ -268,7 +268,7 @@ module Billing
       #
       # Returns true when no region is configured (backward-compatible pass-through).
       # When a region is configured, the product's region metadata must match case-insensitively.
-      # Called by both collect_stripe_plans (refresh path) and the webhook handler.
+      # Called by Pull operation (refresh path) and the webhook handler.
       #
       # @param product [Stripe::Product] The Stripe product
       # @return [Boolean] true if the product matches the configured region (or no region set)
@@ -292,76 +292,23 @@ module Billing
       # 3. **Prune phase**: Plans not in current Stripe catalog are soft-deleted
       # 4. **Cache rebuild**: Price ID lookup cache is refreshed
       #
-      # The catalog is NEVER cleared during sync, eliminating the empty-window
-      # race condition that occurred with the previous clear-then-rebuild pattern.
-      # If Stripe API fails during fetch, no cache modifications occur.
+      # Delegates to Operations::Catalog::Pull for the actual sync.
       #
-      # @param progress [Proc, nil] Optional progress callback (called with status messages)
+      # @param progress [Proc, nil] Optional progress callback
       # @return [Integer] Number of plans synced
-      # @raise [Stripe::StripeError] If Stripe API call fails during fetch phase
+      # @raise [Stripe::StripeError] If Stripe API call fails
       # @raise [Billing::CircuitOpenError] If circuit breaker is open
       def refresh_from_stripe(progress: nil)
-        # Skip Stripe sync in CI/test environments without API key
-        stripe_key = Onetime.billing_config.stripe_key
-        if stripe_key.to_s.strip.empty?
-          OT.lw '[Plan.refresh_from_stripe] Skipping Stripe sync: No API key configured'
-          return 0
+        result = Billing::Operations::Catalog::Pull.call(progress: progress)
+
+        unless result.success
+          error_msg = result.errors.first || 'Unknown error'
+          raise Stripe::StripeError, error_msg if error_msg.include?('Stripe')
+
+          raise StandardError, error_msg
         end
 
-        OT.li '[Plan.refresh_from_stripe] Starting Stripe sync (upsert pattern)'
-
-        # PHASE 1: Fetch all data from Stripe into memory
-        # No Redis writes occur during this phase
-        # Circuit breaker protects against cascade failures during Stripe outages
-        plan_data_list = Billing::StripeCircuitBreaker.call do
-          collect_stripe_plans(progress: progress)
-        end
-
-        if plan_data_list.empty?
-          OT.lw '[Plan.refresh_from_stripe] No valid plans fetched from Stripe'
-          return 0
-        end
-
-        progress&.call("Upserting #{plan_data_list.size} plans...")
-
-        # PHASE 2: Upsert all plans (NO clear_cache!)
-        # Each plan is created or updated individually, ensuring the catalog
-        # is never empty during sync
-        upserted_ids    = []
-        not_persisted   = []
-        plan_data_list.each do |plan_data|
-          plan = upsert_from_stripe_data(plan_data)
-          upserted_ids << plan.plan_id
-
-          # Plans not in instances were either skipped by the stale check
-          # or failed to save. Both cases are logged inside upsert_from_stripe_data
-          # with appropriate severity (ld for skips, le for failures).
-          # O(log n) per call but catalog is small (~20 plans max).
-          not_persisted << plan.plan_id unless instances.member?(plan.plan_id)
-        end
-
-        saved_count = upserted_ids.size - not_persisted.size
-
-        if not_persisted.any?
-          OT.lw "[Plan.refresh_from_stripe] #{not_persisted.size} plan(s) not persisted: #{not_persisted.join(', ')}",
-            {
-              region: Onetime.billing_config.region,
-            }
-        end
-
-        # PHASE 3: Prune stale plans not in current Stripe catalog
-        # Soft-deletes plans that are no longer active in Stripe
-        pruned_count = prune_stale_plans(upserted_ids)
-
-        # PHASE 4: Rebuild lookup cache for O(1) price_id lookups
-        rebuild_stripe_price_id_cache
-
-        # PHASE 5: Update global sync timestamp for O(1) freshness checks
-        update_catalog_sync_timestamp
-
-        OT.li "[Plan.refresh_from_stripe] Synced #{saved_count}/#{upserted_ids.size} plans " \
-              "(#{not_persisted.size} not persisted), pruned #{pruned_count}"
-        saved_count
+        result.plans_synced
       end
 
       # Upsert config-only plans (free tier, etc.) that have no Stripe prices
@@ -466,152 +413,6 @@ module Billing
         OT.li "[Plan.upsert_config_only_plans] Upserted #{upserted_count} config-only plans"
         upserted_count
       end
-
-      private
-
-      # Fetches all plan data from Stripe API into memory
-      #
-      # No Redis writes occur during this phase. If any Stripe API call fails,
-      # the exception propagates up and no cache modifications happen.
-      #
-      # Returns one entry per plan family (e.g., `identity_plus_v1`), with
-      # interval variants (month/year) merged into the `prices` hash.
-      #
-      # @param progress [Proc, nil] Optional progress callback
-      # @return [Array<Hash>] Array of plan data hashes ready for persistence
-      # @raise [Stripe::StripeError] If any Stripe API call fails
-      # @raise [Billing::CatalogValidationError] If any managed products have invalid metadata
-      def collect_stripe_plans(progress: nil)
-        # Ensure Stripe API key is configured (required for console/CLI usage
-        # where StripeSetup initializer may not have run)
-        ensure_stripe_configured!
-
-        # Fetch all active products with onetimesecret metadata
-        products = Stripe::Product.list(
-          {
-            active: true,
-            limit: RECORD_LIMIT,
-          },
-        )
-
-        # Accumulator for merging interval variants into single plan entries
-        plan_data_by_family = {}
-        validation_errors   = []
-        products_processed  = 0
-
-        progress&.call('Fetching products from Stripe...')
-
-        products.auto_paging_each do |product|
-          products_processed += 1
-          progress&.call("Processing product #{products_processed}: #{product.name[0..40]}...") if products_processed == 1 || products_processed % 5 == 0
-
-          # Skip products that aren't valid OTS products (wrong app or missing required metadata)
-          unless valid_ots_product?(product)
-            OT.ld '[Plan.collect_stripe_plans] Skipping invalid product',
-              {
-                product_id: product.id,
-                product_name: product.name,
-                app: product.metadata[Metadata::FIELD_APP],
-              }
-            next
-          end
-
-          # Skip products from a different region when regional isolation is configured
-          unless correct_region?(product)
-            OT.ld '[Plan.collect_stripe_plans] Skipping product from wrong region',
-              {
-                product_id: product.id,
-                product_name: product.name,
-                product_region: product.metadata[Metadata::FIELD_REGION],
-                configured_region: Onetime.billing_config.region,
-              }
-            next
-          end
-
-          # Validate product metadata once before fetching prices (avoid redundant
-          # API calls and duplicate error entries for products with multiple prices)
-          result = validate_product_metadata(product)
-          if result[:missing].any? || result[:blank].any?
-            problems = []
-            problems << "missing: #{result[:missing].join(', ')}" if result[:missing].any?
-            problems << "blank: #{result[:blank].join(', ')}" if result[:blank].any?
-            OT.le '[Plan.collect_stripe_plans] Product failed metadata validation',
-              {
-                product_id: product.id,
-                product_name: product.name,
-                problems: problems.join('; '),
-              }
-            validation_errors << {
-              product_id: product.id,
-              price_id: nil,
-              product_name: product.name,
-              error: "invalid metadata: #{problems.join('; ')}",
-            }
-            next
-          end
-
-          # Fetch all active prices for this product
-          prices = Stripe::Price.list(
-            {
-              product: product.id,
-              active: true,
-              limit: 100,
-            },
-          )
-
-          prices.auto_paging_each do |price|
-            # Skip non-recurring prices
-            next unless price.type == 'recurring'
-
-            # Product metadata already validated above; extract_plan_data won't fail
-            plan_data = extract_plan_data(product, price)
-            plan_id   = plan_data[:plan_id]
-            interval  = price.recurring.interval.to_sym
-
-            if plan_data_by_family.key?(plan_id)
-              # Merge this interval's price data into existing plan entry
-              existing              = plan_data_by_family[plan_id]
-              existing[:prices]     = existing[:prices].merge(plan_data[:prices])
-              existing[:active]     = 'true' if plan_data[:active] == 'true' # Any active price makes plan active
-
-              # Merge stripe_snapshot prices
-              existing[:stripe_snapshot][:prices] =
-                existing[:stripe_snapshot][:prices].merge(plan_data[:stripe_snapshot][:prices])
-            else
-              # First interval variant for this plan family
-              plan_data_by_family[plan_id] = plan_data
-            end
-
-            OT.ld "[Plan.collect_stripe_plans] Collected price for plan: #{plan_id}",
-              {
-                interval: interval,
-                stripe_price_id: price.id,
-                amount: price.unit_amount,
-              }
-          end
-        end
-
-        plan_data_list = plan_data_by_family.values
-
-        OT.li "[Plan.collect_stripe_plans] Collected #{plan_data_list.size} plan families from Stripe"
-
-        # Fail-closed: abort before returning if any managed products had invalid metadata
-        if validation_errors.any?
-          OT.le '[Plan.collect_stripe_plans] Aborting due to validation failures',
-            {
-              error_count: validation_errors.size,
-              valid_count: plan_data_list.size,
-            }
-          raise Billing::CatalogValidationError.new(
-            "#{validation_errors.size} Stripe products failed metadata validation",
-            errors: validation_errors,
-          )
-        end
-
-        plan_data_list
-      end
-
-      public
 
       # Extracts plan data from Stripe product and price objects
       #

--- a/apps/web/billing/operations/catalog/config_loader.rb
+++ b/apps/web/billing/operations/catalog/config_loader.rb
@@ -1,0 +1,236 @@
+# apps/web/billing/operations/catalog/config_loader.rb
+#
+# frozen_string_literal: true
+
+require_relative '../../region_normalizer'
+require_relative 'plan_persister'
+
+module Billing
+  module Operations
+    module Catalog
+      # Loads plans from billing.yaml configuration into Redis cache.
+      #
+      # Handles two scenarios:
+      # 1. Config-only plans (free tier) - plans with `prices: []` that have no Stripe presence
+      # 2. Full config loading - bypasses Stripe entirely for dev/test environments
+      #
+      # @example Upsert config-only plans after Stripe sync
+      #   ConfigLoader.upsert_config_only_plans
+      #
+      # @example Load all plans from config (dev/test)
+      #   ConfigLoader.load_all_from_config
+      #
+      module ConfigLoader
+        extend self
+
+        # Upsert config-only plans (free tier, etc.) that have no Stripe prices
+        #
+        # Called AFTER Stripe sync to add plans with `prices: []` in billing.yaml.
+        # These plans are not synced from Stripe since they have no prices, but should
+        # still appear in the plan catalog for entitlement materialization and display
+        # on pricing pages.
+        #
+        # Since this runs after prune_stale_plans, config-only plans are upserted fresh
+        # each sync cycle with active=true, ensuring they persist in the catalog.
+        #
+        # @return [Integer] Number of config-only plans upserted
+        def upsert_config_only_plans
+          plans_hash = OT.billing_config.plans
+          return 0 if plans_hash.empty?
+
+          upserted_count = 0
+
+          plans_hash.each do |plan_key, plan_def|
+            prices = plan_def['prices'] || []
+
+            # Only process config-only plans (no prices)
+            next unless prices.empty?
+
+            # Config-only plans don't have interval variants - use plan_key as ID
+            plan_id = plan_key.to_s
+
+            # Skip if not configured to show on plans page
+            next unless plan_def['show_on_plans_page'] == true
+
+            # Resolve effective region: explicit plan region, or inherit from deployment
+            # Config-only plans (free tier) typically don't specify a region in YAML
+            # because they're universal - they inherit the deployment's region.
+            configured_region = OT.billing_config.region
+            plan_region       = Billing::RegionNormalizer.normalize(plan_def['region']) || configured_region
+
+            # Skip plans whose effective region doesn't match deployment
+            unless Billing::RegionNormalizer.match?(plan_region, configured_region)
+              OT.ld "[ConfigLoader] Skipping config-only plan for region #{plan_region}: #{plan_key}"
+              next
+            end
+
+            plan = upsert_plan_from_config(plan_id, plan_def, nil)
+            next unless plan
+
+            upserted_count += 1
+            OT.li "[ConfigLoader] Upserted config-only plan: #{plan_id}"
+          end
+
+          OT.li "[ConfigLoader] Upserted #{upserted_count} config-only plans"
+          upserted_count
+        end
+
+        # Load all plans from billing.yaml config into Redis cache
+        #
+        # Bypasses Stripe API and loads plans directly from YAML configuration.
+        # Creates one Plan instance per family (e.g., "identity_plus_v1") with
+        # interval variants stored in the nested `prices` hashkey.
+        #
+        # Uses ConfigResolver to load from spec/billing.test.yaml in test environment.
+        #
+        # @param clear_first [Boolean] Whether to clear existing cache before loading (default: true)
+        # @return [Integer] Number of plans loaded into Redis
+        def load_all_from_config(clear_first: true)
+          plans_hash = OT.billing_config.plans
+          return 0 if plans_hash.empty?
+
+          # Clear existing cache if requested
+          Billing::Plan.clear_cache if clear_first
+
+          plans_count = 0
+
+          plans_hash.each do |plan_key, plan_def|
+            # Skip plans not matching the configured region
+            configured_region = OT.billing_config.region
+            plan_region       = Billing::RegionNormalizer.normalize(plan_def['region'])
+            unless Billing::RegionNormalizer.match?(plan_region, configured_region)
+              OT.ld "[ConfigLoader] Skipping plan for region #{plan_region}: #{plan_key}"
+              next
+            end
+
+            prices_list = plan_def['prices'] || []
+
+            # Skip plans without prices (e.g., free tier - handled by upsert_config_only_plans)
+            if prices_list.empty?
+              OT.ld "[ConfigLoader] Skipping plan without prices: #{plan_key}"
+              next
+            end
+
+            plan = upsert_plan_from_config(plan_key.to_s, plan_def, prices_list)
+            next unless plan
+
+            OT.ld "[ConfigLoader] Cached plan: #{plan_key}",
+              {
+                tier: plan_def['tier'],
+                intervals: prices_list.map { |p| p['interval'] },
+                currency: prices_list.first['currency'] || OT.billing_config.currency,
+              }
+
+            plans_count += 1
+          end
+
+          # Rebuild price ID cache after loading
+          PlanPersister.rebuild_stripe_price_id_cache
+
+          OT.li "[ConfigLoader] Cached #{plans_count} plans from config"
+          plans_count
+        end
+
+        # Upsert a single plan from config definition
+        #
+        # @param plan_id [String] Plan identifier
+        # @param plan_def [Hash] Plan definition from YAML
+        # @param prices_list [Array, nil] List of price definitions, or nil for config-only plans
+        # @return [Billing::Plan, nil] The upserted plan or nil on failure
+        # rubocop:disable Metrics/PerceivedComplexity
+        def upsert_plan_from_config(plan_id, plan_def, prices_list)
+          # Extract plan attributes from config
+          tier               = plan_def['tier']
+          tenancy            = plan_def['tenancy'] || 'multi'
+          display_order      = plan_def['display_order'] || 0
+          entitlements_list  = plan_def['entitlements'] || []
+          features_list      = plan_def['features'] || []
+          show_on_plans_page = plan_def['show_on_plans_page'] == true
+
+          # Convert limits to flattened format
+          limits_hash = (plan_def['limits'] || {}).transform_keys { |k| "#{k}.max" }
+          limits_hash = limits_hash.transform_values do |v|
+            v.nil? || v == -1 ? 'unlimited' : v.to_s
+          end
+
+          # Build nested prices hash from all intervals (if provided)
+          prices_data     = {}
+          family_currency = OT.billing_config.currency
+
+          if prices_list && !prices_list.empty?
+            prices_list.each do |price|
+              interval       = price['interval'].to_sym # :month or :year
+              plan_currency  = price['currency'] || OT.billing_config.currency
+
+              prices_data[interval] = {
+                stripe_price_id: price['price_id'],
+                amount: price['amount'].to_s,
+                currency: plan_currency,
+                billing_scheme: 'per_unit',
+                usage_type: 'licensed',
+                trial_period_days: nil,
+                nickname: nil,
+                active: 'true',
+              }
+            end
+            family_currency = prices_list.first['currency'] || OT.billing_config.currency
+          end
+
+          # Create or update Plan instance
+          plan = Billing::Plan.load(plan_id) || Billing::Plan.new(plan_id: plan_id)
+
+          plan.name               = plan_def['name']
+          plan.tier               = tier
+          plan.currency           = family_currency
+          plan.tenancy            = tenancy
+          plan.display_order      = display_order.to_s
+          plan.show_on_plans_page = show_on_plans_page.to_s
+          plan.description        = plan_def['description']
+          plan.stripe_product_id  = nil  # No Stripe product for config-based plans
+          plan.active             = 'true'
+          plan.plan_code          = plan_def['plan_code']
+          plan.plan_name_label    = plan_def['plan_name_label']
+          plan.includes_plan      = plan_def['includes_plan']
+          plan.is_popular         = (plan_def['is_popular'] == true).to_s
+          plan.region             = Billing::RegionNormalizer.normalize(plan_def['region']) || OT.billing_config.region
+          plan.last_synced_at     = Time.now.to_i.to_s
+
+          # Save scalar fields before writing collections (sets, hashkeys)
+          # which write directly to Redis and expect the parent to exist.
+          unless plan.save
+            OT.le "[ConfigLoader] Save FAILED for plan: #{plan_id}",
+              {
+                tier: tier,
+                tenancy: tenancy,
+              }
+            return nil
+          end
+
+          # Populate collections after save (these write directly to Redis)
+          plan.entitlements.clear
+          entitlements_list.each { |ent| plan.entitlements.add(ent) }
+
+          plan.features.clear
+          features_list.each { |feat| plan.features.add(feat) }
+
+          plan.limits.clear
+          limits_hash.each { |key, val| plan.limits[key] = val }
+
+          # Populate prices hashkey with JSON per interval
+          if prices_data.any?
+            plan.prices.clear
+            prices_data.each do |interval, price_data|
+              plan.prices[interval.to_s] = price_data.to_json
+            end
+          end
+
+          # No stripe_data_snapshot for config-based plans
+          plan.stripe_data_snapshot.value = nil
+
+          plan
+        end
+        # rubocop:enable Metrics/PerceivedComplexity
+      end
+    end
+  end
+end

--- a/apps/web/billing/operations/catalog/plan_persister.rb
+++ b/apps/web/billing/operations/catalog/plan_persister.rb
@@ -1,0 +1,212 @@
+# apps/web/billing/operations/catalog/plan_persister.rb
+#
+# frozen_string_literal: true
+
+module Billing
+  module Operations
+    module Catalog
+      # Persistence helpers for Stripe-to-Redis plan synchronization.
+      #
+      # Handles:
+      # - Upsert from Stripe data (create or update)
+      # - Stale plan pruning (soft-delete)
+      # - Cache rebuild (price_id lookup index)
+      # - Sync timestamp updates
+      #
+      # @example Upsert a plan from Stripe data
+      #   PlanPersister.upsert_from_stripe_data(plan_data)
+      #
+      # @example Prune plans not in current sync
+      #   PlanPersister.prune_stale_plans(current_ids)
+      #
+      module PlanPersister
+        extend self
+
+        # Upsert single plan from Stripe data
+        #
+        # Creates a new plan if it doesn't exist, or updates an existing one.
+        # This pattern avoids the empty catalog window that occurs with clear+rebuild.
+        #
+        # @param plan_data [Hash] Plan data from extract_plan_data or webhook payload
+        # @return [Plan] The upserted plan instance
+        # rubocop:disable Metrics/PerceivedComplexity
+        def upsert_from_stripe_data(plan_data)
+          plan_id = plan_data[:plan_id]
+
+          # Load existing or create new - handle missing entries gracefully
+          existing = begin
+            loaded = Billing::Plan.load(plan_id)
+            loaded if loaded&.exists?
+          rescue Familia::NoIdentifier
+            # Plan hash missing but instances entry persisted - treat as new
+            nil
+          end
+
+          # Check for stale update (out-of-order webhook delivery)
+          # Only skip if BOTH timestamps are valid (> 0) AND the Stripe product
+          # is the same. When stripe_product_id differs (cross-region replacement),
+          # bypass the stale check so the new product always wins.
+          # NOTE: nil == nil is true in Ruby - plans without a stripe_product_id
+          # (e.g., config-only plans created before this field existed) are treated
+          # as "same product", so the stale check still applies. This is the correct
+          # safe default, avoiding accidental overwrites when product provenance is
+          # unknown.
+          if existing && plan_data[:stripe_updated_at]
+            same_product     = existing.stripe_product_id == plan_data[:stripe_product_id]
+            incoming_updated = plan_data[:stripe_updated_at].to_i
+            existing_updated = existing.stripe_updated_at.to_i
+
+            if same_product && incoming_updated > 0 && existing_updated > 0 && incoming_updated <= existing_updated
+              OT.ld "[PlanPersister] Skipping stale update for #{plan_id} " \
+                    "(same_product: #{same_product}, incoming: #{incoming_updated}, existing: #{existing_updated})"
+              return existing
+            end
+          end
+
+          plan = existing || Billing::Plan.new(plan_id: plan_id)
+
+          # Apply family-level scalar fields from plan_data
+          plan.stripe_product_id  = plan_data[:stripe_product_id]
+          plan.name               = plan_data[:name]
+          plan.tier               = plan_data[:tier]
+          plan.currency           = plan_data[:currency]
+          plan.region             = plan_data[:region]
+          plan.tenancy            = plan_data[:tenancy]
+          plan.display_order      = plan_data[:display_order]
+          plan.show_on_plans_page = plan_data[:show_on_plans_page]
+          plan.description        = plan_data[:description]
+          plan.plan_code          = plan_data[:plan_code]
+          plan.is_popular         = plan_data[:is_popular]
+          plan.plan_name_label    = plan_data[:plan_name_label]
+          plan.includes_plan      = plan_data[:includes_plan]
+          plan.active             = plan_data[:active]
+          plan.last_synced_at     = Time.now.to_i.to_s
+
+          # Store stripe_updated_at for future stale update comparison
+          plan.stripe_updated_at  = plan_data[:stripe_updated_at] || Time.now.to_i.to_s
+
+          # Save scalar fields before writing collections (sets, hashkeys)
+          # which write directly to Redis and expect the parent to exist.
+          unless plan.save
+            OT.le "[PlanPersister] Save FAILED for plan: #{plan_id}",
+              {
+                existing: !existing.nil?,
+                region: plan_data[:region],
+                stripe_product_id: plan_data[:stripe_product_id],
+              }
+            return plan
+          end
+
+          # Populate collections after save (these write directly to Redis)
+          plan.entitlements.clear
+          plan_data[:entitlements]&.each { |ent| plan.entitlements.add(ent) }
+
+          plan.features.clear
+          plan_data[:features]&.each { |feat| plan.features.add(feat) }
+
+          plan.limits.clear
+          plan_data[:limits]&.each do |resource, value|
+            key              = "#{resource}.max"
+            val              = value == -1 ? 'unlimited' : value.to_s
+            plan.limits[key] = val
+          end
+
+          # Merge prices into hashkey (interval => JSON price data)
+          # For updates, merge new intervals with existing; for new plans, set all
+          plan_data[:prices]&.each do |interval, price_data|
+            plan.prices[interval.to_s] = price_data.to_json
+          end
+
+          # Clear memoization cache so prices_hash reflects new data
+          plan.instance_variable_set(:@prices_hash, nil)
+
+          # Store Stripe data snapshot for recovery
+          if plan_data[:stripe_snapshot]
+            plan.stripe_data_snapshot.value = plan_data[:stripe_snapshot].to_json
+          end
+
+          action = existing ? 'Updated' : 'Created'
+          OT.ld "[PlanPersister] #{action} plan: #{plan_id}"
+
+          plan
+        end
+        # rubocop:enable Metrics/PerceivedComplexity
+
+        # Remove plans not in current Stripe catalog
+        #
+        # Uses soft-delete pattern - marks plans as inactive rather than destroying.
+        # Handles missing entries gracefully by removing orphaned instances entries.
+        #
+        # @param current_plan_ids [Array<String>] Plan IDs currently in Stripe catalog
+        # @return [Integer] Number of plans marked stale or cleaned up
+        def prune_stale_plans(current_plan_ids)
+          all_cached_ids = Billing::Plan.instances.to_a
+          stale_ids      = all_cached_ids - current_plan_ids
+          pruned_count   = 0
+
+          stale_ids.each do |plan_id|
+            plan = Billing::Plan.load(plan_id)
+
+            if plan&.exists?
+              # Plan exists in Redis - soft-delete by marking inactive
+              plan.active         = 'false'
+              plan.last_synced_at = Time.now.to_i.to_s
+              unless plan.save
+                OT.le "[PlanPersister] Save FAILED for stale plan: #{plan_id}",
+                  {
+                    active: plan.active,
+                    last_synced_at: plan.last_synced_at,
+                    region: plan.region,
+                    stripe_product_id: plan.stripe_product_id,
+                  }
+              end
+              OT.li "[PlanPersister] Marked stale: #{plan_id}"
+              pruned_count       += 1
+            else
+              # Plan hash missing - just remove orphaned instances entry
+              Billing::Plan.instances.remove(plan_id)
+              OT.ld "[PlanPersister] Removed orphaned entry: #{plan_id}"
+              pruned_count += 1
+            end
+          rescue Familia::NoIdentifier => _ex
+            # Object missing but load returned something invalid - clean up instances
+            Billing::Plan.instances.remove(plan_id)
+            OT.ld "[PlanPersister] Cleaned orphan entry: #{plan_id}"
+            pruned_count += 1
+          rescue StandardError => ex
+            # Always clean up orphan entry on unexpected errors to prevent stale references
+            Billing::Plan.instances.remove(plan_id)
+            OT.le '[PlanPersister] Error processing stale plan (cleaned orphan)',
+              {
+                plan_id: plan_id,
+                error: ex.message,
+              }
+          end
+
+          OT.li "[PlanPersister] Pruned #{pruned_count} stale plans" if pruned_count.positive?
+          pruned_count
+        end
+
+        # Rebuild the price ID cache
+        #
+        # Called after plan refresh to ensure cache is up to date.
+        #
+        # @return [Hash<String, Plan>] Rebuilt cache
+        def rebuild_stripe_price_id_cache
+          Billing::Plan.rebuild_stripe_price_id_cache
+        end
+
+        # Update the global catalog sync timestamp
+        #
+        # Called after successful Stripe sync to record when the catalog
+        # was last refreshed. Stores Familia.now (Float) with JSON serialization
+        # to preserve type. TTL matches CATALOG_TTL so the staleness check
+        # in BillingCatalog initializer automatically triggers re-sync.
+        #
+        def update_catalog_sync_timestamp
+          Billing::Plan.catalog_synced_at.value = Familia.now
+        end
+      end
+    end
+  end
+end

--- a/apps/web/billing/operations/catalog/pull.rb
+++ b/apps/web/billing/operations/catalog/pull.rb
@@ -4,6 +4,8 @@
 
 require_relative 'stripe_retry'
 require_relative 'stripe_reader'
+require_relative 'config_loader'
+require_relative 'plan_persister'
 require_relative '../../lib/stripe_circuit_breaker'
 
 module Billing
@@ -64,7 +66,7 @@ module Billing
           stripe_key = Onetime.billing_config.stripe_key
           if stripe_key.to_s.strip.empty?
             OT.lw '[Pull] Skipping Stripe sync: No API key configured'
-            config_plans_loaded = Billing::Plan.upsert_config_only_plans
+            config_plans_loaded = ConfigLoader.upsert_config_only_plans
             return Result.new(
               success: true,
               plans_synced: 0,
@@ -79,7 +81,7 @@ module Billing
             sync_from_stripe
           end
 
-          config_plans_loaded = Billing::Plan.upsert_config_only_plans
+          config_plans_loaded = ConfigLoader.upsert_config_only_plans
 
           Result.new(
             success: true,
@@ -141,7 +143,7 @@ module Billing
           not_persisted = []
 
           plan_data_list.each do |plan_data|
-            plan = Billing::Plan.upsert_from_stripe_data(plan_data)
+            plan = PlanPersister.upsert_from_stripe_data(plan_data)
             upserted_ids << plan.plan_id
             not_persisted << plan.plan_id unless Billing::Plan.instances.member?(plan.plan_id)
           end
@@ -153,13 +155,13 @@ module Billing
           end
 
           # Prune stale plans not in current Stripe catalog
-          pruned_count = Billing::Plan.prune_stale_plans(upserted_ids)
+          pruned_count = PlanPersister.prune_stale_plans(upserted_ids)
 
           # Rebuild lookup cache for O(1) price_id lookups
-          Billing::Plan.rebuild_stripe_price_id_cache
+          PlanPersister.rebuild_stripe_price_id_cache
 
           # Update global sync timestamp
-          Billing::Plan.update_catalog_sync_timestamp
+          PlanPersister.update_catalog_sync_timestamp
 
           OT.li "[Pull] Synced #{saved_count}/#{upserted_ids.size} plans " \
                 "(#{not_persisted.size} not persisted), pruned #{pruned_count}"

--- a/apps/web/billing/operations/catalog/pull.rb
+++ b/apps/web/billing/operations/catalog/pull.rb
@@ -3,14 +3,17 @@
 # frozen_string_literal: true
 
 require_relative 'stripe_retry'
+require_relative 'stripe_reader'
+require_relative '../../lib/stripe_circuit_breaker'
 
 module Billing
   module Operations
     module Catalog
       # Pull products and prices from Stripe to Redis cache.
       #
-      # Wraps Plan.refresh_from_stripe and Plan.upsert_config_only_plans
-      # for CLI and programmatic use. Never writes to stdout directly.
+      # Fetches products and prices via StripeReader (wrapped in circuit breaker),
+      # transforms them into plan data hashes, and persists to Redis.
+      # Never writes to stdout directly.
       #
       # @example
       #   result = Pull.call(region: 'ca', progress: ->(msg) { print "\r#{msg}" })
@@ -57,10 +60,23 @@ module Billing
             report('Cache cleared')
           end
 
+          # Skip Stripe sync if no API key configured
+          stripe_key = Onetime.billing_config.stripe_key
+          if stripe_key.to_s.strip.empty?
+            OT.lw '[Pull] Skipping Stripe sync: No API key configured'
+            config_plans_loaded = Billing::Plan.upsert_config_only_plans
+            return Result.new(
+              success: true,
+              plans_synced: 0,
+              config_plans_loaded: config_plans_loaded,
+              cache_cleared: cache_cleared,
+            )
+          end
+
           report('Pulling from Stripe to Redis cache...')
 
           plans_synced = StripeRetry.with_retry do
-            Billing::Plan.refresh_from_stripe(progress: @progress)
+            sync_from_stripe
           end
 
           config_plans_loaded = Billing::Plan.upsert_config_only_plans
@@ -79,6 +95,14 @@ module Billing
             cache_cleared: cache_cleared,
             errors: ["Stripe error: #{ex.message}"],
           )
+        rescue Billing::CatalogValidationError => ex
+          Result.new(
+            success: false,
+            plans_synced: plans_synced,
+            config_plans_loaded: config_plans_loaded,
+            cache_cleared: cache_cleared,
+            errors: [ex.message],
+          )
         rescue StandardError => ex
           Result.new(
             success: false,
@@ -90,6 +114,156 @@ module Billing
         end
 
         private
+
+        # Synchronize Stripe catalog to Redis using StripeReader
+        #
+        # Stripe API calls are wrapped in circuit breaker to prevent cascade
+        # failures during Stripe outages.
+        #
+        # @return [Integer] Number of plans synced
+        def sync_from_stripe
+          report('Fetching products from Stripe...')
+
+          # PHASE 1: Fetch all data from Stripe (circuit breaker protected)
+          plan_data_list = Billing::StripeCircuitBreaker.call do
+            fetch_and_collect_plan_data
+          end
+
+          if plan_data_list.empty?
+            OT.lw '[Pull] No valid plans collected from Stripe'
+            return 0
+          end
+
+          report("Upserting #{plan_data_list.size} plans...")
+
+          # Upsert all plans
+          upserted_ids  = []
+          not_persisted = []
+
+          plan_data_list.each do |plan_data|
+            plan = Billing::Plan.upsert_from_stripe_data(plan_data)
+            upserted_ids << plan.plan_id
+            not_persisted << plan.plan_id unless Billing::Plan.instances.member?(plan.plan_id)
+          end
+
+          saved_count = upserted_ids.size - not_persisted.size
+
+          if not_persisted.any?
+            OT.lw "[Pull] #{not_persisted.size} plan(s) not persisted: #{not_persisted.join(', ')}"
+          end
+
+          # Prune stale plans not in current Stripe catalog
+          pruned_count = Billing::Plan.prune_stale_plans(upserted_ids)
+
+          # Rebuild lookup cache for O(1) price_id lookups
+          Billing::Plan.rebuild_stripe_price_id_cache
+
+          # Update global sync timestamp
+          Billing::Plan.update_catalog_sync_timestamp
+
+          OT.li "[Pull] Synced #{saved_count}/#{upserted_ids.size} plans " \
+                "(#{not_persisted.size} not persisted), pruned #{pruned_count}"
+          saved_count
+        end
+
+        # Fetch products and prices from Stripe, return plan data hashes
+        #
+        # Called inside circuit breaker. All Stripe API calls happen here.
+        #
+        # @return [Array<Hash>] Plan data hashes ready for upsert
+        def fetch_and_collect_plan_data
+          products = StripeReader.fetch_products(
+            app_identifier: Billing::Metadata::APP_NAME,
+            region_filter: @region || Onetime.billing_config.region,
+          )
+
+          if products.empty?
+            OT.lw '[Pull] No valid products fetched from Stripe'
+            return []
+          end
+
+          report("Fetching prices for #{products.size} products...")
+          prices_by_key = StripeReader.fetch_prices(products)
+
+          collect_plan_data(products, prices_by_key)
+        end
+
+        # Collect plan data from StripeReader output
+        #
+        # Groups products by plan_id (family), merges interval variants,
+        # and validates metadata.
+        #
+        # @param products [Hash<String, Stripe::Product>] Products keyed by match_key (plan_id)
+        # @param prices_by_key [Hash<String, Array<Stripe::Price>>] Prices grouped by match_key
+        # @return [Array<Hash>] Plan data hashes ready for upsert_from_stripe_data
+        def collect_plan_data(products, prices_by_key)
+          plan_data_by_family = {}
+          validation_errors   = []
+          products_processed  = 0
+
+          products.each do |match_key, product|
+            products_processed += 1
+            if products_processed == 1 || products_processed % 5 == 0
+              report("Processing product #{products_processed}: #{product.name[0..40]}...")
+            end
+
+            # Validate product metadata
+            result = Billing::Plan.validate_product_metadata(product)
+            if result[:missing].any? || result[:blank].any?
+              problems = []
+              problems << "missing: #{result[:missing].join(', ')}" if result[:missing].any?
+              problems << "blank: #{result[:blank].join(', ')}" if result[:blank].any?
+              OT.le '[Pull] Product failed metadata validation',
+                { product_id: product.id, product_name: product.name, problems: problems.join('; ') }
+              validation_errors << {
+                product_id: product.id,
+                price_id: nil,
+                product_name: product.name,
+                error: "invalid metadata: #{problems.join('; ')}",
+              }
+              next
+            end
+
+            # Get prices for this product
+            prices = prices_by_key[match_key] || []
+            next if prices.empty?
+
+            prices.each do |price|
+              # Skip non-recurring prices
+              next unless price.type == 'recurring'
+
+              # Extract plan data using Plan's helper
+              plan_data = Billing::Plan.extract_plan_data(product, price)
+              plan_id   = plan_data[:plan_id]
+
+              if plan_data_by_family.key?(plan_id)
+                # Merge this interval's price data into existing plan entry
+                existing          = plan_data_by_family[plan_id]
+                existing[:prices] = existing[:prices].merge(plan_data[:prices])
+                existing[:active] = 'true' if plan_data[:active] == 'true'
+
+                # Merge stripe_snapshot prices
+                existing[:stripe_snapshot][:prices] =
+                  existing[:stripe_snapshot][:prices].merge(plan_data[:stripe_snapshot][:prices])
+              else
+                # First interval variant for this plan family
+                plan_data_by_family[plan_id] = plan_data
+              end
+            end
+          end
+
+          # Fail-closed: abort if any managed products had invalid metadata
+          if validation_errors.any?
+            OT.le '[Pull] Aborting due to validation failures',
+              { error_count: validation_errors.size, valid_count: plan_data_by_family.size }
+            raise Billing::CatalogValidationError.new(
+              "#{validation_errors.size} Stripe products failed metadata validation",
+              errors: validation_errors,
+            )
+          end
+
+          plan_data_by_family.values
+        end
 
         def report(message)
           @progress&.call(message)

--- a/apps/web/billing/operations/catalog/pull.rb
+++ b/apps/web/billing/operations/catalog/pull.rb
@@ -1,0 +1,94 @@
+# apps/web/billing/operations/catalog/pull.rb
+#
+# frozen_string_literal: true
+
+module Billing
+  module Operations
+    module Catalog
+      # Pull products and prices from Stripe to Redis cache.
+      #
+      # Wraps Plan.refresh_from_stripe and Plan.upsert_config_only_plans
+      # for CLI and programmatic use. Never writes to stdout directly.
+      #
+      # @example
+      #   result = Pull.call(region: 'ca', progress: ->(msg) { print "\r#{msg}" })
+      #   if result.success
+      #     puts "Synced #{result.plans_synced} plans"
+      #   end
+      #
+      class Pull
+        Result = Data.define(
+          :success,
+          :plans_synced,
+          :plans_pruned,
+          :config_plans_loaded,
+          :cache_cleared,
+          :errors,
+        ) do
+          def initialize(success:, plans_synced: 0, plans_pruned: 0, config_plans_loaded: 0, cache_cleared: false, errors: [])
+            super
+          end
+        end
+
+        # @param region [String, nil] Region filter for Stripe products
+        # @param clear_cache [Boolean] Clear existing cache before pulling
+        # @param progress [Proc, nil] Called with status messages
+        # @return [Result]
+        def self.call(region: nil, clear_cache: false, progress: nil)
+          new(region: region, clear_cache: clear_cache, progress: progress).call
+        end
+
+        def initialize(region:, clear_cache:, progress:)
+          @region      = region
+          @clear_cache = clear_cache
+          @progress    = progress
+        end
+
+        def call
+          errors        = []
+          cache_cleared = false
+
+          if @clear_cache
+            report('Clearing existing plan cache...')
+            Billing::Plan.clear_cache
+            cache_cleared = true
+            report('Cache cleared')
+          end
+
+          report('Pulling from Stripe to Redis cache...')
+
+          plans_synced = Billing::Plan.refresh_from_stripe(
+            progress: @progress,
+          )
+
+          config_plans_loaded = Billing::Plan.upsert_config_only_plans
+
+          Result.new(
+            success: true,
+            plans_synced: plans_synced,
+            plans_pruned: 0,
+            config_plans_loaded: config_plans_loaded,
+            cache_cleared: cache_cleared,
+            errors: errors,
+          )
+        rescue Stripe::StripeError => ex
+          Result.new(
+            success: false,
+            errors: ["Stripe error: #{ex.message}"],
+          )
+        rescue StandardError => ex
+          Result.new(
+            success: false,
+            errors: ["#{ex.class}: #{ex.message}"],
+          )
+        end
+
+        private
+
+        def report(message)
+          @progress&.call(message)
+        end
+      end
+    end
+  end
+end

--- a/apps/web/billing/operations/catalog/pull.rb
+++ b/apps/web/billing/operations/catalog/pull.rb
@@ -2,6 +2,8 @@
 #
 # frozen_string_literal: true
 
+require_relative 'stripe_retry'
+
 module Billing
   module Operations
     module Catalog
@@ -45,8 +47,9 @@ module Billing
         end
 
         def call
-          errors        = []
-          cache_cleared = false
+          cache_cleared       = false
+          plans_synced        = 0
+          config_plans_loaded = 0
 
           if @clear_cache
             report('Clearing existing plan cache...')
@@ -57,9 +60,9 @@ module Billing
 
           report('Pulling from Stripe to Redis cache...')
 
-          plans_synced = Billing::Plan.refresh_from_stripe(
-            progress: @progress,
-          )
+          plans_synced = StripeRetry.with_retry do
+            Billing::Plan.refresh_from_stripe(progress: @progress)
+          end
 
           config_plans_loaded = Billing::Plan.upsert_config_only_plans
 
@@ -69,16 +72,21 @@ module Billing
             plans_pruned: 0,
             config_plans_loaded: config_plans_loaded,
             cache_cleared: cache_cleared,
-            errors: errors,
           )
         rescue Stripe::StripeError => ex
           Result.new(
             success: false,
+            plans_synced: plans_synced,
+            config_plans_loaded: config_plans_loaded,
+            cache_cleared: cache_cleared,
             errors: ["Stripe error: #{ex.message}"],
           )
         rescue StandardError => ex
           Result.new(
             success: false,
+            plans_synced: plans_synced,
+            config_plans_loaded: config_plans_loaded,
+            cache_cleared: cache_cleared,
             errors: ["#{ex.class}: #{ex.message}"],
           )
         end

--- a/apps/web/billing/operations/catalog/pull.rb
+++ b/apps/web/billing/operations/catalog/pull.rb
@@ -22,12 +22,11 @@ module Billing
         Result = Data.define(
           :success,
           :plans_synced,
-          :plans_pruned,
           :config_plans_loaded,
           :cache_cleared,
           :errors,
         ) do
-          def initialize(success:, plans_synced: 0, plans_pruned: 0, config_plans_loaded: 0, cache_cleared: false, errors: [])
+          def initialize(success:, plans_synced: 0, config_plans_loaded: 0, cache_cleared: false, errors: [])
             super
           end
         end
@@ -69,7 +68,6 @@ module Billing
           Result.new(
             success: true,
             plans_synced: plans_synced,
-            plans_pruned: 0,
             config_plans_loaded: config_plans_loaded,
             cache_cleared: cache_cleared,
           )

--- a/apps/web/billing/operations/catalog/push.rb
+++ b/apps/web/billing/operations/catalog/push.rb
@@ -3,6 +3,7 @@
 # frozen_string_literal: true
 
 require_relative 'stripe_retry'
+require_relative 'stripe_reader'
 
 module Billing
   module Operations
@@ -72,8 +73,18 @@ module Billing
           report("Region filter: #{region_filter || '(none)'}")
           report("Plans to process: #{plans.keys.join(', ')}")
 
-          existing_products = fetch_existing_products(app_identifier, match_fields, region_filter, plans)
-          existing_prices   = fetch_existing_prices(existing_products)
+          override_product_ids = plans.values
+            .map { |plan_def| plan_def['stripe_product_id'] }
+            .compact
+            .to_set
+
+          existing_products = StripeReader.fetch_products(
+            app_identifier: app_identifier,
+            region_filter: region_filter,
+            match_fields: match_fields,
+            override_product_ids: override_product_ids,
+          )
+          existing_prices   = StripeReader.fetch_prices(existing_products)
 
           changes = analyze_changes(plans, existing_products, existing_prices, match_fields, catalog_currency)
 
@@ -122,44 +133,6 @@ module Billing
           catalog.empty? ? nil : catalog
         end
 
-        def fetch_existing_products(app_identifier, match_fields, region_filter, plans = {})
-          products             = {}
-          override_product_ids = plans.values
-            .map { |plan_def| plan_def['stripe_product_id'] }
-            .compact
-            .to_set
-
-          StripeRetry.with_retry do
-            Stripe::Product.list(active: true, limit: 100).auto_paging_each do |product|
-              has_app_match      = product.metadata['app'] == app_identifier
-              has_override_match = override_product_ids.include?(product.id)
-
-              next unless has_app_match || has_override_match
-
-              if region_filter && !has_override_match && !Billing::RegionNormalizer.match?(product.metadata['region'], region_filter)
-                next
-              end
-
-              key = build_match_key_from_metadata(product.metadata, match_fields)
-
-              if key
-                products[key] = product
-              elsif has_override_match
-                products["__id__#{product.id}"] = product
-              end
-            end
-          end
-
-          products
-        end
-
-        def build_match_key_from_metadata(metadata, match_fields)
-          values = match_fields.map { |f| metadata[f]&.to_s }
-          return nil if values.any?(&:nil?)
-
-          values.join('|')
-        end
-
         def build_match_key_from_plan(plan_id, plan_def, match_fields)
           values = match_fields.map do |field|
             field == 'plan_id' ? plan_id : plan_def[field]&.to_s
@@ -167,27 +140,6 @@ module Billing
           return nil if values.any?(&:nil?)
 
           values.join('|')
-        end
-
-        def fetch_existing_prices(products)
-          prices      = {}
-          product_ids = products.values.map(&:id)
-
-          return prices if product_ids.empty?
-
-          StripeRetry.with_retry do
-            Stripe::Price.list(active: true, limit: 100).auto_paging_each do |price|
-              next unless product_ids.include?(price.product)
-
-              match_key = products.find { |_k, p| p.id == price.product }&.first
-              next unless match_key
-
-              prices[match_key] ||= []
-              prices[match_key] << price
-            end
-          end
-
-          prices
         end
 
         def analyze_changes(plans, existing_products, existing_prices, match_fields, catalog_currency)

--- a/apps/web/billing/operations/catalog/push.rb
+++ b/apps/web/billing/operations/catalog/push.rb
@@ -95,7 +95,7 @@ module Billing
             )
           end
 
-          apply_changes(changes, app_identifier)
+          apply_changes(changes, app_identifier, catalog_currency)
 
           Result.new(
             success: true,
@@ -368,11 +368,11 @@ module Billing
           end
         end
 
-        def apply_changes(changes, app_identifier)
+        def apply_changes(changes, app_identifier, catalog_currency)
           new_products = {}
 
           changes[:products_to_create].each do |item|
-            product                      = create_product(item[:plan_id], item[:plan_def], app_identifier)
+            product                      = create_product(item[:plan_id], item[:plan_def], app_identifier, catalog_currency)
             new_products[item[:plan_id]] = product if product
           end
 
@@ -388,8 +388,8 @@ module Billing
           end
         end
 
-        def create_product(plan_id, plan_def, app_identifier)
-          metadata           = build_create_metadata(plan_id, plan_def, app_identifier)
+        def create_product(plan_id, plan_def, app_identifier, catalog_currency)
+          metadata           = build_create_metadata(plan_id, plan_def, app_identifier, catalog_currency)
           marketing_features = (plan_def['features'] || []).map { |f| { name: f } }
 
           product = StripeRetry.with_retry do
@@ -456,7 +456,7 @@ module Billing
           report("  ERROR creating price: #{ex.message}")
         end
 
-        def build_create_metadata(plan_id, plan_def, app_identifier)
+        def build_create_metadata(plan_id, plan_def, app_identifier, catalog_currency)
           limits = plan_def['limits'] || {}
 
           metadata = {
@@ -483,7 +483,7 @@ module Billing
             metadata[field_name] = serialized if serialized
           end
 
-          metadata[Billing::Metadata::FIELD_CURRENCY] = OT.billing_config.currency
+          metadata[Billing::Metadata::FIELD_CURRENCY] = catalog_currency
 
           Billing::Metadata::LIMIT_FIELDS.each do |field_name, yaml_key|
             value                = limits[yaml_key]

--- a/apps/web/billing/operations/catalog/push.rb
+++ b/apps/web/billing/operations/catalog/push.rb
@@ -106,13 +106,13 @@ module Billing
             )
           end
 
-          apply_changes(changes, app_identifier, catalog_currency)
+          actual = apply_changes(changes, app_identifier, catalog_currency)
 
           Result.new(
             success: true,
-            products_created: changes[:products_to_create].size,
-            products_updated: changes[:products_to_update].size,
-            prices_created: changes[:prices_to_create].size,
+            products_created: actual[:products_created],
+            products_updated: actual[:products_updated],
+            prices_created: actual[:prices_created],
           )
         rescue Stripe::StripeError => ex
           Result.new(success: false, errors: ["Stripe error: #{ex.message}"])
@@ -320,24 +320,37 @@ module Billing
           end
         end
 
+        # Apply changes to Stripe and return actual success counts
+        #
+        # @return [Hash] Actual counts: { products_created:, products_updated:, prices_created: }
         def apply_changes(changes, app_identifier, catalog_currency)
-          new_products = {}
+          new_products     = {}
+          products_created = 0
+          products_updated = 0
+          prices_created   = 0
 
           changes[:products_to_create].each do |item|
-            product                      = create_product(item[:plan_id], item[:plan_def], app_identifier, catalog_currency)
-            new_products[item[:plan_id]] = product if product
+            product = create_product(item[:plan_id], item[:plan_def], app_identifier, catalog_currency)
+            if product
+              new_products[item[:plan_id]] = product
+              products_created            += 1
+            end
           end
 
           changes[:products_to_update].each do |item|
-            update_product(item[:product], item[:plan_def], item[:updates])
+            if update_product(item[:product], item[:plan_def], item[:updates])
+              products_updated += 1
+            end
           end
 
           changes[:prices_to_create].each do |item|
             product_id = item[:product_id] || new_products[item[:plan_id]]&.id
             next unless product_id
 
-            create_price(product_id, item)
+            prices_created += 1 if create_price(product_id, item)
           end
+
+          { products_created: products_created, products_updated: products_updated, prices_created: prices_created }
         end
 
         def create_product(plan_id, plan_def, app_identifier, catalog_currency)
@@ -378,14 +391,16 @@ module Billing
 
           params[:metadata] = metadata_updates unless metadata_updates.empty?
 
-          return if params.empty?
+          return false if params.empty?
 
           StripeRetry.with_retry do
             Stripe::Product.update(existing.id, params)
           end
           report("  Updated product: #{existing.id}")
+          true
         rescue Stripe::StripeError => ex
           report("  ERROR updating #{existing.id}: #{ex.message}")
+          false
         end
 
         def create_price(product_id, price_def)
@@ -404,8 +419,10 @@ module Billing
             Stripe::Price.create(params)
           end
           report("  Created price: #{price_def[:amount]}/#{price_def[:interval]} for #{price_def[:plan_id]}")
+          true
         rescue Stripe::StripeError => ex
           report("  ERROR creating price: #{ex.message}")
+          false
         end
 
         def build_create_metadata(plan_id, plan_def, app_identifier, catalog_currency)

--- a/apps/web/billing/operations/catalog/push.rb
+++ b/apps/web/billing/operations/catalog/push.rb
@@ -1,0 +1,498 @@
+# apps/web/billing/operations/catalog/push.rb
+#
+# frozen_string_literal: true
+
+require_relative 'stripe_retry'
+
+module Billing
+  module Operations
+    module Catalog
+      # Push billing catalog to Stripe (create/update products and prices).
+      #
+      # Syncs YAML catalog to Stripe. Prices are NEVER updated - only created
+      # when all required fields are provided. Extracted from BillingCatalogPushCommand.
+      #
+      # @example
+      #   result = Push.call(dry_run: true, progress: ->(msg) { puts msg })
+      #   puts "Would create #{result.products_created} products"
+      #
+      class Push
+        Result = Data.define(
+          :success,
+          :dry_run,
+          :products_created,
+          :products_updated,
+          :prices_created,
+          :no_changes,
+          :errors,
+        ) do
+          def initialize(success:, dry_run: false, products_created: 0, products_updated: 0, prices_created: 0, no_changes: false, errors: [])
+            super
+          end
+        end
+
+        # @param dry_run [Boolean] Preview changes without applying
+        # @param plan_filter [String, nil] Push only a specific plan
+        # @param skip_prices [Boolean] Skip price creation
+        # @param progress [Proc, nil] Called with status messages
+        # @return [Result]
+        def self.call(dry_run: false, plan_filter: nil, skip_prices: false, progress: nil)
+          new(dry_run: dry_run, plan_filter: plan_filter, skip_prices: skip_prices, progress: progress).call
+        end
+
+        def initialize(dry_run:, plan_filter:, skip_prices:, progress:)
+          @dry_run     = dry_run
+          @plan_filter = plan_filter
+          @skip_prices = skip_prices
+          @progress    = progress
+        end
+
+        def call
+          catalog = load_catalog
+          return Result.new(success: false, errors: ['Catalog not found or failed to load']) unless catalog
+
+          app_identifier   = catalog['app_identifier'] || Billing::Metadata::APP_NAME
+          plans            = catalog['plans'] || {}
+          match_fields     = catalog['match_fields'] || ['plan_id']
+          region_filter    = catalog['region']
+          catalog_currency = (catalog['currency'] || 'cad').to_s.strip.downcase
+
+          return Result.new(success: false, errors: ['No plans found in catalog']) if plans.empty?
+
+          if @plan_filter
+            unless plans.key?(@plan_filter)
+              return Result.new(success: false, errors: ["Plan '#{@plan_filter}' not found. Available: #{plans.keys.join(', ')}"])
+            end
+
+            plans = { @plan_filter => plans[@plan_filter] }
+          end
+
+          report("App identifier: #{app_identifier}")
+          report("Match fields: #{match_fields.join(', ')}")
+          report("Region filter: #{region_filter || '(none)'}")
+          report("Plans to process: #{plans.keys.join(', ')}")
+
+          existing_products = fetch_existing_products(app_identifier, match_fields, region_filter, plans)
+          existing_prices   = fetch_existing_prices(existing_products)
+
+          changes = analyze_changes(plans, existing_products, existing_prices, match_fields, catalog_currency)
+
+          if changes[:products_to_create].empty? &&
+             changes[:products_to_update].empty? &&
+             changes[:prices_to_create].empty?
+            return Result.new(success: true, no_changes: true, dry_run: @dry_run)
+          end
+
+          report_changes(changes)
+
+          if @dry_run
+            return Result.new(
+              success: true,
+              dry_run: true,
+              products_created: changes[:products_to_create].size,
+              products_updated: changes[:products_to_update].size,
+              prices_created: changes[:prices_to_create].size,
+            )
+          end
+
+          apply_changes(changes, app_identifier)
+
+          Result.new(
+            success: true,
+            products_created: changes[:products_to_create].size,
+            products_updated: changes[:products_to_update].size,
+            prices_created: changes[:prices_to_create].size,
+          )
+        rescue Stripe::StripeError => ex
+          Result.new(success: false, errors: ["Stripe error: #{ex.message}"])
+        rescue StandardError => ex
+          Result.new(success: false, errors: ["#{ex.class}: #{ex.message}"])
+        end
+
+        private
+
+        def report(message)
+          @progress&.call(message)
+        end
+
+        def load_catalog
+          return nil unless Billing::Config.config_exists?
+
+          catalog = Billing::Config.safe_load_config
+          catalog.empty? ? nil : catalog
+        end
+
+        def fetch_existing_products(app_identifier, match_fields, region_filter, plans = {})
+          products             = {}
+          override_product_ids = plans.values
+            .map { |plan_def| plan_def['stripe_product_id'] }
+            .compact
+            .to_set
+
+          StripeRetry.with_retry do
+            Stripe::Product.list(active: true, limit: 100).auto_paging_each do |product|
+              has_app_match      = product.metadata['app'] == app_identifier
+              has_override_match = override_product_ids.include?(product.id)
+
+              next unless has_app_match || has_override_match
+
+              if region_filter && !has_override_match && !Billing::RegionNormalizer.match?(product.metadata['region'], region_filter)
+                next
+              end
+
+              key = build_match_key_from_metadata(product.metadata, match_fields)
+
+              if key
+                products[key] = product
+              elsif has_override_match
+                products["__id__#{product.id}"] = product
+              end
+            end
+          end
+
+          products
+        end
+
+        def build_match_key_from_metadata(metadata, match_fields)
+          values = match_fields.map { |f| metadata[f]&.to_s }
+          return nil if values.any?(&:nil?)
+
+          values.join('|')
+        end
+
+        def build_match_key_from_plan(plan_id, plan_def, match_fields)
+          values = match_fields.map do |field|
+            field == 'plan_id' ? plan_id : plan_def[field]&.to_s
+          end
+          return nil if values.any?(&:nil?)
+
+          values.join('|')
+        end
+
+        def fetch_existing_prices(products)
+          prices      = {}
+          product_ids = products.values.map(&:id)
+
+          return prices if product_ids.empty?
+
+          StripeRetry.with_retry do
+            Stripe::Price.list(active: true, limit: 100).auto_paging_each do |price|
+              next unless product_ids.include?(price.product)
+
+              match_key = products.find { |_k, p| p.id == price.product }&.first
+              next unless match_key
+
+              prices[match_key] ||= []
+              prices[match_key] << price
+            end
+          end
+
+          prices
+        end
+
+        def analyze_changes(plans, existing_products, existing_prices, match_fields, catalog_currency)
+          changes = {
+            products_to_create: [],
+            products_to_update: [],
+            prices_to_create: [],
+          }
+
+          plans.each do |plan_id, plan_def|
+            existing  = resolve_existing_product(plan_id, plan_def, existing_products, match_fields)
+            match_key = build_match_key_from_plan(plan_id, plan_def, match_fields)
+
+            if existing
+              updates = detect_product_updates(plan_id, existing, plan_def, catalog_currency)
+              unless updates.empty?
+                changes[:products_to_update] << {
+                  plan_id: plan_id,
+                  product: existing,
+                  updates: updates,
+                  plan_def: plan_def,
+                }
+              end
+            elsif plan_def['legacy']
+              report("  ⏭ #{plan_id}: skipping (legacy plan, product not found)")
+              next
+            else
+              changes[:products_to_create] << {
+                plan_id: plan_id,
+                plan_def: plan_def,
+              }
+            end
+
+            next if @skip_prices
+
+            price_changes = analyze_price_changes(
+              plan_id, plan_def, existing, existing_prices[match_key] || [], catalog_currency
+            )
+            changes[:prices_to_create].concat(price_changes)
+          end
+
+          changes
+        end
+
+        def resolve_existing_product(plan_id, plan_def, existing_products, match_fields)
+          if (override_id = plan_def['stripe_product_id'])
+            product = existing_products.values.find { |p| p.id == override_id }
+            if product
+              report("  ℹ #{plan_id}: using stripe_product_id override (#{override_id})")
+              return product
+            else
+              report("  ⚠ #{plan_id}: stripe_product_id '#{override_id}' not found")
+              return nil
+            end
+          end
+
+          match_key = build_match_key_from_plan(plan_id, plan_def, match_fields)
+          existing_products[match_key]
+        end
+
+        def detect_product_updates(plan_id, existing, plan_def, catalog_currency)
+          updates = {}
+
+          if existing.name != plan_def['name']
+            updates[:name] = { from: existing.name, to: plan_def['name'] }
+          end
+
+          existing_features = existing.marketing_features&.map(&:name) || []
+          config_features   = plan_def['features'] || []
+          if existing_features.sort != config_features.sort
+            updates[:marketing_features] = { from: existing_features, to: config_features }
+          end
+
+          metadata_fields = build_syncable_metadata(plan_id, plan_def, catalog_currency)
+
+          metadata_fields.each do |field, expected|
+            current = existing.metadata[field]
+            next if current.to_s == expected.to_s
+
+            updates[:"metadata_#{field}"] = { from: current, to: expected }
+          end
+
+          updates
+        end
+
+        def build_syncable_metadata(plan_id, plan_def, catalog_currency)
+          metadata_fields                                   = {}
+          metadata_fields[Billing::Metadata::FIELD_PLAN_ID] = plan_id
+          limits                                            = plan_def['limits'] || {}
+
+          Billing::Metadata::SYNCABLE_FIELDS.each do |field_name, yaml_key|
+            value = plan_def[yaml_key]
+
+            serialized = case field_name
+                         when Billing::Metadata::FIELD_ENTITLEMENTS
+                           (value || []).join(',')
+                         when Billing::Metadata::FIELD_IS_POPULAR
+                           (value == true).to_s
+                         when Billing::Metadata::FIELD_REGION
+                           Billing::RegionNormalizer.normalize(value)
+                         else
+                           value.to_s
+                         end
+
+            metadata_fields[field_name] = serialized if serialized
+          end
+
+          metadata_fields[Billing::Metadata::FIELD_CURRENCY] = catalog_currency
+
+          Billing::Metadata::LIMIT_FIELDS.each do |field_name, yaml_key|
+            metadata_fields[field_name] = limits[yaml_key].to_s
+          end
+
+          metadata_fields
+        end
+
+        def analyze_price_changes(plan_id, plan_def, existing_product, existing_prices, catalog_currency)
+          changes        = []
+          catalog_prices = plan_def['prices'] || []
+
+          return changes if catalog_prices.empty?
+
+          product_id = existing_product&.id
+
+          catalog_prices.each_with_index do |price_def, idx|
+            resolved_currency = (price_def['currency'] || catalog_currency).to_s.strip.downcase
+
+            missing = []
+            missing << 'amount' unless price_def['amount']
+            missing << 'interval' unless price_def['interval']
+
+            unless missing.empty?
+              report("  ⚠ #{plan_id} price[#{idx}]: skipping - missing #{missing.join(', ')}")
+              next
+            end
+
+            if existing_product
+              matching = existing_prices.find do |p|
+                p.unit_amount == price_def['amount'] &&
+                  p.currency == resolved_currency &&
+                  p.recurring&.interval == price_def['interval']
+              end
+              next if matching
+            end
+
+            changes << {
+              plan_id: plan_id,
+              product_id: product_id,
+              amount: price_def['amount'],
+              currency: resolved_currency,
+              interval: price_def['interval'],
+            }
+          end
+
+          changes
+        end
+
+        def report_changes(changes)
+          unless changes[:products_to_create].empty?
+            report("Products to CREATE: #{changes[:products_to_create].size}")
+            changes[:products_to_create].each do |item|
+              report("  + #{item[:plan_id]}: #{item[:plan_def]['name']}")
+            end
+          end
+
+          unless changes[:products_to_update].empty?
+            report("Products to UPDATE: #{changes[:products_to_update].size}")
+            changes[:products_to_update].each do |item|
+              report("  ~ #{item[:plan_id]} (#{item[:product].id})")
+            end
+          end
+
+          return if changes[:prices_to_create].empty?
+
+          report("Prices to CREATE: #{changes[:prices_to_create].size}")
+          changes[:prices_to_create].each do |item|
+            report("  + #{item[:plan_id]}: #{item[:amount]}/#{item[:interval]}")
+          end
+        end
+
+        def apply_changes(changes, app_identifier)
+          new_products = {}
+
+          changes[:products_to_create].each do |item|
+            product                      = create_product(item[:plan_id], item[:plan_def], app_identifier)
+            new_products[item[:plan_id]] = product if product
+          end
+
+          changes[:products_to_update].each do |item|
+            update_product(item[:product], item[:plan_def], item[:updates])
+          end
+
+          changes[:prices_to_create].each do |item|
+            product_id = item[:product_id] || new_products[item[:plan_id]]&.id
+            next unless product_id
+
+            create_price(product_id, item)
+          end
+        end
+
+        def create_product(plan_id, plan_def, app_identifier)
+          metadata           = build_create_metadata(plan_id, plan_def, app_identifier)
+          marketing_features = (plan_def['features'] || []).map { |f| { name: f } }
+
+          product = StripeRetry.with_retry do
+            Stripe::Product.create(
+              name: plan_def['name'],
+              metadata: metadata,
+              marketing_features: marketing_features,
+            )
+          end
+
+          report("  Created product: #{product.id} (#{plan_id})")
+          product
+        rescue Stripe::StripeError => ex
+          report("  ERROR creating #{plan_id}: #{ex.message}")
+          nil
+        end
+
+        def update_product(existing, _plan_def, updates)
+          params = {}
+
+          params[:name] = updates[:name][:to] if updates[:name]
+
+          if updates[:marketing_features]
+            params[:marketing_features] = updates[:marketing_features][:to].map { |f| { name: f } }
+          end
+
+          metadata_updates = {}
+          updates.each do |field, change|
+            next unless field.to_s.start_with?('metadata_')
+
+            key                   = field.to_s.sub('metadata_', '')
+            metadata_updates[key] = change[:to]
+          end
+
+          params[:metadata] = metadata_updates unless metadata_updates.empty?
+
+          return if params.empty?
+
+          StripeRetry.with_retry do
+            Stripe::Product.update(existing.id, params)
+          end
+          report("  Updated product: #{existing.id}")
+        rescue Stripe::StripeError => ex
+          report("  ERROR updating #{existing.id}: #{ex.message}")
+        end
+
+        def create_price(product_id, price_def)
+          params = {
+            product: product_id,
+            unit_amount: price_def[:amount],
+            currency: price_def[:currency].downcase,
+            recurring: {
+              interval: price_def[:interval],
+            },
+          }
+
+          params[:metadata] = price_def[:metadata] if price_def[:metadata]&.any?
+
+          StripeRetry.with_retry do
+            Stripe::Price.create(params)
+          end
+          report("  Created price: #{price_def[:amount]}/#{price_def[:interval]} for #{price_def[:plan_id]}")
+        rescue Stripe::StripeError => ex
+          report("  ERROR creating price: #{ex.message}")
+        end
+
+        def build_create_metadata(plan_id, plan_def, app_identifier)
+          limits = plan_def['limits'] || {}
+
+          metadata = {
+            Billing::Metadata::FIELD_APP => app_identifier,
+            Billing::Metadata::FIELD_PLAN_ID => plan_id,
+            Billing::Metadata::FIELD_CREATED => Time.now.utc.iso8601,
+          }
+
+          Billing::Metadata::SYNCABLE_FIELDS.each do |field_name, yaml_key|
+            value = plan_def[yaml_key]
+            next unless value
+
+            serialized = case field_name
+                         when Billing::Metadata::FIELD_ENTITLEMENTS
+                           value.join(',')
+                         when Billing::Metadata::FIELD_IS_POPULAR
+                           value == true ? 'true' : nil
+                         when Billing::Metadata::FIELD_REGION
+                           Billing::RegionNormalizer.normalize(value)
+                         else
+                           value.to_s
+                         end
+
+            metadata[field_name] = serialized if serialized
+          end
+
+          metadata[Billing::Metadata::FIELD_CURRENCY] = OT.billing_config.currency
+
+          Billing::Metadata::LIMIT_FIELDS.each do |field_name, yaml_key|
+            value                = limits[yaml_key]
+            metadata[field_name] = value.to_s if value
+          end
+
+          metadata
+        end
+      end
+    end
+  end
+end

--- a/apps/web/billing/operations/catalog/stripe_reader.rb
+++ b/apps/web/billing/operations/catalog/stripe_reader.rb
@@ -9,8 +9,12 @@ module Billing
     module Catalog
       # Consolidated Stripe data fetching for catalog operations.
       #
-      # Single entry point for `Stripe::Product.list` and `Stripe::Price.list`
-      # in the catalog sync path. Used by both Pull and Push operations.
+      # Entry point for `Stripe::Product.list` and `Stripe::Price.list`
+      # in the catalog sync path. Currently used by Push; Pull delegates
+      # to `Plan.refresh_from_stripe` which has its own Stripe calls.
+      #
+      # TODO(#3152 Phase 3): Wire Pull through StripeReader when moving
+      # `refresh_from_stripe` orchestration out of Plan.
       #
       # @example
       #   products = StripeReader.fetch_products(app_identifier: 'onetimesecret')

--- a/apps/web/billing/operations/catalog/stripe_reader.rb
+++ b/apps/web/billing/operations/catalog/stripe_reader.rb
@@ -1,0 +1,95 @@
+# apps/web/billing/operations/catalog/stripe_reader.rb
+#
+# frozen_string_literal: true
+
+require_relative 'stripe_retry'
+
+module Billing
+  module Operations
+    module Catalog
+      # Consolidated Stripe data fetching for catalog operations.
+      #
+      # Single entry point for `Stripe::Product.list` and `Stripe::Price.list`
+      # in the catalog sync path. Used by both Pull and Push operations.
+      #
+      # @example
+      #   products = StripeReader.fetch_products(app_identifier: 'onetimesecret')
+      #   prices   = StripeReader.fetch_prices(products)
+      #
+      module StripeReader
+        extend self
+
+        # Fetch products filtered by app_identifier and optional region.
+        #
+        # Products are keyed by a match_key built from metadata fields,
+        # enabling correlation with YAML plan definitions.
+        #
+        # @param app_identifier [String] Value to match in product metadata['app']
+        # @param region_filter [String, nil] Optional region to filter products
+        # @param match_fields [Array<String>] Fields to build match keys from metadata
+        # @param override_product_ids [Set<String>] Product IDs to include regardless of app match
+        # @return [Hash<String, Stripe::Product>] Products keyed by match_key
+        def fetch_products(app_identifier:, region_filter: nil, match_fields: ['plan_id'], override_product_ids: Set.new)
+          products = {}
+
+          StripeRetry.with_retry do
+            Stripe::Product.list(active: true, limit: 100).auto_paging_each do |product|
+              has_app_match      = product.metadata['app'] == app_identifier
+              has_override_match = override_product_ids.include?(product.id)
+
+              next unless has_app_match || has_override_match
+
+              if region_filter && !has_override_match && !Billing::RegionNormalizer.match?(product.metadata['region'], region_filter)
+                next
+              end
+
+              key = build_match_key_from_metadata(product.metadata, match_fields)
+
+              if key
+                products[key] = product
+              elsif has_override_match
+                products["__id__#{product.id}"] = product
+              end
+            end
+          end
+
+          products
+        end
+
+        # Fetch active prices for given products.
+        #
+        # @param products [Hash<String, Stripe::Product>] Products keyed by match_key
+        # @return [Hash<String, Array<Stripe::Price>>] Prices grouped by match_key
+        def fetch_prices(products)
+          prices      = {}
+          product_ids = products.values.map(&:id)
+
+          return prices if product_ids.empty?
+
+          StripeRetry.with_retry do
+            Stripe::Price.list(active: true, limit: 100).auto_paging_each do |price|
+              next unless product_ids.include?(price.product)
+
+              match_key = products.find { |_k, p| p.id == price.product }&.first
+              next unless match_key
+
+              prices[match_key] ||= []
+              prices[match_key] << price
+            end
+          end
+
+          prices
+        end
+
+        private
+
+        def build_match_key_from_metadata(metadata, match_fields)
+          values = match_fields.map { |f| metadata[f]&.to_s }
+          return nil if values.any?(&:nil?)
+
+          values.join('|')
+        end
+      end
+    end
+  end
+end

--- a/apps/web/billing/operations/catalog/stripe_reader.rb
+++ b/apps/web/billing/operations/catalog/stripe_reader.rb
@@ -9,12 +9,8 @@ module Billing
     module Catalog
       # Consolidated Stripe data fetching for catalog operations.
       #
-      # Entry point for `Stripe::Product.list` and `Stripe::Price.list`
-      # in the catalog sync path. Currently used by Push; Pull delegates
-      # to `Plan.refresh_from_stripe` which has its own Stripe calls.
-      #
-      # TODO(#3152 Phase 3): Wire Pull through StripeReader when moving
-      # `refresh_from_stripe` orchestration out of Plan.
+      # Single entry point for `Stripe::Product.list` and `Stripe::Price.list`
+      # in the catalog sync path. Used by both Pull and Push operations.
       #
       # @example
       #   products = StripeReader.fetch_products(app_identifier: 'onetimesecret')

--- a/apps/web/billing/operations/catalog/stripe_retry.rb
+++ b/apps/web/billing/operations/catalog/stripe_retry.rb
@@ -1,0 +1,52 @@
+# apps/web/billing/operations/catalog/stripe_retry.rb
+#
+# frozen_string_literal: true
+
+module Billing
+  module Operations
+    module Catalog
+      # Retry wrapper for Stripe API calls with backoff strategies.
+      #
+      # Extracted from CLI::BillingHelpers for use in operations layer.
+      # Uses linear backoff for connection errors, exponential for rate limits.
+      #
+      module StripeRetry
+        extend self
+
+        MAX_RETRIES = 3
+        BASE_DELAY  = 2
+
+        # Execute Stripe API call with automatic retry
+        #
+        # @param max_retries [Integer] Maximum retry attempts
+        # @yield Block containing Stripe API call
+        # @return Result of the yielded block
+        # @raise [Stripe::StripeError] If all retries exhausted
+        def with_retry(max_retries: MAX_RETRIES)
+          retries = 0
+          begin
+            yield
+          rescue Stripe::APIConnectionError
+            retries += 1
+            if retries <= max_retries
+              delay = BASE_DELAY * retries
+              OT.lw "Stripe connection error, retrying in #{delay}s (#{retries}/#{max_retries})"
+              sleep(delay)
+              retry
+            end
+            raise
+          rescue Stripe::RateLimitError
+            retries += 1
+            if retries <= max_retries
+              delay = BASE_DELAY * (2**retries)
+              OT.lw "Stripe rate limit, backing off #{delay}s (#{retries}/#{max_retries})"
+              sleep(delay)
+              retry
+            end
+            raise
+          end
+        end
+      end
+    end
+  end
+end

--- a/apps/web/billing/operations/catalog/validate.rb
+++ b/apps/web/billing/operations/catalog/validate.rb
@@ -181,9 +181,9 @@ module Billing
             has_errors = errors.any? { |e| e.include?("Plan #{plan_id}:") || e.include?("/plans/#{plan_id}") }
 
             if has_errors
-              invalid_plans << { id: plan_id, name: data['name'], tier: data['tier'] }
+              invalid_plans << { id: plan_id, name: data['name'], tier: data['tier'], display_order: data['display_order'] || 0 }
             else
-              valid_plans << { id: plan_id, name: data['name'], tier: data['tier'] }
+              valid_plans << { id: plan_id, name: data['name'], tier: data['tier'], display_order: data['display_order'] || 0 }
             end
           end
 

--- a/apps/web/billing/operations/catalog/validate.rb
+++ b/apps/web/billing/operations/catalog/validate.rb
@@ -101,13 +101,13 @@ module Billing
           erb_template = ERB.new(File.read(path))
           yaml_content = erb_template.result
           YAML.safe_load(yaml_content, permitted_classes: [Symbol], symbolize_names: false)
-        rescue StandardError
+        rescue Psych::SyntaxError, Psych::DisallowedClass
           nil
         end
 
         def load_schema(path)
           JSON.parse(File.read(path))
-        rescue StandardError
+        rescue JSON::ParserError
           nil
         end
 

--- a/apps/web/billing/operations/catalog/validate.rb
+++ b/apps/web/billing/operations/catalog/validate.rb
@@ -1,0 +1,199 @@
+# apps/web/billing/operations/catalog/validate.rb
+#
+# frozen_string_literal: true
+
+require 'yaml'
+require 'json_schemer'
+
+module Billing
+  module Operations
+    module Catalog
+      # Validate billing catalog YAML structure using JSON Schema.
+      #
+      # Validates local catalog structure only. For Stripe product metadata
+      # validation, use `bin/ots billing products validate`.
+      #
+      # @example
+      #   result = Validate.call(strict: true)
+      #   if result.valid
+      #     puts "Catalog valid with #{result.plans_validated} plans"
+      #   else
+      #     result.errors.each { |e| puts "ERROR: #{e}" }
+      #   end
+      #
+      class Validate
+        Result = Data.define(
+          :success,
+          :valid,
+          :plans_validated,
+          :errors,
+          :warnings,
+          :plan_summary,
+        ) do
+          def initialize(success:, valid: false, plans_validated: 0, errors: [], warnings: [], plan_summary: {})
+            super
+          end
+        end
+
+        # @param strict [Boolean] Fail on warnings (default: only fail on errors)
+        # @param progress [Proc, nil] Called with status messages
+        # @return [Result]
+        def self.call(strict: false, progress: nil)
+          new(strict: strict, progress: progress).call
+        end
+
+        def initialize(strict:, progress:)
+          @strict   = strict
+          @progress = progress
+        end
+
+        def call
+          catalog_path = Billing::Config.config_path
+          schema_path  = File.join(Onetime::HOME, 'generated', 'schemas', 'config', 'billing.schema.json')
+
+          unless File.exist?(catalog_path)
+            return Result.new(success: false, errors: ["Catalog file not found: #{catalog_path}"])
+          end
+
+          unless File.exist?(schema_path)
+            return Result.new(success: false, errors: ["Schema file not found: #{schema_path}"])
+          end
+
+          report("Validating catalog structure: #{catalog_path}")
+
+          catalog = load_catalog(catalog_path)
+          return Result.new(success: false, errors: ['Failed to load catalog (YAML syntax error)']) unless catalog
+
+          schema = load_schema(schema_path)
+          return Result.new(success: false, errors: ['Failed to load schema (JSON syntax error)']) unless schema
+
+          errors   = []
+          warnings = []
+
+          validate_with_schema(catalog, schema, errors)
+          validate_entitlements_references(catalog, errors, warnings)
+          validate_price_consistency(catalog, warnings)
+
+          plans        = catalog['plans'] || {}
+          plan_summary = build_plan_summary(catalog, errors)
+
+          valid = errors.empty? && (!@strict || warnings.empty?)
+
+          Result.new(
+            success: true,
+            valid: valid,
+            plans_validated: plans.size,
+            errors: errors,
+            warnings: warnings,
+            plan_summary: plan_summary,
+          )
+        rescue StandardError => ex
+          Result.new(success: false, errors: ["#{ex.class}: #{ex.message}"])
+        end
+
+        private
+
+        def report(message)
+          @progress&.call(message)
+        end
+
+        def load_catalog(path)
+          erb_template = ERB.new(File.read(path))
+          yaml_content = erb_template.result
+          YAML.safe_load(yaml_content, permitted_classes: [Symbol], symbolize_names: false)
+        rescue StandardError
+          nil
+        end
+
+        def load_schema(path)
+          JSON.parse(File.read(path))
+        rescue StandardError
+          nil
+        end
+
+        def validate_with_schema(catalog, schema, errors)
+          schemer           = JSONSchemer.schema(schema)
+          validation_errors = schemer.validate(catalog).to_a
+
+          validation_errors.each do |error|
+            location = error['data_pointer'].empty? ? 'root' : error['data_pointer']
+            message  = error['error'] || error['type']
+            errors << "Schema validation: #{location}: #{message}"
+          end
+        end
+
+        def validate_entitlements_references(catalog, _errors, warnings)
+          entitlements = Billing::Config.load_entitlements
+
+          return if entitlements.empty?
+
+          plans = catalog['plans'] || {}
+          plans.each do |plan_id, plan_data|
+            plan_entitlements = plan_data['entitlements'] || []
+            is_legacy         = plan_data['legacy'] == true
+            label             = is_legacy ? "Legacy plan #{plan_id}" : "Plan #{plan_id}"
+
+            plan_entitlements.each do |ent_id|
+              unless entitlements.key?(ent_id)
+                warnings << "#{label}: references unknown entitlement '#{ent_id}'"
+              end
+            end
+          end
+
+          if catalog['legacy_plans']&.any?
+            warnings << 'DEPRECATED: legacy_plans section found. Move plans to plans with legacy: true flag.'
+          end
+        end
+
+        def validate_price_consistency(catalog, warnings)
+          plans = catalog['plans'] || {}
+
+          plans.each do |plan_id, plan_data|
+            prices = plan_data['prices'] || []
+
+            next if plan_data['tier'] == 'free'
+
+            if prices.empty?
+              warnings << "Plan #{plan_id}: No prices defined (expected for paid tier)"
+            end
+
+            intervals = prices.map { |p| p['interval'] }.uniq
+            if intervals.size == 1
+              missing = (%w[month year] - intervals).first
+              warnings << "Plan #{plan_id}: Missing #{missing}ly pricing (recommend both intervals)"
+            end
+
+            interval_counts = prices.group_by { |p| p['interval'] }.transform_values(&:count)
+            interval_counts.each do |interval, count|
+              if count > 1
+                warnings << "Plan #{plan_id}: Duplicate #{interval}ly prices (#{count} found)"
+              end
+            end
+          end
+        end
+
+        def build_plan_summary(catalog, errors)
+          plans         = catalog['plans'] || {}
+          valid_plans   = []
+          invalid_plans = []
+
+          plans.each do |plan_id, data|
+            has_errors = errors.any? { |e| e.include?("Plan #{plan_id}:") || e.include?("/plans/#{plan_id}") }
+
+            if has_errors
+              invalid_plans << { id: plan_id, name: data['name'], tier: data['tier'] }
+            else
+              valid_plans << { id: plan_id, name: data['name'], tier: data['tier'] }
+            end
+          end
+
+          {
+            valid: valid_plans,
+            invalid: invalid_plans,
+            has_free_tier: valid_plans.any? { |p| p[:tier] == 'free' },
+          }
+        end
+      end
+    end
+  end
+end

--- a/apps/web/billing/operations/webhook_handlers/catalog_updated.rb
+++ b/apps/web/billing/operations/webhook_handlers/catalog_updated.rb
@@ -4,6 +4,8 @@
 
 require_relative 'base_handler'
 require_relative '../../lib/stripe_circuit_breaker'
+require_relative '../catalog/pull'
+require_relative '../catalog/plan_persister'
 
 module Billing
   module Operations
@@ -53,7 +55,7 @@ module Billing
             mark_price_inactive(@data_object.id)
           when 'plan.created', 'plan.updated'
             # Legacy plan events - still trigger full refresh for compatibility
-            Billing::Plan.refresh_from_stripe
+            Billing::Operations::Catalog::Pull.call
             billing_logger.info '[CatalogUpdated] Legacy plan event, full refresh complete'
           end
 
@@ -192,11 +194,11 @@ module Billing
             next unless price.type == 'recurring'
 
             plan_data     = Billing::Plan.extract_plan_data(product, price)
-            Billing::Plan.upsert_from_stripe_data(plan_data)
+            Billing::Operations::Catalog::PlanPersister.upsert_from_stripe_data(plan_data)
             synced_count += 1
           end
 
-          Billing::Plan.rebuild_stripe_price_id_cache
+          Billing::Operations::Catalog::PlanPersister.rebuild_stripe_price_id_cache
 
           billing_logger.info '[CatalogUpdated] Synced product',
             {
@@ -227,8 +229,8 @@ module Billing
           return unless price.type == 'recurring'
 
           plan_data = Billing::Plan.extract_plan_data(product, price)
-          Billing::Plan.upsert_from_stripe_data(plan_data)
-          Billing::Plan.rebuild_stripe_price_id_cache
+          Billing::Operations::Catalog::PlanPersister.upsert_from_stripe_data(plan_data)
+          Billing::Operations::Catalog::PlanPersister.rebuild_stripe_price_id_cache
 
           billing_logger.info '[CatalogUpdated] Synced price',
             {
@@ -261,7 +263,7 @@ module Billing
             marked_count += 1
           end
 
-          Billing::Plan.rebuild_stripe_price_id_cache if marked_count > 0
+          Billing::Operations::Catalog::PlanPersister.rebuild_stripe_price_id_cache if marked_count > 0
 
           billing_logger.info '[CatalogUpdated] Product deletion processed',
             {
@@ -291,7 +293,7 @@ module Billing
           plan.last_synced_at = Time.now.to_i.to_s
           plan.save
 
-          Billing::Plan.rebuild_stripe_price_id_cache
+          Billing::Operations::Catalog::PlanPersister.rebuild_stripe_price_id_cache
 
           billing_logger.info '[CatalogUpdated] Marked plan inactive (price deleted)',
             {

--- a/apps/web/billing/spec/cli/catalog_pull_spec.rb
+++ b/apps/web/billing/spec/cli/catalog_pull_spec.rb
@@ -2,17 +2,26 @@
 #
 # frozen_string_literal: true
 
+# Specs for `bin/ots billing catalog pull` CLI wrapper.
+#
+# These test the CLI's public interface and delegation to operations.
+# For detailed logic tests, see: spec/operations/catalog/pull_spec.rb
+
 require_relative '../support/billing_spec_helper'
 require 'onetime/cli'
 require_relative '../../cli/catalog_pull_command'
 
-RSpec.describe 'Billing Catalog Pull CLI', :billing_cli, :integration, :vcr do
+RSpec.describe 'Billing Catalog Pull CLI', :billing_cli do
   subject(:command) { Onetime::CLI::BillingCatalogPullCommand.new }
 
   def capture_stdout
     old_stdout = $stdout
     $stdout = StringIO.new
-    yield
+    begin
+      yield
+    rescue SystemExit
+      # Ignore exit calls
+    end
     $stdout.string
   ensure
     $stdout = old_stdout
@@ -30,21 +39,32 @@ RSpec.describe 'Billing Catalog Pull CLI', :billing_cli, :integration, :vcr do
       end
 
       it 'exits early without pulling' do
-        expect(Billing::Plan).not_to receive(:refresh_from_stripe)
+        expect(Billing::Operations::Catalog::Pull).not_to receive(:call)
         command.call
       end
     end
 
     context 'successful pull' do
+      let(:success_result) do
+        Billing::Operations::Catalog::Pull::Result.new(
+          success: true,
+          plans_synced: 5,
+          config_plans_loaded: 2,
+        )
+      end
+
       before do
-        allow(Billing::Plan).to receive(:refresh_from_stripe).and_return(5)
+        allow(Billing::Operations::Catalog::Pull).to receive(:call).and_return(success_result)
       end
 
       it 'reports number of plans pulled' do
         output = capture_stdout { command.call }
-
-        expect(output).to include('Pulling from Stripe to Redis cache')
         expect(output).to include('Successfully pulled 5 plan(s) from Stripe')
+      end
+
+      it 'reports config-only plans when present' do
+        output = capture_stdout { command.call }
+        expect(output).to include('Upserted 2 config-only plan(s)')
       end
 
       it 'shows next steps after successful pull' do
@@ -52,10 +72,10 @@ RSpec.describe 'Billing Catalog Pull CLI', :billing_cli, :integration, :vcr do
         expect(output).to include('bin/ots billing plans')
       end
 
-      it 'passes progress callback to refresh_from_stripe' do
-        expect(Billing::Plan).to receive(:refresh_from_stripe) do |progress:|
-          expect(progress).to be_a(Method)
-          5
+      it 'passes progress callback to operation' do
+        expect(Billing::Operations::Catalog::Pull).to receive(:call) do |args|
+          expect(args[:progress]).to be_a(Method)
+          success_result
         end
 
         capture_stdout { command.call }
@@ -63,50 +83,43 @@ RSpec.describe 'Billing Catalog Pull CLI', :billing_cli, :integration, :vcr do
     end
 
     context 'with --clear flag' do
-      before do
-        allow(Billing::Plan).to receive(:clear_cache)
-        allow(Billing::Plan).to receive(:refresh_from_stripe).and_return(3)
+      let(:cleared_result) do
+        Billing::Operations::Catalog::Pull::Result.new(
+          success: true,
+          plans_synced: 3,
+          cache_cleared: true,
+        )
       end
 
-      it 'clears cache before pulling' do
-        expect(Billing::Plan).to receive(:clear_cache).ordered
-        expect(Billing::Plan).to receive(:refresh_from_stripe).ordered
+      before do
+        allow(Billing::Operations::Catalog::Pull).to receive(:call).and_return(cleared_result)
+      end
+
+      it 'passes clear_cache: true to operation' do
+        expect(Billing::Operations::Catalog::Pull).to receive(:call) do |args|
+          expect(args[:clear_cache]).to be(true)
+          cleared_result
+        end
 
         capture_stdout { command.call(clear: true) }
       end
-
-      it 'reports cache cleared' do
-        output = capture_stdout { command.call(clear: true) }
-
-        expect(output).to include('Clearing existing plan cache')
-        expect(output).to include('Cache cleared')
-      end
     end
 
-    context 'when Stripe API fails' do
+    context 'when operation fails' do
+      let(:failure_result) do
+        Billing::Operations::Catalog::Pull::Result.new(
+          success: false,
+          errors: ['Stripe error: Invalid API key'],
+        )
+      end
+
       before do
-        allow(Billing::Plan).to receive(:refresh_from_stripe)
-          .and_raise(Stripe::AuthenticationError.new('Invalid API key'))
+        allow(Billing::Operations::Catalog::Pull).to receive(:call).and_return(failure_result)
       end
 
-      it 'displays error with troubleshooting tips' do
+      it 'displays error messages' do
         output = capture_stdout { command.call }
-
-        expect(output).to include('Pull failed')
-        expect(output).to include('Troubleshooting')
-        expect(output).to include('STRIPE_API_KEY')
-      end
-    end
-
-    context 'when unexpected error occurs' do
-      before do
-        allow(Billing::Plan).to receive(:refresh_from_stripe)
-          .and_raise(StandardError.new('Connection timeout'))
-      end
-
-      it 'displays error message' do
-        output = capture_stdout { command.call }
-        expect(output).to include('Error during pull: Connection timeout')
+        expect(output).to include('Error: Stripe error: Invalid API key')
       end
     end
   end
@@ -117,7 +130,6 @@ RSpec.describe 'Billing Catalog Pull CLI', :billing_cli, :integration, :vcr do
         command.send(:show_progress, 'Processing plan 1 of 5...')
       end
 
-      # Should start with carriage return for line overwriting
       expect(output).to start_with("\r")
       expect(output).to include('Processing plan 1 of 5...')
     end

--- a/apps/web/billing/spec/cli/catalog_push_region_spec.rb
+++ b/apps/web/billing/spec/cli/catalog_push_region_spec.rb
@@ -7,6 +7,9 @@
 # NOTE: These tests now target Operations::Catalog::Push directly, as the
 # CLI command is a thin wrapper. For CLI interface tests, see catalog_push_spec.rb.
 #
+# Region filtering tests (Bug #1) now target StripeReader since fetch_existing_products
+# was extracted there. Metadata tests (Bug #2) remain on Push.
+#
 # Covers:
 #   Bug #1 (P0): fetch_existing_products used raw != for region comparison
 #   Bug #2 (P1): build_syncable_metadata wrote nil.to_s -> "" erasing Stripe metadata
@@ -15,6 +18,7 @@
 
 require_relative '../support/billing_spec_helper'
 require_relative '../../operations/catalog/push'
+require_relative '../../operations/catalog/stripe_reader'
 
 # ==============================================================================
 # SECTION 1: build_syncable_metadata - nil region handling (Bug #2)
@@ -91,12 +95,10 @@ RSpec.describe 'Catalog::Push region handling in metadata', :billing_cli do
 end
 
 # ==============================================================================
-# SECTION 2: fetch_existing_products region filtering (Bug #1)
+# SECTION 2: StripeReader.fetch_products region filtering (Bug #1)
 # ==============================================================================
 
-RSpec.describe 'Catalog::Push fetch_existing_products region filtering', :billing_cli do
-  let(:operation) { Billing::Operations::Catalog::Push.new(dry_run: true, plan_filter: nil, skip_prices: true, progress: nil) }
-
+RSpec.describe 'StripeReader.fetch_products region filtering', :billing_cli do
   def mock_stripe_product(id:, plan_id:, region:)
     metadata = {
       'app' => 'onetimesecret',
@@ -105,8 +107,6 @@ RSpec.describe 'Catalog::Push fetch_existing_products region filtering', :billin
     }
     double("Stripe::Product(#{id})", id: id, name: "Plan #{plan_id}", metadata: metadata)
   end
-
-  let(:match_fields) { ['plan_id'] }
 
   let(:nz_product) { mock_stripe_product(id: 'prod_nz', plan_id: 'identity_nz_v1', region: 'NZ') }
   let(:nz_lower_product) { mock_stripe_product(id: 'prod_nz2', plan_id: 'starter_v1', region: 'nz') }
@@ -124,7 +124,10 @@ RSpec.describe 'Catalog::Push fetch_existing_products region filtering', :billin
   end
 
   it 'includes products matching region filter with same case' do
-    result = operation.send(:fetch_existing_products, 'onetimesecret', match_fields, 'NZ')
+    result = Billing::Operations::Catalog::StripeReader.fetch_products(
+      app_identifier: 'onetimesecret',
+      region_filter: 'NZ',
+    )
     product_ids = result.values.map(&:id)
     expect(product_ids).to include('prod_nz')
   end
@@ -132,38 +135,56 @@ RSpec.describe 'Catalog::Push fetch_existing_products region filtering', :billin
   it 'includes products matching region filter case-insensitively (Bug #1 fix)' do
     # Product has region "nz" (lowercase), filter is "NZ" (uppercase)
     # Before the fix, raw != comparison would reject this product
-    result = operation.send(:fetch_existing_products, 'onetimesecret', match_fields, 'NZ')
+    result = Billing::Operations::Catalog::StripeReader.fetch_products(
+      app_identifier: 'onetimesecret',
+      region_filter: 'NZ',
+    )
     product_ids = result.values.map(&:id)
     expect(product_ids).to include('prod_nz2')
   end
 
   it 'excludes products from non-matching regions' do
-    result = operation.send(:fetch_existing_products, 'onetimesecret', match_fields, 'NZ')
+    result = Billing::Operations::Catalog::StripeReader.fetch_products(
+      app_identifier: 'onetimesecret',
+      region_filter: 'NZ',
+    )
     product_ids = result.values.map(&:id)
     expect(product_ids).not_to include('prod_eu')
   end
 
   it 'includes all products when region filter is nil (pass-through)' do
-    result = operation.send(:fetch_existing_products, 'onetimesecret', match_fields, nil)
+    result = Billing::Operations::Catalog::StripeReader.fetch_products(
+      app_identifier: 'onetimesecret',
+      region_filter: nil,
+    )
     product_ids = result.values.map(&:id)
     expect(product_ids).to include('prod_nz', 'prod_nz2', 'prod_eu')
   end
 
   it 'matches lowercase filter against uppercase product region' do
-    result = operation.send(:fetch_existing_products, 'onetimesecret', match_fields, 'nz')
+    result = Billing::Operations::Catalog::StripeReader.fetch_products(
+      app_identifier: 'onetimesecret',
+      region_filter: 'nz',
+    )
     product_ids = result.values.map(&:id)
     expect(product_ids).to include('prod_nz')
     expect(product_ids).not_to include('prod_eu')
   end
 
   it 'excludes products with nil region when filter is set (fail-closed)' do
-    result = operation.send(:fetch_existing_products, 'onetimesecret', match_fields, 'NZ')
+    result = Billing::Operations::Catalog::StripeReader.fetch_products(
+      app_identifier: 'onetimesecret',
+      region_filter: 'NZ',
+    )
     product_ids = result.values.map(&:id)
     expect(product_ids).not_to include('prod_none')
   end
 
   it 'includes products with nil region when filter is nil (pass-through)' do
-    result = operation.send(:fetch_existing_products, 'onetimesecret', match_fields, nil)
+    result = Billing::Operations::Catalog::StripeReader.fetch_products(
+      app_identifier: 'onetimesecret',
+      region_filter: nil,
+    )
     product_ids = result.values.map(&:id)
     expect(product_ids).to include('prod_none')
   end
@@ -173,9 +194,7 @@ end
 # SECTION 3: Override products bypass region filter (Issue #3157)
 # ==============================================================================
 
-RSpec.describe 'Catalog::Push override + region interaction', :billing_cli do
-  let(:operation) { Billing::Operations::Catalog::Push.new(dry_run: true, plan_filter: nil, skip_prices: true, progress: nil) }
-
+RSpec.describe 'StripeReader override + region interaction', :billing_cli do
   def mock_stripe_product(id:, plan_id:, region:, app: 'onetimesecret')
     metadata = { 'app' => app, 'plan_id' => plan_id }
     metadata['region'] = region if region
@@ -191,14 +210,8 @@ RSpec.describe 'Catalog::Push override + region interaction', :billing_cli do
   # Product with correct region for baseline
   let(:nz_product) { mock_stripe_product(id: 'prod_nz', plan_id: 'identity_v1', region: 'NZ') }
 
-  # Plans hash keyed by plan_id (as fetch_existing_products expects)
-  let(:plans) do
-    {
-      'legacy_v1' => { 'plan_id' => 'legacy_v1', 'stripe_product_id' => 'prod_override_legacy' },
-      'starter_v1' => { 'plan_id' => 'starter_v1' }, # No override
-      'identity_v1' => { 'plan_id' => 'identity_v1' },
-    }
-  end
+  # Override product IDs extracted from plans with stripe_product_id
+  let(:override_product_ids) { Set.new(['prod_override_legacy']) }
 
   before do
     product_list = double('ProductList')
@@ -212,7 +225,12 @@ RSpec.describe 'Catalog::Push override + region interaction', :billing_cli do
   it 'includes override product without region metadata when region filter is set (Issue #3157 fix)' do
     # Product has explicit stripe_product_id override but no region metadata
     # Before the fix, region filter would exclude this product
-    result = operation.send(:fetch_existing_products, 'onetimesecret', match_fields, 'NZ', plans)
+    result = Billing::Operations::Catalog::StripeReader.fetch_products(
+      app_identifier: 'onetimesecret',
+      region_filter: 'NZ',
+      match_fields: match_fields,
+      override_product_ids: override_product_ids,
+    )
     product_ids = result.values.map(&:id)
     expect(product_ids).to include('prod_override_legacy')
   end
@@ -220,13 +238,23 @@ RSpec.describe 'Catalog::Push override + region interaction', :billing_cli do
   it 'excludes app-matched products with wrong region when they have no override (regression)' do
     # Product matches app but has EU region while filter is NZ, and no override
     # This should still be filtered out (existing behavior preserved)
-    result = operation.send(:fetch_existing_products, 'onetimesecret', match_fields, 'NZ', plans)
+    result = Billing::Operations::Catalog::StripeReader.fetch_products(
+      app_identifier: 'onetimesecret',
+      region_filter: 'NZ',
+      match_fields: match_fields,
+      override_product_ids: override_product_ids,
+    )
     product_ids = result.values.map(&:id)
     expect(product_ids).not_to include('prod_wrong_region')
   end
 
   it 'includes products with correct region as baseline' do
-    result = operation.send(:fetch_existing_products, 'onetimesecret', match_fields, 'NZ', plans)
+    result = Billing::Operations::Catalog::StripeReader.fetch_products(
+      app_identifier: 'onetimesecret',
+      region_filter: 'NZ',
+      match_fields: match_fields,
+      override_product_ids: override_product_ids,
+    )
     product_ids = result.values.map(&:id)
     expect(product_ids).to include('prod_nz')
   end

--- a/apps/web/billing/spec/cli/catalog_push_region_spec.rb
+++ b/apps/web/billing/spec/cli/catalog_push_region_spec.rb
@@ -4,6 +4,9 @@
 
 # Tests for catalog push region isolation fixes (Issue #2554)
 #
+# NOTE: These tests now target Operations::Catalog::Push directly, as the
+# CLI command is a thin wrapper. For CLI interface tests, see catalog_push_spec.rb.
+#
 # Covers:
 #   Bug #1 (P0): fetch_existing_products used raw != for region comparison
 #   Bug #2 (P1): build_syncable_metadata wrote nil.to_s -> "" erasing Stripe metadata
@@ -11,17 +14,15 @@
 # Run: bundle exec rspec apps/web/billing/spec/cli/catalog_push_region_spec.rb
 
 require_relative '../support/billing_spec_helper'
-require 'onetime/cli'
-require_relative '../../cli/catalog_push_command'
-require_relative '../../errors'
+require_relative '../../operations/catalog/push'
 
 # ==============================================================================
 # SECTION 1: build_syncable_metadata - nil region handling (Bug #2)
 # ==============================================================================
 
-RSpec.describe 'CatalogPushCommand#build_syncable_metadata region handling',
-               :billing_cli, :integration do
-  subject(:command) { Onetime::CLI::BillingCatalogPushCommand.new }
+RSpec.describe 'Catalog::Push region handling in metadata', :billing_cli do
+  # Access the private method on the operation class instance
+  let(:operation) { Billing::Operations::Catalog::Push.new(dry_run: true, plan_filter: nil, skip_prices: true, progress: nil) }
 
   let(:base_plan_def) do
     {
@@ -38,37 +39,37 @@ RSpec.describe 'CatalogPushCommand#build_syncable_metadata region handling',
   describe 'region field in syncable metadata' do
     it 'excludes region field when plan region is nil' do
       plan_def = base_plan_def.merge('region' => nil)
-      result = command.send(:build_syncable_metadata, 'test_plan', plan_def)
+      result = operation.send(:build_syncable_metadata, 'test_plan', plan_def, 'cad')
       expect(result).not_to have_key('region')
     end
 
     it 'excludes region field when plan region is empty string' do
       plan_def = base_plan_def.merge('region' => '')
-      result = command.send(:build_syncable_metadata, 'test_plan', plan_def)
+      result = operation.send(:build_syncable_metadata, 'test_plan', plan_def, 'cad')
       expect(result).not_to have_key('region')
     end
 
     it 'excludes region field when plan region is whitespace' do
       plan_def = base_plan_def.merge('region' => '   ')
-      result = command.send(:build_syncable_metadata, 'test_plan', plan_def)
+      result = operation.send(:build_syncable_metadata, 'test_plan', plan_def, 'cad')
       expect(result).not_to have_key('region')
     end
 
     it 'normalizes lowercase region to uppercase' do
       plan_def = base_plan_def.merge('region' => 'nz')
-      result = command.send(:build_syncable_metadata, 'test_plan', plan_def)
+      result = operation.send(:build_syncable_metadata, 'test_plan', plan_def, 'cad')
       expect(result['region']).to eq('NZ')
     end
 
     it 'preserves already-uppercase region' do
       plan_def = base_plan_def.merge('region' => 'EU')
-      result = command.send(:build_syncable_metadata, 'test_plan', plan_def)
+      result = operation.send(:build_syncable_metadata, 'test_plan', plan_def, 'cad')
       expect(result['region']).to eq('EU')
     end
 
     it 'strips whitespace from region before normalizing' do
       plan_def = base_plan_def.merge('region' => ' ca ')
-      result = command.send(:build_syncable_metadata, 'test_plan', plan_def)
+      result = operation.send(:build_syncable_metadata, 'test_plan', plan_def, 'cad')
       expect(result['region']).to eq('CA')
     end
   end
@@ -78,7 +79,7 @@ RSpec.describe 'CatalogPushCommand#build_syncable_metadata region handling',
   describe 'nil region does not produce empty string (regression)' do
     it 'never writes empty string for region field' do
       plan_def = base_plan_def.merge('region' => nil)
-      result = command.send(:build_syncable_metadata, 'test_plan', plan_def)
+      result = operation.send(:build_syncable_metadata, 'test_plan', plan_def, 'cad')
 
       # The key must either be absent or have a non-empty value
       if result.key?('region')
@@ -93,9 +94,8 @@ end
 # SECTION 2: fetch_existing_products region filtering (Bug #1)
 # ==============================================================================
 
-RSpec.describe 'CatalogPushCommand#fetch_existing_products region filtering',
-               :billing_cli, :integration do
-  subject(:command) { Onetime::CLI::BillingCatalogPushCommand.new }
+RSpec.describe 'Catalog::Push fetch_existing_products region filtering', :billing_cli do
+  let(:operation) { Billing::Operations::Catalog::Push.new(dry_run: true, plan_filter: nil, skip_prices: true, progress: nil) }
 
   def mock_stripe_product(id:, plan_id:, region:)
     metadata = {
@@ -121,11 +121,10 @@ RSpec.describe 'CatalogPushCommand#fetch_existing_products region filtering',
       .and_yield(eu_product)
       .and_yield(no_region_product)
     allow(Stripe::Product).to receive(:list).and_return(product_list)
-    allow(command).to receive(:with_stripe_retry).and_yield
   end
 
   it 'includes products matching region filter with same case' do
-    result = command.send(:fetch_existing_products, 'onetimesecret', match_fields, 'NZ')
+    result = operation.send(:fetch_existing_products, 'onetimesecret', match_fields, 'NZ')
     product_ids = result.values.map(&:id)
     expect(product_ids).to include('prod_nz')
   end
@@ -133,38 +132,38 @@ RSpec.describe 'CatalogPushCommand#fetch_existing_products region filtering',
   it 'includes products matching region filter case-insensitively (Bug #1 fix)' do
     # Product has region "nz" (lowercase), filter is "NZ" (uppercase)
     # Before the fix, raw != comparison would reject this product
-    result = command.send(:fetch_existing_products, 'onetimesecret', match_fields, 'NZ')
+    result = operation.send(:fetch_existing_products, 'onetimesecret', match_fields, 'NZ')
     product_ids = result.values.map(&:id)
     expect(product_ids).to include('prod_nz2')
   end
 
   it 'excludes products from non-matching regions' do
-    result = command.send(:fetch_existing_products, 'onetimesecret', match_fields, 'NZ')
+    result = operation.send(:fetch_existing_products, 'onetimesecret', match_fields, 'NZ')
     product_ids = result.values.map(&:id)
     expect(product_ids).not_to include('prod_eu')
   end
 
   it 'includes all products when region filter is nil (pass-through)' do
-    result = command.send(:fetch_existing_products, 'onetimesecret', match_fields, nil)
+    result = operation.send(:fetch_existing_products, 'onetimesecret', match_fields, nil)
     product_ids = result.values.map(&:id)
     expect(product_ids).to include('prod_nz', 'prod_nz2', 'prod_eu')
   end
 
   it 'matches lowercase filter against uppercase product region' do
-    result = command.send(:fetch_existing_products, 'onetimesecret', match_fields, 'nz')
+    result = operation.send(:fetch_existing_products, 'onetimesecret', match_fields, 'nz')
     product_ids = result.values.map(&:id)
     expect(product_ids).to include('prod_nz')
     expect(product_ids).not_to include('prod_eu')
   end
 
   it 'excludes products with nil region when filter is set (fail-closed)' do
-    result = command.send(:fetch_existing_products, 'onetimesecret', match_fields, 'NZ')
+    result = operation.send(:fetch_existing_products, 'onetimesecret', match_fields, 'NZ')
     product_ids = result.values.map(&:id)
     expect(product_ids).not_to include('prod_none')
   end
 
   it 'includes products with nil region when filter is nil (pass-through)' do
-    result = command.send(:fetch_existing_products, 'onetimesecret', match_fields, nil)
+    result = operation.send(:fetch_existing_products, 'onetimesecret', match_fields, nil)
     product_ids = result.values.map(&:id)
     expect(product_ids).to include('prod_none')
   end
@@ -174,9 +173,8 @@ end
 # SECTION 3: Override products bypass region filter (Issue #3157)
 # ==============================================================================
 
-RSpec.describe 'CatalogPushCommand#fetch_existing_products override + region interaction',
-               :billing_cli, :integration do
-  subject(:command) { Onetime::CLI::BillingCatalogPushCommand.new }
+RSpec.describe 'Catalog::Push override + region interaction', :billing_cli do
+  let(:operation) { Billing::Operations::Catalog::Push.new(dry_run: true, plan_filter: nil, skip_prices: true, progress: nil) }
 
   def mock_stripe_product(id:, plan_id:, region:, app: 'onetimesecret')
     metadata = { 'app' => app, 'plan_id' => plan_id }
@@ -209,13 +207,12 @@ RSpec.describe 'CatalogPushCommand#fetch_existing_products override + region int
       .and_yield(app_match_wrong_region)
       .and_yield(nz_product)
     allow(Stripe::Product).to receive(:list).and_return(product_list)
-    allow(command).to receive(:with_stripe_retry).and_yield
   end
 
   it 'includes override product without region metadata when region filter is set (Issue #3157 fix)' do
     # Product has explicit stripe_product_id override but no region metadata
     # Before the fix, region filter would exclude this product
-    result = command.send(:fetch_existing_products, 'onetimesecret', match_fields, 'NZ', plans)
+    result = operation.send(:fetch_existing_products, 'onetimesecret', match_fields, 'NZ', plans)
     product_ids = result.values.map(&:id)
     expect(product_ids).to include('prod_override_legacy')
   end
@@ -223,13 +220,13 @@ RSpec.describe 'CatalogPushCommand#fetch_existing_products override + region int
   it 'excludes app-matched products with wrong region when they have no override (regression)' do
     # Product matches app but has EU region while filter is NZ, and no override
     # This should still be filtered out (existing behavior preserved)
-    result = command.send(:fetch_existing_products, 'onetimesecret', match_fields, 'NZ', plans)
+    result = operation.send(:fetch_existing_products, 'onetimesecret', match_fields, 'NZ', plans)
     product_ids = result.values.map(&:id)
     expect(product_ids).not_to include('prod_wrong_region')
   end
 
   it 'includes products with correct region as baseline' do
-    result = command.send(:fetch_existing_products, 'onetimesecret', match_fields, 'NZ', plans)
+    result = operation.send(:fetch_existing_products, 'onetimesecret', match_fields, 'NZ', plans)
     product_ids = result.values.map(&:id)
     expect(product_ids).to include('prod_nz')
   end
@@ -239,9 +236,8 @@ end
 # SECTION 4: detect_product_updates detects missing plan_id (Issue #3157)
 # ==============================================================================
 
-RSpec.describe 'CatalogPushCommand#detect_product_updates plan_id detection',
-               :billing_cli, :integration do
-  subject(:command) { Onetime::CLI::BillingCatalogPushCommand.new }
+RSpec.describe 'Catalog::Push detect_product_updates plan_id detection', :billing_cli do
+  let(:operation) { Billing::Operations::Catalog::Push.new(dry_run: true, plan_filter: nil, skip_prices: true, progress: nil) }
 
   it 'detects missing plan_id as a change needing update' do
     # Product exists but lacks plan_id metadata
@@ -254,7 +250,7 @@ RSpec.describe 'CatalogPushCommand#detect_product_updates plan_id detection',
 
     plan_def = { 'name' => 'Test Plan', 'tier' => 'pro' }
 
-    updates = command.send(:detect_product_updates, 'test_plan', existing, plan_def)
+    updates = operation.send(:detect_product_updates, 'test_plan', existing, plan_def, 'cad')
 
     expect(updates).to have_key(:metadata_plan_id)
     expect(updates[:metadata_plan_id][:from]).to be_nil
@@ -271,7 +267,7 @@ RSpec.describe 'CatalogPushCommand#detect_product_updates plan_id detection',
 
     plan_def = { 'name' => 'Test Plan', 'tier' => 'pro' }
 
-    updates = command.send(:detect_product_updates, 'new_plan_id', existing, plan_def)
+    updates = operation.send(:detect_product_updates, 'new_plan_id', existing, plan_def, 'cad')
 
     expect(updates).to have_key(:metadata_plan_id)
     expect(updates[:metadata_plan_id][:from]).to eq('old_plan_id')
@@ -288,7 +284,7 @@ RSpec.describe 'CatalogPushCommand#detect_product_updates plan_id detection',
 
     plan_def = { 'name' => 'Test Plan', 'tier' => 'pro' }
 
-    updates = command.send(:detect_product_updates, 'test_plan', existing, plan_def)
+    updates = operation.send(:detect_product_updates, 'test_plan', existing, plan_def, 'cad')
 
     expect(updates).not_to have_key(:metadata_plan_id)
   end

--- a/apps/web/billing/spec/cli/catalog_push_spec.rb
+++ b/apps/web/billing/spec/cli/catalog_push_spec.rb
@@ -2,467 +2,195 @@
 #
 # frozen_string_literal: true
 
+# Specs for `bin/ots billing catalog push` CLI wrapper.
+#
+# These test the CLI's public interface and delegation to operations.
+# For detailed logic tests (analyze_changes, detect_product_updates, etc.),
+# see: spec/operations/catalog/push_spec.rb
+
 require_relative '../support/billing_spec_helper'
 require 'onetime/cli'
 require_relative '../../cli/catalog_push_command'
-require_relative '../../errors'
 
-RSpec.describe 'Billing Catalog Push CLI', :billing_cli, :integration, :vcr do
+RSpec.describe 'Billing Catalog Push CLI', :billing_cli do
   subject(:command) { Onetime::CLI::BillingCatalogPushCommand.new }
 
   def capture_stdout
     old_stdout = $stdout
     $stdout = StringIO.new
-    yield
+    begin
+      yield
+    rescue SystemExit
+      # Ignore exit calls
+    end
     $stdout.string
   ensure
     $stdout = old_stdout
   end
 
-  # Realistic plan definition matching actual billing.yaml structure
-  let(:plan_def) do
-    {
-      'name' => 'Identity Plus',
-      'tier' => 'plus',
-      'tenancy' => 'shared',
-      'region' => 'global',
-      'display_order' => 2,
-      'show_on_plans_page' => true,
-      'entitlements' => %w[custom_branding api_access support_priority],
-      'limits' => {
-        'teams' => 3,
-        'members_per_team' => 10,
-        'custom_domains' => 2,
-        'secret_lifetime' => 604_800,
-        'secrets_per_day' => 100,
-      },
-      'prices' => [
-        { 'amount' => 1999, 'currency' => 'CAD', 'interval' => 'month' },
-        { 'amount' => 19990, 'currency' => 'CAD', 'interval' => 'year' },
-      ],
-    }
-  end
-
-  # Mock Stripe::Product with realistic structure
-  def mock_product(overrides = {})
-    defaults = {
-      id: 'prod_test123',
-      name: 'Identity Plus',
-      marketing_features: [],
-      metadata: {
-        'app' => 'onetimesecret',
-        'plan_id' => 'identity_plus_v1',
-        'tier' => 'plus',
-        'tenancy' => 'shared',
-        'region' => 'GLOBAL',
-        'display_order' => '2',
-        'show_on_plans_page' => 'true',
-        'entitlements' => 'custom_branding,api_access,support_priority',
-        'limit_teams' => '3',
-        'limit_members_per_team' => '10',
-        'limit_custom_domains' => '2',
-        'limit_secret_lifetime' => '604800',
-        'limit_secrets_per_day' => '100',
-        'currency' => 'cad',
-        'ots_includes_plan' => '',
-        'ots_is_popular' => 'false',
-      },
-    }
-    double('Stripe::Product', defaults.merge(overrides))
-  end
-
-  # Mock Stripe::Price with realistic structure
-  def mock_price(amount:, currency:, interval:, product_id: 'prod_test123')
-    recurring = double('Recurring', interval: interval)
-    double('Stripe::Price',
-      id: "price_#{SecureRandom.hex(8)}",
-      product: product_id,
-      unit_amount: amount,
-      currency: currency.downcase,
-      recurring: recurring)
-  end
-
-  describe '#detect_product_updates (private)' do
-    it 'returns empty hash when product matches plan definition exactly' do
-      existing = mock_product
-      result = command.send(:detect_product_updates, 'identity_plus_v1', existing, plan_def)
-      expect(result).to eq({})
-    end
-
-    it 'detects name changes' do
-      existing = mock_product(name: 'Old Product Name')
-      result = command.send(:detect_product_updates, 'identity_plus_v1', existing, plan_def)
-
-      expect(result).to have_key(:name)
-      expect(result[:name][:from]).to eq('Old Product Name')
-      expect(result[:name][:to]).to eq('Identity Plus')
-    end
-
-    it 'detects tier metadata changes' do
-      metadata = mock_product.metadata.merge('tier' => 'basic')
-      existing = mock_product(metadata: metadata)
-      result = command.send(:detect_product_updates, 'identity_plus_v1', existing, plan_def)
-
-      expect(result).to have_key(:metadata_tier)
-      expect(result[:metadata_tier][:from]).to eq('basic')
-      expect(result[:metadata_tier][:to]).to eq('plus')
-    end
-
-    it 'detects limit field changes' do
-      metadata = mock_product.metadata.merge('limit_teams' => '1')
-      existing = mock_product(metadata: metadata)
-      result = command.send(:detect_product_updates, 'identity_plus_v1', existing, plan_def)
-
-      expect(result).to have_key(:metadata_limit_teams)
-      expect(result[:metadata_limit_teams][:from]).to eq('1')
-      expect(result[:metadata_limit_teams][:to]).to eq('3')
-    end
-
-    it 'detects entitlements changes' do
-      metadata = mock_product.metadata.merge('entitlements' => 'custom_branding')
-      existing = mock_product(metadata: metadata)
-      result = command.send(:detect_product_updates, 'identity_plus_v1', existing, plan_def)
-
-      expect(result).to have_key(:metadata_entitlements)
-      expect(result[:metadata_entitlements][:from]).to eq('custom_branding')
-      expect(result[:metadata_entitlements][:to]).to eq('custom_branding,api_access,support_priority')
-    end
-
-    it 'handles nil metadata values gracefully' do
-      metadata = mock_product.metadata.merge('tier' => nil)
-      existing = mock_product(metadata: metadata)
-
-      # Should not raise, should detect the difference
-      result = command.send(:detect_product_updates, 'identity_plus_v1', existing, plan_def)
-      expect(result).to have_key(:metadata_tier)
-    end
-  end
-
-  describe '#analyze_price_changes (private)' do
-    let(:existing_product) { mock_product }
-
-    it 'returns empty array when no prices in plan definition' do
-      plan_without_prices = plan_def.merge('prices' => [])
-      result = command.send(:analyze_price_changes, 'identity_plus_v1', plan_without_prices, existing_product, [])
-      expect(result).to eq([])
-    end
-
-    it 'returns prices with nil product_id when existing_product is nil (new product)' do
-      result = command.send(:analyze_price_changes, 'identity_plus_v1', plan_def, nil, [])
-      # For new products, we still analyze prices but set product_id to nil
-      # The product_id will be resolved in apply_changes after product creation
-      expect(result.length).to eq(2) # monthly and yearly prices
-      expect(result.all? { |p| p[:product_id].nil? }).to be true
-      expect(result.all? { |p| p[:plan_id] == 'identity_plus_v1' }).to be true
-    end
-
-    it 'skips incomplete price definitions missing amount' do
-      incomplete_plan = plan_def.merge('prices' => [{ 'currency' => 'CAD', 'interval' => 'month' }])
-      result = command.send(:analyze_price_changes, 'identity_plus_v1', incomplete_plan, existing_product, [])
-      expect(result).to eq([])
-    end
-
-    it 'inherits catalog currency when price omits currency' do
-      no_currency_plan = plan_def.merge('prices' => [{ 'amount' => 1999, 'interval' => 'month' }])
-      result = command.send(:analyze_price_changes, 'identity_plus_v1', no_currency_plan, existing_product, [], 'cad')
-      expect(result.length).to eq(1)
-      expect(result.first[:currency]).to eq('cad')
-    end
-
-    it 'skips incomplete price definitions missing interval' do
-      incomplete_plan = plan_def.merge('prices' => [{ 'amount' => 1999, 'currency' => 'CAD' }])
-      result = command.send(:analyze_price_changes, 'identity_plus_v1', incomplete_plan, existing_product, [])
-      expect(result).to eq([])
-    end
-
-    it 'returns empty when matching price already exists' do
-      existing_prices = [mock_price(amount: 1999, currency: 'cad', interval: 'month')]
-      single_price_plan = plan_def.merge('prices' => [{ 'amount' => 1999, 'currency' => 'CAD', 'interval' => 'month' }])
-
-      result = command.send(:analyze_price_changes, 'identity_plus_v1', single_price_plan, existing_product, existing_prices)
-      expect(result).to eq([])
-    end
-
-    it 'returns new price when no match found' do
-      existing_prices = [mock_price(amount: 999, currency: 'cad', interval: 'month')]
-      single_price_plan = plan_def.merge('prices' => [{ 'amount' => 1999, 'currency' => 'CAD', 'interval' => 'month' }])
-
-      result = command.send(:analyze_price_changes, 'identity_plus_v1', single_price_plan, existing_product, existing_prices)
-
-      expect(result.length).to eq(1)
-      expect(result.first[:amount]).to eq(1999)
-      expect(result.first[:currency]).to eq('cad')  # Resolved to lowercase
-      expect(result.first[:interval]).to eq('month')
-      expect(result.first[:plan_id]).to eq('identity_plus_v1')
-    end
-
-    it 'detects multiple missing prices' do
-      # No existing prices, plan has monthly and yearly
-      result = command.send(:analyze_price_changes, 'identity_plus_v1', plan_def, existing_product, [])
-
-      expect(result.length).to eq(2)
-      amounts = result.map { |p| p[:amount] }
-      expect(amounts).to contain_exactly(1999, 19990)
-    end
-  end
-
-  describe '#build_metadata (private)' do
-    let(:app_identifier) { 'onetimesecret' }
-
-    it 'includes required fields: app, plan_id, tier, tenancy, region' do
-      result = command.send(:build_metadata, 'identity_plus_v1', plan_def, app_identifier)
-
-      expect(result['app']).to eq('onetimesecret')
-      expect(result['plan_id']).to eq('identity_plus_v1')
-      expect(result['tier']).to eq('plus')
-      expect(result['tenancy']).to eq('shared')
-      expect(result['region']).to eq('GLOBAL')
-    end
-
-    it 'joins entitlements array with comma' do
-      result = command.send(:build_metadata, 'identity_plus_v1', plan_def, app_identifier)
-      expect(result['entitlements']).to eq('custom_branding,api_access,support_priority')
-    end
-
-    it 'includes display metadata' do
-      result = command.send(:build_metadata, 'identity_plus_v1', plan_def, app_identifier)
-
-      expect(result['display_order']).to eq('2')
-      expect(result['show_on_plans_page']).to eq('true')
-    end
-
-    it 'includes limit fields when present' do
-      result = command.send(:build_metadata, 'identity_plus_v1', plan_def, app_identifier)
-
-      expect(result['limit_teams']).to eq('3')
-      expect(result['limit_members_per_team']).to eq('10')
-      expect(result['limit_custom_domains']).to eq('2')
-      expect(result['limit_secret_lifetime']).to eq('604800')
-      expect(result['limit_secrets_per_day']).to eq('100')
-    end
-
-    it 'omits limit fields when absent from plan definition' do
-      plan_without_limits = plan_def.reject { |k, _| k == 'limits' }
-      result = command.send(:build_metadata, 'identity_plus_v1', plan_without_limits, app_identifier)
-
-      expect(result).not_to have_key('limit_teams')
-      expect(result).not_to have_key('limit_members_per_team')
-    end
-
-    it 'handles empty entitlements array' do
-      plan_no_entitlements = plan_def.merge('entitlements' => [])
-      result = command.send(:build_metadata, 'identity_plus_v1', plan_no_entitlements, app_identifier)
-      expect(result['entitlements']).to eq('')
-    end
-
-    it 'includes created timestamp' do
-      result = command.send(:build_metadata, 'identity_plus_v1', plan_def, app_identifier)
-      expect(result).to have_key('created')
-      expect { Time.iso8601(result['created']) }.not_to raise_error
-    end
-  end
-
-  describe '#analyze_changes (private)' do
-    # Default match fields for most tests - single field matching by plan_id
-    let(:match_fields) { ['plan_id'] }
-
-    it 'identifies products to create when not in Stripe' do
-      plans = { 'new_plan_v1' => plan_def }
-      existing_products = {} # Empty - no products in Stripe
-      existing_prices = {}
-
-      result = command.send(:analyze_changes, plans, existing_products, existing_prices, false, match_fields)
-
-      expect(result[:products_to_create].length).to eq(1)
-      expect(result[:products_to_create].first[:plan_id]).to eq('new_plan_v1')
-      expect(result[:products_to_update]).to be_empty
-    end
-
-    it 'identifies products to update when metadata differs' do
-      plans = { 'identity_plus_v1' => plan_def }
-      outdated_product = mock_product(name: 'Old Name')
-      existing_products = { 'identity_plus_v1' => outdated_product }
-      existing_prices = {}
-
-      result = command.send(:analyze_changes, plans, existing_products, existing_prices, false, match_fields)
-
-      expect(result[:products_to_create]).to be_empty
-      expect(result[:products_to_update].length).to eq(1)
-      expect(result[:products_to_update].first[:updates]).to have_key(:name)
-    end
-
-    it 'skips price analysis when skip_prices is true' do
-      plans = { 'identity_plus_v1' => plan_def }
-      existing_products = { 'identity_plus_v1' => mock_product }
-      existing_prices = {} # No prices - would normally trigger creation
-
-      result = command.send(:analyze_changes, plans, existing_products, existing_prices, true, match_fields)
-
-      expect(result[:prices_to_create]).to be_empty
-    end
-
-    it 'identifies prices to create for existing products' do
-      plans = { 'identity_plus_v1' => plan_def }
-      existing_products = { 'identity_plus_v1' => mock_product }
-      existing_prices = {} # No prices exist
-
-      result = command.send(:analyze_changes, plans, existing_products, existing_prices, false, match_fields)
-
-      expect(result[:prices_to_create].length).to eq(2) # monthly + yearly
-    end
-
-    it 'skips creation for legacy plans when product not found' do
-      legacy_plan = plan_def.merge('legacy' => true, 'stripe_product_id' => 'prod_NotInRegion')
-      plans = { 'identity' => legacy_plan }
-      existing_products = {} # Product not found (e.g., filtered by region)
-      existing_prices = {}
-
-      result = capture_stdout do
-        command.send(:analyze_changes, plans, existing_products, existing_prices, false, match_fields)
-      end
-      # Re-run to get the actual return value (capture_stdout consumes it)
-      changes = command.send(:analyze_changes, plans, existing_products, existing_prices, false, match_fields)
-
-      expect(changes[:products_to_create]).to be_empty
-      expect(changes[:products_to_update]).to be_empty
-      expect(changes[:prices_to_create]).to be_empty
-    end
-
-    it 'still updates legacy plans when product exists in Stripe' do
-      legacy_plan = plan_def.merge('legacy' => true)
-      outdated_product = mock_product(name: 'Old Legacy Name')
-      plans = { 'identity' => legacy_plan }
-      existing_products = { 'identity' => outdated_product }
-      existing_prices = {}
-
-      changes = command.send(:analyze_changes, plans, existing_products, existing_prices, false, match_fields)
-
-      expect(changes[:products_to_create]).to be_empty
-      expect(changes[:products_to_update].length).to eq(1)
-      expect(changes[:products_to_update].first[:plan_id]).to eq('identity')
-    end
+  before do
+    allow(command).to receive(:boot_application!)
+    allow(command).to receive(:stripe_configured?).and_return(true)
   end
 
   describe '#call' do
-    before do
-      # Stub boot and Stripe configuration check
-      allow(command).to receive(:boot_application!)
-      allow(command).to receive(:stripe_configured?).and_return(true)
-    end
-
-    context 'with missing catalog file' do
+    context 'when Stripe is not configured' do
       before do
-        allow(Billing::Config).to receive(:config_exists?).and_return(false)
+        allow(command).to receive(:stripe_configured?).and_return(false)
       end
 
-      it 'reports catalog not found and exits early' do
-        output = capture_stdout { command.call }
-        expect(output).to include('Catalog not found')
-      end
-    end
-
-    context 'with empty plans' do
-      before do
-        allow(Billing::Config).to receive(:config_exists?).and_return(true)
-        allow(Billing::Config).to receive(:safe_load_config).and_return({ 'plans' => {} })
-      end
-
-      it 'reports no plans found' do
-        output = capture_stdout { command.call }
-        expect(output).to include('No plans found in catalog')
-      end
-    end
-
-    context 'with --plan filter for unknown plan' do
-      before do
-        allow(Billing::Config).to receive(:config_exists?).and_return(true)
-        allow(Billing::Config).to receive(:safe_load_config).and_return({
-          'app_identifier' => 'onetimesecret',
-          'plans' => { 'existing_plan' => plan_def },
-        })
-      end
-
-      it 'shows error and lists available plans' do
-        output = capture_stdout { command.call(plan: 'nonexistent_plan') }
-
-        expect(output).to include("Plan 'nonexistent_plan' not found")
-        expect(output).to include('Available plans: existing_plan')
+      it 'exits early without pushing' do
+        expect(Billing::Operations::Catalog::Push).not_to receive(:call)
+        command.call
       end
     end
 
     context 'when no changes needed' do
-      before do
-        allow(Billing::Config).to receive(:config_exists?).and_return(true)
-        allow(Billing::Config).to receive(:safe_load_config).and_return({
-          'app_identifier' => 'onetimesecret',
-          'plans' => { 'identity_plus_v1' => plan_def },
-        })
-        allow(command).to receive(:fetch_existing_products).and_return({ 'identity_plus_v1' => mock_product })
-        allow(command).to receive(:fetch_existing_prices).and_return({
-          'identity_plus_v1' => [
-            mock_price(amount: 1999, currency: 'cad', interval: 'month'),
-            mock_price(amount: 19990, currency: 'cad', interval: 'year'),
-          ],
-        })
-      end
-
-      it 'reports Stripe is in sync' do
-        output = capture_stdout { command.call }
-        expect(output).to include('No changes needed - Stripe is in sync with catalog')
-      end
-    end
-
-    context 'with legacy plan whose product is not in Stripe' do
-      let(:legacy_plan) do
-        plan_def.merge(
-          'legacy' => true,
-          'stripe_product_id' => 'prod_NotInThisRegion',
-          'grandfathered_until' => '2028-01-31',
+      let(:no_changes_result) do
+        Billing::Operations::Catalog::Push::Result.new(
+          success: true,
+          no_changes: true,
         )
       end
 
       before do
-        allow(Billing::Config).to receive(:config_exists?).and_return(true)
-        allow(Billing::Config).to receive(:safe_load_config).and_return({
-          'app_identifier' => 'onetimesecret',
-          'match_fields' => %w[plan_id region],
-          'region' => 'UK',
-          'plans' => { 'identity' => legacy_plan },
-        })
-        allow(command).to receive(:fetch_existing_products).and_return({})
-        allow(command).to receive(:fetch_existing_prices).and_return({})
+        allow(Billing::Operations::Catalog::Push).to receive(:call).and_return(no_changes_result)
+        allow($stdin).to receive(:gets).and_return("y\n")
       end
 
-      it 'reports no changes rather than creating a new product' do
-        output = capture_stdout { command.call(dry_run: true) }
-
-        expect(output).to include('skipping (legacy plan, product not found)')
-        expect(output).to include('No changes needed')
-        expect(output).not_to include('Products to CREATE')
+      it 'reports Stripe is in sync' do
+        output = capture_stdout { command.call(force: true) }
+        expect(output).to include('No changes needed - Stripe is in sync with catalog')
       end
     end
 
     context 'with --dry-run flag' do
+      let(:dry_run_result) do
+        Billing::Operations::Catalog::Push::Result.new(
+          success: true,
+          dry_run: true,
+          products_created: 2,
+          products_updated: 1,
+          prices_created: 4,
+        )
+      end
+
       before do
-        allow(Billing::Config).to receive(:config_exists?).and_return(true)
-        allow(Billing::Config).to receive(:safe_load_config).and_return({
-          'app_identifier' => 'onetimesecret',
-          'plans' => { 'new_plan_v1' => plan_def },
-        })
-        allow(command).to receive(:fetch_existing_products).and_return({})
-        allow(command).to receive(:fetch_existing_prices).and_return({})
+        allow(Billing::Operations::Catalog::Push).to receive(:call).and_return(dry_run_result)
       end
 
-      it 'shows changes with DRY RUN prefix' do
-        output = capture_stdout { command.call(dry_run: true) }
+      it 'passes dry_run: true to operation' do
+        expect(Billing::Operations::Catalog::Push).to receive(:call) do |args|
+          expect(args[:dry_run]).to be(true)
+          dry_run_result
+        end
 
-        expect(output).to include('(DRY RUN)')
-        expect(output).to include('[DRY RUN] Products to CREATE')
-      end
-
-      it 'does not call apply_changes' do
-        expect(command).not_to receive(:apply_changes)
         capture_stdout { command.call(dry_run: true) }
+      end
+
+      it 'shows DRY RUN in output' do
+        output = capture_stdout { command.call(dry_run: true) }
+        expect(output).to include('DRY RUN')
+      end
+
+      it 'reports would-be changes' do
+        output = capture_stdout { command.call(dry_run: true) }
+        expect(output).to include('Would')
+        expect(output).to include('2 product(s)')
+      end
+    end
+
+    context 'with --plan filter' do
+      let(:filtered_result) do
+        Billing::Operations::Catalog::Push::Result.new(
+          success: true,
+          products_created: 1,
+        )
+      end
+
+      before do
+        allow(Billing::Operations::Catalog::Push).to receive(:call).and_return(filtered_result)
+        allow($stdin).to receive(:gets).and_return("y\n")
+      end
+
+      it 'passes plan_filter to operation' do
+        expect(Billing::Operations::Catalog::Push).to receive(:call) do |args|
+          expect(args[:plan_filter]).to eq('identity_plus_v1')
+          filtered_result
+        end
+
+        capture_stdout { command.call(plan: 'identity_plus_v1', force: true) }
+      end
+    end
+
+    context 'with --skip-prices flag' do
+      let(:no_prices_result) do
+        Billing::Operations::Catalog::Push::Result.new(
+          success: true,
+          products_created: 1,
+          prices_created: 0,
+        )
+      end
+
+      before do
+        allow(Billing::Operations::Catalog::Push).to receive(:call).and_return(no_prices_result)
+        allow($stdin).to receive(:gets).and_return("y\n")
+      end
+
+      it 'passes skip_prices: true to operation' do
+        expect(Billing::Operations::Catalog::Push).to receive(:call) do |args|
+          expect(args[:skip_prices]).to be(true)
+          no_prices_result
+        end
+
+        capture_stdout { command.call(skip_prices: true, force: true) }
+      end
+    end
+
+    context 'when operation fails' do
+      let(:failure_result) do
+        Billing::Operations::Catalog::Push::Result.new(
+          success: false,
+          errors: ['Catalog not found or failed to load'],
+        )
+      end
+
+      before do
+        allow(Billing::Operations::Catalog::Push).to receive(:call).and_return(failure_result)
+        allow($stdin).to receive(:gets).and_return("y\n")
+      end
+
+      it 'displays error messages' do
+        output = capture_stdout { command.call(force: true) }
+        expect(output).to include('Error: Catalog not found')
+      end
+    end
+
+    context 'successful push' do
+      let(:success_result) do
+        Billing::Operations::Catalog::Push::Result.new(
+          success: true,
+          products_created: 2,
+          products_updated: 1,
+          prices_created: 4,
+        )
+      end
+
+      before do
+        allow(Billing::Operations::Catalog::Push).to receive(:call).and_return(success_result)
+        allow($stdin).to receive(:gets).and_return("y\n")
+      end
+
+      it 'reports completed changes' do
+        output = capture_stdout { command.call(force: true) }
+        expect(output).to include('Completed:')
+        expect(output).to include('2 product(s)')
+      end
+
+      it 'shows next steps' do
+        output = capture_stdout { command.call(force: true) }
+        expect(output).to include('Catalog push complete!')
+        expect(output).to include('bin/ots billing catalog pull')
       end
     end
   end

--- a/apps/web/billing/spec/cli/catalog_validate_command_spec.rb
+++ b/apps/web/billing/spec/cli/catalog_validate_command_spec.rb
@@ -2,26 +2,18 @@
 #
 # frozen_string_literal: true
 
-# Specs for `bin/ots billing catalog validate`.
+# Specs for `bin/ots billing catalog validate` CLI wrapper.
 #
-# Validates the billing catalog YAML against the Zod-generated JSON Schema
-# at generated/schemas/config/billing.schema.json.
-#
-# These run under spec:fast (no :integration tag, no Stripe/VCR): the
-# command performs local schema validation only and never calls Stripe.
-#
-# Run: pnpm run test:rspec apps/web/billing/spec/cli/catalog_validate_command_spec.rb
+# These test the CLI's public interface and delegation to operations.
+# For detailed logic tests, see: spec/operations/catalog/validate_spec.rb
 
 require_relative '../support/billing_spec_helper'
-require 'tempfile'
 require 'onetime/cli'
 require_relative '../../cli/catalog_validate_command'
 
 RSpec.describe 'Billing Catalog Validate CLI', :billing_cli do
   subject(:command) { Onetime::CLI::BillingCatalogValidateCommand.new }
 
-  # The command calls `exit` to signal pass/fail. Capture stdout and the
-  # resulting exit status.
   def run_command(**kwargs)
     old_stdout = $stdout
     $stdout    = StringIO.new
@@ -37,7 +29,6 @@ RSpec.describe 'Billing Catalog Validate CLI', :billing_cli do
   end
 
   before do
-    # OT is already booted by billing_spec_helper; avoid re-booting in-process.
     allow(command).to receive(:boot_application!)
   end
 
@@ -49,155 +40,134 @@ RSpec.describe 'Billing Catalog Validate CLI', :billing_cli do
     end
   end
 
-  describe '#call with a valid catalog' do
-    # No config_path stub: ConfigResolver resolves the real test catalog
-    # (apps/web/billing/spec/billing.test.yaml) under RACK_ENV=test.
-    it 'passes validation against the current billing catalog' do
-      output, status = run_command
+  describe '#call' do
+    context 'when validation succeeds with no warnings' do
+      let(:valid_result) do
+        Billing::Operations::Catalog::Validate::Result.new(
+          success: true,
+          valid: true,
+          plans_validated: 3,
+          plan_summary: { valid: [{ id: 'test_v1', name: 'Test', tier: 'free' }], invalid: [], has_free_tier: true },
+        )
+      end
 
-      expect(output).to include('VALIDATION PASSED')
-      expect(status).to eq(0)
-    end
-  end
+      before do
+        allow(Billing::Operations::Catalog::Validate).to receive(:call).and_return(valid_result)
+      end
 
-  describe '#call with an invalid catalog' do
-    let(:fixture) { Tempfile.new(['billing_invalid', '.yaml']) }
+      it 'reports VALIDATION PASSED' do
+        output, status = run_command
+        expect(output).to include('VALIDATION PASSED')
+        expect(status).to eq(0)
+      end
 
-    before do
-      allow(Billing::Config).to receive(:config_path).and_return(fixture.path)
-      allow(Billing::Config).to receive(:config_exists?).and_return(true)
-    end
-
-    after do
-      fixture.close
-      fixture.unlink
-    end
-
-    def write_fixture(yaml)
-      fixture.write(yaml)
-      fixture.flush
-    end
-
-    it 'fails when a limit is negative beyond the -1 unlimited sentinel' do
-      write_fixture(<<~YAML)
-        schema_version: "1.0"
-        app_identifier: "onetimesecret"
-        entitlements:
-          create_secrets:
-            category: core
-            description: Can create basic secrets
-        plans:
-          team_plus_v1:
-            name: "Team Plus"
-            tier: single_team
-            entitlements:
-              - create_secrets
-            limits:
-              organizations: -2
-              members_per_team: 1
-              custom_domains: 1
-              secret_lifetime: 100
-            prices:
-              - interval: month
-                amount: 100
-      YAML
-
-      output, status = run_command
-
-      expect(output).to include('VALIDATION FAILED')
-      expect(output).to include('Schema validation:')
-      expect(status).to eq(1)
+      it 'shows plan summary' do
+        output, _status = run_command
+        expect(output).to include('VALID (1)')
+        expect(output).to include('Test')
+      end
     end
 
-    it 'fails when grandfathered_until is not an ISO date' do
-      write_fixture(<<~YAML)
-        schema_version: "1.0"
-        app_identifier: "onetimesecret"
-        entitlements:
-          create_secrets:
-            category: core
-            description: Can create basic secrets
-        plans:
-          free_v1:
-            name: "Free"
-            tier: free
-            grandfathered_until: "not-a-date"
-            entitlements:
-              - create_secrets
-            limits:
-              organizations: 1
-              members_per_team: 1
-              custom_domains: 1
-              secret_lifetime: 100
-            prices: []
-      YAML
+    context 'when validation succeeds with warnings (non-strict)' do
+      let(:warnings_result) do
+        Billing::Operations::Catalog::Validate::Result.new(
+          success: true,
+          valid: true,
+          plans_validated: 2,
+          warnings: ['Plan test_v1: Missing yearly pricing'],
+          plan_summary: { valid: [], invalid: [], has_free_tier: false },
+        )
+      end
 
-      output, status = run_command
+      before do
+        allow(Billing::Operations::Catalog::Validate).to receive(:call).and_return(warnings_result)
+      end
 
-      expect(output).to include('VALIDATION FAILED')
-      expect(status).to eq(1)
+      it 'passes with warnings' do
+        output, status = run_command
+        expect(output).to include('VALIDATION PASSED (warnings only)')
+        expect(output).to include('1 warning(s)')
+        expect(status).to eq(0)
+      end
     end
 
-    it 'fails when plan ID does not match canonical format' do
-      # Issue #3135: Plan IDs must match canonical pattern
-      write_fixture(<<~YAML)
-        schema_version: "1.0"
-        app_identifier: "onetimesecret"
-        entitlements:
-          create_secrets:
-            category: core
-            description: Can create basic secrets
-        plans:
-          invalid_plan_format:
-            name: "Invalid Plan"
-            tier: single_account
-            entitlements:
-              - create_secrets
-            limits:
-              organizations: 1
-              members_per_team: 1
-              custom_domains: 1
-              secret_lifetime: 100
-            prices:
-              - interval: month
-                amount: 900
-      YAML
+    context 'when validation succeeds with warnings (strict mode)' do
+      let(:warnings_result) do
+        Billing::Operations::Catalog::Validate::Result.new(
+          success: true,
+          valid: false,  # strict mode makes warnings fail
+          plans_validated: 2,
+          warnings: ['Plan test_v1: Missing yearly pricing'],
+          plan_summary: { valid: [], invalid: [], has_free_tier: false },
+        )
+      end
 
-      output, status = run_command
+      before do
+        allow(Billing::Operations::Catalog::Validate).to receive(:call).and_return(warnings_result)
+      end
 
-      expect(output).to include('VALIDATION FAILED')
-      expect(output).to include('Schema validation:')
-      expect(status).to eq(1)
+      it 'passes strict: true to operation' do
+        expect(Billing::Operations::Catalog::Validate).to receive(:call) do |args|
+          expect(args[:strict]).to be(true)
+          warnings_result
+        end
+
+        run_command(strict: true)
+      end
+
+      it 'fails in strict mode with warnings' do
+        output, status = run_command(strict: true)
+        expect(output).to include('VALIDATION FAILED')
+        expect(output).to include('warning(s) in strict mode')
+        expect(status).to eq(1)
+      end
     end
 
-    it 'passes when plan ID matches canonical format' do
-      write_fixture(<<~YAML)
-        schema_version: "1.0"
-        app_identifier: "onetimesecret"
-        entitlements:
-          create_secrets:
-            category: core
-            description: Can create basic secrets
-        plans:
-          identity_plus_v1:
-            name: "Identity Plus"
-            tier: single_account
-            entitlements:
-              - create_secrets
-            limits:
-              organizations: 1
-              members_per_team: 1
-              custom_domains: 1
-              secret_lifetime: 100
-            prices:
-              - interval: month
-                amount: 900
-      YAML
+    context 'when validation fails with errors' do
+      let(:error_result) do
+        Billing::Operations::Catalog::Validate::Result.new(
+          success: true,
+          valid: false,
+          plans_validated: 1,
+          errors: ['Schema validation: /plans/bad_plan: required property name is missing'],
+          plan_summary: { valid: [], invalid: [{ id: 'bad_plan', name: nil, tier: nil }], has_free_tier: false },
+        )
+      end
 
-      output, status = run_command
+      before do
+        allow(Billing::Operations::Catalog::Validate).to receive(:call).and_return(error_result)
+      end
 
-      expect(output).to include('VALIDATION PASSED')
-      expect(status).to eq(0)
+      it 'reports VALIDATION FAILED' do
+        output, status = run_command
+        expect(output).to include('VALIDATION FAILED')
+        expect(output).to include('1 error(s) found')
+        expect(status).to eq(1)
+      end
+
+      it 'shows error details' do
+        output, _status = run_command
+        expect(output).to include('Schema validation:')
+      end
+    end
+
+    context 'when operation itself fails' do
+      let(:failure_result) do
+        Billing::Operations::Catalog::Validate::Result.new(
+          success: false,
+          errors: ['Catalog file not found: /path/to/billing.yaml'],
+        )
+      end
+
+      before do
+        allow(Billing::Operations::Catalog::Validate).to receive(:call).and_return(failure_result)
+      end
+
+      it 'displays error and exits 1' do
+        output, status = run_command
+        expect(output).to include('Error: Catalog file not found')
+        expect(status).to eq(1)
+      end
     end
   end
 end

--- a/apps/web/billing/spec/cli/plans_spec.rb
+++ b/apps/web/billing/spec/cli/plans_spec.rb
@@ -5,6 +5,7 @@
 require_relative '../support/billing_spec_helper'
 require 'onetime/cli'
 require_relative '../../cli/plans_command'
+require_relative '../../operations/catalog/pull'
 
 RSpec.describe 'Billing Plans CLI Commands', :billing_cli, :integration, :vcr do
   let(:stripe_client) { Billing::StripeClient.new }
@@ -148,8 +149,18 @@ RSpec.describe 'Billing Plans CLI Commands', :billing_cli, :integration, :vcr do
       end
 
       context 'with --refresh option' do
+        let(:pull_result) do
+          Billing::Operations::Catalog::Pull::Result.new(
+            success: true,
+            plans_synced: 2,
+            config_plans_loaded: 0,
+            cache_cleared: false,
+          )
+        end
+
         before do
-          allow(Billing::Plan).to receive_messages(refresh_from_stripe: 2, list_plans: [sample_plan, sample_plan_eu])
+          allow(Billing::Operations::Catalog::Pull).to receive(:call).and_return(pull_result)
+          allow(Billing::Plan).to receive(:list_plans).and_return([sample_plan, sample_plan_eu])
         end
 
         it 'displays refresh progress message' do
@@ -179,7 +190,7 @@ RSpec.describe 'Billing Plans CLI Commands', :billing_cli, :integration, :vcr do
 
       context 'error handling' do
         it 'handles Stripe API errors during refresh' do
-          allow(Billing::Plan).to receive(:refresh_from_stripe)
+          allow(Billing::Operations::Catalog::Pull).to receive(:call)
             .and_raise(Stripe::InvalidRequestError.new('Invalid API key', 'api_key'))
 
           expect do
@@ -188,7 +199,14 @@ RSpec.describe 'Billing Plans CLI Commands', :billing_cli, :integration, :vcr do
         end
 
         it 'handles missing Stripe configuration gracefully' do
-          allow(Billing::Plan).to receive_messages(refresh_from_stripe: 0, list_plans: [])
+          empty_result = Billing::Operations::Catalog::Pull::Result.new(
+            success: true,
+            plans_synced: 0,
+            config_plans_loaded: 0,
+            cache_cleared: false,
+          )
+          allow(Billing::Operations::Catalog::Pull).to receive(:call).and_return(empty_result)
+          allow(Billing::Plan).to receive(:list_plans).and_return([])
 
           output = capture_stdout { command.call(refresh: true) }
           expect(output).to include('Refreshed 0 plan entries')

--- a/apps/web/billing/spec/models/plan_spec.rb
+++ b/apps/web/billing/spec/models/plan_spec.rb
@@ -194,6 +194,8 @@ RSpec.describe Billing::Plan, type: :billing do
 
   describe '.load_all_from_config' do
     before do
+      # Allow real Plan.load for config loading tests (overrides stub_test_plan_catalog!)
+      allow(Billing::Plan).to receive(:load).and_call_original
       Billing::Plan.clear_cache
     end
 
@@ -230,6 +232,8 @@ RSpec.describe Billing::Plan, type: :billing do
 
   describe '.get_plan' do
     before do
+      # Allow real Plan.load for config loading tests (overrides stub_test_plan_catalog!)
+      allow(Billing::Plan).to receive(:load).and_call_original
       Billing::Plan.load_all_from_config
     end
 
@@ -366,6 +370,8 @@ RSpec.describe Billing::Plan, type: :billing do
     # Higher tiers should include all features from lower tiers
 
     before do
+      # Allow real Plan.load for config loading tests (overrides stub_test_plan_catalog!)
+      allow(Billing::Plan).to receive(:load).and_call_original
       Billing::Plan.load_all_from_config
     end
 

--- a/apps/web/billing/spec/operations/catalog/pull_spec.rb
+++ b/apps/web/billing/spec/operations/catalog/pull_spec.rb
@@ -1,0 +1,117 @@
+# apps/web/billing/spec/operations/catalog/pull_spec.rb
+#
+# frozen_string_literal: true
+
+require_relative '../../support/billing_spec_helper'
+require_relative '../../../operations/catalog/pull'
+
+RSpec.describe Billing::Operations::Catalog::Pull, :billing do
+  describe '.call' do
+    let(:progress_messages) { [] }
+    let(:progress_proc) { ->(msg) { progress_messages << msg } }
+
+    before do
+      allow(Billing::Plan).to receive(:refresh_from_stripe).and_return(5)
+      allow(Billing::Plan).to receive(:upsert_config_only_plans).and_return(1)
+      allow(Billing::Plan).to receive(:clear_cache)
+    end
+
+    context 'successful pull' do
+      subject(:result) { described_class.call(progress: progress_proc) }
+
+      it 'returns success result' do
+        expect(result.success).to be true
+      end
+
+      it 'reports plans synced count' do
+        expect(result.plans_synced).to eq(5)
+      end
+
+      it 'reports config plans loaded' do
+        expect(result.config_plans_loaded).to eq(1)
+      end
+
+      it 'calls progress with status messages' do
+        result
+        expect(progress_messages).to include('Pulling from Stripe to Redis cache...')
+      end
+    end
+
+    context 'with clear_cache option' do
+      subject(:result) { described_class.call(clear_cache: true, progress: progress_proc) }
+
+      it 'clears cache before pulling' do
+        expect(Billing::Plan).to receive(:clear_cache).ordered
+        expect(Billing::Plan).to receive(:refresh_from_stripe).ordered
+        result
+      end
+
+      it 'sets cache_cleared flag' do
+        expect(result.cache_cleared).to be true
+      end
+
+      it 'reports cache clearing in progress' do
+        result
+        expect(progress_messages).to include('Clearing existing plan cache...')
+        expect(progress_messages).to include('Cache cleared')
+      end
+    end
+
+    context 'without clear_cache option' do
+      subject(:result) { described_class.call }
+
+      it 'cache_cleared is false' do
+        expect(result.cache_cleared).to be false
+      end
+    end
+
+    context 'Stripe error' do
+      before do
+        allow(Billing::Plan).to receive(:refresh_from_stripe)
+          .and_raise(Stripe::APIError.new('API key invalid'))
+      end
+
+      subject(:result) { described_class.call }
+
+      it 'returns failure result' do
+        expect(result.success).to be false
+      end
+
+      it 'includes error message' do
+        expect(result.errors).to include(match(/Stripe error/))
+      end
+    end
+
+    context 'unexpected error' do
+      before do
+        allow(Billing::Plan).to receive(:refresh_from_stripe)
+          .and_raise(StandardError.new('Network timeout'))
+      end
+
+      subject(:result) { described_class.call }
+
+      it 'returns failure result' do
+        expect(result.success).to be false
+      end
+
+      it 'includes error class and message' do
+        expect(result.errors.first).to include('StandardError')
+        expect(result.errors.first).to include('Network timeout')
+      end
+    end
+  end
+
+  describe 'Result struct' do
+    it 'has expected fields' do
+      result = described_class::Result.new(success: true)
+      expect(result).to respond_to(:success, :plans_synced, :plans_pruned,
+                                   :config_plans_loaded, :cache_cleared, :errors)
+    end
+
+    it 'has sensible defaults' do
+      result = described_class::Result.new(success: true)
+      expect(result.plans_synced).to eq(0)
+      expect(result.errors).to eq([])
+    end
+  end
+end

--- a/apps/web/billing/spec/operations/catalog/pull_spec.rb
+++ b/apps/web/billing/spec/operations/catalog/pull_spec.rb
@@ -4,14 +4,103 @@
 
 require_relative '../../support/billing_spec_helper'
 require_relative '../../../operations/catalog/pull'
+require_relative '../../../operations/catalog/stripe_reader'
 
 RSpec.describe Billing::Operations::Catalog::Pull, :billing do
   describe '.call' do
     let(:progress_messages) { [] }
     let(:progress_proc) { ->(msg) { progress_messages << msg } }
 
+    let(:mock_product) do
+      double(
+        'Stripe::Product',
+        id: 'prod_test123',
+        name: 'Test Plan',
+        description: 'A test plan',
+        updated: 1700000000,
+        marketing_features: [],
+        metadata: {
+          'app' => 'onetimesecret',
+          'plan_id' => 'test_plan_v1',
+          'tier' => 'test',
+          'region' => 'US',
+          'currency' => 'usd',
+          'plan_code' => 'test',
+          'entitlements' => '',
+          'display_order' => '1',
+          'tenancy' => 'multi',
+          'show_on_plans_page' => 'true',
+        },
+      )
+    end
+
+    let(:mock_price) do
+      double(
+        'Stripe::Price',
+        id: 'price_test123',
+        product: 'prod_test123',
+        type: 'recurring',
+        active: true,
+        currency: 'usd',
+        unit_amount: 999,
+        billing_scheme: 'per_unit',
+        nickname: nil,
+        recurring: double(interval: 'month', usage_type: 'licensed', trial_period_days: nil),
+      )
+    end
+
+    let(:mock_plan) do
+      instance_double(Billing::Plan, plan_id: 'test_plan_v1', exists?: true)
+    end
+
     before do
-      allow(Billing::Plan).to receive(:refresh_from_stripe).and_return(5)
+      # Stub billing config
+      allow(Onetime).to receive(:billing_config).and_return(
+        double(
+          stripe_key: 'sk_test_xxx',
+          region: 'US',
+          currency: 'usd',
+          plans: {},
+        ),
+      )
+
+      # Stub StripeReader
+      allow(Billing::Operations::Catalog::StripeReader).to receive(:fetch_products)
+        .and_return({ 'test_plan_v1' => mock_product })
+      allow(Billing::Operations::Catalog::StripeReader).to receive(:fetch_prices)
+        .and_return({ 'test_plan_v1' => [mock_price] })
+
+      # Stub Plan methods
+      allow(Billing::Plan).to receive(:validate_product_metadata)
+        .and_return({ missing: [], blank: [] })
+      allow(Billing::Plan).to receive(:extract_plan_data).and_return({
+        plan_id: 'test_plan_v1',
+        stripe_product_id: 'prod_test123',
+        stripe_updated_at: '1700000000',
+        name: 'Test Plan',
+        tier: 'test',
+        currency: 'usd',
+        region: 'US',
+        tenancy: 'multi',
+        display_order: '1',
+        show_on_plans_page: 'true',
+        description: 'A test plan',
+        plan_code: 'test',
+        is_popular: 'false',
+        plan_name_label: nil,
+        includes_plan: nil,
+        active: 'true',
+        entitlements: [],
+        features: [],
+        limits: {},
+        stripe_snapshot: { product: {}, prices: { month: {} } },
+        prices: { month: {} },
+      })
+      allow(Billing::Plan).to receive(:upsert_from_stripe_data).and_return(mock_plan)
+      allow(Billing::Plan).to receive(:instances).and_return(double(member?: true))
+      allow(Billing::Plan).to receive(:prune_stale_plans).and_return(0)
+      allow(Billing::Plan).to receive(:rebuild_stripe_price_id_cache)
+      allow(Billing::Plan).to receive(:update_catalog_sync_timestamp)
       allow(Billing::Plan).to receive(:upsert_config_only_plans).and_return(1)
       allow(Billing::Plan).to receive(:clear_cache)
     end
@@ -24,7 +113,7 @@ RSpec.describe Billing::Operations::Catalog::Pull, :billing do
       end
 
       it 'reports plans synced count' do
-        expect(result.plans_synced).to eq(5)
+        expect(result.plans_synced).to eq(1)
       end
 
       it 'reports config plans loaded' do
@@ -35,6 +124,37 @@ RSpec.describe Billing::Operations::Catalog::Pull, :billing do
         result
         expect(progress_messages).to include('Pulling from Stripe to Redis cache...')
       end
+
+      it 'fetches products via StripeReader' do
+        expect(Billing::Operations::Catalog::StripeReader).to receive(:fetch_products)
+          .with(app_identifier: 'onetimesecret', region_filter: 'US')
+        result
+      end
+
+      it 'fetches prices via StripeReader' do
+        expect(Billing::Operations::Catalog::StripeReader).to receive(:fetch_prices)
+        result
+      end
+
+      it 'upserts plans to Redis' do
+        expect(Billing::Plan).to receive(:upsert_from_stripe_data)
+        result
+      end
+
+      it 'prunes stale plans' do
+        expect(Billing::Plan).to receive(:prune_stale_plans).with(['test_plan_v1'])
+        result
+      end
+
+      it 'rebuilds price ID cache' do
+        expect(Billing::Plan).to receive(:rebuild_stripe_price_id_cache)
+        result
+      end
+
+      it 'updates catalog sync timestamp' do
+        expect(Billing::Plan).to receive(:update_catalog_sync_timestamp)
+        result
+      end
     end
 
     context 'with clear_cache option' do
@@ -42,7 +162,7 @@ RSpec.describe Billing::Operations::Catalog::Pull, :billing do
 
       it 'clears cache before pulling' do
         expect(Billing::Plan).to receive(:clear_cache).ordered
-        expect(Billing::Plan).to receive(:refresh_from_stripe).ordered
+        expect(Billing::Operations::Catalog::StripeReader).to receive(:fetch_products).ordered
         result
       end
 
@@ -65,9 +185,43 @@ RSpec.describe Billing::Operations::Catalog::Pull, :billing do
       end
     end
 
+    context 'no Stripe API key configured' do
+      before do
+        allow(Onetime).to receive(:billing_config).and_return(
+          double(stripe_key: '', region: nil, currency: 'usd', plans: {}),
+        )
+      end
+
+      subject(:result) { described_class.call }
+
+      it 'returns success with zero plans synced' do
+        expect(result.success).to be true
+        expect(result.plans_synced).to eq(0)
+      end
+
+      it 'still loads config-only plans' do
+        expect(Billing::Plan).to receive(:upsert_config_only_plans)
+        result
+      end
+    end
+
+    context 'no products found' do
+      before do
+        allow(Billing::Operations::Catalog::StripeReader).to receive(:fetch_products)
+          .and_return({})
+      end
+
+      subject(:result) { described_class.call }
+
+      it 'returns success with zero plans synced' do
+        expect(result.success).to be true
+        expect(result.plans_synced).to eq(0)
+      end
+    end
+
     context 'Stripe error' do
       before do
-        allow(Billing::Plan).to receive(:refresh_from_stripe)
+        allow(Billing::Operations::Catalog::StripeReader).to receive(:fetch_products)
           .and_raise(Stripe::APIError.new('API key invalid'))
       end
 
@@ -82,9 +236,26 @@ RSpec.describe Billing::Operations::Catalog::Pull, :billing do
       end
     end
 
+    context 'validation error' do
+      before do
+        allow(Billing::Plan).to receive(:validate_product_metadata)
+          .and_return({ missing: ['plan_id'], blank: [] })
+      end
+
+      subject(:result) { described_class.call }
+
+      it 'returns failure result' do
+        expect(result.success).to be false
+      end
+
+      it 'includes validation error message' do
+        expect(result.errors.first).to include('metadata validation')
+      end
+    end
+
     context 'unexpected error' do
       before do
-        allow(Billing::Plan).to receive(:refresh_from_stripe)
+        allow(Billing::Operations::Catalog::StripeReader).to receive(:fetch_products)
           .and_raise(StandardError.new('Network timeout'))
       end
 

--- a/apps/web/billing/spec/operations/catalog/pull_spec.rb
+++ b/apps/web/billing/spec/operations/catalog/pull_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe Billing::Operations::Catalog::Pull, :billing do
   describe 'Result struct' do
     it 'has expected fields' do
       result = described_class::Result.new(success: true)
-      expect(result).to respond_to(:success, :plans_synced, :plans_pruned,
+      expect(result).to respond_to(:success, :plans_synced,
                                    :config_plans_loaded, :cache_cleared, :errors)
     end
 

--- a/apps/web/billing/spec/operations/catalog/pull_spec.rb
+++ b/apps/web/billing/spec/operations/catalog/pull_spec.rb
@@ -5,6 +5,8 @@
 require_relative '../../support/billing_spec_helper'
 require_relative '../../../operations/catalog/pull'
 require_relative '../../../operations/catalog/stripe_reader'
+require_relative '../../../operations/catalog/plan_persister'
+require_relative '../../../operations/catalog/config_loader'
 
 RSpec.describe Billing::Operations::Catalog::Pull, :billing do
   describe '.call' do
@@ -96,12 +98,17 @@ RSpec.describe Billing::Operations::Catalog::Pull, :billing do
         stripe_snapshot: { product: {}, prices: { month: {} } },
         prices: { month: {} },
       })
-      allow(Billing::Plan).to receive(:upsert_from_stripe_data).and_return(mock_plan)
+      # Stub PlanPersister methods (extracted from Plan)
+      allow(Billing::Operations::Catalog::PlanPersister).to receive(:upsert_from_stripe_data).and_return(mock_plan)
+      allow(Billing::Operations::Catalog::PlanPersister).to receive(:prune_stale_plans).and_return(0)
+      allow(Billing::Operations::Catalog::PlanPersister).to receive(:rebuild_stripe_price_id_cache)
+      allow(Billing::Operations::Catalog::PlanPersister).to receive(:update_catalog_sync_timestamp)
+
+      # Stub ConfigLoader methods (extracted from Plan)
+      allow(Billing::Operations::Catalog::ConfigLoader).to receive(:upsert_config_only_plans).and_return(1)
+
+      # Stub remaining Plan methods
       allow(Billing::Plan).to receive(:instances).and_return(double(member?: true))
-      allow(Billing::Plan).to receive(:prune_stale_plans).and_return(0)
-      allow(Billing::Plan).to receive(:rebuild_stripe_price_id_cache)
-      allow(Billing::Plan).to receive(:update_catalog_sync_timestamp)
-      allow(Billing::Plan).to receive(:upsert_config_only_plans).and_return(1)
       allow(Billing::Plan).to receive(:clear_cache)
     end
 
@@ -137,22 +144,22 @@ RSpec.describe Billing::Operations::Catalog::Pull, :billing do
       end
 
       it 'upserts plans to Redis' do
-        expect(Billing::Plan).to receive(:upsert_from_stripe_data)
+        expect(Billing::Operations::Catalog::PlanPersister).to receive(:upsert_from_stripe_data)
         result
       end
 
       it 'prunes stale plans' do
-        expect(Billing::Plan).to receive(:prune_stale_plans).with(['test_plan_v1'])
+        expect(Billing::Operations::Catalog::PlanPersister).to receive(:prune_stale_plans).with(['test_plan_v1'])
         result
       end
 
       it 'rebuilds price ID cache' do
-        expect(Billing::Plan).to receive(:rebuild_stripe_price_id_cache)
+        expect(Billing::Operations::Catalog::PlanPersister).to receive(:rebuild_stripe_price_id_cache)
         result
       end
 
       it 'updates catalog sync timestamp' do
-        expect(Billing::Plan).to receive(:update_catalog_sync_timestamp)
+        expect(Billing::Operations::Catalog::PlanPersister).to receive(:update_catalog_sync_timestamp)
         result
       end
     end
@@ -200,7 +207,7 @@ RSpec.describe Billing::Operations::Catalog::Pull, :billing do
       end
 
       it 'still loads config-only plans' do
-        expect(Billing::Plan).to receive(:upsert_config_only_plans)
+        expect(Billing::Operations::Catalog::ConfigLoader).to receive(:upsert_config_only_plans)
         result
       end
     end

--- a/apps/web/billing/spec/operations/catalog/push_spec.rb
+++ b/apps/web/billing/spec/operations/catalog/push_spec.rb
@@ -1,0 +1,192 @@
+# apps/web/billing/spec/operations/catalog/push_spec.rb
+#
+# frozen_string_literal: true
+
+require_relative '../../support/billing_spec_helper'
+require_relative '../../../operations/catalog/push'
+
+RSpec.describe Billing::Operations::Catalog::Push, :billing do
+  let(:progress_messages) { [] }
+  let(:progress_proc) { ->(msg) { progress_messages << msg } }
+
+  let(:valid_catalog) do
+    {
+      'app_identifier' => 'onetimesecret',
+      'currency' => 'cad',
+      'match_fields' => ['plan_id'],
+      'plans' => {
+        'test_plan_v1' => {
+          'name' => 'Test Plan',
+          'tier' => 'single_team',
+          'prices' => [
+            { 'amount' => 1900, 'interval' => 'month' },
+            { 'amount' => 19000, 'interval' => 'year' }
+          ]
+        }
+      }
+    }
+  end
+
+  before do
+    allow(Billing::Config).to receive(:config_exists?).and_return(true)
+    allow(Billing::Config).to receive(:safe_load_config).and_return(valid_catalog)
+  end
+
+  describe '.call' do
+    context 'catalog not found' do
+      before do
+        allow(Billing::Config).to receive(:config_exists?).and_return(false)
+      end
+
+      subject(:result) { described_class.call }
+
+      it 'returns failure' do
+        expect(result.success).to be false
+      end
+
+      it 'includes error message' do
+        expect(result.errors.first).to include('Catalog not found')
+      end
+    end
+
+    context 'empty catalog' do
+      before do
+        allow(Billing::Config).to receive(:safe_load_config).and_return({})
+      end
+
+      subject(:result) { described_class.call }
+
+      it 'returns failure' do
+        expect(result.success).to be false
+      end
+    end
+
+    context 'no plans in catalog' do
+      before do
+        allow(Billing::Config).to receive(:safe_load_config).and_return({ 'plans' => {} })
+      end
+
+      subject(:result) { described_class.call }
+
+      it 'returns failure with no plans error' do
+        expect(result.success).to be false
+        expect(result.errors.first).to include('No plans found')
+      end
+    end
+
+    context 'plan filter with unknown plan' do
+      subject(:result) { described_class.call(plan_filter: 'nonexistent_plan') }
+
+      it 'returns failure' do
+        expect(result.success).to be false
+      end
+
+      it 'lists available plans in error' do
+        expect(result.errors.first).to include('test_plan_v1')
+      end
+    end
+
+    context 'dry run mode' do
+      let(:mock_product_list) { double('ProductList', auto_paging_each: nil) }
+      let(:mock_price_list) { double('PriceList', auto_paging_each: nil) }
+
+      before do
+        allow(Stripe::Product).to receive(:list).and_return(mock_product_list)
+        allow(Stripe::Price).to receive(:list).and_return(mock_price_list)
+      end
+
+      subject(:result) { described_class.call(dry_run: true, progress: progress_proc) }
+
+      it 'returns success' do
+        expect(result.success).to be true
+      end
+
+      it 'sets dry_run flag' do
+        expect(result.dry_run).to be true
+      end
+
+      it 'does not create Stripe products' do
+        expect(Stripe::Product).not_to receive(:create)
+        result
+      end
+
+      it 'reports products to create' do
+        expect(result.products_created).to eq(1)
+      end
+    end
+
+    context 'no changes needed' do
+      before do
+        mock_list = double('List', auto_paging_each: nil)
+        allow(Stripe::Product).to receive(:list).and_return(mock_list)
+        allow(Stripe::Price).to receive(:list).and_return(mock_list)
+      end
+
+      subject(:result) { described_class.call(dry_run: true, progress: progress_proc) }
+
+      it 'in dry_run mode reports changes without applying' do
+        expect(result.success).to be true
+        expect(result.dry_run).to be true
+        expect(result.products_created).to be >= 0
+      end
+    end
+
+    context 'Stripe API error' do
+      before do
+        allow(Stripe::Product).to receive(:list)
+          .and_raise(Stripe::APIError.new('Invalid API key'))
+      end
+
+      subject(:result) { described_class.call }
+
+      it 'returns failure' do
+        expect(result.success).to be false
+      end
+
+      it 'includes Stripe error' do
+        expect(result.errors.first).to include('Stripe error')
+      end
+    end
+  end
+
+  describe 'Result struct' do
+    it 'has expected fields' do
+      result = described_class::Result.new(success: true)
+      expect(result).to respond_to(:success, :dry_run, :products_created,
+                                   :products_updated, :prices_created, :no_changes, :errors)
+    end
+
+    it 'has sensible defaults' do
+      result = described_class::Result.new(success: true)
+      expect(result.dry_run).to be false
+      expect(result.products_created).to eq(0)
+      expect(result.errors).to eq([])
+    end
+  end
+
+  describe 'plan filtering' do
+    let(:multi_plan_catalog) do
+      valid_catalog.merge(
+        'plans' => {
+          'plan_a' => { 'name' => 'Plan A', 'tier' => 'free' },
+          'plan_b' => { 'name' => 'Plan B', 'tier' => 'single_team' }
+        }
+      )
+    end
+
+    before do
+      allow(Billing::Config).to receive(:safe_load_config).and_return(multi_plan_catalog)
+
+      mock_list = double('List', auto_paging_each: nil)
+      allow(Stripe::Product).to receive(:list).and_return(mock_list)
+      allow(Stripe::Price).to receive(:list).and_return(mock_list)
+    end
+
+    it 'processes only specified plan' do
+      result = described_class.call(plan_filter: 'plan_a', dry_run: true, progress: progress_proc)
+      expect(result.success).to be true
+      expect(progress_messages.join).to include('plan_a')
+      expect(progress_messages.join).not_to include('plan_b')
+    end
+  end
+end

--- a/apps/web/billing/spec/operations/catalog/stripe_reader_spec.rb
+++ b/apps/web/billing/spec/operations/catalog/stripe_reader_spec.rb
@@ -1,0 +1,319 @@
+# apps/web/billing/spec/operations/catalog/stripe_reader_spec.rb
+#
+# frozen_string_literal: true
+
+require_relative '../../support/billing_spec_helper'
+require_relative '../../../operations/catalog/stripe_reader'
+
+RSpec.describe Billing::Operations::Catalog::StripeReader, :billing do
+  let(:app_identifier) { 'onetimesecret' }
+  let(:match_fields) { ['plan_id'] }
+
+  def mock_product(id:, metadata:)
+    instance_double(
+      Stripe::Product,
+      id: id,
+      metadata: metadata,
+    )
+  end
+
+  def mock_price(id:, product_id:, amount:, currency:, interval:)
+    recurring = instance_double('Recurring', interval: interval)
+    instance_double(
+      Stripe::Price,
+      id: id,
+      product: product_id,
+      unit_amount: amount,
+      currency: currency,
+      recurring: recurring,
+    )
+  end
+
+  describe '.fetch_products' do
+    let(:product_list) { instance_double('ProductList') }
+
+    before do
+      allow(Stripe::Product).to receive(:list).and_return(product_list)
+    end
+
+    context 'with matching app_identifier' do
+      let(:matching_product) do
+        mock_product(
+          id: 'prod_123',
+          metadata: { 'app' => app_identifier, 'plan_id' => 'basic_v1' },
+        )
+      end
+
+      let(:non_matching_product) do
+        mock_product(
+          id: 'prod_456',
+          metadata: { 'app' => 'other_app', 'plan_id' => 'other_plan' },
+        )
+      end
+
+      before do
+        allow(product_list).to receive(:auto_paging_each)
+          .and_yield(matching_product)
+          .and_yield(non_matching_product)
+      end
+
+      it 'returns only products matching app_identifier' do
+        result = described_class.fetch_products(app_identifier: app_identifier)
+        expect(result.keys).to eq(['basic_v1'])
+        expect(result['basic_v1']).to eq(matching_product)
+      end
+    end
+
+    context 'with region_filter' do
+      let(:us_product) do
+        mock_product(
+          id: 'prod_us',
+          metadata: { 'app' => app_identifier, 'plan_id' => 'basic_us', 'region' => 'US' },
+        )
+      end
+
+      let(:ca_product) do
+        mock_product(
+          id: 'prod_ca',
+          metadata: { 'app' => app_identifier, 'plan_id' => 'basic_ca', 'region' => 'CA' },
+        )
+      end
+
+      before do
+        allow(product_list).to receive(:auto_paging_each)
+          .and_yield(us_product)
+          .and_yield(ca_product)
+        allow(Billing::RegionNormalizer).to receive(:match?).and_call_original
+      end
+
+      it 'filters products by region' do
+        allow(Billing::RegionNormalizer).to receive(:match?).with('US', 'US').and_return(true)
+        allow(Billing::RegionNormalizer).to receive(:match?).with('CA', 'US').and_return(false)
+
+        result = described_class.fetch_products(
+          app_identifier: app_identifier,
+          region_filter: 'US',
+        )
+        expect(result.keys).to eq(['basic_us'])
+      end
+    end
+
+    context 'with override_product_ids' do
+      let(:app_product) do
+        mock_product(
+          id: 'prod_app',
+          metadata: { 'app' => app_identifier, 'plan_id' => 'basic_v1' },
+        )
+      end
+
+      let(:override_product) do
+        mock_product(
+          id: 'prod_override',
+          metadata: { 'app' => 'different_app', 'plan_id' => 'legacy_plan' },
+        )
+      end
+
+      before do
+        allow(product_list).to receive(:auto_paging_each)
+          .and_yield(app_product)
+          .and_yield(override_product)
+      end
+
+      it 'includes override products regardless of app match' do
+        result = described_class.fetch_products(
+          app_identifier: app_identifier,
+          override_product_ids: Set.new(['prod_override']),
+        )
+        expect(result.keys).to contain_exactly('basic_v1', 'legacy_plan')
+      end
+
+      it 'uses __id__ prefix when override product has no match key' do
+        override_no_key = mock_product(
+          id: 'prod_no_key',
+          metadata: { 'app' => 'other' },
+        )
+        allow(product_list).to receive(:auto_paging_each)
+          .and_yield(override_no_key)
+
+        result = described_class.fetch_products(
+          app_identifier: app_identifier,
+          override_product_ids: Set.new(['prod_no_key']),
+        )
+        expect(result.keys).to eq(['__id__prod_no_key'])
+      end
+    end
+
+    context 'with custom match_fields' do
+      let(:multi_field_product) do
+        mock_product(
+          id: 'prod_multi',
+          metadata: {
+            'app' => app_identifier,
+            'plan_id' => 'pro_v1',
+            'region' => 'US',
+          },
+        )
+      end
+
+      before do
+        allow(product_list).to receive(:auto_paging_each)
+          .and_yield(multi_field_product)
+      end
+
+      it 'builds match key from multiple fields' do
+        result = described_class.fetch_products(
+          app_identifier: app_identifier,
+          match_fields: ['plan_id', 'region'],
+        )
+        expect(result.keys).to eq(['pro_v1|US'])
+      end
+    end
+
+    context 'with missing match field values' do
+      let(:incomplete_product) do
+        mock_product(
+          id: 'prod_incomplete',
+          metadata: { 'app' => app_identifier },
+        )
+      end
+
+      before do
+        allow(product_list).to receive(:auto_paging_each)
+          .and_yield(incomplete_product)
+      end
+
+      it 'excludes products with nil match field values' do
+        result = described_class.fetch_products(app_identifier: app_identifier)
+        expect(result).to be_empty
+      end
+    end
+
+    context 'Stripe API retry' do
+      it 'uses StripeRetry.with_retry' do
+        allow(product_list).to receive(:auto_paging_each)
+        expect(Billing::Operations::Catalog::StripeRetry).to receive(:with_retry).and_call_original
+
+        described_class.fetch_products(app_identifier: app_identifier)
+      end
+    end
+  end
+
+  describe '.fetch_prices' do
+    let(:price_list) { instance_double('PriceList') }
+
+    before do
+      allow(Stripe::Price).to receive(:list).and_return(price_list)
+    end
+
+    context 'with empty products' do
+      it 'returns empty hash without calling Stripe' do
+        expect(Stripe::Price).not_to receive(:list)
+        result = described_class.fetch_prices({})
+        expect(result).to eq({})
+      end
+    end
+
+    context 'with products' do
+      let(:product) do
+        mock_product(
+          id: 'prod_123',
+          metadata: { 'app' => app_identifier, 'plan_id' => 'basic_v1' },
+        )
+      end
+
+      let(:products) { { 'basic_v1' => product } }
+
+      let(:matching_price) do
+        mock_price(
+          id: 'price_123',
+          product_id: 'prod_123',
+          amount: 1900,
+          currency: 'cad',
+          interval: 'month',
+        )
+      end
+
+      let(:other_price) do
+        mock_price(
+          id: 'price_456',
+          product_id: 'prod_other',
+          amount: 2900,
+          currency: 'usd',
+          interval: 'month',
+        )
+      end
+
+      before do
+        allow(price_list).to receive(:auto_paging_each)
+          .and_yield(matching_price)
+          .and_yield(other_price)
+      end
+
+      it 'returns prices grouped by match_key' do
+        result = described_class.fetch_prices(products)
+        expect(result.keys).to eq(['basic_v1'])
+        expect(result['basic_v1']).to eq([matching_price])
+      end
+
+      it 'excludes prices for products not in input' do
+        result = described_class.fetch_prices(products)
+        expect(result.values.flatten.map(&:id)).not_to include('price_456')
+      end
+    end
+
+    context 'multiple prices per product' do
+      let(:product) do
+        mock_product(
+          id: 'prod_123',
+          metadata: { 'plan_id' => 'pro_v1' },
+        )
+      end
+
+      let(:products) { { 'pro_v1' => product } }
+
+      let(:monthly_price) do
+        mock_price(
+          id: 'price_month',
+          product_id: 'prod_123',
+          amount: 1900,
+          currency: 'cad',
+          interval: 'month',
+        )
+      end
+
+      let(:yearly_price) do
+        mock_price(
+          id: 'price_year',
+          product_id: 'prod_123',
+          amount: 19000,
+          currency: 'cad',
+          interval: 'year',
+        )
+      end
+
+      before do
+        allow(price_list).to receive(:auto_paging_each)
+          .and_yield(monthly_price)
+          .and_yield(yearly_price)
+      end
+
+      it 'collects all prices for a product' do
+        result = described_class.fetch_prices(products)
+        expect(result['pro_v1'].size).to eq(2)
+        expect(result['pro_v1']).to contain_exactly(monthly_price, yearly_price)
+      end
+    end
+
+    context 'Stripe API retry' do
+      let(:product) { mock_product(id: 'prod_123', metadata: { 'plan_id' => 'basic_v1' }) }
+      let(:products) { { 'basic_v1' => product } }
+
+      it 'uses StripeRetry.with_retry' do
+        allow(price_list).to receive(:auto_paging_each)
+        expect(Billing::Operations::Catalog::StripeRetry).to receive(:with_retry).and_call_original
+
+        described_class.fetch_prices(products)
+      end
+    end
+  end
+end

--- a/apps/web/billing/spec/operations/catalog/stripe_retry_spec.rb
+++ b/apps/web/billing/spec/operations/catalog/stripe_retry_spec.rb
@@ -1,0 +1,176 @@
+# apps/web/billing/spec/operations/catalog/stripe_retry_spec.rb
+#
+# frozen_string_literal: true
+
+require_relative '../../support/billing_spec_helper'
+require_relative '../../../operations/catalog/stripe_retry'
+
+RSpec.describe Billing::Operations::Catalog::StripeRetry, :billing do
+  describe '.with_retry' do
+    let(:call_count) { [] }
+
+    before do
+      # Reset call tracking
+      call_count.clear
+    end
+
+    context 'successful call' do
+      it 'returns block result without retrying' do
+        result = described_class.with_retry { 'success' }
+        expect(result).to eq('success')
+      end
+
+      it 'executes block exactly once' do
+        described_class.with_retry { call_count << 1 }
+        expect(call_count.size).to eq(1)
+      end
+    end
+
+    context 'APIConnectionError with linear backoff' do
+      it 'retries up to max_retries times' do
+        attempts = 0
+        expect do
+          described_class.with_retry(max_retries: 3) do
+            attempts += 1
+            raise Stripe::APIConnectionError.new('Connection failed')
+          end
+        end.to raise_error(Stripe::APIConnectionError)
+        expect(attempts).to eq(4) # initial + 3 retries
+      end
+
+      it 'succeeds after transient failure' do
+        attempts = 0
+        result = described_class.with_retry do
+          attempts += 1
+          raise Stripe::APIConnectionError.new('Transient') if attempts < 2
+
+          'recovered'
+        end
+        expect(result).to eq('recovered')
+        expect(attempts).to eq(2)
+      end
+
+      it 'uses linear backoff (delay = BASE_DELAY * retry_number)' do
+        delays = []
+        allow(described_class).to receive(:sleep) { |d| delays << d }
+
+        expect do
+          described_class.with_retry(max_retries: 3) do
+            raise Stripe::APIConnectionError.new('Connection failed')
+          end
+        end.to raise_error(Stripe::APIConnectionError)
+
+        # Linear: 2*1, 2*2, 2*3
+        expect(delays).to eq([2, 4, 6])
+      end
+
+      it 'respects custom max_retries' do
+        attempts = 0
+        expect do
+          described_class.with_retry(max_retries: 1) do
+            attempts += 1
+            raise Stripe::APIConnectionError.new('Failed')
+          end
+        end.to raise_error(Stripe::APIConnectionError)
+        expect(attempts).to eq(2) # initial + 1 retry
+      end
+    end
+
+    context 'RateLimitError with exponential backoff' do
+      it 'retries up to max_retries times' do
+        attempts = 0
+        expect do
+          described_class.with_retry(max_retries: 3) do
+            attempts += 1
+            raise Stripe::RateLimitError.new('Rate limited')
+          end
+        end.to raise_error(Stripe::RateLimitError)
+        expect(attempts).to eq(4) # initial + 3 retries
+      end
+
+      it 'succeeds after rate limit clears' do
+        attempts = 0
+        result = described_class.with_retry do
+          attempts += 1
+          raise Stripe::RateLimitError.new('Rate limited') if attempts < 3
+
+          'success'
+        end
+        expect(result).to eq('success')
+        expect(attempts).to eq(3)
+      end
+
+      it 'uses exponential backoff (delay = BASE_DELAY * 2^retry_number)' do
+        delays = []
+        allow(described_class).to receive(:sleep) { |d| delays << d }
+
+        expect do
+          described_class.with_retry(max_retries: 3) do
+            raise Stripe::RateLimitError.new('Rate limited')
+          end
+        end.to raise_error(Stripe::RateLimitError)
+
+        # Exponential: 2*2^1, 2*2^2, 2*2^3
+        expect(delays).to eq([4, 8, 16])
+      end
+    end
+
+    context 'other Stripe errors' do
+      it 'does not retry on APIError' do
+        attempts = 0
+        expect do
+          described_class.with_retry do
+            attempts += 1
+            raise Stripe::APIError.new('Bad request')
+          end
+        end.to raise_error(Stripe::APIError)
+        expect(attempts).to eq(1) # no retry
+      end
+
+      it 'does not retry on AuthenticationError' do
+        attempts = 0
+        expect do
+          described_class.with_retry do
+            attempts += 1
+            raise Stripe::AuthenticationError.new('Invalid key')
+          end
+        end.to raise_error(Stripe::AuthenticationError)
+        expect(attempts).to eq(1)
+      end
+
+      it 'does not retry on InvalidRequestError' do
+        attempts = 0
+        expect do
+          described_class.with_retry do
+            attempts += 1
+            raise Stripe::InvalidRequestError.new('Bad param', 'param')
+          end
+        end.to raise_error(Stripe::InvalidRequestError)
+        expect(attempts).to eq(1)
+      end
+    end
+
+    context 'non-Stripe errors' do
+      it 'does not retry on StandardError' do
+        attempts = 0
+        expect do
+          described_class.with_retry do
+            attempts += 1
+            raise StandardError.new('Generic error')
+          end
+        end.to raise_error(StandardError)
+        expect(attempts).to eq(1)
+      end
+    end
+
+    context 'constants' do
+      it 'has MAX_RETRIES of 3' do
+        expect(described_class::MAX_RETRIES).to eq(3)
+      end
+
+      it 'has BASE_DELAY of 2 seconds' do
+        expect(described_class::BASE_DELAY).to eq(2)
+      end
+    end
+  end
+end

--- a/apps/web/billing/spec/operations/catalog/validate_spec.rb
+++ b/apps/web/billing/spec/operations/catalog/validate_spec.rb
@@ -1,0 +1,199 @@
+# apps/web/billing/spec/operations/catalog/validate_spec.rb
+#
+# frozen_string_literal: true
+
+require_relative '../../support/billing_spec_helper'
+require_relative '../../../operations/catalog/validate'
+
+RSpec.describe Billing::Operations::Catalog::Validate, :billing do
+  let(:config_path) { File.join(Onetime::HOME, 'etc', 'config', 'billing.yaml') }
+  let(:schema_path) { File.join(Onetime::HOME, 'generated', 'schemas', 'config', 'billing.schema.json') }
+  let(:progress_messages) { [] }
+  let(:progress_proc) { ->(msg) { progress_messages << msg } }
+
+  describe '.call' do
+    context 'when catalog and schema exist' do
+      before do
+        allow(Billing::Config).to receive(:config_path).and_return(config_path)
+        allow(File).to receive(:exist?).and_call_original
+        allow(File).to receive(:exist?).with(config_path).and_return(true)
+        allow(File).to receive(:exist?).with(schema_path).and_return(true)
+      end
+
+      context 'valid catalog' do
+        let(:valid_catalog) do
+          {
+            'app_identifier' => 'test_app',
+            'plans' => {
+              'test_plan' => {
+                'name' => 'Test Plan',
+                'tier' => 'single_team',
+                'prices' => [
+                  { 'amount' => 1000, 'interval' => 'month' },
+                  { 'amount' => 10000, 'interval' => 'year' }
+                ]
+              }
+            }
+          }
+        end
+
+        let(:valid_schema) do
+          { 'type' => 'object', 'properties' => {} }
+        end
+
+        before do
+          allow(File).to receive(:read).and_call_original
+          allow(File).to receive(:read).with(config_path).and_return(valid_catalog.to_yaml)
+          allow(File).to receive(:read).with(schema_path).and_return(valid_schema.to_json)
+          allow(Billing::Config).to receive(:load_entitlements).and_return({})
+        end
+
+        subject(:result) { described_class.call(progress: progress_proc) }
+
+        it 'returns success' do
+          expect(result.success).to be true
+        end
+
+        it 'reports valid' do
+          expect(result.valid).to be true
+        end
+
+        it 'counts plans validated' do
+          expect(result.plans_validated).to eq(1)
+        end
+
+        it 'has empty errors' do
+          expect(result.errors).to be_empty
+        end
+      end
+
+      context 'catalog with schema errors' do
+        let(:invalid_catalog) do
+          { 'plans' => { 'bad_plan' => 'not_a_hash' } }
+        end
+
+        let(:schema) do
+          {
+            'type' => 'object',
+            'properties' => {
+              'plans' => {
+                'type' => 'object',
+                'additionalProperties' => { 'type' => 'object' }
+              }
+            }
+          }
+        end
+
+        before do
+          allow(File).to receive(:read).and_call_original
+          allow(File).to receive(:read).with(config_path).and_return(invalid_catalog.to_yaml)
+          allow(File).to receive(:read).with(schema_path).and_return(schema.to_json)
+          allow(Billing::Config).to receive(:load_entitlements).and_return({})
+        end
+
+        subject(:result) { described_class.call }
+
+        it 'returns success (operation completed)' do
+          expect(result.success).to be true
+        end
+
+        it 'reports invalid' do
+          expect(result.valid).to be false
+        end
+
+        it 'includes schema errors' do
+          expect(result.errors).not_to be_empty
+          expect(result.errors.first).to include('Schema validation')
+        end
+      end
+    end
+
+    context 'missing catalog file' do
+      before do
+        allow(Billing::Config).to receive(:config_path).and_return('/nonexistent/billing.yaml')
+        allow(File).to receive(:exist?).with('/nonexistent/billing.yaml').and_return(false)
+      end
+
+      subject(:result) { described_class.call }
+
+      it 'returns failure' do
+        expect(result.success).to be false
+      end
+
+      it 'includes file not found error' do
+        expect(result.errors.first).to include('Catalog file not found')
+      end
+    end
+
+    context 'missing schema file' do
+      before do
+        allow(Billing::Config).to receive(:config_path).and_return(config_path)
+        allow(File).to receive(:exist?).with(config_path).and_return(true)
+        allow(File).to receive(:exist?).with(schema_path).and_return(false)
+      end
+
+      subject(:result) { described_class.call }
+
+      it 'returns failure' do
+        expect(result.success).to be false
+      end
+
+      it 'includes schema not found error' do
+        expect(result.errors.first).to include('Schema file not found')
+      end
+    end
+
+    context 'strict mode' do
+      let(:catalog_with_warnings) do
+        {
+          'plans' => {
+            'paid_plan' => {
+              'name' => 'Paid Plan',
+              'tier' => 'single_team',
+              'prices' => [{ 'amount' => 1000, 'interval' => 'month' }]
+            }
+          }
+        }
+      end
+
+      let(:schema) { { 'type' => 'object' } }
+
+      before do
+        allow(Billing::Config).to receive(:config_path).and_return(config_path)
+        allow(File).to receive(:exist?).with(config_path).and_return(true)
+        allow(File).to receive(:exist?).with(schema_path).and_return(true)
+        allow(File).to receive(:read).and_call_original
+        allow(File).to receive(:read).with(config_path).and_return(catalog_with_warnings.to_yaml)
+        allow(File).to receive(:read).with(schema_path).and_return(schema.to_json)
+        allow(Billing::Config).to receive(:load_entitlements).and_return({})
+      end
+
+      it 'fails on warnings in strict mode' do
+        result = described_class.call(strict: true)
+        expect(result.valid).to be false
+        expect(result.warnings).not_to be_empty
+      end
+
+      it 'passes with warnings in non-strict mode' do
+        result = described_class.call(strict: false)
+        expect(result.valid).to be true
+        expect(result.warnings).not_to be_empty
+      end
+    end
+  end
+
+  describe 'Result struct' do
+    it 'has expected fields' do
+      result = described_class::Result.new(success: true)
+      expect(result).to respond_to(:success, :valid, :plans_validated,
+                                   :errors, :warnings, :plan_summary)
+    end
+
+    it 'has sensible defaults' do
+      result = described_class::Result.new(success: true)
+      expect(result.errors).to eq([])
+      expect(result.warnings).to eq([])
+      expect(result.plan_summary).to eq({})
+    end
+  end
+end

--- a/apps/web/billing/spec/support/shared_contexts/with_stripe_vcr.rb
+++ b/apps/web/billing/spec/support/shared_contexts/with_stripe_vcr.rb
@@ -2,6 +2,8 @@
 #
 # frozen_string_literal: true
 
+require_relative '../../../operations/catalog/pull'
+
 # Shared context for Stripe API integration tests with VCR
 #
 # Purpose: Encapsulate VCR setup for tests that make real Stripe API calls.
@@ -42,7 +44,7 @@ RSpec.shared_context 'with_stripe_vcr' do
     # Refresh plan cache from Stripe API (uses VCR cassette)
     # Only runs if STRIPE_API_KEY is configured
     if ENV['STRIPE_API_KEY']
-      Billing::Plan.refresh_from_stripe
+      Billing::Operations::Catalog::Pull.call
     else
       OT.lw '[with_stripe_vcr] Skipping plan refresh: No STRIPE_API_KEY'
     end

--- a/apps/web/billing/spec/support/shared_contexts/with_test_plans.rb
+++ b/apps/web/billing/spec/support/shared_contexts/with_test_plans.rb
@@ -2,6 +2,8 @@
 #
 # frozen_string_literal: true
 
+require_relative '../../../operations/catalog/config_loader'
+
 # Shared context for loading test plans for billing specs
 #
 # Purpose: Enable unit testing of billing logic without Stripe API access.
@@ -27,7 +29,7 @@ RSpec.shared_context 'with_test_plans' do
     allow(Onetime::BillingConfig.instance).to receive(:enabled?).and_return(true)
 
     # Load all plans from test config into Redis cache
-    Billing::Plan.load_all_from_config
+    Billing::Operations::Catalog::ConfigLoader.load_all_from_config
 
     # Mock region to match test plans (EU)
     mock_region!('EU')


### PR DESCRIPTION
For [#3152].

## Summary

Extracts billing catalog operations from the monolithic `Plan` model and CLI commands into dedicated, composable Operations classes. Each operation follows a `.call` interface returning structured `Result` objects, making them reusable from CLI, webhooks, or async jobs.

**Key changes:**
- New `Billing::Operations::Catalog::*` classes (Pull, Push, Validate, ConfigLoader, PlanPersister, StripeReader, StripeRetry)
- CLI commands reduced to thin wrappers around operations
- Webhook handlers updated to use new operations
- Comprehensive test coverage for all new classes

## Architecture

```
Billing::Operations::Catalog::
├── Pull          → Stripe-to-Redis sync
├── Push          → YAML-to-Stripe sync  
├── Validate      → YAML schema validation
├── ConfigLoader  → Config-only plans (free tier)
├── PlanPersister → Redis persistence
├── StripeReader  → Stripe API fetching with region filtering
└── StripeRetry   → Retry/backoff logic for Stripe calls
```

Each operation returns a structured Result with semantic attributes:
- `Pull.Result`: success, plans_synced, config_plans_loaded, cache_cleared, errors
- `Push.Result`: success, dry_run, products_created, products_updated, prices_created, no_changes, errors
- `Validate.Result`: success, valid, plans_validated, errors, warnings, plan_summary

## What Changed

**Plan model** - Removed 622 lines of implementation detail. Delegates to operations, kept public interface for backward compatibility.

**CLI commands** - `CatalogPullCommand`, `CatalogPushCommand`, `CatalogValidateCommand` are now thin wrappers that call operations and format output.

**Webhook handler** - `CatalogUpdated` updated to use `Pull.call` and `PlanPersister` directly.

**Initializer** - `billing_catalog.rb` calls operations with better logging context.

## No Breaking Changes

All public interfaces maintain backward compatibility. `Plan` model retains all public methods (some deprecated). CLI commands accept same arguments.

## Test Plan

- [x] StripeRetry spec (176 lines) - connection errors, rate limits, backoff math
- [x] StripeReader spec (319 lines) - region filtering, metadata matching
- [x] Pull spec (295 lines) - Stripe sync, config fallback, cache clearing
- [x] Push spec (192 lines) - dry-run, change detection, Stripe creation
- [x] Validate spec (199 lines) - schema validation, entitlement checks

Run: `bundle exec rspec spec/operations/catalog/`