### PR TITLE
Fix eslint-plugin-tailwindcss config target for Tailwind v4

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -449,7 +449,11 @@ export default [
       tailwindcss: {
         // These are the default values but feel free to customize
         callees: ['classnames', 'clsx', 'ctl'],
-        config: 'tailwind.config.ts', // returned from `loadConfig()` utility if not provided
+        // Tailwind v4: point at the CSS entry (the design-system source), not the
+        // legacy JS config. Absolute path is required — eslint-plugin-tailwindcss
+        // resolves `tailwindcss` relative to dirname(config), and a relative value
+        // makes that resolution fail ("Could not resolve tailwindcss").
+        config: `${import.meta.dirname}/src/assets/style.css`,
         cssFiles: ['**/*.css', '!**/node_modules', '!**/.*', '!**/dist', '!**/build'],
         cssFilesRefreshRate: 5_000,
         removeDuplicates: true,

--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -1,4 +1,7 @@
 @import "tailwindcss";
+/* This file is the v4 design-system entry. eslint-plugin-tailwindcss points
+   its `config` setting here (absolute path, see eslint.config.ts), NOT at
+   tailwind.config.ts — the plugin reads its config target as CSS. */
 @config "../../tailwind.config.ts";
 @plugin "@tailwindcss/forms";
 @plugin "@tailwindcss/typography";

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -10,6 +10,14 @@ import defaultTheme from 'tailwindcss/defaultTheme';
  * npx prettier path/2/ComponentFile.vue --write --log-level debug
  * <!-- prettier-ignore-attribute class -->
  *
+ * NOTE (v4): This legacy JS config is loaded by the build via the
+ * `@config "../../tailwind.config.ts"` directive in src/assets/style.css.
+ * Do NOT point eslint-plugin-tailwindcss's `settings.tailwindcss.config`
+ * at this file — under v4 the plugin reads its config target *as CSS* and
+ * will throw "Invalid declaration" on this TS source. That setting must
+ * point at the CSS entry (src/assets/style.css), absolute path. See the
+ * note in eslint.config.ts.
+ *
  **/
 
 export default {


### PR DESCRIPTION
## Problem

`pnpm exec eslint` crashed before linting:

```
Error: Could not resolve tailwindcss
  at TailwindUtils.loadConfigV4 (tailwind-api-utils/dist/index.cjs)
```

## Root cause

`eslint.config.ts` set `settings.tailwindcss.config = 'tailwind.config.ts'` — a **relative** path pointing at the **legacy JS config**. Two failures stack:

1. `eslint-plugin-tailwindcss@4-beta` → `tailwind-api-utils` resolves the `tailwindcss` package relative to `dirname(config)`. With a relative value that base is `.`, and `local-pkg` returns `undefined` for a relative base → "Could not resolve tailwindcss". Reproduced: `paths:['.']` → undefined, `paths:['<abs root>']` → resolves.
2. Under v4 the plugin reads its config target **as CSS** and feeds it to `loadDesignSystem`. A `.ts` file throws `Invalid declaration`. Confirmed: absolute `style.css` loads a context, `tailwind.config.ts` does not.

## Fix

Point the setting at the v4 CSS design-system entry, absolute path:

```ts
config: `${import.meta.dirname}/src/assets/style.css`,
```

(`import.meta.dirname` resolves correctly under ESLint's jiti TS loader — verified.)

Added inline notes in `tailwind.config.ts` and `src/assets/style.css` clarifying that the JS config is loaded via the `@config` directive and must **not** be the eslint plugin's `config` target, to avoid repeating the diagnosis.

## Verification

- `pnpm exec eslint src/App.vue` → exit 0, ordinary lint warnings only, no Tailwind crash.
- `tailwind-api-utils` loads `style.css` to a valid context after the CSS comment was added.
- pre-commit ESLint + pnpm lint + type check passed.