### PR TITLE
Use SecureRandom for all randomness in generated-secret password generation (main)

### DIFF
--- a/changelog.d/20260613_194500_claude_3452_strand_secure_random.rst
+++ b/changelog.d/20260613_194500_claude_3452_strand_secure_random.rst
@@ -1,0 +1,6 @@
+.. A new scriv changelog fragment.
+
+Fixed
+-----
+
+- ``Onetime::Utils.strand`` now draws every character of a generated secret from ``SecureRandom``. The complexity branch (used by default when more than one character set is enabled) previously seeded the guaranteed one-per-set characters with ``Array#sample`` and produced the final ordering with ``Array#shuffle``, both of which fall back to Ruby's non-cryptographic Mersenne Twister PRNG. Generated passwords are now fully CSPRNG-backed; there is no change to length, character sets, or the one-char-per-set guarantee. (#3452)

--- a/lib/onetime/utils.rb
+++ b/lib/onetime/utils.rb
@@ -84,8 +84,9 @@ module Onetime
       # @example Generate with custom options
       #   Utils.strand(12, { symbols: true, uppercase: false })
       #
-      # @security Cryptographically secure - uses SecureRandom.random_number which
-      #   provides cryptographically secure random number generation. Suitable for
+      # @security Cryptographically secure - every source of randomness in this
+      #   method (character selection, the guaranteed one-per-set characters, and
+      #   the final positional shuffle) is drawn from SecureRandom. Suitable for
       #   generating secure tokens, passwords, and other security-critical identifiers.
       def strand(len = 12, options = true)
         raise ArgumentError, 'Length must be positive' unless len.positive?
@@ -137,18 +138,20 @@ module Onetime
         # Generate password with guaranteed complexity when multiple character sets are enabled
         password_chars = []
 
-        # Ensure at least one character from each selected set
+        # Ensure at least one character from each selected set. Draw from
+        # SecureRandom (not Array#sample's default Mersenne Twister) so every
+        # character of a generated secret comes from a CSPRNG.
         # When excluding ambiguous chars, sample from filtered sets to maintain guarantee
         if opts['exclude_ambiguous']
-          password_chars << (UPPERCASE - AMBIGUOUS_CHARS).sample if opts['uppercase']
-          password_chars << (LOWERCASE - AMBIGUOUS_CHARS).sample if opts['lowercase']
-          password_chars << (NUMBERS - AMBIGUOUS_CHARS).sample if opts['numbers']
-          password_chars << (SYMBOLS - AMBIGUOUS_CHARS).sample if opts['symbols']
+          password_chars << (UPPERCASE - AMBIGUOUS_CHARS).sample(random: SecureRandom) if opts['uppercase']
+          password_chars << (LOWERCASE - AMBIGUOUS_CHARS).sample(random: SecureRandom) if opts['lowercase']
+          password_chars << (NUMBERS - AMBIGUOUS_CHARS).sample(random: SecureRandom) if opts['numbers']
+          password_chars << (SYMBOLS - AMBIGUOUS_CHARS).sample(random: SecureRandom) if opts['symbols']
         else
-          password_chars << UPPERCASE.sample if opts['uppercase']
-          password_chars << LOWERCASE.sample if opts['lowercase']
-          password_chars << NUMBERS.sample if opts['numbers']
-          password_chars << SYMBOLS.sample if opts['symbols']
+          password_chars << UPPERCASE.sample(random: SecureRandom) if opts['uppercase']
+          password_chars << LOWERCASE.sample(random: SecureRandom) if opts['lowercase']
+          password_chars << NUMBERS.sample(random: SecureRandom) if opts['numbers']
+          password_chars << SYMBOLS.sample(random: SecureRandom) if opts['symbols']
         end
 
         # Fill remaining length with random characters from the full set
@@ -160,8 +163,8 @@ module Onetime
           password_chars.concat(remaining_chars)
         end
 
-        # Shuffle and join to create final password
-        password_chars.shuffle.join
+        # Shuffle (via SecureRandom) and join to create final password
+        password_chars.shuffle(random: SecureRandom).join
       end
 
       # NOTE: Temporary until Familia 2-pre11

--- a/try/unit/utils/utils_try.rb
+++ b/try/unit/utils/utils_try.rb
@@ -44,9 +44,11 @@ Onetime::Utils.strand(16, { 'uppercase' => true, 'lowercase' => true, 'numbers' 
 #=> 16
 
 ## strand complexity path guarantees at least one char from each enabled set
+## (symbols matched as any non-alphanumeric char, since the password only draws
+## from the upper/lower/digit/symbol sets)
 pw = Onetime::Utils.strand(16, { 'uppercase' => true, 'lowercase' => true, 'numbers' => true, 'symbols' => true })
-[!!(pw =~ /[A-Z]/), !!(pw =~ /[a-z]/), !!(pw =~ /[0-9]/)]
-#=> [true, true, true]
+[!!(pw =~ /[A-Z]/), !!(pw =~ /[a-z]/), !!(pw =~ /[0-9]/), !!(pw =~ /[^A-Za-z0-9]/)]
+#=> [true, true, true, true]
 
 ## strand complexity path draws from SecureRandom, not Ruby's seedable PRNG.
 ## With len == set count there are no fill chars, so the whole password comes

--- a/try/unit/utils/utils_try.rb
+++ b/try/unit/utils/utils_try.rb
@@ -39,6 +39,28 @@ Onetime::Utils.strand.size
 Onetime::Utils.strand(20).size
 #=> 20
 
+## strand complexity path (all character sets) honors the requested length
+Onetime::Utils.strand(16, { 'uppercase' => true, 'lowercase' => true, 'numbers' => true, 'symbols' => true }).size
+#=> 16
+
+## strand complexity path guarantees at least one char from each enabled set
+pw = Onetime::Utils.strand(16, { 'uppercase' => true, 'lowercase' => true, 'numbers' => true, 'symbols' => true })
+[!!(pw =~ /[A-Z]/), !!(pw =~ /[a-z]/), !!(pw =~ /[0-9]/)]
+#=> [true, true, true]
+
+## strand complexity path draws from SecureRandom, not Ruby's seedable PRNG.
+## With len == set count there are no fill chars, so the whole password comes
+## from the guaranteed-char sampling + final shuffle. Seeding Kernel#srand
+## identically would make the output reproducible if those used the default
+## (Mersenne Twister) PRNG; SecureRandom makes them differ.
+@cx_opts = { 'uppercase' => true, 'lowercase' => true, 'numbers' => true, 'symbols' => true, 'exclude_ambiguous' => false }
+Kernel.srand(99)
+strand_a = Onetime::Utils.strand(4, @cx_opts)
+Kernel.srand(99)
+strand_b = Onetime::Utils.strand(4, @cx_opts)
+strand_a == strand_b
+#=> false
+
 ## Obscure email address (standard email)
 Onetime::Utils.obscure_email('tryouts@onetimesecret.com')
 #=> 'tr***@o***.com'


### PR DESCRIPTION
## Summary

`main` counterpart of #3452 (which targets `develop`). Cherry-picks #3452's three commits onto a `main` base, byte-for-byte identical, so that the later `main` → `develop` merge introduces no conflicts.

`Onetime::Utils.strand` (`lib/onetime/utils.rb`) is the generator behind the **Generate** secret feature. Its **complexity path** — taken whenever more than one character set is enabled, the *default* configuration — seeded the guaranteed one-per-set characters with `Array#sample` and ordered the result with `Array#shuffle`. Both default to Ruby's **Mersenne Twister**, a non-cryptographic PRNG, so part of every generated secret (the guaranteed chars + the entire ordering) came from predictable randomness — even though the simple path and the method's own `@security` doc already used `SecureRandom`.

## Change

- Pass `random: SecureRandom` to both `sample` and `shuffle` so **every** character value and position is drawn from a CSPRNG.
- Correct the `@security` comment to describe all three randomness sources.

No behavioral/format change — same length, character-class guarantees, and character sets; only the randomness source changes.

## Tests + validation (run locally on Ruby 3.4.9, main base)

Complexity-path coverage in `try/unit/utils/utils_try.rb`: requested length, the one-char-per-set guarantee (incl. symbols), and a regression check that output is **not** reproducible across identical `Kernel#srand` seeds (only holds if `sample`/`shuffle` used the seedable PRNG — fails against the old code).

`bundle exec try try/unit/utils/utils_try.rb` -> **36/36 pass**.

## Relationship to other PRs

- #3452 — same change, targets `develop`. Merge order between the two does not matter; identical content means a conflict-free reconciliation.
- Supersedes #3449 (also targeted `main`), which used `secure_sample` / `secure_shuffle` wrapper helpers. This adopts the simpler inline `random: SecureRandom` form. #3449 will be closed.