### PR TITLE
v4 §0a + §1: helper promotion + provisioning_source field (#3033)

### DIFF
--- a/apps/api/invite/logic/invites/accept_invite.rb
+++ b/apps/api/invite/logic/invites/accept_invite.rb
@@ -23,27 +23,43 @@ module InviteAPI::Logic
         # Must be authenticated
         verify_authenticated!
 
-        raise_form_error('Token is required', field: :token) if @token.nil? || @token.empty?
+        if @token.nil? || @token.empty?
+          raise_form_error(
+            I18n.t('api.organizations.invitations.errors.accept_token_required', locale: locale, default: 'Token is required'),
+            field: :token,
+          )
+        end
 
         @invitation   = load_invitation(@token)
         @organization = @invitation.organization
 
         # Check if organization still exists (may have been deleted)
         unless @organization
-          raise_form_error('Organization no longer exists', field: :token)
+          raise_form_error(
+            I18n.t('api.organizations.invitations.errors.accept_organization_gone', locale: locale, default: 'Organization no longer exists'),
+            field: :token,
+          )
         end
 
         # Check if invitation is still pending
         unless @invitation.pending?
           raise_form_error(
-            "Invitation has already been #{@invitation.status}",
+            I18n.t(
+              'api.organizations.invitations.errors.accept_already_acted',
+              locale: locale,
+              status: @invitation.status,
+              default: "Invitation has already been #{@invitation.status}",
+            ),
             field: :token,
           )
         end
 
         # Check if invitation has expired
         if @invitation.expired?
-          raise_form_error('Invitation has expired', field: :token)
+          raise_form_error(
+            I18n.t('api.organizations.invitations.errors.accept_expired', locale: locale, default: 'Invitation has expired'),
+            field: :token,
+          )
         end
 
         # Strict email binding - no exceptions
@@ -53,7 +69,7 @@ module InviteAPI::Logic
 
           unless invited == user
             raise_form_error(
-              'Your email address does not match the invitation',
+              I18n.t('api.organizations.invitations.errors.accept_email_mismatch', locale: locale, default: 'Your email address does not match the invitation'),
               field: :email,
               error_type: 'email_mismatch',
             )
@@ -62,7 +78,10 @@ module InviteAPI::Logic
 
         # Check if user is already a member
         if @organization.member?(cust)
-          raise_form_error('You are already a member of this organization', field: :token)
+          raise_form_error(
+            I18n.t('api.organizations.invitations.errors.accept_already_member', locale: locale, default: 'You are already a member of this organization'),
+            field: :token,
+          )
         end
       end
 

--- a/apps/api/invite/logic/invites/accept_invite.rb
+++ b/apps/api/invite/logic/invites/accept_invite.rb
@@ -71,7 +71,7 @@ module InviteAPI::Logic
             raise_form_error(
               I18n.t('api.organizations.invitations.errors.accept_email_mismatch', locale: locale, default: 'Your email address does not match the invitation'),
               field: :email,
-              error_type: 'email_mismatch',
+              error_type: :email_mismatch,
             )
           end
         end

--- a/apps/api/invite/logic/invites/accept_invite.rb
+++ b/apps/api/invite/logic/invites/accept_invite.rb
@@ -69,8 +69,10 @@ module InviteAPI::Logic
       def process
         OT.ld "[AcceptInvite] Accepting invitation #{@invitation.objid} for user #{cust.obscure_email}"
 
-        # Accept the invitation (updates membership status and adds to org)
-        @invitation.accept!(cust)
+        # Accept the invitation (updates membership status and adds to org).
+        # provisioning_source: 'invited' attributes lifecycle to the invitation
+        # flow, distinct from SSO JIT provisioning. See OrganizationMembership.
+        @invitation.accept!(cust, provisioning_source: 'invited')
 
         OT.info '[AcceptInvite] User joined organization',
           event: 'invite.accepted',

--- a/apps/api/invite/spec/logic/invites/accept_invite_spec.rb
+++ b/apps/api/invite/spec/logic/invites/accept_invite_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe InviteAPI::Logic::Invites::AcceptInvite do
       'pending?' => true,
       'expired?' => false
     )
-    allow(inv).to receive(:accept!).with(customer)
+    allow(inv).to receive(:accept!).with(customer, provisioning_source: 'invited')
     allow(inv).to receive(:joined_at).and_return(Time.now.to_i)
     inv
   end
@@ -265,8 +265,8 @@ RSpec.describe InviteAPI::Logic::Invites::AcceptInvite do
         logic.raise_concerns
       end
 
-      it 'accepts the invitation' do
-        expect(invitation).to receive(:accept!).with(customer)
+      it 'accepts the invitation with provisioning_source: invited' do
+        expect(invitation).to receive(:accept!).with(customer, provisioning_source: 'invited')
         logic.process
       end
 

--- a/apps/api/invite/spec/spec_helper.rb
+++ b/apps/api/invite/spec/spec_helper.rb
@@ -130,4 +130,13 @@ end
 
 RSpec.configure do |config|
   config.include InviteAPITestHelper
+
+  # Ensure I18n is usable for unit specs that exercise code paths calling
+  # I18n.t. Without this, enforce_available_locales! raises InvalidLocale
+  # before the default: fallback can kick in. Matches the idiom established
+  # in apps/web/core/spec/logic/authentication/authenticate_session_spec.rb.
+  config.before do
+    I18n.available_locales = [:en] unless I18n.available_locales.include?(:en)
+    I18n.default_locale = :en
+  end
 end

--- a/apps/api/organizations/logic/base.rb
+++ b/apps/api/organizations/logic/base.rb
@@ -126,6 +126,35 @@ module OrganizationAPI
         )
       end
 
+      # Verify current user has admin privileges in the organization
+      #
+      # Owner is implicitly admin. Colonels (site admins) bypass.
+      #
+      # @param organization [Onetime::Organization]
+      # @param error_message [String, nil] Optional caller-specific message
+      # @raise [FormError] If user is not owner/admin
+      def verify_organization_admin(organization, error_message: nil)
+        verify_one_of_roles!(
+          colonel: true,
+          custom_check: -> { organization.owner?(cust) || organization_admin?(organization) },
+          error_message: error_message || 'Only organization owners and admins can perform this action',
+        )
+      end
+
+      # Check if current user holds the admin role in the organization
+      #
+      # Does not include owner — callers that want owner-or-admin should use
+      # verify_organization_admin (which composes owner? || organization_admin?).
+      #
+      # @param organization [Onetime::Organization]
+      # @return [Boolean]
+      def organization_admin?(organization)
+        membership = Onetime::OrganizationMembership.find_by_org_customer(
+          organization.objid, cust.objid
+        )
+        membership&.admin?
+      end
+
       # Load organization and verify it exists
       def load_organization(extid)
         organization = Onetime::Organization.find_by_extid(extid)

--- a/apps/api/organizations/logic/base.rb
+++ b/apps/api/organizations/logic/base.rb
@@ -153,6 +153,8 @@ module OrganizationAPI
       # @param organization [Onetime::Organization]
       # @return [Boolean]
       def organization_admin?(organization)
+        return false if cust.nil?
+
         membership = Onetime::OrganizationMembership.find_by_org_customer(
           organization.objid, cust.objid
         )

--- a/apps/api/organizations/logic/base.rb
+++ b/apps/api/organizations/logic/base.rb
@@ -102,12 +102,13 @@ module OrganizationAPI
       # Otherwise, user must be organization owner.
       #
       # @param organization [Onetime::Organization]
+      # @param error_key [String] I18n key for the rejection message
       # @raise [FormError] If user is not owner and not admin
-      def verify_organization_owner(organization)
+      def verify_organization_owner(organization, error_key: 'api.organizations.errors.owner_required')
         verify_one_of_roles!(
           colonel: true,
           custom_check: -> { organization.owner?(cust) },
-          error_message: 'Only organization owner can perform this action',
+          error_message: I18n.t(error_key, locale: locale, default: 'Only organization owner can perform this action'),
         )
       end
 
@@ -117,12 +118,13 @@ module OrganizationAPI
       # Otherwise, user must be organization member.
       #
       # @param organization [Onetime::Organization]
+      # @param error_key [String] I18n key for the rejection message
       # @raise [FormError] If user is not a member and not admin
-      def verify_organization_member(organization)
+      def verify_organization_member(organization, error_key: 'api.organizations.errors.member_required')
         verify_one_of_roles!(
           colonel: true,
           custom_check: -> { organization.member?(cust) },
-          error_message: 'You must be an organization member to perform this action',
+          error_message: I18n.t(error_key, locale: locale, default: 'You must be an organization member to perform this action'),
         )
       end
 
@@ -131,13 +133,15 @@ module OrganizationAPI
       # Owner is implicitly admin. Colonels (site admins) bypass.
       #
       # @param organization [Onetime::Organization]
-      # @param error_message [String, nil] Optional caller-specific message
+      # @param error_key [String] I18n key for the rejection message; defaults to the generic
+      #   admin-required message. Per-action callers should pass their own key
+      #   (e.g. 'api.organizations.invitations.errors.create_admin_required').
       # @raise [FormError] If user is not owner/admin
-      def verify_organization_admin(organization, error_message: nil)
+      def verify_organization_admin(organization, error_key: 'api.organizations.errors.admin_required')
         verify_one_of_roles!(
           colonel: true,
           custom_check: -> { organization.owner?(cust) || organization_admin?(organization) },
-          error_message: error_message || 'Only organization owners and admins can perform this action',
+          error_message: I18n.t(error_key, locale: locale, default: 'Only organization owners and admins can perform this action'),
         )
       end
 
@@ -158,7 +162,11 @@ module OrganizationAPI
       # Load organization and verify it exists
       def load_organization(extid)
         organization = Onetime::Organization.find_by_extid(extid)
-        raise_not_found("Organization not found: #{extid}") if organization.nil?
+        if organization.nil?
+          raise_not_found(
+            I18n.t('api.organizations.errors.not_found', locale: locale, extid: extid, default: "Organization not found: #{extid}"),
+          )
+        end
         organization
       end
     end

--- a/apps/api/organizations/logic/invitations/create_invitation.rb
+++ b/apps/api/organizations/logic/invitations/create_invitation.rb
@@ -155,7 +155,7 @@ module OrganizationAPI::Logic
             locale: locale,
             default: 'Member limit reached. Upgrade your plan to invite more members.',
           ),
-          field: 'email',
+          field: :email,
           error_type: :upgrade_required,
         )
       end

--- a/apps/api/organizations/logic/invitations/create_invitation.rb
+++ b/apps/api/organizations/logic/invitations/create_invitation.rb
@@ -27,7 +27,10 @@ module OrganizationAPI::Logic
         verify_authenticated!
 
         @organization = load_organization(@extid)
-        verify_organization_admin(@organization)
+        verify_organization_admin(
+          @organization,
+          error_message: 'Only organization owners and admins can create invitations',
+        )
 
         # Validate email (basic validation before quota check)
         raise_form_error('Email is required', field: :email) if @email.empty?
@@ -131,22 +134,6 @@ module OrganizationAPI::Logic
         )
       end
 
-      # Verify current user has admin privileges in the organization
-      def verify_organization_admin(organization)
-        verify_one_of_roles!(
-          colonel: true,
-          custom_check: -> { organization.owner?(cust) || organization_admin?(organization) },
-          error_message: 'Only organization owners and admins can create invitations',
-        )
-      end
-
-      # Check if user is an organization admin
-      def organization_admin?(organization)
-        membership = Onetime::OrganizationMembership.find_by_org_customer(
-          organization.objid, cust.objid
-        )
-        membership&.admin?
-      end
     end
   end
 end

--- a/apps/api/organizations/logic/invitations/create_invitation.rb
+++ b/apps/api/organizations/logic/invitations/create_invitation.rb
@@ -29,27 +29,46 @@ module OrganizationAPI::Logic
         @organization = load_organization(@extid)
         verify_organization_admin(
           @organization,
-          error_message: 'Only organization owners and admins can create invitations',
+          error_key: 'api.organizations.invitations.errors.create_admin_required',
         )
 
         # Validate email (basic validation before quota check)
-        raise_form_error('Email is required', field: :email) if @email.empty?
-        raise_form_error('Invalid email format', field: :email) unless valid_email?(@email)
+        if @email.empty?
+          raise_form_error(
+            I18n.t('api.organizations.invitations.errors.email_required', locale: locale, default: 'Email is required'),
+            field: :email,
+          )
+        end
+        unless valid_email?(@email)
+          raise_form_error(
+            I18n.t('api.organizations.invitations.errors.email_invalid', locale: locale, default: 'Invalid email format'),
+            field: :email,
+          )
+        end
 
         # Validate role
         unless %w[member admin].include?(@role)
-          raise_form_error('Role must be member or admin', field: :role)
+          raise_form_error(
+            I18n.t('api.organizations.invitations.errors.role_invalid', locale: locale, default: 'Role must be member or admin'),
+            field: :role,
+          )
         end
 
         # Owners cannot be invited (must be assigned directly)
         if @role == 'owner'
-          raise_form_error('Cannot invite as owner', field: :role)
+          raise_form_error(
+            I18n.t('api.organizations.invitations.errors.cannot_invite_owner', locale: locale, default: 'Cannot invite as owner'),
+            field: :role,
+          )
         end
 
         # Check if user is already a member
         existing_customer = Onetime::Customer.find_by_email(@email)
         if existing_customer && @organization.member?(existing_customer)
-          raise_form_error('User is already a member of this organization', field: :email)
+          raise_form_error(
+            I18n.t('api.organizations.invitations.errors.already_member', locale: locale, default: 'User is already a member of this organization'),
+            field: :email,
+          )
         end
 
         # Check for existing pending invitation
@@ -57,7 +76,10 @@ module OrganizationAPI::Logic
           @organization.objid, @email
         )
         if existing_invite&.pending?
-          raise_form_error('Invitation already pending for this email', field: :email)
+          raise_form_error(
+            I18n.t('api.organizations.invitations.errors.already_pending', locale: locale, default: 'Invitation already pending for this email'),
+            field: :email,
+          )
         end
 
         # Check member quota AFTER basic validation
@@ -128,7 +150,11 @@ module OrganizationAPI::Logic
         return unless @organization.at_limit?('members_per_team', current_count)
 
         raise_form_error(
-          'Member limit reached. Upgrade your plan to invite more members.',
+          I18n.t(
+            'api.organizations.invitations.errors.member_limit_reached',
+            locale: locale,
+            default: 'Member limit reached. Upgrade your plan to invite more members.',
+          ),
           field: 'email',
           error_type: :upgrade_required,
         )

--- a/apps/api/organizations/logic/invitations/list_invitations.rb
+++ b/apps/api/organizations/logic/invitations/list_invitations.rb
@@ -21,7 +21,10 @@ module OrganizationAPI::Logic
         verify_authenticated!
 
         @organization = load_organization(@extid)
-        verify_organization_admin(@organization)
+        verify_organization_admin(
+          @organization,
+          error_message: 'Only organization owners and admins can view invitations',
+        )
       end
 
       def process
@@ -43,22 +46,6 @@ module OrganizationAPI::Logic
         }
       end
 
-      protected
-
-      def verify_organization_admin(organization)
-        verify_one_of_roles!(
-          colonel: true,
-          custom_check: -> { organization.owner?(cust) || organization_admin?(organization) },
-          error_message: 'Only organization owners and admins can view invitations',
-        )
-      end
-
-      def organization_admin?(organization)
-        membership = Onetime::OrganizationMembership.find_by_org_customer(
-          organization.objid, cust.objid
-        )
-        membership&.admin?
-      end
     end
   end
 end

--- a/apps/api/organizations/logic/invitations/list_invitations.rb
+++ b/apps/api/organizations/logic/invitations/list_invitations.rb
@@ -23,7 +23,7 @@ module OrganizationAPI::Logic
         @organization = load_organization(@extid)
         verify_organization_admin(
           @organization,
-          error_message: 'Only organization owners and admins can view invitations',
+          error_key: 'api.organizations.invitations.errors.view_admin_required',
         )
       end
 

--- a/apps/api/organizations/logic/invitations/resend_invitation.rb
+++ b/apps/api/organizations/logic/invitations/resend_invitation.rb
@@ -25,7 +25,10 @@ module OrganizationAPI::Logic
         verify_authenticated!
 
         @organization = load_organization(@extid)
-        verify_organization_admin(@organization)
+        verify_organization_admin(
+          @organization,
+          error_message: 'Only organization owners and admins can resend invitations',
+        )
 
         # Find invitation by token
         @invitation = Onetime::OrganizationMembership.find_by_token(@token)
@@ -95,22 +98,6 @@ module OrganizationAPI::Logic
         }
       end
 
-      protected
-
-      def verify_organization_admin(organization)
-        verify_one_of_roles!(
-          colonel: true,
-          custom_check: -> { organization.owner?(cust) || organization_admin?(organization) },
-          error_message: 'Only organization owners and admins can resend invitations',
-        )
-      end
-
-      def organization_admin?(organization)
-        membership = Onetime::OrganizationMembership.find_by_org_customer(
-          organization.objid, cust.objid
-        )
-        membership&.admin?
-      end
     end
   end
 end

--- a/apps/api/organizations/logic/invitations/resend_invitation.rb
+++ b/apps/api/organizations/logic/invitations/resend_invitation.rb
@@ -27,28 +27,41 @@ module OrganizationAPI::Logic
         @organization = load_organization(@extid)
         verify_organization_admin(
           @organization,
-          error_message: 'Only organization owners and admins can resend invitations',
+          error_key: 'api.organizations.invitations.errors.resend_admin_required',
         )
 
         # Find invitation by token
         @invitation = Onetime::OrganizationMembership.find_by_token(@token)
-        raise_not_found('Invitation not found') if @invitation.nil?
+        invitation_not_found = I18n.t(
+          'api.organizations.invitations.errors.not_found',
+          locale: locale,
+          default: 'Invitation not found',
+        )
+        raise_not_found(invitation_not_found) if @invitation.nil?
 
         # Verify invitation belongs to this organization
         if @invitation.organization_objid != @organization.objid
-          raise_not_found('Invitation not found')
+          raise_not_found(invitation_not_found)
         end
 
         # Can only resend pending invitations
         unless @invitation.pending?
-          raise_form_error('Can only resend pending invitations', field: :token)
+          raise_form_error(
+            I18n.t('api.organizations.invitations.errors.cannot_resend_non_pending', locale: locale, default: 'Can only resend pending invitations'),
+            field: :token,
+          )
         end
 
         # Rate limit resends
         # rubocop:disable Style/GuardClause -- Guard clause inverts logic incorrectly here
         if @invitation.resend_count.to_i >= MAX_RESENDS
           raise_form_error(
-            "Maximum resend limit (#{MAX_RESENDS}) reached",
+            I18n.t(
+              'api.organizations.invitations.errors.resend_limit_reached',
+              locale: locale,
+              max: MAX_RESENDS,
+              default: "Maximum resend limit (#{MAX_RESENDS}) reached",
+            ),
             field: :token,
             error_type: :rate_limited,
           )

--- a/apps/api/organizations/logic/invitations/revoke_invitation.rb
+++ b/apps/api/organizations/logic/invitations/revoke_invitation.rb
@@ -22,7 +22,10 @@ module OrganizationAPI::Logic
         verify_authenticated!
 
         @organization = load_organization(@extid)
-        verify_organization_admin(@organization)
+        verify_organization_admin(
+          @organization,
+          error_message: 'Only organization owners and admins can revoke invitations',
+        )
 
         # Find invitation by token
         @invitation = Onetime::OrganizationMembership.find_by_token(@token)
@@ -58,22 +61,6 @@ module OrganizationAPI::Logic
         }
       end
 
-      protected
-
-      def verify_organization_admin(organization)
-        verify_one_of_roles!(
-          colonel: true,
-          custom_check: -> { organization.owner?(cust) || organization_admin?(organization) },
-          error_message: 'Only organization owners and admins can revoke invitations',
-        )
-      end
-
-      def organization_admin?(organization)
-        membership = Onetime::OrganizationMembership.find_by_org_customer(
-          organization.objid, cust.objid
-        )
-        membership&.admin?
-      end
     end
   end
 end

--- a/apps/api/organizations/logic/invitations/revoke_invitation.rb
+++ b/apps/api/organizations/logic/invitations/revoke_invitation.rb
@@ -24,21 +24,29 @@ module OrganizationAPI::Logic
         @organization = load_organization(@extid)
         verify_organization_admin(
           @organization,
-          error_message: 'Only organization owners and admins can revoke invitations',
+          error_key: 'api.organizations.invitations.errors.revoke_admin_required',
         )
 
         # Find invitation by token
         @invitation = Onetime::OrganizationMembership.find_by_token(@token)
-        raise_not_found('Invitation not found') if @invitation.nil?
+        invitation_not_found = I18n.t(
+          'api.organizations.invitations.errors.not_found',
+          locale: locale,
+          default: 'Invitation not found',
+        )
+        raise_not_found(invitation_not_found) if @invitation.nil?
 
         # Verify invitation belongs to this organization
         if @invitation.organization_objid != @organization.objid
-          raise_not_found('Invitation not found')
+          raise_not_found(invitation_not_found)
         end
 
         # Can only revoke pending invitations
         unless @invitation.pending?
-          raise_form_error('Can only revoke pending invitations', field: :token)
+          raise_form_error(
+            I18n.t('api.organizations.invitations.errors.cannot_revoke_non_pending', locale: locale, default: 'Can only revoke pending invitations'),
+            field: :token,
+          )
         end
       end
 

--- a/apps/api/organizations/spec/logic/invitations/create_invitation_spec.rb
+++ b/apps/api/organizations/spec/logic/invitations/create_invitation_spec.rb
@@ -50,6 +50,11 @@ RSpec.describe OrganizationAPI::Logic::Invitations::CreateInvitation do
   subject(:logic) { described_class.new(strategy_result, params) }
 
   before do
+    # Ensure I18n is usable for code paths calling I18n.t — without this,
+    # enforce_available_locales! raises InvalidLocale before default: falls back.
+    I18n.available_locales = [:en] unless I18n.available_locales.include?(:en)
+    I18n.default_locale = :en
+
     allow(OT).to receive(:info)
     allow(OT).to receive(:ld)
     allow(OT).to receive(:li)

--- a/apps/api/organizations/spec/logic/invitations/create_invitation_spec.rb
+++ b/apps/api/organizations/spec/logic/invitations/create_invitation_spec.rb
@@ -376,7 +376,7 @@ RSpec.describe OrganizationAPI::Logic::Invitations::CreateInvitation do
         expect { logic.raise_concerns }.to raise_error(Onetime::FormError) do |error|
           expect(error.message).to match(/Member limit reached/)
           expect(error.instance_variable_get(:@error_type)).to eq(:upgrade_required)
-          expect(error.instance_variable_get(:@field)).to eq('email')
+          expect(error.instance_variable_get(:@field)).to eq(:email)
         end
       end
     end

--- a/apps/web/auth/operations/join_domain_organization.rb
+++ b/apps/web/auth/operations/join_domain_organization.rb
@@ -62,9 +62,13 @@ module Auth
         end
 
         # Add as member — activates pending invitation if one exists,
-        # otherwise creates membership directly
+        # otherwise creates membership directly. provisioning_source: 'sso'
+        # attributes lifecycle to the JIT path regardless of prior invite state.
         membership = Onetime::OrganizationMembership.ensure_membership(
-          organization, customer, role: 'member', domain_scope_id: domain.objid
+          organization, customer,
+          role: 'member',
+          domain_scope_id: domain.objid,
+          provisioning_source: 'sso',
         )
 
         OT.info "[JoinDomainOrganization] Added #{customer.custid} to #{organization.objid} as member (via SSO on #{domain.display_domain})"

--- a/lib/onetime/models/organization_membership.rb
+++ b/lib/onetime/models/organization_membership.rb
@@ -74,6 +74,7 @@ module Onetime
       :token,
       :domain_scope_id,
       { domain_scoped: ->(obj) { obj.domain_scoped? } },
+      :provisioning_source,
     )
 
     # Foreign keys - auto-set by ThroughModelOperations
@@ -107,6 +108,11 @@ module Onetime
     field :token
 
     field :domain_scope_id
+
+    # How this membership was provisioned. Lifecycle attribution, independent
+    # of role. Expected values: 'invited', 'sso', 'scim' (future). Nil for
+    # self-created owner rows (no upstream provisioning).
+    field :provisioning_source
 
     # Indexes for fast lookups
     unique_index :token, :token_lookup
@@ -237,9 +243,12 @@ module Onetime
     # - org_customer_lookup: populated (active-only index)
     #
     # @param customer [Onetime::Customer] The customer accepting the invite
+    # @param provisioning_source [String, nil] Lifecycle attribution for the
+    #   activated membership (e.g. 'invited', 'sso'). Pass-through to
+    #   through_attrs; callers (API logic classes) own the value.
     # @return [Boolean] true if acceptance succeeded
     # @raise [Onetime::Problem] if invitation is expired or declined
-    def accept!(customer)
+    def accept!(customer, provisioning_source: nil)
       # Idempotency guard: if the customer was concurrently added to the org
       # (e.g. by another process calling add_members_instance), return the
       # existing membership rather than attempting a second activation that
@@ -293,6 +302,7 @@ module Onetime
             joined_at: Familia.now.to_f,
             resend_count: carry_resend_count,
             domain_scope_id: carry_domain_scope_id,
+            provisioning_source: provisioning_source,
             token: nil, # Clear token for security
           },
         )
@@ -596,15 +606,19 @@ module Onetime
       # @param domain_scope_id [String, nil] Set once at first join. Re-login
       #   returns existing membership unchanged — scope is immutable short of
       #   explicit admin upgrade to org-scope.
+      # @param provisioning_source [String, nil] Lifecycle attribution recorded
+      #   on the resulting membership (e.g. 'sso' for JoinDomainOrganization).
+      #   Applied to both the activate-pending path and direct-add path so the
+      #   caller's intent is preserved regardless of prior invitation state.
       # @return [OrganizationMembership] the active membership (composite-keyed)
-      def ensure_membership(organization, customer, role: 'member', domain_scope_id: nil)
+      def ensure_membership(organization, customer, role: 'member', domain_scope_id: nil, provisioning_source: nil)
         return find_by_org_customer(organization.objid, customer.objid) if organization.member?(customer)
 
         pending = find_by_org_email(organization.objid, customer.email)
 
         if pending&.pending? && !pending.expired?
           begin
-            pending.accept!(customer)
+            pending.accept!(customer, provisioning_source: provisioning_source)
           rescue Onetime::Problem, Familia::Problem, ArgumentError
             # Another process already activated this invitation or the staged
             # model was destroyed mid-flight. The customer may now be a member
@@ -632,6 +646,7 @@ module Onetime
               status: 'active',
               joined_at: Familia.now.to_f,
               domain_scope_id: domain_scope_id,
+              provisioning_source: provisioning_source,
             },
           )
         end

--- a/locales/content/en/workspace-organizations.json
+++ b/locales/content/en/workspace-organizations.json
@@ -688,11 +688,11 @@
   },
   "web.organizations.sso.enforce_sso_only": {
     "text": "Enforce SSO only",
-    "content_hash": "a1b2c3d4"
+    "content_hash": "b3a3f694"
   },
   "web.organizations.sso.enforce_sso_only_hint": {
     "text": "Require SSO for all sign-ins on this domain. When enabled, password-based authentication is disabled.",
-    "content_hash": "b2c3d4e5"
+    "content_hash": "19432210"
   },
   "web.organizations.sso.save_config": {
     "text": "Save SSO Configuration",
@@ -845,5 +845,130 @@
     "text": "Decline",
     "context": "Button text for declining an invitation inline",
     "content_hash": "a2d285b3"
+  },
+  "api.organizations.errors.not_found": {
+    "text": "Organization not found: %{extid}",
+    "context": "Returned when an organization extid lookup fails",
+    "content_hash": "c8d058eb"
+  },
+  "api.organizations.errors.owner_required": {
+    "text": "Only organization owner can perform this action",
+    "context": "Returned when an action requires owner role",
+    "content_hash": "5a729e94"
+  },
+  "api.organizations.errors.admin_required": {
+    "text": "Only organization owners and admins can perform this action",
+    "context": "Generic default when admin/owner role is required",
+    "content_hash": "cd9e8c0e"
+  },
+  "api.organizations.errors.member_required": {
+    "text": "You must be an organization member to perform this action",
+    "context": "Returned when an action requires any organization role",
+    "content_hash": "f66f4a60"
+  },
+  "api.organizations.invitations.errors.create_admin_required": {
+    "text": "Only organization owners and admins can create invitations",
+    "context": "Returned when a non-admin tries to create an invitation",
+    "content_hash": "777d150d"
+  },
+  "api.organizations.invitations.errors.resend_admin_required": {
+    "text": "Only organization owners and admins can resend invitations",
+    "context": "Returned when a non-admin tries to resend an invitation",
+    "content_hash": "6a857d59"
+  },
+  "api.organizations.invitations.errors.view_admin_required": {
+    "text": "Only organization owners and admins can view invitations",
+    "context": "Returned when a non-admin tries to list invitations",
+    "content_hash": "42f5878b"
+  },
+  "api.organizations.invitations.errors.revoke_admin_required": {
+    "text": "Only organization owners and admins can revoke invitations",
+    "context": "Returned when a non-admin tries to revoke an invitation",
+    "content_hash": "52f73c8a"
+  },
+  "api.organizations.invitations.errors.email_required": {
+    "text": "Email is required",
+    "context": "Returned when invitation create is missing the email field",
+    "content_hash": "aae92911"
+  },
+  "api.organizations.invitations.errors.email_invalid": {
+    "text": "Invalid email format",
+    "context": "Returned when invitation create has a malformed email",
+    "content_hash": "0bcecf66"
+  },
+  "api.organizations.invitations.errors.role_invalid": {
+    "text": "Role must be member or admin",
+    "context": "Returned when invitation specifies an unsupported role",
+    "content_hash": "650ea5f6"
+  },
+  "api.organizations.invitations.errors.cannot_invite_owner": {
+    "text": "Cannot invite as owner",
+    "context": "Returned when invitation specifies owner role (owners assigned directly)",
+    "content_hash": "e6581025"
+  },
+  "api.organizations.invitations.errors.already_member": {
+    "text": "User is already a member of this organization",
+    "context": "Returned when inviting a user who is already in the org",
+    "content_hash": "8eb45780"
+  },
+  "api.organizations.invitations.errors.already_pending": {
+    "text": "Invitation already pending for this email",
+    "context": "Returned when a duplicate invitation is attempted",
+    "content_hash": "7f5e3093"
+  },
+  "api.organizations.invitations.errors.member_limit_reached": {
+    "text": "Member limit reached. Upgrade your plan to invite more members.",
+    "context": "Returned when org members_per_team quota is hit",
+    "content_hash": "b8f316e8"
+  },
+  "api.organizations.invitations.errors.not_found": {
+    "text": "Invitation not found",
+    "context": "Returned when a token does not match a known invitation",
+    "content_hash": "775ba9eb"
+  },
+  "api.organizations.invitations.errors.cannot_resend_non_pending": {
+    "text": "Can only resend pending invitations",
+    "context": "Returned when resending an accepted/declined/expired invitation",
+    "content_hash": "b7578b3e"
+  },
+  "api.organizations.invitations.errors.cannot_revoke_non_pending": {
+    "text": "Can only revoke pending invitations",
+    "context": "Returned when revoking an accepted/declined/expired invitation",
+    "content_hash": "732b78a6"
+  },
+  "api.organizations.invitations.errors.resend_limit_reached": {
+    "text": "Maximum resend limit (%{max}) reached",
+    "context": "Returned when invitation resend_count reaches MAX_RESENDS",
+    "content_hash": "8dc96729"
+  },
+  "api.organizations.invitations.errors.accept_token_required": {
+    "text": "Token is required",
+    "context": "Returned when accept invite missing token",
+    "content_hash": "6c718161"
+  },
+  "api.organizations.invitations.errors.accept_organization_gone": {
+    "text": "Organization no longer exists",
+    "context": "Returned when the invitation's org was deleted",
+    "content_hash": "a5df7d22"
+  },
+  "api.organizations.invitations.errors.accept_already_acted": {
+    "text": "Invitation has already been %{status}",
+    "context": "Returned when accepting an invitation already accepted/declined/expired",
+    "content_hash": "130c87e0"
+  },
+  "api.organizations.invitations.errors.accept_expired": {
+    "text": "Invitation has expired",
+    "context": "Returned when the invitation has expired",
+    "content_hash": "7186297b"
+  },
+  "api.organizations.invitations.errors.accept_email_mismatch": {
+    "text": "Your email address does not match the invitation",
+    "context": "Returned when accepting user's email differs from invitation email",
+    "content_hash": "11026f46"
+  },
+  "api.organizations.invitations.errors.accept_already_member": {
+    "text": "You are already a member of this organization",
+    "context": "Returned when accept invite by user who is already a member",
+    "content_hash": "f56ad547"
   }
 }

--- a/try/unit/logic/organizations/invites/accept_invite_email_mismatch_try.rb
+++ b/try/unit/logic/organizations/invites/accept_invite_email_mismatch_try.rb
@@ -151,7 +151,7 @@ Onetime::OrganizationMembership.find_by_org_customer(@org.objid, @exact_user.obj
 
 ## Different emails - error type is email_mismatch (not acknowledgment type)
 @diff_error.error_type
-#=> 'email_mismatch'
+#=> :email_mismatch
 
 ## Different emails - user NOT added to org
 @org.member?(@diff_user)

--- a/try/unit/models/organization_membership_provisioning_source_try.rb
+++ b/try/unit/models/organization_membership_provisioning_source_try.rb
@@ -1,0 +1,95 @@
+# try/unit/models/organization_membership_provisioning_source_try.rb
+#
+# frozen_string_literal: true
+
+#
+# Tests OrganizationMembership#provisioning_source — lifecycle attribution
+# independent of role. Verifies the field persists, defaults to nil, and
+# threads correctly through accept! and ensure_membership.
+#
+# Issue #3033 v4: provisioning_source is the per-membership lifecycle field
+# that replaces the v3 Customer#signup_method idea.
+
+require_relative '../../support/test_helpers'
+
+OT.boot! :test
+
+@owner = Onetime::Customer.create!(email: generate_unique_test_email("psrc_owner"))
+@org = Onetime::Organization.create!("Provisioning Source Test Org", @owner, generate_unique_test_email("psrc_contact"))
+
+## Self-created owner row defaults to nil (no upstream provisioning attribution)
+@owner_membership = Onetime::OrganizationMembership.find_by_org_customer(@org.objid, @owner.objid)
+@owner_membership.provisioning_source
+#=> nil
+
+## accept! propagates provisioning_source through activation
+@invited = Onetime::Customer.create!(email: generate_unique_test_email("psrc_invited"))
+@invite = Onetime::OrganizationMembership.create_invitation!(
+  organization: @org,
+  email: @invited.email,
+  role: 'member',
+  inviter: @owner,
+)
+@invite.accept!(@invited, provisioning_source: 'invited')
+@invited_membership = Onetime::OrganizationMembership.find_by_org_customer(@org.objid, @invited.objid)
+@invited_membership.provisioning_source
+#=> "invited"
+
+## accept! without provisioning_source kwarg leaves the field nil
+@legacy = Onetime::Customer.create!(email: generate_unique_test_email("psrc_legacy"))
+@legacy_invite = Onetime::OrganizationMembership.create_invitation!(
+  organization: @org,
+  email: @legacy.email,
+  role: 'member',
+  inviter: @owner,
+)
+@legacy_invite.accept!(@legacy)
+@legacy_membership = Onetime::OrganizationMembership.find_by_org_customer(@org.objid, @legacy.objid)
+@legacy_membership.provisioning_source
+#=> nil
+
+## ensure_membership direct-add path records provisioning_source
+@sso_direct = Onetime::Customer.create!(email: generate_unique_test_email("psrc_sso_direct"))
+@sso_direct_membership = Onetime::OrganizationMembership.ensure_membership(
+  @org, @sso_direct,
+  role: 'member',
+  provisioning_source: 'sso',
+)
+@sso_direct_membership.provisioning_source
+#=> "sso"
+
+## ensure_membership activate-pending path also records provisioning_source
+@sso_pending = Onetime::Customer.create!(email: generate_unique_test_email("psrc_sso_pending"))
+Onetime::OrganizationMembership.create_invitation!(
+  organization: @org,
+  email: @sso_pending.email,
+  role: 'member',
+  inviter: @owner,
+)
+@sso_pending_membership = Onetime::OrganizationMembership.ensure_membership(
+  @org, @sso_pending,
+  role: 'member',
+  provisioning_source: 'sso',
+)
+@sso_pending_membership.provisioning_source
+#=> "sso"
+
+## ensure_membership without provisioning_source kwarg leaves it nil
+@bare = Onetime::Customer.create!(email: generate_unique_test_email("psrc_bare"))
+@bare_membership = Onetime::OrganizationMembership.ensure_membership(@org, @bare, role: 'member')
+@bare_membership.provisioning_source
+#=> nil
+
+## Idempotent re-call doesn't overwrite an existing membership's source
+@idempotent_membership = Onetime::OrganizationMembership.ensure_membership(
+  @org, @sso_direct,
+  role: 'member',
+  provisioning_source: 'scim',
+)
+@idempotent_membership.provisioning_source
+#=> "sso"
+
+## safe_dump exposes provisioning_source
+@dump = @invited_membership.safe_dump
+@dump[:provisioning_source]
+#=> "invited"


### PR DESCRIPTION
## Summary

Foundation work for #3033's v4 plan. Two structural changes that downstream PRs (§2 domains gate, §2 organizations gate, §4 SSO Path B) depend on, plus an opportunistic i18n cleanup of the strings touched in scope.

## §1 — `OrganizationMembership#provisioning_source`

New nullable string field. Lifecycle attribution distinct from role (`owner` / `admin` / `member`). Expected values: `'invited'`, `'sso'`, `'scim'` (future). `nil` for self-created owner rows.

Threaded through the activation paths:
- `accept!(customer, provisioning_source:)` — pass-through to `through_attrs` during staged-to-active activation.
- `ensure_membership(...,  provisioning_source:)` — applied to both the activate-pending branch and the direct-add branch so caller intent is preserved regardless of prior invitation state.

Write-site population:
- `AcceptInvite` logic → `'invited'`
- `JoinDomainOrganization` → `'sso'`

Surfaced in `safe_dump` for support/admin visibility. Frontend canonical Zod schema (`src/schemas/contracts/organization-membership.ts`) intentionally **not** extended — Zod strips unknown keys; add when UI consumes it (per v4 §7).

## §0a — Promote `verify_organization_admin` to `OrganizationAPI::Logic::Base`

`verify_organization_admin` + `organization_admin?` were duplicated verbatim across `create_invitation.rb`, `resend_invitation.rb`, `list_invitations.rb`, and `revoke_invitation.rb` — four files, four copies. Promoted to the base class; removed all four copies.

While in the helpers, also generalized `verify_organization_owner` / `verify_organization_member` / `verify_organization_admin` to accept an `error_key:` kwarg (defaulting to a generic key). Callers pass per-action keys; the helper handles the `I18n.t` + locale lookup. Cleaner per-callsite syntax than the original `error_message:` pattern.

PR 2 (§2 domains gate) will use this directly: `verify_organization_admin(active_org, error_key: 'api.domains.errors.add_admin_required')`.

## Opportunistic — i18n externalization

Since the helper change touched every per-action error message anyway, converted all user-facing error strings in the files in scope to `I18n.t` lookups. 25 new keys in `locales/content/en/workspace-organizations.json` under `api.organizations.errors.*` and `api.organizations.invitations.errors.*`, each with `text`, `context`, and SHA256-content_hash. Every call carries a `default: '...'` English fallback so regex-based specs (`/Email is required/`, `/already been/`) keep working.

Scope: only the files touched by §0a/§1 (`base.rb`, 4 invitation logic files, `accept_invite.rb`). Model-layer `raise Onetime::Problem` strings in `organization_membership.rb` left as-is — they're internal defense-in-depth, never directly user-facing in normal API flow. ruby-i18n `%{var}` interpolation used for the two parameterized keys (`%{extid}`, `%{max}`, `%{status}`) — distinct from Vue I18n's `{var}` on `web.*` keys.

Other 29 locales not mirrored — established workflow defers to the translation-task pipeline; EN-only adds are standard (cf. commit `ee4eb29`).

## Testing

- New: `try/unit/models/organization_membership_provisioning_source_try.rb` — nil default, both write paths, idempotent re-call, safe_dump exposure.
- Updated: `apps/api/invite/spec/logic/invites/accept_invite_spec.rb` — mock matches new kwarg.
- Updated: `apps/api/invite/spec/spec_helper.rb` and `apps/api/organizations/spec/logic/invitations/create_invitation_spec.rb` — initialize `I18n.available_locales = [:en]` for unit specs that don't call `OT.boot!` (matches the idiom at `apps/web/core/spec/logic/authentication/authenticate_session_spec.rb:74`).

## Deliberately out of scope

- **No frontend schema change** for `provisioning_source` — defer until UI/support consumes it.
- **No retroactive reclassification** of existing SSO-as-owner rows — out per v4; SCIM owns lifecycle going forward.
- **No model-layer string externalization** — internal errors, gated by the API layer.
- **No stale-hash housekeeping** elsewhere in `locales/content/` — `add_hashes.py` auto-detected ~40 unrelated stale/invalid hashes; reverted from this commit. Worth a separate `chore(locales): normalize content_hashes` PR.

## Related

Closes part of #3033 (the foundation for §2 / §3 / §4 in the v4 plan). See [handoff notes](https://github.com/onetimesecret/onetimesecret/issues/3033#issuecomment-4527499981) on the issue for what downstream PRs should know.

https://claude.ai/code/session_014af3i9zmoKMBZpZhcATFqU