### PR TITLE
Fix suite-order-dependent flakes in billing isolation setup

### DIFF
--- a/apps/web/billing/spec/support/billing_isolation.rb
+++ b/apps/web/billing/spec/support/billing_isolation.rb
@@ -16,6 +16,29 @@ RSpec.configure do |config|
     BillingTestHelpers.disable_billing!
   end
 
+  # Disable billing before each example group's context hooks, too.
+  #
+  # before(:context)/before(:all) hooks run BEFORE the first before(:each), so a
+  # spec that exercises billing-sensitive logic in before(:all) -- e.g. creating
+  # an Organization that materializes STANDALONE_ENTITLEMENTS at create! time --
+  # would otherwise observe whatever BILLING_ENABLED the environment or a prior
+  # example happened to leave set. Under the `billing: on` CI matrix that default
+  # is "true", which makes Organization.create! treat the org as SaaS and skip
+  # standalone materialization, producing a suite-order-dependent flake where the
+  # outcome tracks the RSpec seed rather than the code (issue #3418).
+  #
+  # This mirrors the before(:each) default at the context scope so the billing
+  # default is deterministic for before(:all) setup as well. It is safe by
+  # construction: the `billing: off` CI matrix already runs every group's
+  # before(:all) with billing disabled, so disabling here cannot introduce new
+  # failures. Groups that need billing enabled during before(:all) opt back in
+  # explicitly within their own before(:all) (e.g. BillingTestHelpers.restore_billing!),
+  # which runs after this hook; per-example billing is unaffected and continues
+  # to opt in via the `billing: true` before(:each) hook below.
+  config.before(:context) do
+    BillingTestHelpers.disable_billing!
+  end
+
   # Clean up billing state after tests that enable it
   config.after(:each) do
     if @billing_enabled_in_test

--- a/spec/integration/all/default_workspace_creation_spec.rb
+++ b/spec/integration/all/default_workspace_creation_spec.rb
@@ -11,14 +11,10 @@ RSpec.describe 'default_workspace_creation_try', type: :integration, order: :def
     ENV.delete('REDIS_URL')
     ENV.delete('VALKEY_URL')
 
-    # Standalone materialization happens inside Organization.create!, which
-    # runs here in before(:all) -- BEFORE billing_isolation.rb's before(:each)
-    # disable hook fires. So a prior spec (or env) leaving BILLING_ENABLED=true
-    # would make create! treat the org as SaaS and skip materialization,
-    # failing the standalone assertions below. Disable billing explicitly here
-    # so this spec is self-contained rather than dependent on hook ordering.
-    BillingTestHelpers.disable_billing!
-
+    # These examples assert standalone-mode materialization, which
+    # Organization.create! performs in this before(:all) only when billing is
+    # disabled. billing_isolation.rb disables billing before every example
+    # group's context hooks (#3418), so no per-spec toggle is needed here.
     begin
       OT.boot! :test, false unless OT.ready?
     rescue Redis::CannotConnectError, Redis::ConnectionError => e

--- a/spec/integration/all/organization_v1_migration_created_by_spec.rb
+++ b/spec/integration/all/organization_v1_migration_created_by_spec.rb
@@ -29,14 +29,10 @@ RSpec.describe 'Organization.create_from_v1_customer! created_by dual-write',
     ENV.delete('REDIS_URL')
     ENV.delete('VALKEY_URL')
 
-    # Standalone materialization happens inside Organization.create!, which
-    # runs here in before(:all) -- BEFORE billing_isolation.rb's before(:each)
-    # disable hook fires. So a prior spec (or env) leaving BILLING_ENABLED=true
-    # would make create! treat the org as SaaS and skip materialization,
-    # failing the standalone assertions below. Disable billing explicitly here
-    # so this spec is self-contained rather than dependent on hook ordering.
-    BillingTestHelpers.disable_billing!
-
+    # These examples assert standalone-mode materialization, which
+    # Organization.create! performs in this before(:all) only when billing is
+    # disabled. billing_isolation.rb disables billing before every example
+    # group's context hooks (#3418), so no per-spec toggle is needed here.
     begin
       OT.boot! :test, false unless OT.ready?
     rescue Redis::CannotConnectError, Redis::ConnectionError => e


### PR DESCRIPTION
## Summary

Fixes #3418

Add a `before(:context)` hook to disable billing before example group context hooks run, ensuring deterministic billing state during `before(:all)` setup. This prevents suite-order-dependent flakes where Organization creation behavior depends on the RSpec seed rather than the code.

The root cause: `before(:context)` hooks run before `before(:each)` hooks, so specs exercising billing-sensitive logic in `before(:all)` (like Organization.create! which materializes STANDALONE_ENTITLEMENTS only when billing is disabled) would observe whatever BILLING_ENABLED state the environment or prior examples left set. Under the `billing: on` CI matrix, this defaults to true, causing inconsistent behavior.

The fix mirrors the existing `before(:each)` disable hook at the context scope. This is safe by construction since the `billing: off` CI matrix already runs every group's `before(:all)` with billing disabled. Groups needing billing enabled during `before(:all)` can explicitly opt back in within their own hook, which runs after this one.

With this fix in place, the explicit `BillingTestHelpers.disable_billing!` calls in individual spec files are no longer needed, so they've been removed and replaced with clarifying comments.

## Related Issues

Fixes #3418

## Test Plan

Existing test suite passes. The change is covered by the `billing: on` and `billing: off` CI matrices which will verify that both billing-enabled and billing-disabled contexts work correctly regardless of RSpec seed.

https://claude.ai/code/session_012UygMQKDkSGHcUcdNpGjoZ