### PR TITLE
docs(ses): record #2833 region-through-validation as resolved by design

### DIFF
--- a/docs/architecture/custom-mail-sender-ses.md
+++ b/docs/architecture/custom-mail-sender-ses.md
@@ -47,15 +47,17 @@ delivery while still using SES for sender-domain DKIM provisioning. If
 `CUSTOM_MAIL_PROVIDER` is unset, the provisioning provider falls back to
 `EMAILER_MODE`.
 
-## Regions — two knobs that must agree
+## Regions — two knobs
 
-SES configuration has **two** region settings that serve different layers.
-For a coherent setup, **set both to the same region**:
+SES configuration exposes **two** region settings that serve different layers.
+Set the provisioning region (`EMAILER_REGION`) to the intended region; the
+validation knob is **currently inert** (see the #2833 decision below), but
+keeping both aligned is recommended and future-proofs the config:
 
 | Env var | Drives | Used by |
 |---|---|---|
 | `EMAILER_REGION` (falls back to `AWS_REGION`) | The SES API client endpoint | Provisioning (`create/get/delete_email_identity`) and delivery |
-| `CUSTOM_MAIL_SES_REGION` | `email_providers.ses.region` config | The DNS **validation** strategy |
+| `CUSTOM_MAIL_SES_REGION` | `email_providers.ses.region` config | Validation config only — **currently inert** (see the #2833 decision below) |
 
 ```bash
 EMAILER_REGION=ca-central-1
@@ -68,13 +70,32 @@ CUSTOM_MAIL_SES_REGION=ca-central-1
 > provisioning would fail. **You must set `EMAILER_REGION` (or `EMAILER_MODE=ses`
 > with a real `EMAILER_REGION`) to a valid AWS region when using SES.**
 
-> **Note (#2833):** Threading `CUSTOM_MAIL_SES_REGION` all the way through the
-> `ValidateSenderDomain` interface is tracked separately in
-> [#2833](https://github.com/onetimesecret/onetimesecret/issues/2833). Until that
-> lands, keep the two region values identical so provisioning and validation
-> agree. SES DKIM records are token-based CNAMEs and are region-independent, so a
-> mismatch is only consequential for region-specific records (e.g. MX/bounce
-> endpoints) and for hitting the correct regional SES API.
+> **Decision ([#2833](https://github.com/onetimesecret/onetimesecret/issues/2833) — resolved by design):**
+> `CUSTOM_MAIL_SES_REGION` is **not** threaded through `ValidateSenderDomain`,
+> and it does not need to be. The validation strategies (SES, SendGrid,
+> Lettermint) are uniform: each reads the already-provisioned records from
+> `mailer_config.dns_records` and runs live DNS lookups against them. They
+> generate nothing from a region, so there is no validation-time value for a
+> region to influence. Region is purely a **provisioning / SES-API** concern —
+> the client region comes from `EMAILER_REGION` (→ `AWS_REGION`), and whatever
+> records SES assigns for that region are stored on the `MailerConfig` and read
+> back verbatim at verification.
+>
+> Concretely, `email_providers.ses.region` is merged by `ProviderConfig` but then
+> dropped by the strategy factory (the validation strategies declare no
+> `accepted_options`), so the value is currently inert. SES DKIM records are
+> token-based CNAMEs and region-independent; any region-specific records (e.g. the
+> `feedback-smtp.<region>.amazonses.com` MAIL FROM MX + SPF) must be emitted by
+> **provisioning** (`SESSenderStrategy#provision_dns_records`), not by validation —
+> that work belongs to this SES-promotion effort, not #2833. The earlier #2833
+> premise (a region-parameterized validation strategy that *generated* regional
+> records) predates the refactor to reading provisioned records and no longer
+> applies.
+>
+> Practical guidance is unchanged: set `EMAILER_REGION`/`AWS_REGION` to the
+> intended region. This two-knob region surface is transitional and expected to
+> consolidate, so prefer driving region from the provisioning side and treat
+> `CUSTOM_MAIL_SES_REGION` as a no-op for now.
 
 ## Credentials
 


### PR DESCRIPTION
Docs-only contribution to the SES-promotion effort (#3359). No behavior change.

## Why

While working #2833 (*Expose SES region parameter through `ValidateSenderDomain`*), we found the issue's premise is stale. The SES guide added in this branch still framed region-through-validation as a separate, pending item ("Note (#2833)… until that lands"). It isn't pending — it's **resolved by design**, and the doc should say so.

## The decision

The validation strategies (SES, SendGrid, Lettermint) are **uniform**: each reads the already-provisioned records from `mailer_config.dns_records` and runs live DNS lookups against them. They generate nothing from a region, so there's no validation-time value for a region to influence.

- `email_providers.ses.region` (← `CUSTOM_MAIL_SES_REGION`) is merged by `ProviderConfig` but then **dropped by the strategy factory** — the validation strategies declare no `accepted_options` — so the knob is currently **inert**.
- Region is purely a **provisioning / SES-API** concern: the client region comes from `EMAILER_REGION` (→ `AWS_REGION`, `Mailer#build_provider_config`). Whatever records SES assigns for that region are stored on the `MailerConfig` and read back verbatim at verification.
- The original #2833 premise (a region-parameterized validation strategy that *generated* regional records) predates the refactor to reading provisioned records and no longer applies.
- Any region-specific records (e.g. the `feedback-smtp.<region>.amazonses.com` MAIL FROM MX + SPF) must be emitted by **provisioning** (`SESSenderStrategy#provision_dns_records`), which is this effort's scope — not #2833's.

We deliberately **did not** reintroduce a `region:`/`subdomain:` option on the validation strategies (it would be dead plumbing that only fed a log line), keeping all three on the established Lettermint convention.

## Changes

`docs/architecture/custom-mail-sender-ses.md`:
- Replace the open `Note (#2833)` with a `Decision (#2833 — resolved by design)` record.
- Correct the region table/intro so `CUSTOM_MAIL_SES_REGION` is described as validation config that is currently inert, rather than "used by the validation strategy".
- Note that the two-knob region surface is transitional and expected to consolidate toward the provisioning side.

## Notes

- Targets `claude/hopeful-gates-KQIy2` (the #3359 branch); the diff is just the one doc commit on top of that branch's tip.
- Once merged, #2833 can be closed as resolved-by-design (referencing this decision record).

https://claude.ai/code/session_01854aL2U7Q1XmbTZ8s6MKeS

---
_Generated by [Claude Code](https://claude.ai/code/session_01854aL2U7Q1XmbTZ8s6MKeS)_