### PR TITLE
Refactor exception logging to use SemanticLogger exception field

### DIFF
--- a/apps/web/billing/cli/plans_materialize_command.rb
+++ b/apps/web/billing/cli/plans_materialize_command.rb
@@ -281,7 +281,7 @@ module Onetime
         end
 
         def format_membership(detail)
-          role = detail[:role] || 'member'
+          role = detail[:role]
           if detail[:status] == :ok
             "#{detail[:objid]} (role=#{role}, plan=#{detail[:planid]}): " \
               "#{detail[:entitlements_count]} entitlements"

--- a/apps/web/billing/operations/materialize_plans.rb
+++ b/apps/web/billing/operations/materialize_plans.rb
@@ -205,9 +205,7 @@ module Billing
         @errors << { org_extid: org.extid, reason: "Org write failed: #{ex.message}" }
         emit(:failed_org_write, org, planid: org.planid, reason: ex.message)
         logger.error 'Org write failed',
-          org_extid: org.extid, planid: org.planid, message: ex.message
-        logger.debug 'Org write failed (backtrace)',
-          org_extid: org.extid, backtrace: ex.backtrace&.join("\n")
+          org_extid: org.extid, planid: org.planid, exception: ex
       end
 
       # Cascade to memberships. Returns :ok or :failed.
@@ -238,10 +236,7 @@ module Billing
             logger.error 'Membership re-materialization failed',
               org_extid: org.extid,
               membership_objid: membership.objid,
-              message: ex.message
-            logger.debug 'Membership re-materialization failed (backtrace)',
-              membership_objid: membership.objid,
-              backtrace: ex.backtrace&.join("\n")
+              exception: ex
           end
         end
 
@@ -304,9 +299,7 @@ module Billing
         @errors << { org_extid: org.extid, reason: reason }
         emit(:failed_cascade, org, planid: org.planid, reason: reason)
         logger.error 'Cascade raised',
-          org_extid: org.extid, planid: org.planid, message: ex.message
-        logger.debug 'Cascade raised (backtrace)',
-          org_extid: org.extid, backtrace: ex.backtrace&.join("\n")
+          org_extid: org.extid, planid: org.planid, exception: ex
       end
 
       def emit(event, org, planid: nil, entitlements_count: nil, cascade: nil, reason: nil)

--- a/apps/web/billing/spec/cli/plans_materialize_command_integration_spec.rb
+++ b/apps/web/billing/spec/cli/plans_materialize_command_integration_spec.rb
@@ -1,0 +1,149 @@
+# apps/web/billing/spec/cli/plans_materialize_command_integration_spec.rb
+#
+# frozen_string_literal: true
+
+# Integration spec for `bin/ots billing plans materialize --include-memberships`.
+# Exercises the cascade end-to-end: real Redis, real Familia models, real plan
+# catalog loaded from spec/billing.test.yaml. The doubles-based unit specs in
+# spec/operations/materialize_plans_spec.rb prove the accounting invariants;
+# this spec proves the cascade actually writes to the membership documents.
+#
+# Run: pnpm run test:rspec apps/web/billing/spec/cli/plans_materialize_command_integration_spec.rb
+
+require_relative '../support/billing_spec_helper'
+require 'onetime/cli'
+require_relative '../../cli/plans_materialize_command'
+
+RSpec.describe 'Billing Plans Materialize CLI (integration)', :integration do
+  include_context 'with_test_plans'
+
+  subject(:command) { Onetime::CLI::BillingPlansMaterializeCommand.new }
+
+  before { allow(command).to receive(:boot_application!) }
+
+  def run_command(**kwargs)
+    old_stdout = $stdout
+    $stdout    = StringIO.new
+    command.call(**kwargs)
+    $stdout.string
+  ensure
+    $stdout = old_stdout
+  end
+
+  # Real Customer + Organization on identity_plus_v1. No materialization yet —
+  # that's what the command is supposed to do.
+  def create_org(display_name:, email_seed:)
+    email    = "plans-materialize-#{email_seed}@example.com"
+    customer = Onetime::Customer.create!(email: email)
+    org      = Onetime::Organization.create!(display_name, customer, email)
+    org.planid = 'identity_plus_v1'
+    org.save
+    [org, customer]
+  end
+
+  # Real OrganizationMembership via add_members_instance — the same path the
+  # operation's active_for_org lookup will find.
+  def add_member(org:, role:, email_seed:)
+    email    = "plans-materialize-mem-#{email_seed}@example.com"
+    customer = Onetime::Customer.create!(email: email)
+    org.add_members_instance(
+      customer,
+      through_attrs: {
+        role:      role,
+        status:    'active',
+        joined_at: Familia.now.to_f,
+      },
+    )
+  end
+
+  describe '--include-memberships --run' do
+    it 'writes membership entitlements as (org.entitlements ∩ ROLE_ENTITLEMENTS[role])' do
+      org, _owner = create_org(display_name: 'Cascade Co', email_seed: 'cascade')
+      admin       = add_member(org: org, role: 'admin',  email_seed: 'admin')
+      member      = add_member(org: org, role: 'member', email_seed: 'plain')
+
+      expect(admin.entitlements_materialized?).to be false
+      expect(member.entitlements_materialized?).to be false
+
+      output = run_command(all: true, include_memberships: true, run: true)
+
+      expect(output).to match(/Succeeded:\s+1/)
+      expect(output).to match(/Orgs cascaded:\s+1/)
+
+      org.refresh!
+      admin.refresh!
+      member.refresh!
+
+      expect(org.entitlements_materialized?).to be true
+      expect(admin.entitlements_materialized?).to be true
+      expect(member.entitlements_materialized?).to be true
+
+      # Role intersection: custom_domains is on the plan AND in the admin
+      # template but NOT the member template — admin must have it, member
+      # must not. This single contrast proves the intersection ran; broad
+      # plan-only entitlements (create_secrets, api_access) prove nothing
+      # about role filtering since both roles are entitled to them.
+      admin_ents  = admin.materialized_entitlements.to_a
+      member_ents = member.materialized_entitlements.to_a
+      expect(admin_ents).to      include('custom_domains')
+      expect(member_ents).not_to include('custom_domains')
+
+      # Owner-only entitlement granted by the plan must not leak down. This
+      # proves the template is a ceiling, not a floor.
+      expect(admin_ents).not_to include('custom_branding')
+    end
+
+    it 'does not touch membership entitlements when --include-memberships is omitted' do
+      org, _ = create_org(display_name: 'No Cascade Co', email_seed: 'no-cascade')
+      admin  = add_member(org: org, role: 'admin', email_seed: 'no-cascade-admin')
+
+      output = run_command(all: true, run: true)
+
+      expect(output).to match(/Succeeded:\s+1/)
+      expect(output).not_to include('Orgs cascaded:')
+
+      org.refresh!
+      admin.refresh!
+      expect(org.entitlements_materialized?).to be true
+      expect(admin.entitlements_materialized?).to be false
+    end
+
+    it 'counts the org as FAILED when any membership materialization raises' do
+      org, _   = create_org(display_name: 'Partial Cascade Co', email_seed: 'partial')
+      ok_mem   = add_member(org: org, role: 'member', email_seed: 'ok')
+      bad_mem  = add_member(org: org, role: 'admin',  email_seed: 'bad')
+
+      # Force one membership to raise during cascade. Stubs the loaded
+      # instances coming out of OrganizationMembership.active_for_org (which
+      # routes through load_multi). Coupled to the active_for_org loader
+      # contract — see organization_membership.rb#active_for_org. If that
+      # method ever changes its batch primitive, this fault injection needs
+      # to follow.
+      allow(Onetime::OrganizationMembership).to receive(:load_multi)
+        .and_wrap_original do |orig, *args|
+          loaded = orig.call(*args)
+          loaded.each do |m|
+            next unless m && m.objid == bad_mem.objid
+
+            allow(m).to receive(:materialize_for_role!).and_raise(StandardError, 'simulated boom')
+          end
+          loaded
+        end
+
+      output = run_command(all: true, include_memberships: true, run: true)
+
+      expect(output).to match(/Failed:\s+1/)
+      expect(output).to match(/Memberships failed:\s+1/)
+      expect(output).to include('membership failures')
+
+      org.refresh!
+      ok_mem.refresh!
+      # Org-level write happened before the cascade; the failure is purely
+      # in the cascade. The good membership still got materialized — the
+      # operation does not roll back partial cascade work. The org-level
+      # FAILED count is the operator-visible signal.
+      expect(org.entitlements_materialized?).to be true
+      expect(ok_mem.entitlements_materialized?).to be true
+    end
+  end
+end

--- a/apps/web/billing/spec/operations/materialize_plans_spec.rb
+++ b/apps/web/billing/spec/operations/materialize_plans_spec.rb
@@ -280,16 +280,19 @@ RSpec.describe Billing::Operations::MaterializePlans, :billing_cli do
         )
       end
 
-      it 'logs cascade failures at error level (paired with debug backtrace path)' do
+      it 'logs per-membership and aggregate cascade failures via SemanticLogger exception field' do
         memberships.each do |m|
           allow(m).to receive(:materialize_for_role!).and_raise(StandardError, 'mem boom')
         end
 
         described_class.call(include_memberships: true, iterator: iterator)
 
+        # `exception:` routes through SemanticLogger's `log.exception` slot so
+        # the production formatter's backtrace truncation (setup_loggers.rb)
+        # applies. A raw `backtrace:` payload field bypasses that policy.
         expect(fake_logger).to have_received(:error).with(
           'Membership re-materialization failed',
-          hash_including(:org_extid, :membership_objid, :message),
+          hash_including(:org_extid, :membership_objid, exception: kind_of(StandardError)),
         ).at_least(:once)
         expect(fake_logger).to have_received(:error).with(
           'Cascade had membership failures',
@@ -297,7 +300,7 @@ RSpec.describe Billing::Operations::MaterializePlans, :billing_cli do
         )
       end
 
-      it 'logs cascade exceptions at error level and emits a debug backtrace line' do
+      it 'logs cascade exceptions via SemanticLogger exception field (production-truncated)' do
         allow(Onetime::OrganizationMembership).to receive(:active_for_org)
           .and_raise(StandardError, 'kaboom')
 
@@ -305,11 +308,7 @@ RSpec.describe Billing::Operations::MaterializePlans, :billing_cli do
 
         expect(fake_logger).to have_received(:error).with(
           'Cascade raised',
-          hash_including(:org_extid, :message),
-        )
-        expect(fake_logger).to have_received(:debug).with(
-          'Cascade raised (backtrace)',
-          hash_including(:org_extid, :backtrace),
+          hash_including(:org_extid, exception: kind_of(StandardError)),
         )
       end
 

--- a/docs/tickets/materialize-plans-metrics-emission.md
+++ b/docs/tickets/materialize-plans-metrics-emission.md
@@ -1,0 +1,51 @@
+# Emit metrics from MaterializePlansResult for non-CLI callers
+
+**Status:** Drafted (blocked posting to GitHub on auth refresh). Follow-up to [#3251](https://github.com/onetimesecret/onetimesecret/issues/3251).
+
+**Labels:** improvement, backend, ruby
+
+---
+
+## Problem
+
+`Billing::Operations::MaterializePlans` ([#3253](https://github.com/onetimesecret/onetimesecret/pull/3253)) was extracted from the CLI command specifically so non-CLI callers — background jobs, rake tasks, future admin UIs — can run the same batch materialization with consistent accounting and logging.
+
+The operation returns a structured `MaterializePlansResult`:
+
+```ruby
+MaterializePlansResult = Data.define(
+  :scanned, :succeeded, :failed,
+  :skipped_no_plan, :skipped_plan_filter,
+  :memberships_succeeded, :memberships_failed, :orgs_cascaded,
+  :errors,
+)
+```
+
+Today this result is consumed by exactly one caller: the CLI's `ProgressRenderer`. Every non-CLI caller would have to manually wire StatsD/Prometheus emission to get the same operational visibility — and there's nothing forcing them to. Result: any background job that ever runs this operation in production will silently lack the metrics the CLI operator has been relying on.
+
+## Proposed change
+
+Emit metrics from inside `MaterializePlans#call` (or via a small `BillingMetrics` collaborator) so every caller — CLI, background job, future admin UI — gets the same counters automatically.
+
+At minimum:
+
+| Metric | Type | Tags |
+|---|---|---|
+| `billing.materialize_plans.orgs.scanned` | counter | `dry_run`, `cascade` |
+| `billing.materialize_plans.orgs.succeeded` | counter | `dry_run`, `cascade` |
+| `billing.materialize_plans.orgs.failed` | counter | `dry_run`, `cascade` |
+| `billing.materialize_plans.orgs.skipped` | counter | `reason` (`no_plan`, `plan_filter`) |
+| `billing.materialize_plans.memberships.succeeded` | counter | — |
+| `billing.materialize_plans.memberships.failed` | counter | — |
+| `billing.materialize_plans.duration_ms` | histogram | `cascade` |
+
+## Acceptance criteria
+
+- A background-job caller of `MaterializePlans.call(...)` emits the metrics above with no additional plumbing.
+- CLI behavior unchanged (renderer continues to consume the result; metrics fire in parallel).
+- The metrics backend is whatever the rest of the app uses (TBD — confirm before implementing; if there is no existing telemetry pipe, this ticket may need to wait for or land alongside one).
+
+## Out of scope
+
+- Tracing (OpenTelemetry spans).
+- Per-org timing breakdowns (the current granularity is the whole batch).


### PR DESCRIPTION
## Summary

Refactor exception logging in `MaterializePlans` operation to use SemanticLogger's `exception:` field instead of manually extracting `message:` and `backtrace:` fields. This ensures production logging formatters (e.g., `setup_loggers.rb`) can apply their backtrace truncation policies consistently across all exception logs.

**Changes:**
- Replace dual `logger.error` + `logger.debug` calls with single `logger.error` call using `exception: ex` parameter
- Update affected error paths: org write failures, membership materialization failures, and cascade exceptions
- Update corresponding specs to verify the `exception:` field is passed
- Fix CLI command to not default `role` to `'member'` when rendering membership details (was masking missing role data)
- Add integration spec (`plans_materialize_command_integration_spec.rb`) exercising the full cascade end-to-end with real Redis, Familia models, and test plan catalog
- Add follow-up ticket draft for metrics emission from `MaterializePlansResult`

## Related Issues

Follow-up to [#3253](https://github.com/onetimesecret/onetimesecret/pull/3253) (MaterializePlans operation extraction).

## Test Plan

- New integration spec covers the full cascade: org materialization + membership entitlements with role-based intersection
- Updated unit specs verify `exception:` field is passed to logger
- Existing CLI and operation tests continue to pass

https://claude.ai/code/session_01CLyAJJVtqFEkJmAReTGLiS