### PR TITLE
Implement ADR-013 error shape for Auth and Billing routers

### DIFF
--- a/apps/web/auth/error_translator.rb
+++ b/apps/web/auth/error_translator.rb
@@ -16,7 +16,10 @@ module Auth
   #
   # The status-code mapping intentionally parallels otto_hooks.rb. If a typed
   # exception's status changes in one place, it should change here as well.
-  # A future refactor may extract a shared registry consumed by both layers.
+  # Coverage symmetry as of this commit: RecordNotFound, MissingSecret,
+  # FormError, LimitExceeded, EntitlementRequired, GuestRoutesDisabled,
+  # Forbidden, Unauthorized are registered in BOTH layers. A future refactor
+  # may extract a shared registry consumed by both layers.
   #
   # This module is pure: input is an Exception, output is a [status, body_hash]
   # pair. It performs no logging, no i18n resolution, and no IO. The caller is

--- a/apps/web/auth/error_translator.rb
+++ b/apps/web/auth/error_translator.rb
@@ -1,0 +1,107 @@
+# apps/web/auth/error_translator.rb
+#
+# frozen_string_literal: true
+
+require 'onetime/errors'
+
+module Auth
+  # Translates typed Onetime exceptions into ADR-013 wire-shape responses
+  # ({ error, error_type, ...class-specific fields }).
+  #
+  # The Auth app runs on Roda, not Otto. Otto-based apps register their typed
+  # exception handlers via Onetime::Application::OttoHooks#configure_otto_request_hook;
+  # Roda has no equivalent register-by-class mechanism, so this module fills
+  # the same role for the Auth Router via Roda's :error_handler plugin
+  # (see apps/web/auth/router.rb).
+  #
+  # The status-code mapping intentionally parallels otto_hooks.rb. If a typed
+  # exception's status changes in one place, it should change here as well.
+  # A future refactor may extract a shared registry consumed by both layers.
+  #
+  # This module is pure: input is an Exception, output is a [status, body_hash]
+  # pair. It performs no logging, no i18n resolution, and no IO. The caller is
+  # responsible for any auth-layer logging.
+  module ErrorTranslator
+    # HTTP status codes for typed Onetime exceptions. Lookup is exact-class
+    # first, then ancestor walk for subclasses not directly registered.
+    STATUS_BY_CLASS = {
+      Onetime::MissingSecret       => 404,
+      Onetime::RecordNotFound      => 404,
+      Onetime::FormError           => 422,
+      Onetime::LimitExceeded       => 429,
+      Onetime::EntitlementRequired => 403,
+      Onetime::GuestRoutesDisabled => 403,
+      Onetime::Forbidden           => 403,
+      Onetime::Unauthorized        => 401,
+    }.freeze
+
+    DEFAULT_STATUS     = 500
+    DEFAULT_ERROR_TYPE = 'ServerError'
+    DEFAULT_MESSAGE    = 'Internal Server Error'
+
+    # ADR-013 body for router-level 404 fallbacks (status_handler(404) and
+    # the route-block catch-all in apps/web/auth/router.rb). Single source of
+    # truth so the two paths cannot drift; the integration spec pins it.
+    NOT_FOUND_BODY = { error: 'Not Found', error_type: 'NotFound' }.freeze
+
+    # Translate an exception into a [status, body_hash] pair per ADR-013.
+    # body_hash is suitable for direct return from a Roda route body (the
+    # :json plugin serializes hashes).
+    #
+    # @param exception [Exception]
+    # @return [Array(Integer, Hash)]
+    def self.translate(exception)
+      [status_for(exception), body_for(exception)]
+    end
+
+    # @param exception [Exception]
+    # @return [Integer] HTTP status code
+    def self.status_for(exception)
+      STATUS_BY_CLASS[exception.class] || ancestor_status(exception) || DEFAULT_STATUS
+    end
+
+    # @param exception [Exception]
+    # @return [Hash] ADR-013 body hash
+    def self.body_for(exception)
+      return generic_body unless known_typed?(exception)
+
+      # Typed Onetime::Problem and Onetime::Forbidden subclasses define a
+      # purpose-built #to_h that returns the ADR-013 shape with any
+      # class-specific fields (field, retry_after, entitlement, etc.).
+      return exception.to_h if exception.respond_to?(:to_h) &&
+                               (exception.is_a?(Onetime::Problem) ||
+                                exception.is_a?(Onetime::Forbidden))
+
+      # Onetime::Unauthorized is a marker class with no #to_h. The message
+      # is caller-supplied and not sensitive at the auth boundary (e.g.
+      # 'Invalid credentials').
+      { error: exception.message, error_type: short_class_name(exception) }
+    end
+
+    def self.ancestor_status(exception)
+      STATUS_BY_CLASS.each_pair do |klass, status|
+        return status if exception.is_a?(klass)
+      end
+      nil
+    end
+    private_class_method :ancestor_status
+
+    # An exception is "typed" iff it is an instance (or subclass) of a class
+    # in STATUS_BY_CLASS. Tying the typed-check to the same source of truth
+    # as the status mapping prevents drift.
+    def self.known_typed?(exception)
+      STATUS_BY_CLASS.each_key.any? { |klass| exception.is_a?(klass) }
+    end
+    private_class_method :known_typed?
+
+    def self.generic_body
+      { error: DEFAULT_MESSAGE, error_type: DEFAULT_ERROR_TYPE }
+    end
+    private_class_method :generic_body
+
+    def self.short_class_name(exception)
+      exception.class.name.to_s.split('::').last
+    end
+    private_class_method :short_class_name
+  end
+end

--- a/apps/web/auth/error_translator.rb
+++ b/apps/web/auth/error_translator.rb
@@ -68,12 +68,13 @@ module Auth
     def self.body_for(exception)
       return generic_body unless known_typed?(exception)
 
-      # Typed Onetime::Problem and Onetime::Forbidden subclasses define a
-      # purpose-built #to_h that returns the ADR-013 shape with any
-      # class-specific fields (field, retry_after, entitlement, etc.).
-      return exception.to_h if exception.respond_to?(:to_h) &&
-                               (exception.is_a?(Onetime::Problem) ||
-                                exception.is_a?(Onetime::Forbidden))
+      # Typed Onetime exceptions in STATUS_BY_CLASS that define #to_h
+      # (Onetime::Problem and Onetime::Forbidden subclasses) return their
+      # purpose-built ADR-013 hash with class-specific fields (field,
+      # retry_after, entitlement, etc.). Using respond_to? rather than
+      # explicit is_a? checks avoids drift as new typed exceptions are
+      # registered.
+      return exception.to_h if exception.respond_to?(:to_h)
 
       # Onetime::Unauthorized is a marker class with no #to_h. The message
       # is caller-supplied and not sensitive at the auth boundary (e.g.
@@ -81,19 +82,22 @@ module Auth
       { error: exception.message, error_type: short_class_name(exception) }
     end
 
+    # Walk the exception's actual inheritance chain (not STATUS_BY_CLASS
+    # iteration order) so the lookup is robust to hash reordering and
+    # returns the closest ancestor's status.
     def self.ancestor_status(exception)
-      STATUS_BY_CLASS.each_pair do |klass, status|
-        return status if exception.is_a?(klass)
+      exception.class.ancestors.each do |ancestor|
+        return STATUS_BY_CLASS[ancestor] if STATUS_BY_CLASS.key?(ancestor)
       end
       nil
     end
     private_class_method :ancestor_status
 
-    # An exception is "typed" iff it is an instance (or subclass) of a class
-    # in STATUS_BY_CLASS. Tying the typed-check to the same source of truth
+    # An exception is "typed" iff one of its ancestors is a key in
+    # STATUS_BY_CLASS. Tying the typed-check to the same source of truth
     # as the status mapping prevents drift.
     def self.known_typed?(exception)
-      STATUS_BY_CLASS.each_key.any? { |klass| exception.is_a?(klass) }
+      exception.class.ancestors.any? { |ancestor| STATUS_BY_CLASS.key?(ancestor) }
     end
     private_class_method :known_typed?
 

--- a/apps/web/auth/error_translator.rb
+++ b/apps/web/auth/error_translator.rb
@@ -28,17 +28,35 @@ module Auth
     # HTTP status codes for typed Onetime exceptions. Lookup is exact-class
     # first, then ancestor walk for subclasses not directly registered.
     STATUS_BY_CLASS = {
-      Onetime::MissingSecret       => 404,
-      Onetime::RecordNotFound      => 404,
-      Onetime::FormError           => 422,
-      Onetime::LimitExceeded       => 429,
+      Onetime::MissingSecret => 404,
+      Onetime::RecordNotFound => 404,
+      Onetime::FormError => 422,
+      Onetime::LimitExceeded => 429,
       Onetime::EntitlementRequired => 403,
       Onetime::GuestRoutesDisabled => 403,
-      Onetime::Forbidden           => 403,
-      Onetime::Unauthorized        => 401,
+      Onetime::Forbidden => 403,
+      Onetime::Unauthorized => 401,
+    }.freeze
+
+    # Per-class log severity for translated exceptions. Mirrors the
+    # `log_level:` values passed to `router.register_error_handler` in
+    # `lib/onetime/application/otto_hooks.rb` so the Roda Auth app and Otto
+    # apps emit at the same level for the same exception class. Exceptions
+    # not present here fall back to DEFAULT_LOG_LEVEL (the unhandled-500
+    # path; matches Otto's `structured_log(:error, 'Unhandled error …')`).
+    LOG_LEVEL_BY_CLASS = {
+      Onetime::MissingSecret => :info,
+      Onetime::RecordNotFound => :info,
+      Onetime::FormError => :info,
+      Onetime::LimitExceeded => :warn,
+      Onetime::EntitlementRequired => :info,
+      Onetime::GuestRoutesDisabled => :info,
+      Onetime::Forbidden => :warn,
+      Onetime::Unauthorized => :warn,
     }.freeze
 
     DEFAULT_STATUS     = 500
+    DEFAULT_LOG_LEVEL  = :error
     DEFAULT_ERROR_TYPE = 'ServerError'
     DEFAULT_MESSAGE    = 'Internal Server Error'
 
@@ -61,6 +79,12 @@ module Auth
     # @return [Integer] HTTP status code
     def self.status_for(exception)
       STATUS_BY_CLASS[exception.class] || ancestor_status(exception) || DEFAULT_STATUS
+    end
+
+    # @param exception [Exception]
+    # @return [Symbol] Log severity (:info, :warn, :error)
+    def self.level_for(exception)
+      LOG_LEVEL_BY_CLASS[exception.class] || ancestor_level(exception) || DEFAULT_LOG_LEVEL
     end
 
     # @param exception [Exception]
@@ -92,6 +116,14 @@ module Auth
       nil
     end
     private_class_method :ancestor_status
+
+    def self.ancestor_level(exception)
+      exception.class.ancestors.each do |ancestor|
+        return LOG_LEVEL_BY_CLASS[ancestor] if LOG_LEVEL_BY_CLASS.key?(ancestor)
+      end
+      nil
+    end
+    private_class_method :ancestor_level
 
     # An exception is "typed" iff one of its ancestors is a key in
     # STATUS_BY_CLASS. Tying the typed-check to the same source of truth

--- a/apps/web/auth/router.rb
+++ b/apps/web/auth/router.rb
@@ -11,6 +11,7 @@ require 'json'
 require 'onetime/logger_methods'
 
 require_relative 'config'
+require_relative 'error_translator'
 require_relative 'routes/account'
 require_relative 'routes/active_sessions'
 require_relative 'routes/mfa'
@@ -49,9 +50,33 @@ module Auth
     # Use its Config class for all authentication configuration.
     plugin :rodauth, auth_class: Auth::Config
 
-    # Status handlers
+    # Translate typed Onetime exceptions to ADR-013 wire shape
+    # ({ error, error_type, ...class-specific }) when they propagate out of a
+    # route block. Additive: existing per-route `rescue StandardError` blocks
+    # still intercept first, so this handler only fires for exceptions that
+    # escape them — typically typed exceptions raised from routes that have
+    # been converted to the typed-raise pattern.
+    #
+    # Rodauth's own auth-flow errors are caught inside Rodauth before
+    # propagating here and are unaffected.
+    #
+    # The body is JSON-serialized in-line rather than relying on `plugin :json`
+    # auto-wrapping the :error_handler return value; that interaction depends
+    # on plugin load order and is brittle. Serializing here keeps the wire
+    # shape correct regardless of plugin layering.
+    plugin :error_handler do |e|
+      status, body = Auth::ErrorTranslator.translate(e)
+      response.status           = status
+      response['content-type']  = 'application/json'
+      body.to_json
+    end
+
+    # Both router-level 404 paths (status_handler and the route-block
+    # catch-all below) return Auth::ErrorTranslator::NOT_FOUND_BODY so they
+    # cannot drift apart. The spec at
+    # apps/web/auth/spec/integration/router_error_shape_spec.rb pins the shape.
     status_handler(404) do
-      { error: 'Not found' }
+      Auth::ErrorTranslator::NOT_FOUND_BODY
     end
 
     # Main routing logic
@@ -92,9 +117,9 @@ module Auth
 
       handle_health_routes(r)
 
-      # Catch-all for undefined routes
+      # Catch-all for undefined routes (ADR-013 shape; shared with status_handler(404))
       response.status = 404
-      { error: 'Endpoint not found' }
+      Auth::ErrorTranslator::NOT_FOUND_BODY
     end
 
     # # Returns the current customer from session or nil (anonymous)

--- a/apps/web/auth/router.rb
+++ b/apps/web/auth/router.rb
@@ -64,8 +64,19 @@ module Auth
     # auto-wrapping the :error_handler return value; that interaction depends
     # on plugin load order and is brittle. Serializing here keeps the wire
     # shape correct regardless of plugin layering.
+    #
+    # Logging: 500s log at :error with backtrace so production failures are
+    # not silent (Roda's :error_handler does not log by default). Translated
+    # typed exceptions log at :info — they are expected outcomes (404/422/
+    # 401/403/429), not bugs.
     plugin :error_handler do |e|
       status, body = Auth::ErrorTranslator.translate(e)
+      if status >= 500
+        auth_logger.error 'Auth router unhandled exception', exception: e
+      else
+        auth_logger.info 'Auth router translated exception',
+          exception_class: e.class.name, status: status
+      end
       response.status           = status
       response['content-type']  = 'application/json'
       body.to_json

--- a/apps/web/auth/router.rb
+++ b/apps/web/auth/router.rb
@@ -67,18 +67,26 @@ module Auth
     #
     # Logging: 500s log at :error with backtrace so production failures are
     # not silent (Roda's :error_handler does not log by default). Translated
-    # typed exceptions log at :info — they are expected outcomes (404/422/
-    # 401/403/429), not bugs.
+    # typed exceptions log at the per-class level from
+    # Auth::ErrorTranslator::LOG_LEVEL_BY_CLASS, which mirrors the
+    # `log_level:` values passed to `register_error_handler` in
+    # `lib/onetime/application/otto_hooks.rb`. That keeps the Roda Auth app
+    # and Otto apps emitting at the same level for the same exception class.
     plugin :error_handler do |e|
-      status, body = Auth::ErrorTranslator.translate(e)
+      status, body             = Auth::ErrorTranslator.translate(e)
       if status >= 500
         auth_logger.error 'Auth router unhandled exception', exception: e
       else
-        auth_logger.info 'Auth router translated exception',
-          exception_class: e.class.name, status: status
+        level = Auth::ErrorTranslator.level_for(e)
+        auth_logger.public_send(
+          level,
+          'Auth router translated exception',
+          exception_class: e.class.name,
+          status: status,
+        )
       end
-      response.status           = status
-      response['content-type']  = 'application/json'
+      response.status          = status
+      response['content-type'] = 'application/json'
       body.to_json
     end
 

--- a/apps/web/auth/spec/integration/full/omniauth_account_creation_spec.rb
+++ b/apps/web/auth/spec/integration/full/omniauth_account_creation_spec.rb
@@ -139,6 +139,72 @@ RSpec.describe 'after_omniauth_create_account operations', type: :integration do
       expect(found.custid).to eq(customer1.custid)
     end
 
+    # Regression guard for the immutability rule documented on CreateCustomer:
+    # signup_domain_id and provisioning_origin are set only when the customer
+    # is first created and must not be rewritten on subsequent SSO logins.
+    # Before PR #3237 the omniauth callback overwrote signup_domain_id after
+    # every SSO login via a custom domain; the fix moved the assignment into
+    # the initial create! and relies on the existing-customer branch being a
+    # no-op for these fields. If that guard is reverted, this spec fails.
+    it 'preserves signup_domain_id on subsequent calls for an existing customer' do
+      email = unique_test_email('signup-domain-immutable')
+      account = create_test_account(email: email)
+      original_domain_id = "domain-original-#{SecureRandom.hex(4)}"
+      different_domain_id = "domain-different-#{SecureRandom.hex(4)}"
+
+      # First call: customer is created with the original signup_domain_id
+      customer1 = Auth::Operations::CreateCustomer.new(
+        account_id: account[:id],
+        account: account,
+        signup_domain_id: original_domain_id,
+      ).call
+      created_customers << customer1
+      expect(customer1.signup_domain_id).to eq(original_domain_id)
+
+      # Second call: same email, different signup_domain_id (simulates a
+      # subsequent SSO login arriving via a different custom domain).
+      customer2 = Auth::Operations::CreateCustomer.new(
+        account_id: account[:id],
+        account: account,
+        signup_domain_id: different_domain_id,
+      ).call
+
+      # Same customer record, original signup_domain_id intact.
+      expect(customer2.custid).to eq(customer1.custid)
+      expect(customer2.signup_domain_id).to eq(original_domain_id)
+
+      # Reload from Redis to confirm nothing was persisted under the new value.
+      reloaded = Onetime::Customer.load(customer1.custid)
+      expect(reloaded.signup_domain_id).to eq(original_domain_id)
+    end
+
+    it 'preserves provisioning_origin on subsequent calls for an existing customer' do
+      email = unique_test_email('provisioning-origin-immutable')
+      account = create_test_account(email: email)
+
+      # First call seeds the customer as an SSO JIT signup.
+      customer1 = Auth::Operations::CreateCustomer.new(
+        account_id: account[:id],
+        account: account,
+        provisioning_origin: 'sso_jit',
+      ).call
+      created_customers << customer1
+      expect(customer1.provisioning_origin).to eq('sso_jit')
+
+      # A later call must not relabel the provisioning origin.
+      customer2 = Auth::Operations::CreateCustomer.new(
+        account_id: account[:id],
+        account: account,
+        provisioning_origin: 'canonical_signup',
+      ).call
+
+      expect(customer2.custid).to eq(customer1.custid)
+      expect(customer2.provisioning_origin).to eq('sso_jit')
+
+      reloaded = Onetime::Customer.load(customer1.custid)
+      expect(reloaded.provisioning_origin).to eq('sso_jit')
+    end
+
     it 'sets default role to customer (not admin or colonel)' do
       email = unique_test_email('default-role')
       account = create_test_account(email: email)

--- a/apps/web/auth/spec/integration/router_error_shape_spec.rb
+++ b/apps/web/auth/spec/integration/router_error_shape_spec.rb
@@ -1,0 +1,214 @@
+# apps/web/auth/spec/integration/router_error_shape_spec.rb
+#
+# frozen_string_literal: true
+
+# =============================================================================
+# TEST TYPE: Integration (wiring) + Unit (translator)
+# =============================================================================
+#
+# Regression guard for ADR-013 on the Auth Router.
+#
+# The Auth app runs on Roda, not Otto. Typed Onetime exceptions are mapped to
+# the ADR-013 wire shape by Auth::ErrorTranslator and wired into the router
+# via Roda's :error_handler plugin.
+#
+# This spec covers two layers:
+#
+#   1. ErrorTranslator (pure unit) — per-exception status + body assertions.
+#   2. Wiring (integration) — a stub Roda app that wires the translator the
+#      same way Auth::Router does, exercised via Rack::Test. If the wiring
+#      pattern stops working in a Roda upgrade or refactor, this fails.
+#
+# A separate at-the-edge HTTP test against Auth::Router is intentionally
+# omitted: booting the production router requires AUTHENTICATION_MODE=full and
+# Rodauth's full DB plumbing, and the value-add over the stub app is small.
+# The status_handler(404) and route-block catch-all shapes are short enough
+# to defend by code review; this spec pins their underlying contract via
+# direct hash literal comparisons.
+#
+# RUN:
+#   pnpm run test:rspec apps/web/auth/spec/integration/router_error_shape_spec.rb
+#
+# =============================================================================
+
+require_relative '../spec_helper'
+require 'rack/test'
+require 'roda'
+require 'json'
+require_relative '../../error_translator'
+
+RSpec.describe 'Auth Router ADR-013 error shape' do
+  # ---------------------------------------------------------------------------
+  # ErrorTranslator unit tests
+  # ---------------------------------------------------------------------------
+  describe Auth::ErrorTranslator do
+    it 'translates Onetime::RecordNotFound to 404 with class name' do
+      status, body = described_class.translate(Onetime::RecordNotFound.new('missing'))
+      expect(status).to eq(404)
+      expect(body).to include(error: 'missing', error_type: 'RecordNotFound')
+    end
+
+    it 'translates Onetime::MissingSecret (subclass of RecordNotFound) to 404' do
+      status, body = described_class.translate(Onetime::MissingSecret.new('gone'))
+      expect(status).to eq(404)
+      expect(body[:error_type]).to eq('RecordNotFound')
+    end
+
+    it 'translates Onetime::FormError to 422 carrying field and error_type' do
+      ex = Onetime::FormError.new('invalid email', field: 'email', error_type: 'FormError')
+      status, body = described_class.translate(ex)
+      expect(status).to eq(422)
+      expect(body).to include(error: 'invalid email', error_type: 'FormError', field: 'email')
+    end
+
+    it 'translates Onetime::Forbidden to 403' do
+      status, body = described_class.translate(Onetime::Forbidden.new('denied'))
+      expect(status).to eq(403)
+      expect(body).to include(error: 'denied', error_type: 'Forbidden')
+    end
+
+    it 'translates Onetime::LimitExceeded to 429 carrying retry_after' do
+      ex = Onetime::LimitExceeded.new('slow down', retry_after: 60, attempts: 5, max_attempts: 5)
+      status, body = described_class.translate(ex)
+      expect(status).to eq(429)
+      expect(body).to include(error_type: 'LimitExceeded', retry_after: 60, attempts: 5, max_attempts: 5)
+    end
+
+    it 'translates Onetime::EntitlementRequired to 403 carrying upgrade path' do
+      ex = Onetime::EntitlementRequired.new(:api_access, current_plan: 'free', upgrade_to: 'pro')
+      status, body = described_class.translate(ex)
+      expect(status).to eq(403)
+      expect(body).to include(error_type: 'EntitlementRequired',
+                              entitlement: :api_access,
+                              current_plan: 'free',
+                              upgrade_to: 'pro')
+    end
+
+    it 'translates Onetime::GuestRoutesDisabled to 403 carrying code' do
+      ex = Onetime::GuestRoutesDisabled.new('disabled', code: 'GUEST_CONCEAL_DISABLED')
+      status, body = described_class.translate(ex)
+      expect(status).to eq(403)
+      expect(body).to include(error_type: 'GuestRoutesDisabled', code: 'GUEST_CONCEAL_DISABLED')
+    end
+
+    it 'translates Onetime::Unauthorized to 401 using the caller message' do
+      status, body = described_class.translate(Onetime::Unauthorized.new('Invalid credentials'))
+      expect(status).to eq(401)
+      expect(body).to eq(error: 'Invalid credentials', error_type: 'Unauthorized')
+    end
+
+    it 'translates an unknown exception to a generic 500 without leaking the message' do
+      status, body = described_class.translate(StandardError.new('internal detail'))
+      expect(status).to eq(500)
+      # The caller message must NOT appear in the response body.
+      expect(body).to eq(error: 'Internal Server Error', error_type: 'ServerError')
+    end
+
+    it 'falls back to 500 for nil-class edge cases (defensive)' do
+      # Bare Exception is not a known type and falls through to the default.
+      status, body = described_class.translate(Exception.new('explode'))
+      expect(status).to eq(500)
+      expect(body[:error_type]).to eq('ServerError')
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Wiring test
+  #
+  # Stub Roda app mirrors the production Auth::Router wiring of
+  # `plugin :error_handler` + `Auth::ErrorTranslator.translate`. If the
+  # plugin contract changes (e.g. Roda renames :error_handler) or our
+  # block stops setting the response correctly, this fails.
+  # ---------------------------------------------------------------------------
+  describe 'Roda :error_handler plugin wiring' do
+    include Rack::Test::Methods
+
+    let(:app) do
+      # Mirror Auth::Router's :error_handler wiring exactly. Do NOT add
+      # plugin :json here — production explicitly JSON-encodes inside the
+      # error_handler block to avoid plugin-order coupling. Testing the same
+      # pattern guards against regressions in that contract.
+      Class.new(Roda) do
+        plugin :error_handler do |e|
+          status, body = Auth::ErrorTranslator.translate(e)
+          response.status           = status
+          response['content-type']  = 'application/json'
+          body.to_json
+        end
+
+        route do |r|
+          r.get('record-not-found') { raise Onetime::RecordNotFound, 'missing' }
+          r.get('form-error') do
+            raise Onetime::FormError.new('bad email', field: 'email', error_type: 'FormError')
+          end
+          r.get('forbidden')   { raise Onetime::Forbidden, 'denied' }
+          r.get('rate-limit')  { raise Onetime::LimitExceeded.new('slow', retry_after: 60) }
+          r.get('unknown')     { raise StandardError, 'leaky internal' }
+        end
+      end
+    end
+
+    it 'returns 404 ADR-013 shape for a route raising RecordNotFound' do
+      get '/record-not-found'
+      expect(last_response.status).to eq(404)
+      expect(last_response.content_type).to include('application/json')
+      body = JSON.parse(last_response.body)
+      expect(body).to include('error' => 'missing', 'error_type' => 'RecordNotFound')
+    end
+
+    it 'returns 422 ADR-013 shape with field for FormError' do
+      get '/form-error'
+      expect(last_response.status).to eq(422)
+      body = JSON.parse(last_response.body)
+      expect(body).to include('error' => 'bad email',
+                              'error_type' => 'FormError',
+                              'field' => 'email')
+    end
+
+    it 'returns 403 ADR-013 shape for Forbidden' do
+      get '/forbidden'
+      expect(last_response.status).to eq(403)
+      body = JSON.parse(last_response.body)
+      expect(body).to include('error' => 'denied', 'error_type' => 'Forbidden')
+    end
+
+    it 'returns 429 ADR-013 shape with retry_after for LimitExceeded' do
+      get '/rate-limit'
+      expect(last_response.status).to eq(429)
+      body = JSON.parse(last_response.body)
+      expect(body).to include('error_type' => 'LimitExceeded', 'retry_after' => 60)
+    end
+
+    it 'returns a generic 500 for unknown exceptions without leaking the message' do
+      get '/unknown'
+      expect(last_response.status).to eq(500)
+      body = JSON.parse(last_response.body)
+      expect(body).to eq('error' => 'Internal Server Error', 'error_type' => 'ServerError')
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Router-level 404 fallback contract
+  #
+  # Auth::Router has two 404 paths:
+  #   - status_handler(404)            (Roda plugin entry)
+  #   - route-block catch-all          (`response.status = 404; ...`)
+  #
+  # Both reference the same constant — Auth::ErrorTranslator::NOT_FOUND_BODY —
+  # so they cannot drift apart. This spec pins the constant's shape; if a
+  # future change re-inlines a literal in either site, code review catches
+  # it (the constant becomes unused).
+  # ---------------------------------------------------------------------------
+  describe 'router-level 404 fallback constant' do
+    it 'Auth::ErrorTranslator::NOT_FOUND_BODY has ADR-013 shape' do
+      expect(Auth::ErrorTranslator::NOT_FOUND_BODY).to eq(
+        error: 'Not Found',
+        error_type: 'NotFound',
+      )
+    end
+
+    it 'Auth::ErrorTranslator::NOT_FOUND_BODY is frozen (cannot be mutated by routing)' do
+      expect(Auth::ErrorTranslator::NOT_FOUND_BODY).to be_frozen
+    end
+  end
+end

--- a/apps/web/auth/spec/router_error_shape_spec.rb
+++ b/apps/web/auth/spec/router_error_shape_spec.rb
@@ -108,6 +108,58 @@ RSpec.describe 'Auth Router ADR-013 error shape' do
       expect(status).to eq(500)
       expect(body[:error_type]).to eq('ServerError')
     end
+
+    # -------------------------------------------------------------------------
+    # level_for: per-class log severity (mirrors otto_hooks.rb `log_level:`)
+    # -------------------------------------------------------------------------
+    describe '.level_for' do
+      it 'returns :info for RecordNotFound (matches otto_hooks)' do
+        expect(described_class.level_for(Onetime::RecordNotFound.new('x'))).to eq(:info)
+      end
+
+      it 'returns :info for MissingSecret (direct key, like RecordNotFound)' do
+        expect(described_class.level_for(Onetime::MissingSecret.new('x'))).to eq(:info)
+      end
+
+      it 'falls back to a registered ancestor when the exact class is unregistered' do
+        # Anonymous subclass of Forbidden — not present in LOG_LEVEL_BY_CLASS,
+        # so lookup must walk ancestors and return Forbidden's :warn.
+        subclass = Class.new(Onetime::Forbidden)
+        expect(described_class.level_for(subclass.new('x'))).to eq(:warn)
+      end
+
+      it 'returns :info for FormError' do
+        ex = Onetime::FormError.new('x', field: 'f', error_type: 'FormError')
+        expect(described_class.level_for(ex)).to eq(:info)
+      end
+
+      it 'returns :warn for Forbidden (matches otto_hooks)' do
+        expect(described_class.level_for(Onetime::Forbidden.new('x'))).to eq(:warn)
+      end
+
+      it 'returns :warn for LimitExceeded (matches otto_hooks)' do
+        ex = Onetime::LimitExceeded.new('x', retry_after: 1)
+        expect(described_class.level_for(ex)).to eq(:warn)
+      end
+
+      it 'returns :warn for Unauthorized (matches otto_hooks)' do
+        expect(described_class.level_for(Onetime::Unauthorized.new('x'))).to eq(:warn)
+      end
+
+      it 'returns :info for EntitlementRequired' do
+        ex = Onetime::EntitlementRequired.new(:api_access)
+        expect(described_class.level_for(ex)).to eq(:info)
+      end
+
+      it 'returns :info for GuestRoutesDisabled' do
+        ex = Onetime::GuestRoutesDisabled.new('x', code: 'X')
+        expect(described_class.level_for(ex)).to eq(:info)
+      end
+
+      it 'falls back to :error for unknown exceptions (matches otto unhandled path)' do
+        expect(described_class.level_for(StandardError.new('x'))).to eq(:error)
+      end
+    end
   end
 
   # ---------------------------------------------------------------------------

--- a/apps/web/auth/spec/router_error_shape_spec.rb
+++ b/apps/web/auth/spec/router_error_shape_spec.rb
@@ -1,9 +1,9 @@
-# apps/web/auth/spec/integration/router_error_shape_spec.rb
+# apps/web/auth/spec/router_error_shape_spec.rb
 #
 # frozen_string_literal: true
 
 # =============================================================================
-# TEST TYPE: Integration (wiring) + Unit (translator)
+# TEST TYPE: Unit (translator) + Wiring (stub Roda app)
 # =============================================================================
 #
 # Regression guard for ADR-013 on the Auth Router.
@@ -15,27 +15,25 @@
 # This spec covers two layers:
 #
 #   1. ErrorTranslator (pure unit) — per-exception status + body assertions.
-#   2. Wiring (integration) — a stub Roda app that wires the translator the
-#      same way Auth::Router does, exercised via Rack::Test. If the wiring
-#      pattern stops working in a Roda upgrade or refactor, this fails.
+#   2. Wiring — a stub Roda app that mirrors production Auth::Router
+#      configuration (plugin order, body encoding), exercised via Rack::Test.
+#      If the wiring pattern stops working in a Roda upgrade or refactor,
+#      this fails.
 #
-# A separate at-the-edge HTTP test against Auth::Router is intentionally
-# omitted: booting the production router requires AUTHENTICATION_MODE=full and
-# Rodauth's full DB plumbing, and the value-add over the stub app is small.
-# The status_handler(404) and route-block catch-all shapes are short enough
-# to defend by code review; this spec pins their underlying contract via
-# direct hash literal comparisons.
+# Lives at apps/web/auth/spec/ root (not under integration/) because the
+# spec needs no Valkey, no DB, and no full-mode boot — the auth spec_helper
+# gates integration helpers and DB flushing on type: :integration tag.
 #
 # RUN:
-#   pnpm run test:rspec apps/web/auth/spec/integration/router_error_shape_spec.rb
+#   pnpm run test:rspec apps/web/auth/spec/router_error_shape_spec.rb
 #
 # =============================================================================
 
-require_relative '../spec_helper'
+require_relative 'spec_helper'
 require 'rack/test'
 require 'roda'
 require 'json'
-require_relative '../../error_translator'
+require_relative '../error_translator'
 
 RSpec.describe 'Auth Router ADR-013 error shape' do
   # ---------------------------------------------------------------------------
@@ -124,11 +122,17 @@ RSpec.describe 'Auth Router ADR-013 error shape' do
     include Rack::Test::Methods
 
     let(:app) do
-      # Mirror Auth::Router's :error_handler wiring exactly. Do NOT add
-      # plugin :json here — production explicitly JSON-encodes inside the
-      # error_handler block to avoid plugin-order coupling. Testing the same
-      # pattern guards against regressions in that contract.
+      # Mirror Auth::Router's plugin order EXACTLY:
+      #   plugin :json, parser: true     <- loaded first
+      #   plugin :error_handler          <- loaded after :json
+      # The error_handler block explicitly .to_json's the body so that the
+      # wire shape is invariant under future Roda plugin-order changes. If
+      # someone removes the manual encoding believing :json will wrap the
+      # error_handler return value, the production app may silently break
+      # under a Roda upgrade — this spec proves the current contract works
+      # with the actual plugin layering.
       Class.new(Roda) do
+        plugin :json, parser: true
         plugin :error_handler do |e|
           status, body = Auth::ErrorTranslator.translate(e)
           response.status           = status

--- a/apps/web/billing/application.rb
+++ b/apps/web/billing/application.rb
@@ -75,10 +75,26 @@ module Billing
       # Billing endpoints require session auth except webhooks
       Core::AuthStrategies.register_essential(router)
 
-      # Default error responses
-      headers             = { 'content-type' => 'text/html' }
-      router.not_found    = [404, headers, ['Not Found']]
-      router.server_error = [500, headers, ['Internal Server Error']]
+      # Default error responses per ADR-013 (4xx/5xx wire format).
+      # Schema: { error: string, error_type: string }
+      # - `error` is the user-facing message displayed by the frontend
+      # - `error_type` is the discriminator the frontend branches on (Ruby class name)
+      #
+      # Typed Onetime exceptions raised from logic classes are rendered by the
+      # per-class handlers registered above in configure_otto_request_hook.
+      # These router-level defaults catch routing-layer 404s (no matching route)
+      # and uncaught 500s (exceptions Otto's handlers don't cover).
+      headers             = { 'content-type' => 'application/json' }
+      router.not_found    = [
+        404,
+        headers,
+        [{ error: 'Not Found', error_type: 'NotFound' }.to_json],
+      ]
+      router.server_error = [
+        500,
+        headers,
+        [{ error: 'Internal Server Error', error_type: 'ServerError' }.to_json],
+      ]
 
       router
     end

--- a/lib/onetime/application/otto_hooks.rb
+++ b/lib/onetime/application/otto_hooks.rb
@@ -85,6 +85,15 @@ module Onetime
           error.to_h
         end
 
+        # Unauthorized errors return 401. Onetime::Unauthorized is a marker
+        # class (no #to_h); messages are caller-supplied and verified
+        # non-sensitive across call sites ('Invalid credentials',
+        # 'Not authorized to update this receipt'). Symmetric with
+        # Auth::ErrorTranslator so the Roda and Otto layers agree.
+        router.register_error_handler(Onetime::Unauthorized, status: 401, log_level: :warn) do |error, _req|
+          { error: error.message, error_type: 'Unauthorized' }
+        end
+
         return unless Onetime.debug?
 
         router.on_request_complete do |req, res, duration|

--- a/spec/integration/api/error_response_shape_spec.rb
+++ b/spec/integration/api/error_response_shape_spec.rb
@@ -131,16 +131,17 @@ RSpec.describe 'API error response wire format (ADR-013)', type: :integration do
   # We do, however, assert the *configured* shape directly to guard against
   # someone editing only the server_error line without exercising it.
   # ---------------------------------------------------------------------------
-  describe 'router.server_error fallback (config-level assertion)' do
-    # Build router instances the same way the apps do, then inspect the
-    # configured server_error tuple. This sidesteps the need to trigger a
-    # real 500 over HTTP while still pinning the wire shape.
-    def configured_server_error(app_class)
-      app = app_class.new
-      router = app.send(:build_router)
-      router.server_error
-    end
+  # Build router instances the same way the apps do, then inspect the
+  # configured server_error tuple. This sidesteps the need to trigger a
+  # real 500 over HTTP while still pinning the wire shape. Defined at the
+  # outer describe so sibling examples (Billing) can reuse it.
+  def configured_server_error(app_class)
+    app = app_class.new
+    router = app.send(:build_router)
+    router.server_error
+  end
 
+  describe 'router.server_error fallback (config-level assertion)' do
     it 'V3 (BaseJSONAPI) emits ADR-013 shape on 500' do
       status, headers, body = configured_server_error(V3::Application)
       expect(status).to eq(500)
@@ -177,14 +178,15 @@ RSpec.describe 'API error response wire format (ADR-013)', type: :integration do
   # billing config, so we inspect the constructed router tuples directly.
   # ---------------------------------------------------------------------------
   describe 'Billing router fallbacks (config-level assertion)' do
-    let(:router) do
+    # Build the router once for the describe. Per-example `let` would rebuild
+    # the full middleware/initializer stack on each it-block.
+    before(:all) do
       require_relative '../../../apps/web/billing/application'
-      app = Billing::Application.new
-      app.send(:build_router)
+      @billing_router = Billing::Application.new.send(:build_router)
     end
 
     it 'emits ADR-013 shape on router.not_found' do
-      status, headers, body = router.not_found
+      status, headers, body = @billing_router.not_found
       expect(status).to eq(404)
       expect(headers['content-type']).to include('application/json')
       expect(JSON.parse(body.first)).to eq(
@@ -194,7 +196,7 @@ RSpec.describe 'API error response wire format (ADR-013)', type: :integration do
     end
 
     it 'emits ADR-013 shape on router.server_error' do
-      status, headers, body = router.server_error
+      status, headers, body = @billing_router.server_error
       expect(status).to eq(500)
       expect(headers['content-type']).to include('application/json')
       expect(JSON.parse(body.first)).to eq(
@@ -203,10 +205,9 @@ RSpec.describe 'API error response wire format (ADR-013)', type: :integration do
       )
     end
 
-    it 'Billing not_found body matches V2/V3 byte-for-byte' do
-      _, _, billing_body = router.not_found
-      _, _, v2_body      = configured_server_error(V2::Application) # reuse helper
-      # Different content (Not Found vs Internal Server Error) so do a key check:
+    it 'Billing not_found body has the same ADR-013 key set as V2' do
+      _, _, billing_body = @billing_router.not_found
+      _, _, v2_body      = configured_server_error(V2::Application)
       expect(JSON.parse(billing_body.first).keys.sort).to eq(%w[error error_type])
       expect(JSON.parse(v2_body.first).keys.sort).to eq(%w[error error_type])
     end

--- a/spec/integration/api/error_response_shape_spec.rb
+++ b/spec/integration/api/error_response_shape_spec.rb
@@ -167,4 +167,53 @@ RSpec.describe 'API error response wire format (ADR-013)', type: :integration do
       expect(v2_body.first).to eq(v3_body.first)
     end
   end
+
+  # ---------------------------------------------------------------------------
+  # Billing (Otto-based; configured in Billing::Application#build_router)
+  #
+  # Billing already wires OttoHooks for typed-exception handlers; the gap was
+  # the router-level not_found/server_error defaults, which previously emitted
+  # text/html. Same config-level pattern as V2/V3 above — boot is gated by
+  # billing config, so we inspect the constructed router tuples directly.
+  # ---------------------------------------------------------------------------
+  describe 'Billing router fallbacks (config-level assertion)' do
+    let(:router) do
+      require_relative '../../../apps/web/billing/application'
+      app = Billing::Application.new
+      app.send(:build_router)
+    end
+
+    it 'emits ADR-013 shape on router.not_found' do
+      status, headers, body = router.not_found
+      expect(status).to eq(404)
+      expect(headers['content-type']).to include('application/json')
+      expect(JSON.parse(body.first)).to eq(
+        'error'      => 'Not Found',
+        'error_type' => 'NotFound',
+      )
+    end
+
+    it 'emits ADR-013 shape on router.server_error' do
+      status, headers, body = router.server_error
+      expect(status).to eq(500)
+      expect(headers['content-type']).to include('application/json')
+      expect(JSON.parse(body.first)).to eq(
+        'error'      => 'Internal Server Error',
+        'error_type' => 'ServerError',
+      )
+    end
+
+    it 'Billing not_found body matches V2/V3 byte-for-byte' do
+      _, _, billing_body = router.not_found
+      _, _, v2_body      = configured_server_error(V2::Application) # reuse helper
+      # Different content (Not Found vs Internal Server Error) so do a key check:
+      expect(JSON.parse(billing_body.first).keys.sort).to eq(%w[error error_type])
+      expect(JSON.parse(v2_body.first).keys.sort).to eq(%w[error error_type])
+    end
+  end
+
+# Auth Router (Roda-based) is covered by a dedicated spec:
+# apps/web/auth/spec/integration/router_error_shape_spec.rb
+# (kept separate because Auth depends on AUTHENTICATION_MODE=full and Rodauth
+# setup; mixing it into this cross-app spec would couple unrelated boot paths).
 end


### PR DESCRIPTION
## Summary

Standardizes error response shapes across Auth (Roda-based) and Billing (Otto-based) routers to comply with ADR-013, ensuring consistent `{ error, error_type, ...class-specific }` JSON responses for all 4xx/5xx errors.

### Changes

**Auth Router (Roda)**
- Added `Auth::ErrorTranslator` module to translate typed `Onetime::*` exceptions into ADR-013 wire shape
- Wired `ErrorTranslator` into Auth::Router via Roda's `:error_handler` plugin
- Updated router-level 404 handlers to use `ErrorTranslator::NOT_FOUND_BODY` constant (prevents drift between `status_handler(404)` and route-block catch-all)
- Added comprehensive spec (`apps/web/auth/spec/router_error_shape_spec.rb`) covering both the translator unit logic and Roda wiring integration

**Billing Router (Otto)**
- Updated `router.not_found` and `router.server_error` defaults from `text/html` to `application/json` with ADR-013 shape
- Added config-level assertions in the integration spec to pin the wire format

**Otto Hooks**
- Registered `Onetime::Unauthorized` handler (status 401) to maintain symmetry between Roda and Otto layers

**Integration Tests**
- Extended `spec/integration/api/error_response_shape_spec.rb` with Billing router fallback assertions
- Added regression guards in `omniauth_account_creation_spec.rb` for `signup_domain_id` and `provisioning_origin` immutability

### Design Notes

- `ErrorTranslator` is pure (no logging, no I/O) and mirrors the status-code mapping in `otto_hooks.rb` for consistency
- Auth spec is isolated at `apps/web/auth/spec/` (not under `integration/`) because it requires no DB or Valkey
- Router-level 404 body is a frozen constant to prevent accidental mutation and ensure both 404 paths stay in sync
- Error handler serializes JSON in-line rather than relying on plugin auto-wrapping to avoid brittle plugin-order dependencies

## Related Issues

## Test Plan

- New unit tests in `apps/web/auth/spec/router_error_shape_spec.rb` cover `ErrorTranslator` logic and Roda wiring
- New integration assertions in `spec/integration/api/error_response_shape_spec.rb` verify Billing router fallbacks
- Existing Auth integration tests pass with new error handling in place
- CI validates all specs pass

https://claude.ai/code/session_01WLkYPRTkqMYqtM5KmYHjU5