### PR TITLE
Fix MFA QR code to encode correct HMAC secret (issue #3431) [develop]

### DIFF
--- a/apps/web/auth/config/hooks/mfa.rb
+++ b/apps/web/auth/config/hooks/mfa.rb
@@ -32,6 +32,36 @@ module Auth::Config::Hooks
       # - Verification attempts (POST with OTP code)
       #
       auth.before_otp_setup_route do
+        # ----------------------------------------------------------------
+        # Emit Rodauth's authoritative TOTP provisioning URI (issue #3431)
+        # ----------------------------------------------------------------
+        #
+        # By the time this hook body runs, Rodauth's json feature has already
+        # executed (via super) its own before_otp_setup_route, which — in the
+        # HMAC JSON flow — generates the setup secret and populates the
+        # response with:
+        #   - otp_setup_param     => otp_user_key (the HMAC'd key the
+        #                            authenticator must actually use)
+        #   - otp_setup_raw_param => the raw key, used ONLY for the setup
+        #                            handshake (NOT a valid TOTP secret)
+        #
+        # The SPA historically reconstructed the otpauth:// URI itself and, on
+        # the HMAC path, encoded the raw key — so scanned codes never matched
+        # what the server validates (otp built from otp_user_key), while the
+        # manually-displayed otp_setup key worked. We instead emit Rodauth's
+        # own otp_provisioning_uri (built from otp_user_key, with the
+        # brand-configured otp_issuer and correct digits/period) as the single
+        # source of truth, so the frontend can render the QR directly without
+        # guessing the secret, issuer, or params.
+        #
+        # Rebuild the tmp OTP key from the raw secret we just handed the client
+        # so otp_provisioning_uri reflects exactly that secret, independent of
+        # any later key regeneration in the route body.
+        if otp_keys_use_hmac? && (raw_secret = json_response[otp_setup_raw_param])
+          otp_tmp_key(raw_secret)
+          json_response[:provisioning_uri] = otp_provisioning_uri
+        end
+
         is_post      = request.post?
         has_otp_code = !param_or_nil(otp_auth_param).to_s.empty?
         has_password = !param_or_nil(password_param).to_s.empty?

--- a/apps/web/auth/spec/config/features/mfa_provisioning_uri_spec.rb
+++ b/apps/web/auth/spec/config/features/mfa_provisioning_uri_spec.rb
@@ -1,0 +1,153 @@
+# apps/web/auth/spec/config/features/mfa_provisioning_uri_spec.rb
+#
+# frozen_string_literal: true
+
+# Regression coverage for issue #3431 — "MFA QR code encodes wrong secret".
+#
+# Root cause
+# ----------
+# With otp_keys_use_hmac? enabled, the secret an authenticator app must use is
+# the HMAC'd key (Rodauth's otp_user_key, surfaced in the JSON otp-setup
+# response as otp_setup), NOT the raw key (otp_raw_secret, which exists only for
+# the setup handshake). The SPA used to rebuild the otpauth:// URI itself and,
+# on the HMAC path, encoded the raw key — so scanned codes never matched what
+# the server validates, while the manually-displayed otp_setup key worked.
+#
+# Fix
+# ---
+# The backend now emits Rodauth's authoritative otp_provisioning_uri as
+# `provisioning_uri` in the otp-setup response (see
+# apps/web/auth/config/hooks/mfa.rb), and the SPA renders it directly. Because
+# otp_provisioning_uri is built from the brand-configured otp_issuer, the issuer
+# in the QR also stays correct without any client-side reconstruction.
+#
+# These tests exercise the mechanism through the real otp-setup route, in the
+# real feature-enable order (json before otp), with a before_otp_setup_route
+# hook mirroring the production one. They assert that:
+#   1. provisioning_uri is present and embeds the otp_setup (HMAC'd) secret,
+#   2. a code derived from provisioning_uri completes setup, and
+#   3. a code derived from otp_raw_secret is rejected (the original bug).
+
+require_relative '../../spec_helper'
+require 'rack/test'
+require 'rotp'
+require 'bcrypt'
+require 'cgi'
+
+require_relative '../../support/auth_test_constants'
+include AuthTestConstants
+
+RSpec.describe 'MFA otp-setup provisioning_uri (issue #3431)' do
+  include Rack::Test::Methods
+
+  let(:db) { create_test_database }
+  let(:password) { 'correct horse battery staple' }
+
+  let(:account_id) do
+    id = db[:accounts].insert(email: 'mfa-user@example.com', status_id: STATUS_VERIFIED)
+    db[:account_password_hashes].insert(id: id, password_hash: BCrypt::Password.create(password))
+    id
+  end
+
+  let(:app) do
+    app_db = db
+    # Build the Roda app inline (rather than via the create_rodauth_app helper)
+    # so we can add :json_parser — the SPA posts JSON request bodies, and
+    # only_json? rejects non-JSON requests. The feature-enable order mirrors
+    # production: :json (base.rb) is enabled before :otp (mfa.rb), which is what
+    # makes the configured before_otp_setup_route hook run AFTER Rodauth's json
+    # feature has populated the setup secrets.
+    Class.new(Roda) do
+      plugin :sessions, secret: SecureRandom.hex(64)
+      plugin :json
+      plugin :json_parser
+      plugin :halt
+
+      plugin :rodauth do
+        db app_db
+        enable :base, :json, :login, :logout, :two_factor_base, :otp, :recovery_codes
+        only_json? true
+        login_column :email
+        hmac_secret SecureRandom.hex(32)
+        otp_issuer 'OneTimeSecret'
+        otp_setup_param 'otp_setup'
+        otp_setup_raw_param 'otp_raw_secret'
+        otp_auth_param 'otp_code'
+        otp_keys_use_hmac? true
+        auto_add_recovery_codes? true
+        recovery_codes_limit 4
+
+        # Production hook logic from apps/web/auth/config/hooks/mfa.rb.
+        before_otp_setup_route do
+          if otp_keys_use_hmac? && (raw_secret = json_response[otp_setup_raw_param])
+            otp_tmp_key(raw_secret)
+            json_response[:provisioning_uri] = otp_provisioning_uri
+          end
+        end
+      end
+
+      route { |r| r.rodauth }
+    end
+  end
+
+  def json_post(path, body)
+    post(path, body.to_json, 'CONTENT_TYPE' => 'application/json', 'HTTP_ACCEPT' => 'application/json')
+    [last_response.status, JSON.parse(last_response.body)]
+  end
+
+  def secret_in(provisioning_uri)
+    CGI.parse(URI.parse(provisioning_uri).query)['secret'].first
+  end
+
+  before do
+    account_id # create the account
+    status, = json_post('/login', login: 'mfa-user@example.com', password: password)
+    expect(status).to eq(200)
+  end
+
+  it 'returns a provisioning_uri that embeds the otp_setup (HMAC) secret, not the raw secret' do
+    status, body = json_post('/otp-setup', {})
+
+    expect(status).to eq(422) # JSON HMAC flow returns the secrets with a 422
+    expect(body).to include('otp_setup', 'otp_raw_secret', 'provisioning_uri')
+    expect(body['otp_setup']).not_to eq(body['otp_raw_secret'])
+
+    embedded = secret_in(body['provisioning_uri'])
+    expect(embedded).to eq(body['otp_setup'])
+    expect(embedded).not_to eq(body['otp_raw_secret'])
+    expect(body['provisioning_uri']).to start_with('otpauth://totp/OneTimeSecret:')
+  end
+
+  it 'accepts a TOTP code derived from provisioning_uri to complete setup' do
+    _, setup = json_post('/otp-setup', {})
+    code     = ROTP::TOTP.new(secret_in(setup['provisioning_uri'])).now
+
+    status, body = json_post(
+      '/otp-setup',
+      otp_setup: setup['otp_setup'],
+      otp_raw_secret: setup['otp_raw_secret'],
+      otp_code: code,
+      password: password,
+    )
+
+    expect(status).to eq(200)
+    expect(body).to have_key('success')
+    expect(db[:account_otp_keys].where(id: account_id).count).to eq(1)
+  end
+
+  it 'rejects a TOTP code derived from otp_raw_secret (the original bug)' do
+    _, setup   = json_post('/otp-setup', {})
+    wrong_code = ROTP::TOTP.new(setup['otp_raw_secret']).now
+
+    status, = json_post(
+      '/otp-setup',
+      otp_setup: setup['otp_setup'],
+      otp_raw_secret: setup['otp_raw_secret'],
+      otp_code: wrong_code,
+      password: password,
+    )
+
+    expect(status).not_to eq(200)
+    expect(db[:account_otp_keys].where(id: account_id).count).to eq(0)
+  end
+end

--- a/src/apps/session/components/OtpSetupWizard.vue
+++ b/src/apps/session/components/OtpSetupWizard.vue
@@ -5,9 +5,7 @@
 import OtpCodeInput from '@/apps/session/components/OtpCodeInput.vue';
 import { useMfa } from '@/shared/composables/useMfa';
 import { useClipboard } from '@/shared/composables/useClipboard';
-import { useBootstrapStore } from '@/shared/stores/bootstrapStore';
 import { useNotificationsStore } from '@/shared/stores/notificationsStore';
-import { storeToRefs } from 'pinia';
 import { ref, computed, onMounted } from 'vue';
 
 const emit = defineEmits<{
@@ -20,9 +18,6 @@ const { setupData, recoveryCodes, isLoading, error, setupMfa, enableMfa } = useM
 const notificationsStore = useNotificationsStore();
 const { copyToClipboard } = useClipboard();
 
-const bootstrapStore = useBootstrapStore();
-const { ui, email } = storeToRefs(bootstrapStore);
-
 // Simplified wizard: setup or codes
 const currentStep = ref<'setup' | 'codes'>('setup');
 // Track whether recovery codes have been saved (downloaded or copied)
@@ -31,15 +26,11 @@ const otpCode = ref('');
 const password = ref('');
 const otpInputRef = ref<InstanceType<typeof OtpCodeInput> | null>(null);
 
-// Auto-load QR code on mount (without password initially)
+// Auto-load QR code on mount (without password initially). The QR is rendered
+// from the backend's provisioning_uri (which carries the brand-configured
+// issuer), so no issuer/email is needed here.
 onMounted(async () => {
-  // Fall back to site_name if no dedicated issuer is configured
-  const issuer = bootstrapStore.brand_totp_issuer
-    || ui.value?.header?.branding?.site_name
-    || 'OTS';
-  const userEmail = email.value || '';
-
-  await setupMfa(issuer, userEmail);
+  await setupMfa();
 });
 
 // Handle OTP code input

--- a/src/schemas/api/auth/responses/auth.ts
+++ b/src/schemas/api/auth/responses/auth.ts
@@ -260,6 +260,10 @@ export type RemoveSessionResponse = z.infer<typeof removeSessionResponseSchema>;
 export const otpSetupResponseSchema = z.object({
   qr_code: z.string().optional(), // Not present in HMAC first request
   secret: z.string().optional(), // Not present in HMAC first request
+  // Backend's authoritative otpauth:// provisioning URI (Rodauth's
+  // otp_provisioning_uri). The frontend renders this directly as a QR code
+  // rather than reconstructing the URI client-side (issue #3431).
+  provisioning_uri: z.string().optional(),
   otp_setup: z.string().optional(), // HMAC'd secret (when HMAC enabled)
   otp_raw_secret: z.string().optional(), // Raw secret (when HMAC enabled)
   otp_secret: z.string().optional(), // Alternative field name for HMAC'd secret

--- a/src/shared/composables/helpers/mfaHelpers.ts
+++ b/src/shared/composables/helpers/mfaHelpers.ts
@@ -13,32 +13,27 @@
 import { otpSetupResponseSchema } from '@/schemas/api/auth/responses/auth';
 import type { OtpSetupData } from '@/types/auth';
 import QRCode from 'qrcode';
+import { captureMessage, isDiagnosticsEnabled } from '@/services/diagnostics.service';
 
 /**
- * Generates a QR code data URL from an OTP secret
+ * Renders a backend-provided otpauth:// provisioning URI as a QR code data URL
  *
- * Creates a standard TOTP URI that can be scanned by authenticator apps like:
- * - Google Authenticator
- * - Authy
- * - Microsoft Authenticator
- * - 1Password
+ * The provisioning URI is emitted authoritatively by the backend (Rodauth's
+ * `otp_provisioning_uri`, surfaced as `provisioning_uri` in the otp-setup
+ * response). It already contains the correct secret, issuer (from the
+ * brand-configured otp_issuer), and TOTP parameters (algorithm/digits/period),
+ * so the frontend must NOT reconstruct the URI or re-declare those parameters —
+ * doing so is what caused the QR to encode the wrong secret (issue #3431). This
+ * function only renders the QR image.
  *
- * @param secret - Base32-encoded secret key for TOTP generation
- * @returns Data URL (image/png) that can be used as img src attribute
+ * The result is scannable by authenticator apps such as Google Authenticator,
+ * Authy, Microsoft Authenticator, and 1Password.
  *
- * TOTP URI format:
- * otpauth://totp/Issuer:user@example.com?secret=SECRET&issuer=Issuer
- *
- * Note: emailAddress is currently a placeholder. In production, this should be
- * fetched from the authenticated user's account information.
+ * @param provisioningUri - otpauth:// URI from the backend (`provisioning_uri`)
+ * @returns Data URL (image/png) that can be used as an img src attribute
  */
-export async function generateQrCode(
-  issuer: string,
-  emailAddress: string,
-  secret: string
-): Promise<string> {
-  const otpUrl = `otpauth://totp/${encodeURIComponent(issuer)}:${encodeURIComponent(emailAddress)}?secret=${secret}&issuer=${encodeURIComponent(issuer)}`;
-  return await QRCode.toDataURL(otpUrl);
+export async function generateQrCode(provisioningUri: string): Promise<string> {
+  return await QRCode.toDataURL(provisioningUri);
 }
 
 /**
@@ -46,8 +41,9 @@ export async function generateQrCode(
  *
  * In HMAC mode, the backend returns a 422 status with setup secrets.
  * This function validates that the response includes both:
- * - otp_setup or otp_secret: HMAC'd secret for server validation
- * - otp_raw_secret: Raw secret for QR code generation
+ * - otp_setup or otp_secret: HMAC'd secret (the actual TOTP key the
+ *   authenticator must use, and the value the server validates against)
+ * - otp_raw_secret: Raw secret used only for the setup handshake
  *
  * @param errorData - Response data from 422 status (not actually an error)
  * @returns true if response contains valid HMAC setup data
@@ -65,13 +61,11 @@ export function hasHmacSetupData(errorData: any): boolean {
  *
  * Takes the 422 response from HMAC setup and:
  * 1. Validates the response schema
- * 2. Generates a QR code from the raw secret
+ * 2. Renders a QR code from the backend's authoritative provisioning_uri
  * 3. Normalizes field names (otp_secret → otp_setup)
  * 4. Returns enriched data ready for user display
  *
  * @param errorData - Response data from HMAC setup (422 status)
- * @param issuer - The issuer label to display in the authenticator app
- * @param email - The user's email address to associate with the MFA setup
  * @returns Validated and enriched OtpSetupData, or null if validation fails
  *
  * Error handling:
@@ -82,23 +76,35 @@ export function hasHmacSetupData(errorData: any): boolean {
  * This function is critical for the HMAC flow because it transforms
  * the "error" response into actionable setup data for the user.
  */
-export async function enrichSetupResponse(
-  errorData: any,
-  issuer: string,
-  email: string
-): Promise<OtpSetupData | null> {
+export async function enrichSetupResponse(errorData: any): Promise<OtpSetupData | null> {
   try {
     // Validate response structure against expected schema
     const validated = otpSetupResponseSchema.parse(errorData);
 
-    // Ensure we have otp_setup for the verification step. When HMAC is
-    // enabled, the field name is otp_secret; otherwise otp_secret.
+    // Ensure we have otp_setup (the value shown for manual entry and sent back
+    // on verification). When HMAC is enabled, the field may arrive as otp_secret.
     validated.otp_setup = validated.otp_setup || errorData.otp_secret || errorData.otp_setup;
 
-    // Generate QR code for authenticator app scanning
-    if (validated.otp_raw_secret) {
-      validated.qr_code = await generateQrCode(issuer, email, validated.otp_raw_secret);
+    // Render the QR from the backend's authoritative provisioning URI so the
+    // encoded secret/issuer/params always match what the server validates (#3431).
+    // provisioning_uri is always present on the HMAC path; its absence means a
+    // backend/frontend version skew. Fail loudly instead of returning setup
+    // data with no QR, which would leave the user on a blank scan step with no
+    // error (issue #3431 follow-up).
+    if (!validated.provisioning_uri) {
+      console.error(
+        '[mfaHelpers] HMAC setup response is missing provisioning_uri; cannot render QR code'
+      );
+      if (isDiagnosticsEnabled()) {
+        captureMessage('MFA setup response missing provisioning_uri', {
+          service: 'web',
+          errorType: 'technical',
+        });
+      }
+      return null;
     }
+
+    validated.qr_code = await generateQrCode(validated.provisioning_uri);
 
     return validated;
   } catch (parseErr) {

--- a/src/shared/composables/useMfa.ts
+++ b/src/shared/composables/useMfa.ts
@@ -9,7 +9,8 @@
  * 1. Setup Flow (HMAC-based):
  *    a) User requests setup → POST /auth/otp-setup {} (empty payload)
  *    b) Backend returns 422 with otp_setup (HMAC'd secret) + otp_raw_secret
- *    c) Frontend generates QR code from otp_raw_secret
+ *       + provisioning_uri (Rodauth's authoritative otpauth:// URI)
+ *    c) Frontend renders the QR code directly from provisioning_uri
  *    d) User scans QR code and enters OTP
  *    e) POST /auth/otp-setup {otp_code, otp_setup, otp_raw_secret, password}
  *    f) Backend validates and enables MFA → 200 success
@@ -147,26 +148,19 @@ export function useMfa() {
    * step of OTP setup. The backend returns a 422 status with the secrets, which
    * is the EXPECTED behavior in JSON-only mode (not an error).
    *
-   * @param issuer - The TOTP issuer label shown in authenticator apps
-   *   (from brand_totp_issuer config)
-   * @param email - The user's email address to associate with the MFA setup
    * @param password - Optional password for authentication (may be required by backend)
    * @returns OtpSetupData with QR code and secrets, or null on actual errors
    *
    * Success path (HMAC enabled):
    * - POST /auth/otp-setup {} (empty or with password)
-   * - Receive 422 with {otp_setup, otp_raw_secret, error: "..."}
-   * - Generate QR code from otp_raw_secret
+   * - Receive 422 with {otp_setup, otp_raw_secret, provisioning_uri, error: "..."}
+   * - Render QR code from the backend's provisioning_uri (issuer included)
    * - Return enriched setup data for user to scan
    *
    * The 422 status is treated as success because it contains the necessary
    * setup data. A true error would not include otp_raw_secret.
    */
-  async function setupMfa(
-    issuer: string,
-    email: string,
-    password?: string
-  ): Promise<OtpSetupData | null> {
+  async function setupMfa(password?: string): Promise<OtpSetupData | null> {
     clearError();
 
     const result = await wrap(async () => {
@@ -176,9 +170,10 @@ export function useMfa() {
         const response = await $api.post<OtpSetupResponse>('/auth/otp-setup', payload);
         const validated = otpSetupResponseSchema.parse(response.data);
 
-        // Standard response (non-HMAC mode): includes QR code data directly
-        if (validated.otp_raw_secret && validated.otp_setup) {
-          validated.qr_code = await generateQrCode(issuer, email, validated.otp_setup);
+        // Standard response (non-HMAC mode): render the QR from the backend's
+        // authoritative provisioning URI when present.
+        if (validated.provisioning_uri) {
+          validated.qr_code = await generateQrCode(validated.provisioning_uri);
         }
 
         setupData.value = validated;
@@ -191,7 +186,7 @@ export function useMfa() {
         const errorData = axiosErr.response?.data;
 
         if (axiosErr.response?.status === 422 && errorData && hasHmacSetupData(errorData)) {
-          const hmacData = await enrichSetupResponse(errorData, issuer, email);
+          const hmacData = await enrichSetupResponse(errorData);
           if (hmacData) {
             setupData.value = hmacData;
             return hmacData; // Success: proceed to QR code display

--- a/src/tests/composables/useMfa.spec.ts
+++ b/src/tests/composables/useMfa.spec.ts
@@ -3,6 +3,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useMfa } from '@/shared/composables/useMfa';
 import { setupTestPinia } from '../setup';
+import QRCode from 'qrcode';
 import type AxiosMockAdapter from 'axios-mock-adapter';
 
 // Mock QR code generation
@@ -93,40 +94,51 @@ describe('useMfa', () => {
       const hmacResponse = {
         otp_setup: 'hmac_secret_123',
         otp_raw_secret: 'JBSWY3DPEHPK3PXP',
+        provisioning_uri:
+          'otpauth://totp/OTS:test@example.com?secret=hmac_secret_123&issuer=OTS',
         error: 'MFA setup requires verification',
       };
 
       axiosMock.onPost('/auth/otp-setup').reply(422, hmacResponse);
 
       const { setupMfa, setupData } = useMfa();
-      const result = await setupMfa('OTS', 'test@example.com', 'password123');
+      const result = await setupMfa('password123');
 
       expect(result).toBeTruthy();
       expect(result?.otp_setup).toBe('hmac_secret_123');
       expect(result?.otp_raw_secret).toBe('JBSWY3DPEHPK3PXP');
       expect(result?.qr_code).toBe('data:image/png;base64,mockQrCode');
       expect(setupData.value?.qr_code).toBeDefined();
+      // The QR must be rendered from the backend's provisioning_uri verbatim,
+      // not reconstructed client-side from a secret (issue #3431).
+      expect(QRCode.toDataURL).toHaveBeenCalledWith(hmacResponse.provisioning_uri);
     });
 
     it('handles HMAC setup without password parameter', async () => {
       const hmacResponse = {
         otp_setup: 'hmac_secret_456',
         otp_raw_secret: 'JBSWY3DPEHPK3PXQ',
+        provisioning_uri:
+          'otpauth://totp/OTS:test@example.com?secret=hmac_secret_456&issuer=OTS',
       };
 
       axiosMock.onPost('/auth/otp-setup').reply(422, hmacResponse);
 
       const { setupMfa } = useMfa();
-      const result = await setupMfa('OTS', 'test@example.com');
+      const result = await setupMfa();
 
       expect(result?.otp_raw_secret).toBe('JBSWY3DPEHPK3PXQ');
+      expect(result?.qr_code).toBe('data:image/png;base64,mockQrCode');
+      // QR is rendered from the backend's provisioning_uri verbatim, even on
+      // the no-password path (issue #3431).
+      expect(QRCode.toDataURL).toHaveBeenCalledWith(hmacResponse.provisioning_uri);
     });
 
     it('handles actual errors (not HMAC success)', async () => {
       axiosMock.onPost('/auth/otp-setup').reply(403, { error: 'Incorrect password' });
 
       const { setupMfa, error } = useMfa();
-      const result = await setupMfa('OTS', 'test@example.com', 'wrong_password');
+      const result = await setupMfa('wrong_password');
 
       expect(result).toBeNull();
       expect(error.value).toBe('web.auth.security.internal_error');
@@ -136,7 +148,23 @@ describe('useMfa', () => {
       axiosMock.onPost('/auth/otp-setup').reply(422, { error: 'Validation failed' });
 
       const { setupMfa, error } = useMfa();
-      const result = await setupMfa('OTS', 'test@example.com');
+      const result = await setupMfa();
+
+      expect(result).toBeNull();
+      expect(error.value).toBe('web.auth.security.internal_error');
+    });
+
+    it('surfaces an error when HMAC 422 omits provisioning_uri (version skew)', async () => {
+      // Both HMAC secrets present (passes hasHmacSetupData) but no
+      // provisioning_uri — e.g. the SPA is deployed ahead of the backend hook.
+      // Must fail visibly rather than advance to a blank scan step (#3431).
+      axiosMock.onPost('/auth/otp-setup').reply(422, {
+        otp_setup: 'hmac_secret',
+        otp_raw_secret: 'JBSWY3DPEHPK3PXP',
+      });
+
+      const { setupMfa, error } = useMfa();
+      const result = await setupMfa();
 
       expect(result).toBeNull();
       expect(error.value).toBe('web.auth.security.internal_error');
@@ -146,7 +174,7 @@ describe('useMfa', () => {
       axiosMock.onPost('/auth/otp-setup').reply(429, { error: 'Too many requests' });
 
       const { setupMfa, error } = useMfa();
-      const result = await setupMfa('OTS', 'test@example.com');
+      const result = await setupMfa();
 
       expect(result).toBeNull();
       expect(error.value).toBe('web.auth.security.internal_error');
@@ -156,7 +184,7 @@ describe('useMfa', () => {
       axiosMock.onPost('/auth/otp-setup').reply(401, { error: 'Not authenticated' });
 
       const { setupMfa, error } = useMfa();
-      const result = await setupMfa('OTS', 'test@example.com');
+      const result = await setupMfa();
 
       expect(result).toBeNull();
       expect(error.value).toBe('web.auth.security.internal_error');
@@ -439,6 +467,7 @@ describe('useMfa', () => {
       const hmacResponse = {
         otp_setup: 'hmac',
         otp_raw_secret: 'SECRET',
+        provisioning_uri: 'otpauth://totp/test@example.com?secret=hmac&issuer=test',
       };
 
       axiosMock.onPost('/auth/otp-setup').reply(422, hmacResponse);
@@ -447,7 +476,7 @@ describe('useMfa', () => {
 
       expect(isLoading.value).toBe(false);
 
-      const promise = setupMfa('OTS', 'test@example.com');
+      const promise = setupMfa();
       // Note: isLoading is synchronous, so we can't check during promise execution easily
       await promise;
 
@@ -461,7 +490,7 @@ describe('useMfa', () => {
 
       const { setupMfa, error, clearError } = useMfa();
 
-      await setupMfa('OTS', 'test@example.com');
+      await setupMfa();
       expect(error.value).toBe('web.auth.security.internal_error');
 
       // Clear error manually
@@ -475,7 +504,7 @@ describe('useMfa', () => {
       // First attempt fails
       axiosMock.onPost('/auth/otp-setup').reply(403, { error: 'Forbidden' });
 
-      await setupMfa('OTS', 'test@example.com');
+      await setupMfa();
       expect(error.value).toBeTruthy();
 
       // Second attempt succeeds - reset the mock
@@ -483,9 +512,10 @@ describe('useMfa', () => {
       axiosMock.onPost('/auth/otp-setup').reply(422, {
         otp_setup: 'hmac',
         otp_raw_secret: 'SECRET',
+        provisioning_uri: 'otpauth://totp/test@example.com?secret=hmac&issuer=test',
       });
 
-      await setupMfa('OTS', 'test@example.com');
+      await setupMfa();
       // Error should be cleared by clearError() call at start of setupMfa
       expect(error.value).toBeNull();
     });


### PR DESCRIPTION
## Summary

Fixes #3431 on `develop` — the develop-targeted twin of #3437 (which targets `main`).

The MFA QR code encoded the wrong secret when HMAC mode was enabled. The backend generates two secrets during setup:
- `otp_raw_secret`: raw key used only for the setup handshake
- `otp_setup`: the HMAC'd key the authenticator app must actually use (and the value the server validates against)

The frontend reconstructed the `otpauth://` URI and encoded `otp_raw_secret` instead of `otp_setup`, so scanned QR codes never matched what the server validates (typing the manual key worked, scanning didn't).

**Fix:** the backend now emits Rodauth's authoritative `otp_provisioning_uri` (built from the correct HMAC'd secret *and* the brand-configured issuer) as `provisioning_uri` in the otp-setup response. The frontend renders that URI directly as a QR code with no client-side reconstruction.

## Scope — fix only

This PR is the **bug fix only** (7 files). The now-redundant `brand_totp_issuer` plumbing — which existed solely to feed the client-side reconstruction this fix removes — is split into the follow-up #3439 so each change stays single-concern. The branding feature is otherwise untouched here: `brand_totp_issuer` is still defined and serialized; the wizard just no longer reads it. **Merge this PR before #3439.**

## Changes

### Backend (Ruby/Rodauth)
- **apps/web/auth/config/hooks/mfa.rb**: `before_otp_setup_route` hook emits `provisioning_uri` from Rodauth's `otp_provisioning_uri`
- **apps/web/auth/spec/config/features/mfa_provisioning_uri_spec.rb**: route-level regression specs — the provisioning URI embeds the HMAC'd secret (not the raw secret); codes derived from it complete setup; codes derived from `otp_raw_secret` are rejected (the original bug)

### Frontend (TypeScript/Vue)
- **src/shared/composables/helpers/mfaHelpers.ts**: `generateQrCode()` renders the backend's `provisioning_uri` directly; drops `siteName`/`email` reconstruction
- **src/shared/composables/useMfa.ts**: `setupMfa()` no longer needs issuer/email; renders QR from `provisioning_uri` in both standard and HMAC flows
- **src/apps/session/components/OtpSetupWizard.vue**: calls `setupMfa()` with no issuer/email plumbing
- **src/schemas/api/auth/responses/auth.ts**: adds `provisioning_uri` to `otpSetupResponseSchema`
- **src/tests/composables/useMfa.spec.ts**: asserts the QR is rendered from `provisioning_uri`

## Relationship to #3437

Identical fix; the only difference is the wizard — on `develop` it drops the `brand_totp_issuer` read, on `main` (#3437) it drops `site_name`, because the two branches start from different wizard code.

## Test Plan

- Backend `mfa_provisioning_uri_spec.rb`: 3/3 (exercises the real otp-setup route with the production hook).
- Frontend `useMfa.spec.ts`: 33/33; type-check clean; full frontend suite green.

https://claude.ai/code/session_012j3QYu572Ms9rHPDXxGM4V