### PR TITLE
Fix UI issues

### DIFF
--- a/apps/web/core/templates/partials/head-base.rue
+++ b/apps/web/core/templates/partials/head-base.rue
@@ -15,15 +15,6 @@
   <title>{{page_title}}</title>
   <meta name="description" content="{{description}}">
 
-  <!-- PWA and app metadata -->
-  <link nonce="{{app.nonce}}" rel="manifest" href="/site.webmanifest">
-  <meta name="theme-color" content="{{brand_primary_color}}" media="(prefers-color-scheme: light)">
-  <meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)">
-  <meta name="mobile-web-app-capable" content="yes">
-  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
-  <meta name="apple-mobile-web-app-title" content="{{page_title}}">
-  <meta name="application-name" content="{{page_title}}">
-
   <!-- Modern favicon strategy -->
   <link nonce="{{app.nonce}}" rel="icon" href="/favicon.ico" sizes="32x32">
   <link nonce="{{app.nonce}}" rel="mask-icon" href="/safari-pinned-tab.svg" color="{{brand_primary_color}}">

--- a/src/schemas/contracts/custom-domain/brand-config.ts
+++ b/src/schemas/contracts/custom-domain/brand-config.ts
@@ -146,7 +146,7 @@ export const brandSettingsCanonical = z
     instructions_post_reveal: z.string().nullish(),
 
     /** Brand description. */
-    description: z.string().optional(),
+    description: z.string().nullish(),
 
     /** Whether button text should be light colored. */
     button_text_light: z.boolean().default(true),

--- a/src/shared/components/logos/OnetimeSecretLogo.vue
+++ b/src/shared/components/logos/OnetimeSecretLogo.vue
@@ -135,7 +135,7 @@
           :size="svgSize"
           :aria-label="ariaLabel"
           :brightness="svgBrightness"
-          class="shrink-0 rounded-lg"
+          class="shrink-0 rounded-lg text-brand-500"
           :style="{ width: `${svgSize}px`, height: `${svgSize}px` }" /></a>
 
       <!-- Jurisdiction selector button -->


### PR DESCRIPTION
Small UI/schema cleanups on the brand and head templates.

- Add brand color to `OnetimeSecretLogo`
- Fix domain brand-config schema (`brand-config.ts`)
- Remove PWA / app metadata from the head-base template

## Changes
- `apps/web/core/templates/partials/head-base.rue` — drop PWA + app metadata
- `src/schemas/contracts/custom-domain/brand-config.ts` — schema fix
- `src/shared/components/logos/OnetimeSecretLogo.vue` — brand color