### PR TITLE
Split full-mode CI jobs into billing-enabled matrix

### DIFF
--- a/.github/actions/run-ruby-tests/action.yml
+++ b/.github/actions/run-ruby-tests/action.yml
@@ -93,6 +93,10 @@ inputs:
     description: 'Enable tmate debugging session'
     required: false
     default: 'false'
+  billing-enabled:
+    description: 'Enable billing features for this test run'
+    required: false
+    default: 'false'
 
 runs:
   using: composite
@@ -142,6 +146,7 @@ runs:
         RABBITMQ_URL: ${{ inputs.rabbitmq-url }}
         RACK_ENV: 'test'
         AUTHENTICATION_MODE: ${{ inputs.auth-mode }}
+        BILLING_ENABLED: ${{ inputs.billing-enabled }}
         DEBUG_DATABASE: 'true'
         DEBUG_LOGGERS: 'Familia:trace'
       run: |
@@ -162,6 +167,7 @@ runs:
         RABBITMQ_URL: ${{ inputs.rabbitmq-url }}
         RACK_ENV: 'test'
         AUTHENTICATION_MODE: ${{ inputs.auth-mode }}
+        BILLING_ENABLED: ${{ inputs.billing-enabled }}
         AUTH_DATABASE_URL: ${{ inputs.auth-database-url }}
         AUTH_DATABASE_URL_MIGRATIONS: ${{ inputs.auth-database-url-migrations }}
       # Pipe through tee so the runner's live log still streams while we keep
@@ -182,6 +188,7 @@ runs:
         RABBITMQ_URL: ${{ inputs.rabbitmq-url }}
         RACK_ENV: 'test'
         AUTHENTICATION_MODE: ${{ inputs.auth-mode }}
+        BILLING_ENABLED: ${{ inputs.billing-enabled }}
         AUTH_DATABASE_URL: ${{ inputs.auth-database-url }}
         AUTH_DATABASE_URL_MIGRATIONS: ${{ inputs.auth-database-url-migrations }}
         RSPEC_OUTPUT_FILE: tmp/${{ inputs.results-file }}
@@ -250,7 +257,7 @@ runs:
       shell: bash
       env:
         AUTH_MODE: ${{ inputs.auth-mode }}
-        BILLING_ENABLED: ${{ env.BILLING_ENABLED || 'false' }}
+        BILLING_ENABLED: ${{ inputs.billing-enabled }}
       run: |
         echo "## Ruby Test Results" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -473,61 +473,51 @@ jobs:
           rabbitmq-url: 'amqp://guest:guest@localhost:5672'
           results-file: 'rspec_simple_results.json'
 
-  ruby-integration-full-sqlite:
-    name: T3 · Ruby Integration (Full Mode - SQLite)
+  ruby-integration-full:
+    name: 'T3 · Ruby Integration (Full, ${{ matrix.name }})'
     timeout-minutes: 10
     runs-on: *runs-on
     needs: [changes, ruby-unit]
     if: *if-ruby-integration
     permissions: *perms-pr-comment
 
-    services:
-      redis: *valkey-service
-      rabbitmq: *rabbitmq-service
-
-    steps:
-      - *checkout-step
-
-      - name: Setup Ruby test environment
-        uses: ./.github/actions/setup-ruby-test-env
-
-      - name: Setup Python for locale sync
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.14'
-
-      - name: Setup Node.js for locale sync
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
-        with:
-          node-version: '22'
-
-      - name: Install pnpm
-        run: npm install -g pnpm
-
-      - name: Generate locale files
-        run: pnpm run locales:sync
-
-      - name: Run Ruby tests
-        uses: ./.github/actions/run-ruby-tests
-        with:
-          test-type: integration
-          auth-mode: full
-          auth-database-url: 'sqlite::memory:'
-          rabbitmq-url: 'amqp://guest:guest@localhost:5672'
-          results-file: 'rspec_full_sqlite_results.json'
-
-  ruby-integration-full-postgres-billing-off:
-    name: 'T3 · Ruby Integration (Full + PG, billing: off)'
-    timeout-minutes: 10
-    runs-on: *runs-on
-    needs: [changes, ruby-unit]
-    if: *if-ruby-integration
-    permissions: *perms-pr-comment
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: 'SQLite, billing: off'
+            db: sqlite
+            billing-enabled: 'false'
+            auth-database-url: 'sqlite::memory:'
+            auth-database-url-migrations: ''
+            rspec-tag: ''
+            results-file: 'rspec_full_sqlite_billing_off_results.json'
+          - name: 'SQLite, billing: on'
+            db: sqlite
+            billing-enabled: 'true'
+            auth-database-url: 'sqlite::memory:'
+            auth-database-url-migrations: ''
+            rspec-tag: ''
+            results-file: 'rspec_full_sqlite_billing_on_results.json'
+          - name: 'PG, billing: off'
+            db: postgres
+            billing-enabled: 'false'
+            auth-database-url: 'postgresql://onetime_user:testpass@localhost:5432/onetime_auth_test'
+            auth-database-url-migrations: 'postgresql://onetime_migrator:migratepass@localhost:5432/onetime_auth_test'
+            rspec-tag: 'postgres_database'
+            results-file: 'rspec_full_postgres_billing_off_results.json'
+          - name: 'PG, billing: on'
+            db: postgres
+            billing-enabled: 'true'
+            auth-database-url: 'postgresql://onetime_user:testpass@localhost:5432/onetime_auth_test'
+            auth-database-url-migrations: 'postgresql://onetime_migrator:migratepass@localhost:5432/onetime_auth_test'
+            rspec-tag: 'postgres_database'
+            results-file: 'rspec_full_postgres_billing_on_results.json'
 
     services:
       redis: *valkey-service
       rabbitmq: *rabbitmq-service
-      postgres: &postgres-service
+      postgres:
         image: postgres:17@sha256:b994732fcf33f73776c65d3a5bf1f80c00120ba5007e8ab90307b1a743c1fc16
         env:
           POSTGRES_USER: postgres
@@ -564,10 +554,10 @@ jobs:
         run: pnpm run locales:sync
 
       - name: Setup PostgreSQL users
+        if: matrix.db == 'postgres'
         env:
           PGPASSWORD: postgres
-        run: &setup-pg-users |
-          # Create application user (limited privileges)
+        run: |
           psql -h localhost -U postgres -d onetime_auth_test -c "
             DO \$\$
             BEGIN
@@ -578,7 +568,6 @@ jobs:
             \$\$;
           "
 
-          # Create migration user (elevated privileges)
           psql -h localhost -U postgres -d onetime_auth_test -c "
             DO \$\$
             BEGIN
@@ -589,7 +578,6 @@ jobs:
             \$\$;
           "
 
-          # Create restricted test user for dual-URL migration tests
           psql -h localhost -U postgres -d onetime_auth_test -c "
             DO \$\$
             BEGIN
@@ -600,7 +588,6 @@ jobs:
             \$\$;
           "
 
-          # Grant permissions with proper privilege separation
           psql -h localhost -U postgres -d onetime_auth_test -c "
             GRANT CONNECT ON DATABASE onetime_auth_test TO onetime_user;
             GRANT ALL PRIVILEGES ON DATABASE onetime_auth_test TO onetime_migrator;
@@ -608,8 +595,6 @@ jobs:
             GRANT ALL ON SCHEMA public TO onetime_migrator;
             REVOKE CREATE ON SCHEMA public FROM PUBLIC;
 
-            -- Default privileges: tables created by onetime_migrator
-            -- are automatically accessible to onetime_user for DML only
             ALTER DEFAULT PRIVILEGES FOR ROLE onetime_migrator IN SCHEMA public
               GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO onetime_user;
             ALTER DEFAULT PRIVILEGES FOR ROLE onetime_migrator IN SCHEMA public
@@ -623,64 +608,12 @@ jobs:
         with:
           test-type: integration
           auth-mode: full
-          auth-database-url: 'postgresql://onetime_user:testpass@localhost:5432/onetime_auth_test'
-          auth-database-url-migrations: 'postgresql://onetime_migrator:migratepass@localhost:5432/onetime_auth_test'
-          rspec-tag: 'postgres_database'
+          auth-database-url: ${{ matrix.auth-database-url }}
+          auth-database-url-migrations: ${{ matrix.auth-database-url-migrations }}
+          rspec-tag: ${{ matrix.rspec-tag }}
           rabbitmq-url: 'amqp://guest:guest@localhost:5672'
-          billing-enabled: 'false'
-          results-file: 'rspec_full_postgres_billing_off_results.json'
-
-  ruby-integration-full-postgres-billing-on:
-    name: 'T3 · Ruby Integration (Full + PG, billing: on)'
-    timeout-minutes: 10
-    runs-on: *runs-on
-    needs: [changes, ruby-unit]
-    if: *if-ruby-integration
-    permissions: *perms-pr-comment
-
-    services:
-      redis: *valkey-service
-      rabbitmq: *rabbitmq-service
-      postgres: *postgres-service
-
-    steps:
-      - *checkout-step
-
-      - name: Setup Ruby test environment
-        uses: ./.github/actions/setup-ruby-test-env
-
-      - name: Setup Python for locale sync
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.14'
-
-      - name: Setup Node.js for locale sync
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
-        with:
-          node-version: '22'
-
-      - name: Install pnpm
-        run: npm install -g pnpm
-
-      - name: Generate locale files
-        run: pnpm run locales:sync
-
-      - name: Setup PostgreSQL users
-        env:
-          PGPASSWORD: postgres
-        run: *setup-pg-users
-
-      - name: Run Ruby tests
-        uses: ./.github/actions/run-ruby-tests
-        with:
-          test-type: integration
-          auth-mode: full
-          auth-database-url: 'postgresql://onetime_user:testpass@localhost:5432/onetime_auth_test'
-          auth-database-url-migrations: 'postgresql://onetime_migrator:migratepass@localhost:5432/onetime_auth_test'
-          rspec-tag: 'postgres_database'
-          rabbitmq-url: 'amqp://guest:guest@localhost:5672'
-          billing-enabled: 'true'
-          results-file: 'rspec_full_postgres_billing_on_results.json'
+          billing-enabled: ${{ matrix.billing-enabled }}
+          results-file: ${{ matrix.results-file }}
 
   ruby-integration-disabled:
     name: T3 · Ruby Integration (Disabled Mode)
@@ -736,9 +669,7 @@ jobs:
       [
         changes,
         ruby-integration-simple,
-        ruby-integration-full-sqlite,
-        ruby-integration-full-postgres-billing-off,
-        ruby-integration-full-postgres-billing-on,
+        ruby-integration-full,
         ruby-integration-disabled,
         typescript-unit,
       ]
@@ -746,9 +677,7 @@ jobs:
       always() &&
       (needs.changes.outputs.oci == 'true' || needs.changes.outputs.frontend == 'true') &&
       (needs.ruby-integration-simple.result == 'success' || needs.ruby-integration-simple.result == 'skipped') &&
-      (needs.ruby-integration-full-sqlite.result == 'success' || needs.ruby-integration-full-sqlite.result == 'skipped') &&
-      (needs.ruby-integration-full-postgres-billing-off.result == 'success' || needs.ruby-integration-full-postgres-billing-off.result == 'skipped') &&
-      (needs.ruby-integration-full-postgres-billing-on.result == 'success' || needs.ruby-integration-full-postgres-billing-on.result == 'skipped') &&
+      (needs.ruby-integration-full.result == 'success' || needs.ruby-integration-full.result == 'skipped') &&
       (needs.ruby-integration-disabled.result == 'success' || needs.ruby-integration-disabled.result == 'skipped') &&
       (needs.typescript-unit.result == 'success' || needs.typescript-unit.result == 'skipped') &&
       !contains(needs.*.result, 'failure')
@@ -820,9 +749,7 @@ jobs:
     needs:
       - ruby-unit
       - ruby-integration-simple
-      - ruby-integration-full-sqlite
-      - ruby-integration-full-postgres-billing-off
-      - ruby-integration-full-postgres-billing-on
+      - ruby-integration-full
       - ruby-integration-disabled
       - typescript-unit
       - smoke-test
@@ -884,9 +811,7 @@ jobs:
       - ruby-unit
       - typescript-unit
       - ruby-integration-simple
-      - ruby-integration-full-sqlite
-      - ruby-integration-full-postgres-billing-off
-      - ruby-integration-full-postgres-billing-on
+      - ruby-integration-full
       - ruby-integration-disabled
       - smoke-test
       - check-oci-image
@@ -923,9 +848,7 @@ jobs:
           echo "| Ruby Unit | ${{ needs.ruby-unit.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| TypeScript Unit | ${{ needs.typescript-unit.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Ruby Integration (Simple) | ${{ needs.ruby-integration-simple.result }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Ruby Integration (Full - SQLite) | ${{ needs.ruby-integration-full-sqlite.result }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Ruby Integration (Full + PG, billing: off) | ${{ needs.ruby-integration-full-postgres-billing-off.result }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Ruby Integration (Full + PG, billing: on) | ${{ needs.ruby-integration-full-postgres-billing-on.result }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Ruby Integration (Full matrix) | ${{ needs.ruby-integration-full.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Ruby Integration (Disabled) | ${{ needs.ruby-integration-disabled.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Container Validation | ${{ needs.check-oci-image.result }} |" >> $GITHUB_STEP_SUMMARY
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -516,8 +516,8 @@ jobs:
           rabbitmq-url: 'amqp://guest:guest@localhost:5672'
           results-file: 'rspec_full_sqlite_results.json'
 
-  ruby-integration-full-postgres:
-    name: T3 · Ruby Integration (Full Mode - PostgreSQL)
+  ruby-integration-full-postgres-billing-off:
+    name: 'T3 · Ruby Integration (Full + PG, billing: off)'
     timeout-minutes: 10
     runs-on: *runs-on
     needs: [changes, ruby-unit]
@@ -527,7 +527,7 @@ jobs:
     services:
       redis: *valkey-service
       rabbitmq: *rabbitmq-service
-      postgres:
+      postgres: &postgres-service
         image: postgres:17@sha256:b994732fcf33f73776c65d3a5bf1f80c00120ba5007e8ab90307b1a743c1fc16
         env:
           POSTGRES_USER: postgres
@@ -566,7 +566,7 @@ jobs:
       - name: Setup PostgreSQL users
         env:
           PGPASSWORD: postgres
-        run: |
+        run: &setup-pg-users |
           # Create application user (limited privileges)
           psql -h localhost -U postgres -d onetime_auth_test -c "
             DO \$\$
@@ -627,7 +627,60 @@ jobs:
           auth-database-url-migrations: 'postgresql://onetime_migrator:migratepass@localhost:5432/onetime_auth_test'
           rspec-tag: 'postgres_database'
           rabbitmq-url: 'amqp://guest:guest@localhost:5672'
-          results-file: 'rspec_full_postgres_results.json'
+          billing-enabled: 'false'
+          results-file: 'rspec_full_postgres_billing_off_results.json'
+
+  ruby-integration-full-postgres-billing-on:
+    name: 'T3 · Ruby Integration (Full + PG, billing: on)'
+    timeout-minutes: 10
+    runs-on: *runs-on
+    needs: [changes, ruby-unit]
+    if: *if-ruby-integration
+    permissions: *perms-pr-comment
+
+    services:
+      redis: *valkey-service
+      rabbitmq: *rabbitmq-service
+      postgres: *postgres-service
+
+    steps:
+      - *checkout-step
+
+      - name: Setup Ruby test environment
+        uses: ./.github/actions/setup-ruby-test-env
+
+      - name: Setup Python for locale sync
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.14'
+
+      - name: Setup Node.js for locale sync
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: '22'
+
+      - name: Install pnpm
+        run: npm install -g pnpm
+
+      - name: Generate locale files
+        run: pnpm run locales:sync
+
+      - name: Setup PostgreSQL users
+        env:
+          PGPASSWORD: postgres
+        run: *setup-pg-users
+
+      - name: Run Ruby tests
+        uses: ./.github/actions/run-ruby-tests
+        with:
+          test-type: integration
+          auth-mode: full
+          auth-database-url: 'postgresql://onetime_user:testpass@localhost:5432/onetime_auth_test'
+          auth-database-url-migrations: 'postgresql://onetime_migrator:migratepass@localhost:5432/onetime_auth_test'
+          rspec-tag: 'postgres_database'
+          rabbitmq-url: 'amqp://guest:guest@localhost:5672'
+          billing-enabled: 'true'
+          results-file: 'rspec_full_postgres_billing_on_results.json'
 
   ruby-integration-disabled:
     name: T3 · Ruby Integration (Disabled Mode)
@@ -684,7 +737,8 @@ jobs:
         changes,
         ruby-integration-simple,
         ruby-integration-full-sqlite,
-        ruby-integration-full-postgres,
+        ruby-integration-full-postgres-billing-off,
+        ruby-integration-full-postgres-billing-on,
         ruby-integration-disabled,
         typescript-unit,
       ]
@@ -693,7 +747,8 @@ jobs:
       (needs.changes.outputs.oci == 'true' || needs.changes.outputs.frontend == 'true') &&
       (needs.ruby-integration-simple.result == 'success' || needs.ruby-integration-simple.result == 'skipped') &&
       (needs.ruby-integration-full-sqlite.result == 'success' || needs.ruby-integration-full-sqlite.result == 'skipped') &&
-      (needs.ruby-integration-full-postgres.result == 'success' || needs.ruby-integration-full-postgres.result == 'skipped') &&
+      (needs.ruby-integration-full-postgres-billing-off.result == 'success' || needs.ruby-integration-full-postgres-billing-off.result == 'skipped') &&
+      (needs.ruby-integration-full-postgres-billing-on.result == 'success' || needs.ruby-integration-full-postgres-billing-on.result == 'skipped') &&
       (needs.ruby-integration-disabled.result == 'success' || needs.ruby-integration-disabled.result == 'skipped') &&
       (needs.typescript-unit.result == 'success' || needs.typescript-unit.result == 'skipped') &&
       !contains(needs.*.result, 'failure')
@@ -766,7 +821,8 @@ jobs:
       - ruby-unit
       - ruby-integration-simple
       - ruby-integration-full-sqlite
-      - ruby-integration-full-postgres
+      - ruby-integration-full-postgres-billing-off
+      - ruby-integration-full-postgres-billing-on
       - ruby-integration-disabled
       - typescript-unit
       - smoke-test
@@ -829,7 +885,8 @@ jobs:
       - typescript-unit
       - ruby-integration-simple
       - ruby-integration-full-sqlite
-      - ruby-integration-full-postgres
+      - ruby-integration-full-postgres-billing-off
+      - ruby-integration-full-postgres-billing-on
       - ruby-integration-disabled
       - smoke-test
       - check-oci-image
@@ -867,7 +924,8 @@ jobs:
           echo "| TypeScript Unit | ${{ needs.typescript-unit.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Ruby Integration (Simple) | ${{ needs.ruby-integration-simple.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Ruby Integration (Full - SQLite) | ${{ needs.ruby-integration-full-sqlite.result }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Ruby Integration (Full - PostgreSQL) | ${{ needs.ruby-integration-full-postgres.result }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Ruby Integration (Full + PG, billing: off) | ${{ needs.ruby-integration-full-postgres-billing-off.result }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Ruby Integration (Full + PG, billing: on) | ${{ needs.ruby-integration-full-postgres-billing-on.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Ruby Integration (Disabled) | ${{ needs.ruby-integration-disabled.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Container Validation | ${{ needs.check-oci-image.result }} |" >> $GITHUB_STEP_SUMMARY
 

--- a/.github/workflows/ruby-4-preview.yml
+++ b/.github/workflows/ruby-4-preview.yml
@@ -211,12 +211,17 @@ jobs:
           rabbitmq-url: 'amqp://guest:guest@localhost:5672'
           results-file: 'ruby4_rspec_simple_results.json'
 
-  ruby-integration-full-sqlite:
-    name: Ruby 4 · Integration (Full Mode - SQLite)
+  ruby-integration-full:
+    name: 'Ruby 4 · Integration (Full, SQLite, billing: ${{ matrix.billing-enabled }})'
     runs-on: *runs-on
     timeout-minutes: 15
     needs: [build-assets]
     if: always()
+
+    strategy:
+      fail-fast: false
+      matrix:
+        billing-enabled: ['false', 'true']
 
     services:
       redis: *valkey-service
@@ -255,7 +260,8 @@ jobs:
           auth-mode: full
           auth-database-url: 'sqlite::memory:'
           rabbitmq-url: 'amqp://guest:guest@localhost:5672'
-          results-file: 'ruby4_rspec_full_sqlite_results.json'
+          billing-enabled: ${{ matrix.billing-enabled }}
+          results-file: 'ruby4_rspec_full_sqlite_billing_${{ matrix.billing-enabled }}_results.json'
 
   ruby-integration-disabled:
     name: Ruby 4 · Integration (Disabled Mode)

--- a/apps/web/billing/operations/materialize_plans.rb
+++ b/apps/web/billing/operations/materialize_plans.rb
@@ -15,7 +15,7 @@ module Billing
     # @!attribute cascade [Hash, nil] { success:, failed:, total: } when cascade ran
     # @!attribute reason [String, nil] Human-readable reason for skip/fail
     MaterializePlansEvent = Data.define(
-      :event, :org_extid, :planid, :entitlements_count, :cascade, :reason,
+      :event, :org_extid, :planid, :entitlements_count, :cascade, :reason
     )
 
     # Aggregate result of MaterializePlans.call.
@@ -34,9 +34,14 @@ module Billing
     # @!attribute orgs_cascaded [Integer] Orgs where cascade was attempted
     # @!attribute errors [Array<Hash>] [{org_extid:, reason:}]
     MaterializePlansResult = Data.define(
-      :scanned, :succeeded, :failed,
-      :skipped_no_plan, :skipped_plan_filter,
-      :memberships_succeeded, :memberships_failed, :orgs_cascaded,
+      :scanned,
+      :succeeded,
+      :failed,
+      :skipped_no_plan,
+      :skipped_plan_filter,
+      :memberships_succeeded,
+      :memberships_failed,
+      :orgs_cascaded,
       :errors,
     )
 
@@ -120,7 +125,7 @@ module Billing
         log_start
         plans_cache = preload_plans
         @iterator.each_record(batch_size: @batch_size) { |org| process_org(org, plans_cache) }
-        result = build_result
+        result      = build_result
         log_end(result)
         result
       end
@@ -128,7 +133,7 @@ module Billing
       private
 
       def logger
-        Onetime.billing_logger
+        Onetime.ents_logger
       end
 
       # Preload all plans (~5) so no Redis reads happen inside the loop.
@@ -148,8 +153,12 @@ module Billing
         return if missing_plan?(org, plan)
 
         if @dry_run
-          emit(:would_materialize, org, planid: org.planid,
-                                        entitlements_count: plan.entitlements.size)
+          emit(
+            :would_materialize,
+            org,
+            planid: org.planid,
+            entitlements_count: plan.entitlements.size,
+          )
           @counts[:succeeded] += 1
           return
         end
@@ -178,19 +187,21 @@ module Billing
       def missing_plan?(org, plan)
         return false if plan
 
-        reason = "Plan '#{org.planid}' not found in catalog or config"
+        reason            = "Plan '#{org.planid}' not found in catalog or config"
         @counts[:failed] += 1
         @errors << { org_extid: org.extid, reason: reason }
         emit(:failed_plan_not_found, org, planid: org.planid, reason: reason)
         logger.warn 'Plan not found in catalog or config',
-          org_extid: org.extid, planid: org.planid
+          org_extid: org.extid,
+          planid: org.planid
         true
       end
 
       def materialize_and_cascade(org, plan)
         org.materialize_entitlements_from_plan(plan)
         logger.debug 'Materialized org entitlements',
-          org_extid: org.extid, planid: org.planid,
+          org_extid: org.extid,
+          planid: org.planid,
           entitlements_count: plan.entitlements.size
       rescue StandardError => ex
         record_org_write_failure(org, ex)
@@ -205,9 +216,13 @@ module Billing
         end
 
         @counts[:succeeded] += 1
-        emit(:materialized, org, planid: org.planid,
-                                 entitlements_count: plan.entitlements.size,
-                                 cascade: @cascade_payload)
+        emit(
+          :materialized,
+          org,
+          planid: org.planid,
+          entitlements_count: plan.entitlements.size,
+          cascade: @cascade_payload,
+        )
       ensure
         @cascade_payload = nil
       end
@@ -217,7 +232,9 @@ module Billing
         @errors << { org_extid: org.extid, reason: "Org write failed: #{ex.message}" }
         emit(:failed_org_write, org, planid: org.planid, reason: ex.message)
         logger.error 'Org write failed',
-          org_extid: org.extid, planid: org.planid, exception: ex
+          org_extid: org.extid,
+          planid: org.planid,
+          exception: ex
       end
 
       # Cascade to memberships. Returns :ok or :failed.
@@ -248,7 +265,6 @@ module Billing
         failed      = 0
 
         memberships.each do |membership|
-          begin
             if membership.materialize_for_role!(org)
               succeeded += 1
               details   << build_membership_detail(membership, org, :ok)
@@ -267,20 +283,19 @@ module Billing
                 membership_objid: membership.objid,
                 role: membership.role
             end
-          rescue StandardError => ex
+        rescue StandardError => ex
             failed  += 1
             details << build_membership_detail(membership, org, :failed, error: ex.message)
             logger.error 'Membership re-materialization failed',
               org_extid: org.extid,
               membership_objid: membership.objid,
               exception: ex
-          end
         end
 
         cascade_result = {
           success: succeeded,
-          failed:  failed,
-          total:   memberships.size,
+          failed: failed,
+          total: memberships.size,
           details: details,
         }
 
@@ -308,35 +323,42 @@ module Billing
       # renderer for --verbose output and by audit-log consumers.
       def build_membership_detail(membership, org, status, error: nil)
         {
-          objid:              membership.objid,
-          role:               membership.role,
-          planid:             org.planid,
+          objid: membership.objid,
+          role: membership.role,
+          planid: org.planid,
           entitlements_count: status == :ok ? membership.materialized_entitlements.size : nil,
-          status:             status,
-          error:              error,
+          status: status,
+          error: error,
         }
       end
 
       def handle_cascade_partial(org, cascade_result)
-        reason = "Cascade had #{cascade_result[:failed]}/#{cascade_result[:total]} membership failures"
+        reason            = "Cascade had #{cascade_result[:failed]}/#{cascade_result[:total]} membership failures"
         @counts[:failed] += 1
         @errors << { org_extid: org.extid, reason: reason }
-        emit(:failed_cascade, org, planid: org.planid,
-                                   cascade: cascade_result,
-                                   reason: reason)
+        emit(
+          :failed_cascade,
+          org,
+          planid: org.planid,
+          cascade: cascade_result,
+          reason: reason,
+        )
         logger.error 'Cascade had membership failures',
-          org_extid: org.extid, planid: org.planid,
+          org_extid: org.extid,
+          planid: org.planid,
           memberships_total: cascade_result[:total],
           memberships_failed: cascade_result[:failed]
       end
 
       def handle_cascade_exception(org, ex)
-        reason = "Cascade raised: #{ex.message}"
+        reason            = "Cascade raised: #{ex.message}"
         @counts[:failed] += 1
         @errors << { org_extid: org.extid, reason: reason }
         emit(:failed_cascade, org, planid: org.planid, reason: reason)
         logger.error 'Cascade raised',
-          org_extid: org.extid, planid: org.planid, exception: ex
+          org_extid: org.extid,
+          planid: org.planid,
+          exception: ex
       end
 
       def emit(event, org, planid: nil, entitlements_count: nil, cascade: nil, reason: nil)

--- a/apps/web/billing/spec/operations/materialize_plans_spec.rb
+++ b/apps/web/billing/spec/operations/materialize_plans_spec.rb
@@ -50,8 +50,8 @@ RSpec.describe Billing::Operations::MaterializePlans, :billing_cli do
     allow(Onetime::OrganizationMembership).to receive(:active_for_org).with(org).and_return(memberships)
 
     # Route the operation's logger to a controllable fake so tests can
-    # assert on log calls without depending on the live billing category.
-    allow(Onetime).to receive(:billing_logger).and_return(fake_logger)
+    # assert on log calls without depending on the live ents category.
+    allow(Onetime).to receive(:ents_logger).and_return(fake_logger)
   end
 
   describe '.call' do

--- a/lib/onetime/models/organization.rb
+++ b/lib/onetime/models/organization.rb
@@ -296,14 +296,14 @@ module Onetime
       end
 
       result = {
-        success:    total - failed.size,
-        failed:     failed.size,
-        total:      total,
+        success: total - failed.size,
+        failed: failed.size,
+        total: total,
         failed_ids: failed.map(&:objid),
       }
 
       OT.info "[rematerialize_all_memberships!] org=#{extid} " \
-        "success=#{result[:success]} failed=#{result[:failed]} total=#{result[:total]}"
+              "success=#{result[:success]} failed=#{result[:failed]} total=#{result[:total]}"
       result
     end
 

--- a/lib/onetime/models/organization/chores/materialize_standalone_entitlements.rb
+++ b/lib/onetime/models/organization/chores/materialize_standalone_entitlements.rb
@@ -66,10 +66,6 @@ Onetime::Organization.chore :materialize_standalone_entitlements do |org|
   begin
     cascade = org.rematerialize_all_memberships!
 
-    # Cross-path consistency with MaterializePlans#handle_cascade_partial: surface a
-    # partial cascade as :error so operators learn about drifted memberships.
-    # Observability only — do NOT abort the chore or fail the org: there is no
-    # results aggregator here, and the org itself was materialized successfully.
     if cascade[:failed].to_i.positive?
       logger.error 'Membership re-materialization had failures',
         chore: :materialize_standalone_entitlements,


### PR DESCRIPTION
## Summary

- Adds `billing-enabled` input to the `run-ruby-tests` composite action so callers can explicitly control `BILLING_ENABLED` in test runs (fixes a bug where the job summary always showed `false` due to a broken env fallback)
- Replaces three separate full-mode integration jobs (`ruby-integration-full-sqlite`, `ruby-integration-full-postgres` x2) with a single `ruby-integration-full` matrix job producing four PR checks: SQLite x billing on/off, PG x billing on/off
- Aligns `ruby-4-preview.yml` full-mode job with the same billing matrix convention

Also includes two prerequisite fixes riding on this branch:
- #3258: emit `:error` on partial cascade failure in `rematerialize_all_memberships!`
- #3257: route `MaterializePlans` logger to `ents_logger`

Resolves #3289

## Test plan

- [ ] CI produces four distinct "Ruby Integration (Full, ...)" checks on this PR
- [ ] Each check's job summary shows correct billing state (true/false)
- [ ] All four matrix entries pass (or fail for legitimate reasons, not config)
- [ ] Downstream jobs (Container Validation, Aggregate, CI Metrics) wait on the matrix job correctly
- [ ] No references to old job names `ruby-integration-full-sqlite` or `ruby-integration-full-postgres` remain