### PR TITLE
Pin @types/estree to 1.0.9

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  '@types/estree': 1.0.9
   brace-expansion: 1.1.13
   flatted: ^3.4.2
   yaml: ^2.8.3
@@ -1774,9 +1775,6 @@ packages:
 
   '@types/esrecurse@4.3.1':
     resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
-
-  '@types/estree@1.0.8':
-    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
@@ -5765,7 +5763,7 @@ snapshots:
 
   '@rollup/pluginutils@5.3.0(rollup@4.59.0)':
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       estree-walker: 2.0.2
       picomatch: 4.0.4
     optionalDependencies:
@@ -6132,8 +6130,6 @@ snapshots:
   '@types/deep-eql@4.0.2': {}
 
   '@types/esrecurse@4.3.1': {}
-
-  '@types/estree@1.0.8': {}
 
   '@types/estree@1.0.9': {}
 
@@ -7328,7 +7324,7 @@ snapshots:
   eslint-scope@9.1.2:
     dependencies:
       '@types/esrecurse': 4.3.1
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       esrecurse: 4.3.0
       estraverse: 5.3.0
 
@@ -7351,7 +7347,7 @@ snapshots:
       '@humanfs/node': 0.16.7
       '@humanwhocodes/module-importer': 1.0.1
       '@humanwhocodes/retry': 0.4.3
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       ajv: 6.14.0
       chalk: 4.1.2
       cross-spawn: 7.0.6
@@ -7413,7 +7409,7 @@ snapshots:
 
   estree-walker@3.0.3:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
 
   esutils@2.0.3: {}
 
@@ -8523,7 +8519,7 @@ snapshots:
 
   rollup@4.59.0:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
     optionalDependencies:
       '@rollup/rollup-android-arm-eabi': 4.59.0
       '@rollup/rollup-android-arm64': 4.59.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,6 +5,7 @@ allowBuilds:
   vue-demi: false
 
 overrides:
+  '@types/estree': '1.0.9'
   brace-expansion: '1.1.13'
   flatted: '^3.4.2'
   yaml: '^2.8.3'


### PR DESCRIPTION
## Summary

Pin the `@types/estree` dependency to version `1.0.9` in the workspace overrides to ensure consistent type definitions across the monorepo.

## Related Issues

<!-- Keywords that auto-close issues when merged: Fixes, Closes, Resolves -->
<!-- Example: Fixes #123 -->

## Test Plan

N/A - This is a dependency pinning change. Existing CI checks will verify that the workspace resolves correctly with the pinned version.

https://claude.ai/code/session_01DDVFzcGdZR5ujHS3m5Ue6B