### PR TITLE
Misc followup: signup config PATCH, omniauth domain fix, error shape tests, ADR-013

### DIFF
--- a/apps/api/domains/logic/signup_config.rb
+++ b/apps/api/domains/logic/signup_config.rb
@@ -3,6 +3,8 @@
 # frozen_string_literal: true
 
 require_relative 'signup_config/base'
+require_relative 'signup_config/audit_logger'
 require_relative 'signup_config/get_signup_config'
 require_relative 'signup_config/put_signup_config'
+require_relative 'signup_config/patch_signup_config'
 require_relative 'signup_config/delete_signup_config'

--- a/apps/api/domains/logic/signup_config/audit_logger.rb
+++ b/apps/api/domains/logic/signup_config/audit_logger.rb
@@ -17,6 +17,7 @@ module DomainsAPI
       # Events:
       #   - domain_signup_config_created: New signup configuration created
       #   - domain_signup_config_replaced: Existing signup configuration fully replaced (PUT)
+      #   - domain_signup_config_updated: Signup configuration partially updated (PATCH)
       #   - domain_signup_config_deleted: Signup configuration removed
       #   - domain_signup_config_enabled: Signup validation enabled for domain
       #   - domain_signup_config_disabled: Signup validation disabled for domain

--- a/apps/api/domains/logic/signup_config/patch_signup_config.rb
+++ b/apps/api/domains/logic/signup_config/patch_signup_config.rb
@@ -1,0 +1,208 @@
+# apps/api/domains/logic/signup_config/patch_signup_config.rb
+#
+# frozen_string_literal: true
+
+require 'onetime/models/custom_domain/signup_config'
+require_relative 'base'
+require_relative 'audit_logger'
+
+module DomainsAPI
+  module Logic
+    module SignupConfig
+      # PATCH Domain Signup Configuration (partial update)
+      #
+      # @api Partially updates the signup validation configuration for a custom domain.
+      #   Uses PATCH semantics: only provided fields are updated; omitted fields
+      #   preserve existing data.
+      #   Requires the requesting user to be an organization owner with
+      #   custom_signup_validation entitlement.
+      #
+      # Request body:
+      # - validation_strategy: Required for create, optional for update (preserves existing if omitted)
+      # - allowed_signup_domains: Optional. Array or comma-separated string.
+      #   When omitted: preserves existing. When provided as []: clears all.
+      # - enabled: Optional. Boolean to enable/disable (preserves existing if omitted)
+      #
+      class PatchSignupConfig < Base
+        include AuditLogger
+
+        VALID_STRATEGY_TYPES = Onetime::CustomDomain::SignupConfig::STRATEGY_TYPES.freeze
+
+        attr_reader :signup_config, :existing_config
+
+        def process_params
+          @domain_id                       = sanitize_identifier(params['extid'])
+          @validation_strategy             = sanitize_plain_text(params['validation_strategy'])
+          # Track whether allowed_signup_domains was explicitly provided (for PATCH semantics)
+          @allowed_signup_domains_provided = params.key?('allowed_signup_domains')
+          @allowed_signup_domains          = parse_allowed_domains(params['allowed_signup_domains'])
+          # Track whether enabled was explicitly provided (for PATCH semantics)
+          @enabled_provided                = !params['enabled'].nil?
+          @enabled                         = parse_boolean(params['enabled'])
+        end
+
+        def raise_concerns
+          # Require authenticated user
+          raise_form_error('Authentication required', field: :user_id, error_type: :unauthorized) if cust.anonymous?
+
+          # Validate domain_id parameter
+          raise_form_error('Domain ID required', field: :domain_id, error_type: :missing) if @domain_id.to_s.empty?
+
+          # Load domain and organization, verify ownership and entitlement
+          authorize_domain_signup_config!(@domain_id)
+
+          # Check if config already exists
+          @existing_config = Onetime::CustomDomain::SignupConfig.find_by_domain_id(@custom_domain.identifier)
+
+          # Resolve effective strategy (PATCH semantics: preserves existing if not provided)
+          resolve_strategy
+
+          # Validate domain_allowlist has at least one domain (using effective values)
+          effective_domains = @allowed_signup_domains_provided ? @allowed_signup_domains : (@existing_config&.allowed_signup_domains || [])
+          validate_allowlist_has_domains(@effective_strategy, effective_domains)
+
+          # Validate domain formats only when explicitly provided
+          validate_domain_formats(@allowed_signup_domains) if @allowed_signup_domains_provided
+        end
+
+        def process
+          OT.ld "[PatchSignupConfig] Patching signup config for domain #{@domain_id} by user #{cust.extid}"
+
+          was_enabled = @existing_config&.enabled?
+
+          if @existing_config
+            changes = compute_signup_changes(@existing_config, params)
+            update_existing_config
+            log_signup_audit_event(
+              event: :domain_signup_config_updated,
+              domain: @custom_domain,
+              org: @organization,
+              actor: cust,
+              validation_strategy: @effective_strategy,
+              changes: changes,
+            )
+          else
+            create_new_config
+            log_signup_audit_event(
+              event: :domain_signup_config_created,
+              domain: @custom_domain,
+              org: @organization,
+              actor: cust,
+              validation_strategy: @effective_strategy,
+            )
+          end
+
+          # Use actual state after update (may be unchanged if enabled wasn't provided)
+          current_enabled = @signup_config.enabled?
+          log_enabled_state_change(was_enabled, current_enabled)
+
+          success_data
+        end
+
+        def success_data
+          {
+            user_id: cust.extid,
+            record: serialize_signup_config(@signup_config),
+          }
+        end
+
+        def form_fields
+          {
+            domain_id: @domain_id,
+            validation_strategy: @effective_strategy,
+            allowed_signup_domains: @allowed_signup_domains,
+            enabled: @enabled,
+          }
+        end
+
+        private
+
+        # PATCH semantics: strategy preserves existing if not provided.
+        # Strategy is still required for new configs.
+        def resolve_strategy
+          if @validation_strategy.to_s.empty?
+            if @existing_config
+              @effective_strategy = @existing_config.validation_strategy
+            else
+              raise_form_error(
+                'Validation strategy is required',
+                field: :validation_strategy,
+                error_type: :missing,
+              )
+            end
+          else
+            validate_strategy_type(@validation_strategy)
+            @effective_strategy = @validation_strategy
+          end
+        end
+
+        def create_new_config
+          @signup_config = Onetime::CustomDomain::SignupConfig.create!(
+            domain_id: @custom_domain.identifier,
+            validation_strategy: @effective_strategy,
+            allowed_signup_domains: @allowed_signup_domains,
+            enabled: @enabled,
+          )
+        end
+
+        # Updates an existing SignupConfig with PATCH semantics.
+        #
+        # Only updates fields that were explicitly provided in the request.
+        #
+        # allowed_signup_domains behavior:
+        # - Omitted: preserves existing domains
+        # - Provided as []: explicitly clears all existing domains
+        # - Provided with values: replaces with new values
+        #
+        def update_existing_config
+          @signup_config                        = @existing_config
+          @signup_config.validation_strategy    = @effective_strategy
+          @signup_config.allowed_signup_domains = @allowed_signup_domains if @allowed_signup_domains_provided
+          @signup_config.enabled                = @enabled.to_s if @enabled_provided
+          @signup_config.updated                = Familia.now.to_i
+
+          @signup_config.commit_fields
+        end
+
+        def serialize_signup_config(config)
+          {
+            domain_id: @custom_domain.extid,
+            validation_strategy: config.validation_strategy,
+            allowed_signup_domains: config.allowed_signup_domains,
+            enabled: config.enabled?,
+            requires_allowlist: config.requires_allowlist?,
+            network_validation: config.network_validation?,
+            created_at: config.created.to_i,
+            updated_at: config.updated.to_i,
+          }
+        end
+
+        # Log enabled/disabled state change if it occurred.
+        #
+        # @param was_enabled [Boolean, nil] Previous enabled state (nil if new config)
+        # @param is_enabled [Boolean] New enabled state
+        def log_enabled_state_change(was_enabled, is_enabled)
+          return if was_enabled == is_enabled
+
+          if is_enabled && (was_enabled.nil? || was_enabled == false)
+            log_signup_audit_event(
+              event: :domain_signup_config_enabled,
+              domain: @custom_domain,
+              org: @organization,
+              actor: cust,
+              validation_strategy: @effective_strategy,
+            )
+          elsif was_enabled == true && !is_enabled
+            log_signup_audit_event(
+              event: :domain_signup_config_disabled,
+              domain: @custom_domain,
+              org: @organization,
+              actor: cust,
+              validation_strategy: @effective_strategy,
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/apps/api/domains/routes.txt
+++ b/apps/api/domains/routes.txt
@@ -57,4 +57,5 @@ DELETE /:extid/incoming-config           DomainsAPI::Logic::IncomingConfig::Dele
 # Domain Signup Configuration (Per-domain email validation strategy)
 GET    /:extid/signup-config             DomainsAPI::Logic::SignupConfig::GetSignupConfig response=json auth=sessionauth
 PUT    /:extid/signup-config             DomainsAPI::Logic::SignupConfig::PutSignupConfig response=json auth=sessionauth
+PATCH  /:extid/signup-config             DomainsAPI::Logic::SignupConfig::PatchSignupConfig response=json auth=sessionauth
 DELETE /:extid/signup-config             DomainsAPI::Logic::SignupConfig::DeleteSignupConfig response=json auth=sessionauth

--- a/apps/api/domains/spec/integration/domain_sender_config_spec.rb
+++ b/apps/api/domains/spec/integration/domain_sender_config_spec.rb
@@ -366,7 +366,7 @@ RSpec.describe 'Domain Sender Config API', type: :integration do
 
           expect(last_response.status).to eq(422)
           body = json_body
-          expect(body['message']).to include('From address')
+          expect(body['error']).to include('From address')
         end
 
         it 'succeeds without provider param (resolved from installation config)' do
@@ -394,7 +394,7 @@ RSpec.describe 'Domain Sender Config API', type: :integration do
 
           expect(last_response.status).to eq(422)
           body = json_body
-          expect(body['message']).to include('Invalid email format')
+          expect(body['error']).to include('Invalid email format')
           expect(body['field']).to eq('from_address')
         end
       end
@@ -419,7 +419,7 @@ RSpec.describe 'Domain Sender Config API', type: :integration do
         # Feature flag check uses raise_form_error -> FormError -> 422
         expect(last_response.status).to eq(422)
         body = json_body
-        expect(body['message']).to include('not enabled')
+        expect(body['error']).to include('not enabled')
       end
 
       it 'returns 403 for non-owner of organization' do
@@ -431,7 +431,7 @@ RSpec.describe 'Domain Sender Config API', type: :integration do
         # Non-owner check uses verify_one_of_roles! -> Onetime::Forbidden -> 403
         expect(last_response.status).to eq(403)
         body = json_body
-        expect(body['message']).to include('owner')
+        expect(body['error']).to include('owner')
       end
 
       it 'returns 422 when organization lacks custom_mail_sender entitlement' do
@@ -446,7 +446,7 @@ RSpec.describe 'Domain Sender Config API', type: :integration do
         # Entitlement check uses raise_form_error -> FormError -> 422
         expect(last_response.status).to eq(422)
         body = json_body
-        expect(body['message']).to include('custom_mail_sender')
+        expect(body['error']).to include('custom_mail_sender')
       end
 
       it 'returns 404 for non-existent domain' do
@@ -456,7 +456,7 @@ RSpec.describe 'Domain Sender Config API', type: :integration do
 
         expect(last_response.status).to eq(404)
         body = json_body
-        expect(body['message']).to include('Domain not found')
+        expect(body['error']).to include('Domain not found')
       end
     end
   end
@@ -543,7 +543,7 @@ RSpec.describe 'Domain Sender Config API', type: :integration do
 
         expect(last_response.status).to eq(404)
         body = json_body
-        expect(body['message']).to include('Sender configuration not found')
+        expect(body['error']).to include('Sender configuration not found')
       end
     end
 
@@ -771,7 +771,7 @@ RSpec.describe 'Domain Sender Config API', type: :integration do
 
         expect(last_response.status).to eq(422)
         body = json_body
-        expect(body['message']).to include('Invalid email format')
+        expect(body['error']).to include('Invalid email format')
         expect(body['field']).to eq('from_address')
       end
     end
@@ -802,7 +802,7 @@ RSpec.describe 'Domain Sender Config API', type: :integration do
 
         expect(last_response.status).to eq(422)
         body = json_body
-        expect(body['message']).to include('required')
+        expect(body['error']).to include('required')
       end
     end
   end
@@ -853,7 +853,7 @@ RSpec.describe 'Domain Sender Config API', type: :integration do
 
         expect(last_response.status).to eq(404)
         body = json_body
-        expect(body['message']).to include('Sender configuration not found')
+        expect(body['error']).to include('Sender configuration not found')
       end
     end
 
@@ -916,7 +916,7 @@ RSpec.describe 'Domain Sender Config API', type: :integration do
 
         expect(last_response.status).to eq(403)
         body = json_body
-        expect(body['message']).to include('owner')
+        expect(body['error']).to include('owner')
       end
 
       it 'returns 422 when organization lacks custom_mail_sender entitlement' do
@@ -928,7 +928,7 @@ RSpec.describe 'Domain Sender Config API', type: :integration do
         # Entitlement check uses raise_form_error -> FormError -> 422
         expect(last_response.status).to eq(422)
         body = json_body
-        expect(body['message']).to include('custom_mail_sender')
+        expect(body['error']).to include('custom_mail_sender')
       end
 
       it 'returns 404 for non-existent domain' do
@@ -937,7 +937,7 @@ RSpec.describe 'Domain Sender Config API', type: :integration do
 
         expect(last_response.status).to eq(404)
         body = json_body
-        expect(body['message']).to include('Domain not found')
+        expect(body['error']).to include('Domain not found')
       end
     end
 
@@ -951,7 +951,7 @@ RSpec.describe 'Domain Sender Config API', type: :integration do
 
         expect(last_response.status).to eq(404)
         body = json_body
-        expect(body['message']).to include('Sender configuration not found')
+        expect(body['error']).to include('Sender configuration not found')
       end
 
       it 'returns 422 when provider is not configured' do
@@ -967,7 +967,7 @@ RSpec.describe 'Domain Sender Config API', type: :integration do
 
         expect(last_response.status).to eq(422)
         body = json_body
-        expect(body['message']).to include('Provider')
+        expect(body['error']).to include('Provider')
       end
     end
 
@@ -1078,8 +1078,8 @@ RSpec.describe 'Domain Sender Config API', type: :integration do
         # The endpoint returns error but may use different status codes
         # Based on the implementation, errors go through error_response which defaults to 400
         body = json_body
-        expect(body).to have_key('message')
-        expect(body['message']).to include('Daily quota exceeded')
+        expect(body).to have_key('error')
+        expect(body['error']).to include('Daily quota exceeded')
       end
     end
   end

--- a/apps/api/domains/spec/integration/domain_signup_config_spec.rb
+++ b/apps/api/domains/spec/integration/domain_signup_config_spec.rb
@@ -166,6 +166,16 @@ RSpec.describe 'Domain Signup Config API', type: :integration do
     JSON.parse(last_response.body)
   end
 
+  def csrf_patch(path, params = {})
+    csrf_token = ensure_csrf_token
+
+    header 'Content-Type', 'application/json'
+    header 'Accept', 'application/json'
+    header 'X-CSRF-Token', csrf_token if csrf_token
+
+    patch path, JSON.generate(params.merge(shrimp: csrf_token))
+  end
+
   # ==========================================================================
   # PUT /api/domains/:extid/signup-config - Create/Replace Signup Config
   # ==========================================================================
@@ -309,7 +319,7 @@ RSpec.describe 'Domain Signup Config API', type: :integration do
 
           expect(last_response.status).to eq(422)
           body = json_body
-          expect(body['message']).to include('Validation strategy')
+          expect(body['error']).to include('Validation strategy')
         end
 
         it 'returns 422 for invalid validation_strategy' do
@@ -320,7 +330,7 @@ RSpec.describe 'Domain Signup Config API', type: :integration do
 
           expect(last_response.status).to eq(422)
           body = json_body
-          expect(body['message']).to include('validation_strategy must be one of')
+          expect(body['error']).to include('validation_strategy must be one of')
         end
 
         it 'returns 422 for domain_allowlist without allowed_signup_domains' do
@@ -331,7 +341,7 @@ RSpec.describe 'Domain Signup Config API', type: :integration do
 
           expect(last_response.status).to eq(422)
           body = json_body
-          expect(body['message']).to include('allowed_signup_domains')
+          expect(body['error']).to include('allowed_signup_domains')
         end
 
         it 'returns 422 for domain_allowlist with empty allowed_signup_domains array' do
@@ -343,7 +353,7 @@ RSpec.describe 'Domain Signup Config API', type: :integration do
 
           expect(last_response.status).to eq(422)
           body = json_body
-          expect(body['message']).to include('allowed_signup_domains')
+          expect(body['error']).to include('allowed_signup_domains')
         end
       end
     end
@@ -366,7 +376,7 @@ RSpec.describe 'Domain Signup Config API', type: :integration do
         # Non-owner check uses verify_one_of_roles! -> Onetime::Forbidden -> 403
         expect(last_response.status).to eq(403)
         body = json_body
-        expect(body['message']).to include('owner')
+        expect(body['error']).to include('owner')
       end
 
       it 'returns 422 when organization lacks custom_signup_validation entitlement' do
@@ -382,7 +392,7 @@ RSpec.describe 'Domain Signup Config API', type: :integration do
         # Entitlement check uses raise_form_error -> FormError -> 422
         expect(last_response.status).to eq(422)
         body = json_body
-        expect(body['message']).to include('custom_signup_validation')
+        expect(body['error']).to include('custom_signup_validation')
       end
 
       it 'returns 404 for non-existent domain' do
@@ -391,7 +401,179 @@ RSpec.describe 'Domain Signup Config API', type: :integration do
 
         expect(last_response.status).to eq(404)
         body = json_body
-        expect(body['message']).to include('Domain not found')
+        expect(body['error']).to include('Domain not found')
+      end
+    end
+  end
+
+  # ==========================================================================
+  # PATCH /api/domains/:extid/signup-config - Partial Update Signup Config
+  # ==========================================================================
+
+  describe 'PATCH /api/domains/:extid/signup-config' do
+    context 'when existing config exists' do
+      before do
+        Onetime::CustomDomain::SignupConfig.create!(
+          domain_id: test_custom_domain.identifier,
+          validation_strategy: 'domain_allowlist',
+          allowed_signup_domains: ['original.com', 'partner.com'],
+          enabled: false,
+        )
+      end
+
+      context 'when authenticated as organization owner' do
+        before do
+          login_as(test_owner)
+        end
+
+        it 'updates only provided fields (PATCH semantics)' do
+          csrf_patch api_path(test_custom_domain.extid), {
+            enabled: true,
+          }
+
+          expect(last_response.status).to eq(200)
+
+          body = json_body
+          record = body['record']
+
+          # Updated field
+          expect(record['enabled']).to be true
+
+          # Preserved fields
+          expect(record['validation_strategy']).to eq('domain_allowlist')
+          expect(record['allowed_signup_domains']).to contain_exactly('original.com', 'partner.com')
+        end
+
+        it 'preserves allowed_signup_domains when not provided' do
+          csrf_patch api_path(test_custom_domain.extid), {
+            enabled: true,
+          }
+
+          expect(last_response.status).to eq(200)
+
+          body = json_body
+          record = body['record']
+          expect(record['allowed_signup_domains']).to contain_exactly('original.com', 'partner.com')
+        end
+
+        it 'replaces allowed_signup_domains when provided with values' do
+          csrf_patch api_path(test_custom_domain.extid), {
+            allowed_signup_domains: ['new-domain.com'],
+          }
+
+          expect(last_response.status).to eq(200)
+
+          body = json_body
+          record = body['record']
+          expect(record['allowed_signup_domains']).to contain_exactly('new-domain.com')
+          # Strategy preserved
+          expect(record['validation_strategy']).to eq('domain_allowlist')
+        end
+
+        it 'updates strategy and preserves enabled state when not provided' do
+          # Start enabled
+          existing = Onetime::CustomDomain::SignupConfig.find_by_domain_id(test_custom_domain.identifier)
+          existing.enabled = 'true'
+          existing.save
+
+          csrf_patch api_path(test_custom_domain.extid), {
+            validation_strategy: 'passthrough',
+          }
+
+          expect(last_response.status).to eq(200)
+
+          body = json_body
+          record = body['record']
+          expect(record['validation_strategy']).to eq('passthrough')
+          expect(record['enabled']).to be true
+        end
+
+        it 'returns 422 when switching to domain_allowlist without provided domains and existing is empty' do
+          # Replace existing config with non-allowlist that has no domains
+          Onetime::CustomDomain::SignupConfig.delete_for_domain!(test_custom_domain.identifier)
+          Onetime::CustomDomain::SignupConfig.create!(
+            domain_id: test_custom_domain.identifier,
+            validation_strategy: 'passthrough',
+            enabled: true,
+          )
+
+          csrf_patch api_path(test_custom_domain.extid), {
+            validation_strategy: 'domain_allowlist',
+          }
+
+          expect(last_response.status).to eq(422)
+          body = json_body
+          expect(body['error']).to include('allowed_signup_domains')
+        end
+
+        it 'returns 422 for invalid validation_strategy' do
+          csrf_patch api_path(test_custom_domain.extid), {
+            validation_strategy: 'invalid_strategy',
+          }
+
+          expect(last_response.status).to eq(422)
+          body = json_body
+          expect(body['error']).to include('validation_strategy must be one of')
+        end
+      end
+    end
+
+    context 'when no existing config' do
+      before do
+        login_as(test_owner)
+      end
+
+      it 'creates new config when providing all required fields (PATCH-as-create)' do
+        csrf_patch api_path(test_custom_domain.extid), valid_passthrough_params
+
+        expect(last_response.status).to eq(200)
+
+        body = json_body
+        record = body['record']
+        expect(record['validation_strategy']).to eq('passthrough')
+        expect(record['enabled']).to be true
+      end
+
+      it 'returns 422 when validation_strategy missing for creation' do
+        csrf_patch api_path(test_custom_domain.extid), {
+          enabled: true,
+        }
+
+        expect(last_response.status).to eq(422)
+        body = json_body
+        expect(body['error']).to include('Validation strategy')
+      end
+    end
+
+    context 'authorization checks' do
+      before do
+        Onetime::CustomDomain::SignupConfig.create!(
+          domain_id: test_custom_domain.identifier,
+          validation_strategy: 'passthrough',
+          enabled: false,
+        )
+      end
+
+      it 'returns 401 for unauthenticated requests' do
+        header 'Accept', 'application/json'
+        header 'Content-Type', 'application/json'
+        patch api_path(test_custom_domain.extid), JSON.generate({ enabled: true })
+
+        expect(last_response.status).to eq(401)
+      end
+
+      it 'returns 403 for non-owner of organization' do
+        login_as(test_non_owner)
+        csrf_patch api_path(test_custom_domain.extid), { enabled: true }
+
+        expect(last_response.status).to eq(403)
+      end
+
+      it 'returns 404 for non-existent domain' do
+        login_as(test_owner)
+        csrf_patch api_path('nonexistent-domain-extid'), { enabled: true }
+
+        expect(last_response.status).to eq(404)
       end
     end
   end
@@ -467,7 +649,7 @@ RSpec.describe 'Domain Signup Config API', type: :integration do
 
         expect(last_response.status).to eq(404)
         body = json_body
-        expect(body['message']).to include('Signup configuration not found')
+        expect(body['error']).to include('Signup configuration not found')
       end
     end
 
@@ -499,7 +681,7 @@ RSpec.describe 'Domain Signup Config API', type: :integration do
 
         expect(last_response.status).to eq(404)
         body = json_body
-        expect(body['message']).to include('Domain not found')
+        expect(body['error']).to include('Domain not found')
       end
     end
   end
@@ -552,7 +734,7 @@ RSpec.describe 'Domain Signup Config API', type: :integration do
 
         expect(last_response.status).to eq(404)
         body = json_body
-        expect(body['message']).to include('Signup configuration not found')
+        expect(body['error']).to include('Signup configuration not found')
       end
     end
 
@@ -584,7 +766,7 @@ RSpec.describe 'Domain Signup Config API', type: :integration do
 
         expect(last_response.status).to eq(404)
         body = json_body
-        expect(body['message']).to include('Domain not found')
+        expect(body['error']).to include('Domain not found')
       end
     end
   end

--- a/apps/api/domains/spec/integration/domain_sso_config_spec.rb
+++ b/apps/api/domains/spec/integration/domain_sso_config_spec.rb
@@ -310,7 +310,7 @@ RSpec.describe 'Domain SSO Config API', type: :integration do
 
           expect(last_response.status).to eq(422)
           body = json_body
-          expect(body['message']).to include('Provider type')
+          expect(body['error']).to include('Provider type')
         end
 
         it 'returns 422 for invalid provider_type' do
@@ -320,7 +320,7 @@ RSpec.describe 'Domain SSO Config API', type: :integration do
 
           expect(last_response.status).to eq(422)
           body = json_body
-          expect(body['message']).to include('Invalid provider type')
+          expect(body['error']).to include('Invalid provider type')
         end
 
         it 'returns 422 for missing client_id' do
@@ -331,7 +331,7 @@ RSpec.describe 'Domain SSO Config API', type: :integration do
 
           expect(last_response.status).to eq(422)
           body = json_body
-          expect(body['message']).to include('Client ID')
+          expect(body['error']).to include('Client ID')
         end
 
         it 'returns 422 for missing client_secret on PUT' do
@@ -342,7 +342,7 @@ RSpec.describe 'Domain SSO Config API', type: :integration do
 
           expect(last_response.status).to eq(422)
           body = json_body
-          expect(body['message']).to include('Client secret')
+          expect(body['error']).to include('Client secret')
         end
 
         it 'returns 422 for missing tenant_id on Entra ID provider' do
@@ -353,7 +353,7 @@ RSpec.describe 'Domain SSO Config API', type: :integration do
 
           expect(last_response.status).to eq(422)
           body = json_body
-          expect(body['message']).to include('Tenant ID')
+          expect(body['error']).to include('Tenant ID')
         end
 
         it 'returns 422 for missing issuer on OIDC provider' do
@@ -364,7 +364,7 @@ RSpec.describe 'Domain SSO Config API', type: :integration do
 
           expect(last_response.status).to eq(422)
           body = json_body
-          expect(body['message']).to include('Issuer URL')
+          expect(body['error']).to include('Issuer URL')
         end
 
         it 'returns 422 for non-HTTPS issuer URL' do
@@ -374,7 +374,7 @@ RSpec.describe 'Domain SSO Config API', type: :integration do
 
           expect(last_response.status).to eq(422)
           body = json_body
-          expect(body['message']).to include('Issuer URL')
+          expect(body['error']).to include('Issuer URL')
         end
       end
     end
@@ -398,7 +398,7 @@ RSpec.describe 'Domain SSO Config API', type: :integration do
         # Feature flag check uses raise_form_error → FormError → 422
         expect(last_response.status).to eq(422)
         body = json_body
-        expect(body['message']).to include('SSO is not enabled')
+        expect(body['error']).to include('SSO is not enabled')
       end
 
       it 'returns 403 for non-owner of organization' do
@@ -409,7 +409,7 @@ RSpec.describe 'Domain SSO Config API', type: :integration do
         # Non-owner check uses verify_one_of_roles! → Onetime::Forbidden → 403
         expect(last_response.status).to eq(403)
         body = json_body
-        expect(body['message']).to include('owner')
+        expect(body['error']).to include('owner')
       end
 
       it 'returns 422 when organization lacks manage_sso entitlement' do
@@ -424,7 +424,7 @@ RSpec.describe 'Domain SSO Config API', type: :integration do
         # Entitlement check uses raise_form_error → FormError → 422
         expect(last_response.status).to eq(422)
         body = json_body
-        expect(body['message']).to include('manage_sso')
+        expect(body['error']).to include('manage_sso')
       end
 
       it 'returns 404 for non-existent domain' do
@@ -433,7 +433,7 @@ RSpec.describe 'Domain SSO Config API', type: :integration do
 
         expect(last_response.status).to eq(404)
         body = json_body
-        expect(body['message']).to include('Domain not found')
+        expect(body['error']).to include('Domain not found')
       end
     end
   end
@@ -517,7 +517,7 @@ RSpec.describe 'Domain SSO Config API', type: :integration do
 
         expect(last_response.status).to eq(404)
         body = json_body
-        expect(body['message']).to include('SSO configuration not found')
+        expect(body['error']).to include('SSO configuration not found')
       end
     end
 
@@ -673,7 +673,7 @@ RSpec.describe 'Domain SSO Config API', type: :integration do
 
         expect(last_response.status).to eq(422)
         body = json_body
-        expect(body['message']).to include('required')
+        expect(body['error']).to include('required')
       end
     end
   end
@@ -725,7 +725,7 @@ RSpec.describe 'Domain SSO Config API', type: :integration do
 
         expect(last_response.status).to eq(404)
         body = json_body
-        expect(body['message']).to include('SSO configuration not found')
+        expect(body['error']).to include('SSO configuration not found')
       end
     end
 
@@ -841,7 +841,7 @@ RSpec.describe 'Domain SSO Config API', type: :integration do
 
         expect(last_response.status).to eq(422)
         body = json_body
-        expect(body['message']).to include('Provider type')
+        expect(body['error']).to include('Provider type')
       end
 
       it 'returns 422 for missing client_id' do
@@ -852,7 +852,7 @@ RSpec.describe 'Domain SSO Config API', type: :integration do
 
         expect(last_response.status).to eq(422)
         body = json_body
-        expect(body['message']).to include('Client ID')
+        expect(body['error']).to include('Client ID')
       end
 
       it 'returns 422 for missing tenant_id on Entra ID' do
@@ -863,7 +863,7 @@ RSpec.describe 'Domain SSO Config API', type: :integration do
 
         expect(last_response.status).to eq(422)
         body = json_body
-        expect(body['message']).to include('Tenant ID')
+        expect(body['error']).to include('Tenant ID')
       end
 
       it 'returns 422 for invalid tenant_id format on Entra ID' do
@@ -875,7 +875,7 @@ RSpec.describe 'Domain SSO Config API', type: :integration do
 
         expect(last_response.status).to eq(422)
         body = json_body
-        expect(body['message']).to include('UUID')
+        expect(body['error']).to include('UUID')
       end
 
       it 'returns 422 for missing issuer on OIDC' do
@@ -886,7 +886,7 @@ RSpec.describe 'Domain SSO Config API', type: :integration do
 
         expect(last_response.status).to eq(422)
         body = json_body
-        expect(body['message']).to include('Issuer URL')
+        expect(body['error']).to include('Issuer URL')
       end
 
       it 'returns 422 for invalid Google client_id format' do
@@ -897,7 +897,7 @@ RSpec.describe 'Domain SSO Config API', type: :integration do
 
         expect(last_response.status).to eq(422)
         body = json_body
-        expect(body['message']).to include('googleusercontent.com')
+        expect(body['error']).to include('googleusercontent.com')
       end
 
       it 'returns 422 for invalid GitHub client_id format' do
@@ -908,7 +908,7 @@ RSpec.describe 'Domain SSO Config API', type: :integration do
 
         expect(last_response.status).to eq(422)
         body = json_body
-        expect(body['message']).to include('Iv1')
+        expect(body['error']).to include('Iv1')
       end
     end
 
@@ -937,7 +937,7 @@ RSpec.describe 'Domain SSO Config API', type: :integration do
         # Non-owner check uses verify_one_of_roles! -> Onetime::Forbidden -> 403
         expect(last_response.status).to eq(403)
         body = json_body
-        expect(body['message']).to include('owner')
+        expect(body['error']).to include('owner')
       end
     end
   end

--- a/apps/web/auth/config/hooks/omniauth.rb
+++ b/apps/web/auth/config/hooks/omniauth.rb
@@ -192,6 +192,13 @@ module Auth::Config::Hooks
           provider: omniauth_provider,
         )
 
+        # Capture the signup domain so it can be set on the new Customer in a
+        # single write (instead of save-then-update). Lookup is cheap and pure;
+        # leave it outside safe_execute so failures still surface.
+        display_domain   = request.env['onetime.display_domain']
+        custom_domain    = display_domain ? Onetime::CustomDomain.load_by_display_domain(display_domain) : nil
+        signup_domain_id = custom_domain&.identifier
+
         # Create Customer record (same as regular signup)
         customer = Onetime::ErrorHandler.safe_execute(
           'create_customer_omniauth',
@@ -203,21 +210,12 @@ module Auth::Config::Hooks
             account: account,
             db: db,
             provisioning_origin: 'sso_jit',
+            signup_domain_id: signup_domain_id,
           ).call
         end
 
         # Create default organization and team
         if customer.is_a?(Onetime::Customer)
-          # Capture the signup domain for re-verification and background jobs
-          display_domain = request.env['onetime.display_domain']
-          if display_domain
-            custom_domain = Onetime::CustomDomain.load_by_display_domain(display_domain)
-            if custom_domain
-              customer.signup_domain_id = custom_domain.identifier
-              customer.save
-            end
-          end
-
           Onetime::ErrorHandler.safe_execute(
             'create_default_workspace_omniauth',
             extid: customer.extid,

--- a/apps/web/auth/operations/create_customer.rb
+++ b/apps/web/auth/operations/create_customer.rb
@@ -18,11 +18,16 @@ module Auth
       # @param provisioning_origin [String, nil] One of Onetime::Customer::PROVISIONING_ORIGINS.
       #   Set on newly-created Customer records as lifecycle/audit metadata.
       #   Ignored when the customer already exists (we don't rewrite history).
-      def initialize(account_id:, account:, db: nil, provisioning_origin: nil)
+      # @param signup_domain_id [String, nil] CustomDomain identifier captured at signup.
+      #   Set on newly-created Customer records. Ignored for existing customers to
+      #   preserve original signup context (same "don't rewrite history" rule as
+      #   provisioning_origin).
+      def initialize(account_id:, account:, db: nil, provisioning_origin: nil, signup_domain_id: nil)
         @account_id          = account_id
         @account             = account
         @db                  = db || Auth::Database.connection
         @provisioning_origin = provisioning_origin
+        @signup_domain_id    = signup_domain_id
       end
 
       # Executes the customer creation/loading operation
@@ -52,9 +57,10 @@ module Auth
             role: 'customer',
             verified: false, # needs to be updated in after_verify_account
             provisioning_origin: @provisioning_origin,
+            signup_domain_id: @signup_domain_id,
           )
 
-          auth_logger.info "[create-customer] Created new customer: #{customer.custid} (role: customer, origin: #{@provisioning_origin || 'unknown'})"
+          auth_logger.info "[create-customer] Created new customer: #{customer.custid} (role: customer, origin: #{@provisioning_origin || 'unknown'}, signup_domain_id: #{@signup_domain_id || 'none'})"
         end
 
         customer

--- a/docs/architecture/decision-records/adr-013-api-error-response-wire-format.md
+++ b/docs/architecture/decision-records/adr-013-api-error-response-wire-format.md
@@ -1,0 +1,57 @@
+---
+id: "013"
+status: proposed
+title: "ADR-013: API 4xx/5xx Error Response Wire Format"
+---
+
+## Status
+
+Proposed
+
+## Date
+
+2026-05-26
+
+## Context
+
+Backend error responses for the JSON APIs (v2, v3, account, organizations, domains) had drifted into two incompatible shapes:
+
+- Application errors (`RecordNotFound`, `FormError`, `Forbidden`, `LimitExceeded`, `EntitlementRequired`, `GuestRoutesDisabled`) emitted `{ error: <class-name>, message: <user-facing text> }`. Some variants omitted one field or used `code:` instead of a type.
+- Otto router fallbacks for `not_found` and `server_error` emitted `{ message:, code: }` (in `base_json_api.rb`) or `{ error: <message> }` with no type (in V1/V2).
+
+The frontend compensated with fallback chains (`details.message || details.error`) and ambiguous interfaces (`HttpErrorLike` accepting `data?: { message?: string }`). `error:` carrying a class name forced callers to guess whether the field was machine-readable or user-readable.
+
+Rodauth, which OTS already runs on the auth surface, emits `{ error: <user-facing message>, "field-error": [...] }`. That convention is the de facto standard the rest of the stack was being measured against.
+
+## Decision
+
+**4xx and 5xx JSON responses emit `{ error: <user-facing message>, error_type: <class name> }`.**
+
+- `error` is the field the frontend displays. It is always a sentence aimed at the end user.
+- `error_type` is the field the frontend branches on. It is the Ruby class name (`RecordNotFound`, `FormError`, `Forbidden`, `LimitExceeded`, `EntitlementRequired`, `GuestRoutesDisabled`, `NotFound`, `ServerError`).
+- Class-specific fields may accompany the pair without renaming it: `field` on `FormError`, `error_key` for i18n lookup, `retry_after`/`attempts`/`max_attempts` on `LimitExceeded`, `entitlement`/`current_plan`/`upgrade_to` on `EntitlementRequired`.
+- `code` is reserved for per-operation discriminators that are not redundant with `error_type`. `GuestRoutesDisabled` uses it (`GUEST_CONCEAL_DISABLED`, `GUEST_REVEAL_DISABLED`, ...) because the class is one and the operations are many. New errors should justify a `code` before adding one; in most cases `error_type` is sufficient.
+
+This applies uniformly to application errors raised from logic classes and to Otto router fallback responses (`router.not_found`, `router.server_error`).
+
+The frontend reads only `error` for display and `error_type` for type branching. Fallback chains (`message || error`) are removed. The `HttpErrorLike` shape is `data?: { error?: string; error_type?: string }`.
+
+Aligning on this shape mirrors Rodauth, removes the field-meaning ambiguity that produced the fallback chains, and lets `error_type` evolve independently of human-readable copy.
+
+## Trade-offs
+
+- **We lose**: backward compatibility for any external consumer reading `message:` on error responses. `GuestRoutesDisabled` is the most likely external break (documented in PR #3221 as a wire-format change).
+- **We gain**: a single, unambiguous error contract across all JSON APIs. Frontend error handling collapses to two field reads.
+## Out of Scope
+
+- **V1 API.** Frozen by policy (see V1 application docstring). Existing V1 error bodies stay as-is.
+- **Success-confirmation payloads.** Endpoints in `apps/api/domains/logic/**` that return `{ success: true, message: ... }` are not error responses and are not governed by this ADR.
+
+## Implementation Notes
+
+Migration tracked in #3221.
+
+### Related ADRs
+
+- ADR-003 (API Parameter Naming): general API field-naming guidance.
+- ADR-010 (Error Handling at Layer Boundaries): when to raise vs. return a default. This ADR governs the wire shape once an error reaches the boundary.

--- a/src/tests/schemas/shapes/config/capabilities.spec.ts
+++ b/src/tests/schemas/shapes/config/capabilities.spec.ts
@@ -1,0 +1,39 @@
+// src/tests/schemas/shapes/config/capabilities.spec.ts
+//
+// The capabilities shape has no defaults or value constraints — it is a
+// pure re-export of the contract. This is a convention guard: if anyone
+// adds augmentation in the shape file, the identity assertion fails and
+// forces a re-read of whether per-section coverage now applies.
+
+import { describe, it, expect } from 'vitest';
+import {
+  capabilitiesSchema,
+  capabilityFlagsSchema,
+} from '@/schemas/contracts/config/section/capabilities';
+import {
+  capabilitiesShape,
+  capabilityFlagsShape,
+} from '@/schemas/shapes/config/section/capabilities';
+
+describe('capabilities shape — re-export convention', () => {
+  it('capabilitiesShape is the contract schema (no augmentation)', () => {
+    expect(capabilitiesShape).toBe(capabilitiesSchema);
+  });
+
+  it('capabilityFlagsShape is the contract schema (no augmentation)', () => {
+    expect(capabilityFlagsShape).toBe(capabilityFlagsSchema);
+  });
+
+  it('parses a populated capability flag block', () => {
+    const result = capabilityFlagsShape.parse({
+      api: true,
+      email: false,
+      custom_domains: true,
+    });
+    expect(result).toEqual({ api: true, email: false, custom_domains: true });
+  });
+
+  it('requires every flag (no defaults backfill missing keys)', () => {
+    expect(() => capabilityFlagsShape.parse({ api: true })).toThrow();
+  });
+});

--- a/src/tests/schemas/shapes/config/development.spec.ts
+++ b/src/tests/schemas/shapes/config/development.spec.ts
@@ -1,0 +1,55 @@
+// src/tests/schemas/shapes/config/development.spec.ts
+//
+// Per-field coverage for the development shape. Every field on the
+// contract is optional; the shape backfills five booleans/strings. The
+// sections.spec.ts smoke test asserts the top-level defaults — this file
+// covers the contract↔shape divergence for each field.
+
+import { describe, it, expect } from 'vitest';
+import { developmentSchema } from '@/schemas/contracts/config/section/development';
+import { developmentShape } from '@/schemas/shapes/config/section/development';
+
+describe('developmentShape — defaults applied on empty input', () => {
+  it('fills every field with the documented default', () => {
+    const result = developmentShape.parse({});
+    expect(result).toEqual({
+      enabled: false,
+      debug: false,
+      frontend_host: 'http://localhost:5173',
+      domain_context_enabled: false,
+      allow_nil_global_secret: false,
+    });
+  });
+
+  it('preserves caller-provided values over defaults', () => {
+    const result = developmentShape.parse({
+      enabled: true,
+      debug: true,
+      frontend_host: 'http://dev.local:5174',
+      domain_context_enabled: true,
+      allow_nil_global_secret: true,
+    });
+    expect(result).toEqual({
+      enabled: true,
+      debug: true,
+      frontend_host: 'http://dev.local:5174',
+      domain_context_enabled: true,
+      allow_nil_global_secret: true,
+    });
+  });
+});
+
+describe('developmentShape — contract vs shape', () => {
+  it.each([
+    ['enabled', undefined, false],
+    ['debug', undefined, false],
+    ['frontend_host', undefined, 'http://localhost:5173'],
+    ['domain_context_enabled', undefined, false],
+    ['allow_nil_global_secret', undefined, false],
+  ])('contract leaves %s undefined; shape fills it', (field, contractExpected, shapeExpected) => {
+    const c = developmentSchema.parse({}) as Record<string, unknown>;
+    const s = developmentShape.parse({}) as Record<string, unknown>;
+    expect(c[field]).toBe(contractExpected);
+    expect(s[field]).toBe(shapeExpected);
+  });
+});

--- a/src/tests/schemas/shapes/config/diagnostics.spec.ts
+++ b/src/tests/schemas/shapes/config/diagnostics.spec.ts
@@ -1,0 +1,85 @@
+// src/tests/schemas/shapes/config/diagnostics.spec.ts
+//
+// Coverage for the diagnostics shape — the top-level `enabled` flag and
+// the three nested sentry trees (defaults / backend / frontend). The
+// frontend tree has the extra `trackComponents` default the other two
+// lack; this file pins that asymmetry.
+
+import { describe, it, expect } from 'vitest';
+import {
+  diagnosticsSchema,
+  diagnosticsSentryDefaultsSchema,
+  diagnosticsSentryFrontendSchema,
+} from '@/schemas/contracts/config/section/diagnostics';
+import {
+  diagnosticsShape,
+  diagnosticsSentryShape,
+  diagnosticsSentryDefaultsShape,
+  diagnosticsSentryBackendShape,
+  diagnosticsSentryFrontendShape,
+} from '@/schemas/shapes/config/section/diagnostics';
+
+describe('diagnosticsShape — top-level defaults', () => {
+  it('enabled defaults to false', () => {
+    expect(diagnosticsShape.parse({}).enabled).toBe(false);
+  });
+
+  it('leaves the sentry sub-tree undefined when omitted', () => {
+    expect(diagnosticsShape.parse({}).sentry).toBeUndefined();
+  });
+});
+
+describe('diagnosticsSentry*Shape — logErrors default', () => {
+  it.each([
+    ['defaults', diagnosticsSentryDefaultsShape],
+    ['backend', diagnosticsSentryBackendShape],
+    ['frontend', diagnosticsSentryFrontendShape],
+  ])('%s shape defaults logErrors to true', (_label, shape) => {
+    expect(shape.parse({}).logErrors).toBe(true);
+  });
+
+  it('frontend shape also defaults trackComponents to true', () => {
+    expect(diagnosticsSentryFrontendShape.parse({}).trackComponents).toBe(true);
+  });
+
+  it.each([
+    ['defaults', diagnosticsSentryDefaultsSchema],
+    ['frontend', diagnosticsSentryFrontendSchema],
+  ])('contract leaves logErrors undefined for %s', (_label, schema) => {
+    expect((schema.parse({}) as { logErrors?: boolean }).logErrors).toBeUndefined();
+  });
+});
+
+describe('diagnosticsSentryShape — composed sub-trees', () => {
+  it('applies logErrors defaults to every sub-tree when each is provided empty', () => {
+    const result = diagnosticsSentryShape.parse({ defaults: {}, backend: {}, frontend: {} });
+    expect(result.defaults?.logErrors).toBe(true);
+    expect(result.backend?.logErrors).toBe(true);
+    expect(result.frontend?.logErrors).toBe(true);
+    expect(result.frontend?.trackComponents).toBe(true);
+  });
+
+  it('preserves a caller-supplied dsn over the implicit defaults', () => {
+    const result = diagnosticsSentryShape.parse({
+      defaults: { dsn: 'https://sentry.example/1' },
+    });
+    expect(result.defaults?.dsn).toBe('https://sentry.example/1');
+    expect(result.defaults?.logErrors).toBe(true);
+  });
+});
+
+describe('diagnosticsShape — composed', () => {
+  it('applies sentry defaults when caller passes empty sentry sub-objects', () => {
+    const result = diagnosticsShape.parse({
+      enabled: true,
+      sentry: { defaults: {}, backend: {}, frontend: {} },
+    });
+    expect(result.enabled).toBe(true);
+    expect(result.sentry?.defaults?.logErrors).toBe(true);
+    expect(result.sentry?.frontend?.trackComponents).toBe(true);
+  });
+
+  it('contract leaves enabled undefined', () => {
+    expect(diagnosticsSchema.parse({}).enabled).toBeUndefined();
+  });
+});

--- a/src/tests/schemas/shapes/config/features.spec.ts
+++ b/src/tests/schemas/shapes/config/features.spec.ts
@@ -1,0 +1,140 @@
+// src/tests/schemas/shapes/config/features.spec.ts
+//
+// Coverage for the features shape — regions, incoming, domains (incl. the
+// ACME endpoint and proxy sub-trees). The `jurisdictions` union added in
+// PR #3206 lives on the contract because `z.union(...)` is a type-format
+// helper; this file exercises all three branches there to lock that down.
+
+import { describe, it, expect } from 'vitest';
+import {
+  featuresIncomingSchema,
+  featuresDomainsAcmeSchema,
+  featuresRegionsSchema,
+} from '@/schemas/contracts/config/section/features';
+import {
+  featuresShape,
+  featuresRegionsShape,
+  featuresIncomingShape,
+  featuresDomainsShape,
+  featuresDomainsProxyShape,
+  featuresDomainsAcmeShape,
+} from '@/schemas/shapes/config/section/features';
+
+describe('featuresIncomingShape — defaults and bounds', () => {
+  it('defaults enabled/memo_max_length/default_ttl on empty input', () => {
+    const result = featuresIncomingShape.parse({});
+    expect(result.enabled).toBe(false);
+    expect(result.memo_max_length).toBe(50);
+    expect(result.default_ttl).toBe(604800);
+  });
+
+  it('rejects non-positive memo_max_length', () => {
+    expect(() => featuresIncomingShape.parse({ memo_max_length: 0 })).toThrow();
+    expect(() => featuresIncomingShape.parse({ memo_max_length: -1 })).toThrow();
+  });
+
+  it('rejects non-integer memo_max_length', () => {
+    expect(() => featuresIncomingShape.parse({ memo_max_length: 12.5 })).toThrow();
+  });
+
+  it('rejects non-positive default_ttl', () => {
+    expect(() => featuresIncomingShape.parse({ default_ttl: 0 })).toThrow();
+  });
+
+  it('contract accepts the same bad values the shape rejects', () => {
+    expect(() => featuresIncomingSchema.parse({ memo_max_length: 0 })).not.toThrow();
+    expect(() => featuresIncomingSchema.parse({ default_ttl: -5 })).not.toThrow();
+  });
+});
+
+describe('featuresRegionsShape — defaults', () => {
+  it('enabled defaults to false', () => {
+    expect(featuresRegionsShape.parse({}).enabled).toBe(false);
+  });
+});
+
+describe('featuresRegions jurisdictions union (contract-side)', () => {
+  it('accepts an array of structured jurisdictions', () => {
+    const value = [
+      { identifier: 'eu', display_name: 'Europe', domain: 'eu.example.com' },
+    ];
+    expect(featuresRegionsSchema.parse({ jurisdictions: value }).jurisdictions).toEqual(value);
+    expect(featuresRegionsShape.parse({ jurisdictions: value }).jurisdictions).toEqual(value);
+  });
+
+  it('accepts a CSV string (raw ENV value)', () => {
+    expect(featuresRegionsShape.parse({ jurisdictions: 'eu,us' }).jurisdictions).toBe('eu,us');
+  });
+
+  it('accepts null (unset ENV)', () => {
+    expect(featuresRegionsShape.parse({ jurisdictions: null }).jurisdictions).toBeNull();
+  });
+
+  it('rejects values that match none of the union branches', () => {
+    expect(() => featuresRegionsShape.parse({ jurisdictions: 42 })).toThrow();
+  });
+});
+
+describe('featuresDomainsAcmeShape — defaults', () => {
+  it('defaults enabled/listen_address/port on empty input', () => {
+    const result = featuresDomainsAcmeShape.parse({});
+    expect(result.enabled).toBe(false);
+    expect(result.listen_address).toBe('127.0.0.1');
+    expect(result.port).toBe('12020');
+  });
+
+  it('accepts both string and number forms of port', () => {
+    expect(featuresDomainsAcmeShape.parse({ port: 12020 }).port).toBe(12020);
+    expect(featuresDomainsAcmeShape.parse({ port: '8443' }).port).toBe('8443');
+  });
+
+  it('contract leaves enabled/port undefined', () => {
+    const result = featuresDomainsAcmeSchema.parse({});
+    expect(result.enabled).toBeUndefined();
+    expect(result.port).toBeUndefined();
+  });
+});
+
+describe('featuresDomainsProxyShape — passthrough', () => {
+  it('is a re-export of the contract (no augmentation)', () => {
+    expect(featuresDomainsProxyShape.parse({})).toEqual({});
+  });
+
+  it('preserves nullable string fields', () => {
+    const result = featuresDomainsProxyShape.parse({ api_key: null, proxy_ip: '10.0.0.1' });
+    expect(result.api_key).toBeNull();
+    expect(result.proxy_ip).toBe('10.0.0.1');
+  });
+});
+
+describe('featuresDomainsShape — composed defaults', () => {
+  it('defaults enabled/require_verified/validation_strategy and nested acme', () => {
+    const result = featuresDomainsShape.parse({ acme: {} });
+    expect(result.enabled).toBe(false);
+    expect(result.require_verified).toBe(false);
+    expect(result.validation_strategy).toBe('passthrough');
+    expect(result.acme?.enabled).toBe(false);
+    expect(result.acme?.listen_address).toBe('127.0.0.1');
+    expect(result.acme?.port).toBe('12020');
+  });
+
+  it('rejects validation_strategy values outside the enum', () => {
+    expect(() => featuresDomainsShape.parse({ validation_strategy: 'made_up' })).toThrow();
+  });
+});
+
+describe('featuresShape — composed defaults', () => {
+  it('applies defaults to every nested sub-tree provided as empty objects', () => {
+    const result = featuresShape.parse({
+      regions: {},
+      incoming: {},
+      domains: { acme: {} },
+    });
+    expect(result.regions?.enabled).toBe(false);
+    expect(result.incoming?.enabled).toBe(false);
+    expect(result.incoming?.memo_max_length).toBe(50);
+    expect(result.incoming?.default_ttl).toBe(604800);
+    expect(result.domains?.enabled).toBe(false);
+    expect(result.domains?.acme?.port).toBe('12020');
+  });
+});

--- a/src/tests/schemas/shapes/config/i18n.spec.ts
+++ b/src/tests/schemas/shapes/config/i18n.spec.ts
@@ -1,0 +1,69 @@
+// src/tests/schemas/shapes/config/i18n.spec.ts
+//
+// Per-field coverage for the i18n shape. The contract requires
+// `fallback_locale` (no .optional()), so every test supplies it.
+
+import { describe, it, expect } from 'vitest';
+import { i18nSchema } from '@/schemas/contracts/config/section/i18n';
+import { i18nShape } from '@/schemas/shapes/config/section/i18n';
+
+const fallback = { en: ['en'] };
+
+describe('i18nShape — defaults applied on minimal input', () => {
+  it('fills every optional field with the documented default', () => {
+    const result = i18nShape.parse({ fallback_locale: fallback });
+    expect(result.enabled).toBe(false);
+    expect(result.default_locale).toBe('en');
+    expect(result.locales).toEqual([]);
+    expect(result.incomplete).toEqual([]);
+    expect(result.date_format).toBe('locale');
+    expect(result.datetime_format).toBe('locale');
+  });
+
+  it('preserves caller-provided values over defaults', () => {
+    const result = i18nShape.parse({
+      enabled: true,
+      default_locale: 'fr',
+      locales: ['en', 'fr'],
+      incomplete: ['zh'],
+      date_format: 'iso',
+      datetime_format: 'iso',
+      fallback_locale: fallback,
+    });
+    expect(result.default_locale).toBe('fr');
+    expect(result.locales).toEqual(['en', 'fr']);
+    expect(result.incomplete).toEqual(['zh']);
+    expect(result.date_format).toBe('iso');
+    expect(result.datetime_format).toBe('iso');
+  });
+});
+
+describe('i18nShape — fallback_locale shape', () => {
+  it('accepts a string value (single fallback)', () => {
+    expect(() => i18nShape.parse({ fallback_locale: { fr: 'en' } })).not.toThrow();
+  });
+
+  it('accepts an array of locale codes', () => {
+    expect(() => i18nShape.parse({ fallback_locale: { fr: ['en', 'de'] } })).not.toThrow();
+  });
+
+  it('rejects non-string/array values', () => {
+    expect(() => i18nShape.parse({ fallback_locale: { fr: 1 } })).toThrow();
+  });
+
+  it('rejects missing fallback_locale entirely', () => {
+    expect(() => i18nShape.parse({})).toThrow();
+  });
+});
+
+describe('i18nShape — contract vs shape', () => {
+  it('contract leaves all optional fields undefined', () => {
+    const c = i18nSchema.parse({ fallback_locale: fallback });
+    expect(c.enabled).toBeUndefined();
+    expect(c.default_locale).toBeUndefined();
+    expect(c.locales).toBeUndefined();
+    expect(c.incomplete).toBeUndefined();
+    expect(c.date_format).toBeUndefined();
+    expect(c.datetime_format).toBeUndefined();
+  });
+});

--- a/src/tests/schemas/shapes/config/jobs.spec.ts
+++ b/src/tests/schemas/shapes/config/jobs.spec.ts
@@ -1,0 +1,216 @@
+// src/tests/schemas/shapes/config/jobs.spec.ts
+//
+// Coverage for the jobs shape — top-level defaults, worker config bounds,
+// scheduler/domain_refresh/expiration_warnings sub-trees, and the six
+// maintenance jobs (phantom_cleanup, data_audit, participation_gc,
+// index_rebuild, instances_rebuild, housekeeping).
+
+import { describe, it, expect } from 'vitest';
+import {
+  jobsSchema,
+  workerConfigSchema,
+} from '@/schemas/contracts/config/section/jobs';
+import {
+  jobsShape,
+  jobsWorkersShape,
+  jobsSchedulerShape,
+  jobsDomainRefreshShape,
+  jobsExpirationWarningsShape,
+  jobsMaintenanceShape,
+  workerConfigShape,
+} from '@/schemas/shapes/config/section/jobs';
+
+describe('jobsShape — top-level defaults', () => {
+  it('fills every documented default on empty input', () => {
+    const result = jobsShape.parse({});
+    expect(result.enabled).toBe(false);
+    expect(result.rabbitmq_url).toBe('amqp://guest:guest@localhost:5672/dev');
+    expect(result.channel_pool_size).toBe(5);
+    expect(result.fallback_to_sync).toBe(true);
+    expect(result.plan_cache_refresh_enabled).toBe(false);
+    expect(result.catalog_retry_enabled).toBe(false);
+    expect(result.dlq_consumer_enabled).toBe(true);
+  });
+
+  it('contract leaves channel_pool_size undefined', () => {
+    expect(jobsSchema.parse({}).channel_pool_size).toBeUndefined();
+  });
+
+  it('rejects non-positive channel_pool_size on the shape', () => {
+    expect(() => jobsShape.parse({ channel_pool_size: 0 })).toThrow();
+    expect(() => jobsShape.parse({ channel_pool_size: -1 })).toThrow();
+  });
+
+  it('rejects non-integer channel_pool_size on the shape', () => {
+    expect(() => jobsShape.parse({ channel_pool_size: 1.5 })).toThrow();
+  });
+});
+
+describe('workerConfigShape — positive-integer bounds', () => {
+  it('accepts positive integers', () => {
+    const result = workerConfigShape.parse({ threads: 4, prefetch: 10 });
+    expect(result).toEqual({ threads: 4, prefetch: 10 });
+  });
+
+  it.each([
+    ['threads', 0],
+    ['threads', -3],
+    ['threads', 1.5],
+    ['prefetch', 0],
+    ['prefetch', -2],
+  ])('rejects %s = %s', (field, value) => {
+    expect(() => workerConfigShape.parse({ threads: 1, prefetch: 1, [field]: value })).toThrow();
+  });
+
+  it('contract accepts the same bad values', () => {
+    expect(() => workerConfigSchema.parse({ threads: 0, prefetch: -1 })).not.toThrow();
+  });
+});
+
+describe('jobsWorkersShape — full worker defaults', () => {
+  it('email worker defaults to { threads: 4, prefetch: 10 }', () => {
+    expect(jobsWorkersShape.parse({}).email).toEqual({ threads: 4, prefetch: 10 });
+  });
+
+  it('notifications worker defaults to { threads: 2, prefetch: 10 }', () => {
+    expect(jobsWorkersShape.parse({}).notifications).toEqual({ threads: 2, prefetch: 10 });
+  });
+
+  it('billing worker defaults to { threads: 2, prefetch: 5 }', () => {
+    expect(jobsWorkersShape.parse({}).billing).toEqual({ threads: 2, prefetch: 5 });
+  });
+
+  it('partial worker overrides do NOT merge (Zod object default is all-or-nothing)', () => {
+    // Documented foot-gun: `default({...})` on an object only fires when
+    // the whole object is `undefined`, so passing a partial workers map
+    // requires explicit override fields. The shape file explains the fix
+    // when a partial-override consumer arrives.
+    const result = jobsWorkersShape.parse({ email: { threads: 10, prefetch: 20 } });
+    expect(result.email).toEqual({ threads: 10, prefetch: 20 });
+  });
+});
+
+describe('jobsSchedulerShape', () => {
+  it('enabled defaults to false', () => {
+    expect(jobsSchedulerShape.parse({}).enabled).toBe(false);
+  });
+});
+
+describe('jobsDomainRefreshShape — defaults and bounds', () => {
+  it('fills every default on empty input', () => {
+    const result = jobsDomainRefreshShape.parse({});
+    expect(result.enabled).toBe(false);
+    expect(result.check_interval).toBe('30m');
+    expect(result.batch_size).toBe(200);
+    expect(result.rate_limit).toBe(0.5);
+  });
+
+  it('rejects non-positive batch_size', () => {
+    expect(() => jobsDomainRefreshShape.parse({ batch_size: 0 })).toThrow();
+  });
+
+  it('accepts zero rate_limit (nonnegative bound)', () => {
+    expect(() => jobsDomainRefreshShape.parse({ rate_limit: 0 })).not.toThrow();
+  });
+
+  it('rejects negative rate_limit', () => {
+    expect(() => jobsDomainRefreshShape.parse({ rate_limit: -0.1 })).toThrow();
+  });
+});
+
+describe('jobsExpirationWarningsShape — defaults and bounds', () => {
+  it('fills every default on empty input', () => {
+    const result = jobsExpirationWarningsShape.parse({});
+    expect(result.enabled).toBe(false);
+    expect(result.check_interval).toBe('1h');
+    expect(result.warning_hours).toBe(24);
+    expect(result.min_ttl_hours).toBe(48);
+    expect(result.batch_size).toBe(100);
+  });
+
+  it.each([
+    ['warning_hours', 0],
+    ['min_ttl_hours', -1],
+    ['batch_size', 0],
+  ])('rejects %s = %s on the shape', (field, value) => {
+    expect(() => jobsExpirationWarningsShape.parse({ [field]: value })).toThrow();
+  });
+});
+
+describe('jobsMaintenanceShape — every sub-job tree applies defaults', () => {
+  it('phantom_cleanup defaults', () => {
+    const result = jobsMaintenanceShape.parse({ phantom_cleanup: {} });
+    expect(result.phantom_cleanup).toEqual({
+      enabled: false,
+      interval: '1h',
+      batch_size: 500,
+      auto_repair: false,
+    });
+  });
+
+  it('data_audit defaults', () => {
+    const result = jobsMaintenanceShape.parse({ data_audit: {} });
+    expect(result.data_audit).toEqual({
+      enabled: false,
+      interval: '6h',
+      sample_size: 100,
+    });
+  });
+
+  it('participation_gc defaults', () => {
+    const result = jobsMaintenanceShape.parse({ participation_gc: {} });
+    expect(result.participation_gc).toEqual({
+      enabled: false,
+      cron: '0 5 * * *',
+      batch_size: 500,
+      auto_repair: false,
+    });
+  });
+
+  it('index_rebuild defaults', () => {
+    const result = jobsMaintenanceShape.parse({ index_rebuild: {} });
+    expect(result.index_rebuild).toEqual({
+      enabled: false,
+      cron: '0 4 * * *',
+      auto_repair: false,
+    });
+  });
+
+  it('instances_rebuild defaults', () => {
+    const result = jobsMaintenanceShape.parse({ instances_rebuild: {} });
+    expect(result.instances_rebuild).toEqual({
+      enabled: false,
+      cron: '0 3 * * 0',
+      auto_repair: false,
+    });
+  });
+
+  it('housekeeping defaults', () => {
+    const result = jobsMaintenanceShape.parse({ housekeeping: {} });
+    expect(result.housekeeping).toEqual({
+      enabled: false,
+      cron: '0 2 * * *',
+    });
+  });
+
+  it('enabled toggle on the top-level maintenance object defaults to false', () => {
+    expect(jobsMaintenanceShape.parse({}).enabled).toBe(false);
+  });
+
+  it('rejects non-positive batch_size on phantom_cleanup', () => {
+    expect(() =>
+      jobsMaintenanceShape.parse({ phantom_cleanup: { batch_size: 0 } })
+    ).toThrow();
+  });
+});
+
+describe('jobsShape — composed sub-trees', () => {
+  it('applies maintenance subtree defaults when nested objects are empty', () => {
+    const result = jobsShape.parse({
+      maintenance: { phantom_cleanup: {}, data_audit: {}, housekeeping: {} },
+    });
+    expect(result.maintenance?.phantom_cleanup?.interval).toBe('1h');
+    expect(result.maintenance?.data_audit?.sample_size).toBe(100);
+    expect(result.maintenance?.housekeeping?.cron).toBe('0 2 * * *');
+  });
+});

--- a/src/tests/schemas/shapes/config/jurisdiction.spec.ts
+++ b/src/tests/schemas/shapes/config/jurisdiction.spec.ts
@@ -1,0 +1,98 @@
+// src/tests/schemas/shapes/config/jurisdiction.spec.ts
+//
+// Coverage for the jurisdiction shape — the identifier length bounds
+// (2–24) and the `enabled` default. The contract carries neither.
+
+import { describe, it, expect } from 'vitest';
+import {
+  jurisdictionSchema,
+  regionsConfigSchema,
+} from '@/schemas/contracts/config/section/jurisdiction';
+import {
+  jurisdictionShape,
+  regionsConfigShape,
+  jurisdictionIconShape,
+  jurisdictionDetailsShape,
+} from '@/schemas/shapes/config/section/jurisdiction';
+
+const minimal = {
+  identifier: 'eu',
+  display_name_i18n_key: 'web.regions.eu',
+  domain: 'eu.example.com',
+};
+
+describe('jurisdictionShape — defaults', () => {
+  it('enabled defaults to true', () => {
+    expect(jurisdictionShape.parse(minimal).enabled).toBe(true);
+  });
+
+  it('contract leaves enabled undefined', () => {
+    expect(jurisdictionSchema.parse(minimal).enabled).toBeUndefined();
+  });
+
+  it('preserves caller-supplied enabled=false', () => {
+    expect(jurisdictionShape.parse({ ...minimal, enabled: false }).enabled).toBe(false);
+  });
+});
+
+describe('jurisdictionShape — identifier bounds (min 2, max 24)', () => {
+  it('accepts a two-character identifier (lower bound)', () => {
+    expect(() => jurisdictionShape.parse({ ...minimal, identifier: 'eu' })).not.toThrow();
+  });
+
+  it('accepts a 24-character identifier (upper bound)', () => {
+    expect(() =>
+      jurisdictionShape.parse({ ...minimal, identifier: 'a'.repeat(24) })
+    ).not.toThrow();
+  });
+
+  it('rejects a one-character identifier', () => {
+    expect(() => jurisdictionShape.parse({ ...minimal, identifier: 'x' })).toThrow();
+  });
+
+  it('rejects a 25-character identifier', () => {
+    expect(() =>
+      jurisdictionShape.parse({ ...minimal, identifier: 'a'.repeat(25) })
+    ).toThrow();
+  });
+
+  it('contract accepts the out-of-range identifiers the shape rejects', () => {
+    expect(() => jurisdictionSchema.parse({ ...minimal, identifier: 'x' })).not.toThrow();
+    expect(() =>
+      jurisdictionSchema.parse({ ...minimal, identifier: 'a'.repeat(25) })
+    ).not.toThrow();
+  });
+});
+
+describe('regionsConfigShape — identifier bounds (no enabled default)', () => {
+  const minimalRegion = {
+    identifier: 'eu',
+    enabled: true,
+    current_jurisdiction: 'eu',
+    jurisdictions: [minimal],
+  };
+
+  it('rejects one-character identifier on the shape', () => {
+    expect(() =>
+      regionsConfigShape.parse({ ...minimalRegion, identifier: 'x' })
+    ).toThrow();
+  });
+
+  it('contract accepts the same one-character identifier', () => {
+    expect(() =>
+      regionsConfigSchema.parse({ ...minimalRegion, identifier: 'x' })
+    ).not.toThrow();
+  });
+});
+
+describe('jurisdiction passthrough shapes', () => {
+  it('jurisdictionIconShape parses a populated icon', () => {
+    const result = jurisdictionIconShape.parse({ collection: 'flag', name: 'eu' });
+    expect(result).toEqual({ collection: 'flag', name: 'eu' });
+  });
+
+  it('jurisdictionDetailsShape parses booleans', () => {
+    const result = jurisdictionDetailsShape.parse({ is_default: true, is_current: false });
+    expect(result).toEqual({ is_default: true, is_current: false });
+  });
+});

--- a/src/tests/schemas/shapes/config/limits.spec.ts
+++ b/src/tests/schemas/shapes/config/limits.spec.ts
@@ -1,0 +1,33 @@
+// src/tests/schemas/shapes/config/limits.spec.ts
+//
+// The limits shape has no defaults or value constraints — each rate limit
+// is an optional number with a catchall for unknown keys. This is a
+// convention guard against silent drift.
+
+import { describe, it, expect } from 'vitest';
+import { limitsSchema } from '@/schemas/contracts/config/section/limits';
+import { limitsShape } from '@/schemas/shapes/config/section/limits';
+
+describe('limits shape — re-export convention', () => {
+  it('limitsShape is the contract schema (no augmentation)', () => {
+    expect(limitsShape).toBe(limitsSchema);
+  });
+
+  it('accepts known rate-limit keys with numeric values', () => {
+    const result = limitsShape.parse({
+      create_secret: 10,
+      show_secret: 100,
+    });
+    expect(result.create_secret).toBe(10);
+    expect(result.show_secret).toBe(100);
+  });
+
+  it('passes unknown keys through the catchall as numbers', () => {
+    const result = limitsShape.parse({ custom_op: 5 });
+    expect((result as Record<string, number>).custom_op).toBe(5);
+  });
+
+  it('rejects non-numeric values on catchall keys', () => {
+    expect(() => limitsShape.parse({ custom_op: 'lots' })).toThrow();
+  });
+});

--- a/src/tests/schemas/shapes/config/mail.spec.ts
+++ b/src/tests/schemas/shapes/config/mail.spec.ts
@@ -1,0 +1,113 @@
+// src/tests/schemas/shapes/config/mail.spec.ts
+//
+// Coverage for the mail shape — emailer (SMTP) defaults and port bounds,
+// truemail validation defaults, the static mailConnection block, and the
+// static mailValidation block.
+
+import { describe, it, expect } from 'vitest';
+import {
+  emailerSchema,
+  truemailSchema,
+  mailConnectionSchema,
+  mailValidationSchema,
+} from '@/schemas/contracts/config/section/mail';
+import {
+  emailerShape,
+  mailShape,
+  truemailShape,
+  mailConnectionShape,
+  mailValidationShape,
+} from '@/schemas/shapes/config/section/mail';
+
+describe('emailerShape — SMTP defaults and bounds', () => {
+  it('fills every documented default on empty input', () => {
+    const result = emailerShape.parse({});
+    expect(result.mode).toBe('smtp');
+    expect(result.from).toBe('CHANGEME@example.com');
+    expect(result.from_name).toBe('Support');
+    expect(result.host).toBe('smtp.provider.com');
+    expect(result.port).toBe(587);
+  });
+
+  it.each([
+    ['zero', 0],
+    ['negative', -25],
+    ['non-integer', 25.5],
+  ])('rejects %s port on the shape', (_label, value) => {
+    expect(() => emailerShape.parse({ port: value })).toThrow();
+  });
+
+  it('contract accepts the bad port values the shape rejects', () => {
+    expect(() => emailerSchema.parse({ port: 0 })).not.toThrow();
+    expect(() => emailerSchema.parse({ port: -25 })).not.toThrow();
+  });
+});
+
+describe('truemailShape — defaults and bounds', () => {
+  it('fills every documented default on empty input', () => {
+    const result = truemailShape.parse({});
+    expect(result.default_validation_type).toBe(':regex');
+    expect(result.verifier_email).toBe('CHANGEME@example.com');
+    expect(result.allowed_domains_only).toBe(false);
+    expect(result.dns).toEqual(['1.1.1.1', '8.8.4.4', '208.67.220.220']);
+    expect(result.smtp_port).toBeUndefined();
+    expect(result.smtp_fail_fast).toBe(false);
+    expect(result.smtp_safe_check).toBe(true);
+    expect(result.not_rfc_mx_lookup_flow).toBe(false);
+  });
+
+  it('logger sub-tree defaults are applied', () => {
+    const result = truemailShape.parse({ logger: {} });
+    expect(result.logger?.tracking_event).toBe(':error');
+    expect(result.logger?.stdout).toBe(true);
+  });
+
+  it('rejects non-positive smtp_port on the shape', () => {
+    expect(() => truemailShape.parse({ smtp_port: 0 })).toThrow();
+  });
+
+  it('contract leaves smtp_safe_check undefined', () => {
+    expect(truemailSchema.parse({}).smtp_safe_check).toBeUndefined();
+  });
+});
+
+describe('mailShape — composed', () => {
+  it('applies truemail sub-tree defaults when nested', () => {
+    const result = mailShape.parse({ truemail: { logger: {} } });
+    expect(result.truemail?.verifier_email).toBe('CHANGEME@example.com');
+    expect(result.truemail?.logger?.stdout).toBe(true);
+  });
+});
+
+describe('mailConnectionShape — defaults', () => {
+  it('fills every documented default on empty input', () => {
+    const result = mailConnectionShape.parse({});
+    expect(result.mode).toBe('smtp');
+    expect(result.auth).toBe('login');
+    expect(result.from).toBe('noreply@example.com');
+    expect(result.fromname).toBe('OneTimeSecret');
+  });
+
+  it('contract leaves auth undefined', () => {
+    expect(mailConnectionSchema.parse({}).auth).toBeUndefined();
+  });
+});
+
+describe('mailValidationShape — defaults', () => {
+  it('fills every documented default on empty input', () => {
+    const result = mailValidationShape.parse({});
+    expect(result.default_validation_type).toBe('mx');
+    expect(result.verifier_email).toBe('example@onetimesecret.dev');
+    expect(result.verifier_domain).toBe('onetimesecret.dev');
+  });
+
+  it('logger sub-tree defaults are applied', () => {
+    const result = mailValidationShape.parse({ logger: {} });
+    expect(result.logger?.tracking_event).toBe('all');
+    expect(result.logger?.stdout).toBe(true);
+  });
+
+  it('contract leaves verifier_email undefined', () => {
+    expect(mailValidationSchema.parse({}).verifier_email).toBeUndefined();
+  });
+});

--- a/src/tests/schemas/shapes/config/secret_options.spec.ts
+++ b/src/tests/schemas/shapes/config/secret_options.spec.ts
@@ -1,0 +1,111 @@
+// src/tests/schemas/shapes/config/secret_options.spec.ts
+//
+// Coverage for the secret_options shape — the per-user-type boundaries
+// schema (`secretOptionBoundariesShape`) carries every default and bound
+// (TTL 60s..30d, size up to 10MB) and is composed via
+// `z.record(UserTypeKeys, ...)` to form `secretOptionsShape`.
+
+import { describe, it, expect } from 'vitest';
+import { secretOptionBoundariesSchema } from '@/schemas/contracts/config/section/secret_options';
+import {
+  secretOptionBoundariesShape,
+  secretOptionsShape,
+} from '@/schemas/shapes/config/section/secret_options';
+
+describe('secretOptionBoundariesShape — defaults', () => {
+  it('applies default_ttl, ttl_options and size on empty input', () => {
+    const result = secretOptionBoundariesShape.parse({});
+    expect(result.default_ttl).toBe(604800);
+    expect(result.ttl_options).toEqual([
+      300, 1800, 3600, 14400, 43200, 86400, 259200, 604800, 1209600, 2592000,
+    ]);
+    expect(result.size).toBe(102400);
+  });
+
+  it('accepts null for default_ttl (preserves nullable wrapper)', () => {
+    const result = secretOptionBoundariesShape.parse({ default_ttl: null });
+    expect(result.default_ttl).toBeNull();
+  });
+
+  it('accepts null for ttl_options', () => {
+    const result = secretOptionBoundariesShape.parse({ ttl_options: null });
+    expect(result.ttl_options).toBeNull();
+  });
+
+  it('accepts null for size', () => {
+    const result = secretOptionBoundariesShape.parse({ size: null });
+    expect(result.size).toBeNull();
+  });
+});
+
+describe('secretOptionBoundariesShape — TTL bounds', () => {
+  it('rejects ttl_options entries below 60s', () => {
+    expect(() => secretOptionBoundariesShape.parse({ ttl_options: [30] })).toThrow();
+  });
+
+  it('rejects ttl_options entries above 30 days', () => {
+    expect(() => secretOptionBoundariesShape.parse({ ttl_options: [2592001] })).toThrow();
+  });
+
+  it('accepts boundary values 60s and 30 days', () => {
+    const result = secretOptionBoundariesShape.parse({ ttl_options: [60, 2592000] });
+    expect(result.ttl_options).toEqual([60, 2592000]);
+  });
+
+  it('rejects non-positive default_ttl', () => {
+    expect(() => secretOptionBoundariesShape.parse({ default_ttl: 0 })).toThrow();
+    expect(() => secretOptionBoundariesShape.parse({ default_ttl: -1 })).toThrow();
+  });
+
+  it('contract accepts the same bad TTL values', () => {
+    expect(() => secretOptionBoundariesSchema.parse({ default_ttl: -1 })).not.toThrow();
+    expect(() => secretOptionBoundariesSchema.parse({ ttl_options: [30] })).not.toThrow();
+  });
+});
+
+describe('secretOptionBoundariesShape — size bounds (1..10MB)', () => {
+  it('accepts the maximum size (10 MB)', () => {
+    expect(secretOptionBoundariesShape.parse({ size: 10485760 }).size).toBe(10485760);
+  });
+
+  it('rejects sizes above 10 MB', () => {
+    expect(() => secretOptionBoundariesShape.parse({ size: 10485761 })).toThrow();
+  });
+
+  it('rejects zero / negative sizes', () => {
+    expect(() => secretOptionBoundariesShape.parse({ size: 0 })).toThrow();
+    expect(() => secretOptionBoundariesShape.parse({ size: -1 })).toThrow();
+  });
+});
+
+describe('secretOptionsShape — record over user types', () => {
+  it('accepts a record keyed by every valid user type and applies per-entry defaults', () => {
+    const result = secretOptionsShape.parse({
+      anonymous: {},
+      authenticated: { default_ttl: 86400 },
+      standard: {},
+      enhanced: {},
+    });
+    expect(result.anonymous?.default_ttl).toBe(604800);
+    expect(result.anonymous?.size).toBe(102400);
+    expect(result.authenticated?.default_ttl).toBe(86400);
+    expect(result.standard?.size).toBe(102400);
+  });
+
+  it('rejects records missing a required user type', () => {
+    // `z.record(z.enum([...]), ...)` requires every enum key to be present.
+    expect(() => secretOptionsShape.parse({ anonymous: {} })).toThrow();
+  });
+
+  it('rejects records keyed by unknown user types', () => {
+    expect(() =>
+      secretOptionsShape.parse({
+        anonymous: {},
+        authenticated: {},
+        standard: {},
+        enhanced: {},
+        unknown_type: {},
+      })
+    ).toThrow();
+  });
+});

--- a/src/tests/schemas/shapes/config/site.spec.ts
+++ b/src/tests/schemas/shapes/config/site.spec.ts
@@ -1,0 +1,218 @@
+// src/tests/schemas/shapes/config/site.spec.ts
+//
+// Coverage for the site shape — the top-level fields plus the eight
+// nested sub-trees (authentication, session, middleware, security/csp,
+// passphrase, password_generation, siteSecretOptions). The `passphrase`
+// minimum_length bounds (0..256) and the password generation length
+// defaults are the load-bearing pieces consumers rely on; the rest is
+// boolean default coverage.
+
+import { describe, it, expect } from 'vitest';
+import {
+  siteSchema,
+  siteAuthenticationSchema,
+  sessionConfigSchema,
+} from '@/schemas/contracts/config/section/site';
+import {
+  siteShape,
+  siteAuthenticationShape,
+  siteSecretOptionsShape,
+  passphraseShape,
+  passwordGenerationShape,
+  sessionConfigShape,
+  middlewareShape,
+  securityShape,
+  cspShape,
+} from '@/schemas/shapes/config/section/site';
+
+describe('siteShape — top-level defaults', () => {
+  it('fills host and ssl on empty input', () => {
+    const result = siteShape.parse({});
+    expect(result.host).toBe('localhost:3000');
+    expect(result.ssl).toBe(false);
+  });
+
+  it('contract leaves host/ssl undefined', () => {
+    const c = siteSchema.parse({});
+    expect(c.host).toBeUndefined();
+    expect(c.ssl).toBeUndefined();
+  });
+});
+
+describe('siteAuthenticationShape — defaults', () => {
+  it('applies signup/signin/required/etc. defaults', () => {
+    const result = siteAuthenticationShape.parse({});
+    expect(result.enabled).toBe(true);
+    expect(result.signup).toBe(true);
+    expect(result.signin).toBe(true);
+    expect(result.autoverify).toBe(false);
+    expect(result.required).toBe(false);
+    expect(result.colonels).toEqual([]);
+    expect(result.allowed_signup_domains).toEqual([]);
+  });
+
+  it('contract leaves these fields undefined', () => {
+    const c = siteAuthenticationSchema.parse({});
+    expect(c.enabled).toBeUndefined();
+    expect(c.colonels).toBeUndefined();
+  });
+});
+
+describe('sessionConfigShape — defaults and bounds', () => {
+  it('fills expire_after, key, secure, same_site, httponly', () => {
+    const result = sessionConfigShape.parse({});
+    expect(result.expire_after).toBe(86400);
+    expect(result.key).toBe('onetime.session');
+    expect(result.secure).toBe(true);
+    expect(result.same_site).toBe('lax');
+    expect(result.httponly).toBe(true);
+  });
+
+  it('rejects non-positive expire_after on the shape', () => {
+    expect(() => sessionConfigShape.parse({ expire_after: 0 })).toThrow();
+    expect(() => sessionConfigShape.parse({ expire_after: -10 })).toThrow();
+  });
+
+  it('rejects non-integer expire_after on the shape', () => {
+    expect(() => sessionConfigShape.parse({ expire_after: 86400.5 })).toThrow();
+  });
+
+  it('contract accepts the same bad expire_after values', () => {
+    expect(() => sessionConfigSchema.parse({ expire_after: -1 })).not.toThrow();
+  });
+
+  it('rejects same_site values outside the enum', () => {
+    expect(() => sessionConfigShape.parse({ same_site: 'wide' })).toThrow();
+  });
+});
+
+describe('cspShape / securityShape', () => {
+  it('csp.enabled defaults to false', () => {
+    expect(cspShape.parse({}).enabled).toBe(false);
+  });
+
+  it('security composes csp', () => {
+    expect(securityShape.parse({ csp: {} }).csp?.enabled).toBe(false);
+  });
+});
+
+describe('middlewareShape — defaults', () => {
+  it('fills every middleware toggle', () => {
+    const result = middlewareShape.parse({});
+    expect(result.static_files).toBe(true);
+    expect(result.utf8_sanitizer).toBe(true);
+    expect(result.authenticity_token).toBe(true);
+    expect(result.http_origin).toBe(false);
+    expect(result.xss_header).toBe(false);
+    expect(result.frame_options).toBe(false);
+    expect(result.path_traversal).toBe(false);
+    expect(result.cookie_tossing).toBe(false);
+    expect(result.ip_spoofing).toBe(false);
+    expect(result.strict_transport).toBe(false);
+  });
+});
+
+describe('passphraseShape — defaults and bounds', () => {
+  it('fills required, minimum_length, maximum_length, enforce_complexity', () => {
+    const result = passphraseShape.parse({});
+    expect(result.required).toBe(false);
+    expect(result.minimum_length).toBe(4);
+    expect(result.maximum_length).toBe(128);
+    expect(result.enforce_complexity).toBe(false);
+  });
+
+  it('accepts minimum_length = 0 (no enforcement)', () => {
+    expect(passphraseShape.parse({ minimum_length: 0 }).minimum_length).toBe(0);
+  });
+
+  it('accepts minimum_length = 256 (upper bound)', () => {
+    expect(passphraseShape.parse({ minimum_length: 256 }).minimum_length).toBe(256);
+  });
+
+  it('rejects minimum_length > 256', () => {
+    expect(() => passphraseShape.parse({ minimum_length: 257 })).toThrow();
+  });
+
+  it('rejects negative minimum_length', () => {
+    expect(() => passphraseShape.parse({ minimum_length: -1 })).toThrow();
+  });
+
+  it('rejects non-positive maximum_length', () => {
+    expect(() => passphraseShape.parse({ maximum_length: 0 })).toThrow();
+  });
+});
+
+describe('passwordGenerationShape — defaults', () => {
+  it('fills default_length and character_sets defaults', () => {
+    const result = passwordGenerationShape.parse({ character_sets: {} });
+    expect(result.default_length).toBe(12);
+    expect(result.character_sets.uppercase).toBe(true);
+    expect(result.character_sets.lowercase).toBe(true);
+    expect(result.character_sets.numbers).toBe(true);
+    expect(result.character_sets.symbols).toBe(true);
+    expect(result.character_sets.exclude_ambiguous).toBe(true);
+  });
+
+  it('rejects non-positive default_length', () => {
+    expect(() =>
+      passwordGenerationShape.parse({ default_length: 0, character_sets: {} })
+    ).toThrow();
+  });
+});
+
+describe('siteSecretOptionsShape — bounds (no defaults at this level)', () => {
+  // siteSecretOptionsSchema requires `passphrase` and `password_generation`
+  // (they are NOT `.optional()` on the contract); every parse below supplies
+  // both as `character_sets: {}` to satisfy the nested character-set object.
+  const passphrase = {};
+  const password_generation = { character_sets: {} };
+
+  it('rejects negative generated_value_display_ttl', () => {
+    expect(() =>
+      siteSecretOptionsShape.parse({
+        generated_value_display_ttl: -1,
+        passphrase,
+        password_generation,
+      })
+    ).toThrow();
+  });
+
+  it('accepts zero generated_value_display_ttl (nonnegative)', () => {
+    const result = siteSecretOptionsShape.parse({
+      generated_value_display_ttl: 0,
+      passphrase,
+      password_generation,
+    });
+    expect(result.generated_value_display_ttl).toBe(0);
+  });
+
+  it('preserves nullable default_ttl', () => {
+    const result = siteSecretOptionsShape.parse({
+      default_ttl: null,
+      passphrase,
+      password_generation,
+    });
+    expect(result.default_ttl).toBeNull();
+  });
+
+  it('applies nested passphrase defaults when caller supplies empty object', () => {
+    const result = siteSecretOptionsShape.parse({ passphrase, password_generation });
+    expect(result.passphrase?.minimum_length).toBe(4);
+    expect(result.passphrase?.maximum_length).toBe(128);
+  });
+});
+
+describe('siteShape — composed sub-trees', () => {
+  it('applies authentication / session / middleware defaults end-to-end', () => {
+    const result = siteShape.parse({
+      authentication: {},
+      session: {},
+      middleware: {},
+      security: { csp: {} },
+    });
+    expect(result.authentication?.signup).toBe(true);
+    expect(result.session?.expire_after).toBe(86400);
+    expect(result.middleware?.static_files).toBe(true);
+    expect(result.security?.csp?.enabled).toBe(false);
+  });
+});

--- a/src/tests/schemas/shapes/config/storage.spec.ts
+++ b/src/tests/schemas/shapes/config/storage.spec.ts
@@ -1,0 +1,87 @@
+// src/tests/schemas/shapes/config/storage.spec.ts
+//
+// Coverage for the storage shape — Redis URI default, per-database
+// number bounds (0..15), and the wrapper `storage.db.connection.url`
+// default.
+
+import { describe, it, expect } from 'vitest';
+import {
+  redisDbsSchema,
+  redisSchema,
+  storageSchema,
+} from '@/schemas/contracts/config/section/storage';
+import {
+  redisDbsShape,
+  redisShape,
+  storageShape,
+} from '@/schemas/shapes/config/section/storage';
+
+describe('redisDbsShape — db number defaults and bounds', () => {
+  it('defaults every db field to 0 on empty input', () => {
+    const result = redisDbsShape.parse({});
+    expect(result.session).toBe(0);
+    expect(result.custom_domain).toBe(0);
+    expect(result.customer).toBe(0);
+    expect(result.metadata).toBe(0);
+    expect(result.secret).toBe(0);
+    expect(result.feedback).toBe(0);
+  });
+
+  it.each([
+    ['session', 0, true],
+    ['session', 15, true],
+    ['session', -1, false],
+    ['session', 16, false],
+    ['session', 7.5, false],
+  ])('%s = %s accepted? %s', (field, value, accepted) => {
+    const parse = () => redisDbsShape.parse({ [field]: value });
+    if (accepted) {
+      expect(parse).not.toThrow();
+    } else {
+      expect(parse).toThrow();
+    }
+  });
+
+  it('contract accepts db numbers outside 0..15', () => {
+    expect(() => redisDbsSchema.parse({ session: 16 })).not.toThrow();
+    expect(() => redisDbsSchema.parse({ session: -1 })).not.toThrow();
+  });
+});
+
+describe('redisShape — uri default', () => {
+  it('defaults uri on empty input', () => {
+    expect(redisShape.parse({}).uri).toBe('redis://127.0.0.1:6379');
+  });
+
+  it('contract leaves uri undefined', () => {
+    expect(redisSchema.parse({}).uri).toBeUndefined();
+  });
+
+  it('applies dbs sub-tree defaults when nested', () => {
+    const result = redisShape.parse({ dbs: {} });
+    expect(result.dbs?.session).toBe(0);
+  });
+
+  it('rejects out-of-range dbs entries through the composed shape', () => {
+    expect(() => redisShape.parse({ dbs: { session: 99 } })).toThrow();
+  });
+});
+
+describe('storageShape — connection url default', () => {
+  it('fills db.connection.url when the wrapper objects are present', () => {
+    const result = storageShape.parse({ db: { connection: {} } });
+    expect(result.db?.connection?.url).toBe('redis://localhost:6379');
+  });
+
+  it('contract leaves db.connection.url undefined', () => {
+    const c = storageSchema.parse({ db: { connection: {} } });
+    expect(c.db?.connection?.url).toBeUndefined();
+  });
+
+  it('preserves caller-supplied database_mapping passthrough', () => {
+    const result = storageShape.parse({
+      db: { connection: {}, database_mapping: { session: 1, customer: 2 } },
+    });
+    expect(result.db?.database_mapping).toEqual({ session: 1, customer: 2 });
+  });
+});

--- a/src/tests/schemas/shapes/config/ui.spec.ts
+++ b/src/tests/schemas/shapes/config/ui.spec.ts
@@ -1,0 +1,104 @@
+// src/tests/schemas/shapes/config/ui.spec.ts
+//
+// Coverage for the ui shape — top-level `ui`/`api` defaults plus the
+// homepage / header / footer_links / workspace_links sub-trees. The
+// capabilities / help / logo schemas are pass-throughs (no augmentation).
+
+import { describe, it, expect } from 'vitest';
+import { uiSchema } from '@/schemas/contracts/config/section/ui';
+import {
+  userInterfaceShape,
+  uiShape,
+  apiShape,
+  userInterfaceLogoShape,
+  userInterfaceHeaderShape,
+  userInterfaceFooterLinksShape,
+  userInterfaceHomepageShape,
+  uiCapabilitiesShape,
+  uiHelpShape,
+} from '@/schemas/shapes/config/section/ui';
+
+describe('uiShape — top-level defaults', () => {
+  it('enabled defaults to true', () => {
+    expect(uiShape.parse({}).enabled).toBe(true);
+  });
+
+  it('contract leaves enabled undefined', () => {
+    expect(uiSchema.parse({}).enabled).toBeUndefined();
+  });
+
+  it('applies homepage defaults when nested object provided', () => {
+    const result = uiShape.parse({ homepage: {} });
+    expect(result.homepage?.matching_cidrs).toEqual([]);
+    expect(result.homepage?.mode_header).toBe('O-Homepage-Mode');
+  });
+
+  it('applies header.enabled default', () => {
+    expect(uiShape.parse({ header: {} }).header?.enabled).toBe(true);
+  });
+
+  it('applies footer_links.enabled default', () => {
+    expect(uiShape.parse({ footer_links: {} }).footer_links?.enabled).toBe(false);
+  });
+
+  it('applies workspace_links.enabled default', () => {
+    expect(uiShape.parse({ workspace_links: {} }).workspace_links?.enabled).toBe(false);
+  });
+});
+
+describe('apiShape', () => {
+  it('enabled defaults to true', () => {
+    expect(apiShape.parse({}).enabled).toBe(true);
+  });
+});
+
+describe('userInterfaceHomepageShape — defaults', () => {
+  it('fills matching_cidrs and mode_header', () => {
+    const result = userInterfaceHomepageShape.parse({});
+    expect(result.matching_cidrs).toEqual([]);
+    expect(result.mode_header).toBe('O-Homepage-Mode');
+  });
+
+  it('leaves mode and public_links untouched', () => {
+    const result = userInterfaceHomepageShape.parse({});
+    expect(result.mode).toBeUndefined();
+    expect(result.public_links).toBeUndefined();
+  });
+});
+
+describe('userInterfaceHeaderShape', () => {
+  it('enabled defaults to true', () => {
+    expect(userInterfaceHeaderShape.parse({}).enabled).toBe(true);
+  });
+
+  it('preserves branding/navigation passthrough', () => {
+    const result = userInterfaceHeaderShape.parse({
+      branding: { site_name: 'OTS' },
+      navigation: { enabled: false },
+    });
+    expect(result.branding?.site_name).toBe('OTS');
+    expect(result.navigation?.enabled).toBe(false);
+  });
+});
+
+describe('userInterfaceFooterLinksShape', () => {
+  it('enabled defaults to false', () => {
+    expect(userInterfaceFooterLinksShape.parse({}).enabled).toBe(false);
+  });
+});
+
+describe('UI pass-through shapes (no augmentation)', () => {
+  it('logo / capabilities / help parse populated input verbatim', () => {
+    expect(userInterfaceLogoShape.parse({ url: '/img/logo.svg' }).url).toBe('/img/logo.svg');
+    expect(uiCapabilitiesShape.parse({ burn: true }).burn).toBe(true);
+    expect(uiHelpShape.parse({ enabled: false }).enabled).toBe(false);
+  });
+});
+
+describe('userInterfaceShape — combined ui + api', () => {
+  it('applies defaults to both branches when nested objects are empty', () => {
+    const result = userInterfaceShape.parse({ ui: {}, api: {} });
+    expect(result.ui?.enabled).toBe(true);
+    expect(result.api?.enabled).toBe(true);
+  });
+});

--- a/try/unit/models/custom_domain_signup_config_try.rb
+++ b/try/unit/models/custom_domain_signup_config_try.rb
@@ -416,6 +416,13 @@ end
 @smtp_config.valid_signup_email?('user@example.com')
 #=> true
 
+## smtp strategy rejects malformed email when Truemail raises (format check runs before Truemail)
+Truemail.define_singleton_method(:validate) do |_email, **_kwargs|
+  raise StandardError, 'SMTP connection refused'
+end
+@smtp_config.valid_signup_email?('not-an-email')
+#=> false
+
 # --- Verify Truemail.validate is invoked with custom_configuration kwarg ---
 #
 # The implementation must use custom_configuration: (per-call override) rather


### PR DESCRIPTION
Bundles several follow-up items from recent issues:

- **#3202** PATCH endpoint for partial signup config updates + set `signup_domain_id` during omniauth `Customer.create!`
- **#3221** ADR-013 documenting 4xx/5xx error response wire format; sweep of stale error-shape assertions across integration tryouts
- **#3212** Per-section shape coverage for all config schema sections (capabilities, features, mail, site, jobs, etc.) — 11 new spec files
- **#3203** SMTP symmetry for malformed-email variant when Truemail raises

Related to #3202, #3221, #3212, #3203