### PR TITLE
Force fresh boot in suite setup to ensure Familia encryption config

### DIFF
--- a/spec/integration/full/infrastructure_spec.rb
+++ b/spec/integration/full/infrastructure_spec.rb
@@ -73,6 +73,29 @@ RSpec.describe 'Full Mode Test Infrastructure', type: :integration do
     end
   end
 
+  # Regression guard for #3256: the full-mode suite setup must leave Familia's
+  # encryption config populated. ConfigureFamilia derives the encryption keys
+  # and current_key_version during boot; if the suite-level boot is skipped
+  # (idempotent in test mode) without that initializer ever running, encrypted
+  # field writes such as Receipt.spawn_pair fail with "Key version cannot be
+  # nil". The suite setup forces a fresh boot to guarantee this state.
+  describe 'Familia encryption configuration' do
+    it 'configures a current_key_version' do
+      expect(Familia.config.current_key_version).not_to be_nil
+    end
+
+    it 'configures encryption_keys for the current version' do
+      version = Familia.config.current_key_version
+      expect(Familia.config.encryption_keys).to include(version)
+    end
+
+    it 'allows encrypted-field writes via Receipt.spawn_pair' do
+      expect {
+        Onetime::Receipt.spawn_pair('anon', 3600, 'regression-guard secret')
+      }.not_to raise_error
+    end
+  end
+
   describe 'AuthAccountFactory' do
     # test_db and AuthAccountFactory are provided by FullModeSuiteDatabase
 

--- a/spec/support/full_mode_suite_database.rb
+++ b/spec/support/full_mode_suite_database.rb
@@ -64,10 +64,22 @@ module FullModeSuiteDatabase
       db = @database
       Auth::Database.define_singleton_method(:connection) { db }
 
-      # Ensure application is booted (idempotent in test mode)
+      # Boot the application with a forced fresh boot.
+      #
+      # `force: true` resets boot state first so the full initializer chain
+      # re-runs here. A plain `Onetime.boot! :test` is idempotent in test mode
+      # and silently skips when boot state is already :started — which happens
+      # whenever an earlier spec (e.g. spec/integration/all boot/config specs)
+      # booted first. The skip is mostly harmless, except it bypasses the
+      # ConfigureFamilia initializer that sets Familia's encryption keys and
+      # current_key_version. Those are process-global; if a prior connect_to_db:
+      # false boot left boot :started without running ConfigureFamilia, the
+      # encryption config is never populated and any encrypted-field write
+      # (e.g. Receipt.spawn_pair) raises "Key version cannot be nil".
+      # Forcing a fresh boot guarantees ConfigureFamilia runs for the suite.
       require 'onetime'
       require 'onetime/config'
-      Onetime.boot! :test
+      Onetime.boot!(:test, force: true)
 
       # Reset and rebuild registry with our test database connection
       require 'onetime/auth_config'

--- a/spec/support/postgres_mode_suite_database.rb
+++ b/spec/support/postgres_mode_suite_database.rb
@@ -113,10 +113,22 @@ module PostgresModeSuiteDatabase
       db = @database
       Auth::Database.define_singleton_method(:connection) { db }
 
-      # Ensure application is booted (idempotent in test mode)
+      # Boot the application with a forced fresh boot.
+      #
+      # `force: true` resets boot state first so the full initializer chain
+      # re-runs here. A plain `Onetime.boot! :test` is idempotent in test mode
+      # and silently skips when boot state is already :started — which happens
+      # whenever an earlier spec (e.g. spec/integration/all boot/config specs)
+      # booted first. The skip is mostly harmless, except it bypasses the
+      # ConfigureFamilia initializer that sets Familia's encryption keys and
+      # current_key_version. Those are process-global; if a prior connect_to_db:
+      # false boot left boot :started without running ConfigureFamilia, the
+      # encryption config is never populated and any encrypted-field write
+      # (e.g. Receipt.spawn_pair) raises "Key version cannot be nil".
+      # Forcing a fresh boot guarantees ConfigureFamilia runs for the suite.
       require 'onetime'
       require 'onetime/config'
-      Onetime.boot! :test
+      Onetime.boot!(:test, force: true)
 
       # Reset and rebuild registry with our test database connection
       require 'onetime/auth_config'


### PR DESCRIPTION
## Summary

#3256

Fixes an issue where the full-mode and postgres-mode suite database setup was skipping the `ConfigureFamilia` initializer, leaving encryption configuration unpopulated. This caused encrypted field writes (e.g., `Receipt.spawn_pair`) to fail with "Key version cannot be nil" when earlier specs had already booted the application.

The fix forces a fresh boot with `Onetime.boot!(:test, force: true)` in both suite setup files, ensuring the full initializer chain re-runs and `ConfigureFamilia` properly configures encryption keys and `current_key_version`.

## Changes

- Modified `spec/support/full_mode_suite_database.rb` to use `force: true` when booting
- Modified `spec/support/postgres_mode_suite_database.rb` to use `force: true` when booting
- Added regression guard tests in `spec/integration/full/infrastructure_spec.rb` to verify:
  - `Familia.config.current_key_version` is populated
  - Encryption keys are configured for the current version
  - `Receipt.spawn_pair` can successfully write encrypted fields

## Test Plan

The new regression guard tests in `infrastructure_spec.rb` verify that the encryption configuration is properly initialized. These tests will fail if the suite setup doesn't force a fresh boot, confirming the fix works as intended.

https://claude.ai/code/session_01SMjXRCWMDWohuypsFP3qfi