### PR TITLE
Add CLI commands for managing global broadcast banner

### DIFF
--- a/lib/onetime/cli.rb
+++ b/lib/onetime/cli.rb
@@ -113,6 +113,7 @@ require_relative 'cli/totp_command'
 require_relative 'cli/ratelimit_command'
 
 # Load banner CLI commands
+require_relative 'cli/banner/shared'
 require_relative 'cli/banner_command'
 require_relative 'cli/banner/set_command'
 require_relative 'cli/banner/show_command'

--- a/lib/onetime/cli.rb
+++ b/lib/onetime/cli.rb
@@ -112,6 +112,12 @@ require_relative 'cli/session_command'
 require_relative 'cli/totp_command'
 require_relative 'cli/ratelimit_command'
 
+# Load banner CLI commands
+require_relative 'cli/banner_command'
+require_relative 'cli/banner/set_command'
+require_relative 'cli/banner/show_command'
+require_relative 'cli/banner/clear_command'
+
 # Load worker and scheduler commands (top-level)
 require_relative 'cli/worker_command'
 require_relative 'cli/scheduler_command'

--- a/lib/onetime/cli/banner/clear_command.rb
+++ b/lib/onetime/cli/banner/clear_command.rb
@@ -26,7 +26,7 @@ module Onetime
       def call(apply: false, **)
         boot_application!
 
-        db = Familia.dbclient(0)
+        db          = Familia.dbclient(0)
         banner_text = db.get('global_banner')
 
         if banner_text.nil? || banner_text.empty?

--- a/lib/onetime/cli/banner/clear_command.rb
+++ b/lib/onetime/cli/banner/clear_command.rb
@@ -18,6 +18,8 @@ module Onetime
     class BannerClearCommand < Command
       desc 'Clear the global broadcast banner (dry-run by default)'
 
+      include Banner::Shared
+
       option :apply,
         type: :boolean,
         default: false,
@@ -27,7 +29,7 @@ module Onetime
         boot_application!
 
         db          = Familia.dbclient(0)
-        banner_text = db.get('global_banner')
+        banner_text = db.get(BANNER_KEY)
 
         if banner_text.nil? || banner_text.empty?
           puts 'No banner is currently set. Nothing to clear.'
@@ -38,7 +40,7 @@ module Onetime
         puts
 
         if apply
-          db.del('global_banner')
+          db.del(BANNER_KEY)
           Onetime::Runtime.update_features(global_banner: nil)
 
           puts 'Banner cleared.'
@@ -48,7 +50,7 @@ module Onetime
         else
           puts 'Would run (re-run with --apply to write):'
           puts '  # DB 0'
-          puts '  DEL global_banner'
+          puts "  DEL #{BANNER_KEY}"
           puts '  # then refresh runtime: Onetime::Runtime.update_features(global_banner: nil)'
         end
       end

--- a/lib/onetime/cli/banner/clear_command.rb
+++ b/lib/onetime/cli/banner/clear_command.rb
@@ -15,47 +15,45 @@
 
 module Onetime
   module CLI
-    module Banner
-      class ClearCommand < Command
-        desc 'Clear the global broadcast banner (dry-run by default)'
+    class BannerClearCommand < Command
+      desc 'Clear the global broadcast banner (dry-run by default)'
 
-        option :apply,
-          type: :boolean,
-          default: false,
-          desc: 'Actually delete from Redis (default is dry-run)'
+      option :apply,
+        type: :boolean,
+        default: false,
+        desc: 'Actually delete from Redis (default is dry-run)'
 
-        def call(apply: false, **)
-          boot_application!
+      def call(apply: false, **)
+        boot_application!
 
-          db = Familia.dbclient(0)
-          banner_text = db.get('global_banner')
+        db = Familia.dbclient(0)
+        banner_text = db.get('global_banner')
 
-          if banner_text.nil? || banner_text.empty?
-            puts 'No banner is currently set. Nothing to clear.'
-            return
-          end
+        if banner_text.nil? || banner_text.empty?
+          puts 'No banner is currently set. Nothing to clear.'
+          return
+        end
 
-          puts format('Current banner: %s', banner_text)
+        puts format('Current banner: %s', banner_text)
+        puts
+
+        if apply
+          db.del('global_banner')
+          Onetime::Runtime.update_features(global_banner: nil)
+
+          puts 'Banner cleared.'
           puts
-
-          if apply
-            db.del('global_banner')
-            Onetime::Runtime.update_features(global_banner: nil)
-
-            puts 'Banner cleared.'
-            puts
-            puts 'Note: runtime refresh reaches this process only.'
-            puts 'Other running processes will pick it up on next boot or re-read.'
-          else
-            puts 'Would run (re-run with --apply to write):'
-            puts '  # DB 0'
-            puts '  DEL global_banner'
-            puts '  # then refresh runtime: Onetime::Runtime.update_features(global_banner: nil)'
-          end
+          puts 'Note: runtime refresh reaches this process only.'
+          puts 'Other running processes will pick it up on next boot or re-read.'
+        else
+          puts 'Would run (re-run with --apply to write):'
+          puts '  # DB 0'
+          puts '  DEL global_banner'
+          puts '  # then refresh runtime: Onetime::Runtime.update_features(global_banner: nil)'
         end
       end
     end
 
-    register 'banner clear', Banner::ClearCommand
+    register 'banner clear', BannerClearCommand
   end
 end

--- a/lib/onetime/cli/banner/clear_command.rb
+++ b/lib/onetime/cli/banner/clear_command.rb
@@ -1,0 +1,61 @@
+# lib/onetime/cli/banner/clear_command.rb
+#
+# frozen_string_literal: true
+
+#
+# CLI command for clearing the global broadcast banner.
+#
+# Dry-run is the default — prints the valkey-cli commands it would run.
+# Pass --apply to actually delete the key.
+#
+# Usage:
+#   bin/ots banner clear           # dry-run
+#   bin/ots banner clear --apply   # delete the key
+#
+
+module Onetime
+  module CLI
+    module Banner
+      class ClearCommand < Command
+        desc 'Clear the global broadcast banner (dry-run by default)'
+
+        option :apply,
+          type: :boolean,
+          default: false,
+          desc: 'Actually delete from Redis (default is dry-run)'
+
+        def call(apply: false, **)
+          boot_application!
+
+          db = Familia.dbclient(0)
+          banner_text = db.get('global_banner')
+
+          if banner_text.nil? || banner_text.empty?
+            puts 'No banner is currently set. Nothing to clear.'
+            return
+          end
+
+          puts format('Current banner: %s', banner_text)
+          puts
+
+          if apply
+            db.del('global_banner')
+            Onetime::Runtime.update_features(global_banner: nil)
+
+            puts 'Banner cleared.'
+            puts
+            puts 'Note: runtime refresh reaches this process only.'
+            puts 'Other running processes will pick it up on next boot or re-read.'
+          else
+            puts 'Would run (re-run with --apply to write):'
+            puts '  # DB 0'
+            puts '  DEL global_banner'
+            puts '  # then refresh runtime: Onetime::Runtime.update_features(global_banner: nil)'
+          end
+        end
+      end
+    end
+
+    register 'banner clear', Banner::ClearCommand
+  end
+end

--- a/lib/onetime/cli/banner/set_command.rb
+++ b/lib/onetime/cli/banner/set_command.rb
@@ -1,0 +1,200 @@
+# lib/onetime/cli/banner/set_command.rb
+#
+# frozen_string_literal: true
+
+#
+# CLI command for setting the global broadcast banner.
+#
+# Dry-run is the default — prints the valkey-cli commands it would run
+# and renders an ASCII preview. Pass --apply to actually write.
+#
+# Usage:
+#   bin/ots banner set "Scheduled maintenance Sun 02:00 UTC"
+#   bin/ots banner set '<a href="/status">Maintenance notice</a>' --apply
+#   bin/ots banner set --file banner.html --apply
+#   bin/ots banner set --file - --apply              # read from stdin
+#   bin/ots banner set "temp notice" --ttl 3600      # auto-expire in 1 hour
+#
+
+module Onetime
+  module CLI
+    module Banner
+      class SetCommand < Command
+        desc 'Set the global broadcast banner (dry-run by default)'
+
+        argument :content,
+          type: :string,
+          required: false,
+          desc: 'Banner content (HTML allowed; frontend sanitizes to <a> tags only)'
+
+        option :apply,
+          type: :boolean,
+          default: false,
+          desc: 'Actually write to Redis (default is dry-run)'
+        option :file,
+          type: :string,
+          aliases: ['f'],
+          desc: 'Read content from file (use - for stdin)'
+        option :ttl,
+          type: :integer,
+          aliases: ['t'],
+          desc: 'Auto-expire banner after this many seconds'
+
+        def call(content: nil, apply: false, file: nil, ttl: nil, **)
+          boot_application!
+
+          banner_text = resolve_content(content, file)
+
+          unless banner_text
+            warn 'Error: provide banner content as an argument or via --file'
+            exit 1
+          end
+
+          if banner_text.empty?
+            warn 'Error: banner content is empty'
+            exit 1
+          end
+
+          display_preview(banner_text)
+
+          if apply
+            write_banner(banner_text, ttl)
+          else
+            display_dry_run(banner_text, ttl)
+          end
+        end
+
+        private
+
+        def resolve_content(content, file)
+          if file
+            if file == '-'
+              $stdin.read.strip
+            elsif File.exist?(file)
+              File.read(file).strip
+            else
+              warn "Error: file not found: #{file}"
+              exit 1
+            end
+          else
+            content
+          end
+        end
+
+        def display_preview(banner_text)
+          plain = strip_html(banner_text)
+
+          puts
+          puts 'Preview (sanitized, links shown as text):'
+
+          top    = "┌#{ "─" * 60 }┐"
+          mid    = "├#{ "─" * 60 }┤"
+          bottom = "└#{ "─" * 60 }┘"
+
+          banner_line = format_centered(plain, 56)
+
+          puts top
+          puts "│ \u{1F4E2}  #{banner_line} [x] │"
+          puts mid
+          puts "│  [ logo ]                                  Sign In   Sign Up │"
+          puts "│#{' ' * 60}│"
+          puts "│#{center_text('Paste a password, secret', 60)}│"
+          puts "│#{center_text('message or private link.', 60)}│"
+          puts "│#{center_text("┌#{ "─" * 30 }┐", 60)}│"
+          puts "│#{center_text("│#{' ' * 30}│", 60)}│"
+          puts "│#{center_text("└#{ "─" * 30 }┘", 60)}│"
+          puts "│#{center_text('[ Create a secret link ]', 60)}│"
+          puts "│#{' ' * 60}│"
+          puts bottom
+        end
+
+        def display_dry_run(banner_text, ttl)
+          escaped = shell_escape(banner_text)
+
+          puts
+          puts 'Would run (re-run with --apply to write):'
+          puts '  # DB 0'
+          if ttl
+            puts "  SET global_banner '#{escaped}' EX #{ttl}"
+          else
+            puts "  SET global_banner '#{escaped}'"
+          end
+          puts '  # then refresh runtime: Onetime::Runtime.update_features(global_banner: ...)'
+        end
+
+        def write_banner(banner_text, ttl)
+          db = Familia.dbclient(0)
+
+          if ttl
+            db.setex('global_banner', ttl, banner_text)
+          else
+            db.set('global_banner', banner_text)
+          end
+
+          Onetime::Runtime.update_features(global_banner: banner_text)
+
+          puts
+          puts 'Banner set.'
+
+          if ttl
+            puts format('  Expires in: %s (%d seconds)', humanize_seconds(ttl), ttl)
+          else
+            puts '  Expires: never (clear manually with `bin/ots banner clear --apply`)'
+          end
+
+          puts
+          puts 'Note: runtime refresh reaches this process only.'
+          puts 'Other running processes will pick it up on next boot or re-read.'
+        end
+
+        def strip_html(html)
+          html
+            .gsub(/<a\s[^>]*>/, '')
+            .gsub(%r{</a>}, '')
+            .gsub(/<[^>]+>/, '')
+            .gsub(/&amp;/, '&')
+            .gsub(/&lt;/, '<')
+            .gsub(/&gt;/, '>')
+            .gsub(/&quot;/, '"')
+            .gsub(/&#39;/, "'")
+            .strip
+        end
+
+        def shell_escape(str)
+          str.gsub("'", "'\\\\''")
+        end
+
+        def format_centered(text, width)
+          if text.length >= width
+            text[0, width]
+          else
+            text.ljust(width)
+          end
+        end
+
+        def center_text(text, width)
+          if text.length >= width
+            text[0, width]
+          else
+            pad = (width - text.length) / 2
+            (' ' * pad) + text + (' ' * (width - text.length - pad))
+          end
+        end
+
+        def humanize_seconds(seconds)
+          if seconds >= 86_400
+            format('%dd %dh', seconds / 86_400, (seconds % 86_400) / 3600)
+          elsif seconds >= 3600
+            format('%dh %dm', seconds / 3600, (seconds % 3600) / 60)
+          elsif seconds >= 60
+            format('%dm %ds', seconds / 60, seconds % 60)
+          else
+            format('%ds', seconds)
+          end
+        end
+      end
+    end
+
+    register 'banner set', Banner::SetCommand
+  end
+end

--- a/lib/onetime/cli/banner/set_command.rb
+++ b/lib/onetime/cli/banner/set_command.rb
@@ -24,6 +24,8 @@ module Onetime
     class BannerSetCommand < Command
       desc 'Set the global broadcast banner (dry-run by default)'
 
+      include Banner::Shared
+
       # Inner display width of the ASCII preview box (between │ borders).
       INNER_WIDTH = 62
 
@@ -82,6 +84,9 @@ module Onetime
           warn "Error: file not found: #{file}"
           exit 1
         end
+      rescue Errno::EACCES, Errno::EISDIR => ex
+        warn "Error: cannot read file #{file}: #{ex.message}"
+        exit 1
       end
 
       # Renders an ASCII mock of the page with the banner across the
@@ -134,9 +139,9 @@ module Onetime
         puts 'Would run (re-run with --apply to write):'
         puts '  # DB 0'
         if ttl
-          puts "  SET global_banner '#{escaped}' EX #{ttl}"
+          puts "  SET #{BANNER_KEY} '#{escaped}' EX #{ttl}"
         else
-          puts "  SET global_banner '#{escaped}'"
+          puts "  SET #{BANNER_KEY} '#{escaped}'"
         end
         puts '  # then refresh runtime: Onetime::Runtime.update_features(global_banner: ...)'
       end
@@ -145,9 +150,9 @@ module Onetime
         db = Familia.dbclient(0)
 
         if ttl
-          db.setex('global_banner', ttl, banner_text)
+          db.setex(BANNER_KEY, ttl, banner_text)
         else
-          db.set('global_banner', banner_text)
+          db.set(BANNER_KEY, banner_text)
         end
 
         Onetime::Runtime.update_features(global_banner: banner_text)
@@ -180,18 +185,6 @@ module Onetime
 
         pad_left = (INNER_WIDTH - text.length) / 2
         "#{' ' * pad_left}#{text}".ljust(INNER_WIDTH)
-      end
-
-      def humanize_seconds(seconds)
-        if seconds >= 86_400
-          format('%dd %dh', seconds / 86_400, (seconds % 86_400) / 3600)
-        elsif seconds >= 3600
-          format('%dh %dm', seconds / 3600, (seconds % 3600) / 60)
-        elsif seconds >= 60
-          format('%dm %ds', seconds / 60, seconds % 60)
-        else
-          format('%ds', seconds)
-        end
       end
     end
 

--- a/lib/onetime/cli/banner/set_command.rb
+++ b/lib/onetime/cli/banner/set_command.rb
@@ -18,183 +18,182 @@
 
 module Onetime
   module CLI
-    module Banner
-      class SetCommand < Command
-        desc 'Set the global broadcast banner (dry-run by default)'
+    class BannerSetCommand < Command
+      desc 'Set the global broadcast banner (dry-run by default)'
 
-        argument :content,
-          type: :string,
-          required: false,
-          desc: 'Banner content (HTML allowed; frontend sanitizes to <a> tags only)'
+      argument :content,
+        type: :string,
+        required: false,
+        desc: 'Banner content (HTML; frontend sanitizes to <a> tags only)'
 
-        option :apply,
-          type: :boolean,
-          default: false,
-          desc: 'Actually write to Redis (default is dry-run)'
-        option :file,
-          type: :string,
-          aliases: ['f'],
-          desc: 'Read content from file (use - for stdin)'
-        option :ttl,
-          type: :integer,
-          aliases: ['t'],
-          desc: 'Auto-expire banner after this many seconds'
+      option :apply,
+        type: :boolean,
+        default: false,
+        desc: 'Actually write to Redis (default is dry-run)'
+      option :file,
+        type: :string,
+        aliases: ['f'],
+        desc: 'Read content from file (use - for stdin); takes precedence over argument'
+      option :ttl,
+        type: :integer,
+        aliases: ['t'],
+        desc: 'Auto-expire banner after this many seconds'
 
-        def call(content: nil, apply: false, file: nil, ttl: nil, **)
-          boot_application!
+      def call(content: nil, apply: false, file: nil, ttl: nil, **)
+        boot_application!
 
-          banner_text = resolve_content(content, file)
+        banner_text = resolve_content(content, file)
 
-          unless banner_text
-            warn 'Error: provide banner content as an argument or via --file'
-            exit 1
-          end
-
-          if banner_text.empty?
-            warn 'Error: banner content is empty'
-            exit 1
-          end
-
-          display_preview(banner_text)
-
-          if apply
-            write_banner(banner_text, ttl)
-          else
-            display_dry_run(banner_text, ttl)
-          end
+        unless banner_text
+          warn 'Error: provide banner content as an argument or via --file'
+          exit 1
         end
 
-        private
-
-        def resolve_content(content, file)
-          if file
-            if file == '-'
-              $stdin.read.strip
-            elsif File.exist?(file)
-              File.read(file).strip
-            else
-              warn "Error: file not found: #{file}"
-              exit 1
-            end
-          else
-            content
-          end
+        if banner_text.empty?
+          warn 'Error: banner content is empty'
+          exit 1
         end
 
-        def display_preview(banner_text)
-          plain = strip_html(banner_text)
+        render_preview(banner_text)
 
-          puts
-          puts 'Preview (sanitized, links shown as text):'
+        if apply
+          write_banner(banner_text, ttl)
+        else
+          render_dry_run(banner_text, ttl)
+        end
+      end
 
-          top    = "┌#{ "─" * 60 }┐"
-          mid    = "├#{ "─" * 60 }┤"
-          bottom = "└#{ "─" * 60 }┘"
+      private
 
-          banner_line = format_centered(plain, 56)
+      def resolve_content(content, file)
+        return content unless file
 
-          puts top
-          puts "│ \u{1F4E2}  #{banner_line} [x] │"
-          puts mid
-          puts "│  [ logo ]                                  Sign In   Sign Up │"
-          puts "│#{' ' * 60}│"
-          puts "│#{center_text('Paste a password, secret', 60)}│"
-          puts "│#{center_text('message or private link.', 60)}│"
-          puts "│#{center_text("┌#{ "─" * 30 }┐", 60)}│"
-          puts "│#{center_text("│#{' ' * 30}│", 60)}│"
-          puts "│#{center_text("└#{ "─" * 30 }┘", 60)}│"
-          puts "│#{center_text('[ Create a secret link ]', 60)}│"
-          puts "│#{' ' * 60}│"
-          puts bottom
+        if file == '-'
+          $stdin.read.strip
+        elsif File.exist?(file)
+          File.read(file).strip
+        else
+          warn "Error: file not found: #{file}"
+          exit 1
+        end
+      end
+
+      # Renders an ASCII mock of the page with the banner across the
+      # top so the operator can see roughly how it lands.
+      #
+      # Content is stripped of HTML and decoded (same result as the
+      # frontend's DOMPurify pass rendered as plain text).
+      INNER_WIDTH = 62
+
+      def render_preview(banner_text)
+        plain = strip_html(banner_text)
+
+        # Banner row budget (display columns):
+        #   " "(1) + megaphone(2) + "  "(2) + text + "  "(2) + "[x]"(3) + " "(1) = 11 fixed
+        text_budget = INNER_WIDTH - 11
+        display = if plain.length > text_budget
+                    "#{plain[0, text_budget - 3]}..."
+                  else
+                    plain
+                  end
+
+        banner_fill = ' ' * (text_budget - display.length)
+
+        header = '  [ logo ]'
+        nav    = 'Sign In   Sign Up '
+        gap    = ' ' * (INNER_WIDTH - header.length - nav.length)
+
+        puts
+        puts 'Preview (sanitized, links shown as text):'
+        puts "┌#{"─" * INNER_WIDTH}┐"
+        puts "│ \u{1F4E2}  #{display}#{banner_fill}  [x] │"
+        puts "├#{"─" * INNER_WIDTH}┤"
+        puts "│#{pad(header + gap + nav)}│"
+        puts "│#{pad('')}│"
+        puts "│#{center('Paste a password, secret')}│"
+        puts "│#{center('message or private link.')}│"
+        puts "│#{center("┌#{"─" * 32}┐")}│"
+        puts "│#{center("│#{' ' * 32}│")}│"
+        puts "│#{center("└#{"─" * 32}┘")}│"
+        puts "│#{center('[ Create a secret link ]')}│"
+        puts "│#{pad('')}│"
+        puts "└#{"─" * INNER_WIDTH}┘"
+      end
+
+      def render_dry_run(banner_text, ttl)
+        escaped = banner_text.gsub("'", "'\\\\''")
+
+        puts
+        puts 'Would run (re-run with --apply to write):'
+        puts '  # DB 0'
+        if ttl
+          puts "  SET global_banner '#{escaped}' EX #{ttl}"
+        else
+          puts "  SET global_banner '#{escaped}'"
+        end
+        puts '  # then refresh runtime: Onetime::Runtime.update_features(global_banner: ...)'
+      end
+
+      def write_banner(banner_text, ttl)
+        db = Familia.dbclient(0)
+
+        if ttl
+          db.setex('global_banner', ttl, banner_text)
+        else
+          db.set('global_banner', banner_text)
         end
 
-        def display_dry_run(banner_text, ttl)
-          escaped = shell_escape(banner_text)
+        Onetime::Runtime.update_features(global_banner: banner_text)
 
-          puts
-          puts 'Would run (re-run with --apply to write):'
-          puts '  # DB 0'
-          if ttl
-            puts "  SET global_banner '#{escaped}' EX #{ttl}"
-          else
-            puts "  SET global_banner '#{escaped}'"
-          end
-          puts '  # then refresh runtime: Onetime::Runtime.update_features(global_banner: ...)'
+        puts
+        puts 'Banner set.'
+        if ttl
+          puts format('  Expires in: %s (%d seconds)', humanize_seconds(ttl), ttl)
+        else
+          puts '  Expires: never (clear manually with `bin/ots banner clear --apply`)'
         end
+        puts
+        puts 'Note: runtime refresh reaches this process only.'
+        puts 'Other running processes will pick it up on next boot or re-read.'
+      end
 
-        def write_banner(banner_text, ttl)
-          db = Familia.dbclient(0)
+      def strip_html(html)
+        html
+          .gsub(/<a\s[^>]*>/, '')
+          .gsub(%r{</a>}, '')
+          .gsub(/<[^>]+>/, '')
+          .gsub('&amp;', '&')
+          .gsub('&lt;', '<')
+          .gsub('&gt;', '>')
+          .gsub('&quot;', '"')
+          .gsub('&#39;', "'")
+          .strip
+      end
 
-          if ttl
-            db.setex('global_banner', ttl, banner_text)
-          else
-            db.set('global_banner', banner_text)
-          end
+      def pad(text)
+        text.ljust(INNER_WIDTH)[0, INNER_WIDTH]
+      end
 
-          Onetime::Runtime.update_features(global_banner: banner_text)
+      def center(text)
+        return text[0, INNER_WIDTH] if text.length >= INNER_WIDTH
 
-          puts
-          puts 'Banner set.'
+        pad_left = (INNER_WIDTH - text.length) / 2
+        "#{' ' * pad_left}#{text}".ljust(INNER_WIDTH)
+      end
 
-          if ttl
-            puts format('  Expires in: %s (%d seconds)', humanize_seconds(ttl), ttl)
-          else
-            puts '  Expires: never (clear manually with `bin/ots banner clear --apply`)'
-          end
-
-          puts
-          puts 'Note: runtime refresh reaches this process only.'
-          puts 'Other running processes will pick it up on next boot or re-read.'
-        end
-
-        def strip_html(html)
-          html
-            .gsub(/<a\s[^>]*>/, '')
-            .gsub(%r{</a>}, '')
-            .gsub(/<[^>]+>/, '')
-            .gsub(/&amp;/, '&')
-            .gsub(/&lt;/, '<')
-            .gsub(/&gt;/, '>')
-            .gsub(/&quot;/, '"')
-            .gsub(/&#39;/, "'")
-            .strip
-        end
-
-        def shell_escape(str)
-          str.gsub("'", "'\\\\''")
-        end
-
-        def format_centered(text, width)
-          if text.length >= width
-            text[0, width]
-          else
-            text.ljust(width)
-          end
-        end
-
-        def center_text(text, width)
-          if text.length >= width
-            text[0, width]
-          else
-            pad = (width - text.length) / 2
-            (' ' * pad) + text + (' ' * (width - text.length - pad))
-          end
-        end
-
-        def humanize_seconds(seconds)
-          if seconds >= 86_400
-            format('%dd %dh', seconds / 86_400, (seconds % 86_400) / 3600)
-          elsif seconds >= 3600
-            format('%dh %dm', seconds / 3600, (seconds % 3600) / 60)
-          elsif seconds >= 60
-            format('%dm %ds', seconds / 60, seconds % 60)
-          else
-            format('%ds', seconds)
-          end
+      def humanize_seconds(seconds)
+        if seconds >= 86_400
+          format('%dd %dh', seconds / 86_400, (seconds % 86_400) / 3600)
+        elsif seconds >= 3600
+          format('%dh %dm', seconds / 3600, (seconds % 3600) / 60)
+        elsif seconds >= 60
+          format('%dm %ds', seconds / 60, seconds % 60)
+        else
+          format('%ds', seconds)
         end
       end
     end
 
-    register 'banner set', Banner::SetCommand
+    register 'banner set', BannerSetCommand
   end
 end

--- a/lib/onetime/cli/banner/set_command.rb
+++ b/lib/onetime/cli/banner/set_command.rb
@@ -17,6 +17,7 @@
 #
 
 require 'cgi'
+require 'sanitize'
 
 module Onetime
   module CLI
@@ -164,7 +165,10 @@ module Onetime
       end
 
       def strip_html(html)
-        CGI.unescapeHTML(html).gsub(/<[^>]+>/, '').strip
+        # Decode entities then strip tags via Sanitize (proper HTML parser,
+        # same decode→sanitize order as the frontend's DOMPurify pipeline).
+        # Sanitize re-encodes & as &amp; — decode that back for plain text.
+        Sanitize.fragment(CGI.unescapeHTML(html)).gsub('&amp;', '&').strip
       end
 
       def pad(text)

--- a/lib/onetime/cli/banner/set_command.rb
+++ b/lib/onetime/cli/banner/set_command.rb
@@ -159,14 +159,12 @@ module Onetime
 
       def strip_html(html)
         html
-          .gsub(/<a\s[^>]*>/, '')
-          .gsub(%r{</a>}, '')
-          .gsub(/<[^>]+>/, '')
           .gsub('&amp;', '&')
           .gsub('&lt;', '<')
           .gsub('&gt;', '>')
           .gsub('&quot;', '"')
           .gsub('&#39;', "'")
+          .gsub(/<[^>]+>/, '')
           .strip
       end
 

--- a/lib/onetime/cli/banner/set_command.rb
+++ b/lib/onetime/cli/banner/set_command.rb
@@ -16,10 +16,15 @@
 #   bin/ots banner set "temp notice" --ttl 3600      # auto-expire in 1 hour
 #
 
+require 'cgi'
+
 module Onetime
   module CLI
     class BannerSetCommand < Command
       desc 'Set the global broadcast banner (dry-run by default)'
+
+      # Inner display width of the ASCII preview box (between │ borders).
+      INNER_WIDTH = 62
 
       argument :content,
         type: :string,
@@ -83,19 +88,17 @@ module Onetime
       #
       # Content is stripped of HTML and decoded (same result as the
       # frontend's DOMPurify pass rendered as plain text).
-      INNER_WIDTH = 62
-
       def render_preview(banner_text)
         plain = strip_html(banner_text)
 
         # Banner row budget (display columns):
         #   " "(1) + megaphone(2) + "  "(2) + text + "  "(2) + "[x]"(3) + " "(1) = 11 fixed
         text_budget = INNER_WIDTH - 11
-        display = if plain.length > text_budget
-                    "#{plain[0, text_budget - 3]}..."
-                  else
-                    plain
-                  end
+        display     = if plain.length > text_budget
+                        "#{plain[0, text_budget - 3]}..."
+                      else
+                        plain
+                      end
 
         banner_fill = ' ' * (text_budget - display.length)
 
@@ -103,21 +106,24 @@ module Onetime
         nav    = 'Sign In   Sign Up '
         gap    = ' ' * (INNER_WIDTH - header.length - nav.length)
 
+        border_h = '─' * INNER_WIDTH
+        input_h  = '─' * 32
+
         puts
         puts 'Preview (sanitized, links shown as text):'
-        puts "┌#{"─" * INNER_WIDTH}┐"
+        puts "┌#{border_h}┐"
         puts "│ \u{1F4E2}  #{display}#{banner_fill}  [x] │"
-        puts "├#{"─" * INNER_WIDTH}┤"
+        puts "├#{border_h}┤"
         puts "│#{pad(header + gap + nav)}│"
         puts "│#{pad('')}│"
         puts "│#{center('Paste a password, secret')}│"
         puts "│#{center('message or private link.')}│"
-        puts "│#{center("┌#{"─" * 32}┐")}│"
+        puts "│#{center("┌#{input_h}┐")}│"
         puts "│#{center("│#{' ' * 32}│")}│"
-        puts "│#{center("└#{"─" * 32}┘")}│"
+        puts "│#{center("└#{input_h}┘")}│"
         puts "│#{center('[ Create a secret link ]')}│"
         puts "│#{pad('')}│"
-        puts "└#{"─" * INNER_WIDTH}┘"
+        puts "└#{border_h}┘"
       end
 
       def render_dry_run(banner_text, ttl)
@@ -158,14 +164,7 @@ module Onetime
       end
 
       def strip_html(html)
-        html
-          .gsub('&amp;', '&')
-          .gsub('&lt;', '<')
-          .gsub('&gt;', '>')
-          .gsub('&quot;', '"')
-          .gsub('&#39;', "'")
-          .gsub(/<[^>]+>/, '')
-          .strip
+        CGI.unescapeHTML(html).gsub(/<[^>]+>/, '').strip
       end
 
       def pad(text)

--- a/lib/onetime/cli/banner/shared.rb
+++ b/lib/onetime/cli/banner/shared.rb
@@ -1,0 +1,26 @@
+# lib/onetime/cli/banner/shared.rb
+#
+# frozen_string_literal: true
+
+# Shared utilities for banner CLI commands.
+# Provides duration formatting used by set and show subcommands.
+
+module Onetime
+  module CLI
+    module Banner
+      module Shared
+        def humanize_seconds(seconds)
+          if seconds >= 86_400
+            format('%dd %dh', seconds / 86_400, (seconds % 86_400) / 3600)
+          elsif seconds >= 3600
+            format('%dh %dm', seconds / 3600, (seconds % 3600) / 60)
+          elsif seconds >= 60
+            format('%dm %ds', seconds / 60, seconds % 60)
+          else
+            format('%ds', seconds)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/onetime/cli/banner/show_command.rb
+++ b/lib/onetime/cli/banner/show_command.rb
@@ -25,9 +25,9 @@ module Onetime
       def call(json: false, **)
         boot_application!
 
-        db = Familia.dbclient(0)
+        db          = Familia.dbclient(0)
         banner_text = db.get('global_banner')
-        ttl = db.ttl('global_banner')
+        ttl         = db.ttl('global_banner')
 
         if json
           display_json(banner_text, ttl)

--- a/lib/onetime/cli/banner/show_command.rb
+++ b/lib/onetime/cli/banner/show_command.rb
@@ -1,0 +1,93 @@
+# lib/onetime/cli/banner/show_command.rb
+#
+# frozen_string_literal: true
+
+#
+# CLI command for displaying the current global broadcast banner.
+#
+# Usage:
+#   bin/ots banner show
+#   bin/ots banner show --json
+#
+
+module Onetime
+  module CLI
+    module Banner
+      class ShowCommand < Command
+        desc 'Show the current global broadcast banner'
+
+        option :json,
+          type: :boolean,
+          default: false,
+          desc: 'Output as JSON'
+
+        def call(json: false, **)
+          boot_application!
+
+          db = Familia.dbclient(0)
+          banner_text = db.get('global_banner')
+          ttl = db.ttl('global_banner')
+
+          if json
+            display_json(banner_text, ttl)
+          else
+            display_text(banner_text, ttl)
+          end
+        end
+
+        private
+
+        def display_json(banner_text, ttl)
+          require 'json'
+
+          data = {
+            key: 'global_banner',
+            database: 0,
+            value: banner_text,
+            ttl: ttl.negative? ? nil : ttl,
+            active: !banner_text.nil? && !banner_text.empty?,
+          }
+
+          puts JSON.pretty_generate(data)
+        end
+
+        def display_text(banner_text, ttl)
+          if banner_text.nil? || banner_text.empty?
+            puts 'No banner is currently set.'
+            return
+          end
+
+          puts 'Global broadcast banner'
+          puts '=' * 60
+          puts
+          puts "  Content:  #{banner_text}"
+          puts "  Length:   #{banner_text.length} characters"
+
+          if ttl >= 0
+            puts format('  TTL:      %d seconds (%s)', ttl, humanize_seconds(ttl))
+          else
+            puts '  TTL:      none (persistent)'
+          end
+
+          puts
+          puts 'Note: branded surfaces with displayGlobalBroadcast=false'
+          puts 'hide the banner regardless of this key.'
+        end
+
+        def humanize_seconds(seconds)
+          if seconds >= 86_400
+            format('%dd %dh', seconds / 86_400, (seconds % 86_400) / 3600)
+          elsif seconds >= 3600
+            format('%dh %dm', seconds / 3600, (seconds % 3600) / 60)
+          elsif seconds >= 60
+            format('%dm %ds', seconds / 60, seconds % 60)
+          else
+            format('%ds', seconds)
+          end
+        end
+      end
+    end
+
+    register 'banner show', Banner::ShowCommand
+  end
+end

--- a/lib/onetime/cli/banner/show_command.rb
+++ b/lib/onetime/cli/banner/show_command.rb
@@ -10,84 +10,82 @@
 #   bin/ots banner show --json
 #
 
+require 'json'
+
 module Onetime
   module CLI
-    module Banner
-      class ShowCommand < Command
-        desc 'Show the current global broadcast banner'
+    class BannerShowCommand < Command
+      desc 'Show the current global broadcast banner'
 
-        option :json,
-          type: :boolean,
-          default: false,
-          desc: 'Output as JSON'
+      option :json,
+        type: :boolean,
+        default: false,
+        desc: 'Output as JSON'
 
-        def call(json: false, **)
-          boot_application!
+      def call(json: false, **)
+        boot_application!
 
-          db = Familia.dbclient(0)
-          banner_text = db.get('global_banner')
-          ttl = db.ttl('global_banner')
+        db = Familia.dbclient(0)
+        banner_text = db.get('global_banner')
+        ttl = db.ttl('global_banner')
 
-          if json
-            display_json(banner_text, ttl)
-          else
-            display_text(banner_text, ttl)
-          end
+        if json
+          display_json(banner_text, ttl)
+        else
+          display_text(banner_text, ttl)
+        end
+      end
+
+      private
+
+      def display_json(banner_text, ttl)
+        data = {
+          key: 'global_banner',
+          database: 0,
+          value: banner_text,
+          ttl: ttl.negative? ? nil : ttl,
+          active: !banner_text.nil? && !banner_text.empty?,
+        }
+
+        puts JSON.pretty_generate(data)
+      end
+
+      def display_text(banner_text, ttl)
+        if banner_text.nil? || banner_text.empty?
+          puts 'No banner is currently set.'
+          return
         end
 
-        private
+        puts 'Global broadcast banner'
+        puts '=' * 60
+        puts
+        puts format('  %-10s %s', 'Content:', banner_text)
+        puts format('  %-10s %d characters', 'Length:', banner_text.length)
 
-        def display_json(banner_text, ttl)
-          require 'json'
-
-          data = {
-            key: 'global_banner',
-            database: 0,
-            value: banner_text,
-            ttl: ttl.negative? ? nil : ttl,
-            active: !banner_text.nil? && !banner_text.empty?,
-          }
-
-          puts JSON.pretty_generate(data)
+        if ttl >= 0
+          puts format('  %-10s %d seconds (%s)', 'TTL:', ttl, humanize_seconds(ttl))
+        else
+          puts format('  %-10s none (persistent)', 'TTL:')
         end
 
-        def display_text(banner_text, ttl)
-          if banner_text.nil? || banner_text.empty?
-            puts 'No banner is currently set.'
-            return
-          end
+        puts
+        puts 'Note: branded surfaces with displayGlobalBroadcast=false'
+        puts 'hide the banner regardless of this key.'
+      end
 
-          puts 'Global broadcast banner'
-          puts '=' * 60
-          puts
-          puts "  Content:  #{banner_text}"
-          puts "  Length:   #{banner_text.length} characters"
-
-          if ttl >= 0
-            puts format('  TTL:      %d seconds (%s)', ttl, humanize_seconds(ttl))
-          else
-            puts '  TTL:      none (persistent)'
-          end
-
-          puts
-          puts 'Note: branded surfaces with displayGlobalBroadcast=false'
-          puts 'hide the banner regardless of this key.'
-        end
-
-        def humanize_seconds(seconds)
-          if seconds >= 86_400
-            format('%dd %dh', seconds / 86_400, (seconds % 86_400) / 3600)
-          elsif seconds >= 3600
-            format('%dh %dm', seconds / 3600, (seconds % 3600) / 60)
-          elsif seconds >= 60
-            format('%dm %ds', seconds / 60, seconds % 60)
-          else
-            format('%ds', seconds)
-          end
+      def humanize_seconds(seconds)
+        if seconds >= 86_400
+          format('%dd %dh', seconds / 86_400, (seconds % 86_400) / 3600)
+        elsif seconds >= 3600
+          format('%dh %dm', seconds / 3600, (seconds % 3600) / 60)
+        elsif seconds >= 60
+          format('%dm %ds', seconds / 60, seconds % 60)
+        else
+          format('%ds', seconds)
         end
       end
     end
 
-    register 'banner show', Banner::ShowCommand
+    register 'banner show', BannerShowCommand
   end
 end

--- a/lib/onetime/cli/banner/show_command.rb
+++ b/lib/onetime/cli/banner/show_command.rb
@@ -17,6 +17,8 @@ module Onetime
     class BannerShowCommand < Command
       desc 'Show the current global broadcast banner'
 
+      include Banner::Shared
+
       option :json,
         type: :boolean,
         default: false,
@@ -26,8 +28,8 @@ module Onetime
         boot_application!
 
         db          = Familia.dbclient(0)
-        banner_text = db.get('global_banner')
-        ttl         = db.ttl('global_banner')
+        banner_text = db.get(BANNER_KEY)
+        ttl         = db.ttl(BANNER_KEY)
 
         if json
           display_json(banner_text, ttl)
@@ -40,7 +42,7 @@ module Onetime
 
       def display_json(banner_text, ttl)
         data = {
-          key: 'global_banner',
+          key: BANNER_KEY,
           database: 0,
           value: banner_text,
           ttl: ttl.negative? ? nil : ttl,
@@ -71,18 +73,6 @@ module Onetime
         puts
         puts 'Note: branded surfaces with displayGlobalBroadcast=false'
         puts 'hide the banner regardless of this key.'
-      end
-
-      def humanize_seconds(seconds)
-        if seconds >= 86_400
-          format('%dd %dh', seconds / 86_400, (seconds % 86_400) / 3600)
-        elsif seconds >= 3600
-          format('%dh %dm', seconds / 3600, (seconds % 3600) / 60)
-        elsif seconds >= 60
-          format('%dm %ds', seconds / 60, seconds % 60)
-        else
-          format('%ds', seconds)
-        end
       end
     end
 

--- a/lib/onetime/cli/banner_command.rb
+++ b/lib/onetime/cli/banner_command.rb
@@ -4,12 +4,17 @@
 
 # CLI command group for managing the global broadcast banner.
 #
+# The global_banner key in Redis DB 0 is read by the
+# CheckGlobalBanner initializer at boot and surfaced by the
+# GlobalBroadcast.vue component. The frontend sanitizes content
+# to <a> tags only (href, target, rel, class attributes).
+#
 # Usage:
-#   bin/ots banner                        # Show usage
-#   bin/ots banner show                   # Show current banner
-#   bin/ots banner set "message"          # Dry-run preview (default)
+#   bin/ots banner                        # Show current banner + usage
+#   bin/ots banner show                   # Show current banner, TTL, status
+#   bin/ots banner set "message"          # Dry-run preview (safe default)
 #   bin/ots banner set "message" --apply  # Write to Redis + refresh runtime
-#   bin/ots banner clear                  # Dry-run (default)
+#   bin/ots banner clear                  # Dry-run (safe default)
 #   bin/ots banner clear --apply          # Remove from Redis + refresh runtime
 
 module Onetime
@@ -20,29 +25,28 @@ module Onetime
       def call(**)
         boot_application!
 
-        banner = Familia.dbclient(0).get('global_banner')
+        banner_text = Familia.dbclient(0).get('global_banner')
 
-        if banner && !banner.empty?
-          puts format('Current banner: %s', banner)
+        if banner_text && !banner_text.empty?
+          puts format('Current banner: %s', banner_text)
         else
           puts 'No banner is currently set.'
         end
 
         puts
         puts 'Usage:'
-        puts '  bin/ots banner show                        # Show current banner and TTL'
-        puts '  bin/ots banner set "message"               # Dry-run preview (safe default)'
-        puts '  bin/ots banner set "message" --apply       # Write to Redis + refresh runtime'
-        puts '  bin/ots banner set --file banner.html      # Read content from file'
-        puts '  bin/ots banner set --file -                # Read content from stdin'
-        puts '  bin/ots banner set "msg" --ttl 3600        # Auto-expire after 1 hour'
-        puts '  bin/ots banner clear                       # Dry-run (safe default)'
-        puts '  bin/ots banner clear --apply               # Remove banner'
+        puts '  bin/ots banner show                       Show current banner and TTL'
+        puts '  bin/ots banner set "message"              Dry-run preview (safe default)'
+        puts '  bin/ots banner set "message" --apply      Write to Redis + refresh runtime'
+        puts '  bin/ots banner set --file banner.html     Read content from file'
+        puts '  bin/ots banner set --file -               Read content from stdin'
+        puts '  bin/ots banner set "msg" --ttl 3600       Auto-expire after 1 hour'
+        puts '  bin/ots banner clear                      Dry-run (safe default)'
+        puts '  bin/ots banner clear --apply              Remove banner'
         puts
-        puts 'Notes:'
-        puts '  Dry-run is the default. Pass --apply to actually write.'
-        puts '  Content is HTML-sanitized by the frontend (<a> tags only).'
-        puts '  Branded surfaces with displayGlobalBroadcast=false hide the banner.'
+        puts 'Dry-run is the default. Pass --apply to actually write.'
+        puts 'Content is HTML — the frontend sanitizes to <a> tags only.'
+        puts 'Branded surfaces with displayGlobalBroadcast=false hide the banner.'
       end
     end
 

--- a/lib/onetime/cli/banner_command.rb
+++ b/lib/onetime/cli/banner_command.rb
@@ -22,10 +22,12 @@ module Onetime
     class BannerCommand < Command
       desc 'Manage the global broadcast banner'
 
+      include Banner::Shared
+
       def call(**)
         boot_application!
 
-        banner_text = Familia.dbclient(0).get('global_banner')
+        banner_text = Familia.dbclient(0).get(BANNER_KEY)
 
         if banner_text && !banner_text.empty?
           puts format('Current banner: %s', banner_text)

--- a/lib/onetime/cli/banner_command.rb
+++ b/lib/onetime/cli/banner_command.rb
@@ -1,0 +1,51 @@
+# lib/onetime/cli/banner_command.rb
+#
+# frozen_string_literal: true
+
+# CLI command group for managing the global broadcast banner.
+#
+# Usage:
+#   bin/ots banner                        # Show usage
+#   bin/ots banner show                   # Show current banner
+#   bin/ots banner set "message"          # Dry-run preview (default)
+#   bin/ots banner set "message" --apply  # Write to Redis + refresh runtime
+#   bin/ots banner clear                  # Dry-run (default)
+#   bin/ots banner clear --apply          # Remove from Redis + refresh runtime
+
+module Onetime
+  module CLI
+    class BannerCommand < Command
+      desc 'Manage the global broadcast banner'
+
+      def call(**)
+        boot_application!
+
+        banner = Familia.dbclient(0).get('global_banner')
+
+        if banner && !banner.empty?
+          puts format('Current banner: %s', banner)
+        else
+          puts 'No banner is currently set.'
+        end
+
+        puts
+        puts 'Usage:'
+        puts '  bin/ots banner show                        # Show current banner and TTL'
+        puts '  bin/ots banner set "message"               # Dry-run preview (safe default)'
+        puts '  bin/ots banner set "message" --apply       # Write to Redis + refresh runtime'
+        puts '  bin/ots banner set --file banner.html      # Read content from file'
+        puts '  bin/ots banner set --file -                # Read content from stdin'
+        puts '  bin/ots banner set "msg" --ttl 3600        # Auto-expire after 1 hour'
+        puts '  bin/ots banner clear                       # Dry-run (safe default)'
+        puts '  bin/ots banner clear --apply               # Remove banner'
+        puts
+        puts 'Notes:'
+        puts '  Dry-run is the default. Pass --apply to actually write.'
+        puts '  Content is HTML-sanitized by the frontend (<a> tags only).'
+        puts '  Branded surfaces with displayGlobalBroadcast=false hide the banner.'
+      end
+    end
+
+    register 'banner', BannerCommand
+  end
+end


### PR DESCRIPTION
## Summary

Add a new CLI command group for managing the global broadcast banner feature. This includes three subcommands:

- `banner show` — Display the current banner and its TTL
- `banner set` — Set a new banner with optional TTL (dry-run by default)
- `banner clear` — Remove the current banner (dry-run by default)

The implementation follows a safe-by-default pattern where `set` and `clear` operations are dry-run previews unless `--apply` is passed. The `set` command supports reading content from arguments, files, or stdin, and includes an ASCII preview of how the banner will appear on the frontend.

## Related Issues

<!-- Add issue number if applicable -->

## Test Plan

Manual testing of CLI commands:
- `bin/ots banner` — Verify usage output and current banner status
- `bin/ots banner show` — Verify banner display and TTL output
- `bin/ots banner show --json` — Verify JSON output format
- `bin/ots banner set "test message"` — Verify dry-run preview and ASCII rendering
- `bin/ots banner set "test message" --apply` — Verify banner is written to Redis and runtime is updated
- `bin/ots banner set --file banner.html --apply` — Verify file reading works
- `bin/ots banner set --ttl 3600 "temp message" --apply` — Verify TTL is set correctly
- `bin/ots banner clear` — Verify dry-run output
- `bin/ots banner clear --apply` — Verify banner is deleted from Redis

https://claude.ai/code/session_01MoQm7GFm3KByAQcko3BRvM