### PR TITLE
MFA hardening: accurate recovery-code docs + loud failure on missing QR URI

### DIFF
--- a/apps/web/auth/config/features/mfa.rb
+++ b/apps/web/auth/config/features/mfa.rb
@@ -62,8 +62,15 @@ module Auth::Config::Features
       # after_login hook in apps/web/auth/config/hooks/login.rb which checks
       # uses_two_factor_authentication? and sets json_response[:mfa_required] = true
 
-      # Generate 8-character alphanumeric codes (like: 4k9m-x2pq)
-      # This provides ~1.7 billion possible codes (36^8)
+      # Recovery codes are CSPRNG-backed (SecureRandom) 64-bit values rendered
+      # in base36 — roughly 13 characters, e.g. "3w5e11264sgsf", with ~1.8e19
+      # (2**64) possibilities. 64 bits is deliberately chosen over a longer
+      # token: recovery codes are verified server-side, are rate-limited, and
+      # are bound to a single account, so they are not an offline-guessable
+      # artifact — and a shorter code is far less error-prone for a user to type
+      # when they are locked out. (Familia labels the 64-bit tier "trace"; the
+      # higher tiers carry the same "resist intentional guessing" caveat and
+      # only buy length, so we stay at 64-bit by design.)
       auth.new_recovery_code do
         Familia.generate_trace_id
       end

--- a/changelog.d/20260613_201500_claude_3455_mfa_hardening.rst
+++ b/changelog.d/20260613_201500_claude_3455_mfa_hardening.rst
@@ -1,0 +1,11 @@
+.. A new scriv changelog fragment.
+
+Fixed
+-----
+
+- MFA OTP setup now fails visibly instead of advancing to a blank QR scan step when a setup response omits ``provisioning_uri``. The 422 (HMAC) path already failed loudly on this; the 200 (non-HMAC) path silently set an undefined ``qr_code``. Both paths now share a ``renderSetupQr`` helper. (#3455)
+
+Changed
+-------
+
+- Corrected the MFA recovery-code generation comment, which inaccurately described the codes as 8-character / ``36^8``. ``new_recovery_code`` emits a CSPRNG-backed 64-bit base36 token (~13 chars, ~1.8e19 possibilities); the comment now documents the real format and entropy. No change to the generated codes. (#3455)

--- a/src/shared/composables/helpers/mfaHelpers.ts
+++ b/src/shared/composables/helpers/mfaHelpers.ts
@@ -37,6 +37,39 @@ export async function generateQrCode(provisioningUri: string): Promise<string> {
 }
 
 /**
+ * Renders the QR code for a parsed otp-setup response from the backend's
+ * authoritative provisioning_uri and returns the response with `qr_code` set.
+ *
+ * Returns null when provisioning_uri is absent. The QR can only be produced
+ * from the backend URI (the SPA must NOT reconstruct it — that caused the
+ * wrong-secret bug in #3431), so a missing provisioning_uri means we cannot
+ * render a scannable code. Failing here — rather than returning setup data
+ * with an undefined qr_code — prevents the wizard from advancing to a blank
+ * scan step with no error. Shared by both the 200 (non-HMAC) and 422 (HMAC)
+ * setup paths so neither can silently surface a broken QR.
+ *
+ * @param validated - A schema-validated otp-setup response
+ * @returns The response with qr_code populated, or null if no provisioning_uri
+ */
+export async function renderSetupQr(validated: OtpSetupData): Promise<OtpSetupData | null> {
+  if (!validated.provisioning_uri) {
+    console.error(
+      '[mfaHelpers] otp-setup response is missing provisioning_uri; cannot render QR code'
+    );
+    if (isDiagnosticsEnabled()) {
+      captureMessage('MFA setup response missing provisioning_uri', {
+        service: 'web',
+        errorType: 'technical',
+      });
+    }
+    return null;
+  }
+
+  validated.qr_code = await generateQrCode(validated.provisioning_uri);
+  return validated;
+}
+
+/**
  * Checks if a response contains valid HMAC setup data
  *
  * In HMAC mode, the backend returns a 422 status with setup secrets.
@@ -88,25 +121,8 @@ export async function enrichSetupResponse(errorData: any): Promise<OtpSetupData 
     // Render the QR from the backend's authoritative provisioning URI so the
     // encoded secret/issuer/params always match what the server validates (#3431).
     // provisioning_uri is always present on the HMAC path; its absence means a
-    // backend/frontend version skew. Fail loudly instead of returning setup
-    // data with no QR, which would leave the user on a blank scan step with no
-    // error (issue #3431 follow-up).
-    if (!validated.provisioning_uri) {
-      console.error(
-        '[mfaHelpers] HMAC setup response is missing provisioning_uri; cannot render QR code'
-      );
-      if (isDiagnosticsEnabled()) {
-        captureMessage('MFA setup response missing provisioning_uri', {
-          service: 'web',
-          errorType: 'technical',
-        });
-      }
-      return null;
-    }
-
-    validated.qr_code = await generateQrCode(validated.provisioning_uri);
-
-    return validated;
+    // backend/frontend version skew, which renderSetupQr fails loudly on.
+    return await renderSetupQr(validated);
   } catch (parseErr) {
     console.error('[mfaHelpers] Parse error:', parseErr);
     return null;

--- a/src/shared/composables/helpers/mfaHelpers.ts
+++ b/src/shared/composables/helpers/mfaHelpers.ts
@@ -65,6 +65,8 @@ export async function renderSetupQr(validated: OtpSetupData): Promise<OtpSetupDa
     return null;
   }
 
+  // Sets qr_code on `validated` in place and returns the same object reference
+  // (callers pass the parsed response and use the return value interchangeably).
   validated.qr_code = await generateQrCode(validated.provisioning_uri);
   return validated;
 }

--- a/src/shared/composables/useMfa.ts
+++ b/src/shared/composables/useMfa.ts
@@ -65,9 +65,9 @@ import { useI18n } from 'vue-i18n';
 import { useApi } from '@/shared/composables/useApi';
 
 import {
-  generateQrCode,
   hasHmacSetupData,
   enrichSetupResponse,
+  renderSetupQr,
   mapMfaError,
 } from './helpers/mfaHelpers';
 
@@ -171,13 +171,17 @@ export function useMfa() {
         const validated = otpSetupResponseSchema.parse(response.data);
 
         // Standard response (non-HMAC mode): render the QR from the backend's
-        // authoritative provisioning URI when present.
-        if (validated.provisioning_uri) {
-          validated.qr_code = await generateQrCode(validated.provisioning_uri);
+        // authoritative provisioning URI. If it's absent we cannot produce a
+        // scannable code (the SPA must not reconstruct the URI — #3431), so
+        // fail visibly rather than advancing to a blank scan step. This mirrors
+        // the 422 (HMAC) path, which fails loudly on the same condition.
+        const enriched = await renderSetupQr(validated);
+        if (!enriched) {
+          throw createError(t('web.auth.security.internal_error'), 'technical');
         }
 
-        setupData.value = validated;
-        return validated;
+        setupData.value = enriched;
+        return enriched;
       } catch (err: unknown) {
         // HMAC Setup Success Path: 422 with secrets (not a real error)
         // When HMAC is enabled, backend returns 422 with otp_setup and otp_raw_secret

--- a/src/tests/composables/useMfa.spec.ts
+++ b/src/tests/composables/useMfa.spec.ts
@@ -189,6 +189,26 @@ describe('useMfa', () => {
       expect(QRCode.toDataURL).not.toHaveBeenCalled();
     });
 
+    it('renders the QR on a 200 setup response that includes provisioning_uri', async () => {
+      // Non-HMAC 200 happy path: provisioning_uri present, so renderSetupQr
+      // produces the QR and setupData is populated (no blank-scan-step).
+      const setupResponse = {
+        otp_setup: 'plain_secret',
+        otp_raw_secret: 'JBSWY3DPEHPK3PXP',
+        provisioning_uri:
+          'otpauth://totp/OTS:test@example.com?secret=plain_secret&issuer=OTS',
+      };
+
+      axiosMock.onPost('/auth/otp-setup').reply(200, setupResponse);
+
+      const { setupMfa, setupData } = useMfa();
+      const result = await setupMfa();
+
+      expect(result?.qr_code).toBe('data:image/png;base64,mockQrCode');
+      expect(setupData.value?.qr_code).toBe('data:image/png;base64,mockQrCode');
+      expect(QRCode.toDataURL).toHaveBeenCalledWith(setupResponse.provisioning_uri);
+    });
+
     it('handles rate limiting errors', async () => {
       axiosMock.onPost('/auth/otp-setup').reply(429, { error: 'Too many requests' });
 

--- a/src/tests/composables/useMfa.spec.ts
+++ b/src/tests/composables/useMfa.spec.ts
@@ -170,6 +170,25 @@ describe('useMfa', () => {
       expect(error.value).toBe('web.auth.security.internal_error');
     });
 
+    it('surfaces an error when a 200 setup response omits provisioning_uri', async () => {
+      // Non-HMAC 200 path with setup secrets but no provisioning_uri: no
+      // scannable QR can be rendered (the SPA must not reconstruct it, #3431),
+      // so setupMfa must fail visibly instead of populating setupData with an
+      // undefined qr_code (the blank-scan-step gap). Mirrors the 422 skew case.
+      axiosMock.onPost('/auth/otp-setup').reply(200, {
+        otp_setup: 'plain_secret',
+        otp_raw_secret: 'JBSWY3DPEHPK3PXP',
+      });
+
+      const { setupMfa, setupData, error } = useMfa();
+      const result = await setupMfa();
+
+      expect(result).toBeNull();
+      expect(setupData.value).toBeNull();
+      expect(error.value).toBe('web.auth.security.internal_error');
+      expect(QRCode.toDataURL).not.toHaveBeenCalled();
+    });
+
     it('handles rate limiting errors', async () => {
       axiosMock.onPost('/auth/otp-setup').reply(429, { error: 'Too many requests' });
 


### PR DESCRIPTION
Two related MFA robustness/clarity fixes surfaced while reviewing the #3431 QR rework.

## 1. Recovery-code comment was factually wrong (`apps/web/auth/config/features/mfa.rb`)

The comment claimed "8-character alphanumeric codes (like: 4k9m-x2pq) — ~1.7 billion (36^8)", but `new_recovery_code` uses `Familia.generate_trace_id`, which emits a **CSPRNG-backed 64-bit base36 token** (~13 chars, ~1.8e19 ≈ 2⁶⁴, no dash). Corrected the comment to the real format/entropy and recorded why 64-bit is the deliberate choice (server-side, rate-limited, account-bound verification; shorter is easier to type when locked out). Generator unchanged — bumping to a higher tier doesn't escape Familia's "resist intentional guessing" caveat and only lengthens the code.

## 2. Blank-QR gap on the non-HMAC (200) setup path (`useMfa.ts` / `mfaHelpers.ts`)

The 422 (HMAC) path already failed loudly when `provisioning_uri` was missing; the 200 path set `setupData` with an undefined `qr_code` → wizard bound to a **blank scan step with no error**. Extracted the guard into a shared `renderSetupQr` helper used by both paths; the 200 path now surfaces an error. Latent today (HMAC always on), but removes the asymmetry.

## Tests + validation (run locally)

- New `useMfa.spec.ts` case: a 200 response with secrets but no `provisioning_uri` returns null, leaves `setupData` null, surfaces `internal_error`, and never calls `QRCode.toDataURL`.

✅ **`vitest run src/tests/composables/useMfa.spec.ts` → 35/35 pass** (incl. the new case) and **`rspec mfa_spec.rb` → 21/21 pass** (the Ruby change is comment-only; spec confirms boot/config untouched). The earlier "couldn't run locally" caveat is resolved.

https://claude.ai/code/session_01Jt6ne55BRYMKMkfSb3nrAV