### PR TITLE
fix: prevent fork PR workflow failures on labeler and CI metrics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -697,7 +697,7 @@ jobs:
       - name: Build Container image
         uses: docker/bake-action@5be5f02ff8819ecd3092ea6b2e6261c31774f2b4 # v6.10.0
         with:
-          source: .  # Use local checkout instead of fetching git URL (avoids PR merge ref issues)
+          source: . # Use local checkout instead of fetching git URL (avoids PR merge ref issues)
           files: docker/bake.hcl
           targets: main
           load: true
@@ -844,9 +844,9 @@ jobs:
           echo "| Ruby Integration (Disabled) | ${{ needs.ruby-integration-disabled.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Container Validation | ${{ needs.check-oci-image.result }} |" >> $GITHUB_STEP_SUMMARY
 
-      # Post CI metrics summary as PR comment (PRs only)
+      # Post CI metrics summary as PR comment (PRs only, skip forks - no write access)
       - name: Post metrics to PR
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork
         uses: actions/github-script@v7
         with:
           github-token: ${{ github.token }}

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -21,7 +21,7 @@
 name: PR Labeler
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened]
 
 jobs:
@@ -34,6 +34,6 @@ jobs:
     steps:
       - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
         with:
-          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          repo-token: '${{ secrets.GITHUB_TOKEN }}'
           configuration-path: .github/labeler.yml
           sync-labels: false


### PR DESCRIPTION
## Problem

Fork PRs use a restricted `GITHUB_TOKEN` with no write permissions, causing two workflows to fail with `403 Resource not accessible by integration`:

- **pr-labeler**: `actions/labeler` cannot add labels
- **ci-metrics**: `post-pr-metrics.cjs` cannot post a PR comment

## Changes

### `.github/workflows/pr-labeler.yml`
Switch trigger from `pull_request` → `pull_request_target`. The `pull_request_target` event runs in the base repo context with full write permissions, even for fork PRs. Safe here because the labeler only reads file paths from the diff — it never checks out or executes fork code.

### `.github/workflows/ci.yml` (ci-metrics job)
Add `&& !github.event.pull_request.head.repo.fork` to the "Post metrics to PR" step condition so it skips gracefully on fork PRs instead of failing. The job-level `GITHUB_STEP_SUMMARY` still captures metrics output for all PRs.