### PR TITLE
Stop backfilling brand_primary_color default at serialization time

### DIFF
--- a/apps/web/core/views/helpers/initialize_view_vars.rb
+++ b/apps/web/core/views/helpers/initialize_view_vars.rb
@@ -188,12 +188,8 @@ module Core
         base_scheme          = safe_site['ssl'] == false ? 'http://' : 'https://'
         baseuri              = base_scheme + site_host
 
-        # Brand config exposed to view templates (mask-icon, etc.)
-        # and to first-paint Vue state. BrandSettingsConstants supplies the
-        # neutral fallbacks (#3B82F6, allow_public_* = false) per #3049.
         brand_defaults              = Onetime::CustomDomain::BrandSettingsConstants::DEFAULTS
-        brand_primary_color         = brand_config['primary_color'] ||
-                                      brand_defaults[:primary_color]
+        brand_primary_color         = brand_config['primary_color']
         support_email               = brand_config['support_email'] ||
                                       Onetime::CustomDomain::BrandSettingsConstants::GLOBAL_DEFAULTS[:support_email]
         # docs_host: full documentation URL exposed to bootstrap. Sources from

--- a/apps/web/core/views/serializers/config_serializer.rb
+++ b/apps/web/core/views/serializers/config_serializer.rb
@@ -66,9 +66,9 @@ module Core
         output['frontend_development'] = development['enabled'] || false
         output['frontend_host']        = development['frontend_host'] || ''
 
-        # Branding config for frontend stores. Sourced from view_vars which
-        # InitializeViewVars populates from OT.conf['brand'] with neutral
-        # BrandSettingsConstants defaults per #3049.
+        # Branding config for frontend stores. brand_primary_color is nil
+        # when BRAND_PRIMARY_COLOR is unset — the frontend fallback chain
+        # resolves the default (#3381).
         output['brand_primary_color']         = view_vars['brand_primary_color']
         output['brand_product_name']          = view_vars['brand_product_name']
         output['brand_product_domain']        = view_vars['brand_product_domain']

--- a/try/unit/config/config_serializer_brand_color_try.rb
+++ b/try/unit/config/config_serializer_brand_color_try.rb
@@ -1,0 +1,65 @@
+# try/unit/config/config_serializer_brand_color_try.rb
+#
+# frozen_string_literal: true
+
+# Verifies that brand_primary_color flows through ConfigSerializer
+# as nil when BRAND_PRIMARY_COLOR is unset, and as the actual value
+# when set. The frontend fallback chain owns the default (#3381).
+
+ENV['AUTHENTICATION_MODE'] = 'full'
+
+require 'rack/request'
+require 'rack/mock'
+
+require_relative '../../support/test_helpers'
+
+require 'onetime'
+require_relative '../../../apps/web/core/views'
+
+OT.boot! :test, false
+
+def minimal_view_vars(overrides = {})
+  {
+    'site' => OT.conf.fetch('site', {}),
+    'features' => OT.conf.fetch('features', {}),
+    'development' => OT.conf.fetch('development', {}),
+    'diagnostics' => OT.conf.fetch('diagnostics', {}),
+    'homepage_mode' => 'default',
+    'display_domain' => 'localhost',
+    'brand_primary_color' => nil,
+    'brand_product_name' => nil,
+    'brand_product_domain' => nil,
+    'brand_support_email' => nil,
+    'brand_corner_style' => 'rounded',
+    'brand_font_family' => 'sans',
+    'brand_button_text_light' => false,
+    'brand_logo_url' => nil,
+    'brand_favicon_url' => nil,
+    'brand_totp_issuer' => nil,
+    'support_email' => nil,
+    'docs_host' => 'https://docs.onetimesecret.com/',
+  }.merge(overrides)
+end
+
+## brand_primary_color is nil when unset
+result = Core::Views::ConfigSerializer.serialize(minimal_view_vars)
+result['brand_primary_color']
+#=> nil
+
+## brand_primary_color passes through explicit hex value
+result = Core::Views::ConfigSerializer.serialize(
+  minimal_view_vars('brand_primary_color' => '#E11D48')
+)
+result['brand_primary_color']
+#=> "#E11D48"
+
+## brand_primary_color passes through neutral hex without substitution
+result = Core::Views::ConfigSerializer.serialize(
+  minimal_view_vars('brand_primary_color' => '#3B82F6')
+)
+result['brand_primary_color']
+#=> "#3B82F6"
+
+## output_template defaults brand_primary_color to nil
+Core::Views::ConfigSerializer.send(:output_template)['brand_primary_color']
+#=> nil

--- a/try/unit/web/page_title_brand_fallback_try.rb
+++ b/try/unit/web/page_title_brand_fallback_try.rb
@@ -116,17 +116,19 @@ vars = @host.initialize_view_vars(Rack::Request.new(build_env))
 vars.key?('brand_primary_color')
 #=> true
 
-## brand_primary_color is a String hex color
-vars = @host.initialize_view_vars(Rack::Request.new(build_env))
-[vars['brand_primary_color'].is_a?(String), vars['brand_primary_color'].start_with?('#')]
+## brand_primary_color is a String hex color when brand primary_color is set
+with_brand_conf({ 'primary_color' => '#112233' }) do
+  vars = @host.initialize_view_vars(Rack::Request.new(build_env))
+  [vars['brand_primary_color'].is_a?(String), vars['brand_primary_color'].start_with?('#')]
+end
 #=> [true, true]
 
-## [regression guard] brand_primary_color default is neutral blue, NOT OTS-orange
+## [regression guard] brand_primary_color is nil when brand absent — backend no longer backfills, frontend fallback chain owns the default (#3381)
 with_brand_conf(nil) do
   vars = @host.initialize_view_vars(Rack::Request.new(build_env))
   vars['brand_primary_color']
 end
-#=> '#3B82F6'
+#=> nil
 
 ## initialize_view_vars exposes 'brand_product_name'
 vars = @host.initialize_view_vars(Rack::Request.new(build_env))


### PR DESCRIPTION
The backend was replacing a nil `BRAND_PRIMARY_COLOR` with `#3B82F6` before shipping to the client, making "unset" indistinguishable from "operator explicitly chose the neutral blue." This made `useBrandTheme.isNeutralColor()` short-circuit and clear overrides, rendering the env var inert when it happened to match the default.

Remove the `|| brand_defaults[:primary_color]` backfill in `initialize_view_vars.rb` so `nil` flows through the serializer to the client. The frontend 3-step fallback chain (`resolvePrimaryColor`) already handles `null` — that's its purpose.

Adds a tryout (`config_serializer_brand_color_try`) to pin the passthrough contract.

Closes #3381