### PR TITLE
Log the real secret id on receipt reveal/burn transitions

### DIFF
--- a/changelog.d/20260613_124500_claude_receipt_audit_log_secret_id.rst
+++ b/changelog.d/20260613_124500_claude_receipt_audit_log_secret_id.rst
@@ -3,10 +3,10 @@
 Fixed
 -----
 
-- The "Receipt state transition to revealed/burned" audit log lines now
-  record the actual secret identifier. Both ``Receipt#revealed!`` and
-  ``Receipt#burned!`` cleared ``secret_identifier`` to an empty string before
-  building the log payload, so every reveal/burn event was logged with
-  ``secret_id: ""`` — defeating the trail for incident review. The identifier
-  is now captured before it is cleared (matching ``orphaned!`` and
-  ``expired!``), so the log reflects which secret the event refers to.
+- The "Receipt state transition" audit log lines now record the actual secret
+  identifier. ``Receipt#revealed!``, ``Receipt#burned!`` and ``Receipt#expired!``
+  cleared ``secret_identifier`` to an empty string before building the log
+  payload, so every reveal/burn/expire event was logged with ``secret_id: ""``
+  — defeating the trail for incident review. The identifier is now captured
+  before it is cleared (matching ``orphaned!``), so the log reflects which
+  secret the event refers to.

--- a/changelog.d/20260613_124500_claude_receipt_audit_log_secret_id.rst
+++ b/changelog.d/20260613_124500_claude_receipt_audit_log_secret_id.rst
@@ -1,0 +1,12 @@
+.. A new scriv changelog fragment.
+
+Fixed
+-----
+
+- The "Receipt state transition to revealed/burned" audit log lines now
+  record the actual secret identifier. Both ``Receipt#revealed!`` and
+  ``Receipt#burned!`` cleared ``secret_identifier`` to an empty string before
+  building the log payload, so every reveal/burn event was logged with
+  ``secret_id: ""`` — defeating the trail for incident review. The identifier
+  is now captured before it is cleared (matching ``orphaned!`` and
+  ``expired!``), so the log reflects which secret the event refers to.

--- a/lib/onetime/models/receipt/features/deprecated_fields.rb
+++ b/lib/onetime/models/receipt/features/deprecated_fields.rb
@@ -156,6 +156,7 @@ module Onetime::Receipt::Features
         return unless state?(:new) || state?(:previewed)
 
         previous_state         = state
+        original_secret_id     = secret_identifier
         self.state             = 'revealed'
         self.revealed          = Familia.now.to_i
         self.secret_identifier = ''
@@ -164,7 +165,7 @@ module Onetime::Receipt::Features
         secret_logger.info 'Receipt state transition to revealed',
           {
             receipt_id: shortid,
-            secret_id: secret_identifier,
+            secret_id: original_secret_id,
             previous_state: previous_state,
             new_state: 'revealed',
             timestamp: revealed,
@@ -204,6 +205,7 @@ module Onetime::Receipt::Features
         return unless state?(:new) || state?(:previewed)
 
         previous_state         = state
+        original_secret_id     = secret_identifier
         self.state             = 'burned'
         self.burned            = Familia.now.to_i
         self.secret_identifier = ''
@@ -212,7 +214,7 @@ module Onetime::Receipt::Features
         secret_logger.info 'Receipt state transition to burned',
           {
             receipt_id: shortid,
-            secret_id: secret_identifier,
+            secret_id: original_secret_id,
             previous_state: previous_state,
             new_state: 'burned',
             timestamp: burned,

--- a/lib/onetime/models/receipt/features/deprecated_fields.rb
+++ b/lib/onetime/models/receipt/features/deprecated_fields.rb
@@ -227,6 +227,7 @@ module Onetime::Receipt::Features
         return unless secret_expired?
 
         previous_state         = state
+        original_secret_id     = secret_identifier
         self.state             = 'expired'
         self.updated           = Familia.now.to_i
         self.secret_identifier = ''
@@ -236,7 +237,7 @@ module Onetime::Receipt::Features
         secret_logger.info 'Receipt state transition to expired',
           {
             receipt_id: shortid,
-            secret_id: secret_identifier,
+            secret_id: original_secret_id,
             previous_state: previous_state,
             new_state: 'expired',
             timestamp: updated,


### PR DESCRIPTION
## Summary

`Receipt#revealed!`, `Receipt#burned!`, and `Receipt#expired!` clear `secret_identifier` to `''` **before** building their audit-log payload, then log the now-empty field:

```ruby
self.secret_identifier = ''
save update_expiration: false

secret_logger.info 'Receipt state transition to revealed',
  {
    receipt_id: shortid,
    secret_id: secret_identifier,   # always "" at this point
    ...
  }
```

So every reveal/burn/expire event is logged with `secret_id: ""`, severing the link between the audit event and the secret it concerns — exactly the information you'd want during incident review on a secret-sharing service.

Only the sibling transition `orphaned!` already gets this right: it snapshots the id into a local (`original_secret_id`) before clearing.

> **Correction:** an earlier revision of this description claimed `expired!` was already correct. That was wrong — `expired!` had the identical defect (caught in review), and is now fixed here alongside `revealed!`/`burned!`.

## Fix

Capture `original_secret_id = secret_identifier` before clearing the field in `revealed!`, `burned!`, and `expired!`, and log that local — matching the existing pattern in `orphaned!`.

Log-only change; no behavioural or stored-data impact. Verified with `try/unit/models/receipt_state_terminology_try.rb` (47/47 pass, which exercises all three transitions) on Ruby 3.4.9.

🤖 Generated with [Claude Code](https://claude.ai/code)