### PR TITLE
Use merge semantics for disabled_homepage_variant; drop UNCHANGED_VARIANT sentinel

### DIFF
--- a/apps/api/domains/logic/homepage_config/put_homepage_config.rb
+++ b/apps/api/domains/logic/homepage_config/put_homepage_config.rb
@@ -14,23 +14,24 @@ module DomainsAPI
       #   domain. Sets the enabled state. Requires the requesting user to be an
       #   organization owner with homepage_secrets entitlement.
       #
-      # Request body:
+      # Request body (optional fields use merge/PATCH-style semantics — an
+      # omitted or null value leaves the stored value unchanged):
       # - enabled: Boolean (required)
       # - signup_enabled: Boolean (optional) — toggles Sign Up link on the homepage
       # - signin_enabled: Boolean (optional) — toggles Sign In link on the homepage
+      # - disabled_homepage_variant: String (optional) — gated-homepage variant
+      #   (closed | minimal | v1). null/omitted leaves it unchanged; "" resets it
+      #   to the deployment default; a recognised id sets it.
       #
       class PutHomepageConfig < Base
         attr_reader :homepage_config
 
         def process_params
-          @domain_id       = sanitize_identifier(params['extid'])
-          @enabled         = parse_boolean(params['enabled'])
-          @signup_enabled  = parse_boolean(params['signup_enabled']) if params.key?('signup_enabled')
-          @signin_enabled  = parse_boolean(params['signin_enabled']) if params.key?('signin_enabled')
-          # Only touch the variant when the client sends the key; an explicit
-          # blank/unknown value clears the override (falls back to default).
-          @set_variant     = params.key?('disabled_homepage_variant')
-          @disabled_homepage_variant = params['disabled_homepage_variant'] if @set_variant
+          @domain_id                 = sanitize_identifier(params['extid'])
+          @enabled                   = parse_boolean(params['enabled'])
+          @signup_enabled            = parse_boolean(params['signup_enabled']) if params.key?('signup_enabled')
+          @signin_enabled            = parse_boolean(params['signin_enabled']) if params.key?('signin_enabled')
+          @disabled_homepage_variant = params['disabled_homepage_variant']
         end
 
         def raise_concerns
@@ -50,7 +51,7 @@ module DomainsAPI
             enabled: @enabled,
             signup_enabled: @signup_enabled,
             signin_enabled: @signin_enabled,
-            **(@set_variant ? { disabled_homepage_variant: @disabled_homepage_variant } : {}),
+            disabled_homepage_variant: @disabled_homepage_variant,
           )
 
           OT.ld "[PutHomepageConfig] saved domain=#{@custom_domain.identifier} " \

--- a/lib/onetime/models/custom_domain/homepage_config.rb
+++ b/lib/onetime/models/custom_domain/homepage_config.rb
@@ -29,11 +29,6 @@ module Onetime
       # domain falls back to the deployment-wide / frontend default.
       VALID_DISABLED_HOMEPAGE_VARIANTS = %w[v1 minimal closed].freeze
 
-      # Sentinel for upsert: distinguishes "caller omitted the variant" (leave
-      # the stored value as-is) from an explicit nil (clear the per-domain
-      # override so the domain falls back to the default).
-      UNCHANGED_VARIANT = Object.new.freeze
-
       prefix :custom_domain__homepage_config
 
       # domain_id is the CustomDomain's identifier (objid), used as our key.
@@ -190,28 +185,31 @@ module Onetime
         #
         # @param domain_id [String] CustomDomain identifier
         # @param enabled [Boolean, String] Whether to enable homepage secrets
+        # @param disabled_homepage_variant [String, nil] Merge semantics, matching
+        #   signup_enabled/signin_enabled: nil leaves the stored value unchanged;
+        #   "" (or any unrecognised value) clears the override back to the default;
+        #   a recognised id ('v1' | 'minimal' | 'closed') sets it.
         # @return [CustomDomain::HomepageConfig] The config (created or updated)
-        def upsert(domain_id:, enabled:, signup_enabled: nil, signin_enabled: nil, disabled_homepage_variant: UNCHANGED_VARIANT)
+        def upsert(domain_id:, enabled:, signup_enabled: nil, signin_enabled: nil, disabled_homepage_variant: nil)
           raise Onetime::Problem, 'domain_id is required' if domain_id.to_s.empty?
 
           config = find_by_domain_id(domain_id)
           now    = Familia.now.to_i
-          set_variant = !disabled_homepage_variant.equal?(UNCHANGED_VARIANT)
 
           if config
-            config.created      ||= now  # repair missing created from legacy records
-            config.enabled        = enabled.to_s
-            config.signup_enabled = signup_enabled unless signup_enabled.nil?
-            config.signin_enabled = signin_enabled unless signin_enabled.nil?
-            config.disabled_homepage_variant = coerce_disabled_homepage_variant(disabled_homepage_variant) if set_variant
-            config.updated        = now
+            config.created                 ||= now  # repair missing created from legacy records
+            config.enabled                   = enabled.to_s
+            config.signup_enabled            = signup_enabled unless signup_enabled.nil?
+            config.signin_enabled            = signin_enabled unless signin_enabled.nil?
+            config.disabled_homepage_variant = coerce_disabled_homepage_variant(disabled_homepage_variant) unless disabled_homepage_variant.nil?
+            config.updated                   = now
           else
             config = new(
               domain_id: domain_id,
               enabled: enabled.to_s,
               signup_enabled: signup_enabled.nil? || signup_enabled,
               signin_enabled: signin_enabled.nil? || signin_enabled,
-              disabled_homepage_variant: set_variant ? coerce_disabled_homepage_variant(disabled_homepage_variant) : nil,
+              disabled_homepage_variant: coerce_disabled_homepage_variant(disabled_homepage_variant),
               created: now,
               updated: now,
             )

--- a/try/unit/models/custom_domain_homepage_config_try.rb
+++ b/try/unit/models/custom_domain_homepage_config_try.rb
@@ -395,9 +395,14 @@ Onetime::CustomDomain::HomepageConfig.find_by_domain_id(@var_domain.identifier).
 @var_cfg.disabled_homepage_variant_value
 #=> nil
 
-## upsert with explicit nil clears a previously stored variant
+## upsert with explicit nil leaves a previously stored variant unchanged (merge semantics)
 Onetime::CustomDomain::HomepageConfig.upsert(domain_id: @var_domain.identifier, enabled: true, disabled_homepage_variant: 'v1')
 @var_cfg = Onetime::CustomDomain::HomepageConfig.upsert(domain_id: @var_domain.identifier, enabled: true, disabled_homepage_variant: nil)
+@var_cfg.disabled_homepage_variant_value
+#=> 'v1'
+
+## upsert with an empty string clears a previously stored variant (reset to default)
+@var_cfg = Onetime::CustomDomain::HomepageConfig.upsert(domain_id: @var_domain.identifier, enabled: true, disabled_homepage_variant: '')
 @var_cfg.disabled_homepage_variant_value
 #=> nil
 


### PR DESCRIPTION
Stacked on #3433 (base = `claude/dazzling-cray-n7q3h6`, **not** `main`). Merge after #3433.

## What

Replaces the `UNCHANGED_VARIANT` sentinel in `HomepageConfig.upsert` with the same `nil`-means-unchanged convention the `signup_enabled` / `signin_enabled` fields already use, and documents the resulting merge semantics on `PUT /homepage-config`.

| Signal | Behaviour |
| --- | --- |
| omitted / JSON `null` | leave the stored variant **unchanged** |
| `""` (empty string) | reset to the deployment default |
| recognised id (`closed` \| `minimal` \| `v1`) | set it (unknown values coerce to `nil`) |

## Why

Per the discussion on #3433, the sentinel was avoidable. The codebase doesn't distinguish `null` from `""` for scalars, but the two halves of this convention already exist independently:

- **`PatchSsoConfig`** preserves scalars on blank (`… unless @x.to_s.empty?`); the partial-update conditional lives in the logic layer, not a model sentinel.
- **`PutSsoConfig`** documents "empty string or null clears optional fields."
- This model's own `signup_enabled` / `signin_enabled` already treat `nil` as "unchanged."

This is the RFC 7396 (JSON Merge Patch) reading — absent/`null` means "don't touch," a concrete value (including `""`) is the update — and it closes the foot-gun where a client whose serializer defaults an unset field to `null` would silently wipe an operator's override.

Naming note: the endpoint stays `PutHomepageConfig` to match its sibling `PutApiConfig` (same PUT-named, upsert-backed shape); only the merge semantics are documented. Happy to rename to `Patch*` separately if you'd prefer strict verb/semantics alignment.

## Tests

`try/unit/models/custom_domain_homepage_config_try.rb`: the "explicit nil clears" case flips to "explicit nil preserves," plus a new "empty string clears" case. RuboCop clean; **67 tryouts pass** (Ruby 3.4.9).

https://claude.ai/code/session_01RFLbwa9HeSP9T9comwSZb9

---
_Generated by [Claude Code](https://claude.ai/code/session_01RFLbwa9HeSP9T9comwSZb9)_