### PR TITLE
Fix incoming secrets UI and API gate when install-level feature is disabled

### DIFF
--- a/apps/web/core/spec/views/serializers/config_serializer_spec.rb
+++ b/apps/web/core/spec/views/serializers/config_serializer_spec.rb
@@ -476,6 +476,7 @@ RSpec.describe Core::Views::ConfigSerializer do
         let(:view_vars_with_incoming) do
           base_view_vars.merge(
             'features' => base_view_vars['features'].merge(
+              'incoming' => { 'enabled' => false },
               'organizations' => { 'enabled' => false, 'incoming_secrets_enabled' => true }
             )
           )

--- a/apps/web/core/spec/views/serializers/config_serializer_spec.rb
+++ b/apps/web/core/spec/views/serializers/config_serializer_spec.rb
@@ -472,10 +472,27 @@ RSpec.describe Core::Views::ConfigSerializer do
         end
       end
 
-      context 'when incoming_secrets_enabled is true' do
+      context 'when incoming_secrets_enabled is true but install-level incoming.enabled is false' do
         let(:view_vars_with_incoming) do
           base_view_vars.merge(
             'features' => base_view_vars['features'].merge(
+              'organizations' => { 'enabled' => false, 'incoming_secrets_enabled' => true }
+            )
+          )
+        end
+
+        it 'returns incoming_secrets_enabled as false (install gate takes precedence)' do
+          result = described_class.build_feature_flags(view_vars_with_incoming)
+
+          expect(result['organizations']['incoming_secrets_enabled']).to be false
+        end
+      end
+
+      context 'when both incoming_secrets_enabled and install-level incoming.enabled are true' do
+        let(:view_vars_with_incoming) do
+          base_view_vars.merge(
+            'features' => base_view_vars['features'].merge(
+              'incoming' => { 'enabled' => true },
               'organizations' => { 'enabled' => false, 'incoming_secrets_enabled' => true }
             )
           )
@@ -501,6 +518,7 @@ RSpec.describe Core::Views::ConfigSerializer do
         let(:view_vars_all_orgs) do
           base_view_vars.merge(
             'features' => base_view_vars['features'].merge(
+              'incoming' => { 'enabled' => true },
               'organizations' => {
                 'enabled' => true,
                 'sso_enabled' => true,
@@ -526,6 +544,7 @@ RSpec.describe Core::Views::ConfigSerializer do
         let(:view_vars_mail_and_incoming_only) do
           base_view_vars.merge(
             'features' => base_view_vars['features'].merge(
+              'incoming' => { 'enabled' => true },
               'organizations' => {
                 'enabled' => true,
                 'sso_enabled' => false,

--- a/apps/web/core/views/serializers/config_serializer.rb
+++ b/apps/web/core/views/serializers/config_serializer.rb
@@ -149,7 +149,8 @@ module Core
               'enabled' => features.dig('organizations', 'enabled') || false,
               'sso_enabled' => features.dig('organizations', 'sso_enabled') || false,
               'custom_mail_enabled' => features.dig('organizations', 'custom_mail_enabled') || false,
-              'incoming_secrets_enabled' => features.dig('organizations', 'incoming_secrets_enabled') || false,
+              'incoming_secrets_enabled' => (features.dig('incoming', 'enabled') &&
+                                              features.dig('organizations', 'incoming_secrets_enabled')) || false,
             },
           }
         end

--- a/locales/content/en/workspace-domains.json
+++ b/locales/content/en/workspace-domains.json
@@ -875,6 +875,12 @@
     "text": "Allow external users to send secrets directly to designated recipients on this domain",
     "content_hash": "452ab4fe"
   },
+  "web.domains.incoming.feature_disabled": {
+    "text": "Incoming Secrets Unavailable"
+  },
+  "web.domains.incoming.feature_disabled_description": {
+    "text": "Incoming secrets is not enabled on this instance. Contact your administrator."
+  },
   "web.domains.incoming.access_denied": {
     "text": "Access Denied",
     "content_hash": "d134ca02"

--- a/src/apps/workspace/domains/DomainIncoming.vue
+++ b/src/apps/workspace/domains/DomainIncoming.vue
@@ -56,6 +56,7 @@ const organization = computed(() =>
 const { can } = useEntitlements(organization);
 const canManageIncoming = computed(() => can(ENTITLEMENTS.INCOMING_SECRETS));
 const billingRoute = computed(() => `/billing/${props.orgid}/plans`);
+const incomingSecretsEnabled = computed(() => isOrgsIncomingSecretsEnabled());
 
 // ---------------------------------------------------------------------------
 // Incoming config composable
@@ -172,7 +173,7 @@ watch(() => props.extid, async () => {
 
       <!-- Feature Disabled at Install Level -->
       <div
-        v-else-if="!isOrgsIncomingSecretsEnabled()"
+        v-else-if="!incomingSecretsEnabled"
         class="rounded-lg border border-gray-200 bg-white p-8 text-center dark:border-gray-700 dark:bg-gray-800">
         <OIcon
           collection="heroicons"

--- a/src/apps/workspace/domains/DomainIncoming.vue
+++ b/src/apps/workspace/domains/DomainIncoming.vue
@@ -23,6 +23,7 @@ import { useIncomingConfig } from '@/shared/composables/useIncomingConfig';
 import { useEntitlements } from '@/shared/composables/useEntitlements';
 import { useOrganizationStore } from '@/shared/stores/organizationStore';
 import { ENTITLEMENTS } from '@/types/organization';
+import { isOrgsIncomingSecretsEnabled } from '@/utils/features';
 
 const { t } = useI18n();
 const router = useRouter();
@@ -167,6 +168,23 @@ watch(() => props.extid, async () => {
       <!-- Error State -->
       <div v-else-if="domainError" class="rounded-lg bg-white p-6 shadow dark:bg-gray-800">
         <BasicFormAlerts :error="domainError.message" />
+      </div>
+
+      <!-- Feature Disabled at Install Level -->
+      <div
+        v-else-if="!isOrgsIncomingSecretsEnabled()"
+        class="rounded-lg border border-gray-200 bg-white p-8 text-center dark:border-gray-700 dark:bg-gray-800">
+        <OIcon
+          collection="heroicons"
+          name="x-circle"
+          class="mx-auto size-12 text-gray-400"
+          aria-hidden="true" />
+        <h3 class="mt-4 text-lg font-semibold text-gray-900 dark:text-white">
+          {{ t('web.domains.incoming.feature_disabled') }}
+        </h3>
+        <p class="mt-2 text-sm text-gray-500 dark:text-gray-400">
+          {{ t('web.domains.incoming.feature_disabled_description') }}
+        </p>
       </div>
 
       <!-- Access Denied / Upgrade Banner -->

--- a/src/tests/apps/workspace/domains/DomainIncoming.spec.ts
+++ b/src/tests/apps/workspace/domains/DomainIncoming.spec.ts
@@ -156,6 +156,11 @@ vi.mock('@/types/organization', () => ({
   },
 }));
 
+let mockIsOrgsIncomingSecretsEnabled = true;
+vi.mock('@/utils/features', () => ({
+  isOrgsIncomingSecretsEnabled: () => mockIsOrgsIncomingSecretsEnabled,
+}));
+
 // ---------------------------------------------------------------------------
 // i18n setup
 // ---------------------------------------------------------------------------
@@ -205,6 +210,7 @@ describe('DomainIncoming', () => {
     vi.clearAllMocks();
 
     // Reset mocks to defaults
+    mockIsOrgsIncomingSecretsEnabled = true;
     mockCanIncoming = ref(true);
     mockDomainState.isLoading.value = false;
     mockDomainState.error.value = null;

--- a/try/unit/config/config_serializer_sso_try.rb
+++ b/try/unit/config/config_serializer_sso_try.rb
@@ -77,10 +77,11 @@ ensure
 end
 
 # Helper to modify organizations feature flags with all four keys
-def with_orgs_features(orgs_enabled: false, sso_enabled: false, custom_mail_enabled: false, incoming_secrets_enabled: false)
+def with_orgs_features(orgs_enabled: false, sso_enabled: false, custom_mail_enabled: false, incoming_secrets_enabled: false, incoming_enabled: incoming_secrets_enabled)
   config = Onetime.auth_config.instance_variable_get(:@config)
   features = config['full']['features'] ||= {}
   original_orgs = features['organizations']
+  original_incoming = features['incoming']
 
   features['organizations'] = {
     'enabled' => orgs_enabled,
@@ -88,12 +89,18 @@ def with_orgs_features(orgs_enabled: false, sso_enabled: false, custom_mail_enab
     'custom_mail_enabled' => custom_mail_enabled,
     'incoming_secrets_enabled' => incoming_secrets_enabled,
   }
+  features['incoming'] = { 'enabled' => incoming_enabled }
   yield
 ensure
   if original_orgs.nil?
     features.delete('organizations')
   else
     features['organizations'] = original_orgs
+  end
+  if original_incoming.nil?
+    features.delete('incoming')
+  else
+    features['incoming'] = original_incoming
   end
 end
 


### PR DESCRIPTION
When the install-level `incoming.enabled` flag is false, the Domains > Incoming page was still showing the full configuration UI rather than a disabled-feature message. This was a two-layer problem: the serializer was not consulting the install-level flag, so `incoming_secrets_enabled` leaked through to the frontend regardless.

## Changes

`config_serializer.rb` — `incoming_secrets_enabled` now requires both `features.incoming.enabled` (install gate) and `features.organizations.incoming_secrets_enabled` to be true. The install flag takes precedence.

`DomainIncoming.vue` — added a guarded render branch that shows an "Incoming Secrets Unavailable" panel before any entitlement or access-denied checks, so users on instances without the feature see a clear explanation instead of a broken or confusing UI.

`workspace-domains.json` — two new English strings for the disabled state (`web.domains.incoming.feature_disabled` and `web.domains.incoming.feature_disabled_description`).

`config_serializer_spec.rb` — test coverage for the new gate: install-level false overrides org-level true; both true passes through. Existing tests updated to set `incoming.enabled: true` so they continue to exercise the enabled path.