### PR TITLE
Add Sign Up link to BrandedMastHead for custom domain users

### DIFF
--- a/src/apps/secret/components/layout/BrandedMastHead.vue
+++ b/src/apps/secret/components/layout/BrandedMastHead.vue
@@ -34,6 +34,16 @@
     return hasSigninRoute && (platformAuthEnabled || platformSsoEnabled || domainSsoEnabled);
   });
 
+  /**
+   * Sign Up requires platform authentication — SSO users are provisioned
+   * through their identity provider, not the platform signup flow, so we
+   * mirror the canonical MastHead gating here rather than the broader SSO
+   * gating used for Sign In.
+   */
+  const showSignUp = computed(() =>
+    authentication.value?.enabled === true && authentication.value?.signup === true
+  );
+
   const handleImageError = () => {
     imageError.value = true;
   };
@@ -53,13 +63,30 @@
 
 <template>
   <div class="relative bg-white py-8 transition-colors duration-200 dark:bg-gray-900">
-    <!-- Sign In Link (for custom domain SSO users) -->
+    <!-- Auth Links (Sign Up / Sign In for custom domain users) -->
     <nav
-      v-if="showSignIn"
-      class="absolute right-4 top-4"
+      v-if="showSignUp || showSignIn"
+      class="absolute right-4 top-4 flex items-center gap-2"
       role="navigation"
       :aria-label="t('web.layout.main_navigation')">
       <router-link
+        v-if="showSignUp"
+        to="/signup"
+        :title="t('web.homepage.signup_individual_and_business_plans')"
+        data-testid="branded-signup-link"
+        class="text-sm font-bold text-gray-600 transition-colors duration-200
+          hover:text-gray-800 dark:text-gray-300 dark:hover:text-white">
+        {{ t('web.COMMON.header_create_account') }}
+      </router-link>
+      <span
+        v-if="showSignUp && showSignIn"
+        class="text-sm text-gray-400"
+        aria-hidden="true"
+        role="separator">
+        |
+      </span>
+      <router-link
+        v-if="showSignIn"
         to="/signin"
         :title="t('web.homepage.log_in_to_onetime_secret')"
         data-testid="branded-signin-link"

--- a/src/apps/secret/components/layout/BrandedMastHead.vue
+++ b/src/apps/secret/components/layout/BrandedMastHead.vue
@@ -90,8 +90,8 @@
         to="/signin"
         :title="t('web.homepage.log_in_to_onetime_secret')"
         data-testid="branded-signin-link"
-        class="text-sm text-gray-500 transition-colors duration-200
-          hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200">
+        class="text-sm text-gray-600 transition-colors duration-200
+          hover:text-gray-800 dark:text-gray-300 dark:hover:text-white">
         {{ t('web.COMMON.header_sign_in') }}
       </router-link>
     </nav>


### PR DESCRIPTION
## Summary

Add a Sign Up link to the BrandedMastHead component alongside the existing Sign In link for custom domain users. The Sign Up link is conditionally displayed based on platform authentication being enabled with signup explicitly enabled, while SSO users are provisioned through their identity provider rather than the platform signup flow.

## Changes

- Added `showSignUp` computed property that checks if platform authentication and signup are enabled
- Updated the navigation section to display both Sign Up and Sign In links when appropriate
- Added a visual separator ("|") between the links when both are visible
- Updated the nav container to use flexbox layout with gap spacing
- Updated the nav comment to reflect that it now handles both auth links

## Related Issues

<!-- Keywords that auto-close issues when merged: Fixes, Closes, Resolves -->
<!-- Example: Fixes #123 -->

## Test Plan

Verify that:
- Sign Up link appears when platform authentication and signup are enabled
- Sign Up link does not appear for SSO-only users
- Sign In link continues to display for custom domain SSO users
- Visual separator appears between Sign Up and Sign In links when both are shown
- Links have appropriate styling and are accessible with proper ARIA labels

https://claude.ai/code/session_011ECiiXCbwSyWEz2aK8fDTf