### PR TITLE
Adopt #3207/#3208 i18n error_key convention in IncomingConfig Logic

### DIFF
--- a/apps/api/domains/logic/incoming_config/base.rb
+++ b/apps/api/domains/logic/incoming_config/base.rb
@@ -32,7 +32,13 @@ module DomainsAPI
         # @raise [FormError] if domain not found
         def load_custom_domain(domain_id)
           domain = Onetime::CustomDomain.find_by_extid(domain_id)
-          raise_not_found("Domain not found: #{domain_id}") if domain.nil?
+          if domain.nil?
+            raise_not_found(
+              "Domain not found: #{domain_id}",
+              error_key: 'api.domains.errors.domain_not_found',
+              args: { extid: domain_id },
+            )
+          end
           domain
         end
 
@@ -43,7 +49,13 @@ module DomainsAPI
         # @raise [FormError] if organization not found
         def load_organization_for_domain(domain)
           org = Onetime::Organization.load(domain.org_id)
-          raise_not_found("Organization not found for domain: #{domain.display_domain}") if org.nil?
+          if org.nil?
+            raise_not_found(
+              "Organization not found for domain: #{domain.display_domain}",
+              error_key: 'api.domains.errors.organization_not_found',
+              args: { domain: domain.display_domain },
+            )
+          end
           org
         end
 
@@ -71,6 +83,7 @@ module DomainsAPI
 
           raise_form_error(
             'Incoming secrets management requires the incoming_secrets entitlement. Please upgrade your plan.',
+            error_key: 'api.domains.errors.incoming_secrets_entitlement_required',
             error_type: :forbidden,
           )
         end
@@ -82,7 +95,11 @@ module DomainsAPI
         # @return [void]
         def authorize_domain_incoming!(domain_id)
           unless OT.conf.dig('features', 'incoming', 'enabled')
-            raise_form_error('Incoming secrets is not enabled on this instance', error_type: :forbidden)
+            raise_form_error(
+              'Incoming secrets is not enabled on this instance',
+              error_key: 'api.domains.errors.incoming_secrets_disabled',
+              error_type: :forbidden,
+            )
           end
 
           @custom_domain = load_custom_domain(domain_id)

--- a/apps/api/domains/logic/incoming_config/delete_incoming_config.rb
+++ b/apps/api/domains/logic/incoming_config/delete_incoming_config.rb
@@ -29,17 +29,37 @@ module DomainsAPI
 
         def raise_concerns
           # Require authenticated user
-          raise_form_error('Authentication required', field: :user_id, error_type: :unauthorized) if cust.anonymous?
+          if cust.anonymous?
+            raise_form_error(
+              'Authentication required',
+              error_key: 'api.errors.authentication_required',
+              field: :user_id,
+              error_type: :unauthorized,
+            )
+          end
 
           # Validate domain_id parameter
-          raise_form_error('Domain ID required', field: :domain_id, error_type: :missing) if @domain_id.to_s.empty?
+          if @domain_id.to_s.empty?
+            raise_form_error(
+              'Domain ID required',
+              error_key: 'api.domains.errors.domain_id_required',
+              field: :domain_id,
+              error_type: :missing,
+            )
+          end
 
           # Load domain and organization, verify ownership and entitlement
           authorize_domain_incoming!(@domain_id)
 
           # Load incoming config
           @incoming_config = Onetime::CustomDomain::IncomingConfig.find_by_domain_id(@custom_domain.identifier)
-          raise_not_found("Incoming configuration not found for domain: #{@domain_id}") if @incoming_config.nil?
+          if @incoming_config.nil?
+            raise_not_found(
+              "Incoming configuration not found for domain: #{@domain_id}",
+              error_key: 'api.domains.errors.incoming_config_not_found',
+              args: { extid: @domain_id },
+            )
+          end
         end
 
         def process

--- a/apps/api/domains/logic/incoming_config/get_incoming_config.rb
+++ b/apps/api/domains/logic/incoming_config/get_incoming_config.rb
@@ -33,10 +33,24 @@ module DomainsAPI
 
         def raise_concerns
           # Require authenticated user
-          raise_form_error('Authentication required', field: :user_id, error_type: :unauthorized) if cust.anonymous?
+          if cust.anonymous?
+            raise_form_error(
+              'Authentication required',
+              error_key: 'api.errors.authentication_required',
+              field: :user_id,
+              error_type: :unauthorized,
+            )
+          end
 
           # Validate domain_id parameter
-          raise_form_error('Domain ID required', field: :domain_id, error_type: :missing) if @domain_id.to_s.empty?
+          if @domain_id.to_s.empty?
+            raise_form_error(
+              'Domain ID required',
+              error_key: 'api.domains.errors.domain_id_required',
+              field: :domain_id,
+              error_type: :missing,
+            )
+          end
 
           # Load domain and organization, verify ownership and entitlement
           authorize_domain_incoming!(@domain_id)

--- a/apps/api/domains/logic/incoming_config/put_incoming_config.rb
+++ b/apps/api/domains/logic/incoming_config/put_incoming_config.rb
@@ -40,10 +40,24 @@ module DomainsAPI
 
         def raise_concerns
           # Require authenticated user
-          raise_form_error('Authentication required', field: :user_id, error_type: :unauthorized) if cust.anonymous?
+          if cust.anonymous?
+            raise_form_error(
+              'Authentication required',
+              error_key: 'api.errors.authentication_required',
+              field: :user_id,
+              error_type: :unauthorized,
+            )
+          end
 
           # Validate domain_id parameter
-          raise_form_error('Domain ID required', field: :domain_id, error_type: :missing) if @domain_id.to_s.empty?
+          if @domain_id.to_s.empty?
+            raise_form_error(
+              'Domain ID required',
+              error_key: 'api.domains.errors.domain_id_required',
+              field: :domain_id,
+              error_type: :missing,
+            )
+          end
 
           # Load domain and organization, verify ownership and entitlement
           authorize_domain_incoming!(@domain_id)
@@ -51,20 +65,37 @@ module DomainsAPI
           # Validate recipients
           max = Onetime::CustomDomain::IncomingConfig::MAX_RECIPIENTS
           if @recipients.size > max
-            raise_form_error("Maximum #{max} recipients allowed", field: :recipients, error_type: :invalid)
+            raise_form_error(
+              "Maximum #{max} recipients allowed",
+              error_key: 'api.domains.errors.recipients_max_exceeded',
+              args: { max: max },
+              field: :recipients,
+              error_type: :invalid,
+            )
           end
 
           # Validate recipient emails with Truemail (write path — admin config)
           @recipients.each do |r|
             unless valid_email?(r[:email])
-              raise_form_error("Invalid email: #{r[:email]}", field: :recipients, error_type: :invalid)
+              raise_form_error(
+                "Invalid email: #{r[:email]}",
+                error_key: 'api.domains.errors.recipients_invalid_email',
+                args: { email: r[:email] },
+                field: :recipients,
+                error_type: :invalid,
+              )
             end
           end
 
           # Check for duplicate emails
           emails = @recipients.map { |r| r[:email] }
           if emails.uniq.size != emails.size
-            raise_form_error('Duplicate recipient emails not allowed', field: :recipients, error_type: :invalid)
+            raise_form_error(
+              'Duplicate recipient emails not allowed',
+              error_key: 'api.domains.errors.recipients_duplicate',
+              field: :recipients,
+              error_type: :invalid,
+            )
           end
         end
 

--- a/apps/api/domains/spec/logic/incoming_config/i18n_error_keys_spec.rb
+++ b/apps/api/domains/spec/logic/incoming_config/i18n_error_keys_spec.rb
@@ -1,0 +1,356 @@
+# apps/api/domains/spec/logic/incoming_config/i18n_error_keys_spec.rb
+#
+# frozen_string_literal: true
+
+# Verifies i18n error_key + args propagation across all migrated raise
+# sites in the IncomingConfig Logic classes.
+#
+# Mirrors the contract established by PRs #3207/#3208: logic classes raise
+# with `error_key` (and optional `args` for interpolation) so the HTTP-edge
+# ErrorResolver can render a localized message per request locale. Legacy
+# English messages are preserved as the I18n.t `default:` fallback.
+#
+# Each test follows the pattern from
+# apps/api/invite/spec/logic/invites/accept_invite_spec.rb:
+#   expect { logic.raise_concerns }
+#     .to raise_error(Onetime::FormError) do |error|
+#       expect(error.error_key).to eq('api.domains.errors.<reason>')
+#     end
+#
+# RUN:
+#   pnpm run test:rspec apps/api/domains/spec/logic/incoming_config/i18n_error_keys_spec.rb
+
+require 'spec_helper'
+require_relative '../../../../../../apps/api/domains/application'
+
+RSpec.describe 'IncomingConfig Logic error_key propagation' do
+  # ---------------------------------------------------------------------------
+  # Fixtures (mocked — no Redis required)
+  # ---------------------------------------------------------------------------
+
+  let(:domain_extid) { 'ext-domain-test' }
+  let(:domain_identifier) { 'domain-test-id' }
+  let(:org_extid) { 'ext-org-test' }
+  let(:org_id) { 'org-test-id' }
+  let(:user_extid) { 'ext-user-test' }
+
+  let(:authenticated_customer) do
+    instance_double(
+      Onetime::Customer,
+      custid: 'cust-test',
+      objid: 'cust-test',
+      extid: user_extid,
+      anonymous?: false,
+      verified?: true,
+    )
+  end
+
+  let(:anonymous_customer) do
+    instance_double(
+      Onetime::Customer,
+      custid: nil,
+      objid: nil,
+      extid: nil,
+      anonymous?: true,
+      verified?: false,
+    )
+  end
+
+  let(:custom_domain) do
+    instance_double(
+      Onetime::CustomDomain,
+      identifier: domain_identifier,
+      extid: domain_extid,
+      display_domain: 'incoming.example.com',
+      org_id: org_id,
+    )
+  end
+
+  let(:organization) do
+    instance_double(
+      Onetime::Organization,
+      objid: org_id,
+      extid: org_extid,
+      display_name: 'Test Org',
+    )
+  end
+
+  let(:session) { { 'authenticated' => true, 'csrf' => 'test-csrf' } }
+
+  let(:strategy_result) do
+    double(
+      'StrategyResult',
+      session: session,
+      user: authenticated_customer,
+      authenticated?: true,
+      metadata: {},
+    )
+  end
+
+  let(:anonymous_strategy_result) do
+    double(
+      'StrategyResult',
+      session: {},
+      user: anonymous_customer,
+      authenticated?: false,
+      metadata: {},
+    )
+  end
+
+  let(:incoming_enabled_conf) do
+    {
+      'features' => { 'incoming' => { 'enabled' => true } },
+      'site' => { 'secret' => 'test-secret' },
+    }
+  end
+
+  before do
+    allow(OT).to receive(:info)
+    allow(OT).to receive(:ld)
+    allow(OT).to receive(:le)
+    allow(OT).to receive(:lw)
+    allow(OT).to receive(:conf).and_return(incoming_enabled_conf)
+
+    # Default happy-path stubs; individual contexts override as needed.
+    allow(Onetime::CustomDomain).to receive(:find_by_extid)
+      .with(domain_extid).and_return(custom_domain)
+    allow(Onetime::Organization).to receive(:load)
+      .with(org_id).and_return(organization)
+    allow(organization).to receive(:owner?).with(authenticated_customer).and_return(true)
+    allow(organization).to receive(:can?).with('incoming_secrets').and_return(true)
+    allow(Onetime::CustomDomain::IncomingConfig).to receive(:find_by_domain_id)
+      .with(domain_identifier).and_return(nil)
+  end
+
+  # ===========================================================================
+  # Shared raises across all three Logic classes (base.rb + raise_concerns)
+  # ===========================================================================
+
+  shared_examples 'a logic class with shared authorization raises' do
+    context 'when the request is anonymous' do
+      let(:logic) { described_class.new(anonymous_strategy_result, params) }
+
+      it 'raises FormError tagged with authentication_required' do
+        expect { logic.raise_concerns }.to raise_error(Onetime::FormError) do |error|
+          expect(error.error_key).to eq('api.errors.authentication_required')
+          expect(error.field).to eq(:user_id)
+          expect(error.error_type).to eq(:unauthorized)
+        end
+      end
+
+      it 'preserves the legacy English message as the I18n fallback' do
+        expect { logic.raise_concerns }.to raise_error(Onetime::FormError) do |error|
+          expect(error.message).to eq('Authentication required')
+        end
+      end
+    end
+
+    context 'when the domain extid is missing' do
+      let(:params_without_extid) { params.merge('extid' => '') }
+      let(:logic) { described_class.new(strategy_result, params_without_extid) }
+
+      it 'raises FormError tagged with domain_id_required' do
+        expect { logic.raise_concerns }.to raise_error(Onetime::FormError) do |error|
+          expect(error.error_key).to eq('api.domains.errors.domain_id_required')
+          expect(error.field).to eq(:domain_id)
+        end
+      end
+    end
+
+    context 'when the incoming feature flag is disabled' do
+      let(:logic) { described_class.new(strategy_result, params) }
+
+      before do
+        allow(OT).to receive(:conf).and_return(
+          'features' => { 'incoming' => { 'enabled' => false } },
+          'site' => { 'secret' => 'test-secret' },
+        )
+      end
+
+      it 'raises FormError tagged with incoming_secrets_disabled' do
+        expect { logic.raise_concerns }.to raise_error(Onetime::FormError) do |error|
+          expect(error.error_key).to eq('api.domains.errors.incoming_secrets_disabled')
+          expect(error.error_type).to eq(:forbidden)
+        end
+      end
+    end
+
+    context 'when CustomDomain.find_by_extid returns nil' do
+      let(:logic) { described_class.new(strategy_result, params) }
+
+      before do
+        allow(Onetime::CustomDomain).to receive(:find_by_extid)
+          .with(domain_extid).and_return(nil)
+      end
+
+      it 'raises RecordNotFound tagged with domain_not_found and the extid in args' do
+        expect { logic.raise_concerns }.to raise_error(Onetime::RecordNotFound) do |error|
+          expect(error.error_key).to eq('api.domains.errors.domain_not_found')
+          expect(error.args).to eq(extid: domain_extid)
+        end
+      end
+    end
+
+    context 'when Organization.load returns nil' do
+      let(:logic) { described_class.new(strategy_result, params) }
+
+      before do
+        allow(Onetime::Organization).to receive(:load)
+          .with(org_id).and_return(nil)
+      end
+
+      it 'raises RecordNotFound tagged with organization_not_found and the domain in args' do
+        expect { logic.raise_concerns }.to raise_error(Onetime::RecordNotFound) do |error|
+          expect(error.error_key).to eq('api.domains.errors.organization_not_found')
+          expect(error.args).to eq(domain: 'incoming.example.com')
+        end
+      end
+    end
+
+    context 'when the organization lacks the incoming_secrets entitlement' do
+      let(:logic) { described_class.new(strategy_result, params) }
+
+      before do
+        allow(organization).to receive(:can?).with('incoming_secrets').and_return(false)
+      end
+
+      it 'raises FormError tagged with incoming_secrets_entitlement_required' do
+        expect { logic.raise_concerns }.to raise_error(Onetime::FormError) do |error|
+          expect(error.error_key).to eq('api.domains.errors.incoming_secrets_entitlement_required')
+          expect(error.error_type).to eq(:forbidden)
+        end
+      end
+    end
+  end
+
+  # ===========================================================================
+  # GetIncomingConfig
+  # ===========================================================================
+
+  describe DomainsAPI::Logic::IncomingConfig::GetIncomingConfig do
+    let(:params) { { 'extid' => domain_extid } }
+
+    include_examples 'a logic class with shared authorization raises'
+  end
+
+  # ===========================================================================
+  # DeleteIncomingConfig
+  # ===========================================================================
+
+  describe DomainsAPI::Logic::IncomingConfig::DeleteIncomingConfig do
+    let(:params) { { 'extid' => domain_extid } }
+
+    include_examples 'a logic class with shared authorization raises'
+
+    context 'when the IncomingConfig record does not exist for the domain' do
+      let(:logic) { described_class.new(strategy_result, params) }
+
+      it 'raises RecordNotFound tagged with incoming_config_not_found and the extid in args' do
+        expect { logic.raise_concerns }.to raise_error(Onetime::RecordNotFound) do |error|
+          expect(error.error_key).to eq('api.domains.errors.incoming_config_not_found')
+          expect(error.args).to eq(extid: domain_extid)
+        end
+      end
+    end
+  end
+
+  # ===========================================================================
+  # PutIncomingConfig — extends the shared raises with recipient validation
+  # ===========================================================================
+
+  describe DomainsAPI::Logic::IncomingConfig::PutIncomingConfig do
+    let(:params) do
+      { 'extid' => domain_extid, 'enabled' => true, 'recipients' => [] }
+    end
+
+    include_examples 'a logic class with shared authorization raises'
+
+    context 'when recipients exceed MAX_RECIPIENTS' do
+      let(:max) { Onetime::CustomDomain::IncomingConfig::MAX_RECIPIENTS }
+      let(:too_many) do
+        (max + 1).times.map { |i| { 'email' => "r#{i}@example.com", 'name' => "R#{i}" } }
+      end
+      let(:logic) do
+        described_class.new(
+          strategy_result,
+          params.merge('recipients' => too_many),
+        )
+      end
+
+      it 'raises FormError tagged with recipients_max_exceeded and the max in args' do
+        expect { logic.raise_concerns }.to raise_error(Onetime::FormError) do |error|
+          expect(error.error_key).to eq('api.domains.errors.recipients_max_exceeded')
+          expect(error.args).to eq(max: max)
+          expect(error.field).to eq(:recipients)
+        end
+      end
+    end
+
+    context 'when a recipient email fails validation' do
+      let(:logic) do
+        described_class.new(
+          strategy_result,
+          params.merge('recipients' => [{ 'email' => 'not-an-email', 'name' => 'X' }]),
+        )
+      end
+
+      before do
+        # parse_recipients downcases + strips, so the email reaches the
+        # validator as 'not-an-email'. Stub valid_email? to return false
+        # for it without touching Truemail's DNS layer.
+        allow_any_instance_of(described_class)
+          .to receive(:valid_email?).with('not-an-email').and_return(false)
+      end
+
+      it 'raises FormError tagged with recipients_invalid_email and the email in args' do
+        expect { logic.raise_concerns }.to raise_error(Onetime::FormError) do |error|
+          expect(error.error_key).to eq('api.domains.errors.recipients_invalid_email')
+          expect(error.args).to eq(email: 'not-an-email')
+          expect(error.field).to eq(:recipients)
+        end
+      end
+    end
+
+    context 'when the recipients list contains duplicate emails' do
+      let(:dup_email) { 'dup@example.com' }
+      let(:logic) do
+        described_class.new(
+          strategy_result,
+          params.merge('recipients' => [
+            { 'email' => dup_email, 'name' => 'First' },
+            { 'email' => dup_email, 'name' => 'Second' },
+          ]),
+        )
+      end
+
+      before do
+        allow_any_instance_of(described_class)
+          .to receive(:valid_email?).with(dup_email).and_return(true)
+      end
+
+      it 'raises FormError tagged with recipients_duplicate' do
+        expect { logic.raise_concerns }.to raise_error(Onetime::FormError) do |error|
+          expect(error.error_key).to eq('api.domains.errors.recipients_duplicate')
+          expect(error.field).to eq(:recipients)
+        end
+      end
+    end
+  end
+
+  # ===========================================================================
+  # to_h serialization includes error_key for HTTP responses
+  # ===========================================================================
+
+  describe 'error.to_h serialization' do
+    let(:params) { { 'extid' => '' } }
+    let(:logic) { DomainsAPI::Logic::IncomingConfig::GetIncomingConfig.new(strategy_result, params) }
+
+    it 'includes error_key in the serialized error body' do
+      expect { logic.raise_concerns }.to raise_error(Onetime::FormError) do |error|
+        expect(error.to_h).to include(
+          error_key: 'api.domains.errors.domain_id_required',
+        )
+      end
+    end
+  end
+end

--- a/locales/content/en/api-domains-errors.json
+++ b/locales/content/en/api-domains-errors.json
@@ -1,0 +1,47 @@
+{
+  "api.domains.errors.domain_id_required": {
+    "text": "Domain ID required",
+    "context": "Returned when a domains-API request is missing the extid path parameter",
+    "content_hash": "6837426b"
+  },
+  "api.domains.errors.domain_not_found": {
+    "text": "Domain not found: %{extid}",
+    "context": "Returned when CustomDomain.find_by_extid returns nil for the requested extid (apps/api/domains/logic/incoming_config/base.rb)",
+    "content_hash": "a0fd1025"
+  },
+  "api.domains.errors.organization_not_found": {
+    "text": "Organization not found for domain: %{domain}",
+    "context": "Returned when Organization.load returns nil for the domain's org_id (apps/api/domains/logic/incoming_config/base.rb)",
+    "content_hash": "632afc93"
+  },
+  "api.domains.errors.incoming_secrets_disabled": {
+    "text": "Incoming secrets is not enabled on this instance",
+    "context": "Returned when features.incoming.enabled is false at the instance level (apps/api/domains/logic/incoming_config/base.rb)",
+    "content_hash": "45c0b5c4"
+  },
+  "api.domains.errors.incoming_secrets_entitlement_required": {
+    "text": "Incoming secrets management requires the incoming_secrets entitlement. Please upgrade your plan.",
+    "context": "Returned when the owning organization lacks the incoming_secrets entitlement (apps/api/domains/logic/incoming_config/base.rb)",
+    "content_hash": "1af54ec2"
+  },
+  "api.domains.errors.incoming_config_not_found": {
+    "text": "Incoming configuration not found for domain: %{extid}",
+    "context": "Returned by DELETE /api/domains/:extid/incoming-config when no IncomingConfig record exists for the domain",
+    "content_hash": "491644a8"
+  },
+  "api.domains.errors.recipients_max_exceeded": {
+    "text": "Maximum %{max} recipients allowed",
+    "context": "Returned by PUT /api/domains/:extid/incoming-config when the request body contains more than IncomingConfig::MAX_RECIPIENTS entries",
+    "content_hash": "159842ad"
+  },
+  "api.domains.errors.recipients_invalid_email": {
+    "text": "Invalid email: %{email}",
+    "context": "Returned by PUT /api/domains/:extid/incoming-config when a recipient email fails Truemail validation",
+    "content_hash": "e9c729c7"
+  },
+  "api.domains.errors.recipients_duplicate": {
+    "text": "Duplicate recipient emails not allowed",
+    "context": "Returned by PUT /api/domains/:extid/incoming-config when the request body contains the same email address more than once",
+    "content_hash": "6de22182"
+  }
+}


### PR DESCRIPTION
Stacked on top of #3210.

## Summary

Brings the four `apps/api/domains/logic/incoming_config/*.rb` Logic classes in line with the i18n `error_key` + `args` pattern introduced by #3207 (ErrorResolver + raise helper signatures) and #3208 (hybrid call shape: legacy English message stays as the `I18n.t default:` fallback while `error_key` + `args` propagate to the HTTP edge for localization).

The `/incoming-config` endpoints are the now-canonical surface that #3210's frontend rewrite consumes — bringing them up to the same i18n contract as the rest of the codebase (invites, secrets, organizations, entitlements) closes the only material gap.

## What changed

**Logic classes** (`apps/api/domains/logic/incoming_config/`):
- `base.rb` — `load_custom_domain`, `load_organization_for_domain`, `verify_incoming_secrets_entitlement`, and the `authorize_domain_incoming!` feature-flag check now raise with `error_key` + `args` while preserving the existing English message as the I18n fallback.
- `put_incoming_config.rb` — auth, extid validation, and the three recipient validators (max count, invalid email, duplicates) now propagate `error_key` + `args`.
- `get_incoming_config.rb` — auth + extid validation.
- `delete_incoming_config.rb` — auth + extid validation + missing-record `RecordNotFound`.

**Locale file** (new):
- `locales/content/en/api-domains-errors.json` — 9 new keys covering the domain-specific errors. The shared `api.errors.authentication_required` (from `00-common.json`) is reused rather than duplicated under the domains namespace.

| New key | Interpolation args |
|---|---|
| `api.domains.errors.domain_id_required` | — |
| `api.domains.errors.domain_not_found` | `%{extid}` |
| `api.domains.errors.organization_not_found` | `%{domain}` |
| `api.domains.errors.incoming_secrets_disabled` | — |
| `api.domains.errors.incoming_secrets_entitlement_required` | — |
| `api.domains.errors.incoming_config_not_found` | `%{extid}` |
| `api.domains.errors.recipients_max_exceeded` | `%{max}` |
| `api.domains.errors.recipients_invalid_email` | `%{email}` |
| `api.domains.errors.recipients_duplicate` | — |

**Spec** (new):
- `apps/api/domains/spec/logic/incoming_config/i18n_error_keys_spec.rb` — focused unit spec that asserts `error_key`, `args`, and (where present) `field` for every migrated raise site, plus a `to_h` serialization check confirming `error_key` lands in the response body. Mirrors the contract pattern from `apps/api/invite/spec/logic/invites/accept_invite_spec.rb` and `apps/api/v2/spec/logic/secrets/base_secret_action_spec.rb`.

Shared examples cover the six raises common to all three Logic classes (auth, extid validation, feature flag, domain not found, org not found, entitlement); per-class contexts cover class-specific raises (PUT's three recipient validators, DELETE's missing-record).

## Why hybrid (legacy message + error_key) rather than pure i18n

Both #3207 (invites) and #3208 (secrets) shipped, with #3208 settling on the hybrid pattern. Reasons to favor it here:
- Unit-style specs that don't boot I18n still see usable English messages (the `ErrorResolver.resolve!` mutation only fires at the HTTP edge).
- Existing log lines, exception inspection, and any callers that read `.message` directly continue to work unchanged.
- The legacy message becomes the `I18n.t default:` fallback — so if a locale key is missing or the resolver fails, the client still gets a sensible English string instead of the raw key.

## Stacking note

Base is `claude/wizardly-gauss-K5SEq` (the #3210 branch), not `main`. Once #3210 merges, GitHub will automatically retarget this PR to `main`. The diff against `main` will then be exactly the 6 files in this commit.

## Test plan

- [ ] CI: T2 Ruby Unit Tests should pick up the new spec at `apps/api/domains/spec/logic/incoming_config/i18n_error_keys_spec.rb`.
- [ ] CI: T1 i18n Validation should accept the new `api-domains-errors.json` (content_hashes were computed via `python3 locales/scripts/add_hashes.py`).
- [ ] Manual: Hit `PUT /api/domains/:extid/incoming-config` with `enabled: true, recipients: [{ email: 'invalid' }]` and confirm the error response body includes `"error_key": "api.domains.errors.recipients_invalid_email"`.
- [ ] Manual: Hit `GET /api/domains/:extid/incoming-config` with an unknown extid and confirm `"error_key": "api.domains.errors.domain_not_found"` with `"message": "Domain not found: <extid>"` (fallback rendering).

https://claude.ai/code/session_01VSmmbp36PVPFg2eL5Yy4uG

---
_Generated by [Claude Code](https://claude.ai/code/session_01VSmmbp36PVPFg2eL5Yy4uG)_