### PR TITLE
Consolidate entitlement resolution: cleanup gaps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -697,7 +697,7 @@ jobs:
       - name: Build Container image
         uses: docker/bake-action@5be5f02ff8819ecd3092ea6b2e6261c31774f2b4 # v6.10.0
         with:
-          source: .  # Use local checkout instead of fetching git URL (avoids PR merge ref issues)
+          source: . # Use local checkout instead of fetching git URL (avoids PR merge ref issues)
           files: docker/bake.hcl
           targets: main
           load: true
@@ -844,9 +844,9 @@ jobs:
           echo "| Ruby Integration (Disabled) | ${{ needs.ruby-integration-disabled.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Container Validation | ${{ needs.check-oci-image.result }} |" >> $GITHUB_STEP_SUMMARY
 
-      # Post CI metrics summary as PR comment (PRs only)
+      # Post CI metrics summary as PR comment (PRs only, skip forks - no write access)
       - name: Post metrics to PR
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork
         uses: actions/github-script@v7
         with:
           github-token: ${{ github.token }}

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -21,7 +21,7 @@
 name: PR Labeler
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened]
 
 jobs:
@@ -34,6 +34,6 @@ jobs:
     steps:
       - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
         with:
-          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          repo-token: '${{ secrets.GITHUB_TOKEN }}'
           configuration-path: .github/labeler.yml
           sync-labels: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -539,7 +539,7 @@ GEM
       prettier_print (>= 1.2.0)
     thor (1.5.0)
     tilt (2.7.0)
-    timecop (0.9.10)
+    timecop (0.9.11)
     timeout (0.6.1)
     tpm-key_attestation (0.14.1)
       bindata (~> 2.4)

--- a/apps/web/billing/errors.rb
+++ b/apps/web/billing/errors.rb
@@ -44,6 +44,29 @@ module Billing
     end
   end
 
+  # InvalidPlanMetadataError - Raised when subscription metadata carries a
+  # malformed canonical plan_id.
+  #
+  # The federated subscription path reads the plan_id from Stripe subscription
+  # metadata (cross-region price IDs aren't in the local catalog). Unlike the
+  # owner path, that value is not catalog-validated, so a typo or stale value
+  # would otherwise be written straight onto org.planid.
+  #
+  # Fail-closed behavior: we raise rather than assigning a malformed plan_id,
+  # which would corrupt entitlement resolution downstream. This mirrors the
+  # owner path's CatalogMissError fail-closed semantics.
+  #
+  class InvalidPlanMetadataError < OpsProblem
+    attr_reader :plan_id, :context
+
+    def initialize(message = nil, plan_id: nil, context: nil)
+      @plan_id   = plan_id
+      @context   = context
+      message  ||= "Malformed canonical plan_id in subscription metadata: #{plan_id.inspect}"
+      super(message)
+    end
+  end
+
   # CatalogValidationError - Raised when Stripe products fail metadata validation
   #
   # This error indicates managed products (app=onetimesecret) have invalid or

--- a/apps/web/billing/operations/apply_subscription_to_org.rb
+++ b/apps/web/billing/operations/apply_subscription_to_org.rb
@@ -343,9 +343,9 @@ module Billing
       def federated_plan_id(raw)
         # Absent metadata is not an error here: @org.planid is left unchanged
         # (the `if plan_id` guard in apply_plan_id), preserving prior state.
-        return nil if raw.nil? || raw.to_s.strip.empty?
+        plan_id = raw.to_s.strip
+        return nil if plan_id.empty?
 
-        plan_id = raw.to_s
         return plan_id if Billing::PlanResolver.canonical_plan_id?(plan_id)
 
         raise Billing::InvalidPlanMetadataError.new(

--- a/apps/web/billing/operations/apply_subscription_to_org.rb
+++ b/apps/web/billing/operations/apply_subscription_to_org.rb
@@ -2,8 +2,10 @@
 #
 # frozen_string_literal: true
 
+require_relative '../errors'
 require_relative '../metadata'
 require_relative '../lib/plan_validator'
+require_relative '../lib/plan_resolver'
 
 module Billing
   module Operations
@@ -317,10 +319,39 @@ module Billing
                     # Federated path: read canonical plan_id directly from metadata
                     # Cross-region price IDs aren't in the local catalog, so we can't
                     # use catalog lookup. Metadata contains the canonical family ID.
-                    @subscription.metadata[Billing::Metadata::FIELD_PLAN_ID]
+                    federated_plan_id(@subscription.metadata[Billing::Metadata::FIELD_PLAN_ID])
                   end
 
         @org.planid = plan_id if plan_id
+      end
+
+      # Validate and return the federated plan_id from subscription metadata.
+      #
+      # The federated path cannot catalog-validate (cross-region price IDs
+      # aren't in the local catalog), but the stored value is the universal
+      # canonical family ID (e.g., 'identity_plus_v1'). We validate its
+      # *shape* against PlanResolver::CANONICAL_PLAN_ID_PATTERN — this rejects
+      # typos, interval-suffixed IDs, and uppercase without requiring local
+      # catalog membership (which would break federation by design).
+      #
+      # Fail-closed: a malformed value raises rather than corrupting
+      # org.planid, mirroring the owner path's CatalogMissError behavior.
+      #
+      # @param raw [String, nil] plan_id from subscription metadata
+      # @return [String, nil] the validated plan_id, or nil if metadata absent
+      # @raise [Billing::InvalidPlanMetadataError] If the value is malformed
+      def federated_plan_id(raw)
+        # Absent metadata is not an error here: @org.planid is left unchanged
+        # (the `if plan_id` guard in apply_plan_id), preserving prior state.
+        return nil if raw.nil? || raw.to_s.strip.empty?
+
+        plan_id = raw.to_s
+        return plan_id if Billing::PlanResolver.canonical_plan_id?(plan_id)
+
+        raise Billing::InvalidPlanMetadataError.new(
+          plan_id: plan_id,
+          context: 'ApplySubscriptionToOrg#apply_plan_id (federated)',
+        )
       end
 
       # Cache Stripe's complimentary marker locally (Stripe → org, never reverse)

--- a/apps/web/billing/spec/operations/apply_subscription_to_org_spec.rb
+++ b/apps/web/billing/spec/operations/apply_subscription_to_org_spec.rb
@@ -215,6 +215,53 @@ RSpec.describe Billing::Operations::ApplySubscriptionToOrg, billing: true do
 
       described_class.call(org, subscription, owner: false)
     end
+
+    it 'raises InvalidPlanMetadataError for a malformed federated plan_id' do
+      # Interval-suffixed value is not a canonical family ID and must be rejected
+      # before it is written onto org.planid.
+      subscription = Stripe::Subscription.construct_from({
+        id: 'sub_test_bad_meta',
+        object: 'subscription',
+        customer: 'cus_test_456',
+        status: 'active',
+        metadata: { 'plan_id' => 'identity_plus_v1_monthly' },
+        items: {
+          data: [{
+            price: { id: 'price_eu_region', product: 'prod_test', metadata: {} },
+            current_period_end: period_end,
+          }],
+        },
+      })
+
+      expect(org).not_to receive(:planid=)
+      expect(org).not_to receive(:save)
+
+      expect {
+        described_class.call(org, subscription, owner: false)
+      }.to raise_error(Billing::InvalidPlanMetadataError, /identity_plus_v1_monthly/)
+    end
+
+    it 'raises InvalidPlanMetadataError for a non-canonical (uppercase) plan_id' do
+      subscription = Stripe::Subscription.construct_from({
+        id: 'sub_test_upper_meta',
+        object: 'subscription',
+        customer: 'cus_test_456',
+        status: 'active',
+        metadata: { 'plan_id' => 'Identity_Plus_V1' },
+        items: {
+          data: [{
+            price: { id: 'price_eu_region', product: 'prod_test', metadata: {} },
+            current_period_end: period_end,
+          }],
+        },
+      })
+
+      expect(org).not_to receive(:planid=)
+
+      expect {
+        described_class.call(org, subscription, owner: false)
+      }.to raise_error(Billing::InvalidPlanMetadataError)
+    end
   end
 
   describe 'planid_override' do

--- a/package.json
+++ b/package.json
@@ -218,7 +218,7 @@
     "jsdom": "^27.4.0",
     "lint-staged": "^16.4.0",
     "playwright": "^1.58.2",
-    "postcss": "^8.5.8",
+    "postcss": "^8.5.10",
     "prettier": "^3.8.1",
     "prettier-plugin-tailwindcss": "^0.7.2",
     "prettier-plugin-vue": "^1.1.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -261,7 +261,7 @@ importers:
         specifier: ^1.58.2
         version: 1.58.2
       postcss:
-        specifier: ^8.5.8
+        specifier: ^8.5.10
         version: 8.5.10
       prettier:
         specifier: ^3.8.1

--- a/src/apps/colonel/views/ColonelOrganizations.vue
+++ b/src/apps/colonel/views/ColonelOrganizations.vue
@@ -18,6 +18,7 @@
     ColonelOrganization,
     InvestigateOrganizationResult,
   } from '@/schemas/api/account/responses/colonel';
+  import { getPlanLabel } from '@/types/billing';
   import { formatDisplayDateTime } from '@/utils/format';
   import { storeToRefs } from 'pinia';
   import { computed, onMounted, ref } from 'vue';
@@ -206,14 +207,10 @@
     return org.contact_email || org.extid;
   }
 
-  // Format plan ID for display (strip common suffixes)
+  // Resolve plan ID to a human-readable display name
   function formatPlanId(planid: string | null): string {
-    if (!planid) return 'free';
-    // Remove common suffixes for cleaner display
-    return planid
-      .replace(/_monthly$/, '')
-      .replace(/_yearly$/, '')
-      .replace(/_v\d+$/, '');
+    if (!planid) return getPlanLabel('free');
+    return getPlanLabel(planid);
   }
 
   const totalOrganizations = computed(() => organizationsPagination.value?.total_count || 0);

--- a/src/apps/workspace/account/settings/OrganizationSettings.vue
+++ b/src/apps/workspace/account/settings/OrganizationSettings.vue
@@ -20,7 +20,7 @@ import { useOrganizationStore } from '@/shared/stores/organizationStore';
 import { storeToRefs } from 'pinia';
 import { useMembersStore } from '@/shared/stores/membersStore';
 import type { Subscription } from '@/types/billing';
-import { getPlanDisplayName, getPlanLabel, getSubscriptionStatusLabel, isLegacyPlan } from '@/types/billing';
+import { getPlanLabel, getSubscriptionStatusLabel, isLegacyPlan } from '@/types/billing';
 import type { CreateInvitationPayload, Organization, OrganizationInvitation } from '@/types/organization';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars -- used in template
 import { formatDisplayDate } from '@/utils/format';
@@ -623,7 +623,7 @@ const handleTabKeydown = (e: KeyboardEvent) => {
             name="credit-card"
             class="size-3.5"
             aria-hidden="true" />
-          {{ organization.planid ? getPlanDisplayName(organization.planid) : t('web.billing.plans.free_plan') }}
+          {{ organization.planid ? getPlanLabel(organization.planid) : t('web.billing.plans.free_plan') }}
         </router-link>
       </div>
 

--- a/src/apps/workspace/account/settings/OrganizationsSettings.vue
+++ b/src/apps/workspace/account/settings/OrganizationsSettings.vue
@@ -13,7 +13,7 @@
   import { useBootstrapStore } from '@/shared/stores/bootstrapStore';
   import { useOrganizationStore } from '@/shared/stores/organizationStore';
   import type { Organization } from '@/types/organization';
-  import { getPlanDisplayName, isLegacyPlan } from '@/types/billing';
+  import { getPlanLabel, isLegacyPlan } from '@/types/billing';
   import { computed, onMounted, ref } from 'vue';
   import { useRouter } from 'vue-router';
 
@@ -44,7 +44,7 @@
    */
   const getOrgPlanName = (org: Organization): string => {
     if (!org.planid) return t('web.billing.plans.free_plan');
-    return getPlanDisplayName(org.planid);
+    return getPlanLabel(org.planid);
   };
 
   // Use the first organization to check entitlements for single-org users

--- a/src/apps/workspace/billing/BillingOverview.vue
+++ b/src/apps/workspace/billing/BillingOverview.vue
@@ -12,7 +12,7 @@ import { classifyError } from '@/schemas/errors';
 import { BillingService, type FederationNotification as FederationNotificationData } from '@/services/billing.service';
 import { useOrganizationStore } from '@/shared/stores/organizationStore';
 import type { PaymentMethod } from '@/types/billing';
-import { getPlanDisplayName, isLegacyPlan } from '@/types/billing';
+import { getPlanLabel, isLegacyPlan } from '@/types/billing';
 import type { Organization } from '@/types/organization';
 import { formatDisplayDate } from '@/utils/format';
 import { computed, onMounted, ref, watch } from 'vue';
@@ -56,7 +56,7 @@ const {
 
 const planName = computed(() => {
   if (!selectedOrg.value?.planid) return t('web.billing.plans.free_plan');
-  return getPlanDisplayName(selectedOrg.value.planid);
+  return getPlanLabel(selectedOrg.value.planid);
 });
 
 const planStatus = computed(() => selectedOrg.value?.planid ? 'active' : 'free');

--- a/src/apps/workspace/billing/PlanSelector.vue
+++ b/src/apps/workspace/billing/PlanSelector.vue
@@ -17,7 +17,7 @@ import type { CurrencyConflictError } from '@/schemas/shapes/account/billing';
 import { BillingService, extractCurrencyConflict, type Plan as BillingPlan, type SubscriptionStatusResponse } from '@/services/billing.service';
 import { useOrganizationStore } from '@/shared/stores/organizationStore';
 import type { BillingInterval } from '@/types/billing';
-import { isLegacyPlan, getPlanDisplayName } from '@/types/billing';
+import { isLegacyPlan, getPlanLabel } from '@/types/billing';
 import type { Organization } from '@/types/organization';
 import { formatDisplayDate } from '@/utils/format';
 import { computed, onMounted, ref } from 'vue';
@@ -133,7 +133,7 @@ const isLegacyCustomer = computed(() =>
 
 // Get display name for current plan (handles legacy naming)
 const currentPlanDisplayName = computed(() =>
-  selectedOrg.value?.planid ? getPlanDisplayName(selectedOrg.value.planid) : null
+  selectedOrg.value?.planid ? getPlanLabel(selectedOrg.value.planid) : null
 );
 
 // Filter plans by selected billing interval

--- a/src/schemas/contracts/billing.ts
+++ b/src/schemas/contracts/billing.ts
@@ -99,25 +99,6 @@ export const invoiceContractSchema = z.object({
 export type InvoiceContract = z.infer<typeof invoiceContractSchema>;
 
 /**
- * Plan schema
- *
- * Validates plan definition data.
- */
-export const planSchema = z.object({
-  id: z.string(),
-  type: planTypeSchema,
-  name: z.string(),
-  description: z.string(),
-  price_monthly: z.number(),
-  price_yearly: z.number(),
-  teams_limit: z.number(),
-  members_per_team_limit: z.number(),
-  features: z.array(z.string()),
-});
-
-export type Plan = z.infer<typeof planSchema>;
-
-/**
  * Payment method card schema
  */
 export const paymentMethodCardSchema = z.object({

--- a/src/tests/apps/workspace/billing/BillingOverview.spec.ts
+++ b/src/tests/apps/workspace/billing/BillingOverview.spec.ts
@@ -76,7 +76,7 @@ vi.mock('@/schemas/errors', () => ({
   classifyError: (err: unknown) => ({ message: err instanceof Error ? err.message : 'Unknown error' }),
 }));
 vi.mock('@/types/billing', () => ({
-  getPlanDisplayName: (id: string) => {
+  getPlanLabel: (id: string) => {
     const names: Record<string, string> = {
       identity_plus_v1: 'Identity Plus',
       identity: 'Identity Plus (Early Supporter)',

--- a/src/tests/types/billing-helpers.spec.ts
+++ b/src/tests/types/billing-helpers.spec.ts
@@ -125,27 +125,24 @@ describe('getSubscriptionStatusLabel', () => {
 });
 
 describe('getPlanLabel', () => {
-  it('returns "Free" for free plan', () => {
-    expect(getPlanLabel('free')).toBe('Free');
+  it('returns "Free" for free_v1 plan ID', () => {
+    expect(getPlanLabel('free_v1')).toBe('Free');
   });
 
-  it('returns "Single Team" for single_team', () => {
-    expect(getPlanLabel('single_team')).toBe('Single Team');
+  it('returns "Identity Plus" for identity_plus_v1 plan ID', () => {
+    expect(getPlanLabel('identity_plus_v1')).toBe('Identity Plus');
   });
 
-  it('returns "Multi Team" for multi_team', () => {
-    expect(getPlanLabel('multi_team')).toBe('Multi Team');
+  it('returns "Team Plus" for team_plus_v1 plan ID', () => {
+    expect(getPlanLabel('team_plus_v1')).toBe('Team Plus');
   });
 
-  it('returns "Identity Plus" for identity_plus', () => {
-    expect(getPlanLabel('identity_plus')).toBe('Identity Plus');
+  it('returns "Identity Plus (Early Supporter)" for legacy identity plan', () => {
+    expect(getPlanLabel('identity')).toBe('Identity Plus (Early Supporter)');
   });
 
-  it('returns "Team Plus" for team_plus', () => {
-    expect(getPlanLabel('team_plus')).toBe('Team Plus');
-  });
-
-  it('falls back to Title Case for unknown plan types', () => {
-    expect(getPlanLabel('custom_plan')).toBe('Custom Plan');
+  it('returns input unchanged for unmapped values', () => {
+    expect(getPlanLabel('custom_plan')).toBe('custom_plan');
+    expect(getPlanLabel('single_team')).toBe('single_team');
   });
 });

--- a/src/tests/types/billing-legacy.spec.ts
+++ b/src/tests/types/billing-legacy.spec.ts
@@ -6,7 +6,7 @@
  * These tests cover the new legacy plan handling functionality:
  * - isLegacyPlan() - detects grandfathered plans
  * - getLegacyPlanInfo() - returns legacy plan metadata
- * - getPlanDisplayName() - displays legacy plans with special suffix
+ * - getPlanLabel() - displays legacy plans with special suffix
  *
  * Legacy plans are grandfathered plans no longer available for new subscriptions
  * but honored for existing customers (e.g., 'identity' -> 'Identity Plus (Early Supporter)')
@@ -16,7 +16,7 @@ import { describe, it, expect } from 'vitest';
 import {
   isLegacyPlan,
   getLegacyPlanInfo,
-  getPlanDisplayName,
+  getPlanLabel,
 } from '@/types/billing';
 
 describe('Legacy Plan Utilities', () => {
@@ -133,79 +133,55 @@ describe('Legacy Plan Utilities', () => {
   });
 
   // ============================================================
-  // getPlanDisplayName() Tests
+  // getPlanLabel() Tests
   // ============================================================
-  describe('getPlanDisplayName()', () => {
+  describe('getPlanLabel()', () => {
     describe('legacy plan display names', () => {
       it('"identity" returns "Identity Plus (Early Supporter)"', () => {
-        expect(getPlanDisplayName('identity')).toBe('Identity Plus (Early Supporter)');
+        expect(getPlanLabel('identity')).toBe('Identity Plus (Early Supporter)');
       });
     });
 
-    describe('current plan display names (existing behavior preserved)', () => {
+    describe('canonical plan ID display names', () => {
       it('"identity_plus_v1" returns "Identity Plus"', () => {
-        expect(getPlanDisplayName('identity_plus_v1')).toBe('Identity Plus');
+        expect(getPlanLabel('identity_plus_v1')).toBe('Identity Plus');
       });
 
       it('"free_v1" returns "Free"', () => {
-        expect(getPlanDisplayName('free_v1')).toBe('Free');
+        expect(getPlanLabel('free_v1')).toBe('Free');
       });
 
       it('"free" returns "Free"', () => {
-        expect(getPlanDisplayName('free')).toBe('Free');
+        expect(getPlanLabel('free')).toBe('Free');
       });
 
       it('"team_plus_v1" returns "Team Plus"', () => {
-        expect(getPlanDisplayName('team_plus_v1')).toBe('Team Plus');
+        expect(getPlanLabel('team_plus_v1')).toBe('Team Plus');
       });
 
-      it('"multi_team_v1" returns "Team Plus"', () => {
-        expect(getPlanDisplayName('multi_team_v1')).toBe('Team Plus');
+      it('"legacy_plan_v1" returns "Legacy Plan"', () => {
+        expect(getPlanLabel('legacy_plan_v1')).toBe('Legacy Plan');
+      });
+    });
+
+    describe('billing tier display names', () => {
+      it('"identity_plus" tier returns "Identity Plus"', () => {
+        expect(getPlanLabel('identity_plus')).toBe('Identity Plus');
       });
 
-      it('"single_team_v1" returns "Single Team"', () => {
-        expect(getPlanDisplayName('single_team_v1')).toBe('Single Team');
+      it('"team_plus" tier returns "Team Plus"', () => {
+        expect(getPlanLabel('team_plus')).toBe('Team Plus');
+      });
+
+      it('"single_team" tier returns "Single Team"', () => {
+        expect(getPlanLabel('single_team')).toBe('Single Team');
       });
     });
 
     describe('edge cases', () => {
-      it('empty string returns "Free"', () => {
-        expect(getPlanDisplayName('')).toBe('Free');
-      });
-
-      it('null returns "Free"', () => {
-        // getPlanDisplayName handles null/undefined gracefully
-        expect(getPlanDisplayName(null as unknown as string)).toBe('Free');
-      });
-
-      it('undefined returns "Free"', () => {
-        // getPlanDisplayName handles null/undefined gracefully
-        expect(getPlanDisplayName(undefined as unknown as string)).toBe('Free');
-      });
-
       it('unknown plan falls back to Title Case conversion', () => {
-        // Should strip version suffix and convert to Title Case
-        // Plan IDs are now family-keyed without interval suffix
-        expect(getPlanDisplayName('some_plan_v1')).toBe('Some Plan');
-        expect(getPlanDisplayName('custom_enterprise_v2')).toBe('Custom Enterprise');
-      });
-    });
-
-    describe('pattern matching order', () => {
-      // Verifies that more specific patterns match before general ones
-      it('"identity_plus" matches before "identity"', () => {
-        expect(getPlanDisplayName('identity_plus_v1')).toBe('Identity Plus');
-        expect(getPlanDisplayName('identity_plus_v2')).toBe('Identity Plus');
-      });
-
-      it('"identity" exact match shows Early Supporter suffix', () => {
-        // Only exact 'identity' should get the Early Supporter treatment
-        expect(getPlanDisplayName('identity')).toBe('Identity Plus (Early Supporter)');
-      });
-
-      it('free pattern takes precedence', () => {
-        expect(getPlanDisplayName('free_v1')).toBe('Free');
-        expect(getPlanDisplayName('free_v2')).toBe('Free');
+        expect(getPlanLabel('some_plan')).toBe('Some Plan');
+        expect(getPlanLabel('custom_enterprise')).toBe('Custom Enterprise');
       });
     });
   });
@@ -397,19 +373,19 @@ describe('OrganizationsSettings Badge Logic', () => {
 
   describe('Plan display name for organization cards', () => {
     it('legacy "identity" shows "Identity Plus (Early Supporter)"', () => {
-      const displayName = getPlanDisplayName('identity');
+      const displayName = getPlanLabel('identity');
       expect(displayName).toBe('Identity Plus (Early Supporter)');
       expect(displayName).toContain('Early Supporter');
     });
 
     it('current "identity_plus_v1" shows "Identity Plus" (no suffix)', () => {
-      const displayName = getPlanDisplayName('identity_plus_v1');
+      const displayName = getPlanLabel('identity_plus_v1');
       expect(displayName).toBe('Identity Plus');
       expect(displayName).not.toContain('Early Supporter');
     });
 
     it('free plan shows "Free"', () => {
-      expect(getPlanDisplayName('free_v1')).toBe('Free');
+      expect(getPlanLabel('free_v1')).toBe('Free');
     });
   });
 

--- a/src/tests/types/billing-legacy.spec.ts
+++ b/src/tests/types/billing-legacy.spec.ts
@@ -151,10 +151,6 @@ describe('Legacy Plan Utilities', () => {
         expect(getPlanLabel('free_v1')).toBe('Free');
       });
 
-      it('"free" returns "Free"', () => {
-        expect(getPlanLabel('free')).toBe('Free');
-      });
-
       it('"team_plus_v1" returns "Team Plus"', () => {
         expect(getPlanLabel('team_plus_v1')).toBe('Team Plus');
       });
@@ -164,24 +160,15 @@ describe('Legacy Plan Utilities', () => {
       });
     });
 
-    describe('billing tier display names', () => {
-      it('"identity_plus" tier returns "Identity Plus"', () => {
-        expect(getPlanLabel('identity_plus')).toBe('Identity Plus');
+    describe('unmapped values', () => {
+      it('returns input unchanged for unmapped plan IDs', () => {
+        expect(getPlanLabel('some_plan')).toBe('some_plan');
+        expect(getPlanLabel('custom_enterprise')).toBe('custom_enterprise');
       });
 
-      it('"team_plus" tier returns "Team Plus"', () => {
-        expect(getPlanLabel('team_plus')).toBe('Team Plus');
-      });
-
-      it('"single_team" tier returns "Single Team"', () => {
-        expect(getPlanLabel('single_team')).toBe('Single Team');
-      });
-    });
-
-    describe('edge cases', () => {
-      it('unknown plan falls back to Title Case conversion', () => {
-        expect(getPlanLabel('some_plan')).toBe('Some Plan');
-        expect(getPlanLabel('custom_enterprise')).toBe('Custom Enterprise');
+      it('returns input unchanged for tier keys (tiers are metadata, not for selection)', () => {
+        expect(getPlanLabel('single_team')).toBe('single_team');
+        expect(getPlanLabel('multi_team')).toBe('multi_team');
       });
     });
   });

--- a/src/types/billing.ts
+++ b/src/types/billing.ts
@@ -74,40 +74,31 @@ import type { InvoiceStatus, PlanType, SubscriptionStatus } from '@/schemas/shap
 import type { ComposerTranslation } from 'vue-i18n';
 
 /**
- * Resolve a plan tier or canonical plan ID to a human-readable display name.
+ * Canonical plan ID to human-readable display name mapping.
  *
- * Accepts both billing tier keys (`free`, `single_team`, `multi_team`,
- * `identity_plus`, `team_plus`) and canonical plan IDs (`free_v1`,
- * `identity_plus_v1`, `team_plus_v1`, ...), plus the legacy `identity`
- * plan. Lookup is an explicit map — no string parsing of plan identity.
+ * Plan IDs are the canonical identifiers (e.g., `identity_plus_v1`).
+ * Billing tiers (`free`, `single_account`, `single_team`, `multi_team`)
+ * are descriptive metadata, not used for selection.
+ */
+const PLAN_LABELS: Record<string, string> = {
+  // Canonical plan IDs
+  free_v1: 'Free',
+  identity_plus_v1: 'Identity Plus',
+  team_plus_v1: 'Team Plus',
+  legacy_plan_v1: 'Legacy Plan',
+  // Legacy/grandfathered identifiers
+  identity: 'Identity Plus (Early Supporter)',
+  free: 'Free', // null-planid fallback in admin views
+};
+
+/**
+ * Resolve a canonical plan ID to a human-readable display name.
  *
- * @param planType - A billing tier key or canonical plan ID
- * @returns A human-readable display name
+ * @param planType - A canonical plan ID (e.g., `identity_plus_v1`)
+ * @returns The display name, or the plan ID unchanged if not mapped
  */
 export function getPlanLabel(planType: PlanType | string): string {
-  const labels: Record<string, string> = {
-    // Billing tier keys
-    free: 'Free',
-    single_team: 'Single Team',
-    multi_team: 'Multi Team',
-    identity_plus: 'Identity Plus',
-    team_plus: 'Team Plus',
-    // Canonical plan IDs
-    free_v1: 'Free',
-    identity_plus_v1: 'Identity Plus',
-    team_plus_v1: 'Team Plus',
-    legacy_plan_v1: 'Legacy Plan',
-    // Legacy/grandfathered plan
-    identity: 'Identity Plus (Early Supporter)',
-  };
-
-  // Direct match
-  if (labels[planType]) {
-    return labels[planType];
-  }
-
-  // Fallback: convert snake_case to Title Case
-  return planType.replace(/_/g, ' ').replace(/\b\w/g, (c: string) => c.toUpperCase());
+  return PLAN_LABELS[planType] ?? planType;
 }
 
 export function getSubscriptionStatusLabel(

--- a/src/types/billing.ts
+++ b/src/types/billing.ts
@@ -15,7 +15,6 @@ export {
   invoiceStatusSchema,
   paymentMethodCardSchema,
   paymentMethodSchema,
-  planSchema,
   planTypeSchema,
   subscriptionSchema,
   subscriptionStatusSchema,
@@ -25,7 +24,6 @@ export {
   type InvoiceStatus,
   type PaymentMethod,
   type PaymentMethodCard,
-  type Plan,
   type PlanType,
   type Subscription,
   type SubscriptionStatus,
@@ -75,14 +73,32 @@ export function getLegacyPlanInfo(
 import type { InvoiceStatus, PlanType, SubscriptionStatus } from '@/schemas/shapes/account/billing';
 import type { ComposerTranslation } from 'vue-i18n';
 
+/**
+ * Resolve a plan tier or canonical plan ID to a human-readable display name.
+ *
+ * Accepts both billing tier keys (`free`, `single_team`, `multi_team`,
+ * `identity_plus`, `team_plus`) and canonical plan IDs (`free_v1`,
+ * `identity_plus_v1`, `team_plus_v1`, ...), plus the legacy `identity`
+ * plan. Lookup is an explicit map — no string parsing of plan identity.
+ *
+ * @param planType - A billing tier key or canonical plan ID
+ * @returns A human-readable display name
+ */
 export function getPlanLabel(planType: PlanType | string): string {
   const labels: Record<string, string> = {
+    // Billing tier keys
     free: 'Free',
-    free_v1: 'Free',
     single_team: 'Single Team',
     multi_team: 'Multi Team',
     identity_plus: 'Identity Plus',
     team_plus: 'Team Plus',
+    // Canonical plan IDs
+    free_v1: 'Free',
+    identity_plus_v1: 'Identity Plus',
+    team_plus_v1: 'Team Plus',
+    legacy_plan_v1: 'Legacy Plan',
+    // Legacy/grandfathered plan
+    identity: 'Identity Plus (Early Supporter)',
   };
 
   // Direct match
@@ -92,52 +108,6 @@ export function getPlanLabel(planType: PlanType | string): string {
 
   // Fallback: convert snake_case to Title Case
   return planType.replace(/_/g, ' ').replace(/\b\w/g, (c: string) => c.toUpperCase());
-}
-
-/**
- * Parse a plan ID to a human-readable display name
- *
- * Handles canonical plan IDs like:
- * - identity_plus_v1 -> Identity Plus
- * - team_plus_v1 -> Team Plus
- * - free_v1 -> Free
- *
- * @param planId - The canonical plan ID (e.g., 'identity_plus_v1')
- * @returns A human-readable display name
- */
-export function getPlanDisplayName(planId: string): string {
-  if (!planId) return 'Free';
-
-  // Check for legacy plans first (centralized logic)
-  const legacyInfo = getLegacyPlanInfo(planId);
-  if (legacyInfo) {
-    return legacyInfo.displayName;
-  }
-
-  // Known plan name mappings (plan ID patterns -> display name)
-  // Order matters: more specific patterns must come before general ones
-  const planPatterns: [RegExp, string][] = [
-    [/^free/i, 'Free'],
-    [/identity_plus/i, 'Identity Plus'],
-    [/team_plus|multi_team/i, 'Team Plus'],
-    [/single_team/i, 'Single Team'],
-    [/identity(?!_plus)/i, 'Identity'], // Other identity-prefixed plans
-  ];
-
-  for (const [pattern, displayName] of planPatterns) {
-    if (pattern.test(planId)) {
-      return displayName;
-    }
-  }
-
-  // Fallback: Convert snake_case to Title Case (removing version suffix)
-  // e.g., 'some_plan_v1' -> 'Some Plan'
-  const baseName = planId
-    .replace(/_v\d+$/, '') // Remove version suffix
-    .replace(/_/g, ' ') // Convert underscores to spaces
-    .replace(/\b\w/g, (c) => c.toUpperCase()); // Title case
-
-  return baseName || planId;
 }
 
 export function getSubscriptionStatusLabel(


### PR DESCRIPTION
## Summary

Follow-up to the Phase 1–3 work in `feature/billing-catalog`. Addresses two gaps found in a gap analysis:

- **Federated validation** — plan_id from cross-region subscriptions is now shape-validated before storage (fail-closed on malformed IDs, absent metadata leaves planid unchanged)
- **Frontend regex removal** — `getPlanDisplayName` and `formatPlanId` replaced with `getPlanLabel` static lookup; dead composite `planSchema` removed

Phase 2 `paid?` consolidation was analyzed and found already resolved by the `WithMaterializedEntitlements` work in #3134.

Closes #3120

## Test plan

- [x] Ruby specs pass (87 examples, 0 failures)
- [x] Frontend type-check passes
- [x] Frontend tests pass (68/68)