### PR TITLE
Fix MFA QR code to encode correct HMAC secret (issue #3431)

### DIFF
--- a/apps/web/auth/config/hooks/mfa.rb
+++ b/apps/web/auth/config/hooks/mfa.rb
@@ -32,6 +32,35 @@ module Auth::Config::Hooks
       # - Verification attempts (POST with OTP code)
       #
       auth.before_otp_setup_route do
+        # ----------------------------------------------------------------
+        # Emit Rodauth's authoritative TOTP provisioning URI (issue #3431)
+        # ----------------------------------------------------------------
+        #
+        # By the time this hook body runs, Rodauth's json feature has already
+        # executed (via super) its own before_otp_setup_route, which — in the
+        # HMAC JSON flow — generates the setup secret and populates the
+        # response with:
+        #   - otp_setup_param     => otp_user_key (the HMAC'd key the
+        #                            authenticator must actually use)
+        #   - otp_setup_raw_param => the raw key, used ONLY for the setup
+        #                            handshake (NOT a valid TOTP secret)
+        #
+        # The SPA historically reconstructed the otpauth:// URI itself and, on
+        # the HMAC path, encoded the raw key — so scanned codes never matched
+        # what the server validates (otp built from otp_user_key), while the
+        # manually-displayed otp_setup key worked. We instead emit Rodauth's
+        # own otp_provisioning_uri (built from otp_user_key, with the correct
+        # issuer/digits/period) as the single source of truth, so the frontend
+        # can render the QR directly without guessing the secret or params.
+        #
+        # Rebuild the tmp OTP key from the raw secret we just handed the client
+        # so otp_provisioning_uri reflects exactly that secret, independent of
+        # any later key regeneration in the route body.
+        if otp_keys_use_hmac? && (raw_secret = json_response[otp_setup_raw_param])
+          otp_tmp_key(raw_secret)
+          json_response[:provisioning_uri] = otp_provisioning_uri
+        end
+
         is_post      = request.post?
         has_otp_code = !param_or_nil(otp_auth_param).to_s.empty?
         has_password = !param_or_nil(password_param).to_s.empty?

--- a/apps/web/auth/spec/config/features/mfa_provisioning_uri_spec.rb
+++ b/apps/web/auth/spec/config/features/mfa_provisioning_uri_spec.rb
@@ -1,0 +1,151 @@
+# apps/web/auth/spec/config/features/mfa_provisioning_uri_spec.rb
+#
+# frozen_string_literal: true
+
+# Regression coverage for issue #3431 — "MFA QR code encodes wrong secret".
+#
+# Root cause
+# ----------
+# With otp_keys_use_hmac? enabled, the secret an authenticator app must use is
+# the HMAC'd key (Rodauth's otp_user_key, surfaced in the JSON otp-setup
+# response as otp_setup), NOT the raw key (otp_raw_secret, which exists only for
+# the setup handshake). The SPA used to rebuild the otpauth:// URI itself and,
+# on the HMAC path, encoded the raw key — so scanned codes never matched what
+# the server validates, while the manually-displayed otp_setup key worked.
+#
+# Fix
+# ---
+# The backend now emits Rodauth's authoritative otp_provisioning_uri as
+# `provisioning_uri` in the otp-setup response (see
+# apps/web/auth/config/hooks/mfa.rb), and the SPA renders it directly.
+#
+# These tests exercise the mechanism through the real otp-setup route, in the
+# real feature-enable order (json before otp), with a before_otp_setup_route
+# hook mirroring the production one. They assert that:
+#   1. provisioning_uri is present and embeds the otp_setup (HMAC'd) secret,
+#   2. a code derived from provisioning_uri completes setup, and
+#   3. a code derived from otp_raw_secret is rejected (the original bug).
+
+require_relative '../../spec_helper'
+require 'rack/test'
+require 'rotp'
+require 'bcrypt'
+require 'cgi'
+
+require_relative '../../support/auth_test_constants'
+include AuthTestConstants
+
+RSpec.describe 'MFA otp-setup provisioning_uri (issue #3431)' do
+  include Rack::Test::Methods
+
+  let(:db) { create_test_database }
+  let(:password) { 'correct horse battery staple' }
+
+  let(:account_id) do
+    id = db[:accounts].insert(email: 'mfa-user@example.com', status_id: STATUS_VERIFIED)
+    db[:account_password_hashes].insert(id: id, password_hash: BCrypt::Password.create(password))
+    id
+  end
+
+  let(:app) do
+    app_db = db
+    # Build the Roda app inline (rather than via the create_rodauth_app helper)
+    # so we can add :json_parser — the SPA posts JSON request bodies, and
+    # only_json? rejects non-JSON requests. The feature-enable order mirrors
+    # production: :json (base.rb) is enabled before :otp (mfa.rb), which is what
+    # makes the configured before_otp_setup_route hook run AFTER Rodauth's json
+    # feature has populated the setup secrets.
+    Class.new(Roda) do
+      plugin :sessions, secret: SecureRandom.hex(64)
+      plugin :json
+      plugin :json_parser
+      plugin :halt
+
+      plugin :rodauth do
+        db app_db
+        enable :base, :json, :login, :logout, :two_factor_base, :otp, :recovery_codes
+        only_json? true
+        login_column :email
+        hmac_secret SecureRandom.hex(32)
+        otp_issuer 'OneTimeSecret'
+        otp_setup_param 'otp_setup'
+        otp_setup_raw_param 'otp_raw_secret'
+        otp_auth_param 'otp_code'
+        otp_keys_use_hmac? true
+        auto_add_recovery_codes? true
+        recovery_codes_limit 4
+
+        # Production hook logic from apps/web/auth/config/hooks/mfa.rb.
+        before_otp_setup_route do
+          if otp_keys_use_hmac? && (raw_secret = json_response[otp_setup_raw_param])
+            otp_tmp_key(raw_secret)
+            json_response[:provisioning_uri] = otp_provisioning_uri
+          end
+        end
+      end
+
+      route { |r| r.rodauth }
+    end
+  end
+
+  def json_post(path, body)
+    post(path, body.to_json, 'CONTENT_TYPE' => 'application/json', 'HTTP_ACCEPT' => 'application/json')
+    [last_response.status, JSON.parse(last_response.body)]
+  end
+
+  def secret_in(provisioning_uri)
+    CGI.parse(URI.parse(provisioning_uri).query)['secret'].first
+  end
+
+  before do
+    account_id # create the account
+    status, = json_post('/login', login: 'mfa-user@example.com', password: password)
+    expect(status).to eq(200)
+  end
+
+  it 'returns a provisioning_uri that embeds the otp_setup (HMAC) secret, not the raw secret' do
+    status, body = json_post('/otp-setup', {})
+
+    expect(status).to eq(422) # JSON HMAC flow returns the secrets with a 422
+    expect(body).to include('otp_setup', 'otp_raw_secret', 'provisioning_uri')
+    expect(body['otp_setup']).not_to eq(body['otp_raw_secret'])
+
+    embedded = secret_in(body['provisioning_uri'])
+    expect(embedded).to eq(body['otp_setup'])
+    expect(embedded).not_to eq(body['otp_raw_secret'])
+    expect(body['provisioning_uri']).to start_with('otpauth://totp/OneTimeSecret:')
+  end
+
+  it 'accepts a TOTP code derived from provisioning_uri to complete setup' do
+    _, setup = json_post('/otp-setup', {})
+    code     = ROTP::TOTP.new(secret_in(setup['provisioning_uri'])).now
+
+    status, body = json_post(
+      '/otp-setup',
+      otp_setup: setup['otp_setup'],
+      otp_raw_secret: setup['otp_raw_secret'],
+      otp_code: code,
+      password: password,
+    )
+
+    expect(status).to eq(200)
+    expect(body).to have_key('success')
+    expect(db[:account_otp_keys].where(id: account_id).count).to eq(1)
+  end
+
+  it 'rejects a TOTP code derived from otp_raw_secret (the original bug)' do
+    _, setup   = json_post('/otp-setup', {})
+    wrong_code = ROTP::TOTP.new(setup['otp_raw_secret']).now
+
+    status, = json_post(
+      '/otp-setup',
+      otp_setup: setup['otp_setup'],
+      otp_raw_secret: setup['otp_raw_secret'],
+      otp_code: wrong_code,
+      password: password,
+    )
+
+    expect(status).not_to eq(200)
+    expect(db[:account_otp_keys].where(id: account_id).count).to eq(0)
+  end
+end

--- a/lib/onetime/application/otto_hooks.rb
+++ b/lib/onetime/application/otto_hooks.rb
@@ -95,6 +95,28 @@ module Onetime
           { error: error.message, error_type: 'Unauthorized' }
         end
 
+        # Plan-catalog cache misses (Billing::PlanCacheMissError) are a known,
+        # expected backend condition: the Stripe-synced plan catalog isn't
+        # populated (or a stale plan_id no longer resolves), so org plan/limit
+        # resolution fails closed in WithMaterializedLimits/WithPlanEntitlements.
+        # That is an ops problem, not an unexpected crash, so it must not surface
+        # as an unhandled 500 on otherwise-valid read endpoints (account
+        # permissions, domains list, organizations). Return 503 with a safe,
+        # generic message — never the error's internal "cache or config" wording
+        # or the plan_id/organization_id it carries.
+        #
+        # Registered by string name (not the constant) per Otto's lazy-loading
+        # form: Otto matches handlers on error.class.name, so this is harmless in
+        # builds where the billing app — and thus Billing::PlanCacheMissError —
+        # is never loaded (the error can't be raised there). log_level :error
+        # keeps the fail-closed design's ops visibility intact.
+        router.register_error_handler('Billing::PlanCacheMissError', status: 503, log_level: :error) do |_error, _req|
+          {
+            error: 'Plan catalog is temporarily unavailable. Please try again shortly.',
+            error_type: 'PlanCatalogUnavailable',
+          }
+        end
+
         # Give the router the same trusted-proxy list as the outer IP-privacy
         # middleware. Done here (not in each build_router) so no Otto app can
         # land with an inconsistent trust list. Placed before the debug-only

--- a/lib/onetime/application/otto_hooks.rb
+++ b/lib/onetime/application/otto_hooks.rb
@@ -117,6 +117,37 @@ module Onetime
           }
         end
 
+        # Stripe circuit breaker open (Billing::CircuitOpenError) is the sibling
+        # "backend temporarily can't serve" case: the breaker trips after
+        # consecutive Stripe failures and fails fast to let the upstream recover.
+        # Like the catalog miss above it is a known backend condition, not a
+        # crash, so map it to 503 rather than letting it surface as a 500.
+        #
+        # Forward-looking, not a fix for an observed 500: today the breaker only
+        # wraps the catalog Pull, whose callers (CLI, boot, webhook handler that
+        # rescues it, scheduled jobs) are off the synchronous HTTP edge, so this
+        # error cannot currently reach an Otto-handled request. The customer
+        # facing billing endpoints call Stripe directly and already handle outages
+        # via their own Stripe::StripeError rescues. This registration only fires
+        # if a synchronous endpoint later routes a Stripe call through the breaker.
+        #
+        # Drop the error's message — it carries the internal failure count
+        # ("...(7 failures)...") — and never name the upstream provider. Surface
+        # retry_after in the body (Otto error handlers return a body hash only and
+        # cannot set a Retry-After response header). log_level :warn, not :error:
+        # this is a transient, self-healing protective state, unlike the catalog
+        # miss which signals an operator-actionable config/sync problem. Registered
+        # by string name per Otto's lazy-loading form (harmless when billing is not
+        # loaded — the error can't be raised there).
+        router.register_error_handler('Billing::CircuitOpenError', status: 503, log_level: :warn) do |error, _req|
+          body               = {
+            error: 'The billing service is temporarily unavailable. Please try again shortly.',
+            error_type: 'BillingServiceUnavailable',
+          }
+          body[:retry_after] = error.retry_after if error.retry_after
+          body
+        end
+
         # Give the router the same trusted-proxy list as the outer IP-privacy
         # middleware. Done here (not in each build_router) so no Otto app can
         # land with an inconsistent trust list. Placed before the debug-only

--- a/spec/integration/api/v2/plan_cache_miss_handling_spec.rb
+++ b/spec/integration/api/v2/plan_cache_miss_handling_spec.rb
@@ -15,13 +15,16 @@ require_relative '../../../../apps/web/billing/errors'
 # 1. When an org has an invalid/nonexistent planid, entitlement checks raise
 #    PlanCacheMissError (not silently returning defaults)
 # 2. Error carries plan_id, organization_id, and context for logging
-# 3. Error type allows API layer to handle it as 500 without exposing internals
+# 3. Error type allows the API edge to map it to a dedicated status without
+#    exposing internals
 #
 # The error flow:
 # 1. API request triggers entitlement check via require_entitlement!
 # 2. require_entitlement! calls auth_org.can?(entitlement)
 # 3. can? calls entitlements which raises PlanCacheMissError for invalid planid
-# 4. Otto catches unhandled exception and returns 500 server_error response
+# 4. OttoHooks#configure_otto_request_hook has a registered handler that maps
+#    Billing::PlanCacheMissError to a 503 (PlanCatalogUnavailable) with a safe,
+#    generic body — it is a known ops condition, not an unhandled 500.
 #
 # Note: Full HTTP integration tests require SECRET env var. These tests verify
 # the error behavior at the logic layer which is sufficient to confirm the
@@ -207,8 +210,9 @@ RSpec.describe 'API V2 PlanCacheMissError Handling', type: :integration, billing
     end
 
     it 'is not a user-actionable error type' do
-      # Unlike EntitlementRequired which returns 403, PlanCacheMissError
-      # should result in 500 because it represents a configuration problem
+      # Unlike EntitlementRequired which returns 403, PlanCacheMissError is not
+      # user-actionable: it represents a backend catalog/ops problem. The API
+      # edge maps it to 503 (see OttoHooks), distinct from the 403 path.
       expect(Billing::PlanCacheMissError.ancestors).not_to include(Onetime::EntitlementRequired)
     end
   end

--- a/spec/unit/onetime/application/otto_hooks_spec.rb
+++ b/spec/unit/onetime/application/otto_hooks_spec.rb
@@ -3,6 +3,7 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require_relative '../../../../apps/web/billing/errors'
 
 RSpec.describe Onetime::Application::OttoHooks do
   # Minimal host: OttoHooks is a mixin, so include it in a bare class.
@@ -39,6 +40,68 @@ RSpec.describe Onetime::Application::OttoHooks do
         expect(router).not_to receive(:add_trusted_proxy)
 
         host.configure_otto_trusted_proxies(router)
+      end
+    end
+  end
+
+  describe '#configure_otto_request_hook error registrations' do
+    # Spy router records every register_error_handler call so we can assert OUR
+    # registrations and exercise the handler blocks without booting a full Otto
+    # app. Only the methods configure_otto_request_hook touches are stubbed.
+    let(:registered) { {} }
+    let(:spy_router) do
+      captured = registered
+      Object.new.tap do |spy|
+        spy.define_singleton_method(:register_request_helpers) { |*| }
+        spy.define_singleton_method(:add_trusted_proxy) { |*| }
+        spy.define_singleton_method(:on_request_complete) { |*, &_blk| }
+        spy.define_singleton_method(:register_error_handler) do |klass, status:, log_level:, &handler|
+          captured[klass] = { status: status, log_level: log_level, handler: handler }
+        end
+      end
+    end
+
+    before do
+      allow(Onetime::Application::MiddlewareStack)
+        .to receive(:trusted_proxy_enabled?).and_return(false)
+      allow(Onetime).to receive(:debug?).and_return(false)
+      host.configure_otto_request_hook(spy_router)
+    end
+
+    describe 'Billing::CircuitOpenError (Stripe breaker open)' do
+      let(:entry) { registered['Billing::CircuitOpenError'] }
+
+      it 'maps to 503 at log_level :warn' do
+        expect(entry).not_to be_nil
+        expect(entry[:status]).to eq(503)
+        expect(entry[:log_level]).to eq(:warn)
+      end
+
+      it 'is registered by string name so it is harmless without the billing app' do
+        expect(registered.keys).to include('Billing::CircuitOpenError')
+      end
+
+      it 'returns a generic body that never leaks the breaker failure count or upstream provider' do
+        # The real error message embeds an internal failure count and "Stripe".
+        error = Billing::CircuitOpenError.new(
+          'Stripe circuit breaker is open (7 failures). Retry after 42s.',
+          retry_after: 42,
+        )
+
+        body = entry[:handler].call(error, nil)
+
+        expect(body[:error_type]).to eq('BillingServiceUnavailable')
+        expect(body[:error]).not_to match(/Stripe|circuit|failure/i)
+        expect(body[:retry_after]).to eq(42)
+        expect(body.values_at(:error, :error_type, :retry_after)).to eq(body.values)
+      end
+
+      it 'omits retry_after when the breaker carries none' do
+        error = Billing::CircuitOpenError.new('Stripe circuit breaker is open')
+
+        body = entry[:handler].call(error, nil)
+
+        expect(body).not_to have_key(:retry_after)
       end
     end
   end

--- a/src/apps/session/components/OtpSetupWizard.vue
+++ b/src/apps/session/components/OtpSetupWizard.vue
@@ -5,9 +5,7 @@
 import OtpCodeInput from '@/apps/session/components/OtpCodeInput.vue';
 import { useMfa } from '@/shared/composables/useMfa';
 import { useClipboard } from '@/shared/composables/useClipboard';
-import { useBootstrapStore } from '@/shared/stores/bootstrapStore';
 import { useNotificationsStore } from '@/shared/stores/notificationsStore';
-import { storeToRefs } from 'pinia';
 import { ref, computed, onMounted } from 'vue';
 
 const emit = defineEmits<{
@@ -20,9 +18,6 @@ const { setupData, recoveryCodes, isLoading, error, setupMfa, enableMfa } = useM
 const notificationsStore = useNotificationsStore();
 const { copyToClipboard } = useClipboard();
 
-const bootstrapStore = useBootstrapStore();
-const { ui, email } = storeToRefs(bootstrapStore);
-
 // Simplified wizard: setup or codes
 const currentStep = ref<'setup' | 'codes'>('setup');
 // Track whether recovery codes have been saved (downloaded or copied)
@@ -31,13 +26,10 @@ const otpCode = ref('');
 const password = ref('');
 const otpInputRef = ref<InstanceType<typeof OtpCodeInput> | null>(null);
 
-// Auto-load QR code on mount (without password initially)
+// Auto-load QR code on mount (without password initially). The QR is rendered
+// from the backend's provisioning_uri, so no site name / email is needed here.
 onMounted(async () => {
-  // Get site name and user email from bootstrap store
-  const siteName = ui.value?.header?.branding?.site_name || 'Onetime Secret';
-  const userEmail = email.value || '';
-
-  await setupMfa(siteName, userEmail);
+  await setupMfa();
 });
 
 // Handle OTP code input

--- a/src/apps/workspace/account/MfaSettings.vue
+++ b/src/apps/workspace/account/MfaSettings.vue
@@ -68,9 +68,21 @@
   <SettingsLayout>
     <div>
       <div class="mb-6">
-        <h1 class="text-3xl font-bold dark:text-white">
-          {{ t('web.auth.mfa.title') }}
-        </h1>
+        <div class="flex items-center gap-3">
+          <h1 class="text-3xl font-bold dark:text-white">
+            {{ t('web.auth.mfa.title') }}
+          </h1>
+          <span
+            v-if="mfaStatus"
+            :class="[
+              'inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium',
+              mfaStatus.enabled
+                ? 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400'
+                : 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-300',
+            ]">
+            {{ mfaStatus.enabled ? t('web.auth.account.mfa_enabled') : t('web.auth.account.mfa_disabled') }}
+          </span>
+        </div>
         <p class="mt-2 text-gray-600 dark:text-gray-400">
           {{ t('web.auth.mfa.setup_description') }}
         </p>
@@ -127,22 +139,10 @@
           class="rounded-lg bg-white p-6 shadow dark:bg-gray-800">
           <div class="flex items-start justify-between">
             <div class="flex-1">
-              <div class="flex items-center gap-3">
-                <i class="fas fa-shield-check text-3xl text-green-500"></i>
-                <div>
-                  <h2 class="text-xl font-semibold dark:text-white">
-                    {{ t('web.auth.mfa.enabled') }}
-                  </h2>
-                  <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">
-                    {{ t('web.auth.mfa.protected_description') }}
-                  </p>
-                </div>
-              </div>
-
               <!-- Last used -->
               <div
                 v-if="mfaStatus.last_used_at"
-                class="mt-4 text-sm text-gray-600 dark:text-gray-400">
+                class="text-sm text-gray-600 dark:text-gray-400">
                 {{
                   t('web.auth.mfa.last_used', {
                     time: formatDisplayDateTime(new Date(mfaStatus.last_used_at)),
@@ -151,7 +151,7 @@
               </div>
               <div
                 v-else
-                class="mt-4 text-sm text-gray-600 dark:text-gray-400">
+                class="text-sm text-gray-600 dark:text-gray-400">
                 {{ t('web.auth.mfa.never_used') }}
               </div>
 
@@ -187,24 +187,8 @@
           class="rounded-lg bg-white p-6 shadow dark:bg-gray-800">
           <div class="flex items-start justify-between">
             <div class="flex-1">
-              <div class="flex items-center gap-3">
-                <i class="fas fa-shield-alt text-3xl text-gray-400"></i>
-                <div>
-                  <h2 class="text-xl font-semibold dark:text-white">
-                    {{ t('web.auth.mfa.disabled') }}
-                  </h2>
-                  <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">
-                    {{ t('web.auth.mfa.enable_description') }}
-                  </p>
-                </div>
-              </div>
-
               <!-- Benefits list -->
-              <ul class="mt-4 space-y-2 text-sm text-gray-600 dark:text-gray-400">
-                <li class="flex items-center">
-                  <i class="fas fa-check mr-2 text-green-500"></i>
-                  {{ t('web.auth.mfa.benefit_unauthorized') }}
-                </li>
+              <ul class="space-y-2 text-sm text-gray-600 dark:text-gray-400">
                 <li class="flex items-center">
                   <i class="fas fa-check mr-2 text-green-500"></i>
                   {{ t('web.auth.mfa.benefit_apps') }}
@@ -222,7 +206,7 @@
               type="button"
               data-testid="mfa-enable-btn"
               class="rounded-md bg-brand-600 px-4 py-2 text-sm font-medium text-white hover:bg-brand-700 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:ring-offset-2">
-              {{ t('web.auth.mfa.enable') }}
+              {{ t('web.settings.security.enable') }}
             </button>
           </div>
         </div>

--- a/src/schemas/api/auth/responses/auth.ts
+++ b/src/schemas/api/auth/responses/auth.ts
@@ -260,6 +260,10 @@ export type RemoveSessionResponse = z.infer<typeof removeSessionResponseSchema>;
 export const otpSetupResponseSchema = z.object({
   qr_code: z.string().optional(), // Not present in HMAC first request
   secret: z.string().optional(), // Not present in HMAC first request
+  // Backend's authoritative otpauth:// provisioning URI (Rodauth's
+  // otp_provisioning_uri). The frontend renders this directly as a QR code
+  // rather than reconstructing the URI client-side (issue #3431).
+  provisioning_uri: z.string().optional(),
   otp_setup: z.string().optional(), // HMAC'd secret (when HMAC enabled)
   otp_raw_secret: z.string().optional(), // Raw secret (when HMAC enabled)
   otp_secret: z.string().optional(), // Alternative field name for HMAC'd secret

--- a/src/shared/composables/helpers/mfaHelpers.ts
+++ b/src/shared/composables/helpers/mfaHelpers.ts
@@ -13,32 +13,26 @@
 import { otpSetupResponseSchema } from '@/schemas/api/auth/responses/auth';
 import type { OtpSetupData } from '@/types/auth';
 import QRCode from 'qrcode';
+import { captureMessage, isDiagnosticsEnabled } from '@/services/diagnostics.service';
 
 /**
- * Generates a QR code data URL from an OTP secret
+ * Renders a backend-provided otpauth:// provisioning URI as a QR code data URL
  *
- * Creates a standard TOTP URI that can be scanned by authenticator apps like:
- * - Google Authenticator
- * - Authy
- * - Microsoft Authenticator
- * - 1Password
+ * The provisioning URI is emitted authoritatively by the backend (Rodauth's
+ * `otp_provisioning_uri`, surfaced as `provisioning_uri` in the otp-setup
+ * response). It already contains the correct secret and TOTP parameters
+ * (issuer/algorithm/digits/period), so the frontend must NOT reconstruct the
+ * URI or re-declare those parameters — doing so is what caused the QR to encode
+ * the wrong secret (issue #3431). This function only renders the QR image.
  *
- * @param secret - Base32-encoded secret key for TOTP generation
- * @returns Data URL (image/png) that can be used as img src attribute
+ * The result is scannable by authenticator apps such as Google Authenticator,
+ * Authy, Microsoft Authenticator, and 1Password.
  *
- * TOTP URI format:
- * otpauth://totp/Issuer:user@example.com?secret=SECRET&issuer=Issuer
- *
- * Note: emailAddress is currently a placeholder. In production, this should be
- * fetched from the authenticated user's account information.
+ * @param provisioningUri - otpauth:// URI from the backend (`provisioning_uri`)
+ * @returns Data URL (image/png) that can be used as an img src attribute
  */
-export async function generateQrCode(
-  issuer: string,
-  emailAddress: string,
-  secret: string
-): Promise<string> {
-  const otpUrl = `otpauth://totp/${encodeURIComponent(issuer)}:${encodeURIComponent(emailAddress)}?secret=${secret}&issuer=${encodeURIComponent(issuer)}`;
-  return await QRCode.toDataURL(otpUrl);
+export async function generateQrCode(provisioningUri: string): Promise<string> {
+  return await QRCode.toDataURL(provisioningUri);
 }
 
 /**
@@ -46,8 +40,9 @@ export async function generateQrCode(
  *
  * In HMAC mode, the backend returns a 422 status with setup secrets.
  * This function validates that the response includes both:
- * - otp_setup or otp_secret: HMAC'd secret for server validation
- * - otp_raw_secret: Raw secret for QR code generation
+ * - otp_setup or otp_secret: HMAC'd secret (the actual TOTP key the
+ *   authenticator must use, and the value the server validates against)
+ * - otp_raw_secret: Raw secret used only for the setup handshake
  *
  * @param errorData - Response data from 422 status (not actually an error)
  * @returns true if response contains valid HMAC setup data
@@ -65,13 +60,11 @@ export function hasHmacSetupData(errorData: any): boolean {
  *
  * Takes the 422 response from HMAC setup and:
  * 1. Validates the response schema
- * 2. Generates a QR code from the raw secret
+ * 2. Renders a QR code from the backend's authoritative provisioning_uri
  * 3. Normalizes field names (otp_secret → otp_setup)
  * 4. Returns enriched data ready for user display
  *
  * @param errorData - Response data from HMAC setup (422 status)
- * @param siteName - The site name to display in the authenticator app
- * @param email - The user's email address to associate with the MFA setup
  * @returns Validated and enriched OtpSetupData, or null if validation fails
  *
  * Error handling:
@@ -82,23 +75,35 @@ export function hasHmacSetupData(errorData: any): boolean {
  * This function is critical for the HMAC flow because it transforms
  * the "error" response into actionable setup data for the user.
  */
-export async function enrichSetupResponse(
-  errorData: any,
-  siteName: string,
-  email: string
-): Promise<OtpSetupData | null> {
+export async function enrichSetupResponse(errorData: any): Promise<OtpSetupData | null> {
   try {
     // Validate response structure against expected schema
     const validated = otpSetupResponseSchema.parse(errorData);
 
-    // Ensure we have otp_setup for the verification step. When HMAC is
-    // enabled, the field name is otp_secret; otherwise otp_secret.
+    // Ensure we have otp_setup (the value shown for manual entry and sent back
+    // on verification). When HMAC is enabled, the field may arrive as otp_secret.
     validated.otp_setup = validated.otp_setup || errorData.otp_secret || errorData.otp_setup;
 
-    // Generate QR code for authenticator app scanning
-    if (validated.otp_raw_secret) {
-      validated.qr_code = await generateQrCode(siteName, email, validated.otp_raw_secret);
+    // Render the QR from the backend's authoritative provisioning URI so the
+    // encoded secret/params always match what the server validates (#3431).
+    // provisioning_uri is always present on the HMAC path; its absence means a
+    // backend/frontend version skew. Fail loudly instead of returning setup
+    // data with no QR, which would leave the user on a blank scan step with no
+    // error (issue #3431 follow-up).
+    if (!validated.provisioning_uri) {
+      console.error(
+        '[mfaHelpers] HMAC setup response is missing provisioning_uri; cannot render QR code'
+      );
+      if (isDiagnosticsEnabled()) {
+        captureMessage('MFA setup response missing provisioning_uri', {
+          service: 'web',
+          errorType: 'technical',
+        });
+      }
+      return null;
     }
+
+    validated.qr_code = await generateQrCode(validated.provisioning_uri);
 
     return validated;
   } catch (parseErr) {

--- a/src/shared/composables/useMfa.ts
+++ b/src/shared/composables/useMfa.ts
@@ -9,7 +9,8 @@
  * 1. Setup Flow (HMAC-based):
  *    a) User requests setup → POST /auth/otp-setup {} (empty payload)
  *    b) Backend returns 422 with otp_setup (HMAC'd secret) + otp_raw_secret
- *    c) Frontend generates QR code from otp_raw_secret
+ *       + provisioning_uri (Rodauth's authoritative otpauth:// URI)
+ *    c) Frontend renders the QR code directly from provisioning_uri
  *    d) User scans QR code and enters OTP
  *    e) POST /auth/otp-setup {otp_code, otp_setup, otp_raw_secret, password}
  *    f) Backend validates and enables MFA → 200 success
@@ -147,25 +148,19 @@ export function useMfa() {
    * step of OTP setup. The backend returns a 422 status with the secrets, which
    * is the EXPECTED behavior in JSON-only mode (not an error).
    *
-   * @param siteName - The site name to display in the authenticator app (e.g., "Onetime Secret")
-   * @param email - The user's email address to associate with the MFA setup
    * @param password - Optional password for authentication (may be required by backend)
    * @returns OtpSetupData with QR code and secrets, or null on actual errors
    *
    * Success path (HMAC enabled):
    * - POST /auth/otp-setup {} (empty or with password)
-   * - Receive 422 with {otp_setup, otp_raw_secret, error: "..."}
-   * - Generate QR code from otp_raw_secret
+   * - Receive 422 with {otp_setup, otp_raw_secret, provisioning_uri, error: "..."}
+   * - Render QR code from the backend's provisioning_uri
    * - Return enriched setup data for user to scan
    *
    * The 422 status is treated as success because it contains the necessary
    * setup data. A true error would not include otp_raw_secret.
    */
-  async function setupMfa(
-    siteName: string,
-    email: string,
-    password?: string
-  ): Promise<OtpSetupData | null> {
+  async function setupMfa(password?: string): Promise<OtpSetupData | null> {
     clearError();
 
     const result = await wrap(async () => {
@@ -175,9 +170,10 @@ export function useMfa() {
         const response = await $api.post<OtpSetupResponse>('/auth/otp-setup', payload);
         const validated = otpSetupResponseSchema.parse(response.data);
 
-        // Standard response (non-HMAC mode): includes QR code data directly
-        if (validated.otp_raw_secret && validated.otp_setup) {
-          validated.qr_code = await generateQrCode(siteName, email, validated.otp_setup);
+        // Standard response (non-HMAC mode): render the QR from the backend's
+        // authoritative provisioning URI when present.
+        if (validated.provisioning_uri) {
+          validated.qr_code = await generateQrCode(validated.provisioning_uri);
         }
 
         setupData.value = validated;
@@ -190,7 +186,7 @@ export function useMfa() {
         const errorData = axiosErr.response?.data;
 
         if (axiosErr.response?.status === 422 && errorData && hasHmacSetupData(errorData)) {
-          const hmacData = await enrichSetupResponse(errorData, siteName, email);
+          const hmacData = await enrichSetupResponse(errorData);
           if (hmacData) {
             setupData.value = hmacData;
             return hmacData; // Success: proceed to QR code display

--- a/src/tests/composables/useMfa.spec.ts
+++ b/src/tests/composables/useMfa.spec.ts
@@ -3,6 +3,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useMfa } from '@/shared/composables/useMfa';
 import { setupTestPinia } from '../setup';
+import QRCode from 'qrcode';
 import type AxiosMockAdapter from 'axios-mock-adapter';
 
 // Mock QR code generation
@@ -93,40 +94,51 @@ describe('useMfa', () => {
       const hmacResponse = {
         otp_setup: 'hmac_secret_123',
         otp_raw_secret: 'JBSWY3DPEHPK3PXP',
+        provisioning_uri:
+          'otpauth://totp/OneTimeSecret:test@example.com?secret=hmac_secret_123&issuer=OneTimeSecret',
         error: 'MFA setup requires verification',
       };
 
       axiosMock.onPost('/auth/otp-setup').reply(422, hmacResponse);
 
       const { setupMfa, setupData } = useMfa();
-      const result = await setupMfa('Onetime Secret', 'test@example.com', 'password123');
+      const result = await setupMfa('password123');
 
       expect(result).toBeTruthy();
       expect(result?.otp_setup).toBe('hmac_secret_123');
       expect(result?.otp_raw_secret).toBe('JBSWY3DPEHPK3PXP');
       expect(result?.qr_code).toBe('data:image/png;base64,mockQrCode');
       expect(setupData.value?.qr_code).toBeDefined();
+      // The QR must be rendered from the backend's provisioning_uri verbatim,
+      // not reconstructed client-side from a secret (issue #3431).
+      expect(QRCode.toDataURL).toHaveBeenCalledWith(hmacResponse.provisioning_uri);
     });
 
     it('handles HMAC setup without password parameter', async () => {
       const hmacResponse = {
         otp_setup: 'hmac_secret_456',
         otp_raw_secret: 'JBSWY3DPEHPK3PXQ',
+        provisioning_uri:
+          'otpauth://totp/OneTimeSecret:test@example.com?secret=hmac_secret_456&issuer=OneTimeSecret',
       };
 
       axiosMock.onPost('/auth/otp-setup').reply(422, hmacResponse);
 
       const { setupMfa } = useMfa();
-      const result = await setupMfa('Onetime Secret', 'test@example.com');
+      const result = await setupMfa();
 
       expect(result?.otp_raw_secret).toBe('JBSWY3DPEHPK3PXQ');
+      expect(result?.qr_code).toBe('data:image/png;base64,mockQrCode');
+      // QR is rendered from the backend's provisioning_uri verbatim, even on
+      // the no-password path (issue #3431).
+      expect(QRCode.toDataURL).toHaveBeenCalledWith(hmacResponse.provisioning_uri);
     });
 
     it('handles actual errors (not HMAC success)', async () => {
       axiosMock.onPost('/auth/otp-setup').reply(403, { error: 'Incorrect password' });
 
       const { setupMfa, error } = useMfa();
-      const result = await setupMfa('Onetime Secret', 'test@example.com', 'wrong_password');
+      const result = await setupMfa('wrong_password');
 
       expect(result).toBeNull();
       expect(error.value).toBe('web.auth.security.internal_error');
@@ -136,7 +148,23 @@ describe('useMfa', () => {
       axiosMock.onPost('/auth/otp-setup').reply(422, { error: 'Validation failed' });
 
       const { setupMfa, error } = useMfa();
-      const result = await setupMfa('Onetime Secret', 'test@example.com');
+      const result = await setupMfa();
+
+      expect(result).toBeNull();
+      expect(error.value).toBe('web.auth.security.internal_error');
+    });
+
+    it('surfaces an error when HMAC 422 omits provisioning_uri (version skew)', async () => {
+      // Both HMAC secrets present (passes hasHmacSetupData) but no
+      // provisioning_uri — e.g. the SPA is deployed ahead of the backend hook.
+      // Must fail visibly rather than advance to a blank scan step (#3431).
+      axiosMock.onPost('/auth/otp-setup').reply(422, {
+        otp_setup: 'hmac_secret',
+        otp_raw_secret: 'JBSWY3DPEHPK3PXP',
+      });
+
+      const { setupMfa, error } = useMfa();
+      const result = await setupMfa();
 
       expect(result).toBeNull();
       expect(error.value).toBe('web.auth.security.internal_error');
@@ -146,7 +174,7 @@ describe('useMfa', () => {
       axiosMock.onPost('/auth/otp-setup').reply(429, { error: 'Too many requests' });
 
       const { setupMfa, error } = useMfa();
-      const result = await setupMfa('Onetime Secret', 'test@example.com');
+      const result = await setupMfa();
 
       expect(result).toBeNull();
       expect(error.value).toBe('web.auth.security.internal_error');
@@ -156,7 +184,7 @@ describe('useMfa', () => {
       axiosMock.onPost('/auth/otp-setup').reply(401, { error: 'Not authenticated' });
 
       const { setupMfa, error } = useMfa();
-      const result = await setupMfa('Onetime Secret', 'test@example.com');
+      const result = await setupMfa();
 
       expect(result).toBeNull();
       expect(error.value).toBe('web.auth.security.internal_error');
@@ -439,6 +467,7 @@ describe('useMfa', () => {
       const hmacResponse = {
         otp_setup: 'hmac',
         otp_raw_secret: 'SECRET',
+        provisioning_uri: 'otpauth://totp/test@example.com?secret=hmac&issuer=test',
       };
 
       axiosMock.onPost('/auth/otp-setup').reply(422, hmacResponse);
@@ -447,7 +476,7 @@ describe('useMfa', () => {
 
       expect(isLoading.value).toBe(false);
 
-      const promise = setupMfa('Onetime Secret', 'test@example.com');
+      const promise = setupMfa();
       // Note: isLoading is synchronous, so we can't check during promise execution easily
       await promise;
 
@@ -461,7 +490,7 @@ describe('useMfa', () => {
 
       const { setupMfa, error, clearError } = useMfa();
 
-      await setupMfa('Onetime Secret', 'test@example.com');
+      await setupMfa();
       expect(error.value).toBe('web.auth.security.internal_error');
 
       // Clear error manually
@@ -475,7 +504,7 @@ describe('useMfa', () => {
       // First attempt fails
       axiosMock.onPost('/auth/otp-setup').reply(403, { error: 'Forbidden' });
 
-      await setupMfa('Onetime Secret', 'test@example.com');
+      await setupMfa();
       expect(error.value).toBeTruthy();
 
       // Second attempt succeeds - reset the mock
@@ -483,9 +512,10 @@ describe('useMfa', () => {
       axiosMock.onPost('/auth/otp-setup').reply(422, {
         otp_setup: 'hmac',
         otp_raw_secret: 'SECRET',
+        provisioning_uri: 'otpauth://totp/test@example.com?secret=hmac&issuer=test',
       });
 
-      await setupMfa('Onetime Secret', 'test@example.com');
+      await setupMfa();
       // Error should be cleared by clearError() call at start of setupMfa
       expect(error.value).toBeNull();
     });


### PR DESCRIPTION
## Summary

Fixes #3431

The MFA QR code was encoding the wrong secret when HMAC mode was enabled. The backend generates two secrets during setup:
- `otp_raw_secret`: Raw key used only for the setup handshake
- `otp_setup`: HMAC'd key that the authenticator app must actually use

The frontend was incorrectly reconstructing the otpauth:// URI and encoding `otp_raw_secret` instead of `otp_setup`, causing scanned QR codes to never match what the server validates.

**Fix:** The backend now emits Rodauth's authoritative `otp_provisioning_uri` (built from the correct HMAC'd secret) in the otp-setup response as `provisioning_uri`. The frontend renders this URI directly as a QR code without reconstruction, ensuring the encoded secret always matches server validation.

## Changes

### Backend (Ruby/Rodauth)
- **apps/web/auth/config/hooks/mfa.rb**: Added `before_otp_setup_route` hook to emit `provisioning_uri` from Rodauth's `otp_provisioning_uri` when HMAC is enabled
- **apps/web/auth/spec/config/features/mfa_provisioning_uri_spec.rb**: Added comprehensive regression tests covering:
  1. `provisioning_uri` embeds the correct HMAC'd secret, not the raw secret
  2. TOTP codes derived from `provisioning_uri` complete setup successfully
  3. TOTP codes derived from `otp_raw_secret` are rejected (the original bug)

### Frontend (TypeScript/Vue)
- **src/shared/composables/helpers/mfaHelpers.ts**: 
  - `generateQrCode()` now accepts the backend's `provisioning_uri` directly instead of reconstructing it from secret/issuer/email
  - `enrichSetupResponse()` renders QR from `provisioning_uri` instead of `otp_raw_secret`
  - Removed `siteName` and `email` parameters (no longer needed)
  
- **src/shared/composables/useMfa.ts**: 
  - `setupMfa()` no longer requires `siteName` and `email` parameters
  - Uses backend's `provisioning_uri` for QR rendering in both standard and HMAC flows
  
- **src/apps/session/components/OtpSetupWizard.vue**: Simplified to call `setupMfa()` without site name/email parameters

- **src/schemas/api/auth/responses/auth.ts**: Added `provisioning_uri` field to `otpSetupResponseSchema`

- **src/tests/composables/useMfa.spec.ts**: Updated tests to verify QR is rendered from `provisioning_uri` and removed site name/email parameter assertions

## Test Plan

Added comprehensive regression test suite (`mfa_provisioning_uri_spec.rb`) that exercises the real otp-setup route with the production hook configuration. Tests verify:
- The provisioning URI embeds the HMAC'd secret (not raw secret)
- Setup completes successfully with codes derived from the provisioning URI
- Setup fails with codes derived from the raw secret (confirming the bug is fixed)

Updated existing frontend unit tests to verify QR code generation uses the backend's `provisioning_uri` directly.

https://claude.ai/code/session_012j3QYu572Ms9rHPDXxGM4V