### PR TITLE
[#I18N] Slash commands → orchestration-only; CLI owns concurrency; .resolved vendoring

### DIFF
--- a/.github/workflows/resolved-freshness.yml
+++ b/.github/workflows/resolved-freshness.yml
@@ -63,10 +63,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout app repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Checkout translation-rules (authority, read-only, pinned)
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: onetimesecret/translation-rules
           # Pinned to a SHA — not a moving branch — so the gate is reproducible.
@@ -78,7 +78,7 @@ jobs:
       - name: Install uv (pinned)
         # The resolver is uv-managed; `uv run` auto-syncs deps from the inline
         # script metadata / lockfile. Pin the installer action, bump deliberately.
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
         with:
           version: "0.5.18"
 

--- a/.github/workflows/resolved-freshness.yml
+++ b/.github/workflows/resolved-freshness.yml
@@ -1,0 +1,192 @@
+# Resolved-artifact freshness + hash gate (translation-rules SPEC.md §2.4).
+#
+# The vendored artifacts — locales/.resolved/<locale>.json (machine governance)
+# and locales/guides/for-translators/<locale>.md (human guide) — are COMMITTED to this
+# repo (SPEC §2.3 "Output commit policy"), not CI-generated-only. That commit
+# is exactly what this gate exists to police: it proves the committed artifacts
+# are (a) pinned to a known translation-rules commit and (b) byte-identical to
+# what that commit's resolver emits. Hand edits to a generated file — the
+# "bypass by direct edit" failure §2.4 is built to stop — are rejected here.
+#
+# SCOPE: resolver-managed locales ONLY. A locale is in scope iff this repo has a
+# vendored locales/.resolved/<locale>.json. We deliberately do NOT hash-gate the
+# whole locales/guides/for-translators/ tree: most guides there are
+# hand-authored prose (Phase 2 not yet migrated, SPEC §7) and would fail a
+# resolver-output comparison. The .resolved/<locale>.json file is the
+# "this locale is resolver-governed" signal — the same role register.yaml plays
+# upstream in validate-register.yml.
+#
+# PINNED_RULES_REF is bumped DELIBERATELY — same protocol as validate-register.yml's
+# `ref:` and yq pins — whenever translation-rules adds or changes a governed
+# locale and the vendored artifacts here are regenerated. It MUST equal the
+# translation-rules commit the committed artifacts were generated from (it is
+# asserted against each .resolved/<locale>.json's _meta.source_commit below);
+# bumping it without re-running locales/scripts/sync-resolved.sh against that
+# same commit will (correctly) fail the gate.
+
+name: resolved-freshness
+
+on:
+  pull_request:
+    paths:
+      - 'locales/.resolved/**'
+      - 'locales/guides/for-translators/**'
+      - 'locales/content/**'
+      # Re-run when the gate's own pin is bumped — otherwise a bad bump merges
+      # unvalidated and fails the next unrelated PR (same reasoning as
+      # validate-register.yml).
+      - '.github/workflows/resolved-freshness.yml'
+  push:
+    branches: [main, develop]
+    paths:
+      - 'locales/.resolved/**'
+      - 'locales/guides/for-translators/**'
+      - 'locales/content/**'
+      - '.github/workflows/resolved-freshness.yml'
+
+permissions:
+  contents: read
+
+env:
+  # translation-rules commit the vendored artifacts were generated from.
+  # Placeholder = validate-register.yml's current ref (translation-rules main as
+  # of 2026-06-11). BUMP DELIBERATELY, as a reviewable diff, to the commit
+  # locales/scripts/sync-resolved.sh was last run against — and regenerate the
+  # vendored artifacts in the same PR. This value is asserted to equal every
+  # .resolved/<locale>.json's _meta.source_commit.
+  PINNED_RULES_REF: 374f5c38639a4a4183e523614d212cc9d2e5ee21
+
+jobs:
+  resolved-freshness:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout app repo
+        uses: actions/checkout@v4
+
+      - name: Checkout translation-rules (authority, read-only, pinned)
+        uses: actions/checkout@v4
+        with:
+          repository: onetimesecret/translation-rules
+          # Pinned to a SHA — not a moving branch — so the gate is reproducible.
+          # Bump deliberately (see PINNED_RULES_REF comment above), same as the
+          # validate-register.yml ref/yq pins.
+          ref: ${{ env.PINNED_RULES_REF }}
+          path: .translation-rules
+
+      - name: Install uv (pinned)
+        # The resolver is uv-managed; `uv run` auto-syncs deps from the inline
+        # script metadata / lockfile. Pin the installer action, bump deliberately.
+        uses: astral-sh/setup-uv@v5
+        with:
+          version: "0.5.18"
+
+      - name: Install jq (for _meta.source_commit assertions)
+        run: |
+          set -euo pipefail
+          if ! command -v jq >/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y jq
+          fi
+          jq --version
+
+      - name: Freshness + hash gate (resolver-managed locales only)
+        env:
+          PINNED_RULES_REF: ${{ env.PINNED_RULES_REF }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+
+          rules=.translation-rules
+          app_locales="$(pwd)/locales"
+          resolved_dir="${app_locales}/.resolved"
+
+          # The pinned checkout must actually be at PINNED_RULES_REF, else every
+          # source_commit assertion below is meaningless.
+          actual_ref="$(git -C "$rules" rev-parse HEAD)"
+          if [ "$actual_ref" != "$PINNED_RULES_REF" ]; then
+            echo "::error::translation-rules checkout is at ${actual_ref}, expected PINNED_RULES_REF=${PINNED_RULES_REF}"
+            exit 1
+          fi
+
+          if [ ! -d "$resolved_dir" ]; then
+            echo "::notice::no locales/.resolved/ dir — nothing vendored yet; gate scanned nothing"
+            exit 0
+          fi
+
+          fail=0
+          checked=0
+
+          # SCOPE: iterate the VENDORED .resolved/<locale>.json files only. This
+          # is what restricts the gate to resolver-managed locales and keeps it
+          # off the hand-authored for-translators guides.
+          for resolved_json in "$resolved_dir"/*.json; do
+            locale="$(basename "$resolved_json" .json)"
+            echo "::group::freshness ${locale}"
+            checked=$((checked + 1))
+
+            # The committed locale must still be governed upstream at the pinned
+            # ref; otherwise we cannot regenerate it to compare.
+            if [ ! -f "${rules}/locales/${locale}/register.yaml" ]; then
+              echo "::error::${locale}: vendored .resolved present but locale is not governed (no register.yaml) at PINNED_RULES_REF — stale vendor or wrong pin"
+              fail=1
+              echo "::endgroup::"
+              continue
+            fi
+
+            # (a) source_commit pin equality.
+            src="$(jq -r '._meta.source_commit // empty' "$resolved_json")"
+            if [ -z "$src" ]; then
+              echo "::error::${locale}: .resolved/${locale}.json has no _meta.source_commit"
+              fail=1
+            elif [ "$src" != "$PINNED_RULES_REF" ]; then
+              echo "::error::${locale}: _meta.source_commit=${src} != PINNED_RULES_REF=${PINNED_RULES_REF} — vendored artifact is stale (re-run locales/scripts/sync-resolved.sh)"
+              fail=1
+            else
+              echo "${locale}: source_commit pin OK (${src})"
+            fi
+
+            # (b) byte-for-byte hash match: regenerate to a throwaway dir and
+            # diff against the committed artifacts. Any hand edit fails here.
+            tmp_emit="$(mktemp -d)"
+            index_tmp="$(mktemp)"
+            (
+              cd "$rules" && \
+              uv run resolver/resolve.py "$locale" \
+                --lint \
+                --emit=md,json \
+                --emit-dir "$tmp_emit" \
+                --source-commit "$PINNED_RULES_REF" \
+                --index-path "$index_tmp"
+            )
+            rm -f "$index_tmp"
+
+            # JSON artifact: committed locales/.resolved/<locale>.json
+            if ! diff -u "$resolved_json" "${tmp_emit}/.resolved/${locale}.json"; then
+              echo "::error::${locale}: committed .resolved/${locale}.json differs from resolver output at PINNED_RULES_REF — hand edit or stale vendor; re-run locales/scripts/sync-resolved.sh"
+              fail=1
+            fi
+
+            # Markdown artifact: committed at locales/guides/for-translators/<locale>.md
+            # (SPEC §2.3). The resolver emits <emit-dir>/guides/for-translators/<locale>.md
+            # and sync-resolved.sh passes --emit-dir <app>/locales, so the committed
+            # guide and the freshly regenerated one share that subpath.
+            committed_md="${app_locales}/guides/for-translators/${locale}.md"
+            if [ ! -f "$committed_md" ]; then
+              echo "::error::${locale}: vendored .resolved present but committed guide ${committed_md#"$(pwd)/"} is missing — re-run locales/scripts/sync-resolved.sh"
+              fail=1
+            elif ! diff -u "$committed_md" "${tmp_emit}/guides/for-translators/${locale}.md"; then
+              echo "::error::${locale}: committed guides/for-translators/${locale}.md differs from resolver output at PINNED_RULES_REF — hand edit or stale vendor; re-run locales/scripts/sync-resolved.sh"
+              fail=1
+            fi
+
+            rm -rf "$tmp_emit"
+            echo "::endgroup::"
+          done
+
+          if [ "$checked" -eq 0 ]; then
+            echo "::notice::no vendored .resolved/<locale>.json files — gate scanned nothing"
+            exit 0
+          fi
+
+          echo "resolved-freshness: checked ${checked} resolver-managed locale(s) against ${PINNED_RULES_REF}"
+          exit "$fail"

--- a/.github/workflows/resolved-freshness.yml
+++ b/.github/workflows/resolved-freshness.yml
@@ -32,6 +32,10 @@ on:
       - 'locales/.resolved/**'
       - 'locales/guides/for-translators/**'
       - 'locales/content/**'
+      # The vendoring script controls the resolver args, emit paths, and the
+      # source_commit/generated_at this gate later asserts — re-run when it
+      # changes so a vendoring-script change can't merge unchecked.
+      - 'locales/scripts/sync-resolved.sh'
       # Re-run when the gate's own pin is bumped — otherwise a bad bump merges
       # unvalidated and fails the next unrelated PR (same reasoning as
       # validate-register.yml).
@@ -42,6 +46,7 @@ on:
       - 'locales/.resolved/**'
       - 'locales/guides/for-translators/**'
       - 'locales/content/**'
+      - 'locales/scripts/sync-resolved.sh'
       - '.github/workflows/resolved-freshness.yml'
 
 permissions:

--- a/.github/workflows/resolved-freshness.yml
+++ b/.github/workflows/resolved-freshness.yml
@@ -114,9 +114,15 @@ jobs:
           # same value locales/scripts/sync-resolved.sh stamps at vendor time.
           # Without this the regenerated JSON below would carry a fresh wall-clock
           # timestamp and the byte-for-byte diff would fail on _meta.generated_at
-          # alone. Deriving it from the SHA keeps the artifact a pure function of
-          # the source commit.
-          gen_at="$(git -C "$rules" show -s --format=%cI "$PINNED_RULES_REF")"
+          # alone.
+          #
+          # Do NOT use %cI: it renders a UTC commit as "+00:00" on git <2.54 but
+          # "Z" on git >=2.54, so this runner and the vendor machine can disagree
+          # byte-for-byte on an identical instant. Force UTC + a literal +00:00
+          # offset via %cd/format-local so the value is a pure function of the
+          # commit across git versions, matching sync-resolved.sh EXACTLY.
+          gen_at="$(TZ=UTC git -C "$rules" show -s \
+            --date=format-local:'%Y-%m-%dT%H:%M:%S+00:00' --format=%cd "$PINNED_RULES_REF")"
 
           if [ ! -d "$resolved_dir" ]; then
             echo "::notice::no locales/.resolved/ dir — nothing vendored yet; gate scanned nothing"

--- a/.github/workflows/resolved-freshness.yml
+++ b/.github/workflows/resolved-freshness.yml
@@ -49,12 +49,14 @@ permissions:
 
 env:
   # translation-rules commit the vendored artifacts were generated from.
-  # Placeholder = validate-register.yml's current ref (translation-rules main as
-  # of 2026-06-11). BUMP DELIBERATELY, as a reviewable diff, to the commit
-  # locales/scripts/sync-resolved.sh was last run against — and regenerate the
-  # vendored artifacts in the same PR. This value is asserted to equal every
-  # .resolved/<locale>.json's _meta.source_commit.
-  PINNED_RULES_REF: 374f5c38639a4a4183e523614d212cc9d2e5ee21
+  # Currently pinned to the tip of translation-rules PR #29
+  # (claude/zen-fermi-7bhcnw) because that branch carries the SPEC §2.3 emit-path
+  # fix this gate's path comparison depends on. RE-PIN to the #29 merge commit on
+  # translation-rules main as the final step before this PR merges — and
+  # regenerate the vendored artifacts (locales/scripts/sync-resolved.sh) in the
+  # same diff. BUMP DELIBERATELY, as a reviewable diff. This value is asserted to
+  # equal every .resolved/<locale>.json's _meta.source_commit.
+  PINNED_RULES_REF: 18c2c91cce6e9ed5ca8520982bdd291740b56b84
 
 jobs:
   resolved-freshness:
@@ -108,6 +110,14 @@ jobs:
             exit 1
           fi
 
+          # Freeze _meta.generated_at to the pinned commit's committer date, the
+          # same value locales/scripts/sync-resolved.sh stamps at vendor time.
+          # Without this the regenerated JSON below would carry a fresh wall-clock
+          # timestamp and the byte-for-byte diff would fail on _meta.generated_at
+          # alone. Deriving it from the SHA keeps the artifact a pure function of
+          # the source commit.
+          gen_at="$(git -C "$rules" show -s --format=%cI "$PINNED_RULES_REF")"
+
           if [ ! -d "$resolved_dir" ]; then
             echo "::notice::no locales/.resolved/ dir — nothing vendored yet; gate scanned nothing"
             exit 0
@@ -156,6 +166,7 @@ jobs:
                 --emit=md,json \
                 --emit-dir "$tmp_emit" \
                 --source-commit "$PINNED_RULES_REF" \
+                --generated-at "$gen_at" \
                 --index-path "$index_tmp"
             )
             rm -f "$index_tmp"

--- a/locales/.resolved/de_AT.json
+++ b/locales/.resolved/de_AT.json
@@ -1,0 +1,250 @@
+{
+  "_meta": {
+    "generated_at": "2026-06-22T01:30:57+00:00",
+    "locale": "de_AT",
+    "schema_version": "1",
+    "source_commit": "18c2c91cce6e9ed5ca8520982bdd291740b56b84"
+  },
+  "anti_patterns_ref": [
+    {
+      "id": "anti.changelog-as-guidance",
+      "rule_ref": "rule.register-lock",
+      "severity": "error",
+      "statement": "Do not treat change-log or descriptive prose as prescriptive translation guidance."
+    },
+    {
+      "id": "anti.harmonize-text-rewrite",
+      "rule_ref": "rule.register-lock",
+      "severity": "error",
+      "statement": "Harmonize keys only — never rewrite translated text. A harmonize task that requires text changes is mislabeled; stop and escalate."
+    }
+  ],
+  "context": [
+    "Brand names stay in English across all locales; only surrounding grammar adapts.",
+    "[SHOULD] Prefer concise phrasing where meaning is preserved, and respect component character limits.",
+    "[SHOULD] Use active imperative voice for action labels and declarative voice for status and error messages."
+  ],
+  "declined_index": [],
+  "glossary": {
+    "secret_object": {
+      "en": "secret",
+      "examples": [
+        {
+          "id": "ex.secret-created#e4355c4f",
+          "rule_refs": [
+            "register.de_AT.formality"
+          ],
+          "senses": [
+            "noun"
+          ],
+          "source": "Your secret has been created.",
+          "target": "Ihr Geheimnis wurde erstellt.",
+          "verdict": "good"
+        },
+        {
+          "id": "ex.secret-genitive#cb21d6c1",
+          "note": "Genitive inflection; word_prefix match keeps the Geheimnis sense.",
+          "senses": [
+            "noun"
+          ],
+          "source": "The secret's link has expired.",
+          "target": "Der Link des Geheimnisses ist abgelaufen.",
+          "verdict": "good"
+        },
+        {
+          "id": "ex.secret-informal#40c23f2d",
+          "note": "Informal possessive 'Dein' — the forbidden register. Reproduces the 2026-04-12 flip.",
+          "senses": [
+            "noun"
+          ],
+          "source": "Your secret has been created.",
+          "target": "Dein Geheimnis wurde erstellt.",
+          "verdict": "bad"
+        }
+      ],
+      "senses": {
+        "noun": {
+          "rule_ref": "rule.terminology-consistency",
+          "target": "Geheimnis"
+        }
+      }
+    },
+    "secret_payload": {
+      "en": "secret message",
+      "examples": [
+        {
+          "id": "ex.message-enter#9a4a3f91",
+          "rule_refs": [
+            "register.de_AT.formality"
+          ],
+          "senses": [
+            "noun"
+          ],
+          "source": "Enter your secret message",
+          "target": "Geben Sie Ihre Nachricht ein",
+          "verdict": "good"
+        },
+        {
+          "id": "ex.message-informal#78142c00",
+          "note": "Informal imperative 'Gib' plus 'deine' — forbidden register.",
+          "senses": [
+            "noun"
+          ],
+          "source": "Enter your secret message",
+          "target": "Gib deine Nachricht ein",
+          "verdict": "bad"
+        }
+      ],
+      "senses": {
+        "noun": {
+          "rule_ref": "rule.terminology-consistency",
+          "target": "Nachricht"
+        }
+      }
+    }
+  },
+  "rationale_index": {
+    "rule.register-lock": [
+      "base/docs/register-lock.md"
+    ],
+    "rule.security-generic-messages": [
+      "base/docs/security-messages.md"
+    ],
+    "rule.terminology-consistency": [
+      "base/docs/terminology.md"
+    ]
+  },
+  "register": {
+    "exceptions": [],
+    "forbidden_tokens": [
+      {
+        "context": "standalone_word",
+        "severity": "error",
+        "token": "du"
+      },
+      {
+        "context": "standalone_word",
+        "severity": "error",
+        "token": "dein"
+      },
+      {
+        "context": "standalone_word",
+        "severity": "error",
+        "token": "deine"
+      },
+      {
+        "context": "standalone_word",
+        "severity": "error",
+        "token": "deinen"
+      },
+      {
+        "context": "standalone_word",
+        "severity": "error",
+        "token": "deinem"
+      },
+      {
+        "context": "standalone_word",
+        "severity": "error",
+        "token": "deiner"
+      },
+      {
+        "context": "standalone_word",
+        "severity": "error",
+        "token": "dich"
+      },
+      {
+        "context": "standalone_word",
+        "severity": "error",
+        "token": "dir"
+      },
+      {
+        "context": "standalone_word",
+        "severity": "error",
+        "token": "euch"
+      },
+      {
+        "context": "standalone_word",
+        "severity": "error",
+        "token": "euer"
+      }
+    ],
+    "form": "formal",
+    "possessive": [
+      "Ihr",
+      "Ihre",
+      "Ihren",
+      "Ihrem",
+      "Ihrer",
+      "Ihres"
+    ],
+    "pronoun": "Sie",
+    "rule_ref": "register.de_AT.formality"
+  },
+  "rules": [
+    {
+      "id": "rule.register-lock",
+      "modality": "MUST",
+      "severity": "error",
+      "statement": "Use the locale's locked register form (formality, pronoun, possessives) in all UI and email content."
+    },
+    {
+      "id": "rule.security-generic-messages",
+      "modality": "MUST",
+      "severity": "error",
+      "statement": "Keep web.auth.security.* messages generic — never reveal which credential failed, precise timing, attempt counts, or account existence."
+    },
+    {
+      "id": "rule.preserve-interpolation",
+      "modality": "MUST",
+      "severity": "error",
+      "statement": "Preserve interpolation placeholders ({var}, {0}, %{var}) exactly — identical names, count, and syntax as the source string."
+    },
+    {
+      "id": "rule.pluralization-syntax",
+      "modality": "MUST",
+      "severity": "error",
+      "statement": "Express countable strings with vue-i18n pipe syntax so the target language's plural forms are expressible."
+    },
+    {
+      "id": "rule.brand-names-untranslated",
+      "modality": "MUST_NOT",
+      "severity": "error",
+      "statement": "Do not translate or transliterate brand names (Onetime Secret, One-Time Secret, Identity Plus, Starlight); adapt only the surrounding grammar."
+    },
+    {
+      "id": "rule.meta-keys-untranslated",
+      "modality": "MUST_NOT",
+      "severity": "error",
+      "statement": "Do not translate underscore-prefixed metadata keys (_README, _meta, _translation_guidelines); they are documentation and never user-facing."
+    },
+    {
+      "id": "rule.terminology-consistency",
+      "modality": "MUST",
+      "severity": "error",
+      "statement": "Use the glossary's chosen term for each concept consistently; do not vary terminology across strings for the same sense."
+    },
+    {
+      "id": "rule.destructive-action-object",
+      "modality": "MUST",
+      "severity": "warning",
+      "statement": "Destructive or irreversible action labels name their object (Delete Account, not Delete)."
+    },
+    {
+      "id": "rule.de-sie",
+      "modality": "MUST",
+      "rule_ref": "rule.register-lock",
+      "severity": "error",
+      "statement": "German content uses the formal Sie form (Sie / Ihr / Ihre), not the informal du."
+    },
+    {
+      "id": "register.de_AT.formality",
+      "modality": "MUST",
+      "retro_refs": [
+        "2026-04-12-de_AT-register-flip"
+      ],
+      "rule_ref": "rule.de-sie",
+      "severity": "error",
+      "statement": "de_AT uses the formal Sie-form throughout product UI and email content; informal du/dein forms are forbidden."
+    }
+  ]
+}

--- a/locales/.resolved/fr_CA.json
+++ b/locales/.resolved/fr_CA.json
@@ -1,0 +1,422 @@
+{
+  "_meta": {
+    "generated_at": "2026-06-22T01:30:57+00:00",
+    "locale": "fr_CA",
+    "schema_version": "1",
+    "source_commit": "18c2c91cce6e9ed5ca8520982bdd291740b56b84"
+  },
+  "anti_patterns_ref": [
+    {
+      "id": "anti.changelog-as-guidance",
+      "rule_ref": "rule.register-lock",
+      "severity": "error",
+      "statement": "Do not treat change-log or descriptive prose as prescriptive translation guidance."
+    },
+    {
+      "id": "anti.harmonize-text-rewrite",
+      "rule_ref": "rule.register-lock",
+      "severity": "error",
+      "statement": "Harmonize keys only — never rewrite translated text. A harmonize task that requires text changes is mislabeled; stop and escalate."
+    }
+  ],
+  "context": [
+    "Brand names stay in English across all locales; only surrounding grammar adapts.",
+    "[SHOULD] Prefer concise phrasing where meaning is preserved, and respect component character limits.",
+    "[SHOULD] Use active imperative voice for action labels and declarative voice for status and error messages."
+  ],
+  "declined_index": [],
+  "glossary": {
+    "burn": {
+      "en": "burn",
+      "examples": [
+        {
+          "id": "ex.burn-good#4bf35a91",
+          "note": "Infinitive 'Brûler' for the button label, per rule.fr-infinitive-buttons.",
+          "rule_refs": [
+            "register.fr.formality",
+            "rule.fr-infinitive-buttons"
+          ],
+          "senses": [
+            "verb"
+          ],
+          "source": "Burn this secret before it is read.",
+          "target": "Brûler ce secret avant qu'il ne soit lu.",
+          "verdict": "good"
+        },
+        {
+          "id": "ex.burn-bad#4228df6b",
+          "note": "Uses 'Détruire' instead of the glossary term 'brûler' — terminology drift.",
+          "senses": [],
+          "source": "Burn this secret before it is read.",
+          "target": "Détruire ce secret avant qu'il ne soit lu.",
+          "verdict": "bad"
+        }
+      ],
+      "senses": {
+        "verb": {
+          "rule_ref": "rule.terminology-consistency",
+          "target": "brûler"
+        }
+      }
+    },
+    "email": {
+      "en": "email",
+      "examples": [
+        {
+          "id": "ex.email-ca-good#75bba47a",
+          "rule_refs": [
+            "register.fr.formality",
+            "rule.fr_CA-courriel"
+          ],
+          "senses": [
+            "noun"
+          ],
+          "source": "Enter your email address.",
+          "target": "Saisissez votre adresse courriel.",
+          "verdict": "good"
+        },
+        {
+          "id": "ex.email-ca-bad#b8f4c2e2",
+          "note": "Uses the European 'e-mail' instead of the Canadian 'courriel' — violates rule.fr_CA-courriel.",
+          "senses": [],
+          "source": "Enter your email address.",
+          "target": "Saisissez votre adresse e-mail.",
+          "verdict": "bad"
+        }
+      ],
+      "senses": {
+        "noun": {
+          "rule_ref": "rule.fr_CA-courriel",
+          "target": "courriel"
+        }
+      }
+    },
+    "encrypt": {
+      "en": "encrypt",
+      "examples": [
+        {
+          "id": "ex.encrypt-good#791f7805",
+          "rule_refs": [
+            "register.fr.formality"
+          ],
+          "senses": [
+            "state"
+          ],
+          "source": "This message is encrypted with your passphrase.",
+          "target": "Ce message est chiffré avec votre phrase secrète.",
+          "verdict": "good"
+        },
+        {
+          "id": "ex.encrypt-bad#450020c5",
+          "note": "Uses 'crypté' (deprecated/incorrect in security French) instead of 'chiffré', plus informal 'ta'.",
+          "senses": [],
+          "source": "This message is encrypted with your passphrase.",
+          "target": "Ce message est crypté avec ta phrase secrète.",
+          "verdict": "bad"
+        }
+      ],
+      "senses": {
+        "state": {
+          "rule_ref": "rule.terminology-consistency",
+          "target": "chiffré"
+        },
+        "verb": {
+          "rule_ref": "rule.terminology-consistency",
+          "target": "chiffrer"
+        }
+      }
+    },
+    "link": {
+      "en": "link",
+      "examples": [
+        {
+          "id": "ex.link-good#77be696f",
+          "rule_refs": [
+            "register.fr.formality"
+          ],
+          "senses": [
+            "noun"
+          ],
+          "source": "Copy the secret link to share it.",
+          "target": "Copiez le lien secret pour le partager.",
+          "verdict": "good"
+        },
+        {
+          "id": "ex.link-bad#748809c5",
+          "note": "Informal imperative 'Copie' plus 'ton' — forbidden tutoiement register.",
+          "senses": [
+            "noun"
+          ],
+          "source": "Copy the secret link to share it.",
+          "target": "Copie ton lien secret pour le partager.",
+          "verdict": "bad"
+        }
+      ],
+      "senses": {
+        "noun": {
+          "rule_ref": "rule.terminology-consistency",
+          "target": "lien"
+        }
+      }
+    },
+    "passphrase": {
+      "en": "passphrase",
+      "examples": [
+        {
+          "id": "ex.passphrase-good#c9b8d63f",
+          "rule_refs": [
+            "register.fr.formality"
+          ],
+          "senses": [
+            "noun"
+          ],
+          "source": "Enter the passphrase to view this secret.",
+          "target": "Saisissez la phrase secrète pour consulter ce secret.",
+          "verdict": "good"
+        },
+        {
+          "id": "ex.passphrase-bad#b2e929e0",
+          "note": "Uses 'mot de passe' (login credential) where 'phrase secrète' (secret protection) is meant — violates rule.fr-passphrase-password.",
+          "senses": [],
+          "source": "Enter the passphrase to view this secret.",
+          "target": "Saisissez le mot de passe pour consulter ce secret.",
+          "verdict": "bad"
+        }
+      ],
+      "senses": {
+        "noun": {
+          "rule_ref": "rule.fr-passphrase-password",
+          "target": "phrase secrète"
+        }
+      }
+    },
+    "password": {
+      "en": "password",
+      "examples": [
+        {
+          "id": "ex.password-good#ed4d76e5",
+          "rule_refs": [
+            "register.fr.formality"
+          ],
+          "senses": [
+            "noun"
+          ],
+          "source": "Enter your password to sign in.",
+          "target": "Saisissez votre mot de passe pour vous connecter.",
+          "verdict": "good"
+        },
+        {
+          "id": "ex.password-bad#83a8f72f",
+          "note": "Informal imperative 'Saisis' plus 'ton' and 'te' — forbidden tutoiement register.",
+          "senses": [
+            "noun"
+          ],
+          "source": "Enter your password to sign in.",
+          "target": "Saisis ton mot de passe pour te connecter.",
+          "verdict": "bad"
+        }
+      ],
+      "senses": {
+        "noun": {
+          "rule_ref": "rule.fr-passphrase-password",
+          "target": "mot de passe"
+        }
+      }
+    },
+    "secret_object": {
+      "en": "secret",
+      "examples": [
+        {
+          "id": "ex.secret-created-good#0492a4bc",
+          "rule_refs": [
+            "register.fr.formality"
+          ],
+          "senses": [
+            "noun"
+          ],
+          "source": "Your secret has been created.",
+          "target": "Votre secret a été créé.",
+          "verdict": "good"
+        },
+        {
+          "id": "ex.secret-informal-bad#250567fe",
+          "note": "Informal possessive 'Ton' — the forbidden tutoiement register.",
+          "senses": [
+            "noun"
+          ],
+          "source": "Your secret has been created.",
+          "target": "Ton secret a été créé.",
+          "verdict": "bad"
+        }
+      ],
+      "senses": {
+        "noun": {
+          "rule_ref": "rule.terminology-consistency",
+          "target": "secret"
+        }
+      }
+    }
+  },
+  "rationale_index": {
+    "rule.register-lock": [
+      "base/docs/register-lock.md"
+    ],
+    "rule.security-generic-messages": [
+      "base/docs/security-messages.md"
+    ],
+    "rule.terminology-consistency": [
+      "base/docs/terminology.md"
+    ]
+  },
+  "register": {
+    "exceptions": [],
+    "forbidden_tokens": [
+      {
+        "context": "standalone_word",
+        "note": "informal subject pronoun",
+        "severity": "error",
+        "token": "tu"
+      },
+      {
+        "context": "standalone_word",
+        "note": "informal possessive (masc.)",
+        "severity": "error",
+        "token": "ton"
+      },
+      {
+        "context": "standalone_word",
+        "note": "informal possessive (fem.)",
+        "severity": "error",
+        "token": "ta"
+      },
+      {
+        "context": "standalone_word",
+        "note": "informal possessive (plural)",
+        "severity": "error",
+        "token": "tes"
+      },
+      {
+        "context": "standalone_word",
+        "note": "informal stressed pronoun",
+        "severity": "error",
+        "token": "toi"
+      },
+      {
+        "context": "standalone_word",
+        "note": "informal object pronoun (non-contracted)",
+        "severity": "error",
+        "token": "te"
+      },
+      {
+        "context": "standalone_word",
+        "note": "informal reflexive",
+        "severity": "error",
+        "token": "toi-même"
+      },
+      {
+        "context": "word_prefix",
+        "note": "elided informal object/reflexive pronoun (t'envoie, t'inscrire)",
+        "severity": "error",
+        "token": "t'"
+      },
+      {
+        "context": "word_prefix",
+        "note": "elided informal pronoun, curly apostrophe (U+2019)",
+        "severity": "error",
+        "token": "t’"
+      }
+    ],
+    "form": "formal",
+    "possessive": [
+      "votre",
+      "vos"
+    ],
+    "pronoun": "vous",
+    "rule_ref": "register.fr.formality"
+  },
+  "rules": [
+    {
+      "id": "rule.register-lock",
+      "modality": "MUST",
+      "severity": "error",
+      "statement": "Use the locale's locked register form (formality, pronoun, possessives) in all UI and email content."
+    },
+    {
+      "id": "rule.security-generic-messages",
+      "modality": "MUST",
+      "severity": "error",
+      "statement": "Keep web.auth.security.* messages generic — never reveal which credential failed, precise timing, attempt counts, or account existence."
+    },
+    {
+      "id": "rule.preserve-interpolation",
+      "modality": "MUST",
+      "severity": "error",
+      "statement": "Preserve interpolation placeholders ({var}, {0}, %{var}) exactly — identical names, count, and syntax as the source string."
+    },
+    {
+      "id": "rule.pluralization-syntax",
+      "modality": "MUST",
+      "severity": "error",
+      "statement": "Express countable strings with vue-i18n pipe syntax so the target language's plural forms are expressible."
+    },
+    {
+      "id": "rule.brand-names-untranslated",
+      "modality": "MUST_NOT",
+      "severity": "error",
+      "statement": "Do not translate or transliterate brand names (Onetime Secret, One-Time Secret, Identity Plus, Starlight); adapt only the surrounding grammar."
+    },
+    {
+      "id": "rule.meta-keys-untranslated",
+      "modality": "MUST_NOT",
+      "severity": "error",
+      "statement": "Do not translate underscore-prefixed metadata keys (_README, _meta, _translation_guidelines); they are documentation and never user-facing."
+    },
+    {
+      "id": "rule.terminology-consistency",
+      "modality": "MUST",
+      "severity": "error",
+      "statement": "Use the glossary's chosen term for each concept consistently; do not vary terminology across strings for the same sense."
+    },
+    {
+      "id": "rule.destructive-action-object",
+      "modality": "MUST",
+      "severity": "warning",
+      "statement": "Destructive or irreversible action labels name their object (Delete Account, not Delete)."
+    },
+    {
+      "id": "register.fr.formality",
+      "modality": "MUST",
+      "rule_ref": "rule.register-lock",
+      "severity": "error",
+      "statement": "French content uses the formal vous register (vous / votre / vos) throughout product UI and email content; informal tutoiement (tu / ton / ta / tes) is forbidden."
+    },
+    {
+      "id": "rule.fr-punctuation-nbsp",
+      "modality": "MUST",
+      "rule_ref": "rule.register-lock",
+      "severity": "error",
+      "statement": "Place a non-breaking space before the double punctuation marks `:` `;` `!` `?`, per French typographic convention."
+    },
+    {
+      "id": "rule.fr-infinitive-buttons",
+      "modality": "MUST",
+      "rule_ref": "rule.message-voice",
+      "severity": "warning",
+      "statement": "Use the infinitive for button and link labels (Mettre à niveau), and the noun form for titles and headings (Mise à niveau)."
+    },
+    {
+      "id": "rule.fr-passphrase-password",
+      "modality": "MUST",
+      "rule_ref": "rule.terminology-consistency",
+      "severity": "error",
+      "statement": "Keep mot de passe (system authentication / login) distinct from phrase secrète (protection of a secret); never use one where the other is meant."
+    },
+    {
+      "id": "rule.fr_CA-courriel",
+      "modality": "MUST",
+      "rule_ref": "rule.terminology-consistency",
+      "severity": "error",
+      "statement": "Canadian French uses \"courriel\" for email throughout UI and email content; the European \"e-mail\" form is not used in fr_CA."
+    }
+  ]
+}

--- a/locales/AGENT_TRANSLATION_PROTOCOL.md
+++ b/locales/AGENT_TRANSLATION_PROTOCOL.md
@@ -1,0 +1,123 @@
+# Agent Translation Protocol
+
+> **Audience: a single automated background translator agent draining one
+> locale.** This is the machine-executable spec the orchestration slash commands
+> (`/d:translate-parallel-agents`, `/d:start-translation-session`,
+> `/d:translate-workflow`) point their `saas-translator` agents at. It is
+> self-contained and executable by reference: an agent given a locale and this
+> file has everything it needs to drain that locale's task queue.
+>
+> **Human-driven, conversational sessions follow a different file.** The manual
+> session — claim/accept/skip/quit, glossary decisions, the QC protocol, and
+> manual export/commit — lives in
+> [`TRANSLATION_PROTOCOL.md`](./TRANSLATION_PROTOCOL.md). Do not run those human
+> steps here.
+
+## Scope
+
+One agent, one locale, one job: translate every pending value and write it back
+to the task DB, then stop. The agent does **not** export, sync, commit, create
+branches, or record glossary decisions — those are human steps in
+`TRANSLATION_PROTOCOL.md`.
+
+Run everything from the repo root. The scripts need no environment setup (the
+project uses direnv via `.envrc`; there is no `source .env.sh`).
+
+## Precondition: resolved governance artifact required
+
+A locale is in the agent-drain set **only once** `locales/.resolved/<LOCALE>.json`
+exists with a populated `register` and a populated `glossary`. That file is the
+resolved governance artifact — the single source of per-locale guidance for
+automated drain. If it is missing or those fields are empty, the locale is **out
+of scope** for automated drain until the governance is back-ported upstream;
+skip it.
+
+Agents read guidance from `locales/.resolved/<LOCALE>.json` and **only** from
+there. Do **not** read `locales/guides/for-translators/*.md` — those are human
+guides, not the resolved artifact.
+
+`locales/.resolved/<LOCALE>.json` carries:
+
+- **`register`** — form/pronoun choice, formality, and `forbidden_tokens` the
+  locale must never emit.
+- **`glossary`** — agreed term senses with examples; the binding rendering for
+  recurring domain/brand terms.
+- **binding rules** — constraints that must hold for every translation.
+- **declined decisions** — choices that were considered and rejected; do not
+  reintroduce them.
+
+## Per-task cycle (one writer per locale, claim-free)
+
+Loop this until the queue is dry:
+
+1. **Get the next task** as JSON:
+   ```bash
+   python3 locales/scripts/i18n tasks next <LOCALE> --json
+   ```
+   Stop when there is no pending task. There is **one writer per locale**, so
+   `tasks next` (which returns only *pending* rows) advances with zero orphans —
+   do **not** use `--claim`.
+
+2. **Translate every value** in the task using the guidance from
+   `locales/.resolved/<LOCALE>.json`.
+
+3. **Write the result object** — a flat `{"key": "translation"}` map whose key
+   set is the **EXACT source key set** (none added, none dropped) — to a
+   per-locale temp file with the Write tool:
+   ```
+   /tmp/trans_<LOCALE>.json
+   ```
+   Per-locale paths keep concurrent agents from clobbering each other. Use a
+   file, not inline JSON: apostrophes and quotes (common in fr/es/it) break
+   shell single-quoting and HEREDOCs.
+
+4. **Save it back** with validation:
+   ```bash
+   python3 locales/scripts/i18n tasks update <ID> --file /tmp/trans_<LOCALE>.json --validate
+   ```
+
+5. **Read the output.** `--validate` is **advisory**: it warns on missing/extra
+   keys but still saves and still exits 0 — it does **not** block a bad write. On
+   any `Warning:` line (e.g. "Missing keys" / "Extra keys"), rebuild the object
+   with the exact source key set and re-run the update. A completed row's key set
+   must match the source exactly.
+
+6. **Loop** back to step 1. Continue until:
+   ```bash
+   python3 locales/scripts/i18n tasks next <LOCALE> --stats
+   ```
+   shows **0 pending**.
+
+## Translation rules
+
+- **Preserve every interpolation/markup token verbatim and in count.** Keep the
+  same set and the same number of: `{var}`, `{{var}}`, `%{var}`, `%s`, `<tag>`.
+  Never translate, reorder away the meaning of, add, or drop a token.
+- **Brand names stay English:** Onetime Secret, Identity Plus, Starlight.
+- **Honor the resolved artifact:** apply `register` (form/pronoun, formality),
+  use the bound `glossary` renderings, satisfy the binding rules, never emit a
+  `forbidden_token`, and never reintroduce a declined decision.
+
+## Audit stage (after a locale drains)
+
+Because `--validate` does not gate writes, the queue showing 0 pending does not
+prove the writes are clean. After a locale drains, audit its completed rows for:
+
+- **key-set match** — each completed row's keys equal the source keys exactly.
+- **token preservation** — every `{var}`, `{{var}}`, `%{var}`, `%s`, `<tag>`
+  from the source survives in the translation, with the same set and count.
+- **untranslated-English leakage** — values left in English where a translation
+  was expected.
+
+Fix any problem in place by rewriting `/tmp/trans_<LOCALE>.json` with the
+corrected object and re-running:
+```bash
+python3 locales/scripts/i18n tasks update <ID> --file /tmp/trans_<LOCALE>.json --validate
+```
+
+## Out of scope for agents
+
+Do **not** export (`tasks export`), do **not** sync (`pnpm run locales:sync` /
+`content compile`), and do **not** commit or create branches. Those are human
+steps documented in `TRANSLATION_PROTOCOL.md`. The agent's job ends when the
+locale shows 0 pending and the audit is clean.

--- a/locales/TRANSLATION_PROTOCOL.md
+++ b/locales/TRANSLATION_PROTOCOL.md
@@ -3,6 +3,16 @@
 Branch: `feature/2319-workflow-historical`
 Issue: #2319
 
+> **Audience: human-driven, conversational sessions.** This file describes the
+> manual translation session — start a conversation with the protocol, claim the
+> next task, propose translations, accept/skip/revisit/quit, record glossary
+> decisions, run QC, and export/commit by hand.
+>
+> **Automated background agents do NOT follow this file.** A single translator
+> agent draining one locale follows the machine-executable spec in
+> [`AGENT_TRANSLATION_PROTOCOL.md`](./AGENT_TRANSLATION_PROTOCOL.md). The
+> orchestration slash commands point their agents at that file.
+
 ## Philosophy
 
 **"Excel first"** - We deliberately keep this workflow manual and conversational. No automation until the process is proven. The scripts are helpers, not a pipeline. Once we know exactly what works, we can build tooling.
@@ -118,39 +128,6 @@ Run `/d:review-locale-branches` to orchestrate parallel code-reviewer agents gro
 1. Automated variable validation (catches mechanical issues)
 2. Agent review by family (linguistic/quality checks)
 3. Triage and fix critical findings before merge
-
-## Parallel / Agent-Driven Sessions
-
-When draining many locales at once (e.g. via `/d:translate-parallel-agents` or
-`/d:start-translation-session`), spawn one `saas-translator` agent per locale. Details
-that aren't obvious and cost a round-trip each to discover:
-
-- **No `.env.sh`.** The project uses direnv (`.envrc`); the legacy `source .env.sh` is
-  gone. The task scripts need no environment setup — run `python3 locales/scripts/i18n tasks ...`
-  directly from the repo root.
-- **One writer per locale; skip `--claim`.** With a single agent per locale there is no
-  race: `tasks next {LOCALE}` (returns the next *pending* task) → translate → `tasks update {ID}`
-  (marks it completed) advances with zero orphans. `--claim` only earns its keep when
-  several writers share one locale; if you use it, reset stranded `in_progress` rows at
-  session start (`tasks update {ID} --status pending`) — `tasks next` only ever returns *pending*
-  tasks, so an abandoned claim is invisible until reset.
-- **Write translations via a temp file, not inline JSON.** Apostrophes and quotes (common
-  in fr/es/it) break shell single-quoting and HEREDOCs. Write the `{"key": "translation"}`
-  object to a temp file and pass `--file`:
-  `tasks update {ID} --file /tmp/trans_{LOCALE}.json --validate`.
-- **`--validate` is advisory.** It warns on missing/extra keys but still saves and still
-  exits 0 — it does NOT block a bad write. Agents must read the `Warning:` lines and
-  re-submit with the exact source key set. A completed row's key set must match the source
-  exactly.
-- **SQLite concurrency: enable WAL, expect lock waits.** All locales write to one
-  `tasks.db`. Out of the box it is `journal_mode=delete`, `busy_timeout=0`. Set WAL once
-  before fanning out so readers never block the writer:
-  `sqlite3 locales/db/tasks.db "PRAGMA journal_mode=WAL"`. `tasks update` connects with a 30s
-  busy timeout; on `database is locked`, wait ~2s and retry (up to 3x).
-- **Verify after draining.** Because `--validate` does not gate writes, audit each locale's
-  completed rows for: key-set mismatch; interpolation/markup tokens (`{var}`, `{{var}}`,
-  `%{x}`, `%s`, `<tag>`) preserved in the translation; and untranslated-English leakage. Fix
-  in place with `tasks update --file`.
 
 ## Task Output Format
 

--- a/locales/guides/for-translators/de_AT.md
+++ b/locales/guides/for-translators/de_AT.md
@@ -1,0 +1,56 @@
+# GENERATED from translation-rules@18c2c91cce6e9ed5ca8520982bdd291740b56b84 — do not edit, do not cite as source
+
+Locale: `de_AT` · schema v1
+
+## Register
+
+- Form: **formal**
+- Pronoun: `Sie`
+- Possessive: `Ihr`, `Ihre`, `Ihren`, `Ihrem`, `Ihrer`, `Ihres`
+- Forbidden tokens:
+  - `du` (standalone_word, error)
+  - `dein` (standalone_word, error)
+  - `deine` (standalone_word, error)
+  - `deinen` (standalone_word, error)
+  - `deinem` (standalone_word, error)
+  - `deiner` (standalone_word, error)
+  - `dich` (standalone_word, error)
+  - `dir` (standalone_word, error)
+  - `euch` (standalone_word, error)
+  - `euer` (standalone_word, error)
+
+## Glossary
+
+### secret_object (en: secret)
+- _noun_: **Geheimnis**
+  - ✓ Your secret has been created. → Ihr Geheimnis wurde erstellt.
+  - ✓ The secret's link has expired. → Der Link des Geheimnisses ist abgelaufen.
+  - ✗ Your secret has been created. → Dein Geheimnis wurde erstellt.
+### secret_payload (en: secret message)
+- _noun_: **Nachricht**
+  - ✓ Enter your secret message → Geben Sie Ihre Nachricht ein
+  - ✗ Enter your secret message → Gib deine Nachricht ein
+
+## Rules (binding)
+
+- **MUST** (error): Use the locale's locked register form (formality, pronoun, possessives) in all UI and email content. `[rule.register-lock]`
+- **MUST** (error): Keep web.auth.security.* messages generic — never reveal which credential failed, precise timing, attempt counts, or account existence. `[rule.security-generic-messages]`
+- **MUST** (error): Preserve interpolation placeholders ({var}, {0}, %{var}) exactly — identical names, count, and syntax as the source string. `[rule.preserve-interpolation]`
+- **MUST** (error): Express countable strings with vue-i18n pipe syntax so the target language's plural forms are expressible. `[rule.pluralization-syntax]`
+- **MUST_NOT** (error): Do not translate or transliterate brand names (Onetime Secret, One-Time Secret, Identity Plus, Starlight); adapt only the surrounding grammar. `[rule.brand-names-untranslated]`
+- **MUST_NOT** (error): Do not translate underscore-prefixed metadata keys (_README, _meta, _translation_guidelines); they are documentation and never user-facing. `[rule.meta-keys-untranslated]`
+- **MUST** (error): Use the glossary's chosen term for each concept consistently; do not vary terminology across strings for the same sense. `[rule.terminology-consistency]`
+- **MUST** (warning): Destructive or irreversible action labels name their object (Delete Account, not Delete). `[rule.destructive-action-object]`
+- **MUST** (error): German content uses the formal Sie form (Sie / Ihr / Ihre), not the informal du. `[rule.de-sie]`
+- **MUST** (error): de_AT uses the formal Sie-form throughout product UI and email content; informal du/dein forms are forbidden. `[register.de_AT.formality]`
+
+## Context (non-binding)
+
+- Brand names stay in English across all locales; only surrounding grammar adapts.
+- [SHOULD] Prefer concise phrasing where meaning is preserved, and respect component character limits.
+- [SHOULD] Use active imperative voice for action labels and declarative voice for status and error messages.
+
+## Anti-patterns
+
+- Do not treat change-log or descriptive prose as prescriptive translation guidance. `[anti.changelog-as-guidance]`
+- Harmonize keys only — never rewrite translated text. A harmonize task that requires text changes is mislabeled; stop and escalate. `[anti.harmonize-text-rewrite]`

--- a/locales/guides/for-translators/fr_CA.md
+++ b/locales/guides/for-translators/fr_CA.md
@@ -1,135 +1,78 @@
-# Translation Guidance for French (Français)
+# GENERATED from translation-rules@18c2c91cce6e9ed5ca8520982bdd291740b56b84 — do not edit, do not cite as source
 
-This document combines the glossary and language-specific notes for French translations of Onetime Secret. It provides standardized translations for key terms and critical translation rules to ensure consistency across all French-language content.
+Locale: `fr_CA` · schema v1
 
-## Language-Specific Rules
+## Register
 
-These rules are critical for maintaining proper French conventions:
+- Form: **formal**
+- Pronoun: `vous`
+- Possessive: `votre`, `vos`
+- Forbidden tokens:
+  - `tu` (standalone_word, error) — informal subject pronoun
+  - `ton` (standalone_word, error) — informal possessive (masc.)
+  - `ta` (standalone_word, error) — informal possessive (fem.)
+  - `tes` (standalone_word, error) — informal possessive (plural)
+  - `toi` (standalone_word, error) — informal stressed pronoun
+  - `te` (standalone_word, error) — informal object pronoun (non-contracted)
+  - `toi-même` (standalone_word, error) — informal reflexive
+  - `t'` (word_prefix, error) — elided informal object/reflexive pronoun (t'envoie, t'inscrire)
+  - `t’` (word_prefix, error) — elided informal pronoun, curly apostrophe (U+2019)
 
-| Règle | Correct | Incorrect | Exemple |
-|-------|---------|-----------|---------|
-| Infinitif vs. Nom | Infinitif (boutons/liens), Nom (titres/headings) | Mixed forms | ✓ Mettre à niveau (button); ✗ Mise à niveau (button) |
-| Mot de passe vs. Phrase secrète | mot de passe (login), phrase secrète (secret) | Mixed usage | ✓ Entrez votre mot de passe (login); ✗ Entrez votre phrase secrète (login) |
-| Ponctuation française | Espace insécable avant `:` `;` `!` `?` | No space | ✓ Question : texte ?; ✗ Question: texte? |
+## Glossary
 
-## Translation Glossary
+### burn (en: burn)
+- _verb_: **brûler**
+  - ✓ Burn this secret before it is read. → Brûler ce secret avant qu'il ne soit lu.
+  - ✗ Burn this secret before it is read. → Détruire ce secret avant qu'il ne soit lu.
+### email (en: email)
+- _noun_: **courriel**
+  - ✓ Enter your email address. → Saisissez votre adresse courriel.
+  - ✗ Enter your email address. → Saisissez votre adresse e-mail.
+### encrypt (en: encrypt)
+- _state_: **chiffré**
+- _verb_: **chiffrer**
+  - ✓ This message is encrypted with your passphrase. → Ce message est chiffré avec votre phrase secrète.
+  - ✗ This message is encrypted with your passphrase. → Ce message est crypté avec ta phrase secrète.
+### link (en: link)
+- _noun_: **lien**
+  - ✓ Copy the secret link to share it. → Copiez le lien secret pour le partager.
+  - ✗ Copy the secret link to share it. → Copie ton lien secret pour le partager.
+### passphrase (en: passphrase)
+- _noun_: **phrase secrète**
+  - ✓ Enter the passphrase to view this secret. → Saisissez la phrase secrète pour consulter ce secret.
+  - ✗ Enter the passphrase to view this secret. → Saisissez le mot de passe pour consulter ce secret.
+### password (en: password)
+- _noun_: **mot de passe**
+  - ✓ Enter your password to sign in. → Saisissez votre mot de passe pour vous connecter.
+  - ✗ Enter your password to sign in. → Saisis ton mot de passe pour te connecter.
+### secret_object (en: secret)
+- _noun_: **secret**
+  - ✓ Your secret has been created. → Votre secret a été créé.
+  - ✗ Your secret has been created. → Ton secret a été créé.
 
-### Terminologie de base
+## Rules (binding)
 
-| anglais | français (CA) | Notes |
-|---------|-------------|-------|
-| secret (noun) | secret | Central concept of the application |
-| secret (adj) | secret/sécurisé | |
-| passphrase | phrase secrète | Authentication method for secrets |
-| burn | brûler | Action to delete a secret before viewing |
-| view/reveal | consulter/afficher | Action to access a secret |
-| link | lien | The URL that provides access to a secret |
-| encrypt/encrypted | chiffrer/chiffré | Security method |
-| secure | sécurisé | State of protection |
+- **MUST** (error): Use the locale's locked register form (formality, pronoun, possessives) in all UI and email content. `[rule.register-lock]`
+- **MUST** (error): Keep web.auth.security.* messages generic — never reveal which credential failed, precise timing, attempt counts, or account existence. `[rule.security-generic-messages]`
+- **MUST** (error): Preserve interpolation placeholders ({var}, {0}, %{var}) exactly — identical names, count, and syntax as the source string. `[rule.preserve-interpolation]`
+- **MUST** (error): Express countable strings with vue-i18n pipe syntax so the target language's plural forms are expressible. `[rule.pluralization-syntax]`
+- **MUST_NOT** (error): Do not translate or transliterate brand names (Onetime Secret, One-Time Secret, Identity Plus, Starlight); adapt only the surrounding grammar. `[rule.brand-names-untranslated]`
+- **MUST_NOT** (error): Do not translate underscore-prefixed metadata keys (_README, _meta, _translation_guidelines); they are documentation and never user-facing. `[rule.meta-keys-untranslated]`
+- **MUST** (error): Use the glossary's chosen term for each concept consistently; do not vary terminology across strings for the same sense. `[rule.terminology-consistency]`
+- **MUST** (warning): Destructive or irreversible action labels name their object (Delete Account, not Delete). `[rule.destructive-action-object]`
+- **MUST** (error): French content uses the formal vous register (vous / votre / vos) throughout product UI and email content; informal tutoiement (tu / ton / ta / tes) is forbidden. `[register.fr.formality]`
+- **MUST** (error): Place a non-breaking space before the double punctuation marks `:` `;` `!` `?`, per French typographic convention. `[rule.fr-punctuation-nbsp]`
+- **MUST** (warning): Use the infinitive for button and link labels (Mettre à niveau), and the noun form for titles and headings (Mise à niveau). `[rule.fr-infinitive-buttons]`
+- **MUST** (error): Keep mot de passe (system authentication / login) distinct from phrase secrète (protection of a secret); never use one where the other is meant. `[rule.fr-passphrase-password]`
+- **MUST** (error): Canadian French uses "courriel" for email throughout UI and email content; the European "e-mail" form is not used in fr_CA. `[rule.fr_CA-courriel]`
 
-### Éléments de l'interface utilisateur
+## Context (non-binding)
 
-| anglais | français (CA) | Notes |
-|---------|-------------|-------|
-| Share a secret | Partager un secret | Main action |
-| Create Account | Créer un compte | Registration |
-| Sign In | Se connecter | Authentication |
-| Dashboard | Compte | User's main page |
-| Settings | Paramètres | Configuration page |
-| Privacy Options | Options de confidentialité | Secret settings |
-| Feedback | Retour d'information | User comments |
+- Brand names stay in English across all locales; only surrounding grammar adapts.
+- [SHOULD] Prefer concise phrasing where meaning is preserved, and respect component character limits.
+- [SHOULD] Use active imperative voice for action labels and declarative voice for status and error messages.
 
-### Conditions d'état
+## Anti-patterns
 
-| anglais | français (CA) | Notes |
-|---------|-------------|-------|
-| received | reçu | Secret has been viewed |
-| burned | brûlé | Secret was deleted before viewing |
-| expired | expiré | Secret is no longer available due to time |
-| created | créé | Secret has been generated |
-| active | actif | Secret is available |
-| inactive | inactif | Secret is not available |
-
-### Termes liés au temps
-
-| anglais | français (CA) | Notes |
-|---------|-------------|-------|
-| expires in | expire dans | Time until secret is no longer available |
-| day/days | jour/jours | Time unit |
-| hour/hours | heure/heures | Time unit |
-| minute/minutes | minute/minutes | Time unit |
-| second/seconds | seconde/secondes | Time unit |
-
-### Caractéristiques de sécurité
-
-| anglais | français (CA) | Notes |
-|---------|-------------|-------|
-| one-time access | accès unique | Core security feature |
-| passphrase protection | protection par phrase secrète | Additional security |
-| encrypted in transit | chiffré en transit | Data protection method |
-| encrypted at rest | chiffré au repos | Storage protection |
-
-### Termes relatifs au compte
-
-| anglais | français (CA) | Notes |
-|---------|-------------|-------|
-| email | courriel | User identifier |
-| password | mot de passe | Authentication |
-| account | compte | User profile |
-| subscription | abonnement | Paid service |
-| customer | client | Paying user |
-
-### Termes liés au domaine
-
-| anglais | français (CA) | Notes |
-|---------|-------------|-------|
-| custom domain | domaine personnalisé | Premium feature |
-| domain verification | vérification du domaine | Setup process |
-| DNS record | enregistrement DNS | Configuration |
-| CNAME record | enregistrement CNAME | DNS setup |
-
-### Messages d'erreur
-
-| anglais | français (CA) | Notes |
-|---------|-------------|-------|
-| error | bug | Problem notification |
-| warning | attention | Caution notification |
-| oops | oups | Friendly error intro |
-
-### Boutons et actions
-
-| anglais | français (CA) | Notes |
-|---------|-------------|-------|
-| submit | soumettre | Form action |
-| cancel | annuler | Negative action |
-| confirm | confirmer | Positive action |
-| copy to clipboard | copier dans le presse-papiers | Utility action |
-| continue | continuer | Navigation |
-| back | retour | Navigation |
-
-### Conditions de commercialisation
-
-| anglais | français (CA) | Notes |
-|---------|-------------|-------|
-| secure links | liens sécurisés | Product feature |
-| privacy-first design | conception privilégiant la protection de la vie privée | Design philosophy |
-| custom branding | image de marque personnalisée | Premium feature |
-
-## Lignes directrices pour la traduction
-
-1. **Consistance** : Utiliser la même traduction pour un terme dans l'ensemble de l'application.
-2. **Contexte** : Tenir compte de la façon dont le terme est utilisé dans l'application.
-3. **Adaptation culturelle** : Adapter les termes aux conventions locales si nécessaire.
-4. **Exactitude technique** : Veiller à ce que les termes relatifs à la sécurité soient traduits avec précision.
-5. **Ton** : Maintenir un ton professionnel mais direct.
-6. **Clés littérales** : Les clés se terminant par `_literal` (ex : `onetime_secret_literal`) contiennent des noms de marque qui doivent rester en anglais tels quels.
-
-## Considérations particulières
-
-- Le terme "secret" est au cœur de la demande et doit être traduit de manière cohérente.
-- Les variations régionales (ex: "courriel" en français canadien vs "e-mail/courriel" en français européen) doivent être respectées.
-- Les termes techniques liés à la sécurité doivent être traduits de manière plus précise que la localisation.
-- Les éléments de l'interface utilisateur doivent respecter les conventions de la plate-forme pour la langue cible.
-- Pour les boutons et liens, utiliser l'infinitif (ex: "Mettre à niveau") plutôt que le nom (ex: "Mise à niveau").
-- Respecter la distinction entre "mot de passe" (pour l'authentification système) et "phrase secrète" (pour la protection des secrets).
-- Toujours inclure un espace insécable avant les signes de ponctuation doubles (`:` `;` `!` `?`).
+- Do not treat change-log or descriptive prose as prescriptive translation guidance. `[anti.changelog-as-guidance]`
+- Harmonize keys only — never rewrite translated text. A harmonize task that requires text changes is mislabeled; stop and escalate. `[anti.harmonize-text-rewrite]`

--- a/locales/scripts/i18n/db.py
+++ b/locales/scripts/i18n/db.py
@@ -53,13 +53,19 @@ def get_connection() -> Iterator[sqlite3.Connection]:
     conn.execute(f"PRAGMA busy_timeout={BUSY_TIMEOUT_SECONDS * 1000}")
     try:
         conn.execute("PRAGMA journal_mode=WAL")
-    except sqlite3.OperationalError:
-        # Switching journal mode is a write, which SQLite refuses on a
-        # read-only DB (a copied snapshot, or a checkout where the file is not
-        # writable). Read-only inspection commands (db query/export, tasks
-        # --stats) must still work, so degrade gracefully: reads run in the
-        # file's existing journal mode.
-        pass
+    except sqlite3.OperationalError as exc:
+        # Switching journal mode is a write, which SQLite refuses on a read-only
+        # DB (a copied snapshot, or a checkout where the file is not writable)
+        # with "attempt to write a readonly database". Read-only inspection
+        # commands (db query/export, tasks --stats) must still work, so degrade
+        # gracefully in THAT case only: reads run in the file's existing journal
+        # mode. Any other OperationalError — notably a lock timeout, which the
+        # busy_timeout set above is meant to absorb — is a real concurrency
+        # failure that WAL exists to prevent; re-raise it rather than silently
+        # leaving parallel agents in rollback-journal mode where they hit
+        # "database is locked".
+        if "readonly" not in str(exc).lower():
+            raise
     try:
         yield conn
     finally:

--- a/locales/scripts/i18n/db.py
+++ b/locales/scripts/i18n/db.py
@@ -43,11 +43,16 @@ def get_connection() -> Iterator[sqlite3.Connection]:
     """
     conn = sqlite3.connect(DB_FILE, timeout=BUSY_TIMEOUT_SECONDS)
     conn.row_factory = sqlite3.Row
-    # Set outside any transaction (connection is in autocommit here).
-    # journal_mode=WAL fails harmlessly (returns the existing mode) on a
-    # read-only or :memory: DB, so guard nothing — just apply.
-    conn.execute("PRAGMA journal_mode=WAL")
+    # Set outside any transaction (connection is in autocommit here). Order
+    # matters: install busy_timeout BEFORE the journal_mode=WAL switch, since
+    # switching to WAL itself takes a write lock — with the timeout armed it
+    # waits for a concurrent writer instead of raising "database is locked"
+    # during connection setup. (The connect timeout above already arms a busy
+    # handler, so this is belt-and-suspenders, but it keeps intent explicit and
+    # survives any change to that default.) journal_mode=WAL returns the
+    # existing mode harmlessly on a read-only or :memory: DB.
     conn.execute(f"PRAGMA busy_timeout={BUSY_TIMEOUT_SECONDS * 1000}")
+    conn.execute("PRAGMA journal_mode=WAL")
     try:
         yield conn
     finally:

--- a/locales/scripts/i18n/db.py
+++ b/locales/scripts/i18n/db.py
@@ -6,8 +6,18 @@ Ported from the legacy ``locales/scripts/store.py`` (connection + schema
 pieces only). Query/export/import logic lives with the ``db`` command group,
 not here. Path constants come from :mod:`i18n.config`.
 
-The connection uses ``timeout=30`` to tolerate write-lock contention when
-several locale agents run in parallel against the one DB file.
+Concurrency is the tool's job, not the caller's. ``tasks.db`` is a single
+file shared by every parallel locale agent, so :func:`get_connection` sets
+two pragmas on every connect:
+
+- ``journal_mode=WAL`` — readers never block the writer and vice versa, which
+  is what makes one-writer-per-locale fan-out safe. WAL is persisted on the
+  file, but we set it each connect so a freshly created or copied DB is always
+  in WAL without an out-of-band step.
+- ``busy_timeout`` (= the connect ``timeout``, in ms) — on lock contention
+  SQLite blocks and retries internally for this long instead of raising
+  ``database is locked`` immediately. Callers and agents therefore do not need
+  their own "wait and retry on locked" loop.
 """
 
 from __future__ import annotations
@@ -18,15 +28,26 @@ from typing import Iterator
 
 from .config import DB_DIR, DB_FILE, SCHEMA_FILE
 
+# How long (seconds) a connection waits on a held lock before giving up.
+# Drives both the sqlite3 connect timeout and the busy_timeout pragma.
+BUSY_TIMEOUT_SECONDS = 30
+
 
 @contextmanager
 def get_connection() -> Iterator[sqlite3.Connection]:
     """Context manager for database connections.
 
+    Enables WAL and a busy timeout on every connection so concurrent locale
+    agents tolerate lock contention without caller-side retry logic.
     Abstracts connection handling for future migration to libsql.
     """
-    conn = sqlite3.connect(DB_FILE, timeout=30)
+    conn = sqlite3.connect(DB_FILE, timeout=BUSY_TIMEOUT_SECONDS)
     conn.row_factory = sqlite3.Row
+    # Set outside any transaction (connection is in autocommit here).
+    # journal_mode=WAL fails harmlessly (returns the existing mode) on a
+    # read-only or :memory: DB, so guard nothing — just apply.
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute(f"PRAGMA busy_timeout={BUSY_TIMEOUT_SECONDS * 1000}")
     try:
         yield conn
     finally:

--- a/locales/scripts/i18n/db.py
+++ b/locales/scripts/i18n/db.py
@@ -43,30 +43,35 @@ def get_connection() -> Iterator[sqlite3.Connection]:
     """
     conn = sqlite3.connect(DB_FILE, timeout=BUSY_TIMEOUT_SECONDS)
     conn.row_factory = sqlite3.Row
-    # Set outside any transaction (connection is in autocommit here). Order
-    # matters: install busy_timeout BEFORE the journal_mode=WAL switch, since
-    # switching to WAL itself takes a write lock — with the timeout armed it
-    # waits for a concurrent writer instead of raising "database is locked"
-    # during connection setup. (The connect timeout above already arms a busy
-    # handler, so this is belt-and-suspenders, but it keeps intent explicit and
-    # survives any change to that default.)
-    conn.execute(f"PRAGMA busy_timeout={BUSY_TIMEOUT_SECONDS * 1000}")
+    # Pragma setup and the yield share one try/finally so the connection is
+    # ALWAYS closed — including when a setup pragma re-raises (e.g. a lock
+    # timeout on the WAL switch below). Closing only after a successful setup
+    # would leak the handle/lock in exactly the contended batch that triggered
+    # the failure.
     try:
-        conn.execute("PRAGMA journal_mode=WAL")
-    except sqlite3.OperationalError as exc:
-        # Switching journal mode is a write, which SQLite refuses on a read-only
-        # DB (a copied snapshot, or a checkout where the file is not writable)
-        # with "attempt to write a readonly database". Read-only inspection
-        # commands (db query/export, tasks --stats) must still work, so degrade
-        # gracefully in THAT case only: reads run in the file's existing journal
-        # mode. Any other OperationalError — notably a lock timeout, which the
-        # busy_timeout set above is meant to absorb — is a real concurrency
-        # failure that WAL exists to prevent; re-raise it rather than silently
-        # leaving parallel agents in rollback-journal mode where they hit
-        # "database is locked".
-        if "readonly" not in str(exc).lower():
-            raise
-    try:
+        # Set outside any transaction (connection is in autocommit here). Order
+        # matters: install busy_timeout BEFORE the journal_mode=WAL switch, since
+        # switching to WAL itself takes a write lock — with the timeout armed it
+        # waits for a concurrent writer instead of raising "database is locked"
+        # during connection setup. (The connect timeout above already arms a busy
+        # handler, so this is belt-and-suspenders, but it keeps intent explicit
+        # and survives any change to that default.)
+        conn.execute(f"PRAGMA busy_timeout={BUSY_TIMEOUT_SECONDS * 1000}")
+        try:
+            conn.execute("PRAGMA journal_mode=WAL")
+        except sqlite3.OperationalError as exc:
+            # Switching journal mode is a write, which SQLite refuses on a
+            # read-only DB (a copied snapshot, or a checkout where the file is
+            # not writable) with "attempt to write a readonly database".
+            # Read-only inspection commands (db query/export, tasks --stats)
+            # must still work, so degrade gracefully in THAT case only: reads run
+            # in the file's existing journal mode. Any other OperationalError —
+            # notably a lock timeout, which the busy_timeout set above is meant
+            # to absorb — is a real concurrency failure that WAL exists to
+            # prevent; re-raise it rather than silently leaving parallel agents
+            # in rollback-journal mode where they hit "database is locked".
+            if "readonly" not in str(exc).lower():
+                raise
         yield conn
     finally:
         conn.close()

--- a/locales/scripts/i18n/db.py
+++ b/locales/scripts/i18n/db.py
@@ -49,10 +49,17 @@ def get_connection() -> Iterator[sqlite3.Connection]:
     # waits for a concurrent writer instead of raising "database is locked"
     # during connection setup. (The connect timeout above already arms a busy
     # handler, so this is belt-and-suspenders, but it keeps intent explicit and
-    # survives any change to that default.) journal_mode=WAL returns the
-    # existing mode harmlessly on a read-only or :memory: DB.
+    # survives any change to that default.)
     conn.execute(f"PRAGMA busy_timeout={BUSY_TIMEOUT_SECONDS * 1000}")
-    conn.execute("PRAGMA journal_mode=WAL")
+    try:
+        conn.execute("PRAGMA journal_mode=WAL")
+    except sqlite3.OperationalError:
+        # Switching journal mode is a write, which SQLite refuses on a
+        # read-only DB (a copied snapshot, or a checkout where the file is not
+        # writable). Read-only inspection commands (db query/export, tasks
+        # --stats) must still work, so degrade gracefully: reads run in the
+        # file's existing journal mode.
+        pass
     try:
         yield conn
     finally:

--- a/locales/scripts/review-locale-branches.sh
+++ b/locales/scripts/review-locale-branches.sh
@@ -65,6 +65,11 @@ cmd_validate() {
   local results_dir="${1:-/tmp}"
   mkdir -p "$results_dir"
 
+  # `validate` parses each report with jq; if jq is missing every parse fails and
+  # the loop prints ERROR for every locale yet still exits 0 — a clean-looking but
+  # empty report. Fail closed instead of failing open.
+  command -v jq >/dev/null 2>&1 || die "jq not found on PATH; the validate stage needs it to parse mismatch counts"
+
   # Enumerate i18n/update-* refs, local AND remote (a fresh checkout commonly
   # has them only as origin/i18n/update-*). Keep each ref's full name so we can
   # validate that branch's CONTENT — not whatever happens to be checked out —

--- a/locales/scripts/review-locale-branches.sh
+++ b/locales/scripts/review-locale-branches.sh
@@ -78,8 +78,15 @@ cmd_validate() {
   done < <(git for-each-ref --format='%(refname:short)' \
              'refs/heads/i18n/update-*' 'refs/remotes/origin/i18n/update-*')
 
+  # Iterate locales in a stable, sorted order. Associative-array key order is
+  # hash-order (not deterministic across runs), but the slash command documents
+  # Stage 1 output as deterministic so saved reports diff cleanly run-to-run.
   local out rc count wtbase wt
-  for locale in "${!ref_for[@]}"; do
+  local -a sorted_locales=()
+  if [ "${#ref_for[@]}" -gt 0 ]; then
+    mapfile -t sorted_locales < <(printf '%s\n' "${!ref_for[@]}" | sort)
+  fi
+  for locale in "${sorted_locales[@]}"; do
     ref="${ref_for[$locale]}"
     out="${results_dir}/i18n-validate-${locale}.json"
 

--- a/locales/scripts/review-locale-branches.sh
+++ b/locales/scripts/review-locale-branches.sh
@@ -65,12 +65,23 @@ cmd_validate() {
   local results_dir="${1:-/tmp}"
   mkdir -p "$results_dir"
 
-  for branch in $(git branch --list 'i18n/update-*' | tr -d ' ' | sed 's/\x1b\[[0-9;]*m//g'); do
-    local locale="${branch#i18n/update-}"
-    local out="${results_dir}/i18n-validate-${locale}.json"
-    python3 locales/scripts/i18n validate variables --json --locale "$locale" > "$out"
-    local count
-    count=$(jq '.summary | to_entries | map(.value) | add // 0' "$out")
+  # Enumerate i18n/update-* branches both local and remote: a fresh CI checkout
+  # commonly has them only as origin/i18n/update-*. Strip the remote prefix and
+  # de-duplicate so each locale is validated exactly once.
+  local branches
+  branches=$(git for-each-ref --format='%(refname:short)' \
+    'refs/heads/i18n/update-*' 'refs/remotes/origin/i18n/update-*' \
+    | sed 's#^origin/##' | sort -u)
+
+  local branch locale out count
+  for branch in $branches; do
+    locale="${branch#i18n/update-}"
+    out="${results_dir}/i18n-validate-${locale}.json"
+    # `validate variables` exits non-zero when it finds mismatches; under
+    # `set -e` that would abort the whole report on the first bad locale, so
+    # swallow the status (the JSON is still written to stdout) and keep going.
+    python3 locales/scripts/i18n validate variables --json --locale "$locale" > "$out" 2>/dev/null || true
+    count=$(jq '.summary | to_entries | map(.value) | add // 0' "$out" 2>/dev/null || echo 0)
     if [ "$count" -gt 0 ]; then
       echo "$locale: $count variable mismatches — $out"
     fi

--- a/locales/scripts/review-locale-branches.sh
+++ b/locales/scripts/review-locale-branches.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+#
+# Deterministic mechanics for the review-locale-branches workflow.
+#
+# This script is the single source of truth for the family->locales mapping
+# and the non-agent (deterministic) stages of the locale-branch review:
+#   - Stage 1 variable validation  (subcommand: validate)
+#   - Stage 3 group consolidation   (subcommand: consolidate)
+# The agent orchestration and triage stages live in the slash command
+# (locales/slash_commands/review-locale-branches.md), which calls this script.
+#
+# Usage:
+#   locales/scripts/review-locale-branches.sh validate [RESULTS_DIR]
+#   locales/scripts/review-locale-branches.sh consolidate REVIEW_DIR
+#   locales/scripts/review-locale-branches.sh init REVIEW_DIR
+#   locales/scripts/review-locale-branches.sh families
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Family -> locales mapping (authoritative; used by consolidate and families)
+# ---------------------------------------------------------------------------
+# Ordered list of family group names, and a lookup from group -> space-
+# separated locale list. Keep these in sync with the table in the slash
+# command (review-locale-branches.md).
+
+FAMILY_GROUPS=(semitic-rtl slavic germanic romance cjk other)
+
+declare -A FAMILY_LOCALES=(
+  [semitic-rtl]="ar he"
+  [slavic]="bg cs pl ru sl_SI uk"
+  [germanic]="de de_AT nl sv_SE"
+  [romance]="ca_ES es fr_CA fr_FR it_IT pt_BR pt_PT"
+  [cjk]="ja ko zh"
+  [other]="da_DK el_GR eo hu mi_NZ tr vi"
+)
+
+die() { echo "error: $1" >&2; exit 1; }
+
+# ---------------------------------------------------------------------------
+# families: print the family->locales mapping, one group per line.
+# ---------------------------------------------------------------------------
+cmd_families() {
+  for group in "${FAMILY_GROUPS[@]}"; do
+    printf '%s: %s\n' "$group" "${FAMILY_LOCALES[$group]}"
+  done
+}
+
+# ---------------------------------------------------------------------------
+# init REVIEW_DIR: create the review output directory.
+# ---------------------------------------------------------------------------
+cmd_init() {
+  local review_dir="${1:-}"
+  [[ -n "$review_dir" ]] || die "init requires REVIEW_DIR"
+  mkdir -p "$review_dir"
+}
+
+# ---------------------------------------------------------------------------
+# validate [RESULTS_DIR]: Stage 1.
+# For each i18n/update-* branch, run variable validation with --json, write
+# the JSON to RESULTS_DIR, and print one line per locale whose total mismatch
+# count is > 0. Always exits 0 (this is a report, not a gate).
+# ---------------------------------------------------------------------------
+cmd_validate() {
+  local results_dir="${1:-/tmp}"
+  mkdir -p "$results_dir"
+
+  for branch in $(git branch --list 'i18n/update-*' | tr -d ' ' | sed 's/\x1b\[[0-9;]*m//g'); do
+    local locale="${branch#i18n/update-}"
+    local out="${results_dir}/i18n-validate-${locale}.json"
+    python3 locales/scripts/i18n validate variables --json --locale "$locale" > "$out"
+    local count
+    count=$(jq '.summary | to_entries | map(.value) | add // 0' "$out")
+    if [ "$count" -gt 0 ]; then
+      echo "$locale: $count variable mismatches — $out"
+    fi
+  done
+
+  return 0
+}
+
+# ---------------------------------------------------------------------------
+# consolidate REVIEW_DIR: Stage 3.
+# For each family group, write ${REVIEW_DIR}/${group}.md by concatenating the
+# per-locale ${REVIEW_DIR}/${loc}.md files that exist.
+# ---------------------------------------------------------------------------
+cmd_consolidate() {
+  local review_dir="${1:-}"
+  [[ -n "$review_dir" ]] || die "consolidate requires REVIEW_DIR"
+
+  local review_date
+  review_date=$(basename "$review_dir")
+
+  for group in "${FAMILY_GROUPS[@]}"; do
+    local locales="${FAMILY_LOCALES[$group]}"
+    local group_file="${review_dir}/${group}.md"
+
+    echo "# ${group} Group Review - ${review_date}" > "$group_file"
+    echo "" >> "$group_file"
+    echo "Locales: ${locales}" >> "$group_file"
+    echo "" >> "$group_file"
+
+    for loc in $locales; do
+      if [ -f "${review_dir}/${loc}.md" ]; then
+        echo "---" >> "$group_file"
+        cat "${review_dir}/${loc}.md" >> "$group_file"
+        echo "" >> "$group_file"
+      fi
+    done
+  done
+}
+
+# ---------------------------------------------------------------------------
+# Dispatch
+# ---------------------------------------------------------------------------
+main() {
+  local cmd="${1:-}"
+  [[ -n "$cmd" ]] || die "usage: $(basename "$0") {validate|consolidate|init|families} [args]"
+  shift
+
+  case "$cmd" in
+    validate)    cmd_validate "$@" ;;
+    consolidate) cmd_consolidate "$@" ;;
+    init)        cmd_init "$@" ;;
+    families)    cmd_families "$@" ;;
+    *)           die "unknown subcommand: $cmd" ;;
+  esac
+}
+
+main "$@"

--- a/locales/scripts/review-locale-branches.sh
+++ b/locales/scripts/review-locale-branches.sh
@@ -65,23 +65,49 @@ cmd_validate() {
   local results_dir="${1:-/tmp}"
   mkdir -p "$results_dir"
 
-  # Enumerate i18n/update-* branches both local and remote: a fresh CI checkout
-  # commonly has them only as origin/i18n/update-*. Strip the remote prefix and
-  # de-duplicate so each locale is validated exactly once.
-  local branches
-  branches=$(git for-each-ref --format='%(refname:short)' \
-    'refs/heads/i18n/update-*' 'refs/remotes/origin/i18n/update-*' \
-    | sed 's#^origin/##' | sort -u)
+  # Enumerate i18n/update-* refs, local AND remote (a fresh checkout commonly
+  # has them only as origin/i18n/update-*). Keep each ref's full name so we can
+  # validate that branch's CONTENT — not whatever happens to be checked out —
+  # and dedup by locale, preferring a local branch over its remote ref.
+  local ref locale
+  declare -A ref_for=()
+  while IFS= read -r ref; do
+    [[ -n "$ref" ]] || continue
+    locale="${ref##*i18n/update-}"
+    [[ -n "${ref_for[$locale]:-}" ]] || ref_for["$locale"]="$ref"
+  done < <(git for-each-ref --format='%(refname:short)' \
+             'refs/heads/i18n/update-*' 'refs/remotes/origin/i18n/update-*')
 
-  local branch locale out count
-  for branch in $branches; do
-    locale="${branch#i18n/update-}"
+  local out rc count wtbase wt
+  for locale in "${!ref_for[@]}"; do
+    ref="${ref_for[$locale]}"
     out="${results_dir}/i18n-validate-${locale}.json"
-    # `validate variables` exits non-zero when it finds mismatches; under
-    # `set -e` that would abort the whole report on the first bad locale, so
-    # swallow the status (the JSON is still written to stdout) and keep going.
-    python3 locales/scripts/i18n validate variables --json --locale "$locale" > "$out" 2>/dev/null || true
-    count=$(jq '.summary | to_entries | map(.value) | add // 0' "$out" 2>/dev/null || echo 0)
+
+    # Materialize the branch in a throwaway detached worktree and validate its
+    # content there, so the report reflects the review branch rather than the
+    # current working tree. --detach avoids "branch already checked out".
+    wtbase="$(mktemp -d)"
+    wt="${wtbase}/wt"
+    if ! git worktree add --quiet --detach "$wt" "$ref" >/dev/null 2>&1; then
+      echo "$locale: ERROR — could not materialize $ref for validation" >&2
+      rm -rf "$wtbase"
+      continue
+    fi
+    rc=0
+    ( cd "$wt" && python3 locales/scripts/i18n validate variables --json --locale "$locale" ) \
+      >"$out" 2>/dev/null || rc=$?
+    git worktree remove --force "$wt" >/dev/null 2>&1 || true
+    rm -rf "$wtbase"
+
+    # Distinguish three outcomes by parsing the report, not by the exit code
+    # alone: a genuine failure (no parseable JSON — missing locale, crash, old
+    # CLI) must surface as an ERROR, not read as clean; "mismatches found"
+    # (valid JSON, rc!=0) reports the count; a clean run prints nothing.
+    count="$(jq '.summary | to_entries | map(.value) | add // 0' "$out" 2>/dev/null || true)"
+    if ! [[ "$count" =~ ^[0-9]+$ ]]; then
+      echo "$locale: ERROR — validation produced no parseable report (exit ${rc}); see $out" >&2
+      continue
+    fi
     if [ "$count" -gt 0 ]; then
       echo "$locale: $count variable mismatches — $out"
     fi

--- a/locales/scripts/sync-resolved.sh
+++ b/locales/scripts/sync-resolved.sh
@@ -16,15 +16,35 @@
 # lives at locales/guides/for-translators/<locale>.md with a base-only stub.
 #
 # Usage:
-#   locales/scripts/sync-resolved.sh [RULES_DIR]
+#   locales/scripts/sync-resolved.sh [RULES_DIR]              # refresh vendored set
+#   LOCALES="de_AT fr_CA" locales/scripts/sync-resolved.sh    # vendor a specific set
 #
 #   RULES_DIR  Path to a translation-rules checkout. Arg 1 overrides the
 #              ${RULES_DIR} env var, which defaults to ".translation-rules"
 #              (the read-only pinned checkout path used by the CI workflows).
+#   LOCALES    Optional space-separated allow-list. When set, vendor exactly these
+#              locales (still subject to the governed guard); a requested locale
+#              that is ungoverned or absent upstream is a hard error.
 #
-# Idempotent: re-running against the same checkout reproduces byte-identical
-# artifacts (the resolver pins _meta.source_commit to the SHA; pass
-# --generated-at upstream if you also need a frozen timestamp). Safe to re-run.
+#              When UNSET, the default set is the locales ALREADY vendored in this
+#              repo — i.e. the basenames of locales/.resolved/*.json. This is the
+#              same set the §2.4 freshness gate audits, so a bare re-run refreshes
+#              exactly what is committed and NOTHING ELSE. Critically, it will NOT
+#              vendor an upstream-governed locale that is not yet part of the
+#              committed set (e.g. fr/fr_CA pending native-speaker sign-off):
+#              doing so would byte-lock unreviewed governance and clobber the
+#              hand-authored locales/guides/for-translators/<locale>.md. Adding a
+#              locale is therefore a deliberate `LOCALES=<new>` run, after which it
+#              joins the committed set and subsequent bare runs keep it fresh.
+#
+#              Bootstrapping (no .resolved/ yet) with LOCALES unset vendors nothing
+#              and tells you to name the locale explicitly.
+#
+# Idempotent and fully reproducible: re-running against the same checkout emits
+# byte-identical artifacts. _meta.source_commit is pinned to the checkout SHA and
+# _meta.generated_at is pinned to that commit's committer date (%cI), so the
+# artifact is a pure function of the source commit — which is exactly what the
+# §2.4 freshness gate relies on when it regenerates and diffs. Safe to re-run.
 #
 # This script writes ONLY into the app repo's locales/ dir. It writes the
 # resolver index to a throwaway temp path so the rules repo's
@@ -64,10 +84,41 @@ fi
 
 # --- pin to the checkout's HEAD ----------------------------------------------
 SHA="$(git -C "$RULES_DIR" rev-parse HEAD)"
+# Freeze _meta.generated_at to the source commit's committer date so the emitted
+# artifact is a pure function of $SHA (no wall-clock drift between this vendor
+# run and the CI freshness gate's regeneration). resolved-freshness.yml derives
+# the SAME value from PINNED_RULES_REF; the two MUST stay in lock-step.
+GENERATED_AT="$(git -C "$RULES_DIR" show -s --format=%cI "$SHA")"
+
+# Resolve the set of locales to vendor. An explicit LOCALES allow-list wins;
+# otherwise default to the locales ALREADY vendored (basenames of the committed
+# locales/.resolved/*.json). Defaulting to the committed set — rather than to
+# "every governed locale upstream" — is what keeps a bare re-run from silently
+# vendoring an un-signed-off locale and clobbering its hand-authored guide.
+REQUESTED_LOCALES="${LOCALES:-}"
+default_set=0
+if [ -z "$REQUESTED_LOCALES" ]; then
+  default_set=1
+  for j in "$APP_LOCALES_DIR"/.resolved/*.json; do
+    [ -e "$j" ] || continue
+    REQUESTED_LOCALES="${REQUESTED_LOCALES:+$REQUESTED_LOCALES }$(basename "$j" .json)"
+  done
+  if [ -z "$REQUESTED_LOCALES" ]; then
+    echo "sync-resolved: nothing vendored yet and no LOCALES given — nothing to do." >&2
+    echo "       To bootstrap a locale: LOCALES=\"de_AT\" $0 [RULES_DIR]" >&2
+    exit 0
+  fi
+fi
 
 echo "sync-resolved: rules checkout = $RULES_DIR"
 echo "sync-resolved: rules SHA      = $SHA"
+echo "sync-resolved: generated_at   = $GENERATED_AT"
 echo "sync-resolved: emit target    = $APP_LOCALES_DIR"
+if [ "$default_set" -eq 1 ]; then
+  echo "sync-resolved: locale set     = $REQUESTED_LOCALES (default: already-vendored)"
+else
+  echo "sync-resolved: locale set     = $REQUESTED_LOCALES (explicit LOCALES)"
+fi
 echo
 
 # --- emit per governed locale ------------------------------------------------
@@ -78,6 +129,13 @@ skipped=()
 for d in "$RULES_DIR"/locales/*/; do
   [ -d "$d" ] || continue
   locale="$(basename "$d")"
+
+  # Vendor only the resolved set (explicit LOCALES, or the already-vendored
+  # default). Anything outside it is left untouched on disk.
+  case " $REQUESTED_LOCALES " in
+    *" $locale "*) : ;;          # in set — fall through
+    *) continue ;;               # not in set — leave any existing vendor untouched
+  esac
 
   # CRITICAL GUARD: only governed locales (those with register.yaml upstream)
   # are eligible. Anything else is a hand-authored content locale; emitting for
@@ -91,8 +149,8 @@ for d in "$RULES_DIR"/locales/*/; do
   echo "::sync ${locale}"
   # Run the resolver from inside the rules repo so it finds base.yaml, schema/,
   # locales/, retrospectives/ via its own defaults. Emit BOTH artifacts pinned
-  # to $SHA. Write the index to a throwaway temp file so the rules repo's
-  # committed resolver/index.json is left untouched.
+  # to $SHA + $GENERATED_AT. Write the index to a throwaway temp file so the
+  # rules repo's committed resolver/index.json is left untouched.
   index_tmp="$(mktemp)"
   (
     cd "$RULES_DIR" && \
@@ -101,11 +159,27 @@ for d in "$RULES_DIR"/locales/*/; do
       --emit=md,json \
       --emit-dir "$APP_LOCALES_DIR" \
       --source-commit "$SHA" \
+      --generated-at "$GENERATED_AT" \
       --index-path "$index_tmp"
   )
   rm -f "$index_tmp"
   synced+=("$locale")
 done
+
+# A requested locale that never synced is a typo or an ungoverned/absent locale
+# upstream — fail loudly rather than silently vendoring nothing for it.
+if [ -n "$REQUESTED_LOCALES" ]; then
+  for want in $REQUESTED_LOCALES; do
+    found=0
+    for got in "${synced[@]:-}"; do
+      [ "$got" = "$want" ] && found=1 && break
+    done
+    if [ "$found" -eq 0 ]; then
+      echo "error: requested locale '${want}' was not vendored — ungoverned (no register.yaml) or absent at $RULES_DIR/locales/${want}" >&2
+      exit 2
+    fi
+  done
+fi
 
 # --- summary -----------------------------------------------------------------
 echo

--- a/locales/scripts/sync-resolved.sh
+++ b/locales/scripts/sync-resolved.sh
@@ -149,7 +149,15 @@ if [ "${#preflight_bad[@]}" -ne 0 ]; then
   exit 2
 fi
 
-# --- emit per governed locale ------------------------------------------------
+# --- emit per governed locale (into a STAGING dir for atomic vendoring) -------
+# Emit every requested locale into a throwaway staging dir FIRST. Only after the
+# whole set resolves + lints + emits cleanly do we publish into locales/ (below).
+# Under `set -e`, a resolver/lint/schema failure on any locale aborts here before
+# a single file lands in locales/ — so a failed run never leaves a partial vendor
+# update. The existence/governance preflight above cannot catch a mid-run
+# resolver error; staging closes that gap.
+STAGE="$(mktemp -d)"
+trap 'rm -rf "$STAGE"' EXIT
 synced=()
 skipped=()
 
@@ -177,15 +185,16 @@ for d in "$RULES_DIR"/locales/*/; do
   echo "::sync ${locale}"
   # Run the resolver from inside the rules repo so it finds base.yaml, schema/,
   # locales/, retrospectives/ via its own defaults. Emit BOTH artifacts pinned
-  # to $SHA + $GENERATED_AT. Write the index to a throwaway temp file so the
-  # rules repo's committed resolver/index.json is left untouched.
+  # to $SHA + $GENERATED_AT into the STAGING dir (published into locales/ only
+  # after the whole set succeeds). Write the index to a throwaway temp file so
+  # the rules repo's committed resolver/index.json is left untouched.
   index_tmp="$(mktemp)"
   (
     cd "$RULES_DIR" && \
     uv run resolver/resolve.py "$locale" \
       --lint \
       --emit=md,json \
-      --emit-dir "$APP_LOCALES_DIR" \
+      --emit-dir "$STAGE" \
       --source-commit "$SHA" \
       --generated-at "$GENERATED_AT" \
       --index-path "$index_tmp"
@@ -208,6 +217,17 @@ if [ -n "$REQUESTED_LOCALES" ]; then
     fi
   done
 fi
+
+# --- publish: every requested locale emitted cleanly — copy staged artifacts --
+# into locales/ in one pass. NOTHING above this line has written to the app's
+# locales/ tree, so any abort before this point leaves the working tree
+# untouched (true all-or-nothing).
+for locale in "${synced[@]:-}"; do
+  [ -n "$locale" ] || continue
+  mkdir -p "$APP_LOCALES_DIR/.resolved" "$APP_LOCALES_DIR/guides/for-translators"
+  cp "$STAGE/.resolved/${locale}.json"            "$APP_LOCALES_DIR/.resolved/${locale}.json"
+  cp "$STAGE/guides/for-translators/${locale}.md" "$APP_LOCALES_DIR/guides/for-translators/${locale}.md"
+done
 
 # --- summary -----------------------------------------------------------------
 echo

--- a/locales/scripts/sync-resolved.sh
+++ b/locales/scripts/sync-resolved.sh
@@ -121,6 +121,27 @@ else
 fi
 echo
 
+# --- preflight: validate the FULL requested set before emitting anything ------
+# Vendoring is all-or-nothing. The emit loop below writes each locale's artifacts
+# as it goes, so without this gate a single bad locale (a typo, or one absent /
+# ungoverned upstream) would abort MID-RUN — after earlier locales were already
+# written — leaving a dirty partial vendor update. Validate every requested
+# locale up front and bail before touching the working tree.
+preflight_bad=()
+for want in $REQUESTED_LOCALES; do
+  if [ ! -d "$RULES_DIR/locales/$want" ]; then
+    echo "error: requested locale '${want}' is absent upstream (no $RULES_DIR/locales/${want})" >&2
+    preflight_bad+=("$want")
+  elif [ ! -f "$RULES_DIR/locales/$want/register.yaml" ]; then
+    echo "error: requested locale '${want}' is ungoverned (no register.yaml) — cannot vendor" >&2
+    preflight_bad+=("$want")
+  fi
+done
+if [ "${#preflight_bad[@]}" -ne 0 ]; then
+  echo "sync-resolved: aborting before any emit — cannot vendor: ${preflight_bad[*]}" >&2
+  exit 2
+fi
+
 # --- emit per governed locale ------------------------------------------------
 synced=()
 skipped=()

--- a/locales/scripts/sync-resolved.sh
+++ b/locales/scripts/sync-resolved.sh
@@ -88,7 +88,14 @@ SHA="$(git -C "$RULES_DIR" rev-parse HEAD)"
 # artifact is a pure function of $SHA (no wall-clock drift between this vendor
 # run and the CI freshness gate's regeneration). resolved-freshness.yml derives
 # the SAME value from PINNED_RULES_REF; the two MUST stay in lock-step.
-GENERATED_AT="$(git -C "$RULES_DIR" show -s --format=%cI "$SHA")"
+#
+# Do NOT use git's %cI here: it renders a UTC commit as "+00:00" on git <2.54
+# but "Z" on git >=2.54, so the vendor machine and the CI runner can disagree
+# byte-for-byte on an identical instant (this exact drift red-failed the gate).
+# Instead force UTC and a literal +00:00 offset via %cd/format-local, which is a
+# pure function of the commit across every git version.
+GENERATED_AT="$(TZ=UTC git -C "$RULES_DIR" show -s \
+  --date=format-local:'%Y-%m-%dT%H:%M:%S+00:00' --format=%cd "$SHA")"
 
 # Resolve the set of locales to vendor. An explicit LOCALES allow-list wins;
 # otherwise default to the locales ALREADY vendored (basenames of the committed

--- a/locales/scripts/sync-resolved.sh
+++ b/locales/scripts/sync-resolved.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+#
+# sync-resolved.sh — vendor the committed translation-rules artifacts into the
+# app repo (SPEC.md §2.3 "Output commit policy"). For every GOVERNED locale in
+# a translation-rules checkout, run the resolver to emit BOTH artifacts —
+# .resolved/<locale>.json (machine governance) and guides/for-translators/<locale>.md
+# (human guide) — pinned to that checkout's HEAD SHA, into this app repo's
+# locales/ dir. The emitted files are what the §2.4 freshness gate
+# (resolved-freshness.yml) later hash-checks; they are COMMITTED, not CI-only.
+#
+# GOVERNED = a translation-rules locale directory that contains a register.yaml.
+# That file is the "resolved-only-ready" signal (see authoring/backfill-locale.md):
+# without a register an agent gets no formality lock and no terminology, which
+# re-opens the 2026-04-12 register-regression class. Ungoverned content locales
+# are SKIPPED — emitting for them would clobber the hand-authored guide that
+# lives at locales/guides/for-translators/<locale>.md with a base-only stub.
+#
+# Usage:
+#   locales/scripts/sync-resolved.sh [RULES_DIR]
+#
+#   RULES_DIR  Path to a translation-rules checkout. Arg 1 overrides the
+#              ${RULES_DIR} env var, which defaults to ".translation-rules"
+#              (the read-only pinned checkout path used by the CI workflows).
+#
+# Idempotent: re-running against the same checkout reproduces byte-identical
+# artifacts (the resolver pins _meta.source_commit to the SHA; pass
+# --generated-at upstream if you also need a frozen timestamp). Safe to re-run.
+#
+# This script writes ONLY into the app repo's locales/ dir. It writes the
+# resolver index to a throwaway temp path so the rules repo's
+# resolver/index.json is never touched.
+
+set -euo pipefail
+
+# --- locate the translation-rules checkout -----------------------------------
+RULES_DIR="${1:-${RULES_DIR:-.translation-rules}}"
+
+if [ ! -d "$RULES_DIR" ]; then
+  echo "error: translation-rules checkout not found at: $RULES_DIR" >&2
+  echo "       pass it as arg 1 or set \$RULES_DIR (default: .translation-rules)" >&2
+  exit 2
+fi
+# Absolute path — the resolver is invoked from inside $RULES_DIR (cd), so every
+# path we hand it must be absolute to stay anchored to the app repo.
+RULES_DIR="$(cd "$RULES_DIR" && pwd)"
+
+if [ ! -f "$RULES_DIR/resolver/resolve.py" ]; then
+  echo "error: $RULES_DIR does not look like a translation-rules checkout" >&2
+  echo "       (missing resolver/resolve.py)" >&2
+  exit 2
+fi
+
+# --- app repo locales/ dir (emit target) -------------------------------------
+# This script lives at <app>/locales/scripts/sync-resolved.sh; its grandparent
+# is <app>/locales. Resolve from the script's own location so cwd doesn't matter.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+APP_LOCALES_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+if [ ! -d "$APP_LOCALES_DIR/content" ]; then
+  echo "error: $APP_LOCALES_DIR does not look like the app repo's locales/ dir" >&2
+  echo "       (missing content/)" >&2
+  exit 2
+fi
+
+# --- pin to the checkout's HEAD ----------------------------------------------
+SHA="$(git -C "$RULES_DIR" rev-parse HEAD)"
+
+echo "sync-resolved: rules checkout = $RULES_DIR"
+echo "sync-resolved: rules SHA      = $SHA"
+echo "sync-resolved: emit target    = $APP_LOCALES_DIR"
+echo
+
+# --- emit per governed locale ------------------------------------------------
+synced=()
+skipped=()
+
+# Sort for deterministic, reproducible ordering across runs.
+for d in "$RULES_DIR"/locales/*/; do
+  [ -d "$d" ] || continue
+  locale="$(basename "$d")"
+
+  # CRITICAL GUARD: only governed locales (those with register.yaml upstream)
+  # are eligible. Anything else is a hand-authored content locale; emitting for
+  # it would overwrite its hand-authored guide with a base-only stub.
+  if [ ! -f "${d}register.yaml" ]; then
+    echo "skip ${locale}: ungoverned (no register.yaml upstream) — leaving hand-authored guide untouched"
+    skipped+=("$locale")
+    continue
+  fi
+
+  echo "::sync ${locale}"
+  # Run the resolver from inside the rules repo so it finds base.yaml, schema/,
+  # locales/, retrospectives/ via its own defaults. Emit BOTH artifacts pinned
+  # to $SHA. Write the index to a throwaway temp file so the rules repo's
+  # committed resolver/index.json is left untouched.
+  index_tmp="$(mktemp)"
+  (
+    cd "$RULES_DIR" && \
+    uv run resolver/resolve.py "$locale" \
+      --lint \
+      --emit=md,json \
+      --emit-dir "$APP_LOCALES_DIR" \
+      --source-commit "$SHA" \
+      --index-path "$index_tmp"
+  )
+  rm -f "$index_tmp"
+  synced+=("$locale")
+done
+
+# --- summary -----------------------------------------------------------------
+echo
+echo "sync-resolved: done."
+echo "  rules SHA: $SHA"
+echo "  synced (${#synced[@]}): ${synced[*]:-<none>}"
+echo "  skipped (${#skipped[@]}): ${skipped[*]:-<none>}"
+
+if [ "${#synced[@]}" -eq 0 ]; then
+  echo "sync-resolved: warning — no governed locales found under $RULES_DIR/locales" >&2
+fi

--- a/locales/slash_commands/review-locale-branches.md
+++ b/locales/slash_commands/review-locale-branches.md
@@ -6,26 +6,28 @@ Reviews `i18n/update-*` branches by language family using parallel code-reviewer
 
 ### Stage 1: Automated Validation (run first)
 
-Run variable validation with `--json` for deterministic, machine-readable output:
+This stage is pure deterministic mechanics — it lives in the checked-in script,
+not in this prompt. Run variable validation across all `i18n/update-*` branches:
 
 ```bash
-for branch in $(git branch --list 'i18n/update-*' | tr -d ' ' | sed 's/\x1b\[[0-9;]*m//g'); do
-  locale=${branch#i18n/update-}
-  python3 locales/scripts/i18n validate variables --json --locale "$locale" > "/tmp/i18n-validate-${locale}.json"
-  count=$(jq '.summary | to_entries | map(.value) | add // 0' "/tmp/i18n-validate-${locale}.json")
-  if [ "$count" -gt 0 ]; then
-    echo "$locale: $count variable mismatches — /tmp/i18n-validate-${locale}.json"
-  fi
-done
+bash locales/scripts/review-locale-branches.sh validate
 ```
 
-Output is deterministic: `0` = clean, `N` = errors to fix. View details with `jq . /tmp/i18n-validate-{locale}.json`.
+For each branch it runs `python3 locales/scripts/i18n validate variables --json
+--locale <locale>`, writes the JSON to `/tmp/i18n-validate-{locale}.json` (pass a
+`RESULTS_DIR` argument to override), and prints one line per locale with a
+mismatch count > 0. It always exits 0 — it's a report, not a gate.
+
+Output is deterministic: a locale only appears if it has `N > 0` errors to fix.
+View details with `jq . /tmp/i18n-validate-{locale}.json`.
 
 **Why `--json`:** The `--summary` flag outputs bare numbers that are easy to misinterpret. JSON output is unambiguous and includes full issue details for fixing.
 
 ### Stage 2: Agent Review by Language Family
 
-Launch up to 5-6 `code-reviewer` agents in parallel, grouped by language family:
+Launch up to 5-6 `code-reviewer` agents in parallel, grouped by language family.
+The table below is for human readability; the authoritative mapping lives in the
+script — print it with `bash locales/scripts/review-locale-branches.sh families`:
 
 | Family | Locales |
 |--------|---------|
@@ -56,7 +58,7 @@ Create the output directory before launching agents:
 # distinct directories instead of overwriting each other.
 REVIEW_DATE=$(date +%Y-%m-%d-%H%M)
 REVIEW_DIR="locales/reviews/${REVIEW_DATE}"
-mkdir -p "$REVIEW_DIR"
+bash locales/scripts/review-locale-branches.sh init "$REVIEW_DIR"
 ```
 
 For each agent, use `subagent_type: "feature-dev:code-reviewer"` with `run_in_background: true`.
@@ -104,34 +106,17 @@ Format:
 
 ### Stage 3: Consolidate Group Reviews
 
-After all agents complete, create group summary files:
+This stage is pure deterministic mechanics — it lives in the checked-in script.
+After all agents complete, build the per-family group summary files:
 
 ```bash
-for group in semitic-rtl slavic germanic cjk romance other; do
-  # Map group to locales (from table above)
-  case $group in
-    semitic-rtl) locales="ar he" ;;
-    slavic) locales="bg cs pl ru sl_SI uk" ;;
-    germanic) locales="de de_AT nl sv_SE" ;;
-    romance) locales="ca_ES es fr_CA fr_FR it_IT pt_BR pt_PT" ;;
-    cjk) locales="ja ko zh" ;;
-    other) locales="da_DK el_GR eo hu mi_NZ tr vi" ;;
-  esac
-
-  echo "# ${group} Group Review - ${REVIEW_DATE}" > "${REVIEW_DIR}/${group}.md"
-  echo "" >> "${REVIEW_DIR}/${group}.md"
-  echo "Locales: ${locales}" >> "${REVIEW_DIR}/${group}.md"
-  echo "" >> "${REVIEW_DIR}/${group}.md"
-
-  for loc in $locales; do
-    if [ -f "${REVIEW_DIR}/${loc}.md" ]; then
-      echo "---" >> "${REVIEW_DIR}/${group}.md"
-      cat "${REVIEW_DIR}/${loc}.md" >> "${REVIEW_DIR}/${group}.md"
-      echo "" >> "${REVIEW_DIR}/${group}.md"
-    fi
-  done
-done
+bash locales/scripts/review-locale-branches.sh consolidate "$REVIEW_DIR"
 ```
+
+For each family group it writes `${REVIEW_DIR}/${group}.md` by concatenating the
+per-locale `${REVIEW_DIR}/${loc}.md` files that exist, with a header and `---`
+separators. The family->locales mapping comes from the script's authoritative
+table (see `review-locale-branches.sh families`).
 
 ### Stage 4: Triage and Fix
 

--- a/locales/slash_commands/review-locale-branches.md
+++ b/locales/slash_commands/review-locale-branches.md
@@ -52,7 +52,9 @@ locales/reviews/{DATE}/
 Create the output directory before launching agents:
 
 ```bash
-REVIEW_DATE=$(date +%Y-%m-%d)
+# Timestamp to the minute so multiple review runs on the same day land in
+# distinct directories instead of overwriting each other.
+REVIEW_DATE=$(date +%Y-%m-%d-%H%M)
 REVIEW_DIR="locales/reviews/${REVIEW_DATE}"
 mkdir -p "$REVIEW_DIR"
 ```

--- a/locales/slash_commands/start-translation-session.md
+++ b/locales/slash_commands/start-translation-session.md
@@ -1,36 +1,45 @@
 ---
 description: Start a parallel translation session with background agents for multiple locales
 argument-hint: <locale-codes...> [--focus LOCALE]
-allowed-tools: Bash, Task, Read, Glob, TodoWrite, KillShell
+allowed-tools: Bash, Task, Read, Glob, TodoWrite
 ---
 
 # Start Translation Session
 
-Orchestrates parallel background agents to translate locales using the task-based workflow. Each agent completes tasks independently (one writer per locale), with the main session monitoring progress and replacing agents as they complete.
+Orchestration ONLY. This command launches, monitors, and replaces background
+translator agents. It does **not** carry workflow steps or per-locale conventions:
+each agent follows `locales/AGENT_TRANSLATION_PROTOCOL.md` exactly, and reads its
+per-locale governance from `locales/.resolved/{LOCALE}.json`. Concurrency is owned
+by the CLI (every connection opens WAL with a 30s busy timeout), so there is no
+WAL/lock setup or retry handling here.
 
-## Environment & Concurrency
+One writer per locale: each agent drains its locale's task queue independently;
+the main session tracks progress with TodoWrite and replaces agents as they finish.
 
-- **No `.env.sh`** — the project uses direnv (`.envrc`). Run `python3 locales/scripts/i18n tasks ...`
-  directly from the repo root; the scripts need no sourcing.
-- **Unified CLI** — all locale tooling is one entry point: `python3 locales/scripts/i18n <group> <cmd>`
-  (groups: `tasks` create/next/update/export, `db` init/migrate/query/export/import). The old
-  per-script paths (`locales/scripts/tasks/*.py`, `store.py`, `migrate/export.py`) are gone.
-- **One writer per locale, claim-free** — `tasks next {LOCALE}` (next *pending*) → `tasks update {ID}`
-  (completed) advances with zero orphans, so `--claim` is unnecessary. If you use it with
-  multiple writers on a locale, reset stranded `in_progress` rows at start
-  (`tasks update {ID} --status pending`).
-- **Enable WAL once before launching** — all locales share one `tasks.db`
-  (`journal_mode=delete`, `busy_timeout=0` by default):
-  `sqlite3 locales/db/tasks.db "PRAGMA journal_mode=WAL"`. Agents retry on `database is locked`.
-- **`--validate` is advisory** — warns on key mismatches but still saves; agents must read the
-  warnings and re-submit with the exact source key set. Audit completed rows after draining.
+## Eligibility gate (check per target locale)
+
+A locale is eligible for automated drain **only if**
+`locales/.resolved/{LOCALE}.json` exists with a populated `register` and a
+populated `glossary` (i.e., its governance has been back-ported upstream). For
+every requested locale, verify this first and **SKIP + warn** for any locale that
+lacks it:
+
+```bash
+for locale in $LOCALES; do
+  f="locales/.resolved/$locale.json"
+  if [ -s "$f" ]; then
+    echo "ELIGIBLE: $locale"
+  else
+    echo "SKIP (no resolved governance): $locale — back-port locales/.resolved/$locale.json first"
+  fi
+done
+```
+
+Only launch agents for `ELIGIBLE` locales.
 
 ## Quick Start
 
 ```bash
-# Check what needs translating
-python3 locales/scripts/i18n tasks next --help
-
 # See stats for a locale
 python3 locales/scripts/i18n tasks next fr_CA --stats
 ```
@@ -39,7 +48,7 @@ python3 locales/scripts/i18n tasks next fr_CA --stats
 
 ### 1. Create Tasks (if needed)
 
-For each locale that needs tasks generated:
+For each eligible locale that needs tasks generated:
 
 ```bash
 python3 locales/scripts/i18n tasks create LOCALE
@@ -58,7 +67,9 @@ TodoWrite with todos:
 
 ### 3. Launch Background Agents
 
-For each locale, launch a `saas-translator` agent with `run_in_background: true`:
+For each eligible locale, launch a `saas-translator` agent with
+`run_in_background: true`. The prompt is short — all workflow and governance lives
+in the referenced files:
 
 ```
 Task tool:
@@ -66,123 +77,43 @@ Task tool:
   subagent_type: "saas-translator"
   run_in_background: true
   prompt: |
-    Continue {LANGUAGE} ({LOCALE}) translation for OneTimeSecret.
-
-    **Workflow (run from repo root; no `source .env.sh` — direnv handles env):**
-    1. Next task: `python3 locales/scripts/i18n tasks next {LOCALE} --json`
-       (one writer per locale, so `--claim` is unnecessary; stop when no pending task)
-    2. Translate all keys using conventions below
-    3. Write the {"key": "translation"} object (EXACT source key set) to a temp file
-       with the Write tool, then save with `--file` (apostrophe/quote-safe; avoids
-       HEREDOC and shell-quoting breakage in fr/es/it):
-       ```bash
-       python3 locales/scripts/i18n tasks update TASK_ID --file /tmp/trans_{LOCALE}.json --validate
-       ```
-    4. READ the output: `--validate` only WARNS, it still saves a bad write. On
-       "Warning: Missing/Extra keys", rebuild with the exact source keys and re-run.
-       On "database is locked", wait ~2s and retry.
-    5. Repeat until no more tasks or context limit (aim for 15+ tasks per session)
-
-    **{LOCALE} Conventions:**
-    {CONVENTIONS_FOR_LOCALE}
-
-    **Critical Rules:**
-    - Preserve ALL variables/markup exactly: `{var}`, `{{var}}`, `%{var}`, `%s`, `<tag>`
-    - The saved key set must match the source keys exactly (none added/dropped)
-    - Keep brand name "Onetime Secret" unchanged
-    - Do NOT export translations - only complete tasks
-
-    Complete as many tasks as possible.
+    Drain translation tasks for locale {LOCALE}. Follow
+    locales/AGENT_TRANSLATION_PROTOCOL.md exactly. Per-locale governance
+    (register, glossary, binding rules, declined decisions):
+    locales/.resolved/{LOCALE}.json. Preserve all interpolation/markup tokens;
+    brand names stay English. Loop until 0 pending; do not export or commit.
 ```
 
-### 4. Start Watch Process
+### 4. Monitor Progress (single poll)
 
-Launch a background bash to monitor progress:
+Poll on demand — never spawn background sleep loops. Run a single poll, read it,
+then poll again when ready:
 
 ```bash
-while true; do
-  echo "=== $(date +%H:%M:%S) ==="
-  python3 locales/scripts/i18n db query "SELECT locale, status, COUNT(*) as count FROM translation_tasks GROUP BY locale, status ORDER BY locale, status"
-  sleep 10
+for locale in $ELIGIBLE_LOCALES; do
+  printf "%-6s: " "$locale"
+  python3 locales/scripts/i18n tasks next $locale --stats
 done
 ```
-
-Note the shell_id from the response for later cleanup.
 
 ### 5. Handle Agent Completions
 
 When an agent completes (via `<task-notification>`):
 
-1. **If locale has pending tasks**: Launch replacement agent for same locale
-2. **If locale is complete**: Mark todo as completed, check if new locale should start
-3. **Maintain max 5 agents** running at once
+1. **If locale has pending tasks**: launch a replacement agent for that locale
+   using the same short prompt as step 3.
+2. **If locale is complete**: mark its todo completed; start a queued locale if one
+   is waiting.
+3. **Maintain max 5 agents** running at once.
 
-### 6. Monitor Progress
-
-Check watch output periodically:
-
-```bash
-tail -20 /private/tmp/claude/.../tasks/SHELL_ID.output
-```
-
-Or run stats manually:
-
-```bash
-python3 locales/scripts/i18n tasks next LOCALE --stats
-```
-
-### 7. Session Complete
+### 6. Session Complete
 
 When all locales show 0 pending:
 
-1. Kill watch process: `KillShell with shell_id: "SHELL_ID"`
-2. Clear todo list
-3. Report final status
+1. Clear the todo list.
+2. Report final per-locale status.
 
-**Do NOT export** - that's a separate step for the user to run when ready.
-
-## Locale Conventions Reference
-
-| Locale | Key Conventions |
-|--------|-----------------|
-| **fr_CA** | courriel, mot de passe, phrase secrete; infinitif for buttons; non-breaking space before `: ; ! ?` |
-| **de** | informal "du"; secret→Nachricht, passphrase→Passphrase, burn→loschen; compound nouns |
-| **es** | informal "tu"; secreto, contrasena, frase de contrasena; `?` `!` inverted punctuation |
-| **pt_BR** | informal "voce"; mensagem confidencial, frase secreta; Painel, Configuracoes |
-| **eo** | sekreto, sekreta frazo, pasvorto, forbruligi, retposto; diacritics (ĉĝĵŝŭ) |
-| **fr_FR** | Similar to fr_CA but use "e-mail" not "courriel"; vous form for formal contexts |
-| **it** | informal "tu"; segreto, password, frase segreta; Pannello, Impostazioni |
-| **nl** | informal "je"; geheim, wachtwoord, wachtwoordzin; compound nouns |
-| **ja** | polite form; シークレット, パスワード, パスフレーズ; no spaces between words |
-| **zh** | Simplified; 密码, 密语, 秘密; no spaces |
-| **ko** | polite form; 비밀, 비밀번호, 암호문구 |
-| **ru** | informal "ты"; секрет, пароль, кодовая фраза |
-
-## Agent Replacement Template
-
-When agent completes and locale has remaining tasks:
-
-```
-Task tool:
-  description: "Continue {LOCALE} translation"
-  subagent_type: "saas-translator"
-  run_in_background: true
-  prompt: |
-    Continue {LANGUAGE} ({LOCALE}) translation session. ~{COMPLETED}/{TOTAL} tasks done.
-
-    **Workflow:**
-    1. Run: `python3 locales/scripts/i18n tasks next {LOCALE} --json`
-    2. Translate using established conventions
-    3. Write {"key": "translation"} (exact source keys) to a temp file, then:
-       `python3 locales/scripts/i18n tasks update TASK_ID --file /tmp/trans_{LOCALE}.json --validate`
-       (`--validate` only warns; re-run on key-mismatch warnings. Retry on "database is locked".)
-    4. Repeat until no tasks or context limit
-
-    **{LOCALE} Conventions:**
-    {CONVENTIONS}
-
-    Complete as many tasks as possible.
-```
+**Do NOT export** — that's a separate step the user runs when ready.
 
 ## Recovery After /compact
 
@@ -193,11 +124,10 @@ Task tool:
    done
    ```
 
-2. Rebuild todo list from current state
+2. Rebuild the todo list from current state.
 
-3. Launch agents for locales with pending tasks
-
-4. Restart watch process
+3. Re-check the eligibility gate, then launch agents for eligible locales with
+   pending tasks (same short prompt as step 3).
 
 ## Example Session Status
 
@@ -215,14 +145,9 @@ Task tool:
 
 ## Next Steps After Completion
 
-User should run export manually when ready:
+User runs export manually when ready:
 
 ```bash
 python3 locales/scripts/i18n tasks export LOCALE
-```
-
-Then sync to src:
-
-```bash
 pnpm run locales:sync
 ```

--- a/locales/slash_commands/start-translation-session.md
+++ b/locales/slash_commands/start-translation-session.md
@@ -48,10 +48,13 @@ python3 locales/scripts/i18n tasks next fr_CA --stats
 
 ### 1. Create Tasks (if needed)
 
-For each eligible locale that needs tasks generated:
+For each eligible locale that needs tasks generated, enqueue only the keys still
+untranslated in `content/LOCALE` so a DB rebuild never requeues already-translated
+(reviewed) strings. Use `--missing-only` for existing locales; drop it only to
+bootstrap a brand-new, empty locale:
 
 ```bash
-python3 locales/scripts/i18n tasks create LOCALE
+python3 locales/scripts/i18n tasks create LOCALE --missing-only
 ```
 
 ### 2. Track Agents with TodoWrite

--- a/locales/slash_commands/start-translation-session.md
+++ b/locales/slash_commands/start-translation-session.md
@@ -27,7 +27,7 @@ lacks it:
 ```bash
 for locale in $LOCALES; do
   f="locales/.resolved/$locale.json"
-  if [ -s "$f" ]; then
+  if [ -f "$f" ] && jq -e '((.register // {}) | length > 0) and ((.glossary // {}) | length > 0)' "$f" >/dev/null 2>&1; then
     echo "ELIGIBLE: $locale"
   else
     echo "SKIP (no resolved governance): $locale — back-port locales/.resolved/$locale.json first"

--- a/locales/slash_commands/translate-new-language.md
+++ b/locales/slash_commands/translate-new-language.md
@@ -1,7 +1,7 @@
 ---
 description: Translate locale files for a single target language using git diff detection, routed through the agent protocol
 argument-hint: <lang-code>
-allowed-tools: Bash(git diff:*), Bash(cp:*), Bash(ls:*), Bash(cat:*), Bash([ -s:*), Task, Read, Glob
+allowed-tools: Bash(git diff:*), Bash(cp:*), Bash(ls:*), Bash(cat:*), Bash([ -f:*), Bash(jq:*), Bash(python3 locales/scripts/i18n tasks:*), Task, Read, Glob
 ---
 
 # Translate a Single Language
@@ -29,8 +29,12 @@ A language is eligible for automated drain **only if**
 **SKIP + warn** if it is missing:
 
 ```bash
-[ -s "locales/.resolved/$LANG.json" ] && echo "ELIGIBLE: $LANG" \
-  || echo "SKIP (no resolved governance): $LANG — back-port locales/.resolved/$LANG.json first"
+if [ -f "locales/.resolved/$LANG.json" ] \
+   && jq -e '((.register // {}) | length > 0) and ((.glossary // {}) | length > 0)' "locales/.resolved/$LANG.json" >/dev/null 2>&1; then
+  echo "ELIGIBLE: $LANG"
+else
+  echo "SKIP (no resolved governance): $LANG — back-port locales/.resolved/$LANG.json first"
+fi
 ```
 
 If not eligible, stop and report — do not translate without the resolved artifact.

--- a/locales/slash_commands/translate-new-language.md
+++ b/locales/slash_commands/translate-new-language.md
@@ -1,67 +1,84 @@
 ---
-description: Translate locale files for a target language using git diff workflow
+description: Translate locale files for a single target language using git diff detection, routed through the agent protocol
 argument-hint: <lang-code>
-allowed-tools: Bash(git diff:*), Bash(cp:*), Bash(pnpm run locale:validate:*), Bash(ls:*), Bash(cat:*), Read, Edit, Write, Glob
+allowed-tools: Bash(git diff:*), Bash(cp:*), Bash(ls:*), Bash(cat:*), Bash([ -s:*), Task, Read, Glob
 ---
 
-# Create New Language Translation
+# Translate a Single Language
 
-Uses the `saas-translator` skill.
-
-## Pre-Flight Check
-
-First, detect if this repo has its own translation protocol:
-
-```bash
-# Check for established translation workflow
-ls locales/TRANSLATION_PROTOCOL.md 2>/dev/null && echo "PROTOCOL_FOUND"
-```
-
-**If `PROTOCOL_FOUND`**: This repo has a structured translation workflow. Read and follow `locales/TRANSLATION_PROTOCOL.md` instead of the generic workflow below.
-
-Otherwise, continue with the generic workflow below.
+Orchestration ONLY. This command detects what needs translating for one language,
+then routes the actual translation work to a `saas-translator` agent that follows
+`locales/AGENT_TRANSLATION_PROTOCOL.md` exactly and reads its per-locale governance
+from `locales/.resolved/{LANG}.json`. It carries no per-locale convention prose.
 
 ## Detect Locale Structure
 
 ```bash
-# Modern structure (flat keys with text field)
 ls locales/content/en/*.json 2>/dev/null && echo "MODERN_STRUCTURE"
-
-# Legacy structure
-ls src/locales/en/*.json 2>/dev/null && echo "LEGACY_STRUCTURE"
 ```
 
-Set paths based on detection:
-- **Modern**: `./locales/content/{lang}/`, guide at `locales/guides/for-translators/{lang}.md`
-- **Legacy**: `src/locales/{lang}/`, guide at `src/locales/{lang}/export-guide.md`
+Source of truth is `./locales/content/{lang}/`.
 
-**Paths to IGNORE** (do not edit): `./generate/`, `./src/locales/` — compiled/legacy, not source
+**Paths to IGNORE** (do not edit): `./generate/`, `./src/locales/` — compiled/legacy, not source.
 
-## Workflow
+## Eligibility gate
 
-1. **Get the diff** between English source and target locale:
+A language is eligible for automated drain **only if**
+`locales/.resolved/{LANG}.json` exists with a populated `register` and a populated
+`glossary` (i.e., its governance has been back-ported upstream). Check it first and
+**SKIP + warn** if it is missing:
+
+```bash
+[ -s "locales/.resolved/$LANG.json" ] && echo "ELIGIBLE: $LANG" \
+  || echo "SKIP (no resolved governance): $LANG — back-port locales/.resolved/$LANG.json first"
+```
+
+If not eligible, stop and report — do not translate without the resolved artifact.
+
+## Detection / diff flow
+
+1. **Get the diff** between English source and the target language to scope the
+   new/changed keys:
    ```bash
-   # Modern structure
    git diff --no-index locales/content/en locales/content/{lang} 2>/dev/null || echo "New locale"
-
-   # Legacy structure
-   git diff --no-index src/locales/en src/locales/{lang} 2>/dev/null || echo "New locale"
    ```
 
-2. **Process file by file**, translating new/changed keys from English
+2. **For a brand-new language**, seed the directory from English structure so the
+   keys exist to be drained:
+   ```bash
+   cp -r locales/content/en locales/content/{lang}
+   ```
 
-3. **Reference the locale's export-guide** for language-specific rules (terminology, formality, formatting)
+3. **Build the task queue** so the agent has pending work:
+   ```bash
+   python3 locales/scripts/i18n tasks create {lang}
+   python3 locales/scripts/i18n tasks next {lang} --stats
+   ```
 
-4. **Preserve**: `{{variables}}`, HTML tags, special characters
+## Route the translation to an agent
 
-5. **Validate** if available: `pnpm run locale:validate {lang}`
+Launch a `saas-translator` agent with a short prompt — workflow and governance live
+in the referenced files:
 
-## For New Languages
+```
+Task tool:
+  description: "Translate {LANG}"
+  subagent_type: "saas-translator"
+  prompt: |
+    Drain translation tasks for locale {LANG}. Follow
+    locales/AGENT_TRANSLATION_PROTOCOL.md exactly. Per-locale governance
+    (register, glossary, binding rules, declined decisions):
+    locales/.resolved/{LANG}.json. Preserve all interpolation/markup tokens;
+    brand names stay English. Loop until 0 pending; do not export or commit.
+```
 
-1. Copy English structure to target language directory
-2. Read the export-guide for language-specific conventions (do not edit the guide)
-3. Translate each JSON file, following export-guide rules
+## Done
+
+DONE = `python3 locales/scripts/i18n tasks next {lang} --stats` shows 0 pending.
+Verify, then report. Do NOT export or commit — that's a separate human step.
 
 ## For Multiple Locales in Parallel
 
-Use `/d:translate-parallel-agents` to orchestrate multiple `saas-translator` background agents translating different locales simultaneously. This is more efficient for batch translation work.
+Use `/d:translate-parallel-agents` to orchestrate multiple `saas-translator`
+background agents translating different locales simultaneously. This is more
+efficient for batch translation work.

--- a/locales/slash_commands/translate-new-language.md
+++ b/locales/slash_commands/translate-new-language.md
@@ -11,6 +11,16 @@ then routes the actual translation work to a `saas-translator` agent that follow
 `locales/AGENT_TRANSLATION_PROTOCOL.md` exactly and reads its per-locale governance
 from `locales/.resolved/{LANG}.json`. It carries no per-locale convention prose.
 
+**Prerequisite (resolved-only): governance is back-ported first.** Under the
+resolved-only model a language becomes translatable only once
+`locales/.resolved/{LANG}.json` exists with a populated register + glossary.
+"New language" here means *new to translation* — its governance already exists,
+its content just hasn't been drained yet. This command does **not** bootstrap a
+language from nothing: if the resolved artifact is missing, back-port the
+language in the `translation-rules` repo (`authoring/backfill-locale.md`) and
+vendor the artifact first, then run this command. The gate below enforces that
+ordering rather than silently producing ungoverned translations.
+
 ## Detect Locale Structure
 
 ```bash

--- a/locales/slash_commands/translate-parallel-agents.md
+++ b/locales/slash_commands/translate-parallel-agents.md
@@ -6,31 +6,28 @@ allowed-tools: Bash, Task, Read, Glob, TodoWrite
 
 # Parallel Translation Agent Orchestration
 
-Manages multiple background agents translating locales simultaneously using a task-based workflow with SQLite tracking.
+Orchestration ONLY. This command launches, monitors, and replaces background
+`saas-translator` agents that drain locales in parallel. It carries no workflow
+prose and no per-locale conventions: each agent follows
+`locales/AGENT_TRANSLATION_PROTOCOL.md` exactly and reads its per-locale
+governance from `locales/.resolved/{LOCALE}.json`. Concurrency is owned by the CLI
+(every connection opens WAL with a 30s busy timeout), so there is no WAL/lock
+setup or retry handling here.
 
 ## Prerequisites
 
-This command requires:
-1. A repo with `locales/TRANSLATION_PROTOCOL.md` (task-based workflow)
-2. SQLite task database at `locales/db/tasks.db`
-   - Tables: `translation_tasks`, `sessions`
-   - Schema: `locales/db/schema.sql`
-   - Durable tables committed as SQL dumps: `locales/db/{glossary,session_log,schema_migrations}.sql` (hydrate with `db import`)
-3. Unified CLI at `locales/scripts/i18n` (`tasks create/next/update/export`, `db init/migrate/query/export/import`)
-4. Locale guides at `locales/guides/for-translators/{locale}.md`
-5. Locale JSON files at `./locales/content/{locale}/*.json`
-6. **Paths to IGNORE**: `./generate/`, `./src/locales/` (compiled/legacy, not source)
-
-## Database Initialization
-
-`tasks.db` is NOT in git. Build it from the committed schema + dumps:
-
-```bash
-python3 locales/scripts/i18n db init      # create tasks.db from schema.sql
-python3 locales/scripts/i18n db import    # hydrate glossary/session_log/etc from db/*.sql
-```
-
-The committable tables (`glossary`, `session_log`, `translation_issues`) live in `locales/db/*.sql`.
+1. Unified CLI at `locales/scripts/i18n` (`tasks create/next/update/export`,
+   `db init/migrate/query/export/import`).
+2. SQLite task database at `locales/db/tasks.db` (table `translation_tasks`,
+   schema `locales/db/schema.sql`). It is NOT in git — rebuild it from the
+   committed schema + dumps:
+   ```bash
+   python3 locales/scripts/i18n db init      # create tasks.db from schema.sql
+   python3 locales/scripts/i18n db import    # hydrate glossary/session_log/etc from db/*.sql
+   ```
+3. Per-locale governance at `locales/.resolved/{LOCALE}.json` (see eligibility gate).
+4. Source locale JSON at `./locales/content/{locale}/*.json`.
+5. **Paths to IGNORE**: `./generate/`, `./src/locales/` (compiled/legacy, not source).
 
 ## Arguments
 
@@ -39,11 +36,31 @@ The committable tables (`glossary`, `session_log`, `translation_issues`) live in
 - `--stats`: Show current progress without launching agents
 - `--resume`: Resume monitoring existing agents
 
+## Eligibility gate (check per target locale)
+
+A locale is eligible for automated drain **only if**
+`locales/.resolved/{LOCALE}.json` exists with a populated `register` and a
+populated `glossary` (i.e., its governance has been back-ported upstream). Check
+every target first and **SKIP + warn** for any locale that lacks it:
+
+```bash
+for locale in $LOCALES; do
+  f="locales/.resolved/$locale.json"
+  if [ -s "$f" ]; then
+    echo "ELIGIBLE: $locale"
+  else
+    echo "SKIP (no resolved governance): $locale — back-port locales/.resolved/$locale.json first"
+  fi
+done
+```
+
+Only launch agents for `ELIGIBLE` locales.
+
 ## Workflow
 
 ### 1. Initialize Locales
 
-For each locale that doesn't have tasks yet:
+For each eligible locale that doesn't have tasks yet:
 
 ```bash
 python3 locales/scripts/i18n tasks create LOCALE
@@ -60,41 +77,26 @@ done
 
 ### 3. Launch Background Agents
 
-For each locale with pending tasks, launch a background agent:
+For each eligible locale with pending tasks, launch a background agent. The prompt
+is short — workflow and governance live in the referenced files:
 
 ```
 Task tool with:
   subagent_type: "saas-translator"
   run_in_background: true
   prompt: |
-    Translate OneTimeSecret to {LOCALE}. Work from the repo root; run scripts
-    directly (no `source .env.sh` — the project uses direnv).
-    Locale guide: locales/guides/for-translators/{LOCALE}.md
-    (Regional variants without their own guide fall back to the base, e.g.
-    de_AT -> de.md.)
-
-    Loop, ~50 tasks/round:
-    1. `python3 locales/scripts/i18n tasks next {LOCALE} --json`  (stop if no pending task)
-    2. Translate each value; preserve every variable/tag verbatim ({var}, {{var}},
-       %{var}, %s, <tag>) with the same set and count.
-    3. Write the {"key": "translation"} object (EXACT source key set) to a temp file
-       with the Write tool, then:
-       `python3 locales/scripts/i18n tasks update {ID} --file /tmp/trans_{LOCALE}.json --validate`
-    4. READ the output: `--validate` only WARNS, it still saves a bad write. If you see
-       "Warning: Missing/Extra keys", rebuild with the exact source keys and re-run.
-    5. On "database is locked", wait ~2s and retry (up to 3x).
-    Report completed-this-round and remaining (`tasks next {LOCALE} --stats`).
+    Drain translation tasks for locale {LOCALE}. Follow
+    locales/AGENT_TRANSLATION_PROTOCOL.md exactly. Per-locale governance
+    (register, glossary, binding rules, declined decisions):
+    locales/.resolved/{LOCALE}.json. Preserve all interpolation/markup tokens;
+    brand names stay English. Loop until 0 pending; do not export or commit.
 ```
 
-The `saas-translator` agent knows variable-preservation rules, but the task-DB cycle,
-the `--file` temp-file write (apostrophe-safe), and the `--validate`-is-advisory caveat
-must be in the prompt — see "Agent Execution Notes" below.
+### 4. Monitor Progress (single poll)
 
-### 4. Monitor Progress (CRITICAL)
+**Do NOT wait passively for agent notifications, and do NOT spawn background sleep
+loops.** Proactively run a single poll, read the result, then poll again when ready.
 
-**Do NOT wait passively for agent notifications.** Proactively poll using the existing scripts.
-
-#### Single Poll (Recommended)
 ```bash
 for locale in fr_CA de es pt_BR eo; do
   printf "%-6s: " "$locale"
@@ -103,37 +105,28 @@ for locale in fr_CA de es pt_BR eo; do
 done
 ```
 
-Run this manually, check result, then run again. Do NOT spawn background sleeps.
-
 #### Anti-Pattern: Background Sleep Loops
+
 ```bash
-# WRONG - creates stale notification backlog:
+# WRONG - creates a stale notification backlog:
 sleep 120 && check_status  # spawned as background task
 sleep 120 && check_status  # another background task
 # Results in 10+ stale notifications when they all resolve
 ```
 
 #### Correct Pattern
-1. Run single poll (no sleep, no background)
-2. Review results
-3. Relaunch agents if needed
-4. Manually trigger next poll when ready
 
-**Avoid**: Raw SQLite queries, background sleep loops, passive waiting
+1. Run a single poll (no sleep, no background).
+2. Review results.
+3. Relaunch agents for any locale with pending > 0 (same short prompt as step 3).
+4. Manually trigger the next poll when ready.
 
 ### 5. Completion Criteria
 
-A locale is complete when:
-- `--stats` shows 0 pending tasks
-- All tasks status = 'completed' in database
+A locale is complete when `--stats` shows 0 pending tasks (all rows
+`status = 'completed'`).
 
-Do NOT run export until user explicitly requests it.
-
-## Locale-Specific Conventions
-
-See `locales/guides/for-translators/{locale}.md` for each locale's terminology, formality, and style rules.
-
-Available guides: `ls locales/guides/for-translators/`
+Do NOT run export until the user explicitly requests it.
 
 ## Usage Examples
 
@@ -151,64 +144,28 @@ Available guides: `ls locales/guides/for-translators/`
 /d:translate-parallel-agents pt_BR eo --max-agents 5
 ```
 
-## Agent Execution Notes (hard-won)
-
-- **Environment**: no `.env.sh` (the project uses direnv/`.envrc`). The task scripts need
-  no sourcing — run `python3 locales/scripts/i18n tasks ...` directly from the repo root.
-- **One writer per locale, claim-free**: with a single agent per locale, `tasks next {LOCALE}`
-  (next *pending*) → `tasks update {ID}` (completed) advances with zero orphans; skip `--claim`.
-  If you ever run multiple writers on one locale and use `--claim`, reset stranded
-  `in_progress` rows at start (`tasks update {ID} --status pending`); `tasks next` only returns
-  *pending* tasks, so an abandoned claim is otherwise invisible.
-- **Write via temp file, not inline JSON**: apostrophes/quotes (fr/es/it) break shell
-  quoting and HEREDOCs. Write the object to a file and use
-  `tasks update {ID} --file /tmp/trans_{LOCALE}.json --validate`.
-- **`--validate` is advisory**: it warns on missing/extra keys but still saves and exits 0.
-  Agents must read the warnings and re-submit with the exact source key set.
-- **SQLite concurrency**: all locales share one `tasks.db` (`journal_mode=delete`,
-  `busy_timeout=0` by default). Enable WAL once before launching so readers never block the
-  writer: `sqlite3 locales/db/tasks.db "PRAGMA journal_mode=WAL"`. On `database is locked`,
-  wait ~2s and retry.
-- **Verify after draining**: because `--validate` doesn't gate writes, audit completed rows
-  per locale for key-set mismatch, variable/markup preservation, and untranslated-English
-  leakage; fix with `tasks update --file`.
-
 ## Common Mistakes (Avoid These)
 
-1. **Wrong table name**: The SQLite table is `translation_tasks`, NOT `tasks`
-   ```sql
-   -- WRONG: SELECT * FROM tasks
-   -- RIGHT: SELECT * FROM translation_tasks
-   ```
-
-2. **Wrong locale file path**: Source translations live in `./locales/content/`
-   ```bash
-   # WRONG: ls src/locales/ or ls ./generate/
-   # RIGHT: ls ./locales/content/
-   ```
-
-3. **Passive waiting**: Do NOT just wait for agent completion notifications. Actively poll:
-   ```bash
-   # Use this, not raw sqlite3 queries:
-   python3 locales/scripts/i18n tasks next LOCALE --stats
-   ```
-
-4. **Raw database queries**: The task scripts already exist - use them:
-   ```bash
-   # WRONG: sqlite3 locales/db/tasks.db "SELECT COUNT(*) FROM translation_tasks..."
-   # RIGHT: python3 locales/scripts/i18n tasks next LOCALE --stats
-   ```
-
-5. **Forgetting data hydration**: The DB isn't in git - schema alone gives an empty DB. Run `python3 locales/scripts/i18n db init && python3 locales/scripts/i18n db import`.
+1. **Wrong table name**: the SQLite table is `translation_tasks`, NOT `tasks`.
+2. **Wrong locale file path**: source translations live in `./locales/content/`,
+   not `src/locales/` or `./generate/`.
+3. **Passive waiting**: do NOT just wait for completion notifications — actively
+   poll with `tasks next LOCALE --stats`.
+4. **Raw database queries**: use the CLI (`tasks next LOCALE --stats`), not raw
+   `sqlite3` queries.
+5. **Forgetting data hydration**: the DB isn't in git — run
+   `python3 locales/scripts/i18n db init && python3 locales/scripts/i18n db import`.
 
 ## Recovery
 
-If session compacts or disconnects:
-1. Run `--stats` to see current progress
-2. Run `--resume` to restart monitoring
-3. Agents write directly to database, so no work is lost
+If the session compacts or disconnects:
+1. Run `--stats` to see current progress.
+2. Re-check the eligibility gate.
+3. Run `--resume` to restart monitoring. Agents write directly to the database, so
+   no work is lost.
 
 #### Context Window Full
+
 When approaching context limits, use `/compact` with continuation instructions:
 
 ```
@@ -224,6 +181,6 @@ This preserves the orchestration state across compaction.
 ## Completion
 
 When all locales show 0 pending:
-1. Verify with `--stats`
-2. User can then run export: `python3 locales/scripts/i18n tasks export <locale>`
-3. Run validation: `pnpm run locales:sync`
+1. Verify with `--stats`.
+2. User can then run export: `python3 locales/scripts/i18n tasks export <locale>`.
+3. Run validation: `pnpm run locales:sync`.

--- a/locales/slash_commands/translate-parallel-agents.md
+++ b/locales/slash_commands/translate-parallel-agents.md
@@ -46,7 +46,7 @@ every target first and **SKIP + warn** for any locale that lacks it:
 ```bash
 for locale in $LOCALES; do
   f="locales/.resolved/$locale.json"
-  if [ -s "$f" ]; then
+  if [ -f "$f" ] && jq -e '((.register // {}) | length > 0) and ((.glossary // {}) | length > 0)' "$f" >/dev/null 2>&1; then
     echo "ELIGIBLE: $locale"
   else
     echo "SKIP (no resolved governance): $locale — back-port locales/.resolved/$locale.json first"

--- a/locales/slash_commands/translate-parallel-agents.md
+++ b/locales/slash_commands/translate-parallel-agents.md
@@ -60,10 +60,13 @@ Only launch agents for `ELIGIBLE` locales.
 
 ### 1. Initialize Locales
 
-For each eligible locale that doesn't have tasks yet:
+For each eligible locale that doesn't have tasks yet, enqueue only keys still
+untranslated in `content/LOCALE` (`--missing-only`) so a DB rebuild never requeues
+already-translated, reviewed strings. Omit `--missing-only` only to bootstrap a
+brand-new, empty locale:
 
 ```bash
-python3 locales/scripts/i18n tasks create LOCALE
+python3 locales/scripts/i18n tasks create LOCALE --missing-only
 ```
 
 ### 2. Check Current Status

--- a/locales/slash_commands/translate-parallel-agents.md
+++ b/locales/slash_commands/translate-parallel-agents.md
@@ -118,7 +118,13 @@ sleep 120 && check_status  # another background task
 
 1. Run a single poll (no sleep, no background).
 2. Review results.
-3. Relaunch agents for any locale with pending > 0 (same short prompt as step 3).
+3. Relaunch a locale **only if it has pending > 0 AND no agent is currently
+   running for it**. The agent protocol is claim-free, so the task an active
+   agent is mid-translation stays `pending` until it writes back — relaunching
+   purely on `pending > 0` would start a second writer for a locale that already
+   has one, breaking the one-writer-per-locale invariant and letting two agents
+   update the same task. Track the live agents (the in-progress TodoWrite set /
+   the launched task handles) and exclude their locales.
 4. Manually trigger the next poll when ready.
 
 ### 5. Completion Criteria
@@ -171,7 +177,10 @@ When approaching context limits, use `/compact` with continuation instructions:
 ```
 /compact with instructions to continue monitoring translation agents for fr_CA, de, es.
 Poll with: python3 locales/scripts/i18n tasks next LOCALE --stats
-Relaunch agents for any locale with pending > 0.
+Compaction loses the live-agent set, so re-derive which locales still have a
+running agent BEFORE relaunching, then relaunch only locales with pending > 0
+AND no agent currently running — one writer per locale (the queue is claim-free,
+so an in-flight task stays pending until written).
 ```
 
 Then simply: `Please continue`

--- a/locales/slash_commands/translate-workflow.md
+++ b/locales/slash_commands/translate-workflow.md
@@ -9,9 +9,16 @@ disallowed-tools: Bash(git commit:*), Bash(git push:*), Bash(pnpm run locales:sy
 
 This is an **ultracode** command: it deliberately opts into multi-agent
 orchestration. Author a single self-contained `Workflow` script that drains the
-pending `translation_tasks` queue for the targeted locales, audits the completed
-rows, fixes problems in place, and then **stops**. Export, `pnpm sync`, and the
+pending `translation_tasks` queue for the targeted locales, then **stops**. The
+per-task cycle, audit, and all per-locale governance live in files the agents read
+at runtime — this command is orchestration only. Export, `pnpm sync`, and the
 glossary pass are separate human steps — do not run them.
+
+Each translating/auditing agent follows `locales/AGENT_TRANSLATION_PROTOCOL.md`
+exactly and reads its per-locale governance from
+`locales/.resolved/{LOCALE}.json`. Concurrency is owned by the CLI (every
+connection opens WAL with a 30s busy timeout), so there is no WAL/lock setup or
+retry handling here.
 
 ## Entry point (the only one)
 
@@ -20,8 +27,8 @@ python3 locales/scripts/i18n <group> <cmd>        # --help lists: content tasks 
 ```
 
 The older `locales/scripts/tasks/*.py`, `store.py`, and `migrate` paths were
-**consolidated into this CLI**. Ignore them, and ignore the two stale slash
-commands that still reference them.
+**consolidated into this CLI**. Ignore them, and ignore any stale slash commands
+that still reference them.
 
 ## Phase 0 — scout the work-list inline (before authoring the Workflow)
 
@@ -37,57 +44,36 @@ Discover, do not assume. Run these yourself in the main loop first:
 2. **Targets.** If `$ARGUMENTS` is non-empty, use those locale codes verbatim.
    Otherwise auto-detect: enumerate `locales/content/*` dirs and keep those whose
    `i18n tasks next <loc> --stats` reports `pending > 0`.
-3. **Build the queue per target.** `i18n tasks create <loc>` (re)builds
+3. **Eligibility gate.** A locale is eligible for automated drain **only if**
+   `locales/.resolved/<loc>.json` exists with a populated `register` and a
+   populated `glossary` (its governance has been back-ported upstream). For each
+   candidate target, check this and **SKIP + warn** for any locale that lacks it:
+   ```bash
+   [ -s "locales/.resolved/$loc.json" ] || echo "SKIP (no resolved governance): $loc"
+   ```
+   Pass only eligible targets into the Workflow.
+4. **Build the queue per eligible target.** `i18n tasks create <loc>` (re)builds
    `translation_tasks` from `en`. It is **target-blind**: it will not enqueue
    *stale* keys (already translated, but `en` changed since), so `0 pending`
    means "no untranslated keys," **not** "fully current." Note that limitation;
    do not try to work around it here.
-4. **Enable WAL once, before fan-out.** All locales share one `tasks.db`
-   (`journal_mode=delete`, `busy_timeout=0` by default), so concurrent writers
-   collide:
-   ```bash
-   sqlite3 locales/db/tasks.db "PRAGMA journal_mode=WAL"
-   ```
 
-Record the scouted target list + per-locale pending counts; pass them into the
-Workflow as `args`.
+Record the scouted (and eligible) target list + per-locale pending counts; pass
+them into the Workflow as `args`.
 
 ## Phase 1 — author and run the Workflow
 
 Use the `Workflow` tool. Shape:
 
 - `agentType: "saas-translator"` for every translating/auditing agent.
-- **`pipeline()` over the target locales**, one independent chain per locale — no
-  barrier. Each chain is a **loop-until-dry**: `next --json` → translate → write
-  → `update --validate`, repeated until `--stats` shows `pending == 0`.
+- **`pipeline()` over the eligible target locales**, one independent chain per
+  locale — no barrier. Each chain is a **loop-until-dry** drain.
 - A second pipeline stage **audits** each drained locale and fixes in place.
 
-### Per-task cycle (inside each locale's agent — one writer per locale, claim-free)
-
-`next <loc> --json` → translate every value → write the `{"key":"translation"}`
-object (the **EXACT source key set**) to a **per-locale temp file** →
-`tasks update <ID> --file /tmp/trans_<loc>.json --validate`. Then loop.
-
-- **Temp file is mandatory.** Apostrophes/quotes (fr/es/it) break shell quoting
-  and HEREDOCs. Per-locale paths (`/tmp/trans_<loc>.json`) so concurrent agents
-  never clobber each other.
-- **One writer per locale ⇒ skip `--claim`.** `tasks next` returns only *pending*
-  rows, so a single writer advances with zero orphans.
-- **`--validate` is ADVISORY.** It warns on missing/extra keys but still saves and
-  exits 0. **Read the `Warning:` lines** and re-submit with the exact source key
-  set. A completed row's keys must match the source exactly.
-- **Preserve every var/markup token verbatim and in count:** `{var}`, `{{var}}`,
-  `%{var}`, `%s`, `<tag>`.
-- **Conventions:** `locales/guides/for-translators/<loc>.md`. Regional variants
-  fall back to the base guide (e.g. `de_AT` → `de.md`). Brand names stay English
-  (Onetime Secret, Identity Plus, Starlight, …).
-- **On `database is locked`:** wait ~2s and retry (up to 3×).
-
-### Audit stage (after a locale drains)
-
-Because `--validate` does not gate writes, audit the completed rows per locale
-for: (a) key-set match vs source, (b) variable/markup token preservation, and
-(c) untranslated-English leakage. Fix in place via `tasks update --file`.
+The agents own the per-task cycle, the temp-file/`--validate` handling, the audit,
+and all governance — those are defined in `locales/AGENT_TRANSLATION_PROTOCOL.md`
+and `locales/.resolved/<loc>.json`. Keep the per-locale agent prompt short and
+point it at those files; do not re-derive the cycle here.
 
 The glossary pass (step 7 of the manual protocol) is **NOT** part of this drain.
 Leave it.
@@ -101,25 +87,24 @@ export const meta = {
   phases: [{ title: 'Drain' }, { title: 'Audit' }],
 }
 
-const TARGETS = args.targets   // e.g. ["fr_CA","de","es"] — scouted inline
+const TARGETS = args.targets   // e.g. ["fr_CA","de","es"] — scouted + eligible inline
 
 const results = await pipeline(
   TARGETS,
   loc => agent(
-    `Drain ALL pending translation tasks for locale "${loc}" in this repo.\n` +
-    `Loop until \`python3 locales/scripts/i18n tasks next ${loc} --stats\` shows pending:0.\n` +
-    `Each round: tasks next ${loc} --json -> translate -> Write the {"key":"value"} object\n` +
-    `(EXACT source key set) to /tmp/trans_${loc}.json -> tasks update <ID> --file /tmp/trans_${loc}.json --validate.\n` +
-    `--validate only WARNS; read Warning lines and resubmit with the exact key set.\n` +
-    `Preserve {var} {{var}} %{var} %s <tag> verbatim and in count. Brand names stay English.\n` +
-    `Guide: locales/guides/for-translators/${loc}.md (regional variants fall back to base, e.g. de_AT -> de.md).\n` +
-    `On "database is locked" wait ~2s and retry. Return final pending/completed counts.`,
+    `Drain translation tasks for locale "${loc}". ` +
+    `Follow locales/AGENT_TRANSLATION_PROTOCOL.md exactly. ` +
+    `Per-locale governance (register, glossary, binding rules, declined decisions): ` +
+    `locales/.resolved/${loc}.json. ` +
+    `Preserve all interpolation/markup tokens; brand names stay English. ` +
+    `Loop until 0 pending; do not export or commit. Return final pending/completed counts.`,
     { label: `drain:${loc}`, phase: 'Drain', agentType: 'saas-translator' }
   ),
   (_drained, loc) => agent(
-    `Audit completed translation rows for locale "${loc}": key-set match vs source,\n` +
-    `var/markup token preservation ({var} {{var}} %{var} %s <tag>), and untranslated-English leakage.\n` +
-    `Fix any problems in place via tasks update --file /tmp/trans_${loc}.json. Do NOT export or commit.\n` +
+    `Audit completed translation rows for locale "${loc}" per ` +
+    `locales/AGENT_TRANSLATION_PROTOCOL.md (key-set match vs source, token preservation, ` +
+    `untranslated-English leakage), using governance in locales/.resolved/${loc}.json. ` +
+    `Fix any problems in place. Do NOT export or commit. ` +
     `Return: rows audited, rows fixed, and final \`tasks next ${loc} --stats\` pending count.`,
     { label: `audit:${loc}`, phase: 'Audit', agentType: 'saas-translator' }
   )
@@ -130,9 +115,10 @@ return { results }
 
 ## Done
 
-DONE = every targeted locale shows `pending:0` via
+DONE = every targeted (eligible) locale shows `pending:0` via
 `python3 locales/scripts/i18n tasks next <loc> --stats`. Verify this in the main
-loop after the Workflow returns, then report final per-locale counts.
+loop after the Workflow returns, then report final per-locale counts (and list any
+locales skipped for missing resolved governance).
 
 Do **not** export, do **not** `pnpm sync`, do **not** commit.
 

--- a/locales/slash_commands/translate-workflow.md
+++ b/locales/slash_commands/translate-workflow.md
@@ -41,22 +41,29 @@ Discover, do not assume. Run these yourself in the main loop first:
      `tasks next <loc> --stats`), **or**
    - rebuild: `i18n db init` then `i18n db import` (loads committed
      glossary/session_log).
-2. **Targets.** If `$ARGUMENTS` is non-empty, use those locale codes verbatim.
-   Otherwise auto-detect: enumerate `locales/content/*` dirs and keep those whose
-   `i18n tasks next <loc> --stats` reports `pending > 0`.
+2. **Candidate targets.** If `$ARGUMENTS` is non-empty, use those locale codes
+   verbatim; otherwise enumerate `locales/content/*` dirs as candidates. (Do NOT
+   filter on `pending` yet — a fresh or just-imported DB has no task rows, so an
+   eligible untranslated locale would read `pending == 0` and be dropped before
+   its queue is ever built.)
 3. **Eligibility gate.** A locale is eligible for automated drain **only if**
    `locales/.resolved/<loc>.json` exists with a populated `register` and a
    populated `glossary` (its governance has been back-ported upstream). For each
-   candidate target, check this and **SKIP + warn** for any locale that lacks it:
+   candidate, check this and **SKIP + warn** for any locale that lacks it:
    ```bash
    jq -e '((.register // {}) | length > 0) and ((.glossary // {}) | length > 0)' "locales/.resolved/$loc.json" >/dev/null 2>&1 || echo "SKIP (no resolved governance): $loc"
    ```
-   Pass only eligible targets into the Workflow.
-4. **Build the queue per eligible target.** `i18n tasks create <loc>` (re)builds
-   `translation_tasks` from `en`. It is **target-blind**: it will not enqueue
-   *stale* keys (already translated, but `en` changed since), so `0 pending`
-   means "no untranslated keys," **not** "fully current." Note that limitation;
-   do not try to work around it here.
+4. **Refresh each eligible target's queue, THEN filter on pending.** Build the
+   queue before checking pending. Use `--missing-only` so an existing locale
+   enqueues only keys still untranslated in `content/<loc>` and never requeues
+   already-translated, reviewed strings:
+   ```bash
+   i18n tasks create <loc> --missing-only      # per eligible target
+   i18n tasks next <loc> --stats               # keep targets now showing pending > 0
+   ```
+   `tasks create` is still target-blind about *stale* keys (already translated but
+   `en` changed since), so `0 pending` means "no untranslated keys," **not** "fully
+   current" — note that, don't work around it here.
 
 Record the scouted (and eligible) target list + per-locale pending counts; pass
 them into the Workflow as `args`.

--- a/locales/slash_commands/translate-workflow.md
+++ b/locales/slash_commands/translate-workflow.md
@@ -49,7 +49,7 @@ Discover, do not assume. Run these yourself in the main loop first:
    populated `glossary` (its governance has been back-ported upstream). For each
    candidate target, check this and **SKIP + warn** for any locale that lacks it:
    ```bash
-   [ -s "locales/.resolved/$loc.json" ] || echo "SKIP (no resolved governance): $loc"
+   jq -e '((.register // {}) | length > 0) and ((.glossary // {}) | length > 0)' "locales/.resolved/$loc.json" >/dev/null 2>&1 || echo "SKIP (no resolved governance): $loc"
    ```
    Pass only eligible targets into the Workflow.
 4. **Build the queue per eligible target.** `i18n tasks create <loc>` (re)builds


### PR DESCRIPTION
## Summary
Restructures the locale tooling so each layer owns its proper job: the **CLI** owns operational concerns, **files** own domain/workflow knowledge, and the **slash commands** own only agent orchestration.

## Changes
- **CLI owns SQLite concurrency** (`266d1c0`) — `i18n` opens every connection in WAL with a 30s busy timeout; agents no longer need "enable WAL / retry on locked" instructions.
- **Review dirs timestamped** (`b97efa5`) — `review-locale-branches` uses `%Y-%m-%d-%H%M` so same-day runs don't overwrite each other.
- **Review mechanics extracted** (`fe09504`) — Stage 1 (validate) + Stage 3 (consolidate) moved into `locales/scripts/review-locale-branches.sh`; the command keeps only family-grouped agent orchestration + triage.
- **Protocol split** (`e650854`) — `TRANSLATION_PROTOCOL.md` (human) + new `AGENT_TRANSLATION_PROTOCOL.md` (machine); orchestration commands point agents at the machine protocol instead of re-deriving it.
- **`.resolved` vendoring tooling** (`825a660`) — `sync-resolved.sh` regenerates the committed `.resolved/<locale>.json` + guides from a pinned translation-rules checkout; `resolved-freshness.yml` is the SPEC §2.4 freshness/hash gate.
- **Slash commands orchestration-only** (`582567a`) — drop the conventions table, the re-derived workflow, the WAL/lock text, and `for-translators` as the agent source; agents read `.resolved/<locale>.json` behind a resolved-only eligibility gate.

## Remaining / follow-ups
- Run `sync-resolved.sh` to vendor `.resolved/{de_AT,fr,fr_CA}.json` + guides (not yet done).
- Reconcile `resolved-freshness.yml` to the `guides/for-translators/` path and bump its pinned ref.
- Pairs with the translation-rules PR (French back-port + resolver SPEC §2.3 emit-path fix).

## Test
- `db.py` WAL + busy_timeout verified on-disk and via `get_connection()`.
- `review-locale-branches.sh` and `sync-resolved.sh` pass `bash -n`; `resolved-freshness.yml` parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LvBaGsTCowp2apUgFzZHpd

---
_Generated by [Claude Code](https://claude.ai/code/session_01LvBaGsTCowp2apUgFzZHpd)_