### PR TITLE
Replace OT::Problem with Onetime::Forbidden for access control

### DIFF
--- a/apps/web/billing/controllers/base.rb
+++ b/apps/web/billing/controllers/base.rb
@@ -199,10 +199,15 @@ module Billing
       # @param extid [String] Organization external identifier
       # @param require_owner [Boolean] If true, require current user to be owner
       # @return [Onetime::Organization] Loaded organization
-      # @raise [OT::Problem] If organization not found or access denied
+      # @raise [Onetime::Forbidden] If organization not found, caller is not a
+      #   member, or owner access is required and caller is not an owner.
+      #   All three conditions return 403 deliberately: returning 404 for
+      #   "organization not found" would let an unauthenticated probe
+      #   distinguish real extids from random ones. The handler in
+      #   OttoHooks#configure_otto_request_hook renders the ADR-013 wire shape.
       def load_organization(extid, require_owner: false)
         org = Onetime::Organization.find_by_extid(extid)
-        raise OT::Problem, 'Organization not found' unless org
+        raise Onetime::Forbidden, 'Organization not found' unless org
 
         is_member = org.member?(cust)
         is_owner  = org.owner?(cust)
@@ -213,7 +218,7 @@ module Billing
               extid: extid,
               user: cust.extid,
             }
-          raise OT::Problem, 'Access denied'
+          raise Onetime::Forbidden, 'Access denied'
         end
 
         # Self-heal: owner exists in org hash but missing from members sorted set.
@@ -244,7 +249,7 @@ module Billing
               extid: extid,
               user: cust.extid,
             }
-          raise OT::Problem, 'Owner access required'
+          raise Onetime::Forbidden, 'Owner access required'
         end
 
         org

--- a/apps/web/billing/controllers/billing.rb
+++ b/apps/web/billing/controllers/billing.rb
@@ -45,10 +45,11 @@ module Billing
         end
 
         json_response(data)
-      rescue OT::Problem
-        # Propagate to centralized OttoHooks handler (ADR-013). Listed
-        # explicitly so the StandardError clause below doesn't catch it
-        # and downgrade typed business-rule errors to 500.
+      rescue Onetime::Forbidden
+        # Propagate to OttoHooks Forbidden handler (ADR-013 → 403). Listed
+        # before StandardError so the catch-all below doesn't downgrade
+        # typed access-control errors to 500 (Onetime::Forbidden inherits
+        # from RuntimeError, not OT::Problem, so it's a StandardError).
         raise
       rescue StandardError => ex
         billing_logger.error 'Failed to load billing overview',
@@ -754,8 +755,8 @@ module Billing
           }
 
         json_response({ success: true })
-      rescue OT::Problem
-        # Propagate to centralized OttoHooks handler (ADR-013).
+      rescue Onetime::Forbidden
+        # Propagate to OttoHooks Forbidden handler (ADR-013 → 403).
         raise
       rescue StandardError => ex
         billing_logger.error 'Failed to dismiss federation notification',

--- a/apps/web/billing/controllers/billing.rb
+++ b/apps/web/billing/controllers/billing.rb
@@ -45,9 +45,9 @@ module Billing
         end
 
         json_response(data)
-      rescue OT::Problem => ex
-        json_error(ex.message, status: 403)
       rescue StandardError => ex
+        raise if ex.is_a?(OT::Problem)
+
         billing_logger.error 'Failed to load billing overview',
           {
             exception: ex,
@@ -209,8 +209,6 @@ module Billing
             session_id: checkout_session.id,
           },
         )
-      rescue OT::Problem => ex
-        json_error(ex.message, status: 403)
       rescue Stripe::InvalidRequestError => ex
         if Billing::CurrencyMigrationService.currency_conflict?(ex)
           currencies = Billing::CurrencyMigrationService.parse_currency_conflict(
@@ -329,8 +327,6 @@ module Billing
             has_more: invoices.has_more,
           },
         )
-      rescue OT::Problem => ex
-        json_error(ex.message, status: 403)
       rescue Stripe::StripeError => ex
         billing_logger.error 'Failed to retrieve invoices',
           {
@@ -444,8 +440,6 @@ module Billing
         enrich_with_pending_migration!(data, org)
 
         json_response(data)
-      rescue OT::Problem => ex
-        json_error(ex.message, status: 403)
       rescue Stripe::StripeError => ex
         billing_logger.error 'Failed to retrieve subscription status',
           {
@@ -559,8 +553,6 @@ module Billing
             actual_next_billing_due: actual_next_billing_due, # What they'll actually pay at next billing
           },
         )
-      rescue OT::Problem => ex
-        json_error(ex.message, status: 403)
       rescue Stripe::InvalidRequestError => ex
         billing_logger.warn 'Invalid plan change preview request',
           {
@@ -720,8 +712,6 @@ module Billing
             current_period_end: updated_subscription.items.data.first.current_period_end,
           },
         )
-      rescue OT::Problem => ex
-        json_error(ex.message, status: 403)
       rescue Stripe::InvalidRequestError => ex
         billing_logger.warn 'Invalid plan change request',
           {
@@ -761,9 +751,9 @@ module Billing
           }
 
         json_response({ success: true })
-      rescue OT::Problem => ex
-        json_error(ex.message, status: 403)
       rescue StandardError => ex
+        raise if ex.is_a?(OT::Problem)
+
         billing_logger.error 'Failed to dismiss federation notification',
           {
             exception: ex,
@@ -810,8 +800,6 @@ module Billing
             status: canceled_subscription.status,
           },
         )
-      rescue OT::Problem => ex
-        json_error(ex.message, status: 403)
       rescue Stripe::InvalidRequestError => ex
         billing_logger.warn 'Invalid subscription cancellation request',
           {
@@ -873,8 +861,6 @@ module Billing
             status: updated_subscription.status,
           },
         )
-      rescue OT::Problem => ex
-        json_error(ex.message, status: 403)
       rescue Stripe::InvalidRequestError => ex
         billing_logger.warn 'Invalid subscription reactivation request',
           {
@@ -957,8 +943,6 @@ module Billing
         else
           json_response({ currency_mismatch: false })
         end
-      rescue OT::Problem => ex
-        json_error(ex.message, status: 403)
       rescue Stripe::StripeError => ex
         billing_logger.error 'Currency migration check failed',
           {
@@ -1047,8 +1031,6 @@ module Billing
           }
 
         json_response(result)
-      rescue OT::Problem => ex
-        json_error(ex.message, status: 403)
       rescue Stripe::InvalidRequestError => ex
         billing_logger.warn 'Currency migration request failed',
           {

--- a/apps/web/billing/controllers/billing.rb
+++ b/apps/web/billing/controllers/billing.rb
@@ -45,9 +45,12 @@ module Billing
         end
 
         json_response(data)
+      rescue OT::Problem
+        # Propagate to centralized OttoHooks handler (ADR-013). Listed
+        # explicitly so the StandardError clause below doesn't catch it
+        # and downgrade typed business-rule errors to 500.
+        raise
       rescue StandardError => ex
-        raise if ex.is_a?(OT::Problem)
-
         billing_logger.error 'Failed to load billing overview',
           {
             exception: ex,
@@ -751,9 +754,10 @@ module Billing
           }
 
         json_response({ success: true })
+      rescue OT::Problem
+        # Propagate to centralized OttoHooks handler (ADR-013).
+        raise
       rescue StandardError => ex
-        raise if ex.is_a?(OT::Problem)
-
         billing_logger.error 'Failed to dismiss federation notification',
           {
             exception: ex,

--- a/apps/web/billing/controllers/entitlements.rb
+++ b/apps/web/billing/controllers/entitlements.rb
@@ -55,9 +55,10 @@ module Billing
         }
 
         json_response(data)
+      rescue OT::Problem
+        # Propagate to centralized OttoHooks handler (ADR-013).
+        raise
       rescue StandardError => ex
-        raise if ex.is_a?(OT::Problem)
-
         billing_logger.error 'Failed to load entitlements',
           {
             exception: ex,
@@ -124,9 +125,10 @@ module Billing
         end
 
         json_response(result)
+      rescue OT::Problem
+        # Propagate to centralized OttoHooks handler (ADR-013).
+        raise
       rescue StandardError => ex
-        raise if ex.is_a?(OT::Problem)
-
         billing_logger.error 'Failed entitlement check',
           {
             exception: ex,

--- a/apps/web/billing/controllers/entitlements.rb
+++ b/apps/web/billing/controllers/entitlements.rb
@@ -55,9 +55,9 @@ module Billing
         }
 
         json_response(data)
-      rescue OT::Problem => ex
-        json_error(ex.message, status: 403)
       rescue StandardError => ex
+        raise if ex.is_a?(OT::Problem)
+
         billing_logger.error 'Failed to load entitlements',
           {
             exception: ex,
@@ -124,9 +124,9 @@ module Billing
         end
 
         json_response(result)
-      rescue OT::Problem => ex
-        json_error(ex.message, status: 403)
       rescue StandardError => ex
+        raise if ex.is_a?(OT::Problem)
+
         billing_logger.error 'Failed entitlement check',
           {
             exception: ex,

--- a/apps/web/billing/controllers/entitlements.rb
+++ b/apps/web/billing/controllers/entitlements.rb
@@ -55,8 +55,8 @@ module Billing
         }
 
         json_response(data)
-      rescue OT::Problem
-        # Propagate to centralized OttoHooks handler (ADR-013).
+      rescue Onetime::Forbidden
+        # Propagate to OttoHooks Forbidden handler (ADR-013 → 403).
         raise
       rescue StandardError => ex
         billing_logger.error 'Failed to load entitlements',
@@ -125,8 +125,8 @@ module Billing
         end
 
         json_response(result)
-      rescue OT::Problem
-        # Propagate to centralized OttoHooks handler (ADR-013).
+      rescue Onetime::Forbidden
+        # Propagate to OttoHooks Forbidden handler (ADR-013 → 403).
         raise
       rescue StandardError => ex
         billing_logger.error 'Failed entitlement check',

--- a/lib/onetime/errors.rb
+++ b/lib/onetime/errors.rb
@@ -103,6 +103,28 @@ module Onetime
   class Unauthorized < RuntimeError
   end
 
+  # =========================================================================
+  # CRITICAL ARCHITECTURAL WARNING: EXCEPTION HANDLER ORDERING
+  # =========================================================================
+  #
+  # Onetime::Forbidden represents a standard access-control error (ADR-013).
+  # It inherits from RuntimeError (which is a subclass of StandardError).
+  #
+  # Because of this class hierarchy, in any controller action or middleware
+  # that uses a catch-all rescue block (`rescue StandardError => ex`),
+  # Onetime::Forbidden WILL be caught by that block if not handled first.
+  #
+  # To prevent access control errors from being swallowed, logged as system
+  # failures, and downgraded to 500 Internal Server Errors, you MUST rescue
+  # Onetime::Forbidden explicitly BEFORE StandardError and re-raise it:
+  #
+  #   rescue Onetime::Forbidden
+  #     raise # Propagate up to OttoHooks Forbidden 403 handler
+  #   rescue StandardError => ex
+  #     # Handle unexpected 500 system errors here
+  #   end
+  #
+  # =========================================================================
   class Forbidden < RuntimeError
     attr_accessor :message, :error_key, :args
 


### PR DESCRIPTION
## Summary

Refactor billing and entitlements controllers to use `Onetime::Forbidden` exception instead of `OT::Problem` for access control errors. This aligns with ADR-013 and allows the centralized OttoHooks exception handler to properly render 403 responses with the correct wire format.

### Changes

- **base.rb**: Updated `load_organization` to raise `Onetime::Forbidden` instead of `OT::Problem` for three access control scenarios:
  - Organization not found
  - User is not a member
  - Owner access required but user is not an owner
  
  All three conditions deliberately return 403 to prevent information leakage (distinguishing real extids from random ones).

- **billing.rb**: Removed `rescue OT::Problem` handlers from 9 controller actions and replaced 2 of them with `rescue Onetime::Forbidden` that re-raises to propagate to the OttoHooks handler:
  - `overview`
  - `dismiss_federation_notification`
  
  Removed from: `create_checkout_session`, `list_invoices`, `subscription_status`, `preview_plan_change`, `change_plan`, `cancel_subscription`, `reactivate_subscription`, `check_currency_migration`, `migrate_currency`

- **entitlements.rb**: Replaced `rescue OT::Problem` with `rescue Onetime::Forbidden` that re-raises in:
  - `show`
  - `check`

### Rationale

`Onetime::Forbidden` inherits from `RuntimeError` (not `OT::Problem`), so it's a `StandardError`. By explicitly catching and re-raising it before the catch-all `StandardError` handler, we ensure access control errors are properly propagated to the OttoHooks exception handler rather than being downgraded to 500 errors.

## Related Issues

<!-- Add issue reference if applicable -->

## Test Plan

Existing test suite covers these code paths. Changes are straightforward exception handling refactors with no behavioral changes to the business logic.

https://claude.ai/code/session_01XC8gd8WXRzNJkdaTFNE48z