### PR TITLE
Add code coverage reporting to GitHub Code Quality

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -291,6 +291,8 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      # Required to upload coverage data to GitHub Code Quality.
+      code-quality: write
 
     services:
       redis: &valkey-service
@@ -314,7 +316,12 @@ jobs:
           - 5672:5672
 
     steps:
-      - *checkout-step
+      # Check out the PR head commit (not the merge commit) so coverage line
+      # numbers map correctly to the diff for GitHub Code Quality.
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Setup Ruby test environment
         uses: ./.github/actions/setup-ruby-test-env
@@ -337,6 +344,11 @@ jobs:
       - name: Generate JSON schemas
         run: pnpm run schemas:json:generate
 
+      # Enable SimpleCov for the test run below. Writing to GITHUB_ENV makes
+      # COVERAGE available to the composite action's `rake spec:fast` process.
+      - name: Enable coverage
+        run: echo "COVERAGE=true" >> "$GITHUB_ENV"
+
       - name: Run Ruby tests
         uses: ./.github/actions/run-ruby-tests
         with:
@@ -345,6 +357,16 @@ jobs:
           rabbitmq-url: 'amqp://guest:guest@localhost:5672'
           results-file: 'rspec_unit_results.json'
           debug-enabled: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
+
+      # Uploads coverage/coverage.xml (Cobertura) to GitHub Code Quality.
+      # Skipped on forked PRs, which cannot write Code Quality data.
+      - name: Upload coverage report
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: actions/upload-code-coverage@v1
+        with:
+          file: coverage/coverage.xml
+          language: Ruby
+          label: code-coverage/rspec
 
   typescript-unit:
     name: T2 · TypeScript Unit Tests
@@ -355,8 +377,17 @@ jobs:
       always() &&
       needs.changes.outputs.typescript == 'true' &&
       (needs.typescript-lint.result == 'success' || needs.typescript-lint.result == 'skipped')
+    permissions:
+      contents: read
+      # Required to upload coverage data to GitHub Code Quality.
+      code-quality: write
     steps:
-      - *checkout-step
+      # Check out the PR head commit (not the merge commit) so coverage line
+      # numbers map correctly to the diff for GitHub Code Quality.
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Setup Node.js environment
         uses: ./.github/actions/setup-node-env
@@ -369,8 +400,18 @@ jobs:
       - name: Generate locale files
         run: pnpm run locales:sync
 
-      - name: Run TypeScript tests
-        run: pnpm test
+      - name: Run TypeScript tests with coverage
+        run: pnpm test:base run --coverage --printConsoleTrace
+
+      # Uploads coverage/cobertura-coverage.xml (Cobertura) to Code Quality.
+      # Skipped on forked PRs, which cannot write Code Quality data.
+      - name: Upload coverage report
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: actions/upload-code-coverage@v1
+        with:
+          file: coverage/cobertura-coverage.xml
+          language: TypeScript
+          label: code-coverage/vitest
 
       - name: Run type checking tests
         continue-on-error: true

--- a/.simplecov
+++ b/.simplecov
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+#
+# SimpleCov configuration, auto-loaded by `require 'simplecov'`.
+#
+# Produces a Cobertura XML coverage report consumed by GitHub Code Quality.
+# Coverage is opt-in via COVERAGE=true so normal/local test runs are
+# unaffected. The unit suite runs across several RSpec processes (unit, cli and
+# per-app specs), so each process gets a unique command name and SimpleCov
+# merges their results into a single coverage/coverage.xml.
+if ENV['COVERAGE'] == 'true'
+  require 'simplecov-cobertura'
+
+  SimpleCov.command_name "rspec:#{Process.pid}"
+  # Keep merged results from earlier RSpec processes valid for the whole job.
+  SimpleCov.merge_timeout 3600
+
+  SimpleCov.start do
+    add_filter %r{/spec/}
+    add_filter %r{/try/}
+    add_filter %r{/tryouts/}
+    formatter SimpleCov::Formatter::CoberturaFormatter
+  end
+end

--- a/Gemfile
+++ b/Gemfile
@@ -164,6 +164,7 @@ group :test do
   gem 'rack-test', require: false
   gem 'rspec', git: 'https://github.com/rspec/rspec'
   gem 'simplecov', require: false
+  gem 'simplecov-cobertura', '~> 3.2', require: false # Cobertura XML output for GitHub Code Quality
   gem 'timecop', '~> 0.9'
   gem 'tryouts', '~> 3.7.1', require: false
   gem 'vcr', '~> 6.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -485,6 +485,9 @@ GEM
       docile (~> 1.1)
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
+    simplecov-cobertura (3.2.0)
+      rexml
+      simplecov (~> 0.19)
     simplecov-html (0.13.2)
     simplecov_json_formatter (0.1.4)
     simpleidn (0.2.3)
@@ -680,6 +683,7 @@ DEPENDENCIES
   sentry-ruby
   sequel (~> 5.0)
   simplecov
+  simplecov-cobertura (~> 3.2)
   solargraph
   sqlite3 (~> 2.0)
   stackprof

--- a/apps/api/invite/spec/spec_helper.rb
+++ b/apps/api/invite/spec/spec_helper.rb
@@ -2,6 +2,10 @@
 #
 # frozen_string_literal: true
 
+# Start code coverage before any application code loads (see .simplecov).
+# Enabled only when COVERAGE=true.
+require 'simplecov' if ENV['COVERAGE'] == 'true'
+
 # Invite API Test Helper
 #
 # Run all invite API tests:

--- a/apps/web/auth/spec/spec_helper.rb
+++ b/apps/web/auth/spec/spec_helper.rb
@@ -2,6 +2,10 @@
 #
 # frozen_string_literal: true
 
+# Start code coverage before any application code loads (see .simplecov).
+# Enabled only when COVERAGE=true.
+require 'simplecov' if ENV['COVERAGE'] == 'true'
+
 # Rodauth Feature Configuration Tests
 #
 # These tests verify that Rodauth features are correctly enabled/disabled

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,10 @@
 # This ensures ConfigResolver uses test configs (spec/*.test.yaml) not production configs.
 ENV['RACK_ENV'] = 'test'
 
+# Start code coverage before any application code is required so the whole
+# codebase is tracked. Enabled only when COVERAGE=true (see .simplecov).
+require 'simplecov' if ENV['COVERAGE'] == 'true'
+
 # Debugging helpers for tests
 #
 # To debug tests with IRB console (debugger):

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -40,6 +40,21 @@ export default defineConfig({
       '**/.{idea,git,cache,output,temp}/**',
       'src/tests/e2e/**', // Playwright E2E tests - run separately
     ],
+    coverage: {
+      provider: 'v8',
+      // Cobertura XML is uploaded to GitHub Code Quality; `text` prints a
+      // summary in the CI log. Only emitted when run with --coverage.
+      reporter: ['text', 'cobertura'],
+      reportsDirectory: 'coverage',
+      all: true, // include untested source files so they report as 0% covered
+      include: ['src/**'],
+      exclude: [
+        'src/tests/**',
+        'src/**/*.spec.ts',
+        'src/**/*.spec.vue',
+        'src/**/*.d.ts',
+      ],
+    },
     setupFiles: [
       'src/tests/setup-env.ts',
       'src/tests/setup-stores.ts',


### PR DESCRIPTION
## Summary

Integrate code coverage reporting into the CI/CD pipeline to upload coverage data to GitHub Code Quality for both Ruby and TypeScript test suites.

## Changes

### Ruby Coverage
- Added `.simplecov` configuration file to generate Cobertura XML reports
- Added `simplecov-cobertura` gem dependency for Cobertura XML output format
- Updated `spec_helper.rb` files to conditionally load SimpleCov when `COVERAGE=true`
- Modified Ruby unit test job to enable coverage via environment variable and upload results to GitHub Code Quality

### TypeScript Coverage
- Updated `vitest.config.ts` to configure coverage reporting with v8 provider
- Modified TypeScript test command to include `--coverage` flag
- Added coverage upload step to TypeScript unit test job

### CI/CD Pipeline
- Added `code-quality: write` permission to both Ruby and TypeScript test jobs
- Updated checkout steps to use PR head commit (not merge commit) for accurate coverage line mapping
- Added conditional upload steps that skip on forked PRs (which cannot write Code Quality data)
- Both jobs now explicitly check out code with proper ref configuration

## Related Issues

<!-- Keywords that auto-close issues when merged: Fixes, Closes, Resolves -->

## Test Plan

CI pipeline will validate:
- SimpleCov configuration loads correctly when `COVERAGE=true`
- Ruby tests generate `coverage/coverage.xml` in Cobertura format
- TypeScript tests generate `coverage/cobertura-coverage.xml` in Cobertura format
- Coverage reports upload successfully to GitHub Code Quality
- Forked PRs skip upload steps without failure

https://claude.ai/code/session_01TfZU5oEacUhSTheXyh5wEe