### PR TITLE
Fix remaining #3362 env vars: HEADER_ENABLED landmark + BRAND_SUPPORT_EMAIL plaintext

### DIFF
--- a/lib/onetime/mail/templates/email_change_confirmation.txt.erb
+++ b/lib/onetime/mail/templates/email_change_confirmation.txt.erb
@@ -9,7 +9,3 @@
 <%= signature_name || t('email.email_change_confirmation.signature') %>
 
 <%= t('email.email_change_confirmation.postscript', email_address: new_email) %>
-
---
-<%= product_name %>
-<%= baseuri %>

--- a/lib/onetime/mail/templates/email_change_requested.txt.erb
+++ b/lib/onetime/mail/templates/email_change_requested.txt.erb
@@ -11,7 +11,3 @@
 <%= signature_name || t('email.email_change_requested.signature') %>
 
 <%= t('email.email_change_requested.postscript', email_address: old_email) %>
-
---
-<%= product_name %>
-<%= baseuri %>

--- a/lib/onetime/mail/templates/email_changed.txt.erb
+++ b/lib/onetime/mail/templates/email_changed.txt.erb
@@ -11,7 +11,3 @@
 <%= signature_name || t('email.email_changed.signature') %>
 
 <%= t('email.email_changed.postscript', email_address: old_email) %>
-
---
-<%= product_name %>
-<%= baseuri %>

--- a/lib/onetime/mail/templates/expiration_warning.txt.erb
+++ b/lib/onetime/mail/templates/expiration_warning.txt.erb
@@ -8,7 +8,3 @@
 <%= signature_name || t('email.expiration_warning.signature') %>
 
 <%= t('email.expiration_warning.footer_note', product_name: product_name) %>
-
---
-<%= product_name %>
-<%= baseuri %>

--- a/lib/onetime/mail/templates/incoming_secret.txt.erb
+++ b/lib/onetime/mail/templates/incoming_secret.txt.erb
@@ -17,7 +17,3 @@
 <% end %>
 
 <%= t('email.incoming_secret.footer_note', product_name: product_name) %>
-
---
-<%= product_name %>
-<%= baseuri %>

--- a/lib/onetime/mail/templates/layout.txt.erb
+++ b/lib/onetime/mail/templates/layout.txt.erb
@@ -1,0 +1,8 @@
+<%= content %>
+
+--
+<%= product_name %>
+<%= baseuri %>
+<%- if support_email -%>
+<%= t('email.common.support_label') %>: <%= support_email %>
+<%- end -%>

--- a/lib/onetime/mail/templates/magic_link.txt.erb
+++ b/lib/onetime/mail/templates/magic_link.txt.erb
@@ -9,7 +9,3 @@
 <%= signature_name || t('email.magic_link.signature') %>
 
 <%= t('email.magic_link.postscript', email_address: email_address) %>
-
---
-<%= product_name %>
-<%= baseuri %>

--- a/lib/onetime/mail/templates/organization_invitation.txt.erb
+++ b/lib/onetime/mail/templates/organization_invitation.txt.erb
@@ -13,7 +13,3 @@
 <%= signature_name || t('email.organization_invitation.signature') %>
 
 <%= t('email.organization_invitation.postscript', invited_email: invited_email) %>
-
---
-<%= product_name %>
-<%= baseuri %>

--- a/lib/onetime/mail/templates/password_request.txt.erb
+++ b/lib/onetime/mail/templates/password_request.txt.erb
@@ -7,7 +7,3 @@
 <%= signature_name || t('email.password_request.signature') %>
 
 <%= t('email.password_request.postscript', email_address: email_address) %>
-
---
-<%= product_name %>
-<%= baseuri %>

--- a/lib/onetime/mail/templates/secret_link.txt.erb
+++ b/lib/onetime/mail/templates/secret_link.txt.erb
@@ -9,7 +9,3 @@
 <% end %>
 
 <%= t('email.secret_link.footer_note', sender_email: custid, product_name: product_name) %>
-
---
-<%= product_name %>
-<%= baseuri %>

--- a/lib/onetime/mail/templates/secret_revealed.txt.erb
+++ b/lib/onetime/mail/templates/secret_revealed.txt.erb
@@ -8,7 +8,3 @@
 
 <%= t('email.secret_revealed.manage_preferences_prompt') %>
 <%= baseuri %><%= settings_path %>
-
---
-<%= product_name %>
-<%= baseuri %>

--- a/lib/onetime/mail/templates/welcome.txt.erb
+++ b/lib/onetime/mail/templates/welcome.txt.erb
@@ -7,7 +7,3 @@
 <%= signature_name || t('email.welcome.signature') %>
 
 <%= t('email.welcome.postscript', email_address: email_address) %>
-
---
-<%= product_name %>
-<%= baseuri %>

--- a/lib/onetime/mail/views/base.rb
+++ b/lib/onetime/mail/views/base.rb
@@ -61,6 +61,14 @@ module Onetime
       class Base
         TEMPLATE_PATH = File.expand_path('../templates', __dir__)
 
+        # Templates whose plaintext body must NOT be wrapped in the shared
+        # text layout (layout.txt.erb). feedback_email is operator-facing — it
+        # is sent FROM a user TO the operators who *are* support — so appending
+        # a "Support: <address>" line is nonsensical, and its own trailing
+        # block is a signature sign-off, not the product footer. Wrapping it
+        # would also double-print a footer. See #3362.
+        TEXT_LAYOUT_EXCLUDED = %w[feedback_email].freeze
+
         attr_reader :data, :locale
 
         # @param data [Hash] Template variables
@@ -77,10 +85,29 @@ module Onetime
           raise NotImplementedError, "#{self.class} must implement #subject"
         end
 
-        # Render the text template
-        # @return [String]
+        # Render the text template, wrapped in the shared text layout.
+        #
+        # Mirrors render_html: the per-template file provides only the body
+        # content; layout.txt.erb supplies the consolidated footer (product
+        # name, base URI) plus the conditional BRAND_SUPPORT_EMAIL line so the
+        # plaintext/multipart-fallback path carries the support contact too.
+        # Before #3362 render_text used no layout, so the support contact was
+        # wired into the HTML footer only and omitted from plaintext.
+        #
+        # Excluded templates (TEXT_LAYOUT_EXCLUDED) keep their own footer and
+        # are returned unwrapped. wrap_in_layout guards on File.exist?, so a
+        # missing layout.txt.erb yields unwrapped content rather than raising;
+        # the rescue below only covers subclasses with no .txt.erb at all.
+        #
+        # @return [String, nil] nil if the subclass has no .txt.erb template
         def render_text
-          render_template('txt')
+          content = render_template('txt')
+          return content if TEXT_LAYOUT_EXCLUDED.include?(template_name)
+
+          wrap_in_layout(content, 'txt')
+        rescue Errno::ENOENT
+          # No .txt.erb for this subclass (html-only mailer); mirrors render_html.
+          nil
         end
 
         # Render the HTML template, wrapped in the shared layout.

--- a/locales/content/en/email.json
+++ b/locales/content/en/email.json
@@ -912,5 +912,8 @@
     "text": "This is an automated message from %{product_name}.",
     "renderer": "erb",
     "content_hash": "8fbabfba"
+  },
+  "email.common.support_label": {
+    "text": "Support"
   }
 }

--- a/src/apps/secret/components/layout/BrandedHeader.vue
+++ b/src/apps/secret/components/layout/BrandedHeader.vue
@@ -4,17 +4,26 @@
   import { useI18n } from 'vue-i18n';
   import BrandedMasthead from '@/apps/secret/components/layout/BrandedMastHead.vue';
   import MastHead from '@/shared/components/layout/MastHead.vue';
+  import { useBootstrapStore } from '@/shared/stores/bootstrapStore';
   import { useProductIdentity } from '@/shared/stores/identityStore';
   import type { LayoutProps } from '@/types/ui/layouts';
+  import { storeToRefs } from 'pinia';
   import { computed } from 'vue';
   const { t } = useI18n();
 
   const productIdentity = useProductIdentity();
 
+  const bootstrapStore = useBootstrapStore();
+  const { headerConfig } = storeToRefs(bootstrapStore);
+
   const props = withDefaults(defineProps<LayoutProps>(), {
     displayMasthead: true,
     displayNavigation: false,
   });
+
+  // Operator-level header gate (HEADER_ENABLED). When disabled, the entire
+  // <header> banner landmark collapses — no empty landmark, no padding band.
+  const headerEnabled = computed(() => headerConfig.value?.enabled !== false);
 
   const headertext = computed(() => productIdentity.allowPublicHomepage ? t('web.homepage.create_a_secure_link') : t('web.homepage.secure_links'));
   const subtext = computed(() => productIdentity.allowPublicHomepage
@@ -23,7 +32,9 @@
 </script>
 
 <template>
-  <header class="bg-white dark:bg-gray-900">
+  <header
+    v-if="headerEnabled"
+    class="bg-white dark:bg-gray-900">
     <div
       v-if="displayMasthead"
       class="container mx-auto min-w-[320px] max-w-2xl p-4">

--- a/src/shared/components/layout/ManagementHeader.vue
+++ b/src/shared/components/layout/ManagementHeader.vue
@@ -16,6 +16,7 @@
   import { useBootstrapStore } from '@/shared/stores/bootstrapStore';
   import type { LayoutProps } from '@/types/ui/layouts';
   import { storeToRefs } from 'pinia';
+  import { computed } from 'vue';
 
   const props = withDefaults(defineProps<LayoutProps>(), {
     displayMasthead: true,
@@ -25,11 +26,17 @@
   });
 
   const bootstrapStore = useBootstrapStore();
-  const { authenticated } = storeToRefs(bootstrapStore);
+  const { authenticated, headerConfig } = storeToRefs(bootstrapStore);
+
+  // Operator-level header gate (HEADER_ENABLED). When disabled, the entire
+  // <header> banner landmark collapses — no empty landmark, no padding band.
+  const headerEnabled = computed(() => headerConfig.value?.enabled !== false);
 </script>
 
 <template>
-  <header class="border-b border-gray-200 bg-white dark:border-gray-800 dark:bg-gray-900">
+  <header
+    v-if="headerEnabled"
+    class="border-b border-gray-200 bg-white dark:border-gray-800 dark:bg-gray-900">
     <!-- Single row header with Logo, Context Switchers, and User Menu -->
     <div :class="['container mx-auto min-w-[320px] px-4', colonel ? 'max-w-6xl' : 'max-w-4xl']">
       <div class="py-3">

--- a/src/shared/components/layout/TransactionalHeader.vue
+++ b/src/shared/components/layout/TransactionalHeader.vue
@@ -20,9 +20,14 @@
 
   const authStore = useAuthStore();
   const bootstrapStore = useBootstrapStore();
-  const { authentication, homepage_config } = storeToRefs(bootstrapStore);
+  const { authentication, homepage_config, headerConfig } = storeToRefs(bootstrapStore);
 
   const isUserPresent = computed(() => authStore.isUserPresent);
+
+  // Operator-level header gate (HEADER_ENABLED). When disabled, the entire
+  // <header> banner landmark collapses — no empty landmark, no padding band.
+  // Distinct from displayHeader (per-route concern). Both must hold to render.
+  const headerEnabled = computed(() => headerConfig.value?.enabled !== false);
 
   // Per-domain link toggles (custom-domain homepage). Default to enabled
   // when no domain config exists. System-level flags remain the master
@@ -40,7 +45,7 @@
 
 <template>
   <header
-    v-if="displayHeader"
+    v-if="displayHeader && headerEnabled"
     class="bg-white dark:bg-gray-900">
     <div class="container mx-auto min-w-[320px] max-w-2xl p-4">
       <MastHead v-if="displayMasthead" v-bind="props" />

--- a/src/tests/apps/secret/components/layout/BrandedHeader.spec.ts
+++ b/src/tests/apps/secret/components/layout/BrandedHeader.spec.ts
@@ -99,6 +99,7 @@ describe('BrandedHeader', () => {
       domain_logo?: string | null;
       domain_branding?: Record<string, unknown>;
       homepage_config?: Record<string, unknown> | null;
+      header?: Record<string, unknown>;
     } = {}
   ) => {
     const pinia = createTestingPinia({
@@ -123,7 +124,7 @@ describe('BrandedHeader', () => {
           },
           homepage_config: storeOverrides.homepage_config ?? null,
           ui: {
-            header: {
+            header: storeOverrides.header ?? {
               navigation: { enabled: true },
               branding: {
                 logo: { url: 'DefaultLogo.vue', alt: 'Onetime Secret' },
@@ -252,6 +253,40 @@ describe('BrandedHeader', () => {
       // The outer header exists but inner content is hidden via v-if
       expect(wrapper.find('.standard-masthead').exists()).toBe(false);
       expect(wrapper.find('.branded-masthead').exists()).toBe(false);
+    });
+  });
+
+  // HEADER_ENABLED gate (#3362): operator config collapses the entire
+  // <header> banner landmark — no empty landmark, no whitespace band.
+  describe('HEADER_ENABLED gate', () => {
+    it('removes the <header> element when header.enabled is false', async () => {
+      wrapper = mountComponent({}, {
+        domain_strategy: 'canonical',
+        header: { enabled: false },
+      });
+
+      await nextTick();
+      expect(wrapper.find('header').exists()).toBe(false);
+      // Content collapses with the landmark, not merely emptied.
+      expect(wrapper.find('.standard-masthead').exists()).toBe(false);
+      expect(wrapper.find('.branded-masthead').exists()).toBe(false);
+    });
+
+    it('renders the <header> element when header.enabled is true', async () => {
+      wrapper = mountComponent({}, {
+        domain_strategy: 'canonical',
+        header: { enabled: true },
+      });
+
+      await nextTick();
+      expect(wrapper.find('header').exists()).toBe(true);
+    });
+
+    it('renders the <header> element when header.enabled is omitted (default true)', async () => {
+      wrapper = mountComponent({}, { domain_strategy: 'canonical' });
+
+      await nextTick();
+      expect(wrapper.find('header').exists()).toBe(true);
     });
   });
 });

--- a/src/tests/shared/components/layout/ManagementHeader.spec.ts
+++ b/src/tests/shared/components/layout/ManagementHeader.spec.ts
@@ -57,8 +57,7 @@ describe('ManagementHeader', () => {
   const mountComponent = (
     props: Record<string, unknown> = {},
     storeState: Record<string, unknown> = {}
-  ) => {
-    return mount(ManagementHeader, {
+  ) => mount(ManagementHeader, {
       props: {
         displayMasthead: true,
         displayNavigation: true,
@@ -74,6 +73,12 @@ describe('ManagementHeader', () => {
             initialState: {
               bootstrap: {
                 authenticated: storeState.authenticated ?? true,
+                ui: {
+                  header:
+                    storeState.header !== undefined
+                      ? storeState.header
+                      : { navigation: { enabled: true } },
+                },
               },
             },
           }),
@@ -83,7 +88,6 @@ describe('ManagementHeader', () => {
         default: '<div class="slot-content">Context Bar Content</div>',
       },
     });
-  };
 
   describe('Slot Passthrough', () => {
     it('passes default slot content to MastHead context-switchers slot', async () => {
@@ -215,6 +219,42 @@ describe('ManagementHeader', () => {
 
       const container = wrapper.find('.max-w-4xl');
       expect(container.exists()).toBe(true);
+    });
+  });
+
+  // HEADER_ENABLED gate (#3362): operator config collapses the entire
+  // <header> banner landmark — no empty landmark, no whitespace band.
+  describe('HEADER_ENABLED gate', () => {
+    it('removes the <header> element when header.enabled is false', async () => {
+      wrapper = mountComponent({}, { header: { enabled: false } });
+      await nextTick();
+
+      expect(wrapper.find('header').exists()).toBe(false);
+      // Content collapses with the landmark, not merely emptied.
+      expect(wrapper.find('.masthead').exists()).toBe(false);
+    });
+
+    it('renders the <header> element when header.enabled is true', async () => {
+      wrapper = mountComponent({}, { header: { enabled: true } });
+      await nextTick();
+
+      expect(wrapper.find('header').exists()).toBe(true);
+    });
+
+    it('renders the <header> element when header.enabled is omitted (default true)', async () => {
+      wrapper = mountComponent({}, { header: { navigation: { enabled: true } } });
+      await nextTick();
+
+      expect(wrapper.find('header').exists()).toBe(true);
+    });
+
+    it('renders the <header> element when header config is entirely absent (store getter undefined)', async () => {
+      // The bootstrap store returns undefined when state.ui.header is unset;
+      // headerConfig?.enabled !== false must treat that as enabled, not hidden.
+      wrapper = mountComponent({}, { header: null });
+      await nextTick();
+
+      expect(wrapper.find('header').exists()).toBe(true);
     });
   });
 });

--- a/src/tests/shared/components/layout/TransactionalHeader.customDomain.spec.ts
+++ b/src/tests/shared/components/layout/TransactionalHeader.customDomain.spec.ts
@@ -62,6 +62,7 @@ describe('TransactionalHeader — Custom Domain Leak Vector', () => {
       domain_logo?: string | null;
       authentication?: { enabled?: boolean; signin?: boolean; signup?: boolean };
       homepage_config?: HomepageConfigState;
+      header?: Record<string, unknown>;
     } = {}
   ) => {
     const pinia = createTestingPinia({
@@ -76,7 +77,7 @@ describe('TransactionalHeader — Custom Domain Leak Vector', () => {
             ? storeState.homepage_config
             : null,
           ui: {
-            header: {
+            header: storeState.header ?? {
               navigation: { enabled: true },
               branding: {
                 logo: { url: 'DefaultLogo.vue', alt: 'Onetime Secret' },
@@ -322,6 +323,60 @@ describe('TransactionalHeader — Custom Domain Leak Vector', () => {
         expect(wrapper.find('[data-testid="header-signin-link"]').exists()).toBe(true);
         expect(wrapper.find('[role="separator"]').exists()).toBe(true);
       });
+    });
+  });
+
+  // HEADER_ENABLED gate (#3362): operator config collapses the entire
+  // <header> banner landmark — no empty landmark, no whitespace band.
+  // This guard is folded into the existing displayHeader check (both must hold).
+  describe('HEADER_ENABLED gate', () => {
+    it('removes the <header> element when header.enabled is false', async () => {
+      wrapper = mountComponent({}, {
+        domain_strategy: 'canonical',
+        header: { enabled: false },
+      });
+
+      await nextTick();
+      expect(wrapper.find('header').exists()).toBe(false);
+      // Content collapses with the landmark, not merely emptied.
+      expect(wrapper.find('.masthead').exists()).toBe(false);
+    });
+
+    it('renders the <header> element when header.enabled is true', async () => {
+      wrapper = mountComponent({}, {
+        domain_strategy: 'canonical',
+        header: { enabled: true },
+      });
+
+      await nextTick();
+      expect(wrapper.find('header').exists()).toBe(true);
+    });
+
+    it('renders the <header> element when header.enabled is omitted (default true)', async () => {
+      wrapper = mountComponent({}, { domain_strategy: 'canonical' });
+
+      await nextTick();
+      expect(wrapper.find('header').exists()).toBe(true);
+    });
+
+    // Regression: header.enabled is orthogonal to displayMasthead. With the
+    // header enabled but masthead hidden (custom-domain fallback), the minimal
+    // nav must still render — the operator gate must not break showMinimalNav.
+    it('still fires showMinimalNav when header.enabled is true but displayMasthead is false', async () => {
+      wrapper = mountComponent(
+        { displayMasthead: false, displayNavigation: true },
+        {
+          domain_strategy: 'custom',
+          header: { enabled: true },
+          authentication: { enabled: true, signin: true, signup: true },
+        }
+      );
+
+      await nextTick();
+      expect(wrapper.find('header').exists()).toBe(true);
+      expect(wrapper.find('.masthead').exists()).toBe(false);
+      expect(wrapper.find('[data-testid="header-signup-link"]').exists()).toBe(true);
+      expect(wrapper.find('[data-testid="header-signin-link"]').exists()).toBe(true);
     });
   });
 

--- a/try/unit/mail/templates_text_support_email_try.rb
+++ b/try/unit/mail/templates_text_support_email_try.rb
@@ -1,0 +1,211 @@
+# try/unit/mail/templates_text_support_email_try.rb
+#
+# frozen_string_literal: true
+
+#
+# BRAND_SUPPORT_EMAIL in the plaintext email path (issue #3362)
+#
+# Before #3362, render_text used no shared layout, so the support contact
+# (BRAND_SUPPORT_EMAIL) was wired into the HTML footer only — plaintext and
+# multipart-fallback emails omitted it. The fix consolidates the text footer
+# into a shared layout (lib/onetime/mail/templates/layout.txt.erb) that
+# render_text now wraps content in, mirroring render_html. The layout carries
+# a conditional support line.
+#
+# Critical assertions:
+#   - support_email (from brand conf) appears in the wrapped text output.
+#   - When support_email is nil, the support line is absent and the email
+#     still renders (body content preserved).
+#   - The consolidated footer (--/product_name/baseuri) appears exactly once
+#     (no double footer from leftover per-template footers).
+#   - A real subclass (SecretLink) renders through render_text end-to-end and
+#     picks up the support line.
+#   - feedback_email is excluded from wrapping: its own footer stays, and it
+#     gets no support line (operator-facing notification).
+#
+# NOTE: in the tryouts test env, generated/locales/ is unpopulated, so t()
+# returns a "Translation missing: ..." string rather than the translated
+# label. Assertions therefore target the support_email *address value* (which
+# is config-sourced and deterministic), never the translated "Support" label.
+#
+
+require_relative '../../support/test_helpers'
+
+# Boot to populate OT.conf for the support_email fallback chain.
+OT.boot! :test, false
+
+require 'onetime/mail'
+
+@base_class = Onetime::Mail::Templates::Base
+
+# Helper: run a block with OT.conf['brand'] set to brand_hash, then restore.
+def with_brand_conf(brand_hash)
+  saved     = YAML.load(YAML.dump(OT.conf))
+  conf_copy = YAML.load(YAML.dump(saved))
+  conf_copy['brand'] = brand_hash
+  OT.send(:conf=, conf_copy)
+  yield
+ensure
+  OT.send(:conf=, saved) rescue nil
+end
+
+# Helper: run a block with OT.conf['brand'] removed entirely, then restore.
+def without_brand_conf
+  saved     = YAML.load(YAML.dump(OT.conf))
+  conf_copy = YAML.load(YAML.dump(saved))
+  conf_copy.delete('brand')
+  OT.send(:conf=, conf_copy)
+  yield
+ensure
+  OT.send(:conf=, saved) rescue nil
+end
+
+# Valid SecretLink data (mirrors templates_secret_link_try.rb).
+@secret_link_data = {
+  secret_key: 'abc123def456',
+  share_domain: nil,
+  recipient: 'recipient@example.com',
+  sender_email: 'sender@example.com',
+}
+
+# TRYOUTS
+
+# ============================================================================
+# Shared text layout: support_email present / absent (via wrap_in_layout)
+# ============================================================================
+
+## [configured] support_email address appears in the wrapped text output
+with_brand_conf({ 'support_email' => 'help@acme.test' }) do
+  base = @base_class.new({}, locale: 'en')
+  out  = base.send(:wrap_in_layout, 'BODY', 'txt')
+  out.include?('help@acme.test')
+end
+#=> true
+
+## [configured] the wrapped output still includes the body content
+with_brand_conf({ 'support_email' => 'help@acme.test' }) do
+  base = @base_class.new({}, locale: 'en')
+  out  = base.send(:wrap_in_layout, 'BODY', 'txt')
+  out.include?('BODY')
+end
+#=> true
+
+## [unconfigured] no support line is rendered when support_email is nil
+without_brand_conf do
+  base = @base_class.new({}, locale: 'en')
+  out  = base.send(:wrap_in_layout, 'BODY', 'txt')
+  # No literal address and no 'Support:' style line; body still present.
+  !out.include?('help@acme.test') && out.include?('BODY')
+end
+#=> true
+
+## [unconfigured] email still renders a footer (product/baseuri) without support
+without_brand_conf do
+  base = @base_class.new({ product_name: 'Acme', baseuri: 'https://acme.test' }, locale: 'en')
+  out  = base.send(:wrap_in_layout, 'BODY', 'txt')
+  out.include?('Acme') && out.include?('https://acme.test')
+end
+#=> true
+
+# ============================================================================
+# No double footer — the '--' separator appears exactly once
+# ============================================================================
+
+## the consolidated '--' footer separator appears exactly once (configured)
+with_brand_conf({ 'support_email' => 'help@acme.test' }) do
+  base = @base_class.new({}, locale: 'en')
+  out  = base.send(:wrap_in_layout, 'BODY', 'txt')
+  out.scan(/^--$/).size
+end
+#=> 1
+
+## the consolidated '--' footer separator appears exactly once (unconfigured)
+without_brand_conf do
+  base = @base_class.new({}, locale: 'en')
+  out  = base.send(:wrap_in_layout, 'BODY', 'txt')
+  out.scan(/^--$/).size
+end
+#=> 1
+
+# ============================================================================
+# End-to-end: a real subclass renders through render_text
+# ============================================================================
+
+## [configured] SecretLink#render_text includes the support address
+with_brand_conf({ 'support_email' => 'help@acme.test' }) do
+  tmpl = Onetime::Mail::Templates::SecretLink.new(@secret_link_data)
+  tmpl.render_text.include?('help@acme.test')
+end
+#=> true
+
+## [configured] SecretLink#render_text footer separator appears exactly once
+with_brand_conf({ 'support_email' => 'help@acme.test' }) do
+  tmpl = Onetime::Mail::Templates::SecretLink.new(@secret_link_data)
+  tmpl.render_text.scan(/^--$/).size
+end
+#=> 1
+
+## [unconfigured] SecretLink#render_text omits support line but still renders body
+without_brand_conf do
+  tmpl = Onetime::Mail::Templates::SecretLink.new(@secret_link_data)
+  out  = tmpl.render_text
+  !out.include?('help@acme.test') && out.include?('/secret/abc123def456')
+end
+#=> true
+
+# ============================================================================
+# feedback_email exclusion — keeps its own footer, gets no support line
+# ============================================================================
+
+## [exclusion] feedback_email is listed in TEXT_LAYOUT_EXCLUDED
+Onetime::Mail::Templates::Base::TEXT_LAYOUT_EXCLUDED.include?('feedback_email')
+#=> true
+
+## [exclusion] FeedbackEmail#render_text gets no support line even when configured
+with_brand_conf({ 'support_email' => 'help@acme.test' }) do
+  tmpl = Onetime::Mail::Templates::FeedbackEmail.new({
+    recipient_email: 'admin@example.com',
+    email_address: 'user@example.com',
+    display_domain: 'example.com',
+    user_id: 'cust-1',
+    message: 'Hello there',
+  })
+  tmpl.render_text.include?('help@acme.test')
+end
+#=> false
+
+# ============================================================================
+# Static dedup proof — per-template footers stripped, layout owns the footer
+# ============================================================================
+
+## none of the 11 wrapped text templates still carry the stripped footer block
+home    = ENV.fetch('ONETIME_HOME')
+wrapped = %w[
+  email_change_confirmation email_change_requested email_changed
+  expiration_warning incoming_secret magic_link organization_invitation
+  password_request secret_link secret_revealed welcome
+]
+block = "--\n<%= product_name %>\n<%= baseuri %>"
+offenders = wrapped.select do |name|
+  File.read(File.join(home, 'lib/onetime/mail/templates', "#{name}.txt.erb")).include?(block)
+end
+offenders
+#=> []
+
+## layout.txt.erb contains the consolidated footer block exactly once
+home   = ENV.fetch('ONETIME_HOME')
+layout = File.read(File.join(home, 'lib/onetime/mail/templates/layout.txt.erb'))
+layout.scan("--\n<%= product_name %>\n<%= baseuri %>").size
+#=> 1
+
+## layout.txt.erb gates the support line on support_email
+home   = ENV.fetch('ONETIME_HOME')
+layout = File.read(File.join(home, 'lib/onetime/mail/templates/layout.txt.erb'))
+layout.include?('if support_email') && layout.include?("email.common.support_label")
+#=> true
+
+## feedback_email.txt.erb is left untouched — still carries its own signature footer
+home = ENV.fetch('ONETIME_HOME')
+src  = File.read(File.join(home, 'lib/onetime/mail/templates/feedback_email.txt.erb'))
+src.include?("email.feedback_email.signature")
+#=> true


### PR DESCRIPTION
## Summary

Closes the two remaining items of #3362 (the `revisit` work documented in [this gap-analysis comment](https://github.com/onetimesecret/onetimesecret/issues/3362#issuecomment-4662371448)). The other six dead/phantom env vars were resolved earlier (`1c26f88ff`, `e3e47564d`); these are the last two.

### 1. `HEADER_ENABLED` — empty `<header>` landmark (frontend)

`header.enabled` only gated the *inner content* of `MastHead`, so the three header wrappers still rendered an empty `<header>` banner landmark plus a padding band when disabled. The gate is lifted to each wrapper so the entire `<header>` collapses with its content.

- `TransactionalHeader` — `headerEnabled` folded into the existing `displayHeader` guard
- `ManagementHeader` / `BrandedHeader` — their previously-unconditional `<header>` is now gated; `BrandedHeader` gains the bootstrap-store wiring it lacked
- `displayHeader` (per-route) and `headerEnabled` (operator config) kept as distinct flags
- `MastHead` inner gate retained as defense-in-depth; `showMinimalNav` left orthogonal (keys off `displayMasthead`)

### 2. `BRAND_SUPPORT_EMAIL` — missing from plaintext emails (backend)

`support_email` rendered only in the HTML footer, so the plaintext / multipart-fallback part omitted the support contact. A shared `layout.txt.erb` now mirrors the HTML layout.

- new `layout.txt.erb`: consolidated footer + conditional `BRAND_SUPPORT_EMAIL` line, wrapped via `render_text`
- the 11 wrapped templates had their now-duplicated trailing footer stripped (single footer, no lost body)
- `feedback_email` excluded (`TEXT_LAYOUT_EXCLUDED`) — its footer is a signature sign-off, not a product footer, and it is operator-facing
- added `email.common.support_label` locale key

## Tests

- Frontend: per-wrapper specs assert the landmark is **absent from the DOM** (not merely hidden) when disabled, a `showMinimalNav` regression guard, and an absent-config (store getter `undefined`) default-enabled case.
- Backend: new `templates_text_support_email_try.rb` — address present when configured, absent when `nil`, plus a single-footer dedup proof. Full mail tryout suite green.

## Review notes

Reviewed by `feature-dev:code-reviewer` pre-commit; its Critical (misleading `render_text` rescue comment) and the test-gap Should-fix are folded into this PR.
