### PR TITLE
Make entitlement schema fail-open for unknown values

### DIFF
--- a/src/schemas/contracts/organization.ts
+++ b/src/schemas/contracts/organization.ts
@@ -5,6 +5,8 @@
 //
 // Architecture: contract → shape → API
 
+import { captureMessage } from '@/services/diagnostics.service';
+
 /**
  * Organization record contracts defining field names and wire format.
  *
@@ -113,32 +115,50 @@ export const organizationRoleSchema = membershipRoleSchema;
 export type OrganizationRole = z.infer<typeof organizationRoleSchema>;
 
 /**
- * Entitlement schema
+ * Known entitlements for TypeScript type checking
  *
- * Maps to STANDALONE_ENTITLEMENTS in backend (lib/onetime/billing/catalog.rb)
+ * Maps to STANDALONE_ENTITLEMENTS in backend
+ * @see etc/examples/billing.example.yaml
+ * @see lib/onetime/billing/catalog.rb
  */
-export const entitlementSchema = z.enum([
-  // Core entitlements (standalone mode)
+export const KNOWN_ENTITLEMENTS = [
   'api_access',
+  'audit_logs',
+  'create_secrets',
+  'custom_branding',
   'custom_domains',
+  'custom_mail_sender',
   'custom_privacy_defaults',
   'extended_default_expiration',
-  'custom_mail_sender',
   'flexible_from_domain',
-  'custom_branding',
-  'incoming_secrets',
-  'manage_orgs',
-  'manage_teams',
-  'manage_members',
-  'manage_sso',
-  'audit_logs',
-  // Free tier entitlements (from billing.yaml free_v1 plan)
-  'create_secrets',
-  'view_receipt',
-  // Paid plan entitlements (from billing.yaml)
   'homepage_secrets',
-  'flexible_from_domain',
-]);
+  'incoming_secrets',
+  'ip_access_rules',
+  'manage_members',
+  'manage_orgs',
+  'manage_sso',
+  'manage_teams',
+  'notifications',
+  'view_receipt',
+  'workspace_branding',
+] as const;
+
+const knownEntitlementSet = new Set<string>(KNOWN_ENTITLEMENTS);
+const warnedEntitlements = new Set<string>();
+
+/**
+ * Entitlement schema - accepts any string to avoid breaking on unknown entitlements.
+ * Logs a warning for unknown values (once per value) to surface config drift.
+ */
+export const entitlementSchema = z.string().transform((val) => {
+  if (!knownEntitlementSet.has(val) && !warnedEntitlements.has(val)) {
+    warnedEntitlements.add(val);
+    const message = `Unfamiliar entitlement: "${val}"`;
+    console.warn(`[entitlements] ${message}`);
+    captureMessage(message, { level: 'warning', tags: { entitlement: val } });
+  }
+  return val;
+});
 
 export type Entitlement = z.infer<typeof entitlementSchema>;
 

--- a/src/shared/composables/useEntitlements.ts
+++ b/src/shared/composables/useEntitlements.ts
@@ -13,19 +13,30 @@ import { useI18n } from 'vue-i18n';
  * Used when API data is not available
  */
 const FALLBACK_DISPLAY_KEYS: Record<string, string> = {
+  // Core
+  [ENTITLEMENTS.CREATE_SECRETS]: 'web.billing.overview.entitlements.create_secrets',
+  [ENTITLEMENTS.VIEW_RECEIPT]: 'web.billing.overview.entitlements.view_receipt',
+  [ENTITLEMENTS.HOMEPAGE_SECRETS]: 'web.billing.overview.entitlements.homepage_secrets',
+  [ENTITLEMENTS.INCOMING_SECRETS]: 'web.billing.overview.entitlements.incoming_secrets',
+  [ENTITLEMENTS.NOTIFICATIONS]: 'web.billing.overview.entitlements.notifications',
+  // Infrastructure
   [ENTITLEMENTS.API_ACCESS]: 'web.billing.overview.entitlements.api_access',
   [ENTITLEMENTS.CUSTOM_DOMAINS]: 'web.billing.overview.entitlements.custom_domains',
+  [ENTITLEMENTS.IP_ACCESS_RULES]: 'web.billing.overview.entitlements.ip_access_rules',
+  // Privacy & Defaults
   [ENTITLEMENTS.CUSTOM_PRIVACY_DEFAULTS]: 'web.billing.overview.entitlements.custom_privacy_defaults',
   [ENTITLEMENTS.EXTENDED_DEFAULT_EXPIRATION]: 'web.billing.overview.entitlements.extended_default_expiration',
   [ENTITLEMENTS.CUSTOM_MAIL_SENDER]: 'web.billing.overview.entitlements.custom_mail_sender',
   [ENTITLEMENTS.FLEXIBLE_FROM_DOMAIN]: 'web.billing.overview.entitlements.flexible_from_domain',
+  // Branding
   [ENTITLEMENTS.CUSTOM_BRANDING]: 'web.billing.overview.entitlements.custom_branding',
-  [ENTITLEMENTS.HOMEPAGE_SECRETS]: 'web.billing.overview.entitlements.homepage_secrets',
-  [ENTITLEMENTS.INCOMING_SECRETS]: 'web.billing.overview.entitlements.incoming_secrets',
+  [ENTITLEMENTS.WORKSPACE_BRANDING]: 'web.billing.overview.entitlements.workspace_branding',
+  // Organization Management
   [ENTITLEMENTS.MANAGE_ORGS]: 'web.billing.overview.entitlements.manage_orgs',
   [ENTITLEMENTS.MANAGE_TEAMS]: 'web.billing.overview.entitlements.manage_teams',
   [ENTITLEMENTS.MANAGE_MEMBERS]: 'web.billing.overview.entitlements.manage_members',
   [ENTITLEMENTS.MANAGE_SSO]: 'web.billing.overview.entitlements.manage_sso',
+  // Advanced
   [ENTITLEMENTS.AUDIT_LOGS]: 'web.billing.overview.entitlements.audit_logs',
 };
 

--- a/src/types/organization.ts
+++ b/src/types/organization.ts
@@ -44,9 +44,17 @@ export {
  * Note: The Entitlement type is derived from entitlementSchema in schemas.
  */
 export const ENTITLEMENTS = {
+  // Core
+  CREATE_SECRETS: 'create_secrets',
+  VIEW_RECEIPT: 'view_receipt',
+  HOMEPAGE_SECRETS: 'homepage_secrets',
+  INCOMING_SECRETS: 'incoming_secrets',
+  NOTIFICATIONS: 'notifications',
+
   // Infrastructure
   API_ACCESS: 'api_access',
   CUSTOM_DOMAINS: 'custom_domains',
+  IP_ACCESS_RULES: 'ip_access_rules',
 
   // Privacy & Defaults
   CUSTOM_PRIVACY_DEFAULTS: 'custom_privacy_defaults',
@@ -56,10 +64,7 @@ export const ENTITLEMENTS = {
 
   // Branding
   CUSTOM_BRANDING: 'custom_branding',
-  HOMEPAGE_SECRETS: 'homepage_secrets',
-
-  // Secret Features
-  INCOMING_SECRETS: 'incoming_secrets',
+  WORKSPACE_BRANDING: 'workspace_branding',
 
   // Organization Management
   MANAGE_ORGS: 'manage_orgs',


### PR DESCRIPTION
Related to #3120

- Change entitlementSchema from z.enum to z.string with transform
- Log unknown entitlements to console and Sentry (deduplicated)
- Sync KNOWN_ENTITLEMENTS with backend billing.yaml definitions
- Add missing entitlements: notifications, workspace_branding, ip_access_rules
