### PR TITLE
fix(#3130): check pending_plan_intent on login for cross-session redirect

### DIFF
--- a/apps/web/auth/config/hooks/billing.rb
+++ b/apps/web/auth/config/hooks/billing.rb
@@ -110,7 +110,10 @@ module Auth::Config::Hooks
           interval = session[SESSION_KEY_INTERVAL]
 
           # Fallback to Redis-backed pending_plan_intent if session keys are empty (issue #3130)
-          # This handles the case where user signs up, verifies email, then logs in with fresh session
+          # This handles the case where user signs up, verifies email, then logs in with fresh session.
+          # Note: New signups won't have MFA enabled (requires verified account + successful auth first).
+          # If flow changes to allow MFA setup before subscribing, both after_login and
+          # after_two_factor_authentication would call this — first clears intent, second is a no-op.
           if product.nil? && interval.nil? && account
             product, interval = extract_pending_plan_intent_from_customer
           end

--- a/apps/web/auth/config/hooks/billing.rb
+++ b/apps/web/auth/config/hooks/billing.rb
@@ -52,6 +52,26 @@ module Auth::Config::Hooks
     SESSION_KEY_PRODUCT  = :billing_product
     SESSION_KEY_INTERVAL = :billing_interval
 
+    # Extracts and clears pending_plan_intent from a customer record.
+    # Returns [product, interval] or [nil, nil] if not found or parse error.
+    #
+    # This module method is used by both the Rodauth hook and tests.
+    #
+    # @param customer [Onetime::Customer] Customer record with pending_plan_intent field
+    # @param logger [Proc, nil] Optional logging callback for parse errors
+    # @return [Array<String, String>, Array<nil, nil>] [product, interval] tuple
+    def self.extract_pending_plan_intent(customer, logger: nil)
+      return [nil, nil] unless customer
+      return [nil, nil] if customer.pending_plan_intent&.value.to_s.strip == ''
+
+      intent = JSON.parse(customer.pending_plan_intent.value)
+      customer.pending_plan_intent.delete!
+      [intent['product'], intent['interval']]
+    rescue JSON::ParserError => ex
+      logger&.call(ex)
+      [nil, nil]
+    end
+
     def self.configure(auth)
       # Lazy-load billing dependencies only when actually configuring
       # This prevents LoadError on self-hosted instances where billing is disabled
@@ -88,6 +108,12 @@ module Auth::Config::Hooks
         def add_billing_redirect_to_response
           product  = session[SESSION_KEY_PRODUCT]
           interval = session[SESSION_KEY_INTERVAL]
+
+          # Fallback to Redis-backed pending_plan_intent if session keys are empty (issue #3130)
+          # This handles the case where user signs up, verifies email, then logs in with fresh session
+          if product.nil? && interval.nil? && account
+            product, interval = extract_pending_plan_intent_from_customer
+          end
 
           # No plan selection params stored
           return unless product || interval
@@ -158,6 +184,26 @@ module Auth::Config::Hooks
         # Checks if billing is enabled.
         def billing_enabled?
           Onetime.conf.dig('billing', 'enabled').to_s == 'true'
+        end
+
+        # Extracts product/interval from customer's pending_plan_intent in Redis.
+        # Returns [product, interval] or [nil, nil] if not found or parse error.
+        # Delegates to the module method for testability.
+        def extract_pending_plan_intent_from_customer
+          customer       = Onetime::Customer.find_by_extid(account[:external_id])
+          correlation_id = session[:auth_correlation_id]
+
+          Billing.extract_pending_plan_intent(
+            customer,
+            logger: ->(e) {
+                        Auth::Logging.log_auth_event(
+                          :pending_plan_intent_parse_error,
+                          level: :warn,
+                          error: e.message,
+                          correlation_id: correlation_id,
+                        )
+            },
+          )
         end
       end
       # rubocop:enable Lint/NestedMethodDefinition

--- a/apps/web/auth/config/hooks/billing.rb
+++ b/apps/web/auth/config/hooks/billing.rb
@@ -65,6 +65,8 @@ module Auth::Config::Hooks
       return [nil, nil] if customer.pending_plan_intent&.value.to_s.strip == ''
 
       intent = JSON.parse(customer.pending_plan_intent.value)
+      return [nil, nil] unless intent.is_a?(Hash)
+
       customer.pending_plan_intent.delete!
       [intent['product'], intent['interval']]
     rescue JSON::ParserError => ex

--- a/apps/web/auth/spec/integration/pending_plan_intent_flow_spec.rb
+++ b/apps/web/auth/spec/integration/pending_plan_intent_flow_spec.rb
@@ -606,4 +606,139 @@ RSpec.describe 'Pending plan intent flow (issue #3126)', type: :integration do
       expect(json_response).not_to have_key(:billing_redirect)
     end
   end
+
+  # ==========================================================================
+  # True HTTP Integration Tests (full Rodauth stack)
+  # ==========================================================================
+  #
+  # These tests exercise the actual /login endpoint through the full Rack/Rodauth
+  # stack, verifying that pending_plan_intent fallback works in production.
+  #
+  # Unlike the unit-style tests above (which call helper methods directly), these
+  # tests make real HTTP requests and verify real JSON responses.
+  #
+  # @see apps/web/auth/spec/unit/hooks/billing_spec.rb for unit tests of the
+  #      extract_pending_plan_intent module method
+  #
+  describe 'HTTP integration: login with pending_plan_intent fallback' do
+    # Test password used for all HTTP login tests
+    TEST_PASSWORD = 'TestPassword123!'
+
+    # Creates a verified account with a password hash for HTTP login testing.
+    # Uses Argon2 (Rodauth's default) to hash the password.
+    def create_account_with_password(email:, password: TEST_PASSWORD)
+      db = Auth::Database.connection
+      extid = SecureRandom.uuid
+
+      # Create verified account
+      account_id = db[:accounts].insert(
+        email: email,
+        status_id: 2, # verified status (1=unverified, 2=verified, 3=closed)
+        external_id: extid,
+        created_at: Time.now,
+        updated_at: Time.now
+      )
+      created_account_ids << account_id
+
+      # Create password hash using Argon2 (Rodauth's default)
+      # Cost params match test config in config/features/argon2.rb
+      require 'argon2'
+      hasher = Argon2::Password.new(t_cost: 1, m_cost: 5, p_cost: 1)
+      password_hash = hasher.create(password)
+
+      db[:account_password_hashes].insert(
+        id: account_id,
+        password_hash: password_hash
+      )
+
+      { id: account_id, email: email, external_id: extid }
+    end
+
+    it 'returns billing_redirect in JSON response when pending_plan_intent exists' do
+      email = unique_test_email('http-login')
+      account = create_account_with_password(email: email)
+
+      # Create customer with pending_plan_intent
+      operation = Auth::Operations::CreateCustomer.new(
+        account_id: account[:id],
+        account: account,
+        db: Auth::Database.connection
+      )
+      customer = operation.call
+      created_customers << customer
+
+      # Set pending_plan_intent (simulating signup with plan params)
+      intent = {
+        product: 'identity_plus_v1',
+        interval: 'monthly',
+        captured_at: Time.now.utc.iso8601,
+        source_url: '/signup?product=identity_plus_v1&interval=monthly',
+      }.to_json
+      customer.pending_plan_intent = intent
+
+      # Make actual HTTP login request
+      header 'Content-Type', 'application/json'
+      header 'Accept', 'application/json'
+      post '/login', JSON.generate(login: email, password: TEST_PASSWORD)
+
+      # Verify successful login
+      expect(last_response.status).to be_between(200, 302)
+
+      # Parse JSON response to check for billing_redirect
+      # Rodauth returns JSON for JSON Accept header
+      if last_response.content_type&.include?('application/json')
+        response_body = JSON.parse(last_response.body)
+
+        expect(response_body).to have_key('billing_redirect')
+        expect(response_body['billing_redirect']['product']).to eq('identity_plus_v1')
+        expect(response_body['billing_redirect']['interval']).to eq('monthly')
+      else
+        # If redirect response, billing_redirect should be in session
+        # (frontend handles redirect from session in non-JSON flow)
+        expect(last_response.status).to eq(302)
+      end
+
+      # Verify intent was cleared (single-use)
+      customer.pending_plan_intent.reload! if customer.pending_plan_intent.respond_to?(:reload!)
+      expect(customer.pending_plan_intent.value.to_s).to eq('')
+    end
+
+    it 'clears pending_plan_intent after first successful login' do
+      email = unique_test_email('http-clear')
+      account = create_account_with_password(email: email)
+
+      operation = Auth::Operations::CreateCustomer.new(
+        account_id: account[:id],
+        account: account,
+        db: Auth::Database.connection
+      )
+      customer = operation.call
+      created_customers << customer
+
+      customer.pending_plan_intent = { product: 'team_plus_v1', interval: 'yearly' }.to_json
+
+      # First login
+      header 'Content-Type', 'application/json'
+      header 'Accept', 'application/json'
+      post '/login', JSON.generate(login: email, password: TEST_PASSWORD)
+
+      expect(last_response.status).to be_between(200, 302)
+
+      # Intent should be cleared
+      customer.pending_plan_intent.reload! if customer.pending_plan_intent.respond_to?(:reload!)
+      expect(customer.pending_plan_intent.value.to_s).to eq('')
+
+      # Second login should not have billing_redirect
+      # (need to logout first or use different session)
+      clear_cookies
+      header 'Content-Type', 'application/json'
+      header 'Accept', 'application/json'
+      post '/login', JSON.generate(login: email, password: TEST_PASSWORD)
+
+      if last_response.content_type&.include?('application/json')
+        response_body = JSON.parse(last_response.body)
+        expect(response_body).not_to have_key('billing_redirect')
+      end
+    end
+  end
 end

--- a/apps/web/auth/spec/integration/pending_plan_intent_flow_spec.rb
+++ b/apps/web/auth/spec/integration/pending_plan_intent_flow_spec.rb
@@ -38,6 +38,10 @@ RSpec.describe 'Pending plan intent flow (issue #3126)', type: :integration do
     require_relative '../../operations/create_customer'
     require_relative '../../operations/create_default_workspace'
 
+    # Load the billing hooks module (for extract_pending_plan_intent)
+    module Auth; module Config; module Hooks; end; end; end unless defined?(Auth::Config::Hooks)
+    require_relative '../../config/hooks/billing'
+
     # Load billing dependencies for plan validation
     begin
       require_relative '../../../billing/lib/plan_resolver'
@@ -194,35 +198,27 @@ RSpec.describe 'Pending plan intent flow (issue #3126)', type: :integration do
   describe 'intent surfacing in after_verify_account' do
     let(:session) { {} }
 
+    # Uses the production extract_pending_plan_intent method to ensure tests
+    # match actual behavior (including clearing via delete!).
     def surface_plan_intent(customer:, session:, plan_valid: true)
       pending_intent = customer.pending_plan_intent&.value
 
       return { surfaced: false, reason: :no_intent } if pending_intent.to_s.strip == ''
 
-      begin
-        intent = JSON.parse(pending_intent)
-      rescue JSON::ParserError
-        customer.pending_plan_intent = nil
-        return { surfaced: false, reason: :invalid_json }
-      end
+      # Use production module method which handles JSON parsing and clearing via delete!
+      product, interval = Auth::Config::Hooks::Billing.extract_pending_plan_intent(customer)
 
-      product = intent['product']
-      interval = intent['interval']
+      return { surfaced: false, reason: :invalid_json } if product.nil? && interval.nil? && pending_intent.to_s.strip != ''
 
       unless product && interval
-        customer.pending_plan_intent = nil
         return { surfaced: false, reason: :missing_fields }
       end
 
       # In production, we'd validate with Billing::PlanResolver
       # For tests, use the plan_valid parameter
       unless plan_valid
-        customer.pending_plan_intent = nil
         return { surfaced: false, reason: :plan_not_found }
       end
-
-      # Clear intent (single-use)
-      customer.pending_plan_intent = nil
 
       # Set session redirect
       session['plan_checkout_redirect'] = "/billing/plans/#{product}/#{interval}"
@@ -304,7 +300,7 @@ RSpec.describe 'Pending plan intent flow (issue #3126)', type: :integration do
       expect(session).not_to have_key('plan_checkout_redirect')
     end
 
-    it 'clears corrupted intent without setting redirect' do
+    it 'does not surface corrupted intent but leaves it in place for debugging' do
       email = unique_test_email('corrupted')
       account = create_test_account(email: email)
 
@@ -317,16 +313,18 @@ RSpec.describe 'Pending plan intent flow (issue #3126)', type: :integration do
       created_customers << customer
 
       # Set corrupted intent
-      customer.pending_plan_intent = 'not-valid-json{{'
+      corrupted_value = 'not-valid-json{{'
+      customer.pending_plan_intent = corrupted_value
 
       result = surface_plan_intent(customer: customer, session: session)
 
       expect(result[:surfaced]).to be false
       expect(result[:reason]).to eq(:invalid_json)
-      expect(customer.pending_plan_intent.value.to_s).to eq('')
+      # Production does NOT clear on parse error - allows debugging/retry
+      expect(customer.pending_plan_intent.value).to eq(corrupted_value)
     end
 
-    it 'clears intent when plan no longer exists' do
+    it 'clears intent after parse even when plan no longer exists' do
       email = unique_test_email('discontinued')
       account = create_test_account(email: email)
 
@@ -346,6 +344,7 @@ RSpec.describe 'Pending plan intent flow (issue #3126)', type: :integration do
 
       expect(result[:surfaced]).to be false
       expect(result[:reason]).to eq(:plan_not_found)
+      # Production clears intent after successful JSON parse (before validation)
       expect(customer.pending_plan_intent.value.to_s).to eq('')
     end
   end
@@ -430,6 +429,181 @@ RSpec.describe 'Pending plan intent flow (issue #3126)', type: :integration do
       url = "/billing/plans/#{product}/#{interval}"
 
       expect(url).to eq('/billing/plans/plan-with-dashes_v1/monthly')
+    end
+  end
+
+  # ==========================================================================
+  # Cross-Session Login Flow Tests (pending_plan_intent fallback)
+  # ==========================================================================
+  #
+  # Tests the scenario where a user signs up with plan params, the intent is
+  # stored in customer.pending_plan_intent, and then they log in from a
+  # different session (no session keys) and expect billing_redirect.
+
+  describe 'cross-session login flow with pending_plan_intent' do
+    # Uses the production Auth::Config::Hooks::Billing.extract_pending_plan_intent
+    # method to ensure tests match actual behavior.
+    def add_billing_redirect_to_response(session:, json_response:, customer:, plan_valid: true)
+      product  = session[:billing_product]
+      interval = session[:billing_interval]
+
+      # Fallback to pending_plan_intent when session keys are empty
+      # Uses production module method for extraction
+      if product.nil? && interval.nil? && customer
+        product, interval = Auth::Config::Hooks::Billing.extract_pending_plan_intent(customer)
+      end
+
+      return unless product && interval
+
+      if plan_valid
+        json_response[:billing_redirect] = {
+          product: product,
+          interval: interval,
+          valid: true,
+        }
+      else
+        json_response[:billing_redirect] = {
+          product: product,
+          interval: interval,
+          valid: false,
+          error: "Plan not found: #{product}_#{interval}",
+        }
+      end
+
+      # Clear session keys after use
+      session.delete(:billing_product)
+      session.delete(:billing_interval)
+    end
+
+    it 'returns billing_redirect from pending_plan_intent on fresh login session' do
+      email = unique_test_email('cross-session')
+      account = create_test_account(email: email)
+
+      # Step 1: Create customer (simulating signup)
+      operation = Auth::Operations::CreateCustomer.new(
+        account_id: account[:id],
+        account: account,
+        db: Auth::Database.connection
+      )
+      customer = operation.call
+      created_customers << customer
+
+      # Step 2: Set pending_plan_intent (simulating after_create_account hook)
+      intent = {
+        product: 'identity_plus_v1',
+        interval: 'monthly',
+        captured_at: Time.now.utc.iso8601,
+      }.to_json
+      customer.pending_plan_intent = intent
+
+      # Step 3: Simulate fresh login session (no plan keys in session)
+      fresh_session = {}
+      json_response = {}
+
+      # Step 4: Call add_billing_redirect_to_response (simulating after_login)
+      add_billing_redirect_to_response(
+        session: fresh_session,
+        json_response: json_response,
+        customer: customer
+      )
+
+      # Verify billing_redirect is returned from pending_plan_intent
+      expect(json_response).to have_key(:billing_redirect)
+      expect(json_response[:billing_redirect][:product]).to eq('identity_plus_v1')
+      expect(json_response[:billing_redirect][:interval]).to eq('monthly')
+      expect(json_response[:billing_redirect][:valid]).to be true
+    end
+
+    it 'clears pending_plan_intent after successful cross-session login' do
+      email = unique_test_email('clear-intent')
+      account = create_test_account(email: email)
+
+      operation = Auth::Operations::CreateCustomer.new(
+        account_id: account[:id],
+        account: account,
+        db: Auth::Database.connection
+      )
+      customer = operation.call
+      created_customers << customer
+
+      # Set pending_plan_intent
+      intent = { product: 'team_plus_v1', interval: 'yearly' }.to_json
+      customer.pending_plan_intent = intent
+
+      # Fresh login
+      fresh_session = {}
+      json_response = {}
+      add_billing_redirect_to_response(
+        session: fresh_session,
+        json_response: json_response,
+        customer: customer
+      )
+
+      # Intent should be cleared
+      expect(customer.pending_plan_intent.value.to_s).to eq('')
+
+      # Second login should not have billing_redirect
+      second_session = {}
+      second_response = {}
+      add_billing_redirect_to_response(
+        session: second_session,
+        json_response: second_response,
+        customer: customer
+      )
+
+      expect(second_response).not_to have_key(:billing_redirect)
+    end
+
+    it 'session keys take precedence over pending_plan_intent' do
+      email = unique_test_email('session-precedence')
+      account = create_test_account(email: email)
+
+      operation = Auth::Operations::CreateCustomer.new(
+        account_id: account[:id],
+        account: account,
+        db: Auth::Database.connection
+      )
+      customer = operation.call
+      created_customers << customer
+
+      # Set pending_plan_intent to one plan
+      intent = { product: 'identity_plus_v1', interval: 'monthly' }.to_json
+      customer.pending_plan_intent = intent
+
+      # Login session has different plan
+      session_with_plan = {
+        billing_product: 'team_plus_v1',
+        billing_interval: 'yearly',
+      }
+      json_response = {}
+
+      add_billing_redirect_to_response(
+        session: session_with_plan,
+        json_response: json_response,
+        customer: customer
+      )
+
+      # Session plan should win
+      expect(json_response[:billing_redirect][:product]).to eq('team_plus_v1')
+      expect(json_response[:billing_redirect][:interval]).to eq('yearly')
+
+      # pending_plan_intent should NOT be cleared (session was used instead)
+      expect(customer.pending_plan_intent.value).to eq(intent)
+    end
+
+    it 'handles no customer gracefully (nil account lookup)' do
+      fresh_session = {}
+      json_response = {}
+
+      expect {
+        add_billing_redirect_to_response(
+          session: fresh_session,
+          json_response: json_response,
+          customer: nil
+        )
+      }.not_to raise_error
+
+      expect(json_response).not_to have_key(:billing_redirect)
     end
   end
 end

--- a/apps/web/auth/spec/unit/hooks/billing_spec.rb
+++ b/apps/web/auth/spec/unit/hooks/billing_spec.rb
@@ -166,5 +166,93 @@ RSpec.describe Auth::Config::Hooks::Billing do
         expect(interval).to eq('yearly')
       end
     end
+
+    # =========================================================================
+    # Non-Hash JSON types: graceful handling without TypeError
+    # =========================================================================
+    # These test the guard added in billing.rb line 68:
+    #   return [nil, nil] unless intent.is_a?(Hash)
+    # Previously, non-Hash JSON would crash with TypeError on field access.
+    # Now returns [nil, nil] and preserves intent for debugging (no delete!).
+
+    context 'when pending_plan_intent contains JSON array (empty)' do
+      let(:customer) { MockCustomer.new('[]') }
+
+      it 'returns [nil, nil]' do
+        product, interval = described_class.extract_pending_plan_intent(customer)
+
+        expect([product, interval]).to eq([nil, nil])
+      end
+
+      it 'does NOT call delete! (preserves intent for debugging)' do
+        described_class.extract_pending_plan_intent(customer)
+
+        expect(customer.pending_plan_intent.value).to eq('[]')
+      end
+    end
+
+    context 'when pending_plan_intent contains JSON array (non-empty)' do
+      let(:customer) { MockCustomer.new('[1, 2, 3]') }
+
+      it 'returns [nil, nil]' do
+        product, interval = described_class.extract_pending_plan_intent(customer)
+
+        expect([product, interval]).to eq([nil, nil])
+      end
+
+      it 'does NOT call delete! (preserves intent for debugging)' do
+        described_class.extract_pending_plan_intent(customer)
+
+        expect(customer.pending_plan_intent.value).to eq('[1, 2, 3]')
+      end
+    end
+
+    context 'when pending_plan_intent contains JSON string' do
+      let(:customer) { MockCustomer.new('"just a string"') }
+
+      it 'returns [nil, nil]' do
+        product, interval = described_class.extract_pending_plan_intent(customer)
+
+        expect([product, interval]).to eq([nil, nil])
+      end
+
+      it 'does NOT call delete! (preserves intent for debugging)' do
+        described_class.extract_pending_plan_intent(customer)
+
+        expect(customer.pending_plan_intent.value).to eq('"just a string"')
+      end
+    end
+
+    context 'when pending_plan_intent contains JSON null' do
+      let(:customer) { MockCustomer.new('null') }
+
+      it 'returns [nil, nil]' do
+        product, interval = described_class.extract_pending_plan_intent(customer)
+
+        expect([product, interval]).to eq([nil, nil])
+      end
+
+      it 'does NOT call delete! (preserves intent for debugging)' do
+        described_class.extract_pending_plan_intent(customer)
+
+        expect(customer.pending_plan_intent.value).to eq('null')
+      end
+    end
+
+    context 'when pending_plan_intent contains JSON number' do
+      let(:customer) { MockCustomer.new('42') }
+
+      it 'returns [nil, nil]' do
+        product, interval = described_class.extract_pending_plan_intent(customer)
+
+        expect([product, interval]).to eq([nil, nil])
+      end
+
+      it 'does NOT call delete! (preserves intent for debugging)' do
+        described_class.extract_pending_plan_intent(customer)
+
+        expect(customer.pending_plan_intent.value).to eq('42')
+      end
+    end
   end
 end

--- a/apps/web/auth/spec/unit/hooks/billing_spec.rb
+++ b/apps/web/auth/spec/unit/hooks/billing_spec.rb
@@ -1,0 +1,170 @@
+# apps/web/auth/spec/unit/hooks/billing_spec.rb
+#
+# frozen_string_literal: true
+
+# =============================================================================
+# TEST TYPE: Unit Tests for Billing::extract_pending_plan_intent
+# =============================================================================
+#
+# WHAT THIS TESTS:
+#   The pending_plan_intent extraction logic in Auth::Config::Hooks::Billing.
+#   Tests the module method directly with mock customer objects.
+#
+# SCOPE:
+#   These are pure unit tests that call the extract_pending_plan_intent module
+#   method directly with mock objects. They verify the method's logic in
+#   isolation: JSON parsing, field extraction, clearing via delete!, and
+#   error handling.
+#
+#   For true HTTP integration tests that exercise the full Rodauth login stack
+#   (making actual POST /login requests and verifying billing_redirect in the
+#   JSON response), see:
+#
+#     apps/web/auth/spec/integration/pending_plan_intent_flow_spec.rb
+#     → describe 'HTTP integration: login with pending_plan_intent fallback'
+#
+# RUN:
+#   source .env.test && pnpm run test:rspec apps/web/auth/spec/unit/hooks/billing_spec.rb
+#
+# =============================================================================
+
+require 'rspec'
+require 'json'
+
+# Define the namespace hierarchy before loading the module
+module Auth; end
+module Auth::Config; end
+module Auth::Config::Hooks; end
+
+# Load the actual production module
+require_relative '../../../config/hooks/billing'
+
+RSpec.describe Auth::Config::Hooks::Billing do
+  describe '.extract_pending_plan_intent' do
+    # Mock Familia::StringKey behavior matching production
+    class MockStringKey
+      attr_reader :value
+
+      def initialize(value)
+        @value = value
+      end
+
+      def to_s
+        @value.to_s
+      end
+
+      def delete!
+        @value = nil
+      end
+    end
+
+    # Mock customer with pending_plan_intent field matching Familia interface
+    class MockCustomer
+      attr_reader :pending_plan_intent
+
+      def initialize(intent_value = nil)
+        @pending_plan_intent = MockStringKey.new(intent_value)
+      end
+    end
+
+    context 'when customer has valid pending_plan_intent JSON' do
+      let(:intent_json) { { 'product' => 'identity_plus_v1', 'interval' => 'monthly' }.to_json }
+      let(:customer) { MockCustomer.new(intent_json) }
+
+      it 'returns [product, interval] tuple' do
+        product, interval = described_class.extract_pending_plan_intent(customer)
+
+        expect(product).to eq('identity_plus_v1')
+        expect(interval).to eq('monthly')
+      end
+
+      it 'clears pending_plan_intent via delete! (single-use)' do
+        described_class.extract_pending_plan_intent(customer)
+
+        expect(customer.pending_plan_intent.value).to be_nil
+      end
+    end
+
+    context 'when customer is nil' do
+      it 'returns [nil, nil]' do
+        product, interval = described_class.extract_pending_plan_intent(nil)
+
+        expect(product).to be_nil
+        expect(interval).to be_nil
+      end
+    end
+
+    context 'when pending_plan_intent is empty string' do
+      let(:customer) { MockCustomer.new('') }
+
+      it 'returns [nil, nil]' do
+        product, interval = described_class.extract_pending_plan_intent(customer)
+
+        expect(product).to be_nil
+        expect(interval).to be_nil
+      end
+    end
+
+    context 'when pending_plan_intent is whitespace only' do
+      let(:customer) { MockCustomer.new('   ') }
+
+      it 'returns [nil, nil]' do
+        product, interval = described_class.extract_pending_plan_intent(customer)
+
+        expect(product).to be_nil
+        expect(interval).to be_nil
+      end
+    end
+
+    context 'when pending_plan_intent contains invalid JSON' do
+      let(:customer) { MockCustomer.new('not-valid-json{{') }
+      let(:logged_errors) { [] }
+      let(:logger) { ->(e) { logged_errors << e } }
+
+      it 'returns [nil, nil]' do
+        product, interval = described_class.extract_pending_plan_intent(customer, logger: logger)
+
+        expect(product).to be_nil
+        expect(interval).to be_nil
+      end
+
+      it 'calls logger with the parse error' do
+        described_class.extract_pending_plan_intent(customer, logger: logger)
+
+        expect(logged_errors.size).to eq(1)
+        expect(logged_errors.first).to be_a(JSON::ParserError)
+      end
+    end
+
+    context 'when pending_plan_intent JSON is missing required fields' do
+      let(:intent_json) { { 'product' => 'identity_plus_v1' }.to_json }
+      let(:customer) { MockCustomer.new(intent_json) }
+
+      it 'returns partial data (product present, interval nil)' do
+        product, interval = described_class.extract_pending_plan_intent(customer)
+
+        expect(product).to eq('identity_plus_v1')
+        expect(interval).to be_nil
+      end
+    end
+
+    context 'when pending_plan_intent has extra fields' do
+      let(:intent_json) do
+        {
+          'product' => 'team_plus_v1',
+          'interval' => 'yearly',
+          'captured_at' => '2024-01-15T10:30:00Z',
+          'source' => 'pricing_page',
+        }.to_json
+      end
+      let(:customer) { MockCustomer.new(intent_json) }
+
+      it 'extracts only product and interval' do
+        product, interval = described_class.extract_pending_plan_intent(customer)
+
+        expect(product).to eq('team_plus_v1')
+        expect(interval).to eq('yearly')
+      end
+    end
+  end
+end


### PR DESCRIPTION
#3130 

## Summary

Fixes the scenario where users sign up with a plan selection, verify email from a different session, then log in — and get dumped on `/dashboard` instead of being redirected to complete their purchase.

The issue: `add_billing_redirect_to_response` only checked session keys, but those are lost when the user logs in from a fresh session after email verification.

The fix: fall back to `customer.pending_plan_intent` in Redis when session keys are empty. Intent is single-use (cleared after first consumption).

## Changes

- **billing.rb**: Added `extract_pending_plan_intent` module method (JSON parsing, field extraction, clearing via `delete!`) and integrated fallback into `add_billing_redirect_to_response`
- **Tests**: Unit tests for the module method, cross-session flow tests, and true HTTP integration tests that POST to `/login` through the full Rodauth stack

## Test plan

- [x] Run unit tests: `bundle exec rspec apps/web/auth/spec/unit/hooks/billing_spec.rb`
- [x] Run integration tests: `bundle exec rspec apps/web/auth/spec/integration/pending_plan_intent_flow_spec.rb`
- [x] Manual: signup with plan params → verify email → login from fresh session → confirm redirect to checkout