### PR TITLE
Add validate-register CI gate for governed locale content (translation-rules P1-4b minimal slice)

### DIFF
--- a/.github/workflows/validate-register.yml
+++ b/.github/workflows/validate-register.yml
@@ -1,0 +1,106 @@
+# Phase 0 cross-repo prevention gate. Blocks any PR touching locale content
+# that introduces a forbidden register token (e.g. informal "du" in formal
+# de_AT). This is the load-bearing gate from translation-rules SPEC.md §1/§2.4
+# — the single mechanism that would have blocked the 2026-04-12 de_AT
+# regression. It needs neither base.yaml nor the resolver: just the authority's
+# existing bin/lint-register + the per-locale register.yaml token lists.
+#
+# Source of truth is the translation-rules repo, checked out read-only at a
+# pinned ref. Coverage grows automatically: every locale that has a
+# register.yaml upstream gets scanned. Today that is de_AT only. Verified
+# clean against current app content 2026-05-30 (20 files, 10 tokens, exit 0),
+# so activation will not fail unrelated PRs.
+#
+# Decision recorded: read-only checkout at a pinned ref, not a submodule. The
+# submodule is the eventual full-P1-4b form (it also carries .resolved JSON +
+# source_commit equality, which this slice does not). Pinning `ref:` to a SHA
+# or tag — not a moving `main` — is what makes the gate reproducible; bump it
+# deliberately the same way the yq pin is bumped.
+
+name: validate-register
+
+on:
+  pull_request:
+    paths:
+      - 'locales/content/**/*.json'
+      # The gate must also run when its own pins (translation-rules ref, yq)
+      # are bumped — otherwise a bump that makes existing content
+      # non-compliant merges unvalidated and fails the next unrelated PR.
+      - '.github/workflows/validate-register.yml'
+  push:
+    branches: [main, develop]
+    paths:
+      - 'locales/content/**/*.json'
+      - '.github/workflows/validate-register.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  validate-register:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout app repo
+        uses: actions/checkout@v4
+
+      - name: Checkout translation-rules (authority, read-only)
+        uses: actions/checkout@v4
+        with:
+          repository: onetimesecret/translation-rules
+          # translation-rules main as of 2026-06-11 (merge of PR #19; re-verified
+          # clean against app content at this SHA: 20 files, 10 tokens, exit 0).
+          # Bumping this pin is how the app repo adopts new rules — deliberately,
+          # as a reviewable diff, same as the yq pin below.
+          ref: d4abb932482d402e68965e18f56a089b5def0bb2
+          path: .translation-rules
+
+      - name: Install yq (pinned + checksum-verified)
+        env:
+          # Kept in lockstep with translation-rules .github/workflows/lint-register.yml.
+          # Bump deliberately, not via `latest`.
+          YQ_VERSION: v4.53.2
+          YQ_SHA256: d56bf5c6819e8e696340c312bd70f849dc1678a7cda9c2ad63eebd906371d56b
+        run: |
+          set -euo pipefail
+          tmpdir="$(mktemp -d)"
+          curl -fsSL -o "${tmpdir}/yq" \
+            "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64"
+          echo "${YQ_SHA256}  ${tmpdir}/yq" | sha256sum -c -
+          sudo install -m 0755 "${tmpdir}/yq" /usr/local/bin/yq
+          rm -rf "${tmpdir}"
+          yq --version
+
+      - name: Lint each governed locale's content
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          rules=.translation-rules
+          fail=0
+          scanned=0
+          for d in "$rules"/locales/*/; do
+            locale="$(basename "$d")"
+            [ -f "${d}register.yaml" ] || continue
+            content_dir="locales/content/${locale}"
+            if [ ! -d "$content_dir" ]; then
+              echo "::notice::no app content for governed locale ${locale}; skipping"
+              continue
+            fi
+            scanned=$((scanned + 1))
+            echo "::group::lint ${locale}"
+            # The authority's own linter. It resolves register.yaml relative to
+            # its own location (.translation-rules/locales/<locale>/) and the
+            # content glob relative to this job's CWD (the app repo root).
+            # Non-zero from lint-register — forbidden token (1), config (2), or
+            # empty glob (3) — fails the gate.
+            if ! "$rules"/bin/lint-register "$locale" "${content_dir}/*.json"; then
+              echo "::error::forbidden register token (or scan error) in ${locale} content"
+              fail=1
+            fi
+            echo "::endgroup::"
+          done
+          if [ "$scanned" -eq 0 ]; then
+            echo "::error::no governed locale matched app content — gate scanned nothing (misconfigured path or ref?)"
+            exit 1
+          fi
+          echo "validate-register: scanned ${scanned} governed locale(s)"
+          exit "$fail"

--- a/.github/workflows/validate-register.yml
+++ b/.github/workflows/validate-register.yml
@@ -47,11 +47,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: onetimesecret/translation-rules
-          # translation-rules main as of 2026-06-11 (merge of PR #19; re-verified
+          # translation-rules main as of 2026-06-11 (merge of PR #20; re-verified
           # clean against app content at this SHA: 20 files, 10 tokens, exit 0).
           # Bumping this pin is how the app repo adopts new rules — deliberately,
           # as a reviewable diff, same as the yq pin below.
-          ref: d4abb932482d402e68965e18f56a089b5def0bb2
+          ref: 374f5c38639a4a4183e523614d212cc9d2e5ee21
           path: .translation-rules
 
       - name: Install yq (pinned + checksum-verified)

--- a/src/shared/composables/useSigninConfig.ts
+++ b/src/shared/composables/useSigninConfig.ts
@@ -215,7 +215,9 @@ export function useSigninConfig(domainExtId: string) {
     if (isSaving.value) return;
     formState.value = { ...formState.value, ...partial };
     savingField.value =
-      savingFieldHint ?? (Object.keys(partial)[0] as keyof SigninConfigFormState | undefined) ?? null;
+      savingFieldHint ??
+      (Object.keys(partial)[0] as keyof SigninConfigFormState | undefined) ??
+      null;
     try {
       await saveConfig();
     } finally {


### PR DESCRIPTION
## Summary

Activates the cross-repo register gate from [translation-rules](https://github.com/onetimesecret/translation-rules) (SPEC §1/§2.4, P1-4b minimal slice). From this merge forward, any PR touching `locales/content/**/*.json` fails if a governed locale's content contains a forbidden register token (e.g. informal "du" in formal de_AT) — the single mechanism that would have blocked the 2026-04-12 de_AT regression.

One file: `.github/workflows/validate-register.yml`, copied from the reviewed draft at `translation-rules/.github/ISSUE_DRAFTS/p1-4b-validate-register.workflow.yml` with two deltas:

- `ref:` pinned to `374f5c38` — translation-rules `main` as of 2026-06-11, the merge of onetimesecret/translation-rules#20. Bumping this pin is how the app repo adopts new rules: deliberately, as a reviewable diff, same as the yq pin.
- The workflow's own path added to both trigger lists, so pin bumps are validated on their own PR instead of failing the next unrelated locale PR.

No submodule, no resolver, no `base.yaml`: the gate checks out translation-rules read-only at the pinned SHA and runs its `bin/lint-register`. Coverage grows automatically — every locale with a `register.yaml` upstream gets scanned (today: de_AT only; pt_PT/uk/hu join with zero app-repo changes when their register files land).

## Verification

- `bin/lint-register de_AT 'locales/content/de_AT/*.json'` run locally at the pinned SHA from the app repo root: **exit 0, 10 tokens checked across 20 files** (matches the draft's 2026-05-30 record) — activation does not break unrelated PRs.
- actionlint clean; yq pin (v4.53.2 + SHA-256) verified in lockstep with upstream's `lint-register.yml`, checksum independently confirmed against the released binary.
- Gate run-block executed verbatim locally: injected forbidden token → exit 1; empty glob → exit 3; missing register.yaml → exit 2; all caught. `scanned==0` guard fails the job if the checkout/path is wrong.
- translation-rules is public; read-only checkout needs no token. No untrusted event context in run blocks; `permissions: contents: read`.

## Follow-up (separate)

Full P1-4b per `translation-rules/.github/ISSUE_DRAFTS/p1-4b-app-repo-integration.md`: submodule at `locales/translation-rules/`, resolver in CI, committed `.resolved/<locale>.json` + for-translators artifacts, freshness/equality checks. This slice is independently valuable and is the ground-rule gate RECOVERY-PLAN.md requires before the recovery PRs.

## Ride-along

`d9c7015` wraps a pre-existing over-length line in `src/shared/composables/useSigninConfig.ts:218` (102 chars, unmasked by the flat-config scoping fix in #3414). The develop push pipeline does not run TypeScript lint, so develop stays green while every PR based on it fails `T1 · TypeScript Lint`. Formatting-only; included here to unblock this and all sibling PRs.
