### PR TITLE
Make boot errors fatal in CLI mode unless SAFE_BOOT=1

### DIFF
--- a/apps/api/domains/cli/helpers.rb
+++ b/apps/api/domains/cli/helpers.rb
@@ -97,13 +97,7 @@ module Onetime
       end
 
       def get_validation_strategy
-        conf = OT.conf
-        if conf.nil?
-          puts "Warning: OT.conf is nil, can't read features.domains.validation_strategy"
-          puts 'Using passthrough strategy (live checks disabled)'
-          return Onetime::DomainValidation::PassthroughStrategy.new({})
-        end
-        Onetime::DomainValidation::Strategy.for_config(conf)
+        Onetime::DomainValidation::Strategy.for_config(OT.conf)
       end
 
       def format_verification_state(state)

--- a/bin/ots
+++ b/bin/ots
@@ -47,6 +47,7 @@ rescue Onetime::FatalBootError => ex
   exit 1
 rescue RuntimeError => ex
   warn ex.message
+  warn ex.backtrace if debug
   exit ex.respond_to?(:exit_code) ? ex.exit_code : 1
 rescue StandardError => ex
   puts ex.message

--- a/bin/ots
+++ b/bin/ots
@@ -29,6 +29,8 @@ ARGV.each_with_index do |arg, _idx|
   when '-D', '--debug'
     debug = true
     OT.instance_variable_set(:@debug, true)
+  when '--safe-boot'
+    ENV['SAFE_BOOT'] = 'true'
   else
     remaining_args << arg
   end
@@ -40,6 +42,8 @@ rescue Onetime::FatalBootError => ex
   # Boot-fatal errors (e.g. deprecated/invalid config) already include a
   # user-facing message — surface it directly without a backtrace.
   warn ex.message
+  warn ''
+  warn 'Run with --safe-boot (or SAFE_BOOT=1) to bypass this error and inspect state.'
   exit 1
 rescue RuntimeError => ex
   warn ex.message

--- a/bin/ots
+++ b/bin/ots
@@ -43,7 +43,7 @@ rescue Onetime::FatalBootError => ex
   # user-facing message — surface it directly without a backtrace.
   warn ex.message
   warn ''
-  warn 'Run with --safe-boot (or SAFE_BOOT=1) to bypass this error and inspect state.'
+  warn 'Use --safe-boot to bypass this error and access the debugging console.'
   exit 1
 rescue RuntimeError => ex
   warn ex.message

--- a/bin/ots
+++ b/bin/ots
@@ -43,7 +43,7 @@ rescue Onetime::FatalBootError => ex
   # user-facing message — surface it directly without a backtrace.
   warn ex.message
   warn ''
-  warn 'Use --safe-boot to bypass this error and access the debugging console.'
+  warn 'Use --safe-boot (or SAFE_BOOT=1) to bypass this error and access the debugging console.'
   exit 1
 rescue RuntimeError => ex
   warn ex.message

--- a/bin/ots
+++ b/bin/ots
@@ -36,9 +36,14 @@ end
 
 begin
   Dry::CLI.new(Onetime::CLI).call(arguments: remaining_args)
+rescue Onetime::FatalBootError => ex
+  # Boot-fatal errors (e.g. deprecated/invalid config) already include a
+  # user-facing message — surface it directly without a backtrace.
+  warn ex.message
+  exit 1
 rescue RuntimeError => ex
   warn ex.message
-  exit ex.exit_code if ex.respond_to?(:exit_code)
+  exit ex.respond_to?(:exit_code) ? ex.exit_code : 1
 rescue StandardError => ex
   puts ex.message
   puts ex.backtrace if debug

--- a/lib/onetime/boot.rb
+++ b/lib/onetime/boot.rb
@@ -208,6 +208,10 @@ module Onetime
       #
       # allow(Onetime).to receive(:connect_databases).and_call_original
       #
+      # Fatal errors (e.g. ConfigError) leave the application in an unusable
+      # state — always re-raise so callers can present the message instead
+      # of hitting nil errors downstream.
+      raise ex if ex.is_a?(FatalBootError)
       raise ex unless mode?(:cli) # allows for debugging in the console
     rescue Redis::CannotConnectError => ex
       failed!(ex)

--- a/lib/onetime/boot.rb
+++ b/lib/onetime/boot.rb
@@ -170,7 +170,7 @@ module Onetime
       unless health[:healthy]
         failed       = @boot_registry.initializers.select(&:failed?)
         failed_names = failed.map { |i| "#{i.name} (#{i.error.class}: #{i.error.message})" }
-        raise OT::Problem, "Initializer(s) failed: #{failed_names.join(', ')}"
+        raise OT::ConfigError, "Initializer(s) failed: #{failed_names.join(', ')}"
       end
 
       started!
@@ -210,13 +210,16 @@ module Onetime
       #
       # Fatal errors (e.g. ConfigError) leave the application in an unusable
       # state — always re-raise so callers can present the message instead
-      # of hitting nil errors downstream.
-      raise ex if ex.is_a?(FatalBootError)
+      # of hitting nil errors downstream. SAFE_BOOT=1 in CLI mode bypasses
+      # this for interactive debugging.
+      raise ex if ex.is_a?(FatalBootError) && !safe_boot?
       raise ex unless mode?(:cli) # allows for debugging in the console
     rescue Redis::CannotConnectError => ex
       failed!(ex)
       OT.le "Cannot connect to the database #{Familia.uri} (#{ex.class})"
-      raise ex unless mode?(:cli)
+      # Database connection failures leave the app unusable. SAFE_BOOT=1 in
+      # CLI mode bypasses this so the REPL can come up for diagnosis.
+      raise ex unless safe_boot?
     end
 
     # Replaces the global configuration instance with the provided data.
@@ -336,6 +339,13 @@ module Onetime
 
     def ssl_enabled?
       conf&.dig('site', 'ssl') || env == 'production'
+    end
+
+    # CLI-only escape hatch: when SAFE_BOOT=1, boot! logs fatal errors but
+    # does not re-raise, letting the REPL come up for inspection. Set via
+    # `bin/ots --safe-boot <cmd>` or `SAFE_BOOT=1 bin/ots <cmd>`.
+    def safe_boot?
+      mode?(:cli) && Onetime::Utils.yes?(ENV.fetch('SAFE_BOOT', nil))
     end
 
     # Replaces the global configuration instance. This method is private to

--- a/lib/onetime/cli.rb
+++ b/lib/onetime/cli.rb
@@ -18,11 +18,6 @@ module Onetime
       def boot_application!
         # Make sure all the models are loaded before calling boot
         OT.boot! :cli
-
-        # boot! swallows exceptions in CLI mode (for console debugging).
-        # Commands that depend on a fully-booted app should fail fast
-        # with a clear message instead of hitting nil errors later.
-        warn 'Boot failed: OT.conf is nil' unless OT.conf
       end
 
       protected

--- a/lib/onetime/config.rb
+++ b/lib/onetime/config.rb
@@ -295,7 +295,7 @@ module Onetime
         conf['features']['regions']['jurisdictions'] = entries.map do |entry|
           identifier, domain = entry.split(':', 2).map(&:strip)
           if identifier.empty? || domain.to_s.empty?
-            raise OT::Problem, "Invalid JURISDICTIONS format: '#{entry}' (expected ID:domain)"
+            raise OT::ConfigError, "Invalid JURISDICTIONS format: '#{entry}' (expected ID:domain)"
           end
 
           {

--- a/lib/onetime/errors.rb
+++ b/lib/onetime/errors.rb
@@ -36,6 +36,7 @@ module Onetime
   end
 
   class MigrationError < Problem
+    include FatalBootError
   end
 
   class RecordNotFound < Problem

--- a/lib/onetime/errors.rb
+++ b/lib/onetime/errors.rb
@@ -3,6 +3,13 @@
 # frozen_string_literal: true
 
 module Onetime
+  # Marker module for boot errors that must always halt execution, even in
+  # CLI mode. Without this marker, boot! swallows OT::Problem in :cli to
+  # allow REPL debugging — but config errors leave OT.conf unusable, so
+  # commands hit nil errors downstream. Including this module signals
+  # "boot cannot recover from this; surface the error to the user."
+  module FatalBootError; end
+
   # The Problem class inherits from RuntimeError, which is a subclass of StandardError.
   # Both RuntimeError and StandardError are standard exception classes in Ruby, but
   # RuntimeError is used for errors that are typically caused by the program's logic
@@ -25,6 +32,7 @@ module Onetime
   # correctly and needs to be reviewed and corrected before normal operation
   # can proceed.
   class ConfigError < Problem
+    include FatalBootError
   end
 
   class MigrationError < Problem

--- a/scripts/upgrades/v0.24.5/rebuild_custom_domain_indexes.rb
+++ b/scripts/upgrades/v0.24.5/rebuild_custom_domain_indexes.rb
@@ -242,11 +242,13 @@ if $PROGRAM_NAME == __FILE__
     warn 'Refusing: --execute requires CONFIRM=yes.'
     exit 2
   end
-  OT.boot! :cli
-  abort 'Boot failed: OT.conf is nil' unless OT.conf
   begin
+    OT.boot! :cli
     Onetime::CustomDomain::IndexRebuilder.run(execute: execute, verbose: verbose)
     exit 0
+  rescue Onetime::FatalBootError => ex
+    warn ex.message
+    exit 1
   rescue StandardError => ex
     warn "[rebuild_custom_domain_indexes] #{ex.class}: #{ex.message}"
     warn ex.backtrace.first(10).join("\n") if verbose

--- a/spec/integration/all/initializers/boot_part2_spec.rb
+++ b/spec/integration/all/initializers/boot_part2_spec.rb
@@ -246,6 +246,29 @@ RSpec.describe "Onetime global state after boot", type: :integration do
           Onetime.boot!(:test)
         }.to raise_error(Redis::CannotConnectError, "Test Redis error")
       end
+
+      it "re-raises FatalBootError in :cli mode (e.g. ConfigError)" do
+        # Bad config (deprecation, validation, etc.) leaves OT.conf nil — we
+        # must surface the actual error rather than swallowing it for REPL
+        # debugging. ConfigError includes FatalBootError to signal this.
+        config_error = OT::ConfigError.new("Deprecated configuration detected: foo.bar")
+        allow(Onetime::Config).to receive(:after_load).and_raise(config_error)
+
+        expect {
+          Onetime.boot!(:cli)
+        }.to raise_error(OT::ConfigError, /Deprecated configuration detected/)
+      end
+
+      it "still swallows non-fatal OT::Problem in :cli mode for REPL debugging" do
+        # Non-fatal Problem errors (e.g. transient initializer failures) remain
+        # swallowed in CLI mode so the console session can stay alive.
+        non_fatal_error = OT::Problem.new("Some non-fatal problem")
+        allow(Onetime::Config).to receive(:after_load).and_raise(non_fatal_error)
+
+        expect {
+          Onetime.boot!(:cli)
+        }.not_to raise_error
+      end
     end
   end
 end

--- a/spec/integration/all/initializers/boot_part2_spec.rb
+++ b/spec/integration/all/initializers/boot_part2_spec.rb
@@ -286,14 +286,60 @@ RSpec.describe "Onetime global state after boot", type: :integration do
       end
 
       it "still swallows non-fatal OT::Problem in :cli mode for REPL debugging" do
-        # Non-fatal Problem errors (e.g. transient initializer failures) remain
-        # swallowed in CLI mode so the console session can stay alive.
+        # Bare OT::Problem (without FatalBootError) remains swallowed in CLI mode.
+        # Initializer failures now raise ConfigError instead, so the realistic
+        # set of cases hitting this branch is small — but the swallow remains
+        # for any future non-fatal Problem subclass.
         non_fatal_error = OT::Problem.new("Some non-fatal problem")
         allow(Onetime::Config).to receive(:after_load).and_raise(non_fatal_error)
 
         expect {
           Onetime.boot!(:cli)
         }.not_to raise_error
+      end
+
+      it "raises Redis::CannotConnectError in :cli mode (now treated as fatal)" do
+        # Previously swallowed in :cli; reviewer noted that a dead database is
+        # functionally identical to nil config (commands hit nil errors).
+        # SAFE_BOOT=1 is the escape hatch for diagnosing connection issues.
+        redis_error = Redis::CannotConnectError.new("Test Redis error")
+        allow(Familia).to receive(:uri=).and_raise(redis_error)
+
+        expect {
+          Onetime.boot!(:cli)
+        }.to raise_error(Redis::CannotConnectError, "Test Redis error")
+      end
+
+      context "with SAFE_BOOT=1" do
+        before { ENV['SAFE_BOOT'] = 'true' }
+        after  { ENV.delete('SAFE_BOOT') }
+
+        it "swallows ConfigError in :cli mode so the REPL can come up" do
+          deprecated_conf = loaded_config.dup
+          deprecated_conf['site']['domains'] = { 'enabled' => true }
+          allow(Onetime::Config).to receive(:load).and_return(deprecated_conf)
+
+          expect { Onetime.boot!(:cli) }.not_to raise_error
+          expect(Onetime.boot_failed?).to be true
+        end
+
+        it "swallows Redis::CannotConnectError in :cli mode" do
+          redis_error = Redis::CannotConnectError.new("Test Redis error")
+          allow(Familia).to receive(:uri=).and_raise(redis_error)
+
+          expect { Onetime.boot!(:cli) }.not_to raise_error
+          expect(Onetime.boot_failed?).to be true
+        end
+
+        it "has no effect outside :cli mode (errors still raise in :test/:app)" do
+          deprecated_conf = loaded_config.dup
+          deprecated_conf['site']['domains'] = { 'enabled' => true }
+          allow(Onetime::Config).to receive(:load).and_return(deprecated_conf)
+
+          expect {
+            Onetime.boot!(:test)
+          }.to raise_error(OT::ConfigError, /site\.domains is ignored/)
+        end
       end
     end
   end

--- a/spec/integration/all/initializers/boot_part2_spec.rb
+++ b/spec/integration/all/initializers/boot_part2_spec.rb
@@ -273,6 +273,18 @@ RSpec.describe "Onetime global state after boot", type: :integration do
         }.to raise_error(OT::ConfigError, /site\.domains is ignored/)
       end
 
+      it "re-raises ConfigError from deprecated env var in :cli mode" do
+        # Env-var deprecations go through a separate branch in check_deprecations
+        # (ENV check vs config-path check). Cover both to prevent silent regressions.
+        ENV['UI_HOMEPAGE_TRUSTED_PROXY_DEPTH'] = '5'
+
+        expect {
+          Onetime.boot!(:cli)
+        }.to raise_error(OT::ConfigError, /trusted_proxy_depth is ignored/)
+      ensure
+        ENV.delete('UI_HOMEPAGE_TRUSTED_PROXY_DEPTH')
+      end
+
       it "still swallows non-fatal OT::Problem in :cli mode for REPL debugging" do
         # Non-fatal Problem errors (e.g. transient initializer failures) remain
         # swallowed in CLI mode so the console session can stay alive.

--- a/spec/integration/all/initializers/boot_part2_spec.rb
+++ b/spec/integration/all/initializers/boot_part2_spec.rb
@@ -247,16 +247,30 @@ RSpec.describe "Onetime global state after boot", type: :integration do
         }.to raise_error(Redis::CannotConnectError, "Test Redis error")
       end
 
-      it "re-raises FatalBootError in :cli mode (e.g. ConfigError)" do
-        # Bad config (deprecation, validation, etc.) leaves OT.conf nil — we
-        # must surface the actual error rather than swallowing it for REPL
-        # debugging. ConfigError includes FatalBootError to signal this.
-        config_error = OT::ConfigError.new("Deprecated configuration detected: foo.bar")
-        allow(Onetime::Config).to receive(:after_load).and_raise(config_error)
+      it "re-raises ConfigError from deprecated config in :cli mode" do
+        # Real path: load returns a config with a deprecated key, check_deprecations
+        # raises ConfigError (which includes FatalBootError), and boot! must
+        # propagate it instead of swallowing for the CLI REPL.
+        deprecated_conf = loaded_config.dup
+        deprecated_conf['site']['domains'] = { 'enabled' => true }
+        allow(Onetime::Config).to receive(:load).and_return(deprecated_conf)
 
         expect {
           Onetime.boot!(:cli)
-        }.to raise_error(OT::ConfigError, /Deprecated configuration detected/)
+        }.to raise_error(OT::ConfigError, /site\.domains is ignored/)
+      end
+
+      it "re-raises ConfigError in non-CLI mode too (parity with prior behavior)" do
+        # FatalBootError must NOT regress the non-CLI path — config errors
+        # have always halted there. Verifies the new marker doesn't change
+        # behavior outside CLI mode.
+        deprecated_conf = loaded_config.dup
+        deprecated_conf['site']['domains'] = { 'enabled' => true }
+        allow(Onetime::Config).to receive(:load).and_return(deprecated_conf)
+
+        expect {
+          Onetime.boot!(:test)
+        }.to raise_error(OT::ConfigError, /site\.domains is ignored/)
       end
 
       it "still swallows non-fatal OT::Problem in :cli mode for REPL debugging" do


### PR DESCRIPTION
## Summary

Refactor boot error handling to treat configuration and migration errors as fatal in CLI mode, while providing a `SAFE_BOOT=1` escape hatch for interactive debugging. Previously, `OT::Problem` exceptions were silently swallowed in CLI mode to allow REPL access, but this masked configuration errors that left the application in an unusable state (with `OT.conf` nil), causing downstream nil errors.

### Key Changes

1. **Introduce `FatalBootError` marker module** (`lib/onetime/errors.rb`):
   - New marker module to distinguish boot errors that must always halt execution
   - `ConfigError` and `MigrationError` now include this module
   - Signals that the application cannot recover from these errors

2. **Update boot error handling** (`lib/onetime/boot.rb`):
   - `FatalBootError` exceptions are now re-raised in CLI mode unless `SAFE_BOOT=1` is set
   - `Redis::CannotConnectError` is now treated as fatal (database unavailability makes the app unusable)
   - Added `safe_boot?` helper method to check for `SAFE_BOOT=1` environment variable
   - Changed initializer failure error from `OT::Problem` to `OT::ConfigError`

3. **Add CLI support** (`bin/ots`):
   - New `--safe-boot` flag to enable `SAFE_BOOT=1` mode
   - Catch `FatalBootError` at the CLI entry point and display user-friendly error messages
   - Suggest using `--safe-boot` as an escape hatch for diagnosis

4. **Remove defensive nil checks**:
   - `lib/onetime/cli.rb`: Removed check for `OT.conf` nil after boot (now guaranteed by fatal errors)
   - `apps/api/domains/cli/helpers.rb`: Removed nil guard in `get_validation_strategy`
   - `scripts/upgrades/v0.24.5/rebuild_custom_domain_indexes.rb`: Removed nil check, added proper error handling

5. **Raise `ConfigError` for invalid config** (`lib/onetime/config.rb`):
   - Changed `JURISDICTIONS` format validation to raise `ConfigError` instead of generic `Problem`

## Related Issues

<!-- Add issue number if applicable -->

## Test Plan

Comprehensive test coverage added in `spec/integration/all/initializers/boot_part2_spec.rb`:
- ConfigError re-raised in CLI mode
- ConfigError re-raised in non-CLI mode (parity check)
- ConfigError from deprecated env vars re-raised in CLI mode
- Non-fatal `OT::Problem` still swallowed in CLI mode
- `Redis::CannotConnectError` now treated as fatal in CLI mode
- `SAFE_BOOT=1` swallows ConfigError and Redis errors in CLI mode only
- `SAFE_BOOT=1` has no effect outside CLI mode

All existing tests pass; new tests verify the error handling behavior across different boot modes and configurations.

https://claude.ai/code/session_01TGMpvLicfhNa5T2SXfCHdz