### PR TITLE
Use forked rodauth-oauth with oauth_mount_prefix to fix prefix mismatch

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,14 @@ gem 'otto', '~> 2.2'
 gem 'rhales', '~> 0.6.2'
 gem 'roda', '~> 3.0'
 gem 'rodauth', '~> 2.0'
-gem 'rodauth-oauth', '~> 1.6'
+# Forked to add `oauth_mount_prefix`, which fixes the Rack::URLMap mount-prefix
+# mismatch (discovery URLs, issuer, and per-endpoint CSRF exemptions losing the
+# `/auth` mount point) at the gem level — see onetimesecret/onetimesecret#3465
+# and apps/web/auth/docs/rodauth-prefix-mismatch.md. Pin to a tag/SHA once the
+# change is upstreamed to os85/rodauth-oauth.
+gem 'rodauth-oauth', '~> 1.6',
+  git: 'https://github.com/onetimesecret/rodauth-oauth.git',
+  branch: 'claude/gifted-volta-4tpzai'
 gem 'rodauth-omniauth', '~> 0.4'
 gem 'rodauth-tools', '~> 0.3.1'
 

--- a/Gemfile
+++ b/Gemfile
@@ -25,11 +25,13 @@ gem 'rodauth', '~> 2.0'
 # Forked to add `oauth_mount_prefix`, which fixes the Rack::URLMap mount-prefix
 # mismatch (discovery URLs, issuer, and per-endpoint CSRF exemptions losing the
 # `/auth` mount point) at the gem level — see onetimesecret/onetimesecret#3465
-# and apps/web/auth/docs/rodauth-prefix-mismatch.md. Pin to a tag/SHA once the
-# change is upstreamed to os85/rodauth-oauth.
+# and apps/web/auth/docs/rodauth-prefix-mismatch.md. Pinned to an immutable SHA
+# (not the mutable `claude/gifted-volta-4tpzai` branch) so `bundle update` can't
+# silently drift this security-critical gem. Bump the ref when the fork advances;
+# drop the fork once the change is upstreamed to os85/rodauth-oauth.
 gem 'rodauth-oauth', '~> 1.6',
   git: 'https://github.com/onetimesecret/rodauth-oauth.git',
-  branch: 'claude/gifted-volta-4tpzai'
+  ref: '6e91089d5ee598a5ee6e78a5992d9e778ba7ccad'
 gem 'rodauth-omniauth', '~> 0.4'
 gem 'rodauth-tools', '~> 0.3.1'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,13 @@
 GIT
+  remote: https://github.com/onetimesecret/rodauth-oauth.git
+  revision: 6e91089d5ee598a5ee6e78a5992d9e778ba7ccad
+  branch: claude/gifted-volta-4tpzai
+  specs:
+    rodauth-oauth (1.6.5)
+      base64
+      rodauth (~> 2.28)
+
+GIT
   remote: https://github.com/rspec/rspec
   revision: 1559574cba6d7cb49bdeadacb20ba008390e2981
   specs:
@@ -408,9 +417,6 @@ GEM
     rodauth (2.42.0)
       roda (>= 2.6.0)
       sequel (>= 4)
-    rodauth-oauth (1.6.4)
-      base64
-      rodauth (~> 2.0)
     rodauth-omniauth (0.6.2)
       omniauth (~> 2.0)
       rodauth (~> 2.36)
@@ -654,7 +660,7 @@ DEPENDENCIES
   rhales (~> 0.6.2)
   roda (~> 3.0)
   rodauth (~> 2.0)
-  rodauth-oauth (~> 1.6)
+  rodauth-oauth (~> 1.6)!
   rodauth-omniauth (~> 0.4)
   rodauth-tools (~> 0.3.1)
   rotp (~> 6.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/onetimesecret/rodauth-oauth.git
   revision: 6e91089d5ee598a5ee6e78a5992d9e778ba7ccad
-  branch: claude/gifted-volta-4tpzai
+  ref: 6e91089d5ee598a5ee6e78a5992d9e778ba7ccad
   specs:
     rodauth-oauth (1.6.5)
       base64

--- a/apps/web/auth/config/features/oauth.rb
+++ b/apps/web/auth/config/features/oauth.rb
@@ -40,11 +40,6 @@ require 'rodauth/oauth'
 
 module Auth::Config::Features
   module OAuth
-    # Endpoints reached programmatically by SP clients — no browser session,
-    # no CSRF. /authorize is intentionally absent: it is browser-driven and
-    # must keep CSRF protection. See the check_csrf? override below.
-    OAUTH_NO_CSRF_PATHS = %w[/token /userinfo /revoke /jwks].freeze
-
     def self.configure(auth)
       auth.enable :oauth_authorization_code_grant,
         :oauth_pkce,
@@ -57,77 +52,33 @@ module Auth::Config::Features
       auth.oauth_applications_table :oauth_applications
       auth.oauth_grants_table :oauth_grants
 
-      # ─── Issuer / authorization server URL ────────────────────────────
-      # The OP is mounted at base_url + Auth::Application.uri_prefix
-      # (e.g. http://localhost:3000/auth). The gem's default
-      # `authorization_server_url` returns just `base_url`, missing the
-      # mount prefix — that would make ID tokens claim `iss:
-      # http://localhost:3000` while OmniAuth/discovery clients expect
-      # `http://localhost:3000/auth`.
+      # ─── Mount prefix / issuer ─────────────────────────────────────────
+      # The OP is mounted under Auth::Application.uri_prefix (e.g. /auth) via
+      # Rack::URLMap, which sets SCRIPT_NAME=/auth and strips it from PATH_INFO.
+      # Rodauth route matching keeps working off `remaining_path` (so `prefix`
+      # is left at its empty default), but `base_url`/`route_path` don't include
+      # the mount point — so discovery URLs, the `issuer`, and the per-endpoint
+      # CSRF exemptions used to drop `/auth`.
       #
-      # We override `authorization_server_url` (consumed by the default
-      # `oauth_jwt_issuer`, oauth_jwt_base.rb:36) AND
-      # `oauth_server_metadata_body` so the discovery `issuer` field
-      # honors the same value — by default that field is `base_url`
-      # ignoring authorization_server_url (oauth_base.rb:746-748).
-      #
-      # OAUTH_ISSUER overrides both for static prod deployments.
+      # The forked rodauth-oauth exposes `oauth_mount_prefix` (Gemfile pins the
+      # fork; see #3465 and apps/web/auth/docs/rodauth-prefix-mismatch.md). It
+      # makes the gem honor the mount point in `*_path`/`*_url` generation, the
+      # discovery `issuer` (via authorization_server_url), and the per-feature
+      # `check_csrf?` comparisons — replacing the local
+      # prefix_oauth_endpoint_urls! helper and the oauth_server_metadata_body /
+      # openid_configuration_body / check_csrf? overrides this file used to
+      # carry. Route matching is unaffected (it uses remaining_path), so setting
+      # rodauth's global `prefix` is still not needed.
+      auth.oauth_mount_prefix Auth::Application.uri_prefix
+
+      # The gem derives the discovery `issuer` (and oauth_jwt_issuer,
+      # oauth_jwt_base.rb:36) from authorization_server_url, whose default is now
+      # `base_url + oauth_mount_prefix`. The only issuer behavior that stays
+      # OTS-specific is OAUTH_ISSUER, which pins the issuer for static prod
+      # deployments; fall back to the gem default otherwise.
       auth.auth_class_eval do
         define_method(:authorization_server_url) do
-          ENV.fetch('OAUTH_ISSUER') { "#{base_url}#{Auth::Application.uri_prefix}" }
-        end
-
-        # The gem's *_url methods build `base_url + route_path(name)`, and
-        # route_path uses rodauth's `prefix` (empty by default). Since this
-        # rodauth instance is mounted under Auth::Application.uri_prefix
-        # (`/auth`), the generated URLs come out without that prefix
-        # (e.g. `http://host/authorize` instead of `http://host/auth/authorize`).
-        #
-        # Setting rodauth.prefix system-wide is NOT a viable fix: doing so
-        # also changes `request.is *_path` matching, but `remaining_path` is
-        # already `/token` after Rack::URLMap strips SCRIPT_NAME, breaking
-        # every rodauth route. The mismatch is structural — see
-        # apps/web/auth/docs/rodauth-prefix-mismatch.md for the full analysis.
-        define_method(:oauth_server_metadata_body) do |path = nil|
-          body          = super(path)
-          body[:issuer] = authorization_server_url
-
-          prefix_oauth_endpoint_urls!(body)
-          body
-        end
-
-        # OIDC discovery (`/.well-known/openid-configuration`) goes through
-        # `openid_configuration_body`, which calls oauth_server_metadata_body
-        # but then merges in `userinfo_endpoint: userinfo_url` AFTER our patch
-        # (oidc.rb:811). Re-apply the prefix patch after super so userinfo
-        # comes out with /auth.
-        define_method(:openid_configuration_body) do |path = nil|
-          body = super(path)
-          prefix_oauth_endpoint_urls!(body)
-          body
-        end
-
-        # Shared helper to rewrite endpoint URLs in a metadata body, adding
-        # the Rack mount prefix when missing. rodauth-oauth builds URLs from
-        # `base_url + route_path(name)` and route_path uses rodauth's own
-        # `prefix` (empty by default); since the auth app is mounted under
-        # /auth, the generated URLs need the prefix added.
-        define_method(:prefix_oauth_endpoint_urls!) do |body|
-          uri_prefix = Auth::Application.uri_prefix
-          [:authorization_endpoint, :token_endpoint, :userinfo_endpoint, :jwks_uri, :revocation_endpoint, :registration_endpoint, :introspection_endpoint, :end_session_endpoint].each do |key|
-            next unless body[key].is_a?(String)
-
-            uri = URI.parse(body[key])
-            # Treat as already-prefixed only when the path starts with
-            # "/auth/" or equals "/auth" — guard against substring matches
-            # (e.g. URI "/authorize" contains "/auth" but is NOT prefixed).
-            next if uri.path == uri_prefix
-            next if uri.path.start_with?("#{uri_prefix}/")
-
-            uri.path  = "#{uri_prefix}#{uri.path}"
-            body[key] = uri.to_s
-          end
-          body
+          ENV.fetch('OAUTH_ISSUER') { super() }
         end
       end
 
@@ -198,28 +149,24 @@ module Auth::Config::Features
         end
       end
 
-      # ─── CSRF bypass for IdP endpoints ─────────────────────────────────
-      # rodauth-oauth's per-feature `check_csrf?` overrides compare against
-      # *unprefixed* path names (e.g. `/token`), but rodauth's `request.path`
-      # returns the full Rack `SCRIPT_NAME + PATH_INFO` (e.g. `/auth/token`)
-      # — see oauth_base.rb:158. With rodauth's `prefix` left at the default
-      # empty string but Auth::Router mounted at /auth, those comparisons
-      # never match and the gem's intended CSRF exemption silently fails
-      # back to super. (Underlying issue: rodauth prefix mismatch — see
-      # apps/web/auth/docs/rodauth-prefix-mismatch.md.)
+      # ─── CSRF: keep /revoke exempt (load-bearing, OTS-specific) ─────────
+      # Now that oauth_mount_prefix aligns the gem's `*_path` helpers with the
+      # browser-absolute `request.path`, the gem's own per-feature `check_csrf?`
+      # exemptions work again: /token (oauth_base) and /userinfo (oidc) are
+      # exempt at the gem level, /authorize keeps CSRF (browser-driven), and
+      # /jwks is GET-only. So the broad local request.path override is gone.
       #
-      # Endpoints in OAUTH_NO_CSRF_PATHS (defined above) are reached
-      # programmatically by SP clients without a browser session, so CSRF
-      # doesn't apply. PKCE + client_secret on /token + bearer auth on
-      # /userinfo provide the protocol-level equivalents. /authorize is *not*
-      # in this set — it is browser-driven and must keep CSRF protection
-      # (matches gem behavior in non-JSON mode).
+      # The one exemption the gem does NOT give us is a blanket /revoke: its
+      # oauth_token_revocation `check_csrf?` enforces CSRF on form-encoded
+      # /revoke (exempting only JSON), which is inverted from RFC 7009 —
+      # /revoke is form-encoded and authenticated by client credentials, not
+      # CSRF tokens. SP clients call it programmatically, so we exempt it
+      # regardless of content type. This is independent of the prefix fix; do
+      # NOT drop it. (revoke_path is mount-aware via oauth_mount_prefix, so this
+      # matches request.path under the /auth mount.)
       auth.auth_class_eval do
         define_method(:check_csrf?) do
-          paths      = Auth::Config::Features::OAuth::OAUTH_NO_CSRF_PATHS
-          full_paths = paths.map { |p| "#{Auth::Application.uri_prefix}#{p}" }
-          return false if full_paths.include?(request.path)
-          return false if request.path.start_with?("#{Auth::Application.uri_prefix}/.well-known/")
+          return false if request.path == revoke_path
 
           super()
         end

--- a/apps/web/auth/config/features/oauth.rb
+++ b/apps/web/auth/config/features/oauth.rb
@@ -69,7 +69,11 @@ module Auth::Config::Features
       # openid_configuration_body / check_csrf? overrides this file used to
       # carry. Route matching is unaffected (it uses remaining_path), so setting
       # rodauth's global `prefix` is still not needed.
-      auth.oauth_mount_prefix Auth::Application.uri_prefix
+      # Block form (not a bare value): Auth::Application is not defined yet when
+      # this config loads (application.rb requires config.rb before defining the
+      # Application class), so the prefix must be resolved lazily at request
+      # time, when oauth_mount_prefix is first read.
+      auth.oauth_mount_prefix { Auth::Application.uri_prefix }
 
       # The gem derives the discovery `issuer` (and oauth_jwt_issuer,
       # oauth_jwt_base.rb:36) from authorization_server_url, whose default is now

--- a/apps/web/auth/docs/rodauth-prefix-mismatch.md
+++ b/apps/web/auth/docs/rodauth-prefix-mismatch.md
@@ -1,6 +1,17 @@
-# Rodauth Prefix Mismatch — Investigation & Deferral
+# Rodauth Prefix Mismatch — Investigation & Resolution
 
 Issue #3104 follow-up item #12.
+
+> **Update — resolved in #3465.** The decoupling knob described under
+> "When this might become a fix" now exists. The forked `rodauth-oauth`
+> (consumed via the `Gemfile`) adds an `oauth_mount_prefix` setting, and the
+> local override surface in `features/oauth.rb` has collapsed to that single
+> setting plus a slim `OAUTH_ISSUER` shim and the load-bearing `/revoke` CSRF
+> exemption. The rest of this document is the original investigation, retained
+> for history, with two **Correction** notes inline: the claim that setting
+> `rodauth.prefix '/auth'` "breaks every rodauth route" does **not** hold for
+> rodauth 2.42.0 — route matching is segment-based and prefix-independent (see
+> the empirical table under "Why we don't fix the root cause").
 
 ## Summary
 
@@ -19,11 +30,21 @@ namespaces inside the rodauth instance:
 | `*_url` methods         | `base_url + /token`          |
 
 `request.is` / `r.on` match against `remaining_path`, while the gem's CSRF
-and metadata code paths inspect `request.path`. Setting `rodauth.prefix =
-'/auth'` would synchronize those, but would also produce `remaining_path =
-'/token'` versus required `'/auth/token'` in `request.is token_path`,
-breaking every rodauth route. The two namespaces are mutually exclusive at
-the framework level.
+and metadata code paths inspect `request.path`.
+
+> **Correction (#3465).** An earlier draft claimed that setting
+> `rodauth.prefix = '/auth'` would make `request.is token_path` require
+> `/auth/token` while `remaining_path` is `/token`, "breaking every rodauth
+> route," and that the two namespaces are "mutually exclusive at the framework
+> level." That is **not** how rodauth 2.42.0 matches. `handle_<name>` runs
+> `request.is send(:"#{name}_route")` against the bare route *segment*
+> (`"token"`), and `route!` looks up `route_hash[remaining_path]` whose keys
+> are `"/#{segment}"` — both prefix-independent. `prefix` only feeds
+> `route_path` (URL generation and the `check_csrf?` string comparisons), not
+> matching. So `prefix '/auth'` under `Rack::URLMap('/auth')` routes fine; it
+> fixes the URL and CSRF symptoms but **not** the issuer, and it is rejected
+> for a different reason (blast radius on every non-OAuth route). See the
+> corrected rationale and empirical table below.
 
 ## Concrete symptoms
 
@@ -110,9 +131,16 @@ Two things follow:
 
 Three approaches were considered and rejected:
 
-1. **Set `rodauth.prefix '/auth'`.** Breaks route matching: `request.is
-   token_path` becomes `request.is '/auth/token'`, but `remaining_path` is
-   `/token` after URLMap strips `SCRIPT_NAME`. Every rodauth route 404s.
+1. **Set `rodauth.prefix '/auth'`.** ~~Breaks route matching~~ — it does
+   **not** (see the Correction in Summary and the table below). Under
+   `Rack::URLMap('/auth')`, `prefix '/auth'` routes correctly and fixes the
+   discovery-URL and CSRF symptoms. The real reasons to avoid it: (a) it does
+   **not** fix the issuer (`base_url`, prefix-independent); and (b) `prefix`
+   prefixes **every** rodauth route's URL generation (login, logout, omniauth,
+   email links), whereas OTS only wants the OAuth/OIDC endpoints prefixed and
+   already does manual `Auth::Application.uri_prefix` prefixing elsewhere
+   (`json_mode.rb`) that assumes unprefixed `*_path`. The OAuth-scoped,
+   gem-level `oauth_mount_prefix` (taken in #3465) avoids that blast radius.
 
 2. **Mount auth app at `/` and route internally with `r.on('auth')`.**
    Loses isolation from main app routing; conflicts with the
@@ -124,37 +152,58 @@ Three approaches were considered and rejected:
    user who has set `rodauth.prefix` non-empty. Belongs in an upstream
    issue, not a local monkey-patch.
 
-The current patch surface (3 method overrides + 1 helper) is small,
-documented, and exercised by integration tests. The cost of carrying it
-is lower than the cost of any structural fix.
+At the time of writing, the patch surface (3 method overrides + 1 helper) was
+deemed smaller than any structural fix. **#3465 superseded that judgment:** the
+gem-level `oauth_mount_prefix` collapses the surface to one setting (plus the
+`OAUTH_ISSUER` shim and the `/revoke` exemption), so the structural fix is now
+the cheaper one to carry.
+
+### Empirical verification (rodauth 2.42.0)
+
+Measured with `Rack::Test` + `Rack::URLMap` — pristine rodauth core (no fork)
+for the routing rows, the fork for the post-fix row:
+
+| Scenario | Result |
+|----------|--------|
+| pristine core — `prefix '/auth'` + `URLMap('/auth')`, `GET /auth/login` | `200`, login form → **routes** (refutes "every route 404s") |
+| pristine core — `prefix` unset + `URLMap('/auth')`, `GET /auth/login` | `200` → routes (OTS today) |
+| pristine core — `prefix '/auth'`, **no** mount, `GET /auth/login` | `404`; `GET /login` → `200` (prefix alone doesn't relocate routes; the mount does) |
+| **fork (post-fix)** — `oauth_mount_prefix '/auth'` (prefix unset) + `URLMap('/auth')` | `POST /auth/token` routes & **CSRF-exempt**; discovery `token_endpoint` = `http://example.org/auth/token`, `issuer` = `http://example.org/auth` |
+
+The first three rows show `prefix` is irrelevant to *matching* (segment-based,
+via `route_hash[remaining_path]` + `request.is <segment>`); the fourth shows the
+fork's `oauth_mount_prefix` carrying the mount point into URL generation, the
+`issuer`, and the per-endpoint CSRF comparisons without touching matching.
+Pinned by `rodauth-oauth`'s `test/oauth/mount_prefix_test.rb` (URLMap mount) and
+an OTS-config replica run under Ruby 3.4.9.
 
 ## Regression coverage
 
-Any new rodauth-oauth route or per-feature `check_csrf?` override the gem
-adds in a future version will hit the same trap. Reviewers of gem bumps
-should check:
+**Superseded by #3465.** New OAuth routes and per-feature `check_csrf?`
+overrides are now handled at the gem level: every route defined via the fork's
+`auth_server_route` gets mount-aware `*_path`/`*_url` automatically, so there is
+no local list (`OAUTH_NO_CSRF_PATHS`) or helper (`prefix_oauth_endpoint_urls!`)
+to keep in sync — both were removed. The gem-bump checklist now lives in the
+fork (`doc/release_notes/1_6_5.md`): a new per-feature CSRF override must compare
+against the route's (mount-aware) `*_path`, and new discovery fields must be
+populated from a route's `*_url` helper rather than `base_url` directly.
 
-- `grep -rn 'case request.path' rodauth-oauth-X.Y.Z/lib/` — any new
-  per-feature CSRF override needs its path added to `OAUTH_NO_CSRF_PATHS`.
-- `grep -rn 'oauth_server_metadata_body\|openid_configuration_body'` for
-  new metadata fields that bypass `prefix_oauth_endpoint_urls!`.
-- Any new `*_endpoint` field added to discovery metadata needs to be
-  appended to the symbol list at `features/oauth.rb:116`.
+Integration tests pinning the behavior:
 
-Current integration tests pinning the behavior:
+- `apps/web/auth/spec/integration/oauth/*` — exercise discovery, /token,
+  /userinfo, /revoke under the `/auth` mount.
+- `rodauth-oauth`'s `test/oauth/mount_prefix_test.rb` — pins the gem-level
+  mount-prefix behavior (discovery URLs, issuer, and /token CSRF exemption
+  under a `Rack::URLMap` mount).
 
-- `spec/integration/oauth_idp_lifecycle_spec.rb` — exercises /token,
-  /userinfo, /revoke under the `/auth` mount; would 403 on CSRF or 404
-  on path mismatch if the overrides regressed.
-- Discovery endpoint specs — verify the `iss` field and endpoint URLs
-  contain `/auth`.
+## This became the fix (#3465)
 
-## When this might become a fix
-
-If rodauth or rodauth-oauth grows a config knob that decouples
-"prefix used for URL generation" from "prefix used for `request.is`
-matching" (e.g. an explicit `mount_prefix` separate from `prefix`), all
-three overrides above collapse into a single setting. Until then, the
-mismatch is a framework-level constraint of running rodauth-oauth
-behind `Rack::URLMap`, and the local patch is the right place to absorb
-it.
+rodauth-oauth grew exactly the config knob anticipated here: an
+`oauth_mount_prefix` that decouples "prefix used for URL generation /
+`request.path` comparison" from "prefix used for route matching" (which stays on
+`remaining_path`). The forked gem (consumed via the `Gemfile`) honors it in the
+discovery metadata builders, the per-feature `check_csrf?` comparisons, and the
+issuer derivation, so the three local overrides collapsed into the single
+`auth.oauth_mount_prefix { Auth::Application.uri_prefix }` setting. The `/revoke`
+CSRF exemption is retained separately (load-bearing — see the Nuance section);
+the `OAUTH_ISSUER` shim is retained for static prod deployments.


### PR DESCRIPTION
## Summary

Fixes #3465

Resolves the Rack::URLMap mount-prefix mismatch by consuming a forked `rodauth-oauth` that adds an `oauth_mount_prefix` setting. This setting makes the gem honor the `/auth` mount point in discovery URLs, the issuer, and per-endpoint CSRF exemptions — eliminating the need for local method overrides.

### Changes

**`Gemfile`:**
- Pin `rodauth-oauth` to a fork (`onetimesecret/rodauth-oauth`, branch `claude/gifted-volta-4tpzai`) that adds `oauth_mount_prefix` support

**`apps/web/auth/config/features/oauth.rb`:**
- Remove `OAUTH_NO_CSRF_PATHS` constant (no longer needed; CSRF exemptions now work at the gem level)
- Remove `prefix_oauth_endpoint_urls!` helper (gem now handles mount-aware URL generation)
- Remove `oauth_server_metadata_body` and `openid_configuration_body` overrides (gem now includes mount prefix in discovery metadata)
- Add single `auth.oauth_mount_prefix { Auth::Application.uri_prefix }` setting to configure the gem's mount-aware behavior
- Simplify `authorization_server_url` override to only handle the `OAUTH_ISSUER` env var fallback (issuer derivation now uses the mount-aware `authorization_server_url` by default)
- Simplify `check_csrf?` override to only exempt `/revoke` (the load-bearing, OTS-specific exemption; `/token` and `/userinfo` are now exempt at the gem level)

**`apps/web/auth/docs/rodauth-prefix-mismatch.md`:**
- Update title to reflect resolution
- Add summary note documenting the fix via `oauth_mount_prefix`
- Correct earlier claims about route matching (empirically verified that `prefix` does not affect matching in rodauth 2.42.0)
- Document the empirical verification table showing the fix works
- Update regression coverage section to reflect gem-level handling
- Rename final section from "When this might become a fix" to "This became the fix (#3465)"

### Why

The local patch surface (3 method overrides + 1 helper) was carrying the burden of synchronizing the mount point across URL generation, discovery metadata, and CSRF exemptions. The forked gem now handles this at the source, collapsing the surface to a single setting plus two load-bearing shims (`OAUTH_ISSUER` and `/revoke` exemption).

## Related Issues

Fixes #3465

## Test Plan

Existing integration tests in `apps/web/auth/spec/integration/oauth/*` exercise discovery, `/token`, `/userinfo`, and `/revoke` under the `/auth` mount and will verify that:
- Discovery endpoints return URLs with the `/auth` prefix
- The `issuer` field includes `/auth`
- `/token` and `/revoke` are CSRF-exempt
- Routes continue to match correctly

The forked gem's `test/oauth/mount_prefix_test.rb` pins the mount-prefix behavior at the gem level.

https://claude.ai/code/session_01Fx3zMECVcyNSa7uPhZaAs1