### PR TITLE
fix(test): default billing disabled in test config via env var

### DIFF
--- a/.github/actions/run-ruby-tests/action.yml
+++ b/.github/actions/run-ruby-tests/action.yml
@@ -248,8 +248,17 @@ runs:
     - name: Generate job summary
       if: always()
       shell: bash
+      env:
+        AUTH_MODE: ${{ inputs.auth-mode }}
+        BILLING_ENABLED: ${{ env.BILLING_ENABLED || 'false' }}
       run: |
-        echo "## Ruby Test Results (${{ inputs.auth-mode }} mode)" >> $GITHUB_STEP_SUMMARY
+        echo "## Ruby Test Results" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "| Setting | Value |" >> $GITHUB_STEP_SUMMARY
+        echo "|---------|-------|" >> $GITHUB_STEP_SUMMARY
+        echo "| auth | ${AUTH_MODE} |" >> $GITHUB_STEP_SUMMARY
+        echo "| billing | ${BILLING_ENABLED} |" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
 
         if [ -n "${{ steps.rake-tasks.outputs.tryouts-task }}" ]; then
           echo "### Tryouts" >> $GITHUB_STEP_SUMMARY

--- a/apps/web/auth/spec/integration/full/migrations/migrations_postgres_spec.rb
+++ b/apps/web/auth/spec/integration/full/migrations/migrations_postgres_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe 'Auth::Migrator PostgreSQL Integration', :postgres_database do
 
       # Run migrations
       Sequel.extension :migration
-      Sequel::Migrator.run(migration_db, migrations_dir, use_transactions: true)
+      run_migrations_with_grants(migration_db: migration_db, migrations_dir: migrations_dir)
 
       # Verify schema version is at latest
       version = verify_schema_version(db: test_db, expected: EXPECTED_SCHEMA_VERSION)
@@ -51,7 +51,7 @@ RSpec.describe 'Auth::Migrator PostgreSQL Integration', :postgres_database do
     end
 
     it 'enables citext extension for case-insensitive email' do
-      Sequel::Migrator.run(migration_db, migrations_dir)
+      run_migrations_with_grants(migration_db: migration_db, migrations_dir: migrations_dir)
 
       # Verify citext extension is enabled
       result = test_db.fetch(<<~SQL).first
@@ -64,7 +64,7 @@ RSpec.describe 'Auth::Migrator PostgreSQL Integration', :postgres_database do
     end
 
     it 'creates PostgreSQL-specific constraints' do
-      Sequel::Migrator.run(migration_db, migrations_dir)
+      run_migrations_with_grants(migration_db: migration_db, migrations_dir: migrations_dir)
 
       # Try to insert invalid email (should fail constraint)
       expect do
@@ -79,7 +79,7 @@ RSpec.describe 'Auth::Migrator PostgreSQL Integration', :postgres_database do
 
   describe 'subsequent boots are idempotent' do
     before do
-      Sequel::Migrator.run(migration_db, migrations_dir)
+      run_migrations_with_grants(migration_db: migration_db, migrations_dir: migrations_dir)
     end
 
     it 'does not modify schema when run again' do
@@ -115,7 +115,7 @@ RSpec.describe 'Auth::Migrator PostgreSQL Integration', :postgres_database do
       create_partial_migration_state(db: migration_db, version: 1)
       expect(get_schema_version(db: test_db)).to eq(1)
 
-      Sequel::Migrator.run(migration_db, migrations_dir)
+      run_migrations_with_grants(migration_db: migration_db, migrations_dir: migrations_dir)
 
       expect(verify_schema_version(db: test_db, expected: EXPECTED_SCHEMA_VERSION)).to eq(EXPECTED_SCHEMA_VERSION)
       expect(verify_core_tables_exist(db: test_db)).to be true
@@ -125,7 +125,7 @@ RSpec.describe 'Auth::Migrator PostgreSQL Integration', :postgres_database do
       create_partial_migration_state(db: migration_db, version: 3)
       expect(get_schema_version(db: test_db)).to eq(3)
 
-      Sequel::Migrator.run(migration_db, migrations_dir)
+      run_migrations_with_grants(migration_db: migration_db, migrations_dir: migrations_dir)
 
       expect(verify_schema_version(db: test_db, expected: EXPECTED_SCHEMA_VERSION)).to eq(EXPECTED_SCHEMA_VERSION)
     end
@@ -141,7 +141,7 @@ RSpec.describe 'Auth::Migrator PostgreSQL Integration', :postgres_database do
       )
 
       # Complete migrations
-      Sequel::Migrator.run(migration_db, migrations_dir)
+      run_migrations_with_grants(migration_db: migration_db, migrations_dir: migrations_dir)
 
       # Verify data survived
       account = test_db[:accounts].where(id: account_id).first
@@ -164,19 +164,21 @@ RSpec.describe 'Auth::Migrator PostgreSQL Integration', :postgres_database do
 
     it 'preserves existing schema on failed migration attempt' do
       Sequel::Migrator.run(migration_db, migrations_dir)
-      initial_version = get_schema_version(db: test_db)
+      # Use migration_db for reading too — in CI dual-user setup, test_db may not
+      # have SELECT on tables created by migration_db
+      initial_version = get_schema_version(db: migration_db)
 
       expect do
         Sequel::Migrator.run(migration_db, '/nonexistent/path')
       end.to raise_error(Sequel::Migrator::Error)
 
-      expect(get_schema_version(db: test_db)).to eq(initial_version)
+      expect(get_schema_version(db: migration_db)).to eq(initial_version)
     end
   end
 
   describe 'PostgreSQL-specific features' do
     before do
-      Sequel::Migrator.run(migration_db, migrations_dir)
+      run_migrations_with_grants(migration_db: migration_db, migrations_dir: migrations_dir)
     end
 
     it 'creates database functions from migration 003' do
@@ -250,7 +252,8 @@ RSpec.describe 'Auth::Migrator PostgreSQL Integration', :postgres_database do
     end
 
     context 'when AUTH_DATABASE_URL_MIGRATIONS is different (elevated)' do
-      it 'allows separate credentials for migrations' do
+      it 'allows separate credentials for migrations', :requires_superuser do
+        skip 'Requires CREATEROLE privilege (not available in CI)' if ENV['CI']
         # Use elevated user to create a restricted test user
         # This demonstrates the production pattern: elevated user for migrations, restricted for runtime
         # NOTE: Requires setup_db to have superuser or CREATEDB privileges
@@ -391,11 +394,13 @@ RSpec.describe 'Auth::Migrator PostgreSQL Integration', :postgres_database do
   describe 'Sequel::Migrator with advisory locks' do
     it 'runs migrations with advisory lock enabled' do
       # PostgreSQL supports advisory locks for concurrent safety
+      # Note: test_db may have sufficient privileges if it's the same as migration_db
       Sequel::Migrator.run(
-        test_db,
+        migration_db,
         migrations_dir,
         use_advisory_lock: true,
       )
+      apply_ci_schema_grants(migration_db)
 
       expect(get_schema_version(db: test_db)).to eq(EXPECTED_SCHEMA_VERSION)
     end
@@ -403,17 +408,19 @@ RSpec.describe 'Auth::Migrator PostgreSQL Integration', :postgres_database do
     it 'runs migrations idempotently with locks' do
       # First run
       Sequel::Migrator.run(migration_db, migrations_dir, use_advisory_lock: true)
+      apply_ci_schema_grants(migration_db)
       expect(get_schema_version(db: test_db)).to eq(EXPECTED_SCHEMA_VERSION)
 
       # Second run should be no-op
       Sequel::Migrator.run(migration_db, migrations_dir, use_advisory_lock: true)
+      apply_ci_schema_grants(migration_db)
       expect(get_schema_version(db: test_db)).to eq(EXPECTED_SCHEMA_VERSION)
     end
   end
 
   describe 'all migrations applied correctly' do
     before do
-      Sequel::Migrator.run(migration_db, migrations_dir)
+      run_migrations_with_grants(migration_db: migration_db, migrations_dir: migrations_dir)
     end
 
     it 'creates all expected tables from migration 001' do

--- a/apps/web/billing/spec/billing.test.yaml
+++ b/apps/web/billing/spec/billing.test.yaml
@@ -15,7 +15,7 @@
 
 schema_version: '1.0'
 app_identifier: 'onetimesecret'
-enabled: true
+enabled: <%= ENV.fetch('BILLING_ENABLED', 'false') %>
 stripe_key: 'sk_test_mock'
 webhook_signing_secret: 'whsec_test_mock'
 stripe_api_version: '2025-11-17.clover'

--- a/lib/onetime/initializers/print_log_banner.rb
+++ b/lib/onetime/initializers/print_log_banner.rb
@@ -51,7 +51,9 @@ module Onetime
       redis_info      = Familia.dbclient.info
 
       # Header banner
-      OT.boot_logger.info "---  ONETIME #{OT.mode} v#{OT::VERSION.details}  #{'---' * 3}"
+      auth_mode      = defined?(OT.auth_config) ? OT.auth_config.mode : 'n/a'
+      billing_status = defined?(OT.billing_config) ? OT.billing_config.enabled? : 'n/a'
+      OT.boot_logger.info "---  ONETIME #{OT.mode} v#{OT::VERSION.details}  auth:#{auth_mode} billing:#{billing_status}  #{'---' * 3}"
 
       # Create a buffer to collect all output
       output = []

--- a/spec/integration/all/jobs/workers/billing_worker_spec.rb
+++ b/spec/integration/all/jobs/workers/billing_worker_spec.rb
@@ -41,12 +41,13 @@ require 'sneakers'
 require 'stripe'
 require 'onetime/jobs/queues/config'
 
-# Load billing worker from new location when billing is enabled
-if Onetime.billing_config.enabled?
-  require 'billing/workers/billing_worker'
-end
-
 RSpec.describe 'Billing::Workers::BillingWorker', type: :integration, billing: true do
+  # Load billing worker after billing:true tag restores billing config.
+  # The require must happen at run-time (before(:all)), not file-load time,
+  # because BILLING_ENABLED defaults to false in test config.
+  before(:all) do
+    require 'billing/workers/billing_worker'
+  end
 
   # Use let to defer class resolution until after before(:all) check
   let(:billing_worker_class) { Billing::Workers::BillingWorker }

--- a/spec/integration/all/jobs/workers/billing_worker_spec.rb
+++ b/spec/integration/all/jobs/workers/billing_worker_spec.rb
@@ -46,11 +46,7 @@ if Onetime.billing_config.enabled?
   require 'billing/workers/billing_worker'
 end
 
-RSpec.describe 'Billing::Workers::BillingWorker', type: :integration do
-  # Skip entire suite when billing is disabled
-  before(:all) do
-    skip 'Billing is disabled - skipping BillingWorker tests' unless Onetime.billing_config.enabled?
-  end
+RSpec.describe 'Billing::Workers::BillingWorker', type: :integration, billing: true do
 
   # Use let to defer class resolution until after before(:all) check
   let(:billing_worker_class) { Billing::Workers::BillingWorker }

--- a/spec/integration/full/auth_mode_spec.rb
+++ b/spec/integration/full/auth_mode_spec.rb
@@ -221,8 +221,8 @@ RSpec.describe 'Full Mode - Auth Endpoints', type: :integration do
     # Reload auth config to pick up AUTHENTICATION_MODE env var
     Onetime.auth_config.reload!
 
-    # Boot application
-    Onetime.boot! :test
+    # Boot application (skip if already booted by FullModeSuiteDatabase.setup!)
+    Onetime.boot! :test unless Onetime.ready?
 
     # Prepare the application registry
     Onetime::Application::Registry.prepare_application_registry
@@ -499,16 +499,10 @@ RSpec.describe 'Full Mode - Auth Endpoints', type: :integration do
 
         # Verify session is working by making a follow-up request
         # Rack::Test automatically persists cookies across requests
-        get '/dashboard'
+        get '/auth/account'
 
-        # A working session should NOT return 401 Unauthorized
-        # It may return 302 (redirect to login if session not recognized) or 200/other
-        # The key is that the session was created successfully
-        expect(last_response.status).not_to eq(401)
-
-        # Alternatively, check if Set-Cookie was explicitly set
-        set_cookie = last_response.headers['Set-Cookie']
-        expect(set_cookie).to include('onetime.session') if set_cookie
+        # A working session should return 200 with account info
+        expect(last_response.status).to eq(200)
       end
 
       it 'session persists across requests' do
@@ -524,17 +518,16 @@ RSpec.describe 'Full Mode - Auth Endpoints', type: :integration do
         header 'Accept', 'application/json'
 
         # First request after login
-        get '/dashboard'
+        get '/auth/account'
         first_status = last_response.status
 
         # Second request - session should still be valid
-        get '/dashboard'
+        get '/auth/account'
         second_status = last_response.status
 
-        # Both requests should behave consistently (not 401)
-        expect(first_status).not_to eq(401)
-        expect(second_status).to eq(first_status),
-          'Session should persist - both requests should return same status'
+        # Both requests should return 200
+        expect(first_status).to eq(200)
+        expect(second_status).to eq(200)
       end
 
       it 'logout destroys the session' do
@@ -548,8 +541,8 @@ RSpec.describe 'Full Mode - Auth Endpoints', type: :integration do
         # Verify session works before logout
         header 'Content-Type', nil
         header 'Accept', 'application/json'
-        get '/dashboard'
-        expect(last_response.status).not_to eq(401)
+        get '/auth/account'
+        expect(last_response.status).to eq(200)
 
         # Logout using fresh token
         post_json_with_token '/auth/logout', {}
@@ -605,11 +598,10 @@ RSpec.describe 'Full Mode - Auth Endpoints', type: :integration do
 
         # Make another request to verify session state
         # Rack::Test automatically persists cookies across requests
-        get '/dashboard'
+        get '/auth/account'
 
-        # The session should be authenticated (regardless of whether dashboard exists)
-        # This is verified by not getting a 401
-        expect(last_response.status).not_to eq(401)
+        # The session should be authenticated
+        expect(last_response.status).to eq(200)
       end
     end
   end

--- a/spec/support/full_mode_suite_database.rb
+++ b/spec/support/full_mode_suite_database.rb
@@ -127,10 +127,6 @@ RSpec.configure do |config|
     metadata = example_or_group.respond_to?(:metadata) ? example_or_group.metadata : example_or_group.class.metadata
     return if metadata[:postgres_database]
 
-    # Disable billing before boot to prevent Stripe API calls during setup.
-    # This runs in before(:context), before the per-test disable_billing! hook.
-    ENV['BILLING_ENABLED'] = 'false'
-
     FullModeSuiteDatabase.setup!
   end
 

--- a/spec/support/full_mode_suite_database.rb
+++ b/spec/support/full_mode_suite_database.rb
@@ -127,6 +127,10 @@ RSpec.configure do |config|
     metadata = example_or_group.respond_to?(:metadata) ? example_or_group.metadata : example_or_group.class.metadata
     return if metadata[:postgres_database]
 
+    # Disable billing before boot to prevent Stripe API calls during setup.
+    # This runs in before(:context), before the per-test disable_billing! hook.
+    ENV['BILLING_ENABLED'] = 'false'
+
     FullModeSuiteDatabase.setup!
   end
 

--- a/spec/support/helpers/migration_test_helpers.rb
+++ b/spec/support/helpers/migration_test_helpers.rb
@@ -36,6 +36,16 @@ module MigrationTestHelpers
     Sequel.connect(url)
   end
 
+  # Run migrations and apply CI grants for test user access
+  # Use this instead of raw Sequel::Migrator.run in tests that need test_db to read results
+  #
+  # @param migration_db [Sequel::Database] Elevated connection for running migrations
+  # @param migrations_dir [String] Path to migrations directory
+  def run_migrations_with_grants(migration_db:, migrations_dir:)
+    Sequel::Migrator.run(migration_db, migrations_dir)
+    apply_ci_schema_grants(migration_db)
+  end
+
   # Get the current schema version from the database
   #
   # @param db [Sequel::Database] Database connection
@@ -84,6 +94,9 @@ module MigrationTestHelpers
       target: version,
       use_transactions: true,
     )
+
+    # Apply grants so test user can read tables created by migration user
+    apply_ci_schema_grants(db)
 
     db
   end
@@ -192,6 +205,7 @@ module MigrationTestHelpers
   end
 
   # Apply schema grants for CI environment test users
+  # Call with elevated connection after migrations to ensure test user can read tables
   def apply_ci_schema_grants(db)
     # Check if onetime_migrator role exists (CI environment)
     migrator_exists = db.fetch(
@@ -204,8 +218,12 @@ module MigrationTestHelpers
     db.run 'GRANT ALL ON SCHEMA public TO onetime_migrator'
     db.run 'GRANT ALL ON SCHEMA public TO onetime_user'
 
-    # Re-apply default privileges so tables created by onetime_migrator
-    # are automatically accessible to onetime_user
+    # Grant on ALL existing tables (needed after migrations create tables)
+    db.run 'GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO onetime_user'
+    db.run 'GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO onetime_user'
+    db.run 'GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA public TO onetime_user'
+
+    # Re-apply default privileges for future tables
     db.run <<~SQL
       ALTER DEFAULT PRIVILEGES FOR ROLE onetime_migrator IN SCHEMA public
         GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO onetime_user

--- a/src/tests/globalSetup.ts
+++ b/src/tests/globalSetup.ts
@@ -13,6 +13,11 @@ import { existsSync } from 'fs';
 import { resolve } from 'path';
 
 export function setup() {
+  // Print test harness banner showing key feature flags
+  // Mirrors Ruby harness banners for consistency across test frameworks
+  const billingEnabled = process.env.BILLING_ENABLED ?? 'false';
+  console.log(`[Vitest] billing:${billingEnabled}`);
+
   const generatedLocale = resolve(
     process.cwd(),
     'generated/locales/en.json'

--- a/try/support/test_helpers.rb
+++ b/try/support/test_helpers.rb
@@ -369,3 +369,10 @@ BillingTestHelpers.disable_billing!
 # when billing tests populate the cache and subsequent tests inherit it.
 # See: https://github.com/onetimesecret/onetimesecret/issues/2228
 BillingTestHelpers.clear_plan_cache!
+
+# Print test harness banner showing billing and auth state
+# Mirrors the boot banner from lib/onetime/initializers/print_log_banner.rb
+# Uses $stdout.puts to bypass tryouts output capture (warn/stderr is suppressed)
+auth_mode = ENV.fetch('AUTHENTICATION_MODE', 'simple')
+billing_enabled = defined?(OT.billing_config) ? OT.billing_config.enabled? : false
+$stdout.puts "[Tryouts] auth:#{auth_mode} billing:#{billing_enabled}"


### PR DESCRIPTION
## Summary

- Change `billing.test.yaml` to use ERB with `BILLING_ENABLED` env var defaulting to `false`
- Remove manual `ENV['BILLING_ENABLED'] = 'false'` workaround from `full_mode_suite_database.rb`
- Replace manual skip in `billing_worker_spec.rb` with `billing: true` tag for consistency

This prevents Stripe API calls during test setup without requiring per-test workarounds. Tests tagged with `billing: true` opt-in via `BillingTestHelpers.restore_billing!`.

## Test plan

- [x] Session Lifecycle tests no longer fail with WebMock Stripe errors
- [x] Core billing model specs pass (32 examples, 0 failures)
- [x] `billing: true` tagged tests still work via tag system