### PR TITLE
refactor: convert config contracts to type-only schemas per entity-contract convention

### DIFF
--- a/src/schemas/contracts/config/auth.ts
+++ b/src/schemas/contracts/config/auth.ts
@@ -5,9 +5,11 @@
  *
  * Zod v4 schema for etc/defaults/auth.defaults.yaml
  *
+ * Per contracts convention, this schema describes field names and types only.
+ * Defaults and value constraints belong in shapes — not here.
+ *
  * Purpose:
- * - Type-safe validation of authentication configuration
- * - Runtime validation for YAML parsing
+ * - Type-safe field definitions for authentication configuration
  * - TypeScript type inference for auth config usage
  */
 
@@ -27,8 +29,8 @@ const authModeSchema = z.enum(['simple', 'full']);
  * Simple mode settings (Redis-only authentication)
  */
 const simpleModeSchema = z.object({
-  password_hash_cost: z.number().int().positive().optional(),
-  session_timeout: z.number().int().positive().optional(),
+  password_hash_cost: z.number().optional(),
+  session_timeout: z.number().optional(),
 });
 
 /**
@@ -43,7 +45,7 @@ const fullModeSchema = z.object({
    *   - 'sqlite://data/auth.db' - Relative path
    *   - 'sqlite:///data/auth.db' - Absolute path
    */
-  database_url: z.string().default('sqlite://data/auth.db'),
+  database_url: z.string().optional(),
 
   /**
    * Migrations connection (PostgreSQL, MySQL, MS SQL Server only)
@@ -65,7 +67,7 @@ const fullModeSchema = z.object({
  * NOTE: session has been moved to site config (site.session)
  */
 const authConfigSchema = z.object({
-  mode: authModeSchema.default('simple'),
+  mode: authModeSchema.optional(),
   simple: simpleModeSchema.optional(),
   full: fullModeSchema.optional(),
 });

--- a/src/schemas/contracts/config/billing.ts
+++ b/src/schemas/contracts/config/billing.ts
@@ -26,6 +26,21 @@
  *   through exactly as the hand-written schema did.
  * - Required vs optional fields mirror the hand-written `required` arrays.
  *
+ * ## Tradeoff: type-only contracts and what that means for the CLI
+ *
+ * Stripping the value constraints (`.min(1)` on strings, `.min(-1)` on plan
+ * limit integers, `.min(0)` on price amounts and display_order, `.int()`
+ * everywhere, the `match_fields.default(['plan_id'])`) weakens the CLI
+ * validation performed by `bin/ots billing catalog validate`. The CLI now
+ * checks structure and types, but no longer rejects an empty description,
+ * a negative price amount, or a missing `match_fields` array. These bounds
+ * will move to a `src/schemas/shapes/config/` layer — a separate design
+ * decision, not part of this sweep — and re-tighten the CLI when that layer
+ * lands. Field-format regex patterns (`stripe_product_id`,
+ * `grandfathered_until`, `CANONICAL_PLAN_ID_PATTERN`, `schema_version`) are
+ * preserved because they describe the kind of string that is valid (a type
+ * format, not a value bound).
+ *
  * Purpose:
  * - Type-safe field definitions for billing catalog configuration
  * - TypeScript type inference for billing config usage

--- a/src/schemas/contracts/config/billing.ts
+++ b/src/schemas/contracts/config/billing.ts
@@ -10,9 +10,12 @@
  * generated/schemas/config/billing.schema.json, which the
  * `bin/ots billing catalog validate` CLI uses to validate the catalog.
  *
- * It is a faithful port of the previously hand-written JSON Schema
- * (draft-07) for the billing catalog. To preserve that document's
- * validation coverage:
+ * Per contracts convention, this schema describes field names and types only.
+ * Defaults and value constraints (`.min`, `.max`, length bounds, `match_fields`
+ * default) belong in shapes — not here. Loose objects and field-format regexes
+ * are retained: `z.looseObject` is a structural type modifier (it says "extra
+ * keys are allowed"), and regex patterns describe what kind of string is
+ * valid (a format, not a value bound).
  *
  * - Every object is modelled with `z.looseObject` because the
  *   hand-written schema never set `additionalProperties: false`. The CLI
@@ -24,8 +27,7 @@
  * - Required vs optional fields mirror the hand-written `required` arrays.
  *
  * Purpose:
- * - Type-safe validation of billing catalog configuration
- * - Runtime validation for YAML parsing
+ * - Type-safe field definitions for billing catalog configuration
  * - TypeScript type inference for billing config usage
  * - Entitlement definitions (system-wide features)
  * - Plan catalog definitions (active and legacy plans)
@@ -100,7 +102,7 @@ export type EntitlementCategory = z.infer<typeof EntitlementCategorySchema>;
  */
 export const EntitlementDefinitionSchema = z.looseObject({
   category: EntitlementCategorySchema,
-  description: z.string().min(1).describe('Human-readable description of the entitlement'),
+  description: z.string().describe('Human-readable description of the entitlement'),
 });
 
 export type EntitlementDefinition = z.infer<typeof EntitlementDefinitionSchema>;
@@ -149,12 +151,12 @@ export type CurrencyCode = z.infer<typeof CurrencyCodeSchema>;
 /**
  * Limit Value
  *
- * Resource limits: an integer >= -1 (-1 = unlimited, 0+ = specific
- * limit) or null (to be determined). Mirrors the hand-written
- * `LimitValue` `oneOf: [{ integer, minimum: -1 }, { null }]`.
+ * Resource limits: a number (-1 = unlimited, 0+ = specific limit) or null
+ * (to be determined). Numeric bound (`>= -1`) and integer constraint belong
+ * in a shape — not here.
  */
 export const LimitValueSchema = z.union([
-  z.number().int().min(-1).describe('-1 = unlimited, 0+ = specific limit'),
+  z.number().describe('-1 = unlimited, 0+ = specific limit'),
   z.null().describe('To be determined'),
 ]);
 
@@ -180,7 +182,7 @@ export type PlanLimits = z.infer<typeof PlanLimitsSchema>;
  */
 export const PlanPriceSchema = z.looseObject({
   interval: BillingIntervalSchema,
-  amount: z.number().int().min(0).describe('Amount in cents (e.g., 2900 = $29.00)'),
+  amount: z.number().describe('Amount in cents (e.g., 2900 = $29.00)'),
   currency: CurrencyCodeSchema.optional().describe(
     'Per-price currency override. Inherits from top-level currency when omitted.'
   ),
@@ -198,7 +200,7 @@ export type PlanPrice = z.infer<typeof PlanPriceSchema>;
  * - All other tiers require Stripe product creation
  */
 export const PlanDefinitionSchema = z.looseObject({
-  name: z.string().min(1).describe('Display name for the plan'),
+  name: z.string().describe('Display name for the plan'),
   tier: BillingTierSchema.optional().describe('Billing tier (optional for draft plans)'),
   tenancy: TenancyTypeSchema.optional().describe('Tenancy type (optional for draft plans)'),
   // Region resolves from an ERB-templated env var in real configs and may
@@ -215,7 +217,7 @@ export const PlanDefinitionSchema = z.looseObject({
     .describe('Direct Stripe product ID binding (escape hatch for matching issues)'),
   plan_name_label: z.string().optional().describe('i18n key for plan category label'),
   display_order: z
-    .union([z.number().int().min(0), z.null()])
+    .union([z.number(), z.null()])
     .optional()
     .describe('Sort order on plans page (higher = earlier)'),
   show_on_plans_page: z.boolean().optional().describe('Visibility on public plans page'),
@@ -223,7 +225,7 @@ export const PlanDefinitionSchema = z.looseObject({
     .string()
     .optional()
     .describe('Plan ID this plan includes (for "Includes everything in X" display)'),
-  description: z.string().min(1).optional().describe('Plan description for documentation'),
+  description: z.string().optional().describe('Plan description for documentation'),
   legacy: z.boolean().optional().describe('Marks plan as legacy/grandfathered (no longer offered)'),
   grandfathered_until: z
     .string()
@@ -231,11 +233,8 @@ export const PlanDefinitionSchema = z.looseObject({
     .optional()
     .describe('ISO date until which plan is grandfathered (YYYY-MM-DD)'),
 
-  entitlements: z.array(z.string().min(1)).describe('Array of entitlement IDs'),
-  features: z
-    .array(z.string().min(1))
-    .optional()
-    .describe('Array of i18n feature keys for UI display'),
+  entitlements: z.array(z.string()).describe('Array of entitlement IDs'),
+  features: z.array(z.string()).optional().describe('Array of i18n feature keys for UI display'),
   limits: PlanLimitsSchema,
   prices: z.array(PlanPriceSchema).describe('Available pricing options'),
 });
@@ -283,15 +282,11 @@ export const BillingConfigSchema = z.looseObject({
     .string()
     .regex(/^\d+\.\d+$/)
     .describe('Schema version identifier'),
-  app_identifier: z
-    .string()
-    .min(1)
-    .describe('Application identifier for Stripe metadata matching'),
+  app_identifier: z.string().describe('Application identifier for Stripe metadata matching'),
 
   match_fields: z
-    .array(z.string().min(1))
-    .min(1)
-    .default(['plan_id'])
+    .array(z.string())
+    .optional()
     .describe('Fields used to build composite match key for Stripe product identification'),
   // Region resolves from an ERB-templated env var and may be empty (null).
   region: z

--- a/src/schemas/contracts/config/config.ts
+++ b/src/schemas/contracts/config/config.ts
@@ -354,9 +354,12 @@ const mutableMailSchema = z.object({
 
 /**
  * Simple logging schema for static config
+ *
+ * Per contracts convention: field name + type only. Runtime default is the
+ * supplier's responsibility (Ruby / store).
  */
 const simpleLoggingSchema = z.object({
-  http_requests: z.boolean().default(true),
+  http_requests: z.boolean().optional(),
 });
 
 /**

--- a/src/schemas/contracts/config/config.ts
+++ b/src/schemas/contracts/config/config.ts
@@ -12,6 +12,22 @@
  *
  * The API response schemas use booleanOrString/numberOrString for flexibility
  * when parsing backend responses that may have coerced values.
+ *
+ * ## Tradeoff: type-only contracts and what that means for the CLI
+ *
+ * Per the entity-contract convention (#3212), the composed section schemas are
+ * type-only — they describe field names and output types, no defaults, no
+ * numeric/length bounds. The JSON Schema produced from `staticConfigSchema`
+ * and consumed by `bin/ots config validate` therefore validates *structure
+ * and types* only. Value bounds that used to live in section schemas
+ * (e.g. port ranges, passphrase length bounds, Redis db number bounds) and
+ * defaults that used to live in section schemas (e.g. `host`, SMTP defaults,
+ * session expiry) no longer participate in CLI validation.
+ *
+ * Defaults are now the runtime layer's responsibility (Ruby application config
+ * loader / frontend store). Value bounds will move to a `src/schemas/shapes/
+ * config/` layer — a separate design decision, not part of this sweep. Until
+ * that layer lands, the CLI is intentionally less strict.
  */
 
 import { z } from 'zod';

--- a/src/schemas/contracts/config/index.ts
+++ b/src/schemas/contracts/config/index.ts
@@ -6,8 +6,7 @@
  * Zod v4 schemas for application configuration files (YAML/JSON)
  *
  * Purpose:
- * - Type-safe validation of configuration files
- * - Runtime validation for config parsing
+ * - Type-safe field definitions for configuration files
  * - TypeScript type inference for configuration usage
  * - Integration between backend YAML configs and frontend
  *
@@ -18,6 +17,30 @@
  * - auth.ts: Authentication configuration (auth.defaults.yaml)
  * - logging.ts: Logging configuration (logging.defaults.yaml)
  * - billing.ts: Unified billing configuration (billing.yaml)
+ *
+ * ## Tradeoff: contracts are type-only (#3212)
+ *
+ * Following the entity-contract convention, every config contract in this
+ * directory describes field names and output types only — no defaults, no
+ * numeric/length bounds. Structural modifiers (`.optional`, `.nullable`,
+ * `.nullish`) and type-format helpers (`.regex`, `.email`, `.enum`,
+ * `.literal`, `.union`, `z.looseObject`) are retained because they describe
+ * the type itself.
+ *
+ * Consequences:
+ * - **Defaults**: now the runtime layer's responsibility (Ruby application
+ *   config loader / frontend store). The contracts no longer fill in missing
+ *   fields when parsing partial input.
+ * - **CLI validators**: `bin/ots config validate` and
+ *   `bin/ots billing catalog validate` continue to validate structure and
+ *   types, but no longer enforce removed value bounds (e.g. port ranges,
+ *   passphrase length bounds, plan limit `>= -1`, Redis db number range,
+ *   empty-string rejection). The CLIs are intentionally less strict during
+ *   this interim.
+ * - **Shapes layer**: removed defaults/bounds that have a consumer (e.g.
+ *   frontend code that expected a numeric default) will move to
+ *   `src/schemas/shapes/config/` when that layer is introduced — a separate
+ *   design decision.
  */
 
 // ============================================================================

--- a/src/schemas/contracts/config/logging.ts
+++ b/src/schemas/contracts/config/logging.ts
@@ -5,9 +5,12 @@
  *
  * Zod v4 schema for etc/defaults/logging.defaults.yaml
  *
+ * Per contracts convention, this schema describes field names and types only.
+ * Defaults and value constraints (per-logger defaults, slow_request_ms bound,
+ * default ignore_paths list) belong in shapes — not here.
+ *
  * Purpose:
- * - Type-safe validation of logging configuration
- * - Runtime validation for YAML parsing
+ * - Type-safe field definitions for logging configuration
  * - TypeScript type inference for logging config usage
  *
  * Strategic categories for debugging and operational instrumentation:
@@ -44,39 +47,31 @@ const httpCaptureSchema = z.enum(['minimal', 'standard', 'debug']);
  * Named logger levels
  * Each category can be configured independently
  */
-const loggersSchema = z.object({
-  App: logLevelSchema.default('info'),
-  Auth: logLevelSchema.default('info'),
-  Billing: logLevelSchema.default('info'),
-  Boot: logLevelSchema.default('info'),
-  Familia: logLevelSchema.default('warn'),
-  HTTP: logLevelSchema.default('warn'),
-  Otto: logLevelSchema.default('warn'),
-  Rhales: logLevelSchema.default('error'),
-  Secret: logLevelSchema.default('info'),
-  Sequel: logLevelSchema.default('warn'),
-  Session: logLevelSchema.default('info'),
-}).catchall(logLevelSchema);
+const loggersSchema = z
+  .object({
+    App: logLevelSchema.optional(),
+    Auth: logLevelSchema.optional(),
+    Billing: logLevelSchema.optional(),
+    Boot: logLevelSchema.optional(),
+    Familia: logLevelSchema.optional(),
+    HTTP: logLevelSchema.optional(),
+    Otto: logLevelSchema.optional(),
+    Rhales: logLevelSchema.optional(),
+    Secret: logLevelSchema.optional(),
+    Sequel: logLevelSchema.optional(),
+    Session: logLevelSchema.optional(),
+  })
+  .catchall(logLevelSchema);
 
 /**
  * HTTP request logging configuration
  */
 const httpLoggingSchema = z.object({
-  enabled: z.boolean().default(true),
+  enabled: z.boolean().optional(),
   level: nullableString,
-  capture: httpCaptureSchema.default('standard'),
-  slow_request_ms: z.number().int().positive().default(1000),
-  ignore_paths: z.array(z.string()).default([
-    '/api/v1/status',
-    '/api/v2/status',
-    '/api/v3/status',
-    '/health',
-    '/healthcheck',
-    '/favicon.ico',
-    '/_vite/*',
-    '/assets/*',
-    '/dist/*',
-  ]),
+  capture: httpCaptureSchema.optional(),
+  slow_request_ms: z.number().optional(),
+  ignore_paths: z.array(z.string()).optional(),
 });
 
 /**
@@ -85,8 +80,8 @@ const httpLoggingSchema = z.object({
  * Matches the structure from etc/defaults/logging.defaults.yaml
  */
 const loggingConfigSchema = z.object({
-  default_level: logLevelSchema.default('info'),
-  formatter: formatterSchema.default('color'),
+  default_level: logLevelSchema.optional(),
+  formatter: formatterSchema.optional(),
   loggers: loggersSchema.optional(),
   http: httpLoggingSchema.optional(),
 });

--- a/src/schemas/contracts/config/public.ts
+++ b/src/schemas/contracts/config/public.ts
@@ -3,11 +3,15 @@
 /**
  * Public API Configuration Response Schemas
  *
- * These schemas validate public settings API responses where values are
- * native types (boolean, number) from Ruby/YAML serialized to JSON.
+ * These schemas describe the shape of public settings API responses where
+ * values are native types (boolean, number) from Ruby/YAML serialized to JSON.
+ *
+ * Per contracts convention, this schema describes field names and types only.
+ * Defaults and value constraints (TTL bounds, passphrase length bounds,
+ * password generation length bounds) belong in shapes — not here.
  *
  * NOTE: These are distinct from the YAML config section schemas which
- * validate backend configuration file structure.
+ * describe backend configuration file structure.
  */
 
 import { z } from 'zod';
@@ -15,80 +19,56 @@ import { z } from 'zod';
 /**
  * Public API Secret Options Schema
  *
+ * Defines the fields the public settings endpoint returns for secret creation
+ * options. Defaults are supplied by the runtime layer (Ruby serializer / store).
+ *
  * @example Validate and parse the data
  *    const parsedSecretOptions: SecretOptions = publicSecretOptionsSchema.parse(receivedSecretOptions);
  */
 export const publicSecretOptionsSchema = z.object({
-  /**
-   * Default Time-To-Live (TTL) for secrets in seconds
-   * Default: 604800 (7 days in seconds)
-   */
-  default_ttl: z.number().int().positive().default(604800),
+  /** Default Time-To-Live (TTL) for secrets in seconds. */
+  default_ttl: z.number().optional(),
 
-  /**
-   * Available TTL options for secret creation (in seconds)
-   * These options will be presented to users when they create a new secret
-   * Format: Array of integers representing seconds
-   * Default: [300, 1800, 3600, 14400, 43200, 86400, 259200, 604800, 1209600]
-   */
-  ttl_options: z
-    .array(z.number().int().positive().min(60).max(2592000))
-    .default([300, 1800, 3600, 14400, 43200, 86400, 259200, 604800, 1209600, 2592000]),
+  /** Available TTL options for secret creation (in seconds). */
+  ttl_options: z.array(z.number()).optional(),
 
-  /**
-   * Settings for the passphrase field that protects access to secrets
-   */
+  /** Settings for the passphrase field that protects access to secrets */
   passphrase: z
     .object({
-      /**
-       * Whether passphrases are required for all secrets
-       */
-      required: z.boolean().default(false),
+      /** Whether passphrases are required for all secrets. */
+      required: z.boolean().optional(),
 
       /**
        * Minimum length required for passphrases.
-       * Default: 4. Set to 0 to disable enforcement.
        * @sync apps/api/v1/logic/secrets/base_secret_action.rb — passphrase validation
        */
-      minimum_length: z.number().int().min(0).max(256).default(4),
+      minimum_length: z.number().optional(),
 
-      /**
-       * Maximum length allowed for passphrases
-       */
-      maximum_length: z.number().int().min(8).max(1024).default(128),
+      /** Maximum length allowed for passphrases. */
+      maximum_length: z.number().optional(),
 
-      /**
-       * Whether to enforce complexity requirements
-       */
-      enforce_complexity: z.boolean().default(false),
+      /** Whether to enforce complexity requirements. */
+      enforce_complexity: z.boolean().optional(),
     })
     .optional(),
 
-  /**
-   * Settings for password generation feature
-   */
+  /** Settings for password generation feature */
   password_generation: z
     .object({
-      /**
-       * Default length for generated passwords
-       */
-      default_length: z.number().int().min(4).max(128).default(12),
+      /** Default length for generated passwords. */
+      default_length: z.number().optional(),
 
-      /**
-       * Available length options for password generation
-       */
-      length_options: z.array(z.number().int().min(4).max(128)).default([8, 12, 16, 20, 24, 32]),
+      /** Available length options for password generation. */
+      length_options: z.array(z.number()).optional(),
 
-      /**
-       * Character sets to include in generated passwords
-       */
+      /** Character sets to include in generated passwords. */
       character_sets: z
         .object({
-          uppercase: z.boolean().default(true),
-          lowercase: z.boolean().default(true),
-          numbers: z.boolean().default(true),
-          symbols: z.boolean().default(false),
-          exclude_ambiguous: z.boolean().default(true),
+          uppercase: z.boolean().optional(),
+          lowercase: z.boolean().optional(),
+          numbers: z.boolean().optional(),
+          symbols: z.boolean().optional(),
+          exclude_ambiguous: z.boolean().optional(),
         })
         .optional(),
     })
@@ -103,38 +83,26 @@ export type PublicSecretOptions = z.infer<typeof publicSecretOptionsSchema>;
 /**
  * Public API Authentication Schema
  *
- * This schema validates public settings API responses where boolean
+ * This schema describes public settings API responses where boolean
  * values are native types from Ruby/YAML serialized to JSON.
  */
 export const publicAuthenticationSchema = z.object({
-  /**
-   * Flag to enable or disable authentication
-   */
+  /** Flag to enable or disable authentication. */
   enabled: z.boolean(),
 
-  /**
-   * Flag to allow or disallow user sign-up
-   */
+  /** Flag to allow or disallow user sign-up. */
   signup: z.boolean(),
 
-  /**
-   * Flag to allow or disallow user sign-in
-   */
+  /** Flag to allow or disallow user sign-in. */
   signin: z.boolean(),
 
-  /**
-   * Flag to enable or disable automatic verification
-   */
+  /** Flag to enable or disable automatic verification. */
   autoverify: z.boolean(),
 
-  /**
-   * Flag to enable or disable homepage secret form when not logged in.
-   */
+  /** Flag to enable or disable homepage secret form when not logged in. */
   required: z.boolean(),
 
-  /**
-   * Authentication mode: 'simple' (Redis-only) or 'full' (Rodauth with SQL db)
-   */
+  /** Authentication mode: 'simple' (Redis-only) or 'full' (Rodauth with SQL db). */
   mode: z.enum(['simple', 'full']).optional(),
 });
 
@@ -237,7 +205,7 @@ const supportSchema = z.object({
 /**
  * Public API Features Schema
  *
- * This schema validates public settings API responses for feature flags
+ * This schema describes public settings API responses for feature flags
  * where boolean values are native types from Ruby/YAML serialized to JSON.
  */
 export const publicFeaturesSchema = z.object({

--- a/src/schemas/contracts/config/section/development.ts
+++ b/src/schemas/contracts/config/section/development.ts
@@ -4,23 +4,23 @@
  * Development Configuration Schema
  *
  * Maps to the `development:` section in config.defaults.yaml
- */
-
-import { z } from 'zod';
-
-/**
- * Development mode configuration
+ *
+ * Per contracts convention, this schema describes field names and types only.
+ * Defaults and value constraints belong in shapes — not here.
  *
  * - allow_nil_global_secret: Recovery mode for secrets created without encryption key.
  *   Only effective when development.enabled is true; the config normalization layer
  *   forces this to false when development mode is off.
  */
+
+import { z } from 'zod';
+
 const developmentSchema = z.object({
-  enabled: z.boolean().default(false),
-  debug: z.boolean().default(false),
-  frontend_host: z.string().default('http://localhost:5173'),
-  domain_context_enabled: z.boolean().default(false),
-  allow_nil_global_secret: z.boolean().default(false),
+  enabled: z.boolean().optional(),
+  debug: z.boolean().optional(),
+  frontend_host: z.string().optional(),
+  domain_context_enabled: z.boolean().optional(),
+  allow_nil_global_secret: z.boolean().optional(),
 });
 
 export { developmentSchema };

--- a/src/schemas/contracts/config/section/diagnostics.ts
+++ b/src/schemas/contracts/config/section/diagnostics.ts
@@ -4,6 +4,9 @@
  * Diagnostics Configuration Schema
  *
  * Maps to the `diagnostics:` section in config.defaults.yaml
+ *
+ * Per contracts convention, this schema describes field names and types only.
+ * Defaults and value constraints belong in shapes — not here.
  */
 
 import { z } from 'zod';
@@ -16,7 +19,7 @@ const diagnosticsSentryDefaultsSchema = z.object({
   dsn: nullableString,
   sampleRate: z.union([z.string(), z.number()]).optional(),
   maxBreadcrumbs: z.union([z.string(), z.number()]).optional(),
-  logErrors: z.boolean().default(true),
+  logErrors: z.boolean().optional(),
 });
 
 /**
@@ -28,7 +31,7 @@ const diagnosticsSentryBackendSchema = diagnosticsSentryDefaultsSchema.extend({}
  * Sentry frontend configuration
  */
 const diagnosticsSentryFrontendSchema = diagnosticsSentryDefaultsSchema.extend({
-  trackComponents: z.boolean().default(true),
+  trackComponents: z.boolean().optional(),
 });
 
 /**
@@ -44,7 +47,7 @@ const diagnosticsSentrySchema = z.object({
  * Complete diagnostics schema
  */
 const diagnosticsSchema = z.object({
-  enabled: z.boolean().default(false),
+  enabled: z.boolean().optional(),
   sentry: diagnosticsSentrySchema.optional(),
 });
 

--- a/src/schemas/contracts/config/section/features.ts
+++ b/src/schemas/contracts/config/section/features.ts
@@ -4,6 +4,9 @@
  * Features Configuration Schema
  *
  * Maps to the `features:` section in config.defaults.yaml
+ *
+ * Per contracts convention, this schema describes field names and types only.
+ * Defaults and value constraints belong in shapes — not here.
  */
 
 import { z } from 'zod';
@@ -18,9 +21,9 @@ const incomingRecipientSchema = z.tuple([z.string(), z.string().optional()]).nul
  * Incoming secrets feature configuration
  */
 const featuresIncomingSchema = z.object({
-  enabled: z.boolean().default(false),
-  memo_max_length: z.number().int().positive().default(50),
-  default_ttl: z.number().int().positive().default(604800),
+  enabled: z.boolean().optional(),
+  memo_max_length: z.number().optional(),
+  default_ttl: z.number().optional(),
   default_passphrase: z.string().nullable().optional(),
   recipients: z.array(incomingRecipientSchema).optional(),
 });
@@ -54,7 +57,7 @@ const featuresRegionJurisdictionSchema = z.object({
  * an operator does provide a structured list.
  */
 const featuresRegionsSchema = z.object({
-  enabled: z.boolean().default(false),
+  enabled: z.boolean().optional(),
   current_jurisdiction: nullableString,
   jurisdictions: z
     .union([z.array(featuresRegionJurisdictionSchema), z.string(), z.null()])
@@ -81,9 +84,9 @@ const featuresDomainsProxySchema = z.object({
  * Both representations are semantically the same TCP port.
  */
 const featuresDomainsAcmeSchema = z.object({
-  enabled: z.boolean().default(false),
-  listen_address: z.string().default('127.0.0.1'),
-  port: z.union([z.string(), z.number()]).default('12020'),
+  enabled: z.boolean().optional(),
+  listen_address: z.string().optional(),
+  port: z.union([z.string(), z.number()]).optional(),
 });
 
 /**
@@ -94,12 +97,10 @@ const featuresDomainsAcmeSchema = z.object({
  * rename here must be applied on the Ruby side as well.
  */
 const featuresDomainsSchema = z.object({
-  enabled: z.boolean().default(false),
-  require_verified: z.boolean().default(false),
+  enabled: z.boolean().optional(),
+  require_verified: z.boolean().optional(),
   default: nullableString,
-  validation_strategy: z
-    .enum(['passthrough', 'approximated', 'caddy_on_demand'])
-    .default('passthrough'),
+  validation_strategy: z.enum(['passthrough', 'approximated', 'caddy_on_demand']).optional(),
   approximated: featuresDomainsProxySchema.optional(),
   acme: featuresDomainsAcmeSchema.optional(),
 });

--- a/src/schemas/contracts/config/section/i18n.ts
+++ b/src/schemas/contracts/config/section/i18n.ts
@@ -4,21 +4,21 @@
  * Internationalization Configuration Schema
  *
  * Maps to the `internationalization:` section in config.defaults.yaml
+ *
+ * Per contracts convention, this schema describes field names and types only.
+ * Defaults and value constraints belong in shapes — not here.
  */
 
 import { z } from 'zod';
 
-/**
- * i18n configuration schema
- */
 const i18nSchema = z.object({
-  enabled: z.boolean().default(false),
-  default_locale: z.string().default('en'),
+  enabled: z.boolean().optional(),
+  default_locale: z.string().optional(),
   fallback_locale: z.record(z.string(), z.union([z.array(z.string()), z.string()])),
-  locales: z.array(z.string()).default([]),
-  incomplete: z.array(z.string()).default([]),
-  date_format: z.string().default('locale'),
-  datetime_format: z.string().default('locale'),
+  locales: z.array(z.string()).optional(),
+  incomplete: z.array(z.string()).optional(),
+  date_format: z.string().optional(),
+  datetime_format: z.string().optional(),
 });
 
 export { i18nSchema };

--- a/src/schemas/contracts/config/section/jurisdiction.ts
+++ b/src/schemas/contracts/config/section/jurisdiction.ts
@@ -6,8 +6,10 @@
  * Defines the canonical structure for jurisdiction/region configuration.
  * Maps to the `regions:` section in config.defaults.yaml.
  *
- * This contract defines field names and output types only.
- * Wire-format transforms (string→boolean) live in shapes/config/jurisdiction.ts.
+ * Per contracts convention, this schema describes field names and types only.
+ * Defaults and value constraints (e.g. identifier length bounds) belong in
+ * shapes — not here. Wire-format transforms (string→boolean) live in
+ * shapes/config/jurisdiction.ts.
  */
 
 import { z } from 'zod';
@@ -27,11 +29,11 @@ const jurisdictionIconSchema = z.object({
  * which components resolve via i18n. display_name is computed at runtime.
  */
 const jurisdictionSchema = z.object({
-  identifier: z.string().min(2).max(24),
+  identifier: z.string(),
   display_name_i18n_key: z.string(),
   domain: z.string(),
   icon: jurisdictionIconSchema.optional(),
-  enabled: z.boolean().default(true),
+  enabled: z.boolean().optional(),
 });
 
 /**
@@ -43,7 +45,7 @@ const regionSchema = jurisdictionSchema;
  * Canonical regions configuration schema
  */
 const regionsConfigSchema = z.object({
-  identifier: z.string().min(2).max(24),
+  identifier: z.string(),
   enabled: z.boolean(),
   current_jurisdiction: z.string(),
   jurisdictions: z.array(jurisdictionSchema),

--- a/src/schemas/contracts/config/section/mail.ts
+++ b/src/schemas/contracts/config/section/mail.ts
@@ -4,6 +4,9 @@
  * Mail Configuration Schema
  *
  * Maps to the `emailer:` and `mail:` sections in config.defaults.yaml
+ *
+ * Per contracts convention, this schema describes field names and types only.
+ * Defaults and value constraints belong in shapes — not here.
  */
 
 import { z } from 'zod';
@@ -13,13 +16,13 @@ import { nullableString } from '../shared/primitives';
  * Emailer (SMTP) configuration
  */
 const emailerSchema = z.object({
-  mode: z.string().default('smtp'),
+  mode: z.string().optional(),
   region: z.string().optional(),
-  from: z.string().default('CHANGEME@example.com'),
-  from_name: z.string().default('Support'),
+  from: z.string().optional(),
+  from_name: z.string().optional(),
   reply_to: nullableString,
-  host: z.string().default('smtp.provider.com'),
-  port: z.number().int().positive().default(587),
+  host: z.string().optional(),
+  port: z.number().optional(),
   user: nullableString,
   pass: nullableString,
   auth: nullableString, // 'login', 'plain', etc.
@@ -30,8 +33,8 @@ const emailerSchema = z.object({
  * Truemail logger configuration
  */
 const truemailLoggerSchema = z.object({
-  tracking_event: z.string().default(':error'),
-  stdout: z.boolean().default(true),
+  tracking_event: z.string().optional(),
+  stdout: z.boolean().optional(),
   log_absolute_path: z.string().optional(),
 });
 
@@ -39,24 +42,24 @@ const truemailLoggerSchema = z.object({
  * Truemail validation configuration
  */
 const truemailSchema = z.object({
-  default_validation_type: z.string().default(':regex'),
-  verifier_email: z.string().default('CHANGEME@example.com'),
+  default_validation_type: z.string().optional(),
+  verifier_email: z.string().optional(),
   verifier_domain: z.string().optional(),
   connection_timeout: z.number().optional(),
   response_timeout: z.number().optional(),
   connection_attempts: z.number().optional(),
   validation_type_for: z.record(z.string(), z.string()).optional(),
-  allowed_domains_only: z.boolean().default(false),
+  allowed_domains_only: z.boolean().optional(),
   allowed_emails: z.array(z.string()).optional(),
   blocked_emails: z.array(z.string()).optional(),
   allowed_domains: z.array(z.string()).optional(),
   blocked_domains: z.array(z.string()).optional(),
   blocked_mx_ip_addresses: z.array(z.string()).optional(),
-  dns: z.array(z.string()).default(['1.1.1.1', '8.8.4.4', '208.67.220.220']),
-  smtp_port: z.number().int().positive().optional(),
-  smtp_fail_fast: z.boolean().default(false),
-  smtp_safe_check: z.boolean().default(true),
-  not_rfc_mx_lookup_flow: z.boolean().default(false),
+  dns: z.array(z.string()).optional(),
+  smtp_port: z.number().optional(),
+  smtp_fail_fast: z.boolean().optional(),
+  smtp_safe_check: z.boolean().optional(),
+  not_rfc_mx_lookup_flow: z.boolean().optional(),
   email_pattern: z.string().optional(),
   smtp_error_body_pattern: z.string().optional(),
   logger: truemailLoggerSchema.optional(),
@@ -73,11 +76,11 @@ const mailSchema = z.object({
  * Combined mail connection schema (for static config)
  */
 const mailConnectionSchema = z.object({
-  mode: z.string().default('smtp'),
-  auth: z.string().default('login'),
+  mode: z.string().optional(),
+  auth: z.string().optional(),
   region: z.string().optional(),
-  from: z.string().default('noreply@example.com'),
-  fromname: z.string().default('OneTimeSecret'),
+  from: z.string().optional(),
+  fromname: z.string().optional(),
   host: z.string().optional(),
   port: z.number().optional(),
   user: nullableString,
@@ -89,9 +92,9 @@ const mailConnectionSchema = z.object({
  * Mail validation schema (for static config)
  */
 const mailValidationSchema = z.object({
-  default_validation_type: z.string().default('mx'),
-  verifier_email: z.string().default('example@onetimesecret.dev'),
-  verifier_domain: z.string().default('onetimesecret.dev'),
+  default_validation_type: z.string().optional(),
+  verifier_email: z.string().optional(),
+  verifier_domain: z.string().optional(),
   connection_timeout: z.number().optional(),
   response_timeout: z.number().optional(),
   connection_attempts: z.number().optional(),
@@ -107,11 +110,13 @@ const mailValidationSchema = z.object({
   smtp_fail_fast: z.boolean().optional(),
   smtp_safe_check: z.boolean().optional(),
   not_rfc_mx_lookup_flow: z.boolean().optional(),
-  logger: z.object({
-    tracking_event: z.string().default('all'),
-    stdout: z.boolean().default(true),
-    log_absolute_path: z.string().optional(),
-  }).optional(),
+  logger: z
+    .object({
+      tracking_event: z.string().optional(),
+      stdout: z.boolean().optional(),
+      log_absolute_path: z.string().optional(),
+    })
+    .optional(),
 });
 
 export {

--- a/src/schemas/contracts/config/section/secret_options.ts
+++ b/src/schemas/contracts/config/section/secret_options.ts
@@ -5,6 +5,10 @@
  *
  * Defines TTL and size limits for different user types.
  * Previously defined in Onetime::Plan.load_plans!
+ *
+ * Per contracts convention, this schema describes field names and types only.
+ * Defaults and value constraints (TTL bounds, size limits) belong in shapes —
+ * not here.
  */
 
 import { z } from 'zod';
@@ -14,36 +18,14 @@ import { ValidKeys as UserTypeKeys } from '../shared/user_types';
  * Secret option boundaries for a user type
  */
 const secretOptionBoundariesSchema = z.object({
-  /**
-   * Default Time-To-Live (TTL) for secrets in seconds
-   * @default 604800 (7 days)
-   */
-  default_ttl: z.number().int().positive().nullable().default(604800),
+  /** Default Time-To-Live (TTL) for secrets in seconds. */
+  default_ttl: z.number().nullable().optional(),
 
-  /**
-   * Available TTL options for secret creation (in seconds)
-   * @min 60 - One minute
-   * @max 2592000 - 30 days
-   * @default [300, 1800, 3600, 14400, 43200, 86400, 259200, 604800, 1209600, 2592000]
-   */
-  ttl_options: z
-    .array(z.number().int().positive().min(60).max(2592000))
-    .nullable()
-    .default([300, 1800, 3600, 14400, 43200, 86400, 259200, 604800, 1209600, 2592000]),
+  /** Available TTL options for secret creation (in seconds). */
+  ttl_options: z.array(z.number()).nullable().optional(),
 
-  /**
-   * Maximum secret size in bytes
-   * @max 10485760 (10MB)
-   * @default 102400 (100KB)
-   */
-  size: z
-    .number()
-    .int()
-    .positive()
-    .min(1)
-    .max(10485760)
-    .nullable()
-    .default(102400),
+  /** Maximum secret size in bytes. */
+  size: z.number().nullable().optional(),
 });
 
 /**

--- a/src/schemas/contracts/config/section/site.ts
+++ b/src/schemas/contracts/config/section/site.ts
@@ -4,6 +4,10 @@
  * Site Configuration Schema
  *
  * Maps to the `site:` section in config.defaults.yaml
+ *
+ * Per contracts convention, this schema describes field names and types only.
+ * Defaults and value constraints (port bounds, length bounds, etc.) belong in
+ * shapes — not here.
  */
 
 import { z } from 'zod';
@@ -13,13 +17,13 @@ import { nullableString } from '../shared/primitives';
  * Authentication settings within site configuration
  */
 const siteAuthenticationSchema = z.object({
-  enabled: z.boolean().default(true),
-  signup: z.boolean().default(true),
-  signin: z.boolean().default(true),
-  autoverify: z.boolean().default(false),
-  required: z.boolean().default(false),
-  colonels: z.array(z.string()).default([]),
-  allowed_signup_domains: z.array(z.string()).default([]),
+  enabled: z.boolean().optional(),
+  signup: z.boolean().optional(),
+  signin: z.boolean().optional(),
+  autoverify: z.boolean().optional(),
+  required: z.boolean().optional(),
+  colonels: z.array(z.string()).optional(),
+  allowed_signup_domains: z.array(z.string()).optional(),
 });
 
 /**
@@ -37,18 +41,18 @@ const siteSupportSchema = z.object({
  */
 const sessionConfigSchema = z.object({
   secret: nullableString,
-  expire_after: z.number().int().positive().default(86400), // 24 hours
-  key: z.string().default('onetime.session'),
-  secure: z.boolean().default(true),
-  same_site: z.enum(['strict', 'lax', 'none']).default('lax'),
-  httponly: z.boolean().default(true),
+  expire_after: z.number().optional(),
+  key: z.string().optional(),
+  secure: z.boolean().optional(),
+  same_site: z.enum(['strict', 'lax', 'none']).optional(),
+  httponly: z.boolean().optional(),
 });
 
 /**
  * Content Security Policy configuration
  */
 const cspSchema = z.object({
-  enabled: z.boolean().default(false),
+  enabled: z.boolean().optional(),
 });
 
 /**
@@ -67,46 +71,45 @@ const securitySchema = z.object({
  * Relocated from experimental to site as these are now stable.
  */
 const middlewareSchema = z.object({
-  static_files: z.boolean().default(true),
-  utf8_sanitizer: z.boolean().default(true),
-  authenticity_token: z.boolean().default(true),
-  http_origin: z.boolean().default(false),
-  xss_header: z.boolean().default(false),
-  frame_options: z.boolean().default(false),
-  path_traversal: z.boolean().default(false),
-  cookie_tossing: z.boolean().default(false),
-  ip_spoofing: z.boolean().default(false),
-  strict_transport: z.boolean().default(false),
+  static_files: z.boolean().optional(),
+  utf8_sanitizer: z.boolean().optional(),
+  authenticity_token: z.boolean().optional(),
+  http_origin: z.boolean().optional(),
+  xss_header: z.boolean().optional(),
+  frame_options: z.boolean().optional(),
+  path_traversal: z.boolean().optional(),
+  cookie_tossing: z.boolean().optional(),
+  ip_spoofing: z.boolean().optional(),
+  strict_transport: z.boolean().optional(),
 });
 
 /**
  * Secret options - passphrase settings
  */
 const passphraseSchema = z.object({
-  required: z.boolean().default(false),
+  required: z.boolean().optional(),
   /**
    * Minimum length required for passphrases.
-   * Default: 4. Set to 0 to disable enforcement.
    * @sync apps/api/v1/logic/secrets/base_secret_action.rb — passphrase validation
    */
-  minimum_length: z.number().int().min(0).max(256).default(4),
-  maximum_length: z.number().int().positive().default(128),
-  enforce_complexity: z.boolean().default(false),
+  minimum_length: z.number().optional(),
+  maximum_length: z.number().optional(),
+  enforce_complexity: z.boolean().optional(),
 });
 
 /**
  * Secret options - password generation settings
  */
 const passwordGenerationCharacterSetsSchema = z.object({
-  uppercase: z.boolean().default(true),
-  lowercase: z.boolean().default(true),
-  numbers: z.boolean().default(true),
-  symbols: z.boolean().default(true),
-  exclude_ambiguous: z.boolean().default(true),
+  uppercase: z.boolean().optional(),
+  lowercase: z.boolean().optional(),
+  numbers: z.boolean().optional(),
+  symbols: z.boolean().optional(),
+  exclude_ambiguous: z.boolean().optional(),
 });
 
 const passwordGenerationSchema = z.object({
-  default_length: z.number().int().positive().default(12),
+  default_length: z.number().optional(),
   character_sets: passwordGenerationCharacterSetsSchema,
 });
 
@@ -114,9 +117,9 @@ const passwordGenerationSchema = z.object({
  * Secret options configuration
  */
 const siteSecretOptionsSchema = z.object({
-  default_ttl: z.number().int().positive().nullable().optional(),
+  default_ttl: z.number().nullable().optional(),
   ttl_options: z.string().nullable().optional(), // Raw string from env, parsed elsewhere
-  generated_value_display_ttl: z.number().int().nonnegative().optional(),
+  generated_value_display_ttl: z.number().optional(),
   passphrase: passphraseSchema,
   password_generation: passwordGenerationSchema,
 });
@@ -125,8 +128,8 @@ const siteSecretOptionsSchema = z.object({
  * Complete site schema matching config.defaults.yaml site: section
  */
 const siteSchema = z.object({
-  host: z.string().default('localhost:3000'),
-  ssl: z.boolean().default(false),
+  host: z.string().optional(),
+  ssl: z.boolean().optional(),
   secret: z.string().nullable().optional(),
   interface: z.any().optional(), // Defined in ui.ts for mutable config
   secret_options: siteSecretOptionsSchema.optional(),

--- a/src/schemas/contracts/config/section/storage.ts
+++ b/src/schemas/contracts/config/section/storage.ts
@@ -4,28 +4,32 @@
  * Storage Configuration Schema
  *
  * Maps to the `redis:` section in config.defaults.yaml
+ *
+ * Per contracts convention, this schema describes field names and types only.
+ * Defaults and value constraints (e.g. Redis db number range 0-15) belong in
+ * shapes — not here.
  */
 
 import { z } from 'zod';
 
 /**
  * Redis database mapping
- * Maps database names to their Redis database numbers (0-15)
+ * Maps database names to their Redis database numbers.
  */
 const redisDbsSchema = z.object({
-  session: z.number().int().min(0).max(15).default(0),
-  custom_domain: z.number().int().min(0).max(15).default(0),
-  customer: z.number().int().min(0).max(15).default(0),
-  metadata: z.number().int().min(0).max(15).default(0),
-  secret: z.number().int().min(0).max(15).default(0),
-  feedback: z.number().int().min(0).max(15).default(0),
+  session: z.number(),
+  custom_domain: z.number(),
+  customer: z.number(),
+  metadata: z.number(),
+  secret: z.number(),
+  feedback: z.number(),
 });
 
 /**
  * Redis/Valkey connection configuration
  */
 const redisSchema = z.object({
-  uri: z.string().default('redis://127.0.0.1:6379'),
+  uri: z.string(),
   dbs: redisDbsSchema.optional(),
 });
 
@@ -36,7 +40,7 @@ const storageSchema = z.object({
   db: z
     .object({
       connection: z.object({
-        url: z.string().default('redis://localhost:6379'),
+        url: z.string(),
       }),
       database_mapping: z.record(z.string(), z.number().nullable()).optional(),
     })

--- a/src/schemas/contracts/config/section/ui.ts
+++ b/src/schemas/contracts/config/section/ui.ts
@@ -4,6 +4,9 @@
  * User Interface Configuration Schema
  *
  * Maps to the `site.interface:` section in config.defaults.yaml
+ *
+ * Per contracts convention, this schema describes field names and types only.
+ * Defaults and value constraints belong in shapes — not here.
  */
 
 import { z } from 'zod';
@@ -40,15 +43,15 @@ const userInterfaceHeaderNavigationSchema = z.object({
  */
 const userInterfaceHomepageSchema = z.object({
   mode: z.string().nullable().optional(),
-  matching_cidrs: z.array(z.string()).default([]),
-  mode_header: z.string().default('O-Homepage-Mode'),
+  matching_cidrs: z.array(z.string()).optional(),
+  mode_header: z.string().optional(),
 });
 
 /**
  * Header configuration
  */
 const userInterfaceHeaderSchema = z.object({
-  enabled: z.boolean().default(true),
+  enabled: z.boolean().optional(),
   branding: userInterfaceHeaderBrandingSchema.optional(),
   navigation: userInterfaceHeaderNavigationSchema.optional(),
 });
@@ -75,7 +78,7 @@ const userInterfaceFooterGroupSchema = z.object({
  * Footer links configuration
  */
 const userInterfaceFooterLinksSchema = z.object({
-  enabled: z.boolean().default(false),
+  enabled: z.boolean().optional(),
   groups: z.array(userInterfaceFooterGroupSchema).optional(),
 });
 
@@ -83,8 +86,8 @@ const userInterfaceFooterLinksSchema = z.object({
  * Workspace links configuration (authenticated users only)
  */
 const userInterfaceWorkspaceLinksSchema = z.object({
-  enabled: z.boolean().default(false),
-  links: z.array(userInterfaceFooterLinkSchema).default([]),
+  enabled: z.boolean().optional(),
+  links: z.array(userInterfaceFooterLinkSchema).optional(),
 });
 
 /**
@@ -105,7 +108,7 @@ const uiHelpSchema = z.object({
 });
 
 const uiSchema = z.object({
-  enabled: z.boolean().default(true),
+  enabled: z.boolean().optional(),
   homepage: userInterfaceHomepageSchema.optional(),
   header: userInterfaceHeaderSchema.optional(),
   footer_links: userInterfaceFooterLinksSchema.optional(),
@@ -118,7 +121,7 @@ const uiSchema = z.object({
  * API configuration schema
  */
 const apiSchema = z.object({
-  enabled: z.boolean().default(true),
+  enabled: z.boolean().optional(),
 });
 
 /**

--- a/src/tests/schemas/contracts/config/public.spec.ts
+++ b/src/tests/schemas/contracts/config/public.spec.ts
@@ -1,8 +1,9 @@
-// src/tests/schemas/shapes/config/public.spec.ts
-
+// src/tests/schemas/contracts/config/public.spec.ts
 //
-// Tests for publicSecretOptionsSchema covering various configurations
-// that may be encountered from different deployment environments.
+// Tests for the public.ts contract schemas. These schemas describe the shape
+// of public-settings API responses (field names and types only). Per the
+// entity-contract convention, defaults and value bounds belong in shapes —
+// the runtime layer (Ruby serializer / store) supplies defaults at its layer.
 
 import { describe, it, expect } from 'vitest';
 import {
@@ -12,21 +13,14 @@ import {
 } from '@/schemas/contracts/config/public';
 
 describe('publicSecretOptionsSchema', () => {
-  describe('default values', () => {
-    it('parses empty object with all defaults', () => {
+  describe('empty / partial input', () => {
+    it('parses empty object with all fields undefined', () => {
       const result = publicSecretOptionsSchema.parse({});
 
-      expect(result.default_ttl).toBe(604800); // 7 days
-      expect(result.ttl_options).toEqual([
-        300, 1800, 3600, 14400, 43200, 86400, 259200, 604800, 1209600, 2592000,
-      ]);
+      expect(result.default_ttl).toBeUndefined();
+      expect(result.ttl_options).toBeUndefined();
       expect(result.passphrase).toBeUndefined();
       expect(result.password_generation).toBeUndefined();
-    });
-
-    it('applies default TTL of 7 days (604800 seconds)', () => {
-      const result = publicSecretOptionsSchema.parse({});
-      expect(result.default_ttl).toBe(604800);
     });
   });
 
@@ -46,32 +40,18 @@ describe('publicSecretOptionsSchema', () => {
       expect(result.ttl_options).toEqual(customOptions);
     });
 
-    it('enforces minimum TTL of 60 seconds in options', () => {
-      expect(() =>
-        publicSecretOptionsSchema.parse({
-          ttl_options: [30], // Below minimum
-        })
-      ).toThrow();
-    });
-
-    it('enforces maximum TTL of 30 days (2592000 seconds) in options', () => {
-      expect(() =>
-        publicSecretOptionsSchema.parse({
-          ttl_options: [3000000], // Above maximum
-        })
-      ).toThrow();
-    });
-
-    it('accepts boundary TTL values', () => {
+    it('accepts any positive numeric values in ttl_options', () => {
+      // Value bounds (min 60, max 2592000) belong in shapes — the contract
+      // accepts any number here.
       const result = publicSecretOptionsSchema.parse({
-        ttl_options: [60, 2592000], // Min and max allowed
+        ttl_options: [30, 60, 2592000, 3000000],
       });
-      expect(result.ttl_options).toEqual([60, 2592000]);
+      expect(result.ttl_options).toEqual([30, 60, 2592000, 3000000]);
     });
   });
 
   describe('passphrase configuration', () => {
-    it('accepts passphrase settings object', () => {
+    it('accepts full passphrase settings object', () => {
       const result = publicSecretOptionsSchema.parse({
         passphrase: {
           required: true,
@@ -87,7 +67,7 @@ describe('publicSecretOptionsSchema', () => {
       expect(result.passphrase?.enforce_complexity).toBe(true);
     });
 
-    it('applies passphrase defaults when partial object provided', () => {
+    it('allows partial passphrase object (other fields undefined)', () => {
       const result = publicSecretOptionsSchema.parse({
         passphrase: {
           required: true,
@@ -95,9 +75,9 @@ describe('publicSecretOptionsSchema', () => {
       });
 
       expect(result.passphrase?.required).toBe(true);
-      expect(result.passphrase?.minimum_length).toBe(4); // default
-      expect(result.passphrase?.maximum_length).toBe(128); // default
-      expect(result.passphrase?.enforce_complexity).toBe(false); // default
+      expect(result.passphrase?.minimum_length).toBeUndefined();
+      expect(result.passphrase?.maximum_length).toBeUndefined();
+      expect(result.passphrase?.enforce_complexity).toBeUndefined();
     });
 
     it('accepts native boolean for required field', () => {
@@ -110,7 +90,7 @@ describe('publicSecretOptionsSchema', () => {
       expect(result.passphrase?.required).toBe(true);
     });
 
-    it('accepts zero for minimum_length (no enforcement)', () => {
+    it('accepts zero for minimum_length', () => {
       const result = publicSecretOptionsSchema.parse({
         passphrase: {
           minimum_length: 0,
@@ -120,24 +100,16 @@ describe('publicSecretOptionsSchema', () => {
       expect(result.passphrase?.minimum_length).toBe(0);
     });
 
-    it('enforces maximum passphrase minimum_length constraint', () => {
-      expect(() =>
-        publicSecretOptionsSchema.parse({
-          passphrase: {
-            minimum_length: 300, // Above maximum of 256
-          },
-        })
-      ).toThrow();
-    });
+    it('accepts large values (no upper bound at the contract layer)', () => {
+      const result = publicSecretOptionsSchema.parse({
+        passphrase: {
+          minimum_length: 300,
+          maximum_length: 2000,
+        },
+      });
 
-    it('enforces maximum passphrase length constraints', () => {
-      expect(() =>
-        publicSecretOptionsSchema.parse({
-          passphrase: {
-            maximum_length: 2000, // Above maximum of 1024
-          },
-        })
-      ).toThrow();
+      expect(result.passphrase?.minimum_length).toBe(300);
+      expect(result.passphrase?.maximum_length).toBe(2000);
     });
   });
 
@@ -163,33 +135,24 @@ describe('publicSecretOptionsSchema', () => {
       expect(result.password_generation?.character_sets?.exclude_ambiguous).toBe(false);
     });
 
-    it('applies password generation defaults', () => {
+    it('allows empty password_generation object (all fields undefined)', () => {
       const result = publicSecretOptionsSchema.parse({
         password_generation: {},
       });
 
-      expect(result.password_generation?.default_length).toBe(12);
-      expect(result.password_generation?.length_options).toEqual([8, 12, 16, 20, 24, 32]);
+      expect(result.password_generation?.default_length).toBeUndefined();
+      expect(result.password_generation?.length_options).toBeUndefined();
+      expect(result.password_generation?.character_sets).toBeUndefined();
     });
 
-    it('enforces password length minimum of 4', () => {
-      expect(() =>
-        publicSecretOptionsSchema.parse({
-          password_generation: {
-            default_length: 2,
-          },
-        })
-      ).toThrow();
-    });
+    it('accepts any numeric values (no length bounds at the contract layer)', () => {
+      const result = publicSecretOptionsSchema.parse({
+        password_generation: {
+          default_length: 2,
+        },
+      });
 
-    it('enforces password length maximum of 128', () => {
-      expect(() =>
-        publicSecretOptionsSchema.parse({
-          password_generation: {
-            default_length: 256,
-          },
-        })
-      ).toThrow();
+      expect(result.password_generation?.default_length).toBe(2);
     });
   });
 
@@ -251,15 +214,19 @@ describe('publicSecretOptionsSchema', () => {
   });
 
   describe('type inference', () => {
-    it('infers correct TypeScript type', () => {
-      const config: SecretOptions = publicSecretOptionsSchema.parse({});
+    it('infers correct TypeScript type with optional numeric fields', () => {
+      const config: SecretOptions = publicSecretOptionsSchema.parse({
+        default_ttl: 86400,
+        ttl_options: [60, 3600],
+      });
 
-      // Type assertions - these would fail compilation if types are wrong
-      const _ttl: number = config.default_ttl;
-      const _options: number[] = config.ttl_options;
+      // Type assertions - these would fail compilation if types are wrong.
+      // default_ttl and ttl_options are now optional in the contract.
+      const _ttl: number | undefined = config.default_ttl;
+      const _options: number[] | undefined = config.ttl_options;
 
-      expect(_ttl).toBeDefined();
-      expect(_options).toBeDefined();
+      expect(_ttl).toBe(86400);
+      expect(_options).toEqual([60, 3600]);
     });
   });
 });


### PR DESCRIPTION
## Summary

#3212

Refactor all configuration contract schemas to follow the entity-contract convention: describe field names and output types only, removing defaults and numeric/length bounds. These constraints now belong in a separate shapes layer (to be implemented separately).

### Changes

**Schema Updates:**
- `src/schemas/contracts/config/public.ts`: Removed `.default()` calls and numeric bounds (TTL min/max, passphrase length bounds, password generation length bounds). Fields like `default_ttl`, `ttl_options`, and nested passphrase/password_generation fields are now optional without defaults.
- `src/schemas/contracts/config/section/site.ts`: Removed defaults from authentication, session, CSP, middleware, passphrase, and password generation schemas.
- `src/schemas/contracts/config/section/mail.ts`: Removed defaults from emailer, Truemail, and mail connection schemas.
- `src/schemas/contracts/config/logging.ts`: Removed defaults from logger levels, HTTP logging, and top-level logging config.
- `src/schemas/contracts/config/section/secret_options.ts`: Removed numeric bounds and defaults from TTL and size limit schemas.
- `src/schemas/contracts/config/billing.ts`: Removed `.min()` constraints from description, limit values, and price amounts; preserved regex patterns as they describe type format, not value bounds.
- `src/schemas/contracts/config/section/features.ts`: Removed defaults from incoming, regions, and domains/ACME schemas.
- `src/schemas/contracts/config/section/development.ts`: Removed defaults from all development mode fields.
- `src/schemas/contracts/config/section/storage.ts`: Removed Redis db number bounds (0-15) and URI defaults.
- `src/schemas/contracts/config/section/ui.ts`: Removed defaults from homepage, header, and footer schemas.
- `src/schemas/contracts/config/section/i18n.ts`: Removed defaults from i18n configuration.
- `src/schemas/contracts/config/auth.ts`: Removed numeric bounds from password hash cost and session timeout.
- `src/schemas/contracts/config/section/jurisdiction.ts`: Updated documentation to reflect type-only contract approach.
- `src/schemas/contracts/config/section/diagnostics.ts`: Updated documentation.
- `src/schemas/contracts/config/config.ts`: Added comprehensive documentation explaining the tradeoff and CLI validation implications.
- `src/schemas/contracts/config/index.ts`: Added detailed explanation of the contracts-are-type-only design decision.

**Test Updates:**
- `src/tests/schemas/contracts/config/public.spec.ts`: Updated all tests to reflect type-only contracts:
  - Changed "default values" describe block to "empty / partial input"
  - Updated assertions to expect `undefined` instead of default values
  - Removed tests that enforced numeric bounds (TTL min/max, passphrase length bounds, password generation length bounds)
  - Updated tests to accept any numeric values (e.g., TTL options below 60 or above 2592000 seconds)
  - Updated type inference test to reflect optional numeric fields
  - Updated test descriptions and comments to clarify the contract layer's responsibility

### Rationale

Per the entity-contract convention, contracts describe the shape of data (field names and types) without imposing business logic constraints. Defaults and value bounds are runtime concerns that belong in:
- **Defaults**: Ruby application config loader / frontend store
- **Value bounds**: A separate `src/schemas/shapes/config/` layer (future work)

This separation allows contracts to be stable type definitions while runtime behavior can evolve independently.

### Impact on CLI Validators

`bin/ots config validate` and `bin/ots billing catalog validate` now validate structure and types only. They no longer enforce removed value bounds (port ranges, passphrase length bounds, plan limit `>= -1`, Redis db number range, empty-string rejection). The CLIs are intentionally less strict during this interim period until the shapes layer is implemented.

## Related Issues

Implements entity-contract convention for all config schemas.

## Test Plan

Existing test suite updated and passing. Tests now verify that:
- Partial/empty

https://claude.ai/code/session_015bCX1scG3R8YJVKXKZkYcD