### PR TITLE
Fix e2e tests for updated invite flow UI and API endpoints

### DIFF
--- a/e2e/full/invitation-email-mismatch-acknowledgment.spec.ts
+++ b/e2e/full/invitation-email-mismatch-acknowledgment.spec.ts
@@ -140,7 +140,7 @@ async function createInvitation(
 /**
  * Get current organization extid from URL
  */
-async function getCurrentOrgExtid(page: Page): Promise<string> {
+function getCurrentOrgExtid(page: Page): string {
   const url = page.url();
   const match = url.match(/\/org\/([^/]+)/);
   return match?.[1] || '';
@@ -150,7 +150,7 @@ async function getCurrentOrgExtid(page: Page): Promise<string> {
  * Extract invitation token from pending invitations list via API
  */
 async function getInvitationToken(page: Page, email: string): Promise<string | null> {
-  const orgExtid = await getCurrentOrgExtid(page);
+  const orgExtid = getCurrentOrgExtid(page);
   const response = await page.request.get(`/api/v2/org/${orgExtid}/invitations`);
   const data = await response.json();
 

--- a/e2e/full/invitation-email-mismatch-acknowledgment.spec.ts
+++ b/e2e/full/invitation-email-mismatch-acknowledgment.spec.ts
@@ -40,11 +40,21 @@ const generateTestEmail = (prefix: string) =>
 // -----------------------------------------------------------------------------
 
 /**
+ * Context options for a truly unauthenticated browser context.
+ *
+ * `browser.newContext()` inherits the `full` project's `use` options —
+ * including its storageState (the owner session) — so a bare newContext()
+ * is NOT unauthenticated. Pass these options to opt out explicitly.
+ */
+const unauthenticatedContext = { storageState: { cookies: [], origins: [] } };
+
+/**
  * Authenticate user via login form using password tab.
  *
- * Only valid on pages from a fresh `browser.newContext()` (unauthenticated):
- * the default `page` fixture already carries the storageState session, and
- * an authenticated visitor to /signin is redirected away from the form.
+ * Only valid on pages from an unauthenticated context
+ * (`browser.newContext(unauthenticatedContext)`): the default `page` fixture
+ * and bare `browser.newContext()` carry the storageState session, and an
+ * authenticated visitor to /signin is redirected away from the form.
  */
 async function loginUser(page: Page, email?: string, password?: string): Promise<void> {
   await page.goto('/signin');
@@ -120,7 +130,7 @@ async function createInvitation(
   await roleSelect.selectOption(role);
 
   // Submit
-  const sendButton = page.getByRole('button', { name: /send invite/i });
+  const sendButton = page.getByRole('button', { name: /send invit/i });
   await sendButton.click();
 
   // Wait for success
@@ -158,8 +168,8 @@ test.describe('MISMATCH-001: Email Mismatch Warning Display', () => {
   test('When logged in with different email, mismatch warning shows Continue As option', async ({
     browser,
   }) => {
-    const ownerContext = await browser.newContext();
-    const wrongUserContext = await browser.newContext();
+    const ownerContext = await browser.newContext(unauthenticatedContext);
+    const wrongUserContext = await browser.newContext(unauthenticatedContext);
 
     const ownerPage = await ownerContext.newPage();
     const wrongUserPage = await wrongUserContext.newPage();
@@ -207,8 +217,8 @@ test.describe('MISMATCH-002: Accept Button Hidden When Email Mismatch', () => {
   test('Accept button is NOT visible when email mismatch exists (strict binding)', async ({
     browser,
   }) => {
-    const ownerContext = await browser.newContext();
-    const wrongUserContext = await browser.newContext();
+    const ownerContext = await browser.newContext(unauthenticatedContext);
+    const wrongUserContext = await browser.newContext(unauthenticatedContext);
 
     const ownerPage = await ownerContext.newPage();
     const wrongUserPage = await wrongUserContext.newPage();
@@ -255,8 +265,8 @@ test.describe('MISMATCH-003: Continue As Triggers Logout', () => {
   test('Clicking "Continue as" logs out user and redirects to invite page', async ({
     browser,
   }) => {
-    const ownerContext = await browser.newContext();
-    const wrongUserContext = await browser.newContext();
+    const ownerContext = await browser.newContext(unauthenticatedContext);
+    const wrongUserContext = await browser.newContext(unauthenticatedContext);
 
     const ownerPage = await ownerContext.newPage();
     const wrongUserPage = await wrongUserContext.newPage();
@@ -283,9 +293,9 @@ test.describe('MISMATCH-003: Continue As Triggers Logout', () => {
       await wrongUserPage.waitForURL(/\/invite\//, { timeout: 10000 });
 
       // Verify user is logged out
-      const response = await wrongUserPage.request.get('/api/v2/bootstrap/authenticated');
+      const response = await wrongUserPage.request.get('/bootstrap/me');
       const data = await response.json();
-      expect(data.authenticated || data.record?.authenticated).toBeFalsy();
+      expect(data.authenticated).toBeFalsy();
     } finally {
       await ownerContext.close();
       await wrongUserContext.close();
@@ -303,9 +313,9 @@ test.describe('MISMATCH-004: Unauthenticated User Sees Inline Auth Forms', () =>
     context,
   }) => {
     // Get the current (storageState) user's email
-    const bootstrapResponse = await page.request.get('/api/v2/bootstrap/authenticated');
+    const bootstrapResponse = await page.request.get('/bootstrap/me');
     const bootstrapData = await bootstrapResponse.json();
-    const currentEmail = bootstrapData.record?.email;
+    const currentEmail = bootstrapData.email;
     expect(currentEmail).toBeTruthy();
 
     // Create invitation for a different test email
@@ -356,8 +366,8 @@ test.describe('MISMATCH-005: API Rejects Email Mismatch', () => {
   test.skip(!hasTestCredentials, 'Skipping: TEST_USER_EMAIL and TEST_USER_PASSWORD required');
 
   test('Direct API call with mismatched email returns error', async ({ browser }) => {
-    const ownerContext = await browser.newContext();
-    const wrongUserContext = await browser.newContext();
+    const ownerContext = await browser.newContext(unauthenticatedContext);
+    const wrongUserContext = await browser.newContext(unauthenticatedContext);
 
     const ownerPage = await ownerContext.newPage();
     const wrongUserPage = await wrongUserContext.newPage();
@@ -391,8 +401,8 @@ test.describe('MISMATCH-005: API Rejects Email Mismatch', () => {
   });
 
   test('API rejects even with acknowledge_email_mismatch flag (security change)', async ({ browser }) => {
-    const ownerContext = await browser.newContext();
-    const wrongUserContext = await browser.newContext();
+    const ownerContext = await browser.newContext(unauthenticatedContext);
+    const wrongUserContext = await browser.newContext(unauthenticatedContext);
 
     const ownerPage = await ownerContext.newPage();
     const wrongUserPage = await wrongUserContext.newPage();

--- a/e2e/full/invite-flow-states.spec.ts
+++ b/e2e/full/invite-flow-states.spec.ts
@@ -42,11 +42,21 @@ const generateTestEmail = (prefix: string) =>
 // -----------------------------------------------------------------------------
 
 /**
+ * Context options for a truly unauthenticated browser context.
+ *
+ * `browser.newContext()` inherits the `full` project's `use` options —
+ * including its storageState (the owner session) — so a bare newContext()
+ * is NOT unauthenticated. Pass these options to opt out explicitly.
+ */
+const unauthenticatedContext = { storageState: { cookies: [], origins: [] } };
+
+/**
  * Authenticate user via login form using password tab.
  *
- * Only valid on pages from a fresh `browser.newContext()` (unauthenticated):
- * the default `page` fixture already carries the storageState session, and
- * an authenticated visitor to /signin is redirected away from the form.
+ * Only valid on pages from an unauthenticated context
+ * (`browser.newContext(unauthenticatedContext)`): the default `page` fixture
+ * and bare `browser.newContext()` carry the storageState session, and an
+ * authenticated visitor to /signin is redirected away from the form.
  */
 async function loginUser(page: Page, email?: string, password?: string): Promise<void> {
   await page.goto('/signin');
@@ -124,7 +134,7 @@ async function createInvitation(
   await roleSelect.selectOption(role);
 
   // Submit
-  const sendButton = page.getByRole('button', { name: /send invite/i });
+  const sendButton = page.getByRole('button', { name: /send invit/i });
   await sendButton.click();
 
   // Wait for success
@@ -191,8 +201,8 @@ test.describe('INV-001: New User Atomic Signup Flow', () => {
       const signupForm = page.getByTestId('invite-signup-form');
       await expect(signupForm).toBeVisible();
 
-      // Email should be displayed (readonly from invitation)
-      await expect(page.getByText(invitedEmail)).toBeVisible();
+      // Email should be displayed (readonly input prefilled from invitation)
+      await expect(page.getByTestId('invite-signup-email-input')).toHaveValue(invitedEmail);
 
       // Fill password fields
       const passwordInput = signupForm.locator('input[type="password"]').first();
@@ -207,13 +217,20 @@ test.describe('INV-001: New User Atomic Signup Flow', () => {
         await termsCheckbox.check();
       }
 
-      // Submit form - "Create Account & Join" button
+      // Submit form - "Continue" button
       const submitButton = signupForm.locator('button[type="submit"]');
       await expect(submitButton).toBeEnabled();
       await submitButton.click();
 
-      // Verify success message and redirect
-      await expect(page.getByText(/accept_success|joined|welcome/i)).toBeVisible({
+      // Signup establishes the session but does NOT accept the invitation:
+      // the state machine recomputes to direct_accept and the user confirms
+      // the join with the explicit Accept button (AcceptInvite.onAuthSuccess).
+      const acceptButton = page.getByTestId('accept-invitation-btn');
+      await expect(acceptButton).toBeVisible({ timeout: 15000 });
+      await acceptButton.click();
+
+      // Verify the terminal accepted state ("Invitation accepted successfully")
+      await expect(page.getByTestId('invite-accepted')).toBeVisible({
         timeout: 15000,
       });
 
@@ -265,8 +282,8 @@ test.describe('INV-004: Existing User Signin Flow', () => {
 
   test('existing user can signin and accept invitation', async ({ browser }) => {
     // Create two browser contexts - one for owner, one for invited user
-    const ownerContext = await browser.newContext();
-    const inviteeContext = await browser.newContext();
+    const ownerContext = await browser.newContext(unauthenticatedContext);
+    const inviteeContext = await browser.newContext(unauthenticatedContext);
 
     const ownerPage = await ownerContext.newPage();
     const inviteePage = await inviteeContext.newPage();
@@ -305,8 +322,10 @@ test.describe('INV-004: Existing User Signin Flow', () => {
         const signinForm = inviteePage.getByTestId('invite-signin-form');
         await expect(signinForm).toBeVisible();
 
-        // Email should be displayed (readonly from invitation)
-        await expect(inviteePage.getByText(invitedEmail)).toBeVisible();
+        // Email should be displayed (readonly input prefilled from invitation)
+        await expect(inviteePage.getByTestId('invite-signin-email-input')).toHaveValue(
+          invitedEmail
+        );
 
         // The form expects password for the invited email
         // Since this is a generated email, the account may not exist
@@ -350,8 +369,8 @@ test.describe('INV-006: Direct Accept Flow', () => {
 
   test('signed-in user with matching email can accept directly', async ({ browser }) => {
     // Create two contexts - owner creates invitation for test user email
-    const ownerContext = await browser.newContext();
-    const matchingUserContext = await browser.newContext();
+    const ownerContext = await browser.newContext(unauthenticatedContext);
+    const matchingUserContext = await browser.newContext(unauthenticatedContext);
 
     const ownerPage = await ownerContext.newPage();
     const matchingUserPage = await matchingUserContext.newPage();
@@ -452,8 +471,8 @@ test.describe('INV-007: Wrong Email State', () => {
   test.skip(!hasTestCredentials, 'Skipping: TEST_USER_EMAIL and TEST_USER_PASSWORD required');
 
   test('signed-in user with wrong email sees continue-as prompt', async ({ browser }) => {
-    const ownerContext = await browser.newContext();
-    const wrongUserContext = await browser.newContext();
+    const ownerContext = await browser.newContext(unauthenticatedContext);
+    const wrongUserContext = await browser.newContext(unauthenticatedContext);
 
     const ownerPage = await ownerContext.newPage();
     const wrongUserPage = await wrongUserContext.newPage();
@@ -503,9 +522,9 @@ test.describe('INV-007: Wrong Email State', () => {
       await wrongUserPage.waitForURL(/\/invite\//, { timeout: 10000 });
 
       // Verify user is logged out
-      const response = await wrongUserPage.request.get('/api/v2/bootstrap/authenticated');
+      const response = await wrongUserPage.request.get('/bootstrap/me');
       const data = await response.json();
-      expect(data.authenticated || data.record?.authenticated).toBeFalsy();
+      expect(data.authenticated).toBeFalsy();
     } finally {
       await ownerContext.close();
       await wrongUserContext.close();
@@ -521,9 +540,9 @@ test.describe('INV-008: Already Member State', () => {
   test('already member shows info message', async ({ page }) => {
     // The storageState session is the org owner (already a member of their org)
     // Get owner's email
-    const bootstrapResponse = await page.request.get('/api/v2/bootstrap/authenticated');
+    const bootstrapResponse = await page.request.get('/bootstrap/me');
     const bootstrapData = await bootstrapResponse.json();
-    const ownerEmail = bootstrapData.record?.email;
+    const ownerEmail = bootstrapData.email;
     expect(ownerEmail).toBeTruthy();
 
     // Navigate to org team and try to create invitation for self
@@ -536,11 +555,13 @@ test.describe('INV-008: Already Member State', () => {
     const emailInput = page.locator('#invite-email');
     await emailInput.fill(ownerEmail);
 
-    const sendButton = page.getByRole('button', { name: /send invite/i });
+    const sendButton = page.getByRole('button', { name: /send invit/i });
     await sendButton.click();
 
-    // Should show error about already being a member
-    await expect(page.getByText(/already|member|exists/i)).toBeVisible({ timeout: 10000 });
+    // Should show error about already being a member. Keep the pattern
+    // specific: bare /member/i matches the team page chrome (Invite Member
+    // button, Members heading) and trips strict mode.
+    await expect(page.getByText(/already a member/i)).toBeVisible({ timeout: 10000 });
   });
 });
 
@@ -677,11 +698,12 @@ test.describe('Invite Flow State Transitions', () => {
     await expect(page.locator('html[data-app-ready="true"]')).toBeAttached();
 
     // Invitation context should show:
-    // - Invited email
-    await expect(page.getByText(testEmail)).toBeVisible();
+    // - Invited email (readonly input prefilled from the invitation; the
+    //   email is not rendered as page text in the signup_required state)
+    await expect(page.getByTestId('invite-signup-email-input')).toHaveValue(testEmail);
 
     // - Role (member/admin)
-    await expect(page.getByText(/member|admin/i)).toBeVisible();
+    await expect(page.getByText(/member|admin/i).first()).toBeVisible();
 
     // - Organization name (varies by test environment)
     const invitationContext = page.getByTestId('invitation-context');

--- a/e2e/full/invite-token-security.spec.ts
+++ b/e2e/full/invite-token-security.spec.ts
@@ -86,7 +86,7 @@ async function createInvitation(
   await roleSelect.selectOption(role);
 
   // Submit
-  const sendButton = page.getByRole('button', { name: /send invite/i });
+  const sendButton = page.getByRole('button', { name: /send invit/i });
   await sendButton.click();
 
   // Wait for success
@@ -187,11 +187,11 @@ test.describe('SEC-INV-001: Garbage invite_token does NOT auto-login', () => {
     // Regardless of whether account creation succeeded (200) or was rejected
     // (e.g., CSRF issue, validation error), the critical assertion is that
     // the garbage invite_token did NOT grant an authenticated session.
-    const authResponse = await page.request.get('/api/v2/bootstrap/authenticated');
+    const authResponse = await page.request.get('/bootstrap/me');
     const authData = await authResponse.json();
 
     // SECURITY ASSERTION: garbage token must NOT grant authenticated session
-    expect(authData.authenticated || authData.record?.authenticated).toBeFalsy();
+    expect(authData.authenticated).toBeFalsy();
   });
 });
 
@@ -227,9 +227,9 @@ test.describe('SEC-INV-002: Garbage invite_token does NOT suppress verification'
 
     // Whether the POST succeeded (200) or was rejected by middleware (403),
     // the user must NOT be authenticated.
-    const authResponse = await page.request.get('/api/v2/bootstrap/authenticated');
+    const authResponse = await page.request.get('/bootstrap/me');
     const authData = await authResponse.json();
-    expect(authData.authenticated || authData.record?.authenticated).toBeFalsy();
+    expect(authData.authenticated).toBeFalsy();
 
     if (status === 200) {
       // Account was created. Now verify the account is NOT auto-verified
@@ -317,20 +317,22 @@ test.describe('SEC-INV-003: Valid invite_token auto-login works', () => {
         await termsCheckbox.check();
       }
 
-      // Submit - "Create Account & Join" or similar
+      // Submit - "Continue" button
       const submitButton = signupForm.locator('button[type="submit"]');
       await expect(submitButton).toBeEnabled();
       await submitButton.click();
 
-      // Wait for success - should redirect (autologin fires with valid token)
-      await expect(
-        page.getByText(/accept_success|joined|welcome|success/i)
-      ).toBeVisible({ timeout: 15000 });
+      // Signup with a valid token establishes a session (autologin) and the
+      // page recomputes to the direct_accept confirmation state - the
+      // invitation itself stays pending until the explicit Accept click.
+      await expect(page.getByTestId('invite-direct-accept')).toBeVisible({
+        timeout: 15000,
+      });
 
       // Verify user IS authenticated (autologin worked)
-      const authResponse = await page.request.get('/api/v2/bootstrap/authenticated');
+      const authResponse = await page.request.get('/bootstrap/me');
       const authData = await authResponse.json();
-      expect(authData.authenticated || authData.record?.authenticated).toBeTruthy();
+      expect(authData.authenticated).toBeTruthy();
     } else if (isSigninRequired) {
       // Account already exists for this generated email - unusual but possible
       test.info().annotations.push({
@@ -349,6 +351,10 @@ test.describe('SEC-INV-004: Direct API attack with garbage invite_token', () => 
   test('POST to /auth/create-account with garbage invite_token does not grant a session', async ({
     page,
   }) => {
+    // The full project starts authenticated via storageState; this scenario
+    // simulates an *anonymous* attacker, so drop that session first.
+    await page.context().clearCookies();
+
     const testEmail = generateTestEmail('api-attack');
     const testPassword = 'TestPassword123!';
 
@@ -378,11 +384,11 @@ test.describe('SEC-INV-004: Direct API attack with garbage invite_token', () => 
       // but the critical check: was a session cookie set? (autologin)
 
       // Check if we got auto-logged-in (we should NOT be)
-      const authResponse = await page.request.get('/api/v2/bootstrap/authenticated');
+      const authResponse = await page.request.get('/bootstrap/me');
       const authData = await authResponse.json();
 
       // SECURITY ASSERTION: garbage token must NOT grant authenticated session
-      expect(authData.authenticated || authData.record?.authenticated).toBeFalsy();
+      expect(authData.authenticated).toBeFalsy();
 
       // Also verify: if we try to access protected resources, we're denied
       const protectedResponse = await page.request.get('/api/v2/account', {
@@ -397,6 +403,9 @@ test.describe('SEC-INV-004: Direct API attack with garbage invite_token', () => 
   test('POST to /auth/create-account with empty invite_token behaves normally', async ({
     page,
   }) => {
+    // Anonymous-visitor scenario: drop the storageState session first.
+    await page.context().clearCookies();
+
     const testEmail = generateTestEmail('empty-token');
     const testPassword = 'TestPassword123!';
 
@@ -419,15 +428,18 @@ test.describe('SEC-INV-004: Direct API attack with garbage invite_token', () => 
 
     if (response.status() === 200) {
       // No autologin should happen with empty token
-      const authResponse = await page.request.get('/api/v2/bootstrap/authenticated');
+      const authResponse = await page.request.get('/bootstrap/me');
       const authData = await authResponse.json();
-      expect(authData.authenticated || authData.record?.authenticated).toBeFalsy();
+      expect(authData.authenticated).toBeFalsy();
     }
   });
 
   test('POST to /auth/create-account with UUID-shaped fake token does not grant a session', async ({
     page,
   }) => {
+    // Anonymous-visitor scenario: drop the storageState session first.
+    await page.context().clearCookies();
+
     const testEmail = generateTestEmail('uuid-fake-token');
     const testPassword = 'TestPassword123!';
 
@@ -452,9 +464,9 @@ test.describe('SEC-INV-004: Direct API attack with garbage invite_token', () => 
     });
 
     if (response.status() === 200) {
-      const authResponse = await page.request.get('/api/v2/bootstrap/authenticated');
+      const authResponse = await page.request.get('/bootstrap/me');
       const authData = await authResponse.json();
-      expect(authData.authenticated || authData.record?.authenticated).toBeFalsy();
+      expect(authData.authenticated).toBeFalsy();
     }
   });
 });
@@ -467,6 +479,10 @@ test.describe('SEC-INV-005: Invite page with garbage token', () => {
   test('visiting /invite/garbage-token shows invalid state with no auth forms', async ({
     page,
   }) => {
+    // The final assertion checks an anonymous visitor stays unauthenticated,
+    // so drop the storageState session first.
+    await page.context().clearCookies();
+
     const garbageToken = 'garbage_security_test_' + Date.now();
 
     await page.goto(`/invite/${garbageToken}`);
@@ -492,9 +508,9 @@ test.describe('SEC-INV-005: Invite page with garbage token', () => {
     await expect(declineButton).not.toBeVisible();
 
     // User should NOT be authenticated
-    const authResponse = await page.request.get('/api/v2/bootstrap/authenticated');
+    const authResponse = await page.request.get('/bootstrap/me');
     const authData = await authResponse.json();
-    expect(authData.authenticated || authData.record?.authenticated).toBeFalsy();
+    expect(authData.authenticated).toBeFalsy();
   });
 });
 

--- a/e2e/full/org-invitation-flow.spec.ts
+++ b/e2e/full/org-invitation-flow.spec.ts
@@ -164,7 +164,7 @@ async function getInvitationToken(page: Page, email: string): Promise<string | n
   // We'll need to intercept the API call or check the URL after clicking
   // For now, we'll use the API to get the token
   const response = await page.request.get(
-    `/api/v2/org/${await getCurrentOrgExtid(page)}/invitations`
+    `/api/v2/org/${getCurrentOrgExtid(page)}/invitations`
   );
   const data = await response.json();
 
@@ -175,7 +175,7 @@ async function getInvitationToken(page: Page, email: string): Promise<string | n
 /**
  * Get current organization extid from URL
  */
-async function getCurrentOrgExtid(page: Page): Promise<string> {
+function getCurrentOrgExtid(page: Page): string {
   const url = page.url();
   const match = url.match(/\/org\/([^/]+)/);
   return match?.[1] || '';

--- a/e2e/full/org-invitation-flow.spec.ts
+++ b/e2e/full/org-invitation-flow.spec.ts
@@ -50,11 +50,21 @@ const generateTestEmail = (prefix: string) =>
 // -----------------------------------------------------------------------------
 
 /**
+ * Context options for a truly unauthenticated browser context.
+ *
+ * `browser.newContext()` inherits the `full` project's `use` options —
+ * including its storageState (the owner session) — so a bare newContext()
+ * is NOT unauthenticated. Pass these options to opt out explicitly.
+ */
+const unauthenticatedContext = { storageState: { cookies: [], origins: [] } };
+
+/**
  * Authenticate user via login form using password tab.
  *
- * Only valid on pages from a fresh `browser.newContext()` (unauthenticated):
- * the default `page` fixture already carries the storageState session, and
- * an authenticated visitor to /signin is redirected away from the form.
+ * Only valid on pages from an unauthenticated context
+ * (`browser.newContext(unauthenticatedContext)`): the default `page` fixture
+ * and bare `browser.newContext()` carry the storageState session, and an
+ * authenticated visitor to /signin is redirected away from the form.
  */
 async function loginUser(page: Page, email?: string, password?: string): Promise<void> {
   await page.goto('/signin');
@@ -130,7 +140,7 @@ async function createInvitation(
   await roleSelect.selectOption(role);
 
   // Submit
-  const sendButton = page.getByRole('button', { name: /send invite/i });
+  const sendButton = page.getByRole('button', { name: /send invit/i });
   await sendButton.click();
 
   // Wait for success
@@ -229,7 +239,7 @@ test.describe('INV-001: Organization Invitation Sending', () => {
     await emailInput.fill(testEmail);
     await roleSelect.selectOption('member');
 
-    const sendButton = page.getByRole('button', { name: /send invite/i });
+    const sendButton = page.getByRole('button', { name: /send invit/i });
     await sendButton.click();
 
     // Verify success message
@@ -284,8 +294,8 @@ test.describe('INV-002: Unauthenticated User Inline Auth Flow', () => {
       // Inline signup form should be visible
       const signupForm = page.getByTestId('invite-signup-form');
       await expect(signupForm).toBeVisible();
-      // Email should be displayed from invitation
-      await expect(page.getByText(testEmail)).toBeVisible();
+      // Email should be displayed from invitation (readonly input value)
+      await expect(page.getByTestId('invite-signup-email-input')).toHaveValue(testEmail);
     } else if (hasSigninForm) {
       // Inline signin form should be visible
       const signinForm = page.getByTestId('invite-signin-form');
@@ -304,8 +314,8 @@ test.describe('INV-003: Email Mismatch Warning', () => {
     browser,
   }) => {
     // Create two browser contexts - one for owner, one for wrong user
-    const ownerContext = await browser.newContext();
-    const wrongUserContext = await browser.newContext();
+    const ownerContext = await browser.newContext(unauthenticatedContext);
+    const wrongUserContext = await browser.newContext(unauthenticatedContext);
 
     const ownerPage = await ownerContext.newPage();
     const wrongUserPage = await wrongUserContext.newPage();
@@ -336,8 +346,9 @@ test.describe('INV-003: Email Mismatch Warning', () => {
       // Verify warning shows factual "Different account" framing
       await expect(wrongUserPage.getByText(/different|mismatch/i)).toBeVisible();
 
-      // Verify invited email is shown
-      await expect(wrongUserPage.getByText(invitedEmail)).toBeVisible();
+      // Verify invited email is shown (appears in both the warning body and
+      // the "Continue as" button - first() avoids a strict mode violation)
+      await expect(wrongUserPage.getByText(invitedEmail).first()).toBeVisible();
 
       // Verify "Continue as" button is visible (using testid)
       const continueAsBtn = wrongUserPage.getByTestId('continue-as-btn');
@@ -359,8 +370,8 @@ test.describe('INV-004: Continue As Invited Email Flow', () => {
   test('Clicking Continue As logs out and redirects to invite page', async ({
     browser,
   }) => {
-    const ownerContext = await browser.newContext();
-    const wrongUserContext = await browser.newContext();
+    const ownerContext = await browser.newContext(unauthenticatedContext);
+    const wrongUserContext = await browser.newContext(unauthenticatedContext);
 
     const ownerPage = await ownerContext.newPage();
     const wrongUserPage = await wrongUserContext.newPage();
@@ -387,9 +398,9 @@ test.describe('INV-004: Continue As Invited Email Flow', () => {
       await wrongUserPage.waitForURL(/\/invite\//, { timeout: 10000 });
 
       // Verify user is logged out by checking API
-      const response = await wrongUserPage.request.get('/api/v2/bootstrap/authenticated');
+      const response = await wrongUserPage.request.get('/bootstrap/me');
       const data = await response.json();
-      expect(data.authenticated || data.record?.authenticated).toBeFalsy();
+      expect(data.authenticated).toBeFalsy();
     } finally {
       await ownerContext.close();
       await wrongUserContext.close();
@@ -407,7 +418,7 @@ test.describe('INV-005: Matching Email User Flow', () => {
     // We'll simulate by having the org owner invite themselves (edge case) or
     // by creating a specific user account first
 
-    const ownerContext = await browser.newContext();
+    const ownerContext = await browser.newContext(unauthenticatedContext);
     const ownerPage = await ownerContext.newPage();
 
     try {
@@ -431,12 +442,17 @@ test.describe('INV-005: Matching Email User Flow', () => {
       await ownerPage.goto(`/invite/${token}`);
       await expect(ownerPage.locator('html[data-app-ready="true"]')).toBeAttached();
 
-      // Accept button should be visible (even for unauthenticated)
-      const acceptButton = ownerPage.getByRole('button', { name: /accept/i });
-      await expect(acceptButton).toBeVisible();
+      // Unauthenticated + unknown email shows the signup_required state with
+      // an inline signup form: a "Continue" submit (the accept path) and a
+      // "Decline" button - there is no standalone Accept button here.
+      const signupState = ownerPage.getByTestId('invite-signup-required');
+      await expect(signupState).toBeVisible();
+
+      const signupSubmit = ownerPage.getByTestId('invite-signup-submit');
+      await expect(signupSubmit).toBeVisible();
 
       // Decline button should also be visible
-      const declineButton = ownerPage.getByRole('button', { name: /decline/i });
+      const declineButton = ownerPage.getByTestId('invite-signup-decline');
       await expect(declineButton).toBeVisible();
 
       // Invitation details should show organization and role
@@ -624,9 +640,9 @@ test.describe('INV-014: Duplicate Member Invitation', () => {
     await navigateToOrgTeam(page);
 
     // Get the owner's email (who is already a member)
-    const bootstrapResponse = await page.request.get('/api/v2/bootstrap/authenticated');
+    const bootstrapResponse = await page.request.get('/bootstrap/me');
     const bootstrapData = await bootstrapResponse.json();
-    const ownerEmail = bootstrapData.record?.email;
+    const ownerEmail = bootstrapData.email;
 
     // Try to invite the owner (existing member)
     const inviteButton = page.getByRole('button', { name: /invite member/i });
@@ -635,11 +651,13 @@ test.describe('INV-014: Duplicate Member Invitation', () => {
     const emailInput = page.locator('#invite-email');
     await emailInput.fill(ownerEmail);
 
-    const sendButton = page.getByRole('button', { name: /send invite/i });
+    const sendButton = page.getByRole('button', { name: /send invit/i });
     await sendButton.click();
 
-    // Should show error about already being a member
-    await expect(page.getByText(/already|member|exists/i)).toBeVisible({ timeout: 10000 });
+    // Should show error about already being a member. Keep the pattern
+    // specific: bare /member/i matches the team page chrome (Invite Member
+    // button, Members heading) and trips strict mode.
+    await expect(page.getByText(/already a member/i)).toBeVisible({ timeout: 10000 });
   });
 });
 
@@ -719,8 +737,8 @@ test.describe('INV-SEC-002: Account Enumeration Prevention', () => {
   test('Continue-as flow does not reveal whether invited email has existing account', async ({
     browser,
   }) => {
-    const ownerContext = await browser.newContext();
-    const wrongUserContext = await browser.newContext();
+    const ownerContext = await browser.newContext(unauthenticatedContext);
+    const wrongUserContext = await browser.newContext(unauthenticatedContext);
 
     const ownerPage = await ownerContext.newPage();
     const wrongUserPage = await wrongUserContext.newPage();

--- a/e2e/full/organization-members.spec.ts
+++ b/e2e/full/organization-members.spec.ts
@@ -372,7 +372,7 @@ test.describe('MBR-INVITE: Invite Member Flow', () => {
     const emailInput = page.locator('#invite-email');
     await emailInput.fill('invalid-email');
 
-    const sendButton = page.getByRole('button', { name: /send invite/i });
+    const sendButton = page.getByRole('button', { name: /send invit/i });
     await sendButton.click();
 
     // Should show validation error or HTML5 validation prevents submission
@@ -390,9 +390,9 @@ test.describe('MBR-INVITE: Invite Member Flow', () => {
     }
 
     // Get the owner's email (who is already a member)
-    const bootstrapResponse = await page.request.get('/api/v2/bootstrap/authenticated');
+    const bootstrapResponse = await page.request.get('/bootstrap/me');
     const bootstrapData = await bootstrapResponse.json();
-    const ownerEmail = bootstrapData.record?.email;
+    const ownerEmail = bootstrapData.email;
 
     if (!ownerEmail) {
       test.skip(true, 'Could not get owner email from bootstrap');
@@ -406,11 +406,13 @@ test.describe('MBR-INVITE: Invite Member Flow', () => {
     const emailInput = page.locator('#invite-email');
     await emailInput.fill(ownerEmail);
 
-    const sendButton = page.getByRole('button', { name: /send invite/i });
+    const sendButton = page.getByRole('button', { name: /send invit/i });
     await sendButton.click();
 
-    // Should show error about already being a member
-    await expect(page.getByText(/already|member|exists/i)).toBeVisible({ timeout: 10000 });
+    // Should show error about already being a member. Keep the pattern
+    // specific: bare /member/i matches the team page chrome (Invite Member
+    // button, Members heading) and trips strict mode.
+    await expect(page.getByText(/already a member/i)).toBeVisible({ timeout: 10000 });
   });
 });
 


### PR DESCRIPTION
## Summary

Updates end-to-end tests to align with changes to the invitation flow UI components, API endpoints, and state machine behavior. The changes ensure tests accurately reflect the current implementation of the invitation acceptance flow.

## Key Changes

### Test Infrastructure
- Added `unauthenticatedContext` helper constant to explicitly create truly unauthenticated browser contexts, since `browser.newContext()` inherits the project's `storageState` (owner session) by default
- Updated all multi-context tests to use `unauthenticatedContext` when creating separate user contexts

### API Endpoint Updates
- Updated bootstrap API calls from `/api/v2/bootstrap/authenticated` to `/bootstrap/me`
- Simplified response data access: changed from `data.record?.email` to `data.email` and `data.authenticated || data.record?.authenticated` to `data.authenticated`

### UI Component Selector Updates
- Changed button selectors from `/send invite/i` to `/send invit/i` (case-insensitive partial match)
- Updated email display assertions to use `getByTestId('invite-signup-email-input')` with `.toHaveValue()` instead of `.getByText()`, reflecting that emails are now readonly input fields rather than displayed text
- Updated error message assertions to use more specific patterns like `/already a member/i` instead of broad `/already|member|exists/i` to avoid strict mode violations

### Invitation Flow State Changes
- Updated tests to reflect that signup with a valid token establishes a session but does NOT immediately accept the invitation
- Added explicit Accept button click after signup (the state machine recomputes to `direct_accept` state)
- Changed success assertions to look for `invite-accepted` or `invite-direct-accept` test IDs instead of generic success messages
- Updated test expectations for the `INV-005: Matching Email User Flow` to expect signup form in `signup_required` state rather than a standalone Accept button

### Security Test Updates
- Added `clearCookies()` calls in security tests (`SEC-INV-004`, `SEC-INV-005`) to simulate anonymous attacker scenarios, since the test context starts authenticated via `storageState`

## Test Plan

All changes are to e2e test files. The test suite validates:
- Invitation creation and sending
- User signup/signin flows with invitations
- Email mismatch handling and "Continue As" flows
- Direct accept flows for matching emails
- Security scenarios with invalid/garbage tokens
- API endpoint behavior and authentication state

Existing test infrastructure and CI will validate these changes.

https://claude.ai/code/session_01Dh42b89eiUX8WVncE8rnzU