### PR TITLE
[#3269] Skeleton loading components + authenticated /pricing redirect

### DIFF
--- a/apps/web/core/templates/index.rue
+++ b/apps/web/core/templates/index.rue
@@ -76,7 +76,7 @@
            the other, or neither:
              data-show-orb="true|false"   tri-color spinning orb
              data-show-text="true|false"  "Loading..." text with blinking dots -->
-      <div class="app-fallback" data-show-orb="true" data-show-text="true">
+      <div class="app-fallback" data-show-orb="true" data-show-text="false">
         <div class="app-fallback-inner">
           <div class="loader-orb" aria-hidden="true"></div>
           <div class="loader-text" role="status">Loading<span class="dot">.</span><span class="dot">.</span><span class="dot">.</span></div>

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -485,6 +485,18 @@ export default [
   },
 
   /**
+   * Closet Skeleton Primitive Exception
+   * The `Skeleton` primitive (issue #3269) uses an intentional single-word name;
+   * its siblings (TableSkeleton, SecretSkeleton, ...) compose from it.
+   */
+  {
+    files: ['src/shared/components/closet/Skeleton.vue'],
+    rules: {
+      'vue/multi-word-component-names': 'off', // Allow single-word name for the base skeleton primitive
+    },
+  },
+
+  /**
    * Test Files Configuration
    * Relaxes naming conventions and adds specific rules for test files
    */

--- a/src/apps/colonel/views/ColonelOrganizations.vue
+++ b/src/apps/colonel/views/ColonelOrganizations.vue
@@ -544,7 +544,7 @@
                       @click="handleInvestigate(org.extid)">
                       <svg
                         v-if="investigatingOrgs.has(org.extid)"
-                        class="mr-1 size-3 animate-spin"
+                        class="mr-1 size-3 animate-spin motion-reduce:animate-none"
                         fill="none"
                         viewBox="0 0 24 24">
                         <circle

--- a/src/apps/secret/components/conceal/HomepageAccessToggle.vue
+++ b/src/apps/secret/components/conceal/HomepageAccessToggle.vue
@@ -45,10 +45,11 @@ const emit = defineEmits<{
       v-if="disabled"
       class="absolute inset-0 flex items-center justify-center">
       <svg
-        class="size-4 animate-spin text-white"
+        class="size-4 animate-spin text-white motion-reduce:animate-none"
         xmlns="http://www.w3.org/2000/svg"
         fill="none"
-        viewBox="0 0 24 24">
+        viewBox="0 0 24 24"
+        aria-hidden="true">
         <circle
           class="opacity-25"
           cx="12"
@@ -61,6 +62,7 @@ const emit = defineEmits<{
           fill="currentColor"
           d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
       </svg>
+      <span class="sr-only">{{ t('web.COMMON.loading') }}</span>
     </span>
   </button>
 </template>

--- a/src/apps/secret/reveal/BurnSecret.vue
+++ b/src/apps/secret/reveal/BurnSecret.vue
@@ -24,7 +24,7 @@
     <!-- Loading State -->
     <div
       v-if="isLoading"
-      class="animate-pulse space-y-4"
+      class="animate-pulse motion-reduce:animate-none space-y-4"
       role="status"
       aria-live="polite"
       aria-busy="true">

--- a/src/apps/secret/reveal/branded/ShowSecret.vue
+++ b/src/apps/secret/reveal/branded/ShowSecret.vue
@@ -41,15 +41,12 @@
     :branded="true"
     :site-host="siteHost"
     class="container mx-auto mt-24 px-4">
-    <!-- Loading slot -->
-    <template #loading="{}">
-      <div class="flex justify-center">
-        <!-- prettier-ignore-attribute class -->
-        <div
-          class="size-32 animate-spin
-          rounded-full border-4 border-brand-500 border-t-transparent"></div>
-      </div>
-    </template>
+    <!--
+      No #loading slot: BaseShowSecret renders its own <SecretSkeleton> for the
+      secret fetch (see BaseShowSecret template). A #loading slot here never
+      rendered (the base has no <slot name="loading">), so the old spinner was
+      dead markup.
+    -->
 
     <!-- Error slot -->
     <template #error="{ error }">

--- a/src/apps/secret/reveal/canonical/ShowSecret.vue
+++ b/src/apps/secret/reveal/canonical/ShowSecret.vue
@@ -65,18 +65,12 @@
     :branded="false"
     :site-host="siteHost"
     class="container mx-auto mt-24 px-4">
-    <!-- Loading slot -->
-    <template #loading="{}">
-      <div class="flex justify-center">
-        <div
-          class="size-32 animate-spin rounded-full
-            border-4 border-brand-500 border-t-transparent"
-          role="status"
-          aria-live="polite">
-          <span class="sr-only">{{ t('web.COMMON.loading') }}</span>
-        </div>
-      </div>
-    </template>
+    <!--
+      No #loading slot: BaseShowSecret renders its own <SecretSkeleton> for the
+      secret fetch (see BaseShowSecret template). A #loading slot here never
+      rendered (the base has no <slot name="loading">), so the old spinner was
+      dead markup.
+    -->
 
     <!-- Error slot -->
     <template #error="{ error }">

--- a/src/apps/secret/support/Pricing.vue
+++ b/src/apps/secret/support/Pricing.vue
@@ -4,7 +4,7 @@
   import { useI18n } from 'vue-i18n';
   import { RouterLink, useRoute } from 'vue-router';
   import BasicFormAlerts from '@/shared/components/forms/BasicFormAlerts.vue';
-  import OIcon from '@/shared/components/icons/OIcon.vue';
+  import CardGridSkeleton from '@/shared/components/closet/CardGridSkeleton.vue';
   import PlanCard from '@/shared/components/billing/PlanCard.vue';
   import FeedbackToggle from '@/shared/components/ui/FeedbackToggle.vue';
   import { classifyError } from '@/schemas/errors';
@@ -227,20 +227,9 @@
         :error="error" />
 
       <!-- Loading State -->
-      <div
+      <CardGridSkeleton
         v-if="isLoadingPlans"
-        class="flex items-center justify-center py-12">
-        <div class="text-center">
-          <OIcon
-            collection="heroicons"
-            name="arrow-path"
-            class="mx-auto size-8 animate-spin text-gray-400"
-            aria-hidden="true" />
-          <p class="mt-2 text-sm text-gray-500 dark:text-gray-400">
-            {{ t('web.COMMON.loading') }}
-          </p>
-        </div>
-      </div>
+        class="py-12" />
 
       <!-- Free Tier Section (standalone banner mode) -->
       <div

--- a/src/apps/secret/support/Pricing.vue
+++ b/src/apps/secret/support/Pricing.vue
@@ -4,7 +4,7 @@
   import { useI18n } from 'vue-i18n';
   import { RouterLink, useRoute } from 'vue-router';
   import BasicFormAlerts from '@/shared/components/forms/BasicFormAlerts.vue';
-  import CardGridSkeleton from '@/shared/components/closet/CardGridSkeleton.vue';
+  import PlanCardSkeleton from '@/shared/components/billing/PlanCardSkeleton.vue';
   import PlanCard from '@/shared/components/billing/PlanCard.vue';
   import FeedbackToggle from '@/shared/components/ui/FeedbackToggle.vue';
   import { classifyError } from '@/schemas/errors';
@@ -227,7 +227,7 @@
         :error="error" />
 
       <!-- Loading State -->
-      <CardGridSkeleton
+      <PlanCardSkeleton
         v-if="isLoadingPlans"
         class="py-12" />
 
@@ -270,7 +270,7 @@
           :is-recommended="isPlanRecommended(plan)"
           :is-highlighted="isPlanHighlighted(plan)"
           :button-label="getCtaLabel(plan)"
-          class="w-full max-w-sm sm:w-80">
+          class="w-full max-w-sm">
           <template #action="{ plan: currentPlan }">
             <RouterLink
               v-if="signupEnabled"

--- a/src/apps/session/components/InviteSignInForm.vue
+++ b/src/apps/session/components/InviteSignInForm.vue
@@ -497,7 +497,7 @@ const handleSubmit = async () => {
               data-testid="invite-signin-magic-link-button">
               <span v-if="isMagicLinkLoading" class="flex items-center justify-center">
                 <svg
-                  class="-ml-1 mr-3 size-5 animate-spin text-white"
+                  class="-ml-1 mr-3 size-5 animate-spin motion-reduce:animate-none text-white"
                   xmlns="http://www.w3.org/2000/svg"
                   fill="none"
                   viewBox="0 0 24 24"
@@ -778,7 +778,7 @@ const handleSubmit = async () => {
             data-testid="invite-signin-magic-link-button">
             <span v-if="isMagicLinkLoading" class="flex items-center justify-center">
               <svg
-                class="-ml-1 mr-3 size-5 animate-spin text-white"
+                class="-ml-1 mr-3 size-5 animate-spin motion-reduce:animate-none text-white"
                 xmlns="http://www.w3.org/2000/svg"
                 fill="none"
                 viewBox="0 0 24 24"

--- a/src/apps/session/components/InviteSignUpForm.vue
+++ b/src/apps/session/components/InviteSignUpForm.vue
@@ -627,7 +627,7 @@ aria-hidden="true" />
               data-testid="invite-signup-magic-link-button">
               <span v-if="isMagicLinkLoading" class="flex items-center justify-center">
                 <svg
-                  class="-ml-1 mr-3 size-5 animate-spin text-white"
+                  class="-ml-1 mr-3 size-5 animate-spin motion-reduce:animate-none text-white"
                   xmlns="http://www.w3.org/2000/svg"
                   fill="none"
                   viewBox="0 0 24 24"
@@ -1017,7 +1017,7 @@ aria-hidden="true" />
             data-testid="invite-signup-magic-link-button">
             <span v-if="isMagicLinkLoading" class="flex items-center justify-center">
               <svg
-                class="-ml-1 mr-3 size-5 animate-spin text-white"
+                class="-ml-1 mr-3 size-5 animate-spin motion-reduce:animate-none text-white"
                 xmlns="http://www.w3.org/2000/svg"
                 fill="none"
                 viewBox="0 0 24 24"

--- a/src/apps/session/components/MagicLinkForm.vue
+++ b/src/apps/session/components/MagicLinkForm.vue
@@ -127,7 +127,7 @@ const handleTryAgain = () => {
           v-if="isLoading"
           class="flex items-center">
           <svg
-            class="-ml-1 mr-3 size-5 animate-spin text-white"
+            class="-ml-1 mr-3 size-5 animate-spin motion-reduce:animate-none text-white"
             xmlns="http://www.w3.org/2000/svg"
             fill="none"
             viewBox="0 0 24 24"

--- a/src/apps/session/components/PasswordlessFirstSignIn.vue
+++ b/src/apps/session/components/PasswordlessFirstSignIn.vue
@@ -349,7 +349,7 @@ data-testid="passkey-panel">
                 data-testid="webauthn-submit">
                 <span v-if="isLoading" class="flex items-center">
                   <svg
-                    class="-ml-1 mr-3 size-5 animate-spin text-white"
+                    class="-ml-1 mr-3 size-5 animate-spin motion-reduce:animate-none text-white"
                     xmlns="http://www.w3.org/2000/svg"
                     fill="none"
                     viewBox="0 0 24 24"
@@ -438,7 +438,7 @@ data-testid="passkey-panel">
               data-testid="magic-link-submit">
               <span v-if="isLoading" class="flex items-center">
                 <svg
-                  class="-ml-1 mr-3 size-5 animate-spin text-white"
+                  class="-ml-1 mr-3 size-5 animate-spin motion-reduce:animate-none text-white"
                   xmlns="http://www.w3.org/2000/svg"
                   fill="none"
                   viewBox="0 0 24 24"

--- a/src/apps/session/components/SsoButton.vue
+++ b/src/apps/session/components/SsoButton.vue
@@ -110,7 +110,7 @@ const handleSsoLogin = () => {
       data-testid="sso-button">
       <span v-if="isLoading" class="flex items-center gap-2">
         <svg
-          class="size-5 animate-spin text-gray-500 dark:text-gray-400"
+          class="size-5 animate-spin motion-reduce:animate-none text-gray-500 dark:text-gray-400"
           xmlns="http://www.w3.org/2000/svg"
           fill="none"
           viewBox="0 0 24 24"

--- a/src/apps/session/views/AcceptInvite.vue
+++ b/src/apps/session/views/AcceptInvite.vue
@@ -4,6 +4,7 @@
   import { useI18n } from 'vue-i18n';
   import BasicFormAlerts from '@/shared/components/forms/BasicFormAlerts.vue';
   import OIcon from '@/shared/components/icons/OIcon.vue';
+  import Skeleton from '@/shared/components/closet/Skeleton.vue';
   import InviteSignUpForm from '@/apps/session/components/InviteSignUpForm.vue';
   import InviteSignInForm from '@/apps/session/components/InviteSignInForm.vue';
   import { useAsyncHandler } from '@/shared/composables/useAsyncHandler';
@@ -259,17 +260,36 @@
     <div
       v-if="inviteState === 'loading'"
       data-testid="invite-loading"
-      class="flex items-center justify-center py-12">
-      <div class="text-center">
-        <OIcon
-          collection="heroicons"
-          name="arrow-path"
-          class="mx-auto size-8 animate-spin text-gray-400"
-          aria-hidden="true" />
-        <p class="mt-2 text-sm text-gray-500 dark:text-gray-400">
-          {{ t('web.organizations.invitations.loading_invitation') }}
-        </p>
+      role="status"
+      aria-busy="true"
+      class="animate-pulse space-y-6 rounded-lg border border-gray-200 bg-white p-8 shadow-sm motion-reduce:animate-none dark:border-gray-700 dark:bg-gray-800">
+      <span class="sr-only">{{ t('web.COMMON.loading') }}</span>
+      <!-- Heading block -->
+      <Skeleton
+        width="w-2/3"
+        height="h-8"
+        :pulse="false" />
+      <!-- Invite-context lines -->
+      <div class="space-y-3">
+        <Skeleton
+          width="w-1/2"
+          height="h-4"
+          :pulse="false" />
+        <Skeleton
+          width="w-3/4"
+          height="h-4"
+          :pulse="false" />
+        <Skeleton
+          width="w-2/5"
+          height="h-4"
+          :pulse="false" />
       </div>
+      <!-- Action button block -->
+      <Skeleton
+        width="w-full"
+        height="h-10"
+        rounded="rounded-md"
+        :pulse="false" />
     </div>
 
     <!-- Invalid/Expired State -->

--- a/src/apps/session/views/EmailLogin.vue
+++ b/src/apps/session/views/EmailLogin.vue
@@ -35,7 +35,7 @@ onMounted(async () => {
         v-if="isLoading"
         class="text-center">
         <svg
-          class="mx-auto size-16 animate-spin text-brand-600 dark:text-brand-400"
+          class="mx-auto size-16 animate-spin motion-reduce:animate-none text-brand-600 dark:text-brand-400"
           xmlns="http://www.w3.org/2000/svg"
           fill="none"
           viewBox="0 0 24 24"

--- a/src/apps/session/views/VerifyAccount.vue
+++ b/src/apps/session/views/VerifyAccount.vue
@@ -91,7 +91,7 @@
         <div class="flex">
           <div class="shrink-0">
             <svg
-              class="size-5 animate-spin text-blue-400"
+              class="size-5 animate-spin motion-reduce:animate-none text-blue-400"
               xmlns="http://www.w3.org/2000/svg"
               fill="none"
               viewBox="0 0 24 24"

--- a/src/apps/workspace/account/ActiveSessions.vue
+++ b/src/apps/workspace/account/ActiveSessions.vue
@@ -7,6 +7,7 @@
   import SettingsLayout from '@/apps/workspace/layouts/SettingsLayout.vue';
   import ConfirmDialog from '@/shared/components/modals/ConfirmDialog.vue';
   import OIcon from '@/shared/components/icons/OIcon.vue';
+  import ListSkeleton from '@/shared/components/closet/ListSkeleton.vue';
   import { useActiveSessions } from '@/shared/composables/useActiveSessions';
   import { computed, onMounted, ref } from 'vue';
 
@@ -73,16 +74,7 @@
       </div>
 
       <!-- Loading state -->
-      <div
-        v-if="isLoading"
-        class="flex items-center justify-center py-12">
-        <OIcon
-          collection="heroicons"
-          name="arrow-path"
-          class="mr-2 size-6 animate-spin text-gray-400"
-          aria-hidden="true" />
-        <span class="text-gray-600 dark:text-gray-400">{{ t('web.LABELS.loading') }}</span>
-      </div>
+      <ListSkeleton v-if="isLoading" />
 
       <!-- Error state -->
       <div

--- a/src/apps/workspace/account/PasskeySettings.vue
+++ b/src/apps/workspace/account/PasskeySettings.vue
@@ -3,6 +3,7 @@
 <script setup lang="ts">
   import { useI18n } from 'vue-i18n';
   import OIcon from '@/shared/components/icons/OIcon.vue';
+  import ListSkeleton from '@/shared/components/closet/ListSkeleton.vue';
   import SettingsLayout from '@/apps/workspace/layouts/SettingsLayout.vue';
   import PasswordConfirmModal from '@/shared/components/modals/PasswordConfirmModal.vue';
   import { useWebAuthn } from '@/shared/composables/useWebAuthn';
@@ -102,16 +103,7 @@
       </div>
 
       <!-- Loading state -->
-      <div
-        v-if="isLoadingPasskeys"
-        class="flex items-center justify-center py-12">
-        <OIcon
-          collection="heroicons"
-          name="arrow-path"
-          class="mr-2 size-6 animate-spin text-gray-400"
-          aria-hidden="true" />
-        <span class="text-gray-600 dark:text-gray-400">Loading passkeys...</span>
-      </div>
+      <ListSkeleton v-if="isLoadingPasskeys" />
 
       <!-- Browser not supported -->
       <div

--- a/src/apps/workspace/account/PasskeySettings.vue
+++ b/src/apps/workspace/account/PasskeySettings.vue
@@ -103,7 +103,10 @@
       </div>
 
       <!-- Loading state -->
-      <ListSkeleton v-if="isLoadingPasskeys" />
+      <ListSkeleton
+        v-if="isLoadingPasskeys"
+        icon
+        icon-size="w-5" />
 
       <!-- Browser not supported -->
       <div

--- a/src/apps/workspace/account/settings/ChangeEmail.vue
+++ b/src/apps/workspace/account/settings/ChangeEmail.vue
@@ -410,7 +410,7 @@
                   v-if="isLoading"
                   collection="heroicons"
                   name="arrow-path-solid"
-                  class="size-4 animate-spin"
+                  class="size-4 animate-spin motion-reduce:animate-none"
                   aria-hidden="true" />
                 {{
                   isLoading

--- a/src/apps/workspace/account/settings/ConfirmEmailChange.vue
+++ b/src/apps/workspace/account/settings/ConfirmEmailChange.vue
@@ -64,7 +64,7 @@
         <OIcon
           collection="heroicons"
           name="arrow-path-solid"
-          class="mx-auto size-8 animate-spin
+          class="mx-auto size-8 animate-spin motion-reduce:animate-none
             text-brand-500"
           aria-hidden="true" />
         <p

--- a/src/apps/workspace/account/settings/OrgSettingsSkeleton.vue
+++ b/src/apps/workspace/account/settings/OrgSettingsSkeleton.vue
@@ -1,0 +1,108 @@
+<!-- src/apps/workspace/account/settings/OrgSettingsSkeleton.vue -->
+
+<script setup lang="ts">
+  /**
+   * OrgSettingsSkeleton
+   *
+   * Page-specific loading placeholder for OrganizationSettings.vue. Co-located
+   * with the view (mirrors how DashboardSkeleton lives beside the dashboard).
+   *
+   * Where SettingsSkeleton is generic field-group chrome, this one reproduces
+   * the geometry unique to this page: the two-part page header (back-arrow +
+   * truncated title on the left, a pill-shaped billing chip on the right) and
+   * the underlined tab bar. Below that it shows a single content panel whose
+   * body mirrors the general/settings-tab field shape — so the comparison
+   * against SettingsSkeleton is apples-to-apples on the body and isolates the
+   * header + tab bar as the thing only the page-specific skeleton captures.
+   *
+   * Geometry is hardcoded to this one view; it is intentionally not prop-driven.
+   *
+   * Note on fidelity: the live page hides the tab bar while loading
+   * (it is gated on the fetched `organization`), so the real on-screen load is
+   * just header + spinner. This skeleton previews the *loaded* chrome instead —
+   * the point of a layout-aware skeleton is to reserve the post-load shape.
+   */
+  import { useI18n } from 'vue-i18n';
+  import Skeleton from '@/shared/components/closet/Skeleton.vue';
+
+  const { t } = useI18n();
+</script>
+
+<template>
+  <div
+    role="status"
+    aria-busy="true"
+    class="mx-auto max-w-4xl animate-pulse space-y-6 px-4 py-8 motion-reduce:animate-none sm:px-6 lg:px-8">
+    <span class="sr-only">{{ t('web.COMMON.loading') }}</span>
+
+    <!-- Page header: back-arrow + title (left), billing chip (right) -->
+    <div class="flex items-center justify-between">
+      <div class="flex items-center gap-2">
+        <!-- Back arrow -->
+        <Skeleton
+          width="w-5"
+          height="h-5"
+          :pulse="false" />
+        <!-- Org title -->
+        <Skeleton
+          width="w-48"
+          height="h-6"
+          :pulse="false" />
+      </div>
+      <!-- Billing/plan chip (pill) -->
+      <Skeleton
+        width="w-24"
+        height="h-7"
+        rounded="rounded-full"
+        :pulse="false" />
+    </div>
+
+    <!-- Tab bar (underlined nav): a row of tab-label blocks above the border -->
+    <div class="flex space-x-8 border-b border-gray-200 pb-4 dark:border-gray-700">
+      <Skeleton
+        class="w-16"
+        height="h-4"
+        :pulse="false" />
+      <Skeleton
+        class="w-16"
+        height="h-4"
+        :pulse="false" />
+      <Skeleton
+        class="w-16"
+        height="h-4"
+        :pulse="false" />
+    </div>
+
+    <!-- Content panel: section header (title + subtitle) over a field body -->
+    <div class="rounded-lg border border-gray-200/60 dark:border-gray-700/60">
+      <!-- Panel header -->
+      <div class="space-y-2 border-b border-gray-200 px-6 py-4 dark:border-gray-700">
+        <Skeleton
+          width="w-40"
+          height="h-5"
+          :pulse="false" />
+        <Skeleton
+          width="w-2/3"
+          height="h-3"
+          :pulse="false" />
+      </div>
+
+      <!-- Panel body: label + input field groups -->
+      <div class="space-y-6 p-6">
+        <div
+          v-for="n in 2"
+          :key="n"
+          class="space-y-2">
+          <Skeleton
+            width="w-1/4"
+            height="h-4"
+            :pulse="false" />
+          <Skeleton
+            height="h-10"
+            rounded="rounded-md"
+            :pulse="false" />
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/src/apps/workspace/account/settings/OrganizationSettings.vue
+++ b/src/apps/workspace/account/settings/OrganizationSettings.vue
@@ -8,6 +8,9 @@ import MembersTable from '@/apps/workspace/components/members/MembersTable.vue';
 import DomainsTable from '@/apps/workspace/components/domains/DomainsTable.vue';
 import EmptyState from '@/shared/components/ui/EmptyState.vue';
 import EntitlementUpgradePrompt from '@/apps/workspace/components/billing/EntitlementUpgradePrompt.vue';
+import SettingsSkeleton from '@/shared/components/closet/SettingsSkeleton.vue';
+import ListSkeleton from '@/shared/components/closet/ListSkeleton.vue';
+import TableSkeleton from '@/shared/components/closet/TableSkeleton.vue';
 import { useEntitlements } from '@/shared/composables/useEntitlements';
 import { useAsyncHandler } from '@/shared/composables/useAsyncHandler';
 import { useEntitlementError } from '@/shared/composables/useEntitlementError';
@@ -737,18 +740,7 @@ const handleTabKeydown = (e: KeyboardEvent) => {
       </div>
 
       <!-- Loading State -->
-      <div v-if="isLoading" class="flex items-center justify-center py-12">
-        <div class="text-center">
-          <OIcon
-            collection="heroicons"
-            name="arrow-path"
-            class="mx-auto size-8 animate-spin text-gray-400"
-            aria-hidden="true" />
-          <p class="mt-2 text-sm text-gray-500 dark:text-gray-400">
-            {{ t('web.COMMON.loading') }}
-          </p>
-        </div>
-      </div>
+      <SettingsSkeleton v-if="isLoading" />
 
       <!-- Error State: Organization not found or failed to load -->
       <div v-else-if="orgNotFound || (error && !organization)" class="flex items-center justify-center py-12">
@@ -1072,13 +1064,7 @@ const handleTabKeydown = (e: KeyboardEvent) => {
               </p>
             </div>
 
-            <div v-else class="flex items-center justify-center py-8">
-              <OIcon
-                collection="heroicons"
-                name="arrow-path"
-                class="size-6 animate-spin text-gray-400"
-                aria-hidden="true" />
-            </div>
+            <ListSkeleton v-else />
 
             <div v-if="invitations.length > 0" class="mt-6 border-t border-gray-200 pt-6 dark:border-gray-700">
               <h4 class="text-sm font-medium text-gray-700 dark:text-gray-300">
@@ -1158,13 +1144,7 @@ const handleTabKeydown = (e: KeyboardEvent) => {
 
           <div class="p-6">
             <!-- Loading State -->
-            <div v-if="isLoadingDomains" class="flex items-center justify-center py-8">
-              <OIcon
-                collection="heroicons"
-                name="arrow-path"
-                class="size-6 animate-spin text-gray-400"
-                aria-hidden="true" />
-            </div>
+            <TableSkeleton v-if="isLoadingDomains" />
 
             <!-- Error State -->
             <BasicFormAlerts
@@ -1234,13 +1214,9 @@ const handleTabKeydown = (e: KeyboardEvent) => {
               </div>
 
               <div class="p-6">
-                <div v-if="isLoadingBilling" class="flex items-center justify-center py-8">
-                  <OIcon
-                    collection="heroicons"
-                    name="arrow-path"
-                    class="size-6 animate-spin text-gray-400"
-                    aria-hidden="true" />
-                </div>
+                <SettingsSkeleton
+                  v-if="isLoadingBilling"
+                  :heading="false" />
 
                 <div v-else-if="subscription" class="space-y-4">
                   <!-- Plan Info -->
@@ -1478,14 +1454,7 @@ const handleTabKeydown = (e: KeyboardEvent) => {
 
             <div class="p-6">
               <!-- Loading state -->
-              <div v-if="isLoadingDomains" class="flex items-center justify-center py-8">
-                <OIcon
-                  collection="heroicons"
-                  name="arrow-path"
-                  class="size-6 animate-spin text-gray-400"
-                  aria-hidden="true" />
-                <span class="sr-only">{{ t('web.COMMON.loading') }}</span>
-              </div>
+              <ListSkeleton v-if="isLoadingDomains" />
 
               <!-- Empty state -->
               <div v-else-if="domainCount === 0" class="py-8 text-center">

--- a/src/apps/workspace/account/settings/OrganizationSettings.vue
+++ b/src/apps/workspace/account/settings/OrganizationSettings.vue
@@ -1301,7 +1301,7 @@ const handleTabKeydown = (e: KeyboardEvent) => {
                       <div
                         v-for="i in 4"
                         :key="i"
-                        class="flex animate-pulse items-center gap-2">
+                        class="flex animate-pulse motion-reduce:animate-none items-center gap-2">
                         <div class="size-5 rounded-full bg-gray-200 dark:bg-gray-700"></div>
                         <div class="h-4 w-32 rounded bg-gray-200 dark:bg-gray-700"></div>
                       </div>

--- a/src/apps/workspace/account/settings/OrganizationSettings.vue
+++ b/src/apps/workspace/account/settings/OrganizationSettings.vue
@@ -1064,7 +1064,7 @@ const handleTabKeydown = (e: KeyboardEvent) => {
               </p>
             </div>
 
-            <ListSkeleton v-else />
+            <TableSkeleton v-else />
 
             <div v-if="invitations.length > 0" class="mt-6 border-t border-gray-200 pt-6 dark:border-gray-700">
               <h4 class="text-sm font-medium text-gray-700 dark:text-gray-300">
@@ -1454,7 +1454,10 @@ const handleTabKeydown = (e: KeyboardEvent) => {
 
             <div class="p-6">
               <!-- Loading state -->
-              <ListSkeleton v-if="isLoadingDomains" />
+              <ListSkeleton
+                v-if="isLoadingDomains"
+                icon
+                icon-size="w-5" />
 
               <!-- Empty state -->
               <div v-else-if="domainCount === 0" class="py-8 text-center">

--- a/src/apps/workspace/account/settings/OrganizationsSettings.vue
+++ b/src/apps/workspace/account/settings/OrganizationsSettings.vue
@@ -9,6 +9,7 @@
   import { useI18n } from 'vue-i18n';
   import OIcon from '@/shared/components/icons/OIcon.vue';
   import CreateOrganizationModal from '@/apps/workspace/components/organizations/CreateOrganizationModal.vue';
+  import ListSkeleton from '@/shared/components/closet/ListSkeleton.vue';
   import { useEntitlements } from '@/shared/composables/useEntitlements';
   import { useBootstrapStore } from '@/shared/stores/bootstrapStore';
   import { useOrganizationStore } from '@/shared/stores/organizationStore';
@@ -139,20 +140,7 @@
         class="rounded-lg border border-gray-200/60 bg-white/60 shadow-sm backdrop-blur-sm dark:border-gray-700/60 dark:bg-gray-800/60">
         <div class="p-6">
           <!-- Loading State -->
-          <div
-            v-if="isLoading"
-            class="flex items-center justify-center py-12">
-            <div class="text-center">
-              <OIcon
-                collection="heroicons"
-                name="arrow-path"
-                class="mx-auto size-8 animate-spin text-gray-400"
-                aria-hidden="true" />
-              <p class="mt-2 text-sm text-gray-500 dark:text-gray-400">
-                {{ t('web.COMMON.loading') }}
-              </p>
-            </div>
-          </div>
+          <ListSkeleton v-if="isLoading" />
 
           <!-- Organizations List -->
           <div

--- a/src/apps/workspace/account/settings/ProfileSettings.vue
+++ b/src/apps/workspace/account/settings/ProfileSettings.vue
@@ -348,7 +348,7 @@
             <div
               v-for="i in 4"
               :key="i"
-              class="flex animate-pulse items-center gap-2">
+              class="flex animate-pulse motion-reduce:animate-none items-center gap-2">
               <div class="size-5 rounded-full bg-gray-200 dark:bg-gray-700"></div>
               <div class="h-4 w-32 rounded bg-gray-200 dark:bg-gray-700"></div>
             </div>

--- a/src/apps/workspace/billing/BillingOverview.vue
+++ b/src/apps/workspace/billing/BillingOverview.vue
@@ -4,6 +4,7 @@
 import { useI18n } from 'vue-i18n';
 import { useRoute } from 'vue-router';
 import BasicFormAlerts from '@/shared/components/forms/BasicFormAlerts.vue';
+import SettingsSkeleton from '@/shared/components/closet/SettingsSkeleton.vue';
 import OIcon from '@/shared/components/icons/OIcon.vue';
 import BillingLayout from '@/shared/components/layout/BillingLayout.vue';
 import FederationNotification from './FederationNotification.vue';
@@ -234,18 +235,7 @@ onMounted(async () => {
       <BasicFormAlerts v-if="success" :success="success" />
 
       <!-- Loading State -->
-      <div v-if="isLoading" class="flex items-center justify-center py-12">
-        <div class="text-center">
-          <OIcon
-            collection="heroicons"
-            name="arrow-path"
-            class="mx-auto size-8 animate-spin text-gray-400"
-            aria-hidden="true" />
-          <p class="mt-2 text-sm text-gray-500 dark:text-gray-400">
-            {{ t('web.COMMON.loading') }}
-          </p>
-        </div>
-      </div>
+      <SettingsSkeleton v-if="isLoading" />
 
       <!-- Empty State: No Organizations -->
       <div v-else-if="organizations.length === 0" class="rounded-lg border border-gray-200/60 bg-white/60 p-12 text-center shadow-sm backdrop-blur-sm dark:border-gray-700/60 dark:bg-gray-800/60">

--- a/src/apps/workspace/billing/BillingOverview.vue
+++ b/src/apps/workspace/billing/BillingOverview.vue
@@ -323,7 +323,7 @@ onMounted(async () => {
                 <div
                   v-for="i in 4"
                   :key="i"
-                  class="flex animate-pulse items-center gap-2">
+                  class="flex animate-pulse motion-reduce:animate-none items-center gap-2">
                   <div class="size-5 rounded-full bg-gray-200 dark:bg-gray-700"></div>
                   <div class="h-4 w-32 rounded bg-gray-200 dark:bg-gray-700"></div>
                 </div>
@@ -421,8 +421,12 @@ onMounted(async () => {
                       v-else
                       collection="heroicons"
                       name="arrow-path"
-                      class="size-4 animate-spin"
+                      class="size-4 animate-spin motion-reduce:animate-none"
                       aria-hidden="true" />
+                    <span
+                      v-if="isSavingBillingEmail"
+                      class="sr-only"
+                      >{{ t('web.COMMON.loading') }}</span>
                   </button>
                   <button
                     type="button"

--- a/src/apps/workspace/billing/CurrencyMigrationModal.vue
+++ b/src/apps/workspace/billing/CurrencyMigrationModal.vue
@@ -310,7 +310,7 @@ function handleClose() {
                     v-if="isMigrating"
                     collection="heroicons"
                     name="arrow-path"
-                    class="mr-2 size-4 animate-spin"
+                    class="mr-2 size-4 animate-spin motion-reduce:animate-none"
                     aria-hidden="true" />
                   {{ isMigrating
                     ? t('web.COMMON.processing')

--- a/src/apps/workspace/billing/FederationNotification.vue
+++ b/src/apps/workspace/billing/FederationNotification.vue
@@ -90,8 +90,12 @@ const handleDismiss = async () => {
           v-else
           collection="heroicons"
           name="arrow-path"
-          class="size-5 animate-spin"
+          class="size-5 animate-spin motion-reduce:animate-none"
           aria-hidden="true" />
+        <span
+          v-if="isDismissing"
+          class="sr-only"
+          >{{ t('web.COMMON.loading') }}</span>
       </button>
     </div>
   </div>

--- a/src/apps/workspace/billing/InvoiceList.vue
+++ b/src/apps/workspace/billing/InvoiceList.vue
@@ -4,6 +4,7 @@
 import { useI18n } from 'vue-i18n';
 import { useRoute } from 'vue-router';
 import BasicFormAlerts from '@/shared/components/forms/BasicFormAlerts.vue';
+import TableSkeleton from '@/shared/components/closet/TableSkeleton.vue';
 import OIcon from '@/shared/components/icons/OIcon.vue';
 import BillingLayout from '@/shared/components/layout/BillingLayout.vue';
 import { classifyError } from '@/schemas/errors';
@@ -79,18 +80,7 @@ onMounted(async () => {
       <BasicFormAlerts v-if="error" :error="error" />
 
       <!-- Loading State -->
-      <div v-if="isLoading" class="flex items-center justify-center py-12">
-        <div class="text-center">
-          <OIcon
-            collection="heroicons"
-            name="arrow-path"
-            class="mx-auto size-8 animate-spin text-gray-400"
-            aria-hidden="true" />
-          <p class="mt-2 text-sm text-gray-500 dark:text-gray-400">
-            {{ t('web.COMMON.loading') }}
-          </p>
-        </div>
-      </div>
+      <TableSkeleton v-if="isLoading" />
 
       <!-- Invoice Table -->
       <div v-else-if="invoices.length > 0" class="overflow-hidden rounded-lg border border-gray-200/60 bg-white/60 shadow-sm backdrop-blur-sm dark:border-gray-700/60 dark:bg-gray-800/60">

--- a/src/apps/workspace/billing/PendingMigrationBanner.vue
+++ b/src/apps/workspace/billing/PendingMigrationBanner.vue
@@ -59,7 +59,7 @@ const currencyUpper = computed(() => props.targetCurrency.toUpperCase());
               v-if="isCompletingMigration"
               collection="heroicons"
               name="arrow-path"
-              class="mr-2 size-4 animate-spin"
+              class="mr-2 size-4 animate-spin motion-reduce:animate-none"
               aria-hidden="true" />
             {{ isCompletingMigration
               ? t('web.COMMON.processing')

--- a/src/apps/workspace/billing/PlanChangeModal.vue
+++ b/src/apps/workspace/billing/PlanChangeModal.vue
@@ -450,7 +450,7 @@ aria-live="polite">
                     v-if="isChangingPlan"
                     collection="heroicons"
                     name="arrow-path"
-                    class="mr-2 size-4 animate-spin"
+                    class="mr-2 size-4 animate-spin motion-reduce:animate-none"
                     aria-hidden="true" />
                   {{ isChangingPlan ? t('web.COMMON.processing') : confirmButtonLabel }}
                 </button>

--- a/src/apps/workspace/billing/PlanChangeModal.vue
+++ b/src/apps/workspace/billing/PlanChangeModal.vue
@@ -2,6 +2,7 @@
 
 <script setup lang="ts">
 import { useI18n } from 'vue-i18n';
+import Skeleton from '@/shared/components/closet/Skeleton.vue';
 import OIcon from '@/shared/components/icons/OIcon.vue';
 import { Dialog, DialogPanel, DialogTitle, TransitionChild, TransitionRoot } from '@headlessui/vue';
 import { BillingService, type Plan as BillingPlan, type PlanChangePreviewResponse } from '@/services/billing.service';
@@ -265,12 +266,24 @@ aria-describedby="plan-change-description"
               </div>
 
               <!-- Loading State -->
-              <div v-if="isLoadingPreview" class="mt-6 flex items-center justify-center py-8">
-                <OIcon
-                  collection="heroicons"
-                  name="arrow-path"
-                  class="size-8 animate-spin text-gray-400"
-                  aria-hidden="true" />
+              <div
+                v-if="isLoadingPreview"
+                role="status"
+                aria-busy="true"
+                class="mt-6 animate-pulse space-y-3 rounded-lg border border-gray-200 bg-gray-50 p-4 motion-reduce:animate-none dark:border-gray-700 dark:bg-gray-900/50">
+                <span class="sr-only">{{ t('web.COMMON.loading') }}</span>
+                <Skeleton
+                  width="w-1/2"
+                  height="h-4"
+                  :pulse="false" />
+                <Skeleton
+                  width="w-2/3"
+                  height="h-4"
+                  :pulse="false" />
+                <Skeleton
+                  width="w-1/3"
+                  height="h-4"
+                  :pulse="false" />
               </div>
 
               <!-- Error State -->

--- a/src/apps/workspace/billing/PlanSelector.vue
+++ b/src/apps/workspace/billing/PlanSelector.vue
@@ -3,6 +3,7 @@
 <script setup lang="ts">
 import { useI18n } from 'vue-i18n';
 import BasicFormAlerts from '@/shared/components/forms/BasicFormAlerts.vue';
+import CardGridSkeleton from '@/shared/components/closet/CardGridSkeleton.vue';
 import BillingLayout from '@/shared/components/layout/BillingLayout.vue';
 import FeedbackToggle from '@/shared/components/ui/FeedbackToggle.vue';
 import OIcon from '@/shared/components/icons/OIcon.vue';
@@ -600,18 +601,7 @@ aria-live="polite">
       <BasicFormAlerts v-if="definitionsError" :error="definitionsError" />
 
       <!-- Loading State -->
-      <div v-if="isLoadingContent" class="flex items-center justify-center py-12">
-        <div class="text-center">
-          <OIcon
-            collection="heroicons"
-            name="arrow-path"
-            class="mx-auto size-8 animate-spin text-gray-400"
-            aria-hidden="true" />
-          <p class="mt-2 text-sm text-gray-500 dark:text-gray-400">
-            {{ t('web.COMMON.loading') }}
-          </p>
-        </div>
-      </div>
+      <CardGridSkeleton v-if="isLoadingContent" />
 
       <!-- Free Tier Section (standalone banner mode) -->
       <div

--- a/src/apps/workspace/billing/PlanSelector.vue
+++ b/src/apps/workspace/billing/PlanSelector.vue
@@ -3,7 +3,7 @@
 <script setup lang="ts">
 import { useI18n } from 'vue-i18n';
 import BasicFormAlerts from '@/shared/components/forms/BasicFormAlerts.vue';
-import CardGridSkeleton from '@/shared/components/closet/CardGridSkeleton.vue';
+import PlanCardSkeleton from '@/shared/components/billing/PlanCardSkeleton.vue';
 import BillingLayout from '@/shared/components/layout/BillingLayout.vue';
 import FeedbackToggle from '@/shared/components/ui/FeedbackToggle.vue';
 import OIcon from '@/shared/components/icons/OIcon.vue';
@@ -601,11 +601,11 @@ aria-live="polite">
       <BasicFormAlerts v-if="definitionsError" :error="definitionsError" />
 
       <!-- Loading State -->
-      <CardGridSkeleton v-if="isLoadingContent" />
+      <PlanCardSkeleton v-if="isLoadingContent" />
 
       <!-- Free Tier Section (standalone banner mode) -->
       <div
-        v-if="freePlanStandalone && freePlan && !isLoadingContent"
+        v-else-if="freePlanStandalone && freePlan"
         class="rounded-lg border border-gray-200/60 bg-gray-50/60 p-6 shadow-sm backdrop-blur-sm dark:border-gray-700/60 dark:bg-gray-900/50">
         <div class="flex flex-col items-center justify-between gap-4 sm:flex-row">
           <div>
@@ -625,7 +625,7 @@ aria-live="polite">
       </div>
 
       <!-- No Plans Message -->
-      <div v-else-if="!isLoadingContent && filteredPlans.length === 0" class="rounded-lg border border-gray-200/60 bg-gray-50/60 p-8 text-center shadow-sm backdrop-blur-sm dark:border-gray-700/60 dark:bg-gray-900/50">
+      <div v-else-if="filteredPlans.length === 0" class="rounded-lg border border-gray-200/60 bg-gray-50/60 p-8 text-center shadow-sm backdrop-blur-sm dark:border-gray-700/60 dark:bg-gray-900/50">
         <p class="text-gray-600 dark:text-gray-400">
           {{ t('web.billing.plans.no_plans_available', { interval: billingInterval === 'year' ? t('web.billing.plans.yearly').toLowerCase() : t('web.billing.plans.monthly').toLowerCase() }) }}
         </p>

--- a/src/apps/workspace/components/account/AccountDeleteButtonWithModalForm.vue
+++ b/src/apps/workspace/components/account/AccountDeleteButtonWithModalForm.vue
@@ -141,7 +141,7 @@ const closeDeleteModal = () => {
               v-if="isDeleting"
               collection="heroicons"
               name="arrow-path"
-              class="-ml-1 mr-3 size-5 animate-spin"
+              class="-ml-1 mr-3 size-5 animate-spin motion-reduce:animate-none"
               aria-hidden="true" />
             <!-- no-symbol: Reserved exclusively for destructive/irreversible actions -->
             <OIcon

--- a/src/apps/workspace/components/account/DomainBrandView.vue
+++ b/src/apps/workspace/components/account/DomainBrandView.vue
@@ -68,10 +68,11 @@ const backgroundIcon = computed(() => props.defaultIcon);
             v-if="loading"
             class="absolute inset-0 flex items-center justify-center rounded-md bg-gray-200/75 dark:bg-gray-800/75">
             <svg
-              class="size-8 animate-spin text-brand-600"
+              class="size-8 animate-spin text-brand-600 motion-reduce:animate-none"
               xmlns="http://www.w3.org/2000/svg"
               fill="none"
-              viewBox="0 0 24 24">
+              viewBox="0 0 24 24"
+              aria-hidden="true">
               <circle
                 class="opacity-25"
                 cx="12"
@@ -84,6 +85,7 @@ const backgroundIcon = computed(() => props.defaultIcon);
                 fill="currentColor"
                 d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
             </svg>
+            <span class="sr-only">{{ t('web.COMMON.loading') }}</span>
           </div>
         </div>
       </div>

--- a/src/apps/workspace/components/dashboard/BrandSettingsBar.vue
+++ b/src/apps/workspace/components/dashboard/BrandSettingsBar.vue
@@ -132,7 +132,7 @@
                 v-if="isLoading"
                 collection="mdi"
                 name="loading"
-                class="-ml-1 mr-2 size-4 animate-spin" />
+                class="-ml-1 mr-2 size-4 animate-spin motion-reduce:animate-none" />
               <OIcon
                 v-else
                 collection="mdi"

--- a/src/apps/workspace/components/dashboard/DomainHeader.vue
+++ b/src/apps/workspace/components/dashboard/DomainHeader.vue
@@ -96,8 +96,8 @@
         v-else
         class="mt-4 flex flex-col gap-1">
         <!-- Loading placeholder -->
-        <div class="h-8 w-64 animate-pulse rounded bg-gray-200 dark:bg-gray-700"></div>
-        <div class="h-4 w-24 animate-pulse rounded bg-gray-200 dark:bg-gray-700"></div>
+        <div class="h-8 w-64 animate-pulse motion-reduce:animate-none rounded bg-gray-200 dark:bg-gray-700"></div>
+        <div class="h-4 w-24 animate-pulse motion-reduce:animate-none rounded bg-gray-200 dark:bg-gray-700"></div>
       </div>
     </div>
   </div>

--- a/src/apps/workspace/components/domains/DnsWidget.vue
+++ b/src/apps/workspace/components/domains/DnsWidget.vue
@@ -2,6 +2,7 @@
 
 <script setup lang="ts">
   import { useI18n } from 'vue-i18n';
+  import Skeleton from '@/shared/components/closet/Skeleton.vue';
   import { useDnsWidget, type DnsRecord } from '@/shared/composables/useDnsWidget';
   import { computed, onMounted, watch } from 'vue';
 
@@ -137,11 +138,15 @@
     <!-- Loading state -->
     <div
       v-if="isLoading"
-      class="flex items-center justify-center py-8">
-      <div class="h-8 w-8 animate-spin rounded-full border-4 border-brand-500 border-t-transparent" ></div>
-      <span class="ml-3 text-gray-600 dark:text-gray-400">
-        {{ t('web.COMMON.loading') }}
-      </span>
+      role="status"
+      aria-busy="true"
+      class="animate-pulse space-y-3 py-8 motion-reduce:animate-none">
+      <span class="sr-only">{{ t('web.COMMON.loading') }}</span>
+      <Skeleton
+        :count="4"
+        height="h-12"
+        rounded="rounded-md"
+        :pulse="false" />
     </div>
 
     <!-- Error state -->

--- a/src/apps/workspace/components/domains/DomainEmailConfigForm.vue
+++ b/src/apps/workspace/components/domains/DomainEmailConfigForm.vue
@@ -262,7 +262,7 @@ const providerDisplayName = computed(() => {
             v-if="isTesting"
             collection="heroicons"
             name="arrow-path"
-            class="size-4 animate-spin"
+            class="size-4 animate-spin motion-reduce:animate-none"
             aria-hidden="true" />
           <OIcon
             v-else
@@ -467,7 +467,7 @@ const providerDisplayName = computed(() => {
           v-if="isSaving"
           collection="heroicons"
           name="arrow-path"
-          class="size-4 animate-spin"
+          class="size-4 animate-spin motion-reduce:animate-none"
           aria-hidden="true" />
         <span v-if="isSaving">{{ t('web.COMMON.saving') }}</span>
         <span v-else>{{ t('web.domains.email.save_changes') }}</span>

--- a/src/apps/workspace/components/domains/DomainEmailDnsRecords.vue
+++ b/src/apps/workspace/components/domains/DomainEmailDnsRecords.vue
@@ -97,7 +97,7 @@ const formatDate = (date: Date): string => new Intl.DateTimeFormat(undefined, {
           v-if="isValidating"
           collection="heroicons"
           name="arrow-path"
-          class="size-4 animate-spin"
+          class="size-4 animate-spin motion-reduce:animate-none"
           aria-hidden="true" />
         <OIcon
           v-else

--- a/src/apps/workspace/components/domains/DomainForm.vue
+++ b/src/apps/workspace/components/domains/DomainForm.vue
@@ -118,7 +118,7 @@ class="space-y-6">
             v-if="isSubmitting"
             class="inline-flex items-center">
             <svg
-              class="-ml-1 mr-2 size-5 animate-spin text-white"
+              class="-ml-1 mr-2 size-5 animate-spin motion-reduce:animate-none text-white"
               xmlns="http://www.w3.org/2000/svg"
               fill="none"
               viewBox="0 0 24 24">

--- a/src/apps/workspace/components/domains/DomainIncomingConfigForm.vue
+++ b/src/apps/workspace/components/domains/DomainIncomingConfigForm.vue
@@ -476,7 +476,7 @@ function handleToggleEnabled(): void {
           v-if="isSaving"
           collection="heroicons"
           name="arrow-path"
-          class="size-4 animate-spin"
+          class="size-4 animate-spin motion-reduce:animate-none"
           aria-hidden="true" />
         <span v-if="isSaving">{{ t('web.COMMON.saving') }}</span>
         <span v-else>{{ t('web.domains.incoming.save_changes') }}</span>

--- a/src/apps/workspace/components/domains/DomainSignupConfigForm.vue
+++ b/src/apps/workspace/components/domains/DomainSignupConfigForm.vue
@@ -11,6 +11,7 @@
 import { useI18n } from 'vue-i18n';
 import { computed, ref, watch } from 'vue';
 import OIcon from '@/shared/components/icons/OIcon.vue';
+import SettingsSkeleton from '@/shared/components/closet/SettingsSkeleton.vue';
 import {
   SIGNUP_STRATEGY_METADATA,
   type CustomDomainSignupConfig,
@@ -173,14 +174,9 @@ watch(newDomain, () => {
 <template>
   <div class="space-y-6">
     <!-- Loading State -->
-    <div v-if="isLoading" class="flex items-center justify-center py-12">
-      <OIcon
-        collection="heroicons"
-        name="arrow-path"
-        class="size-8 animate-spin text-gray-400"
-        aria-hidden="true" />
-      <span class="sr-only">{{ t('web.COMMON.loading') }}</span>
-    </div>
+    <SettingsSkeleton
+      v-if="isLoading"
+      :heading="false" />
 
     <!-- Form -->
     <form v-else

--- a/src/apps/workspace/components/domains/DomainSignupConfigForm.vue
+++ b/src/apps/workspace/components/domains/DomainSignupConfigForm.vue
@@ -439,7 +439,7 @@ class="space-y-6">
             v-if="isSaving"
             collection="heroicons"
             name="arrow-path"
-            class="size-4 animate-spin"
+            class="size-4 animate-spin motion-reduce:animate-none"
             aria-hidden="true" />
           <span v-if="isSaving">{{ t('web.COMMON.saving') }}</span>
           <span v-else>{{ isEditing ? t('web.COMMON.save_changes') : t('web.domains.signup.save_config') }}</span>

--- a/src/apps/workspace/components/domains/DomainSsoConfigForm.vue
+++ b/src/apps/workspace/components/domains/DomainSsoConfigForm.vue
@@ -11,6 +11,7 @@
 import { useI18n } from 'vue-i18n';
 import { computed, ref, watch } from 'vue';
 import OIcon from '@/shared/components/icons/OIcon.vue';
+import SettingsSkeleton from '@/shared/components/closet/SettingsSkeleton.vue';
 import {
   SSO_PROVIDER_METADATA,
   type CustomDomainSsoConfig,
@@ -212,14 +213,9 @@ watch(newDomain, () => {
 <template>
   <div class="space-y-6">
     <!-- Loading State -->
-    <div v-if="isLoading" class="flex items-center justify-center py-12">
-      <OIcon
-        collection="heroicons"
-        name="arrow-path"
-        class="size-8 animate-spin text-gray-400"
-        aria-hidden="true" />
-      <span class="sr-only">{{ t('web.COMMON.loading') }}</span>
-    </div>
+    <SettingsSkeleton
+      v-if="isLoading"
+      :heading="false" />
 
     <!-- Form -->
     <form v-else

--- a/src/apps/workspace/components/domains/DomainSsoConfigForm.vue
+++ b/src/apps/workspace/components/domains/DomainSsoConfigForm.vue
@@ -458,7 +458,7 @@ aria-hidden="true">*</span>
               collection="heroicons"
               name="arrow-path"
               size="4"
-              class="animate-spin"
+              class="animate-spin motion-reduce:animate-none"
               aria-hidden="true" />
             <OIcon
               v-else
@@ -803,7 +803,7 @@ aria-hidden="true">*</span>
             v-if="isSaving"
             collection="heroicons"
             name="arrow-path"
-            class="size-4 animate-spin"
+            class="size-4 animate-spin motion-reduce:animate-none"
             aria-hidden="true" />
           <span v-if="isSaving">{{ t('web.COMMON.saving') }}</span>
           <span v-else>{{ isEditing ? t('web.COMMON.save_changes') : t('web.organizations.sso.save_config') }}</span>

--- a/src/apps/workspace/components/domains/PrivacyDefaultsModal.vue
+++ b/src/apps/workspace/components/domains/PrivacyDefaultsModal.vue
@@ -297,7 +297,7 @@
                       v-if="isSaving"
                       collection="mdi"
                       name="loading"
-                      class="-ml-0.5 mr-2 size-4 animate-spin" />
+                      class="-ml-0.5 mr-2 size-4 animate-spin motion-reduce:animate-none" />
                     <OIcon
                       v-else
                       collection="mdi"

--- a/src/apps/workspace/components/domains/VerifyDomainDetails.vue
+++ b/src/apps/workspace/components/domains/VerifyDomainDetails.vue
@@ -85,7 +85,7 @@ const verify = async () => {
           collection="mdi"
           :name="isLoading ? 'loading' : 'check-circle'"
           class="size-5"
-          :class="{ 'animate-spin': isLoading }"
+          :class="{ 'animate-spin motion-reduce:animate-none': isLoading }"
           aria-hidden="true" />
       </button>
     </div>

--- a/src/apps/workspace/dashboard/DashboardSkeleton.vue
+++ b/src/apps/workspace/dashboard/DashboardSkeleton.vue
@@ -3,37 +3,72 @@
 <!-- Loading skeleton that mimics dashboard layout without content -->
 
 <script setup lang="ts">
+  import { useI18n } from 'vue-i18n';
+  import Skeleton from '@/shared/components/closet/Skeleton.vue';
+
+  const { t } = useI18n();
 </script>
 
 <template>
-  <div class="container mx-auto min-w-[320px] max-w-2xl animate-pulse">
+  <div
+    role="status"
+    aria-busy="true"
+    class="container mx-auto min-w-[320px] max-w-2xl animate-pulse motion-reduce:animate-none">
+    <span class="sr-only">{{ t('web.COMMON.loading') }}</span>
     <!-- Secret Form Skeleton -->
     <div class="mb-10 space-y-4">
       <!-- Textarea placeholder -->
-      <div class="h-32 rounded-lg bg-gray-200 dark:bg-gray-700"></div>
+      <Skeleton
+        height="h-32"
+        rounded="rounded-lg"
+        :pulse="false" />
 
       <!-- Options row placeholder -->
+      <!-- w-1/3 sizes the flex item (Skeleton's root), so it goes on `class`. -->
       <div class="flex gap-4">
-        <div class="h-10 w-1/3 rounded-lg bg-gray-200 dark:bg-gray-700"></div>
-        <div class="h-10 w-1/3 rounded-lg bg-gray-200 dark:bg-gray-700"></div>
+        <Skeleton
+          class="w-1/3"
+          height="h-10"
+          rounded="rounded-lg"
+          :pulse="false" />
+        <Skeleton
+          class="w-1/3"
+          height="h-10"
+          rounded="rounded-lg"
+          :pulse="false" />
       </div>
 
-      <!-- Button placeholder -->
-      <div class="h-12 w-full rounded-lg bg-gray-300 dark:bg-gray-600"></div>
+      <!-- Button placeholder (was gray-300/600 → normalizes to gray-200/700) -->
+      <Skeleton
+        height="h-12"
+        rounded="rounded-lg"
+        :pulse="false" />
     </div>
 
     <!-- Teams Section Skeleton (optional, appears for team-capable users) -->
     <div class="mb-10 space-y-4">
       <!-- Section header -->
       <div class="flex items-center justify-between">
-        <div class="h-6 w-32 rounded bg-gray-200 dark:bg-gray-700"></div>
-        <div class="h-4 w-20 rounded bg-gray-200 dark:bg-gray-700"></div>
+        <Skeleton
+          class="w-32"
+          height="h-6"
+          :pulse="false" />
+        <Skeleton
+          class="w-20"
+          height="h-4"
+          :pulse="false" />
       </div>
 
       <!-- Team cards grid -->
       <div class="grid gap-4 sm:grid-cols-2">
-        <div class="h-24 rounded-lg bg-gray-200 dark:bg-gray-700"></div>
-        <div class="h-24 rounded-lg bg-gray-200 dark:bg-gray-700"></div>
+        <Skeleton
+          height="h-24"
+          rounded="rounded-lg"
+          :pulse="false" />
+        <Skeleton
+          height="h-24"
+          rounded="rounded-lg"
+          :pulse="false" />
       </div>
     </div>
   </div>

--- a/src/apps/workspace/domains/DomainEmail.vue
+++ b/src/apps/workspace/domains/DomainEmail.vue
@@ -17,6 +17,7 @@ import BasicFormAlerts from '@/shared/components/forms/BasicFormAlerts.vue';
 import DomainHeader from '@/apps/workspace/components/dashboard/DomainHeader.vue';
 import DomainEmailConfigForm from '@/apps/workspace/components/domains/DomainEmailConfigForm.vue';
 import DomainEmailDnsRecords from '@/apps/workspace/components/domains/DomainEmailDnsRecords.vue';
+import SettingsSkeleton from '@/shared/components/closet/SettingsSkeleton.vue';
 import { useDomain } from '@/shared/composables/useDomain';
 
 import { useEmailConfig } from '@/shared/composables/useEmailConfig';
@@ -172,18 +173,7 @@ watch(hasEntitlement, async (entitled) => {
     <!-- Content -->
     <div class="mx-auto max-w-4xl px-4 py-8 sm:px-6 lg:px-8">
       <!-- Loading State -->
-      <div v-if="domainLoading" class="flex items-center justify-center py-12">
-        <div class="text-center">
-          <OIcon
-            collection="heroicons"
-            name="arrow-path"
-            class="mx-auto size-8 animate-spin text-gray-400"
-            aria-hidden="true" />
-          <p class="mt-2 text-sm text-gray-500 dark:text-gray-400">
-            {{ t('web.COMMON.loading') }}
-          </p>
-        </div>
-      </div>
+      <SettingsSkeleton v-if="domainLoading" />
 
       <!-- Error State -->
       <div v-else-if="domainError" class="rounded-lg bg-white p-6 shadow dark:bg-gray-800">
@@ -244,14 +234,7 @@ watch(hasEntitlement, async (entitled) => {
 
           <div class="p-6 space-y-8">
             <!-- Email config loading -->
-            <div v-if="emailLoading && !isInitialized" class="flex items-center justify-center py-12">
-              <OIcon
-                collection="heroicons"
-                name="arrow-path"
-                class="size-8 animate-spin text-gray-400"
-                aria-hidden="true" />
-              <span class="sr-only">{{ t('web.COMMON.loading') }}</span>
-            </div>
+            <SettingsSkeleton v-if="emailLoading && !isInitialized" />
 
             <template v-else>
 

--- a/src/apps/workspace/domains/DomainEmail.vue
+++ b/src/apps/workspace/domains/DomainEmail.vue
@@ -234,7 +234,9 @@ watch(hasEntitlement, async (entitled) => {
 
           <div class="p-6 space-y-8">
             <!-- Email config loading -->
-            <SettingsSkeleton v-if="emailLoading && !isInitialized" />
+            <SettingsSkeleton
+              v-if="emailLoading && !isInitialized"
+              :heading="false" />
 
             <template v-else>
 

--- a/src/apps/workspace/domains/DomainIncoming.vue
+++ b/src/apps/workspace/domains/DomainIncoming.vue
@@ -219,7 +219,9 @@ watch(() => props.extid, async () => {
 
         <div class="p-6 space-y-6">
           <!-- Incoming config loading -->
-          <SettingsSkeleton v-if="incomingLoading && !isInitialized" />
+          <SettingsSkeleton
+            v-if="incomingLoading && !isInitialized"
+            :heading="false" />
 
           <template v-else>
             <DomainIncomingConfigForm

--- a/src/apps/workspace/domains/DomainIncoming.vue
+++ b/src/apps/workspace/domains/DomainIncoming.vue
@@ -16,6 +16,7 @@ import OIcon from '@/shared/components/icons/OIcon.vue';
 import BasicFormAlerts from '@/shared/components/forms/BasicFormAlerts.vue';
 import DomainHeader from '@/apps/workspace/components/dashboard/DomainHeader.vue';
 import DomainIncomingConfigForm from '@/apps/workspace/components/domains/DomainIncomingConfigForm.vue';
+import SettingsSkeleton from '@/shared/components/closet/SettingsSkeleton.vue';
 import { useDomain } from '@/shared/composables/useDomain';
 
 import { useIncomingConfig } from '@/shared/composables/useIncomingConfig';
@@ -161,18 +162,7 @@ watch(() => props.extid, async () => {
     <!-- Content -->
     <div class="mx-auto max-w-4xl px-4 py-8 sm:px-6 lg:px-8">
       <!-- Loading State -->
-      <div v-if="domainLoading" class="flex items-center justify-center py-12">
-        <div class="text-center">
-          <OIcon
-            collection="heroicons"
-            name="arrow-path"
-            class="mx-auto size-8 animate-spin text-gray-400"
-            aria-hidden="true" />
-          <p class="mt-2 text-sm text-gray-500 dark:text-gray-400">
-            {{ t('web.COMMON.loading') }}
-          </p>
-        </div>
-      </div>
+      <SettingsSkeleton v-if="domainLoading" />
 
       <!-- Error State -->
       <div v-else-if="domainError" class="rounded-lg bg-white p-6 shadow dark:bg-gray-800">
@@ -229,14 +219,7 @@ watch(() => props.extid, async () => {
 
         <div class="p-6 space-y-6">
           <!-- Incoming config loading -->
-          <div v-if="incomingLoading && !isInitialized" class="flex items-center justify-center py-12">
-            <OIcon
-              collection="heroicons"
-              name="arrow-path"
-              class="size-8 animate-spin text-gray-400"
-              aria-hidden="true" />
-            <span class="sr-only">{{ t('web.COMMON.loading') }}</span>
-          </div>
+          <SettingsSkeleton v-if="incomingLoading && !isInitialized" />
 
           <template v-else>
             <DomainIncomingConfigForm

--- a/src/apps/workspace/domains/DomainSignup.vue
+++ b/src/apps/workspace/domains/DomainSignup.vue
@@ -16,6 +16,7 @@ import OIcon from '@/shared/components/icons/OIcon.vue';
 import BasicFormAlerts from '@/shared/components/forms/BasicFormAlerts.vue';
 import DomainHeader from '@/apps/workspace/components/dashboard/DomainHeader.vue';
 import DomainSignupConfigForm from '@/apps/workspace/components/domains/DomainSignupConfigForm.vue';
+import SettingsSkeleton from '@/shared/components/closet/SettingsSkeleton.vue';
 import { useDomain } from '@/shared/composables/useDomain';
 
 import { useSignupConfig } from '@/shared/composables/useSignupConfig';
@@ -157,18 +158,7 @@ watch(canCustomSignup, async (entitled) => {
     <!-- Content -->
     <div class="mx-auto max-w-4xl px-4 py-8 sm:px-6 lg:px-8">
       <!-- Loading State -->
-      <div v-if="domainLoading || signupLoading" class="flex items-center justify-center py-12">
-        <div class="text-center">
-          <OIcon
-            collection="heroicons"
-            name="arrow-path"
-            class="mx-auto size-8 animate-spin text-gray-400"
-            aria-hidden="true" />
-          <p class="mt-2 text-sm text-gray-500 dark:text-gray-400">
-            {{ t('web.COMMON.loading') }}
-          </p>
-        </div>
-      </div>
+      <SettingsSkeleton v-if="domainLoading || signupLoading" />
 
       <!-- Error State -->
       <div v-else-if="domainError || signupError" class="rounded-lg bg-white p-6 shadow dark:bg-gray-800">

--- a/src/apps/workspace/domains/DomainSso.vue
+++ b/src/apps/workspace/domains/DomainSso.vue
@@ -16,6 +16,7 @@ import OIcon from '@/shared/components/icons/OIcon.vue';
 import BasicFormAlerts from '@/shared/components/forms/BasicFormAlerts.vue';
 import DomainHeader from '@/apps/workspace/components/dashboard/DomainHeader.vue';
 import DomainSsoConfigForm from '@/apps/workspace/components/domains/DomainSsoConfigForm.vue';
+import SettingsSkeleton from '@/shared/components/closet/SettingsSkeleton.vue';
 import { useDomain } from '@/shared/composables/useDomain';
 
 import { useSsoConfig } from '@/shared/composables/useSsoConfig';
@@ -151,18 +152,7 @@ watch(canManageSso, async (entitled) => {
     <!-- Content -->
     <div class="mx-auto max-w-4xl px-4 py-8 sm:px-6 lg:px-8">
       <!-- Loading State (domain or SSO config) -->
-      <div v-if="domainLoading || ssoLoading" class="flex items-center justify-center py-12">
-        <div class="text-center">
-          <OIcon
-            collection="heroicons"
-            name="arrow-path"
-            class="mx-auto size-8 animate-spin text-gray-400"
-            aria-hidden="true" />
-          <p class="mt-2 text-sm text-gray-500 dark:text-gray-400">
-            {{ t('web.COMMON.loading') }}
-          </p>
-        </div>
-      </div>
+      <SettingsSkeleton v-if="domainLoading || ssoLoading" />
 
       <!-- Error State -->
       <div v-else-if="domainError || ssoError" class="rounded-lg bg-white p-6 shadow dark:bg-gray-800">

--- a/src/apps/workspace/domains/DomainVerify.vue
+++ b/src/apps/workspace/domains/DomainVerify.vue
@@ -253,7 +253,7 @@
           @click="triggerVerification">
           <svg
             v-if="verificationInProgress"
-            class="-ml-1 mr-2 h-4 w-4 animate-spin"
+            class="-ml-1 mr-2 h-4 w-4 animate-spin motion-reduce:animate-none"
             aria-hidden="true"
             xmlns="http://www.w3.org/2000/svg"
             fill="none"

--- a/src/router/public.routes.ts
+++ b/src/router/public.routes.ts
@@ -4,10 +4,11 @@ import HomepageContainer from '@/apps/secret/conceal/Homepage.vue';
 import TransactionalFooter from '@/shared/components/layout/TransactionalFooter.vue';
 import TransactionalHeader from '@/shared/components/layout/TransactionalHeader.vue';
 import TransactionalLayout from '@/shared/layouts/TransactionalLayout.vue';
+import { useAuthStore } from '@/shared/stores/authStore';
 import { useBootstrapStore } from '@/shared/stores/bootstrapStore';
 import { SCOPE_PRESETS } from '@/types/router';
 import type { LayoutProps } from '@/types/ui/layouts';
-import { RouteRecordRaw } from 'vue-router';
+import { RouteRecordRaw, type RouteLocationNormalized } from 'vue-router';
 
 // Extend RouteRecordRaw meta to include our custom componentMode
 declare module 'vue-router' {
@@ -103,6 +104,30 @@ function getLayoutPropsForMode(componentMode: string, domainStrategy: string): L
   return layoutProps;
 }
 
+/**
+ * Authenticated visitors to the public /pricing routes are already signed up
+ * (and may be on a paid plan), so the marketing CTAs route them to /signup,
+ * which the auth guard then blocks — the click logs but goes nowhere.
+ * Redirect them to the in-app plan selector instead, carrying any deep-linked
+ * product/interval as the query params PlanSelector already parses. The
+ * /billing/plans redirect resolves the current org into /billing/:extid/plans.
+ */
+function redirectAuthenticatedToPlans(to: RouteLocationNormalized) {
+  const authStore = useAuthStore();
+  if (!authStore.isAuthenticated) return true;
+
+  const query: Record<string, string> = {};
+  const product = (to.params.product ?? to.query.product) as string | undefined;
+  const interval = (to.params.interval ?? to.query.interval) as string | undefined;
+  if (product) query.product = product;
+  if (interval) {
+    const yearAliases = ['year', 'yearly', 'annual'];
+    query.interval = yearAliases.includes(interval.toLowerCase()) ? 'yearly' : 'monthly';
+  }
+
+  return { path: '/billing/plans', query };
+}
+
 const routes: Array<RouteRecordRaw> = [
   {
     path: '/',
@@ -188,6 +213,7 @@ const routes: Array<RouteRecordRaw> = [
     path: '/pricing',
     name: 'Pricing',
     component: () => import('@/apps/secret/support/Pricing.vue'),
+    beforeEnter: redirectAuthenticatedToPlans,
     meta: {
       title: 'web.TITLES.pricing',
       requiresAuth: false,
@@ -210,6 +236,7 @@ const routes: Array<RouteRecordRaw> = [
     path: '/pricing/:product',
     name: 'PricingProduct',
     component: () => import('@/apps/secret/support/Pricing.vue'),
+    beforeEnter: redirectAuthenticatedToPlans,
     meta: {
       title: 'web.TITLES.pricing',
       requiresAuth: false,
@@ -228,6 +255,7 @@ const routes: Array<RouteRecordRaw> = [
     path: '/pricing/:product/:interval',
     name: 'PricingProductInterval',
     component: () => import('@/apps/secret/support/Pricing.vue'),
+    beforeEnter: redirectAuthenticatedToPlans,
     meta: {
       title: 'web.TITLES.pricing',
       requiresAuth: false,

--- a/src/router/public.routes.ts
+++ b/src/router/public.routes.ts
@@ -112,13 +112,18 @@ function getLayoutPropsForMode(componentMode: string, domainStrategy: string): L
  * product/interval as the query params PlanSelector already parses. The
  * /billing/plans redirect resolves the current org into /billing/:extid/plans.
  */
-function redirectAuthenticatedToPlans(to: RouteLocationNormalized) {
+export function redirectAuthenticatedToPlans(to: RouteLocationNormalized) {
   const authStore = useAuthStore();
   if (!authStore.isAuthenticated) return true;
 
   const query: Record<string, string> = {};
-  const product = (to.params.product ?? to.query.product) as string | undefined;
-  const interval = (to.params.interval ?? to.query.interval) as string | undefined;
+  // Route params are scalar, but query params can arrive as arrays
+  // (?interval=a&interval=b). Collapse to the first value so the
+  // string ops below never see an array and throw mid-navigation.
+  const rawProduct = to.params.product ?? to.query.product;
+  const product = Array.isArray(rawProduct) ? rawProduct[0] : rawProduct;
+  const rawInterval = to.params.interval ?? to.query.interval;
+  const interval = Array.isArray(rawInterval) ? rawInterval[0] : rawInterval;
   if (product) query.product = product;
   if (interval) {
     const yearAliases = ['year', 'yearly', 'annual'];

--- a/src/shared/components/base/BaseShowSecret.vue
+++ b/src/shared/components/base/BaseShowSecret.vue
@@ -78,14 +78,14 @@
       <!-- Global Loading State -->
       <div
         v-if="state.isLoading"
-        class="animate-pulse space-y-6 p-4">
+        class="animate-pulse motion-reduce:animate-none space-y-6 p-4">
         <SecretSkeleton />
       </div>
 
       <!-- Initial Loading - Prevent UnknownSecret flash -->
       <div
         v-else-if="!state.isLoading && !record && !state.error"
-        class="animate-pulse space-y-6 p-4">
+        class="animate-pulse motion-reduce:animate-none space-y-6 p-4">
         <SecretSkeleton />
       </div>
 

--- a/src/shared/components/billing/PlanCardSkeleton.vue
+++ b/src/shared/components/billing/PlanCardSkeleton.vue
@@ -1,0 +1,121 @@
+<!-- src/shared/components/billing/PlanCardSkeleton.vue -->
+
+<script setup lang="ts">
+  /**
+   * PlanCardSkeleton
+   *
+   * Loading placeholder for the billing "Select a Plan" grid (#3269). Mirrors
+   * the geometry of PlanCard.vue (title, big price + "/month", a "Features"
+   * label over a checklist, and a full-width footer button separated by a top
+   * border) so the load→loaded transition has no layout jump.
+   *
+   * The whole grid is reproduced: the outer wrapper matches PlanSelector's live
+   * grid (`mx-auto flex max-w-[1600px] flex-wrap justify-center gap-6`), and
+   * each card sits in `<div class="flex w-full max-w-sm">`, identical to the
+   * real cards so widths line up exactly.
+   *
+   * Per the primitive gotcha (decisions rule 7), we emit our own `v-for` rows
+   * instead of the primitive's `count` prop for structured markup. Relative
+   * widths inside flex rows (the feature text lines) are applied via `class=`
+   * on the Skeleton — a relative `width` prop would size the inner block against
+   * a shrink-wrapped flex item and collapse to zero. Fixed widths (price blocks,
+   * stacked block-context blocks) use the `width` prop directly.
+   *
+   * a11y: the outermost wrapper is the busy status region with an sr-only
+   * loading label and owns the single pulse; every child passes `:pulse="false"`.
+   */
+  import { useI18n } from 'vue-i18n';
+  import Skeleton from '@/shared/components/closet/Skeleton.vue';
+
+  interface Props {
+    /** Number of card skeletons to render. */
+    count?: number;
+  }
+
+  withDefaults(defineProps<Props>(), {
+    count: 2,
+  });
+
+  /** Varied feature text-line widths so the checklist reads as real copy. */
+  const featureWidths = ['w-3/4', 'w-2/3', 'w-1/2', 'w-3/5', 'w-2/3'];
+
+  const { t } = useI18n();
+</script>
+
+<template>
+  <div
+    role="status"
+    aria-busy="true"
+    class="mx-auto flex max-w-[1600px] flex-wrap justify-center gap-6 animate-pulse motion-reduce:animate-none">
+    <span class="sr-only">{{ t('web.COMMON.loading') }}</span>
+
+    <div
+      v-for="n in count"
+      :key="n"
+      class="flex w-full max-w-sm">
+      <!-- Card root: mirrors PlanCard's default (non-highlighted) outer card. -->
+      <div
+        class="relative flex w-full flex-col rounded-2xl border border-gray-200 bg-white shadow-sm dark:border-gray-700 dark:bg-gray-800">
+        <div class="flex-1 p-6">
+          <!-- Header: plan title -->
+          <div class="mb-4">
+            <Skeleton
+              width="w-1/2"
+              height="h-6"
+              :pulse="false" />
+          </div>
+
+          <!-- Price: large amount + small "/month" on a baseline row -->
+          <div class="mb-6">
+            <div class="flex items-baseline gap-2">
+              <Skeleton
+                width="w-32"
+                height="h-10"
+                :pulse="false" />
+              <Skeleton
+                width="w-16"
+                height="h-4"
+                :pulse="false" />
+            </div>
+          </div>
+
+          <!-- Features: label over a checklist of icon + text-line rows -->
+          <div class="space-y-3">
+            <Skeleton
+              width="w-24"
+              height="h-4"
+              :pulse="false" />
+
+            <ul class="space-y-2">
+              <li
+                v-for="(featureWidth, i) in featureWidths"
+                :key="i"
+                class="flex items-start gap-2">
+                <!-- Fixed-size square check-icon block (size-5). -->
+                <Skeleton
+                  width="w-5"
+                  height="h-5"
+                  rounded="rounded-none"
+                  :pulse="false" />
+                <!-- Relative-width text line: width on class (flex item). -->
+                <Skeleton
+                  :class="featureWidth"
+                  height="h-4"
+                  :pulse="false" />
+              </li>
+            </ul>
+          </div>
+        </div>
+
+        <!-- Footer: full-width action button, separated by a top border. -->
+        <div class="border-t border-gray-200 p-6 dark:border-gray-700">
+          <Skeleton
+            width="w-full"
+            height="h-9"
+            rounded="rounded-md"
+            :pulse="false" />
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/src/shared/components/closet/CardGridSkeleton.vue
+++ b/src/shared/components/closet/CardGridSkeleton.vue
@@ -1,0 +1,51 @@
+<!-- src/shared/components/closet/CardGridSkeleton.vue -->
+
+<script setup lang="ts">
+  /**
+   * CardGridSkeleton
+   *
+   * Loading placeholder for the card-grid archetype (3 TARGET sites in #3269:
+   * pricing plan cards, plan selector, plan preview modal).
+   *
+   * Renders a responsive grid of equal card blocks (`sm:grid-cols-2`, matching
+   * the dashboard team grid). The column count is fixed, not a prop: Tailwind's
+   * JIT only generates classes it can see as complete literals, so an
+   * interpolated `sm:grid-cols-${n}` would silently fail to produce CSS.
+   *
+   * Per the primitive gotcha (decisions rule 7), cards are emitted with our own
+   * `v-for`, not the primitive's `count` prop (which would stack flat blocks in
+   * a single column rather than fill grid cells).
+   *
+   * a11y: the wrapper is the busy status region with an sr-only loading label
+   * and owns the single pulse; child cards pass `:pulse="false"`.
+   */
+  import { useI18n } from 'vue-i18n';
+  import Skeleton from '@/shared/components/closet/Skeleton.vue';
+
+  interface Props {
+    /** Number of card blocks to render in the grid. */
+    count?: number;
+  }
+
+  withDefaults(defineProps<Props>(), {
+    count: 3,
+  });
+
+  const { t } = useI18n();
+</script>
+
+<template>
+  <div
+    role="status"
+    aria-busy="true"
+    class="grid animate-pulse gap-4 motion-reduce:animate-none sm:grid-cols-2">
+    <span class="sr-only">{{ t('web.COMMON.loading') }}</span>
+
+    <Skeleton
+      v-for="n in count"
+      :key="n"
+      height="h-40"
+      rounded="rounded-lg"
+      :pulse="false" />
+  </div>
+</template>

--- a/src/shared/components/closet/ListSkeleton.vue
+++ b/src/shared/components/closet/ListSkeleton.vue
@@ -4,12 +4,18 @@
   /**
    * ListSkeleton
    *
-   * Loading placeholder for the list archetype (5 TARGET sites in #3269:
-   * members, active sessions, domains, organizations, pending invitations).
+   * Loading placeholder for the list archetype in #3269: active sessions,
+   * SSO domains, organizations, passkeys, pending invitations. (The members
+   * list renders a real `<table>`, so it uses TableSkeleton, not this.)
    *
-   * Each row mirrors the shape those lists share: a growing left text column
-   * (a primary label line over a shorter secondary line) and a small trailing
-   * action block on the right.
+   * Each row mirrors the shape those lists share: an optional leading
+   * icon/avatar block, a growing text column (a primary label line over a
+   * shorter secondary line), and a small trailing action block on the right.
+   *
+   * Icon-led rows (passkeys, SSO domains, members) start with a small icon or
+   * a circular avatar. Toggle the leading block with `icon`, and size/shape it
+   * with `iconSize` (a `w-N`/`h-N` value applied to both axes) and
+   * `iconRounded`. Text-led rows (organizations) leave `icon` off (default).
    *
    * Per the primitive gotcha (decisions rule 7), we emit our own `v-for` rows
    * instead of the primitive's `count` prop — `count` only reproduces a flat
@@ -20,17 +26,33 @@
    * a11y: the wrapper is the busy status region with an sr-only loading label
    * and owns the single pulse; children pass `:pulse="false"`.
    */
+  import { computed } from 'vue';
   import { useI18n } from 'vue-i18n';
   import Skeleton from '@/shared/components/closet/Skeleton.vue';
 
   interface Props {
     /** Number of list rows to render. */
     count?: number;
+    /** Render a leading icon/avatar block on each row. */
+    icon?: boolean;
+    /**
+     * Width utility for the leading block, also applied as its height (square
+     * footprint), e.g. 'w-5' → a 5×5 icon, 'w-10' → a 10×10 avatar.
+     */
+    iconSize?: string;
+    /** Corner utility for the leading block, e.g. 'rounded-full' for avatars. */
+    iconRounded?: string;
   }
 
-  withDefaults(defineProps<Props>(), {
+  const props = withDefaults(defineProps<Props>(), {
     count: 3,
+    icon: false,
+    iconSize: 'w-5',
+    iconRounded: 'rounded',
   });
+
+  /** Derive the height utility from iconSize (w-N → h-N) for a square block. */
+  const iconHeight = computed(() => props.iconSize.replace(/^w-/, 'h-'));
 
   const { t } = useI18n();
 </script>
@@ -46,6 +68,14 @@
       v-for="n in count"
       :key="n"
       class="flex items-center justify-between gap-4 rounded-md px-4 py-3">
+      <!-- Optional leading icon/avatar block. Width AND height are set so the
+           primitive's w-full/h-4 defaults don't leak onto the square block. -->
+      <Skeleton
+        v-if="icon"
+        :width="iconSize"
+        :height="iconHeight"
+        :rounded="iconRounded"
+        :pulse="false" />
       <!-- Growing text column: primary line over a shorter secondary line.
            flex-1 sizes the row item, so it lives on the wrapper class. -->
       <div class="flex-1 space-y-2">

--- a/src/shared/components/closet/ListSkeleton.vue
+++ b/src/shared/components/closet/ListSkeleton.vue
@@ -1,0 +1,69 @@
+<!-- src/shared/components/closet/ListSkeleton.vue -->
+
+<script setup lang="ts">
+  /**
+   * ListSkeleton
+   *
+   * Loading placeholder for the list archetype (5 TARGET sites in #3269:
+   * members, active sessions, domains, organizations, pending invitations).
+   *
+   * Each row mirrors the shape those lists share: a growing left text column
+   * (a primary label line over a shorter secondary line) and a small trailing
+   * action block on the right.
+   *
+   * Per the primitive gotcha (decisions rule 7), we emit our own `v-for` rows
+   * instead of the primitive's `count` prop — `count` only reproduces a flat
+   * run of identical blocks at `space-y-2`, not a structured row. For the same
+   * reason, the growing text column is sized with `flex-1` on the row markup,
+   * never via the Skeleton `width` prop.
+   *
+   * a11y: the wrapper is the busy status region with an sr-only loading label
+   * and owns the single pulse; children pass `:pulse="false"`.
+   */
+  import { useI18n } from 'vue-i18n';
+  import Skeleton from '@/shared/components/closet/Skeleton.vue';
+
+  interface Props {
+    /** Number of list rows to render. */
+    count?: number;
+  }
+
+  withDefaults(defineProps<Props>(), {
+    count: 3,
+  });
+
+  const { t } = useI18n();
+</script>
+
+<template>
+  <div
+    role="status"
+    aria-busy="true"
+    class="animate-pulse space-y-3 motion-reduce:animate-none">
+    <span class="sr-only">{{ t('web.COMMON.loading') }}</span>
+
+    <div
+      v-for="n in count"
+      :key="n"
+      class="flex items-center justify-between gap-4 rounded-md px-4 py-3">
+      <!-- Growing text column: primary line over a shorter secondary line.
+           flex-1 sizes the row item, so it lives on the wrapper class. -->
+      <div class="flex-1 space-y-2">
+        <Skeleton
+          width="w-1/3"
+          height="h-4"
+          :pulse="false" />
+        <Skeleton
+          width="w-1/4"
+          height="h-3"
+          :pulse="false" />
+      </div>
+      <!-- Trailing action block. -->
+      <Skeleton
+        class="w-16"
+        height="h-8"
+        rounded="rounded-md"
+        :pulse="false" />
+    </div>
+  </div>
+</template>

--- a/src/shared/components/closet/ListSkeleton.vue
+++ b/src/shared/components/closet/ListSkeleton.vue
@@ -52,7 +52,7 @@
   });
 
   /** Derive the height utility from iconSize (w-N → h-N) for a square block. */
-  const iconHeight = computed(() => props.iconSize.replace(/^w-/, 'h-'));
+  const iconHeight = computed(() => props.iconSize.replace(/\bw-/g, 'h-'));
 
   const { t } = useI18n();
 </script>

--- a/src/shared/components/closet/ReceiptSkeleton.vue
+++ b/src/shared/components/closet/ReceiptSkeleton.vue
@@ -1,15 +1,38 @@
 <!-- src/shared/components/closet/ReceiptSkeleton.vue -->
 
+<script setup lang="ts">
+  import { useI18n } from 'vue-i18n';
+  import Skeleton from '@/shared/components/closet/Skeleton.vue';
+
+  const { t } = useI18n();
+</script>
+
 <template>
-  <div class="animate-pulse space-y-8">
-    <!-- Secret Link Skeleton -->
-    <section class="h-24 rounded-lg bg-gray-100 dark:bg-gray-800"></section>
+  <div
+    role="status"
+    aria-busy="true"
+    class="animate-pulse space-y-8 motion-reduce:animate-none">
+    <span class="sr-only">{{ t('web.COMMON.loading') }}</span>
+    <!-- Secret Link Skeleton (empty block → normalizes gray-100/800 to gray-200/700) -->
+    <Skeleton
+      height="h-24"
+      rounded="rounded-lg"
+      :pulse="false" />
 
     <!-- Status & Timeline Skeleton -->
+    <!-- Panel bg (gray-50/gray-800) kept AS-IS: it's a container, not a placeholder
+         block. Normalizing it to gray-200/700 would make its nested blocks vanish. -->
     <section class="rounded-lg bg-gray-50 p-4 dark:bg-gray-800">
       <div class="mb-4 flex items-center justify-between">
-        <div class="h-4 w-24 rounded bg-gray-200 dark:bg-gray-700"></div>
-        <div class="h-6 w-32 rounded-full bg-gray-200 dark:bg-gray-700"></div>
+        <Skeleton
+          class="w-24"
+          height="h-4"
+          :pulse="false" />
+        <Skeleton
+          class="w-32"
+          height="h-6"
+          rounded="rounded-full"
+          :pulse="false" />
       </div>
 
       <div class="space-y-6">
@@ -17,33 +40,62 @@
           v-for="n in 3"
           :key="n"
           class="flex gap-4">
-          <div class="size-12 rounded-full bg-gray-200 dark:bg-gray-700"></div>
+          <!-- Avatar circle (size-12 → w-12 h-12) -->
+          <Skeleton
+            width="w-12"
+            height="h-12"
+            rounded="rounded-full"
+            :pulse="false" />
           <div class="space-y-2">
-            <div class="h-4 w-32 rounded bg-gray-200 dark:bg-gray-700"></div>
-            <div class="h-3 w-48 rounded bg-gray-200 dark:bg-gray-700"></div>
+            <Skeleton
+              class="w-32"
+              height="h-4"
+              :pulse="false" />
+            <Skeleton
+              class="w-48"
+              height="h-3"
+              :pulse="false" />
           </div>
         </div>
       </div>
     </section>
 
     <!-- Instructions Skeleton -->
+    <!-- Panel bg (gray-50/gray-800) kept AS-IS for the same container reason. -->
     <section class="space-y-4 rounded-lg bg-gray-50 p-4 dark:bg-gray-800">
-      <div class="h-4 w-40 rounded bg-gray-200 dark:bg-gray-700"></div>
+      <Skeleton
+        class="w-40"
+        height="h-4"
+        :pulse="false" />
       <div class="space-y-3">
         <div
           v-for="n in 3"
           :key="n"
           class="flex gap-2">
-          <div class="size-5 rounded bg-gray-200 dark:bg-gray-700"></div>
-          <div class="h-4 w-full rounded bg-gray-200 dark:bg-gray-700"></div>
+          <!-- Bullet (size-5 → w-5 h-5) -->
+          <Skeleton
+            width="w-5"
+            height="h-5"
+            :pulse="false" />
+          <!-- w-full sizes the flex item, so it goes on `class`. -->
+          <Skeleton
+            class="w-full"
+            height="h-4"
+            :pulse="false" />
         </div>
       </div>
     </section>
 
     <!-- Actions Skeleton -->
     <section class="space-y-3">
-      <div class="h-10 rounded-md bg-gray-200 dark:bg-gray-700"></div>
-      <div class="h-10 rounded-md bg-gray-200 dark:bg-gray-700"></div>
+      <Skeleton
+        height="h-10"
+        rounded="rounded-md"
+        :pulse="false" />
+      <Skeleton
+        height="h-10"
+        rounded="rounded-md"
+        :pulse="false" />
     </section>
   </div>
 </template>

--- a/src/shared/components/closet/SecretSkeleton.vue
+++ b/src/shared/components/closet/SecretSkeleton.vue
@@ -1,19 +1,42 @@
 <!-- src/shared/components/closet/SecretSkeleton.vue -->
 
 <script setup lang="ts">
+  import { useI18n } from 'vue-i18n';
+  import Skeleton from '@/shared/components/closet/Skeleton.vue';
 
+  const { t } = useI18n();
 </script>
 
 <template>
   <!-- Main Content Box -->
-  <div class="rounded-lg border border-gray-200 p-6 dark:border-gray-700">
-    <!-- Secret Info Line -->
-    <div class="mb-4 h-6 w-2/3 rounded-lg bg-gray-200 dark:bg-gray-700"></div>
+  <!-- The status/sr-only live on the static outer container; the pulse stays
+       on the inner wrapper so the border does not animate. -->
+  <div
+    role="status"
+    aria-busy="true"
+    class="rounded-lg border border-gray-200 p-6 dark:border-gray-700">
+    <span class="sr-only">{{ t('web.COMMON.loading') }}</span>
+    <!-- Pulse wrapper (border stays static, matching the other skeletons) -->
+    <div class="animate-pulse motion-reduce:animate-none">
+      <!-- Secret Info Line -->
+      <Skeleton
+        class="mb-4"
+        height="h-6"
+        width="w-2/3"
+        rounded="rounded-lg"
+        :pulse="false" />
 
-    <!-- Form/Content Area -->
-    <div class="space-y-4">
-      <div class="h-12 rounded-lg bg-gray-200 dark:bg-gray-700"></div>
-      <div class="h-12 rounded-lg bg-gray-200 dark:bg-gray-700"></div>
+      <!-- Form/Content Area -->
+      <div class="space-y-4">
+        <Skeleton
+          height="h-12"
+          rounded="rounded-lg"
+          :pulse="false" />
+        <Skeleton
+          height="h-12"
+          rounded="rounded-lg"
+          :pulse="false" />
+      </div>
     </div>
   </div>
 </template>

--- a/src/shared/components/closet/SettingsSkeleton.vue
+++ b/src/shared/components/closet/SettingsSkeleton.vue
@@ -1,0 +1,71 @@
+<!-- src/shared/components/closet/SettingsSkeleton.vue -->
+
+<script setup lang="ts">
+  /**
+   * SettingsSkeleton
+   *
+   * General, prop-driven loading placeholder for the settings-page archetype
+   * (the highest-leverage shape in the #3269 inventory: 9 TARGET sites across
+   * account settings, org settings, billing overview, and domain-detail pages).
+   *
+   * Structure: an optional heading block followed by N field groups, each a
+   * short label line over a full-width input bar. The form-fields archetype
+   * (config forms whose fields await an API) is the same shape with no heading,
+   * so pass `:heading="false"` rather than reaching for a separate component.
+   *
+   * This is generic chrome. For a skeleton that mirrors one specific page's
+   * header + tab bar, build a co-located page-specific skeleton instead
+   * (see OrgSettingsSkeleton.vue).
+   *
+   * a11y: the wrapper announces itself as a busy status region with an sr-only
+   * loading label; the wrapper owns the single pulse, so every child Skeleton
+   * passes `:pulse="false"`.
+   */
+  import { useI18n } from 'vue-i18n';
+  import Skeleton from '@/shared/components/closet/Skeleton.vue';
+
+  interface Props {
+    /** Number of label+input field groups to render. */
+    groups?: number;
+    /** Render a leading section-heading block. */
+    heading?: boolean;
+  }
+
+  withDefaults(defineProps<Props>(), {
+    groups: 3,
+    heading: true,
+  });
+
+  const { t } = useI18n();
+</script>
+
+<template>
+  <div
+    role="status"
+    aria-busy="true"
+    class="animate-pulse space-y-6 motion-reduce:animate-none">
+    <span class="sr-only">{{ t('web.COMMON.loading') }}</span>
+
+    <!-- Section heading -->
+    <Skeleton
+      v-if="heading"
+      width="w-1/3"
+      height="h-6"
+      :pulse="false" />
+
+    <!-- Field groups: label line over a full-width input bar -->
+    <div
+      v-for="n in groups"
+      :key="n"
+      class="space-y-2">
+      <Skeleton
+        width="w-1/4"
+        height="h-4"
+        :pulse="false" />
+      <Skeleton
+        height="h-10"
+        rounded="rounded-md"
+        :pulse="false" />
+    </div>
+  </div>
+</template>

--- a/src/shared/components/closet/Skeleton.vue
+++ b/src/shared/components/closet/Skeleton.vue
@@ -1,0 +1,53 @@
+<!-- src/shared/components/closet/Skeleton.vue -->
+
+<script setup lang="ts">
+  /**
+   * Skeleton
+   *
+   * Foundational loading-placeholder primitive. Renders one or more
+   * decorative gray blocks. It is intentionally a "dumb" block: it carries
+   * no `role="status"`, `aria-busy`, or `sr-only` text — those announcements
+   * belong to the composite skeletons / usage sites that arrange these blocks.
+   *
+   * Reduced motion: when `pulse` is true the wrapper uses
+   * `animate-pulse motion-reduce:animate-none`, so users with
+   * `prefers-reduced-motion: reduce` see a static gray block (still reads as a
+   * placeholder) instead of a pulsing one.
+   */
+  interface Props {
+    /** Tailwind width utility, e.g. 'w-2/3'. */
+    width?: string;
+    /** Tailwind height utility, e.g. 'h-6'. */
+    height?: string;
+    /** Tailwind corner utility: 'rounded' | 'rounded-lg' | 'rounded-full'. */
+    rounded?: string;
+    /** Number of identical rows to repeat. */
+    count?: number;
+    /**
+     * Wrap the blocks in `animate-pulse`. Set to false when a parent element
+     * already drives the pulse animation (avoids double-animating).
+     */
+    pulse?: boolean;
+  }
+
+  withDefaults(defineProps<Props>(), {
+    width: 'w-full',
+    height: 'h-4',
+    rounded: 'rounded',
+    count: 1,
+    pulse: false,
+  });
+</script>
+
+<template>
+  <div
+    :class="pulse && 'animate-pulse motion-reduce:animate-none'"
+    class="space-y-2">
+    <div
+      v-for="n in count"
+      :key="n"
+      aria-hidden="true"
+      :class="[width, height, rounded]"
+      class="bg-gray-200 dark:bg-gray-700"></div>
+  </div>
+</template>

--- a/src/shared/components/closet/TableSkeleton.vue
+++ b/src/shared/components/closet/TableSkeleton.vue
@@ -1,11 +1,30 @@
 <!-- src/shared/components/closet/TableSkeleton.vue -->
 
+<script setup lang="ts">
+  import { useI18n } from 'vue-i18n';
+  import Skeleton from '@/shared/components/closet/Skeleton.vue';
+
+  const { t } = useI18n();
+</script>
+
 <template>
-  <div class="animate-pulse">
-    <div class="mb-4 h-12 rounded-t bg-gray-200 dark:bg-gray-700"></div>
-    <div
-      v-for="n in 3"
-      :key="n"
-      class="mb-2 h-16 bg-gray-100 dark:bg-gray-800"></div>
+  <div
+    role="status"
+    aria-busy="true"
+    class="animate-pulse motion-reduce:animate-none">
+    <span class="sr-only">{{ t('web.COMMON.loading') }}</span>
+    <!-- Header row -->
+    <Skeleton
+      class="mb-4"
+      height="h-12"
+      rounded="rounded-t"
+      :pulse="false" />
+    <!-- Body rows -->
+    <Skeleton
+      class="mb-2"
+      height="h-16"
+      rounded="rounded-none"
+      :count="3"
+      :pulse="false" />
   </div>
 </template>

--- a/src/shared/components/modals/PasswordConfirmModal.vue
+++ b/src/shared/components/modals/PasswordConfirmModal.vue
@@ -258,7 +258,7 @@ watch(
                       v-if="loading"
                       collection="heroicons"
                       name="arrow-path"
-                      class="-ml-1 mr-2 size-4 animate-spin"
+                      class="-ml-1 mr-2 size-4 animate-spin motion-reduce:animate-none"
                       aria-hidden="true" />
                     {{ buttonText }}
                   </button>

--- a/src/shared/components/modals/PlanPreviewModal.vue
+++ b/src/shared/components/modals/PlanPreviewModal.vue
@@ -1,7 +1,7 @@
 <!-- src/shared/components/modals/PlanPreviewModal.vue -->
 
 <script setup lang="ts">
-import SettingsSkeleton from '@/shared/components/closet/SettingsSkeleton.vue';
+import ListSkeleton from '@/shared/components/closet/ListSkeleton.vue';
 import OIcon from '@/shared/components/icons/OIcon.vue';
 import { usePreviewPlanMode } from '@/shared/composables/usePreviewPlanMode';
 import { useBootstrapStore } from '@/shared/stores/bootstrapStore';
@@ -266,7 +266,7 @@ const handleClose = () => {
                 <div
                   v-if="isLoadingPlans"
                   class="mt-5">
-                  <SettingsSkeleton :heading="false" />
+                  <ListSkeleton />
                 </div>
 
                 <!-- Plans Error State -->

--- a/src/shared/components/modals/PlanPreviewModal.vue
+++ b/src/shared/components/modals/PlanPreviewModal.vue
@@ -1,6 +1,7 @@
 <!-- src/shared/components/modals/PlanPreviewModal.vue -->
 
 <script setup lang="ts">
+import SettingsSkeleton from '@/shared/components/closet/SettingsSkeleton.vue';
 import OIcon from '@/shared/components/icons/OIcon.vue';
 import { usePreviewPlanMode } from '@/shared/composables/usePreviewPlanMode';
 import { useBootstrapStore } from '@/shared/stores/bootstrapStore';
@@ -265,14 +266,7 @@ const handleClose = () => {
                 <div
                   v-if="isLoadingPlans"
                   class="mt-5">
-                  <div class="flex items-center justify-center py-8">
-                    <div class="text-center">
-                      <div class="inline-block size-8 animate-spin rounded-full border-4 border-solid border-brand-500 border-r-transparent"></div>
-                      <p class="mt-2 text-sm text-gray-600 dark:text-gray-400">
-                        {{ t('web.COMMON.loading') }}
-                      </p>
-                    </div>
-                  </div>
+                  <SettingsSkeleton :heading="false" />
                 </div>
 
                 <!-- Plans Error State -->

--- a/src/shared/components/ui/notifications/StatusBar.vue
+++ b/src/shared/components/ui/notifications/StatusBar.vue
@@ -69,7 +69,7 @@ const getStatusConfig = (type: string | null) => ({
     icon: 'loading',
     classes: 'bg-brandcompdim-50/90 dark:bg-brandcompdim-950/90',
     textClasses: 'text-brandcompdim-700 dark:text-brandcompdim-100',
-    iconClasses: 'text-brandcompdim-600 dark:text-brandcompdim-300 animate-spin'
+    iconClasses: 'text-brandcompdim-600 dark:text-brandcompdim-300 animate-spin motion-reduce:animate-none'
   },
 })[type || 'info'];
 

--- a/src/shared/components/ui/notifications/StatusCorner.vue
+++ b/src/shared/components/ui/notifications/StatusCorner.vue
@@ -92,7 +92,7 @@ const getStatusConfig = (type: string | null) =>
       icon: 'loading',
       bgClasses: 'bg-brandcompdim-50/95 dark:bg-brandcompdim-950/95',
       textClasses: 'text-brandcompdim-700 dark:text-brandcompdim-100',
-      iconClasses: 'text-brandcompdim-600 dark:text-brandcompdim-300 animate-spin',
+      iconClasses: 'text-brandcompdim-600 dark:text-brandcompdim-300 animate-spin motion-reduce:animate-none',
       ringClasses: 'ring-brandcompdim-200/50 dark:ring-brandcompdim-800/50',
     },
   })[type || 'info'];

--- a/src/shared/components/ui/notifications/SubtleProgress.vue
+++ b/src/shared/components/ui/notifications/SubtleProgress.vue
@@ -107,7 +107,7 @@ const getStatusConfig = (type: string | null) =>
       icon: 'loading',
       bgClasses: 'bg-brandcompdim-50/95 dark:bg-brandcompdim-950/95',
       textClasses: 'text-brandcompdim-700 dark:text-brandcompdim-100',
-      iconClasses: 'text-brandcompdim-600 dark:text-brandcompdim-300 animate-spin',
+      iconClasses: 'text-brandcompdim-600 dark:text-brandcompdim-300 animate-spin motion-reduce:animate-none',
       ringClasses: 'ring-brandcompdim-300/50 dark:ring-brandcompdim-700/50',
       pulse: false,
     },

--- a/src/tests/apps/secret/support/Pricing.spec.ts
+++ b/src/tests/apps/secret/support/Pricing.spec.ts
@@ -485,10 +485,10 @@ describe('Pricing.vue', () => {
       await new Promise(resolve => setTimeout(resolve, 0));
       await wrapper.vm.$nextTick();
 
-      // At this point, loadPlans should be in progress (promise pending)
-      // The loading div contains an OIcon with animate-spin class - but OIcon is mocked
-      // so we check for the loading container and text instead
-      const loadingContainer = wrapper.find('[class*="flex items-center justify-center py-12"]');
+      // At this point, loadPlans should be in progress (promise pending).
+      // The loading state now renders <CardGridSkeleton>, a role="status"
+      // region with an sr-only loading label (no visible spinner/text).
+      const loadingContainer = wrapper.find('[role="status"][aria-busy="true"]');
       expect(loadingContainer.exists()).toBe(true);
       expect(wrapper.text()).toContain('Loading...');
 
@@ -501,8 +501,8 @@ describe('Pricing.vue', () => {
       mockListPlans.mockResolvedValueOnce({ plans: defaultPlans });
       await mountComponent();
 
-      // After loading completes, spinner should be gone
-      expect(wrapper.find('.animate-spin').exists()).toBe(false);
+      // After loading completes, the loading skeleton should be gone
+      expect(wrapper.find('[role="status"][aria-busy="true"]').exists()).toBe(false);
     });
 
     it('shows empty state when no plans available', async () => {

--- a/src/tests/apps/secret/support/Pricing.spec.ts
+++ b/src/tests/apps/secret/support/Pricing.spec.ts
@@ -486,7 +486,7 @@ describe('Pricing.vue', () => {
       await wrapper.vm.$nextTick();
 
       // At this point, loadPlans should be in progress (promise pending).
-      // The loading state now renders <CardGridSkeleton>, a role="status"
+      // The loading state now renders <PlanCardSkeleton>, a role="status"
       // region with an sr-only loading label (no visible spinner/text).
       const loadingContainer = wrapper.find('[role="status"][aria-busy="true"]');
       expect(loadingContainer.exists()).toBe(true);

--- a/src/tests/apps/workspace/account/settings/OrgSettingsSkeleton.spec.ts
+++ b/src/tests/apps/workspace/account/settings/OrgSettingsSkeleton.spec.ts
@@ -1,0 +1,60 @@
+// src/tests/apps/workspace/account/settings/OrgSettingsSkeleton.spec.ts
+
+//
+// Structure spec for the page-specific OrgSettingsSkeleton. Asserts the a11y
+// status wrapper, single-parent pulse, the page geometry unique to this view
+// (the max-w-4xl container, the two-part header with a pill billing chip, and
+// the underlined tab bar) plus the field-group panel body.
+//
+
+import { mount } from '@vue/test-utils';
+import { describe, it, expect, vi } from 'vitest';
+import OrgSettingsSkeleton from '@/apps/workspace/account/settings/OrgSettingsSkeleton.vue';
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}));
+
+const blocks = (wrapper: ReturnType<typeof mount>) =>
+  wrapper.findAll('[aria-hidden="true"]');
+
+describe('OrgSettingsSkeleton', () => {
+  it('exposes a busy status region with an sr-only loading label', () => {
+    const wrapper = mount(OrgSettingsSkeleton);
+    expect(wrapper.attributes('role')).toBe('status');
+    expect(wrapper.attributes('aria-busy')).toBe('true');
+    const srOnly = wrapper.find('.sr-only');
+    expect(srOnly.exists()).toBe(true);
+    expect(srOnly.text()).toBe('web.COMMON.loading');
+    expect(srOnly.attributes('aria-hidden')).toBeUndefined();
+  });
+
+  it('drives a single pulse from the page wrapper with reduced-motion freeze', () => {
+    const wrapper = mount(OrgSettingsSkeleton);
+    expect(wrapper.classes()).toContain('animate-pulse');
+    expect(wrapper.classes()).toContain('motion-reduce:animate-none');
+    expect(wrapper.findAll('.animate-pulse')).toHaveLength(1);
+  });
+
+  it('keeps the page container width constraint', () => {
+    const wrapper = mount(OrgSettingsSkeleton);
+    expect(wrapper.classes()).toContain('mx-auto');
+    expect(wrapper.classes()).toContain('max-w-4xl');
+  });
+
+  it('renders the pill-shaped billing chip (rounded-full) in the header', () => {
+    const wrapper = mount(OrgSettingsSkeleton);
+    const pills = blocks(wrapper).filter((b) => b.classes().includes('rounded-full'));
+    expect(pills).toHaveLength(1);
+  });
+
+  it('renders an underlined tab bar of label blocks', () => {
+    const wrapper = mount(OrgSettingsSkeleton);
+    const tabBar = wrapper.find('.border-b');
+    expect(tabBar.exists()).toBe(true);
+    // Three tab labels live inside the bordered nav row. w-16 is a fallthrough
+    // class on the Skeleton root wrapper (the flex item), not the inner block.
+    const tabLabels = tabBar.findAll('.w-16');
+    expect(tabLabels).toHaveLength(3);
+  });
+});

--- a/src/tests/apps/workspace/billing/InvoiceList.spec.ts
+++ b/src/tests/apps/workspace/billing/InvoiceList.spec.ts
@@ -201,9 +201,9 @@ describe('InvoiceList', () => {
       wrapper = await mountComponent(false);
       await nextTick();
 
-      // Should show loading spinner
-      const spinner = wrapper.find('[data-name="arrow-path"]');
-      expect(spinner.exists()).toBe(true);
+      // Should show the loading skeleton (busy status region with sr-only label)
+      const skeleton = wrapper.find('[role="status"][aria-busy="true"]');
+      expect(skeleton.exists()).toBe(true);
       expect(wrapper.text()).toContain('Loading...');
 
       // Clean up

--- a/src/tests/apps/workspace/components/domains/DomainSsoConfigForm.spec.ts
+++ b/src/tests/apps/workspace/components/domains/DomainSsoConfigForm.spec.ts
@@ -656,9 +656,9 @@ describe('DomainSsoConfigForm', () => {
         isLoading: true,
       });
 
-      // Should show loading state
-      const loadingIcon = wrapper.find('[data-icon-name="arrow-path"]');
-      expect(loadingIcon.exists()).toBe(true);
+      // Should show loading skeleton (SettingsSkeleton) with its busy status region
+      const skeleton = wrapper.find('[role="status"]');
+      expect(skeleton.exists()).toBe(true);
     });
 
     it('shows form when isLoading is false', async () => {

--- a/src/tests/apps/workspace/dashboard/DashboardSkeleton.spec.ts
+++ b/src/tests/apps/workspace/dashboard/DashboardSkeleton.spec.ts
@@ -1,0 +1,62 @@
+// src/tests/apps/workspace/dashboard/DashboardSkeleton.spec.ts
+
+//
+// Layout-regression guard for DashboardSkeleton after composing it from the
+// Skeleton primitive. The fragile bits:
+// - the container constraints (mx-auto, min/max width) survive,
+// - the two `w-1/3` options bars are sized on the flex item (Skeleton root),
+//   not on the inner block where they would collapse to a sliver,
+// - one parent owns the pulse + reduced-motion freeze.
+//
+
+import { mount } from '@vue/test-utils';
+import { describe, it, expect, vi } from 'vitest';
+import DashboardSkeleton from '@/apps/workspace/dashboard/DashboardSkeleton.vue';
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}));
+
+const blocks = (wrapper: ReturnType<typeof mount>) =>
+  wrapper.findAll('[aria-hidden="true"]');
+
+describe('DashboardSkeleton', () => {
+  it('exposes a busy status region with an sr-only loading label', () => {
+    const wrapper = mount(DashboardSkeleton);
+    expect(wrapper.attributes('role')).toBe('status');
+    expect(wrapper.attributes('aria-busy')).toBe('true');
+    const srOnly = wrapper.find('.sr-only');
+    expect(srOnly.exists()).toBe(true);
+    expect(srOnly.text()).toBe('web.COMMON.loading');
+    expect(srOnly.attributes('aria-hidden')).toBeUndefined();
+  });
+
+  it('keeps the centered, width-constrained container', () => {
+    const wrapper = mount(DashboardSkeleton);
+    const cls = (wrapper.element as HTMLElement).className;
+    expect(cls).toContain('mx-auto');
+    expect(cls).toContain('min-w-[320px]');
+    expect(cls).toContain('max-w-2xl');
+  });
+
+  it('drives one pulse from the container with reduced-motion freeze', () => {
+    const wrapper = mount(DashboardSkeleton);
+    expect(wrapper.classes()).toContain('animate-pulse');
+    expect(wrapper.classes()).toContain('motion-reduce:animate-none');
+    expect(wrapper.findAll('.animate-pulse')).toHaveLength(1);
+  });
+
+  it('sizes the two options bars on the flex item, not the inner block', () => {
+    const wrapper = mount(DashboardSkeleton);
+    // w-1/3 must be on a Skeleton root (the flex child), never on an
+    // aria-hidden block (that would be 1/3 of a shrink-to-fit wrapper ≈ 0).
+    const thirdBlocks = blocks(wrapper).filter((b) =>
+      b.classes().includes('w-1/3')
+    );
+    expect(thirdBlocks).toHaveLength(0);
+    const thirdWrappers = wrapper
+      .findAll('.w-1\\/3')
+      .filter((el) => el.attributes('aria-hidden') !== 'true');
+    expect(thirdWrappers).toHaveLength(2);
+  });
+});

--- a/src/tests/apps/workspace/domains/DomainSso.spec.ts
+++ b/src/tests/apps/workspace/domains/DomainSso.spec.ts
@@ -311,9 +311,9 @@ describe('DomainSso', () => {
       mockDomainLoading.value = true;
       wrapper = await mountComponent();
 
-      // Should show loading indicator
-      const loadingIcon = wrapper.find('[data-icon-name="arrow-path"]');
-      expect(loadingIcon.exists()).toBe(true);
+      // Should show loading skeleton (SettingsSkeleton) with its busy status region
+      const skeleton = wrapper.find('[role="status"]');
+      expect(skeleton.exists()).toBe(true);
       expect(wrapper.text()).toContain('Loading...');
     });
 
@@ -519,12 +519,13 @@ describe('DomainSso', () => {
       expect(srOnly.text()).toBe('Back');
     });
 
-    it('loading spinner has aria-hidden attribute', async () => {
+    it('loading skeleton exposes a busy status region', async () => {
       mockDomainLoading.value = true;
       wrapper = await mountComponent();
 
-      const spinnerIcon = wrapper.find('[data-icon-name="arrow-path"]');
-      expect(spinnerIcon.exists()).toBe(true);
+      const skeleton = wrapper.find('[role="status"]');
+      expect(skeleton.exists()).toBe(true);
+      expect(skeleton.attributes('aria-busy')).toBe('true');
     });
   });
 });

--- a/src/tests/router/public.routes.spec.ts
+++ b/src/tests/router/public.routes.spec.ts
@@ -3,8 +3,9 @@
 import { createTestingPinia } from '@pinia/testing';
 import { setActivePinia } from 'pinia';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { RouteRecordRaw } from 'vue-router';
+import { RouteLocationNormalized, RouteRecordRaw } from 'vue-router';
 
+import { useAuthStore } from '@/shared/stores/authStore';
 import { useBootstrapStore } from '@/shared/stores/bootstrapStore';
 
 // Mock stores used by useDomainContext
@@ -19,6 +20,10 @@ vi.mock('@/shared/stores/organizationStore', () => ({
   useOrganizationStore: () => ({
     currentOrganization: null,
   }),
+}));
+
+vi.mock('@/shared/stores/authStore', () => ({
+  useAuthStore: vi.fn(() => ({ isAuthenticated: false })),
 }));
 
 // Set up Pinia before importing routes (routes use bootstrapStore at module level)
@@ -41,7 +46,7 @@ const pinia = createTestingPinia({
 setActivePinia(pinia);
 
 // Import routes after Pinia is set up
-import publicRoutes from '@/router/public.routes';
+import publicRoutes, { redirectAuthenticatedToPlans } from '@/router/public.routes';
 
 describe('Public Routes', () => {
   describe('Homepage Route', () => {
@@ -73,4 +78,87 @@ describe('Public Routes', () => {
   // NOTE: Feedback route has been removed and is no longer available
 
   // NOTE: Translations route has been removed and is no longer available
+
+  describe('redirectAuthenticatedToPlans', () => {
+    const makeRoute = (
+      overrides: Partial<RouteLocationNormalized> = {}
+    ): RouteLocationNormalized => ({
+      meta: {},
+      path: '/pricing',
+      name: 'Pricing',
+      params: {},
+      query: {},
+      hash: '',
+      fullPath: '/pricing',
+      matched: [],
+      redirectedFrom: undefined,
+      ...overrides,
+    });
+
+    const authenticate = (isAuthenticated: boolean) => {
+      vi.mocked(useAuthStore).mockReturnValue({
+        isAuthenticated,
+      } as ReturnType<typeof useAuthStore>);
+    };
+
+    beforeEach(() => {
+      vi.clearAllMocks();
+    });
+
+    it('lets unauthenticated visitors through (returns true)', () => {
+      authenticate(false);
+      expect(redirectAuthenticatedToPlans(makeRoute())).toBe(true);
+    });
+
+    it('redirects authenticated visitors to the plan selector', () => {
+      authenticate(true);
+      expect(redirectAuthenticatedToPlans(makeRoute())).toEqual({
+        path: '/billing/plans',
+        query: {},
+      });
+    });
+
+    it('carries a deep-linked product param through the redirect', () => {
+      authenticate(true);
+      expect(
+        redirectAuthenticatedToPlans(makeRoute({ params: { product: 'pro' } }))
+      ).toEqual({ path: '/billing/plans', query: { product: 'pro' } });
+    });
+
+    it('maps year-alias intervals (annual/year/yearly) to "yearly"', () => {
+      authenticate(true);
+      for (const alias of ['annual', 'year', 'yearly', 'ANNUAL']) {
+        expect(
+          redirectAuthenticatedToPlans(makeRoute({ params: { interval: alias } }))
+        ).toEqual({ path: '/billing/plans', query: { interval: 'yearly' } });
+      }
+    });
+
+    it('maps any non-year interval to "monthly"', () => {
+      authenticate(true);
+      expect(
+        redirectAuthenticatedToPlans(makeRoute({ params: { interval: 'month' } }))
+      ).toEqual({ path: '/billing/plans', query: { interval: 'monthly' } });
+    });
+
+    it('does not throw on array query params and collapses to the first value', () => {
+      authenticate(true);
+      // ?interval=annual&interval=monthly arrives as an array; the old code
+      // called interval.toLowerCase() on the array and crashed navigation.
+      const run = () =>
+        redirectAuthenticatedToPlans(
+          makeRoute({
+            query: {
+              product: ['pro', 'team'],
+              interval: ['annual', 'monthly'],
+            },
+          })
+        );
+      expect(run).not.toThrow();
+      expect(run()).toEqual({
+        path: '/billing/plans',
+        query: { product: 'pro', interval: 'yearly' },
+      });
+    });
+  });
 });

--- a/src/tests/shared/components/billing/PlanCardSkeleton.spec.ts
+++ b/src/tests/shared/components/billing/PlanCardSkeleton.spec.ts
@@ -1,0 +1,58 @@
+// src/tests/shared/components/billing/PlanCardSkeleton.spec.ts
+
+//
+// Structure spec for the PlanCardSkeleton composite (billing plan-card
+// archetype, #3269). Asserts the a11y status wrapper, single-parent pulse,
+// prop-driven card count (asserted on the .max-w-sm card wrappers so it
+// survives geometry tweaks to the feature checklist), and that the pulse class
+// lives only on the wrapper, never duplicated on child blocks.
+//
+
+import { mount } from '@vue/test-utils';
+import { describe, it, expect, vi } from 'vitest';
+import PlanCardSkeleton from '@/shared/components/billing/PlanCardSkeleton.vue';
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}));
+
+const cards = (wrapper: ReturnType<typeof mount>) =>
+  wrapper.findAll('.max-w-sm');
+
+describe('PlanCardSkeleton', () => {
+  it('exposes a busy status region with an sr-only loading label', () => {
+    const wrapper = mount(PlanCardSkeleton);
+    expect(wrapper.attributes('role')).toBe('status');
+    expect(wrapper.attributes('aria-busy')).toBe('true');
+    const srOnly = wrapper.find('.sr-only');
+    expect(srOnly.exists()).toBe(true);
+    expect(srOnly.text()).toBe('web.COMMON.loading');
+    expect(srOnly.attributes('aria-hidden')).toBeUndefined();
+  });
+
+  it('drives a single pulse from the wrapper with reduced-motion freeze', () => {
+    const wrapper = mount(PlanCardSkeleton);
+    expect(wrapper.classes()).toContain('animate-pulse');
+    expect(wrapper.classes()).toContain('motion-reduce:animate-none');
+    expect(wrapper.findAll('.animate-pulse')).toHaveLength(1);
+  });
+
+  it('renders 2 card skeletons by default', () => {
+    const wrapper = mount(PlanCardSkeleton);
+    expect(cards(wrapper)).toHaveLength(2);
+  });
+
+  it('honours the count prop', () => {
+    const wrapper = mount(PlanCardSkeleton, { props: { count: 3 } });
+    expect(cards(wrapper)).toHaveLength(3);
+  });
+
+  it('mirrors the live grid wrapper geometry', () => {
+    const wrapper = mount(PlanCardSkeleton);
+    // The outermost wrapper must match PlanSelector's real grid so the
+    // load→loaded transition does not jump.
+    expect(wrapper.classes()).toContain('max-w-[1600px]');
+    expect(wrapper.classes()).toContain('flex-wrap');
+    expect(wrapper.classes()).toContain('justify-center');
+  });
+});

--- a/src/tests/shared/components/closet/CardGridSkeleton.spec.ts
+++ b/src/tests/shared/components/closet/CardGridSkeleton.spec.ts
@@ -1,0 +1,54 @@
+// src/tests/shared/components/closet/CardGridSkeleton.spec.ts
+
+//
+// Structure spec for the CardGridSkeleton composite (card-grid archetype).
+// Asserts the a11y status wrapper, single-parent pulse, the responsive grid
+// classes (literal sm:grid-cols-2 — never interpolated, or JIT drops it), and
+// the prop-driven card count.
+//
+
+import { mount } from '@vue/test-utils';
+import { describe, it, expect, vi } from 'vitest';
+import CardGridSkeleton from '@/shared/components/closet/CardGridSkeleton.vue';
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}));
+
+const blocks = (wrapper: ReturnType<typeof mount>) =>
+  wrapper.findAll('[aria-hidden="true"]');
+
+describe('CardGridSkeleton', () => {
+  it('exposes a busy status region with an sr-only loading label', () => {
+    const wrapper = mount(CardGridSkeleton);
+    expect(wrapper.attributes('role')).toBe('status');
+    expect(wrapper.attributes('aria-busy')).toBe('true');
+    const srOnly = wrapper.find('.sr-only');
+    expect(srOnly.exists()).toBe(true);
+    expect(srOnly.text()).toBe('web.COMMON.loading');
+    expect(srOnly.attributes('aria-hidden')).toBeUndefined();
+  });
+
+  it('drives a single pulse from the grid wrapper with reduced-motion freeze', () => {
+    const wrapper = mount(CardGridSkeleton);
+    expect(wrapper.classes()).toContain('animate-pulse');
+    expect(wrapper.classes()).toContain('motion-reduce:animate-none');
+    expect(wrapper.findAll('.animate-pulse')).toHaveLength(1);
+  });
+
+  it('lays the cards out in a responsive grid (literal sm:grid-cols-2)', () => {
+    const wrapper = mount(CardGridSkeleton);
+    expect(wrapper.classes()).toContain('grid');
+    expect(wrapper.classes()).toContain('sm:grid-cols-2');
+  });
+
+  it('renders the default 3 cards', () => {
+    const wrapper = mount(CardGridSkeleton);
+    expect(blocks(wrapper)).toHaveLength(3);
+  });
+
+  it('honours the count prop (6 cards)', () => {
+    const wrapper = mount(CardGridSkeleton, { props: { count: 6 } });
+    expect(blocks(wrapper)).toHaveLength(6);
+  });
+});

--- a/src/tests/shared/components/closet/ListSkeleton.spec.ts
+++ b/src/tests/shared/components/closet/ListSkeleton.spec.ts
@@ -47,6 +47,32 @@ describe('ListSkeleton', () => {
     expect(blocks(wrapper)).toHaveLength(15);
   });
 
+  it('omits the leading icon block by default (text-led rows)', () => {
+    const wrapper = mount(ListSkeleton);
+    // No icon → no rounded-full or square leading block; default rows are
+    // 3 blocks each (primary + secondary line + trailing action).
+    expect(blocks(wrapper)).toHaveLength(9);
+  });
+
+  it('adds a leading icon block per row when icon is set (4 blocks/row)', () => {
+    const wrapper = mount(ListSkeleton, { props: { count: 3, icon: true } });
+    expect(blocks(wrapper)).toHaveLength(12);
+  });
+
+  it('sizes and shapes the leading icon block (avatar variant)', () => {
+    const wrapper = mount(ListSkeleton, {
+      props: { count: 1, icon: true, iconSize: 'w-10', iconRounded: 'rounded-full' },
+    });
+    const iconBlock = blocks(wrapper).find(
+      (b) => b.classes().includes('rounded-full')
+    );
+    expect(iconBlock).toBeTruthy();
+    // iconSize sizes both axes (w-10 → h-10) so the primitive's w-full/h-4
+    // defaults do not leak onto the square block.
+    expect(iconBlock!.classes()).toContain('w-10');
+    expect(iconBlock!.classes()).toContain('h-10');
+  });
+
   it('sizes the growing text column via flex-1 on the row, not a block', () => {
     const wrapper = mount(ListSkeleton);
     // flex-1 must live on a row wrapper (the flex item), never on an

--- a/src/tests/shared/components/closet/ListSkeleton.spec.ts
+++ b/src/tests/shared/components/closet/ListSkeleton.spec.ts
@@ -1,0 +1,61 @@
+// src/tests/shared/components/closet/ListSkeleton.spec.ts
+
+//
+// Structure spec for the ListSkeleton composite (list archetype). Asserts the
+// a11y status wrapper, single-parent pulse, prop-driven row count (3 blocks per
+// row: primary line + secondary line + trailing action), and that the growing
+// text column is sized via flex-1 on the row markup (not the Skeleton width
+// prop), per decisions rule 7.
+//
+
+import { mount } from '@vue/test-utils';
+import { describe, it, expect, vi } from 'vitest';
+import ListSkeleton from '@/shared/components/closet/ListSkeleton.vue';
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}));
+
+const blocks = (wrapper: ReturnType<typeof mount>) =>
+  wrapper.findAll('[aria-hidden="true"]');
+
+describe('ListSkeleton', () => {
+  it('exposes a busy status region with an sr-only loading label', () => {
+    const wrapper = mount(ListSkeleton);
+    expect(wrapper.attributes('role')).toBe('status');
+    expect(wrapper.attributes('aria-busy')).toBe('true');
+    const srOnly = wrapper.find('.sr-only');
+    expect(srOnly.exists()).toBe(true);
+    expect(srOnly.text()).toBe('web.COMMON.loading');
+    expect(srOnly.attributes('aria-hidden')).toBeUndefined();
+  });
+
+  it('drives a single pulse from the wrapper with reduced-motion freeze', () => {
+    const wrapper = mount(ListSkeleton);
+    expect(wrapper.classes()).toContain('animate-pulse');
+    expect(wrapper.classes()).toContain('motion-reduce:animate-none');
+    expect(wrapper.findAll('.animate-pulse')).toHaveLength(1);
+  });
+
+  it('renders the default 3 rows (3 blocks per row = 9 blocks)', () => {
+    const wrapper = mount(ListSkeleton);
+    expect(blocks(wrapper)).toHaveLength(9);
+  });
+
+  it('honours the count prop (5 rows = 15 blocks)', () => {
+    const wrapper = mount(ListSkeleton, { props: { count: 5 } });
+    expect(blocks(wrapper)).toHaveLength(15);
+  });
+
+  it('sizes the growing text column via flex-1 on the row, not a block', () => {
+    const wrapper = mount(ListSkeleton);
+    // flex-1 must live on a row wrapper (the flex item), never on an
+    // aria-hidden Skeleton block — there it would not stretch the row.
+    const flexBlocks = blocks(wrapper).filter((b) => b.classes().includes('flex-1'));
+    expect(flexBlocks).toHaveLength(0);
+    const flexWrappers = wrapper
+      .findAll('.flex-1')
+      .filter((el) => el.attributes('aria-hidden') !== 'true');
+    expect(flexWrappers).toHaveLength(3);
+  });
+});

--- a/src/tests/shared/components/closet/ListSkeleton.spec.ts
+++ b/src/tests/shared/components/closet/ListSkeleton.spec.ts
@@ -73,6 +73,20 @@ describe('ListSkeleton', () => {
     expect(iconBlock!.classes()).toContain('h-10');
   });
 
+  it('derives the icon height for every responsive width class', () => {
+    // A responsive iconSize like "w-5 md:w-8" must map every width class to a
+    // height class (h-5 md:h-8). Replacing only the leading "w-" would leave
+    // the height axis as "h-5 md:w-8" — missing md:h-8 — so the block would
+    // lose its square aspect ratio at the md breakpoint.
+    const wrapper = mount(ListSkeleton, {
+      props: { count: 1, icon: true, iconSize: 'w-5 md:w-8' },
+    });
+    const iconBlock = blocks(wrapper).find((b) => b.classes().includes('w-5'));
+    expect(iconBlock).toBeTruthy();
+    expect(iconBlock!.classes()).toContain('h-5');
+    expect(iconBlock!.classes()).toContain('md:h-8');
+  });
+
   it('sizes the growing text column via flex-1 on the row, not a block', () => {
     const wrapper = mount(ListSkeleton);
     // flex-1 must live on a row wrapper (the flex item), never on an

--- a/src/tests/shared/components/closet/ReceiptSkeleton.spec.ts
+++ b/src/tests/shared/components/closet/ReceiptSkeleton.spec.ts
@@ -1,0 +1,70 @@
+// src/tests/shared/components/closet/ReceiptSkeleton.spec.ts
+
+//
+// Layout-regression guard for ReceiptSkeleton — the heaviest refactor.
+// The load-bearing invariants:
+// - the gray-50/gray-800 *panel* backgrounds are preserved (they are containers,
+//   not placeholder blocks; normalizing them would make nested blocks vanish),
+// - circular avatars stay round and 12-sized,
+// - the `w-full` instruction line lands on the flex item (Skeleton root), not on
+//   the inner block where w-1/3-style collapse would occur,
+// - a single parent owns the pulse + reduced-motion freeze.
+//
+
+import { mount } from '@vue/test-utils';
+import { describe, it, expect, vi } from 'vitest';
+import ReceiptSkeleton from '@/shared/components/closet/ReceiptSkeleton.vue';
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}));
+
+const blocks = (wrapper: ReturnType<typeof mount>) =>
+  wrapper.findAll('[aria-hidden="true"]');
+
+describe('ReceiptSkeleton', () => {
+  it('exposes a busy status region with an sr-only loading label', () => {
+    const wrapper = mount(ReceiptSkeleton);
+    expect(wrapper.attributes('role')).toBe('status');
+    expect(wrapper.attributes('aria-busy')).toBe('true');
+    const srOnly = wrapper.find('.sr-only');
+    expect(srOnly.exists()).toBe(true);
+    expect(srOnly.text()).toBe('web.COMMON.loading');
+    expect(srOnly.attributes('aria-hidden')).toBeUndefined();
+  });
+
+  it('drives one pulse from the root with reduced-motion freeze', () => {
+    const wrapper = mount(ReceiptSkeleton);
+    expect(wrapper.classes()).toContain('animate-pulse');
+    expect(wrapper.classes()).toContain('motion-reduce:animate-none');
+    expect(wrapper.findAll('.animate-pulse')).toHaveLength(1);
+  });
+
+  it('preserves the two gray-50 container panels (not normalized to blocks)', () => {
+    const wrapper = mount(ReceiptSkeleton);
+    const panels = wrapper.findAll('section.bg-gray-50');
+    expect(panels).toHaveLength(2);
+    panels.forEach((p) => expect(p.classes()).toContain('dark:bg-gray-800'));
+  });
+
+  it('renders 3 circular avatars at w-12 h-12', () => {
+    const wrapper = mount(ReceiptSkeleton);
+    const avatars = blocks(wrapper).filter(
+      (b) => b.classes().includes('rounded-full') && b.classes().includes('w-12')
+    );
+    expect(avatars).toHaveLength(3);
+    avatars.forEach((a) => expect(a.classes()).toContain('h-12'));
+  });
+
+  it('sizes the instruction line via the flex-item wrapper (w-full on Skeleton root)', () => {
+    const wrapper = mount(ReceiptSkeleton);
+    // The 3 instruction rows are `flex gap-2`; the text line's flex item is the
+    // Skeleton root carrying w-full. If w-full had been passed as the `width`
+    // prop it would land on the inner block inside a shrink-to-fit wrapper and
+    // collapse. Assert at least 3 non-block (wrapper) elements carry w-full.
+    const fullWrappers = wrapper
+      .findAll('.w-full')
+      .filter((el) => el.attributes('aria-hidden') !== 'true');
+    expect(fullWrappers.length).toBeGreaterThanOrEqual(3);
+  });
+});

--- a/src/tests/shared/components/closet/SecretSkeleton.spec.ts
+++ b/src/tests/shared/components/closet/SecretSkeleton.spec.ts
@@ -1,0 +1,61 @@
+// src/tests/shared/components/closet/SecretSkeleton.spec.ts
+
+//
+// Layout-regression guard for SecretSkeleton. Verifies the bordered container
+// is preserved and static (the pulse lives on an inner wrapper, so the border
+// does not animate), and that the 2/3-width heading + two body blocks survive.
+//
+
+import { mount } from '@vue/test-utils';
+import { describe, it, expect, vi } from 'vitest';
+import SecretSkeleton from '@/shared/components/closet/SecretSkeleton.vue';
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}));
+
+const blocks = (wrapper: ReturnType<typeof mount>) =>
+  wrapper.findAll('[aria-hidden="true"]');
+
+describe('SecretSkeleton', () => {
+  it('keeps the bordered, padded container', () => {
+    const wrapper = mount(SecretSkeleton);
+    const container = wrapper.get('div');
+    expect(container.classes()).toContain('rounded-lg');
+    expect(container.classes()).toContain('border');
+    expect(container.classes()).toContain('p-6');
+  });
+
+  it('exposes the busy status region on the static outer container', () => {
+    const wrapper = mount(SecretSkeleton);
+    // role/aria/sr-only live on the OUTER container (the pulse stays inner so
+    // the border does not animate). Query the container directly: leading
+    // template comments make wrapper.attributes() unreliable for the root.
+    const container = wrapper.get('div');
+    expect(container.attributes('role')).toBe('status');
+    expect(container.attributes('aria-busy')).toBe('true');
+    expect(container.classes()).not.toContain('animate-pulse');
+    const srOnly = wrapper.find('.sr-only');
+    expect(srOnly.exists()).toBe(true);
+    expect(srOnly.text()).toBe('web.COMMON.loading');
+    expect(srOnly.attributes('aria-hidden')).toBeUndefined();
+  });
+
+  it('pulses on an inner wrapper, leaving the border static', () => {
+    const wrapper = mount(SecretSkeleton);
+    // Outer container is not animated.
+    expect(wrapper.classes()).not.toContain('animate-pulse');
+    const pulses = wrapper.findAll('.animate-pulse');
+    expect(pulses).toHaveLength(1);
+    expect(pulses[0].classes()).toContain('motion-reduce:animate-none');
+  });
+
+  it('renders the 2/3-width heading plus two body blocks', () => {
+    const wrapper = mount(SecretSkeleton);
+    const all = blocks(wrapper);
+    expect(all).toHaveLength(3);
+    // Heading is the only one constrained to two-thirds width.
+    const twoThirds = all.filter((b) => b.classes().includes('w-2/3'));
+    expect(twoThirds).toHaveLength(1);
+  });
+});

--- a/src/tests/shared/components/closet/SettingsSkeleton.spec.ts
+++ b/src/tests/shared/components/closet/SettingsSkeleton.spec.ts
@@ -1,0 +1,55 @@
+// src/tests/shared/components/closet/SettingsSkeleton.spec.ts
+
+//
+// Structure spec for the general SettingsSkeleton composite (settings-page
+// archetype). Asserts the a11y status wrapper, single-parent pulse with
+// reduced-motion freeze, prop-driven field-group count, and the form-fields
+// fold (heading=false drops the heading block but keeps the groups).
+//
+
+import { mount } from '@vue/test-utils';
+import { describe, it, expect, vi } from 'vitest';
+import SettingsSkeleton from '@/shared/components/closet/SettingsSkeleton.vue';
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}));
+
+const blocks = (wrapper: ReturnType<typeof mount>) =>
+  wrapper.findAll('[aria-hidden="true"]');
+
+describe('SettingsSkeleton', () => {
+  it('exposes a busy status region with an sr-only loading label', () => {
+    const wrapper = mount(SettingsSkeleton);
+    expect(wrapper.attributes('role')).toBe('status');
+    expect(wrapper.attributes('aria-busy')).toBe('true');
+    const srOnly = wrapper.find('.sr-only');
+    expect(srOnly.exists()).toBe(true);
+    expect(srOnly.text()).toBe('web.COMMON.loading');
+    expect(srOnly.attributes('aria-hidden')).toBeUndefined();
+  });
+
+  it('drives a single pulse from the wrapper with reduced-motion freeze', () => {
+    const wrapper = mount(SettingsSkeleton);
+    expect(wrapper.classes()).toContain('animate-pulse');
+    expect(wrapper.classes()).toContain('motion-reduce:animate-none');
+    // Children pass :pulse="false" — no nested pulse wrappers.
+    expect(wrapper.findAll('.animate-pulse')).toHaveLength(1);
+  });
+
+  it('renders heading + default 3 field groups (1 + 3*2 = 7 blocks)', () => {
+    const wrapper = mount(SettingsSkeleton);
+    expect(blocks(wrapper)).toHaveLength(7);
+  });
+
+  it('honours the groups prop (heading + 5 groups = 11 blocks)', () => {
+    const wrapper = mount(SettingsSkeleton, { props: { groups: 5 } });
+    expect(blocks(wrapper)).toHaveLength(11);
+  });
+
+  it('drops the heading when heading=false (form-fields fold)', () => {
+    const wrapper = mount(SettingsSkeleton, { props: { heading: false, groups: 3 } });
+    // No heading block: just 3 groups * 2 = 6 blocks.
+    expect(blocks(wrapper)).toHaveLength(6);
+  });
+});

--- a/src/tests/shared/components/closet/Skeleton.spec.ts
+++ b/src/tests/shared/components/closet/Skeleton.spec.ts
@@ -1,0 +1,105 @@
+// src/tests/shared/components/closet/Skeleton.spec.ts
+
+//
+// Tests for Skeleton.vue, the foundational loading-placeholder primitive:
+// - Default render (single decorative block, fixed gap + color tokens)
+// - `count` repeats N blocks
+// - `pulse` toggles the animate-pulse + motion-reduce wrapper class
+// - width / height / rounded utilities propagate to each block
+//
+// Skeleton has no i18n/router/store dependencies, so a plain mount with no
+// mocks is sufficient.
+
+import { mount } from '@vue/test-utils';
+import { describe, it, expect } from 'vitest';
+import Skeleton from '@/shared/components/closet/Skeleton.vue';
+
+const blocks = (wrapper: ReturnType<typeof mount>) =>
+  wrapper.findAll('[aria-hidden="true"]');
+
+describe('Skeleton', () => {
+  describe('default render', () => {
+    it('renders a single decorative block', () => {
+      const wrapper = mount(Skeleton);
+      expect(blocks(wrapper)).toHaveLength(1);
+    });
+
+    it('applies the fixed space-y-2 gap on the wrapper', () => {
+      const wrapper = mount(Skeleton);
+      expect(wrapper.classes()).toContain('space-y-2');
+    });
+
+    it('marks blocks as decorative with aria-hidden', () => {
+      const wrapper = mount(Skeleton);
+      expect(blocks(wrapper)[0].attributes('aria-hidden')).toBe('true');
+    });
+
+    it('uses the established skeleton color tokens', () => {
+      const wrapper = mount(Skeleton);
+      const block = blocks(wrapper)[0];
+      expect(block.classes()).toContain('bg-gray-200');
+      expect(block.classes()).toContain('dark:bg-gray-700');
+    });
+
+    it('applies the default width/height/rounded utilities', () => {
+      const wrapper = mount(Skeleton);
+      const block = blocks(wrapper)[0];
+      expect(block.classes()).toContain('w-full');
+      expect(block.classes()).toContain('h-4');
+      expect(block.classes()).toContain('rounded');
+    });
+
+    it('does not pulse by default', () => {
+      const wrapper = mount(Skeleton);
+      expect(wrapper.classes()).not.toContain('animate-pulse');
+      expect(wrapper.classes()).not.toContain('motion-reduce:animate-none');
+    });
+  });
+
+  describe('count', () => {
+    it('renders N blocks', () => {
+      const wrapper = mount(Skeleton, { props: { count: 4 } });
+      expect(blocks(wrapper)).toHaveLength(4);
+    });
+
+    it('renders a single block when count is 1', () => {
+      const wrapper = mount(Skeleton, { props: { count: 1 } });
+      expect(blocks(wrapper)).toHaveLength(1);
+    });
+  });
+
+  describe('pulse', () => {
+    it('adds animate-pulse and motion-reduce:animate-none when true', () => {
+      const wrapper = mount(Skeleton, { props: { pulse: true } });
+      expect(wrapper.classes()).toContain('animate-pulse');
+      expect(wrapper.classes()).toContain('motion-reduce:animate-none');
+    });
+
+    it('adds neither class when false', () => {
+      const wrapper = mount(Skeleton, { props: { pulse: false } });
+      expect(wrapper.classes()).not.toContain('animate-pulse');
+      expect(wrapper.classes()).not.toContain('motion-reduce:animate-none');
+    });
+  });
+
+  describe('utility propagation', () => {
+    it('propagates width/height/rounded to every block', () => {
+      const wrapper = mount(Skeleton, {
+        props: {
+          width: 'w-2/3',
+          height: 'h-6',
+          rounded: 'rounded-full',
+          count: 3,
+        },
+      });
+
+      const all = blocks(wrapper);
+      expect(all).toHaveLength(3);
+      all.forEach((block) => {
+        expect(block.classes()).toContain('w-2/3');
+        expect(block.classes()).toContain('h-6');
+        expect(block.classes()).toContain('rounded-full');
+      });
+    });
+  });
+});

--- a/src/tests/shared/components/closet/TableSkeleton.spec.ts
+++ b/src/tests/shared/components/closet/TableSkeleton.spec.ts
@@ -1,0 +1,52 @@
+// src/tests/shared/components/closet/TableSkeleton.spec.ts
+
+//
+// Layout-regression guard for TableSkeleton after refactoring it to compose
+// from the Skeleton primitive. Asserts the geometry the visual reviewer cares
+// about: one header row + a 3-row body, the parent owns the pulse (children do
+// not double-animate), and rows stay square-cornered (rounded-none).
+//
+
+import { mount } from '@vue/test-utils';
+import { describe, it, expect, vi } from 'vitest';
+import TableSkeleton from '@/shared/components/closet/TableSkeleton.vue';
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}));
+
+const blocks = (wrapper: ReturnType<typeof mount>) =>
+  wrapper.findAll('[aria-hidden="true"]');
+
+describe('TableSkeleton', () => {
+  it('exposes a busy status region with an sr-only loading label', () => {
+    const wrapper = mount(TableSkeleton);
+    expect(wrapper.attributes('role')).toBe('status');
+    expect(wrapper.attributes('aria-busy')).toBe('true');
+    const srOnly = wrapper.find('.sr-only');
+    expect(srOnly.exists()).toBe(true);
+    expect(srOnly.text()).toBe('web.COMMON.loading');
+    // The label must remain announceable (not aria-hidden).
+    expect(srOnly.attributes('aria-hidden')).toBeUndefined();
+  });
+
+  it('renders a header block plus 3 body rows (4 blocks total)', () => {
+    const wrapper = mount(TableSkeleton);
+    expect(blocks(wrapper)).toHaveLength(4);
+  });
+
+  it('drives the pulse from one parent wrapper with reduced-motion freeze', () => {
+    const wrapper = mount(TableSkeleton);
+    expect(wrapper.classes()).toContain('animate-pulse');
+    expect(wrapper.classes()).toContain('motion-reduce:animate-none');
+    // No nested pulse wrappers (children pass :pulse="false").
+    expect(wrapper.findAll('.animate-pulse')).toHaveLength(1);
+  });
+
+  it('keeps the header rounded-t and the body rows square', () => {
+    const wrapper = mount(TableSkeleton);
+    const all = blocks(wrapper);
+    expect(all[0].classes()).toContain('rounded-t');
+    expect(all[1].classes()).toContain('rounded-none');
+  });
+});


### PR DESCRIPTION
Resolves #3269

Replaces page-load spinners across the app with shape-aware skeleton placeholders that mirror the final layout, reducing layout shift and improving perceived load time. Built bottom-up: a `Skeleton` primitive, a set of composite variants, then adoption across ~40 routes.

## What changed

**Skeleton component library** (`src/shared/components/closet/`)
- `Skeleton.vue` — base block primitive (width/height/rounded/count/pulse), `aria-hidden`, pulse gated behind a prop.
- Composite variants matching page archetypes: `ListSkeleton`, `TableSkeleton`, `CardGridSkeleton`, `SettingsSkeleton`, `ReceiptSkeleton`, `SecretSkeleton`, plus `PlanCardSkeleton` (billing) and page-specific `OrgSettingsSkeleton` / refactored `DashboardSkeleton`.
- `eslint.config.ts` adds a `vue/multi-word-component-names` exception for the single-word `Skeleton` primitive.

**Adoption across routes**
- Domain, billing, pricing, auth, and workspace loading states now render the appropriately-sized skeleton instead of a centered spinner.
- `PlanCardSkeleton` is reused on both the billing plan selector and the public pricing page.
- Removed dead `#loading` slot markup from the branded/canonical `ShowSecret` views (`BaseShowSecret` owns the loading state).

**Pricing redirect** (`src/router/public.routes.ts`)
- Authenticated users hitting `/pricing` (and `/:product`, `/:product/:interval`) are redirected to the in-app plan selector at `/billing/plans`, carrying `product`/`interval` query params with interval normalization (`annual`/`yearly` → `yearly`).

**Reduced-motion / accessibility**
- All skeleton pulses and retained loading spinners carry `motion-reduce:animate-none`; label-less spinners gain `sr-only` loading text so a frozen icon still conveys state under `prefers-reduced-motion: reduce`.

**While the Vue app boots**, the pre-hydration HTML shell shows only the centered circle (`index.rue`).

## Worth a look in review
- **Pricing redirect UX** (`public.routes.ts`): the redirect is silent. A signed-in user deep-linking `/pricing/pro/annual` from an email lands on `/billing/plans` with no explanation. Confirm this matches product intent.
- **Redirect test gap**: `redirectAuthenticatedToPlans` has no dedicated unit test for the auth-gate or param normalization.
- Intentionally left un-guarded for reduced-motion: the dashboard refresh action spinner and `StatusBadge`/`TimelineDisplay` chrome animations (not critical loading feedback).

## Testing
14 new spec files cover the primitive and every composite skeleton; `Pricing`, `InvoiceList`, `DomainSso` specs updated for the new shapes.
