### PR TITLE
Fix colonel preview plan mode not reflecting the selected plan

### DIFF
--- a/apps/web/billing/controllers/entitlements.rb
+++ b/apps/web/billing/controllers/entitlements.rb
@@ -205,9 +205,19 @@ module Billing
       # - Organization has no planid
       # - Entitlements not materialized and plan not found in cache
       #
+      # Preview mode: when a colonel is previewing a plan
+      # (session[:entitlement_preview_planid] is set), the limits come from the
+      # previewed plan instead of the org's actual plan. This mirrors the
+      # entitlements side (org.entitlements_for_request(session)); without it the
+      # previewed plan's entitlements would surface while its limits would not,
+      # leaving limit-gated UI reflecting the wrong plan.
+      #
       # @param org [Onetime::Organization] Organization instance
       # @return [Hash] Limits with nil for infinity
       def build_limits_hash(org)
+        preview_planid = session_preview_planid
+        return preview_limits_hash(preview_planid) if preview_planid
+
         return {} if org.planid.to_s.empty?
 
         # Materialized path: read from org-local storage (no Plan.load)
@@ -225,6 +235,46 @@ module Billing
         limits = plan.limits_hash
         limits.transform_values do |value|
           value == Float::INFINITY ? nil : value
+        end
+      end
+
+      # Colonel preview plan id from the session, or nil when not previewing.
+      #
+      # Guards against non-hash sessions and treats blank values as "no preview"
+      # (matching limit_for_request / the SetEntitlementPreview clear path).
+      #
+      # @return [String, nil] Preview plan id, or nil
+      def session_preview_planid
+        return nil unless session.respond_to?(:[])
+
+        planid = session[:entitlement_preview_planid]
+        return nil if planid.nil? || planid.to_s.empty?
+
+        planid.to_s
+      end
+
+      # Build the limits hash for a previewed plan.
+      #
+      # Loads the plan via the same Stripe-cache-then-config fallback used when
+      # setting preview mode, and emits the same on-wire format as
+      # build_limits_hash (flattened keys, nil for unlimited). Returns an empty
+      # hash when the plan cannot be resolved.
+      #
+      # @param planid [String] Previewed plan id
+      # @return [Hash] Limits with nil for infinity
+      def preview_limits_hash(planid)
+        result = ::Billing::Plan.load_with_fallback(planid)
+
+        if result[:plan]
+          result[:plan].limits_hash.transform_values do |value|
+            value == Float::INFINITY ? nil : value
+          end
+        elsif result[:config]
+          (result[:config][:limits] || {}).transform_values do |value|
+            value == 'unlimited' ? nil : value.to_i
+          end
+        else
+          {}
         end
       end
 

--- a/apps/web/billing/spec/controllers/entitlements_preview_limits_spec.rb
+++ b/apps/web/billing/spec/controllers/entitlements_preview_limits_spec.rb
@@ -1,0 +1,107 @@
+# apps/web/billing/spec/controllers/entitlements_preview_limits_spec.rb
+#
+# frozen_string_literal: true
+
+# Unit tests for the colonel preview-mode limit resolution in the Entitlements
+# controller. These exercise the pure limit-building helpers in isolation
+# (no VCR / Stripe / HTTP) by allocating a controller instance and stubbing
+# Billing::Plan, mirroring the helper-method pattern in plan_switching_spec.rb.
+#
+# Regression coverage for: GET /billing/api/entitlements/:extid returning the
+# org's actual-plan limits while a colonel is previewing a different plan. The
+# entitlements were already preview-aware (entitlements_for_request); limits
+# were not, so limit-gated UI reflected the wrong plan.
+
+require_relative '../support/billing_spec_helper'
+require_relative '../../application'
+
+RSpec.describe 'Billing::Controllers::Entitlements preview limits' do
+  # Allocate without running initialize (which performs workspace self-healing
+  # and needs a full request). We only call the pure limit helpers.
+  let(:controller) { Billing::Controllers::Entitlements.allocate }
+
+  def stub_session(session)
+    req = instance_double('Rack::Request', env: { 'rack.session' => session })
+    controller.instance_variable_set(:@req, req)
+  end
+
+  describe '#session_preview_planid' do
+    it 'returns the symbol-keyed preview plan id' do
+      stub_session(entitlement_preview_planid: 'identity_v1')
+      expect(controller.send(:session_preview_planid)).to eq('identity_v1')
+    end
+
+    it 'treats a blank preview plan id as no preview' do
+      stub_session(entitlement_preview_planid: '')
+      expect(controller.send(:session_preview_planid)).to be_nil
+    end
+
+    it 'returns nil when no preview key is present' do
+      stub_session({})
+      expect(controller.send(:session_preview_planid)).to be_nil
+    end
+
+    it 'returns nil for a non-hash (corrupt/absent) session' do
+      stub_session(nil)
+      expect(controller.send(:session_preview_planid)).to be_nil
+    end
+  end
+
+  describe '#preview_limits_hash' do
+    it 'maps a Stripe-cached plan, converting infinity to nil' do
+      plan = instance_double(
+        'Billing::Plan',
+        limits_hash: { 'teams.max' => 1, 'custom_domains.max' => Float::INFINITY },
+      )
+      allow(::Billing::Plan).to receive(:load_with_fallback)
+        .with('identity_v1')
+        .and_return({ plan: plan, config: nil, source: 'stripe' })
+
+      expect(controller.send(:preview_limits_hash, 'identity_v1')).to eq(
+        'teams.max' => 1,
+        'custom_domains.max' => nil,
+      )
+    end
+
+    it 'maps a config-only plan, converting unlimited to nil and strings to ints' do
+      allow(::Billing::Plan).to receive(:load_with_fallback)
+        .with('free_v1')
+        .and_return(
+          {
+            plan: nil,
+            config: { limits: { 'teams.max' => 'unlimited', 'total_members_per_org.max' => '5' } },
+            source: 'local_config',
+          },
+        )
+
+      expect(controller.send(:preview_limits_hash, 'free_v1')).to eq(
+        'teams.max' => nil,
+        'total_members_per_org.max' => 5,
+      )
+    end
+
+    it 'returns an empty hash when the plan cannot be resolved' do
+      allow(::Billing::Plan).to receive(:load_with_fallback)
+        .with('nope')
+        .and_return({ plan: nil, config: nil, source: nil })
+
+      expect(controller.send(:preview_limits_hash, 'nope')).to eq({})
+    end
+  end
+
+  describe '#build_limits_hash with preview active' do
+    it 'returns the previewed plan limits and never consults the org' do
+      stub_session(entitlement_preview_planid: 'identity_v1')
+      plan = instance_double('Billing::Plan', limits_hash: { 'teams.max' => 1 })
+      allow(::Billing::Plan).to receive(:load_with_fallback)
+        .with('identity_v1')
+        .and_return({ plan: plan, config: nil, source: 'stripe' })
+
+      # A bare double with no stubbed methods: if the preview short-circuit
+      # regressed and the org were consulted, this would raise.
+      org = double('Organization')
+
+      expect(controller.send(:build_limits_hash, org)).to eq('teams.max' => 1)
+    end
+  end
+end

--- a/apps/web/core/views/serializers/organization_serializer.rb
+++ b/apps/web/core/views/serializers/organization_serializer.rb
@@ -50,7 +50,13 @@ module Core
         # Includes only the fields needed for:
         # - Domain context initialization (id, extid)
         # - Basic display (display_name, is_default)
-        # - Entitlement checks (planid, entitlements, limits)
+        # - Plan identity and role (planid, current_user_role)
+        #
+        # NOTE: entitlements and limits are intentionally NOT included here.
+        # They are served by the preview-aware billing entitlements endpoint
+        # (GET /billing/api/entitlements/:extid) and loaded into the org via
+        # organizationStore.fetchEntitlements. Adding them here would bypass
+        # colonel preview mode, which only the billing endpoint resolves.
         #
         # @param org [Onetime::Organization] Organization to serialize
         # @param cust [Onetime::Customer] Current user for role calculation

--- a/docs/diagrams/preview-mode-resolution.svg
+++ b/docs/diagrams/preview-mode-resolution.svg
@@ -1,0 +1,87 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1100 720" font-family="-apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif">
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#374151"/>
+    </marker>
+  </defs>
+
+  <rect x="0" y="0" width="1100" height="720" fill="#ffffff"/>
+  <rect x="6" y="6" width="1088" height="708" rx="14" fill="none" stroke="#e5e7eb" stroke-width="2"/>
+
+  <!-- Title -->
+  <text x="550" y="40" text-anchor="middle" font-size="25" font-weight="700" fill="#111827">Colonel Preview Plan Mode — why the resolution algebra matters</text>
+  <text x="550" y="68" text-anchor="middle" font-size="15" fill="#6b7280">Worked example: a colonel on free_v1 previews identity_plus_v1   (free_v1 &#8838; identity_plus_v1)</text>
+
+  <line x1="550" y1="92" x2="550" y2="548" stroke="#e5e7eb" stroke-width="2"/>
+
+  <!-- ============ LEFT: INTERSECTION ============ -->
+  <rect x="60" y="96" width="460" height="44" rx="10" fill="#fee2e2" stroke="#dc2626" stroke-width="1.5"/>
+  <line x1="82" y1="112" x2="96" y2="126" stroke="#dc2626" stroke-width="2.6" stroke-linecap="round"/>
+  <line x1="96" y1="112" x2="82" y2="126" stroke="#dc2626" stroke-width="2.6" stroke-linecap="round"/>
+  <text x="300" y="124" text-anchor="middle" font-size="16" font-weight="700" fill="#991b1b">Intersection   ·   effective = Preview &#8745; Org</text>
+
+  <!-- Nested Venn: Org (free) is a subset of Preview (identity_plus) -->
+  <circle cx="300" cy="300" r="128" fill="#fef3c7" stroke="#f59e0b" stroke-width="2.5"/>
+  <circle cx="262" cy="330" r="74" fill="#bfdbfe" stroke="#2563eb" stroke-width="2.5"/>
+
+  <text x="300" y="200" text-anchor="middle" font-size="13" font-weight="700" fill="#b45309">Preview = identity_plus_v1</text>
+
+  <!-- preview-only ring features (dropped) -->
+  <text x="372" y="262" text-anchor="middle" font-size="12.5" fill="#92400e">custom_domains</text>
+  <text x="372" y="280" text-anchor="middle" font-size="12.5" fill="#92400e">create_team</text>
+  <text x="372" y="298" text-anchor="middle" font-size="12.5" fill="#92400e">priority_support</text>
+  <text x="396" y="226" text-anchor="middle" font-size="11.5" font-style="italic" fill="#dc2626">dropped by &#8745;</text>
+
+  <!-- intersection = the org subset = result -->
+  <text x="248" y="318" text-anchor="middle" font-size="12.5" font-weight="700" fill="#1e3a8a">create_secrets</text>
+  <text x="248" y="336" text-anchor="middle" font-size="12.5" font-weight="700" fill="#1e3a8a">basic_sharing</text>
+  <text x="248" y="372" text-anchor="middle" font-size="11.5" font-weight="700" fill="#16a34a">&#8745; = result</text>
+
+  <text x="262" y="430" text-anchor="middle" font-size="12.5" font-weight="700" fill="#2563eb">Org = free_v1</text>
+
+  <!-- Result strip -->
+  <rect x="60" y="455" width="460" height="74" rx="10" fill="#fef2f2" stroke="#fecaca" stroke-width="1.5"/>
+  <text x="290" y="483" text-anchor="middle" font-size="15" font-weight="700" fill="#991b1b">Result = { create_secrets, basic_sharing }</text>
+  <text x="290" y="507" text-anchor="middle" font-size="13" fill="#6b7280">The 3 upgrade features are dropped &#8594; preview shows the</text>
+  <text x="290" y="523" text-anchor="middle" font-size="13" fill="#6b7280">FREE plan. Previewing an upgrade is a no-op.</text>
+
+  <!-- ============ RIGHT: RESET + SUBSTITUTE ============ -->
+  <rect x="580" y="96" width="460" height="44" rx="10" fill="#dcfce7" stroke="#16a34a" stroke-width="1.5"/>
+  <polyline points="600,119 606,125 616,110" fill="none" stroke="#16a34a" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+  <text x="816" y="124" text-anchor="middle" font-size="15.5" font-weight="700" fill="#166534">Reset + Substitute   ·   (Org &#8722; revokes) &#8746; grants</text>
+
+  <!-- Step 1: Org -->
+  <rect x="650" y="166" width="320" height="56" rx="10" fill="#bfdbfe" stroke="#2563eb" stroke-width="2"/>
+  <text x="810" y="190" text-anchor="middle" font-size="13.5" font-weight="700" fill="#1e3a8a">Org = free_v1</text>
+  <text x="810" y="210" text-anchor="middle" font-size="12.5" fill="#1e3a8a">{ create_secrets, basic_sharing }</text>
+
+  <line x1="810" y1="222" x2="810" y2="252" stroke="#374151" stroke-width="1.6" marker-end="url(#arrow)"/>
+  <text x="826" y="242" text-anchor="start" font-size="12.5" font-weight="700" fill="#dc2626">&#8722; revokes  (= Org's current set)</text>
+
+  <!-- Step 2: empty -->
+  <rect x="700" y="256" width="220" height="46" rx="10" fill="#f3f4f6" stroke="#9ca3af" stroke-width="2"/>
+  <text x="810" y="284" text-anchor="middle" font-size="13.5" fill="#374151">{ }   empty — reset</text>
+
+  <line x1="810" y1="302" x2="810" y2="332" stroke="#374151" stroke-width="1.6" marker-end="url(#arrow)"/>
+  <text x="826" y="322" text-anchor="start" font-size="12.5" font-weight="700" fill="#16a34a">&#8746; grants  (= Preview's set)</text>
+
+  <!-- Step 3: preview set -->
+  <rect x="612" y="336" width="396" height="78" rx="10" fill="#fef3c7" stroke="#f59e0b" stroke-width="2"/>
+  <text x="810" y="360" text-anchor="middle" font-size="13.5" font-weight="700" fill="#b45309">Preview = identity_plus_v1</text>
+  <text x="810" y="381" text-anchor="middle" font-size="12.5" fill="#92400e">{ create_secrets, basic_sharing,</text>
+  <text x="810" y="399" text-anchor="middle" font-size="12.5" fill="#92400e">custom_domains, create_team, priority_support }</text>
+
+  <!-- Result strip -->
+  <rect x="580" y="455" width="460" height="74" rx="10" fill="#f0fdf4" stroke="#bbf7d0" stroke-width="1.5"/>
+  <text x="810" y="483" text-anchor="middle" font-size="15" font-weight="700" fill="#166534">Result = full identity_plus_v1 set</text>
+  <text x="810" y="507" text-anchor="middle" font-size="13" fill="#6b7280">Preview reflects the selected plan — works for</text>
+  <text x="810" y="523" text-anchor="middle" font-size="13" fill="#6b7280">upgrades AND downgrades.</text>
+
+  <!-- ============ BOTTOM BAND ============ -->
+  <rect x="60" y="556" width="980" height="140" rx="12" fill="#f9fafb" stroke="#e5e7eb" stroke-width="1.5"/>
+  <text x="84" y="584" font-size="15.5" font-weight="700" fill="#111827">Why intersection can't model preview</text>
+  <text x="84" y="612" font-size="13.5" fill="#374151">&#8226;  A &#8745; B &#8838; A  — intersection can only REMOVE entitlements, never ADD them, so it can't simulate a richer plan.</text>
+  <text x="84" y="638" font-size="13.5" fill="#374151">&#8226;  Limits are scalar (teams.max = 5) — there is no sensible &#8220;intersection&#8221; of limits. Substitution just takes the previewed plan's limits.</text>
+  <text x="84" y="664" font-size="13.5" fill="#374151">&#8226;  Memberships correctly DO use &#8745;  (org.materialized_entitlements &#8745; ROLE_ENTITLEMENTS[role]) — a member must never exceed the org.</text>
+  <text x="84" y="685" font-size="13.5" fill="#6b7280">    Preview is the opposite requirement: replace, don't restrict.</text>
+</svg>

--- a/src/shared/components/modals/PlanPreviewModal.vue
+++ b/src/shared/components/modals/PlanPreviewModal.vue
@@ -119,13 +119,20 @@ const actualPlanName = computed(() => {
  *    UI keeps gating against the org's actual plan.
  */
 const syncPreviewState = async () => {
-  await bootstrapStore.refresh();
-
+  // The two refreshes are independent and hit different endpoints:
+  //   - bootstrapStore.refresh() updates entitlement_preview_planid /
+  //     _plan_name (the banner) from /bootstrap/me
+  //   - fetchEntitlements() reloads the org's preview-aware entitlements/limits
+  //     (what useEntitlements gates on) from the billing endpoint
+  // The active org's extid does not change across a preview toggle, so resolve
+  // it up front and run both requests concurrently.
   const extid =
     organizationStore.currentOrganization?.extid ?? bootstrapStore.organization?.extid;
-  if (extid) {
-    await organizationStore.fetchEntitlements(extid);
-  }
+
+  await Promise.all([
+    bootstrapStore.refresh(),
+    extid ? organizationStore.fetchEntitlements(extid) : Promise.resolve(),
+  ]);
 };
 
 const handleActivateTestMode = async (planId: string) => {

--- a/src/shared/components/modals/PlanPreviewModal.vue
+++ b/src/shared/components/modals/PlanPreviewModal.vue
@@ -5,6 +5,7 @@ import ListSkeleton from '@/shared/components/closet/ListSkeleton.vue';
 import OIcon from '@/shared/components/icons/OIcon.vue';
 import { usePreviewPlanMode } from '@/shared/composables/usePreviewPlanMode';
 import { useBootstrapStore } from '@/shared/stores/bootstrapStore';
+import { useOrganizationStore } from '@/shared/stores/organizationStore';
 import { createApi } from '@/api';
 import {
   Dialog,
@@ -18,6 +19,7 @@ import { useI18n } from 'vue-i18n';
 
 const { t } = useI18n();
 const bootstrapStore = useBootstrapStore();
+const organizationStore = useOrganizationStore();
 const $api = createApi();
 
 const props = defineProps<{
@@ -101,6 +103,31 @@ const actualPlanName = computed(() => {
   return plan?.name || planId;
 });
 
+/**
+ * Sync client state after the preview override changes on the server.
+ *
+ * Two independent pieces of state must be refreshed, because they come from
+ * different endpoints:
+ *
+ * 1. bootstrapStore.refresh() — picks up `entitlement_preview_planid` /
+ *    `entitlement_preview_plan_name`, which drive the preview banner.
+ *
+ * 2. organizationStore.fetchEntitlements() — the org's entitlements/limits
+ *    (what `useEntitlements` gates features on) are NOT part of the bootstrap
+ *    payload. They are served by the preview-aware billing entitlements
+ *    endpoint. Without re-fetching them, the banner flips but the rest of the
+ *    UI keeps gating against the org's actual plan.
+ */
+const syncPreviewState = async () => {
+  await bootstrapStore.refresh();
+
+  const extid =
+    organizationStore.currentOrganization?.extid ?? bootstrapStore.organization?.extid;
+  if (extid) {
+    await organizationStore.fetchEntitlements(extid);
+  }
+};
+
 const handleActivateTestMode = async (planId: string) => {
   isLoading.value = true;
   error.value = null;
@@ -108,8 +135,9 @@ const handleActivateTestMode = async (planId: string) => {
   try {
     await $api.post('/api/colonel/entitlement-preview', { planid: planId });
 
-    // Refresh bootstrap store to get updated entitlements (no page reload needed)
-    await bootstrapStore.refresh();
+    // Refresh banner state and re-fetch the org's preview-aware entitlements
+    // so feature gating reflects the selected plan (no page reload needed).
+    await syncPreviewState();
     emit('close');
   } catch (err: unknown) {
     console.error('Failed to activate test mode:', err);
@@ -126,8 +154,9 @@ const handleResetToActual = async () => {
   try {
     await $api.post('/api/colonel/entitlement-preview', { planid: null });
 
-    // Refresh bootstrap store to clear test mode (no page reload needed)
-    await bootstrapStore.refresh();
+    // Refresh banner state and re-fetch the org's actual entitlements so
+    // feature gating returns to the real plan (no page reload needed).
+    await syncPreviewState();
     emit('close');
   } catch (err: unknown) {
     console.error('Failed to reset test mode:', err);

--- a/src/shared/components/modals/PlanPreviewModal.vue
+++ b/src/shared/components/modals/PlanPreviewModal.vue
@@ -129,6 +129,17 @@ const syncPreviewState = async () => {
   const extid =
     organizationStore.currentOrganization?.extid ?? bootstrapStore.organization?.extid;
 
+  if (!extid) {
+    // An active org should always be present in the colonel preview context.
+    // If it isn't, the banner would still update while feature gating stayed on
+    // the old plan — the exact mismatch this feature fixes. Surface it instead
+    // of failing silently so the half-updated state is debuggable.
+    console.warn(
+      '[PlanPreviewModal] No organization extid resolvable; skipping entitlements refresh. ' +
+        'Preview banner may not match feature gating until a page reload.'
+    );
+  }
+
   await Promise.all([
     bootstrapStore.refresh(),
     extid ? organizationStore.fetchEntitlements(extid) : Promise.resolve(),

--- a/src/tests/apps/colonel/components/PlanPreviewModal.spec.ts
+++ b/src/tests/apps/colonel/components/PlanPreviewModal.spec.ts
@@ -5,6 +5,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { createI18n } from 'vue-i18n';
 import { createTestingPinia } from '@pinia/testing';
 import PlanPreviewModal from '@/shared/components/modals/PlanPreviewModal.vue';
+import { useOrganizationStore } from '@/shared/stores/organizationStore';
 import { nextTick } from 'vue';
 
 // Mock HeadlessUI components
@@ -144,6 +145,11 @@ describe('PlanPreviewModal', () => {
       },
       global: {
         plugins: [i18n, pinia],
+        // organizationStore calls useApi() at setup; provide a stub so the
+        // store can be instantiated (its actions are stubbed by testing pinia).
+        provide: {
+          api: { get: mockGet, post: mockPost, put: vi.fn(), delete: vi.fn() },
+        },
       },
     });
 
@@ -305,6 +311,58 @@ describe('PlanPreviewModal', () => {
       await nextTick();
 
       expect(wrapper.text()).toContain('Failed to activate test mode');
+    });
+  });
+
+  // Regression: the modal must re-fetch the org's entitlements/limits after a
+  // preview toggle. Those drive useEntitlements feature gating and are NOT in
+  // the bootstrap payload, so refreshing bootstrap alone leaves the UI gating
+  // against the org's real plan instead of the previewed plan.
+  describe('Entitlement refresh', () => {
+    const orgState = {
+      organization: {
+        objid: 'org_1',
+        extid: 'on-abc',
+        display_name: 'Acme',
+        is_default: true,
+      },
+    };
+
+    it('re-fetches org entitlements after activating preview mode', async () => {
+      mockPost.mockResolvedValueOnce({ data: { status: 'active' } });
+
+      wrapper = await mountComponent({}, { ...orgState });
+      const orgStore = useOrganizationStore();
+
+      const planButton = wrapper.findAll('button').find(
+        btn => btn.text().includes('Identity Plus')
+      );
+      await planButton!.trigger('click');
+      await nextTick();
+      await nextTick();
+
+      expect(orgStore.fetchEntitlements).toHaveBeenCalledWith('on-abc');
+    });
+
+    it('re-fetches org entitlements after resetting to actual plan', async () => {
+      mockPost.mockResolvedValueOnce({
+        data: { status: 'cleared', actual_planid: 'free' },
+      });
+
+      wrapper = await mountComponent({}, {
+        entitlement_preview_planid: 'identity_v1',
+        ...orgState,
+      });
+      const orgStore = useOrganizationStore();
+
+      const resetButton = wrapper.findAll('button').find(
+        btn => btn.text().includes('Reset to Actual Plan')
+      );
+      await resetButton!.trigger('click');
+      await nextTick();
+      await nextTick();
+
+      expect(orgStore.fetchEntitlements).toHaveBeenCalledWith('on-abc');
     });
   });
 


### PR DESCRIPTION
## Problem

Colonel "Preview plan mode" appeared to work — the preview banner flipped to the selected plan — but the actual UI kept behaving as if the org were on its real plan. Feature gating (custom domains, branding, SSO, API, team/member limits, …) did not reflect the previewed plan.

## Root cause

The preview override is stored session-side by `SetEntitlementPreview` (grants/revokes sets + `entitlement_preview_planid`). But the data the UI gates on never picked it up, for two independent reasons:

1. **Frontend never re-fetched entitlements.** `PlanPreviewModal` toggled preview, then called only `bootstrapStore.refresh()`. The bootstrap payload's org (`OrganizationSerializer`) carries **only `planid`** — not entitlements/limits. Feature gating reads `org.entitlements`/`org.limits` from the **organization store**, populated by `fetchEntitlements()` (`GET /billing/api/entitlements/:extid`), which was never called on a preview toggle. So the banner updated while `useEntitlements.can()` / `.limit()` kept returning the real plan's values. (The modal's own comment "refresh bootstrap to get updated entitlements" encoded this wrong assumption.)

2. **Backend limits weren't preview-aware.** `Entitlements#show` returned preview-aware entitlements (`org.entitlements_for_request(session)`) but actual-plan limits (`build_limits_hash(org)` ignored the session). So even after a full page reload, limit-gated UI reflected the wrong plan.

## Fix

- **`PlanPreviewModal.vue`** — after activating/resetting preview, re-fetch the active org's entitlements via `organizationStore.fetchEntitlements(extid)` (in addition to refreshing bootstrap for the banner), so `useEntitlements` reflects the previewed plan with no page reload.
- **`entitlements.rb`** — `build_limits_hash` is now preview-aware: when `session[:entitlement_preview_planid]` is set it returns the previewed plan's limits (loaded via the same `Billing::Plan.load_with_fallback` used to set preview), in the same on-wire format (flattened keys, `nil` for unlimited). Mirrors the entitlements side.
- **`organization_serializer.rb`** — corrected the stale comment that claimed it serializes `entitlements`/`limits` (it only serializes `planid`); this is the assumption that led to the broken flow.

## Tests

- `PlanPreviewModal.spec.ts`: asserts `fetchEntitlements` is re-called for the active org after activate **and** reset. (Provides a stub `api` because the org store now instantiates at modal setup.)
- `entitlements_preview_limits_spec.rb` (new): unit coverage for `session_preview_planid`, `preview_limits_hash` (Stripe cache → `nil` for infinity; config → `nil` for `unlimited`, strings → ints; unresolved → `{}`), and `build_limits_hash` short-circuiting to the previewed plan.

Frontend suite (`PlanPreviewModal`, `usePreviewPlanMode`, `bootstrapStore`, `useEntitlements`, `organizationStore`, `UserMenu`) and `vue-tsc` type-check pass locally. The Ruby spec couldn't be run in this environment (Ruby 3.3.6 vs required ≥3.4.7, no Redis); it follows the existing `allocate` + `send(:private_method)` pattern from `plan_switching_spec.rb`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Njg4XA5e2usyzdSvYZhuzX)_