### PR TITLE
Refactor logic classes to use category-aware loggers (tier 1)

### DIFF
--- a/apps/api/account/logic/account/confirm_email_change.rb
+++ b/apps/api/account/logic/account/confirm_email_change.rb
@@ -88,7 +88,7 @@ module AccountAPI::Logic
             fallback: :async_thread,
           )
         rescue StandardError => ex
-          auth_logger.error "[confirm-email-change] Failed to send email-changed notification", exception: ex
+          auth_logger.error '[confirm-email-change] Failed to send email-changed notification', exception: ex
         end
 
         OT.info "[confirm-email-change] Email change confirmed cid/#{@owner.objid} new/#{OT::Utils.obscure_email(new_email)}"
@@ -108,7 +108,7 @@ module AccountAPI::Logic
           customer.update_in_organization_email_index(org, old_email)
         end
       rescue StandardError => ex
-        auth_logger.error "[confirm-email-change] Org index update failed", customer_id: customer.objid, exception: ex
+        auth_logger.error '[confirm-email-change] Org index update failed', extid: customer.extid, exception: ex
       end
 
       def find_auth_account(customer)
@@ -127,7 +127,7 @@ module AccountAPI::Logic
 
         OT.info "[confirm-email-change] Auth database updated cid/#{customer.objid}"
       rescue StandardError => ex
-        auth_logger.error "[confirm-email-change] Auth database update failed", exception: ex
+        auth_logger.error '[confirm-email-change] Auth database update failed', exception: ex
         raise_form_error 'Email change could not be completed', error_type: 'system_error'
       end
 
@@ -153,7 +153,7 @@ module AccountAPI::Logic
         # Also clear the current request's session if present
         sess.clear if sess
       rescue StandardError => ex
-        auth_logger.error "[confirm-email-change] Session invalidation error", exception: ex
+        auth_logger.error '[confirm-email-change] Session invalidation error', exception: ex
       end
 
       # Scan Redis for all session keys belonging to the given customer
@@ -185,7 +185,7 @@ module AccountAPI::Logic
 
         OT.info "[confirm-email-change] Deleted #{deleted} Redis session(s) for cid/#{customer.objid}"
       rescue StandardError => ex
-        auth_logger.error "[confirm-email-change] Redis session cleanup error", exception: ex
+        auth_logger.error '[confirm-email-change] Redis session cleanup error', exception: ex
       end
 
       # Resolve the session secret using the same fallback chain as

--- a/apps/api/account/logic/account/confirm_email_change.rb
+++ b/apps/api/account/logic/account/confirm_email_change.rb
@@ -88,7 +88,7 @@ module AccountAPI::Logic
             fallback: :async_thread,
           )
         rescue StandardError => ex
-          OT.le "[confirm-email-change] Failed to send email-changed notification: #{ex.message}"
+          auth_logger.error "[confirm-email-change] Failed to send email-changed notification", exception: ex
         end
 
         OT.info "[confirm-email-change] Email change confirmed cid/#{@owner.objid} new/#{OT::Utils.obscure_email(new_email)}"
@@ -108,8 +108,7 @@ module AccountAPI::Logic
           customer.update_in_organization_email_index(org, old_email)
         end
       rescue StandardError => ex
-        OT.le "[confirm-email-change] Org index update failed cid/#{customer.objid}: #{ex.message}"
-        OT.le ex.backtrace.first(5).join("\n")
+        auth_logger.error "[confirm-email-change] Org index update failed", customer_id: customer.objid, exception: ex
       end
 
       def find_auth_account(customer)
@@ -128,7 +127,7 @@ module AccountAPI::Logic
 
         OT.info "[confirm-email-change] Auth database updated cid/#{customer.objid}"
       rescue StandardError => ex
-        OT.le "[confirm-email-change] Auth database update failed: #{ex.message}"
+        auth_logger.error "[confirm-email-change] Auth database update failed", exception: ex
         raise_form_error 'Email change could not be completed', error_type: 'system_error'
       end
 
@@ -154,7 +153,7 @@ module AccountAPI::Logic
         # Also clear the current request's session if present
         sess.clear if sess
       rescue StandardError => ex
-        OT.le "[confirm-email-change] Session invalidation error: #{ex.message}"
+        auth_logger.error "[confirm-email-change] Session invalidation error", exception: ex
       end
 
       # Scan Redis for all session keys belonging to the given customer
@@ -186,7 +185,7 @@ module AccountAPI::Logic
 
         OT.info "[confirm-email-change] Deleted #{deleted} Redis session(s) for cid/#{customer.objid}"
       rescue StandardError => ex
-        OT.le "[confirm-email-change] Redis session cleanup error: #{ex.message}"
+        auth_logger.error "[confirm-email-change] Redis session cleanup error", exception: ex
       end
 
       # Resolve the session secret using the same fallback chain as

--- a/apps/api/account/logic/account/destroy_account.rb
+++ b/apps/api/account/logic/account/destroy_account.rb
@@ -15,7 +15,7 @@ module AccountAPI::Logic
       def process_params
         return if params.nil?
 
-        auth_logger.debug "[DestroyAccount#process_params] param keys", param_keys: params.keys.sort
+        auth_logger.debug '[DestroyAccount#process_params] param keys', param_keys: params.keys.sort
         @confirmation = self.class.normalize_password(params['confirmation'])
       end
 
@@ -47,7 +47,7 @@ module AccountAPI::Logic
         # TODO: Limit to dev as well
         if Onetime.debug?
           cust.destroy_requested # not saved
-          auth_logger.debug "[destroy-account] Simulated account destruction", cust_id: cust.objid, role: cust.role, session: session_sid
+          auth_logger.debug '[destroy-account] Simulated account destruction', extid: cust.extid, role: cust.role, session: session_sid
 
           # Since we intentionally don't call Customer#destroy_requested!
           # when running in debug mode (to simulate the destruction but
@@ -125,10 +125,10 @@ module AccountAPI::Logic
       def verify_password_full_mode(password)
         Auth::Config.valid_login_and_password?(login: cust.email, password: password)
       rescue Rodauth::InternalRequestError => ex
-        auth_logger.error "[destroy-account] Rodauth verification failed", exception: ex
+        auth_logger.error '[destroy-account] Rodauth verification failed', exception: ex
         false
       rescue StandardError => ex
-        auth_logger.error "[destroy-account] Password verification error", exception: ex
+        auth_logger.error '[destroy-account] Password verification error', exception: ex
         false
       end
 

--- a/apps/api/account/logic/account/destroy_account.rb
+++ b/apps/api/account/logic/account/destroy_account.rb
@@ -7,6 +7,7 @@ require 'onetime/logic/sso_only_gating'
 module AccountAPI::Logic
   module Account
     class DestroyAccount < AccountAPI::Logic::Base
+      include Onetime::LoggerMethods
       include Onetime::Logic::SsoOnlyGating
 
       attr_reader :raised_concerns_was_called, :greenlighted
@@ -14,7 +15,7 @@ module AccountAPI::Logic
       def process_params
         return if params.nil?
 
-        OT.ld "[DestroyAccount#process_params] param keys: #{params.keys.sort}"
+        auth_logger.debug "[DestroyAccount#process_params] param keys", param_keys: params.keys.sort
         @confirmation = self.class.normalize_password(params['confirmation'])
       end
 
@@ -46,7 +47,7 @@ module AccountAPI::Logic
         # TODO: Limit to dev as well
         if Onetime.debug?
           cust.destroy_requested # not saved
-          OT.ld "[destroy-account] Simulated account destruction #{cust.objid} #{cust.role} #{session_sid}"
+          auth_logger.debug "[destroy-account] Simulated account destruction", cust_id: cust.objid, role: cust.role, session: session_sid
 
           # Since we intentionally don't call Customer#destroy_requested!
           # when running in debug mode (to simulate the destruction but
@@ -124,11 +125,10 @@ module AccountAPI::Logic
       def verify_password_full_mode(password)
         Auth::Config.valid_login_and_password?(login: cust.email, password: password)
       rescue Rodauth::InternalRequestError => ex
-        OT.le "[destroy-account] Rodauth verification failed: #{ex.message}"
+        auth_logger.error "[destroy-account] Rodauth verification failed", exception: ex
         false
       rescue StandardError => ex
-        OT.le "[destroy-account] Password verification error: #{ex.message}"
-        OT.ld ex.backtrace.first(5).join("\n")
+        auth_logger.error "[destroy-account] Password verification error", exception: ex
         false
       end
 

--- a/apps/api/account/logic/account/get_entitlements.rb
+++ b/apps/api/account/logic/account/get_entitlements.rb
@@ -59,6 +59,8 @@ module AccountAPI::Logic
     # - Returns only public entitlement metadata, no sensitive data
     #
     class GetEntitlements < AccountAPI::Logic::Base
+      include Onetime::LoggerMethods
+
       SCHEMAS = { response: 'account' }.freeze
 
       def raise_concerns
@@ -155,11 +157,7 @@ module AccountAPI::Logic
         # Extract just the data hashes (without the interval tracking key)
         plans_by_tier.values.map { |entry| entry[:data] }
       rescue StandardError => ex
-        OT.le '[GetEntitlements] Error loading plans from cache',
-          {
-            exception: ex.class.name,
-            message: ex.message,
-          }
+        billing_logger.error '[GetEntitlements] Error loading plans from cache', exception: ex
         []
       end
 

--- a/apps/api/account/logic/account/request_email_change.rb
+++ b/apps/api/account/logic/account/request_email_change.rb
@@ -143,7 +143,7 @@ module AccountAPI::Logic
             fallback: :sync,
           )
         rescue StandardError => ex
-          OT.le "[request-email-change] Failed to send confirmation email: #{ex.message}"
+          auth_logger.error "[request-email-change] Failed to send confirmation email", exception: ex
         end
 
         # Send notification email to the OLD address (request-time, present tense)
@@ -158,7 +158,7 @@ module AccountAPI::Logic
             fallback: :async_thread,
           )
         rescue StandardError => ex
-          OT.le "[request-email-change] Failed to send notification email: #{ex.message}"
+          auth_logger.error "[request-email-change] Failed to send notification email", exception: ex
         end
       end
 
@@ -179,10 +179,10 @@ module AccountAPI::Logic
       def verify_password_full_mode(password)
         Auth::Config.valid_login_and_password?(login: cust.email, password: password)
       rescue Rodauth::InternalRequestError => ex
-        OT.le "[request-email-change] Rodauth verification failed: #{ex.message}"
+        auth_logger.error "[request-email-change] Rodauth verification failed", exception: ex
         false
       rescue StandardError => ex
-        OT.le "[request-email-change] Password verification error: #{ex.message}"
+        auth_logger.error "[request-email-change] Password verification error", exception: ex
         false
       end
 

--- a/apps/api/account/logic/account/update_password.rb
+++ b/apps/api/account/logic/account/update_password.rb
@@ -7,6 +7,7 @@ require 'onetime/logic/sso_only_gating'
 module AccountAPI::Logic
   module Account
     class UpdatePassword < UpdateAccountField
+      include Onetime::LoggerMethods
       include Onetime::Logic::SsoOnlyGating
 
       def raise_concerns
@@ -15,7 +16,7 @@ module AccountAPI::Logic
       end
 
       def process_params
-        OT.ld "[UpdatePassword#process_params] param keys: #{params.keys.sort}"
+        auth_logger.debug "[UpdatePassword#process_params] param keys", param_keys: params.keys.sort
         @password        = self.class.normalize_password(params['password']) # was currentp
         @newpassword     = self.class.normalize_password(params['newpassword']) # was newp
         @passwordconfirm = self.class.normalize_password(params['password-confirm']) # was newp2
@@ -71,10 +72,10 @@ module AccountAPI::Logic
       def verify_password_full_mode(password)
         Auth::Config.valid_login_and_password?(login: cust.email, password: password)
       rescue Rodauth::InternalRequestError => ex
-        OT.le "[update-password] Rodauth verification failed: #{ex.message}"
+        auth_logger.error "[update-password] Rodauth verification failed", exception: ex
         false
       rescue StandardError => ex
-        OT.le "[update-password] Password verification error: #{ex.message}"
+        auth_logger.error "[update-password] Password verification error", exception: ex
         false
       end
 
@@ -88,7 +89,7 @@ module AccountAPI::Logic
           new_password: @newpassword,
         )
       rescue Rodauth::InternalRequestError => ex
-        OT.le "[update-password] Rodauth change_password failed: #{ex.message}"
+        auth_logger.error "[update-password] Rodauth change_password failed", exception: ex
         raise_form_error 'Password change failed', error_type: 'system_error'
       end
     end

--- a/apps/api/colonel/logic/colonel/get_queue_metrics.rb
+++ b/apps/api/colonel/logic/colonel/get_queue_metrics.rb
@@ -22,6 +22,8 @@ module ColonelAPI
       # run on different machines (no PID file access).
       #
       class GetQueueMetrics < ColonelAPI::Logic::Base
+        include Onetime::LoggerMethods
+
         SCHEMAS = { response: 'queueMetrics' }.freeze
 
         def process_params
@@ -86,12 +88,12 @@ module ColonelAPI
             channel = $rmq_conn.create_channel
             { name: queue_name, pending_messages: 0, consumers: 0 }
           rescue Bunny::Exception => ex
-            OT.le "[GetQueueMetrics] Error checking queue #{queue_name}: #{ex.message}"
+            bunny_logger.error "[GetQueueMetrics] Error checking queue", queue_name: queue_name, exception: ex
             channel = $rmq_conn.create_channel
             { name: queue_name, pending_messages: 0, consumers: 0 }
           end
         rescue Bunny::Exception => ex
-          OT.le "[GetQueueMetrics] Error fetching queue stats: #{ex.message}"
+          bunny_logger.error "[GetQueueMetrics] Error fetching queue stats", exception: ex
           []
         ensure
           channel&.close if channel&.open?

--- a/apps/api/domains/logic/domains/add_domain.rb
+++ b/apps/api/domains/logic/domains/add_domain.rb
@@ -26,6 +26,8 @@ module DomainsAPI::Logic
     # the session is updated.
     #
     class AddDomain < DomainsAPI::Logic::Base
+      include Onetime::LoggerMethods
+
       SCHEMAS = { response: 'customDomain' }.freeze
 
       attr_reader :greenlighted, :custom_domain, :domain_input, :display_domain, :target_organization
@@ -35,11 +37,11 @@ module DomainsAPI::Logic
         @domain_input = sanitize_plain_text(params['domain'])
         @org_id_param = sanitize_identifier(params['org_id'])
 
-        OT.ld "[AddDomain] Parsing #{domain_input}"
+        logger.debug "[AddDomain] Parsing domain", domain_input: domain_input
       end
 
       def raise_concerns
-        OT.ld "[AddDomain] Raising any concerns about #{@domain_input}"
+        logger.debug "[AddDomain] Raising any concerns about domain", domain_input: @domain_input
         # TODO: Consider returning all applicable errors (plural) at once
         raise_form_error 'Please enter a domain' if @domain_input.empty?
         raise_form_error 'Not a valid public domain' unless Onetime::CustomDomain.valid?(@domain_input)
@@ -66,7 +68,7 @@ module DomainsAPI::Logic
         @parsed_domain  = Onetime::CustomDomain.parse(@domain_input, target_organization.objid)
         @display_domain = @parsed_domain.display_domain
 
-        OT.ld "[AddDomain] Display: #{@display_domain}, Identifier: #{@parsed_domain.identifier}"
+        logger.debug "[AddDomain] Domain parsed", display_domain: @display_domain, identifier: @parsed_domain.identifier
 
         # Check for existing domain to provide specific error messages
         existing = Onetime::CustomDomain.load_by_display_domain(@display_domain)
@@ -75,13 +77,13 @@ module DomainsAPI::Logic
 
         # Scenario 1: Domain already in customer's organization (same org_id)
         if existing.org_id.to_s == target_organization.objid.to_s
-          OT.ld "[AddDomain] Domain already in organization: #{@display_domain}"
+          logger.debug "[AddDomain] Domain already in organization", display_domain: @display_domain
           raise_form_error 'Domain already registered in your organization'
         end
 
         # Scenario 2: Domain in another organization (different org_id)
         unless existing.org_id.to_s.empty?
-          OT.le "[AddDomain] Domain belongs to another organization: #{@display_domain}"
+          logger.error "[AddDomain] Domain belongs to another organization", display_domain: @display_domain
           raise_form_error 'Domain is registered to another organization'
         end
 
@@ -92,7 +94,7 @@ module DomainsAPI::Logic
 
       def process
         @greenlighted  = true
-        OT.ld "[AddDomain] Processing #{@display_domain} for org #{target_organization.objid}"
+        logger.debug "[AddDomain] Processing domain", display_domain: @display_domain, org_id: target_organization.objid
 
         @custom_domain = Onetime::CustomDomain.create!(@display_domain, target_organization.objid)
 
@@ -105,10 +107,10 @@ module DomainsAPI::Logic
           # This delegates to the appropriate backend (Approximated, Caddy, passthrough, etc.)
           request_certificate
         rescue HTTParty::ResponseError => ex
-          OT.le format('[AddDomain.request_certificate error] %s %s %s', @cust.extid, @display_domain, ex)
+          logger.error "[AddDomain.request_certificate error]", cust_id: @cust.extid, display_domain: @display_domain, exception: ex
           # Continue processing despite certificate request error
         rescue StandardError => ex
-          OT.le "[AddDomain] Unexpected error: #{ex.message}"
+          logger.error "[AddDomain] Unexpected error", exception: ex
           # Continue processing despite error
         end
 

--- a/apps/api/domains/logic/domains/add_domain.rb
+++ b/apps/api/domains/logic/domains/add_domain.rb
@@ -37,11 +37,11 @@ module DomainsAPI::Logic
         @domain_input = sanitize_plain_text(params['domain'])
         @org_id_param = sanitize_identifier(params['org_id'])
 
-        logger.debug "[AddDomain] Parsing domain", domain_input: domain_input
+        logger.debug '[AddDomain] Parsing domain', domain_input: domain_input
       end
 
       def raise_concerns
-        logger.debug "[AddDomain] Raising any concerns about domain", domain_input: @domain_input
+        logger.debug '[AddDomain] Raising any concerns about domain', domain_input: @domain_input
         # TODO: Consider returning all applicable errors (plural) at once
         raise_form_error 'Please enter a domain' if @domain_input.empty?
         raise_form_error 'Not a valid public domain' unless Onetime::CustomDomain.valid?(@domain_input)
@@ -68,7 +68,7 @@ module DomainsAPI::Logic
         @parsed_domain  = Onetime::CustomDomain.parse(@domain_input, target_organization.objid)
         @display_domain = @parsed_domain.display_domain
 
-        logger.debug "[AddDomain] Domain parsed", display_domain: @display_domain, identifier: @parsed_domain.identifier
+        logger.debug '[AddDomain] Domain parsed', display_domain: @display_domain, identifier: @parsed_domain.identifier
 
         # Check for existing domain to provide specific error messages
         existing = Onetime::CustomDomain.load_by_display_domain(@display_domain)
@@ -77,13 +77,13 @@ module DomainsAPI::Logic
 
         # Scenario 1: Domain already in customer's organization (same org_id)
         if existing.org_id.to_s == target_organization.objid.to_s
-          logger.debug "[AddDomain] Domain already in organization", display_domain: @display_domain
+          logger.debug '[AddDomain] Domain already in organization', display_domain: @display_domain
           raise_form_error 'Domain already registered in your organization'
         end
 
         # Scenario 2: Domain in another organization (different org_id)
         unless existing.org_id.to_s.empty?
-          logger.error "[AddDomain] Domain belongs to another organization", display_domain: @display_domain
+          logger.error '[AddDomain] Domain belongs to another organization', display_domain: @display_domain
           raise_form_error 'Domain is registered to another organization'
         end
 
@@ -94,7 +94,7 @@ module DomainsAPI::Logic
 
       def process
         @greenlighted  = true
-        logger.debug "[AddDomain] Processing domain", display_domain: @display_domain, org_id: target_organization.objid
+        logger.debug '[AddDomain] Processing domain', display_domain: @display_domain, org_id: target_organization.objid
 
         @custom_domain = Onetime::CustomDomain.create!(@display_domain, target_organization.objid)
 
@@ -107,10 +107,10 @@ module DomainsAPI::Logic
           # This delegates to the appropriate backend (Approximated, Caddy, passthrough, etc.)
           request_certificate
         rescue HTTParty::ResponseError => ex
-          logger.error "[AddDomain.request_certificate error]", cust_id: @cust.extid, display_domain: @display_domain, exception: ex
+          logger.error '[AddDomain.request_certificate error]', extid: @cust.extid, display_domain: @display_domain, exception: ex
           # Continue processing despite certificate request error
         rescue StandardError => ex
-          logger.error "[AddDomain] Unexpected error", exception: ex
+          logger.error '[AddDomain] Unexpected error', exception: ex
           # Continue processing despite error
         end
 

--- a/apps/api/domains/spec/logic/domains/add_domain_spec.rb
+++ b/apps/api/domains/spec/logic/domains/add_domain_spec.rb
@@ -58,11 +58,19 @@ RSpec.describe DomainsAPI::Logic::Domains::AddDomain do
   let(:params) { { 'domain' => 'example.com' } }
   let(:logic) { described_class.new(strategy_result, params) }
 
+  # Source now uses the category-aware `logger` (Onetime::LoggerMethods) instead
+  # of the OT.le/OT.ld shims. Stub the instance logger so .debug/.error calls
+  # during #process don't hit the real SemanticLogger and can be asserted on.
+  let(:app_logger_double) do
+    instance_double(SemanticLogger::Logger, info: nil, debug: nil, warn: nil, error: nil)
+  end
+
   before do
     allow(OT).to receive(:info)
     allow(OT).to receive(:ld)
     allow(OT).to receive(:li)
     allow(OT).to receive(:le)
+    allow(logic).to receive(:logger).and_return(app_logger_double)
     allow(OT).to receive(:now).and_return(Time.now.to_i)
     allow(OT).to receive(:conf).and_return({
       'site' => {},
@@ -242,7 +250,7 @@ RSpec.describe DomainsAPI::Logic::Domains::AddDomain do
       allow(strategy).to receive(:request_certificate)
         .and_raise(HTTParty::ResponseError, 'API error')
 
-      expect(OT).to receive(:le).with(/request_certificate error/)
+      expect(app_logger_double).to receive(:error).with(/request_certificate error/, any_args)
       expect { logic.send(:process) }.not_to raise_error
     end
 
@@ -250,7 +258,7 @@ RSpec.describe DomainsAPI::Logic::Domains::AddDomain do
       allow(strategy).to receive(:request_certificate)
         .and_raise(StandardError, 'Unexpected error')
 
-      expect(OT).to receive(:le).with(/Unexpected error/)
+      expect(app_logger_double).to receive(:error).with(/Unexpected error/, any_args)
       expect { logic.send(:process) }.not_to raise_error
     end
 

--- a/apps/api/incoming/logic/create_incoming_secret.rb
+++ b/apps/api/incoming/logic/create_incoming_secret.rb
@@ -84,7 +84,7 @@ module Incoming
 
         # Validate recipient hash exists and maps to valid email
         if @recipient_email.nil?
-          OT.lw "[IncomingSecret] Invalid recipient hash attempted: #{@recipient_hash}"
+          secret_logger.warn "[IncomingSecret] Invalid recipient hash attempted", recipient_hash: @recipient_hash
           raise_form_error 'Invalid recipient'
         end
 
@@ -93,7 +93,7 @@ module Incoming
         # (no DNS) since this runs on every incoming secret creation.
         # Flow: POST /api/incoming/secret -> resolve_recipient_and_config -> here
         unless Truemail.validate(recipient_email.to_s, with: :regex).result.valid?
-          OT.le "[IncomingSecret] Lookup returned invalid email for hash: #{@recipient_hash}"
+          secret_logger.error "[IncomingSecret] Lookup returned invalid email for hash", recipient_hash: @recipient_hash
           raise_form_error 'Invalid recipient configuration'
         end
       end
@@ -234,7 +234,7 @@ module Incoming
 
         Onetime.secret_logger.info "[IncomingSecret] Notification enqueued for #{OT::Utils.obscure_email(recipient_email)} (receipt: #{receipt.shortid})"
       rescue StandardError => ex
-        Onetime.secret_logger.error "[IncomingSecret] Failed to enqueue notification: #{ex.message}"
+        secret_logger.error "[IncomingSecret] Failed to enqueue notification", exception: ex
         # Don't raise - email failure shouldn't prevent secret creation
       end
     end

--- a/apps/api/organizations/logic/organizations/create_organization.rb
+++ b/apps/api/organizations/logic/organizations/create_organization.rb
@@ -29,25 +29,39 @@ module OrganizationAPI::Logic
 
         # Validate display_name (basic validation before quota check)
         if display_name.empty?
-          raise_form_error(error_key: 'api.organizations.errors.display_name_required',
-                           field: 'display_name', error_type: :missing)
+          raise_form_error(
+            error_key: 'api.organizations.errors.display_name_required',
+            field: 'display_name',
+            error_type: :missing,
+          )
         end
 
         if display_name.length > 100
-          raise_form_error(error_key: 'api.organizations.errors.display_name_too_long',
-                           args: { max: 100 }, field: 'display_name', error_type: :invalid)
+          raise_form_error(
+            error_key: 'api.organizations.errors.display_name_too_long',
+            args: { max: 100 },
+            field: 'display_name',
+            error_type: :invalid,
+          )
         end
 
         # Validate contact_email (optional, but must be unique if provided)
         if !contact_email.empty? && Onetime::Organization.contact_email_exists?(contact_email)
-          raise_form_error(error_key: 'api.organizations.errors.contact_email_exists',
-                           field: 'contact_email', error_type: :exists)
+          raise_form_error(
+            error_key: 'api.organizations.errors.contact_email_exists',
+            field: 'contact_email',
+            error_type: :exists,
+          )
         end
 
         # Description is optional but limit length if provided
         if !description.empty? && description.length > 500
-          raise_form_error(error_key: 'api.organizations.errors.description_too_long',
-                           args: { max: 500 }, field: 'description', error_type: :invalid)
+          raise_form_error(
+            error_key: 'api.organizations.errors.description_too_long',
+            args: { max: 500 },
+            field: 'description',
+            error_type: :invalid,
+          )
         end
 
         # Check organization quota AFTER basic validation
@@ -58,7 +72,7 @@ module OrganizationAPI::Logic
       def process
         # Mask display_name in debug logs - safe even for 1-2 char names (Ruby returns available chars)
         masked_name = display_name.length > 3 ? "#{display_name[0, 3]}..." : "[#{display_name.length}chars]"
-        logger.debug "[CreateOrganization] Creating organization", masked_name: masked_name, user_id: cust.extid
+        logger.debug '[CreateOrganization] Creating organization', masked_name: masked_name, extid: cust.extid
 
         # Acquire distributed lock for organization creation to prevent quota race conditions
         lock_key   = "customer:#{cust.objid}:org_creation_lock"
@@ -99,7 +113,7 @@ module OrganizationAPI::Logic
             begin
               lock.release(lock_token)
             rescue StandardError => ex
-              logger.warn "[CreateOrganization] Lock release failed", exception: ex
+              logger.warn '[CreateOrganization] Lock release failed', exception: ex
             end
           end
         end

--- a/apps/api/organizations/logic/organizations/create_organization.rb
+++ b/apps/api/organizations/logic/organizations/create_organization.rb
@@ -11,6 +11,8 @@ module OrganizationAPI::Logic
     #   organization quotas when billing is enabled. Uses a distributed
     #   lock to prevent race conditions during creation.
     class CreateOrganization < OrganizationAPI::Logic::Base
+      include Onetime::LoggerMethods
+
       SCHEMAS = { response: 'organization' }.freeze
 
       attr_reader :organization, :display_name, :description, :contact_email
@@ -56,7 +58,7 @@ module OrganizationAPI::Logic
       def process
         # Mask display_name in debug logs - safe even for 1-2 char names (Ruby returns available chars)
         masked_name = display_name.length > 3 ? "#{display_name[0, 3]}..." : "[#{display_name.length}chars]"
-        OT.ld "[CreateOrganization] Creating organization '#{masked_name}' for user #{cust.extid}"
+        logger.debug "[CreateOrganization] Creating organization", masked_name: masked_name, user_id: cust.extid
 
         # Acquire distributed lock for organization creation to prevent quota race conditions
         lock_key   = "customer:#{cust.objid}:org_creation_lock"
@@ -97,7 +99,7 @@ module OrganizationAPI::Logic
             begin
               lock.release(lock_token)
             rescue StandardError => ex
-              OT.lw "[CreateOrganization] Lock release failed: #{ex.message}"
+              logger.warn "[CreateOrganization] Lock release failed", exception: ex
             end
           end
         end

--- a/apps/api/organizations/spec/logic/organizations/create_organization_spec.rb
+++ b/apps/api/organizations/spec/logic/organizations/create_organization_spec.rb
@@ -40,10 +40,22 @@ RSpec.describe OrganizationAPI::Logic::Organizations::CreateOrganization do
 
   subject(:logic) { described_class.new(strategy_result, params) }
 
+  # Source now uses the category-aware `logger` (Onetime::LoggerMethods) instead
+  # of the OT.ld/OT.lw shims, and passes masked_name/extid as structured kwargs
+  # rather than interpolating them into the message string.
+  let(:app_logger_double) do
+    instance_double(SemanticLogger::Logger, info: nil, debug: nil, warn: nil, error: nil)
+  end
+
   before do
     allow(OT).to receive(:info)
     allow(OT).to receive(:ld)
     allow(OT).to receive(:li)
+    # Stub at the get_logger level (not allow(logic).to receive(:logger)) so we
+    # don't force eager instantiation of the memoized `subject(:logic)` in the
+    # before hook, which would freeze display_name before per-example params edits.
+    allow(Onetime).to receive(:get_logger).and_call_original
+    allow(Onetime).to receive(:get_logger).with('App').and_return(app_logger_double)
   end
 
   describe '#process_params' do
@@ -309,7 +321,8 @@ RSpec.describe OrganizationAPI::Logic::Organizations::CreateOrganization do
       end
 
       it 'masks short organization name in debug logs' do
-        expect(OT).to receive(:ld).with(/\[2chars\]/)
+        expect(app_logger_double).to receive(:debug)
+          .with(/Creating organization/, hash_including(masked_name: '[2chars]'))
         logic.process
       end
     end
@@ -317,7 +330,8 @@ RSpec.describe OrganizationAPI::Logic::Organizations::CreateOrganization do
     context 'with normal display_name (>3 chars)' do
       it 'masks organization name showing only first 3 chars' do
         # Default params has display_name: 'Organization' which masks to 'Org...'
-        expect(OT).to receive(:ld).with(/Creating organization 'Org\.\.\.'/)
+        expect(app_logger_double).to receive(:debug)
+          .with(/Creating organization/, hash_including(masked_name: 'Org...'))
         logic.process
       end
     end
@@ -434,11 +448,10 @@ RSpec.describe OrganizationAPI::Logic::Organizations::CreateOrganization do
         allow(lock).to receive(:acquire).with(ttl: 30).and_return(lock_token)
         allow(lock).to receive(:release).with(lock_token)
           .and_raise(Redis::ConnectionError, 'Connection lost')
-        allow(OT).to receive(:lw)
       end
 
       it 'logs warning but does not raise' do
-        expect(OT).to receive(:lw).with(/Lock release failed/)
+        expect(app_logger_double).to receive(:warn).with(/Lock release failed/, any_args)
         result = logic.process
         expect(result).to have_key(:record)
       end

--- a/apps/api/v1/logic/base.rb
+++ b/apps/api/v1/logic/base.rb
@@ -12,6 +12,7 @@ module V1
     class Base
       using Familia::Refinements::TimeLiterals
 
+      include Onetime::LoggerMethods
       include V1::Logic::UriHelpers
       include Onetime::Security::InputSanitizers
 
@@ -29,7 +30,7 @@ module V1
         process_settings
 
         if cust.is_a?(String)
-          OT.li "[#{self.class}] Friendly reminder to pass in a Customer instance instead of a custid"
+          logger.info "Friendly reminder to pass in a Customer instance instead of a custid", logic_class: self.class
           @cust = Onetime::Customer.load_by_extid_or_email(cust)
         end
 
@@ -46,14 +47,13 @@ module V1
       end
 
       def valid_email?(email_field)
-        OT.ld "[valid_email?] Email field: #{email_field}"
+        logger.debug "[valid_email?] Email field", email_field: email_field
 
         begin
           validator = Truemail.validate(email_field)
 
         rescue StandardError => e
-          OT.le "Email validation error: #{e.message}"
-          OT.le e.backtrace
+          logger.error "Email validation error", exception: e
           false
         else
           valid = validator.result.valid?
@@ -74,7 +74,7 @@ module V1
       end
 
       def form_fields
-        OT.ld "No form_fields method for #{self.class} via:", caller[0..2].join("\n")
+        logger.debug "No form_fields method", logic_class: self.class
         {}
       end
 

--- a/apps/api/v1/logic/base.rb
+++ b/apps/api/v1/logic/base.rb
@@ -74,7 +74,7 @@ module V1
       end
 
       def form_fields
-        logger.debug "No form_fields method", logic_class: self.class
+        logger.debug "No form_fields method", logic_class: self.class, caller: caller[0..2]
         {}
       end
 

--- a/apps/api/v3/logic/feedback.rb
+++ b/apps/api/v3/logic/feedback.rb
@@ -16,6 +16,7 @@ module V3
     # which tracks per-IP submissions in Redis and locks abusers out for
     # an hour after exceeding the threshold.
     class ReceiveFeedback < V3::Logic::Base
+      include Onetime::LoggerMethods
       include Onetime::Security::FeedbackRateLimiter
 
       SCHEMAS = { response: 'feedback' }.freeze
@@ -43,7 +44,7 @@ module V3
 
       def process
         @greenlighted = true
-        OT.ld [:receive_feedback, msg].inspect
+        logger.debug "receive_feedback", msg: msg
 
         begin
           # Resolve the recipient. An explicit emailer.feedback_to override
@@ -52,15 +53,15 @@ module V3
           # Colonels are managed via CLI: bin/ots customers role promote email --role colonel
           recipient_email = feedback_recipient_email
           if recipient_email
-            OT.ld "[receive_feedback] Sending feedback to: #{recipient_email}"
+            logger.debug "[receive_feedback] Sending feedback to", recipient_email: recipient_email
             send_feedback recipient_email, cust, msg
           else
-            OT.ld '[receive_feedback] No feedback recipient configured and no colonels found, skipping email notification'
+            logger.debug "[receive_feedback] No feedback recipient configured, skipping email notification"
           end
         rescue StandardError => ex
           # We liberally rescue all StandardError exceptions here because we don't
           # want to fail the user's feedback submission if we can't send an email.
-          OT.le "Error sending feedback email: #{ex.message}", ex.backtrace
+          logger.error "Error sending feedback email", exception: ex
         end
 
         # Stored Redis copy keeps the metadata appended on a single line so the
@@ -111,7 +112,7 @@ module V3
       end
 
       def send_feedback(recipient_email, sender, message)
-        OT.ld "[send_feedback] Delivering feedback email (#{message.size} chars)"
+        logger.debug "[send_feedback] Delivering feedback email", msg_size: message.size
 
         # Logic classes don't receive req.env, so display_domain may be nil.
         # Fall back to site host from config for feedback emails.
@@ -151,7 +152,7 @@ module V3
             fallback: :none,
           )
         rescue StandardError => ex
-          OT.le "Error sending feedback email: #{ex.message}", ex.backtrace
+          logger.error "Error sending feedback email", exception: ex
           # No need to notify the user of this error. The message is still
           # saved in Redis and available via the colonel interface.
         end

--- a/apps/api/v3/logic/secrets.rb
+++ b/apps/api/v3/logic/secrets.rb
@@ -123,7 +123,7 @@ module V3
           )
         rescue StandardError => ex
           # Log but don't fail the reveal - notification is non-critical
-          secret_logger.error "[RevealSecret] Failed to notify owner: #{ex.message}"
+          secret_logger.error "[RevealSecret] Failed to notify owner", exception: ex
         end
       end
 

--- a/apps/web/billing/logic/welcome.rb
+++ b/apps/web/billing/logic/welcome.rb
@@ -59,7 +59,7 @@ module Billing
 
             unless checkout_email.eql?(cust.email)
               # Security: Don't link checkout to a different account than checkout_email
-              billing_logger.error "[FromStripePaymentLink] Email mismatch: checkout email differs from authenticated user", customer: cust.obscure_email
+              billing_logger.error '[FromStripePaymentLink] Email mismatch: checkout email differs from authenticated user', customer: cust.obscure_email
               raise_form_error 'Please log out first to complete checkout with a different email address'
             end
 
@@ -146,7 +146,7 @@ module Billing
           org.update_from_stripe_subscription(stripe_subscription)
         rescue Stripe::StripeError, Familia::Problem => ex
           # Log but don't fail the checkout flow - billing can be reconciled later
-          billing_logger.error "[FromStripePaymentLink] Error updating organization billing", exception: ex
+          billing_logger.error '[FromStripePaymentLink] Error updating organization billing', exception: ex
         end
 
         # Ensure customer has a default workspace, creating one if needed.
@@ -197,7 +197,7 @@ module Billing
             },
           )
         rescue StandardError => ex
-          billing_logger.error "[FromStripePaymentLink] Error sending verification email", exception: ex
+          billing_logger.error '[FromStripePaymentLink] Error sending verification email', exception: ex
         end
 
         # Preserve existing stripe_customer_id during checkout association
@@ -285,7 +285,7 @@ module Billing
           # The customer_extid was embedded in subscription metadata when checkout was created
           customer = Onetime::Customer.find_by_extid(customer_extid)
           unless customer
-            billing_logger.error "[ProcessCheckoutSession] Customer not found", customer_extid: customer_extid
+            billing_logger.error '[ProcessCheckoutSession] Customer not found', extid: customer_extid
             raise_form_error 'Customer not found'
           end
 
@@ -364,7 +364,7 @@ module Billing
           # 4. Create default org (self-healing fallback - shouldn't happen, checkout requires org context)
           # See: apps/web/auth/operations/create_default_workspace.rb
           billing_logger.warn '[ProcessCheckoutSession] Creating default org during checkout (unexpected)',
-            customer_extid: customer.extid
+            extid: customer.extid
           Onetime::Organization.create!(
             "#{customer.email}'s Workspace",
             customer,

--- a/apps/web/billing/logic/welcome.rb
+++ b/apps/web/billing/logic/welcome.rb
@@ -17,6 +17,8 @@ module Billing
       # @note The external API remains unchanged: GET /welcome?checkout={ID}
       #
       class FromStripePaymentLink < Onetime::Logic::Base
+        include Onetime::LoggerMethods
+
         attr_reader :checkout_session_id,
           :checkout_session,
           :checkout_email,
@@ -57,7 +59,7 @@ module Billing
 
             unless checkout_email.eql?(cust.email)
               # Security: Don't link checkout to a different account than checkout_email
-              OT.le "[FromStripePaymentLink] Email mismatch: checkout email differs from authenticated user #{cust.obscure_email}"
+              billing_logger.error "[FromStripePaymentLink] Email mismatch: checkout email differs from authenticated user", customer: cust.obscure_email
               raise_form_error 'Please log out first to complete checkout with a different email address'
             end
 
@@ -144,7 +146,7 @@ module Billing
           org.update_from_stripe_subscription(stripe_subscription)
         rescue Stripe::StripeError, Familia::Problem => ex
           # Log but don't fail the checkout flow - billing can be reconciled later
-          OT.le "[FromStripePaymentLink] Error updating organization billing: #{ex.message}"
+          billing_logger.error "[FromStripePaymentLink] Error updating organization billing", exception: ex
         end
 
         # Ensure customer has a default workspace, creating one if needed.
@@ -195,7 +197,7 @@ module Billing
             },
           )
         rescue StandardError => ex
-          OT.le "[FromStripePaymentLink] Error sending verification email: #{ex.message}"
+          billing_logger.error "[FromStripePaymentLink] Error sending verification email", exception: ex
         end
 
         # Preserve existing stripe_customer_id during checkout association
@@ -213,12 +215,10 @@ module Billing
           new_id      = fields[:stripe_customer_id].to_s
 
           if existing_id.present? && existing_id != new_id
-            OT.lw '[FromStripePaymentLink] Customer already has stripe_customer_id, keeping existing',
-              {
-                existing: existing_id,
-                new: new_id,
-                customer: customer.obscure_email,
-              }
+            billing_logger.warn '[FromStripePaymentLink] Customer already has stripe_customer_id, keeping existing',
+              existing: existing_id,
+              new: new_id,
+              customer: customer.obscure_email
             fields.delete(:stripe_customer_id)
           end
 
@@ -236,6 +236,8 @@ module Billing
       # @note This is used by /billing/welcome endpoint
       #
       class ProcessCheckoutSession < Onetime::Logic::Base
+        include Onetime::LoggerMethods
+
         attr_reader :session_id, :checkout_session, :subscription, :target_organization
 
         def process_params
@@ -283,7 +285,7 @@ module Billing
           # The customer_extid was embedded in subscription metadata when checkout was created
           customer = Onetime::Customer.find_by_extid(customer_extid)
           unless customer
-            OT.le "[ProcessCheckoutSession] Customer not found: #{customer_extid}"
+            billing_logger.error "[ProcessCheckoutSession] Customer not found", customer_extid: customer_extid
             raise_form_error 'Customer not found'
           end
 
@@ -336,7 +338,7 @@ module Billing
                 { orgid: orgid, extid: org.extid }
               return org
             end
-            OT.lw '[ProcessCheckoutSession] orgid in metadata not found', { orgid: orgid }
+            billing_logger.warn '[ProcessCheckoutSession] orgid in metadata not found', orgid: orgid
           end
 
           # 2. Org already linked to Stripe customer (idempotent replay case)
@@ -361,8 +363,8 @@ module Billing
 
           # 4. Create default org (self-healing fallback - shouldn't happen, checkout requires org context)
           # See: apps/web/auth/operations/create_default_workspace.rb
-          OT.lw '[ProcessCheckoutSession] Creating default org during checkout (unexpected)',
-            { customer_extid: customer.extid }
+          billing_logger.warn '[ProcessCheckoutSession] Creating default org during checkout (unexpected)',
+            customer_extid: customer.extid
           Onetime::Organization.create!(
             "#{customer.email}'s Workspace",
             customer,


### PR DESCRIPTION
## Summary

Follows up on #3221 / #3226. Replaces two weak logging anti-patterns across 13 logic-class files:

- **Pattern A** – Global shortcut calls (`OT.le`, `OT.ld`, `OT.li`, `OT.lw`) replaced with category-aware logger instance methods (`auth_logger.error`, `billing_logger.warn`, `secret_logger.warn`, `bunny_logger.error`, `logger.debug`, etc.)
- **Pattern B** – Manual exception formatting (`"#{ex.message}"` interpolated into strings, separate `OT.le ex.backtrace` / `OT.ld ex.backtrace.first(5).join(...)` lines) replaced with SemanticLogger's native `exception: ex` keyword argument, which captures message + backtrace automatically.

Where a class did not already `include Onetime::LoggerMethods`, the include was added.

## Files changed

**Tier-1 (10 files):**
- `apps/api/account/logic/account/confirm_email_change.rb` – `auth_logger`
- `apps/api/account/logic/account/update_password.rb` – `auth_logger` (+ added include)
- `apps/api/account/logic/account/request_email_change.rb` – `auth_logger`
- `apps/api/account/logic/account/destroy_account.rb` – `auth_logger` (+ added include)
- `apps/api/v1/logic/base.rb` – `logger` (+ added include)
- `apps/api/v3/logic/feedback.rb` – `logger` (+ added include to `ReceiveFeedback`)
- `apps/web/billing/logic/welcome.rb` – `billing_logger` (+ added include to both inner classes)
- `apps/api/colonel/logic/colonel/get_queue_metrics.rb` – `bunny_logger` (+ added include)
- `apps/api/organizations/logic/organizations/create_organization.rb` – `logger` (+ added include)
- `apps/api/domains/logic/domains/add_domain.rb` – `logger` (+ added include)

**Tier-2 (3 files):**
- `apps/api/incoming/logic/create_incoming_secret.rb` – `secret_logger` (already included)
- `apps/api/v3/logic/secrets.rb` – `secret_logger` (already included via parent)
- `apps/api/account/logic/account/get_entitlements.rb` – `billing_logger` (+ added include)

## Out of scope

Tier-3 (debug-heavy shortcut cleanup in non-logic-class files) is not included here and should be a separate PR.

## Notes

- Rubocop could not run in this environment: the container has Ruby 3.3.6 but the Gemfile requires `>= 3.4.7`. No rubocop-reported offenses to report; all changes are mechanical substitutions following the established pattern.
- Separate `OT.le ex.backtrace` / `OT.ld ex.backtrace.first(5).join(...)` lines were deleted wherever they appeared — `exception: ex` already captures the full backtrace via SemanticLogger.

## Test plan

- [ ] Deploy to staging and exercise each affected endpoint; confirm structured log entries appear with correct category tags
- [ ] Verify `auth_logger`, `billing_logger`, `secret_logger`, `bunny_logger` log entries carry the expected `category:` field in production logs
- [ ] Confirm no `OT.le` / `OT.ld` / `OT.li` / `OT.lw` calls remain in the 13 modified files (`grep -r "OT\.l[ediwf]" apps/`)
- [ ] Check that exception log entries include backtrace without any manual `.backtrace` calls


---
_Generated by [Claude Code](https://claude.ai/code/session_01T2fNRzDqAC2vXmtZ9dV711)_