### PR TITLE
Migrate unique_index values from JSON to raw strings for Familia 2.10

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -127,7 +127,7 @@ GEM
       tzinfo
     faker (3.6.1)
       i18n (>= 1.8.11, < 2)
-    familia (2.10.0)
+    familia (2.10.1)
       concurrent-ruby (~> 1.3)
       connection_pool (>= 2.4, < 4.0)
       csv (~> 3.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -272,7 +272,7 @@ GEM
       snaky_hash (~> 2.0, >= 2.0.3)
       version_gem (~> 1.1, >= 1.1.9)
     observer (0.1.2)
-    oj (3.16.17)
+    oj (3.17.3)
       bigdecimal (>= 3.0)
       ostruct (>= 0.2)
     omniauth (2.1.4)
@@ -393,7 +393,7 @@ GEM
       tsort
     redis (5.4.1)
       redis-client (>= 0.22.0)
-    redis-client (0.28.0)
+    redis-client (0.29.0)
       connection_pool
     regexp_parser (2.12.0)
     reline (0.6.3)
@@ -694,9 +694,6 @@ DEPENDENCIES
   vcr (~> 6.0)
   webauthn (~> 3.0)
   webmock (~> 3.0)
-
-RUBY VERSION
-  ruby 3.4.8p72
 
 BUNDLED WITH
   4.0.9

--- a/lib/onetime/initializers.rb
+++ b/lib/onetime/initializers.rb
@@ -32,7 +32,8 @@ require_relative 'initializers/setup_auth_database'     # depends_on: [:logging,
 require_relative 'initializers/setup_rabbitmq'         # depends_on: [:logging]
 require_relative 'initializers/configure_familia'      # depends_on: [:logging]
 require_relative 'initializers/setup_connection_pool'  # depends_on: [:familia_config]
-require_relative 'initializers/check_global_banner'    # depends_on: [:database]
+require_relative 'initializers/check_global_banner'        # depends_on: [:database]
+require_relative 'initializers/check_unique_index_format'  # depends_on: [:database]
 require_relative 'initializers/print_log_banner'       # depends_on: [:logging]
 
 # Convention-based plugin discovery and initialization.

--- a/lib/onetime/initializers/check_unique_index_format.rb
+++ b/lib/onetime/initializers/check_unique_index_format.rb
@@ -11,41 +11,23 @@ module Onetime
     # lookups like CustomDomain.from_display_domain to silently return nil,
     # breaking domain-based org selection (#3347).
     #
-    # This check samples one entry per index. If any value is still
-    # JSON-encoded it logs a warning with the remediation command.
-    # Non-fatal: the app still starts so operators can run the migration.
+    # Delegates to Familia.assert_indexes_current! (v2.10.1) which samples
+    # raw values via HRANDFIELD and checks for legacy encoding. Non-fatal:
+    # the app still starts so operators can run the migration.
     class CheckUniqueIndexFormat < Onetime::Boot::Initializer
       @depends_on = [:database]
       @provides   = [:unique_index_check]
       @optional   = true
 
-      INDEX_KEYS = %w[
-        custom_domain:display_domain_index
-        customer:email_index
-        organization:contact_email_index
-        org_membership:token_lookup
-      ].freeze
-
       def execute(_context)
-        redis       = Familia.dbclient(0)
-        stale_keys  = []
-
-        INDEX_KEYS.each do |key|
-          next unless redis.exists?(key)
-
-          _cursor, entries = redis.hscan(key, '0', count: 5)
-          entries.each do |_field, value|
-            if value.is_a?(String) && value.start_with?('"') && value.end_with?('"')
-              stale_keys << key
-              break
-            end
-          end
+        unless Familia.respond_to?(:assert_indexes_current!)
+          OT.boot_logger.debug '[init] Familia.assert_indexes_current! not available (requires >= 2.10.1); skipping unique_index format check'
+          return
         end
 
-        return if stale_keys.empty?
+        current = Familia.assert_indexes_current!(on_stale: :warn)
+        return if current
 
-        OT.boot_logger.warn "[init] #{stale_keys.size} unique_index(es) contain JSON-encoded values from pre-Familia-2.10:"
-        stale_keys.each { |k| OT.boot_logger.warn "[init]   - #{k}" }
         OT.boot_logger.warn '[init] Run: bin/ots migrate migrations/2026-06-06/20260606_01_unique_index_json_to_raw --run'
         OT.boot_logger.warn '[init] Until migrated, unique_index lookups (e.g. domain SSO) may silently fail. See #3347.'
       end

--- a/lib/onetime/initializers/check_unique_index_format.rb
+++ b/lib/onetime/initializers/check_unique_index_format.rb
@@ -1,0 +1,54 @@
+# lib/onetime/initializers/check_unique_index_format.rb
+#
+# frozen_string_literal: true
+
+module Onetime
+  module Initializers
+    # Detects pre-Familia-2.10 JSON-encoded values in unique_index hashes.
+    #
+    # Familia 2.10 stores unique_index values as raw strings; older versions
+    # stored them JSON-encoded (with surrounding quotes). Stale entries cause
+    # lookups like CustomDomain.from_display_domain to silently return nil,
+    # breaking domain-based org selection (#3347).
+    #
+    # This check samples one entry per index. If any value is still
+    # JSON-encoded it logs a warning with the remediation command.
+    # Non-fatal: the app still starts so operators can run the migration.
+    class CheckUniqueIndexFormat < Onetime::Boot::Initializer
+      @depends_on = [:database]
+      @provides   = [:unique_index_check]
+      @optional   = true
+
+      INDEX_KEYS = %w[
+        custom_domain:display_domain_index
+        customer:email_index
+        organization:contact_email_index
+        org_membership:token_lookup
+      ].freeze
+
+      def execute(_context)
+        redis       = Familia.dbclient(0)
+        stale_keys  = []
+
+        INDEX_KEYS.each do |key|
+          next unless redis.exists?(key)
+
+          _cursor, entries = redis.hscan(key, '0', count: 5)
+          entries.each do |_field, value|
+            if value.is_a?(String) && value.start_with?('"') && value.end_with?('"')
+              stale_keys << key
+              break
+            end
+          end
+        end
+
+        return if stale_keys.empty?
+
+        OT.boot_logger.warn "[init] #{stale_keys.size} unique_index(es) contain JSON-encoded values from pre-Familia-2.10:"
+        stale_keys.each { |k| OT.boot_logger.warn "[init]   - #{k}" }
+        OT.boot_logger.warn '[init] Run: bin/ots migrate migrations/2026-06-06/20260606_01_unique_index_json_to_raw --run'
+        OT.boot_logger.warn '[init] Until migrated, unique_index lookups (e.g. domain SSO) may silently fail. See #3347.'
+      end
+    end
+  end
+end

--- a/migrations/2026-06-06/20260606_01_unique_index_json_to_raw.rb
+++ b/migrations/2026-06-06/20260606_01_unique_index_json_to_raw.rb
@@ -16,9 +16,11 @@
 # This breaks CustomDomain.from_display_domain and any other unique_index
 # finder until the index is rebuilt.
 #
-# This migration discovers all unique_index hashes via Familia's introspection
-# API (v2.10.1), detects JSON-encoded values, and rewrites them as raw strings.
-# Idempotent: already-raw values are skipped.
+# Uses Familia's introspection API (v2.10.1) to discover stale class-level
+# indexes, then falls back to SCAN for org-scoped indexes that the
+# introspection API intentionally excludes (it can't sample instance-scoped
+# indexes without a scope argument). Idempotent: already-raw values are
+# skipped.
 #
 # Usage:
 #   bin/ots migrate 20260606_01_unique_index_json_to_raw           # Preview
@@ -35,19 +37,39 @@ module Onetime
       self.description  = 'Convert unique_index values from JSON-encoded strings to raw strings (Familia 2.10)'
       self.dependencies = []
 
+      # Org-scoped unique_index hashes that Familia.stale_indexes cannot
+      # discover (instance-scoped indexes need a scope argument to sample).
+      # These are fixed patterns tied to the model declarations at the time
+      # this migration was written — acceptable because the migration runs
+      # once against a known data snapshot.
+      SCOPED_INDEX_PATTERNS = [
+        'organization:*:email_index',
+      ].freeze
+
       def prepare
-        @descriptors = Familia.stale_indexes
+        unless Familia.respond_to?(:stale_indexes)
+          raise Familia::Problem,
+            'This migration requires Familia >= 2.10.1 (introspection API). ' \
+            'Update the familia gem and re-run.'
+        end
+
+        @descriptors  = Familia.stale_indexes
+        @scoped_keys  = discover_scoped_index_keys
       end
 
       def migration_needed?
-        @descriptors.any?
+        @descriptors.any? || @scoped_keys.any? { |key| has_legacy_values?(key) }
       end
 
       def migrate
         run_mode_banner
 
         @descriptors.each do |descriptor|
-          convert_index(descriptor)
+          convert_descriptor(descriptor)
+        end
+
+        @scoped_keys.each do |key|
+          convert_raw_key(key)
         end
 
         print_summary do |mode|
@@ -68,9 +90,27 @@ module Onetime
 
       private
 
-      def convert_index(descriptor)
+      def discover_scoped_index_keys
+        keys = []
+        SCOPED_INDEX_PATTERNS.each do |pattern|
+          redis.scan_each(match: pattern) { |key| keys << key }
+        end
+        keys
+      end
+
+      def has_legacy_values?(index_key)
+        redis.hscan_each(index_key, count: 100) do |_field, value|
+          return true if Familia.legacy_json_encoded?(value)
+        end
+        false
+      end
+
+      def convert_descriptor(descriptor)
         hashkey   = descriptor.owner.public_send(descriptor.index_name)
-        index_key = hashkey.dbkey
+        convert_raw_key(hashkey.dbkey, label: descriptor.coordinate)
+      end
+
+      def convert_raw_key(index_key, label: index_key)
         converted = 0
         skipped   = 0
 
@@ -83,7 +123,7 @@ module Onetime
           raw_value = JSON.parse(value)
 
           if dry_run?
-            info "[DRY RUN] #{descriptor.coordinate} field=#{field}: #{value.inspect} -> #{raw_value.inspect}"
+            info "[DRY RUN] #{label} field=#{field}: #{value.inspect} -> #{raw_value.inspect}"
           else
             redis.hset(index_key, field, raw_value)
           end
@@ -96,8 +136,8 @@ module Onetime
         track_stat(:indexes_scanned)
 
         unless converted.zero?
-          label = dry_run? ? 'would convert' : 'converted'
-          info "#{descriptor.coordinate}: #{label} #{converted}, already raw #{skipped}"
+          verb = dry_run? ? 'would convert' : 'converted'
+          info "#{label}: #{verb} #{converted}, already raw #{skipped}"
         end
       end
     end

--- a/migrations/2026-06-06/20260606_01_unique_index_json_to_raw.rb
+++ b/migrations/2026-06-06/20260606_01_unique_index_json_to_raw.rb
@@ -1,0 +1,159 @@
+# migrations/2026-06-06/20260606_01_unique_index_json_to_raw.rb
+#
+# frozen_string_literal: true
+
+#
+# Strip JSON encoding from unique_index hash values after Familia 2.10 upgrade
+#
+# Familia 2.9.x stored unique_index values as JSON-encoded strings:
+#   HSET custom_domain:display_domain_index example.com "\"dom_abc123\""
+#
+# Familia 2.10 stores them as raw strings:
+#   HSET custom_domain:display_domain_index example.com dom_abc123
+#
+# After upgrading, lookups return the quoted identifier (e.g. "\"dom_abc123\"")
+# and Model.load silently returns nil because no record has that literal ID.
+# This breaks CustomDomain.from_display_domain and any other unique_index
+# finder until the index is rebuilt.
+#
+# This migration scans every known unique_index hash, detects JSON-encoded
+# values, and rewrites them as raw strings. Idempotent: already-raw values
+# are skipped.
+#
+# Usage:
+#   bin/ots migrate 20260606_01_unique_index_json_to_raw           # Preview
+#   bin/ots migrate --run 20260606_01_unique_index_json_to_raw     # Execute
+#
+# Refs: #3347
+require 'familia/migration'
+require 'json'
+
+module Onetime
+  module Migrations
+    class UniqueIndexJsonToRaw < Familia::Migration::Base
+      self.migration_id = '20260606_01_unique_index_json_to_raw'
+      self.description  = 'Convert unique_index values from JSON-encoded strings to raw strings (Familia 2.10)'
+      self.dependencies = []
+
+      GLOBAL_INDEX_KEYS = [
+        'custom_domain:display_domain_index',
+        'customer:email_index',
+        'organization:contact_email_index',
+        'org_membership:token_lookup',
+        'organization:stripe_customer_id_index',
+        'organization:stripe_subscription_id_index',
+        'organization:stripe_checkout_email_index',
+        'organization:billing_email_index',
+      ].freeze
+
+      SCOPED_INDEX_PATTERNS = [
+        'organization:*:email_index',
+      ].freeze
+
+      def prepare
+        @index_keys = discover_index_keys
+      end
+
+      def migration_needed?
+        @index_keys.any? { |key| has_json_encoded_values?(key) }
+      end
+
+      def migrate
+        run_mode_banner
+
+        @index_keys.each do |key|
+          convert_index(key)
+        end
+
+        print_summary do |mode|
+          @stats.each { |key, value| info "  #{key}: #{value}" }
+          info ''
+          converted = @stats[:entries_converted] || 0
+          if converted.zero?
+            info 'No JSON-encoded values found — indexes are already consistent.'
+          elsif mode == :dry_run
+            info "Re-run with --run to convert #{converted} value(s)."
+          else
+            info "Converted #{converted} value(s) to raw strings."
+          end
+        end
+
+        true
+      end
+
+      private
+
+      def discover_index_keys
+        keys = []
+
+        GLOBAL_INDEX_KEYS.each do |key|
+          keys << key if redis.exists?(key)
+        end
+
+        SCOPED_INDEX_PATTERNS.each do |pattern|
+          redis.scan_each(match: pattern) do |key|
+            keys << key
+          end
+        end
+
+        keys
+      end
+
+      def has_json_encoded_values?(index_key)
+        redis.hscan_each(index_key, count: 100) do |_field, value|
+          return true if json_encoded_string?(value)
+        end
+        false
+      end
+
+      def convert_index(index_key)
+        converted = 0
+        skipped   = 0
+
+        redis.hscan_each(index_key, count: 100) do |field, value|
+          unless json_encoded_string?(value)
+            skipped += 1
+            next
+          end
+
+          raw_value = JSON.parse(value)
+
+          if dry_run?
+            info "[DRY RUN] #{index_key} field=#{field}: #{value.inspect} -> #{raw_value.inspect}"
+          else
+            redis.hset(index_key, field, raw_value)
+          end
+
+          converted += 1
+          track_stat(:entries_converted)
+        end
+
+        skipped.times { track_stat(:entries_already_raw) }
+        track_stat(:indexes_scanned)
+
+        unless converted.zero?
+          label = dry_run? ? 'would convert' : 'converted'
+          info "#{index_key}: #{label} #{converted}, already raw #{skipped}"
+        end
+      end
+
+      # A value is JSON-encoded if it's a string that starts and ends with
+      # a double-quote character — e.g. "\"dom_abc123\"". A raw identifier
+      # like "dom_abc123" does not start with a quote.
+      def json_encoded_string?(value)
+        return false unless value.is_a?(String)
+        return false if value.empty?
+        return false unless value.start_with?('"') && value.end_with?('"')
+
+        JSON.parse(value).is_a?(String)
+      rescue JSON::ParserError
+        false
+      end
+    end
+  end
+end
+
+if __FILE__ == $0
+  OT.boot! :cli
+  exit(Onetime::Migrations::UniqueIndexJsonToRaw.cli_run)
+end

--- a/migrations/2026-06-06/20260606_01_unique_index_json_to_raw.rb
+++ b/migrations/2026-06-06/20260606_01_unique_index_json_to_raw.rb
@@ -16,9 +16,9 @@
 # This breaks CustomDomain.from_display_domain and any other unique_index
 # finder until the index is rebuilt.
 #
-# This migration scans every known unique_index hash, detects JSON-encoded
-# values, and rewrites them as raw strings. Idempotent: already-raw values
-# are skipped.
+# This migration discovers all unique_index hashes via Familia's introspection
+# API (v2.10.1), detects JSON-encoded values, and rewrites them as raw strings.
+# Idempotent: already-raw values are skipped.
 #
 # Usage:
 #   bin/ots migrate 20260606_01_unique_index_json_to_raw           # Preview
@@ -35,34 +35,19 @@ module Onetime
       self.description  = 'Convert unique_index values from JSON-encoded strings to raw strings (Familia 2.10)'
       self.dependencies = []
 
-      GLOBAL_INDEX_KEYS = [
-        'custom_domain:display_domain_index',
-        'customer:email_index',
-        'organization:contact_email_index',
-        'org_membership:token_lookup',
-        'organization:stripe_customer_id_index',
-        'organization:stripe_subscription_id_index',
-        'organization:stripe_checkout_email_index',
-        'organization:billing_email_index',
-      ].freeze
-
-      SCOPED_INDEX_PATTERNS = [
-        'organization:*:email_index',
-      ].freeze
-
       def prepare
-        @index_keys = discover_index_keys
+        @descriptors = Familia.stale_indexes
       end
 
       def migration_needed?
-        @index_keys.any? { |key| has_json_encoded_values?(key) }
+        @descriptors.any?
       end
 
       def migrate
         run_mode_banner
 
-        @index_keys.each do |key|
-          convert_index(key)
+        @descriptors.each do |descriptor|
+          convert_index(descriptor)
         end
 
         print_summary do |mode|
@@ -83,35 +68,14 @@ module Onetime
 
       private
 
-      def discover_index_keys
-        keys = []
-
-        GLOBAL_INDEX_KEYS.each do |key|
-          keys << key if redis.exists?(key)
-        end
-
-        SCOPED_INDEX_PATTERNS.each do |pattern|
-          redis.scan_each(match: pattern) do |key|
-            keys << key
-          end
-        end
-
-        keys
-      end
-
-      def has_json_encoded_values?(index_key)
-        redis.hscan_each(index_key, count: 100) do |_field, value|
-          return true if json_encoded_string?(value)
-        end
-        false
-      end
-
-      def convert_index(index_key)
+      def convert_index(descriptor)
+        hashkey   = descriptor.owner.public_send(descriptor.index_name)
+        index_key = hashkey.dbkey
         converted = 0
         skipped   = 0
 
         redis.hscan_each(index_key, count: 100) do |field, value|
-          unless json_encoded_string?(value)
+          unless Familia.legacy_json_encoded?(value)
             skipped += 1
             next
           end
@@ -119,7 +83,7 @@ module Onetime
           raw_value = JSON.parse(value)
 
           if dry_run?
-            info "[DRY RUN] #{index_key} field=#{field}: #{value.inspect} -> #{raw_value.inspect}"
+            info "[DRY RUN] #{descriptor.coordinate} field=#{field}: #{value.inspect} -> #{raw_value.inspect}"
           else
             redis.hset(index_key, field, raw_value)
           end
@@ -133,21 +97,8 @@ module Onetime
 
         unless converted.zero?
           label = dry_run? ? 'would convert' : 'converted'
-          info "#{index_key}: #{label} #{converted}, already raw #{skipped}"
+          info "#{descriptor.coordinate}: #{label} #{converted}, already raw #{skipped}"
         end
-      end
-
-      # A value is JSON-encoded if it's a string that starts and ends with
-      # a double-quote character — e.g. "\"dom_abc123\"". A raw identifier
-      # like "dom_abc123" does not start with a quote.
-      def json_encoded_string?(value)
-        return false unless value.is_a?(String)
-        return false if value.empty?
-        return false unless value.start_with?('"') && value.end_with?('"')
-
-        JSON.parse(value).is_a?(String)
-      rescue JSON::ParserError
-        false
       end
     end
   end

--- a/spec/unit/migrations/unique_index_json_to_raw_spec.rb
+++ b/spec/unit/migrations/unique_index_json_to_raw_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe Onetime::Migrations::UniqueIndexJsonToRaw do
 
   before do
     allow(migration).to receive(:redis).and_return(redis)
+    allow(redis).to receive(:scan_each).and_return([].each)
     Familia::Migration.migrations.clear
   end
 
@@ -62,10 +63,33 @@ RSpec.describe Onetime::Migrations::UniqueIndexJsonToRaw do
     end
   end
 
+  describe '#prepare' do
+    it 'raises when Familia lacks introspection API' do
+      allow(Familia).to receive(:respond_to?).and_call_original
+      allow(Familia).to receive(:respond_to?).with(:stale_indexes).and_return(false)
+
+      expect { migration.send(:prepare) }.to raise_error(Familia::Problem, /requires Familia >= 2.10.1/)
+    end
+  end
+
   describe '#migration_needed?' do
     it 'returns true when Familia.stale_indexes returns descriptors' do
       allow(Familia).to receive(:stale_indexes).and_return([descriptor])
       migration.send(:prepare)
+
+      expect(migration.migration_needed?).to be true
+    end
+
+    it 'returns true when scoped indexes have legacy values' do
+      allow(Familia).to receive(:stale_indexes).and_return([])
+      allow(redis).to receive(:scan_each)
+        .with(match: 'organization:*:email_index')
+        .and_yield('organization:org1:email_index')
+      migration.send(:prepare)
+
+      allow(redis).to receive(:hscan_each)
+        .with('organization:org1:email_index', count: 100)
+        .and_yield('user@example.com', '"cust_abc123"')
 
       expect(migration.migration_needed?).to be true
     end
@@ -78,14 +102,14 @@ RSpec.describe Onetime::Migrations::UniqueIndexJsonToRaw do
     end
   end
 
-  describe '#convert_index' do
+  describe '#convert_descriptor' do
     before do
       allow(Familia).to receive(:stale_indexes).and_return([descriptor])
       migration.send(:prepare)
       allow(migration).to receive(:track_stat)
     end
 
-    it 'rewrites JSON-encoded values as raw strings in execute mode' do
+    it 'rewrites JSON-encoded values as raw strings' do
       allow(migration).to receive(:dry_run?).and_return(false)
       allow(migration).to receive(:info)
       entries = [
@@ -97,7 +121,7 @@ RSpec.describe Onetime::Migrations::UniqueIndexJsonToRaw do
         .and_return(entries.each)
       allow(redis).to receive(:hset)
 
-      migration.send(:convert_index, descriptor)
+      migration.send(:convert_descriptor, descriptor)
 
       expect(redis).to have_received(:hset).with('custom_domain:display_domain_index', 'example.com', 'dom_abc123')
       expect(migration).to have_received(:track_stat).with(:entries_converted).once
@@ -112,20 +136,45 @@ RSpec.describe Onetime::Migrations::UniqueIndexJsonToRaw do
         .with('custom_domain:display_domain_index', count: 100)
         .and_return(entries.each)
 
-      migration.send(:convert_index, descriptor)
+      migration.send(:convert_descriptor, descriptor)
 
       expect(migration).to have_received(:track_stat).with(:entries_converted).once
+    end
+  end
+
+  describe '#convert_raw_key (scoped indexes)' do
+    before do
+      allow(Familia).to receive(:stale_indexes).and_return([])
+      allow(redis).to receive(:scan_each)
+        .with(match: 'organization:*:email_index')
+        .and_yield('organization:org1:email_index')
+      migration.send(:prepare)
+      allow(migration).to receive(:track_stat)
+    end
+
+    it 'converts scoped index entries' do
+      allow(migration).to receive(:dry_run?).and_return(false)
+      allow(migration).to receive(:info)
+      entries = [['user@example.com', '"cust_abc123"']]
+      allow(redis).to receive(:hscan_each)
+        .with('organization:org1:email_index', count: 100)
+        .and_return(entries.each)
+      allow(redis).to receive(:hset)
+
+      migration.send(:convert_raw_key, 'organization:org1:email_index')
+
+      expect(redis).to have_received(:hset).with('organization:org1:email_index', 'user@example.com', 'cust_abc123')
     end
 
     it 'skips already-raw values' do
       allow(migration).to receive(:dry_run?).and_return(false)
       allow(migration).to receive(:info)
-      entries = [['example.com', 'dom_abc123']]
+      entries = [['user@example.com', 'cust_abc123']]
       allow(redis).to receive(:hscan_each)
-        .with('custom_domain:display_domain_index', count: 100)
+        .with('organization:org1:email_index', count: 100)
         .and_return(entries.each)
 
-      migration.send(:convert_index, descriptor)
+      migration.send(:convert_raw_key, 'organization:org1:email_index')
 
       expect(migration).not_to have_received(:track_stat).with(:entries_converted)
       expect(migration).to have_received(:track_stat).with(:entries_already_raw).once

--- a/spec/unit/migrations/unique_index_json_to_raw_spec.rb
+++ b/spec/unit/migrations/unique_index_json_to_raw_spec.rb
@@ -1,0 +1,180 @@
+# spec/unit/migrations/unique_index_json_to_raw_spec.rb
+#
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'familia/migration'
+
+require_relative '../../../migrations/2026-06-06/20260606_01_unique_index_json_to_raw'
+
+RSpec.describe Onetime::Migrations::UniqueIndexJsonToRaw do
+  let(:redis) { instance_double('Redis') }
+  let(:migration) { described_class.new }
+
+  before do
+    allow(migration).to receive(:redis).and_return(redis)
+    Familia::Migration.migrations.clear
+  end
+
+  describe '#json_encoded_string?' do
+    it 'detects JSON-encoded string values' do
+      expect(migration.send(:json_encoded_string?, '"dom_abc123"')).to be true
+    end
+
+    it 'rejects raw string values' do
+      expect(migration.send(:json_encoded_string?, 'dom_abc123')).to be false
+    end
+
+    it 'rejects empty strings' do
+      expect(migration.send(:json_encoded_string?, '')).to be false
+    end
+
+    it 'rejects nil' do
+      expect(migration.send(:json_encoded_string?, nil)).to be false
+    end
+
+    it 'rejects non-string values' do
+      expect(migration.send(:json_encoded_string?, 42)).to be false
+    end
+
+    it 'rejects strings that start but do not end with quote' do
+      expect(migration.send(:json_encoded_string?, '"partial')).to be false
+    end
+
+    it 'handles JSON-encoded UUIDs' do
+      expect(migration.send(:json_encoded_string?, '"550e8400-e29b-41d4-a716-446655440000"')).to be true
+    end
+  end
+
+  describe '#discover_index_keys' do
+    before do
+      migration.send(:prepare)
+    end
+
+    it 'includes existing global index keys' do
+      allow(redis).to receive(:exists?).and_return(false)
+      allow(redis).to receive(:exists?).with('custom_domain:display_domain_index').and_return(true)
+      allow(redis).to receive(:exists?).with('customer:email_index').and_return(true)
+      allow(redis).to receive(:scan_each).and_return([].each)
+
+      keys = migration.send(:discover_index_keys)
+      expect(keys).to include('custom_domain:display_domain_index')
+      expect(keys).to include('customer:email_index')
+    end
+
+    it 'excludes non-existent global index keys' do
+      allow(redis).to receive(:exists?).and_return(false)
+      allow(redis).to receive(:scan_each).and_return([].each)
+
+      keys = migration.send(:discover_index_keys)
+      expect(keys).to be_empty
+    end
+
+    it 'discovers org-scoped index keys via SCAN' do
+      allow(redis).to receive(:exists?).and_return(false)
+      scoped_keys = ['organization:org1:email_index', 'organization:org2:email_index']
+      allow(redis).to receive(:scan_each).with(match: 'organization:*:email_index').and_return(scoped_keys.each)
+
+      keys = migration.send(:discover_index_keys)
+      expect(keys).to eq(scoped_keys)
+    end
+  end
+
+  describe '#migration_needed?' do
+    before do
+      migration.send(:prepare)
+    end
+
+    it 'returns true when JSON-encoded values exist' do
+      allow(redis).to receive(:exists?).and_return(false)
+      allow(redis).to receive(:exists?).with('customer:email_index').and_return(true)
+      allow(redis).to receive(:scan_each).and_return([].each)
+      allow(redis).to receive(:hscan_each)
+        .with('customer:email_index', count: 100)
+        .and_yield('user@example.com', '"cust_abc123"')
+
+      expect(migration.migration_needed?).to be true
+    end
+
+    it 'returns false when all values are raw' do
+      allow(redis).to receive(:exists?).and_return(false)
+      allow(redis).to receive(:exists?).with('customer:email_index').and_return(true)
+      allow(redis).to receive(:scan_each).and_return([].each)
+      allow(redis).to receive(:hscan_each)
+        .with('customer:email_index', count: 100)
+        .and_return([['user@example.com', 'cust_abc123']].each)
+
+      expect(migration.migration_needed?).to be false
+    end
+
+    it 'returns false when no index keys exist' do
+      allow(redis).to receive(:exists?).and_return(false)
+      allow(redis).to receive(:scan_each).and_return([].each)
+
+      expect(migration.migration_needed?).to be false
+    end
+  end
+
+  describe '#convert_index' do
+    before do
+      migration.send(:prepare)
+      allow(migration).to receive(:track_stat)
+    end
+
+    it 'rewrites JSON-encoded values as raw strings in execute mode' do
+      allow(migration).to receive(:dry_run?).and_return(false)
+      allow(migration).to receive(:info)
+      entries = [
+        ['example.com', '"dom_abc123"'],
+        ['other.com', 'dom_def456'],
+      ]
+      allow(redis).to receive(:hscan_each)
+        .with('custom_domain:display_domain_index', count: 100)
+        .and_return(entries.each)
+      allow(redis).to receive(:hset)
+
+      migration.send(:convert_index, 'custom_domain:display_domain_index')
+
+      expect(redis).to have_received(:hset).with('custom_domain:display_domain_index', 'example.com', 'dom_abc123')
+      expect(migration).to have_received(:track_stat).with(:entries_converted).once
+      expect(migration).to have_received(:track_stat).with(:entries_already_raw).once
+    end
+
+    it 'does not write in dry-run mode' do
+      allow(migration).to receive(:dry_run?).and_return(true)
+      allow(migration).to receive(:info)
+      entries = [['example.com', '"dom_abc123"']]
+      allow(redis).to receive(:hscan_each)
+        .with('custom_domain:display_domain_index', count: 100)
+        .and_return(entries.each)
+
+      migration.send(:convert_index, 'custom_domain:display_domain_index')
+
+      expect(migration).to have_received(:track_stat).with(:entries_converted).once
+    end
+
+    it 'skips already-raw values' do
+      allow(migration).to receive(:dry_run?).and_return(false)
+      allow(migration).to receive(:info)
+      entries = [['example.com', 'dom_abc123']]
+      allow(redis).to receive(:hscan_each)
+        .with('custom_domain:display_domain_index', count: 100)
+        .and_return(entries.each)
+
+      migration.send(:convert_index, 'custom_domain:display_domain_index')
+
+      expect(migration).not_to have_received(:track_stat).with(:entries_converted)
+      expect(migration).to have_received(:track_stat).with(:entries_already_raw).once
+    end
+  end
+
+  describe 'migration metadata' do
+    it 'has the expected migration_id' do
+      expect(described_class.migration_id).to eq('20260606_01_unique_index_json_to_raw')
+    end
+
+    it 'has no dependencies' do
+      expect(described_class.dependencies).to be_empty
+    end
+  end
+end

--- a/spec/unit/migrations/unique_index_json_to_raw_spec.rb
+++ b/spec/unit/migrations/unique_index_json_to_raw_spec.rb
@@ -10,106 +10,69 @@ require_relative '../../../migrations/2026-06-06/20260606_01_unique_index_json_t
 RSpec.describe Onetime::Migrations::UniqueIndexJsonToRaw do
   let(:redis) { instance_double('Redis') }
   let(:migration) { described_class.new }
+  let(:hashkey) do
+    instance_double('Familia::HashKey', dbkey: 'custom_domain:display_domain_index')
+  end
+  let(:descriptor) do
+    instance_double(
+      'Familia::IndexDescriptor',
+      coordinate: 'CustomDomain:display_domain_index',
+      index_name: :display_domain_index,
+      owner: owner_class,
+    )
+  end
+  let(:owner_class) do
+    double('OwnerClass').tap do |klass|
+      allow(klass).to receive(:public_send).with(:display_domain_index).and_return(hashkey)
+    end
+  end
 
   before do
     allow(migration).to receive(:redis).and_return(redis)
     Familia::Migration.migrations.clear
   end
 
-  describe '#json_encoded_string?' do
+  describe 'Familia.legacy_json_encoded? detection' do
     it 'detects JSON-encoded string values' do
-      expect(migration.send(:json_encoded_string?, '"dom_abc123"')).to be true
+      expect(Familia.legacy_json_encoded?('"dom_abc123"')).to be true
     end
 
     it 'rejects raw string values' do
-      expect(migration.send(:json_encoded_string?, 'dom_abc123')).to be false
+      expect(Familia.legacy_json_encoded?('dom_abc123')).to be false
     end
 
     it 'rejects empty strings' do
-      expect(migration.send(:json_encoded_string?, '')).to be false
+      expect(Familia.legacy_json_encoded?('')).to be false
     end
 
     it 'rejects nil' do
-      expect(migration.send(:json_encoded_string?, nil)).to be false
+      expect(Familia.legacy_json_encoded?(nil)).to be false
     end
 
     it 'rejects non-string values' do
-      expect(migration.send(:json_encoded_string?, 42)).to be false
+      expect(Familia.legacy_json_encoded?(42)).to be false
     end
 
-    it 'rejects strings that start but do not end with quote' do
-      expect(migration.send(:json_encoded_string?, '"partial')).to be false
+    it 'rejects too-short quoted strings' do
+      expect(Familia.legacy_json_encoded?('""')).to be false
     end
 
     it 'handles JSON-encoded UUIDs' do
-      expect(migration.send(:json_encoded_string?, '"550e8400-e29b-41d4-a716-446655440000"')).to be true
-    end
-  end
-
-  describe '#discover_index_keys' do
-    before do
-      migration.send(:prepare)
-    end
-
-    it 'includes existing global index keys' do
-      allow(redis).to receive(:exists?).and_return(false)
-      allow(redis).to receive(:exists?).with('custom_domain:display_domain_index').and_return(true)
-      allow(redis).to receive(:exists?).with('customer:email_index').and_return(true)
-      allow(redis).to receive(:scan_each).and_return([].each)
-
-      keys = migration.send(:discover_index_keys)
-      expect(keys).to include('custom_domain:display_domain_index')
-      expect(keys).to include('customer:email_index')
-    end
-
-    it 'excludes non-existent global index keys' do
-      allow(redis).to receive(:exists?).and_return(false)
-      allow(redis).to receive(:scan_each).and_return([].each)
-
-      keys = migration.send(:discover_index_keys)
-      expect(keys).to be_empty
-    end
-
-    it 'discovers org-scoped index keys via SCAN' do
-      allow(redis).to receive(:exists?).and_return(false)
-      scoped_keys = ['organization:org1:email_index', 'organization:org2:email_index']
-      allow(redis).to receive(:scan_each).with(match: 'organization:*:email_index').and_return(scoped_keys.each)
-
-      keys = migration.send(:discover_index_keys)
-      expect(keys).to eq(scoped_keys)
+      expect(Familia.legacy_json_encoded?('"550e8400-e29b-41d4-a716-446655440000"')).to be true
     end
   end
 
   describe '#migration_needed?' do
-    before do
+    it 'returns true when Familia.stale_indexes returns descriptors' do
+      allow(Familia).to receive(:stale_indexes).and_return([descriptor])
       migration.send(:prepare)
-    end
-
-    it 'returns true when JSON-encoded values exist' do
-      allow(redis).to receive(:exists?).and_return(false)
-      allow(redis).to receive(:exists?).with('customer:email_index').and_return(true)
-      allow(redis).to receive(:scan_each).and_return([].each)
-      allow(redis).to receive(:hscan_each)
-        .with('customer:email_index', count: 100)
-        .and_yield('user@example.com', '"cust_abc123"')
 
       expect(migration.migration_needed?).to be true
     end
 
-    it 'returns false when all values are raw' do
-      allow(redis).to receive(:exists?).and_return(false)
-      allow(redis).to receive(:exists?).with('customer:email_index').and_return(true)
-      allow(redis).to receive(:scan_each).and_return([].each)
-      allow(redis).to receive(:hscan_each)
-        .with('customer:email_index', count: 100)
-        .and_return([['user@example.com', 'cust_abc123']].each)
-
-      expect(migration.migration_needed?).to be false
-    end
-
-    it 'returns false when no index keys exist' do
-      allow(redis).to receive(:exists?).and_return(false)
-      allow(redis).to receive(:scan_each).and_return([].each)
+    it 'returns false when no stale indexes found' do
+      allow(Familia).to receive(:stale_indexes).and_return([])
+      migration.send(:prepare)
 
       expect(migration.migration_needed?).to be false
     end
@@ -117,6 +80,7 @@ RSpec.describe Onetime::Migrations::UniqueIndexJsonToRaw do
 
   describe '#convert_index' do
     before do
+      allow(Familia).to receive(:stale_indexes).and_return([descriptor])
       migration.send(:prepare)
       allow(migration).to receive(:track_stat)
     end
@@ -133,7 +97,7 @@ RSpec.describe Onetime::Migrations::UniqueIndexJsonToRaw do
         .and_return(entries.each)
       allow(redis).to receive(:hset)
 
-      migration.send(:convert_index, 'custom_domain:display_domain_index')
+      migration.send(:convert_index, descriptor)
 
       expect(redis).to have_received(:hset).with('custom_domain:display_domain_index', 'example.com', 'dom_abc123')
       expect(migration).to have_received(:track_stat).with(:entries_converted).once
@@ -148,7 +112,7 @@ RSpec.describe Onetime::Migrations::UniqueIndexJsonToRaw do
         .with('custom_domain:display_domain_index', count: 100)
         .and_return(entries.each)
 
-      migration.send(:convert_index, 'custom_domain:display_domain_index')
+      migration.send(:convert_index, descriptor)
 
       expect(migration).to have_received(:track_stat).with(:entries_converted).once
     end
@@ -161,7 +125,7 @@ RSpec.describe Onetime::Migrations::UniqueIndexJsonToRaw do
         .with('custom_domain:display_domain_index', count: 100)
         .and_return(entries.each)
 
-      migration.send(:convert_index, 'custom_domain:display_domain_index')
+      migration.send(:convert_index, descriptor)
 
       expect(migration).not_to have_received(:track_stat).with(:entries_converted)
       expect(migration).to have_received(:track_stat).with(:entries_already_raw).once


### PR DESCRIPTION
## Summary

[#3347](https://github.com/onetimesecret/onetimesecret/issues/3347)

Adds a data migration to convert unique_index hash values from JSON-encoded strings (Familia 2.9.x format) to raw strings (Familia 2.10 format). After upgrading Familia, stale JSON-encoded entries cause lookups like `CustomDomain.from_display_domain` to silently return nil, breaking domain-based org selection.

The migration:
- Uses Familia's introspection API (v2.10.1+) to discover stale class-level indexes
- Falls back to SCAN patterns for org-scoped indexes that the introspection API cannot discover
- Is idempotent: already-raw values are skipped
- Supports dry-run mode for preview before execution

Also adds a boot-time initializer that warns operators if stale indexes are detected, directing them to run the migration.

## Related Issues

Fixes #3347

## Test Plan

Added comprehensive unit tests covering:
- JSON encoding detection (valid/invalid cases)
- Migration preparation and dependency checks
- Stale index discovery via both Familia API and SCAN patterns
- Value conversion with dry-run and execute modes
- Idempotency (skipping already-raw values)
- Migration metadata validation

All tests pass; migration is non-destructive and can be safely previewed before execution.

https://claude.ai/code/session_01CXUs2nrxhC57dqiac9ksj8