### PR TITLE
Implement targeted retry for membership re-materialization (ADR-012 Stage 3)

### DIFF
--- a/apps/web/billing/operations/apply_subscription_to_org.rb
+++ b/apps/web/billing/operations/apply_subscription_to_org.rb
@@ -136,7 +136,8 @@ module Billing
                 org_extid: org.extid,
                 planid: Billing::Metadata::FREE_PLAN_ID,
                 memberships_total: membership_result[:total],
-                memberships_failed: membership_result[:failed]
+                memberships_failed: membership_result[:failed],
+                memberships_failed_ids: membership_result[:failed_ids]
             end
           rescue StandardError => ex
             OT.le '[ApplySubscriptionToOrg] membership re-materialization failed (free tier)',
@@ -239,7 +240,8 @@ module Billing
               org_extid: org.extid,
               planid: planid,
               memberships_total: membership_result[:total],
-              memberships_failed: membership_result[:failed]
+              memberships_failed: membership_result[:failed],
+              memberships_failed_ids: membership_result[:failed_ids]
           end
         rescue StandardError => ex
           # Membership re-materialization is degradable — the fallback path in

--- a/apps/web/billing/operations/apply_subscription_to_org.rb
+++ b/apps/web/billing/operations/apply_subscription_to_org.rb
@@ -125,6 +125,19 @@ module Billing
                 failed: membership_result[:failed],
                 total: membership_result[:total],
               }
+
+            # Cross-path consistency with MaterializePlans#handle_cascade_partial:
+            # surface a partial cascade as :error so operators learn about drifted
+            # memberships at detection time. Observability only — do NOT propagate
+            # failure: the webhook returns 200 and the downgrade already applied;
+            # a non-200 would make Stripe re-process an already-applied change.
+            if membership_result[:failed].to_i.positive?
+              OT.le '[ApplySubscriptionToOrg] membership re-materialization had failures (free tier)',
+                org_extid: org.extid,
+                planid: Billing::Metadata::FREE_PLAN_ID,
+                memberships_total: membership_result[:total],
+                memberships_failed: membership_result[:failed]
+            end
           rescue StandardError => ex
             OT.le '[ApplySubscriptionToOrg] membership re-materialization failed (free tier)',
               exception: ex,
@@ -215,6 +228,19 @@ module Billing
               failed: membership_result[:failed],
               total: membership_result[:total],
             }
+
+          # Cross-path consistency with MaterializePlans#handle_cascade_partial:
+          # surface a partial cascade as :error so operators learn about drifted
+          # memberships at detection time. Observability only — do NOT propagate
+          # failure: the webhook returns 200 and the plan change already applied;
+          # a non-200 would make Stripe re-process an already-applied change.
+          if membership_result[:failed].to_i.positive?
+            OT.le '[ApplySubscriptionToOrg] membership re-materialization had failures',
+              org_extid: org.extid,
+              planid: planid,
+              memberships_total: membership_result[:total],
+              memberships_failed: membership_result[:failed]
+          end
         rescue StandardError => ex
           # Membership re-materialization is degradable — the fallback path in
           # membership.entitlements computes on-the-fly. Log and continue.

--- a/apps/web/billing/spec/operations/apply_subscription_to_org_spec.rb
+++ b/apps/web/billing/spec/operations/apply_subscription_to_org_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Billing::Operations::ApplySubscriptionToOrg, billing: true do
       materialize_entitlements_from_plan: true,
       materialize_entitlements_from_config: true,
       materialized_entitlements: materialized_set,
-      rematerialize_all_memberships!: { success: 0, failed: 0, total: 0 },
+      rematerialize_all_memberships!: { success: 0, failed: 0, total: 0, failed_ids: [] },
       save: true,
     )
   end
@@ -265,6 +265,64 @@ RSpec.describe Billing::Operations::ApplySubscriptionToOrg, billing: true do
     end
   end
 
+  # Membership cascade escalation, exercised through the public .call API
+  # (owner plan-change path) rather than reaching into the private
+  # execute_materialize. build_subscription resolves to identity_plus_v1, which
+  # materialize_entitlements_for_org then re-materializes onto the members.
+  describe 'membership cascade via .call (plan-change path)' do
+    context 'when the cascade reports partial failures' do
+      it 'escalates to OT.le with planid, counts, and failed member ids' do
+        subscription = build_subscription
+        allow(org).to receive(:rematerialize_all_memberships!)
+          .and_return({ success: 1, failed: 2, total: 3, failed_ids: %w[mem_a mem_b] })
+        allow(OT).to receive(:info)
+
+        expect(OT).to receive(:le).with(
+          '[ApplySubscriptionToOrg] membership re-materialization had failures',
+          hash_including(
+            org_extid: 'on_test_org',
+            planid: 'identity_plus_v1',
+            memberships_total: 3,
+            memberships_failed: 2,
+            memberships_failed_ids: %w[mem_a mem_b],
+          ),
+        )
+
+        described_class.call(org, subscription, owner: true)
+      end
+    end
+
+    context 'when the cascade raises' do
+      it 'logs the error via OT.le, does not propagate, and still saves the org' do
+        subscription = build_subscription
+        allow(org).to receive(:rematerialize_all_memberships!)
+          .and_raise(StandardError.new('boom'))
+        allow(OT).to receive(:info)
+
+        expect(OT).to receive(:le).with(
+          '[ApplySubscriptionToOrg] membership re-materialization failed',
+          hash_including(org_extid: 'on_test_org', exception: kind_of(StandardError)),
+        )
+        expect(org).to receive(:save)
+
+        expect {
+          described_class.call(org, subscription, owner: true)
+        }.not_to raise_error
+      end
+    end
+
+    context 'when the cascade reports no failures' do
+      it 'does not escalate to OT.le' do
+        subscription = build_subscription
+        allow(OT).to receive(:info)
+
+        expect(OT).not_to receive(:le)
+
+        described_class.call(org, subscription, owner: true)
+      end
+    end
+  end
+
   describe 'planid_override' do
     it 'uses override instead of catalog resolution' do
       subscription = build_subscription(price_id: 'price_unknown')
@@ -491,7 +549,7 @@ RSpec.describe Billing::Operations::ApplySubscriptionToOrg, billing: true do
         extid: 'on_cancel_org',
         materialize_entitlements_from_config: true,
         materialized_entitlements: materialized_set,
-        rematerialize_all_memberships!: { success: 0, failed: 0, total: 0 },
+        rematerialize_all_memberships!: { success: 0, failed: 0, total: 0, failed_ids: [] },
         save: true,
       )
     end
@@ -536,11 +594,11 @@ RSpec.describe Billing::Operations::ApplySubscriptionToOrg, billing: true do
         before do
           allow(free_tier_org).to receive(:materialize_entitlements_from_config)
           allow(free_tier_org).to receive(:rematerialize_all_memberships!)
-            .and_return({ success: 1, failed: 2, total: 3 })
+            .and_return({ success: 1, failed: 2, total: 3, failed_ids: %w[mem_x mem_y] })
           allow(OT).to receive(:info)
         end
 
-        it 'escalates to OT.le with org_extid, FREE_PLAN_ID, and counts' do
+        it 'escalates to OT.le with org_extid, FREE_PLAN_ID, counts, and failed ids' do
           expect(OT).to receive(:le).with(
             '[ApplySubscriptionToOrg] membership re-materialization had failures (free tier)',
             hash_including(
@@ -548,6 +606,7 @@ RSpec.describe Billing::Operations::ApplySubscriptionToOrg, billing: true do
               planid: Billing::Metadata::FREE_PLAN_ID,
               memberships_total: 3,
               memberships_failed: 2,
+              memberships_failed_ids: %w[mem_x mem_y],
             ),
           )
 
@@ -639,7 +698,7 @@ RSpec.describe Billing::Operations::ApplySubscriptionToOrg, billing: true do
         materialize_entitlements_from_plan: true,
         materialize_entitlements_from_config: true,
         materialized_entitlements: materialized_set,
-        rematerialize_all_memberships!: { success: 0, failed: 0, total: 0 },
+        rematerialize_all_memberships!: { success: 0, failed: 0, total: 0, failed_ids: [] },
       )
     end
 
@@ -772,57 +831,6 @@ RSpec.describe Billing::Operations::ApplySubscriptionToOrg, billing: true do
           hash_including(source: 'config'),
         )
       end
-
-      context 'when the membership cascade has partial failures' do
-        before do
-          allow(fresh_org).to receive(:materialize_entitlements_from_plan)
-          allow(fresh_org).to receive(:rematerialize_all_memberships!)
-            .and_return({ success: 1, failed: 2, total: 3 })
-          allow(OT).to receive(:info)
-        end
-
-        it 'escalates to OT.le with org_extid, planid, and counts' do
-          expect(OT).to receive(:le).with(
-            '[ApplySubscriptionToOrg] membership re-materialization had failures',
-            hash_including(
-              org_extid: 'on_helper_org',
-              planid: 'identity_plus_v1',
-              memberships_total: 3,
-              memberships_failed: 2,
-            ),
-          )
-
-          described_class.send(:execute_materialize, fresh_org, plan, :cache)
-        end
-      end
-
-      context 'when the membership cascade raises' do
-        before do
-          allow(fresh_org).to receive(:materialize_entitlements_from_plan)
-          allow(fresh_org).to receive(:rematerialize_all_memberships!)
-            .and_raise(StandardError.new('boom'))
-          allow(OT).to receive(:info)
-        end
-
-        it 'logs the raised error via OT.le and does not propagate' do
-          expect(OT).to receive(:le).with(
-            '[ApplySubscriptionToOrg] membership re-materialization failed',
-            hash_including(org_extid: 'on_helper_org', exception: kind_of(StandardError)),
-          )
-
-          expect {
-            described_class.send(:execute_materialize, fresh_org, plan, :cache)
-          }.not_to raise_error
-        end
-
-        it 'still returns a :materialized result' do
-          allow(OT).to receive(:le)
-
-          result = described_class.send(:execute_materialize, fresh_org, plan, :cache)
-
-          expect(result.status).to eq(:materialized)
-        end
-      end
     end
 
     # ------------------------------------------------------------------------
@@ -952,7 +960,7 @@ RSpec.describe Billing::Operations::ApplySubscriptionToOrg, billing: true do
         materialize_entitlements_from_plan: true,
         materialize_entitlements_from_config: true,
         materialized_entitlements: materialized_set,
-        rematerialize_all_memberships!: { success: 0, failed: 0, total: 0 },
+        rematerialize_all_memberships!: { success: 0, failed: 0, total: 0, failed_ids: [] },
       )
     end
 

--- a/apps/web/billing/spec/operations/apply_subscription_to_org_spec.rb
+++ b/apps/web/billing/spec/operations/apply_subscription_to_org_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Billing::Operations::ApplySubscriptionToOrg, billing: true do
       materialize_entitlements_from_plan: true,
       materialize_entitlements_from_config: true,
       materialized_entitlements: materialized_set,
-      rematerialize_all_memberships!: { success: 0, skipped: 0 },
+      rematerialize_all_memberships!: { success: 0, failed: 0, total: 0 },
       save: true,
     )
   end
@@ -491,7 +491,7 @@ RSpec.describe Billing::Operations::ApplySubscriptionToOrg, billing: true do
         extid: 'on_cancel_org',
         materialize_entitlements_from_config: true,
         materialized_entitlements: materialized_set,
-        rematerialize_all_memberships!: { success: 0, skipped: 0 },
+        rematerialize_all_memberships!: { success: 0, failed: 0, total: 0 },
         save: true,
       )
     end
@@ -530,6 +530,42 @@ RSpec.describe Billing::Operations::ApplySubscriptionToOrg, billing: true do
             entitlements_count: 4,
           ),
         )
+      end
+
+      context 'when the membership cascade has partial failures' do
+        before do
+          allow(free_tier_org).to receive(:materialize_entitlements_from_config)
+          allow(free_tier_org).to receive(:rematerialize_all_memberships!)
+            .and_return({ success: 1, failed: 2, total: 3 })
+          allow(OT).to receive(:info)
+        end
+
+        it 'escalates to OT.le with org_extid, FREE_PLAN_ID, and counts' do
+          expect(OT).to receive(:le).with(
+            '[ApplySubscriptionToOrg] membership re-materialization had failures (free tier)',
+            hash_including(
+              org_extid: 'on_cancel_org',
+              planid: Billing::Metadata::FREE_PLAN_ID,
+              memberships_total: 3,
+              memberships_failed: 2,
+            ),
+          )
+
+          described_class.apply_free_tier(free_tier_org, owner: true)
+        end
+      end
+
+      context 'when the membership cascade has no failures' do
+        before do
+          allow(free_tier_org).to receive(:materialize_entitlements_from_config)
+          allow(OT).to receive(:info)
+        end
+
+        it 'does NOT escalate to OT.le' do
+          expect(OT).not_to receive(:le)
+
+          described_class.apply_free_tier(free_tier_org, owner: true)
+        end
       end
     end
 
@@ -603,7 +639,7 @@ RSpec.describe Billing::Operations::ApplySubscriptionToOrg, billing: true do
         materialize_entitlements_from_plan: true,
         materialize_entitlements_from_config: true,
         materialized_entitlements: materialized_set,
-        rematerialize_all_memberships!: { success: 0, skipped: 0 },
+        rematerialize_all_memberships!: { success: 0, failed: 0, total: 0 },
       )
     end
 
@@ -736,6 +772,57 @@ RSpec.describe Billing::Operations::ApplySubscriptionToOrg, billing: true do
           hash_including(source: 'config'),
         )
       end
+
+      context 'when the membership cascade has partial failures' do
+        before do
+          allow(fresh_org).to receive(:materialize_entitlements_from_plan)
+          allow(fresh_org).to receive(:rematerialize_all_memberships!)
+            .and_return({ success: 1, failed: 2, total: 3 })
+          allow(OT).to receive(:info)
+        end
+
+        it 'escalates to OT.le with org_extid, planid, and counts' do
+          expect(OT).to receive(:le).with(
+            '[ApplySubscriptionToOrg] membership re-materialization had failures',
+            hash_including(
+              org_extid: 'on_helper_org',
+              planid: 'identity_plus_v1',
+              memberships_total: 3,
+              memberships_failed: 2,
+            ),
+          )
+
+          described_class.send(:execute_materialize, fresh_org, plan, :cache)
+        end
+      end
+
+      context 'when the membership cascade raises' do
+        before do
+          allow(fresh_org).to receive(:materialize_entitlements_from_plan)
+          allow(fresh_org).to receive(:rematerialize_all_memberships!)
+            .and_raise(StandardError.new('boom'))
+          allow(OT).to receive(:info)
+        end
+
+        it 'logs the raised error via OT.le and does not propagate' do
+          expect(OT).to receive(:le).with(
+            '[ApplySubscriptionToOrg] membership re-materialization failed',
+            hash_including(org_extid: 'on_helper_org', exception: kind_of(StandardError)),
+          )
+
+          expect {
+            described_class.send(:execute_materialize, fresh_org, plan, :cache)
+          }.not_to raise_error
+        end
+
+        it 'still returns a :materialized result' do
+          allow(OT).to receive(:le)
+
+          result = described_class.send(:execute_materialize, fresh_org, plan, :cache)
+
+          expect(result.status).to eq(:materialized)
+        end
+      end
     end
 
     # ------------------------------------------------------------------------
@@ -865,7 +952,7 @@ RSpec.describe Billing::Operations::ApplySubscriptionToOrg, billing: true do
         materialize_entitlements_from_plan: true,
         materialize_entitlements_from_config: true,
         materialized_entitlements: materialized_set,
-        rematerialize_all_memberships!: { success: 0, skipped: 0 },
+        rematerialize_all_memberships!: { success: 0, failed: 0, total: 0 },
       )
     end
 

--- a/lib/onetime/models/organization.rb
+++ b/lib/onetime/models/organization.rb
@@ -269,29 +269,64 @@ module Onetime
     # to propagate the new entitlement set to all memberships. Each membership's
     # effective entitlements are: org.entitlements ∩ ROLE_ENTITLEMENTS[role].
     #
+    # Failures are retried once, targeting only the memberships that failed.
+    # materialize_for_role! is idempotent, so a targeted retry repairs transient
+    # errors (e.g. a Redis blip) without the cost of re-materializing every
+    # member — important at scale (200k+ orgs). Memberships still failing after
+    # the retry are returned in :failed_ids for operator follow-up.
+    #
     # At current scale (orgs are low hundreds of members), this is acceptable
     # inline or in a background job. If org sizes grow to thousands, consider
     # batching or Redis pipelining.
     #
-    # @return [Hash] { success: count, failed: count, total: count }
+    # @return [Hash] { success:, failed:, total:, failed_ids: } — failed_ids
+    #   lists the objids of memberships that failed even after the retry.
     def rematerialize_all_memberships!
       memberships = OrganizationMembership.active_for_org(self)
-      result      = { success: 0, failed: 0, total: memberships.size }
+      total       = memberships.size
 
-      memberships.each do |membership|
-        membership.materialize_for_role!(self)
-        result[:success] += 1
-      rescue StandardError => ex
-        OT.le '[rematerialize_all_memberships!] failed for membership',
-          exception: ex,
-          membership_objid: membership.objid,
-          org_extid: extid
-        result[:failed] += 1
+      # First pass over all active memberships; collect the ones that raised.
+      failed = memberships.reject { |membership| materialize_membership_for_role(membership) }
+
+      # Targeted retry: re-attempt only the failures. The operation is idempotent,
+      # so retrying just the failed set (rather than every member) repairs
+      # transient errors cheaply — re-doing all members would be wasteful at scale.
+      if failed.any?
+        failed = failed.reject { |membership| materialize_membership_for_role(membership, retry_attempt: true) }
       end
 
-      OT.info "[rematerialize_all_memberships!] org=#{extid} success=#{result[:success]} failed=#{result[:failed]}"
+      result = {
+        success:    total - failed.size,
+        failed:     failed.size,
+        total:      total,
+        failed_ids: failed.map(&:objid),
+      }
+
+      OT.info "[rematerialize_all_memberships!] org=#{extid} " \
+        "success=#{result[:success]} failed=#{result[:failed]} total=#{result[:total]}"
       result
     end
+
+    # Materialize a single membership's role entitlements, isolating failures.
+    #
+    # Extracted so the initial pass and the targeted retry in
+    # rematerialize_all_memberships! share identical error handling.
+    #
+    # @param membership [OrganizationMembership]
+    # @param retry_attempt [Boolean] true when invoked from the retry pass (for logs)
+    # @return [Boolean] true on success, false if the attempt raised (logged)
+    def materialize_membership_for_role(membership, retry_attempt: false)
+      membership.materialize_for_role!(self)
+      true
+    rescue StandardError => ex
+      OT.le '[rematerialize_all_memberships!] failed for membership',
+        exception: ex,
+        membership_objid: membership.objid,
+        org_extid: extid,
+        retry_attempt: retry_attempt
+      false
+    end
+    private :materialize_membership_for_role
 
     # Low-level delete with index cleanup
     #

--- a/lib/onetime/models/organization/chores/materialize_standalone_entitlements.rb
+++ b/lib/onetime/models/organization/chores/materialize_standalone_entitlements.rb
@@ -75,7 +75,8 @@ Onetime::Organization.chore :materialize_standalone_entitlements do |org|
         chore: :materialize_standalone_entitlements,
         org_extid: org.extid,
         memberships_total: cascade[:total],
-        memberships_failed: cascade[:failed]
+        memberships_failed: cascade[:failed],
+        memberships_failed_ids: cascade[:failed_ids]
     end
   rescue StandardError => ex
     logger.error 'Membership re-materialization raised',

--- a/lib/onetime/models/organization/chores/materialize_standalone_entitlements.rb
+++ b/lib/onetime/models/organization/chores/materialize_standalone_entitlements.rb
@@ -63,7 +63,26 @@ Onetime::Organization.chore :materialize_standalone_entitlements do |org|
 
   # Cascade to memberships so they're consistent with the org's new entitlements.
   # Without this, memberships remain stale and the runtime fallback can't be removed.
-  org.rematerialize_all_memberships!
+  begin
+    cascade = org.rematerialize_all_memberships!
+
+    # Cross-path consistency with MaterializePlans#handle_cascade_partial: surface a
+    # partial cascade as :error so operators learn about drifted memberships.
+    # Observability only — do NOT abort the chore or fail the org: there is no
+    # results aggregator here, and the org itself was materialized successfully.
+    if cascade[:failed].to_i.positive?
+      logger.error 'Membership re-materialization had failures',
+        chore: :materialize_standalone_entitlements,
+        org_extid: org.extid,
+        memberships_total: cascade[:total],
+        memberships_failed: cascade[:failed]
+    end
+  rescue StandardError => ex
+    logger.error 'Membership re-materialization raised',
+      chore: :materialize_standalone_entitlements,
+      org_extid: org.extid,
+      exception: ex
+  end
 
   entitlement_count = org.materialized_entitlements.size
 

--- a/spec/unit/billing/operations/apply_subscription_to_org_spec.rb
+++ b/spec/unit/billing/operations/apply_subscription_to_org_spec.rb
@@ -155,4 +155,34 @@ RSpec.describe 'Billing::Operations::ApplySubscriptionToOrg.apply_free_tier', bi
       expect(result).to be false
     end
   end
+
+  describe 'membership cascade failure logging' do
+    before { allow(org).to receive(:save).and_return(true) }
+
+    context 'when the cascade reports failures' do
+      let(:rematerialize_result) { { success: 0, failed: 1, total: 1 } }
+
+      it 'escalates to OT.le with FREE_PLAN_ID and counts' do
+        expect(OT).to receive(:le).with(
+          '[ApplySubscriptionToOrg] membership re-materialization had failures (free tier)',
+          hash_including(
+            org_extid: 'on_test123',
+            planid: Billing::Metadata::FREE_PLAN_ID,
+            memberships_total: 1,
+            memberships_failed: 1,
+          ),
+        )
+
+        operation.apply_free_tier(org, owner: true)
+      end
+    end
+
+    context 'when the cascade reports no failures' do
+      it 'does NOT escalate to OT.le' do
+        expect(OT).not_to receive(:le)
+
+        operation.apply_free_tier(org, owner: true)
+      end
+    end
+  end
 end

--- a/spec/unit/billing/operations/apply_subscription_to_org_spec.rb
+++ b/spec/unit/billing/operations/apply_subscription_to_org_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe 'Billing::Operations::ApplySubscriptionToOrg.apply_free_tier', bi
 
   # Mock rematerialize result for membership cascade
   let(:rematerialize_result) do
-    { success: 2, failed: 0, total: 2 }
+    { success: 2, failed: 0, total: 2, failed_ids: [] }
   end
 
   # Org double with writable attributes and materialization support
@@ -160,9 +160,9 @@ RSpec.describe 'Billing::Operations::ApplySubscriptionToOrg.apply_free_tier', bi
     before { allow(org).to receive(:save).and_return(true) }
 
     context 'when the cascade reports failures' do
-      let(:rematerialize_result) { { success: 0, failed: 1, total: 1 } }
+      let(:rematerialize_result) { { success: 0, failed: 1, total: 1, failed_ids: ['mem_z'] } }
 
-      it 'escalates to OT.le with FREE_PLAN_ID and counts' do
+      it 'escalates to OT.le with FREE_PLAN_ID, counts, and failed ids' do
         expect(OT).to receive(:le).with(
           '[ApplySubscriptionToOrg] membership re-materialization had failures (free tier)',
           hash_including(
@@ -170,6 +170,7 @@ RSpec.describe 'Billing::Operations::ApplySubscriptionToOrg.apply_free_tier', bi
             planid: Billing::Metadata::FREE_PLAN_ID,
             memberships_total: 1,
             memberships_failed: 1,
+            memberships_failed_ids: ['mem_z'],
           ),
         )
 

--- a/spec/unit/onetime/models/organization/chores/materialize_standalone_entitlements_spec.rb
+++ b/spec/unit/onetime/models/organization/chores/materialize_standalone_entitlements_spec.rb
@@ -29,8 +29,12 @@ RSpec.describe 'Organization chore: materialize_standalone_entitlements' do
     double('SemanticLogger').tap do |logger|
       allow(logger).to receive(:info) { |_msg, _payload = {}| nil }
       allow(logger).to receive(:warn) { |_msg, _payload = {}| nil }
+      allow(logger).to receive(:error) { |_msg, _payload = {}| nil }
     end
   end
+
+  # Default happy-path cascade result. Branch 3 reads `:failed`/`:total`.
+  let(:cascade_result) { { success: 15, failed: 0, total: 15 } }
 
   # Materialized set stub — chore only reads `.size`
   let(:materialized_set) { double('Set', size: 15) }
@@ -49,7 +53,7 @@ RSpec.describe 'Organization chore: materialize_standalone_entitlements' do
       materialized_entitlements: materialized_set,
     )
     allow(obj).to receive(:materialize_standalone_entitlements!).and_return(true)
-    allow(obj).to receive(:rematerialize_all_memberships!)
+    allow(obj).to receive(:rematerialize_all_memberships!).and_return(cascade_result)
     obj
   end
 
@@ -143,7 +147,7 @@ RSpec.describe 'Organization chore: materialize_standalone_entitlements' do
     end
 
     it 'calls rematerialize_all_memberships! to cascade to members' do
-      expect(org).to receive(:rematerialize_all_memberships!)
+      expect(org).to receive(:rematerialize_all_memberships!).and_return(cascade_result)
       chore.call(org)
     end
 
@@ -168,5 +172,57 @@ RSpec.describe 'Organization chore: materialize_standalone_entitlements' do
       chore.call(org)
     end
 
+    it 'does not log at :error when the cascade has no failures' do
+      expect(mock_logger).not_to receive(:error)
+      chore.call(org)
+    end
+
+    context 'when the membership cascade has partial failures' do
+      let(:cascade_result) { { success: 1, failed: 2, total: 3 } }
+
+      it 'logs the partial failure at :error with org extid and counts' do
+        expect(mock_logger).to receive(:error).with(
+          'Membership re-materialization had failures',
+          hash_including(
+            chore: :materialize_standalone_entitlements,
+            org_extid: 'org_test123',
+            memberships_total: 3,
+            memberships_failed: 2,
+          ),
+        )
+        chore.call(org)
+      end
+
+      it 'still logs the materialization at :info and returns true' do
+        expect(mock_logger).to receive(:info).with(
+          'Materialized standalone entitlements',
+          hash_including(chore: :materialize_standalone_entitlements),
+        )
+        expect(chore.call(org)).to be true
+      end
+    end
+
+    context 'when the membership cascade raises' do
+      before do
+        allow(org).to receive(:rematerialize_all_memberships!)
+          .and_raise(StandardError.new('boom'))
+      end
+
+      it 'logs the raised error and does not propagate' do
+        expect(mock_logger).to receive(:error).with(
+          'Membership re-materialization raised',
+          hash_including(
+            chore: :materialize_standalone_entitlements,
+            org_extid: 'org_test123',
+            exception: kind_of(StandardError),
+          ),
+        )
+        expect { chore.call(org) }.not_to raise_error
+      end
+
+      it 'still completes the chore and returns true' do
+        expect(chore.call(org)).to be true
+      end
+    end
   end
 end

--- a/spec/unit/onetime/models/organization/chores/materialize_standalone_entitlements_spec.rb
+++ b/spec/unit/onetime/models/organization/chores/materialize_standalone_entitlements_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe 'Organization chore: materialize_standalone_entitlements' do
   end
 
   # Default happy-path cascade result. Branch 3 reads `:failed`/`:total`.
-  let(:cascade_result) { { success: 15, failed: 0, total: 15 } }
+  let(:cascade_result) { { success: 15, failed: 0, total: 15, failed_ids: [] } }
 
   # Materialized set stub — chore only reads `.size`
   let(:materialized_set) { double('Set', size: 15) }
@@ -178,9 +178,9 @@ RSpec.describe 'Organization chore: materialize_standalone_entitlements' do
     end
 
     context 'when the membership cascade has partial failures' do
-      let(:cascade_result) { { success: 1, failed: 2, total: 3 } }
+      let(:cascade_result) { { success: 1, failed: 2, total: 3, failed_ids: %w[mem_p mem_q] } }
 
-      it 'logs the partial failure at :error with org extid and counts' do
+      it 'logs the partial failure at :error with org extid, counts, and failed ids' do
         expect(mock_logger).to receive(:error).with(
           'Membership re-materialization had failures',
           hash_including(
@@ -188,6 +188,7 @@ RSpec.describe 'Organization chore: materialize_standalone_entitlements' do
             org_extid: 'org_test123',
             memberships_total: 3,
             memberships_failed: 2,
+            memberships_failed_ids: %w[mem_p mem_q],
           ),
         )
         chore.call(org)

--- a/spec/unit/onetime/models/organization/rematerialize_all_memberships_spec.rb
+++ b/spec/unit/onetime/models/organization/rematerialize_all_memberships_spec.rb
@@ -1,0 +1,155 @@
+# spec/unit/onetime/models/organization/rematerialize_all_memberships_spec.rb
+#
+# frozen_string_literal: true
+
+# Unit tests for Organization#rematerialize_all_memberships! — specifically the
+# targeted single-retry behavior (ADR-012 Stage 3).
+#
+# Strategy: use a real Organization instance (so the method under test runs for
+# real) but stub its collaborators — OrganizationMembership.active_for_org and
+# the per-membership materialize_for_role! — so no Redis is required.
+#
+# Run: pnpm run test:rspec spec/unit/onetime/models/organization/rematerialize_all_memberships_spec.rb
+
+require 'spec_helper'
+
+RSpec.describe 'Onetime::Organization#rematerialize_all_memberships!' do
+  let(:org) do
+    Onetime::Organization.new.tap do |o|
+      allow(o).to receive(:extid).and_return('org_test')
+    end
+  end
+
+  # Build a membership double. `behavior` is a callable invoked on each
+  # materialize_for_role! attempt; it returns true or raises.
+  def membership(objid, &behavior)
+    double(objid).tap do |m|
+      allow(m).to receive(:objid).and_return(objid)
+      allow(m).to receive(:materialize_for_role!, &behavior)
+    end
+  end
+
+  def stub_memberships(list)
+    allow(Onetime::OrganizationMembership).to receive(:active_for_org)
+      .with(org)
+      .and_return(list)
+  end
+
+  before do
+    allow(OT).to receive(:info)
+    allow(OT).to receive(:le)
+  end
+
+  context 'when every membership succeeds on the first pass' do
+    let(:m1) { membership('mem_1') { true } }
+    let(:m2) { membership('mem_2') { true } }
+
+    before { stub_memberships([m1, m2]) }
+
+    it 'reports all successful with empty failed_ids' do
+      expect(org.rematerialize_all_memberships!).to eq(
+        success: 2, failed: 0, total: 2, failed_ids: []
+      )
+    end
+
+    it 'attempts each membership exactly once (no retry pass)' do
+      expect(m1).to receive(:materialize_for_role!).once.and_return(true)
+      expect(m2).to receive(:materialize_for_role!).once.and_return(true)
+
+      org.rematerialize_all_memberships!
+    end
+
+    it 'does not log any error' do
+      expect(OT).not_to receive(:le)
+      org.rematerialize_all_memberships!
+    end
+  end
+
+  context 'when a membership fails the first pass but succeeds on retry' do
+    let(:attempts) { { count: 0 } }
+    let(:flaky) do
+      membership('mem_flaky') do
+        attempts[:count] += 1
+        raise StandardError, 'transient' if attempts[:count] == 1
+
+        true
+      end
+    end
+    let(:steady) { membership('mem_steady') { true } }
+
+    before { stub_memberships([flaky, steady]) }
+
+    it 'repairs the failure and reports zero failures' do
+      expect(org.rematerialize_all_memberships!).to eq(
+        success: 2, failed: 0, total: 2, failed_ids: []
+      )
+    end
+
+    it 'attempts the flaky membership twice and the steady one once' do
+      org.rematerialize_all_memberships!
+
+      expect(attempts[:count]).to eq(2)
+    end
+
+    it 'logs the first-pass failure (but not a final error)' do
+      org.rematerialize_all_memberships!
+
+      expect(OT).to have_received(:le).with(
+        '[rematerialize_all_memberships!] failed for membership',
+        hash_including(membership_objid: 'mem_flaky', org_extid: 'org_test', retry_attempt: false)
+      ).once
+    end
+  end
+
+  context 'when a membership fails both the first pass and the retry' do
+    let(:fail_attempts) { { count: 0 } }
+    let(:broken) do
+      membership('mem_broken') do
+        fail_attempts[:count] += 1
+        raise StandardError, 'permanent'
+      end
+    end
+    let(:ok) { membership('mem_ok') { true } }
+
+    before { stub_memberships([broken, ok]) }
+
+    it 'reports the failure and lists it in failed_ids' do
+      expect(org.rematerialize_all_memberships!).to eq(
+        success: 1, failed: 1, total: 2, failed_ids: ['mem_broken']
+      )
+    end
+
+    it 'retries only the broken membership (the ok one is attempted once)' do
+      expect(ok).to receive(:materialize_for_role!).once.and_return(true)
+
+      org.rematerialize_all_memberships!
+
+      expect(fail_attempts[:count]).to eq(2) # first pass + targeted retry
+    end
+
+    it 'logs both the first-pass and the retry failure with retry_attempt flags' do
+      org.rematerialize_all_memberships!
+
+      expect(OT).to have_received(:le).with(
+        '[rematerialize_all_memberships!] failed for membership',
+        hash_including(membership_objid: 'mem_broken', retry_attempt: false)
+      ).once
+      expect(OT).to have_received(:le).with(
+        '[rematerialize_all_memberships!] failed for membership',
+        hash_including(membership_objid: 'mem_broken', retry_attempt: true)
+      ).once
+    end
+  end
+
+  context 'when there are no active memberships' do
+    before { stub_memberships([]) }
+
+    it 'returns zeroed counts and an empty failed_ids without logging errors' do
+      expect(OT).not_to receive(:le)
+
+      expect(org.rematerialize_all_memberships!).to eq(
+        success: 0, failed: 0, total: 0, failed_ids: []
+      )
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Implements a targeted single-retry strategy for `Organization#rematerialize_all_memberships!` to handle transient failures gracefully without the cost of re-materializing all members at scale.

### Changes

**Core Logic (`lib/onetime/models/organization.rb`)**
- Refactored `rematerialize_all_memberships!` to perform a two-pass approach:
  - First pass: attempt to materialize all active memberships, collecting failures
  - Targeted retry: re-attempt only the memberships that failed (idempotent operation)
- Extracted `materialize_membership_for_role` helper to isolate error handling and ensure consistent logging across both passes
- Updated return value from `{ success:, failed: }` to `{ success:, failed:, total:, failed_ids: }` to surface which memberships remain broken after retry
- Added `retry_attempt` flag to error logs to distinguish first-pass from retry failures

**Error Handling & Observability**
- `ApplySubscriptionToOrg` now logs partial cascade failures via `OT.le` with plan ID, counts, and failed member IDs (both plan-change and free-tier paths)
- `MaterializeStandaloneEntitlements` chore now catches and logs cascade failures at `:error` level without aborting the chore
- All cascade failures are non-fatal: the org is saved and the operation completes (observability-only)

**Tests**
- Added comprehensive unit tests for `rematerialize_all_memberships!` covering:
  - All-success scenario (no retry needed)
  - Transient failure (succeeds on retry)
  - Permanent failure (fails both passes)
  - Empty membership list
- Updated existing test stubs to expect the new return signature
- Added integration tests for cascade failure logging in both `ApplySubscriptionToOrg` and `MaterializeStandaloneEntitlements`

### Rationale

At current scale (200k+ orgs with hundreds of members each), a full re-materialization on any transient error is wasteful. The targeted retry repairs Redis blips and similar transient issues cheaply while still surfacing permanent failures for operator follow-up. The idempotent nature of `materialize_for_role!` makes this safe.

## Related Issues

<!-- Keywords that auto-close issues when merged: Fixes, Closes, Resolves -->

## Test Plan

- New unit tests for `rematerialize_all_memberships!` cover all retry scenarios
- Existing tests updated to expect new return signature
- Integration tests verify cascade failure logging in both subscription and chore paths
- CI passes with all tests

https://claude.ai/code/session_016JdL6Qp2YbA5ToZXL2DziW