### PR TITLE
Add procps package and improve healthcheck logging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -176,12 +176,15 @@ LABEL org.opencontainers.image.version=${VERSION} \
       org.opencontainers.image.source="https://github.com/onetimesecret/onetimesecret"
 
 # Install system packages + S6 dependencies
+# procps provides pgrep, used by bin/healthcheck.sh for role detection
+# (web vs. worker/scheduler) — see docker/entrypoints/healthcheck.sh
 RUN set -eux && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
         libsqlite3-0 \
         libpq5 \
         curl \
+        procps \
         xz-utils \
         ca-certificates && \
     apt-get clean && \
@@ -299,12 +302,15 @@ LABEL org.opencontainers.image.version=${VERSION} \
       org.opencontainers.image.description="Keep passwords out of your inboxes and chat logs with links that work only one time." \
       org.opencontainers.image.source="https://github.com/onetimesecret/onetimesecret"
 
+# procps provides pgrep, used by bin/healthcheck.sh for role detection
+# (web vs. worker/scheduler) — see docker/entrypoints/healthcheck.sh
 RUN set -eux && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
         libsqlite3-0 \
         libpq5 \
         curl \
+        procps \
         ca-certificates && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/*

--- a/docker/entrypoints/healthcheck.sh
+++ b/docker/entrypoints/healthcheck.sh
@@ -40,14 +40,6 @@ parse_amqp_addr() {
   AMQP_PORT="${AMQP_PORT:-5672}"
 }
 
-# Role detection relies on pgrep (procps). If it's missing the script would
-# otherwise exit 1 with an empty Output field in `docker inspect`, which is
-# exactly the silent-failure mode reported in issue #3270.
-if ! command -v pgrep > /dev/null 2>&1; then
-  echo "healthcheck: pgrep not found; install procps in the image" >&2
-  exit 1
-fi
-
 # Web server: puma listens on $PORT (default 3000)
 # Try /health/advanced first (verifies Redis + RabbitMQ + auth DB),
 # fall back to /health (lightweight status-only check).

--- a/docker/entrypoints/healthcheck.sh
+++ b/docker/entrypoints/healthcheck.sh
@@ -40,6 +40,14 @@ parse_amqp_addr() {
   AMQP_PORT="${AMQP_PORT:-5672}"
 }
 
+# Role detection relies on pgrep (procps). If it's missing the script would
+# otherwise exit 1 with an empty Output field in `docker inspect`, which is
+# exactly the silent-failure mode reported in issue #3270.
+if ! command -v pgrep > /dev/null 2>&1; then
+  echo "healthcheck: pgrep not found; install procps in the image" >&2
+  exit 1
+fi
+
 # Web server: puma listens on $PORT (default 3000)
 # Try /health/advanced first (verifies Redis + RabbitMQ + auth DB),
 # fall back to /health (lightweight status-only check).
@@ -60,4 +68,5 @@ if pgrep -f 'bin/ots' > /dev/null 2>&1; then
 fi
 
 # No recognized process found
+echo "healthcheck: no puma or bin/ots process found" >&2
 exit 1


### PR DESCRIPTION
## Summary

Add the `procps` package to Docker images to support process detection in the healthcheck script, and improve error logging when no recognized processes are found.

## Changes

- **Dockerfile**: Added `procps` package to both build stages (lines 185 and 312). This package provides `pgrep`, which is used by `bin/healthcheck.sh` to detect the container's role (web vs. worker/scheduler).
- **docker/entrypoints/healthcheck.sh**: Added informative error message when no recognized process is found, improving debuggability of healthcheck failures.
- Added clarifying comments in Dockerfile explaining the purpose of the `procps` dependency.

## Related Issues

<!-- Keywords that auto-close issues when merged: Fixes, Closes, Resolves -->
<!-- Example: Fixes #123 -->

## Test Plan

Verify that:
1. Docker images build successfully with the new `procps` dependency
2. Healthcheck script correctly identifies web and worker/scheduler processes using `pgrep`
3. Error message is logged when healthcheck fails to find recognized processes

https://claude.ai/code/session_01Cdhxgsx7H3P4bGCkTVFeqk