### PR TITLE
Add network validation strategy tests for mx/smtp email verification

### DIFF
--- a/try/unit/models/custom_domain_signup_config_try.rb
+++ b/try/unit/models/custom_domain_signup_config_try.rb
@@ -29,6 +29,13 @@ OT.info "Cleaned Redis for SignupConfig test run"
 @org = Onetime::Organization.create!("SC Test Org #{@ts}", @owner, "sc_#{@ts}@test.com")
 @domain = Onetime::CustomDomain.create!("sc-test-#{@ts}.example.com", @org.objid)
 
+# Setup for the Network Validation section further down. Tryouts only executes
+# bare code BEFORE the first `##` block, so capture-and-restore state must be
+# established here (not mid-file between tests, which is silently ignored).
+@original_truemail_validate = Truemail.method(:validate)
+TRUEMAIL_VALID_MOCK   = Struct.new(:result).new(Struct.new(:success).new(true))
+TRUEMAIL_INVALID_MOCK = Struct.new(:result).new(Struct.new(:success).new(false))
+
 # --- Constants ---
 
 ## SignupConfig defines STRATEGY_TYPES constant
@@ -280,11 +287,10 @@ end
 #   - Rescue path:  Truemail raises   -> falls back to format-only validation
 #   - build_truemail_config: copies global settings, sets requested type
 #   - Truemail is invoked with custom_configuration: kwarg (not with:)
-
-# Save the original Truemail.validate so we can restore it after these tests.
-# build_truemail_config reads Truemail.configuration (not stubbed) so the
-# real global config remains in effect.
-@original_truemail_validate = Truemail.method(:validate)
+#
+# Note: @original_truemail_validate, TRUEMAIL_VALID_MOCK, and TRUEMAIL_INVALID_MOCK
+# are defined in the file's top-level setup (before the first `##` block).
+# Tryouts only runs bare code before the first test marker.
 
 ## Setup: create a CustomDomain and SignupConfig for mx strategy
 @ts_mx     = Familia.now.to_i
@@ -342,14 +348,14 @@ end
 
 ## mx strategy returns true when Truemail validates successfully
 Truemail.define_singleton_method(:validate) do |_email, **_kwargs|
-  Struct.new(:result).new(Struct.new(:success).new(true))
+  TRUEMAIL_VALID_MOCK
 end
 @mx_config.valid_signup_email?('user@example.com')
 #=> true
 
 ## mx strategy returns false when Truemail rejects the email
 Truemail.define_singleton_method(:validate) do |_email, **_kwargs|
-  Struct.new(:result).new(Struct.new(:success).new(false))
+  TRUEMAIL_INVALID_MOCK
 end
 @mx_config.valid_signup_email?('user@example.com')
 #=> false
@@ -379,14 +385,14 @@ end
 
 ## smtp strategy returns true when Truemail validates successfully
 Truemail.define_singleton_method(:validate) do |_email, **_kwargs|
-  Struct.new(:result).new(Struct.new(:success).new(true))
+  TRUEMAIL_VALID_MOCK
 end
 @smtp_config.valid_signup_email?('user@example.com')
 #=> true
 
 ## smtp strategy returns false when Truemail rejects the email
 Truemail.define_singleton_method(:validate) do |_email, **_kwargs|
-  Struct.new(:result).new(Struct.new(:success).new(false))
+  TRUEMAIL_INVALID_MOCK
 end
 @smtp_config.valid_signup_email?('user@example.com')
 #=> false
@@ -414,7 +420,7 @@ end
 captured = {}
 Truemail.define_singleton_method(:validate) do |_email, **kwargs|
   captured[:kwargs] = kwargs
-  Struct.new(:result).new(Struct.new(:success).new(true))
+  TRUEMAIL_VALID_MOCK
 end
 @mx_config.valid_signup_email?('user@example.com')
 captured[:kwargs].key?(:custom_configuration)
@@ -424,7 +430,7 @@ captured[:kwargs].key?(:custom_configuration)
 captured = {}
 Truemail.define_singleton_method(:validate) do |_email, **kwargs|
   captured[:kwargs] = kwargs
-  Struct.new(:result).new(Struct.new(:success).new(true))
+  TRUEMAIL_VALID_MOCK
 end
 @mx_config.valid_signup_email?('user@example.com')
 captured[:kwargs][:custom_configuration].default_validation_type
@@ -434,7 +440,7 @@ captured[:kwargs][:custom_configuration].default_validation_type
 captured = {}
 Truemail.define_singleton_method(:validate) do |_email, **kwargs|
   captured[:kwargs] = kwargs
-  Struct.new(:result).new(Struct.new(:success).new(true))
+  TRUEMAIL_VALID_MOCK
 end
 @smtp_config.valid_signup_email?('user@example.com')
 captured[:kwargs][:custom_configuration].default_validation_type
@@ -444,7 +450,7 @@ captured[:kwargs][:custom_configuration].default_validation_type
 captured = {}
 Truemail.define_singleton_method(:validate) do |email, **_kwargs|
   captured[:email] = email
-  Struct.new(:result).new(Struct.new(:success).new(true))
+  TRUEMAIL_VALID_MOCK
 end
 @mx_config.valid_signup_email?('user@example.com')
 captured[:email]

--- a/try/unit/models/custom_domain_signup_config_try.rb
+++ b/try/unit/models/custom_domain_signup_config_try.rb
@@ -33,8 +33,13 @@ OT.info "Cleaned Redis for SignupConfig test run"
 # bare code BEFORE the first `##` block, so capture-and-restore state must be
 # established here (not mid-file between tests, which is silently ignored).
 @original_truemail_validate = Truemail.method(:validate)
-TRUEMAIL_VALID_MOCK   = Struct.new(:result).new(Struct.new(:success).new(true))
-TRUEMAIL_INVALID_MOCK = Struct.new(:result).new(Struct.new(:success).new(false))
+
+# Immutable mock shells matching the Truemail.validate -> .result.success
+# call chain. Built once and reused so each test avoids re-allocating Structs.
+TruemailMockResult    = Data.define(:success)
+TruemailMockValidator = Data.define(:result)
+TRUEMAIL_VALID_MOCK   = TruemailMockValidator.new(result: TruemailMockResult.new(success: true))
+TRUEMAIL_INVALID_MOCK = TruemailMockValidator.new(result: TruemailMockResult.new(success: false))
 
 # --- Constants ---
 

--- a/try/unit/models/custom_domain_signup_config_try.rb
+++ b/try/unit/models/custom_domain_signup_config_try.rb
@@ -270,6 +270,191 @@ end
 @corrupt_config.valid_signup_email?('anyone@anywhere.com')
 #=> true
 
+# --- Network Validation Strategy Tests (mx / smtp) ---
+#
+# These tests use Truemail stubbing to exercise the :mx and :smtp validation
+# strategies without making real DNS / SMTP network calls. Coverage:
+#   - Success path: Truemail validates -> valid_signup_email? returns true
+#   - Failure path: Truemail rejects  -> valid_signup_email? returns false
+#   - Early return: format check rejects malformed input before Truemail runs
+#   - Rescue path:  Truemail raises   -> falls back to format-only validation
+#   - build_truemail_config: copies global settings, sets requested type
+#   - Truemail is invoked with custom_configuration: kwarg (not with:)
+
+# Save the original Truemail.validate so we can restore it after these tests.
+# build_truemail_config reads Truemail.configuration (not stubbed) so the
+# real global config remains in effect.
+@original_truemail_validate = Truemail.method(:validate)
+
+## Setup: create a CustomDomain and SignupConfig for mx strategy
+@ts_mx     = Familia.now.to_i
+@domain_mx = Onetime::CustomDomain.create!("sc-mx-#{@ts_mx}-#{SecureRandom.hex(2)}.example.com", @org.objid)
+@mx_config = Onetime::CustomDomain::SignupConfig.create!(
+  domain_id: @domain_mx.identifier,
+  validation_strategy: 'mx',
+  enabled: true,
+)
+@mx_config.validation_strategy
+#=> 'mx'
+
+## Setup: create a CustomDomain and SignupConfig for smtp strategy
+@ts_smtp     = Familia.now.to_i
+@domain_smtp = Onetime::CustomDomain.create!("sc-smtp-#{@ts_smtp}-#{SecureRandom.hex(2)}.example.com", @org.objid)
+@smtp_config = Onetime::CustomDomain::SignupConfig.create!(
+  domain_id: @domain_smtp.identifier,
+  validation_strategy: 'smtp',
+  enabled: true,
+)
+@smtp_config.validation_strategy
+#=> 'smtp'
+
+# --- build_truemail_config (private helper) ---
+
+## build_truemail_config returns a Truemail::Configuration instance
+@mx_config.send(:build_truemail_config, validation_type: :mx).is_a?(Truemail::Configuration)
+#=> true
+
+## build_truemail_config sets default_validation_type to :mx
+@mx_config.send(:build_truemail_config, validation_type: :mx).default_validation_type
+#=> :mx
+
+## build_truemail_config sets default_validation_type to :smtp
+@mx_config.send(:build_truemail_config, validation_type: :smtp).default_validation_type
+#=> :smtp
+
+## build_truemail_config copies verifier_email from the global Truemail config
+@mx_config.send(:build_truemail_config, validation_type: :mx).verifier_email == Truemail.configuration.verifier_email
+#=> true
+
+## build_truemail_config copies verifier_domain from the global Truemail config
+@mx_config.send(:build_truemail_config, validation_type: :mx).verifier_domain == Truemail.configuration.verifier_domain
+#=> true
+
+## build_truemail_config copies connection_timeout from the global Truemail config
+@mx_config.send(:build_truemail_config, validation_type: :mx).connection_timeout == Truemail.configuration.connection_timeout
+#=> true
+
+## build_truemail_config copies response_timeout from the global Truemail config
+@mx_config.send(:build_truemail_config, validation_type: :mx).response_timeout == Truemail.configuration.response_timeout
+#=> true
+
+# --- mx strategy: success / failure / fallback paths ---
+
+## mx strategy returns true when Truemail validates successfully
+Truemail.define_singleton_method(:validate) do |_email, **_kwargs|
+  Struct.new(:result).new(Struct.new(:success).new(true))
+end
+@mx_config.valid_signup_email?('user@example.com')
+#=> true
+
+## mx strategy returns false when Truemail rejects the email
+Truemail.define_singleton_method(:validate) do |_email, **_kwargs|
+  Struct.new(:result).new(Struct.new(:success).new(false))
+end
+@mx_config.valid_signup_email?('user@example.com')
+#=> false
+
+## mx strategy rejects malformed email before invoking Truemail
+Truemail.define_singleton_method(:validate) do |_email, **_kwargs|
+  raise 'Truemail.validate should not be called for malformed input'
+end
+@mx_config.valid_signup_email?('not-an-email')
+#=> false
+
+## mx strategy falls back to format-only validation when Truemail raises (valid format passes)
+Truemail.define_singleton_method(:validate) do |_email, **_kwargs|
+  raise StandardError, 'DNS timeout'
+end
+@mx_config.valid_signup_email?('user@example.com')
+#=> true
+
+## mx strategy rejects malformed email when Truemail raises (format check runs before Truemail)
+Truemail.define_singleton_method(:validate) do |_email, **_kwargs|
+  raise StandardError, 'DNS timeout'
+end
+@mx_config.valid_signup_email?('not-an-email')
+#=> false
+
+# --- smtp strategy: success / failure / fallback paths ---
+
+## smtp strategy returns true when Truemail validates successfully
+Truemail.define_singleton_method(:validate) do |_email, **_kwargs|
+  Struct.new(:result).new(Struct.new(:success).new(true))
+end
+@smtp_config.valid_signup_email?('user@example.com')
+#=> true
+
+## smtp strategy returns false when Truemail rejects the email
+Truemail.define_singleton_method(:validate) do |_email, **_kwargs|
+  Struct.new(:result).new(Struct.new(:success).new(false))
+end
+@smtp_config.valid_signup_email?('user@example.com')
+#=> false
+
+## smtp strategy rejects malformed email before invoking Truemail
+Truemail.define_singleton_method(:validate) do |_email, **_kwargs|
+  raise 'Truemail.validate should not be called for malformed input'
+end
+@smtp_config.valid_signup_email?('not-an-email')
+#=> false
+
+## smtp strategy falls back to format-only validation when Truemail raises (valid format passes)
+Truemail.define_singleton_method(:validate) do |_email, **_kwargs|
+  raise StandardError, 'SMTP connection refused'
+end
+@smtp_config.valid_signup_email?('user@example.com')
+#=> true
+
+# --- Verify Truemail.validate is invoked with custom_configuration kwarg ---
+#
+# The implementation must use custom_configuration: (per-call override) rather
+# than with: (which would require mutating the global Truemail config).
+
+## mx strategy invokes Truemail.validate with custom_configuration kwarg
+captured = {}
+Truemail.define_singleton_method(:validate) do |_email, **kwargs|
+  captured[:kwargs] = kwargs
+  Struct.new(:result).new(Struct.new(:success).new(true))
+end
+@mx_config.valid_signup_email?('user@example.com')
+captured[:kwargs].key?(:custom_configuration)
+#=> true
+
+## mx strategy's custom_configuration has default_validation_type=:mx
+captured = {}
+Truemail.define_singleton_method(:validate) do |_email, **kwargs|
+  captured[:kwargs] = kwargs
+  Struct.new(:result).new(Struct.new(:success).new(true))
+end
+@mx_config.valid_signup_email?('user@example.com')
+captured[:kwargs][:custom_configuration].default_validation_type
+#=> :mx
+
+## smtp strategy's custom_configuration has default_validation_type=:smtp
+captured = {}
+Truemail.define_singleton_method(:validate) do |_email, **kwargs|
+  captured[:kwargs] = kwargs
+  Struct.new(:result).new(Struct.new(:success).new(true))
+end
+@smtp_config.valid_signup_email?('user@example.com')
+captured[:kwargs][:custom_configuration].default_validation_type
+#=> :smtp
+
+## Truemail.validate receives the email argument unchanged
+captured = {}
+Truemail.define_singleton_method(:validate) do |email, **_kwargs|
+  captured[:email] = email
+  Struct.new(:result).new(Struct.new(:success).new(true))
+end
+@mx_config.valid_signup_email?('user@example.com')
+captured[:email]
+#=> 'user@example.com'
+
+## Restore the original Truemail.validate so subsequent code uses the real method
+Truemail.define_singleton_method(:validate, @original_truemail_validate)
+true
+#=> true
+
 # --- Cleanup ---
 
 Familia.dbclient.flushdb


### PR DESCRIPTION
## Summary

Add comprehensive unit tests for the `mx` and `smtp` validation strategies in `CustomDomain::SignupConfig#valid_signup_email?`. These tests exercise the Truemail integration without making real DNS or SMTP network calls by stubbing the `Truemail.validate` method.

## Test Coverage

The new tests verify:

- **Success/failure paths**: Truemail validation results correctly propagate to the return value
- **Early format validation**: Malformed emails are rejected before Truemail is invoked
- **Error handling**: When Truemail raises exceptions, the implementation falls back to format-only validation
- **Configuration building**: The `build_truemail_config` private helper correctly copies global Truemail settings and sets the requested validation type
- **Truemail invocation**: The implementation uses the `custom_configuration:` kwarg (not `with:`) to pass per-call configuration overrides
- **Both strategies**: Identical test patterns for both `:mx` and `:smtp` validation strategies

## Test Plan

Added 21 new unit tests that use Truemail method stubbing to verify the network validation strategies work correctly. All tests are isolated and do not make real network calls. The original `Truemail.validate` method is restored after the test suite completes.

https://claude.ai/code/session_01ETwkzkJasvcSEq4zvVSnJu