### PR TITLE
SES: surface MAIL FROM status and add lifecycle tests

### DIFF
--- a/docs/architecture/custom-mail-sender-ses.md
+++ b/docs/architecture/custom-mail-sender-ses.md
@@ -206,8 +206,8 @@ identity can have DKIM `SUCCESS` while MAIL FROM is in any of these states:
 
 The provisioning flow always calls `PutEmailIdentityMailFromAttributes`, so after
 a successful provision the MAIL FROM status should be `PENDING` (never
-`NOT_STARTED`). If the API call is rejected (e.g. unsupported region), the
-provisioning result sets `mail_from_configured: false` and the success message
+`NOT_STARTED`). If the API call is rejected (e.g. unsupported region),
+`mail_from_domain` is nil in the provisioning result and the success message
 notes "DKIM only" — the identity still works for sending but without SPF
 alignment.
 

--- a/docs/architecture/custom-mail-sender-ses.md
+++ b/docs/architecture/custom-mail-sender-ses.md
@@ -192,6 +192,29 @@ not support it), provisioning still succeeds with the DKIM records and the
 MAIL FROM records are omitted, rather than asking the customer to add records
 SES will not honor.
 
+### MAIL FROM status lifecycle
+
+DKIM verification and MAIL FROM configuration are **independent** in SES. An
+identity can have DKIM `SUCCESS` while MAIL FROM is in any of these states:
+
+| MAIL FROM status | Meaning | What happened |
+|---|---|---|
+| `NOT_STARTED` | `PutEmailIdentityMailFromAttributes` was never called | Identity created without MAIL FROM — DKIM works, but SPF authenticates against `amazonses.com` instead of the sender domain |
+| `PENDING` | MAIL FROM configured, DNS propagation pending | `PutEmailIdentityMailFromAttributes` succeeded; SES is waiting for the MX and SPF TXT records on `mail.<domain>` |
+| `SUCCESS` | MAIL FROM fully verified | SES detected the MX and SPF records — SPF now aligns to the sender domain under DMARC |
+| `FAILED` | MX/SPF records missing or incorrect | SES checked and could not verify — re-check DNS records at the registrar |
+
+The provisioning flow always calls `PutEmailIdentityMailFromAttributes`, so after
+a successful provision the MAIL FROM status should be `PENDING` (never
+`NOT_STARTED`). If the API call is rejected (e.g. unsupported region), the
+provisioning result sets `mail_from_configured: false` and the success message
+notes "DKIM only" — the identity still works for sending but without SPF
+alignment.
+
+`check_provider_verification_status` surfaces both DKIM and MAIL FROM status in
+the `:details` hash (`mail_from_domain` and `mail_from_status`), so callers can
+distinguish "DKIM verified, MAIL FROM pending" from "everything verified."
+
 ### 2. Verify
 
 `ValidateSenderDomain` → `SesValidation` reads the **provisioned** records from

--- a/lib/onetime/mail/sender_strategies/ses_sender_strategy.rb
+++ b/lib/onetime/mail/sender_strategies/ses_sender_strategy.rb
@@ -112,7 +112,6 @@ module Onetime
               identity: domain,
               dkim_status: response.dkim_attributes&.status,
               mail_from_domain: mail_from_domain,
-              mail_from_configured: mail_from_configured,
             },
           }
         rescue Aws::SESV2::Errors::ServiceError => ex

--- a/lib/onetime/mail/sender_strategies/ses_sender_strategy.rb
+++ b/lib/onetime/mail/sender_strategies/ses_sender_strategy.rb
@@ -88,15 +88,23 @@ module Onetime
           # region. Non-fatal: if SES rejects it we keep the DKIM records and
           # drop the MAIL FROM records (see #configure_mail_from).
           mail_from_domain = "#{MAIL_FROM_SUBDOMAIN}.#{domain}"
-          if configure_mail_from(client, domain, mail_from_domain)
+          mail_from_configured = configure_mail_from(client, domain, mail_from_domain)
+
+          if mail_from_configured
             records += build_mail_from_records(mail_from_domain, region)
           else
             mail_from_domain = nil
           end
 
+          message = if mail_from_configured
+                      "Provisioned sender identity for #{domain} with custom MAIL FROM domain"
+                    else
+                      "Provisioned sender identity for #{domain} (MAIL FROM not configured — DKIM only)"
+                    end
+
           {
             success: true,
-            message: "Provisioned sender identity for #{domain}",
+            message: message,
             dns_records: records,
             provider_data: {
               dkim_tokens: dkim_tokens,
@@ -104,6 +112,7 @@ module Onetime
               identity: domain,
               dkim_status: response.dkim_attributes&.status,
               mail_from_domain: mail_from_domain,
+              mail_from_configured: mail_from_configured,
             },
           }
         rescue Aws::SESV2::Errors::ServiceError => ex

--- a/spec/unit/onetime/mail/sender_strategies/ses_sender_strategy_spec.rb
+++ b/spec/unit/onetime/mail/sender_strategies/ses_sender_strategy_spec.rb
@@ -62,7 +62,6 @@ RSpec.describe Onetime::Mail::SenderStrategies::SESSenderStrategy do
         expect(result[:provider_data][:region]).to eq('us-east-1')
         expect(result[:provider_data][:identity]).to eq('example.com')
         expect(result[:provider_data][:mail_from_domain]).to eq('mail.example.com')
-        expect(result[:provider_data][:mail_from_configured]).to be true
       end
 
       it 'configures a custom MAIL FROM domain on the identity' do
@@ -146,7 +145,6 @@ RSpec.describe Onetime::Mail::SenderStrategies::SESSenderStrategy do
         expect(result[:dns_records].map { |r| r[:type] }).to eq(%w[CNAME CNAME])
         expect(result[:dns_records].any? { |r| r[:type] == 'MX' }).to be false
         expect(result[:provider_data][:mail_from_domain]).to be_nil
-        expect(result[:provider_data][:mail_from_configured]).to be false
       end
 
       it 'indicates DKIM-only in the success message' do
@@ -296,15 +294,6 @@ RSpec.describe Onetime::Mail::SenderStrategies::SESSenderStrategy do
         expect(result[:message]).to include('awaiting propagation')
       end
     end
-
-    # MAIL FROM lifecycle: NOT_STARTED → PENDING → SUCCESS
-    #
-    # MAIL FROM configuration is independent of DKIM verification. An identity
-    # can have DKIM SUCCESS while MAIL FROM is still NOT_STARTED (never
-    # configured), PENDING (configured but DNS not yet verified), or SUCCESS.
-    #
-    # "Not started" means PutEmailIdentityMailFromAttributes was never called
-    # for this identity — it does NOT indicate a DKIM problem.
 
     context 'when MAIL FROM was never configured (NOT_STARTED)' do
       let(:dkim_attrs) do

--- a/spec/unit/onetime/mail/sender_strategies/ses_sender_strategy_spec.rb
+++ b/spec/unit/onetime/mail/sender_strategies/ses_sender_strategy_spec.rb
@@ -62,6 +62,7 @@ RSpec.describe Onetime::Mail::SenderStrategies::SESSenderStrategy do
         expect(result[:provider_data][:region]).to eq('us-east-1')
         expect(result[:provider_data][:identity]).to eq('example.com')
         expect(result[:provider_data][:mail_from_domain]).to eq('mail.example.com')
+        expect(result[:provider_data][:mail_from_configured]).to be true
       end
 
       it 'configures a custom MAIL FROM domain on the identity' do
@@ -73,6 +74,12 @@ RSpec.describe Onetime::Mail::SenderStrategies::SESSenderStrategy do
             mail_from_domain: 'mail.example.com',
             behavior_on_mx_failure: 'USE_DEFAULT_VALUE',
           )
+      end
+
+      it 'includes MAIL FROM in the success message' do
+        result = strategy.provision_dns_records(mailer_config, credentials: credentials)
+
+        expect(result[:message]).to include('custom MAIL FROM domain')
       end
     end
 
@@ -139,6 +146,21 @@ RSpec.describe Onetime::Mail::SenderStrategies::SESSenderStrategy do
         expect(result[:dns_records].map { |r| r[:type] }).to eq(%w[CNAME CNAME])
         expect(result[:dns_records].any? { |r| r[:type] == 'MX' }).to be false
         expect(result[:provider_data][:mail_from_domain]).to be_nil
+        expect(result[:provider_data][:mail_from_configured]).to be false
+      end
+
+      it 'indicates DKIM-only in the success message' do
+        result = strategy.provision_dns_records(mailer_config, credentials: credentials)
+
+        expect(result[:message]).to include('MAIL FROM not configured')
+        expect(result[:message]).to include('DKIM only')
+      end
+
+      it 'logs a warning about the MAIL FROM failure' do
+        strategy.provision_dns_records(mailer_config, credentials: credentials)
+
+        expect(strategy).to have_received(:log_warn)
+          .with(a_string_matching(/MAIL FROM setup failed/))
       end
     end
 
@@ -272,6 +294,120 @@ RSpec.describe Onetime::Mail::SenderStrategies::SESSenderStrategy do
         expect(result[:verified]).to be false
         expect(result[:status]).to eq('pending')
         expect(result[:message]).to include('awaiting propagation')
+      end
+    end
+
+    # MAIL FROM lifecycle: NOT_STARTED → PENDING → SUCCESS
+    #
+    # MAIL FROM configuration is independent of DKIM verification. An identity
+    # can have DKIM SUCCESS while MAIL FROM is still NOT_STARTED (never
+    # configured), PENDING (configured but DNS not yet verified), or SUCCESS.
+    #
+    # "Not started" means PutEmailIdentityMailFromAttributes was never called
+    # for this identity — it does NOT indicate a DKIM problem.
+
+    context 'when MAIL FROM was never configured (NOT_STARTED)' do
+      let(:dkim_attrs) do
+        double('DkimAttributes',
+          tokens: %w[abc123 def456 ghi789],
+          status: 'SUCCESS',
+          signing_enabled: true)
+      end
+      let(:mail_from_attrs) do
+        double('MailFromAttributes',
+          mail_from_domain: '',
+          mail_from_domain_status: 'NOT_STARTED')
+      end
+      let(:get_response) do
+        double('GetEmailIdentityResponse',
+          dkim_attributes: dkim_attrs,
+          mail_from_attributes: mail_from_attrs,
+          identity_type: 'DOMAIN')
+      end
+
+      before do
+        allow(mock_client).to receive(:get_email_identity)
+          .with(email_identity: 'example.com')
+          .and_return(get_response)
+      end
+
+      it 'reports DKIM verified but MAIL FROM not started' do
+        result = strategy.check_provider_verification_status(mailer_config, credentials: credentials)
+
+        expect(result[:verified]).to be true
+        expect(result[:status]).to eq('success')
+        expect(result[:details][:mail_from_domain]).to eq('')
+        expect(result[:details][:mail_from_status]).to eq('NOT_STARTED')
+      end
+    end
+
+    context 'when MAIL FROM is pending DNS verification' do
+      let(:dkim_attrs) do
+        double('DkimAttributes',
+          tokens: %w[abc123 def456 ghi789],
+          status: 'SUCCESS',
+          signing_enabled: true)
+      end
+      let(:mail_from_attrs) do
+        double('MailFromAttributes',
+          mail_from_domain: 'mail.example.com',
+          mail_from_domain_status: 'PENDING')
+      end
+      let(:get_response) do
+        double('GetEmailIdentityResponse',
+          dkim_attributes: dkim_attrs,
+          mail_from_attributes: mail_from_attrs,
+          identity_type: 'DOMAIN')
+      end
+
+      before do
+        allow(mock_client).to receive(:get_email_identity)
+          .with(email_identity: 'example.com')
+          .and_return(get_response)
+      end
+
+      it 'reports DKIM verified with MAIL FROM pending' do
+        result = strategy.check_provider_verification_status(mailer_config, credentials: credentials)
+
+        expect(result[:verified]).to be true
+        expect(result[:status]).to eq('success')
+        expect(result[:details][:mail_from_domain]).to eq('mail.example.com')
+        expect(result[:details][:mail_from_status]).to eq('PENDING')
+      end
+    end
+
+    context 'when MAIL FROM verification has failed' do
+      let(:dkim_attrs) do
+        double('DkimAttributes',
+          tokens: %w[abc123 def456 ghi789],
+          status: 'SUCCESS',
+          signing_enabled: true)
+      end
+      let(:mail_from_attrs) do
+        double('MailFromAttributes',
+          mail_from_domain: 'mail.example.com',
+          mail_from_domain_status: 'FAILED')
+      end
+      let(:get_response) do
+        double('GetEmailIdentityResponse',
+          dkim_attributes: dkim_attrs,
+          mail_from_attributes: mail_from_attrs,
+          identity_type: 'DOMAIN')
+      end
+
+      before do
+        allow(mock_client).to receive(:get_email_identity)
+          .with(email_identity: 'example.com')
+          .and_return(get_response)
+      end
+
+      it 'reports DKIM verified despite MAIL FROM failure' do
+        result = strategy.check_provider_verification_status(mailer_config, credentials: credentials)
+
+        expect(result[:verified]).to be true
+        expect(result[:status]).to eq('success')
+        expect(result[:details][:mail_from_domain]).to eq('mail.example.com')
+        expect(result[:details][:mail_from_status]).to eq('FAILED')
       end
     end
 


### PR DESCRIPTION
## Summary

Addresses #3378 — makes MAIL FROM configuration state explicit in provisioning output and adds test coverage for the full MAIL FROM status lifecycle.

- **Differentiated success messages**: provisioning now reports "with custom MAIL FROM domain" or "(MAIL FROM not configured — DKIM only)" instead of a generic message, so operators can tell at a glance whether SPF alignment is set up
- **MAIL FROM lifecycle tests**: three new verification contexts cover NOT_STARTED (never configured), PENDING (configured, DNS pending), and FAILED states — pinning down that DKIM and MAIL FROM are independent in SES
- **Provisioning failure tests**: the MAIL FROM rejection path now verifies the log warning is emitted and the message indicates DKIM-only operation
- **Architecture doc**: new "MAIL FROM status lifecycle" section documents the four states and how the provisioning flow progresses through them

No new fields added to `provider_data` — `mail_from_domain` being nil already signals that MAIL FROM was not configured.

## Test plan

- [ ] Verify new specs pass (NOT_STARTED, PENDING, FAILED lifecycle contexts)
- [ ] Verify existing specs still pass (message wording changed)
- [ ] Confirm MAIL FROM rejection path logs warning and omits MX/TXT records
- [ ] Confirm non-default region test still emits correct `feedback-smtp.<region>.amazonses.com`

Closes #3378


---
_Generated by [Claude Code](https://claude.ai/code/session_01QAwfMC5cCwT8hpGLEkymrC)_