### PR TITLE
E2E: Phase 2.4 defensive-skip triage — env gates + quarantine

### DIFF
--- a/e2e/QUARANTINE.md
+++ b/e2e/QUARANTINE.md
@@ -1,9 +1,14 @@
 # E2E Test Quarantine
 
-> Part of the [E2E remediation plan](./docs/e2e-remediation-plan.md) (Phase 1).
-> **Flake is blocking, not silent**: CI fails on any test that passes only on
-> retry (a `flaky` outcome). A flaky test gets fixed, or it gets quarantined
-> here — it never rides green on a retry.
+> Part of the [E2E remediation plan](./docs/e2e-remediation-plan.md) (Phases 1
+> & 2.4). **Flake is blocking, not silent**: CI fails on any test that passes
+> only on retry (a `flaky` outcome). A flaky test gets fixed, or it gets
+> quarantined here — it never rides green on a retry.
+>
+> This file also tracks **deliberately-dormant** suites (Phase 2.4): tests that
+> cannot run in CI yet because they need fixtures or optional deployment config.
+> They are turned off honestly (`test.fixme`, or an env gate) and listed below
+> so **nobody mistakes a green run for full coverage.**
 
 ## How to quarantine a test
 
@@ -15,19 +20,69 @@
    });
    ```
 
-   `test.fixme` skips the test *and* fails it if it unexpectedly passes, so a
-   silently-recovered test surfaces instead of rotting here.
+   `test.fixme` skips the test and signals "this is known-broken / not-yet-
+   runnable" — unlike a bare `test.skip(true, ...)`, which silently reports a
+   non-running test as green and is banned by the remediation plan.
 
-2. Open (or link) a GitHub issue describing the flake: failure mode, frequency,
-   trace/HTML-report artifact links from the failing run.
+2. Open (or link) a GitHub issue describing why it can't run: missing fixture,
+   missing config, failure mode + trace/HTML-report links if it's a flake.
 
-3. Add a row to the table below. **Owner and issue link are mandatory** — an
-   unowned quarantined test is a deleted test waiting to happen.
+3. Add a row to the relevant table below. **Owner and issue link are
+   mandatory** — an unowned quarantined test is a deleted test waiting to
+   happen.
 
-4. Remove the row (and the `test.fixme`) in the PR that fixes the test.
+4. Remove the row (and the `test.fixme` / env gate) in the PR that makes the
+   test runnable again.
 
-## Quarantined tests
+## Quarantined tests (`test.fixme` — missing fixtures / unimplemented)
+
+These need **seeded data** (a second org, a second member, a captured email)
+that does not exist yet; the fixtures are Phase 3 / PR 6 work.
 
 | Test (file › title) | Owner | Issue | Quarantined | Reason |
 |---------------------|-------|-------|-------------|--------|
-| _none — keep it that way_ | | | | |
+| `full/cross-org-domain-isolation.spec.ts` › whole suite (8 tests) | delano | [#3420](https://github.com/onetimesecret/onetimesecret/issues/3420) | 2026-06-10 | Needs ≥2 orgs with disjoint custom-domain sets. Was the multi-org failure aborting #3412/#3416 CI (the DOM scraper also needs a rewrite). |
+| `full/domains-store-org-cache.spec.ts` › whole suite (5 tests) | delano | [#3420](https://github.com/onetimesecret/onetimesecret/issues/3420) | 2026-06-10 | Needs ≥2 orgs ("Default Workspace" + "Second Organization") with per-org domain caches to compare. |
+| `full/org-switcher-navigation.spec.ts` › whole suite | delano | [#3420](https://github.com/onetimesecret/onetimesecret/issues/3420) | 2026-06-10 | The org switcher only renders for accounts with ≥2 organizations. |
+| `full/domain-context-consultant.spec.ts` › 7 custom-domain placeholders | delano | [#3420](https://github.com/onetimesecret/onetimesecret/issues/3420) | 2026-06-10 | Unimplemented; each needs a custom domain. The 2 *no-custom-domain* tests in the file still run. |
+| `full/domain-sso-config.spec.ts` › TC-DSSO-019 (access denied without entitlement) | delano | [#3420](https://github.com/onetimesecret/onetimesecret/issues/3420) | 2026-06-10 | Inverted precondition — asserts the *absence* of `manage_sso`, but the suite is gated on its presence. Needs a no-entitlement lane. |
+| `full/invite-flow-states.spec.ts` › INV-002 new user via magic link | delano | [#3421](https://github.com/onetimesecret/onetimesecret/issues/3421) | 2026-06-10 | Magic link arrives by email; needs a mail interceptor (Mailpit/MailHog). |
+| `full/invite-flow-states.spec.ts` › INV-003 new user via SSO | delano | [#3421](https://github.com/onetimesecret/onetimesecret/issues/3421) | 2026-06-10 | Needs an SSO/IdP configured plus a captured invite email. |
+| `full/invite-flow-states.spec.ts` › INV-005 existing user with MFA | delano | [#3421](https://github.com/onetimesecret/onetimesecret/issues/3421) | 2026-06-10 | Needs an MFA-enrolled invitee account (`TEST_MFA_*`). |
+| `full/org-invitation-flow.spec.ts` › INV-012 Gmail alias normalization | delano | [#3421](https://github.com/onetimesecret/onetimesecret/issues/3421) | 2026-06-10 | Needs real Gmail accounts + captured invite email. (`normalizeEmail()` is unit-tested.) |
+| `full/org-invitation-flow.spec.ts` › INV-017 full invitation acceptance | delano | [#3421](https://github.com/onetimesecret/onetimesecret/issues/3421) | 2026-06-10 | Needs a second account to sign up with the invited email + Mailpit. |
+| `full-billing/pending-plan-intent.spec.ts` › Post-Verification Redirect | delano | [#3421](https://github.com/onetimesecret/onetimesecret/issues/3421) | 2026-06-10 | Needs a mail interceptor; CI runs `AUTH_AUTOVERIFY=true` and can't exercise the verification redirect. |
+
+> **Still owed (deferred to a CI-verified follow-up, not in this PR):** the
+> `organization-members` role/remove tests (issue
+> [#3419](https://github.com/onetimesecret/onetimesecret/issues/3419)) and the
+> org-existence `test.skip(true)` conversions in `organization-settings`,
+> `identifier-url-patterns`, `scope-switcher`, and `organization-members`. PR 4
+> showed the org UI does not always render as those tests assert, so converting
+> their guards to assertions can introduce fresh red — it must be done against a
+> real CI run, not blind. ~70 `test.skip(true)` remain in those four files.
+
+## Dormant-in-CI suites (`env`-gated — optional config, **NOT coverage yet**)
+
+These suites assert behaviour that only exists when the target has **optional
+deployment config** the CI container does not provision. They are gated on env
+flags (`e2e/support/env.ts`) so the skip names a real condition instead of an
+unconditional skip — strictly better than `test.skip(true, ...)`, but **still
+not coverage** until a lane sets the flag.
+
+> ⚠️ **No CI lane sets any of these flags today**, so every suite below is
+> DORMANT in CI: it does not run, cannot fail, and a green run says nothing
+> about it. Restoring real coverage is **PR 6's job** — it must add a
+> domains/SSO-enabled lane (or local-run docs) that sets these flags and runs
+> these suites, alongside the fixtures. Until then, treat these as a *holding
+> action* that keeps the gate meaningful for everything else, not as tested.
+
+| Suite | Gate (env var) | Issue |
+|-------|----------------|-------|
+| `full/domain-config-consistency.spec.ts` | `E2E_CUSTOM_DOMAINS` | [#3420](https://github.com/onetimesecret/onetimesecret/issues/3420) |
+| `full/domain-email-config.spec.ts` | `E2E_CUSTOM_DOMAINS` | [#3420](https://github.com/onetimesecret/onetimesecret/issues/3420) |
+| `full/domain-navigation.spec.ts` | `E2E_CUSTOM_DOMAINS` | [#3420](https://github.com/onetimesecret/onetimesecret/issues/3420) |
+| `full/domain-sso-config.spec.ts` | `E2E_CUSTOM_DOMAINS` + `E2E_SSO_UI` | [#3420](https://github.com/onetimesecret/onetimesecret/issues/3420) |
+| `full/domain-sso-multi-provider.spec.ts` | `E2E_CUSTOM_DOMAINS` + `E2E_SSO_UI` | [#3420](https://github.com/onetimesecret/onetimesecret/issues/3420) |
+| `auth/sso-csrf.spec.ts` | `E2E_SSO_UI` | [#2798](https://github.com/onetimesecret/onetimesecret/issues/2798) |
+| `full/mfa-bootstrap-reactivity.spec.ts` | `TEST_MFA_*` | [#3421](https://github.com/onetimesecret/onetimesecret/issues/3421) |

--- a/e2e/all/incoming-secrets.spec.ts
+++ b/e2e/all/incoming-secrets.spec.ts
@@ -9,34 +9,29 @@ import { test, expect, Page } from '@playwright/test';
  * pre-configured recipients via /incoming. Recipients are configured
  * server-side, not by user input.
  *
- * Test Scenarios:
- * 1. Navigate to /incoming and verify form loads
- * 2. Verify recipients dropdown populates (when feature enabled)
- * 3. Complete happy-path flow: fill form -> submit -> verify success page
- * 4. Test validation errors (empty required fields)
- * 5. Test character counter for memo field
- * 6. Test feature-disabled state (graceful error message)
- *
- * Prerequisites:
- * - Backend server running with incoming secrets feature enabled in config
- * - At least one recipient configured in the backend
+ * These tests are deterministic: the backend `/api/incoming/config` and
+ * `/api/incoming/secret` calls are intercepted with `page.route` (see the
+ * MOCK_* fixtures below), so the suite exercises the real Vue components
+ * against known config rather than "whatever the container happens to serve".
+ * `/incoming` is a client-side SPA route, so it is always served (HTTP 200) —
+ * the navigation helper asserts that instead of skipping, so a routing or
+ * build regression FAILS the test (E2E remediation plan, Phase 2.4: "a test
+ * must be able to fail").
  *
  * Running:
- *   # With dev server
- *   PLAYWRIGHT_BASE_URL=http://localhost:5173 pnpm test:playwright e2e/all/incoming-secrets.spec.ts
- *
- *   # With production build
  *   PLAYWRIGHT_BASE_URL=http://localhost:7143 pnpm test:playwright e2e/all/incoming-secrets.spec.ts
- *
- * Note: Tests use API mocking to simulate various backend states.
- * If backend doesn't support /incoming route, tests will be skipped.
  */
 
-// Test data constants
+// Test data constants.
+//
+// Recipients use the anonymous-sender shape `{ digest, display_name }` that
+// `incomingConfigSchema` validates (src/schemas/api/incoming/responses/config.ts).
+// Using the wrong shape makes config parsing fail, leaving the form stuck on
+// its loading state — which is exactly how this suite used to silently skip.
 const MOCK_RECIPIENTS = [
-  { hash: 'abc123hash', name: 'Security Team' },
-  { hash: 'def456hash', name: 'Support Team' },
-  { hash: 'ghi789hash', name: 'HR Department' },
+  { digest: 'abc123hash', display_name: 'Security Team' },
+  { digest: 'def456hash', display_name: 'Support Team' },
+  { digest: 'ghi789hash', display_name: 'HR Department' },
 ];
 
 const MOCK_CONFIG_ENABLED = {
@@ -88,7 +83,8 @@ const MOCK_SUCCESS_RESPONSE = {
 };
 
 /**
- * Helper to set up API mocking for incoming config endpoint
+ * Helper to set up API mocking for incoming config endpoint.
+ * `**` spans path segments, so this also matches the real `/api/incoming/config`.
  */
 async function mockIncomingConfig(page: Page, configResponse: object) {
   await page.route('**/incoming/config', async (route) => {
@@ -142,40 +138,35 @@ function filterCriticalErrors(errors: string[]): string[] {
 }
 
 /**
- * Helper to navigate to incoming page with proper setup
- * Returns false if route is not available (404)
+ * Navigate to /incoming with the given config mocked in.
+ *
+ * `/incoming` is a client-side SPA route, so the server always serves the app
+ * shell (HTTP 200), never a 404 — we assert that, so a routing/build
+ * regression fails the test instead of being silently skipped. Then we wait on
+ * the deterministic app-readiness flag (set in src/main.ts after mount +
+ * router.isReady()), never networkidle.
  */
-async function navigateToIncoming(page: Page, configResponse: object): Promise<boolean> {
+async function navigateToIncoming(page: Page, configResponse: object): Promise<void> {
   await mockIncomingConfig(page, configResponse);
   const response = await page.goto('/incoming');
-
-  if (response?.status() === 404) {
-    return false;
-  }
-
-  await page.waitForLoadState('domcontentloaded');
-
-  // Wait for Vue app to render
-  try {
-    await page.waitForSelector('h1, form, [class*="empty"]', { timeout: 10000 });
-  } catch {
-    // Page may be showing error state
-  }
-
-  return true;
+  expect(
+    response?.status(),
+    '/incoming should serve the SPA shell, not a 404'
+  ).not.toBe(404);
+  await expect(page.locator('html[data-app-ready="true"]')).toBeAttached();
 }
 
 /**
- * Helper to wait for form to be interactive
+ * Assert the incoming form is interactive.
+ *
+ * With an enabled config mocked in, IncomingForm renders the form once
+ * loadConfig() resolves; these web-first assertions retry through the brief
+ * loading state. If the form never appears the test FAILS (it no longer
+ * skips), which is the point of this suite.
  */
-async function waitForFormReady(page: Page): Promise<boolean> {
-  try {
-    await page.waitForSelector('form', { state: 'visible', timeout: 5000 });
-    await page.waitForSelector('#incoming-recipient', { state: 'visible', timeout: 5000 });
-    return true;
-  } catch {
-    return false;
-  }
+async function expectFormReady(page: Page): Promise<void> {
+  await expect(page.getByTestId('incoming-form')).toBeVisible();
+  await expect(page.locator('#incoming-recipient')).toBeVisible();
 }
 
 test.describe('Incoming Secrets - Form Loading', () => {
@@ -186,63 +177,17 @@ test.describe('Incoming Secrets - Form Loading', () => {
   test('navigates to /incoming and loads form when feature is enabled', async ({ page }) => {
     const consoleErrors = setupErrorCollection(page);
 
-    // Set up API mocking before navigation
-    await mockIncomingConfig(page, MOCK_CONFIG_ENABLED);
+    await navigateToIncoming(page, MOCK_CONFIG_ENABLED);
+    await expectFormReady(page);
 
-    // Navigate and wait for Vue app to mount
-    const response = await page.goto('/incoming');
+    // Page title renders.
+    await expect(page.locator('h1').first()).toBeVisible();
 
-    // Skip test if route not supported (404)
-    if (response?.status() === 404) {
-      test.skip(true, 'Incoming route not available in this environment');
-      return;
-    }
+    // Recipient dropdown is present (feature enabled).
+    await expect(page.locator('#incoming-recipient')).toBeVisible();
 
-    await page.waitForLoadState('domcontentloaded');
-
-    // Wait for Vue app to hydrate and render content
-    const vueRendered = await page.waitForFunction(() => {
-      const h1 = document.querySelector('h1');
-      return h1 && h1.textContent && h1.textContent.trim().length > 0;
-    }, { timeout: 10000 }).then(() => true).catch(() => false);
-
-    // If Vue app didn't render content, skip the test
-    if (!vueRendered) {
-      // Check if we have at least some content (error page, etc.)
-      const bodyText = await page.textContent('body');
-      const hasContent = bodyText && bodyText.trim().length > 50;
-
-      if (!hasContent) {
-        // No content at all - likely backend not running properly
-        test.skip(true, 'Page content not rendering (backend may not be available)');
-        return;
-      }
-    }
-
-    // Verify page title area is visible (may be in header or page body)
-    const pageTitle = page.locator('h1').first();
-    const hasTitleVisible = await pageTitle.isVisible().catch(() => false);
-
-    if (!hasTitleVisible) {
-      // No title visible - skip as feature not available
-      test.skip(true, 'Page title not visible (feature may not be configured)');
-      return;
-    }
-
-    await expect(pageTitle).toBeVisible();
-
-    // Verify form container is visible (only if feature is enabled)
-    const formContainer = page.locator('form');
-    const hasForm = await formContainer.isVisible().catch(() => false);
-
-    if (hasForm) {
-      // Verify recipient dropdown is present
-      const recipientDropdown = page.locator('#incoming-recipient');
-      await expect(recipientDropdown).toBeVisible();
-    }
-
-    // Verify no critical JavaScript errors occurred (listener was registered
-    // before navigation; the assertions above already waited for the UI)
+    // No critical JavaScript errors occurred (listener was registered before
+    // navigation; the assertions above already waited for the UI).
     const criticalErrors = filterCriticalErrors(consoleErrors);
     expect(
       criticalErrors,
@@ -251,22 +196,11 @@ test.describe('Incoming Secrets - Form Loading', () => {
   });
 
   test('shows feature disabled state when backend has feature disabled', async ({ page }) => {
-    const routeAvailable = await navigateToIncoming(page, MOCK_CONFIG_DISABLED);
+    await navigateToIncoming(page, MOCK_CONFIG_DISABLED);
 
-    if (!routeAvailable) {
-      test.skip(true, 'Incoming route not available');
-      return;
-    }
-
-    // Should show empty state / feature disabled message
-    // The form should NOT be visible
-    const form = page.locator('form');
-    const formVisible = await form.isVisible().catch(() => false);
-    expect(formVisible).toBe(false);
-
-    // Should show some indication that feature is disabled
-    const pageContent = await page.textContent('body');
-    expect(pageContent).toBeTruthy();
+    // The feature-disabled empty state renders and the form must NOT appear.
+    await expect(page.getByTestId('incoming-feature-disabled')).toBeVisible();
+    await expect(page.locator('form')).toBeHidden();
   });
 
   test('handles API error gracefully when config fails to load', async ({ page }) => {
@@ -279,23 +213,18 @@ test.describe('Incoming Secrets - Form Loading', () => {
     });
 
     const response = await page.goto('/incoming');
+    expect(
+      response?.status(),
+      '/incoming should serve the SPA shell, not a 404'
+    ).not.toBe(404);
 
-    if (response?.status() === 404) {
-      test.skip(true, 'Incoming route not available');
-      return;
-    }
-
-    // Wait for the app to finish booting; the mocked 500 means the page
-    // must settle into its error/disabled state without the form.
+    // Wait for the app to finish booting.
     await expect(page.locator('html[data-app-ready="true"]')).toBeAttached();
 
-    // Form should not be visible (web-first assertion retries while the
-    // error handling completes)
-    await expect(page.locator('form')).not.toBeVisible();
-
-    // Page should still render (body element exists)
-    const bodyExists = await page.locator('body').count();
-    expect(bodyExists).toBeGreaterThan(0);
+    // The config error surfaces (useIncomingSecret stores it on configError)
+    // and the form is not shown.
+    await expect(page.getByTestId('incoming-config-error')).toBeVisible();
+    await expect(page.locator('form')).toBeHidden();
   });
 });
 
@@ -305,17 +234,8 @@ test.describe('Incoming Secrets - Recipients Dropdown', () => {
   });
 
   test('populates recipients dropdown with configured recipients', async ({ page }) => {
-    const routeAvailable = await navigateToIncoming(page, MOCK_CONFIG_ENABLED);
-    if (!routeAvailable) {
-      test.skip(true, 'Incoming route not available');
-      return;
-    }
-
-    const formReady = await waitForFormReady(page);
-    if (!formReady) {
-      test.skip(true, 'Form not available (feature may be disabled)');
-      return;
-    }
+    await navigateToIncoming(page, MOCK_CONFIG_ENABLED);
+    await expectFormReady(page);
 
     // Click the recipient dropdown to open it
     const recipientDropdown = page.locator('#incoming-recipient');
@@ -324,48 +244,30 @@ test.describe('Incoming Secrets - Recipients Dropdown', () => {
     // Verify all mock recipients are listed in the dropdown
     const listbox = page.getByTestId('recipient-listbox');
     for (const recipient of MOCK_RECIPIENTS) {
-      const recipientOption = listbox.getByText(recipient.name, { exact: true });
+      const recipientOption = listbox.getByText(recipient.display_name, { exact: true });
       await expect(recipientOption).toBeVisible();
     }
   });
 
   test('allows selecting a recipient from dropdown', async ({ page }) => {
-    const routeAvailable = await navigateToIncoming(page, MOCK_CONFIG_ENABLED);
-    if (!routeAvailable) {
-      test.skip(true, 'Incoming route not available');
-      return;
-    }
-
-    const formReady = await waitForFormReady(page);
-    if (!formReady) {
-      test.skip(true, 'Form not available');
-      return;
-    }
+    await navigateToIncoming(page, MOCK_CONFIG_ENABLED);
+    await expectFormReady(page);
 
     // Open dropdown
     const recipientDropdown = page.locator('#incoming-recipient');
     await recipientDropdown.click();
 
     // Select first recipient
-    const firstRecipient = page.locator(`text=${MOCK_RECIPIENTS[0].name}`).first();
+    const firstRecipient = page.locator(`text=${MOCK_RECIPIENTS[0].display_name}`).first();
     await firstRecipient.click();
 
     // Verify dropdown now shows selected recipient name
-    await expect(recipientDropdown).toContainText(MOCK_RECIPIENTS[0].name);
+    await expect(recipientDropdown).toContainText(MOCK_RECIPIENTS[0].display_name);
   });
 
   test('closes dropdown when clicking outside', async ({ page }) => {
-    const routeAvailable = await navigateToIncoming(page, MOCK_CONFIG_ENABLED);
-    if (!routeAvailable) {
-      test.skip(true, 'Incoming route not available');
-      return;
-    }
-
-    const formReady = await waitForFormReady(page);
-    if (!formReady) {
-      test.skip(true, 'Form not available');
-      return;
-    }
+    await navigateToIncoming(page, MOCK_CONFIG_ENABLED);
+    await expectFormReady(page);
 
     // Open dropdown
     const recipientDropdown = page.locator('#incoming-recipient');
@@ -376,24 +278,15 @@ test.describe('Incoming Secrets - Recipients Dropdown', () => {
     await expect(listbox).toBeVisible();
 
     // Click outside the dropdown
-    await page.locator('h1').click();
+    await page.locator('h1').first().click();
 
     // Dropdown menu should close
-    await expect(listbox).not.toBeVisible();
+    await expect(listbox).toBeHidden();
   });
 
   test('shows empty state when no recipients configured', async ({ page }) => {
-    const routeAvailable = await navigateToIncoming(page, MOCK_CONFIG_NO_RECIPIENTS);
-    if (!routeAvailable) {
-      test.skip(true, 'Incoming route not available');
-      return;
-    }
-
-    const formReady = await waitForFormReady(page);
-    if (!formReady) {
-      test.skip(true, 'Form not available');
-      return;
-    }
+    await navigateToIncoming(page, MOCK_CONFIG_NO_RECIPIENTS);
+    await expectFormReady(page);
 
     // Open dropdown
     const recipientDropdown = page.locator('#incoming-recipient');
@@ -411,17 +304,8 @@ test.describe('Incoming Secrets - Form Validation', () => {
   });
 
   test('submit button is disabled when form is incomplete', async ({ page }) => {
-    const routeAvailable = await navigateToIncoming(page, MOCK_CONFIG_ENABLED);
-    if (!routeAvailable) {
-      test.skip(true, 'Incoming route not available');
-      return;
-    }
-
-    const formReady = await waitForFormReady(page);
-    if (!formReady) {
-      test.skip(true, 'Form not available');
-      return;
-    }
+    await navigateToIncoming(page, MOCK_CONFIG_ENABLED);
+    await expectFormReady(page);
 
     // Find submit button - it should be disabled initially
     const submitButton = page.locator('button[type="submit"]');
@@ -430,17 +314,8 @@ test.describe('Incoming Secrets - Form Validation', () => {
 
   test('submit button becomes enabled when required fields are filled', async ({ page }) => {
     await mockIncomingSecretCreate(page, MOCK_SUCCESS_RESPONSE);
-    const routeAvailable = await navigateToIncoming(page, MOCK_CONFIG_ENABLED);
-    if (!routeAvailable) {
-      test.skip(true, 'Incoming route not available');
-      return;
-    }
-
-    const formReady = await waitForFormReady(page);
-    if (!formReady) {
-      test.skip(true, 'Form not available');
-      return;
-    }
+    await navigateToIncoming(page, MOCK_CONFIG_ENABLED);
+    await expectFormReady(page);
 
     const submitButton = page.locator('button[type="submit"]');
     await expect(submitButton).toBeDisabled();
@@ -448,7 +323,7 @@ test.describe('Incoming Secrets - Form Validation', () => {
     // Select a recipient
     const recipientDropdown = page.locator('#incoming-recipient');
     await recipientDropdown.click();
-    await page.locator(`text=${MOCK_RECIPIENTS[0].name}`).first().click();
+    await page.locator(`text=${MOCK_RECIPIENTS[0].display_name}`).first().click();
 
     // Still disabled - need secret content
     await expect(submitButton).toBeDisabled();
@@ -462,44 +337,26 @@ test.describe('Incoming Secrets - Form Validation', () => {
   });
 
   test('shows validation error when submitting without recipient', async ({ page }) => {
-    const routeAvailable = await navigateToIncoming(page, MOCK_CONFIG_ENABLED);
-    if (!routeAvailable) {
-      test.skip(true, 'Incoming route not available');
-      return;
-    }
-
-    const formReady = await waitForFormReady(page);
-    if (!formReady) {
-      test.skip(true, 'Form not available');
-      return;
-    }
+    await navigateToIncoming(page, MOCK_CONFIG_ENABLED);
+    await expectFormReady(page);
 
     // Fill only secret content
     const secretTextarea = page.locator('textarea').first();
     await secretTextarea.fill('Test secret');
 
-    // Try to submit (button should be disabled, but let's verify the form state)
+    // Without a recipient the submit button stays disabled.
     const submitButton = page.locator('button[type="submit"]');
     await expect(submitButton).toBeDisabled();
   });
 
   test('reset button clears all form fields', async ({ page }) => {
-    const routeAvailable = await navigateToIncoming(page, MOCK_CONFIG_ENABLED);
-    if (!routeAvailable) {
-      test.skip(true, 'Incoming route not available');
-      return;
-    }
-
-    const formReady = await waitForFormReady(page);
-    if (!formReady) {
-      test.skip(true, 'Form not available');
-      return;
-    }
+    await navigateToIncoming(page, MOCK_CONFIG_ENABLED);
+    await expectFormReady(page);
 
     // Fill in form fields
     const recipientDropdown = page.locator('#incoming-recipient');
     await recipientDropdown.click();
-    await page.locator(`text=${MOCK_RECIPIENTS[0].name}`).first().click();
+    await page.locator(`text=${MOCK_RECIPIENTS[0].display_name}`).first().click();
 
     const secretTextarea = page.locator('textarea').first();
     await secretTextarea.fill('Test secret content');
@@ -525,24 +382,14 @@ test.describe('Incoming Secrets - Memo Character Counter', () => {
   });
 
   test('shows character counter when approaching limit', async ({ page }) => {
-    const routeAvailable = await navigateToIncoming(page, MOCK_CONFIG_ENABLED);
-    if (!routeAvailable) {
-      test.skip(true, 'Incoming route not available');
-      return;
-    }
-
-    const formReady = await waitForFormReady(page);
-    if (!formReady) {
-      test.skip(true, 'Form not available');
-      return;
-    }
+    await navigateToIncoming(page, MOCK_CONFIG_ENABLED);
+    await expectFormReady(page);
 
     const memoInput = page.locator('#incoming-memo');
 
-    // Counter should not be visible initially
+    // Counter is hidden until the memo approaches the limit (>80% of 50 chars).
     const counter = page.locator('text=/\\d+\\s*\\/\\s*50/');
-    const counterInitiallyVisible = await counter.isVisible().catch(() => false);
-    expect(counterInitiallyVisible).toBe(false);
+    await expect(counter).toBeHidden();
 
     // Fill memo with 80%+ of limit (40+ chars for 50 char limit)
     await memoInput.fill('This is a long memo that approaches the limit');
@@ -552,37 +399,18 @@ test.describe('Incoming Secrets - Memo Character Counter', () => {
   });
 
   test('respects maxlength attribute on memo input', async ({ page }) => {
-    const routeAvailable = await navigateToIncoming(page, MOCK_CONFIG_ENABLED);
-    if (!routeAvailable) {
-      test.skip(true, 'Incoming route not available');
-      return;
-    }
-
-    const formReady = await waitForFormReady(page);
-    if (!formReady) {
-      test.skip(true, 'Form not available');
-      return;
-    }
+    await navigateToIncoming(page, MOCK_CONFIG_ENABLED);
+    await expectFormReady(page);
 
     const memoInput = page.locator('#incoming-memo');
 
     // Verify maxlength attribute is set
-    const maxLength = await memoInput.getAttribute('maxlength');
-    expect(maxLength).toBe('50');
+    await expect(memoInput).toHaveAttribute('maxlength', '50');
   });
 
   test('counter color changes at limit', async ({ page }) => {
-    const routeAvailable = await navigateToIncoming(page, MOCK_CONFIG_ENABLED);
-    if (!routeAvailable) {
-      test.skip(true, 'Incoming route not available');
-      return;
-    }
-
-    const formReady = await waitForFormReady(page);
-    if (!formReady) {
-      test.skip(true, 'Form not available');
-      return;
-    }
+    await navigateToIncoming(page, MOCK_CONFIG_ENABLED);
+    await expectFormReady(page);
 
     const memoInput = page.locator('#incoming-memo');
 
@@ -604,22 +432,13 @@ test.describe('Incoming Secrets - Happy Path Flow', () => {
     const consoleErrors = setupErrorCollection(page);
 
     await mockIncomingSecretCreate(page, MOCK_SUCCESS_RESPONSE);
-    const routeAvailable = await navigateToIncoming(page, MOCK_CONFIG_ENABLED);
-    if (!routeAvailable) {
-      test.skip(true, 'Incoming route not available');
-      return;
-    }
-
-    const formReady = await waitForFormReady(page);
-    if (!formReady) {
-      test.skip(true, 'Form not available');
-      return;
-    }
+    await navigateToIncoming(page, MOCK_CONFIG_ENABLED);
+    await expectFormReady(page);
 
     // Step 1: Select recipient
     const recipientDropdown = page.locator('#incoming-recipient');
     await recipientDropdown.click();
-    await page.locator(`text=${MOCK_RECIPIENTS[0].name}`).first().click();
+    await page.locator(`text=${MOCK_RECIPIENTS[0].display_name}`).first().click();
 
     // Step 2: Enter secret content
     const secretTextarea = page.locator('textarea').first();
@@ -638,17 +457,12 @@ test.describe('Incoming Secrets - Happy Path Flow', () => {
     await expect(page).toHaveURL(/\/incoming\/test-metadata-key/);
 
     // Step 6: Verify success page elements
-    // Success icon/checkmark should be visible
-    const successHeading = page.locator('h1');
-    await expect(successHeading).toBeVisible();
-
     // Reference ID should be displayed
-    const referenceId = page.locator('code', { hasText: 'test-metadata-key' });
-    await expect(referenceId).toBeVisible();
+    const referenceId = page.getByTestId('incoming-reference-id');
+    await expect(referenceId).toContainText('test-metadata-key');
 
     // "Send Another Secret" button should be visible
-    const createAnotherButton = page.locator('button', { hasText: /send another/i });
-    await expect(createAnotherButton).toBeVisible();
+    await expect(page.getByTestId('incoming-send-another-btn')).toBeVisible();
 
     // Verify no critical errors (listener was registered before navigation;
     // the assertions above already waited for the UI)
@@ -661,63 +475,45 @@ test.describe('Incoming Secrets - Happy Path Flow', () => {
 
   test('success page shows reference ID and copy button', async ({ page }) => {
     await mockIncomingSecretCreate(page, MOCK_SUCCESS_RESPONSE);
-    const routeAvailable = await navigateToIncoming(page, MOCK_CONFIG_ENABLED);
-    if (!routeAvailable) {
-      test.skip(true, 'Incoming route not available');
-      return;
-    }
-
-    const formReady = await waitForFormReady(page);
-    if (!formReady) {
-      test.skip(true, 'Form not available');
-      return;
-    }
+    await navigateToIncoming(page, MOCK_CONFIG_ENABLED);
+    await expectFormReady(page);
 
     // Complete the form
     const recipientDropdown = page.locator('#incoming-recipient');
     await recipientDropdown.click();
-    await page.locator(`text=${MOCK_RECIPIENTS[0].name}`).first().click();
+    await page.locator(`text=${MOCK_RECIPIENTS[0].display_name}`).first().click();
 
     const secretTextarea = page.locator('textarea').first();
     await secretTextarea.fill('Test secret');
 
     await page.locator('button[type="submit"]').click();
-    await page.waitForURL(/\/incoming\//, { timeout: 10000 });
+    await page.waitForURL(/\/incoming\/test-metadata-key/);
 
     // Verify reference ID display
-    const referenceCode = page.locator('code').first();
-    await expect(referenceCode).toContainText('test-metadata-key');
+    await expect(page.getByTestId('incoming-reference-id')).toContainText('test-metadata-key');
 
     // Verify copy button exists
-    const copyButton = page.locator('button[title*="Copy"]');
-    await expect(copyButton).toBeVisible();
+    await expect(page.getByTestId('incoming-copy-reference-btn')).toBeVisible();
   });
 
   test('create another button returns to form', async ({ page }) => {
     await mockIncomingConfig(page, MOCK_CONFIG_ENABLED);
 
-    // Navigate directly to success page
+    // Navigate directly to the success page (receiptKey comes from the URL).
     const response = await page.goto('/incoming/test-metadata-key');
-    if (response?.status() === 404) {
-      test.skip(true, 'Incoming route not available');
-      return;
-    }
+    expect(
+      response?.status(),
+      '/incoming/:receiptKey should serve the SPA shell, not a 404'
+    ).not.toBe(404);
+    await expect(page.locator('html[data-app-ready="true"]')).toBeAttached();
 
-    await page.waitForLoadState('domcontentloaded');
-
-    // Wait for send another secret button
-    const createAnotherButton = page.locator('button', { hasText: /send another/i });
-    const buttonVisible = await createAnotherButton.isVisible({ timeout: 5000 }).catch(() => false);
-
-    if (!buttonVisible) {
-      test.skip(true, 'Success page not rendering properly');
-      return;
-    }
-
+    // The "Send Another Secret" button returns to the form.
+    const createAnotherButton = page.getByTestId('incoming-send-another-btn');
+    await expect(createAnotherButton).toBeVisible();
     await createAnotherButton.click();
 
     // Should navigate back to form
-    await expect(page).toHaveURL('/incoming');
+    await expect(page).toHaveURL(/\/incoming$/);
   });
 });
 
@@ -735,22 +531,13 @@ test.describe('Incoming Secrets - Error Handling', () => {
       });
     });
 
-    const routeAvailable = await navigateToIncoming(page, MOCK_CONFIG_ENABLED);
-    if (!routeAvailable) {
-      test.skip(true, 'Incoming route not available');
-      return;
-    }
-
-    const formReady = await waitForFormReady(page);
-    if (!formReady) {
-      test.skip(true, 'Form not available');
-      return;
-    }
+    await navigateToIncoming(page, MOCK_CONFIG_ENABLED);
+    await expectFormReady(page);
 
     // Fill form
     const recipientDropdown = page.locator('#incoming-recipient');
     await recipientDropdown.click();
-    await page.locator(`text=${MOCK_RECIPIENTS[0].name}`).first().click();
+    await page.locator(`text=${MOCK_RECIPIENTS[0].display_name}`).first().click();
 
     const secretTextarea = page.locator('textarea').first();
     await secretTextarea.fill('Test secret');
@@ -762,38 +549,27 @@ test.describe('Incoming Secrets - Error Handling', () => {
     await failedResponse;
 
     // Form should remain visible for retry
-    const form = page.locator('form');
-    await expect(form).toBeVisible();
+    await expect(page.locator('form')).toBeVisible();
   });
 
   test('handles network timeout gracefully', async ({ page }) => {
     await page.route('**/incoming/secret', async (route) => {
-      // Simulate network delay/timeout
-      await new Promise((resolve) => setTimeout(resolve, 10000));
+      // Simulate network failure
       await route.abort('timedout');
     });
 
-    const routeAvailable = await navigateToIncoming(page, MOCK_CONFIG_ENABLED);
-    if (!routeAvailable) {
-      test.skip(true, 'Incoming route not available');
-      return;
-    }
-
-    const formReady = await waitForFormReady(page);
-    if (!formReady) {
-      test.skip(true, 'Form not available');
-      return;
-    }
+    await navigateToIncoming(page, MOCK_CONFIG_ENABLED);
+    await expectFormReady(page);
 
     // Fill form
     const recipientDropdown = page.locator('#incoming-recipient');
     await recipientDropdown.click();
-    await page.locator(`text=${MOCK_RECIPIENTS[0].name}`).first().click();
+    await page.locator(`text=${MOCK_RECIPIENTS[0].display_name}`).first().click();
 
     const secretTextarea = page.locator('textarea').first();
     await secretTextarea.fill('Test secret');
 
-    // Submit - this will timeout
+    // Submit - this will fail at the network layer
     const submitButton = page.locator('button[type="submit"]');
     await submitButton.click();
 
@@ -808,17 +584,8 @@ test.describe('Incoming Secrets - Accessibility', () => {
   });
 
   test('form elements have proper ARIA attributes', async ({ page }) => {
-    const routeAvailable = await navigateToIncoming(page, MOCK_CONFIG_ENABLED);
-    if (!routeAvailable) {
-      test.skip(true, 'Incoming route not available');
-      return;
-    }
-
-    const formReady = await waitForFormReady(page);
-    if (!formReady) {
-      test.skip(true, 'Form not available');
-      return;
-    }
+    await navigateToIncoming(page, MOCK_CONFIG_ENABLED);
+    await expectFormReady(page);
 
     // Recipient dropdown has aria-label
     const recipientDropdown = page.locator('#incoming-recipient');
@@ -832,17 +599,8 @@ test.describe('Incoming Secrets - Accessibility', () => {
   });
 
   test('dropdown has proper ARIA expanded state', async ({ page }) => {
-    const routeAvailable = await navigateToIncoming(page, MOCK_CONFIG_ENABLED);
-    if (!routeAvailable) {
-      test.skip(true, 'Incoming route not available');
-      return;
-    }
-
-    const formReady = await waitForFormReady(page);
-    if (!formReady) {
-      test.skip(true, 'Form not available');
-      return;
-    }
+    await navigateToIncoming(page, MOCK_CONFIG_ENABLED);
+    await expectFormReady(page);
 
     const recipientDropdown = page.locator('#incoming-recipient');
 
@@ -857,17 +615,8 @@ test.describe('Incoming Secrets - Accessibility', () => {
   });
 
   test('form is keyboard navigable', async ({ page }) => {
-    const routeAvailable = await navigateToIncoming(page, MOCK_CONFIG_ENABLED);
-    if (!routeAvailable) {
-      test.skip(true, 'Incoming route not available');
-      return;
-    }
-
-    const formReady = await waitForFormReady(page);
-    if (!formReady) {
-      test.skip(true, 'Form not available');
-      return;
-    }
+    await navigateToIncoming(page, MOCK_CONFIG_ENABLED);
+    await expectFormReady(page);
 
     // Tab through form elements
     await page.keyboard.press('Tab');
@@ -884,17 +633,8 @@ test.describe('Incoming Secrets - Mobile Responsiveness', () => {
     // Set mobile viewport before navigation
     await page.setViewportSize({ width: 375, height: 667 });
 
-    const routeAvailable = await navigateToIncoming(page, MOCK_CONFIG_ENABLED);
-    if (!routeAvailable) {
-      test.skip(true, 'Incoming route not available');
-      return;
-    }
-
-    const formReady = await waitForFormReady(page);
-    if (!formReady) {
-      test.skip(true, 'Form not available');
-      return;
-    }
+    await navigateToIncoming(page, MOCK_CONFIG_ENABLED);
+    await expectFormReady(page);
 
     // Form should be visible and not overflow
     const form = page.locator('form');
@@ -922,17 +662,8 @@ test.describe('Incoming Secrets - Mobile Responsiveness', () => {
     // Set mobile viewport before navigation
     await page.setViewportSize({ width: 375, height: 667 });
 
-    const routeAvailable = await navigateToIncoming(page, MOCK_CONFIG_ENABLED);
-    if (!routeAvailable) {
-      test.skip(true, 'Incoming route not available');
-      return;
-    }
-
-    const formReady = await waitForFormReady(page);
-    if (!formReady) {
-      test.skip(true, 'Form not available');
-      return;
-    }
+    await navigateToIncoming(page, MOCK_CONFIG_ENABLED);
+    await expectFormReady(page);
 
     // Get button positions
     const submitButton = page.locator('button[type="submit"]');

--- a/e2e/auth/sso-csrf.spec.ts
+++ b/e2e/auth/sso-csrf.spec.ts
@@ -8,6 +8,18 @@
 
 import { test, expect } from '@playwright/test';
 
+import { env, gateReason } from '../support/env';
+
+// HOLDING ACTION — not coverage (E2E remediation plan Phase 2.4 / PR 5).
+// These assert the SSO sign-in UI, which only renders when an OmniAuth/SSO
+// provider is configured — optional deployment config the CI container does
+// not set. Env-gated on E2E_SSO_UI so the skip names a real condition instead
+// of an unconditional skip; CI does not set it (and does not run e2e/auth/ at
+// all), so this suite is DORMANT until a SSO-configured target/lane exists.
+test.beforeEach(() => {
+  test.skip(!env.hasSsoUi, gateReason.ssoUi);
+});
+
 /**
  * SSO Form Submission E2E Tests
  *
@@ -54,10 +66,8 @@ test.describe('SSO Form Submission', () => {
       return !!state.features?.sso;
     });
 
-    if (!ssoEnabled) {
-      test.skip(true, 'SSO is not enabled in this environment');
-      return;
-    }
+    // Gated on E2E_SSO_UI above, so SSO must be enabled here.
+    expect(ssoEnabled, 'SSO should be enabled when E2E_SSO_UI is set').toBe(true);
 
     // SSO button should be visible
     const ssoButton = page.locator('[data-testid="sso-button"]');
@@ -73,12 +83,8 @@ test.describe('SSO Form Submission', () => {
 
     // Check if SSO button exists
     const ssoButton = page.locator('[data-testid="sso-button"]');
-    const ssoButtonVisible = await ssoButton.isVisible().catch(() => false);
-
-    if (!ssoButtonVisible) {
-      test.skip(true, 'SSO button not present - OmniAuth may not be enabled');
-      return;
-    }
+    // Gated on E2E_SSO_UI above, so the SSO button must render here.
+    await expect(ssoButton).toBeVisible();
 
     // Intercept form submissions to verify CSRF token
     let formSubmission: { action: string; method: string; shrimp: string | null } | null = null;
@@ -170,12 +176,8 @@ test.describe('SSO Form Submission', () => {
     await expect(page.locator('html[data-app-ready="true"]')).toBeAttached();
 
     const ssoButton = page.locator('[data-testid="sso-button"]');
-    const ssoButtonVisible = await ssoButton.isVisible().catch(() => false);
-
-    if (!ssoButtonVisible) {
-      test.skip(true, 'SSO button not present - OmniAuth may not be enabled');
-      return;
-    }
+    // Gated on E2E_SSO_UI above, so the SSO button must render here.
+    await expect(ssoButton).toBeVisible();
 
     // Prevent actual form submission
     await page.addInitScript(() => {
@@ -205,12 +207,8 @@ test.describe('SSO Form Submission', () => {
     await expect(page.locator('html[data-app-ready="true"]')).toBeAttached();
 
     const ssoButton = page.locator('[data-testid="sso-button"]');
-    const ssoButtonVisible = await ssoButton.isVisible().catch(() => false);
-
-    if (!ssoButtonVisible) {
-      test.skip(true, 'SSO button not present - OmniAuth may not be enabled');
-      return;
-    }
+    // Gated on E2E_SSO_UI above, so the SSO button must render here.
+    await expect(ssoButton).toBeVisible();
 
     // Divider with "or continue with" text should be visible
     const dividerText = page.locator('text=/or continue with/i');
@@ -224,12 +222,8 @@ test.describe('SSO Form - Structure Validation', () => {
     await expect(page.locator('html[data-app-ready="true"]')).toBeAttached();
 
     const ssoButton = page.locator('[data-testid="sso-button"]');
-    const ssoButtonVisible = await ssoButton.isVisible().catch(() => false);
-
-    if (!ssoButtonVisible) {
-      test.skip(true, 'SSO button not present - OmniAuth may not be enabled');
-      return;
-    }
+    // Gated on E2E_SSO_UI above, so the SSO button must render here.
+    await expect(ssoButton).toBeVisible();
 
     // Capture the form that gets created
     let formAction: string | null = null;
@@ -266,12 +260,8 @@ test.describe('SSO Form - Structure Validation', () => {
     await expect(page.locator('html[data-app-ready="true"]')).toBeAttached();
 
     const ssoButton = page.locator('[data-testid="sso-button"]');
-    const ssoButtonVisible = await ssoButton.isVisible().catch(() => false);
-
-    if (!ssoButtonVisible) {
-      test.skip(true, 'SSO button not present - OmniAuth may not be enabled');
-      return;
-    }
+    // Gated on E2E_SSO_UI above, so the SSO button must render here.
+    await expect(ssoButton).toBeVisible();
 
     // Capture all form inputs
     let formInputs: Array<{ name: string; type: string }> = [];

--- a/e2e/docs/e2e-remediation-plan.md
+++ b/e2e/docs/e2e-remediation-plan.md
@@ -19,7 +19,7 @@
 | Phase 1 / PR 2 — reporter/artifacts + lint-ban + flaky gate | ✅ **Done** | [PR #3411](https://github.com/onetimesecret/onetimesecret/pull/3411) · branch `claude/affectionate-clarke-4fyakw` |
 | Phase 2.1+2.2 / PR 3 — auth setup project + app-readiness signal | 🔄 **In review** | [PR #3412](https://github.com/onetimesecret/onetimesecret/pull/3412) · branch `claude/e2e-phase2-auth-readiness` (rebased onto `develop` after #3411 merged; also carries the CI-triage-round-1 auth-compat sweep of `full/`) |
 | Phase 2.3 / PR 4 — `networkidle`/sleep sweep + lint→error | 🔄 **In review** | [PR #3416](https://github.com/onetimesecret/onetimesecret/pull/3416) (draft) · branch `claude/e2e-phase24-networkidle-sweep`, stacked on #3412; rebase + mark ready once #3412 merges |
-| Phase 2.4 / PR 5 — defensive-skip triage | ⏭️ **Next** | not started |
+| Phase 2.4 / PR 5 — defensive-skip triage | 🔄 **In progress (mechanical half)** | branch `claude/hopeful-bardeen-j5695i` — `all/incoming-secrets` revived (47 self-skips → real assertions), `e2e/support/env.ts` gates, fixture-dependent suites `test.fixme`'d, domain/SSO/MFA suites env-gated. **73 of 143 `test.skip(true)` removed; ~70 org-existence conversions deferred** to a CI-verified follow-up (see `e2e/QUARANTINE.md`). |
 | Phase 3 / PR 6 — fixtures module, pinned config, parallel/shard | ⬜ Todo | not started |
 
 > **CI-signal caveat for stacked PRs:** `container-e2e-tests` only triggers on
@@ -33,6 +33,23 @@
 > workflow it modifies.
 
 ### For a fresh contributor picking up PR 5 (Phase 2.4: defensive-skip triage)
+
+> **Status (PR 5, branch `claude/hopeful-bardeen-j5695i`):** the *mechanical,
+> can't-add-red half* is done — `all/incoming-secrets.spec.ts` revived (its 47
+> self-skips were a bug: the mock recipient shape `{hash,name}` never matched
+> the `{digest,display_name}` schema, so the form never rendered and every test
+> silently skipped; now real assertions), `e2e/support/env.ts` added,
+> fixture-dependent suites `test.fixme`'d and domain/SSO/MFA suites env-gated
+> (all logged in `e2e/QUARANTINE.md`). **73 of 143 `test.skip(true)` removed.**
+> Two things are deliberately **deferred to a CI-verified follow-up** (do NOT do
+> them blind — PR 4 proved the org UI doesn't always render as these tests
+> assert, so converting their guards can trade known red for fresh red):
+> (1) the ~70 org-existence `test.skip(true)` → assertion conversions in
+> `organization-settings`, `identifier-url-patterns`, `scope-switcher`,
+> `organization-members`; (2) the `organization-members` role/remove `test.fixme`
+> rows for issue #3419. Also note: **env-gating is a holding action, not
+> coverage** — no CI lane sets `E2E_CUSTOM_DOMAINS`/`E2E_SSO_UI`/`TEST_MFA_*`
+> yet, so those suites are dormant until PR 6 adds a configured lane.
 
 1. **Verify Phases 0–2.3 already landed — do not redo them.** Phase 1:
    `.github/workflows/e2e.yml` has a "Fail on flaky tests" step. Phase
@@ -286,7 +303,7 @@ _Live status is tracked in the **Progress & how to continue** section near the t
 | 2 | 1 | reporter/artifacts, lint rules (warn), flaky gate | ✅ Done ([#3411](https://github.com/onetimesecret/onetimesecret/pull/3411)) |
 | 3 | 2.1+2.2 | global-setup/auth fixture + app-readiness signal | 🔄 In review ([#3412](https://github.com/onetimesecret/onetimesecret/pull/3412)) — surfaces real `full/` failures (intended) |
 | 4 | 2.3 | `networkidle`/sleep sweep, by directory; lint → error | 🔄 In review ([#3416](https://github.com/onetimesecret/onetimesecret/pull/3416), stacked on #3412) |
-| 5 | 2.4 | defensive-skip triage | Med |
+| 5 | 2.4 | defensive-skip triage — revive `incoming-secrets`, env gates, `fixme` fixture-dependent suites | 🔄 In progress (`claude/hopeful-bardeen-j5695i`); org-existence assertion conversions split to a CI-verified follow-up |
 | 6 | 3 | fixtures.ts, pinned brand, parallel/shard | Low |
 
 ## Key risks & mitigations

--- a/e2e/full-billing/pending-plan-intent.spec.ts
+++ b/e2e/full-billing/pending-plan-intent.spec.ts
@@ -268,9 +268,12 @@ test.describe('Signup Submission with Plan Intent', () => {
 // These tests require email verification to be disabled or a mail interceptor.
 // Marked as skipped by default - enable when test infrastructure supports it.
 
-test.describe('Post-Verification Redirect', () => {
-  // Skip these tests unless email verification is disabled in test environment
-  test.skip(({ page }) => true, 'Requires email verification disabled or mail interceptor');
+// QUARANTINED — E2E remediation plan Phase 2.4 / PR 5 (issue #3421).
+// Needs a mail interceptor (Mailpit/MailHog) to capture the verification link;
+// CI runs with AUTH_AUTOVERIFY=true and cannot exercise the post-verification
+// redirect. Was `test.skip(() => true)` — an unconditional skip that could only
+// pass-or-skip. See e2e/QUARANTINE.md.
+test.describe.fixme('Post-Verification Redirect', () => {
 
   test.describe('when verification is disabled (test mode)', () => {
     test('signup with plan params auto-redirects to checkout after verification', async ({ page }) => {

--- a/e2e/full/cross-org-domain-isolation.spec.ts
+++ b/e2e/full/cross-org-domain-isolation.spec.ts
@@ -206,10 +206,10 @@ test.describe.fixme('Cross-Organization Domain Isolation', () => {
       // Find orgs with domains to test isolation
       const orgsWithDomains = orgs.filter((o) => o.domainCount > 0);
 
-      if (orgsWithDomains.length < 1) {
-        test.skip(true, 'Test requires at least one organization with domains');
-        return;
-      }
+      expect(
+        orgsWithDomains.length,
+        'requires ≥1 org with domains — second-org + per-org-domain fixture (#3420)'
+      ).toBeGreaterThanOrEqual(1);
 
       // Test each org's page (domains tab is default)
       for (const currentOrg of orgs) {
@@ -465,10 +465,10 @@ test.describe.fixme('Cross-Organization Domain Isolation', () => {
             await verifyEmptyDomainsState(page);
           }
         } else {
-          test.skip(true, 'OrgB not found in org switcher dropdown');
+          throw new Error('OrgB not found in org switcher — needs second-org fixture (#3420)');
         }
       } else {
-        test.skip(true, 'Org switcher not visible on domains page');
+        throw new Error('Org switcher not visible on domains page — needs second-org fixture (#3420)');
       }
     });
   });

--- a/e2e/full/cross-org-domain-isolation.spec.ts
+++ b/e2e/full/cross-org-domain-isolation.spec.ts
@@ -172,7 +172,15 @@ async function verifyEmptyDomainsState(page: Page): Promise<void> {
 // Test Suite: Cross-Organization Domain Isolation
 // -----------------------------------------------------------------------------
 
-test.describe('Cross-Organization Domain Isolation', () => {
+// QUARANTINED — E2E remediation plan Phase 2.4 / PR 5 (issue #3420).
+// Every test here needs ≥2 organizations (most with disjoint custom-domain
+// sets) — seeded data relationships the CI account (one default workspace, no
+// domains) does not have. These were among the hard failures aborting the
+// #3412/#3416 runs: the file's getUserOrganizations() DOM scraper times out,
+// tripping --max-failures and hiding the rest of the suite. Quarantined with
+// test.describe.fixme (not test.skip, which hides them) until the second-org +
+// per-org-domain fixtures land in PR 6. See e2e/QUARANTINE.md.
+test.describe.fixme('Cross-Organization Domain Isolation', () => {
   test.beforeEach(async ({ page }) => {
     page.setDefaultTimeout(15000);
   });
@@ -558,7 +566,8 @@ test.describe('Cross-Organization Domain Isolation', () => {
 // Test Suite: API-Level Domain Isolation (Network Interception)
 // -----------------------------------------------------------------------------
 
-test.describe('API-Level Domain Isolation', () => {
+// QUARANTINED with the suite above — needs ≥2 orgs (issue #3420).
+test.describe.fixme('API-Level Domain Isolation', () => {
   test.beforeEach(async ({ page }) => {
     page.setDefaultTimeout(15000);
   });

--- a/e2e/full/domain-config-consistency.spec.ts
+++ b/e2e/full/domain-config-consistency.spec.ts
@@ -27,6 +27,20 @@
 
 import { expect, Page, test } from '@playwright/test';
 
+import { env, gateReason } from '../support/env';
+
+// HOLDING ACTION — not coverage (E2E remediation plan Phase 2.4 / PR 5).
+// Every test needs a custom domain on the test account. That is optional
+// deployment config, so it is env-gated rather than fixme'd (issue #3420):
+// set E2E_CUSTOM_DOMAINS against a domains-enabled target to run it. No CI
+// lane sets that yet, so this suite is DORMANT in CI — real coverage returns
+// when PR 6 adds a domains-enabled lane + fixtures. Gating in a top-level
+// beforeEach skips before the org/domain DOM helpers run, so CI no longer
+// times out here (these were among the #3412/#3416 failures).
+test.beforeEach(() => {
+  test.skip(!env.hasCustomDomains, gateReason.customDomains);
+});
+
 // -----------------------------------------------------------------------------
 // Types
 // -----------------------------------------------------------------------------

--- a/e2e/full/domain-context-consultant.spec.ts
+++ b/e2e/full/domain-context-consultant.spec.ts
@@ -71,13 +71,18 @@ import { test, expect } from '@playwright/test';
  * 3. Mock window.__BOOTSTRAP_ME__ with custom_domains array
  */
 
+// The seven custom-domain workflow tests below are declarative `test.fixme`
+// placeholders — never implemented, all requiring a custom domain on the test
+// account (E2E remediation plan Phase 2.4 / PR 5, issue #3420; see
+// e2e/QUARANTINE.md). The two tests that assert the *no-custom-domain* path
+// (the CI account's reality) run normally — they must stay able to fail.
 test.describe('Domain Context - Consultant Workflow', () => {
   test.beforeEach(async ({ page }) => {
     // Set reasonable timeout for E2E tests
     page.setDefaultTimeout(15000);
   });
 
-  test.skip('displays domain context indicator for user with custom domains', async ({ page }) => {
+  test.fixme('displays domain context indicator for user with custom domains', async ({ page }) => {
     /**
      * This test validates that the domain context indicator appears when a user
      * has custom domains configured.
@@ -109,7 +114,7 @@ test.describe('Domain Context - Consultant Workflow', () => {
     expect(indicatorText?.length).toBeGreaterThan(0);
   });
 
-  test.skip('context indicator shows correct styling for custom domain', async ({ page }) => {
+  test.fixme('context indicator shows correct styling for custom domain', async ({ page }) => {
     /**
      * Validates that custom domains get brand-colored styling
      * while canonical domain gets neutral gray styling.
@@ -133,7 +138,7 @@ test.describe('Domain Context - Consultant Workflow', () => {
     expect(hasCustomStyling).toBe(true);
   });
 
-  test.skip('persists domain context selection across page navigation', async ({ page }) => {
+  test.fixme('persists domain context selection across page navigation', async ({ page }) => {
     /**
      * Validates that domain context persists in sessionStorage and survives
      * page navigation within the same browser session.
@@ -160,7 +165,7 @@ test.describe('Domain Context - Consultant Workflow', () => {
     expect(persistedContext).toBe(initialContext);
   });
 
-  test.skip('creates secret with correct domain context', async ({ page }) => {
+  test.fixme('creates secret with correct domain context', async ({ page }) => {
     /**
      * Full consultant workflow: create a secret and verify it uses
      * the correct domain context.
@@ -241,7 +246,7 @@ test.describe('Domain Context - Consultant Workflow', () => {
     expect(hasDomainContext).toBe(true);
   });
 
-  test.skip('context switcher allows changing between domains', async ({ page }) => {
+  test.fixme('context switcher allows changing between domains', async ({ page }) => {
     /**
      * Tests the DomainContextSwitcher dropdown interaction.
      * Component: src/shared/components/navigation/DomainContextSwitcher.vue
@@ -276,7 +281,7 @@ test.describe('Domain Context - Consultant Workflow', () => {
     expect(storedDomain).toBe('widgets.example.com');
   });
 
-  test.skip('context indicator updates when switching domains', async ({ page }) => {
+  test.fixme('context indicator updates when switching domains', async ({ page }) => {
     /**
      * Validates real-time reactivity when context changes via DomainContextSwitcher.
      *
@@ -306,7 +311,7 @@ test.describe('Domain Context - Consultant Workflow', () => {
     expect(newDomain).not.toBe(initialDomain);
   });
 
-  test.skip('canonical domain shows Personal label', async ({ page }) => {
+  test.fixme('canonical domain shows Personal label', async ({ page }) => {
     /**
      * Validates that the canonical domain displays as "Personal" with gray styling.
      *

--- a/e2e/full/domain-email-config.spec.ts
+++ b/e2e/full/domain-email-config.spec.ts
@@ -24,6 +24,19 @@
 
 import { expect, Page, test } from '@playwright/test';
 
+import { env, gateReason } from '../support/env';
+
+// HOLDING ACTION — not coverage (E2E remediation plan Phase 2.4 / PR 5).
+// Every test needs a custom domain on the test account (optional deployment
+// config), so it is env-gated rather than fixme'd (issue #3420): set
+// E2E_CUSTOM_DOMAINS against a domains-enabled target to run it. No CI lane
+// sets that yet, so this suite is DORMANT in CI — real coverage returns when
+// PR 6 adds a domains-enabled lane + fixtures. Gating before the body runs
+// keeps CI from timing out in the org/domain DOM helpers.
+test.beforeEach(() => {
+  test.skip(!env.hasCustomDomains, gateReason.customDomains);
+});
+
 // -----------------------------------------------------------------------------
 // Types
 // -----------------------------------------------------------------------------

--- a/e2e/full/domain-navigation.spec.ts
+++ b/e2e/full/domain-navigation.spec.ts
@@ -19,6 +19,19 @@
 
 import { expect, Page, test } from '@playwright/test';
 
+import { env, gateReason } from '../support/env';
+
+// HOLDING ACTION — not coverage (E2E remediation plan Phase 2.4 / PR 5).
+// Every test needs a custom domain on the test account (optional deployment
+// config), so it is env-gated rather than fixme'd (issue #3420): set
+// E2E_CUSTOM_DOMAINS against a domains-enabled target to run it. No CI lane
+// sets that yet, so this suite is DORMANT in CI — real coverage returns when
+// PR 6 adds a domains-enabled lane + fixtures. Gating before the body runs
+// keeps CI from timing out in the org/domain DOM helpers.
+test.beforeEach(() => {
+  test.skip(!env.hasCustomDomains, gateReason.customDomains);
+});
+
 // -----------------------------------------------------------------------------
 // Types
 // -----------------------------------------------------------------------------

--- a/e2e/full/domain-sso-config.spec.ts
+++ b/e2e/full/domain-sso-config.spec.ts
@@ -30,6 +30,21 @@
 
 import { expect, Page, test } from '@playwright/test';
 
+import { env, gateReason } from '../support/env';
+
+// HOLDING ACTION — not coverage (E2E remediation plan Phase 2.4 / PR 5).
+// Per-domain SSO config needs BOTH a custom domain and the manage_sso
+// entitlement / SSO UI — optional deployment config, so env-gated rather than
+// fixme'd: set E2E_CUSTOM_DOMAINS and E2E_SSO_UI against a suitably-configured
+// target to run it. No CI lane sets either yet, so this suite is DORMANT in CI
+// — real coverage returns when PR 6 adds a configured lane + fixtures.
+test.beforeEach(() => {
+  test.skip(
+    !env.hasCustomDomains || !env.hasSsoUi,
+    `${gateReason.customDomains} ${gateReason.ssoUi}`
+  );
+});
+
 // -----------------------------------------------------------------------------
 // Types
 // -----------------------------------------------------------------------------
@@ -915,28 +930,25 @@ test.describe('Domain SSO Configuration - Access Control', () => {
     page.setDefaultTimeout(15000);
   });
 
-  test('TC-DSSO-019: shows access denied for users without manage_sso entitlement', async ({
-    page,
-  }) => {
-    const org = await getFirstOrganization(page);
-    test.skip(!org, 'Test requires at least 1 organization');
+  // Inverted precondition: this asserts the *absence* of the manage_sso
+  // entitlement, but the suite above is gated on E2E_SSO_UI (entitlement
+  // present), so it can never hold here. Quarantined as test.fixme until a
+  // no-entitlement lane exists; do not assert this in the SSO-gated file.
+  test.fixme(
+    'TC-DSSO-019: shows access denied for users without manage_sso entitlement',
+    async ({ page }) => {
+      const org = await getFirstOrganization(page);
+      expect(org, 'default workspace should exist').not.toBeNull();
 
-    // Navigate to org settings
-    await page.goto(`/org/${org!.extid}`);
-    await expect(page.locator('html[data-app-ready="true"]')).toBeAttached();
+      // Navigate to org settings
+      await page.goto(`/org/${org!.extid}`);
+      await expect(page.locator('html[data-app-ready="true"]')).toBeAttached();
 
-    // Check if SSO tab is NOT visible (no entitlement)
-    const ssoTab = page.locator('[data-testid="org-tab-sso"]');
-    const ssoTabVisible = await ssoTab.isVisible().catch(() => false);
-
-    if (!ssoTabVisible) {
-      // User doesn't have manage_sso entitlement - SSO tab is correctly hidden
-      expect(ssoTabVisible).toBe(false);
-    } else {
-      // User has entitlement - this test is not applicable
-      test.skip(true, 'User has manage_sso entitlement');
+      // Without the manage_sso entitlement the SSO tab is correctly hidden.
+      const ssoTab = page.locator('[data-testid="org-tab-sso"]');
+      await expect(ssoTab).toBeHidden();
     }
-  });
+  );
 
   test('TC-DSSO-020: domain SSO page shows access denied without entitlement', async ({ page }) => {
     const org = await getFirstOrganization(page);

--- a/e2e/full/domain-sso-multi-provider.spec.ts
+++ b/e2e/full/domain-sso-multi-provider.spec.ts
@@ -31,6 +31,22 @@
 
 import { expect, Page, test } from '@playwright/test';
 
+import { env, gateReason } from '../support/env';
+
+// HOLDING ACTION — not coverage (E2E remediation plan Phase 2.4 / PR 5).
+// Multi-domain SSO needs several custom domains plus the manage_sso
+// entitlement / SSO UI — optional deployment config, so env-gated rather than
+// fixme'd: set E2E_CUSTOM_DOMAINS (multiple) and E2E_SSO_UI against a
+// suitably-configured target to run it. No CI lane sets either yet, so this
+// suite is DORMANT in CI — real coverage returns when PR 6 adds a configured
+// lane + fixtures.
+test.beforeEach(() => {
+  test.skip(
+    !env.hasCustomDomains || !env.hasSsoUi,
+    `${gateReason.customDomains} ${gateReason.ssoUi}`
+  );
+});
+
 // -----------------------------------------------------------------------------
 // Types
 // -----------------------------------------------------------------------------

--- a/e2e/full/domains-store-org-cache.spec.ts
+++ b/e2e/full/domains-store-org-cache.spec.ts
@@ -232,7 +232,12 @@ function extractOrgIdFromRequest(request: Request): string | null {
 // Test Suite: DomainsStore Org Context Cache Fix
 // -----------------------------------------------------------------------------
 
-test.describe('DomainsStore Org Context Cache Fix', () => {
+// QUARANTINED — E2E remediation plan Phase 2.4 / PR 5 (issue #3420).
+// Needs ≥2 organizations (expects orgs literally named "Default Workspace" and
+// "A Second Organization") with per-org domain caches to compare — seeded data
+// the CI account does not have. Quarantined with test.describe.fixme until the
+// second-org + per-org-domain fixtures land in PR 6. See e2e/QUARANTINE.md.
+test.describe.fixme('DomainsStore Org Context Cache Fix', () => {
   test.beforeEach(async ({ page }) => {
     page.setDefaultTimeout(15000);
   });
@@ -538,7 +543,8 @@ test.describe('DomainsStore Org Context Cache Fix', () => {
 // Additional Edge Case Tests
 // -----------------------------------------------------------------------------
 
-test.describe('DomainsStore Cache - Edge Cases', () => {
+// QUARANTINED with the suite above — needs ≥2 orgs (issue #3420).
+test.describe.fixme('DomainsStore Cache - Edge Cases', () => {
   test.beforeEach(async ({ page }) => {
     page.setDefaultTimeout(15000);
   });

--- a/e2e/full/domains-store-org-cache.spec.ts
+++ b/e2e/full/domains-store-org-cache.spec.ts
@@ -359,8 +359,9 @@ test.describe.fixme('DomainsStore Org Context Cache Fix', () => {
 
       // Validate we found two DIFFERENT orgs
       if (defaultWorkspace.extid === secondOrg.extid) {
-        test.skip(true, `Found same org twice: ${defaultWorkspace.name} (${defaultWorkspace.extid})`);
-        return;
+        throw new Error(
+          `expected two distinct orgs but found ${defaultWorkspace.name} twice — needs second-org fixture (#3420)`
+        );
       }
 
       console.log(`[TC-DSC-002] Using Default Workspace: "${defaultWorkspace.name}" (${defaultWorkspace.extid})`);
@@ -559,8 +560,7 @@ test.describe.fixme('DomainsStore Cache - Edge Cases', () => {
     const secondOrg = findOrgByName(orgs, 'Second Organization');
 
     if (!defaultWorkspace || !secondOrg) {
-      test.skip(true, 'Test requires specific organizations');
-      return;
+      throw new Error('requires "Default Workspace" + "Second Organization" — second-org fixture (#3420)');
     }
 
     // Navigate to Default Workspace (domains tab is default)
@@ -621,8 +621,7 @@ test.describe.fixme('DomainsStore Cache - Edge Cases', () => {
 
     const secondOrg = findOrgByName(orgs, 'Second Organization');
     if (!secondOrg) {
-      test.skip(true, 'Test requires "A Second Organization"');
-      return;
+      throw new Error('requires a "Second Organization" — second-org fixture (#3420)');
     }
 
     // Navigate to Second Org (domains tab is default, should be empty)

--- a/e2e/full/invite-flow-states.spec.ts
+++ b/e2e/full/invite-flow-states.spec.ts
@@ -229,10 +229,11 @@ test.describe('INV-001: New User Atomic Signup Flow', () => {
 // -----------------------------------------------------------------------------
 
 test.describe('INV-002: New User Magic Link Flow', () => {
-  test.skip('new user can join via magic link', async () => {
-    // Lower priority - skip if magic link feature not enabled in test env
-    // Magic link requires email delivery infrastructure
-    test.skip(true, 'Magic link flow requires email infrastructure - not tested in basic suite');
+  // QUARANTINED (E2E remediation plan Phase 2.4 / PR 5, issue #3421): the magic
+  // link arrives by email, so this needs a mail interceptor the CI container
+  // does not run. Unimplemented placeholder -> test.fixme. See e2e/QUARANTINE.md.
+  test.fixme('new user can join via magic link', async () => {
+    // TODO(#3421): drive the magic-link join once a mail interceptor exists.
   });
 });
 
@@ -241,9 +242,11 @@ test.describe('INV-002: New User Magic Link Flow', () => {
 // -----------------------------------------------------------------------------
 
 test.describe('INV-003: New User SSO Flow', () => {
-  test.skip('new user can join via SSO', async () => {
-    // Requires SSO configuration in test environment
-    test.skip(true, 'SSO flow requires SSO provider configuration - not tested in basic suite');
+  // QUARANTINED (E2E remediation plan Phase 2.4 / PR 5, issue #3421): needs an
+  // SSO/IdP configured AND a captured invite email. Unimplemented placeholder
+  // -> test.fixme. See e2e/QUARANTINE.md.
+  test.fixme('new user can join via SSO', async () => {
+    // TODO(#3421): drive the SSO join once an IdP + mail interceptor exist.
   });
 });
 
@@ -324,9 +327,11 @@ test.describe('INV-004: Existing User Signin Flow', () => {
 // -----------------------------------------------------------------------------
 
 test.describe('INV-005: Existing User MFA Flow', () => {
-  test.skip('existing user with MFA completes invite flow', async () => {
-    // Requires MFA to be enabled for test user
-    test.skip(true, 'MFA flow requires MFA-enabled test account - not tested in basic suite');
+  // QUARANTINED (E2E remediation plan Phase 2.4 / PR 5, issue #3421): needs an
+  // MFA-enrolled invitee account (TEST_MFA_* — see e2e/support/env.ts).
+  // Unimplemented placeholder -> test.fixme. See e2e/QUARANTINE.md.
+  test.fixme('existing user with MFA completes invite flow', async () => {
+    // TODO(#3421): drive the MFA invite flow with a seeded MFA account.
   });
 });
 

--- a/e2e/full/mfa-bootstrap-reactivity.spec.ts
+++ b/e2e/full/mfa-bootstrap-reactivity.spec.ts
@@ -251,14 +251,14 @@ test.describe('MFA Flow - bootstrapStore Reactivity', () => {
     await loginWithMfaCredentials(page);
     await expect(page).toHaveURL(/\/mfa-verify/);
 
-    // Generate or use provided OTP
-    let otpCode: string;
-    try {
-      otpCode = await generateTotpCode(process.env.TEST_MFA_SECRET || '');
-    } catch (error) {
-      test.skip(true, 'OTP generation not available');
-      return;
-    }
+    // Deriving a live code needs the TOTP seed; gate on it so the requirement
+    // is explicit. A bad/garbage seed now FAILS (generateTotpCode throws)
+    // instead of silently skipping — the skip was the "can't fail" anti-pattern.
+    test.skip(
+      !process.env.TEST_MFA_SECRET,
+      'TC-MFA-004 requires TEST_MFA_SECRET (the TOTP seed) to derive a code'
+    );
+    const otpCode = await generateTotpCode(process.env.TEST_MFA_SECRET as string);
 
     // Enter OTP code
     // Handle both single input and multiple digit inputs

--- a/e2e/full/org-invitation-flow.spec.ts
+++ b/e2e/full/org-invitation-flow.spec.ts
@@ -597,22 +597,14 @@ test.describe('INV-011: Revoke Invitation', () => {
 test.describe('INV-012: Gmail Alias Normalization', () => {
   test.skip(!hasTestCredentials, 'Skipping: Requires specific email setup for Gmail alias testing');
 
-  test.skip('Gmail alias normalization allows user+tag@gmail.com to match user@gmail.com', async () => {
-    // This test requires a real Gmail account setup
-    // The normalizeEmail function in AcceptInvite.vue handles:
-    // - Lowercasing
-    // - Stripping + suffixes (user+tag@domain → user@domain)
-
-    // Verify the normalization function works correctly
-    // by checking the UI behavior when a +tag email is invited
-
-    // Note: Full E2E test would require:
-    // 1. Create invitation for user+tag@gmail.com
-    // 2. Login as user@gmail.com
-    // 3. Verify NO mismatch warning (emails match after normalization)
-
-    // For now, we verify the function exists in the component
-    test.skip(true, 'Gmail alias test requires real email accounts');
+  // QUARANTINED (E2E remediation plan Phase 2.4 / PR 5, issue #3421): needs real
+  // Gmail accounts + captured invite email. Unimplemented placeholder ->
+  // test.fixme. normalizeEmail() in AcceptInvite.vue is unit-tested; see
+  // e2e/QUARANTINE.md.
+  test.fixme('Gmail alias normalization allows user+tag@gmail.com to match user@gmail.com', async () => {
+    // TODO(#3421): create an invite for user+tag@gmail.com, sign in as
+    // user@gmail.com, and assert NO mismatch warning (emails match after
+    // normalization) — once a mail interceptor exists.
   });
 });
 
@@ -765,17 +757,13 @@ test.describe('INV-SEC-002: Account Enumeration Prevention', () => {
 test.describe('INV-017: Complete Invitation Acceptance Flow', () => {
   test.skip(!hasTestCredentials, 'Skipping: TEST_USER_EMAIL and TEST_USER_PASSWORD required');
 
-  test.skip('After accepting invitation, user can see and access the organization in their org list', async () => {
-    // This is a full integration test that would require:
-    // 1. Owner creates invitation
-    // 2. New user creates account with invited email
-    // 3. New user accepts invitation
-    // 4. New user verifies org appears in their list
-
-    // Note: This test is complex and may need Mailpit integration
-    // for full email verification flow
-
-    test.skip(true, 'Full integration test requires email verification setup');
+  // QUARANTINED (E2E remediation plan Phase 2.4 / PR 5, issue #3421): full
+  // multi-account integration — owner invites, a NEW account signs up with the
+  // invited email, accepts, and sees the org. Needs a second account + Mailpit.
+  // Unimplemented placeholder -> test.fixme. See e2e/QUARANTINE.md.
+  test.fixme('After accepting invitation, user can see and access the organization in their org list', async () => {
+    // TODO(#3421): owner creates invite -> new account signs up with the
+    // invited email -> accepts -> asserts the org appears in their list.
   });
 });
 

--- a/e2e/full/org-switcher-navigation.spec.ts
+++ b/e2e/full/org-switcher-navigation.spec.ts
@@ -189,10 +189,7 @@ test.describe.fixme('Org Switcher Navigation - Same Tab Navigation', () => {
     const orgTrigger = orgSwitcher.trigger(page);
     const triggerVisible = await orgTrigger.isVisible().catch(() => false);
 
-    if (!triggerVisible) {
-      test.skip(true, 'Org switcher not visible - may be using hideBoth preset');
-      return;
-    }
+    expect(triggerVisible, 'org switcher requires ≥2 orgs — second-org fixture (#3420)').toBe(true);
 
     // Store the initial URL for comparison
     const initialUrl = page.url();
@@ -243,10 +240,7 @@ test.describe.fixme('Org Switcher Navigation - Same Tab Navigation', () => {
     const orgTrigger = orgSwitcher.trigger(page);
     const triggerVisible = await orgTrigger.isVisible().catch(() => false);
 
-    if (!triggerVisible) {
-      test.skip(true, 'Org switcher not visible on billing tab');
-      return;
-    }
+    expect(triggerVisible, 'org switcher requires ≥2 orgs — second-org fixture (#3420)').toBe(true);
 
     const initialUrl = page.url();
 
@@ -284,10 +278,7 @@ test.describe.fixme('Org Switcher Navigation - Same Tab Navigation', () => {
     const orgTrigger = orgSwitcher.trigger(page);
     const triggerVisible = await orgTrigger.isVisible().catch(() => false);
 
-    if (!triggerVisible) {
-      test.skip(true, 'Org switcher not visible on settings tab');
-      return;
-    }
+    expect(triggerVisible, 'org switcher requires ≥2 orgs — second-org fixture (#3420)').toBe(true);
 
     const initialUrl = page.url();
 
@@ -329,10 +320,7 @@ test.describe.fixme('Org Switcher Navigation - Same Tab Navigation', () => {
     const orgTrigger = orgSwitcher.trigger(page);
     const triggerVisible = await orgTrigger.isVisible().catch(() => false);
 
-    if (!triggerVisible) {
-      test.skip(true, 'Org switcher not visible');
-      return;
-    }
+    expect(triggerVisible, 'org switcher requires ≥2 orgs — second-org fixture (#3420)').toBe(true);
 
     // Record initial state
     const initialExtid = extid1;
@@ -383,10 +371,7 @@ test.describe.fixme('Org Switcher Navigation - Same Tab Navigation', () => {
     const orgTrigger = orgSwitcher.trigger(page);
     const triggerVisible = await orgTrigger.isVisible().catch(() => false);
 
-    if (!triggerVisible) {
-      test.skip(true, 'Org switcher not visible');
-      return;
-    }
+    expect(triggerVisible, 'org switcher requires ≥2 orgs — second-org fixture (#3420)').toBe(true);
 
     // Get initial org name from header/trigger
     const initialTriggerText = await orgTrigger.textContent();
@@ -433,10 +418,7 @@ test.describe.fixme('Org Switcher Navigation - Edge Cases', () => {
     const orgTrigger = orgSwitcher.trigger(page);
     const triggerVisible = await orgTrigger.isVisible().catch(() => false);
 
-    if (!triggerVisible) {
-      test.skip(true, 'Org switcher not visible');
-      return;
-    }
+    expect(triggerVisible, 'org switcher requires ≥2 orgs — second-org fixture (#3420)').toBe(true);
 
     const initialUrl = page.url();
 
@@ -468,10 +450,7 @@ test.describe.fixme('Org Switcher Navigation - Edge Cases', () => {
     const orgTrigger = orgSwitcher.trigger(page);
     const triggerVisible = await orgTrigger.isVisible().catch(() => false);
 
-    if (!triggerVisible) {
-      test.skip(true, 'Org switcher not visible');
-      return;
-    }
+    expect(triggerVisible, 'org switcher requires ≥2 orgs — second-org fixture (#3420)').toBe(true);
 
     // Switch to Second Organization
     await switchOrgViaSwitcher(page, ORG_SECOND);

--- a/e2e/full/org-switcher-navigation.spec.ts
+++ b/e2e/full/org-switcher-navigation.spec.ts
@@ -162,7 +162,13 @@ function getCurrentTab(page: Page): string | null {
 // Org Switcher Navigation Test Suite
 // -----------------------------------------------------------------------------
 
-test.describe('Org Switcher Navigation - Same Tab Navigation', () => {
+// QUARANTINED — E2E remediation plan Phase 2.4 / PR 5 (issue #3420).
+// The org switcher only renders for accounts with ≥2 organizations; the CI
+// account has a single default workspace, so every test here previously
+// pass-or-skipped on "Org switcher not visible". Quarantined with
+// test.describe.fixme until the second-org fixture lands in PR 6.
+// See e2e/QUARANTINE.md.
+test.describe.fixme('Org Switcher Navigation - Same Tab Navigation', () => {
   test.beforeEach(async ({ page }) => {
     page.setDefaultTimeout(15000);
   });
@@ -409,7 +415,8 @@ test.describe('Org Switcher Navigation - Same Tab Navigation', () => {
 // Edge Cases and Error Handling
 // -----------------------------------------------------------------------------
 
-test.describe('Org Switcher Navigation - Edge Cases', () => {
+// QUARANTINED with the suite above — needs ≥2 orgs (issue #3420).
+test.describe.fixme('Org Switcher Navigation - Edge Cases', () => {
   test.beforeEach(async ({ page }) => {
     page.setDefaultTimeout(15000);
   });

--- a/e2e/support/env.ts
+++ b/e2e/support/env.ts
@@ -47,11 +47,14 @@ export const env = {
   /** The SSO sign-in UI is configured (E2E_SSO_UI) — OmniAuth/SSO buttons render. */
   hasSsoUi: flag('E2E_SSO_UI'),
 
-  /** An MFA/TOTP-enrolled account is available (TEST_MFA_USER_*). */
+  /**
+   * An MFA/TOTP-enrolled account is available. Matches the convention already
+   * used by e2e/full/mfa-bootstrap-reactivity.spec.ts.
+   */
   hasMfaAccount:
     flag('TEST_MFA_USER_EMAIL') &&
     flag('TEST_MFA_USER_PASSWORD') &&
-    flag('TEST_MFA_USER_SECRET'),
+    (flag('TEST_MFA_SECRET') || flag('TEST_MFA_OTP')),
 };
 
 /**
@@ -68,5 +71,5 @@ export const gateReason = {
     'an OmniAuth/SSO provider enabled).',
   mfaAccount:
     'Requires an MFA/TOTP-enrolled account — set TEST_MFA_USER_EMAIL / ' +
-    'TEST_MFA_USER_PASSWORD / TEST_MFA_USER_SECRET.',
+    'TEST_MFA_USER_PASSWORD / TEST_MFA_SECRET.',
 } as const;

--- a/e2e/support/env.ts
+++ b/e2e/support/env.ts
@@ -1,0 +1,72 @@
+// e2e/support/env.ts
+//
+// Documented environment gates for the E2E suite
+// (e2e/docs/e2e-remediation-plan.md, Phase 2.4: defensive-skip triage).
+//
+// Guiding principle #1 is "a test must be able to fail": a bare
+// `test.skip(true, ...)` can only pass-or-skip, so it gives zero signal. Where
+// a test genuinely depends on OPTIONAL deployment configuration that the CI
+// container does not provision, gate it on one of the flags below so the skip
+// names a real, documented environment condition instead of an unconditional
+// skip.
+//
+// The CI workflow (.github/workflows/e2e.yml) sets NONE of these, so gated
+// suites skip there cleanly (no false-green "passes"); set them locally
+// against a suitably-configured target to exercise the suite.
+//
+// Note the deliberate split:
+//   - OPTIONAL CONFIG (a custom domain exists, SSO UI is on, an MFA account
+//     exists) -> env-gated here. It is deployment configuration.
+//   - SEEDED DATA RELATIONSHIPS (a second organization, a second member, a
+//     captured invite email) -> NOT env-gated. Those need fixtures, so the
+//     suites are `test.fixme`'d and tracked in e2e/QUARANTINE.md
+//     (issues #3419 / #3420 / #3421). The fixture work is Phase 3 / PR 6.
+
+/** True when an env var is present and not an explicit falsey string. */
+function flag(name: string): boolean {
+  const v = process.env[name];
+  return v !== undefined && v !== '' && v !== '0' && v.toLowerCase() !== 'false';
+}
+
+/**
+ * Custom domains available on the target account. Set E2E_CUSTOM_DOMAINS to a
+ * comma-separated list (or any truthy value) when the target runs with custom
+ * domains enabled and at least one provisioned. Suites that navigate
+ * `/org/:id/domains/:extid/...` gate on `hasCustomDomains`.
+ */
+export const customDomains: string[] = (process.env.E2E_CUSTOM_DOMAINS ?? '')
+  .split(',')
+  .map((s) => s.trim())
+  .filter(Boolean);
+
+export const env = {
+  /** ≥1 custom domain is provisioned on the test account (E2E_CUSTOM_DOMAINS). */
+  hasCustomDomains: customDomains.length > 0,
+  customDomains,
+
+  /** The SSO sign-in UI is configured (E2E_SSO_UI) — OmniAuth/SSO buttons render. */
+  hasSsoUi: flag('E2E_SSO_UI'),
+
+  /** An MFA/TOTP-enrolled account is available (TEST_MFA_USER_*). */
+  hasMfaAccount:
+    flag('TEST_MFA_USER_EMAIL') &&
+    flag('TEST_MFA_USER_PASSWORD') &&
+    flag('TEST_MFA_USER_SECRET'),
+};
+
+/**
+ * Reason strings for the gates above. Keeping them here means a skip's message
+ * always points at the exact env var to set, instead of a vague "feature not
+ * available".
+ */
+export const gateReason = {
+  customDomains:
+    'Requires a custom domain on the test account — set E2E_CUSTOM_DOMAINS ' +
+    '(target must run with domains enabled). See issue #3420.',
+  ssoUi:
+    'Requires the SSO sign-in UI configured — set E2E_SSO_UI (target must have ' +
+    'an OmniAuth/SSO provider enabled).',
+  mfaAccount:
+    'Requires an MFA/TOTP-enrolled account — set TEST_MFA_USER_EMAIL / ' +
+    'TEST_MFA_USER_PASSWORD / TEST_MFA_USER_SECRET.',
+} as const;


### PR DESCRIPTION
## Summary

[#3419](https://github.com/onetimesecret/onetimesecret/issues/3419)

Implements Phase 2.4 of the [E2E remediation plan](e2e/docs/e2e-remediation-plan.md): defensive-skip triage. Converts silent test skips into explicit, documented gates so that:

1. **Tests that depend on optional deployment config** (custom domains, SSO UI, MFA accounts) are env-gated via `e2e/support/env.ts` — CI does not set these flags, so suites skip cleanly with a named reason instead of an unconditional skip.

2. **Tests that need seeded data relationships** (second organization, second member, captured email) are quarantined with `test.fixme` and tracked in `e2e/QUARANTINE.md` — they cannot run until Phase 3 / PR 6 adds the fixtures.

3. **Tests that can fail are allowed to fail** — no more bare `test.skip(true, ...)` that silently report as green. Assertions now use web-first matchers (`.toBeVisible()`, `.toBeAttached()`) so routing/build regressions surface instead of being hidden by defensive skips.

### Key Changes

- **`e2e/support/env.ts`** (new): Centralized environment gates for optional config (custom domains, SSO UI, MFA accounts). Each gate documents the env var to set and links to the issue.

- **`e2e/all/incoming-secrets.spec.ts`**: Refactored to use deterministic API mocking (intercepted `/api/incoming/config` and `/api/incoming/secret`). Removed all defensive skips; now asserts the SPA shell always loads (HTTP 200) and waits on `data-app-ready="true"` instead of `networkidle`. Updated mock recipient shape from `{ hash, name }` to `{ digest, display_name }` to match the real schema.

- **`e2e/auth/sso-csrf.spec.ts`**: Env-gated on `E2E_SSO_UI` (beforeEach skip). Removed inline `test.skip(true, ...)` calls; assertions now expect the SSO button to render.

- **`e2e/full/domain-*.spec.ts`** (6 files): Env-gated on `E2E_CUSTOM_DOMAINS` (beforeEach skip). Removed defensive skips.

- **`e2e/full/domain-sso-*.spec.ts`** (2 files): Env-gated on both `E2E_CUSTOM_DOMAINS` and `E2E_SSO_UI`.

- **`e2e/full/org-switcher-navigation.spec.ts`**: Quarantined with `test.describe.fixme` (needs second-org fixture, issue #3420).

- **`e2e/full/cross-org-domain-isolation.spec.ts`**: Quarantined with `test.describe.fixme` (needs ≥2 orgs with disjoint domain sets, issue #3420).

- **`e2e/full/domains-store-org-cache.spec.ts`**: Quarantined with `test.describe.fixme` (needs second-org fixture, issue #3420).

- **`e2e/full/domain-context-consultant.spec.ts`**: Seven custom-domain tests quarantined with `test.fixme`; two no-custom-domain tests remain runnable.

- **`e2e/full/org-invitation-flow.spec.ts`**: Quarantined `INV-012` (Gmail alias) and `INV-017` (complete flow) with `test.fixme` (need captured email, issue #3421).

- **`e2e/full/invite-flow-states.spec.ts`**: Quarantined `INV-002` (magic link) with `test.fixme` (needs mail interceptor, issue #3421).

https://claude.ai/code/session_01Aj6hyHvb5Q4uxqA1QUTTQ3