### PR TITLE
[#3326] Permissions gating, dashboard redesign, and UI polish

### DIFF
--- a/locales/content/en/admin-colonel.json
+++ b/locales/content/en/admin-colonel.json
@@ -291,6 +291,15 @@
     "text": "Current plan",
     "content_hash": "37ca715f"
   },
+  "web.colonel.previewPlanMode": {
+    "text": "Preview plan mode"
+  },
+  "web.colonel.previewModeDescription": {
+    "text": "Preview the application as it appears to customers on a different plan. This affects your view only and does not change any organization's actual plan."
+  },
+  "web.colonel.previewModeActive": {
+    "text": "Preview active"
+  },
   "web.colonel.availablePlans": {
     "text": "Available plans",
     "content_hash": "20efa44d"

--- a/src/apps/secret/components/SecretReceiptTable.vue
+++ b/src/apps/secret/components/SecretReceiptTable.vue
@@ -1,51 +1,26 @@
 <!-- src/apps/secret/components/SecretReceiptTable.vue -->
 
+<!--
+  Console-style dashboard receipts feed.
+  Lists pending and revealed receipts using SecretReceiptTableItem.
+  Self-evident row design — no table headers needed.
+-->
+
 <script setup lang="ts">
-  import { useI18n } from 'vue-i18n';
-  import OIcon from '@/shared/components/icons/OIcon.vue';
-  import SecretReceiptTableItem from '@/apps/secret/components/SecretReceiptTableItem.vue';
-  import type { ReceiptList } from '@/schemas/shapes/v3/receipt';
-  import { useBootstrapStore } from '@/shared/stores/bootstrapStore';
-  import { storeToRefs } from 'pinia';
-  import { ref } from 'vue';
+import { useI18n } from 'vue-i18n';
+import OIcon from '@/shared/components/icons/OIcon.vue';
+import SecretReceiptTableItem from '@/apps/secret/components/SecretReceiptTableItem.vue';
+import type { ReceiptList } from '@/schemas/shapes/v3/receipt';
 
-  const { t } = useI18n();
+const { t } = useI18n();
 
-  interface Props {
-    pendingReceipts: ReceiptList[];
-    revealedReceipts: ReceiptList[];
-    isLoading: boolean;
-  }
+interface Props {
+  pendingReceipts: ReceiptList[];
+  revealedReceipts: ReceiptList[];
+  isLoading: boolean;
+}
 
-  defineProps<Props>();
-
-  // Get the site host for building share links
-  const bootstrapStore = useBootstrapStore();
-  const { site_host } = storeToRefs(bootstrapStore);
-
-  // Track item being copied for feedback
-  const copiedItemKey = ref<string | null>(null);
-
-  // Create shareable link for an item
-  const getShareLink = (item: ReceiptList) => {
-    const share_domain = item.share_domain ?? site_host.value;
-    return `https://${share_domain}/secret/${item.secret_shortid}`;
-  };
-
-  // Handle copying link to clipboard
-  const handleCopy = async (item: ReceiptList) => {
-    try {
-      await navigator.clipboard.writeText(getShareLink(item));
-      copiedItemKey.value = item.identifier ?? null;
-
-      // Reset copied state after 1.5 seconds
-      setTimeout(() => {
-        copiedItemKey.value = null;
-      }, 1500);
-    } catch (err) {
-      console.error('Failed to copy link: ', err);
-    }
-  };
+defineProps<Props>();
 </script>
 
 <template>
@@ -53,7 +28,7 @@
     class="space-y-8"
     v-cloak>
     <template v-if="isLoading">
-      <!-- Add a loading indicator here -->
+      <!-- Loading indicator -->
       <div class="text-justify">
         <p class="text-gray-600 dark:text-gray-400">
           {{ t('web.COMMON.loading_ellipses') }}
@@ -61,156 +36,27 @@
       </div>
     </template>
     <template v-else>
+      <!-- Pending Receipts Section (not yet revealed) -->
       <section
         class="mb-8"
         aria-labelledby="pending-receipts-heading">
-        <!-- Table with pending receipts (not yet revealed) -->
+        <!-- Console-style list with pending receipts -->
         <!-- prettier-ignore-attribute class -->
         <div
           v-if="pendingReceipts && pendingReceipts.length > 0"
-          class="relative overflow-hidden rounded-lg border border-gray-200/60 bg-white/60 shadow-sm
+          class="relative overflow-hidden rounded-lg border border-gray-200/60 bg-white/60 p-4 shadow-sm
             backdrop-blur-sm dark:border-gray-700/60 dark:bg-gray-800/60">
-          <div class="overflow-x-auto">
-            <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
-              <caption class="sr-only">
-                {{ t('web.dashboard.title_not_received') }}
-              </caption>
-              <thead class="bg-gray-50/80 dark:bg-slate-800/80">
-                <tr>
-                  <!-- prettier-ignore-attribute class -->
-                  <th
-                    scope="col"
-                    class="px-6 py-2.5 text-left text-xs font-medium uppercase tracking-wider
-                      text-gray-700 dark:text-gray-400">
-                    {{ t('web.COMMON.secret') }}
-                  </th>
-                  <!-- prettier-ignore-attribute class -->
-                  <th
-                    scope="col"
-                    class="px-6 py-2.5 text-left text-xs font-medium uppercase tracking-wider
-                      text-gray-700 dark:text-gray-400">
-                    {{ t('web.LABELS.details') }}
-                  </th>
-                  <!-- prettier-ignore-attribute class -->
-                  <th
-                    scope="col"
-                    class="px-6 py-2.5 text-right text-xs font-medium uppercase tracking-wider
-                      text-gray-700 dark:text-gray-400">
-                    {{ t('web.LABELS.actions') }}
-                  </th>
-                </tr>
-              </thead>
-              <tbody class="divide-y divide-gray-200 dark:divide-gray-700">
-                <!-- prettier-ignore-attribute class -->
-                <tr
-                  v-for="item in pendingReceipts"
-                  :key="item.identifier ?? item.shortid ?? undefined"
-                  class="group border-b border-gray-200 transition-all duration-200
-                    hover:bg-gray-50/80 dark:border-gray-700 dark:hover:bg-slate-800/70">
-                  <td class="whitespace-nowrap px-6 py-4">
-                    <SecretReceiptTableItem :secret-receipt="item" />
-                  </td>
-                  <td class="whitespace-nowrap px-6 py-4">
-                    <!-- prettier-ignore-attribute class -->
-                    <div
-                      class="flex flex-row flex-wrap items-center gap-x-3 gap-y-1 text-sm
-                        text-gray-600 dark:text-gray-400">
-                      <span
-                        v-if="item.show_recipients"
-                        :aria-label="t('web.COMMON.secret_recipient_address')"
-                        class="shrink">
-                        {{ item.recipients }}
-                      </span>
-                      <div
-                        v-if="item.has_passphrase"
-                        class="flex items-center">
-                        <OIcon
-                          collection="heroicons"
-                          name="key"
-                          class="size-3 text-emerald-500 dark:text-emerald-400"
-                          aria-hidden="true" />
-                        <span
-                          class="ml-1 font-medium text-emerald-600 dark:text-emerald-400 sm:inline">
-                          <span class="hidden sm:inline">
-                            {{ t('web.COMMON.secret_passphrase') }}
-                          </span>
-                          <span class="sr-only sm:hidden">
-                            {{ t('web.COMMON.secret_passphrase') }}
-                          </span>
-                        </span>
-                      </div>
-                    </div>
-                  </td>
-                  <td class="whitespace-nowrap px-6 py-4 text-right">
-                    <!-- TODO: We need the secret key in the list receipt endpoint to create the link -->
-                    <div class="flex justify-end space-x-2">
-                      <!-- prettier-ignore-attribute class -->
-                      <div
-                        v-if="!item.is_destroyed && false"
-                        class="group relative inline-block">
-                        <!-- Open Secret Button -->
-                        <a
-                          :href="getShareLink(item)"
-                          target="_blank"
-                          class="flex items-center gap-2 rounded-t bg-gray-100 px-3 py-1.5 text-sm font-medium text-gray-700 transition-all hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-gray-300 focus:ring-offset-2 dark:bg-gray-800/50 dark:text-gray-300 dark:hover:bg-gray-700/40">
-                          <OIcon
-                            collection="heroicons"
-                            name="arrow-top-right-on-square"
-                            class="size-4"
-                            aria-hidden="true" />
-                          <span class="sr-only">{{ t('web.COMMON.view_secret') }}</span>
-                        </a>
-                        <!-- Copy Button with Tooltip -->
-                        <div class="relative">
-                          <!-- prettier-ignore-attribute class -->
-                          <button
-                            @click="handleCopy(item)"
-                            class="flex w-full items-center
-                              gap-2 rounded-b border-gray-200 bg-gray-100 px-3 py-1.5 text-sm font-medium text-gray-700 transition-all
-                              hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-gray-300 focus:ring-offset-2
-                              dark:border-gray-700/50 dark:bg-gray-800/50 dark:text-gray-300 dark:hover:bg-gray-700/40">
-                            <OIcon
-                              collection="heroicons"
-                              :name="copiedItemKey === item.identifier ? 'check' : 'clipboard'"
-                              class="size-4"
-                              aria-hidden="true" />
-                            <span class="sr-only">{{ t('web.LABELS.copy_to_clipboard') }}</span>
-                          </button>
-                          <!-- Copy Feedback Tooltip -->
-                          <!-- prettier-ignore-attribute class -->
-                          <div
-                            v-if="copiedItemKey === item.identifier"
-                            class="absolute -top-8 left-1/2 z-10 -translate-x-1/2 whitespace-nowrap
-                            rounded-t bg-gray-800
-                            px-2 py-1 text-xs text-white shadow-lg">
-                            {{ t('web.STATUS.copied') }}
-                            <div
-                              class="absolute left-1/2 top-full size-2 -translate-x-1/2 rotate-45 rounded-b bg-gray-800"></div>
-                          </div>
-                        </div>
-                      </div>
-
-                      <!-- prettier-ignore-attribute class -->
-                      <router-link
-                        v-if="!item.is_destroyed"
-                        :to="{ name: 'Burn secret', params: { receiptIdentifier: item.identifier } }"
-                        class="inline-flex items-center rounded-md bg-red-100 px-2.5 py-1.5 text-sm
-                          font-medium text-red-700 hover:bg-red-200 focus:outline-none focus:ring-2
-                          focus:ring-red-500 focus:ring-offset-2 dark:bg-red-900/30 dark:text-red-300
-                          dark:hover:bg-red-800/40">
-                        <OIcon
-                          collection="heroicons"
-                          name="fire"
-                          class="mr-1.5 size-4"
-                          aria-hidden="true" />
-                        <span>{{ t('web.COMMON.burn') }}</span>
-                      </router-link>
-                    </div>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
+          <ul
+            class="divide-y-0"
+            role="list"
+            :aria-label="t('web.dashboard.title_not_received')">
+            <SecretReceiptTableItem
+              v-for="(item, idx) in pendingReceipts"
+              :key="item.identifier ?? item.shortid ?? idx"
+              :secret-receipt="item"
+              :index="idx + 1"
+              :is-last="idx === pendingReceipts.length - 1" />
+          </ul>
         </div>
 
         <!-- Empty state for not received -->
@@ -247,94 +93,23 @@
           {{ t('web.dashboard.title_received') }}
         </h3>
 
-        <!-- Table with revealed receipts -->
+        <!-- Console-style list with revealed receipts -->
         <!-- prettier-ignore-attribute class -->
         <div
           v-if="revealedReceipts && revealedReceipts.length > 0"
-          class="relative overflow-hidden rounded-lg border border-gray-200/60 bg-white/60 shadow-sm
+          class="relative overflow-hidden rounded-lg border border-gray-200/60 bg-white/60 p-4 shadow-sm
             backdrop-blur-sm dark:border-gray-700/60 dark:bg-gray-800/60">
-          <div class="overflow-x-auto">
-            <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
-              <caption class="sr-only">
-                {{ t('web.dashboard.title_received') }}
-              </caption>
-              <thead class="bg-gray-50/80 dark:bg-slate-800/80">
-                <tr>
-                  <!-- prettier-ignore-attribute class -->
-                  <th
-                    scope="col"
-                    class="px-6 py-2.5 text-left text-xs font-medium uppercase tracking-wider
-                      text-gray-700 dark:text-gray-400">
-                    {{ t('web.COMMON.secret') }}
-                  </th>
-                  <!-- prettier-ignore-attribute class -->
-                  <th
-                    scope="col"
-                    class="px-6 py-2.5 text-left text-xs font-medium uppercase tracking-wider
-                      text-gray-700 dark:text-gray-400">
-                    {{ t('web.LABELS.details') }}
-                  </th>
-                  <!-- prettier-ignore-attribute class -->
-                  <th
-                    scope="col"
-                    class="px-6 py-2.5 text-right text-xs font-medium uppercase tracking-wider
-                      text-gray-700 dark:text-gray-400">
-                    {{ t('web.COMMON.status') }}
-                  </th>
-                </tr>
-              </thead>
-              <tbody class="divide-y divide-gray-200 dark:divide-gray-700">
-                <!-- prettier-ignore-attribute class -->
-                <tr
-                  v-for="item in revealedReceipts"
-                  :key="item.identifier ?? item.shortid ?? undefined"
-                  class="group border-b border-gray-200 transition-all duration-200
-                    hover:bg-gray-50/80 dark:border-gray-700 dark:hover:bg-slate-800/70">
-                  <td class="whitespace-nowrap px-6 py-4">
-                    <SecretReceiptTableItem :secret-receipt="item" />
-                  </td>
-                  <td class="whitespace-nowrap px-6 py-4">
-                    <div
-                      class="flex flex-row flex-wrap items-center gap-x-3 gap-y-1 text-sm text-gray-600 dark:text-gray-400">
-                      <span
-                        v-if="item.show_recipients"
-                        :aria-label="t('web.COMMON.secret_recipient_address')"
-                        class="shrink">
-                        {{ item.recipients }}
-                      </span>
-                    </div>
-                  </td>
-                  <td class="whitespace-nowrap px-6 py-4 text-right">
-                    <span
-                      :class="[
-                        'inline-flex items-center rounded-md px-2.5 py-1.5 text-sm font-medium',
-                        item.is_destroyed
-                          ? 'bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300'
-                          : item.is_burned
-                            ? 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-300'
-                            : 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-300',
-                      ]">
-                      <OIcon
-                        :collection="'heroicons'"
-                        :name="item.is_burned ? 'fire' : 'x-mark'"
-                        size="4"
-                        class="mr-1.5"
-                        aria-hidden="true" />
-                      <span v-if="item.is_expired">
-                        {{ t('web.STATUS.expired') }}
-                      </span>
-                      <span v-else-if="item.is_burned">
-                        {{ t('web.STATUS.burned') }}
-                      </span>
-                      <span v-else>
-                        {{ t('web.STATUS.received') }}
-                      </span>
-                    </span>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
+          <ul
+            class="divide-y-0"
+            role="list"
+            :aria-label="t('web.dashboard.title_received')">
+            <SecretReceiptTableItem
+              v-for="(item, idx) in revealedReceipts"
+              :key="item.identifier ?? item.shortid ?? idx"
+              :secret-receipt="item"
+              :index="idx + 1"
+              :is-last="idx === revealedReceipts.length - 1" />
+          </ul>
         </div>
 
         <!-- Empty state for received -->

--- a/src/apps/secret/components/SecretReceiptTableItem.vue
+++ b/src/apps/secret/components/SecretReceiptTableItem.vue
@@ -46,7 +46,6 @@ const props = defineProps<Props>();
 
 const emit = defineEmits<{
   copy: [];
-  burn: [receipt: ReceiptList];
 }>();
 
 // Track if this row's content was copied
@@ -168,6 +167,21 @@ const isActive = computed(() => itemState.value === 'new' || itemState.value ===
 
 // Check if this is a terminal state (no actions available)
 const isTerminal = computed(() => !isActive.value);
+
+// Terminal state timestamp: use action-specific date when available
+const terminalActionDate = computed(() => {
+  if (itemState.value === 'revealed' && props.secretReceipt.revealed) {
+    return props.secretReceipt.revealed;
+  }
+  if (itemState.value === 'burned' && props.secretReceipt.burned) {
+    return props.secretReceipt.burned;
+  }
+  return props.secretReceipt.created;
+});
+
+const formattedTerminalDate = computed(() =>
+  formatDistanceToNow(terminalActionDate.value, { addSuffix: true })
+);
 
 // Time remaining urgency
 const isUrgent = computed(() => getTtlPercentage.value <= 25 && isActive.value);
@@ -460,8 +474,8 @@ const rowClasses = computed(() => ['font-mono text-sm', isTerminal.value && 'opa
               <span v-else-if="itemState === 'burned'">destroyed:</span>
               <span v-else>expired:</span>
               <span class="ml-1 text-gray-500 dark:text-gray-400">
-                <time :datetime="secretReceipt.created.toISOString()">
-                  {{ formattedDate }}
+                <time :datetime="terminalActionDate.toISOString()">
+                  {{ formattedTerminalDate }}
                 </time>
               </span>
             </div>

--- a/src/apps/secret/components/SecretReceiptTableItem.vue
+++ b/src/apps/secret/components/SecretReceiptTableItem.vue
@@ -102,12 +102,19 @@ const getTtlPercentage = computed(() => {
 
 /**
  * Determine item state based on receipt state.
- * Priority: expired > burned > revealed > previewed > new
+ * Priority: burned > revealed > expired > previewed > new
+ *
+ * Burned and revealed must take precedence over expired/destroyed because
+ * the backend sets multiple flags simultaneously:
+ * - Burned secrets have is_burned=true AND is_destroyed=true AND secret_ttl=0
+ * - Revealed secrets have is_revealed=true AND is_destroyed=true AND secret_ttl=-1
+ *
+ * The UI should show the actual state (burned/revealed) not the side effect.
  */
 const itemState = computed((): 'new' | 'previewed' | 'revealed' | 'burned' | 'expired' => {
-  if (isExpired.value || isDestroyed.value) return 'expired';
   if (isBurned.value) return 'burned';
   if (isRevealed.value) return 'revealed';
+  if (isExpired.value || isDestroyed.value) return 'expired';
   if (isPreviewed.value) return 'previewed';
   return 'new';
 });

--- a/src/apps/secret/components/SecretReceiptTableItem.vue
+++ b/src/apps/secret/components/SecretReceiptTableItem.vue
@@ -1,88 +1,473 @@
 <!-- src/apps/secret/components/SecretReceiptTableItem.vue -->
 
+<!--
+  Console-style receipt item for dashboard.
+  Monospace precision design matching SecretLinksTableRowConsole.
+  Uses tree-style metadata display with ASCII characters.
+
+  ENCRYPTION SIGNAL SYSTEM (Three-Layer):
+  All secrets are encrypted (EO). Some also have passphrase protection (EAP).
+  The UI distinguishes these with redundant visual cues:
+
+  Layer 1 - Persistent iconography:
+    - EO:  Single padlock icon (mid-gray)
+    - EAP: Padlock + checkmark badge (lock-check icon)
+
+  Layer 2 - Visual hierarchy:
+    - Same saturation for both (no downgrading EO)
+
+  Layer 3 - On-demand info:
+    - Hover/tap shows tooltip with explanation
+-->
+
 <script setup lang="ts">
-  import { useI18n } from 'vue-i18n';
+import { useI18n } from 'vue-i18n';
+import { useBootstrapStore } from '@/shared/stores/bootstrapStore';
 import OIcon from '@/shared/components/icons/OIcon.vue';
 import type { ReceiptList } from '@/schemas/shapes/v3/receipt';
-import { formatRelativeTime, formatDisplayDateTime } from '@/utils/format'
-import { computed } from 'vue';
-import { RouterLink } from 'vue-router';
+import { formatTTL } from '@/utils/formatters';
+import { formatDistanceToNow } from 'date-fns';
+import { storeToRefs } from 'pinia';
+import { useRouter } from 'vue-router';
+import { ref, computed } from 'vue';
+
+const router = useRouter();
 const { t } = useI18n();
 
 interface Props {
   secretReceipt: ReceiptList;
+  /** Row index (1-based) for visual reference */
+  index: number;
+  /** Whether this is the last item (no connector line) */
+  isLast?: boolean;
 }
 
 const props = defineProps<Props>();
 
-const linkClass = computed(() => {
-  const baseClass = 'transition-colors focus:outline-none focus:ring-2 focus:ring-brand-500 focus:ring-offset-2';
-  const stateClass = props.secretReceipt.is_destroyed
-    ? 'line-through italic text-gray-400 dark:text-gray-500'
-    : 'text-gray-800 dark:text-gray-200 hover:text-brand-500 dark:hover:text-brand-400';
+const emit = defineEmits<{
+  copy: [];
+  burn: [receipt: ReceiptList];
+}>();
 
-  return [baseClass, stateClass];
+// Track if this row's content was copied
+const isCopied = ref(false);
+
+// Layer 3: Encryption tooltip visibility
+const showEncryptionTooltip = ref(false);
+
+const bootstrapStore = useBootstrapStore();
+const { site_host } = storeToRefs(bootstrapStore);
+
+// Create shareable link with proper domain
+const shareLink = computed(() => {
+  const shareDomain = props.secretReceipt.share_domain ?? site_host.value;
+  return `https://${shareDomain}/secret/${props.secretReceipt.secret_shortid}`;
 });
 
-const linkTitle = computed(() => {
-  if (props.secretReceipt.is_destroyed) {
-    return t('web.STATUS.expired');
+const handleCopy = async () => {
+  if (!isActive.value) return;
+  try {
+    await navigator.clipboard.writeText(shareLink.value);
+    isCopied.value = true;
+    emit('copy');
+    setTimeout(() => {
+      isCopied.value = false;
+    }, 1500);
+  } catch (err) {
+    console.error('Failed to copy text: ', err);
   }
-  if (props.secretReceipt.is_revealed) {
-    return t('web.COMMON.received');
-  }
-  return '';
-}
-);
+};
 
-const displayIdentifier = computed(() => {
-  const shortid = props.secretReceipt.secret_shortid;
-  if (!shortid) return '\u2014';
-  return shortid.length <= 4 ? shortid : shortid.slice(0, 4);
-});
-
+// Format creation date
 const formattedDate = computed(() =>
-  formatRelativeTime(props.secretReceipt.created)
+  formatDistanceToNow(props.secretReceipt.created, { addSuffix: true })
 );
 
-// Compute status icon based on secret state
-const statusIcon = computed(() => {
-  if (props.secretReceipt.is_destroyed) return 'x-mark';
-  if (props.secretReceipt.is_burned) return 'fire';
-  if (props.secretReceipt.is_revealed) return 'check';
-  return 'lock-closed-16-solid';
+// Compute security status and time remaining
+const hasPassphrase = computed(() => props.secretReceipt.has_passphrase);
+const timeRemaining = computed(() => formatTTL(props.secretReceipt.secret_ttl));
+
+// Secret state computations
+const isExpired = computed(() => props.secretReceipt.is_expired || props.secretReceipt.secret_ttl <= 0);
+const isBurned = computed(() => props.secretReceipt.is_burned);
+const isPreviewed = computed(() => props.secretReceipt.is_previewed);
+const isRevealed = computed(() => props.secretReceipt.is_revealed);
+const isDestroyed = computed(() => props.secretReceipt.is_destroyed);
+
+// Calculate TTL percentage for urgency
+const getTtlPercentage = computed(() => {
+  const maxTtl = 604800; // 7 days
+  return Math.floor((props.secretReceipt.secret_ttl / maxTtl) * 100);
 });
 
+/**
+ * Determine item state based on receipt state.
+ * Priority: expired > burned > revealed > previewed > new
+ */
+const itemState = computed((): 'new' | 'previewed' | 'revealed' | 'burned' | 'expired' => {
+  if (isExpired.value || isDestroyed.value) return 'expired';
+  if (isBurned.value) return 'burned';
+  if (isRevealed.value) return 'revealed';
+  if (isPreviewed.value) return 'previewed';
+  return 'new';
+});
+
+// Console-style status configuration
+const statusConfig = computed(() => {
+  switch (itemState.value) {
+    case 'expired':
+      return {
+        symbol: '○', // open circle
+        label: t('web.STATUS.expired').toUpperCase(),
+        colorClass: 'text-gray-500 dark:text-gray-500',
+      };
+    case 'burned':
+      return {
+        symbol: '✕', // multiplication sign (X)
+        label: t('web.STATUS.burned').toUpperCase(),
+        colorClass: 'text-red-600 dark:text-red-400',
+      };
+    case 'revealed':
+      return {
+        symbol: '✓', // check mark
+        label: t('web.STATUS.revealed').toUpperCase(),
+        colorClass: 'text-gray-500 dark:text-gray-400',
+      };
+    case 'previewed':
+      return {
+        symbol: '◐', // half-filled circle
+        label: t('web.STATUS.previewed').toUpperCase(),
+        colorClass: 'text-amber-600 dark:text-amber-400',
+      };
+    default: // new
+      return {
+        symbol: '●', // filled circle
+        label: t('web.STATUS.new').toUpperCase(),
+        colorClass: 'text-emerald-600 dark:text-emerald-400',
+      };
+  }
+});
+
+// Display key (truncated shortid)
+const displayKey = computed(() => {
+  const shortid = props.secretReceipt.secret_shortid;
+  if (!shortid) return '';
+  if (shortid.length <= 4) return shortid;
+  return shortid.slice(0, 4);
+});
+
+// Check if secret is still actionable
+const isActive = computed(() => itemState.value === 'new' || itemState.value === 'previewed');
+
+// Check if this is a terminal state (no actions available)
+const isTerminal = computed(() => !isActive.value);
+
+// Time remaining urgency
+const isUrgent = computed(() => getTtlPercentage.value <= 25 && isActive.value);
+
+// Whether the secret was created on a different domain
+const hasDifferentDomain = computed(
+  () => !!props.secretReceipt.share_domain && props.secretReceipt.share_domain !== site_host.value
+);
+
+// Receipt route for this record
+const receiptRoute = computed(() => ({
+  name: 'Receipt link',
+  params: { receiptIdentifier: props.secretReceipt.identifier }
+}));
+
+// Navigate to receipt when clicking the row background
+const handleRowClick = () => {
+  router.push(receiptRoute.value);
+};
+
+const rowClasses = computed(() => ['font-mono text-sm', isTerminal.value && 'opacity-60']);
 </script>
 
 <template>
-  <div class="flex items-center space-x-2">
-    <!-- Status Icon -->
-    <OIcon
-      collection="heroicons"
-      :name="statusIcon"
-      size="4"
-      aria-hidden="true" />
+  <li
+    :class="rowClasses"
+    class="group/row relative cursor-pointer transition-all duration-150 hover:shadow-sm"
+    @click="handleRowClick">
+    <!-- Content wrapper: contains everything except separator, for watermark positioning -->
+    <div class="relative">
+      <!-- Background watermark: oversized shortid, centered (hidden on mobile) -->
+      <div
+        class="pointer-events-none absolute inset-0 hidden select-none items-center justify-center sm:flex"
+        aria-hidden="true">
+        <span
+          :class="[
+            'font-mono text-[clamp(3.5rem,8vw,4.5rem)] font-light uppercase leading-none tracking-[0.3em] transition-colors duration-150',
+            isTerminal
+              ? 'dark:text-gray-500/12 text-gray-400/15 group-hover/row:text-gray-400/30 dark:group-hover/row:text-gray-500/25'
+              : 'dark:text-gray-500/18 text-gray-400/20 group-hover/row:text-gray-400/40 dark:group-hover/row:text-gray-500/35',
+          ]">
+          {{ displayKey }}
+        </span>
+      </div>
 
-    <!-- Secret Key with Date below -->
-    <div class="flex flex-col">
-      <!-- Secret Key with Link -->
-      <router-link
-        :to="{ name: 'Receipt link', params: { receiptIdentifier: secretReceipt.identifier } }"
-        :class="linkClass"
-        :title="linkTitle"
-        :aria-label="`${t('web.COMMON.secret')} ${displayIdentifier} ${linkTitle}`">
-        <span class="font-mono text-sm font-medium">{{ displayIdentifier }}</span>
-      </router-link>
+      <!-- Header line: #N  padlock  SYMBOL STATUS  Memo/ID -->
+      <div class="relative flex items-start gap-2">
+        <!-- Index prefix (links to receipt) -->
+        <router-link
+          :to="receiptRoute"
+          :aria-label="`${t('web.receipt.view_receipt')} #${index}`"
+          class="cursor-pointer select-none px-1 py-0.5 text-gray-400 no-underline hover:underline dark:text-gray-500"
+          @click.stop>
+          #{{ index }}
+        </router-link>
 
-      <!-- Date Information -->
-      <span
-        class="text-xs text-gray-500 dark:text-gray-400"
-        :title="formatDisplayDateTime(secretReceipt.updated)">
-        {{ formattedDate }}
-      </span>
+        <!--
+          LAYER 1 & 2: Encryption iconography
+          - All items show padlock (EO baseline)
+          - EAP items add lock-check icon
+        -->
+        <div
+          class="group/encrypt relative flex-shrink-0"
+          @mouseenter="showEncryptionTooltip = true"
+          @mouseleave="showEncryptionTooltip = false"
+          @focus="showEncryptionTooltip = true"
+          @blur="showEncryptionTooltip = false"
+          tabindex="0"
+          role="img"
+          :aria-label="
+            hasPassphrase
+              ? `${t('web.LABELS.encrypted')} + ${t('web.LABELS.passphrase_protected')}`
+              : t('web.LABELS.encrypted')
+          ">
+          <!-- Padlock icon (always shown, mid-gray, same saturation for EO and EAP) -->
+          <OIcon
+            v-if="hasPassphrase"
+            collection="tabler"
+            name="lock-check"
+            size="5" />
+          <OIcon
+            v-else
+            collection="tabler"
+            name="lock"
+            size="5" />
+
+          <!-- LAYER 3: Tooltip on hover/focus -->
+          <Transition
+            enter-active-class="transition duration-150 ease-out"
+            enter-from-class="opacity-0 translate-y-1"
+            enter-to-class="opacity-100 translate-y-0"
+            leave-active-class="transition duration-100 ease-in"
+            leave-from-class="opacity-100 translate-y-0"
+            leave-to-class="opacity-0 translate-y-1">
+            <div
+              v-if="showEncryptionTooltip"
+              class="absolute -top-8 left-1/2 z-20 -translate-x-1/2 whitespace-nowrap rounded bg-gray-800 px-2 py-1 text-xs font-medium text-white shadow-lg dark:bg-gray-700">
+              <template v-if="hasPassphrase">
+                {{ t('web.LABELS.encrypted') }}
+                <span class="text-teal-300"> + {{ t('web.LABELS.passphrase_protected') }}</span>
+              </template>
+              <template v-else>
+                {{ t('web.LABELS.encrypted') }}
+              </template>
+              <!-- Tooltip arrow -->
+              <div
+                class="absolute -bottom-1 left-1/2 size-2 -translate-x-1/2 rotate-45 bg-gray-800 dark:bg-gray-700"
+                aria-hidden="true"></div>
+            </div>
+          </Transition>
+        </div>
+
+        <!-- Status label -->
+        <span :class="['font-semibold tracking-wide', statusConfig.colorClass]">
+          {{ statusConfig.label }}
+        </span>
+
+        <!-- Memo or shortid display -->
+        <div class="min-w-0 flex-1">
+          <span
+            v-if="secretReceipt.memo"
+            :class="[
+              'truncate',
+              isActive
+                ? 'text-gray-900 dark:text-gray-100'
+                : 'text-gray-600 dark:text-gray-400',
+            ]">
+            {{ secretReceipt.memo }}
+          </span>
+          <span
+            v-else
+            class="text-gray-400 dark:text-gray-500">
+            {{ displayKey }}
+          </span>
+        </div>
+
+        <!-- Actions (header line, right side) — stop propagation to prevent row click -->
+        <div
+          v-if="isActive"
+          class="flex flex-shrink-0 items-center gap-1 sm:gap-2"
+          @click.stop>
+          <!-- Copy button: icon-only on mobile, text on sm+ -->
+          <button
+            type="button"
+            @click="handleCopy"
+            :class="[
+              'rounded border transition-colors',
+              'p-1.5 sm:px-2 sm:py-0.5',
+              isCopied
+                ? 'border-emerald-300 bg-emerald-50 text-emerald-700 dark:border-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400'
+                : 'border-gray-300 bg-white text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700',
+            ]"
+            :title="t('web.LABELS.copy_to_clipboard')">
+            <!-- Mobile: icon only -->
+            <OIcon
+              v-if="isCopied"
+              collection="heroicons"
+              name="check"
+              class="size-4 sm:hidden" />
+            <OIcon
+              v-else
+              collection="heroicons"
+              name="clipboard"
+              class="size-4 sm:hidden" />
+            <!-- Desktop: text label -->
+            <span class="hidden text-xs font-medium sm:inline">
+              {{ isCopied ? '[ COPIED ]' : '[ COPY ]' }}
+            </span>
+          </button>
+
+          <!-- Open link button: icon-only on mobile, text on sm+ -->
+          <a
+            :href="shareLink"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="rounded border border-gray-300 bg-white p-1.5 text-gray-700 transition-colors hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700 sm:px-2 sm:py-0.5"
+            :title="t('web.COMMON.view_secret')"
+            @click.stop>
+            <!-- Mobile: icon only -->
+            <OIcon
+              collection="heroicons"
+              name="arrow-top-right-on-square"
+              class="size-4 sm:hidden" />
+            <!-- Desktop: text label -->
+            <span class="hidden text-xs font-medium sm:inline">[ OPEN &#8599; ]</span>
+          </a>
+
+          <!-- Burn button: icon-only on mobile, text on sm+ -->
+          <router-link
+            :to="{ name: 'Burn secret', params: { receiptIdentifier: secretReceipt.identifier } }"
+            class="rounded border border-red-300 bg-red-50 p-1.5 text-red-700 transition-colors hover:bg-red-100 dark:border-red-700 dark:bg-red-900/30 dark:text-red-400 dark:hover:bg-red-900/50 sm:px-2 sm:py-0.5"
+            :title="t('web.COMMON.burn')"
+            @click.stop>
+            <!-- Mobile: icon only -->
+            <OIcon
+              collection="heroicons"
+              name="fire"
+              class="size-4 sm:hidden" />
+            <!-- Desktop: text label -->
+            <span class="hidden text-xs font-medium sm:inline">[ BURN ]</span>
+          </router-link>
+        </div>
+      </div>
+
+      <!-- Metadata tree (full tree for active/previewed, minimal for terminal) -->
+      <div class="relative ml-4 mt-1 space-y-0.5 text-gray-600 dark:text-gray-400">
+        <template v-if="isActive">
+          <!-- Domain line (only when share domain differs from site host) -->
+          <div
+            v-if="hasDifferentDomain"
+            class="flex items-center">
+            <span
+              class="mr-2 select-none text-gray-300 dark:text-gray-600"
+              aria-hidden="true"
+              >&#9500;&#9472;</span
+            >
+            <span class="text-gray-400 dark:text-gray-500">via:</span>
+            <span class="ml-1 text-gray-500 dark:text-gray-400">{{ secretReceipt.share_domain }}</span>
+          </div>
+
+          <!-- Recipients line (if shown) -->
+          <div
+            v-if="secretReceipt.show_recipients && secretReceipt.recipients"
+            class="flex items-center">
+            <span
+              class="mr-2 select-none text-gray-300 dark:text-gray-600"
+              aria-hidden="true"
+              >&#9500;&#9472;</span
+            >
+            <span class="text-gray-400 dark:text-gray-500">to:</span>
+            <span class="ml-1 text-gray-500 dark:text-gray-400">{{ secretReceipt.recipients }}</span>
+          </div>
+
+          <!-- Expires line with timestamp on right -->
+          <div class="flex items-center justify-between">
+            <div class="flex items-center">
+              <span
+                class="mr-2 select-none text-gray-300 dark:text-gray-600"
+                aria-hidden="true"
+                >&#9492;&#9472;</span
+              >
+              <span>expires:</span>
+              <span
+                :class="[
+                  'ml-1',
+                  isUrgent
+                    ? 'font-semibold text-amber-600 dark:text-amber-400'
+                    : 'text-gray-700 dark:text-gray-300',
+                ]">
+                {{ timeRemaining }}
+              </span>
+            </div>
+
+            <!-- Timestamp -->
+            <div class="flex items-center gap-2">
+              <span
+                data-test-id="created-timestamp"
+                class="text-xs text-gray-400 dark:text-gray-500">
+                <time :datetime="secretReceipt.created.toISOString()">
+                  {{ formattedDate }}
+                </time>
+              </span>
+            </div>
+          </div>
+        </template>
+
+        <!-- Terminal states: minimal info -->
+        <template v-else>
+          <!-- Domain line (only when share domain differs from site host) -->
+          <div
+            v-if="hasDifferentDomain"
+            class="flex items-center">
+            <span
+              class="mr-2 select-none text-gray-300 dark:text-gray-600"
+              aria-hidden="true"
+              >&#9500;&#9472;</span
+            >
+            <span class="text-gray-400 dark:text-gray-500">via:</span>
+            <span class="ml-1 text-gray-500 dark:text-gray-400">{{ secretReceipt.share_domain }}</span>
+          </div>
+
+          <div class="flex items-center justify-between">
+            <div class="flex items-center">
+              <span
+                class="mr-2 select-none text-gray-300 dark:text-gray-600"
+                aria-hidden="true"
+                >&#9492;&#9472;</span
+              >
+              <span v-if="itemState === 'revealed'">viewed:</span>
+              <span v-else-if="itemState === 'burned'">destroyed:</span>
+              <span v-else>expired:</span>
+              <span class="ml-1 text-gray-500 dark:text-gray-400">
+                <time :datetime="secretReceipt.created.toISOString()">
+                  {{ formattedDate }}
+                </time>
+              </span>
+            </div>
+          </div>
+        </template>
+      </div>
     </div>
-  </div>
+    <!-- /Content wrapper -->
 
-  <!-- Default View (Backward Compatible) -->
+    <!-- Separator line (if not last item) -->
+    <div
+      v-if="!isLast"
+      class="my-4 border-t border-gray-200/60 transition-colors duration-150 group-hover/row:border-gray-300/80 dark:border-gray-700/60 dark:group-hover/row:border-gray-600/80"
+      aria-hidden="true"></div>
+  </li>
 </template>

--- a/src/apps/secret/layouts/SecretLayout.vue
+++ b/src/apps/secret/layouts/SecretLayout.vue
@@ -15,6 +15,7 @@
   import BaseLayout from '@/shared/layouts/BaseLayout.vue';
   import { useBootstrapStore } from '@/shared/stores/bootstrapStore';
   import { useDomainsStore, useReceiptListStore } from '@/shared/stores';
+  import { useOrgPermissions } from '@/shared/composables/useOrgPermissions';
   import { storeToRefs } from 'pinia';
   import type { LayoutProps } from '@/types/ui/layouts';
   import { computed, onMounted } from 'vue';
@@ -36,11 +37,16 @@
   const receiptListStore = useReceiptListStore();
   const domainsStore = useDomainsStore();
 
+  // Permission check for domain management (admins/owners only)
+  const { canManageDomain } = useOrgPermissions();
+
   // Load stores when authenticated (needed for workspace footer mobile nav)
   onMounted(() => {
     if (authenticated.value) {
       receiptListStore.refreshRecords(true);
-      if (domainsEnabled) {
+      // Only fetch domain list for users who can manage domains (admins/owners)
+      // Members get domain context from the permissions API via useDomainContext
+      if (domainsEnabled && canManageDomain.value) {
         domainsStore.refreshRecords({ force: true });
       }
     }

--- a/src/apps/session/components/AuthView.vue
+++ b/src/apps/session/components/AuthView.vue
@@ -7,7 +7,6 @@
     useJurisdictionStore,
     useJurisdictionDisplayNames,
   } from '@/shared/stores/jurisdictionStore';
-  import { storeToRefs } from 'pinia';
   import { computed } from 'vue';
 
   interface IconConfig {
@@ -47,7 +46,6 @@
 
   // Initialize jurisdiction store
   const jurisdictionStore = useJurisdictionStore();
-  const { getCurrentJurisdiction } = storeToRefs(jurisdictionStore);
   const { currentJurisdictionWithDisplayName } = useJurisdictionDisplayNames();
 
   // Compute the current jurisdiction or default to unknown
@@ -66,18 +64,20 @@
     }
   );
 
-  // Compute the background icon based on jurisdiction status
+  // Compute the background icon based on jurisdiction status.
+  // Uses the resolved icon (jurisdiction.icon ?? identifier mapping ?? globe),
+  // not the raw config icon which is undefined when JURISDICTIONS omits it.
   const backgroundIcon = computed((): IconConfig => {
-    if (jurisdictionStore.enabled && getCurrentJurisdiction.value?.icon) {
-      return getCurrentJurisdiction.value.icon;
+    if (jurisdictionStore.enabled) {
+      return currentJurisdiction.value.icon;
     }
     return props.featureIcon;
   });
 
   // Compute the icon to show based on jurisdiction status
   const iconToShow = computed((): IconConfig => {
-    if (jurisdictionStore.enabled && getCurrentJurisdiction.value?.icon) {
-      return getCurrentJurisdiction.value.icon;
+    if (jurisdictionStore.enabled) {
+      return currentJurisdiction.value.icon;
     }
     return props.featureIcon;
   });

--- a/src/apps/workspace/components/domains/DomainsTable.vue
+++ b/src/apps/workspace/components/domains/DomainsTable.vue
@@ -22,7 +22,7 @@
   import { isOrgsSsoEnabled, isOrgsCustomMailEnabled, isOrgsIncomingSecretsEnabled } from '@/utils/features';
 
   import ConfirmDialog from '@/shared/components/modals/ConfirmDialog.vue';
-  import { computed } from 'vue';
+  import { computed, reactive } from 'vue';
 
 const { t } = useI18n();
 
@@ -65,11 +65,29 @@ const { t } = useI18n();
     }
   };
 
-  const handleHomepageToggle = async (domain: CustomDomain) => {
-    const newValue = !(domain.homepage_config?.enabled ?? false);
-    await domainsStore.putHomepageConfig(domain.extid, newValue);
+  // Optimistic toggle state: tracks in-flight toggles by extid so each
+  // switch reflects its pending value immediately and ignores clicks
+  // while its API call is in flight.
+  const pendingToggles: Record<string, boolean> = reactive({});
 
-    emit('toggle-homepage', domain);
+  const isHomepageEnabled = (domain: CustomDomain): boolean => {
+    if (domain.extid in pendingToggles) return pendingToggles[domain.extid];
+    return domain.homepage_config?.enabled ?? false;
+  };
+
+  const isTogglePending = (extid: string): boolean => extid in pendingToggles;
+
+  const handleHomepageToggle = async (domain: CustomDomain) => {
+    if (isTogglePending(domain.extid)) return;
+
+    const newValue = !isHomepageEnabled(domain);
+    pendingToggles[domain.extid] = newValue;
+    try {
+      await domainsStore.putHomepageConfig(domain.extid, newValue);
+      emit('toggle-homepage', domain);
+    } finally {
+      delete pendingToggles[domain.extid];
+    }
   };
 </script>
 
@@ -135,7 +153,7 @@ const { t } = useI18n();
           <tbody class="divide-y divide-gray-200 bg-white dark:divide-gray-700 dark:bg-gray-900">
             <tr
               v-for="domain in domains"
-              :key="domain.domainid"
+              :key="domain.extid"
               class="transition-colors duration-150 hover:bg-gray-50 dark:hover:bg-gray-800">
               <!-- Domain & Status -->
               <td class="px-6 py-4">
@@ -149,8 +167,8 @@ const { t } = useI18n();
               <td class="px-6 py-4 text-center">
                 <div>
                   <ToggleWithIcon
-                    :enabled="domain.homepage_config?.enabled ?? false"
-                    :disabled="isLoading || !canAdmin"
+                    :enabled="isHomepageEnabled(domain)"
+                    :disabled="isLoading || !canAdmin || isTogglePending(domain.extid)"
                     @update:enabled="handleHomepageToggle(domain)" />
                 </div>
               </td>

--- a/src/apps/workspace/layouts/WorkspaceLayout.vue
+++ b/src/apps/workspace/layouts/WorkspaceLayout.vue
@@ -35,6 +35,7 @@
   import { useBootstrapStore } from '@/shared/stores/bootstrapStore';
   import { useDomainsStore, useReceiptListStore } from '@/shared/stores';
   import { usePreviewPlanMode } from '@/shared/composables/usePreviewPlanMode';
+  import { useOrgPermissions } from '@/shared/composables/useOrgPermissions';
   import type { ImprovedLayoutProps } from '@/types/ui/layouts';
   import { storeToRefs } from 'pinia';
   import { computed, onMounted } from 'vue';
@@ -63,10 +64,15 @@
   // Test plan mode composable
   const { isPreviewModeActive } = usePreviewPlanMode();
 
+  // Permission check for domain management (admins/owners only)
+  const { canManageDomain } = useOrgPermissions();
+
   // Centralize store refreshing to avoid duplicate API calls from header and footer
   onMounted(() => {
     receiptListStore.refreshRecords(true);
-    if (domains_enabled.value) {
+    // Only fetch domain list for users who can manage domains (admins/owners)
+    // Members get domain context from the permissions API via useDomainContext
+    if (domains_enabled.value && canManageDomain.value) {
       domainsStore.refreshRecords({ force: true });
     }
   });

--- a/src/shared/components/navigation/UserMenu.vue
+++ b/src/shared/components/navigation/UserMenu.vue
@@ -105,10 +105,10 @@ const isElevatedRole = computed(() =>
   userRole.value === 'owner' || userRole.value === 'admin'
 );
 
-// Domain context display in menu header (canonical site only)
+// Domain context display in menu header
 const { currentContext, isContextActive } = useDomainContext();
 const showDomainContext = computed(() =>
-  isContextActive.value && !isCustom.value && !props.awaitingMfa
+  isContextActive.value && !props.awaitingMfa
 );
 
 const isOpen = ref(false);
@@ -374,52 +374,23 @@ onUnmounted(() => {
         <div
           class="border-b border-gray-200 px-4 py-3
             dark:border-gray-700">
-          <div class="flex items-center justify-between gap-2">
-            <!-- Email -->
+          <!-- Email -->
+          <p
+            class="truncate text-sm font-medium text-gray-900 dark:text-white"
+            :title="cust?.email">
+            {{ cust?.email }}
+          </p>
+          <!-- Domain context + Role badge -->
+          <div
+            v-if="showDomainContext || (isElevatedRole && !awaitingMfa)"
+            class="group/domain mt-1 flex items-center gap-2">
             <p
-              class="min-w-0 truncate text-sm font-medium text-gray-900 dark:text-white"
-              :title="cust?.email">
-              {{ cust?.email }}
-            </p>
-            <!-- Theme Toggle -->
-            <button
-              @click="toggleDarkMode"
-              data-testid="user-menu-theme-toggle"
-              :aria-label="t('web.layout.toggle_dark_mode')"
-              :aria-pressed="isDarkMode"
-              :title="isDarkMode ? t('web.layout.switch_to_blank_mode', ['light']) : t('web.layout.switch_to_blank_mode', ['dark'])"
-              class="flex size-7 shrink-0 items-center justify-center rounded-md
-                text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-700
-                dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-gray-200">
-              <OIcon
-                :collection="isDarkMode ? 'ph' : 'ph'"
-                :name="isDarkMode ? 'moon' : 'sun'"
-                class="size-4"
-                aria-hidden="true" />
-            </button>
-          </div>
-          <!-- Role badge for owners/admins -->
-          <div
-            v-if="isElevatedRole && !awaitingMfa"
-            class="mt-1">
-            <span
-              :class="[
-                'inline-flex items-center rounded-full px-2 py-0.5 text-[11px] font-medium',
-                userRole === 'owner'
-                  ? 'bg-brand-100 text-brand-700 dark:bg-brand-900/30 dark:text-brand-300'
-                  : 'bg-violet-100 text-violet-700 dark:bg-violet-900/30 dark:text-violet-300'
-              ]">
-              {{ t(`web.organizations.members.roles.${userRole}`) }}
-            </span>
-          </div>
-          <!-- Domain context -->
-          <div
-            v-if="showDomainContext"
-            class="group/domain mt-0.5 flex items-center gap-1">
-            <p class="truncate text-sm text-gray-400/80 dark:text-gray-400">
+              v-if="showDomainContext"
+              class="truncate text-sm text-gray-400/80 dark:text-gray-400">
               {{ currentContext.displayName }}
             </p>
             <button
+              v-if="showDomainContext"
               @click.stop="copyToClipboard(currentContext.displayName, 'domain')"
               :title="copiedField === 'domain' ? t('web.COMMON.copied') : t('web.COMMON.copy')"
               class="shrink-0 rounded p-0.5 text-gray-300 transition-all
@@ -433,6 +404,26 @@ onUnmounted(() => {
                 class="size-3"
                 aria-hidden="true" />
             </button>
+            <!-- Role badge -->
+            <span
+              v-if="isElevatedRole && !awaitingMfa"
+              :class="[
+                'shrink-0 inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider',
+                'border shadow-xs',
+                userRole === 'owner'
+                  ? 'border-brand-200/60 bg-brand-50 text-brand-600 dark:border-brand-700/40 dark:bg-brand-950/50 dark:text-brand-400'
+                  : 'border-violet-200/60 bg-violet-50 text-violet-600 dark:border-violet-700/40 dark:bg-violet-950/50 dark:text-violet-400'
+              ]">
+              <span
+                :class="[
+                  'size-1.5 rounded-full',
+                  userRole === 'owner'
+                    ? 'bg-brand-500 dark:bg-brand-400'
+                    : 'bg-violet-500 dark:bg-violet-400'
+                ]"
+                aria-hidden="true"></span>
+              {{ t(`web.organizations.members.roles.${userRole}`) }}
+            </span>
           </div>
           <!-- MFA Required Notice -->
           <div
@@ -496,10 +487,46 @@ onUnmounted(() => {
                 aria-hidden="true" />
             </a>
 
-            <!-- Button Item (for logout) -->
+            <!-- Button Item (for logout, test-plan, etc.) -->
+            <!-- Logout row with theme toggle -->
+            <div
+              v-if="item.id === 'logout'"
+              class="flex items-center justify-between px-4 py-2">
+              <button
+                data-testid="user-menu-logout"
+                class="group flex items-center gap-3 text-sm text-red-600 transition-colors
+                  hover:text-red-700 dark:text-red-400 dark:hover:text-red-300"
+                @click="item.onClick"
+                role="menuitem">
+                <OIcon
+                  :collection="item.icon.collection"
+                  :name="item.icon.name"
+                  class="size-5 text-red-500 transition-colors group-hover:text-red-600
+                    dark:text-red-400 dark:group-hover:text-red-300"
+                  aria-hidden="true" />
+                {{ item.label }}
+              </button>
+              <!-- Theme Toggle -->
+              <button
+                @click.stop="toggleDarkMode"
+                data-testid="user-menu-theme-toggle"
+                :aria-label="t('web.layout.toggle_dark_mode')"
+                :aria-pressed="isDarkMode"
+                :title="isDarkMode ? t('web.layout.switch_to_blank_mode', ['light']) : t('web.layout.switch_to_blank_mode', ['dark'])"
+                class="flex size-7 items-center justify-center rounded-md
+                  text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600
+                  dark:text-gray-500 dark:hover:bg-gray-700 dark:hover:text-gray-300">
+                <OIcon
+                  collection="ph"
+                  :name="isDarkMode ? 'moon' : 'sun'"
+                  class="size-4"
+                  aria-hidden="true" />
+              </button>
+            </div>
+            <!-- Other button items -->
             <button
               v-else-if="item.onClick"
-              :data-testid="item.id === 'logout' ? 'user-menu-logout' : undefined"
+              :data-testid="item.id === 'test-plan' ? 'user-menu-test-plan' : undefined"
               :class="[getMenuItemClasses(item.variant), 'w-full']"
               @click="item.onClick"
               role="menuitem">

--- a/src/shared/layouts/ManagementLayout.vue
+++ b/src/shared/layouts/ManagementLayout.vue
@@ -17,6 +17,7 @@
   import { useBootstrapStore } from '@/shared/stores/bootstrapStore';
   import { useDomainsStore, useReceiptListStore } from '@/shared/stores';
   import { usePreviewPlanMode } from '@/shared/composables/usePreviewPlanMode';
+  import { useOrgPermissions } from '@/shared/composables/useOrgPermissions';
   import { storeToRefs } from 'pinia';
   import type { ImprovedLayoutProps } from '@/types/ui/layouts';
   import { computed, onMounted } from 'vue';
@@ -44,10 +45,15 @@
   // Test plan mode composable
   const { isPreviewModeActive } = usePreviewPlanMode();
 
+  // Permission check for domain management (admins/owners only)
+  const { canManageDomain } = useOrgPermissions();
+
   // Centralize store refreshing to avoid duplicate API calls from header and footer
   onMounted(() => {
     receiptListStore.refreshRecords(true);
-    if (domains_enabled.value) {
+    // Only fetch domain list for users who can manage domains (admins/owners)
+    // Members get domain context from the permissions API via useDomainContext
+    if (domains_enabled.value && canManageDomain.value) {
       domainsStore.refreshRecords({ force: true });
     }
   });

--- a/src/tests/apps/secret/components/SecretReceiptTableItem.spec.ts
+++ b/src/tests/apps/secret/components/SecretReceiptTableItem.spec.ts
@@ -1,7 +1,8 @@
 // src/tests/apps/secret/components/SecretReceiptTableItem.spec.ts
 
-import { mount } from '@vue/test-utils';
+import { mount, VueWrapper } from '@vue/test-utils';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { ComponentPublicInstance } from 'vue';
 
 // Mock vue-i18n
 vi.mock('vue-i18n', () => ({
@@ -10,16 +11,41 @@ vi.mock('vue-i18n', () => ({
   })),
 }));
 
-// Mock format utilities
-vi.mock('@/utils/format', () => ({
-  formatRelativeTime: vi.fn(() => '2 hours ago'),
-  formatDisplayDateTime: vi.fn(() => '2026-03-21 14:30:00'),
+// Mock formatters
+vi.mock('@/utils/formatters', () => ({
+  formatTTL: vi.fn((seconds: number) => `${Math.floor(seconds / 86400)} days`),
+}));
+
+// Mock date-fns
+vi.mock('date-fns', () => ({
+  formatDistanceToNow: vi.fn(() => '2 hours ago'),
+}));
+
+// Mock bootstrap store
+vi.mock('@/shared/stores/bootstrapStore', () => ({
+  useBootstrapStore: vi.fn(() => ({
+    site_host: 'onetimesecret.com',
+  })),
+}));
+
+// Mock pinia storeToRefs
+vi.mock('pinia', () => ({
+  storeToRefs: vi.fn((store) => ({
+    site_host: { value: store.site_host },
+  })),
+}));
+
+// Mock vue-router
+vi.mock('vue-router', () => ({
+  useRouter: vi.fn(() => ({
+    push: vi.fn(),
+  })),
 }));
 
 // Stub RouterLink to avoid router dependency
 const RouterLinkStub = {
   name: 'RouterLink',
-  template: '<a :href="to"><slot /></a>',
+  template: '<a :href="typeof to === \'string\' ? to : to.name"><slot /></a>',
   props: ['to', 'class', 'title', 'aria-label'],
 };
 
@@ -27,7 +53,7 @@ const RouterLinkStub = {
 const OIconStub = {
   name: 'OIcon',
   template: '<span class="icon-stub" />',
-  props: ['collection', 'name', 'size'],
+  props: ['collection', 'name', 'size', 'class'],
 };
 
 function createMockReceipt(overrides = {}) {
@@ -42,18 +68,27 @@ function createMockReceipt(overrides = {}) {
     state: 'new',
     created: new Date(),
     updated: new Date(),
-    is_viewed: false,
-    is_received: false,
+    shared: null,
+    previewed: null,
+    revealed: null,
+    burned: null,
+    has_passphrase: false,
+    is_previewed: false,
+    is_revealed: false,
     is_burned: false,
     is_destroyed: false,
     is_expired: false,
     is_orphaned: false,
+    show_recipients: false,
+    recipients: null,
+    share_domain: null,
+    memo: null,
     ...overrides,
   };
 }
 
 describe('SecretReceiptTableItem', () => {
-  let SecretReceiptTableItem: any;
+  let SecretReceiptTableItem: ReturnType<typeof import('@/apps/secret/components/SecretReceiptTableItem.vue')>['default'];
 
   beforeEach(async () => {
     vi.resetModules();
@@ -64,9 +99,30 @@ describe('SecretReceiptTableItem', () => {
       })),
     }));
 
-    vi.doMock('@/utils/format', () => ({
-      formatRelativeTime: vi.fn(() => '2 hours ago'),
-      formatDisplayDateTime: vi.fn(() => '2026-03-21 14:30:00'),
+    vi.doMock('@/utils/formatters', () => ({
+      formatTTL: vi.fn((seconds: number) => `${Math.floor(seconds / 86400)} days`),
+    }));
+
+    vi.doMock('date-fns', () => ({
+      formatDistanceToNow: vi.fn(() => '2 hours ago'),
+    }));
+
+    vi.doMock('@/shared/stores/bootstrapStore', () => ({
+      useBootstrapStore: vi.fn(() => ({
+        site_host: 'onetimesecret.com',
+      })),
+    }));
+
+    vi.doMock('pinia', () => ({
+      storeToRefs: vi.fn((store) => ({
+        site_host: { value: store.site_host },
+      })),
+    }));
+
+    vi.doMock('vue-router', () => ({
+      useRouter: vi.fn(() => ({
+        push: vi.fn(),
+      })),
     }));
 
     const mod = await import(
@@ -75,59 +131,220 @@ describe('SecretReceiptTableItem', () => {
     SecretReceiptTableItem = mod.default;
   });
 
-  function mountComponent(receiptOverrides = {}) {
+  function mountComponent(
+    receiptOverrides = {},
+    extraProps = {},
+  ): VueWrapper<ComponentPublicInstance> {
     return mount(SecretReceiptTableItem, {
       props: {
         secretReceipt: createMockReceipt(receiptOverrides),
+        index: 1,
+        isLast: false,
+        ...extraProps,
       },
       global: {
         stubs: {
           RouterLink: RouterLinkStub,
           OIcon: OIconStub,
+          Transition: false,
         },
       },
     });
   }
 
-  it('displays secret_shortid when present', () => {
-    const wrapper = mountComponent({ secret_shortid: 'abc123' });
-    const identifier = wrapper.find('.font-mono');
-    expect(identifier.text()).toBe('abc1');
-  });
-
-  it('displays em-dash when secret_shortid is undefined', () => {
-    const wrapper = mountComponent({ secret_shortid: undefined });
-    const identifier = wrapper.find('.font-mono');
-    expect(identifier.text()).toBe('\u2014');
-  });
-
-  it('displays em-dash when secret_shortid is null', () => {
-    const wrapper = mountComponent({ secret_shortid: null });
-    const identifier = wrapper.find('.font-mono');
-    expect(identifier.text()).toBe('\u2014');
-  });
-
-  it('does not display "undefined" string when secret_shortid is missing', () => {
-    const receipt = createMockReceipt();
-    delete (receipt as any).secret_shortid;
-    const wrapper = mount(SecretReceiptTableItem, {
-      props: { secretReceipt: receipt },
-      global: {
-        stubs: {
-          RouterLink: RouterLinkStub,
-          OIcon: OIconStub,
-        },
-      },
+  describe('display key rendering', () => {
+    it('displays truncated secret_shortid when present', () => {
+      const wrapper = mountComponent({ secret_shortid: 'abc12345' });
+      // The displayKey shows first 4 chars in the watermark and header
+      expect(wrapper.text()).toContain('abc1');
     });
-    const identifier = wrapper.find('.font-mono');
-    expect(identifier.text()).not.toBe('undefined');
-    expect(identifier.text()).toBe('\u2014');
+
+    it('displays empty string when secret_shortid is undefined', () => {
+      const wrapper = mountComponent({ secret_shortid: undefined });
+      // Watermark uses displayKey which returns empty string for falsy values
+      const watermark = wrapper.find('[aria-hidden="true"] span');
+      expect(watermark.exists()).toBe(true);
+      // displayKey returns '' for undefined
+    });
+
+    it('displays full shortid when 4 chars or less', () => {
+      const wrapper = mountComponent({ secret_shortid: 'abc' });
+      expect(wrapper.text()).toContain('abc');
+    });
   });
 
-  it('displays em-dash when secret_shortid is empty string', () => {
-    // Empty string is falsy, so component returns em-dash
-    const wrapper = mountComponent({ secret_shortid: '' });
-    const identifier = wrapper.find('.font-mono');
-    expect(identifier.text()).toBe('\u2014');
+  describe('status badge rendering', () => {
+    // Note: Component calls .toUpperCase() on status labels, so expect uppercase
+    it('shows NEW status for new secrets', () => {
+      const wrapper = mountComponent({
+        is_previewed: false,
+        is_revealed: false,
+        is_burned: false,
+        is_destroyed: false,
+        is_expired: false,
+      });
+      expect(wrapper.text()).toContain('WEB.STATUS.NEW');
+    });
+
+    it('shows PREVIEWED status when is_previewed is true', () => {
+      const wrapper = mountComponent({ is_previewed: true });
+      expect(wrapper.text()).toContain('WEB.STATUS.PREVIEWED');
+    });
+
+    it('shows REVEALED status when is_revealed is true', () => {
+      const wrapper = mountComponent({ is_revealed: true });
+      expect(wrapper.text()).toContain('WEB.STATUS.REVEALED');
+    });
+
+    it('shows BURNED status when is_burned is true', () => {
+      const wrapper = mountComponent({ is_burned: true });
+      expect(wrapper.text()).toContain('WEB.STATUS.BURNED');
+    });
+
+    it('shows EXPIRED status when is_expired is true', () => {
+      const wrapper = mountComponent({ is_expired: true });
+      expect(wrapper.text()).toContain('WEB.STATUS.EXPIRED');
+    });
+
+    it('shows EXPIRED status when is_destroyed is true', () => {
+      const wrapper = mountComponent({ is_destroyed: true });
+      expect(wrapper.text()).toContain('WEB.STATUS.EXPIRED');
+    });
+  });
+
+  describe('action buttons', () => {
+    it('shows action buttons for new (active) secrets', () => {
+      const wrapper = mountComponent({
+        is_previewed: false,
+        is_revealed: false,
+        is_burned: false,
+        is_destroyed: false,
+        is_expired: false,
+      });
+      // Should have COPY, OPEN, BURN buttons (text visible on desktop)
+      expect(wrapper.text()).toContain('[ COPY ]');
+      expect(wrapper.text()).toContain('[ OPEN');
+      expect(wrapper.text()).toContain('[ BURN ]');
+    });
+
+    it('shows action buttons for previewed secrets', () => {
+      const wrapper = mountComponent({ is_previewed: true });
+      expect(wrapper.text()).toContain('[ COPY ]');
+      expect(wrapper.text()).toContain('[ BURN ]');
+    });
+
+    it('hides action buttons for revealed (terminal) secrets', () => {
+      const wrapper = mountComponent({ is_revealed: true });
+      expect(wrapper.text()).not.toContain('[ COPY ]');
+      expect(wrapper.text()).not.toContain('[ BURN ]');
+    });
+
+    it('hides action buttons for burned secrets', () => {
+      const wrapper = mountComponent({ is_burned: true });
+      expect(wrapper.text()).not.toContain('[ COPY ]');
+      expect(wrapper.text()).not.toContain('[ BURN ]');
+    });
+
+    it('hides action buttons for expired secrets', () => {
+      const wrapper = mountComponent({ is_expired: true });
+      expect(wrapper.text()).not.toContain('[ COPY ]');
+      expect(wrapper.text()).not.toContain('[ BURN ]');
+    });
+  });
+
+  describe('encryption indicator', () => {
+    it('shows lock icon for encrypted-only secrets', () => {
+      const wrapper = mountComponent({ has_passphrase: false });
+      const icons = wrapper.findAllComponents(OIconStub);
+      const lockIcon = icons.find(
+        (icon) => icon.props('collection') === 'tabler' && icon.props('name') === 'lock'
+      );
+      expect(lockIcon).toBeDefined();
+    });
+
+    it('shows lock-check icon for passphrase-protected secrets', () => {
+      const wrapper = mountComponent({ has_passphrase: true });
+      const icons = wrapper.findAllComponents(OIconStub);
+      const lockCheckIcon = icons.find(
+        (icon) => icon.props('collection') === 'tabler' && icon.props('name') === 'lock-check'
+      );
+      expect(lockCheckIcon).toBeDefined();
+    });
+  });
+
+  describe('metadata tree', () => {
+    it('shows expires line for active secrets', () => {
+      const wrapper = mountComponent({
+        secret_ttl: 604800, // 7 days
+        is_previewed: false,
+        is_revealed: false,
+      });
+      expect(wrapper.text()).toContain('expires:');
+    });
+
+    it('shows domain line when share_domain differs from site_host', () => {
+      const wrapper = mountComponent({
+        share_domain: 'custom.example.com',
+      });
+      expect(wrapper.text()).toContain('via:');
+      expect(wrapper.text()).toContain('custom.example.com');
+    });
+
+    it('hides domain line when share_domain matches site_host', () => {
+      const wrapper = mountComponent({
+        share_domain: 'onetimesecret.com',
+      });
+      expect(wrapper.text()).not.toContain('via:');
+    });
+
+    it('shows recipients when show_recipients is true', () => {
+      const wrapper = mountComponent({
+        show_recipients: true,
+        recipients: 'user@example.com',
+      });
+      expect(wrapper.text()).toContain('to:');
+      expect(wrapper.text()).toContain('user@example.com');
+    });
+  });
+
+  describe('separator line', () => {
+    it('shows separator when isLast is false', () => {
+      const wrapper = mountComponent({}, { isLast: false });
+      const separator = wrapper.find('[aria-hidden="true"].border-t');
+      expect(separator.exists()).toBe(true);
+    });
+
+    it('hides separator when isLast is true', () => {
+      const wrapper = mountComponent({}, { isLast: true });
+      const separator = wrapper.find('[aria-hidden="true"].border-t');
+      expect(separator.exists()).toBe(false);
+    });
+  });
+
+  describe('index display', () => {
+    it('displays the index number', () => {
+      const wrapper = mountComponent({}, { index: 5 });
+      expect(wrapper.text()).toContain('#5');
+    });
+  });
+
+  describe('terminal state styling', () => {
+    it('applies opacity-60 class for terminal states', () => {
+      const wrapper = mountComponent({ is_revealed: true });
+      const li = wrapper.find('li');
+      expect(li.classes()).toContain('opacity-60');
+    });
+
+    it('does not apply opacity-60 for active states', () => {
+      const wrapper = mountComponent({
+        is_previewed: false,
+        is_revealed: false,
+        is_burned: false,
+        is_destroyed: false,
+        is_expired: false,
+      });
+      const li = wrapper.find('li');
+      expect(li.classes()).not.toContain('opacity-60');
+    });
   });
 });

--- a/src/tests/apps/workspace/billing/BillingOverview.spec.ts
+++ b/src/tests/apps/workspace/billing/BillingOverview.spec.ts
@@ -84,6 +84,7 @@ vi.mock('@/types/billing', () => ({
     return names[id] || id;
   },
   isLegacyPlan: (planId: string) => planId === 'identity',
+  isFreePlan: (planId: string) => !planId || planId === 'free' || planId.startsWith('free_'),
 }));
 
 // Use shared fixture factory for overview response

--- a/src/tests/components/SecretReceiptTableItem.spec.ts
+++ b/src/tests/components/SecretReceiptTableItem.spec.ts
@@ -7,7 +7,7 @@
  * When a secret is burned, the backend may also set is_expired=true or secret_ttl=0.
  * The UI must show "BURNED" (not "EXPIRED") because burned is the actual state.
  *
- * Priority: burned > expired > revealed > previewed > new
+ * Priority: burned > revealed > expired > previewed > new
  */
 
 import { mount } from '@vue/test-utils';
@@ -292,6 +292,83 @@ describe('SecretReceiptTableItem', () => {
       const listItem = wrapper.find('li');
 
       expect(listItem.classes()).not.toContain('opacity-60');
+    });
+  });
+
+  describe('terminal state timestamps', () => {
+    it('shows revealed timestamp for viewed state when available', () => {
+      const created = new Date('2026-05-01T10:00:00Z');
+      const revealed = new Date('2026-06-01T15:30:00Z');
+      const receipt = createReceipt({
+        created,
+        revealed,
+        is_revealed: true,
+        is_destroyed: true,
+      });
+
+      const wrapper = mountComponent(receipt);
+      const timeElement = wrapper.find('time');
+
+      expect(timeElement.attributes('datetime')).toBe(revealed.toISOString());
+    });
+
+    it('shows burned timestamp for destroyed state when available', () => {
+      const created = new Date('2026-05-01T10:00:00Z');
+      const burned = new Date('2026-06-02T08:45:00Z');
+      const receipt = createReceipt({
+        created,
+        burned,
+        is_burned: true,
+        is_destroyed: true,
+      });
+
+      const wrapper = mountComponent(receipt);
+      const timeElement = wrapper.find('time');
+
+      expect(timeElement.attributes('datetime')).toBe(burned.toISOString());
+    });
+
+    it('falls back to created timestamp when revealed is null', () => {
+      const created = new Date('2026-05-01T10:00:00Z');
+      const receipt = createReceipt({
+        created,
+        revealed: null,
+        is_revealed: true,
+        is_destroyed: true,
+      });
+
+      const wrapper = mountComponent(receipt);
+      const timeElement = wrapper.find('time');
+
+      expect(timeElement.attributes('datetime')).toBe(created.toISOString());
+    });
+
+    it('falls back to created timestamp when burned is null', () => {
+      const created = new Date('2026-05-01T10:00:00Z');
+      const receipt = createReceipt({
+        created,
+        burned: null,
+        is_burned: true,
+        is_destroyed: true,
+      });
+
+      const wrapper = mountComponent(receipt);
+      const timeElement = wrapper.find('time');
+
+      expect(timeElement.attributes('datetime')).toBe(created.toISOString());
+    });
+
+    it('uses created timestamp for expired state', () => {
+      const created = new Date('2026-05-01T10:00:00Z');
+      const receipt = createReceipt({
+        created,
+        is_expired: true,
+      });
+
+      const wrapper = mountComponent(receipt);
+      const timeElement = wrapper.find('time');
+
+      expect(timeElement.attributes('datetime')).toBe(created.toISOString());
     });
   });
 

--- a/src/tests/components/SecretReceiptTableItem.spec.ts
+++ b/src/tests/components/SecretReceiptTableItem.spec.ts
@@ -1,0 +1,325 @@
+// src/tests/components/SecretReceiptTableItem.spec.ts
+
+/**
+ * Tests for SecretReceiptTableItem component state priority.
+ *
+ * Regression test for burned vs expired status display bug:
+ * When a secret is burned, the backend may also set is_expired=true or secret_ttl=0.
+ * The UI must show "BURNED" (not "EXPIRED") because burned is the actual state.
+ *
+ * Priority: burned > expired > revealed > previewed > new
+ */
+
+import { mount } from '@vue/test-utils';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { createI18n } from 'vue-i18n';
+import { createTestingPinia } from '@pinia/testing';
+import { createRouter, createMemoryHistory } from 'vue-router';
+import SecretReceiptTableItem from '@/apps/secret/components/SecretReceiptTableItem.vue';
+import type { ReceiptList } from '@/schemas/shapes/v3/receipt';
+
+// Minimal i18n setup
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: {
+    en: {
+      web: {
+        STATUS: {
+          expired: 'Expired',
+          burned: 'Burned',
+          revealed: 'Revealed',
+          previewed: 'Previewed',
+          new: 'New',
+        },
+        LABELS: {
+          encrypted: 'Encrypted',
+          passphrase_protected: 'Passphrase protected',
+          copy_to_clipboard: 'Copy to clipboard',
+        },
+        COMMON: {
+          view_secret: 'View secret',
+          burn: 'Burn',
+        },
+        receipt: {
+          view_receipt: 'View receipt',
+        },
+      },
+    },
+  },
+});
+
+// Minimal router
+const router = createRouter({
+  history: createMemoryHistory(),
+  routes: [
+    { path: '/', name: 'Home', component: { template: '<div />' } },
+    { path: '/receipt/:receiptIdentifier', name: 'Receipt link', component: { template: '<div />' } },
+    { path: '/burn/:receiptIdentifier', name: 'Burn secret', component: { template: '<div />' } },
+  ],
+});
+
+/**
+ * Factory for creating receipt test data.
+ * All boolean flags default to false; override as needed.
+ */
+function createReceipt(overrides: Partial<ReceiptList> = {}): ReceiptList {
+  const now = new Date();
+  return {
+    identifier: 'receipt-abc123',
+    key: 'test-key',
+    shortid: 'abc123',
+    state: 'new',
+    custid: 'cust-123',
+    owner_id: 'owner-123',
+    created: now,
+    updated: now,
+    shared: null,
+    previewed: null,
+    revealed: null,
+    burned: null,
+    secret_ttl: 3600,
+    receipt_ttl: 7200,
+    lifespan: 3600,
+    secret_shortid: 'sec-xyz',
+    secret_identifier: 'secret-xyz789',
+    recipients: null,
+    recipient_name: null,
+    share_domain: null,
+    has_passphrase: false,
+    is_previewed: false,
+    is_revealed: false,
+    is_burned: false,
+    is_destroyed: false,
+    is_expired: false,
+    is_orphaned: false,
+    memo: null,
+    kind: 'conceal',
+    show_recipients: false,
+    ...overrides,
+  };
+}
+
+function mountComponent(receipt: ReceiptList) {
+  return mount(SecretReceiptTableItem, {
+    props: {
+      secretReceipt: receipt,
+      index: 1,
+      isLast: false,
+    },
+    global: {
+      plugins: [
+        i18n,
+        router,
+        createTestingPinia({
+          createSpy: vi.fn,
+          initialState: {
+            bootstrap: {
+              site_host: 'onetimesecret.com',
+            },
+          },
+        }),
+      ],
+      stubs: {
+        OIcon: { template: '<span class="icon-stub" />' },
+      },
+    },
+  });
+}
+
+describe('SecretReceiptTableItem', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('itemState priority', () => {
+    it('shows BURNED when is_burned=true even if is_expired=true', () => {
+      // This is the bug: a burned secret often has is_expired=true too
+      const receipt = createReceipt({
+        is_burned: true,
+        is_expired: true,
+        secret_ttl: 0,
+      });
+
+      const wrapper = mountComponent(receipt);
+      const statusLabel = wrapper.find('.font-semibold.tracking-wide');
+
+      expect(statusLabel.text()).toBe('BURNED');
+      expect(statusLabel.classes()).toContain('text-red-600');
+    });
+
+    it('shows BURNED when is_burned=true and secret_ttl=0', () => {
+      const receipt = createReceipt({
+        is_burned: true,
+        secret_ttl: 0,
+      });
+
+      const wrapper = mountComponent(receipt);
+      const statusLabel = wrapper.find('.font-semibold.tracking-wide');
+
+      expect(statusLabel.text()).toBe('BURNED');
+    });
+
+    it('shows BURNED when is_burned=true and is_destroyed=true', () => {
+      const receipt = createReceipt({
+        is_burned: true,
+        is_destroyed: true,
+      });
+
+      const wrapper = mountComponent(receipt);
+      const statusLabel = wrapper.find('.font-semibold.tracking-wide');
+
+      expect(statusLabel.text()).toBe('BURNED');
+    });
+
+    it('shows EXPIRED when is_expired=true but is_burned=false', () => {
+      const receipt = createReceipt({
+        is_expired: true,
+        is_burned: false,
+      });
+
+      const wrapper = mountComponent(receipt);
+      const statusLabel = wrapper.find('.font-semibold.tracking-wide');
+
+      expect(statusLabel.text()).toBe('EXPIRED');
+    });
+
+    it('shows EXPIRED when secret_ttl=0 and is_burned=false', () => {
+      const receipt = createReceipt({
+        secret_ttl: 0,
+        is_burned: false,
+      });
+
+      const wrapper = mountComponent(receipt);
+      const statusLabel = wrapper.find('.font-semibold.tracking-wide');
+
+      expect(statusLabel.text()).toBe('EXPIRED');
+    });
+
+    it('shows EXPIRED when is_destroyed=true but is_burned=false', () => {
+      const receipt = createReceipt({
+        is_destroyed: true,
+        is_burned: false,
+      });
+
+      const wrapper = mountComponent(receipt);
+      const statusLabel = wrapper.find('.font-semibold.tracking-wide');
+
+      expect(statusLabel.text()).toBe('EXPIRED');
+    });
+
+    it('shows REVEALED when is_revealed=true (not expired or burned)', () => {
+      const receipt = createReceipt({
+        is_revealed: true,
+      });
+
+      const wrapper = mountComponent(receipt);
+      const statusLabel = wrapper.find('.font-semibold.tracking-wide');
+
+      expect(statusLabel.text()).toBe('REVEALED');
+    });
+
+    it('shows REVEALED when is_revealed=true even if is_destroyed=true and secret_ttl=-1', () => {
+      // Real backend data: revealed secrets have is_destroyed=true and secret_ttl=-1
+      const receipt = createReceipt({
+        is_revealed: true,
+        is_destroyed: true,
+        secret_ttl: -1,
+      });
+
+      const wrapper = mountComponent(receipt);
+      const statusLabel = wrapper.find('.font-semibold.tracking-wide');
+
+      expect(statusLabel.text()).toBe('REVEALED');
+    });
+
+    it('shows REVEALED when is_revealed=true even if is_expired=true', () => {
+      const receipt = createReceipt({
+        is_revealed: true,
+        is_expired: true,
+      });
+
+      const wrapper = mountComponent(receipt);
+      const statusLabel = wrapper.find('.font-semibold.tracking-wide');
+
+      expect(statusLabel.text()).toBe('REVEALED');
+    });
+
+    it('shows PREVIEWED when is_previewed=true (not expired, burned, or revealed)', () => {
+      const receipt = createReceipt({
+        is_previewed: true,
+      });
+
+      const wrapper = mountComponent(receipt);
+      const statusLabel = wrapper.find('.font-semibold.tracking-wide');
+
+      expect(statusLabel.text()).toBe('PREVIEWED');
+    });
+
+    it('shows NEW when no state flags are set', () => {
+      const receipt = createReceipt();
+
+      const wrapper = mountComponent(receipt);
+      const statusLabel = wrapper.find('.font-semibold.tracking-wide');
+
+      expect(statusLabel.text()).toBe('NEW');
+    });
+  });
+
+  describe('terminal state styling', () => {
+    it('applies terminal opacity for burned state', () => {
+      const receipt = createReceipt({ is_burned: true });
+
+      const wrapper = mountComponent(receipt);
+      const listItem = wrapper.find('li');
+
+      expect(listItem.classes()).toContain('opacity-60');
+    });
+
+    it('applies terminal opacity for expired state', () => {
+      const receipt = createReceipt({ is_expired: true });
+
+      const wrapper = mountComponent(receipt);
+      const listItem = wrapper.find('li');
+
+      expect(listItem.classes()).toContain('opacity-60');
+    });
+
+    it('does not apply terminal opacity for new state', () => {
+      const receipt = createReceipt();
+
+      const wrapper = mountComponent(receipt);
+      const listItem = wrapper.find('li');
+
+      expect(listItem.classes()).not.toContain('opacity-60');
+    });
+  });
+
+  describe('action buttons visibility', () => {
+    it('shows action buttons for new state', () => {
+      const receipt = createReceipt();
+
+      const wrapper = mountComponent(receipt);
+      // For active states, the actions div with buttons should exist
+      const buttons = wrapper.findAll('button');
+
+      expect(buttons.length).toBeGreaterThan(0);
+    });
+
+    it('hides action buttons for burned state', () => {
+      const receipt = createReceipt({ is_burned: true });
+
+      const wrapper = mountComponent(receipt);
+
+      expect(wrapper.findAll('button').length).toBe(0);
+    });
+
+    it('hides action buttons for expired state', () => {
+      const receipt = createReceipt({ is_expired: true });
+
+      const wrapper = mountComponent(receipt);
+
+      expect(wrapper.findAll('button').length).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

This PR continues the permissions API work with three main themes:

**Permissions gating** — Domain store refresh now checks `canManageDomain` before fetching. Members get domain context through the permissions API rather than loading the full domains list. Prevents unauthorized data fetching for non-privileged users.

**Dashboard modernization** — Recent Secrets page redesigned from HTML tables to a console-style layout: monospace font, ASCII tree metadata (├─ ─┴─), large watermark shortid, and status symbols (● ◐ ✓ ✕ ○) instead of colored badges. Mobile-optimized action buttons.

**Bug fixes and polish**:
- Fixed secret status priority: burned/revealed now correctly take precedence over expired flag
- Fixed DomainsTable homepage toggle cross-talk on rapid clicks via optimistic state tracking
- Jurisdiction icon now resolves properly (globe fallback instead of shield)
- UserMenu restructured with vertical flow for email/domain/role badge

## Testing

- Added dedicated regression tests for secret status priority ordering
- Existing test suite passes

## Test plan

- [ ] Verify members cannot see domains sidebar but can still access domain-specific features
- [ ] Visual check on Recent Secrets page (desktop and mobile)
- [ ] Rapid-click homepage toggle in DomainsTable — confirm no cross-talk

Closes #3326