### PR TITLE
Gate RemoveDomain on custom_domains entitlement (#3340)

### DIFF
--- a/apps/api/domains/logic/domains/get_domain.rb
+++ b/apps/api/domains/logic/domains/get_domain.rb
@@ -45,7 +45,9 @@ module DomainsAPI::Logic
         raise_form_error 'Domain has no associated organization' unless domain_org
         require_entitlement_in!(domain_org, 'custom_domains')
 
-        # Domain-scope enforcement: deny if member is scoped to a different domain (#3384)
+        # Domain-scope enforcement: deny if member is scoped to a different domain (#3384).
+        # nil membership is colonel-only here: require_entitlement_in! above
+        # already rejected any non-colonel without an active membership row.
         membership = Onetime::OrganizationMembership.find_by_org_customer(
           domain_org.objid, @cust.objid
         )

--- a/apps/api/domains/logic/domains/get_domain.rb
+++ b/apps/api/domains/logic/domains/get_domain.rb
@@ -35,8 +35,8 @@ module DomainsAPI::Logic
 
         raise_form_error 'Domain not found' unless @custom_domain
 
-        # Verify the customer owns this domain through their organization
-        unless @custom_domain.owner?(@cust)
+        # Verify the customer can access this domain through org membership
+        unless @custom_domain.accessible_by?(@cust)
           raise_form_error 'Domain not found'
         end
 

--- a/apps/api/domains/logic/domains/remove_domain.rb
+++ b/apps/api/domains/logic/domains/remove_domain.rb
@@ -25,9 +25,23 @@ module DomainsAPI::Logic
         @custom_domain = Onetime::CustomDomain.find_by_extid(@extid)
         raise_form_error 'Domain not found' unless @custom_domain
 
-        # Verify the customer owns this domain through their organization
-        unless @custom_domain.owner?(@cust)
+        # Verify the customer can access this domain through org membership
+        unless @custom_domain.accessible_by?(@cust)
           raise_form_error 'Domain not found'
+        end
+
+        # Domain deletion requires admin+ (custom_domains entitlement),
+        # consistent with AddDomain (#3033) and GetDomain.
+        domain_org = @custom_domain.primary_organization
+        raise_form_error 'Domain has no associated organization' unless domain_org
+        require_entitlement_in!(domain_org, 'custom_domains')
+
+        # Domain-scope enforcement: deny cross-domain deletion (#3384)
+        membership = Onetime::OrganizationMembership.find_by_org_customer(
+          domain_org.objid, @cust.objid
+        )
+        if membership && !membership.can_access_domain?(@custom_domain)
+          raise_not_found 'Domain not found'
         end
       end
 

--- a/apps/api/domains/logic/domains/remove_domain.rb
+++ b/apps/api/domains/logic/domains/remove_domain.rb
@@ -36,7 +36,9 @@ module DomainsAPI::Logic
         raise_form_error 'Domain has no associated organization' unless domain_org
         require_entitlement_in!(domain_org, 'custom_domains')
 
-        # Domain-scope enforcement: deny cross-domain deletion (#3384)
+        # Domain-scope enforcement: deny cross-domain deletion (#3384).
+        # nil membership is colonel-only here: require_entitlement_in! above
+        # already rejected any non-colonel without an active membership row.
         membership = Onetime::OrganizationMembership.find_by_org_customer(
           domain_org.objid, @cust.objid
         )

--- a/apps/api/v1/logic/secrets/base_secret_action.rb
+++ b/apps/api/v1/logic/secrets/base_secret_action.rb
@@ -438,7 +438,7 @@ module V1::Logic
             share_domain:   #{@share_domain}
             custom_domain?:  #{custom_domain?}
             allow_public?:   #{domain_record.allow_public_homepage?}
-            owner?:          #{domain_record.owner?(@cust)}
+            accessible?:     #{domain_record.accessible_by?(@cust)}
             verified?:       #{domain_record.verified}
         DEBUG
 
@@ -474,12 +474,12 @@ module V1::Logic
       # - Anonymous on a custom domain: gated by the Homepage Secrets toggle.
       # - Anonymous on canonical with share_domain set: not permitted.
       def validate_domain_permissions(domain_record)
-        # Owner / org member can always use the domain.
-        return if domain_record.owner?(@cust)
+        # Any org member can always use the domain.
+        return if domain_record.accessible_by?(@cust)
 
-        # Authenticated non-owner: permission denied regardless of toggle.
+        # Authenticated non-member: permission denied regardless of toggle.
         unless cust.nil? || cust.anonymous?
-          OT.li "[validate_domain_perm]: #{share_domain} non-owner [#{cust.custid}]"
+          OT.li "[validate_domain_perm]: #{share_domain} non-member [#{cust.custid}]"
           raise_form_error "You do not have permission to use domain: #{share_domain}"
         end
 

--- a/apps/api/v2/logic/secrets/base_secret_action.rb
+++ b/apps/api/v2/logic/secrets/base_secret_action.rb
@@ -431,7 +431,7 @@ module V2::Logic
             domain: domain,
             custom_domain: custom_domain?,
             allow_public: domain_record.allow_public_homepage?,
-            is_owner: domain_record.owner?(@cust),
+            accessible: domain_record.accessible_by?(@cust),
             user_id: @cust&.objid,
           }
 
@@ -477,14 +477,14 @@ module V2::Logic
       # - Anonymous on the canonical domain (with share_domain set to a custom
       #   domain): not permitted.
       def validate_domain_permissions(domain_record)
-        # Owner / org member can always use the domain.
-        return if domain_record.owner?(@cust)
+        # Any org member can always use the domain.
+        return if domain_record.accessible_by?(@cust)
 
-        # Authenticated non-owner: permission denied regardless of toggle.
+        # Authenticated non-member: permission denied regardless of toggle.
         # The toggle controls anonymous traffic, not who may share via the
         # domain when authenticated.
         unless anonymous_user?
-          secret_logger.warn 'Non-owner attempted domain access',
+          secret_logger.warn 'Non-member attempted domain access',
             {
               domain: share_domain,
               user_id: @cust&.objid,

--- a/apps/api/v2/logic/secrets/list_receipts.rb
+++ b/apps/api/v2/logic/secrets/list_receipts.rb
@@ -140,7 +140,7 @@ module V2::Logic
       end
 
       # Domain scope: receipts created with a specific custom domain
-      # Access allowed for domain owner or any member of the domain's organization
+      # Access allowed for any member of the domain's organization
       def query_domain_receipts
         domain = Onetime::CustomDomain.find_by_extid(domain_extid)
         unless domain
@@ -153,8 +153,7 @@ module V2::Logic
           )
         end
 
-        domain_org = domain.organization
-        has_access = domain.owner?(cust) || domain_org&.member?(cust)
+        has_access = domain.accessible_by?(cust)
         unless has_access
           raise_form_error(
             I18n.t(

--- a/apps/api/v2/spec/logic/secrets/base_secret_action_spec.rb
+++ b/apps/api/v2/spec/logic/secrets/base_secret_action_spec.rb
@@ -191,10 +191,10 @@ RSpec.describe 'V2 BaseSecretAction config path bug' do
         organization_instances: [])
     end
 
-    # Stand-in for CustomDomain. owner? and allow_public_homepage? are the
+    # Stand-in for CustomDomain. accessible_by? and allow_public_homepage? are the
     # only methods validate_domain_permissions touches on the record.
     def build_domain_record(owner: false, allow_public_homepage: false)
-      double('CustomDomain', owner?: owner, allow_public_homepage?: allow_public_homepage)
+      double('CustomDomain', accessible_by?: owner, allow_public_homepage?: allow_public_homepage)
     end
 
     # Build a subject seeded with @cust and @share_domain so the helper
@@ -751,7 +751,7 @@ RSpec.describe 'V2 BaseSecretAction config path bug' do
     # Domain double that passes all permission and verification checks.
     def build_passing_domain_record(owner: true)
       double('CustomDomain',
-        owner?: owner,
+        accessible_by?: owner,
         allow_public_homepage?: true,
         verified: 'true')
     end
@@ -821,7 +821,7 @@ RSpec.describe 'V2 BaseSecretAction config path bug' do
       let(:host_domain)     { 'local-secrets.afb.pet' }
       let(:domain_record) do
         double('CustomDomain',
-          owner?: false,
+          accessible_by?: false,
           allow_public_homepage?: false,
           verified: 'true')
       end
@@ -879,7 +879,7 @@ RSpec.describe 'V2 BaseSecretAction config path bug' do
       let(:host_domain)   { 'local-secrets.afb.pet' }
       let(:domain_record) do
         double('CustomDomain',
-          owner?: false,
+          accessible_by?: false,
           allow_public_homepage?: true,
           verified: 'true')
       end
@@ -938,7 +938,7 @@ RSpec.describe 'V2 BaseSecretAction config path bug' do
       let(:host_domain) { 'secrets.acme.com' }
       let(:host_record) do
         double('CustomDomain',
-          owner?: false,
+          accessible_by?: false,
           allow_public_homepage?: true,
           verified: 'true')
       end
@@ -995,7 +995,7 @@ RSpec.describe 'V2 BaseSecretAction config path bug' do
     end
 
     let(:host_record) do
-      double('CustomDomain', owner?: false, allow_public_homepage?: true, verified: 'true')
+      double('CustomDomain', accessible_by?: false, allow_public_homepage?: true, verified: 'true')
     end
 
     # Real nested payload, exactly as a guest POST would arrive.

--- a/lib/onetime/models/custom_domain.rb
+++ b/lib/onetime/models/custom_domain.rb
@@ -243,6 +243,13 @@ module Onetime
     # Check if the given customer can access this domain through their
     # organization membership (any role: owner, admin, or member).
     #
+    # Active status is verified for owners only (via org.owner?); for other
+    # roles this checks presence in the org's members sorted set, which is
+    # intentionally tolerant of legacy members without an
+    # OrganizationMembership record (membership migration is incomplete).
+    # Endpoints needing active-status or role guarantees must follow this
+    # with require_entitlement_in!, which loads the membership record.
+    #
     # @param cust [Onetime::Customer, String] The customer object or customer ID
     # @return [Boolean] true if the customer belongs to the domain's organization
     def accessible_by?(cust)

--- a/lib/onetime/models/custom_domain.rb
+++ b/lib/onetime/models/custom_domain.rb
@@ -240,22 +240,39 @@ module Onetime
       self.class.generate_id
     end
 
-    # Check if the given customer is the owner of this domain
-    # In the new model, ownership is through organization membership
+    # Check if the given customer can access this domain through their
+    # organization membership (any role: owner, admin, or member).
     #
-    # @param cust [Onetime::Customer, String] The customer object or customer ID to check
-    # @return [Boolean] true if the customer is the owner, false otherwise
+    # @param cust [Onetime::Customer, String] The customer object or customer ID
+    # @return [Boolean] true if the customer belongs to the domain's organization
+    def accessible_by?(cust)
+      return false unless org_id
+
+      org = Onetime::Organization.load(org_id)
+      return false unless org
+
+      customer = cust.is_a?(Onetime::Customer) ? cust : Onetime::Customer.load(cust)
+      return false unless customer
+
+      org.owner?(customer) || org.member?(customer)
+    end
+
+    # Strict ownership check: true only if the customer has an owner-role
+    # membership in the domain's organization. Delegates to Organization#owner?
+    # which verifies active membership with role='owner'.
+    #
+    # @param cust [Onetime::Customer, String] The customer object or customer ID
+    # @return [Boolean] true only if the customer is an org owner
     def owner?(cust)
       return false unless org_id
 
       org = Onetime::Organization.load(org_id)
       return false unless org
 
-      # Normalize input to Customer object for safe method calls
       customer = cust.is_a?(Onetime::Customer) ? cust : Onetime::Customer.load(cust)
       return false unless customer
 
-      org.owner?(customer) || org.member?(customer)
+      org.owner?(customer)
     end
 
     # Check if this domain is owned by the given organization

--- a/lib/onetime/models/custom_domain.rb
+++ b/lib/onetime/models/custom_domain.rb
@@ -246,15 +246,9 @@ module Onetime
     # @param cust [Onetime::Customer, String] The customer object or customer ID
     # @return [Boolean] true if the customer belongs to the domain's organization
     def accessible_by?(cust)
-      return false unless org_id
-
-      org = Onetime::Organization.load(org_id)
-      return false unless org
-
-      customer = cust.is_a?(Onetime::Customer) ? cust : Onetime::Customer.load(cust)
-      return false unless customer
-
-      org.owner?(customer) || org.member?(customer)
+      resolve_org_and_customer(cust) do |org, customer|
+        org.owner?(customer) || org.member?(customer)
+      end
     end
 
     # Strict ownership check: true only if the customer has an owner-role
@@ -264,6 +258,14 @@ module Onetime
     # @param cust [Onetime::Customer, String] The customer object or customer ID
     # @return [Boolean] true only if the customer is an org owner
     def owner?(cust)
+      resolve_org_and_customer(cust) do |org, customer|
+        org.owner?(customer)
+      end
+    end
+
+    private
+
+    def resolve_org_and_customer(cust)
       return false unless org_id
 
       org = Onetime::Organization.load(org_id)
@@ -272,8 +274,10 @@ module Onetime
       customer = cust.is_a?(Onetime::Customer) ? cust : Onetime::Customer.load(cust)
       return false unless customer
 
-      org.owner?(customer)
+      yield org, customer
     end
+
+    public
 
     # Check if this domain is owned by the given organization
     #

--- a/lib/onetime/models/organization.rb
+++ b/lib/onetime/models/organization.rb
@@ -64,7 +64,7 @@ module Onetime
     # Core fields
     field :display_name
     field :description
-    field :owner_id       # custid of organization owner (internal objid of Customer)
+    field :owner_id       # DEPRECATED: Use created_by for audit trail, OrganizationMembership role='owner' for authority. Retained until membership migration completes everywhere.
     field :created_by     # Immutable audit field — custid of organization creator. Set once at create!. See ADR-012.
     field :contact_email  # Primary billing/contact email
     field :is_default     # Boolean: true for auto-created workspace (prevents deletion)
@@ -92,7 +92,8 @@ module Onetime
       objid
     end
 
-    # Owner management
+    # DEPRECATED: Loads customer by owner_id. Prefer OrganizationMembership
+    # lookup via find_by_org_customer and checking membership.owner? role.
     def owner
       Onetime::Customer.load(owner_id) if owner_id
     end
@@ -248,6 +249,7 @@ module Onetime
       receipts.member?(dummy_receipt)
     end
 
+    # DEPRECATED: Alias for loading customer via owner_id. See owner_id deprecation note.
     def get_customer
       Onetime::Customer.find_by_objid(owner_id)
     end

--- a/spec/integration/api/domains/remove_domain_role_gate_spec.rb
+++ b/spec/integration/api/domains/remove_domain_role_gate_spec.rb
@@ -1,0 +1,182 @@
+# spec/integration/api/domains/remove_domain_role_gate_spec.rb
+#
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# Integration tests for #3340: RemoveDomain now requires the custom_domains
+# entitlement (admin+), consistent with AddDomain (#3033) and GetDomain.
+# Previously any org member could delete a domain.
+#
+# REQUIREMENTS:
+# - Valkey running on port 2121: pnpm run test:database:start
+# - AUTHENTICATION_MODE=full
+#
+# RUN:
+#   source .env.test && pnpm run test:rspec spec/integration/api/domains/remove_domain_role_gate_spec.rb
+#
+RSpec.describe 'RemoveDomain role gate (#3340)', type: :integration do
+  before(:all) do
+    require 'onetime'
+    Onetime.boot! :test
+
+    require 'domains/logic/base'
+    require 'domains/logic/domains/remove_domain'
+  end
+
+  let(:run_id) { "rmgate_#{Familia.now.to_i}_#{SecureRandom.hex(4)}" }
+
+  let!(:owner) do
+    Onetime::Customer.create!(email: "#{run_id}_owner@test.com")
+  end
+
+  let!(:organization) do
+    org = Onetime::Organization.create!("RM Gate Org #{run_id}", owner, "#{run_id}_org@test.com")
+    org.materialize_standalone_entitlements! if org.respond_to?(:materialize_standalone_entitlements!)
+    owner_m = Onetime::OrganizationMembership.find_by_org_customer(org.objid, owner.objid)
+    owner_m&.materialize_for_role! if owner_m&.respond_to?(:materialize_for_role!)
+    org
+  end
+
+  let!(:admin_user) do
+    Onetime::Customer.create!(email: "#{run_id}_admin@test.com")
+  end
+
+  let!(:member_user) do
+    Onetime::Customer.create!(email: "#{run_id}_member@test.com")
+  end
+
+  let!(:admin_membership) do
+    membership = organization.add_members_instance(admin_user, through_attrs: { role: 'admin' })
+    membership.materialize_for_role! if membership.respond_to?(:materialize_for_role!)
+    membership
+  end
+
+  let!(:member_membership) do
+    membership = organization.add_members_instance(member_user, through_attrs: { role: 'member' })
+    membership.materialize_for_role! if membership.respond_to?(:materialize_for_role!)
+    membership
+  end
+
+  after do
+    organization.list_domains.each { |d| d.destroy! rescue nil }
+    admin_membership&.destroy! rescue nil
+    member_membership&.destroy! rescue nil
+    organization&.destroy! rescue nil
+    admin_user&.destroy! rescue nil
+    member_user&.destroy! rescue nil
+    owner&.destroy! rescue nil
+  end
+
+  def strategy_result_for(customer)
+    double(
+      'StrategyResult',
+      session: {},
+      user: customer,
+      authenticated?: true,
+      auth_method: 'sessionauth',
+      metadata: { organization_context: { organization: organization } },
+    )
+  end
+
+  def create_domain_for_removal(label)
+    domain = Onetime::CustomDomain.new
+    domain.display_domain = "#{run_id}-#{label}.example.com"
+    domain.org_id = organization.objid
+    domain.save
+    organization.domains.add(domain.objid)
+    domain
+  end
+
+  def build_remove_logic(customer, domain)
+    DomainsAPI::Logic::Domains::RemoveDomain.new(
+      strategy_result_for(customer),
+      { 'extid' => domain.extid },
+    )
+  end
+
+  describe 'owner role' do
+    it 'can delete a domain' do
+      domain = create_domain_for_removal('owner-rm')
+      logic = build_remove_logic(owner, domain)
+      expect { logic.raise_concerns }.not_to raise_error
+    end
+  end
+
+  describe 'admin role' do
+    it 'can delete a domain (has custom_domains entitlement)' do
+      domain = create_domain_for_removal('admin-rm')
+      logic = build_remove_logic(admin_user, domain)
+      expect { logic.raise_concerns }.not_to raise_error
+    end
+  end
+
+  describe 'member role' do
+    it 'is rejected with EntitlementRequired (lacks custom_domains)' do
+      domain = create_domain_for_removal('member-rm')
+      logic = build_remove_logic(member_user, domain)
+      expect { logic.raise_concerns }.to raise_error(Onetime::EntitlementRequired)
+    end
+
+    it 'tags the error with the entitlement-required i18n key' do
+      domain = create_domain_for_removal('member-rm-key')
+      logic = build_remove_logic(member_user, domain)
+      expect { logic.raise_concerns }.to raise_error(Onetime::EntitlementRequired) do |error|
+        expect(error.error_key).to eq('api.entitlements.errors.custom_domains_required')
+      end
+    end
+  end
+
+  describe 'non-member' do
+    let!(:outsider) do
+      Onetime::Customer.create!(email: "#{run_id}_outsider@test.com")
+    end
+
+    after do
+      outsider&.destroy! rescue nil
+    end
+
+    it 'gets "Domain not found" before reaching the entitlement gate' do
+      domain = create_domain_for_removal('outsider-rm')
+      logic = build_remove_logic(outsider, domain)
+      expect { logic.raise_concerns }.to raise_error(OT::FormError, /Domain not found/)
+    end
+  end
+
+  describe 'domain-scope enforcement' do
+    let!(:scoped_admin) do
+      Onetime::Customer.create!(email: "#{run_id}_scoped@test.com")
+    end
+
+    let!(:domain_a) { create_domain_for_removal('scope-a') }
+
+    let!(:scoped_membership) do
+      membership = organization.add_members_instance(
+        scoped_admin,
+        through_attrs: {
+          role: 'admin',
+          status: 'active',
+          domain_scope_id: domain_a.objid,
+        },
+      )
+      membership.materialize_for_role! if membership.respond_to?(:materialize_for_role!)
+      membership
+    end
+
+    after do
+      scoped_membership&.destroy! rescue nil
+      scoped_admin&.destroy! rescue nil
+    end
+
+    it 'domain-scoped admin is denied deletion of out-of-scope domain' do
+      other_domain = create_domain_for_removal('scope-other')
+      logic = build_remove_logic(scoped_admin, other_domain)
+      expect { logic.raise_concerns }.to raise_error(OT::RecordNotFound, 'Domain not found')
+    end
+
+    it 'domain-scoped admin can delete their scoped domain' do
+      logic = build_remove_logic(scoped_admin, domain_a)
+      expect { logic.raise_concerns }.not_to raise_error
+    end
+  end
+end

--- a/try/unit/models/custom_domain_migration_try.rb
+++ b/try/unit/models/custom_domain_migration_try.rb
@@ -66,8 +66,8 @@ Familia.dbclient.flushdb if ENV['ENV'] == 'test'
 @domain1.org_id == @organization.objid
 #=> true
 
-## Validation: Domain belongs to organization via owner check
-@domain1.owner?(@customer)
+## Validation: Domain accessible by organization member
+@domain1.accessible_by?(@customer)
 #=> true
 
 ## Validation: Organization tracks its domains

--- a/try/unit/models/organization_try.rb
+++ b/try/unit/models/organization_try.rb
@@ -360,11 +360,11 @@ result
 #=> false
 
 # ============================================================================
-# CustomDomain#owner? Unit B migration coverage (custom_domain.rb:270).
+# CustomDomain#owner? and #accessible_by? (#3340).
+# owner? is strict: true only for membership with role='owner'.
+# accessible_by? is loose: true for any org member (owner, admin, or member).
 # A customer whose custid matches org.owner_id but who has NO membership is
-# no longer treated as the domain's owner. The route-level integration suite
-# (try/integration/api/domains/add_domain_role_gate_try.rb) uses create!
-# exclusively, so this membership-less edge is uncovered there.
+# rejected by both methods.
 # ============================================================================
 
 ## CustomDomain#owner? returns false when org.owner_id matches but no membership
@@ -377,6 +377,22 @@ ghost_org = Onetime::Organization.new(
 ghost_org.save
 ghost_domain = Onetime::CustomDomain.create!("ghost-#{@test_suffix}.example.com", ghost_org.objid)
 result = ghost_domain.owner?(ghost_owner)
+ghost_domain.destroy!
+ghost_org.destroy!
+ghost_owner.destroy!
+result
+#=> false
+
+## CustomDomain#accessible_by? returns false when no membership exists
+ghost_owner = Onetime::Customer.create!(email: "ghost_cd_a2_#{@test_suffix}@onetimesecret.com")
+ghost_org = Onetime::Organization.new(
+  display_name: "Ghost CD Org A2",
+  owner_id: ghost_owner.custid,
+  contact_email: "ghost_cd_a2_#{@test_suffix}@acme.com",
+)
+ghost_org.save
+ghost_domain = Onetime::CustomDomain.create!("ghost2-#{@test_suffix}.example.com", ghost_org.objid)
+result = ghost_domain.accessible_by?(ghost_owner)
 ghost_domain.destroy!
 ghost_org.destroy!
 ghost_owner.destroy!
@@ -400,6 +416,24 @@ ghost_org.destroy!
 ghost_member.destroy!
 result
 #=> true
+
+## CustomDomain#accessible_by? returns true for member-role; owner? returns false
+ghost_member = Onetime::Customer.create!(email: "ghost_cd_c_#{@test_suffix}@onetimesecret.com")
+ghost_org = Onetime::Organization.new(
+  display_name: "Ghost CD Org C",
+  owner_id: "some_other_custid_#{@test_suffix}",
+  contact_email: "ghost_cd_c_#{@test_suffix}@acme.com",
+)
+ghost_org.save
+ghost_org.add_members_instance(ghost_member, through_attrs: { role: 'member' })
+ghost_domain = Onetime::CustomDomain.create!("member-access-#{@test_suffix}.example.com", ghost_org.objid)
+result = [ghost_domain.accessible_by?(ghost_member), ghost_domain.owner?(ghost_member)]
+ghost_domain.destroy!
+ghost_org.remove_members_instance(ghost_member)
+ghost_org.destroy!
+ghost_member.destroy!
+result
+#=> [true, false]
 
 # Teardown
 @org.destroy!


### PR DESCRIPTION
## Summary

[#3340](https://github.com/onetimesecret/onetimesecret/issues/3340)

Enforce the `custom_domains` entitlement requirement for domain deletion, consistent with AddDomain (#3033) and GetDomain. Previously, any organization member could delete a domain. Now only admins and owners (who have the entitlement) can delete domains.

### Key Changes

1. **CustomDomain model**: Split ownership logic into two methods:
   - `accessible_by?(cust)`: Loose check—true for any org member (owner, admin, or member)
   - `owner?(cust)`: Strict check—true only for members with role='owner'

2. **RemoveDomain logic**: Added entitlement gate requiring `custom_domains` after access validation, plus domain-scope enforcement to prevent cross-domain deletion by scoped admins.

3. **Updated callers**: Changed `owner?` calls to `accessible_by?` in domain access validation across v1/v2 secret actions and receipts logic, since those operations should allow any org member, not just owners.

4. **Documentation**: Updated Organization model comments to clarify the deprecation path for `owner_id` field in favor of OrganizationMembership role-based checks.

## Related Issues

Fixes #3340

## Test Plan

Added comprehensive integration test suite (`spec/integration/api/domains/remove_domain_role_gate_spec.rb`) covering:
- Owner can delete domains
- Admin can delete domains (has entitlement)
- Member is rejected with EntitlementRequired error
- Non-members get "Domain not found" before reaching entitlement gate
- Domain-scoped admins cannot delete out-of-scope domains
- Domain-scoped admins can delete their scoped domain

Updated unit tests in `try/unit/models/organization_try.rb` and `try/unit/models/custom_domain_migration_try.rb` to verify both `owner?` and `accessible_by?` behavior.

https://claude.ai/code/session_01JUgkA5DuBZ9QCk7VTiXvSF