### PR TITLE
integration/main into develop

### DIFF
--- a/.env.reference
+++ b/.env.reference
@@ -197,7 +197,7 @@ ORGS_INCOMING_SECRETS_ENABLED=false
 # Data-residency regions: ca-central-1 (Canada), ap-southeast-2 (Sydney),
 # eu-west-1 (Ireland). Confirm SES is available in your target region.
 # Default: us-east-1
-#EMAIL_PROVIDERS_SES_REGION=us-east-1
+#CUSTOM_MAIL_SES_REGION=us-east-1
 
 # --- SendGrid ---
 # Subdomain for SendGrid domain authentication.

--- a/.env.reference
+++ b/.env.reference
@@ -94,12 +94,6 @@ STDOUT_SYNC=false
 
 EMAILER_MODE=smtp
 
-# Provider for custom mail sender domain provisioning (DNS/DKIM).
-# Decouples domain provisioning from the sending transport above.
-# Valid values: ses, sendgrid, lettermint, smtp
-# If unset, falls back to EMAILER_MODE.
-#CUSTOM_MAIL_PROVIDER=
-
 SMTP_HOST=
 SMTP_PORT=587
 SMTP_USERNAME=
@@ -185,6 +179,12 @@ ORGS_INCOMING_SECRETS_ENABLED=false
 # The provider is selected by CUSTOM_MAIL_PROVIDER (above); these settings
 # configure that provider's DNS record values.
 
+# Provider for custom mail sender domain provisioning (DNS/DKIM).
+# Decouples domain provisioning from the sending transport above.
+# Valid values: ses, sendgrid, lettermint, smtp
+# If unset, falls back to EMAILER_MODE.
+#CUSTOM_MAIL_PROVIDER=
+
 # --- AWS SES ---
 # Select SES as the sender-domain provisioning provider with
 # CUSTOM_MAIL_PROVIDER=ses (above). See docs/architecture/custom-mail-sender-ses.md
@@ -209,11 +209,6 @@ ORGS_INCOMING_SECRETS_ENABLED=false
 #CUSTOM_MAIL_SES_ACCESS_KEY_ID=AKIA...
 #CUSTOM_MAIL_SES_SECRET_ACCESS_KEY=...
 
-# --- SendGrid ---
-# Subdomain for SendGrid domain authentication.
-# Default: em
-#CUSTOM_MAIL_SENDGRID_SUBDOMAIN=em
-
 # --- Lettermint ---
 # Lettermint has TWO separate APIs with different auth:
 #   1. Sending API - uses x-lettermint-token header (project token)
@@ -231,6 +226,9 @@ LETTERMINT_TEAM_TOKEN=
 # API base URL (for enterprise/on-premise deployments).
 # Default: https://api.lettermint.co/v1
 #LETTERMINT_BASE_URL=https://api.lettermint.co/v1
+
+# --- SendGrid ---
+# Coming soon...
 
 
 # ═══════════════════════════════════════════════════════════

--- a/.env.reference
+++ b/.env.reference
@@ -190,10 +190,12 @@ ORGS_INCOMING_SECRETS_ENABLED=false
 # CUSTOM_MAIL_PROVIDER=ses (above). See docs/architecture/custom-mail-sender-ses.md
 # for the full domain-level setup, credentials, and IAM permissions.
 #
-# AWS region for the SES DNS validation strategy.
-# For a coherent setup, keep this equal to EMAILER_REGION (which drives the
-# SES API client for provisioning/delivery). NOTE: EMAILER_REGION defaults to
-# the placeholder 'smtp' — set it to a real region when using SES.
+# NOTE: This knob is currently INERT (#2833, resolved by design). Region is a
+# provisioning/SES-API concern, driven by EMAILER_REGION (-> AWS_REGION); the
+# validation strategies read already-provisioned records and use no region.
+# Set EMAILER_REGION (not this) to a real AWS region when using SES — it
+# defaults to the placeholder 'smtp', which is invalid for SES. Setting this to
+# the same region is harmless and future-proofs the config.
 # Data-residency regions: ca-central-1 (Canada), ap-southeast-2 (Sydney),
 # eu-west-1 (Ireland). Confirm SES is available in your target region.
 # Default: us-east-1

--- a/.env.reference
+++ b/.env.reference
@@ -190,16 +190,14 @@ ORGS_INCOMING_SECRETS_ENABLED=false
 # CUSTOM_MAIL_PROVIDER=ses (above). See docs/architecture/custom-mail-sender-ses.md
 # for the full domain-level setup, credentials, and IAM permissions.
 #
-# NOTE: This knob is currently INERT (#2833, resolved by design). Region is a
-# provisioning/SES-API concern, driven by EMAILER_REGION (-> AWS_REGION); the
-# validation strategies read already-provisioned records and use no region.
-# Set EMAILER_REGION (not this) to a real AWS region when using SES — it
-# defaults to the placeholder 'smtp', which is invalid for SES. Setting this to
-# the same region is harmless and future-proofs the config.
+# AWS region for SES sender-domain provisioning (the SESv2 API client used to
+# create/get/delete email identities). This is INDEPENDENT of EMAILER_REGION,
+# which configures the install-level transactional mailer — so you can run, e.g.,
+# SMTP for transactional email and SES for sender provisioning.
 # Data-residency regions: ca-central-1 (Canada), ap-southeast-2 (Sydney),
 # eu-west-1 (Ireland). Confirm SES is available in your target region.
 # Default: us-east-1
-#CUSTOM_MAIL_SES_REGION=us-east-1
+#EMAIL_PROVIDERS_SES_REGION=us-east-1
 
 # --- SendGrid ---
 # Subdomain for SendGrid domain authentication.

--- a/.env.reference
+++ b/.env.reference
@@ -415,14 +415,6 @@ SENTRY_URL=
 SENTRY_RELEASE=
 SENTRY_DIST=frontend
 
-# Directory for on-demand heap dumps. Every OTS process installs a SIGUSR2
-# handler at boot; `kill -USR2 <pid>` writes ObjectSpace.dump_all output to
-# <dir>/heap-<pid>-<epoch>.json (owner-only, 0600). Point this at a writable
-# volume if /tmp is locked down. Analyze with scripts/analyze-heapdump.
-# SECURITY: a heap dump contains plaintext secrets and key material that were
-# live in memory. Treat the file as a credential and delete it after analysis.
-#HEAP_DUMP_DIR=/tmp
-
 
 
 # ═══════════════════════════════════════════════════════════
@@ -482,6 +474,19 @@ SECRET_VARIABLE_NAMES=STRIPE_API_KEY,SECRET,SESSION_SECRET,AUTH_SECRET,ARGON2_SE
 
 # IRB interface for Ruby debugger breakpoints
 #RUBY_DEBUG_IRB_CONSOLE=true
+
+# On-demand heap dumps for diagnosing memory growth. When enabled, every OTS
+# process installs a SIGUSR2 handler at boot; `kill -USR2 <pid>` writes
+# ObjectSpace.dump_all output to HEAP_DUMP_DIR/heap-<pid>-<epoch>.json
+# (owner-only, 0600). Analyze with scripts/analyze-heapdump.
+# SECURITY: a dump contains plaintext secrets and key material that were live
+# in memory — treat the file as a credential and delete it after analysis.
+# Default off; enable explicitly (requires a restart, and on a read-only
+# container a writable HEAP_DUMP_DIR mount).
+#HEAP_DUMP_ENABLED=true
+# Default /var/tmp (disk-backed and persistent on Debian 13, unlike the tmpfs
+# /tmp which consumes RAM against the container's MemoryMax).
+#HEAP_DUMP_DIR=/var/tmp
 
 #RUBY_YJIT_ENABLE=1
 #RUBYOPT="--enable-frozen-string-literal"

--- a/.env.reference
+++ b/.env.reference
@@ -186,7 +186,16 @@ ORGS_INCOMING_SECRETS_ENABLED=false
 # configure that provider's DNS record values.
 
 # --- AWS SES ---
-# AWS region for SES endpoints (affects MX record values).
+# Select SES as the sender-domain provisioning provider with
+# CUSTOM_MAIL_PROVIDER=ses (above). See docs/architecture/custom-mail-sender-ses.md
+# for the full domain-level setup, credentials, and IAM permissions.
+#
+# AWS region for the SES DNS validation strategy.
+# For a coherent setup, keep this equal to EMAILER_REGION (which drives the
+# SES API client for provisioning/delivery). NOTE: EMAILER_REGION defaults to
+# the placeholder 'smtp' — set it to a real region when using SES.
+# Data-residency regions: ca-central-1 (Canada), ap-southeast-2 (Sydney),
+# eu-west-1 (Ireland). Confirm SES is available in your target region.
 # Default: us-east-1
 #CUSTOM_MAIL_SES_REGION=us-east-1
 

--- a/.env.reference
+++ b/.env.reference
@@ -417,8 +417,10 @@ SENTRY_DIST=frontend
 
 # Directory for on-demand heap dumps. Every OTS process installs a SIGUSR2
 # handler at boot; `kill -USR2 <pid>` writes ObjectSpace.dump_all output to
-# <dir>/heap-<pid>-<epoch>.json. Point this at a writable volume if /tmp is
-# locked down. Analyze with scripts/analyze-heapdump.
+# <dir>/heap-<pid>-<epoch>.json (owner-only, 0600). Point this at a writable
+# volume if /tmp is locked down. Analyze with scripts/analyze-heapdump.
+# SECURITY: a heap dump contains plaintext secrets and key material that were
+# live in memory. Treat the file as a credential and delete it after analysis.
 #HEAP_DUMP_DIR=/tmp
 
 

--- a/.env.reference
+++ b/.env.reference
@@ -415,6 +415,12 @@ SENTRY_URL=
 SENTRY_RELEASE=
 SENTRY_DIST=frontend
 
+# Directory for on-demand heap dumps. Every OTS process installs a SIGUSR2
+# handler at boot; `kill -USR2 <pid>` writes ObjectSpace.dump_all output to
+# <dir>/heap-<pid>-<epoch>.json. Point this at a writable volume if /tmp is
+# locked down. Analyze with scripts/analyze-heapdump.
+#HEAP_DUMP_DIR=/tmp
+
 
 
 # ═══════════════════════════════════════════════════════════

--- a/.env.reference
+++ b/.env.reference
@@ -198,6 +198,16 @@ ORGS_INCOMING_SECRETS_ENABLED=false
 # eu-west-1 (Ireland). Confirm SES is available in your target region.
 # Default: us-east-1
 #CUSTOM_MAIL_SES_REGION=us-east-1
+#
+# AWS credentials for the SES provisioning API, kept independent of the SMTP
+# transactional mailer. If you run authenticated SMTP for delivery
+# (EMAILER_MODE=smtp with SMTP_USERNAME/SMTP_PASSWORD), set these (or the
+# standard AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY, which they fall back to)
+# so the SMTP login is NOT used as the AWS key for SES. Leave unset only when
+# SES is also the delivery backend (EMAILER_MODE=ses) and the emailer already
+# carries the AWS keys.
+#CUSTOM_MAIL_SES_ACCESS_KEY_ID=AKIA...
+#CUSTOM_MAIL_SES_SECRET_ACCESS_KEY=...
 
 # --- SendGrid ---
 # Subdomain for SendGrid domain authentication.

--- a/apps/api/domains/cli/reconcile_sender_command.rb
+++ b/apps/api/domains/cli/reconcile_sender_command.rb
@@ -63,9 +63,10 @@ module Onetime
 
         # Refuse to switch providers on an existing config: deleting the
         # config first ensures the old provider's sender identity is torn
-        # down before a new one is created.
+        # down before a new one is created. effective_provider is already
+        # normalized, so we only normalize the user-supplied option.
         if existing_config && provider && !provider.strip.empty? &&
-           provider.strip.downcase != existing_config.effective_provider.to_s.strip.downcase
+           provider.strip.downcase != existing_config.effective_provider
           puts "Error: Existing config uses provider '#{existing_config.effective_provider}', not '#{provider}'."
           puts '  Delete the existing sender config first to switch providers.'
           return
@@ -136,7 +137,7 @@ module Onetime
       #
       # Precedence:
       #   1. Explicit --provider option
-      #   2. Existing config's effective_provider
+      #   2. Existing config's effective_provider (already normalized)
       #   3. Installation-level sender provider (Mailer.determine_sender_provider)
       #
       # @param provider_opt [String, nil] Value of the --provider option
@@ -146,10 +147,10 @@ module Onetime
         provider = provider_opt.to_s.strip.downcase
         return provider unless provider.empty?
 
-        provider = existing_config&.effective_provider.to_s.strip.downcase
+        provider = existing_config&.effective_provider.to_s
         return provider unless provider.empty?
 
-        Onetime::Mail::Mailer.send(:determine_sender_provider).to_s.strip.downcase
+        Onetime::Mail::Mailer.determine_sender_provider.to_s.strip.downcase
       end
 
       def print_dns_records(records)

--- a/apps/api/domains/cli/reconcile_sender_command.rb
+++ b/apps/api/domains/cli/reconcile_sender_command.rb
@@ -7,19 +7,22 @@ require 'onetime/operations/provision_sender_domain'
 
 module Onetime
   module CLI
-    # Reconcile a domain's Lettermint sender configuration.
+    # Reconcile a domain's sender configuration with its mail provider.
+    #
+    # Dispatches on the effective provider (SES, SendGrid, Lettermint),
+    # so it works regardless of which provider a domain is configured for.
     #
     # Handles two scenarios:
-    #   1. Domain was deleted and re-added: the old Lettermint record
-    #      causes a 409 duplicate. This command uses create_or_get_domain
-    #      which handles 409 by fetching the existing record.
-    #   2. Domain was added manually via Lettermint UI: this command
+    #   1. Domain was deleted and re-added: the old provider record
+    #      causes a 409 duplicate. Provisioning handles 409 by fetching
+    #      the existing record.
+    #   2. Domain was added manually via the provider's UI: this command
     #      creates the local MailerConfig and links it to the remote record.
     #
     class DomainsReconcileSenderCommand < Command
       include DomainsHelpers
 
-      desc 'Reconcile Lettermint sender domain with local mailer config'
+      desc 'Reconcile a sender domain with its local mailer config'
 
       argument :domain_name, type: :string, required: true, desc: 'Domain name (e.g. example.com)'
 
@@ -28,12 +31,17 @@ module Onetime
         default: nil,
         desc: 'From address (default: existing mailer_config.from_address)'
 
+      option :provider,
+        type: :string,
+        default: nil,
+        desc: 'Provider for a new config (default: existing config or installation default)'
+
       option :dry_run,
         type: :boolean,
         default: false,
         desc: 'Show what would happen without making changes'
 
-      def call(domain_name:, from_address: nil, dry_run: false, **)
+      def call(domain_name:, from_address: nil, provider: nil, dry_run: false, **)
         boot_application!
 
         domain = load_domain_by_name(domain_name)
@@ -53,21 +61,35 @@ module Onetime
           return
         end
 
-        puts "  from_address: #{resolved_from}"
-        puts "  existing config: #{existing_config ? 'yes' : 'no'}"
-        puts
-
-        if existing_config && existing_config.effective_provider != 'lettermint'
-          puts "Error: Existing config uses provider '#{existing_config.effective_provider}', not 'lettermint'."
+        # Refuse to switch providers on an existing config: deleting the
+        # config first ensures the old provider's sender identity is torn
+        # down before a new one is created.
+        if existing_config && provider && !provider.strip.empty? &&
+           provider.strip.downcase != existing_config.effective_provider.to_s.strip.downcase
+          puts "Error: Existing config uses provider '#{existing_config.effective_provider}', not '#{provider}'."
           puts '  Delete the existing sender config first to switch providers.'
           return
         end
 
+        resolved_provider = resolve_provider(provider, existing_config)
+        valid_providers   = Onetime::CustomDomain::MailerConfig::PROVIDER_TYPES
+        unless valid_providers.include?(resolved_provider)
+          got = resolved_provider.empty? ? '' : " (got '#{resolved_provider}')"
+          puts "Error: Could not resolve a valid sender provider#{got}."
+          puts "  Provide --provider (one of: #{valid_providers.join(', ')})."
+          return
+        end
+
+        puts "  from_address: #{resolved_from}"
+        puts "  provider: #{resolved_provider}"
+        puts "  existing config: #{existing_config ? 'yes' : 'no'}"
+        puts
+
         if dry_run
-          puts '[dry-run] Would reconcile Lettermint sender domain:'
+          puts '[dry-run] Would reconcile sender domain:'
           puts "  domain: #{domain.display_domain}"
           puts "  from_address: #{resolved_from}"
-          puts '  provider: lettermint'
+          puts "  provider: #{resolved_provider}"
           puts "  action: #{existing_config ? 'provision with existing config' : 'create new config, then provision'}"
           return
         end
@@ -80,7 +102,7 @@ module Onetime
             mailer_config = Onetime::CustomDomain::MailerConfig.create!(
               domain_id: domain.identifier,
               from_address: resolved_from,
-              provider: 'lettermint',
+              provider: resolved_provider,
               enabled: false,
               sending_mode: 'platform',
             )
@@ -92,7 +114,7 @@ module Onetime
         end
 
         # Provision via the operation (handles 409 by fetching existing)
-        puts 'Provisioning sender domain with Lettermint...'
+        puts "Provisioning sender domain with #{resolved_provider}..."
         result = Onetime::Operations::ProvisionSenderDomain.new(
           mailer_config: mailer_config,
         ).call
@@ -109,6 +131,26 @@ module Onetime
       end
 
       private
+
+      # Resolve which provider to reconcile against.
+      #
+      # Precedence:
+      #   1. Explicit --provider option
+      #   2. Existing config's effective_provider
+      #   3. Installation-level sender provider (Mailer.determine_sender_provider)
+      #
+      # @param provider_opt [String, nil] Value of the --provider option
+      # @param existing_config [CustomDomain::MailerConfig, nil] Existing config
+      # @return [String] Lowercased provider name, or '' when unresolvable
+      def resolve_provider(provider_opt, existing_config)
+        provider = provider_opt.to_s.strip.downcase
+        return provider unless provider.empty?
+
+        provider = existing_config&.effective_provider.to_s.strip.downcase
+        return provider unless provider.empty?
+
+        Onetime::Mail::Mailer.send(:determine_sender_provider).to_s.strip.downcase
+      end
 
       def print_dns_records(records)
         return if records.nil? || records.empty?

--- a/apps/api/domains/cli/reconcile_sender_command.rb
+++ b/apps/api/domains/cli/reconcile_sender_command.rb
@@ -67,7 +67,7 @@ module Onetime
         # normalized, so we only normalize the user-supplied option.
         if existing_config && provider && !provider.strip.empty? &&
            provider.strip.downcase != existing_config.effective_provider
-          puts "Error: Existing config uses provider '#{existing_config.effective_provider}', not '#{provider}'."
+          puts "Error: Existing config uses provider '#{existing_config.effective_provider}', not '#{provider.strip.downcase}'."
           puts '  Delete the existing sender config first to switch providers.'
           return
         end

--- a/apps/web/auth/spec/unit/domain_sso_config_spec.rb
+++ b/apps/web/auth/spec/unit/domain_sso_config_spec.rb
@@ -381,6 +381,49 @@ RSpec.describe Onetime::CustomDomain::SsoConfig do
     end
   end
 
+  # ==========================================================================
+  # Provider enumeration consistency
+  #
+  # PROVIDER_TYPES is the canonical list of valid SSO providers. Several
+  # in-model structures must enumerate that same set — PROVIDER_METADATA,
+  # PROVIDER_ROUTE_MAP, and the to_omniauth_options dispatch — plus the test
+  # fixtures used to exercise them. SsoConfig has no external strategy registry
+  # to derive from (unlike MailerConfig, whose validation derives from
+  # SenderStrategies), and a case/dispatch statement is code, not data, so these
+  # are kept in lockstep with a guard rather than by construction. Without it, a
+  # provider added to one list but not another would pass validation yet fail at
+  # runtime (e.g. to_omniauth_options raising "Unsupported"). This catches that
+  # drift in CI.
+  # ==========================================================================
+
+  describe 'provider enumeration consistency' do
+    it 'PROVIDER_METADATA covers exactly PROVIDER_TYPES' do
+      expect(described_class::PROVIDER_METADATA.keys.sort)
+        .to eq(described_class::PROVIDER_TYPES.sort)
+    end
+
+    it 'PROVIDER_ROUTE_MAP covers exactly PROVIDER_TYPES' do
+      expect(described_class::PROVIDER_ROUTE_MAP.keys.sort)
+        .to eq(described_class::PROVIDER_TYPES.sort)
+    end
+
+    it 'to_omniauth_options dispatches every PROVIDER_TYPES value' do
+      fake_domain = instance_double(Onetime::CustomDomain, extid: 'cd_guard_extid')
+      allow_any_instance_of(described_class).to receive(:custom_domain).and_return(fake_domain)
+
+      described_class::PROVIDER_TYPES.each do |provider_type|
+        config = build_minimal_domain_sso_config(domain_id: 'guard-domain', provider_type: provider_type)
+        expect { config.to_omniauth_options }
+          .not_to raise_error, "to_omniauth_options has no dispatch branch for '#{provider_type}'"
+      end
+    end
+
+    it 'test fixtures enumerate the same providers as the model' do
+      expect(DomainSsoTestFixtures::PROVIDER_TYPES.map(&:to_s).sort)
+        .to eq(described_class::PROVIDER_TYPES.sort)
+    end
+  end
+
   describe '#requires_domain_filter?' do
     it 'returns true for GitHub' do
       config = build_domain_sso_config(:github)

--- a/apps/web/core/spec/views/serializers/config_serializer_spec.rb
+++ b/apps/web/core/spec/views/serializers/config_serializer_spec.rb
@@ -476,6 +476,7 @@ RSpec.describe Core::Views::ConfigSerializer do
         let(:view_vars_with_incoming) do
           base_view_vars.merge(
             'features' => base_view_vars['features'].merge(
+              'incoming' => { 'enabled' => false },
               'organizations' => { 'enabled' => false, 'incoming_secrets_enabled' => true }
             )
           )

--- a/apps/web/core/spec/views/serializers/config_serializer_spec.rb
+++ b/apps/web/core/spec/views/serializers/config_serializer_spec.rb
@@ -472,10 +472,27 @@ RSpec.describe Core::Views::ConfigSerializer do
         end
       end
 
-      context 'when incoming_secrets_enabled is true' do
+      context 'when incoming_secrets_enabled is true but install-level incoming.enabled is false' do
         let(:view_vars_with_incoming) do
           base_view_vars.merge(
             'features' => base_view_vars['features'].merge(
+              'organizations' => { 'enabled' => false, 'incoming_secrets_enabled' => true }
+            )
+          )
+        end
+
+        it 'returns incoming_secrets_enabled as false (install gate takes precedence)' do
+          result = described_class.build_feature_flags(view_vars_with_incoming)
+
+          expect(result['organizations']['incoming_secrets_enabled']).to be false
+        end
+      end
+
+      context 'when both incoming_secrets_enabled and install-level incoming.enabled are true' do
+        let(:view_vars_with_incoming) do
+          base_view_vars.merge(
+            'features' => base_view_vars['features'].merge(
+              'incoming' => { 'enabled' => true },
               'organizations' => { 'enabled' => false, 'incoming_secrets_enabled' => true }
             )
           )
@@ -501,6 +518,7 @@ RSpec.describe Core::Views::ConfigSerializer do
         let(:view_vars_all_orgs) do
           base_view_vars.merge(
             'features' => base_view_vars['features'].merge(
+              'incoming' => { 'enabled' => true },
               'organizations' => {
                 'enabled' => true,
                 'sso_enabled' => true,
@@ -526,6 +544,7 @@ RSpec.describe Core::Views::ConfigSerializer do
         let(:view_vars_mail_and_incoming_only) do
           base_view_vars.merge(
             'features' => base_view_vars['features'].merge(
+              'incoming' => { 'enabled' => true },
               'organizations' => {
                 'enabled' => true,
                 'sso_enabled' => false,

--- a/apps/web/core/views/serializers/config_serializer.rb
+++ b/apps/web/core/views/serializers/config_serializer.rb
@@ -149,7 +149,8 @@ module Core
               'enabled' => features.dig('organizations', 'enabled') || false,
               'sso_enabled' => features.dig('organizations', 'sso_enabled') || false,
               'custom_mail_enabled' => features.dig('organizations', 'custom_mail_enabled') || false,
-              'incoming_secrets_enabled' => features.dig('organizations', 'incoming_secrets_enabled') || false,
+              'incoming_secrets_enabled' => (features.dig('incoming', 'enabled') &&
+                                              features.dig('organizations', 'incoming_secrets_enabled')) || false,
             },
           }
         end

--- a/bin/dev
+++ b/bin/dev
@@ -24,10 +24,24 @@
 # CONNECT MODE SHORTCUTS (Inside 'overmind connect')
 # -----------------------------------------------------------------------------
 #   Ctrl+b, d                       # Detach (Return to shell, process keeps running)
-#   r                               # Restart the process you are connected to
-#   q                               # Quit connection (Process keeps running)
+#           r                       # Restart the process you are connected to
+#           q                       # Quit connection (Process keeps running)
 #
 #   Usage: Essential for 'binding.pry', 'debugger', or surgical restarts.
+# -----------------------------------------------------------------------------
+# ENVIRONMENT HANDLING
+# -----------------------------------------------------------------------------
+# By default, overmind loads ./.env from the working directory and applies it
+# to all child processes, OVERRIDING inherited shell env vars (including those
+# set by direnv). This causes values like SECRET to be silently blanked when
+# .env is a template (e.g. symlinked to .env.example with SECRET=).
+#
+# OVERMIND_SKIP_ENV=1 disables this: processes inherit the shell environment
+# as-is, exactly what direnv already loaded. Note that .overmind.env files
+# are still loaded and will override the shell env if present.
+#
+# Hivemind has no equivalent flag. With hivemind, ensure your .env file
+# contains the correct values rather than relying on shell inheritance.
 # -----------------------------------------------------------------------------
 
 if command -v overmind >/dev/null 2>&1; then
@@ -85,7 +99,7 @@ fi
 PORT="${PORT_OVERRIDE:-${PORT:-7143}}"
 
 if [[ "$RUNNER" == "overmind" ]]; then
-  exec env PORT="$PORT" overmind start -f "$PROCFILE" "${ARGS[@]}"
+  exec env PORT="$PORT" OVERMIND_SKIP_ENV=1 overmind start -f "$PROCFILE" "${ARGS[@]}"
 else
   exec env PORT="$PORT" hivemind "$PROCFILE" "${ARGS[@]}"
 fi

--- a/changelog.d/20260607_000000_claude_3366_heap_dump_handler.rst
+++ b/changelog.d/20260607_000000_claude_3366_heap_dump_handler.rst
@@ -14,6 +14,15 @@ Added
   ``scripts/analyze-heapdump`` summarizes a dump (object counts by type, bytes
   by type, top STRING allocation sites). (#3366)
 
+Security
+--------
+
+- Heap dumps are written owner-only (``0600``) and created exclusively
+  (``O_EXCL``) so they cannot clobber or follow a pre-planted symlink in a
+  shared ``/tmp``. A dump serializes live String values, so it contains
+  plaintext secrets and key material — treat the file as a credential and
+  delete it after analysis. (#3366)
+
 AI Assistance
 -------------
 

--- a/changelog.d/20260607_000000_claude_3366_heap_dump_handler.rst
+++ b/changelog.d/20260607_000000_claude_3366_heap_dump_handler.rst
@@ -3,25 +3,28 @@
 Added
 -----
 
-- All OTS processes (web, scheduler, worker, CLI) now install a ``SIGUSR2``
-  heap dump handler at boot. Sending ``kill -USR2 <pid>`` writes an
-  ``ObjectSpace.dump_all`` snapshot to ``heap-<pid>-<epoch>.json`` (under
-  ``HEAP_DUMP_DIR``, default ``/tmp``) so operators can diagnose RSS vs. Ruby
-  heap growth in running production containers without attaching GDB or
-  restarting with extra instrumentation. The dump runs in a spawned thread
-  (``ObjectSpace.dump_all`` is not signal-safe) and the handler is installed in
-  the Puma/Sneakers master and inherited by forked workers. A companion
-  ``scripts/analyze-heapdump`` summarizes a dump (object counts by type, bytes
-  by type, top STRING allocation sites). (#3366)
+- Opt-in on-demand heap dumps for diagnosing memory growth. When
+  ``HEAP_DUMP_ENABLED`` is set (default off), every OTS process (web, scheduler,
+  worker, CLI) installs a ``SIGUSR2`` handler at boot; ``kill -USR2 <pid>``
+  writes an ``ObjectSpace.dump_all`` snapshot to ``heap-<pid>-<epoch>.json``
+  (under ``HEAP_DUMP_DIR``, default ``/var/tmp``) so operators can diagnose RSS
+  vs. Ruby heap growth without attaching GDB or restarting with extra
+  instrumentation. The dump runs in a spawned thread (``ObjectSpace.dump_all``
+  is not signal-safe) and the handler is installed in the Puma/Sneakers master
+  and inherited by forked workers. A companion ``scripts/analyze-heapdump``
+  summarizes a dump (object counts by type, bytes by type, top STRING
+  allocation sites). (#3366)
 
 Security
 --------
 
-- Heap dumps are written owner-only (``0600``) and created exclusively
-  (``O_EXCL``) so they cannot clobber or follow a pre-planted symlink in a
-  shared ``/tmp``. A dump serializes live String values, so it contains
-  plaintext secrets and key material — treat the file as a credential and
-  delete it after analysis. (#3366)
+- Heap dumps are off by default and gated behind ``HEAP_DUMP_ENABLED``: a dump
+  serializes live String values, so it contains plaintext secrets and key
+  material, and the handler is a memory-disclosure primitive that bypasses the
+  default container ptrace restriction. When enabled, dumps are written
+  owner-only (``0600``) and created exclusively (``O_EXCL``) so they cannot
+  clobber or follow a pre-planted symlink in a shared directory. Treat a dump
+  file as a credential and delete it after analysis. (#3366)
 
 AI Assistance
 -------------

--- a/changelog.d/20260607_000000_claude_3366_heap_dump_handler.rst
+++ b/changelog.d/20260607_000000_claude_3366_heap_dump_handler.rst
@@ -1,0 +1,21 @@
+.. A new scriv changelog fragment.
+
+Added
+-----
+
+- All OTS processes (web, scheduler, worker, CLI) now install a ``SIGUSR2``
+  heap dump handler at boot. Sending ``kill -USR2 <pid>`` writes an
+  ``ObjectSpace.dump_all`` snapshot to ``heap-<pid>-<epoch>.json`` (under
+  ``HEAP_DUMP_DIR``, default ``/tmp``) so operators can diagnose RSS vs. Ruby
+  heap growth in running production containers without attaching GDB or
+  restarting with extra instrumentation. The dump runs in a spawned thread
+  (``ObjectSpace.dump_all`` is not signal-safe) and the handler is installed in
+  the Puma/Sneakers master and inherited by forked workers. A companion
+  ``scripts/analyze-heapdump`` summarizes a dump (object counts by type, bytes
+  by type, top STRING allocation sites). (#3366)
+
+AI Assistance
+-------------
+
+- Heap dump boot initializer, analysis script, and tests drafted with AI
+  assistance. (#3366)

--- a/docs/architecture/custom-mail-sender-ses.md
+++ b/docs/architecture/custom-mail-sender-ses.md
@@ -47,15 +47,17 @@ delivery while still using SES for sender-domain DKIM provisioning. If
 `CUSTOM_MAIL_PROVIDER` is unset, the provisioning provider falls back to
 `EMAILER_MODE`.
 
-## Regions — two knobs that must agree
+## Regions — two knobs
 
-SES configuration has **two** region settings that serve different layers.
-For a coherent setup, **set both to the same region**:
+SES configuration exposes **two** region settings that serve different layers.
+Set the provisioning region (`EMAILER_REGION`) to the intended region; the
+validation knob is **currently inert** (see the #2833 decision below), but
+keeping both aligned is recommended and future-proofs the config:
 
 | Env var | Drives | Used by |
 |---|---|---|
 | `EMAILER_REGION` (falls back to `AWS_REGION`) | The SES API client endpoint | Provisioning (`create/get/delete_email_identity`) and delivery |
-| `CUSTOM_MAIL_SES_REGION` | `email_providers.ses.region` config | The DNS **validation** strategy |
+| `CUSTOM_MAIL_SES_REGION` | `email_providers.ses.region` config | Validation config only — **currently inert** (see the #2833 decision below) |
 
 ```bash
 EMAILER_REGION=ca-central-1
@@ -68,13 +70,32 @@ CUSTOM_MAIL_SES_REGION=ca-central-1
 > provisioning would fail. **You must set `EMAILER_REGION` (or `EMAILER_MODE=ses`
 > with a real `EMAILER_REGION`) to a valid AWS region when using SES.**
 
-> **Note (#2833):** Threading `CUSTOM_MAIL_SES_REGION` all the way through the
-> `ValidateSenderDomain` interface is tracked separately in
-> [#2833](https://github.com/onetimesecret/onetimesecret/issues/2833). Until that
-> lands, keep the two region values identical so provisioning and validation
-> agree. SES DKIM records are token-based CNAMEs and are region-independent, so a
-> mismatch is only consequential for region-specific records (e.g. MX/bounce
-> endpoints) and for hitting the correct regional SES API.
+> **Decision ([#2833](https://github.com/onetimesecret/onetimesecret/issues/2833) — resolved by design):**
+> `CUSTOM_MAIL_SES_REGION` is **not** threaded through `ValidateSenderDomain`,
+> and it does not need to be. The validation strategies (SES, SendGrid,
+> Lettermint) are uniform: each reads the already-provisioned records from
+> `mailer_config.dns_records` and runs live DNS lookups against them. They
+> generate nothing from a region, so there is no validation-time value for a
+> region to influence. Region is purely a **provisioning / SES-API** concern —
+> the client region comes from `EMAILER_REGION` (→ `AWS_REGION`), and whatever
+> records SES assigns for that region are stored on the `MailerConfig` and read
+> back verbatim at verification.
+>
+> Concretely, `email_providers.ses.region` is merged by `ProviderConfig` but then
+> dropped by the strategy factory (the validation strategies declare no
+> `accepted_options`), so the value is currently inert. SES DKIM records are
+> token-based CNAMEs and region-independent; any region-specific records (e.g. the
+> `feedback-smtp.<region>.amazonses.com` MAIL FROM MX + SPF) must be emitted by
+> **provisioning** (`SESSenderStrategy#provision_dns_records`), not by validation —
+> that work belongs to this SES-promotion effort, not #2833. The earlier #2833
+> premise (a region-parameterized validation strategy that *generated* regional
+> records) predates the refactor to reading provisioned records and no longer
+> applies.
+>
+> Practical guidance is unchanged: set `EMAILER_REGION`/`AWS_REGION` to the
+> intended region. This two-knob region surface is transitional and expected to
+> consolidate, so prefer driving region from the provisioning side and treat
+> `CUSTOM_MAIL_SES_REGION` as a no-op for now.
 
 ## Credentials
 

--- a/docs/architecture/custom-mail-sender-ses.md
+++ b/docs/architecture/custom-mail-sender-ses.md
@@ -1,0 +1,194 @@
+# docs/architecture/custom-mail-sender-ses.md
+---
+title: AWS SES Sender Domain Provider
+type: reference
+status: supported
+updated: 2026-06-08
+summary: Configuring AWS SES as the provider for the domain-level custom sender flow (DKIM provisioning, verification, teardown) including region selection and data-residency.
+---
+
+AWS SES is a supported provider for the **domain-level custom sender flow**: when an
+organization enables a custom sender identity on one of its custom domains, the
+platform calls SES on the organization's behalf to register a sender identity,
+returns the DKIM records the customer must add at their registrar, verifies those
+records, and tears the identity down when the sender config is removed.
+
+This document covers the SES-specific configuration. For the provider-agnostic
+design (the three layers, who picks the provider, how credentials flow), see
+[`custom-mail-sender.md`](./custom-mail-sender.md).
+
+## Scope
+
+SES here is the **sender-domain provisioning provider**, selected once per
+installation. It is **not** a per-customer choice and is **not** something an
+end user picks from a dropdown — exactly as with Lettermint, the operator
+configures the provider, and the customer's only decision is "do I want emails
+from my domain to use my from-address/reply-to?" (see the *Customer Decision
+Surface* section of the architecture overview).
+
+The work this provider enables is the **domain-level lifecycle**:
+
+```
+enable custom sender → provision SES identity → show DKIM CNAMEs
+                     → customer adds DNS → verify → (later) delete
+```
+
+## Selecting SES
+
+Set the provisioning provider:
+
+```bash
+CUSTOM_MAIL_PROVIDER=ses
+```
+
+`CUSTOM_MAIL_PROVIDER` decouples *domain provisioning* from the *sending
+transport* (`EMAILER_MODE`). You can run SMTP (or any transport) for outbound
+delivery while still using SES for sender-domain DKIM provisioning. If
+`CUSTOM_MAIL_PROVIDER` is unset, the provisioning provider falls back to
+`EMAILER_MODE`.
+
+## Regions — two knobs that must agree
+
+SES configuration has **two** region settings that serve different layers.
+For a coherent setup, **set both to the same region**:
+
+| Env var | Drives | Used by |
+|---|---|---|
+| `EMAILER_REGION` (falls back to `AWS_REGION`) | The SES API client endpoint | Provisioning (`create/get/delete_email_identity`) and delivery |
+| `CUSTOM_MAIL_SES_REGION` | `email_providers.ses.region` config | The DNS **validation** strategy |
+
+```bash
+EMAILER_REGION=ca-central-1
+CUSTOM_MAIL_SES_REGION=ca-central-1
+```
+
+> **Gotcha:** `EMAILER_REGION` defaults to the literal placeholder `smtp`, not a
+> real AWS region. Because that placeholder is non-empty it wins over
+> `AWS_REGION`, so the SES client would be built with an invalid region and
+> provisioning would fail. **You must set `EMAILER_REGION` (or `EMAILER_MODE=ses`
+> with a real `EMAILER_REGION`) to a valid AWS region when using SES.**
+
+> **Note (#2833):** Threading `CUSTOM_MAIL_SES_REGION` all the way through the
+> `ValidateSenderDomain` interface is tracked separately in
+> [#2833](https://github.com/onetimesecret/onetimesecret/issues/2833). Until that
+> lands, keep the two region values identical so provisioning and validation
+> agree. SES DKIM records are token-based CNAMEs and are region-independent, so a
+> mismatch is only consequential for region-specific records (e.g. MX/bounce
+> endpoints) and for hitting the correct regional SES API.
+
+## Credentials
+
+The SES API client uses standard AWS credentials, resolved (per
+`Mailer.build_provider_config`) from the emailer config with fallback to the
+AWS SDK environment variables:
+
+```bash
+AWS_ACCESS_KEY_ID=AKIA...
+AWS_SECRET_ACCESS_KEY=...
+```
+
+(When `SMTP_USERNAME` / `SMTP_PASSWORD` are left empty, the resolver falls back
+to `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`.)
+
+The IAM principal needs, at minimum:
+
+| Action | Why |
+|---|---|
+| `ses:CreateEmailIdentity` | Register the sender domain identity |
+| `ses:GetEmailIdentity` | Read DKIM tokens and verification status |
+| `ses:DeleteEmailIdentity` | Tear the identity down on sender-config removal |
+| `ses:SendEmail` | Only if SES is also the delivery transport (`EMAILER_MODE=ses`) |
+
+## Domain-level lifecycle
+
+### 1. Provision
+
+`ProvisionSenderDomain` → `SESSenderStrategy#provision_dns_records` calls
+`CreateEmailIdentity` (or `GetEmailIdentity` if the identity already exists) and
+returns three DKIM CNAME records, relative to the sender domain:
+
+```
+<token1>._domainkey  CNAME  <token1>.dkim.amazonses.com
+<token2>._domainkey  CNAME  <token2>.dkim.amazonses.com
+<token3>._domainkey  CNAME  <token3>.dkim.amazonses.com
+```
+
+The tokens are SES-assigned per domain and stored on the `MailerConfig`
+(`provider_dns_data` for the raw response, `dns_records` for the normalized
+records shown to the customer).
+
+### 2. Verify
+
+`ValidateSenderDomain` → `SesValidation` reads the **provisioned** records from
+`mailer_config.dns_records` (never hardcoded placeholders) and performs live DNS
+lookups. Provider-side status is also available via
+`SESSenderStrategy#check_provider_verification_status`, which maps the SES DKIM
+status (`SUCCESS` / `PENDING` / `FAILED` / `TEMPORARY_FAILURE` / `NOT_STARTED`)
+to a human-readable message.
+
+### 3. Delete
+
+Removing the sender config dispatches to
+`SESSenderStrategy#delete_sender_identity`, which calls `DeleteEmailIdentity`.
+A missing identity is treated as already-deleted (idempotent teardown). This is
+covered by the multi-provider deletion dispatch
+([#3369](https://github.com/onetimesecret/onetimesecret/pull/3369)).
+
+## Data residency
+
+Choose the SES region to match the data-residency requirements of the
+installation and its customers. SES sender identities, DKIM key material, and
+sending metadata live in the region you provision against. Notable regions for
+data-residency-sensitive deployments:
+
+| Region | Location |
+|---|---|
+| `ca-central-1` | Canada (Central) |
+| `ap-southeast-2` | Asia Pacific (Sydney) |
+| `eu-west-1` | Europe (Ireland) |
+| `us-east-1` | US East (N. Virginia) — default |
+
+Set both region knobs to the chosen region:
+
+```bash
+EMAILER_REGION=ca-central-1
+CUSTOM_MAIL_SES_REGION=ca-central-1
+```
+
+Note that SES is not available in every AWS region; confirm SES availability for
+your target region before configuring it.
+
+## Minimal example
+
+SMTP transport for delivery, SES for domain-level sender provisioning, pinned to
+Canada Central for data residency:
+
+```bash
+EMAILER_MODE=smtp
+CUSTOM_MAIL_PROVIDER=ses
+EMAILER_REGION=ca-central-1
+CUSTOM_MAIL_SES_REGION=ca-central-1
+AWS_ACCESS_KEY_ID=AKIA...
+AWS_SECRET_ACCESS_KEY=...
+ORGS_CUSTOM_MAIL_ENABLED=true
+```
+
+## Troubleshooting
+
+- DNS verification failures (records not propagating, value mismatches): see
+  [`docs/runbooks/dns-validation-failures.md`](../runbooks/dns-validation-failures.md).
+- Provisioning fails immediately with an invalid-region error: confirm
+  `EMAILER_REGION` is a real region (see the gotcha above), not the `smtp`
+  placeholder.
+- `check_provider_verification_status` returns `not_found`: the identity was
+  never created (or was deleted) — re-run provisioning.
+
+## Key files
+
+| File | Role |
+|---|---|
+| `lib/onetime/mail/sender_strategies/ses_sender_strategy.rb` | Provision / verify-status / delete via `aws-sdk-sesv2` |
+| `lib/onetime/domain_validation/sender_strategies/ses_validation.rb` | DNS validation from provisioned records |
+| `lib/onetime/mail/delivery/ses.rb` | SES delivery backend (only when `EMAILER_MODE=ses`) |
+| `lib/onetime/domain_validation/sender_strategies/provider_config.rb` | `email_providers.ses` config + region validation |
+| `etc/defaults/config.defaults.yaml` | `emailer.sender_provider`, `email_providers.ses.*` |

--- a/docs/architecture/custom-mail-sender-ses.md
+++ b/docs/architecture/custom-mail-sender-ses.md
@@ -49,24 +49,24 @@ delivery while still using SES for sender-domain DKIM provisioning. If
 
 ## Region
 
-The SES provisioning region is set with its own provider-namespaced variable,
+The SES provisioning region is set with its own dedicated variable,
 **independent of the install-level transactional mailer**:
 
 ```bash
-EMAIL_PROVIDERS_SES_REGION=ca-central-1   # default: us-east-1
+CUSTOM_MAIL_SES_REGION=ca-central-1   # default: us-east-1
 ```
 
 This is the deliberate point of `CUSTOM_MAIL_PROVIDER`: sender-domain
 provisioning is decoupled from `EMAILER_MODE` / `EMAILER_REGION` (which configure
 the install's own transactional email transport). An operator can run, say, SMTP
 for transactional mail and SES for sender-domain provisioning, each with its own
-region. `EMAIL_PROVIDERS_SES_REGION` maps to `email_providers.ses.region` in
+region. `CUSTOM_MAIL_SES_REGION` maps to `email_providers.ses.region` in
 config and feeds the SESv2 API client used for provisioning, verification, and
 teardown via `Mailer.provider_credentials('ses')`.
 
 | Setting | Configures | Source |
 |---|---|---|
-| `EMAIL_PROVIDERS_SES_REGION` | SES **sender-domain provisioning** API client | `email_providers.ses.region` → `provider_credentials('ses')` |
+| `CUSTOM_MAIL_SES_REGION` | SES **sender-domain provisioning** API client | `email_providers.ses.region` → `provider_credentials('ses')` |
 | `EMAILER_REGION` (falls back to `AWS_REGION`) | The install's **transactional mailer** (only when `EMAILER_MODE=ses`) | `emailer.region` → delivery backend |
 
 > **Why a dedicated var?** Earlier, the SES provisioning client pulled its region
@@ -82,7 +82,7 @@ teardown via `Mailer.provider_credentials('ses')`.
 > a **provisioning / SES-API** concern. (This is why
 > [#2833](https://github.com/onetimesecret/onetimesecret/issues/2833) — threading
 > a region through `ValidateSenderDomain` — is not needed: the region belongs on
-> the provisioning side, which is exactly what `EMAIL_PROVIDERS_SES_REGION`
+> the provisioning side, which is exactly what `CUSTOM_MAIL_SES_REGION`
 > drives.) Any region-specific *records* (e.g. the
 > `feedback-smtp.<region>.amazonses.com` MAIL FROM MX + SPF) must be emitted by
 > provisioning (`SESSenderStrategy#provision_dns_records`) and are then stored on
@@ -176,7 +176,7 @@ data-residency-sensitive deployments:
 Set the provisioning region to the chosen region:
 
 ```bash
-EMAIL_PROVIDERS_SES_REGION=ca-central-1
+CUSTOM_MAIL_SES_REGION=ca-central-1
 ```
 
 Note that SES is not available in every AWS region; confirm SES availability for
@@ -186,13 +186,13 @@ your target region before configuring it.
 
 SMTP transport for the install's transactional email, SES for domain-level
 sender provisioning, pinned to Canada Central for data residency. Note that the
-SES provisioning region (`EMAIL_PROVIDERS_SES_REGION`) is set independently of
+SES provisioning region (`CUSTOM_MAIL_SES_REGION`) is set independently of
 the transactional mailer:
 
 ```bash
 EMAILER_MODE=smtp
 CUSTOM_MAIL_PROVIDER=ses
-EMAIL_PROVIDERS_SES_REGION=ca-central-1
+CUSTOM_MAIL_SES_REGION=ca-central-1
 AWS_ACCESS_KEY_ID=AKIA...
 AWS_SECRET_ACCESS_KEY=...
 ORGS_CUSTOM_MAIL_ENABLED=true
@@ -203,7 +203,7 @@ ORGS_CUSTOM_MAIL_ENABLED=true
 - DNS verification failures (records not propagating, value mismatches): see
   [`docs/runbooks/dns-validation-failures.md`](../runbooks/dns-validation-failures.md).
 - Provisioning fails immediately with an invalid-region error: confirm
-  `EMAIL_PROVIDERS_SES_REGION` is a valid AWS region where SES is available
+  `CUSTOM_MAIL_SES_REGION` is a valid AWS region where SES is available
   (it defaults to `us-east-1` if unset).
 - `check_provider_verification_status` returns `not_found`: the identity was
   never created (or was deleted) — re-run provisioning.

--- a/docs/architecture/custom-mail-sender-ses.md
+++ b/docs/architecture/custom-mail-sender-ses.md
@@ -90,25 +90,37 @@ teardown via `Mailer.provider_credentials('ses')`.
 
 ## Credentials
 
-The SES API client uses standard AWS credentials. Two source pairs are accepted
-(resolved per `Mailer.build_provider_config`); the emailer/SMTP fields take
-precedence over the AWS SDK environment variables:
+The SES API client uses standard AWS credentials. To keep sender-domain
+provisioning independent of the install's SMTP/transactional mailer, the key
+pair is resolved with this precedence (highest first):
 
-| Credential | First source (emailer config) | Fallback |
-|---|---|---|
-| Access key | `SMTP_USERNAME` (emailer `user`) | `AWS_ACCESS_KEY_ID` |
-| Secret key | `SMTP_PASSWORD` (emailer `pass`) | `AWS_SECRET_ACCESS_KEY` |
+| Credential | 1st — dedicated | 2nd — AWS SDK env | 3rd — emailer config |
+|---|---|---|---|
+| Access key | `CUSTOM_MAIL_SES_ACCESS_KEY_ID` | `AWS_ACCESS_KEY_ID` | `SMTP_USERNAME` (emailer `user`) |
+| Secret key | `CUSTOM_MAIL_SES_SECRET_ACCESS_KEY` | `AWS_SECRET_ACCESS_KEY` | `SMTP_PASSWORD` (emailer `pass`) |
 
-So you can supply credentials through the dedicated AWS env vars:
+The dedicated `CUSTOM_MAIL_SES_*` vars (or the `AWS_*` vars they fall back to)
+flow through `email_providers.ses` and **override** the emailer-derived values in
+`Mailer.provider_credentials('ses')`. The emailer `user`/`pass` are used only as
+a last resort — i.e. when SES is also the delivery backend (`EMAILER_MODE=ses`)
+and neither the dedicated nor the `AWS_*` vars are set.
 
 ```bash
+# Either set works; the first non-empty source wins:
+CUSTOM_MAIL_SES_ACCESS_KEY_ID=AKIA...
+CUSTOM_MAIL_SES_SECRET_ACCESS_KEY=...
+# or the standard AWS SDK vars:
 AWS_ACCESS_KEY_ID=AKIA...
 AWS_SECRET_ACCESS_KEY=...
 ```
 
-or, when the emailer already carries them, through `SMTP_USERNAME` /
-`SMTP_PASSWORD` — whichever is set first wins (so if `SMTP_USERNAME` is set, the
-AWS env var is ignored).
+> **Why the precedence matters (SMTP collision):** if you run authenticated SMTP
+> for transactional delivery (`EMAILER_MODE=smtp`), `SMTP_USERNAME` /
+> `SMTP_PASSWORD` populate the emailer `user`/`pass`. If those were the first
+> source, the SES API client would silently use your SMTP login as the AWS key
+> pair → opaque `InvalidClientTokenId` failures. Sourcing SES credentials from
+> `CUSTOM_MAIL_SES_*` / `AWS_*` (the two rows above) keeps the SMTP login out of
+> the SES client.
 
 > **Caution:** these must be IAM access keys valid for the **SESv2 API**
 > (`CreateEmailIdentity` etc.). SES *SMTP* credentials are a different artifact
@@ -223,18 +235,25 @@ your target region before configuring it.
 ## Minimal example
 
 SMTP transport for the install's transactional email, SES for domain-level
-sender provisioning, pinned to Canada Central for data residency. Note that the
-SES provisioning region (`CUSTOM_MAIL_SES_REGION`) is set independently of
-the transactional mailer:
+sender provisioning, pinned to Canada Central for data residency. Both the SES
+region **and** credentials are set independently of the transactional mailer, so
+the SES API client is unaffected by the SMTP login used for delivery:
 
 ```bash
 EMAILER_MODE=smtp
+SMTP_USERNAME=smtp-login          # used for SMTP delivery only
+SMTP_PASSWORD=smtp-secret         # NOT used as the SES AWS key
 CUSTOM_MAIL_PROVIDER=ses
 CUSTOM_MAIL_SES_REGION=ca-central-1
-AWS_ACCESS_KEY_ID=AKIA...
-AWS_SECRET_ACCESS_KEY=...
+# SES API credentials (dedicated knob, or set AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY):
+CUSTOM_MAIL_SES_ACCESS_KEY_ID=AKIA...
+CUSTOM_MAIL_SES_SECRET_ACCESS_KEY=...
 ORGS_CUSTOM_MAIL_ENABLED=true
 ```
+
+Here `CUSTOM_MAIL_SES_ACCESS_KEY_ID` / `CUSTOM_MAIL_SES_SECRET_ACCESS_KEY` (or
+the `AWS_*` equivalents) take precedence, so the SES provisioning client uses the
+AWS key pair — never the SMTP login — even though delivery runs over SMTP.
 
 ## Troubleshooting
 

--- a/docs/architecture/custom-mail-sender-ses.md
+++ b/docs/architecture/custom-mail-sender-ses.md
@@ -4,7 +4,7 @@ title: AWS SES Sender Domain Provider
 type: reference
 status: supported
 updated: 2026-06-08
-summary: Configuring AWS SES as the provider for the domain-level custom sender flow (DKIM provisioning, verification, teardown) including region selection and data-residency.
+summary: Configuring AWS SES as the provider for the domain-level custom sender flow (DKIM + custom MAIL FROM provisioning, verification, teardown) including region selection and data-residency.
 ---
 
 AWS SES is a supported provider for the **domain-level custom sender flow**: when an
@@ -84,7 +84,7 @@ teardown via `Mailer.provider_credentials('ses')`.
 > a region through `ValidateSenderDomain` — is not needed: the region belongs on
 > the provisioning side, which is exactly what `CUSTOM_MAIL_SES_REGION`
 > drives.) Any region-specific *records* (e.g. the
-> `feedback-smtp.<region>.amazonses.com` MAIL FROM MX + SPF) must be emitted by
+> `feedback-smtp.<region>.amazonses.com` MAIL FROM MX + SPF) are emitted by
 > provisioning (`SESSenderStrategy#provision_dns_records`) and are then stored on
 > the `MailerConfig` and read back verbatim at verification.
 
@@ -120,7 +120,8 @@ The IAM principal needs, at minimum:
 | Action | Why |
 |---|---|
 | `ses:CreateEmailIdentity` | Register the sender domain identity |
-| `ses:GetEmailIdentity` | Read DKIM tokens and verification status |
+| `ses:PutEmailIdentityMailFromAttributes` | Configure the custom MAIL FROM domain (SPF alignment, bounce handling) |
+| `ses:GetEmailIdentity` | Read DKIM tokens, MAIL FROM status, and verification status |
 | `ses:DeleteEmailIdentity` | Tear the identity down on sender-config removal |
 | `ses:SendEmail` | Only if SES is also the delivery transport (`EMAILER_MODE=ses`) |
 
@@ -128,19 +129,34 @@ The IAM principal needs, at minimum:
 
 ### 1. Provision
 
-`ProvisionSenderDomain` → `SESSenderStrategy#provision_dns_records` calls
-`CreateEmailIdentity` (or `GetEmailIdentity` if the identity already exists) and
-returns three DKIM CNAME records, relative to the sender domain:
+`ProvisionSenderDomain` → `SESSenderStrategy#provision_dns_records`:
+
+1. Calls `CreateEmailIdentity` (or `GetEmailIdentity` if the identity already
+   exists) to register the domain and obtain its DKIM tokens.
+2. Calls `PutEmailIdentityMailFromAttributes` to set a custom MAIL FROM
+   subdomain (`mail.<domain>`, with `behavior_on_mx_failure: USE_DEFAULT_VALUE`),
+   so SPF aligns to the sender domain and bounces are handled on the customer's
+   own domain instead of the shared `amazonses.com` default.
+
+It returns five **fully-qualified** DNS records — three DKIM CNAMEs plus the
+MAIL FROM MX and SPF TXT:
 
 ```
-<token1>._domainkey  CNAME  <token1>.dkim.amazonses.com
-<token2>._domainkey  CNAME  <token2>.dkim.amazonses.com
-<token3>._domainkey  CNAME  <token3>.dkim.amazonses.com
+<token1>._domainkey.<domain>  CNAME  <token1>.dkim.amazonses.com
+<token2>._domainkey.<domain>  CNAME  <token2>.dkim.amazonses.com
+<token3>._domainkey.<domain>  CNAME  <token3>.dkim.amazonses.com
+mail.<domain>                 MX     feedback-smtp.<region>.amazonses.com   (priority 10)
+mail.<domain>                 TXT    v=spf1 include:amazonses.com ~all
 ```
 
-The tokens are SES-assigned per domain and stored on the `MailerConfig`
-(`provider_dns_data` for the raw response, `dns_records` for the normalized
-records shown to the customer).
+The DKIM tokens are SES-assigned per domain; the MAIL FROM MX endpoint is
+region-specific (driven by `CUSTOM_MAIL_SES_REGION`). All records are stored on
+the `MailerConfig` (`provider_dns_data` for the raw response, `dns_records` for
+the normalized records shown to the customer) and read back verbatim at
+verification. If SES rejects the MAIL FROM configuration (e.g. the region does
+not support it), provisioning still succeeds with the DKIM records and the
+MAIL FROM records are omitted, rather than asking the customer to add records
+SES will not honor.
 
 ### 2. Verify
 

--- a/docs/architecture/custom-mail-sender-ses.md
+++ b/docs/architecture/custom-mail-sender-ses.md
@@ -99,17 +99,30 @@ CUSTOM_MAIL_SES_REGION=ca-central-1
 
 ## Credentials
 
-The SES API client uses standard AWS credentials, resolved (per
-`Mailer.build_provider_config`) from the emailer config with fallback to the
-AWS SDK environment variables:
+The SES API client uses standard AWS credentials. Two source pairs are accepted
+(resolved per `Mailer.build_provider_config`); the emailer/SMTP fields take
+precedence over the AWS SDK environment variables:
+
+| Credential | First source (emailer config) | Fallback |
+|---|---|---|
+| Access key | `SMTP_USERNAME` (emailer `user`) | `AWS_ACCESS_KEY_ID` |
+| Secret key | `SMTP_PASSWORD` (emailer `pass`) | `AWS_SECRET_ACCESS_KEY` |
+
+So you can supply credentials through the dedicated AWS env vars:
 
 ```bash
 AWS_ACCESS_KEY_ID=AKIA...
 AWS_SECRET_ACCESS_KEY=...
 ```
 
-(When `SMTP_USERNAME` / `SMTP_PASSWORD` are left empty, the resolver falls back
-to `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`.)
+or, when the emailer already carries them, through `SMTP_USERNAME` /
+`SMTP_PASSWORD` — whichever is set first wins (so if `SMTP_USERNAME` is set, the
+AWS env var is ignored).
+
+> **Caution:** these must be IAM access keys valid for the **SESv2 API**
+> (`CreateEmailIdentity` etc.). SES *SMTP* credentials are a different artifact
+> and will not authenticate the API calls, so if you run SES-over-SMTP for
+> delivery, don't assume the SMTP user/pass double as API keys for provisioning.
 
 The IAM principal needs, at minimum:
 

--- a/docs/architecture/custom-mail-sender-ses.md
+++ b/docs/architecture/custom-mail-sender-ses.md
@@ -125,6 +125,28 @@ The IAM principal needs, at minimum:
 | `ses:DeleteEmailIdentity` | Tear the identity down on sender-config removal |
 | `ses:SendEmail` | Only if SES is also the delivery transport (`EMAILER_MODE=ses`) |
 
+## DMARC alignment (why custom MAIL FROM)
+
+Custom MAIL FROM is what gives SES **SPF alignment**, and it is the direct
+equivalent of Lettermint's Return-Path CNAME — same mechanism, different record
+shape. Lettermint folds it into a single `lm-bounces.<domain>` CNAME (and
+manages the SPF record on its side); SES instead exposes it as an MX + SPF TXT
+that you publish on `mail.<domain>`. Both set the envelope sender (Return-Path)
+to a subdomain of the sender domain, so SPF authenticates against *your* domain.
+
+| | Lettermint | SES *with* MAIL FROM | SES *without* MAIL FROM |
+|---|---|---|---|
+| Records added | one `lm-bounces.<domain>` CNAME | `mail.<domain>` MX + SPF TXT | DKIM CNAMEs only |
+| SPF passes | ✅ your subdomain | ✅ `mail.<domain>` | ✅ but against `amazonses.com` |
+| SPF aligns with `From:` | ✅ relaxed | ✅ relaxed | ❌ |
+| DKIM passes + aligns | ✅ strict | ✅ strict | ✅ strict |
+| DMARC passes via | SPF **and** DKIM | SPF **and** DKIM | DKIM only |
+
+Provisioning configures custom MAIL FROM by default, so DMARC passes via both
+SPF and DKIM rather than DKIM alone — i.e. no single point of failure. (This is
+also why the MAIL FROM MX is region-specific: it points at the regional SES
+feedback endpoint selected by `CUSTOM_MAIL_SES_REGION`.)
+
 ## Domain-level lifecycle
 
 ### 1. Provision

--- a/docs/architecture/custom-mail-sender-ses.md
+++ b/docs/architecture/custom-mail-sender-ses.md
@@ -47,55 +47,46 @@ delivery while still using SES for sender-domain DKIM provisioning. If
 `CUSTOM_MAIL_PROVIDER` is unset, the provisioning provider falls back to
 `EMAILER_MODE`.
 
-## Regions — two knobs
+## Region
 
-SES configuration exposes **two** region settings that serve different layers.
-Set the provisioning region (`EMAILER_REGION`) to the intended region; the
-validation knob is **currently inert** (see the #2833 decision below), but
-keeping both aligned is recommended and future-proofs the config:
-
-| Env var | Drives | Used by |
-|---|---|---|
-| `EMAILER_REGION` (falls back to `AWS_REGION`) | The SES API client endpoint | Provisioning (`create/get/delete_email_identity`) and delivery |
-| `CUSTOM_MAIL_SES_REGION` | `email_providers.ses.region` config | Validation config only — **currently inert** (see the #2833 decision below) |
+The SES provisioning region is set with its own provider-namespaced variable,
+**independent of the install-level transactional mailer**:
 
 ```bash
-EMAILER_REGION=ca-central-1
-CUSTOM_MAIL_SES_REGION=ca-central-1
+EMAIL_PROVIDERS_SES_REGION=ca-central-1   # default: us-east-1
 ```
 
-> **Gotcha:** `EMAILER_REGION` defaults to the literal placeholder `smtp`, not a
-> real AWS region. Because that placeholder is non-empty it wins over
-> `AWS_REGION`, so the SES client would be built with an invalid region and
-> provisioning would fail. **You must set `EMAILER_REGION` (or `EMAILER_MODE=ses`
-> with a real `EMAILER_REGION`) to a valid AWS region when using SES.**
+This is the deliberate point of `CUSTOM_MAIL_PROVIDER`: sender-domain
+provisioning is decoupled from `EMAILER_MODE` / `EMAILER_REGION` (which configure
+the install's own transactional email transport). An operator can run, say, SMTP
+for transactional mail and SES for sender-domain provisioning, each with its own
+region. `EMAIL_PROVIDERS_SES_REGION` maps to `email_providers.ses.region` in
+config and feeds the SESv2 API client used for provisioning, verification, and
+teardown via `Mailer.provider_credentials('ses')`.
 
-> **Decision ([#2833](https://github.com/onetimesecret/onetimesecret/issues/2833) — resolved by design):**
-> `CUSTOM_MAIL_SES_REGION` is **not** threaded through `ValidateSenderDomain`,
-> and it does not need to be. The validation strategies (SES, SendGrid,
-> Lettermint) are uniform: each reads the already-provisioned records from
-> `mailer_config.dns_records` and runs live DNS lookups against them. They
-> generate nothing from a region, so there is no validation-time value for a
-> region to influence. Region is purely a **provisioning / SES-API** concern —
-> the client region comes from `EMAILER_REGION` (→ `AWS_REGION`), and whatever
-> records SES assigns for that region are stored on the `MailerConfig` and read
-> back verbatim at verification.
->
-> Concretely, `email_providers.ses.region` is merged by `ProviderConfig` but then
-> dropped by the strategy factory (the validation strategies declare no
-> `accepted_options`), so the value is currently inert. SES DKIM records are
-> token-based CNAMEs and region-independent; any region-specific records (e.g. the
+| Setting | Configures | Source |
+|---|---|---|
+| `EMAIL_PROVIDERS_SES_REGION` | SES **sender-domain provisioning** API client | `email_providers.ses.region` → `provider_credentials('ses')` |
+| `EMAILER_REGION` (falls back to `AWS_REGION`) | The install's **transactional mailer** (only when `EMAILER_MODE=ses`) | `emailer.region` → delivery backend |
+
+> **Why a dedicated var?** Earlier, the SES provisioning client pulled its region
+> from `emailer.region` (`EMAILER_REGION`, which defaults to the placeholder
+> `smtp`), coupling provisioning to the transactional transport. That is fixed:
+> `provider_credentials('ses')` now sources region from `email_providers.ses`, so
+> `EMAILER_REGION` no longer leaks into SES provisioning.
+
+> **On validation and region:** the validation strategies (SES, SendGrid,
+> Lettermint) are region-agnostic — each reads the already-provisioned records
+> from `mailer_config.dns_records` and runs live DNS lookups against them, so
+> there is nothing for a region to influence at validation time. Region is purely
+> a **provisioning / SES-API** concern. (This is why
+> [#2833](https://github.com/onetimesecret/onetimesecret/issues/2833) — threading
+> a region through `ValidateSenderDomain` — is not needed: the region belongs on
+> the provisioning side, which is exactly what `EMAIL_PROVIDERS_SES_REGION`
+> drives.) Any region-specific *records* (e.g. the
 > `feedback-smtp.<region>.amazonses.com` MAIL FROM MX + SPF) must be emitted by
-> **provisioning** (`SESSenderStrategy#provision_dns_records`), not by validation —
-> that work belongs to this SES-promotion effort, not #2833. The earlier #2833
-> premise (a region-parameterized validation strategy that *generated* regional
-> records) predates the refactor to reading provisioned records and no longer
-> applies.
->
-> Practical guidance is unchanged: set `EMAILER_REGION`/`AWS_REGION` to the
-> intended region. This two-knob region surface is transitional and expected to
-> consolidate, so prefer driving region from the provisioning side and treat
-> `CUSTOM_MAIL_SES_REGION` as a no-op for now.
+> provisioning (`SESSenderStrategy#provision_dns_records`) and are then stored on
+> the `MailerConfig` and read back verbatim at verification.
 
 ## Credentials
 
@@ -182,11 +173,10 @@ data-residency-sensitive deployments:
 | `eu-west-1` | Europe (Ireland) |
 | `us-east-1` | US East (N. Virginia) — default |
 
-Set both region knobs to the chosen region:
+Set the provisioning region to the chosen region:
 
 ```bash
-EMAILER_REGION=ca-central-1
-CUSTOM_MAIL_SES_REGION=ca-central-1
+EMAIL_PROVIDERS_SES_REGION=ca-central-1
 ```
 
 Note that SES is not available in every AWS region; confirm SES availability for
@@ -194,14 +184,15 @@ your target region before configuring it.
 
 ## Minimal example
 
-SMTP transport for delivery, SES for domain-level sender provisioning, pinned to
-Canada Central for data residency:
+SMTP transport for the install's transactional email, SES for domain-level
+sender provisioning, pinned to Canada Central for data residency. Note that the
+SES provisioning region (`EMAIL_PROVIDERS_SES_REGION`) is set independently of
+the transactional mailer:
 
 ```bash
 EMAILER_MODE=smtp
 CUSTOM_MAIL_PROVIDER=ses
-EMAILER_REGION=ca-central-1
-CUSTOM_MAIL_SES_REGION=ca-central-1
+EMAIL_PROVIDERS_SES_REGION=ca-central-1
 AWS_ACCESS_KEY_ID=AKIA...
 AWS_SECRET_ACCESS_KEY=...
 ORGS_CUSTOM_MAIL_ENABLED=true
@@ -212,8 +203,8 @@ ORGS_CUSTOM_MAIL_ENABLED=true
 - DNS verification failures (records not propagating, value mismatches): see
   [`docs/runbooks/dns-validation-failures.md`](../runbooks/dns-validation-failures.md).
 - Provisioning fails immediately with an invalid-region error: confirm
-  `EMAILER_REGION` is a real region (see the gotcha above), not the `smtp`
-  placeholder.
+  `EMAIL_PROVIDERS_SES_REGION` is a valid AWS region where SES is available
+  (it defaults to `us-east-1` if unset).
 - `check_provider_verification_status` returns `not_found`: the identity was
   never created (or was deleted) — re-run provisioning.
 
@@ -225,4 +216,5 @@ ORGS_CUSTOM_MAIL_ENABLED=true
 | `lib/onetime/domain_validation/sender_strategies/ses_validation.rb` | DNS validation from provisioned records |
 | `lib/onetime/mail/delivery/ses.rb` | SES delivery backend (only when `EMAILER_MODE=ses`) |
 | `lib/onetime/domain_validation/sender_strategies/provider_config.rb` | `email_providers.ses` config + region validation |
+| `lib/onetime/mail/mailer.rb` | `provider_credentials('ses')` sources region from `email_providers.ses` (decoupled from `EMAILER_REGION`) |
 | `etc/defaults/config.defaults.yaml` | `emailer.sender_provider`, `email_providers.ses.*` |

--- a/docs/architecture/custom-mail-sender.md
+++ b/docs/architecture/custom-mail-sender.md
@@ -51,6 +51,23 @@ The plumbing underneath -- which provider's API to call, what DNS record shapes 
 
 Different deployments can run different global mailers (e.g. one environment uses SES, another uses Lettermint). Whatever the global mailer is, that same provider is automatically used for customer sender domain provisioning and verification. The sender strategy selection flows from the platform config, not from any per-customer setting.
 
+## Provider Comparison
+
+Every provisioning provider produces the same outcome — DKIM **and** SPF aligned to the customer's domain so DMARC passes via both paths — but each exposes it through different APIs and DNS record shapes. If you already know one provider, this maps it onto the other; if you're starting from scratch, it's the quickest way to see the shape of the problem.
+
+| | AWS SES | Lettermint |
+|---|---|---|
+| Provision API | `CreateEmailIdentity` + `PutEmailIdentityMailFromAttributes` | Team API `POST /domains` |
+| DKIM records | 3 CNAMEs (`<token>._domainkey.<domain>` → `<token>.dkim.amazonses.com`) | CNAME selectors (`<sel>._domainkey.<domain>` → `<sel>.dkim.lettermint.com`) |
+| SPF / envelope sender | custom MAIL FROM on `mail.<domain>`: an **MX + SPF TXT** the customer publishes directly | **one Return-Path CNAME** (`lm-bounces.<domain>`); Lettermint manages the SPF record on its side |
+| Verification status | `GetEmailIdentity` (DKIM + MAIL FROM status) | `GET /domains/:id` (+ `verify` trigger) |
+| Teardown | `DeleteEmailIdentity` | `DELETE /domains/:id` |
+| Strategy class | `SESSenderStrategy` | `LettermintSenderStrategy` |
+
+The one mechanism difference worth internalizing: **SES's custom MAIL FROM and Lettermint's Return-Path CNAME are equivalent** — both set the envelope sender to a subdomain of the sender domain so SPF aligns under DMARC's relaxed rules. Lettermint delegates SPF via a single CNAME (it publishes the SPF record itself); SES has no CNAME-delegated SPF, so the customer publishes an MX (to the regional `feedback-smtp.<region>.amazonses.com` endpoint) plus an SPF TXT directly. SendGrid (`automatic_security`) is CNAME-based like Lettermint. See the [SES guide](./custom-mail-sender-ses.md#dmarc-alignment-why-custom-mail-from) for the full DMARC alignment table.
+
+Validation is identical across providers: each reads the provisioned `dns_records` and runs live DNS lookups — no provider API call (see `ValidateSenderDomain`). Region is purely a provisioning concern (it selects SES's DKIM region and MAIL FROM endpoint); it plays no part in validation.
+
 ## Key Files
 
 | File | Role |

--- a/docs/architecture/custom-mail-sender.md
+++ b/docs/architecture/custom-mail-sender.md
@@ -1,5 +1,7 @@
 # Custom Mail Sender Architecture
 
+> Provider-specific setup guides: [AWS SES](./custom-mail-sender-ses.md).
+
 ## Overview
 
 The custom mail sender system lets customers send secret-link emails from their own domain identity (from-address, reply-to) while the platform handles all provider integration transparently.

--- a/etc/defaults/config.defaults.yaml
+++ b/etc/defaults/config.defaults.yaml
@@ -611,6 +611,17 @@ email_providers:
     # or ap-southeast-2 (Sydney). Confirm SES is available in the region.
     # Override via CUSTOM_MAIL_SES_REGION env var
     region: <%= ENV['CUSTOM_MAIL_SES_REGION'] || 'us-east-1' %>
+    # AWS credentials for the SES provisioning API client, kept independent of
+    # the SMTP/transactional mailer credentials. build_provider_config('ses')
+    # otherwise resolves the key pair from emailer.user/pass (i.e.
+    # SMTP_USERNAME/SMTP_PASSWORD when EMAILER_MODE=smtp), which would silently
+    # use the SMTP login as the AWS key. These dedicated knobs fall back to the
+    # standard AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY and, when set, override
+    # the emailer-derived values. Leave unset only when SES is also the delivery
+    # backend (EMAILER_MODE=ses) and the emailer already carries the AWS keys.
+    # Override via CUSTOM_MAIL_SES_ACCESS_KEY_ID / CUSTOM_MAIL_SES_SECRET_ACCESS_KEY
+    access_key_id: <%= ENV['CUSTOM_MAIL_SES_ACCESS_KEY_ID'] || ENV['AWS_ACCESS_KEY_ID'] %>
+    secret_access_key: <%= ENV['CUSTOM_MAIL_SES_SECRET_ACCESS_KEY'] || ENV['AWS_SECRET_ACCESS_KEY'] %>
     # Number of DKIM selectors (SES uses 3 by default)
     dkim_selector_count: 3
     # SPF include domain

--- a/etc/defaults/config.defaults.yaml
+++ b/etc/defaults/config.defaults.yaml
@@ -609,8 +609,8 @@ email_providers:
     # EMAILER_REGION, which configures the install-level transactional mailer.
     # For data-residency, use a regional endpoint such as ca-central-1 (Canada)
     # or ap-southeast-2 (Sydney). Confirm SES is available in the region.
-    # Override via EMAIL_PROVIDERS_SES_REGION env var
-    region: <%= ENV['EMAIL_PROVIDERS_SES_REGION'] || 'us-east-1' %>
+    # Override via CUSTOM_MAIL_SES_REGION env var
+    region: <%= ENV['CUSTOM_MAIL_SES_REGION'] || 'us-east-1' %>
     # Number of DKIM selectors (SES uses 3 by default)
     dkim_selector_count: 3
     # SPF include domain

--- a/etc/defaults/config.defaults.yaml
+++ b/etc/defaults/config.defaults.yaml
@@ -604,14 +604,13 @@ email_providers:
   # AWS SES configuration
   # See docs/architecture/custom-mail-sender-ses.md for the domain-level flow.
   ses:
-    # Region for email_providers.ses. NOTE: currently INERT (#2833, resolved by
-    # design) — the validation strategies read provisioned records and use no
-    # region. Region is driven by EMAILER_REGION (-> AWS_REGION) on the
-    # provisioning/SES-API side; set that to a real region when using SES. For
-    # data-residency, use a regional endpoint such as ca-central-1 (Canada) or
-    # ap-southeast-2 (Sydney). Confirm SES is available in the region.
-    # Override via CUSTOM_MAIL_SES_REGION env var
-    region: <%= ENV['CUSTOM_MAIL_SES_REGION'] || 'us-east-1' %>
+    # AWS region for SES sender-domain provisioning (the SESv2 API client used
+    # to create/get/delete email identities). This is independent of
+    # EMAILER_REGION, which configures the install-level transactional mailer.
+    # For data-residency, use a regional endpoint such as ca-central-1 (Canada)
+    # or ap-southeast-2 (Sydney). Confirm SES is available in the region.
+    # Override via EMAIL_PROVIDERS_SES_REGION env var
+    region: <%= ENV['EMAIL_PROVIDERS_SES_REGION'] || 'us-east-1' %>
     # Number of DKIM selectors (SES uses 3 by default)
     dkim_selector_count: 3
     # SPF include domain

--- a/etc/defaults/config.defaults.yaml
+++ b/etc/defaults/config.defaults.yaml
@@ -604,10 +604,12 @@ email_providers:
   # AWS SES configuration
   # See docs/architecture/custom-mail-sender-ses.md for the domain-level flow.
   ses:
-    # AWS region for the SES DNS validation strategy.
-    # Keep equal to EMAILER_REGION (which drives the SES API client). For
-    # data-residency, use a regional endpoint such as ca-central-1 (Canada)
-    # or ap-southeast-2 (Sydney). Confirm SES is available in the region.
+    # Region for email_providers.ses. NOTE: currently INERT (#2833, resolved by
+    # design) — the validation strategies read provisioned records and use no
+    # region. Region is driven by EMAILER_REGION (-> AWS_REGION) on the
+    # provisioning/SES-API side; set that to a real region when using SES. For
+    # data-residency, use a regional endpoint such as ca-central-1 (Canada) or
+    # ap-southeast-2 (Sydney). Confirm SES is available in the region.
     # Override via CUSTOM_MAIL_SES_REGION env var
     region: <%= ENV['CUSTOM_MAIL_SES_REGION'] || 'us-east-1' %>
     # Number of DKIM selectors (SES uses 3 by default)

--- a/etc/defaults/config.defaults.yaml
+++ b/etc/defaults/config.defaults.yaml
@@ -602,8 +602,12 @@ emailer:
 #
 email_providers:
   # AWS SES configuration
+  # See docs/architecture/custom-mail-sender-ses.md for the domain-level flow.
   ses:
-    # AWS region for SES endpoints (affects MX record values)
+    # AWS region for the SES DNS validation strategy.
+    # Keep equal to EMAILER_REGION (which drives the SES API client). For
+    # data-residency, use a regional endpoint such as ca-central-1 (Canada)
+    # or ap-southeast-2 (Sydney). Confirm SES is available in the region.
     # Override via CUSTOM_MAIL_SES_REGION env var
     region: <%= ENV['CUSTOM_MAIL_SES_REGION'] || 'us-east-1' %>
     # Number of DKIM selectors (SES uses 3 by default)

--- a/lib/onetime/initializers.rb
+++ b/lib/onetime/initializers.rb
@@ -23,6 +23,7 @@ require_relative 'initializers/configure_truemail'
 require_relative 'initializers/configure_rhales'
 require_relative 'initializers/configure_trusted_proxy'
 require_relative 'initializers/load_fortunes'
+require_relative 'initializers/setup_heap_dump_handler'
 
 # Dependent initializers
 require_relative 'initializers/validate_auth_config'    # depends_on: [:logging]

--- a/lib/onetime/initializers/setup_heap_dump_handler.rb
+++ b/lib/onetime/initializers/setup_heap_dump_handler.rb
@@ -1,0 +1,60 @@
+# lib/onetime/initializers/setup_heap_dump_handler.rb
+#
+# frozen_string_literal: true
+
+module Onetime
+  module Initializers
+    # SetupHeapDumpHandler initializer
+    #
+    # Installs a SIGUSR2 signal handler that writes an ObjectSpace heap dump
+    # to disk on demand. This gives operators a way to capture a Ruby heap
+    # snapshot from a running process without attaching GDB or restarting with
+    # extra instrumentation, which makes diagnosing RSS growth vs. Ruby heap
+    # growth in production containers significantly easier.
+    #
+    # Because this runs as a boot initializer, the handler is installed once for
+    # every OTS process regardless of execution mode (:web, :scheduler, :worker,
+    # :cli). In Puma/Sneakers cluster mode the handler is installed in the master
+    # process and inherited by forked workers — this is why the initializer is
+    # NOT marked @phase = :fork_sensitive. Marking it fork-sensitive would cause
+    # cleanup_before_fork to tear it down before workers are spawned, leaving
+    # them without the handler.
+    #
+    # Usage (after deploy):
+    #   podman exec <container> kill -USR2 <pid>
+    #   # then analyze the dump with: scripts/analyze-heapdump <file>
+    #
+    # The dump is written to HEAP_DUMP_DIR (default /tmp) as
+    # heap-<pid>-<epoch>.json. Process.pid in the filename disambiguates master
+    # vs. worker dumps in cluster mode.
+    #
+    class SetupHeapDumpHandler < Onetime::Boot::Initializer
+      @provides = [:heap_dump]
+      # Failing to install a diagnostic signal handler (e.g. USR2 unavailable on
+      # the platform) must never block application boot.
+      @optional = true
+
+      # Directory where heap dumps are written. Overridable so containers with a
+      # locked-down /tmp can redirect dumps to a writable volume.
+      DUMP_DIR = ENV.fetch('HEAP_DUMP_DIR', '/tmp')
+
+      def execute(_context)
+        Signal.trap('USR2') do
+          # ObjectSpace.dump_all is not signal-safe; running it directly in the
+          # trap context can deadlock or corrupt VM state. Spawning a thread
+          # defers the work to a normal execution context.
+          Thread.new do
+            require 'objspace'
+            path = File.join(DUMP_DIR, "heap-#{Process.pid}-#{Time.now.to_i}.json")
+            File.open(path, 'w') { |f| ObjectSpace.dump_all(output: f) }
+            Onetime.boot_logger.info "[heap] Dump written to #{path}"
+          rescue StandardError => ex
+            Onetime.boot_logger.error "[heap] Dump failed: #{ex.class}: #{ex.message}"
+          end
+        end
+
+        Onetime.boot_logger.debug "[init] SIGUSR2 heap dump handler installed (dir=#{DUMP_DIR})"
+      end
+    end
+  end
+end

--- a/lib/onetime/initializers/setup_heap_dump_handler.rb
+++ b/lib/onetime/initializers/setup_heap_dump_handler.rb
@@ -64,21 +64,32 @@ module Onetime
       end
 
       def execute(_context)
+        # Load objspace once here (execute only runs when the feature is
+        # enabled) rather than acquiring the require-mutex inside the thread
+        # spawned on every signal. require is idempotent.
+        require 'objspace'
+
         Signal.trap('USR2') do
           # ObjectSpace.dump_all is not signal-safe; running it directly in the
           # trap context can deadlock or corrupt VM state. Spawning a thread
           # defers the work to a normal execution context.
           Thread.new do
-            require 'objspace'
-            path = File.join(DUMP_DIR, "heap-#{Process.pid}-#{Time.now.to_i}.json")
+            path    = File.join(DUMP_DIR, "heap-#{Process.pid}-#{Time.now.to_i}.json")
+            created = false
             # WRONLY|CREAT|EXCL + 0600: the dump contains plaintext secrets, so
             # create it owner-only and refuse to write through an existing file
             # or symlink (anti-clobber in a shared directory).
             File.open(path, File::WRONLY | File::CREAT | File::EXCL, 0o600) do |f|
+              created = true
               ObjectSpace.dump_all(output: f)
             end
             Onetime.boot_logger.info "[heap] Dump written to #{path}"
           rescue StandardError => ex
+            # If dump_all raised mid-write we own a partial file that also holds
+            # plaintext secrets: remove it so it neither lingers nor masks the
+            # real cause as Errno::EEXIST on the next dump. Only delete a file we
+            # created — an EEXIST from the open above is not ours to remove.
+            File.delete(path) if created && File.exist?(path)
             Onetime.boot_logger.error "[heap] Dump failed: #{ex.class}: #{ex.message}"
           end
         end

--- a/lib/onetime/initializers/setup_heap_dump_handler.rb
+++ b/lib/onetime/initializers/setup_heap_dump_handler.rb
@@ -12,6 +12,12 @@ module Onetime
     # extra instrumentation, which makes diagnosing RSS growth vs. Ruby heap
     # growth in production containers significantly easier.
     #
+    # Opt-in: the handler is only installed when HEAP_DUMP_ENABLED is truthy
+    # (default off). It is a development/diagnostic tool, not an always-armed
+    # production primitive — see SECURITY below. Enabling it on a read-only
+    # podman container requires mounting a writable HEAP_DUMP_DIR and restarting
+    # anyway, so gating at boot time costs nothing operationally.
+    #
     # Because this runs as a boot initializer, the handler is installed once for
     # every OTS process regardless of execution mode (:web, :scheduler, :worker,
     # :cli). In Puma/Sneakers cluster mode the handler is installed in the master
@@ -20,21 +26,24 @@ module Onetime
     # cleanup_before_fork to tear it down before workers are spawned, leaving
     # them without the handler.
     #
-    # Usage (after deploy):
+    # Usage (after enabling and restarting):
     #   podman exec <container> kill -USR2 <pid>
     #   # then analyze the dump with: scripts/analyze-heapdump <file>
     #
-    # The dump is written to HEAP_DUMP_DIR (default /tmp) as
+    # The dump is written to HEAP_DUMP_DIR (default /var/tmp) as
     # heap-<pid>-<epoch>.json. Process.pid in the filename disambiguates master
-    # vs. worker dumps in cluster mode.
+    # vs. worker dumps in cluster mode. /var/tmp (not /tmp) is the default
+    # because Debian 13 mounts /tmp as tmpfs — a large dump there consumes RAM
+    # (counting against the container's MemoryMax) and is lost on restart,
+    # whereas /var/tmp is disk-backed and persists.
     #
     # SECURITY: ObjectSpace.dump_all serializes the `value` of every live
     # String, so a heap dump captured while secrets are in memory contains
     # plaintext secrets, session tokens, and derived key material. The dump is
     # therefore written owner-only (0600) and created exclusively (O_EXCL) so it
-    # cannot clobber or follow a pre-planted symlink in a shared /tmp. Treat the
-    # resulting file as a credential: restrict, transfer securely, and delete it
-    # once analysis is complete.
+    # cannot clobber or follow a pre-planted symlink in a shared directory. Treat
+    # the resulting file as a credential: restrict, transfer securely, and delete
+    # it once analysis is complete.
     #
     class SetupHeapDumpHandler < Onetime::Boot::Initializer
       @provides = [:heap_dump]
@@ -42,9 +51,17 @@ module Onetime
       # the platform) must never block application boot.
       @optional = true
 
-      # Directory where heap dumps are written. Overridable so containers with a
-      # locked-down /tmp can redirect dumps to a writable volume.
-      DUMP_DIR = ENV.fetch('HEAP_DUMP_DIR', '/tmp')
+      # Directory where heap dumps are written. Overridable so deployments can
+      # redirect dumps to a writable, disk-backed volume. Defaults to /var/tmp
+      # (disk-backed and persistent on Debian 13, unlike the tmpfs /tmp).
+      DUMP_DIR = ENV.fetch('HEAP_DUMP_DIR', '/var/tmp')
+
+      # Default-off: only install the handler when HEAP_DUMP_ENABLED is truthy.
+      # Skipping here means the trap is never registered, so a disabled deploy
+      # carries zero runtime surface for this diagnostic primitive.
+      def should_skip?
+        !Onetime::Utils.yes?(ENV.fetch('HEAP_DUMP_ENABLED', nil))
+      end
 
       def execute(_context)
         Signal.trap('USR2') do
@@ -56,7 +73,7 @@ module Onetime
             path = File.join(DUMP_DIR, "heap-#{Process.pid}-#{Time.now.to_i}.json")
             # WRONLY|CREAT|EXCL + 0600: the dump contains plaintext secrets, so
             # create it owner-only and refuse to write through an existing file
-            # or symlink (anti-clobber in a shared /tmp).
+            # or symlink (anti-clobber in a shared directory).
             File.open(path, File::WRONLY | File::CREAT | File::EXCL, 0o600) do |f|
               ObjectSpace.dump_all(output: f)
             end

--- a/lib/onetime/initializers/setup_heap_dump_handler.rb
+++ b/lib/onetime/initializers/setup_heap_dump_handler.rb
@@ -28,6 +28,14 @@ module Onetime
     # heap-<pid>-<epoch>.json. Process.pid in the filename disambiguates master
     # vs. worker dumps in cluster mode.
     #
+    # SECURITY: ObjectSpace.dump_all serializes the `value` of every live
+    # String, so a heap dump captured while secrets are in memory contains
+    # plaintext secrets, session tokens, and derived key material. The dump is
+    # therefore written owner-only (0600) and created exclusively (O_EXCL) so it
+    # cannot clobber or follow a pre-planted symlink in a shared /tmp. Treat the
+    # resulting file as a credential: restrict, transfer securely, and delete it
+    # once analysis is complete.
+    #
     class SetupHeapDumpHandler < Onetime::Boot::Initializer
       @provides = [:heap_dump]
       # Failing to install a diagnostic signal handler (e.g. USR2 unavailable on
@@ -46,7 +54,12 @@ module Onetime
           Thread.new do
             require 'objspace'
             path = File.join(DUMP_DIR, "heap-#{Process.pid}-#{Time.now.to_i}.json")
-            File.open(path, 'w') { |f| ObjectSpace.dump_all(output: f) }
+            # WRONLY|CREAT|EXCL + 0600: the dump contains plaintext secrets, so
+            # create it owner-only and refuse to write through an existing file
+            # or symlink (anti-clobber in a shared /tmp).
+            File.open(path, File::WRONLY | File::CREAT | File::EXCL, 0o600) do |f|
+              ObjectSpace.dump_all(output: f)
+            end
             Onetime.boot_logger.info "[heap] Dump written to #{path}"
           rescue StandardError => ex
             Onetime.boot_logger.error "[heap] Dump failed: #{ex.class}: #{ex.message}"

--- a/lib/onetime/mail/mailer.rb
+++ b/lib/onetime/mail/mailer.rb
@@ -132,7 +132,22 @@ module Onetime
         #   Onetime::Mail::Mailer.provider_credentials('ses')
         #   # => { 'region' => 'us-east-1', 'access_key_id' => '...', 'secret_access_key' => '...' }
         def provider_credentials(provider)
-          build_provider_config(provider)
+          config = build_provider_config(provider)
+
+          # Sender-domain provisioning is decoupled from the install-level
+          # transactional mailer (EMAILER_MODE / EMAILER_REGION). Provider-
+          # specific settings come from email_providers.<provider> so an
+          # operator can run, e.g., SMTP for transactional delivery while
+          # provisioning sender domains through SES — without EMAILER_REGION
+          # leaking into the SES provisioning client. The delivery path
+          # (create_delivery_backend) keeps using emailer config directly.
+          if provider.to_s.downcase == 'ses'
+            ses_conf = provider_config('ses')
+            region   = ses_conf['region'] || ses_conf[:region]
+            config['region'] = region.to_s if region && !region.to_s.empty?
+          end
+
+          config
         end
 
         # Returns the provider for custom mail sender domain provisioning.

--- a/lib/onetime/mail/mailer.rb
+++ b/lib/onetime/mail/mailer.rb
@@ -135,6 +135,22 @@ module Onetime
           build_provider_config(provider)
         end
 
+        # Returns the provider for custom mail sender domain provisioning.
+        #
+        # Resolves, in order: the explicit `sender_provider` emailer config,
+        # then the sending transport (determine_provider, e.g. EMAILER_MODE).
+        # Public because per-domain sender configs fall back to it when they
+        # carry no explicit provider (see MailerConfig#effective_provider).
+        #
+        # @return [String] Lowercased provider name (e.g. 'ses', 'lettermint')
+        def determine_sender_provider
+          conf = emailer_config
+          sp   = conf['sender_provider']
+          return sp.to_s.downcase.strip if sp.is_a?(String) && !sp.strip.empty?
+
+          determine_provider
+        end
+
         private
 
         def template_class_for(name)
@@ -214,16 +230,6 @@ module Onetime
           else
             warn message
           end
-        end
-
-        # Returns the provider for custom mail sender domain provisioning.
-        # Falls back to the sending transport (determine_provider) when unset.
-        def determine_sender_provider
-          conf = emailer_config
-          sp   = conf['sender_provider']
-          return sp.to_s.downcase.strip if sp.is_a?(String) && !sp.strip.empty?
-
-          determine_provider
         end
 
         def determine_provider

--- a/lib/onetime/mail/mailer.rb
+++ b/lib/onetime/mail/mailer.rb
@@ -135,16 +135,25 @@ module Onetime
           config = build_provider_config(provider)
 
           # Sender-domain provisioning is decoupled from the install-level
-          # transactional mailer (EMAILER_MODE / EMAILER_REGION). Provider-
-          # specific settings come from email_providers.<provider> so an
+          # transactional mailer (EMAILER_MODE / EMAILER_REGION / SMTP_*).
+          # Provider-specific settings come from email_providers.<provider> so an
           # operator can run, e.g., SMTP for transactional delivery while
-          # provisioning sender domains through SES — without EMAILER_REGION
-          # leaking into the SES provisioning client. The delivery path
-          # (create_delivery_backend) keeps using emailer config directly.
+          # provisioning sender domains through SES — without EMAILER_REGION or
+          # the SMTP credentials (SMTP_USERNAME/SMTP_PASSWORD, which
+          # build_provider_config resolves as emailer.user/pass) leaking into the
+          # SES provisioning client. email_providers.ses.{region,access_key_id,
+          # secret_access_key} default to the dedicated CUSTOM_MAIL_SES_* vars
+          # (falling back to AWS_REGION / AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY),
+          # so these override the emailer-derived values whenever set. When none
+          # are set (e.g. EMAILER_MODE=ses, where emailer.user is the AWS key),
+          # the override is skipped and the emailer-derived value is kept. The
+          # delivery path (create_delivery_backend) uses emailer config directly.
           if provider.to_s.downcase == 'ses'
             ses_conf = provider_config('ses')
-            region   = ses_conf['region'] || ses_conf[:region]
-            config['region'] = region.to_s if region && !region.to_s.empty?
+            %w[region access_key_id secret_access_key].each do |key|
+              value = ses_conf[key] || ses_conf[key.to_sym]
+              config[key] = value.to_s unless value.to_s.empty?
+            end
           end
 
           config

--- a/lib/onetime/mail/sender_strategies.rb
+++ b/lib/onetime/mail/sender_strategies.rb
@@ -74,6 +74,20 @@ module Onetime
           PROVISIONING_PROVIDERS.include?(provider.to_s.downcase)
         end
 
+        # Check if a provider has a sender strategy at all.
+        #
+        # Broader than supports_provisioning?: this includes 'smtp', whose
+        # strategy is a deliberate no-op for identity provisioning and
+        # teardown. Use this to decide whether an operation can be
+        # dispatched to a strategy (e.g. sender-identity deletion).
+        #
+        # @param provider [String, Symbol] Provider name
+        # @return [Boolean] true if a strategy is registered for the provider
+        #
+        def supported?(provider)
+          PROVIDER_STRATEGIES.key?(provider.to_s.downcase)
+        end
+
         # List all supported provider names.
         #
         # @return [Array<String>] Provider names

--- a/lib/onetime/mail/sender_strategies/lettermint_sender_strategy.rb
+++ b/lib/onetime/mail/sender_strategies/lettermint_sender_strategy.rb
@@ -30,6 +30,16 @@ module Onetime
       #   lm2._domainkey.example.com CNAME lm2.dkim.lettermint.com
       #   lm-bounces.example.com     CNAME bounces.lmta.net
       #
+      # Provider comparison (for devs coming from SES): the lm-bounces.<domain>
+      # Return-Path CNAME above is Lettermint's equivalent of SES's custom MAIL
+      # FROM. Both put the envelope sender on a subdomain of the sender domain so
+      # SPF aligns with the From: domain under DMARC — same outcome, different
+      # record shape. Lettermint delegates SPF via this one CNAME (it publishes
+      # the SPF record on its side); SES instead emits an MX + SPF TXT on
+      # mail.<domain> that the customer publishes directly. DKIM is CNAME-based
+      # on both. See SESSenderStrategy and
+      # docs/architecture/custom-mail-sender.md (Provider Comparison).
+      #
       # Lettermint has TWO separate APIs:
       #   1. Sending API - uses x-lettermint-token header (project token)
       #   2. Team API    - uses Authorization: Bearer header (team token)

--- a/lib/onetime/mail/sender_strategies/ses_sender_strategy.rb
+++ b/lib/onetime/mail/sender_strategies/ses_sender_strategy.rb
@@ -27,6 +27,16 @@ module Onetime
       #   { type: 'MX',    name: 'mail.example.com',              value: 'feedback-smtp.us-east-1.amazonses.com' }
       #   { type: 'TXT',   name: 'mail.example.com',              value: 'v=spf1 include:amazonses.com ~all' }
       #
+      # Provider comparison (for devs coming from Lettermint): the MAIL FROM
+      # MX + SPF TXT above are SES's equivalent of Lettermint's single
+      # Return-Path CNAME (lm-bounces.<domain>). Both put the envelope sender on
+      # a subdomain of the sender domain so SPF aligns with the From: domain
+      # under DMARC — same outcome, different record shape. SES has no
+      # CNAME-delegated SPF, so the customer publishes the MX (regional feedback
+      # endpoint) and SPF TXT directly, whereas Lettermint manages SPF behind
+      # its CNAME. See LettermintSenderStrategy and
+      # docs/architecture/custom-mail-sender.md (Provider Comparison).
+      #
       # Configuration:
       #   region:            AWS region (default: us-east-1)
       #   access_key_id:     AWS access key

--- a/lib/onetime/mail/sender_strategies/ses_sender_strategy.rb
+++ b/lib/onetime/mail/sender_strategies/ses_sender_strategy.rb
@@ -10,15 +10,22 @@ module Onetime
       # SESSenderStrategy - AWS SES sender domain provisioning.
       #
       # Provisions email identities through SES v2 API and retrieves
-      # DKIM tokens for DNS configuration.
+      # DKIM tokens for DNS configuration. Also configures a custom MAIL
+      # FROM domain so SPF aligns to the sender domain and bounces are
+      # handled on the customer's domain rather than the shared
+      # amazonses.com default.
       #
       # SES provides DKIM authentication via 3 CNAME records with
-      # tokens that must be added to the domain's DNS.
+      # tokens that must be added to the domain's DNS. The custom MAIL
+      # FROM adds an MX record (to the regional feedback endpoint) and an
+      # SPF TXT record on the MAIL FROM subdomain.
       #
-      # Example DNS records returned (name is relative, without the domain suffix):
-      #   { type: 'CNAME', name: 'token1._domainkey', value: 'token1.dkim.amazonses.com' }
-      #   { type: 'CNAME', name: 'token2._domainkey', value: 'token2.dkim.amazonses.com' }
-      #   { type: 'CNAME', name: 'token3._domainkey', value: 'token3.dkim.amazonses.com' }
+      # Example DNS records returned (names are fully-qualified):
+      #   { type: 'CNAME', name: 'token1._domainkey.example.com', value: 'token1.dkim.amazonses.com' }
+      #   { type: 'CNAME', name: 'token2._domainkey.example.com', value: 'token2.dkim.amazonses.com' }
+      #   { type: 'CNAME', name: 'token3._domainkey.example.com', value: 'token3.dkim.amazonses.com' }
+      #   { type: 'MX',    name: 'mail.example.com',              value: 'feedback-smtp.us-east-1.amazonses.com' }
+      #   { type: 'TXT',   name: 'mail.example.com',              value: 'v=spf1 include:amazonses.com ~all' }
       #
       # Configuration:
       #   region:            AWS region (default: us-east-1)
@@ -26,6 +33,13 @@ module Onetime
       #   secret_access_key: AWS secret key
       #
       class SESSenderStrategy < BaseSenderStrategy
+        # Default region when none is supplied via credentials.
+        DEFAULT_REGION = 'us-east-1'
+
+        # Subdomain label used for the custom MAIL FROM domain. AWS convention
+        # is a subdomain of the sender domain (e.g. "mail.example.com").
+        MAIL_FROM_SUBDOMAIN = 'mail'
+
         def provision_dns_records(mailer_config, credentials:)
           domain = extract_domain(mailer_config.from_address)
 
@@ -38,22 +52,48 @@ module Onetime
             }
           end
 
-          log_info "[ses-sender] Provisioning sender identity for #{domain}"
+          missing = missing_credential_keys(credentials)
+          unless missing.empty?
+            return {
+              success: false,
+              message: "AWS credentials required for SES provisioning (missing: #{missing.join(', ')})",
+              dns_records: [],
+              error: 'missing_credentials',
+            }
+          end
+
+          region = credentials['region'] || DEFAULT_REGION
+          log_info "[ses-sender] Provisioning sender identity for #{domain} (region: #{region})"
 
           client   = build_ses_client(credentials)
           response = create_or_get_email_identity(client, domain)
 
           dkim_tokens = response.dkim_attributes&.tokens || []
+          records     = build_dkim_records(dkim_tokens, domain)
+
+          # Configure a custom MAIL FROM domain so SPF aligns to the sender
+          # domain and bounces land on the customer's own domain. SES requires
+          # an MX record (to the regional feedback endpoint) plus an SPF TXT
+          # record on the MAIL FROM subdomain; both are deterministic given the
+          # region. Non-fatal: if SES rejects it we keep the DKIM records and
+          # drop the MAIL FROM records (see #configure_mail_from).
+          mail_from_domain = "#{MAIL_FROM_SUBDOMAIN}.#{domain}"
+          if configure_mail_from(client, domain, mail_from_domain)
+            records += build_mail_from_records(mail_from_domain, region)
+          else
+            mail_from_domain = nil
+          end
 
           {
             success: true,
             message: "Provisioned sender identity for #{domain}",
-            dns_records: build_dkim_records(dkim_tokens),
+            dns_records: records,
             provider_data: {
               dkim_tokens: dkim_tokens,
-              region: credentials['region'] || 'us-east-1',
+              region: region,
               identity: domain,
               dkim_status: response.dkim_attributes&.status,
+              mail_from_domain: mail_from_domain,
             },
           }
         rescue Aws::SESV2::Errors::ServiceError => ex
@@ -63,6 +103,14 @@ module Onetime
             message: "SES provisioning failed: #{ex.message}",
             dns_records: [],
             error: ex.code,
+          }
+        rescue StandardError => ex
+          log_error "[ses-sender] Provisioning failed: #{ex.message}"
+          {
+            success: false,
+            message: "Provisioning failed: #{ex.message}",
+            dns_records: [],
+            error: ex.message,
           }
         end
 
@@ -89,6 +137,7 @@ module Onetime
           dkim_attrs  = response.dkim_attributes
           dkim_status = dkim_attrs&.status || 'NOT_STARTED'
           verified    = dkim_status == 'SUCCESS'
+          mail_from   = response.mail_from_attributes
 
           {
             verified: verified,
@@ -98,6 +147,8 @@ module Onetime
               dkim_signing_enabled: dkim_attrs&.signing_enabled,
               dkim_tokens: dkim_attrs&.tokens,
               identity_type: response.identity_type,
+              mail_from_domain: mail_from&.mail_from_domain,
+              mail_from_status: mail_from&.mail_from_domain_status,
             },
           }
         rescue Aws::SESV2::Errors::NotFoundException
@@ -108,6 +159,13 @@ module Onetime
           }
         rescue Aws::SESV2::Errors::ServiceError => ex
           log_error "[ses-sender] SES API error: #{ex.message}"
+          {
+            verified: false,
+            status: 'error',
+            message: "SES verification check failed: #{ex.message}",
+          }
+        rescue StandardError => ex
+          log_error "[ses-sender] Verification check failed: #{ex.message}"
           {
             verified: false,
             status: 'error',
@@ -145,6 +203,12 @@ module Onetime
             deleted: false,
             message: "SES deletion failed: #{ex.message}",
           }
+        rescue StandardError => ex
+          log_error "[ses-sender] Deletion failed: #{ex.message}"
+          {
+            deleted: false,
+            message: "SES deletion failed: #{ex.message}",
+          }
         end
 
         protected
@@ -165,7 +229,7 @@ module Onetime
           require 'aws-sdk-sesv2'
 
           Aws::SESV2::Client.new(
-            region: credentials['region'] || 'us-east-1',
+            region: credentials['region'] || DEFAULT_REGION,
             credentials: Aws::Credentials.new(
               credentials['access_key_id'],
               credentials['secret_access_key'],
@@ -186,19 +250,89 @@ module Onetime
           client.get_email_identity(email_identity: domain)
         end
 
-        # Builds DNS record hashes from DKIM tokens.
+        # Builds DKIM CNAME record hashes from SES tokens.
+        #
+        # Names are emitted as fully-qualified hostnames (including the sender
+        # domain) so the verification layer can resolve them directly and the
+        # UI can display them verbatim — consistent with the SendGrid and
+        # Lettermint strategies.
         #
         # @param tokens [Array<String>] DKIM tokens from SES
+        # @param domain [String] Sender domain (e.g. "example.com")
         # @return [Array<Hash>] DNS records in standard format
         #
-        def build_dkim_records(tokens)
+        def build_dkim_records(tokens, domain)
           tokens.map do |token|
             {
               type: 'CNAME',
-              name: "#{token}._domainkey",
+              name: "#{token}._domainkey.#{domain}",
               value: "#{token}.dkim.amazonses.com",
             }
           end
+        end
+
+        # Builds the custom MAIL FROM DNS records (MX + SPF TXT).
+        #
+        # The MX points at the regional SES feedback endpoint; the SPF TXT
+        # authorizes amazonses.com for the MAIL FROM subdomain. Both are
+        # required by SES once a custom MAIL FROM domain is configured.
+        #
+        # @param mail_from_domain [String] e.g. "mail.example.com"
+        # @param region [String] AWS region (drives the feedback endpoint)
+        # @return [Array<Hash>] MX and TXT records in standard format
+        #
+        def build_mail_from_records(mail_from_domain, region)
+          [
+            {
+              type: 'MX',
+              name: mail_from_domain,
+              value: "feedback-smtp.#{region}.amazonses.com",
+            },
+            {
+              type: 'TXT',
+              name: mail_from_domain,
+              value: 'v=spf1 include:amazonses.com ~all',
+            },
+          ]
+        end
+
+        # Configures a custom MAIL FROM domain on the SES identity.
+        #
+        # Non-fatal: the identity and DKIM are already provisioned, and a
+        # custom MAIL FROM is an enhancement (SPF alignment + custom
+        # Return-Path). If SES rejects the request we log and skip its records
+        # rather than asking the customer to add records SES will not honor.
+        # USE_DEFAULT_VALUE keeps mail flowing via the amazonses.com MAIL FROM
+        # until the customer's MX propagates.
+        #
+        # @param client [Aws::SESV2::Client]
+        # @param domain [String] Sender domain (the SES identity)
+        # @param mail_from_domain [String] Custom MAIL FROM subdomain
+        # @return [Boolean] true if SES accepted the MAIL FROM configuration
+        #
+        def configure_mail_from(client, domain, mail_from_domain)
+          client.put_email_identity_mail_from_attributes(
+            email_identity: domain,
+            mail_from_domain: mail_from_domain,
+            behavior_on_mx_failure: 'USE_DEFAULT_VALUE',
+          )
+          true
+        rescue Aws::SESV2::Errors::ServiceError => ex
+          log_warn "[ses-sender] MAIL FROM setup failed for #{domain}: #{ex.message}"
+          false
+        end
+
+        # Returns the required credential keys that are missing or blank.
+        #
+        # Mirrors Lettermint/SendGrid which reject missing credentials up
+        # front with a clear error rather than failing at API-call time with
+        # an opaque AWS exception (e.g. MissingCredentialsError).
+        #
+        # @param credentials [Hash] Provider credentials (string keys per contract)
+        # @return [Array<String>] Missing key names (empty if all present)
+        #
+        def missing_credential_keys(credentials)
+          %w[access_key_id secret_access_key].select { |key| credentials[key].to_s.empty? }
         end
 
         # Maps SES DKIM status to human-readable message.

--- a/lib/onetime/models/custom_domain/mailer_config.rb
+++ b/lib/onetime/models/custom_domain/mailer_config.rb
@@ -436,17 +436,20 @@ module Onetime
 
       # Resolve effective provider for this mailer config.
       #
-      # Uses the config's provider field if set, otherwise falls back to
-      # installation-level provider from Mailer.determine_provider.
+      # Uses the config's provider field if set, otherwise falls back to the
+      # installation-level sender provider (Mailer.determine_sender_provider).
+      # The result is normalized (stripped, lowercased) so every consumer —
+      # strategy dispatch, credential lookup, comparisons — sees a canonical
+      # provider name and need not re-normalize.
       #
-      # @return [String, nil] Provider name or nil if not resolvable
+      # @return [String] Lowercased provider name, or '' if not resolvable
       def effective_provider
-        resolved = provider.to_s.strip
+        resolved = provider.to_s.strip.downcase
         return resolved unless resolved.empty?
 
         # Fallback to installation-level sender provider, which itself
         # falls back to the sending transport (EMAILER_MODE).
-        Onetime::Mail::Mailer.send(:determine_sender_provider)
+        Onetime::Mail::Mailer.determine_sender_provider.to_s.strip.downcase
       end
 
       class << self

--- a/lib/onetime/operations/delete_sender_domain.rb
+++ b/lib/onetime/operations/delete_sender_domain.rb
@@ -51,10 +51,20 @@ module Onetime
         strategy    = Onetime::Mail::SenderStrategies.for_provider(provider)
         result      = strategy.delete_sender_identity(@mailer_config, credentials: credentials)
 
-        logger.info 'Sender domain deleted',
-          domain_id: @mailer_config.domain_id,
-          provider: provider,
-          message: result[:message]
+        # Strategies signal an actual teardown via result[:deleted]. SMTP —
+        # and some error/no-op cases — return deleted:false, so log those
+        # distinctly to keep audit trails free of false "deleted" events.
+        if result[:deleted]
+          logger.info 'Sender domain deleted',
+            domain_id: @mailer_config.domain_id,
+            provider: provider,
+            message: result[:message]
+        else
+          logger.info 'Sender domain deletion skipped (no-op)',
+            domain_id: @mailer_config.domain_id,
+            provider: provider,
+            message: result[:message]
+        end
 
         Result.new(success: true, message: result[:message], error: nil)
       rescue StandardError => ex

--- a/lib/onetime/operations/delete_sender_domain.rb
+++ b/lib/onetime/operations/delete_sender_domain.rb
@@ -6,8 +6,13 @@ require_relative '../mail/sender_strategies'
 
 module Onetime
   module Operations
-    # Deletes a sender domain from the mail provider (currently Lettermint).
+    # Deletes a sender domain from its mail provider.
     # Extracted from RemoveDomain and DeleteSenderConfig for reuse.
+    #
+    # Dispatches on the mailer config's effective_provider, so each
+    # provider's sender identity is torn down through its own strategy
+    # (SES, SendGrid, Lettermint). SMTP is a no-op — there is no remote
+    # sender identity to delete.
     #
     # Never raises — all errors are wrapped in the Result.
     # Callers can fire-and-forget: domain/config removal proceeds regardless.
@@ -30,14 +35,17 @@ module Onetime
 
       def call
         return skipped('no mailer config') unless @mailer_config
-        return skipped('not a lettermint provider') unless @mailer_config.effective_provider == 'lettermint'
 
-        credentials = Onetime::Mail::Mailer.provider_credentials('lettermint')
-        strategy    = Onetime::Mail::SenderStrategies.for_provider('lettermint')
+        provider = resolve_provider
+        return skipped('no effective provider') if provider.empty?
+
+        credentials = Onetime::Mail::Mailer.provider_credentials(provider)
+        strategy    = Onetime::Mail::SenderStrategies.for_provider(provider)
         result      = strategy.delete_sender_identity(@mailer_config, credentials: credentials)
 
         logger.info 'Sender domain deleted',
           domain_id: @mailer_config.domain_id,
+          provider: provider,
           message: result[:message]
 
         Result.new(success: true, message: result[:message], error: nil)
@@ -50,6 +58,23 @@ module Onetime
       end
 
       private
+
+      # Resolve the provider to dispatch sender-identity deletion to.
+      #
+      # Prefers the mailer config's effective_provider (which itself
+      # falls back to the installation-level sender provider). When that
+      # is unresolvable, default to 'lettermint' for back-compat with
+      # configs created before the `provider` field existed — but only
+      # when a from_address remains to tear down. Returns an empty
+      # string when there is nothing to act on.
+      #
+      # @return [String] Lowercased provider name, or '' when unresolvable
+      def resolve_provider
+        provider = @mailer_config.effective_provider.to_s.strip.downcase
+        return provider unless provider.empty?
+
+        @mailer_config.from_address.to_s.strip.empty? ? '' : 'lettermint'
+      end
 
       def skipped(reason)
         Result.new(success: true, message: "skipped: #{reason}", error: nil)

--- a/lib/onetime/operations/delete_sender_domain.rb
+++ b/lib/onetime/operations/delete_sender_domain.rb
@@ -12,7 +12,9 @@ module Onetime
     # Dispatches on the mailer config's effective_provider, so each
     # provider's sender identity is torn down through its own strategy
     # (SES, SendGrid, Lettermint). SMTP is a no-op — there is no remote
-    # sender identity to delete.
+    # sender identity to delete. Configs that resolve to no provider, or
+    # to a transport without a sender strategy (e.g. 'logger'), are
+    # skipped rather than treated as errors.
     #
     # Never raises — all errors are wrapped in the Result.
     # Callers can fire-and-forget: domain/config removal proceeds regardless.
@@ -36,8 +38,14 @@ module Onetime
       def call
         return skipped('no mailer config') unless @mailer_config
 
-        provider = resolve_provider
+        # effective_provider is the single source of truth: it returns the
+        # config's provider, or the installation default, already normalized.
+        # Legacy configs predating the provider field resolve correctly here
+        # via that installation-level fallback.
+        provider = @mailer_config.effective_provider.to_s
         return skipped('no effective provider') if provider.empty?
+        return skipped("unsupported provider '#{provider}'") unless
+          Onetime::Mail::SenderStrategies.supported?(provider)
 
         credentials = Onetime::Mail::Mailer.provider_credentials(provider)
         strategy    = Onetime::Mail::SenderStrategies.for_provider(provider)
@@ -58,23 +66,6 @@ module Onetime
       end
 
       private
-
-      # Resolve the provider to dispatch sender-identity deletion to.
-      #
-      # Prefers the mailer config's effective_provider (which itself
-      # falls back to the installation-level sender provider). When that
-      # is unresolvable, default to 'lettermint' for back-compat with
-      # configs created before the `provider` field existed — but only
-      # when a from_address remains to tear down. Returns an empty
-      # string when there is nothing to act on.
-      #
-      # @return [String] Lowercased provider name, or '' when unresolvable
-      def resolve_provider
-        provider = @mailer_config.effective_provider.to_s.strip.downcase
-        return provider unless provider.empty?
-
-        @mailer_config.from_address.to_s.strip.empty? ? '' : 'lettermint'
-      end
 
       def skipped(reason)
         Result.new(success: true, message: "skipped: #{reason}", error: nil)

--- a/locales/content/en/workspace-domains.json
+++ b/locales/content/en/workspace-domains.json
@@ -875,6 +875,12 @@
     "text": "Allow external users to send secrets directly to designated recipients on this domain",
     "content_hash": "452ab4fe"
   },
+  "web.domains.incoming.feature_disabled": {
+    "text": "Incoming Secrets Unavailable"
+  },
+  "web.domains.incoming.feature_disabled_description": {
+    "text": "Incoming secrets is not enabled on this instance. Contact your administrator."
+  },
   "web.domains.incoming.access_denied": {
     "text": "Access Denied",
     "content_hash": "d134ca02"

--- a/scripts/analyze-heapdump
+++ b/scripts/analyze-heapdump
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+# scripts/analyze-heapdump
+
+##
+# HEAP DUMP ANALYSIS SCRIPT
+#
+# Summarizes an ObjectSpace.dump_all heap dump (JSON lines) produced by the
+# SIGUSR2 heap dump handler (see lib/onetime/initializers/setup_heap_dump_handler.rb).
+#
+# Produces three passes:
+#   1. Object counts by type        (what is there a lot of?)
+#   2. Total bytes by type          (what is using the most memory?)
+#   3. Top STRING allocation sites  (where are strings being created?)
+#
+# Usage:
+#   scripts/analyze-heapdump /tmp/heap-<pid>-<epoch>.json
+#
+# Capture a dump first with:
+#   kill -USR2 <pid>          # or: podman exec <container> kill -USR2 <pid>
+#
+# For reference-chain analysis (why is an object still alive), use `sheap`.
+#
+# Requires: jq, awk, sort, uniq
+#
+# Exit codes:
+#   0 - Analysis completed
+#   1 - Missing argument, file not found, or jq unavailable
+
+set -euo pipefail
+
+DUMP="${1:-}"
+
+if [[ -z "$DUMP" ]]; then
+  echo "Usage: $0 <heap-dump.json>" >&2
+  exit 1
+fi
+
+if [[ ! -f "$DUMP" ]]; then
+  echo "Error: file not found: $DUMP" >&2
+  exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "Error: jq is required but not installed" >&2
+  exit 1
+fi
+
+echo "=== Object counts by type (top 20) ==="
+jq -r '.type' "$DUMP" | sort | uniq -c | sort -rn | head -20
+
+echo
+echo "=== Total bytes by type (descending) ==="
+jq -r 'select(.memsize) | "\(.type) \(.memsize)"' "$DUMP" \
+  | awk '{sum[$1]+=$2} END {for (t in sum) print sum[t], t}' | sort -rn
+
+echo
+echo "=== Top STRING allocation sites (file:line, top 20) ==="
+jq -r 'select(.type=="STRING" and .file) | "\(.file):\(.line)"' "$DUMP" \
+  | sort | uniq -c | sort -rn | head -20

--- a/scripts/analyze-heapdump
+++ b/scripts/analyze-heapdump
@@ -19,6 +19,9 @@
 # Capture a dump first with:
 #   kill -USR2 <pid>          # or: podman exec <container> kill -USR2 <pid>
 #
+# SECURITY: a heap dump contains plaintext secrets and key material that were
+# live in memory. Treat the dump file as a credential and delete it when done.
+#
 # For reference-chain analysis (why is an object still alive), use `sheap`.
 #
 # Requires: jq, awk, sort, uniq

--- a/scripts/analyze-heapdump
+++ b/scripts/analyze-heapdump
@@ -14,7 +14,8 @@
 #   3. Top STRING allocation sites  (where are strings being created?)
 #
 # Usage:
-#   scripts/analyze-heapdump /tmp/heap-<pid>-<epoch>.json
+#   scripts/analyze-heapdump /var/tmp/heap-<pid>-<epoch>.json
+#   (the handler writes to HEAP_DUMP_DIR, default /var/tmp)
 #
 # Capture a dump first with:
 #   kill -USR2 <pid>          # or: podman exec <container> kill -USR2 <pid>

--- a/spec/integration/all/default_workspace_creation_spec.rb
+++ b/spec/integration/all/default_workspace_creation_spec.rb
@@ -10,6 +10,15 @@ RSpec.describe 'default_workspace_creation_try', type: :integration, order: :def
     # Clear Redis env vars to ensure test config defaults are used (port 2121)
     ENV.delete('REDIS_URL')
     ENV.delete('VALKEY_URL')
+
+    # Standalone materialization happens inside Organization.create!, which
+    # runs here in before(:all) -- BEFORE billing_isolation.rb's before(:each)
+    # disable hook fires. So a prior spec (or env) leaving BILLING_ENABLED=true
+    # would make create! treat the org as SaaS and skip materialization,
+    # failing the standalone assertions below. Disable billing explicitly here
+    # so this spec is self-contained rather than dependent on hook ordering.
+    BillingTestHelpers.disable_billing!
+
     begin
       OT.boot! :test, false unless OT.ready?
     rescue Redis::CannotConnectError, Redis::ConnectionError => e

--- a/spec/unit/onetime/initializers/setup_heap_dump_handler_spec.rb
+++ b/spec/unit/onetime/initializers/setup_heap_dump_handler_spec.rb
@@ -28,6 +28,40 @@ RSpec.describe Onetime::Initializers::SetupHeapDumpHandler do
       # before Puma/Sneakers workers are spawned, losing the handler.
       expect(described_class.phase).to eq(:preload)
     end
+
+    it 'defaults the dump directory to the disk-backed /var/tmp' do
+      # /tmp is tmpfs on Debian 13; a large dump there consumes RAM and is lost
+      # on restart, so the default must be disk-backed.
+      expect(described_class::DUMP_DIR).to eq('/var/tmp')
+    end
+  end
+
+  describe '#should_skip?' do
+    around do |example|
+      original = ENV.fetch('HEAP_DUMP_ENABLED', nil)
+      example.run
+    ensure
+      if original.nil?
+        ENV.delete('HEAP_DUMP_ENABLED')
+      else
+        ENV['HEAP_DUMP_ENABLED'] = original
+      end
+    end
+
+    it 'skips (handler not installed) when HEAP_DUMP_ENABLED is unset' do
+      ENV.delete('HEAP_DUMP_ENABLED')
+      expect(instance.should_skip?).to be true
+    end
+
+    it 'skips when HEAP_DUMP_ENABLED is a falsey value' do
+      ENV['HEAP_DUMP_ENABLED'] = 'false'
+      expect(instance.should_skip?).to be true
+    end
+
+    it 'runs when HEAP_DUMP_ENABLED is truthy' do
+      ENV['HEAP_DUMP_ENABLED'] = 'true'
+      expect(instance.should_skip?).to be false
+    end
   end
 
   describe '#execute' do

--- a/spec/unit/onetime/initializers/setup_heap_dump_handler_spec.rb
+++ b/spec/unit/onetime/initializers/setup_heap_dump_handler_spec.rb
@@ -76,6 +76,18 @@ RSpec.describe Onetime::Initializers::SetupHeapDumpHandler do
         expect { @handler.call }.not_to raise_error
         expect(logger).to have_received(:error).with(/\[heap\] Dump failed: Errno::EACCES/)
       end
+
+      it 'creates the dump owner-only and refuses to follow an existing file' do
+        # The dump contains plaintext secrets; it must be 0600 and must not
+        # clobber/follow a pre-existing path (symlink defense in a shared /tmp).
+        expect(File).to receive(:open)
+          .with(anything, File::WRONLY | File::CREAT | File::EXCL, 0o600)
+          .and_yield(fake_io)
+
+        instance.execute(context)
+        @handler.call
+        expect(ObjectSpace).to have_received(:dump_all).with(output: fake_io)
+      end
     end
   end
 end

--- a/spec/unit/onetime/initializers/setup_heap_dump_handler_spec.rb
+++ b/spec/unit/onetime/initializers/setup_heap_dump_handler_spec.rb
@@ -1,0 +1,81 @@
+# spec/unit/onetime/initializers/setup_heap_dump_handler_spec.rb
+#
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'onetime/initializers/setup_heap_dump_handler'
+
+RSpec.describe Onetime::Initializers::SetupHeapDumpHandler do
+  let(:instance) { described_class.new }
+  let(:context) { double('context') }
+  let(:logger) { instance_double('SemanticLogger::Logger', info: nil, error: nil, debug: nil) }
+
+  before do
+    allow(Onetime).to receive(:boot_logger).and_return(logger)
+  end
+
+  describe 'metadata' do
+    it 'provides the :heap_dump capability' do
+      expect(described_class.provides).to eq([:heap_dump])
+    end
+
+    it 'is optional so a failed handler install never blocks boot' do
+      expect(described_class.optional).to be true
+    end
+
+    it 'is NOT fork-sensitive so forked workers inherit the handler' do
+      # Marking it :fork_sensitive would have cleanup_before_fork tear it down
+      # before Puma/Sneakers workers are spawned, losing the handler.
+      expect(described_class.phase).to eq(:preload)
+    end
+  end
+
+  describe '#execute' do
+    after do
+      # Restore default disposition so the installed trap does not leak into
+      # other examples.
+      Signal.trap('USR2', 'DEFAULT')
+    end
+
+    it 'installs a USR2 signal handler' do
+      expect(Signal).to receive(:trap).with('USR2')
+      instance.execute(context)
+    end
+
+    it 'logs that the handler was installed' do
+      allow(Signal).to receive(:trap)
+      instance.execute(context)
+      expect(logger).to have_received(:debug).with(/heap dump handler installed/)
+    end
+
+    context 'when the trap fires' do
+      let(:fake_io) { StringIO.new }
+
+      before do
+        # Capture the trap block instead of installing it, and run any spawned
+        # thread synchronously for deterministic assertions.
+        @handler = nil
+        allow(Signal).to receive(:trap).with('USR2') { |&block| @handler = block }
+        allow(Thread).to receive(:new).and_yield
+        allow(File).to receive(:open).and_yield(fake_io)
+        allow(ObjectSpace).to receive(:dump_all)
+      end
+
+      it 'writes a heap dump and logs the path' do
+        instance.execute(context)
+        @handler.call
+
+        expect(ObjectSpace).to have_received(:dump_all).with(output: fake_io)
+        expect(logger).to have_received(:info).with(%r{\[heap\] Dump written to .*heap-#{Process.pid}-\d+\.json})
+      end
+
+      it 'logs an error instead of raising when the dump fails' do
+        allow(ObjectSpace).to receive(:dump_all).and_raise(Errno::EACCES, 'no write')
+
+        instance.execute(context)
+        expect { @handler.call }.not_to raise_error
+        expect(logger).to have_received(:error).with(/\[heap\] Dump failed: Errno::EACCES/)
+      end
+    end
+  end
+end

--- a/spec/unit/onetime/initializers/setup_heap_dump_handler_spec.rb
+++ b/spec/unit/onetime/initializers/setup_heap_dump_handler_spec.rb
@@ -111,6 +111,27 @@ RSpec.describe Onetime::Initializers::SetupHeapDumpHandler do
         expect(logger).to have_received(:error).with(/\[heap\] Dump failed: Errno::EACCES/)
       end
 
+      it 'removes the partial, secret-bearing file when the write fails mid-stream' do
+        allow(ObjectSpace).to receive(:dump_all).and_raise(Errno::ENOSPC, 'disk full')
+        allow(File).to receive(:exist?).and_call_original
+        allow(File).to receive(:exist?).with(a_string_matching(/heap-#{Process.pid}-\d+\.json/)).and_return(true)
+        expect(File).to receive(:delete).with(a_string_matching(/heap-#{Process.pid}-\d+\.json/))
+
+        instance.execute(context)
+        captured[:handler].call
+      end
+
+      it 'does not delete a pre-existing file when exclusive creation is refused' do
+        # An EEXIST from the O_EXCL open means the file is not ours (a leftover
+        # or a symlink-attack target) — deleting it would defeat the guard.
+        allow(File).to receive(:open).and_raise(Errno::EEXIST, 'exists')
+        expect(File).not_to receive(:delete)
+
+        instance.execute(context)
+        expect { captured[:handler].call }.not_to raise_error
+        expect(logger).to have_received(:error).with(/\[heap\] Dump failed: Errno::EEXIST/)
+      end
+
       it 'creates the dump owner-only and refuses to follow an existing file' do
         # The dump contains plaintext secrets; it must be 0600 and must not
         # clobber/follow a pre-existing path (symlink defense in a shared dir).

--- a/spec/unit/onetime/initializers/setup_heap_dump_handler_spec.rb
+++ b/spec/unit/onetime/initializers/setup_heap_dump_handler_spec.rb
@@ -3,6 +3,7 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require 'objspace' # define ObjectSpace.dump_all so verifying doubles can stub it
 require 'onetime/initializers/setup_heap_dump_handler'
 
 RSpec.describe Onetime::Initializers::SetupHeapDumpHandler do
@@ -65,11 +66,8 @@ RSpec.describe Onetime::Initializers::SetupHeapDumpHandler do
   end
 
   describe '#execute' do
-    after do
-      # Restore default disposition so the installed trap does not leak into
-      # other examples.
-      Signal.trap('USR2', 'DEFAULT')
-    end
+    # Every example here stubs Signal.trap, so no real USR2 handler is ever
+    # installed in the test process — nothing to restore afterwards.
 
     it 'installs a USR2 signal handler' do
       expect(Signal).to receive(:trap).with('USR2')
@@ -84,12 +82,14 @@ RSpec.describe Onetime::Initializers::SetupHeapDumpHandler do
 
     context 'when the trap fires' do
       let(:fake_io) { StringIO.new }
+      # Mutable container holding the USR2 handler block captured from the
+      # stubbed Signal.trap (avoids an example-scoped instance variable).
+      let(:captured) { {} }
 
       before do
         # Capture the trap block instead of installing it, and run any spawned
         # thread synchronously for deterministic assertions.
-        @handler = nil
-        allow(Signal).to receive(:trap).with('USR2') { |&block| @handler = block }
+        allow(Signal).to receive(:trap).with('USR2') { |&block| captured[:handler] = block }
         allow(Thread).to receive(:new).and_yield
         allow(File).to receive(:open).and_yield(fake_io)
         allow(ObjectSpace).to receive(:dump_all)
@@ -97,7 +97,7 @@ RSpec.describe Onetime::Initializers::SetupHeapDumpHandler do
 
       it 'writes a heap dump and logs the path' do
         instance.execute(context)
-        @handler.call
+        captured[:handler].call
 
         expect(ObjectSpace).to have_received(:dump_all).with(output: fake_io)
         expect(logger).to have_received(:info).with(%r{\[heap\] Dump written to .*heap-#{Process.pid}-\d+\.json})
@@ -107,19 +107,19 @@ RSpec.describe Onetime::Initializers::SetupHeapDumpHandler do
         allow(ObjectSpace).to receive(:dump_all).and_raise(Errno::EACCES, 'no write')
 
         instance.execute(context)
-        expect { @handler.call }.not_to raise_error
+        expect { captured[:handler].call }.not_to raise_error
         expect(logger).to have_received(:error).with(/\[heap\] Dump failed: Errno::EACCES/)
       end
 
       it 'creates the dump owner-only and refuses to follow an existing file' do
         # The dump contains plaintext secrets; it must be 0600 and must not
-        # clobber/follow a pre-existing path (symlink defense in a shared /tmp).
+        # clobber/follow a pre-existing path (symlink defense in a shared dir).
         expect(File).to receive(:open)
           .with(anything, File::WRONLY | File::CREAT | File::EXCL, 0o600)
           .and_yield(fake_io)
 
         instance.execute(context)
-        @handler.call
+        captured[:handler].call
         expect(ObjectSpace).to have_received(:dump_all).with(output: fake_io)
       end
     end

--- a/spec/unit/onetime/mail/sender_strategies/ses_sender_strategy_spec.rb
+++ b/spec/unit/onetime/mail/sender_strategies/ses_sender_strategy_spec.rb
@@ -10,9 +10,9 @@ RSpec.describe Onetime::Mail::SenderStrategies::SESSenderStrategy do
   let(:strategy) { described_class.new }
   let(:credentials) do
     {
-      access_key_id: 'AKIAIOSFODNN7EXAMPLE',
-      secret_access_key: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
-      region: 'us-east-1',
+      'access_key_id' => 'AKIAIOSFODNN7EXAMPLE',
+      'secret_access_key' => 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
+      'region' => 'us-east-1',
     }
   end
   let(:mailer_config) do
@@ -23,7 +23,11 @@ RSpec.describe Onetime::Mail::SenderStrategies::SESSenderStrategy do
   before do
     allow(strategy).to receive(:build_ses_client).and_return(mock_client)
     allow(strategy).to receive(:log_info)
+    allow(strategy).to receive(:log_warn)
     allow(strategy).to receive(:log_error)
+    # MAIL FROM configuration succeeds by default; individual contexts override.
+    allow(mock_client).to receive(:put_email_identity_mail_from_attributes)
+      .and_return(double('MailFromResponse'))
   end
 
   describe '#provision_dns_records' do
@@ -43,18 +47,32 @@ RSpec.describe Onetime::Mail::SenderStrategies::SESSenderStrategy do
           .and_return(create_response)
       end
 
-      it 'returns success with DNS records' do
+      it 'returns success with fully-qualified DKIM and MAIL FROM records' do
         result = strategy.provision_dns_records(mailer_config, credentials: credentials)
 
         expect(result[:success]).to be true
         expect(result[:dns_records]).to eq([
-          { type: 'CNAME', name: 'abc123._domainkey', value: 'abc123.dkim.amazonses.com' },
-          { type: 'CNAME', name: 'def456._domainkey', value: 'def456.dkim.amazonses.com' },
-          { type: 'CNAME', name: 'ghi789._domainkey', value: 'ghi789.dkim.amazonses.com' },
+          { type: 'CNAME', name: 'abc123._domainkey.example.com', value: 'abc123.dkim.amazonses.com' },
+          { type: 'CNAME', name: 'def456._domainkey.example.com', value: 'def456.dkim.amazonses.com' },
+          { type: 'CNAME', name: 'ghi789._domainkey.example.com', value: 'ghi789.dkim.amazonses.com' },
+          { type: 'MX', name: 'mail.example.com', value: 'feedback-smtp.us-east-1.amazonses.com' },
+          { type: 'TXT', name: 'mail.example.com', value: 'v=spf1 include:amazonses.com ~all' },
         ])
         expect(result[:provider_data][:dkim_tokens]).to eq(%w[abc123 def456 ghi789])
         expect(result[:provider_data][:region]).to eq('us-east-1')
         expect(result[:provider_data][:identity]).to eq('example.com')
+        expect(result[:provider_data][:mail_from_domain]).to eq('mail.example.com')
+      end
+
+      it 'configures a custom MAIL FROM domain on the identity' do
+        strategy.provision_dns_records(mailer_config, credentials: credentials)
+
+        expect(mock_client).to have_received(:put_email_identity_mail_from_attributes)
+          .with(
+            email_identity: 'example.com',
+            mail_from_domain: 'mail.example.com',
+            behavior_on_mx_failure: 'USE_DEFAULT_VALUE',
+          )
       end
     end
 
@@ -81,6 +99,59 @@ RSpec.describe Onetime::Mail::SenderStrategies::SESSenderStrategy do
 
         expect(result[:success]).to be true
         expect(result[:provider_data][:dkim_tokens]).to eq(%w[existing1 existing2 existing3])
+      end
+    end
+
+    context 'with a non-default region' do
+      let(:credentials) do
+        { 'access_key_id' => 'AKIA', 'secret_access_key' => 'secret', 'region' => 'eu-west-1' }
+      end
+      let(:dkim_attrs) { double('DkimAttributes', tokens: ['t1'], status: 'PENDING') }
+
+      before do
+        allow(mock_client).to receive(:create_email_identity)
+          .and_return(double('Resp', dkim_attributes: dkim_attrs))
+      end
+
+      it 'emits the MAIL FROM MX for that region' do
+        result = strategy.provision_dns_records(mailer_config, credentials: credentials)
+
+        mx = result[:dns_records].find { |r| r[:type] == 'MX' }
+        expect(mx[:value]).to eq('feedback-smtp.eu-west-1.amazonses.com')
+        expect(result[:provider_data][:region]).to eq('eu-west-1')
+      end
+    end
+
+    context 'when MAIL FROM configuration is rejected' do
+      let(:dkim_attrs) { double('DkimAttributes', tokens: %w[abc def], status: 'PENDING') }
+
+      before do
+        allow(mock_client).to receive(:create_email_identity)
+          .and_return(double('Resp', dkim_attributes: dkim_attrs))
+        allow(mock_client).to receive(:put_email_identity_mail_from_attributes)
+          .and_raise(Aws::SESV2::Errors::ServiceError.new(nil, 'mail from rejected'))
+      end
+
+      it 'still succeeds with DKIM records but omits MAIL FROM records' do
+        result = strategy.provision_dns_records(mailer_config, credentials: credentials)
+
+        expect(result[:success]).to be true
+        expect(result[:dns_records].map { |r| r[:type] }).to eq(%w[CNAME CNAME])
+        expect(result[:dns_records].any? { |r| r[:type] == 'MX' }).to be false
+        expect(result[:provider_data][:mail_from_domain]).to be_nil
+      end
+    end
+
+    context 'with missing AWS credentials' do
+      let(:credentials) { { 'region' => 'us-east-1' } }
+
+      it 'returns a missing_credentials error without calling SES' do
+        result = strategy.provision_dns_records(mailer_config, credentials: credentials)
+
+        expect(result[:success]).to be false
+        expect(result[:error]).to eq('missing_credentials')
+        expect(result[:dns_records]).to eq([])
+        expect(mock_client).not_to have_received(:put_email_identity_mail_from_attributes)
       end
     end
 
@@ -121,6 +192,21 @@ RSpec.describe Onetime::Mail::SenderStrategies::SESSenderStrategy do
         expect(result[:dns_records]).to eq([])
       end
     end
+
+    context 'when a non-SES error occurs' do
+      before do
+        allow(mock_client).to receive(:create_email_identity)
+          .and_raise(StandardError.new('network down'))
+      end
+
+      it 'wraps the error in a failure result' do
+        result = strategy.provision_dns_records(mailer_config, credentials: credentials)
+
+        expect(result[:success]).to be false
+        expect(result[:message]).to include('Provisioning failed')
+        expect(result[:dns_records]).to eq([])
+      end
+    end
   end
 
   describe '#check_provider_verification_status' do
@@ -131,9 +217,15 @@ RSpec.describe Onetime::Mail::SenderStrategies::SESSenderStrategy do
           status: 'SUCCESS',
           signing_enabled: true)
       end
+      let(:mail_from_attrs) do
+        double('MailFromAttributes',
+          mail_from_domain: 'mail.example.com',
+          mail_from_domain_status: 'SUCCESS')
+      end
       let(:get_response) do
         double('GetEmailIdentityResponse',
           dkim_attributes: dkim_attrs,
+          mail_from_attributes: mail_from_attrs,
           identity_type: 'DOMAIN')
       end
 
@@ -143,12 +235,14 @@ RSpec.describe Onetime::Mail::SenderStrategies::SESSenderStrategy do
           .and_return(get_response)
       end
 
-      it 'returns verified status' do
+      it 'returns verified status with MAIL FROM details' do
         result = strategy.check_provider_verification_status(mailer_config, credentials: credentials)
 
         expect(result[:verified]).to be true
         expect(result[:status]).to eq('success')
         expect(result[:message]).to include('ready for sending')
+        expect(result[:details][:mail_from_domain]).to eq('mail.example.com')
+        expect(result[:details][:mail_from_status]).to eq('SUCCESS')
       end
     end
 
@@ -162,6 +256,7 @@ RSpec.describe Onetime::Mail::SenderStrategies::SESSenderStrategy do
       let(:get_response) do
         double('GetEmailIdentityResponse',
           dkim_attributes: dkim_attrs,
+          mail_from_attributes: nil,
           identity_type: 'DOMAIN')
       end
 
@@ -191,6 +286,20 @@ RSpec.describe Onetime::Mail::SenderStrategies::SESSenderStrategy do
 
         expect(result[:verified]).to be false
         expect(result[:status]).to eq('not_found')
+      end
+    end
+
+    context 'when an unexpected error occurs' do
+      before do
+        allow(mock_client).to receive(:get_email_identity)
+          .and_raise(StandardError.new('boom'))
+      end
+
+      it 'returns error status' do
+        result = strategy.check_provider_verification_status(mailer_config, credentials: credentials)
+
+        expect(result[:verified]).to be false
+        expect(result[:status]).to eq('error')
       end
     end
 
@@ -250,6 +359,19 @@ RSpec.describe Onetime::Mail::SenderStrategies::SESSenderStrategy do
       end
     end
 
+    context 'when an unexpected error occurs' do
+      before do
+        allow(mock_client).to receive(:delete_email_identity)
+          .and_raise(StandardError.new('boom'))
+      end
+
+      it 'returns deleted false' do
+        result = strategy.delete_sender_identity(mailer_config, credentials: credentials)
+
+        expect(result[:deleted]).to be false
+      end
+    end
+
     context 'with invalid from_address' do
       let(:mailer_config) { double('MailerConfig', from_address: '') }
 
@@ -276,8 +398,8 @@ RSpec.describe Onetime::Mail::SenderStrategies::SESSenderStrategy do
   describe 'default region' do
     let(:credentials_no_region) do
       {
-        access_key_id: 'AKIAIOSFODNN7EXAMPLE',
-        secret_access_key: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
+        'access_key_id' => 'AKIAIOSFODNN7EXAMPLE',
+        'secret_access_key' => 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
       }
     end
 
@@ -289,6 +411,17 @@ RSpec.describe Onetime::Mail::SenderStrategies::SESSenderStrategy do
       result = strategy.provision_dns_records(mailer_config, credentials: credentials_no_region)
 
       expect(result[:provider_data][:region]).to eq('us-east-1')
+    end
+
+    it 'uses us-east-1 in the MAIL FROM MX endpoint' do
+      dkim_attrs = double('DkimAttributes', tokens: ['token1'], status: 'PENDING')
+      response = double('Response', dkim_attributes: dkim_attrs)
+      allow(mock_client).to receive(:create_email_identity).and_return(response)
+
+      result = strategy.provision_dns_records(mailer_config, credentials: credentials_no_region)
+
+      mx = result[:dns_records].find { |r| r[:type] == 'MX' }
+      expect(mx[:value]).to eq('feedback-smtp.us-east-1.amazonses.com')
     end
   end
 end

--- a/spec/unit/onetime/mail/sender_strategies_spec.rb
+++ b/spec/unit/onetime/mail/sender_strategies_spec.rb
@@ -82,4 +82,19 @@ RSpec.describe Onetime::Mail::SenderStrategies do
       expect(described_class.supported_providers).to contain_exactly('ses', 'sendgrid', 'lettermint', 'smtp')
     end
   end
+
+  # ==========================================================================
+  # Cross-layer invariant: the strategy registry (what we can dispatch to)
+  # and MailerConfig::PROVIDER_TYPES (what a config may store) are maintained
+  # independently but must hold the same set. Reconcile validates against
+  # PROVIDER_TYPES, DeleteSenderDomain dispatches via .supported? — if they
+  # drift, one path accepts a provider the other rejects. This guards it.
+  # ==========================================================================
+
+  describe 'consistency with MailerConfig::PROVIDER_TYPES' do
+    it 'covers exactly the providers a MailerConfig may store' do
+      expect(described_class.supported_providers.sort)
+        .to eq(Onetime::CustomDomain::MailerConfig::PROVIDER_TYPES.sort)
+    end
+  end
 end

--- a/spec/unit/onetime/mail/sender_strategies_spec.rb
+++ b/spec/unit/onetime/mail/sender_strategies_spec.rb
@@ -1,0 +1,85 @@
+# spec/unit/onetime/mail/sender_strategies_spec.rb
+#
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'onetime/mail/sender_strategies'
+
+RSpec.describe Onetime::Mail::SenderStrategies do
+  # ==========================================================================
+  # .supported? — "has a strategy" (the predicate DeleteSenderDomain dispatches
+  # on). The defining contrast with supports_provisioning? is that it INCLUDES
+  # smtp, whose strategy is a deliberate no-op.
+  # ==========================================================================
+
+  describe '.supported?' do
+    it 'is true for every provider with a registered strategy' do
+      %w[ses sendgrid lettermint smtp].each do |provider|
+        expect(described_class.supported?(provider)).to be(true), "expected '#{provider}' to be supported"
+      end
+    end
+
+    it 'includes smtp, where supports_provisioning? deliberately does not' do
+      expect(described_class.supported?('smtp')).to be true
+      expect(described_class.supports_provisioning?('smtp')).to be false
+    end
+
+    it 'is false for transports/providers without a strategy' do
+      %w[logger mailchimp postmark].each do |provider|
+        expect(described_class.supported?(provider)).to be false
+      end
+    end
+
+    it 'is false for blank/nil input' do
+      expect(described_class.supported?('')).to be false
+      expect(described_class.supported?(nil)).to be false
+    end
+
+    it 'normalizes case and accepts symbols' do
+      expect(described_class.supported?(:SES)).to be true
+      expect(described_class.supported?('LetterMint')).to be true
+    end
+  end
+
+  # ==========================================================================
+  # .for_provider
+  # ==========================================================================
+
+  describe '.for_provider' do
+    it 'returns the matching strategy instance for known providers' do
+      expect(described_class.for_provider('ses')).to be_a(described_class::SESSenderStrategy)
+      expect(described_class.for_provider('smtp')).to be_a(described_class::SMTPSenderStrategy)
+    end
+
+    it 'is case-insensitive' do
+      expect(described_class.for_provider('SendGrid')).to be_a(described_class::SendGridSenderStrategy)
+    end
+
+    it 'raises ArgumentError for unknown providers' do
+      expect { described_class.for_provider('mailchimp') }
+        .to raise_error(ArgumentError, /Unknown sender strategy/)
+    end
+  end
+
+  # ==========================================================================
+  # .supports_provisioning? / .supported_providers
+  # ==========================================================================
+
+  describe '.supports_provisioning?' do
+    it 'is true for API-provisionable providers' do
+      %w[ses sendgrid lettermint].each do |provider|
+        expect(described_class.supports_provisioning?(provider)).to be true
+      end
+    end
+
+    it 'is false for smtp (manual DNS configuration)' do
+      expect(described_class.supports_provisioning?('smtp')).to be false
+    end
+  end
+
+  describe '.supported_providers' do
+    it 'lists every provider that has a strategy' do
+      expect(described_class.supported_providers).to contain_exactly('ses', 'sendgrid', 'lettermint', 'smtp')
+    end
+  end
+end

--- a/spec/unit/onetime/operations/delete_sender_domain_spec.rb
+++ b/spec/unit/onetime/operations/delete_sender_domain_spec.rb
@@ -109,6 +109,26 @@ RSpec.describe Onetime::Operations::DeleteSenderDomain do
       # WebMock (disable_net_connect!) would have flagged any HTTP attempt.
       expect(a_request(:any, /.*/)).not_to have_been_made
     end
+
+    it 'logs a no-op rather than a deletion (result[:deleted] is false)' do
+      config        = mailer_config_for('smtp')
+      smtp_strategy = Onetime::Mail::SenderStrategies::SMTPSenderStrategy.new
+
+      logged = []
+      log    = double('logger')
+      allow(log).to receive(:info) { |*args, **_kw| logged << args.first }
+      allow(log).to receive(:error)
+      allow(Onetime).to receive(:get_logger).and_return(log)
+      allow(Onetime::Mail::Mailer).to receive(:provider_credentials)
+        .and_return({ 'host' => 'smtp.example.com' })
+      allow(Onetime::Mail::SenderStrategies).to receive(:for_provider)
+        .with('smtp').and_return(smtp_strategy)
+
+      described_class.new(mailer_config: config).call
+
+      expect(logged).to include('Sender domain deletion skipped (no-op)')
+      expect(logged).not_to include('Sender domain deleted')
+    end
   end
 
   # ==========================================================================

--- a/spec/unit/onetime/operations/delete_sender_domain_spec.rb
+++ b/spec/unit/onetime/operations/delete_sender_domain_spec.rb
@@ -1,0 +1,177 @@
+# spec/unit/onetime/operations/delete_sender_domain_spec.rb
+#
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'onetime/operations/delete_sender_domain'
+
+RSpec.describe Onetime::Operations::DeleteSenderDomain do
+  let(:mock_credentials) { { 'team_token' => 'fake-test-token' } }
+
+  # Build a MailerConfig stand-in. effective_provider drives dispatch;
+  # from_address is only consulted on the back-compat fallback path.
+  def mailer_config_for(provider, from_address: 'sender@example.com')
+    double(
+      'MailerConfig',
+      domain_id: 'cd:test123',
+      provider: provider,
+      effective_provider: provider,
+      from_address: from_address,
+    )
+  end
+
+  # ==========================================================================
+  # Result object
+  # ==========================================================================
+
+  describe 'Result' do
+    it 'implements success? / failed?' do
+      ok  = described_class::Result.new(success: true, message: 'done', error: nil)
+      bad = described_class::Result.new(success: false, message: nil, error: 'boom')
+
+      expect(ok.success?).to be true
+      expect(ok.failed?).to be false
+      expect(bad.success?).to be false
+      expect(bad.failed?).to be true
+    end
+  end
+
+  # ==========================================================================
+  # #call — per-provider dispatch (the core generalization)
+  # ==========================================================================
+
+  describe '#call dispatch' do
+    before do
+      allow(Onetime::Mail::Mailer).to receive(:provider_credentials).and_return(mock_credentials)
+    end
+
+    %w[ses sendgrid lettermint].each do |provider|
+      it "dispatches deletion to the #{provider} strategy" do
+        config   = mailer_config_for(provider)
+        strategy = double("#{provider}_strategy")
+
+        allow(Onetime::Mail::SenderStrategies).to receive(:for_provider)
+          .with(provider).and_return(strategy)
+        expect(strategy).to receive(:delete_sender_identity)
+          .with(config, credentials: mock_credentials)
+          .and_return({ deleted: true, message: "#{provider} identity deleted" })
+
+        result = described_class.new(mailer_config: config).call
+
+        expect(result.success?).to be true
+        expect(result.message).to eq("#{provider} identity deleted")
+        expect(result.error).to be_nil
+      end
+    end
+
+    it 'loads credentials for the resolved provider' do
+      config   = mailer_config_for('ses')
+      strategy = double('ses_strategy', delete_sender_identity: { deleted: true, message: 'ok' })
+
+      allow(Onetime::Mail::SenderStrategies).to receive(:for_provider)
+        .with('ses').and_return(strategy)
+      expect(Onetime::Mail::Mailer).to receive(:provider_credentials)
+        .with('ses').and_return(mock_credentials)
+
+      described_class.new(mailer_config: config).call
+    end
+
+    it 'downcases the effective provider before dispatch' do
+      config   = mailer_config_for('Lettermint')
+      strategy = double('lm_strategy', delete_sender_identity: { deleted: true, message: 'ok' })
+
+      allow(Onetime::Mail::Mailer).to receive(:provider_credentials)
+        .with('lettermint').and_return(mock_credentials)
+      expect(Onetime::Mail::SenderStrategies).to receive(:for_provider)
+        .with('lettermint').and_return(strategy)
+
+      result = described_class.new(mailer_config: config).call
+
+      expect(result.success?).to be true
+    end
+  end
+
+  # ==========================================================================
+  # #call — SMTP no-op (acceptance: makes no provider API call)
+  # ==========================================================================
+
+  describe '#call with SMTP provider' do
+    it 'returns the SMTP no-op without making any provider API call' do
+      config        = mailer_config_for('smtp')
+      smtp_strategy = Onetime::Mail::SenderStrategies::SMTPSenderStrategy.new
+
+      allow(Onetime::Mail::Mailer).to receive(:provider_credentials)
+        .and_return({ 'host' => 'smtp.example.com' })
+      # Use the real strategy so the genuine no-op path runs.
+      allow(Onetime::Mail::SenderStrategies).to receive(:for_provider)
+        .with('smtp').and_return(smtp_strategy)
+
+      result = described_class.new(mailer_config: config).call
+
+      expect(result.success?).to be true
+      expect(result.message).to eq('SMTP providers do not have sender identities to delete.')
+      # WebMock (disable_net_connect!) would have flagged any HTTP attempt.
+      expect(a_request(:any, /.*/)).not_to have_been_made
+    end
+  end
+
+  # ==========================================================================
+  # #call — skip / back-compat paths
+  # ==========================================================================
+
+  describe '#call skip paths' do
+    it 'skips when mailer_config is nil' do
+      result = described_class.new(mailer_config: nil).call
+
+      expect(result.success?).to be true
+      expect(result.message).to eq('skipped: no mailer config')
+    end
+
+    it 'skips when neither a provider nor a from_address resolves' do
+      config = double('MailerConfig', domain_id: 'cd:x', provider: '', effective_provider: '', from_address: '')
+
+      result = described_class.new(mailer_config: config).call
+
+      expect(result.success?).to be true
+      expect(result.message).to eq('skipped: no effective provider')
+    end
+
+    it 'falls back to lettermint for legacy configs (address present, provider unresolvable)' do
+      config   = double('MailerConfig', domain_id: 'cd:x', provider: '', effective_provider: '', from_address: 'a@b.com')
+      strategy = double('lm_strategy')
+
+      allow(Onetime::Mail::Mailer).to receive(:provider_credentials)
+        .with('lettermint').and_return(mock_credentials)
+      allow(Onetime::Mail::SenderStrategies).to receive(:for_provider)
+        .with('lettermint').and_return(strategy)
+      expect(strategy).to receive(:delete_sender_identity)
+        .and_return({ deleted: true, message: 'legacy lettermint deleted' })
+
+      result = described_class.new(mailer_config: config).call
+
+      expect(result.success?).to be true
+      expect(result.message).to eq('legacy lettermint deleted')
+    end
+  end
+
+  # ==========================================================================
+  # #call — error handling (never raises; wraps failures in Result)
+  # ==========================================================================
+
+  describe '#call error handling' do
+    it 'swallows strategy errors into a failure Result' do
+      config   = mailer_config_for('lettermint')
+      strategy = double('lm_strategy')
+
+      allow(Onetime::Mail::Mailer).to receive(:provider_credentials).and_return(mock_credentials)
+      allow(Onetime::Mail::SenderStrategies).to receive(:for_provider).and_return(strategy)
+      allow(strategy).to receive(:delete_sender_identity).and_raise(StandardError, 'provider API timeout')
+
+      result = described_class.new(mailer_config: config).call
+
+      expect(result.success?).to be false
+      expect(result.failed?).to be true
+      expect(result.error).to eq('provider API timeout')
+    end
+  end
+end

--- a/spec/unit/onetime/operations/delete_sender_domain_spec.rb
+++ b/spec/unit/onetime/operations/delete_sender_domain_spec.rb
@@ -8,15 +8,22 @@ require 'onetime/operations/delete_sender_domain'
 RSpec.describe Onetime::Operations::DeleteSenderDomain do
   let(:mock_credentials) { { 'team_token' => 'fake-test-token' } }
 
-  # Build a MailerConfig stand-in. effective_provider drives dispatch;
-  # from_address is only consulted on the back-compat fallback path.
-  def mailer_config_for(provider, from_address: 'sender@example.com')
+  # Real strategy classes, used for verifying doubles so a signature drift
+  # in #delete_sender_identity would fail these tests.
+  strategy_classes = {
+    'ses'        => Onetime::Mail::SenderStrategies::SESSenderStrategy,
+    'sendgrid'   => Onetime::Mail::SenderStrategies::SendGridSenderStrategy,
+    'lettermint' => Onetime::Mail::SenderStrategies::LettermintSenderStrategy,
+  }.freeze
+
+  # MailerConfig stand-in. effective_provider is the single input the
+  # operation dispatches on (already normalized by the real model).
+  def mailer_config_for(provider)
     double(
       'MailerConfig',
       domain_id: 'cd:test123',
-      provider: provider,
       effective_provider: provider,
-      from_address: from_address,
+      from_address: 'sender@example.com',
     )
   end
 
@@ -45,10 +52,10 @@ RSpec.describe Onetime::Operations::DeleteSenderDomain do
       allow(Onetime::Mail::Mailer).to receive(:provider_credentials).and_return(mock_credentials)
     end
 
-    %w[ses sendgrid lettermint].each do |provider|
+    strategy_classes.each do |provider, klass|
       it "dispatches deletion to the #{provider} strategy" do
         config   = mailer_config_for(provider)
-        strategy = double("#{provider}_strategy")
+        strategy = instance_double(klass)
 
         allow(Onetime::Mail::SenderStrategies).to receive(:for_provider)
           .with(provider).and_return(strategy)
@@ -66,7 +73,10 @@ RSpec.describe Onetime::Operations::DeleteSenderDomain do
 
     it 'loads credentials for the resolved provider' do
       config   = mailer_config_for('ses')
-      strategy = double('ses_strategy', delete_sender_identity: { deleted: true, message: 'ok' })
+      strategy = instance_double(
+        Onetime::Mail::SenderStrategies::SESSenderStrategy,
+        delete_sender_identity: { deleted: true, message: 'ok' },
+      )
 
       allow(Onetime::Mail::SenderStrategies).to receive(:for_provider)
         .with('ses').and_return(strategy)
@@ -74,20 +84,6 @@ RSpec.describe Onetime::Operations::DeleteSenderDomain do
         .with('ses').and_return(mock_credentials)
 
       described_class.new(mailer_config: config).call
-    end
-
-    it 'downcases the effective provider before dispatch' do
-      config   = mailer_config_for('Lettermint')
-      strategy = double('lm_strategy', delete_sender_identity: { deleted: true, message: 'ok' })
-
-      allow(Onetime::Mail::Mailer).to receive(:provider_credentials)
-        .with('lettermint').and_return(mock_credentials)
-      expect(Onetime::Mail::SenderStrategies).to receive(:for_provider)
-        .with('lettermint').and_return(strategy)
-
-      result = described_class.new(mailer_config: config).call
-
-      expect(result.success?).to be true
     end
   end
 
@@ -116,7 +112,7 @@ RSpec.describe Onetime::Operations::DeleteSenderDomain do
   end
 
   # ==========================================================================
-  # #call — skip / back-compat paths
+  # #call — skip paths (no dispatch, no error)
   # ==========================================================================
 
   describe '#call skip paths' do
@@ -127,8 +123,9 @@ RSpec.describe Onetime::Operations::DeleteSenderDomain do
       expect(result.message).to eq('skipped: no mailer config')
     end
 
-    it 'skips when neither a provider nor a from_address resolves' do
-      config = double('MailerConfig', domain_id: 'cd:x', provider: '', effective_provider: '', from_address: '')
+    it 'skips when no provider resolves' do
+      config = double('MailerConfig', domain_id: 'cd:x', effective_provider: '', from_address: 'a@b.com')
+      expect(Onetime::Mail::SenderStrategies).not_to receive(:for_provider)
 
       result = described_class.new(mailer_config: config).call
 
@@ -136,21 +133,15 @@ RSpec.describe Onetime::Operations::DeleteSenderDomain do
       expect(result.message).to eq('skipped: no effective provider')
     end
 
-    it 'falls back to lettermint for legacy configs (address present, provider unresolvable)' do
-      config   = double('MailerConfig', domain_id: 'cd:x', provider: '', effective_provider: '', from_address: 'a@b.com')
-      strategy = double('lm_strategy')
-
-      allow(Onetime::Mail::Mailer).to receive(:provider_credentials)
-        .with('lettermint').and_return(mock_credentials)
-      allow(Onetime::Mail::SenderStrategies).to receive(:for_provider)
-        .with('lettermint').and_return(strategy)
-      expect(strategy).to receive(:delete_sender_identity)
-        .and_return({ deleted: true, message: 'legacy lettermint deleted' })
+    it 'skips a provider that has no sender strategy (e.g. logger)' do
+      config = double('MailerConfig', domain_id: 'cd:x', effective_provider: 'logger', from_address: 'a@b.com')
+      expect(Onetime::Mail::SenderStrategies).not_to receive(:for_provider)
+      expect(Onetime::Mail::Mailer).not_to receive(:provider_credentials)
 
       result = described_class.new(mailer_config: config).call
 
       expect(result.success?).to be true
-      expect(result.message).to eq('legacy lettermint deleted')
+      expect(result.message).to eq("skipped: unsupported provider 'logger'")
     end
   end
 
@@ -161,7 +152,7 @@ RSpec.describe Onetime::Operations::DeleteSenderDomain do
   describe '#call error handling' do
     it 'swallows strategy errors into a failure Result' do
       config   = mailer_config_for('lettermint')
-      strategy = double('lm_strategy')
+      strategy = instance_double(Onetime::Mail::SenderStrategies::LettermintSenderStrategy)
 
       allow(Onetime::Mail::Mailer).to receive(:provider_credentials).and_return(mock_credentials)
       allow(Onetime::Mail::SenderStrategies).to receive(:for_provider).and_return(strategy)

--- a/src/apps/workspace/domains/DomainIncoming.vue
+++ b/src/apps/workspace/domains/DomainIncoming.vue
@@ -56,6 +56,7 @@ const organization = computed(() =>
 const { can } = useEntitlements(organization);
 const canManageIncoming = computed(() => can(ENTITLEMENTS.INCOMING_SECRETS));
 const billingRoute = computed(() => `/billing/${props.orgid}/plans`);
+const incomingSecretsEnabled = computed(() => isOrgsIncomingSecretsEnabled());
 
 // ---------------------------------------------------------------------------
 // Incoming config composable
@@ -172,7 +173,7 @@ watch(() => props.extid, async () => {
 
       <!-- Feature Disabled at Install Level -->
       <div
-        v-else-if="!isOrgsIncomingSecretsEnabled()"
+        v-else-if="!incomingSecretsEnabled"
         class="rounded-lg border border-gray-200 bg-white p-8 text-center dark:border-gray-700 dark:bg-gray-800">
         <OIcon
           collection="heroicons"

--- a/src/apps/workspace/domains/DomainIncoming.vue
+++ b/src/apps/workspace/domains/DomainIncoming.vue
@@ -23,6 +23,7 @@ import { useIncomingConfig } from '@/shared/composables/useIncomingConfig';
 import { useEntitlements } from '@/shared/composables/useEntitlements';
 import { useOrganizationStore } from '@/shared/stores/organizationStore';
 import { ENTITLEMENTS } from '@/types/organization';
+import { isOrgsIncomingSecretsEnabled } from '@/utils/features';
 
 const { t } = useI18n();
 const router = useRouter();
@@ -167,6 +168,23 @@ watch(() => props.extid, async () => {
       <!-- Error State -->
       <div v-else-if="domainError" class="rounded-lg bg-white p-6 shadow dark:bg-gray-800">
         <BasicFormAlerts :error="domainError.message" />
+      </div>
+
+      <!-- Feature Disabled at Install Level -->
+      <div
+        v-else-if="!isOrgsIncomingSecretsEnabled()"
+        class="rounded-lg border border-gray-200 bg-white p-8 text-center dark:border-gray-700 dark:bg-gray-800">
+        <OIcon
+          collection="heroicons"
+          name="x-circle"
+          class="mx-auto size-12 text-gray-400"
+          aria-hidden="true" />
+        <h3 class="mt-4 text-lg font-semibold text-gray-900 dark:text-white">
+          {{ t('web.domains.incoming.feature_disabled') }}
+        </h3>
+        <p class="mt-2 text-sm text-gray-500 dark:text-gray-400">
+          {{ t('web.domains.incoming.feature_disabled_description') }}
+        </p>
       </div>
 
       <!-- Access Denied / Upgrade Banner -->

--- a/src/tests/apps/workspace/domains/DomainIncoming.spec.ts
+++ b/src/tests/apps/workspace/domains/DomainIncoming.spec.ts
@@ -156,6 +156,11 @@ vi.mock('@/types/organization', () => ({
   },
 }));
 
+let mockIsOrgsIncomingSecretsEnabled = true;
+vi.mock('@/utils/features', () => ({
+  isOrgsIncomingSecretsEnabled: () => mockIsOrgsIncomingSecretsEnabled,
+}));
+
 // ---------------------------------------------------------------------------
 // i18n setup
 // ---------------------------------------------------------------------------
@@ -205,6 +210,7 @@ describe('DomainIncoming', () => {
     vi.clearAllMocks();
 
     // Reset mocks to defaults
+    mockIsOrgsIncomingSecretsEnabled = true;
     mockCanIncoming = ref(true);
     mockDomainState.isLoading.value = false;
     mockDomainState.error.value = null;

--- a/try/unit/cli/domains/reconcile_sender_command_try.rb
+++ b/try/unit/cli/domains/reconcile_sender_command_try.rb
@@ -14,6 +14,8 @@
 #   7. Non-lettermint existing config -> reconciles without provider refusal
 #   8. --provider conflicting with existing config -> refuses to switch
 #   9. Unresolvable/invalid provider -> errors, creates no config
+#  10. New config created with explicit non-lettermint --provider
+#  11. Explicit invalid --provider -> errors, creates no config
 #
 # Run:
 #   try try/unit/cli/domains/reconcile_sender_command_try.rb --agent
@@ -284,6 +286,53 @@ end
 
 ## No MailerConfig is created when the provider is unresolvable
 Onetime::CustomDomain::MailerConfig.exists_for_domain?(@domain_9.identifier)
+#=> false
+
+# ===================================================================
+# Case 10: New config created with explicit non-lettermint --provider
+# ===================================================================
+
+## New config is created with the provider given via --provider
+@domain_10 = Onetime::CustomDomain.create!("rsc-newses-#{@timestamp}-#{@entropy}.example.com", @org.objid)
+PSDTestData.canned_result = Onetime::Operations::ProvisionSenderDomain::Result.new(
+  success: true,
+  dns_records: [],
+  provider_data: { 'status' => 'pending' },
+  error: nil,
+)
+@output_10 = capture_stdout do
+  build_cmd.call(
+    domain_name: @domain_10.display_domain,
+    from_address: "noreply@rsc-newses-#{@timestamp}.example.com",
+    provider: 'ses',
+  )
+end
+@mc_10 = Onetime::CustomDomain::MailerConfig.find_by_domain_id(@domain_10.identifier)
+@mc_10.provider
+#=> 'ses'
+
+## Reconcile output reflects the ses provider for the new config
+@output_10.include?('provider: ses')
+#=> true
+
+# ===================================================================
+# Case 11: Explicit invalid --provider -> errors, creates no config
+# ===================================================================
+
+## Explicit invalid --provider is rejected
+@domain_11 = Onetime::CustomDomain.create!("rsc-bad-#{@timestamp}-#{@entropy}.example.com", @org.objid)
+@output_11 = capture_stdout do
+  build_cmd.call(
+    domain_name: @domain_11.display_domain,
+    from_address: "noreply@rsc-bad-#{@timestamp}.example.com",
+    provider: 'mailchimp',
+  )
+end
+@output_11.include?('Could not resolve a valid sender provider')
+#=> true
+
+## No MailerConfig is created for an invalid provider
+Onetime::CustomDomain::MailerConfig.exists_for_domain?(@domain_11.identifier)
 #=> false
 
 # --- Cleanup ---

--- a/try/unit/cli/domains/reconcile_sender_command_try.rb
+++ b/try/unit/cli/domains/reconcile_sender_command_try.rb
@@ -11,6 +11,9 @@
 #   4. Dry-run with existing config -> prints plan with "provision with existing config"
 #   5. Provision success path -> creates MailerConfig, prints "provisioned successfully"
 #   6. Provision failure path -> prints "failed:"
+#   7. Non-lettermint existing config -> reconciles without provider refusal
+#   8. --provider conflicting with existing config -> refuses to switch
+#   9. Unresolvable/invalid provider -> errors, creates no config
 #
 # Run:
 #   try try/unit/cli/domains/reconcile_sender_command_try.rb --agent
@@ -112,6 +115,7 @@ end
   build_cmd.call(
     domain_name: @domain_3.display_domain,
     from_address: "noreply@rsc-dry3-#{@timestamp}.example.com",
+    provider: 'lettermint',
     dry_run: true,
   )
 end
@@ -168,6 +172,7 @@ PSDTestData.canned_result = Onetime::Operations::ProvisionSenderDomain::Result.n
   build_cmd.call(
     domain_name: @domain_5.display_domain,
     from_address: "noreply@rsc-ok-#{@timestamp}.example.com",
+    provider: 'lettermint',
   )
 end
 @output_5.include?('provisioned successfully')
@@ -206,6 +211,7 @@ PSDTestData.canned_result = Onetime::Operations::ProvisionSenderDomain::Result.n
   build_cmd.call(
     domain_name: @domain_6.display_domain,
     from_address: "noreply@rsc-fail-#{@timestamp}.example.com",
+    provider: 'lettermint',
   )
 end
 @output_6.include?('failed:')
@@ -214,6 +220,71 @@ end
 ## Failure output includes the error message
 @output_6.include?('Lettermint API rate limit exceeded')
 #=> true
+
+# ===================================================================
+# Case 7: Non-lettermint existing config -> reconciles, no refusal
+# ===================================================================
+
+## Existing ses config reconciles without the provider-mismatch refusal
+@domain_7 = Onetime::CustomDomain.create!("rsc-ses-#{@timestamp}-#{@entropy}.example.com", @org.objid)
+@mc_7 = Onetime::CustomDomain::MailerConfig.create!(
+  domain_id: @domain_7.identifier,
+  from_address: "noreply@rsc-ses-#{@timestamp}.example.com",
+  provider: 'ses',
+)
+PSDTestData.canned_result = Onetime::Operations::ProvisionSenderDomain::Result.new(
+  success: true,
+  dns_records: [],
+  provider_data: { 'status' => 'pending' },
+  error: nil,
+)
+@output_7 = capture_stdout do
+  build_cmd.call(domain_name: @domain_7.display_domain)
+end
+@output_7.include?('provisioned successfully')
+#=> true
+
+## Reconcile output reflects the ses provider, not lettermint
+@output_7.include?('provider: ses')
+#=> true
+
+## No provider-mismatch refusal for the existing ses config
+@output_7.include?('Delete the existing sender config first')
+#=> false
+
+# ===================================================================
+# Case 8: --provider conflicting with existing config -> refuses switch
+# ===================================================================
+
+## --provider that differs from existing config refuses to switch
+@output_8 = capture_stdout do
+  build_cmd.call(domain_name: @domain_7.display_domain, provider: 'sendgrid')
+end
+@output_8.include?('Delete the existing sender config first')
+#=> true
+
+# ===================================================================
+# Case 9: Unresolvable/invalid provider -> errors, creates no config
+# ===================================================================
+# In the test environment the installation default sender provider is
+# 'logger', which is not a valid MailerConfig provider. With no --provider
+# and no existing config, the command should refuse rather than create an
+# invalid config.
+
+## No valid provider resolvable -> prints error
+@domain_9 = Onetime::CustomDomain.create!("rsc-noprov-#{@timestamp}-#{@entropy}.example.com", @org.objid)
+@output_9 = capture_stdout do
+  build_cmd.call(
+    domain_name: @domain_9.display_domain,
+    from_address: "noreply@rsc-noprov-#{@timestamp}.example.com",
+  )
+end
+@output_9.include?('Could not resolve a valid sender provider')
+#=> true
+
+## No MailerConfig is created when the provider is unresolvable
+Onetime::CustomDomain::MailerConfig.exists_for_domain?(@domain_9.identifier)
+#=> false
 
 # --- Cleanup ---
 PSDTestData.canned_result = nil

--- a/try/unit/config/config_serializer_sso_try.rb
+++ b/try/unit/config/config_serializer_sso_try.rb
@@ -77,10 +77,11 @@ ensure
 end
 
 # Helper to modify organizations feature flags with all four keys
-def with_orgs_features(orgs_enabled: false, sso_enabled: false, custom_mail_enabled: false, incoming_secrets_enabled: false)
+def with_orgs_features(orgs_enabled: false, sso_enabled: false, custom_mail_enabled: false, incoming_secrets_enabled: false, incoming_enabled: incoming_secrets_enabled)
   config = Onetime.auth_config.instance_variable_get(:@config)
   features = config['full']['features'] ||= {}
   original_orgs = features['organizations']
+  original_incoming = features['incoming']
 
   features['organizations'] = {
     'enabled' => orgs_enabled,
@@ -88,12 +89,18 @@ def with_orgs_features(orgs_enabled: false, sso_enabled: false, custom_mail_enab
     'custom_mail_enabled' => custom_mail_enabled,
     'incoming_secrets_enabled' => incoming_secrets_enabled,
   }
+  features['incoming'] = { 'enabled' => incoming_enabled }
   yield
 ensure
   if original_orgs.nil?
     features.delete('organizations')
   else
     features['organizations'] = original_orgs
+  end
+  if original_incoming.nil?
+    features.delete('incoming')
+  else
+    features['incoming'] = original_incoming
   end
 end
 

--- a/try/unit/logic/domains/remove_domain_try.rb
+++ b/try/unit/logic/domains/remove_domain_try.rb
@@ -4,13 +4,13 @@
 
 # Tests for RemoveDomain#delete_sender_domain
 #
-# The method loads mailer_config from the custom domain, checks if the
-# effective provider is 'lettermint', calls strategy.delete_sender_identity,
+# The method loads mailer_config from the custom domain, resolves the
+# effective provider, calls that provider's strategy.delete_sender_identity,
 # and swallows any errors so domain removal always proceeds.
 #
 # Covers:
 #   1. No mailer_config -> strategy never called
-#   2. Provider != 'lettermint' -> strategy never called
+#   2. Non-lettermint provider (ses) -> delete_sender_identity dispatched
 #   3. Provider == 'lettermint' -> delete_sender_identity called once
 #   4. Strategy raises StandardError -> error swallowed, no propagation
 #
@@ -113,10 +113,10 @@ restore_stubs(@ofp_1, @opc_1)
 #=> 0
 
 # ===================================================================
-# Case 2: Provider != 'lettermint' -> strategy never called
+# Case 2: Non-lettermint provider (ses) -> delete_sender_identity dispatched
 # ===================================================================
 
-## delete_sender_domain skips non-lettermint providers
+## delete_sender_domain dispatches deletion for non-lettermint providers
 @domain_2 = Onetime::CustomDomain.create!("rd-ses-#{@timestamp}-#{@entropy}.example.com", @org.objid)
 @mc_2 = Onetime::CustomDomain::MailerConfig.create!(
   domain_id: @domain_2.identifier,
@@ -128,7 +128,7 @@ restore_stubs(@ofp_1, @opc_1)
 @logic_2.send(:delete_sender_domain)
 restore_stubs(@ofp_2, @opc_2)
 @spy_2.delete_calls.size
-#=> 0
+#=> 1
 
 # ===================================================================
 # Case 3: Provider == 'lettermint' -> delete_sender_identity called

--- a/try/unit/mail/provider_credentials_contract_try.rb
+++ b/try/unit/mail/provider_credentials_contract_try.rb
@@ -279,3 +279,42 @@ class Onetime::Mail::Mailer
 end
 Onetime::Mail::Mailer.provider_credentials('ses')['region']
 #=> 'us-east-1'
+
+# --- SES provisioning credentials are decoupled from emailer.user/pass (SMTP_*) ---
+# build_provider_config('ses') resolves access_key_id/secret_access_key from
+# emailer.user/pass (i.e. SMTP_USERNAME/SMTP_PASSWORD when EMAILER_MODE=smtp).
+# email_providers.ses.{access_key_id,secret_access_key} (CUSTOM_MAIL_SES_* /
+# AWS_*) must override them so the SMTP login never leaks into the SES client.
+
+## Delivery-path config exposes the emailer-derived (SMTP) key pair
+@delivery_ses = Onetime::Mail::Mailer.send(:build_provider_config, 'ses')
+[@delivery_ses['access_key_id'], @delivery_ses['secret_access_key']]
+#=> ['smtp_user', 'smtp_pass']
+
+## provider_credentials('ses') overrides the key pair from email_providers.ses
+class Onetime::Mail::Mailer
+  class << self
+    def provider_config(provider)
+      if provider.to_s == 'ses'
+        { 'access_key_id' => 'AKIA_SES', 'secret_access_key' => 'ses-secret' }
+      else
+        {}
+      end
+    end
+  end
+end
+@ses_api_creds = Onetime::Mail::Mailer.provider_credentials('ses')
+[@ses_api_creds['access_key_id'], @ses_api_creds['secret_access_key']]
+#=> ['AKIA_SES', 'ses-secret']
+
+## With no email_providers.ses creds, it falls back to emailer.user/pass
+class Onetime::Mail::Mailer
+  class << self
+    def provider_config(_provider)
+      {}
+    end
+  end
+end
+@fallback_creds = Onetime::Mail::Mailer.provider_credentials('ses')
+[@fallback_creds['access_key_id'], @fallback_creds['secret_access_key']]
+#=> ['smtp_user', 'smtp_pass']

--- a/try/unit/mail/provider_credentials_contract_try.rb
+++ b/try/unit/mail/provider_credentials_contract_try.rb
@@ -247,3 +247,35 @@ creds['region']
 creds = Onetime::Mail::Mailer.provider_credentials('sendgrid')
 creds['api_key']
 #=> 'SG.test-key'
+
+# --- SES provisioning region is decoupled from EMAILER_REGION ---
+# provider_credentials('ses') sources region from email_providers.ses
+# (EMAIL_PROVIDERS_SES_REGION), independent of emailer.region (EMAILER_REGION),
+# so an install can run SMTP transactional mail and SES sender provisioning
+# in different regions.
+
+## SES provisioning region comes from email_providers.ses, overriding emailer.region
+class Onetime::Mail::Mailer
+  class << self
+    def provider_config(provider)
+      provider.to_s == 'ses' ? { 'region' => 'eu-west-1' } : {}
+    end
+  end
+end
+Onetime::Mail::Mailer.provider_credentials('ses')['region']
+#=> 'eu-west-1'
+
+## Delivery path (build_provider_config) still uses emailer.region, unaffected
+Onetime::Mail::Mailer.send(:build_provider_config, 'ses')['region']
+#=> 'us-east-1'
+
+## Restore the default provider_config stub for any later cases
+class Onetime::Mail::Mailer
+  class << self
+    def provider_config(_provider)
+      {}
+    end
+  end
+end
+Onetime::Mail::Mailer.provider_credentials('ses')['region']
+#=> 'us-east-1'

--- a/try/unit/mail/provider_credentials_contract_try.rb
+++ b/try/unit/mail/provider_credentials_contract_try.rb
@@ -250,7 +250,7 @@ creds['api_key']
 
 # --- SES provisioning region is decoupled from EMAILER_REGION ---
 # provider_credentials('ses') sources region from email_providers.ses
-# (EMAIL_PROVIDERS_SES_REGION), independent of emailer.region (EMAILER_REGION),
+# (CUSTOM_MAIL_SES_REGION), independent of emailer.region (EMAILER_REGION),
 # so an install can run SMTP transactional mail and SES sender provisioning
 # in different regions.
 

--- a/try/unit/models/custom_domain_mailer_config_try.rb
+++ b/try/unit/models/custom_domain_mailer_config_try.rb
@@ -16,6 +16,10 @@
 
 require_relative '../../support/test_models'
 
+# effective_provider falls back to the installation-level resolver in the
+# mail layer, so it must be loaded for those cases.
+require 'onetime/mail/mailer'
+
 OT.boot! :test
 
 # Configure Familia encryption with known test keys.
@@ -173,6 +177,21 @@ rescue Onetime::Problem => e
   e.message.include?('provider must be one of')
 end
 #=> true
+
+# --- Resolution: effective_provider ---
+
+## effective_provider returns the config's provider when set
+@config.effective_provider
+#=> 'ses'
+
+## effective_provider falls back to the installation sender provider when unset
+@config_noprov.effective_provider == Onetime::Mail::Mailer.determine_sender_provider
+#=> true
+
+## effective_provider normalizes casing and whitespace at the source
+@config_noprov.provider = '  SES  '
+@config_noprov.effective_provider
+#=> 'ses'
 
 # --- Validation: from_address ---
 


### PR DESCRIPTION
- **Generalize sender-domain delete + reconcile to dispatch on effective_provider**
- **Refine sender-provider resolution: centralize, normalize, skip cleanly**
- **Close test-coverage gaps in sender-provider resolution**
- **Address PR review: accurate delete logging, list-drift guard, normalized error**
- **Fix standalone-materialization spec: disable billing in before(:all)**
- **Add SIGUSR2 heap dump handler boot initializer (#3366)**
- **Harden heap dump file handling against secret leakage (#3366)**
- **Fix incoming secrets UI shown when install-level feature is disabled**
- **Gate heap dump handler behind HEAP_DUMP_ENABLED (default off) (#3366)**
- **Guard DomainIncoming page when install-level incoming feature is disabled**
- **Guard SsoConfig provider-enumeration drift in CI**
- **Fix heap dump handler spec mocks (#3371 CI)**
- **Fix test fixtures missing install-level incoming.enabled gate**
- **Address Greptile review on heap dump handler (#3371)**
- **Address greptile review feedback**
- **docs(ses): document SES as supported domain-level sender provider (#3359)**
- **docs(ses): record #2833 region-through-validation as resolved by design**
- **docs(ses): align env/config comments with #2833 inert-region framing**
- **docs(ses): clarify SES credentials accept SMTP_* or AWS_* (precedence + caution)**
- **fix(ses): source provisioning region from EMAIL_PROVIDERS_SES_REGION, not EMAILER_REGION**
- **revert(ses): keep CUSTOM_MAIL_SES_REGION name; drop EMAIL_PROVIDERS_* rename**
- **dx(bin/dev): skip overmind .env loading to preserve direnv env**
- **feat(ses): provision custom MAIL FROM + FQDN records; harden strategy**
- **docs(ses): explain custom MAIL FROM as Lettermint Return-Path equivalent (DMARC alignment)**
- **docs(mail): cross-link SES/Lettermint provider comparison in module + arch docs**
- **fix(ses): decouple SES API credentials from the SMTP transactional mailer**
- **[#KQIY2] Put CUSTOM_MAIL_PROVIDER close to home**
