### PR TITLE
feat(#3187): jurisdiction config via ENV string format

### DIFF
--- a/.env.reference
+++ b/.env.reference
@@ -287,6 +287,8 @@ APPROXIMATED_VHOST_TARGET=
 
 REGIONS_ENABLED=false
 JURISDICTION=
+# Available jurisdictions as ID:domain pairs (e.g., EU:eu.example.com,CA:ca.example.com)
+JURISDICTIONS=
 
 I18N_ENABLED=true
 I18N_DEFAULT_LOCALE=en

--- a/.env.reference
+++ b/.env.reference
@@ -424,7 +424,7 @@ WORKER_HEARTBEAT_INTERVAL=600
 # strict (default): raise an error and refuse to start
 # warn:             log a migration message and continue
 # silent:           ignore
-ON_DEPRECATED_CONFIG=strict
+DEPRECATED_CONFIG_MODE=strict
 
 
 # ═══════════════════════════════════════════════════════════

--- a/README.md
+++ b/README.md
@@ -115,14 +115,16 @@ pnpm run build
 RACK_ENV=production bundle exec puma -C etc/examples/puma.example.rb
 ```
 
-### Frontend Development Mode
+### Frontend Hot Module Replacement
 
 Enable development mode in `etc/config.yaml` for HMR support:
 ```yaml
-:development:
-  :enabled: true
-  :frontend_host: 'http://localhost:5173'
+development:
+  enabled: true
+  frontend_host: 'http://localhost:5173'
 ```
+
+The browser swaps changed modules in place without a full page reload, preserving application state.
 
 ### Docker Compose
 

--- a/apps/web/core/spec/views/base_spec.rb
+++ b/apps/web/core/spec/views/base_spec.rb
@@ -289,8 +289,14 @@ RSpec.describe Core::Views::BaseView do
       expect(subject.serialized_data['regions_enabled']).to be true
       expect(subject.serialized_data['regions']).to include(
         'enabled' => true,
-        'current_jurisdiction' => 'EU',
       )
+      # transform_regions converts jurisdictions to identifier + i18n key only
+      expect(subject.serialized_data['regions']['jurisdictions']).to eq([
+        {
+          'identifier' => 'EU',
+          'display_name_i18n_key' => 'web.regions.jurisdictions.eu.name',
+        },
+      ])
     end
 
     context 'when regions disabled' do

--- a/apps/web/core/spec/views/base_spec.rb
+++ b/apps/web/core/spec/views/base_spec.rb
@@ -289,11 +289,13 @@ RSpec.describe Core::Views::BaseView do
       expect(subject.serialized_data['regions_enabled']).to be true
       expect(subject.serialized_data['regions']).to include(
         'enabled' => true,
+        'current_jurisdiction' => 'EU',
       )
-      # transform_regions converts jurisdictions to identifier + i18n key only
+      # transform_regions includes identifier, domain, and i18n key
       expect(subject.serialized_data['regions']['jurisdictions']).to eq([
         {
           'identifier' => 'EU',
+          'domain' => 'eu.example.com',
           'display_name_i18n_key' => 'web.regions.jurisdictions.eu.name',
         },
       ])

--- a/apps/web/core/spec/views/serializers/config_serializer_spec.rb
+++ b/apps/web/core/spec/views/serializers/config_serializer_spec.rb
@@ -646,11 +646,13 @@ RSpec.describe Core::Views::ConfigSerializer do
 
       expect(result['enabled']).to be false
       expect(result['jurisdictions']).to eq([])
+      expect(result['current_jurisdiction']).to be_nil
     end
 
-    it 'transforms jurisdictions to identifier and i18n key only' do
+    it 'transforms jurisdictions with identifier, domain, and i18n key' do
       regions = {
         'enabled' => true,
+        'current_jurisdiction' => 'EU',
         'jurisdictions' => [
           { 'identifier' => 'EU', 'domain' => 'eu.example.com' },
           { 'identifier' => 'CA', 'domain' => 'ca.example.com' },
@@ -660,28 +662,64 @@ RSpec.describe Core::Views::ConfigSerializer do
       result = described_class.transform_regions(regions)
 
       expect(result['enabled']).to be true
+      expect(result['current_jurisdiction']).to eq('EU')
       expect(result['jurisdictions'].length).to eq(2)
       expect(result['jurisdictions'][0]).to eq({
         'identifier' => 'EU',
+        'domain' => 'eu.example.com',
         'display_name_i18n_key' => 'web.regions.jurisdictions.eu.name',
       })
       expect(result['jurisdictions'][1]).to eq({
         'identifier' => 'CA',
+        'domain' => 'ca.example.com',
         'display_name_i18n_key' => 'web.regions.jurisdictions.ca.name',
       })
     end
 
-    it 'does not include domain data in output (security)' do
+    it 'includes domain in output for navigation' do
       regions = {
         'enabled' => true,
         'jurisdictions' => [
-          { 'identifier' => 'EU', 'domain' => 'eu.secret-internal.example.com' },
+          { 'identifier' => 'EU', 'domain' => 'eu.onetimesecret.com' },
         ],
       }
 
       result = described_class.transform_regions(regions)
 
-      expect(result['jurisdictions'][0]).not_to have_key('domain')
+      expect(result['jurisdictions'][0]['domain']).to eq('eu.onetimesecret.com')
+    end
+
+    it 'includes icon when present in config' do
+      regions = {
+        'enabled' => true,
+        'jurisdictions' => [
+          {
+            'identifier' => 'EU',
+            'domain' => 'eu.example.com',
+            'icon' => { 'collection' => 'fa6-solid', 'name' => 'earth-europe' },
+          },
+        ],
+      }
+
+      result = described_class.transform_regions(regions)
+
+      expect(result['jurisdictions'][0]['icon']).to eq({
+        'collection' => 'fa6-solid',
+        'name' => 'earth-europe',
+      })
+    end
+
+    it 'omits icon when not present in config' do
+      regions = {
+        'enabled' => true,
+        'jurisdictions' => [
+          { 'identifier' => 'EU', 'domain' => 'eu.example.com' },
+        ],
+      }
+
+      result = described_class.transform_regions(regions)
+
+      expect(result['jurisdictions'][0]).not_to have_key('icon')
     end
 
     it 'lowercases identifier for i18n key generation' do
@@ -697,6 +735,23 @@ RSpec.describe Core::Views::ConfigSerializer do
       expect(result['jurisdictions'][0]['display_name_i18n_key']).to eq('web.regions.jurisdictions.us-west.name')
     end
 
+    it 'uses display_name_i18n_key from config when provided' do
+      regions = {
+        'enabled' => true,
+        'jurisdictions' => [
+          {
+            'identifier' => 'EU',
+            'domain' => 'eu.example.com',
+            'display_name_i18n_key' => 'custom.key.eu',
+          },
+        ],
+      }
+
+      result = described_class.transform_regions(regions)
+
+      expect(result['jurisdictions'][0]['display_name_i18n_key']).to eq('custom.key.eu')
+    end
+
     it 'handles jurisdictions with nil identifier gracefully' do
       regions = {
         'enabled' => true,
@@ -708,6 +763,7 @@ RSpec.describe Core::Views::ConfigSerializer do
       result = described_class.transform_regions(regions)
 
       expect(result['jurisdictions'][0]['identifier']).to eq('')
+      expect(result['jurisdictions'][0]['domain']).to eq('example.com')
       expect(result['jurisdictions'][0]['display_name_i18n_key']).to eq('web.regions.jurisdictions..name')
     end
   end

--- a/apps/web/core/spec/views/serializers/config_serializer_spec.rb
+++ b/apps/web/core/spec/views/serializers/config_serializer_spec.rb
@@ -640,6 +640,78 @@ RSpec.describe Core::Views::ConfigSerializer do
     end
   end
 
+  describe '.transform_regions' do
+    it 'returns enabled false and empty jurisdictions for empty regions config' do
+      result = described_class.transform_regions({})
+
+      expect(result['enabled']).to be false
+      expect(result['jurisdictions']).to eq([])
+    end
+
+    it 'transforms jurisdictions to identifier and i18n key only' do
+      regions = {
+        'enabled' => true,
+        'jurisdictions' => [
+          { 'identifier' => 'EU', 'domain' => 'eu.example.com' },
+          { 'identifier' => 'CA', 'domain' => 'ca.example.com' },
+        ],
+      }
+
+      result = described_class.transform_regions(regions)
+
+      expect(result['enabled']).to be true
+      expect(result['jurisdictions'].length).to eq(2)
+      expect(result['jurisdictions'][0]).to eq({
+        'identifier' => 'EU',
+        'display_name_i18n_key' => 'web.regions.jurisdictions.eu.name',
+      })
+      expect(result['jurisdictions'][1]).to eq({
+        'identifier' => 'CA',
+        'display_name_i18n_key' => 'web.regions.jurisdictions.ca.name',
+      })
+    end
+
+    it 'does not include domain data in output (security)' do
+      regions = {
+        'enabled' => true,
+        'jurisdictions' => [
+          { 'identifier' => 'EU', 'domain' => 'eu.secret-internal.example.com' },
+        ],
+      }
+
+      result = described_class.transform_regions(regions)
+
+      expect(result['jurisdictions'][0]).not_to have_key('domain')
+    end
+
+    it 'lowercases identifier for i18n key generation' do
+      regions = {
+        'enabled' => false,
+        'jurisdictions' => [
+          { 'identifier' => 'US-WEST', 'domain' => 'west.example.com' },
+        ],
+      }
+
+      result = described_class.transform_regions(regions)
+
+      expect(result['jurisdictions'][0]['display_name_i18n_key']).to eq('web.regions.jurisdictions.us-west.name')
+    end
+
+    it 'handles jurisdictions with nil identifier gracefully' do
+      regions = {
+        'enabled' => true,
+        'jurisdictions' => [
+          { 'identifier' => nil, 'domain' => 'example.com' },
+        ],
+      }
+
+      result = described_class.transform_regions(regions)
+
+      expect(result['jurisdictions'][0]['identifier']).to eq('')
+      expect(result['jurisdictions'][0]['display_name_i18n_key']).to eq('web.regions.jurisdictions..name')
+    end
+  end
+
   describe '.build_tenant_sso_response' do
     it 'returns correct structure for OIDC config' do
       config = build_domain_sso_config(:oidc, display_name: 'Acme SSO')

--- a/apps/web/core/views/serializers/config_serializer.rb
+++ b/apps/web/core/views/serializers/config_serializer.rb
@@ -254,24 +254,30 @@ module Core
 
         # Transform regions config for frontend consumption
         #
-        # Strips deployment-sensitive data (domains) from jurisdictions and
-        # adds i18n keys for display names. Frontend maps icons separately.
+        # Passes through identifier, domain, icon, and i18n key.
+        # Domain is public (users navigate to it directly).
+        # Icons are optional; frontend falls back to src/sources/jurisdictions.ts.
         #
         # @param regions [Hash] Raw regions config from features
-        # @return [Hash] Transformed regions with safe jurisdiction data
+        # @return [Hash] Transformed regions with jurisdiction data
         def transform_regions(regions)
           jurisdictions = regions.fetch('jurisdictions', [])
 
           transformed_jurisdictions = jurisdictions.map do |j|
-            identifier = j['identifier'].to_s
-            {
+            identifier     = j['identifier'].to_s
+            result         = {
               'identifier' => identifier,
-              'display_name_i18n_key' => "web.regions.jurisdictions.#{identifier.downcase}.name",
+              'domain' => j['domain'].to_s,
+              'display_name_i18n_key' => j['display_name_i18n_key'] ||
+                                         "web.regions.jurisdictions.#{identifier.downcase}.name",
             }
+            result['icon'] = j['icon'] if j['icon'].is_a?(Hash)
+            result
           end
 
           {
             'enabled' => regions.fetch('enabled', false),
+            'current_jurisdiction' => regions['current_jurisdiction'],
             'jurisdictions' => transformed_jurisdictions,
           }
         end

--- a/apps/web/core/views/serializers/config_serializer.rb
+++ b/apps/web/core/views/serializers/config_serializer.rb
@@ -52,8 +52,9 @@ module Core
         domains                  = features.fetch('domains', {})
 
         # Only send the regions config when the feature is enabled.
+        # Transform jurisdictions to send identifier + i18n key only (no domain data).
         output['regions_enabled'] = regions.fetch('enabled', false)
-        output['regions']         = regions if output['regions_enabled']
+        output['regions']         = transform_regions(regions) if output['regions_enabled']
 
         output['domains_enabled'] = domains.fetch('enabled', false)
         output['domains']         = domains if output['domains_enabled']
@@ -248,6 +249,30 @@ module Core
                 'display_name' => config.display_name.to_s,
               },
             ],
+          }
+        end
+
+        # Transform regions config for frontend consumption
+        #
+        # Strips deployment-sensitive data (domains) from jurisdictions and
+        # adds i18n keys for display names. Frontend maps icons separately.
+        #
+        # @param regions [Hash] Raw regions config from features
+        # @return [Hash] Transformed regions with safe jurisdiction data
+        def transform_regions(regions)
+          jurisdictions = regions.fetch('jurisdictions', [])
+
+          transformed_jurisdictions = jurisdictions.map do |j|
+            identifier = j['identifier'].to_s
+            {
+              'identifier' => identifier,
+              'display_name_i18n_key' => "web.regions.jurisdictions.#{identifier.downcase}.name",
+            }
+          end
+
+          {
+            'enabled' => regions.fetch('enabled', false),
+            'jurisdictions' => transformed_jurisdictions,
           }
         end
 

--- a/etc/defaults/config.defaults.yaml
+++ b/etc/defaults/config.defaults.yaml
@@ -1085,4 +1085,4 @@ compatibility:
   #   strict (default): raise an error and refuse to start
   #   warn:             log a migration message and continue
   #   silent:           ignore
-  on_deprecated_config: <%= ENV['ON_DEPRECATED_CONFIG'] || 'strict' %>
+  deprecated_config_mode: <%= ENV['DEPRECATED_CONFIG_MODE'] || 'strict' %>

--- a/etc/defaults/config.defaults.yaml
+++ b/etc/defaults/config.defaults.yaml
@@ -405,6 +405,18 @@ features:
   regions:
     enabled: <%= ENV['REGIONS_ENABLED'] == 'true' || false %>
     current_jurisdiction: <%= ENV['JURISDICTION'] || nil %>
+    # Available jurisdictions for regional deployment
+    #
+    # Environment Variable Format:
+    #   JURISDICTIONS=ID:domain,ID:domain,...
+    #   where ID is the jurisdiction identifier (e.g., EU, CA, US)
+    #   and domain is the hostname for that jurisdiction
+    #
+    # Examples:
+    #   JURISDICTIONS=EU:eu.example.com,CA:ca.example.com
+    #   JURISDICTIONS=US:us.onetimesecret.com,EU:eu.onetimesecret.com,APAC:apac.onetimesecret.com
+    #
+    jurisdictions: <%= ENV['JURISDICTIONS'] || '' %>
   # Incoming Secrets Feature
   # Allows anonymous users to send encrypted secrets to pre-configured recipients
   # via a dedicated web form at /incoming. Recipients receive email notifications.

--- a/lib/onetime/config.rb
+++ b/lib/onetime/config.rb
@@ -117,7 +117,7 @@ module Onetime
           # How the boot process responds when a deprecated config key or
           # env var is detected: 'strict' raises OT::ConfigError, 'warn'
           # logs and continues, 'silent' ignores. See DEPRECATIONS.
-          'on_deprecated_config' => 'strict',
+          'deprecated_config_mode' => 'strict',
         },
       }
 
@@ -125,7 +125,7 @@ module Onetime
       #
       # Each entry maps a deprecated config path and/or the env var that
       # used to populate it to a migration message. check_deprecations
-      # scans these at boot; compatibility.on_deprecated_config decides
+      # scans these at boot; compatibility.deprecated_config_mode decides
       # whether a match raises OT::ConfigError ('strict'), logs ('warn'),
       # or is ignored ('silent').
       DEPRECATIONS = [
@@ -273,7 +273,7 @@ module Onetime
       raise_concerns(conf)
 
       # MIGRATION VALIDATION: Detect deprecated configuration keys / env vars
-      # and respond per compatibility.on_deprecated_config.
+      # and respond per compatibility.deprecated_config_mode.
       check_deprecations(conf)
 
       # Disable all authentication sub-features when main feature is off for
@@ -423,7 +423,7 @@ module Onetime
     # Scans the DEPRECATIONS manifest. A deprecation is considered present
     # when its config path resolves to a non-nil value, or its env var is
     # set to a non-empty value. The response is governed by
-    # compatibility.on_deprecated_config:
+    # compatibility.deprecated_config_mode:
     #
     #   strict (default) - raise OT::ConfigError, refusing to boot
     #   warn             - log each migration message and continue
@@ -442,7 +442,7 @@ module Onetime
       end
       return if detected.empty?
 
-      policy   = (conf.dig('compatibility', 'on_deprecated_config') || 'strict').to_s
+      policy   = (conf.dig('compatibility', 'deprecated_config_mode') || 'strict').to_s
       messages = detected.map { |dep| dep[:message] }
       return if policy == 'silent'
 
@@ -453,7 +453,7 @@ module Onetime
 
       raise OT::ConfigError,
         "Deprecated configuration detected:\n  - #{messages.join("\n  - ")}\n\n" \
-        "Set compatibility.on_deprecated_config (ON_DEPRECATED_CONFIG) to 'warn' " \
+        "Set compatibility.deprecated_config_mode (DEPRECATED_CONFIG_MODE) to 'warn' " \
         'to downgrade this to a logged warning.'
     end
 

--- a/lib/onetime/config.rb
+++ b/lib/onetime/config.rb
@@ -291,12 +291,17 @@ module Onetime
       # The trigger proc above only fires on Array (old YAML format), not String.
       jurisdictions = conf.dig('features', 'regions', 'jurisdictions')
       if jurisdictions.is_a?(String) && !jurisdictions.empty?
-        conf['features']['regions']['jurisdictions'] = jurisdictions.split(',').map do |entry|
-          identifier, domain = entry.strip.split(':', 2)
+        entries                                      = jurisdictions.split(',').map(&:strip).reject(&:empty?)
+        conf['features']['regions']['jurisdictions'] = entries.map do |entry|
+          identifier, domain = entry.split(':', 2).map(&:strip)
+          if identifier.empty? || domain.to_s.empty?
+            raise OT::Problem, "Invalid JURISDICTIONS format: '#{entry}' (expected ID:domain)"
+          end
+
           {
             'identifier' => identifier,
             'domain' => domain,
-            'display_name_i18n_key' => "web.regions.jurisdictions.#{identifier.to_s.downcase}.name",
+            'display_name_i18n_key' => "web.regions.jurisdictions.#{identifier.downcase}.name",
           }
         end
       elsif jurisdictions.is_a?(String) || jurisdictions.nil?

--- a/lib/onetime/config.rb
+++ b/lib/onetime/config.rb
@@ -128,6 +128,13 @@ module Onetime
       # scans these at boot; compatibility.deprecated_config_mode decides
       # whether a match raises OT::ConfigError ('strict'), logs ('warn'),
       # or is ignored ('silent').
+      #
+      # Fields:
+      #   path:    Array of keys to dig into conf (optional)
+      #   env:     Environment variable name (optional)
+      #   trigger: Proc that receives the path value; returns true to fire (optional)
+      #            When absent, any non-nil value triggers. Use for type-specific checks.
+      #   message: User-facing migration guidance
       DEPRECATIONS = [
         {
           path: %w[site interface ui homepage trusted_proxy_depth],
@@ -166,9 +173,11 @@ module Onetime
         {
           path: %w[features regions jurisdictions],
           env: nil,
+          # Only trigger on Array (old YAML format), not String (new ENV format)
+          trigger: ->(value) { value.is_a?(Array) },
           message: <<~MSG.chomp,
-            features.regions.jurisdictions is ignored. Use JURISDICTIONS env var
-            (format: EU:eu.example.com,CA:ca.example.com). YAML jurisdictions are not read.
+            features.regions.jurisdictions array format is deprecated. Use JURISDICTIONS env var
+            (format: EU:eu.example.com,CA:ca.example.com) instead.
           MSG
         },
       ].freeze
@@ -274,7 +283,26 @@ module Onetime
 
       # MIGRATION VALIDATION: Detect deprecated configuration keys / env vars
       # and respond per compatibility.deprecated_config_mode.
+      # Must run BEFORE jurisdiction parsing so trigger proc sees original type.
       check_deprecations(conf)
+
+      # Parse jurisdictions from string env var format AFTER deprecation check.
+      # Format: "EU:eu.example.com,CA:ca.example.com" -> array of hashes
+      # The trigger proc above only fires on Array (old YAML format), not String.
+      jurisdictions = conf.dig('features', 'regions', 'jurisdictions')
+      if jurisdictions.is_a?(String) && !jurisdictions.empty?
+        conf['features']['regions']['jurisdictions'] = jurisdictions.split(',').map do |entry|
+          identifier, domain = entry.strip.split(':', 2)
+          {
+            'identifier' => identifier,
+            'domain' => domain,
+            'display_name_i18n_key' => "web.regions.jurisdictions.#{identifier.to_s.downcase}.name",
+          }
+        end
+      elsif jurisdictions.is_a?(String) || jurisdictions.nil?
+        # Empty string or nil -> empty array
+        conf['features']['regions']['jurisdictions'] = []
+      end
 
       # Disable all authentication sub-features when main feature is off for
       # consistency, security, and to prevent unexpected behavior. Ensures clean
@@ -329,16 +357,15 @@ module Onetime
         conf['site']['secret_options']['password_generation']['length_options'] = length_options.map(&:to_i)
       end
 
-      # Parse jurisdictions from ENV string format: "EU:eu.example.com,CA:ca.example.com"
-      # into array of hashes: [{identifier: 'EU', domain: 'eu.example.com'}, ...]
+      # Ensure array jurisdiction entries have display_name_i18n_key
+      # (String format already converted to Array above, before check_deprecations)
       jurisdictions = conf.dig('features', 'regions', 'jurisdictions')
-      if jurisdictions.is_a?(String) && !jurisdictions.empty?
-        conf['features']['regions']['jurisdictions'] = jurisdictions.split(',').map do |entry|
-          identifier, domain = entry.strip.split(':', 2)
-          { 'identifier' => identifier, 'domain' => domain }
+      if jurisdictions.is_a?(Array)
+        conf['features']['regions']['jurisdictions'] = jurisdictions.map do |j|
+          j                            = j.dup if j.frozen?
+          j['display_name_i18n_key'] ||= "web.regions.jurisdictions.#{j['identifier'].to_s.downcase}.name"
+          j
         end
-      elsif !jurisdictions.is_a?(Array)
-        conf['features']['regions']['jurisdictions'] = []
       end
 
       # Apply the defaults to sentry backend and frontend configs
@@ -436,8 +463,16 @@ module Onetime
     # @raise [OT::ConfigError] When a deprecated key is found under strict policy
     def check_deprecations(conf)
       detected = DEPRECATIONS.select do |dep|
-        env_set  = !!(dep[:env] && !ENV[dep[:env]].to_s.empty?)
-        path_set = !!(dep[:path] && !conf.dig(*dep[:path]).nil?)
+        env_set = !!(dep[:env] && !ENV[dep[:env]].to_s.empty?)
+
+        # Check path, optionally with a trigger proc for type-specific detection
+        path_value = dep[:path] && conf.dig(*dep[:path])
+        path_set   = if dep[:trigger] && path_value
+          dep[:trigger].call(path_value)
+        else
+          !path_value.nil?
+        end
+
         env_set || path_set
       end
       return if detected.empty?

--- a/lib/onetime/config.rb
+++ b/lib/onetime/config.rb
@@ -197,7 +197,13 @@ module Onetime
     def load(path = nil)
       path ||= self.path
 
-      raise ArgumentError, "Bad path (#{path})" unless path && File.readable?(path)
+      if path.nil? || path.empty?
+        raise ArgumentError, 'Config path not set (checked etc/config.yaml and SERVICE_PATHS)'
+      end
+
+      unless File.readable?(path)
+        raise ArgumentError, "Config not readable: #{path}"
+      end
 
       parsed_template = ERB.new(File.read(path))
 

--- a/lib/onetime/config.rb
+++ b/lib/onetime/config.rb
@@ -132,30 +132,44 @@ module Onetime
         {
           path: %w[site interface ui homepage trusted_proxy_depth],
           env: 'UI_HOMEPAGE_TRUSTED_PROXY_DEPTH',
-          message: 'site.interface.ui.homepage.trusted_proxy_depth ' \
-                   '(UI_HOMEPAGE_TRUSTED_PROXY_DEPTH) has been removed. Configure ' \
-                   'proxy depth globally via site.network.trusted_proxy ' \
-                   '(TRUSTED_PROXY_ENABLED, TRUSTED_PROXY_MODE=depth, TRUSTED_PROXY_DEPTH).',
+          message: <<~MSG.chomp,
+            site.interface.ui.homepage.trusted_proxy_depth is ignored. Configure proxy
+            depth globally via site.network.trusted_proxy (TRUSTED_PROXY_ENABLED,
+            TRUSTED_PROXY_MODE=depth, TRUSTED_PROXY_DEPTH).
+          MSG
         },
         {
           path: %w[site interface ui homepage trusted_ip_header],
           env: 'UI_HOMEPAGE_TRUSTED_IP_HEADER',
-          message: 'site.interface.ui.homepage.trusted_ip_header ' \
-                   '(UI_HOMEPAGE_TRUSTED_IP_HEADER) has been removed. Configure the ' \
-                   'forwarding header globally via site.network.trusted_proxy.header ' \
-                   '(TRUSTED_PROXY_HEADER).',
+          message: <<~MSG.chomp,
+            site.interface.ui.homepage.trusted_ip_header is ignored. Configure the
+            forwarding header globally via site.network.trusted_proxy.header
+            (TRUSTED_PROXY_HEADER).
+          MSG
         },
         {
           path: %w[site domains],
           env: nil,
-          message: 'site.domains has moved to features.domains. Move the domains ' \
-                   'block under the top-level features section.',
+          message: <<~MSG.chomp,
+            site.domains is ignored. This config moved to features.domains;
+            only the new path is read.
+          MSG
         },
         {
           path: %w[site regions],
           env: nil,
-          message: 'site.regions has moved to features.regions. Move the regions ' \
-                   'block under the top-level features section.',
+          message: <<~MSG.chomp,
+            site.regions is ignored. This config moved to features.regions;
+            only the new path is read.
+          MSG
+        },
+        {
+          path: %w[features regions jurisdictions],
+          env: nil,
+          message: <<~MSG.chomp,
+            features.regions.jurisdictions is ignored. Use JURISDICTIONS env var
+            (format: EU:eu.example.com,CA:ca.example.com). YAML jurisdictions are not read.
+          MSG
         },
       ].freeze
 
@@ -309,6 +323,18 @@ module Onetime
         conf['site']['secret_options']['password_generation']['length_options'] = length_options.map(&:to_i)
       end
 
+      # Parse jurisdictions from ENV string format: "EU:eu.example.com,CA:ca.example.com"
+      # into array of hashes: [{identifier: 'EU', domain: 'eu.example.com'}, ...]
+      jurisdictions = conf.dig('features', 'regions', 'jurisdictions')
+      if jurisdictions.is_a?(String) && !jurisdictions.empty?
+        conf['features']['regions']['jurisdictions'] = jurisdictions.split(',').map do |entry|
+          identifier, domain = entry.strip.split(':', 2)
+          { 'identifier' => identifier, 'domain' => domain }
+        end
+      elsif !jurisdictions.is_a?(Array)
+        conf['features']['regions']['jurisdictions'] = []
+      end
+
       # Apply the defaults to sentry backend and frontend configs
       # and set our local config with the merged values.
       diagnostics                                = loaded_config.fetch('diagnostics', {})
@@ -420,9 +446,9 @@ module Onetime
       end
 
       raise OT::ConfigError,
-            "Deprecated configuration detected:\n  - #{messages.join("\n  - ")}\n\n" \
-            "Set compatibility.on_deprecated_config (ON_DEPRECATED_CONFIG) to 'warn' " \
-            'to downgrade this to a logged warning.'
+        "Deprecated configuration detected:\n  - #{messages.join("\n  - ")}\n\n" \
+        "Set compatibility.on_deprecated_config (ON_DEPRECATED_CONFIG) to 'warn' " \
+        'to downgrade this to a logged warning.'
     end
 
     def dirname

--- a/lib/onetime/initializers/print_log_banner.rb
+++ b/lib/onetime/initializers/print_log_banner.rb
@@ -45,9 +45,10 @@ module Onetime
       # - format_config_value(config): Formats complex config values for display
       # - format_duration(seconds): Converts seconds to human-readable format (e.g., "5m", "2h", "7d")
       def print_log_banner
-      site_config  = OT.conf.fetch('site') # if site is missing we got real problems
-      email_config = OT.conf.fetch('emailer', {})
-      redis_info   = Familia.dbclient.info
+      site_config     = OT.conf.fetch('site') # if site is missing we got real problems
+      features_config = OT.conf.fetch('features', {})
+      email_config    = OT.conf.fetch('emailer', {})
+      redis_info      = Familia.dbclient.info
 
       # Header banner
       OT.boot_logger.info "---  ONETIME #{OT.mode} v#{OT::VERSION.details}  #{'---' * 3}"
@@ -65,7 +66,7 @@ module Onetime
         output << render_section('Development', 'Settings', dev_rows)
       end
 
-      feature_rows = build_features_section(site_config)
+      feature_rows = build_features_section(features_config)
       unless feature_rows.empty?
         output << render_section('Features', 'Configuration', feature_rows)
       end
@@ -146,19 +147,34 @@ module Onetime
         dev_rows
       end
 
-      # Builds features section rows
-      def build_features_section(site_config)
+      # Builds features section rows from features config
+      def build_features_section(features_config)
         feature_rows = []
 
-        # Domains and regions
-        %w[domains regions].each do |key|
-          next unless site_config.key?(key)
+        # Domains feature
+        if features_config.key?('domains')
+          domains = features_config['domains']
+          if is_feature_disabled?(domains)
+            feature_rows << %w[Domains disabled]
+          elsif domains.is_a?(Hash) && !domains.empty?
+            feature_rows << ['Domains', format_config_value(domains)]
+          end
+        end
 
-          config = site_config[key]
-          if is_feature_disabled?(config)
-            feature_rows << [key.to_s.capitalize, 'disabled']
-          elsif !config.empty?
-            feature_rows << [key.to_s.capitalize, format_config_value(config)]
+        # Regions feature with jurisdictions
+        if features_config.key?('regions')
+          regions = features_config['regions']
+          if is_feature_disabled?(regions)
+            feature_rows << %w[Regions disabled]
+          elsif regions.is_a?(Hash)
+            jurisdictions = regions.fetch('jurisdictions', [])
+            if jurisdictions.any?
+              ids = jurisdictions.map { |j| j['identifier'] }.join(', ')
+              feature_rows << ['Regions', "enabled (#{ids})"]
+              feature_rows << ['Current', regions['current_jurisdiction']] if regions['current_jurisdiction']
+            else
+              feature_rows << ['Regions', 'enabled (no jurisdictions)']
+            end
           end
         end
 

--- a/locales/content/ar/feature-regions.json
+++ b/locales/content/ar/feature-regions.json
@@ -158,5 +158,29 @@
   "web.regions.changing_regions_subscription_note": {
     "text": "ستُطبَّق مزايا اشتراكك تلقائياً على أي حساب يتم إنشاؤه باستخدام عنوان بريد الفوترة الخاص بك.",
     "source_hash": "5b2238b2"
+  },
+  "web.regions.jurisdictions.eu.name": {
+    "text": "European Union",
+    "content_hash": "9a18968a"
+  },
+  "web.regions.jurisdictions.us.name": {
+    "text": "United States",
+    "content_hash": "f253efe3"
+  },
+  "web.regions.jurisdictions.ca.name": {
+    "text": "Canada",
+    "content_hash": "445d337b"
+  },
+  "web.regions.jurisdictions.uk.name": {
+    "text": "United Kingdom",
+    "content_hash": "89f9c9f4"
+  },
+  "web.regions.jurisdictions.nz.name": {
+    "text": "New Zealand",
+    "content_hash": "c51ed580"
+  },
+  "web.regions.jurisdictions.at.name": {
+    "text": "Austria",
+    "content_hash": "98917390"
   }
 }

--- a/locales/content/ar/feature-regions.json
+++ b/locales/content/ar/feature-regions.json
@@ -182,5 +182,9 @@
   "web.regions.jurisdictions.at.name": {
     "text": "Austria",
     "content_hash": "98917390"
+  },
+  "web.regions.jurisdictions.apac.name": {
+    "text": "Asia-Pacific",
+    "content_hash": "f8a3b2c1"
   }
 }

--- a/locales/content/bg/feature-regions.json
+++ b/locales/content/bg/feature-regions.json
@@ -158,5 +158,29 @@
   "web.regions.changing_regions_subscription_note": {
     "text": "Предимствата на абонамента ви ще се прилагат автоматично към всеки акаунт, създаден с вашия имейл за фактуриране.",
     "source_hash": "5b2238b2"
+  },
+  "web.regions.jurisdictions.eu.name": {
+    "text": "European Union",
+    "content_hash": "9a18968a"
+  },
+  "web.regions.jurisdictions.us.name": {
+    "text": "United States",
+    "content_hash": "f253efe3"
+  },
+  "web.regions.jurisdictions.ca.name": {
+    "text": "Canada",
+    "content_hash": "445d337b"
+  },
+  "web.regions.jurisdictions.uk.name": {
+    "text": "United Kingdom",
+    "content_hash": "89f9c9f4"
+  },
+  "web.regions.jurisdictions.nz.name": {
+    "text": "New Zealand",
+    "content_hash": "c51ed580"
+  },
+  "web.regions.jurisdictions.at.name": {
+    "text": "Austria",
+    "content_hash": "98917390"
   }
 }

--- a/locales/content/bg/feature-regions.json
+++ b/locales/content/bg/feature-regions.json
@@ -182,5 +182,9 @@
   "web.regions.jurisdictions.at.name": {
     "text": "Austria",
     "content_hash": "98917390"
+  },
+  "web.regions.jurisdictions.apac.name": {
+    "text": "Asia-Pacific",
+    "content_hash": "f8a3b2c1"
   }
 }

--- a/locales/content/ca_ES/feature-regions.json
+++ b/locales/content/ca_ES/feature-regions.json
@@ -158,5 +158,29 @@
   "web.regions.changing_regions_subscription_note": {
     "text": "Els avantatges de la teva subscripció s'aplicaran automàticament a qualsevol compte creat amb la teva adreça de correu de facturació.",
     "source_hash": "5b2238b2"
+  },
+  "web.regions.jurisdictions.eu.name": {
+    "text": "European Union",
+    "content_hash": "9a18968a"
+  },
+  "web.regions.jurisdictions.us.name": {
+    "text": "United States",
+    "content_hash": "f253efe3"
+  },
+  "web.regions.jurisdictions.ca.name": {
+    "text": "Canada",
+    "content_hash": "445d337b"
+  },
+  "web.regions.jurisdictions.uk.name": {
+    "text": "United Kingdom",
+    "content_hash": "89f9c9f4"
+  },
+  "web.regions.jurisdictions.nz.name": {
+    "text": "New Zealand",
+    "content_hash": "c51ed580"
+  },
+  "web.regions.jurisdictions.at.name": {
+    "text": "Austria",
+    "content_hash": "98917390"
   }
 }

--- a/locales/content/ca_ES/feature-regions.json
+++ b/locales/content/ca_ES/feature-regions.json
@@ -182,5 +182,9 @@
   "web.regions.jurisdictions.at.name": {
     "text": "Austria",
     "content_hash": "98917390"
+  },
+  "web.regions.jurisdictions.apac.name": {
+    "text": "Asia-Pacific",
+    "content_hash": "f8a3b2c1"
   }
 }

--- a/locales/content/cs/feature-regions.json
+++ b/locales/content/cs/feature-regions.json
@@ -182,5 +182,9 @@
   "web.regions.jurisdictions.at.name": {
     "text": "Austria",
     "content_hash": "98917390"
+  },
+  "web.regions.jurisdictions.apac.name": {
+    "text": "Asia-Pacific",
+    "content_hash": "f8a3b2c1"
   }
 }

--- a/locales/content/cs/feature-regions.json
+++ b/locales/content/cs/feature-regions.json
@@ -158,5 +158,29 @@
   "web.regions.changing_regions_subscription_note": {
     "text": "Výhody tvého předplatného se automaticky uplatní na jakýkoli účet vytvořený s tvou fakturační e-mailovou adresou.",
     "source_hash": "5b2238b2"
+  },
+  "web.regions.jurisdictions.eu.name": {
+    "text": "European Union",
+    "content_hash": "9a18968a"
+  },
+  "web.regions.jurisdictions.us.name": {
+    "text": "United States",
+    "content_hash": "f253efe3"
+  },
+  "web.regions.jurisdictions.ca.name": {
+    "text": "Canada",
+    "content_hash": "445d337b"
+  },
+  "web.regions.jurisdictions.uk.name": {
+    "text": "United Kingdom",
+    "content_hash": "89f9c9f4"
+  },
+  "web.regions.jurisdictions.nz.name": {
+    "text": "New Zealand",
+    "content_hash": "c51ed580"
+  },
+  "web.regions.jurisdictions.at.name": {
+    "text": "Austria",
+    "content_hash": "98917390"
   }
 }

--- a/locales/content/da_DK/feature-regions.json
+++ b/locales/content/da_DK/feature-regions.json
@@ -158,5 +158,29 @@
   "web.regions.changing_regions_subscription_note": {
     "text": "Dine abonnementsfordele gælder automatisk for enhver konto oprettet med din fakturerings-e-mailadresse.",
     "source_hash": "5b2238b2"
+  },
+  "web.regions.jurisdictions.eu.name": {
+    "text": "European Union",
+    "content_hash": "9a18968a"
+  },
+  "web.regions.jurisdictions.us.name": {
+    "text": "United States",
+    "content_hash": "f253efe3"
+  },
+  "web.regions.jurisdictions.ca.name": {
+    "text": "Canada",
+    "content_hash": "445d337b"
+  },
+  "web.regions.jurisdictions.uk.name": {
+    "text": "United Kingdom",
+    "content_hash": "89f9c9f4"
+  },
+  "web.regions.jurisdictions.nz.name": {
+    "text": "New Zealand",
+    "content_hash": "c51ed580"
+  },
+  "web.regions.jurisdictions.at.name": {
+    "text": "Austria",
+    "content_hash": "98917390"
   }
 }

--- a/locales/content/da_DK/feature-regions.json
+++ b/locales/content/da_DK/feature-regions.json
@@ -182,5 +182,9 @@
   "web.regions.jurisdictions.at.name": {
     "text": "Austria",
     "content_hash": "98917390"
+  },
+  "web.regions.jurisdictions.apac.name": {
+    "text": "Asia-Pacific",
+    "content_hash": "f8a3b2c1"
   }
 }

--- a/locales/content/de/feature-regions.json
+++ b/locales/content/de/feature-regions.json
@@ -158,5 +158,29 @@
   "web.regions.changing_regions_subscription_note": {
     "text": "Deine Abonnementvorteile gelten automatisch für jedes Konto, das mit deiner Rechnungs-E-Mail-Adresse erstellt wurde.",
     "source_hash": "5b2238b2"
+  },
+  "web.regions.jurisdictions.eu.name": {
+    "text": "European Union",
+    "content_hash": "9a18968a"
+  },
+  "web.regions.jurisdictions.us.name": {
+    "text": "United States",
+    "content_hash": "f253efe3"
+  },
+  "web.regions.jurisdictions.ca.name": {
+    "text": "Canada",
+    "content_hash": "445d337b"
+  },
+  "web.regions.jurisdictions.uk.name": {
+    "text": "United Kingdom",
+    "content_hash": "89f9c9f4"
+  },
+  "web.regions.jurisdictions.nz.name": {
+    "text": "New Zealand",
+    "content_hash": "c51ed580"
+  },
+  "web.regions.jurisdictions.at.name": {
+    "text": "Austria",
+    "content_hash": "98917390"
   }
 }

--- a/locales/content/de/feature-regions.json
+++ b/locales/content/de/feature-regions.json
@@ -182,5 +182,9 @@
   "web.regions.jurisdictions.at.name": {
     "text": "Austria",
     "content_hash": "98917390"
+  },
+  "web.regions.jurisdictions.apac.name": {
+    "text": "Asia-Pacific",
+    "content_hash": "f8a3b2c1"
   }
 }

--- a/locales/content/de_AT/feature-regions.json
+++ b/locales/content/de_AT/feature-regions.json
@@ -158,5 +158,29 @@
   "web.regions.changing_regions_subscription_note": {
     "text": "Ihre Abonnementvorteile werden automatisch auf jedes Konto angewendet, das mit Ihrer Rechnungs-E-Mail-Adresse erstellt wurde.",
     "source_hash": "5b2238b2"
+  },
+  "web.regions.jurisdictions.eu.name": {
+    "text": "European Union",
+    "content_hash": "9a18968a"
+  },
+  "web.regions.jurisdictions.us.name": {
+    "text": "United States",
+    "content_hash": "f253efe3"
+  },
+  "web.regions.jurisdictions.ca.name": {
+    "text": "Canada",
+    "content_hash": "445d337b"
+  },
+  "web.regions.jurisdictions.uk.name": {
+    "text": "United Kingdom",
+    "content_hash": "89f9c9f4"
+  },
+  "web.regions.jurisdictions.nz.name": {
+    "text": "New Zealand",
+    "content_hash": "c51ed580"
+  },
+  "web.regions.jurisdictions.at.name": {
+    "text": "Austria",
+    "content_hash": "98917390"
   }
 }

--- a/locales/content/de_AT/feature-regions.json
+++ b/locales/content/de_AT/feature-regions.json
@@ -182,5 +182,9 @@
   "web.regions.jurisdictions.at.name": {
     "text": "Austria",
     "content_hash": "98917390"
+  },
+  "web.regions.jurisdictions.apac.name": {
+    "text": "Asia-Pacific",
+    "content_hash": "f8a3b2c1"
   }
 }

--- a/locales/content/el_GR/feature-regions.json
+++ b/locales/content/el_GR/feature-regions.json
@@ -158,5 +158,29 @@
   "web.regions.changing_regions_subscription_note": {
     "text": "Τα πλεονεκτήματα της συνδρομής σας θα εφαρμοστούν αυτόματα σε κάθε λογαριασμό που δημιουργείται με τη διεύθυνση email χρέωσης.",
     "source_hash": "5b2238b2"
+  },
+  "web.regions.jurisdictions.eu.name": {
+    "text": "European Union",
+    "content_hash": "9a18968a"
+  },
+  "web.regions.jurisdictions.us.name": {
+    "text": "United States",
+    "content_hash": "f253efe3"
+  },
+  "web.regions.jurisdictions.ca.name": {
+    "text": "Canada",
+    "content_hash": "445d337b"
+  },
+  "web.regions.jurisdictions.uk.name": {
+    "text": "United Kingdom",
+    "content_hash": "89f9c9f4"
+  },
+  "web.regions.jurisdictions.nz.name": {
+    "text": "New Zealand",
+    "content_hash": "c51ed580"
+  },
+  "web.regions.jurisdictions.at.name": {
+    "text": "Austria",
+    "content_hash": "98917390"
   }
 }

--- a/locales/content/el_GR/feature-regions.json
+++ b/locales/content/el_GR/feature-regions.json
@@ -182,5 +182,9 @@
   "web.regions.jurisdictions.at.name": {
     "text": "Austria",
     "content_hash": "98917390"
+  },
+  "web.regions.jurisdictions.apac.name": {
+    "text": "Asia-Pacific",
+    "content_hash": "f8a3b2c1"
   }
 }

--- a/locales/content/en/feature-regions.json
+++ b/locales/content/en/feature-regions.json
@@ -162,5 +162,29 @@
   "web.regions.changing_regions_subscription_note": {
     "text": "Your subscription benefits will automatically apply to any account created with your billing email address.",
     "content_hash": "5b2238b2"
+  },
+  "web.regions.jurisdictions.eu.name": {
+    "text": "European Union",
+    "content_hash": "9a18968a"
+  },
+  "web.regions.jurisdictions.us.name": {
+    "text": "United States",
+    "content_hash": "f253efe3"
+  },
+  "web.regions.jurisdictions.ca.name": {
+    "text": "Canada",
+    "content_hash": "445d337b"
+  },
+  "web.regions.jurisdictions.uk.name": {
+    "text": "United Kingdom",
+    "content_hash": "89f9c9f4"
+  },
+  "web.regions.jurisdictions.nz.name": {
+    "text": "New Zealand",
+    "content_hash": "c51ed580"
+  },
+  "web.regions.jurisdictions.at.name": {
+    "text": "Austria",
+    "content_hash": "98917390"
   }
 }

--- a/locales/content/en/feature-regions.json
+++ b/locales/content/en/feature-regions.json
@@ -186,5 +186,9 @@
   "web.regions.jurisdictions.at.name": {
     "text": "Austria",
     "content_hash": "98917390"
+  },
+  "web.regions.jurisdictions.apac.name": {
+    "text": "Asia-Pacific",
+    "content_hash": "f8a3b2c1"
   }
 }

--- a/locales/content/eo/feature-regions.json
+++ b/locales/content/eo/feature-regions.json
@@ -158,5 +158,29 @@
   "web.regions.changing_regions_subscription_note": {
     "text": "Viaj abonaj avantaĝoj aŭtomate aplikiĝos al ĉiu konto kreita per via faktura retpoŝta adreso.",
     "source_hash": "5b2238b2"
+  },
+  "web.regions.jurisdictions.eu.name": {
+    "text": "European Union",
+    "content_hash": "9a18968a"
+  },
+  "web.regions.jurisdictions.us.name": {
+    "text": "United States",
+    "content_hash": "f253efe3"
+  },
+  "web.regions.jurisdictions.ca.name": {
+    "text": "Canada",
+    "content_hash": "445d337b"
+  },
+  "web.regions.jurisdictions.uk.name": {
+    "text": "United Kingdom",
+    "content_hash": "89f9c9f4"
+  },
+  "web.regions.jurisdictions.nz.name": {
+    "text": "New Zealand",
+    "content_hash": "c51ed580"
+  },
+  "web.regions.jurisdictions.at.name": {
+    "text": "Austria",
+    "content_hash": "98917390"
   }
 }

--- a/locales/content/eo/feature-regions.json
+++ b/locales/content/eo/feature-regions.json
@@ -182,5 +182,9 @@
   "web.regions.jurisdictions.at.name": {
     "text": "Austria",
     "content_hash": "98917390"
+  },
+  "web.regions.jurisdictions.apac.name": {
+    "text": "Asia-Pacific",
+    "content_hash": "f8a3b2c1"
   }
 }

--- a/locales/content/es/feature-regions.json
+++ b/locales/content/es/feature-regions.json
@@ -158,5 +158,29 @@
   "web.regions.changing_regions_subscription_note": {
     "text": "Los beneficios de tu suscripción se aplicarán automáticamente a cualquier cuenta creada con tu dirección de correo de facturación.",
     "source_hash": "5b2238b2"
+  },
+  "web.regions.jurisdictions.eu.name": {
+    "text": "European Union",
+    "content_hash": "9a18968a"
+  },
+  "web.regions.jurisdictions.us.name": {
+    "text": "United States",
+    "content_hash": "f253efe3"
+  },
+  "web.regions.jurisdictions.ca.name": {
+    "text": "Canada",
+    "content_hash": "445d337b"
+  },
+  "web.regions.jurisdictions.uk.name": {
+    "text": "United Kingdom",
+    "content_hash": "89f9c9f4"
+  },
+  "web.regions.jurisdictions.nz.name": {
+    "text": "New Zealand",
+    "content_hash": "c51ed580"
+  },
+  "web.regions.jurisdictions.at.name": {
+    "text": "Austria",
+    "content_hash": "98917390"
   }
 }

--- a/locales/content/es/feature-regions.json
+++ b/locales/content/es/feature-regions.json
@@ -182,5 +182,9 @@
   "web.regions.jurisdictions.at.name": {
     "text": "Austria",
     "content_hash": "98917390"
+  },
+  "web.regions.jurisdictions.apac.name": {
+    "text": "Asia-Pacific",
+    "content_hash": "f8a3b2c1"
   }
 }

--- a/locales/content/fr_CA/feature-regions.json
+++ b/locales/content/fr_CA/feature-regions.json
@@ -158,5 +158,29 @@
   "web.regions.changing_regions_subscription_note": {
     "text": "Vos avantages d'abonnement s'appliqueront automatiquement à tout compte créé avec votre adresse courriel de facturation.",
     "source_hash": "5b2238b2"
+  },
+  "web.regions.jurisdictions.eu.name": {
+    "text": "European Union",
+    "content_hash": "9a18968a"
+  },
+  "web.regions.jurisdictions.us.name": {
+    "text": "United States",
+    "content_hash": "f253efe3"
+  },
+  "web.regions.jurisdictions.ca.name": {
+    "text": "Canada",
+    "content_hash": "445d337b"
+  },
+  "web.regions.jurisdictions.uk.name": {
+    "text": "United Kingdom",
+    "content_hash": "89f9c9f4"
+  },
+  "web.regions.jurisdictions.nz.name": {
+    "text": "New Zealand",
+    "content_hash": "c51ed580"
+  },
+  "web.regions.jurisdictions.at.name": {
+    "text": "Austria",
+    "content_hash": "98917390"
   }
 }

--- a/locales/content/fr_CA/feature-regions.json
+++ b/locales/content/fr_CA/feature-regions.json
@@ -182,5 +182,9 @@
   "web.regions.jurisdictions.at.name": {
     "text": "Austria",
     "content_hash": "98917390"
+  },
+  "web.regions.jurisdictions.apac.name": {
+    "text": "Asia-Pacific",
+    "content_hash": "f8a3b2c1"
   }
 }

--- a/locales/content/fr_FR/feature-regions.json
+++ b/locales/content/fr_FR/feature-regions.json
@@ -158,5 +158,29 @@
   "web.regions.changing_regions_subscription_note": {
     "text": "Vos avantages d'abonnement s'appliqueront automatiquement à tout compte créé avec votre adresse e-mail de facturation.",
     "source_hash": "5b2238b2"
+  },
+  "web.regions.jurisdictions.eu.name": {
+    "text": "European Union",
+    "content_hash": "9a18968a"
+  },
+  "web.regions.jurisdictions.us.name": {
+    "text": "United States",
+    "content_hash": "f253efe3"
+  },
+  "web.regions.jurisdictions.ca.name": {
+    "text": "Canada",
+    "content_hash": "445d337b"
+  },
+  "web.regions.jurisdictions.uk.name": {
+    "text": "United Kingdom",
+    "content_hash": "89f9c9f4"
+  },
+  "web.regions.jurisdictions.nz.name": {
+    "text": "New Zealand",
+    "content_hash": "c51ed580"
+  },
+  "web.regions.jurisdictions.at.name": {
+    "text": "Austria",
+    "content_hash": "98917390"
   }
 }

--- a/locales/content/fr_FR/feature-regions.json
+++ b/locales/content/fr_FR/feature-regions.json
@@ -182,5 +182,9 @@
   "web.regions.jurisdictions.at.name": {
     "text": "Austria",
     "content_hash": "98917390"
+  },
+  "web.regions.jurisdictions.apac.name": {
+    "text": "Asia-Pacific",
+    "content_hash": "f8a3b2c1"
   }
 }

--- a/locales/content/he/feature-regions.json
+++ b/locales/content/he/feature-regions.json
@@ -158,5 +158,29 @@
   "web.regions.changing_regions_subscription_note": {
     "text": "הטבות המנוי שלך יחולו אוטומטית על כל חשבון שנוצר עם כתובת הדואר האלקטרוני לחיוב שלך.",
     "source_hash": "5b2238b2"
+  },
+  "web.regions.jurisdictions.eu.name": {
+    "text": "European Union",
+    "content_hash": "9a18968a"
+  },
+  "web.regions.jurisdictions.us.name": {
+    "text": "United States",
+    "content_hash": "f253efe3"
+  },
+  "web.regions.jurisdictions.ca.name": {
+    "text": "Canada",
+    "content_hash": "445d337b"
+  },
+  "web.regions.jurisdictions.uk.name": {
+    "text": "United Kingdom",
+    "content_hash": "89f9c9f4"
+  },
+  "web.regions.jurisdictions.nz.name": {
+    "text": "New Zealand",
+    "content_hash": "c51ed580"
+  },
+  "web.regions.jurisdictions.at.name": {
+    "text": "Austria",
+    "content_hash": "98917390"
   }
 }

--- a/locales/content/he/feature-regions.json
+++ b/locales/content/he/feature-regions.json
@@ -182,5 +182,9 @@
   "web.regions.jurisdictions.at.name": {
     "text": "Austria",
     "content_hash": "98917390"
+  },
+  "web.regions.jurisdictions.apac.name": {
+    "text": "Asia-Pacific",
+    "content_hash": "f8a3b2c1"
   }
 }

--- a/locales/content/hu/feature-regions.json
+++ b/locales/content/hu/feature-regions.json
@@ -158,5 +158,29 @@
   "web.regions.changing_regions_subscription_note": {
     "text": "Az előfizetési előnyök automatikusan érvényesek minden olyan fiókra, amelyet a számlázási e-mail címével hoztak létre.",
     "source_hash": "5b2238b2"
+  },
+  "web.regions.jurisdictions.eu.name": {
+    "text": "European Union",
+    "content_hash": "9a18968a"
+  },
+  "web.regions.jurisdictions.us.name": {
+    "text": "United States",
+    "content_hash": "f253efe3"
+  },
+  "web.regions.jurisdictions.ca.name": {
+    "text": "Canada",
+    "content_hash": "445d337b"
+  },
+  "web.regions.jurisdictions.uk.name": {
+    "text": "United Kingdom",
+    "content_hash": "89f9c9f4"
+  },
+  "web.regions.jurisdictions.nz.name": {
+    "text": "New Zealand",
+    "content_hash": "c51ed580"
+  },
+  "web.regions.jurisdictions.at.name": {
+    "text": "Austria",
+    "content_hash": "98917390"
   }
 }

--- a/locales/content/hu/feature-regions.json
+++ b/locales/content/hu/feature-regions.json
@@ -182,5 +182,9 @@
   "web.regions.jurisdictions.at.name": {
     "text": "Austria",
     "content_hash": "98917390"
+  },
+  "web.regions.jurisdictions.apac.name": {
+    "text": "Asia-Pacific",
+    "content_hash": "f8a3b2c1"
   }
 }

--- a/locales/content/it_IT/feature-regions.json
+++ b/locales/content/it_IT/feature-regions.json
@@ -158,5 +158,29 @@
   "web.regions.changing_regions_subscription_note": {
     "text": "I vantaggi dell'abbonamento verranno applicati automaticamente a qualsiasi account creato con l'indirizzo email di fatturazione.",
     "source_hash": "5b2238b2"
+  },
+  "web.regions.jurisdictions.eu.name": {
+    "text": "European Union",
+    "content_hash": "9a18968a"
+  },
+  "web.regions.jurisdictions.us.name": {
+    "text": "United States",
+    "content_hash": "f253efe3"
+  },
+  "web.regions.jurisdictions.ca.name": {
+    "text": "Canada",
+    "content_hash": "445d337b"
+  },
+  "web.regions.jurisdictions.uk.name": {
+    "text": "United Kingdom",
+    "content_hash": "89f9c9f4"
+  },
+  "web.regions.jurisdictions.nz.name": {
+    "text": "New Zealand",
+    "content_hash": "c51ed580"
+  },
+  "web.regions.jurisdictions.at.name": {
+    "text": "Austria",
+    "content_hash": "98917390"
   }
 }

--- a/locales/content/it_IT/feature-regions.json
+++ b/locales/content/it_IT/feature-regions.json
@@ -182,5 +182,9 @@
   "web.regions.jurisdictions.at.name": {
     "text": "Austria",
     "content_hash": "98917390"
+  },
+  "web.regions.jurisdictions.apac.name": {
+    "text": "Asia-Pacific",
+    "content_hash": "f8a3b2c1"
   }
 }

--- a/locales/content/ja/feature-regions.json
+++ b/locales/content/ja/feature-regions.json
@@ -158,5 +158,29 @@
   "web.regions.changing_regions_subscription_note": {
     "text": "サブスクリプション特典は、請求先メールアドレスで作成されたすべてのアカウントに自動的に適用されます。",
     "source_hash": "5b2238b2"
+  },
+  "web.regions.jurisdictions.eu.name": {
+    "text": "European Union",
+    "content_hash": "9a18968a"
+  },
+  "web.regions.jurisdictions.us.name": {
+    "text": "United States",
+    "content_hash": "f253efe3"
+  },
+  "web.regions.jurisdictions.ca.name": {
+    "text": "Canada",
+    "content_hash": "445d337b"
+  },
+  "web.regions.jurisdictions.uk.name": {
+    "text": "United Kingdom",
+    "content_hash": "89f9c9f4"
+  },
+  "web.regions.jurisdictions.nz.name": {
+    "text": "New Zealand",
+    "content_hash": "c51ed580"
+  },
+  "web.regions.jurisdictions.at.name": {
+    "text": "Austria",
+    "content_hash": "98917390"
   }
 }

--- a/locales/content/ja/feature-regions.json
+++ b/locales/content/ja/feature-regions.json
@@ -182,5 +182,9 @@
   "web.regions.jurisdictions.at.name": {
     "text": "Austria",
     "content_hash": "98917390"
+  },
+  "web.regions.jurisdictions.apac.name": {
+    "text": "Asia-Pacific",
+    "content_hash": "f8a3b2c1"
   }
 }

--- a/locales/content/ko/feature-regions.json
+++ b/locales/content/ko/feature-regions.json
@@ -158,5 +158,29 @@
   "web.regions.changing_regions_subscription_note": {
     "text": "결제 이메일 주소로 생성된 모든 계정에 구독 혜택이 자동으로 적용됩니다.",
     "source_hash": "5b2238b2"
+  },
+  "web.regions.jurisdictions.eu.name": {
+    "text": "European Union",
+    "content_hash": "9a18968a"
+  },
+  "web.regions.jurisdictions.us.name": {
+    "text": "United States",
+    "content_hash": "f253efe3"
+  },
+  "web.regions.jurisdictions.ca.name": {
+    "text": "Canada",
+    "content_hash": "445d337b"
+  },
+  "web.regions.jurisdictions.uk.name": {
+    "text": "United Kingdom",
+    "content_hash": "89f9c9f4"
+  },
+  "web.regions.jurisdictions.nz.name": {
+    "text": "New Zealand",
+    "content_hash": "c51ed580"
+  },
+  "web.regions.jurisdictions.at.name": {
+    "text": "Austria",
+    "content_hash": "98917390"
   }
 }

--- a/locales/content/ko/feature-regions.json
+++ b/locales/content/ko/feature-regions.json
@@ -182,5 +182,9 @@
   "web.regions.jurisdictions.at.name": {
     "text": "Austria",
     "content_hash": "98917390"
+  },
+  "web.regions.jurisdictions.apac.name": {
+    "text": "Asia-Pacific",
+    "content_hash": "f8a3b2c1"
   }
 }

--- a/locales/content/mi_NZ/feature-regions.json
+++ b/locales/content/mi_NZ/feature-regions.json
@@ -158,5 +158,29 @@
   "web.regions.changing_regions_subscription_note": {
     "text": "Ka tukuna aunoa ō painga ohaurunga ki ngā pūkete katoa i hangaia mā tō wāhitau īmēra nama.",
     "source_hash": "5b2238b2"
+  },
+  "web.regions.jurisdictions.eu.name": {
+    "text": "European Union",
+    "content_hash": "9a18968a"
+  },
+  "web.regions.jurisdictions.us.name": {
+    "text": "United States",
+    "content_hash": "f253efe3"
+  },
+  "web.regions.jurisdictions.ca.name": {
+    "text": "Canada",
+    "content_hash": "445d337b"
+  },
+  "web.regions.jurisdictions.uk.name": {
+    "text": "United Kingdom",
+    "content_hash": "89f9c9f4"
+  },
+  "web.regions.jurisdictions.nz.name": {
+    "text": "New Zealand",
+    "content_hash": "c51ed580"
+  },
+  "web.regions.jurisdictions.at.name": {
+    "text": "Austria",
+    "content_hash": "98917390"
   }
 }

--- a/locales/content/mi_NZ/feature-regions.json
+++ b/locales/content/mi_NZ/feature-regions.json
@@ -182,5 +182,9 @@
   "web.regions.jurisdictions.at.name": {
     "text": "Austria",
     "content_hash": "98917390"
+  },
+  "web.regions.jurisdictions.apac.name": {
+    "text": "Asia-Pacific",
+    "content_hash": "f8a3b2c1"
   }
 }

--- a/locales/content/nl/feature-regions.json
+++ b/locales/content/nl/feature-regions.json
@@ -158,5 +158,29 @@
   "web.regions.changing_regions_subscription_note": {
     "text": "Je abonnementsvoordelen worden automatisch toegepast op elk account dat is aangemaakt met je factuur-e-mailadres.",
     "source_hash": "5b2238b2"
+  },
+  "web.regions.jurisdictions.eu.name": {
+    "text": "European Union",
+    "content_hash": "9a18968a"
+  },
+  "web.regions.jurisdictions.us.name": {
+    "text": "United States",
+    "content_hash": "f253efe3"
+  },
+  "web.regions.jurisdictions.ca.name": {
+    "text": "Canada",
+    "content_hash": "445d337b"
+  },
+  "web.regions.jurisdictions.uk.name": {
+    "text": "United Kingdom",
+    "content_hash": "89f9c9f4"
+  },
+  "web.regions.jurisdictions.nz.name": {
+    "text": "New Zealand",
+    "content_hash": "c51ed580"
+  },
+  "web.regions.jurisdictions.at.name": {
+    "text": "Austria",
+    "content_hash": "98917390"
   }
 }

--- a/locales/content/nl/feature-regions.json
+++ b/locales/content/nl/feature-regions.json
@@ -182,5 +182,9 @@
   "web.regions.jurisdictions.at.name": {
     "text": "Austria",
     "content_hash": "98917390"
+  },
+  "web.regions.jurisdictions.apac.name": {
+    "text": "Asia-Pacific",
+    "content_hash": "f8a3b2c1"
   }
 }

--- a/locales/content/pl/feature-regions.json
+++ b/locales/content/pl/feature-regions.json
@@ -158,5 +158,29 @@
   "web.regions.changing_regions_subscription_note": {
     "text": "Korzyści z Twojej subskrypcji zostaną automatycznie zastosowane do każdego konta utworzonego z Twoim adresem e-mail do rozliczeń.",
     "source_hash": "5b2238b2"
+  },
+  "web.regions.jurisdictions.eu.name": {
+    "text": "European Union",
+    "content_hash": "9a18968a"
+  },
+  "web.regions.jurisdictions.us.name": {
+    "text": "United States",
+    "content_hash": "f253efe3"
+  },
+  "web.regions.jurisdictions.ca.name": {
+    "text": "Canada",
+    "content_hash": "445d337b"
+  },
+  "web.regions.jurisdictions.uk.name": {
+    "text": "United Kingdom",
+    "content_hash": "89f9c9f4"
+  },
+  "web.regions.jurisdictions.nz.name": {
+    "text": "New Zealand",
+    "content_hash": "c51ed580"
+  },
+  "web.regions.jurisdictions.at.name": {
+    "text": "Austria",
+    "content_hash": "98917390"
   }
 }

--- a/locales/content/pl/feature-regions.json
+++ b/locales/content/pl/feature-regions.json
@@ -182,5 +182,9 @@
   "web.regions.jurisdictions.at.name": {
     "text": "Austria",
     "content_hash": "98917390"
+  },
+  "web.regions.jurisdictions.apac.name": {
+    "text": "Asia-Pacific",
+    "content_hash": "f8a3b2c1"
   }
 }

--- a/locales/content/pt_BR/feature-regions.json
+++ b/locales/content/pt_BR/feature-regions.json
@@ -158,5 +158,29 @@
   "web.regions.changing_regions_subscription_note": {
     "text": "Os benefícios da sua assinatura serão aplicados automaticamente a qualquer conta criada com seu endereço de e-mail de cobrança.",
     "source_hash": "5b2238b2"
+  },
+  "web.regions.jurisdictions.eu.name": {
+    "text": "European Union",
+    "content_hash": "9a18968a"
+  },
+  "web.regions.jurisdictions.us.name": {
+    "text": "United States",
+    "content_hash": "f253efe3"
+  },
+  "web.regions.jurisdictions.ca.name": {
+    "text": "Canada",
+    "content_hash": "445d337b"
+  },
+  "web.regions.jurisdictions.uk.name": {
+    "text": "United Kingdom",
+    "content_hash": "89f9c9f4"
+  },
+  "web.regions.jurisdictions.nz.name": {
+    "text": "New Zealand",
+    "content_hash": "c51ed580"
+  },
+  "web.regions.jurisdictions.at.name": {
+    "text": "Austria",
+    "content_hash": "98917390"
   }
 }

--- a/locales/content/pt_BR/feature-regions.json
+++ b/locales/content/pt_BR/feature-regions.json
@@ -182,5 +182,9 @@
   "web.regions.jurisdictions.at.name": {
     "text": "Austria",
     "content_hash": "98917390"
+  },
+  "web.regions.jurisdictions.apac.name": {
+    "text": "Asia-Pacific",
+    "content_hash": "f8a3b2c1"
   }
 }

--- a/locales/content/pt_PT/feature-regions.json
+++ b/locales/content/pt_PT/feature-regions.json
@@ -182,5 +182,9 @@
   "web.regions.jurisdictions.at.name": {
     "text": "Austria",
     "content_hash": "98917390"
+  },
+  "web.regions.jurisdictions.apac.name": {
+    "text": "Asia-Pacific",
+    "content_hash": "f8a3b2c1"
   }
 }

--- a/locales/content/pt_PT/feature-regions.json
+++ b/locales/content/pt_PT/feature-regions.json
@@ -158,5 +158,29 @@
   "web.regions.changing_regions_subscription_note": {
     "text": "Os benefícios da sua subscrição serão aplicados automaticamente a qualquer conta criada com o seu endereço de e-mail de faturação.",
     "source_hash": "5b2238b2"
+  },
+  "web.regions.jurisdictions.eu.name": {
+    "text": "European Union",
+    "content_hash": "9a18968a"
+  },
+  "web.regions.jurisdictions.us.name": {
+    "text": "United States",
+    "content_hash": "f253efe3"
+  },
+  "web.regions.jurisdictions.ca.name": {
+    "text": "Canada",
+    "content_hash": "445d337b"
+  },
+  "web.regions.jurisdictions.uk.name": {
+    "text": "United Kingdom",
+    "content_hash": "89f9c9f4"
+  },
+  "web.regions.jurisdictions.nz.name": {
+    "text": "New Zealand",
+    "content_hash": "c51ed580"
+  },
+  "web.regions.jurisdictions.at.name": {
+    "text": "Austria",
+    "content_hash": "98917390"
   }
 }

--- a/locales/content/ru/feature-regions.json
+++ b/locales/content/ru/feature-regions.json
@@ -182,5 +182,9 @@
   "web.regions.jurisdictions.at.name": {
     "text": "Austria",
     "content_hash": "98917390"
+  },
+  "web.regions.jurisdictions.apac.name": {
+    "text": "Asia-Pacific",
+    "content_hash": "f8a3b2c1"
   }
 }

--- a/locales/content/ru/feature-regions.json
+++ b/locales/content/ru/feature-regions.json
@@ -158,5 +158,29 @@
   "web.regions.changing_regions_subscription_note": {
     "text": "Преимущества Вашей подписки будут автоматически применены к любому аккаунту, созданному с Вашим платёжным адресом электронной почты.",
     "source_hash": "5b2238b2"
+  },
+  "web.regions.jurisdictions.eu.name": {
+    "text": "European Union",
+    "content_hash": "9a18968a"
+  },
+  "web.regions.jurisdictions.us.name": {
+    "text": "United States",
+    "content_hash": "f253efe3"
+  },
+  "web.regions.jurisdictions.ca.name": {
+    "text": "Canada",
+    "content_hash": "445d337b"
+  },
+  "web.regions.jurisdictions.uk.name": {
+    "text": "United Kingdom",
+    "content_hash": "89f9c9f4"
+  },
+  "web.regions.jurisdictions.nz.name": {
+    "text": "New Zealand",
+    "content_hash": "c51ed580"
+  },
+  "web.regions.jurisdictions.at.name": {
+    "text": "Austria",
+    "content_hash": "98917390"
   }
 }

--- a/locales/content/sl_SI/feature-regions.json
+++ b/locales/content/sl_SI/feature-regions.json
@@ -158,5 +158,29 @@
   "web.regions.changing_regions_subscription_note": {
     "text": "Ugodnosti vaše naročnine se bodo samodejno uporabile za vsak račun, ustvarjen z vašim e-poštnim naslovom za obračun.",
     "source_hash": "5b2238b2"
+  },
+  "web.regions.jurisdictions.eu.name": {
+    "text": "European Union",
+    "content_hash": "9a18968a"
+  },
+  "web.regions.jurisdictions.us.name": {
+    "text": "United States",
+    "content_hash": "f253efe3"
+  },
+  "web.regions.jurisdictions.ca.name": {
+    "text": "Canada",
+    "content_hash": "445d337b"
+  },
+  "web.regions.jurisdictions.uk.name": {
+    "text": "United Kingdom",
+    "content_hash": "89f9c9f4"
+  },
+  "web.regions.jurisdictions.nz.name": {
+    "text": "New Zealand",
+    "content_hash": "c51ed580"
+  },
+  "web.regions.jurisdictions.at.name": {
+    "text": "Austria",
+    "content_hash": "98917390"
   }
 }

--- a/locales/content/sl_SI/feature-regions.json
+++ b/locales/content/sl_SI/feature-regions.json
@@ -182,5 +182,9 @@
   "web.regions.jurisdictions.at.name": {
     "text": "Austria",
     "content_hash": "98917390"
+  },
+  "web.regions.jurisdictions.apac.name": {
+    "text": "Asia-Pacific",
+    "content_hash": "f8a3b2c1"
   }
 }

--- a/locales/content/sv_SE/feature-regions.json
+++ b/locales/content/sv_SE/feature-regions.json
@@ -158,5 +158,29 @@
   "web.regions.changing_regions_subscription_note": {
     "text": "Dina prenumerationsförmåner gäller automatiskt för alla konton som skapas med din e-postadress för fakturering.",
     "source_hash": "5b2238b2"
+  },
+  "web.regions.jurisdictions.eu.name": {
+    "text": "European Union",
+    "content_hash": "9a18968a"
+  },
+  "web.regions.jurisdictions.us.name": {
+    "text": "United States",
+    "content_hash": "f253efe3"
+  },
+  "web.regions.jurisdictions.ca.name": {
+    "text": "Canada",
+    "content_hash": "445d337b"
+  },
+  "web.regions.jurisdictions.uk.name": {
+    "text": "United Kingdom",
+    "content_hash": "89f9c9f4"
+  },
+  "web.regions.jurisdictions.nz.name": {
+    "text": "New Zealand",
+    "content_hash": "c51ed580"
+  },
+  "web.regions.jurisdictions.at.name": {
+    "text": "Austria",
+    "content_hash": "98917390"
   }
 }

--- a/locales/content/sv_SE/feature-regions.json
+++ b/locales/content/sv_SE/feature-regions.json
@@ -182,5 +182,9 @@
   "web.regions.jurisdictions.at.name": {
     "text": "Austria",
     "content_hash": "98917390"
+  },
+  "web.regions.jurisdictions.apac.name": {
+    "text": "Asia-Pacific",
+    "content_hash": "f8a3b2c1"
   }
 }

--- a/locales/content/tr/feature-regions.json
+++ b/locales/content/tr/feature-regions.json
@@ -158,5 +158,29 @@
   "web.regions.changing_regions_subscription_note": {
     "text": "Abonelik avantajlarınız, fatura e-posta adresinizle oluşturulan tüm hesaplara otomatik olarak uygulanır.",
     "source_hash": "5b2238b2"
+  },
+  "web.regions.jurisdictions.eu.name": {
+    "text": "European Union",
+    "content_hash": "9a18968a"
+  },
+  "web.regions.jurisdictions.us.name": {
+    "text": "United States",
+    "content_hash": "f253efe3"
+  },
+  "web.regions.jurisdictions.ca.name": {
+    "text": "Canada",
+    "content_hash": "445d337b"
+  },
+  "web.regions.jurisdictions.uk.name": {
+    "text": "United Kingdom",
+    "content_hash": "89f9c9f4"
+  },
+  "web.regions.jurisdictions.nz.name": {
+    "text": "New Zealand",
+    "content_hash": "c51ed580"
+  },
+  "web.regions.jurisdictions.at.name": {
+    "text": "Austria",
+    "content_hash": "98917390"
   }
 }

--- a/locales/content/tr/feature-regions.json
+++ b/locales/content/tr/feature-regions.json
@@ -182,5 +182,9 @@
   "web.regions.jurisdictions.at.name": {
     "text": "Austria",
     "content_hash": "98917390"
+  },
+  "web.regions.jurisdictions.apac.name": {
+    "text": "Asia-Pacific",
+    "content_hash": "f8a3b2c1"
   }
 }

--- a/locales/content/uk/feature-regions.json
+++ b/locales/content/uk/feature-regions.json
@@ -158,5 +158,29 @@
   "web.regions.changing_regions_subscription_note": {
     "text": "Переваги вашої підписки автоматично застосовуватимуться до будь-якого облікового запису, створеного з вашою адресою електронної пошти для оплати.",
     "source_hash": "5b2238b2"
+  },
+  "web.regions.jurisdictions.eu.name": {
+    "text": "European Union",
+    "content_hash": "9a18968a"
+  },
+  "web.regions.jurisdictions.us.name": {
+    "text": "United States",
+    "content_hash": "f253efe3"
+  },
+  "web.regions.jurisdictions.ca.name": {
+    "text": "Canada",
+    "content_hash": "445d337b"
+  },
+  "web.regions.jurisdictions.uk.name": {
+    "text": "United Kingdom",
+    "content_hash": "89f9c9f4"
+  },
+  "web.regions.jurisdictions.nz.name": {
+    "text": "New Zealand",
+    "content_hash": "c51ed580"
+  },
+  "web.regions.jurisdictions.at.name": {
+    "text": "Austria",
+    "content_hash": "98917390"
   }
 }

--- a/locales/content/uk/feature-regions.json
+++ b/locales/content/uk/feature-regions.json
@@ -182,5 +182,9 @@
   "web.regions.jurisdictions.at.name": {
     "text": "Austria",
     "content_hash": "98917390"
+  },
+  "web.regions.jurisdictions.apac.name": {
+    "text": "Asia-Pacific",
+    "content_hash": "f8a3b2c1"
   }
 }

--- a/locales/content/vi/feature-regions.json
+++ b/locales/content/vi/feature-regions.json
@@ -158,5 +158,29 @@
   "web.regions.changing_regions_subscription_note": {
     "text": "Quyền lợi đăng ký của bạn sẽ tự động áp dụng cho bất kỳ tài khoản nào được tạo bằng địa chỉ email thanh toán.",
     "source_hash": "5b2238b2"
+  },
+  "web.regions.jurisdictions.eu.name": {
+    "text": "European Union",
+    "content_hash": "9a18968a"
+  },
+  "web.regions.jurisdictions.us.name": {
+    "text": "United States",
+    "content_hash": "f253efe3"
+  },
+  "web.regions.jurisdictions.ca.name": {
+    "text": "Canada",
+    "content_hash": "445d337b"
+  },
+  "web.regions.jurisdictions.uk.name": {
+    "text": "United Kingdom",
+    "content_hash": "89f9c9f4"
+  },
+  "web.regions.jurisdictions.nz.name": {
+    "text": "New Zealand",
+    "content_hash": "c51ed580"
+  },
+  "web.regions.jurisdictions.at.name": {
+    "text": "Austria",
+    "content_hash": "98917390"
   }
 }

--- a/locales/content/vi/feature-regions.json
+++ b/locales/content/vi/feature-regions.json
@@ -182,5 +182,9 @@
   "web.regions.jurisdictions.at.name": {
     "text": "Austria",
     "content_hash": "98917390"
+  },
+  "web.regions.jurisdictions.apac.name": {
+    "text": "Asia-Pacific",
+    "content_hash": "f8a3b2c1"
   }
 }

--- a/locales/content/zh/feature-regions.json
+++ b/locales/content/zh/feature-regions.json
@@ -158,5 +158,29 @@
   "web.regions.changing_regions_subscription_note": {
     "text": "您的订阅权益将自动应用于使用账单邮箱地址创建的任何账户。",
     "source_hash": "5b2238b2"
+  },
+  "web.regions.jurisdictions.eu.name": {
+    "text": "European Union",
+    "content_hash": "9a18968a"
+  },
+  "web.regions.jurisdictions.us.name": {
+    "text": "United States",
+    "content_hash": "f253efe3"
+  },
+  "web.regions.jurisdictions.ca.name": {
+    "text": "Canada",
+    "content_hash": "445d337b"
+  },
+  "web.regions.jurisdictions.uk.name": {
+    "text": "United Kingdom",
+    "content_hash": "89f9c9f4"
+  },
+  "web.regions.jurisdictions.nz.name": {
+    "text": "New Zealand",
+    "content_hash": "c51ed580"
+  },
+  "web.regions.jurisdictions.at.name": {
+    "text": "Austria",
+    "content_hash": "98917390"
   }
 }

--- a/locales/content/zh/feature-regions.json
+++ b/locales/content/zh/feature-regions.json
@@ -182,5 +182,9 @@
   "web.regions.jurisdictions.at.name": {
     "text": "Austria",
     "content_hash": "98917390"
+  },
+  "web.regions.jurisdictions.apac.name": {
+    "text": "Asia-Pacific",
+    "content_hash": "f8a3b2c1"
   }
 }

--- a/spec/config.test.yaml
+++ b/spec/config.test.yaml
@@ -81,19 +81,10 @@ features:
   regions:
     enabled: false
     current_jurisdiction: 'EU'
-    jurisdictions:
-      - identifier: AT
-        display_name: Atat Region
-        domain: at.example.com
-        icon:
-          collection: heroicon
-          name: inbox
-      - identifier: CE
-        display_name: CECE Region
-        domain: ce.example.com
-        icon:
-          collection: heroicon
-          name: mail
+    # JURISDICTIONS env var format: ID:domain,ID:domain
+    # Example: JURISDICTIONS=AT:at.example.com,CE:ce.example.com
+    # For tests, this is set in spec_helper or individual specs via ENV
+    jurisdictions: <%= ENV['JURISDICTIONS'] || '' %>
   domains:
     enabled: false
     # The default domain used for link URLs. When not set or empty,

--- a/spec/integration/all/config/after_load_spec.rb
+++ b/spec/integration/all/config/after_load_spec.rb
@@ -334,7 +334,7 @@ RSpec.describe "Onetime boot configuration process", type: :integration do
 
       processed_config = Onetime::Config.after_load(config)
 
-      expect(processed_config['features']['regions']).to eq({ 'enabled' => false })
+      expect(processed_config['features']['regions']).to eq({ 'enabled' => false, 'jurisdictions' => [] })
     end
 
     it 'disables authentication sub-features when main feature is off' do
@@ -688,18 +688,18 @@ RSpec.describe "Onetime boot configuration process", type: :integration do
         }.to raise_error(OT::ConfigError, /site\.domains/)
       end
 
-      it 'logs and continues when on_deprecated_config is warn' do
+      it 'logs and continues when deprecated_config_mode is warn' do
         allow(OT).to receive(:le)
         base_config['site']['regions'] = { 'enabled' => true }
-        base_config['compatibility'] = { 'on_deprecated_config' => 'warn' }
+        base_config['compatibility'] = { 'deprecated_config_mode' => 'warn' }
 
         expect { Onetime::Config.after_load(base_config) }.not_to raise_error
         expect(OT).to have_received(:le).with(/CONFIG DEPRECATION.*site\.regions/)
       end
 
-      it 'ignores deprecated keys when on_deprecated_config is silent' do
+      it 'ignores deprecated keys when deprecated_config_mode is silent' do
         base_config['site']['domains'] = { 'enabled' => true }
-        base_config['compatibility'] = { 'on_deprecated_config' => 'silent' }
+        base_config['compatibility'] = { 'deprecated_config_mode' => 'silent' }
 
         expect { Onetime::Config.after_load(base_config) }.not_to raise_error
       end
@@ -709,7 +709,7 @@ RSpec.describe "Onetime boot configuration process", type: :integration do
 
         expect {
           Onetime::Config.after_load(base_config)
-        }.to raise_error(OT::ConfigError, /UI_HOMEPAGE_TRUSTED_PROXY_DEPTH/)
+        }.to raise_error(OT::ConfigError, /trusted_proxy_depth is ignored/)
       ensure
         ENV.delete('UI_HOMEPAGE_TRUSTED_PROXY_DEPTH')
       end

--- a/spec/unit/onetime/config/load_spec.rb
+++ b/spec/unit/onetime/config/load_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe Onetime::Config do
 
       it 'raises ArgumentError for unreadable file' do
         nonexistent_path = '/path/does/not/exist.yaml'
-        expect { described_class.load(nonexistent_path) }.to raise_error(OT::ConfigError, /Bad path/)
+        expect { described_class.load(nonexistent_path) }.to raise_error(OT::ConfigError, /Config not readable/)
       end
 
       it 'exits with error for invalid YAML' do

--- a/spec/unit/onetime/config_spec.rb
+++ b/spec/unit/onetime/config_spec.rb
@@ -274,7 +274,7 @@ RSpec.describe Onetime::Config do
           'site' => { 'secret' => 'test-secret' },
           'mail' => { 'truemail' => {} },
           'features' => { 'regions' => { 'jurisdictions' => jurisdictions_value } },
-          'compatibility' => { 'on_deprecated_config' => 'silent' },
+          'compatibility' => { 'deprecated_config_mode' => 'silent' },
         }
       end
 
@@ -386,12 +386,12 @@ RSpec.describe Onetime::Config do
 
         expect {
           described_class.after_load(config)
-        }.to raise_error(OT::ConfigError, /features\.regions\.jurisdictions array in YAML is deprecated/)
+        }.to raise_error(OT::ConfigError, /features\.regions\.jurisdictions is ignored/)
       end
 
       it 'logs warning in warn mode when YAML array is present' do
         config = build_deprecated_config.merge(
-          'compatibility' => { 'on_deprecated_config' => 'warn' }
+          'compatibility' => { 'deprecated_config_mode' => 'warn' }
         )
 
         expect(OT).to receive(:le).with(/CONFIG DEPRECATION:.*jurisdictions/)
@@ -403,7 +403,7 @@ RSpec.describe Onetime::Config do
 
       it 'ignores deprecation in silent mode' do
         config = build_deprecated_config.merge(
-          'compatibility' => { 'on_deprecated_config' => 'silent' }
+          'compatibility' => { 'deprecated_config_mode' => 'silent' }
         )
 
         expect {

--- a/spec/unit/onetime/config_spec.rb
+++ b/spec/unit/onetime/config_spec.rb
@@ -278,27 +278,43 @@ RSpec.describe Onetime::Config do
         }
       end
 
-      it 'parses single jurisdiction from env format' do
+      it 'parses single jurisdiction from env format with i18n key' do
         config = build_config('EU:eu.example.com')
 
         result = described_class.after_load(config)
         jurisdictions = result.dig('features', 'regions', 'jurisdictions')
 
         expect(jurisdictions).to eq([
-          { 'identifier' => 'EU', 'domain' => 'eu.example.com' },
+          {
+            'identifier' => 'EU',
+            'domain' => 'eu.example.com',
+            'display_name_i18n_key' => 'web.regions.jurisdictions.eu.name',
+          },
         ])
       end
 
-      it 'parses multiple jurisdictions from env format' do
+      it 'parses multiple jurisdictions from env format with i18n keys' do
         config = build_config('EU:eu.example.com,CA:ca.example.com,US:us.example.com')
 
         result = described_class.after_load(config)
         jurisdictions = result.dig('features', 'regions', 'jurisdictions')
 
         expect(jurisdictions).to eq([
-          { 'identifier' => 'EU', 'domain' => 'eu.example.com' },
-          { 'identifier' => 'CA', 'domain' => 'ca.example.com' },
-          { 'identifier' => 'US', 'domain' => 'us.example.com' },
+          {
+            'identifier' => 'EU',
+            'domain' => 'eu.example.com',
+            'display_name_i18n_key' => 'web.regions.jurisdictions.eu.name',
+          },
+          {
+            'identifier' => 'CA',
+            'domain' => 'ca.example.com',
+            'display_name_i18n_key' => 'web.regions.jurisdictions.ca.name',
+          },
+          {
+            'identifier' => 'US',
+            'domain' => 'us.example.com',
+            'display_name_i18n_key' => 'web.regions.jurisdictions.us.name',
+          },
         ])
       end
 
@@ -337,7 +353,11 @@ RSpec.describe Onetime::Config do
         jurisdictions = result.dig('features', 'regions', 'jurisdictions')
 
         expect(jurisdictions).to eq([
-          { 'identifier' => 'EU', 'domain' => '' },
+          {
+            'identifier' => 'EU',
+            'domain' => '',
+            'display_name_i18n_key' => 'web.regions.jurisdictions.eu.name',
+          },
         ])
       end
 
@@ -349,18 +369,26 @@ RSpec.describe Onetime::Config do
 
         # split(':', 2) preserves the port in domain
         expect(jurisdictions).to eq([
-          { 'identifier' => 'EU', 'domain' => 'eu.example.com:8443' },
+          {
+            'identifier' => 'EU',
+            'domain' => 'eu.example.com:8443',
+            'display_name_i18n_key' => 'web.regions.jurisdictions.eu.name',
+          },
         ])
       end
 
-      it 'preserves existing array format' do
+      it 'preserves existing array format and adds i18n key' do
         config = build_config([{ 'identifier' => 'AT', 'domain' => 'at.example.com' }])
 
         result = described_class.after_load(config)
         jurisdictions = result.dig('features', 'regions', 'jurisdictions')
 
         expect(jurisdictions).to eq([
-          { 'identifier' => 'AT', 'domain' => 'at.example.com' },
+          {
+            'identifier' => 'AT',
+            'domain' => 'at.example.com',
+            'display_name_i18n_key' => 'web.regions.jurisdictions.at.name',
+          },
         ])
       end
     end
@@ -386,7 +414,7 @@ RSpec.describe Onetime::Config do
 
         expect {
           described_class.after_load(config)
-        }.to raise_error(OT::ConfigError, /features\.regions\.jurisdictions is ignored/)
+        }.to raise_error(OT::ConfigError, /jurisdictions array format is deprecated/)
       end
 
       it 'logs warning in warn mode when YAML array is present' do
@@ -394,7 +422,7 @@ RSpec.describe Onetime::Config do
           'compatibility' => { 'deprecated_config_mode' => 'warn' }
         )
 
-        expect(OT).to receive(:le).with(/CONFIG DEPRECATION:.*jurisdictions/)
+        expect(OT).to receive(:le).with(/CONFIG DEPRECATION:.*jurisdictions array format/)
 
         expect {
           described_class.after_load(config)

--- a/spec/unit/onetime/config_spec.rb
+++ b/spec/unit/onetime/config_spec.rb
@@ -267,6 +267,151 @@ RSpec.describe Onetime::Config do
   end
 
   describe '#after_load' do
+    context 'jurisdiction parsing from JURISDICTIONS env var' do
+      # Use 'silent' to bypass deprecation check - we're testing parsing, not deprecation
+      def build_config(jurisdictions_value)
+        {
+          'site' => { 'secret' => 'test-secret' },
+          'mail' => { 'truemail' => {} },
+          'features' => { 'regions' => { 'jurisdictions' => jurisdictions_value } },
+          'compatibility' => { 'on_deprecated_config' => 'silent' },
+        }
+      end
+
+      it 'parses single jurisdiction from env format' do
+        config = build_config('EU:eu.example.com')
+
+        result = described_class.after_load(config)
+        jurisdictions = result.dig('features', 'regions', 'jurisdictions')
+
+        expect(jurisdictions).to eq([
+          { 'identifier' => 'EU', 'domain' => 'eu.example.com' },
+        ])
+      end
+
+      it 'parses multiple jurisdictions from env format' do
+        config = build_config('EU:eu.example.com,CA:ca.example.com,US:us.example.com')
+
+        result = described_class.after_load(config)
+        jurisdictions = result.dig('features', 'regions', 'jurisdictions')
+
+        expect(jurisdictions).to eq([
+          { 'identifier' => 'EU', 'domain' => 'eu.example.com' },
+          { 'identifier' => 'CA', 'domain' => 'ca.example.com' },
+          { 'identifier' => 'US', 'domain' => 'us.example.com' },
+        ])
+      end
+
+      it 'handles empty string as empty array' do
+        config = build_config('')
+
+        result = described_class.after_load(config)
+        jurisdictions = result.dig('features', 'regions', 'jurisdictions')
+
+        expect(jurisdictions).to eq([])
+      end
+
+      it 'handles nil as empty array' do
+        config = build_config(nil)
+
+        result = described_class.after_load(config)
+        jurisdictions = result.dig('features', 'regions', 'jurisdictions')
+
+        expect(jurisdictions).to eq([])
+      end
+
+      it 'trims whitespace around entries' do
+        config = build_config(' EU:eu.example.com , CA:ca.example.com ')
+
+        result = described_class.after_load(config)
+        jurisdictions = result.dig('features', 'regions', 'jurisdictions')
+
+        expect(jurisdictions[0]['identifier']).to eq('EU')
+        expect(jurisdictions[1]['identifier']).to eq('CA')
+      end
+
+      it 'handles malformed entry (missing domain) gracefully' do
+        config = build_config('EU:')
+
+        result = described_class.after_load(config)
+        jurisdictions = result.dig('features', 'regions', 'jurisdictions')
+
+        expect(jurisdictions).to eq([
+          { 'identifier' => 'EU', 'domain' => '' },
+        ])
+      end
+
+      it 'handles entry with multiple colons (domain with port)' do
+        config = build_config('EU:eu.example.com:8443')
+
+        result = described_class.after_load(config)
+        jurisdictions = result.dig('features', 'regions', 'jurisdictions')
+
+        # split(':', 2) preserves the port in domain
+        expect(jurisdictions).to eq([
+          { 'identifier' => 'EU', 'domain' => 'eu.example.com:8443' },
+        ])
+      end
+
+      it 'preserves existing array format' do
+        config = build_config([{ 'identifier' => 'AT', 'domain' => 'at.example.com' }])
+
+        result = described_class.after_load(config)
+        jurisdictions = result.dig('features', 'regions', 'jurisdictions')
+
+        expect(jurisdictions).to eq([
+          { 'identifier' => 'AT', 'domain' => 'at.example.com' },
+        ])
+      end
+    end
+
+    context 'deprecation detection for YAML jurisdictions array' do
+      def build_deprecated_config
+        {
+          'site' => { 'secret' => 'test-secret' },
+          'mail' => { 'truemail' => {} },
+          'features' => {
+            'regions' => {
+              'jurisdictions' => [
+                { 'identifier' => 'EU', 'domain' => 'eu.example.com' },
+              ],
+            },
+          },
+        }
+      end
+
+      it 'raises ConfigError in strict mode (default) when YAML array is present' do
+        config = build_deprecated_config
+        # strict is the default when not specified
+
+        expect {
+          described_class.after_load(config)
+        }.to raise_error(OT::ConfigError, /features\.regions\.jurisdictions array in YAML is deprecated/)
+      end
+
+      it 'logs warning in warn mode when YAML array is present' do
+        config = build_deprecated_config.merge(
+          'compatibility' => { 'on_deprecated_config' => 'warn' }
+        )
+
+        expect(OT).to receive(:le).with(/CONFIG DEPRECATION:.*jurisdictions/)
+
+        expect {
+          described_class.after_load(config)
+        }.not_to raise_error
+      end
+
+      it 'ignores deprecation in silent mode' do
+        config = build_deprecated_config.merge(
+          'compatibility' => { 'on_deprecated_config' => 'silent' }
+        )
+
+        expect {
+          described_class.after_load(config)
+        }.not_to raise_error
+      end
+    end
+
     context 'site configuration validation' do
       it 'uses default values when site has minimal config' do
         raw_config = {

--- a/spec/unit/onetime/config_spec.rb
+++ b/spec/unit/onetime/config_spec.rb
@@ -343,22 +343,44 @@ RSpec.describe Onetime::Config do
         jurisdictions = result.dig('features', 'regions', 'jurisdictions')
 
         expect(jurisdictions[0]['identifier']).to eq('EU')
+        expect(jurisdictions[0]['domain']).to eq('eu.example.com')
         expect(jurisdictions[1]['identifier']).to eq('CA')
+        expect(jurisdictions[1]['domain']).to eq('ca.example.com')
       end
 
-      it 'handles malformed entry (missing domain) gracefully' do
-        config = build_config('EU:')
+      it 'handles trailing comma gracefully' do
+        config = build_config('EU:eu.example.com,CA:ca.example.com,')
 
         result = described_class.after_load(config)
         jurisdictions = result.dig('features', 'regions', 'jurisdictions')
 
-        expect(jurisdictions).to eq([
-          {
-            'identifier' => 'EU',
-            'domain' => '',
-            'display_name_i18n_key' => 'web.regions.jurisdictions.eu.name',
-          },
-        ])
+        expect(jurisdictions.length).to eq(2)
+        expect(jurisdictions[0]['identifier']).to eq('EU')
+        expect(jurisdictions[1]['identifier']).to eq('CA')
+      end
+
+      it 'raises OT::Problem when domain is missing' do
+        config = build_config('EU:')
+
+        expect {
+          described_class.after_load(config)
+        }.to raise_error(OT::Problem, /Invalid JURISDICTIONS format:.*EU:.*expected ID:domain/)
+      end
+
+      it 'raises OT::Problem when identifier is missing' do
+        config = build_config(':domain.com')
+
+        expect {
+          described_class.after_load(config)
+        }.to raise_error(OT::Problem, /Invalid JURISDICTIONS format:.*:domain.com.*expected ID:domain/)
+      end
+
+      it 'raises OT::Problem for entry with only colon' do
+        config = build_config(':')
+
+        expect {
+          described_class.after_load(config)
+        }.to raise_error(OT::Problem, /Invalid JURISDICTIONS format/)
       end
 
       it 'handles entry with multiple colons (domain with port)' do

--- a/src/apps/session/components/AuthView.vue
+++ b/src/apps/session/components/AuthView.vue
@@ -3,8 +3,10 @@
 <script setup lang="ts">
   import { useI18n } from 'vue-i18n';
   import OIcon from '@/shared/components/icons/OIcon.vue';
-  import type { Jurisdiction } from '@/schemas/shapes/config';
-  import { useJurisdictionStore } from '@/shared/stores/jurisdictionStore';
+  import {
+    useJurisdictionStore,
+    useJurisdictionDisplayNames,
+  } from '@/shared/stores/jurisdictionStore';
   import { storeToRefs } from 'pinia';
   import { computed } from 'vue';
 
@@ -46,20 +48,22 @@
   // Initialize jurisdiction store
   const jurisdictionStore = useJurisdictionStore();
   const { getCurrentJurisdiction } = storeToRefs(jurisdictionStore);
+  const { currentJurisdictionWithDisplayName } = useJurisdictionDisplayNames();
 
   // Compute the current jurisdiction or default to unknown
-  const currentJurisdiction = computed(
-    (): Jurisdiction =>
-      getCurrentJurisdiction.value || {
-        identifier: t('web.regions.unknown_jurisdiction'),
-        display_name: t('web.regions.unknown_jurisdiction'),
-        domain: '',
-        icon: {
-          collection: 'mdi',
-          name: 'help-circle',
-        },
-        enabled: false,
-      }
+  // Uses resolved display_name from i18n
+  const currentJurisdiction = computed(() =>
+    currentJurisdictionWithDisplayName.value || {
+      identifier: t('web.regions.unknown_jurisdiction'),
+      display_name_i18n_key: 'web.regions.unknown_jurisdiction',
+      display_name: t('web.regions.unknown_jurisdiction'),
+      domain: '',
+      icon: {
+        collection: 'mdi',
+        name: 'help-circle',
+      },
+      enabled: false,
+    }
   );
 
   // Compute the background icon based on jurisdiction status

--- a/src/apps/session/views/Register.vue
+++ b/src/apps/session/views/Register.vue
@@ -5,30 +5,28 @@
   import AlternateSignUpMethods from '@/apps/session/components/AlternateSignUpMethods.vue';
   import AuthView from '@/apps/session/components/AuthView.vue';
   import SignUpForm from '@/apps/session/components/SignUpForm.vue';
-  import { useJurisdictionStore } from '@/shared/stores/jurisdictionStore';
+  import { useJurisdictionDisplayNames } from '@/shared/stores/jurisdictionStore';
   import { useLanguageStore } from '@/shared/stores/languageStore';
-  import { storeToRefs } from 'pinia';
   import { computed } from 'vue';
   import { useRoute } from 'vue-router';
   const { t } = useI18n();
   const route = useRoute();
 
-  const jurisdictionStore = useJurisdictionStore();
-  const { getCurrentJurisdiction } = storeToRefs(jurisdictionStore);
+  const { currentJurisdictionWithDisplayName } = useJurisdictionDisplayNames();
 
   const languageStore = useLanguageStore();
-  const currentJurisdiction = computed(
-    () =>
-      getCurrentJurisdiction.value || {
-        identifier: t('web.regions.unknown_jurisdiction'),
-        display_name: t('web.regions.unknown_jurisdiction'),
-        domain: '',
-        icon: {
-          collection: 'mdi',
-          name: 'help-circle',
-        },
-        enabled: false,
-      }
+  const currentJurisdiction = computed(() =>
+    currentJurisdictionWithDisplayName.value || {
+      identifier: t('web.regions.unknown_jurisdiction'),
+      display_name_i18n_key: 'web.regions.unknown_jurisdiction',
+      display_name: t('web.regions.unknown_jurisdiction'),
+      domain: '',
+      icon: {
+        collection: 'mdi',
+        name: 'help-circle',
+      },
+      enabled: false,
+    }
   );
 
   const alternateProviders = [

--- a/src/apps/workspace/account/region/CurrentRegion.vue
+++ b/src/apps/workspace/account/region/CurrentRegion.vue
@@ -5,13 +5,12 @@
   import OIcon from '@/shared/components/icons/OIcon.vue';
   import SettingsLayout from '@/apps/workspace/layouts/SettingsLayout.vue';
   import JurisdictionInfo from '@/shared/components/modals/settings/JurisdictionInfo.vue';
-  import { useJurisdictionStore } from '@/shared/stores/jurisdictionStore';
-  import { computed, onMounted } from 'vue';
+  import { useJurisdictionStore, useJurisdictionDisplayNames } from '@/shared/stores/jurisdictionStore';
+  import { onMounted } from 'vue';
 
   const { t } = useI18n();
   const jurisdictionStore = useJurisdictionStore();
-
-  const currentJurisdiction = computed(() => jurisdictionStore.getCurrentJurisdiction);
+  const { currentJurisdictionWithDisplayName: currentJurisdiction } = useJurisdictionDisplayNames();
 
   onMounted(async () => {
     jurisdictionStore.init();

--- a/src/schemas/contracts/config/public.ts
+++ b/src/schemas/contracts/config/public.ts
@@ -144,13 +144,21 @@ export const publicAuthenticationSchema = z.object({
 export type PublicAuthenticationSettings = z.infer<typeof publicAuthenticationSchema>;
 
 /**
+ * Schema for jurisdiction icon
+ */
+const jurisdictionIconSchema = z.object({
+  collection: z.string(),
+  name: z.string(),
+});
+
+/**
  * Schema for the :jurisdiction section
  */
 const jurisdictionSchema = z.object({
   identifier: z.string(),
   display_name_i18n_key: z.string(),
   domain: z.string(),
-  icon: z.string(),
+  icon: jurisdictionIconSchema.optional(),
 });
 
 /**

--- a/src/schemas/contracts/config/public.ts
+++ b/src/schemas/contracts/config/public.ts
@@ -148,7 +148,7 @@ export type PublicAuthenticationSettings = z.infer<typeof publicAuthenticationSc
  */
 const jurisdictionSchema = z.object({
   identifier: z.string(),
-  display_name: z.string(),
+  display_name_i18n_key: z.string(),
   domain: z.string(),
   icon: z.string(),
 });

--- a/src/schemas/contracts/config/section/jurisdiction.ts
+++ b/src/schemas/contracts/config/section/jurisdiction.ts
@@ -22,12 +22,15 @@ const jurisdictionIconSchema = z.object({
 
 /**
  * Canonical jurisdiction schema
+ *
+ * The serializer sends display_name_i18n_key (e.g., 'web.regions.jurisdictions.eu.name')
+ * which components resolve via i18n. display_name is computed at runtime.
  */
 const jurisdictionSchema = z.object({
   identifier: z.string().min(2).max(24),
-  display_name: z.string(),
+  display_name_i18n_key: z.string(),
   domain: z.string(),
-  icon: jurisdictionIconSchema,
+  icon: jurisdictionIconSchema.optional(),
   enabled: z.boolean().default(true),
 });
 

--- a/src/shared/components/logos/OnetimeSecretLogo.vue
+++ b/src/shared/components/logos/OnetimeSecretLogo.vue
@@ -6,7 +6,10 @@
   import OIcon from '@/shared/components/icons/OIcon.vue';
   import OnetimeSecretIcon from '@/shared/components/icons/OnetimeSecretIcon.vue';
   import type { Jurisdiction } from '@/schemas/contracts/config/section/jurisdiction';
-  import { useJurisdictionStore } from '@/shared/stores/jurisdictionStore';
+  import {
+    useJurisdictionStore,
+    useJurisdictionDisplayNames,
+  } from '@/shared/stores/jurisdictionStore';
   import type { LogoConfig } from '@/types/ui/layouts';
   import { onKeyStroke, useEventListener } from '@vueuse/core';
   import { computed, nextTick, ref, watch } from 'vue';
@@ -37,9 +40,8 @@
 
   // Jurisdiction store and selection handling
   const jurisdictionStore = useJurisdictionStore();
-  const currentJurisdiction = computed<Jurisdiction | null>(
-    () => jurisdictionStore.getCurrentJurisdiction
-  );
+  const { jurisdictionsWithDisplayName, currentJurisdictionWithDisplayName } = useJurisdictionDisplayNames();
+  const currentJurisdiction = currentJurisdictionWithDisplayName;
 
   const canShowJurisdictionSelector = computed(() => (
       !props.isUserPresent &&
@@ -176,7 +178,7 @@
             </div>
             <!-- prettier-ignore-attribute class -->
             <div
-              v-for="(jurisdiction, index) in jurisdictionStore.jurisdictions"
+              v-for="(jurisdiction, index) in jurisdictionsWithDisplayName"
               :key="jurisdiction.identifier"
               :id="`jurisdiction-option-${index}`"
               role="option"

--- a/src/shared/components/modals/settings/JurisdictionInfo.vue
+++ b/src/shared/components/modals/settings/JurisdictionInfo.vue
@@ -1,28 +1,33 @@
 <!-- src/shared/components/modals/settings/JurisdictionInfo.vue -->
 
 <script setup lang="ts">
-  import { useI18n } from 'vue-i18n';
+import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
 import OIcon from '@/shared/components/icons/OIcon.vue';
 import type { Jurisdiction } from '@/schemas/shapes/config';
+import { resolveJurisdictionIcon, resolveJurisdictionDisplayName } from '@/shared/stores/jurisdictionStore';
 
 const { t } = useI18n();
 
-defineProps<{
+const props = defineProps<{
   jurisdiction: Jurisdiction;
 }>();
+
+const icon = computed(() => resolveJurisdictionIcon(props.jurisdiction));
+const displayName = computed(() => resolveJurisdictionDisplayName(props.jurisdiction, t));
 </script>
 
 <template>
   <div class="space-y-4 sm:space-y-6">
     <div class="flex flex-col items-center gap-2 sm:flex-row">
       <OIcon
-        :collection="jurisdiction.icon.collection"
-        :name="jurisdiction.icon.name"
+        :collection="icon.collection"
+        :name="icon.name"
         class="size-5 shrink-0"
         aria-hidden="true" />
       <p class="m-0 text-center text-gray-700 dark:text-gray-200 sm:text-left">
         {{ t('web.regions.your_account_and_data_are_protected_under_the_la') }}
-        <strong class="font-medium">{{ jurisdiction.display_name }}</strong>
+        <strong class="font-medium">{{ displayName }}</strong>
       </p>
     </div>
 

--- a/src/shared/components/modals/settings/JurisdictionList.vue
+++ b/src/shared/components/modals/settings/JurisdictionList.vue
@@ -1,9 +1,10 @@
 <!-- src/shared/components/modals/settings/JurisdictionList.vue -->
 
 <script setup lang="ts">
-  import { useI18n } from 'vue-i18n';
+import { useI18n } from 'vue-i18n';
 import OIcon from '@/shared/components/icons/OIcon.vue';
 import type { Jurisdiction } from '@/schemas/shapes/config';
+import { resolveJurisdictionIcon, resolveJurisdictionDisplayName } from '@/shared/stores/jurisdictionStore';
 
 const { t } = useI18n();
 
@@ -14,6 +15,9 @@ const props = defineProps<{
 
 const isCurrentJurisdiction = (jurisdiction: Jurisdiction) =>
   jurisdiction.identifier === props.currentJurisdiction?.identifier;
+
+const getIcon = (jurisdiction: Jurisdiction) => resolveJurisdictionIcon(jurisdiction);
+const getDisplayName = (jurisdiction: Jurisdiction) => resolveJurisdictionDisplayName(jurisdiction, t);
 </script>
 
 <template>
@@ -26,8 +30,8 @@ const isCurrentJurisdiction = (jurisdiction: Jurisdiction) =>
       class="flex flex-wrap items-center gap-3 p-3 transition-colors hover:bg-gray-50 dark:hover:bg-gray-800 sm:flex-nowrap sm:p-4">
       <div class="flex w-full items-center gap-3 sm:w-auto">
         <OIcon
-          :collection="jurisdiction.icon.collection"
-          :name="jurisdiction.icon.name"
+          :collection="getIcon(jurisdiction).collection"
+          :name="getIcon(jurisdiction).name"
           class="size-5 shrink-0 text-gray-400 dark:text-gray-500"
           aria-hidden="true" />
 
@@ -36,8 +40,8 @@ const isCurrentJurisdiction = (jurisdiction: Jurisdiction) =>
           :class="{ 'font-medium': isCurrentJurisdiction(jurisdiction) }"
           class="grow text-sm text-gray-700 hover:text-brand-600 dark:text-gray-200 dark:hover:text-brand-400"
           :aria-current="isCurrentJurisdiction(jurisdiction) ? 'true' : undefined"
-          :aria-label="t('web.regions.jurisdiction_display_name_iscurrentjurisdiction_', [jurisdiction.display_name, isCurrentJurisdiction(jurisdiction) ? `(Current)` : ``])">
-          {{ jurisdiction.display_name }}
+          :aria-label="t('web.regions.jurisdiction_display_name_iscurrentjurisdiction_', [getDisplayName(jurisdiction), isCurrentJurisdiction(jurisdiction) ? `(Current)` : ``])">
+          {{ getDisplayName(jurisdiction) }}
         </a>
       </div>
 

--- a/src/shared/components/modals/settings/JurisdictionTab.vue
+++ b/src/shared/components/modals/settings/JurisdictionTab.vue
@@ -4,7 +4,7 @@
   import { useI18n } from 'vue-i18n';
 import OIcon from '@/shared/components/icons/OIcon.vue';
 import { useBootstrapStore } from '@/shared/stores/bootstrapStore';
-import { useJurisdictionStore } from '@/shared/stores/jurisdictionStore';
+import { useJurisdictionDisplayNames } from '@/shared/stores/jurisdictionStore';
 import { storeToRefs } from 'pinia';
 import { computed } from 'vue';
 
@@ -16,9 +16,10 @@ import JurisdictionList from './JurisdictionList.vue';
 const bootstrapStore = useBootstrapStore();
 const { cust } = storeToRefs(bootstrapStore);
 
-const jurisdictionStore = useJurisdictionStore();
-const currentJurisdiction = computed(() => jurisdictionStore.getCurrentJurisdiction);
-const jurisdictions = computed(() => jurisdictionStore.getAllJurisdictions);
+const {
+  currentJurisdictionWithDisplayName: currentJurisdiction,
+  jurisdictionsWithDisplayName: jurisdictions,
+} = useJurisdictionDisplayNames();
 const customerId = computed(() => cust.value?.extid);
 </script>
 

--- a/src/shared/components/ui/JurisdictionToggle.vue
+++ b/src/shared/components/ui/JurisdictionToggle.vue
@@ -4,11 +4,17 @@
   import { useI18n } from 'vue-i18n';
   import OIcon from '@/shared/components/icons/OIcon.vue';
   import { useClickOutside } from '@/shared/composables/useClickOutside';
-  import type { Jurisdiction } from '@/schemas/contracts/config/section/jurisdiction';
-  import { useJurisdictionStore } from '@/shared/stores/jurisdictionStore';
-  import { computed, ref } from 'vue';
+    import {
+    useJurisdictionDisplayNames,
+    type JurisdictionWithDisplayName,
+  } from '@/shared/stores/jurisdictionStore';
+  import { ref } from 'vue';
 
 const { t } = useI18n();
+  const {
+    currentJurisdictionWithDisplayName,
+    jurisdictionsWithDisplayName,
+  } = useJurisdictionDisplayNames();
 
   /* Vue 3 Reactivity Guide: Rules for Store Access
   * ─────────────────────────────────────────
@@ -24,15 +30,10 @@ const { t } = useI18n();
   *    const jurisdictionStore = useJurisdictionStore()
   *    <template>{{ jurisdictionStore.currentJurisdiction }}</template> => {...}
   */
-  const jurisdictionStore = useJurisdictionStore();
 
-  // Computed properties with null checks
-  const currentJurisdiction = computed<Jurisdiction | null>(
-    () => jurisdictionStore.getCurrentJurisdiction
-  );
-  const jurisdictions = computed<Jurisdiction[]>(
-    () => jurisdictionStore.getAllJurisdictions
-  );
+  // Use jurisdictions with resolved display names
+  const currentJurisdiction = currentJurisdictionWithDisplayName;
+  const jurisdictions = jurisdictionsWithDisplayName;
 
   const isOpen = ref(false);
   const dropdownRef = ref<HTMLElement | null>(null);
@@ -69,7 +70,7 @@ const { t } = useI18n();
   };
 
   // Navigate to the appropriate jurisdiction URL
-  const navigateToJurisdiction = (jurisdiction: Jurisdiction) => {
+  const navigateToJurisdiction = (jurisdiction: JurisdictionWithDisplayName) => {
     window.location.href = `https://${jurisdiction.domain}/`;
   };
 
@@ -117,7 +118,7 @@ const { t } = useI18n();
   };
 
   // Handle option item activation via keyboard or click
-  const handleOptionActivation = (jurisdiction: Jurisdiction, index: number) => {
+  const handleOptionActivation = (jurisdiction: JurisdictionWithDisplayName, index: number) => {
     activeIndex.value = index;
     navigateToJurisdiction(jurisdiction);
   };
@@ -125,9 +126,9 @@ const { t } = useI18n();
   useClickOutside(dropdownRef, closeDropdown);
 
   // Safety functions for icon props
-  const getIconCollection = (jurisdiction: Jurisdiction | null): string => jurisdiction?.icon?.collection || 'fa6-solid';
+  const getIconCollection = (jurisdiction: JurisdictionWithDisplayName | null): string => jurisdiction?.icon?.collection || 'fa6-solid';
 
-  const getIconName = (jurisdiction: Jurisdiction | null): string => jurisdiction?.icon?.name || 'globe';
+  const getIconName = (jurisdiction: JurisdictionWithDisplayName | null): string => jurisdiction?.icon?.name || 'globe';
 </script>
 
 <template>

--- a/src/shared/stores/jurisdictionStore.ts
+++ b/src/shared/stores/jurisdictionStore.ts
@@ -26,10 +26,11 @@ export function resolveJurisdictionIcon(jurisdiction: Jurisdiction): Jurisdictio
 }
 
 /**
- * Jurisdiction with resolved display_name from i18n.
+ * Jurisdiction with resolved display_name from i18n and resolved icon.
  */
 export interface JurisdictionWithDisplayName extends Jurisdiction {
   display_name: string;
+  icon: JurisdictionIcon;
 }
 
 /**
@@ -59,12 +60,14 @@ export function useJurisdictionDisplayNames() {
     return {
       ...jurisdiction,
       display_name: resolveDisplayName(jurisdiction),
+      icon: resolveJurisdictionIcon(jurisdiction),
     };
   });
 
   const jurisdictionsWithDisplayName = computed((): JurisdictionWithDisplayName[] => jurisdictionStore.getAllJurisdictions.map((j) => ({
       ...j,
       display_name: resolveDisplayName(j),
+      icon: resolveJurisdictionIcon(j),
     })));
 
   return {

--- a/src/shared/stores/jurisdictionStore.ts
+++ b/src/shared/stores/jurisdictionStore.ts
@@ -2,12 +2,96 @@
 
 import { createError } from '@/shared/composables/useAsyncHandler';
 import { PiniaPluginOptions } from '@/plugins/pinia';
-import type { Jurisdiction, RegionsConfig } from '@/schemas/shapes/config';
+import type { Jurisdiction, JurisdictionIcon, RegionsConfig } from '@/schemas/shapes/config';
 import { useBootstrapStore } from '@/shared/stores/bootstrapStore';
 import { useApi } from '@/shared/composables/useApi';
 import type { PiniaCustomProperties } from 'pinia';
 import { defineStore, storeToRefs } from 'pinia';
 import { computed, ref } from 'vue';
+import { useI18n } from 'vue-i18n';
+
+/**
+ * Default icon mapping for jurisdiction identifiers.
+ * Used when jurisdiction.icon is not provided in config.
+ */
+export const JURISDICTION_ICONS: Record<string, JurisdictionIcon> = {
+  EU: { collection: 'heroicons-solid', name: 'globe-europe-africa' },
+  US: { collection: 'heroicons-solid', name: 'flag' },
+  CA: { collection: 'heroicons-solid', name: 'flag' },
+  UK: { collection: 'heroicons-solid', name: 'flag' },
+  NZ: { collection: 'heroicons-solid', name: 'globe-asia-australia' },
+  AT: { collection: 'heroicons-solid', name: 'flag' },
+};
+
+const DEFAULT_ICON: JurisdictionIcon = {
+  collection: 'heroicons-solid',
+  name: 'globe-alt',
+};
+
+/**
+ * Get the icon for a jurisdiction identifier.
+ * Falls back to globe-alt if no mapping exists.
+ */
+export function getJurisdictionIcon(identifier: string): JurisdictionIcon {
+  return JURISDICTION_ICONS[identifier.toUpperCase()] ?? DEFAULT_ICON;
+}
+
+/**
+ * Resolve the icon for a jurisdiction, preferring the jurisdiction's own icon
+ * if present, otherwise falling back to the identifier mapping.
+ */
+export function resolveJurisdictionIcon(jurisdiction: Jurisdiction): JurisdictionIcon {
+  return jurisdiction.icon ?? getJurisdictionIcon(jurisdiction.identifier);
+}
+
+/**
+ * Jurisdiction with resolved display_name from i18n.
+ */
+export interface JurisdictionWithDisplayName extends Jurisdiction {
+  display_name: string;
+}
+
+/**
+ * Resolve display_name from i18n key.
+ * Must be called within Vue's setup context.
+ */
+export function resolveJurisdictionDisplayName(
+  jurisdiction: Jurisdiction,
+  t: (key: string) => string
+): string {
+  return t(jurisdiction.display_name_i18n_key);
+}
+
+/**
+ * Composable that provides jurisdictions with resolved display names.
+ * Must be called within Vue's setup context.
+ */
+export function useJurisdictionDisplayNames() {
+  const { t } = useI18n();
+  const jurisdictionStore = useJurisdictionStore();
+
+  const resolveDisplayName = (jurisdiction: Jurisdiction): string => t(jurisdiction.display_name_i18n_key);
+
+  const currentJurisdictionWithDisplayName = computed((): JurisdictionWithDisplayName | null => {
+    const jurisdiction = jurisdictionStore.getCurrentJurisdiction;
+    if (!jurisdiction) return null;
+    return {
+      ...jurisdiction,
+      display_name: resolveDisplayName(jurisdiction),
+    };
+  });
+
+  const jurisdictionsWithDisplayName = computed((): JurisdictionWithDisplayName[] => jurisdictionStore.getAllJurisdictions.map((j) => ({
+      ...j,
+      display_name: resolveDisplayName(j),
+    })));
+
+  return {
+    resolveDisplayName,
+    currentJurisdictionWithDisplayName,
+    jurisdictionsWithDisplayName,
+  };
+}
 
 /**
  * N.B.

--- a/src/shared/stores/jurisdictionStore.ts
+++ b/src/shared/stores/jurisdictionStore.ts
@@ -9,32 +9,13 @@ import type { PiniaCustomProperties } from 'pinia';
 import { defineStore, storeToRefs } from 'pinia';
 import { computed, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
+import {
+  JURISDICTION_ICONS,
+  getJurisdictionIcon,
+} from '@/sources/jurisdictions';
 
-/**
- * Default icon mapping for jurisdiction identifiers.
- * Used when jurisdiction.icon is not provided in config.
- */
-export const JURISDICTION_ICONS: Record<string, JurisdictionIcon> = {
-  EU: { collection: 'heroicons-solid', name: 'globe-europe-africa' },
-  US: { collection: 'heroicons-solid', name: 'flag' },
-  CA: { collection: 'heroicons-solid', name: 'flag' },
-  UK: { collection: 'heroicons-solid', name: 'flag' },
-  NZ: { collection: 'heroicons-solid', name: 'globe-asia-australia' },
-  AT: { collection: 'heroicons-solid', name: 'flag' },
-};
-
-const DEFAULT_ICON: JurisdictionIcon = {
-  collection: 'heroicons-solid',
-  name: 'globe-alt',
-};
-
-/**
- * Get the icon for a jurisdiction identifier.
- * Falls back to globe-alt if no mapping exists.
- */
-export function getJurisdictionIcon(identifier: string): JurisdictionIcon {
-  return JURISDICTION_ICONS[identifier.toUpperCase()] ?? DEFAULT_ICON;
-}
+// Re-export for backward compatibility
+export { JURISDICTION_ICONS, getJurisdictionIcon };
 
 /**
  * Resolve the icon for a jurisdiction, preferring the jurisdiction's own icon

--- a/src/sources/jurisdictions.ts
+++ b/src/sources/jurisdictions.ts
@@ -1,0 +1,41 @@
+// src/sources/jurisdictions.ts
+//
+// Static jurisdiction metadata for icon display.
+// Identifiers and domains come from config (ENV/YAML).
+// Display names come from i18n keys: web.regions.jurisdictions.{id}.name
+
+/**
+ * Icon configuration for jurisdiction display.
+ * Matches JurisdictionIcon type from schemas/contracts/config/section/jurisdiction.ts
+ */
+export interface JurisdictionIconConfig {
+  collection: string;
+  name: string;
+}
+
+/**
+ * Default icon definitions for known jurisdiction identifiers.
+ * Used when jurisdiction config doesn't include icon data.
+ */
+export const JURISDICTION_ICONS: Record<string, JurisdictionIconConfig> = {
+  EU: { collection: 'fa6-solid', name: 'earth-europe' },
+  US: { collection: 'fa6-solid', name: 'earth-americas' },
+  CA: { collection: 'fa6-solid', name: 'earth-americas' },
+  UK: { collection: 'fa6-solid', name: 'earth-europe' },
+  NZ: { collection: 'fa6-solid', name: 'earth-oceania' },
+  AT: { collection: 'fa6-solid', name: 'earth-europe' },
+  APAC: { collection: 'fa6-solid', name: 'earth-asia' },
+};
+
+export const DEFAULT_JURISDICTION_ICON: JurisdictionIconConfig = {
+  collection: 'fa6-solid',
+  name: 'globe',
+};
+
+/**
+ * Get the icon for a jurisdiction identifier.
+ * Falls back to default globe icon if no mapping exists.
+ */
+export function getJurisdictionIcon(identifier: string): JurisdictionIconConfig {
+  return JURISDICTION_ICONS[identifier.toUpperCase()] ?? DEFAULT_JURISDICTION_ICON;
+}

--- a/src/tests/sources/jurisdictions.spec.ts
+++ b/src/tests/sources/jurisdictions.spec.ts
@@ -1,0 +1,63 @@
+// src/tests/sources/jurisdictions.spec.ts
+
+import { describe, it, expect } from 'vitest';
+import {
+  JURISDICTION_ICONS,
+  DEFAULT_JURISDICTION_ICON,
+  getJurisdictionIcon,
+} from '@/sources/jurisdictions';
+
+describe('jurisdictions', () => {
+  describe('JURISDICTION_ICONS', () => {
+    it('contains expected jurisdiction identifiers', () => {
+      expect(JURISDICTION_ICONS).toHaveProperty('EU');
+      expect(JURISDICTION_ICONS).toHaveProperty('US');
+      expect(JURISDICTION_ICONS).toHaveProperty('CA');
+      expect(JURISDICTION_ICONS).toHaveProperty('UK');
+      expect(JURISDICTION_ICONS).toHaveProperty('NZ');
+    });
+
+    it('uses fa6-solid collection for all icons', () => {
+      Object.values(JURISDICTION_ICONS).forEach((icon) => {
+        expect(icon.collection).toBe('fa6-solid');
+      });
+    });
+  });
+
+  describe('DEFAULT_JURISDICTION_ICON', () => {
+    it('provides fa6-solid globe as fallback', () => {
+      expect(DEFAULT_JURISDICTION_ICON).toEqual({
+        collection: 'fa6-solid',
+        name: 'globe',
+      });
+    });
+  });
+
+  describe('getJurisdictionIcon', () => {
+    it('returns mapped icon for known identifier', () => {
+      expect(getJurisdictionIcon('EU')).toEqual({
+        collection: 'fa6-solid',
+        name: 'earth-europe',
+      });
+    });
+
+    it('returns default for unknown identifier', () => {
+      expect(getJurisdictionIcon('XX')).toEqual(DEFAULT_JURISDICTION_ICON);
+    });
+
+    it('handles case insensitivity (lowercase input)', () => {
+      expect(getJurisdictionIcon('eu')).toEqual(getJurisdictionIcon('EU'));
+    });
+
+    it('handles case insensitivity (mixed case input)', () => {
+      expect(getJurisdictionIcon('Eu')).toEqual(getJurisdictionIcon('EU'));
+    });
+
+    it('returns correct icon for each known jurisdiction', () => {
+      expect(getJurisdictionIcon('US').name).toBe('earth-americas');
+      expect(getJurisdictionIcon('CA').name).toBe('earth-americas');
+      expect(getJurisdictionIcon('UK').name).toBe('earth-europe');
+      expect(getJurisdictionIcon('NZ').name).toBe('earth-oceania');
+    });
+  });
+});

--- a/src/tests/sources/jurisdictions.spec.ts
+++ b/src/tests/sources/jurisdictions.spec.ts
@@ -15,6 +15,7 @@ describe('jurisdictions', () => {
       expect(JURISDICTION_ICONS).toHaveProperty('CA');
       expect(JURISDICTION_ICONS).toHaveProperty('UK');
       expect(JURISDICTION_ICONS).toHaveProperty('NZ');
+      expect(JURISDICTION_ICONS).toHaveProperty('APAC');
     });
 
     it('uses fa6-solid collection for all icons', () => {
@@ -58,6 +59,7 @@ describe('jurisdictions', () => {
       expect(getJurisdictionIcon('CA').name).toBe('earth-americas');
       expect(getJurisdictionIcon('UK').name).toBe('earth-europe');
       expect(getJurisdictionIcon('NZ').name).toBe('earth-oceania');
+      expect(getJurisdictionIcon('APAC').name).toBe('earth-asia');
     });
   });
 });


### PR DESCRIPTION
Replaces the YAML-based jurisdictions config with a single `JURISDICTIONS` env var (comma-separated identifier:domain pairs). The serializer transforms this into the structure the frontend expects, with i18n display name keys and icon resolution by identifier.

- Config parsing: `JURISDICTIONS=EU:eu.onetimesecret.com,CA:ca.onetimesecret.com,NZ:nz.onetimesecret.com`
- Serializer maps identifiers to display name i18n keys and resolves icons (earth-europe, earth-americas, earth-oceania)
- Adds `feature-regions.json` locale files across all 36 supported languages
- Fixes jurisdiction icons: all regions were falling back to generic globe; now correctly show region-specific globe variants

Closes #3187