### PR TITLE
Address #3239 review feedback: RSA key error, CSRF exemption gating, docs

### DIFF
--- a/apps/api/v1/logic/base.rb
+++ b/apps/api/v1/logic/base.rb
@@ -16,6 +16,20 @@ module V1
       include Onetime::LoggerMethods
       include V1::Logic::UriHelpers
       include Onetime::Security::InputSanitizers
+
+      # AuthorizationPolicies supplies the shared authorization/entitlement
+      # predicates (anonymous_user?, has_system_role?, verify_*!) mixed into
+      # every other API logic base (Onetime::Logic::Base, colonel/, organizations/,
+      # domains/). It is included here as forward-looking foundation for ADR-012
+      # Stage 3 entitlement enforcement in V1.
+      #
+      # NOTE (currently dormant in V1): these helpers are not yet called from V1
+      # logic. require_entitlement! lives in Onetime::Logic::Base — NOT in this
+      # module — and V1::Logic::Base does not inherit from it, so V1's only
+      # entitlement gate (Secrets::BaseSecretAction) is guarded behind
+      # `respond_to?(:auth_org) && auth_org`, which is never true until V1 gains
+      # OrganizationContext. Keep the include so V1 stays aligned with the other
+      # logic bases; remove it only if the ADR-012 V1 rollout is abandoned.
       include Onetime::Application::AuthorizationPolicies
 
       attr_reader :sess, :cust, :params, :locale, :processed_params

--- a/apps/web/auth/config/features/oauth.rb
+++ b/apps/web/auth/config/features/oauth.rb
@@ -294,6 +294,17 @@ module Auth::Config::Features
               'Regenerate with: bin/generate_oauth_keys (or `openssl genrsa 2048`), ' \
               'and ensure the full PEM — including the BEGIN/END lines — is present.'
       end
+
+      # OpenSSL::PKey::RSA.new also parses a PUBLIC-key PEM without error, so an
+      # operator who pastes the public half boots clean and only fails later at
+      # /token (signing needs the private exponent — RSA#sign raises without it).
+      # Fail fast at boot with the same actionable error instead.
+      unless private_key.private?
+        raise 'OAUTH_JWT_RSA_PRIVATE_KEY contains an RSA public key, not a private key. ' \
+              'Provide the full private-key PEM (the block beginning ' \
+              '`-----BEGIN [RSA] PRIVATE KEY-----`); regenerate with: ' \
+              'bin/generate_oauth_keys (or `openssl genrsa 2048`).'
+      end
       auth.oauth_jwt_keys('RS256' => private_key)
       auth.oauth_jwt_public_keys('RS256' => private_key.public_key)
     end

--- a/apps/web/auth/config/features/oauth.rb
+++ b/apps/web/auth/config/features/oauth.rb
@@ -275,13 +275,25 @@ module Auth::Config::Features
       #
       # The public key is derived from the private key — no separate env
       # var. JWKS exposes the public modulus + exponent.
+      #
+      # `gsub('\n', "\n")` reverses the escaping bin/generate_oauth_keys applies
+      # (pem.gsub("\n", '\n')) so the key fits on one line in a .env file. A raw
+      # multi-line PEM — e.g. a Docker/K8s secret — is unaffected: it contains no
+      # literal backslash-n, so both the escaped single-line and the unescaped
+      # multi-line forms load.
       private_pem = ENV.fetch('OAUTH_JWT_RSA_PRIVATE_KEY') do
         raise 'OAUTH_JWT_RSA_PRIVATE_KEY must be set when AUTH_OAUTH_ENABLED=true. ' \
               'Generate with: bin/generate_oauth_keys (or `openssl genrsa 2048`).'
-      end.gsub('\n', "\n") # unescape the single-line .env form back into a
-      # multi-line PEM (mirrors the gsub("\n", '\n') in bin/generate_oauth_keys);
-      # a no-op for raw multi-line values from Docker/K8s secrets.
-      private_key = OpenSSL::PKey::RSA.new(private_pem)
+      end.gsub('\n', "\n")
+      private_key = begin
+        OpenSSL::PKey::RSA.new(private_pem)
+      rescue OpenSSL::PKey::RSAError => ex
+        # A bare OpenSSL "Neither PUB key nor PRIV key" message at boot is
+        # opaque to an operator. Name the env var and the fix instead.
+        raise "OAUTH_JWT_RSA_PRIVATE_KEY is not a valid RSA private key (#{ex.message}). " \
+              'Regenerate with: bin/generate_oauth_keys (or `openssl genrsa 2048`), ' \
+              'and ensure the full PEM — including the BEGIN/END lines — is present.'
+      end
       auth.oauth_jwt_keys('RS256' => private_key)
       auth.oauth_jwt_public_keys('RS256' => private_key.public_key)
     end

--- a/apps/web/auth/spec/unit/oauth_jwt_key_stability_spec.rb
+++ b/apps/web/auth/spec/unit/oauth_jwt_key_stability_spec.rb
@@ -86,4 +86,23 @@ RSpec.describe 'OAuth JWT key stability across boots' do
         .to raise_error(OpenSSL::PKey::RSAError)
     end
   end
+
+  describe 'public-key-only material is distinguishable from a private key' do
+    # OpenSSL::PKey::RSA.new parses a PUBLIC-key PEM without raising, so the
+    # loader can't rely on a parse error to catch an operator who pasted the
+    # public half — signing would then fail at /token instead of at boot.
+    # features/oauth.rb guards on `private_key.private?`; pin that discriminator
+    # so the guard can't silently regress.
+    let(:public_pem) { OpenSSL::PKey::RSA.new(pem).public_key.to_pem }
+
+    it 'parses a public-only PEM but reports private? == false (must be rejected)' do
+      key = OpenSSL::PKey::RSA.new(public_pem)
+      expect(key).to be_a(OpenSSL::PKey::RSA)
+      expect(key.private?).to be(false)
+    end
+
+    it 'reports private? == true for the full keypair (accepted)' do
+      expect(OpenSSL::PKey::RSA.new(pem).private?).to be(true)
+    end
+  end
 end

--- a/apps/web/auth/spec/unit/oauth_jwt_key_stability_spec.rb
+++ b/apps/web/auth/spec/unit/oauth_jwt_key_stability_spec.rb
@@ -47,4 +47,43 @@ RSpec.describe 'OAuth JWT key stability across boots' do
     expect(key).to be_a(OpenSSL::PKey::RSA)
     expect(key.public_key).to be_a(OpenSSL::PKey::RSA)
   end
+
+  # The generator↔loader contract. bin/generate_oauth_keys emits a single-line
+  # value with escaped newlines (pem.gsub("\n", '\n')) so it fits in a .env
+  # file; features/oauth.rb reverses it with gsub('\n', "\n") before
+  # OpenSSL::PKey::RSA.new. Every integration spec seeds a raw multi-line PEM,
+  # so without these examples the escaped-key path the generator actually
+  # produces would be entirely untested — and a regression in either gsub would
+  # ship silently (the original #3239 review finding).
+  describe 'escaped single-line key round-trip (matches bin/generate_oauth_keys)' do
+    # Mirror of the unescape in apps/web/auth/config/features/oauth.rb.
+    def load_pem(raw) = OpenSSL::PKey::RSA.new(raw.gsub('\n', "\n"))
+
+    it 'loads a key escaped exactly as the generator emits it' do
+      escaped = pem.gsub("\n", '\n') # what bin/generate_oauth_keys writes
+      expect(escaped).to include('\n')      # sanity: it really is single-line
+      expect(escaped).not_to include("\n")  # ...with no real newlines
+
+      key = load_pem(escaped)
+      expect(key).to be_a(OpenSSL::PKey::RSA)
+      # Same key material as the multi-line source, not a re-parse artifact.
+      expect(key.to_pem).to eq(pem)
+    end
+
+    it 'still loads an unescaped multi-line PEM unchanged' do
+      key = load_pem(pem)
+      expect(key.to_pem).to eq(pem)
+    end
+  end
+
+  describe 'malformed key handling' do
+    # features/oauth.rb wraps the load in a rescue that re-raises a message
+    # naming OAUTH_JWT_RSA_PRIVATE_KEY and the generator. This pins that a
+    # garbage value raises OpenSSL::PKey::RSAError (the class that rescue
+    # catches), so the operator-facing wrapper keeps firing.
+    it 'raises OpenSSL::PKey::RSAError for a non-PEM value' do
+      expect { OpenSSL::PKey::RSA.new('not-a-key') }
+        .to raise_error(OpenSSL::PKey::RSAError)
+    end
+  end
 end

--- a/docs/authentication/oauth-server.md
+++ b/docs/authentication/oauth-server.md
@@ -204,12 +204,17 @@ The env var accepts a single-line PEM with literal `\n` escapes (`bin/generate_o
 
 ### URI Scheme Restriction
 
+The default depends on the environment: **production defaults to `https` only**; development and test default to `http https` so localhost callbacks work. `OAUTH_VALID_URI_SCHEMES` (a space-separated list) overrides the default in any environment:
+
 ```bash
-# Production: restrict redirect URIs to https
+# Allow http callbacks in a non-production deployment (e.g. staging on http)
+export OAUTH_VALID_URI_SCHEMES="http https"
+
+# Force https-only even outside production
 export OAUTH_VALID_URI_SCHEMES=https
 ```
 
-Default is `"http https"` so localhost callbacks work in development. Tighten in production to block plaintext callbacks from registered clients.
+An `http://` redirect URI is interceptable, letting an attacker steal the authorization code before PKCE verification — which is why production refuses it by default.
 
 ### Revoking a Client
 
@@ -228,9 +233,49 @@ WHERE oauth_application_id = (
 
 ### CSRF Bypass for Programmatic Endpoints
 
-The endpoints in `OAUTH_NO_CSRF_PATHS` (`/token`, `/userinfo`, `/revoke`, `/jwks`) bypass rodauth's CSRF check because they are reached programmatically without a browser session. PKCE, client authentication on `/token`, and Bearer authentication on `/userinfo` provide protocol-level equivalents. `/authorize` is **not** in this set — it is browser-driven and keeps CSRF protection.
+The programmatic IdP endpoints — `/auth/token`, `/auth/userinfo`, `/auth/revoke`, `/auth/jwks`, and `/auth/.well-known/*` — are exempt from OTS's Rack-level CSRF check (`Rack::Protection::AuthenticityToken`) because SP clients reach them without a browser session. PKCE, client authentication on `/token`, and Bearer authentication on `/userinfo` provide protocol-level equivalents. `/authorize` is **not** exempt — it is browser-driven (the resource owner POSTs the consent form) and keeps CSRF protection.
 
-See `apps/web/auth/config/features/oauth.rb:200-209` for the override; the prefix-mismatch reason this override exists is documented in [rodauth-prefix-mismatch.md](../../apps/web/auth/docs/rodauth-prefix-mismatch.md).
+The exemption is **gated on `AUTH_OAUTH_ENABLED`**: when the IdP is off these paths are not mounted and receive no bypass, so an unrelated future route at one of those paths cannot silently inherit a CSRF exemption. See the `allow_if` block in `lib/onetime/middleware/security.rb`.
+
+At the rodauth layer only `/revoke` needs an explicit `check_csrf?` override — the gem inverts RFC 7009 and would otherwise enforce CSRF on the form-encoded revoke call; see `apps/web/auth/config/features/oauth.rb`. The mount-prefix reason the gem's own per-endpoint exemptions line up with the browser-absolute path is documented in [rodauth-prefix-mismatch.md](../../apps/web/auth/docs/rodauth-prefix-mismatch.md).
+
+## Troubleshooting
+
+### `OAUTH_JWT_RSA_PRIVATE_KEY is not a valid RSA private key` at boot
+
+The env var is set but does not contain a parseable RSA PEM. Common causes: the value was truncated, the `-----BEGIN/END-----` lines are missing, or a public key (not a private key) was pasted. Both forms are accepted — a raw multi-line PEM, or the escaped single-line form (`...\n...`) that `bin/generate_oauth_keys` emits — so you do not need to convert between them. Regenerate and re-paste the full block:
+
+```bash
+bin/generate_oauth_keys >> .env
+```
+
+### `OAUTH_JWT_RSA_PRIVATE_KEY must be set when AUTH_OAUTH_ENABLED=true`
+
+The feature flag is on but no signing key is present. Generate one (above). The key is required — without it the IdP cannot sign ID tokens or JWT access tokens.
+
+### Discovery `issuer` is wrong / SP rejects the ID token issuer
+
+By default the `issuer` is derived as `base_url` + the auth mount prefix (e.g. `https://example.com/auth`). Behind a proxy or with a non-default external URL it can resolve to the wrong host, and SP-side issuer validation will then fail. Pin it explicitly:
+
+```bash
+export OAUTH_ISSUER=https://id.example.com/auth
+```
+
+### Refresh token is never issued
+
+`offline_access` must survive the scope intersection. It has to be present in **all three** places: the client's `/authorize` request, the server allow-list (`oauth_application_scopes`), and the client's own `scopes` column in `oauth_applications`. Missing from any one of them and rodauth-oauth strips it, and with `:oidc` enabled no refresh token is issued.
+
+### `/authorize` rejects a client with `invalid_request` (no PKCE)
+
+PKCE is mandatory (`oauth_require_pkce true`): every client must send a `code_challenge` using `S256`. The `plain` method is rejected outright by migration `010`'s CHECK constraint.
+
+### CSRF `403` on `/token`, `/userinfo`, `/revoke`, or `/jwks`
+
+The CSRF exemption for these endpoints is gated on `AUTH_OAUTH_ENABLED`. If you see a `403` from the Rack CSRF layer, confirm the flag is actually `true` in the running process — when it is off the bypass is intentionally inactive.
+
+### Migrations `008`/`009`/`010` fail to apply
+
+They must run in order against the auth database (`010` adds a CHECK constraint to the table `009` creates). Confirm the auth DB URL is reachable and that earlier auth migrations (`001`+) already applied. See the migration files under `apps/web/auth/migrations/`.
 
 ## Local Development
 

--- a/lib/onetime/middleware/security.rb
+++ b/lib/onetime/middleware/security.rb
@@ -159,12 +159,22 @@ Onetime::Middleware::Security.middleware_components = {
         # would let a malicious page silently issue authorization codes to
         # an attacker-controlled client. Pure-API SP clients call /authorize
         # via redirect, not POST, so CSRF is irrelevant for them.
-        path = req.path.chomp('/')
-        return true if path == '/auth/token'
-        return true if path == '/auth/userinfo'
-        return true if path == '/auth/revoke'
-        return true if path == '/auth/jwks'
-        return true if req.path.start_with?('/auth/.well-known/')
+        #
+        # Gated on oauth_enabled?: these exemptions are only safe because the
+        # IdP owns these exact paths. When AUTH_OAUTH_ENABLED is off the OAuth
+        # routes are not mounted, so the only thing the bypass could do is hand
+        # an unrelated future route at one of these paths a silent CSRF
+        # exemption. Scoping to oauth_enabled? keeps the exemption tracking the
+        # feature that justifies it (#3239 review). The check is cheap —
+        # feature_enabled? short-circuits to false unless auth runs in full mode.
+        if Onetime.auth_config&.oauth_enabled?
+          path = req.path.chomp('/')
+          return true if path == '/auth/token'
+          return true if path == '/auth/userinfo'
+          return true if path == '/auth/revoke'
+          return true if path == '/auth/jwks'
+          return true if req.path.start_with?('/auth/.well-known/')
+        end
 
         false
       },

--- a/spec/integration/all/csrf_enforcement_spec.rb
+++ b/spec/integration/all/csrf_enforcement_spec.rb
@@ -289,6 +289,59 @@ RSpec.describe 'CSRF Enforcement', type: :integration do
       end
     end
 
+    describe 'OAuth/OIDC IdP endpoints bypass CSRF only when the IdP is enabled' do
+      # The exemptions for /auth/token, /userinfo, /revoke, /jwks and
+      # /.well-known/* are gated on Onetime.auth_config.oauth_enabled? so a
+      # future unrelated route sharing one of those paths can't inherit a CSRF
+      # bypass while the IdP is off (#3239 review). Drive the proc directly,
+      # stubbing the flag, rather than depending on ambient test config.
+      let(:allow_if) do
+        Onetime::Middleware::Security.middleware_components['AuthenticityToken'][:options][:allow_if]
+      end
+
+      # Programmatic IdP endpoints reached by SP clients, not the browser.
+      exempt_paths = %w[
+        /auth/token
+        /auth/userinfo
+        /auth/revoke
+        /auth/jwks
+        /auth/.well-known/openid-configuration
+        /auth/.well-known/oauth-authorization-server
+      ]
+
+      context 'when the IdP is enabled' do
+        before { allow(Onetime.auth_config).to receive(:oauth_enabled?).and_return(true) }
+
+        exempt_paths.each do |p|
+          it "bypasses CSRF for #{p}" do
+            env = { 'PATH_INFO' => p, 'REQUEST_METHOD' => 'POST' }
+            expect(allow_if.call(env)).to be true
+          end
+        end
+
+        it 'normalizes a trailing slash on exact-match paths (/auth/token/)' do
+          env = { 'PATH_INFO' => '/auth/token/', 'REQUEST_METHOD' => 'POST' }
+          expect(allow_if.call(env)).to be true
+        end
+
+        it 'does NOT bypass CSRF for /auth/authorize (browser-driven consent POST)' do
+          env = { 'PATH_INFO' => '/auth/authorize', 'REQUEST_METHOD' => 'POST' }
+          expect(allow_if.call(env)).to be false
+        end
+      end
+
+      context 'when the IdP is disabled' do
+        before { allow(Onetime.auth_config).to receive(:oauth_enabled?).and_return(false) }
+
+        exempt_paths.each do |p|
+          it "enforces CSRF for #{p} (no silent bypass for an unrelated route)" do
+            env = { 'PATH_INFO' => p, 'REQUEST_METHOD' => 'POST' }
+            expect(allow_if.call(env)).to be false
+          end
+        end
+      end
+    end
+
     describe 'non-API web routes enforce CSRF' do
       it 'POST to /feedback API route bypasses CSRF' do
         response = @mock_request.post('/api/v2/feedback', {


### PR DESCRIPTION
## Summary

Stacked on top of `feature/3104-idp` (PR #3239). Addresses the remaining review feedback on the OAuth2/OIDC IdP work, plus closes a real test gap and corrects some doc drift. Four focused commits; the IdP stays gated behind `AUTH_OAUTH_ENABLED`, so nothing here changes default behaviour.

## What's in here

**`fix(oauth)`: actionable error for an invalid RSA signing key**
- `OpenSSL::PKey::RSA.new` raised a bare `Neither PUB key nor PRIV key` at boot when `OAUTH_JWT_RSA_PRIVATE_KEY` was malformed. Wrapped it to re-raise naming the env var and the regeneration path.
- Closes a genuine test gap: every integration spec seeds a *multi-line* PEM, but `bin/generate_oauth_keys` actually emits an *escaped single-line* key. The `\n` round-trip — the original Gemini finding — was untested. Pinned the generator↔loader contract (escaped + multi-line both load, material preserved) and the malformed-key error class in `oauth_jwt_key_stability_spec.rb`.

**`fix(security)`: gate OAuth CSRF exemptions on `AUTH_OAUTH_ENABLED`**
- The Rack-level CSRF bypass for `/auth/token|userinfo|revoke|jwks|.well-known/*` was registered unconditionally. While the IdP is off those paths aren't mounted, so it's inert today — but it's a latent hazard: a future unrelated route at one of those paths would silently inherit a CSRF bypass. Scoped it to `Onetime.auth_config&.oauth_enabled?`. Added `csrf_enforcement_spec` coverage for both states.

**`docs(oauth)`: troubleshooting + correct stale notes**
- New Troubleshooting section in the operator guide (invalid/missing RSA key, wrong discovery issuer, refresh-token scope intersection, mandatory PKCE, CSRF 403s, migration ordering).
- Corrected two now-stale claims: the URI-scheme default (production is already https-only) and the CSRF section (referenced a non-existent `OAUTH_NO_CSRF_PATHS`; now describes the Rack-level, flag-gated reality).

**`docs(api)`: clarify the V1 `AuthorizationPolicies` include**
- The include arrived via an ADR-012 commit with an inaccurate rationale ("for `require_entitlement!`" — which lives in `Onetime::Logic::Base`, not in that module, and isn't reachable in V1). Replaced it with an accurate note: forward-looking ADR-012 foundation, currently dormant in V1, kept to stay aligned with the other logic bases. No behaviour change.

## Test plan

Run under Ruby 3.4.9 / RSpec 4.0.0.beta1:

- [x] `bundle exec rspec apps/web/auth/spec/unit/oauth_jwt_key_stability_spec.rb` — 6 examples, 0 failures (incl. escaped-key round-trip + malformed-key)
- [x] `bundle exec rspec spec/integration/all/csrf_enforcement_spec.rb` — 51 examples, 0 failures (IdP paths bypassed when enabled, trailing-slash normalised, `/authorize` never bypassed, all six paths enforce CSRF when the IdP is disabled)

## Notes

- Base is `feature/3104-idp` so this shows only the four review-response commits and merges back into #3239.
- The stale Gemini `\n` thread on #3239 was already addressed in that branch's code and has been resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0138TDJUAfbz61aLi7KhaiyF

---
_Generated by [Claude Code](https://claude.ai/code/session_0138TDJUAfbz61aLi7KhaiyF)_