### PR TITLE
Add billing orgs validate command to detect unresolvable plan IDs

### DIFF
--- a/apps/web/billing/cli/billing_command.rb
+++ b/apps/web/billing/cli/billing_command.rb
@@ -47,6 +47,7 @@ module Onetime
             bin/ots billing diagnose EMAIL        Diagnose entitlement resolution for a user
             bin/ots billing diagnose EMAIL --entitlement custom_mail_sender
             bin/ots billing diagnose EMAIL --verbose
+            bin/ots billing orgs validate         Detect orgs whose planid doesn't resolve
 
           Testing:
             bin/ots billing test create-customer  Create test customer with card

--- a/apps/web/billing/cli/catalog_validate_command.rb
+++ b/apps/web/billing/cli/catalog_validate_command.rb
@@ -3,6 +3,7 @@
 # frozen_string_literal: true
 
 require_relative 'helpers'
+require_relative 'validation_helpers'
 require_relative '../operations/catalog/validate'
 
 module Onetime
@@ -14,6 +15,7 @@ module Onetime
     # unknown fields), run: bin/ots billing products validate
     class BillingCatalogValidateCommand < Command
       include BillingHelpers
+      include ValidationHelpers
 
       desc 'Validate plan catalog YAML structure (schema validation only)'
 
@@ -38,7 +40,11 @@ module Onetime
         end
 
         print_plan_summary(result.plan_summary)
-        print_validation_results(result.errors, result.warnings, strict, result.valid)
+        print_errors_section(result.errors) if result.errors.any?
+        print_warnings_section(result.warnings) if result.warnings.any?
+        print_final_status(result.errors, result.warnings, strict)
+
+        exit(result.valid ? 0 : 1)
       end
 
       private
@@ -52,63 +58,30 @@ module Onetime
         invalid = summary[:invalid] || []
 
         puts
-        if valid.any?
-          puts "VALID (#{valid.size}) " + ('-' * (60 - "VALID (#{valid.size}) ".length))
-          valid.sort_by { |p| -(p[:display_order] || 0) }.each do |plan|
-            marker = plan[:tier] == 'free' ? '*' : ' '
-            name   = (plan[:name] || plan[:id]).to_s
-            puts "  #{marker} #{name.ljust(20)} (#{plan[:id]})"
-          end
-          puts if invalid.any?
-        end
+        print_plan_summary_group('VALID', valid) if valid.any?
+        puts if valid.any? && invalid.any?
+        print_plan_summary_group('INVALID', invalid, indent: '    ') if invalid.any?
 
-        if invalid.any?
-          puts "INVALID (#{invalid.size}) " + ('-' * (60 - "INVALID (#{invalid.size}) ".length))
-          invalid.each do |plan|
-            name = (plan[:name] || plan[:id]).to_s
-            puts "    #{name} (#{plan[:id]})"
-          end
-        end
+        return unless summary[:has_free_tier]
 
-        if summary[:has_free_tier]
-          puts
-          puts '  * Free tier valid in catalog, does not have a Stripe product'
-        end
+        puts
+        puts '  * Free tier valid in catalog, does not have a Stripe product'
       end
 
-      def print_validation_results(errors, warnings, strict, valid)
-        puts
-        puts '-' * 62
+      def print_plan_summary_group(label, plans, indent: '  ')
+        heading = "#{label} (#{plans.size}) "
+        puts heading + ('-' * (60 - heading.length))
 
-        if errors.any?
-          puts "VALIDATION FAILED: #{errors.size} error(s) found"
-          puts '-' * 62
-          puts
-          errors.each { |e| puts "  #{e}" }
-          puts
-          exit 1
-        elsif warnings.any? && strict
-          puts "VALIDATION FAILED: #{warnings.size} warning(s) in strict mode"
-          puts '-' * 62
-          puts
-          warnings.each { |w| puts "  #{w}" }
-          puts
-          exit 1
-        elsif warnings.any?
-          puts 'VALIDATION PASSED (warnings only)'
-          puts '-' * 62
-          puts
-          puts "  #{warnings.size} warning(s):"
-          puts
-          warnings.each { |w| puts "  #{w}" }
-          puts
-        else
-          puts 'VALIDATION PASSED'
-          puts '-' * 62
-          puts
+        sorted = plans.sort_by { |p| -(p[:display_order] || 0) }
+        sorted.each do |plan|
+          name = (plan[:name] || plan[:id]).to_s
+          if label == 'VALID'
+            marker = plan[:tier] == 'free' ? '*' : ' '
+            puts "#{indent}#{marker} #{name.ljust(20)} (#{plan[:id]})"
+          else
+            puts "#{indent}#{name} (#{plan[:id]})"
+          end
         end
-
-        exit(valid ? 0 : 1)
       end
     end
   end

--- a/apps/web/billing/cli/orgs_command.rb
+++ b/apps/web/billing/cli/orgs_command.rb
@@ -1,0 +1,37 @@
+# apps/web/billing/cli/orgs_command.rb
+#
+# frozen_string_literal: true
+
+require_relative 'helpers'
+
+module Onetime
+  module CLI
+    # Parent help command for `billing orgs` subcommands.
+    class BillingOrgsCommand < Command
+      include BillingHelpers
+
+      desc 'Inspect organization billing state'
+
+      def call(**)
+        puts <<~HELP
+          Organization Billing Commands:
+
+            bin/ots billing orgs validate   Detect orgs with plan IDs that don't resolve
+
+          Examples:
+            # Scan all orgs for unresolvable plan IDs
+            bin/ots billing orgs validate
+
+            # Same scan, JSON output for tooling
+            bin/ots billing orgs validate --json
+
+            # Show per-org details as the scan runs
+            bin/ots billing orgs validate --verbose
+
+        HELP
+      end
+    end
+  end
+end
+
+Onetime::CLI.register 'billing orgs', Onetime::CLI::BillingOrgsCommand

--- a/apps/web/billing/cli/orgs_validate_command.rb
+++ b/apps/web/billing/cli/orgs_validate_command.rb
@@ -1,0 +1,194 @@
+# apps/web/billing/cli/orgs_validate_command.rb
+#
+# frozen_string_literal: true
+
+require 'json'
+
+require_relative 'helpers'
+
+module Onetime
+  module CLI
+    # Detect organizations whose `planid` cannot be resolved against the
+    # Redis plan cache or billing.yaml config.
+    #
+    # Since PR #3097 (issue #3089), billing fails closed on plan cache
+    # misses: an org with an unresolvable planid raises
+    # `Billing::PlanCacheMissError` instead of silently falling back to
+    # free tier. This command lets operators scan production for orgs
+    # that would break before rolling out a change.
+    #
+    # Usage:
+    #   bin/ots billing orgs validate
+    #   bin/ots billing orgs validate --verbose
+    #   bin/ots billing orgs validate --json
+    #
+    # Exits non-zero when at least one org has an unresolvable planid,
+    # so the command is safe to gate deploys on.
+    #
+    # @see https://github.com/onetimesecret/onetimesecret/issues/3099
+    class BillingOrgsValidateCommand < Command
+      include BillingHelpers
+
+      desc "Detect orgs whose planid doesn't resolve in cache or config"
+
+      option :verbose,
+        type: :boolean,
+        default: false,
+        aliases: ['v'],
+        desc: 'Print each invalid org as it is detected'
+
+      option :json,
+        type: :boolean,
+        default: false,
+        desc: 'Emit machine-readable JSON instead of a text report'
+
+      def call(verbose: false, json: false, **)
+        boot_application!
+
+        unless billing_module_loaded?
+          warn 'Billing module is not loaded; nothing to validate.'
+          exit 0
+        end
+
+        stats        = init_stats
+        invalid_orgs = []
+
+        Onetime::Organization.instances.each_record(batch_size: 100) do |org|
+          process_org(org, stats, invalid_orgs, verbose: verbose && !json)
+        end
+
+        report = build_report(stats, invalid_orgs)
+
+        if json
+          puts JSON.pretty_generate(report)
+        else
+          print_text_report(report)
+        end
+
+        exit(invalid_orgs.empty? ? 0 : 1)
+      end
+
+      private
+
+      def billing_module_loaded?
+        defined?(::Billing::Plan) && ::Billing::Plan.respond_to?(:load_with_fallback)
+      end
+
+      def init_stats
+        {
+          total: 0,
+          skipped_no_planid: 0,
+          valid_stripe: 0,
+          valid_config: 0,
+          invalid: 0,
+        }
+      end
+
+      def process_org(org, stats, invalid_orgs, verbose:)
+        stats[:total] += 1
+        planid         = org.planid.to_s
+
+        if planid.empty?
+          stats[:skipped_no_planid] += 1
+          return
+        end
+
+        result = ::Billing::Plan.load_with_fallback(planid)
+
+        case result[:source]
+        when 'stripe'
+          stats[:valid_stripe] += 1
+        when 'local_config'
+          stats[:valid_config] += 1
+        else
+          stats[:invalid] += 1
+          entry           = build_invalid_entry(org, planid)
+          invalid_orgs << entry
+          puts format_verbose_line(entry) if verbose
+        end
+      end
+
+      def build_invalid_entry(org, planid)
+        {
+          extid: org.extid,
+          display_name: org.display_name.to_s,
+          planid: planid,
+          stripe_customer_id: org.stripe_customer_id.to_s,
+          stripe_subscription_id: org.stripe_subscription_id.to_s,
+          subscription_status: org.subscription_status.to_s,
+        }
+      end
+
+      def format_verbose_line(entry)
+        sub_state = entry[:subscription_status].empty? ? '(no sub)' : entry[:subscription_status]
+        "  invalid: #{entry[:extid]}  planid=#{entry[:planid]}  sub=#{sub_state}"
+      end
+
+      def build_report(stats, invalid_orgs)
+        {
+          stats: stats,
+          invalid_orgs: invalid_orgs,
+          invalid_by_planid: group_by_planid(invalid_orgs),
+        }
+      end
+
+      def group_by_planid(invalid_orgs)
+        grouped = invalid_orgs.group_by { |o| o[:planid] }
+        # Sort by descending count so the worst offenders surface first.
+        grouped.sort_by { |_planid, orgs| -orgs.size }.to_h
+      end
+
+      def print_text_report(report)
+        stats        = report[:stats]
+        invalid_orgs = report[:invalid_orgs]
+        grouped      = report[:invalid_by_planid]
+
+        puts
+        puts 'Organization Plan ID Validation'
+        puts '=' * 60
+        puts "  Total orgs scanned:       #{stats[:total]}"
+        puts "  Skipped (no planid):      #{stats[:skipped_no_planid]}"
+        puts "  Valid (Redis cache):      #{stats[:valid_stripe]}"
+        puts "  Valid (billing.yaml):     #{stats[:valid_config]}"
+        puts "  Invalid plan IDs:         #{stats[:invalid]}"
+        puts
+
+        if invalid_orgs.empty?
+          puts 'All organizations have resolvable plan IDs.'
+          return
+        end
+
+        print_invalid_groups(grouped)
+        print_resolution_hints
+      end
+
+      def print_invalid_groups(grouped)
+        puts 'INVALID PLAN IDS'
+        puts '-' * 60
+
+        grouped.each do |planid, orgs|
+          puts
+          puts "  #{planid} (#{orgs.size} #{orgs.size == 1 ? 'org' : 'orgs'}):"
+          orgs.each do |org|
+            name      = org[:display_name].empty? ? '(no name)' : org[:display_name]
+            sub_state = org[:subscription_status].empty? ? 'no sub' : org[:subscription_status]
+            puts "    - #{org[:extid]}  #{name}  [#{sub_state}]"
+          end
+        end
+        puts
+      end
+
+      def print_resolution_hints
+        puts '-' * 60
+        puts 'Resolution:'
+        puts '  - Update org.planid to a value in the catalog or billing.yaml'
+        puts '  - Or add the missing plan to billing.yaml / Stripe catalog'
+        puts '  - Refresh the plan cache: bin/ots billing catalog pull'
+        puts '  - Inspect a specific org:  bin/ots billing diagnose --org <extid>'
+        puts
+      end
+    end
+  end
+end
+
+Onetime::CLI.register 'billing orgs validate', Onetime::CLI::BillingOrgsValidateCommand

--- a/apps/web/billing/cli/orgs_validate_command.rb
+++ b/apps/web/billing/cli/orgs_validate_command.rb
@@ -54,13 +54,14 @@ module Onetime
 
         stats        = init_stats
         invalid_orgs = []
+        plan_cache   = {}
 
         total             = Onetime::Organization.instances.element_count
         progress_interval = [total / 10, 1].max
         show_progress     = !json && !verbose
 
         Onetime::Organization.instances.each_record(batch_size: 100) do |org|
-          process_org(org, stats, invalid_orgs, verbose: verbose && !json)
+          process_org(org, stats, invalid_orgs, plan_cache, verbose: verbose && !json)
           print_progress(stats[:total], total, progress_interval, label: 'organizations scanned') if show_progress
         end
 
@@ -97,7 +98,7 @@ module Onetime
         }
       end
 
-      def process_org(org, stats, invalid_orgs, verbose:)
+      def process_org(org, stats, invalid_orgs, plan_cache, verbose:)
         stats[:total] += 1
         planid         = org.planid.to_s
 
@@ -106,7 +107,11 @@ module Onetime
           return
         end
 
-        result = ::Billing::Plan.load_with_fallback(planid)
+        # Memoize per planid: most orgs share a small set of canonical
+        # plans, so this collapses many HGETALLs into one per unique id.
+        result = plan_cache.fetch(planid) do
+          plan_cache[planid] = ::Billing::Plan.load_with_fallback(planid)
+        end
 
         case result[:source]
         when 'stripe'

--- a/apps/web/billing/cli/orgs_validate_command.rb
+++ b/apps/web/billing/cli/orgs_validate_command.rb
@@ -5,6 +5,7 @@
 require 'json'
 
 require_relative 'helpers'
+require_relative 'validation_helpers'
 
 module Onetime
   module CLI
@@ -28,6 +29,7 @@ module Onetime
     # @see https://github.com/onetimesecret/onetimesecret/issues/3099
     class BillingOrgsValidateCommand < Command
       include BillingHelpers
+      include ValidationHelpers
 
       desc "Detect orgs whose planid doesn't resolve in cache or config"
 
@@ -45,17 +47,24 @@ module Onetime
       def call(verbose: false, json: false, **)
         boot_application!
 
-        unless billing_module_loaded?
-          warn 'Billing module is not loaded; nothing to validate.'
+        unless billing_enabled?
+          warn 'Billing is not enabled; nothing to validate.'
           exit 0
         end
 
         stats        = init_stats
         invalid_orgs = []
 
+        total             = Onetime::Organization.instances.element_count
+        progress_interval = [total / 10, 1].max
+        show_progress     = !json && !verbose
+
         Onetime::Organization.instances.each_record(batch_size: 100) do |org|
           process_org(org, stats, invalid_orgs, verbose: verbose && !json)
+          print_progress(stats[:total], total, progress_interval, label: 'organizations scanned') if show_progress
         end
+
+        clear_progress_line if show_progress
 
         report = build_report(stats, invalid_orgs)
 
@@ -70,8 +79,12 @@ module Onetime
 
       private
 
-      def billing_module_loaded?
-        defined?(::Billing::Plan) && ::Billing::Plan.respond_to?(:load_with_fallback)
+      def billing_enabled?
+        return false unless defined?(Onetime::BillingConfig)
+        return false unless Onetime::BillingConfig.instance.enabled?
+        return false unless defined?(::Billing::Plan) && ::Billing::Plan.respond_to?(:load_with_fallback)
+
+        true
       end
 
       def init_stats
@@ -145,7 +158,7 @@ module Onetime
 
         puts
         puts 'Organization Plan ID Validation'
-        puts '=' * 60
+        print_separator(60, '=')
         puts "  Total orgs scanned:       #{stats[:total]}"
         puts "  Skipped (no planid):      #{stats[:skipped_no_planid]}"
         puts "  Valid (Redis cache):      #{stats[:valid_stripe]}"
@@ -164,7 +177,7 @@ module Onetime
 
       def print_invalid_groups(grouped)
         puts 'INVALID PLAN IDS'
-        puts '-' * 60
+        print_separator(60, '-')
 
         grouped.each do |planid, orgs|
           puts
@@ -179,13 +192,14 @@ module Onetime
       end
 
       def print_resolution_hints
-        puts '-' * 60
-        puts 'Resolution:'
-        puts '  - Update org.planid to a value in the catalog or billing.yaml'
-        puts '  - Or add the missing plan to billing.yaml / Stripe catalog'
-        puts '  - Refresh the plan cache: bin/ots billing catalog pull'
-        puts '  - Inspect a specific org:  bin/ots billing diagnose --org <extid>'
-        puts
+        print_resolution_section(
+          [
+            'Update org.planid to a value in the catalog or billing.yaml',
+            'Or add the missing plan to billing.yaml / Stripe catalog',
+            'Refresh the plan cache: bin/ots billing catalog pull',
+            'Inspect a specific org:  bin/ots billing diagnose --org <extid>',
+          ],
+        )
       end
     end
   end

--- a/apps/web/billing/cli/validation_helpers.rb
+++ b/apps/web/billing/cli/validation_helpers.rb
@@ -5,7 +5,8 @@
 module Onetime
   module CLI
     # Shared validation helpers for billing commands
-    # Used by prices_validate, plans_validate, and products_validate commands
+    # Used by prices_validate, plans_validate, products_validate, and
+    # orgs_validate commands.
     module ValidationHelpers
       # Status indicators (consistent across all validation commands)
       STATUS_VALID      = '✓ Valid'
@@ -96,10 +97,11 @@ module Onetime
       #
       # @param title [String] Section title
       # @param width [Integer] Line width (default: 80)
-      def print_section_header(title, width = 80)
-        print_separator(width)
+      # @param char [String] Separator character (default: '━')
+      def print_section_header(title, width = 80, char = '━')
+        print_separator(width, char)
         puts title
-        print_separator(width)
+        print_separator(width, char)
       end
 
       # Prints structured errors with details and resolution steps
@@ -216,6 +218,54 @@ module Onetime
           item_id = item.is_a?(Hash) ? item[id_field] : item.send(id_field)
           !error_ids.include?(item_id) && !warning_ids.include?(item_id)
         end
+      end
+
+      # Prints an in-place progress indicator to stdout.
+      #
+      # Emits a CR-prefixed line at most every `interval` iterations (and
+      # always on the final iteration). Caller is responsible for calling
+      # {#clear_progress_line} when the loop completes.
+      #
+      # @param current [Integer] Current iteration count (1-indexed)
+      # @param total [Integer] Total iterations expected
+      # @param interval [Integer] How often to emit progress (every Nth iteration)
+      # @param label [String] What's being processed (e.g., 'organizations scanned')
+      def print_progress(current, total, interval, label: 'items processed')
+        return unless (current % interval).zero? || current == total
+
+        print "\r  Progress: #{current}/#{total} #{label}"
+        $stdout.flush
+      end
+
+      # Clears the current progress line from stdout.
+      #
+      # Overwrites the line with whitespace and resets the cursor to the
+      # start of the line, allowing subsequent output to begin cleanly.
+      #
+      # @param width [Integer] Width of the line to clear (default: 80)
+      def clear_progress_line(width = 80)
+        print "\r" + (' ' * width) + "\r"
+        $stdout.flush
+      end
+
+      # Prints a standalone "Resolution:" block listing next-step hints.
+      #
+      # Use this for commands that surface aggregate guidance (e.g., a list
+      # of operator commands to run after a scan) separate from structured
+      # per-item errors. Structured errors should embed their own
+      # `:resolution` array and let {#print_errors_section} render them.
+      #
+      # @param steps [Array<String>] Resolution hint lines to print
+      # @param width [Integer] Separator line width (default: 60)
+      # @param char [String] Separator character (default: '-')
+      # @param label [String] Heading label (default: 'Resolution:')
+      def print_resolution_section(steps, width: 60, char: '-', label: 'Resolution:')
+        return if steps.empty?
+
+        print_separator(width, char)
+        puts label
+        steps.each { |step| puts "  - #{step}" }
+        puts
       end
     end
   end

--- a/apps/web/billing/spec/cli/catalog_validate_command_spec.rb
+++ b/apps/web/billing/spec/cli/catalog_validate_command_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe 'Billing Catalog Validate CLI', :billing_cli do
 
       it 'passes with warnings' do
         output, status = run_command
-        expect(output).to include('VALIDATION PASSED (warnings only)')
+        expect(output).to include('VALIDATION PASSED')
         expect(output).to include('1 warning(s)')
         expect(status).to eq(0)
       end
@@ -118,7 +118,7 @@ RSpec.describe 'Billing Catalog Validate CLI', :billing_cli do
       it 'fails in strict mode with warnings' do
         output, status = run_command(strict: true)
         expect(output).to include('VALIDATION FAILED')
-        expect(output).to include('warning(s) in strict mode')
+        expect(output).to include('treated as errors in strict mode')
         expect(status).to eq(1)
       end
     end
@@ -141,13 +141,18 @@ RSpec.describe 'Billing Catalog Validate CLI', :billing_cli do
       it 'reports VALIDATION FAILED' do
         output, status = run_command
         expect(output).to include('VALIDATION FAILED')
-        expect(output).to include('1 error(s) found')
+        expect(output).to include('1 item(s) have errors')
         expect(status).to eq(1)
       end
 
       it 'shows error details' do
         output, _status = run_command
         expect(output).to include('Schema validation:')
+      end
+
+      it 'includes the ERRORS section heading' do
+        output, _status = run_command
+        expect(output).to include('ERRORS (1)')
       end
     end
 

--- a/apps/web/billing/spec/cli/orgs_validate_command_integration_spec.rb
+++ b/apps/web/billing/spec/cli/orgs_validate_command_integration_spec.rb
@@ -1,0 +1,208 @@
+# apps/web/billing/spec/cli/orgs_validate_command_integration_spec.rb
+#
+# frozen_string_literal: true
+
+# Integration spec for `bin/ots billing orgs validate`.
+#
+# Complements the mock-heavy unit spec
+# (orgs_validate_command_spec.rb) by exercising the command end-to-end
+# against real Redis and real Familia objects:
+#
+#   - Real Onetime::Customer and Onetime::Organization persistence
+#   - Real Onetime::Organization.instances sorted-set iteration
+#   - Real Billing::Plan.load_with_fallback resolution against the
+#     Redis cache populated from spec/billing.test.yaml
+#
+# Uses the `:integration` symbol tag so the billing_spec_helper hooks
+# run `flushdb` and `mock_billing_config!` between tests. The
+# Plan.load stub from `stub_test_plan_catalog!` is reset to
+# `and_call_original` so real plans persisted by ConfigLoader are
+# visible to the command.
+#
+# Run: pnpm run test:rspec apps/web/billing/spec/cli/orgs_validate_command_integration_spec.rb
+
+require 'json'
+
+require_relative '../support/billing_spec_helper'
+require 'onetime/cli'
+require_relative '../../cli/orgs_validate_command'
+require_relative '../../operations/catalog/config_loader'
+
+RSpec.describe 'Billing Orgs Validate CLI (integration)', :integration do
+  subject(:command) { Onetime::CLI::BillingOrgsValidateCommand.new }
+
+  # The :integration before hook calls stub_test_plan_catalog! which
+  # mocks Billing::Plan.load for test_plan_v1 and identity_plus_v1.
+  # That defeats the point of an integration test, so reset to the real
+  # implementation and let the data we persist below drive resolution.
+  before do
+    allow(command).to receive(:boot_application!)
+    allow(Billing::Plan).to receive(:load).and_call_original
+
+    # Load plans from spec/billing.test.yaml into Redis. This populates
+    # the `instances` sorted set and gives us a real plan (identity_plus_v1)
+    # that load_with_fallback can resolve via the Stripe-cache path.
+    Billing::Operations::Catalog::ConfigLoader.load_all_from_config
+  end
+
+  def run_command(**kwargs)
+    old_stdout = $stdout
+    $stdout    = StringIO.new
+    status     = nil
+    begin
+      command.call(**kwargs)
+    rescue SystemExit => e
+      status = e.status
+    end
+    [$stdout.string, status]
+  ensure
+    $stdout = old_stdout
+  end
+
+  # Build a real Customer + Organization in Redis with the requested
+  # planid. Each call uses a unique email so multiple orgs/customers can
+  # coexist without colliding with unique indexes.
+  def create_org(planid:, display_name: 'Test Org', email_seed: nil, **extra)
+    seed     = email_seed || SecureRandom.hex(4)
+    email    = "orgs-validate-#{seed}@example.com"
+    customer = Onetime::Customer.create!(email: email)
+    org      = Onetime::Organization.create!(display_name, customer, email)
+    org.planid = planid
+    extra.each { |k, v| org.send("#{k}=", v) }
+    org.save
+    org
+  end
+
+  describe 'happy path: all orgs resolvable' do
+    it 'exits 0 when every org has a planid that resolves via Redis cache' do
+      # identity_plus_v1 is persisted to Redis by ConfigLoader above and
+      # resolves through Billing::Plan.load (source: 'stripe').
+      create_org(planid: 'identity_plus_v1', display_name: 'Acme Inc')
+
+      output, status = run_command
+
+      expect(status).to eq(0)
+      expect(output).to include('Total orgs scanned:       1')
+      expect(output).to include('Skipped (no planid):      0')
+      expect(output).to include('Valid (Redis cache):      1')
+      expect(output).to include('Invalid plan IDs:         0')
+      expect(output).to include('All organizations have resolvable plan IDs.')
+      expect(output).not_to include('INVALID PLAN IDS')
+    end
+  end
+
+  describe 'invalid planid' do
+    it 'exits 1 and reports the org under the invalid planid heading' do
+      org = create_org(
+        planid: 'definitely_not_a_real_plan_v99',
+        display_name: 'Ghost Co',
+      )
+
+      output, status = run_command
+
+      expect(status).to eq(1)
+      expect(output).to include('Invalid plan IDs:         1')
+      expect(output).to include('INVALID PLAN IDS')
+      expect(output).to include('definitely_not_a_real_plan_v99 (1 org)')
+      expect(output).to include(org.extid)
+      expect(output).to include('Ghost Co')
+      expect(output).to include('Resolution:')
+    end
+  end
+
+  describe 'mixed orgs: valid + invalid + empty planid' do
+    it 'reports correct counts for each bucket' do
+      create_org(planid: 'identity_plus_v1', display_name: 'Valid Org', email_seed: 'valid')
+      create_org(planid: 'ghost_plan_v1',    display_name: 'Invalid Org', email_seed: 'invalid')
+
+      # Empty planid: create org then blank out the default 'free_v1'
+      # assigned in Organization#init.
+      empty_org        = create_org(planid: 'free_v1', display_name: 'Empty Org', email_seed: 'empty')
+      empty_org.planid = ''
+      empty_org.save
+
+      output, status = run_command
+
+      expect(status).to eq(1)
+      expect(output).to include('Total orgs scanned:       3')
+      expect(output).to include('Skipped (no planid):      1')
+      expect(output).to include('Valid (Redis cache):      1')
+      expect(output).to include('Invalid plan IDs:         1')
+    end
+  end
+
+  describe 'cache miss with config fallback' do
+    it 'counts an org whose planid only exists in billing.yaml as Valid (billing.yaml)' do
+      # free_v1 is in spec/billing.test.yaml but is skipped by
+      # ConfigLoader (no prices), so it is NOT persisted to Redis.
+      # load_with_fallback should therefore miss the cache and hit
+      # load_from_config, returning source: 'local_config'.
+      config_plan = Billing::Plan.load_from_config('free_v1')
+
+      if config_plan.nil?
+        skip 'free_v1 not available via Billing::Config.load_plans in this environment'
+      end
+
+      # Sanity check: free_v1 must not be in the Redis cache for this
+      # test to mean anything. ConfigLoader skips priceless plans so
+      # this should hold, but guard against silent regressions.
+      expect(Billing::Plan.load('free_v1')).to be_nil
+
+      create_org(planid: 'free_v1', display_name: 'Config Fallback Org')
+
+      output, status = run_command
+
+      expect(status).to eq(0)
+      expect(output).to include('Valid (billing.yaml):     1')
+      expect(output).to include('Valid (Redis cache):      0')
+      expect(output).to include('All organizations have resolvable plan IDs.')
+    end
+  end
+
+  describe '--json output' do
+    it 'emits a parseable JSON document matching the documented contract' do
+      valid_org   = create_org(planid: 'identity_plus_v1', display_name: 'Valid Co', email_seed: 'json-valid')
+      invalid_org = create_org(
+        planid: 'ghost_v1',
+        display_name: 'Ghost Co',
+        email_seed: 'json-invalid',
+        stripe_customer_id: 'cus_int_1',
+        stripe_subscription_id: 'sub_int_1',
+        subscription_status: 'canceled',
+      )
+
+      output, status = run_command(json: true)
+
+      expect(status).to eq(1)
+
+      # Suppresses the text report.
+      expect(output).not_to include('Organization Plan ID Validation')
+      expect(output).not_to include('Resolution:')
+
+      parsed = JSON.parse(output)
+
+      expect(parsed['stats']).to include(
+        'total' => 2,
+        'invalid' => 1,
+        'valid_stripe' => 1,
+        'skipped_no_planid' => 0,
+      )
+
+      expect(parsed['invalid_orgs'].size).to eq(1)
+      expect(parsed['invalid_orgs'].first).to include(
+        'extid' => invalid_org.extid,
+        'planid' => 'ghost_v1',
+        'display_name' => 'Ghost Co',
+        'stripe_customer_id' => 'cus_int_1',
+        'stripe_subscription_id' => 'sub_int_1',
+        'subscription_status' => 'canceled',
+      )
+
+      # Make sure the valid org is NOT in the invalid list.
+      expect(parsed['invalid_orgs'].map { |o| o['extid'] }).not_to include(valid_org.extid)
+
+      expect(parsed['invalid_by_planid']).to have_key('ghost_v1')
+      expect(parsed['invalid_by_planid']['ghost_v1'].size).to eq(1)
+    end
+  end
+end

--- a/apps/web/billing/spec/cli/orgs_validate_command_spec.rb
+++ b/apps/web/billing/spec/cli/orgs_validate_command_spec.rb
@@ -1,0 +1,246 @@
+# apps/web/billing/spec/cli/orgs_validate_command_spec.rb
+#
+# frozen_string_literal: true
+
+require 'json'
+
+require_relative '../support/billing_spec_helper'
+require 'onetime/cli'
+require_relative '../../cli/orgs_validate_command'
+
+RSpec.describe 'Billing Orgs Validate CLI', :billing_cli do
+  subject(:command) { Onetime::CLI::BillingOrgsValidateCommand.new }
+
+  let(:mock_instances) { instance_double(Familia::SortedSet) }
+
+  def run_command(**kwargs)
+    old_stdout = $stdout
+    $stdout    = StringIO.new
+    status     = nil
+    begin
+      command.call(**kwargs)
+    rescue SystemExit => e
+      status = e.status
+    end
+    [$stdout.string, status]
+  ensure
+    $stdout = old_stdout
+  end
+
+  def mock_org(extid:, planid:, display_name: 'Test Org', stripe_customer_id: '', stripe_subscription_id: '', subscription_status: '')
+    instance_double(
+      Onetime::Organization,
+      extid: extid,
+      planid: planid,
+      display_name: display_name,
+      stripe_customer_id: stripe_customer_id,
+      stripe_subscription_id: stripe_subscription_id,
+      subscription_status: subscription_status,
+    )
+  end
+
+  before do
+    allow(command).to receive(:boot_application!)
+    allow(Onetime::Organization).to receive(:instances).and_return(mock_instances)
+  end
+
+  describe 'when all orgs have resolvable plan IDs' do
+    let(:org_valid_stripe) { mock_org(extid: 'on_valid_a', planid: 'identity_plus_v1') }
+    let(:org_valid_config) { mock_org(extid: 'on_valid_b', planid: 'free_v1') }
+    let(:org_no_plan)      { mock_org(extid: 'on_empty', planid: '') }
+
+    before do
+      allow(mock_instances).to receive(:each_record)
+        .and_yield(org_valid_stripe)
+        .and_yield(org_valid_config)
+        .and_yield(org_no_plan)
+
+      allow(::Billing::Plan).to receive(:load_with_fallback)
+        .with('identity_plus_v1')
+        .and_return(plan: double, config: nil, source: 'stripe')
+
+      allow(::Billing::Plan).to receive(:load_with_fallback)
+        .with('free_v1')
+        .and_return(plan: nil, config: {}, source: 'local_config')
+    end
+
+    it 'exits 0 and reports success' do
+      output, status = run_command
+
+      expect(status).to eq(0)
+      expect(output).to include('Total orgs scanned:       3')
+      expect(output).to include('Skipped (no planid):      1')
+      expect(output).to include('Valid (Redis cache):      1')
+      expect(output).to include('Valid (billing.yaml):     1')
+      expect(output).to include('Invalid plan IDs:         0')
+      expect(output).to include('All organizations have resolvable plan IDs.')
+      expect(output).not_to include('INVALID PLAN IDS')
+    end
+  end
+
+  describe 'when some orgs have unresolvable plan IDs' do
+    let(:org_invalid_a) { mock_org(extid: 'on_a', planid: 'ghost_plan', display_name: 'Acme', subscription_status: 'active') }
+    let(:org_invalid_b) { mock_org(extid: 'on_b', planid: 'ghost_plan', display_name: 'Beta') }
+    let(:org_invalid_c) { mock_org(extid: 'on_c', planid: 'typo_plus_v1', display_name: '') }
+    let(:org_valid)     { mock_org(extid: 'on_ok', planid: 'identity_plus_v1') }
+
+    before do
+      allow(mock_instances).to receive(:each_record)
+        .and_yield(org_invalid_a)
+        .and_yield(org_invalid_b)
+        .and_yield(org_invalid_c)
+        .and_yield(org_valid)
+
+      allow(::Billing::Plan).to receive(:load_with_fallback)
+        .with('ghost_plan')
+        .and_return(plan: nil, config: nil, source: nil)
+
+      allow(::Billing::Plan).to receive(:load_with_fallback)
+        .with('typo_plus_v1')
+        .and_return(plan: nil, config: nil, source: nil)
+
+      allow(::Billing::Plan).to receive(:load_with_fallback)
+        .with('identity_plus_v1')
+        .and_return(plan: double, config: nil, source: 'stripe')
+    end
+
+    it 'exits 1 when invalid orgs are found' do
+      _output, status = run_command
+
+      expect(status).to eq(1)
+    end
+
+    it 'groups invalid orgs by planid, sorted by count descending' do
+      output, _status = run_command
+
+      expect(output).to include('Invalid plan IDs:         3')
+      expect(output).to include('INVALID PLAN IDS')
+
+      # ghost_plan appears before typo_plus_v1 because it has more orgs (2 vs 1)
+      ghost_idx = output.index('ghost_plan (2 orgs)')
+      typo_idx  = output.index('typo_plus_v1 (1 org)')
+      expect(ghost_idx).not_to be_nil
+      expect(typo_idx).not_to be_nil
+      expect(ghost_idx).to be < typo_idx
+    end
+
+    it 'lists each invalid org under its planid heading' do
+      output, _status = run_command
+
+      expect(output).to include('on_a  Acme  [active]')
+      expect(output).to include('on_b  Beta  [no sub]')
+      expect(output).to include('on_c  (no name)  [no sub]')
+    end
+
+    it 'prints resolution hints' do
+      output, _status = run_command
+
+      expect(output).to include('Resolution:')
+      expect(output).to include('bin/ots billing catalog pull')
+      expect(output).to include('bin/ots billing diagnose --org')
+    end
+  end
+
+  describe '--json output' do
+    let(:org_invalid) { mock_org(extid: 'on_x', planid: 'ghost', display_name: 'Ghost Co', stripe_customer_id: 'cus_1', stripe_subscription_id: 'sub_1', subscription_status: 'canceled') }
+    let(:org_valid)   { mock_org(extid: 'on_y', planid: 'identity_plus_v1') }
+
+    before do
+      allow(mock_instances).to receive(:each_record)
+        .and_yield(org_invalid)
+        .and_yield(org_valid)
+
+      allow(::Billing::Plan).to receive(:load_with_fallback)
+        .with('ghost')
+        .and_return(plan: nil, config: nil, source: nil)
+
+      allow(::Billing::Plan).to receive(:load_with_fallback)
+        .with('identity_plus_v1')
+        .and_return(plan: double, config: nil, source: 'stripe')
+    end
+
+    it 'emits valid JSON with stats and invalid orgs' do
+      output, status = run_command(json: true)
+
+      expect(status).to eq(1)
+      parsed = JSON.parse(output)
+
+      expect(parsed['stats']).to include(
+        'total' => 2,
+        'invalid' => 1,
+        'valid_stripe' => 1,
+      )
+
+      expect(parsed['invalid_orgs'].size).to eq(1)
+      expect(parsed['invalid_orgs'].first).to include(
+        'extid' => 'on_x',
+        'planid' => 'ghost',
+        'display_name' => 'Ghost Co',
+        'stripe_customer_id' => 'cus_1',
+        'stripe_subscription_id' => 'sub_1',
+        'subscription_status' => 'canceled',
+      )
+
+      expect(parsed['invalid_by_planid']).to have_key('ghost')
+      expect(parsed['invalid_by_planid']['ghost'].size).to eq(1)
+    end
+
+    it 'suppresses the text report when --json is set' do
+      output, _status = run_command(json: true)
+
+      expect(output).not_to include('Organization Plan ID Validation')
+      expect(output).not_to include('Resolution:')
+    end
+  end
+
+  describe '--verbose output' do
+    let(:org_invalid) { mock_org(extid: 'on_v', planid: 'ghost', subscription_status: 'past_due') }
+
+    before do
+      allow(mock_instances).to receive(:each_record).and_yield(org_invalid)
+      allow(::Billing::Plan).to receive(:load_with_fallback)
+        .with('ghost')
+        .and_return(plan: nil, config: nil, source: nil)
+    end
+
+    it 'prints invalid orgs as they are detected' do
+      output, _status = run_command(verbose: true)
+
+      expect(output).to include('invalid: on_v  planid=ghost  sub=past_due')
+    end
+
+    it 'does not print per-org lines when --json is also set' do
+      output, _status = run_command(verbose: true, json: true)
+
+      expect(output).not_to include('invalid: on_v')
+    end
+  end
+
+  describe 'when no organizations exist' do
+    before do
+      allow(mock_instances).to receive(:each_record)
+    end
+
+    it 'exits 0 with zero counts' do
+      output, status = run_command
+
+      expect(status).to eq(0)
+      expect(output).to include('Total orgs scanned:       0')
+      expect(output).to include('All organizations have resolvable plan IDs.')
+    end
+  end
+
+  describe 'when the billing module is not loaded' do
+    before do
+      allow(command).to receive(:billing_module_loaded?).and_return(false)
+      allow(mock_instances).to receive(:each_record)
+    end
+
+    it 'exits 0 without scanning organizations' do
+      _output, status = run_command
+
+      expect(status).to eq(0)
+      expect(mock_instances).not_to have_received(:each_record)
+    end
+  end
+end

--- a/apps/web/billing/spec/cli/orgs_validate_command_spec.rb
+++ b/apps/web/billing/spec/cli/orgs_validate_command_spec.rb
@@ -143,6 +143,17 @@ RSpec.describe 'Billing Orgs Validate CLI', :billing_cli do
       expect(output).to include('bin/ots billing catalog pull')
       expect(output).to include('bin/ots billing diagnose --org')
     end
+
+    it 'memoizes Plan.load_with_fallback per planid (no N+1)' do
+      run_command
+
+      # ghost_plan appears on two orgs; identity_plus_v1 and
+      # typo_plus_v1 appear on one each. Without memoization we'd
+      # see 4 calls; with memoization we see 3 (one per unique id).
+      expect(::Billing::Plan).to have_received(:load_with_fallback).with('ghost_plan').once
+      expect(::Billing::Plan).to have_received(:load_with_fallback).with('typo_plus_v1').once
+      expect(::Billing::Plan).to have_received(:load_with_fallback).with('identity_plus_v1').once
+    end
   end
 
   describe '--json output' do

--- a/apps/web/billing/spec/cli/orgs_validate_command_spec.rb
+++ b/apps/web/billing/spec/cli/orgs_validate_command_spec.rb
@@ -41,7 +41,9 @@ RSpec.describe 'Billing Orgs Validate CLI', :billing_cli do
 
   before do
     allow(command).to receive(:boot_application!)
+    allow(command).to receive(:billing_enabled?).and_return(true)
     allow(Onetime::Organization).to receive(:instances).and_return(mock_instances)
+    allow(mock_instances).to receive(:element_count).and_return(0)
   end
 
   describe 'when all orgs have resolvable plan IDs' do
@@ -50,6 +52,7 @@ RSpec.describe 'Billing Orgs Validate CLI', :billing_cli do
     let(:org_no_plan)      { mock_org(extid: 'on_empty', planid: '') }
 
     before do
+      allow(mock_instances).to receive(:element_count).and_return(3)
       allow(mock_instances).to receive(:each_record)
         .and_yield(org_valid_stripe)
         .and_yield(org_valid_config)
@@ -85,6 +88,7 @@ RSpec.describe 'Billing Orgs Validate CLI', :billing_cli do
     let(:org_valid)     { mock_org(extid: 'on_ok', planid: 'identity_plus_v1') }
 
     before do
+      allow(mock_instances).to receive(:element_count).and_return(4)
       allow(mock_instances).to receive(:each_record)
         .and_yield(org_invalid_a)
         .and_yield(org_invalid_b)
@@ -146,6 +150,7 @@ RSpec.describe 'Billing Orgs Validate CLI', :billing_cli do
     let(:org_valid)   { mock_org(extid: 'on_y', planid: 'identity_plus_v1') }
 
     before do
+      allow(mock_instances).to receive(:element_count).and_return(2)
       allow(mock_instances).to receive(:each_record)
         .and_yield(org_invalid)
         .and_yield(org_valid)
@@ -197,6 +202,7 @@ RSpec.describe 'Billing Orgs Validate CLI', :billing_cli do
     let(:org_invalid) { mock_org(extid: 'on_v', planid: 'ghost', subscription_status: 'past_due') }
 
     before do
+      allow(mock_instances).to receive(:element_count).and_return(1)
       allow(mock_instances).to receive(:each_record).and_yield(org_invalid)
       allow(::Billing::Plan).to receive(:load_with_fallback)
         .with('ghost')
@@ -230,9 +236,9 @@ RSpec.describe 'Billing Orgs Validate CLI', :billing_cli do
     end
   end
 
-  describe 'when the billing module is not loaded' do
+  describe 'when billing is not enabled' do
     before do
-      allow(command).to receive(:billing_module_loaded?).and_return(false)
+      allow(command).to receive(:billing_enabled?).and_return(false)
       allow(mock_instances).to receive(:each_record)
     end
 


### PR DESCRIPTION
## Summary

[#3099](https://github.com/onetimesecret/onetimesecret/issues/3099)

Adds a new CLI command `bin/ots billing orgs validate` that scans all organizations to detect those with plan IDs that cannot be resolved in the Redis cache or billing.yaml config. This command enables operators to identify problematic organizations before deploying changes that enforce strict plan resolution (as introduced in PR #3097).

The command:
- Iterates through all organizations and attempts to resolve each planid via `Billing::Plan.load_with_fallback`
- Categorizes results: valid (Redis cache), valid (config fallback), skipped (no planid), or invalid
- Exits with status 0 if all orgs are resolvable, status 1 if any are invalid
- Supports `--verbose` flag to print per-org details during the scan
- Supports `--json` flag for machine-readable output suitable for tooling/automation
- Provides resolution hints when invalid orgs are found

Also refactors shared validation helpers into a new `ValidationHelpers` module and updates `catalog_validate_command` to use them, reducing code duplication.

## Related Issues

Fixes #3099

## Test Plan

Added comprehensive unit tests (`orgs_validate_command_spec.rb`) covering:
- Happy path: all orgs resolvable
- Invalid planids with proper grouping and reporting
- JSON output format and contract
- Verbose mode output
- Edge cases (no orgs, billing disabled)

Added integration tests (`orgs_validate_command_integration_spec.rb`) exercising:
- Real Redis persistence and Familia sorted-set iteration
- Real plan resolution via cache and config fallback
- Mixed scenarios with valid, invalid, and empty planids
- JSON output against real data

Existing catalog_validate_command tests updated to reflect refactored output format.

https://claude.ai/code/session_01S94Urc7zP9esPqP75tgi4h