### PR TITLE
Add Ents and Org logging categories to structured logging system

### DIFF
--- a/apps/api/organizations/spec/logic/organizations/create_organization_spec.rb
+++ b/apps/api/organizations/spec/logic/organizations/create_organization_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe OrganizationAPI::Logic::Organizations::CreateOrganization do
   # Source now uses the category-aware `logger` (Onetime::LoggerMethods) instead
   # of the OT.ld/OT.lw shims, and passes masked_name/extid as structured kwargs
   # rather than interpolating them into the message string.
-  let(:app_logger_double) do
+  let(:org_logger_double) do
     instance_double(SemanticLogger::Logger, info: nil, debug: nil, warn: nil, error: nil)
   end
 
@@ -55,7 +55,7 @@ RSpec.describe OrganizationAPI::Logic::Organizations::CreateOrganization do
     # don't force eager instantiation of the memoized `subject(:logic)` in the
     # before hook, which would freeze display_name before per-example params edits.
     allow(Onetime).to receive(:get_logger).and_call_original
-    allow(Onetime).to receive(:get_logger).with('App').and_return(app_logger_double)
+    allow(Onetime).to receive(:get_logger).with('Org').and_return(org_logger_double)
   end
 
   describe '#process_params' do
@@ -321,7 +321,7 @@ RSpec.describe OrganizationAPI::Logic::Organizations::CreateOrganization do
       end
 
       it 'masks short organization name in debug logs' do
-        expect(app_logger_double).to receive(:debug)
+        expect(org_logger_double).to receive(:debug)
           .with(/Creating organization/, hash_including(masked_name: '[2chars]'))
         logic.process
       end
@@ -330,7 +330,7 @@ RSpec.describe OrganizationAPI::Logic::Organizations::CreateOrganization do
     context 'with normal display_name (>3 chars)' do
       it 'masks organization name showing only first 3 chars' do
         # Default params has display_name: 'Organization' which masks to 'Org...'
-        expect(app_logger_double).to receive(:debug)
+        expect(org_logger_double).to receive(:debug)
           .with(/Creating organization/, hash_including(masked_name: 'Org...'))
         logic.process
       end
@@ -451,7 +451,7 @@ RSpec.describe OrganizationAPI::Logic::Organizations::CreateOrganization do
       end
 
       it 'logs warning but does not raise' do
-        expect(app_logger_double).to receive(:warn).with(/Lock release failed/, any_args)
+        expect(org_logger_double).to receive(:warn).with(/Lock release failed/, any_args)
         result = logic.process
         expect(result).to have_key(:record)
       end

--- a/etc/defaults/logging.defaults.yaml
+++ b/etc/defaults/logging.defaults.yaml
@@ -6,9 +6,11 @@
 #   App       - Default fallback for application-level logging
 #   Auth      - Authentication/authorization flows
 #   Bunny     - RabbitMQ AMQP client (connection, heartbeats)
+#   Ents      - Plan materialization, grants/revokes, plan→permission application
 #   Familia   - Redis operations via Familia ORM
 #   HTTP      - HTTP requests, responses, and middleware
 #   Jobs      - Job publishing (enqueue_email, fallback handling)
+#   Org       - Organization + membership lifecycle (create/destroy/activate/cascade)
 #   Otto      - Otto framework operations
 #   Rhales    - Rhales template rendering (future)
 #   Scheduler - Scheduled/recurring background jobs (rufus-scheduler)
@@ -51,14 +53,16 @@ formatter: <%= ENV['LOG_FORMATTER'] || 'color' %>
 loggers:
   App: warn       # Default application logger
   Auth: info      # Authentication/authorization flows
-  Billing: warn   # Only used when billing.enabled=true
+  Billing: warn   # Stripe checkout, payment intents, subscription webhooks, invoices, plan catalog sync
   Boot: warn      # During initialization
   Bunny: warn     # RabbitMQ client (heartbeats at debug level)
   Chores: info    # Familia::Horreum models housekeeping chores
+  Ents: info      # Entitlement materialization, grants/revokes, plan→permission application
   Jobs: info      # Job publishing (Publisher.enqueue_email, fallbacks)
   CLI: info       # Command-line interface operations
   Familia: info   # Redis/Familia main database operations
   HTTP: info      # HTTP requests and middleware operations
+  Org: info       # Organization + membership lifecycle (create/destroy/activate/cascade)
   Otto: info      # Otto framework operations
   Rhales: error   # Rhales template rendering (suppress unescaped HTML warnings)
   Scheduler: info # Scheduled/recurring background jobs

--- a/lib/onetime/class_methods.rb
+++ b/lib/onetime/class_methods.rb
@@ -306,7 +306,7 @@ module Onetime
       case path
       when %r{/auth/|/authenticate|/session}i then 'Auth'
       when %r{entitlement|materialize|grant_probono}i then 'Ents'
-      when %r{/organization|organization_context|organization_loader}i then 'Org'
+      when %r{organization|membership}i then 'Org'
       when %r{/billing/|/stripe|/subscription}i then 'Billing'
       when %r{/secrets?/|/metadata}i then 'Secret'
       when %r{/controllers?/|/middleware/|/request}i then 'HTTP'

--- a/lib/onetime/class_methods.rb
+++ b/lib/onetime/class_methods.rb
@@ -305,6 +305,8 @@ module Onetime
     def category_for_path(path)
       case path
       when %r{/auth/|/authenticate|/session}i then 'Auth'
+      when %r{entitlement|materialize|grant_probono}i then 'Ents'
+      when %r{/organization|organization_context|organization_loader}i then 'Org'
       when %r{/billing/|/stripe|/subscription}i then 'Billing'
       when %r{/secrets?/|/metadata}i then 'Secret'
       when %r{/controllers?/|/middleware/|/request}i then 'HTTP'

--- a/lib/onetime/initializers/setup_loggers.rb
+++ b/lib/onetime/initializers/setup_loggers.rb
@@ -10,8 +10,8 @@ module Onetime
   module Initializers
     # Configures SemanticLogger with strategic categories for debugging.
     #
-    # Categories: App, Auth, Billing, Boot, Bunny, Familia, HTTP, Jobs,
-    # Otto, Rhales, Secret, Sequel, Session.
+    # Categories: App, Auth, Billing, Boot, Bunny, Ents, Familia, HTTP,
+    # Jobs, Org, Otto, Rhales, Secret, Sequel, Session.
     #
     # Configuration loaded from etc/logging.yaml with environment variable
     # overrides. Logger instances are cached because SemanticLogger[]
@@ -37,9 +37,11 @@ module Onetime
         'Billing' => 'DEBUG_BILLING',
         'Boot' => 'DEBUG_BOOT',
         'Bunny' => 'DEBUG_BUNNY',
+        'Ents' => 'DEBUG_ENTS',
         'Familia' => 'DEBUG_FAMILIA',
         'HTTP' => 'DEBUG_HTTP',
         'Jobs' => 'DEBUG_JOBS',
+        'Org' => 'DEBUG_ORG',
         'Otto' => 'DEBUG_OTTO',
         'Rhales' => 'DEBUG_RHALES',
         'Scheduler' => 'DEBUG_SCHEDULER',

--- a/lib/onetime/logger_methods.rb
+++ b/lib/onetime/logger_methods.rb
@@ -8,7 +8,8 @@ module Onetime
   # Category-aware logging support for Onetime classes and modules.
   #
   # Provides access to SemanticLogger instances scoped to strategic categories:
-  # Auth, Bunny, Familia, HTTP, Jobs, Otto, Rhales, Secret, Session, App (default).
+  # Auth, Bunny, Ents, Familia, HTTP, Jobs, Org, Otto, Rhales, Secret, Session,
+  # App (default).
   #
   # Usage in classes:
   #   class MyAuthController
@@ -134,6 +135,10 @@ module Onetime
       Onetime.get_logger('Bunny')
     end
 
+    def ents_logger
+      Onetime.get_logger('Ents')
+    end
+
     def auth_logger
       Onetime.get_logger('Auth')
     end
@@ -144,6 +149,10 @@ module Onetime
 
     def http_logger
       Onetime.get_logger('HTTP')
+    end
+
+    def org_logger
+      Onetime.get_logger('Org')
     end
 
     def otto_logger
@@ -223,9 +232,11 @@ module Onetime
       # Check for strategic category patterns in class name
       category_patterns = {
         /Authentication|Auth(?!or)/i => 'Auth',
+        /Entitlement|Materialize|GrantProbono/i => 'Ents',
         /Familia/i => 'Familia',
         /HTTP|Request|Response|Controller/i => 'HTTP',
         /Jobs|Worker|Publisher|Scheduler/i => 'Jobs',
+        /Organization|Membership/i => 'Org',
         /Otto/i => 'Otto',
         /Rhales/i => 'Rhales',
         /Secret|Metadata/i => 'Secret',

--- a/lib/onetime/logger_methods.rb
+++ b/lib/onetime/logger_methods.rb
@@ -233,10 +233,10 @@ module Onetime
       category_patterns = {
         /Authentication|Auth(?!or)/i => 'Auth',
         /Entitlement|Materialize|GrantProbono/i => 'Ents',
+        /Organization|Membership/i => 'Org',
         /Familia/i => 'Familia',
         /HTTP|Request|Response|Controller/i => 'HTTP',
         /Jobs|Worker|Publisher|Scheduler/i => 'Jobs',
-        /Organization|Membership/i => 'Org',
         /Otto/i => 'Otto',
         /Rhales/i => 'Rhales',
         /Secret|Metadata/i => 'Secret',

--- a/try/system/logger_methods_try.rb
+++ b/try/system/logger_methods_try.rb
@@ -17,7 +17,7 @@ OT.boot! :test, true
 # Onetime Logging System Tests
 #
 # Tests for the structured logging system with strategic categories.
-# Categories: Auth, Session, HTTP, Familia, Otto, Rhales, Secret, App
+# Categories: Auth, Ents, Session, HTTP, Familia, Org, Otto, Rhales, Secret, App
 
 ## Configuration Loading - Config file exists
 File.exist?(File.join(Dir.pwd, 'etc', 'logging.yaml'))
@@ -55,8 +55,16 @@ SemanticLogger['Session']
 SemanticLogger['HTTP']
 #=:> SemanticLogger::Logger
 
+## SemanticLogger Integration - Ents logger exists
+SemanticLogger['Ents']
+#=:> SemanticLogger::Logger
+
 ## SemanticLogger Integration - Familia logger exists
 SemanticLogger['Familia']
+#=:> SemanticLogger::Logger
+
+## SemanticLogger Integration - Org logger exists
+SemanticLogger['Org']
 #=:> SemanticLogger::Logger
 
 ## SemanticLogger Integration - Otto logger exists
@@ -108,6 +116,16 @@ test_instance = TestLoggingClass.new
 test_instance.app_logger
 #=:> SemanticLogger::Logger
 
+## Logging Module - Ents logger accessor
+test_instance = TestLoggingClass.new
+test_instance.ents_logger
+#=:> SemanticLogger::Logger
+
+## Logging Module - Org logger accessor
+test_instance = TestLoggingClass.new
+test_instance.org_logger
+#=:> SemanticLogger::Logger
+
 ## Category Inference - Auth pattern detection
 class TestAuthClass
   include Onetime::LoggerMethods
@@ -139,6 +157,30 @@ end
 test_controller = TestController.new
 test_controller.send(:infer_category)
 #=> "HTTP"
+
+## Category Inference - Entitlement pattern detection
+class TestEntitlementClass
+  include Onetime::LoggerMethods
+end
+test_ents = TestEntitlementClass.new
+test_ents.send(:infer_category)
+#=> "Ents"
+
+## Category Inference - Organization pattern detection
+class TestOrganizationClass
+  include Onetime::LoggerMethods
+end
+test_org = TestOrganizationClass.new
+test_org.send(:infer_category)
+#=> "Org"
+
+## Category Inference - Membership pattern detection
+class TestMembershipClass
+  include Onetime::LoggerMethods
+end
+test_membership = TestMembershipClass.new
+test_membership.send(:infer_category)
+#=> "Org"
 
 ## Category Inference - Default fallback
 class TestRandomClass


### PR DESCRIPTION
## Summary

Extends the structured logging system with two new strategic logging categories:

- **Ents**: Plan materialization, grants/revokes, and plan→permission application
- **Org**: Organization and membership lifecycle operations (create/destroy/activate/cascade)

This change adds logger accessors, category inference patterns, configuration defaults, and debug environment variable mappings for both new categories across the logging infrastructure.

## Changes

### Core Logging Module (`lib/onetime/logger_methods.rb`)
- Added `ents_logger` and `org_logger` accessor methods
- Extended `infer_category` pattern matching to detect:
  - Entitlement/Materialize/GrantProbono classes → 'Ents'
  - Organization/Membership classes → 'Org'
- Updated module documentation to list new categories

### Logger Setup (`lib/onetime/initializers/setup_loggers.rb`)
- Added `DEBUG_ENTS` and `DEBUG_ORG` environment variable mappings
- Updated initializer documentation

### Class Methods (`lib/onetime/class_methods.rb`)
- Extended `category_for_path` to detect:
  - Entitlement/materialize/grant_probono paths → 'Ents'
  - Organization/organization_context/organization_loader paths → 'Org'

### Configuration (`etc/defaults/logging.defaults.yaml`)
- Added Ents and Org logger definitions with `info` level
- Updated category documentation with descriptions

### Tests (`try/system/logger_methods_try.rb`)
- Added integration tests for Ents and Org logger existence
- Added accessor tests for both new loggers
- Added category inference tests for Entitlement, Organization, and Membership patterns
- Updated category list in file header

## Test Plan

Existing integration tests in `try/system/logger_methods_try.rb` verify:
- Logger instances are accessible via `SemanticLogger['Ents']` and `SemanticLogger['Org']`
- Accessor methods `ents_logger` and `org_logger` return valid logger instances
- Category inference correctly identifies Entitlement, Organization, and Membership classes

https://claude.ai/code/session_014betfncXEwswGnZCZTZ6wY