### PR TITLE
Fix #3427: give the IP privacy middleware a trusted-proxy config

### DIFF
--- a/lib/onetime/application/middleware_stack.rb
+++ b/lib/onetime/application/middleware_stack.rb
@@ -125,6 +125,53 @@ module Onetime
           end
         end
 
+        # IP ranges that are always treated as proxy hops, never as the client.
+        # Covers RFC1918, loopback, link-local, and IPv6 ULA/loopback. Otto's
+        # IPPrivacyMiddleware walks X-Forwarded-For and returns the first
+        # address that does NOT match a trusted proxy, so trusting these private
+        # ranges is what lets the real public visitor IP surface in deployments
+        # where every proxy hop has an internal address (Kubernetes ingress,
+        # cloud load balancers).
+        PRIVATE_PROXY_RANGES = %r{
+          \A(?:
+            10\.|
+            127\.|
+            192\.168\.|
+            169\.254\.|
+            172\.(?:1[6-9]|2\d|3[01])\.|
+            ::1\z|
+            f[cd]
+          )
+        }ix
+
+        # Build the Otto security config handed to IPPrivacyMiddleware.
+        #
+        # Returns nil when trusted proxy support is disabled, which leaves the
+        # middleware in its default direct-connection mode (REMOTE_ADDR is the
+        # client) — correct for deployments not behind a proxy.
+        #
+        # When site.network.trusted_proxy is enabled, the returned config trusts
+        # the private proxy ranges so the middleware resolves the real client
+        # from the forwarded headers instead of masking the ingress hop. This
+        # mirrors the trust the ConfigureTrustedProxy initializer applies to
+        # Rack::Request#ip, keeping both IP resolution paths in agreement.
+        #
+        # NOTE: only RFC1918/loopback proxy hops are trusted here. Trusting
+        # public proxy ranges (e.g. a CDN with public egress IPs) would need
+        # CIDR matching, which Otto's prefix-based trusted_proxy list does not
+        # support. The site.network.trusted_proxy.cidrs setting therefore only
+        # affects Rack::Request#ip today, not this middleware.
+        #
+        # @return [Otto::Security::Config, nil]
+        def ip_privacy_security_config
+          trusted_proxy = OT.conf.dig('site', 'network', 'trusted_proxy') || {}
+          return nil unless trusted_proxy['enabled'] == true
+
+          config = Otto::Security::Config.new
+          config.add_trusted_proxy(PRIVATE_PROXY_RANGES)
+          config
+        end
+
         def configure(builder, application_context: nil)
           logger = Onetime.get_logger('App')
           logger.debug 'Configuring common middleware',
@@ -134,12 +181,21 @@ module Onetime
 
           # IP Privacy FIRST - masks public IPs before logging/monitoring
           # Private/localhost IPs are automatically exempted for development
-          # Uses Otto's privacy middleware as a standalone Rack component
+          # Uses Otto's privacy middleware as a standalone Rack component.
+          #
+          # The middleware needs a security config that knows which proxies to
+          # trust; without one it treats REMOTE_ADDR (the ingress/proxy hop) as
+          # the client and overwrites X-Forwarded-For with it, hiding the real
+          # visitor IP from every downstream consumer (ban checks, sessions,
+          # identity resolution, the Colonel "current IP" panel). See
+          # ip_privacy_security_config.
+          ip_privacy_config = ip_privacy_security_config
           logger.debug 'Setting up IP Privacy middleware',
             {
               note: 'masks public IPs',
+              trusted_proxy: !ip_privacy_config.nil?,
             }
-          builder.use Otto::Security::Middleware::IPPrivacyMiddleware
+          builder.use Otto::Security::Middleware::IPPrivacyMiddleware, ip_privacy_config
 
           # IP Ban middleware - blocks banned IPs (after IP privacy)
           logger.debug 'Setting up IP Ban middleware'

--- a/spec/unit/onetime/application/middleware_stack_spec.rb
+++ b/spec/unit/onetime/application/middleware_stack_spec.rb
@@ -1,0 +1,61 @@
+# spec/unit/onetime/application/middleware_stack_spec.rb
+#
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Onetime::Application::MiddlewareStack do
+  describe '.ip_privacy_security_config' do
+    subject(:config) { described_class.ip_privacy_security_config }
+
+    def stub_conf(trusted_proxy)
+      allow(OT).to receive(:conf).and_return(
+        'site' => { 'network' => { 'trusted_proxy' => trusted_proxy } }
+      )
+    end
+
+    context 'when trusted_proxy is absent' do
+      before { allow(OT).to receive(:conf).and_return({}) }
+
+      it 'returns nil so the middleware stays in direct-connection mode' do
+        expect(config).to be_nil
+      end
+    end
+
+    context 'when trusted_proxy is disabled' do
+      before { stub_conf('enabled' => false) }
+
+      it 'returns nil' do
+        expect(config).to be_nil
+      end
+    end
+
+    context 'when trusted_proxy is enabled' do
+      before { stub_conf('enabled' => true) }
+
+      it 'returns an Otto security config' do
+        expect(config).to be_a(Otto::Security::Config)
+      end
+
+      it 'trusts RFC1918 proxy hops' do
+        aggregate_failures do
+          expect(config.trusted_proxy?('10.244.10.0')).to be(true)
+          expect(config.trusted_proxy?('192.168.1.1')).to be(true)
+          expect(config.trusted_proxy?('172.16.0.1')).to be(true)
+          expect(config.trusted_proxy?('172.31.255.255')).to be(true)
+          expect(config.trusted_proxy?('127.0.0.1')).to be(true)
+        end
+      end
+
+      it 'does not trust public client addresses' do
+        aggregate_failures do
+          expect(config.trusted_proxy?('203.0.113.42')).to be(false)
+          expect(config.trusted_proxy?('198.51.100.7')).to be(false)
+          # 172.32 is outside the RFC1918 172.16/12 block
+          expect(config.trusted_proxy?('172.32.0.1')).to be(false)
+        end
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
Fixes #3427.

The IP privacy middleware is mounted first in the common stack with no security config:

```ruby
builder.use Otto::Security::Middleware::IPPrivacyMiddleware
```

With `@security_config` nil, Otto's `resolve_client_ip` returns `REMOTE_ADDR` without reading `X-Forwarded-For`, masks it, and overwrites the forwarded headers with the masked value. Behind a proxy the real client IP is gone before any later middleware or auth strategy calls `request.ip`, so the `site.network.trusted_proxy` config from #3116 (which only configures `Rack::Request#ip`) runs too late to help. Details in #3427.

## Change

`MiddlewareStack` builds an `Otto::Security::Config` and passes it to the middleware. When `site.network.trusted_proxy.enabled` is true it trusts the private proxy ranges (RFC1918, loopback, link-local, IPv6 ULA/loopback), so the middleware resolves the client from the forwarded headers and masks that instead. When trusted proxy is off, the helper returns nil and behaviour is unchanged, so direct-connection deployments are unaffected.

## Limits

- Only RFC1918/loopback hops are trusted. Public proxy ranges (a CDN with public egress IPs) would need CIDR matching, which Otto's prefix-based trusted-proxy list doesn't do, so `site.network.trusted_proxy.cidrs` still only affects `Rack::Request#ip`. Noted in a code comment.
- The stored/displayed IP is still masked to a /24 by the existing privacy settings. This just makes it the correct /24 rather than the proxy's.

## Tests

Added `spec/unit/onetime/application/middleware_stack_spec.rb` for the absent, disabled, and enabled cases. I couldn't run the suite locally (no bundler in my env), so please let CI confirm.
