### PR TITLE
feat: add HELP_ENABLED env var to hide Need help? modal on secret pages

### DIFF
--- a/.env.reference
+++ b/.env.reference
@@ -341,6 +341,9 @@ UI_HOMEPAGE_MATCHING_CIDRS=
 UI_HOMEPAGE_MODE_HEADER=
 UI_HOMEPAGE_DEFAULT_MODE=
 
+# Show help modals on secret reveal/receipt pages. Set to 'false' to hide.
+HELP_ENABLED=true
+
 # One of: DefaultLogo.vue, LegacyLogo.vue, OnetimeSecretLogo.vue
 #LOGO_URL=
 

--- a/.pre-push-config.yaml
+++ b/.pre-push-config.yaml
@@ -56,6 +56,10 @@ repos:
         name: Validate YAML files
         args: ['--allow-multiple-documents']
         files: \.(yaml|yml)$
+        # These config files are ERB templates, not plain YAML: they carry
+        # <% %> control tags that the YAML parser cannot handle. They are
+        # rendered through ERB before being parsed at runtime.
+        exclude: '^etc/defaults/.*\.yaml$|^etc/examples/billing\.example\.yaml$|^spec/.*\.test\.yaml$'
 
       - id: check-toml
         name: Validate TOML files

--- a/etc/defaults/config.defaults.yaml
+++ b/etc/defaults/config.defaults.yaml
@@ -163,7 +163,8 @@ site:
       # Show or hide the version number in the workspace footer
       show_version: <%= ENV['FOOTER_VERSION_ENABLED'] != 'false' %>
       # Show or hide the "Need help?" modal trigger on secret pages
-      help_enabled: <%= ENV['HELP_ENABLED'] != 'false' %>
+      help:
+        enabled: <%= ENV['HELP_ENABLED'] != 'false' %>
     # Controls whether the API endpoints are available. When disabled, the API
     # is completely disabled. Requests to /api/* will return 404.
     api:

--- a/etc/defaults/config.defaults.yaml
+++ b/etc/defaults/config.defaults.yaml
@@ -162,6 +162,8 @@ site:
         <% end %>
       # Show or hide the version number in the workspace footer
       show_version: <%= ENV['FOOTER_VERSION_ENABLED'] != 'false' %>
+      # Show or hide the "Need help?" modal trigger on secret pages
+      help_enabled: <%= ENV['HELP_ENABLED'] != 'false' %>
     # Controls whether the API endpoints are available. When disabled, the API
     # is completely disabled. Requests to /api/* will return 404.
     api:

--- a/src/apps/secret/components/canonical/SecretConfirmationForm.vue
+++ b/src/apps/secret/components/canonical/SecretConfirmationForm.vue
@@ -4,8 +4,14 @@
   import { useI18n } from 'vue-i18n';
   import NeedHelpModal from '@/shared/components/modals/NeedHelpModal.vue';
   import SecretRecipientHelpContent from '@/apps/secret/components/SecretRecipientHelpContent.vue';
+  import { useBootstrapStore } from '@/shared/stores/bootstrapStore';
   import type { Secret, SecretDetails } from '@/schemas/shapes/v3/secret';
   import { ref, computed } from 'vue';
+  import { storeToRefs } from 'pinia';
+
+  const bootstrapStore = useBootstrapStore();
+  const { ui } = storeToRefs(bootstrapStore);
+  const helpEnabled = computed(() => ui.value?.help_enabled ?? true);
 
   interface Props {
     secretIdentifier: string;
@@ -71,6 +77,7 @@
 
       <!-- Help Modal Trigger positioned to the right -->
       <NeedHelpModal
+        v-if="helpEnabled"
         link-icon-name="question-mark-circle-16-solid"
         link-text-label="">
         <!-- prettier-ignore-attribute class -->

--- a/src/apps/secret/components/canonical/SecretConfirmationForm.vue
+++ b/src/apps/secret/components/canonical/SecretConfirmationForm.vue
@@ -7,11 +7,9 @@
   import { useBootstrapStore } from '@/shared/stores/bootstrapStore';
   import type { Secret, SecretDetails } from '@/schemas/shapes/v3/secret';
   import { ref, computed } from 'vue';
-  import { storeToRefs } from 'pinia';
 
   const bootstrapStore = useBootstrapStore();
-  const { ui } = storeToRefs(bootstrapStore);
-  const helpEnabled = computed(() => ui.value?.help_enabled ?? true);
+  const helpEnabled = computed(() => bootstrapStore.ui?.help_enabled ?? true);
 
   interface Props {
     secretIdentifier: string;

--- a/src/apps/secret/components/canonical/SecretConfirmationForm.vue
+++ b/src/apps/secret/components/canonical/SecretConfirmationForm.vue
@@ -9,7 +9,7 @@
   import { ref, computed } from 'vue';
 
   const bootstrapStore = useBootstrapStore();
-  const helpEnabled = computed(() => bootstrapStore.ui?.help_enabled ?? true);
+  const helpEnabled = computed(() => bootstrapStore.ui?.help?.enabled ?? true);
 
   interface Props {
     secretIdentifier: string;

--- a/src/apps/secret/components/canonical/SecretDisplayCase.vue
+++ b/src/apps/secret/components/canonical/SecretDisplayCase.vue
@@ -17,7 +17,7 @@
     () => bootstrapStore.authentication?.enabled
       && bootstrapStore.authentication?.signin
   );
-  const helpEnabled = computed(() => bootstrapStore.ui?.help_enabled ?? true);
+  const helpEnabled = computed(() => bootstrapStore.ui?.help?.enabled ?? true);
 
   interface Props {
     record: Secret | null;

--- a/src/apps/secret/components/canonical/SecretDisplayCase.vue
+++ b/src/apps/secret/components/canonical/SecretDisplayCase.vue
@@ -17,6 +17,7 @@
     () => bootstrapStore.authentication?.enabled
       && bootstrapStore.authentication?.signin
   );
+  const helpEnabled = computed(() => bootstrapStore.ui?.help_enabled ?? true);
 
   interface Props {
     record: Secret | null;
@@ -79,6 +80,7 @@
         </div>
         <!-- Help Modal Trigger positioned to the right -->
         <NeedHelpModal
+          v-if="helpEnabled"
           link-icon-name="question-mark-circle-16-solid"
           link-text-label="">
           <button

--- a/src/apps/secret/reveal/ShowReceipt.vue
+++ b/src/apps/secret/reveal/ShowReceipt.vue
@@ -286,12 +286,12 @@
         <!-- Help Section with Card Styling -->
         <!-- prettier-ignore-attribute class -->
         <section
-          v-if="isAvailable"
+          v-if="isAvailable && helpEnabled"
           aria-labelledby="section-help"
           class="relative rounded-xl border border-gray-200/60
           bg-white/60 p-4 shadow-sm backdrop-blur-sm sm:p-6
           dark:border-gray-700/60 dark:bg-gray-800/60">
-          <NeedHelpModal v-if="helpEnabled">
+          <NeedHelpModal>
             <template #content>
               <ReceiptFAQ
                 :record="record"

--- a/src/apps/secret/reveal/ShowReceipt.vue
+++ b/src/apps/secret/reveal/ShowReceipt.vue
@@ -11,6 +11,7 @@
   import SecretLink from '@/apps/secret/components/receipt/SecretLink.vue';
   import StatusBadge from '@/apps/secret/components/receipt/StatusBadge.vue';
   import TimelineDisplay from '@/apps/secret/components/receipt/TimelineDisplay.vue';
+  import { useBootstrapStore } from '@/shared/stores/bootstrapStore';
   import { useReceipt } from '@/shared/composables/useReceipt';
   import { useSecretExpiration, EXPIRATION_EVENTS } from '@/shared/composables/useSecretExpiration';
   import { useBootstrapStore } from '@/shared/stores/bootstrapStore';
@@ -18,6 +19,9 @@
   import { onMounted, onUnmounted, watch, computed, ref } from 'vue';
 
   import UnknownReceipt from './UnknownReceipt.vue';
+
+  const bootstrapStore = useBootstrapStore();
+  const helpEnabled = computed(() => bootstrapStore.ui?.help_enabled ?? true);
 
   // Define props
   interface Props {
@@ -287,7 +291,7 @@
           class="relative rounded-xl border border-gray-200/60
           bg-white/60 p-4 shadow-sm backdrop-blur-sm sm:p-6
           dark:border-gray-700/60 dark:bg-gray-800/60">
-          <NeedHelpModal>
+          <NeedHelpModal v-if="helpEnabled">
             <template #content>
               <ReceiptFAQ
                 :record="record"

--- a/src/apps/secret/reveal/ShowReceipt.vue
+++ b/src/apps/secret/reveal/ShowReceipt.vue
@@ -11,7 +11,6 @@
   import SecretLink from '@/apps/secret/components/receipt/SecretLink.vue';
   import StatusBadge from '@/apps/secret/components/receipt/StatusBadge.vue';
   import TimelineDisplay from '@/apps/secret/components/receipt/TimelineDisplay.vue';
-  import { useBootstrapStore } from '@/shared/stores/bootstrapStore';
   import { useReceipt } from '@/shared/composables/useReceipt';
   import { useSecretExpiration, EXPIRATION_EVENTS } from '@/shared/composables/useSecretExpiration';
   import { useBootstrapStore } from '@/shared/stores/bootstrapStore';
@@ -19,9 +18,6 @@
   import { onMounted, onUnmounted, watch, computed, ref } from 'vue';
 
   import UnknownReceipt from './UnknownReceipt.vue';
-
-  const bootstrapStore = useBootstrapStore();
-  const helpEnabled = computed(() => bootstrapStore.ui?.help_enabled ?? true);
 
   // Define props
   interface Props {
@@ -50,6 +46,7 @@
   const bootstrapStore = useBootstrapStore();
   const { uiCapabilities } = storeToRefs(bootstrapStore);
   const showBurn = computed(() => uiCapabilities.value?.burn !== false);
+  const helpEnabled = computed(() => bootstrapStore.ui?.help?.enabled ?? true);
 
   const goBack = () => {
     window.history.back();

--- a/src/apps/secret/reveal/UnknownSecret.vue
+++ b/src/apps/secret/reveal/UnknownSecret.vue
@@ -5,9 +5,13 @@
   import BaseUnknownSecret from '@/shared/components/base/BaseUnknownSecret.vue';
   import NeedHelpModal from '@/shared/components/modals/NeedHelpModal.vue';
   import UnknownSecretHelpContent from '@/apps/secret/components/UnknownSecretHelpContent.vue';
+  import { useBootstrapStore } from '@/shared/stores/bootstrapStore';
   import type { BrandSettings } from '@/schemas/shapes/v3/custom-domain';
+  import { computed } from 'vue';
 
-const { t } = useI18n();
+  const { t } = useI18n();
+  const bootstrapStore = useBootstrapStore();
+  const helpEnabled = computed(() => bootstrapStore.ui?.help_enabled ?? true);
 
   interface Props {
     branded?: boolean;
@@ -55,6 +59,7 @@ const { t } = useI18n();
 
           <!-- Help Modal Trigger -->
           <NeedHelpModal
+            v-if="helpEnabled"
             link-icon-name="question-mark-circle-16-solid"
             link-text-label=""
             aria-haspopup="dialog">

--- a/src/apps/secret/reveal/UnknownSecret.vue
+++ b/src/apps/secret/reveal/UnknownSecret.vue
@@ -11,7 +11,7 @@
 
   const { t } = useI18n();
   const bootstrapStore = useBootstrapStore();
-  const helpEnabled = computed(() => bootstrapStore.ui?.help_enabled ?? true);
+  const helpEnabled = computed(() => bootstrapStore.ui?.help?.enabled ?? true);
 
   interface Props {
     branded?: boolean;

--- a/src/schemas/contracts/bootstrap.ts
+++ b/src/schemas/contracts/bootstrap.ts
@@ -155,6 +155,7 @@ export const uiInterfaceSchema = z.object({
   workspace_links: workspaceLinksConfigSchema.optional(),
   capabilities: uiCapabilitiesSchema.optional(),
   show_version: z.boolean().default(true),
+  help_enabled: z.boolean().default(true),
 });
 
 // ═══════════════════════════════════════════════════════════════════════════════

--- a/src/schemas/contracts/bootstrap.ts
+++ b/src/schemas/contracts/bootstrap.ts
@@ -148,6 +148,10 @@ export const uiCapabilitiesSchema = z.object({
   recipient: z.boolean().optional(),
 });
 
+export const uiHelpSchema = z.object({
+  enabled: z.boolean().default(true),
+});
+
 export const uiInterfaceSchema = z.object({
   enabled: z.boolean().default(true),
   header: headerConfigSchema.optional(),
@@ -155,7 +159,7 @@ export const uiInterfaceSchema = z.object({
   workspace_links: workspaceLinksConfigSchema.optional(),
   capabilities: uiCapabilitiesSchema.optional(),
   show_version: z.boolean().default(true),
-  help_enabled: z.boolean().default(true),
+  help: uiHelpSchema.optional(),
 });
 
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -358,6 +362,7 @@ export type HeaderBranding = z.infer<typeof headerBrandingSchema>;
 export type HeaderNavigation = z.infer<typeof headerNavigationSchema>;
 export type HeaderConfig = z.infer<typeof headerConfigSchema>;
 export type UiCapabilities = z.infer<typeof uiCapabilitiesSchema>;
+export type UiHelp = z.infer<typeof uiHelpSchema>;
 export type UiInterface = z.infer<typeof uiInterfaceSchema>;
 export type AuthenticationSettings = z.infer<typeof authenticationSettingsSchema>;
 export type SSOProvider = z.infer<typeof ssoProviderSchema>;

--- a/src/schemas/contracts/config/section/ui.ts
+++ b/src/schemas/contracts/config/section/ui.ts
@@ -97,6 +97,13 @@ const uiCapabilitiesSchema = z.object({
   recipient: z.boolean().optional(),
 });
 
+/**
+ * UI help configuration
+ */
+const uiHelpSchema = z.object({
+  enabled: z.boolean().optional(),
+});
+
 const uiSchema = z.object({
   enabled: z.boolean().default(true),
   homepage: userInterfaceHomepageSchema.optional(),
@@ -104,6 +111,7 @@ const uiSchema = z.object({
   footer_links: userInterfaceFooterLinksSchema.optional(),
   workspace_links: userInterfaceWorkspaceLinksSchema.optional(),
   capabilities: uiCapabilitiesSchema.optional(),
+  help: uiHelpSchema.optional(),
 });
 
 /**
@@ -130,4 +138,5 @@ export {
   userInterfaceFooterLinksSchema,
   userInterfaceHomepageSchema,
   uiCapabilitiesSchema,
+  uiHelpSchema,
 };

--- a/src/tests/contracts/bootstrap-schema-contract.spec.ts
+++ b/src/tests/contracts/bootstrap-schema-contract.spec.ts
@@ -214,6 +214,7 @@ describe('Bootstrap Zod schema validation', () => {
       const defaults = BOOTSTRAP_UI_DEFAULTS;
 
       expect(defaults.ui).toEqual({ enabled: true });
+      expect(defaults.ui.help).toBeUndefined();
       expect(defaults.messages).toEqual([]);
       expect(defaults.features).toEqual({ markdown: false });
       expect(defaults.supported_locales).toEqual([]);
@@ -240,6 +241,7 @@ describe('Bootstrap Zod schema validation', () => {
       expect(result.success).toBe(true);
       if (result.success) {
         expect(result.data.ui).toEqual({ enabled: true });
+        expect(result.data.ui.help).toBeUndefined();
         expect(result.data.messages).toEqual([]);
       }
     });
@@ -380,6 +382,9 @@ describe('Bootstrap realistic payload parsing', () => {
               ],
             },
           ],
+        },
+        help: {
+          enabled: true,
         },
       },
       messages: [{ type: 'info' as const, content: 'Welcome back!' }],

--- a/src/tests/schemas/contracts/config/ui-capabilities.spec.ts
+++ b/src/tests/schemas/contracts/config/ui-capabilities.spec.ts
@@ -6,10 +6,12 @@
 import { describe, it, expect } from 'vitest';
 import {
   uiCapabilitiesSchema as configUiCapabilitiesSchema,
+  uiHelpSchema as configUiHelpSchema,
   uiSchema as configUiSchema,
 } from '@/schemas/contracts/config/section/ui';
 import {
   uiCapabilitiesSchema as bootstrapUiCapabilitiesSchema,
+  uiHelpSchema as bootstrapUiHelpSchema,
   uiInterfaceSchema as bootstrapUiInterfaceSchema,
 } from '@/schemas/contracts/bootstrap';
 
@@ -142,6 +144,117 @@ describe('uiCapabilitiesSchema nested in parent schema (bootstrap uiInterfaceSch
     expect(result.success).toBe(true);
     if (result.success) {
       expect(result.data.capabilities).toBeUndefined();
+    }
+  });
+});
+
+/**
+ * Both config and bootstrap define their own uiHelpSchema.
+ * These tests verify both behave identically for explicit values
+ * and integrate with their respective parent schemas.
+ */
+describe.each([
+  { label: 'config/section/ui', schema: configUiHelpSchema },
+  { label: 'contracts/bootstrap', schema: bootstrapUiHelpSchema },
+])('uiHelpSchema ($label)', ({ schema }) => {
+  it('accepts { enabled: true }', () => {
+    const result = schema.safeParse({ enabled: true });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.enabled).toBe(true);
+    }
+  });
+
+  it('accepts { enabled: false }', () => {
+    const result = schema.safeParse({ enabled: false });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.enabled).toBe(false);
+    }
+  });
+
+  it('accepts empty object', () => {
+    const result = schema.safeParse({});
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects non-boolean value for enabled', () => {
+    const result = schema.safeParse({ enabled: 'yes' });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].path).toContain('enabled');
+    }
+  });
+});
+
+describe('uiHelpSchema default behavior differences', () => {
+  it('config schema: enabled is undefined when omitted', () => {
+    const result = configUiHelpSchema.safeParse({});
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.enabled).toBeUndefined();
+    }
+  });
+
+  it('bootstrap schema: enabled defaults to true when omitted', () => {
+    const result = bootstrapUiHelpSchema.safeParse({});
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.enabled).toBe(true);
+    }
+  });
+});
+
+describe('uiHelpSchema nested in parent schema (config uiSchema)', () => {
+  it('parses help nested inside uiSchema', () => {
+    const input = {
+      enabled: true,
+      help: {
+        enabled: false,
+      },
+    };
+
+    const result = configUiSchema.safeParse(input);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.help?.enabled).toBe(false);
+    }
+  });
+
+  it('parses uiSchema without help field', () => {
+    const input = { enabled: true };
+
+    const result = configUiSchema.safeParse(input);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.help).toBeUndefined();
+    }
+  });
+});
+
+describe('uiHelpSchema nested in parent schema (bootstrap uiInterfaceSchema)', () => {
+  it('parses help nested inside uiInterfaceSchema', () => {
+    const input = {
+      enabled: true,
+      help: {
+        enabled: true,
+      },
+    };
+
+    const result = bootstrapUiInterfaceSchema.safeParse(input);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.help?.enabled).toBe(true);
+    }
+  });
+
+  it('parses uiInterfaceSchema without help field', () => {
+    const input = { enabled: true };
+
+    const result = bootstrapUiInterfaceSchema.safeParse(input);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.help).toBeUndefined();
     }
   });
 });


### PR DESCRIPTION
## Summary

- Adds `HELP_ENABLED` env var (default: `true`) under `site.interface.ui.help_enabled` in the config
- Exposes `help_enabled` via the `uiInterfaceSchema` Zod schema and the bootstrap `ui` payload
- All four components that render the "Need help?" modal trigger now hide it when `help_enabled` is `false`

## Affected components

| Component | Usage |
|---|---|
| `SecretConfirmationForm.vue` | Secret reveal / passphrase prompt |
| `SecretDisplayCase.vue` | Secret display after reveal |
| `UnknownSecret.vue` | Secret no longer available page |
| `ShowReceipt.vue` | Receipt / confirmation page |

## Configuration

```
HELP_ENABLED=false
```

Closes #3110