### PR TITLE
Phase 2.3–2.4: E2E remediation, signin config, branding, and auth improvements

### DIFF
--- a/src/shared/composables/useSecret.ts
+++ b/src/shared/composables/useSecret.ts
@@ -40,6 +40,12 @@ export function useSecret(secretIdentifier: string, options?: SecretOptions) {
     success: '',
   });
 
+  // Pull the caller's onError out so we can compose it instead of letting the
+  // `...restOptions` spread replace ours. If a caller-supplied onError clobbered
+  // the default, `state.errorCode` would never be set and `isNotFound` would be
+  // permanently false — silently reverting the #3424 404-vs-error disambiguation.
+  const { onError: callerOnError, ...restOptions } = options ?? {};
+
   const defaultAsyncHandlerOptions: AsyncHandlerOptions = {
     notify: (message, severity) => {
       if (severity === 'error') {
@@ -52,8 +58,9 @@ export function useSecret(secretIdentifier: string, options?: SecretOptions) {
     onError: (err) => {
       state.success = '';
       state.errorCode = err.code ?? null;
+      callerOnError?.(err);
     },
-    ...options,
+    ...restOptions,
   };
 
   const { wrap } = useAsyncHandler(defaultAsyncHandlerOptions);

--- a/src/utils/schemaValidation.ts
+++ b/src/utils/schemaValidation.ts
@@ -81,8 +81,12 @@ export function gracefulParse<T>(
   // expose the failing paths as a searchable `schemaField` tag, so the next
   // "no longer available" report names its own cause instead of being inferred.
   //
-  // Only field paths, issue codes, and Zod's type-level messages are logged —
-  // never the offending values — so this stays safe for secret payloads.
+  // We log field paths, issue codes, and Zod's type-level messages — not the
+  // parsed values themselves. One caveat: Zod's `invalid_enum_value` message
+  // embeds the received value (e.g. "...received 'x'"). Today that is safe
+  // because the only enum fields are `state`/`secret_state`, whose values are
+  // non-sensitive state names. If you add an enum over user-supplied data,
+  // redact or drop its message before it reaches Sentry.
   const issues = result.error.issues;
   const fieldPaths = [...new Set(issues.map((i) => i.path.join('.') || '(root)'))];
   const fieldSummary = issues


### PR DESCRIPTION
Feedback for [3517](https://github.com/onetimesecret/onetimesecret/pull/3517). 

## Summary

Comprehensive update addressing E2E test suite remediation (Phases 2.3–2.4), per-domain signin configuration, brand system enhancements, and authentication infrastructure improvements.

### Key Changes

**E2E Test Suite Remediation**
- Added `e2e/global.setup.ts` for centralized auth session management (Phase 2.1)
- Created `e2e/support/env.ts` for documented environment gates
- Added `e2e/QUARANTINE.md` to track flaky tests
- Added `e2e/docs/e2e-remediation-plan.md` documenting the multi-phase remediation strategy
- Updated all E2E test prerequisites to reference `storageState` instead of manual `TEST_USER_*` env vars
- Added `e2e/all/brand-customization.spec.ts` for brand palette CSS variable validation
- Updated `e2e/playwright.config.ts` with global setup project configuration

**Per-Domain Signin Configuration**
- Added `lib/onetime/models/custom_domain/signin_config.rb` — new model for per-domain sign-in method policies
- Added `apps/api/domains/logic/signin_config/` suite:
  - `base.rb`, `get_signin_config.rb`, `put_signin_config.rb`, `delete_signin_config.rb`
  - `audit_logger.rb` for structured logging of signin config changes
- Added corresponding unit tests in `apps/api/domains/spec/logic/signin_config/`
- Updated `apps/api/domains/routes.txt` with new signin config endpoints
- Added locale strings for SSO enforcement notice

**Brand System Architecture**
- Enhanced `lib/onetime/models/custom_domain/brand_settings.rb` with URI validation and expanded constants
- Added `docs/architecture/branding.md` documenting three-tier brand fallback system
- Added `docs/product/branding-favicon.md` for favicon/icon pack guidance
- Added `apps/web/core/logic/page/get_webmanifest.rb` for PWA manifest generation
- Updated `apps/web/core/controllers/page.rb` with webmanifest route
- Enhanced `apps/web/core/views/serializers/config_serializer.rb` to expose brand variables in bootstrap

**Authentication & IP Resolution**
- Removed `lib/onetime/initializers/configure_trusted_proxy.rb` (consolidated into middleware)
- Removed `lib/onetime/helpers/client_ip_helpers.rb` (consolidated into auth helpers)
- Updated `lib/onetime/application/auth_strategies/helpers.rb` with improved IP resolution
- Updated `lib/onetime/application/middleware_stack.rb` with clarified proxy configuration
- Updated `apps/web/auth/spec/unit/helpers_spec.rb` to lock down IP-resolution contract

**Email & Locale Updates**
- Added `lib/onetime/mail/templates/layout.txt.erb` for plain-text email layout
- Updated all email templates to use shared layout (removed redundant footers)
- Updated `lib/onetime/mail/views/base.rb` with layout wrapping control
- Updated locale strings across 20+ languages for branding, domains, and auth features
- Added new locale keys for signin config and SSO enforcement messaging

**Configuration & Infrastructure**
- Added `compose.test.yml` for test service dependencies
- Added `.github/workflows/validate-register.yml` for locale register validation
- Updated `.env.reference` with new config options and changed `EMAILER_SHOW_LOGO` default to `false`
- Updated `Dockerfile` with test build stage
- Updated `install-dev.sh` and `install-test.sh` with new dependencies
- Added `docker/public/.gitignore` for public asset directory

**Documentation & Specs**
- Added `docs/specs/issue-3424-root-cause-analysis.md` for secret availability issue analysis
- Updated `locales/TRANSLATION_PROTOCOL.md` with tooling documentation
- Updated `locales/README.md` with architecture notes
- Updated `.github/

https://claude.ai/code/session_01GD8wPVQtwFK7PSKtnNns7p