### PR TITLE
Per-domain sign-in disable: expressible control + friendly 'unavailable' page

### DIFF
--- a/apps/web/core/views/serializers/config_serializer.rb
+++ b/apps/web/core/views/serializers/config_serializer.rb
@@ -165,6 +165,7 @@ module Core
           features = view_vars['features'] || {}
 
           {
+            'signin' => resolve_signin(view_vars),
             'lockout' => Onetime.auth_config.lockout_enabled?,
             'password_requirements' => Onetime.auth_config.password_requirements_enabled?,
             'active_sessions' => Onetime.auth_config.active_sessions_enabled?,
@@ -194,6 +195,34 @@ module Core
           end
 
           Onetime.auth_config.restrict_to
+        end
+
+        # Resolve sign-in availability for the current request context.
+        #
+        # AND semantics (mirrors resolve_email_auth): a domain may DISABLE
+        # sign-in entirely but can never enable it when sign-in is off
+        # globally (AUTH_ENABLED + AUTH_SIGNIN). The domain override only
+        # ever narrows the global capability.
+        #
+        # This is the DISPLAY gate: features.signin in the bootstrap lets
+        # the public /signin page render a friendly "not available" notice
+        # instead of the auth form. The runtime POST gate lives in
+        # Core::Controllers::Base#signin_enabled? and consults the same
+        # SigninConfig state.
+        #
+        # @param view_vars [Hash] View variables with request context
+        # @return [Boolean] true if sign-in is available
+        def resolve_signin(view_vars)
+          auth_settings = (view_vars['site'] || {})['authentication'] || {}
+          global        = !!(auth_settings['enabled'] && auth_settings['signin'])
+
+          domain_id = resolve_domain_id(view_vars)
+          if domain_id
+            signin_config = Onetime::CustomDomain::SigninConfig.find_by_domain_id(domain_id)
+            return global && signin_config.signin_enabled? if signin_config&.enabled?
+          end
+
+          global
         end
 
         # Resolve email_auth availability for the current request context.

--- a/locales/content/en/session-auth.json
+++ b/locales/content/en/session-auth.json
@@ -128,6 +128,14 @@
     "context": "Shown on signin page when SSO signup is blocked by the email domain policy (per-domain SignupConfig or global allowed_signup_domains).",
     "content_hash": "87603782"
   },
+  "web.login.signin_disabled_heading": {
+    "text": "Sign-in is not available",
+    "context": "Page heading on /signin when sign-in is disabled for the current domain (per-domain SigninConfig)."
+  },
+  "web.login.signin_disabled_message": {
+    "text": "Sign-in is currently not available on this domain.",
+    "context": "Body text of the notice shown instead of the auth form when sign-in is disabled for the current domain. A return-to-homepage link is shown below it."
+  },
   "web.signup.create_your_account": {
     "text": "Create Your Account",
     "content_hash": "5f4c33d7"

--- a/locales/content/en/workspace-domains.json
+++ b/locales/content/en/workspace-domains.json
@@ -1180,6 +1180,15 @@
   "web.domains.signin.mode_one_hint": {
     "text": "Restrict the sign-in page to a single method. Only methods available on this domain are listed."
   },
+  "web.domains.signin.mode_disabled": {
+    "text": "Sign-in disabled"
+  },
+  "web.domains.signin.mode_disabled_hint": {
+    "text": "Users cannot sign in on this domain."
+  },
+  "web.domains.signin.mode_disabled_notice": {
+    "text": "Visitors to this domain's sign-in page see a notice that sign-in is not available, with a link back to the homepage. Your previous method settings are kept and restored when you re-enable sign-in."
+  },
   "web.domains.signin.methods_list_label": {
     "text": "Methods shown on the sign-in page"
   },

--- a/src/apps/session/views/Login.vue
+++ b/src/apps/session/views/Login.vue
@@ -4,6 +4,7 @@
 import { useI18n } from 'vue-i18n';
 import AuthMethodSelector from '@/apps/session/components/AuthMethodSelector.vue';
 import AuthView from '@/apps/session/components/AuthView.vue';
+import OIcon from '@/shared/components/icons/OIcon.vue';
 import { useBootstrapStore } from '@/shared/stores/bootstrapStore';
 import { useProductIdentity } from '@/shared/stores/identityStore';
 import { useLanguageStore } from '@/shared/stores/languageStore';
@@ -18,7 +19,14 @@ const router = useRouter();
 
 const languageStore = useLanguageStore();
 const bootstrapStore = useBootstrapStore();
-const { authentication } = storeToRefs(bootstrapStore);
+const { authentication, features } = storeToRefs(bootstrapStore);
+
+// Per-domain sign-in disable (#3415). features.signin is the resolved
+// availability for THIS domain context (AND of global AUTH_SIGNIN and the
+// domain SigninConfig). Only an explicit false disables: the global-off case
+// never reaches this page (the requiresFeature route guard redirects to '/'),
+// so in practice this branch renders for domain-level disables.
+const signinDisabled = computed(() => features.value?.signin === false);
 
 // Custom domain branding: replace generic icon with domain logo on sign-in page
 const identityStore = useProductIdentity();
@@ -81,30 +89,49 @@ const handleModeChange = (_mode: AuthMode) => {
 
 <template>
   <AuthView
-    :heading="t('web.COMMON.login_to_your_account')"
+    :heading="signinDisabled ? t('web.login.signin_disabled_heading') : t('web.COMMON.login_to_your_account')"
     heading-id="signin-heading"
     :title-logo="isCustom ? logoUri : null"
     :title="isCustom ? displayName : null"
     :with-subheading="true"
     :hide-icon="false"
     :hide-background-icon="isCustom"
-    :show-return-home="false">
+    :show-return-home="signinDisabled">
     <template #form>
-      <!-- Auth error from redirects (SSO failure, invalid magic link, etc.) -->
+      <!-- Sign-in disabled for this domain: friendly notice instead of the
+           auth form. AuthView's return-home link provides the way out. -->
       <div
-        v-if="authError"
-        role="alert"
-        class="mb-4 rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700 dark:border-red-800 dark:bg-red-900/20 dark:text-red-400">
-        {{ authError }}
+        v-if="signinDisabled"
+        data-testid="signin-disabled-panel"
+        class="space-y-3 py-2 text-center">
+        <OIcon
+          collection="heroicons"
+          name="lock-closed"
+          class="mx-auto size-10 text-gray-400 dark:text-gray-500"
+          aria-hidden="true" />
+        <p class="text-sm text-gray-600 dark:text-gray-400">
+          {{ t('web.login.signin_disabled_message') }}
+        </p>
       </div>
 
-      <AuthMethodSelector
-        ref="authMethodSelectorRef"
-        :locale="languageStore.currentLocale ?? ''"
-        @mode-change="handleModeChange" />
+      <template v-else>
+        <!-- Auth error from redirects (SSO failure, invalid magic link, etc.) -->
+        <div
+          v-if="authError"
+          role="alert"
+          class="mb-4 rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700 dark:border-red-800 dark:bg-red-900/20 dark:text-red-400">
+          {{ authError }}
+        </div>
+
+        <AuthMethodSelector
+          ref="authMethodSelectorRef"
+          :locale="languageStore.currentLocale ?? ''"
+          @mode-change="handleModeChange" />
+      </template>
     </template>
     <template #footer>
       <nav
+        v-if="!signinDisabled"
         aria-label="Additional sign-in options"
         class="flex items-center justify-center gap-2 text-sm">
         <!-- Consistent footer for all modes when passwordless methods enabled -->

--- a/src/apps/workspace/components/domains/DomainSigninConfigForm.vue
+++ b/src/apps/workspace/components/domains/DomainSigninConfigForm.vue
@@ -108,6 +108,13 @@ const isModeOne = computed(
 
 const isModeAny = computed(() => !isModeDisabled.value && !isModeOne.value);
 
+/** Hint paragraph under the mode switch, per active mode. */
+const modeHint = computed(() => {
+  if (isModeDisabled.value) return t('web.domains.signin.mode_disabled_hint');
+  if (isModeOne.value) return t('web.domains.signin.mode_one_hint');
+  return t('web.domains.signin.mode_any_hint');
+});
+
 // ---------------------------------------------------------------------------
 // Mode switch keyboard support (roving tabindex)
 // ---------------------------------------------------------------------------
@@ -121,7 +128,11 @@ const isModeAny = computed(() => !isModeDisabled.value && !isModeOne.value);
  */
 const MODE_SEGMENT_IDS = ['signin-mode-any', 'signin-mode-one', 'signin-mode-disabled'] as const;
 
-const checkedModeIndex = computed(() => (isModeDisabled.value ? 2 : isModeOne.value ? 1 : 0));
+const checkedModeIndex = computed(() => {
+  if (isModeDisabled.value) return 2;
+  if (isModeOne.value) return 1;
+  return 0;
+});
 
 const modeTabindex = (index: number) => (checkedModeIndex.value === index ? 0 : -1);
 
@@ -354,13 +365,7 @@ const handleDelete = () => {
         <p
           id="signin-mode-hint"
           class="mt-2 text-sm text-gray-500 dark:text-gray-400">
-          {{
-            isModeDisabled
-              ? t('web.domains.signin.mode_disabled_hint')
-              : isModeOne
-                ? t('web.domains.signin.mode_one_hint')
-                : t('web.domains.signin.mode_any_hint')
-          }}
+          {{ modeHint }}
         </p>
       </fieldset>
 

--- a/src/apps/workspace/components/domains/DomainSigninConfigForm.vue
+++ b/src/apps/workspace/components/domains/DomainSigninConfigForm.vue
@@ -109,6 +109,47 @@ const isModeOne = computed(
 const isModeAny = computed(() => !isModeDisabled.value && !isModeOne.value);
 
 // ---------------------------------------------------------------------------
+// Mode switch keyboard support (roving tabindex)
+// ---------------------------------------------------------------------------
+
+/**
+ * Roving tabindex: the radiogroup is a single tab stop (the checked
+ * segment); arrow keys move focus between segments. Activation stays on
+ * click/Enter/Space (manual activation) — selecting a mode fires an
+ * auto-save PUT, and WAI-ARIA APG recommends NOT having selection follow
+ * focus when activation has side effects like network requests.
+ */
+const MODE_SEGMENT_IDS = ['signin-mode-any', 'signin-mode-one', 'signin-mode-disabled'] as const;
+
+const checkedModeIndex = computed(() => (isModeDisabled.value ? 2 : isModeOne.value ? 1 : 0));
+
+const modeTabindex = (index: number) => (checkedModeIndex.value === index ? 0 : -1);
+
+const onModeKeydown = (event: KeyboardEvent) => {
+  const handled = ['ArrowRight', 'ArrowDown', 'ArrowLeft', 'ArrowUp', 'Home', 'End'];
+  if (!handled.includes(event.key)) return;
+  event.preventDefault();
+
+  const segments = MODE_SEGMENT_IDS.map((id) => document.getElementById(id)).filter(
+    (el): el is HTMLElement => el !== null
+  );
+  if (segments.length === 0) return;
+
+  const current = segments.indexOf(document.activeElement as HTMLElement);
+  let next: number;
+  if (event.key === 'Home') {
+    next = 0;
+  } else if (event.key === 'End') {
+    next = segments.length - 1;
+  } else {
+    const delta = event.key === 'ArrowRight' || event.key === 'ArrowDown' ? 1 : -1;
+    const from = current === -1 ? checkedModeIndex.value : current;
+    next = (from + delta + segments.length) % segments.length;
+  }
+  segments[next].focus();
+};
+
+// ---------------------------------------------------------------------------
 // Method availability (only offer globally-available methods)
 // ---------------------------------------------------------------------------
 
@@ -186,7 +227,11 @@ const selectModeAny = () => {
   if (props.formState.restrict_to !== null) patch.restrict_to = null;
   if (!props.formState.signin_enabled) patch.signin_enabled = true;
   if (Object.keys(patch).length === 0) return;
-  emit('auto-save', patch, 'restrict_to');
+  // Attribute the saving indicator to restrict_to only when it is actually
+  // in the patch; a pure re-enable from "Sign-in disabled" (restrict_to
+  // already null) saves signin_enabled alone.
+  const fieldKey = 'restrict_to' in patch ? 'restrict_to' : 'signin_enabled';
+  emit('auto-save', patch, fieldKey);
 };
 
 /**
@@ -254,12 +299,14 @@ const handleDelete = () => {
         <div
           class="mt-3 inline-flex rounded-lg border border-gray-300 bg-gray-100 p-1 dark:border-gray-600 dark:bg-gray-700"
           role="radiogroup"
-          aria-labelledby="signin-mode-legend">
+          aria-labelledby="signin-mode-legend"
+          @keydown="onModeKeydown">
           <button
             id="signin-mode-any"
             type="button"
             role="radio"
             :aria-checked="isModeAny"
+            :tabindex="modeTabindex(0)"
             :disabled="isSaving"
             @click="selectModeAny"
             :class="[
@@ -275,6 +322,7 @@ const handleDelete = () => {
             type="button"
             role="radio"
             :aria-checked="isModeOne"
+            :tabindex="modeTabindex(1)"
             :disabled="isSaving"
             @click="selectModeOne"
             :class="[
@@ -290,6 +338,7 @@ const handleDelete = () => {
             type="button"
             role="radio"
             :aria-checked="isModeDisabled"
+            :tabindex="modeTabindex(2)"
             :disabled="isSaving"
             @click="selectModeDisabled"
             :class="[

--- a/src/apps/workspace/components/domains/DomainSigninConfigForm.vue
+++ b/src/apps/workspace/components/domains/DomainSigninConfigForm.vue
@@ -4,21 +4,29 @@
 /**
  * Domain Sign-In Configuration Form
  *
- * Presentational component for per-domain signin overrides. Two modes,
- * switched by a 2-segment control:
+ * Presentational component for per-domain signin overrides. Three modes,
+ * switched by a 3-segment control:
  *
- * - "Any available method" (restrict_to === null): the sign-in page shows
- *   every globally-available method. Email / SSO carry per-domain availability
- *   toggles (AND semantics — a domain can only narrow a global method).
+ * - "Any available method" (signin_enabled && restrict_to === null): the
+ *   sign-in page shows every globally-available method. Email / SSO carry
+ *   per-domain availability toggles (AND semantics — a domain can only
+ *   narrow a global method).
  *
- * - "One specific method" (restrict_to !== null): the sign-in page shows ONLY
- *   the chosen method. No availability toggles here, so "restrict to X while X
- *   disabled" is unexpressible. Picking a method also flips that method's
- *   availability flag on (the login page gates restrict_to through the same
- *   availability resolution), committed atomically in one PUT.
+ * - "One specific method" (signin_enabled && restrict_to !== null): the
+ *   sign-in page shows ONLY the chosen method. No availability toggles here,
+ *   so "restrict to X while X disabled" is unexpressible. Picking a method
+ *   also flips that method's availability flag on (the login page gates
+ *   restrict_to through the same availability resolution), committed
+ *   atomically in one PUT.
  *
- * Only globally-available methods are offered in either mode — otherwise a
- * restrict_to value with no backing method would yield a blank login page.
+ * - "Sign-in disabled" (signin_enabled === false): no sign-in at all on this
+ *   domain. The public sign-in page shows a "not available" notice and POST
+ *   /signin is blocked server-side. restrict_to and the availability flags
+ *   are preserved so switching back restores the previous setup.
+ *
+ * Only globally-available methods are offered in either method mode —
+ * otherwise a restrict_to value with no backing method would yield a blank
+ * login page.
  *
  * Everything auto-saves (PUT is full-replacement); there is no Save button.
  */
@@ -88,7 +96,17 @@ const { t } = useI18n();
  */
 const oneSelectedIntent = ref(false);
 
-const isModeOne = computed(() => props.formState.restrict_to !== null || oneSelectedIntent.value);
+/**
+ * "Sign-in disabled" wins over a preserved restrict_to: when signin_enabled
+ * is false the method modes are not shown, whatever restrict_to holds.
+ */
+const isModeDisabled = computed(() => props.formState.signin_enabled === false);
+
+const isModeOne = computed(
+  () => !isModeDisabled.value && (props.formState.restrict_to !== null || oneSelectedIntent.value)
+);
+
+const isModeAny = computed(() => !isModeDisabled.value && !isModeOne.value);
 
 // ---------------------------------------------------------------------------
 // Method availability (only offer globally-available methods)
@@ -157,20 +175,40 @@ const isEditing = computed(() => props.isConfigured);
 // Handlers
 // ---------------------------------------------------------------------------
 
-/** Switch to "Any available method": clears restrict_to (REPLACE → show all). */
+/**
+ * Switch to "Any available method": clears restrict_to (REPLACE → show all)
+ * and re-enables sign-in when coming from "Sign-in disabled" — committed
+ * atomically as one PUT.
+ */
 const selectModeAny = () => {
   oneSelectedIntent.value = false;
-  if (props.formState.restrict_to !== null) {
-    emit('auto-save', { restrict_to: null }, 'restrict_to');
-  }
+  const patch: Partial<SigninConfigFormState> = {};
+  if (props.formState.restrict_to !== null) patch.restrict_to = null;
+  if (!props.formState.signin_enabled) patch.signin_enabled = true;
+  if (Object.keys(patch).length === 0) return;
+  emit('auto-save', patch, 'restrict_to');
 };
 
 /**
  * Switch to "One specific method": reveal the picker locally but do NOT save
- * until a method is actually chosen (no method = nothing to persist).
+ * until a method is actually chosen (no method = nothing to persist). Coming
+ * from "Sign-in disabled", re-enabling IS persisted immediately — sign-in
+ * must come back on even before a method is picked (a preserved restrict_to
+ * restores that method; null shows the picker).
  */
 const selectModeOne = () => {
   oneSelectedIntent.value = true;
+  if (!props.formState.signin_enabled) {
+    emit('auto-save', { signin_enabled: true }, 'signin_enabled');
+  }
+};
+
+/** Switch to "Sign-in disabled": persists signin_enabled=false immediately. */
+const selectModeDisabled = () => {
+  oneSelectedIntent.value = false;
+  if (props.formState.signin_enabled) {
+    emit('auto-save', { signin_enabled: false }, 'signin_enabled');
+  }
 };
 
 /**
@@ -186,6 +224,7 @@ const selectMethod = (value: SigninRestrictTo) => {
   const patch: Partial<SigninConfigFormState> = { restrict_to: value };
   if (value === 'email_auth') patch.email_auth_enabled = true;
   if (value === 'sso') patch.sso_enabled = true;
+  if (!props.formState.signin_enabled) patch.signin_enabled = true;
   emit('auto-save', patch, 'restrict_to');
 };
 
@@ -220,12 +259,12 @@ const handleDelete = () => {
             id="signin-mode-any"
             type="button"
             role="radio"
-            :aria-checked="!isModeOne"
+            :aria-checked="isModeAny"
             :disabled="isSaving"
             @click="selectModeAny"
             :class="[
               'rounded-md px-4 py-1.5 text-sm font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500',
-              !isModeOne
+              isModeAny
                 ? 'bg-white text-gray-900 shadow-sm dark:bg-gray-800 dark:text-white'
                 : 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200',
             ]">
@@ -246,19 +285,57 @@ const handleDelete = () => {
             ]">
             {{ t('web.domains.signin.mode_one') }}
           </button>
+          <button
+            id="signin-mode-disabled"
+            type="button"
+            role="radio"
+            :aria-checked="isModeDisabled"
+            :disabled="isSaving"
+            @click="selectModeDisabled"
+            :class="[
+              'rounded-md px-4 py-1.5 text-sm font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500',
+              isModeDisabled
+                ? 'bg-white text-gray-900 shadow-sm dark:bg-gray-800 dark:text-white'
+                : 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200',
+            ]">
+            {{ t('web.domains.signin.mode_disabled') }}
+          </button>
         </div>
 
         <p
           id="signin-mode-hint"
           class="mt-2 text-sm text-gray-500 dark:text-gray-400">
-          {{ isModeOne ? t('web.domains.signin.mode_one_hint') : t('web.domains.signin.mode_any_hint') }}
+          {{
+            isModeDisabled
+              ? t('web.domains.signin.mode_disabled_hint')
+              : isModeOne
+                ? t('web.domains.signin.mode_one_hint')
+                : t('web.domains.signin.mode_any_hint')
+          }}
         </p>
       </fieldset>
 
       <!-- ===================================================================
+           Mode: Sign-in disabled — no method list; explain what visitors see
+           =================================================================== -->
+      <div
+        v-if="isModeDisabled"
+        data-testid="signin-disabled-mode-notice"
+        class="flex items-start gap-3 rounded-md bg-amber-50 px-4 py-3 dark:bg-amber-900/20">
+        <OIcon
+          collection="heroicons"
+          name="information-circle"
+          class="mt-0.5 size-5 flex-shrink-0 text-amber-500 dark:text-amber-400"
+          aria-hidden="true" />
+        <p class="flex-1 text-sm text-amber-700 dark:text-amber-300">
+          {{ t('web.domains.signin.mode_disabled_notice') }}
+        </p>
+      </div>
+
+      <!-- ===================================================================
            Mode A — Any available method: static rows + availability toggles
            =================================================================== -->
-      <fieldset v-if="!isModeOne" class="space-y-3">
+      <fieldset v-else-if="!isModeOne" class="space-y-3">
         <legend class="text-sm font-medium text-gray-900 dark:text-white">
           {{ t('web.domains.signin.methods_list_label') }}
         </legend>

--- a/src/schemas/contracts/bootstrap.ts
+++ b/src/schemas/contracts/bootstrap.ts
@@ -263,6 +263,10 @@ const organizationFeaturesInner = z.object({
 
 export const featuresSchema = z.object({
   markdown: z.boolean().default(false),
+  // Sign-in availability for the current domain context (AND of global
+  // AUTH_SIGNIN and the domain SigninConfig). false renders the public
+  // /signin page as a friendly "not available" notice (#3415).
+  signin: z.boolean().optional(),
   mfa: z.boolean().optional(),
   lockout: z.boolean().optional(),
   password_requirements: z.boolean().optional(),

--- a/src/schemas/contracts/bootstrap.ts
+++ b/src/schemas/contracts/bootstrap.ts
@@ -264,8 +264,10 @@ const organizationFeaturesInner = z.object({
 export const featuresSchema = z.object({
   markdown: z.boolean().default(false),
   // Sign-in availability for the current domain context (AND of global
-  // AUTH_SIGNIN and the domain SigninConfig). false renders the public
-  // /signin page as a friendly "not available" notice (#3415).
+  // AUTH_SIGNIN and the domain SigninConfig). Only an explicit false
+  // disables — it renders the public /signin page as a friendly "not
+  // available" notice (#3415); true and undefined (older backends) both
+  // keep the auth form.
   signin: z.boolean().optional(),
   mfa: z.boolean().optional(),
   lockout: z.boolean().optional(),

--- a/src/tests/apps/session/views/Login.spec.ts
+++ b/src/tests/apps/session/views/Login.spec.ts
@@ -48,6 +48,14 @@ vi.mock('@/utils/features', () => ({
   hasPasswordlessMethods: () => false,
 }));
 
+vi.mock('@/shared/components/icons/OIcon.vue', () => ({
+  default: {
+    name: 'OIcon',
+    template: '<span class="o-icon" :data-icon-name="name" />',
+    props: ['collection', 'name', 'size'],
+  },
+}));
+
 // Mock stores
 vi.mock('@/shared/stores/languageStore', () => ({
   useLanguageStore: () => ({
@@ -72,6 +80,8 @@ const i18n = createI18n({
           },
           create_account_prefix: "Don't have an account?",
           create_account_link: 'Sign up',
+          signin_disabled_heading: 'Sign-in is not available',
+          signin_disabled_message: 'Sign-in is currently not available on this domain.',
         },
       },
     },
@@ -82,7 +92,10 @@ describe('Login.vue auth_error handling', () => {
   let router: Router;
   let wrapper: VueWrapper;
 
-  const createWrapper = async (query: Record<string, string> = {}) => {
+  const createWrapper = async (
+    query: Record<string, string> = {},
+    initialState: Record<string, unknown> = {}
+  ) => {
     router = createRouter({
       history: createMemoryHistory(),
       routes: [
@@ -102,6 +115,7 @@ describe('Login.vue auth_error handling', () => {
           createTestingPinia({
             createSpy: vi.fn,
             stubActions: false,
+            initialState,
           }),
         ],
         stubs: {
@@ -218,6 +232,69 @@ describe('Login.vue auth_error handling', () => {
 
       const alert = wrapper.find('[role="alert"]');
       expect(alert.exists()).toBe(true);
+    });
+  });
+
+  // ---------------------------------------------------------------------
+  // Per-domain sign-in disable (#3415)
+  //
+  // features.signin is the resolved availability for the current domain
+  // context (AND of global AUTH_SIGNIN and the domain SigninConfig). An
+  // explicit false renders a friendly "not available" panel instead of
+  // the auth form; true or absent (older backends) renders the form.
+  // ---------------------------------------------------------------------
+
+  describe('per-domain sign-in disabled (features.signin === false)', () => {
+    const disabledState = { bootstrap: { features: { signin: false } } };
+
+    it('renders the disabled panel instead of the auth form', async () => {
+      wrapper = await createWrapper({}, disabledState);
+      await flushPromises();
+
+      expect(wrapper.find('[data-testid="signin-disabled-panel"]').exists()).toBe(true);
+      expect(wrapper.find('[data-testid="auth-method-selector"]').exists()).toBe(false);
+    });
+
+    it('shows the not-available message', async () => {
+      wrapper = await createWrapper({}, disabledState);
+      await flushPromises();
+
+      expect(wrapper.text()).toContain('Sign-in is currently not available on this domain.');
+    });
+
+    it('switches the page heading and enables the return-home affordance', async () => {
+      wrapper = await createWrapper({}, disabledState);
+      await flushPromises();
+
+      const authView = wrapper.findComponent({ name: 'AuthView' });
+      expect(authView.props('heading')).toBe('Sign-in is not available');
+      expect(authView.props('showReturnHome')).toBe(true);
+    });
+
+    it('hides the footer sign-in options', async () => {
+      wrapper = await createWrapper({}, disabledState);
+      await flushPromises();
+
+      expect(wrapper.find('nav[aria-label="Additional sign-in options"]').exists()).toBe(false);
+    });
+
+    it('renders the auth form when features.signin is true', async () => {
+      wrapper = await createWrapper({}, { bootstrap: { features: { signin: true } } });
+      await flushPromises();
+
+      expect(wrapper.find('[data-testid="auth-method-selector"]').exists()).toBe(true);
+      expect(wrapper.find('[data-testid="signin-disabled-panel"]').exists()).toBe(false);
+
+      const authView = wrapper.findComponent({ name: 'AuthView' });
+      expect(authView.props('showReturnHome')).toBe(false);
+    });
+
+    it('renders the auth form when features.signin is absent (older backends)', async () => {
+      wrapper = await createWrapper({});
+      await flushPromises();
+
+      expect(wrapper.find('[data-testid="auth-method-selector"]').exists()).toBe(true);
+      expect(wrapper.find('[data-testid="signin-disabled-panel"]').exists()).toBe(false);
     });
   });
 });

--- a/src/tests/apps/workspace/components/domains/DomainSigninConfigForm.spec.ts
+++ b/src/tests/apps/workspace/components/domains/DomainSigninConfigForm.spec.ts
@@ -324,13 +324,15 @@ describe('DomainSigninConfigForm', () => {
       expect(wrapper.find('[data-testid="signin-disabled-mode-notice"]').exists()).toBe(false);
     });
 
-    it('re-enabling via "Any available method" saves signin_enabled=true', async () => {
+    it('re-enabling via "Any available method" saves signin_enabled=true with matching field key', async () => {
+      // The saving-field hint must name what is actually in the patch: a
+      // pure re-enable (restrict_to already null) saves signin_enabled only.
       wrapper = mountForm({ formState: disabledFormState });
       await wrapper.find('#signin-mode-any').trigger('click');
 
       const emitted = wrapper.emitted('auto-save');
       expect(emitted).toBeTruthy();
-      expect(emitted![0][0]).toEqual({ signin_enabled: true });
+      expect(emitted![0]).toEqual([{ signin_enabled: true }, 'signin_enabled']);
     });
 
     it('re-enabling via Any also clears a preserved restrict_to atomically', async () => {
@@ -338,7 +340,10 @@ describe('DomainSigninConfigForm', () => {
       await wrapper.find('#signin-mode-any').trigger('click');
 
       const emitted = wrapper.emitted('auto-save');
-      expect(emitted![0][0]).toEqual({ restrict_to: null, signin_enabled: true });
+      expect(emitted![0]).toEqual([
+        { restrict_to: null, signin_enabled: true },
+        'restrict_to',
+      ]);
     });
 
     it('re-enabling via "One specific method" saves signin_enabled=true immediately', async () => {
@@ -853,29 +858,59 @@ describe('DomainSigninConfigForm', () => {
     });
 
     // -------------------------------------------------------------------
-    // Keyboard / roving-tabindex gap (documented, not enforced)
+    // Keyboard navigation (roving tabindex)
     //
-    // The frontend agent flagged that the mode switch is built from plain
-    // <button>s in a role="radiogroup" WITHOUT arrow-key roving tabindex —
-    // an ARIA radiogroup is expected to manage a single tab-stop and move
-    // selection with Arrow keys. These tests document the CURRENT behavior
-    // (each segment is natively Tab-reachable; Enter/click activates) and
-    // make the missing roving visible without failing the build.
-    //
-    // TODO a11y: roving tabindex — the radiogroup segments should use a
-    // single tab-stop with arrow-key navigation and aria-checked-driven
-    // focus, rather than being independently Tab-focusable <button>s.
+    // The radiogroup is a single tab stop: the CHECKED segment carries
+    // tabindex="0", the others "-1". Arrow keys move focus between
+    // segments WITHOUT selecting — activation stays on click/Enter/Space
+    // (manual activation), because selecting a mode fires an auto-save
+    // PUT and selection-follows-focus would write on every arrow press.
     // -------------------------------------------------------------------
-    describe('keyboard navigation (roving-tabindex gap)', () => {
-      it('mode segments are each independently Tab-reachable (no roving tabindex)', () => {
+    describe('keyboard navigation (roving tabindex)', () => {
+      it('only the checked segment is in the tab order', () => {
+        wrapper = mountForm(); // defaults to mode Any
+        expect(wrapper.find('#signin-mode-any').attributes('tabindex')).toBe('0');
+        expect(wrapper.find('#signin-mode-one').attributes('tabindex')).toBe('-1');
+        expect(wrapper.find('#signin-mode-disabled').attributes('tabindex')).toBe('-1');
+      });
+
+      it('the tab stop follows the checked segment', () => {
+        wrapper = mountForm({ formState: { ...defaultFormState, signin_enabled: false } });
+        expect(wrapper.find('#signin-mode-disabled').attributes('tabindex')).toBe('0');
+        expect(wrapper.find('#signin-mode-any').attributes('tabindex')).toBe('-1');
+        expect(wrapper.find('#signin-mode-one').attributes('tabindex')).toBe('-1');
+      });
+
+      it('ArrowRight moves focus to the next segment without selecting', async () => {
         wrapper = mountForm();
         const any = wrapper.find('#signin-mode-any');
-        const one = wrapper.find('#signin-mode-one');
-        // Roving would set tabindex="-1" on the unselected segment; current
-        // markup sets none, so both are in the natural tab order. Documenting
-        // the gap: neither carries a roving tabindex attribute.
-        expect(any.attributes('tabindex')).toBeUndefined();
-        expect(one.attributes('tabindex')).toBeUndefined();
+        (any.element as HTMLElement).focus();
+        await any.trigger('keydown', { key: 'ArrowRight' });
+
+        expect(document.activeElement?.id).toBe('signin-mode-one');
+        // Focus moved, nothing selected or saved.
+        expect(wrapper.find('#signin-mode-any').attributes('aria-checked')).toBe('true');
+        expect(wrapper.emitted('auto-save')).toBeFalsy();
+      });
+
+      it('ArrowLeft wraps from the first to the last segment', async () => {
+        wrapper = mountForm();
+        const any = wrapper.find('#signin-mode-any');
+        (any.element as HTMLElement).focus();
+        await any.trigger('keydown', { key: 'ArrowLeft' });
+
+        expect(document.activeElement?.id).toBe('signin-mode-disabled');
+      });
+
+      it('End jumps to the last segment, Home back to the first', async () => {
+        wrapper = mountForm();
+        const any = wrapper.find('#signin-mode-any');
+        (any.element as HTMLElement).focus();
+        await any.trigger('keydown', { key: 'End' });
+        expect(document.activeElement?.id).toBe('signin-mode-disabled');
+
+        await wrapper.find('#signin-mode-disabled').trigger('keydown', { key: 'Home' });
+        expect(document.activeElement?.id).toBe('signin-mode-any');
       });
 
       it('activating a segment via keyboard (Enter→click) switches mode', async () => {

--- a/src/tests/apps/workspace/components/domains/DomainSigninConfigForm.spec.ts
+++ b/src/tests/apps/workspace/components/domains/DomainSigninConfigForm.spec.ts
@@ -1,15 +1,18 @@
 // src/tests/apps/workspace/components/domains/DomainSigninConfigForm.spec.ts
 //
-// Tests for DomainSigninConfigForm.vue covering the two-mode redesign:
+// Tests for DomainSigninConfigForm.vue covering the three-mode design:
 // 1. Loading skeleton display
-// 2. Mode switch (Any available method / One specific method) as radiogroup
+// 2. Mode switch (Any available method / One specific method / Sign-in
+//    disabled) as radiogroup
 // 3. Mode A: static rows + availability toggles (email_auth, sso), auto-save
 // 4. Mode B: single-choice restrict_to radios, picking flips availability flag
-// 5. Global availability gating hides unavailable methods in both modes
-// 6. SSO Configure reachable in both modes; upgrade hint when !canManageSso
-// 7. Per-field loading feedback via savingField
-// 8. Delete confirmation two-step
-// 9. Accessibility (radiogroup roles, aria-describedby, role="switch")
+// 5. Disabled mode (#3415): persists signin_enabled=false, hides method UI,
+//    preserves restrict_to/flags; re-enabling transitions save atomically
+// 6. Global availability gating hides unavailable methods in both method modes
+// 7. SSO Configure reachable in both method modes; upgrade hint when !canManageSso
+// 8. Per-field loading feedback via savingField
+// 9. Delete confirmation two-step
+// 10. Accessibility (radiogroup roles, aria-describedby, role="switch")
 
 import { readFileSync } from 'fs';
 import { resolve } from 'path';
@@ -100,6 +103,8 @@ const COPY = {
   availabilityGlobalOff: t('web.domains.signin.availability_global_off'),
   availabilityUnavailable: t('web.domains.signin.availability_unavailable'),
   allowOnDomain: t('web.domains.signin.allow_on_domain'),
+  modeDisabledHint: t('web.domains.signin.mode_disabled_hint'),
+  modeDisabledNotice: t('web.domains.signin.mode_disabled_notice'),
   resetToDefaults: t('web.domains.signin.reset_to_defaults'),
   resetConfirm: t('web.domains.signin.reset_confirm'),
   resetAction: t('web.domains.signin.reset_action'),
@@ -239,6 +244,118 @@ describe('DomainSigninConfigForm', () => {
       // Picker is revealed (radio list rendered) but nothing persisted yet.
       expect(wrapper.find('#signin-restrict-password').exists()).toBe(true);
       expect(wrapper.emitted('auto-save')).toBeFalsy();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Mode: Sign-in disabled (#3415)
+  //
+  // Third segment in the mode switch. signin_enabled === false wins over a
+  // preserved restrict_to for display; transitions persist signin_enabled
+  // atomically with whatever else the target mode requires.
+  // -----------------------------------------------------------------------
+
+  describe('mode: sign-in disabled', () => {
+    const disabledFormState: SigninConfigFormState = {
+      ...defaultFormState,
+      signin_enabled: false,
+    };
+
+    it('renders the third segment in the mode switch', () => {
+      wrapper = mountForm();
+      expect(wrapper.find('#signin-mode-disabled').exists()).toBe(true);
+      expect(wrapper.find('#signin-mode-disabled').attributes('role')).toBe('radio');
+    });
+
+    it('is checked when signin_enabled is false', () => {
+      wrapper = mountForm({ formState: disabledFormState });
+      expect(wrapper.find('#signin-mode-disabled').attributes('aria-checked')).toBe('true');
+      expect(wrapper.find('#signin-mode-any').attributes('aria-checked')).toBe('false');
+      expect(wrapper.find('#signin-mode-one').attributes('aria-checked')).toBe('false');
+    });
+
+    it('wins over a preserved restrict_to for display', () => {
+      wrapper = mountForm({ formState: { ...disabledFormState, restrict_to: 'sso' } });
+      expect(wrapper.find('#signin-mode-disabled').attributes('aria-checked')).toBe('true');
+      expect(wrapper.find('#signin-mode-one').attributes('aria-checked')).toBe('false');
+    });
+
+    it('clicking "Sign-in disabled" auto-saves signin_enabled=false', async () => {
+      wrapper = mountForm(); // defaultFormState has signin_enabled: true
+      await wrapper.find('#signin-mode-disabled').trigger('click');
+
+      const emitted = wrapper.emitted('auto-save');
+      expect(emitted).toBeTruthy();
+      expect(emitted![0]).toEqual([{ signin_enabled: false }, 'signin_enabled']);
+    });
+
+    it('clicking it again when already disabled does not auto-save', async () => {
+      wrapper = mountForm({ formState: disabledFormState });
+      await wrapper.find('#signin-mode-disabled').trigger('click');
+      expect(wrapper.emitted('auto-save')).toBeFalsy();
+    });
+
+    it('disabling does NOT clear restrict_to or availability flags (preserved for re-enable)', async () => {
+      wrapper = mountForm({
+        formState: { ...defaultFormState, restrict_to: 'sso', sso_enabled: true },
+      });
+      await wrapper.find('#signin-mode-disabled').trigger('click');
+
+      const patch = wrapper.emitted('auto-save')![0][0] as Partial<SigninConfigFormState>;
+      expect(Object.keys(patch)).toEqual(['signin_enabled']);
+    });
+
+    it('hides method toggles and radios while disabled', () => {
+      wrapper = mountForm({ formState: { ...disabledFormState, restrict_to: 'sso' } });
+      expect(toggles(wrapper)).toHaveLength(0);
+      expect(wrapper.findAll('input[type="radio"][name="restrict_to"]')).toHaveLength(0);
+    });
+
+    it('shows the disabled-mode hint and notice', () => {
+      wrapper = mountForm({ formState: disabledFormState });
+      expect(wrapper.find('#signin-mode-hint').text()).toContain(COPY.modeDisabledHint);
+      expect(wrapper.find('[data-testid="signin-disabled-mode-notice"]').text()).toContain(
+        COPY.modeDisabledNotice
+      );
+    });
+
+    it('does not show the notice in the method modes', () => {
+      wrapper = mountForm();
+      expect(wrapper.find('[data-testid="signin-disabled-mode-notice"]').exists()).toBe(false);
+    });
+
+    it('re-enabling via "Any available method" saves signin_enabled=true', async () => {
+      wrapper = mountForm({ formState: disabledFormState });
+      await wrapper.find('#signin-mode-any').trigger('click');
+
+      const emitted = wrapper.emitted('auto-save');
+      expect(emitted).toBeTruthy();
+      expect(emitted![0][0]).toEqual({ signin_enabled: true });
+    });
+
+    it('re-enabling via Any also clears a preserved restrict_to atomically', async () => {
+      wrapper = mountForm({ formState: { ...disabledFormState, restrict_to: 'sso' } });
+      await wrapper.find('#signin-mode-any').trigger('click');
+
+      const emitted = wrapper.emitted('auto-save');
+      expect(emitted![0][0]).toEqual({ restrict_to: null, signin_enabled: true });
+    });
+
+    it('re-enabling via "One specific method" saves signin_enabled=true immediately', async () => {
+      // Unlike the Any→One transition (which persists nothing until a method
+      // is picked), leaving the disabled state must persist signin_enabled
+      // right away — the public page should stop showing the notice.
+      wrapper = mountForm({ formState: disabledFormState });
+      await wrapper.find('#signin-mode-one').trigger('click');
+
+      const emitted = wrapper.emitted('auto-save');
+      expect(emitted).toBeTruthy();
+      expect(emitted![0]).toEqual([{ signin_enabled: true }, 'signin_enabled']);
+    });
+
+    it('mode switch segments are disabled while saving', () => {
+      wrapper = mountForm({ isSaving: true });
+      expect(wrapper.find('#signin-mode-disabled').attributes('disabled')).toBeDefined();
     });
   });
 

--- a/src/tests/components/DomainHeader.spec.ts
+++ b/src/tests/components/DomainHeader.spec.ts
@@ -137,12 +137,16 @@ describe('DomainHeader', () => {
       expect(link.attributes('href')).toBe('https://example.com/incoming');
     });
 
-    it('hides external link when hasUnsavedChanges is true', () => {
+    // The external link is ALWAYS visible since e42617e ([#3383] "always
+    // show domain icon" — the showExternalLink computed and its v-show were
+    // removed). These cases pin that contract across the two conditions
+    // that previously hid it.
+
+    it('keeps external link visible when hasUnsavedChanges is true', () => {
       const domain = createMockDomain();
       const wrapper = mountComponent({ domain, hasUnsavedChanges: true });
       const link = wrapper.find('a[target="_blank"]');
-      // v-show sets display:none, element still exists
-      expect(link.isVisible()).toBe(false);
+      expect(link.isVisible()).toBe(true);
     });
 
     it('shows external link when hasUnsavedChanges is false and domain is active', () => {
@@ -152,17 +156,14 @@ describe('DomainHeader', () => {
       expect(link.isVisible()).toBe(true);
     });
 
-    it('hides external link when the domain is not active', () => {
-      // Inactive/unverified domains have no live frontend — the external
-      // link would resolve to a non-functional host. Hide it regardless
-      // of the unsaved-changes flag.
+    it('keeps external link visible when the domain is not active', () => {
       mockIsActive.value = false;
       mockDisplayStatus.value = 'Pending';
       mockStatusIcon.value = 'close-circle';
       const domain = createMockDomain();
       const wrapper = mountComponent({ domain, hasUnsavedChanges: false });
       const link = wrapper.find('a[target="_blank"]');
-      expect(link.isVisible()).toBe(false);
+      expect(link.isVisible()).toBe(true);
     });
   });
 

--- a/try/integration/domain_auth_enforcement_try.rb
+++ b/try/integration/domain_auth_enforcement_try.rb
@@ -13,6 +13,7 @@
 # Also exercises the serializer-level visibility gates:
 #   - DomainSerializer.effective_signin_enabled? / effective_signup_enabled?
 #   - ConfigSerializer.resolve_restrict_to
+#   - ConfigSerializer.resolve_signin (features.signin display gate)
 #
 # Covers:
 #   1. No SigninConfig record -> falls back to global
@@ -22,6 +23,7 @@
 #   5. Default reconciliation: new SigninConfig conservative defaults
 #   6. Serializer visibility gates
 #   7. ConfigSerializer resolve_restrict_to domain override
+#   11. ConfigSerializer resolve_signin AND semantics (#3415)
 #
 # Run:
 #   try try/integration/domain_auth_enforcement_try.rb --agent
@@ -475,6 +477,93 @@ Core::Views::ConfigSerializer.send(:resolve_tenant_sso_config, { 'display_domain
   !Core::Views::ConfigSerializer.send(:resolve_tenant_sso_config, { 'display_domain' => @domain_sso_c.display_domain }).nil?,
 ]
 #=> [true, true]
+
+# ===================================================================
+# 11. ConfigSerializer resolve_signin (features.signin, AND semantics)
+# ===================================================================
+#
+# resolve_signin is the DISPLAY gate for per-domain sign-in disable
+# (#3415): it feeds features.signin in the bootstrap so the public
+# /signin page can render a friendly "not available" notice instead
+# of the auth form. Global signin comes from site.authentication
+# (AUTH_ENABLED + AUTH_SIGNIN) via view_vars['site'], so each case
+# passes it explicitly — no singleton stubbing needed. AND semantics:
+# a domain may DISABLE sign-in but can never enable it when sign-in
+# is globally off.
+
+@site_signin_on  = { 'authentication' => { 'enabled' => true, 'signin' => true } }
+@site_signin_off = { 'authentication' => { 'enabled' => true, 'signin' => false } }
+@site_auth_off   = { 'authentication' => { 'enabled' => false, 'signin' => true } }
+
+## resolve_signin: global on + no domain context => true
+Core::Views::ConfigSerializer.send(:resolve_signin, { 'site' => @site_signin_on })
+#=> true
+
+## resolve_signin: global signin off + no domain context => false
+Core::Views::ConfigSerializer.send(:resolve_signin, { 'site' => @site_signin_off })
+#=> false
+
+## resolve_signin: global auth master off + no domain context => false
+Core::Views::ConfigSerializer.send(:resolve_signin, { 'site' => @site_auth_off })
+#=> false
+
+## resolve_signin: domain with no SigninConfig => global (true)
+@domain_si_a = Onetime::CustomDomain.create!("dae-si-a-#{@ts}-#{SecureRandom.hex(2)}.example.com", @org.objid)
+Core::Views::ConfigSerializer.send(
+  :resolve_signin,
+  { 'site' => @site_signin_on, 'display_domain' => @domain_si_a.display_domain },
+)
+#=> true
+
+## resolve_signin: global on + master ON + signin_enabled false => false (domain disables)
+@domain_si_b = Onetime::CustomDomain.create!("dae-si-b-#{@ts}-#{SecureRandom.hex(2)}.example.com", @org.objid)
+@config_si_b = Onetime::CustomDomain::SigninConfig.create!(
+  domain_id: @domain_si_b.identifier,
+  enabled: true,
+  signin_enabled: false,
+)
+Core::Views::ConfigSerializer.send(
+  :resolve_signin,
+  { 'site' => @site_signin_on, 'display_domain' => @domain_si_b.display_domain },
+)
+#=> false
+
+## resolve_signin: global on + master ON + signin_enabled true => true
+@domain_si_c = Onetime::CustomDomain.create!("dae-si-c-#{@ts}-#{SecureRandom.hex(2)}.example.com", @org.objid)
+@config_si_c = Onetime::CustomDomain::SigninConfig.create!(
+  domain_id: @domain_si_c.identifier,
+  enabled: true,
+  signin_enabled: true,
+)
+Core::Views::ConfigSerializer.send(
+  :resolve_signin,
+  { 'site' => @site_signin_on, 'display_domain' => @domain_si_c.display_domain },
+)
+#=> true
+
+## resolve_signin: global OFF + master ON + signin_enabled true => false (domain cannot widen)
+Core::Views::ConfigSerializer.send(
+  :resolve_signin,
+  { 'site' => @site_signin_off, 'display_domain' => @domain_si_c.display_domain },
+)
+#=> false
+
+## resolve_signin: master OFF + signin_enabled false => global (true; config ignored)
+@domain_si_d = Onetime::CustomDomain.create!("dae-si-d-#{@ts}-#{SecureRandom.hex(2)}.example.com", @org.objid)
+@config_si_d = Onetime::CustomDomain::SigninConfig.create!(
+  domain_id: @domain_si_d.identifier,
+  enabled: false,
+  signin_enabled: false,
+)
+Core::Views::ConfigSerializer.send(
+  :resolve_signin,
+  { 'site' => @site_signin_on, 'display_domain' => @domain_si_d.display_domain },
+)
+#=> true
+
+## resolve_signin: missing site config => false (no global capability to narrow)
+Core::Views::ConfigSerializer.send(:resolve_signin, {})
+#=> false
 
 # --- Cleanup ---
 


### PR DESCRIPTION
## Summary

Closes #3415. Stacked on `feature/3383-sso-modal` (sub-task of #3383).

Wires the existing `SigninConfig.signin_enabled` state end-to-end so per-domain "sign-in disabled" is expressible in the admin UI and visible on the public sign-in page. No new master toggle — the existing form surface and data model are reused.

### Backend — surface the signal
- `ConfigSerializer.resolve_signin` mirrors `resolve_email_auth` with **AND semantics**: a domain can disable sign-in but can never enable it when it is globally off (`AUTH_ENABLED` + `AUTH_SIGNIN`). Exposed as `features.signin` in the bootstrap — baked into `features.*` like the sibling resolvers, no standalone bootstrap object.
- The runtime POST `/signin` gate (`Base#signin_enabled?`) is untouched and remains regression-covered.

### Public page — render the message
- `Login.vue`: when `features.signin === false`, renders a friendly "Sign-in is not available" panel instead of `AuthMethodSelector`, switches the page heading, hides the footer sign-in options, and enables `AuthView`'s existing `showReturnHome` affordance.
- **Global** sign-in-off behavior is unchanged: the `requiresFeature` route guard still redirects to `/` before this page renders, so the panel only appears for domain-level disables.

### Admin control — make it expressible
- `DomainSigninConfigForm.vue`: third segment "Sign-in disabled" in the "How can users sign in?" selector. Selecting it persists `signin_enabled=false` through the existing full-replacement PUT; the two method modes persist `signin_enabled=true` atomically with their own fields.
- `restrict_to` and the availability flags are preserved across disable, so re-enabling restores the previous setup. Disabled mode wins over a preserved `restrict_to` for display.

### i18n + tests
- New locale keys: `web.login.signin_disabled_heading/_message` (public notice), `web.domains.signin.mode_disabled/_hint/_notice` (selector).
- `featuresSchema`: optional boolean `signin`.
- Tryout section 11 in `domain_auth_enforcement_try.rb`: `resolve_signin` across global on/off × domain enabled/disabled, master-switch fallback, missing-site fail-closed.
- `Login.spec.ts`: disabled-panel branch (panel rendered, form hidden, heading/return-home, true/absent fallbacks).
- `DomainSigninConfigForm.spec.ts`: third mode segment, persistence payloads, preservation across disable, re-enable transitions.

## Acceptance criteria

- [x] Operator can disable sign-in for a custom domain from the admin form (master switch on + "Sign-in disabled" selected)
- [x] Domain `/signin` shows a friendly "not available / return home" message — not the auth form, not a silent redirect
- [x] Re-enabling (selecting a method mode) restores the normal sign-in form
- [x] Global sign-in-off behavior unchanged (existing guard still redirects to `/`)
- [x] POST `/signin` remains blocked server-side (existing `base.rb` gate, regression-covered in tryout sections 3–4)
- [x] Resolver honors AND semantics: a domain cannot enable sign-in when it is globally off
- [ ] In-browser verification on a live custom domain (`local-secrets1.afb.pet`) — not possible from this environment, needs a manual pass

## Test results

- `Login.spec.ts` + `DomainSigninConfigForm.spec.ts`: 92 passed
- Scoped suites (`apps/session`, `workspace/components/domains`, `router`, `utils`): 953 passed
- `bootstrap-schema-contract.spec.ts`: 84 passed; i18n `key-validation.spec.ts`: 11 passed
- `vue-tsc` type-check: clean
- Ruby tryouts: syntax-checked only — container has Ruby 3.3.6 but the Gemfile requires ≥ 3.4.7, so `domain_auth_enforcement_try.rb` needs CI to execute

https://claude.ai/code/session_01Tdz8GJoUu6AF9SjoLguGNT

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tdz8GJoUu6AF9SjoLguGNT)_