### PR TITLE
Honour continue=false on burn endpoints (v1 and v2)

### DIFF
--- a/apps/api/v1/logic/secrets/burn_secret.rb
+++ b/apps/api/v1/logic/secrets/burn_secret.rb
@@ -33,11 +33,9 @@ module V1::Logic
 
           @correct_passphrase = !potential_secret.has_passphrase? || potential_secret.passphrase?(passphrase)
           viewable = potential_secret.viewable?
-          # Use the parsed @continue boolean (set in process_params), not the raw
-          # param. The raw value is a string for form/query requests, and every
-          # non-empty string — including "false" — is truthy in Ruby, so reading
-          # params['continue'] directly would burn the secret even when the
-          # client explicitly sent continue=false.
+          # Use the parsed boolean (true / 'true' only), not the raw param: the
+          # raw value treats any non-empty string as truthy, so a deliberate
+          # `continue=false` would burn the secret anyway.
           @greenlighted = viewable && correct_passphrase && continue
 
           if greenlighted

--- a/apps/api/v1/logic/secrets/burn_secret.rb
+++ b/apps/api/v1/logic/secrets/burn_secret.rb
@@ -33,8 +33,12 @@ module V1::Logic
 
           @correct_passphrase = !potential_secret.has_passphrase? || potential_secret.passphrase?(passphrase)
           viewable = potential_secret.viewable?
-          continue_result = params['continue']
-          @greenlighted = viewable && correct_passphrase && continue_result
+          # Use the parsed @continue boolean (set in process_params), not the raw
+          # param. The raw value is a string for form/query requests, and every
+          # non-empty string — including "false" — is truthy in Ruby, so reading
+          # params['continue'] directly would burn the secret even when the
+          # client explicitly sent continue=false.
+          @greenlighted = viewable && correct_passphrase && continue
 
           if greenlighted
             @secret = potential_secret

--- a/apps/api/v1/spec/logic/secrets/burn_secret_spec.rb
+++ b/apps/api/v1/spec/logic/secrets/burn_secret_spec.rb
@@ -81,5 +81,29 @@ RSpec.describe V1::Logic::Secrets::BurnSecret do
         expect(secret).to have_received(:burned!)
       end
     end
+
+    # Regression: the burn must honour the parsed `continue` boolean, not the
+    # raw param. Every non-empty string is truthy in Ruby, so reading
+    # params['continue'] directly burned the secret even when the caller
+    # explicitly sent continue=false (the common form/query shape).
+    context 'when continue is the string "false"' do
+      subject { described_class.new(session, customer, base_params.merge('continue' => 'false')) }
+
+      before do
+        allow(secret).to receive(:burned!)
+      end
+
+      it 'does not burn the secret' do
+        subject.process
+
+        expect(secret).not_to have_received(:burned!)
+      end
+
+      it 'does not greenlight the burn' do
+        subject.process
+
+        expect(subject.greenlighted).to be_falsey
+      end
+    end
   end
 end

--- a/apps/api/v1/spec/logic/secrets/burn_secret_spec.rb
+++ b/apps/api/v1/spec/logic/secrets/burn_secret_spec.rb
@@ -49,9 +49,8 @@ RSpec.describe V1::Logic::Secrets::BurnSecret do
 
   before do
     allow(Onetime::Receipt).to receive(:load).with('receipt123').and_return(receipt)
-    # Stub load_owner (the correct method name) on the secret.
-    # The production code at burn_secret.rb:39 calls load_customer,
-    # which does NOT exist, so process will raise NoMethodError.
+    # Stub load_owner on the secret — process calls it to resolve the owner
+    # before incrementing their secrets_burned counter.
     allow(secret).to receive(:load_owner).and_return(owner)
   end
 
@@ -64,8 +63,6 @@ RSpec.describe V1::Logic::Secrets::BurnSecret do
       it 'calls load_owner on the secret to retrieve the owner' do
         subject.process
 
-        # This test will FAIL because the production code calls
-        # secret.load_customer instead of secret.load_owner
         expect(secret).to have_received(:load_owner)
       end
 
@@ -82,10 +79,10 @@ RSpec.describe V1::Logic::Secrets::BurnSecret do
       end
     end
 
-    # Regression: the burn must honour the parsed `continue` boolean, not the
-    # raw param. Every non-empty string is truthy in Ruby, so reading
-    # params['continue'] directly burned the secret even when the caller
-    # explicitly sent continue=false (the common form/query shape).
+    # Regression: the greenlight must honor the parsed `continue` boolean, not
+    # the raw param. The string "false" is truthy in Ruby, so the previous
+    # `continue_result = params['continue']` would burn a secret even when the
+    # caller explicitly passed continue=false.
     context 'when continue is the string "false"' do
       subject { described_class.new(session, customer, base_params.merge('continue' => 'false')) }
 
@@ -99,7 +96,7 @@ RSpec.describe V1::Logic::Secrets::BurnSecret do
         expect(secret).not_to have_received(:burned!)
       end
 
-      it 'does not greenlight the burn' do
+      it 'is not greenlighted' do
         subject.process
 
         expect(subject.greenlighted).to be_falsey

--- a/apps/api/v2/logic/secrets/burn_secret.rb
+++ b/apps/api/v2/logic/secrets/burn_secret.rb
@@ -53,11 +53,9 @@ module V2::Logic
 
         @correct_passphrase = !potential_secret.has_passphrase? || potential_secret.passphrase?(passphrase)
         viewable            = potential_secret.viewable?
-        # Use the parsed @continue boolean (set in process_params), not the raw
-        # param. The raw value is a string for form/query requests, and every
-        # non-empty string — including "false" — is truthy in Ruby, so reading
-        # params['continue'] directly would burn the secret even when the
-        # client explicitly sent continue=false.
+        # Use the parsed boolean (true / 'true' only), not the raw param: the
+        # raw value treats any non-empty string as truthy, so a deliberate
+        # `continue=false` would burn the secret anyway.
         @greenlighted       = viewable && correct_passphrase && continue
 
         secret_logger.debug 'Secret burn initiated',

--- a/apps/api/v2/logic/secrets/burn_secret.rb
+++ b/apps/api/v2/logic/secrets/burn_secret.rb
@@ -53,8 +53,12 @@ module V2::Logic
 
         @correct_passphrase = !potential_secret.has_passphrase? || potential_secret.passphrase?(passphrase)
         viewable            = potential_secret.viewable?
-        continue_result     = params['continue']
-        @greenlighted       = viewable && correct_passphrase && continue_result
+        # Use the parsed @continue boolean (set in process_params), not the raw
+        # param. The raw value is a string for form/query requests, and every
+        # non-empty string — including "false" — is truthy in Ruby, so reading
+        # params['continue'] directly would burn the secret even when the
+        # client explicitly sent continue=false.
+        @greenlighted       = viewable && correct_passphrase && continue
 
         secret_logger.debug 'Secret burn initiated',
           {
@@ -63,7 +67,7 @@ module V2::Logic
             viewable: viewable,
             has_passphrase: potential_secret.has_passphrase?,
             passphrase_correct: correct_passphrase,
-            continue: continue_result,
+            continue: continue,
             user_id: cust&.custid,
           }
 

--- a/apps/api/v2/spec/logic/secrets/burn_secret_spec.rb
+++ b/apps/api/v2/spec/logic/secrets/burn_secret_spec.rb
@@ -1,87 +1,75 @@
-# apps/api/v2/spec/logic/secrets/burn_secret_spec.rb
+# apps/api/v2/spec/logic/secrets/burn_secret.rb
 #
 # frozen_string_literal: true
 
+require_relative '../../../application'
 require_relative File.join(Onetime::HOME, 'spec', 'spec_helper')
-require_relative File.join(Onetime::HOME, 'spec', 'support', 'model_test_helper.rb')
 
-# Regression coverage for the v2 burn endpoint mirroring the v1 spec: the
-# destructive burn must be gated on the parsed `continue` boolean, not the raw
-# param. Every non-empty string is truthy in Ruby, so reading params['continue']
-# directly burned the secret even when the caller explicitly sent
-# continue=false (the common form/query shape).
+# Regression coverage for the v2 burn confirmation flag.
 #
-# V2::Logic::Base#initialize wires session/customer/org/domain context from a
-# StrategyResult, none of which is relevant to the greenlight decision. We
-# exercise #process in isolation by populating the inputs it reads and stubbing
-# success_data (whose URL/serialization chain is out of scope here).
-RSpec.describe V2::Logic::Secrets::BurnSecret do
-  before(:all) { OT.boot!(:test) }
-
-  let(:customer) do
-    double('Onetime::Customer', anonymous?: false, custid: 'cust123', objid: 'cust123', increment_field: nil)
+# BurnSecret#process must greenlight the destructive burn on the parsed
+# `@continue` boolean (true / 'true' only), NOT the raw params['continue']
+# string — every non-empty string is truthy in Ruby, so reading the raw param
+# would burn the secret even when the caller explicitly sent continue=false.
+#
+# Uses real Receipt/Secret objects (spawn_pair) so process -> success_data runs
+# end-to-end without stubbing the URL/serialization helpers.
+RSpec.describe V2::Logic::Secrets::BurnSecret, type: :integration do
+  before(:all) do
+    require 'onetime'
+    Onetime.boot! :test
   end
 
-  let(:secret) do
-    double('Onetime::Secret',
-      identifier: 'secret123',
-      shortid: 'secret12',
-      viewable?: true,
-      has_passphrase?: false,
-      passphrase?: true,
-      load_owner: nil)
+  def mock_session
+    store = {}
+    session = double('Session')
+    allow(session).to receive(:[]) { |k| store[k] }
+    allow(session).to receive(:[]=) { |k, v| store[k] = v }
+    session
   end
 
-  let(:receipt) { double('Onetime::Receipt', identifier: 'receipt123', load_secret: secret) }
+  # Build a BurnSecret instance over a real receipt with the api_access
+  # entitlement granted (we exercise process directly, not raise_concerns).
+  def build_logic(params)
+    customer = double('Customer', custid: 'anon', anonymous?: true, objid: nil)
+    org      = double('Organization', objid: "org_#{SecureRandom.hex(4)}")
+    allow(org).to receive(:can?).and_return(true)
 
-  def build_subject(continue:)
-    logic = described_class.allocate
-    logic.instance_variable_set(:@receipt, receipt)
-    logic.instance_variable_set(:@passphrase, 'pass123')
-    logic.instance_variable_set(:@continue, [true, 'true'].include?(continue))
-    logic.instance_variable_set(:@params, { 'continue' => continue })
-    logic.instance_variable_set(:@cust, customer)
-    allow(logic).to receive(:success_data).and_return({})
-    logic
+    strategy_result = double('StrategyResult',
+      session: mock_session,
+      user: customer,
+      metadata: { organization: org },
+      auth_method: 'basicauth')
+
+    # process derives cust from strategy_result.user and never calls org, so no
+    # accessor stubbing is needed (we exercise process directly, not raise_concerns).
+    described_class.new(strategy_result, params)
   end
 
-  describe '#process' do
-    before { allow(secret).to receive(:burned!) }
+  let!(:pair)    { Onetime::Receipt.spawn_pair(nil, 3600, 'a secret value') }
+  let(:receipt)  { pair.first }
+  let(:secret)   { pair.last }
 
-    context 'when continue is the string "false"' do
-      subject { build_subject(continue: 'false') }
+  context 'when continue is the string "false"' do
+    it 'does not greenlight and leaves the secret intact' do
+      logic = build_logic('identifier' => receipt.identifier, 'continue' => 'false')
+      logic.process_params
+      logic.process
 
-      it 'does not burn the secret' do
-        subject.process
-
-        expect(secret).not_to have_received(:burned!)
-      end
-
-      it 'does not greenlight the burn' do
-        subject.process
-
-        expect(subject.greenlighted).to be_falsey
-      end
+      expect(logic.greenlighted).to be_falsey
+      # The secret was not burned, so it is still loadable and viewable.
+      reloaded = Onetime::Secret.load(secret.identifier)
+      expect(reloaded&.viewable?).to be true
     end
+  end
 
-    context 'when continue is the string "true"' do
-      subject { build_subject(continue: 'true') }
+  context 'when continue is "true"' do
+    it 'greenlights and burns the secret' do
+      logic = build_logic('identifier' => receipt.identifier, 'continue' => 'true')
+      logic.process_params
+      logic.process
 
-      before do
-        allow(Onetime::Customer).to receive(:secrets_burned).and_return(double('Counter', increment: 1))
-      end
-
-      it 'burns the secret' do
-        subject.process
-
-        expect(secret).to have_received(:burned!)
-      end
-
-      it 'greenlights the burn' do
-        subject.process
-
-        expect(subject.greenlighted).to be_truthy
-      end
+      expect(logic.greenlighted).to be true
     end
   end
 end

--- a/apps/api/v2/spec/logic/secrets/burn_secret_spec.rb
+++ b/apps/api/v2/spec/logic/secrets/burn_secret_spec.rb
@@ -1,0 +1,87 @@
+# apps/api/v2/spec/logic/secrets/burn_secret_spec.rb
+#
+# frozen_string_literal: true
+
+require_relative File.join(Onetime::HOME, 'spec', 'spec_helper')
+require_relative File.join(Onetime::HOME, 'spec', 'support', 'model_test_helper.rb')
+
+# Regression coverage for the v2 burn endpoint mirroring the v1 spec: the
+# destructive burn must be gated on the parsed `continue` boolean, not the raw
+# param. Every non-empty string is truthy in Ruby, so reading params['continue']
+# directly burned the secret even when the caller explicitly sent
+# continue=false (the common form/query shape).
+#
+# V2::Logic::Base#initialize wires session/customer/org/domain context from a
+# StrategyResult, none of which is relevant to the greenlight decision. We
+# exercise #process in isolation by populating the inputs it reads and stubbing
+# success_data (whose URL/serialization chain is out of scope here).
+RSpec.describe V2::Logic::Secrets::BurnSecret do
+  before(:all) { OT.boot!(:test) }
+
+  let(:customer) do
+    double('Onetime::Customer', anonymous?: false, custid: 'cust123', objid: 'cust123', increment_field: nil)
+  end
+
+  let(:secret) do
+    double('Onetime::Secret',
+      identifier: 'secret123',
+      shortid: 'secret12',
+      viewable?: true,
+      has_passphrase?: false,
+      passphrase?: true,
+      load_owner: nil)
+  end
+
+  let(:receipt) { double('Onetime::Receipt', identifier: 'receipt123', load_secret: secret) }
+
+  def build_subject(continue:)
+    logic = described_class.allocate
+    logic.instance_variable_set(:@receipt, receipt)
+    logic.instance_variable_set(:@passphrase, 'pass123')
+    logic.instance_variable_set(:@continue, [true, 'true'].include?(continue))
+    logic.instance_variable_set(:@params, { 'continue' => continue })
+    logic.instance_variable_set(:@cust, customer)
+    allow(logic).to receive(:success_data).and_return({})
+    logic
+  end
+
+  describe '#process' do
+    before { allow(secret).to receive(:burned!) }
+
+    context 'when continue is the string "false"' do
+      subject { build_subject(continue: 'false') }
+
+      it 'does not burn the secret' do
+        subject.process
+
+        expect(secret).not_to have_received(:burned!)
+      end
+
+      it 'does not greenlight the burn' do
+        subject.process
+
+        expect(subject.greenlighted).to be_falsey
+      end
+    end
+
+    context 'when continue is the string "true"' do
+      subject { build_subject(continue: 'true') }
+
+      before do
+        allow(Onetime::Customer).to receive(:secrets_burned).and_return(double('Counter', increment: 1))
+      end
+
+      it 'burns the secret' do
+        subject.process
+
+        expect(secret).to have_received(:burned!)
+      end
+
+      it 'greenlights the burn' do
+        subject.process
+
+        expect(subject.greenlighted).to be_truthy
+      end
+    end
+  end
+end

--- a/changelog.d/20260613_123000_claude_burn_continue_boolean.rst
+++ b/changelog.d/20260613_123000_claude_burn_continue_boolean.rst
@@ -1,0 +1,13 @@
+.. A new scriv changelog fragment.
+
+Fixed
+-----
+
+- The burn endpoints (v1 and v2) now honour ``continue=false``. Both parsed
+  the flag into a proper boolean in ``process_params`` but then computed
+  ``greenlighted`` from the raw ``params['continue']`` instead. Because every
+  non-empty string is truthy in Ruby, a request carrying the string
+  ``"false"`` (the common shape for form/query submissions) burned the secret
+  anyway, destroying it against the caller's explicit intent. The greenlight
+  check now uses the parsed ``continue`` boolean, so only a genuine truthy
+  confirmation burns the secret.


### PR DESCRIPTION
## Summary

The v1 and v2 `BurnSecret` logics both parse the confirmation flag into a real boolean in `process_params`:

```ruby
@continue = [true, 'true'].include?(params['continue'])
```

…but then compute the greenlight from the **raw** param instead of the parsed value:

```ruby
continue_result = params['continue']
@greenlighted   = viewable && correct_passphrase && continue_result
```

In Ruby every non-empty string is truthy, so a request carrying the string `"false"` — the common shape for form/query submissions — yields `continue_result = "false"` (truthy) and **burns the secret anyway**, destroying it against the caller's explicit intent. The whole point of the burn confirmation is to gate this destructive, irreversible action.

## Fix

Use the already-parsed `continue` boolean in the greenlight check (and in the v2 debug log) so only a genuine truthy confirmation burns the secret. This matches how `show`/`reveal` already parse and consume the flag (`params['continue'].to_s == 'true'`).

```ruby
@greenlighted = viewable && correct_passphrase && continue
```

## Notes

- Behaviour for the intended happy path is unchanged: `continue=true` / `continue: true` still burns.
- The only behavioural change is that `continue="false"` (and other non-truthy string values) now correctly does **not** burn — previously it did.
- Existing `apps/api/v1/spec/logic/secrets/burn_secret_spec.rb` sends `'continue' => 'true'` and still greenlights.
- `ruby -c` clean on both files.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0116X8RbQ4qVt7jbPLF1h6Ur)_