### PR TITLE
E2E Phase 2.1+2.2: auth via setup project + storageState, deterministic app-readiness signal

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -211,8 +211,15 @@ jobs:
           # the container, which CI does not configure yet. The trailing
           # slashes matter: CLI filters are partial-path matches, so a bare
           # 'e2e/full' would also pull in 'e2e/full-billing/'.
+          #
+          # --max-failures=20: the full/ suite is newly enabled and still
+          # being triaged (e2e/docs/e2e-remediation-plan.md, Phase 2). At 5,
+          # one failure class aborts the run and hides everything behind it
+          # ("272 did not run" on the first #3412 run); 20 keeps the
+          # circuit-breaker for catastrophic runs while surfacing whole
+          # failure classes per CI cycle. Tighten again once triage is done.
           pnpm test:playwright e2e/all/ e2e/full/ \
-            --max-failures=5
+            --max-failures=20
         env:
           PLAYWRIGHT_BASE_URL: ${{ env.TEST_BASE_URL }}
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -120,6 +120,11 @@ jobs:
           # neutral default (#3049); the brand-customization E2E asserts the
           # mask-icon color matches it exactly. Without this the tags are
           # correctly omitted (unbranded) and that assertion has nothing to test.
+          #
+          # AUTH_AUTOVERIFY=true makes accounts created via /signup verified
+          # immediately (no email round-trip), which is what lets the e2e
+          # auth setup project (e2e/global.setup.ts) register + sign in the
+          # ephemeral TEST_USER_* account for the full/ suite.
           docker run -d \
             --name ${{ env.CONTAINER_NAME }} \
             --link ${{ env.REDIS_CONTAINER_NAME }}:redis \
@@ -130,6 +135,7 @@ jobs:
             -e SSL=false \
             -e RACK_ENV=production \
             -e BRAND_PRIMARY_COLOR='#3B82F6' \
+            -e AUTH_AUTOVERIFY=true \
             ${{ env.OCI_IMAGE_NAME }}
 
           if [ "${{ env.DEBUG_ENABLED }}" == "true" ]; then
@@ -189,10 +195,23 @@ jobs:
           # override replaces the whole array and breaks the report artifacts
           # and the flaky gate below.
 
-          # Run only 'all/' tests - these work without auth or billing configuration
-          # Tests in 'full/' require authenticated sessions
-          # Tests in 'full-billing/' require auth + billing enabled
-          pnpm test:playwright e2e/all/ \
+          # Ephemeral credentials for the authenticated 'full/' suite.
+          # e2e/global.setup.ts registers this account via the app's own
+          # /signup flow (AUTH_AUTOVERIFY=true on the container makes it
+          # immediately sign-in-able) and saves the session for storageState.
+          # Never hardcode these; they live only for this container's life.
+          export TEST_USER_EMAIL="e2e-$(openssl rand -hex 8)@example.com"
+          TEST_USER_PASSWORD="$(openssl rand -base64 24)"
+          echo "::add-mask::$TEST_USER_PASSWORD"
+          export TEST_USER_PASSWORD
+
+          # Run 'all/' (credential-free) and 'full/' (authenticated via the
+          # setup project + storageState; see e2e/playwright.config.ts).
+          # 'full-billing/' additionally requires billing to be enabled on
+          # the container, which CI does not configure yet. The trailing
+          # slashes matter: CLI filters are partial-path matches, so a bare
+          # 'e2e/full' would also pull in 'e2e/full-billing/'.
+          pnpm test:playwright e2e/all/ e2e/full/ \
             --max-failures=5
         env:
           PLAYWRIGHT_BASE_URL: ${{ env.TEST_BASE_URL }}

--- a/.gitignore
+++ b/.gitignore
@@ -107,4 +107,6 @@ test-results/
 playwright-report/
 blob-report/
 playwright/.cache/
+# Saved authenticated session (e2e/global.setup.ts) - never commit
+e2e/.auth/
 *.egg-info/

--- a/e2e/docs/e2e-remediation-plan.md
+++ b/e2e/docs/e2e-remediation-plan.md
@@ -1,6 +1,6 @@
 # E2E Test Suite Remediation Plan
 
-> Status: **In progress** — Phase 0 complete ([PR #3409](https://github.com/onetimesecret/onetimesecret/pull/3409)); Phase 1 / PR 2 in review; **next up: PR 3 / Phase 2.**
+> Status: **In progress** — Phase 0 complete ([PR #3409](https://github.com/onetimesecret/onetimesecret/pull/3409)); Phase 1 / PR 2 in review ([PR #3411](https://github.com/onetimesecret/onetimesecret/pull/3411)); Phase 2.1+2.2 / PR 3 in review ([PR #3412](https://github.com/onetimesecret/onetimesecret/pull/3412)); **next up: PR 4 / Phase 2.3.**
 > Created: 2026-06-09 · Last updated: 2026-06-09 · Owner: TBD
 >
 > Motivation: The `container-e2e-tests` check has been a chronic source of red
@@ -17,7 +17,8 @@
 |------------|--------|-------|
 | Phase 0 / PR 1 — unblock #3399 mask-icon + this plan | ✅ **Done** | [PR #3409](https://github.com/onetimesecret/onetimesecret/pull/3409) · branch `claude/sleepy-shannon-21ko6k` |
 | Phase 1 / PR 2 — reporter/artifacts + lint-ban + flaky gate | 🔄 **In review** | [PR #3411](https://github.com/onetimesecret/onetimesecret/pull/3411) · branch `claude/affectionate-clarke-4fyakw` |
-| Phase 2 / PRs 3–5 — auth fixture, readiness signal, `networkidle` sweep, skip triage | ⏭️ **Next** | not started |
+| Phase 2.1+2.2 / PR 3 — auth setup project + app-readiness signal | 🔄 **In review** | [PR #3412](https://github.com/onetimesecret/onetimesecret/pull/3412) · branch `claude/e2e-phase2-auth-readiness` (stacked on #3411) |
+| Phase 2.3–2.4 / PRs 4–5 — `networkidle` sweep + lint→error, skip triage | ⏭️ **Next** | not started |
 | Phase 3 / PR 6 — fixtures module, pinned config, parallel/shard | ⬜ Todo | not started |
 
 > **CI-signal caveat for stacked PRs:** `container-e2e-tests` only triggers on
@@ -30,43 +31,68 @@
 > PR 3 onward: base on `develop` so each phase is exercised by the very
 > workflow it modifies.
 
-### For a fresh contributor picking up PR 3
+### For a fresh contributor picking up PR 4 (Phase 2.3: `networkidle`/sleep sweep, lint → error)
 
-1. **Verify Phases 0–1 already landed — do not redo them.** Phase 0:
-   `git log --oneline | grep -Ei "head-base|brand color"` shows the two
-   conditional-render commits. Phase 1: `pnpm lint:e2e` runs (≈341 warnings, 0
-   errors), `.github/workflows/e2e.yml` has a "Fail on flaky tests" step, and
-   `e2e/playwright.config.ts` has the environment-aware `reporter` array. If
-   any of that is missing, see [PR #3411](https://github.com/onetimesecret/onetimesecret/pull/3411).
-2. **Where to branch PR 3.** If #3411 has merged, branch off `develop`.
-   Otherwise stack on `claude/affectionate-clarke-4fyakw` — PR 3 edits
-   `e2e/playwright.config.ts` and `e2e.yml`, both touched by PR 2. Either way
-   the PR must **target `develop`** (see the CI-signal caveat above).
-3. **Concrete starting points** (verified against the tree as of Phase 1):
-   - Credential gating in `full/` is `test.skip(!hasTestCredentials, ...)`
-     driven by `TEST_USER_EMAIL` / `TEST_USER_PASSWORD` (79 sites; canonical
-     pattern at `e2e/full/cross-org-domain-isolation.spec.ts:35`). **No auth
-     fixture, `globalSetup`, or `storageState` exists anywhere yet.**
-   - `e2e/playwright.config.ts` defines a single `chromium` project — the
-     `setup` project, `dependencies: ['setup']`, and `storageState` all go
-     there.
-   - The app-readiness signal belongs right after `app.mount('#app')` in
-     `src/main.ts` (~line 25); specs currently poll `window.__BOOTSTRAP_ME__`
-     directly instead.
-   - The workflow's "Run Playwright E2E tests" step runs `e2e/all/` only and
-     seeds no credentials — extend it to `e2e/all e2e/full` and inject
-     `TEST_USER_*` env vars.
-4. **Definition of done for PR 3:** `full/` executes in CI against a seeded
-   session — red is acceptable and *expected* at first (it surfaces real,
-   previously-masked failures; quarantine via `e2e/QUARANTINE.md` rather than
-   re-skipping); the readiness signal exists and the auth/setup path waits on
-   it instead of `networkidle`.
+1. **Verify Phases 0–2.2 already landed — do not redo them.** Phase 1:
+   `pnpm lint:e2e` runs (341 warnings, 0 errors), `.github/workflows/e2e.yml`
+   has a "Fail on flaky tests" step. Phase 2.1+2.2: `e2e/global.setup.ts`
+   exists, `e2e/playwright.config.ts` has `setup`/`chromium`/`full`/
+   `full-billing` projects, and `src/main.ts` sets
+   `html[data-app-ready="true"]`. If any of that is missing, see
+   [PR #3411](https://github.com/onetimesecret/onetimesecret/pull/3411) /
+   [PR #3412](https://github.com/onetimesecret/onetimesecret/pull/3412).
+2. **Where to branch PR 4.** If #3412 has merged, branch off `develop`.
+   Otherwise stack on `claude/e2e-phase2-auth-readiness` — PR 4 sweeps the
+   spec files and flips the lint rules, and needs PR 3's readiness signal to
+   sweep *to*. Either way the PR must **target `develop`** (see the CI-signal
+   caveat above).
+3. **Concrete starting points** (verified against the tree as of PR 3):
+   - The lint baseline is **341 warnings, 0 errors** from `pnpm lint:e2e`:
+     298 `playwright/no-networkidle` + 43 `playwright/no-wait-for-timeout`.
+     By directory: `all/` 29, `auth/` 16, `full/` 262, `full-billing/` 34.
+     Sweep **per directory** (one reviewable commit each); flip both rules
+     from `'warn'` to `'error'` at `eslint.config.ts:606-607` in the final
+     commit, once the count is 0. Don't use `--quiet` to check progress — it
+     skips *executing* warn-level rules; `pnpm lint:e2e` shows them.
+   - The replacement primitive: wait on the app-readiness flag with a
+     web-first assertion —
+     `await expect(page.locator('html[data-app-ready="true"]')).toBeAttached()`.
+     Canonical usage: `e2e/global.setup.ts:53`. The flag is set in
+     `src/main.ts:47` after mount + brand theme + `router.isReady()`. For
+     waits that aren't "is the app up" (element state, URL changes), use
+     ordinary web-first assertions / `waitForURL` instead.
+   - 9 spec files also read or poll `window.__BOOTSTRAP_ME__` — some via
+     `waitForFunction` (e.g. `e2e/all/integration.spec.ts:307`), some via
+     `page.evaluate` reads (e.g. `e2e/auth/sso-csrf.spec.ts:47`); list them
+     with `grep -rl __BOOTSTRAP_ME__ e2e/all e2e/auth e2e/full`. Replace the
+     *readiness-polling* uses with the readiness flag while you're in each
+     file — that is explicitly Phase 2.2's "tests wait on that" half. (Reads
+     that inspect bootstrap *content*, like the sso-csrf shrimp checks, are
+     fine to keep.)
+   - Known interaction in `full/`: every spec still runs a manual
+     `loginUser(page)` helper (pattern at
+     `e2e/full/cross-org-domain-isolation.spec.ts:55-78`) even though the
+     `full` project now starts authenticated via `storageState`. When
+     sweeping `full/`, expect those helpers to be dead weight or actively
+     broken (an authed user visiting `/signin` gets redirected) — deleting
+     the call sites is in scope where it unblocks the sweep; broader spec
+     triage (the 143 defensive skips) stays PR 5.
+   - Check CI state of #3412 first: the first `full/` runs are *expected* red
+     (previously-masked failures). Quarantine via `e2e/QUARANTINE.md`
+     (`test.fixme` + owner + issue link) rather than re-skipping; the flaky
+     gate stays blocking.
+4. **Definition of done for PR 4:** `pnpm lint:e2e` reports **0 problems**
+   with both rules at `'error'`; no `networkidle` / `waitForTimeout` /
+   `__BOOTSTRAP_ME__`-polling call sites remain in `e2e/`; suite passes (or
+   failures are quarantined with issue links), and no test regresses to
+   pass-only-on-retry (the flaky gate enforces this).
 5. **Hand off before you open the PR.** This doc is the tracker — leave it the
    way you found it: set your row in the Progress table and the PR-sequence
    table (status + PR link), update the status line at the top, and **rewrite
-   this section for PR 4** with verified file/line starting points (don't
-   guess — confirm them against your final tree the way the pointers above
-   were). A stale pickup section costs the next contributor their first hour.
+   this section for PR 5** (defensive-skip triage, Phase 2.4) with verified
+   file/line starting points (don't guess — confirm them against your final
+   tree the way the pointers above were). A stale pickup section costs the
+   next contributor their first hour.
 
 ## Headline finding
 
@@ -205,15 +231,19 @@ CI **red**.
 
 ## Phase 2 — Make coverage real
 
-1. **Auth via global-setup + `storageState`.** `e2e/global.setup.ts` (setup
-   project) registers a test user via `/signup` (fallback: `docker exec`
-   `Onetime::Customer.create!`), logs in, saves `e2e/.auth/user.json`. Config
-   adds `setup` project; `full`/`full-billing` get `dependencies: ['setup']` +
-   `storageState`. Workflow seeds `TEST_USER_*` and runs `e2e/all e2e/full`.
-2. **Deterministic app-readiness signal.** Frontend sets
-   `document.documentElement.dataset.appReady = 'true'` after mount + brand
-   theme applied; tests wait on that, replacing `__BOOTSTRAP_ME__` polling +
-   `networkidle`. *(Highest-leverage flake fix.)*
+1. ✅ **Auth via global-setup + `storageState`** ([#3412](https://github.com/onetimesecret/onetimesecret/pull/3412)).
+   `e2e/global.setup.ts` (setup project) registers a test user via `/signup`
+   (fallback: `docker exec` `Onetime::Customer.create!` — not needed; the CI
+   container runs with `AUTH_AUTOVERIFY=true`), logs in, saves
+   `e2e/.auth/user.json`. Config adds `setup` project; `full`/`full-billing`
+   get `dependencies: ['setup']` + `storageState`. Workflow seeds ephemeral
+   `TEST_USER_*` and runs `e2e/all/ e2e/full/`.
+2. ✅ **Deterministic app-readiness signal** ([#3412](https://github.com/onetimesecret/onetimesecret/pull/3412), signal half).
+   Frontend sets `document.documentElement.dataset.appReady = 'true'` in
+   `src/main.ts` after mount + brand theme application + `router.isReady()`;
+   the setup/auth path waits on it. The other half — migrating *specs* off
+   `__BOOTSTRAP_ME__` polling + `networkidle` onto the flag — lands with the
+   PR 4 sweep. *(Highest-leverage flake fix.)*
 3. **Sweep `networkidle` → web-first assertions** (300 sites), per directory.
 4. **Convert the 143 defensive skips**: (a) guaranteed precondition → run it;
    (b) genuinely optional feature → tagged project, not runtime self-skip;
@@ -241,7 +271,7 @@ _Live status is tracked in the **Progress & how to continue** section near the t
 |----|-------|-------|---------------|
 | 1 | 0 | mask-icon conditional render + deterministic (skip-free) test + Ruby spec + CI brand-color pin | ✅ Done ([#3409](https://github.com/onetimesecret/onetimesecret/pull/3409)) — unblocks #3399 |
 | 2 | 1 | reporter/artifacts, lint rules (warn), flaky gate | 🔄 In review ([#3411](https://github.com/onetimesecret/onetimesecret/pull/3411)) |
-| 3 | 2.1+2.2 | global-setup/auth fixture + app-readiness signal | Med — surfaces real `full/` failures (intended) |
+| 3 | 2.1+2.2 | global-setup/auth fixture + app-readiness signal | 🔄 In review ([#3412](https://github.com/onetimesecret/onetimesecret/pull/3412), stacked on #3411) — surfaces real `full/` failures (intended) |
 | 4 | 2.3 | `networkidle`/sleep sweep, by directory; lint → error | Med — large but mechanical |
 | 5 | 2.4 | defensive-skip triage | Med |
 | 6 | 3 | fixtures.ts, pinned brand, parallel/shard | Low |

--- a/e2e/docs/e2e-remediation-plan.md
+++ b/e2e/docs/e2e-remediation-plan.md
@@ -1,6 +1,6 @@
 # E2E Test Suite Remediation Plan
 
-> Status: **In progress** — Phase 0 complete ([PR #3409](https://github.com/onetimesecret/onetimesecret/pull/3409)); Phase 1 / PR 2 in review ([PR #3411](https://github.com/onetimesecret/onetimesecret/pull/3411)); Phase 2.1+2.2 / PR 3 in review ([PR #3412](https://github.com/onetimesecret/onetimesecret/pull/3412)); **next up: PR 4 / Phase 2.3.**
+> Status: **In progress** — Phases 0–1 complete ([PR #3409](https://github.com/onetimesecret/onetimesecret/pull/3409), [PR #3411](https://github.com/onetimesecret/onetimesecret/pull/3411)); Phase 2.1+2.2 / PR 3 in review ([PR #3412](https://github.com/onetimesecret/onetimesecret/pull/3412)); **next up: PR 4 / Phase 2.3.**
 > Created: 2026-06-09 · Last updated: 2026-06-09 · Owner: TBD
 >
 > Motivation: The `container-e2e-tests` check has been a chronic source of red
@@ -16,8 +16,8 @@
 | Phase / PR | Status | Where |
 |------------|--------|-------|
 | Phase 0 / PR 1 — unblock #3399 mask-icon + this plan | ✅ **Done** | [PR #3409](https://github.com/onetimesecret/onetimesecret/pull/3409) · branch `claude/sleepy-shannon-21ko6k` |
-| Phase 1 / PR 2 — reporter/artifacts + lint-ban + flaky gate | 🔄 **In review** | [PR #3411](https://github.com/onetimesecret/onetimesecret/pull/3411) · branch `claude/affectionate-clarke-4fyakw` |
-| Phase 2.1+2.2 / PR 3 — auth setup project + app-readiness signal | 🔄 **In review** | [PR #3412](https://github.com/onetimesecret/onetimesecret/pull/3412) · branch `claude/e2e-phase2-auth-readiness` (stacked on #3411) |
+| Phase 1 / PR 2 — reporter/artifacts + lint-ban + flaky gate | ✅ **Done** | [PR #3411](https://github.com/onetimesecret/onetimesecret/pull/3411) · branch `claude/affectionate-clarke-4fyakw` |
+| Phase 2.1+2.2 / PR 3 — auth setup project + app-readiness signal | 🔄 **In review** | [PR #3412](https://github.com/onetimesecret/onetimesecret/pull/3412) · branch `claude/e2e-phase2-auth-readiness` (rebased onto `develop` after #3411 merged) |
 | Phase 2.3–2.4 / PRs 4–5 — `networkidle` sweep + lint→error, skip triage | ⏭️ **Next** | not started |
 | Phase 3 / PR 6 — fixtures module, pinned config, parallel/shard | ⬜ Todo | not started |
 
@@ -270,8 +270,8 @@ _Live status is tracked in the **Progress & how to continue** section near the t
 | PR | Phase | Scope | Risk / status |
 |----|-------|-------|---------------|
 | 1 | 0 | mask-icon conditional render + deterministic (skip-free) test + Ruby spec + CI brand-color pin | ✅ Done ([#3409](https://github.com/onetimesecret/onetimesecret/pull/3409)) — unblocks #3399 |
-| 2 | 1 | reporter/artifacts, lint rules (warn), flaky gate | 🔄 In review ([#3411](https://github.com/onetimesecret/onetimesecret/pull/3411)) |
-| 3 | 2.1+2.2 | global-setup/auth fixture + app-readiness signal | 🔄 In review ([#3412](https://github.com/onetimesecret/onetimesecret/pull/3412), stacked on #3411) — surfaces real `full/` failures (intended) |
+| 2 | 1 | reporter/artifacts, lint rules (warn), flaky gate | ✅ Done ([#3411](https://github.com/onetimesecret/onetimesecret/pull/3411)) |
+| 3 | 2.1+2.2 | global-setup/auth fixture + app-readiness signal | 🔄 In review ([#3412](https://github.com/onetimesecret/onetimesecret/pull/3412)) — surfaces real `full/` failures (intended) |
 | 4 | 2.3 | `networkidle`/sleep sweep, by directory; lint → error | Med — large but mechanical |
 | 5 | 2.4 | defensive-skip triage | Med |
 | 6 | 3 | fixtures.ts, pinned brand, parallel/shard | Low |

--- a/e2e/full-billing/billing-blockers.spec.ts
+++ b/e2e/full-billing/billing-blockers.spec.ts
@@ -12,7 +12,7 @@
 // - BLOCKER 10: /org/domains route broken
 //
 // Prerequisites:
-// - Set TEST_USER_EMAIL and TEST_USER_PASSWORD environment variables
+// - Authenticated via the project storageState (e2e/global.setup.ts consumes TEST_USER_*)
 // - Application running locally or PLAYWRIGHT_BASE_URL set
 //
 // Usage:
@@ -24,29 +24,6 @@
 //   PLAYWRIGHT_BASE_URL=https://dev.onetime.dev TEST_USER_EMAIL=... pnpm test:playwright billing-blockers.spec.ts
 
 import { expect, Page, test } from '@playwright/test';
-
-// Check if test credentials are configured
-const hasTestCredentials = !!(process.env.TEST_USER_EMAIL && process.env.TEST_USER_PASSWORD);
-
-/**
- * Authenticate user via login form
- */
-async function loginUser(page: Page): Promise<void> {
-  await page.goto('/signin');
-
-  const emailInput = page.locator('input[type="email"], input[name="email"]');
-  const passwordInput = page.locator('input[type="password"], input[name="password"]');
-  const submitButton = page.locator('button[type="submit"]');
-
-  if (await emailInput.isVisible()) {
-    await emailInput.fill(process.env.TEST_USER_EMAIL || 'test@example.com');
-    await passwordInput.fill(process.env.TEST_USER_PASSWORD || 'testpassword');
-    await submitButton.click();
-
-    // Wait for redirect to dashboard/account
-    await page.waitForURL(/\/(account|dashboard)/, { timeout: 30000 });
-  }
-}
 
 /**
  * Wait for API response and capture result
@@ -81,8 +58,6 @@ async function _waitForApiResponse(
 }
 
 test.describe('Stripe Integration Blockers - E2E', () => {
-  test.skip(!hasTestCredentials, 'Skipping: TEST_USER_EMAIL and TEST_USER_PASSWORD required');
-
   test.beforeEach(async ({ page }) => {
     page.setDefaultTimeout(15000);
   });
@@ -93,7 +68,6 @@ test.describe('Stripe Integration Blockers - E2E', () => {
   // ---------------------------------------------------------------------------
   test.describe('BLOCKER 1 & 2: Billing Plans Page', () => {
     test('TC-2309-001: Monthly plans tab displays available plans', async ({ page }) => {
-      await loginUser(page);
       await page.goto('/billing/plans');
 
       // Wait for page to load
@@ -129,7 +103,6 @@ test.describe('Stripe Integration Blockers - E2E', () => {
     });
 
     test('TC-2309-002: Yearly plans tab displays available plans', async ({ page }) => {
-      await loginUser(page);
       await page.goto('/billing/plans');
 
       await page.waitForLoadState('networkidle');
@@ -164,7 +137,6 @@ test.describe('Stripe Integration Blockers - E2E', () => {
     });
 
     test('Plans API returns non-empty plans array', async ({ page }) => {
-      await loginUser(page);
 
       // Intercept API call
       const apiPromise = page.waitForResponse(
@@ -188,7 +160,6 @@ test.describe('Stripe Integration Blockers - E2E', () => {
     });
 
     test('Plan cards include required information', async ({ page }) => {
-      await loginUser(page);
       await page.goto('/billing/plans');
       await page.waitForLoadState('networkidle');
 
@@ -214,7 +185,6 @@ test.describe('Stripe Integration Blockers - E2E', () => {
   // ---------------------------------------------------------------------------
   test.describe('BLOCKER 4: Dashboard Upgrade Banner', () => {
     test('TC-2309-004: Free user sees plan indicator or upgrade prompt', async ({ page }) => {
-      await loginUser(page);
       await page.goto('/dashboard');
       await page.waitForLoadState('networkidle');
 
@@ -243,7 +213,6 @@ test.describe('Stripe Integration Blockers - E2E', () => {
     });
 
     test('Upgrade link navigates to plans page', async ({ page }) => {
-      await loginUser(page);
       await page.goto('/dashboard');
       await page.waitForLoadState('networkidle');
 
@@ -265,7 +234,6 @@ test.describe('Stripe Integration Blockers - E2E', () => {
   // ---------------------------------------------------------------------------
   test.describe('BLOCKER 5: Account Settings Billing Link', () => {
     test('TC-2309-005: Account settings includes billing navigation', async ({ page }) => {
-      await loginUser(page);
       await page.goto('/account');
       await page.waitForLoadState('networkidle');
 
@@ -290,7 +258,6 @@ test.describe('Stripe Integration Blockers - E2E', () => {
     });
 
     test('Billing link navigates to billing overview', async ({ page }) => {
-      await loginUser(page);
       await page.goto('/account');
       await page.waitForLoadState('networkidle');
 
@@ -309,7 +276,6 @@ test.describe('Stripe Integration Blockers - E2E', () => {
   // ---------------------------------------------------------------------------
   test.describe('BLOCKER 6: Billing Overview Features', () => {
     test('TC-2309-006: Billing overview displays plan features', async ({ page }) => {
-      await loginUser(page);
       await page.goto('/billing/overview');
       await page.waitForLoadState('networkidle');
 
@@ -337,7 +303,6 @@ test.describe('Stripe Integration Blockers - E2E', () => {
     });
 
     test('Current plan card displays correctly', async ({ page }) => {
-      await loginUser(page);
       await page.goto('/billing/overview');
       await page.waitForLoadState('networkidle');
 
@@ -356,7 +321,6 @@ test.describe('Stripe Integration Blockers - E2E', () => {
     });
 
     test('Entitlements API returns 200', async ({ page }) => {
-      await loginUser(page);
 
       // Intercept entitlements API call
       const apiPromise = page.waitForResponse(
@@ -386,7 +350,6 @@ test.describe('Stripe Integration Blockers - E2E', () => {
   // ---------------------------------------------------------------------------
   test.describe('BLOCKER 9: Billing History Organization Resolution', () => {
     test('TC-2309-009: Billing history loads without organization error', async ({ page }) => {
-      await loginUser(page);
       await page.goto('/billing/invoices');
       await page.waitForLoadState('networkidle');
 
@@ -414,7 +377,6 @@ test.describe('Stripe Integration Blockers - E2E', () => {
     });
 
     test('Organization selector works correctly', async ({ page }) => {
-      await loginUser(page);
       await page.goto('/billing/invoices');
       await page.waitForLoadState('networkidle');
 
@@ -436,7 +398,6 @@ test.describe('Stripe Integration Blockers - E2E', () => {
   // ---------------------------------------------------------------------------
   test.describe('BLOCKER 10: Organization Domains Route', () => {
     test('TC-2309-010: /org/domains route loads correctly', async ({ page }) => {
-      await loginUser(page);
       await page.goto('/org/domains');
       await page.waitForLoadState('networkidle');
 
@@ -461,7 +422,6 @@ test.describe('Stripe Integration Blockers - E2E', () => {
     });
 
     test('Domains page accessible from organization navigation', async ({ page }) => {
-      await loginUser(page);
       await page.goto('/orgs');
       await page.waitForLoadState('networkidle');
 
@@ -490,7 +450,6 @@ test.describe('Stripe Integration Blockers - E2E', () => {
   // ---------------------------------------------------------------------------
   test.describe('Billing Navigation Integration', () => {
     test('User menu has billing option', async ({ page }) => {
-      await loginUser(page);
       await page.goto('/dashboard');
 
       // Open user menu
@@ -516,7 +475,6 @@ test.describe('Stripe Integration Blockers - E2E', () => {
     });
 
     test('Footer has Plans link', async ({ page }) => {
-      await loginUser(page);
       await page.goto('/dashboard');
       await page.waitForLoadState('networkidle');
 
@@ -533,7 +491,6 @@ test.describe('Stripe Integration Blockers - E2E', () => {
     });
 
     test('Complete upgrade flow is accessible', async ({ page }) => {
-      await loginUser(page);
 
       // Start from dashboard
       await page.goto('/dashboard');

--- a/e2e/full-billing/pending-plan-intent.spec.ts
+++ b/e2e/full-billing/pending-plan-intent.spec.ts
@@ -25,6 +25,13 @@
 
 import { test, expect, Page } from '@playwright/test';
 
+// The `full-billing` project starts every test authenticated as TEST_USER_*
+// via storageState (e2e/playwright.config.ts), but this whole file tests the
+// *unauthenticated* pricing -> signup -> checkout intent flow (an
+// authenticated visitor never sees the signup form or the signup redirects).
+// Opt out of the shared session.
+test.use({ storageState: { cookies: [], origins: [] } });
+
 /**
  * Generate a unique test email for signup
  */

--- a/e2e/full-billing/plan-switching.spec.ts
+++ b/e2e/full-billing/plan-switching.spec.ts
@@ -24,6 +24,13 @@
 
 import { test, expect, Page } from '@playwright/test';
 
+// The `full-billing` project starts every test authenticated as TEST_USER_*
+// via storageState (e2e/playwright.config.ts), but this file signs in as a
+// *subscriber* account (TEST_SUBSCRIBER_*, falling back to TEST_USER_*) via
+// the real form. Opt out of the shared session so /signin renders the form
+// instead of redirecting an already-authenticated visitor away.
+test.use({ storageState: { cookies: [], origins: [] } });
+
 // Check if subscriber credentials are configured
 const hasSubscriberCredentials = !!(
   process.env.TEST_SUBSCRIBER_EMAIL && process.env.TEST_SUBSCRIBER_PASSWORD

--- a/e2e/full-billing/pricing-flow.spec.ts
+++ b/e2e/full-billing/pricing-flow.spec.ts
@@ -22,6 +22,14 @@
 
 import { test, expect, Page } from '@playwright/test';
 
+// The `full-billing` project starts every test authenticated as TEST_USER_*
+// via storageState (e2e/playwright.config.ts), but this file tests the
+// *public* pricing page as an anonymous visitor (plan CTAs link to /signup,
+// and the navigation test asserts the "Sign in" link reaches /signin - a
+// route authenticated visitors are redirected away from). Opt out of the
+// shared session.
+test.use({ storageState: { cookies: [], origins: [] } });
+
 /**
  * Wait for the pricing page to fully load with plans
  */

--- a/e2e/full/cross-org-domain-isolation.spec.ts
+++ b/e2e/full/cross-org-domain-isolation.spec.ts
@@ -14,7 +14,7 @@
  * - The issue occurs because the domain list doesn't respect the org context from URL
  *
  * Prerequisites:
- * - Set TEST_USER_EMAIL and TEST_USER_PASSWORD environment variables
+ * - Authenticated via the project storageState (e2e/global.setup.ts consumes TEST_USER_*)
  * - User must have access to at least 2 organizations
  * - At least one org should have custom domains, another can be empty
  * - Application running locally or PLAYWRIGHT_BASE_URL set
@@ -31,9 +31,6 @@
 
 import { expect, Page, test } from '@playwright/test';
 
-// Check if test credentials are configured
-const hasTestCredentials = !!(process.env.TEST_USER_EMAIL && process.env.TEST_USER_PASSWORD);
-
 // -----------------------------------------------------------------------------
 // Types
 // -----------------------------------------------------------------------------
@@ -48,34 +45,6 @@ interface OrgInfo {
 // -----------------------------------------------------------------------------
 // Test Helpers
 // -----------------------------------------------------------------------------
-
-/**
- * Authenticate user via login form
- */
-async function loginUser(page: Page): Promise<void> {
-  await page.goto('/signin');
-
-  // Click Password tab - Magic Link is the default, password input is hidden
-  const passwordTab = page.getByRole('tab', { name: /password/i });
-  await passwordTab.waitFor({ state: 'visible', timeout: 5000 });
-  await passwordTab.click();
-
-  // Wait for password input to be visible after tab switch
-  const passwordInput = page.locator('input[type="password"]');
-  await passwordInput.waitFor({ state: 'visible', timeout: 5000 });
-
-  // Now fill the form (email input is in the password tab panel)
-  const emailInput = page.locator('#signin-email-password');
-  await emailInput.fill(process.env.TEST_USER_EMAIL || '');
-  await passwordInput.fill(process.env.TEST_USER_PASSWORD || '');
-
-  // Submit
-  const submitButton = page.locator('button[type="submit"]');
-  await submitButton.click();
-
-  // Wait for redirect to dashboard/account
-  await page.waitForURL(/\/(account|dashboard|org)/, { timeout: 30000 });
-}
 
 /**
  * Get list of organizations the user has access to
@@ -204,11 +173,8 @@ async function verifyEmptyDomainsState(page: Page): Promise<void> {
 // -----------------------------------------------------------------------------
 
 test.describe('Cross-Organization Domain Isolation', () => {
-  test.skip(!hasTestCredentials, 'Skipping: TEST_USER_EMAIL and TEST_USER_PASSWORD required');
-
   test.beforeEach(async ({ page }) => {
     page.setDefaultTimeout(15000);
-    await loginUser(page);
   });
 
   // -------------------------------------------------------------------------
@@ -600,11 +566,8 @@ test.describe('Cross-Organization Domain Isolation', () => {
 // -----------------------------------------------------------------------------
 
 test.describe('API-Level Domain Isolation', () => {
-  test.skip(!hasTestCredentials, 'Skipping: TEST_USER_EMAIL and TEST_USER_PASSWORD required');
-
   test.beforeEach(async ({ page }) => {
     page.setDefaultTimeout(15000);
-    await loginUser(page);
   });
 
   test('TC-DOI-008: API requests include correct org context parameter', async ({ page }) => {

--- a/e2e/full/domain-config-consistency.spec.ts
+++ b/e2e/full/domain-config-consistency.spec.ts
@@ -16,7 +16,7 @@
  * 5. Cross-screen consistency
  *
  * Prerequisites:
- * - Set TEST_USER_EMAIL and TEST_USER_PASSWORD environment variables
+ * - Authenticated via the project storageState (e2e/global.setup.ts consumes TEST_USER_*)
  * - User must have access to an organization with relevant entitlements
  * - At least one custom domain should exist for testing
  *
@@ -26,8 +26,6 @@
  */
 
 import { expect, Page, test } from '@playwright/test';
-
-const hasTestCredentials = !!(process.env.TEST_USER_EMAIL && process.env.TEST_USER_PASSWORD);
 
 // -----------------------------------------------------------------------------
 // Types
@@ -48,29 +46,6 @@ type ConfigScreenType = 'email' | 'sso' | 'incoming';
 // -----------------------------------------------------------------------------
 // Test Helpers
 // -----------------------------------------------------------------------------
-
-/**
- * Authenticate user via login form
- */
-async function loginUser(page: Page): Promise<void> {
-  await page.goto('/signin');
-
-  const passwordTab = page.getByRole('tab', { name: /password/i });
-  await passwordTab.waitFor({ state: 'visible', timeout: 5000 });
-  await passwordTab.click();
-
-  const passwordInput = page.locator('input[type="password"]');
-  await passwordInput.waitFor({ state: 'visible', timeout: 5000 });
-
-  const emailInput = page.locator('#signin-email-password');
-  await emailInput.fill(process.env.TEST_USER_EMAIL || '');
-  await passwordInput.fill(process.env.TEST_USER_PASSWORD || '');
-
-  const submitButton = page.locator('button[type="submit"]');
-  await submitButton.click();
-
-  await page.waitForURL(/\/(account|dashboard|org)/, { timeout: 30000 });
-}
 
 /**
  * Get the first organization the user has access to
@@ -194,11 +169,8 @@ async function getElementYPosition(element: ReturnType<Page['locator']>): Promis
 // -----------------------------------------------------------------------------
 
 test.describe('Domain Config - Toggle-Form State Coupling', () => {
-  test.skip(!hasTestCredentials, 'Skipping: TEST_USER_EMAIL and TEST_USER_PASSWORD required');
-
   test.beforeEach(async ({ page }) => {
     page.setDefaultTimeout(15000);
-    await loginUser(page);
   });
 
   test('TC-DCC-001: form fields are disabled when toggle is OFF (Incoming)', async ({ page }) => {
@@ -325,11 +297,8 @@ test.describe('Domain Config - Toggle-Form State Coupling', () => {
 // -----------------------------------------------------------------------------
 
 test.describe('Domain Config - Info Banner Visibility', () => {
-  test.skip(!hasTestCredentials, 'Skipping: TEST_USER_EMAIL and TEST_USER_PASSWORD required');
-
   test.beforeEach(async ({ page }) => {
     page.setDefaultTimeout(15000);
-    await loginUser(page);
   });
 
   test('TC-DCC-004: shows info banner when feature is disabled', async ({ page }) => {
@@ -408,11 +377,8 @@ test.describe('Domain Config - Info Banner Visibility', () => {
 // -----------------------------------------------------------------------------
 
 test.describe('Domain Config - Toggle Position and Label', () => {
-  test.skip(!hasTestCredentials, 'Skipping: TEST_USER_EMAIL and TEST_USER_PASSWORD required');
-
   test.beforeEach(async ({ page }) => {
     page.setDefaultTimeout(15000);
-    await loginUser(page);
   });
 
   test('TC-DCC-006: toggle is positioned after form fields (Incoming)', async ({ page }) => {
@@ -464,11 +430,8 @@ test.describe('Domain Config - Toggle Position and Label', () => {
 // -----------------------------------------------------------------------------
 
 test.describe('Domain Config - Cross-Screen Consistency', () => {
-  test.skip(!hasTestCredentials, 'Skipping: TEST_USER_EMAIL and TEST_USER_PASSWORD required');
-
   test.beforeEach(async ({ page }) => {
     page.setDefaultTimeout(15000);
-    await loginUser(page);
   });
 
   test('TC-DCC-008: all config screens have consistent toggle placement', async ({ page }) => {
@@ -549,11 +512,8 @@ test.describe('Domain Config - Cross-Screen Consistency', () => {
 // -----------------------------------------------------------------------------
 
 test.describe('Domain Config - Accessibility', () => {
-  test.skip(!hasTestCredentials, 'Skipping: TEST_USER_EMAIL and TEST_USER_PASSWORD required');
-
   test.beforeEach(async ({ page }) => {
     page.setDefaultTimeout(15000);
-    await loginUser(page);
   });
 
   test('TC-DCC-010: toggle has proper ARIA attributes', async ({ page }) => {

--- a/e2e/full/domain-email-config.spec.ts
+++ b/e2e/full/domain-email-config.spec.ts
@@ -13,7 +13,7 @@
  * 4. Saves or deletes configuration
  *
  * Prerequisites:
- * - Set TEST_USER_EMAIL and TEST_USER_PASSWORD environment variables
+ * - Authenticated via the project storageState (e2e/global.setup.ts consumes TEST_USER_*)
  * - User must have access to an organization with custom domains
  * - At least one custom domain should exist for testing
  *
@@ -23,8 +23,6 @@
  */
 
 import { expect, Page, test } from '@playwright/test';
-
-const hasTestCredentials = !!(process.env.TEST_USER_EMAIL && process.env.TEST_USER_PASSWORD);
 
 // -----------------------------------------------------------------------------
 // Types
@@ -43,29 +41,6 @@ interface DomainInfo {
 // -----------------------------------------------------------------------------
 // Test Helpers
 // -----------------------------------------------------------------------------
-
-/**
- * Authenticate user via login form
- */
-async function loginUser(page: Page): Promise<void> {
-  await page.goto('/signin');
-
-  const passwordTab = page.getByRole('tab', { name: /password/i });
-  await passwordTab.waitFor({ state: 'visible', timeout: 5000 });
-  await passwordTab.click();
-
-  const passwordInput = page.locator('input[type="password"]');
-  await passwordInput.waitFor({ state: 'visible', timeout: 5000 });
-
-  const emailInput = page.locator('#signin-email-password');
-  await emailInput.fill(process.env.TEST_USER_EMAIL || '');
-  await passwordInput.fill(process.env.TEST_USER_PASSWORD || '');
-
-  const submitButton = page.locator('button[type="submit"]');
-  await submitButton.click();
-
-  await page.waitForURL(/\/(account|dashboard|org)/, { timeout: 30000 });
-}
 
 /**
  * Get the first organization the user has access to
@@ -161,11 +136,8 @@ async function isToggleEnabled(toggle: ReturnType<Page['locator']>): Promise<boo
 // -----------------------------------------------------------------------------
 
 test.describe('Domain Email Config - Form Loading', () => {
-  test.skip(!hasTestCredentials, 'Skipping: TEST_USER_EMAIL and TEST_USER_PASSWORD required');
-
   test.beforeEach(async ({ page }) => {
     page.setDefaultTimeout(15000);
-    await loginUser(page);
   });
 
   test('TC-DEC-001: email config form loads successfully', async ({ page }) => {
@@ -220,11 +192,8 @@ test.describe('Domain Email Config - Form Loading', () => {
 // -----------------------------------------------------------------------------
 
 test.describe('Domain Email Config - Form Fields', () => {
-  test.skip(!hasTestCredentials, 'Skipping: TEST_USER_EMAIL and TEST_USER_PASSWORD required');
-
   test.beforeEach(async ({ page }) => {
     page.setDefaultTimeout(15000);
-    await loginUser(page);
   });
 
   test('TC-DEC-004: from_name field accepts input', async ({ page }) => {
@@ -298,11 +267,8 @@ test.describe('Domain Email Config - Form Fields', () => {
 // -----------------------------------------------------------------------------
 
 test.describe('Domain Email Config - Toggle Behavior', () => {
-  test.skip(!hasTestCredentials, 'Skipping: TEST_USER_EMAIL and TEST_USER_PASSWORD required');
-
   test.beforeEach(async ({ page }) => {
     page.setDefaultTimeout(15000);
-    await loginUser(page);
   });
 
   test('TC-DEC-008: enabled toggle is present', async ({ page }) => {
@@ -365,11 +331,8 @@ test.describe('Domain Email Config - Toggle Behavior', () => {
 // -----------------------------------------------------------------------------
 
 test.describe('Domain Email Config - Form Validation', () => {
-  test.skip(!hasTestCredentials, 'Skipping: TEST_USER_EMAIL and TEST_USER_PASSWORD required');
-
   test.beforeEach(async ({ page }) => {
     page.setDefaultTimeout(15000);
-    await loginUser(page);
   });
 
   test('TC-DEC-011: save button disabled when required fields empty', async ({ page }) => {
@@ -441,11 +404,8 @@ test.describe('Domain Email Config - Form Validation', () => {
 // -----------------------------------------------------------------------------
 
 test.describe('Domain Email Config - Save and Delete', () => {
-  test.skip(!hasTestCredentials, 'Skipping: TEST_USER_EMAIL and TEST_USER_PASSWORD required');
-
   test.beforeEach(async ({ page }) => {
     page.setDefaultTimeout(15000);
-    await loginUser(page);
   });
 
   test('TC-DEC-014: save button submits form', async ({ page }) => {
@@ -551,16 +511,12 @@ test.describe('Domain Email Config - Save and Delete', () => {
 // -----------------------------------------------------------------------------
 
 test.describe('Domain Email Config - Mobile', () => {
-  test.skip(!hasTestCredentials, 'Skipping: TEST_USER_EMAIL and TEST_USER_PASSWORD required');
-
   test.beforeEach(async ({ page }) => {
     page.setDefaultTimeout(15000);
   });
 
   test('TC-DEC-017: form is usable on mobile viewport', async ({ page }) => {
     await page.setViewportSize({ width: 375, height: 667 });
-
-    await loginUser(page);
 
     const org = await getFirstOrganization(page);
     test.skip(!org, 'Test requires at least 1 organization');

--- a/e2e/full/domain-navigation.spec.ts
+++ b/e2e/full/domain-navigation.spec.ts
@@ -9,7 +9,7 @@
  * - DomainVerify -> DomainDetail
  *
  * Prerequisites:
- * - Set TEST_USER_EMAIL and TEST_USER_PASSWORD environment variables
+ * - Authenticated via the project storageState (e2e/global.setup.ts consumes TEST_USER_*)
  * - User must have access to an organization with at least one domain
  *
  * Usage:
@@ -18,8 +18,6 @@
  */
 
 import { expect, Page, test } from '@playwright/test';
-
-const hasTestCredentials = !!(process.env.TEST_USER_EMAIL && process.env.TEST_USER_PASSWORD);
 
 // -----------------------------------------------------------------------------
 // Types
@@ -38,29 +36,6 @@ interface DomainInfo {
 // -----------------------------------------------------------------------------
 // Test Helpers
 // -----------------------------------------------------------------------------
-
-/**
- * Authenticate user via login form
- */
-async function loginUser(page: Page): Promise<void> {
-  await page.goto('/signin');
-
-  const passwordTab = page.getByRole('tab', { name: /password/i });
-  await passwordTab.waitFor({ state: 'visible', timeout: 5000 });
-  await passwordTab.click();
-
-  const passwordInput = page.locator('input[type="password"]');
-  await passwordInput.waitFor({ state: 'visible', timeout: 5000 });
-
-  const emailInput = page.locator('#signin-email-password');
-  await emailInput.fill(process.env.TEST_USER_EMAIL || '');
-  await passwordInput.fill(process.env.TEST_USER_PASSWORD || '');
-
-  const submitButton = page.locator('button[type="submit"]');
-  await submitButton.click();
-
-  await page.waitForURL(/\/(account|dashboard|org)/, { timeout: 30000 });
-}
 
 /**
  * Get the first organization the user has access to
@@ -124,11 +99,8 @@ async function clickBackButton(page: Page): Promise<void> {
 // -----------------------------------------------------------------------------
 
 test.describe('Domain Sub-page Navigation', () => {
-  test.skip(!hasTestCredentials, 'Skipping: TEST_USER_EMAIL and TEST_USER_PASSWORD required');
-
   test.beforeEach(async ({ page }) => {
     page.setDefaultTimeout(15000);
-    await loginUser(page);
   });
 
   test('TC-DN-001: SSO page back button navigates to DomainDetail', async ({ page }) => {
@@ -231,11 +203,8 @@ test.describe('Domain Sub-page Navigation', () => {
 // -----------------------------------------------------------------------------
 
 test.describe('DomainHeader External Link', () => {
-  test.skip(!hasTestCredentials, 'Skipping: TEST_USER_EMAIL and TEST_USER_PASSWORD required');
-
   test.beforeEach(async ({ page }) => {
     page.setDefaultTimeout(15000);
-    await loginUser(page);
   });
 
   test('TC-DN-004: DomainIncoming header link includes /incoming path', async ({ page }) => {

--- a/e2e/full/domain-sso-config.spec.ts
+++ b/e2e/full/domain-sso-config.spec.ts
@@ -14,7 +14,7 @@
  * 5. Tests connection -> saves config
  *
  * Prerequisites:
- * - Set TEST_USER_EMAIL and TEST_USER_PASSWORD environment variables
+ * - Authenticated via the project storageState (e2e/global.setup.ts consumes TEST_USER_*)
  * - User must have access to an organization with the manage_sso entitlement
  * - At least one custom domain should exist for testing
  *
@@ -29,9 +29,6 @@
  */
 
 import { expect, Page, test } from '@playwright/test';
-
-// Check if test credentials are configured
-const hasTestCredentials = !!(process.env.TEST_USER_EMAIL && process.env.TEST_USER_PASSWORD);
 
 // -----------------------------------------------------------------------------
 // Types
@@ -51,34 +48,6 @@ interface DomainInfo {
 // -----------------------------------------------------------------------------
 // Test Helpers
 // -----------------------------------------------------------------------------
-
-/**
- * Authenticate user via login form
- */
-async function loginUser(page: Page): Promise<void> {
-  await page.goto('/signin');
-
-  // Click Password tab - Magic Link is the default, password input is hidden
-  const passwordTab = page.getByRole('tab', { name: /password/i });
-  await passwordTab.waitFor({ state: 'visible', timeout: 5000 });
-  await passwordTab.click();
-
-  // Wait for password input to be visible after tab switch
-  const passwordInput = page.locator('input[type="password"]');
-  await passwordInput.waitFor({ state: 'visible', timeout: 5000 });
-
-  // Fill the form
-  const emailInput = page.locator('#signin-email-password');
-  await emailInput.fill(process.env.TEST_USER_EMAIL || '');
-  await passwordInput.fill(process.env.TEST_USER_PASSWORD || '');
-
-  // Submit
-  const submitButton = page.locator('button[type="submit"]');
-  await submitButton.click();
-
-  // Wait for redirect to dashboard/account
-  await page.waitForURL(/\/(account|dashboard|org)/, { timeout: 30000 });
-}
 
 /**
  * Get the first organization the user has access to
@@ -197,11 +166,8 @@ async function navigateToDomainSsoPage(
 // -----------------------------------------------------------------------------
 
 test.describe('Domain SSO Configuration - Navigation', () => {
-  test.skip(!hasTestCredentials, 'Skipping: TEST_USER_EMAIL and TEST_USER_PASSWORD required');
-
   test.beforeEach(async ({ page }) => {
     page.setDefaultTimeout(15000);
-    await loginUser(page);
   });
 
   test('TC-DSSO-001: navigates from org settings SSO tab to domain SSO page', async ({ page }) => {
@@ -279,11 +245,8 @@ test.describe('Domain SSO Configuration - Navigation', () => {
 // -----------------------------------------------------------------------------
 
 test.describe('Domain SSO Configuration - Domain List', () => {
-  test.skip(!hasTestCredentials, 'Skipping: TEST_USER_EMAIL and TEST_USER_PASSWORD required');
-
   test.beforeEach(async ({ page }) => {
     page.setDefaultTimeout(15000);
-    await loginUser(page);
   });
 
   test('TC-DSSO-004: displays list of domains with SSO status badges', async ({ page }) => {
@@ -380,11 +343,8 @@ test.describe('Domain SSO Configuration - Domain List', () => {
 // -----------------------------------------------------------------------------
 
 test.describe('Domain SSO Configuration - Form', () => {
-  test.skip(!hasTestCredentials, 'Skipping: TEST_USER_EMAIL and TEST_USER_PASSWORD required');
-
   test.beforeEach(async ({ page }) => {
     page.setDefaultTimeout(15000);
-    await loginUser(page);
   });
 
   test('TC-DSSO-008: shows empty form for domain without SSO config', async ({ page }) => {
@@ -540,11 +500,8 @@ test.describe('Domain SSO Configuration - Form', () => {
 // -----------------------------------------------------------------------------
 
 test.describe('Domain SSO Configuration - Test Connection', () => {
-  test.skip(!hasTestCredentials, 'Skipping: TEST_USER_EMAIL and TEST_USER_PASSWORD required');
-
   test.beforeEach(async ({ page }) => {
     page.setDefaultTimeout(15000);
-    await loginUser(page);
   });
 
   test('TC-DSSO-013: test connection button sends test request', async ({ page }) => {
@@ -705,11 +662,8 @@ test.describe('Domain SSO Configuration - Test Connection', () => {
 // -----------------------------------------------------------------------------
 
 test.describe('Domain SSO Configuration - Save and Delete', () => {
-  test.skip(!hasTestCredentials, 'Skipping: TEST_USER_EMAIL and TEST_USER_PASSWORD required');
-
   test.beforeEach(async ({ page }) => {
     page.setDefaultTimeout(15000);
-    await loginUser(page);
   });
 
   test('TC-DSSO-016: save button creates new SSO config', async ({ page }) => {
@@ -834,11 +788,8 @@ test.describe('Domain SSO Configuration - Save and Delete', () => {
 // -----------------------------------------------------------------------------
 
 test.describe('Domain SSO Configuration - Multi-Domain', () => {
-  test.skip(!hasTestCredentials, 'Skipping: TEST_USER_EMAIL and TEST_USER_PASSWORD required');
-
   test.beforeEach(async ({ page }) => {
     page.setDefaultTimeout(15000);
-    await loginUser(page);
   });
 
   test('TC-DSSO-018: can configure different SSO providers for two domains in same org', async ({
@@ -959,11 +910,8 @@ test.describe('Domain SSO Configuration - Multi-Domain', () => {
 // -----------------------------------------------------------------------------
 
 test.describe('Domain SSO Configuration - Access Control', () => {
-  test.skip(!hasTestCredentials, 'Skipping: TEST_USER_EMAIL and TEST_USER_PASSWORD required');
-
   test.beforeEach(async ({ page }) => {
     page.setDefaultTimeout(15000);
-    await loginUser(page);
   });
 
   test('TC-DSSO-019: shows access denied for users without manage_sso entitlement', async ({

--- a/e2e/full/domain-sso-multi-provider.spec.ts
+++ b/e2e/full/domain-sso-multi-provider.spec.ts
@@ -15,7 +15,7 @@
  * This validates the architecture that SSO config is scoped to domain, not org.
  *
  * Prerequisites:
- * - Set TEST_USER_EMAIL and TEST_USER_PASSWORD environment variables
+ * - Authenticated via the project storageState (e2e/global.setup.ts consumes TEST_USER_*)
  * - User must have access to an organization with manage_sso entitlement
  * - Organization must have at least 2 custom domains
  *
@@ -30,9 +30,6 @@
  */
 
 import { expect, Page, test } from '@playwright/test';
-
-// Check if test credentials are configured
-const hasTestCredentials = !!(process.env.TEST_USER_EMAIL && process.env.TEST_USER_PASSWORD);
 
 // -----------------------------------------------------------------------------
 // Types
@@ -64,34 +61,6 @@ interface SsoConfigData {
 // -----------------------------------------------------------------------------
 // Test Helpers
 // -----------------------------------------------------------------------------
-
-/**
- * Authenticate user via login form
- */
-async function loginUser(page: Page): Promise<void> {
-  await page.goto('/signin');
-
-  // Click Password tab - Magic Link is the default, password input is hidden
-  const passwordTab = page.getByRole('tab', { name: /password/i });
-  await passwordTab.waitFor({ state: 'visible', timeout: 5000 });
-  await passwordTab.click();
-
-  // Wait for password input to be visible after tab switch
-  const passwordInput = page.locator('input[type="password"]');
-  await passwordInput.waitFor({ state: 'visible', timeout: 5000 });
-
-  // Fill the form
-  const emailInput = page.locator('#signin-email-password');
-  await emailInput.fill(process.env.TEST_USER_EMAIL || '');
-  await passwordInput.fill(process.env.TEST_USER_PASSWORD || '');
-
-  // Submit
-  const submitButton = page.locator('button[type="submit"]');
-  await submitButton.click();
-
-  // Wait for redirect to dashboard/account
-  await page.waitForURL(/\/(account|dashboard|org)/, { timeout: 30000 });
-}
 
 /**
  * Get the first organization the user has access to
@@ -327,11 +296,8 @@ async function setupDomainSsoMock(
 // -----------------------------------------------------------------------------
 
 test.describe('Multi-Domain SSO - Different Providers per Domain', () => {
-  test.skip(!hasTestCredentials, 'Skipping: TEST_USER_EMAIL and TEST_USER_PASSWORD required');
-
   test.beforeEach(async ({ page }) => {
     page.setDefaultTimeout(15000);
-    await loginUser(page);
   });
 
   test('TC-MPROV-001: configure Entra ID for first domain and Google for second domain', async ({
@@ -603,11 +569,8 @@ test.describe('Multi-Domain SSO - Different Providers per Domain', () => {
 // -----------------------------------------------------------------------------
 
 test.describe('Multi-Domain SSO - SSO Hub Display', () => {
-  test.skip(!hasTestCredentials, 'Skipping: TEST_USER_EMAIL and TEST_USER_PASSWORD required');
-
   test.beforeEach(async ({ page }) => {
     page.setDefaultTimeout(15000);
-    await loginUser(page);
   });
 
   test('TC-MPROV-005: SSO hub displays all organization domains', async ({ page }) => {
@@ -700,11 +663,8 @@ test.describe('Multi-Domain SSO - SSO Hub Display', () => {
 // -----------------------------------------------------------------------------
 
 test.describe('Multi-Domain SSO - Provider-Specific Fields', () => {
-  test.skip(!hasTestCredentials, 'Skipping: TEST_USER_EMAIL and TEST_USER_PASSWORD required');
-
   test.beforeEach(async ({ page }) => {
     page.setDefaultTimeout(15000);
-    await loginUser(page);
   });
 
   test('TC-MPROV-008: Entra ID requires tenant_id field', async ({ page }) => {
@@ -820,11 +780,8 @@ test.describe('Multi-Domain SSO - Provider-Specific Fields', () => {
 // -----------------------------------------------------------------------------
 
 test.describe('Multi-Domain SSO - Configuration Isolation', () => {
-  test.skip(!hasTestCredentials, 'Skipping: TEST_USER_EMAIL and TEST_USER_PASSWORD required');
-
   test.beforeEach(async ({ page }) => {
     page.setDefaultTimeout(15000);
-    await loginUser(page);
   });
 
   test('TC-MPROV-012: domain A config is not visible on domain B page', async ({ page }) => {

--- a/e2e/full/domains-store-org-cache.spec.ts
+++ b/e2e/full/domains-store-org-cache.spec.ts
@@ -11,8 +11,7 @@
  * requested org differs from the cached org.
  *
  * Prerequisites:
- * - TEST_USER_EMAIL=domaincontext@onetime.dev
- * - TEST_USER_PASSWORD from environment variable
+ * - Authenticated via the project storageState (e2e/global.setup.ts consumes TEST_USER_*)
  * - User must have 2 organizations:
  *   - "Default Workspace" with custom domains
  *   - "A Second Organization" with no custom domains
@@ -26,12 +25,6 @@
  */
 
 import { expect, Page, Request, test } from '@playwright/test';
-
-// Check if test credentials are configured
-const hasTestCredentials = !!(process.env.TEST_USER_EMAIL && process.env.TEST_USER_PASSWORD);
-
-// Test user should be domaincontext@onetime.dev per requirements
-const TEST_USER_EMAIL = process.env.TEST_USER_EMAIL || 'domaincontext@onetime.dev';
 
 // -----------------------------------------------------------------------------
 // Types
@@ -53,34 +46,6 @@ interface ApiCallInfo {
 // -----------------------------------------------------------------------------
 // Test Helpers
 // -----------------------------------------------------------------------------
-
-/**
- * Authenticate user via login form
- */
-async function loginUser(page: Page): Promise<void> {
-  await page.goto('/signin');
-
-  // Click Password tab - Magic Link is the default, password input is hidden
-  const passwordTab = page.getByRole('tab', { name: /password/i });
-  await passwordTab.waitFor({ state: 'visible', timeout: 5000 });
-  await passwordTab.click();
-
-  // Wait for password input to be visible after tab switch
-  const passwordInput = page.locator('input[type="password"]');
-  await passwordInput.waitFor({ state: 'visible', timeout: 5000 });
-
-  // Now fill the form (email input is in the password tab panel)
-  const emailInput = page.locator('#signin-email-password');
-  await emailInput.fill(TEST_USER_EMAIL);
-  await passwordInput.fill(process.env.TEST_USER_PASSWORD || '');
-
-  // Submit
-  const submitButton = page.locator('button[type="submit"]');
-  await submitButton.click();
-
-  // Wait for redirect to dashboard/account
-  await page.waitForURL(/\/(account|dashboard|org)/, { timeout: 30000 });
-}
 
 /**
  * Get list of organizations the user has access to
@@ -268,11 +233,8 @@ function extractOrgIdFromRequest(request: Request): string | null {
 // -----------------------------------------------------------------------------
 
 test.describe('DomainsStore Org Context Cache Fix', () => {
-  test.skip(!hasTestCredentials, 'Skipping: TEST_USER_EMAIL and TEST_USER_PASSWORD required');
-
   test.beforeEach(async ({ page }) => {
     page.setDefaultTimeout(15000);
-    await loginUser(page);
   });
 
   // ---------------------------------------------------------------------------
@@ -577,11 +539,8 @@ test.describe('DomainsStore Org Context Cache Fix', () => {
 // -----------------------------------------------------------------------------
 
 test.describe('DomainsStore Cache - Edge Cases', () => {
-  test.skip(!hasTestCredentials, 'Skipping: TEST_USER_EMAIL and TEST_USER_PASSWORD required');
-
   test.beforeEach(async ({ page }) => {
     page.setDefaultTimeout(15000);
-    await loginUser(page);
   });
 
   test('TC-DSC-004: Browser back/forward maintains correct org domain context', async ({

--- a/e2e/full/identifier-url-patterns.spec.ts
+++ b/e2e/full/identifier-url-patterns.spec.ts
@@ -14,7 +14,7 @@
 //   - md: Metadata (e.g., mdx7y4z1)
 //
 // Prerequisites:
-//   - Set TEST_USER_EMAIL and TEST_USER_PASSWORD environment variables
+//   - Authenticated via the project storageState (e2e/global.setup.ts consumes TEST_USER_*)
 //   - Application running locally or PLAYWRIGHT_BASE_URL set
 //   - User should have at least one organization and optionally domains
 //
@@ -35,9 +35,6 @@ declare global {
     };
   }
 }
-
-// Check if test credentials are configured
-const hasTestCredentials = !!(process.env.TEST_USER_EMAIL && process.env.TEST_USER_PASSWORD);
 
 // -----------------------------------------------------------------------------
 // Identifier Pattern Constants
@@ -78,26 +75,6 @@ const PATTERNS = {
 // -----------------------------------------------------------------------------
 // Test Helpers
 // -----------------------------------------------------------------------------
-
-/**
- * Authenticate user via login form
- */
-async function loginUser(page: Page): Promise<void> {
-  await page.goto('/signin');
-
-  const emailInput = page.locator('input[type="email"], input[name="email"]');
-  const passwordInput = page.locator('input[type="password"], input[name="password"]');
-  const submitButton = page.locator('button[type="submit"]');
-
-  if (await emailInput.isVisible()) {
-    await emailInput.fill(process.env.TEST_USER_EMAIL || 'test@example.com');
-    await passwordInput.fill(process.env.TEST_USER_PASSWORD || 'testpassword');
-    await submitButton.click();
-
-    // Wait for redirect to dashboard/account
-    await page.waitForURL(/\/(account|dashboard)/, { timeout: 30000 });
-  }
-}
 
 /**
  * Check if a URL path contains a UUID (internal ID format)
@@ -167,11 +144,8 @@ function extractIdentifiers(url: string): string[] {
 // -----------------------------------------------------------------------------
 
 test.describe('Opaque Identifier Pattern - URL Security', () => {
-  test.skip(!hasTestCredentials, 'Skipping: TEST_USER_EMAIL and TEST_USER_PASSWORD required');
-
   test.beforeEach(async ({ page }) => {
     page.setDefaultTimeout(15000);
-    await loginUser(page);
   });
 
   // -------------------------------------------------------------------------
@@ -495,11 +469,8 @@ test.describe('Opaque Identifier Pattern - URL Security', () => {
 // -----------------------------------------------------------------------------
 
 test.describe('Opaque Identifier Pattern - Security Validation', () => {
-  test.skip(!hasTestCredentials, 'Skipping: TEST_USER_EMAIL and TEST_USER_PASSWORD required');
-
   test.beforeEach(async ({ page }) => {
     page.setDefaultTimeout(15000);
-    await loginUser(page);
   });
 
   test('TC-ID-040: No internal IDs exposed in network requests', async ({ page }) => {
@@ -619,11 +590,8 @@ test.describe('Opaque Identifier Pattern - Security Validation', () => {
 // -----------------------------------------------------------------------------
 
 test.describe('Opaque Identifier Pattern - Format Consistency', () => {
-  test.skip(!hasTestCredentials, 'Skipping: TEST_USER_EMAIL and TEST_USER_PASSWORD required');
-
   test.beforeEach(async ({ page }) => {
     page.setDefaultTimeout(15000);
-    await loginUser(page);
   });
 
   test('TC-ID-050: Organization ExtIds consistently use "on" prefix', async ({ page }) => {
@@ -728,11 +696,8 @@ test.describe('Opaque Identifier Pattern - Format Consistency', () => {
 // -----------------------------------------------------------------------------
 
 test.describe('Opaque Identifier Pattern - Regression Prevention', () => {
-  test.skip(!hasTestCredentials, 'Skipping: TEST_USER_EMAIL and TEST_USER_PASSWORD required');
-
   test.beforeEach(async ({ page }) => {
     page.setDefaultTimeout(15000);
-    await loginUser(page);
   });
 
   test('TC-ID-060: Verify window state uses correct ID fields', async ({ page }) => {

--- a/e2e/full/invitation-email-mismatch-acknowledgment.spec.ts
+++ b/e2e/full/invitation-email-mismatch-acknowledgment.spec.ts
@@ -16,7 +16,9 @@
  * 3. "Continue as" triggers logout and redirect to invite page
  *
  * Prerequisites:
- * - Set TEST_USER_EMAIL, TEST_USER_PASSWORD environment variables
+ * - Authenticated as the org owner via the project storageState
+ *   (e2e/global.setup.ts consumes TEST_USER_*); multi-context scenarios sign
+ *   in manually inside fresh (unauthenticated) browser contexts
  * - Application running locally or PLAYWRIGHT_BASE_URL set
  *
  * Usage:
@@ -38,7 +40,11 @@ const generateTestEmail = (prefix: string) =>
 // -----------------------------------------------------------------------------
 
 /**
- * Authenticate user via login form using password tab
+ * Authenticate user via login form using password tab.
+ *
+ * Only valid on pages from a fresh `browser.newContext()` (unauthenticated):
+ * the default `page` fixture already carries the storageState session, and
+ * an authenticated visitor to /signin is redirected away from the form.
  */
 async function loginUser(page: Page, email?: string, password?: string): Promise<void> {
   await page.goto('/signin');
@@ -286,15 +292,11 @@ test.describe('MISMATCH-003: Continue As Triggers Logout', () => {
 // -----------------------------------------------------------------------------
 
 test.describe('MISMATCH-004: Unauthenticated User Sees Inline Auth Forms', () => {
-  test.skip(!hasTestCredentials, 'Skipping: TEST_USER_EMAIL and TEST_USER_PASSWORD required');
-
   test('When unauthenticated, shows signup or signin inline form (no mismatch)', async ({
     page,
     context,
   }) => {
-    await loginUser(page);
-
-    // Get current user's email
+    // Get the current (storageState) user's email
     const bootstrapResponse = await page.request.get('/api/v2/bootstrap/authenticated');
     const bootstrapData = await bootstrapResponse.json();
     const currentEmail = bootstrapData.record?.email;

--- a/e2e/full/invite-flow-states.spec.ts
+++ b/e2e/full/invite-flow-states.spec.ts
@@ -18,7 +18,9 @@
  * - Strict email binding (no acknowledge_email_mismatch option)
  *
  * Prerequisites:
- * - Set TEST_USER_EMAIL, TEST_USER_PASSWORD environment variables for org owner
+ * - Authenticated as the org owner via the project storageState
+ *   (e2e/global.setup.ts consumes TEST_USER_*); multi-context scenarios sign
+ *   in manually inside fresh (unauthenticated) browser contexts
  * - Application running locally or PLAYWRIGHT_BASE_URL set
  *
  * Usage:
@@ -40,7 +42,11 @@ const generateTestEmail = (prefix: string) =>
 // -----------------------------------------------------------------------------
 
 /**
- * Authenticate user via login form using password tab
+ * Authenticate user via login form using password tab.
+ *
+ * Only valid on pages from a fresh `browser.newContext()` (unauthenticated):
+ * the default `page` fixture already carries the storageState session, and
+ * an authenticated visitor to /signin is redirected away from the form.
  */
 async function loginUser(page: Page, email?: string, password?: string): Promise<void> {
   await page.goto('/signin');
@@ -145,11 +151,8 @@ async function getInvitationToken(page: Page, email: string): Promise<string | n
 // -----------------------------------------------------------------------------
 
 test.describe('INV-001: New User Atomic Signup Flow', () => {
-  test.skip(!hasTestCredentials, 'Skipping: TEST_USER_EMAIL and TEST_USER_PASSWORD required');
-
   test('new user can signup and join organization atomically', async ({ page, context }) => {
-    // Setup: Login as org owner and create invitation for new email
-    await loginUser(page);
+    // Setup: create an invitation for a new email (storageState session is the org owner)
     const invitedEmail = generateTestEmail('new-user-signup');
     const testPassword = 'TestPassword123!';
 
@@ -504,12 +507,8 @@ test.describe('INV-007: Wrong Email State', () => {
 // -----------------------------------------------------------------------------
 
 test.describe('INV-008: Already Member State', () => {
-  test.skip(!hasTestCredentials, 'Skipping: TEST_USER_EMAIL and TEST_USER_PASSWORD required');
-
   test('already member shows info message', async ({ page }) => {
-    // Login as org owner (who is already a member of their org)
-    await loginUser(page);
-
+    // The storageState session is the org owner (already a member of their org)
     // Get owner's email
     const bootstrapResponse = await page.request.get('/api/v2/bootstrap/authenticated');
     const bootstrapData = await bootstrapResponse.json();
@@ -585,11 +584,8 @@ test.describe('INV-010: Invalid Token State', () => {
     await expect(invitationDetails).not.toBeVisible();
   });
 
-  test.skip(!hasTestCredentials, 'Skipping: TEST_USER_EMAIL and TEST_USER_PASSWORD required');
-
   test('revoked invitation link becomes invalid', async ({ page, context }) => {
-    // Login and create an invitation
-    await loginUser(page);
+    // Create an invitation (storageState session is the org owner)
     const testEmail = generateTestEmail('revoke-test');
     await navigateToOrgTeam(page);
     await createInvitation(page, testEmail);
@@ -624,11 +620,8 @@ test.describe('INV-010: Invalid Token State', () => {
 // -----------------------------------------------------------------------------
 
 test.describe('Invite Flow State Transitions', () => {
-  test.skip(!hasTestCredentials, 'Skipping: TEST_USER_EMAIL and TEST_USER_PASSWORD required');
-
   test('loading state shows spinner during fetch', async ({ page, context }) => {
     // Create invitation first
-    await loginUser(page);
     const testEmail = generateTestEmail('loading-test');
     await navigateToOrgTeam(page);
     await createInvitation(page, testEmail);
@@ -661,7 +654,6 @@ test.describe('Invite Flow State Transitions', () => {
 
   test('invitation context displays organization info', async ({ page, context }) => {
     // Create invitation
-    await loginUser(page);
     const testEmail = generateTestEmail('context-test');
     await navigateToOrgTeam(page);
     await createInvitation(page, testEmail);

--- a/e2e/full/invite-token-security.spec.ts
+++ b/e2e/full/invite-token-security.spec.ts
@@ -22,7 +22,8 @@
  * - SEC-INV-005: Email-mismatched invite_token does NOT auto-login
  *
  * Prerequisites:
- * - Set TEST_USER_EMAIL, TEST_USER_PASSWORD environment variables for org owner
+ * - Authenticated as the org owner via the project storageState
+ *   (e2e/global.setup.ts consumes TEST_USER_*)
  * - Application running locally or PLAYWRIGHT_BASE_URL set
  *
  * Usage:
@@ -32,9 +33,6 @@
 
 import { expect, Page, test } from '@playwright/test';
 
-// Check if test credentials are configured
-const hasTestCredentials = !!(process.env.TEST_USER_EMAIL && process.env.TEST_USER_PASSWORD);
-
 // Generate unique email addresses for test isolation
 const generateTestEmail = (prefix: string) =>
   `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}@test.onetimesecret.com`;
@@ -42,34 +40,6 @@ const generateTestEmail = (prefix: string) =>
 // -----------------------------------------------------------------------------
 // Test Helpers
 // -----------------------------------------------------------------------------
-
-/**
- * Authenticate user via login form using password tab
- */
-async function loginUser(page: Page, email?: string, password?: string): Promise<void> {
-  await page.goto('/signin');
-
-  // Click Password tab - Magic Link is the default, password input is hidden
-  const passwordTab = page.getByRole('tab', { name: /password/i });
-  await passwordTab.waitFor({ state: 'visible', timeout: 5000 });
-  await passwordTab.click();
-
-  // Wait for password input to be visible after tab switch
-  const passwordInput = page.locator('input[type="password"]');
-  await passwordInput.waitFor({ state: 'visible', timeout: 5000 });
-
-  // Fill the form
-  const emailInput = page.locator('#signin-email-password');
-  await emailInput.fill(email || process.env.TEST_USER_EMAIL || '');
-  await passwordInput.fill(password || process.env.TEST_USER_PASSWORD || '');
-
-  // Submit
-  const submitButton = page.locator('button[type="submit"]');
-  await submitButton.click();
-
-  // Wait for redirect to dashboard/account
-  await page.waitForURL(/\/(account|dashboard|org)/, { timeout: 30000 });
-}
 
 /**
  * Navigate to organization team settings page
@@ -194,6 +164,10 @@ async function createAccountViaAPI(
 
 test.describe('SEC-INV-001: Garbage invite_token does NOT auto-login', () => {
   test('signup with garbage invite_token leaves user unauthenticated', async ({ page }) => {
+    // The full project starts authenticated via storageState; this scenario
+    // asserts an *unauthenticated* outcome, so drop that session first.
+    await page.context().clearCookies();
+
     const testEmail = generateTestEmail('garbage-token');
     const testPassword = 'TestPassword123!';
     const garbageToken = 'nonexistent_garbage_token_' + Date.now();
@@ -229,6 +203,10 @@ test.describe('SEC-INV-002: Garbage invite_token does NOT suppress verification'
   test('signup with garbage invite_token results in unverified account state', async ({
     page,
   }) => {
+    // The full project starts authenticated via storageState; this scenario
+    // asserts an *unauthenticated* outcome, so drop that session first.
+    await page.context().clearCookies();
+
     const testEmail = generateTestEmail('verify-not-suppressed');
     const testPassword = 'TestPassword123!';
     const garbageToken = 'fake_token_should_not_suppress_' + Date.now();
@@ -292,14 +270,11 @@ test.describe('SEC-INV-002: Garbage invite_token does NOT suppress verification'
 // -----------------------------------------------------------------------------
 
 test.describe('SEC-INV-003: Valid invite_token auto-login works', () => {
-  test.skip(!hasTestCredentials, 'Skipping: TEST_USER_EMAIL and TEST_USER_PASSWORD required');
-
   test('signup with valid invite_token auto-logs-in and auto-verifies the user', async ({
     page,
     context,
   }) => {
-    // Step 1: Login as org owner and create a valid invitation
-    await loginUser(page);
+    // Step 1: create a valid invitation (storageState session is the org owner)
     const invitedEmail = generateTestEmail('valid-token-autologin');
     const testPassword = 'TestPassword123!';
 

--- a/e2e/full/mfa-bootstrap-reactivity.spec.ts
+++ b/e2e/full/mfa-bootstrap-reactivity.spec.ts
@@ -27,6 +27,13 @@
 
 import { test, expect, Page } from '@playwright/test';
 
+// The `full` project starts every test authenticated as TEST_USER_* via
+// storageState (e2e/playwright.config.ts), but this file exercises the
+// sign-in flow itself with a *different*, MFA-enrolled account
+// (TEST_MFA_USER_*). Opt out of the shared session so /signin renders the
+// form instead of redirecting an already-authenticated visitor away.
+test.use({ storageState: { cookies: [], origins: [] } });
+
 // Check if MFA test credentials are configured
 const hasMfaCredentials = !!(
   process.env.TEST_MFA_USER_EMAIL &&

--- a/e2e/full/org-invitation-flow.spec.ts
+++ b/e2e/full/org-invitation-flow.spec.ts
@@ -14,7 +14,10 @@
  * Issue: https://github.com/onetimesecret/onetimesecret/issues/2319
  *
  * Prerequisites:
- * - Set TEST_USER_EMAIL, TEST_USER_PASSWORD environment variables for org owner
+ * - Authenticated as the org owner via the project storageState
+ *   (e2e/global.setup.ts consumes TEST_USER_*); the multi-context scenarios
+ *   below additionally sign in manually inside fresh (unauthenticated)
+ *   browser contexts
  * - Application running locally or PLAYWRIGHT_BASE_URL set
  * - Mailpit or similar for email testing (optional for full flow)
  *
@@ -47,7 +50,11 @@ const generateTestEmail = (prefix: string) =>
 // -----------------------------------------------------------------------------
 
 /**
- * Authenticate user via login form using password tab
+ * Authenticate user via login form using password tab.
+ *
+ * Only valid on pages from a fresh `browser.newContext()` (unauthenticated):
+ * the default `page` fixture already carries the storageState session, and
+ * an authenticated visitor to /signin is redirected away from the form.
  */
 async function loginUser(page: Page, email?: string, password?: string): Promise<void> {
   await page.goto('/signin');
@@ -182,11 +189,8 @@ async function _createAccount(page: Page, email: string, password: string): Prom
 // -----------------------------------------------------------------------------
 
 test.describe('INV-001: Organization Invitation Sending', () => {
-  test.skip(!hasTestCredentials, 'Skipping: TEST_USER_EMAIL and TEST_USER_PASSWORD required');
-
   test.beforeEach(async ({ page }) => {
     page.setDefaultTimeout(15000);
-    await loginUser(page);
   });
 
   test('Organization owner can send invitation to new member with email validation', async ({
@@ -235,14 +239,11 @@ test.describe('INV-001: Organization Invitation Sending', () => {
 // -----------------------------------------------------------------------------
 
 test.describe('INV-002: Unauthenticated User Inline Auth Flow', () => {
-  test.skip(!hasTestCredentials, 'Skipping: TEST_USER_EMAIL and TEST_USER_PASSWORD required');
-
   test('Unauthenticated user sees inline signup/signin form on invitation page', async ({
     page,
     context,
   }) => {
     // First, create an invitation as org owner
-    await loginUser(page);
     const testEmail = generateTestEmail('inline-auth-test');
     await navigateToOrgTeam(page);
     await createInvitation(page, testEmail);
@@ -445,11 +446,8 @@ test.describe('INV-005: Matching Email User Flow', () => {
 // -----------------------------------------------------------------------------
 
 test.describe('INV-007a: Authenticated Decline Flow', () => {
-  test.skip(!hasTestCredentials, 'Skipping: TEST_USER_EMAIL and TEST_USER_PASSWORD required');
-
   test('Authenticated user can decline invitation and is redirected home', async ({ page }) => {
     // Create invitation
-    await loginUser(page);
     const testEmail = generateTestEmail('decline-auth');
     await navigateToOrgTeam(page);
     await createInvitation(page, testEmail);
@@ -473,14 +471,11 @@ test.describe('INV-007a: Authenticated Decline Flow', () => {
 });
 
 test.describe('INV-007b: Unauthenticated Decline Flow', () => {
-  test.skip(!hasTestCredentials, 'Skipping: TEST_USER_EMAIL and TEST_USER_PASSWORD required');
-
   test('Unauthenticated user can decline invitation without signing in', async ({
     page,
     context,
   }) => {
     // Create invitation as owner
-    await loginUser(page);
     const testEmail = generateTestEmail('decline-unauth');
     await navigateToOrgTeam(page);
     await createInvitation(page, testEmail);
@@ -533,10 +528,7 @@ test.describe('INV-008: Expired Invitation', () => {
 // -----------------------------------------------------------------------------
 
 test.describe('INV-010: Resend Invitation', () => {
-  test.skip(!hasTestCredentials, 'Skipping: TEST_USER_EMAIL and TEST_USER_PASSWORD required');
-
   test('Organization owner can resend pending invitation', async ({ page }) => {
-    await loginUser(page);
     const testEmail = generateTestEmail('resend');
 
     await navigateToOrgTeam(page);
@@ -560,13 +552,10 @@ test.describe('INV-010: Resend Invitation', () => {
 });
 
 test.describe('INV-011: Revoke Invitation', () => {
-  test.skip(!hasTestCredentials, 'Skipping: TEST_USER_EMAIL and TEST_USER_PASSWORD required');
-
   test('Organization owner can revoke pending invitation making link invalid', async ({
     page,
     context,
   }) => {
-    await loginUser(page);
     const testEmail = generateTestEmail('revoke');
 
     await navigateToOrgTeam(page);
@@ -632,10 +621,7 @@ test.describe('INV-012: Gmail Alias Normalization', () => {
 // -----------------------------------------------------------------------------
 
 test.describe('INV-014: Duplicate Member Invitation', () => {
-  test.skip(!hasTestCredentials, 'Skipping: TEST_USER_EMAIL and TEST_USER_PASSWORD required');
-
   test('Inviting existing organization member shows validation error', async ({ page }) => {
-    await loginUser(page);
 
     await navigateToOrgTeam(page);
 
@@ -687,6 +673,11 @@ test.describe('INV-016: Invalid Token', () => {
 
 test.describe('INV-SEC-001: Open Redirect Prevention', () => {
   test('Open redirect attack prevention validates redirect parameter', async ({ page }) => {
+    // This test exercises the *login form's* redirect handling, so drop the
+    // storageState session first - an authenticated visitor to /signin is
+    // redirected away and the form (with its assertions) never renders.
+    await page.context().clearCookies();
+
     // Attempt to use malicious redirect URL
     const maliciousRedirects = [
       'https://evil.com/phishing',

--- a/e2e/full/org-switcher-navigation.spec.ts
+++ b/e2e/full/org-switcher-navigation.spec.ts
@@ -11,7 +11,7 @@
 // navigates to the equivalent page for the new org.
 //
 // Prerequisites:
-// - Set TEST_USER_EMAIL and TEST_USER_PASSWORD environment variables
+// - Authenticated via the project storageState (e2e/global.setup.ts consumes TEST_USER_*)
 // - Test user must have at least 2 organizations
 // - Test user: domaincontext@onetime.dev (has "Default Workspace" and "A Second Organization")
 // - Base URL: https://dev.onetime.dev (or PLAYWRIGHT_BASE_URL)
@@ -24,9 +24,6 @@
 //
 
 import { expect, Page, test } from '@playwright/test';
-
-// Check if test credentials are configured
-const hasTestCredentials = !!(process.env.TEST_USER_EMAIL && process.env.TEST_USER_PASSWORD);
 
 // Known org names for test user domaincontext@onetime.dev
 const ORG_DEFAULT = 'Default Workspace';
@@ -44,34 +41,6 @@ const TABS = {
 // -----------------------------------------------------------------------------
 // Test Helpers
 // -----------------------------------------------------------------------------
-
-/**
- * Authenticate user via login form
- */
-async function loginUser(page: Page): Promise<void> {
-  await page.goto('/signin');
-
-  // Click Password tab - Magic Link is the default, password input is hidden
-  const passwordTab = page.getByRole('tab', { name: /password/i });
-  await passwordTab.waitFor({ state: 'visible', timeout: 5000 });
-  await passwordTab.click();
-
-  // Wait for password input to be visible after tab switch
-  const passwordInput = page.locator('input[type="password"]');
-  await passwordInput.waitFor({ state: 'visible', timeout: 5000 });
-
-  // Now fill the form (email input is in the password tab panel)
-  const emailInput = page.locator('#signin-email-password');
-  await emailInput.fill(process.env.TEST_USER_EMAIL || 'domaincontext@onetime.dev');
-  await passwordInput.fill(process.env.TEST_USER_PASSWORD || 'testpassword');
-
-  // Submit
-  const submitButton = page.locator('button[type="submit"]');
-  await submitButton.click();
-
-  // Wait for redirect to dashboard/account
-  await page.waitForURL(/\/(account|dashboard)/, { timeout: 30000 });
-}
 
 /**
  * Extract org extid from URL
@@ -190,11 +159,8 @@ function getCurrentTab(page: Page): string | null {
 // -----------------------------------------------------------------------------
 
 test.describe('Org Switcher Navigation - Same Tab Navigation', () => {
-  test.skip(!hasTestCredentials, 'Skipping: TEST_USER_EMAIL and TEST_USER_PASSWORD required');
-
   test.beforeEach(async ({ page }) => {
     page.setDefaultTimeout(15000);
-    await loginUser(page);
   });
 
   // -------------------------------------------------------------------------
@@ -441,11 +407,8 @@ test.describe('Org Switcher Navigation - Same Tab Navigation', () => {
 // -----------------------------------------------------------------------------
 
 test.describe('Org Switcher Navigation - Edge Cases', () => {
-  test.skip(!hasTestCredentials, 'Skipping: TEST_USER_EMAIL and TEST_USER_PASSWORD required');
-
   test.beforeEach(async ({ page }) => {
     page.setDefaultTimeout(15000);
-    await loginUser(page);
   });
 
   // -------------------------------------------------------------------------

--- a/e2e/full/organization-members.spec.ts
+++ b/e2e/full/organization-members.spec.ts
@@ -19,7 +19,7 @@
  * - Owner role cannot be assigned via UI
  *
  * Prerequisites:
- * - Set TEST_USER_EMAIL and TEST_USER_PASSWORD environment variables (org owner)
+ * - Authenticated as the org owner via the project storageState (e2e/global.setup.ts consumes TEST_USER_*)
  * - Set TEST_ADMIN_EMAIL and TEST_ADMIN_PASSWORD for admin user tests (optional)
  * - Set TEST_MEMBER_EMAIL and TEST_MEMBER_PASSWORD for member user tests (optional)
  * - Application running locally or PLAYWRIGHT_BASE_URL set
@@ -52,9 +52,17 @@ interface OrgInfo {
 // -----------------------------------------------------------------------------
 
 /**
- * Authenticate user via login form
+ * Sign in as a *different* account than the shared session (e.g. the
+ * TEST_ADMIN_* / TEST_MEMBER_* role accounts in the hierarchy/permission
+ * suites below).
+ *
+ * The `full` project starts every test already authenticated as TEST_USER_*
+ * via storageState (e2e/playwright.config.ts), so the session must be
+ * dropped first — an authenticated visitor to /signin is redirected away
+ * and never sees the form.
  */
 async function loginUser(page: Page, email?: string, password?: string): Promise<void> {
+  await page.context().clearCookies();
   await page.goto('/signin');
 
   // Click Password tab - Magic Link is the default, password input is hidden
@@ -185,11 +193,8 @@ async function getInvitationToken(page: Page, email: string): Promise<string | n
 // -----------------------------------------------------------------------------
 
 test.describe('MBR-LIST: Organization Members List', () => {
-  test.skip(!hasTestCredentials, 'Skipping: TEST_USER_EMAIL and TEST_USER_PASSWORD required');
-
   test.beforeEach(async ({ page }) => {
     page.setDefaultTimeout(15000);
-    await loginUser(page);
   });
 
   test('MBR-LIST-001: Team tab appears in organization settings navigation', async ({ page }) => {
@@ -273,11 +278,8 @@ test.describe('MBR-LIST: Organization Members List', () => {
 // -----------------------------------------------------------------------------
 
 test.describe('MBR-INVITE: Invite Member Flow', () => {
-  test.skip(!hasTestCredentials, 'Skipping: TEST_USER_EMAIL and TEST_USER_PASSWORD required');
-
   test.beforeEach(async ({ page }) => {
     page.setDefaultTimeout(15000);
-    await loginUser(page);
   });
 
   test('MBR-INVITE-001: Owner can see and click Invite Member button', async ({ page }) => {
@@ -411,11 +413,8 @@ test.describe('MBR-INVITE: Invite Member Flow', () => {
 // -----------------------------------------------------------------------------
 
 test.describe('MBR-ROLE: Change Member Role', () => {
-  test.skip(!hasTestCredentials, 'Skipping: TEST_USER_EMAIL and TEST_USER_PASSWORD required');
-
   test.beforeEach(async ({ page }) => {
     page.setDefaultTimeout(15000);
-    await loginUser(page);
   });
 
   test('MBR-ROLE-001: Owner sees role selector dropdown for non-owner members', async ({
@@ -554,11 +553,8 @@ test.describe('MBR-ROLE: Change Member Role', () => {
 // -----------------------------------------------------------------------------
 
 test.describe('MBR-REMOVE: Remove Member', () => {
-  test.skip(!hasTestCredentials, 'Skipping: TEST_USER_EMAIL and TEST_USER_PASSWORD required');
-
   test.beforeEach(async ({ page }) => {
     page.setDefaultTimeout(15000);
-    await loginUser(page);
   });
 
   test('MBR-REMOVE-001: Owner sees remove button for non-owner members', async ({ page }) => {
@@ -696,11 +692,8 @@ test.describe('MBR-REMOVE: Remove Member', () => {
 // -----------------------------------------------------------------------------
 
 test.describe('MBR-INVMGMT: Invitation Management', () => {
-  test.skip(!hasTestCredentials, 'Skipping: TEST_USER_EMAIL and TEST_USER_PASSWORD required');
-
   test.beforeEach(async ({ page }) => {
     page.setDefaultTimeout(15000);
-    await loginUser(page);
   });
 
   test('MBR-INVMGMT-001: Owner can resend pending invitation', async ({ page }) => {
@@ -767,15 +760,11 @@ test.describe('MBR-INVMGMT: Invitation Management', () => {
 // -----------------------------------------------------------------------------
 
 test.describe('MBR-ACCEPT: Accept Invitation Flow', () => {
-  test.skip(!hasTestCredentials, 'Skipping: TEST_USER_EMAIL and TEST_USER_PASSWORD required');
-
   test('MBR-ACCEPT-001: Valid invitation token shows invitation details', async ({
     page,
     context,
   }) => {
-    // Create invitation as owner
-    await loginUser(page);
-
+    // Create invitation as owner (storageState session)
     let orgExtid: string;
     try {
       orgExtid = await navigateToOrgTeam(page);
@@ -808,9 +797,7 @@ test.describe('MBR-ACCEPT: Accept Invitation Flow', () => {
     page,
     context,
   }) => {
-    // Create invitation as owner
-    await loginUser(page);
-
+    // Create invitation as owner (storageState session)
     try {
       await navigateToOrgTeam(page);
     } catch {
@@ -847,9 +834,7 @@ test.describe('MBR-ACCEPT: Accept Invitation Flow', () => {
     page,
     context,
   }) => {
-    // Create invitation as owner
-    await loginUser(page);
-
+    // Create invitation as owner (storageState session)
     try {
       await navigateToOrgTeam(page);
     } catch {

--- a/e2e/full/organization-settings.spec.ts
+++ b/e2e/full/organization-settings.spec.ts
@@ -26,7 +26,7 @@
  *   - org-section-settings: Settings panel
  *
  * Prerequisites:
- * - Set TEST_USER_EMAIL and TEST_USER_PASSWORD environment variables
+ * - Authenticated via the project storageState (e2e/global.setup.ts consumes TEST_USER_*)
  * - Test user must have at least one organization
  *
  * Usage:
@@ -35,9 +35,6 @@
  */
 
 import { expect, Page, test } from '@playwright/test';
-
-// Check if test credentials are configured
-const hasTestCredentials = !!(process.env.TEST_USER_EMAIL && process.env.TEST_USER_PASSWORD);
 
 // -----------------------------------------------------------------------------
 // Types
@@ -51,34 +48,6 @@ interface OrgInfo {
 // -----------------------------------------------------------------------------
 // Test Helpers
 // -----------------------------------------------------------------------------
-
-/**
- * Authenticate user via login form
- */
-async function loginUser(page: Page): Promise<void> {
-  await page.goto('/signin');
-
-  // Click Password tab - Magic Link is the default, password input is hidden
-  const passwordTab = page.getByRole('tab', { name: /password/i });
-  await passwordTab.waitFor({ state: 'visible', timeout: 5000 });
-  await passwordTab.click();
-
-  // Wait for password input to be visible after tab switch
-  const passwordInput = page.locator('input[type="password"]');
-  await passwordInput.waitFor({ state: 'visible', timeout: 5000 });
-
-  // Fill the form
-  const emailInput = page.locator('#signin-email-password');
-  await emailInput.fill(process.env.TEST_USER_EMAIL || '');
-  await passwordInput.fill(process.env.TEST_USER_PASSWORD || '');
-
-  // Submit
-  const submitButton = page.locator('button[type="submit"]');
-  await submitButton.click();
-
-  // Wait for redirect to dashboard/account
-  await page.waitForURL(/\/(account|dashboard|org)/, { timeout: 30000 });
-}
 
 /**
  * Get the first organization from the /orgs page
@@ -125,11 +94,8 @@ function getCurrentTab(page: Page): string | null {
 // -----------------------------------------------------------------------------
 
 test.describe('ORG-LIST: Organizations List Page (/orgs)', () => {
-  test.skip(!hasTestCredentials, 'Skipping: TEST_USER_EMAIL and TEST_USER_PASSWORD required');
-
   test.beforeEach(async ({ page }) => {
     page.setDefaultTimeout(15000);
-    await loginUser(page);
   });
 
   test('ORG-LIST-001: Organizations list renders with correct testids', async ({ page }) => {
@@ -250,13 +216,11 @@ test.describe('ORG-LIST: Organizations List Page (/orgs)', () => {
 // -----------------------------------------------------------------------------
 
 test.describe('ORG-DETAIL: Organization Settings Page (/org/:extid/:tab?)', () => {
-  test.skip(!hasTestCredentials, 'Skipping: TEST_USER_EMAIL and TEST_USER_PASSWORD required');
 
   let testOrg: OrgInfo | null = null;
 
   test.beforeEach(async ({ page }) => {
     page.setDefaultTimeout(15000);
-    await loginUser(page);
     testOrg = await getFirstOrganization(page);
   });
 
@@ -620,11 +584,8 @@ test.describe('ORG-DETAIL: Organization Settings Page (/org/:extid/:tab?)', () =
 // -----------------------------------------------------------------------------
 
 test.describe('ORG-ERROR: Organization Error States', () => {
-  test.skip(!hasTestCredentials, 'Skipping: TEST_USER_EMAIL and TEST_USER_PASSWORD required');
-
   test.beforeEach(async ({ page }) => {
     page.setDefaultTimeout(15000);
-    await loginUser(page);
   });
 
   test('ORG-ERROR-001: Invalid org extid shows error state', async ({ page }) => {
@@ -652,13 +613,11 @@ test.describe('ORG-ERROR: Organization Error States', () => {
 // -----------------------------------------------------------------------------
 
 test.describe('ORG-A11Y: Organization Settings Accessibility', () => {
-  test.skip(!hasTestCredentials, 'Skipping: TEST_USER_EMAIL and TEST_USER_PASSWORD required');
 
   let testOrg: OrgInfo | null = null;
 
   test.beforeEach(async ({ page }) => {
     page.setDefaultTimeout(15000);
-    await loginUser(page);
     testOrg = await getFirstOrganization(page);
   });
 

--- a/e2e/full/scope-switcher.spec.ts
+++ b/e2e/full/scope-switcher.spec.ts
@@ -12,7 +12,7 @@
 // - Edge cases (single org user, no domains)
 //
 // Prerequisites:
-// - Set TEST_USER_EMAIL and TEST_USER_PASSWORD environment variables
+// - Authenticated via the project storageState (e2e/global.setup.ts consumes TEST_USER_*)
 // - Application running locally or PLAYWRIGHT_BASE_URL set
 // - User should have multiple organizations and domains for full coverage
 //
@@ -26,9 +26,6 @@
 //     pnpm test:playwright scope-switcher.spec.ts
 
 import { expect, Page, test } from '@playwright/test';
-
-// Check if test credentials are configured
-const hasTestCredentials = !!(process.env.TEST_USER_EMAIL && process.env.TEST_USER_PASSWORD);
 
 /**
  * Data-testid recommendations for components:
@@ -53,26 +50,6 @@ const hasTestCredentials = !!(process.env.TEST_USER_EMAIL && process.env.TEST_US
 // -----------------------------------------------------------------------------
 // Test Helpers
 // -----------------------------------------------------------------------------
-
-/**
- * Authenticate user via login form
- */
-async function loginUser(page: Page): Promise<void> {
-  await page.goto('/signin');
-
-  const emailInput = page.locator('input[type="email"], input[name="email"]');
-  const passwordInput = page.locator('input[type="password"], input[name="password"]');
-  const submitButton = page.locator('button[type="submit"]');
-
-  if (await emailInput.isVisible()) {
-    await emailInput.fill(process.env.TEST_USER_EMAIL || 'test@example.com');
-    await passwordInput.fill(process.env.TEST_USER_PASSWORD || 'testpassword');
-    await submitButton.click();
-
-    // Wait for redirect to dashboard/account
-    await page.waitForURL(/\/(account|dashboard)/, { timeout: 30000 });
-  }
-}
 
 /**
  * Locators for Organization Scope Switcher
@@ -153,11 +130,8 @@ async function isElementDisabled(
 // -----------------------------------------------------------------------------
 
 test.describe('Scope Switcher - Visibility Rules', () => {
-  test.skip(!hasTestCredentials, 'Skipping: TEST_USER_EMAIL and TEST_USER_PASSWORD required');
-
   test.beforeEach(async ({ page }) => {
     page.setDefaultTimeout(15000);
-    await loginUser(page);
   });
 
   // -------------------------------------------------------------------------
@@ -496,11 +470,8 @@ test.describe('Scope Switcher - Visibility Rules', () => {
 // -----------------------------------------------------------------------------
 
 test.describe('Scope Switcher - Switching Behavior', () => {
-  test.skip(!hasTestCredentials, 'Skipping: TEST_USER_EMAIL and TEST_USER_PASSWORD required');
-
   test.beforeEach(async ({ page }) => {
     page.setDefaultTimeout(15000);
-    await loginUser(page);
   });
 
   // -------------------------------------------------------------------------
@@ -712,11 +683,8 @@ test.describe('Scope Switcher - Switching Behavior', () => {
 // -----------------------------------------------------------------------------
 
 test.describe('Scope Switcher - Locked State Behavior', () => {
-  test.skip(!hasTestCredentials, 'Skipping: TEST_USER_EMAIL and TEST_USER_PASSWORD required');
-
   test.beforeEach(async ({ page }) => {
     page.setDefaultTimeout(15000);
-    await loginUser(page);
   });
 
   test('TC-SS-040: Locked org switcher shows current org but is not clickable', async ({
@@ -797,11 +765,8 @@ test.describe('Scope Switcher - Locked State Behavior', () => {
 // -----------------------------------------------------------------------------
 
 test.describe('Scope Switcher - Edge Cases', () => {
-  test.skip(!hasTestCredentials, 'Skipping: TEST_USER_EMAIL and TEST_USER_PASSWORD required');
-
   test.beforeEach(async ({ page }) => {
     page.setDefaultTimeout(15000);
-    await loginUser(page);
   });
 
   test('TC-SS-050: Single org user sees switcher with one option', async ({ page }) => {
@@ -921,11 +886,8 @@ test.describe('Scope Switcher - Edge Cases', () => {
 // -----------------------------------------------------------------------------
 
 test.describe('Scope Switcher - State Persistence', () => {
-  test.skip(!hasTestCredentials, 'Skipping: TEST_USER_EMAIL and TEST_USER_PASSWORD required');
-
   test.beforeEach(async ({ page }) => {
     page.setDefaultTimeout(15000);
-    await loginUser(page);
   });
 
   test('TC-SS-060: Org selection persists across page navigation', async ({ page }) => {
@@ -993,11 +955,8 @@ test.describe('Scope Switcher - State Persistence', () => {
 // -----------------------------------------------------------------------------
 
 test.describe('Scope Switcher - Accessibility', () => {
-  test.skip(!hasTestCredentials, 'Skipping: TEST_USER_EMAIL and TEST_USER_PASSWORD required');
-
   test.beforeEach(async ({ page }) => {
     page.setDefaultTimeout(15000);
-    await loginUser(page);
   });
 
   test('TC-SS-070: Org switcher has proper ARIA labels', async ({ page }) => {

--- a/e2e/full/settings-layout.spec.ts
+++ b/e2e/full/settings-layout.spec.ts
@@ -1,6 +1,6 @@
 // src/tests/e2e/settings-layout.spec.ts
 
-import { test, expect, Page } from '@playwright/test';
+import { test, expect } from '@playwright/test';
 
 /**
  * E2E Tests - Settings Layout Refactoring Validation
@@ -31,34 +31,9 @@ import { test, expect, Page } from '@playwright/test';
  * 4. Route Transitions - navigation between settings pages is smooth
  */
 
-// Check if test credentials are configured (required for authenticated tests)
-const hasTestCredentials = !!(process.env.TEST_USER_EMAIL && process.env.TEST_USER_PASSWORD);
-
-// Helper to authenticate user (adjust based on actual auth flow)
-async function loginUser(page: Page): Promise<void> {
-  // Navigate to login page
-  await page.goto('/signin');
-
-  // Fill login form - adjust selectors to match actual form
-  const emailInput = page.locator('input[type="email"], input[name="email"]');
-  const passwordInput = page.locator('input[type="password"], input[name="password"]');
-  const submitButton = page.locator('button[type="submit"]');
-
-  // Check if login form is visible
-  if (await emailInput.isVisible()) {
-    await emailInput.fill(process.env.TEST_USER_EMAIL || 'test@example.com');
-    await passwordInput.fill(process.env.TEST_USER_PASSWORD || 'testpassword');
-    await submitButton.click();
-
-    // Wait for redirect to dashboard/account (longer timeout for CI)
-    await page.waitForURL(/\/(account|dashboard)/, { timeout: 30000 });
-  }
-}
-
 test.describe('E2E - Settings Layout Refactoring', () => {
   // Skip all tests if test credentials are not configured
   // These tests require authentication which needs a seeded test user
-  test.skip(!hasTestCredentials, 'Skipping: TEST_USER_EMAIL and TEST_USER_PASSWORD required');
 
   test.beforeEach(async ({ page }) => {
     page.setDefaultTimeout(15000);
@@ -66,7 +41,6 @@ test.describe('E2E - Settings Layout Refactoring', () => {
 
   test.describe('Settings Page Navigation', () => {
     test('sidebar navigation renders all main sections', async ({ page }) => {
-      await loginUser(page);
       await page.goto('/account/settings/profile');
 
       // Wait for settings layout to load
@@ -83,7 +57,6 @@ test.describe('E2E - Settings Layout Refactoring', () => {
     });
 
     test('clicking navigation item navigates to correct route', async ({ page }) => {
-      await loginUser(page);
       await page.goto('/account/settings/profile');
 
       // Click on Security link
@@ -97,7 +70,6 @@ test.describe('E2E - Settings Layout Refactoring', () => {
     });
 
     test('active navigation item is visually distinguished', async ({ page }) => {
-      await loginUser(page);
       await page.goto('/account/settings/profile');
 
       // Find the Profile nav item
@@ -118,7 +90,6 @@ test.describe('E2E - Settings Layout Refactoring', () => {
     });
 
     test('child navigation items appear when parent is active', async ({ page }) => {
-      await loginUser(page);
       await page.goto('/account/settings/profile');
 
       // Profile children should be visible
@@ -135,7 +106,6 @@ test.describe('E2E - Settings Layout Refactoring', () => {
     });
 
     test('child navigation routes work correctly', async ({ page }) => {
-      await loginUser(page);
       await page.goto('/account/settings/profile');
 
       // Click on Preferences (child of Profile)
@@ -148,7 +118,6 @@ test.describe('E2E - Settings Layout Refactoring', () => {
 
   test.describe('Settings Sections Rendering', () => {
     test('Profile settings section renders correctly', async ({ page }) => {
-      await loginUser(page);
       await page.goto('/account/settings/profile');
 
       // Check for profile-specific content
@@ -165,7 +134,6 @@ test.describe('E2E - Settings Layout Refactoring', () => {
     });
 
     test('Security settings section renders correctly', async ({ page }) => {
-      await loginUser(page);
       await page.goto('/account/settings/security');
 
       const content = page.locator('main');
@@ -179,7 +147,6 @@ test.describe('E2E - Settings Layout Refactoring', () => {
     });
 
     test('API settings section renders correctly', async ({ page }) => {
-      await loginUser(page);
       await page.goto('/account/settings/api');
 
       const content = page.locator('main');
@@ -193,7 +160,6 @@ test.describe('E2E - Settings Layout Refactoring', () => {
     });
 
     test('section cards have proper structure', async ({ page }) => {
-      await loginUser(page);
       await page.goto('/account/settings/profile');
 
       // Check for card-style sections
@@ -211,7 +177,6 @@ test.describe('E2E - Settings Layout Refactoring', () => {
 
   test.describe('Mobile Responsive Behavior', () => {
     test('layout adapts to mobile viewport', async ({ page }) => {
-      await loginUser(page);
 
       // Set mobile viewport
       await page.setViewportSize({ width: 375, height: 667 });
@@ -233,7 +198,6 @@ test.describe('E2E - Settings Layout Refactoring', () => {
     test('navigation is accessible on mobile', async ({ page }) => {
       await page.setViewportSize({ width: 375, height: 667 });
 
-      await loginUser(page);
       await page.goto('/account/settings/profile');
 
       // Navigation should still be usable
@@ -248,7 +212,6 @@ test.describe('E2E - Settings Layout Refactoring', () => {
     test('content does not overflow horizontally on mobile', async ({ page }) => {
       await page.setViewportSize({ width: 375, height: 667 });
 
-      await loginUser(page);
       await page.goto('/account/settings/profile');
 
       // Wait for layout to stabilize
@@ -275,7 +238,6 @@ test.describe('E2E - Settings Layout Refactoring', () => {
     test('sidebar width is correct on desktop', async ({ page }) => {
       await page.setViewportSize({ width: 1280, height: 800 });
 
-      await loginUser(page);
       await page.goto('/account/settings/profile');
 
       // Sidebar should have fixed width on desktop (md:w-72 = 288px)
@@ -292,7 +254,6 @@ test.describe('E2E - Settings Layout Refactoring', () => {
 
   test.describe('Route Transitions', () => {
     test('navigation between settings pages preserves layout', async ({ page }) => {
-      await loginUser(page);
       await page.goto('/account/settings/profile');
 
       // Navigate through multiple pages
@@ -313,7 +274,6 @@ test.describe('E2E - Settings Layout Refactoring', () => {
     });
 
     test('breadcrumb updates on navigation', async ({ page }) => {
-      await loginUser(page);
       await page.goto('/account/settings/profile');
 
       // Check breadcrumb shows Settings
@@ -327,7 +287,6 @@ test.describe('E2E - Settings Layout Refactoring', () => {
     });
 
     test('clicking breadcrumb Account link navigates to account page', async ({ page }) => {
-      await loginUser(page);
       await page.goto('/account/settings/profile');
 
       // Click Account in breadcrumb
@@ -338,7 +297,6 @@ test.describe('E2E - Settings Layout Refactoring', () => {
     });
 
     test('browser back button works correctly', async ({ page }) => {
-      await loginUser(page);
       await page.goto('/account/settings/profile');
 
       // Navigate to Security
@@ -353,7 +311,6 @@ test.describe('E2E - Settings Layout Refactoring', () => {
     });
 
     test('direct URL navigation works', async ({ page }) => {
-      await loginUser(page);
 
       // Navigate directly to various settings pages
       const pages = [
@@ -372,7 +329,6 @@ test.describe('E2E - Settings Layout Refactoring', () => {
 
   test.describe('Accessibility', () => {
     test('settings navigation has proper ARIA attributes', async ({ page }) => {
-      await loginUser(page);
       await page.goto('/account/settings/profile');
 
       const nav = page.locator('nav[aria-label="Settings navigation"]');
@@ -381,7 +337,6 @@ test.describe('E2E - Settings Layout Refactoring', () => {
     });
 
     test('page has single h1', async ({ page }) => {
-      await loginUser(page);
       await page.goto('/account/settings/profile');
 
       const h1Elements = page.locator('h1');
@@ -391,7 +346,6 @@ test.describe('E2E - Settings Layout Refactoring', () => {
     });
 
     test('navigation links are focusable', async ({ page }) => {
-      await loginUser(page);
       await page.goto('/account/settings/profile');
 
       // Tab to first nav link
@@ -419,7 +373,6 @@ test.describe('E2E - Settings Layout Refactoring', () => {
     });
 
     test('Enter key activates navigation links', async ({ page }) => {
-      await loginUser(page);
       await page.goto('/account/settings/profile');
 
       // Focus on Security link
@@ -436,7 +389,6 @@ test.describe('E2E - Settings Layout Refactoring', () => {
 
   test.describe('Error Handling', () => {
     test('handles missing settings route gracefully', async ({ page }) => {
-      await loginUser(page);
 
       await page.goto('/account/settings/nonexistent');
 
@@ -450,7 +402,6 @@ test.describe('E2E - Settings Layout Refactoring', () => {
     });
 
     test('settings page recovers from failed API calls', async ({ page }) => {
-      await loginUser(page);
 
       // Block API calls to simulate failure
       await page.route('**/api/**', (route) => route.abort());

--- a/e2e/global.setup.ts
+++ b/e2e/global.setup.ts
@@ -1,0 +1,100 @@
+// e2e/global.setup.ts
+
+/**
+ * Auth setup project (e2e/docs/e2e-remediation-plan.md, Phase 2.1)
+ *
+ * Obtains an authenticated session once per run and saves it to
+ * STORAGE_STATE (e2e/.auth/user.json, gitignored). The `full` and
+ * `full-billing` projects declare `dependencies: ['setup']` and consume the
+ * saved session via `storageState`, so their tests start already signed in.
+ *
+ * Strategy: register via the real /signup flow, then sign in via /signin —
+ * exercising the same product code paths users hit, with no backend seam.
+ * Requirements on the target server:
+ *  - signup enabled (site.authentication.signup, default on)
+ *  - autoverify enabled (AUTH_AUTOVERIFY=true) so the new account is
+ *    immediately sign-in-able without an email round-trip. The CI workflow
+ *    sets this on the container; see .github/workflows/e2e.yml.
+ * Registration is idempotent: the backend intentionally returns the same
+ * success response for new and already-existing accounts (email-enumeration
+ * prevention), so re-running against the same server is safe.
+ *
+ * Fallback (documented in the plan, not currently needed): seed directly via
+ *   docker exec <container> ... Onetime::Customer.create!(...)
+ *
+ * Readiness: waits on `html[data-app-ready="true"]` (set in src/main.ts
+ * after mount + brand theme application + router.isReady()) — never
+ * `networkidle` or `waitForTimeout`.
+ */
+
+import { expect, test as setup } from '@playwright/test';
+
+import { STORAGE_STATE } from './playwright.config';
+
+const TEST_USER_EMAIL = process.env.TEST_USER_EMAIL ?? '';
+const TEST_USER_PASSWORD = process.env.TEST_USER_PASSWORD ?? '';
+
+setup('register and authenticate test user', async ({ page }) => {
+  if (!TEST_USER_EMAIL || !TEST_USER_PASSWORD) {
+    throw new Error(
+      'TEST_USER_EMAIL and TEST_USER_PASSWORD must be set to run the ' +
+        'authenticated suites (full/, full-billing/). ' +
+        'CI generates ephemeral credentials in .github/workflows/e2e.yml; ' +
+        'locally, export both env vars before running.'
+    );
+  }
+
+  // ---------------------------------------------------------------------
+  // Register via the signup form. With autoverify enabled the account is
+  // created verified; if the account already exists the backend still
+  // responds with success (enumeration prevention) and we proceed to signin.
+  // ---------------------------------------------------------------------
+  await page.goto('/signup');
+  await expect(page.locator('html[data-app-ready="true"]')).toBeAttached();
+
+  await expect(page.getByTestId('signup-form')).toBeVisible();
+  await page.getByTestId('signup-email-input').fill(TEST_USER_EMAIL);
+  await page.getByTestId('signup-password-input').fill(TEST_USER_PASSWORD);
+  await page.getByTestId('signup-terms-checkbox').check();
+  await page.getByTestId('signup-submit').click();
+
+  // On success the SPA navigates to /signin (useAuth.signup()).
+  await page.waitForURL(/\/signin/);
+
+  // ---------------------------------------------------------------------
+  // Sign in. Default deployments (no passwordless methods) render
+  // SignInForm directly; passwordless-first deployments render a tabbed
+  // form (PasswordlessFirstSignIn) where the password panel sits behind a
+  // "Password" tab and uses different test ids.
+  // ---------------------------------------------------------------------
+  const signinForm = page.getByTestId('signin-form');
+  const passwordTab = page.getByRole('tab', { name: /password/i });
+  await expect(signinForm.or(passwordTab).first()).toBeVisible();
+
+  if (await passwordTab.isVisible()) {
+    // Passwordless-first variant (magic links / WebAuthn enabled)
+    await passwordTab.click();
+    await page.getByTestId('password-email-input').fill(TEST_USER_EMAIL);
+    await page.getByTestId('password-input').fill(TEST_USER_PASSWORD);
+    await page.getByTestId('password-submit').click();
+  } else {
+    // Password-only variant (CI container default)
+    await page.getByTestId('signin-email-input').fill(TEST_USER_EMAIL);
+    await page.getByTestId('signin-password-input').fill(TEST_USER_PASSWORD);
+    await page.getByTestId('signin-submit').click();
+  }
+
+  // Successful login navigates away from /signin (router.push('/') then the
+  // post-auth redirect). Failed logins stay on /signin with an inline error,
+  // which this assertion surfaces via timeout + screenshot/trace.
+  await expect(page).not.toHaveURL(/\/signin/, { timeout: 30000 });
+  await expect(page.locator('html[data-app-ready="true"]')).toBeAttached();
+
+  // Verify the session server-side before persisting it: /bootstrap/me
+  // reflects the authenticated state for the cookies this page holds.
+  const me = await page.request.get('/bootstrap/me');
+  expect(me.ok()).toBe(true);
+  expect((await me.json()).authenticated).toBe(true);
+
+  await page.context().storageState({ path: STORAGE_STATE });
+});

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,9 +1,25 @@
 // e2e/playwright.config.ts
 
 import { defineConfig, devices } from '@playwright/test';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 // Default local server URL (Ruby backend with built assets)
 const DEFAULT_LOCAL_URL = 'http://localhost:7143';
+
+// Directory containing this config file. package.json is `"type": "module"`,
+// so the config loads as ESM and `__dirname` is unavailable.
+const CONFIG_DIR = path.dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Authenticated session produced by global.setup.ts and consumed by the
+ * `full` / `full-billing` projects via `storageState`. Absolute on purpose
+ * so writer (setup script) and readers (project `use` blocks) agree on one
+ * location regardless of cwd — Playwright path resolution is inconsistent
+ * (e.g. the blob reporter below resolves against cwd, not the config dir).
+ * The .auth/ directory is gitignored.
+ */
+export const STORAGE_STATE = path.join(CONFIG_DIR, '.auth', 'user.json');
 
 /**
  * Playwright configuration for E2E integration testing
@@ -84,14 +100,66 @@ export default defineConfig({
     navigationTimeout: 15000,
   },
 
-  /* Configure projects for major browsers */
+  /* Configure projects.
+   *
+   * Auth model (e2e/docs/e2e-remediation-plan.md, Phase 2.1):
+   *  - `setup` registers/signs in the TEST_USER_* account once via the real
+   *    signup + signin UI and saves the session to STORAGE_STATE.
+   *  - `full` and `full-billing` depend on `setup` and start every test
+   *    already authenticated via storageState.
+   *  - `chromium` (all/ + auth/ suites) stays credential-free: no
+   *    dependency on `setup`, no storageState.
+   *
+   * CLI path filters (e.g. `pnpm test:playwright e2e/all e2e/full`) select
+   * which suites run; Playwright always runs dependency projects in full, so
+   * `setup` only executes when a dependent project has matching tests.
+   */
   projects: [
     {
-      name: 'chromium',
+      name: 'setup',
+      // Overrides the top-level testMatch (which only matches *.spec.ts)
+      testMatch: 'global.setup.ts',
       use: {
         ...devices['Desktop Chrome'],
         // Extra time for container responses
         actionTimeout: 30000,
+      },
+    },
+
+    {
+      // Credential-free suites: all/ (runs in CI) and auth/ (unauthenticated
+      // signup/SSO-CSRF flows). Keep the historical project name so existing
+      // `--project=chromium` invocations keep working.
+      name: 'chromium',
+      testIgnore: ['full/**', 'full-billing/**'],
+      use: {
+        ...devices['Desktop Chrome'],
+        // Extra time for container responses
+        actionTimeout: 30000,
+      },
+    },
+
+    {
+      // Authenticated suite; requires TEST_USER_EMAIL / TEST_USER_PASSWORD.
+      name: 'full',
+      testMatch: 'full/**/*.spec.ts',
+      dependencies: ['setup'],
+      use: {
+        ...devices['Desktop Chrome'],
+        actionTimeout: 30000,
+        storageState: STORAGE_STATE,
+      },
+    },
+
+    {
+      // Authenticated suite + billing enabled on the target server.
+      name: 'full-billing',
+      testMatch: 'full-billing/**/*.spec.ts',
+      dependencies: ['setup'],
+      use: {
+        ...devices['Desktop Chrome'],
+        actionTimeout: 30000,
+        storageState: STORAGE_STATE,
       },
     },
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,6 +8,7 @@ import 'vite/modulepreload-polyfill';
 import App from './App.vue';
 import './assets/style.css';
 import { AppInitializer } from './plugins/core/appInitializer';
+import { loggingService } from './services/logging.service';
 
 // Handle Vite chunk loading failures that occur when cached HTML references
 // stale chunk hashes after a deployment. Without this, users see a blank page.
@@ -23,3 +24,34 @@ window.addEventListener('vite:preloadError', (event) => {
 const app = createApp(App);
 app.use(AppInitializer, { debug: false });
 app.mount('#app');
+
+/**
+ * Deterministic app-readiness signal for E2E tests
+ * (e2e/docs/e2e-remediation-plan.md, Phase 2.2). Tests wait on
+ * `html[data-app-ready="true"]` instead of `networkidle` or polling
+ * `window.__BOOTSTRAP_ME__`.
+ *
+ * Why this flag is truthful at this point:
+ * - `app.mount()` is synchronous and runs App.vue's setup(), which activates
+ *   useBrandTheme(). Its `immediate: true` watcher applies the brand palette
+ *   (or clears overrides) with no awaits before the DOM writes, sourced from
+ *   bootstrap data consumed before Pinia install — so by the time mount()
+ *   returns, the initial brand theme has been applied.
+ * - The initial route resolution (including lazy-loaded route components) IS
+ *   asynchronous, so gate the flag on router.isReady(): "ready" then also
+ *   means the first navigation has been resolved and rendered.
+ */
+app.config.globalProperties.$router
+  .isReady()
+  .then(() => {
+    document.documentElement.dataset.appReady = 'true';
+  })
+  .catch((error: unknown) => {
+    // Deliberately do NOT set the flag: a failed initial navigation means the
+    // app is not usable, and E2E waits should fail loudly with a trace.
+    loggingService.error(
+      error instanceof Error
+        ? error
+        : new Error(`[main] Initial navigation failed; app-ready flag not set: ${String(error)}`)
+    );
+  });


### PR DESCRIPTION
> [!NOTE]
> Originally stacked on #3411 (Phase 1), which **merged to `develop` while this PR was in flight**. The branch has been rebased onto `develop`, so the diff is now the PR 3 commits only. Left as draft for a maintainer to flip ready — note that per the remediation plan, the first `full/` CI runs are *expected* to be red (see "Deferred to CI" below).

PR 3 of the [E2E remediation plan](https://github.com/onetimesecret/onetimesecret/blob/claude/e2e-phase2-auth-readiness/e2e/docs/e2e-remediation-plan.md) — Phase 2 items 1 and 2.

## What this does

### 2.1 Auth via setup project + `storageState`
- **`e2e/global.setup.ts`** (new): a Playwright `setup` project that registers the `TEST_USER_*` account through the app's real `/signup` flow, signs in via `/signin`, verifies the session against `/bootstrap/me`, and saves it to `e2e/.auth/user.json` (gitignored).
- **`e2e/playwright.config.ts`**: four projects — `setup`; `chromium` (`all/` + `auth/`, credential-free, name kept so existing `--project=chromium` usage works); `full` and `full-billing` with `dependencies: ['setup']` + `storageState`. `STORAGE_STATE` is exported as an absolute path (Playwright path resolution is cwd-inconsistent; see the blob-reporter lesson from #3411).
- **`.github/workflows/e2e.yml`**: container now starts with `AUTH_AUTOVERIFY=true`; the Playwright step generates ephemeral credentials (`openssl rand`, password masked, never hardcoded) and runs `e2e/all/ e2e/full/`. Trailing slashes are load-bearing — CLI filters are partial-path matches, so a bare `e2e/full` also pulls in `e2e/full-billing/` (verified via `--list`). Flaky gate and artifact uploads unchanged.

### 2.2 Deterministic app-readiness signal
- **`src/main.ts`** sets `html[data-app-ready="true"]` once the app is genuinely usable. Placement rationale (investigated, not guessed): `app.mount()` synchronously runs App.vue setup → `useBrandTheme()`'s `immediate` watcher applies the brand palette with **no awaits before its DOM writes**, sourced entirely from bootstrap data consumed pre-Pinia — so theme application completes within `mount()`. What *is* async is initial route resolution (lazy route components), so the flag is gated on `router.isReady()`. On a failed initial navigation the flag is deliberately withheld so E2E waits fail loudly with a trace.
- `global.setup.ts` waits on this attribute via web-first assertions — zero `networkidle` / `waitForTimeout` in any code added here.

## Design decision: signup flow, not docker-exec seeding

The plan allows either registering via `/signup` or seeding via `docker exec ... Onetime::Customer.create!`. This PR uses the **signup flow**, because the evidence says it works and it's strictly more valuable:

- The CI container runs **simple auth mode** (no `AUTHENTICATION_MODE` env → `etc/defaults/auth.defaults.yaml` defaults to `simple`), where `POST /auth/create-account` is handled by `Core::Controllers::Registration` → `AccountAPI::Logic::Account::CreateAccount`. With `AUTH_AUTOVERIFY=true`, it sets `cust.verified = true` at creation (`apps/api/account/logic/account/create_account.rb:102`), so password signin succeeds immediately — no email round-trip.
- Registration is **idempotent by design**: the backend returns identical success for new and existing accounts (email-enumeration prevention), so reruns against a long-lived server are safe.
- Default Truemail validation is `:regex` (`etc/defaults/config.defaults.yaml`), so generated `e2e-@example.com` addresses pass without MX lookups.
- It exercises the real signup + signin product paths on every CI run, instead of coupling the workflow to internal Ruby APIs. The docker-exec fallback remains documented in `global.setup.ts` and the plan if signup is ever disabled in the container.

The setup script handles both signin form variants: password-only (`SignInForm`, the CI container default) and passwordless-first (tabbed `PasswordlessFirstSignIn`, when magic links/WebAuthn are enabled locally).

## Verified locally

- `pnpm lint:e2e`: **341 warnings, 0 errors — identical to the Phase 1 baseline**; the new setup file adds zero warnings.
- `pnpm lint:quick`: exit 0. `pnpm run type-check` (vue-tsc over src incl. `main.ts`): exit 0. Standalone `tsc --noEmit --strict` over `e2e/global.setup.ts` + `e2e/playwright.config.ts`: exit 0.
- `playwright --list`: 415 tests / 30 files, no project overlap (setup 1, chromium 70 = all/+auth/, full 277, full-billing 67).
- Filter simulation: `e2e/all/ e2e/full/` selects chromium(49 in all/) + full(277) + setup(1); `e2e/all/` alone selects chromium only (setup correctly **not** triggered — `all/` stays credential-free).

## Deferred to CI (and expected to be red at first)

Running the authenticated flow end-to-end needs the built OCI container + Redis; that isn't feasible in the dev container (no built assets/app server). Per the plan's definition of done for PR 3, **the first `full/` runs are expected to surface real, previously-masked failures** — notably, the 19 `full/` specs still perform their own manual `loginUser()` against `/signin` while now starting authenticated, and many depend on multi-org fixtures that don't exist yet. That red is the point: it converts "never executes, looks green" into visible signal. Triage path: fix or quarantine via `e2e/QUARANTINE.md` (flaky gate stays blocking); the spec-level sweep is PR 4/5 scope.

## CI triage round 1 (run 27241214905)

The first `container-e2e-tests` run failed exactly as predicted above: **5 failed, 19 skipped, 272 did not run, 31 passed**. All 5 failures (`cross-org-domain-isolation.spec.ts` TC-DOI-001…005, plus one beforeEach hook error) shared one signature — the manual `loginUser()` helper timing out on `getByRole('tab', { name: /password/i })` at `/signin`. **Root cause:** the `full` project now starts authenticated via `storageState`, so `/signin` redirects the already-signed-in visitor away and the form never renders. The "272 did not run" is `--max-failures=5` aborting on the first file of this class; every `full/` spec carried the same pattern. Phase 1 infra all worked: flaky gate ran clean, both artifact uploads landed (report 39 files, test-results 51 files with traces/screenshots/videos).

Pushed in response (commits `f1b5d75`, `3e91e17`, `a84e280`):
- **Deleted** the dead `loginUser()` helpers + call sites in the 13 specs that only ever signed in as the default `TEST_USER_*` account — storageState provides that exact session — along with the `hasTestCredentials` self-skips that existed solely to guard those deleted sign-ins (broader skip triage remains PR 5).
- **Adapted** specs that genuinely need a different session: multi-context invite/mismatch suites keep `loginUser` for fresh `browser.newContext()` pages (which correctly don't inherit storageState); admin/member role logins in `organization-members` now clear cookies first; `invite-token-security`'s SEC-INV-001/002 clear cookies before asserting *unauthenticated* outcomes; `mfa-bootstrap-reactivity`, `plan-switching`, `pending-plan-intent`, and `pricing-flow` opt out of the shared session via `test.use({ storageState: { cookies: [], origins: [] } })` since they exercise sign-in/signup/anonymous flows by design.
- **Raised `--max-failures` 5 → 20** (triage-visibility aid only) so one failure class can't hide everything behind it; retries, flaky gate, and artifact uploads untouched.

Re-verified after the sweep: `pnpm lint:e2e` still **341 warnings / 0 errors**; `playwright --list` still 415 tests / 30 files; strict `tsc` over `e2e/full*/` shows the identical pre-existing 9 errors as before (line shifts only — these specs aren't in the project tsconfig). Remaining red in the next run, if any, should be genuine fixture/feature gaps — PR 4/5 scope.

https://claude.ai/code/session_01WRor5yk5SGGE7KWg1bFf99