### PR TITLE
Address PR #3402 review: BANNER_KEY, duration forwarding, scoped styles, reduced motion

### DIFF
--- a/lib/onetime/cli/banner/shared.rb
+++ b/lib/onetime/cli/banner/shared.rb
@@ -9,6 +9,8 @@ module Onetime
   module CLI
     module Banner
       module Shared
+        BANNER_KEY = 'global_banner'
+
         def humanize_seconds(seconds)
           if seconds >= 86_400
             format('%dd %dh', seconds / 86_400, (seconds % 86_400) / 3600)

--- a/src/shared/components/ui/notifications/global/NotificationBanner.vue
+++ b/src/shared/components/ui/notifications/global/NotificationBanner.vue
@@ -50,12 +50,12 @@ const showProgressBar = computed(() =>
 
 <template>
   <Transition
-    enter-active-class="transform ease-out duration-300 transition"
+    enter-active-class="transform ease-out duration-300 transition motion-reduce:duration-0"
     :enter-from-class="position === 'top'
       ? '-translate-y-2 opacity-0 sm:-translate-y-0 sm:translate-x-2'
       : 'translate-y-2 opacity-0 sm:translate-y-0 sm:translate-x-2'"
     enter-to-class="translate-y-0 opacity-100 sm:translate-x-0"
-    leave-active-class="transition ease-in duration-100"
+    leave-active-class="transition ease-in duration-100 motion-reduce:duration-0"
     leave-from-class="opacity-100"
     leave-to-class="opacity-0">
     <div
@@ -108,7 +108,7 @@ const showProgressBar = computed(() =>
   </Transition>
 </template>
 
-<style>
+<style scoped>
 @keyframes shrink {
   from { width: 100%; }
   to { width: 0%; }

--- a/src/shared/components/ui/notifications/global/NotificationCard.vue
+++ b/src/shared/components/ui/notifications/global/NotificationCard.vue
@@ -64,10 +64,10 @@ const showProgressBar = computed(() =>
 
 <template>
   <Transition
-    enter-active-class="transform ease-out duration-300 transition"
+    enter-active-class="transform ease-out duration-300 transition motion-reduce:duration-0"
     :enter-from-class="enterFromClasses"
     enter-to-class="translate-x-0 opacity-100"
-    leave-active-class="transition ease-in duration-200"
+    leave-active-class="transition ease-in duration-200 motion-reduce:duration-0"
     leave-from-class="opacity-100 translate-x-0"
     :leave-to-class="enterFromClasses">
     <div
@@ -112,7 +112,7 @@ const showProgressBar = computed(() =>
   </Transition>
 </template>
 
-<style>
+<style scoped>
 @keyframes shrink {
   from { width: 100%; }
   to { width: 0%; }

--- a/src/shared/components/ui/notifications/global/NotificationHost.vue
+++ b/src/shared/components/ui/notifications/global/NotificationHost.vue
@@ -51,6 +51,7 @@ const variantComponent = computed(() => ({
       :message="translatedMessage"
       :severity="notifications.severity"
       :position="notifications.position"
+      :duration="notifications.duration"
       @dismiss="notifications.hide" />
   </Teleport>
 </template>

--- a/src/shared/components/ui/notifications/global/NotificationPill.vue
+++ b/src/shared/components/ui/notifications/global/NotificationPill.vue
@@ -22,6 +22,7 @@ interface Props {
   alignment?: 'left' | 'right';
   showLabel?: boolean;
   rounded?: RoundedSize;
+  duration?: number;
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -31,6 +32,7 @@ const props = withDefaults(defineProps<Props>(), {
   alignment: 'right',
   showLabel: true,
   rounded: 'md',
+  duration: 5000,
 });
 
 const effectiveSeverity = computed(() => props.loading ? 'loading' : props.severity);
@@ -69,10 +71,10 @@ const iconClasses = computed(() => {
 
 <template>
   <Transition
-    enter-active-class="transform ease-out duration-200 transition"
+    enter-active-class="transform ease-out duration-200 transition motion-reduce:duration-0"
     :enter-from-class="enterFromClasses"
     enter-to-class="translate-x-0 opacity-100 scale-100"
-    leave-active-class="transition ease-in duration-150"
+    leave-active-class="transition ease-in duration-150 motion-reduce:duration-0"
     leave-from-class="opacity-100 scale-100"
     :leave-to-class="enterFromClasses">
     <div
@@ -111,7 +113,7 @@ const iconClasses = computed(() => {
   </Transition>
 </template>
 
-<style>
+<style scoped>
 @keyframes subtle-pulse {
   0%,
   100% {

--- a/src/shared/stores/notificationsStore.ts
+++ b/src/shared/stores/notificationsStore.ts
@@ -21,11 +21,12 @@ export type NotificationsStore = {
   severity: NotificationSeverity;
   isVisible: boolean;
   position: NotificationPosition;
+  duration: number;
   _initialized: boolean;
 
   // Actions
   init: () => void;
-  show: (msg: string, sev: 'success' | 'error' | 'info', pos?: NotificationPosition, duration?: number) => void;
+  show: (msg: string, sev: 'success' | 'error' | 'info', pos?: NotificationPosition, dur?: number) => void;
   hide: () => void;
   $reset: () => void;
 } & PiniaCustomProperties;
@@ -66,6 +67,7 @@ export const useNotificationsStore = defineStore('notifications', () => {
   const severity = ref<NotificationSeverity>(null);
   const isVisible = ref(false);
   const position = ref<NotificationPosition>('top');
+  const duration = ref(DEFAULT_AUTO_HIDE_MS);
   const _initialized = ref(false);
   let _hideTimerId: ReturnType<typeof setTimeout> | null = null;
 
@@ -102,7 +104,7 @@ export const useNotificationsStore = defineStore('notifications', () => {
   }
 
   /** Display a notification with auto-dismissal. Defaults to 5 s; pass 0 or negative to disable. */
-  function show(msg: string, sev: NotificationSeverity, pos?: NotificationPosition, duration?: number) {
+  function show(msg: string, sev: NotificationSeverity, pos?: NotificationPosition, dur?: number) {
     // Clear any pending hide timer so earlier timeouts don't dismiss this message
     if (_hideTimerId !== null) {
       clearTimeout(_hideTimerId);
@@ -112,9 +114,10 @@ export const useNotificationsStore = defineStore('notifications', () => {
     message.value = msg;
     severity.value = sev;
     position.value = pos || 'top';
-    isVisible.value = true;
 
-    const ms = duration ?? DEFAULT_AUTO_HIDE_MS;
+    const ms = dur ?? DEFAULT_AUTO_HIDE_MS;
+    duration.value = ms;
+    isVisible.value = true;
     if (ms > 0) {
       _hideTimerId = setTimeout(() => {
         hide();
@@ -131,6 +134,7 @@ export const useNotificationsStore = defineStore('notifications', () => {
     isVisible.value = false;
     message.value = '';
     severity.value = null;
+    duration.value = DEFAULT_AUTO_HIDE_MS;
   }
 
   /** Reset store to initial state (clears message, severity, visibility, position). */
@@ -143,6 +147,7 @@ export const useNotificationsStore = defineStore('notifications', () => {
     severity.value = null;
     isVisible.value = false;
     position.value = 'top';
+    duration.value = DEFAULT_AUTO_HIDE_MS;
     _initialized.value = false;
   }
 
@@ -154,6 +159,7 @@ export const useNotificationsStore = defineStore('notifications', () => {
     severity,
     isVisible,
     position,
+    duration,
     _initialized,
 
     // Actions

--- a/src/tests/shared/components/ui/notifications/NotificationHost.spec.ts
+++ b/src/tests/shared/components/ui/notifications/NotificationHost.spec.ts
@@ -11,7 +11,7 @@
 // one is already visible, the auto-dismiss timer must be RESET so the new
 // message gets its full duration before hiding.
 
-import { NotificationHost } from '@/shared/components/ui/notifications';
+import { NotificationHost, NotificationPill } from '@/shared/components/ui/notifications';
 import { useNotificationsStore } from '@/shared/stores/notificationsStore';
 import { mount, VueWrapper } from '@vue/test-utils';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -112,6 +112,36 @@ describe('NotificationHost (auto-dismiss)', () => {
 
       vi.advanceTimersByTime(10_000);
       expect(notifications.isVisible).toBe(true);
+    });
+  });
+
+  // Forwarding: the store owns `duration`; NotificationHost binds it onto the
+  // teleported variant component (`:duration="notifications.duration"`). A
+  // distinctive value (2000, not the 5000 default that every link in the
+  // chain falls back to) is required — a broken binding would let the child's
+  // own `withDefaults` 5000 mask the failure.
+  describe('Duration forwarding to child component', () => {
+    it('forwards the store duration onto the rendered variant', async () => {
+      wrapper = mountComponent();
+
+      notifications.show('first', 'success', undefined, 2000);
+      await nextTick();
+
+      const pill = wrapper.findComponent(NotificationPill);
+      expect(pill.exists()).toBe(true);
+      expect(notifications.duration).toBe(2000);
+      expect(pill.props('duration')).toBe(2000);
+    });
+
+    it('forwards the default duration when none is supplied', async () => {
+      wrapper = mountComponent();
+
+      notifications.show('first', 'success');
+      await nextTick();
+
+      const pill = wrapper.findComponent(NotificationPill);
+      expect(notifications.duration).toBe(5000);
+      expect(pill.props('duration')).toBe(5000);
     });
   });
 });


### PR DESCRIPTION
## Summary

Addresses all review feedback from PR #3402 (main → develop merge):

- **BANNER_KEY missing** — Define `BANNER_KEY = 'global_banner'` in `Banner::Shared`, fixing `NameError` on all banner CLI commands (`set`, `show`, `clear`)
- **Duration not forwarded** — Expose `duration` as reactive state in `notificationsStore`, forward through `NotificationHost` to child progress bars so animation length matches the actual auto-dismiss delay
- **Unscoped global styles** — Scope `@keyframes shrink` and `.progress-shrink` in Card, Banner, and Pill via `<style scoped>` to prevent global CSS leaks
- **Reduced motion gaps** — Add `motion-reduce:duration-0` to all `<Transition>` enter/leave active classes for consistent `prefers-reduced-motion` support
- **Pill duration fallthrough** — Declare `duration` prop on `NotificationPill` to prevent it falling through to `<Transition>`'s built-in `duration` prop (which would hold dismissed pills in DOM for 5s after fade-out)

## Test plan

- [x] `vue-tsc --noEmit` passes
- [x] NotificationHost specs pass (3/3)
- [ ] Verify banner CLI commands work: `bin/ots banner set "test" --apply`, `bin/ots banner show`, `bin/ots banner clear --apply`
- [ ] Verify notification pill dismisses immediately (no 5s DOM retention)

Closes #3402