### PR TITLE
ci(claude): configurable model selection with fallback (develop)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -13,6 +13,16 @@ on:
       - 'main'
     types: [opened, synchronize, labeled]
   workflow_dispatch:
+    inputs:
+      model:
+        description: "Claude model for this run (overrides the CLAUDE_MODEL repo variable)"
+        type: choice
+        required: false
+        default: claude-sonnet-4-6
+        options:
+          - claude-sonnet-4-6
+          - claude-opus-4-6
+          - claude-haiku-4-5-20251001
 
 jobs:
   claude-review:
@@ -65,9 +75,12 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
-          # Pin an explicit model: the action's default (claude-sonnet-4-20250514)
-          # is retired and returns a 404. Bump as newer models ship.
-          model: "claude-sonnet-4-6"
+          # Primary model precedence: the workflow_dispatch "model" input (manual
+          # runs) -> the CLAUDE_MODEL repo variable -> this built-in default. The
+          # action's frozen default (claude-sonnet-4-20250514) is retired and
+          # 404s. Fall back to Sonnet on overload.
+          model: "${{ inputs.model || vars.CLAUDE_MODEL || 'claude-sonnet-4-6' }}"
+          fallback_model: "${{ vars.CLAUDE_FALLBACK_MODEL || 'claude-sonnet-4-6' }}"
 
           # Direct prompt for automated review (no @claude mention needed)
           direct_prompt: |
@@ -100,7 +113,7 @@ jobs:
       - name: Remove claude-review label
         # Remove label whether success or failure - prevents getting stuck
         if: always() && github.event.action != 'opened'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             try {

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -54,9 +54,12 @@ jobs:
           additional_permissions: |
             actions: read
 
-          # Pin an explicit model: the action's default (claude-sonnet-4-20250514)
-          # is retired and returns a 404. Bump as newer models ship.
-          model: "claude-sonnet-4-6"
+          # Primary model: set the CLAUDE_MODEL repo variable to override without
+          # editing this file. Pinning a current id avoids the action's frozen
+          # default (claude-sonnet-4-20250514), which is retired and 404s. Fall
+          # back to Sonnet if the primary is unavailable or overloaded.
+          model: "${{ vars.CLAUDE_MODEL || 'claude-sonnet-4-6' }}"
+          fallback_model: "${{ vars.CLAUDE_FALLBACK_MODEL || 'claude-sonnet-4-6' }}"
 
           # Optional: Customize the trigger phrase (default: @claude)
           # trigger_phrase: "/claude"


### PR DESCRIPTION
## Summary

Aligns the Claude Code workflows with the canonical `rhales` setup while **preserving this repo's Sonnet default** and its app-specific triggers/guards. Identical change to its paired `main` PR.

> **Paired PR:** this targets `develop`; an identical change targets `main` (the default branch). Both are needed because `issue_comment` / `workflow_dispatch`-triggered runs execute the workflow file from the **default branch**, while most PRs branch from `develop`. Landing it on only one branch leaves the other stale. The Claude workflows are currently byte-identical on `develop` and `main`, so this is a clean cherry-pick.

## Changes

`.github/workflows/claude.yml`
- Make the primary model configurable via `CLAUDE_MODEL` (**default unchanged: `claude-sonnet-4-6`**) instead of a hard-coded id.
- Add `fallback_model` (`CLAUDE_FALLBACK_MODEL` → `claude-sonnet-4-6`) so an unavailable/overloaded primary degrades gracefully instead of failing the check.

`.github/workflows/claude-code-review.yml`
- Same model + fallback config, with a `workflow_dispatch` `model` choice input (precedence: input → `CLAUDE_MODEL` → default).
- Bump `actions/github-script` v7 → v9 in the label-cleanup step.

## Notes

- Sonnet is kept as the default; set the `CLAUDE_MODEL` repo variable to switch to Opus (with automatic Sonnet fallback) without editing the workflow.
- App-specific bits untouched: `pull_request` branch filters, bot/fork `if:` guards, and the SHA-pinned `actions/checkout`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P9DBMriY9snxDUEAG7EJE4

---
_Generated by [Claude Code](https://claude.ai/code/session_01P9DBMriY9snxDUEAG7EJE4)_