### PR TITLE
ci(i18n): tolerate quoted TRANSLATION_RULES_REF in Renovate customManager

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -87,7 +87,10 @@
         '^\\.github/workflows/(resolved-derive-gate|validate-register)\\.yml$',
       ],
       matchStrings: [
-        'TRANSLATION_RULES_REF:\\s+(?<currentValue>v\\d+\\.\\d+\\.\\d+)',
+        // Optional quotes tolerated: the workflows emit the bare form
+        // (TRANSLATION_RULES_REF: v0.1.1), but a quoted value ('v0.1.1' or
+        // "v0.1.1") must still match so auto-bumps don't silently stop.
+        'TRANSLATION_RULES_REF:\\s+["\']?(?<currentValue>v\\d+\\.\\d+\\.\\d+)["\']?',
       ],
       depNameTemplate: 'onetimesecret/translation-rules',
       datasourceTemplate: 'github-tags',


### PR DESCRIPTION
Follow-up to #3541 (deferred item 3).

## Problem
The Renovate `customManager` that bumps the translation-rules DATA ref keys
its regex on the **bare** emitted form:

```
TRANSLATION_RULES_REF:\s+(?<currentValue>v\d+\.\d+\.\d+)
```

The two derive gates currently emit exactly that (`TRANSLATION_RULES_REF: v0.1.1`),
so it works today. But it's latent-fragile: if anyone ever quotes the value
(`'v0.1.1'` or `"v0.1.1"`), the match silently fails and auto-bumps stop with
no error — the ref just goes stale.

## Fix
Make the surrounding quote optional:

```
TRANSLATION_RULES_REF:\s+["']?(?<currentValue>v\d+\.\d+\.\d+)["']?
```

Bare and quoted forms both match and extract the same `currentValue`. The
workflows continue to emit the bare form — **no behavior change today**, just
removes a silent-failure trap.

## Verification
- Regex matches all three forms (`bare`, `'…'`, `"…"`) → extracts `v0.1.1`.
- `.github/renovate.json5` parses cleanly via `JSON5.parse` (the `\'` escape
  inside the single-quoted matchString is valid).

Closes the last open nit from the #3541 handoff; items 1 (`declare -A` bash-4)
and 2 (`DEFAULT_REF` reads workflow `env`) were assessed as best-left-closed.