### PR TITLE
Persist user's sign-in mode preference with 30-day expiry

### DIFF
--- a/src/apps/session/components/PasswordlessFirstSignIn.vue
+++ b/src/apps/session/components/PasswordlessFirstSignIn.vue
@@ -103,6 +103,8 @@ const savedIndex = savedMode ? tabs.value.findIndex(tab => tab.id === savedMode)
 const selectedTabIndex = ref(savedIndex >= 0 ? savedIndex : 0);
 if (savedIndex >= 0 && savedMode) {
   saveSigninModePreference(savedMode);
+} else if (savedMode) {
+  try { localStorage.removeItem(SIGNIN_MODE_KEY); } catch { /* localStorage unavailable */ }
 }
 
 // Prefill email from query param (e.g., from invitation flow)

--- a/src/apps/session/components/PasswordlessFirstSignIn.vue
+++ b/src/apps/session/components/PasswordlessFirstSignIn.vue
@@ -32,6 +32,35 @@ const emit = defineEmits<{
   (e: 'mode-change', mode: AuthMode): void;
 }>();
 
+const SIGNIN_MODE_KEY = 'onetimeSigninMode';
+const SIGNIN_MODE_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+
+function loadSigninModePreference(): AuthMode | null {
+  try {
+    const stored = localStorage.getItem(SIGNIN_MODE_KEY);
+    if (!stored) return null;
+    const parsed = JSON.parse(stored);
+    if (parsed.expiresAt && Date.now() < parsed.expiresAt) {
+      return parsed.mode;
+    }
+    localStorage.removeItem(SIGNIN_MODE_KEY);
+  } catch {
+    localStorage.removeItem(SIGNIN_MODE_KEY);
+  }
+  return null;
+}
+
+function saveSigninModePreference(mode: AuthMode) {
+  try {
+    localStorage.setItem(SIGNIN_MODE_KEY, JSON.stringify({
+      mode,
+      expiresAt: Date.now() + SIGNIN_MODE_TTL_MS,
+    }));
+  } catch {
+    // localStorage unavailable
+  }
+}
+
 // Build dynamic tabs based on enabled features
 interface TabConfig {
   id: AuthMode;
@@ -57,8 +86,10 @@ const tabs = computed<TabConfig[]>(() => {
   return result;
 });
 
-// Tab index management
-const selectedTabIndex = ref(0);
+// Tab index management — restore saved preference if still valid
+const savedMode = loadSigninModePreference();
+const savedIndex = savedMode ? tabs.value.findIndex(tab => tab.id === savedMode) : -1;
+const selectedTabIndex = ref(savedIndex >= 0 ? savedIndex : 0);
 
 // Prefill email from query param (e.g., from invitation flow)
 // Single email ref shared across all auth tabs for consistent UX
@@ -109,6 +140,7 @@ const togglePasswordVisibility = () => {
 const handleTabChange = (index: number) => {
   selectedTabIndex.value = index;
   const mode = tabs.value[index]?.id ?? 'password';
+  saveSigninModePreference(mode);
 
   // Clear errors when switching tabs
   if (mode === 'passkey') {
@@ -144,9 +176,6 @@ const handleTryAgain = () => {
   clearMagicLinkState();
   email.value = '';
 };
-
-// Find tab index by mode ID (available for future use)
-const _getTabIndexByMode = (mode: AuthMode): number => tabs.value.findIndex(tab => tab.id === mode);
 
 // Check if a specific tab is the passkey tab
 const isPasskeyTab = (index: number): boolean => tabs.value[index]?.id === 'passkey';

--- a/src/apps/session/components/PasswordlessFirstSignIn.vue
+++ b/src/apps/session/components/PasswordlessFirstSignIn.vue
@@ -34,18 +34,24 @@ const emit = defineEmits<{
 
 const SIGNIN_MODE_KEY = 'onetimeSigninMode';
 const SIGNIN_MODE_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+const VALID_AUTH_MODES: readonly AuthMode[] = ['passkey', 'passwordless', 'password'];
+
+function isAuthMode(value: unknown): value is AuthMode {
+  return typeof value === 'string' && VALID_AUTH_MODES.includes(value as AuthMode);
+}
 
 function loadSigninModePreference(): AuthMode | null {
   try {
     const stored = localStorage.getItem(SIGNIN_MODE_KEY);
     if (!stored) return null;
     const parsed = JSON.parse(stored);
-    if (parsed.expiresAt && Date.now() < parsed.expiresAt) {
+    if (isAuthMode(parsed.mode) && parsed.expiresAt && Date.now() < parsed.expiresAt) {
+      saveSigninModePreference(parsed.mode);
       return parsed.mode;
     }
     localStorage.removeItem(SIGNIN_MODE_KEY);
   } catch {
-    localStorage.removeItem(SIGNIN_MODE_KEY);
+    try { localStorage.removeItem(SIGNIN_MODE_KEY); } catch { /* localStorage unavailable */ }
   }
   return null;
 }

--- a/src/apps/session/components/PasswordlessFirstSignIn.vue
+++ b/src/apps/session/components/PasswordlessFirstSignIn.vue
@@ -33,14 +33,15 @@ const emit = defineEmits<{
 }>();
 
 const SIGNIN_MODE_KEY = 'onetimeSigninMode';
-const SIGNIN_MODE_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+const SIGNIN_MODE_TTL_MS = 30 * ONE_DAY_MS;
 const VALID_AUTH_MODES: readonly AuthMode[] = ['passkey', 'passwordless', 'password'];
 
 function isAuthMode(value: unknown): value is AuthMode {
   return typeof value === 'string' && VALID_AUTH_MODES.includes(value as AuthMode);
 }
 
-function loadSigninModePreference(): AuthMode | null {
+function loadSigninModePreference(): { mode: AuthMode; expiresAt: number } | null {
   try {
     const stored = localStorage.getItem(SIGNIN_MODE_KEY);
     if (!stored) return null;
@@ -52,7 +53,7 @@ function loadSigninModePreference(): AuthMode | null {
       typeof parsed.expiresAt === 'number' &&
       Date.now() < parsed.expiresAt
     ) {
-      return parsed.mode;
+      return { mode: parsed.mode, expiresAt: parsed.expiresAt };
     }
     localStorage.removeItem(SIGNIN_MODE_KEY);
   } catch {
@@ -98,12 +99,15 @@ const tabs = computed<TabConfig[]>(() => {
 });
 
 // Tab index management — restore saved preference if the mode is still available
-const savedMode = loadSigninModePreference();
-const savedIndex = savedMode ? tabs.value.findIndex(tab => tab.id === savedMode) : -1;
+const savedPref = loadSigninModePreference();
+const savedIndex = savedPref ? tabs.value.findIndex(tab => tab.id === savedPref.mode) : -1;
 const selectedTabIndex = ref(savedIndex >= 0 ? savedIndex : 0);
-if (savedIndex >= 0 && savedMode) {
-  saveSigninModePreference(savedMode);
-} else if (savedMode) {
+if (savedIndex >= 0 && savedPref) {
+  const refreshThreshold = SIGNIN_MODE_TTL_MS - ONE_DAY_MS;
+  if (savedPref.expiresAt - Date.now() < refreshThreshold) {
+    saveSigninModePreference(savedPref.mode);
+  }
+} else if (savedPref) {
   try { localStorage.removeItem(SIGNIN_MODE_KEY); } catch { /* localStorage unavailable */ }
 }
 

--- a/src/apps/session/components/PasswordlessFirstSignIn.vue
+++ b/src/apps/session/components/PasswordlessFirstSignIn.vue
@@ -26,7 +26,8 @@ const props = withDefaults(defineProps<Props>(), {
   webauthnEnabled: false,
 });
 
-type AuthMode = 'passkey' | 'passwordless' | 'password';
+const VALID_AUTH_MODES = ['passkey', 'passwordless', 'password'] as const;
+type AuthMode = (typeof VALID_AUTH_MODES)[number];
 
 const emit = defineEmits<{
   (e: 'mode-change', mode: AuthMode): void;
@@ -35,10 +36,9 @@ const emit = defineEmits<{
 const SIGNIN_MODE_KEY = 'onetimeSigninMode';
 const ONE_DAY_MS = 24 * 60 * 60 * 1000;
 const SIGNIN_MODE_TTL_MS = 30 * ONE_DAY_MS;
-const VALID_AUTH_MODES: readonly AuthMode[] = ['passkey', 'passwordless', 'password'];
 
 function isAuthMode(value: unknown): value is AuthMode {
-  return typeof value === 'string' && VALID_AUTH_MODES.includes(value as AuthMode);
+  return typeof value === 'string' && (VALID_AUTH_MODES as readonly string[]).includes(value);
 }
 
 function loadSigninModePreference(): { mode: AuthMode; expiresAt: number } | null {

--- a/src/apps/session/components/PasswordlessFirstSignIn.vue
+++ b/src/apps/session/components/PasswordlessFirstSignIn.vue
@@ -107,6 +107,9 @@ if (savedIndex >= 0 && savedPref) {
   if (savedPref.expiresAt - Date.now() < refreshThreshold) {
     saveSigninModePreference(savedPref.mode);
   }
+  if (savedIndex > 0) {
+    emit('mode-change', savedPref.mode);
+  }
 } else if (savedPref) {
   try { localStorage.removeItem(SIGNIN_MODE_KEY); } catch { /* localStorage unavailable */ }
 }

--- a/src/apps/session/components/PasswordlessFirstSignIn.vue
+++ b/src/apps/session/components/PasswordlessFirstSignIn.vue
@@ -45,8 +45,13 @@ function loadSigninModePreference(): AuthMode | null {
     const stored = localStorage.getItem(SIGNIN_MODE_KEY);
     if (!stored) return null;
     const parsed = JSON.parse(stored);
-    if (isAuthMode(parsed.mode) && parsed.expiresAt && Date.now() < parsed.expiresAt) {
-      saveSigninModePreference(parsed.mode);
+    if (
+      parsed &&
+      typeof parsed === 'object' &&
+      isAuthMode(parsed.mode) &&
+      typeof parsed.expiresAt === 'number' &&
+      Date.now() < parsed.expiresAt
+    ) {
       return parsed.mode;
     }
     localStorage.removeItem(SIGNIN_MODE_KEY);
@@ -92,10 +97,13 @@ const tabs = computed<TabConfig[]>(() => {
   return result;
 });
 
-// Tab index management — restore saved preference if still valid
+// Tab index management — restore saved preference if the mode is still available
 const savedMode = loadSigninModePreference();
 const savedIndex = savedMode ? tabs.value.findIndex(tab => tab.id === savedMode) : -1;
 const selectedTabIndex = ref(savedIndex >= 0 ? savedIndex : 0);
+if (savedIndex >= 0 && savedMode) {
+  saveSigninModePreference(savedMode);
+}
 
 // Prefill email from query param (e.g., from invitation flow)
 // Single email ref shared across all auth tabs for consistent UX


### PR DESCRIPTION
## Summary

Add localStorage-based persistence of the user's selected authentication mode (passkey, passwordless, or password) on the sign-in page. The preference is stored with a 30-day TTL and automatically restored on subsequent visits, improving UX by remembering the user's last chosen authentication method.

## Changes

- Added `loadSigninModePreference()` to retrieve and validate stored auth mode from localStorage with expiry checking
- Added `saveSigninModePreference()` to persist the selected auth mode with a 30-day expiration timestamp
- Updated tab initialization to restore the saved preference if still valid, falling back to the first tab otherwise
- Modified `handleTabChange()` to save the preference whenever the user switches authentication modes
- Removed unused `_getTabIndexByMode()` helper function
- Includes error handling for localStorage unavailability (private/incognito mode)

## Related Issues

<!-- Add issue number if applicable -->

## Test Plan

- Verify that selecting a different auth mode persists across page reloads
- Verify that the preference expires after 30 days (can be tested by manually adjusting stored timestamp)
- Verify that invalid or corrupted stored data is gracefully cleared
- Verify that the component works correctly in private/incognito mode where localStorage is unavailable
- Existing component tests should continue to pass

https://claude.ai/code/session_01415QRJDoXzSwBpo9NEfN16