### PR TITLE
ci(i18n): decouple translation-rules data ref from the derive action pin (variable + dispatch override)

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -71,14 +71,15 @@
     },
   ],
 
-  // Track the pinned translation-rules commit in BOTH derive gates, bumping
-  // each to the latest vX.Y.Z release tag and keeping their PINNED_RULES_REF in
-  // lockstep:
+  // Bump the translation-rules DATA ref (TRANSLATION_RULES_REF) in both derive
+  // gates to the latest vX.Y.Z release tag:
   //   - resolved-derive-gate.yml (authority freshness/integrity)
   //   - validate-register.yml    (cross-locale content register lint)
-  // The regex matches the `<sha> # vX.Y.Z` release form both gates now use. The
-  // `uses:` action digest is handled by the built-in github-actions manager
-  // (helpers:pinGitHubActionDigests).
+  // This is the human-readable tag the derive action resolves at run time — a
+  // bare tag string, not a digest. The separate `uses:` action digest (the code
+  // that runs) is pinned to a SHA and bumped by the built-in github-actions
+  // manager (helpers:pinGitHubActionDigests). Two independent axes that normally
+  // land on the same release.
   customManagers: [
     {
       customType: 'regex',
@@ -86,7 +87,7 @@
         '^\\.github/workflows/(resolved-derive-gate|validate-register)\\.yml$',
       ],
       matchStrings: [
-        'PINNED_RULES_REF:\\s+(?<currentDigest>[a-f0-9]{40})\\s+#\\s+(?<currentValue>v\\d+\\.\\d+\\.\\d+)',
+        'TRANSLATION_RULES_REF:\\s+(?<currentValue>v\\d+\\.\\d+\\.\\d+)',
       ],
       depNameTemplate: 'onetimesecret/translation-rules',
       datasourceTemplate: 'github-tags',

--- a/.github/workflows/resolved-derive-gate.yml
+++ b/.github/workflows/resolved-derive-gate.yml
@@ -10,10 +10,12 @@
 # governance does not lint clean, this fails — so the app can never pin to a
 # broken authority commit.
 #
-# The single canonical translation-rules pin is PINNED_RULES_REF below, kept in
-# lockstep with the `uses:` action ref (a literal SHA is required there). Bump
-# deliberately; #38 wires Renovate to bump it automatically against
-# translation-rules' vX.Y.Z release tags.
+# Two separate axes, not one pin: the derive ACTION pin (`uses:` digest — the
+# tool that runs, a literal SHA is required there) and the translation-rules REF
+# (TRANSLATION_RULES_REF below — the rules/engine data it derives). Both live in
+# the translation-rules repo and Renovate normally bumps each to the same vX.Y.Z
+# tag (#38), but they are tracked independently and the ref can be overridden
+# per-run (repo variable / dispatch input) without moving the action pin.
 
 name: resolved-derive-gate
 
@@ -27,17 +29,34 @@ on:
     paths:
       - 'locales/content/**'
       - '.github/workflows/resolved-derive-gate.yml'
-  # Allow manual verification on any branch (e.g. before this lands on main).
-  workflow_dispatch: {}
+  # Allow manual verification on any branch (e.g. before this lands on main),
+  # optionally against a candidate translation-rules ref before pinning it.
+  workflow_dispatch:
+    inputs:
+      rules_ref:
+        description: >-
+          Override the translation-rules ref (40-hex SHA or vX.Y.Z) for this run
+          only. Blank → repo variable TRANSLATION_RULES_REF → the in-file
+          default. Does NOT change the derive action pin in `uses:`.
+        required: false
+        type: string
 
 permissions:
   contents: read
 
 env:
-  # Canonical translation-rules pin. Keep in lockstep with the `uses:` ref below;
-  # Renovate bumps both to the latest vX.Y.Z release (renovate.json5 customManager
-  # for this line; built-in github-actions manager for the `uses:` digest).
-  PINNED_RULES_REF: 658c4109b629ffb7d1926a7c8c00e2c08076228a # v0.1.1
+  # The translation-rules VERSION (rules + resolver engine) this gate derives and
+  # lints. Distinct from the derive ACTION pin in `uses:` below (the tool that
+  # runs, a literal SHA is required there). Renovate normally bumps both to the
+  # same vX.Y.Z release — customManager for this line, built-in github-actions
+  # manager for the `uses:` digest — but they are independent axes, and this ref
+  # can be overridden per-run via the TRANSLATION_RULES_REF repo variable or the
+  # rules_ref dispatch input.
+  #
+  # A human-readable vX.Y.Z tag (not a digest): the derive action resolves it to
+  # a commit at run time. The supply-chain pin is the `uses:` digest; this is the
+  # readable, first-party data version. Renovate's customManager bumps the tag.
+  TRANSLATION_RULES_REF: v0.1.1
 
 jobs:
   resolved-derive-gate:
@@ -46,11 +65,34 @@ jobs:
       - name: Checkout app repo
         uses: actions/checkout@v4
 
-      - name: Derive + lint all governed locales at the pin
+      - name: Resolve translation-rules ref
+        # Precedence: dispatch input → repo variable → in-file default. Each
+        # candidate is passed through an env var (never interpolated into the
+        # shell) and the winner is shape-checked to a 40-hex SHA or vX.Y.Z tag
+        # before use. This only selects the data/engine ref; the derive action
+        # pin in the next step's `uses:` is a separate, fixed literal.
+        env:
+          DISPATCH_REF: ${{ github.event.inputs.rules_ref }}
+          VAR_REF: ${{ vars.TRANSLATION_RULES_REF }}
+          DEFAULT_REF: ${{ env.TRANSLATION_RULES_REF }}
+        run: |
+          set -euo pipefail
+          if   [ -n "${DISPATCH_REF}" ]; then ref="${DISPATCH_REF}"; src="dispatch input"
+          elif [ -n "${VAR_REF}" ];      then ref="${VAR_REF}";      src="repo variable"
+          else                                ref="${DEFAULT_REF}";  src="in-file default"
+          fi
+          if ! printf '%s' "${ref}" | grep -Eq '^([0-9a-f]{40}|v[0-9]+\.[0-9]+\.[0-9]+)$'; then
+            echo "::error::invalid translation-rules ref '${ref}' (want 40-hex SHA or vX.Y.Z)"
+            exit 1
+          fi
+          echo "::notice::translation-rules ref = ${ref} (source: ${src})"
+          echo "EFFECTIVE_RULES_REF=${ref}" >> "$GITHUB_ENV"
+
+      - name: Derive + lint all governed locales at the resolved ref
         id: derive
         uses: onetimesecret/translation-rules/.github/actions/derive@658c4109b629ffb7d1926a7c8c00e2c08076228a # v0.1.1
         with:
-          ref: ${{ env.PINNED_RULES_REF }}
+          ref: ${{ env.EFFECTIVE_RULES_REF }}
           locales: all
           emit: md,json
           lint: 'true'
@@ -58,14 +100,18 @@ jobs:
           # derived from translation-rules; ignored, regenerated each run.
           emit-dir: generated/i18n
 
-      - name: Assert the derive ran at the canonical pin
+      - name: Assert the derive resolved the requested ref to a commit
+        # source-commit is the requested ref (tag or SHA) resolved to a concrete
+        # commit by the action. A non-empty 40-hex SHA proves the derive ran and
+        # resolved our ref; the logged `ref → commit` mapping records exactly
+        # which translation-rules commit this run was evaluated against.
         env:
           GOT: ${{ steps.derive.outputs.source-commit }}
-          WANT: ${{ env.PINNED_RULES_REF }}
+          REF: ${{ env.EFFECTIVE_RULES_REF }}
         run: |
           set -euo pipefail
-          if [ "$GOT" != "$WANT" ]; then
-            echo "::error::derive ran at ${GOT}, expected canonical pin ${WANT}"
+          if ! printf '%s' "${GOT}" | grep -Eq '^[0-9a-f]{40}$'; then
+            echo "::error::derive did not resolve ${REF} to a commit (source-commit='${GOT}')"
             exit 1
           fi
-          echo "resolved-derive-gate: derived + linted at canonical pin ${GOT}"
+          echo "resolved-derive-gate: derived + linted at translation-rules ${REF} → ${GOT}"

--- a/.github/workflows/resolved-derive-gate.yml
+++ b/.github/workflows/resolved-derive-gate.yml
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout app repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Resolve translation-rules ref
         # Precedence: dispatch input → repo variable → in-file default. Each
@@ -71,6 +71,10 @@ jobs:
         # shell) and the winner is shape-checked to a 40-hex SHA or vX.Y.Z tag
         # before use. This only selects the data/engine ref; the derive action
         # pin in the next step's `uses:` is a separate, fixed literal.
+        #
+        # NOTE: this resolve+validate block is intentionally duplicated verbatim
+        # in .github/workflows/validate-register.yml. A composite action would add
+        # more indirection than it saves for ~15 lines; keep the two copies in sync.
         env:
           DISPATCH_REF: ${{ github.event.inputs.rules_ref }}
           VAR_REF: ${{ vars.TRANSLATION_RULES_REF }}
@@ -81,8 +85,18 @@ jobs:
           elif [ -n "${VAR_REF}" ];      then ref="${VAR_REF}";      src="repo variable"
           else                                ref="${DEFAULT_REF}";  src="in-file default"
           fi
-          if ! printf '%s' "${ref}" | grep -Eq '^([0-9a-f]{40}|v[0-9]+\.[0-9]+\.[0-9]+)$'; then
-            echo "::error::invalid translation-rules ref '${ref}' (want 40-hex SHA or vX.Y.Z)"
+          # bash =~ matches the WHOLE string; grep -E '^...$' anchors per LINE, so a
+          # multiline value whose first line looks valid (e.g. "v1.2.3\n::error::x")
+          # slips past grep and reaches the ::notice:: echo and the GITHUB_ENV write
+          # below — an injection sink. Whole-string matching rejects it outright.
+          if [[ ! "${ref}" =~ ^([0-9a-fA-F]{40}|v[0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
+            # Keep the rejected value OUT of the ::error:: workflow command: it is
+            # unvalidated input and could carry newlines or ::workflow-command::
+            # sequences the runner would interpret from the log stream. The
+            # annotation stays constant; the raw value is shown on a plain line,
+            # shell-escaped (%q) so any control characters render inert.
+            echo "::error::invalid translation-rules ref (want 40-hex SHA or vX.Y.Z); rejected value printed below"
+            printf 'rejected ref (escaped): %q\n' "${ref}"
             exit 1
           fi
           echo "::notice::translation-rules ref = ${ref} (source: ${src})"
@@ -110,8 +124,13 @@ jobs:
           REF: ${{ env.EFFECTIVE_RULES_REF }}
         run: |
           set -euo pipefail
-          if ! printf '%s' "${GOT}" | grep -Eq '^[0-9a-f]{40}$'; then
-            echo "::error::derive did not resolve ${REF} to a commit (source-commit='${GOT}')"
+          # Whole-string match (see the resolve step's note on grep's per-line gap).
+          if [[ ! "${GOT}" =~ ^[0-9a-f]{40}$ ]]; then
+            # ${REF} is already shape-validated (safe to interpolate). ${GOT} is the
+            # action's raw output and only reaches this branch when malformed, so
+            # keep it out of the ::error:: command and print it shell-escaped (%q).
+            echo "::error::derive did not resolve ${REF} to a commit; malformed source-commit printed below"
+            printf 'source-commit (escaped): %q\n' "${GOT}"
             exit 1
           fi
           echo "resolved-derive-gate: derived + linted at translation-rules ${REF} → ${GOT}"

--- a/.github/workflows/validate-register.yml
+++ b/.github/workflows/validate-register.yml
@@ -56,17 +56,36 @@ on:
   # full scan for verifying the burndown.
   schedule:
     - cron: '0 6 * * 1'
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      rules_ref:
+        description: >-
+          Override the translation-rules ref (40-hex SHA or vX.Y.Z) for this run
+          only. Blank → repo variable TRANSLATION_RULES_REF → the in-file
+          default. Does NOT change the derive action pin in `uses:`.
+        required: false
+        type: string
 
 permissions:
   contents: read
 
 env:
-  # Canonical translation-rules pin, kept in lockstep with the `uses:` ref below
-  # (a literal SHA is required there) and with resolved-derive-gate.yml. The
-  # `<sha> # vX.Y.Z` form is what Renovate's customManager (renovate.json5)
-  # tracks, bumping both gates to the latest vX.Y.Z release (#38).
-  PINNED_RULES_REF: 658c4109b629ffb7d1926a7c8c00e2c08076228a # v0.1.1
+  # The translation-rules VERSION to evaluate against — the register rules and
+  # resolver engine (lib/resolver/lint_content.py) the derive action checks out
+  # at `ref:`. This is a DIFFERENT axis from the derive ACTION pin in `uses:`
+  # below: that pins the tool that runs (a literal SHA is required there); this
+  # pins the data + engine it runs against. Both live in the translation-rules
+  # repo, so Renovate normally bumps each to the same vX.Y.Z tag — but they are
+  # tracked independently now (customManager for this line; the built-in
+  # github-actions manager for the `uses:` digest), and only this ref can be
+  # floated per-run via the TRANSLATION_RULES_REF repo variable or the rules_ref
+  # dispatch input, without disturbing the action pin.
+  #
+  # A human-readable vX.Y.Z tag (not a digest): translation-rules is first-party
+  # and the derive action resolves the tag to a commit at run time, so this is a
+  # readability/ergonomics choice, not a supply-chain pin. The supply-chain pin
+  # is the `uses:` digest. Renovate's customManager bumps this tag string.
+  TRANSLATION_RULES_REF: v0.1.1
 
 jobs:
   validate-register:
@@ -79,11 +98,34 @@ jobs:
           # changed locales (the scope step below).
           fetch-depth: 0
 
-      - name: Derive resolved registers for all governed locales at the pin
+      - name: Resolve translation-rules ref
+        # Precedence: dispatch input → repo variable → in-file default. Each
+        # candidate is passed through an env var (never interpolated into the
+        # shell) and the winner is shape-checked to a 40-hex SHA or vX.Y.Z tag
+        # before use. This only selects the data/engine ref; the derive action
+        # pin in the next step's `uses:` is a separate, fixed literal.
+        env:
+          DISPATCH_REF: ${{ github.event.inputs.rules_ref }}
+          VAR_REF: ${{ vars.TRANSLATION_RULES_REF }}
+          DEFAULT_REF: ${{ env.TRANSLATION_RULES_REF }}
+        run: |
+          set -euo pipefail
+          if   [ -n "${DISPATCH_REF}" ]; then ref="${DISPATCH_REF}"; src="dispatch input"
+          elif [ -n "${VAR_REF}" ];      then ref="${VAR_REF}";      src="repo variable"
+          else                                ref="${DEFAULT_REF}";  src="in-file default"
+          fi
+          if ! printf '%s' "${ref}" | grep -Eq '^([0-9a-f]{40}|v[0-9]+\.[0-9]+\.[0-9]+)$'; then
+            echo "::error::invalid translation-rules ref '${ref}' (want 40-hex SHA or vX.Y.Z)"
+            exit 1
+          fi
+          echo "::notice::translation-rules ref = ${ref} (source: ${src})"
+          echo "EFFECTIVE_RULES_REF=${ref}" >> "$GITHUB_ENV"
+
+      - name: Derive resolved registers for all governed locales at the resolved ref
         id: derive
         uses: onetimesecret/translation-rules/.github/actions/derive@658c4109b629ffb7d1926a7c8c00e2c08076228a # v0.1.1
         with:
-          ref: ${{ env.PINNED_RULES_REF }}
+          ref: ${{ env.EFFECTIVE_RULES_REF }}
           locales: all
           # Only the .resolved/<locale>.json registers are needed here. The
           # authority-model lint (examples + embedded docs) is a separate
@@ -96,17 +138,21 @@ jobs:
           emit-dir: generated/i18n
           checkout-path: .translation-rules
 
-      - name: Assert the derive ran at the canonical pin
+      - name: Assert the derive resolved the requested ref to a commit
+        # source-commit is the requested ref (tag or SHA) resolved to a concrete
+        # commit by the action. A non-empty 40-hex SHA proves the derive ran and
+        # resolved our ref; the logged `ref → commit` mapping records exactly
+        # which translation-rules commit this run was evaluated against.
         env:
           GOT: ${{ steps.derive.outputs.source-commit }}
-          WANT: ${{ env.PINNED_RULES_REF }}
+          REF: ${{ env.EFFECTIVE_RULES_REF }}
         run: |
           set -euo pipefail
-          if [ "$GOT" != "$WANT" ]; then
-            echo "::error::derive ran at ${GOT}, expected canonical pin ${WANT}"
+          if ! printf '%s' "${GOT}" | grep -Eq '^[0-9a-f]{40}$'; then
+            echo "::error::derive did not resolve ${REF} to a commit (source-commit='${GOT}')"
             exit 1
           fi
-          echo "validate-register: derived resolved registers at canonical pin ${GOT}"
+          echo "validate-register: derived resolved registers at translation-rules ${REF} → ${GOT}"
 
       - name: Lint shipped content against each locale's resolved register
         env:

--- a/.github/workflows/validate-register.yml
+++ b/.github/workflows/validate-register.yml
@@ -92,7 +92,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout app repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           # Full history so a PR run can diff against its base SHA to find the
           # changed locales (the scope step below).
@@ -104,6 +104,10 @@ jobs:
         # shell) and the winner is shape-checked to a 40-hex SHA or vX.Y.Z tag
         # before use. This only selects the data/engine ref; the derive action
         # pin in the next step's `uses:` is a separate, fixed literal.
+        #
+        # NOTE: this resolve+validate block is intentionally duplicated verbatim
+        # in .github/workflows/resolved-derive-gate.yml. A composite action would
+        # add more indirection than it saves for ~15 lines; keep the copies in sync.
         env:
           DISPATCH_REF: ${{ github.event.inputs.rules_ref }}
           VAR_REF: ${{ vars.TRANSLATION_RULES_REF }}
@@ -114,8 +118,18 @@ jobs:
           elif [ -n "${VAR_REF}" ];      then ref="${VAR_REF}";      src="repo variable"
           else                                ref="${DEFAULT_REF}";  src="in-file default"
           fi
-          if ! printf '%s' "${ref}" | grep -Eq '^([0-9a-f]{40}|v[0-9]+\.[0-9]+\.[0-9]+)$'; then
-            echo "::error::invalid translation-rules ref '${ref}' (want 40-hex SHA or vX.Y.Z)"
+          # bash =~ matches the WHOLE string; grep -E '^...$' anchors per LINE, so a
+          # multiline value whose first line looks valid (e.g. "v1.2.3\n::error::x")
+          # slips past grep and reaches the ::notice:: echo and the GITHUB_ENV write
+          # below — an injection sink. Whole-string matching rejects it outright.
+          if [[ ! "${ref}" =~ ^([0-9a-fA-F]{40}|v[0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
+            # Keep the rejected value OUT of the ::error:: workflow command: it is
+            # unvalidated input and could carry newlines or ::workflow-command::
+            # sequences the runner would interpret from the log stream. The
+            # annotation stays constant; the raw value is shown on a plain line,
+            # shell-escaped (%q) so any control characters render inert.
+            echo "::error::invalid translation-rules ref (want 40-hex SHA or vX.Y.Z); rejected value printed below"
+            printf 'rejected ref (escaped): %q\n' "${ref}"
             exit 1
           fi
           echo "::notice::translation-rules ref = ${ref} (source: ${src})"
@@ -148,8 +162,13 @@ jobs:
           REF: ${{ env.EFFECTIVE_RULES_REF }}
         run: |
           set -euo pipefail
-          if ! printf '%s' "${GOT}" | grep -Eq '^[0-9a-f]{40}$'; then
-            echo "::error::derive did not resolve ${REF} to a commit (source-commit='${GOT}')"
+          # Whole-string match (see the resolve step's note on grep's per-line gap).
+          if [[ ! "${GOT}" =~ ^[0-9a-f]{40}$ ]]; then
+            # ${REF} is already shape-validated (safe to interpolate). ${GOT} is the
+            # action's raw output and only reaches this branch when malformed, so
+            # keep it out of the ::error:: command and print it shell-escaped (%q).
+            echo "::error::derive did not resolve ${REF} to a commit; malformed source-commit printed below"
+            printf 'source-commit (escaped): %q\n' "${GOT}"
             exit 1
           fi
           echo "validate-register: derived resolved registers at translation-rules ${REF} → ${GOT}"


### PR DESCRIPTION
Closes #3540
Upstream doc follow-up: onetimesecret/translation-rules#48

## What & why

The register gates (`validate-register.yml`, `resolved-derive-gate.yml`) fused two unrelated axes into a single `PINNED_RULES_REF` SHA:

- the **derive action code** that runs in CI (`uses: …/derive@<sha>`) — a supply-chain control, and
- the **translation-rules data + resolver engine** the action derives (`ref:`) — first-party data we bump often (register exceptions, false-positive fixes, new governed locales).

This decouples them so the data version can move independently, and a candidate translation-rules release can be dry-run against the corpus before the app commits to it.

## Changes

- **Derive action pin** — unchanged: stays a SHA digest in `uses:` (Renovate built-in github-actions manager). `uses:` cannot take an expression, so this is irreducibly literal.
- **translation-rules ref** — now `TRANSLATION_RULES_REF`, a human-readable `vX.Y.Z` tag, resolved per run with precedence **`workflow_dispatch` input `rules_ref` → repo variable `vars.TRANSLATION_RULES_REF` → in-file default**.
- **Resolve step** selects + shape-validates the ref (40-hex SHA or `vX.Y.Z`). Candidate values pass through `env:` vars, never interpolated into the shell — preserves the "no injection vectors" property from the prior security review of these gates.
- **Assertion** relaxed from `source-commit == pin` to "derive resolved the ref to a concrete commit" + logged `ref → commit`. A tag can't string-equal the resolved SHA, and the two-SHA-lockstep check is obsoleted now that there's a single `ref:` source.
- **Renovate** customManager now matches the bare `TRANSLATION_RULES_REF: vX.Y.Z` tag (no digest); the `uses:` digest stays on the built-in manager.

Steady state is unchanged: with the repo variable unset and no dispatch override, both gates run at the in-file `v0.1.1`, Renovate-bumped, in lockstep with the action pin. The override is opt-in.

## No upstream code change

The derive action at `v0.1.1` already accepts a tag in `ref:` and resolves it to a commit via `git rev-parse HEAD` (ref-type agnostic), emitting `source-commit`. translation-rules#48 is a docs-only follow-up to make that consumer contract (tag immutability + action/data-ref back-compat) explicit.

## Test plan

- [ ] CI: both gates green on this PR (they run on `.github/workflows/*` changes — a full-corpus scan, since the gate files changed).
- [ ] Workflow logs show `::notice::translation-rules ref = v0.1.1 (source: in-file default)` and the assertion line `… → 658c4109b…`.
- [ ] `Actions → validate-register → Run workflow` with `rules_ref` blank → resolves to `v0.1.1`; with `rules_ref = <a tag/SHA>` → resolves to that ref (visible in the notice line).
- [ ] Renovate dry-run / next run still proposes translation-rules bumps against the `TRANSLATION_RULES_REF` line.
