### PR TITLE
dx(bin/dev): skip overmind .env loading to preserve direnv env

### DIFF
--- a/bin/dev
+++ b/bin/dev
@@ -24,10 +24,24 @@
 # CONNECT MODE SHORTCUTS (Inside 'overmind connect')
 # -----------------------------------------------------------------------------
 #   Ctrl+b, d                       # Detach (Return to shell, process keeps running)
-#   r                               # Restart the process you are connected to
-#   q                               # Quit connection (Process keeps running)
+#           r                       # Restart the process you are connected to
+#           q                       # Quit connection (Process keeps running)
 #
 #   Usage: Essential for 'binding.pry', 'debugger', or surgical restarts.
+# -----------------------------------------------------------------------------
+# ENVIRONMENT HANDLING
+# -----------------------------------------------------------------------------
+# By default, overmind loads ./.env from the working directory and applies it
+# to all child processes, OVERRIDING inherited shell env vars (including those
+# set by direnv). This causes values like SECRET to be silently blanked when
+# .env is a template (e.g. symlinked to .env.example with SECRET=).
+#
+# OVERMIND_SKIP_ENV=1 disables this: processes inherit the shell environment
+# as-is, exactly what direnv already loaded. Note that .overmind.env files
+# are still loaded and will override the shell env if present.
+#
+# Hivemind has no equivalent flag. With hivemind, ensure your .env file
+# contains the correct values rather than relying on shell inheritance.
 # -----------------------------------------------------------------------------
 
 if command -v overmind >/dev/null 2>&1; then
@@ -85,7 +99,7 @@ fi
 PORT="${PORT_OVERRIDE:-${PORT:-7143}}"
 
 if [[ "$RUNNER" == "overmind" ]]; then
-  exec env PORT="$PORT" overmind start -f "$PROCFILE" "${ARGS[@]}"
+  exec env PORT="$PORT" OVERMIND_SKIP_ENV=1 overmind start -f "$PROCFILE" "${ARGS[@]}"
 else
   exec env PORT="$PORT" hivemind "$PROCFILE" "${ARGS[@]}"
 fi


### PR DESCRIPTION
Adds `OVERMIND_SKIP_ENV=1` to the overmind invocation so child processes inherit the shell environment set by direnv, rather than having it overridden by `.env`.

Without this, overmind loads `.env` from the working directory before starting each process. Since `.env` is symlinked to `.env.example` (which has `SECRET=` blank), overmind was silently clobbering the `SECRET` value that direnv loaded from `.env.local` — causing the app to boot with a nil secret and raise `OT::ConfigError`.

Also documents the env-handling behaviour in the script header, including the hivemind caveat (no equivalent flag exists).

Follows d9560bbc2 which introduced the `.envrc` pattern with `.env.local` override support.