### PR TITLE
Fix theme toggle click on auth pages; improve light-mode watermark contrast

### DIFF
--- a/src/apps/secret/components/SecretLinksTableRowConsole.vue
+++ b/src/apps/secret/components/SecretLinksTableRowConsole.vue
@@ -263,8 +263,8 @@
           :class="[
             'font-mono text-[clamp(3.5rem,8vw,4.5rem)] font-light uppercase leading-none tracking-[0.3em] transition-colors duration-150',
             isTerminal
-              ? 'dark:text-gray-500/12 text-gray-400/15 group-hover/row:text-gray-400/30 dark:group-hover/row:text-gray-500/25'
-              : 'dark:text-gray-500/18 text-gray-400/20 group-hover/row:text-gray-400/40 dark:group-hover/row:text-gray-500/35',
+              ? 'text-gray-500/20 group-hover/row:text-gray-500/35 dark:text-gray-500/12 dark:group-hover/row:text-gray-500/25'
+              : 'text-gray-500/25 group-hover/row:text-gray-500/45 dark:text-gray-500/18 dark:group-hover/row:text-gray-500/35',
           ]">
           {{ displayKey }}
         </span>

--- a/src/apps/secret/components/SecretReceiptTableItem.vue
+++ b/src/apps/secret/components/SecretReceiptTableItem.vue
@@ -220,8 +220,8 @@ const rowClasses = computed(() => ['font-mono text-sm', isTerminal.value && 'opa
           :class="[
             'font-mono text-[clamp(3.5rem,8vw,4.5rem)] font-light uppercase leading-none tracking-[0.3em] transition-colors duration-150',
             isTerminal
-              ? 'dark:text-gray-500/12 text-gray-400/15 group-hover/row:text-gray-400/30 dark:group-hover/row:text-gray-500/25'
-              : 'dark:text-gray-500/18 text-gray-400/20 group-hover/row:text-gray-400/40 dark:group-hover/row:text-gray-500/35',
+              ? 'text-gray-500/20 group-hover/row:text-gray-500/35 dark:text-gray-500/12 dark:group-hover/row:text-gray-500/25'
+              : 'text-gray-500/25 group-hover/row:text-gray-500/45 dark:text-gray-500/18 dark:group-hover/row:text-gray-500/35',
           ]">
           {{ displayKey }}
         </span>

--- a/src/apps/session/components/AuthView.vue
+++ b/src/apps/session/components/AuthView.vue
@@ -87,7 +87,7 @@
   <div
     class="relative flex min-h-screen items-start justify-center overflow-hidden bg-gray-50 px-4 pt-12 dark:bg-gray-900 sm:px-6 sm:pt-16 lg:px-8">
     <!-- Background Icon -->
-    <div v-if="!hideBackgroundIcon" class="fixed inset-0 overflow-hidden opacity-5 dark:opacity-5 blur-md">
+    <div v-if="!hideBackgroundIcon" class="pointer-events-none fixed inset-0 overflow-hidden opacity-5 dark:opacity-5 blur-md">
       <OIcon
         v-if="backgroundIcon && backgroundIcon.collection && backgroundIcon.name"
         :collection="backgroundIcon.collection"


### PR DESCRIPTION
## Summary

- The fixed background icon overlay in `AuthView` (`fixed inset-0`) was intercepting clicks on the theme toggle button on signin/signup pages. The jurisdiction and language toggles escaped it because their wrapper divs have `position: relative`, but the theme toggle is a bare `<button>` with no positioning. Added `pointer-events-none` to the overlay.
- Receipt list watermark text (the 4-char shortid background) was barely visible in light mode. Switched from `gray-400` at 15–20% opacity to `gray-500` at 20–25% opacity for better visibility. Dark mode values unchanged.

## Test plan

- [ ] Navigate to `/signin` or `/signup`, verify the theme toggle in the footer is clickable and toggles between light/dark mode
- [ ] Verify the jurisdiction and language toggles still work as before
- [ ] Sign in, create a secret, view the dashboard receipt list in light mode — confirm the watermark shortid is visible (not just on hover)
- [ ] Switch to dark mode — confirm watermark appearance is unchanged