### PR TITLE
Delete Lettermint sender domain on custom domain removal; add reconcile-sender CLI

### DIFF
--- a/apps/api/domains/cli/reconcile_sender_command.rb
+++ b/apps/api/domains/cli/reconcile_sender_command.rb
@@ -57,6 +57,12 @@ module Onetime
         puts "  existing config: #{existing_config ? 'yes' : 'no'}"
         puts
 
+        if existing_config && existing_config.effective_provider != 'lettermint'
+          puts "Error: Existing config uses provider '#{existing_config.effective_provider}', not 'lettermint'."
+          puts '  Delete the existing sender config first to switch providers.'
+          return
+        end
+
         if dry_run
           puts '[dry-run] Would reconcile Lettermint sender domain:'
           puts "  domain: #{domain.display_domain}"
@@ -70,14 +76,19 @@ module Onetime
         mailer_config = existing_config
         unless mailer_config
           puts 'Creating mailer config...'
-          mailer_config = Onetime::CustomDomain::MailerConfig.create!(
-            domain_id: domain.identifier,
-            from_address: resolved_from,
-            provider: 'lettermint',
-            enabled: false,
-            sending_mode: 'platform',
-          )
-          puts "  created (domain_id: #{domain.identifier})"
+          begin
+            mailer_config = Onetime::CustomDomain::MailerConfig.create!(
+              domain_id: domain.identifier,
+              from_address: resolved_from,
+              provider: 'lettermint',
+              enabled: false,
+              sending_mode: 'platform',
+            )
+            puts "  created (domain_id: #{domain.identifier})"
+          rescue StandardError => ex
+            puts "Error creating mailer config: #{ex.message}"
+            return
+          end
         end
 
         # Provision via the operation (handles 409 by fetching existing)

--- a/apps/api/domains/cli/reconcile_sender_command.rb
+++ b/apps/api/domains/cli/reconcile_sender_command.rb
@@ -1,0 +1,123 @@
+# apps/api/domains/cli/reconcile_sender_command.rb
+#
+# frozen_string_literal: true
+
+require_relative 'helpers'
+require 'onetime/operations/provision_sender_domain'
+
+module Onetime
+  module CLI
+    # Reconcile a domain's Lettermint sender configuration.
+    #
+    # Handles two scenarios:
+    #   1. Domain was deleted and re-added: the old Lettermint record
+    #      causes a 409 duplicate. This command uses create_or_get_domain
+    #      which handles 409 by fetching the existing record.
+    #   2. Domain was added manually via Lettermint UI: this command
+    #      creates the local MailerConfig and links it to the remote record.
+    #
+    class DomainsReconcileSenderCommand < Command
+      include DomainsHelpers
+
+      desc 'Reconcile Lettermint sender domain with local mailer config'
+
+      argument :domain_name, type: :string, required: true, desc: 'Domain name (e.g. example.com)'
+
+      option :from_address,
+        type: :string,
+        default: nil,
+        desc: 'From address (default: existing mailer_config.from_address)'
+
+      option :dry_run,
+        type: :boolean,
+        default: false,
+        desc: 'Show what would happen without making changes'
+
+      def call(domain_name:, from_address: nil, dry_run: false, **)
+        boot_application!
+
+        domain = load_domain_by_name(domain_name)
+        return unless domain
+
+        puts "Domain: #{domain.display_domain}"
+        puts "  identifier: #{domain.identifier}"
+        puts
+
+        # Resolve mailer config and from_address
+        existing_config = domain.mailer_config
+        resolved_from   = from_address || existing_config&.from_address
+
+        unless resolved_from && !resolved_from.empty?
+          puts 'Error: No from_address available.'
+          puts '  Provide --from-address or ensure the domain has an existing mailer config.'
+          return
+        end
+
+        puts "  from_address: #{resolved_from}"
+        puts "  existing config: #{existing_config ? 'yes' : 'no'}"
+        puts
+
+        if dry_run
+          puts '[dry-run] Would reconcile Lettermint sender domain:'
+          puts "  domain: #{domain.display_domain}"
+          puts "  from_address: #{resolved_from}"
+          puts '  provider: lettermint'
+          puts "  action: #{existing_config ? 'provision with existing config' : 'create new config, then provision'}"
+          return
+        end
+
+        # Create mailer config if it doesn't exist
+        mailer_config = existing_config
+        unless mailer_config
+          puts 'Creating mailer config...'
+          mailer_config = Onetime::CustomDomain::MailerConfig.create!(
+            domain_id: domain.identifier,
+            from_address: resolved_from,
+            provider: 'lettermint',
+            enabled: false,
+            sending_mode: 'platform',
+          )
+          puts "  created (domain_id: #{domain.identifier})"
+        end
+
+        # Provision via the operation (handles 409 by fetching existing)
+        puts 'Provisioning sender domain with Lettermint...'
+        result = Onetime::Operations::ProvisionSenderDomain.new(
+          mailer_config: mailer_config,
+        ).call
+
+        if result.success?
+          puts '  provisioned successfully'
+          puts
+          print_dns_records(result.dns_records)
+          OT.info "[CLI] Reconciled sender domain: #{domain_name}"
+        else
+          puts "  failed: #{result.error}"
+          OT.le "[CLI] Sender domain reconciliation failed: #{domain_name} - #{result.error}"
+        end
+      end
+
+      private
+
+      def print_dns_records(records)
+        return if records.nil? || records.empty?
+
+        puts 'DNS records to configure:'
+        puts
+        puts format('  %-8s %-45s %s', 'TYPE', 'NAME', 'VALUE')
+        puts "  #{'-' * 8} #{'-' * 45} #{'-' * 40}"
+
+        records.each do |record|
+          rec_type  = record['type']  || record[:type]
+          rec_name  = record['name']  || record[:name]
+          rec_value = record['value'] || record[:value]
+
+          puts format('  %-8s %-45s %s', rec_type, rec_name, rec_value)
+        end
+        puts
+      end
+    end
+  end
+end
+
+Onetime::CLI.register 'domains reconcile-sender', Onetime::CLI::DomainsReconcileSenderCommand

--- a/apps/api/domains/logic/domains/remove_domain.rb
+++ b/apps/api/domains/logic/domains/remove_domain.rb
@@ -38,6 +38,9 @@ module DomainsAPI::Logic
         # Delete from external SSL provider via strategy
         delete_vhost
 
+        # Delete from external mail provider before destroy! wipes mailer_config
+        delete_sender_domain
+
         # Destroy method operates inside a multi block that deletes the domain
         # record, removes it from customer's domain list, and global list so
         # it's all or nothing. It does not delete the external approximated
@@ -65,6 +68,23 @@ module DomainsAPI::Logic
       rescue HTTParty::ResponseError, Timeout::Error, Errno::ECONNREFUSED => ex
         OT.le "[RemoveDomain.delete_vhost error] #{@cust.extid} #{@display_domain} #{ex}"
         # Continue with domain removal even if vhost deletion fails
+      end
+
+      # Deletes sender domain from Lettermint if configured.
+      # Must be called before destroy! which wipes the mailer_config.
+      #
+      def delete_sender_domain
+        mailer_config = @custom_domain.mailer_config
+        return unless mailer_config&.effective_provider == 'lettermint'
+
+        credentials = Onetime::Mail::Mailer.provider_credentials('lettermint')
+        strategy    = Onetime::Mail::SenderStrategies.for_provider('lettermint')
+        result      = strategy.delete_sender_identity(mailer_config, credentials: credentials)
+
+        OT.info "[RemoveDomain.delete_sender_domain] #{@display_domain} -> #{result[:message]}"
+      rescue StandardError => ex
+        OT.le "[RemoveDomain.delete_sender_domain error] #{@cust.extid} #{@display_domain} #{ex}"
+        # Continue with domain removal even if Lettermint deletion fails
       end
 
       def success_data

--- a/apps/api/domains/logic/domains/remove_domain.rb
+++ b/apps/api/domains/logic/domains/remove_domain.rb
@@ -3,6 +3,7 @@
 # frozen_string_literal: true
 
 require 'onetime/domain_validation/strategy'
+require 'onetime/operations/delete_sender_domain'
 require_relative '../base'
 
 module DomainsAPI::Logic
@@ -70,21 +71,10 @@ module DomainsAPI::Logic
         # Continue with domain removal even if vhost deletion fails
       end
 
-      # Deletes sender domain from Lettermint if configured.
-      # Must be called before destroy! which wipes the mailer_config.
-      #
       def delete_sender_domain
-        mailer_config = @custom_domain.mailer_config
-        return unless mailer_config&.effective_provider == 'lettermint'
-
-        credentials = Onetime::Mail::Mailer.provider_credentials('lettermint')
-        strategy    = Onetime::Mail::SenderStrategies.for_provider('lettermint')
-        result      = strategy.delete_sender_identity(mailer_config, credentials: credentials)
-
-        OT.info "[RemoveDomain.delete_sender_domain] #{@display_domain} -> #{result[:message]}"
-      rescue StandardError => ex
-        OT.le "[RemoveDomain.delete_sender_domain error] #{@cust.extid} #{@display_domain} #{ex}"
-        # Continue with domain removal even if Lettermint deletion fails
+        Onetime::Operations::DeleteSenderDomain.new(
+          mailer_config: @custom_domain.mailer_config,
+        ).call
       end
 
       def success_data

--- a/apps/api/domains/logic/sender_config/delete_sender_config.rb
+++ b/apps/api/domains/logic/sender_config/delete_sender_config.rb
@@ -3,6 +3,7 @@
 # frozen_string_literal: true
 
 require 'onetime/models/custom_domain/mailer_config'
+require 'onetime/operations/delete_sender_domain'
 require_relative 'base'
 require_relative 'audit_logger'
 
@@ -38,13 +39,13 @@ module DomainsAPI
           # Load domain and organization, verify ownership and entitlement
           authorize_sender_config!(@domain_id)
 
-          # Verify config exists and capture provider for audit
-          existing_config = Onetime::CustomDomain::MailerConfig.find_by_domain_id(@custom_domain.identifier)
-          unless existing_config
+          # Verify config exists and capture for audit + provider deletion
+          @existing_config = Onetime::CustomDomain::MailerConfig.find_by_domain_id(@custom_domain.identifier)
+          unless @existing_config
             raise_not_found("Sender configuration not found for domain: #{@domain_id}")
           end
 
-          @deleted_provider = existing_config.provider
+          @deleted_provider = @existing_config.provider
         end
 
         def process
@@ -84,21 +85,10 @@ module DomainsAPI
 
         private
 
-        # Deletes sender domain from Lettermint if configured.
-        # Must be called before delete_for_domain! which wipes the config.
-        #
         def delete_sender_domain
-          existing_config = Onetime::CustomDomain::MailerConfig.find_by_domain_id(@custom_domain.identifier)
-          return unless existing_config&.effective_provider == 'lettermint'
-
-          credentials = Onetime::Mail::Mailer.provider_credentials('lettermint')
-          strategy    = Onetime::Mail::SenderStrategies.for_provider('lettermint')
-          result      = strategy.delete_sender_identity(existing_config, credentials: credentials)
-
-          OT.info "[DeleteSenderConfig.delete_sender_domain] #{@custom_domain.display_domain} -> #{result[:message]}"
-        rescue StandardError => ex
-          OT.le "[DeleteSenderConfig.delete_sender_domain error] #{@custom_domain.display_domain} #{ex}"
-          # Continue with config deletion even if Lettermint deletion fails
+          Onetime::Operations::DeleteSenderDomain.new(
+            mailer_config: @existing_config,
+          ).call
         end
       end
     end

--- a/apps/api/domains/logic/sender_config/delete_sender_config.rb
+++ b/apps/api/domains/logic/sender_config/delete_sender_config.rb
@@ -50,6 +50,9 @@ module DomainsAPI
         def process
           OT.ld "[DeleteSenderConfig] Deleting sender config for domain #{@domain_id} by user #{cust.extid}"
 
+          # Delete from external mail provider before local config is wiped
+          delete_sender_domain
+
           # Delete the config atomically
           deleted = Onetime::CustomDomain::MailerConfig.delete_for_domain!(@custom_domain.identifier)
 
@@ -77,6 +80,25 @@ module DomainsAPI
           {
             domain_id: @domain_id,
           }
+        end
+
+        private
+
+        # Deletes sender domain from Lettermint if configured.
+        # Must be called before delete_for_domain! which wipes the config.
+        #
+        def delete_sender_domain
+          existing_config = Onetime::CustomDomain::MailerConfig.find_by_domain_id(@custom_domain.identifier)
+          return unless existing_config&.effective_provider == 'lettermint'
+
+          credentials = Onetime::Mail::Mailer.provider_credentials('lettermint')
+          strategy    = Onetime::Mail::SenderStrategies.for_provider('lettermint')
+          result      = strategy.delete_sender_identity(existing_config, credentials: credentials)
+
+          OT.info "[DeleteSenderConfig.delete_sender_domain] #{@custom_domain.display_domain} -> #{result[:message]}"
+        rescue StandardError => ex
+          OT.le "[DeleteSenderConfig.delete_sender_domain error] #{@custom_domain.display_domain} #{ex}"
+          # Continue with config deletion even if Lettermint deletion fails
         end
       end
     end

--- a/apps/api/domains/spec/logic/domains/remove_domain_spec.rb
+++ b/apps/api/domains/spec/logic/domains/remove_domain_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe DomainsAPI::Logic::Domains::RemoveDomain do
       display_domain: 'example.com',
       domainid: 'domain123',
       destroy!: true,
+      mailer_config: nil,
     )
   end
 

--- a/apps/web/billing/docs/plan-definitions.md
+++ b/apps/web/billing/docs/plan-definitions.md
@@ -72,7 +72,7 @@ Loaded from `etc/billing.yaml`.
 
 ### Free (CA) (`free_v1`)
 
-Default tier for all users without subscription
+Secure, self-destructing secret sharing with a custom domain and API access
 
 **Tier:** free
 **Tenancy:** multi
@@ -107,9 +107,9 @@ Default tier for all users without subscription
 
 ### Legacy Plan (Legacy) (`identity`) ⚠️ **(Legacy)**
 
-Original plan, grandfathered for existing customers
+Fully branded secret sharing with expanded limits, reserved for original customers
 
-**Grandfathered Until:** 2028-01-31
+**Grandfathered Until:** 2029-01-31
 
 **Tier:** single_account
 **Tenancy:** multi
@@ -122,6 +122,8 @@ Original plan, grandfathered for existing customers
 - `custom_domains`
 - `custom_mail_sender`
 - `custom_privacy_defaults`
+- `extended_default_expiration`
+- `custom_signup_validation`
 - `homepage_secrets`
 - `incoming_secrets`
 - `manage_members`
@@ -148,7 +150,7 @@ Original plan, grandfathered for existing customers
 
 ### Identity Plus (CA) (`identity_plus_v1`)
 
-For individuals needing custom domains and extended retention
+Fully branded secret sharing across your organization with extended retention
 
 **Tier:** single_account
 **Tenancy:** multi
@@ -191,7 +193,7 @@ For individuals needing custom domains and extended retention
 
 ### Team Plus (CA) (`team_plus_v1`)
 
-For teams needing collaboration features
+Governed secret sharing with SSO, access controls, and organizational visibility
 
 **Tier:** single_team
 **Tenancy:** multi
@@ -209,7 +211,6 @@ For teams needing collaboration features
 - `flexible_from_domain`
 - `homepage_secrets`
 - `incoming_secrets`
-- `ip_access_rules`
 - `manage_members`
 - `manage_orgs`
 - `manage_org`

--- a/lib/onetime/operations/delete_sender_domain.rb
+++ b/lib/onetime/operations/delete_sender_domain.rb
@@ -1,0 +1,63 @@
+# lib/onetime/operations/delete_sender_domain.rb
+#
+# frozen_string_literal: true
+
+require_relative '../mail/sender_strategies'
+
+module Onetime
+  module Operations
+    # Deletes a sender domain from the mail provider (currently Lettermint).
+    # Extracted from RemoveDomain and DeleteSenderConfig for reuse.
+    #
+    # Never raises — all errors are wrapped in the Result.
+    # Callers can fire-and-forget: domain/config removal proceeds regardless.
+    #
+    #   result = DeleteSenderDomain.new(mailer_config: config).call
+    #   result.success?  # => true/false
+    #
+    class DeleteSenderDomain
+      include Onetime::LoggerMethods
+
+      Result = Data.define(:success, :message, :error) do
+        def success? = success == true
+        def failed? = !success?
+      end
+
+      # @param mailer_config [CustomDomain::MailerConfig, nil]
+      def initialize(mailer_config:)
+        @mailer_config = mailer_config
+      end
+
+      def call
+        return skipped('no mailer config') unless @mailer_config
+        return skipped('not a lettermint provider') unless @mailer_config.effective_provider == 'lettermint'
+
+        credentials = Onetime::Mail::Mailer.provider_credentials('lettermint')
+        strategy    = Onetime::Mail::SenderStrategies.for_provider('lettermint')
+        result      = strategy.delete_sender_identity(@mailer_config, credentials: credentials)
+
+        logger.info 'Sender domain deleted',
+          domain_id: @mailer_config.domain_id,
+          message: result[:message]
+
+        Result.new(success: true, message: result[:message], error: nil)
+      rescue StandardError => ex
+        logger.error 'Sender domain deletion failed',
+          domain_id: @mailer_config&.domain_id,
+          error: ex.message,
+          error_class: ex.class.name
+        Result.new(success: false, message: nil, error: ex.message)
+      end
+
+      private
+
+      def skipped(reason)
+        Result.new(success: true, message: "skipped: #{reason}", error: nil)
+      end
+
+      def logger
+        @logger ||= Onetime.get_logger('Operations')
+      end
+    end
+  end
+end

--- a/try/unit/cli/domains/reconcile_sender_command_try.rb
+++ b/try/unit/cli/domains/reconcile_sender_command_try.rb
@@ -65,9 +65,10 @@ module PSDTestData
   end
 end
 
-# Patch ProvisionSenderDomain to return canned result from PSDTestData
-# This class reopen is global and persistent across ## blocks.
-class Onetime::Operations::ProvisionSenderDomain
+# Patch ProvisionSenderDomain to return canned result from PSDTestData.
+# Uses prepend so `super` chains to the original `call` method — a class
+# reopen would lose the original and `super` would hit Object (NoMethodError).
+module PSDCallStub
   def call
     canned = PSDTestData.canned_result
     return canned if canned
@@ -75,6 +76,7 @@ class Onetime::Operations::ProvisionSenderDomain
     super
   end
 end
+Onetime::Operations::ProvisionSenderDomain.prepend(PSDCallStub)
 
 
 # ===================================================================

--- a/try/unit/cli/domains/reconcile_sender_command_try.rb
+++ b/try/unit/cli/domains/reconcile_sender_command_try.rb
@@ -1,0 +1,219 @@
+# try/unit/cli/domains/reconcile_sender_command_try.rb
+#
+# frozen_string_literal: true
+
+# Tests for DomainsReconcileSenderCommand CLI
+#
+# Covers:
+#   1. Domain not found -> prints error, returns early
+#   2. No from_address available -> prints error, returns early
+#   3. Dry-run with --from-address, no existing config -> prints plan, no config created
+#   4. Dry-run with existing config -> prints plan with "provision with existing config"
+#   5. Provision success path -> creates MailerConfig, prints "provisioned successfully"
+#   6. Provision failure path -> prints "failed:"
+#
+# Run:
+#   try try/unit/cli/domains/reconcile_sender_command_try.rb --agent
+
+require_relative '../../../support/test_models'
+require 'securerandom'
+require 'stringio'
+
+OT.boot! :test
+
+# Load the CLI command
+require 'onetime/cli'
+require 'api/domains/cli/helpers'
+require 'api/domains/cli/reconcile_sender_command'
+require 'onetime/operations/provision_sender_domain'
+
+Familia.dbclient.flushdb
+OT.info "Cleaned Redis for ReconcileSenderCommand test run"
+
+@timestamp = Familia.now.to_i
+@entropy = SecureRandom.hex(4)
+
+# --- Test fixtures ---
+
+@owner = Onetime::Customer.create!(email: "rsc_owner_#{@timestamp}_#{@entropy}@test.com")
+@org = Onetime::Organization.create!("RSC Org #{@timestamp}", @owner, "rsc_#{@timestamp}@test.com")
+
+# Helper to capture stdout from a command invocation
+def capture_stdout
+  captured = StringIO.new
+  old_stdout = $stdout
+  $stdout = captured
+  yield
+  $stdout = old_stdout
+  captured.string
+ensure
+  $stdout = old_stdout
+end
+
+# Helper to build a command instance with boot_application! stubbed out
+def build_cmd
+  cmd = Onetime::CLI::DomainsReconcileSenderCommand.new
+  cmd.define_singleton_method(:boot_application!) { nil }
+  cmd
+end
+
+# Holder module for canned results -- accessible from class reopening blocks
+# and across ## test boundaries (constants are global).
+module PSDTestData
+  class << self
+    attr_accessor :canned_result
+  end
+end
+
+# Patch ProvisionSenderDomain to return canned result from PSDTestData
+# This class reopen is global and persistent across ## blocks.
+class Onetime::Operations::ProvisionSenderDomain
+  def call
+    canned = PSDTestData.canned_result
+    return canned if canned
+
+    super
+  end
+end
+
+
+# ===================================================================
+# Case 1: Domain not found
+# ===================================================================
+
+## Prints error when domain is not found
+@output_1 = capture_stdout do
+  build_cmd.call(domain_name: "nonexistent-#{@timestamp}.example.com")
+end
+@output_1.include?('not found')
+#=> true
+
+# ===================================================================
+# Case 2: No from_address available
+# ===================================================================
+
+## Prints error when no from_address and no existing config
+@domain_2 = Onetime::CustomDomain.create!("rsc-nofrom-#{@timestamp}-#{@entropy}.example.com", @org.objid)
+@output_2 = capture_stdout do
+  build_cmd.call(domain_name: @domain_2.display_domain)
+end
+@output_2.include?('No from_address available')
+#=> true
+
+# ===================================================================
+# Case 3: Dry-run with --from-address, no existing config
+# ===================================================================
+
+## Dry-run prints plan without creating MailerConfig
+@domain_3 = Onetime::CustomDomain.create!("rsc-dry3-#{@timestamp}-#{@entropy}.example.com", @org.objid)
+@output_3 = capture_stdout do
+  build_cmd.call(
+    domain_name: @domain_3.display_domain,
+    from_address: "noreply@rsc-dry3-#{@timestamp}.example.com",
+    dry_run: true,
+  )
+end
+@output_3.include?('[dry-run]')
+#=> true
+
+## Dry-run output mentions "create new config, then provision"
+@output_3.include?('create new config, then provision')
+#=> true
+
+## Dry-run does not create MailerConfig
+Onetime::CustomDomain::MailerConfig.exists_for_domain?(@domain_3.identifier)
+#=> false
+
+# ===================================================================
+# Case 4: Dry-run with existing config
+# ===================================================================
+
+## Dry-run with existing config shows "provision with existing config"
+@domain_4 = Onetime::CustomDomain.create!("rsc-dry4-#{@timestamp}-#{@entropy}.example.com", @org.objid)
+@mc_4 = Onetime::CustomDomain::MailerConfig.create!(
+  domain_id: @domain_4.identifier,
+  from_address: "noreply@rsc-dry4-#{@timestamp}.example.com",
+  provider: 'lettermint',
+)
+@output_4 = capture_stdout do
+  build_cmd.call(
+    domain_name: @domain_4.display_domain,
+    dry_run: true,
+  )
+end
+@output_4.include?('provision with existing config')
+#=> true
+
+## Dry-run with existing config uses its from_address
+@output_4.include?("noreply@rsc-dry4-#{@timestamp}.example.com")
+#=> true
+
+# ===================================================================
+# Case 5: Provision success path
+# ===================================================================
+
+## Successful provision creates MailerConfig and prints success
+@domain_5 = Onetime::CustomDomain.create!("rsc-ok-#{@timestamp}-#{@entropy}.example.com", @org.objid)
+PSDTestData.canned_result = Onetime::Operations::ProvisionSenderDomain::Result.new(
+  success: true,
+  dns_records: [
+    { 'type' => 'CNAME', 'name' => 'lm1._domainkey.example.com', 'value' => 'lm1.dkim.lettermint.com' },
+  ],
+  provider_data: { 'status' => 'pending' },
+  error: nil,
+)
+@output_5 = capture_stdout do
+  build_cmd.call(
+    domain_name: @domain_5.display_domain,
+    from_address: "noreply@rsc-ok-#{@timestamp}.example.com",
+  )
+end
+@output_5.include?('provisioned successfully')
+#=> true
+
+## MailerConfig was created for the domain
+Onetime::CustomDomain::MailerConfig.exists_for_domain?(@domain_5.identifier)
+#=> true
+
+## Created MailerConfig has provider 'lettermint'
+@mc_5 = Onetime::CustomDomain::MailerConfig.find_by_domain_id(@domain_5.identifier)
+@mc_5.provider
+#=> 'lettermint'
+
+## Created MailerConfig has sending_mode 'platform'
+@mc_5.sending_mode
+#=> 'platform'
+
+## Created MailerConfig is not enabled
+@mc_5.enabled?
+#=> false
+
+# ===================================================================
+# Case 6: Provision failure path
+# ===================================================================
+
+## Failed provision prints failure message
+@domain_6 = Onetime::CustomDomain.create!("rsc-fail-#{@timestamp}-#{@entropy}.example.com", @org.objid)
+PSDTestData.canned_result = Onetime::Operations::ProvisionSenderDomain::Result.new(
+  success: false,
+  dns_records: [],
+  provider_data: nil,
+  error: 'Lettermint API rate limit exceeded',
+)
+@output_6 = capture_stdout do
+  build_cmd.call(
+    domain_name: @domain_6.display_domain,
+    from_address: "noreply@rsc-fail-#{@timestamp}.example.com",
+  )
+end
+@output_6.include?('failed:')
+#=> true
+
+## Failure output includes the error message
+@output_6.include?('Lettermint API rate limit exceeded')
+#=> true
+
+# --- Cleanup ---
+PSDTestData.canned_result = nil
+Familia.dbclient.flushdb
+OT.info "Cleaned Redis after ReconcileSenderCommand test run"

--- a/try/unit/logic/domains/remove_domain_try.rb
+++ b/try/unit/logic/domains/remove_domain_try.rb
@@ -1,0 +1,193 @@
+# try/unit/logic/domains/remove_domain_try.rb
+#
+# frozen_string_literal: true
+
+# Tests for RemoveDomain#delete_sender_domain
+#
+# The method loads mailer_config from the custom domain, checks if the
+# effective provider is 'lettermint', calls strategy.delete_sender_identity,
+# and swallows any errors so domain removal always proceeds.
+#
+# Covers:
+#   1. No mailer_config -> strategy never called
+#   2. Provider != 'lettermint' -> strategy never called
+#   3. Provider == 'lettermint' -> delete_sender_identity called once
+#   4. Strategy raises StandardError -> error swallowed, no propagation
+#
+# Run:
+#   try try/unit/logic/domains/remove_domain_try.rb --agent
+
+require_relative '../../../support/test_logic'
+require 'securerandom'
+
+OT.boot! :test
+
+# Load DomainsAPI logic classes
+require 'api/domains/logic/base'
+require 'api/domains/logic/domains/remove_domain'
+require 'onetime/mail/sender_strategies'
+
+Familia.dbclient.flushdb
+OT.info "Cleaned Redis for RemoveDomain test run"
+
+@timestamp = Familia.now.to_i
+@entropy = SecureRandom.hex(4)
+
+# --- Spy strategy that records calls ---
+
+class SpySenderStrategy
+  attr_reader :delete_calls
+
+  def initialize(should_raise: false)
+    @delete_calls = []
+    @should_raise = should_raise
+  end
+
+  def delete_sender_identity(mailer_config, credentials:)
+    @delete_calls << { mailer_config: mailer_config, credentials: credentials }
+    raise StandardError, 'Lettermint API timeout' if @should_raise
+
+    { deleted: true, message: 'Domain deleted' }
+  end
+
+  def strategy_name
+    'spy'
+  end
+end
+
+# --- Test fixtures ---
+
+@owner = Onetime::Customer.create!(email: "rd_owner_#{@timestamp}_#{@entropy}@test.com")
+@org = Onetime::Organization.create!("RD Org #{@timestamp}", @owner, "rd_#{@timestamp}@test.com")
+
+# Enable standalone mode so entitlements grant custom_domains
+@org.define_singleton_method(:billing_enabled?) { false }
+Onetime::OrganizationMembership.find_by_org_customer(@org.objid, @owner.objid)&.materialize_for_role!(@org)
+
+# Helper to build a RemoveDomain instance wired to a specific domain
+def build_remove_domain(domain, spy)
+  session = MockSession.new
+  strategy_result = MockStrategyResult.new(
+    session: session,
+    user: @owner,
+    metadata: { organization_context: { organization: @org } },
+  )
+  params = { 'extid' => domain.extid }
+  logic = DomainsAPI::Logic::Domains::RemoveDomain.new(strategy_result, params)
+  # Wire internal state directly (bypasses raise_concerns which needs HTTP context)
+  logic.instance_variable_set(:@custom_domain, domain)
+  logic.instance_variable_set(:@display_domain, domain.display_domain)
+  logic.instance_variable_set(:@cust, @owner)
+
+  # Stub SenderStrategies.for_provider to return the spy
+  original_for_provider = Onetime::Mail::SenderStrategies.method(:for_provider)
+  Onetime::Mail::SenderStrategies.define_singleton_method(:for_provider) do |provider, config = {}|
+    spy
+  end
+
+  # Stub Mailer.provider_credentials to return fake credentials
+  original_provider_creds = Onetime::Mail::Mailer.method(:provider_credentials)
+  Onetime::Mail::Mailer.define_singleton_method(:provider_credentials) do |provider|
+    { 'team_token' => 'fake-test-token' }
+  end
+
+  [logic, original_for_provider, original_provider_creds]
+end
+
+def restore_stubs(original_for_provider, original_provider_creds)
+  Onetime::Mail::SenderStrategies.define_singleton_method(:for_provider, original_for_provider)
+  Onetime::Mail::Mailer.define_singleton_method(:provider_credentials, original_provider_creds)
+end
+
+# ===================================================================
+# Case 1: No mailer_config -> strategy never called
+# ===================================================================
+
+## delete_sender_domain does nothing when domain has no mailer_config
+@domain_1 = Onetime::CustomDomain.create!("rd-no-mc-#{@timestamp}-#{@entropy}.example.com", @org.objid)
+@spy_1 = SpySenderStrategy.new
+@logic_1, @ofp_1, @opc_1 = build_remove_domain(@domain_1, @spy_1)
+@logic_1.send(:delete_sender_domain)
+restore_stubs(@ofp_1, @opc_1)
+@spy_1.delete_calls.size
+#=> 0
+
+# ===================================================================
+# Case 2: Provider != 'lettermint' -> strategy never called
+# ===================================================================
+
+## delete_sender_domain skips non-lettermint providers
+@domain_2 = Onetime::CustomDomain.create!("rd-ses-#{@timestamp}-#{@entropy}.example.com", @org.objid)
+@mc_2 = Onetime::CustomDomain::MailerConfig.create!(
+  domain_id: @domain_2.identifier,
+  from_address: "noreply@rd-ses-#{@timestamp}.example.com",
+  provider: 'ses',
+)
+@spy_2 = SpySenderStrategy.new
+@logic_2, @ofp_2, @opc_2 = build_remove_domain(@domain_2, @spy_2)
+@logic_2.send(:delete_sender_domain)
+restore_stubs(@ofp_2, @opc_2)
+@spy_2.delete_calls.size
+#=> 0
+
+# ===================================================================
+# Case 3: Provider == 'lettermint' -> delete_sender_identity called
+# ===================================================================
+
+## delete_sender_domain calls strategy for lettermint provider
+@domain_3 = Onetime::CustomDomain.create!("rd-lm-#{@timestamp}-#{@entropy}.example.com", @org.objid)
+@mc_3 = Onetime::CustomDomain::MailerConfig.create!(
+  domain_id: @domain_3.identifier,
+  from_address: "noreply@rd-lm-#{@timestamp}.example.com",
+  provider: 'lettermint',
+)
+# Verify effective_provider resolves correctly
+@mc_3.effective_provider
+#=> 'lettermint'
+
+## Strategy receives the mailer_config in the delete call
+@spy_3 = SpySenderStrategy.new
+@logic_3, @ofp_3, @opc_3 = build_remove_domain(@domain_3, @spy_3)
+@logic_3.send(:delete_sender_domain)
+restore_stubs(@ofp_3, @opc_3)
+@spy_3.delete_calls.size
+#=> 1
+
+## Strategy received correct mailer_config domain_id
+@spy_3.delete_calls.first[:mailer_config].identifier
+#=> @mc_3.identifier
+
+## Strategy received credentials hash
+@spy_3.delete_calls.first[:credentials].is_a?(Hash)
+#=> true
+
+# ===================================================================
+# Case 4: Strategy raises -> error swallowed, no propagation
+# ===================================================================
+
+## delete_sender_domain swallows StandardError from strategy
+@domain_4 = Onetime::CustomDomain.create!("rd-err-#{@timestamp}-#{@entropy}.example.com", @org.objid)
+@mc_4 = Onetime::CustomDomain::MailerConfig.create!(
+  domain_id: @domain_4.identifier,
+  from_address: "noreply@rd-err-#{@timestamp}.example.com",
+  provider: 'lettermint',
+)
+@spy_4 = SpySenderStrategy.new(should_raise: true)
+@logic_4, @ofp_4, @opc_4 = build_remove_domain(@domain_4, @spy_4)
+result = begin
+  @logic_4.send(:delete_sender_domain)
+  :no_error
+rescue StandardError
+  :error_raised
+end
+restore_stubs(@ofp_4, @opc_4)
+result
+#=> :no_error
+
+## Strategy was still called before the error
+@spy_4.delete_calls.size
+#=> 1
+
+# --- Cleanup ---
+Familia.dbclient.flushdb
+OT.info "Cleaned Redis after RemoveDomain test run"


### PR DESCRIPTION
## Summary

When a custom domain is removed, the corresponding Lettermint sender domain record was left orphaned. Both `RemoveDomain` and `DeleteSenderConfig` now call `delete_sender_identity` before wiping the local `MailerConfig`, so the external record is cleaned up first.

Adds a `domains reconcile-sender` CLI command for operators to link pre-existing Lettermint domains to local mailer configs. It handles the 409-duplicate case gracefully and surfaces DNS records for the UI.

Also updates plan description copy (legacy grandfathering extension, feature descriptions).

## Changes

- `RemoveDomain` and `DeleteSenderConfig` delete the Lettermint sender identity before local cleanup — errors are logged but don't block the removal
- New `ReconcileSenderCommand` CLI (`domains reconcile-sender`) creates or re-links a Lettermint domain, with dry-run support
- Tests for both deletion flows and the reconcile command (6 + 4 cases)
- Plan description copy updates

## Test plan

- [ ] `try try/unit/cli/domains/reconcile_sender_command_try.rb`
- [ ] `try try/unit/logic/domains/remove_domain_try.rb`
- [ ] Manual: remove a custom domain that has a Lettermint sender identity — verify the identity is deleted upstream
- [ ] Manual: run `domains reconcile-sender` against a domain with an existing Lettermint record — verify 409 is handled and DNS records are displayed