### PR TITLE
Fix Playwright strict mode violations in e2e tests

### DIFF
--- a/e2e/full/domain-incoming-entitlement.spec.ts
+++ b/e2e/full/domain-incoming-entitlement.spec.ts
@@ -56,12 +56,18 @@ interface DomainInfo {
 /**
  * Authenticate user via login form.
  *
+ * The `full` project starts every test already authenticated as TEST_USER_*
+ * via storageState (e2e/playwright.config.ts), so the session must be dropped
+ * first — an authenticated visitor to /signin is redirected away by the auth
+ * route guard (src/router/guards.routes.ts) and never sees the form.
+ *
  * Handles both signin variants (canonical logic: e2e/global.setup.ts):
  * - default deployments render SignInForm directly (the CI container does);
  * - passwordless-first deployments hide the password panel behind a
  *   "Password" tab with different test ids.
  */
 async function loginUser(page: Page): Promise<void> {
+  await page.context().clearCookies();
   await page.goto('/signin');
 
   const signinEmail = process.env.TEST_USER_EMAIL || '';

--- a/e2e/full/org-invitation-flow.spec.ts
+++ b/e2e/full/org-invitation-flow.spec.ts
@@ -262,8 +262,10 @@ test.describe('INV-002: Unauthenticated User Inline Auth Flow', () => {
     await page.goto(`/invite/${token}`);
     await expect(page.locator('html[data-app-ready="true"]')).toBeAttached();
 
-    // Verify invitation details page loads
-    await expect(page.getByText(/invitation/i)).toBeVisible();
+    // Verify invitation details page loads. The page renders "invitation"
+    // in both the heading and supporting copy, so scope to the first match
+    // to avoid a strict-mode violation.
+    await expect(page.getByText(/invitation/i).first()).toBeVisible();
 
     // With Phase 7 inline forms, unauthenticated users see one of:
     // - signup_required state (new user, no account) with inline signup form
@@ -330,8 +332,10 @@ test.describe('INV-003: Email Mismatch Warning', () => {
       const mismatchWarning = wrongUserPage.getByTestId('email-mismatch-warning');
       await expect(mismatchWarning).toBeVisible();
 
-      // Verify warning shows factual "Different account" framing
-      await expect(wrongUserPage.getByText(/different|mismatch/i)).toBeVisible();
+      // Verify warning shows factual "Different account" framing. The
+      // copy + the "Continue as" button both match, so scope to the first
+      // to avoid a strict-mode violation.
+      await expect(wrongUserPage.getByText(/different|mismatch/i).first()).toBeVisible();
 
       // Verify invited email is shown (appears in both the warning body and
       // the "Continue as" button - first() avoids a strict mode violation)
@@ -498,8 +502,15 @@ test.describe('INV-007b: Unauthenticated Decline Flow', () => {
     await page.goto(`/invite/${token}`);
     await expect(page.locator('html[data-app-ready="true"]')).toBeAttached();
 
-    // Decline button should work without auth (use testid to avoid matching email containing "decline")
-    const declineButton = page.getByTestId('decline-invitation-btn');
+    // Decline button should work without auth. An unauthenticated invitee
+    // lands in the signup_required (or signin_required) state, where the
+    // decline control lives inside InviteSignUpForm / InviteSignInForm with
+    // the testid invite-signup-decline / invite-signin-decline — not the
+    // authenticated-state decline-invitation-btn.
+    const declineButton = page
+      .getByTestId('invite-signup-decline')
+      .or(page.getByTestId('invite-signin-decline'))
+      .first();
     await expect(declineButton).toBeVisible();
     await declineButton.click();
 
@@ -692,15 +703,17 @@ test.describe('INV-SEC-001: Open Redirect Prevention', () => {
     for (const maliciousUrl of maliciousRedirects) {
       await page.goto(`/signin?redirect=${encodeURIComponent(maliciousUrl)}`);
 
-      // Fill login form
-      const emailInput = page.getByLabel(/email/i);
-      const passwordInput = page.getByLabel(/password/i);
+      // Fill login form. Use the form's test ids — getByLabel(/password/i)
+      // also matches the show-password toggle and the "Forgot your password?"
+      // link, a strict-mode violation.
+      const emailInput = page.getByTestId('signin-email-input');
+      const passwordInput = page.getByTestId('signin-password-input');
 
       if (await emailInput.isVisible()) {
         await emailInput.fill(process.env.TEST_USER_EMAIL || '');
         await passwordInput.fill(process.env.TEST_USER_PASSWORD || '');
 
-        const submitButton = page.getByRole('button', { name: /sign in/i });
+        const submitButton = page.getByTestId('signin-submit');
         await submitButton.click();
 
         // Should NOT redirect to external URL

--- a/e2e/full/organization-members.spec.ts
+++ b/e2e/full/organization-members.spec.ts
@@ -349,12 +349,17 @@ test.describe('MBR-INVITE: Invite Member Flow', () => {
     // Pending invitation should appear in list
     await expect(page.getByText(testEmail)).toBeVisible({ timeout: 10000 });
 
-    // Pending badge should be visible
+    // Pending badge should be visible. Scope to this invitation's row
+    // (data-testid="org-invitation-row" in OrganizationSettings.vue) — a
+    // bare .rounded-md matches the list container too, so the badge filter
+    // would resolve to every pending invitation in the org (strict-mode
+    // violation once prior runs leave rows behind).
     const pendingBadge = page
-      .locator('.rounded-md')
+      .getByTestId('org-invitation-row')
       .filter({ hasText: testEmail })
       .locator('span')
-      .filter({ hasText: /pending/i });
+      .filter({ hasText: /pending/i })
+      .first();
     await expect(pendingBadge).toBeVisible();
   });
 


### PR DESCRIPTION
## Summary

Resolve Playwright strict mode violations across multiple e2e test files by scoping selectors to specific elements and using test IDs instead of generic locators that match multiple elements.

## Changes

### org-invitation-flow.spec.ts
- **Line 267**: Added `.first()` to invitation text selector to avoid matching multiple occurrences in heading and copy
- **Line 335**: Added `.first()` to "different/mismatch" text selector that matched both warning copy and button text
- **Lines 505-511**: Replaced generic `decline-invitation-btn` testid with context-aware selectors (`invite-signup-decline` or `invite-signin-decline`) that target the correct decline button in unauthenticated signup/signin forms
- **Lines 706-708**: Replaced generic label selectors with testids (`signin-email-input`, `signin-password-input`) to avoid matching password toggle and "Forgot password" link
- **Line 715**: Replaced role-based button selector with testid (`signin-submit`) for sign-in button

### organization-members.spec.ts
- **Lines 352-361**: Scoped pending badge selector to specific invitation row using `org-invitation-row` testid and added `.first()` to avoid matching all pending badges in the organization

### domain-incoming-entitlement.spec.ts
- **Lines 59-62**: Added documentation explaining why session must be cleared before signin form test
- **Line 70**: Added `await page.context().clearCookies()` to clear authenticated session before navigating to signin, allowing the form to render (authenticated users are redirected by route guard)

## Related Issues

N/A

## Test Plan

All changes are to e2e test selectors to comply with Playwright's strict mode. The existing e2e test suite validates these changes—tests will fail if selectors are incorrect or elements are not found. CI test runs confirm the fixes resolve strict mode violations.

https://claude.ai/code/session_018X4DkiwvtYsrbYz36k4CE6