### PR TITLE
[#3326] Entitlement-gate org tabs, free-plan billing UI, and plan definition updates

### DIFF
--- a/apps/web/billing/docs/plan-definitions.md
+++ b/apps/web/billing/docs/plan-definitions.md
@@ -37,6 +37,7 @@ Loaded from `etc/billing.yaml`.
 
 ### Collaboration
 
+- **`manage_orgs`**: Add and manage organizations on your account
 - **`manage_org`**: Can manage organization settings, members, and domains
 - **`manage_teams`**: Can create and manage teams
 - **`manage_members`**: Can create and manage organization members
@@ -55,6 +56,7 @@ Loaded from `etc/billing.yaml`.
 
 - **`api_access`**: Can use REST API endpoints
 - **`custom_domains`**: Can configure custom domains
+- **`manage_billing`**: Can manage billing details and change plans
 
 
 ## Plans Overview
@@ -82,13 +84,16 @@ Default tier for all users without subscription
 - `custom_domains`
 - `homepage_secrets`
 - `incoming_secrets`
+- `manage_orgs`
+- `manage_org`
 - `view_receipt`
 
 **Limits:**
 
 | Resource | Limit | Notes |
 |----------|-------|-------|
-| organizations | ∞ (unlimited) |  |
+| organizations | 10 |  |
+| total_members_per_org | 1 | Individual only |
 | members_per_org_max | 1 |  |
 | members_per_org | 1 |  |
 | role_members_per_org | 1 |  |
@@ -120,6 +125,8 @@ Original plan, grandfathered for existing customers
 - `homepage_secrets`
 - `incoming_secrets`
 - `manage_members`
+- `manage_billing`
+- `manage_orgs`
 - `manage_org`
 - `view_receipt`
 
@@ -129,8 +136,8 @@ Original plan, grandfathered for existing customers
 |----------|-------|-------|
 | custom_domains | ∞ (unlimited) |  |
 | organizations | 10 |  |
-| role_admins_per_org | 0 |  |
-| role_members_per_org | ∞ (unlimited) |  |
+| role_admins_per_org | 10 |  |
+| role_members_per_org | 50 |  |
 | role_owners_per_org | 1 |  |
 | secret_lifetime | 2592000 | 30 days |
 | secrets_per_day | ∞ (unlimited) |  |
@@ -158,6 +165,8 @@ For individuals needing custom domains and extended retention
 - `homepage_secrets`
 - `incoming_secrets`
 - `manage_members`
+- `manage_billing`
+- `manage_orgs`
 - `manage_org`
 - `view_receipt`
 
@@ -168,7 +177,7 @@ For individuals needing custom domains and extended retention
 | custom_domains | ∞ (unlimited) |  |
 | organizations | 10 |  |
 | role_admins_per_org | 0 |  |
-| role_members_per_org | ∞ (unlimited) |  |
+| role_members_per_org | 50 |  |
 | role_owners_per_org | 1 |  |
 | secret_lifetime | 2592000 | 30 days |
 | secrets_per_day | ∞ (unlimited) |  |
@@ -202,6 +211,7 @@ For teams needing collaboration features
 - `incoming_secrets`
 - `ip_access_rules`
 - `manage_members`
+- `manage_orgs`
 - `manage_org`
 - `manage_sso`
 - `manage_teams`
@@ -214,12 +224,12 @@ For teams needing collaboration features
 |----------|-------|-------|
 | custom_domains | ∞ (unlimited) |  |
 | organizations | 10 |  |
-| role_admins_per_org | ∞ (unlimited) |  |
-| role_members_per_org | ∞ (unlimited) |  |
-| role_owners_per_org | 1 |  |
+| role_admins_per_org | 50 |  |
+| role_members_per_org | 100 |  |
+| role_owners_per_org | 50 |  |
 | secret_lifetime | 2592000 | 30 days |
 | secrets_per_day | ∞ (unlimited) |  |
-| total_members_per_org | 1 | Individual only |
+| total_members_per_org | 100 |  |
 
 **Pricing:**
 - Monthly: $85.0 CAD

--- a/e2e/full/organization-settings.spec.ts
+++ b/e2e/full/organization-settings.spec.ts
@@ -531,6 +531,71 @@ test.describe('ORG-DETAIL: Organization Settings Page (/org/:extid/:tab?)', () =
     expect(getCurrentTab(page)).toBe('subscription');
   });
 
+  test('ORG-DETAIL-011: Back/forward to entitlement-gated tab redirects to domains', async ({ page }) => {
+    if (!testOrg) {
+      test.skip(true, 'No organizations available for testing');
+      return;
+    }
+
+    await page.goto(`/org/${testOrg.extid}`);
+    await page.waitForLoadState('networkidle');
+
+    // Check which tabs the user lacks access to
+    const membersTab = page.getByTestId('org-tab-members');
+    const ssoTab = page.getByTestId('org-tab-sso');
+    const hasMembersTab = await membersTab.isVisible().catch(() => false);
+    const hasSsoTab = await ssoTab.isVisible().catch(() => false);
+
+    // If user has access to both members and SSO, we can't test the redirect
+    if (hasMembersTab && hasSsoTab) {
+      test.skip(true, 'User has access to all tabs - cannot test entitlement redirect');
+      return;
+    }
+
+    // Determine which gated tab to test
+    const gatedTab = !hasMembersTab ? 'members' : 'sso';
+
+    // Navigate to domains, then settings to build history
+    await page.goto(`/org/${testOrg.extid}/domains`);
+    await page.waitForLoadState('networkidle');
+
+    const settingsTab = page.getByTestId('org-tab-settings');
+    await settingsTab.click();
+    await page.waitForURL(/\/settings/);
+
+    // Directly navigate to the gated tab URL (simulating a bookmark or typed URL)
+    await page.goto(`/org/${testOrg.extid}/${gatedTab}`);
+    await page.waitForLoadState('networkidle');
+
+    // Should redirect to domains since user lacks entitlement
+    await page.waitForURL(/\/domains/, { timeout: 5000 });
+    expect(getCurrentTab(page)).toBe('domains');
+
+    // Verify the domains tab is actually selected
+    const domainsTab = page.getByTestId('org-tab-domains');
+    await expect(domainsTab).toHaveAttribute('aria-selected', 'true');
+
+    // Now test back/forward: go to settings first
+    await settingsTab.click();
+    await page.waitForURL(/\/settings/);
+
+    // Manually push the gated URL into history via evaluate
+    await page.evaluate((url) => {
+      window.history.pushState({}, '', url);
+    }, `/org/${testOrg.extid}/${gatedTab}`);
+
+    // Go back (should land on the gated URL, then immediately redirect)
+    await page.goBack();
+    await page.waitForLoadState('networkidle');
+
+    // URL should be corrected to domains
+    await page.waitForURL(/\/domains/, { timeout: 5000 });
+    expect(getCurrentTab(page)).toBe('domains');
+
+    // Verify the UI state matches
+    await expect(domainsTab).toHaveAttribute('aria-selected', 'true');
+  });
+
   test('ORG-TAB-ORDER-001: Tabs render in correct visual order', async ({ page }) => {
     if (!testOrg) {
       test.skip(true, 'No organizations available for testing');
@@ -690,6 +755,7 @@ test.describe('ORG-A11Y: Organization Settings Accessibility', () => {
  * | ORG-DETAIL-008  | Back navigation to /orgs works                 | High       | Automated  |
  * | ORG-DETAIL-009  | Direct URL navigation to specific tabs works   | High       | Automated  |
  * | ORG-DETAIL-010  | Browser back/forward preserves tab state       | Medium     | Automated  |
+ * | ORG-DETAIL-011  | Back/forward to gated tab redirects to domains | High       | Automated  |
  * | ORG-TAB-ORDER-001| Tabs render in correct visual order           | High       | Automated  |
  * | ORG-ERROR-001   | Invalid org extid shows error state            | High       | Automated  |
  * | ORG-A11Y-001    | Tab navigation with keyboard (Arrow keys)      | Medium     | Automated  |

--- a/locales/content/en/00-common.json
+++ b/locales/content/en/00-common.json
@@ -1479,6 +1479,10 @@
     "context": "Feedback when content copied to clipboard",
     "content_hash": "8d525e5f"
   },
+  "web.COMMON.copy": {
+    "text": "Copy",
+    "context": "Tooltip for copy buttons"
+  },
   "web.COMMON.copy_email": {
     "text": "Copy email address",
     "context": "Tooltip for copy email button in user menu",

--- a/locales/content/en/workspace-billing.json
+++ b/locales/content/en/workspace-billing.json
@@ -215,6 +215,9 @@
     "text": "Manage Organization",
     "content_hash": "f03a4985"
   },
+  "web.billing.overview.entitlements.manage_orgs": {
+    "text": "Manage Organizations"
+  },
   "web.billing.overview.entitlements.manage_teams": {
     "text": "Manage Teams",
     "content_hash": "2a52d5b4"
@@ -230,6 +233,12 @@
   "web.billing.overview.entitlements.audit_logs": {
     "text": "Audit Logs",
     "content_hash": "5428d7fe"
+  },
+  "web.billing.overview.entitlements.manage_billing": {
+    "text": "Manage Billing"
+  },
+  "web.billing.overview.entitlements.custom_signup_validation": {
+    "text": "Custom Signup Validation"
   },
   "web.billing.overview.entitlements.sso": {
     "text": "Single Sign-On",

--- a/locales/content/en/workspace-billing.json
+++ b/locales/content/en/workspace-billing.json
@@ -296,6 +296,15 @@
     "text": "Member Management",
     "content_hash": "b38b89db"
   },
+  "web.billing.features.manage_orgs": {
+    "text": "Organization Management"
+  },
+  "web.billing.features.flexible_from_domain": {
+    "text": "Flexible Email Sender Domain"
+  },
+  "web.billing.features.unlimited_admins": {
+    "text": "Unlimited Administrators"
+  },
   "web.billing.features.audit_logs": {
     "text": "Audit Logs",
     "content_hash": "5428d7fe"

--- a/locales/content/en/workspace-organizations.json
+++ b/locales/content/en/workspace-organizations.json
@@ -239,6 +239,9 @@
     "text": "This will permanently delete the organization. This action cannot be undone.",
     "content_hash": "ab2d2c05"
   },
+  "web.organizations.delete_organization_remove_domains_first": {
+    "text": "Remove all custom domains before deleting this organization."
+  },
   "web.organizations.delete": {
     "text": "Delete",
     "content_hash": "e2d0a549"
@@ -285,6 +288,9 @@
   },
   "web.organizations.leave_organization_success": {
     "text": "You have left the organization."
+  },
+  "web.organizations.leave_error": {
+    "text": "Failed to leave organization"
   },
   "web.organizations.members.title": {
     "text": "Members",

--- a/src/apps/workspace/account/settings/OrganizationSettings.vue
+++ b/src/apps/workspace/account/settings/OrganizationSettings.vue
@@ -27,7 +27,7 @@ import { useOrganizationStore } from '@/shared/stores/organizationStore';
 import { storeToRefs } from 'pinia';
 import { useMembersStore } from '@/shared/stores/membersStore';
 import type { Subscription } from '@/types/billing';
-import { getPlanLabel, getSubscriptionStatusLabel, isLegacyPlan } from '@/types/billing';
+import { getPlanLabel, getSubscriptionStatusLabel, isFreePlan, isLegacyPlan } from '@/types/billing';
 import type { CreateInvitationPayload, Organization, OrganizationInvitation, OrganizationRole } from '@/types/organization';
 import { formatDisplayDate } from '@/utils/format';
 import { isOrgsSsoEnabled } from '@/utils/features';
@@ -311,8 +311,7 @@ watch(formData, () => {
   }
 }, { deep: true });
 
-// Billing email is only shown for paid plans (organizations with a planid set)
-const hasPaidPlan = computed(() => !!organization.value?.planid);
+const hasPaidPlan = computed(() => !isFreePlan(organization.value?.planid));
 
 // Legacy plan detection for grandfathered Early Supporter customers
 const isLegacyCustomer = computed(() =>

--- a/src/apps/workspace/account/settings/OrganizationSettings.vue
+++ b/src/apps/workspace/account/settings/OrganizationSettings.vue
@@ -124,8 +124,13 @@ watch(
     const urlTab = newTab as string | undefined;
     if (urlTab && URL_TO_TAB[urlTab]) {
       const resolved = URL_TO_TAB[urlTab];
-      if (resolved === 'members' && !canManageMembers.value) return;
-      if (resolved === 'sso' && !canManageSso.value) return;
+      if (
+        (resolved === 'members' && !canManageMembers.value) ||
+        (resolved === 'sso' && !canManageSso.value)
+      ) {
+        setActiveTab('domains');
+        return;
+      }
       activeTab.value = resolved;
     } else if (!urlTab) {
       activeTab.value = props.initialTab;

--- a/src/apps/workspace/account/settings/OrganizationSettings.vue
+++ b/src/apps/workspace/account/settings/OrganizationSettings.vue
@@ -116,13 +116,17 @@ const setActiveTab = (tab: TabType) => {
   router.replace({ params: { ...route.params, tab: urlTab } });
 };
 
-// Watch for route param changes (e.g., back/forward navigation)
+// Watch for route param changes (e.g., back/forward navigation).
+// Reject navigation to entitlement-gated tabs the user can't access.
 watch(
   () => route.params.tab,
   (newTab) => {
     const urlTab = newTab as string | undefined;
     if (urlTab && URL_TO_TAB[urlTab]) {
-      activeTab.value = URL_TO_TAB[urlTab];
+      const resolved = URL_TO_TAB[urlTab];
+      if (resolved === 'members' && !canManageMembers.value) return;
+      if (resolved === 'sso' && !canManageSso.value) return;
+      activeTab.value = resolved;
     } else if (!urlTab) {
       activeTab.value = props.initialTab;
     }
@@ -207,9 +211,15 @@ const { isRevealed: isLeaveRevealed, reveal: revealLeave, confirm: confirmLeave,
 
 const handleDeleteOrganization = async () => {
   const { isCanceled } = await revealDelete();
-  if (!isCanceled) {
+  if (isCanceled) return;
+
+  try {
     await organizationStore.deleteOrganization(orgId.value);
     router.push('/dashboard');
+  } catch (err) {
+    const classified = classifyError(err);
+    error.value = classified.message || t('web.organizations.delete_error');
+    console.error('[OrganizationSettings] Error deleting organization:', err);
   }
 };
 
@@ -218,9 +228,15 @@ const handleLeaveOrganization = async () => {
   if (!member) return;
 
   const { isCanceled } = await revealLeave();
-  if (!isCanceled) {
+  if (isCanceled) return;
+
+  try {
     await membersStore.removeMember(orgId.value, member.extid);
     router.push('/dashboard');
+  } catch (err) {
+    const classified = classifyError(err);
+    error.value = classified.message || t('web.organizations.leave_error');
+    console.error('[OrganizationSettings] Error leaving organization:', err);
   }
 };
 
@@ -572,6 +588,15 @@ onMounted(async () => {
 
   await loadOrganization();
 
+  // Redirect away from entitlement-gated tabs the user can't access
+  // (e.g. direct URL navigation to /org/.../members without manage_members)
+  if (
+    (activeTab.value === 'members' && !canManageMembers.value) ||
+    (activeTab.value === 'sso' && !canManageSso.value)
+  ) {
+    setActiveTab('domains');
+  }
+
   // Members are always loaded so the general tab's "Leave" button can
   // identify the current user's membership record.
   loadMembers();
@@ -649,11 +674,10 @@ watch(orgId, async (newOrgId, oldOrgId) => {
 
 // Keyboard navigation for tabs (WCAG 2.1 AA)
 const handleTabKeydown = (e: KeyboardEvent) => {
-  // Build visible tabs array dynamically based on entitlements
-  const tabs: TabType[] = ['domains', 'members'];
-  if (canManageSso.value) {
-    tabs.push('sso');
-  }
+  // Build navigable tabs array — only tabs the user can actually reach
+  const tabs: TabType[] = ['domains'];
+  if (canManageMembers.value) tabs.push('members');
+  if (canManageSso.value) tabs.push('sso');
   tabs.push('general');
 
   const currentIndex = tabs.indexOf(activeTab.value);
@@ -745,38 +769,44 @@ const handleTabKeydown = (e: KeyboardEvent) => {
             ]">
             {{ t('web.organizations.tabs.domains') }}
           </button>
-          <!-- Members tab -->
+          <!-- Members tab (entitlement-gated) -->
           <button
             id="org-tab-members"
             role="tab"
             :aria-selected="activeTab === 'members'"
+            :aria-disabled="!canManageMembers"
             :tabindex="activeTab === 'members' ? 0 : -1"
             aria-controls="org-panel-members"
             data-testid="org-tab-members"
-            @click="setActiveTab('members')"
+            @click="canManageMembers && setActiveTab('members')"
             :class="[
               'whitespace-nowrap border-b-2 px-1 py-4 text-sm font-medium',
-              activeTab === 'members'
-                ? 'border-brand-500 text-brand-600 dark:border-brand-400 dark:text-brand-400'
-                : 'border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700 dark:text-gray-400 dark:hover:border-gray-600 dark:hover:text-gray-300',
+              !canManageMembers
+                ? 'cursor-not-allowed border-transparent text-gray-400 dark:text-gray-600'
+                : activeTab === 'members'
+                  ? 'border-brand-500 text-brand-600 dark:border-brand-400 dark:text-brand-400'
+                  : 'border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700 dark:text-gray-400 dark:hover:border-gray-600 dark:hover:text-gray-300',
             ]">
             {{ t('web.organizations.tabs.members') }}
           </button>
-          <!-- SSO tab - single sign-on configuration (entitlement-gated) -->
+          <!-- SSO tab (feature-flag + entitlement-gated) -->
           <button
-            v-if="canManageSso"
+            v-if="isOrgsSsoEnabled()"
             id="org-tab-sso"
             role="tab"
             :aria-selected="activeTab === 'sso'"
+            :aria-disabled="!canManageSso"
             :tabindex="activeTab === 'sso' ? 0 : -1"
             aria-controls="org-panel-sso"
             data-testid="org-tab-sso"
-            @click="setActiveTab('sso')"
+            @click="canManageSso && setActiveTab('sso')"
             :class="[
               'whitespace-nowrap border-b-2 px-1 py-4 text-sm font-medium',
-              activeTab === 'sso'
-                ? 'border-brand-500 text-brand-600 dark:border-brand-400 dark:text-brand-400'
-                : 'border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700 dark:text-gray-400 dark:hover:border-gray-600 dark:hover:text-gray-300',
+              !canManageSso
+                ? 'cursor-not-allowed border-transparent text-gray-400 dark:text-gray-600'
+                : activeTab === 'sso'
+                  ? 'border-brand-500 text-brand-600 dark:border-brand-400 dark:text-brand-400'
+                  : 'border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700 dark:text-gray-400 dark:hover:border-gray-600 dark:hover:text-gray-300',
             ]">
             {{ t('web.organizations.tabs.sso') }}
           </button>

--- a/src/apps/workspace/billing/BillingOverview.vue
+++ b/src/apps/workspace/billing/BillingOverview.vue
@@ -13,7 +13,7 @@ import { classifyError } from '@/schemas/errors';
 import { BillingService, type FederationNotification as FederationNotificationData } from '@/services/billing.service';
 import { useOrganizationStore } from '@/shared/stores/organizationStore';
 import type { PaymentMethod } from '@/types/billing';
-import { getPlanLabel, isLegacyPlan } from '@/types/billing';
+import { getPlanLabel, isFreePlan, isLegacyPlan } from '@/types/billing';
 import type { Organization } from '@/types/organization';
 import { formatDisplayDate } from '@/utils/format';
 import { computed, onMounted, ref, watch } from 'vue';
@@ -62,9 +62,12 @@ const planName = computed(() => {
   return getPlanLabel(selectedOrg.value.planid);
 });
 
-const planStatus = computed(() => selectedOrg.value?.planid ? 'active' : 'free');
+const planStatus = computed(() => {
+  const planid = selectedOrg.value?.planid;
+  if (!planid || isFreePlan(planid)) return 'free';
+  return 'active';
+});
 
-// Billing email is only editable for paid plans
 const hasPaidPlan = computed(() => planStatus.value === 'active');
 
 // Legacy plan detection for grandfathered customers
@@ -282,13 +285,9 @@ onMounted(async () => {
                   {{ planName }}
                 </p>
                 <span
-                  :class="[
-                    'mt-2 inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium',
-                    planStatus === 'active'
-                      ? 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400'
-                      : 'bg-gray-100 text-gray-800 dark:bg-gray-900/30 dark:text-gray-400',
-                  ]">
-                  {{ planStatus === 'active' ? t('web.billing.subscription.active') : t('web.billing.plans.free_plan') }}
+                  v-if="hasPaidPlan"
+                  class="mt-2 inline-flex items-center rounded-full bg-green-100 px-2.5 py-0.5 text-xs font-medium text-green-800 dark:bg-green-900/30 dark:text-green-400">
+                  {{ t('web.billing.subscription.active') }}
                 </span>
                 <!-- Next Billing Date -->
                 <p

--- a/src/types/billing.ts
+++ b/src/types/billing.ts
@@ -48,6 +48,11 @@ export function isLegacyPlan(planId: string): boolean {
   return LEGACY_PLAN_IDS.some((legacy) => planId === legacy);
 }
 
+export function isFreePlan(planId: string | undefined | null): boolean {
+  if (!planId) return true;
+  return planId === 'free' || planId.startsWith('free_');
+}
+
 /**
  * Get detailed information about a legacy plan
  *


### PR DESCRIPTION
Follow-up to #3329 — these commits were finished but not pushed before that PR merged, so they missed the merge.

## What changed

- **Entitlement-gated org settings tabs** (`OrganizationSettings.vue`): Members and SSO tabs are disabled (not hidden) when the user lacks `manage_members` / `manage_sso`. Direct URL navigation to a gated tab now redirects to `domains` on mount and is rejected by the route-param watcher and keyboard navigation. SSO tab visibility is driven by the `isOrgsSsoEnabled()` feature flag, with the entitlement controlling whether it's interactive.
- **Free-plan billing UI**: Introduced `isFreePlan()` in `src/types/billing.ts` to treat `free` / `free_*` plan IDs as free. `BillingOverview.vue` and `OrganizationSettings.vue` now hide the Billing Contact card and the "Active" badge for free plans instead of keying off mere presence of `planid`.
- **Error handling**: Delete- and leave-organization handlers wrap the store call in try/catch and surface a classified error message.
- **Plan definitions** (`plan-definitions.md`): Added `manage_orgs` / `manage_billing` entitlements; updated member/role limits (free org cap 10, identity/individual role caps, team role caps) to match the catalog.
- **Locale strings**: New keys for the added entitlements/features, copy tooltip, and org leave/delete-domain-first errors.

Resolves #3326
Related to #3329