### PR TITLE
Honor the parsed `continue` flag when burning a secret (v1 + v2)

### DIFF
--- a/apps/api/v1/logic/secrets/burn_secret.rb
+++ b/apps/api/v1/logic/secrets/burn_secret.rb
@@ -33,8 +33,10 @@ module V1::Logic
 
           @correct_passphrase = !potential_secret.has_passphrase? || potential_secret.passphrase?(passphrase)
           viewable = potential_secret.viewable?
-          continue_result = params['continue']
-          @greenlighted = viewable && correct_passphrase && continue_result
+          # Use the parsed boolean (true / 'true' only), not the raw param: the
+          # raw value treats any non-empty string as truthy, so a deliberate
+          # `continue=false` would burn the secret anyway.
+          @greenlighted = viewable && correct_passphrase && continue
 
           if greenlighted
             @secret = potential_secret

--- a/apps/api/v1/spec/logic/secrets/burn_secret_spec.rb
+++ b/apps/api/v1/spec/logic/secrets/burn_secret_spec.rb
@@ -49,9 +49,8 @@ RSpec.describe V1::Logic::Secrets::BurnSecret do
 
   before do
     allow(Onetime::Receipt).to receive(:load).with('receipt123').and_return(receipt)
-    # Stub load_owner (the correct method name) on the secret.
-    # The production code at burn_secret.rb:39 calls load_customer,
-    # which does NOT exist, so process will raise NoMethodError.
+    # Stub load_owner on the secret — process calls it to resolve the owner
+    # before incrementing their secrets_burned counter.
     allow(secret).to receive(:load_owner).and_return(owner)
   end
 
@@ -64,8 +63,6 @@ RSpec.describe V1::Logic::Secrets::BurnSecret do
       it 'calls load_owner on the secret to retrieve the owner' do
         subject.process
 
-        # This test will FAIL because the production code calls
-        # secret.load_customer instead of secret.load_owner
         expect(secret).to have_received(:load_owner)
       end
 

--- a/apps/api/v1/spec/logic/secrets/burn_secret_spec.rb
+++ b/apps/api/v1/spec/logic/secrets/burn_secret_spec.rb
@@ -81,5 +81,29 @@ RSpec.describe V1::Logic::Secrets::BurnSecret do
         expect(secret).to have_received(:burned!)
       end
     end
+
+    # Regression: the greenlight must honor the parsed `continue` boolean, not
+    # the raw param. The string "false" is truthy in Ruby, so the previous
+    # `continue_result = params['continue']` would burn a secret even when the
+    # caller explicitly passed continue=false.
+    context 'when continue is the string "false"' do
+      subject { described_class.new(session, customer, base_params.merge('continue' => 'false')) }
+
+      before do
+        allow(secret).to receive(:burned!)
+      end
+
+      it 'does not burn the secret' do
+        subject.process
+
+        expect(secret).not_to have_received(:burned!)
+      end
+
+      it 'is not greenlighted' do
+        subject.process
+
+        expect(subject.greenlighted).to be_falsey
+      end
+    end
   end
 end

--- a/apps/api/v2/logic/secrets/burn_secret.rb
+++ b/apps/api/v2/logic/secrets/burn_secret.rb
@@ -53,8 +53,10 @@ module V2::Logic
 
         @correct_passphrase = !potential_secret.has_passphrase? || potential_secret.passphrase?(passphrase)
         viewable            = potential_secret.viewable?
-        continue_result     = params['continue']
-        @greenlighted       = viewable && correct_passphrase && continue_result
+        # Use the parsed boolean (true / 'true' only), not the raw param: the
+        # raw value treats any non-empty string as truthy, so a deliberate
+        # `continue=false` would burn the secret anyway.
+        @greenlighted       = viewable && correct_passphrase && continue
 
         secret_logger.debug 'Secret burn initiated',
           {
@@ -63,7 +65,7 @@ module V2::Logic
             viewable: viewable,
             has_passphrase: potential_secret.has_passphrase?,
             passphrase_correct: correct_passphrase,
-            continue: continue_result,
+            continue: continue,
             user_id: cust&.custid,
           }
 

--- a/apps/api/v2/spec/logic/secrets/burn_secret_spec.rb
+++ b/apps/api/v2/spec/logic/secrets/burn_secret_spec.rb
@@ -1,0 +1,75 @@
+# apps/api/v2/spec/logic/secrets/burn_secret.rb
+#
+# frozen_string_literal: true
+
+require_relative '../../../application'
+require_relative File.join(Onetime::HOME, 'spec', 'spec_helper')
+
+# Regression coverage for the v2 burn confirmation flag.
+#
+# BurnSecret#process must greenlight the destructive burn on the parsed
+# `@continue` boolean (true / 'true' only), NOT the raw params['continue']
+# string — every non-empty string is truthy in Ruby, so reading the raw param
+# would burn the secret even when the caller explicitly sent continue=false.
+#
+# Uses real Receipt/Secret objects (spawn_pair) so process -> success_data runs
+# end-to-end without stubbing the URL/serialization helpers.
+RSpec.describe V2::Logic::Secrets::BurnSecret, type: :integration do
+  before(:all) do
+    require 'onetime'
+    Onetime.boot! :test
+  end
+
+  def mock_session
+    store = {}
+    session = double('Session')
+    allow(session).to receive(:[]) { |k| store[k] }
+    allow(session).to receive(:[]=) { |k, v| store[k] = v }
+    session
+  end
+
+  # Build a BurnSecret instance over a real receipt with the api_access
+  # entitlement granted (we exercise process directly, not raise_concerns).
+  def build_logic(params)
+    customer = double('Customer', custid: 'anon', anonymous?: true, objid: nil)
+    org      = double('Organization', objid: "org_#{SecureRandom.hex(4)}")
+    allow(org).to receive(:can?).and_return(true)
+
+    strategy_result = double('StrategyResult',
+      session: mock_session,
+      user: customer,
+      metadata: { organization: org },
+      auth_method: 'basicauth')
+
+    # process derives cust from strategy_result.user and never calls org, so no
+    # accessor stubbing is needed (we exercise process directly, not raise_concerns).
+    described_class.new(strategy_result, params)
+  end
+
+  let!(:pair)    { Onetime::Receipt.spawn_pair(nil, 3600, 'a secret value') }
+  let(:receipt)  { pair.first }
+  let(:secret)   { pair.last }
+
+  context 'when continue is the string "false"' do
+    it 'does not greenlight and leaves the secret intact' do
+      logic = build_logic('identifier' => receipt.identifier, 'continue' => 'false')
+      logic.process_params
+      logic.process
+
+      expect(logic.greenlighted).to be_falsey
+      # The secret was not burned, so it is still loadable and viewable.
+      reloaded = Onetime::Secret.load(secret.identifier)
+      expect(reloaded&.viewable?).to be true
+    end
+  end
+
+  context 'when continue is "true"' do
+    it 'greenlights and burns the secret' do
+      logic = build_logic('identifier' => receipt.identifier, 'continue' => 'true')
+      logic.process_params
+      logic.process
+
+      expect(logic.greenlighted).to be true
+    end
+  end
+end

--- a/changelog.d/20260613_200500_claude_3454_burn_continue_flag.rst
+++ b/changelog.d/20260613_200500_claude_3454_burn_continue_flag.rst
@@ -1,0 +1,6 @@
+.. A new scriv changelog fragment.
+
+Fixed
+-----
+
+- Burning a secret now honors the parsed ``continue`` confirmation flag instead of the raw request parameter. ``BurnSecret`` (v1 and v2) greenlighted the destructive burn on ``params['continue']`` directly, and because any non-empty string is truthy in Ruby a caller that explicitly sent ``continue=false`` would still burn the secret. Only ``true`` / ``'true'`` now confirms a burn, matching the reveal/show actions. (#3454)


### PR DESCRIPTION
## The bug

`BurnSecret#process` (v1 and v2) parses the confirmation flag into a boolean in `process_params` (`@continue = [true, 'true'].include?(params['continue'])`) but then greenlit the **destructive burn** on the *raw* param (`continue_result = params['continue']`). Since any non-empty string is truthy in Ruby, a caller sending `continue=false` (or `"0"`, etc.) would still have the secret **burned**; the parsed `@continue` was dead code.

## The fix

Use the parsed `continue` reader for the greenlight (and the v2 debug log) in both v1 and v2, so only `true` / `'true'` confirms the burn. No change to the happy path.

## Tests + validation (run locally on Ruby 3.4.9)

Added a v1 regression spec: with `continue='false'`, `process` neither calls `burned!` nor sets `greenlighted`. (V1's `Logic::Base#initialize` runs `process_params`, so the existing spec pattern covers `@continue`.)

✅ **`bundle exec rspec apps/api/v1/spec/logic/secrets/burn_secret_spec.rb` → 5/5 pass** (Ruby 3.4.9, Redis on test port), including both new `continue='false'` cases. The earlier "verified by inspection only" caveat is resolved.

https://claude.ai/code/session_01Jt6ne55BRYMKMkfSb3nrAV