### PR TITLE
Replace CSS class selectors with test IDs in E2E tests

### DIFF
--- a/e2e/full/invite-flow-states.spec.ts
+++ b/e2e/full/invite-flow-states.spec.ts
@@ -627,7 +627,7 @@ test.describe('INV-010: Invalid Token State', () => {
     expect(token).toBeTruthy();
 
     // Find and click revoke button
-    const invitationRow = page.locator('.rounded-md').filter({ hasText: testEmail });
+    const invitationRow = page.getByTestId('org-invitation-row').filter({ hasText: testEmail });
     const revokeButton = invitationRow.getByRole('button', { name: /revoke/i });
 
     await expect(revokeButton).toBeVisible();

--- a/e2e/full/org-invitation-flow.spec.ts
+++ b/e2e/full/org-invitation-flow.spec.ts
@@ -148,24 +148,11 @@ async function createInvitation(
 }
 
 /**
- * Extract invitation token from pending invitations list
+ * Extract invitation token from pending invitations list via API
  */
 async function getInvitationToken(page: Page, email: string): Promise<string | null> {
-  // Look for the pending invitation row
-  const invitationRow = page.locator('.rounded-md').filter({
-    hasText: email,
-  });
-
-  if (!(await invitationRow.isVisible())) {
-    return null;
-  }
-
-  // The token should be available via the resend/revoke button actions
-  // We'll need to intercept the API call or check the URL after clicking
-  // For now, we'll use the API to get the token
-  const response = await page.request.get(
-    `/api/v2/org/${getCurrentOrgExtid(page)}/invitations`
-  );
+  const orgExtid = getCurrentOrgExtid(page);
+  const response = await page.request.get(`/api/v2/org/${orgExtid}/invitations`);
   const data = await response.json();
 
   const invitation = data.records?.find((inv: { email: string }) => inv.email === email);
@@ -557,7 +544,7 @@ test.describe('INV-010: Resend Invitation', () => {
     await createInvitation(page, testEmail);
 
     // Find the resend button for this invitation
-    const invitationRow = page.locator('.rounded-md').filter({ hasText: testEmail });
+    const invitationRow = page.getByTestId('org-invitation-row').filter({ hasText: testEmail });
     const resendButton = invitationRow.getByRole('button', { name: /resend/i });
 
     await expect(resendButton).toBeVisible();
@@ -588,7 +575,7 @@ test.describe('INV-011: Revoke Invitation', () => {
     expect(token).toBeTruthy();
 
     // Find and click revoke button
-    const invitationRow = page.locator('.rounded-md').filter({ hasText: testEmail });
+    const invitationRow = page.getByTestId('org-invitation-row').filter({ hasText: testEmail });
     const revokeButton = invitationRow.getByRole('button', { name: /revoke/i });
 
     await expect(revokeButton).toBeVisible();

--- a/src/apps/workspace/account/settings/OrganizationSettings.vue
+++ b/src/apps/workspace/account/settings/OrganizationSettings.vue
@@ -1319,6 +1319,7 @@ const handleTabKeydown = (e: KeyboardEvent) => {
                 <div
                   v-for="invitation in invitations"
                   :key="invitation.id"
+                  data-testid="org-invitation-row"
                   class="flex items-center justify-between rounded-md bg-gray-50 px-4 py-3 dark:bg-gray-700/50">
                   <div class="flex flex-col gap-1 sm:flex-row sm:items-center sm:gap-3">
                     <span class="text-sm font-medium text-gray-900 dark:text-white">{{ invitation.email }}</span>


### PR DESCRIPTION
## Summary

Improve E2E test reliability by replacing brittle CSS class selectors (`.rounded-md`) with semantic test IDs (`data-testid="org-invitation-row"`). This change makes tests more maintainable and less prone to breaking when styling changes occur.

## Changes

- Added `data-testid="org-invitation-row"` to the invitation row element in `OrganizationSettings.vue`
- Updated E2E tests to use `getByTestId('org-invitation-row')` instead of `locator('.rounded-md')`
- Simplified `getInvitationToken()` helper function by removing unnecessary DOM visibility checks that relied on CSS selectors
- Updated affected tests in both `org-invitation-flow.spec.ts` and `invite-flow-states.spec.ts`

## Related Issues

<!-- Add issue number if applicable -->

## Test Plan

Existing E2E tests cover these changes:
- `INV-010: Resend Invitation` - verifies resend button visibility and functionality
- `INV-011: Revoke Invitation` - verifies revoke button visibility and functionality
- `INV-010: Invalid Token State` - verifies token revocation flow

All affected test cases continue to pass with the new test ID selectors.

https://claude.ai/code/session_01Eyhd2U8y1oe6HyVkeSdGfm