### PR TITLE
feat: hide API key section in Account Settings when API_ENABLED=false

### DIFF
--- a/apps/web/core/spec/views/serializers/config_serializer_spec.rb
+++ b/apps/web/core/spec/views/serializers/config_serializer_spec.rb
@@ -70,7 +70,21 @@ RSpec.describe Core::Views::ConfigSerializer do
       'site' => {
         'host' => canonical_domain,
         'ssl' => true,
-        'interface' => { 'ui' => {} },
+        'interface' => {
+          'ui' => {},
+          'api' => {
+            'enabled' => true,
+            'guest_routes' => {
+              'enabled' => true,
+              'conceal' => true,
+              'generate' => true,
+              'reveal' => true,
+              'burn' => true,
+              'show' => true,
+              'receipt' => true,
+            },
+          },
+        },
         'authentication' => {},
         'secret_options' => {},
         'support' => { 'host' => 'support.example.com' },
@@ -128,6 +142,47 @@ RSpec.describe Core::Views::ConfigSerializer do
     it 'includes sso in features' do
       result = described_class.serialize(base_view_vars)
       expect(result['features']).to have_key('sso')
+    end
+
+    it 'returns api as a nested object with enabled and guest_routes' do
+      result = described_class.serialize(base_view_vars)
+      expect(result).to have_key('api')
+      expect(result['api']).to be_a(Hash)
+      expect(result['api']['enabled']).to be true
+      expect(result['api']['guest_routes']).to be_a(Hash)
+      expect(result['api']['guest_routes']['conceal']).to be true
+    end
+
+    context 'when api config is missing' do
+      let(:minimal_view_vars) do
+        base_view_vars.merge(
+          'site' => base_view_vars['site'].merge('interface' => { 'ui' => {} })
+        )
+      end
+
+      it 'defaults api.enabled to true and guest_routes to empty hash' do
+        result = described_class.serialize(minimal_view_vars)
+        expect(result['api']['enabled']).to be true
+        expect(result['api']['guest_routes']).to eq({})
+      end
+    end
+
+    context 'when api.enabled is explicitly false' do
+      let(:api_disabled_view_vars) do
+        base_view_vars.merge(
+          'site' => base_view_vars['site'].merge(
+            'interface' => {
+              'ui' => {},
+              'api' => { 'enabled' => false, 'guest_routes' => {} },
+            }
+          )
+        )
+      end
+
+      it 'returns api.enabled as false' do
+        result = described_class.serialize(api_disabled_view_vars)
+        expect(result['api']['enabled']).to be false
+      end
     end
   end
 

--- a/apps/web/core/views/serializers/config_serializer.rb
+++ b/apps/web/core/views/serializers/config_serializer.rb
@@ -39,6 +39,7 @@ module Core
         diagnostics = view_vars['diagnostics']
 
         output['ui']             = site.dig('interface', 'ui')
+        output['api_enabled']    = site.dig('interface', 'api', 'enabled') != false
         output['authentication'] = site.fetch('authentication', nil)
         output['homepage_mode']  = view_vars['homepage_mode']
         output['secret_options'] = site['secret_options']
@@ -98,6 +99,7 @@ module Core
         # @return [Hash] Template with all possible configuration output fields
         def output_template
           {
+            'api_enabled' => nil,
             'authentication' => nil,
             'd9s_enabled' => nil,
             'development' => nil,

--- a/apps/web/core/views/serializers/config_serializer.rb
+++ b/apps/web/core/views/serializers/config_serializer.rb
@@ -39,7 +39,10 @@ module Core
         diagnostics = view_vars['diagnostics']
 
         output['ui']             = site.dig('interface', 'ui')
-        output['api_enabled']    = site.dig('interface', 'api', 'enabled') != false
+        output['api']            = {
+          'enabled' => site.dig('interface', 'api', 'enabled') != false,
+          'guest_routes' => site.dig('interface', 'api', 'guest_routes') || {},
+        }
         output['authentication'] = site.fetch('authentication', nil)
         output['homepage_mode']  = view_vars['homepage_mode']
         output['secret_options'] = site['secret_options']
@@ -99,7 +102,7 @@ module Core
         # @return [Hash] Template with all possible configuration output fields
         def output_template
           {
-            'api_enabled' => nil,
+            'api' => nil,
             'authentication' => nil,
             'd9s_enabled' => nil,
             'development' => nil,

--- a/locales/content/en/workspace-account.json
+++ b/locales/content/en/workspace-account.json
@@ -527,6 +527,10 @@
     "text": "Regenerating your API key will invalidate the current key. Update all applications using the old key.",
     "content_hash": "ab168f83"
   },
+  "web.settings.api.api_disabled_notice": {
+    "text": "The API is disabled for this instance.",
+    "content_hash": "00000000"
+  },
   "web.settings.privacy.title": {
     "text": "Privacy Settings",
     "content_hash": "eefad6ba"

--- a/src/apps/workspace/account/settings/ApiSettings.vue
+++ b/src/apps/workspace/account/settings/ApiSettings.vue
@@ -6,12 +6,15 @@
   import OIcon from '@/shared/components/icons/OIcon.vue';
   import SettingsLayout from '@/apps/workspace/layouts/SettingsLayout.vue';
   import { useAccountStore } from '@/shared/stores/accountStore';
+  import { useBootstrapStore } from '@/shared/stores/bootstrapStore';
   import { storeToRefs } from 'pinia';
   import { onMounted } from 'vue';
 
   const { t } = useI18n();
   const accountStore = useAccountStore();
   const { account } = storeToRefs(accountStore);
+  const bootstrapStore = useBootstrapStore();
+  const { api_enabled } = storeToRefs(bootstrapStore);
 
   onMounted(async () => {
     await accountStore.fetch();
@@ -20,7 +23,22 @@
 
 <template>
   <SettingsLayout>
-    <div class="space-y-8">
+    <div
+      v-if="!api_enabled"
+      class="rounded-lg bg-gray-50 p-6 text-center dark:bg-gray-800/60">
+      <OIcon
+        collection="heroicons"
+        name="x-circle-solid"
+        class="mx-auto mb-3 size-8 text-gray-400 dark:text-gray-500"
+        aria-hidden="true" />
+      <p class="text-sm text-gray-600 dark:text-gray-400">
+        {{ t('web.settings.api.api_disabled_notice') }}
+      </p>
+    </div>
+
+    <div
+      v-else
+      class="space-y-8">
       <!-- API Key Section -->
       <section
         class="rounded-lg border border-gray-200/60 bg-white/60 shadow-sm backdrop-blur-sm dark:border-gray-700/60 dark:bg-gray-800/60">
@@ -67,4 +85,5 @@
       </div>
     </div>
   </SettingsLayout>
+
 </template>

--- a/src/apps/workspace/account/settings/ApiSettings.vue
+++ b/src/apps/workspace/account/settings/ApiSettings.vue
@@ -14,7 +14,7 @@
   const accountStore = useAccountStore();
   const { account } = storeToRefs(accountStore);
   const bootstrapStore = useBootstrapStore();
-  const { api_enabled } = storeToRefs(bootstrapStore);
+  const apiConfig = bootstrapStore.apiConfig;
 
   onMounted(async () => {
     await accountStore.fetch();
@@ -24,7 +24,7 @@
 <template>
   <SettingsLayout>
     <div
-      v-if="!api_enabled"
+      v-if="!apiConfig.enabled"
       class="rounded-lg bg-gray-50 p-6 text-center dark:bg-gray-800/60">
       <OIcon
         collection="heroicons"

--- a/src/schemas/contracts/bootstrap.ts
+++ b/src/schemas/contracts/bootstrap.ts
@@ -157,6 +157,31 @@ export const uiInterfaceSchema = z.object({
 });
 
 // ═══════════════════════════════════════════════════════════════════════════════
+// API CONFIGURATION SCHEMAS
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/**
+ * Guest route permissions for API access.
+ */
+export const apiGuestRoutesSchema = z.object({
+  enabled: z.boolean().default(true),
+  conceal: z.boolean().default(true),
+  generate: z.boolean().default(true),
+  reveal: z.boolean().default(true),
+  burn: z.boolean().default(true),
+  show: z.boolean().default(true),
+  receipt: z.boolean().default(true),
+});
+
+/**
+ * API interface configuration schema controlling API access and guest routes.
+ */
+export const apiInterfaceSchema = z.object({
+  enabled: z.boolean().default(true),
+  guest_routes: apiGuestRoutesSchema.default(apiGuestRoutesSchema.parse({})),
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
 // AUTHENTICATION SCHEMAS
 // ═══════════════════════════════════════════════════════════════════════════════
 
@@ -357,6 +382,8 @@ export type HeaderNavigation = z.infer<typeof headerNavigationSchema>;
 export type HeaderConfig = z.infer<typeof headerConfigSchema>;
 export type UiCapabilities = z.infer<typeof uiCapabilitiesSchema>;
 export type UiInterface = z.infer<typeof uiInterfaceSchema>;
+export type ApiGuestRoutes = z.infer<typeof apiGuestRoutesSchema>;
+export type ApiInterface = z.infer<typeof apiInterfaceSchema>;
 export type AuthenticationSettings = z.infer<typeof authenticationSettingsSchema>;
 export type SSOProvider = z.infer<typeof ssoProviderSchema>;
 export type SSOConfig = z.infer<typeof ssoConfigSchema>;
@@ -392,12 +419,26 @@ export type Passphrase = z.infer<typeof passphraseSchema>;
  * - I18nSerializer fields
  * - MessagesSerializer fields
  * - SystemSerializer fields
+ *
+ * ## Schema contract pattern: `.default()` vs `.optional()`
+ *
+ * Use `.default(...)` for fields the Ruby serializer ALWAYS emits. This:
+ * - Documents the actual contract (Ruby always sends it)
+ * - Produces a non-optional TypeScript type (no unnecessary `?.` guards)
+ * - Provides a fallback if parsing somehow receives `undefined`
+ *
+ * Use `.optional()` ONLY for fields Ruby conditionally emits (e.g., `regions`
+ * is only sent when `regions_enabled` is true). The TypeScript type will
+ * include `| undefined`, correctly reflecting the contract.
+ *
+ * When in doubt, check the Ruby serializer's `output_template` and the field
+ * assignment logic to determine which pattern applies.
  */
 export const bootstrapSchema = z.object({
   // ─────────────────────────────────────────────────────────────────────────────
   // ConfigSerializer fields
   // ─────────────────────────────────────────────────────────────────────────────
-  api_enabled: z.boolean().default(true),
+  api: apiInterfaceSchema.default(apiInterfaceSchema.parse({})),
   authentication: authenticationSettingsSchema.default(authenticationSettingsInner.parse({})),
   d9s_enabled: z.boolean().default(false),
   diagnostics: diagnosticsSchema.default(diagnosticsInner.parse({})),
@@ -490,9 +531,9 @@ export const bootstrapSchema = z.object({
   entitlement_preview_plan_name: z.string().nullish(),
 
   // ─────────────────────────────────────────────────────────────────────────────
-  // Development
+  // Development (always emitted by ConfigSerializer)
   // ─────────────────────────────────────────────────────────────────────────────
-  development: developmentConfigSchema.optional(),
+  development: developmentConfigSchema.default(developmentConfigSchema.parse({})),
 });
 
 // ═══════════════════════════════════════════════════════════════════════════════

--- a/src/schemas/contracts/bootstrap.ts
+++ b/src/schemas/contracts/bootstrap.ts
@@ -397,6 +397,7 @@ export const bootstrapSchema = z.object({
   // ─────────────────────────────────────────────────────────────────────────────
   // ConfigSerializer fields
   // ─────────────────────────────────────────────────────────────────────────────
+  api_enabled: z.boolean().default(true),
   authentication: authenticationSettingsSchema.default(authenticationSettingsInner.parse({})),
   d9s_enabled: z.boolean().default(false),
   diagnostics: diagnosticsSchema.default(diagnosticsInner.parse({})),

--- a/src/shared/stores/bootstrapStore.ts
+++ b/src/shared/stores/bootstrapStore.ts
@@ -3,6 +3,8 @@
 import { getBootstrapSnapshot, updateBootstrapSnapshot } from '@/services/bootstrap.service';
 import {
   bootstrapSchema,
+  type ApiGuestRoutes,
+  type ApiInterface,
   type BootstrapPayload,
   type FooterLinksConfig,
   type HeaderConfig,
@@ -34,7 +36,8 @@ const SCHEMA_DEFAULTS = bootstrapSchema.parse({});
  */
 const DEFAULTS: BootstrapPayload = {
   ...SCHEMA_DEFAULTS,
-  // Explicitly include optional fields that Zod omits
+  // Explicitly include optional fields that Zod omits (fields marked .optional()
+  // in the schema, not fields with .default() which are included in SCHEMA_DEFAULTS)
   apitoken: undefined,
   customer_since: undefined,
   regions: undefined,
@@ -43,7 +46,6 @@ const DEFAULTS: BootstrapPayload = {
   entitlement_preview_planid: undefined,
   entitlement_preview_plan_name: undefined,
   organization: undefined,
-  development: undefined,
 };
 
 /**
@@ -158,6 +160,18 @@ export const useBootstrapStore = defineStore('bootstrap', {
      * Each flag is undefined when unset; consumers treat undefined as enabled.
      */
     uiCapabilities: (state): UiCapabilities | undefined => state.ui.capabilities,
+
+    /**
+     * API configuration from bootstrap payload.
+     * Contains enabled flag and guest route permissions.
+     */
+    apiConfig: (state): ApiInterface => state.api,
+
+    /**
+     * Guest route permissions for API access.
+     * Controls which API routes are available to unauthenticated users.
+     */
+    guestRoutes: (state): ApiGuestRoutes => state.api.guest_routes,
   },
 
   // ═══════════════════════════════════════════════════════════════════════════
@@ -276,6 +290,7 @@ export const useBootstrapStore = defineStore('bootstrap', {
     resetForLogout(): void {
       // Capture current server config values before reset
       const preservedConfig = {
+        api: this.api,
         authentication: this.authentication,
         ui: this.ui,
         features: this.features,
@@ -290,6 +305,7 @@ export const useBootstrapStore = defineStore('bootstrap', {
       // Restore server config fields and _initialized flag
       // Use functional $patch to avoid _DeepPartial type issues
       this.$patch((state) => {
+        state.api = preservedConfig.api;
         state.authentication = preservedConfig.authentication;
         state.ui = preservedConfig.ui;
         state.features = preservedConfig.features;

--- a/src/tests/contracts/bootstrap-schema-contract.spec.ts
+++ b/src/tests/contracts/bootstrap-schema-contract.spec.ts
@@ -10,7 +10,7 @@
 
 import { describe, expect, it } from 'vitest';
 import type { BootstrapPayload } from '@/schemas/contracts/bootstrap';
-import { featuresSchema, organizationSchema } from '@/schemas/contracts/bootstrap';
+import { apiInterfaceSchema, featuresSchema, organizationSchema } from '@/schemas/contracts/bootstrap';
 import { bootstrapUiSchema, BOOTSTRAP_UI_DEFAULTS } from './bootstrap-test-schema';
 import {
   ALL_SERIALIZER_FIELDS,
@@ -242,6 +242,80 @@ describe('Bootstrap Zod schema validation', () => {
         expect(result.data.ui).toEqual({ enabled: true });
         expect(result.data.messages).toEqual([]);
       }
+    });
+  });
+
+  describe('apiInterfaceSchema', () => {
+    it('provides sensible defaults for empty input', () => {
+      const result = apiInterfaceSchema.parse({});
+
+      expect(result.enabled).toBe(true);
+      expect(result.guest_routes).toBeDefined();
+      expect(result.guest_routes.enabled).toBe(true);
+      expect(result.guest_routes.conceal).toBe(true);
+      expect(result.guest_routes.generate).toBe(true);
+      expect(result.guest_routes.reveal).toBe(true);
+      expect(result.guest_routes.burn).toBe(true);
+      expect(result.guest_routes.show).toBe(true);
+      expect(result.guest_routes.receipt).toBe(true);
+    });
+
+    it('accepts api.enabled as false', () => {
+      const api = { enabled: false };
+      const result = apiInterfaceSchema.safeParse(api);
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.enabled).toBe(false);
+      }
+    });
+
+    it('accepts full api object with all guest_routes', () => {
+      const api = {
+        enabled: true,
+        guest_routes: {
+          enabled: true,
+          conceal: true,
+          generate: false,
+          reveal: true,
+          burn: false,
+          show: true,
+          receipt: true,
+        },
+      };
+
+      const result = apiInterfaceSchema.safeParse(api);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.guest_routes.generate).toBe(false);
+        expect(result.data.guest_routes.burn).toBe(false);
+      }
+    });
+
+    it('applies defaults for missing guest_routes keys', () => {
+      const api = {
+        enabled: true,
+        guest_routes: { enabled: false },
+      };
+
+      const result = apiInterfaceSchema.safeParse(api);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.guest_routes.enabled).toBe(false);
+        // Other keys default to true
+        expect(result.data.guest_routes.conceal).toBe(true);
+        expect(result.data.guest_routes.reveal).toBe(true);
+      }
+    });
+
+    it('rejects malformed api object gracefully', () => {
+      const malformed = {
+        enabled: 'yes', // should be boolean
+        guest_routes: 'all', // should be object
+      };
+
+      const result = apiInterfaceSchema.safeParse(malformed);
+      expect(result.success).toBe(false);
     });
   });
 

--- a/src/tests/contracts/bootstrap-serializer-fields.ts
+++ b/src/tests/contracts/bootstrap-serializer-fields.ts
@@ -29,6 +29,7 @@ export const AUTHENTICATION_SERIALIZER_FIELDS = [
 // Source: apps/web/core/views/serializers/config_serializer.rb
 // ============================================================================
 export const CONFIG_SERIALIZER_FIELDS = [
+  'api_enabled',
   'authentication',
   'd9s_enabled',
   'development',

--- a/src/tests/contracts/bootstrap-serializer-fields.ts
+++ b/src/tests/contracts/bootstrap-serializer-fields.ts
@@ -29,7 +29,7 @@ export const AUTHENTICATION_SERIALIZER_FIELDS = [
 // Source: apps/web/core/views/serializers/config_serializer.rb
 // ============================================================================
 export const CONFIG_SERIALIZER_FIELDS = [
-  'api_enabled',
+  'api',
   'authentication',
   'd9s_enabled',
   'development',

--- a/src/tests/contracts/bootstrap-test-schema.ts
+++ b/src/tests/contracts/bootstrap-test-schema.ts
@@ -20,7 +20,8 @@ export const bootstrapUiSchema = z.object({
   ui: uiInterfaceSchema.default({ enabled: true }),
   messages: z.array(messageSchema).default([]),
   features: featuresSchema.default({ markdown: false }),
-  development: developmentConfigSchema.optional(),
+  // Ruby always emits development; organization is conditional
+  development: developmentConfigSchema.default(developmentConfigSchema.parse({})),
   organization: organizationSchema.optional(),
   supported_locales: z.array(z.string()).default([]),
   default_locale: z.string().default('en'),

--- a/src/tests/stores/bootstrapStore.spec.ts
+++ b/src/tests/stores/bootstrapStore.spec.ts
@@ -1043,8 +1043,8 @@ describe('bootstrapStore', () => {
       expect(freshStore.default_locale).toBe(BOOTSTRAP_UI_DEFAULTS.default_locale);
       expect(freshStore.supported_locales).toEqual(BOOTSTRAP_UI_DEFAULTS.supported_locales);
 
-      // Development (both undefined by default)
-      expect(freshStore.development).toBe(BOOTSTRAP_UI_DEFAULTS.development);
+      // Development (both have schema defaults - Ruby always emits this field)
+      expect(freshStore.development).toEqual(BOOTSTRAP_UI_DEFAULTS.development);
 
       // Organization (both undefined by default)
       expect(freshStore.organization).toBe(BOOTSTRAP_UI_DEFAULTS.organization);


### PR DESCRIPTION
## Summary

- Exposes `api_enabled` from the Ruby config serializer to the frontend bootstrap payload
- Adds `api_enabled` to the Zod bootstrap schema (default: `true`)
- In Account Settings → API tab: shows a notice instead of the key form when the API is disabled
- Adds English i18n key `web.settings.api.api_disabled_notice`

## Before / After

**Before:** Users with `API_ENABLED=false` still see their API key, copy it, try to use it, and get a 404 with no explanation.

**After:** The API key section is replaced with a clear notice that the API is disabled for this instance.

Closes #3115