### PR TITLE
Wire ui.capabilities flags to their UI surfaces

### DIFF
--- a/docs/specs/domain-permissions.md
+++ b/docs/specs/domain-permissions.md
@@ -1,3 +1,5 @@
+# docs/specs/domain-permissions.md
+---
 # Domain Permissions for Secret Creation
 
 Behavioral specification for `validate_domain_permissions` authorization logic.

--- a/docs/specs/secret-creation-flows.md
+++ b/docs/specs/secret-creation-flows.md
@@ -1,0 +1,85 @@
+# docs/specs/secret-creation-flows.md
+---
+# Secret Creation Flows
+
+Behavioral specification for the post-submit navigation flows of the secret
+creation forms. Three flows exist; this document records what controls each and
+how they differ, ahead of any consolidation work.
+
+## Overview
+
+| Flow | What happens after submit | Control point |
+|---|---|---|
+| Two-page | Navigate to `/receipt/:identifier` | `workspaceMode = false` (default) |
+| Workspace (one-page) | Stay in place, `RecentSecretsTable` refreshes inline | `workspaceMode = true` |
+| Incoming | Navigate `/incoming` → `/incoming/:receiptKey` | unconditional |
+
+The "one-page" flow is **not a modal**. It is the form resetting in place with
+an inline table refresh. The Incoming flow is **not a modal either** — it is a
+two-route page swap styled to *look* like a modal dialog (centered
+`max-w-3xl` card with `rounded-2xl shadow-lg`), with no backdrop, no `<dialog>`,
+no `Teleport`, no focus trap, and no Esc-to-dismiss.
+
+## Flow Selection
+
+`workspaceMode` is a client-side preference only — a boolean in `localStorage`
+under key `onetimeWorkspaceMode`. There is no server config flag for it. It
+persists across sessions (not `sessionStorage`).
+
+| Entry point | Form component | `workspaceMode` source | Resulting flow |
+|---|---|---|---|
+| `/` (standard) | `SecretForm` | prop from `localReceiptStore` via `HomepageContent` | two-page or workspace |
+| `/` (custom domain) | `SecretForm` | prop omitted → defaults `false` | always two-page |
+| `/dashboard` | `WorkspaceSecretForm` | reads `localReceiptStore` directly | two-page or workspace |
+| `/incoming` | `IncomingForm` | n/a | always two-page (Incoming) |
+
+## Navigation Decision Matrix
+
+The navigation branch lives in each form's `onSuccess` callback, **not** in the
+shared `useSecretConcealer` composable — the composable only invokes
+`onSuccess` and returns.
+
+| Form | Action | `workspaceMode` | Result |
+|---|---|---|---|
+| `SecretForm` | any | `false` | `router.push('/receipt/:id')` |
+| `SecretForm` | any | `true` | stay in place |
+| `WorkspaceSecretForm` | `create-link` | `false` | `router.push('/receipt/:id')` |
+| `WorkspaceSecretForm` | `create-link` | `true` | stay in place |
+| `WorkspaceSecretForm` | `generate-password` | any | `router.push('/receipt/:id')` — always navigates |
+| `IncomingForm` | submit | n/a | `router.push({name:'IncomingSuccess'})` |
+
+`generate-password` in the workspace form always navigates regardless of
+`workspaceMode`.
+
+## Incoming Flow Routes
+
+| Route | Name | Component |
+|---|---|---|
+| `/incoming` | `IncomingSecretForm` | `IncomingForm` |
+| `/incoming/:receiptKey` | `IncomingSuccess` | `IncomingSuccess` |
+
+Submit navigates form → success page. "Create another" on the success page
+navigates back to `IncomingSecretForm`. Page content does not persist across
+either transition — each is a full route swap.
+
+## Consolidation Notes
+
+- Nothing architectural blocks workspace mode on the standard homepage:
+  `HomepageContent` already reads and passes `localReceiptStore.workspaceMode`,
+  and the workspace toggle checkbox already exists in `RecentSecretsTable`.
+- `BrandedHomepage` hardcodes two-page (omits the `workspaceMode` prop) —
+  workspace mode can never activate on custom domains without a change there.
+- A *true* modal+same-page experience (receipt rendered in an overlay over a
+  persisting form) does not exist anywhere today. The Incoming card styling can
+  be reused for the shell, but the modal mechanics would be net-new.
+- `views/incoming/IncomingSecretForm.vue` and `IncomingSuccessView.vue` are
+  orphaned duplicates — no router references them; safe to delete.
+
+## Implementation References
+
+- `localReceiptStore` — `workspaceMode` state and `localStorage` persistence
+- `SecretForm.vue` — homepage form, `onSuccess` nav branch
+- `WorkspaceSecretForm.vue` — dashboard form, `onSuccess` nav branch
+- `useSecretConcealer` — shared submission orchestrator (no routing)
+- `useIncomingSecret` — Incoming orchestration and default navigation
+- `IncomingForm.vue` / `IncomingSuccess.vue` — live Incoming views

--- a/src/apps/secret/components/form/SecretForm.vue
+++ b/src/apps/secret/components/form/SecretForm.vue
@@ -71,6 +71,14 @@
   const passphraseConfig = computed(() => secretOptions.value?.passphrase);
   const isPassphraseRequired = computed(() => passphraseConfig.value?.required || false);
 
+  // Recipient field is shown only when the route opts in (withRecipient) AND the
+  // ui.capabilities.recipient flag is not explicitly disabled. An unset flag
+  // (undefined) is treated as enabled, matching the config default of true.
+  const { uiCapabilities } = storeToRefs(bootstrapStore);
+  const showRecipient = computed(
+    () => props.withRecipient && uiCapabilities.value?.recipient !== false
+  );
+
   // Helper function to get validation errors
   const getError = (field: keyof typeof form) => validation.errors.get(field);
 
@@ -415,7 +423,7 @@
 
           <!-- Recipient Field -->
           <div
-            v-if="props.withRecipient"
+            v-if="showRecipient"
             class="mt-6">
             <h3>
               <label

--- a/src/apps/secret/reveal/ShowReceipt.vue
+++ b/src/apps/secret/reveal/ShowReceipt.vue
@@ -13,6 +13,8 @@
   import TimelineDisplay from '@/apps/secret/components/receipt/TimelineDisplay.vue';
   import { useReceipt } from '@/shared/composables/useReceipt';
   import { useSecretExpiration, EXPIRATION_EVENTS } from '@/shared/composables/useSecretExpiration';
+  import { useBootstrapStore } from '@/shared/stores/bootstrapStore';
+  import { storeToRefs } from 'pinia';
   import { onMounted, onUnmounted, watch, computed, ref } from 'vue';
 
   import UnknownReceipt from './UnknownReceipt.vue';
@@ -37,6 +39,13 @@
   );
 
   const isAvailable = computed(() => !(record.value?.is_destroyed || record.value?.is_burned || record.value?.is_revealed));
+
+  // The receipt-page Burn action is shown unless ui.capabilities.burn is
+  // explicitly disabled. An unset flag (undefined) is treated as enabled,
+  // matching the config default of true.
+  const bootstrapStore = useBootstrapStore();
+  const { uiCapabilities } = storeToRefs(bootstrapStore);
+  const showBurn = computed(() => uiCapabilities.value?.burn !== false);
 
   const goBack = () => {
     window.history.back();
@@ -254,7 +263,7 @@
           <!-- Actions Section with Improved Layout -->
           <!-- prettier-ignore-attribute class -->
           <section
-            v-if="isAvailable"
+            v-if="isAvailable && showBurn"
             class="border-t border-gray-200/60 bg-gray-50 p-4 sm:p-6
             dark:border-gray-700/60 dark:bg-gray-800/30"
             aria-labelledby="section-actions">

--- a/src/apps/secret/routes/receipt.ts
+++ b/src/apps/secret/routes/receipt.ts
@@ -16,6 +16,17 @@ const validateReceiptKey = (key: string | string[]): key is string =>
   typeof key === 'string' && /^[a-zA-Z0-9]+$/.test(key);
 
 /**
+ * Checks if the receipt capability is enabled.
+ * The receipt page is gated unless ui.capabilities.receipt is explicitly
+ * disabled. An unset flag (undefined) is treated as enabled, matching
+ * the config default of true.
+ */
+const isReceiptCapabilityEnabled = (): boolean => {
+  const bootstrapStore = useBootstrapStore();
+  return bootstrapStore.uiCapabilities?.receipt !== false;
+};
+
+/**
  * Shared route configuration for receipt-related routes.
  * Handles validation and type safety for the receiptIdentifier parameter.
  *
@@ -47,6 +58,11 @@ const withValidatedReceiptKey = {
 
     const isValid = validateReceiptKey(to.params.receiptIdentifier);
     if (!isValid) {
+      return { name: 'NotFound' };
+    }
+
+    // Gate the entire page when receipt capability is disabled
+    if (!isReceiptCapabilityEnabled()) {
       return { name: 'NotFound' };
     }
   },

--- a/src/apps/secret/routes/receipt.ts
+++ b/src/apps/secret/routes/receipt.ts
@@ -36,7 +36,17 @@ const isReceiptCapabilityEnabled = (): boolean => {
  */
 const withValidatedReceiptKey = {
   beforeEnter: (to: RouteLocationNormalized) => {
-    // Use bootstrap store for domain strategy
+    // Validate key and check capability before any other work
+    const isValid = validateReceiptKey(to.params.receiptIdentifier);
+    if (!isValid) {
+      return { name: 'NotFound' };
+    }
+
+    if (!isReceiptCapabilityEnabled()) {
+      return { name: 'NotFound' };
+    }
+
+    // Configure layout for custom domains
     const bootstrapStore = useBootstrapStore();
     const domainStrategy = bootstrapStore.domain_strategy as string;
 
@@ -54,16 +64,6 @@ const withValidatedReceiptKey = {
         displayPoweredBy: true,
         displayToggles: true,
       };
-    }
-
-    const isValid = validateReceiptKey(to.params.receiptIdentifier);
-    if (!isValid) {
-      return { name: 'NotFound' };
-    }
-
-    // Gate the entire page when receipt capability is disabled
-    if (!isReceiptCapabilityEnabled()) {
-      return { name: 'NotFound' };
     }
   },
   props: (route: RouteLocationNormalized) => ({

--- a/src/apps/secret/routes/secret.ts
+++ b/src/apps/secret/routes/secret.ts
@@ -2,6 +2,7 @@
 
 import SecretRevealLayout from '@/apps/secret/layouts/SecretRevealLayout.vue';
 import ShowSecretContainer from '@/apps/secret/reveal/ShowSecret.vue';
+import { useBootstrapStore } from '@/shared/stores/bootstrapStore';
 import type { RouteLocationNormalized, RouteRecordRaw } from 'vue-router';
 import { SCOPE_PRESETS } from '@/types/router';
 
@@ -14,11 +15,23 @@ const validateSecretKey = (key: string | string[]): key is string =>
   typeof key === 'string' && /^[a-zA-Z0-9]+$/.test(key);
 
 /**
+ * Checks if the show capability is enabled.
+ * The secret view page is gated unless ui.capabilities.show is explicitly
+ * disabled. An unset flag (undefined) is treated as enabled, matching
+ * the config default of true.
+ */
+const isShowCapabilityEnabled = (): boolean => {
+  const bootstrapStore = useBootstrapStore();
+  return bootstrapStore.uiCapabilities?.show !== false;
+};
+
+/**
  * Shared route configuration for secret-related routes.
  * Handles validation and type safety for the secretIdentifier parameter.
  *
  * - Validates secretIdentifier format in beforeEnter guard
- * - Redirects to Not Found for invalid keys
+ * - Checks ui.capabilities.show is not disabled
+ * - Redirects to Not Found for invalid keys or disabled capability
  * - Provides typed secretIdentifier prop to components
  */
 const withValidatedSecretKey = {
@@ -26,6 +39,11 @@ const withValidatedSecretKey = {
     const isValid = validateSecretKey(to.params.secretIdentifier);
 
     if (!isValid) {
+      return { name: 'NotFound' };
+    }
+
+    // Gate the entire page when show capability is disabled
+    if (!isShowCapabilityEnabled()) {
       return { name: 'NotFound' };
     }
   },

--- a/src/apps/workspace/components/forms/WorkspaceSecretForm.vue
+++ b/src/apps/workspace/components/forms/WorkspaceSecretForm.vue
@@ -193,6 +193,13 @@
   // Track selected action from SplitButton
   const selectedAction = ref<'create-link' | 'generate-password'>('create-link');
 
+  // Recipient field shows in create-link mode unless ui.capabilities.recipient
+  // is explicitly disabled. An unset flag is treated as enabled (config default).
+  const { uiCapabilities } = storeToRefs(bootstrapStore);
+  const showRecipient = computed(
+    () => selectedAction.value === 'create-link' && uiCapabilities.value?.recipient !== false
+  );
+
   // Platform detection for keyboard hint (desktop only)
   const isDesktop = useMediaQuery('(min-width: 640px)');
   const isMac = computed(() =>
@@ -313,7 +320,7 @@
 
           <!-- Recipient Field (create-link mode only) -->
           <div
-            v-if="selectedAction === 'create-link'"
+            v-if="showRecipient"
             class="mt-4">
             <label
               for="workspace-recipient"

--- a/src/shared/stores/bootstrapStore.ts
+++ b/src/shared/stores/bootstrapStore.ts
@@ -6,6 +6,7 @@ import {
   type BootstrapPayload,
   type FooterLinksConfig,
   type HeaderConfig,
+  type UiCapabilities,
 } from '@/schemas/contracts/bootstrap';
 import { defineStore } from 'pinia';
 
@@ -151,6 +152,12 @@ export const useBootstrapStore = defineStore('bootstrap', {
      * Provides typed access to footer config with fallback.
      */
     footerLinksConfig: (state): FooterLinksConfig | undefined => state.ui.footer_links,
+
+    /**
+     * UI capability flags controlling optional form-field visibility.
+     * Each flag is undefined when unset; consumers treat undefined as enabled.
+     */
+    uiCapabilities: (state): UiCapabilities | undefined => state.ui.capabilities,
   },
 
   // ═══════════════════════════════════════════════════════════════════════════

--- a/src/tests/components/SecretFormCapabilities.spec.ts
+++ b/src/tests/components/SecretFormCapabilities.spec.ts
@@ -1,0 +1,102 @@
+// src/tests/components/SecretFormCapabilities.spec.ts
+
+import { mount } from '@vue/test-utils';
+import { createTestingPinia } from '@pinia/testing';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import SecretForm from '@/apps/secret/components/form/SecretForm.vue';
+
+vi.mock('@/shared/composables/useDomainContext', () => ({
+  useDomainContext: vi.fn(() => ({
+    currentContext: { value: { domain: '', displayName: '', isCanonical: true } },
+    isContextActive: { value: false },
+    hasMultipleContexts: { value: false },
+    availableDomains: { value: [] },
+    setContext: vi.fn(),
+    resetContext: vi.fn(),
+  })),
+}));
+
+vi.mock('@/shared/composables/useSecretConcealer', () => ({
+  useSecretConcealer: vi.fn(() => ({
+    form: { secret: '', passphrase: '', ttl: 300, share_domain: '', recipient: '' },
+    validation: { errors: new Map() },
+    operations: { updateField: vi.fn(), reset: vi.fn() },
+    isSubmitting: false,
+    submit: vi.fn(),
+  })),
+}));
+
+vi.mock('@/shared/composables/usePrivacyOptions', () => ({
+  usePrivacyOptions: vi.fn(() => ({
+    state: { passphraseVisibility: false },
+    lifetimeOptions: [{ label: '5 minutes', value: 300 }],
+    updatePassphrase: vi.fn(),
+    updateTtl: vi.fn(),
+    updateRecipient: vi.fn(),
+    togglePassphraseVisibility: vi.fn(),
+  })),
+}));
+
+vi.mock('vue-router', () => ({
+  useRouter: vi.fn(() => ({ push: vi.fn() })),
+}));
+
+vi.mock('vue-i18n', () => ({
+  useI18n: vi.fn(() => ({
+    t: vi.fn((key: string) => key),
+  })),
+}));
+
+const RECIPIENT_TESTID = '[data-testid="secret-recipient-input"]';
+
+const mountForm = (
+  withRecipient: boolean,
+  recipientCapability: boolean | undefined
+) => {
+  const capabilities =
+    recipientCapability === undefined ? {} : { recipient: recipientCapability };
+  return mount(SecretForm, {
+    props: { enabled: true, withRecipient },
+    global: {
+      plugins: [
+        createTestingPinia({
+          createSpy: vi.fn,
+          initialState: {
+            bootstrap: {
+              ui: { capabilities },
+              secret_options: {
+                passphrase: { required: false, minimum_length: 8, enforce_complexity: false },
+              },
+            },
+          },
+        }),
+      ],
+    },
+  });
+};
+
+describe('SecretForm - recipient capability gating', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('hides the recipient field when ui.capabilities.recipient is false', () => {
+    const wrapper = mountForm(true, false);
+    expect(wrapper.find(RECIPIENT_TESTID).exists()).toBe(false);
+  });
+
+  it('shows the recipient field when ui.capabilities.recipient is true', () => {
+    const wrapper = mountForm(true, true);
+    expect(wrapper.find(RECIPIENT_TESTID).exists()).toBe(true);
+  });
+
+  it('shows the recipient field when the capability flag is unset (default enabled)', () => {
+    const wrapper = mountForm(true, undefined);
+    expect(wrapper.find(RECIPIENT_TESTID).exists()).toBe(true);
+  });
+
+  it('keeps the recipient field hidden when withRecipient is false regardless of capability', () => {
+    const wrapper = mountForm(false, true);
+    expect(wrapper.find(RECIPIENT_TESTID).exists()).toBe(false);
+  });
+});

--- a/src/tests/components/ShowReceiptCapabilities.spec.ts
+++ b/src/tests/components/ShowReceiptCapabilities.spec.ts
@@ -1,0 +1,129 @@
+// src/tests/components/ShowReceiptCapabilities.spec.ts
+
+import { mount } from '@vue/test-utils';
+import { createTestingPinia } from '@pinia/testing';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ref } from 'vue';
+import ShowReceipt from '@/apps/secret/reveal/ShowReceipt.vue';
+import BurnButtonForm from '@/apps/secret/components/receipt/BurnButtonForm.vue';
+
+// Default record/details represent an available (not destroyed/burned/revealed)
+// receipt so that `isAvailable` is true and the Burn action section can render.
+// Tests that need an unavailable receipt override the record before mounting.
+const recordRef = ref<Record<string, unknown> | null>(null);
+const detailsRef = ref<Record<string, unknown> | null>(null);
+
+vi.mock('@/shared/composables/useReceipt', () => ({
+  useReceipt: vi.fn(() => ({
+    record: recordRef,
+    details: detailsRef,
+    isLoading: ref(false),
+    passphrase: ref(''),
+    error: ref(null),
+    canBurn: ref(true),
+    fetch: vi.fn(),
+    burn: vi.fn(),
+    reset: vi.fn(),
+  })),
+}));
+
+vi.mock('@/shared/composables/useSecretExpiration', () => ({
+  useSecretExpiration: vi.fn(() => ({
+    onExpirationEvent: vi.fn(),
+  })),
+  EXPIRATION_EVENTS: { EXPIRED: 'expired', WARNING: 'warning' },
+}));
+
+vi.mock('vue-i18n', () => ({
+  useI18n: vi.fn(() => ({
+    t: vi.fn((key: string) => key),
+  })),
+}));
+
+const availableRecord = () => ({
+  key: 'testkey',
+  is_destroyed: false,
+  is_burned: false,
+  is_revealed: false,
+  is_previewed: false,
+});
+
+const burnedRecord = () => ({
+  ...availableRecord(),
+  is_burned: true,
+});
+
+const baseDetails = () => ({
+  show_secret: false,
+  secret_value: null,
+  show_recipients: false,
+  has_passphrase: false,
+});
+
+const mountReceipt = (
+  burnCapability: boolean | undefined,
+  record: Record<string, unknown> = availableRecord()
+) => {
+  recordRef.value = record;
+  detailsRef.value = baseDetails();
+
+  const capabilities =
+    burnCapability === undefined ? {} : { burn: burnCapability };
+
+  return mount(ShowReceipt, {
+    props: { receiptIdentifier: 'testkey' },
+    global: {
+      plugins: [
+        createTestingPinia({
+          createSpy: vi.fn,
+          initialState: {
+            bootstrap: {
+              ui: { capabilities },
+            },
+          },
+        }),
+      ],
+      // Stub child components: BurnButtonForm is kept stubbed (not deep-rendered)
+      // so the test asserts on the gated section rather than the child's own
+      // internals (which call useReceipt and run timers).
+      stubs: {
+        BurnButtonForm: true,
+        SecretLink: true,
+        StatusBadge: true,
+        TimelineDisplay: true,
+        ReceiptFAQ: true,
+        NeedHelpModal: true,
+        OIcon: true,
+        ReceiptSkeleton: true,
+        UnknownReceipt: true,
+        CopyButton: true,
+      },
+    },
+  });
+};
+
+describe('ShowReceipt - burn capability gating', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('hides the Burn action when ui.capabilities.burn is false', () => {
+    const wrapper = mountReceipt(false);
+    expect(wrapper.findComponent(BurnButtonForm).exists()).toBe(false);
+  });
+
+  it('shows the Burn action when ui.capabilities.burn is true', () => {
+    const wrapper = mountReceipt(true);
+    expect(wrapper.findComponent(BurnButtonForm).exists()).toBe(true);
+  });
+
+  it('shows the Burn action when the capability flag is unset (default enabled)', () => {
+    const wrapper = mountReceipt(undefined);
+    expect(wrapper.findComponent(BurnButtonForm).exists()).toBe(true);
+  });
+
+  it('keeps the Burn action hidden for an unavailable receipt regardless of capability', () => {
+    const wrapper = mountReceipt(true, burnedRecord());
+    expect(wrapper.findComponent(BurnButtonForm).exists()).toBe(false);
+  });
+});

--- a/src/tests/components/ShowReceiptRouteCapabilities.spec.ts
+++ b/src/tests/components/ShowReceiptRouteCapabilities.spec.ts
@@ -1,0 +1,97 @@
+// src/tests/components/ShowReceiptRouteCapabilities.spec.ts
+
+import { createTestingPinia } from '@pinia/testing';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { RouteLocationNormalized } from 'vue-router';
+
+// Import the routes to test the beforeEnter guard
+import receiptRoutes from '@/apps/secret/routes/receipt';
+
+/**
+ * Creates a mock route location for testing route guards.
+ */
+const createMockRoute = (receiptIdentifier: string): RouteLocationNormalized => ({
+  params: { receiptIdentifier },
+  path: `/receipt/${receiptIdentifier}`,
+  name: 'Receipt link',
+  matched: [],
+  fullPath: `/receipt/${receiptIdentifier}`,
+  query: {},
+  hash: '',
+  redirectedFrom: undefined,
+  meta: {},
+});
+
+/**
+ * Sets up the testing pinia with the specified receipt capability value.
+ */
+const setupPinia = (receiptCapability: boolean | undefined) => {
+  const capabilities =
+    receiptCapability === undefined ? {} : { receipt: receiptCapability };
+
+  return createTestingPinia({
+    createSpy: vi.fn,
+    initialState: {
+      bootstrap: {
+        ui: { capabilities },
+      },
+    },
+  });
+};
+
+describe('Receipt route - receipt capability gating', () => {
+  const receiptRoute = receiptRoutes[0];
+  const beforeEnter = receiptRoute.beforeEnter as (
+    to: RouteLocationNormalized
+  ) => { name: string } | undefined;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('redirects to NotFound when ui.capabilities.receipt is false', () => {
+    setupPinia(false);
+    const mockRoute = createMockRoute('abc123');
+
+    const result = beforeEnter(mockRoute);
+
+    expect(result).toEqual({ name: 'NotFound' });
+  });
+
+  it('allows navigation when ui.capabilities.receipt is true', () => {
+    setupPinia(true);
+    const mockRoute = createMockRoute('abc123');
+
+    const result = beforeEnter(mockRoute);
+
+    expect(result).toBeUndefined();
+  });
+
+  it('allows navigation when the capability flag is unset (default enabled)', () => {
+    setupPinia(undefined);
+    const mockRoute = createMockRoute('abc123');
+
+    const result = beforeEnter(mockRoute);
+
+    expect(result).toBeUndefined();
+  });
+
+  it('redirects to NotFound for invalid receiptIdentifier regardless of capability', () => {
+    setupPinia(true);
+    const mockRoute = createMockRoute('invalid-key!');
+
+    const result = beforeEnter(mockRoute);
+
+    expect(result).toEqual({ name: 'NotFound' });
+  });
+
+  it('validates receiptIdentifier before checking capability (short-circuits)', () => {
+    // When key is invalid, should redirect without checking capability
+    setupPinia(false);
+    const mockRoute = createMockRoute('');
+
+    const result = beforeEnter(mockRoute);
+
+    expect(result).toEqual({ name: 'NotFound' });
+  });
+});

--- a/src/tests/components/ShowSecretCapabilities.spec.ts
+++ b/src/tests/components/ShowSecretCapabilities.spec.ts
@@ -1,0 +1,97 @@
+// src/tests/components/ShowSecretCapabilities.spec.ts
+
+import { createTestingPinia } from '@pinia/testing';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { RouteLocationNormalized } from 'vue-router';
+
+// Import the routes to test the beforeEnter guard
+import secretRoutes from '@/apps/secret/routes/secret';
+
+/**
+ * Creates a mock route location for testing route guards.
+ */
+const createMockRoute = (secretIdentifier: string): RouteLocationNormalized => ({
+  params: { secretIdentifier },
+  path: `/secret/${secretIdentifier}`,
+  name: 'Secret link',
+  matched: [],
+  fullPath: `/secret/${secretIdentifier}`,
+  query: {},
+  hash: '',
+  redirectedFrom: undefined,
+  meta: {},
+});
+
+/**
+ * Sets up the testing pinia with the specified show capability value.
+ */
+const setupPinia = (showCapability: boolean | undefined) => {
+  const capabilities =
+    showCapability === undefined ? {} : { show: showCapability };
+
+  return createTestingPinia({
+    createSpy: vi.fn,
+    initialState: {
+      bootstrap: {
+        ui: { capabilities },
+      },
+    },
+  });
+};
+
+describe('Secret route - show capability gating', () => {
+  const secretRoute = secretRoutes[0];
+  const beforeEnter = secretRoute.beforeEnter as (
+    to: RouteLocationNormalized
+  ) => { name: string } | undefined;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('redirects to NotFound when ui.capabilities.show is false', () => {
+    setupPinia(false);
+    const mockRoute = createMockRoute('abc123');
+
+    const result = beforeEnter(mockRoute);
+
+    expect(result).toEqual({ name: 'NotFound' });
+  });
+
+  it('allows navigation when ui.capabilities.show is true', () => {
+    setupPinia(true);
+    const mockRoute = createMockRoute('abc123');
+
+    const result = beforeEnter(mockRoute);
+
+    expect(result).toBeUndefined();
+  });
+
+  it('allows navigation when the capability flag is unset (default enabled)', () => {
+    setupPinia(undefined);
+    const mockRoute = createMockRoute('abc123');
+
+    const result = beforeEnter(mockRoute);
+
+    expect(result).toBeUndefined();
+  });
+
+  it('redirects to NotFound for invalid secretIdentifier regardless of capability', () => {
+    setupPinia(true);
+    const mockRoute = createMockRoute('invalid-key!');
+
+    const result = beforeEnter(mockRoute);
+
+    expect(result).toEqual({ name: 'NotFound' });
+  });
+
+  it('validates secretIdentifier before checking capability (short-circuits)', () => {
+    // When key is invalid, should redirect without checking capability
+    setupPinia(false);
+    const mockRoute = createMockRoute('');
+
+    const result = beforeEnter(mockRoute);
+
+    expect(result).toEqual({ name: 'NotFound' });
+  });
+});

--- a/src/tests/components/WorkspaceSecretFormCapabilities.spec.ts
+++ b/src/tests/components/WorkspaceSecretFormCapabilities.spec.ts
@@ -1,0 +1,98 @@
+// src/tests/components/WorkspaceSecretFormCapabilities.spec.ts
+
+import { mount } from '@vue/test-utils';
+import { createTestingPinia } from '@pinia/testing';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ref } from 'vue';
+import WorkspaceSecretForm from '@/apps/workspace/components/forms/WorkspaceSecretForm.vue';
+
+vi.mock('@/shared/composables/useDomainContext', () => ({
+  useDomainContext: vi.fn(() => ({
+    currentContext: { value: { domain: '', displayName: '', isCanonical: true } },
+    isContextActive: { value: false },
+  })),
+}));
+
+vi.mock('@/shared/composables/useSecretConcealer', () => ({
+  useSecretConcealer: vi.fn(() => ({
+    form: { secret: '', passphrase: '', ttl: 604800, share_domain: '', recipient: '' },
+    validation: { errors: new Map() },
+    operations: { updateField: vi.fn(), reset: vi.fn() },
+    isSubmitting: false,
+    submit: vi.fn(),
+  })),
+}));
+
+vi.mock('@/shared/composables/useCharCounter', () => ({
+  useCharCounter: vi.fn(() => ({
+    isHovering: ref(false),
+    formatNumber: (n: number) => String(n),
+  })),
+}));
+
+vi.mock('@/shared/composables/useTextarea', () => ({
+  useTextarea: vi.fn(() => ({
+    content: ref(''),
+    charCount: ref(0),
+    textareaRef: ref(null),
+    checkContentLength: vi.fn(),
+    clearTextarea: vi.fn(),
+  })),
+}));
+
+vi.mock('@/services/logging.service', () => ({
+  loggingService: { debug: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('vue-router', () => ({
+  useRouter: vi.fn(() => ({ push: vi.fn() })),
+}));
+
+vi.mock('vue-i18n', () => ({
+  useI18n: vi.fn(() => ({
+    t: vi.fn((key: string) => key),
+  })),
+}));
+
+const RECIPIENT_SELECTOR = '#workspace-recipient';
+
+const mountForm = (recipientCapability: boolean | undefined) => {
+  const capabilities =
+    recipientCapability === undefined ? {} : { recipient: recipientCapability };
+  return mount(WorkspaceSecretForm, {
+    global: {
+      plugins: [
+        createTestingPinia({
+          createSpy: vi.fn,
+          initialState: {
+            bootstrap: {
+              ui: { capabilities },
+              secret_options: { default_ttl: 604800 },
+            },
+          },
+        }),
+      ],
+    },
+  });
+};
+
+describe('WorkspaceSecretForm - recipient capability gating', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('hides the recipient field when ui.capabilities.recipient is false', () => {
+    const wrapper = mountForm(false);
+    expect(wrapper.find(RECIPIENT_SELECTOR).exists()).toBe(false);
+  });
+
+  it('shows the recipient field when ui.capabilities.recipient is true', () => {
+    const wrapper = mountForm(true);
+    expect(wrapper.find(RECIPIENT_SELECTOR).exists()).toBe(true);
+  });
+
+  it('shows the recipient field when the capability flag is unset (default enabled)', () => {
+    const wrapper = mountForm(undefined);
+    expect(wrapper.find(RECIPIENT_SELECTOR).exists()).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Completes the wiring of `ui.capabilities.*` flags from config to UI components. These flags were validated and shipped to the client but never consumed — setting `UI_CAPABILITIES_RECIPIENT=false` had no visible effect.

**Capabilities wired:**
- `recipient` — gates the recipient email field on secret creation forms (`SecretForm.vue`, `WorkspaceSecretForm.vue`)
- `burn` — gates the Burn action on the receipt page (`ShowReceipt.vue`)
- `show` — gates the entire secret-view route (`/secret/:secretIdentifier`)
- `receipt` — gates the entire receipt route (`/receipt/:receiptIdentifier`)

**Implementation pattern:**
- Element-level (`recipient`, `burn`): computed prop reads `bootstrapStore.uiCapabilities`, uses `!== false` semantics
- Page-level (`show`, `receipt`): route guard in `beforeEnter`, redirects to NotFound when disabled

Closes #3178

## Test plan

- [x] Set `UI_CAPABILITIES_RECIPIENT=false`, verify recipient field hidden on dashboard secret form
- [x] Set `UI_CAPABILITIES_BURN=false`, verify Burn action hidden on receipt page
- [x] Set `UI_CAPABILITIES_SHOW=false`, verify `/secret/:id` routes redirect to 404
- [x] Set `UI_CAPABILITIES_RECEIPT=false`, verify `/receipt/:id` routes redirect to 404
- [x] Verify all capabilities default to enabled when unset
- [ ] `pnpm vitest run src/tests/components/*Capabilities*.spec.ts` — 21 tests pass