### PR TITLE
Fix: give the IP privacy middleware a trusted-proxy config

### DIFF
--- a/lib/onetime/application/middleware_stack.rb
+++ b/lib/onetime/application/middleware_stack.rb
@@ -54,6 +54,33 @@ module Onetime
         'application/x-www-form-urlencoded' => proc { |body| Rack::Utils.parse_nested_query(body) },
       }.freeze
 
+      # IP ranges that are always treated as proxy hops, never as the client.
+      # IPv4: RFC1918 (10/8, 172.16/12, 192.168/16), loopback (127/8) and
+      # link-local (169.254/16). IPv6: loopback (::1), ULA (fc00::/7, the
+      # f[cd] branch) and link-local (fe80::/10, the fe[89ab] branch). Otto's
+      # IPPrivacyMiddleware walks X-Forwarded-For and returns the first
+      # address that does NOT match a trusted proxy, so trusting these private
+      # ranges is what lets the real public visitor IP surface in deployments
+      # where every proxy hop has an internal address (Kubernetes ingress,
+      # cloud load balancers).
+      #
+      # Defined at module scope (not inside `class << self`) so it is reachable
+      # as MiddlewareStack::PRIVATE_PROXY_RANGES from the Otto router wiring in
+      # OttoHooks, while remaining lexically visible to the singleton methods
+      # below.
+      PRIVATE_PROXY_RANGES = /
+        \A(?:
+          10\.|
+          127\.|
+          192\.168\.|
+          169\.254\.|
+          172\.(?:1[6-9]|2\d|3[01])\.|
+          ::1\z|
+          f[cd]|
+          fe[89ab]
+        )
+      /ix
+
       class << self
         # Build locale map for Otto::Locale::Middleware
         #
@@ -125,25 +152,6 @@ module Onetime
           end
         end
 
-        # IP ranges that are always treated as proxy hops, never as the client.
-        # Covers RFC1918, loopback, link-local, and IPv6 ULA/loopback. Otto's
-        # IPPrivacyMiddleware walks X-Forwarded-For and returns the first
-        # address that does NOT match a trusted proxy, so trusting these private
-        # ranges is what lets the real public visitor IP surface in deployments
-        # where every proxy hop has an internal address (Kubernetes ingress,
-        # cloud load balancers).
-        PRIVATE_PROXY_RANGES = %r{
-          \A(?:
-            10\.|
-            127\.|
-            192\.168\.|
-            169\.254\.|
-            172\.(?:1[6-9]|2\d|3[01])\.|
-            ::1\z|
-            f[cd]
-          )
-        }ix
-
         # Build the Otto security config handed to IPPrivacyMiddleware.
         #
         # Returns nil when trusted proxy support is disabled, which leaves the
@@ -164,12 +172,24 @@ module Onetime
         #
         # @return [Otto::Security::Config, nil]
         def ip_privacy_security_config
-          trusted_proxy = OT.conf.dig('site', 'network', 'trusted_proxy') || {}
-          return nil unless trusted_proxy['enabled'] == true
+          return nil unless trusted_proxy_enabled?
 
           config = Otto::Security::Config.new
           config.add_trusted_proxy(PRIVATE_PROXY_RANGES)
           config
+        end
+
+        # Whether the deployment has declared a trusted reverse proxy in front
+        # of the app (site.network.trusted_proxy.enabled). Single source of
+        # truth for both IP-resolution paths: the outer IPPrivacyMiddleware
+        # (ip_privacy_security_config, above) and the Otto router's own trust
+        # list (OttoHooks#configure_otto_trusted_proxies). Keeping one predicate
+        # ensures the two paths never disagree about whether to honor forwarded
+        # headers.
+        #
+        # @return [Boolean]
+        def trusted_proxy_enabled?
+          OT.conf.dig('site', 'network', 'trusted_proxy', 'enabled') == true
         end
 
         def configure(builder, application_context: nil)

--- a/lib/onetime/application/middleware_stack.rb
+++ b/lib/onetime/application/middleware_stack.rb
@@ -125,6 +125,53 @@ module Onetime
           end
         end
 
+        # IP ranges that are always treated as proxy hops, never as the client.
+        # Covers RFC1918, loopback, link-local, and IPv6 ULA/loopback. Otto's
+        # IPPrivacyMiddleware walks X-Forwarded-For and returns the first
+        # address that does NOT match a trusted proxy, so trusting these private
+        # ranges is what lets the real public visitor IP surface in deployments
+        # where every proxy hop has an internal address (Kubernetes ingress,
+        # cloud load balancers).
+        PRIVATE_PROXY_RANGES = %r{
+          \A(?:
+            10\.|
+            127\.|
+            192\.168\.|
+            169\.254\.|
+            172\.(?:1[6-9]|2\d|3[01])\.|
+            ::1\z|
+            f[cd]
+          )
+        }ix
+
+        # Build the Otto security config handed to IPPrivacyMiddleware.
+        #
+        # Returns nil when trusted proxy support is disabled, which leaves the
+        # middleware in its default direct-connection mode (REMOTE_ADDR is the
+        # client) — correct for deployments not behind a proxy.
+        #
+        # When site.network.trusted_proxy is enabled, the returned config trusts
+        # the private proxy ranges so the middleware resolves the real client
+        # from the forwarded headers instead of masking the ingress hop. This
+        # mirrors the trust the ConfigureTrustedProxy initializer applies to
+        # Rack::Request#ip, keeping both IP resolution paths in agreement.
+        #
+        # NOTE: only RFC1918/loopback proxy hops are trusted here. Trusting
+        # public proxy ranges (e.g. a CDN with public egress IPs) would need
+        # CIDR matching, which Otto's prefix-based trusted_proxy list does not
+        # support. The site.network.trusted_proxy.cidrs setting therefore only
+        # affects Rack::Request#ip today, not this middleware.
+        #
+        # @return [Otto::Security::Config, nil]
+        def ip_privacy_security_config
+          trusted_proxy = OT.conf.dig('site', 'network', 'trusted_proxy') || {}
+          return nil unless trusted_proxy['enabled'] == true
+
+          config = Otto::Security::Config.new
+          config.add_trusted_proxy(PRIVATE_PROXY_RANGES)
+          config
+        end
+
         def configure(builder, application_context: nil)
           logger = Onetime.get_logger('App')
           logger.debug 'Configuring common middleware',
@@ -134,12 +181,21 @@ module Onetime
 
           # IP Privacy FIRST - masks public IPs before logging/monitoring
           # Private/localhost IPs are automatically exempted for development
-          # Uses Otto's privacy middleware as a standalone Rack component
+          # Uses Otto's privacy middleware as a standalone Rack component.
+          #
+          # The middleware needs a security config that knows which proxies to
+          # trust; without one it treats REMOTE_ADDR (the ingress/proxy hop) as
+          # the client and overwrites X-Forwarded-For with it, hiding the real
+          # visitor IP from every downstream consumer (ban checks, sessions,
+          # identity resolution, the Colonel "current IP" panel). See
+          # ip_privacy_security_config.
+          ip_privacy_config = ip_privacy_security_config
           logger.debug 'Setting up IP Privacy middleware',
             {
               note: 'masks public IPs',
+              trusted_proxy: !ip_privacy_config.nil?,
             }
-          builder.use Otto::Security::Middleware::IPPrivacyMiddleware
+          builder.use Otto::Security::Middleware::IPPrivacyMiddleware, ip_privacy_config
 
           # IP Ban middleware - blocks banned IPs (after IP privacy)
           logger.debug 'Setting up IP Ban middleware'

--- a/lib/onetime/application/otto_hooks.rb
+++ b/lib/onetime/application/otto_hooks.rb
@@ -12,6 +12,7 @@
 require_relative '../logger_methods'
 require_relative 'request_helpers'
 require_relative 'error_resolver'
+require_relative 'middleware_stack'
 
 module Onetime
   module Application
@@ -94,6 +95,12 @@ module Onetime
           { error: error.message, error_type: 'Unauthorized' }
         end
 
+        # Give the router the same trusted-proxy list as the outer IP-privacy
+        # middleware. Done here (not in each build_router) so no Otto app can
+        # land with an inconsistent trust list. Placed before the debug-only
+        # request-logging hook below so it runs in production too.
+        configure_otto_trusted_proxies(router)
+
         return unless Onetime.debug?
 
         router.on_request_complete do |req, res, duration|
@@ -117,6 +124,30 @@ module Onetime
               user_agent: req.user_agent&.slice(0, 100),
             }
         end
+      end
+
+      # Mirror the trusted-proxy list onto the Otto router's own security
+      # config so req.client_ipaddress and req.secure? agree with Rack's
+      # request.ip about which hops to trust. No-op unless
+      # site.network.trusted_proxy is enabled (same gate as the outer
+      # IPPrivacyMiddleware via MiddlewareStack.ip_privacy_security_config).
+      #
+      # Defense-in-depth, not the primary path: the outer middleware runs
+      # first and has already rewritten REMOTE_ADDR to the resolved (masked)
+      # client by the time the router sees a request. For public clients that
+      # masked address is not a trusted proxy, so this list does not fire and
+      # they still depend on the outer rewrite — this list keeps resolution
+      # correct if that middleware is ever reordered or removed. It does change
+      # the private-origin requests the outer middleware exempts from masking
+      # (REMOTE_ADDR left private): the router now walks X-Forwarded-For and
+      # honors X-Forwarded-Proto for those, instead of returning the proxy hop.
+      #
+      # @param router [Otto] The Otto router instance to configure
+      # @return [void]
+      def configure_otto_trusted_proxies(router)
+        return unless Onetime::Application::MiddlewareStack.trusted_proxy_enabled?
+
+        router.add_trusted_proxy(Onetime::Application::MiddlewareStack::PRIVATE_PROXY_RANGES)
       end
     end
   end

--- a/spec/integration/all/organization_v1_migration_created_by_spec.rb
+++ b/spec/integration/all/organization_v1_migration_created_by_spec.rb
@@ -28,6 +28,15 @@ RSpec.describe 'Organization.create_from_v1_customer! created_by dual-write',
     require 'securerandom'
     ENV.delete('REDIS_URL')
     ENV.delete('VALKEY_URL')
+
+    # Standalone materialization happens inside Organization.create!, which
+    # runs here in before(:all) -- BEFORE billing_isolation.rb's before(:each)
+    # disable hook fires. So a prior spec (or env) leaving BILLING_ENABLED=true
+    # would make create! treat the org as SaaS and skip materialization,
+    # failing the standalone assertions below. Disable billing explicitly here
+    # so this spec is self-contained rather than dependent on hook ordering.
+    BillingTestHelpers.disable_billing!
+
     begin
       OT.boot! :test, false unless OT.ready?
     rescue Redis::CannotConnectError, Redis::ConnectionError => e

--- a/spec/unit/onetime/application/middleware_stack_spec.rb
+++ b/spec/unit/onetime/application/middleware_stack_spec.rb
@@ -1,0 +1,61 @@
+# spec/unit/onetime/application/middleware_stack_spec.rb
+#
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Onetime::Application::MiddlewareStack do
+  describe '.ip_privacy_security_config' do
+    subject(:config) { described_class.ip_privacy_security_config }
+
+    def stub_conf(trusted_proxy)
+      allow(OT).to receive(:conf).and_return(
+        'site' => { 'network' => { 'trusted_proxy' => trusted_proxy } }
+      )
+    end
+
+    context 'when trusted_proxy is absent' do
+      before { allow(OT).to receive(:conf).and_return({}) }
+
+      it 'returns nil so the middleware stays in direct-connection mode' do
+        expect(config).to be_nil
+      end
+    end
+
+    context 'when trusted_proxy is disabled' do
+      before { stub_conf('enabled' => false) }
+
+      it 'returns nil' do
+        expect(config).to be_nil
+      end
+    end
+
+    context 'when trusted_proxy is enabled' do
+      before { stub_conf('enabled' => true) }
+
+      it 'returns an Otto security config' do
+        expect(config).to be_a(Otto::Security::Config)
+      end
+
+      it 'trusts RFC1918 proxy hops' do
+        aggregate_failures do
+          expect(config.trusted_proxy?('10.244.10.0')).to be(true)
+          expect(config.trusted_proxy?('192.168.1.1')).to be(true)
+          expect(config.trusted_proxy?('172.16.0.1')).to be(true)
+          expect(config.trusted_proxy?('172.31.255.255')).to be(true)
+          expect(config.trusted_proxy?('127.0.0.1')).to be(true)
+        end
+      end
+
+      it 'does not trust public client addresses' do
+        aggregate_failures do
+          expect(config.trusted_proxy?('203.0.113.42')).to be(false)
+          expect(config.trusted_proxy?('198.51.100.7')).to be(false)
+          # 172.32 is outside the RFC1918 172.16/12 block
+          expect(config.trusted_proxy?('172.32.0.1')).to be(false)
+        end
+      end
+    end
+
+  end
+end

--- a/spec/unit/onetime/application/middleware_stack_spec.rb
+++ b/spec/unit/onetime/application/middleware_stack_spec.rb
@@ -44,6 +44,18 @@ RSpec.describe Onetime::Application::MiddlewareStack do
           expect(config.trusted_proxy?('172.16.0.1')).to be(true)
           expect(config.trusted_proxy?('172.31.255.255')).to be(true)
           expect(config.trusted_proxy?('127.0.0.1')).to be(true)
+          # IPv4 link-local (169.254/16)
+          expect(config.trusted_proxy?('169.254.1.1')).to be(true)
+        end
+      end
+
+      it 'trusts IPv6 loopback, ULA, and link-local proxy hops' do
+        aggregate_failures do
+          expect(config.trusted_proxy?('::1')).to be(true)            # loopback
+          expect(config.trusted_proxy?('fc00::1')).to be(true)        # ULA
+          expect(config.trusted_proxy?('fd12:3456::1')).to be(true)   # ULA
+          expect(config.trusted_proxy?('fe80::1')).to be(true)        # link-local
+          expect(config.trusted_proxy?('feb0::1')).to be(true)        # link-local /10 upper bound
         end
       end
 
@@ -53,9 +65,35 @@ RSpec.describe Onetime::Application::MiddlewareStack do
           expect(config.trusted_proxy?('198.51.100.7')).to be(false)
           # 172.32 is outside the RFC1918 172.16/12 block
           expect(config.trusted_proxy?('172.32.0.1')).to be(false)
+          # Global-unicast IPv6 (2000::/3) must not match the fc/fd/fe branches
+          expect(config.trusted_proxy?('2001:db8::1')).to be(false)
+          # fec0::/10 (deprecated site-local) is outside fe80::/10 link-local
+          expect(config.trusted_proxy?('fec0::1')).to be(false)
         end
       end
     end
 
+    describe '.trusted_proxy_enabled?' do
+      def stub_conf(trusted_proxy)
+        allow(OT).to receive(:conf).and_return(
+          'site' => { 'network' => { 'trusted_proxy' => trusted_proxy } }
+        )
+      end
+
+      it 'is false when the trusted_proxy section is absent' do
+        allow(OT).to receive(:conf).and_return({})
+        expect(described_class.trusted_proxy_enabled?).to be(false)
+      end
+
+      it 'is false when explicitly disabled' do
+        stub_conf('enabled' => false)
+        expect(described_class.trusted_proxy_enabled?).to be(false)
+      end
+
+      it 'is true only when explicitly enabled' do
+        stub_conf('enabled' => true)
+        expect(described_class.trusted_proxy_enabled?).to be(true)
+      end
+    end
   end
 end

--- a/spec/unit/onetime/application/otto_hooks_spec.rb
+++ b/spec/unit/onetime/application/otto_hooks_spec.rb
@@ -1,0 +1,45 @@
+# spec/unit/onetime/application/otto_hooks_spec.rb
+#
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Onetime::Application::OttoHooks do
+  # Minimal host: OttoHooks is a mixin, so include it in a bare class.
+  let(:host_class) { Class.new { include Onetime::Application::OttoHooks } }
+  let(:host)       { host_class.new }
+
+  # Stand-in for the Otto router. We only assert OUR wiring (the gate + the
+  # ranges handed over); Otto's own client_ipaddress / secure? resolution from
+  # that trust list is covered by the gem.
+  let(:router) { instance_double(Otto) }
+
+  describe '#configure_otto_trusted_proxies' do
+    context 'when trusted_proxy is enabled' do
+      before do
+        allow(Onetime::Application::MiddlewareStack)
+          .to receive(:trusted_proxy_enabled?).and_return(true)
+      end
+
+      it 'hands the router the shared private-proxy ranges' do
+        expect(router).to receive(:add_trusted_proxy)
+          .with(Onetime::Application::MiddlewareStack::PRIVATE_PROXY_RANGES)
+
+        host.configure_otto_trusted_proxies(router)
+      end
+    end
+
+    context 'when trusted_proxy is disabled' do
+      before do
+        allow(Onetime::Application::MiddlewareStack)
+          .to receive(:trusted_proxy_enabled?).and_return(false)
+      end
+
+      it 'leaves the router trust list empty (direct-connection mode)' do
+        expect(router).not_to receive(:add_trusted_proxy)
+
+        host.configure_otto_trusted_proxies(router)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #3427.

The IP privacy middleware is mounted first in the common stack with no security config:

```ruby
builder.use Otto::Security::Middleware::IPPrivacyMiddleware
```

With `@security_config` nil, Otto's `resolve_client_ip` returns `REMOTE_ADDR` without reading `X-Forwarded-For`, masks it, and overwrites the forwarded headers with the masked value. Behind a proxy the real client IP is gone before any later middleware or auth strategy calls `request.ip`, so the `site.network.trusted_proxy` config from #3116 (which only configures `Rack::Request#ip`) runs too late to help. Details in #3427.

## Change

`MiddlewareStack` builds an `Otto::Security::Config` and passes it to the middleware. When `site.network.trusted_proxy.enabled` is true it trusts the private proxy ranges (RFC1918, loopback, link-local, IPv6 ULA/loopback), so the middleware resolves the client from the forwarded headers and masks that instead. When trusted proxy is off, the helper returns nil and behaviour is unchanged, so direct-connection deployments are unaffected.

## Limits

- Only RFC1918/loopback hops are trusted. Public proxy ranges (a CDN with public egress IPs) would need CIDR matching, which Otto's prefix-based trusted-proxy list doesn't do, so `site.network.trusted_proxy.cidrs` still only affects `Rack::Request#ip`. Noted in a code comment.
- The stored/displayed IP is still masked to a /24 by the existing privacy settings. This just makes it the correct /24 rather than the proxy's.

## Tests

Added `spec/unit/onetime/application/middleware_stack_spec.rb` for the absent, disabled, and enabled cases (documentation IPs only). Couldn't run the suite locally (no bundler in my env), so please let CI confirm.
