### PR TITLE
[#3486] fix(jobs): sync email fallback no longer 500s on delivery failure

### DIFF
--- a/apps/api/account/logic/authentication/reset_password_request.rb
+++ b/apps/api/account/logic/authentication/reset_password_request.rb
@@ -65,10 +65,11 @@ module AccountAPI::Logic
         # Best-effort delivery (issue #3486). With background jobs enabled the
         # email is queued; with jobs disabled (the default) it is delivered
         # synchronously. Either way the publisher logs/reports a delivery failure
-        # (Sentry) rather than raising — the reset secret is already persisted,
-        # the user can request another, and we return a generic response
-        # regardless to avoid leaking account existence or delivery status.
-        Onetime::Jobs::Publisher.enqueue_email(
+        # (Sentry) rather than raising — the reset secret is already persisted
+        # and the user can request another. We return the same generic response
+        # whether or not delivery succeeds, so the result never reveals delivery
+        # status.
+        queued = Onetime::Jobs::Publisher.enqueue_email(
           :password_request,
           {
             email_address: cust.email,
@@ -78,12 +79,17 @@ module AccountAPI::Logic
           fallback: :sync,
         )
 
-        auth_logger.info 'Password reset email dispatched',
+        # `queued` is true when handed to RabbitMQ, false when the publisher fell
+        # back to best-effort delivery (sync/thread). A synchronous delivery
+        # failure is reported by the publisher, not here, so this records the
+        # attempt without asserting the message was actually delivered.
+        auth_logger.info 'Password reset email dispatch requested',
           {
             customer_id: cust.extid,
             email: cust.obscure_email,
             session_id: safe_session_id,
             secret_identifier: secret.identifier,
+            queued: queued,
           }
 
         success_data

--- a/apps/api/account/logic/authentication/reset_password_request.rb
+++ b/apps/api/account/logic/authentication/reset_password_request.rb
@@ -62,7 +62,12 @@ module AccountAPI::Logic
               status: :pending,
             }
 
-          send_verification_email
+          # send_verification_email defaults to the request-context cust, which
+          # is nil in this unauthenticated flow. Pass the looked-up customer
+          # explicitly so the verification secret binds to the right account
+          # (PR #3545 review) — otherwise this 500s instead of returning the
+          # intended generic success.
+          send_verification_email(customer: cust)
           return success_data
         end
 

--- a/apps/api/account/logic/authentication/reset_password_request.rb
+++ b/apps/api/account/logic/authentication/reset_password_request.rb
@@ -62,40 +62,29 @@ module AccountAPI::Logic
             token: token&.slice(0, 8), # Only log first 8 chars for debugging
           }
 
-        begin
-          # Critical auth flow: use sync fallback to ensure email is sent
-          # User is waiting for password reset, blocking is acceptable
-          Onetime::Jobs::Publisher.enqueue_email(
-            :password_request,
-            {
-              email_address: cust.email,
-              secret: secret,
-              locale: locale || cust.locale || OT.default_locale,
-            },
-            fallback: :sync,
-          )
-        rescue StandardError => ex
-          errmsg = "Couldn't send the notification email. Let know below."
-          auth_logger.error 'Password reset email delivery failed',
-            {
-              customer_id: cust.extid,
-              email: cust.obscure_email,
-              error: ex.message,
-              session_id: safe_session_id,
-            }
+        # Best-effort delivery (issue #3486). With background jobs enabled the
+        # email is queued; with jobs disabled (the default) it is delivered
+        # synchronously. Either way the publisher logs/reports a delivery failure
+        # (Sentry) rather than raising — the reset secret is already persisted,
+        # the user can request another, and we return a generic response
+        # regardless to avoid leaking account existence or delivery status.
+        Onetime::Jobs::Publisher.enqueue_email(
+          :password_request,
+          {
+            email_address: cust.email,
+            secret: secret,
+            locale: locale || cust.locale || OT.default_locale,
+          },
+          fallback: :sync,
+        )
 
-          set_error_message(errmsg)
-        else
-          auth_logger.info 'Password reset email sent',
-            {
-              customer_id: cust.extid,
-              email: cust.obscure_email,
-              session_id: safe_session_id,
-              secret_identifier: secret.identifier,
-            }
-
-          set_info_message "We sent instructions to #{cust.objid}"
-        end
+        auth_logger.info 'Password reset email dispatched',
+          {
+            customer_id: cust.extid,
+            email: cust.obscure_email,
+            session_id: safe_session_id,
+            secret_identifier: secret.identifier,
+          }
 
         success_data
       end

--- a/apps/api/account/logic/authentication/reset_password_request.rb
+++ b/apps/api/account/logic/authentication/reset_password_request.rb
@@ -20,10 +20,15 @@ module AccountAPI::Logic
       end
 
       def raise_concerns
-        return if valid_email?(@login_or_email) && Onetime::Customer.exists?(@login_or_email)
+        # Security (CWE-204): email enumeration prevention. Validate only the
+        # email FORMAT here — do NOT check account existence in the validation
+        # layer. Existence is handled in #process, which returns the same generic
+        # response whether or not the account exists, so a non-existent address
+        # is indistinguishable from a registered one (mirrors CreateAccount). A
+        # malformed address is a fact the caller already knows, so rejecting it
+        # leaks nothing.
+        return if valid_email?(@login_or_email)
 
-        # A generic error is raised for either an invalid email format or a non-existent
-        # account. This is to prevent attackers from enumerating valid accounts.
         raise_form_error 'Invalid email address', field: 'email', error_type: 'invalid'
       end
 
@@ -32,7 +37,22 @@ module AccountAPI::Logic
         # which obviously makes it available to other methods and potentially
         # leaks data. This reset password request logic is sensitive and not
         # authenticated, so be careful about what is returned or logged.
-        cust = Onetime::Customer.load @login_or_email
+        #
+        # Security (CWE-204): raise_concerns validated only the email format, so
+        # a well-formed address for a non-existent account reaches here. We
+        # perform side effects only for a real account and return the same
+        # generic response in every case, so the result never reveals whether the
+        # account exists. (Response timing still differs and is a weaker residual
+        # channel not addressed here.)
+        cust = Onetime::Customer.find_by_email(@login_or_email)
+
+        if cust.nil?
+          # Unregistered address: do nothing observable, return the same generic
+          # response a real account would get.
+          auth_logger.info 'Password reset requested for unregistered email',
+            { session_id: safe_session_id }
+          return success_data
+        end
 
         if cust.pending?
           auth_logger.info 'Resending verification email for pending customer',
@@ -43,8 +63,7 @@ module AccountAPI::Logic
             }
 
           send_verification_email
-          msg = "#{I18n.t('web.COMMON.verification_sent_to', locale: @locale)} #{cust.objid}."
-          return set_info_message(msg)
+          return success_data
         end
 
         secret                    = Onetime::Secret.create! @login_or_email, [@login_or_email]

--- a/apps/api/account/spec/logic/authentication/reset_password_request_spec.rb
+++ b/apps/api/account/spec/logic/authentication/reset_password_request_spec.rb
@@ -1,0 +1,96 @@
+# apps/api/account/spec/logic/authentication/reset_password_request_spec.rb
+#
+# frozen_string_literal: true
+#
+# Unit tests for ResetPasswordRequest, focused on the email-delivery contract
+# after issue #3486: a fallback: :sync delivery failure must not 500 the
+# request, and the flow returns a generic success response regardless (so it
+# never leaks account existence or delivery status).
+#
+# Run with:
+#   source .env.test && bundle exec rspec apps/api/account/spec/logic/authentication/reset_password_request_spec.rb
+
+require_relative File.join(Onetime::HOME, 'spec', 'spec_helper')
+require 'account/logic'
+
+RSpec.describe AccountAPI::Logic::Authentication::ResetPasswordRequest do
+  let(:email) { 'user@example.com' }
+  let(:session) { { 'id' => 'sess-123', 'csrf' => 'csrf-token' } }
+  let(:strategy_result) do
+    double('StrategyResult',
+      session: session,
+      user: nil, # Unauthenticated reset request
+      authenticated?: false,
+      auth_method: :noauth,
+      metadata: {})
+  end
+  let(:params) { { 'login' => email } }
+
+  subject(:logic) { described_class.new(strategy_result, params) }
+
+  let(:customer) do
+    double('Customer',
+      extid: 'cust-ext-1',
+      objid: 'cust-obj-1',
+      email: email,
+      obscure_email: 'u***@example.com',
+      locale: 'en')
+  end
+
+  let(:secret) { double('Secret', identifier: 'secret-id-1') }
+
+  before do
+    allow(OT).to receive(:info)
+    allow(OT).to receive(:ld)
+    allow(OT).to receive(:li)
+    allow(OT).to receive(:le)
+    allow(OT).to receive(:default_locale).and_return('en')
+    allow(OT).to receive(:conf).and_return({
+      'site' => { 'authentication' => {} },
+      'features' => {},
+    })
+
+    # Customer lookup, taking the non-pending (normal reset) path
+    allow(Onetime::Customer).to receive(:load).with(email).and_return(customer)
+    allow(customer).to receive(:pending?).and_return(false)
+    allow(customer).to receive(:reset_secret=)
+
+    # Verification secret creation
+    allow(Onetime::Secret).to receive(:create!).and_return(secret)
+    allow(secret).to receive(:default_expiration=)
+    allow(secret).to receive(:verification=)
+    allow(secret).to receive(:save)
+
+    # Quiet the auth logger
+    allow(logic).to receive(:auth_logger).and_return(double('auth_logger').as_null_object)
+  end
+
+  describe '#process email delivery (issue #3486)' do
+    it 'enqueues the reset email with fallback: :sync' do
+      expect(Onetime::Jobs::Publisher).to receive(:enqueue_email).with(
+        :password_request,
+        hash_including(email_address: email, secret: secret),
+        fallback: :sync,
+      )
+
+      logic.process
+    end
+
+    it 'returns a generic success response' do
+      allow(Onetime::Jobs::Publisher).to receive(:enqueue_email)
+
+      expect(logic.process).to include(sent: true)
+    end
+
+    it 'does not raise or change the response when sync delivery fails' do
+      # The publisher swallows/reports a :sync delivery failure (returns false)
+      # rather than raising, so the request still succeeds — the reset secret is
+      # already persisted and the user can request another.
+      allow(Onetime::Jobs::Publisher).to receive(:enqueue_email).and_return(false)
+
+      result = nil
+      expect { result = logic.process }.not_to raise_error
+      expect(result).to include(sent: true)
+    end
+  end
+end

--- a/apps/api/account/spec/logic/authentication/reset_password_request_spec.rb
+++ b/apps/api/account/spec/logic/authentication/reset_password_request_spec.rb
@@ -111,6 +111,35 @@ RSpec.describe AccountAPI::Logic::Authentication::ResetPasswordRequest do
     end
   end
 
+  describe '#process for a pending (unverified) account (PR #3545: nil-customer fix)' do
+    before do
+      allow(customer).to receive(:pending?).and_return(true)
+    end
+
+    it 'returns the same generic success response' do
+      allow(logic).to receive(:send_verification_email)
+
+      expect(logic.process).to include(sent: true)
+    end
+
+    it 'resends verification to the looked-up customer, not the nil request-context cust' do
+      # Regression for the P1: send_verification_email defaults to the
+      # request-context cust (nil here), so the reset flow must pass the
+      # looked-up customer explicitly or it 500s.
+      expect(logic).to receive(:send_verification_email).with(customer: customer)
+
+      logic.process
+    end
+
+    it 'does not create a password-reset secret or send a reset email' do
+      allow(logic).to receive(:send_verification_email)
+      expect(Onetime::Secret).not_to receive(:create!)
+      expect(Onetime::Jobs::Publisher).not_to receive(:enqueue_email)
+
+      logic.process
+    end
+  end
+
   describe '#process email delivery (issue #3486)' do
     it 'enqueues the reset email with fallback: :sync' do
       expect(Onetime::Jobs::Publisher).to receive(:enqueue_email).with(

--- a/apps/api/account/spec/logic/authentication/reset_password_request_spec.rb
+++ b/apps/api/account/spec/logic/authentication/reset_password_request_spec.rb
@@ -4,8 +4,9 @@
 #
 # Unit tests for ResetPasswordRequest, focused on the email-delivery contract
 # after issue #3486: a fallback: :sync delivery failure must not 500 the
-# request, and the flow returns a generic success response regardless (so it
-# never leaks account existence or delivery status).
+# request. Once the account is validated (in raise_concerns), the flow returns
+# the same generic success response whether or not delivery succeeds, so the
+# result never reveals delivery status.
 #
 # Run with:
 #   source .env.test && bundle exec rspec apps/api/account/spec/logic/authentication/reset_password_request_spec.rb

--- a/apps/api/account/spec/logic/authentication/reset_password_request_spec.rb
+++ b/apps/api/account/spec/logic/authentication/reset_password_request_spec.rb
@@ -2,11 +2,16 @@
 #
 # frozen_string_literal: true
 #
-# Unit tests for ResetPasswordRequest, focused on the email-delivery contract
-# after issue #3486: a fallback: :sync delivery failure must not 500 the
-# request. Once the account is validated (in raise_concerns), the flow returns
-# the same generic success response whether or not delivery succeeds, so the
-# result never reveals delivery status.
+# Unit tests for ResetPasswordRequest, covering two security/robustness
+# properties (issue #3486 and PR #3545 review):
+#
+#  1. Email enumeration prevention (CWE-204): raise_concerns validates only the
+#     email format, and #process returns the same generic success response
+#     whether or not the account exists — no secret created and no email sent
+#     for an unregistered address.
+#  2. A fallback: :sync delivery failure must not 500 the request; the response
+#     is identical whether or not delivery succeeds, so it never reveals
+#     delivery status.
 #
 # Run with:
 #   source .env.test && bundle exec rspec apps/api/account/spec/logic/authentication/reset_password_request_spec.rb
@@ -51,8 +56,8 @@ RSpec.describe AccountAPI::Logic::Authentication::ResetPasswordRequest do
       'features' => {},
     })
 
-    # Customer lookup, taking the non-pending (normal reset) path
-    allow(Onetime::Customer).to receive(:load).with(email).and_return(customer)
+    # Customer lookup: default to an existing, non-pending (normal reset) account
+    allow(Onetime::Customer).to receive(:find_by_email).with(email).and_return(customer)
     allow(customer).to receive(:pending?).and_return(false)
     allow(customer).to receive(:reset_secret=)
 
@@ -64,6 +69,46 @@ RSpec.describe AccountAPI::Logic::Authentication::ResetPasswordRequest do
 
     # Quiet the auth logger
     allow(logic).to receive(:auth_logger).and_return(double('auth_logger').as_null_object)
+  end
+
+  describe '#raise_concerns (CWE-204 enumeration prevention)' do
+    it 'does not raise for a well-formed but unregistered email' do
+      allow(logic).to receive(:valid_email?).and_return(true)
+
+      expect { logic.raise_concerns }.not_to raise_error
+    end
+
+    it 'raises only on an invalid email format' do
+      allow(logic).to receive(:valid_email?).and_return(false)
+
+      expect { logic.raise_concerns }.to raise_error(OT::FormError, /Invalid email address/)
+    end
+
+    it 'never checks account existence in the validation layer' do
+      allow(logic).to receive(:valid_email?).and_return(true)
+
+      expect(Onetime::Customer).not_to receive(:find_by_email)
+      expect(Onetime::Customer).not_to receive(:exists?)
+
+      logic.raise_concerns
+    end
+  end
+
+  describe '#process for an unregistered email (CWE-204 enumeration prevention)' do
+    before do
+      allow(Onetime::Customer).to receive(:find_by_email).with(email).and_return(nil)
+    end
+
+    it 'returns the same generic success response as a registered account' do
+      expect(logic.process).to include(sent: true)
+    end
+
+    it 'creates no reset secret and sends no email' do
+      expect(Onetime::Secret).not_to receive(:create!)
+      expect(Onetime::Jobs::Publisher).not_to receive(:enqueue_email)
+
+      logic.process
+    end
   end
 
   describe '#process email delivery (issue #3486)' do

--- a/changelog.d/20260629_000000_claude_3486_sync_fallback_no_500.rst
+++ b/changelog.d/20260629_000000_claude_3486_sync_fallback_no_500.rst
@@ -1,0 +1,13 @@
+.. A new scriv changelog fragment.
+
+Fixed
+-----
+
+- A ``fallback: :sync`` email delivery failure (for example, an unreachable SMTP
+  host while background jobs are disabled) no longer returns HTTP 500 after the
+  underlying record was already persisted. Synchronous fallback delivery now
+  honours its documented contract — it blocks and delivers, logging/reporting a
+  failure instead of raising — so organization invitations, email-change
+  requests, password resets, and Rodauth auth emails degrade gracefully and stay
+  resendable. Use ``fallback: :raise`` when a caller must surface the failure.
+  (#3486)

--- a/changelog.d/20260629_010000_claude_3486_reset_password_enumeration.rst
+++ b/changelog.d/20260629_010000_claude_3486_reset_password_enumeration.rst
@@ -1,0 +1,12 @@
+.. A new scriv changelog fragment.
+
+Security
+--------
+
+- Password-reset requests no longer reveal whether an email address has an
+  account (CWE-204). ``ResetPasswordRequest`` previously returned a generic
+  success for a registered address but raised "Invalid email address" for an
+  unregistered one, which allowed account enumeration. Validation now checks
+  only the email format; a well-formed but unregistered address gets the same
+  generic success response, with no reset secret created and no email sent —
+  matching the existing ``CreateAccount`` behaviour. (#3486)

--- a/changelog.d/20260630_220000_claude_3486_pending_reset_nil_customer.rst
+++ b/changelog.d/20260630_220000_claude_3486_pending_reset_nil_customer.rst
@@ -1,0 +1,12 @@
+.. A new scriv changelog fragment.
+
+Fixed
+-----
+
+- A password-reset request for a pending (unverified) account no longer returns
+  a 500. ``send_verification_email`` bound the verification secret to the
+  request-context customer, which is nil in the unauthenticated reset flow; it
+  now accepts the recipient explicitly (defaulting to ``cust``), so the resend
+  succeeds and the request returns the same generic success as every other case
+  — keeping the password-reset response uniform across registered, pending and
+  unregistered addresses. (#3486)

--- a/lib/onetime/jobs/publisher.rb
+++ b/lib/onetime/jobs/publisher.rb
@@ -439,22 +439,29 @@ module Onetime
         Thread.new do
           deliver_email(email_type, template: template, data: data, raw_email: raw_email, domain_id: domain_id)
         rescue StandardError => ex
-          # Log/report but don't crash - this is fire-and-forget
+          # Fire-and-forget: catch broadly here (unlike :sync) because an
+          # uncaught error would die with the thread and lose the report —
+          # and there is no caller to surface a programming fault to anyway.
           report_delivery_failure(ex, email_type, :async_thread)
         end
         # rubocop:enable ThreadSafety/NewThread
-        #
         logger.info 'Spawned thread for email delivery', email_type: email_type
       end
 
       # Blocking synchronous delivery.
       #
-      # Contract: :sync blocks and delivers, but does NOT raise on a delivery
+      # Contract: :sync blocks and delivers, but does NOT raise on a *delivery*
       # failure. The triggering operation (invitation, email change, password
       # reset, etc.) has already persisted its record before the email step,
-      # and a resend path exists, so a delivery error is logged/reported rather
-      # than propagated as an HTTP 500. Callers that need the failure to
+      # and a resend path exists, so a delivery failure is logged/reported
+      # rather than propagated as an HTTP 500. Callers that need the failure to
       # propagate should use fallback: :raise instead.
+      #
+      # Only Onetime::Mail::DeliveryError is swallowed — that is the type the
+      # mail layer raises for transport/provider failures (SMTP unreachable,
+      # etc.). Any other error is a programming/config fault rather than a
+      # delivery failure, so it propagates and surfaces in dev/test/CI instead
+      # of silently "succeeding".
       #
       # @param email_type [Symbol] :templated or :raw
       # @return [Boolean] true if delivered, false if delivery failed
@@ -469,7 +476,7 @@ module Onetime
         deliver_email(email_type, template: template, data: data, raw_email: raw_email, domain_id: domain_id)
         logger.info 'Sent email synchronously', email_type: email_type
         true
-      rescue StandardError => ex
+      rescue Onetime::Mail::DeliveryError => ex
         report_delivery_failure(ex, email_type, :sync)
         false
       end

--- a/lib/onetime/jobs/publisher.rb
+++ b/lib/onetime/jobs/publisher.rb
@@ -12,12 +12,21 @@ module Onetime
     # Thread-safe RabbitMQ publisher with configurable fallback behavior
     #
     # Uses connection pool for thread safety in multi-threaded environments
-    # like Puma. Fallback behavior is configurable per-call:
+    # like Puma. When a message cannot be enqueued (jobs disabled or RabbitMQ
+    # unavailable), the fallback strategy decides what happens. Configurable
+    # per-call:
     #
-    #   - :async_thread - Spawn a thread to deliver (non-blocking, default)
-    #   - :sync         - Block and deliver synchronously
-    #   - :raise        - Raise an error on failure
-    #   - :none         - Log and return false silently
+    #   - :async_thread - Deliver in a background thread (non-blocking,
+    #                     default). Delivery failures are logged/reported,
+    #                     never raised.
+    #   - :sync         - Block and deliver synchronously. Delivery failures
+    #                     are logged/reported but NOT raised: the record the
+    #                     caller already persisted stands and a resend path
+    #                     exists, so the request should not 500. Use :raise
+    #                     when the caller must surface delivery failures.
+    #   - :raise        - Do not attempt fallback delivery; raise a
+    #                     DeliveryError so the caller can surface/propagate it.
+    #   - :none         - Do not deliver; log and return false silently.
     #
     # Example:
     #   # Default: async thread fallback (best for Puma)
@@ -430,16 +439,25 @@ module Onetime
         Thread.new do
           deliver_email(email_type, template: template, data: data, raw_email: raw_email, domain_id: domain_id)
         rescue StandardError => ex
-          # Log but don't crash - this is fire-and-forget
-          logger.error 'Async thread delivery failed', error: ex.message, backtrace: ex.backtrace.first(5)
+          # Log/report but don't crash - this is fire-and-forget
+          report_delivery_failure(ex, email_type, :async_thread)
         end
         # rubocop:enable ThreadSafety/NewThread
         #
         logger.info 'Spawned thread for email delivery', email_type: email_type
       end
 
-      # Blocking synchronous delivery
+      # Blocking synchronous delivery.
+      #
+      # Contract: :sync blocks and delivers, but does NOT raise on a delivery
+      # failure. The triggering operation (invitation, email change, password
+      # reset, etc.) has already persisted its record before the email step,
+      # and a resend path exists, so a delivery error is logged/reported rather
+      # than propagated as an HTTP 500. Callers that need the failure to
+      # propagate should use fallback: :raise instead.
+      #
       # @param email_type [Symbol] :templated or :raw
+      # @return [Boolean] true if delivered, false if delivery failed
       def send_synchronously(email_type)
         template  = @pending_template
         data      = @pending_data
@@ -450,6 +468,34 @@ module Onetime
 
         deliver_email(email_type, template: template, data: data, raw_email: raw_email, domain_id: domain_id)
         logger.info 'Sent email synchronously', email_type: email_type
+        true
+      rescue StandardError => ex
+        report_delivery_failure(ex, email_type, :sync)
+        false
+      end
+
+      # Log and report a best-effort fallback delivery failure without
+      # propagating it. Shared by the :sync and :async_thread strategies, which
+      # both deliver best-effort: the triggering operation has already
+      # completed, so the failure is recorded (log + Sentry) rather than
+      # raised. Use fallback: :raise when the caller must see the error.
+      #
+      # @param ex [Exception] The delivery error
+      # @param email_type [Symbol] :templated or :raw
+      # @param mode [Symbol] The fallback strategy that was in effect
+      def report_delivery_failure(ex, email_type, mode)
+        logger.error 'Fallback email delivery failed',
+          mode: mode,
+          email_type: email_type,
+          error: ex.message,
+          backtrace: ex.backtrace&.first(5)
+
+        return unless defined?(Sentry) && Sentry.initialized?
+
+        Sentry.capture_exception(ex) do |scope|
+          scope.set_tags(component: 'jobs.publisher', fallback: mode)
+          scope.set_context('email_delivery', { email_type: email_type })
+        end
       end
 
       # Actually deliver the email

--- a/lib/onetime/logic/base.rb
+++ b/lib/onetime/logic/base.rb
@@ -348,29 +348,36 @@ module Onetime
         warn "[set_error_message] #{caller(1..3)}"
       end
 
-      # Requires the implementing class to have cust and session fields
+      # Send (or resend) a verification email.
+      #
+      # @param customer [Onetime::Customer] the recipient. Defaults to the
+      #   request-context `cust`. Unauthenticated flows (e.g. the public
+      #   password-reset request) have a nil `cust`, so they MUST pass the
+      #   looked-up customer explicitly — otherwise the verification secret binds
+      #   to nil and the request 500s.
       #
       # Used by:
-      #   - AccountAPI::Logic::Account::CreateAccount
-      #   - Core::Logic::Authentication::AuthenticateSession
-      def send_verification_email(_token = nil)
+      #   - AccountAPI::Logic::Account::CreateAccount (implicit cust)
+      #   - Core::Logic::Authentication::AuthenticateSession (implicit cust)
+      #   - AccountAPI::Logic::Authentication::ResetPasswordRequest (explicit)
+      def send_verification_email(_token = nil, customer: cust)
         msg = format("Thanks for verifying your account. We got you a secret fortune cookie!\n\n\"%s\"", OT::Utils.random_fortune)
 
-        _receipt, secret = Onetime::Receipt.spawn_pair(cust&.objid, 24.days, msg)
+        _receipt, secret = Onetime::Receipt.spawn_pair(customer&.objid, 24.days, msg)
 
         secret.verification = true
-        secret.custid       = cust.custid
+        secret.custid       = customer.custid
         secret.save
 
         # The reset_secret field is a related standalone dbkey, writes
         # immediately. e.g. customer:abcd1234:reset_secret
-        cust.reset_secret = secret.identifier
+        customer.reset_secret = secret.identifier
 
         begin
           Onetime::Mail::Mailer.deliver(
             :welcome,
             {
-              email_address: cust.email,
+              email_address: customer.email,
               secret: secret,
             },
             locale: locale || 'en',

--- a/spec/integration/all/authentication_security_spec.rb
+++ b/spec/integration/all/authentication_security_spec.rb
@@ -344,14 +344,22 @@ RSpec.describe 'Authentication Security Attack Vectors', type: :integration do
         expect { reset_request_logic.raise_concerns }.to raise_error(OT::FormError, /Invalid email address/)
       end
 
-      it 'protects against email enumeration through error messages' do
+      it 'does not reveal account existence for a valid, unregistered email (CWE-204)' do
         params = { login: 'nonexistent@example.com' }
         reset_request_logic = AccountAPI::Logic::Authentication::ResetPasswordRequest.new(strategy_result, params)
         allow(reset_request_logic).to receive(:valid_email?).and_return(true)
-        allow(Onetime::Customer).to receive(:exists?).and_return(false)
+        allow(Onetime::Customer).to receive(:find_by_email).and_return(nil)
 
-        # Uses the same generic error for non-existent accounts to prevent enumeration
-        expect { reset_request_logic.raise_concerns }.to raise_error(OT::FormError, /Invalid email address/)
+        # A well-formed but unregistered address must be indistinguishable from a
+        # registered one. raise_concerns validates only the format (no raise here
+        # for non-existence — that would leak account existence), and process
+        # returns the same generic success an existing account gets, with no
+        # secret created and no email sent.
+        expect { reset_request_logic.raise_concerns }.not_to raise_error
+
+        expect(Onetime::Secret).not_to receive(:create!)
+        expect(Onetime::Jobs::Publisher).not_to receive(:enqueue_email)
+        expect(reset_request_logic.process).to include(sent: true)
       end
     end
   end

--- a/spec/unit/onetime/jobs/publisher_spec.rb
+++ b/spec/unit/onetime/jobs/publisher_spec.rb
@@ -235,6 +235,42 @@ RSpec.describe Onetime::Jobs::Publisher do
 
         expect(Onetime::Mail).to have_received(:deliver).with(:welcome, { email: 'test@example.com' }, sender_config: nil)
       end
+
+      # Regression for #3486: a :sync delivery failure (e.g. unreachable SMTP)
+      # must not raise out of the publisher. The caller has already persisted
+      # its record, so blocking-and-delivering should degrade gracefully rather
+      # than 500 the request. Contrast with :raise, which propagates.
+      context 'when synchronous delivery fails' do
+        let(:delivery_error) do
+          Onetime::Mail::DeliveryError.new('SMTP unreachable', transient: true)
+        end
+
+        before do
+          allow(Onetime::Mail).to receive(:deliver).and_raise(delivery_error)
+        end
+
+        it 'does not raise to the caller' do
+          expect {
+            publisher.enqueue_email(:welcome, { email: 'test@example.com' }, fallback: :sync)
+          }.not_to raise_error
+        end
+
+        it 'returns false (fallback used, not queued)' do
+          result = publisher.enqueue_email(:welcome, { email: 'test@example.com' }, fallback: :sync)
+
+          expect(result).to be false
+        end
+
+        it 'routes the failure to out-of-band reporting (log + Sentry)' do
+          # Stubbed as a no-op so the assertion is independent of Sentry/logger
+          # state in the test env; the helper's contents are exercised separately.
+          allow(publisher).to receive(:report_delivery_failure)
+
+          publisher.enqueue_email(:welcome, { email: 'test@example.com' }, fallback: :sync)
+
+          expect(publisher).to have_received(:report_delivery_failure).with(delivery_error, :templated, :sync)
+        end
+      end
     end
 
     context 'with fallback: :async_thread (default)' do
@@ -295,6 +331,19 @@ RSpec.describe Onetime::Jobs::Publisher do
         publisher.enqueue_email_raw(raw_email, fallback: :sync)
 
         expect(Onetime::Mail).to have_received(:deliver_raw).with(raw_email, sender_config: nil)
+      end
+
+      # Regression for #3486: the Rodauth delivery hook uses enqueue_email_raw
+      # with fallback: :sync. An unreachable SMTP host must not surface as a 500.
+      it 'does not raise when synchronous raw delivery fails' do
+        allow(Onetime::Mail).to receive(:deliver_raw)
+          .and_raise(Onetime::Mail::DeliveryError.new('SMTP unreachable', transient: true))
+
+        result = nil
+        expect {
+          result = publisher.enqueue_email_raw(raw_email, fallback: :sync)
+        }.not_to raise_error
+        expect(result).to be false
       end
     end
   end
@@ -478,6 +527,19 @@ RSpec.describe Onetime::Jobs::Publisher do
 
           expect(result).to be false
           expect(Onetime::Mail).to have_received(:deliver)
+        end
+
+        # Regression for #3486: even when RabbitMQ is unavailable AND the sync
+        # fallback delivery itself fails, :sync must not raise to the caller.
+        it 'does not raise when the sync fallback delivery also fails' do
+          allow(Onetime::Mail).to receive(:deliver)
+            .and_raise(Onetime::Mail::DeliveryError.new('SMTP unreachable', transient: true))
+
+          result = nil
+          expect {
+            result = publisher.enqueue_email(:welcome, { email: 'test@example.com' }, fallback: :sync)
+          }.not_to raise_error
+          expect(result).to be false
         end
       end
     end

--- a/spec/unit/onetime/jobs/publisher_spec.rb
+++ b/spec/unit/onetime/jobs/publisher_spec.rb
@@ -271,6 +271,18 @@ RSpec.describe Onetime::Jobs::Publisher do
           expect(publisher).to have_received(:report_delivery_failure).with(delivery_error, :templated, :sync)
         end
       end
+
+      # Narrowed rescue (PR #3545 review): only Onetime::Mail::DeliveryError is
+      # swallowed. A non-delivery error (e.g. a template bug) is a programming
+      # fault and must propagate so it surfaces in dev/test/CI instead of the
+      # request silently "succeeding".
+      it 'propagates a non-delivery error instead of swallowing it' do
+        allow(Onetime::Mail).to receive(:deliver).and_raise(NoMethodError.new("undefined method 'foo'"))
+
+        expect {
+          publisher.enqueue_email(:welcome, { email: 'test@example.com' }, fallback: :sync)
+        }.to raise_error(NoMethodError)
+      end
     end
 
     context 'with fallback: :async_thread (default)' do
@@ -344,6 +356,69 @@ RSpec.describe Onetime::Jobs::Publisher do
           result = publisher.enqueue_email_raw(raw_email, fallback: :sync)
         }.not_to raise_error
         expect(result).to be false
+      end
+    end
+  end
+
+  # ==========================================================================
+  # Fallback Delivery Reporting Tests
+  # ==========================================================================
+  # report_delivery_failure is the shared log + Sentry sink for the best-effort
+  # :sync and :async_thread strategies. It must record the failure without
+  # raising, and only touch Sentry when it is initialized.
+  # ==========================================================================
+
+  describe '#report_delivery_failure' do
+    subject(:publisher) { described_class.new }
+
+    let(:error) { Onetime::Mail::DeliveryError.new('SMTP unreachable', transient: true) }
+    let(:logger_double) { double('logger', error: nil) }
+
+    before do
+      allow(publisher).to receive(:logger).and_return(logger_double)
+      # Sentry is require: false; ensure a constant exists with the methods we
+      # stub (self-methods so verify_partial_doubles is satisfied). Default to
+      # not-initialized for determinism across environments.
+      stub_const('Sentry', Module.new do
+        def self.initialized?; end
+
+        def self.capture_exception(_exception); end
+      end)
+      allow(Sentry).to receive(:initialized?).and_return(false)
+      allow(Sentry).to receive(:capture_exception)
+    end
+
+    it 'logs the failure at error level and does not raise' do
+      expect {
+        publisher.send(:report_delivery_failure, error, :templated, :sync)
+      }.not_to raise_error
+
+      expect(logger_double).to have_received(:error).with(
+        'Fallback email delivery failed',
+        hash_including(mode: :sync, email_type: :templated, error: 'SMTP unreachable')
+      )
+    end
+
+    it 'does not capture to Sentry when it is not initialized' do
+      publisher.send(:report_delivery_failure, error, :templated, :sync)
+
+      expect(Sentry).not_to have_received(:capture_exception)
+    end
+
+    context 'when Sentry is initialized' do
+      let(:scope) { double('Sentry::Scope', set_tags: nil, set_context: nil) }
+
+      before do
+        allow(Sentry).to receive(:initialized?).and_return(true)
+        allow(Sentry).to receive(:capture_exception).and_yield(scope)
+      end
+
+      it 'captures the exception with component tags and email context' do
+        publisher.send(:report_delivery_failure, error, :raw, :async_thread)
+
+        expect(Sentry).to have_received(:capture_exception).with(error)
+        expect(scope).to have_received(:set_tags).with(component: 'jobs.publisher', fallback: :async_thread)
+        expect(scope).to have_received(:set_context).with('email_delivery', { email_type: :raw })
       end
     end
   end


### PR DESCRIPTION
When jobs are disabled (the default) or RabbitMQ is unavailable,
Publisher#enqueue_email(..., fallback: :sync) delivered synchronously but
unrescued: an unreachable SMTP host raised out of the publisher and the
request returned HTTP 500 - even though the domain record (invitation,
email-change request, etc.) was already persisted before the email step.

Make :sync honour its documented contract ("block and deliver") as distinct
from :raise ("raise on failure"): send_synchronously now rescues delivery
errors, reports them out-of-band (log + Sentry), and returns false instead
of propagating. This fixes the contract in one place and benefits every
fallback: :sync caller (org invitation create/resend, password reset,
request/resend email change, and the Rodauth delivery hook) - each of which
has a resend or retry path, so the operation degrades gracefully.

:raise, :none, and :async_thread are unchanged; async_thread now shares the
same log/report helper for consistent observability.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01X2v3GNuqwjxudGqz2t4RjQ