### PR TITLE
Guard SsoConfig provider-enumeration drift in CI

### DIFF
--- a/apps/web/auth/spec/unit/domain_sso_config_spec.rb
+++ b/apps/web/auth/spec/unit/domain_sso_config_spec.rb
@@ -381,6 +381,49 @@ RSpec.describe Onetime::CustomDomain::SsoConfig do
     end
   end
 
+  # ==========================================================================
+  # Provider enumeration consistency
+  #
+  # PROVIDER_TYPES is the canonical list of valid SSO providers. Several
+  # in-model structures must enumerate that same set — PROVIDER_METADATA,
+  # PROVIDER_ROUTE_MAP, and the to_omniauth_options dispatch — plus the test
+  # fixtures used to exercise them. SsoConfig has no external strategy registry
+  # to derive from (unlike MailerConfig, whose validation derives from
+  # SenderStrategies), and a case/dispatch statement is code, not data, so these
+  # are kept in lockstep with a guard rather than by construction. Without it, a
+  # provider added to one list but not another would pass validation yet fail at
+  # runtime (e.g. to_omniauth_options raising "Unsupported"). This catches that
+  # drift in CI.
+  # ==========================================================================
+
+  describe 'provider enumeration consistency' do
+    it 'PROVIDER_METADATA covers exactly PROVIDER_TYPES' do
+      expect(described_class::PROVIDER_METADATA.keys.sort)
+        .to eq(described_class::PROVIDER_TYPES.sort)
+    end
+
+    it 'PROVIDER_ROUTE_MAP covers exactly PROVIDER_TYPES' do
+      expect(described_class::PROVIDER_ROUTE_MAP.keys.sort)
+        .to eq(described_class::PROVIDER_TYPES.sort)
+    end
+
+    it 'to_omniauth_options dispatches every PROVIDER_TYPES value' do
+      fake_domain = instance_double(Onetime::CustomDomain, extid: 'cd_guard_extid')
+      allow_any_instance_of(described_class).to receive(:custom_domain).and_return(fake_domain)
+
+      described_class::PROVIDER_TYPES.each do |provider_type|
+        config = build_minimal_domain_sso_config(domain_id: 'guard-domain', provider_type: provider_type)
+        expect { config.to_omniauth_options }
+          .not_to raise_error, "to_omniauth_options has no dispatch branch for '#{provider_type}'"
+      end
+    end
+
+    it 'test fixtures enumerate the same providers as the model' do
+      expect(DomainSsoTestFixtures::PROVIDER_TYPES.map(&:to_s).sort)
+        .to eq(described_class::PROVIDER_TYPES.sort)
+    end
+  end
+
   describe '#requires_domain_filter?' do
     it 'returns true for GitHub' do
       config = build_domain_sso_config(:github)


### PR DESCRIPTION
SsoConfig::PROVIDER_TYPES is the canonical SSO provider list, but several in-model structures must enumerate the same set independently: PROVIDER_METADATA, PROVIDER_ROUTE_MAP, the to_omniauth_options dispatch, and the test fixtures. Unlike MailerConfig (which derives validity from the SenderStrategies registry), SsoConfig has no external registry to derive from and its dispatch is a case statement -- code, not data -- so the sets are kept in lockstep with a guard rather than by construction.

Without this guard, a provider added to one structure but not another would pass validation yet fail at runtime (e.g. to_omniauth_options raising). These four specs catch that drift in CI.

## Summary

Picked from #3370 

## Related Issues

#3357 