### PR TITLE
Require explicit user confirmation on org invite acceptance

### DIFF
--- a/apps/api/invite/logic/invites/accept_invite.rb
+++ b/apps/api/invite/logic/invites/accept_invite.rb
@@ -13,6 +13,8 @@ module InviteAPI::Logic
     # Creates the organization membership and clears the invitation token.
     #
     class AcceptInvite < InviteAPI::Logic::Base
+      include Onetime::LoggerMethods
+
       attr_reader :invitation, :organization, :membership
 
       def process_params
@@ -88,14 +90,16 @@ module InviteAPI::Logic
       end
 
       def process
-        OT.ld "[AcceptInvite] Accepting invitation #{@invitation.objid} for user #{cust.obscure_email}"
+        auth_logger.debug 'Accepting invitation',
+          invitation_id: @invitation.objid,
+          user: cust.obscure_email
 
         # Accept the invitation (updates membership status and adds to org).
         # provisioning_source: 'invited' attributes lifecycle to the invitation
         # flow, distinct from SSO JIT provisioning. See OrganizationMembership.
         @invitation.accept!(cust, provisioning_source: 'invited')
 
-        OT.info '[AcceptInvite] User joined organization',
+        auth_logger.info 'User joined organization',
           event: 'invite.accepted',
           invitation_id: @invitation.objid,
           organization_id: @organization.extid,

--- a/apps/api/invite/logic/invites/accept_invite.rb
+++ b/apps/api/invite/logic/invites/accept_invite.rb
@@ -30,6 +30,7 @@ module InviteAPI::Logic
             'Token is required',
             error_key: 'api.invite.errors.token_required',
             field: :token,
+            error_type: :missing,
           )
         end
 
@@ -42,6 +43,7 @@ module InviteAPI::Logic
             'Organization no longer exists',
             error_key: 'api.invite.errors.organization_no_longer_exists',
             field: :token,
+            error_type: :missing,
           )
         end
 
@@ -52,6 +54,7 @@ module InviteAPI::Logic
             error_key: 'api.invite.errors.invitation_already_processed',
             args: { status: @invitation.status },
             field: :token,
+            error_type: :invalid,
           )
         end
 
@@ -61,6 +64,7 @@ module InviteAPI::Logic
             'Invitation has expired',
             error_key: 'api.invite.errors.invitation_expired',
             field: :token,
+            error_type: :expired,
           )
         end
 
@@ -86,6 +90,7 @@ module InviteAPI::Logic
           'You are already a member of this organization',
           error_key: 'api.invite.errors.already_member',
           field: :token,
+          error_type: :exists,
         )
       end
 

--- a/apps/api/invite/logic/invites/decline_invite.rb
+++ b/apps/api/invite/logic/invites/decline_invite.rb
@@ -31,14 +31,14 @@ module InviteAPI::Logic
         rate_limiter.record_attempt
 
         if @token.nil? || @token.empty?
-          raise_form_error(error_key: 'api.invite.errors.token_required', field: :token)
+          raise_form_error(error_key: 'api.invite.errors.token_required', field: :token, error_type: :missing)
         end
 
         @invitation = load_invitation(@token)
 
         # Check if organization still exists (may have been deleted)
         unless @invitation.organization
-          raise_form_error(error_key: 'api.invite.errors.organization_no_longer_exists', field: :token)
+          raise_form_error(error_key: 'api.invite.errors.organization_no_longer_exists', field: :token, error_type: :missing)
         end
 
         # Check if invitation is still pending
@@ -48,6 +48,7 @@ module InviteAPI::Logic
           error_key: 'api.invite.errors.invitation_already_processed',
           args: { status: @invitation.status },
           field: :token,
+          error_type: :invalid,
         )
 
         # NOTE: We allow declining expired invitations since the user

--- a/apps/api/invite/logic/invites/decline_invite.rb
+++ b/apps/api/invite/logic/invites/decline_invite.rb
@@ -15,6 +15,8 @@ module InviteAPI::Logic
     # The token itself serves as proof of access.
     #
     class DeclineInvite < InviteAPI::Logic::Base
+      include Onetime::LoggerMethods
+
       attr_reader :invitation
 
       def process_params
@@ -53,12 +55,13 @@ module InviteAPI::Logic
       end
 
       def process
-        OT.ld "[DeclineInvite] Declining invitation #{@invitation.objid}"
+        auth_logger.debug 'Declining invitation',
+          invitation_id: @invitation.objid
 
         organization = @invitation.organization
         @invitation.decline!
 
-        OT.info '[DeclineInvite] Invitation declined',
+        auth_logger.info 'Invitation declined',
           event: 'invite.declined',
           invitation_id: @invitation.objid,
           organization_id: organization&.extid,

--- a/apps/api/invite/logic/invites/show_invite.rb
+++ b/apps/api/invite/logic/invites/show_invite.rb
@@ -24,6 +24,8 @@ module InviteAPI::Logic
     # Only raises 404 for truly invalid tokens (not found).
     #
     class ShowInvite < InviteAPI::Logic::Base
+      include Onetime::LoggerMethods
+
       attr_reader :invitation
 
       def process_params
@@ -53,7 +55,9 @@ module InviteAPI::Logic
       end
 
       def process
-        OT.ld "[ShowInvite] Showing invitation #{@invitation.objid} (status: #{@invitation.status})"
+        auth_logger.debug 'Showing invitation',
+          invitation_id: @invitation.objid,
+          status: @invitation.status
 
         success_data
       end
@@ -65,12 +69,15 @@ module InviteAPI::Logic
         result[:record][:actionable]     = actionable?
         result[:record][:account_exists] = account_exists?
 
-        OT.ld "[ShowInvite.success_data] domain_strategy=#{domain_strategy.inspect} display_domain=#{display_domain.inspect}"
-        OT.ld "[ShowInvite.success_data] custom_domain?=#{custom_domain?}"
+        auth_logger.debug 'Building success_data',
+          domain_strategy: domain_strategy,
+          display_domain: display_domain,
+          custom_domain: custom_domain?
 
         if custom_domain?
           domain = Onetime::CustomDomain.from_display_domain(display_domain)
-          OT.ld "[ShowInvite.success_data] found domain=#{domain&.display_domain.inspect}"
+          auth_logger.debug 'Found custom domain',
+            domain: domain&.display_domain
           if domain
             result[:record][:branding]     = serialize_brand_public(domain.brand_settings, domain)
             result[:record][:auth_methods] = build_auth_methods(domain.sso_config)

--- a/apps/api/invite/logic/invites/show_invite.rb
+++ b/apps/api/invite/logic/invites/show_invite.rb
@@ -40,14 +40,14 @@ module InviteAPI::Logic
         rate_limiter.record_attempt
 
         if @token.nil? || @token.empty?
-          raise_form_error(error_key: 'api.invite.errors.token_required', field: :token)
+          raise_form_error(error_key: 'api.invite.errors.token_required', field: :token, error_type: :missing)
         end
 
         @invitation = load_invitation(@token)
 
         # Check if organization still exists (may have been deleted)
         unless @invitation.organization
-          raise_form_error(error_key: 'api.invite.errors.organization_no_longer_exists', field: :token)
+          raise_form_error(error_key: 'api.invite.errors.organization_no_longer_exists', field: :token, error_type: :missing)
         end
 
         # NOTE: We no longer raise errors for non-pending or expired invitations.

--- a/apps/api/invite/logic/invites/signup_and_accept.rb
+++ b/apps/api/invite/logic/invites/signup_and_accept.rb
@@ -33,6 +33,8 @@ module InviteAPI::Logic
     # 9. Auto-logs in the user
     #
     class SignupAndAccept < InviteAPI::Logic::Base
+      include Onetime::LoggerMethods
+
       attr_reader :invitation, :customer
 
       def process_params
@@ -98,46 +100,38 @@ module InviteAPI::Logic
       end
 
       def process
-        OT.ld "[SignupAndAccept] Creating account and accepting invitation for #{OT::Utils.obscure_email(@email)}"
+        auth_logger.debug 'Creating account and accepting invitation',
+          email: OT::Utils.obscure_email(@email)
 
-        # Create account in authdb via Rodauth internal_request
-        # This bypasses the before_create_account hook (which we already validated)
+        # Create account in authdb via Rodauth internal_request.
+        # The after_create_account hook (apps/web/auth/config/hooks/account.rb)
+        # handles Customer creation, default workspace, invitation acceptance,
+        # and auto-verification at the SQL level — all gated on the
+        # invite_token we pass through.
         account_id = create_rodauth_account
 
-        # Fetch the created account
-        account = Auth::Database.connection[:accounts].where(id: account_id).first
+        # Refetch the account; external_id is populated by the hook's
+        # CreateCustomer linking step.
+        account   = Auth::Database.connection[:accounts].where(id: account_id).first
+        @customer = Onetime::Customer.find_by_extid(account[:external_id]) if account[:external_id]
 
-        # Create Customer in Redis and link to account
-        @customer = Auth::Operations::CreateCustomer.new(
-          account_id: account_id,
-          account: account,
-          db: Auth::Database.connection,
-        ).call
+        unless @customer
+          auth_logger.error 'Customer missing after create_account',
+            account_id: account_id
+          raise_form_error('Account created but customer record missing', field: :email)
+        end
 
-        # Create default workspace
-        Auth::Operations::CreateDefaultWorkspace.new(customer: @customer).call
-
-        # Accept the invitation
-        accept_result = Auth::Operations::AcceptInvitation.new(
-          customer: @customer,
-          token: @token,
-        ).call
-
-        unless accept_result[:accepted]
-          # Shouldn't happen since we validated the invite, but handle gracefully
-          OT.le "[SignupAndAccept] Invitation acceptance failed: #{accept_result[:reason]}"
+        # Reload the invitation to pick up the acceptance state written by the hook.
+        @invitation = load_invitation(@token)
+        if @invitation.nil? || @invitation.pending?
+          auth_logger.error 'Invitation not accepted by hook',
+            token_prefix: @token[0..7]
           raise_form_error('Failed to accept invitation', field: :token)
         end
 
-        # Mark account as verified (invite proves email ownership)
-        Auth::Database.connection[:accounts]
-          .where(id: account_id)
-          .update(status_id: 2) # Verified status
-
-        # Set up session for auto-login
         setup_session(account_id, account)
 
-        OT.info '[SignupAndAccept] User signed up and joined organization',
+        auth_logger.info 'User signed up and joined organization',
           event: 'invite.signup_accepted',
           invitation_id: @invitation.objid,
           organization_id: @invitation.organization.extid,
@@ -198,9 +192,15 @@ module InviteAPI::Logic
       def create_rodauth_account
         # Use Rodauth's internal_request feature to create the account
         # This ensures password hashing is done correctly (Argon2 in this project)
+        #
+        # Pass invite_token via params: so send_verify_account_email's suppression
+        # branch fires (see apps/web/auth/config/features/account_management.rb).
+        # Without this, Rodauth tries to build a verify-account URL and fails on
+        # the missing `domain` (internal_request has no HTTP host).
         result = Auth::Config.create_account(
           login: normalize_email(@email),
           password: @password,
+          params: { 'invite_token' => @token },
         )
 
         unless result
@@ -209,7 +209,10 @@ module InviteAPI::Logic
 
         result # Returns account_id on success
       rescue Rodauth::InternalRequestError => ex
-        OT.le "[SignupAndAccept] Rodauth internal_request error: #{ex.message}"
+        auth_logger.error 'Rodauth internal_request error',
+          exception: ex,
+          email: OT::Utils.obscure_email(@email),
+          token_prefix: @token[0..7]
 
         # Parse field errors from Rodauth
         if ex.field_errors&.any?

--- a/apps/api/invite/logic/invites/signup_and_accept.rb
+++ b/apps/api/invite/logic/invites/signup_and_accept.rb
@@ -122,10 +122,19 @@ module InviteAPI::Logic
         end
 
         # Reload the invitation to pick up the acceptance state written by the hook.
-        @invitation = load_invitation(@token)
+        # NOTE: cannot use find_by_token here — accept! removes the token from
+        # token_lookup (pending-only index, cleared for security). Look up the
+        # now-active membership via org_customer_lookup, which accept! populates.
+        org_objid   = @invitation.organization_objid
+        @invitation = Onetime::OrganizationMembership.find_by_org_customer(
+          org_objid,
+          @customer.objid,
+        )
         if @invitation.nil? || @invitation.pending?
           auth_logger.error 'Invitation not accepted by hook',
-            token_prefix: @token[0..7]
+            token_prefix: @token[0..7],
+            org_objid: org_objid,
+            customer_objid: @customer.objid
           raise_form_error('Failed to accept invitation', field: :token)
         end
 
@@ -197,17 +206,27 @@ module InviteAPI::Logic
         # branch fires (see apps/web/auth/config/features/account_management.rb).
         # Without this, Rodauth tries to build a verify-account URL and fails on
         # the missing `domain` (internal_request has no HTTP host).
-        result = Auth::Config.create_account(
+        #
+        # Rodauth's internal_request create_account returns nil on success by
+        # contract (see rodauth_spec.rb assertions of `must_be_nil`); errors are
+        # signalled via Rodauth::InternalRequestError. Look up the account row
+        # by email after the call to obtain the account_id.
+        Auth::Config.create_account(
           login: normalize_email(@email),
           password: @password,
           params: { 'invite_token' => @token },
         )
 
-        unless result
+        account = Auth::Database.connection[:accounts]
+          .where(email: normalize_email(@email)).first
+
+        unless account
+          auth_logger.error 'Account row missing after create_account',
+            email: OT::Utils.obscure_email(@email)
           raise_form_error('Failed to create account', field: :email)
         end
 
-        result # Returns account_id on success
+        account[:id]
       rescue Rodauth::InternalRequestError => ex
         auth_logger.error 'Rodauth internal_request error',
           exception: ex,

--- a/apps/api/invite/logic/invites/signup_and_accept.rb
+++ b/apps/api/invite/logic/invites/signup_and_accept.rb
@@ -6,7 +6,7 @@ require 'onetime/security/invite_token_rate_limiter'
 
 module InviteAPI::Logic
   module Invites
-    # Atomic signup + invitation acceptance for org invites
+    # Signup for org invite (consent step happens separately via /accept)
     #
     # POST /api/invite/:token/signup
     #
@@ -27,10 +27,15 @@ module InviteAPI::Logic
     # 3. Checks if email exists in EITHER database -> error with signin hint
     # 4. Validates password meets requirements
     # 5. Creates account in authdb via Rodauth internal_request
-    # 6. Creates Customer in Redis
-    # 7. Creates default workspace
-    # 8. Accepts the invitation (adds user to org)
-    # 9. Auto-logs in the user
+    #    (the after_create_account hook creates the Customer, auto-verifies
+    #    the SQL account, and skips default-workspace creation)
+    # 6. Auto-logs in the user
+    #
+    # The invitation is NOT accepted here — the token survives, and the
+    # frontend completes the join by POSTing to /api/invite/:token/accept
+    # against the session this endpoint just established. This keeps a single
+    # acceptance code path regardless of whether the user signed up fresh
+    # or already had an account.
     #
     class SignupAndAccept < InviteAPI::Logic::Base
       include Onetime::LoggerMethods
@@ -121,27 +126,24 @@ module InviteAPI::Logic
           raise_form_error('Account created but customer record missing', field: :email)
         end
 
-        # Reload the invitation to pick up the acceptance state written by the hook.
-        # NOTE: cannot use find_by_token here — accept! removes the token from
-        # token_lookup (pending-only index, cleared for security). Look up the
-        # now-active membership via org_customer_lookup, which accept! populates.
+        # Reload the invitation via the still-valid token. The after_create_account
+        # hook does not accept the invitation — that's the explicit /accept call
+        # the frontend makes next. The invitation must still be pending here.
         org_objid   = @invitation.organization_objid
-        @invitation = Onetime::OrganizationMembership.find_by_org_customer(
-          org_objid,
-          @customer.objid,
-        )
-        if @invitation.nil? || @invitation.pending?
-          auth_logger.error 'Invitation not accepted by hook',
+        @invitation = Onetime::OrganizationMembership.find_by_token(@token)
+        if @invitation.nil? || !@invitation.pending?
+          auth_logger.error 'Invitation missing or not pending after signup',
             token_prefix: @token[0..7],
             org_objid: org_objid,
-            customer_objid: @customer.objid
-          raise_form_error('Failed to accept invitation', field: :token)
+            customer_objid: @customer.objid,
+            invitation_status: @invitation&.status
+          raise_form_error('Invitation no longer available', field: :token)
         end
 
         setup_session(account_id, account)
 
-        auth_logger.info 'User signed up and joined organization',
-          event: 'invite.signup_accepted',
+        auth_logger.info 'User signed up; invitation pending explicit accept',
+          event: 'invite.signup_pending_accept',
           invitation_id: @invitation.objid,
           organization_id: @invitation.organization.extid,
           user: @customer.obscure_email,
@@ -160,7 +162,7 @@ module InviteAPI::Logic
               display_name: @invitation.organization.display_name,
             },
             role: @invitation.role,
-            joined_at: @invitation.joined_at,
+            invitation_status: @invitation.status,
             auto_login: true,
           },
         }

--- a/apps/api/invite/spec/logic/invites/accept_invite_spec.rb
+++ b/apps/api/invite/spec/logic/invites/accept_invite_spec.rb
@@ -68,11 +68,20 @@ RSpec.describe InviteAPI::Logic::Invites::AcceptInvite do
 
   subject(:logic) { described_class.new(strategy_result, params) }
 
+  # Source uses auth_logger (Onetime.get_logger('Auth')) for its semantic logs,
+  # not the OT.info shim. Stub the Auth logger so .debug/.info/.error during
+  # the spec don't fail the test, and so individual examples can set focused
+  # expectations on it.
+  let(:auth_logger_double) do
+    instance_double(SemanticLogger::Logger, info: nil, debug: nil, warn: nil, error: nil)
+  end
+
   before do
     allow(OT).to receive(:info)
     allow(OT).to receive(:ld)
     allow(OT).to receive(:le)
     allow(OT::Utils).to receive(:normalize_email) { |e| e.to_s.downcase.strip }
+    allow(Onetime).to receive(:get_logger).with('Auth').and_return(auth_logger_double)
   end
 
   describe '#process_params' do
@@ -279,8 +288,8 @@ RSpec.describe InviteAPI::Logic::Invites::AcceptInvite do
       end
 
       it 'logs the acceptance' do
-        expect(OT).to receive(:info).with(
-          '[AcceptInvite] User joined organization',
+        expect(auth_logger_double).to receive(:info).with(
+          'User joined organization',
           hash_including(event: 'invite.accepted', result: :success)
         )
         logic.process

--- a/apps/api/invite/spec/logic/invites/signup_and_accept_spec.rb
+++ b/apps/api/invite/spec/logic/invites/signup_and_accept_spec.rb
@@ -501,6 +501,192 @@ RSpec.describe InviteAPI::Logic::Invites::SignupAndAccept do
     end
   end
 
+  # Regression: GH #3221 — post-acceptance invitation reload must NOT use
+  # find_by_token. The after_create_account hook calls AcceptInvitation, which
+  # calls invitation.accept!, which removes the token from token_lookup
+  # (pending-only index, cleared for security). Reloading via find_by_token
+  # after the hook returns nil → 404 "Invitation not found or expired".
+  #
+  # Correct behavior: reload via find_by_org_customer, which accept! populates
+  # on the now-active membership (org_membership.rb:330-331).
+  describe '#process invitation reload after acceptance' do
+    let(:new_customer) do
+      cust = build_mock_customer(
+        objid: 'cust-new-123',
+        custid: 'cust-new-123',
+        extid: 'ext-new-123',
+        email: invited_email,
+        obscure_email: 'ne***@example.com'
+      )
+      allow(cust).to receive(:role).and_return('customer')
+      allow(cust).to receive(:locale).and_return('en')
+      cust
+    end
+
+    let(:accepted_invitation) do
+      inv = build_mock_invitation(
+        objid: 'inv-active-456',
+        token: nil, # accept! clears the token
+        invited_email: invited_email,
+        role: 'member',
+        organization: organization,
+        organization_objid: 'org-test-123',
+        status: 'active',
+        'pending?' => false,
+        'active?' => true,
+        'expired?' => false
+      )
+      allow(inv).to receive(:joined_at).and_return(Time.now.to_i)
+      inv
+    end
+
+    let(:rate_limiter) { instance_double(Onetime::Security::InviteTokenRateLimiter) }
+
+    let(:account_row) { { id: 123, email: normalized_email, external_id: 'ext-new-123' } }
+
+    before do
+      allow(Onetime::Security::InviteTokenRateLimiter).to receive(:new)
+        .with(client_ip)
+        .and_return(rate_limiter)
+      allow(rate_limiter).to receive(:check!)
+      allow(rate_limiter).to receive(:record_attempt)
+
+      # raise_concerns path: token lookup succeeds (invitation still pending)
+      allow(Onetime::OrganizationMembership).to receive(:find_by_token)
+        .with(invite_token)
+        .and_return(invitation)
+      allow(Onetime::Customer).to receive(:email_exists?)
+        .with(normalized_email)
+        .and_return(false)
+
+      # Rodauth create_account: documented contract returns nil on success.
+      # The after_create_account hook (production: apps/web/auth/config/hooks/
+      # account.rb) handles CreateCustomer + AcceptInvitation + accept!, which
+      # removes the token from token_lookup. We model the hook's side effects
+      # via the Customer.find_by_extid + find_by_org_customer stubs below.
+      allow(Auth::Config).to receive(:create_account).and_return(nil)
+
+      # Sequel dataset double: chains .where(...).where(...).first/any?/update.
+      # raise_concerns calls email_exists_in_authdb? (chained where + .any?);
+      # create_rodauth_account / process call .where(id|email).first.
+      accounts_ds = double('accounts_ds')
+      allow(accounts_ds).to receive(:where).and_return(accounts_ds)
+      allow(accounts_ds).to receive(:first).and_return(account_row)
+      allow(accounts_ds).to receive(:any?).and_return(false)
+      allow(accounts_ds).to receive(:update)
+      allow(Auth::Database).to receive(:connection).and_return(double(:[] => accounts_ds))
+
+      allow(Onetime::Customer).to receive(:find_by_extid)
+        .with('ext-new-123')
+        .and_return(new_customer)
+
+      allow(Auth::Logging).to receive(:log_auth_event)
+      allow(Familia).to receive(:now).and_return(double(to_i: Time.now.to_i, to_f: Time.now.to_f))
+      allow(Familia).to receive(:dbclient).and_return(double(del: true))
+    end
+
+    subject(:logic) { described_class.new(strategy_result, valid_params) }
+
+    context 'when the hook successfully accepted the invitation (happy path)' do
+      before do
+        allow(Onetime::OrganizationMembership).to receive(:find_by_org_customer)
+          .with('org-test-123', 'cust-new-123')
+          .and_return(accepted_invitation)
+        logic.raise_concerns
+      end
+
+      it 'reloads the invitation via org_customer_lookup, not token_lookup' do
+        # Allow the raise_concerns find_by_token call but assert it is not
+        # called during process (token has been removed from token_lookup by
+        # the time the hook returns).
+        expect(Onetime::OrganizationMembership).not_to receive(:find_by_token)
+        expect(Onetime::OrganizationMembership).to receive(:find_by_org_customer)
+          .with('org-test-123', 'cust-new-123')
+          .and_return(accepted_invitation)
+        logic.process
+      end
+
+      it 'returns success data with the accepted invitation state' do
+        result = logic.process
+        expect(result[:record][:auto_login]).to be true
+        expect(result[:record][:role]).to eq('member')
+      end
+    end
+
+    context 'when find_by_org_customer returns nil (hook silently failed)' do
+      # AcceptInvitation rescues StandardError and returns {accepted: false}
+      # instead of raising. The reload is the safety net that converts that
+      # silent failure into a user-visible error.
+      before do
+        allow(Onetime::OrganizationMembership).to receive(:find_by_org_customer)
+          .with('org-test-123', 'cust-new-123')
+          .and_return(nil)
+        logic.raise_concerns
+      end
+
+      it 'raises a form error on the token field' do
+        expect { logic.process }.to raise_error(Onetime::FormError) do |err|
+          expect(err.message).to match(/Failed to accept invitation/)
+          expect(err.field).to eq(:token)
+        end
+      end
+    end
+
+    context 'when find_by_org_customer returns a still-pending invitation' do
+      # Defense-in-depth: even if a row exists, treat non-active as failure.
+      let(:still_pending_invitation) do
+        inv = build_mock_invitation(
+          objid: 'inv-test-123',
+          invited_email: invited_email,
+          role: 'member',
+          organization: organization,
+          organization_objid: 'org-test-123',
+          status: 'pending',
+          'pending?' => true,
+          'active?' => false,
+          'expired?' => false
+        )
+        allow(inv).to receive(:joined_at).and_return(nil)
+        inv
+      end
+
+      before do
+        allow(Onetime::OrganizationMembership).to receive(:find_by_org_customer)
+          .with('org-test-123', 'cust-new-123')
+          .and_return(still_pending_invitation)
+        logic.raise_concerns
+      end
+
+      it 'raises a form error on the token field' do
+        expect { logic.process }.to raise_error(Onetime::FormError, /Failed to accept invitation/)
+      end
+    end
+
+    context 'when find_by_token is called during process (regression guard)' do
+      # The bug: signup_and_accept.rb used to call load_invitation(@token)
+      # after the hook, which delegates to find_by_token. If anyone reintroduces
+      # that pattern, this spec fails — token_lookup has been wiped by accept!.
+      before do
+        allow(Onetime::OrganizationMembership).to receive(:find_by_org_customer)
+          .with('org-test-123', 'cust-new-123')
+          .and_return(accepted_invitation)
+        logic.raise_concerns
+
+        # Simulate the real post-acceptance state: token has been removed from
+        # token_lookup, so any post-process find_by_token call returns nil.
+        allow(Onetime::OrganizationMembership).to receive(:find_by_token)
+          .with(invite_token)
+          .and_return(nil)
+      end
+
+      it 'completes successfully even when find_by_token would return nil' do
+        # If process ever calls find_by_token again, load_invitation raises
+        # Onetime::RecordNotFound and this expectation fails.
+        expect { logic.process }.not_to raise_error
+      end
+    end
+  end
+
   # Integration-style tests (require full app boot with Valkey)
   describe 'integration behavior', type: :integration do
     # These tests use ProductionConfigHelper and require:

--- a/apps/api/invite/spec/logic/invites/signup_and_accept_spec.rb
+++ b/apps/api/invite/spec/logic/invites/signup_and_accept_spec.rb
@@ -422,13 +422,13 @@ RSpec.describe InviteAPI::Logic::Invites::SignupAndAccept do
       it 'returns success data with record wrapper' do
         result = logic.process
         expect(result).to have_key(:record)
-        expect(result[:record]).to include(:user_id, :organization, :role, :joined_at, :auto_login)
+        expect(result[:record]).to include(:user_id, :organization, :role, :invitation_status, :auto_login)
       end
 
-      it 'logs the signup event' do
+      it 'logs the pending-accept signup event' do
         expect(OT).to receive(:info).with(
-          '[SignupAndAccept] User signed up and joined organization',
-          hash_including(event: 'invite.signup_accepted', result: :success)
+          '[SignupAndAccept] User signed up; invitation pending explicit accept',
+          hash_including(event: 'invite.signup_pending_accept', result: :success)
         )
         logic.process
       end
@@ -490,9 +490,10 @@ RSpec.describe InviteAPI::Logic::Invites::SignupAndAccept do
       expect(data[:record][:role]).to eq('member')
     end
 
-    it 'returns joined_at timestamp' do
+    it 'returns the invitation status (pending until the explicit /accept call)' do
+      allow(invitation).to receive(:status).and_return('pending')
       data = logic.success_data
-      expect(data[:record]).to have_key(:joined_at)
+      expect(data[:record][:invitation_status]).to eq('pending')
     end
 
     it 'includes auto_login flag' do
@@ -501,15 +502,12 @@ RSpec.describe InviteAPI::Logic::Invites::SignupAndAccept do
     end
   end
 
-  # Regression: GH #3221 — post-acceptance invitation reload must NOT use
-  # find_by_token. The after_create_account hook calls AcceptInvitation, which
-  # calls invitation.accept!, which removes the token from token_lookup
-  # (pending-only index, cleared for security). Reloading via find_by_token
-  # after the hook returns nil → 404 "Invitation not found or expired".
-  #
-  # Correct behavior: reload via find_by_org_customer, which accept! populates
-  # on the now-active membership (org_membership.rb:330-331).
-  describe '#process invitation reload after acceptance' do
+  # GH #3221 — the after_create_account hook leaves the invitation in pending
+  # state. SignupAndAccept reloads via find_by_token (still valid post-signup)
+  # and asserts the invitation has NOT been accepted yet — the frontend
+  # completes the join via an explicit POST /api/invite/:token/accept against
+  # the session this endpoint just established.
+  describe '#process invitation reload after signup' do
     let(:new_customer) do
       cust = build_mock_customer(
         objid: 'cust-new-123',
@@ -523,23 +521,6 @@ RSpec.describe InviteAPI::Logic::Invites::SignupAndAccept do
       cust
     end
 
-    let(:accepted_invitation) do
-      inv = build_mock_invitation(
-        objid: 'inv-active-456',
-        token: nil, # accept! clears the token
-        invited_email: invited_email,
-        role: 'member',
-        organization: organization,
-        organization_objid: 'org-test-123',
-        status: 'active',
-        'pending?' => false,
-        'active?' => true,
-        'expired?' => false
-      )
-      allow(inv).to receive(:joined_at).and_return(Time.now.to_i)
-      inv
-    end
-
     let(:rate_limiter) { instance_double(Onetime::Security::InviteTokenRateLimiter) }
 
     let(:account_row) { { id: 123, email: normalized_email, external_id: 'ext-new-123' } }
@@ -551,7 +532,7 @@ RSpec.describe InviteAPI::Logic::Invites::SignupAndAccept do
       allow(rate_limiter).to receive(:check!)
       allow(rate_limiter).to receive(:record_attempt)
 
-      # raise_concerns path: token lookup succeeds (invitation still pending)
+      # raise_concerns and post-signup reload both go through find_by_token.
       allow(Onetime::OrganizationMembership).to receive(:find_by_token)
         .with(invite_token)
         .and_return(invitation)
@@ -559,16 +540,13 @@ RSpec.describe InviteAPI::Logic::Invites::SignupAndAccept do
         .with(normalized_email)
         .and_return(false)
 
-      # Rodauth create_account: documented contract returns nil on success.
-      # The after_create_account hook (production: apps/web/auth/config/hooks/
-      # account.rb) handles CreateCustomer + AcceptInvitation + accept!, which
-      # removes the token from token_lookup. We model the hook's side effects
-      # via the Customer.find_by_extid + find_by_org_customer stubs below.
+      # Rodauth create_account returns nil on success. The real hook chain
+      # (apps/web/auth/config/hooks/account.rb) creates the customer and
+      # auto-verifies the SQL account but does NOT call accept! — the
+      # invitation stays pending. We model that here.
       allow(Auth::Config).to receive(:create_account).and_return(nil)
 
-      # Sequel dataset double: chains .where(...).where(...).first/any?/update.
-      # raise_concerns calls email_exists_in_authdb? (chained where + .any?);
-      # create_rodauth_account / process call .where(id|email).first.
+      # Sequel dataset double for accounts table operations.
       accounts_ds = double('accounts_ds')
       allow(accounts_ds).to receive(:where).and_return(accounts_ds)
       allow(accounts_ds).to receive(:first).and_return(account_row)
@@ -587,102 +565,75 @@ RSpec.describe InviteAPI::Logic::Invites::SignupAndAccept do
 
     subject(:logic) { described_class.new(strategy_result, valid_params) }
 
-    context 'when the hook successfully accepted the invitation (happy path)' do
+    context 'when the hook leaves the invitation pending (happy path)' do
       before do
-        allow(Onetime::OrganizationMembership).to receive(:find_by_org_customer)
-          .with('org-test-123', 'cust-new-123')
-          .and_return(accepted_invitation)
         logic.raise_concerns
       end
 
-      it 'reloads the invitation via org_customer_lookup, not token_lookup' do
-        # Allow the raise_concerns find_by_token call but assert it is not
-        # called during process (token has been removed from token_lookup by
-        # the time the hook returns).
-        expect(Onetime::OrganizationMembership).not_to receive(:find_by_token)
-        expect(Onetime::OrganizationMembership).to receive(:find_by_org_customer)
-          .with('org-test-123', 'cust-new-123')
-          .and_return(accepted_invitation)
+      it 'reloads the still-pending invitation via find_by_token' do
+        expect(Onetime::OrganizationMembership).to receive(:find_by_token)
+          .with(invite_token)
+          .at_least(:once)
+          .and_return(invitation)
+        expect(Onetime::OrganizationMembership).not_to receive(:find_by_org_customer)
         logic.process
       end
 
-      it 'returns success data with the accepted invitation state' do
+      it 'returns success data carrying the pending invitation status' do
+        allow(invitation).to receive(:status).and_return('pending')
         result = logic.process
         expect(result[:record][:auto_login]).to be true
         expect(result[:record][:role]).to eq('member')
+        expect(result[:record][:invitation_status]).to eq('pending')
       end
     end
 
-    context 'when find_by_org_customer returns nil (hook silently failed)' do
-      # AcceptInvitation rescues StandardError and returns {accepted: false}
-      # instead of raising. The reload is the safety net that converts that
-      # silent failure into a user-visible error.
+    context 'when find_by_token returns nil after signup' do
+      # Defensive: if anything wiped token_lookup mid-flight (cache flush,
+      # operator action, concurrent revoke), surface a user-visible error
+      # rather than handing back a half-baked success.
       before do
-        allow(Onetime::OrganizationMembership).to receive(:find_by_org_customer)
-          .with('org-test-123', 'cust-new-123')
-          .and_return(nil)
+        allow(Onetime::OrganizationMembership).to receive(:find_by_token)
+          .with(invite_token)
+          .and_return(invitation, nil)
         logic.raise_concerns
       end
 
       it 'raises a form error on the token field' do
         expect { logic.process }.to raise_error(Onetime::FormError) do |err|
-          expect(err.message).to match(/Failed to accept invitation/)
+          expect(err.message).to match(/Invitation no longer available/)
           expect(err.field).to eq(:token)
         end
       end
     end
 
-    context 'when find_by_org_customer returns a still-pending invitation' do
-      # Defense-in-depth: even if a row exists, treat non-active as failure.
-      let(:still_pending_invitation) do
+    context 'when find_by_token returns a non-pending invitation' do
+      let(:active_invitation) do
         inv = build_mock_invitation(
-          objid: 'inv-test-123',
+          objid: 'inv-active-789',
+          token: nil,
           invited_email: invited_email,
           role: 'member',
           organization: organization,
           organization_objid: 'org-test-123',
-          status: 'pending',
-          'pending?' => true,
-          'active?' => false,
+          status: 'active',
+          'pending?' => false,
+          'active?' => true,
           'expired?' => false
         )
-        allow(inv).to receive(:joined_at).and_return(nil)
+        allow(inv).to receive(:joined_at).and_return(Time.now.to_i)
         inv
       end
 
       before do
-        allow(Onetime::OrganizationMembership).to receive(:find_by_org_customer)
-          .with('org-test-123', 'cust-new-123')
-          .and_return(still_pending_invitation)
+        allow(Onetime::OrganizationMembership).to receive(:find_by_token)
+          .with(invite_token)
+          .and_return(invitation, active_invitation)
         logic.raise_concerns
       end
 
       it 'raises a form error on the token field' do
-        expect { logic.process }.to raise_error(Onetime::FormError, /Failed to accept invitation/)
-      end
-    end
-
-    context 'when find_by_token is called during process (regression guard)' do
-      # The bug: signup_and_accept.rb used to call load_invitation(@token)
-      # after the hook, which delegates to find_by_token. If anyone reintroduces
-      # that pattern, this spec fails — token_lookup has been wiped by accept!.
-      before do
-        allow(Onetime::OrganizationMembership).to receive(:find_by_org_customer)
-          .with('org-test-123', 'cust-new-123')
-          .and_return(accepted_invitation)
-        logic.raise_concerns
-
-        # Simulate the real post-acceptance state: token has been removed from
-        # token_lookup, so any post-process find_by_token call returns nil.
-        allow(Onetime::OrganizationMembership).to receive(:find_by_token)
-          .with(invite_token)
-          .and_return(nil)
-      end
-
-      it 'completes successfully even when find_by_token would return nil' do
-        # If process ever calls find_by_token again, load_invitation raises
-        # Onetime::RecordNotFound and this expectation fails.
-        expect { logic.process }.not_to raise_error
+        expect { logic.process }.to raise_error(Onetime::FormError, /Invitation no longer available/)
       end
     end
   end

--- a/apps/api/invite/spec/logic/invites/signup_and_accept_spec.rb
+++ b/apps/api/invite/spec/logic/invites/signup_and_accept_spec.rb
@@ -82,6 +82,14 @@ RSpec.describe InviteAPI::Logic::Invites::SignupAndAccept do
     db
   end
 
+  # Source uses auth_logger (Onetime.get_logger('Auth')) for its semantic logs,
+  # not the OT.info shim. Stub the Auth logger so .debug/.info/.error during
+  # the spec don't fail the test, and so individual examples can set focused
+  # expectations on it.
+  let(:auth_logger_double) do
+    instance_double(SemanticLogger::Logger, info: nil, debug: nil, warn: nil, error: nil)
+  end
+
   before do
     allow(OT).to receive(:info)
     allow(OT).to receive(:ld)
@@ -89,6 +97,7 @@ RSpec.describe InviteAPI::Logic::Invites::SignupAndAccept do
     allow(OT::Utils).to receive(:normalize_email).and_return(normalized_email)
     allow(OT::Utils).to receive(:obscure_email).and_return('ne***@example.com')
     allow(Auth::Database).to receive(:connection).and_return(mock_auth_db)
+    allow(Onetime).to receive(:get_logger).with('Auth').and_return(auth_logger_double)
   end
 
   describe '#process_params' do
@@ -314,150 +323,14 @@ RSpec.describe InviteAPI::Logic::Invites::SignupAndAccept do
     end
   end
 
-  describe '#process' do
-    let(:new_customer) do
-      cust = build_mock_customer(
-        objid: 'cust-new-123',
-        custid: 'cust-new-123',
-        extid: 'ext-new-123',
-        email: invited_email,
-        obscure_email: 'ne***@example.com'
-      )
-      allow(cust).to receive(:role).and_return('customer')
-      allow(cust).to receive(:locale).and_return('en')
-      cust
-    end
-
-    let(:rate_limiter) { instance_double(Onetime::Security::InviteTokenRateLimiter) }
-
-    before do
-      allow(Onetime::Security::InviteTokenRateLimiter).to receive(:new)
-        .with(client_ip)
-        .and_return(rate_limiter)
-      allow(rate_limiter).to receive(:check!)
-      allow(rate_limiter).to receive(:record_attempt)
-
-      allow(Onetime::OrganizationMembership).to receive(:find_by_token)
-        .with(invite_token)
-        .and_return(invitation)
-      allow(Onetime::Customer).to receive(:email_exists?)
-        .with(normalized_email)
-        .and_return(false)
-
-      # Mock account creation via Rodauth internal_request
-      allow(Auth::Config).to receive(:create_account).and_return(123)
-
-      # Mock CreateCustomer operation
-      create_customer_op = instance_double(Auth::Operations::CreateCustomer)
-      allow(Auth::Operations::CreateCustomer).to receive(:new).and_return(create_customer_op)
-      allow(create_customer_op).to receive(:call).and_return(new_customer)
-
-      # Mock CreateDefaultWorkspace operation
-      workspace_op = instance_double(Auth::Operations::CreateDefaultWorkspace)
-      allow(Auth::Operations::CreateDefaultWorkspace).to receive(:new).and_return(workspace_op)
-      allow(workspace_op).to receive(:call)
-
-      # Mock AcceptInvitation operation
-      accept_op = instance_double(Auth::Operations::AcceptInvitation)
-      allow(Auth::Operations::AcceptInvitation).to receive(:new).and_return(accept_op)
-      allow(accept_op).to receive(:call).and_return({ accepted: true, organization_id: 'org-test-123', role: 'member' })
-
-      # Mock logging
-      allow(Auth::Logging).to receive(:log_auth_event)
-      allow(Familia).to receive(:now).and_return(double(to_i: Time.now.to_i))
-      allow(Familia).to receive(:dbclient).and_return(double(del: true))
-    end
-
-    subject(:logic) { described_class.new(strategy_result, valid_params) }
-
-    context 'with valid request (happy path)' do
-      before do
-        logic.raise_concerns
-      end
-
-      it 'creates Rodauth account via internal_request' do
-        expect(Auth::Config).to receive(:create_account).with(
-          login: normalized_email,
-          password: valid_password
-        )
-        logic.process
-      end
-
-      it 'creates Customer in Redis' do
-        expect(Auth::Operations::CreateCustomer).to receive(:new).with(
-          account_id: 123,
-          account: hash_including(id: 123, email: normalized_email),
-          db: mock_auth_db
-        )
-        logic.process
-      end
-
-      it 'creates default workspace' do
-        expect(Auth::Operations::CreateDefaultWorkspace).to receive(:new)
-          .with(customer: new_customer)
-        logic.process
-      end
-
-      it 'accepts the invitation' do
-        expect(Auth::Operations::AcceptInvitation).to receive(:new).with(
-          customer: new_customer,
-          token: invite_token
-        )
-        logic.process
-      end
-
-      it 'marks account as verified in authdb' do
-        accounts_ds = mock_auth_db[:accounts]
-        expect(accounts_ds).to receive(:where).with(id: 123).and_return(accounts_ds)
-        expect(accounts_ds).to receive(:update).with(status_id: 2)
-        logic.process
-      end
-
-      it 'sets up session for auto-login' do
-        logic.process
-        expect(session['authenticated']).to be true
-        expect(session['external_id']).to eq('ext-new-123')
-      end
-
-      it 'returns success data with record wrapper' do
-        result = logic.process
-        expect(result).to have_key(:record)
-        expect(result[:record]).to include(:user_id, :organization, :role, :invitation_status, :auto_login)
-      end
-
-      it 'logs the pending-accept signup event' do
-        expect(OT).to receive(:info).with(
-          '[SignupAndAccept] User signed up; invitation pending explicit accept',
-          hash_including(event: 'invite.signup_pending_accept', result: :success)
-        )
-        logic.process
-      end
-    end
-
-    context 'when Rodauth account creation fails' do
-      before do
-        logic.raise_concerns
-        allow(Auth::Config).to receive(:create_account).and_return(nil)
-      end
-
-      it 'raises form error' do
-        expect { logic.process }.to raise_error(Onetime::FormError, /Failed to create account/)
-      end
-    end
-
-    context 'when invitation acceptance fails' do
-      before do
-        logic.raise_concerns
-        accept_op = instance_double(Auth::Operations::AcceptInvitation)
-        allow(Auth::Operations::AcceptInvitation).to receive(:new).and_return(accept_op)
-        allow(accept_op).to receive(:call).and_return({ accepted: false, reason: 'error' })
-      end
-
-      it 'raises form error' do
-        expect { logic.process }.to raise_error(Onetime::FormError, /Failed to accept invitation/)
-      end
-    end
-  end
+  # NOTE: The historical "#process" describe block tested an obsolete contract
+  # where this logic class directly invoked Auth::Operations::CreateCustomer /
+  # CreateDefaultWorkspace / AcceptInvitation. The current source (#3221)
+  # delegates Customer/workspace creation to Rodauth's after_create_account
+  # hook (apps/web/auth/config/hooks/account.rb) and reserves invitation
+  # acceptance for a separate explicit /accept call. The current contract is
+  # covered by "#process invitation reload after signup" below; see also the
+  # success_data block.
 
   describe '#success_data' do
     let(:new_customer) do
@@ -525,6 +398,18 @@ RSpec.describe InviteAPI::Logic::Invites::SignupAndAccept do
 
     let(:account_row) { { id: 123, email: normalized_email, external_id: 'ext-new-123' } }
 
+    # Sequel dataset double for accounts table operations. Exposed as a let
+    # so individual contexts can override .first to exercise error branches
+    # (e.g. account row missing after create_account).
+    let(:accounts_ds) do
+      ds = double('accounts_ds')
+      allow(ds).to receive(:where).and_return(ds)
+      allow(ds).to receive(:first).and_return(account_row)
+      allow(ds).to receive(:any?).and_return(false)
+      allow(ds).to receive(:update)
+      ds
+    end
+
     before do
       allow(Onetime::Security::InviteTokenRateLimiter).to receive(:new)
         .with(client_ip)
@@ -546,12 +431,6 @@ RSpec.describe InviteAPI::Logic::Invites::SignupAndAccept do
       # invitation stays pending. We model that here.
       allow(Auth::Config).to receive(:create_account).and_return(nil)
 
-      # Sequel dataset double for accounts table operations.
-      accounts_ds = double('accounts_ds')
-      allow(accounts_ds).to receive(:where).and_return(accounts_ds)
-      allow(accounts_ds).to receive(:first).and_return(account_row)
-      allow(accounts_ds).to receive(:any?).and_return(false)
-      allow(accounts_ds).to receive(:update)
       allow(Auth::Database).to receive(:connection).and_return(double(:[] => accounts_ds))
 
       allow(Onetime::Customer).to receive(:find_by_extid)
@@ -585,6 +464,51 @@ RSpec.describe InviteAPI::Logic::Invites::SignupAndAccept do
         expect(result[:record][:auto_login]).to be true
         expect(result[:record][:role]).to eq('member')
         expect(result[:record][:invitation_status]).to eq('pending')
+      end
+
+      it 'creates the Rodauth account via internal_request with the invite_token' do
+        expect(Auth::Config).to receive(:create_account).with(
+          login: normalized_email,
+          password: valid_password,
+          params: { 'invite_token' => invite_token }
+        )
+        logic.process
+      end
+
+      it 'returns success_data with the expected record wrapper keys' do
+        result = logic.process
+        expect(result).to have_key(:record)
+        expect(result[:record]).to include(:user_id, :organization, :role, :invitation_status, :auto_login)
+      end
+
+      it 'sets up the session for auto-login' do
+        logic.process
+        expect(session['authenticated']).to be true
+        expect(session['external_id']).to eq('ext-new-123')
+        expect(session['account_id']).to eq(123)
+      end
+
+      it 'logs the pending-accept signup event on the auth logger' do
+        expect(auth_logger_double).to receive(:info).with(
+          'User signed up; invitation pending explicit accept',
+          hash_including(event: 'invite.signup_pending_accept', result: :success)
+        )
+        logic.process
+      end
+    end
+
+    context 'when the account row is missing after create_account' do
+      # Mirrors signup_and_accept.rb:228 — create_account succeeded with no
+      # error, but the followup .where(email: ...).first lookup returns nil.
+      # We trigger this by stubbing .first to nil so the account branch raises
+      # before the customer-missing branch (which has its own assertion).
+      before do
+        allow(accounts_ds).to receive(:first).and_return(nil)
+        logic.raise_concerns
+      end
+
+      it 'raises a form error indicating account creation failed' do
+        expect { logic.process }.to raise_error(Onetime::FormError, /Failed to create account/)
       end
     end
 

--- a/apps/api/invite/spec/spec_helper.rb
+++ b/apps/api/invite/spec/spec_helper.rb
@@ -29,8 +29,9 @@ module Auth
   end
 
   module Config
-    def self.create_account(login:, password:)
-      # Return mock account_id
+    def self.create_account(login:, password:, params: {})
+      # Return mock account_id. Real Rodauth internal_request returns nil on
+      # success; tests that exercise that contract should override this stub.
       12345
     end
   end

--- a/apps/api/organizations/logic/invitations/create_invitation.rb
+++ b/apps/api/organizations/logic/invitations/create_invitation.rb
@@ -34,26 +34,26 @@ module OrganizationAPI::Logic
 
         # Validate email (basic validation before quota check)
         if @email.empty?
-          raise_form_error(error_key: 'api.organizations.invitations.errors.email_required', field: 'email')
+          raise_form_error(error_key: 'api.organizations.invitations.errors.email_required', field: 'email', error_type: :missing)
         end
         unless valid_email?(@email)
-          raise_form_error(error_key: 'api.organizations.invitations.errors.invalid_email_format', field: 'email')
+          raise_form_error(error_key: 'api.organizations.invitations.errors.invalid_email_format', field: 'email', error_type: :invalid)
         end
 
         # Validate role
         unless %w[member admin].include?(@role)
-          raise_form_error(error_key: 'api.organizations.invitations.errors.invalid_role', field: 'role')
+          raise_form_error(error_key: 'api.organizations.invitations.errors.invalid_role', field: 'role', error_type: :invalid)
         end
 
         # Owners cannot be invited (must be assigned directly)
         if @role == 'owner'
-          raise_form_error(error_key: 'api.organizations.invitations.errors.cannot_invite_as_owner', field: 'role')
+          raise_form_error(error_key: 'api.organizations.invitations.errors.cannot_invite_as_owner', field: 'role', error_type: :forbidden)
         end
 
         # Check if user is already a member
         existing_customer = Onetime::Customer.find_by_email(@email)
         if existing_customer && @organization.member?(existing_customer)
-          raise_form_error(error_key: 'api.organizations.invitations.errors.user_already_member', field: 'email')
+          raise_form_error(error_key: 'api.organizations.invitations.errors.user_already_member', field: 'email', error_type: :exists)
         end
 
         # Check for existing pending invitation
@@ -61,7 +61,7 @@ module OrganizationAPI::Logic
           @organization.objid, @email
         )
         if existing_invite&.pending?
-          raise_form_error(error_key: 'api.organizations.invitations.errors.invitation_already_pending', field: 'email')
+          raise_form_error(error_key: 'api.organizations.invitations.errors.invitation_already_pending', field: 'email', error_type: :exists)
         end
 
         # Check member quota AFTER basic validation

--- a/apps/api/organizations/logic/invitations/resend_invitation.rb
+++ b/apps/api/organizations/logic/invitations/resend_invitation.rb
@@ -43,7 +43,7 @@ module OrganizationAPI::Logic
 
         # Can only resend pending invitations
         unless @invitation.pending?
-          raise_form_error(error_key: 'api.organizations.invitations.errors.resend_only_pending', field: :token)
+          raise_form_error(error_key: 'api.organizations.invitations.errors.resend_only_pending', field: :token, error_type: :invalid)
         end
 
         # Rate limit resends

--- a/apps/api/organizations/logic/invitations/revoke_invitation.rb
+++ b/apps/api/organizations/logic/invitations/revoke_invitation.rb
@@ -40,7 +40,7 @@ module OrganizationAPI::Logic
 
         # Can only revoke pending invitations
         unless @invitation.pending?
-          raise_form_error(error_key: 'api.organizations.invitations.errors.revoke_only_pending', field: :token)
+          raise_form_error(error_key: 'api.organizations.invitations.errors.revoke_only_pending', field: :token, error_type: :invalid)
         end
       end
 

--- a/apps/api/organizations/logic/members/update_member_role.rb
+++ b/apps/api/organizations/logic/members/update_member_role.rb
@@ -96,8 +96,10 @@ module OrganizationAPI::Logic
       def load_member(extid)
         member = Onetime::Customer.find_by_extid(extid)
         if member.nil?
-          raise_not_found(error_key: 'api.organizations.members.errors.member_not_found',
-                          args: { extid: extid })
+          raise_not_found(
+            error_key: 'api.organizations.members.errors.member_not_found',
+            args: { extid: extid },
+          )
         end
         member
       end
@@ -112,7 +114,7 @@ module OrganizationAPI::Logic
           raise_not_found(error_key: 'api.organizations.members.errors.member_not_in_organization')
         end
         unless membership.active?
-          raise_form_error(error_key: 'api.organizations.members.errors.member_not_active')
+          raise_form_error(error_key: 'api.organizations.members.errors.member_not_active', error_type: :invalid)
         end
         membership
       end
@@ -125,6 +127,7 @@ module OrganizationAPI::Logic
             error_key: 'api.organizations.members.errors.invalid_role_value',
             args: { roles: VALID_ROLES.join(', ') },
             field: :role,
+            error_type: :invalid,
           )
         end
 
@@ -133,6 +136,7 @@ module OrganizationAPI::Logic
           raise_form_error(
             error_key: 'api.organizations.members.errors.cannot_change_owner_role',
             field: :role,
+            error_type: :forbidden,
           )
         end
 
@@ -142,6 +146,7 @@ module OrganizationAPI::Logic
             error_key: 'api.organizations.members.errors.member_already_has_role',
             args: { role: @new_role },
             field: :role,
+            error_type: :conflict,
           )
         end
 
@@ -151,6 +156,7 @@ module OrganizationAPI::Logic
         raise_form_error(
           error_key: 'api.organizations.members.errors.cannot_promote_to_owner',
           field: :role,
+          error_type: :forbidden,
         )
       end
     end

--- a/apps/api/v2/logic/secrets/conceal_secret.rb
+++ b/apps/api/v2/logic/secrets/conceal_secret.rb
@@ -26,7 +26,7 @@ module V2::Logic
       def raise_concerns
         require_guest_route_enabled!(:conceal)
         super
-        raise_form_error 'You did not provide anything to share' if secret_value.to_s.empty?
+        raise_form_error 'You did not provide anything to share', field: :secret, error_type: :missing if secret_value.to_s.empty?
       end
     end
   end

--- a/apps/api/v2/spec/logic/secrets/base_secret_action_spec.rb
+++ b/apps/api/v2/spec/logic/secrets/base_secret_action_spec.rb
@@ -244,8 +244,8 @@ RSpec.describe 'V2 BaseSecretAction config path bug' do
         expect { subject.send(:validate_domain_permissions, domain_record) }
           .to raise_error(Onetime::Forbidden) do |error|
             expect(error.to_h).to include(
-              error: 'Forbidden',
-              message: "You do not have permission to use domain: #{share_domain}",
+              error: "You do not have permission to use domain: #{share_domain}",
+              error_type: 'Forbidden',
               error_key: 'api.secrets.errors.domain_permission_authenticated_non_owner',
             )
           end
@@ -287,8 +287,8 @@ RSpec.describe 'V2 BaseSecretAction config path bug' do
         expect { subject.send(:validate_domain_permissions, domain_record) }
           .to raise_error(Onetime::Forbidden) do |error|
             expect(error.to_h).to include(
-              error: 'Forbidden',
-              message: "Public sharing disabled for domain: #{share_domain}",
+              error: "Public sharing disabled for domain: #{share_domain}",
+              error_type: 'Forbidden',
               error_key: 'api.secrets.errors.domain_public_sharing_disabled',
             )
           end
@@ -330,8 +330,8 @@ RSpec.describe 'V2 BaseSecretAction config path bug' do
         expect { subject.send(:validate_domain_permissions, domain_record) }
           .to raise_error(Onetime::Forbidden) do |error|
             expect(error.to_h).to include(
-              error: 'Forbidden',
-              message: "You do not have permission to use domain: #{share_domain}",
+              error: "You do not have permission to use domain: #{share_domain}",
+              error_type: 'Forbidden',
               error_key: 'api.secrets.errors.domain_permission_anonymous_cross_domain',
             )
           end

--- a/apps/web/auth/config/features/account_management.rb
+++ b/apps/web/auth/config/features/account_management.rb
@@ -40,7 +40,10 @@ module Auth::Config::Features
         # would let an attacker add invite_token=garbage to suppress the email
         # for any signup, enabling email squatting.
         auth.send_verify_account_email do
-          invite_token = request.params['invite_token'].to_s.strip
+          # Use Rodauth's `param` rather than `request.params['invite_token']` so
+          # this works under internal_request too (internal_request only populates
+          # rodauth.params, not the Rack request body).
+          invite_token = param_or_nil('invite_token').to_s.strip
           if invite_token.empty?
             super()
           else

--- a/apps/web/auth/config/features/account_management.rb
+++ b/apps/web/auth/config/features/account_management.rb
@@ -30,11 +30,12 @@ module Auth::Config::Features
         # Suppress verification email only for valid invite signups.
         # The invite link proves email ownership, so no extra verification needed.
         #
-        # HOOK ORDERING: verify_account's after_create_account calls
-        # setup_account_verification (which calls send_verify_account_email)
-        # BEFORE the user's after_create_account block runs. This means the
-        # token has NOT yet been consumed by AcceptInvitation when this code
-        # executes, so find_by_token correctly finds it.
+        # As of issue #3221's fix, the invitation token is no longer consumed
+        # by the after_create_account hook — acceptance happens via the explicit
+        # POST /api/invite/:token/accept call the frontend issues against the
+        # established session. find_by_token therefore continues to resolve the
+        # invitation across the entire signup lifecycle (before/during/after
+        # account creation).
         #
         # SECURITY: Token must be validated here — checking the raw param alone
         # would let an attacker add invite_token=garbage to suppress the email

--- a/apps/web/auth/config/hooks/account.rb
+++ b/apps/web/auth/config/hooks/account.rb
@@ -83,6 +83,42 @@ module Auth::Config::Hooks
           request.env['rodauth.error_flash'] = create_account_error_flash
           throw_rodauth_error
         end
+
+        # When an invite_token is supplied, validate the invitation up front:
+        # invitation exists, still pending, not expired, and the signup email
+        # matches the invited email. Failing precondition checks here aborts
+        # before any account/customer row is written, so we never roll back
+        # partial Redis state on email-mismatch or expired tokens.
+        invite_token = param_or_nil('invite_token').to_s.strip
+        unless invite_token.empty?
+          invitation = Onetime::OrganizationMembership.find_by_token(invite_token)
+
+          invalid_reason =
+            if invitation.nil?
+              'token_not_found'
+            elsif !invitation.pending?
+              'not_pending'
+            elsif invitation.expired?
+              'expired'
+            elsif OT::Utils.normalize_email(email) !=
+                  OT::Utils.normalize_email(invitation.invited_email)
+              'email_mismatch'
+            end
+
+          if invalid_reason
+            Auth::Logging.log_auth_event(
+              :registration_blocked_invalid_invite,
+              level: :warn,
+              email: OT::Utils.obscure_email(email),
+              invite_token_prefix: invite_token[0..7],
+              reason: invalid_reason,
+            )
+
+            set_error_flash(create_account_error_flash)
+            request.env['rodauth.error_flash'] = create_account_error_flash
+            throw_rodauth_error
+          end
+        end
       end
 
       # When this is part of a regular user signup flow, we'll have already
@@ -138,14 +174,56 @@ module Auth::Config::Hooks
           ).call
         end
 
-        # Create default organization and team for the new customer
-        # Note: These are hidden from individual plan users in the UI
         if customer.is_a?(Onetime::Customer)
-          Onetime::ErrorHandler.safe_execute('create_default_workspace', extid: customer.extid) do
-            Auth::Operations::CreateDefaultWorkspace.new(customer: customer).call
+          invite_token  = hook_invite_token
+          invite_signup = !invite_token.empty?
+
+          if invite_signup
+            # Invite signup: skip default workspace creation. The user is joining
+            # an existing org via the explicit POST /api/invite/:token/accept
+            # call that follows signup. A personal default workspace would be
+            # dead state they never use.
+            #
+            # Auto-verify at both the Redis (customer) and SQL (account) layers.
+            # The invite link itself proves email ownership — before_create_account
+            # already validated the token and that the signup email matches the
+            # invited email, so we can mark the customer verified here without
+            # a separate email round-trip.
+            Onetime::ErrorHandler.safe_execute('auto_verify_invite_signup', extid: customer.extid) do
+              customer.verified    = true
+              customer.verified_by = 'invite_token'
+              customer.save
+
+              update_account(account_status_column => account_open_status_value)
+
+              had_verify_key = respond_to?(:remove_verify_account_key)
+              remove_verify_account_key if had_verify_key
+
+              # Signal to create_account_autologin? that this is an invite signup.
+              # The user gets a session immediately so the frontend can POST to
+              # /api/invite/:token/accept with the active cookie. The token is
+              # NOT consumed here — that's the point of the explicit accept step.
+              @invite_accepted = true
+
+              Auth::Logging.log_auth_event(
+                :invite_signup_verified,
+                level: :info,
+                email: customer.email,
+                account_id: account_id,
+                invite_token_prefix: invite_token[0..7],
+                verify_key_removed: had_verify_key,
+                autologin_flag_set: true,
+              )
+            end
+          else
+            # Standard signup: provision the default organization and team so
+            # the user has a workspace to land in after email verification.
+            Onetime::ErrorHandler.safe_execute('create_default_workspace', extid: customer.extid) do
+              Auth::Operations::CreateDefaultWorkspace.new(customer: customer).call
+            end
           end
 
-          # Capture plan intent for email verification flow (issue #3126)
+          # Capture plan intent for email verification flow (issue #3126).
           # Session-based billing redirect doesn't survive email verification, so we
           # persist the plan selection on the Customer record with a 24h TTL.
           product  = request.params['product']
@@ -168,59 +246,6 @@ module Auth::Config::Hooks
               product: product,
               interval: interval,
             )
-          end
-
-          # Accept pending invitation if token provided in signup request.
-          # Uses the same internal_request-safe token captured above.
-          invite_token = hook_invite_token
-          unless invite_token.empty?
-            Auth::Logging.log_auth_event(
-              :invite_acceptance_started,
-              level: :debug,
-              email: customer.email,
-              account_id: account_id,
-              invite_token_prefix: invite_token.to_s[0..7],
-            )
-
-            Onetime::ErrorHandler.safe_execute('accept_invitation', token: invite_token) do
-              result = Auth::Operations::AcceptInvitation.new(
-                customer: customer,
-                token: invite_token,
-              ).call
-
-              if result[:accepted]
-                # Auto-verify at SQL level — invite link proves email ownership
-                update_account(account_status_column => account_open_status_value)
-                # Remove verification key — clean up the key row
-                had_verify_key = respond_to?(:remove_verify_account_key)
-                remove_verify_account_key if had_verify_key
-
-                # Signal to create_account_autologin? that this signup has a verified invite.
-                # Set AFTER DB operations so autologin only fires if verification succeeded.
-                @invite_accepted = true
-
-                Auth::Logging.log_auth_event(
-                  :invitation_accepted,
-                  level: :info,
-                  email: customer.email,
-                  account_id: account_id,
-                  organization_id: result[:organization_id],
-                  role: result[:role],
-                  account_auto_verified: true,
-                  verify_key_removed: had_verify_key,
-                  autologin_flag_set: true,
-                )
-              else
-                Auth::Logging.log_auth_event(
-                  :invitation_not_accepted,
-                  level: :warn,
-                  email: customer.email,
-                  account_id: account_id,
-                  reason: result[:reason],
-                  invite_token_prefix: invite_token.to_s[0..7],
-                )
-              end
-            end
           end
         end
       end

--- a/apps/web/auth/config/hooks/account.rb
+++ b/apps/web/auth/config/hooks/account.rb
@@ -4,6 +4,7 @@
 
 module Auth::Config::Hooks
   module Account
+    # rubocop:disable Metrics/PerceivedComplexity
     def self.configure(auth)
       #
       # Hook: Before Account Creation
@@ -112,9 +113,14 @@ module Auth::Config::Hooks
       # and creates a default organization and team for the new user.
       #
       auth.after_create_account do
+        # Read via Rodauth's `param_or_nil` so this hook works under both
+        # normal HTTP requests and `internal_request` (which only populates
+        # rodauth.params, not the Rack request body).
+        hook_invite_token = param_or_nil('invite_token').to_s.strip
+
         # Determine the provisioning origin from request context. This is
         # metadata only — capabilities are governed by org/team role.
-        provisioning_origin = if request.params['invite_token'].to_s.strip != ''
+        provisioning_origin = if hook_invite_token != ''
                                 'invite'
                               elsif request.env['onetime.display_domain'] &&
                                     Onetime::CustomDomain.load_by_display_domain(request.env['onetime.display_domain'])
@@ -164,9 +170,10 @@ module Auth::Config::Hooks
             )
           end
 
-          # Accept pending invitation if token provided in signup request
-          invite_token = request.params['invite_token']
-          if invite_token && !invite_token.to_s.strip.empty?
+          # Accept pending invitation if token provided in signup request.
+          # Uses the same internal_request-safe token captured above.
+          invite_token = hook_invite_token
+          unless invite_token.empty?
             Auth::Logging.log_auth_event(
               :invite_acceptance_started,
               level: :debug,
@@ -384,5 +391,6 @@ module Auth::Config::Hooks
         end
       end
     end
+    # rubocop:enable Metrics/PerceivedComplexity
   end
 end

--- a/apps/web/auth/config/hooks/error_handling.rb
+++ b/apps/web/auth/config/hooks/error_handling.rb
@@ -15,7 +15,7 @@ module Auth::Config::Hooks
           Auth::Logging.log_auth_event(
             :around_rodauth,
             level: :debug,
-            session_id: session.id,
+            session_id: session.respond_to?(:id) ? session.id : session[:session_id],
             current_route: current_route,
             request_path: request.path,
           )
@@ -58,7 +58,7 @@ module Auth::Config::Hooks
               level: :error,
               current_route: current_route,
               request_path: request.path,
-              session_id: session.id,
+              session_id: session.respond_to?(:id) ? session.id : session[:session_id],
               error_class: ex.class.name,
               error_message: ex.message,
               backtrace: ex.backtrace&.first(5),
@@ -72,7 +72,7 @@ module Auth::Config::Hooks
             level: :warn,
             current_route: current_route,
             request_path: request.path,
-            session_id: session.id,
+            session_id: session.respond_to?(:id) ? session.id : session[:session_id],
             orphaned_account_id: session_account_id,
             message: 'Session references deleted account - clearing session',
           )
@@ -108,7 +108,7 @@ module Auth::Config::Hooks
             level: :error,
             current_route: current_route,
             request_path: request.path,
-            session_id: session.id,
+            session_id: session.respond_to?(:id) ? session.id : session[:session_id],
             error_class: ex.class.name,
             error_message: ex.message,
             error_backtrace: ex.backtrace&.first(5),

--- a/apps/web/auth/config/hooks/login.rb
+++ b/apps/web/auth/config/hooks/login.rb
@@ -188,14 +188,10 @@ module Auth::Config::Hooks
             )
           end
 
-          # Accept pending invitation if token provided in login request
-          Login.accept_invite_on_login(
-            request: request,
-            account: account,
-            account_id: account_id,
-            session: session,
-            correlation_id: correlation_id,
-          )
+          # Invitation acceptance is intentionally not performed here. The
+          # frontend issues an explicit POST /api/invite/:token/accept after
+          # login completes, giving a single acceptance code path regardless
+          # of whether the user signed up fresh or already had an account.
         end
       end
 
@@ -241,46 +237,6 @@ module Auth::Config::Hooks
             level: :warn,
             email: OT::Utils.obscure_email(email),
             ip: request.ip,
-            correlation_id: correlation_id,
-          )
-        end
-      end
-    end
-
-    # Accept pending invitation if token provided in login request
-    # Extracted to reduce complexity in configure method
-    def self.accept_invite_on_login(request:, account:, account_id:, session:, correlation_id:)
-      invite_token = request.params['invite_token']
-      return unless invite_token && !invite_token.to_s.strip.empty?
-
-      customer = Onetime::Customer.find_by_email(account[:email])
-      return unless customer
-
-      Onetime::ErrorHandler.safe_execute('accept_invitation_on_login', token: invite_token) do
-        result = Auth::Operations::AcceptInvitation.new(
-          customer: customer,
-          token: invite_token,
-        ).call
-
-        if result[:accepted]
-          Auth::Logging.log_auth_event(
-            :invitation_accepted_on_login,
-            level: :info,
-            account_id: account_id,
-            organization_id: result[:organization_id],
-            role: result[:role],
-            correlation_id: correlation_id,
-          )
-
-          # Clear org cache so next request picks up the new org
-          cache_key = "org_context:#{customer.objid}"
-          session.delete(cache_key)
-        else
-          Auth::Logging.log_auth_event(
-            :invitation_skipped_on_login,
-            level: :info,
-            account_id: account_id,
-            reason: result[:reason],
             correlation_id: correlation_id,
           )
         end

--- a/apps/web/auth/spec/integration/full/invite_signup_autologin_internal_request_spec.rb
+++ b/apps/web/auth/spec/integration/full/invite_signup_autologin_internal_request_spec.rb
@@ -1,0 +1,137 @@
+# apps/web/auth/spec/integration/full/invite_signup_autologin_internal_request_spec.rb
+#
+# frozen_string_literal: true
+
+# =============================================================================
+# TEST TYPE: Integration (regression for issue #3221)
+# =============================================================================
+#
+# Reproduces the bug surfaced by POST /api/invite/:token/signup returning
+# 422 "Failed to create account" *after* the account was successfully created
+# and the invitation was accepted.
+#
+# Root cause:
+#   Auth::Config.create_account(login:, password:, params: {invite_token:})
+#   returns nil when the after_create_account hook sets @invite_accepted = true,
+#   which flips create_account_autologin? to true. Under internal_request mode
+#   Rodauth's autologin path calls autologin_session('create_account') (which
+#   bypasses after_login) followed by create_account_response (which throws
+#   :halt via redirect). handle_internal_request catches the halt and returns
+#   @internal_request_return_value — but that ivar is only set by the
+#   internal_request override of after_login, which autologin_session never
+#   triggers. Result: caller sees nil, treats it as failure, raises FormError.
+#
+# The signature this test pins down (the "bug triad"):
+#   1. result of Auth::Config.create_account is nil
+#   2. the accounts row was created (account creation actually succeeded)
+#   3. the invitation was accepted (after_create_account hook ran to completion,
+#      so @invite_accepted = true, so autologin path fired — which is the
+#      precise condition that breaks the return value)
+#
+# After the fix only assertion (1) flips — result must be the account_id.
+#
+# REQUIREMENTS:
+# - Valkey running on port 2121: pnpm run test:database:start
+# - AUTH_DATABASE_URL set (SQLite or PostgreSQL)
+# - AUTHENTICATION_MODE=full
+#
+# RUN:
+#   source .env.test && pnpm run test:rspec \
+#     apps/web/auth/spec/integration/full/invite_signup_autologin_internal_request_spec.rb
+#
+# =============================================================================
+
+require_relative '../../spec_helper'
+
+RSpec.describe 'Invite signup via Rodauth internal_request (issue #3221)', type: :integration do
+  before(:all) do
+    require 'onetime'
+    require 'onetime/application/registry'
+    require 'onetime/auth_config'
+
+    Onetime.auth_config.reload! if Onetime.respond_to?(:auth_config) && Onetime.auth_config.respond_to?(:reload!)
+    Onetime::Application::Registry.reset! if Onetime::Application::Registry.respond_to?(:reset!)
+
+    Onetime.boot!(:test, force: true)
+    Onetime::Application::Registry.prepare_application_registry
+  end
+
+  before do
+    unless defined?(Auth::Database) && Auth::Database.connection
+      skip 'Auth database not configured (run with AUTH_DATABASE_URL set)'
+    end
+  end
+
+  let(:test_suffix) { "#{Familia.now.to_i}_#{SecureRandom.hex(4)}" }
+  let(:owner_email) { "invite_owner_#{test_suffix}@onetimesecret.com" }
+  let(:invited_email) { "invitee_#{test_suffix}@onetimesecret.com" }
+  let(:password) { 'TestPassword123!' }
+
+  let(:owner) { Onetime::Customer.create!(email: owner_email, role: 'customer') }
+  let(:organization) do
+    Onetime::Organization.create!(
+      "Invite Autologin Org #{test_suffix}",
+      owner,
+      owner_email,
+      is_default: true,
+    )
+  end
+  let(:invitation) do
+    Onetime::OrganizationMembership.create_invitation!(
+      organization: organization,
+      email: invited_email,
+      inviter: owner,
+      role: 'member',
+    )
+  end
+
+  after do
+    Auth::Database.connection[:accounts].where(email: invited_email).delete
+    invitation&.destroy_with_index_cleanup! rescue nil
+    organization&.destroy! rescue nil
+    owner&.destroy! rescue nil
+    Onetime::Customer.find_by_email(invited_email)&.destroy! rescue nil
+  rescue StandardError
+    # Non-fatal cleanup error
+  end
+
+  it 'returns the account_id when invite acceptance triggers autologin' do
+    # Force lazy lets to materialise (owner, org, invitation) in the documented
+    # order so the after_create_account hook sees a valid pending invitation.
+    expect(invitation.pending?).to be(true)
+    invite_token = invitation.token
+
+    # Exact call shape used by apps/api/invite/logic/invites/signup_and_accept.rb:200
+    result = Auth::Config.create_account(
+      login: invited_email,
+      password: password,
+      params: { 'invite_token' => invite_token },
+    )
+
+    # ---- Bug triad ----------------------------------------------------------
+
+    # (2) The account row exists in authdb — proves create_account did NOT bail
+    # out early (e.g. before_create_account rejection, login_valid_email?
+    # failure, signup-validation block). If this fails the test isn't
+    # reproducing #3221; account creation died upstream of the autologin path.
+    account_row = Auth::Database.connection[:accounts].where(email: invited_email).first
+    expect(account_row).not_to be_nil
+    # auto-verified by the hook (status_id 2 = Verified) — invite proves email ownership
+    expect(account_row[:status_id]).to eq(2)
+
+    # (3) The invitation was accepted — proves the after_create_account hook
+    # reached the @invite_accepted = true line, which is the precondition that
+    # makes create_account_autologin? return true.
+    activated_membership = Onetime::OrganizationMembership.find_by_org_customer(
+      organization.objid,
+      Onetime::Customer.find_by_email(invited_email)&.objid,
+    )
+    expect(activated_membership).not_to be_nil
+    expect(activated_membership.active?).to be(true)
+
+    # (1) THE BUG: Auth::Config.create_account returns nil despite (2) + (3)
+    # succeeding. This assertion fails today; after the fix it must hold.
+    expect(result).not_to be_nil
+    expect(result).to eq(account_row[:id])
+  end
+end

--- a/apps/web/auth/spec/integration/full/invite_signup_autologin_internal_request_spec.rb
+++ b/apps/web/auth/spec/integration/full/invite_signup_autologin_internal_request_spec.rb
@@ -6,30 +6,22 @@
 # TEST TYPE: Integration (regression for issue #3221)
 # =============================================================================
 #
-# Reproduces the bug surfaced by POST /api/invite/:token/signup returning
-# 422 "Failed to create account" *after* the account was successfully created
-# and the invitation was accepted.
+# Pins the post-signup contract from the bug fix in this branch:
 #
-# Root cause:
-#   apps/api/invite/logic/invites/signup_and_accept.rb treated the return value
-#   of Auth::Config.create_account(...) as the success signal. Rodauth's
-#   internal_request create_account contract returns nil on success — see
-#   rodauth_spec.rb:1039 (`app.rodauth.create_account(...).must_be_nil`
-#   followed immediately by a successful login). The only setter for
-#   @internal_request_return_value in lib/rodauth/features/internal_request.rb
-#   is after_login (:131-134), which the create_account flow never triggers.
+#   1. POST /api/invite/:token/signup creates the account, auto-verifies it,
+#      and skips default-workspace creation (the user is joining an existing
+#      org via invite — a personal workspace would be dead state).
+#   2. The after_create_account hook does NOT accept the invitation. The
+#      token stays valid in token_lookup, the invitation stays in `pending`
+#      state. Acceptance happens via the explicit POST /api/invite/:token/
+#      accept call the frontend issues against the established session —
+#      one acceptance code path for both signup and login flows.
+#   3. After the explicit /accept call, the invitation reaches `active` and
+#      the customer appears in org.members.
 #
-#   Treating nil as failure caused SignupAndAccept to raise FormError despite
-#   the account row, customer, workspace, and invitation acceptance all being
-#   committed by the after_create_account hooks.
-#
-# Contract this test pins down:
-#   - the accounts row is created and auto-verified (status_id = 2)
-#   - the invitation is accepted via after_create_account hook
-#   - Auth::Config.account_id_for_login resolves the new account
-#
-# Before the fix, the assertion that exercises the SignupAndAccept code path
-# (it surfaces nil-as-failure) fails. After the fix, all assertions pass.
+# Before the bug fix, the hook auto-accepted via Auth::Operations::AcceptInvitation
+# during after_create_account, wiping token_lookup before the user's Accept
+# click could resolve it (404), and rendering Decline non-functional.
 #
 # REQUIREMENTS:
 # - Valkey running on port 2121: pnpm run test:database:start
@@ -96,15 +88,12 @@ RSpec.describe 'Invite signup via Rodauth internal_request (issue #3221)', type:
     # Non-fatal cleanup error
   end
 
-  it 'creates the account and accepts the invitation via internal_request' do
+  it 'creates the account and leaves the invitation pending for explicit accept' do
     # Force lazy lets to materialise (owner, org, invitation) in the documented
     # order so the after_create_account hook sees a valid pending invitation.
     expect(invitation.pending?).to be(true)
     invite_token = invitation.token
 
-    # Exact call shape used by apps/api/invite/logic/invites/signup_and_accept.rb.
-    # Rodauth's internal_request create_account returns nil on success by
-    # contract — see rodauth_spec.rb:1039. Do not assert on the return value.
     Auth::Config.create_account(
       login: invited_email,
       password: password,
@@ -117,19 +106,112 @@ RSpec.describe 'Invite signup via Rodauth internal_request (issue #3221)', type:
     expect(account_row).not_to be_nil
     expect(account_row[:status_id]).to eq(2)
 
-    # The invitation was accepted — the after_create_account hook ran to
-    # completion (Customer linked, workspace created, membership activated).
-    activated_membership = Onetime::OrganizationMembership.find_by_org_customer(
-      organization.objid,
-      Onetime::Customer.find_by_email(invited_email)&.objid,
-    )
-    expect(activated_membership).not_to be_nil
-    expect(activated_membership.active?).to be(true)
+    # The invitation is NOT yet accepted. Token survives in token_lookup so
+    # the frontend's explicit POST /api/invite/:token/accept can complete the
+    # join against the session that internal_request established.
+    looked_up_via_token = Onetime::OrganizationMembership.find_by_token(invite_token)
+    expect(looked_up_via_token).not_to be_nil
+    expect(looked_up_via_token.pending?).to be(true)
 
-    # SignupAndAccept looks up the account_id after the call rather than
-    # relying on the (nil) return value. Mirror that here so the spec regresses
-    # if the lookup path ever breaks.
+    # No membership in org.members yet — accept! has not run.
+    invitee_customer = Onetime::Customer.find_by_email(invited_email)
+    expect(invitee_customer).not_to be_nil
+    expect(organization.member?(invitee_customer)).to be(false)
+    expect(
+      Onetime::OrganizationMembership.find_by_org_customer(
+        organization.objid,
+        invitee_customer.objid,
+      ),
+    ).to be_nil
+
+    # Default workspace is intentionally skipped for invite signups — invitees
+    # join an existing org, so a personal default workspace would be dead state.
+    expect(invitee_customer.verified?).to be(true)
+
     looked_up_id = Auth::Config.account_id_for_login(login: invited_email)
     expect(looked_up_id).to eq(account_row[:id])
+  end
+
+  it 'completes the join when /accept runs after signup' do
+    expect(invitation.pending?).to be(true)
+    invite_token = invitation.token
+
+    Auth::Config.create_account(
+      login: invited_email,
+      password: password,
+      params: { 'invite_token' => invite_token },
+    )
+
+    invitee_customer = Onetime::Customer.find_by_email(invited_email)
+    expect(invitee_customer).not_to be_nil
+
+    # Simulate the explicit POST /api/invite/:token/accept the frontend issues
+    # with the established session: load the still-pending invitation and call
+    # accept!. Org membership flips to active in one step (auto-promote, since
+    # requires_admin_approval? is false).
+    invitation_for_accept = Onetime::OrganizationMembership.find_by_token(invite_token)
+    expect(invitation_for_accept).not_to be_nil
+    expect(invitation_for_accept.pending?).to be(true)
+
+    invitation_for_accept.accept!(invitee_customer, provisioning_source: 'invited')
+
+    expect(organization.member?(invitee_customer)).to be(true)
+
+    active_membership = Onetime::OrganizationMembership.find_by_org_customer(
+      organization.objid,
+      invitee_customer.objid,
+    )
+    expect(active_membership).not_to be_nil
+    expect(active_membership.active?).to be(true)
+
+    # Token consumed on accept — find_by_token must no longer resolve.
+    expect(Onetime::OrganizationMembership.find_by_token(invite_token)).to be_nil
+  end
+
+  it 'preserves the token after signup so /decline stays functional' do
+    expect(invitation.pending?).to be(true)
+    invite_token = invitation.token
+
+    Auth::Config.create_account(
+      login: invited_email,
+      password: password,
+      params: { 'invite_token' => invite_token },
+    )
+
+    invitation_for_decline = Onetime::OrganizationMembership.find_by_token(invite_token)
+    expect(invitation_for_decline).not_to be_nil
+    expect(invitation_for_decline.pending?).to be(true)
+
+    invitation_for_decline.decline!
+
+    expect(invitation_for_decline.status).to eq('declined')
+    # SQL account intact — the user can still log in as a personal account.
+    account_row = Auth::Database.connection[:accounts].where(email: invited_email).first
+    expect(account_row).not_to be_nil
+  end
+
+  it 'blocks signup when invite_token email does not match login email' do
+    expect(invitation.pending?).to be(true)
+    invite_token = invitation.token
+    other_email  = "other_#{test_suffix}@onetimesecret.com"
+
+    expect {
+      Auth::Config.create_account(
+        login: other_email,
+        password: password,
+        params: { 'invite_token' => invite_token },
+      )
+    }.to raise_error(Rodauth::InternalRequestError)
+
+    # No account written: before_create_account aborted the flow.
+    other_account = Auth::Database.connection[:accounts].where(email: other_email).first
+    expect(other_account).to be_nil
+
+    # Invitation still resolves by its token (untouched).
+    untouched = Onetime::OrganizationMembership.find_by_token(invite_token)
+    expect(untouched).not_to be_nil
+    expect(untouched.pending?).to be(true)
+  ensure
+    Auth::Database.connection[:accounts].where(email: other_email).delete if defined?(other_email)
   end
 end

--- a/apps/web/auth/spec/integration/full/invite_signup_autologin_internal_request_spec.rb
+++ b/apps/web/auth/spec/integration/full/invite_signup_autologin_internal_request_spec.rb
@@ -11,24 +11,25 @@
 # and the invitation was accepted.
 #
 # Root cause:
-#   Auth::Config.create_account(login:, password:, params: {invite_token:})
-#   returns nil when the after_create_account hook sets @invite_accepted = true,
-#   which flips create_account_autologin? to true. Under internal_request mode
-#   Rodauth's autologin path calls autologin_session('create_account') (which
-#   bypasses after_login) followed by create_account_response (which throws
-#   :halt via redirect). handle_internal_request catches the halt and returns
-#   @internal_request_return_value — but that ivar is only set by the
-#   internal_request override of after_login, which autologin_session never
-#   triggers. Result: caller sees nil, treats it as failure, raises FormError.
+#   apps/api/invite/logic/invites/signup_and_accept.rb treated the return value
+#   of Auth::Config.create_account(...) as the success signal. Rodauth's
+#   internal_request create_account contract returns nil on success — see
+#   rodauth_spec.rb:1039 (`app.rodauth.create_account(...).must_be_nil`
+#   followed immediately by a successful login). The only setter for
+#   @internal_request_return_value in lib/rodauth/features/internal_request.rb
+#   is after_login (:131-134), which the create_account flow never triggers.
 #
-# The signature this test pins down (the "bug triad"):
-#   1. result of Auth::Config.create_account is nil
-#   2. the accounts row was created (account creation actually succeeded)
-#   3. the invitation was accepted (after_create_account hook ran to completion,
-#      so @invite_accepted = true, so autologin path fired — which is the
-#      precise condition that breaks the return value)
+#   Treating nil as failure caused SignupAndAccept to raise FormError despite
+#   the account row, customer, workspace, and invitation acceptance all being
+#   committed by the after_create_account hooks.
 #
-# After the fix only assertion (1) flips — result must be the account_id.
+# Contract this test pins down:
+#   - the accounts row is created and auto-verified (status_id = 2)
+#   - the invitation is accepted via after_create_account hook
+#   - Auth::Config.account_id_for_login resolves the new account
+#
+# Before the fix, the assertion that exercises the SignupAndAccept code path
+# (it surfaces nil-as-failure) fails. After the fix, all assertions pass.
 #
 # REQUIREMENTS:
 # - Valkey running on port 2121: pnpm run test:database:start
@@ -95,33 +96,29 @@ RSpec.describe 'Invite signup via Rodauth internal_request (issue #3221)', type:
     # Non-fatal cleanup error
   end
 
-  it 'returns the account_id when invite acceptance triggers autologin' do
+  it 'creates the account and accepts the invitation via internal_request' do
     # Force lazy lets to materialise (owner, org, invitation) in the documented
     # order so the after_create_account hook sees a valid pending invitation.
     expect(invitation.pending?).to be(true)
     invite_token = invitation.token
 
-    # Exact call shape used by apps/api/invite/logic/invites/signup_and_accept.rb:200
-    result = Auth::Config.create_account(
+    # Exact call shape used by apps/api/invite/logic/invites/signup_and_accept.rb.
+    # Rodauth's internal_request create_account returns nil on success by
+    # contract — see rodauth_spec.rb:1039. Do not assert on the return value.
+    Auth::Config.create_account(
       login: invited_email,
       password: password,
       params: { 'invite_token' => invite_token },
     )
 
-    # ---- Bug triad ----------------------------------------------------------
-
-    # (2) The account row exists in authdb — proves create_account did NOT bail
-    # out early (e.g. before_create_account rejection, login_valid_email?
-    # failure, signup-validation block). If this fails the test isn't
-    # reproducing #3221; account creation died upstream of the autologin path.
+    # Account row exists and is auto-verified (status_id 2 = Verified) by the
+    # after_create_account hook since the invite proves email ownership.
     account_row = Auth::Database.connection[:accounts].where(email: invited_email).first
     expect(account_row).not_to be_nil
-    # auto-verified by the hook (status_id 2 = Verified) — invite proves email ownership
     expect(account_row[:status_id]).to eq(2)
 
-    # (3) The invitation was accepted — proves the after_create_account hook
-    # reached the @invite_accepted = true line, which is the precondition that
-    # makes create_account_autologin? return true.
+    # The invitation was accepted — the after_create_account hook ran to
+    # completion (Customer linked, workspace created, membership activated).
     activated_membership = Onetime::OrganizationMembership.find_by_org_customer(
       organization.objid,
       Onetime::Customer.find_by_email(invited_email)&.objid,
@@ -129,9 +126,10 @@ RSpec.describe 'Invite signup via Rodauth internal_request (issue #3221)', type:
     expect(activated_membership).not_to be_nil
     expect(activated_membership.active?).to be(true)
 
-    # (1) THE BUG: Auth::Config.create_account returns nil despite (2) + (3)
-    # succeeding. This assertion fails today; after the fix it must hold.
-    expect(result).not_to be_nil
-    expect(result).to eq(account_row[:id])
+    # SignupAndAccept looks up the account_id after the call rather than
+    # relying on the (nil) return value. Mirror that here so the spec regresses
+    # if the lookup path ever breaks.
+    looked_up_id = Auth::Config.account_id_for_login(login: invited_email)
+    expect(looked_up_id).to eq(account_row[:id])
   end
 end

--- a/docs/product/README.md
+++ b/docs/product/README.md
@@ -20,6 +20,7 @@ Frontend architecture and design documentation for Onetime Secret.
 |----------|---------|
 | [Request Lifecycle](request-lifecycle.md) | How requests flow through the system (routing → rendering) |
 | [Secret Lifecycle](secret-lifecycle.md) | FSM states for secret entities (idle → revealed → burned) |
+| [Organization Invites](organization-invites.md) | Invite lifecycle, API surface, anti-abuse posture |
 | [URI Path Mapping](uri-paths-to-views-structure.md) | URL → Vue component mapping table |
 
 ## Key Concepts

--- a/docs/product/organization-invites.md
+++ b/docs/product/organization-invites.md
@@ -1,0 +1,111 @@
+---
+title: Organization Invites
+type: reference
+status: draft
+updated: 2026-05-25
+summary: Invite lifecycle, API surface, and the dimensions that matter for SaaS invite flows
+---
+
+# Organization Invites
+
+End-to-end flow from "owner clicks invite" to "invitee is an active org member." The lifecycle is one record (`OrganizationMembership`) progressing through states; the token is the unguessable handle that drives the invitee's view.
+
+## Lifecycle
+
+`OrganizationMembership.status` is the FSM. Token is set during `pending`, cleared on terminal transitions.
+
+| State | Set by | Token | Indexed in |
+|-------|--------|-------|------------|
+| `pending` | `Organization#invite_member` | yes | `token_lookup`, `org_email_lookup`, `pending_invitations` |
+| `accepted` | `accept!` when `requires_admin_approval?` returns true (gated; awaiting approval workflow) | nil | none |
+| `active` | `activate!` (auto-promoted from `accept!`) | nil | `org.members`, `org_customer_lookup` |
+| `declined` | `decline!` | nil | none |
+| expired | implicit (`pending_at + 7d`) | yes (until cleanup) | unchanged |
+| revoked | `revoke!` | — | record destroyed |
+
+`lib/onetime/models/organization_membership.rb` is the canonical reference. `INVITATION_TTL_SECONDS = 7.days`.
+
+## Flow
+
+```
+owner POST /api/org/:extid/invitations   → status=pending, token issued, email queued
+invitee GET /invite/:token               → AcceptInvite.vue resolves state
+       │
+       ├─ unauthenticated, no account   → inline signup → /accept
+       ├─ unauthenticated, account exists → inline signin → /accept
+       ├─ authenticated, email matches  → explicit Accept click → /accept
+       ├─ authenticated, email mismatch → must logout + reauthenticate
+       └─ Decline                       → /decline
+```
+
+Acceptance is **always an explicit user click**. Signup/signin establishes auth; the invite is not auto-claimed in the auth hook. See `src/apps/session/views/AcceptInvite.vue` and `src/apps/session/composables/useInviteAuth.ts`.
+
+## API surface
+
+| Method | Path | Auth | Logic class |
+|--------|------|------|-------------|
+| GET | `/api/invite/:token` | noauth (rate-limited) | `InviteAPI::Logic::Invites::ShowInvite` |
+| POST | `/api/invite/:token/accept` | sessionauth | `InviteAPI::Logic::Invites::AcceptInvite` |
+| POST | `/api/invite/:token/decline` | noauth | `InviteAPI::Logic::Invites::DeclineInvite` |
+| GET | `/api/org/:extid/invitations` | sessionauth (admin) | `OrganizationAPI::Logic::Invitations::ListInvitations` |
+| POST | `/api/org/:extid/invitations` | sessionauth (admin) | `OrganizationAPI::Logic::Invitations::CreateInvitation` |
+| POST | `/api/org/:extid/invitations/:token/resend` | sessionauth (admin) | `OrganizationAPI::Logic::Invitations::ResendInvitation` |
+| DELETE | `/api/org/:extid/invitations/:token` | sessionauth (admin) | `OrganizationAPI::Logic::Invitations::RevokeInvitation` |
+
+`ShowInvite` returns structured responses for *every* invitation state (pending/accepted/declined/expired). Only truly unknown tokens 404. The response carries computed flags `actionable` and `account_exists` so the frontend can branch without a second round-trip.
+
+## Dimensions we track
+
+Reference: industry comparison across 10 SaaS products (Clerk, GitHub, Slack, Notion, Linear, Figma, 1Password, Atlassian, WorkOS, Zitadel). These are the dimensions on which invite systems differ, and where OTS sits.
+
+| Dimension | OTS position | Notes |
+|-----------|--------------|-------|
+| Invite channel | Email only | No secret link, no Slack app, no SCIM yet |
+| Expiry | 7 days, hardcoded | Matches GitHub. Not configurable. |
+| Token lifecycle | New token on resend (old invalidated) | `ResendInvitation` calls `generate_token!`, max 3 resends |
+| Role at invite | Set at invite (`through_attrs[:role]`) | Majority pattern |
+| Account creation | Embedded in flow | Inline `InviteSignUpForm` / `InviteSignInForm` |
+| Account-exists branching | Returned in `ShowInvite` response (`account_exists`) | Same pattern as Clerk `__clerk_status`, WorkOS user-exists fork |
+| Admin confirmation | Not required (`requires_admin_approval?` hardcoded `false`) | Branch exists in `accept!` for the future approval workflow |
+| Email match | Strict, case-insensitive | Enforced in `accept!` and at signup hook (`before_create_account`) — defense in depth |
+| Anti-enumeration | `InviteTokenRateLimiter` on GET (per-IP) | Mirrors GitHub verified-email matching, in spirit |
+| Acceptance trigger | Explicit user click | No auto-accept post-auth; intentional anti-phishing posture |
+| Post-accept onboarding | None | Lands on `/orgs` |
+
+## Frontend state machine
+
+`AcceptInvite.vue` drives the view via a single computed `inviteState`:
+
+```
+loading → { signup_required | signin_required | direct_accept | wrong_email |
+            already_accepted | invalid }
+                                  ↓ (user action resolves)
+                            { accepted | declined }
+```
+
+`accepted`/`declined` are terminal pins — once set, the state machine ignores further transitions until the redirect timer fires. This prevents the action row from flickering back into view during the redirect delay. The pattern mirrors `useSecretLifecycle` (see [Secret Lifecycle](secret-lifecycle.md)).
+
+## Anti-abuse
+
+- **Rate limiter on `GET /api/invite/:token`** (`Onetime::Security::InviteTokenRateLimiter`) — per-IP, prevents token enumeration on the noauth endpoint.
+- **Email match in `accept!`** — even with a valid session and valid token, the authenticated email must match the invite. The check is repeated at signup hook level so partial Redis state never lands.
+- **Token consumed on accept/decline** — `token_lookup` index entry is removed; resending generates a fresh token (old one becomes a dead lookup).
+- **Resend cap** — 3 resends per invitation.
+- **Pending-state indexes cleared atomically** in `accept!` with a rescue that restores them on Redis/validation failure.
+
+## Open decisions
+
+These map to dimensions in the industry comparison that OTS hasn't resolved yet.
+
+- **Approval workflow** — `requires_admin_approval?` is hardcoded `false` pending the approval endpoint. The `accepted` state and `awaiting_approval` staging set are scaffolded for the follow-up that flips the gate.
+- **Open invite links** — no Notion-style secret link or 1Password-style sign-up link. Adding one would require admin confirmation (1Password model) to bound blast radius.
+- **Domain-aware behavior** — no consumer-vs-corporate domain distinction (WorkOS pattern). Currently treats `user@gmail.com` and `user@acme.com` identically.
+- **Custom branding propagation** — `ShowInvite` returns custom-domain branding when the request hits a branded domain. Confirmed working; not yet documented as a guarantee.
+
+## Related
+
+- [Secret Lifecycle](secret-lifecycle.md) — the same Context/Lifecycle separation pattern
+- `lib/onetime/models/organization_membership.rb` — model + lifecycle methods
+- `apps/api/invite/` — invitee-facing API
+- `apps/api/organizations/logic/invitations/` — owner-facing API
+- `src/apps/session/views/AcceptInvite.vue` — frontend state machine

--- a/etc/defaults/logging.defaults.yaml
+++ b/etc/defaults/logging.defaults.yaml
@@ -8,6 +8,7 @@
 #   Bunny     - RabbitMQ AMQP client (connection, heartbeats)
 #   Familia   - Redis operations via Familia ORM
 #   HTTP      - HTTP requests, responses, and middleware
+#   Jobs      - Job publishing (enqueue_email, fallback handling)
 #   Otto      - Otto framework operations
 #   Rhales    - Rhales template rendering (future)
 #   Scheduler - Scheduled/recurring background jobs (rufus-scheduler)
@@ -24,6 +25,7 @@
 #   DEBUG_AUTH=1                          - Quick debug flag for Auth
 #   DEBUG_BUNNY=1                         - Quick debug flag for Bunny (RabbitMQ)
 #   DEBUG_HTTP=1                          - Quick debug flag for HTTP
+#   DEBUG_JOBS=1                          - Quick debug flag for Jobs (publishing)
 #   DEBUG_SCHEDULER=1                     - Quick debug flag for Scheduler
 #   DEBUG_SECRET=1                        - Quick debug flag for Secret
 #   DEBUG_SESSION=1                       - Quick debug flag for Session
@@ -56,6 +58,7 @@ loggers:
   Billing: info   # Only used when billing.enabled=true
   Boot: info      # During initialization
   Bunny: info     # RabbitMQ client (heartbeats at debug level)
+  Jobs: info      # Job publishing (Publisher.enqueue_email, fallbacks)
   CLI: info       # Command-line interface operations
   Familia: info   # Redis/Familia main database operations
   HTTP: info      # HTTP requests and middleware operations

--- a/install-dev.sh
+++ b/install-dev.sh
@@ -6,6 +6,7 @@
 #   - Links shared dev resources from OTS_DEV_CONFIG
 #   - Installs Ruby gems (bundle install)
 #   - Installs Node packages (pnpm install)
+#   - Installs the pre-commit/pre-push git hooks and their tool envs
 #   - Cleans any pre-existing frontend build output (pnpm run clean)
 #   - Points the Caddy webroot symlink at this checkout's public/web
 #
@@ -138,6 +139,55 @@ link_caddy_webroot() {
     fi
 }
 
+# Install the pre-commit-managed git hooks and pre-build their isolated
+# tool environments (rubocop, eslint, etc). Two configs are in play:
+#   .pre-commit-config.yaml  -> pre-commit, prepare-commit-msg, post-* hooks
+#                               (hook types come from default_install_hook_types)
+#   .pre-push-config.yaml    -> pre-push hooks (separate config + hook type)
+#
+# --install-hooks pre-builds the hook environments so the first commit/push
+# is not slowed down by a one-time dependency download. Hooks land in the
+# common git dir, so a worktree forest shares one set — re-running here is
+# idempotent.
+install_git_hooks() {
+    if [[ "${has_pre_commit}" != true ]]; then
+        echo "Skip: pre-commit not installed — git hooks not configured"
+        return
+    fi
+
+    # pre-commit refuses to install while core.hooksPath is set, since it
+    # cannot guarantee git will invoke the hooks it writes. Surface the
+    # one-line fix instead of aborting the whole script.
+    local hooks_path
+    hooks_path="$(git config --get core.hooksPath || true)"
+    if [[ -n "$hooks_path" ]]; then
+        echo ""
+        echo ">>> WARNING: git hooks NOT installed"
+        echo "    pre-commit will not install while core.hooksPath is set."
+        echo "    Current value: $hooks_path"
+
+        # If it merely pins git's own default hooks dir, clearing it
+        # changes nothing — say so, so the user isn't left guessing.
+        local default_hooks resolved_hooks
+        default_hooks="$(cd "$(git rev-parse --git-path hooks)" 2>/dev/null && pwd -P || true)"
+        resolved_hooks="$(cd "$hooks_path" 2>/dev/null && pwd -P || true)"
+        if [[ -n "$default_hooks" && "$resolved_hooks" == "$default_hooks" ]]; then
+            echo "    (This is git's default hooks directory. Clearing the setting for this local checkout is safe.)"
+        fi
+
+        echo "    To enable git hooks, clear it and re-run this script:"
+        echo "      git config --unset-all core.hooksPath"
+        echo ""
+        return
+    fi
+
+    pre-commit install --install-hooks \
+        || { echo "Warning: pre-commit hook install failed — git hooks not configured"; return; }
+    pre-commit install --hook-type pre-push \
+        --config .pre-push-config.yaml --install-hooks \
+        || { echo "Warning: pre-push hook install failed"; return; }
+}
+
 link_resource() {
     local local_path="$1"
     local shared_name="$2"
@@ -203,6 +253,20 @@ if ! command -v overmind &>/dev/null; then
     echo ""
 fi
 
+# Check for pre-commit (manages the git pre-commit/pre-push hooks) — cache
+# result for reuse below. Not required to run the app, so warn and continue.
+has_pre_commit=true
+if ! command -v pre-commit &>/dev/null; then
+    has_pre_commit=false
+    echo "Warning: pre-commit not found — git pre-commit/pre-push hooks will not be installed"
+    echo "  Install one of:"
+    echo "    pipx install pre-commit        (recommended — isolated)"
+    echo "    brew install pre-commit        (macOS)"
+    echo "    pip install --user pre-commit"
+    echo "  Docs: https://pre-commit.com"
+    echo ""
+fi
+
 # Warn if shared config directory is absent
 if [[ ! -d "$OTS_DEV_CONFIG" ]]; then
     echo "Warning: $OTS_DEV_CONFIG does not exist — config symlinks will be skipped"
@@ -248,6 +312,10 @@ bundle install
 echo "---"
 echo "Installing Node packages..."
 pnpm install
+
+echo "---"
+echo "Installing git hooks (pre-commit, pre-push)..."
+install_git_hooks
 
 echo "---"
 echo "Removing frontend build output (public/web/dist)..."

--- a/lib/onetime/cli/queue/dlq_command.rb
+++ b/lib/onetime/cli/queue/dlq_command.rb
@@ -47,7 +47,7 @@ module Onetime
         end
 
         def with_rabbitmq_connection
-          url  = ENV.fetch('RABBITMQ_URL', 'amqp://guest:guest@localhost:5672')
+          url  = OT.conf.dig('jobs', 'rabbitmq_url')
           conn = Bunny.new(url)
           conn.start
           yield conn

--- a/lib/onetime/cli/queue/init_command.rb
+++ b/lib/onetime/cli/queue/init_command.rb
@@ -50,7 +50,7 @@ module Onetime
         def call(force: false, dry_run: false, **)
           boot_application!
 
-          amqp_url = ENV.fetch('RABBITMQ_URL', 'amqp://guest:guest@localhost:5672')
+          amqp_url = OT.conf.dig('jobs', 'rabbitmq_url')
           parsed   = parse_amqp_url(amqp_url)
 
           puts 'RabbitMQ Initialization'

--- a/lib/onetime/cli/queue/ping_command.rb
+++ b/lib/onetime/cli/queue/ping_command.rb
@@ -76,7 +76,7 @@ module Onetime
         private
 
         def ping_queues(queue_names, wait_seconds)
-          amqp_url = ENV.fetch('RABBITMQ_URL', 'amqp://guest:guest@localhost:5672')
+          amqp_url = OT.conf.dig('jobs', 'rabbitmq_url')
 
           bunny_config = {
             logger: Onetime.get_logger('Bunny'),

--- a/lib/onetime/cli/queue/rabbitmq_helpers.rb
+++ b/lib/onetime/cli/queue/rabbitmq_helpers.rb
@@ -32,13 +32,15 @@ module Onetime
         end
 
         # Base URL for the RabbitMQ Management HTTP API.
+        # ENV override intentional: management API often on different host/port than AMQP.
         def management_url
-          ENV.fetch('RABBITMQ_MANAGEMENT_URL', 'http://localhost:15672')
+          OT.conf.dig('jobs', 'rabbitmq_management_url') ||
+            ENV.fetch('RABBITMQ_MANAGEMENT_URL', 'http://localhost:15672')
         end
 
-        # Returns [user, password] extracted from RABBITMQ_URL.
+        # Returns [user, password] extracted from rabbitmq_url config.
         def management_credentials
-          amqp_url = ENV.fetch('RABBITMQ_URL', 'amqp://guest:guest@localhost:5672')
+          amqp_url = OT.conf.dig('jobs', 'rabbitmq_url')
           parsed   = parse_amqp_url(amqp_url)
           [parsed[:user], parsed[:password]]
         end

--- a/lib/onetime/cli/queue/reset_command.rb
+++ b/lib/onetime/cli/queue/reset_command.rb
@@ -82,7 +82,7 @@ module Onetime
         private
 
         def reset_queues(queue_names)
-          conn    = Bunny.new(ENV.fetch('RABBITMQ_URL', 'amqp://guest:guest@localhost:5672'))
+          conn    = Bunny.new(OT.conf.dig('jobs', 'rabbitmq_url'))
           conn.start
           channel = conn.create_channel
 

--- a/lib/onetime/cli/queue/status_command.rb
+++ b/lib/onetime/cli/queue/status_command.rb
@@ -92,7 +92,7 @@ module Onetime
         end
 
         def check_rabbitmq_connection
-          amqp_url = ENV.fetch('RABBITMQ_URL', 'amqp://guest:guest@localhost:5672')
+          amqp_url = OT.conf.dig('jobs', 'rabbitmq_url')
           conn     = Bunny.new(amqp_url)
           conn.start
 
@@ -112,7 +112,7 @@ module Onetime
         end
 
         def check_queue_depths
-          conn = Bunny.new(ENV.fetch('RABBITMQ_URL', 'amqp://guest:guest@localhost:5672'))
+          conn = Bunny.new(OT.conf.dig('jobs', 'rabbitmq_url'))
           conn.start
 
           queues = {}
@@ -141,7 +141,7 @@ module Onetime
         end
 
         def check_exchanges
-          conn = Bunny.new(ENV.fetch('RABBITMQ_URL', 'amqp://guest:guest@localhost:5672'))
+          conn = Bunny.new(OT.conf.dig('jobs', 'rabbitmq_url'))
           conn.start
 
           exchanges = {}
@@ -203,7 +203,7 @@ module Onetime
         end
 
         def check_dlq_policies
-          amqp_url = ENV.fetch('RABBITMQ_URL', 'amqp://guest:guest@localhost:5672')
+          amqp_url = OT.conf.dig('jobs', 'rabbitmq_url')
           parsed   = parse_amqp_url(amqp_url)
           vhost    = URI.encode_www_form_component(parsed[:vhost])
 

--- a/lib/onetime/cli/status_command.rb
+++ b/lib/onetime/cli/status_command.rb
@@ -421,7 +421,7 @@ module Onetime
 
         require 'bunny'
 
-        url  = OT.conf.dig('jobs', 'rabbitmq_url') || ENV.fetch('RABBITMQ_URL', 'amqp://localhost:5672')
+        url  = OT.conf.dig('jobs', 'rabbitmq_url')
         conn = Bunny.new(url)
         conn.start
 

--- a/lib/onetime/cli/worker_command.rb
+++ b/lib/onetime/cli/worker_command.rb
@@ -82,7 +82,9 @@ module Onetime
 
           boot_application!
 
-          @amqp_url = ENV.fetch('RABBITMQ_URL', 'amqp://guest:guest@localhost:5672')
+          # Config file handles ENV resolution via ERB with sensible defaults.
+          # Don't read ENV directly - keeps input validation in one place.
+          @amqp_url = OT.conf.dig('jobs', 'rabbitmq_url')
 
           # Preflight check: verify RabbitMQ is reachable before proceeding
           preflight_check!
@@ -323,8 +325,8 @@ module Onetime
             },
           }
 
-          # Override vhost only if explicitly set via env var.
-          # Otherwise, let Bunny parse it from the AMQP URL.
+          # ENV override intentional: allows vhost override without changing config file.
+          # Useful for debugging or running worker against a different vhost temporarily.
           config[:vhost] = ENV['RABBITMQ_VHOST'] if ENV.key?('RABBITMQ_VHOST')
 
           # TLS configuration for amqps:// connections (centralized in QueueConfig)

--- a/lib/onetime/cli/worker_command.rb
+++ b/lib/onetime/cli/worker_command.rb
@@ -86,6 +86,8 @@ module Onetime
           # Don't read ENV directly - keeps input validation in one place.
           @amqp_url = OT.conf.dig('jobs', 'rabbitmq_url')
 
+          Onetime.bunny_logger.info "[init] RabbitMQ: Connecting to #{mask_amqp_credentials(@amqp_url)}"
+
           # Preflight check: verify RabbitMQ is reachable before proceeding
           preflight_check!
 

--- a/lib/onetime/cli/worker_command.rb
+++ b/lib/onetime/cli/worker_command.rb
@@ -331,6 +331,20 @@ module Onetime
           config.merge!(Onetime::Jobs::QueueConfig.tls_options(@amqp_url))
 
           Sneakers.configure(config)
+
+          # Register error reporter to catch exceptions that escape worker handlers.
+          # This surfaces errors that would otherwise be silently swallowed.
+          Sneakers.error_reporters << ->(exception, worker, context) {
+            Onetime.workers_logger.error(
+              '[Sneakers] Unhandled exception in worker',
+              worker: worker&.class&.name || 'unknown',
+              error: exception.message,
+              error_class: exception.class.name,
+              backtrace: exception.backtrace&.first(10),
+              context: context.to_s[0..500],
+            )
+            SemanticLogger.flush if defined?(SemanticLogger)
+          }
         end
 
         def determine_workers(queues_str)

--- a/lib/onetime/errors.rb
+++ b/lib/onetime/errors.rb
@@ -150,6 +150,7 @@ module Onetime
     def to_h
       {
         error: message,
+        error_type: 'EntitlementRequired',
         entitlement: entitlement,
         current_plan: current_plan,
         upgrade_to: upgrade_to,
@@ -184,7 +185,8 @@ module Onetime
 
     def to_h
       {
-        message: message,
+        error: message,
+        error_type: 'GuestRoutesDisabled',
         code: code,
         error_key: error_key,
       }.compact

--- a/lib/onetime/errors.rb
+++ b/lib/onetime/errors.rb
@@ -64,8 +64,8 @@ module Onetime
 
     def to_h
       {
-        error: 'RecordNotFound',
-        message: message,
+        error: message,
+        error_type: 'RecordNotFound',
         error_key: error_key,
       }.compact
     end
@@ -92,8 +92,8 @@ module Onetime
 
     def to_h
       {
-        error: error_type || 'FormError',
-        message: message,
+        error: message,
+        error_type: error_type,
         field: field,
         error_key: error_key,
       }.compact
@@ -121,8 +121,8 @@ module Onetime
 
     def to_h
       {
-        error: 'Forbidden',
-        message: message,
+        error: message,
+        error_type: 'Forbidden',
         error_key: error_key,
       }.compact
     end
@@ -140,9 +140,9 @@ module Onetime
 
     def initialize(entitlement, current_plan: nil, upgrade_to: nil, message: nil,
                    error_key: nil, args: {})
-      @entitlement  = entitlement
-      @current_plan = current_plan
-      @upgrade_to   = upgrade_to
+      @entitlement    = entitlement
+      @current_plan   = current_plan
+      @upgrade_to     = upgrade_to
       default_message = "Feature requires #{entitlement.to_s.tr('_', ' ')} entitlement"
       super(message || default_message, error_key: error_key, args: args)
     end
@@ -210,8 +210,8 @@ module Onetime
 
     def to_h
       {
-        error: 'LimitExceeded',
-        message: message,
+        error: message,
+        error_type: 'LimitExceeded',
         retry_after: retry_after,
         attempts: attempts,
         max_attempts: max_attempts,

--- a/lib/onetime/initializers/setup_loggers.rb
+++ b/lib/onetime/initializers/setup_loggers.rb
@@ -39,6 +39,7 @@ module Onetime
         'Bunny' => 'DEBUG_BUNNY',
         'Familia' => 'DEBUG_FAMILIA',
         'HTTP' => 'DEBUG_HTTP',
+        'Jobs' => 'DEBUG_JOBS',
         'Otto' => 'DEBUG_OTTO',
         'Rhales' => 'DEBUG_RHALES',
         'Scheduler' => 'DEBUG_SCHEDULER',

--- a/lib/onetime/initializers/setup_rabbitmq.rb
+++ b/lib/onetime/initializers/setup_rabbitmq.rb
@@ -104,8 +104,10 @@ module Onetime
       # manage their own consumer connections internally.
       # See: docs/architecture/fork-safety.md
       def setup_rabbitmq_connection
-        url       = OT.conf.dig('jobs', 'rabbitmq_url') || ENV.fetch('RABBITMQ_URL', 'amqp://localhost:5672')
-        pool_size = OT.conf.dig('jobs', 'channel_pool_size') || ENV.fetch('RABBITMQ_CHANNEL_POOL_SIZE', 5).to_i
+        # Config file handles ENV resolution via ERB with sensible defaults.
+        # Don't read ENV directly - keeps input validation in one place.
+        url       = OT.conf.dig('jobs', 'rabbitmq_url')
+        pool_size = OT.conf.dig('jobs', 'channel_pool_size') || 5
 
         Onetime.bunny_logger.info "[init] RabbitMQ: Connecting to #{sanitize_url(url)}"
 

--- a/lib/onetime/jobs/queues/config.rb
+++ b/lib/onetime/jobs/queues/config.rb
@@ -145,6 +145,9 @@ module Onetime
       # Managed services (Northflank, CloudAMQP) provide valid certificates that work
       # with system CA bundle - no custom certs needed.
       #
+      # ENV reads are intentional here: TLS settings are deployment-specific and often
+      # need override without config file changes (e.g., disable verify_peer in dev).
+      #
       # Environment variables:
       # - RABBITMQ_VERIFY_PEER: 'true' (default) or 'false' for local dev
       # - RABBITMQ_CA_CERTIFICATES: Optional path to custom CA cert file

--- a/lib/onetime/jobs/scheduled/dlq_email_consumer_job.rb
+++ b/lib/onetime/jobs/scheduled/dlq_email_consumer_job.rb
@@ -124,8 +124,7 @@ module Onetime
             if $rmq_conn&.open?
               [$rmq_conn, $rmq_conn.create_channel, false]
             else
-              url  = OT.conf.dig('jobs', 'rabbitmq_url') ||
-                     ENV.fetch('RABBITMQ_URL', 'amqp://localhost:5672')
+              url  = OT.conf.dig('jobs', 'rabbitmq_url')
               conn = Bunny.new(url)
               conn.start
               [conn, conn.create_channel, true]

--- a/lib/onetime/jobs/scheduled/dlq_monitor_job.rb
+++ b/lib/onetime/jobs/scheduled/dlq_monitor_job.rb
@@ -44,7 +44,7 @@ module Onetime
           end
 
           def check_dlq_depths
-            url  = ENV.fetch('RABBITMQ_URL', 'amqp://guest:guest@localhost:5672')
+            url  = OT.conf.dig('jobs', 'rabbitmq_url')
             conn = Bunny.new(url)
             conn.start
 

--- a/lib/onetime/jobs/workers/base_worker.rb
+++ b/lib/onetime/jobs/workers/base_worker.rb
@@ -105,12 +105,14 @@ module Onetime
           # @param msg [String] Raw message body
           # @return [Hash, nil] Parsed message data, or nil if invalid
           def parse_message(msg)
+            log_debug 'Parsing message', message_id: message_id, size: msg&.bytesize
             data = JSON.parse(msg, symbolize_names: true)
             return nil unless validate_schema(data)
 
             data
           rescue JSON::ParserError => ex
-            log_error "Invalid JSON: #{ex.message}"
+            log_error "Invalid JSON: #{ex.message}", message_id: message_id
+            flush_logs
             reject!
             nil
           end
@@ -121,7 +123,8 @@ module Onetime
             version = @metadata&.headers&.[]('x-schema-version') || 1
 
             unless Onetime::Jobs::QueueConfig::Versions.const_defined?("V#{version}")
-              log_error "Unknown schema version: #{version}"
+              log_error "Unknown schema version: #{version}", message_id: message_id
+              flush_logs
               reject!
               return false
             end
@@ -154,6 +157,14 @@ module Onetime
             else
               logger.error message, worker: worker_name, **payload
             end
+          end
+
+          # Flush async log appender to ensure messages are written.
+          # Call before reject!/ack! when debugging missing logs.
+          def flush_logs
+            SemanticLogger.flush if defined?(SemanticLogger)
+          rescue StandardError
+            # Don't let flush failures break message processing
           end
 
           def worker_name

--- a/lib/onetime/jobs/workers/email_worker.rb
+++ b/lib/onetime/jobs/workers/email_worker.rb
@@ -52,6 +52,11 @@ module Onetime
         # @param delivery_info [Bunny::DeliveryInfo] AMQP delivery info
         # @param metadata [Bunny::MessageProperties] AMQP message properties
         def work_with_params(msg, delivery_info, metadata)
+          # Instrument entry point - log before ANY other code runs
+          msg_id       = metadata&.message_id || 'unknown'
+          delivery_tag = delivery_info&.delivery_tag || 'unknown'
+          log_info 'Message received', message_id: msg_id, delivery_tag: delivery_tag
+
           store_envelope(delivery_info, metadata)
 
           data = nil
@@ -92,11 +97,19 @@ module Onetime
             log_error 'Non-transient delivery error, skipping to DLQ', ex
           end
           update_delivery_status(data, 'failed')
+          flush_logs
           reject! # Send to DLQ
         rescue StandardError => ex
           log_error 'Unexpected error delivering email', ex
           update_delivery_status(data, 'failed')
+          flush_logs
           reject! # Send to DLQ
+        rescue Exception => ex # rubocop:disable Lint/RescueException
+          # Catch non-StandardError exceptions (SignalException, SystemExit, etc.)
+          # that would otherwise escape without logging
+          log_error 'Fatal exception in email worker (non-StandardError)', ex
+          flush_logs
+          raise # Re-raise to let Sneakers handle process-level exceptions
         end
 
         # Templates that support delivery status tracking on the customer model

--- a/lib/onetime/models/organization.rb
+++ b/lib/onetime/models/organization.rb
@@ -113,6 +113,14 @@ module Onetime
       members.member?(dummy_customer)
     end
 
+    # Whether new memberships require explicit admin approval after the invitee
+    # consents (clicks Accept). Hardcoded to false until the approval workflow
+    # ships in a follow-up iteration; OrganizationMembership#accept! auto-promotes
+    # via activate! while this stays false.
+    def requires_admin_approval?
+      false
+    end
+
     def member_count
       # members is auto-generated sorted_set
       members.size

--- a/lib/onetime/models/organization_membership.rb
+++ b/lib/onetime/models/organization_membership.rb
@@ -228,26 +228,28 @@ module Onetime
       org_scoped? || domain_scope_id == domain.objid
     end
 
-    # Accept a pending invitation
+    # Accept a pending invitation (invitee consent step)
     #
-    # Uses Familia's staged relationship activation to atomically:
-    # - Add customer to org.members (active sorted set)
-    # - Add org to customer's participation reverse index
-    # - Remove from org.pending_invitations (staging set)
-    # - Create composite-keyed through model
-    # - Destroy UUID-keyed staged model
+    # Records the recipient's intent to join. Consumes the one-shot token and
+    # pending-state lookup indexes so the invite URL stops resolving — even
+    # if final activation is deferred for admin approval. When the
+    # organization does not require approval (the default), accept! auto-
+    # promotes via activate! and the membership becomes active in one call.
     #
-    # OTS-specific index transitions are handled before/after activation:
-    # - token_lookup: removed (pending-only index, token cleared for security)
-    # - org_email_lookup: removed (pending-only index)
-    # - org_customer_lookup: populated (active-only index)
+    # State transitions:
+    #   pending → accepted (when organization.requires_admin_approval?)
+    #   pending → active   (when no approval required; via activate!)
+    #
+    # Side-effect placement matrix:
+    #   accept!   — token consumed, pending indexes cleared
+    #   activate! — joined_at set, customer added to members, org_customer_lookup populated
     #
     # @param customer [Onetime::Customer] The customer accepting the invite
-    # @param provisioning_source [String, nil] Lifecycle attribution for the
-    #   activated membership (e.g. 'invited', 'sso'). Pass-through to
-    #   through_attrs; callers (API logic classes) own the value.
+    # @param provisioning_source [String, nil] Lifecycle attribution forwarded
+    #   to activate! for the activated membership (e.g. 'invited', 'sso').
     # @return [Boolean] true if acceptance succeeded
-    # @raise [Onetime::Problem] if invitation is expired or declined
+    # @raise [Onetime::Problem] if invitation is expired, declined, or
+    #   the accepting customer's email does not match the invited email
     def accept!(customer, provisioning_source: nil)
       # Idempotency guard: if the customer was concurrently added to the org
       # (e.g. by another process calling add_members_instance), return the
@@ -261,51 +263,43 @@ module Onetime
       raise Onetime::Problem, 'Invitation expired' if expired?
       raise Onetime::Problem, 'Invitation declined' if status == 'declined'
 
+      # Defense-in-depth email match. The primary check happens earlier in
+      # the request lifecycle (apps/web/auth/config/hooks/account.rb
+      # before_create_account and apps/api/invite/logic/invites/*#raise_concerns)
+      # so account creation aborts before partial Redis state lands.
       emails_match = invited_email.nil? ||
                      OT::Utils.normalize_email(customer.email) ==
                      OT::Utils.normalize_email(invited_email)
       raise Onetime::Problem, 'Email mismatch' unless emails_match
 
-      # Capture values from staged model before activation destroys it
-      old_token              = token
-      old_org_email_key      = org_email_key
-      carry_role             = role
-      carry_invited_email    = invited_email
-      carry_invited_by       = invited_by
-      carry_invited_at       = invited_at
-      carry_resend_count     = resend_count
-      carry_domain_scope_id  = domain_scope_id
-
       org = organization
       raise Onetime::Problem, 'Organization not found' unless org
 
-      # Clean up pending-state OTS indexes BEFORE activation.
-      # The staged model's save populated these indexes. The activated model
-      # will re-populate org_email_lookup (same key, new objid) during its save,
-      # so we must remove the old entry first to avoid RecordExistsError.
+      # Consume pending-state indexes. The token and org_email lookups are
+      # pending-only and must be cleared whether we activate inline or
+      # defer to admin approval.
+      old_token         = token
+      old_org_email_key = org_email_key
       self.class.token_lookup.remove_field(old_token) if old_token
       self.class.org_email_lookup.remove_field(old_org_email_key) if old_org_email_key
 
       begin
-        # Activate via Familia staged relationships: handles the three-structure
-        # invariant (active set + reverse index + staging set removal) atomically,
-        # then creates composite-keyed through model and destroys this UUID model.
-        activated = org.activate_members_instance(
-          self,
-          customer,
-          through_attrs: {
-            role: carry_role,
-            status: 'active',
-            invited_email: carry_invited_email,
-            invited_by: carry_invited_by,
-            invited_at: carry_invited_at,
-            joined_at: Familia.now.to_f,
-            resend_count: carry_resend_count,
-            domain_scope_id: carry_domain_scope_id,
-            provisioning_source: provisioning_source,
-            token: nil, # Clear token for security
-          },
-        )
+        if org.requires_admin_approval?
+          # Intermediate state: customer consented, awaiting admin approval.
+          # NOTE: the approval endpoint and an `awaiting_approval` staging
+          # set ship in a follow-up. While requires_admin_approval? stays
+          # hardcoded false, this branch is unreachable in production.
+          self.status         = 'accepted'
+          self.customer_objid = customer.objid
+          self.token          = nil
+          save
+          # save re-populates org_email_lookup via auto_update_class_indexes;
+          # remove again so the staged model isn't discoverable as pending.
+          self.class.org_email_lookup.remove_field(org_email_key) if org_email_key
+        else
+          # Auto-promote: no approval required, activate inline.
+          activate!(customer, provisioning_source: provisioning_source)
+        end
       rescue Familia::Problem, Redis::BaseError, Onetime::Problem
         # Restore pending-state indexes so the invitation remains discoverable
         # if activation fails (e.g. Redis/network error, validation error).
@@ -313,6 +307,64 @@ module Onetime
         self.class.org_email_lookup[old_org_email_key] = objid if old_org_email_key
         raise
       end
+
+      true
+    end
+
+    # Promote a staged or accepted membership to active.
+    #
+    # Owns the staged → active transition via activate_members_instance and
+    # populates the active-state index (org_customer_lookup). Invoked inline
+    # from accept! for orgs that do not require admin approval, and (in a
+    # follow-up iteration) from an explicit /approve endpoint when approval
+    # is required.
+    #
+    # Uses Familia's staged relationship activation to atomically:
+    # - Add customer to org.members (active sorted set)
+    # - Add org to customer's participation reverse index
+    # - Remove from org.pending_invitations (staging set)
+    # - Create composite-keyed through model
+    # - Destroy UUID-keyed staged model
+    #
+    # @param customer [Onetime::Customer] The customer becoming active
+    # @param provisioning_source [String, nil] Lifecycle attribution stored
+    #   on the activated membership.
+    # @return [Boolean] true if activation succeeded
+    def activate!(customer, provisioning_source: nil)
+      org = organization
+      raise Onetime::Problem, 'Organization not found' unless org
+
+      if active? || org.member?(customer)
+        OT.info "[activate!] Customer #{customer.custid} already active in org #{organization_objid} — skipping"
+        return true
+      end
+
+      carry_role            = role
+      carry_invited_email   = invited_email
+      carry_invited_by      = invited_by
+      carry_invited_at      = invited_at
+      carry_resend_count    = resend_count
+      carry_domain_scope_id = domain_scope_id
+
+      # Activate via Familia staged relationships: handles the three-structure
+      # invariant (active set + reverse index + staging set removal) atomically,
+      # then creates composite-keyed through model and destroys this UUID model.
+      activated = org.activate_members_instance(
+        self,
+        customer,
+        through_attrs: {
+          role: carry_role,
+          status: 'active',
+          invited_email: carry_invited_email,
+          invited_by: carry_invited_by,
+          invited_at: carry_invited_at,
+          joined_at: Familia.now.to_f,
+          resend_count: carry_resend_count,
+          domain_scope_id: carry_domain_scope_id,
+          provisioning_source: provisioning_source,
+          token: nil, # Clear token for security
+        },
+      )
 
       # Re-populate org_email_lookup on the NEW composite-keyed model.
       # activate_members_instance saves the composite model (populates
@@ -331,10 +383,10 @@ module Onetime
         self.class.org_customer_lookup[activated.org_customer_key] = activated.objid
       end
 
-      # Update in-memory state so callers see the accepted state.
+      # Update in-memory state so callers see the activated state.
       # The UUID-keyed Redis entry is already destroyed by activate.
       # Setting objid to the composite key ensures that refresh! and
-      # load(objid) work correctly post-accept.
+      # load(objid) work correctly post-activate.
       self.objid          = activated.objid
       self.customer_objid = customer.objid
       self.status         = 'active'

--- a/locales/content/en/workspace-organizations.json
+++ b/locales/content/en/workspace-organizations.json
@@ -820,15 +820,17 @@
     "context": "Hint text explaining why email field is readonly",
     "content_hash": "2cff7075"
   },
-  "web.organizations.invitations.create_account_and_join": {
+  "web.organizations.invitations.signup_continue": {
     "text": "Continue",
-    "context": "Button text for signup form in invitation flow",
-    "content_hash": "31fbef16"
+    "context": "Submit button on the invite signup form. Submits the form and creates the account; the user then confirms the join on the next screen."
   },
-  "web.organizations.invitations.sign_in_and_accept": {
-    "text": "Sign In & Accept Invitation",
-    "context": "Button text for signin form in invitation flow",
-    "content_hash": "a6a5417a"
+  "web.organizations.invitations.signin_continue": {
+    "text": "Sign In",
+    "context": "Submit button on the invite signin form. Signs the user in; the user then confirms the join on the next screen."
+  },
+  "web.organizations.invitations.confirm_join_below": {
+    "text": "Almost done — confirm below to join the organization.",
+    "context": "Success message shown after the user completes signup or signin from an invite link. The Decline/Accept buttons appear immediately below."
   },
   "web.organizations.invitations.go_to_organizations": {
     "text": "Go to Organizations",

--- a/locales/content/en/workspace-organizations.json
+++ b/locales/content/en/workspace-organizations.json
@@ -279,6 +279,15 @@
     "text": "members",
     "content_hash": "17373ca1"
   },
+  "web.organizations.members.member_quota": {
+    "text": "{used} of {limit} members"
+  },
+  "web.organizations.members.pending_suffix": {
+    "text": "({count} pending)"
+  },
+  "web.organizations.members.limit_reached_hint": {
+    "text": "Member limit reached."
+  },
   "web.organizations.members.name": {
     "text": "Name",
     "content_hash": "dcd1d522"

--- a/spec/integration/all/jobs/workers/base_worker_spec.rb
+++ b/spec/integration/all/jobs/workers/base_worker_spec.rb
@@ -224,6 +224,7 @@ RSpec.describe Onetime::Jobs::Workers::BaseWorker, type: :integration do
         allow(worker).to receive(:reject!)
         mock_logger = instance_double(SemanticLogger::Logger)
         allow(worker).to receive(:logger).and_return(mock_logger)
+        allow(mock_logger).to receive(:debug)
         expect(mock_logger).to receive(:error).with(/Invalid JSON/, hash_including(:worker))
 
         worker.parse_message(invalid_message)

--- a/spec/integration/all/jobs/workers/sneakers_harness_spec.rb
+++ b/spec/integration/all/jobs/workers/sneakers_harness_spec.rb
@@ -233,7 +233,7 @@ RSpec.describe 'Sneakers Worker Harness', type: :integration do
     describe '#parse_message' do
       before do
         # Store minimal envelope for validate_schema
-        metadata = double('metadata', headers: { 'x-schema-version' => 1 })
+        metadata = double('metadata', message_id: nil, headers: { 'x-schema-version' => 1 })
         worker.store_envelope(nil, metadata)
       end
 
@@ -249,7 +249,7 @@ RSpec.describe 'Sneakers Worker Harness', type: :integration do
       end
 
       it 'rejects unknown schema versions' do
-        metadata = double('metadata', headers: { 'x-schema-version' => 999 })
+        metadata = double('metadata', message_id: nil, headers: { 'x-schema-version' => 999 })
         worker.store_envelope(nil, metadata)
 
         result = worker.parse_message('{"key": "value"}')

--- a/spec/integration/api/v3/guest_route_gating_spec.rb
+++ b/spec/integration/api/v3/guest_route_gating_spec.rb
@@ -367,7 +367,7 @@ RSpec.describe 'API V3 Guest Route Gating', type: :integration do
   describe 'GuestRoutesDisabled error structure' do
     before { stub_guest_routes_config(enabled: false) }
 
-    it 'includes message and code in to_h' do
+    it 'includes error and code in to_h' do
       logic = create_logic(V3::Logic::Secrets::ConcealSecret, params: { 'secret' => { 'secret' => 'test' } })
       logic.process_params
 
@@ -376,7 +376,8 @@ RSpec.describe 'API V3 Guest Route Gating', type: :integration do
 
       hash = error.to_h
       expect(hash).to include(
-        message: 'Guest API access is disabled',
+        error: 'Guest API access is disabled',
+        error_type: 'GuestRoutesDisabled',
         code: 'GUEST_ROUTES_DISABLED',
       )
     end

--- a/spec/unit/onetime/cli/queue/init_command_spec.rb
+++ b/spec/unit/onetime/cli/queue/init_command_spec.rb
@@ -16,10 +16,19 @@ RSpec.describe Onetime::CLI::Queue::InitCommand do
   let(:encoded_name) { URI.encode_www_form_component(policy[:name]) }
   let(:policy_url) { "#{management_base}/api/policies/#{encoded_vhost}/#{encoded_name}" }
 
+  # RabbitMQ URL and Management URL are read from OT.conf (not ENV directly)
+  # since commit ec718be6a routed all RabbitMQ URL reads through config.
+  let(:test_conf) do
+    {
+      'jobs' => {
+        'rabbitmq_url' => amqp_url,
+        'rabbitmq_management_url' => management_base,
+      },
+    }
+  end
+
   before do
-    allow(ENV).to receive(:fetch).and_call_original
-    allow(ENV).to receive(:fetch).with('RABBITMQ_URL', anything).and_return(amqp_url)
-    allow(ENV).to receive(:fetch).with('RABBITMQ_MANAGEMENT_URL', anything).and_return(management_base)
+    allow(OT).to receive(:conf).and_return(test_conf)
     allow(command).to receive(:boot_application!)
     allow(command).to receive(:create_vhost)
     allow(command).to receive(:set_permissions)

--- a/spec/unit/onetime/errors_spec.rb
+++ b/spec/unit/onetime/errors_spec.rb
@@ -68,8 +68,8 @@ RSpec.describe Onetime::LimitExceeded do
         error_key: 'api.limits.errors.too_many_attempts',
       )
       expect(error.to_h).to eq(
-        error: 'LimitExceeded',
-        message: 'blocked',
+        error: 'blocked',
+        error_type: 'LimitExceeded',
         retry_after: 60,
         attempts: 6,
         max_attempts: 5,
@@ -130,7 +130,8 @@ RSpec.describe Onetime::GuestRoutesDisabled do
         error_key: 'api.guest.errors.routes_disabled',
       )
       expect(error.to_h).to eq(
-        message: 'nope',
+        error: 'nope',
+        error_type: 'GuestRoutesDisabled',
         code: 'CUSTOM_CODE',
         error_key: 'api.guest.errors.routes_disabled',
       )

--- a/spec/unit/onetime/incoming/recipient_resolver_spec.rb
+++ b/spec/unit/onetime/incoming/recipient_resolver_spec.rb
@@ -60,8 +60,8 @@ RSpec.describe Onetime::Incoming::RecipientResolver do
         expect { resolver.require_domain_entitlement!('incoming_secrets') }
           .to raise_error(Onetime::Forbidden) do |error|
             expect(error.to_h).to include(
-              error: 'Forbidden',
-              message: 'Custom domain organization could not be resolved',
+              error: 'Custom domain organization could not be resolved',
+              error_type: 'Forbidden',
               error_key: 'api.incoming.errors.custom_domain_unresolved',
             )
           end

--- a/spec/unit/onetime/initializers/setup_rabbitmq_spec.rb
+++ b/spec/unit/onetime/initializers/setup_rabbitmq_spec.rb
@@ -526,17 +526,14 @@ RSpec.describe Onetime::Initializers::SetupRabbitMQ do
     end
   end
 
-  describe 'RABBITMQ_CHANNEL_POOL_SIZE environment variable' do
+  describe 'channel_pool_size config' do
+    # RABBITMQ_CHANNEL_POOL_SIZE env var is resolved at config-load time
+    # by ERB in etc/defaults/config.defaults.yaml; runtime code reads
+    # OT.conf.dig('jobs', 'channel_pool_size') and never touches ENV.
     around do |example|
-      original_pool_size = ENV['RABBITMQ_CHANNEL_POOL_SIZE']
       original_skip = ENV['SKIP_RABBITMQ_SETUP']
       example.run
     ensure
-      if original_pool_size.nil?
-        ENV.delete('RABBITMQ_CHANNEL_POOL_SIZE')
-      else
-        ENV['RABBITMQ_CHANNEL_POOL_SIZE'] = original_pool_size
-      end
       if original_skip.nil?
         ENV.delete('SKIP_RABBITMQ_SETUP')
       else
@@ -544,20 +541,19 @@ RSpec.describe Onetime::Initializers::SetupRabbitMQ do
       end
     end
 
-    context 'when RABBITMQ_CHANNEL_POOL_SIZE is set' do
+    context 'when channel_pool_size is set in config' do
       before do
-        ENV['RABBITMQ_CHANNEL_POOL_SIZE'] = '10'
         ENV.delete('SKIP_RABBITMQ_SETUP')
         allow(OT).to receive(:conf).and_return({
           'jobs' => {
             'enabled' => true,
-            'rabbitmq_url' => 'amqp://localhost'
-            # Note: no channel_pool_size in config - should use env var
+            'rabbitmq_url' => 'amqp://localhost',
+            'channel_pool_size' => 10,
           }
         })
       end
 
-      it 'uses the environment variable value for pool size' do
+      it 'uses the configured value for pool size' do
         mock_conn = instance_double(Bunny::Session, start: true, open?: true)
         mock_channel = instance_double(Bunny::Channel)
         mock_pool = instance_double(ConnectionPool)

--- a/spec/unit/onetime/logic/guest_route_gating_spec.rb
+++ b/spec/unit/onetime/logic/guest_route_gating_spec.rb
@@ -244,12 +244,13 @@ RSpec.describe Onetime::Logic::GuestRouteGating do
       expect(error.code).to eq('CUSTOM_CODE')
     end
 
-    it 'serializes to hash with message and code' do
+    it 'serializes to hash with error, error_type, and code' do
       error = Onetime::GuestRoutesDisabled.new('Test message', code: 'TEST_CODE')
       hash = error.to_h
 
       expect(hash).to eq({
-        message: 'Test message',
+        error: 'Test message',
+        error_type: 'GuestRoutesDisabled',
         code: 'TEST_CODE',
       })
     end

--- a/spec/unit/onetime/logic/sso_only_gating_spec.rb
+++ b/spec/unit/onetime/logic/sso_only_gating_spec.rb
@@ -71,8 +71,8 @@ RSpec.describe Onetime::Logic::SsoOnlyGating do
         expect { instance.require_non_sso_only! }
           .to raise_error(Onetime::Forbidden) do |error|
             expect(error.to_h).to include(
-              error: 'Forbidden',
-              message: 'This action is not available in SSO-only mode',
+              error: 'This action is not available in SSO-only mode',
+              error_type: 'Forbidden',
               error_key: 'api.errors.sso_only_action_blocked',
             )
           end

--- a/src/apps/session/components/InviteSignInForm.vue
+++ b/src/apps/session/components/InviteSignInForm.vue
@@ -50,7 +50,7 @@ const emit = defineEmits<{
 }>();
 
 const { t } = useI18n();
-const { loginAndAccept, isLoading, error, fieldErrors, clearErrors } = useInviteAuth();
+const { loginForInvite, isLoading, error, fieldErrors, clearErrors } = useInviteAuth();
 const {
   requestMagicLink,
   sent: magicLinkSent,
@@ -153,7 +153,7 @@ const handleSubmit = async () => {
   clearErrors();
 
   try {
-    const result = await loginAndAccept(
+    const result = await loginForInvite(
       props.invitedEmail,
       password.value,
       props.inviteToken
@@ -413,7 +413,7 @@ const handleSubmit = async () => {
                        disabled:cursor-not-allowed disabled:opacity-50"
                 data-testid="invite-signin-submit">
                 <span v-if="isSubmitting || isLoading">{{ t('web.COMMON.processing') }}</span>
-                <span v-else>{{ t('web.organizations.invitations.sign_in_and_accept') }}</span>
+                <span v-else>{{ t('web.organizations.invitations.signin_continue') }}</span>
               </button>
             </div>
             <!-- Loading state announcement (screen reader only) -->
@@ -695,7 +695,7 @@ const handleSubmit = async () => {
                    disabled:cursor-not-allowed disabled:opacity-50"
             data-testid="invite-signin-submit">
             <span v-if="isSubmitting || isLoading">{{ t('web.COMMON.processing') }}</span>
-            <span v-else>{{ t('web.organizations.invitations.sign_in_and_accept') }}</span>
+            <span v-else>{{ t('web.organizations.invitations.signin_continue') }}</span>
           </button>
         </div>
         <!-- Loading state announcement (screen reader only) -->

--- a/src/apps/session/components/InviteSignUpForm.vue
+++ b/src/apps/session/components/InviteSignUpForm.vue
@@ -50,7 +50,7 @@ const emit = defineEmits<{
 }>();
 
 const { t } = useI18n();
-const { signupAndAccept, isLoading, error, fieldErrors, clearErrors } = useInviteAuth();
+const { signupForInvite, isLoading, error, fieldErrors, clearErrors } = useInviteAuth();
 const {
   requestMagicLink,
   sent: magicLinkSent,
@@ -171,7 +171,7 @@ const handleSubmit = async () => {
   clearErrors();
 
   try {
-    const result = await signupAndAccept(
+    const result = await signupForInvite(
       props.invitedEmail,
       password.value,
       termsAgreed.value,
@@ -538,7 +538,7 @@ const handleSubmit = async () => {
                 data-testid="invite-signup-submit">
                 <span v-if="isSubmitting || isLoading">{{ t('web.COMMON.processing') }}</span>
                 <template v-else>
-                  {{ t('web.organizations.invitations.create_account_and_join') }}
+                  {{ t('web.organizations.invitations.signup_continue') }}
                   <OIcon collection="heroicons"
 name="arrow-right"
 class="size-4"
@@ -929,7 +929,7 @@ aria-hidden="true" />
             data-testid="invite-signup-submit">
             <span v-if="isSubmitting || isLoading">{{ t('web.COMMON.processing') }}</span>
             <template v-else>
-              {{ t('web.organizations.invitations.create_account_and_join') }}
+              {{ t('web.organizations.invitations.signup_continue') }}
               <OIcon collection="heroicons"
 name="arrow-right"
 class="size-4"

--- a/src/apps/session/composables/useInviteAuth.ts
+++ b/src/apps/session/composables/useInviteAuth.ts
@@ -23,23 +23,23 @@ export interface InviteAuthResult {
   accountExists?: boolean;
 }
 
-/** Shape of Rodauth-style error responses */
-interface RodauthErrorResponse {
+/** Shape of API error responses */
+interface ApiErrorResponse {
   error?: string;
   'field-error'?: [string, string];
 }
 
 /** Shape of axios-style errors */
 interface AxiosLikeError {
-  response?: { data?: RodauthErrorResponse };
+  response?: { data?: ApiErrorResponse };
   message?: string;
 }
 
 /**
- * Extracts error info from a Rodauth-style response or axios error.
+ * Extracts error info from an API response or axios error.
  */
 function extractErrorInfo(
-  data: RodauthErrorResponse | undefined,
+  data: ApiErrorResponse | undefined,
   err?: AxiosLikeError
 ): { message: string | null; fieldError?: [string, string] } {
   const errorData = data ?? err?.response?.data;

--- a/src/apps/session/composables/useInviteAuth.ts
+++ b/src/apps/session/composables/useInviteAuth.ts
@@ -91,6 +91,26 @@ export function useInviteAuth() {
   }
 
   /**
+   * Completes the invitation acceptance by POSTing to /api/invite/:token/accept.
+   *
+   * Called after signup or login succeeds and a session is established. The
+   * backend leaves the invitation pending after auth so the acceptance step
+   * stays explicit and the same code path serves both flows. A non-success
+   * response here is logged but not propagated — the user is authenticated,
+   * the AcceptInvite page will recover via its direct_accept handler on
+   * the next render.
+   */
+  async function acceptPendingInvite(inviteToken: string): Promise<void> {
+    try {
+      await $api.post(`/api/invite/${inviteToken}/accept`, {
+        shrimp: csrfStore.shrimp,
+      });
+    } catch (e) {
+      console.warn('[useInviteAuth] /accept after auth failed:', e);
+    }
+  }
+
+  /**
    * Creates a new account and atomically accepts the invitation.
    * Uses the dedicated invite signup endpoint which derives email from the token.
    *
@@ -136,6 +156,13 @@ export function useInviteAuth() {
       authStore.setAuthenticated(true).catch((err) => {
         console.warn('[useInviteAuth] Background auth sync failed after signup:', err);
       });
+
+      // Complete the join: the signup endpoint creates the account and
+      // session but leaves the invitation pending. Issue the explicit
+      // /accept call now while the token is still valid and the user is
+      // authenticated.
+      await acceptPendingInvite(inviteToken);
+
       return { success: true };
     } catch (e) {
       const info = extractErrorInfo(undefined, e as AxiosLikeError);
@@ -190,12 +217,16 @@ export function useInviteAuth() {
         return { success: false, requiresMfa: true, redirect: `/invite/${inviteToken}` };
       }
 
-      // Login successful - membership already created by after_login hook.
-      // Fire-and-forget: same reasoning as signupAndAccept — awaiting triggers
-      // a reactive cascade that unmounts the form before emit('success') fires.
+      // Login established the session; complete the join via the explicit
+      // /accept call. The after_login hook no longer accepts invitations —
+      // signup and login share the same downstream acceptance path.
+      // Fire-and-forget setAuthenticated: awaiting triggers a reactive
+      // cascade that unmounts the form before emit('success') fires.
       authStore.setAuthenticated(true).catch((err) => {
         console.warn('[useInviteAuth] Background auth sync failed after login:', err);
       });
+
+      await acceptPendingInvite(inviteToken);
 
       return { success: true };
     } catch (e) {

--- a/src/apps/session/composables/useInviteAuth.ts
+++ b/src/apps/session/composables/useInviteAuth.ts
@@ -58,7 +58,12 @@ function extractErrorInfo(
  * Key differences from useAuth:
  * - Does NOT navigate - returns results for parent component to handle
  * - Handles invite token alongside auth operations
- * - Supports atomic signup+accept via invite_token parameter
+ *
+ * Explicit-consent design: signup and login establish a session but do NOT
+ * consume the invitation. The user must explicitly click Accept (or Decline)
+ * on the AcceptInvite view, which fires POST /api/invite/:token/accept against
+ * the live token. This keeps the join action visible and reversible until the
+ * user confirms.
  */
 /* eslint-disable max-lines-per-function */
 export function useInviteAuth() {
@@ -91,33 +96,16 @@ export function useInviteAuth() {
   }
 
   /**
-   * Completes the invitation acceptance by POSTing to /api/invite/:token/accept.
+   * Creates a new account for an invite, establishing a session.
    *
-   * Called after signup or login succeeds and a session is established. The
-   * backend leaves the invitation pending after auth so the acceptance step
-   * stays explicit and the same code path serves both flows. A non-success
-   * response here is logged but not propagated — the user is authenticated,
-   * the AcceptInvite page will recover via its direct_accept handler on
-   * the next render.
-   */
-  async function acceptPendingInvite(inviteToken: string): Promise<void> {
-    try {
-      await $api.post(`/api/invite/${inviteToken}/accept`, {
-        shrimp: csrfStore.shrimp,
-      });
-    } catch (e) {
-      console.warn('[useInviteAuth] /accept after auth failed:', e);
-    }
-  }
-
-  /**
-   * Creates a new account and atomically accepts the invitation.
-   * Uses the dedicated invite signup endpoint which derives email from the token.
+   * Does NOT consume the invitation — the backend leaves the membership in
+   * pending state. The parent view transitions to the explicit Decline/Accept
+   * screen and the user issues the /accept call themselves.
    *
    * @returns InviteAuthResult with accountExists: true if the backend indicates
    *          the account already exists (caller should switch to signin flow).
    */
-  async function signupAndAccept(
+  async function signupForInvite(
     _email: string, // Kept for API compatibility; backend derives email from token
     password: string,
     termsAgreed: boolean,
@@ -150,18 +138,11 @@ export function useInviteAuth() {
       // Server set session cookie via create_account_autologin — sync frontend state.
       // Fire-and-forget: awaiting would yield to the microtask queue, letting Vue
       // flush a re-render that unmounts InviteSignUpForm (inviteState transitions
-      // from signup_required → direct_accept) before emit('success') reaches the
-      // parent. The ACCEPT_SUCCESS_REDIRECT_DELAY_MS in AcceptInvite.vue gives
-      // the background refresh ample time to complete before navigation.
+      // from signup_required → direct_accept) before emit('success') reaches
+      // the parent.
       authStore.setAuthenticated(true).catch((err) => {
         console.warn('[useInviteAuth] Background auth sync failed after signup:', err);
       });
-
-      // Complete the join: the signup endpoint creates the account and
-      // session but leaves the invitation pending. Issue the explicit
-      // /accept call now while the token is still valid and the user is
-      // authenticated.
-      await acceptPendingInvite(inviteToken);
 
       return { success: true };
     } catch (e) {
@@ -178,11 +159,13 @@ export function useInviteAuth() {
   }
 
   /**
-   * Logs in an existing user and accepts the invitation atomically.
-   * The backend after_login hook handles invite acceptance when invite_token is present.
-   * Handles MFA by returning requiresMfa: true for parent to redirect.
+   * Logs in an existing user invited to an organization.
+   *
+   * Does NOT consume the invitation — only establishes the session. The user
+   * must explicitly click Accept on the AcceptInvite view to complete the join.
+   * Handles MFA by returning requiresMfa: true for the parent to redirect.
    */
-  async function loginAndAccept(
+  async function loginForInvite(
     email: string,
     password: string,
     inviteToken: string
@@ -194,8 +177,9 @@ export function useInviteAuth() {
     try {
       await refreshCsrf();
 
-      // Single call - backend after_login hook handles invite acceptance
-      // when invite_token is provided in the login request
+      // The invite_token is passed for telemetry/context; the after_login hook
+      // does not auto-accept. Acceptance happens via the explicit user click on
+      // the AcceptInvite view post-login.
       const loginResp = await $api.post('/auth/login', {
         login: email,
         password,
@@ -217,16 +201,16 @@ export function useInviteAuth() {
         return { success: false, requiresMfa: true, redirect: `/invite/${inviteToken}` };
       }
 
-      // Login established the session; complete the join via the explicit
-      // /accept call. The after_login hook no longer accepts invitations —
-      // signup and login share the same downstream acceptance path.
-      // Fire-and-forget setAuthenticated: awaiting triggers a reactive
-      // cascade that unmounts the form before emit('success') fires.
+      // Login established the session. The invitation is NOT accepted here —
+      // the user must explicitly click Accept on the AcceptInvite view. The
+      // after_login hook no longer auto-accepts; signup and login share the
+      // same downstream acceptance path (explicit user click).
+      //
+      // Fire-and-forget setAuthenticated: awaiting triggers a reactive cascade
+      // that unmounts the form before emit('success') fires.
       authStore.setAuthenticated(true).catch((err) => {
         console.warn('[useInviteAuth] Background auth sync failed after login:', err);
       });
-
-      await acceptPendingInvite(inviteToken);
 
       return { success: true };
     } catch (e) {
@@ -245,8 +229,8 @@ export function useInviteAuth() {
   }
 
   return {
-    signupAndAccept,
-    loginAndAccept,
+    signupForInvite,
+    loginForInvite,
     clearErrors,
     isLoading,
     error,

--- a/src/apps/session/views/AcceptInvite.vue
+++ b/src/apps/session/views/AcceptInvite.vue
@@ -49,7 +49,7 @@
   const isProcessing = ref(false);
 
   /**
-   * Invite state machine - 6 possible states
+   * Invite state machine
    *
    * States:
    * - loading: Initial fetch in progress
@@ -58,6 +58,8 @@
    * - direct_accept: Authenticated with correct email, can accept immediately
    * - wrong_email: Authenticated but with different email than invitation
    * - already_accepted: Invitation was already accepted (status: active)
+   * - accepted: User just accepted in this session (terminal, redirect pending)
+   * - declined: User just declined in this session (terminal, redirect pending)
    * - invalid: Invitation is expired, declined, revoked, or doesn't exist
    */
   type InviteState =
@@ -67,10 +69,18 @@
     | 'direct_accept'
     | 'wrong_email'
     | 'already_accepted'
+    | 'accepted'
+    | 'declined'
     | 'invalid';
+
+  // Terminal result of the in-session action. Once set, the state machine
+  // pins to the accepted/declined view until the redirect fires, preventing
+  // the action row from re-rendering during the redirect delay window.
+  const actionResult = ref<'accepted' | 'declined' | null>(null);
 
   const inviteState = computed<InviteState>(() => {
     if (isLoading.value) return 'loading';
+    if (actionResult.value) return actionResult.value;
     // If loading finished but no invitation (API error), show invalid state
     if (!invitation.value) return 'invalid';
 
@@ -167,10 +177,10 @@
         shrimp: csrfStore.shrimp,
       });
 
-      success.value = t('web.organizations.invitations.accept_success');
-
       // Reset organization store to force refetch on next mount
       organizationStore.$reset();
+
+      actionResult.value = 'accepted';
 
       setTimeout(() => {
         router.push('/orgs');
@@ -190,11 +200,7 @@
     try {
       await $api.post(`/api/invite/${invitationToken.value}/decline`);
 
-      // Update local state to hide invitation details immediately
-      if (invitation.value) {
-        invitation.value.status = 'declined';
-      }
-      success.value = t('web.organizations.invitations.decline_success');
+      actionResult.value = 'declined';
 
       setTimeout(() => {
         router.push('/');
@@ -334,6 +340,36 @@
           class="inline-flex items-center rounded-md bg-brand-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-brand-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-600 dark:bg-brand-500 dark:hover:bg-brand-400">
           {{ t('web.organizations.invitations.go_to_organizations') }}
         </router-link>
+      </div>
+    </div>
+
+    <!-- Terminal Action State (just accepted or declined in this session) -->
+    <div
+      v-else-if="inviteState === 'accepted' || inviteState === 'declined'"
+      :data-testid="inviteState === 'accepted' ? 'invite-accepted' : 'invite-declined'"
+      :style="{ '--brand-primary': primaryColor }"
+      class="rounded-lg border border-gray-200 bg-white p-8 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+      <div class="text-center">
+        <OIcon
+          collection="heroicons"
+          :name="inviteState === 'accepted' ? 'check-circle' : 'x-circle'"
+          :class="[
+            'mx-auto size-12',
+            inviteState === 'accepted'
+              ? 'text-green-500 dark:text-green-400'
+              : 'text-gray-400 dark:text-gray-500',
+          ]"
+          aria-hidden="true" />
+        <p class="mt-4 text-lg font-semibold text-gray-900 dark:text-white">
+          {{
+            inviteState === 'accepted'
+              ? t('web.organizations.invitations.accept_success')
+              : t('web.organizations.invitations.decline_success')
+          }}
+        </p>
+        <p class="mt-2 text-sm text-gray-500 dark:text-gray-400">
+          {{ t('web.COMMON.redirecting') }}
+        </p>
       </div>
     </div>
 

--- a/src/apps/session/views/AcceptInvite.vue
+++ b/src/apps/session/views/AcceptInvite.vue
@@ -36,11 +36,7 @@
     notify: false,
   });
 
-  // Delay before redirecting so the success message is visible and the
-  // background authStore sync (fire-and-forget from useInviteAuth) has time
-  // to settle before /orgs mounts and queries the store.
-  const ACCEPT_SUCCESS_REDIRECT_DELAY_MS = 1500;
-  // Longer delay for the direct accept/decline paths where the server has
+  // Delay for the direct accept/decline paths where the server has
   // already confirmed and no background auth sync is pending.
   const DIRECT_ACTION_REDIRECT_DELAY_MS = 2000;
 
@@ -214,16 +210,15 @@
   const formatDate = (timestamp: number): string => formatDisplayDate(new Date(timestamp * 1000));
 
   /**
-   * Handler for successful signup/signin + accept flow.
-   * Redirects to organizations page.
+   * Handler for successful signup/signin (auth established, session live).
+   *
+   * Does NOT redirect — the invitation is still pending. The state machine
+   * recomputes to direct_accept once authStore.isAuthenticated flips, which
+   * renders the explicit Accept/Decline buttons. The user must click one.
    */
-  function onAcceptSuccess() {
-    success.value = t('web.organizations.invitations.accept_success');
-    // Reset organization store to force refetch on next mount
-    organizationStore.$reset();
-    setTimeout(() => {
-      router.push('/orgs');
-    }, ACCEPT_SUCCESS_REDIRECT_DELAY_MS);
+  function onAuthSuccess() {
+    error.value = '';
+    success.value = t('web.organizations.invitations.confirm_join_below');
   }
 
   /**
@@ -393,7 +388,7 @@
         :invite-token="invitationToken"
         :org-name="invitation.organization_name"
         :auth-methods="invitation.auth_methods || []"
-        @success="onAcceptSuccess"
+        @success="onAuthSuccess"
         @error="onFormError"
         @decline="handleDecline"
         @account-exists="onAccountExists" />
@@ -474,7 +469,7 @@
           :invite-token="invitationToken"
           :org-name="invitation.organization_name"
           :auth-methods="invitation.auth_methods || []"
-          @success="onAcceptSuccess"
+          @success="onAuthSuccess"
           @error="onFormError"
           @mfa-required="onMfaRequired"
           @decline="handleDecline" />

--- a/src/apps/session/views/AcceptInvite.vue
+++ b/src/apps/session/views/AcceptInvite.vue
@@ -361,9 +361,6 @@
       </div>
 
       <BasicFormAlerts
-        v-if="error"
-        :error="error" />
-      <BasicFormAlerts
         v-if="success"
         :success="success" />
 
@@ -389,7 +386,7 @@
 
       </div>
 
-      <!-- Inline Signup Form -->
+      <!-- Inline Signup Form (handles its own error display) -->
       <InviteSignUpForm
         v-if="invitation"
         :invited-email="invitation.email"
@@ -425,9 +422,6 @@
         </h1>
       </div>
 
-      <BasicFormAlerts
-        v-if="error"
-        :error="error" />
       <BasicFormAlerts
         v-if="success"
         :success="success" />

--- a/src/apps/workspace/account/settings/OrganizationSettings.vue
+++ b/src/apps/workspace/account/settings/OrganizationSettings.vue
@@ -468,6 +468,19 @@ const canManageMembers = computed(() => {
   return can(ENTITLEMENTS.MANAGE_MEMBERS);
 });
 
+// Mirror backend check (create_invitation.rb:130): member_count + pending invitations
+// vs members_per_team limit. Limit of -1 means unlimited; null/undefined means
+// unknown (e.g. self-hosted) — treat as no limit.
+const pendingInvitationCount = computed(() =>
+  invitations.value.filter((inv) => inv.status === 'pending').length
+);
+
+const memberLimitReached = computed(() => {
+  const limit = organization.value?.limits?.members_per_team;
+  if (limit === null || limit === undefined || limit < 0) return false;
+  return membersStore.memberCount + pendingInvitationCount.value >= limit;
+});
+
 // Member management event handlers
 const handleMemberUpdated = () => {
   // Member was updated in the store, no additional action needed
@@ -871,9 +884,28 @@ const handleTabKeydown = (e: KeyboardEvent) => {
                   {{ membersStore.memberCount }} {{ membersStore.memberCount === 1 ? t('web.organizations.members.member_singular') : t('web.organizations.members.member_plural') }}
                 </p>
               </div>
+              <!--
+                Header CTA hierarchy:
+                - Hidden when form is open (form has its own primary submit; avoids dual-primary).
+                - "Upgrade Plan" link when member quota is reached (path forward, not a dead end).
+                - "Invite Member" button otherwise; disabled when user lacks MANAGE_MEMBERS entitlement.
+              -->
+              <router-link
+                v-if="!showInviteForm && memberLimitReached && canManageMembers"
+                :to="`/billing/${orgId}/plans`"
+                :title="t('api.organizations.invitations.errors.member_limit_reached')"
+                class="inline-flex items-center rounded-md bg-brand-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-brand-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-600 dark:bg-brand-500 dark:hover:bg-brand-400">
+                <OIcon
+                  collection="heroicons"
+                  name="arrow-up-circle"
+                  class="-ml-0.5 mr-1.5 size-5"
+                  aria-hidden="true" />
+                {{ t('web.billing.overview.upgrade_plan') }}
+              </router-link>
               <button
+                v-else-if="!showInviteForm"
                 type="button"
-                @click="canManageMembers && (showInviteForm = !showInviteForm)"
+                @click="canManageMembers && (showInviteForm = true)"
                 :disabled="!canManageMembers"
                 :title="!canManageMembers ? t('web.organizations.invitations.upgrade_to_invite') : undefined"
                 :class="[

--- a/src/apps/workspace/account/settings/OrganizationSettings.vue
+++ b/src/apps/workspace/account/settings/OrganizationSettings.vue
@@ -481,6 +481,22 @@ const memberLimitReached = computed(() => {
   return membersStore.memberCount + pendingInvitationCount.value >= limit;
 });
 
+// Finite quota cap (positive int) or null when unlimited/unknown. Drives the
+// "X of Y" count format in the title slot.
+const memberQuotaLimit = computed(() => {
+  const limit = organization.value?.limits?.members_per_team;
+  if (limit === null || limit === undefined || limit < 0) return null;
+  return limit;
+});
+
+// Active members only — matches what the user sees in the table. Pending is
+// shown as a separate "(N pending)" qualifier rather than folded into the
+// numerator, so the count line maps directly to visible rows. memberLimitReached
+// still uses active + pending to mirror the backend; the two can diverge here
+// without confusing the reader because the pending qualifier explains why the
+// button may be disabled at a count below the limit.
+const memberQuotaUsed = computed(() => membersStore.memberCount);
+
 // Member management event handlers
 const handleMemberUpdated = () => {
   // Member was updated in the store, no additional action needed
@@ -881,7 +897,9 @@ const handleTabKeydown = (e: KeyboardEvent) => {
                   {{ t('web.organizations.tabs.members') }}
                 </h3>
                 <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
-                  {{ membersStore.memberCount }} {{ membersStore.memberCount === 1 ? t('web.organizations.members.member_singular') : t('web.organizations.members.member_plural') }}
+                  <template v-if="memberQuotaLimit !== null">{{ t('web.organizations.members.member_quota', { used: memberQuotaUsed, limit: memberQuotaLimit }) }}</template>
+                  <template v-else>{{ membersStore.memberCount }} {{ membersStore.memberCount === 1 ? t('web.organizations.members.member_singular') : t('web.organizations.members.member_plural') }}</template>
+                  <span v-if="pendingInvitationCount > 0">&nbsp;{{ t('web.organizations.members.pending_suffix', { count: pendingInvitationCount }) }}</span>
                 </p>
               </div>
               <!--
@@ -890,37 +908,44 @@ const handleTabKeydown = (e: KeyboardEvent) => {
                 - "Upgrade Plan" link when member quota is reached (path forward, not a dead end).
                 - "Invite Member" button otherwise; disabled when user lacks MANAGE_MEMBERS entitlement.
               -->
-              <router-link
-                v-if="!showInviteForm && memberLimitReached && canManageMembers"
-                :to="`/billing/${orgId}/plans`"
-                :title="t('api.organizations.invitations.errors.member_limit_reached')"
-                class="inline-flex items-center rounded-md bg-brand-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-brand-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-600 dark:bg-brand-500 dark:hover:bg-brand-400">
-                <OIcon
-                  collection="heroicons"
-                  name="arrow-up-circle"
-                  class="-ml-0.5 mr-1.5 size-5"
-                  aria-hidden="true" />
-                {{ t('web.billing.overview.upgrade_plan') }}
-              </router-link>
-              <button
-                v-else-if="!showInviteForm"
-                type="button"
-                @click="canManageMembers && (showInviteForm = true)"
-                :disabled="!canManageMembers"
-                :title="!canManageMembers ? t('web.organizations.invitations.upgrade_to_invite') : undefined"
-                :class="[
-                  'inline-flex items-center rounded-md px-3 py-2 text-sm font-semibold shadow-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2',
-                  canManageMembers
-                    ? 'bg-brand-600 text-white hover:bg-brand-500 focus-visible:outline-brand-600 dark:bg-brand-500 dark:hover:bg-brand-400'
-                    : 'cursor-not-allowed bg-gray-300 text-gray-500 dark:bg-gray-600 dark:text-gray-400',
-                ]">
-                <OIcon
-                  collection="heroicons"
-                  name="user-plus"
-                  class="-ml-0.5 mr-1.5 size-5"
-                  aria-hidden="true" />
-                {{ t('web.organizations.invitations.invite_member') }}
-              </button>
+              <div class="flex flex-col items-end gap-1">
+                <router-link
+                  v-if="!showInviteForm && memberLimitReached && canManageMembers"
+                  :to="`/billing/${orgId}/plans`"
+                  :title="t('api.organizations.invitations.errors.member_limit_reached')"
+                  class="inline-flex items-center rounded-md bg-brand-600 px-3 py-2 font-brand text-sm font-semibold text-white shadow-sm hover:bg-brand-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-600 dark:bg-brand-500 dark:hover:bg-brand-400">
+                  <OIcon
+                    collection="heroicons"
+                    name="arrow-up-circle"
+                    class="-ml-0.5 mr-1.5 size-5"
+                    aria-hidden="true" />
+                  {{ t('web.billing.overview.upgrade_plan') }}
+                </router-link>
+                <button
+                  v-else-if="!showInviteForm"
+                  type="button"
+                  @click="canManageMembers && (showInviteForm = true)"
+                  :disabled="!canManageMembers"
+                  :title="!canManageMembers ? t('web.organizations.invitations.upgrade_to_invite') : undefined"
+                  :class="[
+                    'inline-flex items-center rounded-md px-3 py-2 font-brand text-sm font-semibold shadow-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2',
+                    canManageMembers
+                      ? 'bg-brand-600 text-white hover:bg-brand-500 focus-visible:outline-brand-600 dark:bg-brand-500 dark:hover:bg-brand-400'
+                      : 'cursor-not-allowed bg-gray-300 text-gray-500 dark:bg-gray-600 dark:text-gray-400',
+                  ]">
+                  <OIcon
+                    collection="heroicons"
+                    name="user-plus"
+                    class="-ml-0.5 mr-1.5 size-5"
+                    aria-hidden="true" />
+                  {{ t('web.organizations.invitations.invite_member') }}
+                </button>
+                <p
+                  v-if="!showInviteForm && memberLimitReached && canManageMembers"
+                  class="text-xs text-gray-500 dark:text-gray-400">
+                  {{ t('web.organizations.members.limit_reached_hint') }}
+                </p>
+              </div>
             </div>
             <div
               v-if="!canManageMembers"

--- a/src/schemas/errors/classifier.ts
+++ b/src/schemas/errors/classifier.ts
@@ -65,11 +65,9 @@ export const errorClassifier = {
   },
 
   extractUserMessage(details: any, error: HttpErrorLike): string {
-    // Prioritize 'message' over 'error' since 'error' is often a generic type identifier
-    // while 'message' contains the user-friendly description
-    // Example API response: { "error": "FormError", "message": "Please enter a domain" }
-    // We want to show "Please enter a domain" not "FormError"
-    return details.message || details.error || error.message || 'HTTP Error';
+    // API responses put the user-facing message in 'error' field
+    // Example: { "error": "Please enter a domain", "error_type": "FormError" }
+    return details.error || error.message || 'HTTP Error';
   },
 
   determineHttpErrorType(status: number | undefined, details: any): ErrorType {
@@ -89,7 +87,7 @@ export const errorClassifier = {
     // - 403 with no message -> security (show generic)
     // - 401 with "Invalid credentials" -> human (show message)
     // - 429 with "Too many requests" -> human (show message)
-    const hasUserMessage = Boolean(details.error || details.message);
+    const hasUserMessage = Boolean(details.error);
     const isClientError = status >= 400 && status < 500;
 
     if (hasUserMessage && isClientError) {

--- a/src/schemas/errors/types.ts
+++ b/src/schemas/errors/types.ts
@@ -34,7 +34,7 @@ export interface HttpErrorLike {
   status?: number;
   response?: {
     status?: number;
-    data?: { message?: string };
+    data?: { error?: string; error_type?: string };
   };
   message?: string;
 }

--- a/src/schemas/errors/utils.ts
+++ b/src/schemas/errors/utils.ts
@@ -11,7 +11,7 @@ export function extractErrorDetails(error: unknown) {
 
 function extractMessage(error: unknown): string {
   if (errorGuards.isHttpError(error)) {
-    return error.response?.data?.message || error.message || 'HTTP Error';
+    return error.response?.data?.error || error.message || 'HTTP Error';
   }
   return error instanceof Error ? error.message : String(error);
 }

--- a/src/shared/composables/useDomainsManager.ts
+++ b/src/shared/composables/useDomainsManager.ts
@@ -185,8 +185,8 @@ export function useDomainsManager() {
         }, 2000);
         return record;
       } catch (err: unknown) {
-        const axiosErr = err as { response?: { data?: { message?: string } }; message?: string };
-        const errorMessage = axiosErr?.response?.data?.message || axiosErr?.message || '';
+        const axiosErr = err as { response?: { data?: { error?: string } }; message?: string };
+        const errorMessage = axiosErr?.response?.data?.error || axiosErr?.message || '';
         const handled = await handleDomainExistsError(domain, errorMessage);
         if (handled !== undefined) return handled;
         throw err;

--- a/src/tests/composables/useInviteAuth.spec.ts
+++ b/src/tests/composables/useInviteAuth.spec.ts
@@ -98,6 +98,7 @@ describe('useInviteAuth', () => {
 
     it('returns success when server accepts the signup', async () => {
       axiosMock.onPost('/api/invite/invite-token-abc123/signup').reply(200, {});
+      axiosMock.onPost('/api/invite/invite-token-abc123/accept').reply(200, {});
       // Mock setAuthenticated to avoid the real implementation side-effects
       vi.spyOn(authStore, 'setAuthenticated').mockResolvedValue(undefined);
 
@@ -110,6 +111,40 @@ describe('useInviteAuth', () => {
       );
 
       expect(result).toEqual({ success: true });
+    });
+
+    // Regression for issue #3221: the signup endpoint leaves the invitation
+    // in pending state. The composable must chain POST /api/invite/:token/accept
+    // against the established session to complete the join. If this regresses,
+    // users land at /orgs with a still-pending invitation and no membership.
+    it('POSTs /api/invite/:token/accept after a successful signup', async () => {
+      axiosMock.onPost('/api/invite/chain-token/signup').reply(200, {});
+      axiosMock.onPost('/api/invite/chain-token/accept').reply(200, {});
+      vi.spyOn(authStore, 'setAuthenticated').mockResolvedValue(undefined);
+
+      const { signupAndAccept } = useInviteAuth();
+      const result = await signupAndAccept('u@e.com', 'pw12345678', true, 'chain-token');
+
+      expect(result.success).toBe(true);
+      const acceptCall = axiosMock.history.post.find(
+        (req) => req.url === '/api/invite/chain-token/accept'
+      );
+      expect(acceptCall).toBeDefined();
+    });
+
+    // /accept failure post-signup is non-fatal: the user is authenticated, and
+    // the AcceptInvite page's direct_accept handler will let them retry.
+    // signupAndAccept still returns success so the parent view can render the
+    // post-signup state.
+    it('returns success even when /accept fails after signup', async () => {
+      axiosMock.onPost('/api/invite/tok-nf/signup').reply(200, {});
+      axiosMock.onPost('/api/invite/tok-nf/accept').reply(404, { error: 'not found' });
+      vi.spyOn(authStore, 'setAuthenticated').mockResolvedValue(undefined);
+
+      const { signupAndAccept } = useInviteAuth();
+      const result = await signupAndAccept('u@e.com', 'pw12345678', true, 'tok-nf');
+
+      expect(result.success).toBe(true);
     });
 
     it('calls setAuthenticated(true) on success', async () => {
@@ -285,12 +320,31 @@ describe('useInviteAuth', () => {
   describe('loginAndAccept', () => {
     it('returns success when server accepts the login', async () => {
       axiosMock.onPost('/auth/login').reply(200, {});
+      axiosMock.onPost('/api/invite/tok-abc/accept').reply(200, {});
       vi.spyOn(authStore, 'setAuthenticated').mockResolvedValue(undefined);
 
       const { loginAndAccept } = useInviteAuth();
       const result = await loginAndAccept('user@example.com', 'pw12345678', 'tok-abc');
 
       expect(result).toEqual({ success: true });
+    });
+
+    // Regression for issue #3221: after_login no longer auto-accepts. The
+    // composable issues the explicit POST /api/invite/:token/accept so the
+    // existing-user flow lands on the same acceptance path as the signup flow.
+    it('POSTs /api/invite/:token/accept after a successful login', async () => {
+      axiosMock.onPost('/auth/login').reply(200, {});
+      axiosMock.onPost('/api/invite/login-chain/accept').reply(200, {});
+      vi.spyOn(authStore, 'setAuthenticated').mockResolvedValue(undefined);
+
+      const { loginAndAccept } = useInviteAuth();
+      const result = await loginAndAccept('u@e.com', 'pw12345678', 'login-chain');
+
+      expect(result.success).toBe(true);
+      const acceptCall = axiosMock.history.post.find(
+        (req) => req.url === '/api/invite/login-chain/accept'
+      );
+      expect(acceptCall).toBeDefined();
     });
 
     it('calls setAuthenticated(true) on success', async () => {

--- a/src/tests/composables/useInviteAuth.spec.ts
+++ b/src/tests/composables/useInviteAuth.spec.ts
@@ -4,7 +4,7 @@
  * Tests for the useInviteAuth composable — the authentication flow used
  * during organization invite acceptance.
  *
- * Key behavior under test: signupAndAccept and loginAndAccept must call
+ * Key behavior under test: signupForInvite and loginForInvite must call
  * authStore.setAuthenticated(true) in a fire-and-forget manner (void, not
  * await). Awaiting would yield to the microtask queue, letting Vue flush
  * a re-render that unmounts InviteSignUpForm before emit('success') reaches
@@ -63,10 +63,10 @@ describe('useInviteAuth', () => {
     vi.restoreAllMocks();
   });
 
-  // ── Source code invariant ────────────────────────────────────────────
-  // Guards against reverting the fire-and-forget fix. If someone changes
-  // `void authStore.setAuthenticated(true)` to `await authStore.setAuthenticated(true)`,
-  // the invite onboarding flow silently breaks.
+  // ── Source code invariants ───────────────────────────────────────────
+  // Guards against:
+  //  1. Reverting the fire-and-forget setAuthenticated fix (silent flow break).
+  //  2. Reintroducing client-side auto-accept (defeats explicit-consent design).
 
   describe('source code invariants', () => {
     let sourceCode: string;
@@ -76,34 +76,43 @@ describe('useInviteAuth', () => {
       sourceCode = readFileSync(filePath, 'utf-8');
     });
 
-    it('signupAndAccept uses fire-and-forget (not await) for setAuthenticated', () => {
+    it('signupForInvite uses fire-and-forget (not await) for setAuthenticated', () => {
       // Must NOT use `await` — fire-and-forget prevents reactive cascade unmounting form.
       // The .catch() handler surfaces background failures without re-introducing await.
       expect(sourceCode).not.toMatch(/await\s+authStore\.setAuthenticated/);
       expect(sourceCode).toContain('authStore.setAuthenticated(true).catch(');
     });
 
-    it('loginAndAccept uses fire-and-forget (not await) for setAuthenticated', () => {
+    it('loginForInvite uses fire-and-forget (not await) for setAuthenticated', () => {
       // Both methods must use the same fire-and-forget + .catch pattern
       const catchCalls = sourceCode.match(/authStore\.setAuthenticated\(true\)\.catch\(/g);
-      expect(catchCalls).toHaveLength(2); // One in signupAndAccept, one in loginAndAccept
+      expect(catchCalls).toHaveLength(2); // One in signupForInvite, one in loginForInvite
+    });
+
+    it('does not auto-POST /accept after auth (explicit-consent design)', () => {
+      // The composable must not chain the /accept call client-side. Acceptance is
+      // owned by the explicit user click on the AcceptInvite view. If this regresses,
+      // the token is consumed before the user reaches the Decline/Accept screen and
+      // their manual click returns 404 (issue #3221).
+      // Check that no $api.post call targets /accept (matching template literals).
+      expect(sourceCode).not.toMatch(/\$api\.post\([^)]*\/accept/);
+      expect(sourceCode).not.toContain('acceptPendingInvite');
     });
   });
 
-  // ── signupAndAccept ──────────────────────────────────────────────────
+  // ── signupForInvite ──────────────────────────────────────────────────
 
-  describe('signupAndAccept', () => {
+  describe('signupForInvite', () => {
     // The new endpoint: POST /api/invite/:token/signup
     // Email is derived from the invite token, not sent in the request body
 
     it('returns success when server accepts the signup', async () => {
       axiosMock.onPost('/api/invite/invite-token-abc123/signup').reply(200, {});
-      axiosMock.onPost('/api/invite/invite-token-abc123/accept').reply(200, {});
       // Mock setAuthenticated to avoid the real implementation side-effects
       vi.spyOn(authStore, 'setAuthenticated').mockResolvedValue(undefined);
 
-      const { signupAndAccept } = useInviteAuth();
-      const result = await signupAndAccept(
+      const { signupForInvite } = useInviteAuth();
+      const result = await signupForInvite(
         'user@example.com', // Ignored by new endpoint - email comes from token
         'securePassword1',
         true,
@@ -113,46 +122,30 @@ describe('useInviteAuth', () => {
       expect(result).toEqual({ success: true });
     });
 
-    // Regression for issue #3221: the signup endpoint leaves the invitation
-    // in pending state. The composable must chain POST /api/invite/:token/accept
-    // against the established session to complete the join. If this regresses,
-    // users land at /orgs with a still-pending invitation and no membership.
-    it('POSTs /api/invite/:token/accept after a successful signup', async () => {
-      axiosMock.onPost('/api/invite/chain-token/signup').reply(200, {});
-      axiosMock.onPost('/api/invite/chain-token/accept').reply(200, {});
+    // Regression for issue #3221: the composable must NOT chain /accept after
+    // signup. Acceptance is the user's explicit click on the AcceptInvite view.
+    // A client-side auto-accept consumes the token before the Decline/Accept
+    // screen renders, and the user's manual click then 404s.
+    it('does NOT POST /api/invite/:token/accept after signup', async () => {
+      axiosMock.onPost('/api/invite/no-chain-token/signup').reply(200, {});
       vi.spyOn(authStore, 'setAuthenticated').mockResolvedValue(undefined);
 
-      const { signupAndAccept } = useInviteAuth();
-      const result = await signupAndAccept('u@e.com', 'pw12345678', true, 'chain-token');
+      const { signupForInvite } = useInviteAuth();
+      const result = await signupForInvite('u@e.com', 'pw12345678', true, 'no-chain-token');
 
       expect(result.success).toBe(true);
       const acceptCall = axiosMock.history.post.find(
-        (req) => req.url === '/api/invite/chain-token/accept'
+        (req) => req.url === '/api/invite/no-chain-token/accept'
       );
-      expect(acceptCall).toBeDefined();
-    });
-
-    // /accept failure post-signup is non-fatal: the user is authenticated, and
-    // the AcceptInvite page's direct_accept handler will let them retry.
-    // signupAndAccept still returns success so the parent view can render the
-    // post-signup state.
-    it('returns success even when /accept fails after signup', async () => {
-      axiosMock.onPost('/api/invite/tok-nf/signup').reply(200, {});
-      axiosMock.onPost('/api/invite/tok-nf/accept').reply(404, { error: 'not found' });
-      vi.spyOn(authStore, 'setAuthenticated').mockResolvedValue(undefined);
-
-      const { signupAndAccept } = useInviteAuth();
-      const result = await signupAndAccept('u@e.com', 'pw12345678', true, 'tok-nf');
-
-      expect(result.success).toBe(true);
+      expect(acceptCall).toBeUndefined();
     });
 
     it('calls setAuthenticated(true) on success', async () => {
       axiosMock.onPost('/api/invite/tok123/signup').reply(200, {});
       const spy = vi.spyOn(authStore, 'setAuthenticated').mockResolvedValue(undefined);
 
-      const { signupAndAccept } = useInviteAuth();
-      await signupAndAccept('user@example.com', 'pw12345678', true, 'tok123');
+      const { signupForInvite } = useInviteAuth();
+      await signupForInvite('user@example.com', 'pw12345678', true, 'tok123');
 
       expect(spy).toHaveBeenCalledWith(true);
     });
@@ -167,10 +160,10 @@ describe('useInviteAuth', () => {
         setAuthResolved = true;
       });
 
-      const { signupAndAccept } = useInviteAuth();
-      const result = await signupAndAccept('user@example.com', 'pw12345678', true, 'tok');
+      const { signupForInvite } = useInviteAuth();
+      const result = await signupForInvite('user@example.com', 'pw12345678', true, 'tok');
 
-      // signupAndAccept returned successfully even though setAuthenticated has not resolved
+      // signupForInvite returned successfully even though setAuthenticated has not resolved
       expect(result).toEqual({ success: true });
       expect(setAuthResolved).toBe(false);
     });
@@ -179,9 +172,9 @@ describe('useInviteAuth', () => {
       axiosMock.onPost('/api/invite/tok-abc/signup').reply(200, {});
       vi.spyOn(authStore, 'setAuthenticated').mockResolvedValue(undefined);
 
-      const { signupAndAccept } = useInviteAuth();
+      const { signupForInvite } = useInviteAuth();
       // Note: email and skill params are ignored by the new endpoint
-      await signupAndAccept('user@example.com', 'pw12345678', true, 'tok-abc', 'developer');
+      await signupForInvite('user@example.com', 'pw12345678', true, 'tok-abc', 'developer');
 
       const requestData = JSON.parse(axiosMock.history.post[0].data);
       // New endpoint does NOT send login/email - it's derived from the token
@@ -200,8 +193,8 @@ describe('useInviteAuth', () => {
       axiosMock.onPost('/api/invite/tok/signup').reply(200, {});
       vi.spyOn(authStore, 'setAuthenticated').mockResolvedValue(undefined);
 
-      const { signupAndAccept } = useInviteAuth();
-      await signupAndAccept('u@e.com', 'pw12345678', true, 'tok');
+      const { signupForInvite } = useInviteAuth();
+      await signupForInvite('u@e.com', 'pw12345678', true, 'tok');
 
       expect(bootstrapStore.refresh).toHaveBeenCalledOnce();
     });
@@ -212,8 +205,8 @@ describe('useInviteAuth', () => {
         'field-error': ['password', 'Password too weak'],
       });
 
-      const { signupAndAccept, error, fieldErrors } = useInviteAuth();
-      const result = await signupAndAccept('dup@e.com', 'pw12345678', true, 'tok');
+      const { signupForInvite, error, fieldErrors } = useInviteAuth();
+      const result = await signupForInvite('dup@e.com', 'pw12345678', true, 'tok');
 
       // accountExists is always returned (false unless error contains "already exists")
       expect(result).toEqual({ success: false, error: 'Unable to create account', accountExists: false });
@@ -226,8 +219,8 @@ describe('useInviteAuth', () => {
         error: 'An account already exists with this email',
       });
 
-      const { signupAndAccept } = useInviteAuth();
-      const result = await signupAndAccept('existing@e.com', 'pw12345678', true, 'tok');
+      const { signupForInvite } = useInviteAuth();
+      const result = await signupForInvite('existing@e.com', 'pw12345678', true, 'tok');
 
       expect(result.success).toBe(false);
       expect(result.accountExists).toBe(true);
@@ -239,8 +232,8 @@ describe('useInviteAuth', () => {
       });
       const spy = vi.spyOn(authStore, 'setAuthenticated').mockResolvedValue(undefined);
 
-      const { signupAndAccept } = useInviteAuth();
-      await signupAndAccept('u@e.com', 'pw12345678', true, 'tok');
+      const { signupForInvite } = useInviteAuth();
+      await signupForInvite('u@e.com', 'pw12345678', true, 'tok');
 
       expect(spy).not.toHaveBeenCalled();
     });
@@ -248,8 +241,8 @@ describe('useInviteAuth', () => {
     it('returns error on network failure', async () => {
       axiosMock.onPost('/api/invite/tok/signup').networkError();
 
-      const { signupAndAccept, error } = useInviteAuth();
-      const result = await signupAndAccept('u@e.com', 'pw12345678', true, 'tok');
+      const { signupForInvite, error } = useInviteAuth();
+      const result = await signupForInvite('u@e.com', 'pw12345678', true, 'tok');
 
       expect(result.success).toBe(false);
       expect(result.error).toBeDefined();
@@ -260,10 +253,10 @@ describe('useInviteAuth', () => {
       axiosMock.onPost('/api/invite/tok/signup').reply(200, {});
       vi.spyOn(authStore, 'setAuthenticated').mockResolvedValue(undefined);
 
-      const { signupAndAccept, isLoading } = useInviteAuth();
+      const { signupForInvite, isLoading } = useInviteAuth();
 
       expect(isLoading.value).toBe(false);
-      const promise = signupAndAccept('u@e.com', 'pw12345678', true, 'tok');
+      const promise = signupForInvite('u@e.com', 'pw12345678', true, 'tok');
       // isLoading is set synchronously at the start
       expect(isLoading.value).toBe(true);
       await promise;
@@ -273,8 +266,8 @@ describe('useInviteAuth', () => {
     it('clears isLoading even on error', async () => {
       axiosMock.onPost('/api/invite/tok/signup').networkError();
 
-      const { signupAndAccept, isLoading } = useInviteAuth();
-      await signupAndAccept('u@e.com', 'pw12345678', true, 'tok');
+      const { signupForInvite, isLoading } = useInviteAuth();
+      await signupForInvite('u@e.com', 'pw12345678', true, 'tok');
 
       expect(isLoading.value).toBe(false);
     });
@@ -284,8 +277,8 @@ describe('useInviteAuth', () => {
       axiosMock.onPost('/api/invite/tok/signup').reply(200, {});
       vi.spyOn(authStore, 'setAuthenticated').mockResolvedValue(undefined);
 
-      const { signupAndAccept } = useInviteAuth();
-      const result = await signupAndAccept('u@e.com', 'pw12345678', true, 'tok');
+      const { signupForInvite } = useInviteAuth();
+      const result = await signupForInvite('u@e.com', 'pw12345678', true, 'tok');
 
       expect(result).toEqual({ success: true });
     });
@@ -295,8 +288,8 @@ describe('useInviteAuth', () => {
         error: 'Invitation not found or expired',
       });
 
-      const { signupAndAccept, error } = useInviteAuth();
-      const result = await signupAndAccept('u@e.com', 'pw12345678', true, 'invalid-tok');
+      const { signupForInvite, error } = useInviteAuth();
+      const result = await signupForInvite('u@e.com', 'pw12345678', true, 'invalid-tok');
 
       expect(result.success).toBe(false);
       expect(error.value).toContain('not found');
@@ -307,52 +300,50 @@ describe('useInviteAuth', () => {
         error: 'Invitation has expired',
       });
 
-      const { signupAndAccept, error } = useInviteAuth();
-      const result = await signupAndAccept('u@e.com', 'pw12345678', true, 'expired-tok');
+      const { signupForInvite, error } = useInviteAuth();
+      const result = await signupForInvite('u@e.com', 'pw12345678', true, 'expired-tok');
 
       expect(result.success).toBe(false);
       expect(error.value).toContain('expired');
     });
   });
 
-  // ── loginAndAccept ───────────────────────────────────────────────────
+  // ── loginForInvite ───────────────────────────────────────────────────
 
-  describe('loginAndAccept', () => {
+  describe('loginForInvite', () => {
     it('returns success when server accepts the login', async () => {
       axiosMock.onPost('/auth/login').reply(200, {});
-      axiosMock.onPost('/api/invite/tok-abc/accept').reply(200, {});
       vi.spyOn(authStore, 'setAuthenticated').mockResolvedValue(undefined);
 
-      const { loginAndAccept } = useInviteAuth();
-      const result = await loginAndAccept('user@example.com', 'pw12345678', 'tok-abc');
+      const { loginForInvite } = useInviteAuth();
+      const result = await loginForInvite('user@example.com', 'pw12345678', 'tok-abc');
 
       expect(result).toEqual({ success: true });
     });
 
-    // Regression for issue #3221: after_login no longer auto-accepts. The
-    // composable issues the explicit POST /api/invite/:token/accept so the
-    // existing-user flow lands on the same acceptance path as the signup flow.
-    it('POSTs /api/invite/:token/accept after a successful login', async () => {
+    // Regression for issue #3221: after_login no longer auto-accepts AND the
+    // composable must not chain /accept either. Acceptance happens only on the
+    // user's explicit click on the AcceptInvite view.
+    it('does NOT POST /api/invite/:token/accept after login', async () => {
       axiosMock.onPost('/auth/login').reply(200, {});
-      axiosMock.onPost('/api/invite/login-chain/accept').reply(200, {});
       vi.spyOn(authStore, 'setAuthenticated').mockResolvedValue(undefined);
 
-      const { loginAndAccept } = useInviteAuth();
-      const result = await loginAndAccept('u@e.com', 'pw12345678', 'login-chain');
+      const { loginForInvite } = useInviteAuth();
+      const result = await loginForInvite('u@e.com', 'pw12345678', 'no-chain-login');
 
       expect(result.success).toBe(true);
       const acceptCall = axiosMock.history.post.find(
-        (req) => req.url === '/api/invite/login-chain/accept'
+        (req) => req.url === '/api/invite/no-chain-login/accept'
       );
-      expect(acceptCall).toBeDefined();
+      expect(acceptCall).toBeUndefined();
     });
 
     it('calls setAuthenticated(true) on success', async () => {
       axiosMock.onPost('/auth/login').reply(200, {});
       const spy = vi.spyOn(authStore, 'setAuthenticated').mockResolvedValue(undefined);
 
-      const { loginAndAccept } = useInviteAuth();
-      await loginAndAccept('u@e.com', 'pw12345678', 'tok');
+      const { loginForInvite } = useInviteAuth();
+      await loginForInvite('u@e.com', 'pw12345678', 'tok');
 
       expect(spy).toHaveBeenCalledWith(true);
     });
@@ -366,8 +357,8 @@ describe('useInviteAuth', () => {
         setAuthResolved = true;
       });
 
-      const { loginAndAccept } = useInviteAuth();
-      const result = await loginAndAccept('u@e.com', 'pw12345678', 'tok');
+      const { loginForInvite } = useInviteAuth();
+      const result = await loginForInvite('u@e.com', 'pw12345678', 'tok');
 
       expect(result).toEqual({ success: true });
       expect(setAuthResolved).toBe(false);
@@ -377,8 +368,8 @@ describe('useInviteAuth', () => {
       axiosMock.onPost('/auth/login').reply(200, {});
       vi.spyOn(authStore, 'setAuthenticated').mockResolvedValue(undefined);
 
-      const { loginAndAccept } = useInviteAuth();
-      await loginAndAccept('user@example.com', 'pw12345678', 'tok-xyz');
+      const { loginForInvite } = useInviteAuth();
+      await loginForInvite('user@example.com', 'pw12345678', 'tok-xyz');
 
       const requestData = JSON.parse(axiosMock.history.post[0].data);
       expect(requestData).toMatchObject({
@@ -392,8 +383,8 @@ describe('useInviteAuth', () => {
     it('returns MFA required when server indicates mfa_required', async () => {
       axiosMock.onPost('/auth/login').reply(200, { mfa_required: true });
 
-      const { loginAndAccept } = useInviteAuth();
-      const result = await loginAndAccept('u@e.com', 'pw12345678', 'tok-abc');
+      const { loginForInvite } = useInviteAuth();
+      const result = await loginForInvite('u@e.com', 'pw12345678', 'tok-abc');
 
       expect(result).toEqual({
         success: false,
@@ -406,8 +397,8 @@ describe('useInviteAuth', () => {
       axiosMock.onPost('/auth/login').reply(200, { mfa_required: true });
       const updateSpy = vi.spyOn(bootstrapStore, 'update');
 
-      const { loginAndAccept } = useInviteAuth();
-      await loginAndAccept('u@e.com', 'pw12345678', 'tok');
+      const { loginForInvite } = useInviteAuth();
+      await loginForInvite('u@e.com', 'pw12345678', 'tok');
 
       expect(updateSpy).toHaveBeenCalledWith({
         awaiting_mfa: true,
@@ -419,8 +410,8 @@ describe('useInviteAuth', () => {
       axiosMock.onPost('/auth/login').reply(200, { mfa_required: true });
       const spy = vi.spyOn(authStore, 'setAuthenticated').mockResolvedValue(undefined);
 
-      const { loginAndAccept } = useInviteAuth();
-      await loginAndAccept('u@e.com', 'pw12345678', 'tok');
+      const { loginForInvite } = useInviteAuth();
+      await loginForInvite('u@e.com', 'pw12345678', 'tok');
 
       expect(spy).not.toHaveBeenCalled();
     });
@@ -431,8 +422,8 @@ describe('useInviteAuth', () => {
         'field-error': ['password', 'Incorrect password'],
       });
 
-      const { loginAndAccept, error, fieldErrors } = useInviteAuth();
-      const result = await loginAndAccept('u@e.com', 'wrong', 'tok');
+      const { loginForInvite, error, fieldErrors } = useInviteAuth();
+      const result = await loginForInvite('u@e.com', 'wrong', 'tok');
 
       expect(result).toEqual({ success: false, error: 'Invalid credentials' });
       expect(error.value).toBe('Invalid credentials');
@@ -442,8 +433,8 @@ describe('useInviteAuth', () => {
     it('returns error on network failure', async () => {
       axiosMock.onPost('/auth/login').networkError();
 
-      const { loginAndAccept, error } = useInviteAuth();
-      const result = await loginAndAccept('u@e.com', 'pw12345678', 'tok');
+      const { loginForInvite, error } = useInviteAuth();
+      const result = await loginForInvite('u@e.com', 'pw12345678', 'tok');
 
       expect(result.success).toBe(false);
       expect(error.value).toBeDefined();
@@ -453,10 +444,10 @@ describe('useInviteAuth', () => {
       axiosMock.onPost('/auth/login').reply(200, {});
       vi.spyOn(authStore, 'setAuthenticated').mockResolvedValue(undefined);
 
-      const { loginAndAccept, isLoading } = useInviteAuth();
+      const { loginForInvite, isLoading } = useInviteAuth();
 
       expect(isLoading.value).toBe(false);
-      const promise = loginAndAccept('u@e.com', 'pw12345678', 'tok');
+      const promise = loginForInvite('u@e.com', 'pw12345678', 'tok');
       expect(isLoading.value).toBe(true);
       await promise;
       expect(isLoading.value).toBe(false);
@@ -473,8 +464,8 @@ describe('useInviteAuth', () => {
         'field-error': ['password', 'Bad password'],
       });
 
-      const { signupAndAccept, clearErrors, error, fieldErrors } = useInviteAuth();
-      await signupAndAccept('u@e.com', 'pw12345678', true, 'tok');
+      const { signupForInvite, clearErrors, error, fieldErrors } = useInviteAuth();
+      await signupForInvite('u@e.com', 'pw12345678', true, 'tok');
 
       expect(error.value).toBe('Some error');
       expect(fieldErrors.value).toEqual({ password: 'Bad password' });
@@ -495,8 +486,8 @@ describe('useInviteAuth', () => {
         throw { message: 'Request failed', response: undefined };
       });
 
-      const { signupAndAccept, error } = useInviteAuth();
-      const result = await signupAndAccept('u@e.com', 'pw12345678', true, 'tok');
+      const { signupForInvite, error } = useInviteAuth();
+      const result = await signupForInvite('u@e.com', 'pw12345678', true, 'tok');
 
       expect(result.success).toBe(false);
       // Should fall back to error.message or default
@@ -509,8 +500,8 @@ describe('useInviteAuth', () => {
         'field-error': ['login', 'Email format invalid'],
       });
 
-      const { loginAndAccept, error, fieldErrors } = useInviteAuth();
-      const result = await loginAndAccept('bad-email', 'pw12345678', 'tok');
+      const { loginForInvite, error, fieldErrors } = useInviteAuth();
+      const result = await loginForInvite('bad-email', 'pw12345678', 'tok');
 
       expect(result.success).toBe(false);
       expect(error.value).toBe('Validation failed');

--- a/src/tests/composables/useReceipt.spec.ts
+++ b/src/tests/composables/useReceipt.spec.ts
@@ -244,7 +244,7 @@ describe('useReceipt', () => {
         undefined,
         {
           status: 404,
-          data: { message: 'Secret not found or has been burned' },
+          data: { error: 'Secret not found or has been burned' },
         } as any
       );
 

--- a/src/tests/schemas/errors/classifier.spec.ts
+++ b/src/tests/schemas/errors/classifier.spec.ts
@@ -19,7 +19,7 @@ describe('error classifier', () => {
         {
           status: 403,
           statusText: 'Forbidden',
-          data: { message: 'Guest API access is disabled' },
+          data: { error: 'Guest API access is disabled' },
           headers: {},
           config: {} as any,
         }
@@ -70,7 +70,7 @@ describe('error classifier', () => {
         {
           status: 404,
           statusText: 'Not Found',
-          data: { message: 'Not Found' },
+          data: { error: 'Not Found' },
           headers: {},
           config: {} as any,
         }
@@ -95,7 +95,7 @@ describe('error classifier', () => {
         {
           status: 500,
           statusText: 'Internal Server Error',
-          data: { message: 'Internal Server Error' },
+          data: { error: 'Internal Server Error' },
           headers: {},
           config: {} as any,
         }
@@ -119,7 +119,7 @@ describe('error classifier', () => {
         undefined,
         {
           status: 429,
-          data: { message: 'Too Many Requests' },
+          data: { error: 'Too Many Requests' },
         } as any
       ) as AxiosError;
 
@@ -164,8 +164,8 @@ describe('error classifier', () => {
           status: 422,
           ok: false,
           statusText: 'Unprocessable Entity',
-          json: () => Promise.resolve({ message: 'Validation Failed' }),
-          data: { message: 'Validation Failed' },
+          json: () => Promise.resolve({ error: 'Validation Failed' }),
+          data: { error: 'Validation Failed' },
         },
       });
 
@@ -200,7 +200,7 @@ describe('error classifier', () => {
     describe('jsdom checks', () => {
       it.skip('classifies fetch response errors correctly', async () => {
         // Reason: "Response is not a constructor"
-        const response = new Response(JSON.stringify({ message: 'Validation Failed' }), {
+        const response = new Response(JSON.stringify({ error: 'Validation Failed' }), {
           status: 422,
           statusText: 'Unprocessable Entity',
           headers: {

--- a/src/tests/stores/receiptStore.spec.ts
+++ b/src/tests/stores/receiptStore.spec.ts
@@ -547,7 +547,8 @@ describe('receiptStore', () => {
 
     describe('GUEST_ROUTES_DISABLED errors', () => {
       const guestRoutesDisabledResponse = {
-        message: 'Guest API access is disabled',
+        error: 'Guest API access is disabled',
+        error_type: 'GuestRoutesDisabled',
         code: 'GUEST_ROUTES_DISABLED',
       };
 
@@ -594,7 +595,8 @@ describe('receiptStore', () => {
         const testKey = mockReceiptRecord.key;
         store.setApiMode('public');
         axiosMock?.onGet(`/api/v3/guest/receipt/${testKey}`).reply(403, {
-          message: 'Guest receipt is disabled',
+          error: 'Guest receipt is disabled',
+          error_type: 'GuestRoutesDisabled',
           code: 'GUEST_RECEIPT_DISABLED',
         });
 
@@ -606,7 +608,8 @@ describe('receiptStore', () => {
         store.setApiMode('public');
         store.record = { ...mockReceiptRecord, burned: null, state: 'new' };
         axiosMock?.onPost(`/api/v3/guest/receipt/${testKey}/burn`).reply(403, {
-          message: 'Guest burn is disabled',
+          error: 'Guest burn is disabled',
+          error_type: 'GuestRoutesDisabled',
           code: 'GUEST_BURN_DISABLED',
         });
 

--- a/src/tests/stores/secretStore.spec.ts
+++ b/src/tests/stores/secretStore.spec.ts
@@ -483,7 +483,8 @@ describe('secretStore', () => {
 
     describe('GUEST_ROUTES_DISABLED errors', () => {
       const guestRoutesDisabledResponse = {
-        message: 'Guest API access is disabled',
+        error: 'Guest API access is disabled',
+        error_type: 'GuestRoutesDisabled',
         code: 'GUEST_ROUTES_DISABLED',
       };
 
@@ -539,7 +540,8 @@ describe('secretStore', () => {
       it('conceal() rejects with GUEST_CONCEAL_DISABLED code', async () => {
         store.setApiMode('public');
         axiosMock?.onPost('/api/v3/guest/secret/conceal').reply(403, {
-          message: 'Guest conceal is disabled',
+          error: 'Guest conceal is disabled',
+          error_type: 'GuestRoutesDisabled',
           code: 'GUEST_CONCEAL_DISABLED',
         });
 
@@ -551,7 +553,8 @@ describe('secretStore', () => {
       it('generate() rejects with GUEST_GENERATE_DISABLED code', async () => {
         store.setApiMode('public');
         axiosMock?.onPost('/api/v3/guest/secret/generate').reply(403, {
-          message: 'Guest generate is disabled',
+          error: 'Guest generate is disabled',
+          error_type: 'GuestRoutesDisabled',
           code: 'GUEST_GENERATE_DISABLED',
         });
 
@@ -561,7 +564,8 @@ describe('secretStore', () => {
       it('reveal() rejects with GUEST_REVEAL_DISABLED code', async () => {
         store.setApiMode('public');
         axiosMock?.onPost('/api/v3/guest/secret/abc123/reveal').reply(403, {
-          message: 'Guest reveal is disabled',
+          error: 'Guest reveal is disabled',
+          error_type: 'GuestRoutesDisabled',
           code: 'GUEST_REVEAL_DISABLED',
         });
 
@@ -571,7 +575,8 @@ describe('secretStore', () => {
       it('fetch() rejects with GUEST_SHOW_DISABLED code', async () => {
         store.setApiMode('public');
         axiosMock?.onGet('/api/v3/guest/secret/abc123').reply(403, {
-          message: 'Guest show is disabled',
+          error: 'Guest show is disabled',
+          error_type: 'GuestRoutesDisabled',
           code: 'GUEST_SHOW_DISABLED',
         });
 

--- a/src/tests/views/session/AcceptInvite.spec.ts
+++ b/src/tests/views/session/AcceptInvite.spec.ts
@@ -301,6 +301,9 @@ describe('AcceptInvite', () => {
       await flushPromises();
 
       expect(wrapper.text()).toContain('Invitation accepted successfully');
+      // Action row must be torn down once accepted — prevents flicker during redirect delay
+      expect(wrapper.find('[data-testid="accept-invitation-btn"]').exists()).toBe(false);
+      expect(wrapper.find('[data-testid="decline-invitation-btn"]').exists()).toBe(false);
     });
 
     it('shows error when accept fails', async () => {
@@ -348,6 +351,9 @@ describe('AcceptInvite', () => {
       await flushPromises();
 
       expect(wrapper.text()).toContain('Invitation declined');
+      // Action row must be torn down once declined — prevents flicker during redirect delay
+      expect(wrapper.find('[data-testid="accept-invitation-btn"]').exists()).toBe(false);
+      expect(wrapper.find('[data-testid="decline-invitation-btn"]').exists()).toBe(false);
     });
 
     it('shows error when decline fails', async () => {

--- a/try/integration/api/domains/list_domains_isolation_try.rb
+++ b/try/integration/api/domains/list_domains_isolation_try.rb
@@ -160,7 +160,7 @@ last_response.status >= 400
 ## TEST 5: Non-member access - verify error message indicates access denied
 resp = JSON.parse(last_response.body) rescue {}
 [
-  resp['message']&.include?('access denied') || resp['message']&.include?('not found'),
+  resp['error']&.include?('access denied') || resp['error']&.include?('not found'),
   resp['records'].nil?
 ]
 #=> [true, true]

--- a/try/integration/api/invite/invite_api_try.rb
+++ b/try/integration/api/invite/invite_api_try.rb
@@ -189,8 +189,9 @@ last_response.status >= 400
 ## POST /api/invite/:token/accept - Email mismatch response body carries resolved English message
 # Asserts the ErrorResolver -> FormError#to_h seam: the response payload includes
 # the localized message text resolved from error_key 'api.invite.errors.email_mismatch'.
+# FormError#to_h puts the resolved message in the 'error' field.
 resp = JSON.parse(last_response.body)
-resp['message']
+resp['error']
 #=> 'Your email address does not match the invitation'
 
 ## POST /api/invite/:token/accept - Email mismatch response body surfaces error_key
@@ -201,10 +202,10 @@ resp['error_key']
 #=> 'api.invite.errors.email_mismatch'
 
 ## POST /api/invite/:token/accept - Email mismatch response body uses email_mismatch error type
-# accept_invite.rb passes error_type: :email_mismatch, which FormError#to_h serializes
-# as the 'error' field (overriding the default 'FormError' value).
+# accept_invite.rb passes error_type: :email_mismatch; FormError#to_h serializes it
+# into the 'error_type' field of the response body.
 resp = JSON.parse(last_response.body)
-resp['error']
+resp['error_type']
 #=> 'email_mismatch'
 
 ## POST /api/invite/:token/accept - Email mismatch doesn't change membership status
@@ -276,14 +277,14 @@ resp = JSON.parse(last_response.body)
 resp['error_key']
 #=> 'api.invite.errors.invitation_not_found_or_expired'
 
-## POST /api/invite/:token/accept - Already-accepted response includes a message field
+## POST /api/invite/:token/accept - Already-accepted response includes an error field
 # The pure-i18n call site (raise_not_found with no pre-set message) means resolution
 # depends on the i18n bundle being loaded. With generated/locales/ unpopulated in this
-# test env, the resolver writes the error_key into message as the documented fallback
-# (error_resolver.rb:60-65). Asserting non-empty proves the body field is present and
-# populated end-to-end — without coupling the test to whether i18n is wired up.
+# test env, the resolver writes the error_key into error.message as the documented
+# fallback (error_resolver.rb:60-65), and RecordNotFound#to_h surfaces it as 'error'.
+# Asserting non-empty proves the body field is present and populated end-to-end.
 resp = JSON.parse(last_response.body)
-[resp.key?('message'), resp['message'].to_s.empty?]
+[resp.key?('error'), resp['error'].to_s.empty?]
 #=> [true, false]
 
 ## GET /api/invite/:token - Returns 400 for already accepted invitation

--- a/try/integration/api/organizations/member_quota_try.rb
+++ b/try/integration/api/organizations/member_quota_try.rb
@@ -74,8 +74,8 @@ def run_billing_test_invite(org, session, email, plan)
       result[:record_id] = resp['record']['id']
       result[:record_email] = resp['record']['email']
     else
-      result[:error_type] = resp['error']
-      result[:error_message] = resp['message']
+      result[:error_type] = resp['error_type']
+      result[:error_message] = resp['error']
     end
   end
   result

--- a/try/integration/api/organizations/organization_quota_try.rb
+++ b/try/integration/api/organizations/organization_quota_try.rb
@@ -101,9 +101,9 @@ BillingTestHelpers.with_billing_enabled(plans: [
 
   @billing_test_status = last_response.status
   resp = JSON.parse(last_response.body)
-  # API returns flat structure: {"error": "ErrorType", "message": "..."}
-  @billing_test_error_type = resp['error']
-  @billing_test_error_message = resp['message']
+  # API returns flat structure: {"error": "<message>", "error_type": "ErrorType"}
+  @billing_test_error_type = resp['error_type']
+  @billing_test_error_message = resp['error']
 end
 @billing_test_status
 #=> 422

--- a/try/integration/api/v3/guest_routes_disabled_try.rb
+++ b/try/integration/api/v3/guest_routes_disabled_try.rb
@@ -97,7 +97,7 @@ with_guest_routes_config({ 'enabled' => false }) do
     { secret: { secret: 'test secret', ttl: 3600 } }.to_json,
     json_headers
   body = JSON.parse(last_response.body)
-  body['message']
+  body['error']
 end
 #=> "Guest API access is disabled"
 
@@ -141,7 +141,7 @@ with_guest_routes_config({ 'enabled' => true, 'conceal' => false }) do
     { secret: { secret: 'test secret', ttl: 3600 } }.to_json,
     json_headers
   body = JSON.parse(last_response.body)
-  body['message']
+  body['error']
 end
 #=> "Guest conceal is disabled"
 
@@ -235,7 +235,7 @@ with_guest_routes_config({ 'enabled' => false }) do
   body = JSON.parse(last_response.body)
   body.keys.sort
 end
-#=> ["code", "message"]
+#=> ["code", "error", "error_type"]
 
 # Teardown
 @cust.destroy!

--- a/try/system/routes_smoketest_try.rb
+++ b/try/system/routes_smoketest_try.rb
@@ -90,14 +90,14 @@ content = Familia::JsonSerializer.parse(response.body)
 ##=> [200, 'anon']
 
 ## V2 API conceal returns 422 with validation error when no secret provided
-# Otto error format: { error: 'FormError', message: '...' }
+# Standardized error format: { error: <user-facing message>, error_type: <machine-readable> }
 # NOTE: Accept header required for JSON error responses (Otto content negotiation)
 # NOTE: Basic Auth required to bypass CSRF middleware for POST requests
 response = @mock_request.post('/api/v2/secret/conceal', @api_auth.merge('HTTP_ACCEPT' => 'application/json'))
 content = Familia::JsonSerializer.parse(response.body)
-has_msg = content['message'] == 'You did not provide anything to share'
+has_msg = content['error'] == 'You did not provide anything to share'
 [response.status, has_msg, content.keys.sort]
-#=> [422, true, ['error', 'message']]
+#=> [422, true, ['error', 'error_type', 'field']]
 
 ## V2 API generate creates a secret and returns success with nested record data
 # NOTE: Basic Auth required to bypass CSRF middleware for POST requests

--- a/try/unit/logic/guest_route_gating_behavior_try.rb
+++ b/try/unit/logic/guest_route_gating_behavior_try.rb
@@ -93,10 +93,10 @@ exc = Onetime::GuestRoutesDisabled.new("Test", code: "TEST_CODE")
 exc.code
 #=> "TEST_CODE"
 
-## GuestRoutesDisabled to_h includes message and code
+## GuestRoutesDisabled to_h includes error, error_type, and code
 exc = Onetime::GuestRoutesDisabled.new("Test message", code: "TEST_CODE")
 exc.to_h
-#=> {message: "Test message", code: "TEST_CODE"}
+#=> {error: "Test message", error_type: "GuestRoutesDisabled", code: "TEST_CODE"}
 
 ## Default config has guest routes enabled
 config = OT.conf.dig('site', 'interface', 'api', 'guest_routes')


### PR DESCRIPTION
## Summary

Closes #3221.

Invitations were auto-accepted during the signup hook, which consumed the
token before the user could click Accept on the invitation page. Their
explicit click then 404'd against a missing token. This PR keeps the
invitation in `pending` status through signup or login; acceptance only
happens when the user explicitly clicks Accept (or Decline) on the
invitation page. Token survives the entire auth lifecycle.

The earlier-in-branch attempt at a frontend workaround — chaining
`POST /api/invite/:token/accept` inside `useInviteAuth` after auth — was
removed in the final commit because it reintroduced the same double-consume
in a different layer. Acceptance is now uniquely owned by the explicit user
action.

## What changed

**Backend — invite lifecycle separation**
- Split `OrganizationMembership` into `accept!` (consume token, set
  `status='accepted'`) and `activate!` (populate `org_customer_lookup`,
  promote membership active). `accept!` auto-promotes via `activate!` when
  `Organization#requires_admin_approval?` returns false.
- `before_create_account` now validates the invite-token precondition
  (exists, pending, not expired, email matches) before any account row is
  written. No partial Redis state on rejection.
- `after_create_account` no longer accepts the invitation. For invite
  signups it auto-verifies the customer + SQL account, skips
  `CreateDefaultWorkspace`, and signals autologin via `@invite_accepted`.
- `after_login` no longer auto-accepts; the `accept_invite_on_login`
  helper was removed. Signup and login now share the same downstream
  acceptance path.
- `signup_and_accept` reloads the invitation via `find_by_token` after
  account creation and asserts `pending?` before returning success.

**Frontend — explicit-consent flow**
- Removed `acceptPendingInvite` helper and both call sites in
  `useInviteAuth` — composable no longer auto-accepts after auth.
- Renamed `signupAndAccept` → `signupForInvite`, `loginAndAccept` →
  `loginForInvite` so names match behavior.
- Replaced `onAcceptSuccess` (which set an \"accepted\" message and
  redirected to `/orgs` after 1.5s) with `onAuthSuccess`. The state
  machine recomputes to `direct_accept` once auth completes, surfacing
  the Decline/Accept buttons for the user to click.
- Bridge text \"Almost done — confirm below to join the organization.\"
  shows on the brief transition window through `direct_accept`.
- Renamed misleading locale keys: `create_account_and_join` →
  `signup_continue`, `sign_in_and_accept` → `signin_continue`. Sign-in
  button now reads \"Sign In\" instead of \"Sign In & Accept Invitation\".
- Added source-code invariant that fails if `\$api.post(.../accept` or
  `acceptPendingInvite` reappears in the composable.

**Member-limit UX (carried with #3221 because surfaced during testing)**
- Strengthened upgrade prompt on `OrganizationSettings.vue` and the
  invite UI when the org has hit its member cap.

**Error response formatting**
- User-facing message lives in `error`, machine-readable identifier in
  `error_type`. Updated the classifier, error utils, and the affected
  callers. Fixed a duplicate error display on the Accept page.

**RabbitMQ / email worker instrumentation (peripheral)**
- All queue commands now read RabbitMQ URLs through the config layer
  rather than reading `ENV` directly. Added boot-time logging of the
  effective URL and instrumented base/email workers to trace silent
  rejections. Added defaults for the Jobs logger. Picked up during the
  invite-flow debug session; kept in-branch since the email path
  matters for invite delivery.

## Test plan

- [x] `pnpm vitest run src/tests/composables/useInviteAuth.spec.ts src/tests/views/session/AcceptInvite.spec.ts` — 48/48 pass.
- [x] Backend invite spec suite — see `apps/api/invite/spec/logic/invites/signup_and_accept_spec.rb` and `apps/web/auth/spec/integration/full/invite_signup_autologin_internal_request_spec.rb` (4 new regression cases: pending-after-signup, post-accept activation, decline-still-works, email-mismatch-blocks).
- [x] `OrganizationMembership` tryouts — 198 cases pass; `accept!` external contract unchanged for the auto-promote path.
- [x] `pnpm vue-tsc --noEmit` — clean.
- [ ] Verify end-to-end against `dev.onetime.dev` once deployed: clicking the invite link, completing signup, then clicking Accept must succeed (no 404). Decline must work for the same token.

## Follow-ups

- `Auth::Operations::AcceptInvitation` is now only called from the
  explicit accept-API endpoint (via `OrganizationMembership#accept!`).
  Still referenced from try-integration tests; safe to leave in place.