### PR TITLE
Add one-click SSO to disabled homepage and refactor SSO form submission*

### DIFF
--- a/.env.reference
+++ b/.env.reference
@@ -366,6 +366,17 @@ UI_HOMEPAGE_DEFAULT_MODE=
 # secret form itself is gated by auth. Leave blank to hide the link.
 HOMEPAGE_PUBLIC_LINKS_RECIPIENT_INTRO=
 
+# Which landing page the homepage shows when secret creation is gated by auth
+# (auth.required, or UI_HOMEPAGE_MODE=external). Deployment-wide default;
+# per-domain config and the ?variant= URL override still take precedence.
+# One of:
+#   closed  - quiet "members only" two-tagline page, no sign-in button (default)
+#   minimal - small mark + headline + sign-in CTA (one-click SSO when a single
+#             provider is the only login method, otherwise links to /signin)
+#   v1      - full hero: mark, eyebrow, headline, CTA, trust strip, optional promo
+# Leave blank to use the default (closed).
+DEFAULT_DISABLED_HOMEPAGE_VARIANT=
+
 # Show help modals on secret reveal/receipt pages. Set to 'false' to hide.
 HELP_ENABLED=true
 

--- a/apps/api/domains/logic/homepage_config/get_homepage_config.rb
+++ b/apps/api/domains/logic/homepage_config/get_homepage_config.rb
@@ -45,6 +45,7 @@ module DomainsAPI
                         enabled: @homepage_config.enabled?,
                         signup_enabled: @homepage_config.signup_enabled?,
                         signin_enabled: @homepage_config.signin_enabled?,
+                        disabled_homepage_variant: @homepage_config.disabled_homepage_variant_value,
                         created_at: @homepage_config.created.to_i,
                         updated_at: @homepage_config.updated.to_i,
                       }

--- a/apps/api/domains/logic/homepage_config/put_homepage_config.rb
+++ b/apps/api/domains/logic/homepage_config/put_homepage_config.rb
@@ -55,7 +55,9 @@ module DomainsAPI
 
           OT.ld "[PutHomepageConfig] saved domain=#{@custom_domain.identifier} " \
                 "enabled=#{@homepage_config.enabled?} signup=#{@homepage_config.signup_enabled?} " \
-                "signin=#{@homepage_config.signin_enabled?} updated=#{@homepage_config.updated}"
+                "signin=#{@homepage_config.signin_enabled?} " \
+                "variant=#{@homepage_config.disabled_homepage_variant_value.inspect} " \
+                "updated=#{@homepage_config.updated}"
 
           success_data
         end

--- a/apps/api/domains/logic/homepage_config/put_homepage_config.rb
+++ b/apps/api/domains/logic/homepage_config/put_homepage_config.rb
@@ -27,6 +27,10 @@ module DomainsAPI
           @enabled         = parse_boolean(params['enabled'])
           @signup_enabled  = parse_boolean(params['signup_enabled']) if params.key?('signup_enabled')
           @signin_enabled  = parse_boolean(params['signin_enabled']) if params.key?('signin_enabled')
+          # Only touch the variant when the client sends the key; an explicit
+          # blank/unknown value clears the override (falls back to default).
+          @set_variant     = params.key?('disabled_homepage_variant')
+          @disabled_homepage_variant = params['disabled_homepage_variant'] if @set_variant
         end
 
         def raise_concerns
@@ -46,6 +50,7 @@ module DomainsAPI
             enabled: @enabled,
             signup_enabled: @signup_enabled,
             signin_enabled: @signin_enabled,
+            **(@set_variant ? { disabled_homepage_variant: @disabled_homepage_variant } : {}),
           )
 
           OT.ld "[PutHomepageConfig] saved domain=#{@custom_domain.identifier} " \
@@ -63,6 +68,7 @@ module DomainsAPI
               enabled: @homepage_config.enabled?,
               signup_enabled: @homepage_config.signup_enabled?,
               signin_enabled: @homepage_config.signin_enabled?,
+              disabled_homepage_variant: @homepage_config.disabled_homepage_variant_value,
               created_at: @homepage_config.created.to_i,
               updated_at: @homepage_config.updated.to_i,
             },

--- a/apps/api/domains/logic/homepage_config/put_homepage_config.rb
+++ b/apps/api/domains/logic/homepage_config/put_homepage_config.rb
@@ -14,23 +14,24 @@ module DomainsAPI
       #   domain. Sets the enabled state. Requires the requesting user to be an
       #   organization owner with homepage_secrets entitlement.
       #
-      # Request body:
+      # Request body (optional fields use merge/PATCH-style semantics — an
+      # omitted or null value leaves the stored value unchanged):
       # - enabled: Boolean (required)
       # - signup_enabled: Boolean (optional) — toggles Sign Up link on the homepage
       # - signin_enabled: Boolean (optional) — toggles Sign In link on the homepage
+      # - disabled_homepage_variant: String (optional) — gated-homepage variant
+      #   (closed | minimal | v1). null/omitted leaves it unchanged; "" resets it
+      #   to the deployment default; a recognised id sets it.
       #
       class PutHomepageConfig < Base
         attr_reader :homepage_config
 
         def process_params
-          @domain_id       = sanitize_identifier(params['extid'])
-          @enabled         = parse_boolean(params['enabled'])
-          @signup_enabled  = parse_boolean(params['signup_enabled']) if params.key?('signup_enabled')
-          @signin_enabled  = parse_boolean(params['signin_enabled']) if params.key?('signin_enabled')
-          # Only touch the variant when the client sends the key; an explicit
-          # blank/unknown value clears the override (falls back to default).
-          @set_variant     = params.key?('disabled_homepage_variant')
-          @disabled_homepage_variant = params['disabled_homepage_variant'] if @set_variant
+          @domain_id                 = sanitize_identifier(params['extid'])
+          @enabled                   = parse_boolean(params['enabled'])
+          @signup_enabled            = parse_boolean(params['signup_enabled']) if params.key?('signup_enabled')
+          @signin_enabled            = parse_boolean(params['signin_enabled']) if params.key?('signin_enabled')
+          @disabled_homepage_variant = params['disabled_homepage_variant']
         end
 
         def raise_concerns
@@ -50,7 +51,7 @@ module DomainsAPI
             enabled: @enabled,
             signup_enabled: @signup_enabled,
             signin_enabled: @signin_enabled,
-            **(@set_variant ? { disabled_homepage_variant: @disabled_homepage_variant } : {}),
+            disabled_homepage_variant: @disabled_homepage_variant,
           )
 
           OT.ld "[PutHomepageConfig] saved domain=#{@custom_domain.identifier} " \

--- a/apps/web/core/views/serializers/domain_serializer.rb
+++ b/apps/web/core/views/serializers/domain_serializer.rb
@@ -108,6 +108,7 @@ module Core
             'enabled' => homepage_config.enabled?,
             'signup_enabled' => homepage_config.signup_enabled?,
             'signin_enabled' => homepage_config.signin_enabled?,
+            'disabled_homepage_variant' => homepage_config.disabled_homepage_variant_value,
             'created_at' => homepage_config.created&.to_i,
             'updated_at' => homepage_config.updated&.to_i,
           }

--- a/etc/defaults/config.defaults.yaml
+++ b/etc/defaults/config.defaults.yaml
@@ -58,6 +58,12 @@ site:
         mode: <%= ENV['UI_HOMEPAGE_MODE'] || nil %>
         matching_cidrs: <%= ENV['UI_HOMEPAGE_MATCHING_CIDRS']&.split(',')&.map(&:strip) || [] %>
         mode_header: <%= ENV['UI_HOMEPAGE_MODE_HEADER'] || 'O-Homepage-Mode' %>
+        # Deployment-wide default landing page when the homepage secret form
+        # is gated by auth (auth.required or mode=external). One of: closed
+        # (quiet two-tagline, no CTA), minimal, or v1. Per-domain config and
+        # the ?variant= URL override take precedence; blank uses the frontend
+        # default (closed).
+        disabled_variant: <%= ENV['DEFAULT_DISABLED_HOMEPAGE_VARIANT'] || nil %>
         # Links rendered when a public visitor lands on the homepage but
         # the secret form is gated by auth (e.g. mode=external). Recipients
         # arriving via a shared link use these to learn about the service.

--- a/lib/onetime/models/custom_domain/homepage_config.rb
+++ b/lib/onetime/models/custom_domain/homepage_config.rb
@@ -29,11 +29,6 @@ module Onetime
       # domain falls back to the deployment-wide / frontend default.
       VALID_DISABLED_HOMEPAGE_VARIANTS = %w[v1 minimal closed].freeze
 
-      # Sentinel for upsert: distinguishes "caller omitted the variant" (leave
-      # the stored value as-is) from an explicit nil (clear the per-domain
-      # override so the domain falls back to the default).
-      UNCHANGED_VARIANT = Object.new.freeze
-
       prefix :custom_domain__homepage_config
 
       # domain_id is the CustomDomain's identifier (objid), used as our key.
@@ -190,28 +185,31 @@ module Onetime
         #
         # @param domain_id [String] CustomDomain identifier
         # @param enabled [Boolean, String] Whether to enable homepage secrets
+        # @param disabled_homepage_variant [String, nil] Merge semantics, matching
+        #   signup_enabled/signin_enabled: nil leaves the stored value unchanged;
+        #   "" (or any unrecognised value) clears the override back to the default;
+        #   a recognised id ('v1' | 'minimal' | 'closed') sets it.
         # @return [CustomDomain::HomepageConfig] The config (created or updated)
-        def upsert(domain_id:, enabled:, signup_enabled: nil, signin_enabled: nil, disabled_homepage_variant: UNCHANGED_VARIANT)
+        def upsert(domain_id:, enabled:, signup_enabled: nil, signin_enabled: nil, disabled_homepage_variant: nil)
           raise Onetime::Problem, 'domain_id is required' if domain_id.to_s.empty?
 
           config = find_by_domain_id(domain_id)
           now    = Familia.now.to_i
-          set_variant = !disabled_homepage_variant.equal?(UNCHANGED_VARIANT)
 
           if config
-            config.created      ||= now  # repair missing created from legacy records
-            config.enabled        = enabled.to_s
-            config.signup_enabled = signup_enabled unless signup_enabled.nil?
-            config.signin_enabled = signin_enabled unless signin_enabled.nil?
-            config.disabled_homepage_variant = coerce_disabled_homepage_variant(disabled_homepage_variant) if set_variant
-            config.updated        = now
+            config.created                 ||= now  # repair missing created from legacy records
+            config.enabled                   = enabled.to_s
+            config.signup_enabled            = signup_enabled unless signup_enabled.nil?
+            config.signin_enabled            = signin_enabled unless signin_enabled.nil?
+            config.disabled_homepage_variant = coerce_disabled_homepage_variant(disabled_homepage_variant) unless disabled_homepage_variant.nil?
+            config.updated                   = now
           else
             config = new(
               domain_id: domain_id,
               enabled: enabled.to_s,
               signup_enabled: signup_enabled.nil? || signup_enabled,
               signin_enabled: signin_enabled.nil? || signin_enabled,
-              disabled_homepage_variant: set_variant ? coerce_disabled_homepage_variant(disabled_homepage_variant) : nil,
+              disabled_homepage_variant: coerce_disabled_homepage_variant(disabled_homepage_variant),
               created: now,
               updated: now,
             )

--- a/lib/onetime/models/custom_domain/homepage_config.rb
+++ b/lib/onetime/models/custom_domain/homepage_config.rb
@@ -24,6 +24,16 @@ module Onetime
 
       SCHEMA = 'models/domain-homepage-config'
 
+      # Recognised disabled-homepage variants (mirrors the frontend
+      # disabledHomepageVariantSchema). Anything else is treated as nil so the
+      # domain falls back to the deployment-wide / frontend default.
+      VALID_DISABLED_HOMEPAGE_VARIANTS = %w[v1 minimal closed].freeze
+
+      # Sentinel for upsert: distinguishes "caller omitted the variant" (leave
+      # the stored value as-is) from an explicit nil (clear the per-domain
+      # override so the domain falls back to the default).
+      UNCHANGED_VARIANT = Object.new.freeze
+
       prefix :custom_domain__homepage_config
 
       # domain_id is the CustomDomain's identifier (objid), used as our key.
@@ -41,6 +51,12 @@ module Onetime
       # the link regardless of this domain-level value.
       field :signup_enabled
       field :signin_enabled
+
+      # Which disabled-homepage variant this domain renders when the homepage
+      # secret form is gated by auth. nil (unset) = fall back to the
+      # deployment-wide default (site.interface.ui.homepage.disabled_variant)
+      # and ultimately the frontend DEFAULT_DISABLED_HOMEPAGE_VARIANT constant.
+      field :disabled_homepage_variant
 
       # Timestamps (Unix epoch integers)
       field :created
@@ -69,6 +85,13 @@ module Onetime
       # Whether the Sign In link should render on this domain's homepage.
       def signin_enabled?
         signin_enabled != false
+      end
+
+      # Recognised disabled-homepage variant for this domain, or nil to fall
+      # back to the deployment-wide / frontend default. Guards against blank or
+      # stale values in Redis (records pre-dating this field have none).
+      def disabled_homepage_variant_value
+        self.class.coerce_disabled_homepage_variant(disabled_homepage_variant)
       end
 
       # Enable homepage secrets for this domain.
@@ -112,6 +135,10 @@ module Onetime
       def validation_errors
         errors = []
         errors << 'domain_id is required' if domain_id.to_s.empty?
+        unless disabled_homepage_variant.to_s.empty? ||
+               VALID_DISABLED_HOMEPAGE_VARIANTS.include?(disabled_homepage_variant.to_s)
+          errors << "invalid disabled_homepage_variant: #{disabled_homepage_variant}"
+        end
         errors
       end
 
@@ -123,6 +150,14 @@ module Onetime
       end
 
       class << self
+        # Normalise a disabled-homepage variant to a recognised id, or nil
+        # (= use the deployment-wide / frontend default). Blank and unknown
+        # values both collapse to nil.
+        def coerce_disabled_homepage_variant(value)
+          v = value.to_s.strip
+          VALID_DISABLED_HOMEPAGE_VARIANTS.include?(v) ? v : nil
+        end
+
         # Find homepage config by domain ID.
         #
         # @param domain_id [String] CustomDomain identifier (objid)
@@ -156,17 +191,19 @@ module Onetime
         # @param domain_id [String] CustomDomain identifier
         # @param enabled [Boolean, String] Whether to enable homepage secrets
         # @return [CustomDomain::HomepageConfig] The config (created or updated)
-        def upsert(domain_id:, enabled:, signup_enabled: nil, signin_enabled: nil)
+        def upsert(domain_id:, enabled:, signup_enabled: nil, signin_enabled: nil, disabled_homepage_variant: UNCHANGED_VARIANT)
           raise Onetime::Problem, 'domain_id is required' if domain_id.to_s.empty?
 
           config = find_by_domain_id(domain_id)
           now    = Familia.now.to_i
+          set_variant = !disabled_homepage_variant.equal?(UNCHANGED_VARIANT)
 
           if config
             config.created      ||= now  # repair missing created from legacy records
             config.enabled        = enabled.to_s
             config.signup_enabled = signup_enabled unless signup_enabled.nil?
             config.signin_enabled = signin_enabled unless signin_enabled.nil?
+            config.disabled_homepage_variant = coerce_disabled_homepage_variant(disabled_homepage_variant) if set_variant
             config.updated        = now
           else
             config = new(
@@ -174,6 +211,7 @@ module Onetime
               enabled: enabled.to_s,
               signup_enabled: signup_enabled.nil? || signup_enabled,
               signin_enabled: signin_enabled.nil? || signin_enabled,
+              disabled_homepage_variant: set_variant ? coerce_disabled_homepage_variant(disabled_homepage_variant) : nil,
               created: now,
               updated: now,
             )
@@ -241,6 +279,9 @@ module Onetime
           config.enabled        = attrs[:enabled].to_s if attrs.key?(:enabled)
           config.signup_enabled = attrs[:signup_enabled] if attrs.key?(:signup_enabled)
           config.signin_enabled = attrs[:signin_enabled] if attrs.key?(:signin_enabled)
+          if attrs.key?(:disabled_homepage_variant)
+            config.disabled_homepage_variant = coerce_disabled_homepage_variant(attrs[:disabled_homepage_variant])
+          end
 
           now            = Familia.now.to_i
           config.created = now

--- a/src/apps/secret/views/DisabledHomepage.vue
+++ b/src/apps/secret/views/DisabledHomepage.vue
@@ -3,7 +3,7 @@
 <script setup lang="ts">
   import type { DisabledHomepageVariant } from '@/schemas/contracts/disabled-homepage';
   import { computed, type Component } from 'vue';
-  import DisabledLegacy from './disabled/variants/DisabledLegacy.vue';
+  import DisabledClosed from './disabled/variants/DisabledClosed.vue';
   import DisabledMinimal from './disabled/variants/DisabledMinimal.vue';
   import DisabledV1 from './disabled/variants/DisabledV1.vue';
   import { useDisabledConfig } from './disabled/useDisabledConfig';
@@ -36,7 +36,7 @@
   const VARIANTS: Record<DisabledHomepageVariant, Component> = {
     v1: DisabledV1,
     minimal: DisabledMinimal,
-    legacy: DisabledLegacy,
+    closed: DisabledClosed,
   };
 
   const { variant, props } = useDisabledConfig();

--- a/src/apps/secret/views/DisabledHomepage.vue
+++ b/src/apps/secret/views/DisabledHomepage.vue
@@ -51,7 +51,14 @@
     of each variant). The disabled-homepage routes hide the layout
     masthead so this area is genuinely free.
   -->
-  <component
-    :is="ActiveVariant"
-    v-bind="props" />
+  <!--
+    Super-light-grey surface (light mode only) so a variant's white sign-in
+    CTA reads as a raised control. Scoped to the gated homepage — not app-wide;
+    dark mode is left untouched.
+  -->
+  <div class="flex w-full flex-1 flex-col bg-gray-50 dark:bg-transparent">
+    <component
+      :is="ActiveVariant"
+      v-bind="props" />
+  </div>
 </template>

--- a/src/apps/secret/views/disabled/README.md
+++ b/src/apps/secret/views/disabled/README.md
@@ -11,9 +11,9 @@ src/apps/secret/views/
 └── disabled/
     ├── useDisabledConfig.ts    derives { variant, props } from stores
     └── variants/
-        ├── DisabledV1.vue       default — full hero + trust strip + promo
-        ├── DisabledMinimal.vue  small mark + headline + ghost CTA
-        └── DisabledLegacy.vue   pre-refresh two-tagline (rollback target)
+        ├── DisabledV1.vue       full hero + trust strip + promo + SSO-aware CTA
+        ├── DisabledMinimal.vue  small mark + headline + SSO-aware ghost CTA
+        └── DisabledClosed.vue   pre-refresh two-tagline, no CTA (default)
 ```
 
 Dispatcher consumes `useDisabledConfig()`, picks a component from a
@@ -35,7 +35,7 @@ The optional affordance overrides stay on the site-level
 
 | location                                          | field                       | type                            | semantics                                                |
 | ------------------------------------------------- | --------------------------- | ------------------------------- | -------------------------------------------------------- |
-| `homepage_config`                                 | `disabled_homepage_variant` | `'v1' \| 'minimal' \| 'legacy' \| null` | which component this domain renders (`null` = default)   |
+| `homepage_config`                                 | `disabled_homepage_variant` | `'v1' \| 'minimal' \| 'closed' \| null` | which component this domain renders (`null` = default)   |
 | `bootstrap.disabled_homepage`                     | `show_promo`                | `boolean \| null`               | tri-state override (`null` = auto, `true/false` = force) |
 | `bootstrap.disabled_homepage`                     | `show_what_is_this`         | `boolean \| null`               | same                                                     |
 
@@ -59,9 +59,10 @@ per-domain operator config is the long-term path: PATCH the value, no
 frontend release. Until then:
 
 - **Frontend default**: change `DEFAULT_DISABLED_HOMEPAGE_VARIANT` in
-  `disabled-homepage.ts`. Requires a frontend release. This is the
-  source of truth for unconfigured domains and the canonical site.
-- **URL param**: `?variant=legacy` on any disabled-homepage URL.
+  `disabled-homepage.ts` (currently `closed`). Requires a frontend
+  release. This is the source of truth for unconfigured domains and the
+  canonical site.
+- **URL param**: `?variant=minimal` on any disabled-homepage URL.
 
 Override individual feature flags via the site-level bootstrap block —
 set `show_promo` / `show_what_is_this` to `true` / `false` / `null`
@@ -77,6 +78,23 @@ set `show_promo` / `show_what_is_this` to `true` / `false` / `null`
 
 Missing URLs suppress the matching affordance — an operator override
 can't resurrect a link to `https:///` or to `null`.
+
+## Sign-in CTA (one-click SSO)
+
+The `minimal` / `v1` variants render a sign-in CTA (the `closed` default
+has none). The CTA's target is derived in `useDisabledConfig`:
+
+- **One-click SSO** — when SSO is the only login method *and* exactly one
+  provider is configured, the CTA POSTs straight to `/auth/sso/:provider`
+  (via `shared/utils/sso.ts`), skipping `/signin`. In that configuration
+  `/signin` is itself just a single "Sign in with X" button, so the hop
+  adds nothing. "SSO only" mirrors `AuthMethodSelector`: global
+  `restrict_to === 'sso'`, or a custom domain with `enforce_sso_only`.
+- **Otherwise** — the CTA is a normal `<router-link to="/signin">`, so
+  multi-provider and mixed-method deployments keep the chooser.
+
+The composable exposes `ssoOneClick`, `ssoProviderName`, and `onSsoLogin`
+in the props bag; variants stay presentational and never read stores.
 
 ## Centred logo
 

--- a/src/apps/secret/views/disabled/useDisabledConfig.ts
+++ b/src/apps/secret/views/disabled/useDisabledConfig.ts
@@ -16,15 +16,19 @@ import {
   DEFAULT_DISABLED_HOMEPAGE_VARIANT,
   disabledHomepageVariantSchema,
 } from '@/schemas/contracts/disabled-homepage';
+import type { Features } from '@/schemas/contracts/bootstrap';
 import { useBootstrapStore } from '@/shared/stores/bootstrapStore';
+import { useCsrfStore } from '@/shared/stores/csrfStore';
 import { useProductIdentity } from '@/shared/stores/identityStore';
+import type { SsoProvider } from '@/utils/features';
+import { submitSsoLogin } from '@/shared/utils/sso';
 import { storeToRefs } from 'pinia';
 import { computed, type ComputedRef } from 'vue';
 
 /**
  * Read a one-off variant override from the current URL.
  *
- * Operator/dogfood escape hatch: `?variant=legacy` (or `minimal` / `v1`)
+ * Operator/dogfood escape hatch: `?variant=minimal` (or `v1` / `closed`)
  * wins over bootstrap config. Useful for previewing a variant before
  * flipping the deployment default, and for sanity-checking dispatch
  * when bootstrap is suspected of carrying a stale value.
@@ -74,6 +78,16 @@ export interface DisabledHomepageProps {
   showPromo: boolean;
   /** External href for the promo's "Learn how" link — null when unresolvable. */
   promoHref: string | null;
+  /**
+   * Whether the sign-in CTA should initiate SSO directly instead of routing
+   * to /signin. True only when SSO is the sole login method and exactly one
+   * provider is configured, so the extra /signin hop adds nothing.
+   */
+  ssoOneClick: boolean;
+  /** Display name of the single SSO provider, for the one-click CTA label. */
+  ssoProviderName: string | null;
+  /** Initiates one-click SSO login (POST to /auth/sso/:provider). */
+  onSsoLogin: () => void;
 }
 
 interface DisabledHomepageBindings {
@@ -93,14 +107,43 @@ function applyOverride(override: boolean | null | undefined, auto: boolean): boo
   return override === null || override === undefined ? auto : override;
 }
 
+/**
+ * The single SSO provider to one-click into from the disabled-homepage CTA, or
+ * null when the CTA should fall back to the standard /signin link.
+ *
+ * Returns a provider only when SSO is the sole login method — mirroring
+ * AuthMethodSelector: global `restrict_to === 'sso'`, or a custom domain with
+ * `enforce_sso_only` — *and* exactly one provider is configured. With multiple
+ * providers, /signin still has to present a chooser, so the hop earns its keep
+ * and we don't short-circuit it.
+ */
+function resolveSsoOneClickProvider(
+  features: Features | undefined,
+  isCustom: boolean
+): SsoProvider | null {
+  const sso = features?.sso;
+  const providers =
+    sso && typeof sso !== 'boolean' && sso.enabled && Array.isArray(sso.providers)
+      ? sso.providers
+      : [];
+  if (providers.length !== 1) return null;
+
+  const restrictedToSso = features?.restrict_to === 'sso';
+  const enforcedForDomain =
+    typeof sso === 'object' && sso !== null ? sso.enforce_sso_only === true : false;
+  return restrictedToSso || (isCustom && enforcedForDomain) ? providers[0] : null;
+}
+
 export function useDisabledConfig(): DisabledHomepageBindings {
   const identityStore = useProductIdentity();
   const { isCustom, primaryColor, logoUri, displayName, displayDomain, brand, siteHost } =
     storeToRefs(identityStore);
 
   const bootstrapStore = useBootstrapStore();
-  const { authentication, billing_enabled, disabled_homepage, homepage_config, ui } =
+  const { authentication, billing_enabled, disabled_homepage, features, homepage_config, ui } =
     storeToRefs(bootstrapStore);
+
+  const csrfStore = useCsrfStore();
 
   // "Branded" means a custom domain has actually been configured with a brand
   // description — distinct from isCustom, which can be true even when no
@@ -154,6 +197,19 @@ export function useDisabledConfig(): DisabledHomepageBindings {
 
   const showSignin = computed(() => !!authentication.value?.signin);
 
+  // One-click SSO: when SSO is the only sign-in method and a single provider
+  // is configured, the CTA POSTs straight to the IdP instead of routing to
+  // /signin (itself just a lone "Sign in with <provider>" button in that
+  // configuration). See resolveSsoOneClickProvider for the gating.
+  const ssoProvider = computed(() => resolveSsoOneClickProvider(features.value, isCustom.value));
+  const ssoOneClick = computed(() => showSignin.value && ssoProvider.value !== null);
+
+  const onSsoLogin = () => {
+    const provider = ssoProvider.value;
+    if (!provider) return;
+    submitSsoLogin({ routeName: provider.route_name, shrimp: csrfStore.shrimp });
+  };
+
   // Variant resolution: URL override → per-domain homepage_config →
   // frontend default. URL is read once at composable-call time (page
   // loads don't preserve query params); the homepage_config fallback
@@ -184,6 +240,9 @@ export function useDisabledConfig(): DisabledHomepageBindings {
     get whatIsThisHref() { return whatIsThisHref.value; },
     get showPromo() { return showPromo.value; },
     get promoHref() { return promoHref.value; },
+    get ssoOneClick() { return ssoOneClick.value; },
+    get ssoProviderName() { return ssoProvider.value?.display_name ?? null; },
+    onSsoLogin,
   } satisfies DisabledHomepageProps;
 
   return { variant, props };

--- a/src/apps/secret/views/disabled/useDisabledConfig.ts
+++ b/src/apps/secret/views/disabled/useDisabledConfig.ts
@@ -210,18 +210,22 @@ export function useDisabledConfig(): DisabledHomepageBindings {
     submitSsoLogin({ routeName: provider.route_name, shrimp: csrfStore.shrimp });
   };
 
-  // Variant resolution: URL override → per-domain homepage_config →
-  // frontend default. URL is read once at composable-call time (page
-  // loads don't preserve query params); the homepage_config fallback
-  // stays reactive so a $patch on the domain config still flips the
-  // variant. When neither resolves, fall through to the frontend
-  // constant — homepage_config is null on the canonical site and on
-  // any custom domain that hasn't opted into a non-default variant.
+  // Variant resolution (highest precedence first):
+  //   1. ?variant= URL override (dogfood/preview)
+  //   2. per-domain homepage_config.disabled_homepage_variant
+  //   3. deployment-wide ui.homepage.disabled_variant
+  //      (DEFAULT_DISABLED_HOMEPAGE_VARIANT env var)
+  //   4. frontend DEFAULT_DISABLED_HOMEPAGE_VARIANT constant
+  // URL is read once at composable-call time (page loads don't preserve query
+  // params); the store-backed fallbacks stay reactive so a $patch on the
+  // domain or site config still flips the variant. homepage_config is null on
+  // the canonical site and on any custom domain that hasn't opted in.
   const urlOverride = readUrlVariantOverride();
   const variant = computed<DisabledHomepageVariant>(
     () =>
       urlOverride ??
       homepage_config.value?.disabled_homepage_variant ??
+      ui.value?.homepage?.disabled_variant ??
       DEFAULT_DISABLED_HOMEPAGE_VARIANT
   );
 

--- a/src/apps/secret/views/disabled/variants/DisabledClosed.vue
+++ b/src/apps/secret/views/disabled/variants/DisabledClosed.vue
@@ -1,21 +1,21 @@
-<!-- src/apps/secret/views/disabled/variants/DisabledLegacy.vue -->
+<!-- src/apps/secret/views/disabled/variants/DisabledClosed.vue -->
 
 <script setup lang="ts">
   import DisabledHomepageTaglines from '@/apps/secret/components/conceal/DisabledHomepageTaglines.vue';
   import type { DisabledHomepageProps } from '../useDisabledConfig';
 
   /*
-    Legacy — the original two-tagline placeholder.
+    Closed — the quiet two-tagline placeholder (the default).
 
-    Kept as a rollback target for the V1 refresh. Renders the same
-    `DisabledHomepageTaglines` component the `disabled-ui` mode still uses,
-    so behaviour is identical to the pre-refresh DisabledHomepage.
+    Renders the same `DisabledHomepageTaglines` component the `disabled-ui`
+    mode still uses, so behaviour is identical to the pre-refresh
+    DisabledHomepage: a plain "members only" notice with no sign-in CTA.
 
     Accepts the full DisabledHomepageProps contract for compatibility with
     the dispatcher, but only consumes what it needs.
   */
 
-  // Legacy variant ignores the props bag entirely — kept for contract
+  // Closed variant ignores the props bag entirely — kept for contract
   // compatibility with the dispatcher. The `_` prefix matches the project's
   // unused-vars lint allowlist.
   const _props = defineProps<DisabledHomepageProps>();

--- a/src/apps/secret/views/disabled/variants/DisabledMinimal.vue
+++ b/src/apps/secret/views/disabled/variants/DisabledMinimal.vue
@@ -7,7 +7,7 @@
   import { computed, ref, watch } from 'vue';
 
   /*
-    Minimal — a quiet refresh of the legacy two-tagline view.
+    Minimal — a quiet refresh of the closed two-tagline view.
 
     Same visual restraint as the original (small mark, single column,
     no promo, no trust strip, no eyebrow), but with refreshed copy and a
@@ -60,7 +60,7 @@
       </div>
     </div>
 
-    <!-- Headline (smaller than V1, larger than legacy) -->
+    <!-- Headline (smaller than V1, larger than closed) -->
     <h1 class="text-balance font-brand text-2xl font-bold leading-tight tracking-tight text-gray-800 dark:text-gray-100 sm:text-3xl">
       <i18n-t
         v-if="isBranded"
@@ -96,8 +96,26 @@
 
     <!-- CTA row (ghost button, smaller than V1) -->
     <div class="mt-6 inline-flex flex-wrap items-center justify-center gap-x-5 gap-y-2">
+      <!-- One-click SSO: skip /signin and POST straight to the provider when
+           SSO is the only login method and a single provider is configured. -->
+      <button
+        v-if="showSignin && ssoOneClick"
+        type="button"
+        data-testid="disabled-homepage-sso"
+        class="inline-flex items-center gap-2 rounded-lg border border-gray-300 bg-white px-5 py-2 text-sm font-semibold text-gray-800 transition-colors hover:border-gray-400 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:ring-offset-2 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100 dark:hover:border-gray-600 dark:hover:bg-gray-800 dark:focus:ring-offset-gray-900"
+        @click="onSsoLogin">
+        {{
+          ssoProviderName
+            ? $t('web.login.sign_in_with_provider', { provider: ssoProviderName })
+            : $t('homepage_secrets.disabled.signin_cta')
+        }}
+        <OIcon
+          collection="heroicons"
+          name="arrow-right"
+          class="size-4" />
+      </button>
       <router-link
-        v-if="showSignin"
+        v-else-if="showSignin"
         to="/signin"
         data-testid="disabled-homepage-signin"
         class="inline-flex items-center gap-2 rounded-lg border border-gray-300 bg-white px-5 py-2 text-sm font-semibold text-gray-800 transition-colors hover:border-gray-400 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:ring-offset-2 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100 dark:hover:border-gray-600 dark:hover:bg-gray-800 dark:focus:ring-offset-gray-900">

--- a/src/apps/secret/views/disabled/variants/DisabledMinimal.vue
+++ b/src/apps/secret/views/disabled/variants/DisabledMinimal.vue
@@ -102,7 +102,7 @@
         v-if="ssoOneClick"
         type="button"
         data-testid="disabled-homepage-sso"
-        class="inline-flex items-center gap-2 rounded-lg border border-gray-300 bg-white px-5 py-2 text-sm font-semibold text-gray-800 transition-colors hover:border-gray-400 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:ring-offset-2 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100 dark:hover:border-gray-600 dark:hover:bg-gray-800 dark:focus:ring-offset-gray-900"
+        class="inline-flex items-center gap-2 rounded-lg border border-gray-300 bg-white px-5 py-2 text-sm font-semibold text-gray-800 cursor-pointer shadow-sm transition-colors hover:border-gray-400 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:ring-offset-2 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100 dark:hover:border-gray-600 dark:hover:bg-gray-800 dark:focus:ring-offset-gray-900"
         @click="onSsoLogin">
         {{
           ssoProviderName

--- a/src/apps/secret/views/disabled/variants/DisabledMinimal.vue
+++ b/src/apps/secret/views/disabled/variants/DisabledMinimal.vue
@@ -99,7 +99,7 @@
       <!-- One-click SSO: skip /signin and POST straight to the provider when
            SSO is the only login method and a single provider is configured. -->
       <button
-        v-if="showSignin && ssoOneClick"
+        v-if="ssoOneClick"
         type="button"
         data-testid="disabled-homepage-sso"
         class="inline-flex items-center gap-2 rounded-lg border border-gray-300 bg-white px-5 py-2 text-sm font-semibold text-gray-800 transition-colors hover:border-gray-400 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:ring-offset-2 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100 dark:hover:border-gray-600 dark:hover:bg-gray-800 dark:focus:ring-offset-gray-900"

--- a/src/apps/secret/views/disabled/variants/DisabledV1.vue
+++ b/src/apps/secret/views/disabled/variants/DisabledV1.vue
@@ -128,7 +128,7 @@
         v-if="ssoOneClick"
         type="button"
         data-testid="disabled-homepage-sso"
-        class="inline-flex items-center gap-2 rounded-xl bg-brand-600 px-7 py-3.5 font-sans text-[15px] font-semibold text-white shadow-sm transition-colors hover:bg-brand-700 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900"
+        class="inline-flex cursor-pointer items-center gap-2 rounded-xl bg-brand-600 px-7 py-3.5 font-sans text-[15px] font-semibold text-white shadow-sm transition-colors hover:bg-brand-700 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900"
         @click="onSsoLogin">
         {{
           ssoProviderName

--- a/src/apps/secret/views/disabled/variants/DisabledV1.vue
+++ b/src/apps/secret/views/disabled/variants/DisabledV1.vue
@@ -122,8 +122,26 @@
 
     <!-- CTA row -->
     <div class="mt-9 inline-flex flex-wrap items-center justify-center gap-x-6 gap-y-3">
+      <!-- One-click SSO: skip /signin and POST straight to the provider when
+           SSO is the only login method and a single provider is configured. -->
+      <button
+        v-if="showSignin && ssoOneClick"
+        type="button"
+        data-testid="disabled-homepage-sso"
+        class="inline-flex items-center gap-2 rounded-xl bg-brand-600 px-7 py-3.5 font-sans text-[15px] font-semibold text-white shadow-sm transition-colors hover:bg-brand-700 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900"
+        @click="onSsoLogin">
+        {{
+          ssoProviderName
+            ? $t('web.login.sign_in_with_provider', { provider: ssoProviderName })
+            : $t('homepage_secrets.disabled.signin_cta')
+        }}
+        <OIcon
+          collection="heroicons"
+          name="arrow-right"
+          class="size-4" />
+      </button>
       <router-link
-        v-if="showSignin"
+        v-else-if="showSignin"
         to="/signin"
         data-testid="disabled-homepage-signin"
         class="inline-flex items-center gap-2 rounded-xl bg-brand-600 px-7 py-3.5 font-sans text-[15px] font-semibold text-white shadow-sm transition-colors hover:bg-brand-700 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900">

--- a/src/apps/secret/views/disabled/variants/DisabledV1.vue
+++ b/src/apps/secret/views/disabled/variants/DisabledV1.vue
@@ -125,7 +125,7 @@
       <!-- One-click SSO: skip /signin and POST straight to the provider when
            SSO is the only login method and a single provider is configured. -->
       <button
-        v-if="showSignin && ssoOneClick"
+        v-if="ssoOneClick"
         type="button"
         data-testid="disabled-homepage-sso"
         class="inline-flex items-center gap-2 rounded-xl bg-brand-600 px-7 py-3.5 font-sans text-[15px] font-semibold text-white shadow-sm transition-colors hover:bg-brand-700 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900"

--- a/src/apps/session/components/SsoButton.vue
+++ b/src/apps/session/components/SsoButton.vue
@@ -4,7 +4,8 @@
 import { useI18n } from 'vue-i18n';
 import OIcon from '@/shared/components/icons/OIcon.vue';
 import { useCsrfStore } from '@/shared/stores/csrfStore';
-import { ref, computed } from 'vue';
+import { submitSsoLogin } from '@/shared/utils/sso';
+import { ref } from 'vue';
 
 export interface Props {
   /**
@@ -40,54 +41,19 @@ const csrfStore = useCsrfStore();
 const isLoading = ref(false);
 
 /**
- * SSO route path built from the routeName prop.
- */
-const ssoRoute = computed(() => `/auth/sso/${props.routeName}`);
-
-/**
- * Initiates SSO login by submitting a form to the provider endpoint.
- * This creates a traditional form POST to /auth/sso/:provider which triggers
- * the OmniAuth flow and redirects to the identity provider.
+ * Initiates SSO login by submitting a form POST to /auth/sso/:provider,
+ * which triggers the OmniAuth flow and redirects to the identity provider.
+ *
+ * The form submission navigates away from the page, so there's no response
+ * to handle and no need to reset isLoading.
  */
 const handleSsoLogin = () => {
   isLoading.value = true;
-
-  // Create and submit a form to POST to the SSO endpoint
-  // This needs to be a form submission (not fetch) because it redirects to the IdP
-  const form = document.createElement('form');
-  form.method = 'POST';
-  form.action = ssoRoute.value;
-
-  /**
-   * Include CSRF token in form submission for consistency.
-   *
-   * Note: Rack::Protection skips /auth/sso/* routes (see security.rb).
-   * OmniAuth's OAuth state parameter provides CSRF protection instead.
-   * The shrimp token is included but not validated for these routes.
-   */
-  const csrfInput = document.createElement('input');
-  csrfInput.type = 'hidden';
-  csrfInput.name = 'shrimp';
-  csrfInput.value = csrfStore.shrimp;
-  form.appendChild(csrfInput);
-
-  /**
-   * Include redirect URL when provided.
-   * The backend will store this and redirect the user after successful SSO.
-   */
-  if (props.redirect) {
-    const redirectInput = document.createElement('input');
-    redirectInput.type = 'hidden';
-    redirectInput.name = 'redirect';
-    redirectInput.value = props.redirect;
-    form.appendChild(redirectInput);
-  }
-
-  document.body.appendChild(form);
-  form.submit();
-
-  // Note: The form submission will navigate away from the page,
-  // so we don't need to handle the response or reset isLoading
+  submitSsoLogin({
+    routeName: props.routeName,
+    shrimp: csrfStore.shrimp,
+    redirect: props.redirect || undefined,
+  });
 };
 </script>
 

--- a/src/schemas/contracts/bootstrap.ts
+++ b/src/schemas/contracts/bootstrap.ts
@@ -22,7 +22,7 @@ import { z } from 'zod';
 import { CanonicalPlanIdSchema } from '@/schemas/contracts/config/billing';
 import { regionsConfigSchema } from '@/schemas/contracts/config/section/jurisdiction';
 import { brandSettingsCanonical, homepageConfigCanonical } from '@/schemas/contracts/custom-domain';
-import { disabledHomepageConfigSchema } from '@/schemas/contracts/disabled-homepage';
+import { disabledHomepageConfigSchema, disabledHomepageVariantSchema } from '@/schemas/contracts/disabled-homepage';
 import { customerCanonical } from '@/schemas/contracts/customer';
 
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -169,6 +169,17 @@ export const homepagePublicLinksSchema = z.object({
  */
 export const homepageUiConfigSchema = z.object({
   public_links: homepagePublicLinksSchema.optional(),
+  /**
+   * Deployment-wide default disabled-homepage variant, from the
+   * `DEFAULT_DISABLED_HOMEPAGE_VARIANT` env var
+   * (`site.interface.ui.homepage.disabled_variant`). Sits between the
+   * per-domain `homepage_config.disabled_homepage_variant` and the frontend
+   * `DEFAULT_DISABLED_HOMEPAGE_VARIANT` constant in the resolution chain.
+   *
+   * `.catch(null)` so an unrecognised value degrades to the frontend default
+   * rather than failing the whole bootstrap parse.
+   */
+  disabled_variant: disabledHomepageVariantSchema.nullable().catch(null).optional(),
 });
 
 export const uiInterfaceSchema = z.object({

--- a/src/schemas/contracts/disabled-homepage.ts
+++ b/src/schemas/contracts/disabled-homepage.ts
@@ -20,16 +20,19 @@ import { z } from 'zod';
 /**
  * Visual variant for the disabled-homepage view.
  *
+ * - `closed`: the quiet two-tagline placeholder (default). No CTA — the
+ *   understated "members only" landing page private instances had before
+ *   the refresh.
+ * - `minimal`: quiet refresh of the two-tagline shape — small mark, headline,
+ *   subtitle, and a sign-in CTA (one-click SSO when a single provider is the
+ *   only login method, otherwise a link to /signin). No trust strip or promo.
  * - `v1`: the full hero refresh — mark, eyebrow, headline, CTA, trust strip,
- *   optional promo
- * - `minimal`: quiet refresh of the legacy two-tagline shape — small mark,
- *   headline, subtitle, ghost CTA. No trust strip or promo (default).
- * - `legacy`: the original two-tagline placeholder (rollback target)
+ *   optional promo. Same SSO-aware CTA as `minimal`.
  *
  * New variants must be registered in the dispatcher map in
  * `DisabledHomepage.vue` *and* added here.
  */
-export const disabledHomepageVariantSchema = z.enum(['v1', 'minimal', 'legacy']);
+export const disabledHomepageVariantSchema = z.enum(['v1', 'minimal', 'closed']);
 export type DisabledHomepageVariant = z.infer<typeof disabledHomepageVariantSchema>;
 
 /**
@@ -37,8 +40,12 @@ export type DisabledHomepageVariant = z.infer<typeof disabledHomepageVariantSche
  * `homepage_config.disabled_homepage_variant` nor the `?variant` URL
  * override resolves to a value. The dispatcher and the composable both
  * import this so the default stays in one place.
+ *
+ * Defaults to `closed`: the quiet, pre-refresh landing page. Operators who
+ * want a sign-in CTA on the gated homepage opt into `minimal` / `v1`
+ * per-domain (or deployment-wide by changing this constant).
  */
-export const DEFAULT_DISABLED_HOMEPAGE_VARIANT: DisabledHomepageVariant = 'minimal';
+export const DEFAULT_DISABLED_HOMEPAGE_VARIANT: DisabledHomepageVariant = 'closed';
 
 /**
  * Tri-state operator override: null = use auto-detection rules,

--- a/src/shared/utils/sso.ts
+++ b/src/shared/utils/sso.ts
@@ -1,0 +1,63 @@
+// src/shared/utils/sso.ts
+//
+// Shared helper for initiating an SSO sign-in. SSO login is a traditional
+// form POST to /auth/sso/:provider (not a fetch) because the endpoint
+// triggers the OmniAuth flow and redirects the browser to the identity
+// provider — an XHR can't follow that cross-origin redirect.
+//
+// Used by both the dedicated SsoButton on /signin and the one-click SSO CTA
+// on the disabled-homepage variants, so the form-building stays in one place.
+
+export interface SubmitSsoLoginOptions {
+  /**
+   * SSO route name used to build the POST action URL (`/auth/sso/:routeName`).
+   * Corresponds to the `name:` option in auth.omniauth_provider.
+   * Example: 'oidc', 'google', 'entra', 'github'.
+   */
+  routeName: string;
+
+  /**
+   * CSRF (shrimp) token included for form consistency.
+   *
+   * Note: Rack::Protection skips /auth/sso/* routes (see security.rb);
+   * OmniAuth's OAuth state parameter provides CSRF protection instead. The
+   * token is submitted but not validated for these routes.
+   */
+  shrimp?: string;
+
+  /**
+   * URL to return to after successful SSO authentication (e.g. '/invite/abc').
+   * When provided, the backend stores it and redirects there post-login.
+   */
+  redirect?: string;
+}
+
+/**
+ * Build and submit a POST form that initiates SSO login for the given
+ * provider. Navigates the browser away to the IdP, so nothing runs after
+ * `form.submit()` returns.
+ */
+export function submitSsoLogin({ routeName, shrimp, redirect }: SubmitSsoLoginOptions): void {
+  const form = document.createElement('form');
+  form.method = 'POST';
+  form.action = `/auth/sso/${routeName}`;
+
+  if (shrimp) {
+    const csrfInput = document.createElement('input');
+    csrfInput.type = 'hidden';
+    csrfInput.name = 'shrimp';
+    csrfInput.value = shrimp;
+    form.appendChild(csrfInput);
+  }
+
+  if (redirect) {
+    const redirectInput = document.createElement('input');
+    redirectInput.type = 'hidden';
+    redirectInput.name = 'redirect';
+    redirectInput.value = redirect;
+    form.appendChild(redirectInput);
+  }
+
+  document.body.appendChild(form);
+  form.submit();
+}

--- a/src/tests/apps/secret/views/useDisabledConfig.spec.ts
+++ b/src/tests/apps/secret/views/useDisabledConfig.spec.ts
@@ -42,6 +42,9 @@ interface SetupOptions {
   /** Per-domain disabled-homepage variant. Null/omitted means
    *  "use the frontend DEFAULT_DISABLED_HOMEPAGE_VARIANT". */
   homepageVariant?: 'v1' | 'minimal' | 'closed' | null;
+  /** Deployment-wide default variant (ui.homepage.disabled_variant, from the
+   *  DEFAULT_DISABLED_HOMEPAGE_VARIANT env var). */
+  siteDefaultVariant?: 'v1' | 'minimal' | 'closed' | null;
   /** Tri-state operator overrides for the auto-detected affordances. */
   disabledHomepage?: {
     show_promo?: boolean | null;
@@ -75,6 +78,7 @@ function setup(opts: SetupOptions = {}) {
       ...bootstrap.ui,
       homepage: {
         ...(bootstrap.ui.homepage ?? { matching_cidrs: [], mode_header: 'O-Homepage-Mode' }),
+        disabled_variant: opts.siteDefaultVariant ?? null,
         public_links: {
           recipient_intro: opts.recipientIntroUrl ?? null,
         },
@@ -164,6 +168,22 @@ describe('useDisabledConfig', () => {
 
     it('respects the per-domain variant from homepage_config', () => {
       const { config } = setup({ homepageVariant: 'v1' });
+      expect(config.variant.value).toBe('v1');
+    });
+
+    it('uses the deployment-wide ui.homepage.disabled_variant when no per-domain config', () => {
+      const { config } = setup({ siteDefaultVariant: 'minimal' });
+      expect(config.variant.value).toBe('minimal');
+    });
+
+    it('per-domain homepage_config wins over the deployment-wide default', () => {
+      const { config } = setup({ siteDefaultVariant: 'minimal', homepageVariant: 'v1' });
+      expect(config.variant.value).toBe('v1');
+    });
+
+    it('?variant override wins over the deployment-wide default', () => {
+      window.history.replaceState({}, '', '/?variant=v1');
+      const { config } = setup({ siteDefaultVariant: 'minimal' });
       expect(config.variant.value).toBe('v1');
     });
 

--- a/src/tests/apps/secret/views/useDisabledConfig.spec.ts
+++ b/src/tests/apps/secret/views/useDisabledConfig.spec.ts
@@ -12,12 +12,19 @@
 import { useDisabledConfig } from '@/apps/secret/views/disabled/useDisabledConfig';
 import { useBootstrapStore } from '@/shared/stores/bootstrapStore';
 import { useProductIdentity } from '@/shared/stores/identityStore';
+import { submitSsoLogin } from '@/shared/utils/sso';
 import { createPinia, setActivePinia } from 'pinia';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Identity store reads i18n during init (preReveal default copy); stub it.
 vi.mock('vue-i18n', () => ({
   useI18n: () => ({ t: (key: string) => key }),
+}));
+
+// Spy on the SSO form-submit helper so onSsoLogin can be asserted without
+// navigating the jsdom window.
+vi.mock('@/shared/utils/sso', () => ({
+  submitSsoLogin: vi.fn(),
 }));
 
 interface SetupOptions {
@@ -34,12 +41,19 @@ interface SetupOptions {
   recipientIntroUrl?: string | null;
   /** Per-domain disabled-homepage variant. Null/omitted means
    *  "use the frontend DEFAULT_DISABLED_HOMEPAGE_VARIANT". */
-  homepageVariant?: 'v1' | 'minimal' | 'legacy' | null;
+  homepageVariant?: 'v1' | 'minimal' | 'closed' | null;
   /** Tri-state operator overrides for the auto-detected affordances. */
   disabledHomepage?: {
     show_promo?: boolean | null;
     show_what_is_this?: boolean | null;
   };
+  // SSO one-click context
+  /** Configured SSO providers (features.sso.providers). */
+  ssoProviders?: Array<{ route_name: string; display_name: string }>;
+  /** Global SSO-only restriction (features.restrict_to === 'sso'). */
+  ssoOnly?: boolean;
+  /** Per-domain SSO enforcement (features.sso.enforce_sso_only). */
+  enforceSsoOnly?: boolean;
 }
 
 /**
@@ -69,6 +83,21 @@ function setup(opts: SetupOptions = {}) {
     disabled_homepage: {
       show_promo: opts.disabledHomepage?.show_promo ?? null,
       show_what_is_this: opts.disabledHomepage?.show_what_is_this ?? null,
+    },
+    // Specify features fully rather than spreading bootstrap.features: the
+    // store's `state: () => ({ ...DEFAULTS })` shallow-spread shares one
+    // features object across instances, and $patch's deep-merge would
+    // otherwise leak restrict_to/sso between tests.
+    features: {
+      restrict_to: opts.ssoOnly ? 'sso' : null,
+      sso:
+        opts.ssoProviders === undefined && opts.enforceSsoOnly === undefined
+          ? false
+          : {
+              enabled: true,
+              providers: opts.ssoProviders ?? [],
+              enforce_sso_only: opts.enforceSsoOnly ?? false,
+            },
     },
     homepage_config:
       opts.homepageVariant === undefined
@@ -122,15 +151,15 @@ describe('useDisabledConfig', () => {
       window.history.replaceState({}, '', '/');
     });
 
-    it('falls back to the frontend default (minimal) when no per-domain config', () => {
+    it('falls back to the frontend default (closed) when no per-domain config', () => {
       const { config } = setup();
-      expect(config.variant.value).toBe('minimal');
+      expect(config.variant.value).toBe('closed');
     });
 
     it('falls back to the frontend default when homepage_config sets variant=null', () => {
       // Null means "no per-domain override" — operator never opted in.
       const { config } = setup({ homepageVariant: null });
-      expect(config.variant.value).toBe('minimal');
+      expect(config.variant.value).toBe('closed');
     });
 
     it('respects the per-domain variant from homepage_config', () => {
@@ -145,16 +174,16 @@ describe('useDisabledConfig', () => {
       bootstrap.$patch({
         homepage_config: {
           ...bootstrap.homepage_config!,
-          disabled_homepage_variant: 'legacy',
+          disabled_homepage_variant: 'closed',
         },
       });
-      expect(config.variant.value).toBe('legacy');
+      expect(config.variant.value).toBe('closed');
     });
 
     it('?variant URL override wins over homepage_config', () => {
-      window.history.replaceState({}, '', '/?variant=legacy');
+      window.history.replaceState({}, '', '/?variant=closed');
       const { config } = setup({ homepageVariant: 'v1' });
-      expect(config.variant.value).toBe('legacy');
+      expect(config.variant.value).toBe('closed');
     });
 
     it('?variant override falls through silently when the value is invalid', () => {
@@ -170,8 +199,67 @@ describe('useDisabledConfig', () => {
       const { config } = setup({ homepageVariant: 'v1' });
       expect(config.variant.value).toBe('v1');
 
-      window.history.replaceState({}, '', '/?variant=legacy');
+      window.history.replaceState({}, '', '/?variant=closed');
       expect(config.variant.value).toBe('v1');
+    });
+  });
+
+  describe('one-click SSO', () => {
+    const oneProvider = [{ route_name: 'oidc', display_name: 'Okta' }];
+
+    it('is off by default (no SSO restriction)', () => {
+      const { config } = setup();
+      expect(config.props.ssoOneClick).toBe(false);
+      expect(config.props.ssoProviderName).toBeNull();
+    });
+
+    it('is on when SSO is the only method and a single provider is configured', () => {
+      const { config } = setup({ ssoOnly: true, ssoProviders: oneProvider });
+      expect(config.props.ssoOneClick).toBe(true);
+      expect(config.props.ssoProviderName).toBe('Okta');
+    });
+
+    it('is off with multiple providers (the chooser on /signin is still needed)', () => {
+      const { config } = setup({
+        ssoOnly: true,
+        ssoProviders: [
+          { route_name: 'oidc', display_name: 'Okta' },
+          { route_name: 'google', display_name: 'Google' },
+        ],
+      });
+      expect(config.props.ssoOneClick).toBe(false);
+    });
+
+    it('is off when a single provider exists but SSO is not the only method', () => {
+      // Other login methods remain, so /signin still offers a real choice.
+      const { config } = setup({ ssoProviders: oneProvider });
+      expect(config.props.ssoOneClick).toBe(false);
+    });
+
+    it('is on for a custom domain enforcing SSO with a single provider', () => {
+      const { config } = setup({
+        domainStrategy: 'custom',
+        enforceSsoOnly: true,
+        ssoProviders: oneProvider,
+      });
+      expect(config.props.ssoOneClick).toBe(true);
+    });
+
+    it('is off when sign-in is disabled, even with single-provider SSO-only', () => {
+      const { config } = setup({ authSignin: false, ssoOnly: true, ssoProviders: oneProvider });
+      expect(config.props.ssoOneClick).toBe(false);
+    });
+
+    it('onSsoLogin submits an SSO form for the single provider', () => {
+      const { config } = setup({ ssoOnly: true, ssoProviders: oneProvider });
+      config.props.onSsoLogin();
+      expect(submitSsoLogin).toHaveBeenCalledWith(expect.objectContaining({ routeName: 'oidc' }));
+    });
+
+    it('onSsoLogin is a no-op when not in one-click mode', () => {
+      const { config } = setup({ ssoProviders: oneProvider });
+      config.props.onSsoLogin();
+      expect(submitSsoLogin).not.toHaveBeenCalled();
     });
   });
 

--- a/try/unit/models/custom_domain_homepage_config_try.rb
+++ b/try/unit/models/custom_domain_homepage_config_try.rb
@@ -345,5 +345,77 @@ Onetime::CustomDomain::HomepageConfig.exists_for_domain?(@focd2_domain.identifie
 @focd2_cfg2.signin_enabled?
 #=> false
 
+# -------------------------------------------------------------------
+# disabled_homepage_variant field coverage
+# -------------------------------------------------------------------
+
+## coerce_disabled_homepage_variant accepts a recognised variant
+Onetime::CustomDomain::HomepageConfig.coerce_disabled_homepage_variant('minimal')
+#=> 'minimal'
+
+## coerce_disabled_homepage_variant trims surrounding whitespace
+Onetime::CustomDomain::HomepageConfig.coerce_disabled_homepage_variant('  v1  ')
+#=> 'v1'
+
+## coerce_disabled_homepage_variant returns nil for an unknown value
+Onetime::CustomDomain::HomepageConfig.coerce_disabled_homepage_variant('bogus')
+#=> nil
+
+## coerce_disabled_homepage_variant returns nil for blank input
+Onetime::CustomDomain::HomepageConfig.coerce_disabled_homepage_variant('')
+#=> nil
+
+## Setup: fresh domain for variant tests
+@var_domain = Onetime::CustomDomain.create!("hp-cfg-var-#{@ts}-#{@entropy}.example.com", @org.objid)
+Onetime::CustomDomain::HomepageConfig.delete_for_domain!(@var_domain.identifier)
+Onetime::CustomDomain::HomepageConfig.exists_for_domain?(@var_domain.identifier)
+#=> false
+
+## upsert without a variant leaves disabled_homepage_variant_value nil (use default)
+@var_cfg = Onetime::CustomDomain::HomepageConfig.upsert(domain_id: @var_domain.identifier, enabled: true)
+@var_cfg.disabled_homepage_variant_value
+#=> nil
+
+## upsert with a recognised variant stores it
+@var_cfg = Onetime::CustomDomain::HomepageConfig.upsert(domain_id: @var_domain.identifier, enabled: true, disabled_homepage_variant: 'minimal')
+@var_cfg.disabled_homepage_variant_value
+#=> 'minimal'
+
+## reload from Redis confirms the variant persisted
+Onetime::CustomDomain::HomepageConfig.find_by_domain_id(@var_domain.identifier).disabled_homepage_variant_value
+#=> 'minimal'
+
+## upsert without the variant kwarg does not clobber the stored value
+@var_cfg = Onetime::CustomDomain::HomepageConfig.upsert(domain_id: @var_domain.identifier, enabled: false)
+@var_cfg.disabled_homepage_variant_value
+#=> 'minimal'
+
+## upsert with an unknown variant coerces to nil (clears the override)
+@var_cfg = Onetime::CustomDomain::HomepageConfig.upsert(domain_id: @var_domain.identifier, enabled: true, disabled_homepage_variant: 'nope')
+@var_cfg.disabled_homepage_variant_value
+#=> nil
+
+## upsert with explicit nil clears a previously stored variant
+Onetime::CustomDomain::HomepageConfig.upsert(domain_id: @var_domain.identifier, enabled: true, disabled_homepage_variant: 'v1')
+@var_cfg = Onetime::CustomDomain::HomepageConfig.upsert(domain_id: @var_domain.identifier, enabled: true, disabled_homepage_variant: nil)
+@var_cfg.disabled_homepage_variant_value
+#=> nil
+
+## create! stores a coerced variant
+@cr_domain = Onetime::CustomDomain.create!("hp-cfg-cr-#{@ts}-#{@entropy}.example.com", @org.objid)
+Onetime::CustomDomain::HomepageConfig.delete_for_domain!(@cr_domain.identifier)
+@cr_cfg = Onetime::CustomDomain::HomepageConfig.create!(domain_id: @cr_domain.identifier, enabled: true, disabled_homepage_variant: 'v1')
+@cr_cfg.disabled_homepage_variant_value
+#=> 'v1'
+
+## validation_errors flags a stored value outside the recognised set
+@bad_cfg = Onetime::CustomDomain::HomepageConfig.new(domain_id: 'x', disabled_homepage_variant: 'bogus')
+@bad_cfg.validation_errors.any? { |e| e.include?('disabled_homepage_variant') }
+#=> true
+
+## validation_errors stays clean for a recognised variant
+Onetime::CustomDomain::HomepageConfig.new(domain_id: 'x', disabled_homepage_variant: 'closed').validation_errors
+#=> []
+
 # Teardown
 Familia.dbclient.flushdb

--- a/try/unit/models/custom_domain_homepage_config_try.rb
+++ b/try/unit/models/custom_domain_homepage_config_try.rb
@@ -395,9 +395,14 @@ Onetime::CustomDomain::HomepageConfig.find_by_domain_id(@var_domain.identifier).
 @var_cfg.disabled_homepage_variant_value
 #=> nil
 
-## upsert with explicit nil clears a previously stored variant
+## upsert with explicit nil leaves a previously stored variant unchanged (merge semantics)
 Onetime::CustomDomain::HomepageConfig.upsert(domain_id: @var_domain.identifier, enabled: true, disabled_homepage_variant: 'v1')
 @var_cfg = Onetime::CustomDomain::HomepageConfig.upsert(domain_id: @var_domain.identifier, enabled: true, disabled_homepage_variant: nil)
+@var_cfg.disabled_homepage_variant_value
+#=> 'v1'
+
+## upsert with an empty string clears a previously stored variant (reset to default)
+@var_cfg = Onetime::CustomDomain::HomepageConfig.upsert(domain_id: @var_domain.identifier, enabled: true, disabled_homepage_variant: '')
 @var_cfg.disabled_homepage_variant_value
 #=> nil
 


### PR DESCRIPTION
Contributes to https://github.com/onetimesecret/onetimesecret/issues/3426.

## Summary

Implements one-click SSO on the disabled homepage variants (`minimal` and `v1`) when SSO is the sole login method with a single provider configured. Extracts the SSO form-submission logic into a shared utility (`submitSsoLogin`) used by both the dedicated `SsoButton` component and the new disabled-homepage CTA.

Also renames the `legacy` disabled-homepage variant to `closed` and makes it the new default, better reflecting its purpose as a quiet, pre-refresh placeholder with no sign-in CTA.

## Key Changes

- **New `shared/utils/sso.ts`**: Shared helper for building and submitting SSO login forms. Centralizes the form-creation logic previously duplicated in `SsoButton.vue`.
- **Enhanced `useDisabledConfig` composable**: 
  - Adds `ssoOneClick`, `ssoProviderName`, and `onSsoLogin` to the props bag
  - Implements `resolveSsoOneClickProvider()` to determine when one-click SSO should be active (mirrors `AuthMethodSelector` logic: global `restrict_to === 'sso'` or custom domain with `enforce_sso_only`)
  - Properly isolates SSO/features config in test setup to prevent test pollution
- **Updated disabled-homepage variants**:
  - `DisabledV1` and `DisabledMinimal` now render a one-click SSO button when applicable, falling back to `/signin` link otherwise
  - Both variants use the shared `submitSsoLogin` utility via the composable's `onSsoLogin` callback
- **Variant naming**: Renamed `DisabledLegacy.vue` → `DisabledClosed.vue` and updated `DEFAULT_DISABLED_HOMEPAGE_VARIANT` from `minimal` to `closed`
- **Refactored `SsoButton.vue`**: Simplified to use the new `submitSsoLogin` utility, removing duplicated form-building logic

## Related Issues

<!-- Add issue number if applicable -->

## Test Plan

Comprehensive unit tests added to `useDisabledConfig.spec.ts`:
- One-click SSO is off by default (no SSO restriction)
- One-click SSO activates when SSO is the only method with a single provider
- One-click SSO is off with multiple providers (chooser still needed)
- One-click SSO respects custom domain `enforce_sso_only` setting
- One-click SSO is disabled when sign-in is disabled
- `onSsoLogin` correctly submits the SSO form for the single provider
- `onSsoLogin` is a no-op when not in one-click mode

All existing tests pass; variant naming updates reflected in test expectations.

https://claude.ai/code/session_01RFLbwa9HeSP9T9comwSZb9