### PR TITLE
ci: pin Claude model to claude-sonnet-4-6 on default branch

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -65,8 +65,9 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
-          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
-          # model: "claude-opus-4-20250514"
+          # Pin an explicit model: the action's default (claude-sonnet-4-20250514)
+          # is retired and returns a 404. Bump as newer models ship.
+          model: "claude-sonnet-4-6"
 
           # Direct prompt for automated review (no @claude mention needed)
           direct_prompt: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -54,8 +54,9 @@ jobs:
           additional_permissions: |
             actions: read
 
-          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
-          # model: "claude-opus-4-20250514"
+          # Pin an explicit model: the action's default (claude-sonnet-4-20250514)
+          # is retired and returns a 404. Bump as newer models ship.
+          model: "claude-sonnet-4-6"
 
           # Optional: Customize the trigger phrase (default: @claude)
           # trigger_phrase: "/claude"


### PR DESCRIPTION
## Summary

Ports `develop`'s commit `4365a7573` ("Update Claude model to claude-sonnet-4-6") onto **`main`**, pinning the model in both `claude.yml` and `claude-code-review.yml`. After this change these two files are **byte-identical to `develop`**.

This fixes the consistently-failing Claude PR review workflow. Root cause is two compounding bugs, confirmed from live run logs:

### Bug 1 — workflow divergence (the dominant failure)
`claude-code-action` exchanges its OIDC token for a GitHub App token **only if the running workflow file is byte-identical to the version on the default branch (`main`)**. The model pin was added to `develop` but never to `main`, so every `develop`-based PR fails at token exchange before Claude runs:

```
App token exchange failed: 401 Unauthorized - Workflow validation failed.
The workflow file must exist and have identical content to the version on
the repository's default branch.
```

### Bug 2 — retired default model
`main` left `model:` commented out, so the action fell back to its built-in default `claude-sonnet-4-20250514`, which is retired:

```
API Error: 404 {"type":"not_found_error","message":"model: claude-sonnet-4-20250514"}
```

(Observed in PR #3505, which is `main`-identical so it cleared validation but then 404'd at the model call. The `CLAUDE_CODE_OAUTH_TOKEN` itself is **valid** — auth succeeded; only the model was not found. There is no `fallback_model` configured anywhere.)

### Why this one change fixes both
- Pins a current model → no more 404 (Bug 2).
- Makes `main` == `develop` for these files → `develop`-based PRs pass workflow validation (Bug 1).

## ⚠️ Expected: this PR's own `claude-review` check will fail
Because validation is performed against the **current** default branch, any PR that edits the Claude workflow fails its own check until merged. That is the intended catch-22 — **merge on green elsewhere; the Claude check failing here is expected and is exactly what this PR fixes going forward.** If branch protection blocks the merge on it, an admin override / merge-without-the-check is needed this one time.

## After merge
Once on `main`, re-confirm `develop` (and other long-lived branches) match `main` for these two files so their PRs validate cleanly. The same recipe applies to the other affected repos: the **default branch** must pin a current model and be the canonical copy of the Claude workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XirYeFkGrDMEboiabQAsug)_