### PR TITLE
fix(test): relocate full-mode auth specs and fix schema version detection

### DIFF
--- a/HANDOFF-auth-spec-tiering.md
+++ b/HANDOFF-auth-spec-tiering.md
@@ -1,0 +1,188 @@
+# Handoff: auth-strategy specs fail under Full · SQLite after spec re-tiering
+
+**Status:** OPEN — needs decision/investigation
+**Area:** Rodauth / auth test infrastructure (PR #3239, `feature/3104-idp`)
+**Work branch:** `claude/happy-hopper-DjiFk`
+**Owner of original task:** "Get the GA workflow passing in a responsible manner."
+
+---
+
+## TL;DR
+
+Getting the GA workflow green uncovered three layered problems. Two are **fixed and
+verified green**; the third is **open**:
+
+| # | Problem | Status |
+|---|---|---|
+| A | `PostgreSQL Migrations & Triggers` red: `EXPECTED_SCHEMA_VERSION` hardcoded `7`, real schema is `10` (OAuth migrations 008–010) | ✅ Fixed — Migration Tests workflow green |
+| B | `T2 · Ruby Unit Tests` aborted: 20 auth specs boot full-mode Rodauth via the shared spec_helper but ran in the simple-mode unit tier → nil `db` → whole run aborted | ✅ Fixed — unit tier green (relocated to `integration/full`) |
+| C | **`T3 · Ruby Integration (Full, SQLite)` red: 27 failures in the 3 relocated auth-*strategy* specs — auth fails on SQLite, passes on PostgreSQL** | ❌ **OPEN (this ticket)** |
+
+The first re-run after B also surfaced a pre-existing latent bug (a stayer spec stubbed
+`Auth::Database` without requiring it) — fixed in commit `c4094ee9`.
+
+---
+
+## Commits on `claude/happy-hopper-DjiFk`
+
+- `474a076c` — `fix(test): derive PG suite schema version from migration files` (Problem A)
+- `86b5d1dc` — `test(auth): relocate full-mode auth specs into integration/full tier` (Problem B; 20 file moves)
+- `c4094ee9` — `fix(test): require auth/database in set_customer_verification_spec` (latent stayer bug)
+
+All three are verified green **except** the SQLite integration job below.
+
+## CI evidence (workflow_dispatch on the work branch)
+
+- Migration Tests run `27048119964` → **all green** (confirms A).
+- CI run `27048326493` (HEAD `c4094ee9`):
+  - `T2 · Ruby Unit Tests` → **success** (confirms B; 0 → 1637 examples actually executing)
+  - `T3 · Ruby Integration (Full, PG, billing on/off)` → **success**
+  - `T3 · Ruby Integration (Full, PG agnostic, billing on/off)` → **success**
+  - `T3 · Ruby Integration (Simple/Disabled), Smoke` → **success**
+  - `T3 · Ruby Integration (Full, SQLite, billing: on)` (job `79839125862`) → **failure**
+  - `T3 · Ruby Integration (Full, SQLite, billing: off)` (job `79839125887`) → **failure**
+
+`1637 examples, 27 failures, 18 pending` — **all 27 failures are in the three relocated
+strategy specs.**
+
+---
+
+## The open issue (C)
+
+### Symptom
+
+Under **Full mode on SQLite only**, every example in these three relocated specs fails:
+
+- `apps/web/auth/spec/integration/full/session_auth_strategy_spec.rb`
+- `apps/web/auth/spec/integration/full/noauth_strategy_spec.rb`
+- `apps/web/auth/spec/integration/full/basic_auth_strategy_spec.rb`
+
+The strategy's `#authenticate` returns `Otto::Security::Authentication::AuthFailure`
+instead of a `StrategyResult`, so assertions like:
+
+```
+expect(result).to be_a(Otto::Security::Authentication::StrategyResult)
+expect(result.authenticated?).to be true
+# and: undefined method `session'/`user'/`metadata' for an instance of …AuthFailure
+```
+
+all fail. The **same specs pass on Full · PostgreSQL** (both billing variants).
+
+### Why this is surprising / notable
+
+The strategy auth path touches **no SQL** — it is Redis/Familia-based:
+
+- `base_session_auth_strategy.rb#authenticate` →
+  `cust = Onetime::Customer.load_by_extid_or_email(external_id)` (Redis), then
+  `load_organization_context(...)`, then `success(...)`.
+  Returns `failure('[CUSTOMER_NOT_FOUND] …')` if the customer can't be resolved.
+- `strategy_test_context.rb` creates the test customer **in Valkey/Redis only**
+  (`Onetime::Customer.new(email:).save`), and the session env carries
+  `external_id => test_customer.extid`.
+- `grep` across `lib/onetime/application/auth_strategies/` shows **no** `Auth::Database`,
+  `Sequel`, or `rodauth` references.
+
+So a failure that depends on the SQL backend (SQLite vs PG) for a Redis-only auth path
+points at **test-suite/shared-state interaction**, not the strategy logic itself.
+
+### Important framing: these specs never actually ran in CI before
+
+Before commit `86b5d1dc`, these specs lived in `apps/web/auth/spec/unit/` and were
+executed by the **simple-mode** unit tier, where the shared auth spec_helper's
+unconditional `require '../application'` crashed at load (`db` nil). The whole unit run
+aborted, so **these examples had never executed in CI in any mode**. Relocating them to
+`integration/full` made them run for the first time; they pass on PG and fail on SQLite.
+This is newly *surfaced* behavior, not a regression in product code.
+
+(Author intent note: `router_error_shape_spec.rb` was explicitly written to need "no
+full-mode boot," and `helpers_spec` / `omniauth_tenant_helpers_spec` are described as pure
+unit tests — yet all three transitively require the app-booting spec_helper. The root
+cause behind Problem B is that `apps/web/auth/spec/spec_helper.rb` *unconditionally* boots
+full-mode Rodauth for every consumer. Relocation treated the symptom; see "Options" #3.)
+
+---
+
+## Hypotheses for C (most → least likely)
+
+1. **SQLite `:memory:` connection-scoping / shared-suite state.** The `:full_auth_mode`
+   suite (`spec/support/full_mode_suite_database.rb`) connects one in-memory SQLite DB,
+   stubs `Auth::Database.connection`, and force-boots the app once for the whole suite.
+   Adding 20 specs changed suite composition/ordering. On SQLite the shared in-memory DB
+   + force-boot may leave Familia/Redis config, encryption keys, or `Onetime` boot state
+   in a condition where `Onetime::Customer.load_by_extid_or_email` (or
+   `load_organization_context`) can't resolve the just-saved customer → `AuthFailure`.
+   PG uses a real shared server and doesn't hit the in-memory-per-connection pitfall.
+2. **Ordering-dependent pollution** exposed only in the SQLite job's execution order
+   (deterministic: 27/27, both billing variants).
+3. **A genuine SQLite-specific bug** somewhere in `load_organization_context` / customer
+   resolution that only this newly-running spec exercises.
+
+### Confirm which, fast
+
+Add a one-line diagnostic (temporarily) or inspect the failure message: the strategy
+returns a *specific* `failure('[CUSTOMER_NOT_FOUND] …')` vs `[SESSION_NOT_AUTHENTICATED]`
+vs an `additional_checks` failure. The exact failure tag tells you whether the Redis
+customer lookup is empty (→ Familia/Redis/boot-state hypothesis #1) or something later.
+The full job log (`get_job_logs job_id=79839125887 tail_lines=2500`) has the
+`Failure/Error` blocks starting ~line 1683; pull the lines just above each to capture the
+`failure(...)` tag and any `[CUSTOMER_NOT_FOUND]` log entries.
+
+---
+
+## Options to resolve C
+
+1. **Investigate & fix the SQLite/shared-suite interaction (preferred if the goal is
+   real coverage).** Likely in `spec/support/full_mode_suite_database.rb` (boot/stub
+   lifecycle) or the strategy specs' `before` hook (`Onetime.boot! :test unless
+   Onetime.ready?` racing the suite's force-boot). This keeps the strategy specs running
+   in full mode (where they belong) on both backends.
+2. **Re-tier the strategy specs to where they pass.** They are session/Redis strategy
+   tests; if they don't need the SQL backend, they may belong in `integration/simple`
+   (or a dedicated path), not `integration/full`. They pass on Full·PG, so this is a
+   judgement call about intended coverage.
+3. **Fix the root cause behind Problem B instead of relocating** — give the auth spec
+   suite a lightweight helper (or gate `require '../application'`) so genuine unit specs
+   (`helpers_spec`, `omniauth_tenant_helpers_spec`, `router_error_shape_spec`, and these
+   strategy specs) can run as fast unit tests without booting full-mode Rodauth. This
+   would let several of the 20 relocated specs move *back* to the fast tier and likely
+   sidesteps C entirely. Larger change; revisits the relocation.
+4. **Quarantine** the 3 strategy specs from the SQLite job (tag + exclude) as a stopgap
+   to get GA green now, with a follow-up issue for #1/#3. Least satisfying.
+
+A maintainer decision is needed here because it's in the Rodauth/OmniAuth/OAuth area and
+trades off coverage vs. effort vs. correctness.
+
+---
+
+## How to reproduce locally
+
+> Note: the dev container used for this work has Ruby 3.3.6 and no bundle, so the suite
+> could not be run locally; everything was verified via CI `workflow_dispatch`. Repro
+> below assumes a working Ruby ≥3.4.7 + `bundle install`.
+
+```bash
+# Fails (SQLite full mode) — mirrors the red CI job:
+AUTH_DATABASE_URL='sqlite::memory:' bundle exec rake spec:integration:full
+
+# Passes (PostgreSQL full mode):
+AUTH_DATABASE_URL_PG='postgresql://onetime_user:testpass@localhost:5432/onetime_auth_test' \
+  bundle exec rake spec:integration:full:postgres
+
+# Narrow to one relocated spec:
+AUTH_DATABASE_URL='sqlite::memory:' AUTHENTICATION_MODE=full RACK_ENV=test \
+  bundle exec rspec apps/web/auth/spec/integration/full/session_auth_strategy_spec.rb
+```
+
+Run the spec **as part of the full suite** (not in isolation) to reproduce — the
+hypothesis is that the failure depends on shared-suite state, so a lone-file run may pass.
+
+---
+
+## Files of interest
+
+- Relocated specs (now failing on SQLite): `apps/web/auth/spec/integration/full/{session_auth_strategy,noauth_strategy,basic_auth_strategy}_spec.rb`
+- Shared context: `apps/web/auth/spec/support/strategy_test_context.rb`
+- Strategy code (Redis-based, no SQL): `lib/onetime/application/auth_strategies/{base_session_auth_strategy,basic_auth_strategy,no_auth_strategy}.rb`
+- Full-mode suite setup (prime suspect): `spec/support/full_mode_suite_database.rb`
+- The unconditional app-boot at the heart of Problem B: `apps/web/auth/spec/spec_helper.rb` (≈line 111, `require_relative '../application'`)
+- Tiering rules: `lib/tasks/spec.rake` (`spec:fast` → `spec:apps:web_auth`; `spec:integration:full`)

--- a/apps/web/auth/spec/integration/full/basic_auth_strategy_spec.rb
+++ b/apps/web/auth/spec/integration/full/basic_auth_strategy_spec.rb
@@ -1,4 +1,4 @@
-# apps/web/auth/spec/unit/basic_auth_strategy_spec.rb
+# apps/web/auth/spec/integration/full/basic_auth_strategy_spec.rb
 #
 # frozen_string_literal: true
 
@@ -7,11 +7,11 @@
 # Requires Valkey on port 2121 (pnpm run test:database:start).
 #
 # Run:
-#   pnpm run test:rspec apps/web/auth/spec/unit/basic_auth_strategy_spec.rb
+#   pnpm run test:rspec apps/web/auth/spec/integration/full/basic_auth_strategy_spec.rb
 
-require_relative '../spec_helper'
-require_relative '../support/strategy_test_context'
-require_relative '../support/shared_examples/session_contract_examples'
+require_relative '../../spec_helper'
+require_relative '../../support/strategy_test_context'
+require_relative '../../support/shared_examples/session_contract_examples'
 
 RSpec.describe Onetime::Application::AuthStrategies::BasicAuthStrategy, type: :integration do
   include_context 'strategy test'

--- a/apps/web/auth/spec/integration/full/config/email_modules_spec.rb
+++ b/apps/web/auth/spec/integration/full/config/email_modules_spec.rb
@@ -1,4 +1,4 @@
-# apps/web/auth/spec/config/email_modules_spec.rb
+# apps/web/auth/spec/integration/full/config/email_modules_spec.rb
 #
 # frozen_string_literal: true
 
@@ -27,7 +27,7 @@
 #
 # =============================================================================
 
-require_relative '../spec_helper'
+require_relative '../../../spec_helper'
 require 'mail'
 
 # Define the Auth::Config namespace so the email modules can load without a full
@@ -45,7 +45,7 @@ Auth::Config.const_set(:Email, Module.new) unless Auth::Config.const_defined?(:E
 # Track whether refactored modules are available
 REFACTORED_MODULES_AVAILABLE = begin
   # Check if email subdirectory exists with the expected files
-  email_dir = File.expand_path('../../config/email', __dir__)
+  email_dir = File.expand_path('../../../../config/email', __dir__)
   File.exist?(File.join(email_dir, 'helpers.rb')) &&
     File.exist?(File.join(email_dir, 'verify_account.rb')) &&
     File.exist?(File.join(email_dir, 'reset_password.rb')) &&
@@ -61,7 +61,7 @@ RSpec.describe 'Auth::Config::Email modules' do
     before(:all) do
       next unless REFACTORED_MODULES_AVAILABLE
 
-      require_relative '../../config/email/helpers'
+      require_relative '../../../../config/email/helpers'
     end
 
     it 'is defined' do
@@ -84,7 +84,7 @@ RSpec.describe 'Auth::Config::Email modules' do
     before(:all) do
       next unless REFACTORED_MODULES_AVAILABLE
 
-      require_relative '../../config/email/verify_account'
+      require_relative '../../../../config/email/verify_account'
     end
 
     it 'is defined' do
@@ -107,7 +107,7 @@ RSpec.describe 'Auth::Config::Email modules' do
     before(:all) do
       next unless REFACTORED_MODULES_AVAILABLE
 
-      require_relative '../../config/email/reset_password'
+      require_relative '../../../../config/email/reset_password'
     end
 
     it 'is defined' do
@@ -130,7 +130,7 @@ RSpec.describe 'Auth::Config::Email modules' do
     before(:all) do
       next unless REFACTORED_MODULES_AVAILABLE
 
-      require_relative '../../config/email/delivery'
+      require_relative '../../../../config/email/delivery'
     end
 
     it 'is defined' do
@@ -533,7 +533,7 @@ RSpec.describe 'Auth::Config::Email modules' do
     # It will be removed once refactoring is complete
 
     it 'module file exists and is loadable' do
-      email_file = File.expand_path('../../config/email.rb', __dir__)
+      email_file = File.expand_path('../../../../config/email.rb', __dir__)
       expect(File.exist?(email_file)).to be true
     end
 
@@ -541,7 +541,7 @@ RSpec.describe 'Auth::Config::Email modules' do
       # The module is defined when the file is loaded
       # We verify the constant exists (may be defined by earlier tests)
       # Load the email module if not already loaded
-      require_relative '../../config/email'
+      require_relative '../../../../config/email'
 
       expect(defined?(Auth::Config::Email)).to eq('constant')
     end

--- a/apps/web/auth/spec/integration/full/config/env_conditionals_spec.rb
+++ b/apps/web/auth/spec/integration/full/config/env_conditionals_spec.rb
@@ -1,4 +1,4 @@
-# apps/web/auth/spec/config/env_conditionals_spec.rb
+# apps/web/auth/spec/integration/full/config/env_conditionals_spec.rb
 #
 # frozen_string_literal: true
 
@@ -13,7 +13,7 @@
 # The Phase 1 feature specs test that features work when enabled;
 # these tests verify the ENV parsing that controls enablement.
 
-require_relative '../spec_helper'
+require_relative '../../../spec_helper'
 require 'climate_control'
 
 RSpec.describe 'Auth::Config ENV Conditional Logic' do

--- a/apps/web/auth/spec/integration/full/config/env_feature_loading_spec.rb
+++ b/apps/web/auth/spec/integration/full/config/env_feature_loading_spec.rb
@@ -1,4 +1,4 @@
-# apps/web/auth/spec/config/env_feature_loading_spec.rb
+# apps/web/auth/spec/integration/full/config/env_feature_loading_spec.rb
 #
 # frozen_string_literal: true
 
@@ -28,7 +28,7 @@
 #
 # =============================================================================
 
-require_relative '../spec_helper'
+require_relative '../../../spec_helper'
 require 'climate_control'
 require 'rodauth'
 
@@ -42,7 +42,7 @@ module Auth; end
 Auth.const_set(:Config, Class.new(Rodauth::Auth)) unless defined?(Auth::Config)
 Auth::Config.const_set(:Features, Module.new) unless Auth::Config.const_defined?(:Features, false)
 
-require_relative '../../config/features/mfa'
+require_relative '../../../../config/features/mfa'
 
 RSpec.describe 'ENV-conditional feature loading' do
   let(:db) { create_test_database }

--- a/apps/web/auth/spec/integration/full/config/features/active_sessions_spec.rb
+++ b/apps/web/auth/spec/integration/full/config/features/active_sessions_spec.rb
@@ -1,4 +1,4 @@
-# apps/web/auth/spec/config/features/active_sessions_spec.rb
+# apps/web/auth/spec/integration/full/config/features/active_sessions_spec.rb
 #
 # frozen_string_literal: true
 
@@ -10,7 +10,7 @@
 #
 # Reference: apps/web/auth/config/features/active_sessions.rb
 
-require_relative '../../spec_helper'
+require_relative '../../../../spec_helper'
 
 RSpec.describe 'Auth::Config::Features::ActiveSessions' do
   let(:db) { create_test_database }

--- a/apps/web/auth/spec/integration/full/config/features/email_auth_spec.rb
+++ b/apps/web/auth/spec/integration/full/config/features/email_auth_spec.rb
@@ -1,4 +1,4 @@
-# apps/web/auth/spec/config/features/email_auth_spec.rb
+# apps/web/auth/spec/integration/full/config/features/email_auth_spec.rb
 #
 # frozen_string_literal: true
 
@@ -10,7 +10,7 @@
 #
 # Reference: apps/web/auth/config/features/email_auth.rb
 
-require_relative '../../spec_helper'
+require_relative '../../../../spec_helper'
 
 RSpec.describe 'Auth::Config::Features::EmailAuth' do
   let(:db) { create_test_database }

--- a/apps/web/auth/spec/integration/full/config/features/feature_combinations_spec.rb
+++ b/apps/web/auth/spec/integration/full/config/features/feature_combinations_spec.rb
@@ -1,4 +1,4 @@
-# apps/web/auth/spec/config/features/feature_combinations_spec.rb
+# apps/web/auth/spec/integration/full/config/features/feature_combinations_spec.rb
 #
 # frozen_string_literal: true
 
@@ -9,9 +9,9 @@
 #
 # Reference: apps/web/auth/config.rb
 
-require_relative '../../spec_helper'
+require_relative '../../../../spec_helper'
 
-require_relative '../../support/auth_test_constants'
+require_relative '../../../../support/auth_test_constants'
 include AuthTestConstants
 
 RSpec.describe 'Rodauth Feature Combinations' do

--- a/apps/web/auth/spec/integration/full/config/features/lockout_spec.rb
+++ b/apps/web/auth/spec/integration/full/config/features/lockout_spec.rb
@@ -1,4 +1,4 @@
-# apps/web/auth/spec/config/features/lockout_spec.rb
+# apps/web/auth/spec/integration/full/config/features/lockout_spec.rb
 #
 # frozen_string_literal: true
 
@@ -10,7 +10,7 @@
 #
 # Reference: apps/web/auth/config/features/lockout.rb
 
-require_relative '../../spec_helper'
+require_relative '../../../../spec_helper'
 
 RSpec.describe 'Auth::Config::Features::Lockout' do
   let(:db) { create_test_database }

--- a/apps/web/auth/spec/integration/full/config/features/mfa_spec.rb
+++ b/apps/web/auth/spec/integration/full/config/features/mfa_spec.rb
@@ -1,4 +1,4 @@
-# apps/web/auth/spec/config/features/mfa_spec.rb
+# apps/web/auth/spec/integration/full/config/features/mfa_spec.rb
 #
 # frozen_string_literal: true
 
@@ -10,9 +10,9 @@
 #
 # Reference: apps/web/auth/config/features/mfa.rb
 
-require_relative '../../spec_helper'
+require_relative '../../../../spec_helper'
 
-require_relative '../../support/auth_test_constants'
+require_relative '../../../../support/auth_test_constants'
 include AuthTestConstants
 
 RSpec.describe 'Auth::Config::Features::MFA' do

--- a/apps/web/auth/spec/integration/full/config/features/password_requirements_spec.rb
+++ b/apps/web/auth/spec/integration/full/config/features/password_requirements_spec.rb
@@ -1,4 +1,4 @@
-# apps/web/auth/spec/config/features/password_requirements_spec.rb
+# apps/web/auth/spec/integration/full/config/features/password_requirements_spec.rb
 #
 # frozen_string_literal: true
 
@@ -10,7 +10,7 @@
 #
 # Reference: apps/web/auth/config/features/password_requirements.rb
 
-require_relative '../../spec_helper'
+require_relative '../../../../spec_helper'
 
 RSpec.describe 'Auth::Config::Features::PasswordRequirements' do
   let(:db) { create_test_database }

--- a/apps/web/auth/spec/integration/full/config/features/remember_me_spec.rb
+++ b/apps/web/auth/spec/integration/full/config/features/remember_me_spec.rb
@@ -1,4 +1,4 @@
-# apps/web/auth/spec/config/features/remember_me_spec.rb
+# apps/web/auth/spec/integration/full/config/features/remember_me_spec.rb
 #
 # frozen_string_literal: true
 
@@ -10,7 +10,7 @@
 #
 # Reference: apps/web/auth/config/features/remember_me.rb
 
-require_relative '../../spec_helper'
+require_relative '../../../../spec_helper'
 
 RSpec.describe 'Auth::Config::Features::RememberMe' do
   let(:db) { create_test_database }

--- a/apps/web/auth/spec/integration/full/config/features/webauthn_spec.rb
+++ b/apps/web/auth/spec/integration/full/config/features/webauthn_spec.rb
@@ -1,4 +1,4 @@
-# apps/web/auth/spec/config/features/webauthn_spec.rb
+# apps/web/auth/spec/integration/full/config/features/webauthn_spec.rb
 #
 # frozen_string_literal: true
 
@@ -10,7 +10,7 @@
 #
 # Reference: apps/web/auth/config/features/webauthn.rb
 
-require_relative '../../spec_helper'
+require_relative '../../../../spec_helper'
 
 RSpec.describe 'Auth::Config::Features::WebAuthn' do
   let(:db) { create_test_database }

--- a/apps/web/auth/spec/integration/full/config/production_boot_spec.rb
+++ b/apps/web/auth/spec/integration/full/config/production_boot_spec.rb
@@ -1,4 +1,4 @@
-# apps/web/auth/spec/config/production_boot_spec.rb
+# apps/web/auth/spec/integration/full/config/production_boot_spec.rb
 #
 # frozen_string_literal: true
 
@@ -29,7 +29,7 @@
 #
 # =============================================================================
 
-require_relative '../spec_helper'
+require_relative '../../../spec_helper'
 require 'climate_control'
 
 # Define the Auth::Config namespace so the feature/hook modules can load without
@@ -52,7 +52,7 @@ RSpec.describe 'Auth module structure smoke tests' do
     before(:all) do
       # Load the features index which requires all feature modules
       # (Auth::Config namespace is established by the top-level shim above)
-      require_relative '../../config/features'
+      require_relative '../../../../config/features'
     end
 
     describe 'Lockout module' do
@@ -187,7 +187,7 @@ RSpec.describe 'Auth module structure smoke tests' do
   describe 'Auth::Config::Hooks modules' do
     before(:all) do
       # Load hooks index
-      require_relative '../../config/hooks'
+      require_relative '../../../../config/hooks'
     end
 
     describe 'Account hooks module' do
@@ -263,7 +263,7 @@ RSpec.describe 'Auth module structure smoke tests' do
 
   describe 'Auth::Config::Base module' do
     before(:all) do
-      require_relative '../../config/base'
+      require_relative '../../../../config/base'
     end
 
     it 'is defined' do
@@ -277,7 +277,7 @@ RSpec.describe 'Auth module structure smoke tests' do
 
   describe 'Auth::Config::Email module' do
     before(:all) do
-      require_relative '../../config/email'
+      require_relative '../../../../config/email'
     end
 
     it 'is defined' do

--- a/apps/web/auth/spec/integration/full/domain_sso_config_spec.rb
+++ b/apps/web/auth/spec/integration/full/domain_sso_config_spec.rb
@@ -1,4 +1,4 @@
-# apps/web/auth/spec/unit/domain_sso_config_spec.rb
+# apps/web/auth/spec/integration/full/domain_sso_config_spec.rb
 #
 # frozen_string_literal: true
 
@@ -19,10 +19,10 @@
 # Integration tests for persistence belong in a separate file.
 #
 # Run:
-#   pnpm run test:rspec apps/web/auth/spec/unit/domain_sso_config_spec.rb
+#   pnpm run test:rspec apps/web/auth/spec/integration/full/domain_sso_config_spec.rb
 
-require_relative '../spec_helper'
-require_relative '../support/domain_sso_test_fixtures'
+require_relative '../../spec_helper'
+require_relative '../../support/domain_sso_test_fixtures'
 
 RSpec.describe Onetime::CustomDomain::SsoConfig do
   include DomainSsoTestFixtures

--- a/apps/web/auth/spec/integration/full/helpers_spec.rb
+++ b/apps/web/auth/spec/integration/full/helpers_spec.rb
@@ -1,4 +1,4 @@
-# apps/web/auth/spec/unit/helpers_spec.rb
+# apps/web/auth/spec/integration/full/helpers_spec.rb
 #
 # frozen_string_literal: true
 
@@ -12,9 +12,9 @@
 # `REMOTE_ADDR` (no regression for default deployments).
 #
 # Run:
-#   pnpm run test:rspec apps/web/auth/spec/unit/helpers_spec.rb
+#   pnpm run test:rspec apps/web/auth/spec/integration/full/helpers_spec.rb
 
-require_relative '../spec_helper'
+require_relative '../../spec_helper'
 
 require 'rack/request'
 require 'onetime/application/auth_strategies/helpers'

--- a/apps/web/auth/spec/integration/full/migrations/migrations_sqlite_spec.rb
+++ b/apps/web/auth/spec/integration/full/migrations/migrations_sqlite_spec.rb
@@ -13,7 +13,9 @@ RSpec.describe 'Auth::Migrator SQLite Integration', :sqlite_database do
   let(:migrations_dir) { File.join(Onetime::HOME, 'apps', 'web', 'auth', 'migrations') }
   # Derive the latest schema version from the migration files so this spec does
   # not need editing each time a migration lands (the gap that left it at 6).
-  let(:latest_version) { Dir.glob(File.join(migrations_dir, '[0-9]*_*.rb')).count }
+  # Use the highest migration number (matches Sequel's schema_info.version),
+  # not the file count, so non-contiguous numbering still resolves correctly.
+  let(:latest_version) { Dir.glob(File.join(migrations_dir, '[0-9]*_*.rb')).map { |f| File.basename(f).to_i }.max }
   let(:test_db_file) { File.join(Dir.tmpdir, "test_auth_#{SecureRandom.hex(4)}.db") }
   let(:test_db) { Sequel.connect("sqlite://#{test_db_file}") }
 

--- a/apps/web/auth/spec/integration/full/noauth_strategy_spec.rb
+++ b/apps/web/auth/spec/integration/full/noauth_strategy_spec.rb
@@ -1,4 +1,4 @@
-# apps/web/auth/spec/unit/noauth_strategy_spec.rb
+# apps/web/auth/spec/integration/full/noauth_strategy_spec.rb
 #
 # frozen_string_literal: true
 
@@ -7,11 +7,11 @@
 # Requires Valkey on port 2121 (pnpm run test:database:start).
 #
 # Run:
-#   pnpm run test:rspec apps/web/auth/spec/unit/noauth_strategy_spec.rb
+#   pnpm run test:rspec apps/web/auth/spec/integration/full/noauth_strategy_spec.rb
 
-require_relative '../spec_helper'
-require_relative '../support/strategy_test_context'
-require_relative '../support/shared_examples/session_contract_examples'
+require_relative '../../spec_helper'
+require_relative '../../support/strategy_test_context'
+require_relative '../../support/shared_examples/session_contract_examples'
 
 RSpec.describe Onetime::Application::AuthStrategies::NoAuthStrategy, type: :integration do
   include_context 'strategy test'
@@ -132,7 +132,7 @@ RSpec.describe Onetime::Application::AuthStrategies::NoAuthStrategy, type: :inte
     # Source comment accuracy
     # -----------------------------------------------------------------
     context 'source documentation' do
-      let(:source_file) { File.read(File.expand_path('../../../../../lib/onetime/application/auth_strategies/no_auth_strategy.rb', __dir__)) }
+      let(:source_file) { File.read(File.expand_path('../../../../../../lib/onetime/application/auth_strategies/no_auth_strategy.rb', __dir__)) }
 
       it 'comment says "Try session first, then fall back to anonymous" (no mention of Basic auth handling here)' do
         # The NoAuthStrategy comment must describe its own scope accurately:

--- a/apps/web/auth/spec/integration/full/omniauth_tenant_helpers_spec.rb
+++ b/apps/web/auth/spec/integration/full/omniauth_tenant_helpers_spec.rb
@@ -1,4 +1,4 @@
-# apps/web/auth/spec/unit/omniauth_tenant_helpers_spec.rb
+# apps/web/auth/spec/integration/full/omniauth_tenant_helpers_spec.rb
 #
 # frozen_string_literal: true
 
@@ -11,9 +11,9 @@
 # No Valkey, no HTTP -- pure Ruby method testing with doubles.
 #
 # Run:
-#   pnpm run test:rspec apps/web/auth/spec/unit/omniauth_tenant_helpers_spec.rb
+#   pnpm run test:rspec apps/web/auth/spec/integration/full/omniauth_tenant_helpers_spec.rb
 
-require_relative '../spec_helper'
+require_relative '../../spec_helper'
 
 # Define the Auth::Config namespace (normally provided by auth app boot).
 # Auth::Config MUST be a Rodauth::Auth subclass here, never a plain
@@ -28,10 +28,10 @@ Auth.const_set(:Config, Class.new(Rodauth::Auth)) unless defined?(Auth::Config)
 Auth::Config.const_set(:Hooks, Module.new) unless Auth::Config.const_defined?(:Hooks, false)
 
 # Require Auth::Logging (used by the hook for audit events)
-require_relative '../../lib/logging'
+require_relative '../../../lib/logging'
 
 # Require the hook module under test
-require_relative '../../config/hooks/omniauth_tenant'
+require_relative '../../../config/hooks/omniauth_tenant'
 
 RSpec.describe Auth::Config::Hooks::OmniAuthTenant do
   let(:helpers) { described_class }

--- a/apps/web/auth/spec/integration/full/router_error_shape_spec.rb
+++ b/apps/web/auth/spec/integration/full/router_error_shape_spec.rb
@@ -1,4 +1,4 @@
-# apps/web/auth/spec/router_error_shape_spec.rb
+# apps/web/auth/spec/integration/full/router_error_shape_spec.rb
 #
 # frozen_string_literal: true
 
@@ -25,15 +25,15 @@
 # gates integration helpers and DB flushing on type: :integration tag.
 #
 # RUN:
-#   pnpm run test:rspec apps/web/auth/spec/router_error_shape_spec.rb
+#   pnpm run test:rspec apps/web/auth/spec/integration/full/router_error_shape_spec.rb
 #
 # =============================================================================
 
-require_relative 'spec_helper'
+require_relative '../../spec_helper'
 require 'rack/test'
 require 'roda'
 require 'json'
-require_relative '../error_translator'
+require_relative '../../../error_translator'
 
 RSpec.describe 'Auth Router ADR-013 error shape' do
   # ---------------------------------------------------------------------------

--- a/apps/web/auth/spec/integration/full/seed_dev_oauth_client_idempotency_spec.rb
+++ b/apps/web/auth/spec/integration/full/seed_dev_oauth_client_idempotency_spec.rb
@@ -1,4 +1,4 @@
-# apps/web/auth/spec/unit/seed_dev_oauth_client_idempotency_spec.rb
+# apps/web/auth/spec/integration/full/seed_dev_oauth_client_idempotency_spec.rb
 #
 # frozen_string_literal: true
 
@@ -46,7 +46,7 @@ ENV['OAUTH_JWT_RSA_PRIVATE_KEY'] ||= OpenSSL::PKey::RSA.new(2048).to_pem
 require 'securerandom'
 ENV['OAUTH_SP_DEV_CLIENT_SECRET'] ||= "unit-spec-placeholder-#{SecureRandom.hex(8)}"
 
-require_relative '../spec_helper'
+require_relative '../../spec_helper'
 
 require 'sequel'
 require 'bcrypt'

--- a/apps/web/auth/spec/integration/full/session_auth_strategy_spec.rb
+++ b/apps/web/auth/spec/integration/full/session_auth_strategy_spec.rb
@@ -1,4 +1,4 @@
-# apps/web/auth/spec/unit/session_auth_strategy_spec.rb
+# apps/web/auth/spec/integration/full/session_auth_strategy_spec.rb
 #
 # frozen_string_literal: true
 
@@ -7,11 +7,11 @@
 # Requires Valkey on port 2121 (pnpm run test:database:start).
 #
 # Run:
-#   pnpm run test:rspec apps/web/auth/spec/unit/session_auth_strategy_spec.rb
+#   pnpm run test:rspec apps/web/auth/spec/integration/full/session_auth_strategy_spec.rb
 
-require_relative '../spec_helper'
-require_relative '../support/strategy_test_context'
-require_relative '../support/shared_examples/session_contract_examples'
+require_relative '../../spec_helper'
+require_relative '../../support/strategy_test_context'
+require_relative '../../support/shared_examples/session_contract_examples'
 
 RSpec.describe Onetime::Application::AuthStrategies::SessionAuthStrategy, type: :integration do
   include_context 'strategy test'

--- a/apps/web/auth/spec/operations/set_customer_verification_spec.rb
+++ b/apps/web/auth/spec/operations/set_customer_verification_spec.rb
@@ -14,6 +14,7 @@
 # Run: pnpm run test:rspec apps/web/auth/spec/operations/set_customer_verification_spec.rb
 
 require 'spec_helper'
+require 'auth/database' # defines Auth::Database so the connection stubs below resolve
 require 'auth/operations/set_customer_verification'
 
 RSpec.describe Auth::Operations::SetCustomerVerification do

--- a/spec/support/postgres_mode_suite_database.rb
+++ b/spec/support/postgres_mode_suite_database.rb
@@ -51,7 +51,15 @@ require_relative 'factories/auth_account_factory'
 #
 module PostgresModeSuiteDatabase
   REQUIRED_TABLES = %i[accounts account_statuses account_password_hashes].freeze
-  EXPECTED_SCHEMA_VERSION = 7
+  # Latest schema version, derived from the migration files rather than
+  # hardcoded so this constant does not need hand-editing each time a migration
+  # lands (the gap that left it at 7 after OAuth migrations 008–010). Mirrors
+  # the dynamic `latest_version` in the sibling SQLite migration spec. Resolved
+  # relative to this file so it does not depend on Onetime::HOME being loaded
+  # when this support file is required.
+  EXPECTED_SCHEMA_VERSION = Dir.glob(
+    File.expand_path('../../apps/web/auth/migrations/[0-9]*_*.rb', __dir__),
+  ).count
 
   class << self
     attr_reader :database, :migration_database

--- a/spec/support/postgres_mode_suite_database.rb
+++ b/spec/support/postgres_mode_suite_database.rb
@@ -53,13 +53,15 @@ module PostgresModeSuiteDatabase
   REQUIRED_TABLES = %i[accounts account_statuses account_password_hashes].freeze
   # Latest schema version, derived from the migration files rather than
   # hardcoded so this constant does not need hand-editing each time a migration
-  # lands (the gap that left it at 7 after OAuth migrations 008–010). Mirrors
-  # the dynamic `latest_version` in the sibling SQLite migration spec. Resolved
-  # relative to this file so it does not depend on Onetime::HOME being loaded
-  # when this support file is required.
+  # lands (the gap that left it at 7 after OAuth migrations 008–010). Uses the
+  # highest migration number — which is what Sequel's schema_info.version
+  # records — rather than the file count, so it stays correct even if the
+  # numbering is ever non-contiguous. Mirrors the sibling SQLite migration spec.
+  # Resolved relative to this file so it does not depend on Onetime::HOME being
+  # loaded when this support file is required.
   EXPECTED_SCHEMA_VERSION = Dir.glob(
     File.expand_path('../../apps/web/auth/migrations/[0-9]*_*.rb', __dir__),
-  ).count
+  ).map { |path| File.basename(path).to_i }.max
 
   class << self
     attr_reader :database, :migration_database


### PR DESCRIPTION
## Summary

Fixes #3239

This PR addresses two test infrastructure issues uncovered while getting the GA workflow passing:

1. **Schema version detection** (`spec/support/postgres_mode_suite_database.rb`): The `EXPECTED_SCHEMA_VERSION` constant was hardcoded to `7`, but recent OAuth migrations (008–010) brought the actual schema to version `10`. Now derives the version dynamically from migration files to avoid manual updates.

2. **Auth spec tiering** (20 file moves to `apps/web/auth/spec/integration/full/`): Several auth specs were incorrectly placed in the `unit/` tier but required full-mode Rodauth boot via the shared `spec_helper`. This caused the entire unit test run to abort with `db` nil. Relocated these specs to the `integration/full/` tier where they belong and can properly boot the application.

3. **Latent test bug** (`apps/web/auth/spec/operations/set_customer_verification_spec.rb`): Added missing `require 'auth/database'` that was exposed by the relocation.

### Relocated specs
- `session_auth_strategy_spec.rb`
- `noauth_strategy_spec.rb`
- `basic_auth_strategy_spec.rb`
- `helpers_spec.rb`
- `omniauth_tenant_helpers_spec.rb`
- `router_error_shape_spec.rb`
- `domain_sso_config_spec.rb`
- `seed_dev_oauth_client_idempotency_spec.rb`
- Config/feature specs (email_modules, production_boot, env_feature_loading, feature_combinations, mfa, active_sessions, email_auth, lockout, password_requirements, remember_me, webauthn, env_conditionals)

All require paths updated to reflect new directory structure.

## Related Issues

Fixes #3104 (indirectly via PR #3239)

## Test Plan

- Migration Tests workflow: **green** (confirms schema version fix)
- T2 · Ruby Unit Tests: **green** (1637 examples now execute; previously aborted)
- T3 · Ruby Integration (Full, PostgreSQL): **green** (both billing variants)
- T3 · Ruby Integration (Simple/Disabled, Smoke): **green**

Note: T3 · Ruby Integration (Full, SQLite) shows 27 failures in the relocated strategy specs. This is a newly surfaced issue (specs never ran in CI before) documented in `HANDOFF-auth-spec-tiering.md` and requires separate investigation into SQLite shared-suite state interactions.

https://claude.ai/code/session_01QPsbM2RNrTaVNrjRTHhKPV