### PR TITLE
Document Auth::Config one-shot configuration and add test helpers

### DIFF
--- a/apps/web/auth/config.rb
+++ b/apps/web/auth/config.rb
@@ -27,11 +27,6 @@ module Auth
 
     class << self
       attr_accessor :configured
-
-      # Reset configuration state (for testing only)
-      def reset_configuration!
-        @configured = false
-      end
     end
 
     require_relative 'lib/logging'

--- a/apps/web/auth/docs/auth-config-one-shot.md
+++ b/apps/web/auth/docs/auth-config-one-shot.md
@@ -97,7 +97,7 @@ If a test suite genuinely needs to reconfigure `Auth::Config` itself (not
 just a fresh anonymous class), the class must be entirely reconstructed:
 
 ```ruby
-Auth::ConfigRecreator.with_fresh_config(features: { mfa: true }) do
+Auth::ConfigRecreator.with_fresh_config(env_overrides: { 'AUTH_MFA_ENABLED' => 'true' }) do
   # Auth::Config is a brand-new class here
   # All memoized references (Auth::Router, etc.) are stale
 end

--- a/apps/web/auth/docs/auth-config-one-shot.md
+++ b/apps/web/auth/docs/auth-config-one-shot.md
@@ -1,0 +1,132 @@
+# ADR: Auth::Config is one-shot (not reconfigurable)
+
+## Status
+
+Accepted (May 2026)
+
+## Context
+
+`Auth::Config < Rodauth::Auth` can be configured exactly once per process.
+A `@configured` class-level guard enforces this; without it, a second
+`configure do ... end` block corrupts the class.
+
+### Root cause
+
+Rodauth's `Configuration#apply` mutates the auth class in two irreversible
+ways:
+
+1. **`routes.concat`** — appends route entries. A second apply duplicates
+   every route with no dedup.
+2. **`include`** — inserts feature modules into the ancestor chain. Ruby has
+   no public API to remove an included module from a class.
+
+Because both operations are additive and non-idempotent, "reset and
+reconfigure with different feature flags" is not possible on an existing
+class instance.
+
+### Why `reset_configuration!` was a footgun
+
+A previous implementation exposed:
+
+```ruby
+def self.reset_configuration!
+  @configured = false
+end
+```
+
+This flipped the guard without undoing any structural mutations (routes,
+included modules, method definitions). Calling it then re-running
+`configure` would:
+
+- Double-register every route
+- Re-include feature modules (no-op for ancestors, but triggers
+  `included` hooks again)
+- Re-execute hook blocks that assume single-run semantics
+
+The method has been removed.
+
+## Decision
+
+### Production
+
+Production reads ENV once at boot and never reconfigures. The guard is
+dormant — it exists only as a safety net against accidental re-entry from
+code reloading or registry discovery.
+
+### Tests
+
+Tests that need different feature flag combinations use one of two
+patterns:
+
+#### Pattern 1: Fresh Roda app per example (preferred)
+
+`RodauthTestHelper.create_rodauth_app` builds an anonymous `Class.new(Roda)`
+with the desired features. Each spec gets its own class — no shared state,
+no contamination.
+
+```ruby
+let(:app) do
+  create_rodauth_app(db: db, features: [:base, :login, :otp]) do
+    otp_issuer 'Test'
+  end
+end
+```
+
+#### Pattern 2: ENV capture/restore (integration tests)
+
+Integration tests that boot the full application capture AUTH_* env vars
+before loading `Auth::Config` and restore them in `after(:all)`, preventing
+feature-flag leakage between spec files:
+
+```ruby
+before(:all) do
+  @saved_env = ENV.select { |k, _| k.start_with?('AUTH_') }
+  # ... set test-specific env vars ...
+  boot_onetime_app
+end
+
+after(:all) do
+  ENV.reject! { |k, _| k.start_with?('AUTH_') }
+  @saved_env.each { |k, v| ENV[k] = v }
+end
+```
+
+#### Pattern 3: Recreate-class workaround (last resort)
+
+If a test suite genuinely needs to reconfigure `Auth::Config` itself (not
+just a fresh anonymous class), the class must be entirely reconstructed:
+
+```ruby
+Auth::ConfigRecreator.with_fresh_config(features: { mfa: true }) do
+  # Auth::Config is a brand-new class here
+  # All memoized references (Auth::Router, etc.) are stale
+end
+```
+
+This is invasive because it requires:
+
+1. Removing the old `Auth::Config` constant
+2. Creating a new `Class.new(Rodauth::Auth)`
+3. Re-requiring every `config/*.rb` file (they reopen the class namespace)
+4. Re-registering with the Roda plugin system
+5. Updating every memoized reference
+
+Use Pattern 1 instead whenever possible.
+
+## Consequences
+
+- `Auth::Config` is immutable after first configuration
+- No `reset_configuration!` method exists
+- Tests that need feature variation use fresh anonymous classes
+- The recreate-class pattern exists as documented escape hatch but carries
+  high maintenance cost
+- Upstream rodauth changes should be monitored on each version bump for
+  a potential class-reset API
+
+## Related
+
+- Issue: #3238
+- Parent: #3104 (OAuth/OIDC IdP feature)
+- `apps/web/auth/config.rb` — the `@configured` guard
+- `apps/web/auth/spec/spec_helper.rb` — ENV capture/restore helpers
+- `apps/web/auth/spec/support/config_recreator.rb` — recreate-class utility

--- a/apps/web/auth/spec/spec_helper.rb
+++ b/apps/web/auth/spec/spec_helper.rb
@@ -80,6 +80,7 @@ require 'rack/test'
 require_relative 'support/omniauth_test_helper'
 require_relative 'support/auth_test_constants'
 require_relative 'support/mock_omniauth_strategy'
+require_relative 'support/config_recreator'
 require_relative '../database'
 
 # =============================================================================
@@ -552,6 +553,17 @@ RSpec.configure do |config|
   # Integration test helpers (for tests requiring full app boot)
   config.include Rack::Test::Methods, type: :integration
   config.include ProductionConfigHelper, type: :integration
+
+  # Capture AUTH_* env vars before integration suite to prevent leakage
+  # between spec files that set different feature flags.
+  # See: apps/web/auth/docs/auth-config-one-shot.md (Pattern 2)
+  config.before(:all, type: :integration) do
+    @saved_auth_env = Auth::ConfigRecreator.capture_auth_env
+  end
+
+  config.after(:all, type: :integration) do
+    Auth::ConfigRecreator.restore_auth_env(@saved_auth_env) if @saved_auth_env
+  end
 
   # Skip integration tests if Valkey not available
   config.before(:each, type: :integration) do

--- a/apps/web/auth/spec/support/config_recreator.rb
+++ b/apps/web/auth/spec/support/config_recreator.rb
@@ -25,12 +25,12 @@ module Auth
     # app is re-booted afterward.
     #
     def self.with_fresh_config(env_overrides: {})
-      original_class = Auth::Config
-      original_configured = Auth::Config.configured
+      original_class = defined?(Auth::Config) ? Auth::Config : nil
+      original_configured = original_class&.configured
 
       begin
-        # Remove the existing constant so we can define a new one
-        Auth.send(:remove_const, :Config)
+        # Remove the existing constant if it exists
+        Auth.send(:remove_const, :Config) if original_class
 
         # Apply env overrides
         saved_env = {}
@@ -47,12 +47,17 @@ module Auth
           attr_accessor :configured
         end
 
+        # Reload the configuration file to populate the class with new env overrides
+        load File.expand_path('../../config.rb', __dir__)
+
         yield Auth::Config
       ensure
         # Restore original class
         Auth.send(:remove_const, :Config) if defined?(Auth::Config)
-        Auth.const_set(:Config, original_class)
-        Auth::Config.instance_variable_set(:@configured, original_configured)
+        if original_class
+          Auth.const_set(:Config, original_class)
+          Auth::Config.instance_variable_set(:@configured, original_configured)
+        end
 
         # Restore env
         saved_env&.each do |key, value|
@@ -79,7 +84,7 @@ module Auth
     # @param saved [Hash] previously captured env vars from capture_auth_env
     def self.restore_auth_env(saved)
       ENV.reject! { |k, _| k.start_with?('AUTH_') }
-      saved.each { |k, v| ENV[k] = v }
+      saved&.each { |k, v| ENV[k] = v }
     end
   end
 end

--- a/apps/web/auth/spec/support/config_recreator.rb
+++ b/apps/web/auth/spec/support/config_recreator.rb
@@ -1,0 +1,85 @@
+# apps/web/auth/spec/support/config_recreator.rb
+#
+# frozen_string_literal: true
+
+module Auth
+  # Recreates Auth::Config from scratch for test suites that need to
+  # reconfigure with different feature flags. This is a last-resort pattern;
+  # prefer RodauthTestHelper.create_rodauth_app for isolated feature testing.
+  #
+  # See: apps/web/auth/docs/auth-config-one-shot.md (Pattern 3)
+  #
+  module ConfigRecreator
+    # Yields with a freshly-constructed Auth::Config class.
+    #
+    # Captures the current Auth::Config, removes it from the constant table,
+    # builds a new one via the standard config.rb require path, then restores
+    # the original after the block completes.
+    #
+    # @param env_overrides [Hash] ENV vars to set during reconstruction
+    # @yield Block executed with the fresh Auth::Config in place
+    #
+    # WARNING: This invalidates all memoized references to Auth::Config
+    # (Auth::Router's rodauth plugin, application registry entries, etc.).
+    # Only use in isolated before(:all)/after(:all) blocks where the full
+    # app is re-booted afterward.
+    #
+    def self.with_fresh_config(env_overrides: {})
+      original_class = Auth::Config
+      original_configured = Auth::Config.configured
+
+      begin
+        # Remove the existing constant so we can define a new one
+        Auth.send(:remove_const, :Config)
+
+        # Apply env overrides
+        saved_env = {}
+        env_overrides.each do |key, value|
+          saved_env[key] = ENV[key]
+          ENV[key] = value
+        end
+
+        # Define a fresh Auth::Config class
+        Auth.const_set(:Config, Class.new(Rodauth::Auth))
+        Auth::Config.instance_variable_set(:@configured, false)
+
+        class << Auth::Config
+          attr_accessor :configured
+        end
+
+        yield Auth::Config
+      ensure
+        # Restore original class
+        Auth.send(:remove_const, :Config) if defined?(Auth::Config)
+        Auth.const_set(:Config, original_class)
+        Auth::Config.instance_variable_set(:@configured, original_configured)
+
+        # Restore env
+        saved_env&.each do |key, value|
+          if value.nil?
+            ENV.delete(key)
+          else
+            ENV[key] = value
+          end
+        end
+      end
+    end
+
+    # Captures all AUTH_* environment variables. Use in before(:all) blocks
+    # to snapshot env state before integration tests modify it.
+    #
+    # @return [Hash] captured env vars
+    def self.capture_auth_env
+      ENV.select { |k, _| k.start_with?('AUTH_') }.to_h
+    end
+
+    # Restores previously-captured AUTH_* environment variables, removing
+    # any that were added during the test run.
+    #
+    # @param saved [Hash] previously captured env vars from capture_auth_env
+    def self.restore_auth_env(saved)
+      ENV.reject! { |k, _| k.start_with?('AUTH_') }
+      saved.each { |k, v| ENV[k] = v }
+    end
+  end
+end


### PR DESCRIPTION
## Summary

#3238

Formalizes the one-shot configuration pattern for `Auth::Config` with comprehensive documentation and test infrastructure. Removes the footgun `reset_configuration!` method and provides three documented patterns for tests that need feature variation.

### Changes

1. **Added ADR document** (`auth-config-one-shot.md`): Explains why `Auth::Config` cannot be reconfigured after initial setup (Rodauth's `Configuration#apply` mutates routes and included modules irreversibly), documents the three test patterns, and clarifies consequences.

2. **Added `ConfigRecreator` utility** (`config_recreator.rb`): Provides last-resort helpers for tests that genuinely need to reconstruct `Auth::Config`:
   - `with_fresh_config`: Temporarily replaces `Auth::Config` with a fresh class for a block
   - `capture_auth_env` / `restore_auth_env`: Snapshot/restore AUTH_* env vars to prevent feature-flag leakage between integration test files

3. **Removed `reset_configuration!` method**: This method was a footgun—it flipped the guard without undoing structural mutations (routes, included modules), causing double-registration and re-execution of hooks on reconfigure.

4. **Updated spec_helper**: Added automatic ENV capture/restore for integration tests (Pattern 2 from ADR) to prevent feature-flag contamination between spec files.

### Test Patterns Documented

- **Pattern 1 (preferred)**: Fresh anonymous Roda app per example via `RodauthTestHelper.create_rodauth_app`
- **Pattern 2 (integration tests)**: ENV capture/restore to isolate feature flags between spec files
- **Pattern 3 (last resort)**: `ConfigRecreator.with_fresh_config` for tests that must reconfigure `Auth::Config` itself

## Related Issues

Fixes #3238

## Test Plan

Existing test infrastructure validates the patterns:
- Unit/feature tests use Pattern 1 (fresh app per example)
- Integration tests now use Pattern 2 (automatic ENV capture/restore in spec_helper)
- ConfigRecreator is available for any test suite that needs Pattern 3

No new test cases needed; the documentation and helpers enable existing tests to work correctly without `reset_configuration!`.

https://claude.ai/code/session_01QV6SGaq9HnUHvYCsJn3VDL