### PR TITLE
Include plan limits in entitlements staleness detection

### DIFF
--- a/lib/onetime/models/organization/features/with_materialized_entitlements.rb
+++ b/lib/onetime/models/organization/features/with_materialized_entitlements.rb
@@ -33,6 +33,29 @@ module Onetime
           Digest::SHA256.hexdigest(content)[0, 12]
         end
 
+        # Compute content hash for a full materialized snapshot (entitlements + limits).
+        # The org materializes both, so staleness detection must cover both — otherwise
+        # plan edits that only touch limits look "fresh."
+        #
+        # When limits are empty/nil the result equals entitlements_content_hash, so
+        # orgs on limits-free plans stay fresh across this change.
+        #
+        # @param entitlements [Array<String>, Enumerable] Entitlement strings
+        # @param limits [Hash, nil] Flattened limits (e.g., {"teams.max" => "5"})
+        # @return [String] 12-char hex hash
+        def self.snapshot_content_hash(entitlements, limits = nil)
+          ent_part = entitlements.to_a.sort.join(',')
+          limits_h = limits ? limits.to_h : {}
+          return Digest::SHA256.hexdigest(ent_part)[0, 12] if limits_h.empty?
+
+          limits_part = limits_h
+            .map { |k, v| [k.to_s, v.to_s] }
+            .sort
+            .map { |k, v| "#{k}=#{v}" }
+            .join(',')
+          Digest::SHA256.hexdigest("#{ent_part}|#{limits_part}")[0, 12]
+        end
+
         def self.included(base)
           OT.ld "[features] #{base}: #{name}"
 
@@ -68,6 +91,10 @@ module Onetime
           def entitlements_content_hash(entitlements)
             WithMaterializedEntitlements.entitlements_content_hash(entitlements)
           end
+
+          def snapshot_content_hash(entitlements, limits = nil)
+            WithMaterializedEntitlements.snapshot_content_hash(entitlements, limits)
+          end
         end
 
         module InstanceMethods
@@ -82,8 +109,12 @@ module Onetime
           # @param plan [Billing::Plan] Plan to materialize from
           # @return [Boolean] True if materialization succeeded
           def materialize_entitlements_from_plan(plan)
-            # Compute content hash and set scalar field first
-            content_hash                      = self.class.entitlements_content_hash(plan.entitlements.to_a)
+            # Hash covers entitlements + limits — both are part of the materialized
+            # snapshot, so a limits-only plan change must mark the org stale.
+            content_hash                      = self.class.snapshot_content_hash(
+              plan.entitlements.to_a,
+              plan.limits.hgetall,
+            )
             self.materialized_entitlements_at = "#{Familia.now.to_i}:#{content_hash}"
 
             # Save scalar, then execute collection operations
@@ -114,8 +145,8 @@ module Onetime
             entitlements = plan_data[:entitlements] || []
             limits       = plan_data[:limits] || {}
 
-            # Compute content hash and set scalar field first
-            content_hash                      = self.class.entitlements_content_hash(entitlements)
+            # Hash covers entitlements + limits (see materialize_entitlements_from_plan).
+            content_hash                      = self.class.snapshot_content_hash(entitlements, limits)
             self.materialized_entitlements_at = "#{Familia.now.to_i}:#{content_hash}"
 
             # Save scalar, then execute collection operations
@@ -231,12 +262,14 @@ module Onetime
             return true unless applied
 
             # Handle both Plan objects and config Hashes
-            entitlements = if plan.respond_to?(:entitlements)
-                             plan.entitlements.to_a
-                           else
-                             plan[:entitlements] || []
-                           end
-            current_hash = self.class.entitlements_content_hash(entitlements)
+            if plan.respond_to?(:entitlements)
+              entitlements = plan.entitlements.to_a
+              limits       = plan.limits.hgetall
+            else
+              entitlements = plan[:entitlements] || []
+              limits       = plan[:limits] || {}
+            end
+            current_hash = self.class.snapshot_content_hash(entitlements, limits)
             applied[:content_hash] != current_hash
           end
 

--- a/spec/unit/onetime/models/features/with_materialized_entitlements_spec.rb
+++ b/spec/unit/onetime/models/features/with_materialized_entitlements_spec.rb
@@ -399,6 +399,41 @@ RSpec.describe 'WithMaterializedEntitlements', billing: true do
       # plan now has different entitlements
       expect(org.entitlements_stale?(plan)).to be true
     end
+
+    it 'returns true when only plan limits changed (entitlements identical)' do
+      # Regression for #3280: a plan edit that only touches limits used to look
+      # "fresh" because the stamp hashed entitlements only.
+      old_limits = { 'teams.max' => '1' }
+      old_hash   = feature_mod.snapshot_content_hash(plan_ents, old_limits)
+      org.materialized_entitlements_at = "1716000000:#{old_hash}"
+
+      new_plan = plan_with(entitlements: plan_ents, limits: { 'teams.max' => '5' })
+
+      expect(org.entitlements_stale?(new_plan)).to be true
+    end
+
+    it 'returns false when both entitlements and limits match plan' do
+      limits        = { 'teams.max' => '5', 'secret_lifetime.max' => 'unlimited' }
+      expected_hash = feature_mod.snapshot_content_hash(plan_ents, limits)
+      org.materialized_entitlements_at = "1716000000:#{expected_hash}"
+
+      stamped_plan = plan_with(entitlements: plan_ents, limits: limits)
+
+      expect(org.entitlements_stale?(stamped_plan)).to be false
+    end
+
+    it 'accepts a config-hash plan and compares against its limits' do
+      limits        = { 'organizations.max' => '5' }
+      expected_hash = feature_mod.snapshot_content_hash(plan_ents, limits)
+      org.materialized_entitlements_at = "1716000000:#{expected_hash}"
+
+      config_plan = { entitlements: plan_ents, limits: limits }
+
+      expect(org.entitlements_stale?(config_plan)).to be false
+
+      changed_config = { entitlements: plan_ents, limits: { 'organizations.max' => '10' } }
+      expect(org.entitlements_stale?(changed_config)).to be true
+    end
   end
 
   # ============================================================================
@@ -550,6 +585,48 @@ RSpec.describe 'WithMaterializedEntitlements', billing: true do
 
       expect(h).to be_a(String)
       expect(h.length).to eq(12)
+    end
+  end
+
+  describe '.snapshot_content_hash' do
+    subject { feature_mod }
+
+    it 'equals entitlements_content_hash when limits are empty (back-compat)' do
+      ents = %w[api_access custom_domains]
+
+      expect(subject.snapshot_content_hash(ents, {})).to eq(subject.entitlements_content_hash(ents))
+      expect(subject.snapshot_content_hash(ents, nil)).to eq(subject.entitlements_content_hash(ents))
+    end
+
+    it 'differs when limit values differ' do
+      ents = %w[api_access]
+
+      h1 = subject.snapshot_content_hash(ents, { 'teams.max' => '1' })
+      h2 = subject.snapshot_content_hash(ents, { 'teams.max' => '5' })
+
+      expect(h1).not_to eq(h2)
+    end
+
+    it 'is stable regardless of limit key order' do
+      ents   = %w[api_access]
+      limits = { 'teams.max' => '5', 'secret_lifetime.max' => 'unlimited' }
+
+      h1 = subject.snapshot_content_hash(ents, limits)
+      h2 = subject.snapshot_content_hash(ents, limits.to_a.reverse.to_h)
+
+      expect(h1).to eq(h2)
+    end
+
+    it 'treats string and symbol limit keys as equivalent' do
+      ents = %w[api_access]
+
+      h1 = subject.snapshot_content_hash(ents, { 'teams.max' => '5' })
+      h2 = subject.snapshot_content_hash(ents, { teams_max: '5' })
+
+      # different keys -> different hashes, but stringification within a single
+      # call must be deterministic
+      expect(h2).to eq(subject.snapshot_content_hash(ents, { 'teams_max' => '5' }))
+      expect(h1).not_to eq(h2)
     end
   end
 end


### PR DESCRIPTION
## Summary

Fixes #3280

Plan edits that only modify limits (without changing entitlements) were incorrectly marked as "fresh" because the staleness check only hashed entitlements. Since both entitlements and limits are materialized on the organization, both must be included in the content hash to properly detect when a plan has changed.

### Changes

- Added `snapshot_content_hash` method that hashes both entitlements and limits together
- Updated `materialize_entitlements_from_plan` and `materialize_entitlements_from_config` to use the new method
- Updated `entitlements_stale?` to compare against the full snapshot hash (handles both Plan objects and config Hashes)
- Maintains backward compatibility: when limits are empty/nil, the hash equals the old `entitlements_content_hash`

## Related Issues

Fixes #3280

## Test Plan

Added comprehensive unit tests covering:
- Staleness detection when only limits change (regression test for #3280)
- Staleness detection when both entitlements and limits match
- Support for config-hash plans with limits
- `snapshot_content_hash` stability across limit key ordering and string/symbol equivalence
- Backward compatibility when limits are empty

All new tests pass; existing tests continue to pass.

https://claude.ai/code/session_011gCWsSCukSZCuMBkctSjru