### PR TITLE
Decouple custom mail sender provider from email transport

### DIFF
--- a/.env.reference
+++ b/.env.reference
@@ -93,6 +93,13 @@ STDOUT_SYNC=false
 # ═══════════════════════════════════════════════════════════
 
 EMAILER_MODE=smtp
+
+# Provider for custom mail sender domain provisioning (DNS/DKIM).
+# Decouples domain provisioning from the sending transport above.
+# Valid values: ses, sendgrid, lettermint, smtp
+# If unset, falls back to EMAILER_MODE.
+#CUSTOM_MAIL_PROVIDER=
+
 SMTP_HOST=
 SMTP_PORT=587
 SMTP_USERNAME=
@@ -171,22 +178,22 @@ ORGS_CUSTOM_MAIL_ENABLED=false
 ORGS_INCOMING_SECRETS_ENABLED=false
 
 # ═══════════════════════════════════════════════════════════
-#  EMAIL PROVIDER DNS SETTINGS
+#  CUSTOM MAIL SENDER DNS SETTINGS
 # ═══════════════════════════════════════════════════════════
 # These settings control DNS record generation for DKIM, SPF, and related
 # email authentication when setting up custom mail sender domains.
-# The installation-level email provider (EMAILER_MODE) handles sending;
-# these settings generate the correct DNS records for domain verification.
+# The provider is selected by CUSTOM_MAIL_PROVIDER (above); these settings
+# configure that provider's DNS record values.
 
 # --- AWS SES ---
 # AWS region for SES endpoints (affects MX record values).
 # Default: us-east-1
-#EMAIL_PROVIDERS_SES_REGION=us-east-1
+#CUSTOM_MAIL_SES_REGION=us-east-1
 
 # --- SendGrid ---
 # Subdomain for SendGrid domain authentication.
 # Default: em
-#EMAIL_PROVIDERS_SENDGRID_SUBDOMAIN=em
+#CUSTOM_MAIL_SENDGRID_SUBDOMAIN=em
 
 # --- Lettermint ---
 # Lettermint has TWO separate APIs with different auth:
@@ -205,10 +212,6 @@ LETTERMINT_TEAM_TOKEN=
 # API base URL (for enterprise/on-premise deployments).
 # Default: https://api.lettermint.co/v1
 #LETTERMINT_BASE_URL=https://api.lettermint.co/v1
-
-# SPF include domain.
-# Default: lettermint.co
-#EMAIL_PROVIDERS_LETTERMINT_SPF_INCLUDE=lettermint.co
 
 
 # ═══════════════════════════════════════════════════════════

--- a/etc/defaults/config.defaults.yaml
+++ b/etc/defaults/config.defaults.yaml
@@ -566,6 +566,11 @@ emailer:
   # Production Settings (for reference)
   # ----------------------------------
   mode: <%= ENV['EMAILER_MODE'] || 'smtp' %>
+  # Provider for custom mail sender domain provisioning (DNS/DKIM).
+  # When set, decouples domain provisioning from the sending transport.
+  # Valid values: ses, sendgrid, lettermint, smtp
+  # If unset, falls back to mode (EMAILER_MODE).
+  sender_provider: <%= ENV['CUSTOM_MAIL_PROVIDER'] || nil %>
   region: <%= ENV['EMAILER_REGION'] || 'smtp' %>
   from: <%= ENV['FROM_EMAIL'] || ENV['FROM'] || 'CHANGEME@example.com' %>
   from_name: <%= ENV['FROM_NAME'] || 'Support' %>
@@ -599,8 +604,8 @@ email_providers:
   # AWS SES configuration
   ses:
     # AWS region for SES endpoints (affects MX record values)
-    # Override via EMAIL_PROVIDERS_SES_REGION env var
-    region: <%= ENV['EMAIL_PROVIDERS_SES_REGION'] || 'us-east-1' %>
+    # Override via CUSTOM_MAIL_SES_REGION env var
+    region: <%= ENV['CUSTOM_MAIL_SES_REGION'] || 'us-east-1' %>
     # Number of DKIM selectors (SES uses 3 by default)
     dkim_selector_count: 3
     # SPF include domain
@@ -609,8 +614,8 @@ email_providers:
   # SendGrid configuration
   sendgrid:
     # Branding subdomain prefix (appears in CNAME records)
-    # Override via EMAIL_PROVIDERS_SENDGRID_SUBDOMAIN env var
-    subdomain: <%= ENV['EMAIL_PROVIDERS_SENDGRID_SUBDOMAIN'] || 'em' %>
+    # Override via CUSTOM_MAIL_SENDGRID_SUBDOMAIN env var
+    subdomain: <%= ENV['CUSTOM_MAIL_SENDGRID_SUBDOMAIN'] || 'em' %>
     # DKIM selector names
     dkim_selectors:
       - s1
@@ -639,11 +644,11 @@ email_providers:
     # Override via LETTERMINT_BASE_URL env var
     api_base_url: <%= ENV['LETTERMINT_BASE_URL'] || 'https://api.lettermint.co/v1' %>
     # SPF CNAME subdomain prefix (e.g., 'lm-bounces' creates lm-bounces.yourdomain.com)
-    # Override via EMAIL_PROVIDERS_LETTERMINT_SPF_CNAME_PREFIX env var
-    spf_cname_prefix: <%= ENV['EMAIL_PROVIDERS_LETTERMINT_SPF_CNAME_PREFIX'] || 'lm-bounces' %>
+    # Override via CUSTOM_MAIL_LETTERMINT_SPF_CNAME_PREFIX env var
+    spf_cname_prefix: <%= ENV['CUSTOM_MAIL_LETTERMINT_SPF_CNAME_PREFIX'] || 'lm-bounces' %>
     # SPF CNAME target domain (Lettermint maintains SPF at this target)
-    # Override via EMAIL_PROVIDERS_LETTERMINT_SPF_CNAME_TARGET env var
-    spf_cname_target: <%= ENV['EMAIL_PROVIDERS_LETTERMINT_SPF_CNAME_TARGET'] || 'bounces.lmta.net' %>
+    # Override via CUSTOM_MAIL_LETTERMINT_SPF_CNAME_TARGET env var
+    spf_cname_target: <%= ENV['CUSTOM_MAIL_LETTERMINT_SPF_CNAME_TARGET'] || 'bounces.lmta.net' %>
 
 mail:
   truemail:

--- a/lib/onetime/mail/mailer.rb
+++ b/lib/onetime/mail/mailer.rb
@@ -216,6 +216,16 @@ module Onetime
           end
         end
 
+        # Returns the provider for custom mail sender domain provisioning.
+        # Falls back to the sending transport (determine_provider) when unset.
+        def determine_sender_provider
+          conf = emailer_config
+          sp   = conf['sender_provider']
+          return sp.to_s.downcase.strip if sp.is_a?(String) && !sp.strip.empty?
+
+          determine_provider
+        end
+
         def determine_provider
           conf = emailer_config
           mode = conf['mode']&.to_s&.downcase

--- a/lib/onetime/models/custom_domain/mailer_config.rb
+++ b/lib/onetime/models/custom_domain/mailer_config.rb
@@ -444,8 +444,9 @@ module Onetime
         resolved = provider.to_s.strip
         return resolved unless resolved.empty?
 
-        # Fallback to installation config
-        Onetime::Mail::Mailer.send(:determine_provider)
+        # Fallback to installation-level sender provider, which itself
+        # falls back to the sending transport (EMAILER_MODE).
+        Onetime::Mail::Mailer.send(:determine_sender_provider)
       end
 
       class << self


### PR DESCRIPTION
Closes #3343

## Summary
- Add `CUSTOM_MAIL_PROVIDER` env var to select domain provisioning provider independently of `EMAILER_MODE`
- Add `Mailer.determine_sender_provider` with fallback chain: per-domain provider → `CUSTOM_MAIL_PROVIDER` → `EMAILER_MODE`
- Rename `EMAIL_PROVIDERS_*` env vars to `CUSTOM_MAIL_*` (no backwards compat — never used in production)
- Drop unused `EMAIL_PROVIDERS_LETTERMINT_SPF_INCLUDE` (documented but never wired)

## Test plan
- [x] Existing tryouts pass (103/103): `mailer_config_try.rb`, `mailer_backend_selection_try.rb`
- [ ] Verify `CUSTOM_MAIL_PROVIDER=lettermint` + `EMAILER_MODE=smtp` resolves Lettermint for provisioning, SMTP for sending
- [ ] Verify unset `CUSTOM_MAIL_PROVIDER` preserves existing behavior (falls back to `EMAILER_MODE`)