### PR TITLE
[#3221] Add error_type to i18n-keyed raise_form_error calls

### DIFF
--- a/apps/api/invite/logic/invites/accept_invite.rb
+++ b/apps/api/invite/logic/invites/accept_invite.rb
@@ -30,6 +30,7 @@ module InviteAPI::Logic
             'Token is required',
             error_key: 'api.invite.errors.token_required',
             field: :token,
+            error_type: :missing,
           )
         end
 
@@ -42,6 +43,7 @@ module InviteAPI::Logic
             'Organization no longer exists',
             error_key: 'api.invite.errors.organization_no_longer_exists',
             field: :token,
+            error_type: :missing,
           )
         end
 
@@ -52,6 +54,7 @@ module InviteAPI::Logic
             error_key: 'api.invite.errors.invitation_already_processed',
             args: { status: @invitation.status },
             field: :token,
+            error_type: :invalid,
           )
         end
 
@@ -61,6 +64,7 @@ module InviteAPI::Logic
             'Invitation has expired',
             error_key: 'api.invite.errors.invitation_expired',
             field: :token,
+            error_type: :expired,
           )
         end
 
@@ -86,6 +90,7 @@ module InviteAPI::Logic
           'You are already a member of this organization',
           error_key: 'api.invite.errors.already_member',
           field: :token,
+          error_type: :exists,
         )
       end
 

--- a/apps/api/invite/logic/invites/decline_invite.rb
+++ b/apps/api/invite/logic/invites/decline_invite.rb
@@ -31,14 +31,14 @@ module InviteAPI::Logic
         rate_limiter.record_attempt
 
         if @token.nil? || @token.empty?
-          raise_form_error(error_key: 'api.invite.errors.token_required', field: :token)
+          raise_form_error(error_key: 'api.invite.errors.token_required', field: :token, error_type: :missing)
         end
 
         @invitation = load_invitation(@token)
 
         # Check if organization still exists (may have been deleted)
         unless @invitation.organization
-          raise_form_error(error_key: 'api.invite.errors.organization_no_longer_exists', field: :token)
+          raise_form_error(error_key: 'api.invite.errors.organization_no_longer_exists', field: :token, error_type: :missing)
         end
 
         # Check if invitation is still pending
@@ -48,6 +48,7 @@ module InviteAPI::Logic
           error_key: 'api.invite.errors.invitation_already_processed',
           args: { status: @invitation.status },
           field: :token,
+          error_type: :invalid,
         )
 
         # NOTE: We allow declining expired invitations since the user

--- a/apps/api/invite/logic/invites/show_invite.rb
+++ b/apps/api/invite/logic/invites/show_invite.rb
@@ -40,14 +40,14 @@ module InviteAPI::Logic
         rate_limiter.record_attempt
 
         if @token.nil? || @token.empty?
-          raise_form_error(error_key: 'api.invite.errors.token_required', field: :token)
+          raise_form_error(error_key: 'api.invite.errors.token_required', field: :token, error_type: :missing)
         end
 
         @invitation = load_invitation(@token)
 
         # Check if organization still exists (may have been deleted)
         unless @invitation.organization
-          raise_form_error(error_key: 'api.invite.errors.organization_no_longer_exists', field: :token)
+          raise_form_error(error_key: 'api.invite.errors.organization_no_longer_exists', field: :token, error_type: :missing)
         end
 
         # NOTE: We no longer raise errors for non-pending or expired invitations.

--- a/apps/api/invite/spec/logic/invites/accept_invite_spec.rb
+++ b/apps/api/invite/spec/logic/invites/accept_invite_spec.rb
@@ -68,11 +68,20 @@ RSpec.describe InviteAPI::Logic::Invites::AcceptInvite do
 
   subject(:logic) { described_class.new(strategy_result, params) }
 
+  # Source uses auth_logger (Onetime.get_logger('Auth')) for its semantic logs,
+  # not the OT.info shim. Stub the Auth logger so .debug/.info/.error during
+  # the spec don't fail the test, and so individual examples can set focused
+  # expectations on it.
+  let(:auth_logger_double) do
+    instance_double(SemanticLogger::Logger, info: nil, debug: nil, warn: nil, error: nil)
+  end
+
   before do
     allow(OT).to receive(:info)
     allow(OT).to receive(:ld)
     allow(OT).to receive(:le)
     allow(OT::Utils).to receive(:normalize_email) { |e| e.to_s.downcase.strip }
+    allow(Onetime).to receive(:get_logger).with('Auth').and_return(auth_logger_double)
   end
 
   describe '#process_params' do
@@ -279,8 +288,8 @@ RSpec.describe InviteAPI::Logic::Invites::AcceptInvite do
       end
 
       it 'logs the acceptance' do
-        expect(OT).to receive(:info).with(
-          '[AcceptInvite] User joined organization',
+        expect(auth_logger_double).to receive(:info).with(
+          'User joined organization',
           hash_including(event: 'invite.accepted', result: :success)
         )
         logic.process

--- a/apps/api/invite/spec/logic/invites/signup_and_accept_spec.rb
+++ b/apps/api/invite/spec/logic/invites/signup_and_accept_spec.rb
@@ -82,6 +82,14 @@ RSpec.describe InviteAPI::Logic::Invites::SignupAndAccept do
     db
   end
 
+  # Source uses auth_logger (Onetime.get_logger('Auth')) for its semantic logs,
+  # not the OT.info shim. Stub the Auth logger so .debug/.info/.error during
+  # the spec don't fail the test, and so individual examples can set focused
+  # expectations on it.
+  let(:auth_logger_double) do
+    instance_double(SemanticLogger::Logger, info: nil, debug: nil, warn: nil, error: nil)
+  end
+
   before do
     allow(OT).to receive(:info)
     allow(OT).to receive(:ld)
@@ -89,6 +97,7 @@ RSpec.describe InviteAPI::Logic::Invites::SignupAndAccept do
     allow(OT::Utils).to receive(:normalize_email).and_return(normalized_email)
     allow(OT::Utils).to receive(:obscure_email).and_return('ne***@example.com')
     allow(Auth::Database).to receive(:connection).and_return(mock_auth_db)
+    allow(Onetime).to receive(:get_logger).with('Auth').and_return(auth_logger_double)
   end
 
   describe '#process_params' do
@@ -314,150 +323,14 @@ RSpec.describe InviteAPI::Logic::Invites::SignupAndAccept do
     end
   end
 
-  describe '#process' do
-    let(:new_customer) do
-      cust = build_mock_customer(
-        objid: 'cust-new-123',
-        custid: 'cust-new-123',
-        extid: 'ext-new-123',
-        email: invited_email,
-        obscure_email: 'ne***@example.com'
-      )
-      allow(cust).to receive(:role).and_return('customer')
-      allow(cust).to receive(:locale).and_return('en')
-      cust
-    end
-
-    let(:rate_limiter) { instance_double(Onetime::Security::InviteTokenRateLimiter) }
-
-    before do
-      allow(Onetime::Security::InviteTokenRateLimiter).to receive(:new)
-        .with(client_ip)
-        .and_return(rate_limiter)
-      allow(rate_limiter).to receive(:check!)
-      allow(rate_limiter).to receive(:record_attempt)
-
-      allow(Onetime::OrganizationMembership).to receive(:find_by_token)
-        .with(invite_token)
-        .and_return(invitation)
-      allow(Onetime::Customer).to receive(:email_exists?)
-        .with(normalized_email)
-        .and_return(false)
-
-      # Mock account creation via Rodauth internal_request
-      allow(Auth::Config).to receive(:create_account).and_return(123)
-
-      # Mock CreateCustomer operation
-      create_customer_op = instance_double(Auth::Operations::CreateCustomer)
-      allow(Auth::Operations::CreateCustomer).to receive(:new).and_return(create_customer_op)
-      allow(create_customer_op).to receive(:call).and_return(new_customer)
-
-      # Mock CreateDefaultWorkspace operation
-      workspace_op = instance_double(Auth::Operations::CreateDefaultWorkspace)
-      allow(Auth::Operations::CreateDefaultWorkspace).to receive(:new).and_return(workspace_op)
-      allow(workspace_op).to receive(:call)
-
-      # Mock AcceptInvitation operation
-      accept_op = instance_double(Auth::Operations::AcceptInvitation)
-      allow(Auth::Operations::AcceptInvitation).to receive(:new).and_return(accept_op)
-      allow(accept_op).to receive(:call).and_return({ accepted: true, organization_id: 'org-test-123', role: 'member' })
-
-      # Mock logging
-      allow(Auth::Logging).to receive(:log_auth_event)
-      allow(Familia).to receive(:now).and_return(double(to_i: Time.now.to_i))
-      allow(Familia).to receive(:dbclient).and_return(double(del: true))
-    end
-
-    subject(:logic) { described_class.new(strategy_result, valid_params) }
-
-    context 'with valid request (happy path)' do
-      before do
-        logic.raise_concerns
-      end
-
-      it 'creates Rodauth account via internal_request' do
-        expect(Auth::Config).to receive(:create_account).with(
-          login: normalized_email,
-          password: valid_password
-        )
-        logic.process
-      end
-
-      it 'creates Customer in Redis' do
-        expect(Auth::Operations::CreateCustomer).to receive(:new).with(
-          account_id: 123,
-          account: hash_including(id: 123, email: normalized_email),
-          db: mock_auth_db
-        )
-        logic.process
-      end
-
-      it 'creates default workspace' do
-        expect(Auth::Operations::CreateDefaultWorkspace).to receive(:new)
-          .with(customer: new_customer)
-        logic.process
-      end
-
-      it 'accepts the invitation' do
-        expect(Auth::Operations::AcceptInvitation).to receive(:new).with(
-          customer: new_customer,
-          token: invite_token
-        )
-        logic.process
-      end
-
-      it 'marks account as verified in authdb' do
-        accounts_ds = mock_auth_db[:accounts]
-        expect(accounts_ds).to receive(:where).with(id: 123).and_return(accounts_ds)
-        expect(accounts_ds).to receive(:update).with(status_id: 2)
-        logic.process
-      end
-
-      it 'sets up session for auto-login' do
-        logic.process
-        expect(session['authenticated']).to be true
-        expect(session['external_id']).to eq('ext-new-123')
-      end
-
-      it 'returns success data with record wrapper' do
-        result = logic.process
-        expect(result).to have_key(:record)
-        expect(result[:record]).to include(:user_id, :organization, :role, :invitation_status, :auto_login)
-      end
-
-      it 'logs the pending-accept signup event' do
-        expect(OT).to receive(:info).with(
-          '[SignupAndAccept] User signed up; invitation pending explicit accept',
-          hash_including(event: 'invite.signup_pending_accept', result: :success)
-        )
-        logic.process
-      end
-    end
-
-    context 'when Rodauth account creation fails' do
-      before do
-        logic.raise_concerns
-        allow(Auth::Config).to receive(:create_account).and_return(nil)
-      end
-
-      it 'raises form error' do
-        expect { logic.process }.to raise_error(Onetime::FormError, /Failed to create account/)
-      end
-    end
-
-    context 'when invitation acceptance fails' do
-      before do
-        logic.raise_concerns
-        accept_op = instance_double(Auth::Operations::AcceptInvitation)
-        allow(Auth::Operations::AcceptInvitation).to receive(:new).and_return(accept_op)
-        allow(accept_op).to receive(:call).and_return({ accepted: false, reason: 'error' })
-      end
-
-      it 'raises form error' do
-        expect { logic.process }.to raise_error(Onetime::FormError, /Failed to accept invitation/)
-      end
-    end
-  end
+  # NOTE: The historical "#process" describe block tested an obsolete contract
+  # where this logic class directly invoked Auth::Operations::CreateCustomer /
+  # CreateDefaultWorkspace / AcceptInvitation. The current source (#3221)
+  # delegates Customer/workspace creation to Rodauth's after_create_account
+  # hook (apps/web/auth/config/hooks/account.rb) and reserves invitation
+  # acceptance for a separate explicit /accept call. The current contract is
+  # covered by "#process invitation reload after signup" below; see also the
+  # success_data block.
 
   describe '#success_data' do
     let(:new_customer) do
@@ -525,6 +398,18 @@ RSpec.describe InviteAPI::Logic::Invites::SignupAndAccept do
 
     let(:account_row) { { id: 123, email: normalized_email, external_id: 'ext-new-123' } }
 
+    # Sequel dataset double for accounts table operations. Exposed as a let
+    # so individual contexts can override .first to exercise error branches
+    # (e.g. account row missing after create_account).
+    let(:accounts_ds) do
+      ds = double('accounts_ds')
+      allow(ds).to receive(:where).and_return(ds)
+      allow(ds).to receive(:first).and_return(account_row)
+      allow(ds).to receive(:any?).and_return(false)
+      allow(ds).to receive(:update)
+      ds
+    end
+
     before do
       allow(Onetime::Security::InviteTokenRateLimiter).to receive(:new)
         .with(client_ip)
@@ -546,12 +431,6 @@ RSpec.describe InviteAPI::Logic::Invites::SignupAndAccept do
       # invitation stays pending. We model that here.
       allow(Auth::Config).to receive(:create_account).and_return(nil)
 
-      # Sequel dataset double for accounts table operations.
-      accounts_ds = double('accounts_ds')
-      allow(accounts_ds).to receive(:where).and_return(accounts_ds)
-      allow(accounts_ds).to receive(:first).and_return(account_row)
-      allow(accounts_ds).to receive(:any?).and_return(false)
-      allow(accounts_ds).to receive(:update)
       allow(Auth::Database).to receive(:connection).and_return(double(:[] => accounts_ds))
 
       allow(Onetime::Customer).to receive(:find_by_extid)
@@ -585,6 +464,51 @@ RSpec.describe InviteAPI::Logic::Invites::SignupAndAccept do
         expect(result[:record][:auto_login]).to be true
         expect(result[:record][:role]).to eq('member')
         expect(result[:record][:invitation_status]).to eq('pending')
+      end
+
+      it 'creates the Rodauth account via internal_request with the invite_token' do
+        expect(Auth::Config).to receive(:create_account).with(
+          login: normalized_email,
+          password: valid_password,
+          params: { 'invite_token' => invite_token }
+        )
+        logic.process
+      end
+
+      it 'returns success_data with the expected record wrapper keys' do
+        result = logic.process
+        expect(result).to have_key(:record)
+        expect(result[:record]).to include(:user_id, :organization, :role, :invitation_status, :auto_login)
+      end
+
+      it 'sets up the session for auto-login' do
+        logic.process
+        expect(session['authenticated']).to be true
+        expect(session['external_id']).to eq('ext-new-123')
+        expect(session['account_id']).to eq(123)
+      end
+
+      it 'logs the pending-accept signup event on the auth logger' do
+        expect(auth_logger_double).to receive(:info).with(
+          'User signed up; invitation pending explicit accept',
+          hash_including(event: 'invite.signup_pending_accept', result: :success)
+        )
+        logic.process
+      end
+    end
+
+    context 'when the account row is missing after create_account' do
+      # Mirrors signup_and_accept.rb:228 — create_account succeeded with no
+      # error, but the followup .where(email: ...).first lookup returns nil.
+      # We trigger this by stubbing .first to nil so the account branch raises
+      # before the customer-missing branch (which has its own assertion).
+      before do
+        allow(accounts_ds).to receive(:first).and_return(nil)
+        logic.raise_concerns
+      end
+
+      it 'raises a form error indicating account creation failed' do
+        expect { logic.process }.to raise_error(Onetime::FormError, /Failed to create account/)
       end
     end
 

--- a/apps/api/organizations/logic/invitations/create_invitation.rb
+++ b/apps/api/organizations/logic/invitations/create_invitation.rb
@@ -34,26 +34,26 @@ module OrganizationAPI::Logic
 
         # Validate email (basic validation before quota check)
         if @email.empty?
-          raise_form_error(error_key: 'api.organizations.invitations.errors.email_required', field: 'email')
+          raise_form_error(error_key: 'api.organizations.invitations.errors.email_required', field: 'email', error_type: :missing)
         end
         unless valid_email?(@email)
-          raise_form_error(error_key: 'api.organizations.invitations.errors.invalid_email_format', field: 'email')
+          raise_form_error(error_key: 'api.organizations.invitations.errors.invalid_email_format', field: 'email', error_type: :invalid)
         end
 
         # Validate role
         unless %w[member admin].include?(@role)
-          raise_form_error(error_key: 'api.organizations.invitations.errors.invalid_role', field: 'role')
+          raise_form_error(error_key: 'api.organizations.invitations.errors.invalid_role', field: 'role', error_type: :invalid)
         end
 
         # Owners cannot be invited (must be assigned directly)
         if @role == 'owner'
-          raise_form_error(error_key: 'api.organizations.invitations.errors.cannot_invite_as_owner', field: 'role')
+          raise_form_error(error_key: 'api.organizations.invitations.errors.cannot_invite_as_owner', field: 'role', error_type: :forbidden)
         end
 
         # Check if user is already a member
         existing_customer = Onetime::Customer.find_by_email(@email)
         if existing_customer && @organization.member?(existing_customer)
-          raise_form_error(error_key: 'api.organizations.invitations.errors.user_already_member', field: 'email')
+          raise_form_error(error_key: 'api.organizations.invitations.errors.user_already_member', field: 'email', error_type: :exists)
         end
 
         # Check for existing pending invitation
@@ -61,7 +61,7 @@ module OrganizationAPI::Logic
           @organization.objid, @email
         )
         if existing_invite&.pending?
-          raise_form_error(error_key: 'api.organizations.invitations.errors.invitation_already_pending', field: 'email')
+          raise_form_error(error_key: 'api.organizations.invitations.errors.invitation_already_pending', field: 'email', error_type: :exists)
         end
 
         # Check member quota AFTER basic validation

--- a/apps/api/organizations/logic/invitations/resend_invitation.rb
+++ b/apps/api/organizations/logic/invitations/resend_invitation.rb
@@ -43,7 +43,7 @@ module OrganizationAPI::Logic
 
         # Can only resend pending invitations
         unless @invitation.pending?
-          raise_form_error(error_key: 'api.organizations.invitations.errors.resend_only_pending', field: :token)
+          raise_form_error(error_key: 'api.organizations.invitations.errors.resend_only_pending', field: :token, error_type: :invalid)
         end
 
         # Rate limit resends

--- a/apps/api/organizations/logic/invitations/revoke_invitation.rb
+++ b/apps/api/organizations/logic/invitations/revoke_invitation.rb
@@ -40,7 +40,7 @@ module OrganizationAPI::Logic
 
         # Can only revoke pending invitations
         unless @invitation.pending?
-          raise_form_error(error_key: 'api.organizations.invitations.errors.revoke_only_pending', field: :token)
+          raise_form_error(error_key: 'api.organizations.invitations.errors.revoke_only_pending', field: :token, error_type: :invalid)
         end
       end
 

--- a/apps/api/organizations/logic/members/update_member_role.rb
+++ b/apps/api/organizations/logic/members/update_member_role.rb
@@ -96,8 +96,10 @@ module OrganizationAPI::Logic
       def load_member(extid)
         member = Onetime::Customer.find_by_extid(extid)
         if member.nil?
-          raise_not_found(error_key: 'api.organizations.members.errors.member_not_found',
-                          args: { extid: extid })
+          raise_not_found(
+            error_key: 'api.organizations.members.errors.member_not_found',
+            args: { extid: extid },
+          )
         end
         member
       end
@@ -112,7 +114,7 @@ module OrganizationAPI::Logic
           raise_not_found(error_key: 'api.organizations.members.errors.member_not_in_organization')
         end
         unless membership.active?
-          raise_form_error(error_key: 'api.organizations.members.errors.member_not_active')
+          raise_form_error(error_key: 'api.organizations.members.errors.member_not_active', error_type: :invalid)
         end
         membership
       end
@@ -125,6 +127,7 @@ module OrganizationAPI::Logic
             error_key: 'api.organizations.members.errors.invalid_role_value',
             args: { roles: VALID_ROLES.join(', ') },
             field: :role,
+            error_type: :invalid,
           )
         end
 
@@ -133,6 +136,7 @@ module OrganizationAPI::Logic
           raise_form_error(
             error_key: 'api.organizations.members.errors.cannot_change_owner_role',
             field: :role,
+            error_type: :forbidden,
           )
         end
 
@@ -142,6 +146,7 @@ module OrganizationAPI::Logic
             error_key: 'api.organizations.members.errors.member_already_has_role',
             args: { role: @new_role },
             field: :role,
+            error_type: :conflict,
           )
         end
 
@@ -151,6 +156,7 @@ module OrganizationAPI::Logic
         raise_form_error(
           error_key: 'api.organizations.members.errors.cannot_promote_to_owner',
           field: :role,
+          error_type: :forbidden,
         )
       end
     end

--- a/install-dev.sh
+++ b/install-dev.sh
@@ -6,6 +6,7 @@
 #   - Links shared dev resources from OTS_DEV_CONFIG
 #   - Installs Ruby gems (bundle install)
 #   - Installs Node packages (pnpm install)
+#   - Installs the pre-commit/pre-push git hooks and their tool envs
 #   - Cleans any pre-existing frontend build output (pnpm run clean)
 #   - Points the Caddy webroot symlink at this checkout's public/web
 #
@@ -138,6 +139,55 @@ link_caddy_webroot() {
     fi
 }
 
+# Install the pre-commit-managed git hooks and pre-build their isolated
+# tool environments (rubocop, eslint, etc). Two configs are in play:
+#   .pre-commit-config.yaml  -> pre-commit, prepare-commit-msg, post-* hooks
+#                               (hook types come from default_install_hook_types)
+#   .pre-push-config.yaml    -> pre-push hooks (separate config + hook type)
+#
+# --install-hooks pre-builds the hook environments so the first commit/push
+# is not slowed down by a one-time dependency download. Hooks land in the
+# common git dir, so a worktree forest shares one set — re-running here is
+# idempotent.
+install_git_hooks() {
+    if [[ "${has_pre_commit}" != true ]]; then
+        echo "Skip: pre-commit not installed — git hooks not configured"
+        return
+    fi
+
+    # pre-commit refuses to install while core.hooksPath is set, since it
+    # cannot guarantee git will invoke the hooks it writes. Surface the
+    # one-line fix instead of aborting the whole script.
+    local hooks_path
+    hooks_path="$(git config --get core.hooksPath || true)"
+    if [[ -n "$hooks_path" ]]; then
+        echo ""
+        echo ">>> WARNING: git hooks NOT installed"
+        echo "    pre-commit will not install while core.hooksPath is set."
+        echo "    Current value: $hooks_path"
+
+        # If it merely pins git's own default hooks dir, clearing it
+        # changes nothing — say so, so the user isn't left guessing.
+        local default_hooks resolved_hooks
+        default_hooks="$(cd "$(git rev-parse --git-path hooks)" 2>/dev/null && pwd -P || true)"
+        resolved_hooks="$(cd "$hooks_path" 2>/dev/null && pwd -P || true)"
+        if [[ -n "$default_hooks" && "$resolved_hooks" == "$default_hooks" ]]; then
+            echo "    (This is git's default hooks directory. Clearing the setting for this local checkout is safe.)"
+        fi
+
+        echo "    To enable git hooks, clear it and re-run this script:"
+        echo "      git config --unset-all core.hooksPath"
+        echo ""
+        return
+    fi
+
+    pre-commit install --install-hooks \
+        || { echo "Warning: pre-commit hook install failed — git hooks not configured"; return; }
+    pre-commit install --hook-type pre-push \
+        --config .pre-push-config.yaml --install-hooks \
+        || { echo "Warning: pre-push hook install failed"; return; }
+}
+
 link_resource() {
     local local_path="$1"
     local shared_name="$2"
@@ -203,6 +253,20 @@ if ! command -v overmind &>/dev/null; then
     echo ""
 fi
 
+# Check for pre-commit (manages the git pre-commit/pre-push hooks) — cache
+# result for reuse below. Not required to run the app, so warn and continue.
+has_pre_commit=true
+if ! command -v pre-commit &>/dev/null; then
+    has_pre_commit=false
+    echo "Warning: pre-commit not found — git pre-commit/pre-push hooks will not be installed"
+    echo "  Install one of:"
+    echo "    pipx install pre-commit        (recommended — isolated)"
+    echo "    brew install pre-commit        (macOS)"
+    echo "    pip install --user pre-commit"
+    echo "  Docs: https://pre-commit.com"
+    echo ""
+fi
+
 # Warn if shared config directory is absent
 if [[ ! -d "$OTS_DEV_CONFIG" ]]; then
     echo "Warning: $OTS_DEV_CONFIG does not exist — config symlinks will be skipped"
@@ -248,6 +312,10 @@ bundle install
 echo "---"
 echo "Installing Node packages..."
 pnpm install
+
+echo "---"
+echo "Installing git hooks (pre-commit, pre-push)..."
+install_git_hooks
 
 echo "---"
 echo "Removing frontend build output (public/web/dist)..."

--- a/lib/onetime/errors.rb
+++ b/lib/onetime/errors.rb
@@ -150,6 +150,7 @@ module Onetime
     def to_h
       {
         error: message,
+        error_type: 'EntitlementRequired',
         entitlement: entitlement,
         current_plan: current_plan,
         upgrade_to: upgrade_to,
@@ -184,7 +185,8 @@ module Onetime
 
     def to_h
       {
-        message: message,
+        error: message,
+        error_type: 'GuestRoutesDisabled',
         code: code,
         error_key: error_key,
       }.compact

--- a/spec/integration/api/v3/guest_route_gating_spec.rb
+++ b/spec/integration/api/v3/guest_route_gating_spec.rb
@@ -367,7 +367,7 @@ RSpec.describe 'API V3 Guest Route Gating', type: :integration do
   describe 'GuestRoutesDisabled error structure' do
     before { stub_guest_routes_config(enabled: false) }
 
-    it 'includes message and code in to_h' do
+    it 'includes error and code in to_h' do
       logic = create_logic(V3::Logic::Secrets::ConcealSecret, params: { 'secret' => { 'secret' => 'test' } })
       logic.process_params
 
@@ -376,7 +376,8 @@ RSpec.describe 'API V3 Guest Route Gating', type: :integration do
 
       hash = error.to_h
       expect(hash).to include(
-        message: 'Guest API access is disabled',
+        error: 'Guest API access is disabled',
+        error_type: 'GuestRoutesDisabled',
         code: 'GUEST_ROUTES_DISABLED',
       )
     end

--- a/spec/unit/onetime/cli/queue/init_command_spec.rb
+++ b/spec/unit/onetime/cli/queue/init_command_spec.rb
@@ -16,10 +16,19 @@ RSpec.describe Onetime::CLI::Queue::InitCommand do
   let(:encoded_name) { URI.encode_www_form_component(policy[:name]) }
   let(:policy_url) { "#{management_base}/api/policies/#{encoded_vhost}/#{encoded_name}" }
 
+  # RabbitMQ URL and Management URL are read from OT.conf (not ENV directly)
+  # since commit ec718be6a routed all RabbitMQ URL reads through config.
+  let(:test_conf) do
+    {
+      'jobs' => {
+        'rabbitmq_url' => amqp_url,
+        'rabbitmq_management_url' => management_base,
+      },
+    }
+  end
+
   before do
-    allow(ENV).to receive(:fetch).and_call_original
-    allow(ENV).to receive(:fetch).with('RABBITMQ_URL', anything).and_return(amqp_url)
-    allow(ENV).to receive(:fetch).with('RABBITMQ_MANAGEMENT_URL', anything).and_return(management_base)
+    allow(OT).to receive(:conf).and_return(test_conf)
     allow(command).to receive(:boot_application!)
     allow(command).to receive(:create_vhost)
     allow(command).to receive(:set_permissions)

--- a/spec/unit/onetime/errors_spec.rb
+++ b/spec/unit/onetime/errors_spec.rb
@@ -68,8 +68,8 @@ RSpec.describe Onetime::LimitExceeded do
         error_key: 'api.limits.errors.too_many_attempts',
       )
       expect(error.to_h).to eq(
-        error: 'LimitExceeded',
-        message: 'blocked',
+        error: 'blocked',
+        error_type: 'LimitExceeded',
         retry_after: 60,
         attempts: 6,
         max_attempts: 5,
@@ -130,7 +130,8 @@ RSpec.describe Onetime::GuestRoutesDisabled do
         error_key: 'api.guest.errors.routes_disabled',
       )
       expect(error.to_h).to eq(
-        message: 'nope',
+        error: 'nope',
+        error_type: 'GuestRoutesDisabled',
         code: 'CUSTOM_CODE',
         error_key: 'api.guest.errors.routes_disabled',
       )

--- a/spec/unit/onetime/incoming/recipient_resolver_spec.rb
+++ b/spec/unit/onetime/incoming/recipient_resolver_spec.rb
@@ -60,8 +60,8 @@ RSpec.describe Onetime::Incoming::RecipientResolver do
         expect { resolver.require_domain_entitlement!('incoming_secrets') }
           .to raise_error(Onetime::Forbidden) do |error|
             expect(error.to_h).to include(
-              error: 'Forbidden',
-              message: 'Custom domain organization could not be resolved',
+              error: 'Custom domain organization could not be resolved',
+              error_type: 'Forbidden',
               error_key: 'api.incoming.errors.custom_domain_unresolved',
             )
           end

--- a/spec/unit/onetime/initializers/setup_rabbitmq_spec.rb
+++ b/spec/unit/onetime/initializers/setup_rabbitmq_spec.rb
@@ -526,17 +526,14 @@ RSpec.describe Onetime::Initializers::SetupRabbitMQ do
     end
   end
 
-  describe 'RABBITMQ_CHANNEL_POOL_SIZE environment variable' do
+  describe 'channel_pool_size config' do
+    # RABBITMQ_CHANNEL_POOL_SIZE env var is resolved at config-load time
+    # by ERB in etc/defaults/config.defaults.yaml; runtime code reads
+    # OT.conf.dig('jobs', 'channel_pool_size') and never touches ENV.
     around do |example|
-      original_pool_size = ENV['RABBITMQ_CHANNEL_POOL_SIZE']
       original_skip = ENV['SKIP_RABBITMQ_SETUP']
       example.run
     ensure
-      if original_pool_size.nil?
-        ENV.delete('RABBITMQ_CHANNEL_POOL_SIZE')
-      else
-        ENV['RABBITMQ_CHANNEL_POOL_SIZE'] = original_pool_size
-      end
       if original_skip.nil?
         ENV.delete('SKIP_RABBITMQ_SETUP')
       else
@@ -544,20 +541,19 @@ RSpec.describe Onetime::Initializers::SetupRabbitMQ do
       end
     end
 
-    context 'when RABBITMQ_CHANNEL_POOL_SIZE is set' do
+    context 'when channel_pool_size is set in config' do
       before do
-        ENV['RABBITMQ_CHANNEL_POOL_SIZE'] = '10'
         ENV.delete('SKIP_RABBITMQ_SETUP')
         allow(OT).to receive(:conf).and_return({
           'jobs' => {
             'enabled' => true,
-            'rabbitmq_url' => 'amqp://localhost'
-            # Note: no channel_pool_size in config - should use env var
+            'rabbitmq_url' => 'amqp://localhost',
+            'channel_pool_size' => 10,
           }
         })
       end
 
-      it 'uses the environment variable value for pool size' do
+      it 'uses the configured value for pool size' do
         mock_conn = instance_double(Bunny::Session, start: true, open?: true)
         mock_channel = instance_double(Bunny::Channel)
         mock_pool = instance_double(ConnectionPool)

--- a/spec/unit/onetime/logic/guest_route_gating_spec.rb
+++ b/spec/unit/onetime/logic/guest_route_gating_spec.rb
@@ -244,12 +244,13 @@ RSpec.describe Onetime::Logic::GuestRouteGating do
       expect(error.code).to eq('CUSTOM_CODE')
     end
 
-    it 'serializes to hash with message and code' do
+    it 'serializes to hash with error, error_type, and code' do
       error = Onetime::GuestRoutesDisabled.new('Test message', code: 'TEST_CODE')
       hash = error.to_h
 
       expect(hash).to eq({
-        message: 'Test message',
+        error: 'Test message',
+        error_type: 'GuestRoutesDisabled',
         code: 'TEST_CODE',
       })
     end

--- a/spec/unit/onetime/logic/sso_only_gating_spec.rb
+++ b/spec/unit/onetime/logic/sso_only_gating_spec.rb
@@ -71,8 +71,8 @@ RSpec.describe Onetime::Logic::SsoOnlyGating do
         expect { instance.require_non_sso_only! }
           .to raise_error(Onetime::Forbidden) do |error|
             expect(error.to_h).to include(
-              error: 'Forbidden',
-              message: 'This action is not available in SSO-only mode',
+              error: 'This action is not available in SSO-only mode',
+              error_type: 'Forbidden',
               error_key: 'api.errors.sso_only_action_blocked',
             )
           end

--- a/src/tests/composables/useReceipt.spec.ts
+++ b/src/tests/composables/useReceipt.spec.ts
@@ -244,7 +244,7 @@ describe('useReceipt', () => {
         undefined,
         {
           status: 404,
-          data: { message: 'Secret not found or has been burned' },
+          data: { error: 'Secret not found or has been burned' },
         } as any
       );
 

--- a/src/tests/schemas/errors/classifier.spec.ts
+++ b/src/tests/schemas/errors/classifier.spec.ts
@@ -19,7 +19,7 @@ describe('error classifier', () => {
         {
           status: 403,
           statusText: 'Forbidden',
-          data: { message: 'Guest API access is disabled' },
+          data: { error: 'Guest API access is disabled' },
           headers: {},
           config: {} as any,
         }
@@ -70,7 +70,7 @@ describe('error classifier', () => {
         {
           status: 404,
           statusText: 'Not Found',
-          data: { message: 'Not Found' },
+          data: { error: 'Not Found' },
           headers: {},
           config: {} as any,
         }
@@ -95,7 +95,7 @@ describe('error classifier', () => {
         {
           status: 500,
           statusText: 'Internal Server Error',
-          data: { message: 'Internal Server Error' },
+          data: { error: 'Internal Server Error' },
           headers: {},
           config: {} as any,
         }
@@ -119,7 +119,7 @@ describe('error classifier', () => {
         undefined,
         {
           status: 429,
-          data: { message: 'Too Many Requests' },
+          data: { error: 'Too Many Requests' },
         } as any
       ) as AxiosError;
 
@@ -164,8 +164,8 @@ describe('error classifier', () => {
           status: 422,
           ok: false,
           statusText: 'Unprocessable Entity',
-          json: () => Promise.resolve({ message: 'Validation Failed' }),
-          data: { message: 'Validation Failed' },
+          json: () => Promise.resolve({ error: 'Validation Failed' }),
+          data: { error: 'Validation Failed' },
         },
       });
 
@@ -200,7 +200,7 @@ describe('error classifier', () => {
     describe('jsdom checks', () => {
       it.skip('classifies fetch response errors correctly', async () => {
         // Reason: "Response is not a constructor"
-        const response = new Response(JSON.stringify({ message: 'Validation Failed' }), {
+        const response = new Response(JSON.stringify({ error: 'Validation Failed' }), {
           status: 422,
           statusText: 'Unprocessable Entity',
           headers: {

--- a/src/tests/stores/receiptStore.spec.ts
+++ b/src/tests/stores/receiptStore.spec.ts
@@ -547,7 +547,8 @@ describe('receiptStore', () => {
 
     describe('GUEST_ROUTES_DISABLED errors', () => {
       const guestRoutesDisabledResponse = {
-        message: 'Guest API access is disabled',
+        error: 'Guest API access is disabled',
+        error_type: 'GuestRoutesDisabled',
         code: 'GUEST_ROUTES_DISABLED',
       };
 
@@ -594,7 +595,8 @@ describe('receiptStore', () => {
         const testKey = mockReceiptRecord.key;
         store.setApiMode('public');
         axiosMock?.onGet(`/api/v3/guest/receipt/${testKey}`).reply(403, {
-          message: 'Guest receipt is disabled',
+          error: 'Guest receipt is disabled',
+          error_type: 'GuestRoutesDisabled',
           code: 'GUEST_RECEIPT_DISABLED',
         });
 
@@ -606,7 +608,8 @@ describe('receiptStore', () => {
         store.setApiMode('public');
         store.record = { ...mockReceiptRecord, burned: null, state: 'new' };
         axiosMock?.onPost(`/api/v3/guest/receipt/${testKey}/burn`).reply(403, {
-          message: 'Guest burn is disabled',
+          error: 'Guest burn is disabled',
+          error_type: 'GuestRoutesDisabled',
           code: 'GUEST_BURN_DISABLED',
         });
 

--- a/src/tests/stores/secretStore.spec.ts
+++ b/src/tests/stores/secretStore.spec.ts
@@ -483,7 +483,8 @@ describe('secretStore', () => {
 
     describe('GUEST_ROUTES_DISABLED errors', () => {
       const guestRoutesDisabledResponse = {
-        message: 'Guest API access is disabled',
+        error: 'Guest API access is disabled',
+        error_type: 'GuestRoutesDisabled',
         code: 'GUEST_ROUTES_DISABLED',
       };
 
@@ -539,7 +540,8 @@ describe('secretStore', () => {
       it('conceal() rejects with GUEST_CONCEAL_DISABLED code', async () => {
         store.setApiMode('public');
         axiosMock?.onPost('/api/v3/guest/secret/conceal').reply(403, {
-          message: 'Guest conceal is disabled',
+          error: 'Guest conceal is disabled',
+          error_type: 'GuestRoutesDisabled',
           code: 'GUEST_CONCEAL_DISABLED',
         });
 
@@ -551,7 +553,8 @@ describe('secretStore', () => {
       it('generate() rejects with GUEST_GENERATE_DISABLED code', async () => {
         store.setApiMode('public');
         axiosMock?.onPost('/api/v3/guest/secret/generate').reply(403, {
-          message: 'Guest generate is disabled',
+          error: 'Guest generate is disabled',
+          error_type: 'GuestRoutesDisabled',
           code: 'GUEST_GENERATE_DISABLED',
         });
 
@@ -561,7 +564,8 @@ describe('secretStore', () => {
       it('reveal() rejects with GUEST_REVEAL_DISABLED code', async () => {
         store.setApiMode('public');
         axiosMock?.onPost('/api/v3/guest/secret/abc123/reveal').reply(403, {
-          message: 'Guest reveal is disabled',
+          error: 'Guest reveal is disabled',
+          error_type: 'GuestRoutesDisabled',
           code: 'GUEST_REVEAL_DISABLED',
         });
 
@@ -571,7 +575,8 @@ describe('secretStore', () => {
       it('fetch() rejects with GUEST_SHOW_DISABLED code', async () => {
         store.setApiMode('public');
         axiosMock?.onGet('/api/v3/guest/secret/abc123').reply(403, {
-          message: 'Guest show is disabled',
+          error: 'Guest show is disabled',
+          error_type: 'GuestRoutesDisabled',
           code: 'GUEST_SHOW_DISABLED',
         });
 

--- a/try/unit/logic/guest_route_gating_behavior_try.rb
+++ b/try/unit/logic/guest_route_gating_behavior_try.rb
@@ -93,10 +93,10 @@ exc = Onetime::GuestRoutesDisabled.new("Test", code: "TEST_CODE")
 exc.code
 #=> "TEST_CODE"
 
-## GuestRoutesDisabled to_h includes message and code
+## GuestRoutesDisabled to_h includes error, error_type, and code
 exc = Onetime::GuestRoutesDisabled.new("Test message", code: "TEST_CODE")
 exc.to_h
-#=> {message: "Test message", code: "TEST_CODE"}
+#=> {error: "Test message", error_type: "GuestRoutesDisabled", code: "TEST_CODE"}
 
 ## Default config has guest routes enabled
 config = OT.conf.dig('site', 'interface', 'api', 'guest_routes')


### PR DESCRIPTION
## Summary

Stacked on top of `feature/3221-fix-invite-signup-flow`. Continues the error-response standardization started in d19f5c7d9.

`FormError#to_h` now returns `{ error:, error_type:, field:, error_key: }.compact`. Raise sites that pass `error_key:` (i18n shape) but no `error_type:` get the discriminator dropped by `compact`, leaving the frontend without the machine-readable type it relies on after the standardization.

This PR adds `error_type:` to all 17 i18n-keyed raises in the v2 invite/organizations logic classes.

## Files touched (7)

- `apps/api/invite/logic/invites/accept_invite.rb` — 5 raises
- `apps/api/invite/logic/invites/decline_invite.rb` — 3 raises
- `apps/api/invite/logic/invites/show_invite.rb` — 2 raises
- `apps/api/organizations/logic/invitations/create_invitation.rb` — 6 raises
- `apps/api/organizations/logic/invitations/resend_invitation.rb` — 1 raise
- `apps/api/organizations/logic/invitations/revoke_invitation.rb` — 1 raise
- `apps/api/organizations/logic/members/update_member_role.rb` — 5 raises (4 i18n + 1 unrelated rubocop fix to a nearby `raise_not_found` call)

## error_type vocabulary used

| value | applied to |
|---|---|
| `:missing` | token absent, organization gone |
| `:invalid` | role value invalid, invitation already processed, wrong state for action |
| `:forbidden` | cannot change/promote owner role, cannot invite as owner |
| `:conflict` | member already has role |
| `:exists` | already member, pending invite already exists |
| `:expired` | invitation past expiry |

## Out of scope

- **V1** (`apps/api/v1/`) untouched per discussion — uses a separate error path via `apps/api/v1/controllers/helpers.rb`, not the otto_hooks edge handler.
- **Non-i18n raises** (no `error_key:`, ~189 sites under `apps/api/domains/`, `apps/api/colonel/`, `apps/api/account/`, etc.) deferred to a follow-up.

## Test plan

- [x] Affected spec suite (`apps/api/invite/spec/`, `apps/api/organizations/spec/logic/invitations|members/`) — 113 examples, 11 failures, all pre-existing on parent branch (verified by stash + checkout)
- [x] `try/system/routes_smoketest_try.rb` (touched by parent commit) — 8/8 pass
- [ ] Frontend confirms `error_type` is now populated in responses for invite/organization error paths