### PR TITLE
Support DB-agnostic auth specs on PostgreSQL

### DIFF
--- a/.github/actions/run-ruby-tests/action.yml
+++ b/.github/actions/run-ruby-tests/action.yml
@@ -97,6 +97,10 @@ inputs:
     description: 'Enable billing features for this test run'
     required: false
     default: 'false'
+  db-engine:
+    description: 'Database engine label for job summary (e.g., sqlite, postgres)'
+    required: false
+    default: ''
 
 runs:
   using: composite
@@ -122,6 +126,8 @@ runs:
         elif [ "$TEST_TYPE" == "integration" ]; then
           if [ "$AUTH_MODE" == "full" ] && [ "$RSPEC_TAG" == "postgres_database" ]; then
             echo "rspec-task=spec:integration:full:postgres" >> $GITHUB_OUTPUT
+          elif [ "$AUTH_MODE" == "full" ] && [ "$RSPEC_TAG" == "agnostic_on_pg" ]; then
+            echo "rspec-task=spec:integration:full:agnostic_on_pg" >> $GITHUB_OUTPUT
           else
             echo "rspec-task=spec:integration:$AUTH_MODE" >> $GITHUB_OUTPUT
           fi
@@ -258,6 +264,7 @@ runs:
       env:
         AUTH_MODE: ${{ inputs.auth-mode }}
         BILLING_ENABLED: ${{ inputs.billing-enabled }}
+        DB_ENGINE: ${{ inputs.db-engine }}
       run: |
         echo "## Ruby Test Results" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
@@ -265,6 +272,9 @@ runs:
         echo "|---------|-------|" >> $GITHUB_STEP_SUMMARY
         echo "| auth | ${AUTH_MODE} |" >> $GITHUB_STEP_SUMMARY
         echo "| billing | ${BILLING_ENABLED} |" >> $GITHUB_STEP_SUMMARY
+        if [ -n "${DB_ENGINE}" ]; then
+          echo "| db engine | ${DB_ENGINE} |" >> $GITHUB_STEP_SUMMARY
+        fi
         echo "" >> $GITHUB_STEP_SUMMARY
 
         if [ -n "${{ steps.rake-tasks.outputs.tryouts-task }}" ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -513,6 +513,20 @@ jobs:
             auth-database-url-migrations: 'postgresql://onetime_migrator:migratepass@localhost:5432/onetime_auth_test'
             rspec-tag: 'postgres_database'
             results-file: 'rspec_full_postgres_billing_on_results.json'
+          - name: 'PG agnostic, billing: off'
+            db: postgres
+            billing-enabled: 'false'
+            auth-database-url: 'postgresql://onetime_user:testpass@localhost:5432/onetime_auth_test'
+            auth-database-url-migrations: 'postgresql://onetime_migrator:migratepass@localhost:5432/onetime_auth_test'
+            rspec-tag: 'agnostic_on_pg'
+            results-file: 'rspec_full_pg_agnostic_billing_off_results.json'
+          - name: 'PG agnostic, billing: on'
+            db: postgres
+            billing-enabled: 'true'
+            auth-database-url: 'postgresql://onetime_user:testpass@localhost:5432/onetime_auth_test'
+            auth-database-url-migrations: 'postgresql://onetime_migrator:migratepass@localhost:5432/onetime_auth_test'
+            rspec-tag: 'agnostic_on_pg'
+            results-file: 'rspec_full_pg_agnostic_billing_on_results.json'
 
     services:
       redis: *valkey-service
@@ -614,6 +628,7 @@ jobs:
           rabbitmq-url: 'amqp://guest:guest@localhost:5672'
           billing-enabled: ${{ matrix.billing-enabled }}
           results-file: ${{ matrix.results-file }}
+          db-engine: ${{ matrix.db }}
 
   ruby-integration-disabled:
     name: T3 · Ruby Integration (Disabled Mode)

--- a/apps/web/auth/spec/integration/full/invite_signup_autologin_internal_request_spec.rb
+++ b/apps/web/auth/spec/integration/full/invite_signup_autologin_internal_request_spec.rb
@@ -222,13 +222,24 @@ RSpec.describe 'Invite signup via Rodauth internal_request (issue #3221)', type:
     expect(untouched.pending?).to be(true)
   ensure
     # Cleanup any orphaned records created if the validation didn't block signup.
-    # Disable FK checks to allow deletion in any order without constraint errors.
     if defined?(other_email)
       Onetime::Customer.find_by_email(other_email)&.destroy!
       db = Auth::Database.connection
-      db.run('PRAGMA foreign_keys = OFF')
-      db[:accounts].where(email: other_email).delete
-      db.run('PRAGMA foreign_keys = ON')
+      if db.database_type == :sqlite
+        db.run('PRAGMA foreign_keys = OFF')
+        db[:accounts].where(email: other_email).delete
+        db.run('PRAGMA foreign_keys = ON')
+      else
+        account_row = db[:accounts].where(email: other_email).first
+        if account_row
+          AuthAccountFactory::RODAUTH_TABLES.each do |table|
+            next if table == :accounts
+            next unless db.table_exists?(table)
+            db[table].where(account_id: account_row[:id]).delete rescue nil
+          end
+          db[:accounts].where(email: other_email).delete
+        end
+      end
     end
   end
 end

--- a/apps/web/auth/spec/integration/full/migrations/migrations_sqlite_spec.rb
+++ b/apps/web/auth/spec/integration/full/migrations/migrations_sqlite_spec.rb
@@ -7,7 +7,7 @@ require 'support/helpers/migration_test_helpers'
 
 # Test SQLite migrations without full application boot
 # These tests directly use Sequel::Migrator and don't require Redis/Familia
-RSpec.describe 'Auth::Migrator SQLite Integration' do
+RSpec.describe 'Auth::Migrator SQLite Integration', :sqlite_database do
   include MigrationTestHelpers
 
   let(:migrations_dir) { File.join(Onetime::HOME, 'apps', 'web', 'auth', 'migrations') }

--- a/lib/tasks/spec.rake
+++ b/lib/tasks/spec.rake
@@ -170,10 +170,16 @@ namespace :spec do
       migration_url = ENV.fetch('AUTH_DATABASE_URL_MIGRATIONS', nil)
       env['AUTH_DATABASE_URL_MIGRATIONS'] = migration_url if migration_url
 
+      # Root-level specs MUST load before app-level specs. The root spec_helper
+      # registers define_derived_metadata for :full_auth_mode (matched by file
+      # path). If app-level specs load first, their RSpec.describe creates
+      # metadata before the derivation rule exists, so :full_auth_mode is never
+      # set and FullModeSuiteDatabase.setup! never fires — leaving the PG
+      # database without tables (seed-dependent "accounts does not exist").
       patterns = [
-        *Dir.glob('apps/*/*/spec/integration/full'),
         'spec/integration/full',
         'spec/integration/all',
+        *Dir.glob('apps/*/*/spec/integration/full'),
       ]
       sh env, "bundle exec rspec #{patterns.join(' ')} --tag ~postgres_database --tag ~sqlite_database #{rspec_format_options}"
     end

--- a/lib/tasks/spec.rake
+++ b/lib/tasks/spec.rake
@@ -140,7 +140,7 @@ namespace :spec do
       end
     end
 
-    desc 'Run full mode with PostgreSQL'
+    desc 'Run full mode with PostgreSQL (PG-only specs)'
     task 'full:postgres' do
       env      = {
         'RACK_ENV' => 'test',
@@ -155,6 +155,27 @@ namespace :spec do
         'spec/integration/full',
       ]
       sh env, "bundle exec rspec #{patterns.join(' ')} --tag postgres_database #{rspec_format_options}"
+    end
+
+    desc 'Run DB-agnostic full mode specs against PostgreSQL'
+    task 'full:agnostic_on_pg' do
+      env = {
+        'RACK_ENV' => 'test',
+        'AUTHENTICATION_MODE' => 'full',
+        'AUTH_DATABASE_URL' => ENV.fetch(
+          'AUTH_DATABASE_URL',
+          'postgresql://postgres@localhost:5432/onetime_auth_test',
+        ),
+      }
+      migration_url = ENV.fetch('AUTH_DATABASE_URL_MIGRATIONS', nil)
+      env['AUTH_DATABASE_URL_MIGRATIONS'] = migration_url if migration_url
+
+      patterns = [
+        *Dir.glob('apps/*/*/spec/integration/full'),
+        'spec/integration/full',
+        'spec/integration/all',
+      ]
+      sh env, "bundle exec rspec #{patterns.join(' ')} --tag ~postgres_database --tag ~sqlite_database #{rspec_format_options}"
     end
 
     desc 'Run all integration tests (all modes, isolated processes)'

--- a/spec/support/full_mode_suite_database.rb
+++ b/spec/support/full_mode_suite_database.rb
@@ -57,6 +57,11 @@ module FullModeSuiteDatabase
       if @using_postgres
         clean_postgres_for_setup
         run_postgres_migrations
+        tables_on_user = @database.tables rescue []
+        tables_on_migrator = @migration_database&.tables rescue []
+        warn "[FullModeSuiteDatabase] PG migration complete."
+        warn "[FullModeSuiteDatabase]   user conn tables (#{@database.opts[:user]}): #{tables_on_user.sort.inspect}"
+        warn "[FullModeSuiteDatabase]   migrator conn tables: #{tables_on_migrator.sort.inspect}"
       else
         migrations_path = File.join(Onetime::HOME, 'apps', 'web', 'auth', 'migrations')
         Sequel::Migrator.run(@database, migrations_path)
@@ -273,7 +278,12 @@ RSpec.configure do |config|
     db_url = ENV.fetch('AUTH_DATABASE_URL', '')
     auth_mode = ENV.fetch('AUTHENTICATION_MODE', 'simple')
     if auth_mode == 'full' && db_url.start_with?('postgresql://', 'postgres://')
+      warn "[FullModeSuiteDatabase] before(:suite) triggering early PG setup (url=#{db_url[0..30]}...)"
       FullModeSuiteDatabase.setup!
+      warn "[FullModeSuiteDatabase] before(:suite) complete. setup_complete?=#{FullModeSuiteDatabase.setup_complete?}"
+      warn "[FullModeSuiteDatabase] database.tables=#{FullModeSuiteDatabase.database&.tables&.sort&.inspect}"
+    else
+      warn "[FullModeSuiteDatabase] before(:suite) skipped (auth_mode=#{auth_mode}, db_url_prefix=#{db_url[0..15]})"
     end
   end
 

--- a/spec/support/full_mode_suite_database.rb
+++ b/spec/support/full_mode_suite_database.rb
@@ -7,9 +7,10 @@ require_relative 'factories/auth_account_factory'
 
 # Suite-level database setup for full auth mode tests.
 #
-# Creates a single in-memory SQLite database shared across all :full_auth_mode
-# tagged specs within a test suite run. This avoids the overhead of creating
-# and migrating a database per-file or per-test.
+# Connects to whatever AUTH_DATABASE_URL specifies — SQLite (in-memory or
+# file-backed) or PostgreSQL — so the same DB-agnostic specs can run against
+# either engine. When no URL is set, defaults to in-memory SQLite for local
+# development speed.
 #
 # The database is lazily initialized when the first :full_auth_mode spec runs,
 # and torn down only at suite end. This ensures:
@@ -31,7 +32,7 @@ require_relative 'factories/auth_account_factory'
 #
 module FullModeSuiteDatabase
   class << self
-    attr_reader :database
+    attr_reader :database, :migration_database
 
     def setup!
       return if @setup_complete
@@ -40,19 +41,26 @@ module FullModeSuiteDatabase
       require 'auth/database'
       Sequel.extension :migration
 
-      # Use SQLite for non-PostgreSQL full auth mode tests.
-      # AUTH_DATABASE_URL is reserved for PostgreSQL tests (see postgres_mode_suite_database.rb).
-      # Only use AUTH_DATABASE_URL if it's explicitly a SQLite URL (for CI file-based SQLite).
       database_url = ENV.fetch('AUTH_DATABASE_URL', nil)
-      @database = if database_url && database_url.start_with?('sqlite')
+
+      @using_postgres = database_url &&
+                        database_url.start_with?('postgresql://', 'postgres://')
+
+      @database = if @using_postgres
+        Sequel.connect(database_url)
+      elsif database_url && database_url.start_with?('sqlite')
         Sequel.connect(database_url)
       else
-        Sequel.sqlite  # In-memory SQLite for local development
+        Sequel.sqlite
       end
 
-      # Run Rodauth migrations
-      migrations_path = File.join(Onetime::HOME, 'apps', 'web', 'auth', 'migrations')
-      Sequel::Migrator.run(@database, migrations_path)
+      if @using_postgres
+        clean_postgres_for_setup
+        run_postgres_migrations
+      else
+        migrations_path = File.join(Onetime::HOME, 'apps', 'web', 'auth', 'migrations')
+        Sequel::Migrator.run(@database, migrations_path)
+      end
 
       # Save original connection method for restoration
       @original_connection_method = Auth::Database.method(:connection)
@@ -94,6 +102,8 @@ module FullModeSuiteDatabase
     def teardown!
       return unless @setup_complete
 
+      @migration_database&.disconnect
+      @migration_database = nil
       @database&.disconnect
       @database = nil
 
@@ -117,25 +127,94 @@ module FullModeSuiteDatabase
       @setup_complete == true
     end
 
+    def postgres?
+      @using_postgres == true
+    end
+
+    def engine_label
+      postgres? ? 'PostgreSQL' : 'SQLite'
+    end
+
     # Clean all Rodauth tables (for tests that need a fresh database state)
     def clean_tables!
       return unless @database
 
+      if postgres?
+        clean_tables_postgres!
+      else
+        clean_tables_sqlite!
+      end
+    end
+
+    private
+
+    def clean_tables_sqlite!
       AuthAccountFactory::RODAUTH_TABLES.each do |table|
         @database[table].delete if @database.table_exists?(table)
       rescue Sequel::DatabaseError
         nil
       end
     end
+
+    def clean_tables_postgres!
+      db = @migration_database || @database
+      AuthAccountFactory::RODAUTH_TABLES.each do |table|
+        next unless db.table_exists?(table)
+        db[table].truncate(cascade: true)
+      rescue Sequel::DatabaseError => e
+        warn "Failed to truncate #{table}: #{e.message}"
+      end
+    end
+
+    # Drop all tables so migrations re-run from scratch on PostgreSQL.
+    # Mirrors PostgresModeSuiteDatabase#clean_database_for_setup.
+    def clean_postgres_for_setup
+      migration_url = ENV['AUTH_DATABASE_URL_MIGRATIONS']
+      use_elevated = migration_url &&
+                     !migration_url.to_s.empty? &&
+                     migration_url != ENV['AUTH_DATABASE_URL']
+
+      if use_elevated
+        elevated_db = Sequel.connect(migration_url)
+        begin
+          drop_all_tables(elevated_db)
+        ensure
+          elevated_db.disconnect
+        end
+      else
+        drop_all_tables(@database)
+      end
+    end
+
+    def drop_all_tables(db)
+      tables = db.tables
+      return unless tables.any?
+
+      table_list = tables.map { |t| db.literal(Sequel.identifier(t)) }.join(', ')
+      db.run "DROP TABLE IF EXISTS #{table_list} CASCADE"
+    end
+
+    def run_postgres_migrations
+      migrations_path = File.join(Onetime::HOME, 'apps', 'web', 'auth', 'migrations')
+      migration_url = ENV['AUTH_DATABASE_URL_MIGRATIONS']
+
+      if migration_url && !migration_url.to_s.empty? && migration_url != ENV['AUTH_DATABASE_URL']
+        @migration_database ||= Sequel.connect(migration_url)
+        Sequel::Migrator.run(@migration_database, migrations_path)
+      else
+        Sequel::Migrator.run(@database, migrations_path)
+        @migration_database = nil
+      end
+    end
   end
 end
 
-# RSpec configuration for full auth mode tests with SQLite
+# RSpec configuration for full auth mode tests (SQLite or PostgreSQL)
 RSpec.configure do |config|
   # Database setup lambda - shared between :full_auth_mode and :sqlite_database tags
   # Setup is idempotent, so it's safe if multiple hooks trigger it
   full_mode_setup = lambda do |example_or_group|
-    # Skip if this is a PostgreSQL test
+    # Skip if this is a PG-only spec (handled by PostgresModeSuiteDatabase)
     metadata = example_or_group.respond_to?(:metadata) ? example_or_group.metadata : example_or_group.class.metadata
     return if metadata[:postgres_database]
 
@@ -150,7 +229,7 @@ RSpec.configure do |config|
   end
 
   # Lazy setup for :full_auth_mode specs (derived from spec/integration/full/ directory)
-  # This ensures SQLite database is set up even without explicit :sqlite_database tag
+  # This ensures the database is set up even without explicit :sqlite_database tag
   config.before(:context, :full_auth_mode, &full_mode_setup)
   config.after(:context, :full_auth_mode, &full_mode_cleanup)
 
@@ -175,6 +254,9 @@ RSpec.configure do |config|
   # Suite-level teardown: only runs once at the very end
   # Note: Simple/disabled mode tests explicitly clear the stub if needed
   config.after(:suite) do
+    if FullModeSuiteDatabase.setup_complete?
+      warn "[FullModeSuiteDatabase] Suite ran on #{FullModeSuiteDatabase.engine_label}"
+    end
     FullModeSuiteDatabase.teardown!
   end
 

--- a/spec/support/full_mode_suite_database.rb
+++ b/spec/support/full_mode_suite_database.rb
@@ -57,11 +57,6 @@ module FullModeSuiteDatabase
       if @using_postgres
         clean_postgres_for_setup
         run_postgres_migrations
-        tables_on_user = @database.tables rescue []
-        tables_on_migrator = @migration_database&.tables rescue []
-        warn "[FullModeSuiteDatabase] PG migration complete."
-        warn "[FullModeSuiteDatabase]   user conn tables (#{@database.opts[:user]}): #{tables_on_user.sort.inspect}"
-        warn "[FullModeSuiteDatabase]   migrator conn tables: #{tables_on_migrator.sort.inspect}"
       else
         migrations_path = File.join(Onetime::HOME, 'apps', 'web', 'auth', 'migrations')
         Sequel::Migrator.run(@database, migrations_path)
@@ -278,12 +273,7 @@ RSpec.configure do |config|
     db_url = ENV.fetch('AUTH_DATABASE_URL', '')
     auth_mode = ENV.fetch('AUTHENTICATION_MODE', 'simple')
     if auth_mode == 'full' && db_url.start_with?('postgresql://', 'postgres://')
-      warn "[FullModeSuiteDatabase] before(:suite) triggering early PG setup (url=#{db_url[0..30]}...)"
       FullModeSuiteDatabase.setup!
-      warn "[FullModeSuiteDatabase] before(:suite) complete. setup_complete?=#{FullModeSuiteDatabase.setup_complete?}"
-      warn "[FullModeSuiteDatabase] database.tables=#{FullModeSuiteDatabase.database&.tables&.sort&.inspect}"
-    else
-      warn "[FullModeSuiteDatabase] before(:suite) skipped (auth_mode=#{auth_mode}, db_url_prefix=#{db_url[0..15]})"
     end
   end
 

--- a/spec/support/full_mode_suite_database.rb
+++ b/spec/support/full_mode_suite_database.rb
@@ -160,7 +160,7 @@ module FullModeSuiteDatabase
       db = @migration_database || @database
       AuthAccountFactory::RODAUTH_TABLES.each do |table|
         next unless db.table_exists?(table)
-        db[table].truncate(cascade: true)
+        db[table].truncate(cascade: true, restart: true)
       rescue Sequel::DatabaseError => e
         warn "Failed to truncate #{table}: #{e.message}"
       end
@@ -188,10 +188,23 @@ module FullModeSuiteDatabase
 
     def drop_all_tables(db)
       tables = db.tables
-      return unless tables.any?
+      if tables.any?
+        table_list = tables.map { |t| db.literal(Sequel.identifier(t)) }.join(', ')
+        db.run "DROP TABLE IF EXISTS #{table_list} CASCADE"
+      end
 
-      table_list = tables.map { |t| db.literal(Sequel.identifier(t)) }.join(', ')
-      db.run "DROP TABLE IF EXISTS #{table_list} CASCADE"
+      our_functions = %w[
+        rodauth_get_salt
+        rodauth_valid_password_hash
+        cleanup_expired_tokens
+        update_last_login_time
+        cleanup_expired_tokens_extended
+        update_accounts_updated_at
+        update_session_last_use
+        cleanup_old_audit_logs
+        get_account_security_summary
+      ]
+      db.run "DROP FUNCTION IF EXISTS #{our_functions.join(', ')} CASCADE"
     end
 
     def run_postgres_migrations

--- a/spec/support/full_mode_suite_database.rb
+++ b/spec/support/full_mode_suite_database.rb
@@ -47,7 +47,7 @@ module FullModeSuiteDatabase
                         database_url.start_with?('postgresql://', 'postgres://')
 
       @database = if @using_postgres
-        Sequel.connect(database_url)
+        Sequel.connect(database_url).tap { |db| db.extension :date_arithmetic }
       elsif database_url && database_url.start_with?('sqlite')
         Sequel.connect(database_url)
       else

--- a/spec/support/full_mode_suite_database.rb
+++ b/spec/support/full_mode_suite_database.rb
@@ -264,6 +264,19 @@ RSpec.configure do |config|
   config.after(:each, :full_auth_mode, &full_mode_per_test_cleanup)
   config.after(:each, :sqlite_database, &full_mode_per_test_cleanup)
 
+  # Early PG setup: when AUTH_DATABASE_URL is PostgreSQL and mode is full,
+  # run FullModeSuiteDatabase.setup! at suite start so tables exist before
+  # any example — regardless of RSpec seed or context ordering. Without this,
+  # app-level specs whose metadata derives :full_auth_mode too late can hit
+  # the PG database before migrations run.
+  config.before(:suite) do
+    db_url = ENV.fetch('AUTH_DATABASE_URL', '')
+    auth_mode = ENV.fetch('AUTHENTICATION_MODE', 'simple')
+    if auth_mode == 'full' && db_url.start_with?('postgresql://', 'postgres://')
+      FullModeSuiteDatabase.setup!
+    end
+  end
+
   # Suite-level teardown: only runs once at the very end
   # Note: Simple/disabled mode tests explicitly clear the stub if needed
   config.after(:suite) do

--- a/spec/support/postgres_mode_suite_database.rb
+++ b/spec/support/postgres_mode_suite_database.rb
@@ -105,7 +105,7 @@ module PostgresModeSuiteDatabase
       database_url = ENV['AUTH_DATABASE_URL']
 
       # Create PostgreSQL database connection
-      @database = Sequel.connect(database_url)
+      @database = Sequel.connect(database_url).tap { |db| db.extension :date_arithmetic }
 
       # Verify we're connected to PostgreSQL
       unless @database.database_type == :postgres


### PR DESCRIPTION
## Summary

The ~42 DB-agnostic full-mode integration specs (auth hooks, env toggles, SSO, rodauth lifecycle, admin interface, etc.) never ran against PostgreSQL. `FullModeSuiteDatabase.setup!` silently rejected PostgreSQL URLs, falling back to in-memory SQLite even when `AUTH_DATABASE_URL` pointed at PG.

- Makes `FullModeSuiteDatabase` honor PostgreSQL `AUTH_DATABASE_URL` values, mirroring `PostgresModeSuiteDatabase` patterns (privilege separation, TRUNCATE CASCADE cleanup, migration connection)
- Adds `:sqlite_database` tag to `migrations_sqlite_spec.rb` so it is excluded from PG runs
- Adds rake task `spec:integration:full:agnostic_on_pg` that runs `--tag ~postgres_database --tag ~sqlite_database` against PG
- Adds CI matrix entries (PG agnostic, billing: off/on) to the `ruby-integration-full` job
- Routes the new `agnostic_on_pg` rspec-tag through `run-ruby-tests` action
- Shows db engine in CI job summary

Existing SQLite and PG-only CI jobs are unaffected.

Closes #3292

## Test plan

- [ ] New "PG agnostic" CI matrix entries pass (billing off + on)
- [ ] Existing SQLite CI jobs still pass unchanged
- [ ] Existing PG-only CI jobs still pass unchanged
- [ ] Job summary shows `db engine` row for full-mode variants
- [ ] `[FullModeSuiteDatabase] Suite ran on PostgreSQL` appears in agnostic-on-PG job logs

https://claude.ai/code/session_01KGH33gHRpJecZzvJTzhtKL