### PR TITLE
fix: resolve pre-push hook false failures on YAML/JSON checks

### DIFF
--- a/.pre-push-config.yaml
+++ b/.pre-push-config.yaml
@@ -64,6 +64,9 @@ repos:
       - id: check-json
         name: Validate JSON files
         files: \.json$
+        # tsconfig*.json files are JSONC (TypeScript permits comments); the
+        # broken.json fixture is an intentionally-malformed test input.
+        exclude: '(^|/)tsconfig[^/]*\.json$|^src/tests/i18n/fixtures/invalid/syntax/broken\.json$'
 
       - id: mixed-line-ending
         name: Check line endings

--- a/etc/examples/homepage_modes.example.yaml
+++ b/etc/examples/homepage_modes.example.yaml
@@ -35,6 +35,7 @@ site:
         mode_header: "O-Homepage-Mode"
         trusted_proxy_depth: 1   # Trust single reverse proxy (nginx, Caddy, etc.)
 
+---
 # =============================================================================
 # Example 2: External Mode for Public Access (Behind Reverse Proxy)
 # =============================================================================
@@ -52,6 +53,7 @@ site:
         mode_header: "O-Homepage-Mode"
         trusted_proxy_depth: 1   # Trust single reverse proxy
 
+---
 # =============================================================================
 # Example 3: Direct Connection (No Reverse Proxy)
 # =============================================================================
@@ -71,6 +73,7 @@ site:
         mode_header: "O-Homepage-Mode"
         trusted_proxy_depth: 0   # NOT behind proxy - use direct connection IP
 
+---
 # =============================================================================
 # Example 4: Behind Load Balancer AND Reverse Proxy
 # =============================================================================
@@ -93,6 +96,7 @@ site:
         mode_header: "O-Homepage-Mode"
         trusted_proxy_depth: 2   # Trust 2 proxy layers (CDN + reverse proxy)
 
+---
 # =============================================================================
 # Example 5: IPv6 Networks (Behind Reverse Proxy)
 # =============================================================================


### PR DESCRIPTION
Fixes two latent issues that caused pre-push hooks to fail on diverged history.

**YAML duplicate keys** — `homepage_modes.example.yaml` had 5 `site:` top-level keys in a single YAML document. Parsers silently keep only the last. Added `---` document separators between all five examples.

**JSON false positives** — the `check-json` hook reported 3 files it cannot handle: `tsconfig*.json` files are JSONC (TypeScript permits comments, not strict JSON), and `src/tests/i18n/fixtures/invalid/syntax/broken.json` is an intentionally-malformed test fixture. Added an `exclude:` pattern to skip them.