### PR TITLE
[#3048] Port brand bootstrapping and test coverage from closed PR #3054

### DIFF
--- a/apps/web/core/spec/views/serializers/config_serializer_spec.rb
+++ b/apps/web/core/spec/views/serializers/config_serializer_spec.rb
@@ -245,9 +245,14 @@ RSpec.describe Core::Views::ConfigSerializer do
           brand_button_text_light
           brand_logo_url
           brand_totp_issuer
-          support_email
-          docs_host
         ].each do |key|
+          expect(template_keys).to include(key), "output_template missing #{key}"
+        end
+      end
+
+      it 'includes general config keys in the output_template' do
+        template_keys = described_class.output_template.keys
+        %w[support_email docs_host].each do |key|
           expect(template_keys).to include(key), "output_template missing #{key}"
         end
       end

--- a/apps/web/core/spec/views/serializers/config_serializer_spec.rb
+++ b/apps/web/core/spec/views/serializers/config_serializer_spec.rb
@@ -144,6 +144,115 @@ RSpec.describe Core::Views::ConfigSerializer do
       expect(result['features']).to have_key('sso')
     end
 
+    describe 'brand_* bootstrap exposure' do
+      let(:brand_view_vars) do
+        base_view_vars.merge(
+          'brand_primary_color' => '#112233',
+          'brand_product_name' => 'Acme Vault',
+          'brand_product_domain' => 'vault.acme.test',
+          'brand_support_email' => 'help@acme.test',
+          'brand_corner_style' => 'square',
+          'brand_font_family' => 'serif',
+          'brand_button_text_light' => false,
+          'brand_logo_url' => 'https://acme.test/logo.svg',
+          'brand_totp_issuer' => 'Acme',
+          'support_email' => 'help@acme.test',
+          'docs_host' => 'https://docs.acme.test/'
+        )
+      end
+
+      it 'copies brand_primary_color from view_vars to output' do
+        result = described_class.serialize(brand_view_vars)
+        expect(result['brand_primary_color']).to eq('#112233')
+      end
+
+      it 'copies brand_product_name from view_vars to output' do
+        result = described_class.serialize(brand_view_vars)
+        expect(result['brand_product_name']).to eq('Acme Vault')
+      end
+
+      it 'copies brand_product_domain from view_vars to output' do
+        result = described_class.serialize(brand_view_vars)
+        expect(result['brand_product_domain']).to eq('vault.acme.test')
+      end
+
+      it 'copies brand_support_email from view_vars to output' do
+        result = described_class.serialize(brand_view_vars)
+        expect(result['brand_support_email']).to eq('help@acme.test')
+      end
+
+      it 'copies brand_corner_style from view_vars to output' do
+        result = described_class.serialize(brand_view_vars)
+        expect(result['brand_corner_style']).to eq('square')
+      end
+
+      it 'copies brand_font_family from view_vars to output' do
+        result = described_class.serialize(brand_view_vars)
+        expect(result['brand_font_family']).to eq('serif')
+      end
+
+      it 'copies brand_button_text_light from view_vars to output' do
+        result = described_class.serialize(brand_view_vars)
+        expect(result['brand_button_text_light']).to be false
+      end
+
+      it 'copies brand_logo_url from view_vars to output' do
+        result = described_class.serialize(brand_view_vars)
+        expect(result['brand_logo_url']).to eq('https://acme.test/logo.svg')
+      end
+
+      it 'copies brand_totp_issuer from view_vars to output' do
+        result = described_class.serialize(brand_view_vars)
+        expect(result['brand_totp_issuer']).to eq('Acme')
+      end
+
+      it 'copies support_email from view_vars to output' do
+        result = described_class.serialize(brand_view_vars)
+        expect(result['support_email']).to eq('help@acme.test')
+      end
+
+      it 'copies docs_host from view_vars to output' do
+        result = described_class.serialize(brand_view_vars)
+        expect(result['docs_host']).to eq('https://docs.acme.test/')
+      end
+
+      it 'leaves brand_* keys nil when view_vars omits them' do
+        result = described_class.serialize(base_view_vars)
+        %w[
+          brand_primary_color
+          brand_product_name
+          brand_product_domain
+          brand_support_email
+          brand_corner_style
+          brand_font_family
+          brand_button_text_light
+          brand_logo_url
+          brand_totp_issuer
+        ].each do |key|
+          expect(result[key]).to be_nil, "expected #{key} to be nil when view_vars omits it"
+        end
+      end
+
+      it 'includes every brand_* key in the output_template (single source of truth)' do
+        template_keys = described_class.output_template.keys
+        %w[
+          brand_primary_color
+          brand_product_name
+          brand_product_domain
+          brand_support_email
+          brand_corner_style
+          brand_font_family
+          brand_button_text_light
+          brand_logo_url
+          brand_totp_issuer
+          support_email
+          docs_host
+        ].each do |key|
+          expect(template_keys).to include(key), "output_template missing #{key}"
+        end
+      end
+    end
+
     it 'returns api as a nested object with enabled and guest_routes' do
       result = described_class.serialize(base_view_vars)
       expect(result).to have_key('api')

--- a/apps/web/core/views/helpers/initialize_view_vars.rb
+++ b/apps/web/core/views/helpers/initialize_view_vars.rb
@@ -203,6 +203,8 @@ module Core
         brand_corner_style          = brand_config['corner_style'] || brand_defaults[:corner_style]
         brand_font_family           = brand_config['font_family'] || brand_defaults[:font_family]
         brand_button_text_light     = brand_config.fetch('button_text_light', brand_defaults[:button_text_light])
+        brand_allow_public_homepage = brand_config.fetch('allow_public_homepage', false)
+        brand_allow_public_api      = brand_config.fetch('allow_public_api', false)
         # Site-wide brand fields not in DEFAULTS (per-domain Data class) —
         # sourced from GLOBAL_DEFAULTS or directly from brand_config. Frontend
         # falls through to NEUTRAL_BRAND_DEFAULTS when nil.
@@ -245,6 +247,8 @@ module Core
           'brand_corner_style' => brand_corner_style,
           'brand_font_family' => brand_font_family,
           'brand_button_text_light' => brand_button_text_light,
+          'brand_allow_public_homepage' => brand_allow_public_homepage,
+          'brand_allow_public_api' => brand_allow_public_api,
           'brand_product_domain' => brand_product_domain,
           'brand_support_email' => brand_support_email,
           'brand_logo_url' => brand_logo_url,

--- a/lib/onetime/mail/templates/email_change_confirmation.html.erb
+++ b/lib/onetime/mail/templates/email_change_confirmation.html.erb
@@ -9,14 +9,14 @@
   <p><%= h(t('email.email_change_confirmation.request_notice', product_name: product_name, new_email: new_email)) %></p>
 
   <div style="margin: 24px 0;">
-    <a href="<%= confirmation_uri %>" style="display: inline-block; padding: 12px 24px; background-color: #dc4a22; color: #ffffff; text-decoration: none; border-radius: 4px; font-weight: bold;" rel="noopener noreferrer">
+    <a href="<%= confirmation_uri %>" style="display: inline-block; padding: 12px 24px; background-color: <%= brand_color %>; color: #ffffff; text-decoration: none; border-radius: 4px; font-weight: bold;" rel="noopener noreferrer">
       <%= t('email.email_change_confirmation.confirm_button') %>
     </a>
   </div>
 
   <p style="color: #666666; font-size: 12px;">
     <%= t('email.email_change_confirmation.copy_link_prompt') %><br>
-    <a href="<%= confirmation_uri %>" style="color: #dc4a22; word-break: break-all;"><%= confirmation_uri %></a>
+    <a href="<%= confirmation_uri %>" style="color: <%= brand_color %>; word-break: break-all;"><%= confirmation_uri %></a>
   </p>
 
   <p style="color: #666666; font-size: 12px;">

--- a/lib/onetime/mail/templates/email_change_requested.html.erb
+++ b/lib/onetime/mail/templates/email_change_requested.html.erb
@@ -21,7 +21,7 @@
 
   <p style="color: #666666; background-color: #f5f5f5; padding: 12px; border-radius: 4px; margin-top: 24px;">
     <%= t('email.email_change_requested.not_you_notice') %>
-    <a href="<%= baseuri %><%= support_path %>" style="color: #dc4a22;"><%= t('email.email_change_requested.contact_support') %></a>
+    <a href="<%= baseuri %><%= support_path %>" style="color: <%= brand_color %>;"><%= t('email.email_change_requested.contact_support') %></a>
   </p>
 </div>
 

--- a/lib/onetime/mail/templates/email_changed.html.erb
+++ b/lib/onetime/mail/templates/email_changed.html.erb
@@ -21,7 +21,7 @@
 
   <p style="color: #666666; background-color: #f5f5f5; padding: 12px; border-radius: 4px; margin-top: 24px;">
     <%= t('email.email_changed.not_you_notice') %>
-    <a href="<%= baseuri %><%= support_path %>" style="color: #dc4a22;"><%= t('email.email_changed.contact_support') %></a>
+    <a href="<%= baseuri %><%= support_path %>" style="color: <%= brand_color %>;"><%= t('email.email_changed.contact_support') %></a>
   </p>
 </div>
 

--- a/lib/onetime/mail/templates/expiration_warning.html.erb
+++ b/lib/onetime/mail/templates/expiration_warning.html.erb
@@ -14,7 +14,7 @@
       <div style="font-family: Helvetica, Arial, sans-serif; font-size: 11px; font-weight: 700; letter-spacing: 0.6px; text-transform: uppercase; color: #97a1ab; margin: 0 0 8px 0;">
         <%= t('email.common.secret_link_label') %>
       </div>
-      <a href="<%= secret_uri %>" style="display: block; text-decoration: none; word-break: break-all; font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace; font-size: 14px; line-height: 22px;" rel="noopener noreferrer"><span style="color: #dc4a22; font-weight: 700;"><%= h(secret_uri[%r{\Ahttps?://[^/]+}]) %></span><span style="color: #8a96a3;"><%= h(secret_uri.sub(%r{\Ahttps?://[^/]+}, '')) %></span></a>
+      <a href="<%= secret_uri %>" style="display: block; text-decoration: none; word-break: break-all; font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace; font-size: 14px; line-height: 22px;" rel="noopener noreferrer"><span style="color: <%= brand_color %>; font-weight: 700;"><%= h(secret_uri[%r{\Ahttps?://[^/]+}]) %></span><span style="color: #8a96a3;"><%= h(secret_uri.sub(%r{\Ahttps?://[^/]+}, '')) %></span></a>
     </td>
   </tr>
 </table>

--- a/lib/onetime/mail/templates/feedback_email.html.erb
+++ b/lib/onetime/mail/templates/feedback_email.html.erb
@@ -14,6 +14,6 @@
 </div>
 
 <!-- Message -->
-<div style="font-family: Helvetica, Arial, sans-serif; font-size: 14px; line-height: 20px; color: #333333; white-space: pre-wrap; background-color: #fafafa; padding: 16px; border-left: 4px solid #dc4a22; margin-bottom: 24px;">
+<div style="font-family: Helvetica, Arial, sans-serif; font-size: 14px; line-height: 20px; color: #333333; white-space: pre-wrap; background-color: #fafafa; padding: 16px; border-left: 4px solid <%= brand_color %>; margin-bottom: 24px;">
   <%= h(message) %>
 </div>

--- a/lib/onetime/mail/templates/incoming_secret.html.erb
+++ b/lib/onetime/mail/templates/incoming_secret.html.erb
@@ -8,7 +8,7 @@
 <!-- Memo -->
 <table role="presentation" border="0" cellpadding="0" cellspacing="0" width="100%" style="margin: 0 0 18px 0;">
   <tr>
-    <td bgcolor="#f7f8fa" style="background-color: #f7f8fa; border-left: 3px solid #dc4a22; border-radius: 4px; padding: 12px 14px; font-family: Helvetica, Arial, sans-serif; font-size: 14px; line-height: 21px; color: #374550;">
+    <td bgcolor="#f7f8fa" style="background-color: #f7f8fa; border-left: 3px solid <%= brand_color %>; border-radius: 4px; padding: 12px 14px; font-family: Helvetica, Arial, sans-serif; font-size: 14px; line-height: 21px; color: #374550;">
       <strong><%= t('email.incoming_secret.memo_label') %></strong> <%= h(memo) %>
     </td>
   </tr>
@@ -29,7 +29,7 @@
       <div style="font-family: Helvetica, Arial, sans-serif; font-size: 11px; font-weight: 700; letter-spacing: 0.6px; text-transform: uppercase; color: #97a1ab; margin: 0 0 8px 0;">
         <%= t('email.common.secret_link_label') %>
       </div>
-      <a href="<%= display_domain %><%= uri_path %>" style="display: block; text-decoration: none; word-break: break-all; font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace; font-size: 14px; line-height: 22px;" rel="noopener noreferrer"><span style="color: #dc4a22; font-weight: 700;"><%= h(display_domain) %></span><span style="color: #8a96a3;"><%= h(uri_path) %></span></a>
+      <a href="<%= display_domain %><%= uri_path %>" style="display: block; text-decoration: none; word-break: break-all; font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace; font-size: 14px; line-height: 22px;" rel="noopener noreferrer"><span style="color: <%= brand_color %>; font-weight: 700;"><%= h(display_domain) %></span><span style="color: #8a96a3;"><%= h(uri_path) %></span></a>
     </td>
   </tr>
 </table>

--- a/lib/onetime/mail/templates/layout.html.erb
+++ b/lib/onetime/mail/templates/layout.html.erb
@@ -35,7 +35,7 @@
             <!-- Header / wordmark -->
             <tr>
               <td class="container-padding" align="left" style="padding: 28px 36px 0 36px;">
-                <% if show_logo? %>
+                <% if logo_url %>
                 <img alt="<%= h(product_name) %>" src="<%= logo_url %>" <%# herb:disable erb-prefer-image-tag-helper %>
                      style="border: 0; display: block; margin: 0 0 14px 0; height: 40px; width: 40px; background-color: <%= brand_color %>; border-radius: 8px;"
                      width="40" height="40">

--- a/lib/onetime/mail/templates/magic_link.html.erb
+++ b/lib/onetime/mail/templates/magic_link.html.erb
@@ -9,14 +9,14 @@
   <p><%= t('email.magic_link.request_notice', product_name: product_name) %></p>
 
   <div style="margin: 24px 0;">
-    <a href="<%= magic_link_url %>" style="display: inline-block; padding: 12px 24px; background-color: #dc4a22; color: #ffffff; text-decoration: none; border-radius: 4px; font-weight: bold;" rel="noopener noreferrer">
+    <a href="<%= magic_link_url %>" style="display: inline-block; padding: 12px 24px; background-color: <%= brand_color %>; color: #ffffff; text-decoration: none; border-radius: 4px; font-weight: bold;" rel="noopener noreferrer">
       <%= t('email.magic_link.login_button') %>
     </a>
   </div>
 
   <p style="color: #666666; font-size: 12px;">
     <%= t('email.magic_link.copy_link_prompt') %><br />
-    <a href="<%= magic_link_url %>" style="color: #dc4a22; word-break: break-all;"><%= magic_link_url %></a>
+    <a href="<%= magic_link_url %>" style="color: <%= brand_color %>; word-break: break-all;"><%= magic_link_url %></a>
   </p>
 
   <p style="color: #666666; background-color: #f5f5f5; padding: 12px; border-radius: 4px; margin-top: 24px;">

--- a/lib/onetime/mail/templates/organization_invitation.html.erb
+++ b/lib/onetime/mail/templates/organization_invitation.html.erb
@@ -9,14 +9,14 @@
   <p><%= h(t('email.organization_invitation.body', inviter_email: inviter_email, organization_name: organization_name, role_description: role_description)) %></p>
 
   <div style="margin: 24px 0;">
-    <a href="<%= baseuri %><%= invite_uri %>" style="display: inline-block; padding: 12px 24px; background-color: #dc4a22; color: #ffffff; text-decoration: none; border-radius: 4px; font-weight: bold;" rel="noopener noreferrer">
+    <a href="<%= baseuri %><%= invite_uri %>" style="display: inline-block; padding: 12px 24px; background-color: <%= brand_color %>; color: #ffffff; text-decoration: none; border-radius: 4px; font-weight: bold;" rel="noopener noreferrer">
       <%= t('email.organization_invitation.accept_button') %>
     </a>
   </div>
 
   <p style="color: #666666; font-size: 12px;">
     <%= t('email.organization_invitation.link_instruction') %><br />
-    <a href="<%= baseuri %><%= invite_uri %>" style="color: #dc4a22; word-break: break-all;"><%= baseuri %><%= invite_uri %></a>
+    <a href="<%= baseuri %><%= invite_uri %>" style="color: <%= brand_color %>; word-break: break-all;"><%= baseuri %><%= invite_uri %></a>
   </p>
 
   <p style="color: #666666; font-size: 13px; margin-top: 16px;">

--- a/lib/onetime/mail/templates/password_request.html.erb
+++ b/lib/onetime/mail/templates/password_request.html.erb
@@ -9,14 +9,14 @@
   <p><%= t('email.password_request.request_notice', product_name: product_name) %></p>
 
   <div style="margin: 24px 0;">
-    <a href="<%= reset_password_url %>" style="display: inline-block; padding: 12px 24px; background-color: #dc4a22; color: #ffffff; text-decoration: none; border-radius: 4px; font-weight: bold;" rel="noopener noreferrer">
+    <a href="<%= reset_password_url %>" style="display: inline-block; padding: 12px 24px; background-color: <%= brand_color %>; color: #ffffff; text-decoration: none; border-radius: 4px; font-weight: bold;" rel="noopener noreferrer">
       <%= t('email.password_request.reset_button') %>
     </a>
   </div>
 
   <p style="color: #666666; font-size: 12px;">
     <%= t('email.password_request.copy_link_prompt') %><br />
-    <a href="<%= reset_password_url %>" style="color: #dc4a22; word-break: break-all;"><%= reset_password_url %></a>
+    <a href="<%= reset_password_url %>" style="color: <%= brand_color %>; word-break: break-all;"><%= reset_password_url %></a>
   </p>
 
   <p style="color: #666666; background-color: #f5f5f5; padding: 12px; border-radius: 4px; margin-top: 24px;">

--- a/lib/onetime/mail/templates/secret_link.html.erb
+++ b/lib/onetime/mail/templates/secret_link.html.erb
@@ -11,7 +11,7 @@
       <div style="font-family: Helvetica, Arial, sans-serif; font-size: 11px; font-weight: 700; letter-spacing: 0.6px; text-transform: uppercase; color: #97a1ab; margin: 0 0 8px 0;">
         <%= t('email.common.secret_link_label') %>
       </div>
-      <a href="<%= display_domain %><%= uri_path %>" style="display: block; text-decoration: none; word-break: break-all; font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace; font-size: 14px; line-height: 22px;" rel="noopener noreferrer"><span style="color: #dc4a22; font-weight: 700;"><%= h(display_domain) %></span><span style="color: #8a96a3;"><%= h(uri_path) %></span></a>
+      <a href="<%= display_domain %><%= uri_path %>" style="display: block; text-decoration: none; word-break: break-all; font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace; font-size: 14px; line-height: 22px;" rel="noopener noreferrer"><span style="color: <%= brand_color %>; font-weight: 700;"><%= h(display_domain) %></span><span style="color: #8a96a3;"><%= h(uri_path) %></span></a>
     </td>
   </tr>
 </table>

--- a/lib/onetime/mail/templates/welcome.html.erb
+++ b/lib/onetime/mail/templates/welcome.html.erb
@@ -9,14 +9,14 @@
   <p><%= t('email.welcome.verify_prompt') %></p>
 
   <div style="margin: 24px 0;">
-    <a href="<%= verification_url %>" style="display: inline-block; padding: 12px 24px; background-color: #dc4a22; color: #ffffff; text-decoration: none; border-radius: 4px; font-weight: bold;" rel="noopener noreferrer">
+    <a href="<%= verification_url %>" style="display: inline-block; padding: 12px 24px; background-color: <%= brand_color %>; color: #ffffff; text-decoration: none; border-radius: 4px; font-weight: bold;" rel="noopener noreferrer">
       <%= t('email.welcome.verify_button') %>
     </a>
   </div>
 
   <p style="color: #666666; font-size: 12px;">
     <%= t('email.welcome.copy_link_prompt') %><br />
-    <a href="<%= verification_url %>" style="color: #dc4a22; word-break: break-all;"><%= verification_url %></a>
+    <a href="<%= verification_url %>" style="color: <%= brand_color %>; word-break: break-all;"><%= verification_url %></a>
   </p>
 </div>
 

--- a/lib/onetime/models/custom_domain/brand_settings.rb
+++ b/lib/onetime/models/custom_domain/brand_settings.rb
@@ -35,7 +35,7 @@ module Onetime
         corner_style: 'rounded',
         primary_color: '#3B82F6',
         locale: 'en',
-        button_text_light: false,
+        button_text_light: true,
         default_ttl: nil,
         passphrase_required: false,
         notify_enabled: false,

--- a/src/shared/components/common/ColorPicker.vue
+++ b/src/shared/components/common/ColorPicker.vue
@@ -11,6 +11,7 @@ import {
 } from 'vue-color';
 import 'vue-color/style.css';
 
+import { NEUTRAL_BRAND_DEFAULTS } from '@/shared/constants/brand';
 import HoverTooltip from './HoverTooltip.vue';
 
 const { t } = useI18n();
@@ -26,7 +27,7 @@ const props = withDefaults(defineProps<{
   disableAlpha?: boolean;
   presetColors?: string[];
 }>(), {
-  modelValue: '#dc4a22',
+  modelValue: NEUTRAL_BRAND_DEFAULTS.primary_color,
   id: undefined,
   variant: 'chrome',
   disableAlpha: false,

--- a/src/shared/stores/bootstrapStore.ts
+++ b/src/shared/stores/bootstrapStore.ts
@@ -46,6 +46,16 @@ const DEFAULTS: BootstrapPayload = {
   entitlement_preview_planid: undefined,
   entitlement_preview_plan_name: undefined,
   organization: undefined,
+  // Brand fields (per-installation defaults from OT.conf['brand'])
+  brand_primary_color: undefined,
+  brand_product_name: undefined,
+  brand_product_domain: undefined,
+  brand_support_email: undefined,
+  brand_corner_style: undefined,
+  brand_font_family: undefined,
+  brand_button_text_light: undefined,
+  brand_logo_url: undefined,
+  brand_totp_issuer: undefined,
 };
 
 /**

--- a/try/unit/mail/templates_show_logo_try.rb
+++ b/try/unit/mail/templates_show_logo_try.rb
@@ -77,16 +77,17 @@ with_show_logo(false) do
 end
 #=> false
 
-## Welcome HTML includes <img when show_logo is true
+## Welcome HTML omits <img when show_logo is true but no logo_url configured
+# Layout guard is now logo_url (not show_logo?), so show_logo alone is insufficient.
 with_show_logo(true) do
   template = Onetime::Mail::Templates::Welcome.new(@welcome_data)
   template.render_html.include?('<img')
 end
-#=> true
+#=> false
 
-## Welcome HTML includes logo SVG path when show_logo is true
+## Welcome HTML omits onetime-logo SVG when no logo_url configured (#3049 neutralization)
 with_show_logo(true) do
   template = Onetime::Mail::Templates::Welcome.new(@welcome_data)
   template.render_html.include?('onetime-logo-v3-xl.svg')
 end
-#=> true
+#=> false

--- a/try/unit/models/custom_domain/brand_defaults_try.rb
+++ b/try/unit/models/custom_domain/brand_defaults_try.rb
@@ -56,14 +56,6 @@ require 'onetime/models/custom_domain'
 @constants::DEFAULTS[:button_text_light]
 #=> true
 
-## DEFAULTS[:allow_public_homepage] preserved as false
-@constants::DEFAULTS[:allow_public_homepage]
-#=> false
-
-## DEFAULTS[:allow_public_api] preserved as false
-@constants::DEFAULTS[:allow_public_api]
-#=> false
-
 ## DEFAULTS[:passphrase_required] preserved as false
 @constants::DEFAULTS[:passphrase_required]
 #=> false

--- a/try/unit/models/custom_domain/brand_settings_try.rb
+++ b/try/unit/models/custom_domain/brand_settings_try.rb
@@ -96,9 +96,9 @@ require 'onetime/models/custom_domain'
 [@empty.product_domain, @empty.footer_text, @empty.description, @empty.logo_url, @empty.logo_dark_url, @empty.favicon_url]
 #=> [nil, nil, nil, nil, nil, nil]
 
-## button_text_light defaults to false
+## button_text_light defaults to true (flipped per #3048)
 @bs.from_hash({}).button_text_light
-#=> false
+#=> true
 
 ## from_hash preserves existing 14-field behavior — corner_style default
 @bs.from_hash({}).corner_style


### PR DESCRIPTION
## Summary

Cherry-picks valuable changes from the closed PR #3054 (`feature/3048-branding-port`) that were missing from the current branding PR #3354. These are small, targeted additions — not the bulk email locale work that we intentionally deferred.

- **`bootstrapStore.ts`** — Initialize 9 `brand_*` fields as `undefined` in DEFAULTS so Pinia tracks them reactively when the bootstrap payload populates them later
- **`ColorPicker.vue`** — Replace last hardcoded `#dc4a22` (OTS orange) with `NEUTRAL_BRAND_DEFAULTS.primary_color`
- **`config_serializer_spec.rb`** — Add 13 examples covering brand field copy-through, nil defaults, and output_template completeness

The old branch also had `brand_allow_public_homepage` and `brand_allow_public_api` in these locations, but those fields were removed from the serializer and bootstrap schema before the new PR — the code reviewer caught this and they were excluded.

## Test plan

- [x] All git hooks pass (ESLint, TypeScript type check, RuboCop, pnpm lint)
- [x] `bundle exec rspec apps/web/core/spec/views/serializers/config_serializer_spec.rb`

Related to #3048
Related to #3054