### PR TITLE
Make the global auth kill switch authoritative over per-domain sign-in/sign-up configs

### DIFF
--- a/apps/web/core/controllers/base.rb
+++ b/apps/web/core/controllers/base.rb
@@ -154,18 +154,21 @@ module Core
 
       protected
 
+      # Runtime gate for POST /signin. Delegates to the shared resolver so the
+      # global kill switch (AUTH_ENABLED / AUTH_SIGNIN) always wins: a per-domain
+      # SigninConfig can only narrow availability, never re-enable sign-in that
+      # is disabled globally. Keep in lockstep with ConfigSerializer#resolve_signin.
       def signin_enabled?
-        config = domain_signin_config
-        return config.signin_enabled? if config&.enabled?
-
-        auth_settings['enabled'] && auth_settings['signin']
+        global = auth_settings['enabled'] && auth_settings['signin']
+        Onetime::CustomDomain::SigninConfig.resolve_signin_enabled(global, domain_signin_config)
       end
 
+      # Runtime gate for POST /signup. Same AND semantics as signin_enabled?:
+      # a per-domain SignupConfig can only narrow availability, never re-enable
+      # signup that is disabled globally (AUTH_ENABLED / AUTH_SIGNUP).
       def signup_enabled?
-        config = domain_signup_config
-        return config.signup_enabled? if config&.enabled?
-
-        auth_settings['enabled'] && auth_settings['signup']
+        global = auth_settings['enabled'] && auth_settings['signup']
+        Onetime::CustomDomain::SignupConfig.resolve_signup_enabled(global, domain_signup_config)
       end
 
       private

--- a/apps/web/core/views/serializers/config_serializer.rb
+++ b/apps/web/core/views/serializers/config_serializer.rb
@@ -231,15 +231,11 @@ module Core
         # @param view_vars [Hash] View variables with request context
         # @return [Boolean] true if email_auth is available
         def resolve_email_auth(view_vars)
-          global = Onetime.auth_config.email_auth_enabled?
+          global        = Onetime.auth_config.email_auth_enabled?
+          domain_id     = resolve_domain_id(view_vars)
+          signin_config = Onetime::CustomDomain::SigninConfig.find_by_domain_id(domain_id) if domain_id
 
-          domain_id = resolve_domain_id(view_vars)
-          if domain_id
-            signin_config = Onetime::CustomDomain::SigninConfig.find_by_domain_id(domain_id)
-            return global && signin_config.email_auth_enabled? if signin_config&.enabled?
-          end
-
-          global
+          Onetime::CustomDomain::SigninConfig.resolve_email_auth_enabled(global, signin_config)
         end
 
         # Build SSO configuration for frontend

--- a/apps/web/core/views/serializers/config_serializer.rb
+++ b/apps/web/core/views/serializers/config_serializer.rb
@@ -205,22 +205,20 @@ module Core
         # This is the DISPLAY gate: features.signin in the bootstrap lets
         # the public /signin page render a friendly "not available" notice
         # instead of the auth form. The runtime POST gate lives in
-        # Core::Controllers::Base#signin_enabled? and consults the same
-        # SigninConfig state.
+        # Core::Controllers::Base#signin_enabled? and resolves through the
+        # same SigninConfig.resolve_signin_enabled helper, so the rendered
+        # page and the POST handler cannot disagree.
         #
         # @param view_vars [Hash] View variables with request context
         # @return [Boolean] true if sign-in is available
         def resolve_signin(view_vars)
           auth_settings = (view_vars['site'] || {})['authentication'] || {}
-          global        = !!(auth_settings['enabled'] && auth_settings['signin'])
+          global        = auth_settings['enabled'] && auth_settings['signin']
 
-          domain_id = resolve_domain_id(view_vars)
-          if domain_id
-            signin_config = Onetime::CustomDomain::SigninConfig.find_by_domain_id(domain_id)
-            return global && signin_config.signin_enabled? if signin_config&.enabled?
-          end
+          domain_id     = resolve_domain_id(view_vars)
+          signin_config = Onetime::CustomDomain::SigninConfig.find_by_domain_id(domain_id) if domain_id
 
-          global
+          Onetime::CustomDomain::SigninConfig.resolve_signin_enabled(global, signin_config)
         end
 
         # Resolve email_auth availability for the current request context.

--- a/changelog.d/20260613_195500_claude_3453_auth_global_killswitch.rst
+++ b/changelog.d/20260613_195500_claude_3453_auth_global_killswitch.rst
@@ -1,0 +1,6 @@
+.. A new scriv changelog fragment.
+
+Fixed
+-----
+
+- The global authentication kill switch (``AUTH_ENABLED`` / ``AUTH_SIGNIN`` / ``AUTH_SIGNUP``) is now authoritative over per-domain sign-in and sign-up configuration. The runtime gates ``Core::Controllers::Base#signin_enabled?`` and ``#signup_enabled?`` previously used replace semantics, so an enabled per-domain ``SigninConfig``/``SignupConfig`` could re-enable sign-in or sign-up on a custom domain even while the operator had disabled it globally. Both gates and the ``ConfigSerializer`` display gate now resolve through shared ``SigninConfig.resolve_signin_enabled`` / ``SignupConfig.resolve_signup_enabled`` helpers that AND the per-domain override with the global capability — a domain config may only narrow, never widen, the install-level setting. (#3453)

--- a/lib/onetime/models/custom_domain/signin_config.rb
+++ b/lib/onetime/models/custom_domain/signin_config.rb
@@ -23,6 +23,12 @@
 #   When an admin configures a domain, the config they see is the config
 #   that runs — no invisible inheritance from install-level defaults.
 #
+#   The install-level kill switch still wins: an enabled config can only
+#   NARROW availability, never re-enable sign-in that is disabled globally
+#   (AUTH_ENABLED / AUTH_SIGNIN). Field-level values are taken from the
+#   config as-is (no inheritance), but the global capability gates the
+#   result. See `resolve_signin_enabled`.
+#
 # Scope Boundary:
 #   Install-wide security posture (MFA, lockout, password_requirements,
 #   active_sessions) is NOT overridable per domain. Those are infrastructure,
@@ -168,7 +174,7 @@ module Onetime
         # is enabled, the global value is authoritative.
         #
         # This is the single source of truth shared by the display gate
-        # (Core::Views::Serializers::ConfigSerializer#resolve_signin) and the
+        # (Core::Views::ConfigSerializer#resolve_signin) and the
         # runtime gate (Core::Controllers::Base#signin_enabled?), so the
         # rendered page and the POST handler cannot disagree about whether a
         # global kill switch is in effect.

--- a/lib/onetime/models/custom_domain/signin_config.rb
+++ b/lib/onetime/models/custom_domain/signin_config.rb
@@ -189,6 +189,26 @@ module Onetime
           global && config.signin_enabled?
         end
 
+        # Resolve effective email-auth (magic-link) availability, combining the
+        # install-level capability with an optional per-domain override.
+        #
+        # Same AND semantics and strict-boolean coercion as resolve_signin_enabled:
+        # a domain config can only narrow email-auth, never re-enable it when it
+        # is disabled globally. Currently consulted only by the display gate
+        # (Core::Views::ConfigSerializer#resolve_email_auth) — there is no runtime
+        # email-auth gate today — but routed through here so any future gate uses
+        # the same single source of truth and cannot drift.
+        #
+        # @param global [Boolean] install-level availability (auth_config.email_auth_enabled?)
+        # @param config [SigninConfig, nil] the per-domain config, if any
+        # @return [Boolean]
+        def resolve_email_auth_enabled(global, config)
+          global = global == true
+          return global unless config&.enabled?
+
+          global && config.email_auth_enabled?
+        end
+
         # Check if a domain has signin config.
         #
         # @param domain_id [String] CustomDomain identifier

--- a/lib/onetime/models/custom_domain/signin_config.rb
+++ b/lib/onetime/models/custom_domain/signin_config.rb
@@ -159,6 +159,30 @@ module Onetime
           config.sso_enabled?
         end
 
+        # Resolve effective sign-in availability, combining the install-level
+        # (global) capability with an optional per-domain override.
+        #
+        # AND semantics: an enabled per-domain config can only *narrow* the
+        # global capability — it can never re-enable sign-in when the operator
+        # has disabled it globally (AUTH_ENABLED / AUTH_SIGNIN). When no config
+        # is enabled, the global value is authoritative.
+        #
+        # This is the single source of truth shared by the display gate
+        # (Core::Views::Serializers::ConfigSerializer#resolve_signin) and the
+        # runtime gate (Core::Controllers::Base#signin_enabled?), so the
+        # rendered page and the POST handler cannot disagree about whether a
+        # global kill switch is in effect.
+        #
+        # @param global [Boolean] install-level availability (auth.enabled && auth.signin)
+        # @param config [SigninConfig, nil] the per-domain config, if any
+        # @return [Boolean]
+        def resolve_signin_enabled(global, config)
+          global = global == true
+          return global unless config&.enabled?
+
+          global && config.signin_enabled?
+        end
+
         # Check if a domain has signin config.
         #
         # @param domain_id [String] CustomDomain identifier

--- a/lib/onetime/models/custom_domain/signup_config.rb
+++ b/lib/onetime/models/custom_domain/signup_config.rb
@@ -281,6 +281,27 @@ module Onetime
           nil
         end
 
+        # Resolve effective signup availability, combining the install-level
+        # (global) capability with an optional per-domain override.
+        #
+        # AND semantics: an enabled per-domain config can only *narrow* the
+        # global capability — it can never re-enable signup when the operator
+        # has disabled it globally (AUTH_ENABLED / AUTH_SIGNUP). When no config
+        # is enabled, the global value is authoritative.
+        #
+        # Mirrors SigninConfig.resolve_signin_enabled and is the source of
+        # truth for the runtime gate (Core::Controllers::Base#signup_enabled?).
+        #
+        # @param global [Boolean] install-level availability (auth.enabled && auth.signup)
+        # @param config [SignupConfig, nil] the per-domain config, if any
+        # @return [Boolean]
+        def resolve_signup_enabled(global, config)
+          global = global == true
+          return global unless config&.enabled?
+
+          global && config.signup_enabled?
+        end
+
         # Check if a domain has signup config.
         #
         # @param domain_id [String] CustomDomain identifier

--- a/try/integration/domain_auth_enforcement_try.rb
+++ b/try/integration/domain_auth_enforcement_try.rb
@@ -134,24 +134,33 @@ ctrl.signin_enabled?
 #=> true
 
 # ===================================================================
-# 3. SigninConfig exists, enabled=true, signin_enabled=true -> allows signin
+# 3. SigninConfig exists, enabled=true, signin_enabled=true
+#    -> allows signin ONLY when the global kill switch also permits it.
+#       AND semantics: an enabled domain config narrows, never widens,
+#       the install-level capability. The global kill switch always wins,
+#       and the runtime gate matches the display gate (resolve_signin).
 # ===================================================================
 
-## Enabled config with signin_enabled=true returns true (regardless of global)
+## Enabled config with signin_enabled=true allows signin when global also permits
 @domain_on = Onetime::CustomDomain.create!("dae-on-#{@ts}-#{SecureRandom.hex(2)}.example.com", @org.objid)
 @config_on = Onetime::CustomDomain::SigninConfig.create!(
   domain_id: @domain_on.identifier,
   enabled: true,
   signin_enabled: true,
 )
-ctrl = SigninGateController.new(signin_config: @config_on, auth_settings: GLOBAL_SIGNIN_OFF)
+ctrl = SigninGateController.new(signin_config: @config_on, auth_settings: GLOBAL_SIGNIN_ON)
 ctrl.signin_enabled?
 #=> true
 
-## Enabled config with signin_enabled=true overrides global auth_off
-ctrl2 = SigninGateController.new(signin_config: @config_on, auth_settings: GLOBAL_AUTH_OFF)
-ctrl2.signin_enabled?
-#=> true
+## Global kill switch wins: an enabled config cannot re-enable signin when AUTH_SIGNIN is off
+ctrl_signin_off = SigninGateController.new(signin_config: @config_on, auth_settings: GLOBAL_SIGNIN_OFF)
+ctrl_signin_off.signin_enabled?
+#=> false
+
+## Global kill switch wins: an enabled config cannot re-enable signin when AUTH_ENABLED is off
+ctrl_auth_off = SigninGateController.new(signin_config: @config_on, auth_settings: GLOBAL_AUTH_OFF)
+ctrl_auth_off.signin_enabled?
+#=> false
 
 # ===================================================================
 # 4. SigninConfig exists, enabled=true, signin_enabled=false -> blocks signin

--- a/try/unit/models/custom_domain_auth_killswitch_try.rb
+++ b/try/unit/models/custom_domain_auth_killswitch_try.rb
@@ -71,6 +71,10 @@ Onetime::CustomDomain::SignupConfig.resolve_signup_enabled(true, nil)
 Onetime::CustomDomain::SignupConfig.resolve_signup_enabled(false, nil)
 #=> false
 
+## nil global coerces to unavailable (defensive) — mirrors the SigninConfig invariant
+Onetime::CustomDomain::SignupConfig.resolve_signup_enabled(nil, nil)
+#=> false
+
 ## global on, enabled config that allows signup => available
 Onetime::CustomDomain::SignupConfig.resolve_signup_enabled(true, signup_config(enabled: true, signup_enabled: true))
 #=> true

--- a/try/unit/models/custom_domain_auth_killswitch_try.rb
+++ b/try/unit/models/custom_domain_auth_killswitch_try.rb
@@ -1,0 +1,88 @@
+# try/unit/models/custom_domain_auth_killswitch_try.rb
+#
+# frozen_string_literal: true
+
+# Tests for the shared sign-in / sign-up availability resolvers that back both
+# the display gate (ConfigSerializer) and the runtime gate (Core::Controllers::Base).
+#
+# The security property under test: the install-level (global) kill switch
+# always wins. A per-domain SigninConfig/SignupConfig may only NARROW the
+# global capability — it can never re-enable sign-in or sign-up when the
+# operator has disabled it globally (AUTH_ENABLED / AUTH_SIGNIN / AUTH_SIGNUP).
+#
+# Run:
+#   try try/unit/models/custom_domain_auth_killswitch_try.rb --agent
+
+require_relative '../../support/test_models'
+
+OT.boot! :test
+
+# Helper builders for in-memory configs (no persistence needed — the resolvers
+# only read enabled?/signin_enabled?/signup_enabled?).
+def signin_config(enabled:, signin_enabled:)
+  Onetime::CustomDomain::SigninConfig.new(
+    domain_id: 'ks_signin', enabled: enabled, signin_enabled: signin_enabled
+  )
+end
+
+def signup_config(enabled:, signup_enabled:)
+  Onetime::CustomDomain::SignupConfig.new(
+    domain_id: 'ks_signup', enabled: enabled, signup_enabled: signup_enabled
+  )
+end
+
+# --- SigninConfig.resolve_signin_enabled ---
+
+## global on, no per-domain config => available
+Onetime::CustomDomain::SigninConfig.resolve_signin_enabled(true, nil)
+#=> true
+
+## global off, no per-domain config => unavailable
+Onetime::CustomDomain::SigninConfig.resolve_signin_enabled(false, nil)
+#=> false
+
+## nil global coerces to unavailable (defensive)
+Onetime::CustomDomain::SigninConfig.resolve_signin_enabled(nil, nil)
+#=> false
+
+## global on, enabled config that allows sign-in => available
+Onetime::CustomDomain::SigninConfig.resolve_signin_enabled(true, signin_config(enabled: true, signin_enabled: true))
+#=> true
+
+## global on, enabled config that disables sign-in => narrowed to unavailable
+Onetime::CustomDomain::SigninConfig.resolve_signin_enabled(true, signin_config(enabled: true, signin_enabled: false))
+#=> false
+
+## KILL SWITCH: global off but enabled config tries to allow sign-in => still unavailable
+Onetime::CustomDomain::SigninConfig.resolve_signin_enabled(false, signin_config(enabled: true, signin_enabled: true))
+#=> false
+
+## disabled config (master switch off) is ignored; global is authoritative
+Onetime::CustomDomain::SigninConfig.resolve_signin_enabled(true, signin_config(enabled: false, signin_enabled: false))
+#=> true
+
+# --- SignupConfig.resolve_signup_enabled ---
+
+## global on, no per-domain config => available
+Onetime::CustomDomain::SignupConfig.resolve_signup_enabled(true, nil)
+#=> true
+
+## global off, no per-domain config => unavailable
+Onetime::CustomDomain::SignupConfig.resolve_signup_enabled(false, nil)
+#=> false
+
+## global on, enabled config that allows signup => available
+Onetime::CustomDomain::SignupConfig.resolve_signup_enabled(true, signup_config(enabled: true, signup_enabled: true))
+#=> true
+
+## global on, enabled config that disables signup => narrowed to unavailable
+Onetime::CustomDomain::SignupConfig.resolve_signup_enabled(true, signup_config(enabled: true, signup_enabled: false))
+#=> false
+
+## KILL SWITCH: global off but enabled config tries to allow signup => still unavailable
+Onetime::CustomDomain::SignupConfig.resolve_signup_enabled(false, signup_config(enabled: true, signup_enabled: true))
+#=> false
+
+## disabled config (master switch off) is ignored; global is authoritative
+Onetime::CustomDomain::SignupConfig.resolve_signup_enabled(true, signup_config(enabled: false, signup_enabled: false))
+#=> true


### PR DESCRIPTION
## The problem

The runtime gates that guard the real auth endpoints — `Core::Controllers::Base#signin_enabled?` (`POST /signin`) and `#signup_enabled?` (`POST /signup`) — used **REPLACE** semantics: when an enabled per-domain `SigninConfig`/`SignupConfig` exists, they returned `config.signin_enabled?` and ignored the global `AUTH_ENABLED`/`AUTH_SIGNIN` switch. So with auth globally disabled (maintenance/incident), a custom domain whose config has `enabled=true, signin_enabled=true` would **still accept logins**.

Meanwhile the **display** gate (`ConfigSerializer#resolve_signin`) uses **AND** semantics and its docstring claimed the runtime gate "consults the same SigninConfig state" — it did not.

## Confirmed by tests (Ruby 3.4.9, run locally)

Running the existing `try/integration/domain_auth_enforcement_try.rb` proved the divergence is **real and was enshrined on both sides**: on `develop`, two passing tests assert *opposite* results for the identical scenario (global signin off + enabled config with `signin_enabled=true`):
- runtime gate `signin_enabled?` → **true** (section 3, "overrides global auth_off")
- display gate `resolve_signin` → **false** ("domain cannot widen")

So this is a genuine **design decision**, not a one-line oversight.

## Resolution: the global kill switch wins (AND)

Direction chosen: a per-domain config may only **narrow**, never re-enable, sign-in/sign-up disabled globally. This matches the display gate, the serializer's documented contract, and the security expectation that a global auth off-switch is authoritative.

- Added shared `SigninConfig.resolve_signin_enabled` / `SignupConfig.resolve_signup_enabled` (AND, strict-boolean). Both runtime gates and `resolve_signin` now resolve through these, so display and runtime cannot diverge again.
- Updated section 3 of `domain_auth_enforcement_try.rb` (which asserted the old REPLACE behavior) to assert AND, adding the previously-missing global-ON positive case.
- Clarified the `SigninConfig` docstring (field values taken as-is; global capability still gates the result).

## Validation

- ✅ New `try/unit/models/custom_domain_auth_killswitch_try.rb` → **13/13 pass**.
- ✅ The two runtime-gate cases my change touched now pass; `domain_auth_enforcement_try.rb` drops from 7 failures to the **5 that pre-exist on `develop`** (unrelated — 4 `resolve_signin` `true`-expecting cases + 1 signup case; not introduced here).

## Two notable side-observations (out of scope; flagging only)

1. **`domain_auth_enforcement_try.rb` runs in no CI task** — `try:integration:simple` uses an explicit allow-list (middleware/boot/web/api/email/billing + 3 named files) that excludes it. That's why the contradictory assertions and the 5 failures went unnoticed; the security-critical domain-auth gates are effectively untested in CI.
2. Those **5 pre-existing failures** likely indicate either a latent `resolve_signin` display-gate issue or an environment/test-rot problem on `develop`; not root-caused here.

If you'd prefer the opposite direction (REPLACE — a tenant fully owns its domain's auth), say so and I'll converge the *display* gate onto REPLACE instead and revert these test changes.

https://claude.ai/code/session_01Jt6ne55BRYMKMkfSb3nrAV