### PR TITLE
[#3334] Backfill missing OrganizationMembership through-models

### DIFF
--- a/lib/onetime/models/customer.rb
+++ b/lib/onetime/models/customer.rb
@@ -172,7 +172,7 @@ module Onetime
       # uuid_v4, hex, etc.) in @objid_generator_used for provenance tracking.
       # Accessing @objid directly bypasses the lazy generation mechanism and
       # skips provenance tracking, causing ExternalIdentifier derivation to fail.
-      self.custid ||= objid # previously <=0.22, custid was email address.
+      self.custid ||= objid
       self.role   ||= 'customer'
 
       # When an instance is first created, any field that doesn't have a

--- a/lib/onetime/models/organization/chores/ensure_member_through_models.rb
+++ b/lib/onetime/models/organization/chores/ensure_member_through_models.rb
@@ -10,13 +10,12 @@
 # in Redis. The v0.25.6 `require_entitlement!` gate requires this
 # through-model to exist AND have materialized entitlements.
 #
-# Five branches per member entry:
+# Four branches per member entry (ghost records filtered by load_multi):
 #
 #   1. Through-model exists AND materialized      → silent no-op
 #   2. Through-model exists, NOT materialized      → materialize only
-#   3. Through-model missing, customer loadable    → create + materialize
-#   4. Through-model missing, customer NOT loadable → warn (stale ZSET entry)
-#   5. org.members empty                           → no-op
+#   3. Through-model missing, customer present     → create + materialize
+#   4. org.members empty                           → no-op
 #
 # Run via HousekeepingJob:
 #   HousekeepingJob.perform('Onetime::Organization', :ensure_member_through_models)
@@ -34,21 +33,14 @@ Onetime::Organization.chore :ensure_member_through_models do |org|
   owner_objid = org.owner_id
   modified    = false
 
-  org.members.to_a.each do |customer_objid|
-    membership = OT::OrganizationMembership.find_by_org_customer(org.objid, customer_objid)
+  # Batch-load customers from the ZSET; compact drops ghost records.
+  customers = OT::Customer.load_multi(org.members.to_a).compact
+
+  customers.each do |customer|
+    membership = OT::OrganizationMembership.find_by_org_customer(org.objid, customer.objid)
 
     if membership.nil?
-      customer = OT::Customer.load(customer_objid)
-
-      if customer.nil? || !customer.exists?
-        logger.warn 'Stale ZSET entry: customer not loadable',
-          chore: :ensure_member_through_models,
-          org_extid: org.extid,
-          customer_objid: customer_objid
-        next
-      end
-
-      role = customer_objid == owner_objid ? 'owner' : 'member'
+      role = customer.objid == owner_objid ? 'owner' : 'member'
 
       membership = org.add_members_instance(
         customer,
@@ -62,7 +54,7 @@ Onetime::Organization.chore :ensure_member_through_models do |org|
       logger.info 'Created membership through-model',
         chore: :ensure_member_through_models,
         org_extid: org.extid,
-        customer_objid: customer_objid,
+        customer_objid: customer.objid,
         role: role
 
       modified = true
@@ -79,7 +71,7 @@ Onetime::Organization.chore :ensure_member_through_models do |org|
     logger.info 'Materialized membership entitlements',
       chore: :ensure_member_through_models,
       org_extid: org.extid,
-      customer_objid: customer_objid
+      customer_objid: customer.objid
 
     modified = true
   end

--- a/lib/onetime/models/organization/chores/ensure_member_through_models.rb
+++ b/lib/onetime/models/organization/chores/ensure_member_through_models.rb
@@ -33,47 +33,51 @@ Onetime::Organization.chore :ensure_member_through_models do |org|
   owner_objid = org.owner_id
   modified    = false
 
-  # Batch-load customers from the ZSET; compact drops ghost records.
-  customers = OT::Customer.load_multi(org.members.to_a).compact
+  # Ensure org-level entitlements exist before iterating members.
+  org.materialize_standalone_entitlements! if org.entitlements.empty?
 
-  customers.each do |customer|
-    membership = OT::OrganizationMembership.find_by_org_customer(org.objid, customer.objid)
+  org.members.to_a.each_slice(100) do |batch|
+    OT::Customer.load_multi(batch).compact.each do |customer|
+      membership = OT::OrganizationMembership.find_by_org_customer(org.objid, customer.objid)
 
-    if membership.nil?
-      role = customer.objid == owner_objid ? 'owner' : 'member'
+      if membership.nil?
+        role = customer.objid == owner_objid ? 'owner' : 'member'
 
-      membership = org.add_members_instance(
-        customer,
-        through_attrs: {
-          role: role,
-          status: 'active',
-          joined_at: org.created.to_f,
-        },
-      )
+        membership = org.add_members_instance(
+          customer,
+          through_attrs: {
+            role: role,
+            status: 'active',
+            joined_at: org.created.to_f,
+          },
+        )
 
-      logger.info 'Created membership through-model',
+        logger.info 'Created membership through-model',
+          chore: :ensure_member_through_models,
+          org_extid: org.extid,
+          customer_objid: customer.objid,
+          role: role
+
+        modified = true
+      end
+
+      next unless membership && !membership.entitlements_materialized?
+
+      membership.materialize_for_role!(org)
+
+      logger.info 'Materialized membership entitlements',
+        chore: :ensure_member_through_models,
+        org_extid: org.extid,
+        customer_objid: customer.objid
+
+      modified = true
+    rescue StandardError => ex
+      logger.error 'Member processing failed',
         chore: :ensure_member_through_models,
         org_extid: org.extid,
         customer_objid: customer.objid,
-        role: role
-
-      modified = true
+        error: ex.message
     end
-
-    next unless membership && !membership.entitlements_materialized?
-
-    if org.entitlements.empty?
-      org.materialize_standalone_entitlements!
-    end
-
-    membership.materialize_for_role!(org)
-
-    logger.info 'Materialized membership entitlements',
-      chore: :ensure_member_through_models,
-      org_extid: org.extid,
-      customer_objid: customer.objid
-
-    modified = true
   end
 
   modified || nil

--- a/lib/onetime/models/organization/chores/ensure_member_through_models.rb
+++ b/lib/onetime/models/organization/chores/ensure_member_through_models.rb
@@ -1,0 +1,88 @@
+# lib/onetime/models/organization/chores/ensure_member_through_models.rb
+#
+# frozen_string_literal: true
+
+# Housekeeping chore: Backfill missing OrganizationMembership through-models
+# for pre-v0.25.6 accounts.
+#
+# Pre-v0.25.6 accounts have their customer objid in `org.members` (a Familia
+# sorted set / Redis ZSET) but no corresponding OrganizationMembership hash
+# in Redis. The v0.25.6 `require_entitlement!` gate requires this
+# through-model to exist AND have materialized entitlements.
+#
+# Five branches per member entry:
+#
+#   1. Through-model exists AND materialized      → silent no-op
+#   2. Through-model exists, NOT materialized      → materialize only
+#   3. Through-model missing, customer loadable    → create + materialize
+#   4. Through-model missing, customer NOT loadable → warn (stale ZSET entry)
+#   5. org.members empty                           → no-op
+#
+# Run via HousekeepingJob:
+#   HousekeepingJob.perform('Onetime::Organization', :ensure_member_through_models)
+
+module Onetime
+  module Chores
+    module EnsureMemberThroughModels
+      # No constants needed — the logic is purely structural.
+    end
+  end
+end
+
+Onetime::Organization.chore :ensure_member_through_models do |org|
+  logger      = Onetime.get_logger('Chores')
+  owner_objid = org.owner_id
+  modified    = false
+
+  org.members.to_a.each do |customer_objid|
+    membership = OT::OrganizationMembership.find_by_org_customer(org.objid, customer_objid)
+
+    if membership.nil?
+      customer = OT::Customer.load(customer_objid)
+
+      if customer.nil? || !customer.exists?
+        logger.warn 'Stale ZSET entry: customer not loadable',
+          chore: :ensure_member_through_models,
+          org_extid: org.extid,
+          customer_objid: customer_objid
+        next
+      end
+
+      role = customer_objid == owner_objid ? 'owner' : 'member'
+
+      membership = org.add_members_instance(
+        customer,
+        through_attrs: {
+          role: role,
+          status: 'active',
+          joined_at: org.created.to_f,
+        },
+      )
+
+      logger.info 'Created membership through-model',
+        chore: :ensure_member_through_models,
+        org_extid: org.extid,
+        customer_objid: customer_objid,
+        role: role
+
+      modified = true
+    end
+
+    next unless membership && !membership.entitlements_materialized?
+
+    if org.entitlements.empty?
+      org.materialize_standalone_entitlements!
+    end
+
+    membership.materialize_for_role!(org)
+
+    logger.info 'Materialized membership entitlements',
+      chore: :ensure_member_through_models,
+      org_extid: org.extid,
+      customer_objid: customer_objid
+
+    modified = true
+  end
+
+  modified || nil
+end

--- a/spec/unit/onetime/models/organization/chores/ensure_member_through_models_spec.rb
+++ b/spec/unit/onetime/models/organization/chores/ensure_member_through_models_spec.rb
@@ -8,12 +8,11 @@
 # or actual Organization instances. Uses an instance_double that mirrors
 # the interface the chore expects.
 #
-# Five branches per member entry:
+# Four branches per member entry (ghost records filtered by load_multi):
 #   1. Through-model exists AND materialized      → silent no-op
 #   2. Through-model exists, NOT materialized      → materialize only
-#   3. Through-model missing, customer loadable    → create + materialize
-#   4. Through-model missing, customer NOT loadable → warn (stale ZSET entry)
-#   5. org.members empty                           → no-op
+#   3. Through-model missing, customer present     → create + materialize
+#   4. org.members empty                           → no-op
 #
 # Run: bundle exec rspec spec/unit/onetime/models/organization/chores/ensure_member_through_models_spec.rb
 
@@ -33,8 +32,15 @@ RSpec.describe 'Organization chore: ensure_member_through_models' do
     end
   end
 
-  # Stub for org.members — responds to .to_a
+  # Stub for org.members — responds to .to_a returning objid strings
   let(:members_set) { double('SortedSet', to_a: member_objids) }
+
+  # Default: no members. Override per context.
+  let(:member_objids) { [] }
+
+  # Customer doubles returned by load_multi — override per context.
+  # Compact is called on the result, so nils are filtered (ghost records).
+  let(:loaded_customers) { [] }
 
   # Stub for org.entitlements — responds to .empty?
   let(:entitlements_list) { double('Entitlements', empty?: entitlements_empty) }
@@ -60,10 +66,12 @@ RSpec.describe 'Organization chore: ensure_member_through_models' do
 
   before do
     allow(Onetime).to receive(:get_logger).with('Chores').and_return(mock_logger)
+    allow(OT::Customer).to receive(:load_multi)
+      .with(member_objids)
+      .and_return(loaded_customers)
   end
 
   # Default values — overridden per context
-  let(:member_objids) { [] }
   let(:owner_objid) { 'cust_owner' }
 
   describe 'chore registration' do
@@ -76,8 +84,9 @@ RSpec.describe 'Organization chore: ensure_member_through_models' do
     end
   end
 
-  describe 'Branch 5: org.members empty (no-op)' do
+  describe 'Branch 4: org.members empty (no-op)' do
     let(:member_objids) { [] }
+    let(:loaded_customers) { [] }
 
     it 'returns nil' do
       expect(chore.call(org)).to be_nil
@@ -91,7 +100,9 @@ RSpec.describe 'Organization chore: ensure_member_through_models' do
   end
 
   describe 'Branch 1: through-model exists AND materialized (silent no-op)' do
+    let(:customer_a) { double('Customer', objid: 'cust_a') }
     let(:member_objids) { ['cust_a'] }
+    let(:loaded_customers) { [customer_a] }
 
     let(:existing_membership) do
       double('Membership',
@@ -127,7 +138,9 @@ RSpec.describe 'Organization chore: ensure_member_through_models' do
   end
 
   describe 'Branch 2: through-model exists, NOT materialized (materialize only)' do
+    let(:customer_a) { double('Customer', objid: 'cust_a') }
     let(:member_objids) { ['cust_a'] }
+    let(:loaded_customers) { [customer_a] }
 
     let(:existing_membership) do
       double('Membership',
@@ -189,13 +202,11 @@ RSpec.describe 'Organization chore: ensure_member_through_models' do
     end
   end
 
-  describe 'Branch 3: through-model missing, customer loadable (create + materialize)' do
+  describe 'Branch 3: through-model missing, customer present (create + materialize)' do
+    let(:customer_a) { double('Customer', objid: 'cust_a') }
     let(:member_objids) { ['cust_a'] }
+    let(:loaded_customers) { [customer_a] }
     let(:owner_objid) { 'cust_owner' }
-
-    let(:customer) do
-      double('Customer', exists?: true)
-    end
 
     let(:created_membership) do
       double('Membership',
@@ -209,22 +220,14 @@ RSpec.describe 'Organization chore: ensure_member_through_models' do
       allow(OT::OrganizationMembership).to receive(:find_by_org_customer)
         .with('org_objid_123', 'cust_a')
         .and_return(nil)
-      allow(OT::Customer).to receive(:load)
-        .with('cust_a')
-        .and_return(customer)
       allow(org).to receive(:add_members_instance)
-        .with(customer, through_attrs: hash_including(:role, :status, :joined_at))
+        .with(customer_a, through_attrs: hash_including(:role, :status, :joined_at))
         .and_return(created_membership)
-    end
-
-    it 'loads the customer' do
-      expect(OT::Customer).to receive(:load).with('cust_a').and_return(customer)
-      chore.call(org)
     end
 
     it 'creates a membership with correct attributes' do
       expect(org).to receive(:add_members_instance).with(
-        customer,
+        customer_a,
         through_attrs: hash_including(
           role: 'member',
           status: 'active',
@@ -269,69 +272,46 @@ RSpec.describe 'Organization chore: ensure_member_through_models' do
     end
   end
 
-  describe 'Branch 4: through-model missing, customer NOT loadable (warn + skip)' do
-    let(:member_objids) { ['cust_stale'] }
+  describe 'Ghost record filtering' do
+    let(:member_objids) { ['cust_live', 'cust_ghost'] }
+    let(:customer_live) { double('Customer', objid: 'cust_live') }
+    # load_multi returns nil for ghost; compact drops it
+    let(:loaded_customers) { [customer_live, nil] }
+
+    let(:existing_membership) do
+      double('Membership', entitlements_materialized?: true)
+    end
 
     before do
+      allow(OT::Customer).to receive(:load_multi)
+        .with(['cust_live', 'cust_ghost'])
+        .and_return([customer_live, nil])
       allow(OT::OrganizationMembership).to receive(:find_by_org_customer)
-        .with('org_objid_123', 'cust_stale')
-        .and_return(nil)
+        .with('org_objid_123', 'cust_live')
+        .and_return(existing_membership)
     end
 
-    context 'when Customer.load returns nil' do
-      before do
-        allow(OT::Customer).to receive(:load).with('cust_stale').and_return(nil)
-      end
-
-      it 'logs a warning about the stale ZSET entry' do
-        expect(mock_logger).to receive(:warn).with(
-          'Stale ZSET entry: customer not loadable',
-          hash_including(
-            chore: :ensure_member_through_models,
-            org_extid: 'org_test123',
-            customer_objid: 'cust_stale',
-          ),
-        )
-        chore.call(org)
-      end
-
-      it 'does not create a membership' do
-        expect(org).not_to receive(:add_members_instance)
-        chore.call(org)
-      end
-
-      it 'returns nil' do
-        expect(chore.call(org)).to be_nil
-      end
+    it 'only processes the live customer' do
+      expect(OT::OrganizationMembership).to receive(:find_by_org_customer)
+        .with('org_objid_123', 'cust_live')
+        .and_return(existing_membership)
+      expect(OT::OrganizationMembership).not_to receive(:find_by_org_customer)
+        .with('org_objid_123', 'cust_ghost')
+      chore.call(org)
     end
 
-    context 'when customer exists? returns false' do
-      let(:ghost_customer) { double('Customer', exists?: false) }
-
-      before do
-        allow(OT::Customer).to receive(:load).with('cust_stale').and_return(ghost_customer)
-      end
-
-      it 'logs a warning about the stale ZSET entry' do
-        expect(mock_logger).to receive(:warn).with(
-          'Stale ZSET entry: customer not loadable',
-          hash_including(customer_objid: 'cust_stale'),
-        )
-        chore.call(org)
-      end
-
-      it 'does not create a membership' do
-        expect(org).not_to receive(:add_members_instance)
-        chore.call(org)
-      end
+    it 'does not attempt to create a membership for the ghost' do
+      expect(org).not_to receive(:add_members_instance)
+      chore.call(org)
     end
   end
 
   describe 'Role assignment' do
-    let(:member_objids) { ['cust_owner'] }
     let(:owner_objid) { 'cust_owner' }
+    let(:customer_owner) { double('Customer', objid: 'cust_owner') }
+    let(:member_objids) { ['cust_owner'] }
+    let(:loaded_customers) { [customer_owner] }
 
-    let(:customer) { double('Customer', exists?: true) }
     let(:created_membership) do
       double('Membership', entitlements_materialized?: false).tap do |m|
         allow(m).to receive(:materialize_for_role!)
@@ -342,16 +322,13 @@ RSpec.describe 'Organization chore: ensure_member_through_models' do
       allow(OT::OrganizationMembership).to receive(:find_by_org_customer)
         .with('org_objid_123', 'cust_owner')
         .and_return(nil)
-      allow(OT::Customer).to receive(:load)
-        .with('cust_owner')
-        .and_return(customer)
       allow(org).to receive(:add_members_instance).and_return(created_membership)
     end
 
     context 'when customer_objid matches owner_id' do
       it 'assigns role "owner"' do
         expect(org).to receive(:add_members_instance).with(
-          customer,
+          customer_owner,
           through_attrs: hash_including(role: 'owner'),
         ).and_return(created_membership)
         chore.call(org)
@@ -359,20 +336,22 @@ RSpec.describe 'Organization chore: ensure_member_through_models' do
     end
 
     context 'when customer_objid does not match owner_id' do
+      let(:customer_regular) { double('Customer', objid: 'cust_regular') }
       let(:member_objids) { ['cust_regular'] }
+      let(:loaded_customers) { [customer_regular] }
 
       before do
+        allow(OT::Customer).to receive(:load_multi)
+          .with(['cust_regular'])
+          .and_return([customer_regular])
         allow(OT::OrganizationMembership).to receive(:find_by_org_customer)
           .with('org_objid_123', 'cust_regular')
           .and_return(nil)
-        allow(OT::Customer).to receive(:load)
-          .with('cust_regular')
-          .and_return(customer)
       end
 
       it 'assigns role "member"' do
         expect(org).to receive(:add_members_instance).with(
-          customer,
+          customer_regular,
           through_attrs: hash_including(role: 'member'),
         ).and_return(created_membership)
         chore.call(org)
@@ -381,7 +360,9 @@ RSpec.describe 'Organization chore: ensure_member_through_models' do
   end
 
   describe 'Org entitlements empty triggers materialization' do
+    let(:customer_a) { double('Customer', objid: 'cust_a') }
     let(:member_objids) { ['cust_a'] }
+    let(:loaded_customers) { [customer_a] }
     let(:entitlements_empty) { true }
 
     let(:existing_membership) do
@@ -408,7 +389,9 @@ RSpec.describe 'Organization chore: ensure_member_through_models' do
   end
 
   describe 'Idempotent re-run' do
+    let(:customer_a) { double('Customer', objid: 'cust_a') }
     let(:member_objids) { ['cust_a'] }
+    let(:loaded_customers) { [customer_a] }
 
     let(:materialized_membership) do
       double('Membership', entitlements_materialized?: true)
@@ -438,9 +421,15 @@ RSpec.describe 'Organization chore: ensure_member_through_models' do
   end
 
   describe 'Multiple members with mixed states' do
-    let(:member_objids) { ['cust_owner', 'cust_existing', 'cust_missing', 'cust_stale'] }
     let(:owner_objid) { 'cust_owner' }
     let(:entitlements_empty) { false }
+
+    let(:customer_owner) { double('OwnerCustomer', objid: 'cust_owner') }
+    let(:customer_existing) { double('ExistingCustomer', objid: 'cust_existing') }
+    let(:customer_missing) { double('MissingCustomer', objid: 'cust_missing') }
+
+    let(:member_objids) { ['cust_owner', 'cust_existing', 'cust_missing'] }
+    let(:loaded_customers) { [customer_owner, customer_existing, customer_missing] }
 
     # cust_owner: through-model exists, already materialized (Branch 1)
     let(:owner_membership) do
@@ -454,17 +443,17 @@ RSpec.describe 'Organization chore: ensure_member_through_models' do
       end
     end
 
-    # cust_missing: through-model missing, customer loadable (Branch 3)
-    let(:missing_customer) { double('MissingCustomer', exists?: true) }
+    # cust_missing: through-model missing, customer present (Branch 3)
     let(:created_membership) do
       double('CreatedMembership', entitlements_materialized?: false).tap do |m|
         allow(m).to receive(:materialize_for_role!)
       end
     end
 
-    # cust_stale: through-model missing, customer NOT loadable (Branch 4)
-
     before do
+      allow(OT::Customer).to receive(:load_multi)
+        .with(['cust_owner', 'cust_existing', 'cust_missing'])
+        .and_return([customer_owner, customer_existing, customer_missing])
       allow(OT::OrganizationMembership).to receive(:find_by_org_customer)
         .with('org_objid_123', 'cust_owner')
         .and_return(owner_membership)
@@ -474,15 +463,9 @@ RSpec.describe 'Organization chore: ensure_member_through_models' do
       allow(OT::OrganizationMembership).to receive(:find_by_org_customer)
         .with('org_objid_123', 'cust_missing')
         .and_return(nil)
-      allow(OT::OrganizationMembership).to receive(:find_by_org_customer)
-        .with('org_objid_123', 'cust_stale')
-        .and_return(nil)
-
-      allow(OT::Customer).to receive(:load).with('cust_missing').and_return(missing_customer)
-      allow(OT::Customer).to receive(:load).with('cust_stale').and_return(nil)
 
       allow(org).to receive(:add_members_instance)
-        .with(missing_customer, through_attrs: hash_including(role: 'member'))
+        .with(customer_missing, through_attrs: hash_including(role: 'member'))
         .and_return(created_membership)
     end
 
@@ -500,28 +483,15 @@ RSpec.describe 'Organization chore: ensure_member_through_models' do
       chore.call(org)
     end
 
-    it 'creates a through-model for the missing but loadable customer' do
+    it 'creates a through-model for the missing but present customer' do
       expect(org).to receive(:add_members_instance)
-        .with(missing_customer, through_attrs: hash_including(role: 'member'))
+        .with(customer_missing, through_attrs: hash_including(role: 'member'))
         .and_return(created_membership)
       chore.call(org)
     end
 
     it 'materializes the newly created membership' do
       expect(created_membership).to receive(:materialize_for_role!).with(org)
-      chore.call(org)
-    end
-
-    it 'warns about the stale customer entry' do
-      expect(mock_logger).to receive(:warn).with(
-        'Stale ZSET entry: customer not loadable',
-        hash_including(customer_objid: 'cust_stale'),
-      )
-      chore.call(org)
-    end
-
-    it 'does not attempt to create a membership for the stale entry' do
-      expect(org).not_to receive(:add_members_instance).with(anything, through_attrs: hash_including(customer_objid: 'cust_stale'))
       chore.call(org)
     end
   end

--- a/spec/unit/onetime/models/organization/chores/ensure_member_through_models_spec.rb
+++ b/spec/unit/onetime/models/organization/chores/ensure_member_through_models_spec.rb
@@ -1,0 +1,528 @@
+# spec/unit/onetime/models/organization/chores/ensure_member_through_models_spec.rb
+#
+# frozen_string_literal: true
+
+# Unit tests for the ensure_member_through_models housekeeping chore.
+#
+# Tests the membership through-model backfill logic without requiring Redis
+# or actual Organization instances. Uses an instance_double that mirrors
+# the interface the chore expects.
+#
+# Five branches per member entry:
+#   1. Through-model exists AND materialized      → silent no-op
+#   2. Through-model exists, NOT materialized      → materialize only
+#   3. Through-model missing, customer loadable    → create + materialize
+#   4. Through-model missing, customer NOT loadable → warn (stale ZSET entry)
+#   5. org.members empty                           → no-op
+#
+# Run: bundle exec rspec spec/unit/onetime/models/organization/chores/ensure_member_through_models_spec.rb
+
+require 'spec_helper'
+
+# Load the chore registration
+require_relative '../../../../../../lib/onetime/models/organization/chores/ensure_member_through_models'
+
+RSpec.describe 'Organization chore: ensure_member_through_models' do
+  let(:chore) { Onetime::Organization.chores[:ensure_member_through_models] }
+
+  let(:mock_logger) do
+    double('SemanticLogger').tap do |logger|
+      allow(logger).to receive(:info) { |_msg, _payload = {}| nil }
+      allow(logger).to receive(:warn) { |_msg, _payload = {}| nil }
+      allow(logger).to receive(:error) { |_msg, _payload = {}| nil }
+    end
+  end
+
+  # Stub for org.members — responds to .to_a
+  let(:members_set) { double('SortedSet', to_a: member_objids) }
+
+  # Stub for org.entitlements — responds to .empty?
+  let(:entitlements_list) { double('Entitlements', empty?: entitlements_empty) }
+  let(:entitlements_empty) { false }
+
+  # Stub for org.created — responds to .to_f
+  let(:org_created) { double('Created', to_f: 1700000000.0) }
+
+  let(:org) do
+    obj = instance_double(
+      'Onetime::Organization',
+      objid: 'org_objid_123',
+      extid: 'org_test123',
+      owner_id: owner_objid,
+      members: members_set,
+      entitlements: entitlements_list,
+      created: org_created,
+    )
+    allow(obj).to receive(:add_members_instance).and_return(nil)
+    allow(obj).to receive(:materialize_standalone_entitlements!)
+    obj
+  end
+
+  before do
+    allow(Onetime).to receive(:get_logger).with('Chores').and_return(mock_logger)
+  end
+
+  # Default values — overridden per context
+  let(:member_objids) { [] }
+  let(:owner_objid) { 'cust_owner' }
+
+  describe 'chore registration' do
+    it 'is registered on Onetime::Organization' do
+      expect(Onetime::Organization.chores).to have_key(:ensure_member_through_models)
+    end
+
+    it 'is a callable block' do
+      expect(chore).to respond_to(:call)
+    end
+  end
+
+  describe 'Branch 5: org.members empty (no-op)' do
+    let(:member_objids) { [] }
+
+    it 'returns nil' do
+      expect(chore.call(org)).to be_nil
+    end
+
+    it 'does not log' do
+      expect(mock_logger).not_to receive(:info)
+      expect(mock_logger).not_to receive(:warn)
+      chore.call(org)
+    end
+  end
+
+  describe 'Branch 1: through-model exists AND materialized (silent no-op)' do
+    let(:member_objids) { ['cust_a'] }
+
+    let(:existing_membership) do
+      double('Membership',
+        entitlements_materialized?: true,
+      )
+    end
+
+    before do
+      allow(OT::OrganizationMembership).to receive(:find_by_org_customer)
+        .with('org_objid_123', 'cust_a')
+        .and_return(existing_membership)
+    end
+
+    it 'returns nil' do
+      expect(chore.call(org)).to be_nil
+    end
+
+    it 'does not create a membership' do
+      expect(org).not_to receive(:add_members_instance)
+      chore.call(org)
+    end
+
+    it 'does not materialize' do
+      expect(existing_membership).not_to receive(:materialize_for_role!)
+      chore.call(org)
+    end
+
+    it 'does not log' do
+      expect(mock_logger).not_to receive(:info)
+      expect(mock_logger).not_to receive(:warn)
+      chore.call(org)
+    end
+  end
+
+  describe 'Branch 2: through-model exists, NOT materialized (materialize only)' do
+    let(:member_objids) { ['cust_a'] }
+
+    let(:existing_membership) do
+      double('Membership',
+        entitlements_materialized?: false,
+      ).tap do |m|
+        allow(m).to receive(:materialize_for_role!)
+      end
+    end
+
+    before do
+      allow(OT::OrganizationMembership).to receive(:find_by_org_customer)
+        .with('org_objid_123', 'cust_a')
+        .and_return(existing_membership)
+    end
+
+    it 'calls materialize_for_role! on the membership' do
+      expect(existing_membership).to receive(:materialize_for_role!).with(org)
+      chore.call(org)
+    end
+
+    it 'does not create a new membership' do
+      expect(org).not_to receive(:add_members_instance)
+      chore.call(org)
+    end
+
+    it 'returns true' do
+      expect(chore.call(org)).to be true
+    end
+
+    it 'logs the materialization at :info' do
+      expect(mock_logger).to receive(:info).with(
+        'Materialized membership entitlements',
+        hash_including(
+          chore: :ensure_member_through_models,
+          org_extid: 'org_test123',
+          customer_objid: 'cust_a',
+        ),
+      )
+      chore.call(org)
+    end
+
+    context 'when org.entitlements is empty' do
+      let(:entitlements_empty) { true }
+
+      it 'calls materialize_standalone_entitlements! before materializing membership' do
+        expect(org).to receive(:materialize_standalone_entitlements!)
+        expect(existing_membership).to receive(:materialize_for_role!).with(org)
+        chore.call(org)
+      end
+    end
+
+    context 'when org.entitlements is NOT empty' do
+      let(:entitlements_empty) { false }
+
+      it 'does not call materialize_standalone_entitlements!' do
+        expect(org).not_to receive(:materialize_standalone_entitlements!)
+        chore.call(org)
+      end
+    end
+  end
+
+  describe 'Branch 3: through-model missing, customer loadable (create + materialize)' do
+    let(:member_objids) { ['cust_a'] }
+    let(:owner_objid) { 'cust_owner' }
+
+    let(:customer) do
+      double('Customer', exists?: true)
+    end
+
+    let(:created_membership) do
+      double('Membership',
+        entitlements_materialized?: false,
+      ).tap do |m|
+        allow(m).to receive(:materialize_for_role!)
+      end
+    end
+
+    before do
+      allow(OT::OrganizationMembership).to receive(:find_by_org_customer)
+        .with('org_objid_123', 'cust_a')
+        .and_return(nil)
+      allow(OT::Customer).to receive(:load)
+        .with('cust_a')
+        .and_return(customer)
+      allow(org).to receive(:add_members_instance)
+        .with(customer, through_attrs: hash_including(:role, :status, :joined_at))
+        .and_return(created_membership)
+    end
+
+    it 'loads the customer' do
+      expect(OT::Customer).to receive(:load).with('cust_a').and_return(customer)
+      chore.call(org)
+    end
+
+    it 'creates a membership with correct attributes' do
+      expect(org).to receive(:add_members_instance).with(
+        customer,
+        through_attrs: hash_including(
+          role: 'member',
+          status: 'active',
+          joined_at: 1700000000.0,
+        ),
+      ).and_return(created_membership)
+      chore.call(org)
+    end
+
+    it 'materializes the created membership' do
+      expect(created_membership).to receive(:materialize_for_role!).with(org)
+      chore.call(org)
+    end
+
+    it 'returns true' do
+      expect(chore.call(org)).to be true
+    end
+
+    it 'logs the creation at :info' do
+      expect(mock_logger).to receive(:info).with(
+        'Created membership through-model',
+        hash_including(
+          chore: :ensure_member_through_models,
+          org_extid: 'org_test123',
+          customer_objid: 'cust_a',
+          role: 'member',
+        ),
+      )
+      chore.call(org)
+    end
+
+    it 'logs the materialization at :info' do
+      expect(mock_logger).to receive(:info).with(
+        'Materialized membership entitlements',
+        hash_including(
+          chore: :ensure_member_through_models,
+          org_extid: 'org_test123',
+          customer_objid: 'cust_a',
+        ),
+      )
+      chore.call(org)
+    end
+  end
+
+  describe 'Branch 4: through-model missing, customer NOT loadable (warn + skip)' do
+    let(:member_objids) { ['cust_stale'] }
+
+    before do
+      allow(OT::OrganizationMembership).to receive(:find_by_org_customer)
+        .with('org_objid_123', 'cust_stale')
+        .and_return(nil)
+    end
+
+    context 'when Customer.load returns nil' do
+      before do
+        allow(OT::Customer).to receive(:load).with('cust_stale').and_return(nil)
+      end
+
+      it 'logs a warning about the stale ZSET entry' do
+        expect(mock_logger).to receive(:warn).with(
+          'Stale ZSET entry: customer not loadable',
+          hash_including(
+            chore: :ensure_member_through_models,
+            org_extid: 'org_test123',
+            customer_objid: 'cust_stale',
+          ),
+        )
+        chore.call(org)
+      end
+
+      it 'does not create a membership' do
+        expect(org).not_to receive(:add_members_instance)
+        chore.call(org)
+      end
+
+      it 'returns nil' do
+        expect(chore.call(org)).to be_nil
+      end
+    end
+
+    context 'when customer exists? returns false' do
+      let(:ghost_customer) { double('Customer', exists?: false) }
+
+      before do
+        allow(OT::Customer).to receive(:load).with('cust_stale').and_return(ghost_customer)
+      end
+
+      it 'logs a warning about the stale ZSET entry' do
+        expect(mock_logger).to receive(:warn).with(
+          'Stale ZSET entry: customer not loadable',
+          hash_including(customer_objid: 'cust_stale'),
+        )
+        chore.call(org)
+      end
+
+      it 'does not create a membership' do
+        expect(org).not_to receive(:add_members_instance)
+        chore.call(org)
+      end
+    end
+  end
+
+  describe 'Role assignment' do
+    let(:member_objids) { ['cust_owner'] }
+    let(:owner_objid) { 'cust_owner' }
+
+    let(:customer) { double('Customer', exists?: true) }
+    let(:created_membership) do
+      double('Membership', entitlements_materialized?: false).tap do |m|
+        allow(m).to receive(:materialize_for_role!)
+      end
+    end
+
+    before do
+      allow(OT::OrganizationMembership).to receive(:find_by_org_customer)
+        .with('org_objid_123', 'cust_owner')
+        .and_return(nil)
+      allow(OT::Customer).to receive(:load)
+        .with('cust_owner')
+        .and_return(customer)
+      allow(org).to receive(:add_members_instance).and_return(created_membership)
+    end
+
+    context 'when customer_objid matches owner_id' do
+      it 'assigns role "owner"' do
+        expect(org).to receive(:add_members_instance).with(
+          customer,
+          through_attrs: hash_including(role: 'owner'),
+        ).and_return(created_membership)
+        chore.call(org)
+      end
+    end
+
+    context 'when customer_objid does not match owner_id' do
+      let(:member_objids) { ['cust_regular'] }
+
+      before do
+        allow(OT::OrganizationMembership).to receive(:find_by_org_customer)
+          .with('org_objid_123', 'cust_regular')
+          .and_return(nil)
+        allow(OT::Customer).to receive(:load)
+          .with('cust_regular')
+          .and_return(customer)
+      end
+
+      it 'assigns role "member"' do
+        expect(org).to receive(:add_members_instance).with(
+          customer,
+          through_attrs: hash_including(role: 'member'),
+        ).and_return(created_membership)
+        chore.call(org)
+      end
+    end
+  end
+
+  describe 'Org entitlements empty triggers materialization' do
+    let(:member_objids) { ['cust_a'] }
+    let(:entitlements_empty) { true }
+
+    let(:existing_membership) do
+      double('Membership', entitlements_materialized?: false).tap do |m|
+        allow(m).to receive(:materialize_for_role!)
+      end
+    end
+
+    before do
+      allow(OT::OrganizationMembership).to receive(:find_by_org_customer)
+        .with('org_objid_123', 'cust_a')
+        .and_return(existing_membership)
+    end
+
+    it 'calls materialize_standalone_entitlements! on the org' do
+      expect(org).to receive(:materialize_standalone_entitlements!)
+      chore.call(org)
+    end
+
+    it 'then materializes the membership' do
+      expect(existing_membership).to receive(:materialize_for_role!).with(org)
+      chore.call(org)
+    end
+  end
+
+  describe 'Idempotent re-run' do
+    let(:member_objids) { ['cust_a'] }
+
+    let(:materialized_membership) do
+      double('Membership', entitlements_materialized?: true)
+    end
+
+    before do
+      allow(OT::OrganizationMembership).to receive(:find_by_org_customer)
+        .with('org_objid_123', 'cust_a')
+        .and_return(materialized_membership)
+    end
+
+    it 'returns nil on first call (already materialized)' do
+      expect(chore.call(org)).to be_nil
+    end
+
+    it 'returns nil on second call (still no-op)' do
+      chore.call(org)
+      expect(chore.call(org)).to be_nil
+    end
+
+    it 'never creates or materializes' do
+      expect(org).not_to receive(:add_members_instance)
+      expect(materialized_membership).not_to receive(:materialize_for_role!)
+      chore.call(org)
+      chore.call(org)
+    end
+  end
+
+  describe 'Multiple members with mixed states' do
+    let(:member_objids) { ['cust_owner', 'cust_existing', 'cust_missing', 'cust_stale'] }
+    let(:owner_objid) { 'cust_owner' }
+    let(:entitlements_empty) { false }
+
+    # cust_owner: through-model exists, already materialized (Branch 1)
+    let(:owner_membership) do
+      double('OwnerMembership', entitlements_materialized?: true)
+    end
+
+    # cust_existing: through-model exists, NOT materialized (Branch 2)
+    let(:existing_membership) do
+      double('ExistingMembership', entitlements_materialized?: false).tap do |m|
+        allow(m).to receive(:materialize_for_role!)
+      end
+    end
+
+    # cust_missing: through-model missing, customer loadable (Branch 3)
+    let(:missing_customer) { double('MissingCustomer', exists?: true) }
+    let(:created_membership) do
+      double('CreatedMembership', entitlements_materialized?: false).tap do |m|
+        allow(m).to receive(:materialize_for_role!)
+      end
+    end
+
+    # cust_stale: through-model missing, customer NOT loadable (Branch 4)
+
+    before do
+      allow(OT::OrganizationMembership).to receive(:find_by_org_customer)
+        .with('org_objid_123', 'cust_owner')
+        .and_return(owner_membership)
+      allow(OT::OrganizationMembership).to receive(:find_by_org_customer)
+        .with('org_objid_123', 'cust_existing')
+        .and_return(existing_membership)
+      allow(OT::OrganizationMembership).to receive(:find_by_org_customer)
+        .with('org_objid_123', 'cust_missing')
+        .and_return(nil)
+      allow(OT::OrganizationMembership).to receive(:find_by_org_customer)
+        .with('org_objid_123', 'cust_stale')
+        .and_return(nil)
+
+      allow(OT::Customer).to receive(:load).with('cust_missing').and_return(missing_customer)
+      allow(OT::Customer).to receive(:load).with('cust_stale').and_return(nil)
+
+      allow(org).to receive(:add_members_instance)
+        .with(missing_customer, through_attrs: hash_including(role: 'member'))
+        .and_return(created_membership)
+    end
+
+    it 'returns true (modifications were made)' do
+      expect(chore.call(org)).to be true
+    end
+
+    it 'skips the already-materialized owner membership' do
+      expect(owner_membership).not_to receive(:materialize_for_role!)
+      chore.call(org)
+    end
+
+    it 'materializes the existing but unmaterialized membership' do
+      expect(existing_membership).to receive(:materialize_for_role!).with(org)
+      chore.call(org)
+    end
+
+    it 'creates a through-model for the missing but loadable customer' do
+      expect(org).to receive(:add_members_instance)
+        .with(missing_customer, through_attrs: hash_including(role: 'member'))
+        .and_return(created_membership)
+      chore.call(org)
+    end
+
+    it 'materializes the newly created membership' do
+      expect(created_membership).to receive(:materialize_for_role!).with(org)
+      chore.call(org)
+    end
+
+    it 'warns about the stale customer entry' do
+      expect(mock_logger).to receive(:warn).with(
+        'Stale ZSET entry: customer not loadable',
+        hash_including(customer_objid: 'cust_stale'),
+      )
+      chore.call(org)
+    end
+
+    it 'does not attempt to create a membership for the stale entry' do
+      expect(org).not_to receive(:add_members_instance).with(anything, through_attrs: hash_including(customer_objid: 'cust_stale'))
+      chore.call(org)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Pre-v0.25.6 accounts have customer objids in `org.members` (Redis ZSET) but no corresponding `OrganizationMembership` hash. The v0.25.6 `require_entitlement!` gate requires this through-model to exist with materialized entitlements. This PR adds a housekeeping chore that backfills the missing through-models and materializes their entitlements.

- Adds `ensure_member_through_models` chore that handles four states per member: already complete (no-op), exists but unmaterialized (materialize), missing (create + materialize), empty org (skip)
- Replaces broken `each_record` iteration with batch `load_multi` in slices of 100 for production scale (300k+ orgs)
- Hoists org-level entitlement materialization before the member loop (one Redis read instead of N)
- Per-member rescue ensures one bad record doesn't abort the rest of an org's members
- Removes stale `custid-was-email` comment from `customer.rb`

## Test plan

- [x] 498 lines of RSpec coverage for all four branches, ghost record filtering, role assignment, entitlements materialization, idempotence, and mixed-state scenarios
- [ ] Run against staging with representative org data
- [ ] Verify idempotence: re-running the chore on already-backfilled orgs produces no changes

Closes #3334