### PR TITLE
Simplify database debug logging configuration

### DIFF
--- a/lib/onetime/initializers/setup_database_logging.rb
+++ b/lib/onetime/initializers/setup_database_logging.rb
@@ -23,10 +23,7 @@ module Onetime
           return Onetime.familia_logger.warn "[setup_database_logging] Blocked in #{OT.env}"
         end
 
-        # Check multiple environment variables for database debugging specifically
-        debug_enabled = %w[DATABASE_DEBUG DEBUG_DATABASE DEBUG_VALKEY DEBUG_REDIS].any? do |val|
-          Onetime::Utils.yes?(ENV.fetch(val, nil))
-        end
+        debug_enabled = Onetime::Utils.yes?(ENV.fetch('DEBUG_DATABASE', nil))
 
         # Enables Familia's database logging (automatically registers middleware)
         Familia.enable_database_logging = debug_enabled


### PR DESCRIPTION
## Summary

Simplify the database debug logging initialization by removing support for multiple environment variable names and standardizing on a single `DEBUG_DATABASE` variable.

## Changes

- Removed support for `DATABASE_DEBUG`, `DEBUG_VALKEY`, and `DEBUG_REDIS` environment variables
- Consolidated debug flag detection to use only `DEBUG_DATABASE`
- Simplified the conditional logic from a multi-variable check to a single variable lookup

## Related Issues

<!-- Keywords that auto-close issues when merged: Fixes, Closes, Resolves -->
<!-- Example: Fixes #123 -->

## Test Plan

N/A - This is a straightforward configuration simplification. Existing initialization tests will verify the behavior continues to work correctly with the `DEBUG_DATABASE` variable.

https://claude.ai/code/session_01GAycr6QLdhg4vids2aPAa6