### PR TITLE
Cast numeric fields to numbers at safe_dump boundary (#3424) *

### DIFF
--- a/changelog.d/20260612_180000_claude_3424_safe_dump_numeric_cast.rst
+++ b/changelog.d/20260612_180000_claude_3424_safe_dump_numeric_cast.rst
@@ -1,0 +1,6 @@
+.. A new scriv changelog fragment.
+
+Fixed
+-----
+
+- Secret and Receipt API responses now cast their numeric fields (``lifespan``, ``secret_ttl``, ``metadata_ttl``, ``receipt_ttl``, ``created``, ``updated``) to integers at the ``safe_dump`` serialization boundary. Familia v2 storage is type-preserving, so a record whose numeric fields were ever written as strings (unconverted params, console writes, raw ``HSET``) would hydrate them as strings and fail the strict ``z.number()`` V3 schema — recipients saw "That information is no longer available" for secrets that were never consumed, with the sender's dashboard stuck on "Previewed". The cast is a no-op for healthy records and neutralizes affected ones; unset lifespans remain ``null`` and unset receipt ``secret_ttl`` remains ``-1``. (#3424, #3268)

--- a/changelog.d/20260612_180000_claude_3424_safe_dump_numeric_cast.rst
+++ b/changelog.d/20260612_180000_claude_3424_safe_dump_numeric_cast.rst
@@ -3,4 +3,9 @@
 Fixed
 -----
 
-- Secret and Receipt API responses now cast their numeric fields (``lifespan``, ``secret_ttl``, ``metadata_ttl``, ``receipt_ttl``, ``created``, ``updated``) to integers at the ``safe_dump`` serialization boundary. Familia v2 storage is type-preserving, so a record whose numeric fields were ever written as strings (unconverted params, console writes, raw ``HSET``) would hydrate them as strings and fail the strict ``z.number()`` V3 schema — recipients saw "That information is no longer available" for secrets that were never consumed, with the sender's dashboard stuck on "Previewed". The cast is a no-op for healthy records and neutralizes affected ones; unset lifespans remain ``null`` and unset receipt ``secret_ttl`` remains ``-1``. (#3424, #3268)
+- Secret and Receipt API responses now coerce their numeric fields to numbers at the ``safe_dump`` serialization boundary: TTL/lifespan fields (``lifespan``, ``secret_ttl``, ``metadata_ttl``, ``receipt_ttl``) cast to integers, and the ``created``/``updated`` timestamps cast to floats so their sub-second precision (used as sorted-set scores) is preserved. Familia v2 storage is type-preserving, so a record whose numeric fields were ever written as strings (unconverted params, console writes, raw ``HSET``) hydrated them as strings and failed the strict ``z.number()`` V3 schema — recipients saw "That information is no longer available" for secrets that were never consumed, with the sender's dashboard stuck on "Previewed". The cast is a no-op for healthy records and neutralizes affected ones; unset lifespans remain ``null`` and unset receipt ``secret_ttl`` remains ``-1``. (#3424, #3268)
+
+Added
+-----
+
+- ``scripts/diagnostics/detect_string_typed_numerics.rb``, a read-only scan that finds Secret/Receipt records whose numeric fields are stored as JSON strings at rest (the corruption behind #3424, distinct from the non-JSON bytes that ``check_raw_email_fields.rb`` finds for #3016). The ``safe_dump`` cast keeps the API correct, but the bytes stay corrupt; this locates them and reports a per-record signature to help trace the writer. (#3424)

--- a/lib/onetime/models/receipt/features/safe_dump_fields.rb
+++ b/lib/onetime/models/receipt/features/safe_dump_fields.rb
@@ -62,13 +62,21 @@ module Onetime::Receipt::Features
                 val.empty? ? m.secret_identifier.to_s.slice(0, 8) : val
         }
       base.safe_dump_field :secret_identifier
-      base.safe_dump_field :secret_ttl, ->(m) { m.secret_ttl || -1 }
-      base.safe_dump_field :metadata_ttl, ->(m) { m.lifespan }
-      base.safe_dump_field :receipt_ttl, ->(m) { m.lifespan }
-      base.safe_dump_field :lifespan
+
+      # Numeric fields are cast at this boundary because Familia v2 storage
+      # is type-preserving, not type-enforcing: a String written upstream
+      # hydrates as a String and fails the strict z.number() V3 schema. The
+      # cast is a no-op for healthy records; unset secret_ttl stays -1 and
+      # unset lifespans stay nil, as before. See the longer note in
+      # secret/features/safe_dump_fields.rb and #3424.
+      # Mechanism tests: try/unit/models/secret_numeric_field_types_try.rb
+      base.safe_dump_field :secret_ttl, ->(m) { m.secret_ttl.to_i > 0 ? m.secret_ttl.to_i : -1 }
+      base.safe_dump_field :metadata_ttl, ->(m) { m.lifespan.to_i > 0 ? m.lifespan.to_i : nil }
+      base.safe_dump_field :receipt_ttl, ->(m) { m.lifespan.to_i > 0 ? m.lifespan.to_i : nil }
+      base.safe_dump_field :lifespan, ->(m) { m.lifespan.to_i > 0 ? m.lifespan.to_i : nil }
       base.safe_dump_field :share_domain
-      base.safe_dump_field :created
-      base.safe_dump_field :updated
+      base.safe_dump_field :created, ->(m) { m.created&.to_i }
+      base.safe_dump_field :updated, ->(m) { m.updated&.to_i }
       base.safe_dump_field :shared
       # Obscure recipient emails at serialization time so the raw address
       # never reaches the frontend, while the underlying record keeps the

--- a/lib/onetime/models/receipt/features/safe_dump_fields.rb
+++ b/lib/onetime/models/receipt/features/safe_dump_fields.rb
@@ -63,20 +63,20 @@ module Onetime::Receipt::Features
         }
       base.safe_dump_field :secret_identifier
 
-      # Numeric fields are cast at this boundary because Familia v2 storage
-      # is type-preserving, not type-enforcing: a String written upstream
-      # hydrates as a String and fails the strict z.number() V3 schema. The
-      # cast is a no-op for healthy records; unset secret_ttl stays -1 and
-      # unset lifespans stay nil, as before. See the longer note in
-      # secret/features/safe_dump_fields.rb and #3424.
-      # Mechanism tests: try/unit/models/secret_numeric_field_types_try.rb
+      # Cast numeric fields at the serialization boundary — see the full note
+      # in secret/features/safe_dump_fields.rb (#3424). TTL/lifespan use to_i
+      # (lossless integer-second durations; secret_ttl keeps -1 and lifespan
+      # keeps nil when unset). created/updated use to_f, NOT to_i, to preserve
+      # the sub-second precision that matters when these values are used as
+      # sorted-set scores. Detector:
+      # scripts/diagnostics/detect_string_typed_numerics.rb
       base.safe_dump_field :secret_ttl, ->(m) { m.secret_ttl.to_i > 0 ? m.secret_ttl.to_i : -1 }
       base.safe_dump_field :metadata_ttl, ->(m) { m.lifespan.to_i > 0 ? m.lifespan.to_i : nil }
       base.safe_dump_field :receipt_ttl, ->(m) { m.lifespan.to_i > 0 ? m.lifespan.to_i : nil }
       base.safe_dump_field :lifespan, ->(m) { m.lifespan.to_i > 0 ? m.lifespan.to_i : nil }
       base.safe_dump_field :share_domain
-      base.safe_dump_field :created, ->(m) { m.created&.to_i }
-      base.safe_dump_field :updated, ->(m) { m.updated&.to_i }
+      base.safe_dump_field :created, ->(m) { m.created&.to_f }
+      base.safe_dump_field :updated, ->(m) { m.updated&.to_f }
       base.safe_dump_field :shared
       # Obscure recipient emails at serialization time so the raw address
       # never reaches the frontend, while the underlying record keeps the

--- a/lib/onetime/models/secret/features/safe_dump_fields.rb
+++ b/lib/onetime/models/secret/features/safe_dump_fields.rb
@@ -37,23 +37,29 @@ module Onetime::Secret::Features
       base.safe_dump_field :shortid, ->(obj) { obj.shortid }
       base.safe_dump_field :state
 
-      # Numeric fields are cast at this boundary because Familia v2 storage
-      # is type-preserving, not type-enforcing: a record written with String
-      # values anywhere upstream (unconverted params, console writes, raw
-      # HSET) hydrates those Strings right back, and the V3 API schema
-      # rejects the payload — z.number() does not coerce "604800", so the
-      # recipient sees "no longer available" for a secret that was never
-      # consumed (#3424). The cast is a no-op for healthy records and
-      # guarantees the wire type either way; unset lifespans stay nil.
-      # Longer term this belongs in proactive coercion at write/load time
-      # rather than at the last mile.
+      # Cast numeric fields at this boundary: Familia v2 storage is
+      # type-preserving, not type-enforcing, so a value written as a Ruby
+      # String anywhere upstream (unconverted params, console writes, raw
+      # HSET) hydrates back as a String, and the strict z.number() V3 schema
+      # then rejects the whole payload — the recipient sees "no longer
+      # available" for a secret that was never consumed (#3424). The cast is
+      # a no-op for healthy records and neutralizes poisoned ones either way.
+      #   - lifespan / *_ttl are integer-second durations: to_i is lossless,
+      #     and the > 0 guard preserves nil/-1 for unset values.
+      #   - created / updated are float epoch seconds (Familia.now): to_f, NOT
+      #     to_i. These values double as sorted-set scores, so truncating the
+      #     sub-second precision would reorder range queries. The contract is
+      #     z.number(), which accepts either, so we keep the fuller value.
+      # Longer term this belongs in proactive coercion at write/load time, not
+      # at the last mile. A read-only detector for already-poisoned records
+      # lives in scripts/diagnostics/detect_string_typed_numerics.rb.
       # Mechanism tests: try/unit/models/secret_numeric_field_types_try.rb
       base.safe_dump_field :secret_ttl, ->(m) { m.lifespan.to_i > 0 ? m.lifespan.to_i : nil }
       base.safe_dump_field :lifespan, ->(m) { m.lifespan.to_i > 0 ? m.lifespan.to_i : nil }
       base.safe_dump_field :has_passphrase, ->(m) { m.has_passphrase? }
       base.safe_dump_field :verification, ->(m) { m.verification? }
-      base.safe_dump_field :created, ->(m) { m.created&.to_i }
-      base.safe_dump_field :updated, ->(m) { m.updated&.to_i }
+      base.safe_dump_field :created, ->(m) { m.created&.to_f }
+      base.safe_dump_field :updated, ->(m) { m.updated&.to_f }
 
       # State boolean fields - canonical names
       base.safe_dump_field :is_previewed, ->(m) { m.state?(:previewed) }

--- a/lib/onetime/models/secret/features/safe_dump_fields.rb
+++ b/lib/onetime/models/secret/features/safe_dump_fields.rb
@@ -36,12 +36,24 @@ module Onetime::Secret::Features
       base.safe_dump_field :key, ->(obj) { obj.identifier }
       base.safe_dump_field :shortid, ->(obj) { obj.shortid }
       base.safe_dump_field :state
-      base.safe_dump_field :secret_ttl, ->(m) { m.lifespan }
-      base.safe_dump_field :lifespan
+
+      # Numeric fields are cast at this boundary because Familia v2 storage
+      # is type-preserving, not type-enforcing: a record written with String
+      # values anywhere upstream (unconverted params, console writes, raw
+      # HSET) hydrates those Strings right back, and the V3 API schema
+      # rejects the payload — z.number() does not coerce "604800", so the
+      # recipient sees "no longer available" for a secret that was never
+      # consumed (#3424). The cast is a no-op for healthy records and
+      # guarantees the wire type either way; unset lifespans stay nil.
+      # Longer term this belongs in proactive coercion at write/load time
+      # rather than at the last mile.
+      # Mechanism tests: try/unit/models/secret_numeric_field_types_try.rb
+      base.safe_dump_field :secret_ttl, ->(m) { m.lifespan.to_i > 0 ? m.lifespan.to_i : nil }
+      base.safe_dump_field :lifespan, ->(m) { m.lifespan.to_i > 0 ? m.lifespan.to_i : nil }
       base.safe_dump_field :has_passphrase, ->(m) { m.has_passphrase? }
       base.safe_dump_field :verification, ->(m) { m.verification? }
-      base.safe_dump_field :created
-      base.safe_dump_field :updated
+      base.safe_dump_field :created, ->(m) { m.created&.to_i }
+      base.safe_dump_field :updated, ->(m) { m.updated&.to_i }
 
       # State boolean fields - canonical names
       base.safe_dump_field :is_previewed, ->(m) { m.state?(:previewed) }

--- a/scripts/diagnostics/detect_string_typed_numerics.rb
+++ b/scripts/diagnostics/detect_string_typed_numerics.rb
@@ -1,0 +1,165 @@
+# scripts/diagnostics/detect_string_typed_numerics.rb
+#
+# Read-only diagnostic for issue #3424. Scans Secret and Receipt records in
+# Redis and reports any whose numeric fields are stored as JSON *strings*
+# (e.g. "604800") instead of JSON numbers (604800).
+#
+# WHY THIS IS A DISTINCT CHECK FROM check_raw_email_fields.rb (#3016):
+#   #3016 looks for values that are not valid JSON at all (a bare,
+#   unquoted string). This bug is the mirror image: the value IS valid
+#   JSON, but it is a JSON string where the V3 API schema requires a JSON
+#   number. Familia v2 storage is type-preserving, so a field written as a
+#   Ruby String anywhere upstream round-trips as a String forever, and the
+#   strict z.number() V3 schema then rejects the whole secret payload — the
+#   recipient sees "no longer available" for a secret that was never
+#   consumed.
+#
+# The safe_dump boundary cast (lib/onetime/models/{secret,receipt}/features/
+# safe_dump_fields.rb) makes the API serve correct numbers regardless, so
+# this scan is for finding and locating the corruption at rest, not for
+# restoring availability. It does NOT modify any data.
+#
+# The per-record signature is the useful part for root-causing: created and
+# updated are float epoch seconds written by Familia on every save, so a
+# record whose `updated` is a clean number while `lifespan`/`created` are
+# strings was poisoned at creation and saved since; an all-strings record
+# was written once and never re-saved through the model.
+#
+# Usage standalone:
+#   bundle exec ruby scripts/diagnostics/detect_string_typed_numerics.rb
+#
+# Usage from bin/console (does NOT auto-run; call explicitly):
+#   load 'scripts/diagnostics/detect_string_typed_numerics.rb'
+#   Diagnostics::DetectStringTypedNumerics.run(verbose: true)
+#
+# frozen_string_literal: true
+
+module Diagnostics
+  module DetectStringTypedNumerics
+    extend self
+
+    # Numeric fields stored on each model (derived safe_dump fields like
+    # secret_ttl on Secret or metadata_ttl on Receipt are computed from these
+    # and need no separate check).
+    MODELS = {
+      'secret' => { match: 'secret:*:object', fields: %w[lifespan created updated] },
+      'receipt' => { match: 'receipt:*:object', fields: %w[secret_ttl lifespan created updated] },
+    }.freeze
+
+    # True when a stored Redis value is valid JSON whose parsed Ruby type is
+    # a String. That is the #3424 poison: "604800" parses to the String
+    # "604800", not the Integer 604800.
+    #
+    # Returns false for:
+    #   - nil / empty (unset field)
+    #   - bare JSON numbers ("604800" without quotes parses to a number)
+    #   - bare non-JSON strings (those are #3016's concern; parse raises here)
+    def string_typed_numeric?(raw)
+      return false if raw.nil? || raw.empty?
+
+      Familia::JsonSerializer.parse(raw).is_a?(String)
+    rescue JSON::ParserError, Familia::SerializerError
+      false
+    end
+
+    # Given a model's raw hgetall hash, return the subset of the supplied
+    # numeric field names whose stored value is a JSON string.
+    def poisoned_fields(fields, field_names)
+      field_names.select { |name| string_typed_numeric?(fields[name]) }
+    end
+
+    def run(sample_limit: 10, verbose: false)
+      redis  = Familia.dbclient
+      report = {}
+
+      MODELS.each do |model, spec|
+        report[model] = scan_model(redis, model, spec, sample_limit)
+      end
+
+      print_report(report, sample_limit, verbose)
+      report
+    end
+
+    private
+
+    def scan_model(redis, model, spec, sample_limit)
+      result = { total: 0, poisoned: 0, by_field: Hash.new(0), samples: [] }
+
+      redis.scan_each(match: spec[:match], count: 200) do |key|
+        next unless redis.type(key) == 'hash'
+
+        result[:total] += 1
+        if (result[:total] % 1000).zero?
+          $stderr.print "\rScanned #{result[:total]} #{model} records..."
+        end
+
+        fields = redis.hgetall(key)
+        bad    = poisoned_fields(fields, spec[:fields])
+        next if bad.empty?
+
+        result[:poisoned]                         += 1
+        bad.each { |name| result[:by_field][name] += 1 }
+        next unless result[:samples].size < sample_limit
+
+        result[:samples] << {
+          key: key,
+          poisoned_fields: bad,
+          stored: bad.to_h { |name| [name, fields[name]] },
+          # Signature: was `updated` healed by a later save while other fields
+          # stayed poisoned? Helps distinguish poisoned-at-create from a writer
+          # that bypasses the model entirely.
+          updated_healthy: !string_typed_numeric?(fields['updated']) && !fields['updated'].to_s.empty?,
+        }
+      end
+
+      $stderr.print "\r" if result[:total] >= 1000
+      result
+    end
+
+    def print_report(report, sample_limit, verbose)
+      puts '=' * 60
+      puts 'String-Typed Numeric Field Diagnostic (#3424)'
+      puts '=' * 60
+      puts
+
+      total_poisoned = report.values.sum { |r| r[:poisoned] }
+
+      report.each do |model, r|
+        puts "#{model}: #{r[:poisoned]} poisoned of #{r[:total]} scanned"
+        r[:by_field].sort.each { |name, count| puts "    #{name}: #{count}" }
+      end
+      puts
+
+      if total_poisoned.zero?
+        puts '(No string-typed numeric fields found — keyspace is clean.)'
+        return
+      end
+
+      report.each do |model, r|
+        next if r[:samples].empty?
+
+        puts '-' * 60
+        puts "Sample #{model} records (#{[r[:poisoned], sample_limit].min} of #{r[:poisoned]}):"
+        puts '-' * 60
+        r[:samples].each_with_index do |sample, i|
+          puts "  #{i + 1}. key: #{sample[:key]}"
+          puts "     poisoned: #{sample[:poisoned_fields].join(', ')}"
+          puts "     updated healed by later save: #{sample[:updated_healthy]}"
+          if verbose
+            sample[:stored].each { |name, value| puts "       #{name}: #{value}" }
+          end
+          puts
+        end
+      end
+    end
+  end
+end
+
+# Auto-run only on direct execution. Deliberately NOT keyed on defined?(OT):
+# requiring this file (e.g. from a tryout) must not trigger a full keyspace
+# scan. From a console, call Diagnostics::DetectStringTypedNumerics.run.
+if __FILE__ == $PROGRAM_NAME
+  require_relative '../../lib/onetime'
+  OT.boot! :cli
+  Diagnostics::DetectStringTypedNumerics.run(verbose: true)
+end

--- a/scripts/diagnostics/detect_string_typed_numerics.rb
+++ b/scripts/diagnostics/detect_string_typed_numerics.rb
@@ -68,12 +68,15 @@ module Diagnostics
       field_names.select { |name| string_typed_numeric?(fields[name]) }
     end
 
-    def run(sample_limit: 10, verbose: false)
+    # scan_count is the Redis SCAN COUNT hint per iteration; raise it for
+    # large keyspaces to reduce round-trips (at the cost of longer
+    # individual SCAN calls on the server).
+    def run(sample_limit: 10, verbose: false, scan_count: 200)
       redis  = Familia.dbclient
       report = {}
 
       MODELS.each do |model, spec|
-        report[model] = scan_model(redis, model, spec, sample_limit)
+        report[model] = scan_model(redis, model, spec, sample_limit, scan_count)
       end
 
       print_report(report, sample_limit, verbose)
@@ -82,10 +85,10 @@ module Diagnostics
 
     private
 
-    def scan_model(redis, model, spec, sample_limit)
+    def scan_model(redis, model, spec, sample_limit, scan_count)
       result = { total: 0, poisoned: 0, by_field: Hash.new(0), samples: [] }
 
-      redis.scan_each(match: spec[:match], count: 200) do |key|
+      redis.scan_each(match: spec[:match], count: scan_count) do |key|
         next unless redis.type(key) == 'hash'
 
         result[:total] += 1

--- a/src/tests/stores/secrets/secretStoreFieldHandling.spec.ts
+++ b/src/tests/stores/secrets/secretStoreFieldHandling.spec.ts
@@ -211,12 +211,16 @@ describe('secretStore', () => {
     });
 
     // Issue #3424: a backend record whose numeric fields were written as
-    // Ruby Strings (Familia v2 preserves the written type) serializes as
-    // {"lifespan":"604800",...}. The V3 schema is strict z.number() with no
-    // coercion, so parsing must fail — the store surfaces a fetch error,
-    // record stays null, and the recipient sees UnknownSecret ("no longer
-    // available") even though the backend returned 200 and the secret was
-    // never consumed. Backend-side reproduction of the same mechanism:
+    // Ruby Strings (Familia v2 preserves the written type) used to
+    // serialize as {"lifespan":"604800",...}. The V3 schema is strict
+    // z.number() with no coercion, so parsing fails — the store surfaces a
+    // fetch error, record stays null, and the recipient sees UnknownSecret
+    // ("no longer available") even though the backend returned 200 and the
+    // secret was never consumed. Current backends cast these fields at the
+    // safe_dump boundary, so string payloads can only come from older or
+    // third-party servers — and the schema intentionally stays strict
+    // rather than papering over them with coercion. Backend-side
+    // reproduction + cast regression tests:
     // try/unit/models/secret_numeric_field_types_try.rb
     describe('numeric field wire types (issue #3424)', () => {
       it('rejects string-typed lifespan/secret_ttl (V3 z.number() does not coerce)', async () => {

--- a/src/tests/stores/secrets/secretStoreFieldHandling.spec.ts
+++ b/src/tests/stores/secrets/secretStoreFieldHandling.spec.ts
@@ -210,6 +210,62 @@ describe('secretStore', () => {
       });
     });
 
+    // Issue #3424: a backend record whose numeric fields were written as
+    // Ruby Strings (Familia v2 preserves the written type) serializes as
+    // {"lifespan":"604800",...}. The V3 schema is strict z.number() with no
+    // coercion, so parsing must fail — the store surfaces a fetch error,
+    // record stays null, and the recipient sees UnknownSecret ("no longer
+    // available") even though the backend returned 200 and the secret was
+    // never consumed. Backend-side reproduction of the same mechanism:
+    // try/unit/models/secret_numeric_field_types_try.rb
+    describe('numeric field wire types (issue #3424)', () => {
+      it('rejects string-typed lifespan/secret_ttl (V3 z.number() does not coerce)', async () => {
+        const response = {
+          ...mockSecretResponse,
+          record: {
+            ...mockSecretResponse.record,
+            lifespan: '604800',
+            secret_ttl: '604800',
+          },
+        };
+        axiosMock?.onGet('/api/v3/secret/abc123').reply(200, response);
+
+        // "604800" fails where 604800 would pass
+        await expect(store.fetch('abc123')).rejects.toThrow();
+      });
+
+      it('rejects string-typed created/updated timestamps', async () => {
+        const response = {
+          ...mockSecretResponse,
+          record: {
+            ...mockSecretResponse.record,
+            created: '1735142814.123456',
+            updated: '1735204014',
+          },
+        };
+        axiosMock?.onGet('/api/v3/secret/abc123').reply(200, response);
+
+        await expect(store.fetch('abc123')).rejects.toThrow();
+      });
+
+      it('accepts float timestamps (Familia.now writes float epoch seconds)', async () => {
+        const response = {
+          ...mockSecretResponse,
+          record: {
+            ...mockSecretResponse.record,
+            created: 1735142814.71047,
+            updated: 1735204014.123456,
+          },
+        };
+        axiosMock?.onGet('/api/v3/secret/abc123').reply(200, response);
+
+        await store.fetch('abc123');
+        const created = store.record?.created;
+        expect(created).toBeInstanceOf(Date);
+        expect(Math.floor(created!.getTime() / 1000)).toBe(1735142814);
+      });
+    });
+
     describe('field interaction', () => {
       it('preserves both fields through store operations', async () => {
         // Setup initial state

--- a/try/unit/models/secret_numeric_field_types_try.rb
+++ b/try/unit/models/secret_numeric_field_types_try.rb
@@ -240,6 +240,25 @@ unsaved = Onetime::Secret.new(owner_id: 'anon')
 unsaved.safe_dump[:lifespan]
 #=> nil
 
+## Degenerate case: a JSON-quoted empty string at rest ('""', a writer
+## assigned a Ruby "") hydrates as "" and dumps as 0.0. Deliberate:
+## created/updated are NON-nullable z.number() in the V3 secret and
+## receipt shapes, so emitting nil here would fail gracefulParse and make
+## the record unreachable again -- a wrong-but-parseable epoch-0 keeps it
+## viewable. The detector flags these records (see part 6).
+@redis.hset(@sticky.dbkey, 'created', '""')
+loaded = Onetime::Secret.load(@sticky.objid)
+[loaded.created, loaded.safe_dump[:created]]
+#=> ['', 0.0]
+
+## Truly empty bytes at rest ('') are a different case: Familia's
+## deserialize_value treats them as unset and hydrates nil, so the
+## nil-safe cast dumps nil, never 0.0
+@redis.hset(@sticky.dbkey, 'created', '')
+loaded = Onetime::Secret.load(@sticky.objid)
+[loaded.created, loaded.safe_dump[:created]]
+#=> [nil, nil]
+
 # ------------------------------------------------------------------
 # 6. Detector. The boundary cast fixes the wire but leaves the at-rest
 #    bytes corrupt, so scripts/diagnostics/detect_string_typed_numerics.rb
@@ -264,6 +283,12 @@ unsaved.safe_dump[:lifespan]
 ## nil and empty (unset field) are not flagged
 [@detector.string_typed_numeric?(nil), @detector.string_typed_numeric?('')]
 #=> [false, false]
+
+## A JSON-quoted EMPTY string at rest IS flagged: the raw bytes '""' are
+## not empty, and they parse to a Ruby String -- so the degenerate
+## records from part 5 do surface in a scan
+@detector.string_typed_numeric?('""')
+#=> true
 
 ## A bare non-JSON string is NOT this bug -- that is #3016's detector
 @detector.string_typed_numeric?('anon')

--- a/try/unit/models/secret_numeric_field_types_try.rb
+++ b/try/unit/models/secret_numeric_field_types_try.rb
@@ -35,11 +35,16 @@
 #    encodes whatever Ruby type the application assigned. Assign a String
 #    (an unconverted form param, config value, console fix, or any code
 #    path that calls hset with a quoted value) and the record is poisoned:
-#    it hydrates as String on every subsequent load, safe_dump passes the
-#    String through unchanged (no cast at the serialization boundary), and
-#    every V3 GET for that record fails schema validation forever. The
-#    recipient flow never heals it: previewed! uses save_fields(:state),
-#    which rewrites only the state field.
+#    it hydrates as String on every subsequent load. The recipient flow
+#    never heals it: previewed! uses save_fields(:state), which rewrites
+#    only the state field.
+#
+# MITIGATION (#3424): the safe_dump lambdas in Secret and Receipt now cast
+# the numeric fields at the serialization boundary (lifespan/secret_ttl
+# via to_i with nil/-1 preserved for unset, created/updated via &.to_i).
+# Hydration is intentionally untouched -- getters still return whatever
+# type is at rest (parts 3 and 4 below pin that) -- but the wire format is
+# numeric even for poisoned records, so the V3 schema passes either way.
 #
 # The companion frontend test (string-typed lifespan/created rejected by
 # the V3 schema) lives in:
@@ -83,9 +88,10 @@ loaded = Onetime::Secret.load(@secret.objid)
 #=> [Float, Float]
 
 ## safe_dump emits native numeric types for all four V3 z.number() fields
+## (the boundary cast truncates float timestamps to whole epoch seconds)
 sd = Onetime::Secret.load(@secret.objid).safe_dump
 [sd[:lifespan].class, sd[:secret_ttl].class, sd[:created].class, sd[:updated].class]
-#=> [Integer, Integer, Float, Float]
+#=> [Integer, Integer, Integer, Integer]
 
 ## The rendered JSON carries unquoted numbers -- this payload passes the
 ## V3 schema (lifespan: z.number(), secret_ttl: z.number())
@@ -99,14 +105,14 @@ fresh = Onetime::Secret.load(@secret.objid)
 fresh.previewed!
 sd = Onetime::Secret.load(@secret.objid).safe_dump
 [sd[:state], sd[:lifespan].class, sd[:created].class]
-#=> ['previewed', Integer, Float]
+#=> ['previewed', Integer, Integer]
 
 ## Receipt safe_dump numeric fields are natively typed too
 ## (lifespan, secret_ttl, metadata_ttl, receipt_ttl, created, updated)
 sd = Onetime::Receipt.load(@receipt.objid).safe_dump
 [sd[:lifespan].class, sd[:secret_ttl].class, sd[:metadata_ttl].class,
  sd[:receipt_ttl].class, sd[:created].class, sd[:updated].class,]
-#=> [Integer, Integer, Integer, Integer, Float, Float]
+#=> [Integer, Integer, Integer, Integer, Integer, Integer]
 
 # ------------------------------------------------------------------
 # 2. Ruling out bare bytes at rest (v1-era raw values, and the
@@ -129,12 +135,18 @@ loaded = Onetime::Secret.load(@secret.objid)
 
 # ------------------------------------------------------------------
 # 3. THE REPRODUCTION. JSON-quoted numeric strings at rest are the
-#    only state that produces the #3424 payload. deserialize_value
-#    faithfully returns a Ruby String, and safe_dump has no cast at
-#    the boundary, so the String goes straight to the wire.
+#    only state that produces the #3424 payload: deserialize_value
+#    faithfully returns a Ruby String. Before the boundary cast,
+#    safe_dump passed that String straight to the wire
+#    ('{"lifespan":"604800"}'), which strict z.number() rejects --
+#    gracefulParse threw, record stayed null, and the recipient saw
+#    UnknownSecret ("That information is no longer available"). The
+#    cast now neutralizes the poison at serialization time.
 # ------------------------------------------------------------------
 
-## JSON-quoted numeric bytes (quote bytes included) hydrate as String
+## JSON-quoted numeric bytes (quote bytes included) hydrate as String --
+## the poisoned state. Hydration is intentionally not coerced; only the
+## safe_dump boundary is.
 @redis.hset(@secret_key, 'lifespan', '"604800"')
 @redis.hset(@secret_key, 'created', '"1735142814.123456"')
 @redis.hset(@secret_key, 'updated', '"1735204014"')
@@ -142,18 +154,17 @@ loaded = Onetime::Secret.load(@secret.objid)
 [loaded.lifespan.class, loaded.created.class, loaded.updated.class]
 #=> [String, String, String]
 
-## safe_dump passes the Strings through unchanged -- the exact field
-## values reported in #3424 (strings where the V3 schema wants numbers)
+## The boundary cast recovers native Integers from the poisoned record,
+## so the V3 payload carries numbers despite the Strings underneath
 sd = Onetime::Secret.load(@secret.objid).safe_dump
 [sd[:lifespan], sd[:secret_ttl], sd[:created], sd[:updated]]
-#=> ['604800', '604800', '1735142814.123456', '1735204014']
+#=> [604800, 604800, 1735142814, 1735204014]
 
-## The rendered JSON now carries quoted numerics. z.number() does not
-## coerce, so gracefulParse throws, record stays null, and the recipient
-## sees UnknownSecret ("That information is no longer available")
+## The rendered JSON is unquoted -- this payload passes the strict
+## z.number() fields of the V3 schema even for a poisoned record
 sd = Onetime::Secret.load(@secret.objid).safe_dump
 Familia::JsonSerializer.dump(lifespan: sd[:lifespan], secret_ttl: sd[:secret_ttl])
-#=> '{"lifespan":"604800","secret_ttl":"604800"}'
+#=> '{"lifespan":604800,"secret_ttl":604800}'
 
 # ------------------------------------------------------------------
 # 4. The writer mechanism: how an environment gets into that state.
@@ -187,18 +198,20 @@ loaded = Onetime::Secret.load(@sticky.objid)
 #=> [String, Float, String]
 
 ## The recipient flow cannot heal a poisoned record either: previewed!
-## writes only the state field, so the String survives to the V3 payload
+## writes only the state field. The String survives at rest -- but the
+## boundary cast keeps the V3 payload numeric regardless
 poisoned = Onetime::Secret.load(@poisoned.objid)
 poisoned.previewed!
-Onetime::Secret.load(@poisoned.objid).safe_dump[:lifespan]
-#=> '604800'
+reloaded = Onetime::Secret.load(@poisoned.objid)
+[reloaded.lifespan.class, reloaded.safe_dump[:lifespan]]
+#=> [String, 604800]
 
 # ------------------------------------------------------------------
-# 5. Fix verification harness. The boundary cast proposed in #3268 /
-#    #3424 normalizes poisoned records and is a no-op for healthy
-#    ones, so it would make safe_dump output schema-valid either way.
-#    (Not applied to the model here -- this documents the behavior a
-#    fix must satisfy.)
+# 5. Cast semantics pinned at the getter level. The safe_dump lambdas
+#    in secret/features/safe_dump_fields.rb (and the receipt mirror)
+#    rely on to_i recovering Integers from poisoned Strings while
+#    being a no-op for healthy values, with nil preserved for unset
+#    lifespans. These cases pin that contract.
 # ------------------------------------------------------------------
 
 ## to_i recovers native Integers from a poisoned record's String fields
@@ -211,6 +224,12 @@ loaded = Onetime::Secret.load(@poisoned.objid)
 value = Onetime::Secret.load(@secret2.objid).lifespan
 [value, value.to_i]
 #=> [3600, 3600]
+
+## An unset lifespan stays nil on the wire (not 0): the V3 null-rejection
+## path for legacy records is unchanged by the cast
+unsaved = Onetime::Secret.new(owner_id: 'anon')
+unsaved.safe_dump[:lifespan]
+#=> nil
 
 # TEARDOWN
 

--- a/try/unit/models/secret_numeric_field_types_try.rb
+++ b/try/unit/models/secret_numeric_field_types_try.rb
@@ -1,0 +1,222 @@
+# try/unit/models/secret_numeric_field_types_try.rb
+#
+# frozen_string_literal: true
+
+# Reproduction + mechanism isolation for issue #3424 (follow-up to #3268):
+# "Secrets immediately show 'no longer available' / marked previewed, never
+# viewable (V3 schema numeric type mismatch)".
+#
+# Reported symptom: GET /api/v3/guest/secret/:identifier returns 200, but
+# `lifespan`, `secret_ttl`, `created` and `updated` arrive as JSON strings
+# ("604800") instead of numbers (604800). The V3 Zod schema declares these
+# fields z.number() (strict, no coercion), so gracefulParse throws, the
+# record stays null, and the recipient sees UnknownSecret even though the
+# secret was never consumed.
+#
+# These tests isolate the exact mechanism by checking types at every
+# boundary against a real database: at-rest bytes -> hydrated getters ->
+# safe_dump -> rendered JSON. Three findings:
+#
+# 1. The default write path is fully typed. spawn_pair stores lifespan as a
+#    bare JSON integer and created/updated as bare JSON floats (Familia.now
+#    is Float). Hydration parses them back to Integer/Float, and safe_dump
+#    emits native numbers. This is why the bug does not reproduce in a
+#    clean environment (delano's result on #3268).
+#
+# 2. Bare numeric bytes at rest are NOT the mechanism. Familia v2's
+#    deserializer (Oj :strict) parses unquoted bytes like "604800" or
+#    "1735142814.123456" to Integer/Float. So v1-era raw values, and the
+#    hypothesis that "floats stored as strings don't hydrate back as
+#    floats", are both ruled out.
+#
+# 3. The ONLY at-rest state that reproduces the reported payload is a
+#    JSON-QUOTED numeric string ('"604800"', quote bytes included). Familia
+#    v2's serializer is type-preserving by contract: serialize_value JSON-
+#    encodes whatever Ruby type the application assigned. Assign a String
+#    (an unconverted form param, config value, console fix, or any code
+#    path that calls hset with a quoted value) and the record is poisoned:
+#    it hydrates as String on every subsequent load, safe_dump passes the
+#    String through unchanged (no cast at the serialization boundary), and
+#    every V3 GET for that record fails schema validation forever. The
+#    recipient flow never heals it: previewed! uses save_fields(:state),
+#    which rewrites only the state field.
+#
+# The companion frontend test (string-typed lifespan/created rejected by
+# the V3 schema) lives in:
+#   src/tests/stores/secrets/secretStoreFieldHandling.spec.ts
+#
+# See also: try/unit/models/customer_field_serialization_try.rb (#3016),
+# the mirror-image bug where writers bypassed JSON serialization.
+
+require_relative '../../support/test_models'
+
+OT.boot! :test, true
+
+@redis = Familia.dbclient
+@lifespan = 604_800
+@receipt, @secret = Onetime::Receipt.spawn_pair('anon', @lifespan, 'numeric type fidelity probe')
+@secret_key = @secret.dbkey
+
+# ------------------------------------------------------------------
+# 1. Healthy write path: spawn_pair -> at-rest bytes -> load ->
+#    safe_dump. Everything is natively typed. This codifies why the
+#    bug does NOT reproduce in a clean environment.
+# ------------------------------------------------------------------
+
+## At rest, lifespan is stored as a bare JSON integer (no quote bytes)
+@redis.hget(@secret_key, 'lifespan')
+#=> '604800'
+
+## At rest, created is a bare JSON float: Familia.now (Float seconds),
+## written by prepare_for_save, serialized without quotes
+raw = @redis.hget(@secret_key, 'created')
+[raw.start_with?('"'), raw.match?(/\A\d+\.\d+\z/)]
+#=> [false, true]
+
+## A fresh load hydrates lifespan back as Integer
+Onetime::Secret.load(@secret.objid).lifespan
+#=> 604800
+
+## A fresh load hydrates created/updated back as Float
+loaded = Onetime::Secret.load(@secret.objid)
+[loaded.created.class, loaded.updated.class]
+#=> [Float, Float]
+
+## safe_dump emits native numeric types for all four V3 z.number() fields
+sd = Onetime::Secret.load(@secret.objid).safe_dump
+[sd[:lifespan].class, sd[:secret_ttl].class, sd[:created].class, sd[:updated].class]
+#=> [Integer, Integer, Float, Float]
+
+## The rendered JSON carries unquoted numbers -- this payload passes the
+## V3 schema (lifespan: z.number(), secret_ttl: z.number())
+sd = Onetime::Secret.load(@secret.objid).safe_dump
+Familia::JsonSerializer.dump(lifespan: sd[:lifespan], secret_ttl: sd[:secret_ttl])
+#=> '{"lifespan":604800,"secret_ttl":604800}'
+
+## previewed! (the exact ShowSecret flow the recipient triggers) only
+## rewrites state via save_fields(:state); numeric fields keep their types
+fresh = Onetime::Secret.load(@secret.objid)
+fresh.previewed!
+sd = Onetime::Secret.load(@secret.objid).safe_dump
+[sd[:state], sd[:lifespan].class, sd[:created].class]
+#=> ['previewed', Integer, Float]
+
+## Receipt safe_dump numeric fields are natively typed too
+## (lifespan, secret_ttl, metadata_ttl, receipt_ttl, created, updated)
+sd = Onetime::Receipt.load(@receipt.objid).safe_dump
+[sd[:lifespan].class, sd[:secret_ttl].class, sd[:metadata_ttl].class,
+ sd[:receipt_ttl].class, sd[:created].class, sd[:updated].class,]
+#=> [Integer, Integer, Integer, Integer, Float, Float]
+
+# ------------------------------------------------------------------
+# 2. Ruling out bare bytes at rest (v1-era raw values, and the
+#    "floats stored as strings don't hydrate as floats" hypothesis
+#    from the issue thread). Oj :strict parses bare numeric bytes
+#    to native numbers, so these are NOT the mechanism.
+# ------------------------------------------------------------------
+
+## Bare integer bytes (v1-style raw hset, no JSON quotes) hydrate as Integer
+@redis.hset(@secret_key, 'lifespan', '86400')
+Onetime::Secret.load(@secret.objid).lifespan
+#=> 86400
+
+## Bare float bytes hydrate as Float -- a float stored as an unquoted
+## string DOES come back as a Float
+@redis.hset(@secret_key, 'created', '1735142814.123456')
+loaded = Onetime::Secret.load(@secret.objid)
+[loaded.created.class, loaded.created]
+#=> [Float, 1735142814.123456]
+
+# ------------------------------------------------------------------
+# 3. THE REPRODUCTION. JSON-quoted numeric strings at rest are the
+#    only state that produces the #3424 payload. deserialize_value
+#    faithfully returns a Ruby String, and safe_dump has no cast at
+#    the boundary, so the String goes straight to the wire.
+# ------------------------------------------------------------------
+
+## JSON-quoted numeric bytes (quote bytes included) hydrate as String
+@redis.hset(@secret_key, 'lifespan', '"604800"')
+@redis.hset(@secret_key, 'created', '"1735142814.123456"')
+@redis.hset(@secret_key, 'updated', '"1735204014"')
+loaded = Onetime::Secret.load(@secret.objid)
+[loaded.lifespan.class, loaded.created.class, loaded.updated.class]
+#=> [String, String, String]
+
+## safe_dump passes the Strings through unchanged -- the exact field
+## values reported in #3424 (strings where the V3 schema wants numbers)
+sd = Onetime::Secret.load(@secret.objid).safe_dump
+[sd[:lifespan], sd[:secret_ttl], sd[:created], sd[:updated]]
+#=> ['604800', '604800', '1735142814.123456', '1735204014']
+
+## The rendered JSON now carries quoted numerics. z.number() does not
+## coerce, so gracefulParse throws, record stays null, and the recipient
+## sees UnknownSecret ("That information is no longer available")
+sd = Onetime::Secret.load(@secret.objid).safe_dump
+Familia::JsonSerializer.dump(lifespan: sd[:lifespan], secret_ttl: sd[:secret_ttl])
+#=> '{"lifespan":"604800","secret_ttl":"604800"}'
+
+# ------------------------------------------------------------------
+# 4. The writer mechanism: how an environment gets into that state.
+#    Familia v2's contract is "the type you save is the type you get
+#    back". JSON field serialization preserves application types; it
+#    does not normalize numeric strings. One stringly-typed writer
+#    poisons the record permanently.
+# ------------------------------------------------------------------
+
+## Assigning a String lifespan (an unconverted param/config value)
+## stores JSON-quoted bytes -- the poisoned at-rest state from part 3
+@poisoned = Onetime::Secret.new(owner_id: 'anon')
+@poisoned.lifespan = '604800'
+@poisoned.save
+@redis.hget(@poisoned.dbkey, 'lifespan')
+#=> '"604800"'
+
+## ...and that record hydrates as String on every load thereafter
+Onetime::Secret.load(@poisoned.objid).lifespan.class
+#=> String
+
+## Diagnostic signature of a poisoned record: a full save() heals
+## `updated` (prepare_for_save always overwrites it with Familia.now)
+## but never `created` (set with ||=) and never `lifespan`
+@sticky = Onetime::Secret.new(owner_id: 'anon')
+@sticky.lifespan = '604800'
+@sticky.created  = '1735142814'
+@sticky.save
+loaded = Onetime::Secret.load(@sticky.objid)
+[loaded.created.class, loaded.updated.class, loaded.lifespan.class]
+#=> [String, Float, String]
+
+## The recipient flow cannot heal a poisoned record either: previewed!
+## writes only the state field, so the String survives to the V3 payload
+poisoned = Onetime::Secret.load(@poisoned.objid)
+poisoned.previewed!
+Onetime::Secret.load(@poisoned.objid).safe_dump[:lifespan]
+#=> '604800'
+
+# ------------------------------------------------------------------
+# 5. Fix verification harness. The boundary cast proposed in #3268 /
+#    #3424 normalizes poisoned records and is a no-op for healthy
+#    ones, so it would make safe_dump output schema-valid either way.
+#    (Not applied to the model here -- this documents the behavior a
+#    fix must satisfy.)
+# ------------------------------------------------------------------
+
+## to_i recovers native Integers from a poisoned record's String fields
+loaded = Onetime::Secret.load(@poisoned.objid)
+[loaded.lifespan.to_i, loaded.lifespan.to_i > 0 ? loaded.lifespan.to_i : nil]
+#=> [604800, 604800]
+
+## ...and is a no-op for a healthy record's native values
+@receipt2, @secret2 = Onetime::Receipt.spawn_pair('anon', 3600, 'healthy control')
+value = Onetime::Secret.load(@secret2.objid).lifespan
+[value, value.to_i]
+#=> [3600, 3600]
+
+# TEARDOWN
+
+@secret.delete!
+@receipt.delete!
+@secret2.delete!
+@receipt2.delete!
+@poisoned.delete!
+@sticky.delete!

--- a/try/unit/models/secret_numeric_field_types_try.rb
+++ b/try/unit/models/secret_numeric_field_types_try.rb
@@ -40,11 +40,15 @@
 #    only the state field.
 #
 # MITIGATION (#3424): the safe_dump lambdas in Secret and Receipt now cast
-# the numeric fields at the serialization boundary (lifespan/secret_ttl
-# via to_i with nil/-1 preserved for unset, created/updated via &.to_i).
-# Hydration is intentionally untouched -- getters still return whatever
-# type is at rest (parts 3 and 4 below pin that) -- but the wire format is
-# numeric even for poisoned records, so the V3 schema passes either way.
+# the numeric fields at the serialization boundary. lifespan/secret_ttl use
+# to_i (lossless integer-second durations, nil/-1 preserved for unset);
+# created/updated use to_f, NOT to_i, to keep the sub-second precision that
+# matters when those values are used as sorted-set scores. Hydration is
+# intentionally untouched -- getters still return whatever type is at rest
+# (parts 3 and 4 below pin that) -- but the wire format is numeric even for
+# poisoned records, so the V3 schema passes either way. A read-only detector
+# for finding already-poisoned records at rest lives in
+# scripts/diagnostics/detect_string_typed_numerics.rb (part 6 below).
 #
 # The companion frontend test (string-typed lifespan/created rejected by
 # the V3 schema) lives in:
@@ -54,10 +58,12 @@
 # the mirror-image bug where writers bypassed JSON serialization.
 
 require_relative '../../support/test_models'
+require_relative '../../../scripts/diagnostics/detect_string_typed_numerics'
 
 OT.boot! :test, true
 
 @redis = Familia.dbclient
+@detector = Diagnostics::DetectStringTypedNumerics
 @lifespan = 604_800
 @receipt, @secret = Onetime::Receipt.spawn_pair('anon', @lifespan, 'numeric type fidelity probe')
 @secret_key = @secret.dbkey
@@ -87,11 +93,12 @@ loaded = Onetime::Secret.load(@secret.objid)
 [loaded.created.class, loaded.updated.class]
 #=> [Float, Float]
 
-## safe_dump emits native numeric types for all four V3 z.number() fields
-## (the boundary cast truncates float timestamps to whole epoch seconds)
+## safe_dump emits native numeric types for all four V3 z.number() fields:
+## integer-second durations and float epoch-second timestamps (to_f keeps
+## the float; truncating would reorder sorted-set range queries)
 sd = Onetime::Secret.load(@secret.objid).safe_dump
 [sd[:lifespan].class, sd[:secret_ttl].class, sd[:created].class, sd[:updated].class]
-#=> [Integer, Integer, Integer, Integer]
+#=> [Integer, Integer, Float, Float]
 
 ## The rendered JSON carries unquoted numbers -- this payload passes the
 ## V3 schema (lifespan: z.number(), secret_ttl: z.number())
@@ -105,14 +112,14 @@ fresh = Onetime::Secret.load(@secret.objid)
 fresh.previewed!
 sd = Onetime::Secret.load(@secret.objid).safe_dump
 [sd[:state], sd[:lifespan].class, sd[:created].class]
-#=> ['previewed', Integer, Integer]
+#=> ['previewed', Integer, Float]
 
 ## Receipt safe_dump numeric fields are natively typed too
 ## (lifespan, secret_ttl, metadata_ttl, receipt_ttl, created, updated)
 sd = Onetime::Receipt.load(@receipt.objid).safe_dump
 [sd[:lifespan].class, sd[:secret_ttl].class, sd[:metadata_ttl].class,
  sd[:receipt_ttl].class, sd[:created].class, sd[:updated].class,]
-#=> [Integer, Integer, Integer, Integer, Integer, Integer]
+#=> [Integer, Integer, Integer, Integer, Float, Float]
 
 # ------------------------------------------------------------------
 # 2. Ruling out bare bytes at rest (v1-era raw values, and the
@@ -154,11 +161,13 @@ loaded = Onetime::Secret.load(@secret.objid)
 [loaded.lifespan.class, loaded.created.class, loaded.updated.class]
 #=> [String, String, String]
 
-## The boundary cast recovers native Integers from the poisoned record,
-## so the V3 payload carries numbers despite the Strings underneath
+## The boundary cast recovers native numbers from the poisoned record, so
+## the V3 payload carries numbers despite the Strings underneath. lifespan/
+## secret_ttl come back Integer (to_i); created/updated come back Float
+## (to_f), preserving the stored sub-second value
 sd = Onetime::Secret.load(@secret.objid).safe_dump
 [sd[:lifespan], sd[:secret_ttl], sd[:created], sd[:updated]]
-#=> [604800, 604800, 1735142814, 1735204014]
+#=> [604800, 604800, 1735142814.123456, 1735204014.0]
 
 ## The rendered JSON is unquoted -- this payload passes the strict
 ## z.number() fields of the V3 schema even for a poisoned record
@@ -231,11 +240,58 @@ unsaved = Onetime::Secret.new(owner_id: 'anon')
 unsaved.safe_dump[:lifespan]
 #=> nil
 
+# ------------------------------------------------------------------
+# 6. Detector. The boundary cast fixes the wire but leaves the at-rest
+#    bytes corrupt, so scripts/diagnostics/detect_string_typed_numerics.rb
+#    scans for records that need fixing (and helps locate the writer).
+#    It flags JSON strings where the schema wants JSON numbers -- the
+#    mirror image of #3016's detector, which flags non-JSON bytes. These
+#    pin the predicate so the scan can be trusted.
+# ------------------------------------------------------------------
+
+## A JSON-quoted numeric string (the #3424 poison) is detected
+@detector.string_typed_numeric?('"604800"')
+#=> true
+
+## A bare JSON number is healthy (parses to Integer, not String)
+@detector.string_typed_numeric?('604800')
+#=> false
+
+## A bare JSON float is healthy (parses to Float)
+@detector.string_typed_numeric?('1735142814.123456')
+#=> false
+
+## nil and empty (unset field) are not flagged
+[@detector.string_typed_numeric?(nil), @detector.string_typed_numeric?('')]
+#=> [false, false]
+
+## A bare non-JSON string is NOT this bug -- that is #3016's detector
+@detector.string_typed_numeric?('anon')
+#=> false
+
+## poisoned_fields returns only the string-typed numeric fields from a hash
+fields = { 'lifespan' => '"604800"', 'created' => '1781282977.7', 'updated' => '"1781282977"' }
+@detector.poisoned_fields(fields, %w[lifespan created updated]).sort
+#=> ['lifespan', 'updated']
+
+## End-to-end: a poisoned record's real hgetall is flagged by the detector
+raw = @redis.hgetall(@poisoned.dbkey)
+@detector.poisoned_fields(raw, %w[lifespan created updated]).include?('lifespan')
+#=> true
+
+## ...and a healthy record's hgetall is clean
+@receipt3, @secret3 = Onetime::Receipt.spawn_pair('anon', 3600, 'detector control')
+raw = @redis.hgetall(@secret3.dbkey)
+@detector.poisoned_fields(raw, %w[lifespan created updated])
+#=> []
+
 # TEARDOWN
 
 @secret.delete!
 @receipt.delete!
 @secret2.delete!
 @receipt2.delete!
+@secret3.delete!
+@receipt3.delete!
 @poisoned.delete!
 @sticky.delete!


### PR DESCRIPTION
> **\* This PR has deployment notes** (see the section below) to copy into the release notes later.

## Summary

[#3424](https://github.com/onetimesecret/onetimesecret/issues/3424)

Fixes an issue where Secret and Receipt API responses could contain numeric fields as JSON strings instead of numbers, causing the strict V3 Zod schema to reject the payload. Recipients would see "That information is no longer available" even though the secret was never consumed.

The root cause: Familia v2 storage is type-preserving, not type-enforcing. When numeric fields (lifespan, created, updated, etc.) are written as Ruby Strings anywhere upstream—unconverted form parameters, console writes, raw HSET commands—they hydrate back as Strings on every subsequent load. The V3 schema declares these fields as `z.number()` with no coercion, so `gracefulParse` fails and the record stays null.

**Solution:** Cast numeric fields at the `safe_dump` serialization boundary:
- TTL/lifespan fields (`lifespan`, `secret_ttl`, `metadata_ttl`, `receipt_ttl`) cast to integers via `to_i`, preserving nil/-1 for unset values
- Timestamp fields (`created`, `updated`) cast to floats via `to_f` to preserve sub-second precision (these values are used as sorted-set scores)

The cast is a no-op for healthy records and neutralizes poisoned ones at the wire level, ensuring the V3 schema always receives valid numbers regardless of what's stored at rest.

## Changes

- **lib/onetime/models/secret/features/safe_dump_fields.rb**: Added casting lambdas for `lifespan`, `secret_ttl`, `created`, and `updated` fields
- **lib/onetime/models/receipt/features/safe_dump_fields.rb**: Added casting lambdas for `secret_ttl`, `metadata_ttl`, `receipt_ttl`, `lifespan`, `created`, and `updated` fields
- **scripts/diagnostics/detect_string_typed_numerics.rb**: New read-only diagnostic tool to scan for and report records with string-typed numeric fields at rest
- **try/unit/models/secret_numeric_field_types_try.rb**: Comprehensive mechanism isolation tests covering healthy writes, poisoned records, cast semantics, and detector validation
- **src/tests/stores/secrets/secretStoreFieldHandling.spec.ts**: Frontend tests validating that string-typed numeric fields are rejected by the V3 schema while float timestamps are accepted

## Running the detector

`scripts/diagnostics/detect_string_typed_numerics.rb` is **read-only** — it never modifies data. It scans `secret:*:object` and `receipt:*:object` in the configured Redis/Valkey and reports which records have numeric fields stored as JSON strings.

Standalone (boots the app to pick up the configured database, then scans):

```bash
bundle exec ruby scripts/diagnostics/detect_string_typed_numerics.rb
```

From a console (does **not** auto-run; call it explicitly):

```ruby
load 'scripts/diagnostics/detect_string_typed_numerics.rb'
Diagnostics::DetectStringTypedNumerics.run(verbose: true)
```

Run it against each affected environment (e.g. preprod and prod separately). Sample output:

```
secret: 1 poisoned of 3 scanned
    lifespan: 1
receipt: 1 poisoned of 2 scanned
    lifespan: 1
    secret_ttl: 1

  1. key: secret:iv0rl2x2...:object
     poisoned: lifespan
     updated healed by later save: true
       lifespan: "604800"
```

Reading the report:
- **per-field counts** show which fields are affected and how widely.
- **`updated healed by later save`** is the root-causing signal. `created`/`updated` are float epoch seconds rewritten by Familia on every save, so `true` means the record was poisoned at creation but model-saved since (the writer set the field as a String before the first save); an all-strings record (`false`) was written once and never re-saved through the model — pointing at a path that bypasses the model entirely.

## Deployment notes

*(copy to release notes)*

- **No migration is required to restore availability.** The `safe_dump` cast takes effect as soon as this release is deployed; secrets that were unreachable due to #3424 become viewable again immediately, with no data rewrite.
- **Backward compatible.** The cast is a no-op for healthy records and only normalizes the wire format, so there is no behavior change for unaffected installs.
- **The at-rest corruption is not rewritten by this change.** Operators who experienced #3424 should run the read-only detector (above) to quantify affected records. The corrupt bytes remain in Redis, but because the API output is now correct, cleanup is non-urgent and can follow once the upstream writer is identified.
- **This is an interim fix.** Long-term, numeric coercion should move to write/load time in the model layer; the boundary cast can be removed once that lands and the keyspace has been normalized.

## Related Issues

Fixes #3424
Follows up on #3268

## Test Plan

- Comprehensive backend tryout tests in `try/unit/models/secret_numeric_field_types_try.rb` validate the cast mechanism at every boundary: at-rest bytes → hydrated getters → safe_dump → rendered JSON, and pin the detector predicate
- Frontend tests in `secretStoreFieldHandling.spec.ts` confirm the V3 schema rejects string-typed numerics while accepting valid float timestamps
- Diagnostic tool can be run standalone or from console to identify already-poisoned records in production
- Existing test suite passes; cast is transparent to healthy records (tryouts 28 + receipt_safe_dump 23 + safe_dump 4; rspec receipt + v1/v2 secrets 198 examples 0 failures; vitest store + contracts 122)

https://claude.ai/code/session_01D64mKxWuahA2t1QYue3SCj