### PR TITLE
Fix brand head-base E2E failure (conditional render) + E2E remediation plan

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -115,6 +115,11 @@ jobs:
           # Generate a secure secret for testing
           TEST_SECRET=$(openssl rand -hex 32)
 
+          # Pin a deterministic brand color so the container is "branded" and
+          # head-base.rue renders the mask-icon/theme-color tags. #3B82F6 is the
+          # neutral default (#3049); the brand-customization E2E asserts the
+          # mask-icon color matches it exactly. Without this the tags are
+          # correctly omitted (unbranded) and that assertion has nothing to test.
           docker run -d \
             --name ${{ env.CONTAINER_NAME }} \
             --link ${{ env.REDIS_CONTAINER_NAME }}:redis \
@@ -124,6 +129,7 @@ jobs:
             -e HOST=localhost:3000 \
             -e SSL=false \
             -e RACK_ENV=production \
+            -e BRAND_PRIMARY_COLOR='#3B82F6' \
             ${{ env.OCI_IMAGE_NAME }}
 
           if [ "${{ env.DEBUG_ENABLED }}" == "true" ]; then

--- a/apps/web/core/spec/views/base_spec.rb
+++ b/apps/web/core/spec/views/base_spec.rb
@@ -145,6 +145,52 @@ RSpec.describe Core::Views::BaseView do
     end
   end
 
+  describe 'has_brand_color contract' do
+    # has_brand_color drives the conditional render of the brand-colored
+    # head tags (mask-icon + light theme-color) in head-base.rue. It MUST be
+    # false when no brand primary_color is configured so unbranded
+    # deployments omit those tags (and the frontend falls through to
+    # NEUTRAL_BRAND_DEFAULTS), and true when a color is configured.
+    #
+    # See: apps/web/core/views/helpers/initialize_view_vars.rb
+    #      apps/web/core/templates/partials/head-base.rue
+    #      e2e/all/brand-customization.spec.ts
+
+    context 'when no brand primary_color is configured (unbranded)' do
+      it 'sets has_brand_color to false' do
+        expect(subject.view_vars['has_brand_color']).to be false
+      end
+
+      it 'leaves brand_primary_color nil' do
+        expect(subject.view_vars['brand_primary_color']).to be_nil
+      end
+    end
+
+    context 'when brand primary_color is an empty/whitespace string' do
+      let(:config) do
+        super().merge('brand' => { 'primary_color' => '   ' })
+      end
+
+      it 'sets has_brand_color to false' do
+        expect(subject.view_vars['has_brand_color']).to be false
+      end
+    end
+
+    context 'when a brand primary_color is configured (branded)' do
+      let(:config) do
+        super().merge('brand' => { 'primary_color' => '#112233' })
+      end
+
+      it 'sets has_brand_color to true' do
+        expect(subject.view_vars['has_brand_color']).to be true
+      end
+
+      it 'exposes the configured brand_primary_color' do
+        expect(subject.view_vars['brand_primary_color']).to eq('#112233')
+      end
+    end
+  end
+
   describe '#add_message' do
     it 'adds info message to messages array' do
       subject.add_message('Test message')

--- a/apps/web/core/templates/partials/head-base.rue
+++ b/apps/web/core/templates/partials/head-base.rue
@@ -17,8 +17,10 @@
 
   <!-- Modern favicon strategy -->
   <link nonce="{{app.nonce}}" rel="icon" href="/favicon.ico" sizes="32x32">
+  {{#if has_brand_color}}
   <link nonce="{{app.nonce}}" rel="mask-icon" href="/safari-pinned-tab.svg" color="{{brand_primary_color}}">
   <meta name="theme-color" content="{{brand_primary_color}}" media="(prefers-color-scheme: light)">
+  {{/if}}
   <meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)">
 
   {{#if no_cache}}

--- a/apps/web/core/views/base.rb
+++ b/apps/web/core/views/base.rb
@@ -121,6 +121,7 @@ module Core
           'site_host' => view_vars['site_host'],
           'no_cache' => view_vars['no_cache'],
           'brand_primary_color' => view_vars['brand_primary_color'],
+          'has_brand_color' => view_vars['has_brand_color'],
           'vite_assets_html' => vite_assets(
             nonce: view_vars['nonce'],
             development: view_vars['frontend_development'],

--- a/apps/web/core/views/helpers/initialize_view_vars.rb
+++ b/apps/web/core/views/helpers/initialize_view_vars.rb
@@ -190,6 +190,7 @@ module Core
 
         brand_defaults              = Onetime::CustomDomain::BrandSettingsConstants::DEFAULTS
         brand_primary_color         = brand_config['primary_color']
+        has_brand_color             = !brand_primary_color.to_s.strip.empty?
         support_email               = brand_config['support_email'] ||
                                       Onetime::CustomDomain::BrandSettingsConstants::GLOBAL_DEFAULTS[:support_email]
         # docs_host: full documentation URL exposed to bootstrap. Sources from
@@ -240,6 +241,7 @@ module Core
           'site' => safe_site,
           'site_host' => site_host,
           'brand_primary_color' => brand_primary_color,
+          'has_brand_color' => has_brand_color,
           'brand_product_name' => brand_product_name,
           'brand_corner_style' => brand_corner_style,
           'brand_font_family' => brand_font_family,

--- a/e2e/all/brand-customization.spec.ts
+++ b/e2e/all/brand-customization.spec.ts
@@ -327,32 +327,37 @@ test.describe('Brand Customization - Console Error Monitoring', () => {
 });
 
 test.describe('Brand Customization - head-base meta tags', () => {
-  // head-base.rue partial conditionally renders the brand-colored tags:
+  // head-base.rue conditionally renders the brand-colored tags:
   //   {{#if has_brand_color}}
   //     <link rel="mask-icon" href="..." color="{{brand_primary_color}}">
   //     <meta name="theme-color" content="{{brand_primary_color}}" ...>
   //   {{/if}}
-  // These tags are ONLY emitted when a brand color is configured. Unbranded
-  // deployments (including the default CI E2E container) deliberately omit
-  // them so the frontend can fall through to NEUTRAL_BRAND_DEFAULTS. When the
-  // mask-icon tag is present, its color attribute must be a valid hex color.
+  // The tags are emitted only when a brand color is configured; unbranded
+  // deployments deliberately omit them so the frontend can fall through to
+  // NEUTRAL_BRAND_DEFAULTS. This suite expects a brand color to be configured
+  // (CI pins BRAND_PRIMARY_COLOR=#3B82F6, the neutral default / NEUTRAL_BLUE),
+  // so the tag is always present and its color must match exactly — no skip,
+  // so a regression in the template→config wiring fails the build.
 
-  test('mask-icon, when present, carries a valid hex color', async ({ page }) => {
+  test('mask-icon renders with the configured brand color', async ({ page }) => {
     await page.goto('/');
     const maskIcon = page.locator('link[rel="mask-icon"]');
 
-    // Unbranded deployments legitimately omit the mask-icon tag (no brand
-    // color configured), in which case there is nothing to validate.
-    if ((await maskIcon.count()) === 0) {
-      test.skip(true, 'mask-icon absent: no brand color configured in this environment');
-      return;
-    }
+    await expect(
+      maskIcon,
+      'mask-icon tag must render when a brand color is configured'
+    ).toHaveCount(1);
+    await expect(maskIcon).toHaveAttribute('color', NEUTRAL_BLUE);
+  });
 
-    const color = await maskIcon.getAttribute('color');
-    expect(
-      color && isHexColor(color),
-      `mask-icon color must be a hex color, got: ${color}`
-    ).toBe(true);
+  test('light theme-color meta agrees with the mask-icon brand color', async ({ page }) => {
+    await page.goto('/');
+    const themeColor = page.locator(
+      'meta[name="theme-color"][media="(prefers-color-scheme: light)"]'
+    );
+
+    await expect(themeColor).toHaveCount(1);
+    await expect(themeColor).toHaveAttribute('content', NEUTRAL_BLUE);
   });
 });
 

--- a/e2e/all/brand-customization.spec.ts
+++ b/e2e/all/brand-customization.spec.ts
@@ -327,25 +327,31 @@ test.describe('Brand Customization - Console Error Monitoring', () => {
 });
 
 test.describe('Brand Customization - head-base meta tags', () => {
-  // head-base.rue partial renders:
-  //   <link rel="mask-icon" href="..." color="{{brand_primary_color}}">
-  // The color attribute should carry a hex color value derived from the
-  // configured brand color.
-  //
-  // Note: <meta name="theme-color"> was removed in 5b2e760 (PWA cleanup).
+  // head-base.rue partial conditionally renders the brand-colored tags:
+  //   {{#if has_brand_color}}
+  //     <link rel="mask-icon" href="..." color="{{brand_primary_color}}">
+  //     <meta name="theme-color" content="{{brand_primary_color}}" ...>
+  //   {{/if}}
+  // These tags are ONLY emitted when a brand color is configured. Unbranded
+  // deployments (including the default CI E2E container) deliberately omit
+  // them so the frontend can fall through to NEUTRAL_BRAND_DEFAULTS. When the
+  // mask-icon tag is present, its color attribute must be a valid hex color.
 
-  test('link mask-icon color attribute carries a valid hex color', async ({ page }) => {
+  test('mask-icon, when present, carries a valid hex color', async ({ page }) => {
     await page.goto('/');
-    await page.waitForLoadState('networkidle');
+    const maskIcon = page.locator('link[rel="mask-icon"]');
 
-    const maskIconColor = await page
-      .locator('link[rel="mask-icon"]')
-      .getAttribute('color');
+    // Unbranded deployments legitimately omit the mask-icon tag (no brand
+    // color configured), in which case there is nothing to validate.
+    if ((await maskIcon.count()) === 0) {
+      test.skip(true, 'mask-icon absent: no brand color configured in this environment');
+      return;
+    }
 
-    expect(maskIconColor, 'link[mask-icon] color should be present').toBeTruthy();
+    const color = await maskIcon.getAttribute('color');
     expect(
-      maskIconColor && isHexColor(maskIconColor),
-      `link[mask-icon] color should be a hex color, got: ${maskIconColor}`
+      color && isHexColor(color),
+      `mask-icon color must be a hex color, got: ${color}`
     ).toBe(true);
   });
 });

--- a/e2e/docs/e2e-remediation-plan.md
+++ b/e2e/docs/e2e-remediation-plan.md
@@ -1,11 +1,45 @@
 # E2E Test Suite Remediation Plan
 
-> Status: **Proposed** · Created: 2026-06-09 · Owner: TBD
+> Status: **In progress** — Phase 0 complete ([PR #3409](https://github.com/onetimesecret/onetimesecret/pull/3409)); **next up: PR 2 / Phase 1.**
+> Created: 2026-06-09 · Last updated: 2026-06-09 · Owner: TBD
 >
 > Motivation: The `container-e2e-tests` check has been a chronic source of red
 > CI and perceived flakiness (e.g. PR #3399). This document itemizes the root
 > causes and lays out a phased, best-practice remediation so the suite becomes
 > trustworthy, fast, and maintainable. **We have no room for flaky tests.**
+>
+> **This is a living tracker.** Update the Progress section and the PR-sequence
+> table as each slice lands.
+
+## Progress & how to continue
+
+| Phase / PR | Status | Where |
+|------------|--------|-------|
+| Phase 0 / PR 1 — unblock #3399 mask-icon + this plan | ✅ **Done** | [PR #3409](https://github.com/onetimesecret/onetimesecret/pull/3409) · branch `claude/sleepy-shannon-21ko6k` |
+| Phase 1 / PR 2 — reporter/artifacts + lint-ban + flaky gate | ⏭️ **Next** | not started |
+| Phase 2 / PRs 3–5 — auth fixture, readiness signal, `networkidle` sweep, skip triage | ⬜ Todo | not started |
+| Phase 3 / PR 6 — fixtures module, pinned config, parallel/shard | ⬜ Todo | not started |
+
+### For a fresh contributor picking up PR 2
+
+1. **Verify Phase 0 already landed — do not redo it.** The mask-icon /
+   `has_brand_color` conditional render and the `BRAND_PRIMARY_COLOR` CI pin are
+   done. `git log --oneline | grep -Ei "head-base|brand color"` should show the
+   two Phase 0 commits. PR 2 starts at **Phase 1** below.
+2. **Branch reality.** Phase 0 lives on `claude/sleepy-shannon-21ko6k`, which is
+   **stacked on #3399's branch** (`claude/dazzling-lovelace-semxai`) because the
+   fix depends on #3399's `e621290` ("Pass brand_primary_color to Rhales template
+   context").
+3. **Where to branch PR 2.** Phase 1 (reporter / lint / flaky-gate) is
+   **independent of the brand work** — it touches `e2e/playwright.config.ts`,
+   `package.json`, `.github/workflows/e2e.yml`, and `eslint.config.ts`, none of
+   which need #3399. If #3399 + PR #3409 have merged to `develop`, branch PR 2 off
+   `develop`. Otherwise branch off `claude/sleepy-shannon-21ko6k` to continue the
+   stack so the `e2e.yml` edits don't conflict with Phase 0's, and rebase onto
+   `develop` once the stack merges.
+4. **Definition of done for PR 2:** the Phase 1 acceptance bullet, **plus** a
+   manual check that HTML + trace artifacts appear on a failed run and that a
+   deliberately-flaky test turns the job red.
 
 ## Headline finding
 
@@ -111,17 +145,34 @@ branches; the head-base E2E asserts an exact color with **no** `test.skip` and
 
 ## Phase 1 — Stop the bleeding (mechanical, high-leverage)
 
+> **Concrete starting points** (verified against the tree as of Phase 0):
+> - The reporter override that breaks the HTML report lives in **two** places that
+>   both override the `reporter` array in `e2e/playwright.config.ts:38`: the
+>   `package.json` `test:playwright` script (`--reporter=list`) and the
+>   `.github/workflows/e2e.yml` "Run Playwright E2E tests" step (`--reporter=github`).
+>   Net effect today: `playwright-report/` is never produced, so the upload step
+>   logs "No files were found with the provided path: e2e/playwright-report/".
+> - The `e2e.yml` "Upload Playwright Report" step currently uploads only
+>   `e2e/playwright-report/`; add `e2e/test-results/` (traces/videos/screenshots).
+> - Lint config is the flat `eslint.config.ts` at repo root. It currently targets
+>   `src/**` and does **not** lint `e2e/**` — add an `e2e/**` block.
+
 1. **Fix reporter/artifacts.** Make `e2e/playwright.config.ts` reporters
    environment-aware (CI: `list`, `github`, `html`, `json`, `blob`); drop the
    hard-coded `--reporter` overrides in `package.json` and `.github/workflows/e2e.yml`;
    upload both `e2e/playwright-report/` and `e2e/test-results/` with `if: always()`.
 2. **Lint-ban flaky primitives.** Add `eslint-plugin-playwright` to
-   `eslint.config.ts` for `e2e/**`; `no-restricted-syntax` forbidding
+   `eslint.config.ts` with an `e2e/**` block; `no-restricted-syntax` forbidding
    `waitForLoadState('networkidle')` and `page.waitForTimeout(...)`. Roll out
-   `warn` → directory sweeps → `error`.
+   `warn` → directory sweeps → `error` (there are ~300 `networkidle` + ~43
+   `waitForTimeout` call-sites today, so do **not** flip to `error` in this PR).
 3. **Make flake blocking.** Keep `retries: 2` for traces, add a CI step parsing
-   `results.json` that fails the job on any `flaky` outcome. Add
+   the JSON reporter output that fails the job on any `flaky` outcome. Add
    `e2e/QUARANTINE.md` for `test.fixme`'d tests with owner + issue link.
+
+**Acceptance:** HTML report + traces uploaded on failure; `networkidle` /
+`waitForTimeout` lint rules active (at `warn`); a retry-only ("flaky") pass turns
+CI **red**.
 
 ---
 
@@ -157,9 +208,11 @@ branches; the head-base E2E asserts an exact color with **no** `test.skip` and
 
 ## Suggested PR sequence
 
-| PR | Phase | Scope | Risk |
-|----|-------|-------|------|
-| 1 | 0 | mask-icon conditional render + deterministic (skip-free) test + Ruby spec + CI brand-color pin | Low — unblocks #3399 |
+_Live status is tracked in the **Progress & how to continue** section near the top._
+
+| PR | Phase | Scope | Risk / status |
+|----|-------|-------|---------------|
+| 1 | 0 | mask-icon conditional render + deterministic (skip-free) test + Ruby spec + CI brand-color pin | ✅ Done ([#3409](https://github.com/onetimesecret/onetimesecret/pull/3409)) — unblocks #3399 |
 | 2 | 1 | reporter/artifacts, lint rules (warn), flaky gate | Low |
 | 3 | 2.1+2.2 | global-setup/auth fixture + app-readiness signal | Med — surfaces real `full/` failures (intended) |
 | 4 | 2.3 | `networkidle`/sleep sweep, by directory; lint → error | Med — large but mechanical |

--- a/e2e/docs/e2e-remediation-plan.md
+++ b/e2e/docs/e2e-remediation-plan.md
@@ -95,9 +95,17 @@ change without brand config; it is deterministic, not random.
    valid, present must be hex.
 5. **Backend regression spec**: unbranded → no `mask-icon` tag; branded → tag
    present with exact value. Locks the contract.
+6. **Pin a deterministic brand color in CI** (`.github/workflows/e2e.yml`): run
+   the container with `-e BRAND_PRIMARY_COLOR='#3B82F6'` (the neutral default,
+   `#3049`). This makes the head-base assertion deterministic so the E2E test can
+   require the tag's presence and assert its exact color **without a defensive
+   skip** — the test fails on any template→config regression rather than silently
+   skipping. (Pulled forward from Phase 3 so PR 1 exemplifies "a test must be able
+   to fail" instead of introducing a new self-skip.)
 
 **Acceptance:** `container-e2e-tests` green on #3399; new Ruby spec covers both
-branches.
+branches; the head-base E2E asserts an exact color with **no** `test.skip` and
+**no** `networkidle`.
 
 ---
 
@@ -139,8 +147,9 @@ branches.
 
 1. **`e2e/fixtures.ts`**: `authedPage`, auto-collecting `consoleErrors` fixture
    (single maintained ignore-list), `gotoReady(path)` helper.
-2. **Pin a known brand config** in `e2e.yml` (`BRAND_PRIMARY_COLOR=#3B82F6`);
-   upgrade the mask-icon test to strict equality.
+2. **Extend the pinned-config approach** beyond the brand color (done for
+   `BRAND_PRIMARY_COLOR` in Phase 0) so every environment-coupled assertion tests
+   a known, deterministic state rather than "whatever the default serves".
 3. **Parallelize + shard**: once tests own their data, `fullyParallel: true`,
    raise `workers`, add a CI shard matrix merging `blob` reports.
 
@@ -150,7 +159,7 @@ branches.
 
 | PR | Phase | Scope | Risk |
 |----|-------|-------|------|
-| 1 | 0 | mask-icon conditional render + test + Ruby spec | Low — unblocks #3399 |
+| 1 | 0 | mask-icon conditional render + deterministic (skip-free) test + Ruby spec + CI brand-color pin | Low — unblocks #3399 |
 | 2 | 1 | reporter/artifacts, lint rules (warn), flaky gate | Low |
 | 3 | 2.1+2.2 | global-setup/auth fixture + app-readiness signal | Med — surfaces real `full/` failures (intended) |
 | 4 | 2.3 | `networkidle`/sleep sweep, by directory; lint → error | Med — large but mechanical |

--- a/e2e/docs/e2e-remediation-plan.md
+++ b/e2e/docs/e2e-remediation-plan.md
@@ -1,0 +1,173 @@
+# E2E Test Suite Remediation Plan
+
+> Status: **Proposed** · Created: 2026-06-09 · Owner: TBD
+>
+> Motivation: The `container-e2e-tests` check has been a chronic source of red
+> CI and perceived flakiness (e.g. PR #3399). This document itemizes the root
+> causes and lays out a phased, best-practice remediation so the suite becomes
+> trustworthy, fast, and maintainable. **We have no room for flaky tests.**
+
+## Headline finding
+
+The failures are **not** primarily random flake. The recurring red on
+brand/TOTP branches is a **deterministic test/behavior contradiction** sitting on
+top of a genuinely fragile suite. The systemic fragility (300 `networkidle`
+waits, 143 self-skipping tests, a 23-file `full/` suite that never runs in CI)
+is what earns it the "chronically failing" reputation.
+
+## Guiding principles
+
+1. **A test must be able to fail.** Anything that can only pass-or-skip is
+   deleted or made deterministic.
+2. **No timing guesses.** Replace `networkidle` / `waitForTimeout` with
+   web-first assertions and an explicit app-readiness signal.
+3. **Flake is blocking, not silent.** Retries stay as a trace-gathering net, but
+   a "passed-only-on-retry" result turns CI red.
+4. **One correct pattern, in one place.** Shared fixtures, not 29
+   re-implementations.
+5. **Land it in reviewable slices.** No single 343-file diff.
+
+---
+
+## Itemized problems (evidence)
+
+Gathered across 29 spec files / 412 `test()` blocks.
+
+### The immediate hard failure
+
+`e2e/all/brand-customization.spec.ts:337 › link mask-icon color attribute
+carries a valid hex color` — `Received: ""`.
+
+- Template renders `color="{{brand_primary_color}}"`
+  (`apps/web/core/templates/partials/head-base.rue:20`).
+- `brand_primary_color = brand_config['primary_color']` with **no fallback**
+  (`apps/web/core/views/helpers/initialize_view_vars.rb:192`).
+- Commits `6d26430` ("Stop backfilling brand_primary_color default at
+  serialization time") and `e621290` deliberately removed the default so the
+  frontend can fall through to `NEUTRAL_BRAND_DEFAULTS`.
+- The CI E2E container runs **unbranded** (no `BRAND_*` env), so the attribute
+  renders as `color=""` — but the test asserts it is *always* a valid hex.
+
+This fails 100% of the time on any branch carrying the "stop backfilling"
+change without brand config; it is deterministic, not random.
+
+### Systemic problems
+
+| # | Problem | Evidence | Why it hurts |
+|---|---------|----------|--------------|
+| 1 | `networkidle` everywhere | **300** `waitForLoadState('networkidle')` | Officially discouraged by Playwright; races SPA hydration → #1 flake source. |
+| 2 | Hard-coded sleeps | **43** `waitForTimeout()` | Arbitrary sleeps either flake (too short) or waste time (too long). |
+| 3 | "Defensive skip" tests that can't fail | **143** `test.skip(true, 'route/form not available')` | Zero signal; reports green. 19 of 48 CI tests skip this way — false confidence. |
+| 4 | A whole suite that never runs in CI | `full/` (19) + `full-billing/` (4) gated by **127** `test.skip(!hasCredentials)`; CI only runs `e2e/all/` and passes no creds | Hundreds of tests look like coverage but execute *never*. No auth fixture exists. |
+| 5 | Broken artifact pipeline | Workflow `--reporter=github` overrides config `html` reporter → "No files were found ... playwright-report/" | No HTML report / trace artifact on failure → slow repeated re-runs. |
+| 6 | Retries silently mask flake | `retries: 2` + `--max-failures=5`, no flaky gate | Flaky tests green-washed on retry with no tracking/quarantine. |
+| 7 | No shared fixtures | No `e2e/*.ts` helper module; every spec re-implements login/nav/waits | Fixes must be applied 29× and drift. |
+| 8 | Environment coupling | Brand tests assert against "whatever the default container serves" | Behavior changes (#3381) silently break tests; no known brand state pinned. |
+| 9 | Serial + slow | `workers: 1`, `fullyParallel: false` → 2.8 min for 28 tests | One hung test blocks all; slow feedback discourages local runs. |
+
+---
+
+## Phase 0 — Unblock CI (the mask-icon failure)
+
+**Direction: conditional render + test asserts "if present, valid hex".**
+
+1. **`apps/web/core/views/helpers/initialize_view_vars.rb`** (~line 192): add an
+   explicit boolean rather than relying on template-engine truthiness:
+   ```ruby
+   brand_primary_color = brand_config['primary_color']
+   has_brand_color     = !brand_primary_color.to_s.strip.empty?
+   ```
+   Add `'has_brand_color' => has_brand_color,` to the returned view-vars hash
+   (near line 242).
+2. **`apps/web/core/views/base.rb`** (`render`, ~line 123): add
+   `'has_brand_color' => view_vars['has_brand_color'],` to `template_vars` so the
+   template context can see it.
+3. **`apps/web/core/templates/partials/head-base.rue`** (lines 20–22): only emit
+   brand-colored tags when a color exists (no empty `color=""` / `content=""`):
+   ```handlebars
+   {{#if has_brand_color}}
+     <link nonce="{{app.nonce}}" rel="mask-icon" href="/safari-pinned-tab.svg" color="{{brand_primary_color}}">
+     <meta name="theme-color" content="{{brand_primary_color}}" media="(prefers-color-scheme: light)">
+   {{/if}}
+   <meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)">
+   ```
+4. **`e2e/all/brand-customization.spec.ts:337`**: assert reality — absent is
+   valid, present must be hex.
+5. **Backend regression spec**: unbranded → no `mask-icon` tag; branded → tag
+   present with exact value. Locks the contract.
+
+**Acceptance:** `container-e2e-tests` green on #3399; new Ruby spec covers both
+branches.
+
+---
+
+## Phase 1 — Stop the bleeding (mechanical, high-leverage)
+
+1. **Fix reporter/artifacts.** Make `e2e/playwright.config.ts` reporters
+   environment-aware (CI: `list`, `github`, `html`, `json`, `blob`); drop the
+   hard-coded `--reporter` overrides in `package.json` and `.github/workflows/e2e.yml`;
+   upload both `e2e/playwright-report/` and `e2e/test-results/` with `if: always()`.
+2. **Lint-ban flaky primitives.** Add `eslint-plugin-playwright` to
+   `eslint.config.ts` for `e2e/**`; `no-restricted-syntax` forbidding
+   `waitForLoadState('networkidle')` and `page.waitForTimeout(...)`. Roll out
+   `warn` → directory sweeps → `error`.
+3. **Make flake blocking.** Keep `retries: 2` for traces, add a CI step parsing
+   `results.json` that fails the job on any `flaky` outcome. Add
+   `e2e/QUARANTINE.md` for `test.fixme`'d tests with owner + issue link.
+
+---
+
+## Phase 2 — Make coverage real
+
+1. **Auth via global-setup + `storageState`.** `e2e/global.setup.ts` (setup
+   project) registers a test user via `/signup` (fallback: `docker exec`
+   `Onetime::Customer.create!`), logs in, saves `e2e/.auth/user.json`. Config
+   adds `setup` project; `full`/`full-billing` get `dependencies: ['setup']` +
+   `storageState`. Workflow seeds `TEST_USER_*` and runs `e2e/all e2e/full`.
+2. **Deterministic app-readiness signal.** Frontend sets
+   `document.documentElement.dataset.appReady = 'true'` after mount + brand
+   theme applied; tests wait on that, replacing `__BOOTSTRAP_ME__` polling +
+   `networkidle`. *(Highest-leverage flake fix.)*
+3. **Sweep `networkidle` → web-first assertions** (300 sites), per directory.
+4. **Convert the 143 defensive skips**: (a) guaranteed precondition → run it;
+   (b) genuinely optional feature → tagged project, not runtime self-skip;
+   (c) unimplemented → `test.fixme` + issue link.
+
+---
+
+## Phase 3 — Structure & speed
+
+1. **`e2e/fixtures.ts`**: `authedPage`, auto-collecting `consoleErrors` fixture
+   (single maintained ignore-list), `gotoReady(path)` helper.
+2. **Pin a known brand config** in `e2e.yml` (`BRAND_PRIMARY_COLOR=#3B82F6`);
+   upgrade the mask-icon test to strict equality.
+3. **Parallelize + shard**: once tests own their data, `fullyParallel: true`,
+   raise `workers`, add a CI shard matrix merging `blob` reports.
+
+---
+
+## Suggested PR sequence
+
+| PR | Phase | Scope | Risk |
+|----|-------|-------|------|
+| 1 | 0 | mask-icon conditional render + test + Ruby spec | Low — unblocks #3399 |
+| 2 | 1 | reporter/artifacts, lint rules (warn), flaky gate | Low |
+| 3 | 2.1+2.2 | global-setup/auth fixture + app-readiness signal | Med — surfaces real `full/` failures (intended) |
+| 4 | 2.3 | `networkidle`/sleep sweep, by directory; lint → error | Med — large but mechanical |
+| 5 | 2.4 | defensive-skip triage | Med |
+| 6 | 3 | fixtures.ts, pinned brand, parallel/shard | Low |
+
+## Key risks & mitigations
+
+- **Turning on `full/` will reveal genuine bugs** previously masked by skips —
+  that is the goal; budget for fixes, land behind the flaky gate.
+- **Auth seeding** assumes `/signup` is enabled in the container; if closed,
+  seed via `docker exec ... Onetime::Customer.create!`.
+- **Mass lint flip** staged `warn` → sweep → `error` to keep diffs reviewable.
+
+## Acceptance criteria (end state)
+
+- Green CI with **0 skipped-by-default** tests in `all/`.
+- `full/` + `full-billing/` execute in CI against a seeded session.
+- **No** `networkidle` / `waitForTimeout` in the suite (lint-enforced).
+- A retry-only pass turns CI **red**; HTML + trace artifacts always uploaded.


### PR DESCRIPTION
## Summary

Stacked on top of **#3399** (`claude/dazzling-lovelace-semxai`) to unblock its failing `container-e2e-tests` check and lay the groundwork for a healthier E2E suite.

The E2E test `brand-customization.spec.ts › mask-icon color` fails on #3399 with `Received: ""`. **Root cause:** #3399 (with #3381/#3397) deliberately stopped backfilling a default for `brand_primary_color`, so in the unbranded CI container the template rendered `color=""`, while the test asserted an always-present hex.

### Changes
- **Conditional render** — `head-base.rue` emits the `mask-icon` + light `theme-color` tags only when a brand color is configured (`{{#if has_brand_color}}`), gated by a new precomputed `has_brand_color` view var threaded through `initialize_view_vars.rb` → `base.rb` render context. No more empty `color=""` / `content=""` attributes.
- **Deterministic E2E** — the CI container now pins `BRAND_PRIMARY_COLOR=#3B82F6` (the neutral default), and the test asserts the **exact** color with web-first assertions — **no `test.skip`, no `networkidle`**. A companion test asserts the light `theme-color` meta agrees with the mask-icon, guarding the template↔config drift that motivated #3399.
- **Backend regression spec** locks the `has_brand_color` contract (unbranded → `false`; branded → `true` + value).
- **E2E remediation plan** (`e2e/docs/e2e-remediation-plan.md`) — itemizes the suite's systemic flakiness (300 `networkidle` waits, 143 self-skipping tests, a `full/` suite that never runs in CI, broken report artifacts) and proposes a phased fix. **This PR is Phase 0.**

### Relationship to #3399
This branch is stacked on #3399's head, so this PR contains only the E2E fix + plan. Merging it into `claude/dazzling-lovelace-semxai` turns #3399's E2E check green. Targeting `develop` directly would be incoherent — the fix builds on #3399's `e621290` ("Pass brand_primary_color to Rhales template context").

## Test plan
- [x] `apps/web/core/spec/views/base_spec.rb` — 26 examples, 0 failures (incl. 5 new `has_brand_color` contract tests)
- [x] `tsc --noEmit` on the modified spec — clean
- [ ] CI `container-e2e-tests` green (mask-icon asserts exact `#3B82F6`, no skip)

https://claude.ai/code/session_01XEDpFBMAYvXHPtHqCWmpuK

---
_Generated by [Claude Code](https://claude.ai/code/session_01XEDpFBMAYvXHPtHqCWmpuK)_