### PR TITLE
fix(#3218): wire disabled-homepage variant to per-domain config

### DIFF
--- a/apps/web/core/routes.txt
+++ b/apps/web/core/routes.txt
@@ -52,6 +52,11 @@ GET   /secret/*                                  Core::Controllers::Page#index a
 GET   /l/*                                       Core::Controllers::Page#index auth=noauth
 GET   /l                                         Core::Controllers::Page#index auth=noauth
 
+# Developer/operator preview of the disabled-homepage view alongside the live
+# masthead. Not linked from navigation; mirrors the disabled-homepage flow
+# without flipping UI_ENABLED / auth.required on the backend.
+GET   /disabled                                  Core::Controllers::Page#index auth=noauth
+
 # Incoming secrets - anonymous secret submission to configured recipients
 GET   /incoming                                  Core::Controllers::Page#index auth=noauth
 GET   /incoming/*                                Core::Controllers::Page#index auth=noauth

--- a/src/apps/secret/views/DisabledHomepage.vue
+++ b/src/apps/secret/views/DisabledHomepage.vue
@@ -53,6 +53,5 @@
   -->
   <component
     :is="ActiveVariant"
-    :data-variant="variant"
     v-bind="props" />
 </template>

--- a/src/apps/secret/views/DisabledHomepage.vue
+++ b/src/apps/secret/views/DisabledHomepage.vue
@@ -2,6 +2,7 @@
 
 <script setup lang="ts">
   import type { DisabledHomepageVariant } from '@/schemas/contracts/disabled-homepage';
+  import { DEFAULT_DISABLED_HOMEPAGE_VARIANT } from '@/schemas/contracts/disabled-homepage';
   import { computed, type Component } from 'vue';
   import DisabledLegacy from './disabled/variants/DisabledLegacy.vue';
   import DisabledMinimal from './disabled/variants/DisabledMinimal.vue';
@@ -13,12 +14,15 @@
 
     Shown when UI is enabled but the homepage secret form is gated by
     authentication (auth required, or homepage mode is "external"). Picks a
-    visual variant from bootstrap config and renders it with a single
+    visual variant from per-domain config and renders it with a single
     presentational props bag derived in `useDisabledConfig`.
 
-    Operators can flip the variant or override individual feature flags via
-    `bootstrap.disabled_homepage` without a frontend release. Adding a new
-    variant requires touching three places:
+    Variant resolution (see useDisabledConfig):
+      1. `?variant` URL override (dogfood / preview)
+      2. `homepage_config.disabled_homepage_variant` for the active domain
+      3. `DEFAULT_DISABLED_HOMEPAGE_VARIANT` frontend constant
+
+    Adding a new variant requires touching three places:
       1. drop the component under `disabled/variants/`,
       2. register it in the VARIANTS map below,
       3. add its name to `disabledHomepageVariantSchema` in
@@ -37,10 +41,14 @@
   };
 
   const { variant, props } = useDisabledConfig();
-  // Fallback to v1 covers the (statically unreachable) case where bootstrap
-  // carries a variant id the frontend doesn't recognise — e.g. backend
-  // emits a new variant before the matching component ships.
-  const ActiveVariant = computed(() => VARIANTS[variant.value] ?? DisabledV1);
+  // Fallback covers the (statically unreachable) case where the per-domain
+  // config carries a variant id the frontend doesn't recognise — e.g.
+  // server emits a new variant before the matching component ships. The
+  // frontend default is the source of truth for "if we can't dispatch,
+  // what do we render?" — keep it in sync with the constant.
+  const ActiveVariant = computed(
+    () => VARIANTS[variant.value] ?? VARIANTS[DEFAULT_DISABLED_HOMEPAGE_VARIANT]
+  );
 </script>
 
 <template>

--- a/src/apps/secret/views/DisabledHomepage.vue
+++ b/src/apps/secret/views/DisabledHomepage.vue
@@ -2,7 +2,6 @@
 
 <script setup lang="ts">
   import type { DisabledHomepageVariant } from '@/schemas/contracts/disabled-homepage';
-  import { DEFAULT_DISABLED_HOMEPAGE_VARIANT } from '@/schemas/contracts/disabled-homepage';
   import { computed, type Component } from 'vue';
   import DisabledLegacy from './disabled/variants/DisabledLegacy.vue';
   import DisabledMinimal from './disabled/variants/DisabledMinimal.vue';
@@ -41,14 +40,7 @@
   };
 
   const { variant, props } = useDisabledConfig();
-  // Fallback covers the (statically unreachable) case where the per-domain
-  // config carries a variant id the frontend doesn't recognise — e.g.
-  // server emits a new variant before the matching component ships. The
-  // frontend default is the source of truth for "if we can't dispatch,
-  // what do we render?" — keep it in sync with the constant.
-  const ActiveVariant = computed(
-    () => VARIANTS[variant.value] ?? VARIANTS[DEFAULT_DISABLED_HOMEPAGE_VARIANT]
-  );
+  const ActiveVariant = computed(() => VARIANTS[variant.value]);
 </script>
 
 <template>

--- a/src/apps/secret/views/disabled/README.md
+++ b/src/apps/secret/views/disabled/README.md
@@ -22,16 +22,26 @@ bag. Variants are presentational — no store reads.
 
 ## Bootstrap contract
 
-`bootstrap.disabled_homepage` (`schemas/contracts/disabled-homepage.ts`):
+The variant is a **per-domain** setting, living on
+`homepage_config.disabled_homepage_variant`
+(`schemas/contracts/custom-domain/homepage-config.ts`). It rides the
+existing `/homepage-config` endpoint that already gates
+`signup_enabled` / `signin_enabled` per custom domain — `null` means
+"use the deployment-wide frontend default".
 
-| field               | type                                   | semantics                                              |
-| ------------------- | -------------------------------------- | ------------------------------------------------------ |
-| `variant`           | `'v1' \| 'minimal' \| 'legacy'`        | which component to render                              |
-| `show_promo`        | `boolean \| null`                      | tri-state override (`null` = auto, `true/false` = force) |
-| `show_what_is_this` | `boolean \| null`                      | same                                                   |
+The optional affordance overrides stay on the site-level
+`bootstrap.disabled_homepage` block
+(`schemas/contracts/disabled-homepage.ts`):
 
-All fields optional with sensible defaults; backend may omit the block.
-Ruby serializer wiring is TBD — auto-detection rules apply until then.
+| location                                          | field                       | type                            | semantics                                                |
+| ------------------------------------------------- | --------------------------- | ------------------------------- | -------------------------------------------------------- |
+| `homepage_config`                                 | `disabled_homepage_variant` | `'v1' \| 'minimal' \| 'legacy' \| null` | which component this domain renders (`null` = default)   |
+| `bootstrap.disabled_homepage`                     | `show_promo`                | `boolean \| null`               | tri-state override (`null` = auto, `true/false` = force) |
+| `bootstrap.disabled_homepage`                     | `show_what_is_this`         | `boolean \| null`               | same                                                     |
+
+All fields optional with sensible defaults; backend may omit either.
+Ruby serializer wiring for the per-domain variant field is TBD —
+auto-detection / frontend default applies until then.
 
 ## Flipping the variant
 
@@ -39,26 +49,23 @@ Resolution order (highest priority first):
 
 1. **`?variant=<id>` URL query param** — dogfood / debugging escape hatch.
    Read once per page load; invalid values fall through silently.
-2. **`bootstrap.disabled_homepage.variant`** — operator config via
-   server-injected window state.
-3. **Schema default** in `disabled-homepage.ts`.
+2. **`homepage_config.disabled_homepage_variant`** — per-domain
+   operator config via the `/homepage-config` endpoint.
+3. **`DEFAULT_DISABLED_HOMEPAGE_VARIANT`** — frontend constant in
+   `schemas/contracts/disabled-homepage.ts`.
 
-Once the Ruby serializer emits `disabled_homepage`, operator config is
-the long-term path: change the value, bounce the app, next page load
-picks it up. No frontend release. Until then:
+Once the Ruby `/homepage-config` endpoint accepts the variant field,
+per-domain operator config is the long-term path: PATCH the value, no
+frontend release. Until then:
 
-- **Schema default**: change `disabledHomepageVariantSchema.default('v1')`.
-  Requires both a frontend release *and* regenerating the JSON schemas
-  Rhales reads (`pnpm run schemas:rhales:generate`) — Rhales applies
-  defaults server-side, so a frontend-only change is invisible.
-- **Bootstrap window state**: inject in the Ruby HTML template before
-  the bundle loads, e.g.
-  `window.__BOOTSTRAP_ME__.disabled_homepage = { variant: 'legacy', ... }`.
-  Per-deployment, no frontend release.
+- **Frontend default**: change `DEFAULT_DISABLED_HOMEPAGE_VARIANT` in
+  `disabled-homepage.ts`. Requires a frontend release. This is the
+  source of truth for unconfigured domains and the canonical site.
 - **URL param**: `?variant=legacy` on any disabled-homepage URL.
 
-Override individual feature flags the same way via bootstrap — set
-`show_promo` / `show_what_is_this` to `true` / `false` / `null` (= auto).
+Override individual feature flags via the site-level bootstrap block —
+set `show_promo` / `show_what_is_this` to `true` / `false` / `null`
+(= auto).
 
 ### Verifying which variant is rendering
 
@@ -103,8 +110,8 @@ Set in `etc/defaults/config.defaults.yaml` under `site.interface.ui.homepage.pub
 2. Register in `VARIANTS` in `DisabledHomepage.vue`.
 3. Add `'x'` to `disabledHomepageVariantSchema`.
 
-Unrecognized variant ids fall back to `v1` (defense in depth — Zod
-would already reject the value at parse time).
+Unrecognized variant ids fall back to `DEFAULT_DISABLED_HOMEPAGE_VARIANT`
+(defense in depth — Zod would already reject the value at parse time).
 
 ## Tests
 

--- a/src/apps/secret/views/disabled/README.md
+++ b/src/apps/secret/views/disabled/README.md
@@ -67,11 +67,6 @@ Override individual feature flags via the site-level bootstrap block —
 set `show_promo` / `show_what_is_this` to `true` / `false` / `null`
 (= auto).
 
-### Verifying which variant is rendering
-
-Each variant's root element carries a `data-variant` attribute (set by
-the dispatcher) so you can inspect in DevTools without a console log.
-
 ## Auto-detection (suppressed by overrides)
 
 - **`isBranded`** = `isCustom && !!brand.description`

--- a/src/apps/secret/views/disabled/useDisabledConfig.ts
+++ b/src/apps/secret/views/disabled/useDisabledConfig.ts
@@ -5,11 +5,17 @@
 // single props bag to whichever variant is selected and the variants stay
 // purely presentational.
 //
-// The composable applies auto-detection rules by default and lets operator
-// overrides (bootstrap.disabled_homepage) win when set.
+// Variant comes from the per-domain `homepage_config.disabled_homepage_variant`
+// (with a `?variant` URL override and a frontend-constant fallback). The
+// affordance flags (show_promo / show_what_is_this) come from auto-detection
+// rules plus operator overrides on the site-level `bootstrap.disabled_homepage`
+// block.
 
 import type { DisabledHomepageVariant } from '@/schemas/contracts/disabled-homepage';
-import { disabledHomepageVariantSchema } from '@/schemas/contracts/disabled-homepage';
+import {
+  DEFAULT_DISABLED_HOMEPAGE_VARIANT,
+  disabledHomepageVariantSchema,
+} from '@/schemas/contracts/disabled-homepage';
 import { useBootstrapStore } from '@/shared/stores/bootstrapStore';
 import { useProductIdentity } from '@/shared/stores/identityStore';
 import { storeToRefs } from 'pinia';
@@ -93,7 +99,8 @@ export function useDisabledConfig(): DisabledHomepageBindings {
     storeToRefs(identityStore);
 
   const bootstrapStore = useBootstrapStore();
-  const { authentication, billing_enabled, disabled_homepage, ui } = storeToRefs(bootstrapStore);
+  const { authentication, billing_enabled, disabled_homepage, homepage_config, ui } =
+    storeToRefs(bootstrapStore);
 
   // "Branded" means a custom domain has actually been configured with a brand
   // description — distinct from isCustom, which can be true even when no
@@ -147,12 +154,19 @@ export function useDisabledConfig(): DisabledHomepageBindings {
 
   const showSignin = computed(() => !!authentication.value?.signin);
 
-  // Variant resolution: URL override → bootstrap config. URL is read once
-  // at composable-call time (page loads don't preserve query params); the
-  // bootstrap fallback stays reactive so a $patch still flips the variant.
+  // Variant resolution: URL override → per-domain homepage_config →
+  // frontend default. URL is read once at composable-call time (page
+  // loads don't preserve query params); the homepage_config fallback
+  // stays reactive so a $patch on the domain config still flips the
+  // variant. When neither resolves, fall through to the frontend
+  // constant — homepage_config is null on the canonical site and on
+  // any custom domain that hasn't opted into a non-default variant.
   const urlOverride = readUrlVariantOverride();
   const variant = computed<DisabledHomepageVariant>(
-    () => urlOverride ?? disabled_homepage.value.variant
+    () =>
+      urlOverride ??
+      homepage_config.value?.disabled_homepage_variant ??
+      DEFAULT_DISABLED_HOMEPAGE_VARIANT
   );
 
   // Getter object: `v-bind="props"` evaluates each property on every render,

--- a/src/schemas/contracts/custom-domain/homepage-config.ts
+++ b/src/schemas/contracts/custom-domain/homepage-config.ts
@@ -7,6 +7,8 @@
 
 import { z } from 'zod';
 
+import { disabledHomepageVariantSchema } from '@/schemas/contracts/disabled-homepage';
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Homepage config canonical schema
 // ─────────────────────────────────────────────────────────────────────────────
@@ -40,6 +42,16 @@ export const homepageConfigCanonical = z.object({
    * flag remains the master switch — the frontend ANDs both layers.
    */
   signin_enabled: z.boolean().default(true),
+
+  /**
+   * Which disabled-homepage variant this domain renders when the homepage
+   * secret form is gated by auth. Null means "use the frontend default"
+   * (DEFAULT_DISABLED_HOMEPAGE_VARIANT) — operators only set this when
+   * they want to deviate from the deployment-wide default.
+   *
+   * The ?variant URL override still wins for dogfood/preview.
+   */
+  disabled_homepage_variant: disabledHomepageVariantSchema.nullable().default(null),
 
   /** Configuration creation timestamp (Unix epoch seconds). Null if unconfigured. */
   created_at: z.number().nullable(),

--- a/src/schemas/contracts/custom-domain/homepage-config.ts
+++ b/src/schemas/contracts/custom-domain/homepage-config.ts
@@ -49,9 +49,14 @@ export const homepageConfigCanonical = z.object({
    * (DEFAULT_DISABLED_HOMEPAGE_VARIANT) — operators only set this when
    * they want to deviate from the deployment-wide default.
    *
+   * `.catch(null)` over `.default(null)`: a future backend may emit a
+   * variant id this frontend version doesn't recognise; degrading to
+   * null (and thus to the frontend default) is preferable to crashing
+   * the whole bootstrap payload parse.
+   *
    * The ?variant URL override still wins for dogfood/preview.
    */
-  disabled_homepage_variant: disabledHomepageVariantSchema.nullable().default(null),
+  disabled_homepage_variant: disabledHomepageVariantSchema.nullable().catch(null),
 
   /** Configuration creation timestamp (Unix epoch seconds). Null if unconfigured. */
   created_at: z.number().nullable(),

--- a/src/schemas/contracts/disabled-homepage.ts
+++ b/src/schemas/contracts/disabled-homepage.ts
@@ -3,13 +3,17 @@
 // Disabled-homepage view configuration — frontend rendering knobs for the
 // DisabledHomepage view shown when the homepage secret form is gated by auth.
 //
-// All fields are optional with sensible auto-detection defaults so the
-// contract is forward-compatible: a backend that doesn't emit this block
-// still produces the default behaviour, and operators can flip individual
-// knobs without a frontend release once the backend wires it up.
+// Two layers live here:
 //
-// Auto-detection rules live in `useDisabledConfig` — these are the
-// operator overrides.
+//  1. The variant enum + frontend default. The variant itself is a
+//     per-domain setting (lives on homepageConfigCanonical), with a
+//     frontend constant fallback for the canonical site / unconfigured
+//     domains. Keeping the enum here lets both the URL-override parser
+//     and the per-domain field share a single source of truth.
+//
+//  2. Tri-state operator overrides for the optional affordances
+//     (show_promo, show_what_is_this). Auto-detection rules live in
+//     `useDisabledConfig` — these are the operator overrides on top.
 
 import { z } from 'zod';
 
@@ -17,9 +21,9 @@ import { z } from 'zod';
  * Visual variant for the disabled-homepage view.
  *
  * - `v1`: the full hero refresh — mark, eyebrow, headline, CTA, trust strip,
- *   optional promo (default)
+ *   optional promo
  * - `minimal`: quiet refresh of the legacy two-tagline shape — small mark,
- *   headline, subtitle, ghost CTA. No trust strip or promo.
+ *   headline, subtitle, ghost CTA. No trust strip or promo (default).
  * - `legacy`: the original two-tagline placeholder (rollback target)
  *
  * New variants must be registered in the dispatcher map in
@@ -29,13 +33,20 @@ export const disabledHomepageVariantSchema = z.enum(['v1', 'minimal', 'legacy'])
 export type DisabledHomepageVariant = z.infer<typeof disabledHomepageVariantSchema>;
 
 /**
+ * Frontend fallback variant — used when neither the per-domain
+ * `homepage_config.disabled_homepage_variant` nor the `?variant` URL
+ * override resolves to a value. The dispatcher and the composable both
+ * import this so the default stays in one place.
+ */
+export const DEFAULT_DISABLED_HOMEPAGE_VARIANT: DisabledHomepageVariant = 'minimal';
+
+/**
  * Tri-state operator override: null = use auto-detection rules,
  * true = force-show, false = force-hide.
  */
 const overrideSchema = z.boolean().nullable().default(null);
 
 export const disabledHomepageConfigSchema = z.object({
-  variant: disabledHomepageVariantSchema.default('v1'),
   show_promo: overrideSchema,
   show_what_is_this: overrideSchema,
 });

--- a/src/tests/apps/secret/views/useDisabledConfig.spec.ts
+++ b/src/tests/apps/secret/views/useDisabledConfig.spec.ts
@@ -32,8 +32,11 @@ interface SetupOptions {
   billingEnabled?: boolean;
   authSignin?: boolean;
   recipientIntroUrl?: string | null;
+  /** Per-domain disabled-homepage variant. Null/omitted means
+   *  "use the frontend DEFAULT_DISABLED_HOMEPAGE_VARIANT". */
+  homepageVariant?: 'v1' | 'minimal' | 'legacy' | null;
+  /** Tri-state operator overrides for the auto-detected affordances. */
   disabledHomepage?: {
-    variant?: 'v1' | 'minimal' | 'legacy';
     show_promo?: boolean | null;
     show_what_is_this?: boolean | null;
   };
@@ -64,10 +67,21 @@ function setup(opts: SetupOptions = {}) {
       },
     },
     disabled_homepage: {
-      variant: opts.disabledHomepage?.variant ?? 'v1',
       show_promo: opts.disabledHomepage?.show_promo ?? null,
       show_what_is_this: opts.disabledHomepage?.show_what_is_this ?? null,
     },
+    homepage_config:
+      opts.homepageVariant === undefined
+        ? null
+        : {
+            domain_id: 'test-domain',
+            enabled: true,
+            signup_enabled: true,
+            signin_enabled: true,
+            disabled_homepage_variant: opts.homepageVariant,
+            created_at: null,
+            updated_at: null,
+          },
   });
 
   const identity = useProductIdentity();
@@ -108,39 +122,44 @@ describe('useDisabledConfig', () => {
       window.history.replaceState({}, '', '/');
     });
 
-    it('defaults to v1 when bootstrap omits disabled_homepage', () => {
+    it('falls back to the frontend default (minimal) when no per-domain config', () => {
       const { config } = setup();
-      expect(config.variant.value).toBe('v1');
-    });
-
-    it('respects the configured variant', () => {
-      const { config } = setup({ disabledHomepage: { variant: 'minimal' } });
       expect(config.variant.value).toBe('minimal');
     });
 
-    it('reacts when bootstrap mutates the variant mid-session', () => {
-      const { config, bootstrap } = setup({ disabledHomepage: { variant: 'v1' } });
+    it('falls back to the frontend default when homepage_config sets variant=null', () => {
+      // Null means "no per-domain override" — operator never opted in.
+      const { config } = setup({ homepageVariant: null });
+      expect(config.variant.value).toBe('minimal');
+    });
+
+    it('respects the per-domain variant from homepage_config', () => {
+      const { config } = setup({ homepageVariant: 'v1' });
+      expect(config.variant.value).toBe('v1');
+    });
+
+    it('reacts when homepage_config mutates mid-session', () => {
+      const { config, bootstrap } = setup({ homepageVariant: 'v1' });
       expect(config.variant.value).toBe('v1');
 
       bootstrap.$patch({
-        disabled_homepage: {
-          variant: 'legacy',
-          show_promo: null,
-          show_what_is_this: null,
+        homepage_config: {
+          ...bootstrap.homepage_config!,
+          disabled_homepage_variant: 'legacy',
         },
       });
       expect(config.variant.value).toBe('legacy');
     });
 
-    it('?variant URL override wins over bootstrap', () => {
+    it('?variant URL override wins over homepage_config', () => {
       window.history.replaceState({}, '', '/?variant=legacy');
-      const { config } = setup({ disabledHomepage: { variant: 'v1' } });
+      const { config } = setup({ homepageVariant: 'v1' });
       expect(config.variant.value).toBe('legacy');
     });
 
     it('?variant override falls through silently when the value is invalid', () => {
       window.history.replaceState({}, '', '/?variant=banana');
-      const { config } = setup({ disabledHomepage: { variant: 'minimal' } });
+      const { config } = setup({ homepageVariant: 'minimal' });
       expect(config.variant.value).toBe('minimal');
     });
 
@@ -148,7 +167,7 @@ describe('useDisabledConfig', () => {
       // Intentional: a mid-session URL mutation doesn't flip the variant
       // without re-mounting. Mirrors how operators use the override —
       // pick a variant on page load, not while the page is open.
-      const { config } = setup({ disabledHomepage: { variant: 'v1' } });
+      const { config } = setup({ homepageVariant: 'v1' });
       expect(config.variant.value).toBe('v1');
 
       window.history.replaceState({}, '', '/?variant=legacy');

--- a/src/tests/schemas/contracts/custom-domain/homepage-config.spec.ts
+++ b/src/tests/schemas/contracts/custom-domain/homepage-config.spec.ts
@@ -1,0 +1,56 @@
+// src/tests/schemas/contracts/custom-domain/homepage-config.spec.ts
+//
+// Contract tests for per-domain homepage config — focused on the
+// forward-compat behavior of disabled_homepage_variant.
+
+import { homepageConfigCanonical } from '@/schemas/contracts/custom-domain/homepage-config';
+import { describe, expect, it } from 'vitest';
+
+describe('homepageConfigCanonical', () => {
+  const basePayload = {
+    domain_id: 'd_123',
+    enabled: true,
+    signup_enabled: true,
+    signin_enabled: true,
+    created_at: 1700000000,
+    updated_at: 1700000000,
+  };
+
+  describe('disabled_homepage_variant', () => {
+    it('accepts a known variant', () => {
+      const result = homepageConfigCanonical.safeParse({
+        ...basePayload,
+        disabled_homepage_variant: 'minimal',
+      });
+      expect(result.success).toBe(true);
+      expect(result.success && result.data.disabled_homepage_variant).toBe('minimal');
+    });
+
+    it('accepts null', () => {
+      const result = homepageConfigCanonical.safeParse({
+        ...basePayload,
+        disabled_homepage_variant: null,
+      });
+      expect(result.success).toBe(true);
+      expect(result.success && result.data.disabled_homepage_variant).toBeNull();
+    });
+
+    it('defaults missing field to null', () => {
+      const result = homepageConfigCanonical.safeParse(basePayload);
+      expect(result.success).toBe(true);
+      expect(result.success && result.data.disabled_homepage_variant).toBeNull();
+    });
+
+    it('degrades an unknown variant to null instead of failing parse', () => {
+      // Forward-compat: a future backend may emit a variant id this
+      // frontend doesn't know about. The whole bootstrap payload must
+      // still parse — the composable falls back to the frontend default.
+      const result = homepageConfigCanonical.safeParse({
+        ...basePayload,
+        disabled_homepage_variant: 'future_variant_v99',
+      });
+      expect(result.success).toBe(true);
+      expect(result.success && result.data.disabled_homepage_variant).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
Closes #3218 

## Summary

- Variant moves from `bootstrap.disabled_homepage.variant` (latent shared-reference / mutation footgun in Pinia DEFAULTS) to per-domain `homepage_config.disabled_homepage_variant`, where the other per-domain homepage knobs (`signup_enabled` / `signin_enabled`) already live. Resolution chain in `useDisabledConfig`: `?variant` URL override → `homepage_config.disabled_homepage_variant` → `DEFAULT_DISABLED_HOMEPAGE_VARIANT` frontend constant (now `'minimal'`).
- Adds `/disabled` to `apps/web/core/routes.txt` so the Ruby router serves the SPA at the preview URL instead of 404ing before Vue mounts.
- Cleanup: composable owns variant resolution end-to-end, so the dispatcher's `?? VARIANTS[DEFAULT_DISABLED_HOMEPAGE_VARIANT]` fallback was dead and is gone, along with the unused `data-variant` debug attribute.

Once the Ruby `/homepage-config` endpoint accepts the new field, operators can pick a variant per custom domain without a frontend release. Until then the frontend constant is the only effective dial.

Closes the symptom in #3218 where the dispatcher always rendered the legacy variant regardless of the schema default.

## Test plan

- [x] `pnpm test:base run src/tests/apps/secret/views/useDisabledConfig.spec.ts` (33 passing — covers URL override, per-domain variant, mid-session mutation, fallback to frontend default, invalid-override pass-through)
- [x] `pnpm test:base run src/tests/apps/secret/ src/tests/stores/bootstrapStore.spec.ts src/tests/contracts/` (589 passing, no regressions)
- [x] `pnpm type-check` clean
- [x] Verified locally: `/disabled` renders the `minimal` variant by default; `?variant=v1` and `?variant=legacy` switch as expected

https://claude.ai/code/session_01T6dCcQFneAFGajFrbxUhcU

---
_Generated by [Claude Code](https://claude.ai/code/session_01T6dCcQFneAFGajFrbxUhcU)_