### PR TITLE
Support multi-provider sender domain deletion

### DIFF
--- a/apps/api/domains/cli/reconcile_sender_command.rb
+++ b/apps/api/domains/cli/reconcile_sender_command.rb
@@ -63,9 +63,10 @@ module Onetime
 
         # Refuse to switch providers on an existing config: deleting the
         # config first ensures the old provider's sender identity is torn
-        # down before a new one is created.
+        # down before a new one is created. effective_provider is already
+        # normalized, so we only normalize the user-supplied option.
         if existing_config && provider && !provider.strip.empty? &&
-           provider.strip.downcase != existing_config.effective_provider.to_s.strip.downcase
+           provider.strip.downcase != existing_config.effective_provider
           puts "Error: Existing config uses provider '#{existing_config.effective_provider}', not '#{provider}'."
           puts '  Delete the existing sender config first to switch providers.'
           return
@@ -136,7 +137,7 @@ module Onetime
       #
       # Precedence:
       #   1. Explicit --provider option
-      #   2. Existing config's effective_provider
+      #   2. Existing config's effective_provider (already normalized)
       #   3. Installation-level sender provider (Mailer.determine_sender_provider)
       #
       # @param provider_opt [String, nil] Value of the --provider option
@@ -146,10 +147,10 @@ module Onetime
         provider = provider_opt.to_s.strip.downcase
         return provider unless provider.empty?
 
-        provider = existing_config&.effective_provider.to_s.strip.downcase
+        provider = existing_config&.effective_provider.to_s
         return provider unless provider.empty?
 
-        Onetime::Mail::Mailer.send(:determine_sender_provider).to_s.strip.downcase
+        Onetime::Mail::Mailer.determine_sender_provider.to_s.strip.downcase
       end
 
       def print_dns_records(records)

--- a/apps/api/domains/cli/reconcile_sender_command.rb
+++ b/apps/api/domains/cli/reconcile_sender_command.rb
@@ -7,19 +7,22 @@ require 'onetime/operations/provision_sender_domain'
 
 module Onetime
   module CLI
-    # Reconcile a domain's Lettermint sender configuration.
+    # Reconcile a domain's sender configuration with its mail provider.
+    #
+    # Dispatches on the effective provider (SES, SendGrid, Lettermint),
+    # so it works regardless of which provider a domain is configured for.
     #
     # Handles two scenarios:
-    #   1. Domain was deleted and re-added: the old Lettermint record
-    #      causes a 409 duplicate. This command uses create_or_get_domain
-    #      which handles 409 by fetching the existing record.
-    #   2. Domain was added manually via Lettermint UI: this command
+    #   1. Domain was deleted and re-added: the old provider record
+    #      causes a 409 duplicate. Provisioning handles 409 by fetching
+    #      the existing record.
+    #   2. Domain was added manually via the provider's UI: this command
     #      creates the local MailerConfig and links it to the remote record.
     #
     class DomainsReconcileSenderCommand < Command
       include DomainsHelpers
 
-      desc 'Reconcile Lettermint sender domain with local mailer config'
+      desc 'Reconcile a sender domain with its local mailer config'
 
       argument :domain_name, type: :string, required: true, desc: 'Domain name (e.g. example.com)'
 
@@ -28,12 +31,17 @@ module Onetime
         default: nil,
         desc: 'From address (default: existing mailer_config.from_address)'
 
+      option :provider,
+        type: :string,
+        default: nil,
+        desc: 'Provider for a new config (default: existing config or installation default)'
+
       option :dry_run,
         type: :boolean,
         default: false,
         desc: 'Show what would happen without making changes'
 
-      def call(domain_name:, from_address: nil, dry_run: false, **)
+      def call(domain_name:, from_address: nil, provider: nil, dry_run: false, **)
         boot_application!
 
         domain = load_domain_by_name(domain_name)
@@ -53,21 +61,35 @@ module Onetime
           return
         end
 
-        puts "  from_address: #{resolved_from}"
-        puts "  existing config: #{existing_config ? 'yes' : 'no'}"
-        puts
-
-        if existing_config && existing_config.effective_provider != 'lettermint'
-          puts "Error: Existing config uses provider '#{existing_config.effective_provider}', not 'lettermint'."
+        # Refuse to switch providers on an existing config: deleting the
+        # config first ensures the old provider's sender identity is torn
+        # down before a new one is created.
+        if existing_config && provider && !provider.strip.empty? &&
+           provider.strip.downcase != existing_config.effective_provider.to_s.strip.downcase
+          puts "Error: Existing config uses provider '#{existing_config.effective_provider}', not '#{provider}'."
           puts '  Delete the existing sender config first to switch providers.'
           return
         end
 
+        resolved_provider = resolve_provider(provider, existing_config)
+        valid_providers   = Onetime::CustomDomain::MailerConfig::PROVIDER_TYPES
+        unless valid_providers.include?(resolved_provider)
+          got = resolved_provider.empty? ? '' : " (got '#{resolved_provider}')"
+          puts "Error: Could not resolve a valid sender provider#{got}."
+          puts "  Provide --provider (one of: #{valid_providers.join(', ')})."
+          return
+        end
+
+        puts "  from_address: #{resolved_from}"
+        puts "  provider: #{resolved_provider}"
+        puts "  existing config: #{existing_config ? 'yes' : 'no'}"
+        puts
+
         if dry_run
-          puts '[dry-run] Would reconcile Lettermint sender domain:'
+          puts '[dry-run] Would reconcile sender domain:'
           puts "  domain: #{domain.display_domain}"
           puts "  from_address: #{resolved_from}"
-          puts '  provider: lettermint'
+          puts "  provider: #{resolved_provider}"
           puts "  action: #{existing_config ? 'provision with existing config' : 'create new config, then provision'}"
           return
         end
@@ -80,7 +102,7 @@ module Onetime
             mailer_config = Onetime::CustomDomain::MailerConfig.create!(
               domain_id: domain.identifier,
               from_address: resolved_from,
-              provider: 'lettermint',
+              provider: resolved_provider,
               enabled: false,
               sending_mode: 'platform',
             )
@@ -92,7 +114,7 @@ module Onetime
         end
 
         # Provision via the operation (handles 409 by fetching existing)
-        puts 'Provisioning sender domain with Lettermint...'
+        puts "Provisioning sender domain with #{resolved_provider}..."
         result = Onetime::Operations::ProvisionSenderDomain.new(
           mailer_config: mailer_config,
         ).call
@@ -109,6 +131,26 @@ module Onetime
       end
 
       private
+
+      # Resolve which provider to reconcile against.
+      #
+      # Precedence:
+      #   1. Explicit --provider option
+      #   2. Existing config's effective_provider
+      #   3. Installation-level sender provider (Mailer.determine_sender_provider)
+      #
+      # @param provider_opt [String, nil] Value of the --provider option
+      # @param existing_config [CustomDomain::MailerConfig, nil] Existing config
+      # @return [String] Lowercased provider name, or '' when unresolvable
+      def resolve_provider(provider_opt, existing_config)
+        provider = provider_opt.to_s.strip.downcase
+        return provider unless provider.empty?
+
+        provider = existing_config&.effective_provider.to_s.strip.downcase
+        return provider unless provider.empty?
+
+        Onetime::Mail::Mailer.send(:determine_sender_provider).to_s.strip.downcase
+      end
 
       def print_dns_records(records)
         return if records.nil? || records.empty?

--- a/apps/api/domains/cli/reconcile_sender_command.rb
+++ b/apps/api/domains/cli/reconcile_sender_command.rb
@@ -67,7 +67,7 @@ module Onetime
         # normalized, so we only normalize the user-supplied option.
         if existing_config && provider && !provider.strip.empty? &&
            provider.strip.downcase != existing_config.effective_provider
-          puts "Error: Existing config uses provider '#{existing_config.effective_provider}', not '#{provider}'."
+          puts "Error: Existing config uses provider '#{existing_config.effective_provider}', not '#{provider.strip.downcase}'."
           puts '  Delete the existing sender config first to switch providers.'
           return
         end

--- a/lib/onetime/mail/mailer.rb
+++ b/lib/onetime/mail/mailer.rb
@@ -135,6 +135,22 @@ module Onetime
           build_provider_config(provider)
         end
 
+        # Returns the provider for custom mail sender domain provisioning.
+        #
+        # Resolves, in order: the explicit `sender_provider` emailer config,
+        # then the sending transport (determine_provider, e.g. EMAILER_MODE).
+        # Public because per-domain sender configs fall back to it when they
+        # carry no explicit provider (see MailerConfig#effective_provider).
+        #
+        # @return [String] Lowercased provider name (e.g. 'ses', 'lettermint')
+        def determine_sender_provider
+          conf = emailer_config
+          sp   = conf['sender_provider']
+          return sp.to_s.downcase.strip if sp.is_a?(String) && !sp.strip.empty?
+
+          determine_provider
+        end
+
         private
 
         def template_class_for(name)
@@ -214,16 +230,6 @@ module Onetime
           else
             warn message
           end
-        end
-
-        # Returns the provider for custom mail sender domain provisioning.
-        # Falls back to the sending transport (determine_provider) when unset.
-        def determine_sender_provider
-          conf = emailer_config
-          sp   = conf['sender_provider']
-          return sp.to_s.downcase.strip if sp.is_a?(String) && !sp.strip.empty?
-
-          determine_provider
         end
 
         def determine_provider

--- a/lib/onetime/mail/sender_strategies.rb
+++ b/lib/onetime/mail/sender_strategies.rb
@@ -74,6 +74,20 @@ module Onetime
           PROVISIONING_PROVIDERS.include?(provider.to_s.downcase)
         end
 
+        # Check if a provider has a sender strategy at all.
+        #
+        # Broader than supports_provisioning?: this includes 'smtp', whose
+        # strategy is a deliberate no-op for identity provisioning and
+        # teardown. Use this to decide whether an operation can be
+        # dispatched to a strategy (e.g. sender-identity deletion).
+        #
+        # @param provider [String, Symbol] Provider name
+        # @return [Boolean] true if a strategy is registered for the provider
+        #
+        def supported?(provider)
+          PROVIDER_STRATEGIES.key?(provider.to_s.downcase)
+        end
+
         # List all supported provider names.
         #
         # @return [Array<String>] Provider names

--- a/lib/onetime/models/custom_domain/mailer_config.rb
+++ b/lib/onetime/models/custom_domain/mailer_config.rb
@@ -436,17 +436,20 @@ module Onetime
 
       # Resolve effective provider for this mailer config.
       #
-      # Uses the config's provider field if set, otherwise falls back to
-      # installation-level provider from Mailer.determine_provider.
+      # Uses the config's provider field if set, otherwise falls back to the
+      # installation-level sender provider (Mailer.determine_sender_provider).
+      # The result is normalized (stripped, lowercased) so every consumer —
+      # strategy dispatch, credential lookup, comparisons — sees a canonical
+      # provider name and need not re-normalize.
       #
-      # @return [String, nil] Provider name or nil if not resolvable
+      # @return [String] Lowercased provider name, or '' if not resolvable
       def effective_provider
-        resolved = provider.to_s.strip
+        resolved = provider.to_s.strip.downcase
         return resolved unless resolved.empty?
 
         # Fallback to installation-level sender provider, which itself
         # falls back to the sending transport (EMAILER_MODE).
-        Onetime::Mail::Mailer.send(:determine_sender_provider)
+        Onetime::Mail::Mailer.determine_sender_provider.to_s.strip.downcase
       end
 
       class << self

--- a/lib/onetime/operations/delete_sender_domain.rb
+++ b/lib/onetime/operations/delete_sender_domain.rb
@@ -51,10 +51,20 @@ module Onetime
         strategy    = Onetime::Mail::SenderStrategies.for_provider(provider)
         result      = strategy.delete_sender_identity(@mailer_config, credentials: credentials)
 
-        logger.info 'Sender domain deleted',
-          domain_id: @mailer_config.domain_id,
-          provider: provider,
-          message: result[:message]
+        # Strategies signal an actual teardown via result[:deleted]. SMTP —
+        # and some error/no-op cases — return deleted:false, so log those
+        # distinctly to keep audit trails free of false "deleted" events.
+        if result[:deleted]
+          logger.info 'Sender domain deleted',
+            domain_id: @mailer_config.domain_id,
+            provider: provider,
+            message: result[:message]
+        else
+          logger.info 'Sender domain deletion skipped (no-op)',
+            domain_id: @mailer_config.domain_id,
+            provider: provider,
+            message: result[:message]
+        end
 
         Result.new(success: true, message: result[:message], error: nil)
       rescue StandardError => ex

--- a/lib/onetime/operations/delete_sender_domain.rb
+++ b/lib/onetime/operations/delete_sender_domain.rb
@@ -6,8 +6,13 @@ require_relative '../mail/sender_strategies'
 
 module Onetime
   module Operations
-    # Deletes a sender domain from the mail provider (currently Lettermint).
+    # Deletes a sender domain from its mail provider.
     # Extracted from RemoveDomain and DeleteSenderConfig for reuse.
+    #
+    # Dispatches on the mailer config's effective_provider, so each
+    # provider's sender identity is torn down through its own strategy
+    # (SES, SendGrid, Lettermint). SMTP is a no-op — there is no remote
+    # sender identity to delete.
     #
     # Never raises — all errors are wrapped in the Result.
     # Callers can fire-and-forget: domain/config removal proceeds regardless.
@@ -30,14 +35,17 @@ module Onetime
 
       def call
         return skipped('no mailer config') unless @mailer_config
-        return skipped('not a lettermint provider') unless @mailer_config.effective_provider == 'lettermint'
 
-        credentials = Onetime::Mail::Mailer.provider_credentials('lettermint')
-        strategy    = Onetime::Mail::SenderStrategies.for_provider('lettermint')
+        provider = resolve_provider
+        return skipped('no effective provider') if provider.empty?
+
+        credentials = Onetime::Mail::Mailer.provider_credentials(provider)
+        strategy    = Onetime::Mail::SenderStrategies.for_provider(provider)
         result      = strategy.delete_sender_identity(@mailer_config, credentials: credentials)
 
         logger.info 'Sender domain deleted',
           domain_id: @mailer_config.domain_id,
+          provider: provider,
           message: result[:message]
 
         Result.new(success: true, message: result[:message], error: nil)
@@ -50,6 +58,23 @@ module Onetime
       end
 
       private
+
+      # Resolve the provider to dispatch sender-identity deletion to.
+      #
+      # Prefers the mailer config's effective_provider (which itself
+      # falls back to the installation-level sender provider). When that
+      # is unresolvable, default to 'lettermint' for back-compat with
+      # configs created before the `provider` field existed — but only
+      # when a from_address remains to tear down. Returns an empty
+      # string when there is nothing to act on.
+      #
+      # @return [String] Lowercased provider name, or '' when unresolvable
+      def resolve_provider
+        provider = @mailer_config.effective_provider.to_s.strip.downcase
+        return provider unless provider.empty?
+
+        @mailer_config.from_address.to_s.strip.empty? ? '' : 'lettermint'
+      end
 
       def skipped(reason)
         Result.new(success: true, message: "skipped: #{reason}", error: nil)

--- a/lib/onetime/operations/delete_sender_domain.rb
+++ b/lib/onetime/operations/delete_sender_domain.rb
@@ -12,7 +12,9 @@ module Onetime
     # Dispatches on the mailer config's effective_provider, so each
     # provider's sender identity is torn down through its own strategy
     # (SES, SendGrid, Lettermint). SMTP is a no-op — there is no remote
-    # sender identity to delete.
+    # sender identity to delete. Configs that resolve to no provider, or
+    # to a transport without a sender strategy (e.g. 'logger'), are
+    # skipped rather than treated as errors.
     #
     # Never raises — all errors are wrapped in the Result.
     # Callers can fire-and-forget: domain/config removal proceeds regardless.
@@ -36,8 +38,14 @@ module Onetime
       def call
         return skipped('no mailer config') unless @mailer_config
 
-        provider = resolve_provider
+        # effective_provider is the single source of truth: it returns the
+        # config's provider, or the installation default, already normalized.
+        # Legacy configs predating the provider field resolve correctly here
+        # via that installation-level fallback.
+        provider = @mailer_config.effective_provider.to_s
         return skipped('no effective provider') if provider.empty?
+        return skipped("unsupported provider '#{provider}'") unless
+          Onetime::Mail::SenderStrategies.supported?(provider)
 
         credentials = Onetime::Mail::Mailer.provider_credentials(provider)
         strategy    = Onetime::Mail::SenderStrategies.for_provider(provider)
@@ -58,23 +66,6 @@ module Onetime
       end
 
       private
-
-      # Resolve the provider to dispatch sender-identity deletion to.
-      #
-      # Prefers the mailer config's effective_provider (which itself
-      # falls back to the installation-level sender provider). When that
-      # is unresolvable, default to 'lettermint' for back-compat with
-      # configs created before the `provider` field existed — but only
-      # when a from_address remains to tear down. Returns an empty
-      # string when there is nothing to act on.
-      #
-      # @return [String] Lowercased provider name, or '' when unresolvable
-      def resolve_provider
-        provider = @mailer_config.effective_provider.to_s.strip.downcase
-        return provider unless provider.empty?
-
-        @mailer_config.from_address.to_s.strip.empty? ? '' : 'lettermint'
-      end
 
       def skipped(reason)
         Result.new(success: true, message: "skipped: #{reason}", error: nil)

--- a/spec/integration/all/default_workspace_creation_spec.rb
+++ b/spec/integration/all/default_workspace_creation_spec.rb
@@ -10,6 +10,15 @@ RSpec.describe 'default_workspace_creation_try', type: :integration, order: :def
     # Clear Redis env vars to ensure test config defaults are used (port 2121)
     ENV.delete('REDIS_URL')
     ENV.delete('VALKEY_URL')
+
+    # Standalone materialization happens inside Organization.create!, which
+    # runs here in before(:all) -- BEFORE billing_isolation.rb's before(:each)
+    # disable hook fires. So a prior spec (or env) leaving BILLING_ENABLED=true
+    # would make create! treat the org as SaaS and skip materialization,
+    # failing the standalone assertions below. Disable billing explicitly here
+    # so this spec is self-contained rather than dependent on hook ordering.
+    BillingTestHelpers.disable_billing!
+
     begin
       OT.boot! :test, false unless OT.ready?
     rescue Redis::CannotConnectError, Redis::ConnectionError => e

--- a/spec/unit/onetime/mail/sender_strategies_spec.rb
+++ b/spec/unit/onetime/mail/sender_strategies_spec.rb
@@ -82,4 +82,19 @@ RSpec.describe Onetime::Mail::SenderStrategies do
       expect(described_class.supported_providers).to contain_exactly('ses', 'sendgrid', 'lettermint', 'smtp')
     end
   end
+
+  # ==========================================================================
+  # Cross-layer invariant: the strategy registry (what we can dispatch to)
+  # and MailerConfig::PROVIDER_TYPES (what a config may store) are maintained
+  # independently but must hold the same set. Reconcile validates against
+  # PROVIDER_TYPES, DeleteSenderDomain dispatches via .supported? — if they
+  # drift, one path accepts a provider the other rejects. This guards it.
+  # ==========================================================================
+
+  describe 'consistency with MailerConfig::PROVIDER_TYPES' do
+    it 'covers exactly the providers a MailerConfig may store' do
+      expect(described_class.supported_providers.sort)
+        .to eq(Onetime::CustomDomain::MailerConfig::PROVIDER_TYPES.sort)
+    end
+  end
 end

--- a/spec/unit/onetime/mail/sender_strategies_spec.rb
+++ b/spec/unit/onetime/mail/sender_strategies_spec.rb
@@ -1,0 +1,85 @@
+# spec/unit/onetime/mail/sender_strategies_spec.rb
+#
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'onetime/mail/sender_strategies'
+
+RSpec.describe Onetime::Mail::SenderStrategies do
+  # ==========================================================================
+  # .supported? — "has a strategy" (the predicate DeleteSenderDomain dispatches
+  # on). The defining contrast with supports_provisioning? is that it INCLUDES
+  # smtp, whose strategy is a deliberate no-op.
+  # ==========================================================================
+
+  describe '.supported?' do
+    it 'is true for every provider with a registered strategy' do
+      %w[ses sendgrid lettermint smtp].each do |provider|
+        expect(described_class.supported?(provider)).to be(true), "expected '#{provider}' to be supported"
+      end
+    end
+
+    it 'includes smtp, where supports_provisioning? deliberately does not' do
+      expect(described_class.supported?('smtp')).to be true
+      expect(described_class.supports_provisioning?('smtp')).to be false
+    end
+
+    it 'is false for transports/providers without a strategy' do
+      %w[logger mailchimp postmark].each do |provider|
+        expect(described_class.supported?(provider)).to be false
+      end
+    end
+
+    it 'is false for blank/nil input' do
+      expect(described_class.supported?('')).to be false
+      expect(described_class.supported?(nil)).to be false
+    end
+
+    it 'normalizes case and accepts symbols' do
+      expect(described_class.supported?(:SES)).to be true
+      expect(described_class.supported?('LetterMint')).to be true
+    end
+  end
+
+  # ==========================================================================
+  # .for_provider
+  # ==========================================================================
+
+  describe '.for_provider' do
+    it 'returns the matching strategy instance for known providers' do
+      expect(described_class.for_provider('ses')).to be_a(described_class::SESSenderStrategy)
+      expect(described_class.for_provider('smtp')).to be_a(described_class::SMTPSenderStrategy)
+    end
+
+    it 'is case-insensitive' do
+      expect(described_class.for_provider('SendGrid')).to be_a(described_class::SendGridSenderStrategy)
+    end
+
+    it 'raises ArgumentError for unknown providers' do
+      expect { described_class.for_provider('mailchimp') }
+        .to raise_error(ArgumentError, /Unknown sender strategy/)
+    end
+  end
+
+  # ==========================================================================
+  # .supports_provisioning? / .supported_providers
+  # ==========================================================================
+
+  describe '.supports_provisioning?' do
+    it 'is true for API-provisionable providers' do
+      %w[ses sendgrid lettermint].each do |provider|
+        expect(described_class.supports_provisioning?(provider)).to be true
+      end
+    end
+
+    it 'is false for smtp (manual DNS configuration)' do
+      expect(described_class.supports_provisioning?('smtp')).to be false
+    end
+  end
+
+  describe '.supported_providers' do
+    it 'lists every provider that has a strategy' do
+      expect(described_class.supported_providers).to contain_exactly('ses', 'sendgrid', 'lettermint', 'smtp')
+    end
+  end
+end

--- a/spec/unit/onetime/operations/delete_sender_domain_spec.rb
+++ b/spec/unit/onetime/operations/delete_sender_domain_spec.rb
@@ -109,6 +109,26 @@ RSpec.describe Onetime::Operations::DeleteSenderDomain do
       # WebMock (disable_net_connect!) would have flagged any HTTP attempt.
       expect(a_request(:any, /.*/)).not_to have_been_made
     end
+
+    it 'logs a no-op rather than a deletion (result[:deleted] is false)' do
+      config        = mailer_config_for('smtp')
+      smtp_strategy = Onetime::Mail::SenderStrategies::SMTPSenderStrategy.new
+
+      logged = []
+      log    = double('logger')
+      allow(log).to receive(:info) { |*args, **_kw| logged << args.first }
+      allow(log).to receive(:error)
+      allow(Onetime).to receive(:get_logger).and_return(log)
+      allow(Onetime::Mail::Mailer).to receive(:provider_credentials)
+        .and_return({ 'host' => 'smtp.example.com' })
+      allow(Onetime::Mail::SenderStrategies).to receive(:for_provider)
+        .with('smtp').and_return(smtp_strategy)
+
+      described_class.new(mailer_config: config).call
+
+      expect(logged).to include('Sender domain deletion skipped (no-op)')
+      expect(logged).not_to include('Sender domain deleted')
+    end
   end
 
   # ==========================================================================

--- a/spec/unit/onetime/operations/delete_sender_domain_spec.rb
+++ b/spec/unit/onetime/operations/delete_sender_domain_spec.rb
@@ -1,0 +1,177 @@
+# spec/unit/onetime/operations/delete_sender_domain_spec.rb
+#
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'onetime/operations/delete_sender_domain'
+
+RSpec.describe Onetime::Operations::DeleteSenderDomain do
+  let(:mock_credentials) { { 'team_token' => 'fake-test-token' } }
+
+  # Build a MailerConfig stand-in. effective_provider drives dispatch;
+  # from_address is only consulted on the back-compat fallback path.
+  def mailer_config_for(provider, from_address: 'sender@example.com')
+    double(
+      'MailerConfig',
+      domain_id: 'cd:test123',
+      provider: provider,
+      effective_provider: provider,
+      from_address: from_address,
+    )
+  end
+
+  # ==========================================================================
+  # Result object
+  # ==========================================================================
+
+  describe 'Result' do
+    it 'implements success? / failed?' do
+      ok  = described_class::Result.new(success: true, message: 'done', error: nil)
+      bad = described_class::Result.new(success: false, message: nil, error: 'boom')
+
+      expect(ok.success?).to be true
+      expect(ok.failed?).to be false
+      expect(bad.success?).to be false
+      expect(bad.failed?).to be true
+    end
+  end
+
+  # ==========================================================================
+  # #call — per-provider dispatch (the core generalization)
+  # ==========================================================================
+
+  describe '#call dispatch' do
+    before do
+      allow(Onetime::Mail::Mailer).to receive(:provider_credentials).and_return(mock_credentials)
+    end
+
+    %w[ses sendgrid lettermint].each do |provider|
+      it "dispatches deletion to the #{provider} strategy" do
+        config   = mailer_config_for(provider)
+        strategy = double("#{provider}_strategy")
+
+        allow(Onetime::Mail::SenderStrategies).to receive(:for_provider)
+          .with(provider).and_return(strategy)
+        expect(strategy).to receive(:delete_sender_identity)
+          .with(config, credentials: mock_credentials)
+          .and_return({ deleted: true, message: "#{provider} identity deleted" })
+
+        result = described_class.new(mailer_config: config).call
+
+        expect(result.success?).to be true
+        expect(result.message).to eq("#{provider} identity deleted")
+        expect(result.error).to be_nil
+      end
+    end
+
+    it 'loads credentials for the resolved provider' do
+      config   = mailer_config_for('ses')
+      strategy = double('ses_strategy', delete_sender_identity: { deleted: true, message: 'ok' })
+
+      allow(Onetime::Mail::SenderStrategies).to receive(:for_provider)
+        .with('ses').and_return(strategy)
+      expect(Onetime::Mail::Mailer).to receive(:provider_credentials)
+        .with('ses').and_return(mock_credentials)
+
+      described_class.new(mailer_config: config).call
+    end
+
+    it 'downcases the effective provider before dispatch' do
+      config   = mailer_config_for('Lettermint')
+      strategy = double('lm_strategy', delete_sender_identity: { deleted: true, message: 'ok' })
+
+      allow(Onetime::Mail::Mailer).to receive(:provider_credentials)
+        .with('lettermint').and_return(mock_credentials)
+      expect(Onetime::Mail::SenderStrategies).to receive(:for_provider)
+        .with('lettermint').and_return(strategy)
+
+      result = described_class.new(mailer_config: config).call
+
+      expect(result.success?).to be true
+    end
+  end
+
+  # ==========================================================================
+  # #call — SMTP no-op (acceptance: makes no provider API call)
+  # ==========================================================================
+
+  describe '#call with SMTP provider' do
+    it 'returns the SMTP no-op without making any provider API call' do
+      config        = mailer_config_for('smtp')
+      smtp_strategy = Onetime::Mail::SenderStrategies::SMTPSenderStrategy.new
+
+      allow(Onetime::Mail::Mailer).to receive(:provider_credentials)
+        .and_return({ 'host' => 'smtp.example.com' })
+      # Use the real strategy so the genuine no-op path runs.
+      allow(Onetime::Mail::SenderStrategies).to receive(:for_provider)
+        .with('smtp').and_return(smtp_strategy)
+
+      result = described_class.new(mailer_config: config).call
+
+      expect(result.success?).to be true
+      expect(result.message).to eq('SMTP providers do not have sender identities to delete.')
+      # WebMock (disable_net_connect!) would have flagged any HTTP attempt.
+      expect(a_request(:any, /.*/)).not_to have_been_made
+    end
+  end
+
+  # ==========================================================================
+  # #call — skip / back-compat paths
+  # ==========================================================================
+
+  describe '#call skip paths' do
+    it 'skips when mailer_config is nil' do
+      result = described_class.new(mailer_config: nil).call
+
+      expect(result.success?).to be true
+      expect(result.message).to eq('skipped: no mailer config')
+    end
+
+    it 'skips when neither a provider nor a from_address resolves' do
+      config = double('MailerConfig', domain_id: 'cd:x', provider: '', effective_provider: '', from_address: '')
+
+      result = described_class.new(mailer_config: config).call
+
+      expect(result.success?).to be true
+      expect(result.message).to eq('skipped: no effective provider')
+    end
+
+    it 'falls back to lettermint for legacy configs (address present, provider unresolvable)' do
+      config   = double('MailerConfig', domain_id: 'cd:x', provider: '', effective_provider: '', from_address: 'a@b.com')
+      strategy = double('lm_strategy')
+
+      allow(Onetime::Mail::Mailer).to receive(:provider_credentials)
+        .with('lettermint').and_return(mock_credentials)
+      allow(Onetime::Mail::SenderStrategies).to receive(:for_provider)
+        .with('lettermint').and_return(strategy)
+      expect(strategy).to receive(:delete_sender_identity)
+        .and_return({ deleted: true, message: 'legacy lettermint deleted' })
+
+      result = described_class.new(mailer_config: config).call
+
+      expect(result.success?).to be true
+      expect(result.message).to eq('legacy lettermint deleted')
+    end
+  end
+
+  # ==========================================================================
+  # #call — error handling (never raises; wraps failures in Result)
+  # ==========================================================================
+
+  describe '#call error handling' do
+    it 'swallows strategy errors into a failure Result' do
+      config   = mailer_config_for('lettermint')
+      strategy = double('lm_strategy')
+
+      allow(Onetime::Mail::Mailer).to receive(:provider_credentials).and_return(mock_credentials)
+      allow(Onetime::Mail::SenderStrategies).to receive(:for_provider).and_return(strategy)
+      allow(strategy).to receive(:delete_sender_identity).and_raise(StandardError, 'provider API timeout')
+
+      result = described_class.new(mailer_config: config).call
+
+      expect(result.success?).to be false
+      expect(result.failed?).to be true
+      expect(result.error).to eq('provider API timeout')
+    end
+  end
+end

--- a/spec/unit/onetime/operations/delete_sender_domain_spec.rb
+++ b/spec/unit/onetime/operations/delete_sender_domain_spec.rb
@@ -8,15 +8,22 @@ require 'onetime/operations/delete_sender_domain'
 RSpec.describe Onetime::Operations::DeleteSenderDomain do
   let(:mock_credentials) { { 'team_token' => 'fake-test-token' } }
 
-  # Build a MailerConfig stand-in. effective_provider drives dispatch;
-  # from_address is only consulted on the back-compat fallback path.
-  def mailer_config_for(provider, from_address: 'sender@example.com')
+  # Real strategy classes, used for verifying doubles so a signature drift
+  # in #delete_sender_identity would fail these tests.
+  strategy_classes = {
+    'ses'        => Onetime::Mail::SenderStrategies::SESSenderStrategy,
+    'sendgrid'   => Onetime::Mail::SenderStrategies::SendGridSenderStrategy,
+    'lettermint' => Onetime::Mail::SenderStrategies::LettermintSenderStrategy,
+  }.freeze
+
+  # MailerConfig stand-in. effective_provider is the single input the
+  # operation dispatches on (already normalized by the real model).
+  def mailer_config_for(provider)
     double(
       'MailerConfig',
       domain_id: 'cd:test123',
-      provider: provider,
       effective_provider: provider,
-      from_address: from_address,
+      from_address: 'sender@example.com',
     )
   end
 
@@ -45,10 +52,10 @@ RSpec.describe Onetime::Operations::DeleteSenderDomain do
       allow(Onetime::Mail::Mailer).to receive(:provider_credentials).and_return(mock_credentials)
     end
 
-    %w[ses sendgrid lettermint].each do |provider|
+    strategy_classes.each do |provider, klass|
       it "dispatches deletion to the #{provider} strategy" do
         config   = mailer_config_for(provider)
-        strategy = double("#{provider}_strategy")
+        strategy = instance_double(klass)
 
         allow(Onetime::Mail::SenderStrategies).to receive(:for_provider)
           .with(provider).and_return(strategy)
@@ -66,7 +73,10 @@ RSpec.describe Onetime::Operations::DeleteSenderDomain do
 
     it 'loads credentials for the resolved provider' do
       config   = mailer_config_for('ses')
-      strategy = double('ses_strategy', delete_sender_identity: { deleted: true, message: 'ok' })
+      strategy = instance_double(
+        Onetime::Mail::SenderStrategies::SESSenderStrategy,
+        delete_sender_identity: { deleted: true, message: 'ok' },
+      )
 
       allow(Onetime::Mail::SenderStrategies).to receive(:for_provider)
         .with('ses').and_return(strategy)
@@ -74,20 +84,6 @@ RSpec.describe Onetime::Operations::DeleteSenderDomain do
         .with('ses').and_return(mock_credentials)
 
       described_class.new(mailer_config: config).call
-    end
-
-    it 'downcases the effective provider before dispatch' do
-      config   = mailer_config_for('Lettermint')
-      strategy = double('lm_strategy', delete_sender_identity: { deleted: true, message: 'ok' })
-
-      allow(Onetime::Mail::Mailer).to receive(:provider_credentials)
-        .with('lettermint').and_return(mock_credentials)
-      expect(Onetime::Mail::SenderStrategies).to receive(:for_provider)
-        .with('lettermint').and_return(strategy)
-
-      result = described_class.new(mailer_config: config).call
-
-      expect(result.success?).to be true
     end
   end
 
@@ -116,7 +112,7 @@ RSpec.describe Onetime::Operations::DeleteSenderDomain do
   end
 
   # ==========================================================================
-  # #call — skip / back-compat paths
+  # #call — skip paths (no dispatch, no error)
   # ==========================================================================
 
   describe '#call skip paths' do
@@ -127,8 +123,9 @@ RSpec.describe Onetime::Operations::DeleteSenderDomain do
       expect(result.message).to eq('skipped: no mailer config')
     end
 
-    it 'skips when neither a provider nor a from_address resolves' do
-      config = double('MailerConfig', domain_id: 'cd:x', provider: '', effective_provider: '', from_address: '')
+    it 'skips when no provider resolves' do
+      config = double('MailerConfig', domain_id: 'cd:x', effective_provider: '', from_address: 'a@b.com')
+      expect(Onetime::Mail::SenderStrategies).not_to receive(:for_provider)
 
       result = described_class.new(mailer_config: config).call
 
@@ -136,21 +133,15 @@ RSpec.describe Onetime::Operations::DeleteSenderDomain do
       expect(result.message).to eq('skipped: no effective provider')
     end
 
-    it 'falls back to lettermint for legacy configs (address present, provider unresolvable)' do
-      config   = double('MailerConfig', domain_id: 'cd:x', provider: '', effective_provider: '', from_address: 'a@b.com')
-      strategy = double('lm_strategy')
-
-      allow(Onetime::Mail::Mailer).to receive(:provider_credentials)
-        .with('lettermint').and_return(mock_credentials)
-      allow(Onetime::Mail::SenderStrategies).to receive(:for_provider)
-        .with('lettermint').and_return(strategy)
-      expect(strategy).to receive(:delete_sender_identity)
-        .and_return({ deleted: true, message: 'legacy lettermint deleted' })
+    it 'skips a provider that has no sender strategy (e.g. logger)' do
+      config = double('MailerConfig', domain_id: 'cd:x', effective_provider: 'logger', from_address: 'a@b.com')
+      expect(Onetime::Mail::SenderStrategies).not_to receive(:for_provider)
+      expect(Onetime::Mail::Mailer).not_to receive(:provider_credentials)
 
       result = described_class.new(mailer_config: config).call
 
       expect(result.success?).to be true
-      expect(result.message).to eq('legacy lettermint deleted')
+      expect(result.message).to eq("skipped: unsupported provider 'logger'")
     end
   end
 
@@ -161,7 +152,7 @@ RSpec.describe Onetime::Operations::DeleteSenderDomain do
   describe '#call error handling' do
     it 'swallows strategy errors into a failure Result' do
       config   = mailer_config_for('lettermint')
-      strategy = double('lm_strategy')
+      strategy = instance_double(Onetime::Mail::SenderStrategies::LettermintSenderStrategy)
 
       allow(Onetime::Mail::Mailer).to receive(:provider_credentials).and_return(mock_credentials)
       allow(Onetime::Mail::SenderStrategies).to receive(:for_provider).and_return(strategy)

--- a/try/unit/cli/domains/reconcile_sender_command_try.rb
+++ b/try/unit/cli/domains/reconcile_sender_command_try.rb
@@ -14,6 +14,8 @@
 #   7. Non-lettermint existing config -> reconciles without provider refusal
 #   8. --provider conflicting with existing config -> refuses to switch
 #   9. Unresolvable/invalid provider -> errors, creates no config
+#  10. New config created with explicit non-lettermint --provider
+#  11. Explicit invalid --provider -> errors, creates no config
 #
 # Run:
 #   try try/unit/cli/domains/reconcile_sender_command_try.rb --agent
@@ -284,6 +286,53 @@ end
 
 ## No MailerConfig is created when the provider is unresolvable
 Onetime::CustomDomain::MailerConfig.exists_for_domain?(@domain_9.identifier)
+#=> false
+
+# ===================================================================
+# Case 10: New config created with explicit non-lettermint --provider
+# ===================================================================
+
+## New config is created with the provider given via --provider
+@domain_10 = Onetime::CustomDomain.create!("rsc-newses-#{@timestamp}-#{@entropy}.example.com", @org.objid)
+PSDTestData.canned_result = Onetime::Operations::ProvisionSenderDomain::Result.new(
+  success: true,
+  dns_records: [],
+  provider_data: { 'status' => 'pending' },
+  error: nil,
+)
+@output_10 = capture_stdout do
+  build_cmd.call(
+    domain_name: @domain_10.display_domain,
+    from_address: "noreply@rsc-newses-#{@timestamp}.example.com",
+    provider: 'ses',
+  )
+end
+@mc_10 = Onetime::CustomDomain::MailerConfig.find_by_domain_id(@domain_10.identifier)
+@mc_10.provider
+#=> 'ses'
+
+## Reconcile output reflects the ses provider for the new config
+@output_10.include?('provider: ses')
+#=> true
+
+# ===================================================================
+# Case 11: Explicit invalid --provider -> errors, creates no config
+# ===================================================================
+
+## Explicit invalid --provider is rejected
+@domain_11 = Onetime::CustomDomain.create!("rsc-bad-#{@timestamp}-#{@entropy}.example.com", @org.objid)
+@output_11 = capture_stdout do
+  build_cmd.call(
+    domain_name: @domain_11.display_domain,
+    from_address: "noreply@rsc-bad-#{@timestamp}.example.com",
+    provider: 'mailchimp',
+  )
+end
+@output_11.include?('Could not resolve a valid sender provider')
+#=> true
+
+## No MailerConfig is created for an invalid provider
+Onetime::CustomDomain::MailerConfig.exists_for_domain?(@domain_11.identifier)
 #=> false
 
 # --- Cleanup ---

--- a/try/unit/cli/domains/reconcile_sender_command_try.rb
+++ b/try/unit/cli/domains/reconcile_sender_command_try.rb
@@ -11,6 +11,9 @@
 #   4. Dry-run with existing config -> prints plan with "provision with existing config"
 #   5. Provision success path -> creates MailerConfig, prints "provisioned successfully"
 #   6. Provision failure path -> prints "failed:"
+#   7. Non-lettermint existing config -> reconciles without provider refusal
+#   8. --provider conflicting with existing config -> refuses to switch
+#   9. Unresolvable/invalid provider -> errors, creates no config
 #
 # Run:
 #   try try/unit/cli/domains/reconcile_sender_command_try.rb --agent
@@ -112,6 +115,7 @@ end
   build_cmd.call(
     domain_name: @domain_3.display_domain,
     from_address: "noreply@rsc-dry3-#{@timestamp}.example.com",
+    provider: 'lettermint',
     dry_run: true,
   )
 end
@@ -168,6 +172,7 @@ PSDTestData.canned_result = Onetime::Operations::ProvisionSenderDomain::Result.n
   build_cmd.call(
     domain_name: @domain_5.display_domain,
     from_address: "noreply@rsc-ok-#{@timestamp}.example.com",
+    provider: 'lettermint',
   )
 end
 @output_5.include?('provisioned successfully')
@@ -206,6 +211,7 @@ PSDTestData.canned_result = Onetime::Operations::ProvisionSenderDomain::Result.n
   build_cmd.call(
     domain_name: @domain_6.display_domain,
     from_address: "noreply@rsc-fail-#{@timestamp}.example.com",
+    provider: 'lettermint',
   )
 end
 @output_6.include?('failed:')
@@ -214,6 +220,71 @@ end
 ## Failure output includes the error message
 @output_6.include?('Lettermint API rate limit exceeded')
 #=> true
+
+# ===================================================================
+# Case 7: Non-lettermint existing config -> reconciles, no refusal
+# ===================================================================
+
+## Existing ses config reconciles without the provider-mismatch refusal
+@domain_7 = Onetime::CustomDomain.create!("rsc-ses-#{@timestamp}-#{@entropy}.example.com", @org.objid)
+@mc_7 = Onetime::CustomDomain::MailerConfig.create!(
+  domain_id: @domain_7.identifier,
+  from_address: "noreply@rsc-ses-#{@timestamp}.example.com",
+  provider: 'ses',
+)
+PSDTestData.canned_result = Onetime::Operations::ProvisionSenderDomain::Result.new(
+  success: true,
+  dns_records: [],
+  provider_data: { 'status' => 'pending' },
+  error: nil,
+)
+@output_7 = capture_stdout do
+  build_cmd.call(domain_name: @domain_7.display_domain)
+end
+@output_7.include?('provisioned successfully')
+#=> true
+
+## Reconcile output reflects the ses provider, not lettermint
+@output_7.include?('provider: ses')
+#=> true
+
+## No provider-mismatch refusal for the existing ses config
+@output_7.include?('Delete the existing sender config first')
+#=> false
+
+# ===================================================================
+# Case 8: --provider conflicting with existing config -> refuses switch
+# ===================================================================
+
+## --provider that differs from existing config refuses to switch
+@output_8 = capture_stdout do
+  build_cmd.call(domain_name: @domain_7.display_domain, provider: 'sendgrid')
+end
+@output_8.include?('Delete the existing sender config first')
+#=> true
+
+# ===================================================================
+# Case 9: Unresolvable/invalid provider -> errors, creates no config
+# ===================================================================
+# In the test environment the installation default sender provider is
+# 'logger', which is not a valid MailerConfig provider. With no --provider
+# and no existing config, the command should refuse rather than create an
+# invalid config.
+
+## No valid provider resolvable -> prints error
+@domain_9 = Onetime::CustomDomain.create!("rsc-noprov-#{@timestamp}-#{@entropy}.example.com", @org.objid)
+@output_9 = capture_stdout do
+  build_cmd.call(
+    domain_name: @domain_9.display_domain,
+    from_address: "noreply@rsc-noprov-#{@timestamp}.example.com",
+  )
+end
+@output_9.include?('Could not resolve a valid sender provider')
+#=> true
+
+## No MailerConfig is created when the provider is unresolvable
+Onetime::CustomDomain::MailerConfig.exists_for_domain?(@domain_9.identifier)
+#=> false
 
 # --- Cleanup ---
 PSDTestData.canned_result = nil

--- a/try/unit/logic/domains/remove_domain_try.rb
+++ b/try/unit/logic/domains/remove_domain_try.rb
@@ -4,13 +4,13 @@
 
 # Tests for RemoveDomain#delete_sender_domain
 #
-# The method loads mailer_config from the custom domain, checks if the
-# effective provider is 'lettermint', calls strategy.delete_sender_identity,
+# The method loads mailer_config from the custom domain, resolves the
+# effective provider, calls that provider's strategy.delete_sender_identity,
 # and swallows any errors so domain removal always proceeds.
 #
 # Covers:
 #   1. No mailer_config -> strategy never called
-#   2. Provider != 'lettermint' -> strategy never called
+#   2. Non-lettermint provider (ses) -> delete_sender_identity dispatched
 #   3. Provider == 'lettermint' -> delete_sender_identity called once
 #   4. Strategy raises StandardError -> error swallowed, no propagation
 #
@@ -113,10 +113,10 @@ restore_stubs(@ofp_1, @opc_1)
 #=> 0
 
 # ===================================================================
-# Case 2: Provider != 'lettermint' -> strategy never called
+# Case 2: Non-lettermint provider (ses) -> delete_sender_identity dispatched
 # ===================================================================
 
-## delete_sender_domain skips non-lettermint providers
+## delete_sender_domain dispatches deletion for non-lettermint providers
 @domain_2 = Onetime::CustomDomain.create!("rd-ses-#{@timestamp}-#{@entropy}.example.com", @org.objid)
 @mc_2 = Onetime::CustomDomain::MailerConfig.create!(
   domain_id: @domain_2.identifier,
@@ -128,7 +128,7 @@ restore_stubs(@ofp_1, @opc_1)
 @logic_2.send(:delete_sender_domain)
 restore_stubs(@ofp_2, @opc_2)
 @spy_2.delete_calls.size
-#=> 0
+#=> 1
 
 # ===================================================================
 # Case 3: Provider == 'lettermint' -> delete_sender_identity called

--- a/try/unit/models/custom_domain_mailer_config_try.rb
+++ b/try/unit/models/custom_domain_mailer_config_try.rb
@@ -16,6 +16,10 @@
 
 require_relative '../../support/test_models'
 
+# effective_provider falls back to the installation-level resolver in the
+# mail layer, so it must be loaded for those cases.
+require 'onetime/mail/mailer'
+
 OT.boot! :test
 
 # Configure Familia encryption with known test keys.
@@ -173,6 +177,21 @@ rescue Onetime::Problem => e
   e.message.include?('provider must be one of')
 end
 #=> true
+
+# --- Resolution: effective_provider ---
+
+## effective_provider returns the config's provider when set
+@config.effective_provider
+#=> 'ses'
+
+## effective_provider falls back to the installation sender provider when unset
+@config_noprov.effective_provider == Onetime::Mail::Mailer.determine_sender_provider
+#=> true
+
+## effective_provider normalizes casing and whitespace at the source
+@config_noprov.provider = '  SES  '
+@config_noprov.effective_provider
+#=> 'ses'
 
 # --- Validation: from_address ---
 


### PR DESCRIPTION
Resolves #3357

## Summary

Generalize sender domain deletion to support SES, SendGrid, and Lettermint providers, not just Lettermint. The operation now dispatches on the mailer config's `effective_provider` to route deletion requests to the appropriate provider strategy.

### Key Changes

- **DeleteSenderDomain operation**: Refactored to dispatch deletion across all supported providers (SES, SendGrid, Lettermint, SMTP). SMTP is a no-op since it has no remote sender identity. Configs with unsupported providers are skipped gracefully rather than treated as errors.

- **MailerConfig#effective_provider**: Now normalizes the result (lowercased, stripped) so all consumers see a canonical provider name. Falls back to the installation-level sender provider when the config's provider field is unset.

- **Mailer.determine_sender_provider**: Made public (moved from private) to support the fallback chain in `effective_provider`. Resolves the explicit `sender_provider` config, then falls back to the sending transport.

- **SenderStrategies.supported?**: New method to check if a provider has a registered strategy (broader than `supports_provisioning?`, includes SMTP).

- **DomainsReconcileSenderCommand**: Updated to accept a `--provider` option and work with any supported provider, not just Lettermint. Validates provider resolution and refuses to switch providers on an existing config without explicit deletion first.

### Testing

- Added comprehensive unit tests for DeleteSenderDomain covering per-provider dispatch, SMTP no-op, skip paths, and error handling.
- Updated integration tests (try files) to verify multi-provider reconciliation, provider validation, and conflict detection.
- Existing tests pass with the normalized `effective_provider` behavior.

https://claude.ai/code/session_01Q56xnsqmkqpsTjhpiFhEKW