### PR TITLE
Add on-demand heap dumps for memory growth diagnostics

### DIFF
--- a/.env.reference
+++ b/.env.reference
@@ -415,14 +415,6 @@ SENTRY_URL=
 SENTRY_RELEASE=
 SENTRY_DIST=frontend
 
-# Directory for on-demand heap dumps. Every OTS process installs a SIGUSR2
-# handler at boot; `kill -USR2 <pid>` writes ObjectSpace.dump_all output to
-# <dir>/heap-<pid>-<epoch>.json (owner-only, 0600). Point this at a writable
-# volume if /tmp is locked down. Analyze with scripts/analyze-heapdump.
-# SECURITY: a heap dump contains plaintext secrets and key material that were
-# live in memory. Treat the file as a credential and delete it after analysis.
-#HEAP_DUMP_DIR=/tmp
-
 
 
 # ═══════════════════════════════════════════════════════════
@@ -482,6 +474,19 @@ SECRET_VARIABLE_NAMES=STRIPE_API_KEY,SECRET,SESSION_SECRET,AUTH_SECRET,ARGON2_SE
 
 # IRB interface for Ruby debugger breakpoints
 #RUBY_DEBUG_IRB_CONSOLE=true
+
+# On-demand heap dumps for diagnosing memory growth. When enabled, every OTS
+# process installs a SIGUSR2 handler at boot; `kill -USR2 <pid>` writes
+# ObjectSpace.dump_all output to HEAP_DUMP_DIR/heap-<pid>-<epoch>.json
+# (owner-only, 0600). Analyze with scripts/analyze-heapdump.
+# SECURITY: a dump contains plaintext secrets and key material that were live
+# in memory — treat the file as a credential and delete it after analysis.
+# Default off; enable explicitly (requires a restart, and on a read-only
+# container a writable HEAP_DUMP_DIR mount).
+#HEAP_DUMP_ENABLED=true
+# Default /var/tmp (disk-backed and persistent on Debian 13, unlike the tmpfs
+# /tmp which consumes RAM against the container's MemoryMax).
+#HEAP_DUMP_DIR=/var/tmp
 
 #RUBY_YJIT_ENABLE=1
 #RUBYOPT="--enable-frozen-string-literal"

--- a/.env.reference
+++ b/.env.reference
@@ -417,8 +417,10 @@ SENTRY_DIST=frontend
 
 # Directory for on-demand heap dumps. Every OTS process installs a SIGUSR2
 # handler at boot; `kill -USR2 <pid>` writes ObjectSpace.dump_all output to
-# <dir>/heap-<pid>-<epoch>.json. Point this at a writable volume if /tmp is
-# locked down. Analyze with scripts/analyze-heapdump.
+# <dir>/heap-<pid>-<epoch>.json (owner-only, 0600). Point this at a writable
+# volume if /tmp is locked down. Analyze with scripts/analyze-heapdump.
+# SECURITY: a heap dump contains plaintext secrets and key material that were
+# live in memory. Treat the file as a credential and delete it after analysis.
 #HEAP_DUMP_DIR=/tmp
 
 

--- a/.env.reference
+++ b/.env.reference
@@ -415,6 +415,12 @@ SENTRY_URL=
 SENTRY_RELEASE=
 SENTRY_DIST=frontend
 
+# Directory for on-demand heap dumps. Every OTS process installs a SIGUSR2
+# handler at boot; `kill -USR2 <pid>` writes ObjectSpace.dump_all output to
+# <dir>/heap-<pid>-<epoch>.json. Point this at a writable volume if /tmp is
+# locked down. Analyze with scripts/analyze-heapdump.
+#HEAP_DUMP_DIR=/tmp
+
 
 
 # ═══════════════════════════════════════════════════════════

--- a/changelog.d/20260607_000000_claude_3366_heap_dump_handler.rst
+++ b/changelog.d/20260607_000000_claude_3366_heap_dump_handler.rst
@@ -14,6 +14,15 @@ Added
   ``scripts/analyze-heapdump`` summarizes a dump (object counts by type, bytes
   by type, top STRING allocation sites). (#3366)
 
+Security
+--------
+
+- Heap dumps are written owner-only (``0600``) and created exclusively
+  (``O_EXCL``) so they cannot clobber or follow a pre-planted symlink in a
+  shared ``/tmp``. A dump serializes live String values, so it contains
+  plaintext secrets and key material — treat the file as a credential and
+  delete it after analysis. (#3366)
+
 AI Assistance
 -------------
 

--- a/changelog.d/20260607_000000_claude_3366_heap_dump_handler.rst
+++ b/changelog.d/20260607_000000_claude_3366_heap_dump_handler.rst
@@ -3,25 +3,28 @@
 Added
 -----
 
-- All OTS processes (web, scheduler, worker, CLI) now install a ``SIGUSR2``
-  heap dump handler at boot. Sending ``kill -USR2 <pid>`` writes an
-  ``ObjectSpace.dump_all`` snapshot to ``heap-<pid>-<epoch>.json`` (under
-  ``HEAP_DUMP_DIR``, default ``/tmp``) so operators can diagnose RSS vs. Ruby
-  heap growth in running production containers without attaching GDB or
-  restarting with extra instrumentation. The dump runs in a spawned thread
-  (``ObjectSpace.dump_all`` is not signal-safe) and the handler is installed in
-  the Puma/Sneakers master and inherited by forked workers. A companion
-  ``scripts/analyze-heapdump`` summarizes a dump (object counts by type, bytes
-  by type, top STRING allocation sites). (#3366)
+- Opt-in on-demand heap dumps for diagnosing memory growth. When
+  ``HEAP_DUMP_ENABLED`` is set (default off), every OTS process (web, scheduler,
+  worker, CLI) installs a ``SIGUSR2`` handler at boot; ``kill -USR2 <pid>``
+  writes an ``ObjectSpace.dump_all`` snapshot to ``heap-<pid>-<epoch>.json``
+  (under ``HEAP_DUMP_DIR``, default ``/var/tmp``) so operators can diagnose RSS
+  vs. Ruby heap growth without attaching GDB or restarting with extra
+  instrumentation. The dump runs in a spawned thread (``ObjectSpace.dump_all``
+  is not signal-safe) and the handler is installed in the Puma/Sneakers master
+  and inherited by forked workers. A companion ``scripts/analyze-heapdump``
+  summarizes a dump (object counts by type, bytes by type, top STRING
+  allocation sites). (#3366)
 
 Security
 --------
 
-- Heap dumps are written owner-only (``0600``) and created exclusively
-  (``O_EXCL``) so they cannot clobber or follow a pre-planted symlink in a
-  shared ``/tmp``. A dump serializes live String values, so it contains
-  plaintext secrets and key material — treat the file as a credential and
-  delete it after analysis. (#3366)
+- Heap dumps are off by default and gated behind ``HEAP_DUMP_ENABLED``: a dump
+  serializes live String values, so it contains plaintext secrets and key
+  material, and the handler is a memory-disclosure primitive that bypasses the
+  default container ptrace restriction. When enabled, dumps are written
+  owner-only (``0600``) and created exclusively (``O_EXCL``) so they cannot
+  clobber or follow a pre-planted symlink in a shared directory. Treat a dump
+  file as a credential and delete it after analysis. (#3366)
 
 AI Assistance
 -------------

--- a/changelog.d/20260607_000000_claude_3366_heap_dump_handler.rst
+++ b/changelog.d/20260607_000000_claude_3366_heap_dump_handler.rst
@@ -1,0 +1,21 @@
+.. A new scriv changelog fragment.
+
+Added
+-----
+
+- All OTS processes (web, scheduler, worker, CLI) now install a ``SIGUSR2``
+  heap dump handler at boot. Sending ``kill -USR2 <pid>`` writes an
+  ``ObjectSpace.dump_all`` snapshot to ``heap-<pid>-<epoch>.json`` (under
+  ``HEAP_DUMP_DIR``, default ``/tmp``) so operators can diagnose RSS vs. Ruby
+  heap growth in running production containers without attaching GDB or
+  restarting with extra instrumentation. The dump runs in a spawned thread
+  (``ObjectSpace.dump_all`` is not signal-safe) and the handler is installed in
+  the Puma/Sneakers master and inherited by forked workers. A companion
+  ``scripts/analyze-heapdump`` summarizes a dump (object counts by type, bytes
+  by type, top STRING allocation sites). (#3366)
+
+AI Assistance
+-------------
+
+- Heap dump boot initializer, analysis script, and tests drafted with AI
+  assistance. (#3366)

--- a/lib/onetime/initializers.rb
+++ b/lib/onetime/initializers.rb
@@ -23,6 +23,7 @@ require_relative 'initializers/configure_truemail'
 require_relative 'initializers/configure_rhales'
 require_relative 'initializers/configure_trusted_proxy'
 require_relative 'initializers/load_fortunes'
+require_relative 'initializers/setup_heap_dump_handler'
 
 # Dependent initializers
 require_relative 'initializers/validate_auth_config'    # depends_on: [:logging]

--- a/lib/onetime/initializers/setup_heap_dump_handler.rb
+++ b/lib/onetime/initializers/setup_heap_dump_handler.rb
@@ -1,0 +1,60 @@
+# lib/onetime/initializers/setup_heap_dump_handler.rb
+#
+# frozen_string_literal: true
+
+module Onetime
+  module Initializers
+    # SetupHeapDumpHandler initializer
+    #
+    # Installs a SIGUSR2 signal handler that writes an ObjectSpace heap dump
+    # to disk on demand. This gives operators a way to capture a Ruby heap
+    # snapshot from a running process without attaching GDB or restarting with
+    # extra instrumentation, which makes diagnosing RSS growth vs. Ruby heap
+    # growth in production containers significantly easier.
+    #
+    # Because this runs as a boot initializer, the handler is installed once for
+    # every OTS process regardless of execution mode (:web, :scheduler, :worker,
+    # :cli). In Puma/Sneakers cluster mode the handler is installed in the master
+    # process and inherited by forked workers — this is why the initializer is
+    # NOT marked @phase = :fork_sensitive. Marking it fork-sensitive would cause
+    # cleanup_before_fork to tear it down before workers are spawned, leaving
+    # them without the handler.
+    #
+    # Usage (after deploy):
+    #   podman exec <container> kill -USR2 <pid>
+    #   # then analyze the dump with: scripts/analyze-heapdump <file>
+    #
+    # The dump is written to HEAP_DUMP_DIR (default /tmp) as
+    # heap-<pid>-<epoch>.json. Process.pid in the filename disambiguates master
+    # vs. worker dumps in cluster mode.
+    #
+    class SetupHeapDumpHandler < Onetime::Boot::Initializer
+      @provides = [:heap_dump]
+      # Failing to install a diagnostic signal handler (e.g. USR2 unavailable on
+      # the platform) must never block application boot.
+      @optional = true
+
+      # Directory where heap dumps are written. Overridable so containers with a
+      # locked-down /tmp can redirect dumps to a writable volume.
+      DUMP_DIR = ENV.fetch('HEAP_DUMP_DIR', '/tmp')
+
+      def execute(_context)
+        Signal.trap('USR2') do
+          # ObjectSpace.dump_all is not signal-safe; running it directly in the
+          # trap context can deadlock or corrupt VM state. Spawning a thread
+          # defers the work to a normal execution context.
+          Thread.new do
+            require 'objspace'
+            path = File.join(DUMP_DIR, "heap-#{Process.pid}-#{Time.now.to_i}.json")
+            File.open(path, 'w') { |f| ObjectSpace.dump_all(output: f) }
+            Onetime.boot_logger.info "[heap] Dump written to #{path}"
+          rescue StandardError => ex
+            Onetime.boot_logger.error "[heap] Dump failed: #{ex.class}: #{ex.message}"
+          end
+        end
+
+        Onetime.boot_logger.debug "[init] SIGUSR2 heap dump handler installed (dir=#{DUMP_DIR})"
+      end
+    end
+  end
+end

--- a/lib/onetime/initializers/setup_heap_dump_handler.rb
+++ b/lib/onetime/initializers/setup_heap_dump_handler.rb
@@ -64,21 +64,32 @@ module Onetime
       end
 
       def execute(_context)
+        # Load objspace once here (execute only runs when the feature is
+        # enabled) rather than acquiring the require-mutex inside the thread
+        # spawned on every signal. require is idempotent.
+        require 'objspace'
+
         Signal.trap('USR2') do
           # ObjectSpace.dump_all is not signal-safe; running it directly in the
           # trap context can deadlock or corrupt VM state. Spawning a thread
           # defers the work to a normal execution context.
           Thread.new do
-            require 'objspace'
-            path = File.join(DUMP_DIR, "heap-#{Process.pid}-#{Time.now.to_i}.json")
+            path    = File.join(DUMP_DIR, "heap-#{Process.pid}-#{Time.now.to_i}.json")
+            created = false
             # WRONLY|CREAT|EXCL + 0600: the dump contains plaintext secrets, so
             # create it owner-only and refuse to write through an existing file
             # or symlink (anti-clobber in a shared directory).
             File.open(path, File::WRONLY | File::CREAT | File::EXCL, 0o600) do |f|
+              created = true
               ObjectSpace.dump_all(output: f)
             end
             Onetime.boot_logger.info "[heap] Dump written to #{path}"
           rescue StandardError => ex
+            # If dump_all raised mid-write we own a partial file that also holds
+            # plaintext secrets: remove it so it neither lingers nor masks the
+            # real cause as Errno::EEXIST on the next dump. Only delete a file we
+            # created — an EEXIST from the open above is not ours to remove.
+            File.delete(path) if created && File.exist?(path)
             Onetime.boot_logger.error "[heap] Dump failed: #{ex.class}: #{ex.message}"
           end
         end

--- a/lib/onetime/initializers/setup_heap_dump_handler.rb
+++ b/lib/onetime/initializers/setup_heap_dump_handler.rb
@@ -12,6 +12,12 @@ module Onetime
     # extra instrumentation, which makes diagnosing RSS growth vs. Ruby heap
     # growth in production containers significantly easier.
     #
+    # Opt-in: the handler is only installed when HEAP_DUMP_ENABLED is truthy
+    # (default off). It is a development/diagnostic tool, not an always-armed
+    # production primitive — see SECURITY below. Enabling it on a read-only
+    # podman container requires mounting a writable HEAP_DUMP_DIR and restarting
+    # anyway, so gating at boot time costs nothing operationally.
+    #
     # Because this runs as a boot initializer, the handler is installed once for
     # every OTS process regardless of execution mode (:web, :scheduler, :worker,
     # :cli). In Puma/Sneakers cluster mode the handler is installed in the master
@@ -20,21 +26,24 @@ module Onetime
     # cleanup_before_fork to tear it down before workers are spawned, leaving
     # them without the handler.
     #
-    # Usage (after deploy):
+    # Usage (after enabling and restarting):
     #   podman exec <container> kill -USR2 <pid>
     #   # then analyze the dump with: scripts/analyze-heapdump <file>
     #
-    # The dump is written to HEAP_DUMP_DIR (default /tmp) as
+    # The dump is written to HEAP_DUMP_DIR (default /var/tmp) as
     # heap-<pid>-<epoch>.json. Process.pid in the filename disambiguates master
-    # vs. worker dumps in cluster mode.
+    # vs. worker dumps in cluster mode. /var/tmp (not /tmp) is the default
+    # because Debian 13 mounts /tmp as tmpfs — a large dump there consumes RAM
+    # (counting against the container's MemoryMax) and is lost on restart,
+    # whereas /var/tmp is disk-backed and persists.
     #
     # SECURITY: ObjectSpace.dump_all serializes the `value` of every live
     # String, so a heap dump captured while secrets are in memory contains
     # plaintext secrets, session tokens, and derived key material. The dump is
     # therefore written owner-only (0600) and created exclusively (O_EXCL) so it
-    # cannot clobber or follow a pre-planted symlink in a shared /tmp. Treat the
-    # resulting file as a credential: restrict, transfer securely, and delete it
-    # once analysis is complete.
+    # cannot clobber or follow a pre-planted symlink in a shared directory. Treat
+    # the resulting file as a credential: restrict, transfer securely, and delete
+    # it once analysis is complete.
     #
     class SetupHeapDumpHandler < Onetime::Boot::Initializer
       @provides = [:heap_dump]
@@ -42,9 +51,17 @@ module Onetime
       # the platform) must never block application boot.
       @optional = true
 
-      # Directory where heap dumps are written. Overridable so containers with a
-      # locked-down /tmp can redirect dumps to a writable volume.
-      DUMP_DIR = ENV.fetch('HEAP_DUMP_DIR', '/tmp')
+      # Directory where heap dumps are written. Overridable so deployments can
+      # redirect dumps to a writable, disk-backed volume. Defaults to /var/tmp
+      # (disk-backed and persistent on Debian 13, unlike the tmpfs /tmp).
+      DUMP_DIR = ENV.fetch('HEAP_DUMP_DIR', '/var/tmp')
+
+      # Default-off: only install the handler when HEAP_DUMP_ENABLED is truthy.
+      # Skipping here means the trap is never registered, so a disabled deploy
+      # carries zero runtime surface for this diagnostic primitive.
+      def should_skip?
+        !Onetime::Utils.yes?(ENV.fetch('HEAP_DUMP_ENABLED', nil))
+      end
 
       def execute(_context)
         Signal.trap('USR2') do
@@ -56,7 +73,7 @@ module Onetime
             path = File.join(DUMP_DIR, "heap-#{Process.pid}-#{Time.now.to_i}.json")
             # WRONLY|CREAT|EXCL + 0600: the dump contains plaintext secrets, so
             # create it owner-only and refuse to write through an existing file
-            # or symlink (anti-clobber in a shared /tmp).
+            # or symlink (anti-clobber in a shared directory).
             File.open(path, File::WRONLY | File::CREAT | File::EXCL, 0o600) do |f|
               ObjectSpace.dump_all(output: f)
             end

--- a/lib/onetime/initializers/setup_heap_dump_handler.rb
+++ b/lib/onetime/initializers/setup_heap_dump_handler.rb
@@ -28,6 +28,14 @@ module Onetime
     # heap-<pid>-<epoch>.json. Process.pid in the filename disambiguates master
     # vs. worker dumps in cluster mode.
     #
+    # SECURITY: ObjectSpace.dump_all serializes the `value` of every live
+    # String, so a heap dump captured while secrets are in memory contains
+    # plaintext secrets, session tokens, and derived key material. The dump is
+    # therefore written owner-only (0600) and created exclusively (O_EXCL) so it
+    # cannot clobber or follow a pre-planted symlink in a shared /tmp. Treat the
+    # resulting file as a credential: restrict, transfer securely, and delete it
+    # once analysis is complete.
+    #
     class SetupHeapDumpHandler < Onetime::Boot::Initializer
       @provides = [:heap_dump]
       # Failing to install a diagnostic signal handler (e.g. USR2 unavailable on
@@ -46,7 +54,12 @@ module Onetime
           Thread.new do
             require 'objspace'
             path = File.join(DUMP_DIR, "heap-#{Process.pid}-#{Time.now.to_i}.json")
-            File.open(path, 'w') { |f| ObjectSpace.dump_all(output: f) }
+            # WRONLY|CREAT|EXCL + 0600: the dump contains plaintext secrets, so
+            # create it owner-only and refuse to write through an existing file
+            # or symlink (anti-clobber in a shared /tmp).
+            File.open(path, File::WRONLY | File::CREAT | File::EXCL, 0o600) do |f|
+              ObjectSpace.dump_all(output: f)
+            end
             Onetime.boot_logger.info "[heap] Dump written to #{path}"
           rescue StandardError => ex
             Onetime.boot_logger.error "[heap] Dump failed: #{ex.class}: #{ex.message}"

--- a/scripts/analyze-heapdump
+++ b/scripts/analyze-heapdump
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+# scripts/analyze-heapdump
+
+##
+# HEAP DUMP ANALYSIS SCRIPT
+#
+# Summarizes an ObjectSpace.dump_all heap dump (JSON lines) produced by the
+# SIGUSR2 heap dump handler (see lib/onetime/initializers/setup_heap_dump_handler.rb).
+#
+# Produces three passes:
+#   1. Object counts by type        (what is there a lot of?)
+#   2. Total bytes by type          (what is using the most memory?)
+#   3. Top STRING allocation sites  (where are strings being created?)
+#
+# Usage:
+#   scripts/analyze-heapdump /tmp/heap-<pid>-<epoch>.json
+#
+# Capture a dump first with:
+#   kill -USR2 <pid>          # or: podman exec <container> kill -USR2 <pid>
+#
+# For reference-chain analysis (why is an object still alive), use `sheap`.
+#
+# Requires: jq, awk, sort, uniq
+#
+# Exit codes:
+#   0 - Analysis completed
+#   1 - Missing argument, file not found, or jq unavailable
+
+set -euo pipefail
+
+DUMP="${1:-}"
+
+if [[ -z "$DUMP" ]]; then
+  echo "Usage: $0 <heap-dump.json>" >&2
+  exit 1
+fi
+
+if [[ ! -f "$DUMP" ]]; then
+  echo "Error: file not found: $DUMP" >&2
+  exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "Error: jq is required but not installed" >&2
+  exit 1
+fi
+
+echo "=== Object counts by type (top 20) ==="
+jq -r '.type' "$DUMP" | sort | uniq -c | sort -rn | head -20
+
+echo
+echo "=== Total bytes by type (descending) ==="
+jq -r 'select(.memsize) | "\(.type) \(.memsize)"' "$DUMP" \
+  | awk '{sum[$1]+=$2} END {for (t in sum) print sum[t], t}' | sort -rn
+
+echo
+echo "=== Top STRING allocation sites (file:line, top 20) ==="
+jq -r 'select(.type=="STRING" and .file) | "\(.file):\(.line)"' "$DUMP" \
+  | sort | uniq -c | sort -rn | head -20

--- a/scripts/analyze-heapdump
+++ b/scripts/analyze-heapdump
@@ -19,6 +19,9 @@
 # Capture a dump first with:
 #   kill -USR2 <pid>          # or: podman exec <container> kill -USR2 <pid>
 #
+# SECURITY: a heap dump contains plaintext secrets and key material that were
+# live in memory. Treat the dump file as a credential and delete it when done.
+#
 # For reference-chain analysis (why is an object still alive), use `sheap`.
 #
 # Requires: jq, awk, sort, uniq

--- a/scripts/analyze-heapdump
+++ b/scripts/analyze-heapdump
@@ -14,7 +14,8 @@
 #   3. Top STRING allocation sites  (where are strings being created?)
 #
 # Usage:
-#   scripts/analyze-heapdump /tmp/heap-<pid>-<epoch>.json
+#   scripts/analyze-heapdump /var/tmp/heap-<pid>-<epoch>.json
+#   (the handler writes to HEAP_DUMP_DIR, default /var/tmp)
 #
 # Capture a dump first with:
 #   kill -USR2 <pid>          # or: podman exec <container> kill -USR2 <pid>

--- a/spec/unit/onetime/initializers/setup_heap_dump_handler_spec.rb
+++ b/spec/unit/onetime/initializers/setup_heap_dump_handler_spec.rb
@@ -28,6 +28,40 @@ RSpec.describe Onetime::Initializers::SetupHeapDumpHandler do
       # before Puma/Sneakers workers are spawned, losing the handler.
       expect(described_class.phase).to eq(:preload)
     end
+
+    it 'defaults the dump directory to the disk-backed /var/tmp' do
+      # /tmp is tmpfs on Debian 13; a large dump there consumes RAM and is lost
+      # on restart, so the default must be disk-backed.
+      expect(described_class::DUMP_DIR).to eq('/var/tmp')
+    end
+  end
+
+  describe '#should_skip?' do
+    around do |example|
+      original = ENV.fetch('HEAP_DUMP_ENABLED', nil)
+      example.run
+    ensure
+      if original.nil?
+        ENV.delete('HEAP_DUMP_ENABLED')
+      else
+        ENV['HEAP_DUMP_ENABLED'] = original
+      end
+    end
+
+    it 'skips (handler not installed) when HEAP_DUMP_ENABLED is unset' do
+      ENV.delete('HEAP_DUMP_ENABLED')
+      expect(instance.should_skip?).to be true
+    end
+
+    it 'skips when HEAP_DUMP_ENABLED is a falsey value' do
+      ENV['HEAP_DUMP_ENABLED'] = 'false'
+      expect(instance.should_skip?).to be true
+    end
+
+    it 'runs when HEAP_DUMP_ENABLED is truthy' do
+      ENV['HEAP_DUMP_ENABLED'] = 'true'
+      expect(instance.should_skip?).to be false
+    end
   end
 
   describe '#execute' do

--- a/spec/unit/onetime/initializers/setup_heap_dump_handler_spec.rb
+++ b/spec/unit/onetime/initializers/setup_heap_dump_handler_spec.rb
@@ -76,6 +76,18 @@ RSpec.describe Onetime::Initializers::SetupHeapDumpHandler do
         expect { @handler.call }.not_to raise_error
         expect(logger).to have_received(:error).with(/\[heap\] Dump failed: Errno::EACCES/)
       end
+
+      it 'creates the dump owner-only and refuses to follow an existing file' do
+        # The dump contains plaintext secrets; it must be 0600 and must not
+        # clobber/follow a pre-existing path (symlink defense in a shared /tmp).
+        expect(File).to receive(:open)
+          .with(anything, File::WRONLY | File::CREAT | File::EXCL, 0o600)
+          .and_yield(fake_io)
+
+        instance.execute(context)
+        @handler.call
+        expect(ObjectSpace).to have_received(:dump_all).with(output: fake_io)
+      end
     end
   end
 end

--- a/spec/unit/onetime/initializers/setup_heap_dump_handler_spec.rb
+++ b/spec/unit/onetime/initializers/setup_heap_dump_handler_spec.rb
@@ -1,0 +1,81 @@
+# spec/unit/onetime/initializers/setup_heap_dump_handler_spec.rb
+#
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'onetime/initializers/setup_heap_dump_handler'
+
+RSpec.describe Onetime::Initializers::SetupHeapDumpHandler do
+  let(:instance) { described_class.new }
+  let(:context) { double('context') }
+  let(:logger) { instance_double('SemanticLogger::Logger', info: nil, error: nil, debug: nil) }
+
+  before do
+    allow(Onetime).to receive(:boot_logger).and_return(logger)
+  end
+
+  describe 'metadata' do
+    it 'provides the :heap_dump capability' do
+      expect(described_class.provides).to eq([:heap_dump])
+    end
+
+    it 'is optional so a failed handler install never blocks boot' do
+      expect(described_class.optional).to be true
+    end
+
+    it 'is NOT fork-sensitive so forked workers inherit the handler' do
+      # Marking it :fork_sensitive would have cleanup_before_fork tear it down
+      # before Puma/Sneakers workers are spawned, losing the handler.
+      expect(described_class.phase).to eq(:preload)
+    end
+  end
+
+  describe '#execute' do
+    after do
+      # Restore default disposition so the installed trap does not leak into
+      # other examples.
+      Signal.trap('USR2', 'DEFAULT')
+    end
+
+    it 'installs a USR2 signal handler' do
+      expect(Signal).to receive(:trap).with('USR2')
+      instance.execute(context)
+    end
+
+    it 'logs that the handler was installed' do
+      allow(Signal).to receive(:trap)
+      instance.execute(context)
+      expect(logger).to have_received(:debug).with(/heap dump handler installed/)
+    end
+
+    context 'when the trap fires' do
+      let(:fake_io) { StringIO.new }
+
+      before do
+        # Capture the trap block instead of installing it, and run any spawned
+        # thread synchronously for deterministic assertions.
+        @handler = nil
+        allow(Signal).to receive(:trap).with('USR2') { |&block| @handler = block }
+        allow(Thread).to receive(:new).and_yield
+        allow(File).to receive(:open).and_yield(fake_io)
+        allow(ObjectSpace).to receive(:dump_all)
+      end
+
+      it 'writes a heap dump and logs the path' do
+        instance.execute(context)
+        @handler.call
+
+        expect(ObjectSpace).to have_received(:dump_all).with(output: fake_io)
+        expect(logger).to have_received(:info).with(%r{\[heap\] Dump written to .*heap-#{Process.pid}-\d+\.json})
+      end
+
+      it 'logs an error instead of raising when the dump fails' do
+        allow(ObjectSpace).to receive(:dump_all).and_raise(Errno::EACCES, 'no write')
+
+        instance.execute(context)
+        expect { @handler.call }.not_to raise_error
+        expect(logger).to have_received(:error).with(/\[heap\] Dump failed: Errno::EACCES/)
+      end
+    end
+  end
+end

--- a/spec/unit/onetime/initializers/setup_heap_dump_handler_spec.rb
+++ b/spec/unit/onetime/initializers/setup_heap_dump_handler_spec.rb
@@ -111,6 +111,27 @@ RSpec.describe Onetime::Initializers::SetupHeapDumpHandler do
         expect(logger).to have_received(:error).with(/\[heap\] Dump failed: Errno::EACCES/)
       end
 
+      it 'removes the partial, secret-bearing file when the write fails mid-stream' do
+        allow(ObjectSpace).to receive(:dump_all).and_raise(Errno::ENOSPC, 'disk full')
+        allow(File).to receive(:exist?).and_call_original
+        allow(File).to receive(:exist?).with(a_string_matching(/heap-#{Process.pid}-\d+\.json/)).and_return(true)
+        expect(File).to receive(:delete).with(a_string_matching(/heap-#{Process.pid}-\d+\.json/))
+
+        instance.execute(context)
+        captured[:handler].call
+      end
+
+      it 'does not delete a pre-existing file when exclusive creation is refused' do
+        # An EEXIST from the O_EXCL open means the file is not ours (a leftover
+        # or a symlink-attack target) — deleting it would defeat the guard.
+        allow(File).to receive(:open).and_raise(Errno::EEXIST, 'exists')
+        expect(File).not_to receive(:delete)
+
+        instance.execute(context)
+        expect { captured[:handler].call }.not_to raise_error
+        expect(logger).to have_received(:error).with(/\[heap\] Dump failed: Errno::EEXIST/)
+      end
+
       it 'creates the dump owner-only and refuses to follow an existing file' do
         # The dump contains plaintext secrets; it must be 0600 and must not
         # clobber/follow a pre-existing path (symlink defense in a shared dir).

--- a/spec/unit/onetime/initializers/setup_heap_dump_handler_spec.rb
+++ b/spec/unit/onetime/initializers/setup_heap_dump_handler_spec.rb
@@ -3,6 +3,7 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require 'objspace' # define ObjectSpace.dump_all so verifying doubles can stub it
 require 'onetime/initializers/setup_heap_dump_handler'
 
 RSpec.describe Onetime::Initializers::SetupHeapDumpHandler do
@@ -65,11 +66,8 @@ RSpec.describe Onetime::Initializers::SetupHeapDumpHandler do
   end
 
   describe '#execute' do
-    after do
-      # Restore default disposition so the installed trap does not leak into
-      # other examples.
-      Signal.trap('USR2', 'DEFAULT')
-    end
+    # Every example here stubs Signal.trap, so no real USR2 handler is ever
+    # installed in the test process — nothing to restore afterwards.
 
     it 'installs a USR2 signal handler' do
       expect(Signal).to receive(:trap).with('USR2')
@@ -84,12 +82,14 @@ RSpec.describe Onetime::Initializers::SetupHeapDumpHandler do
 
     context 'when the trap fires' do
       let(:fake_io) { StringIO.new }
+      # Mutable container holding the USR2 handler block captured from the
+      # stubbed Signal.trap (avoids an example-scoped instance variable).
+      let(:captured) { {} }
 
       before do
         # Capture the trap block instead of installing it, and run any spawned
         # thread synchronously for deterministic assertions.
-        @handler = nil
-        allow(Signal).to receive(:trap).with('USR2') { |&block| @handler = block }
+        allow(Signal).to receive(:trap).with('USR2') { |&block| captured[:handler] = block }
         allow(Thread).to receive(:new).and_yield
         allow(File).to receive(:open).and_yield(fake_io)
         allow(ObjectSpace).to receive(:dump_all)
@@ -97,7 +97,7 @@ RSpec.describe Onetime::Initializers::SetupHeapDumpHandler do
 
       it 'writes a heap dump and logs the path' do
         instance.execute(context)
-        @handler.call
+        captured[:handler].call
 
         expect(ObjectSpace).to have_received(:dump_all).with(output: fake_io)
         expect(logger).to have_received(:info).with(%r{\[heap\] Dump written to .*heap-#{Process.pid}-\d+\.json})
@@ -107,19 +107,19 @@ RSpec.describe Onetime::Initializers::SetupHeapDumpHandler do
         allow(ObjectSpace).to receive(:dump_all).and_raise(Errno::EACCES, 'no write')
 
         instance.execute(context)
-        expect { @handler.call }.not_to raise_error
+        expect { captured[:handler].call }.not_to raise_error
         expect(logger).to have_received(:error).with(/\[heap\] Dump failed: Errno::EACCES/)
       end
 
       it 'creates the dump owner-only and refuses to follow an existing file' do
         # The dump contains plaintext secrets; it must be 0600 and must not
-        # clobber/follow a pre-existing path (symlink defense in a shared /tmp).
+        # clobber/follow a pre-existing path (symlink defense in a shared dir).
         expect(File).to receive(:open)
           .with(anything, File::WRONLY | File::CREAT | File::EXCL, 0o600)
           .and_yield(fake_io)
 
         instance.execute(context)
-        @handler.call
+        captured[:handler].call
         expect(ObjectSpace).to have_received(:dump_all).with(output: fake_io)
       end
     end


### PR DESCRIPTION
## Summary

Fixes #3366

Adds an opt-in `SIGUSR2` signal handler that enables operators to capture Ruby heap snapshots from running processes on demand, without requiring GDB attachment or process restart. This facilitates diagnosing RSS vs. Ruby heap growth in production containers.

## Changes

- **SetupHeapDumpHandler initializer**: Installs a `SIGUSR2` handler at boot (when `HEAP_DUMP_ENABLED` is truthy) that spawns a thread to write `ObjectSpace.dump_all` output to `HEAP_DUMP_DIR/heap-<pid>-<epoch>.json`. The handler is installed in the master process and inherited by forked Puma/Sneakers workers.

- **analyze-heapdump script**: Companion analysis tool that summarizes heap dumps with three passes: object counts by type, total bytes by type, and top STRING allocation sites.

- **Security**: Dumps are off by default and gated behind `HEAP_DUMP_ENABLED`. When enabled, dumps are written owner-only (0600) and created exclusively (O_EXCL) to prevent symlink attacks in shared directories. Dumps contain plaintext secrets and key material and should be treated as credentials.

- **Configuration**: Added `HEAP_DUMP_ENABLED` and `HEAP_DUMP_DIR` environment variables to `.env.reference` with documentation.

## Related Issues

Fixes #3366

## Test Plan

Added comprehensive unit tests in `spec/unit/onetime/initializers/setup_heap_dump_handler_spec.rb` covering:
- Metadata (provides, optional, phase, default dump directory)
- Skip logic based on `HEAP_DUMP_ENABLED` environment variable
- Signal handler installation and logging
- Heap dump generation with proper file permissions (0600, O_EXCL)
- Error handling when dump fails
- Thread spawning for signal-safe execution

All tests pass; the initializer is marked optional so handler installation failures never block boot.

https://claude.ai/code/session_01AAuQ6BbkyaHZvwE93Je68h