### PR TITLE
Fix primaryColor fallback chain to include install config (#3381)

### DIFF
--- a/e2e/all/brand-customization.spec.ts
+++ b/e2e/all/brand-customization.spec.ts
@@ -328,26 +328,11 @@ test.describe('Brand Customization - Console Error Monitoring', () => {
 
 test.describe('Brand Customization - head-base meta tags', () => {
   // head-base.rue partial renders:
-  //   <meta name="theme-color" content="{{brand_primary_color}}" media="(prefers-color-scheme: light)">
   //   <link rel="mask-icon" href="..." color="{{brand_primary_color}}">
-  // Both should carry a hex color value derived from the configured brand color.
-
-  test('meta theme-color carries a valid hex color', async ({ page }) => {
-    await page.goto('/');
-    await page.waitForLoadState('networkidle');
-
-    // There are two theme-color metas (light + dark media). The light one
-    // is the brand-driven value; the dark one is hardcoded #1a1a1a.
-    const lightThemeColor = await page
-      .locator('meta[name="theme-color"][media*="light"]')
-      .getAttribute('content');
-
-    expect(lightThemeColor, 'meta[theme-color] light should be present').toBeTruthy();
-    expect(
-      lightThemeColor && isHexColor(lightThemeColor),
-      `meta[theme-color] light should be a hex color, got: ${lightThemeColor}`
-    ).toBe(true);
-  });
+  // The color attribute should carry a hex color value derived from the
+  // configured brand color.
+  //
+  // Note: <meta name="theme-color"> was removed in 5b2e760 (PWA cleanup).
 
   test('link mask-icon color attribute carries a valid hex color', async ({ page }) => {
     await page.goto('/');
@@ -362,20 +347,6 @@ test.describe('Brand Customization - head-base meta tags', () => {
       maskIconColor && isHexColor(maskIconColor),
       `link[mask-icon] color should be a hex color, got: ${maskIconColor}`
     ).toBe(true);
-  });
-
-  test('theme-color and mask-icon agree on the brand color', async ({ page }) => {
-    await page.goto('/');
-    await page.waitForLoadState('networkidle');
-
-    const lightThemeColor = await page
-      .locator('meta[name="theme-color"][media*="light"]')
-      .getAttribute('content');
-    const maskIconColor = await page
-      .locator('link[rel="mask-icon"]')
-      .getAttribute('color');
-
-    expect(lightThemeColor?.toLowerCase()).toBe(maskIconColor?.toLowerCase());
   });
 });
 

--- a/src/shared/stores/identityStore.ts
+++ b/src/shared/stores/identityStore.ts
@@ -131,6 +131,14 @@ export const useProductIdentity = defineStore('productIdentity', () => {
     state.buttonTextLight = brand?.button_text_light ?? DEFAULT_BUTTON_TEXT_LIGHT;
   });
 
+  // Watch for install-config color changes (e.g. /bootstrap/me refresh)
+  watch(
+    () => bootstrapStore.brand_primary_color,
+    () => {
+      state.primaryColor = resolvePrimaryColor(state.brand?.primary_color);
+    }
+  );
+
   // Watch homepage_config for toggle state (authoritative source, separate from brand)
   watch(homepage_config, (newConfig) => {
     state.allowPublicHomepage = newConfig?.enabled ?? false;

--- a/src/shared/stores/identityStore.ts
+++ b/src/shared/stores/identityStore.ts
@@ -74,13 +74,21 @@ export const useProductIdentity = defineStore('productIdentity', () => {
    *   1. Per-domain branding (Redis custom domain settings)
    *   2. Install config (BRAND_PRIMARY_COLOR env var via bootstrapStore)
    *   3. Neutral last resort (NEUTRAL_BRAND_DEFAULTS.primary_color)
+   *
+   * Both steps 1 and 2 are validated through primaryColorValidator so
+   * malformed values degrade gracefully instead of reaching the palette
+   * generator.
    */
   function resolvePrimaryColor(brandColor: unknown): string {
-    const parsed = gracefulParse(primaryColorValidator, brandColor, 'PrimaryColor');
-    const validated = parsed.ok ? parsed.data : null;
+    const domainParsed = gracefulParse(primaryColorValidator, brandColor, 'PrimaryColor');
+    const domainValidated = domainParsed.ok ? domainParsed.data : null;
+
+    const installParsed = gracefulParse(primaryColorValidator, bootstrapStore.brand_primary_color, 'InstallPrimaryColor');
+    const installValidated = installParsed.ok ? installParsed.data : null;
+
     return (
-      validated ??
-      bootstrapStore.brand_primary_color ??
+      domainValidated ??
+      installValidated ??
       NEUTRAL_BRAND_DEFAULTS.primary_color
     );
   }

--- a/src/shared/stores/identityStore.ts
+++ b/src/shared/stores/identityStore.ts
@@ -70,6 +70,22 @@ export const useProductIdentity = defineStore('productIdentity', () => {
   } = storeToRefs(bootstrapStore);
 
   /**
+   * Resolves the active primary color through a 3-step fallback chain:
+   *   1. Per-domain branding (Redis custom domain settings)
+   *   2. Install config (BRAND_PRIMARY_COLOR env var via bootstrapStore)
+   *   3. Neutral last resort (NEUTRAL_BRAND_DEFAULTS.primary_color)
+   */
+  function resolvePrimaryColor(brandColor: unknown): string {
+    const parsed = gracefulParse(primaryColorValidator, brandColor, 'PrimaryColor');
+    const validated = parsed.ok ? parsed.data : null;
+    return (
+      validated ??
+      bootstrapStore.brand_primary_color ??
+      NEUTRAL_BRAND_DEFAULTS.primary_color
+    );
+  }
+
+  /**
    * Creates initial identity state from bootstrapStore values
    * Handles validation and default values for branding fields
    */
@@ -77,8 +93,7 @@ export const useProductIdentity = defineStore('productIdentity', () => {
     const brandResult = gracefulParse(brandSettingsSchema, domain_branding.value ?? {}, 'BrandSettings');
     const brand = brandResult.ok ? brandResult.data : null;
 
-    const colorResult = gracefulParse(primaryColorValidator, brand?.primary_color, 'PrimaryColor');
-    const primaryColor = colorResult.ok ? (colorResult.data ?? NEUTRAL_BRAND_DEFAULTS.primary_color) : NEUTRAL_BRAND_DEFAULTS.primary_color;
+    const primaryColor = resolvePrimaryColor(brand?.primary_color);
     const buttonTextLight = brand?.button_text_light ?? DEFAULT_BUTTON_TEXT_LIGHT;
     const allowPublicHomepage = homepage_config.value?.enabled ?? false;
 
@@ -104,8 +119,7 @@ export const useProductIdentity = defineStore('productIdentity', () => {
     const brand = brandResult.ok ? brandResult.data : null;
     state.brand = brand;
 
-    const colorResult = gracefulParse(primaryColorValidator, brand?.primary_color, 'PrimaryColor');
-    state.primaryColor = colorResult.ok ? (colorResult.data ?? NEUTRAL_BRAND_DEFAULTS.primary_color) : NEUTRAL_BRAND_DEFAULTS.primary_color;
+    state.primaryColor = resolvePrimaryColor(brand?.primary_color);
     state.buttonTextLight = brand?.button_text_light ?? DEFAULT_BUTTON_TEXT_LIGHT;
   });
 

--- a/src/tests/composables/useBrandTheme.spec.ts
+++ b/src/tests/composables/useBrandTheme.spec.ts
@@ -365,4 +365,41 @@ describe('useBrandTheme', () => {
       scope.stop();
     });
   });
+
+  describe('install-config color override (#3381 regression guard)', () => {
+    it('non-neutral install color overrides --color-brand-500 on the DOM', async () => {
+      // Simulates the identityStore resolving to an install-level brand color
+      // (BRAND_PRIMARY_COLOR env var) when no per-domain branding is set.
+      const INSTALL_COLOR = '#E11D48';
+      mockPrimaryColor.value = INSTALL_COLOR;
+
+      const scope = effectScope();
+      scope.run(() => useBrandTheme());
+      await nextTick();
+
+      const expected = generateBrandPalette(INSTALL_COLOR);
+      expect(getVar('--color-brand-500')).toBe(expected['--color-brand-500']);
+      expect(getVar('--color-brand-500')).not.toBe('');
+
+      scope.stop();
+    });
+
+    it('install color palette is fully applied (not partial)', async () => {
+      const INSTALL_COLOR = '#E11D48';
+      mockPrimaryColor.value = INSTALL_COLOR;
+
+      const scope = effectScope();
+      scope.run(() => useBrandTheme());
+      await nextTick();
+
+      const expected = generateBrandPalette(INSTALL_COLOR);
+      let appliedCount = 0;
+      for (const [key, value] of Object.entries(expected)) {
+        if (getVar(key) === value) appliedCount++;
+      }
+      expect(appliedCount).toBe(ALL_KEYS.length);
+
+      scope.stop();
+    });
+  });
 });

--- a/src/tests/stores/identityStore.spec.ts
+++ b/src/tests/stores/identityStore.spec.ts
@@ -1,0 +1,130 @@
+// src/tests/stores/identityStore.spec.ts
+//
+// Precedence contract tests for the primaryColor 3-step fallback chain
+// in identityStore's resolvePrimaryColor():
+//   1. Per-domain branding (Redis custom domain settings)
+//   2. Install config (BRAND_PRIMARY_COLOR via bootstrapStore)
+//   3. Neutral last resort (NEUTRAL_BRAND_DEFAULTS.primary_color)
+
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  vi,
+} from 'vitest';
+import { createPinia, setActivePinia } from 'pinia';
+import { NEUTRAL_BRAND_DEFAULTS } from '@/shared/constants/brand';
+
+const NEUTRAL_HEX = NEUTRAL_BRAND_DEFAULTS.primary_color;
+const INSTALL_COLOR = '#E11D48';
+const DOMAIN_COLOR = '#22C55E';
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock('@/services/bootstrap.service', () => ({
+  getBootstrapSnapshot: vi.fn(() => null),
+  updateBootstrapSnapshot: vi.fn(),
+  _resetForTesting: vi.fn(),
+}));
+
+import { useBootstrapStore } from '@/shared/stores/bootstrapStore';
+import { useProductIdentity } from '@/shared/stores/identityStore';
+
+describe('identityStore primaryColor resolution', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  describe('3-step fallback chain precedence', () => {
+    it('uses per-domain color when set (step 1 wins)', () => {
+      const bootstrap = useBootstrapStore();
+      bootstrap.$patch({
+        domain_branding: { primary_color: DOMAIN_COLOR },
+        brand_primary_color: INSTALL_COLOR,
+      });
+
+      const identity = useProductIdentity();
+
+      expect(identity.primaryColor.toUpperCase()).toBe(DOMAIN_COLOR.toUpperCase());
+    });
+
+    it('falls through to install config when no per-domain color (step 2 wins)', () => {
+      const bootstrap = useBootstrapStore();
+      bootstrap.$patch({
+        domain_branding: null,
+        brand_primary_color: INSTALL_COLOR,
+      });
+
+      const identity = useProductIdentity();
+
+      expect(identity.primaryColor.toUpperCase()).toBe(INSTALL_COLOR.toUpperCase());
+    });
+
+    it('falls through to install config when per-domain color is null (step 2 wins)', () => {
+      const bootstrap = useBootstrapStore();
+      bootstrap.$patch({
+        domain_branding: { primary_color: null },
+        brand_primary_color: INSTALL_COLOR,
+      });
+
+      const identity = useProductIdentity();
+
+      expect(identity.primaryColor.toUpperCase()).toBe(INSTALL_COLOR.toUpperCase());
+    });
+
+    it('falls through to neutral default when neither is set (step 3 wins)', () => {
+      const bootstrap = useBootstrapStore();
+      bootstrap.$patch({
+        domain_branding: null,
+        brand_primary_color: undefined,
+      });
+
+      const identity = useProductIdentity();
+
+      expect(identity.primaryColor.toUpperCase()).toBe(NEUTRAL_HEX.toUpperCase());
+    });
+
+    it('falls through to neutral default when per-domain color is invalid hex', () => {
+      const bootstrap = useBootstrapStore();
+      bootstrap.$patch({
+        domain_branding: { primary_color: 'not-a-color' },
+        brand_primary_color: undefined,
+      });
+
+      const identity = useProductIdentity();
+
+      expect(identity.primaryColor.toUpperCase()).toBe(NEUTRAL_HEX.toUpperCase());
+    });
+
+    it('falls through to install config when per-domain color is invalid hex (step 2 catches)', () => {
+      const bootstrap = useBootstrapStore();
+      bootstrap.$patch({
+        domain_branding: { primary_color: 'bad' },
+        brand_primary_color: INSTALL_COLOR,
+      });
+
+      const identity = useProductIdentity();
+
+      expect(identity.primaryColor.toUpperCase()).toBe(INSTALL_COLOR.toUpperCase());
+    });
+  });
+
+  describe('brand_primary_color is no longer an orphaned bootstrap field', () => {
+    it('bootstrapStore.brand_primary_color is consumed by identityStore', () => {
+      const bootstrap = useBootstrapStore();
+      bootstrap.$patch({
+        domain_branding: null,
+        brand_primary_color: '#8B5CF6',
+      });
+
+      const identity = useProductIdentity();
+
+      expect(identity.primaryColor.toUpperCase()).toBe('#8B5CF6');
+    });
+  });
+});

--- a/src/tests/stores/identityStore.spec.ts
+++ b/src/tests/stores/identityStore.spec.ts
@@ -156,6 +156,39 @@ describe('identityStore primaryColor resolution', () => {
 
       expect(upperHex(identity.primaryColor)).toBe(upperHex(NEUTRAL_HEX));
     });
+
+    it('install config changing independently of domain_branding updates primaryColor', async () => {
+      const bootstrap = useBootstrapStore();
+      bootstrap.$patch({
+        domain_branding: null,
+        brand_primary_color: INSTALL_COLOR,
+      });
+
+      const identity = useProductIdentity();
+      expect(upperHex(identity.primaryColor)).toBe(upperHex(INSTALL_COLOR));
+
+      const NEW_INSTALL = '#8B5CF6';
+      bootstrap.$patch({ brand_primary_color: NEW_INSTALL });
+      await nextTick();
+
+      expect(upperHex(identity.primaryColor)).toBe(upperHex(NEW_INSTALL));
+    });
+
+    it('install config removed independently falls to neutral', async () => {
+      const bootstrap = useBootstrapStore();
+      bootstrap.$patch({
+        domain_branding: null,
+        brand_primary_color: INSTALL_COLOR,
+      });
+
+      const identity = useProductIdentity();
+      expect(upperHex(identity.primaryColor)).toBe(upperHex(INSTALL_COLOR));
+
+      bootstrap.$patch({ brand_primary_color: undefined });
+      await nextTick();
+
+      expect(upperHex(identity.primaryColor)).toBe(upperHex(NEUTRAL_HEX));
+    });
   });
 
   // ═══════════════════════════════════════════════════════════════════════════

--- a/src/tests/stores/identityStore.spec.ts
+++ b/src/tests/stores/identityStore.spec.ts
@@ -5,6 +5,9 @@
 //   1. Per-domain branding (Redis custom domain settings)
 //   2. Install config (BRAND_PRIMARY_COLOR via bootstrapStore)
 //   3. Neutral last resort (NEUTRAL_BRAND_DEFAULTS.primary_color)
+//
+// These tests pin the resolution order so a partial port or refactor
+// cannot silently drop a rung (the class of bug that produced #3381).
 
 import {
   describe,
@@ -13,8 +16,11 @@ import {
   beforeEach,
   vi,
 } from 'vitest';
+import { nextTick } from 'vue';
 import { createPinia, setActivePinia } from 'pinia';
 import { NEUTRAL_BRAND_DEFAULTS } from '@/shared/constants/brand';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
 
 const NEUTRAL_HEX = NEUTRAL_BRAND_DEFAULTS.primary_color;
 const INSTALL_COLOR = '#E11D48';
@@ -35,12 +41,20 @@ vi.mock('@/services/bootstrap.service', () => ({
 import { useBootstrapStore } from '@/shared/stores/bootstrapStore';
 import { useProductIdentity } from '@/shared/stores/identityStore';
 
+function upperHex(hex: string): string {
+  return hex.toUpperCase();
+}
+
 describe('identityStore primaryColor resolution', () => {
   beforeEach(() => {
     setActivePinia(createPinia());
   });
 
-  describe('3-step fallback chain precedence', () => {
+  // ═══════════════════════════════════════════════════════════════════════════
+  // INITIAL STATE — tests getInitialState() path
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  describe('3-step fallback chain (initial state)', () => {
     it('uses per-domain color when set (step 1 wins)', () => {
       const bootstrap = useBootstrapStore();
       bootstrap.$patch({
@@ -50,7 +64,7 @@ describe('identityStore primaryColor resolution', () => {
 
       const identity = useProductIdentity();
 
-      expect(identity.primaryColor.toUpperCase()).toBe(DOMAIN_COLOR.toUpperCase());
+      expect(upperHex(identity.primaryColor)).toBe(upperHex(DOMAIN_COLOR));
     });
 
     it('falls through to install config when no per-domain color (step 2 wins)', () => {
@@ -62,7 +76,7 @@ describe('identityStore primaryColor resolution', () => {
 
       const identity = useProductIdentity();
 
-      expect(identity.primaryColor.toUpperCase()).toBe(INSTALL_COLOR.toUpperCase());
+      expect(upperHex(identity.primaryColor)).toBe(upperHex(INSTALL_COLOR));
     });
 
     it('falls through to install config when per-domain color is null (step 2 wins)', () => {
@@ -74,7 +88,7 @@ describe('identityStore primaryColor resolution', () => {
 
       const identity = useProductIdentity();
 
-      expect(identity.primaryColor.toUpperCase()).toBe(INSTALL_COLOR.toUpperCase());
+      expect(upperHex(identity.primaryColor)).toBe(upperHex(INSTALL_COLOR));
     });
 
     it('falls through to neutral default when neither is set (step 3 wins)', () => {
@@ -86,33 +100,133 @@ describe('identityStore primaryColor resolution', () => {
 
       const identity = useProductIdentity();
 
-      expect(identity.primaryColor.toUpperCase()).toBe(NEUTRAL_HEX.toUpperCase());
+      expect(upperHex(identity.primaryColor)).toBe(upperHex(NEUTRAL_HEX));
     });
+  });
 
-    it('falls through to neutral default when per-domain color is invalid hex', () => {
+  // ═══════════════════════════════════════════════════════════════════════════
+  // WATCHER PATH — tests domain_branding watcher
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  describe('3-step fallback chain (reactive watcher)', () => {
+    it('domain color arriving via watcher overrides install config', async () => {
       const bootstrap = useBootstrapStore();
       bootstrap.$patch({
-        domain_branding: { primary_color: 'not-a-color' },
+        domain_branding: null,
+        brand_primary_color: INSTALL_COLOR,
+      });
+
+      const identity = useProductIdentity();
+      expect(upperHex(identity.primaryColor)).toBe(upperHex(INSTALL_COLOR));
+
+      bootstrap.$patch({ domain_branding: { primary_color: DOMAIN_COLOR } });
+      await nextTick();
+
+      expect(upperHex(identity.primaryColor)).toBe(upperHex(DOMAIN_COLOR));
+    });
+
+    it('clearing domain color via watcher falls back to install config', async () => {
+      const bootstrap = useBootstrapStore();
+      bootstrap.$patch({
+        domain_branding: { primary_color: DOMAIN_COLOR },
+        brand_primary_color: INSTALL_COLOR,
+      });
+
+      const identity = useProductIdentity();
+      expect(upperHex(identity.primaryColor)).toBe(upperHex(DOMAIN_COLOR));
+
+      bootstrap.$patch({ domain_branding: null });
+      await nextTick();
+
+      expect(upperHex(identity.primaryColor)).toBe(upperHex(INSTALL_COLOR));
+    });
+
+    it('clearing domain color with no install config falls to neutral', async () => {
+      const bootstrap = useBootstrapStore();
+      bootstrap.$patch({
+        domain_branding: { primary_color: DOMAIN_COLOR },
         brand_primary_color: undefined,
       });
 
       const identity = useProductIdentity();
+      expect(upperHex(identity.primaryColor)).toBe(upperHex(DOMAIN_COLOR));
 
-      expect(identity.primaryColor.toUpperCase()).toBe(NEUTRAL_HEX.toUpperCase());
+      bootstrap.$patch({ domain_branding: null });
+      await nextTick();
+
+      expect(upperHex(identity.primaryColor)).toBe(upperHex(NEUTRAL_HEX));
     });
+  });
 
-    it('falls through to install config when per-domain color is invalid hex (step 2 catches)', () => {
+  // ═══════════════════════════════════════════════════════════════════════════
+  // VALIDATION — malformed inputs degrade gracefully
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  describe('graceful degradation for invalid inputs', () => {
+    it('invalid per-domain hex falls through to install config', () => {
       const bootstrap = useBootstrapStore();
       bootstrap.$patch({
-        domain_branding: { primary_color: 'bad' },
+        domain_branding: { primary_color: 'not-a-color' },
         brand_primary_color: INSTALL_COLOR,
       });
 
       const identity = useProductIdentity();
 
-      expect(identity.primaryColor.toUpperCase()).toBe(INSTALL_COLOR.toUpperCase());
+      expect(upperHex(identity.primaryColor)).toBe(upperHex(INSTALL_COLOR));
+    });
+
+    it('invalid per-domain hex with no install config falls to neutral', () => {
+      const bootstrap = useBootstrapStore();
+      bootstrap.$patch({
+        domain_branding: { primary_color: 'bad' },
+        brand_primary_color: undefined,
+      });
+
+      const identity = useProductIdentity();
+
+      expect(upperHex(identity.primaryColor)).toBe(upperHex(NEUTRAL_HEX));
+    });
+
+    it('invalid install config hex falls through to neutral', () => {
+      const bootstrap = useBootstrapStore();
+      bootstrap.$patch({
+        domain_branding: null,
+        brand_primary_color: 'rgb(255,0,0)',
+      });
+
+      const identity = useProductIdentity();
+
+      expect(upperHex(identity.primaryColor)).toBe(upperHex(NEUTRAL_HEX));
+    });
+
+    it('both inputs invalid falls through to neutral', () => {
+      const bootstrap = useBootstrapStore();
+      bootstrap.$patch({
+        domain_branding: { primary_color: 'garbage' },
+        brand_primary_color: 'also-garbage',
+      });
+
+      const identity = useProductIdentity();
+
+      expect(upperHex(identity.primaryColor)).toBe(upperHex(NEUTRAL_HEX));
+    });
+
+    it('3-digit hex is normalized to 6-digit', () => {
+      const bootstrap = useBootstrapStore();
+      bootstrap.$patch({
+        domain_branding: null,
+        brand_primary_color: '#F00',
+      });
+
+      const identity = useProductIdentity();
+
+      expect(upperHex(identity.primaryColor)).toBe('#FF0000');
     });
   });
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // ORPHAN GUARD — brand_primary_color has a live consumer
+  // ═══════════════════════════════════════════════════════════════════════════
 
   describe('brand_primary_color is no longer an orphaned bootstrap field', () => {
     it('bootstrapStore.brand_primary_color is consumed by identityStore', () => {
@@ -124,7 +238,61 @@ describe('identityStore primaryColor resolution', () => {
 
       const identity = useProductIdentity();
 
-      expect(identity.primaryColor.toUpperCase()).toBe('#8B5CF6');
+      expect(upperHex(identity.primaryColor)).toBe('#8B5CF6');
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // CROSS-SOURCE CONSTANT EQUALITY
+  //
+  // The neutral brand color (#3B82F6) is defined in four places:
+  //   - TS:   NEUTRAL_BRAND_DEFAULTS.primary_color  (brand.ts)
+  //   - Ruby: BrandSettings::DEFAULTS[:primary_color] (brand_settings.rb)
+  //   - CSS:  @theme { --color-brand-500 }           (style.css)
+  //   - ENV:  .env.reference BRAND_PRIMARY_COLOR      (.env.reference)
+  //
+  // If any of these drift, the sentinel-value collision described in #3381
+  // makes the boundary between "unset" and "explicitly neutral" unobservable.
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  describe('cross-source neutral color constant', () => {
+    const CANONICAL = NEUTRAL_BRAND_DEFAULTS.primary_color.toUpperCase();
+
+    it('TS NEUTRAL_BRAND_DEFAULTS.primary_color is #3B82F6', () => {
+      expect(CANONICAL).toBe('#3B82F6');
+    });
+
+    it('Ruby BrandSettings::DEFAULTS[:primary_color] matches TS constant', () => {
+      const ruby = readFileSync(
+        resolve(process.cwd(), 'lib/onetime/models/custom_domain/brand_settings.rb'),
+        'utf-8',
+      );
+      // Match primary_color inside the DEFAULTS hash, not in comments or examples
+      const defaultsBlock = ruby.match(/DEFAULTS\s*=\s*\{([^}]+)\}/s);
+      expect(defaultsBlock).not.toBeNull();
+      const colorMatch = defaultsBlock![1].match(/primary_color:\s*'(#[0-9A-Fa-f]{6})'/);
+      expect(colorMatch).not.toBeNull();
+      expect(colorMatch![1].toUpperCase()).toBe(CANONICAL);
+    });
+
+    it('.env.reference BRAND_PRIMARY_COLOR example matches TS constant', () => {
+      const env = readFileSync(
+        resolve(process.cwd(), '.env.reference'),
+        'utf-8',
+      );
+      const match = env.match(/BRAND_PRIMARY_COLOR='(#[0-9A-Fa-f]{6})'/);
+      expect(match).not.toBeNull();
+      expect(match![1].toUpperCase()).toBe(CANONICAL);
+    });
+
+    it('CSS @theme --color-brand-500 seed matches TS constant', () => {
+      const css = readFileSync(
+        resolve(process.cwd(), 'src/assets/style.css'),
+        'utf-8',
+      );
+      const match = css.match(/--color-brand-500:\s*(#[0-9A-Fa-f]{6})/);
+      expect(match).not.toBeNull();
+      expect(match![1].toUpperCase()).toBe(CANONICAL);
     });
   });
 });


### PR DESCRIPTION
## Summary

Fixes #3381

The `identityStore` was not consuming the `brand_primary_color` field from `bootstrapStore` (set via the `BRAND_PRIMARY_COLOR` environment variable). This meant that install-level branding configuration was being silently ignored, with the system falling directly from per-domain branding to the neutral default.

This PR implements a proper 3-step fallback chain for primary color resolution:
1. Per-domain branding (Redis custom domain settings)
2. Install config (`BRAND_PRIMARY_COLOR` env var via bootstrapStore)
3. Neutral last resort (`NEUTRAL_BRAND_DEFAULTS.primary_color`)

The fix extracts the color resolution logic into a dedicated `resolvePrimaryColor()` function that validates inputs at each step and gracefully degrades to the next fallback if a value is missing or invalid.

## Related Issues

Fixes #3381

## Test Plan

Added comprehensive test suite (`src/tests/stores/identityStore.spec.ts`) covering:
- All three steps of the fallback chain in both initial state and reactive watcher scenarios
- Graceful degradation for malformed color inputs
- Validation that `brand_primary_color` is now consumed by identityStore
- Cross-source constant equality checks ensuring the neutral color (#3B82F6) is consistent across TS, Ruby, CSS, and environment configuration

Added regression guard tests to `useBrandTheme.spec.ts` verifying that install-config colors properly override the DOM theme variables.

All tests pass with the implementation.

https://claude.ai/code/session_018HJPZ8a6CPz2LXBXu4Dp5R