### PR TITLE
Fix(ci): use a distinct fallback model for Claude workflows

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -78,9 +78,11 @@ jobs:
           # Primary model precedence: the workflow_dispatch "model" input (manual
           # runs) -> the CLAUDE_MODEL repo variable -> this built-in default. The
           # action's frozen default (claude-sonnet-4-20250514) is retired and
-          # 404s. Fall back to Sonnet on overload.
+          # 404s. Fall back to Haiku on overload. The fallback default MUST differ
+          # from the primary default: the action errors with "Fallback model
+          # cannot be the same as the main model" when they resolve to the same id.
           model: "${{ inputs.model || vars.CLAUDE_MODEL || 'claude-sonnet-4-6' }}"
-          fallback_model: "${{ vars.CLAUDE_FALLBACK_MODEL || 'claude-sonnet-4-6' }}"
+          fallback_model: "${{ vars.CLAUDE_FALLBACK_MODEL || 'claude-haiku-4-5-20251001' }}"
 
           # Direct prompt for automated review (no @claude mention needed)
           direct_prompt: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -57,9 +57,11 @@ jobs:
           # Primary model: set the CLAUDE_MODEL repo variable to override without
           # editing this file. Pinning a current id avoids the action's frozen
           # default (claude-sonnet-4-20250514), which is retired and 404s. Fall
-          # back to Sonnet if the primary is unavailable or overloaded.
+          # back to Haiku if the primary is unavailable or overloaded. The fallback
+          # default MUST differ from the primary default: the action errors with
+          # "Fallback model cannot be the same as the main model" otherwise.
           model: "${{ vars.CLAUDE_MODEL || 'claude-sonnet-4-6' }}"
-          fallback_model: "${{ vars.CLAUDE_FALLBACK_MODEL || 'claude-sonnet-4-6' }}"
+          fallback_model: "${{ vars.CLAUDE_FALLBACK_MODEL || 'claude-haiku-4-5-20251001' }}"
 
           # Optional: Customize the trigger phrase (default: @claude)
           # trigger_phrase: "/claude"


### PR DESCRIPTION
## What

Default the Claude GitHub Action `fallback_model` to a model distinct from the primary in both `claude.yml` and `claude-code-review.yml`.

## Why

The `claude-review` check on the v0.26 promote PR (#3525) failed with:

```
Error: Fallback model cannot be the same as the main model.
Please specify a different model for --fallback-model.
```

Both `model` and `fallback_model` defaulted to `claude-sonnet-4-6`, so when neither the `CLAUDE_MODEL` nor `CLAUDE_FALLBACK_MODEL` repo variable is set, the action received identical primary and fallback ids and exited 1.

## Change

- `fallback_model` now defaults to `claude-haiku-4-5-20251001` (distinct from the Sonnet primary) in both workflows.
- Added a comment noting the two defaults must not collapse to the same id again.
- `claude.yml` carried the same latent defect — it only avoided failing because it is gated on an `@claude` mention — so it is fixed here too.

## Notes

- Branched off `main` for a clean, immediate merge to `main`.
- The same fix is also present on the develop-side branch behind PR #3526, so PR #3525's `claude-review` check (which runs from develop's copy of the workflow) turns green once that lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019BLJqpo39VdkW7A6GgWp4j)_