### PR TITLE
Add billing catalog sync command and extract progress renderer

### DIFF
--- a/apps/web/billing/cli/billing_command.rb
+++ b/apps/web/billing/cli/billing_command.rb
@@ -69,6 +69,7 @@ module Onetime
 
           Catalog & Sync:
             bin/ots billing catalog            Manage plan catalog
+            bin/ots billing catalog sync       Full sync: push + pull + materialize
             bin/ots billing catalog validate   Validate catalog YAML and Stripe consistency
             bin/ots billing catalog generate-docs  Generate catalog documentation
             bin/ots billing sync               Full sync from Stripe to Redis

--- a/apps/web/billing/cli/catalog_command.rb
+++ b/apps/web/billing/cli/catalog_command.rb
@@ -18,6 +18,7 @@ module Onetime
           synchronization with Stripe, and documentation generation.
 
           Available subcommands:
+            sync          - Full sync: push + pull + materialize (all three steps)
             push          - Push catalog to Stripe (create/update products)
             pull          - Pull from Stripe to Redis cache
             validate      - Validate catalog YAML structure and Stripe consistency
@@ -25,6 +26,8 @@ module Onetime
 
           Examples:
             bin/ots billing catalog                    # Show this help
+            bin/ots billing catalog sync --dry-run    # Preview full catalog sync
+            bin/ots billing catalog sync --force      # Full sync without prompts
             bin/ots billing catalog push --dry-run    # Preview changes to Stripe
             bin/ots billing catalog push              # Push catalog to Stripe
             bin/ots billing catalog pull              # Sync Stripe to Redis

--- a/apps/web/billing/cli/catalog_pull_command.rb
+++ b/apps/web/billing/cli/catalog_pull_command.rb
@@ -43,7 +43,7 @@ module Onetime
       private
 
       def show_progress(message)
-        print "\r#{message}"
+        print "\r#{message}\e[K"
         $stdout.flush
       end
     end

--- a/apps/web/billing/cli/catalog_sync_command.rb
+++ b/apps/web/billing/cli/catalog_sync_command.rb
@@ -189,12 +189,10 @@ module Onetime
                                                 dry_run: dry_run,
                                                 include_memberships: include_memberships)
 
-        filter_args = plan ? { plan_filter: plan } : {}
-
         result = ::Billing::Operations::MaterializePlans.call(
+          plan_filter: plan,
           include_memberships: include_memberships,
           dry_run: dry_run,
-          **filter_args,
         ) { |event| renderer.render(event) }
 
         puts

--- a/apps/web/billing/cli/catalog_sync_command.rb
+++ b/apps/web/billing/cli/catalog_sync_command.rb
@@ -243,7 +243,7 @@ module Onetime
       end
 
       def show_pull_progress(message)
-        print "\r  #{message}"
+        print "\r  #{message}\e[K"
         $stdout.flush
       end
 

--- a/apps/web/billing/cli/catalog_sync_command.rb
+++ b/apps/web/billing/cli/catalog_sync_command.rb
@@ -1,0 +1,300 @@
+# apps/web/billing/cli/catalog_sync_command.rb
+#
+# frozen_string_literal: true
+
+require_relative 'helpers'
+require_relative '../operations/catalog/push'
+require_relative '../operations/catalog/pull'
+require_relative '../operations/materialize_plans'
+
+module Onetime
+  module CLI
+    # Full catalog sync: push to Stripe, pull to Redis, materialize entitlements
+    #
+    # Composes three operations in sequence:
+    #   1. catalog push  — sync YAML catalog to Stripe
+    #   2. catalog pull  — pull Stripe products/prices into Redis cache
+    #   3. plans materialize — materialize entitlements on organizations
+    #
+    # Aborts on first failure so downstream steps never run against stale data.
+    #
+    class BillingCatalogSyncCommand < Command
+      include BillingHelpers
+
+      desc 'Full catalog sync: push to Stripe, pull to cache, materialize plans'
+
+      option :dry_run,
+        type: :boolean,
+        default: false,
+        desc: 'Preview all steps without making changes'
+
+      option :force,
+        type: :boolean,
+        default: false,
+        desc: 'Skip confirmation prompts'
+
+      option :plan,
+        type: :string,
+        desc: 'Limit to a specific plan (e.g., identity_plus_v1)'
+
+      option :skip_prices,
+        type: :boolean,
+        default: false,
+        desc: 'Skip price creation during push'
+
+      option :include_memberships,
+        type: :boolean,
+        default: false,
+        desc: 'Cascade materialization to active memberships'
+
+      option :verbose,
+        type: :boolean,
+        default: false,
+        aliases: ['v'],
+        desc: 'Show per-membership detail during materialization'
+
+      option :quiet,
+        type: :boolean,
+        default: false,
+        aliases: ['q'],
+        desc: 'Suppress per-org progress during materialization'
+
+      def call(dry_run: false, force: false, plan: nil, skip_prices: false, include_memberships: false, verbose: false, quiet: false, **)
+        boot_application!
+        return unless stripe_configured?
+
+        puts "Billing Catalog Sync#{' (DRY RUN)' if dry_run}"
+        puts '=' * 60
+        puts
+        puts 'This command runs three steps in sequence:'
+        puts '  1. Push catalog to Stripe'
+        puts '  2. Pull from Stripe to Redis cache'
+        puts '  3. Materialize entitlements on organizations'
+        puts
+
+        return unless step_push(dry_run: dry_run, force: force, plan: plan, skip_prices: skip_prices)
+        return unless step_pull(dry_run: dry_run)
+        step_materialize(dry_run: dry_run, plan: plan, include_memberships: include_memberships,
+                         verbose: verbose, quiet: quiet)
+
+        puts
+        puts '=' * 60
+        puts "Catalog sync #{dry_run ? 'preview' : ''} complete!"
+      end
+
+      private
+
+      def step_push(dry_run:, force:, plan:, skip_prices:)
+        print_step_header(1, 'Catalog Push')
+
+        preview = Billing::Operations::Catalog::Push.call(
+          dry_run: true,
+          plan_filter: plan,
+          skip_prices: skip_prices,
+          progress: method(:show_progress),
+        )
+
+        unless preview.success
+          preview.errors.each { |e| puts "  Error: #{e}" }
+          puts "\nAborting sync: catalog push preview failed."
+          return false
+        end
+
+        if preview.no_changes
+          puts '  No changes needed — Stripe is in sync with catalog.'
+          return true
+        end
+
+        puts "  Would create #{preview.products_created} product(s)" if preview.products_created > 0
+        puts "  Would update #{preview.products_updated} product(s)" if preview.products_updated > 0
+        puts "  Would create #{preview.prices_created} price(s)" if preview.prices_created > 0
+
+        return true if dry_run
+
+        unless force
+          print "\n  Proceed with catalog push? (y/n): "
+          response = $stdin.gets
+          unless response&.chomp&.downcase == 'y'
+            puts "\nAborted by user."
+            return false
+          end
+        end
+
+        result = Billing::Operations::Catalog::Push.call(
+          dry_run: false,
+          plan_filter: plan,
+          skip_prices: skip_prices,
+          progress: method(:show_progress),
+        )
+
+        unless result.success
+          result.errors.each { |e| puts "  Error: #{e}" }
+          puts "\nAborting sync: catalog push failed."
+          return false
+        end
+
+        puts "  Created #{result.products_created} product(s)" if result.products_created > 0
+        puts "  Updated #{result.products_updated} product(s)" if result.products_updated > 0
+        puts "  Created #{result.prices_created} price(s)" if result.prices_created > 0
+        true
+      end
+
+      def step_pull(dry_run:)
+        print_step_header(2, 'Catalog Pull')
+
+        if dry_run
+          puts '  Skipped (dry run) — would pull products/prices from Stripe to Redis.'
+          return true
+        end
+
+        result = Billing::Operations::Catalog::Pull.call(
+          clear_cache: false,
+          progress: method(:show_pull_progress),
+        )
+
+        puts
+
+        unless result.success
+          result.errors.each { |e| puts "  Error: #{e}" }
+          puts "\nAborting sync: catalog pull failed."
+          return false
+        end
+
+        puts "  Pulled #{result.plans_synced} plan(s) from Stripe."
+        puts "  Upserted #{result.config_plans_loaded} config-only plan(s)." if result.config_plans_loaded > 0
+        true
+      end
+
+      def step_materialize(dry_run:, plan:, include_memberships:, verbose:, quiet:)
+        print_step_header(3, 'Plans Materialize')
+
+        total = Onetime::Organization.instances.element_count
+
+        if total.zero?
+          puts '  No organizations found — nothing to materialize.'
+          return true
+        end
+
+        scope = plan ? "organizations on plan '#{plan}'" : 'all organizations'
+        scope += ' + memberships cascade' if include_memberships
+
+        if dry_run
+          puts "  Dry run: would materialize #{scope}."
+        else
+          puts "  Materializing #{scope}..."
+        end
+
+        verbosity = resolve_verbosity(verbose: verbose, quiet: quiet)
+        renderer  = MaterializeStepRenderer.new(total: total, verbosity: verbosity,
+                                                dry_run: dry_run,
+                                                include_memberships: include_memberships)
+
+        filter_args = plan ? { plan_filter: plan } : {}
+
+        result = ::Billing::Operations::MaterializePlans.call(
+          include_memberships: include_memberships,
+          dry_run: dry_run,
+          **filter_args,
+        ) { |event| renderer.render(event) }
+
+        puts
+        puts "  Scanned: #{result.scanned}"
+        puts "  Succeeded: #{result.succeeded}"
+        puts "  Failed: #{result.failed}" if result.failed > 0
+        puts "  Skipped (no plan): #{result.skipped_no_plan}" if result.skipped_no_plan > 0
+        puts "  Skipped (plan filter): #{result.skipped_plan_filter}" if result.skipped_plan_filter > 0
+
+        if include_memberships && !dry_run
+          puts "  Memberships materialized: #{result.memberships_succeeded}"
+          puts "  Memberships failed: #{result.memberships_failed}" if result.memberships_failed > 0
+        end
+
+        unless result.errors.empty?
+          puts "\n  Errors:"
+          result.errors.each { |err| puts "    - #{err[:org_extid]}: #{err[:reason]}" }
+        end
+
+        true
+      end
+
+      def resolve_verbosity(verbose:, quiet:)
+        return :quiet if quiet
+        return :verbose if verbose
+
+        :default
+      end
+
+      def print_step_header(number, name)
+        puts
+        puts "Step #{number}: #{name}"
+        puts '-' * 40
+      end
+
+      def show_progress(message)
+        puts "  #{message}"
+      end
+
+      def show_pull_progress(message)
+        print "\r  #{message}"
+        $stdout.flush
+      end
+
+      # Compact progress renderer for the materialize step.
+      class MaterializeStepRenderer
+        def initialize(total:, verbosity:, dry_run:, include_memberships:)
+          @total               = total
+          @verbosity           = verbosity
+          @dry_run             = dry_run
+          @include_memberships = include_memberships
+          @processed           = 0
+        end
+
+        def render(event)
+          @processed += 1
+          return if @verbosity == :quiet
+
+          puts "    [#{@processed}/#{@total}] #{describe(event)}"
+          render_membership_detail(event) if @verbosity == :verbose
+        end
+
+        private
+
+        def render_membership_detail(event)
+          details = event.cascade && event.cascade[:details]
+          return if details.nil? || details.empty?
+
+          details.each do |m|
+            status = m[:status] == :ok ? "#{m[:entitlements_count]} entitlements" : "FAILED — #{m[:error]}"
+            puts "        -> #{m[:objid]} (role=#{m[:role]}): #{status}"
+          end
+        end
+
+        def describe(event)
+          case event.event
+          when :materialized
+            cascade = event.cascade ? " + cascaded #{event.cascade[:success]}/#{event.cascade[:total]} memberships" : ''
+            "Materialized: #{event.org_extid} (#{event.planid}, #{event.entitlements_count} entitlements)#{cascade}"
+          when :would_materialize
+            cascade_hint = @include_memberships ? ' (+memberships cascade)' : ''
+            "Would materialize: #{event.org_extid} (#{event.planid}, #{event.entitlements_count} entitlements)#{cascade_hint}"
+          when :skipped_plan_filter
+            "Skipping (plan filter): #{event.org_extid}"
+          when :skipped_no_plan
+            "Skipping (no planid): #{event.org_extid}"
+          when :failed_plan_not_found
+            "Error: #{event.reason} (#{event.org_extid})"
+          when :failed_org_write
+            "Error: org write failed for #{event.org_extid}: #{event.reason}"
+          when :failed_cascade
+            cascade = event.cascade ? " (#{event.cascade[:success]}/#{event.cascade[:total]} succeeded)" : ''
+            "Error: cascade failed for #{event.org_extid}: #{event.reason}#{cascade}"
+          else
+            "[#{event.event}] #{event.org_extid}"
+          end
+        end
+      end
+    end
+  end
+end
+
+Onetime::CLI.register 'billing catalog sync', Onetime::CLI::BillingCatalogSyncCommand

--- a/apps/web/billing/cli/catalog_sync_command.rb
+++ b/apps/web/billing/cli/catalog_sync_command.rb
@@ -3,6 +3,7 @@
 # frozen_string_literal: true
 
 require_relative 'helpers'
+require_relative '../lib/materialize_progress_renderer'
 require_relative '../operations/catalog/push'
 require_relative '../operations/catalog/pull'
 require_relative '../operations/materialize_plans'
@@ -74,12 +75,18 @@ module Onetime
 
         return unless step_push(dry_run: dry_run, force: force, plan: plan, skip_prices: skip_prices)
         return unless step_pull(dry_run: dry_run)
-        step_materialize(dry_run: dry_run, plan: plan, include_memberships: include_memberships,
-                         verbose: verbose, quiet: quiet)
+        materialize_ok = step_materialize(dry_run: dry_run, plan: plan,
+                                          include_memberships: include_memberships,
+                                          verbose: verbose, quiet: quiet)
 
         puts
         puts '=' * 60
-        puts "Catalog sync #{dry_run ? 'preview' : ''} complete!"
+        if materialize_ok
+          puts "Catalog sync #{dry_run ? 'preview ' : ''}complete!"
+        else
+          puts "Catalog sync #{dry_run ? 'preview ' : ''}finished with materialization errors."
+          puts 'Review the errors above. Push and pull succeeded.'
+        end
       end
 
       private
@@ -185,9 +192,12 @@ module Onetime
         end
 
         verbosity = resolve_verbosity(verbose: verbose, quiet: quiet)
-        renderer  = MaterializeStepRenderer.new(total: total, verbosity: verbosity,
-                                                dry_run: dry_run,
-                                                include_memberships: include_memberships)
+        renderer  = Billing::MaterializeProgressRenderer.new(
+                      total: total,
+                      verbosity: verbosity,
+                      include_memberships: include_memberships,
+                      indent: 4,
+                    )
 
         result = ::Billing::Operations::MaterializePlans.call(
           plan_filter: plan,
@@ -212,7 +222,7 @@ module Onetime
           result.errors.each { |err| puts "    - #{err[:org_extid]}: #{err[:reason]}" }
         end
 
-        true
+        result.errors.empty?
       end
 
       def resolve_verbosity(verbose:, quiet:)
@@ -237,60 +247,6 @@ module Onetime
         $stdout.flush
       end
 
-      # Compact progress renderer for the materialize step.
-      class MaterializeStepRenderer
-        def initialize(total:, verbosity:, dry_run:, include_memberships:)
-          @total               = total
-          @verbosity           = verbosity
-          @dry_run             = dry_run
-          @include_memberships = include_memberships
-          @processed           = 0
-        end
-
-        def render(event)
-          @processed += 1
-          return if @verbosity == :quiet
-
-          puts "    [#{@processed}/#{@total}] #{describe(event)}"
-          render_membership_detail(event) if @verbosity == :verbose
-        end
-
-        private
-
-        def render_membership_detail(event)
-          details = event.cascade && event.cascade[:details]
-          return if details.nil? || details.empty?
-
-          details.each do |m|
-            status = m[:status] == :ok ? "#{m[:entitlements_count]} entitlements" : "FAILED — #{m[:error]}"
-            puts "        -> #{m[:objid]} (role=#{m[:role]}): #{status}"
-          end
-        end
-
-        def describe(event)
-          case event.event
-          when :materialized
-            cascade = event.cascade ? " + cascaded #{event.cascade[:success]}/#{event.cascade[:total]} memberships" : ''
-            "Materialized: #{event.org_extid} (#{event.planid}, #{event.entitlements_count} entitlements)#{cascade}"
-          when :would_materialize
-            cascade_hint = @include_memberships ? ' (+memberships cascade)' : ''
-            "Would materialize: #{event.org_extid} (#{event.planid}, #{event.entitlements_count} entitlements)#{cascade_hint}"
-          when :skipped_plan_filter
-            "Skipping (plan filter): #{event.org_extid}"
-          when :skipped_no_plan
-            "Skipping (no planid): #{event.org_extid}"
-          when :failed_plan_not_found
-            "Error: #{event.reason} (#{event.org_extid})"
-          when :failed_org_write
-            "Error: org write failed for #{event.org_extid}: #{event.reason}"
-          when :failed_cascade
-            cascade = event.cascade ? " (#{event.cascade[:success]}/#{event.cascade[:total]} succeeded)" : ''
-            "Error: cascade failed for #{event.org_extid}: #{event.reason}#{cascade}"
-          else
-            "[#{event.event}] #{event.org_extid}"
-          end
-        end
-      end
     end
   end
 end

--- a/apps/web/billing/cli/plans_materialize_command.rb
+++ b/apps/web/billing/cli/plans_materialize_command.rb
@@ -3,6 +3,7 @@
 # frozen_string_literal: true
 
 require_relative 'helpers'
+require_relative '../lib/materialize_progress_renderer'
 require_relative '../operations/materialize_plans'
 
 module Onetime
@@ -94,10 +95,11 @@ module Onetime
                           include_memberships: include_memberships)
 
         verbosity = resolve_verbosity(verbose: verbose, quiet: quiet)
-        renderer  = ProgressRenderer.new(total: total,
-                                         verbosity: verbosity,
-                                         dry_run: dry_run,
-                                         include_memberships: include_memberships)
+        renderer  = Billing::MaterializeProgressRenderer.new(
+                      total: total,
+                      verbosity: verbosity,
+                      include_memberships: include_memberships,
+                    )
 
         result = ::Billing::Operations::MaterializePlans.call(
           plan_filter: plan,
@@ -243,77 +245,6 @@ module Onetime
         true
       end
 
-      # Renders streaming progress events to stdout.
-      #
-      # Three modes:
-      #   :default — one line per org (the audit-log baseline)
-      #   :verbose — :default plus one line per membership under each cascade
-      #   :quiet   — no per-org output (banner and final summary only)
-      #
-      # Decoupled from the operation so other callers (jobs, future UIs)
-      # can plug in their own renderers.
-      class ProgressRenderer
-        def initialize(total:, verbosity:, dry_run:, include_memberships:)
-          @total               = total
-          @verbosity           = verbosity
-          @dry_run             = dry_run
-          @include_memberships = include_memberships
-          @processed           = 0
-        end
-
-        def render(event)
-          @processed += 1
-          return if @verbosity == :quiet
-
-          puts "  [#{@processed}/#{@total}] #{describe(event)}"
-          render_membership_detail(event) if @verbosity == :verbose
-        end
-
-        private
-
-        def render_membership_detail(event)
-          details = event.cascade && event.cascade[:details]
-          return if details.nil? || details.empty?
-
-          details.each do |m|
-            puts "      ↳ #{format_membership(m)}"
-          end
-        end
-
-        def format_membership(detail)
-          role = detail[:role]
-          if detail[:status] == :ok
-            "#{detail[:objid]} (role=#{role}, plan=#{detail[:planid]}): " \
-              "#{detail[:entitlements_count]} entitlements"
-          else
-            "#{detail[:objid]} (role=#{role}): FAILED — #{detail[:error]}"
-          end
-        end
-
-        def describe(event)
-          case event.event
-          when :materialized
-            cascade = event.cascade ? " + cascaded #{event.cascade[:success]}/#{event.cascade[:total]} memberships" : ''
-            "Materialized: #{event.org_extid} (#{event.planid}, #{event.entitlements_count} entitlements)#{cascade}"
-          when :would_materialize
-            cascade_hint = @include_memberships ? ' (+memberships cascade)' : ''
-            "Would materialize: #{event.org_extid} (#{event.planid}, #{event.entitlements_count} entitlements)#{cascade_hint}"
-          when :skipped_plan_filter
-            "Skipping (plan filter): #{event.org_extid}"
-          when :skipped_no_plan
-            "Skipping (no planid): #{event.org_extid}"
-          when :failed_plan_not_found
-            "Error: #{event.reason} (#{event.org_extid})"
-          when :failed_org_write
-            "Error: org write failed for #{event.org_extid}: #{event.reason}"
-          when :failed_cascade
-            cascade = event.cascade ? " (#{event.cascade[:success]}/#{event.cascade[:total]} succeeded)" : ''
-            "Error: cascade failed for #{event.org_extid}: #{event.reason}#{cascade}"
-          else
-            "[#{event.event}] #{event.org_extid}"
-          end
-        end
-      end
     end
   end
 end

--- a/apps/web/billing/lib/materialize_progress_renderer.rb
+++ b/apps/web/billing/lib/materialize_progress_renderer.rb
@@ -1,0 +1,85 @@
+# apps/web/billing/lib/materialize_progress_renderer.rb
+#
+# frozen_string_literal: true
+
+module Billing
+  # Renders MaterializePlans streaming events to stdout.
+  #
+  # Three verbosity modes:
+  #   :default — one line per org (the audit-log baseline)
+  #   :verbose — :default plus one line per membership under each cascade
+  #   :quiet   — no per-org output (caller handles banner and summary)
+  #
+  # Decoupled from the operation so CLI commands, background jobs, and
+  # future UIs can plug in their own renderers. The +indent+ parameter
+  # lets callers control nesting depth (e.g., standalone command vs.
+  # step inside a composite command).
+  #
+  class MaterializeProgressRenderer
+    # @param total [Integer] Total orgs to scan (for progress counter)
+    # @param verbosity [:default, :verbose, :quiet]
+    # @param include_memberships [Boolean] Whether cascade is enabled
+    # @param indent [Integer] Leading spaces for progress lines (detail lines add 4 more)
+    def initialize(total:, verbosity: :default, include_memberships: false, indent: 2)
+      @total               = total
+      @verbosity           = verbosity
+      @include_memberships = include_memberships
+      @prefix              = ' ' * indent
+      @detail_prefix       = ' ' * (indent + 4)
+      @processed           = 0
+    end
+
+    def render(event)
+      @processed += 1
+      return if @verbosity == :quiet
+
+      puts "#{@prefix}[#{@processed}/#{@total}] #{describe(event)}"
+      render_membership_detail(event) if @verbosity == :verbose
+    end
+
+    private
+
+    def render_membership_detail(event)
+      details = event.cascade && event.cascade[:details]
+      return if details.nil? || details.empty?
+
+      details.each do |m|
+        puts "#{@detail_prefix}↳ #{format_membership(m)}"
+      end
+    end
+
+    def format_membership(detail)
+      role = detail[:role]
+      if detail[:status] == :ok
+        "#{detail[:objid]} (role=#{role}, plan=#{detail[:planid]}): " \
+          "#{detail[:entitlements_count]} entitlements"
+      else
+        "#{detail[:objid]} (role=#{role}): FAILED — #{detail[:error]}"
+      end
+    end
+
+    def describe(event)
+      case event.event
+      when :materialized
+        cascade = event.cascade ? " + cascaded #{event.cascade[:success]}/#{event.cascade[:total]} memberships" : ''
+        "Materialized: #{event.org_extid} (#{event.planid}, #{event.entitlements_count} entitlements)#{cascade}"
+      when :would_materialize
+        cascade_hint = @include_memberships ? ' (+memberships cascade)' : ''
+        "Would materialize: #{event.org_extid} (#{event.planid}, #{event.entitlements_count} entitlements)#{cascade_hint}"
+      when :skipped_plan_filter
+        "Skipping (plan filter): #{event.org_extid}"
+      when :skipped_no_plan
+        "Skipping (no planid): #{event.org_extid}"
+      when :failed_plan_not_found
+        "Error: #{event.reason} (#{event.org_extid})"
+      when :failed_org_write
+        "Error: org write failed for #{event.org_extid}: #{event.reason}"
+      when :failed_cascade
+        cascade = event.cascade ? " (#{event.cascade[:success]}/#{event.cascade[:total]} succeeded)" : ''
+        "Error: cascade failed for #{event.org_extid}: #{event.reason}#{cascade}"
+      else
+        "[#{event.event}] #{event.org_extid}"
+      end
+    end
+  end
+end

--- a/apps/web/billing/spec/cli/catalog_sync_command_spec.rb
+++ b/apps/web/billing/spec/cli/catalog_sync_command_spec.rb
@@ -1,0 +1,383 @@
+# apps/web/billing/spec/cli/catalog_sync_command_spec.rb
+#
+# frozen_string_literal: true
+
+# Specs for `bin/ots billing catalog sync` CLI wrapper.
+#
+# The command composes three operations in sequence: push, pull, materialize.
+# These specs verify step orchestration, option forwarding, abort-on-failure,
+# and output under success/failure/dry-run modes.
+#
+# Run: pnpm run test:rspec apps/web/billing/spec/cli/catalog_sync_command_spec.rb
+
+require_relative '../support/billing_spec_helper'
+require 'onetime/cli'
+require_relative '../../cli/catalog_sync_command'
+
+RSpec.describe 'Billing Catalog Sync CLI', :billing_cli do
+  subject(:command) { Onetime::CLI::BillingCatalogSyncCommand.new }
+
+  def capture_stdout
+    old_stdout = $stdout
+    $stdout = StringIO.new
+    begin
+      yield
+    rescue SystemExit
+      # Ignore exit calls
+    end
+    $stdout.string
+  ensure
+    $stdout = old_stdout
+  end
+
+  def push_result(success: true, no_changes: false, products_created: 0, products_updated: 0, prices_created: 0, errors: [])
+    Billing::Operations::Catalog::Push::Result.new(
+      success: success,
+      dry_run: false,
+      products_created: products_created,
+      products_updated: products_updated,
+      prices_created: prices_created,
+      no_changes: no_changes,
+      errors: errors,
+    )
+  end
+
+  def pull_result(success: true, plans_synced: 3, config_plans_loaded: 0, errors: [])
+    Billing::Operations::Catalog::Pull::Result.new(
+      success: success,
+      plans_synced: plans_synced,
+      config_plans_loaded: config_plans_loaded,
+      errors: errors,
+    )
+  end
+
+  def materialize_result(succeeded: 1, failed: 0, scanned: 1,
+                         skipped_no_plan: 0, skipped_plan_filter: 0,
+                         memberships_succeeded: 0, memberships_failed: 0,
+                         orgs_cascaded: 0, errors: [])
+    Billing::Operations::MaterializePlansResult.new(
+      scanned: scanned,
+      succeeded: succeeded,
+      failed: failed,
+      skipped_no_plan: skipped_no_plan,
+      skipped_plan_filter: skipped_plan_filter,
+      memberships_succeeded: memberships_succeeded,
+      memberships_failed: memberships_failed,
+      orgs_cascaded: orgs_cascaded,
+      errors: errors,
+    )
+  end
+
+  before do
+    allow(command).to receive(:boot_application!)
+    allow(command).to receive(:stripe_configured?).and_return(true)
+    instances = instance_double(Familia::SortedSet, element_count: 1)
+    allow(Onetime::Organization).to receive(:instances).and_return(instances)
+  end
+
+  describe 'stripe configuration' do
+    it 'exits early when Stripe is not configured' do
+      allow(command).to receive(:stripe_configured?).and_return(false)
+      expect(Billing::Operations::Catalog::Push).not_to receive(:call)
+
+      command.call
+    end
+  end
+
+  describe 'full sync (happy path)' do
+    before do
+      allow(Billing::Operations::Catalog::Push).to receive(:call)
+        .and_return(push_result(no_changes: true))
+      allow(Billing::Operations::Catalog::Pull).to receive(:call)
+        .and_return(pull_result)
+      allow(Billing::Operations::MaterializePlans).to receive(:call)
+        .and_return(materialize_result)
+    end
+
+    it 'runs all three steps in sequence' do
+      output = capture_stdout { command.call(force: true) }
+
+      expect(output).to include('Step 1: Catalog Push')
+      expect(output).to include('Step 2: Catalog Pull')
+      expect(output).to include('Step 3: Plans Materialize')
+    end
+
+    it 'reports success when all steps complete without errors' do
+      output = capture_stdout { command.call(force: true) }
+
+      expect(output).to include('Catalog sync complete!')
+    end
+  end
+
+  describe 'step 1: catalog push' do
+    context 'when no changes needed' do
+      before do
+        allow(Billing::Operations::Catalog::Push).to receive(:call)
+          .and_return(push_result(no_changes: true))
+        allow(Billing::Operations::Catalog::Pull).to receive(:call)
+          .and_return(pull_result)
+        allow(Billing::Operations::MaterializePlans).to receive(:call)
+          .and_return(materialize_result)
+      end
+
+      it 'continues to pull and materialize' do
+        capture_stdout { command.call(force: true) }
+
+        expect(Billing::Operations::Catalog::Pull).to have_received(:call)
+        expect(Billing::Operations::MaterializePlans).to have_received(:call)
+      end
+
+      it 'reports catalog is in sync' do
+        output = capture_stdout { command.call(force: true) }
+        expect(output).to include('No changes needed')
+      end
+    end
+
+    context 'when push preview fails' do
+      before do
+        allow(Billing::Operations::Catalog::Push).to receive(:call)
+          .and_return(push_result(success: false, errors: ['Invalid catalog']))
+      end
+
+      it 'aborts sync and does not run pull or materialize' do
+        expect(Billing::Operations::Catalog::Pull).not_to receive(:call)
+        expect(Billing::Operations::MaterializePlans).not_to receive(:call)
+
+        output = capture_stdout { command.call(force: true) }
+        expect(output).to include('Aborting sync: catalog push preview failed')
+      end
+    end
+
+    context 'when changes exist and --force is set' do
+      before do
+        # First call is preview (dry_run: true), second is actual push
+        allow(Billing::Operations::Catalog::Push).to receive(:call)
+          .and_return(
+            push_result(products_created: 2, prices_created: 1),
+            push_result(products_created: 2, prices_created: 1),
+          )
+        allow(Billing::Operations::Catalog::Pull).to receive(:call)
+          .and_return(pull_result)
+        allow(Billing::Operations::MaterializePlans).to receive(:call)
+          .and_return(materialize_result)
+      end
+
+      it 'skips confirmation prompt and proceeds' do
+        output = capture_stdout { command.call(force: true) }
+
+        expect(Billing::Operations::Catalog::Push).to have_received(:call).twice
+        expect(output).to include('Created 2 product(s)')
+      end
+    end
+
+    context 'when user declines confirmation' do
+      before do
+        allow(Billing::Operations::Catalog::Push).to receive(:call)
+          .and_return(push_result(products_created: 1))
+        allow($stdin).to receive(:gets).and_return("n\n")
+      end
+
+      it 'aborts sync' do
+        expect(Billing::Operations::Catalog::Pull).not_to receive(:call)
+
+        output = capture_stdout { command.call }
+        expect(output).to include('Aborted by user')
+      end
+    end
+  end
+
+  describe 'step 2: catalog pull' do
+    context 'when pull fails' do
+      before do
+        allow(Billing::Operations::Catalog::Push).to receive(:call)
+          .and_return(push_result(no_changes: true))
+        allow(Billing::Operations::Catalog::Pull).to receive(:call)
+          .and_return(pull_result(success: false, errors: ['Connection refused']))
+      end
+
+      it 'aborts sync and does not run materialize' do
+        expect(Billing::Operations::MaterializePlans).not_to receive(:call)
+
+        output = capture_stdout { command.call(force: true) }
+        expect(output).to include('Aborting sync: catalog pull failed')
+      end
+    end
+  end
+
+  describe 'step 3: plans materialize' do
+    before do
+      allow(Billing::Operations::Catalog::Push).to receive(:call)
+        .and_return(push_result(no_changes: true))
+      allow(Billing::Operations::Catalog::Pull).to receive(:call)
+        .and_return(pull_result)
+    end
+
+    it 'reports success statistics' do
+      allow(Billing::Operations::MaterializePlans).to receive(:call)
+        .and_return(materialize_result(scanned: 5, succeeded: 4, skipped_no_plan: 1))
+
+      output = capture_stdout { command.call(force: true) }
+      expect(output).to include('Scanned: 5')
+      expect(output).to include('Succeeded: 4')
+      expect(output).to include('Skipped (no plan): 1')
+    end
+
+    context 'with materialization errors' do
+      it 'reports errors in the final banner' do
+        allow(Billing::Operations::MaterializePlans).to receive(:call)
+          .and_return(materialize_result(
+            failed: 1,
+            errors: [{ org_extid: 'org_broken', reason: 'plan not found' }],
+          ))
+
+        output = capture_stdout { command.call(force: true) }
+        expect(output).to include('finished with materialization errors')
+        expect(output).to include('Push and pull succeeded')
+        expect(output).to include('org_broken')
+      end
+    end
+
+    context 'with zero organizations' do
+      before do
+        empty = instance_double(Familia::SortedSet, element_count: 0)
+        allow(Onetime::Organization).to receive(:instances).and_return(empty)
+      end
+
+      it 'reports nothing to materialize and still succeeds' do
+        expect(Billing::Operations::MaterializePlans).not_to receive(:call)
+
+        output = capture_stdout { command.call(force: true) }
+        expect(output).to include('No organizations found')
+        expect(output).to include('complete!')
+      end
+    end
+  end
+
+  describe 'option forwarding' do
+    before do
+      allow(Billing::Operations::Catalog::Push).to receive(:call)
+        .and_return(push_result(no_changes: true))
+      allow(Billing::Operations::Catalog::Pull).to receive(:call)
+        .and_return(pull_result)
+      allow(Billing::Operations::MaterializePlans).to receive(:call)
+        .and_return(materialize_result)
+    end
+
+    it 'forwards --plan to push and materialize' do
+      capture_stdout { command.call(force: true, plan: 'identity_plus_v1') }
+
+      expect(Billing::Operations::Catalog::Push).to have_received(:call)
+        .with(hash_including(plan_filter: 'identity_plus_v1'))
+      expect(Billing::Operations::MaterializePlans).to have_received(:call)
+        .with(hash_including(plan_filter: 'identity_plus_v1'))
+    end
+
+    it 'forwards --skip-prices to push' do
+      capture_stdout { command.call(force: true, skip_prices: true) }
+
+      expect(Billing::Operations::Catalog::Push).to have_received(:call)
+        .with(hash_including(skip_prices: true))
+    end
+
+    it 'forwards --include-memberships to materialize' do
+      capture_stdout { command.call(force: true, include_memberships: true) }
+
+      expect(Billing::Operations::MaterializePlans).to have_received(:call)
+        .with(hash_including(include_memberships: true))
+    end
+  end
+
+  describe 'dry-run mode' do
+    before do
+      allow(Billing::Operations::Catalog::Push).to receive(:call)
+        .and_return(push_result(products_created: 1))
+      allow(Billing::Operations::MaterializePlans).to receive(:call)
+        .and_return(materialize_result)
+    end
+
+    it 'shows DRY RUN banner' do
+      output = capture_stdout { command.call(dry_run: true) }
+      expect(output).to include('(DRY RUN)')
+    end
+
+    it 'skips pull step entirely' do
+      expect(Billing::Operations::Catalog::Pull).not_to receive(:call)
+
+      output = capture_stdout { command.call(dry_run: true) }
+      expect(output).to include('Skipped (dry run)')
+    end
+
+    it 'does not prompt for push confirmation' do
+      expect($stdin).not_to receive(:gets)
+
+      capture_stdout { command.call(dry_run: true) }
+    end
+
+    it 'passes dry_run: true to materialize' do
+      capture_stdout { command.call(dry_run: true) }
+
+      expect(Billing::Operations::MaterializePlans).to have_received(:call)
+        .with(hash_including(dry_run: true))
+    end
+  end
+
+  describe 'progress rendering' do
+    before do
+      allow(Billing::Operations::Catalog::Push).to receive(:call)
+        .and_return(push_result(no_changes: true))
+      allow(Billing::Operations::Catalog::Pull).to receive(:call)
+        .and_return(pull_result)
+    end
+
+    def stub_materialize_with_event(event)
+      allow(Billing::Operations::MaterializePlans).to receive(:call) do |**, &blk|
+        blk.call(event)
+        materialize_result
+      end
+    end
+
+    it 'renders per-org progress lines by default' do
+      stub_materialize_with_event(
+        Billing::Operations::MaterializePlansEvent.new(
+          event: :materialized, org_extid: 'org_abc', planid: 'p1',
+          entitlements_count: 5, cascade: nil, reason: nil,
+        ),
+      )
+
+      output = capture_stdout { command.call(force: true) }
+      expect(output).to include('Materialized: org_abc')
+    end
+
+    it 'suppresses per-org lines under --quiet' do
+      stub_materialize_with_event(
+        Billing::Operations::MaterializePlansEvent.new(
+          event: :materialized, org_extid: 'org_abc', planid: 'p1',
+          entitlements_count: 5, cascade: nil, reason: nil,
+        ),
+      )
+
+      output = capture_stdout { command.call(force: true, quiet: true) }
+      expect(output).not_to include('Materialized: org_abc')
+    end
+
+    it 'shows membership detail under --verbose' do
+      stub_materialize_with_event(
+        Billing::Operations::MaterializePlansEvent.new(
+          event: :materialized, org_extid: 'org_abc', planid: 'p1',
+          entitlements_count: 5,
+          cascade: {
+            success: 1, failed: 0, total: 1,
+            details: [
+              { objid: 'mem_111', role: 'owner', planid: 'p1', entitlements_count: 8, status: :ok, error: nil },
+            ],
+          },
+          reason: nil,
+        ),
+      )
+
+      output = capture_stdout { command.call(force: true, verbose: true) }
+      expect(output).to include('mem_111')
+      expect(output).to include('role=owner')
+    end
+  end
+end

--- a/apps/web/billing/spec/lib/materialize_progress_renderer_spec.rb
+++ b/apps/web/billing/spec/lib/materialize_progress_renderer_spec.rb
@@ -1,0 +1,170 @@
+# apps/web/billing/spec/lib/materialize_progress_renderer_spec.rb
+#
+# frozen_string_literal: true
+
+# Unit tests for Billing::MaterializeProgressRenderer
+#
+# Tests cover verbosity modes, indent control, and event formatting.
+#
+# Run: pnpm run test:rspec apps/web/billing/spec/lib/materialize_progress_renderer_spec.rb
+
+require_relative '../support/billing_spec_helper'
+require_relative '../../lib/materialize_progress_renderer'
+require_relative '../../operations/materialize_plans'
+
+RSpec.describe Billing::MaterializeProgressRenderer, type: :billing do
+  def capture_stdout
+    old_stdout = $stdout
+    $stdout = StringIO.new
+    yield
+    $stdout.string
+  ensure
+    $stdout = old_stdout
+  end
+
+  def make_event(event:, org_extid: 'org_1', planid: 'plan_v1', entitlements_count: 5, cascade: nil, reason: nil)
+    Billing::Operations::MaterializePlansEvent.new(
+      event: event,
+      org_extid: org_extid,
+      planid: planid,
+      entitlements_count: entitlements_count,
+      cascade: cascade,
+      reason: reason,
+    )
+  end
+
+  describe 'indent control' do
+    it 'uses 2-space indent by default' do
+      renderer = described_class.new(total: 1)
+      output = capture_stdout { renderer.render(make_event(event: :materialized)) }
+
+      expect(output).to start_with('  [')
+    end
+
+    it 'uses custom indent when specified' do
+      renderer = described_class.new(total: 1, indent: 4)
+      output = capture_stdout { renderer.render(make_event(event: :materialized)) }
+
+      expect(output).to start_with('    [')
+    end
+  end
+
+  describe 'progress counter' do
+    it 'increments counter across calls' do
+      renderer = described_class.new(total: 3)
+
+      lines = capture_stdout do
+        3.times { renderer.render(make_event(event: :materialized)) }
+      end.lines
+
+      expect(lines[0]).to include('[1/3]')
+      expect(lines[1]).to include('[2/3]')
+      expect(lines[2]).to include('[3/3]')
+    end
+  end
+
+  describe 'verbosity modes' do
+    it ':default renders per-org lines without membership detail' do
+      event = make_event(
+        event: :materialized,
+        cascade: { success: 1, failed: 0, total: 1, details: [
+          { objid: 'mem_1', role: 'owner', planid: 'p1', entitlements_count: 3, status: :ok, error: nil },
+        ] },
+      )
+      renderer = described_class.new(total: 1, verbosity: :default)
+
+      output = capture_stdout { renderer.render(event) }
+
+      expect(output).to include('Materialized: org_1')
+      expect(output).not_to include('mem_1')
+    end
+
+    it ':verbose adds per-membership detail lines' do
+      event = make_event(
+        event: :materialized,
+        cascade: { success: 1, failed: 0, total: 1, details: [
+          { objid: 'mem_1', role: 'owner', planid: 'p1', entitlements_count: 3, status: :ok, error: nil },
+        ] },
+      )
+      renderer = described_class.new(total: 1, verbosity: :verbose, include_memberships: true)
+
+      output = capture_stdout { renderer.render(event) }
+
+      expect(output).to include('Materialized: org_1')
+      expect(output).to include('mem_1')
+      expect(output).to include('role=owner')
+      expect(output).to include('3 entitlements')
+    end
+
+    it ':quiet suppresses all output' do
+      renderer = described_class.new(total: 1, verbosity: :quiet)
+      output = capture_stdout { renderer.render(make_event(event: :materialized)) }
+
+      expect(output).to be_empty
+    end
+  end
+
+  describe 'event descriptions' do
+    let(:renderer) { described_class.new(total: 1) }
+
+    it 'describes :materialized events' do
+      output = capture_stdout { renderer.render(make_event(event: :materialized)) }
+      expect(output).to include('Materialized: org_1 (plan_v1, 5 entitlements)')
+    end
+
+    it 'describes :would_materialize with cascade hint when enabled' do
+      renderer = described_class.new(total: 1, include_memberships: true)
+      output = capture_stdout { renderer.render(make_event(event: :would_materialize)) }
+
+      expect(output).to include('Would materialize: org_1')
+      expect(output).to include('(+memberships cascade)')
+    end
+
+    it 'describes :skipped_no_plan events' do
+      output = capture_stdout { renderer.render(make_event(event: :skipped_no_plan)) }
+      expect(output).to include('Skipping (no planid): org_1')
+    end
+
+    it 'describes :skipped_plan_filter events' do
+      output = capture_stdout { renderer.render(make_event(event: :skipped_plan_filter)) }
+      expect(output).to include('Skipping (plan filter): org_1')
+    end
+
+    it 'describes :failed_plan_not_found events' do
+      output = capture_stdout do
+        renderer.render(make_event(event: :failed_plan_not_found, reason: 'no such plan'))
+      end
+      expect(output).to include('Error: no such plan (org_1)')
+    end
+
+    it 'describes :failed_cascade with partial success count' do
+      event = make_event(
+        event: :failed_cascade,
+        reason: 'partial failure',
+        cascade: { success: 2, failed: 1, total: 3 },
+      )
+      output = capture_stdout { renderer.render(event) }
+
+      expect(output).to include('cascade failed for org_1')
+      expect(output).to include('2/3 succeeded')
+    end
+  end
+
+  describe 'membership failure rendering' do
+    it 'shows FAILED marker for errored memberships in verbose mode' do
+      event = make_event(
+        event: :materialized,
+        cascade: { success: 0, failed: 1, total: 1, details: [
+          { objid: 'mem_bad', role: 'member', planid: 'p1', entitlements_count: 0, status: :error, error: 'write failed' },
+        ] },
+      )
+      renderer = described_class.new(total: 1, verbosity: :verbose, include_memberships: true)
+
+      output = capture_stdout { renderer.render(event) }
+
+      expect(output).to include('mem_bad')
+      expect(output).to include('FAILED')
+      expect(output).to include('write failed')
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds a new `billing catalog sync` CLI command that orchestrates a full catalog synchronization workflow in three sequential steps:
1. Push catalog to Stripe
2. Pull products/prices from Stripe to Redis cache
3. Materialize entitlements on organizations

Also extracts the progress renderer from `PlansMaterializeCommand` into a reusable `MaterializeProgressRenderer` class to support multiple CLI commands and future integrations.

## Changes

### New Files
- **`apps/web/billing/cli/catalog_sync_command.rb`**: Composite command that chains push → pull → materialize operations with proper error handling and user confirmation flows. Supports dry-run mode, plan filtering, membership cascade, and configurable verbosity.
- **`apps/web/billing/lib/materialize_progress_renderer.rb`**: Extracted progress renderer supporting three verbosity modes (default, verbose, quiet) with configurable indentation for use in nested command contexts.

### Modified Files
- **`apps/web/billing/cli/plans_materialize_command.rb`**: Refactored to use the extracted `MaterializeProgressRenderer` instead of the inline `ProgressRenderer` class.
- **`apps/web/billing/cli/catalog_command.rb`**: Updated help text to document the new `sync` subcommand.
- **`apps/web/billing/cli/billing_command.rb`**: Updated help text to document the new `billing catalog sync` command.

## Design Notes

The `MaterializeProgressRenderer` is decoupled from the operation to allow different CLI commands, background jobs, and future UIs to plug in their own renderers. The `indent` parameter enables proper nesting when the renderer is used as a step within a composite command.

The sync command aborts on first failure to prevent downstream steps from running against stale data, ensuring data consistency across the three-step workflow.

## Test Plan

Existing tests for `MaterializePlans` operation continue to pass. The new command can be tested via:
```bash
bin/ots billing catalog sync --dry-run
bin/ots billing catalog sync --dry-run --plan identity_plus_v1
bin/ots billing catalog sync --force
```

https://claude.ai/code/session_01QxCEmgwj6yQHmEyTmxscJK