### PR TITLE
Promote AWS SES sender-domain provisioning to a supported provider

### DIFF
--- a/.env.reference
+++ b/.env.reference
@@ -197,7 +197,7 @@ ORGS_INCOMING_SECRETS_ENABLED=false
 # Data-residency regions: ca-central-1 (Canada), ap-southeast-2 (Sydney),
 # eu-west-1 (Ireland). Confirm SES is available in your target region.
 # Default: us-east-1
-#EMAIL_PROVIDERS_SES_REGION=us-east-1
+#CUSTOM_MAIL_SES_REGION=us-east-1
 
 # --- SendGrid ---
 # Subdomain for SendGrid domain authentication.

--- a/.env.reference
+++ b/.env.reference
@@ -94,12 +94,6 @@ STDOUT_SYNC=false
 
 EMAILER_MODE=smtp
 
-# Provider for custom mail sender domain provisioning (DNS/DKIM).
-# Decouples domain provisioning from the sending transport above.
-# Valid values: ses, sendgrid, lettermint, smtp
-# If unset, falls back to EMAILER_MODE.
-#CUSTOM_MAIL_PROVIDER=
-
 SMTP_HOST=
 SMTP_PORT=587
 SMTP_USERNAME=
@@ -185,6 +179,12 @@ ORGS_INCOMING_SECRETS_ENABLED=false
 # The provider is selected by CUSTOM_MAIL_PROVIDER (above); these settings
 # configure that provider's DNS record values.
 
+# Provider for custom mail sender domain provisioning (DNS/DKIM).
+# Decouples domain provisioning from the sending transport above.
+# Valid values: ses, sendgrid, lettermint, smtp
+# If unset, falls back to EMAILER_MODE.
+#CUSTOM_MAIL_PROVIDER=
+
 # --- AWS SES ---
 # Select SES as the sender-domain provisioning provider with
 # CUSTOM_MAIL_PROVIDER=ses (above). See docs/architecture/custom-mail-sender-ses.md
@@ -209,11 +209,6 @@ ORGS_INCOMING_SECRETS_ENABLED=false
 #CUSTOM_MAIL_SES_ACCESS_KEY_ID=AKIA...
 #CUSTOM_MAIL_SES_SECRET_ACCESS_KEY=...
 
-# --- SendGrid ---
-# Subdomain for SendGrid domain authentication.
-# Default: em
-#CUSTOM_MAIL_SENDGRID_SUBDOMAIN=em
-
 # --- Lettermint ---
 # Lettermint has TWO separate APIs with different auth:
 #   1. Sending API - uses x-lettermint-token header (project token)
@@ -231,6 +226,9 @@ LETTERMINT_TEAM_TOKEN=
 # API base URL (for enterprise/on-premise deployments).
 # Default: https://api.lettermint.co/v1
 #LETTERMINT_BASE_URL=https://api.lettermint.co/v1
+
+# --- SendGrid ---
+# Coming soon...
 
 
 # ═══════════════════════════════════════════════════════════

--- a/.env.reference
+++ b/.env.reference
@@ -190,10 +190,12 @@ ORGS_INCOMING_SECRETS_ENABLED=false
 # CUSTOM_MAIL_PROVIDER=ses (above). See docs/architecture/custom-mail-sender-ses.md
 # for the full domain-level setup, credentials, and IAM permissions.
 #
-# AWS region for the SES DNS validation strategy.
-# For a coherent setup, keep this equal to EMAILER_REGION (which drives the
-# SES API client for provisioning/delivery). NOTE: EMAILER_REGION defaults to
-# the placeholder 'smtp' — set it to a real region when using SES.
+# NOTE: This knob is currently INERT (#2833, resolved by design). Region is a
+# provisioning/SES-API concern, driven by EMAILER_REGION (-> AWS_REGION); the
+# validation strategies read already-provisioned records and use no region.
+# Set EMAILER_REGION (not this) to a real AWS region when using SES — it
+# defaults to the placeholder 'smtp', which is invalid for SES. Setting this to
+# the same region is harmless and future-proofs the config.
 # Data-residency regions: ca-central-1 (Canada), ap-southeast-2 (Sydney),
 # eu-west-1 (Ireland). Confirm SES is available in your target region.
 # Default: us-east-1

--- a/.env.reference
+++ b/.env.reference
@@ -190,16 +190,14 @@ ORGS_INCOMING_SECRETS_ENABLED=false
 # CUSTOM_MAIL_PROVIDER=ses (above). See docs/architecture/custom-mail-sender-ses.md
 # for the full domain-level setup, credentials, and IAM permissions.
 #
-# NOTE: This knob is currently INERT (#2833, resolved by design). Region is a
-# provisioning/SES-API concern, driven by EMAILER_REGION (-> AWS_REGION); the
-# validation strategies read already-provisioned records and use no region.
-# Set EMAILER_REGION (not this) to a real AWS region when using SES — it
-# defaults to the placeholder 'smtp', which is invalid for SES. Setting this to
-# the same region is harmless and future-proofs the config.
+# AWS region for SES sender-domain provisioning (the SESv2 API client used to
+# create/get/delete email identities). This is INDEPENDENT of EMAILER_REGION,
+# which configures the install-level transactional mailer — so you can run, e.g.,
+# SMTP for transactional email and SES for sender provisioning.
 # Data-residency regions: ca-central-1 (Canada), ap-southeast-2 (Sydney),
 # eu-west-1 (Ireland). Confirm SES is available in your target region.
 # Default: us-east-1
-#CUSTOM_MAIL_SES_REGION=us-east-1
+#EMAIL_PROVIDERS_SES_REGION=us-east-1
 
 # --- SendGrid ---
 # Subdomain for SendGrid domain authentication.

--- a/.env.reference
+++ b/.env.reference
@@ -186,7 +186,16 @@ ORGS_INCOMING_SECRETS_ENABLED=false
 # configure that provider's DNS record values.
 
 # --- AWS SES ---
-# AWS region for SES endpoints (affects MX record values).
+# Select SES as the sender-domain provisioning provider with
+# CUSTOM_MAIL_PROVIDER=ses (above). See docs/architecture/custom-mail-sender-ses.md
+# for the full domain-level setup, credentials, and IAM permissions.
+#
+# AWS region for the SES DNS validation strategy.
+# For a coherent setup, keep this equal to EMAILER_REGION (which drives the
+# SES API client for provisioning/delivery). NOTE: EMAILER_REGION defaults to
+# the placeholder 'smtp' — set it to a real region when using SES.
+# Data-residency regions: ca-central-1 (Canada), ap-southeast-2 (Sydney),
+# eu-west-1 (Ireland). Confirm SES is available in your target region.
 # Default: us-east-1
 #CUSTOM_MAIL_SES_REGION=us-east-1
 

--- a/.env.reference
+++ b/.env.reference
@@ -198,6 +198,16 @@ ORGS_INCOMING_SECRETS_ENABLED=false
 # eu-west-1 (Ireland). Confirm SES is available in your target region.
 # Default: us-east-1
 #CUSTOM_MAIL_SES_REGION=us-east-1
+#
+# AWS credentials for the SES provisioning API, kept independent of the SMTP
+# transactional mailer. If you run authenticated SMTP for delivery
+# (EMAILER_MODE=smtp with SMTP_USERNAME/SMTP_PASSWORD), set these (or the
+# standard AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY, which they fall back to)
+# so the SMTP login is NOT used as the AWS key for SES. Leave unset only when
+# SES is also the delivery backend (EMAILER_MODE=ses) and the emailer already
+# carries the AWS keys.
+#CUSTOM_MAIL_SES_ACCESS_KEY_ID=AKIA...
+#CUSTOM_MAIL_SES_SECRET_ACCESS_KEY=...
 
 # --- SendGrid ---
 # Subdomain for SendGrid domain authentication.

--- a/docs/architecture/custom-mail-sender-ses.md
+++ b/docs/architecture/custom-mail-sender-ses.md
@@ -47,15 +47,17 @@ delivery while still using SES for sender-domain DKIM provisioning. If
 `CUSTOM_MAIL_PROVIDER` is unset, the provisioning provider falls back to
 `EMAILER_MODE`.
 
-## Regions — two knobs that must agree
+## Regions — two knobs
 
-SES configuration has **two** region settings that serve different layers.
-For a coherent setup, **set both to the same region**:
+SES configuration exposes **two** region settings that serve different layers.
+Set the provisioning region (`EMAILER_REGION`) to the intended region; the
+validation knob is **currently inert** (see the #2833 decision below), but
+keeping both aligned is recommended and future-proofs the config:
 
 | Env var | Drives | Used by |
 |---|---|---|
 | `EMAILER_REGION` (falls back to `AWS_REGION`) | The SES API client endpoint | Provisioning (`create/get/delete_email_identity`) and delivery |
-| `CUSTOM_MAIL_SES_REGION` | `email_providers.ses.region` config | The DNS **validation** strategy |
+| `CUSTOM_MAIL_SES_REGION` | `email_providers.ses.region` config | Validation config only — **currently inert** (see the #2833 decision below) |
 
 ```bash
 EMAILER_REGION=ca-central-1
@@ -68,13 +70,32 @@ CUSTOM_MAIL_SES_REGION=ca-central-1
 > provisioning would fail. **You must set `EMAILER_REGION` (or `EMAILER_MODE=ses`
 > with a real `EMAILER_REGION`) to a valid AWS region when using SES.**
 
-> **Note (#2833):** Threading `CUSTOM_MAIL_SES_REGION` all the way through the
-> `ValidateSenderDomain` interface is tracked separately in
-> [#2833](https://github.com/onetimesecret/onetimesecret/issues/2833). Until that
-> lands, keep the two region values identical so provisioning and validation
-> agree. SES DKIM records are token-based CNAMEs and are region-independent, so a
-> mismatch is only consequential for region-specific records (e.g. MX/bounce
-> endpoints) and for hitting the correct regional SES API.
+> **Decision ([#2833](https://github.com/onetimesecret/onetimesecret/issues/2833) — resolved by design):**
+> `CUSTOM_MAIL_SES_REGION` is **not** threaded through `ValidateSenderDomain`,
+> and it does not need to be. The validation strategies (SES, SendGrid,
+> Lettermint) are uniform: each reads the already-provisioned records from
+> `mailer_config.dns_records` and runs live DNS lookups against them. They
+> generate nothing from a region, so there is no validation-time value for a
+> region to influence. Region is purely a **provisioning / SES-API** concern —
+> the client region comes from `EMAILER_REGION` (→ `AWS_REGION`), and whatever
+> records SES assigns for that region are stored on the `MailerConfig` and read
+> back verbatim at verification.
+>
+> Concretely, `email_providers.ses.region` is merged by `ProviderConfig` but then
+> dropped by the strategy factory (the validation strategies declare no
+> `accepted_options`), so the value is currently inert. SES DKIM records are
+> token-based CNAMEs and region-independent; any region-specific records (e.g. the
+> `feedback-smtp.<region>.amazonses.com` MAIL FROM MX + SPF) must be emitted by
+> **provisioning** (`SESSenderStrategy#provision_dns_records`), not by validation —
+> that work belongs to this SES-promotion effort, not #2833. The earlier #2833
+> premise (a region-parameterized validation strategy that *generated* regional
+> records) predates the refactor to reading provisioned records and no longer
+> applies.
+>
+> Practical guidance is unchanged: set `EMAILER_REGION`/`AWS_REGION` to the
+> intended region. This two-knob region surface is transitional and expected to
+> consolidate, so prefer driving region from the provisioning side and treat
+> `CUSTOM_MAIL_SES_REGION` as a no-op for now.
 
 ## Credentials
 

--- a/docs/architecture/custom-mail-sender-ses.md
+++ b/docs/architecture/custom-mail-sender-ses.md
@@ -1,0 +1,194 @@
+# docs/architecture/custom-mail-sender-ses.md
+---
+title: AWS SES Sender Domain Provider
+type: reference
+status: supported
+updated: 2026-06-08
+summary: Configuring AWS SES as the provider for the domain-level custom sender flow (DKIM provisioning, verification, teardown) including region selection and data-residency.
+---
+
+AWS SES is a supported provider for the **domain-level custom sender flow**: when an
+organization enables a custom sender identity on one of its custom domains, the
+platform calls SES on the organization's behalf to register a sender identity,
+returns the DKIM records the customer must add at their registrar, verifies those
+records, and tears the identity down when the sender config is removed.
+
+This document covers the SES-specific configuration. For the provider-agnostic
+design (the three layers, who picks the provider, how credentials flow), see
+[`custom-mail-sender.md`](./custom-mail-sender.md).
+
+## Scope
+
+SES here is the **sender-domain provisioning provider**, selected once per
+installation. It is **not** a per-customer choice and is **not** something an
+end user picks from a dropdown — exactly as with Lettermint, the operator
+configures the provider, and the customer's only decision is "do I want emails
+from my domain to use my from-address/reply-to?" (see the *Customer Decision
+Surface* section of the architecture overview).
+
+The work this provider enables is the **domain-level lifecycle**:
+
+```
+enable custom sender → provision SES identity → show DKIM CNAMEs
+                     → customer adds DNS → verify → (later) delete
+```
+
+## Selecting SES
+
+Set the provisioning provider:
+
+```bash
+CUSTOM_MAIL_PROVIDER=ses
+```
+
+`CUSTOM_MAIL_PROVIDER` decouples *domain provisioning* from the *sending
+transport* (`EMAILER_MODE`). You can run SMTP (or any transport) for outbound
+delivery while still using SES for sender-domain DKIM provisioning. If
+`CUSTOM_MAIL_PROVIDER` is unset, the provisioning provider falls back to
+`EMAILER_MODE`.
+
+## Regions — two knobs that must agree
+
+SES configuration has **two** region settings that serve different layers.
+For a coherent setup, **set both to the same region**:
+
+| Env var | Drives | Used by |
+|---|---|---|
+| `EMAILER_REGION` (falls back to `AWS_REGION`) | The SES API client endpoint | Provisioning (`create/get/delete_email_identity`) and delivery |
+| `CUSTOM_MAIL_SES_REGION` | `email_providers.ses.region` config | The DNS **validation** strategy |
+
+```bash
+EMAILER_REGION=ca-central-1
+CUSTOM_MAIL_SES_REGION=ca-central-1
+```
+
+> **Gotcha:** `EMAILER_REGION` defaults to the literal placeholder `smtp`, not a
+> real AWS region. Because that placeholder is non-empty it wins over
+> `AWS_REGION`, so the SES client would be built with an invalid region and
+> provisioning would fail. **You must set `EMAILER_REGION` (or `EMAILER_MODE=ses`
+> with a real `EMAILER_REGION`) to a valid AWS region when using SES.**
+
+> **Note (#2833):** Threading `CUSTOM_MAIL_SES_REGION` all the way through the
+> `ValidateSenderDomain` interface is tracked separately in
+> [#2833](https://github.com/onetimesecret/onetimesecret/issues/2833). Until that
+> lands, keep the two region values identical so provisioning and validation
+> agree. SES DKIM records are token-based CNAMEs and are region-independent, so a
+> mismatch is only consequential for region-specific records (e.g. MX/bounce
+> endpoints) and for hitting the correct regional SES API.
+
+## Credentials
+
+The SES API client uses standard AWS credentials, resolved (per
+`Mailer.build_provider_config`) from the emailer config with fallback to the
+AWS SDK environment variables:
+
+```bash
+AWS_ACCESS_KEY_ID=AKIA...
+AWS_SECRET_ACCESS_KEY=...
+```
+
+(When `SMTP_USERNAME` / `SMTP_PASSWORD` are left empty, the resolver falls back
+to `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`.)
+
+The IAM principal needs, at minimum:
+
+| Action | Why |
+|---|---|
+| `ses:CreateEmailIdentity` | Register the sender domain identity |
+| `ses:GetEmailIdentity` | Read DKIM tokens and verification status |
+| `ses:DeleteEmailIdentity` | Tear the identity down on sender-config removal |
+| `ses:SendEmail` | Only if SES is also the delivery transport (`EMAILER_MODE=ses`) |
+
+## Domain-level lifecycle
+
+### 1. Provision
+
+`ProvisionSenderDomain` → `SESSenderStrategy#provision_dns_records` calls
+`CreateEmailIdentity` (or `GetEmailIdentity` if the identity already exists) and
+returns three DKIM CNAME records, relative to the sender domain:
+
+```
+<token1>._domainkey  CNAME  <token1>.dkim.amazonses.com
+<token2>._domainkey  CNAME  <token2>.dkim.amazonses.com
+<token3>._domainkey  CNAME  <token3>.dkim.amazonses.com
+```
+
+The tokens are SES-assigned per domain and stored on the `MailerConfig`
+(`provider_dns_data` for the raw response, `dns_records` for the normalized
+records shown to the customer).
+
+### 2. Verify
+
+`ValidateSenderDomain` → `SesValidation` reads the **provisioned** records from
+`mailer_config.dns_records` (never hardcoded placeholders) and performs live DNS
+lookups. Provider-side status is also available via
+`SESSenderStrategy#check_provider_verification_status`, which maps the SES DKIM
+status (`SUCCESS` / `PENDING` / `FAILED` / `TEMPORARY_FAILURE` / `NOT_STARTED`)
+to a human-readable message.
+
+### 3. Delete
+
+Removing the sender config dispatches to
+`SESSenderStrategy#delete_sender_identity`, which calls `DeleteEmailIdentity`.
+A missing identity is treated as already-deleted (idempotent teardown). This is
+covered by the multi-provider deletion dispatch
+([#3369](https://github.com/onetimesecret/onetimesecret/pull/3369)).
+
+## Data residency
+
+Choose the SES region to match the data-residency requirements of the
+installation and its customers. SES sender identities, DKIM key material, and
+sending metadata live in the region you provision against. Notable regions for
+data-residency-sensitive deployments:
+
+| Region | Location |
+|---|---|
+| `ca-central-1` | Canada (Central) |
+| `ap-southeast-2` | Asia Pacific (Sydney) |
+| `eu-west-1` | Europe (Ireland) |
+| `us-east-1` | US East (N. Virginia) — default |
+
+Set both region knobs to the chosen region:
+
+```bash
+EMAILER_REGION=ca-central-1
+CUSTOM_MAIL_SES_REGION=ca-central-1
+```
+
+Note that SES is not available in every AWS region; confirm SES availability for
+your target region before configuring it.
+
+## Minimal example
+
+SMTP transport for delivery, SES for domain-level sender provisioning, pinned to
+Canada Central for data residency:
+
+```bash
+EMAILER_MODE=smtp
+CUSTOM_MAIL_PROVIDER=ses
+EMAILER_REGION=ca-central-1
+CUSTOM_MAIL_SES_REGION=ca-central-1
+AWS_ACCESS_KEY_ID=AKIA...
+AWS_SECRET_ACCESS_KEY=...
+ORGS_CUSTOM_MAIL_ENABLED=true
+```
+
+## Troubleshooting
+
+- DNS verification failures (records not propagating, value mismatches): see
+  [`docs/runbooks/dns-validation-failures.md`](../runbooks/dns-validation-failures.md).
+- Provisioning fails immediately with an invalid-region error: confirm
+  `EMAILER_REGION` is a real region (see the gotcha above), not the `smtp`
+  placeholder.
+- `check_provider_verification_status` returns `not_found`: the identity was
+  never created (or was deleted) — re-run provisioning.
+
+## Key files
+
+| File | Role |
+|---|---|
+| `lib/onetime/mail/sender_strategies/ses_sender_strategy.rb` | Provision / verify-status / delete via `aws-sdk-sesv2` |
+| `lib/onetime/domain_validation/sender_strategies/ses_validation.rb` | DNS validation from provisioned records |
+| `lib/onetime/mail/delivery/ses.rb` | SES delivery backend (only when `EMAILER_MODE=ses`) |
+| `lib/onetime/domain_validation/sender_strategies/provider_config.rb` | `email_providers.ses` config + region validation |
+| `etc/defaults/config.defaults.yaml` | `emailer.sender_provider`, `email_providers.ses.*` |

--- a/docs/architecture/custom-mail-sender-ses.md
+++ b/docs/architecture/custom-mail-sender-ses.md
@@ -49,24 +49,24 @@ delivery while still using SES for sender-domain DKIM provisioning. If
 
 ## Region
 
-The SES provisioning region is set with its own provider-namespaced variable,
+The SES provisioning region is set with its own dedicated variable,
 **independent of the install-level transactional mailer**:
 
 ```bash
-EMAIL_PROVIDERS_SES_REGION=ca-central-1   # default: us-east-1
+CUSTOM_MAIL_SES_REGION=ca-central-1   # default: us-east-1
 ```
 
 This is the deliberate point of `CUSTOM_MAIL_PROVIDER`: sender-domain
 provisioning is decoupled from `EMAILER_MODE` / `EMAILER_REGION` (which configure
 the install's own transactional email transport). An operator can run, say, SMTP
 for transactional mail and SES for sender-domain provisioning, each with its own
-region. `EMAIL_PROVIDERS_SES_REGION` maps to `email_providers.ses.region` in
+region. `CUSTOM_MAIL_SES_REGION` maps to `email_providers.ses.region` in
 config and feeds the SESv2 API client used for provisioning, verification, and
 teardown via `Mailer.provider_credentials('ses')`.
 
 | Setting | Configures | Source |
 |---|---|---|
-| `EMAIL_PROVIDERS_SES_REGION` | SES **sender-domain provisioning** API client | `email_providers.ses.region` → `provider_credentials('ses')` |
+| `CUSTOM_MAIL_SES_REGION` | SES **sender-domain provisioning** API client | `email_providers.ses.region` → `provider_credentials('ses')` |
 | `EMAILER_REGION` (falls back to `AWS_REGION`) | The install's **transactional mailer** (only when `EMAILER_MODE=ses`) | `emailer.region` → delivery backend |
 
 > **Why a dedicated var?** Earlier, the SES provisioning client pulled its region
@@ -82,7 +82,7 @@ teardown via `Mailer.provider_credentials('ses')`.
 > a **provisioning / SES-API** concern. (This is why
 > [#2833](https://github.com/onetimesecret/onetimesecret/issues/2833) — threading
 > a region through `ValidateSenderDomain` — is not needed: the region belongs on
-> the provisioning side, which is exactly what `EMAIL_PROVIDERS_SES_REGION`
+> the provisioning side, which is exactly what `CUSTOM_MAIL_SES_REGION`
 > drives.) Any region-specific *records* (e.g. the
 > `feedback-smtp.<region>.amazonses.com` MAIL FROM MX + SPF) must be emitted by
 > provisioning (`SESSenderStrategy#provision_dns_records`) and are then stored on
@@ -176,7 +176,7 @@ data-residency-sensitive deployments:
 Set the provisioning region to the chosen region:
 
 ```bash
-EMAIL_PROVIDERS_SES_REGION=ca-central-1
+CUSTOM_MAIL_SES_REGION=ca-central-1
 ```
 
 Note that SES is not available in every AWS region; confirm SES availability for
@@ -186,13 +186,13 @@ your target region before configuring it.
 
 SMTP transport for the install's transactional email, SES for domain-level
 sender provisioning, pinned to Canada Central for data residency. Note that the
-SES provisioning region (`EMAIL_PROVIDERS_SES_REGION`) is set independently of
+SES provisioning region (`CUSTOM_MAIL_SES_REGION`) is set independently of
 the transactional mailer:
 
 ```bash
 EMAILER_MODE=smtp
 CUSTOM_MAIL_PROVIDER=ses
-EMAIL_PROVIDERS_SES_REGION=ca-central-1
+CUSTOM_MAIL_SES_REGION=ca-central-1
 AWS_ACCESS_KEY_ID=AKIA...
 AWS_SECRET_ACCESS_KEY=...
 ORGS_CUSTOM_MAIL_ENABLED=true
@@ -203,7 +203,7 @@ ORGS_CUSTOM_MAIL_ENABLED=true
 - DNS verification failures (records not propagating, value mismatches): see
   [`docs/runbooks/dns-validation-failures.md`](../runbooks/dns-validation-failures.md).
 - Provisioning fails immediately with an invalid-region error: confirm
-  `EMAIL_PROVIDERS_SES_REGION` is a valid AWS region where SES is available
+  `CUSTOM_MAIL_SES_REGION` is a valid AWS region where SES is available
   (it defaults to `us-east-1` if unset).
 - `check_provider_verification_status` returns `not_found`: the identity was
   never created (or was deleted) — re-run provisioning.

--- a/docs/architecture/custom-mail-sender-ses.md
+++ b/docs/architecture/custom-mail-sender-ses.md
@@ -90,25 +90,37 @@ teardown via `Mailer.provider_credentials('ses')`.
 
 ## Credentials
 
-The SES API client uses standard AWS credentials. Two source pairs are accepted
-(resolved per `Mailer.build_provider_config`); the emailer/SMTP fields take
-precedence over the AWS SDK environment variables:
+The SES API client uses standard AWS credentials. To keep sender-domain
+provisioning independent of the install's SMTP/transactional mailer, the key
+pair is resolved with this precedence (highest first):
 
-| Credential | First source (emailer config) | Fallback |
-|---|---|---|
-| Access key | `SMTP_USERNAME` (emailer `user`) | `AWS_ACCESS_KEY_ID` |
-| Secret key | `SMTP_PASSWORD` (emailer `pass`) | `AWS_SECRET_ACCESS_KEY` |
+| Credential | 1st — dedicated | 2nd — AWS SDK env | 3rd — emailer config |
+|---|---|---|---|
+| Access key | `CUSTOM_MAIL_SES_ACCESS_KEY_ID` | `AWS_ACCESS_KEY_ID` | `SMTP_USERNAME` (emailer `user`) |
+| Secret key | `CUSTOM_MAIL_SES_SECRET_ACCESS_KEY` | `AWS_SECRET_ACCESS_KEY` | `SMTP_PASSWORD` (emailer `pass`) |
 
-So you can supply credentials through the dedicated AWS env vars:
+The dedicated `CUSTOM_MAIL_SES_*` vars (or the `AWS_*` vars they fall back to)
+flow through `email_providers.ses` and **override** the emailer-derived values in
+`Mailer.provider_credentials('ses')`. The emailer `user`/`pass` are used only as
+a last resort — i.e. when SES is also the delivery backend (`EMAILER_MODE=ses`)
+and neither the dedicated nor the `AWS_*` vars are set.
 
 ```bash
+# Either set works; the first non-empty source wins:
+CUSTOM_MAIL_SES_ACCESS_KEY_ID=AKIA...
+CUSTOM_MAIL_SES_SECRET_ACCESS_KEY=...
+# or the standard AWS SDK vars:
 AWS_ACCESS_KEY_ID=AKIA...
 AWS_SECRET_ACCESS_KEY=...
 ```
 
-or, when the emailer already carries them, through `SMTP_USERNAME` /
-`SMTP_PASSWORD` — whichever is set first wins (so if `SMTP_USERNAME` is set, the
-AWS env var is ignored).
+> **Why the precedence matters (SMTP collision):** if you run authenticated SMTP
+> for transactional delivery (`EMAILER_MODE=smtp`), `SMTP_USERNAME` /
+> `SMTP_PASSWORD` populate the emailer `user`/`pass`. If those were the first
+> source, the SES API client would silently use your SMTP login as the AWS key
+> pair → opaque `InvalidClientTokenId` failures. Sourcing SES credentials from
+> `CUSTOM_MAIL_SES_*` / `AWS_*` (the two rows above) keeps the SMTP login out of
+> the SES client.
 
 > **Caution:** these must be IAM access keys valid for the **SESv2 API**
 > (`CreateEmailIdentity` etc.). SES *SMTP* credentials are a different artifact
@@ -223,18 +235,25 @@ your target region before configuring it.
 ## Minimal example
 
 SMTP transport for the install's transactional email, SES for domain-level
-sender provisioning, pinned to Canada Central for data residency. Note that the
-SES provisioning region (`CUSTOM_MAIL_SES_REGION`) is set independently of
-the transactional mailer:
+sender provisioning, pinned to Canada Central for data residency. Both the SES
+region **and** credentials are set independently of the transactional mailer, so
+the SES API client is unaffected by the SMTP login used for delivery:
 
 ```bash
 EMAILER_MODE=smtp
+SMTP_USERNAME=smtp-login          # used for SMTP delivery only
+SMTP_PASSWORD=smtp-secret         # NOT used as the SES AWS key
 CUSTOM_MAIL_PROVIDER=ses
 CUSTOM_MAIL_SES_REGION=ca-central-1
-AWS_ACCESS_KEY_ID=AKIA...
-AWS_SECRET_ACCESS_KEY=...
+# SES API credentials (dedicated knob, or set AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY):
+CUSTOM_MAIL_SES_ACCESS_KEY_ID=AKIA...
+CUSTOM_MAIL_SES_SECRET_ACCESS_KEY=...
 ORGS_CUSTOM_MAIL_ENABLED=true
 ```
+
+Here `CUSTOM_MAIL_SES_ACCESS_KEY_ID` / `CUSTOM_MAIL_SES_SECRET_ACCESS_KEY` (or
+the `AWS_*` equivalents) take precedence, so the SES provisioning client uses the
+AWS key pair — never the SMTP login — even though delivery runs over SMTP.
 
 ## Troubleshooting
 

--- a/docs/architecture/custom-mail-sender-ses.md
+++ b/docs/architecture/custom-mail-sender-ses.md
@@ -4,7 +4,7 @@ title: AWS SES Sender Domain Provider
 type: reference
 status: supported
 updated: 2026-06-08
-summary: Configuring AWS SES as the provider for the domain-level custom sender flow (DKIM provisioning, verification, teardown) including region selection and data-residency.
+summary: Configuring AWS SES as the provider for the domain-level custom sender flow (DKIM + custom MAIL FROM provisioning, verification, teardown) including region selection and data-residency.
 ---
 
 AWS SES is a supported provider for the **domain-level custom sender flow**: when an
@@ -84,7 +84,7 @@ teardown via `Mailer.provider_credentials('ses')`.
 > a region through `ValidateSenderDomain` — is not needed: the region belongs on
 > the provisioning side, which is exactly what `CUSTOM_MAIL_SES_REGION`
 > drives.) Any region-specific *records* (e.g. the
-> `feedback-smtp.<region>.amazonses.com` MAIL FROM MX + SPF) must be emitted by
+> `feedback-smtp.<region>.amazonses.com` MAIL FROM MX + SPF) are emitted by
 > provisioning (`SESSenderStrategy#provision_dns_records`) and are then stored on
 > the `MailerConfig` and read back verbatim at verification.
 
@@ -120,7 +120,8 @@ The IAM principal needs, at minimum:
 | Action | Why |
 |---|---|
 | `ses:CreateEmailIdentity` | Register the sender domain identity |
-| `ses:GetEmailIdentity` | Read DKIM tokens and verification status |
+| `ses:PutEmailIdentityMailFromAttributes` | Configure the custom MAIL FROM domain (SPF alignment, bounce handling) |
+| `ses:GetEmailIdentity` | Read DKIM tokens, MAIL FROM status, and verification status |
 | `ses:DeleteEmailIdentity` | Tear the identity down on sender-config removal |
 | `ses:SendEmail` | Only if SES is also the delivery transport (`EMAILER_MODE=ses`) |
 
@@ -128,19 +129,34 @@ The IAM principal needs, at minimum:
 
 ### 1. Provision
 
-`ProvisionSenderDomain` → `SESSenderStrategy#provision_dns_records` calls
-`CreateEmailIdentity` (or `GetEmailIdentity` if the identity already exists) and
-returns three DKIM CNAME records, relative to the sender domain:
+`ProvisionSenderDomain` → `SESSenderStrategy#provision_dns_records`:
+
+1. Calls `CreateEmailIdentity` (or `GetEmailIdentity` if the identity already
+   exists) to register the domain and obtain its DKIM tokens.
+2. Calls `PutEmailIdentityMailFromAttributes` to set a custom MAIL FROM
+   subdomain (`mail.<domain>`, with `behavior_on_mx_failure: USE_DEFAULT_VALUE`),
+   so SPF aligns to the sender domain and bounces are handled on the customer's
+   own domain instead of the shared `amazonses.com` default.
+
+It returns five **fully-qualified** DNS records — three DKIM CNAMEs plus the
+MAIL FROM MX and SPF TXT:
 
 ```
-<token1>._domainkey  CNAME  <token1>.dkim.amazonses.com
-<token2>._domainkey  CNAME  <token2>.dkim.amazonses.com
-<token3>._domainkey  CNAME  <token3>.dkim.amazonses.com
+<token1>._domainkey.<domain>  CNAME  <token1>.dkim.amazonses.com
+<token2>._domainkey.<domain>  CNAME  <token2>.dkim.amazonses.com
+<token3>._domainkey.<domain>  CNAME  <token3>.dkim.amazonses.com
+mail.<domain>                 MX     feedback-smtp.<region>.amazonses.com   (priority 10)
+mail.<domain>                 TXT    v=spf1 include:amazonses.com ~all
 ```
 
-The tokens are SES-assigned per domain and stored on the `MailerConfig`
-(`provider_dns_data` for the raw response, `dns_records` for the normalized
-records shown to the customer).
+The DKIM tokens are SES-assigned per domain; the MAIL FROM MX endpoint is
+region-specific (driven by `CUSTOM_MAIL_SES_REGION`). All records are stored on
+the `MailerConfig` (`provider_dns_data` for the raw response, `dns_records` for
+the normalized records shown to the customer) and read back verbatim at
+verification. If SES rejects the MAIL FROM configuration (e.g. the region does
+not support it), provisioning still succeeds with the DKIM records and the
+MAIL FROM records are omitted, rather than asking the customer to add records
+SES will not honor.
 
 ### 2. Verify
 

--- a/docs/architecture/custom-mail-sender-ses.md
+++ b/docs/architecture/custom-mail-sender-ses.md
@@ -99,17 +99,30 @@ CUSTOM_MAIL_SES_REGION=ca-central-1
 
 ## Credentials
 
-The SES API client uses standard AWS credentials, resolved (per
-`Mailer.build_provider_config`) from the emailer config with fallback to the
-AWS SDK environment variables:
+The SES API client uses standard AWS credentials. Two source pairs are accepted
+(resolved per `Mailer.build_provider_config`); the emailer/SMTP fields take
+precedence over the AWS SDK environment variables:
+
+| Credential | First source (emailer config) | Fallback |
+|---|---|---|
+| Access key | `SMTP_USERNAME` (emailer `user`) | `AWS_ACCESS_KEY_ID` |
+| Secret key | `SMTP_PASSWORD` (emailer `pass`) | `AWS_SECRET_ACCESS_KEY` |
+
+So you can supply credentials through the dedicated AWS env vars:
 
 ```bash
 AWS_ACCESS_KEY_ID=AKIA...
 AWS_SECRET_ACCESS_KEY=...
 ```
 
-(When `SMTP_USERNAME` / `SMTP_PASSWORD` are left empty, the resolver falls back
-to `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`.)
+or, when the emailer already carries them, through `SMTP_USERNAME` /
+`SMTP_PASSWORD` — whichever is set first wins (so if `SMTP_USERNAME` is set, the
+AWS env var is ignored).
+
+> **Caution:** these must be IAM access keys valid for the **SESv2 API**
+> (`CreateEmailIdentity` etc.). SES *SMTP* credentials are a different artifact
+> and will not authenticate the API calls, so if you run SES-over-SMTP for
+> delivery, don't assume the SMTP user/pass double as API keys for provisioning.
 
 The IAM principal needs, at minimum:
 

--- a/docs/architecture/custom-mail-sender-ses.md
+++ b/docs/architecture/custom-mail-sender-ses.md
@@ -125,6 +125,28 @@ The IAM principal needs, at minimum:
 | `ses:DeleteEmailIdentity` | Tear the identity down on sender-config removal |
 | `ses:SendEmail` | Only if SES is also the delivery transport (`EMAILER_MODE=ses`) |
 
+## DMARC alignment (why custom MAIL FROM)
+
+Custom MAIL FROM is what gives SES **SPF alignment**, and it is the direct
+equivalent of Lettermint's Return-Path CNAME — same mechanism, different record
+shape. Lettermint folds it into a single `lm-bounces.<domain>` CNAME (and
+manages the SPF record on its side); SES instead exposes it as an MX + SPF TXT
+that you publish on `mail.<domain>`. Both set the envelope sender (Return-Path)
+to a subdomain of the sender domain, so SPF authenticates against *your* domain.
+
+| | Lettermint | SES *with* MAIL FROM | SES *without* MAIL FROM |
+|---|---|---|---|
+| Records added | one `lm-bounces.<domain>` CNAME | `mail.<domain>` MX + SPF TXT | DKIM CNAMEs only |
+| SPF passes | ✅ your subdomain | ✅ `mail.<domain>` | ✅ but against `amazonses.com` |
+| SPF aligns with `From:` | ✅ relaxed | ✅ relaxed | ❌ |
+| DKIM passes + aligns | ✅ strict | ✅ strict | ✅ strict |
+| DMARC passes via | SPF **and** DKIM | SPF **and** DKIM | DKIM only |
+
+Provisioning configures custom MAIL FROM by default, so DMARC passes via both
+SPF and DKIM rather than DKIM alone — i.e. no single point of failure. (This is
+also why the MAIL FROM MX is region-specific: it points at the regional SES
+feedback endpoint selected by `CUSTOM_MAIL_SES_REGION`.)
+
 ## Domain-level lifecycle
 
 ### 1. Provision

--- a/docs/architecture/custom-mail-sender-ses.md
+++ b/docs/architecture/custom-mail-sender-ses.md
@@ -47,55 +47,46 @@ delivery while still using SES for sender-domain DKIM provisioning. If
 `CUSTOM_MAIL_PROVIDER` is unset, the provisioning provider falls back to
 `EMAILER_MODE`.
 
-## Regions — two knobs
+## Region
 
-SES configuration exposes **two** region settings that serve different layers.
-Set the provisioning region (`EMAILER_REGION`) to the intended region; the
-validation knob is **currently inert** (see the #2833 decision below), but
-keeping both aligned is recommended and future-proofs the config:
-
-| Env var | Drives | Used by |
-|---|---|---|
-| `EMAILER_REGION` (falls back to `AWS_REGION`) | The SES API client endpoint | Provisioning (`create/get/delete_email_identity`) and delivery |
-| `CUSTOM_MAIL_SES_REGION` | `email_providers.ses.region` config | Validation config only — **currently inert** (see the #2833 decision below) |
+The SES provisioning region is set with its own provider-namespaced variable,
+**independent of the install-level transactional mailer**:
 
 ```bash
-EMAILER_REGION=ca-central-1
-CUSTOM_MAIL_SES_REGION=ca-central-1
+EMAIL_PROVIDERS_SES_REGION=ca-central-1   # default: us-east-1
 ```
 
-> **Gotcha:** `EMAILER_REGION` defaults to the literal placeholder `smtp`, not a
-> real AWS region. Because that placeholder is non-empty it wins over
-> `AWS_REGION`, so the SES client would be built with an invalid region and
-> provisioning would fail. **You must set `EMAILER_REGION` (or `EMAILER_MODE=ses`
-> with a real `EMAILER_REGION`) to a valid AWS region when using SES.**
+This is the deliberate point of `CUSTOM_MAIL_PROVIDER`: sender-domain
+provisioning is decoupled from `EMAILER_MODE` / `EMAILER_REGION` (which configure
+the install's own transactional email transport). An operator can run, say, SMTP
+for transactional mail and SES for sender-domain provisioning, each with its own
+region. `EMAIL_PROVIDERS_SES_REGION` maps to `email_providers.ses.region` in
+config and feeds the SESv2 API client used for provisioning, verification, and
+teardown via `Mailer.provider_credentials('ses')`.
 
-> **Decision ([#2833](https://github.com/onetimesecret/onetimesecret/issues/2833) — resolved by design):**
-> `CUSTOM_MAIL_SES_REGION` is **not** threaded through `ValidateSenderDomain`,
-> and it does not need to be. The validation strategies (SES, SendGrid,
-> Lettermint) are uniform: each reads the already-provisioned records from
-> `mailer_config.dns_records` and runs live DNS lookups against them. They
-> generate nothing from a region, so there is no validation-time value for a
-> region to influence. Region is purely a **provisioning / SES-API** concern —
-> the client region comes from `EMAILER_REGION` (→ `AWS_REGION`), and whatever
-> records SES assigns for that region are stored on the `MailerConfig` and read
-> back verbatim at verification.
->
-> Concretely, `email_providers.ses.region` is merged by `ProviderConfig` but then
-> dropped by the strategy factory (the validation strategies declare no
-> `accepted_options`), so the value is currently inert. SES DKIM records are
-> token-based CNAMEs and region-independent; any region-specific records (e.g. the
+| Setting | Configures | Source |
+|---|---|---|
+| `EMAIL_PROVIDERS_SES_REGION` | SES **sender-domain provisioning** API client | `email_providers.ses.region` → `provider_credentials('ses')` |
+| `EMAILER_REGION` (falls back to `AWS_REGION`) | The install's **transactional mailer** (only when `EMAILER_MODE=ses`) | `emailer.region` → delivery backend |
+
+> **Why a dedicated var?** Earlier, the SES provisioning client pulled its region
+> from `emailer.region` (`EMAILER_REGION`, which defaults to the placeholder
+> `smtp`), coupling provisioning to the transactional transport. That is fixed:
+> `provider_credentials('ses')` now sources region from `email_providers.ses`, so
+> `EMAILER_REGION` no longer leaks into SES provisioning.
+
+> **On validation and region:** the validation strategies (SES, SendGrid,
+> Lettermint) are region-agnostic — each reads the already-provisioned records
+> from `mailer_config.dns_records` and runs live DNS lookups against them, so
+> there is nothing for a region to influence at validation time. Region is purely
+> a **provisioning / SES-API** concern. (This is why
+> [#2833](https://github.com/onetimesecret/onetimesecret/issues/2833) — threading
+> a region through `ValidateSenderDomain` — is not needed: the region belongs on
+> the provisioning side, which is exactly what `EMAIL_PROVIDERS_SES_REGION`
+> drives.) Any region-specific *records* (e.g. the
 > `feedback-smtp.<region>.amazonses.com` MAIL FROM MX + SPF) must be emitted by
-> **provisioning** (`SESSenderStrategy#provision_dns_records`), not by validation —
-> that work belongs to this SES-promotion effort, not #2833. The earlier #2833
-> premise (a region-parameterized validation strategy that *generated* regional
-> records) predates the refactor to reading provisioned records and no longer
-> applies.
->
-> Practical guidance is unchanged: set `EMAILER_REGION`/`AWS_REGION` to the
-> intended region. This two-knob region surface is transitional and expected to
-> consolidate, so prefer driving region from the provisioning side and treat
-> `CUSTOM_MAIL_SES_REGION` as a no-op for now.
+> provisioning (`SESSenderStrategy#provision_dns_records`) and are then stored on
+> the `MailerConfig` and read back verbatim at verification.
 
 ## Credentials
 
@@ -182,11 +173,10 @@ data-residency-sensitive deployments:
 | `eu-west-1` | Europe (Ireland) |
 | `us-east-1` | US East (N. Virginia) — default |
 
-Set both region knobs to the chosen region:
+Set the provisioning region to the chosen region:
 
 ```bash
-EMAILER_REGION=ca-central-1
-CUSTOM_MAIL_SES_REGION=ca-central-1
+EMAIL_PROVIDERS_SES_REGION=ca-central-1
 ```
 
 Note that SES is not available in every AWS region; confirm SES availability for
@@ -194,14 +184,15 @@ your target region before configuring it.
 
 ## Minimal example
 
-SMTP transport for delivery, SES for domain-level sender provisioning, pinned to
-Canada Central for data residency:
+SMTP transport for the install's transactional email, SES for domain-level
+sender provisioning, pinned to Canada Central for data residency. Note that the
+SES provisioning region (`EMAIL_PROVIDERS_SES_REGION`) is set independently of
+the transactional mailer:
 
 ```bash
 EMAILER_MODE=smtp
 CUSTOM_MAIL_PROVIDER=ses
-EMAILER_REGION=ca-central-1
-CUSTOM_MAIL_SES_REGION=ca-central-1
+EMAIL_PROVIDERS_SES_REGION=ca-central-1
 AWS_ACCESS_KEY_ID=AKIA...
 AWS_SECRET_ACCESS_KEY=...
 ORGS_CUSTOM_MAIL_ENABLED=true
@@ -212,8 +203,8 @@ ORGS_CUSTOM_MAIL_ENABLED=true
 - DNS verification failures (records not propagating, value mismatches): see
   [`docs/runbooks/dns-validation-failures.md`](../runbooks/dns-validation-failures.md).
 - Provisioning fails immediately with an invalid-region error: confirm
-  `EMAILER_REGION` is a real region (see the gotcha above), not the `smtp`
-  placeholder.
+  `EMAIL_PROVIDERS_SES_REGION` is a valid AWS region where SES is available
+  (it defaults to `us-east-1` if unset).
 - `check_provider_verification_status` returns `not_found`: the identity was
   never created (or was deleted) — re-run provisioning.
 
@@ -225,4 +216,5 @@ ORGS_CUSTOM_MAIL_ENABLED=true
 | `lib/onetime/domain_validation/sender_strategies/ses_validation.rb` | DNS validation from provisioned records |
 | `lib/onetime/mail/delivery/ses.rb` | SES delivery backend (only when `EMAILER_MODE=ses`) |
 | `lib/onetime/domain_validation/sender_strategies/provider_config.rb` | `email_providers.ses` config + region validation |
+| `lib/onetime/mail/mailer.rb` | `provider_credentials('ses')` sources region from `email_providers.ses` (decoupled from `EMAILER_REGION`) |
 | `etc/defaults/config.defaults.yaml` | `emailer.sender_provider`, `email_providers.ses.*` |

--- a/docs/architecture/custom-mail-sender.md
+++ b/docs/architecture/custom-mail-sender.md
@@ -51,6 +51,23 @@ The plumbing underneath -- which provider's API to call, what DNS record shapes 
 
 Different deployments can run different global mailers (e.g. one environment uses SES, another uses Lettermint). Whatever the global mailer is, that same provider is automatically used for customer sender domain provisioning and verification. The sender strategy selection flows from the platform config, not from any per-customer setting.
 
+## Provider Comparison
+
+Every provisioning provider produces the same outcome — DKIM **and** SPF aligned to the customer's domain so DMARC passes via both paths — but each exposes it through different APIs and DNS record shapes. If you already know one provider, this maps it onto the other; if you're starting from scratch, it's the quickest way to see the shape of the problem.
+
+| | AWS SES | Lettermint |
+|---|---|---|
+| Provision API | `CreateEmailIdentity` + `PutEmailIdentityMailFromAttributes` | Team API `POST /domains` |
+| DKIM records | 3 CNAMEs (`<token>._domainkey.<domain>` → `<token>.dkim.amazonses.com`) | CNAME selectors (`<sel>._domainkey.<domain>` → `<sel>.dkim.lettermint.com`) |
+| SPF / envelope sender | custom MAIL FROM on `mail.<domain>`: an **MX + SPF TXT** the customer publishes directly | **one Return-Path CNAME** (`lm-bounces.<domain>`); Lettermint manages the SPF record on its side |
+| Verification status | `GetEmailIdentity` (DKIM + MAIL FROM status) | `GET /domains/:id` (+ `verify` trigger) |
+| Teardown | `DeleteEmailIdentity` | `DELETE /domains/:id` |
+| Strategy class | `SESSenderStrategy` | `LettermintSenderStrategy` |
+
+The one mechanism difference worth internalizing: **SES's custom MAIL FROM and Lettermint's Return-Path CNAME are equivalent** — both set the envelope sender to a subdomain of the sender domain so SPF aligns under DMARC's relaxed rules. Lettermint delegates SPF via a single CNAME (it publishes the SPF record itself); SES has no CNAME-delegated SPF, so the customer publishes an MX (to the regional `feedback-smtp.<region>.amazonses.com` endpoint) plus an SPF TXT directly. SendGrid (`automatic_security`) is CNAME-based like Lettermint. See the [SES guide](./custom-mail-sender-ses.md#dmarc-alignment-why-custom-mail-from) for the full DMARC alignment table.
+
+Validation is identical across providers: each reads the provisioned `dns_records` and runs live DNS lookups — no provider API call (see `ValidateSenderDomain`). Region is purely a provisioning concern (it selects SES's DKIM region and MAIL FROM endpoint); it plays no part in validation.
+
 ## Key Files
 
 | File | Role |

--- a/docs/architecture/custom-mail-sender.md
+++ b/docs/architecture/custom-mail-sender.md
@@ -1,5 +1,7 @@
 # Custom Mail Sender Architecture
 
+> Provider-specific setup guides: [AWS SES](./custom-mail-sender-ses.md).
+
 ## Overview
 
 The custom mail sender system lets customers send secret-link emails from their own domain identity (from-address, reply-to) while the platform handles all provider integration transparently.

--- a/etc/defaults/config.defaults.yaml
+++ b/etc/defaults/config.defaults.yaml
@@ -611,6 +611,17 @@ email_providers:
     # or ap-southeast-2 (Sydney). Confirm SES is available in the region.
     # Override via CUSTOM_MAIL_SES_REGION env var
     region: <%= ENV['CUSTOM_MAIL_SES_REGION'] || 'us-east-1' %>
+    # AWS credentials for the SES provisioning API client, kept independent of
+    # the SMTP/transactional mailer credentials. build_provider_config('ses')
+    # otherwise resolves the key pair from emailer.user/pass (i.e.
+    # SMTP_USERNAME/SMTP_PASSWORD when EMAILER_MODE=smtp), which would silently
+    # use the SMTP login as the AWS key. These dedicated knobs fall back to the
+    # standard AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY and, when set, override
+    # the emailer-derived values. Leave unset only when SES is also the delivery
+    # backend (EMAILER_MODE=ses) and the emailer already carries the AWS keys.
+    # Override via CUSTOM_MAIL_SES_ACCESS_KEY_ID / CUSTOM_MAIL_SES_SECRET_ACCESS_KEY
+    access_key_id: <%= ENV['CUSTOM_MAIL_SES_ACCESS_KEY_ID'] || ENV['AWS_ACCESS_KEY_ID'] %>
+    secret_access_key: <%= ENV['CUSTOM_MAIL_SES_SECRET_ACCESS_KEY'] || ENV['AWS_SECRET_ACCESS_KEY'] %>
     # Number of DKIM selectors (SES uses 3 by default)
     dkim_selector_count: 3
     # SPF include domain

--- a/etc/defaults/config.defaults.yaml
+++ b/etc/defaults/config.defaults.yaml
@@ -609,8 +609,8 @@ email_providers:
     # EMAILER_REGION, which configures the install-level transactional mailer.
     # For data-residency, use a regional endpoint such as ca-central-1 (Canada)
     # or ap-southeast-2 (Sydney). Confirm SES is available in the region.
-    # Override via EMAIL_PROVIDERS_SES_REGION env var
-    region: <%= ENV['EMAIL_PROVIDERS_SES_REGION'] || 'us-east-1' %>
+    # Override via CUSTOM_MAIL_SES_REGION env var
+    region: <%= ENV['CUSTOM_MAIL_SES_REGION'] || 'us-east-1' %>
     # Number of DKIM selectors (SES uses 3 by default)
     dkim_selector_count: 3
     # SPF include domain

--- a/etc/defaults/config.defaults.yaml
+++ b/etc/defaults/config.defaults.yaml
@@ -604,14 +604,13 @@ email_providers:
   # AWS SES configuration
   # See docs/architecture/custom-mail-sender-ses.md for the domain-level flow.
   ses:
-    # Region for email_providers.ses. NOTE: currently INERT (#2833, resolved by
-    # design) — the validation strategies read provisioned records and use no
-    # region. Region is driven by EMAILER_REGION (-> AWS_REGION) on the
-    # provisioning/SES-API side; set that to a real region when using SES. For
-    # data-residency, use a regional endpoint such as ca-central-1 (Canada) or
-    # ap-southeast-2 (Sydney). Confirm SES is available in the region.
-    # Override via CUSTOM_MAIL_SES_REGION env var
-    region: <%= ENV['CUSTOM_MAIL_SES_REGION'] || 'us-east-1' %>
+    # AWS region for SES sender-domain provisioning (the SESv2 API client used
+    # to create/get/delete email identities). This is independent of
+    # EMAILER_REGION, which configures the install-level transactional mailer.
+    # For data-residency, use a regional endpoint such as ca-central-1 (Canada)
+    # or ap-southeast-2 (Sydney). Confirm SES is available in the region.
+    # Override via EMAIL_PROVIDERS_SES_REGION env var
+    region: <%= ENV['EMAIL_PROVIDERS_SES_REGION'] || 'us-east-1' %>
     # Number of DKIM selectors (SES uses 3 by default)
     dkim_selector_count: 3
     # SPF include domain

--- a/etc/defaults/config.defaults.yaml
+++ b/etc/defaults/config.defaults.yaml
@@ -604,10 +604,12 @@ email_providers:
   # AWS SES configuration
   # See docs/architecture/custom-mail-sender-ses.md for the domain-level flow.
   ses:
-    # AWS region for the SES DNS validation strategy.
-    # Keep equal to EMAILER_REGION (which drives the SES API client). For
-    # data-residency, use a regional endpoint such as ca-central-1 (Canada)
-    # or ap-southeast-2 (Sydney). Confirm SES is available in the region.
+    # Region for email_providers.ses. NOTE: currently INERT (#2833, resolved by
+    # design) — the validation strategies read provisioned records and use no
+    # region. Region is driven by EMAILER_REGION (-> AWS_REGION) on the
+    # provisioning/SES-API side; set that to a real region when using SES. For
+    # data-residency, use a regional endpoint such as ca-central-1 (Canada) or
+    # ap-southeast-2 (Sydney). Confirm SES is available in the region.
     # Override via CUSTOM_MAIL_SES_REGION env var
     region: <%= ENV['CUSTOM_MAIL_SES_REGION'] || 'us-east-1' %>
     # Number of DKIM selectors (SES uses 3 by default)

--- a/etc/defaults/config.defaults.yaml
+++ b/etc/defaults/config.defaults.yaml
@@ -602,8 +602,12 @@ emailer:
 #
 email_providers:
   # AWS SES configuration
+  # See docs/architecture/custom-mail-sender-ses.md for the domain-level flow.
   ses:
-    # AWS region for SES endpoints (affects MX record values)
+    # AWS region for the SES DNS validation strategy.
+    # Keep equal to EMAILER_REGION (which drives the SES API client). For
+    # data-residency, use a regional endpoint such as ca-central-1 (Canada)
+    # or ap-southeast-2 (Sydney). Confirm SES is available in the region.
     # Override via CUSTOM_MAIL_SES_REGION env var
     region: <%= ENV['CUSTOM_MAIL_SES_REGION'] || 'us-east-1' %>
     # Number of DKIM selectors (SES uses 3 by default)

--- a/lib/onetime/mail/mailer.rb
+++ b/lib/onetime/mail/mailer.rb
@@ -132,7 +132,22 @@ module Onetime
         #   Onetime::Mail::Mailer.provider_credentials('ses')
         #   # => { 'region' => 'us-east-1', 'access_key_id' => '...', 'secret_access_key' => '...' }
         def provider_credentials(provider)
-          build_provider_config(provider)
+          config = build_provider_config(provider)
+
+          # Sender-domain provisioning is decoupled from the install-level
+          # transactional mailer (EMAILER_MODE / EMAILER_REGION). Provider-
+          # specific settings come from email_providers.<provider> so an
+          # operator can run, e.g., SMTP for transactional delivery while
+          # provisioning sender domains through SES — without EMAILER_REGION
+          # leaking into the SES provisioning client. The delivery path
+          # (create_delivery_backend) keeps using emailer config directly.
+          if provider.to_s.downcase == 'ses'
+            ses_conf = provider_config('ses')
+            region   = ses_conf['region'] || ses_conf[:region]
+            config['region'] = region.to_s if region && !region.to_s.empty?
+          end
+
+          config
         end
 
         # Returns the provider for custom mail sender domain provisioning.

--- a/lib/onetime/mail/mailer.rb
+++ b/lib/onetime/mail/mailer.rb
@@ -135,16 +135,25 @@ module Onetime
           config = build_provider_config(provider)
 
           # Sender-domain provisioning is decoupled from the install-level
-          # transactional mailer (EMAILER_MODE / EMAILER_REGION). Provider-
-          # specific settings come from email_providers.<provider> so an
+          # transactional mailer (EMAILER_MODE / EMAILER_REGION / SMTP_*).
+          # Provider-specific settings come from email_providers.<provider> so an
           # operator can run, e.g., SMTP for transactional delivery while
-          # provisioning sender domains through SES — without EMAILER_REGION
-          # leaking into the SES provisioning client. The delivery path
-          # (create_delivery_backend) keeps using emailer config directly.
+          # provisioning sender domains through SES — without EMAILER_REGION or
+          # the SMTP credentials (SMTP_USERNAME/SMTP_PASSWORD, which
+          # build_provider_config resolves as emailer.user/pass) leaking into the
+          # SES provisioning client. email_providers.ses.{region,access_key_id,
+          # secret_access_key} default to the dedicated CUSTOM_MAIL_SES_* vars
+          # (falling back to AWS_REGION / AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY),
+          # so these override the emailer-derived values whenever set. When none
+          # are set (e.g. EMAILER_MODE=ses, where emailer.user is the AWS key),
+          # the override is skipped and the emailer-derived value is kept. The
+          # delivery path (create_delivery_backend) uses emailer config directly.
           if provider.to_s.downcase == 'ses'
             ses_conf = provider_config('ses')
-            region   = ses_conf['region'] || ses_conf[:region]
-            config['region'] = region.to_s if region && !region.to_s.empty?
+            %w[region access_key_id secret_access_key].each do |key|
+              value = ses_conf[key] || ses_conf[key.to_sym]
+              config[key] = value.to_s unless value.to_s.empty?
+            end
           end
 
           config

--- a/lib/onetime/mail/sender_strategies/lettermint_sender_strategy.rb
+++ b/lib/onetime/mail/sender_strategies/lettermint_sender_strategy.rb
@@ -30,6 +30,16 @@ module Onetime
       #   lm2._domainkey.example.com CNAME lm2.dkim.lettermint.com
       #   lm-bounces.example.com     CNAME bounces.lmta.net
       #
+      # Provider comparison (for devs coming from SES): the lm-bounces.<domain>
+      # Return-Path CNAME above is Lettermint's equivalent of SES's custom MAIL
+      # FROM. Both put the envelope sender on a subdomain of the sender domain so
+      # SPF aligns with the From: domain under DMARC — same outcome, different
+      # record shape. Lettermint delegates SPF via this one CNAME (it publishes
+      # the SPF record on its side); SES instead emits an MX + SPF TXT on
+      # mail.<domain> that the customer publishes directly. DKIM is CNAME-based
+      # on both. See SESSenderStrategy and
+      # docs/architecture/custom-mail-sender.md (Provider Comparison).
+      #
       # Lettermint has TWO separate APIs:
       #   1. Sending API - uses x-lettermint-token header (project token)
       #   2. Team API    - uses Authorization: Bearer header (team token)

--- a/lib/onetime/mail/sender_strategies/ses_sender_strategy.rb
+++ b/lib/onetime/mail/sender_strategies/ses_sender_strategy.rb
@@ -27,6 +27,16 @@ module Onetime
       #   { type: 'MX',    name: 'mail.example.com',              value: 'feedback-smtp.us-east-1.amazonses.com' }
       #   { type: 'TXT',   name: 'mail.example.com',              value: 'v=spf1 include:amazonses.com ~all' }
       #
+      # Provider comparison (for devs coming from Lettermint): the MAIL FROM
+      # MX + SPF TXT above are SES's equivalent of Lettermint's single
+      # Return-Path CNAME (lm-bounces.<domain>). Both put the envelope sender on
+      # a subdomain of the sender domain so SPF aligns with the From: domain
+      # under DMARC — same outcome, different record shape. SES has no
+      # CNAME-delegated SPF, so the customer publishes the MX (regional feedback
+      # endpoint) and SPF TXT directly, whereas Lettermint manages SPF behind
+      # its CNAME. See LettermintSenderStrategy and
+      # docs/architecture/custom-mail-sender.md (Provider Comparison).
+      #
       # Configuration:
       #   region:            AWS region (default: us-east-1)
       #   access_key_id:     AWS access key

--- a/lib/onetime/mail/sender_strategies/ses_sender_strategy.rb
+++ b/lib/onetime/mail/sender_strategies/ses_sender_strategy.rb
@@ -10,15 +10,22 @@ module Onetime
       # SESSenderStrategy - AWS SES sender domain provisioning.
       #
       # Provisions email identities through SES v2 API and retrieves
-      # DKIM tokens for DNS configuration.
+      # DKIM tokens for DNS configuration. Also configures a custom MAIL
+      # FROM domain so SPF aligns to the sender domain and bounces are
+      # handled on the customer's domain rather than the shared
+      # amazonses.com default.
       #
       # SES provides DKIM authentication via 3 CNAME records with
-      # tokens that must be added to the domain's DNS.
+      # tokens that must be added to the domain's DNS. The custom MAIL
+      # FROM adds an MX record (to the regional feedback endpoint) and an
+      # SPF TXT record on the MAIL FROM subdomain.
       #
-      # Example DNS records returned (name is relative, without the domain suffix):
-      #   { type: 'CNAME', name: 'token1._domainkey', value: 'token1.dkim.amazonses.com' }
-      #   { type: 'CNAME', name: 'token2._domainkey', value: 'token2.dkim.amazonses.com' }
-      #   { type: 'CNAME', name: 'token3._domainkey', value: 'token3.dkim.amazonses.com' }
+      # Example DNS records returned (names are fully-qualified):
+      #   { type: 'CNAME', name: 'token1._domainkey.example.com', value: 'token1.dkim.amazonses.com' }
+      #   { type: 'CNAME', name: 'token2._domainkey.example.com', value: 'token2.dkim.amazonses.com' }
+      #   { type: 'CNAME', name: 'token3._domainkey.example.com', value: 'token3.dkim.amazonses.com' }
+      #   { type: 'MX',    name: 'mail.example.com',              value: 'feedback-smtp.us-east-1.amazonses.com' }
+      #   { type: 'TXT',   name: 'mail.example.com',              value: 'v=spf1 include:amazonses.com ~all' }
       #
       # Configuration:
       #   region:            AWS region (default: us-east-1)
@@ -26,6 +33,13 @@ module Onetime
       #   secret_access_key: AWS secret key
       #
       class SESSenderStrategy < BaseSenderStrategy
+        # Default region when none is supplied via credentials.
+        DEFAULT_REGION = 'us-east-1'
+
+        # Subdomain label used for the custom MAIL FROM domain. AWS convention
+        # is a subdomain of the sender domain (e.g. "mail.example.com").
+        MAIL_FROM_SUBDOMAIN = 'mail'
+
         def provision_dns_records(mailer_config, credentials:)
           domain = extract_domain(mailer_config.from_address)
 
@@ -38,22 +52,48 @@ module Onetime
             }
           end
 
-          log_info "[ses-sender] Provisioning sender identity for #{domain}"
+          missing = missing_credential_keys(credentials)
+          unless missing.empty?
+            return {
+              success: false,
+              message: "AWS credentials required for SES provisioning (missing: #{missing.join(', ')})",
+              dns_records: [],
+              error: 'missing_credentials',
+            }
+          end
+
+          region = credentials['region'] || DEFAULT_REGION
+          log_info "[ses-sender] Provisioning sender identity for #{domain} (region: #{region})"
 
           client   = build_ses_client(credentials)
           response = create_or_get_email_identity(client, domain)
 
           dkim_tokens = response.dkim_attributes&.tokens || []
+          records     = build_dkim_records(dkim_tokens, domain)
+
+          # Configure a custom MAIL FROM domain so SPF aligns to the sender
+          # domain and bounces land on the customer's own domain. SES requires
+          # an MX record (to the regional feedback endpoint) plus an SPF TXT
+          # record on the MAIL FROM subdomain; both are deterministic given the
+          # region. Non-fatal: if SES rejects it we keep the DKIM records and
+          # drop the MAIL FROM records (see #configure_mail_from).
+          mail_from_domain = "#{MAIL_FROM_SUBDOMAIN}.#{domain}"
+          if configure_mail_from(client, domain, mail_from_domain)
+            records += build_mail_from_records(mail_from_domain, region)
+          else
+            mail_from_domain = nil
+          end
 
           {
             success: true,
             message: "Provisioned sender identity for #{domain}",
-            dns_records: build_dkim_records(dkim_tokens),
+            dns_records: records,
             provider_data: {
               dkim_tokens: dkim_tokens,
-              region: credentials['region'] || 'us-east-1',
+              region: region,
               identity: domain,
               dkim_status: response.dkim_attributes&.status,
+              mail_from_domain: mail_from_domain,
             },
           }
         rescue Aws::SESV2::Errors::ServiceError => ex
@@ -63,6 +103,14 @@ module Onetime
             message: "SES provisioning failed: #{ex.message}",
             dns_records: [],
             error: ex.code,
+          }
+        rescue StandardError => ex
+          log_error "[ses-sender] Provisioning failed: #{ex.message}"
+          {
+            success: false,
+            message: "Provisioning failed: #{ex.message}",
+            dns_records: [],
+            error: ex.message,
           }
         end
 
@@ -89,6 +137,7 @@ module Onetime
           dkim_attrs  = response.dkim_attributes
           dkim_status = dkim_attrs&.status || 'NOT_STARTED'
           verified    = dkim_status == 'SUCCESS'
+          mail_from   = response.mail_from_attributes
 
           {
             verified: verified,
@@ -98,6 +147,8 @@ module Onetime
               dkim_signing_enabled: dkim_attrs&.signing_enabled,
               dkim_tokens: dkim_attrs&.tokens,
               identity_type: response.identity_type,
+              mail_from_domain: mail_from&.mail_from_domain,
+              mail_from_status: mail_from&.mail_from_domain_status,
             },
           }
         rescue Aws::SESV2::Errors::NotFoundException
@@ -108,6 +159,13 @@ module Onetime
           }
         rescue Aws::SESV2::Errors::ServiceError => ex
           log_error "[ses-sender] SES API error: #{ex.message}"
+          {
+            verified: false,
+            status: 'error',
+            message: "SES verification check failed: #{ex.message}",
+          }
+        rescue StandardError => ex
+          log_error "[ses-sender] Verification check failed: #{ex.message}"
           {
             verified: false,
             status: 'error',
@@ -145,6 +203,12 @@ module Onetime
             deleted: false,
             message: "SES deletion failed: #{ex.message}",
           }
+        rescue StandardError => ex
+          log_error "[ses-sender] Deletion failed: #{ex.message}"
+          {
+            deleted: false,
+            message: "SES deletion failed: #{ex.message}",
+          }
         end
 
         protected
@@ -165,7 +229,7 @@ module Onetime
           require 'aws-sdk-sesv2'
 
           Aws::SESV2::Client.new(
-            region: credentials['region'] || 'us-east-1',
+            region: credentials['region'] || DEFAULT_REGION,
             credentials: Aws::Credentials.new(
               credentials['access_key_id'],
               credentials['secret_access_key'],
@@ -186,19 +250,89 @@ module Onetime
           client.get_email_identity(email_identity: domain)
         end
 
-        # Builds DNS record hashes from DKIM tokens.
+        # Builds DKIM CNAME record hashes from SES tokens.
+        #
+        # Names are emitted as fully-qualified hostnames (including the sender
+        # domain) so the verification layer can resolve them directly and the
+        # UI can display them verbatim — consistent with the SendGrid and
+        # Lettermint strategies.
         #
         # @param tokens [Array<String>] DKIM tokens from SES
+        # @param domain [String] Sender domain (e.g. "example.com")
         # @return [Array<Hash>] DNS records in standard format
         #
-        def build_dkim_records(tokens)
+        def build_dkim_records(tokens, domain)
           tokens.map do |token|
             {
               type: 'CNAME',
-              name: "#{token}._domainkey",
+              name: "#{token}._domainkey.#{domain}",
               value: "#{token}.dkim.amazonses.com",
             }
           end
+        end
+
+        # Builds the custom MAIL FROM DNS records (MX + SPF TXT).
+        #
+        # The MX points at the regional SES feedback endpoint; the SPF TXT
+        # authorizes amazonses.com for the MAIL FROM subdomain. Both are
+        # required by SES once a custom MAIL FROM domain is configured.
+        #
+        # @param mail_from_domain [String] e.g. "mail.example.com"
+        # @param region [String] AWS region (drives the feedback endpoint)
+        # @return [Array<Hash>] MX and TXT records in standard format
+        #
+        def build_mail_from_records(mail_from_domain, region)
+          [
+            {
+              type: 'MX',
+              name: mail_from_domain,
+              value: "feedback-smtp.#{region}.amazonses.com",
+            },
+            {
+              type: 'TXT',
+              name: mail_from_domain,
+              value: 'v=spf1 include:amazonses.com ~all',
+            },
+          ]
+        end
+
+        # Configures a custom MAIL FROM domain on the SES identity.
+        #
+        # Non-fatal: the identity and DKIM are already provisioned, and a
+        # custom MAIL FROM is an enhancement (SPF alignment + custom
+        # Return-Path). If SES rejects the request we log and skip its records
+        # rather than asking the customer to add records SES will not honor.
+        # USE_DEFAULT_VALUE keeps mail flowing via the amazonses.com MAIL FROM
+        # until the customer's MX propagates.
+        #
+        # @param client [Aws::SESV2::Client]
+        # @param domain [String] Sender domain (the SES identity)
+        # @param mail_from_domain [String] Custom MAIL FROM subdomain
+        # @return [Boolean] true if SES accepted the MAIL FROM configuration
+        #
+        def configure_mail_from(client, domain, mail_from_domain)
+          client.put_email_identity_mail_from_attributes(
+            email_identity: domain,
+            mail_from_domain: mail_from_domain,
+            behavior_on_mx_failure: 'USE_DEFAULT_VALUE',
+          )
+          true
+        rescue Aws::SESV2::Errors::ServiceError => ex
+          log_warn "[ses-sender] MAIL FROM setup failed for #{domain}: #{ex.message}"
+          false
+        end
+
+        # Returns the required credential keys that are missing or blank.
+        #
+        # Mirrors Lettermint/SendGrid which reject missing credentials up
+        # front with a clear error rather than failing at API-call time with
+        # an opaque AWS exception (e.g. MissingCredentialsError).
+        #
+        # @param credentials [Hash] Provider credentials (string keys per contract)
+        # @return [Array<String>] Missing key names (empty if all present)
+        #
+        def missing_credential_keys(credentials)
+          %w[access_key_id secret_access_key].select { |key| credentials[key].to_s.empty? }
         end
 
         # Maps SES DKIM status to human-readable message.

--- a/spec/unit/onetime/mail/sender_strategies/ses_sender_strategy_spec.rb
+++ b/spec/unit/onetime/mail/sender_strategies/ses_sender_strategy_spec.rb
@@ -10,9 +10,9 @@ RSpec.describe Onetime::Mail::SenderStrategies::SESSenderStrategy do
   let(:strategy) { described_class.new }
   let(:credentials) do
     {
-      access_key_id: 'AKIAIOSFODNN7EXAMPLE',
-      secret_access_key: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
-      region: 'us-east-1',
+      'access_key_id' => 'AKIAIOSFODNN7EXAMPLE',
+      'secret_access_key' => 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
+      'region' => 'us-east-1',
     }
   end
   let(:mailer_config) do
@@ -23,7 +23,11 @@ RSpec.describe Onetime::Mail::SenderStrategies::SESSenderStrategy do
   before do
     allow(strategy).to receive(:build_ses_client).and_return(mock_client)
     allow(strategy).to receive(:log_info)
+    allow(strategy).to receive(:log_warn)
     allow(strategy).to receive(:log_error)
+    # MAIL FROM configuration succeeds by default; individual contexts override.
+    allow(mock_client).to receive(:put_email_identity_mail_from_attributes)
+      .and_return(double('MailFromResponse'))
   end
 
   describe '#provision_dns_records' do
@@ -43,18 +47,32 @@ RSpec.describe Onetime::Mail::SenderStrategies::SESSenderStrategy do
           .and_return(create_response)
       end
 
-      it 'returns success with DNS records' do
+      it 'returns success with fully-qualified DKIM and MAIL FROM records' do
         result = strategy.provision_dns_records(mailer_config, credentials: credentials)
 
         expect(result[:success]).to be true
         expect(result[:dns_records]).to eq([
-          { type: 'CNAME', name: 'abc123._domainkey', value: 'abc123.dkim.amazonses.com' },
-          { type: 'CNAME', name: 'def456._domainkey', value: 'def456.dkim.amazonses.com' },
-          { type: 'CNAME', name: 'ghi789._domainkey', value: 'ghi789.dkim.amazonses.com' },
+          { type: 'CNAME', name: 'abc123._domainkey.example.com', value: 'abc123.dkim.amazonses.com' },
+          { type: 'CNAME', name: 'def456._domainkey.example.com', value: 'def456.dkim.amazonses.com' },
+          { type: 'CNAME', name: 'ghi789._domainkey.example.com', value: 'ghi789.dkim.amazonses.com' },
+          { type: 'MX', name: 'mail.example.com', value: 'feedback-smtp.us-east-1.amazonses.com' },
+          { type: 'TXT', name: 'mail.example.com', value: 'v=spf1 include:amazonses.com ~all' },
         ])
         expect(result[:provider_data][:dkim_tokens]).to eq(%w[abc123 def456 ghi789])
         expect(result[:provider_data][:region]).to eq('us-east-1')
         expect(result[:provider_data][:identity]).to eq('example.com')
+        expect(result[:provider_data][:mail_from_domain]).to eq('mail.example.com')
+      end
+
+      it 'configures a custom MAIL FROM domain on the identity' do
+        strategy.provision_dns_records(mailer_config, credentials: credentials)
+
+        expect(mock_client).to have_received(:put_email_identity_mail_from_attributes)
+          .with(
+            email_identity: 'example.com',
+            mail_from_domain: 'mail.example.com',
+            behavior_on_mx_failure: 'USE_DEFAULT_VALUE',
+          )
       end
     end
 
@@ -81,6 +99,59 @@ RSpec.describe Onetime::Mail::SenderStrategies::SESSenderStrategy do
 
         expect(result[:success]).to be true
         expect(result[:provider_data][:dkim_tokens]).to eq(%w[existing1 existing2 existing3])
+      end
+    end
+
+    context 'with a non-default region' do
+      let(:credentials) do
+        { 'access_key_id' => 'AKIA', 'secret_access_key' => 'secret', 'region' => 'eu-west-1' }
+      end
+      let(:dkim_attrs) { double('DkimAttributes', tokens: ['t1'], status: 'PENDING') }
+
+      before do
+        allow(mock_client).to receive(:create_email_identity)
+          .and_return(double('Resp', dkim_attributes: dkim_attrs))
+      end
+
+      it 'emits the MAIL FROM MX for that region' do
+        result = strategy.provision_dns_records(mailer_config, credentials: credentials)
+
+        mx = result[:dns_records].find { |r| r[:type] == 'MX' }
+        expect(mx[:value]).to eq('feedback-smtp.eu-west-1.amazonses.com')
+        expect(result[:provider_data][:region]).to eq('eu-west-1')
+      end
+    end
+
+    context 'when MAIL FROM configuration is rejected' do
+      let(:dkim_attrs) { double('DkimAttributes', tokens: %w[abc def], status: 'PENDING') }
+
+      before do
+        allow(mock_client).to receive(:create_email_identity)
+          .and_return(double('Resp', dkim_attributes: dkim_attrs))
+        allow(mock_client).to receive(:put_email_identity_mail_from_attributes)
+          .and_raise(Aws::SESV2::Errors::ServiceError.new(nil, 'mail from rejected'))
+      end
+
+      it 'still succeeds with DKIM records but omits MAIL FROM records' do
+        result = strategy.provision_dns_records(mailer_config, credentials: credentials)
+
+        expect(result[:success]).to be true
+        expect(result[:dns_records].map { |r| r[:type] }).to eq(%w[CNAME CNAME])
+        expect(result[:dns_records].any? { |r| r[:type] == 'MX' }).to be false
+        expect(result[:provider_data][:mail_from_domain]).to be_nil
+      end
+    end
+
+    context 'with missing AWS credentials' do
+      let(:credentials) { { 'region' => 'us-east-1' } }
+
+      it 'returns a missing_credentials error without calling SES' do
+        result = strategy.provision_dns_records(mailer_config, credentials: credentials)
+
+        expect(result[:success]).to be false
+        expect(result[:error]).to eq('missing_credentials')
+        expect(result[:dns_records]).to eq([])
+        expect(mock_client).not_to have_received(:put_email_identity_mail_from_attributes)
       end
     end
 
@@ -121,6 +192,21 @@ RSpec.describe Onetime::Mail::SenderStrategies::SESSenderStrategy do
         expect(result[:dns_records]).to eq([])
       end
     end
+
+    context 'when a non-SES error occurs' do
+      before do
+        allow(mock_client).to receive(:create_email_identity)
+          .and_raise(StandardError.new('network down'))
+      end
+
+      it 'wraps the error in a failure result' do
+        result = strategy.provision_dns_records(mailer_config, credentials: credentials)
+
+        expect(result[:success]).to be false
+        expect(result[:message]).to include('Provisioning failed')
+        expect(result[:dns_records]).to eq([])
+      end
+    end
   end
 
   describe '#check_provider_verification_status' do
@@ -131,9 +217,15 @@ RSpec.describe Onetime::Mail::SenderStrategies::SESSenderStrategy do
           status: 'SUCCESS',
           signing_enabled: true)
       end
+      let(:mail_from_attrs) do
+        double('MailFromAttributes',
+          mail_from_domain: 'mail.example.com',
+          mail_from_domain_status: 'SUCCESS')
+      end
       let(:get_response) do
         double('GetEmailIdentityResponse',
           dkim_attributes: dkim_attrs,
+          mail_from_attributes: mail_from_attrs,
           identity_type: 'DOMAIN')
       end
 
@@ -143,12 +235,14 @@ RSpec.describe Onetime::Mail::SenderStrategies::SESSenderStrategy do
           .and_return(get_response)
       end
 
-      it 'returns verified status' do
+      it 'returns verified status with MAIL FROM details' do
         result = strategy.check_provider_verification_status(mailer_config, credentials: credentials)
 
         expect(result[:verified]).to be true
         expect(result[:status]).to eq('success')
         expect(result[:message]).to include('ready for sending')
+        expect(result[:details][:mail_from_domain]).to eq('mail.example.com')
+        expect(result[:details][:mail_from_status]).to eq('SUCCESS')
       end
     end
 
@@ -162,6 +256,7 @@ RSpec.describe Onetime::Mail::SenderStrategies::SESSenderStrategy do
       let(:get_response) do
         double('GetEmailIdentityResponse',
           dkim_attributes: dkim_attrs,
+          mail_from_attributes: nil,
           identity_type: 'DOMAIN')
       end
 
@@ -191,6 +286,20 @@ RSpec.describe Onetime::Mail::SenderStrategies::SESSenderStrategy do
 
         expect(result[:verified]).to be false
         expect(result[:status]).to eq('not_found')
+      end
+    end
+
+    context 'when an unexpected error occurs' do
+      before do
+        allow(mock_client).to receive(:get_email_identity)
+          .and_raise(StandardError.new('boom'))
+      end
+
+      it 'returns error status' do
+        result = strategy.check_provider_verification_status(mailer_config, credentials: credentials)
+
+        expect(result[:verified]).to be false
+        expect(result[:status]).to eq('error')
       end
     end
 
@@ -250,6 +359,19 @@ RSpec.describe Onetime::Mail::SenderStrategies::SESSenderStrategy do
       end
     end
 
+    context 'when an unexpected error occurs' do
+      before do
+        allow(mock_client).to receive(:delete_email_identity)
+          .and_raise(StandardError.new('boom'))
+      end
+
+      it 'returns deleted false' do
+        result = strategy.delete_sender_identity(mailer_config, credentials: credentials)
+
+        expect(result[:deleted]).to be false
+      end
+    end
+
     context 'with invalid from_address' do
       let(:mailer_config) { double('MailerConfig', from_address: '') }
 
@@ -276,8 +398,8 @@ RSpec.describe Onetime::Mail::SenderStrategies::SESSenderStrategy do
   describe 'default region' do
     let(:credentials_no_region) do
       {
-        access_key_id: 'AKIAIOSFODNN7EXAMPLE',
-        secret_access_key: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
+        'access_key_id' => 'AKIAIOSFODNN7EXAMPLE',
+        'secret_access_key' => 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
       }
     end
 
@@ -289,6 +411,17 @@ RSpec.describe Onetime::Mail::SenderStrategies::SESSenderStrategy do
       result = strategy.provision_dns_records(mailer_config, credentials: credentials_no_region)
 
       expect(result[:provider_data][:region]).to eq('us-east-1')
+    end
+
+    it 'uses us-east-1 in the MAIL FROM MX endpoint' do
+      dkim_attrs = double('DkimAttributes', tokens: ['token1'], status: 'PENDING')
+      response = double('Response', dkim_attributes: dkim_attrs)
+      allow(mock_client).to receive(:create_email_identity).and_return(response)
+
+      result = strategy.provision_dns_records(mailer_config, credentials: credentials_no_region)
+
+      mx = result[:dns_records].find { |r| r[:type] == 'MX' }
+      expect(mx[:value]).to eq('feedback-smtp.us-east-1.amazonses.com')
     end
   end
 end

--- a/try/unit/mail/provider_credentials_contract_try.rb
+++ b/try/unit/mail/provider_credentials_contract_try.rb
@@ -279,3 +279,42 @@ class Onetime::Mail::Mailer
 end
 Onetime::Mail::Mailer.provider_credentials('ses')['region']
 #=> 'us-east-1'
+
+# --- SES provisioning credentials are decoupled from emailer.user/pass (SMTP_*) ---
+# build_provider_config('ses') resolves access_key_id/secret_access_key from
+# emailer.user/pass (i.e. SMTP_USERNAME/SMTP_PASSWORD when EMAILER_MODE=smtp).
+# email_providers.ses.{access_key_id,secret_access_key} (CUSTOM_MAIL_SES_* /
+# AWS_*) must override them so the SMTP login never leaks into the SES client.
+
+## Delivery-path config exposes the emailer-derived (SMTP) key pair
+@delivery_ses = Onetime::Mail::Mailer.send(:build_provider_config, 'ses')
+[@delivery_ses['access_key_id'], @delivery_ses['secret_access_key']]
+#=> ['smtp_user', 'smtp_pass']
+
+## provider_credentials('ses') overrides the key pair from email_providers.ses
+class Onetime::Mail::Mailer
+  class << self
+    def provider_config(provider)
+      if provider.to_s == 'ses'
+        { 'access_key_id' => 'AKIA_SES', 'secret_access_key' => 'ses-secret' }
+      else
+        {}
+      end
+    end
+  end
+end
+@ses_api_creds = Onetime::Mail::Mailer.provider_credentials('ses')
+[@ses_api_creds['access_key_id'], @ses_api_creds['secret_access_key']]
+#=> ['AKIA_SES', 'ses-secret']
+
+## With no email_providers.ses creds, it falls back to emailer.user/pass
+class Onetime::Mail::Mailer
+  class << self
+    def provider_config(_provider)
+      {}
+    end
+  end
+end
+@fallback_creds = Onetime::Mail::Mailer.provider_credentials('ses')
+[@fallback_creds['access_key_id'], @fallback_creds['secret_access_key']]
+#=> ['smtp_user', 'smtp_pass']

--- a/try/unit/mail/provider_credentials_contract_try.rb
+++ b/try/unit/mail/provider_credentials_contract_try.rb
@@ -247,3 +247,35 @@ creds['region']
 creds = Onetime::Mail::Mailer.provider_credentials('sendgrid')
 creds['api_key']
 #=> 'SG.test-key'
+
+# --- SES provisioning region is decoupled from EMAILER_REGION ---
+# provider_credentials('ses') sources region from email_providers.ses
+# (EMAIL_PROVIDERS_SES_REGION), independent of emailer.region (EMAILER_REGION),
+# so an install can run SMTP transactional mail and SES sender provisioning
+# in different regions.
+
+## SES provisioning region comes from email_providers.ses, overriding emailer.region
+class Onetime::Mail::Mailer
+  class << self
+    def provider_config(provider)
+      provider.to_s == 'ses' ? { 'region' => 'eu-west-1' } : {}
+    end
+  end
+end
+Onetime::Mail::Mailer.provider_credentials('ses')['region']
+#=> 'eu-west-1'
+
+## Delivery path (build_provider_config) still uses emailer.region, unaffected
+Onetime::Mail::Mailer.send(:build_provider_config, 'ses')['region']
+#=> 'us-east-1'
+
+## Restore the default provider_config stub for any later cases
+class Onetime::Mail::Mailer
+  class << self
+    def provider_config(_provider)
+      {}
+    end
+  end
+end
+Onetime::Mail::Mailer.provider_credentials('ses')['region']
+#=> 'us-east-1'

--- a/try/unit/mail/provider_credentials_contract_try.rb
+++ b/try/unit/mail/provider_credentials_contract_try.rb
@@ -250,7 +250,7 @@ creds['api_key']
 
 # --- SES provisioning region is decoupled from EMAILER_REGION ---
 # provider_credentials('ses') sources region from email_providers.ses
-# (EMAIL_PROVIDERS_SES_REGION), independent of emailer.region (EMAILER_REGION),
+# (CUSTOM_MAIL_SES_REGION), independent of emailer.region (EMAILER_REGION),
 # so an install can run SMTP transactional mail and SES sender provisioning
 # in different regions.
 


### PR DESCRIPTION
Closes #3359

## Summary

Promotes AWS SES from sender-domain *scaffolding* to a functional, documented provider at parity with Lettermint, and decouples SES provisioning (region **and** credentials) from the install's transactional mailer. This PR started as documentation; it now also carries the code changes needed to make SES actually provision a complete, verifiable sender domain.

## Code

**`SESSenderStrategy` (`lib/onetime/mail/sender_strategies/ses_sender_strategy.rb`)**
- **Fully-qualified DKIM record names** (`<token>._domainkey.<domain>`) instead of relative ones. The validation layer looks up `record[:host]` verbatim with no domain qualification, so the previous relative names could never resolve — i.e. SES DKIM verification could not succeed. Now matches the SendGrid/Lettermint/frontend convention.
- **Custom MAIL FROM provisioning** — calls `PutEmailIdentityMailFromAttributes` (`mail.<domain>`, `USE_DEFAULT_VALUE`) and emits the region-specific MX (`feedback-smtp.<region>.amazonses.com`) + SPF TXT alongside DKIM, so SPF aligns to the sender domain and DMARC passes via **both** SPF and DKIM. This is SES's equivalent of Lettermint's Return-Path CNAME. Non-fatal: if SES rejects MAIL FROM, provisioning still succeeds with DKIM and omits the MAIL FROM records.
- **Credential pre-flight** and **hardened error handling** (`StandardError` in addition to `Aws::SESV2::Errors::ServiceError` across provision/verify/delete); MAIL FROM status surfaced in verification details.

**Region & credential decoupling (`lib/onetime/mail/mailer.rb`)**
- `provider_credentials('ses')` sources `region`, `access_key_id`, and `secret_access_key` from `email_providers.ses`, overriding the emailer-derived values. This stops `EMAILER_REGION` and the SMTP login (`SMTP_USERNAME`/`SMTP_PASSWORD`, which `build_provider_config` resolves as `emailer.user/pass`) from leaking into the SES API client when running SMTP delivery + SES provisioning — the credential leak previously caused silent `InvalidClientTokenId` failures. The override only fires on non-empty values, so `EMAILER_MODE=ses` installs keep working unchanged.

## Config & docs

- `etc/defaults/config.defaults.yaml`: `email_providers.ses.{region,access_key_id,secret_access_key}` ← `CUSTOM_MAIL_SES_REGION` / `CUSTOM_MAIL_SES_ACCESS_KEY_ID` / `CUSTOM_MAIL_SES_SECRET_ACCESS_KEY` (with `AWS_*` fallback).
- `.env.reference`: documents the new knobs.
- `docs/architecture/custom-mail-sender-ses.md`: provisioning lifecycle incl. MAIL FROM, a DMARC-alignment section, credential-precedence table, and `ses:PutEmailIdentityMailFromAttributes` in the IAM list.
- `docs/architecture/custom-mail-sender.md`: cross-provider comparison (SES ↔ Lettermint); reciprocal notes added to both strategy class docs.

## Tests

- `spec/unit/onetime/mail/sender_strategies/ses_sender_strategy_spec.rb`: FQDN records, MAIL FROM emission + region, non-fatal MAIL FROM, credential pre-flight, error paths.
- `try/unit/mail/provider_credentials_contract_try.rb`: region + credential override and the `emailer.user/pass` fallback.

## Not covered here

#3359's first acceptance criterion — provision → verify → delete end-to-end against a **real SES account** — requires live AWS credentials and a real domain, so it can only be exercised outside CI.

https://claude.ai/code/session_01UMnPUoRZxY2hqiD1ZtR72q