### PR TITLE
Add clarifying comments to OAuth JWT RSA key parsing

### DIFF
--- a/apps/web/auth/config/features/oauth.rb
+++ b/apps/web/auth/config/features/oauth.rb
@@ -278,7 +278,9 @@ module Auth::Config::Features
       private_pem = ENV.fetch('OAUTH_JWT_RSA_PRIVATE_KEY') do
         raise 'OAUTH_JWT_RSA_PRIVATE_KEY must be set when AUTH_OAUTH_ENABLED=true. ' \
               'Generate with: bin/generate_oauth_keys (or `openssl genrsa 2048`).'
-      end.gsub('\n', "\n")
+      end.gsub('\n', "\n") # unescape the single-line .env form back into a
+      # multi-line PEM (mirrors the gsub("\n", '\n') in bin/generate_oauth_keys);
+      # a no-op for raw multi-line values from Docker/K8s secrets.
       private_key = OpenSSL::PKey::RSA.new(private_pem)
       auth.oauth_jwt_keys('RS256' => private_key)
       auth.oauth_jwt_public_keys('RS256' => private_key.public_key)


### PR DESCRIPTION
## Summary

Added clarifying comments to the `gsub('\n', "\n")` call in the OAuth JWT RSA private key configuration to explain its purpose and behavior across different deployment environments.

## Details

The comments document that:
- The `gsub` call unescapes the single-line `.env` form back into a multi-line PEM format
- This mirrors the inverse `gsub("\n", '\n')` operation in `bin/generate_oauth_keys`
- The operation is a no-op for raw multi-line values from Docker/Kubernetes secrets

This improves code maintainability by clarifying why this string transformation is necessary and how it handles different input formats.

## Test Plan

N/A - Documentation-only change with no functional modifications.

https://claude.ai/code/session_01DT8JFAopsSBfmR64FioUaa