### PR TITLE
[#3271] fix: stop shadowing Familia load() in CustomDomain

### DIFF
--- a/apps/web/auth/spec/integration/domain_sso_tenant_resolution_spec.rb
+++ b/apps/web/auth/spec/integration/domain_sso_tenant_resolution_spec.rb
@@ -224,7 +224,6 @@ RSpec.describe 'Domain SSO Tenant Resolution', type: :integration do
       it 'handles missing organization gracefully' do
         # Domain exists but org was deleted
         # Stub custom_domain to return nil (simulates orphaned domain)
-        # since CustomDomain.load now requires (display_domain, org_id)
         config = build_domain_sso_config(:oidc)
         config.define_singleton_method(:custom_domain) { nil }
         expect(config.organization).to be_nil

--- a/lib/onetime/models/custom_domain.rb
+++ b/lib/onetime/models/custom_domain.rb
@@ -1052,18 +1052,6 @@ module Onetime
         instances.rangebyscoreraw(spoint, epoint).collect { |identifier| load(identifier) }
       end
 
-      # Implement a load method for CustomDomain to make sure the
-      # correct derived ID is used as the key.
-      def load(display_domain, org_id)
-        custom_domain = parse(display_domain, org_id).tap do |obj|
-          OT.ld "[CustomDomain.load] Got #{obj.identifier} #{obj.display_domain} #{obj.org_id}"
-          raise Onetime::RecordNotFound, "Domain not found #{obj.display_domain}" unless obj.exists?
-        end
-
-        # Continue with the built-in `load` from Familia.
-        super(custom_domain.identifier)
-      end
-
       # Load a custom domain by display domain only. Used during requests
       # after determining the domain strategy is :custom.
       #

--- a/try/unit/models/custom_domain_load_contract_try.rb
+++ b/try/unit/models/custom_domain_load_contract_try.rb
@@ -1,0 +1,99 @@
+# try/unit/models/custom_domain_load_contract_try.rb
+#
+# frozen_string_literal: true
+
+# Tests for CustomDomain's Familia load(identifier) contract.
+#
+# Regression coverage for #3271: CustomDomain.load used to shadow Familia's
+# load(identifier) with an incompatible (display_domain, org_id) signature,
+# raising ArgumentError on every CustomDomain.load(objid) caller. The seven
+# CLI doctor callers and JoinDomainOrganization all relied on the Familia
+# idiom and broke the moment they ran. The old two-arg override could never
+# return a record anyway: parse() builds a fresh object with a random objid
+# (Familia.generate_id), so the obj.exists? guard always failed. It was
+# removed rather than renamed.
+#
+# After the fix:
+#   - CustomDomain.load(identifier) resolves through Familia's base loader
+#     (same as find_by_identifier(identifier)).
+#
+# Run:
+#   bundle exec try try/unit/models/custom_domain_load_contract_try.rb
+
+require_relative '../../support/test_models'
+
+OT.boot! :test
+
+Familia.dbclient.flushdb
+OT.info "Cleaned Redis for CustomDomain.load contract test"
+
+@ts = Familia.now.to_i
+@entropy = SecureRandom.hex(4)
+@fqdn = "load-contract-#{@ts}-#{@entropy}.example.com"
+@owner = Onetime::Customer.create!(email: "load_contract_#{@ts}_#{@entropy}@test.com")
+@org = Onetime::Organization.create!("Load Contract Org #{@ts}", @owner, "load_contract_#{@ts}@test.com")
+@domain = Onetime::CustomDomain.create!(@fqdn, @org.objid)
+
+# --- Familia contract: load(identifier) ---
+
+## CustomDomain.load(identifier) returns the record for a known identifier
+Onetime::CustomDomain.load(@domain.identifier).class
+#=> Onetime::CustomDomain
+
+## CustomDomain.load(identifier) returns the same record as find_by_identifier
+Onetime::CustomDomain.load(@domain.identifier).identifier
+#=> @domain.identifier
+
+## CustomDomain.load(identifier) returns nil for unknown identifier
+Onetime::CustomDomain.load('nonexistent-domain-id-xyz')
+#=> nil
+
+## CustomDomain.load(identifier) and find_by_identifier(identifier) agree
+[
+  Onetime::CustomDomain.load(@domain.identifier).identifier,
+  Onetime::CustomDomain.find_by_identifier(@domain.identifier).identifier,
+]
+#=> [@domain.identifier, @domain.identifier]
+
+# --- Two-arg load is gone (regression guard) ---
+#
+# The old shadowing override raised ArgumentError on single-arg callers.
+# Make sure single-arg load is now the only signature CustomDomain exposes,
+# so a future re-introduction of the two-arg form fails this test.
+
+## CustomDomain.load no longer accepts (display_domain, org_id)
+begin
+  Onetime::CustomDomain.load(@fqdn, @org.objid)
+  :no_raise
+rescue ArgumentError
+  :raised
+end
+#=> :raised
+
+# --- Doctor-style usage: scan instances and load by objid ---
+#
+# Mirrors lib/onetime/cli/domains/doctor_command.rb#scan_all_domains, which
+# iterates CustomDomain.instances and calls CustomDomain.load(objid). Before
+# the fix this raised ArgumentError on the first iteration.
+
+## Iterating instances and calling load(objid) does not raise
+@loaded_identifiers = Onetime::CustomDomain.instances.members.collect do |objid|
+  Onetime::CustomDomain.load(objid)&.identifier
+end.compact
+@loaded_identifiers.include?(@domain.identifier)
+#=> true
+
+# --- recent() uses load(identifier) internally ---
+#
+# CustomDomain.recent iterates instances and calls load(identifier). Before
+# the fix this raised on every call. The score-range edge means a domain
+# created in the same second as now isn't guaranteed to be included, so we
+# only assert the call doesn't raise.
+
+## recent() runs without raising on the load(identifier) call inside the loop
+Onetime::CustomDomain.recent.is_a?(Array)
+#=> true
+
+# Teardown
+Familia.dbclient.flushdb
+OT.info "Cleaned Redis after CustomDomain.load contract test"

--- a/try/unit/models/custom_domain_mailer_config_try.rb
+++ b/try/unit/models/custom_domain_mailer_config_try.rb
@@ -427,11 +427,7 @@ Onetime::CustomDomain::MailerConfig.delete_for_domain!('')
 #=> true
 
 # --- MailerConfig reverse navigation ---
-# BUG: MailerConfig#custom_domain calls CustomDomain.load(domain_id) but
-# CustomDomain.load requires 2 args (display_domain, org_id). This raises
-# ArgumentError at runtime. Should use find_by_identifier(domain_id) instead.
 
-## mailer_config.custom_domain raises ArgumentError (known bug: load expects 2 args)
 ## custom_domain returns the parent CustomDomain
 @config.custom_domain.class
 #=> Onetime::CustomDomain


### PR DESCRIPTION
CustomDomain.load defined a two-arg (display_domain, org_id) signature that shadowed Familia::Horreum.load(identifier). Every single-arg caller raised ArgumentError on the first invocation. The override was also internally broken: parse() builds a fresh object with a random objid (Familia.generate_id), so the obj.exists? guard could never succeed.

Removing the override restores the Familia contract for the eight single-arg callers (7 in CLI doctor commands, 1 in JoinDomainOrganization) and for the internal CustomDomain.recent loop.

Adds custom_domain_load_contract_try as regression coverage. Drops the stale BUG comment in custom_domain_mailer_config_try and a parallel comment in domain_sso_tenant_resolution_spec.

https://claude.ai/code/session_01LDAdoe6fnVhU9PBrDMXP7H

## Summary

[#ISSUE_NUMBER](https://github.com/onetimesecret/onetimesecret/issues/ISSUE_NUMBER)

<!-- Brief description of changes -->

## Related Issues

<!-- Keywords that auto-close issues when merged: Fixes, Closes, Resolves -->
<!-- Example: Fixes #123 -->

## Test Plan

<!-- How was this tested? -->
