### PR TITLE
Simplified brand/image endpoint implementations; also renames concern to policy

### DIFF
--- a/apps/api/domains/logic/api_config/base.rb
+++ b/apps/api/domains/logic/api_config/base.rb
@@ -3,7 +3,7 @@
 # frozen_string_literal: true
 
 require 'onetime/models/custom_domain/api_config'
-require_relative '../concerns/domain_config_authorization'
+require_relative '../../policies/domain_config_authorization'
 
 module DomainsAPI
   module Logic
@@ -17,7 +17,7 @@ module DomainsAPI
       #   4. Verify organization has api_access entitlement
       #
       class Base < DomainsAPI::Logic::Base
-        include DomainsAPI::Logic::Concerns::DomainConfigAuthorization
+        include DomainsAPI::Policies::DomainConfigAuthorization
 
         attr_reader :custom_domain, :organization
 

--- a/apps/api/domains/logic/concerns/domain_config_authorization.rb
+++ b/apps/api/domains/logic/concerns/domain_config_authorization.rb
@@ -10,13 +10,20 @@ module DomainsAPI
       # Shared authorization logic for domain config endpoints.
       #
       # Provides the common authorization flow used by domain config
-      # base classes (ApiConfig, HomepageConfig, SenderConfig, SsoConfig):
+      # base classes (ApiConfig, HomepageConfig, SenderConfig, SsoConfig)
+      # and write-path brand/image endpoints (UpdateDomainBrand,
+      # UpdateDomainImage, RemoveDomainImage):
       #
       #   1. Check feature flag (if config_feature_flag is defined)
       #   2. Load CustomDomain by domain_id (extid)
       #   3. Load Organization via domain.org_id
-      #   4. Verify user is organization owner (colonel bypass)
+      #   4. Verify user has manage_org in the organization (colonel bypass)
       #   5. Verify organization has the required entitlement
+      #
+      # Read-only brand/image endpoints (GetDomainBrand, GetDomainImage)
+      # intentionally skip this concern — they check custom_branding
+      # membership directly so regular org members can view the brand
+      # management page (rendered as a disabled overlay in the UI).
       #
       # Including classes must define:
       #   - `config_entitlement` returning the entitlement name string

--- a/apps/api/domains/logic/domains/get_domain_brand.rb
+++ b/apps/api/domains/logic/domains/get_domain_brand.rb
@@ -40,7 +40,7 @@ module DomainsAPI::Logic
 
         @custom_domain = load_custom_domain(@extid)
         @organization = load_organization_for_domain(@custom_domain)
-        require_entitlement_in!(@organization, 'custom_branding')
+        require_entitlement_in!(@organization, config_entitlement)
       end
 
       def process

--- a/apps/api/domains/logic/domains/get_domain_brand.rb
+++ b/apps/api/domains/logic/domains/get_domain_brand.rb
@@ -9,9 +9,21 @@ module DomainsAPI::Logic
   module Domains
     # Get Domain Brand Settings
     #
-    # @api Retrieves the brand settings for a custom domain. Requires the
-    #   custom_branding entitlement. Returns the brand configuration
-    #   including name, tagline, colors, fonts, and homepage settings.
+    # @api Retrieves the brand settings for a custom domain. Returns the
+    #   brand configuration including name, tagline, colors, fonts, and
+    #   homepage settings.
+    #
+    # Authorization model (read-only — no DomainConfigAuthorization):
+    #   1. Verify user belongs to an organization (require_organization!)
+    #   2. Load CustomDomain by extid
+    #   3. Verify user owns the domain (owner? check)
+    #   4. Verify user's membership has custom_branding entitlement
+    #
+    # Unlike the write counterpart (UpdateDomainBrand), this endpoint
+    # does NOT require manage_org. Regular org members can read brand
+    # settings so the UI can render the brand page as a disabled overlay,
+    # keeping premium features visible per modern SaaS convention.
+    #
     class GetDomainBrand < DomainsAPI::Logic::Base
       SCHEMAS = { response: 'brandSettings' }.freeze
 

--- a/apps/api/domains/logic/domains/get_domain_brand.rb
+++ b/apps/api/domains/logic/domains/get_domain_brand.rb
@@ -37,6 +37,7 @@ module DomainsAPI::Logic
 
       def raise_concerns
         raise_form_error 'Please provide a domain ID' if @extid.empty?
+        raise_form_error 'Invalid domain identifier format' unless @extid.match?(/\A[a-z0-9]+\z/)
 
         @custom_domain = load_custom_domain(@extid)
         @organization = load_organization_for_domain(@custom_domain)

--- a/apps/api/domains/logic/domains/get_domain_brand.rb
+++ b/apps/api/domains/logic/domains/get_domain_brand.rb
@@ -4,6 +4,7 @@
 
 require 'onetime/domain_validation/strategy'
 require_relative '../base'
+require_relative '../../policies/domain_config_authorization'
 
 module DomainsAPI::Logic
   module Domains
@@ -13,11 +14,10 @@ module DomainsAPI::Logic
     #   brand configuration including name, tagline, colors, fonts, and
     #   homepage settings.
     #
-    # Authorization model (read-only — no DomainConfigAuthorization):
-    #   1. Verify user belongs to an organization (require_organization!)
-    #   2. Load CustomDomain by extid
-    #   3. Verify user owns the domain (owner? check)
-    #   4. Verify user's membership has custom_branding entitlement
+    # Authorization model (read-only, via DomainConfigAuthorization helpers):
+    #   1. Load CustomDomain by extid
+    #   2. Load Organization via domain.org_id
+    #   3. Verify user's membership has custom_branding entitlement
     #
     # Unlike the write counterpart (UpdateDomainBrand), this endpoint
     # does NOT require manage_org. Regular org members can read brand
@@ -25,6 +25,8 @@ module DomainsAPI::Logic
     # keeping premium features visible per modern SaaS convention.
     #
     class GetDomainBrand < DomainsAPI::Logic::Base
+      include DomainsAPI::Policies::DomainConfigAuthorization
+
       SCHEMAS = { response: 'brandSettings' }.freeze
 
       attr_reader :brand_settings, :display_domain, :custom_domain
@@ -36,22 +38,9 @@ module DomainsAPI::Logic
       def raise_concerns
         raise_form_error 'Please provide a domain ID' if @extid.empty?
 
-        # Get customer's organization for domain ownership
-        # Organization available via @organization
-        require_organization!
-
-        @custom_domain = Onetime::CustomDomain.find_by_extid(@extid)
-
-        raise_form_error 'Domain not found' unless @custom_domain
-
-        # Verify the customer owns this domain through their organization
-        unless @custom_domain.owner?(@cust)
-          raise_form_error 'Domain not found'
-        end
-
-        domain_org = @custom_domain.primary_organization
-        raise_form_error 'Domain has no associated organization' unless domain_org
-        require_entitlement_in!(domain_org, 'custom_branding')
+        @custom_domain = load_custom_domain(@extid)
+        @organization = load_organization_for_domain(@custom_domain)
+        require_entitlement_in!(@organization, 'custom_branding')
       end
 
       def process
@@ -66,6 +55,16 @@ module DomainsAPI::Logic
           user_id: @cust.objid,
           record: @custom_domain.safe_dump.fetch(:brand, {}),
         }
+      end
+
+      protected
+
+      def config_entitlement
+        'custom_branding'
+      end
+
+      def config_entitlement_error
+        'Custom branding requires the custom_branding entitlement. Please upgrade your plan.'
       end
     end
   end

--- a/apps/api/domains/logic/domains/get_domain_brand.rb
+++ b/apps/api/domains/logic/domains/get_domain_brand.rb
@@ -22,8 +22,6 @@ module DomainsAPI::Logic
       end
 
       def raise_concerns
-        require_entitlement!('custom_branding')
-
         raise_form_error 'Please provide a domain ID' if @extid.empty?
 
         # Get customer's organization for domain ownership
@@ -38,6 +36,10 @@ module DomainsAPI::Logic
         unless @custom_domain.owner?(@cust)
           raise_form_error 'Domain not found'
         end
+
+        domain_org = @custom_domain.primary_organization
+        raise_form_error 'Domain has no associated organization' unless domain_org
+        require_entitlement_in!(domain_org, 'custom_branding')
       end
 
       def process

--- a/apps/api/domains/logic/domains/get_domain_image.rb
+++ b/apps/api/domains/logic/domains/get_domain_image.rb
@@ -27,8 +27,6 @@ module DomainsAPI::Logic
       end
 
       def raise_concerns
-        require_entitlement!('custom_branding')
-
         raise_form_error 'Please provide a domain ID' if @extid.empty?
 
         # Get customer's organization for domain ownership
@@ -42,6 +40,10 @@ module DomainsAPI::Logic
         unless @custom_domain.owner?(@cust)
           raise_form_error 'Domain not found'
         end
+
+        domain_org = @custom_domain.primary_organization
+        raise_form_error 'Domain has no associated organization' unless domain_org
+        require_entitlement_in!(domain_org, 'custom_branding')
 
         @display_domain = @custom_domain.display_domain
 

--- a/apps/api/domains/logic/domains/get_domain_image.rb
+++ b/apps/api/domains/logic/domains/get_domain_image.rb
@@ -45,7 +45,7 @@ module DomainsAPI::Logic
 
         @custom_domain = load_custom_domain(@extid)
         @organization = load_organization_for_domain(@custom_domain)
-        require_entitlement_in!(@organization, 'custom_branding')
+        require_entitlement_in!(@organization, config_entitlement)
 
         @display_domain = @custom_domain.display_domain
 

--- a/apps/api/domains/logic/domains/get_domain_image.rb
+++ b/apps/api/domains/logic/domains/get_domain_image.rb
@@ -42,6 +42,7 @@ module DomainsAPI::Logic
 
       def raise_concerns
         raise_form_error 'Please provide a domain ID' if @extid.empty?
+        raise_form_error 'Invalid domain identifier format' unless @extid.match?(/\A[a-z0-9]+\z/)
 
         @custom_domain = load_custom_domain(@extid)
         @organization = load_organization_for_domain(@custom_domain)

--- a/apps/api/domains/logic/domains/get_domain_image.rb
+++ b/apps/api/domains/logic/domains/get_domain_image.rb
@@ -3,6 +3,7 @@
 # frozen_string_literal: true
 
 require 'base64'
+require_relative '../../policies/domain_config_authorization'
 
 module DomainsAPI::Logic
   module Domains
@@ -12,11 +13,10 @@ module DomainsAPI::Logic
     #   base64-encoded data with content type metadata. Returns 404 if no
     #   image is stored.
     #
-    # Authorization model (read-only — no DomainConfigAuthorization):
-    #   1. Verify user belongs to an organization (require_organization!)
-    #   2. Load CustomDomain by extid
-    #   3. Verify user owns the domain (owner? check)
-    #   4. Verify user's membership has custom_branding entitlement
+    # Authorization model (read-only, via DomainConfigAuthorization helpers):
+    #   1. Load CustomDomain by extid
+    #   2. Load Organization via domain.org_id
+    #   3. Verify user's membership has custom_branding entitlement
     #
     # Unlike the write counterparts (UpdateDomainImage, RemoveDomainImage),
     # this endpoint does NOT require manage_org. Regular org members can
@@ -24,6 +24,8 @@ module DomainsAPI::Logic
     # overlay, keeping premium features visible per modern SaaS convention.
     #
     class GetDomainImage < DomainsAPI::Logic::Base
+      include DomainsAPI::Policies::DomainConfigAuthorization
+
       SCHEMAS = { response: 'imageProps' }.freeze
 
       attr_reader :display_domain, :image_field, :image, :custom_domain
@@ -41,21 +43,9 @@ module DomainsAPI::Logic
       def raise_concerns
         raise_form_error 'Please provide a domain ID' if @extid.empty?
 
-        # Get customer's organization for domain ownership
-        # Organization available via @organization
-        require_organization!
-
-        @custom_domain = Onetime::CustomDomain.find_by_extid(@extid)
-        raise_form_error 'Domain not found' unless custom_domain
-
-        # Verify the customer owns this domain through their organization
-        unless @custom_domain.owner?(@cust)
-          raise_form_error 'Domain not found'
-        end
-
-        domain_org = @custom_domain.primary_organization
-        raise_form_error 'Domain has no associated organization' unless domain_org
-        require_entitlement_in!(domain_org, 'custom_branding')
+        @custom_domain = load_custom_domain(@extid)
+        @organization = load_organization_for_domain(@custom_domain)
+        require_entitlement_in!(@organization, 'custom_branding')
 
         @display_domain = @custom_domain.display_domain
 
@@ -78,11 +68,22 @@ module DomainsAPI::Logic
         }
       end
 
+      protected
+
+      def config_entitlement
+        'custom_branding'
+      end
+
+      def config_entitlement_error
+        'Custom branding requires the custom_branding entitlement. Please upgrade your plan.'
+      end
+
+      private
+
       # e.g. custom_domain.logo
       def _image_field
         custom_domain.send(self.class.field)
       end
-      private :_image_field
     end
 
     class GetDomainLogo < GetDomainImage

--- a/apps/api/domains/logic/domains/get_domain_image.rb
+++ b/apps/api/domains/logic/domains/get_domain_image.rb
@@ -9,8 +9,20 @@ module DomainsAPI::Logic
     # Get Domain Image
     #
     # @api Retrieves a stored image (logo or icon) for a custom domain as
-    #   base64-encoded data with content type metadata. Requires the
-    #   custom_branding entitlement. Returns 404 if no image is stored.
+    #   base64-encoded data with content type metadata. Returns 404 if no
+    #   image is stored.
+    #
+    # Authorization model (read-only — no DomainConfigAuthorization):
+    #   1. Verify user belongs to an organization (require_organization!)
+    #   2. Load CustomDomain by extid
+    #   3. Verify user owns the domain (owner? check)
+    #   4. Verify user's membership has custom_branding entitlement
+    #
+    # Unlike the write counterparts (UpdateDomainImage, RemoveDomainImage),
+    # this endpoint does NOT require manage_org. Regular org members can
+    # read image data so the UI can render the brand page as a disabled
+    # overlay, keeping premium features visible per modern SaaS convention.
+    #
     class GetDomainImage < DomainsAPI::Logic::Base
       SCHEMAS = { response: 'imageProps' }.freeze
 

--- a/apps/api/domains/logic/domains/remove_domain_image.rb
+++ b/apps/api/domains/logic/domains/remove_domain_image.rb
@@ -40,6 +40,7 @@ module DomainsAPI::Logic
         OT.ld "[#{self.class}] Raising concerns for extid: #{@extid}"
 
         raise_form_error 'Domain ID is required' if @extid.empty?
+        raise_form_error 'Invalid domain identifier format' unless @extid.match?(/\A[a-z0-9]+\z/)
 
         authorize_domain_config!(@extid)
 

--- a/apps/api/domains/logic/domains/remove_domain_image.rb
+++ b/apps/api/domains/logic/domains/remove_domain_image.rb
@@ -21,8 +21,6 @@ module DomainsAPI::Logic
       end
 
       def raise_concerns
-        require_entitlement!('custom_branding')
-
         OT.ld "[#{self.class}] Raising concerns for extid: #{@extid}"
 
         raise_form_error 'Domain ID is required' if @extid.empty?
@@ -38,6 +36,10 @@ module DomainsAPI::Logic
         unless @custom_domain.owner?(@cust)
           raise_form_error 'Invalid Domain'
         end
+
+        domain_org = @custom_domain.primary_organization
+        raise_form_error 'Domain has no associated organization' unless domain_org
+        require_entitlement_in!(domain_org, 'custom_branding')
 
         @display_domain = @custom_domain.display_domain
 

--- a/apps/api/domains/logic/domains/remove_domain_image.rb
+++ b/apps/api/domains/logic/domains/remove_domain_image.rb
@@ -4,7 +4,7 @@
 
 require 'onetime/domain_validation/strategy'
 require_relative '../base'
-require_relative '../concerns/domain_config_authorization'
+require_relative '../../policies/domain_config_authorization'
 
 module DomainsAPI::Logic
   module Domains
@@ -22,7 +22,7 @@ module DomainsAPI::Logic
     # members can view the brand page (disabled overlay in the UI).
     #
     class RemoveDomainImage < DomainsAPI::Logic::Base
-      include DomainsAPI::Logic::Concerns::DomainConfigAuthorization
+      include DomainsAPI::Policies::DomainConfigAuthorization
 
       attr_reader :greenlighted, :display_domain, :custom_domain
 

--- a/apps/api/domains/logic/domains/remove_domain_image.rb
+++ b/apps/api/domains/logic/domains/remove_domain_image.rb
@@ -41,7 +41,7 @@ module DomainsAPI::Logic
 
         raise_form_error 'Domain ID is required' if @extid.empty?
 
-        authorize_domain_brand!(@extid)
+        authorize_domain_config!(@extid)
 
         @display_domain = @custom_domain.display_domain
 
@@ -76,10 +76,6 @@ module DomainsAPI::Logic
 
       def config_entitlement_error
         'Custom branding requires the custom_branding entitlement. Please upgrade your plan.'
-      end
-
-      def authorize_domain_brand!(domain_id)
-        authorize_domain_config!(domain_id)
       end
 
       private

--- a/apps/api/domains/logic/domains/remove_domain_image.rb
+++ b/apps/api/domains/logic/domains/remove_domain_image.rb
@@ -4,10 +4,13 @@
 
 require 'onetime/domain_validation/strategy'
 require_relative '../base'
+require_relative '../concerns/domain_config_authorization'
 
 module DomainsAPI::Logic
   module Domains
     class RemoveDomainImage < DomainsAPI::Logic::Base
+      include DomainsAPI::Logic::Concerns::DomainConfigAuthorization
+
       attr_reader :greenlighted, :display_domain, :custom_domain
 
       @field = nil
@@ -25,21 +28,7 @@ module DomainsAPI::Logic
 
         raise_form_error 'Domain ID is required' if @extid.empty?
 
-        # Get customer's organization for domain ownership
-        # Organization available via @organization
-        require_organization!
-
-        @custom_domain = Onetime::CustomDomain.find_by_extid(@extid)
-        raise_form_error 'Invalid Domain' unless @custom_domain
-
-        # Verify the customer owns this domain through their organization
-        unless @custom_domain.owner?(@cust)
-          raise_form_error 'Invalid Domain'
-        end
-
-        domain_org = @custom_domain.primary_organization
-        raise_form_error 'Domain has no associated organization' unless domain_org
-        require_entitlement_in!(domain_org, 'custom_branding')
+        authorize_domain_brand!(@extid)
 
         @display_domain = @custom_domain.display_domain
 
@@ -66,16 +55,30 @@ module DomainsAPI::Logic
         }
       end
 
+      protected
+
+      def config_entitlement
+        'custom_branding'
+      end
+
+      def config_entitlement_error
+        'Custom branding requires the custom_branding entitlement. Please upgrade your plan.'
+      end
+
+      def authorize_domain_brand!(domain_id)
+        authorize_domain_config!(domain_id)
+      end
+
+      private
+
       def image_exists?
         _image_field.key?('encoded')
       end
-      private :image_exists?
 
       # e.g. custom_domain.logo
       def _image_field
         custom_domain.send(self.class.field)
       end
-      private :_image_field
     end
 
     class RemoveDomainLogo < RemoveDomainImage

--- a/apps/api/domains/logic/domains/remove_domain_image.rb
+++ b/apps/api/domains/logic/domains/remove_domain_image.rb
@@ -8,6 +8,19 @@ require_relative '../concerns/domain_config_authorization'
 
 module DomainsAPI::Logic
   module Domains
+    # Remove Domain Image
+    #
+    # @api Removes a stored image (logo or icon) from a custom domain.
+    #
+    # Authorization model (via DomainConfigAuthorization):
+    #   1. Load CustomDomain by extid
+    #   2. Load Organization via domain.org_id
+    #   3. Verify user has manage_org in the organization
+    #   4. Verify organization has custom_branding entitlement
+    #
+    # Read-only counterpart GetDomainImage skips manage_org so regular
+    # members can view the brand page (disabled overlay in the UI).
+    #
     class RemoveDomainImage < DomainsAPI::Logic::Base
       include DomainsAPI::Logic::Concerns::DomainConfigAuthorization
 

--- a/apps/api/domains/logic/domains/update_domain_brand.rb
+++ b/apps/api/domains/logic/domains/update_domain_brand.rb
@@ -159,6 +159,9 @@ module DomainsAPI::Logic
         raise_form_error "Invalid corner style - must be one of: #{Onetime::CustomDomain::BrandSettings::CORNERS.join(', ')}"
       end
 
+      # Currently disabled (see raise_concerns). When re-enabled, uses
+      # org-membership-level check rather than the previous user-level check,
+      # since domain branding is an org-scoped feature.
       def validate_privacy_defaults_entitlement
         privacy_keys = %w[default_ttl passphrase_required notify_enabled]
         return unless privacy_keys.any? { |k| @brand_settings.key?(k) }

--- a/apps/api/domains/logic/domains/update_domain_brand.rb
+++ b/apps/api/domains/logic/domains/update_domain_brand.rb
@@ -185,7 +185,11 @@ module DomainsAPI::Logic
           raise_form_error 'Invalid default TTL - must be a positive integer (seconds)'
         end
 
-        # Gate extended TTL values behind entitlement
+        # Gate extended TTL values behind entitlement.
+        # Intentionally uses org-membership-level check (require_entitlement_in!)
+        # rather than the previous user-level check (require_entitlement!), since
+        # domain branding is an org-scoped feature — the entitlement should flow
+        # from org membership, not personal grants.
         free_ttl = Onetime::Models::Features::WithEntitlements::DEFAULT_FREE_TTL
         if ttl_value > free_ttl
           require_entitlement_in!(@organization, 'extended_default_expiration')

--- a/apps/api/domains/logic/domains/update_domain_brand.rb
+++ b/apps/api/domains/logic/domains/update_domain_brand.rb
@@ -5,7 +5,7 @@
 require 'onetime/domain_validation/strategy'
 require 'onetime/domain_validation/features'
 require_relative '../base'
-require_relative '../concerns/domain_config_authorization'
+require_relative '../../policies/domain_config_authorization'
 
 module DomainsAPI::Logic
   module Domains
@@ -25,7 +25,7 @@ module DomainsAPI::Logic
     # members can view the brand page (disabled overlay in the UI).
     #
     class UpdateDomainBrand < DomainsAPI::Logic::Base
-      include DomainsAPI::Logic::Concerns::DomainConfigAuthorization
+      include DomainsAPI::Policies::DomainConfigAuthorization
 
       SCHEMAS = { response: 'brandSettings' }.freeze
 

--- a/apps/api/domains/logic/domains/update_domain_brand.rb
+++ b/apps/api/domains/logic/domains/update_domain_brand.rb
@@ -50,7 +50,7 @@ module DomainsAPI::Logic
         raise_form_error 'Please provide a domain ID' if @extid.to_s.empty?
         raise_form_error 'Invalid domain identifier format' unless valid_extid?(@extid)
 
-        authorize_domain_brand!(@extid)
+        authorize_domain_config!(@extid)
 
         validate_brand_settings
         validate_brand_values
@@ -111,10 +111,6 @@ module DomainsAPI::Logic
 
       def config_entitlement_error
         'Custom branding requires the custom_branding entitlement. Please upgrade your plan.'
-      end
-
-      def authorize_domain_brand!(domain_id)
-        authorize_domain_config!(domain_id)
       end
 
       private

--- a/apps/api/domains/logic/domains/update_domain_brand.rb
+++ b/apps/api/domains/logic/domains/update_domain_brand.rb
@@ -35,11 +35,14 @@ module DomainsAPI::Logic
       # Validate the input parameters
       # Sets error messages if any parameter is invalid
       def raise_concerns
-        require_entitlement!('custom_branding')
-
         OT.ld "[UpdateDomainBrand] Validating domain: #{@extid} with settings: #{@brand_settings.keys}"
 
         validate_domain
+
+        domain_org = @custom_domain.primary_organization
+        raise_form_error 'Domain has no associated organization' unless domain_org
+        require_entitlement_in!(domain_org, 'custom_branding')
+
         validate_brand_settings
 
         validate_brand_values
@@ -171,7 +174,8 @@ module DomainsAPI::Logic
         privacy_keys = %w[default_ttl passphrase_required notify_enabled]
         return unless privacy_keys.any? { |k| @brand_settings.key?(k) }
 
-        require_entitlement!('custom_privacy_defaults')
+        domain_org = @custom_domain.primary_organization
+        require_entitlement_in!(domain_org, 'custom_privacy_defaults')
       end
 
       def validate_default_ttl
@@ -197,7 +201,8 @@ module DomainsAPI::Logic
         # Gate extended TTL values behind entitlement
         free_ttl = Onetime::Models::Features::WithEntitlements::DEFAULT_FREE_TTL
         if ttl_value > free_ttl
-          require_entitlement!('extended_default_expiration')
+          domain_org = @custom_domain.primary_organization
+          require_entitlement_in!(domain_org, 'extended_default_expiration')
         end
 
         # Update the brand_settings hash with the coerced value

--- a/apps/api/domains/logic/domains/update_domain_brand.rb
+++ b/apps/api/domains/logic/domains/update_domain_brand.rb
@@ -39,9 +39,9 @@ module DomainsAPI::Logic
 
         validate_domain
 
-        domain_org = @custom_domain.primary_organization
-        raise_form_error 'Domain has no associated organization' unless domain_org
-        require_entitlement_in!(domain_org, 'custom_branding')
+        @domain_org = @custom_domain.primary_organization
+        raise_form_error 'Domain has no associated organization' unless @domain_org
+        require_entitlement_in!(@domain_org, 'custom_branding')
 
         validate_brand_settings
 
@@ -174,8 +174,7 @@ module DomainsAPI::Logic
         privacy_keys = %w[default_ttl passphrase_required notify_enabled]
         return unless privacy_keys.any? { |k| @brand_settings.key?(k) }
 
-        domain_org = @custom_domain.primary_organization
-        require_entitlement_in!(domain_org, 'custom_privacy_defaults')
+        require_entitlement_in!(@domain_org, 'custom_privacy_defaults')
       end
 
       def validate_default_ttl
@@ -201,8 +200,7 @@ module DomainsAPI::Logic
         # Gate extended TTL values behind entitlement
         free_ttl = Onetime::Models::Features::WithEntitlements::DEFAULT_FREE_TTL
         if ttl_value > free_ttl
-          domain_org = @custom_domain.primary_organization
-          require_entitlement_in!(domain_org, 'extended_default_expiration')
+          require_entitlement_in!(@domain_org, 'extended_default_expiration')
         end
 
         # Update the brand_settings hash with the coerced value

--- a/apps/api/domains/logic/domains/update_domain_brand.rb
+++ b/apps/api/domains/logic/domains/update_domain_brand.rb
@@ -5,6 +5,7 @@
 require 'onetime/domain_validation/strategy'
 require 'onetime/domain_validation/features'
 require_relative '../base'
+require_relative '../concerns/domain_config_authorization'
 
 module DomainsAPI::Logic
   module Domains
@@ -12,9 +13,11 @@ module DomainsAPI::Logic
     #
     # @api Updates brand settings for a custom domain including name,
     #   tagline, primary color, font family, corner style, homepage URL,
-    #   and default TTL. Requires the custom_branding entitlement.
-    #   Returns the updated brand settings.
+    #   and default TTL. Requires the custom_branding entitlement and
+    #   manage_org permission. Returns the updated brand settings.
     class UpdateDomainBrand < DomainsAPI::Logic::Base
+      include DomainsAPI::Logic::Concerns::DomainConfigAuthorization
+
       SCHEMAS = { response: 'brandSettings' }.freeze
 
       attr_reader :greenlighted, :brand_settings, :display_domain, :custom_domain
@@ -32,19 +35,15 @@ module DomainsAPI::Logic
         @brand_settings = params['brand']&.transform_keys(&:to_s)&.slice(*valid_keys) || {}
       end
 
-      # Validate the input parameters
-      # Sets error messages if any parameter is invalid
       def raise_concerns
         OT.ld "[UpdateDomainBrand] Validating domain: #{@extid} with settings: #{@brand_settings.keys}"
 
-        validate_domain
+        raise_form_error 'Please provide a domain ID' if @extid.to_s.empty?
+        raise_form_error 'Invalid domain identifier format' unless valid_extid?(@extid)
 
-        @domain_org = @custom_domain.primary_organization
-        raise_form_error 'Domain has no associated organization' unless @domain_org
-        require_entitlement_in!(@domain_org, 'custom_branding')
+        authorize_domain_brand!(@extid)
 
         validate_brand_settings
-
         validate_brand_values
 
         # Disabled while we figure out whether we want this entitlement at all
@@ -71,7 +70,6 @@ module DomainsAPI::Logic
       # Update the brand settings for the custom domain
       # Familia v2 hashkeys auto-serialize via serialize_value, so pass raw values
       def update_brand_settings
-        # Update or remove brand settings - Familia handles JSON serialization automatically
         brand_settings.each do |key, value|
           if value.nil?
             OT.ld "[UpdateDomainBrand] Removing brand setting: #{key}"
@@ -96,35 +94,21 @@ module DomainsAPI::Logic
         false
       end
 
-      private
+      protected
 
-      def validate_domain
-        if @extid.nil? || @extid.empty?
-          OT.ld '[UpdateDomainBrand] Error: Missing domain ID'
-          raise_form_error 'Please provide a domain ID'
-        end
-
-        # Validate extid format (alphanumeric only, no dots/special chars)
-        # This catches cases where domain name is passed instead of extid
-        unless valid_extid?(@extid)
-          OT.ld "[UpdateDomainBrand] Error: Invalid extid format '#{@extid}'"
-          raise_form_error 'Invalid domain identifier format'
-        end
-
-        # Get customer's organization for domain ownership
-        # Organization available via @organization
-        require_organization!
-
-        @custom_domain = Onetime::CustomDomain.find_by_extid(@extid)
-
-        raise_form_error 'Domain not found' unless @custom_domain&.exists?
-
-        # Verify the customer owns this domain through their organization
-        unless @custom_domain.owner?(@cust)
-          OT.ld "[UpdateDomainBrand] Error: Domain #{@extid} not owned by organization #{organization.objid}"
-          raise_form_error 'Domain not found'
-        end
+      def config_entitlement
+        'custom_branding'
       end
+
+      def config_entitlement_error
+        'Custom branding requires the custom_branding entitlement. Please upgrade your plan.'
+      end
+
+      def authorize_domain_brand!(domain_id)
+        authorize_domain_config!(domain_id)
+      end
+
+      private
 
       def validate_brand_settings
         return if @brand_settings.is_a?(Hash)
@@ -174,14 +158,13 @@ module DomainsAPI::Logic
         privacy_keys = %w[default_ttl passphrase_required notify_enabled]
         return unless privacy_keys.any? { |k| @brand_settings.key?(k) }
 
-        require_entitlement_in!(@domain_org, 'custom_privacy_defaults')
+        require_entitlement_in!(@organization, 'custom_privacy_defaults')
       end
 
       def validate_default_ttl
         ttl = @brand_settings['default_ttl']
         return if ttl.nil?
 
-        # Coerce to integer if string with strict validation
         ttl_value = ttl
         if ttl.is_a?(String)
           begin
@@ -200,16 +183,12 @@ module DomainsAPI::Logic
         # Gate extended TTL values behind entitlement
         free_ttl = Onetime::Models::Features::WithEntitlements::DEFAULT_FREE_TTL
         if ttl_value > free_ttl
-          require_entitlement_in!(@domain_org, 'extended_default_expiration')
+          require_entitlement_in!(@organization, 'extended_default_expiration')
         end
 
-        # Update the brand_settings hash with the coerced value
         @brand_settings['default_ttl'] = ttl_value
       end
 
-      # Validate extid format (lowercase alphanumeric only)
-      # extids are generated identifiers like "abc123def456"
-      # Domain names contain dots and are not valid extids
       def valid_extid?(extid)
         extid.match?(/\A[a-z0-9]+\z/)
       end

--- a/apps/api/domains/logic/domains/update_domain_brand.rb
+++ b/apps/api/domains/logic/domains/update_domain_brand.rb
@@ -13,8 +13,17 @@ module DomainsAPI::Logic
     #
     # @api Updates brand settings for a custom domain including name,
     #   tagline, primary color, font family, corner style, homepage URL,
-    #   and default TTL. Requires the custom_branding entitlement and
-    #   manage_org permission. Returns the updated brand settings.
+    #   and default TTL. Returns the updated brand settings.
+    #
+    # Authorization model (via DomainConfigAuthorization):
+    #   1. Load CustomDomain by extid
+    #   2. Load Organization via domain.org_id
+    #   3. Verify user has manage_org in the organization
+    #   4. Verify organization has custom_branding entitlement
+    #
+    # Read-only counterpart GetDomainBrand skips manage_org so regular
+    # members can view the brand page (disabled overlay in the UI).
+    #
     class UpdateDomainBrand < DomainsAPI::Logic::Base
       include DomainsAPI::Logic::Concerns::DomainConfigAuthorization
 

--- a/apps/api/domains/logic/domains/update_domain_image.rb
+++ b/apps/api/domains/logic/domains/update_domain_image.rb
@@ -82,7 +82,7 @@ module DomainsAPI::Logic
       def raise_concerns
         raise_form_error 'Domain ID is required' if @extid.empty?
 
-        authorize_domain_brand!(@extid)
+        authorize_domain_config!(@extid)
 
         @display_domain = @custom_domain.display_domain
 
@@ -143,10 +143,6 @@ module DomainsAPI::Logic
 
       def config_entitlement_error
         'Custom branding requires the custom_branding entitlement. Please upgrade your plan.'
-      end
-
-      def authorize_domain_brand!(domain_id)
-        authorize_domain_config!(domain_id)
       end
 
       private

--- a/apps/api/domains/logic/domains/update_domain_image.rb
+++ b/apps/api/domains/logic/domains/update_domain_image.rb
@@ -7,6 +7,7 @@ require 'fastimage'
 
 require 'onetime/domain_validation/strategy'
 require_relative '../base'
+require_relative '../concerns/domain_config_authorization'
 
 module DomainsAPI::Logic
   module Domains
@@ -21,9 +22,12 @@ module DomainsAPI::Logic
     #
     # @api Uploads and stores an image (logo or icon) for a custom domain.
     #   Accepts standard image formats (JPEG, PNG, GIF, SVG, WebP, BMP,
-    #   TIFF) up to 2 MB. Requires the custom_branding entitlement.
-    #   Returns the stored image metadata including dimensions and ratio.
+    #   TIFF) up to 2 MB. Requires the custom_branding entitlement and
+    #   manage_org permission. Returns the stored image metadata including
+    #   dimensions and ratio.
     class UpdateDomainImage < DomainsAPI::Logic::Base
+      include DomainsAPI::Logic::Concerns::DomainConfigAuthorization
+
       SCHEMAS = { response: 'imageProps' }.freeze
 
       attr_reader :greenlighted,
@@ -43,75 +47,40 @@ module DomainsAPI::Logic
         attr_reader :field
       end
 
-      # Processes the parameters for the domain logo update.
-      # Extracts and sets instance variables for the domain extid and uploaded image file.
-      # Handles cases where the image parameter is either a hash (from a form upload) or a file object directly.
       def process_params
-        # Sanitize the extid to only allow alphanumeric, underscore, and hyphen characters
         @extid = sanitize_identifier(params['extid'])
 
-        # Debug: Log what we received
         OT.ld "[UpdateDomainImage] params keys: #{params.keys.inspect}"
         OT.ld "[UpdateDomainImage] params['image'] class: #{params['image'].class}"
         OT.ld "[UpdateDomainImage] params['image']: #{params['image'].inspect.slice(0, 200)}"
 
-        # Retrieve the image parameter from the request.
         # Rack 3's multipart parser returns symbol keys (:tempfile, :filename, :type)
         # Stringify them to maintain consistent string keys at API boundaries
         @image = params['image']
         @image = @image.transform_keys(&:to_s) if @image.is_a?(Hash)
 
-        # Check if the image parameter is a hash (typical for form uploads).
         if @image.is_a?(Hash) && @image['tempfile']
-          # Extract the tempfile, filename, and content type from the hash.
           @uploaded_file = @image['tempfile']
           @filename      = @image['filename']
           @content_type  = @image['type']
-
-        # Check if the image parameter is a file object directly
-        # (e.g. it's the Tempfile or StringIO).
         elsif @image.respond_to?(:read)
-          # Set the uploaded file to the image parameter directly.
           @uploaded_file = @image
-          # Extract the original filename if available.
           @filename      = @image.original_filename if @image.respond_to?(:original_filename)
-          # Extract the content type if available.
           @content_type  = @image.content_type if @image.respond_to?(:content_type)
         end
       end
 
-      # Validate the input parameters
-      # Sets error messages if any parameter is invalid
       def raise_concerns
         raise_form_error 'Domain ID is required' if @extid.empty?
 
-        # Get customer's organization for domain ownership
-        # Organization available via @organization
-        require_organization!
-
-        # Check if the domain exists and belongs to the current customer
-        @custom_domain = Onetime::CustomDomain.find_by_extid(@extid)
-        raise_form_error 'Invalid Domain' unless @custom_domain
-
-        # Verify the customer owns this domain through their organization
-        unless @custom_domain.owner?(@cust)
-          raise_form_error 'Invalid Domain'
-        end
-
-        domain_org = @custom_domain.primary_organization
-        raise_form_error 'Domain has no associated organization' unless domain_org
-        require_entitlement_in!(domain_org, 'custom_branding')
+        authorize_domain_brand!(@extid)
 
         @display_domain = @custom_domain.display_domain
 
-        # Validate the logo file
         raise_form_error 'Image file is required' unless @uploaded_file
 
         @bytes = @uploaded_file.size
         raise_form_error 'Image file is too large' if bytes > MAX_IMAGE_BYTES
-
-        # Raise an error if the file type is not one of the allowed image types
-        # Allowed types: JPEG, PNG, GIF, SVG, WEBP, BMP, TIFF
         raise_form_error 'Invalid file type' unless IMAGE_MIME_TYPES.include?(@content_type)
 
         @greenlighted = true
@@ -157,11 +126,26 @@ module DomainsAPI::Logic
         }
       end
 
+      protected
+
+      def config_entitlement
+        'custom_branding'
+      end
+
+      def config_entitlement_error
+        'Custom branding requires the custom_branding entitlement. Please upgrade your plan.'
+      end
+
+      def authorize_domain_brand!(domain_id)
+        authorize_domain_config!(domain_id)
+      end
+
+      private
+
       # e.g. custom_domain.logo
       def _image_field
         custom_domain.send(self.class.field)
       end
-      private :_image_field
     end
 
     class UpdateDomainLogo < UpdateDomainImage

--- a/apps/api/domains/logic/domains/update_domain_image.rb
+++ b/apps/api/domains/logic/domains/update_domain_image.rb
@@ -7,7 +7,7 @@ require 'fastimage'
 
 require 'onetime/domain_validation/strategy'
 require_relative '../base'
-require_relative '../concerns/domain_config_authorization'
+require_relative '../../policies/domain_config_authorization'
 
 module DomainsAPI::Logic
   module Domains
@@ -35,7 +35,7 @@ module DomainsAPI::Logic
     # members can view the brand page (disabled overlay in the UI).
     #
     class UpdateDomainImage < DomainsAPI::Logic::Base
-      include DomainsAPI::Logic::Concerns::DomainConfigAuthorization
+      include DomainsAPI::Policies::DomainConfigAuthorization
 
       SCHEMAS = { response: 'imageProps' }.freeze
 

--- a/apps/api/domains/logic/domains/update_domain_image.rb
+++ b/apps/api/domains/logic/domains/update_domain_image.rb
@@ -22,9 +22,18 @@ module DomainsAPI::Logic
     #
     # @api Uploads and stores an image (logo or icon) for a custom domain.
     #   Accepts standard image formats (JPEG, PNG, GIF, SVG, WebP, BMP,
-    #   TIFF) up to 2 MB. Requires the custom_branding entitlement and
-    #   manage_org permission. Returns the stored image metadata including
+    #   TIFF) up to 2 MB. Returns the stored image metadata including
     #   dimensions and ratio.
+    #
+    # Authorization model (via DomainConfigAuthorization):
+    #   1. Load CustomDomain by extid
+    #   2. Load Organization via domain.org_id
+    #   3. Verify user has manage_org in the organization
+    #   4. Verify organization has custom_branding entitlement
+    #
+    # Read-only counterpart GetDomainImage skips manage_org so regular
+    # members can view the brand page (disabled overlay in the UI).
+    #
     class UpdateDomainImage < DomainsAPI::Logic::Base
       include DomainsAPI::Logic::Concerns::DomainConfigAuthorization
 

--- a/apps/api/domains/logic/domains/update_domain_image.rb
+++ b/apps/api/domains/logic/domains/update_domain_image.rb
@@ -81,6 +81,7 @@ module DomainsAPI::Logic
 
       def raise_concerns
         raise_form_error 'Domain ID is required' if @extid.empty?
+        raise_form_error 'Invalid domain identifier format' unless @extid.match?(/\A[a-z0-9]+\z/)
 
         authorize_domain_config!(@extid)
 

--- a/apps/api/domains/logic/domains/update_domain_image.rb
+++ b/apps/api/domains/logic/domains/update_domain_image.rb
@@ -83,8 +83,6 @@ module DomainsAPI::Logic
       # Validate the input parameters
       # Sets error messages if any parameter is invalid
       def raise_concerns
-        require_entitlement!('custom_branding')
-
         raise_form_error 'Domain ID is required' if @extid.empty?
 
         # Get customer's organization for domain ownership
@@ -99,6 +97,10 @@ module DomainsAPI::Logic
         unless @custom_domain.owner?(@cust)
           raise_form_error 'Invalid Domain'
         end
+
+        domain_org = @custom_domain.primary_organization
+        raise_form_error 'Domain has no associated organization' unless domain_org
+        require_entitlement_in!(domain_org, 'custom_branding')
 
         @display_domain = @custom_domain.display_domain
 

--- a/apps/api/domains/logic/homepage_config/base.rb
+++ b/apps/api/domains/logic/homepage_config/base.rb
@@ -3,7 +3,7 @@
 # frozen_string_literal: true
 
 require 'onetime/models/custom_domain/homepage_config'
-require_relative '../concerns/domain_config_authorization'
+require_relative '../../policies/domain_config_authorization'
 
 module DomainsAPI
   module Logic
@@ -17,7 +17,7 @@ module DomainsAPI
       #   4. Verify organization has homepage_secrets entitlement
       #
       class Base < DomainsAPI::Logic::Base
-        include DomainsAPI::Logic::Concerns::DomainConfigAuthorization
+        include DomainsAPI::Policies::DomainConfigAuthorization
 
         attr_reader :custom_domain, :organization
 

--- a/apps/api/domains/logic/sender_config/base.rb
+++ b/apps/api/domains/logic/sender_config/base.rb
@@ -3,7 +3,7 @@
 # frozen_string_literal: true
 
 require 'onetime/models/custom_domain/mailer_config'
-require_relative '../concerns/domain_config_authorization'
+require_relative '../../policies/domain_config_authorization'
 
 module DomainsAPI
   module Logic
@@ -18,7 +18,7 @@ module DomainsAPI
       #   5. Verify organization has custom_mail_sender entitlement
       #
       class Base < DomainsAPI::Logic::Base
-        include DomainsAPI::Logic::Concerns::DomainConfigAuthorization
+        include DomainsAPI::Policies::DomainConfigAuthorization
 
         VERIFICATION_STATUS_PENDING = 'pending'
 

--- a/apps/api/domains/logic/signup_config/base.rb
+++ b/apps/api/domains/logic/signup_config/base.rb
@@ -4,7 +4,7 @@
 
 require 'public_suffix'
 require 'onetime/models/custom_domain/signup_config'
-require_relative '../concerns/domain_config_authorization'
+require_relative '../../policies/domain_config_authorization'
 
 module DomainsAPI
   module Logic
@@ -18,7 +18,7 @@ module DomainsAPI
       #   4. Verify organization has custom_signup_validation entitlement
       #
       class Base < DomainsAPI::Logic::Base
-        include DomainsAPI::Logic::Concerns::DomainConfigAuthorization
+        include DomainsAPI::Policies::DomainConfigAuthorization
 
         attr_reader :custom_domain, :organization
 

--- a/apps/api/domains/logic/sso_config/base.rb
+++ b/apps/api/domains/logic/sso_config/base.rb
@@ -3,7 +3,7 @@
 # frozen_string_literal: true
 
 require 'onetime/models/custom_domain/sso_config'
-require_relative '../concerns/domain_config_authorization'
+require_relative '../../policies/domain_config_authorization'
 
 module DomainsAPI
   module Logic
@@ -18,7 +18,7 @@ module DomainsAPI
       #   5. Verify organization has manage_sso entitlement
       #
       class Base < DomainsAPI::Logic::Base
-        include DomainsAPI::Logic::Concerns::DomainConfigAuthorization
+        include DomainsAPI::Policies::DomainConfigAuthorization
 
         attr_reader :custom_domain, :organization
 

--- a/apps/api/domains/policies/domain_config_authorization.rb
+++ b/apps/api/domains/policies/domain_config_authorization.rb
@@ -1,62 +1,61 @@
-# apps/api/domains/logic/concerns/domain_config_authorization.rb
+# apps/api/domains/policies/domain_config_authorization.rb
 #
 # frozen_string_literal: true
 
 require 'onetime/application/authorization_policies'
 
 module DomainsAPI
-  module Logic
-    module Concerns
-      # Shared authorization logic for domain config endpoints.
-      #
-      # Provides the common authorization flow used by domain config
-      # base classes (ApiConfig, HomepageConfig, SenderConfig, SsoConfig)
-      # and write-path brand/image endpoints (UpdateDomainBrand,
-      # UpdateDomainImage, RemoveDomainImage):
-      #
-      #   1. Check feature flag (if config_feature_flag is defined)
-      #   2. Load CustomDomain by domain_id (extid)
-      #   3. Load Organization via domain.org_id
-      #   4. Verify user has manage_org in the organization (colonel bypass)
-      #   5. Verify organization has the required entitlement
-      #
-      # Read-only brand/image endpoints (GetDomainBrand, GetDomainImage)
-      # intentionally skip this concern — they check custom_branding
-      # membership directly so regular org members can view the brand
-      # management page (rendered as a disabled overlay in the UI).
-      #
-      # Including classes must define:
-      #   - `config_entitlement` returning the entitlement name string
-      #   - `config_entitlement_error` returning the error message string
-      #
-      # Including classes may optionally define:
-      #   - `config_feature_flag` returning the feature flag path
-      #      (e.g. 'custom_mail_enabled') checked under
-      #      features.organizations in config. Returns nil by default
-      #      (no feature flag check).
-      #   - `config_feature_flag_error` returning the error message when
-      #      the feature flag is disabled.
-      #   - `config_log_tag` returning a string tag for structured log
-      #      messages (e.g. 'SenderConfig'). Defaults to the enclosing
-      #      module's short name.
-      #
-      # Example:
-      #
-      #   class Base < DomainsAPI::Logic::Base
-      #     include DomainsAPI::Logic::Concerns::DomainConfigAuthorization
-      #
-      #     protected
-      #
-      #     def config_entitlement
-      #       'api_access'
-      #     end
-      #
-      #     def config_entitlement_error
-      #       'API configuration requires the api_access entitlement. Please upgrade your plan.'
-      #     end
-      #   end
-      #
-      module DomainConfigAuthorization
+  module Policies
+    # Shared authorization policy for domain config endpoints.
+    #
+    # Provides the common authorization flow used by domain config
+    # base classes (ApiConfig, HomepageConfig, SenderConfig, SsoConfig)
+    # and write-path brand/image endpoints (UpdateDomainBrand,
+    # UpdateDomainImage, RemoveDomainImage):
+    #
+    #   1. Check feature flag (if config_feature_flag is defined)
+    #   2. Load CustomDomain by domain_id (extid)
+    #   3. Load Organization via domain.org_id
+    #   4. Verify user has manage_org in the organization (colonel bypass)
+    #   5. Verify organization has the required entitlement
+    #
+    # Read-only brand/image endpoints (GetDomainBrand, GetDomainImage)
+    # intentionally skip this policy — they check custom_branding
+    # membership directly so regular org members can view the brand
+    # management page (rendered as a disabled overlay in the UI).
+    #
+    # Including classes must define:
+    #   - `config_entitlement` returning the entitlement name string
+    #   - `config_entitlement_error` returning the error message string
+    #
+    # Including classes may optionally define:
+    #   - `config_feature_flag` returning the feature flag path
+    #      (e.g. 'custom_mail_enabled') checked under
+    #      features.organizations in config. Returns nil by default
+    #      (no feature flag check).
+    #   - `config_feature_flag_error` returning the error message when
+    #      the feature flag is disabled.
+    #   - `config_log_tag` returning a string tag for structured log
+    #      messages (e.g. 'SenderConfig'). Defaults to the enclosing
+    #      module's short name.
+    #
+    # Example:
+    #
+    #   class Base < DomainsAPI::Logic::Base
+    #     include DomainsAPI::Policies::DomainConfigAuthorization
+    #
+    #     protected
+    #
+    #     def config_entitlement
+    #       'api_access'
+    #     end
+    #
+    #     def config_entitlement_error
+    #       'API configuration requires the api_access entitlement. Please upgrade your plan.'
+    #     end
+    #   end
+    #
+    module DomainConfigAuthorization
         def self.included(base)
           base.include Onetime::Application::AuthorizationPolicies
         end
@@ -176,7 +175,6 @@ module DomainsAPI
             { domain_id: domain_id, actor: cust&.custid }.to_json
           raise_form_error(config_feature_flag_error, error_type: :forbidden)
         end
-      end
     end
   end
 end

--- a/apps/api/domains/policies/domain_config_authorization.rb
+++ b/apps/api/domains/policies/domain_config_authorization.rb
@@ -85,7 +85,20 @@ module DomainsAPI
         org
       end
 
-      # Verify organization has the required entitlement.
+      # Verify organization has the required entitlement at the plan level.
+      #
+      # Uses organization.can? (org plan capabilities) rather than
+      # membership.can? (per-member entitlements). This is intentional:
+      # authorize_domain_config! already verifies the user is an active
+      # member with manage_org via require_entitlement_in!, so this
+      # step answers "does the org's plan include this feature?" — not
+      # "does this individual member have the feature?"
+      #
+      # Note: read-only endpoints (GetDomainBrand, GetDomainImage) use
+      # require_entitlement_in! which checks membership-level entitlements
+      # instead. The two checks can diverge when per-member grants/revokes
+      # are in play (ADR-012), but this matches the existing pattern across
+      # all config endpoints.
       #
       # Delegates to `config_entitlement` for the entitlement name and
       # `config_entitlement_error` for the error message. Both must be

--- a/apps/api/domains/policies/domain_config_authorization.rb
+++ b/apps/api/domains/policies/domain_config_authorization.rb
@@ -20,9 +20,10 @@ module DomainsAPI
     #   5. Verify organization has the required entitlement
     #
     # Read-only brand/image endpoints (GetDomainBrand, GetDomainImage)
-    # intentionally skip this policy — they check custom_branding
-    # membership directly so regular org members can view the brand
-    # management page (rendered as a disabled overlay in the UI).
+    # include this module but intentionally skip authorize_domain_config! —
+    # they call load_custom_domain / load_organization_for_domain /
+    # require_entitlement_in! directly so regular org members (without
+    # manage_org) can view the brand page as a disabled overlay in the UI.
     #
     # Including classes must define:
     #   - `config_entitlement` returning the entitlement name string
@@ -56,125 +57,125 @@ module DomainsAPI
     #   end
     #
     module DomainConfigAuthorization
-        def self.included(base)
-          base.include Onetime::Application::AuthorizationPolicies
+      def self.included(base)
+        base.include Onetime::Application::AuthorizationPolicies
+      end
+
+      protected
+
+      # Load and verify domain exists.
+      #
+      # @param domain_id [String] Domain extid
+      # @return [Onetime::CustomDomain] The loaded domain
+      # @raise [FormError] if domain not found
+      def load_custom_domain(domain_id)
+        domain = Onetime::CustomDomain.find_by_extid(domain_id)
+        raise_not_found("Domain not found: #{domain_id}") if domain.nil?
+        domain
+      end
+
+      # Load organization from domain's org_id.
+      #
+      # @param domain [Onetime::CustomDomain] The domain
+      # @return [Onetime::Organization] The owning organization
+      # @raise [FormError] if organization not found
+      def load_organization_for_domain(domain)
+        org = Onetime::Organization.load(domain.org_id)
+        raise_not_found("Organization not found for domain: #{domain.display_domain}") if org.nil?
+        org
+      end
+
+      # Verify organization has the required entitlement.
+      #
+      # Delegates to `config_entitlement` for the entitlement name and
+      # `config_entitlement_error` for the error message. Both must be
+      # defined by the including class.
+      #
+      # @param organization [Onetime::Organization]
+      # @raise [FormError] if entitlement not present
+      def verify_config_entitlement(organization)
+        return if organization.can?(config_entitlement)
+
+        OT.info format('[%s] Authorization denied: missing %s entitlement', config_log_tag, config_entitlement),
+          { org_id: organization.extid, actor: cust&.custid }.to_json
+        raise_form_error(
+          config_entitlement_error,
+          error_type: :forbidden,
+        )
+      end
+
+      # Feature flag path under features.organizations config.
+      # Override in subclass to require a feature flag. Returns nil
+      # by default (no feature flag check).
+      #
+      # @return [String, nil] Feature flag key or nil
+      def config_feature_flag
+        nil
+      end
+
+      # Error message when the feature flag is disabled.
+      # Override in subclass to customize.
+      #
+      # @return [String]
+      def config_feature_flag_error
+        "#{config_log_tag} is not enabled on this instance"
+      end
+
+      # Log tag for structured log messages. Defaults to the
+      # enclosing module's short name (e.g. 'SsoConfig').
+      #
+      # @return [String]
+      def config_log_tag
+        self.class.name&.split('::')&.[](-2) || self.class.to_s
+      end
+
+      # Full authorization check for domain config operations.
+      # Loads domain and organization, verifies ownership and entitlement.
+      #
+      # Sets @custom_domain and @organization as side effects.
+      #
+      # @param domain_id [String] Domain extid
+      # @return [void]
+      def authorize_domain_config!(domain_id)
+        verify_feature_flag!(domain_id)
+
+        @custom_domain = load_custom_domain(domain_id)
+        @organization  = load_organization_for_domain(@custom_domain)
+
+        require_entitlement_in!(@organization, 'manage_org')
+        verify_config_entitlement(@organization)
+
+        OT.ld format('[%s] Authorization granted: domain=%s org=%s actor=%s', config_log_tag, @custom_domain.display_domain, @organization.extid, cust&.custid)
+      end
+
+      # Parse boolean from various input formats.
+      #
+      # @param value [Boolean, String, Integer, nil] Value to parse
+      # @return [Boolean] true if value represents truthy, false otherwise
+      def parse_boolean(value)
+        case value
+        when true, 'true', '1', 1
+          true
+        else
+          false
         end
+      end
 
-        protected
+      private
 
-        # Load and verify domain exists.
-        #
-        # @param domain_id [String] Domain extid
-        # @return [Onetime::CustomDomain] The loaded domain
-        # @raise [FormError] if domain not found
-        def load_custom_domain(domain_id)
-          domain = Onetime::CustomDomain.find_by_extid(domain_id)
-          raise_not_found("Domain not found: #{domain_id}") if domain.nil?
-          domain
-        end
+      # Check the feature flag if one is configured.
+      #
+      # @param domain_id [String] Domain extid (for logging)
+      # @raise [FormError] if feature flag is disabled
+      def verify_feature_flag!(domain_id)
+        flag = config_feature_flag
+        return if flag.nil?
+        return if OT.conf.dig('features', 'organizations', flag)
 
-        # Load organization from domain's org_id.
-        #
-        # @param domain [Onetime::CustomDomain] The domain
-        # @return [Onetime::Organization] The owning organization
-        # @raise [FormError] if organization not found
-        def load_organization_for_domain(domain)
-          org = Onetime::Organization.load(domain.org_id)
-          raise_not_found("Organization not found for domain: #{domain.display_domain}") if org.nil?
-          org
-        end
-
-        # Verify organization has the required entitlement.
-        #
-        # Delegates to `config_entitlement` for the entitlement name and
-        # `config_entitlement_error` for the error message. Both must be
-        # defined by the including class.
-        #
-        # @param organization [Onetime::Organization]
-        # @raise [FormError] if entitlement not present
-        def verify_config_entitlement(organization)
-          return if organization.can?(config_entitlement)
-
-          OT.info format('[%s] Authorization denied: missing %s entitlement', config_log_tag, config_entitlement),
-            { org_id: organization.extid, actor: cust&.custid }.to_json
-          raise_form_error(
-            config_entitlement_error,
-            error_type: :forbidden,
-          )
-        end
-
-        # Feature flag path under features.organizations config.
-        # Override in subclass to require a feature flag. Returns nil
-        # by default (no feature flag check).
-        #
-        # @return [String, nil] Feature flag key or nil
-        def config_feature_flag
-          nil
-        end
-
-        # Error message when the feature flag is disabled.
-        # Override in subclass to customize.
-        #
-        # @return [String]
-        def config_feature_flag_error
-          "#{config_log_tag} is not enabled on this instance"
-        end
-
-        # Log tag for structured log messages. Defaults to the
-        # enclosing module's short name (e.g. 'SsoConfig').
-        #
-        # @return [String]
-        def config_log_tag
-          self.class.name&.split('::')&.[](-2) || self.class.to_s
-        end
-
-        # Full authorization check for domain config operations.
-        # Loads domain and organization, verifies ownership and entitlement.
-        #
-        # Sets @custom_domain and @organization as side effects.
-        #
-        # @param domain_id [String] Domain extid
-        # @return [void]
-        def authorize_domain_config!(domain_id)
-          verify_feature_flag!(domain_id)
-
-          @custom_domain = load_custom_domain(domain_id)
-          @organization  = load_organization_for_domain(@custom_domain)
-
-          require_entitlement_in!(@organization, 'manage_org')
-          verify_config_entitlement(@organization)
-
-          OT.ld format('[%s] Authorization granted: domain=%s org=%s actor=%s', config_log_tag, @custom_domain.display_domain, @organization.extid, cust&.custid)
-        end
-
-        # Parse boolean from various input formats.
-        #
-        # @param value [Boolean, String, Integer, nil] Value to parse
-        # @return [Boolean] true if value represents truthy, false otherwise
-        def parse_boolean(value)
-          case value
-          when true, 'true', '1', 1
-            true
-          else
-            false
-          end
-        end
-
-        private
-
-        # Check the feature flag if one is configured.
-        #
-        # @param domain_id [String] Domain extid (for logging)
-        # @raise [FormError] if feature flag is disabled
-        def verify_feature_flag!(domain_id)
-          flag = config_feature_flag
-          return if flag.nil?
-          return if OT.conf.dig('features', 'organizations', flag)
-
-          OT.info format('[%s] Authorization denied: %s feature flag disabled', config_log_tag, flag),
-            { domain_id: domain_id, actor: cust&.custid }.to_json
-          raise_form_error(config_feature_flag_error, error_type: :forbidden)
-        end
+        OT.info format('[%s] Authorization denied: %s feature flag disabled', config_log_tag, flag),
+          { domain_id: domain_id, actor: cust&.custid }.to_json
+        raise_form_error(config_feature_flag_error, error_type: :forbidden)
+      end
     end
   end
 end

--- a/apps/api/domains/spec/logic/domains/get_domain_brand_spec.rb
+++ b/apps/api/domains/spec/logic/domains/get_domain_brand_spec.rb
@@ -1,0 +1,293 @@
+# apps/api/domains/spec/logic/domains/get_domain_brand_spec.rb
+#
+# frozen_string_literal: true
+
+# Unit tests for GetDomainBrand read-only authorization logic.
+#
+# GetDomainBrand includes DomainConfigAuthorization but intentionally
+# skips authorize_domain_config! — it calls load_custom_domain,
+# load_organization_for_domain, and require_entitlement_in! directly
+# so regular org members (without manage_org) can view brand settings
+# as a disabled overlay in the UI.
+#
+# RUN:
+#   pnpm run test:rspec apps/api/domains/spec/logic/domains/get_domain_brand_spec.rb
+
+require_relative File.join(Onetime::HOME, 'spec', 'spec_helper')
+require_relative '../../../../../../apps/api/domains/application'
+
+RSpec.describe DomainsAPI::Logic::Domains::GetDomainBrand do
+  let(:owner) do
+    instance_double(
+      Onetime::Customer,
+      custid: 'owner123',
+      objid: 'owner123',
+      extid: 'ext-owner123',
+      anonymous?: false,
+      verified?: true,
+    )
+  end
+
+  let(:member) do
+    instance_double(
+      Onetime::Customer,
+      custid: 'member123',
+      objid: 'member123',
+      extid: 'ext-member123',
+      anonymous?: false,
+      verified?: true,
+    )
+  end
+
+  let(:organization) do
+    instance_double(
+      Onetime::Organization,
+      objid: 'org123',
+      extid: 'ext-org123',
+      display_name: 'Test Org',
+    )
+  end
+
+  let(:brand_data) do
+    { name: 'Test Brand', primary_color: '#FF0000' }
+  end
+
+  let(:custom_domain) do
+    instance_double(
+      Onetime::CustomDomain,
+      identifier: 'domain123',
+      extid: 'ext-domain123',
+      display_domain: 'example.com',
+      org_id: 'org123',
+      safe_dump: { brand: brand_data },
+    )
+  end
+
+  let(:session) do
+    {
+      'authenticated' => true,
+      'csrf' => 'test-csrf-token',
+    }
+  end
+
+  let(:owner_strategy_result) do
+    double('StrategyResult',
+      session: session,
+      user: owner,
+      authenticated?: true,
+      metadata: {},
+    )
+  end
+
+  let(:member_strategy_result) do
+    double('StrategyResult',
+      session: session,
+      user: member,
+      authenticated?: true,
+      metadata: {},
+    )
+  end
+
+  let(:params) { { 'extid' => 'abc123' } }
+  let(:logic) { described_class.new(owner_strategy_result, params) }
+
+  let(:owner_membership) do
+    instance_double(
+      Onetime::OrganizationMembership,
+      active?: true,
+      can?: true,
+    )
+  end
+
+  let(:member_membership) do
+    instance_double(
+      Onetime::OrganizationMembership,
+      active?: true,
+    )
+  end
+
+  let(:non_member_membership) { nil }
+
+  before do
+    allow(OT).to receive(:info)
+    allow(OT).to receive(:ld)
+    allow(OT).to receive(:li)
+    allow(OT).to receive(:le)
+    allow(OT).to receive(:now).and_return(Time.now.to_i)
+
+    allow(Onetime::OrganizationMembership).to receive(:find_by_org_customer)
+      .with('org123', 'owner123')
+      .and_return(owner_membership)
+  end
+
+  describe 'policy integration' do
+    it 'includes DomainConfigAuthorization policy' do
+      expect(described_class).to be < DomainsAPI::Policies::DomainConfigAuthorization
+    end
+
+    it 'includes AuthorizationPolicies via the policy' do
+      expect(described_class).to be < Onetime::Application::AuthorizationPolicies
+    end
+
+    it 'returns custom_branding as config_entitlement' do
+      expect(logic.send(:config_entitlement)).to eq('custom_branding')
+    end
+
+    it 'returns nil as config_feature_flag (no feature flag for branding)' do
+      expect(logic.send(:config_feature_flag)).to be_nil
+    end
+
+    it 'returns Domains as config_log_tag' do
+      expect(logic.send(:config_log_tag)).to eq('Domains')
+    end
+  end
+
+  describe '#raise_concerns (read-only authorization)' do
+    context 'when extid is empty' do
+      let(:params) { { 'extid' => '' } }
+
+      it 'raises FormError' do
+        logic.process_params
+        expect { logic.raise_concerns }.to raise_error(Onetime::FormError, /domain ID/)
+      end
+    end
+
+    context 'when extid has invalid format' do
+      let(:params) { { 'extid' => 'ABC-123!' } }
+
+      it 'raises FormError for invalid identifier format' do
+        logic.process_params
+        expect { logic.raise_concerns }.to raise_error(Onetime::FormError, /Invalid domain identifier/)
+      end
+    end
+
+    context 'when domain not found' do
+      let(:params) { { 'extid' => 'nonexistent' } }
+
+      before do
+        allow(Onetime::CustomDomain).to receive(:find_by_extid).with('nonexistent').and_return(nil)
+      end
+
+      it 'raises RecordNotFound' do
+        logic.process_params
+        expect { logic.raise_concerns }.to raise_error(Onetime::RecordNotFound)
+      end
+    end
+
+    context 'when organization not found' do
+      before do
+        allow(Onetime::CustomDomain).to receive(:find_by_extid).with('abc123').and_return(custom_domain)
+        allow(Onetime::Organization).to receive(:load).with('org123').and_return(nil)
+      end
+
+      it 'raises RecordNotFound' do
+        logic.process_params
+        expect { logic.raise_concerns }.to raise_error(Onetime::RecordNotFound)
+      end
+    end
+
+    context 'when user is not a member of the organization' do
+      let(:outsider) do
+        instance_double(
+          Onetime::Customer,
+          custid: 'outsider123',
+          objid: 'outsider123',
+          extid: 'ext-outsider123',
+          anonymous?: false,
+          verified?: true,
+        )
+      end
+
+      let(:outsider_strategy_result) do
+        double('StrategyResult',
+          session: session,
+          user: outsider,
+          authenticated?: true,
+          metadata: {},
+        )
+      end
+
+      let(:logic) { described_class.new(outsider_strategy_result, params) }
+
+      before do
+        allow(Onetime::CustomDomain).to receive(:find_by_extid).with('abc123').and_return(custom_domain)
+        allow(Onetime::Organization).to receive(:load).with('org123').and_return(organization)
+        allow(outsider).to receive(:role).and_return('customer')
+        allow(Onetime::OrganizationMembership).to receive(:find_by_org_customer)
+          .with('org123', 'outsider123')
+          .and_return(nil)
+      end
+
+      it 'raises Forbidden' do
+        logic.process_params
+        expect { logic.raise_concerns }.to raise_error(Onetime::Forbidden)
+      end
+    end
+
+    context 'when member lacks custom_branding entitlement' do
+      let(:logic) { described_class.new(member_strategy_result, params) }
+
+      before do
+        allow(Onetime::CustomDomain).to receive(:find_by_extid).with('abc123').and_return(custom_domain)
+        allow(Onetime::Organization).to receive(:load).with('org123').and_return(organization)
+        allow(member).to receive(:role).and_return('customer')
+        allow(member_membership).to receive(:can?).with('custom_branding').and_return(false)
+        allow(Onetime::OrganizationMembership).to receive(:find_by_org_customer)
+          .with('org123', 'member123')
+          .and_return(member_membership)
+        allow(organization).to receive(:planid).and_return('basic')
+      end
+
+      it 'raises EntitlementRequired for custom_branding' do
+        logic.process_params
+        expect { logic.raise_concerns }.to raise_error(Onetime::EntitlementRequired) do |error|
+          expect(error.entitlement).to eq('custom_branding')
+        end
+      end
+    end
+
+    context 'when regular member has custom_branding entitlement (no manage_org needed)' do
+      let(:logic) { described_class.new(member_strategy_result, params) }
+
+      before do
+        allow(Onetime::CustomDomain).to receive(:find_by_extid).with('abc123').and_return(custom_domain)
+        allow(Onetime::Organization).to receive(:load).with('org123').and_return(organization)
+        allow(member).to receive(:role).and_return('customer')
+        allow(member_membership).to receive(:can?).with('custom_branding').and_return(true)
+        allow(Onetime::OrganizationMembership).to receive(:find_by_org_customer)
+          .with('org123', 'member123')
+          .and_return(member_membership)
+      end
+
+      it 'does not raise an error' do
+        logic.process_params
+        expect { logic.raise_concerns }.not_to raise_error
+      end
+
+      it 'sets @custom_domain' do
+        logic.process_params
+        logic.raise_concerns
+        expect(logic.instance_variable_get(:@custom_domain)).to eq(custom_domain)
+      end
+
+      it 'sets @organization' do
+        logic.process_params
+        logic.raise_concerns
+        expect(logic.instance_variable_get(:@organization)).to eq(organization)
+      end
+    end
+
+    context 'when user is a colonel (site admin)' do
+      before do
+        allow(Onetime::CustomDomain).to receive(:find_by_extid).with('abc123').and_return(custom_domain)
+        allow(Onetime::Organization).to receive(:load).with('org123').and_return(organization)
+        allow(owner).to receive(:role).and_return('colonel')
+      end
+
+      it 'allows access due to colonel bypass' do
+        logic.process_params
+        expect { logic.raise_concerns }.not_to raise_error
+      end
+    end
+  end
+end

--- a/apps/api/domains/spec/logic/domains/get_domain_image_spec.rb
+++ b/apps/api/domains/spec/logic/domains/get_domain_image_spec.rb
@@ -1,0 +1,357 @@
+# apps/api/domains/spec/logic/domains/get_domain_image_spec.rb
+#
+# frozen_string_literal: true
+
+# Unit tests for GetDomainImage read-only authorization logic.
+#
+# GetDomainImage (and its subclasses GetDomainLogo, GetDomainIcon)
+# includes DomainConfigAuthorization but intentionally skips
+# authorize_domain_config! — it calls load_custom_domain,
+# load_organization_for_domain, and require_entitlement_in! directly
+# so regular org members (without manage_org) can view image data
+# and the UI can render the brand page as a disabled overlay.
+#
+# RUN:
+#   pnpm run test:rspec apps/api/domains/spec/logic/domains/get_domain_image_spec.rb
+
+require_relative File.join(Onetime::HOME, 'spec', 'spec_helper')
+require_relative '../../../../../../apps/api/domains/application'
+
+RSpec.describe DomainsAPI::Logic::Domains::GetDomainImage do
+  let(:owner) do
+    instance_double(
+      Onetime::Customer,
+      custid: 'owner123',
+      objid: 'owner123',
+      extid: 'ext-owner123',
+      anonymous?: false,
+      verified?: true,
+    )
+  end
+
+  let(:member) do
+    instance_double(
+      Onetime::Customer,
+      custid: 'member123',
+      objid: 'member123',
+      extid: 'ext-member123',
+      anonymous?: false,
+      verified?: true,
+    )
+  end
+
+  let(:organization) do
+    instance_double(
+      Onetime::Organization,
+      objid: 'org123',
+      extid: 'ext-org123',
+      display_name: 'Test Org',
+    )
+  end
+
+  let(:logo_field) do
+    double('LogoField',
+      '[]' => nil,
+      'key?' => true,
+      hgetall: { 'encoded' => 'base64data', 'filename' => 'logo.png', 'content_type' => 'image/png' },
+    )
+  end
+
+  let(:empty_logo_field) do
+    double('EmptyLogoField',
+      '[]' => nil,
+      'key?' => false,
+    )
+  end
+
+  let(:custom_domain) do
+    instance_double(
+      Onetime::CustomDomain,
+      identifier: 'domain123',
+      extid: 'ext-domain123',
+      display_domain: 'example.com',
+      org_id: 'org123',
+    )
+  end
+
+  let(:session) do
+    {
+      'authenticated' => true,
+      'csrf' => 'test-csrf-token',
+    }
+  end
+
+  let(:owner_strategy_result) do
+    double('StrategyResult',
+      session: session,
+      user: owner,
+      authenticated?: true,
+      metadata: {},
+    )
+  end
+
+  let(:member_strategy_result) do
+    double('StrategyResult',
+      session: session,
+      user: member,
+      authenticated?: true,
+      metadata: {},
+    )
+  end
+
+  let(:params) { { 'extid' => 'abc123' } }
+
+  let(:owner_membership) do
+    instance_double(
+      Onetime::OrganizationMembership,
+      active?: true,
+      can?: true,
+    )
+  end
+
+  let(:member_membership) do
+    instance_double(
+      Onetime::OrganizationMembership,
+      active?: true,
+    )
+  end
+
+  before do
+    allow(OT).to receive(:info)
+    allow(OT).to receive(:ld)
+    allow(OT).to receive(:li)
+    allow(OT).to receive(:le)
+    allow(OT).to receive(:now).and_return(Time.now.to_i)
+
+    allow(Onetime::OrganizationMembership).to receive(:find_by_org_customer)
+      .with('org123', 'owner123')
+      .and_return(owner_membership)
+  end
+
+  describe DomainsAPI::Logic::Domains::GetDomainLogo do
+    let(:logic) { described_class.new(owner_strategy_result, params) }
+
+    describe 'policy integration' do
+      it 'includes DomainConfigAuthorization policy' do
+        expect(described_class).to be < DomainsAPI::Policies::DomainConfigAuthorization
+      end
+
+      it 'includes AuthorizationPolicies via the policy' do
+        expect(described_class).to be < Onetime::Application::AuthorizationPolicies
+      end
+
+      it 'returns custom_branding as config_entitlement' do
+        expect(logic.send(:config_entitlement)).to eq('custom_branding')
+      end
+
+      it 'uses :logo as the image field' do
+        expect(described_class.field).to eq(:logo)
+      end
+    end
+
+    describe '#raise_concerns (read-only authorization)' do
+      context 'when extid is empty' do
+        let(:params) { { 'extid' => '' } }
+
+        it 'raises FormError' do
+          logic.process_params
+          expect { logic.raise_concerns }.to raise_error(Onetime::FormError, /domain ID/)
+        end
+      end
+
+      context 'when extid has invalid format' do
+        let(:params) { { 'extid' => 'ABC-123!' } }
+
+        it 'raises FormError for invalid identifier format' do
+          logic.process_params
+          expect { logic.raise_concerns }.to raise_error(Onetime::FormError, /Invalid domain identifier/)
+        end
+      end
+
+      context 'when domain not found' do
+        let(:params) { { 'extid' => 'nonexistent' } }
+
+        before do
+          allow(Onetime::CustomDomain).to receive(:find_by_extid).with('nonexistent').and_return(nil)
+        end
+
+        it 'raises RecordNotFound' do
+          logic.process_params
+          expect { logic.raise_concerns }.to raise_error(Onetime::RecordNotFound)
+        end
+      end
+
+      context 'when organization not found' do
+        before do
+          allow(Onetime::CustomDomain).to receive(:find_by_extid).with('abc123').and_return(custom_domain)
+          allow(Onetime::Organization).to receive(:load).with('org123').and_return(nil)
+        end
+
+        it 'raises RecordNotFound' do
+          logic.process_params
+          expect { logic.raise_concerns }.to raise_error(Onetime::RecordNotFound)
+        end
+      end
+
+      context 'when user is not a member of the organization' do
+        let(:outsider) do
+          instance_double(
+            Onetime::Customer,
+            custid: 'outsider123',
+            objid: 'outsider123',
+            extid: 'ext-outsider123',
+            anonymous?: false,
+            verified?: true,
+          )
+        end
+
+        let(:outsider_strategy_result) do
+          double('StrategyResult',
+            session: session,
+            user: outsider,
+            authenticated?: true,
+            metadata: {},
+          )
+        end
+
+        let(:logic) { described_class.new(outsider_strategy_result, params) }
+
+        before do
+          allow(Onetime::CustomDomain).to receive(:find_by_extid).with('abc123').and_return(custom_domain)
+          allow(Onetime::Organization).to receive(:load).with('org123').and_return(organization)
+          allow(outsider).to receive(:role).and_return('customer')
+          allow(Onetime::OrganizationMembership).to receive(:find_by_org_customer)
+            .with('org123', 'outsider123')
+            .and_return(nil)
+        end
+
+        it 'raises Forbidden' do
+          logic.process_params
+          expect { logic.raise_concerns }.to raise_error(Onetime::Forbidden)
+        end
+      end
+
+      context 'when member lacks custom_branding entitlement' do
+        let(:logic) { described_class.new(member_strategy_result, params) }
+
+        before do
+          allow(Onetime::CustomDomain).to receive(:find_by_extid).with('abc123').and_return(custom_domain)
+          allow(Onetime::Organization).to receive(:load).with('org123').and_return(organization)
+          allow(member).to receive(:role).and_return('customer')
+          allow(member_membership).to receive(:can?).with('custom_branding').and_return(false)
+          allow(Onetime::OrganizationMembership).to receive(:find_by_org_customer)
+            .with('org123', 'member123')
+            .and_return(member_membership)
+          allow(organization).to receive(:planid).and_return('basic')
+        end
+
+        it 'raises EntitlementRequired for custom_branding' do
+          logic.process_params
+          expect { logic.raise_concerns }.to raise_error(Onetime::EntitlementRequired) do |error|
+            expect(error.entitlement).to eq('custom_branding')
+          end
+        end
+      end
+
+      context 'when regular member has custom_branding (no manage_org needed)' do
+        let(:logic) { described_class.new(member_strategy_result, params) }
+
+        before do
+          allow(Onetime::CustomDomain).to receive(:find_by_extid).with('abc123').and_return(custom_domain)
+          allow(Onetime::Organization).to receive(:load).with('org123').and_return(organization)
+          allow(member).to receive(:role).and_return('customer')
+          allow(member_membership).to receive(:can?).with('custom_branding').and_return(true)
+          allow(Onetime::OrganizationMembership).to receive(:find_by_org_customer)
+            .with('org123', 'member123')
+            .and_return(member_membership)
+          allow(custom_domain).to receive(:logo).and_return(logo_field)
+          allow(logo_field).to receive(:[]).with('encoded').and_return('base64data')
+        end
+
+        it 'does not raise an error' do
+          logic.process_params
+          expect { logic.raise_concerns }.not_to raise_error
+        end
+
+        it 'sets @custom_domain' do
+          logic.process_params
+          logic.raise_concerns
+          expect(logic.instance_variable_get(:@custom_domain)).to eq(custom_domain)
+        end
+
+        it 'sets @organization' do
+          logic.process_params
+          logic.raise_concerns
+          expect(logic.instance_variable_get(:@organization)).to eq(organization)
+        end
+      end
+
+      context 'when no image is stored' do
+        before do
+          allow(Onetime::CustomDomain).to receive(:find_by_extid).with('abc123').and_return(custom_domain)
+          allow(Onetime::Organization).to receive(:load).with('org123').and_return(organization)
+          allow(owner).to receive(:role).and_return('customer')
+          allow(custom_domain).to receive(:logo).and_return(empty_logo_field)
+          allow(empty_logo_field).to receive(:[]).with('encoded').and_return(nil)
+        end
+
+        it 'raises RecordNotFound for missing image' do
+          logic.process_params
+          expect { logic.raise_concerns }.to raise_error(Onetime::RecordNotFound)
+        end
+      end
+
+      context 'when user is a colonel (site admin)' do
+        before do
+          allow(Onetime::CustomDomain).to receive(:find_by_extid).with('abc123').and_return(custom_domain)
+          allow(Onetime::Organization).to receive(:load).with('org123').and_return(organization)
+          allow(owner).to receive(:role).and_return('colonel')
+          allow(custom_domain).to receive(:logo).and_return(logo_field)
+          allow(logo_field).to receive(:[]).with('encoded').and_return('base64data')
+        end
+
+        it 'allows access due to colonel bypass' do
+          logic.process_params
+          expect { logic.raise_concerns }.not_to raise_error
+        end
+      end
+    end
+  end
+
+  describe DomainsAPI::Logic::Domains::GetDomainIcon do
+    let(:icon_field) do
+      double('IconField',
+        '[]' => nil,
+        'key?' => true,
+        hgetall: { 'encoded' => 'base64data', 'filename' => 'icon.png', 'content_type' => 'image/png' },
+      )
+    end
+
+    let(:logic) { described_class.new(owner_strategy_result, params) }
+
+    it 'uses :icon as the image field' do
+      expect(described_class.field).to eq(:icon)
+    end
+
+    context 'when regular member has custom_branding (no manage_org needed)' do
+      let(:logic) { described_class.new(member_strategy_result, params) }
+
+      before do
+        allow(Onetime::CustomDomain).to receive(:find_by_extid).with('abc123').and_return(custom_domain)
+        allow(Onetime::Organization).to receive(:load).with('org123').and_return(organization)
+        allow(member).to receive(:role).and_return('customer')
+        allow(member_membership).to receive(:can?).with('custom_branding').and_return(true)
+        allow(Onetime::OrganizationMembership).to receive(:find_by_org_customer)
+          .with('org123', 'member123')
+          .and_return(member_membership)
+        allow(custom_domain).to receive(:icon).and_return(icon_field)
+        allow(icon_field).to receive(:[]).with('encoded').and_return('base64data')
+      end
+
+      it 'does not raise an error' do
+        logic.process_params
+        expect { logic.raise_concerns }.not_to raise_error
+      end
+    end
+  end
+end

--- a/apps/api/domains/spec/logic/sender_config/base_spec.rb
+++ b/apps/api/domains/spec/logic/sender_config/base_spec.rb
@@ -13,7 +13,7 @@
 #   4. Organization entitlement: custom_mail_sender
 #
 # Authorization errors are raised via the DomainConfigAuthorization
-# concern using raise_form_error (FormError with error_type: :forbidden)
+# policy using raise_form_error (FormError with error_type: :forbidden)
 # for feature flag and entitlement checks, and Onetime::Forbidden for
 # organization ownership checks (via verify_one_of_roles!).
 #
@@ -117,12 +117,12 @@ RSpec.describe DomainsAPI::Logic::SenderConfig::Base do
       .and_return(owner_membership)
   end
 
-  describe 'concern integration' do
-    it 'includes DomainConfigAuthorization concern' do
-      expect(described_class).to be < DomainsAPI::Logic::Concerns::DomainConfigAuthorization
+  describe 'policy integration' do
+    it 'includes DomainConfigAuthorization policy' do
+      expect(described_class).to be < DomainsAPI::Policies::DomainConfigAuthorization
     end
 
-    it 'includes AuthorizationPolicies via the concern' do
+    it 'includes AuthorizationPolicies via the policy' do
       expect(described_class).to be < Onetime::Application::AuthorizationPolicies
     end
 

--- a/apps/api/domains/spec/logic/sso_config/base_spec.rb
+++ b/apps/api/domains/spec/logic/sso_config/base_spec.rb
@@ -5,7 +5,7 @@
 # Unit tests for SsoConfig::Base authorization logic.
 #
 # Authorization errors are raised via the DomainConfigAuthorization
-# concern using raise_form_error (FormError with error_type: :forbidden)
+# policy using raise_form_error (FormError with error_type: :forbidden)
 # for feature flag and entitlement checks, and Onetime::Forbidden for
 # organization ownership checks (via verify_one_of_roles!).
 #
@@ -109,12 +109,12 @@ RSpec.describe DomainsAPI::Logic::SsoConfig::Base do
       .and_return(owner_membership)
   end
 
-  describe 'concern integration' do
-    it 'includes DomainConfigAuthorization concern' do
-      expect(described_class).to be < DomainsAPI::Logic::Concerns::DomainConfigAuthorization
+  describe 'policy integration' do
+    it 'includes DomainConfigAuthorization policy' do
+      expect(described_class).to be < DomainsAPI::Policies::DomainConfigAuthorization
     end
 
-    it 'includes AuthorizationPolicies via the concern' do
+    it 'includes AuthorizationPolicies via the policy' do
       expect(described_class).to be < Onetime::Application::AuthorizationPolicies
     end
 

--- a/apps/api/domains/try/logic/domain_config_authorization_try.rb
+++ b/apps/api/domains/try/logic/domain_config_authorization_try.rb
@@ -2,10 +2,10 @@
 #
 # frozen_string_literal: true
 
-# Tests for shared domain config authorization logic
+# Tests for shared domain config authorization policy
 #
 # All four config types (ApiConfig, HomepageConfig, SenderConfig,
-# SsoConfig) use the DomainConfigAuthorization concern:
+# SsoConfig) use the DomainConfigAuthorization policy:
 #   1. verify_feature_flag! - check feature flag (if defined)
 #   2. load_custom_domain - find domain by extid
 #   3. load_organization_for_domain - find org from domain's org_id
@@ -182,34 +182,34 @@ end
 #=> 'forbidden'
 
 # ============================================================
-# Concern module inclusion
+# Policy module inclusion
 # ============================================================
 
-## ApiConfig::Base includes DomainConfigAuthorization concern
-DomainsAPI::Logic::ApiConfig::Base.include?(DomainsAPI::Logic::Concerns::DomainConfigAuthorization)
+## ApiConfig::Base includes DomainConfigAuthorization policy
+DomainsAPI::Logic::ApiConfig::Base.include?(DomainsAPI::Policies::DomainConfigAuthorization)
 #=> true
 
-## HomepageConfig::Base includes DomainConfigAuthorization concern
-DomainsAPI::Logic::HomepageConfig::Base.include?(DomainsAPI::Logic::Concerns::DomainConfigAuthorization)
+## HomepageConfig::Base includes DomainConfigAuthorization policy
+DomainsAPI::Logic::HomepageConfig::Base.include?(DomainsAPI::Policies::DomainConfigAuthorization)
 #=> true
 
-## SenderConfig::Base includes DomainConfigAuthorization concern
-DomainsAPI::Logic::SenderConfig::Base.include?(DomainsAPI::Logic::Concerns::DomainConfigAuthorization)
+## SenderConfig::Base includes DomainConfigAuthorization policy
+DomainsAPI::Logic::SenderConfig::Base.include?(DomainsAPI::Policies::DomainConfigAuthorization)
 #=> true
 
-## SsoConfig::Base includes DomainConfigAuthorization concern
-DomainsAPI::Logic::SsoConfig::Base.include?(DomainsAPI::Logic::Concerns::DomainConfigAuthorization)
+## SsoConfig::Base includes DomainConfigAuthorization policy
+DomainsAPI::Logic::SsoConfig::Base.include?(DomainsAPI::Policies::DomainConfigAuthorization)
 #=> true
 
-## ApiConfig::Base includes AuthorizationPolicies via concern
+## ApiConfig::Base includes AuthorizationPolicies via policy
 DomainsAPI::Logic::ApiConfig::Base.include?(Onetime::Application::AuthorizationPolicies)
 #=> true
 
-## SenderConfig::Base includes AuthorizationPolicies via concern
+## SenderConfig::Base includes AuthorizationPolicies via policy
 DomainsAPI::Logic::SenderConfig::Base.include?(Onetime::Application::AuthorizationPolicies)
 #=> true
 
-## SsoConfig::Base includes AuthorizationPolicies via concern
+## SsoConfig::Base includes AuthorizationPolicies via policy
 DomainsAPI::Logic::SsoConfig::Base.include?(Onetime::Application::AuthorizationPolicies)
 #=> true
 
@@ -380,7 +380,7 @@ end
 #=> :forbidden
 
 # ============================================================
-# authorize_domain_config! (shared concern method)
+# authorize_domain_config! (shared policy method)
 # ============================================================
 
 ## authorize_domain_config! sets custom_domain and organization

--- a/apps/web/auth/spec/integration/full/omniauth_csrf_spec.rb
+++ b/apps/web/auth/spec/integration/full/omniauth_csrf_spec.rb
@@ -110,6 +110,13 @@ RSpec.describe 'OmniAuth CSRF Configuration' do
 
     before(:all) do
       Onetime.boot! :test
+
+      # DomainStrategy class vars are normally set when the middleware is
+      # first instantiated (i.e., on the first Rack request). The
+      # canonical_host let evaluates BEFORE any request, so initialize
+      # eagerly to avoid a nil fallback that mismatches the hook's check.
+      domains_config = OT.conf&.dig('features', 'domains') || {}
+      Onetime::Middleware::DomainStrategy.initialize_from_config(domains_config)
     end
 
     let(:sso_path) { '/auth/sso/oidc' }


### PR DESCRIPTION
## Summary

Reorganizes domain configuration authorization logic from a concern-based architecture to a policy-based architecture. This change improves code organization and enables reuse across both config endpoints (ApiConfig, HomepageConfig, SenderConfig, SsoConfig) and brand/image management endpoints (UpdateDomainBrand, UpdateDomainImage, RemoveDomainImage, GetDomainBrand, GetDomainImage).

### Key Changes

1. **Moved and renamed module**: `DomainsAPI::Logic::Concerns::DomainConfigAuthorization` → `DomainsAPI::Policies::DomainConfigAuthorization`
   - Updated file location from `apps/api/domains/logic/concerns/` to `apps/api/domains/policies/`
   - Updated all require statements across config and brand/image classes

2. **Enhanced authorization documentation**: Updated docstrings to clarify:
   - Authorization now checks `manage_org` role instead of just organization ownership
   - Read-only endpoints (GetDomainBrand, GetDomainImage) intentionally skip manage_org requirement to allow regular members to view brand settings as disabled UI overlays
   - Write endpoints (UpdateDomainBrand, UpdateDomainImage, RemoveDomainImage) require manage_org

3. **Simplified brand/image endpoint implementations**:
   - Removed duplicate domain validation and authorization logic
   - Replaced inline checks with `authorize_domain_config!` calls from the policy
   - Removed redundant `require_entitlement!` calls in favor of policy-driven entitlement checks
   - Cleaned up comments and improved code clarity

4. **Updated all config base classes**: ApiConfig, HomepageConfig, SenderConfig, SignupConfig, SsoConfig now require from the policies directory

5. **Updated tests**: Modified test files to reference the new policy module path and updated terminology from "concern" to "policy"

6. **Added spec coverage for read endpoint authorization**: New specs for GetDomainBrand and GetDomainImage verify the read-only authorization model (no manage_org required, entitlement check, colonel bypass, non-member rejection)

7. **Fixed OmniAuth CSRF spec**: Eagerly initializes DomainStrategy class vars in `before(:all)` so the `canonical_host` let resolves correctly before the first Rack request

### Authorization Flow

The policy provides a consistent authorization pattern:
1. Check feature flag (if defined)
2. Load CustomDomain by extid
3. Load Organization via domain.org_id
4. Verify user has manage_org in organization (write endpoints only)
5. Verify organization has required entitlement

### Behavioral Change: `extended_default_expiration` entitlement level

`validate_default_ttl` in UpdateDomainBrand previously used `require_entitlement!('extended_default_expiration')` (user-level check). It now uses `require_entitlement_in!(@organization, 'extended_default_expiration')` (org-membership-level check). This is intentional — domain branding is an org-scoped feature, so the entitlement should flow from org membership rather than personal grants. Any account that held this entitlement at the user level (not through org membership) would need the entitlement added to their org membership.

## Related Issues

- #3340 — `CustomDomain#owner?` semantics (follow-up)

## Test Plan

- Existing unit tests pass with updated module references
- New specs for GetDomainBrand and GetDomainImage cover read-only authorization model
- Feature flag, domain/org loading, entitlement verification, and error handling all tested
- OmniAuth CSRF spec fix resolves pre-existing T3 SQLite billing:off failure

https://claude.ai/code/session_01EAhEnN3GDGxj9XbXPybdrH