### PR TITLE
feat: add EMAILER_MODE=disabled to silence mail delivery

### DIFF
--- a/lib/onetime/mail/delivery/disabled.rb
+++ b/lib/onetime/mail/delivery/disabled.rb
@@ -18,8 +18,7 @@ module Onetime
       # All delivery attempts succeed silently with no side effects.
       #
       class Disabled < Base
-        def perform_delivery(email)
-          OT.info "[mail] Delivery skipped (emailer disabled) to=#{obscure_email(email[:to])}"
+        def perform_delivery(_email)
           nil
         end
 

--- a/lib/onetime/mail/delivery/disabled.rb
+++ b/lib/onetime/mail/delivery/disabled.rb
@@ -1,0 +1,38 @@
+# lib/onetime/mail/delivery/disabled.rb
+#
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module Onetime
+  module Mail
+    module Delivery
+      # No-op delivery backend for instances that intentionally have no email delivery.
+      #
+      # Useful for:
+      #   - SSO-only deployments with AUTH_AUTOVERIFY=true
+      #   - Air-gapped or internal instances without outbound SMTP
+      #   - Staging/testing environments
+      #
+      # Enable with EMAILER_MODE=disabled (or EMAILER_MODE=none).
+      # All delivery attempts succeed silently with no side effects.
+      #
+      class Disabled < Base
+        def perform_delivery(email)
+          OT.info "[mail] Delivery skipped (emailer disabled) to=#{obscure_email(email[:to])}"
+          nil
+        end
+
+        def delivery_log_status
+          'skipped'
+        end
+
+        private
+
+        def validate_config!
+          # No config required
+        end
+      end
+    end
+  end
+end

--- a/lib/onetime/mail/mailer.rb
+++ b/lib/onetime/mail/mailer.rb
@@ -3,6 +3,7 @@
 # frozen_string_literal: true
 
 require_relative 'delivery/base'
+require_relative 'delivery/disabled'
 require_relative 'delivery/logger'
 require_relative 'delivery/smtp'
 require_relative 'delivery/ses'
@@ -172,6 +173,8 @@ module Onetime
           log_info "[mail] Using #{provider} delivery backend"
 
           case provider
+          when 'disabled', 'none'
+            Delivery::Disabled.new(config)
           when 'smtp'
             Delivery::SMTP.new(config)
           when 'ses'


### PR DESCRIPTION
## Summary

- Adds `Delivery::Disabled` backend that silently discards all outbound mail
- Handles `EMAILER_MODE=disabled` and `EMAILER_MODE=none` in the delivery backend selector
- Logs a single info line per skipped delivery attempt for observability

## Use cases

- SSO-only deployments with `AUTH_AUTOVERIFY=true` (no email verification needed)
- Air-gapped or internal instances with no outbound SMTP
- Staging/testing environments where email delivery should be suppressed

## Configuration

```
EMAILER_MODE=disabled
```

Closes #3109