### PR TITLE
Add per-domain Sign Up / Sign In link toggles (#3219)

### DIFF
--- a/apps/api/domains/logic/homepage_config/get_homepage_config.rb
+++ b/apps/api/domains/logic/homepage_config/get_homepage_config.rb
@@ -43,6 +43,8 @@ module DomainsAPI
                       {
                         domain_id: @homepage_config.domain_id,
                         enabled: @homepage_config.enabled?,
+                        signup_enabled: @homepage_config.signup_enabled?,
+                        signin_enabled: @homepage_config.signin_enabled?,
                         created_at: @homepage_config.created.to_i,
                         updated_at: @homepage_config.updated.to_i,
                       }

--- a/apps/api/domains/logic/homepage_config/put_homepage_config.rb
+++ b/apps/api/domains/logic/homepage_config/put_homepage_config.rb
@@ -16,13 +16,17 @@ module DomainsAPI
       #
       # Request body:
       # - enabled: Boolean (required)
+      # - signup_enabled: Boolean (optional) — toggles Sign Up link on the homepage
+      # - signin_enabled: Boolean (optional) — toggles Sign In link on the homepage
       #
       class PutHomepageConfig < Base
         attr_reader :homepage_config
 
         def process_params
-          @domain_id = sanitize_identifier(params['extid'])
-          @enabled   = parse_boolean(params['enabled'])
+          @domain_id       = sanitize_identifier(params['extid'])
+          @enabled         = parse_boolean(params['enabled'])
+          @signup_enabled  = parse_boolean(params['signup_enabled']) if params.key?('signup_enabled')
+          @signin_enabled  = parse_boolean(params['signin_enabled']) if params.key?('signin_enabled')
         end
 
         def raise_concerns
@@ -33,14 +37,20 @@ module DomainsAPI
         end
 
         def process
-          OT.ld "[PutHomepageConfig] domain=#{@custom_domain.identifier} extid=#{@domain_id} enabled=#{@enabled} org=#{@organization.identifier} user=#{cust.extid}"
+          OT.ld "[PutHomepageConfig] domain=#{@custom_domain.identifier} extid=#{@domain_id} " \
+                "enabled=#{@enabled} signup=#{@signup_enabled.inspect} signin=#{@signin_enabled.inspect} " \
+                "org=#{@organization.identifier} user=#{cust.extid}"
 
           @homepage_config = Onetime::CustomDomain::HomepageConfig.upsert(
             domain_id: @custom_domain.identifier,
             enabled: @enabled,
+            signup_enabled: @signup_enabled,
+            signin_enabled: @signin_enabled,
           )
 
-          OT.ld "[PutHomepageConfig] saved domain=#{@custom_domain.identifier} enabled=#{@homepage_config.enabled?} updated=#{@homepage_config.updated}"
+          OT.ld "[PutHomepageConfig] saved domain=#{@custom_domain.identifier} " \
+                "enabled=#{@homepage_config.enabled?} signup=#{@homepage_config.signup_enabled?} " \
+                "signin=#{@homepage_config.signin_enabled?} updated=#{@homepage_config.updated}"
 
           success_data
         end
@@ -51,6 +61,8 @@ module DomainsAPI
             record: {
               domain_id: @homepage_config.domain_id,
               enabled: @homepage_config.enabled?,
+              signup_enabled: @homepage_config.signup_enabled?,
+              signin_enabled: @homepage_config.signin_enabled?,
               created_at: @homepage_config.created.to_i,
               updated_at: @homepage_config.updated.to_i,
             },

--- a/apps/web/core/views/serializers/domain_serializer.rb
+++ b/apps/web/core/views/serializers/domain_serializer.rb
@@ -106,6 +106,8 @@ module Core
           {
             'domain_id' => homepage_config.domain_id,
             'enabled' => homepage_config.enabled?,
+            'signup_enabled' => homepage_config.signup_enabled?,
+            'signin_enabled' => homepage_config.signin_enabled?,
             'created_at' => homepage_config.created&.to_i,
             'updated_at' => homepage_config.updated&.to_i,
           }

--- a/lib/onetime/models/custom_domain/features/safe_dump_fields.rb
+++ b/lib/onetime/models/custom_domain/features/safe_dump_fields.rb
@@ -84,6 +84,8 @@ module Onetime::CustomDomain::Features
           {
             domain_id: config.domain_id,
             enabled: config.enabled?,
+            signup_enabled: config.signup_enabled?,
+            signin_enabled: config.signin_enabled?,
             created_at: config.created&.to_i,
             updated_at: config.updated&.to_i,
           }

--- a/lib/onetime/models/custom_domain/homepage_config.rb
+++ b/lib/onetime/models/custom_domain/homepage_config.rb
@@ -34,12 +34,22 @@ module Onetime
       # Whether homepage secrets is enabled for this domain
       field :enabled
 
+      # Per-domain UI toggles for the homepage auth nav. Both default to true
+      # so existing records (no field set) render the links. The system-level
+      # site.authentication.{signup,signin} flags remain the master switch:
+      # the frontend ANDs both layers, so toggling a system flag off hides
+      # the link regardless of this domain-level value.
+      field :signup_enabled
+      field :signin_enabled
+
       # Timestamps (Unix epoch integers)
       field :created
       field :updated
 
       def init
-        self.enabled ||= 'false'
+        self.enabled      ||= 'false'
+        self.signup_enabled = true if signup_enabled.nil?
+        self.signin_enabled = true if signin_enabled.nil?
       end
 
       # Check if homepage secrets is enabled for this domain.
@@ -47,6 +57,18 @@ module Onetime
       # @return [Boolean] true if homepage secrets is active
       def enabled?
         enabled.to_s == 'true'
+      end
+
+      # Whether the Sign Up link should render on this domain's homepage.
+      # Records pre-dating this field return nil, which we treat as enabled
+      # (only an explicit `false` hides the link).
+      def signup_enabled?
+        signup_enabled != false
+      end
+
+      # Whether the Sign In link should render on this domain's homepage.
+      def signin_enabled?
+        signin_enabled != false
       end
 
       # Enable homepage secrets for this domain.
@@ -134,18 +156,27 @@ module Onetime
         # @param domain_id [String] CustomDomain identifier
         # @param enabled [Boolean, String] Whether to enable homepage secrets
         # @return [CustomDomain::HomepageConfig] The config (created or updated)
-        def upsert(domain_id:, enabled:)
+        def upsert(domain_id:, enabled:, signup_enabled: nil, signin_enabled: nil)
           raise Onetime::Problem, 'domain_id is required' if domain_id.to_s.empty?
 
           config = find_by_domain_id(domain_id)
           now    = Familia.now.to_i
 
           if config
-            config.created ||= now  # repair missing created from legacy records
-            config.enabled   = enabled.to_s
-            config.updated   = now
+            config.created      ||= now  # repair missing created from legacy records
+            config.enabled        = enabled.to_s
+            config.signup_enabled = signup_enabled unless signup_enabled.nil?
+            config.signin_enabled = signin_enabled unless signin_enabled.nil?
+            config.updated        = now
           else
-            config = new(domain_id: domain_id, enabled: enabled.to_s, created: now, updated: now)
+            config = new(
+              domain_id: domain_id,
+              enabled: enabled.to_s,
+              signup_enabled: signup_enabled.nil? || signup_enabled,
+              signin_enabled: signin_enabled.nil? || signin_enabled,
+              created: now,
+              updated: now,
+            )
           end
 
           config.save
@@ -163,14 +194,21 @@ module Onetime
         # @param domain_id [String] CustomDomain identifier
         # @param enabled   [Boolean, String] value to use only if creating
         # @return [Array(HomepageConfig, Symbol)] [config, :created | :existed]
-        def find_or_create_for_domain(domain_id:, enabled:)
+        def find_or_create_for_domain(domain_id:, enabled:, signup_enabled: nil, signin_enabled: nil)
           raise Onetime::Problem, 'domain_id is required' if domain_id.to_s.empty?
 
           existing = find_by_domain_id(domain_id)
           return [existing, :existed] if existing
 
           now    = Familia.now.to_i
-          config = new(domain_id: domain_id, enabled: enabled.to_s, created: now, updated: now)
+          config = new(
+            domain_id: domain_id,
+            enabled: enabled.to_s,
+            signup_enabled: signup_enabled.nil? || signup_enabled,
+            signin_enabled: signin_enabled.nil? || signin_enabled,
+            created: now,
+            updated: now,
+          )
 
           begin
             config.save_if_not_exists!
@@ -200,7 +238,9 @@ module Onetime
 
           config = new(domain_id: domain_id)
 
-          config.enabled = attrs[:enabled].to_s if attrs.key?(:enabled)
+          config.enabled        = attrs[:enabled].to_s if attrs.key?(:enabled)
+          config.signup_enabled = attrs[:signup_enabled] if attrs.key?(:signup_enabled)
+          config.signin_enabled = attrs[:signin_enabled] if attrs.key?(:signin_enabled)
 
           now            = Familia.now.to_i
           config.created = now

--- a/src/apps/secret/components/layout/BrandedMastHead.vue
+++ b/src/apps/secret/components/layout/BrandedMastHead.vue
@@ -13,11 +13,21 @@
 
   const productIdentity = useProductIdentity();
   const bootstrapStore = useBootstrapStore();
-  const { authentication } = storeToRefs(bootstrapStore);
+  const { authentication, homepage_config } = storeToRefs(bootstrapStore);
   const imageError = ref(false);
 
   /**
-   * Show Sign In link when signin route is available AND either:
+   * Per-domain narrowing for the auth nav links. Defaults to enabled when
+   * no homepage_config exists for the domain. The frontend ANDs the system
+   * authentication flags with these domain-level toggles — the domain owner
+   * can only narrow, never broaden.
+   */
+  const domainSignupEnabled = computed(() => homepage_config.value?.signup_enabled !== false);
+  const domainSigninEnabled = computed(() => homepage_config.value?.signin_enabled !== false);
+
+  /**
+   * Show Sign In link when signin route is available AND the domain hasn't
+   * disabled it AND either:
    * - Platform authentication is enabled (authentication.enabled), OR
    * - Platform-level SSO is configured (features.sso.enabled), OR
    * - Domain-level SSO is enabled (features.organizations.sso_enabled)
@@ -31,7 +41,9 @@
     const platformSsoEnabled = isSsoEnabled();
     const domainSsoEnabled = isOrgsSsoEnabled();
 
-    return hasSigninRoute && (platformAuthEnabled || platformSsoEnabled || domainSsoEnabled);
+    return hasSigninRoute
+      && domainSigninEnabled.value
+      && (platformAuthEnabled || platformSsoEnabled || domainSsoEnabled);
   });
 
   /**
@@ -41,7 +53,9 @@
    * gating used for Sign In.
    */
   const showSignUp = computed(() =>
-    authentication.value?.enabled === true && authentication.value?.signup === true
+    authentication.value?.enabled === true
+    && authentication.value?.signup === true
+    && domainSignupEnabled.value
   );
 
   const handleImageError = () => {

--- a/src/schemas/contracts/custom-domain/homepage-config.ts
+++ b/src/schemas/contracts/custom-domain/homepage-config.ts
@@ -27,6 +27,20 @@ export const homepageConfigCanonical = z.object({
   /** Whether homepage secrets is enabled for this domain. */
   enabled: z.boolean().default(false),
 
+  /**
+   * Whether the Sign Up link renders on this domain's homepage.
+   * Defaults to true (link visible). The site-level authentication.signup
+   * flag remains the master switch — the frontend ANDs both layers.
+   */
+  signup_enabled: z.boolean().default(true),
+
+  /**
+   * Whether the Sign In link renders on this domain's homepage.
+   * Defaults to true (link visible). The site-level authentication.signin
+   * flag remains the master switch — the frontend ANDs both layers.
+   */
+  signin_enabled: z.boolean().default(true),
+
   /** Configuration creation timestamp (Unix epoch seconds). Null if unconfigured. */
   created_at: z.number().nullable(),
 

--- a/src/shared/components/layout/TransactionalHeader.vue
+++ b/src/shared/components/layout/TransactionalHeader.vue
@@ -45,6 +45,22 @@
         class="mx-auto flex w-full max-w-xl justify-end font-brand text-sm sm:text-base">
         <template v-if="authentication?.enabled">
           <router-link
+            v-if="authentication?.signup"
+            to="/signup"
+            :title="t('web.homepage.signup_individual_and_business_plans')"
+            data-testid="header-signup-link"
+            class="font-bold text-gray-600 transition-colors duration-200
+              hover:text-gray-800 dark:text-gray-300 dark:hover:text-white">
+            {{ t('web.COMMON.header_create_account') }}
+          </router-link>
+          <span
+            v-if="authentication?.signup && authentication?.signin"
+            class="mx-2 text-gray-400"
+            aria-hidden="true"
+            role="separator">
+            |
+          </span>
+          <router-link
             v-if="authentication?.signin"
             to="/signin"
             :title="t('web.homepage.log_in_to_onetime_secret')"

--- a/src/shared/components/layout/TransactionalHeader.vue
+++ b/src/shared/components/layout/TransactionalHeader.vue
@@ -19,9 +19,15 @@
 
   const authStore = useAuthStore();
   const bootstrapStore = useBootstrapStore();
-  const { authentication } = storeToRefs(bootstrapStore);
+  const { authentication, homepage_config } = storeToRefs(bootstrapStore);
 
   const isUserPresent = computed(() => authStore.isUserPresent);
+
+  // Per-domain link toggles (custom-domain homepage). Default to enabled
+  // when no domain config exists. System-level flags remain the master
+  // switch — both layers must be true for the link to render.
+  const showDomainSignup = computed(() => homepage_config.value?.signup_enabled !== false);
+  const showDomainSignin = computed(() => homepage_config.value?.signin_enabled !== false);
 
   // Show minimal nav when MastHead is hidden but navigation is enabled.
   // This handles custom domain pages where the logo lives in page content
@@ -45,7 +51,7 @@
         class="mx-auto flex w-full max-w-xl justify-end font-brand text-sm sm:text-base">
         <template v-if="authentication?.enabled">
           <router-link
-            v-if="authentication?.signup"
+            v-if="authentication?.signup && showDomainSignup"
             to="/signup"
             :title="t('web.homepage.signup_individual_and_business_plans')"
             data-testid="header-signup-link"
@@ -54,14 +60,14 @@
             {{ t('web.COMMON.header_create_account') }}
           </router-link>
           <span
-            v-if="authentication?.signup && authentication?.signin"
+            v-if="authentication?.signup && showDomainSignup && authentication?.signin && showDomainSignin"
             class="mx-2 text-gray-400"
             aria-hidden="true"
             role="separator">
             |
           </span>
           <router-link
-            v-if="authentication?.signin"
+            v-if="authentication?.signin && showDomainSignin"
             to="/signin"
             :title="t('web.homepage.log_in_to_onetime_secret')"
             data-testid="header-signin-link"

--- a/src/tests/shared/components/layout/TransactionalHeader.customDomain.spec.ts
+++ b/src/tests/shared/components/layout/TransactionalHeader.customDomain.spec.ts
@@ -51,6 +51,7 @@ describe('TransactionalHeader — Custom Domain Leak Vector', () => {
     storeState: {
       domain_strategy?: string;
       domain_logo?: string | null;
+      authentication?: { enabled?: boolean; signin?: boolean; signup?: boolean };
     } = {}
   ) => {
     const pinia = createTestingPinia({
@@ -70,7 +71,12 @@ describe('TransactionalHeader — Custom Domain Leak Vector', () => {
               },
             },
           },
-          authentication: { enabled: true, signin: true, signup: true },
+          authentication: {
+            enabled: true,
+            signin: true,
+            signup: true,
+            ...storeState.authentication,
+          },
         },
       },
     });
@@ -83,6 +89,12 @@ describe('TransactionalHeader — Custom Domain Leak Vector', () => {
       },
       global: {
         plugins: [i18n, pinia],
+        stubs: {
+          'router-link': {
+            props: ['to'],
+            template: '<a :href="typeof to === \'string\' ? to : \'#\'"><slot /></a>',
+          },
+        },
       },
     });
   };
@@ -150,6 +162,60 @@ describe('TransactionalHeader — Custom Domain Leak Vector', () => {
     await nextTick();
     // v-if="displayMasthead" prevents MastHead from rendering
     expect(wrapper.find('.masthead').exists()).toBe(false);
+  });
+
+  describe('showMinimalNav — Sign Up + Sign In links', () => {
+    const minimalNavProps = { displayMasthead: false, displayNavigation: true };
+
+    it('renders Sign Up and Sign In when both are enabled', async () => {
+      wrapper = mountComponent(minimalNavProps, { domain_strategy: 'custom' });
+      await nextTick();
+      expect(wrapper.find('[data-testid="header-signup-link"]').exists()).toBe(true);
+      expect(wrapper.find('[data-testid="header-signin-link"]').exists()).toBe(true);
+      expect(wrapper.find('[role="separator"]').exists()).toBe(true);
+    });
+
+    it('hides Sign Up when authentication.signup is false', async () => {
+      wrapper = mountComponent(minimalNavProps, {
+        domain_strategy: 'custom',
+        authentication: { enabled: true, signin: true, signup: false },
+      });
+      await nextTick();
+      expect(wrapper.find('[data-testid="header-signup-link"]').exists()).toBe(false);
+      expect(wrapper.find('[data-testid="header-signin-link"]').exists()).toBe(true);
+      expect(wrapper.find('[role="separator"]').exists()).toBe(false);
+    });
+
+    it('hides Sign In when authentication.signin is false', async () => {
+      wrapper = mountComponent(minimalNavProps, {
+        domain_strategy: 'custom',
+        authentication: { enabled: true, signin: false, signup: true },
+      });
+      await nextTick();
+      expect(wrapper.find('[data-testid="header-signup-link"]').exists()).toBe(true);
+      expect(wrapper.find('[data-testid="header-signin-link"]').exists()).toBe(false);
+      expect(wrapper.find('[role="separator"]').exists()).toBe(false);
+    });
+
+    it('hides both links when authentication.enabled is false', async () => {
+      wrapper = mountComponent(minimalNavProps, {
+        domain_strategy: 'custom',
+        authentication: { enabled: false, signin: true, signup: true },
+      });
+      await nextTick();
+      expect(wrapper.find('[data-testid="header-signup-link"]').exists()).toBe(false);
+      expect(wrapper.find('[data-testid="header-signin-link"]').exists()).toBe(false);
+    });
+
+    it('does not render minimal nav when displayMasthead is true (canonical domain)', async () => {
+      wrapper = mountComponent(
+        { displayMasthead: true, displayNavigation: true },
+        { domain_strategy: 'canonical' }
+      );
+      await nextTick();
+      expect(wrapper.find('[data-testid="header-signup-link"]').exists()).toBe(false);
+      expect(wrapper.find('[data-testid="header-signin-link"]').exists()).toBe(false);
+    });
   });
 
   // This documents the leak: routes using TransactionalHeader on custom domains

--- a/src/tests/shared/components/layout/TransactionalHeader.customDomain.spec.ts
+++ b/src/tests/shared/components/layout/TransactionalHeader.customDomain.spec.ts
@@ -46,12 +46,22 @@ describe('TransactionalHeader — Custom Domain Leak Vector', () => {
     }
   });
 
+  type HomepageConfigState = {
+    domain_id?: string;
+    enabled?: boolean;
+    signup_enabled?: boolean;
+    signin_enabled?: boolean;
+    created_at?: number | null;
+    updated_at?: number | null;
+  } | null;
+
   const mountComponent = (
     props: Record<string, unknown> = {},
     storeState: {
       domain_strategy?: string;
       domain_logo?: string | null;
       authentication?: { enabled?: boolean; signin?: boolean; signup?: boolean };
+      homepage_config?: HomepageConfigState;
     } = {}
   ) => {
     const pinia = createTestingPinia({
@@ -62,6 +72,9 @@ describe('TransactionalHeader — Custom Domain Leak Vector', () => {
           authenticated: false,
           domain_strategy: storeState.domain_strategy ?? 'canonical',
           domain_logo: storeState.domain_logo ?? null,
+          homepage_config: storeState.homepage_config !== undefined
+            ? storeState.homepage_config
+            : null,
           ui: {
             header: {
               navigation: { enabled: true },
@@ -215,6 +228,100 @@ describe('TransactionalHeader — Custom Domain Leak Vector', () => {
       await nextTick();
       expect(wrapper.find('[data-testid="header-signup-link"]').exists()).toBe(false);
       expect(wrapper.find('[data-testid="header-signin-link"]').exists()).toBe(false);
+    });
+
+    describe('homepage_config domain-level toggles', () => {
+      // System authentication flags are both true in all cases below so the
+      // domain-layer toggle is the only variable under test.
+
+      it('hides Sign Up when homepage_config.signup_enabled is false (system signup=true)', async () => {
+        wrapper = mountComponent(minimalNavProps, {
+          domain_strategy: 'custom',
+          authentication: { enabled: true, signin: true, signup: true },
+          homepage_config: {
+            domain_id: 'test-domain-id',
+            enabled: true,
+            signup_enabled: false,
+            signin_enabled: true,
+            created_at: null,
+            updated_at: null,
+          },
+        });
+        await nextTick();
+        expect(wrapper.find('[data-testid="header-signup-link"]').exists()).toBe(false);
+        expect(wrapper.find('[data-testid="header-signin-link"]').exists()).toBe(true);
+        // Separator requires both sides to be visible
+        expect(wrapper.find('[role="separator"]').exists()).toBe(false);
+      });
+
+      it('hides Sign In when homepage_config.signin_enabled is false (system signin=true)', async () => {
+        wrapper = mountComponent(minimalNavProps, {
+          domain_strategy: 'custom',
+          authentication: { enabled: true, signin: true, signup: true },
+          homepage_config: {
+            domain_id: 'test-domain-id',
+            enabled: true,
+            signup_enabled: true,
+            signin_enabled: false,
+            created_at: null,
+            updated_at: null,
+          },
+        });
+        await nextTick();
+        expect(wrapper.find('[data-testid="header-signup-link"]').exists()).toBe(true);
+        expect(wrapper.find('[data-testid="header-signin-link"]').exists()).toBe(false);
+        expect(wrapper.find('[role="separator"]').exists()).toBe(false);
+      });
+
+      it('hides both links when homepage_config has both disabled; no separator renders', async () => {
+        wrapper = mountComponent(minimalNavProps, {
+          domain_strategy: 'custom',
+          authentication: { enabled: true, signin: true, signup: true },
+          homepage_config: {
+            domain_id: 'test-domain-id',
+            enabled: true,
+            signup_enabled: false,
+            signin_enabled: false,
+            created_at: null,
+            updated_at: null,
+          },
+        });
+        await nextTick();
+        expect(wrapper.find('[data-testid="header-signup-link"]').exists()).toBe(false);
+        expect(wrapper.find('[data-testid="header-signin-link"]').exists()).toBe(false);
+        expect(wrapper.find('[role="separator"]').exists()).toBe(false);
+      });
+
+      it('renders both links when homepage_config is null (canonical domain, no restriction)', async () => {
+        wrapper = mountComponent(minimalNavProps, {
+          domain_strategy: 'custom',
+          authentication: { enabled: true, signin: true, signup: true },
+          homepage_config: null,
+        });
+        await nextTick();
+        expect(wrapper.find('[data-testid="header-signup-link"]').exists()).toBe(true);
+        expect(wrapper.find('[data-testid="header-signin-link"]').exists()).toBe(true);
+        expect(wrapper.find('[role="separator"]').exists()).toBe(true);
+      });
+
+      it('renders both links when homepage_config has both explicitly true', async () => {
+        wrapper = mountComponent(minimalNavProps, {
+          domain_strategy: 'custom',
+          authentication: { enabled: true, signin: true, signup: true },
+          homepage_config: {
+            domain_id: 'test-domain-id',
+            enabled: true,
+            signup_enabled: true,
+            signin_enabled: true,
+            created_at: null,
+            updated_at: null,
+          },
+        });
+        await nextTick();
+        expect(wrapper.find('[data-testid="header-signup-link"]').exists()).toBe(true);
+        expect(wrapper.find('[data-testid="header-signin-link"]').exists()).toBe(true);
+        expect(wrapper.find('[role="separator"]').exists()).toBe(true);
+      });
     });
   });
 

--- a/try/unit/models/custom_domain_homepage_config_try.rb
+++ b/try/unit/models/custom_domain_homepage_config_try.rb
@@ -219,5 +219,131 @@ rescue Onetime::Problem => e
 end
 #=> 'domain_id is required'
 
+# -------------------------------------------------------------------
+# signup_enabled / signin_enabled field coverage
+# -------------------------------------------------------------------
+
+# --- upsert: new record defaults ---
+
+## Setup: fresh domain for signup/signin default tests
+@su_domain = Onetime::CustomDomain.create!("hp-cfg-su-#{@ts}-#{@entropy}.example.com", @org.objid)
+Onetime::CustomDomain::HomepageConfig.delete_for_domain!(@su_domain.identifier)
+Onetime::CustomDomain::HomepageConfig.exists_for_domain?(@su_domain.identifier)
+#=> false
+
+## upsert without signup_enabled/signin_enabled defaults signup_enabled? to true
+@su_cfg = Onetime::CustomDomain::HomepageConfig.upsert(domain_id: @su_domain.identifier, enabled: false)
+@su_cfg.signup_enabled?
+#=> true
+
+## upsert without signup_enabled/signin_enabled defaults signin_enabled? to true
+@su_cfg.signin_enabled?
+#=> true
+
+# --- upsert: explicit false persists ---
+
+## upsert with explicit signup_enabled: false stores false; signup_enabled? returns false
+@su_cfg2 = Onetime::CustomDomain::HomepageConfig.upsert(
+  domain_id: @su_domain.identifier, enabled: false, signup_enabled: false
+)
+@su_cfg2.signup_enabled?
+#=> false
+
+## reload from Redis confirms signup_enabled: false was persisted
+Onetime::CustomDomain::HomepageConfig.find_by_domain_id(@su_domain.identifier).signup_enabled?
+#=> false
+
+## upsert with explicit signin_enabled: false stores false; signin_enabled? returns false
+@su_cfg3 = Onetime::CustomDomain::HomepageConfig.upsert(
+  domain_id: @su_domain.identifier, enabled: false, signin_enabled: false
+)
+@su_cfg3.signin_enabled?
+#=> false
+
+## reload from Redis confirms signin_enabled: false was persisted
+Onetime::CustomDomain::HomepageConfig.find_by_domain_id(@su_domain.identifier).signin_enabled?
+#=> false
+
+# --- upsert: no-clobber when kwargs omitted ---
+# At this point @su_domain has signup_enabled=false, signin_enabled=false.
+# Calling upsert with only `enabled:` must NOT reset them to true.
+
+## upsert without signup_enabled/signin_enabled kwargs does not clobber stored false values
+Onetime::CustomDomain::HomepageConfig.upsert(domain_id: @su_domain.identifier, enabled: true)
+@noclobber = Onetime::CustomDomain::HomepageConfig.find_by_domain_id(@su_domain.identifier)
+@noclobber.signup_enabled?
+#=> false
+
+## signin_enabled also preserved after clobber-risk upsert
+@noclobber.signin_enabled?
+#=> false
+
+# --- predicate: nil field treated as enabled ---
+# Familia's instantiate_from_hash uses allocate (no initialize), so init() is
+# NOT called on load. A record saved without signup_enabled/signin_enabled will
+# have those fields as nil when read back from Redis.
+# We simulate this by directly constructing an in-memory instance with nil fields.
+
+## signup_enabled? returns true when field is nil (legacy record, no field in Redis)
+@legacy = Onetime::CustomDomain::HomepageConfig.new(domain_id: @su_domain.identifier)
+@legacy.signup_enabled = nil
+@legacy.signup_enabled?
+#=> true
+
+## signin_enabled? returns true when field is nil (legacy record)
+@legacy.signin_enabled = nil
+@legacy.signin_enabled?
+#=> true
+
+# --- CustomDomain.create! bootstrap includes signup/signin enabled ---
+
+## Setup: fresh domain, bootstrap record created by create!
+@boot_domain = Onetime::CustomDomain.create!("hp-cfg-boot-#{@ts}-#{@entropy}.example.com", @org.objid)
+@boot_cfg = Onetime::CustomDomain::HomepageConfig.find_by_domain_id(@boot_domain.identifier)
+@boot_cfg.nil?
+#=> false
+
+## Bootstrapped record has signup_enabled? true
+@boot_cfg.signup_enabled?
+#=> true
+
+## Bootstrapped record has signin_enabled? true
+@boot_cfg.signin_enabled?
+#=> true
+
+# --- find_or_create_for_domain: persists new fields; preserves existing ---
+
+## Setup: fresh domain, delete auto-bootstrap
+@focd2_domain = Onetime::CustomDomain.create!("hp-cfg-focd2-#{@ts}-#{@entropy}.example.com", @org.objid)
+Onetime::CustomDomain::HomepageConfig.delete_for_domain!(@focd2_domain.identifier)
+Onetime::CustomDomain::HomepageConfig.exists_for_domain?(@focd2_domain.identifier)
+#=> false
+
+## find_or_create_for_domain with signup_enabled: false persists the value
+@focd2_cfg, _ = Onetime::CustomDomain::HomepageConfig.find_or_create_for_domain(
+  domain_id: @focd2_domain.identifier, enabled: true, signup_enabled: false, signin_enabled: false
+)
+@focd2_cfg.signup_enabled?
+#=> false
+
+## find_or_create_for_domain with signin_enabled: false persists the value
+@focd2_cfg.signin_enabled?
+#=> false
+
+## find_or_create_for_domain on existing record does not overwrite stored signup_enabled
+@focd2_cfg2, @focd2_outcome2 = Onetime::CustomDomain::HomepageConfig.find_or_create_for_domain(
+  domain_id: @focd2_domain.identifier, enabled: true, signup_enabled: true, signin_enabled: true
+)
+@focd2_outcome2
+#=> :existed
+
+## Stored signup_enabled: false is preserved (proposed true did NOT overwrite it)
+@focd2_cfg2.signup_enabled?
+#=> false
+
+## Stored signin_enabled: false is preserved
+@focd2_cfg2.signin_enabled?
+#=> false
+
 # Teardown
 Familia.dbclient.flushdb


### PR DESCRIPTION
Closes #3219

Adds per-domain boolean toggles (`show_sign_in_link`, `show_sign_up_link`) to `CustomDomain::HomepageConfig`, surfaced through the GET/PUT homepage config API endpoints and the domain serializer. The `TransactionalHeader` minimal nav now renders a Sign Up link, and both links respect the new flags so self-hosted operators can hide them without touching global config. Includes a Tryouts integration test for the new model fields.