### PR TITLE
Make test setup runnable on a fresh clone (install-test.sh + rspec from rubygems)

### DIFF
--- a/.env.test.example
+++ b/.env.test.example
@@ -1,0 +1,28 @@
+# .env.test.example — template for running the test suite
+#
+# Copy to .env.test (install-test.sh does this for you) and fill in only what
+# you need. Most tests need NOTHING here:
+#
+#   - The RSpec unit/fast suites force RACK_ENV=test in spec/spec_helper.rb and
+#     read spec/config.test.yaml, which hardcodes its secrets and the datastore
+#     URI (redis://127.0.0.1:2121/0). install-test.sh starts that datastore.
+#   - Vitest needs no database at all.
+#
+# The variables below are ONLY required for the PostgreSQL-backed integration
+# tests (rake spec:integration:full:postgres). Leave them blank/commented to
+# run the unit suites without Postgres.
+
+# Informational: spec_helper.rb sets this itself; direnv lanes also read it.
+RACK_ENV=test
+
+# ─── PostgreSQL integration tests (optional) ─────────────────────────
+# Superuser URL used by install-test.sh to create the test database and run
+# apps/web/auth/migrations/schemas/postgres/initialize_test_db.sql, which
+# provisions the least-privilege roles below. The database name MUST contain
+# "test" (the init script refuses otherwise).
+#AUTH_DATABASE_URL_TEST_SUPERUSER=postgresql://postgres@localhost:5432/onetime_auth_test
+
+# Runtime (DML-only) and migration (DDL) connections the integration tests use.
+# These match the roles created by initialize_test_db.sql.
+#AUTH_DATABASE_URL=postgresql://onetime_user:testpass@localhost:5432/onetime_auth_test
+#AUTH_DATABASE_URL_MIGRATIONS=postgresql://onetime_migrator:migratepass@localhost:5432/onetime_auth_test

--- a/.gitignore
+++ b/.gitignore
@@ -107,6 +107,7 @@ scripts/api-validation/diffs
 .test-mode
 !.env.example
 !.env.reference
+!.env.test.example
 
 
 # Playwright paths

--- a/Gemfile
+++ b/Gemfile
@@ -162,7 +162,7 @@ group :test do
   gem 'bunny-mock', '~> 1.7', require: false  # Mock RabbitMQ for testing
   gem 'climate_control'
   gem 'rack-test', require: false
-  gem 'rspec', git: 'https://github.com/rspec/rspec'
+  gem 'rspec', '4.0.0.beta1'
   gem 'simplecov', require: false
   gem 'simplecov-cobertura', '~> 3.2', require: false # Cobertura XML output for GitHub Code Quality
   gem 'timecop', '~> 0.9'
@@ -170,8 +170,8 @@ group :test do
   gem 'vcr', '~> 6.0'
   gem 'webmock', '~> 3.0'
 
-  # RSpec components
+  # RSpec components, pinned to match the rspec 4.0.0.beta1 release on rubygems.
   %w[rspec-core rspec-expectations rspec-mocks rspec-support].each do |lib|
-    gem lib, git: 'https://github.com/rspec/rspec', glob: "#{lib}/#{lib}.gemspec"
+    gem lib, '4.0.0.beta1'
   end
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,45 +1,3 @@
-GIT
-  remote: https://github.com/rspec/rspec
-  revision: 1559574cba6d7cb49bdeadacb20ba008390e2981
-  specs:
-    rspec (4.0.0.beta1)
-      rspec-core (= 4.0.0.beta1)
-      rspec-expectations (= 4.0.0.beta1)
-      rspec-mocks (= 4.0.0.beta1)
-
-GIT
-  remote: https://github.com/rspec/rspec
-  revision: 1559574cba6d7cb49bdeadacb20ba008390e2981
-  glob: rspec-core/rspec-core.gemspec
-  specs:
-    rspec-core (4.0.0.beta1)
-      rspec-support (= 4.0.0.beta1)
-
-GIT
-  remote: https://github.com/rspec/rspec
-  revision: 1559574cba6d7cb49bdeadacb20ba008390e2981
-  glob: rspec-expectations/rspec-expectations.gemspec
-  specs:
-    rspec-expectations (4.0.0.beta1)
-      diff-lcs (>= 1.6.0, < 3.0)
-      rspec-support (= 4.0.0.beta1)
-
-GIT
-  remote: https://github.com/rspec/rspec
-  revision: 1559574cba6d7cb49bdeadacb20ba008390e2981
-  glob: rspec-mocks/rspec-mocks.gemspec
-  specs:
-    rspec-mocks (4.0.0.beta1)
-      diff-lcs (>= 1.6.0, < 3.0)
-      rspec-support (= 4.0.0.beta1)
-
-GIT
-  remote: https://github.com/rspec/rspec
-  revision: 1559574cba6d7cb49bdeadacb20ba008390e2981
-  glob: rspec-support/rspec-support.gemspec
-  specs:
-    rspec-support (4.0.0.beta1)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -422,6 +380,19 @@ GEM
       chunky_png (~> 1.0)
       rqrcode_core (~> 2.0)
     rqrcode_core (2.1.0)
+    rspec (4.0.0.beta1)
+      rspec-core (= 4.0.0.beta1)
+      rspec-expectations (= 4.0.0.beta1)
+      rspec-mocks (= 4.0.0.beta1)
+    rspec-core (4.0.0.beta1)
+      rspec-support (= 4.0.0.beta1)
+    rspec-expectations (4.0.0.beta1)
+      diff-lcs (>= 1.6.0, < 3.0)
+      rspec-support (= 4.0.0.beta1)
+    rspec-mocks (4.0.0.beta1)
+      diff-lcs (>= 1.6.0, < 3.0)
+      rspec-support (= 4.0.0.beta1)
+    rspec-support (4.0.0.beta1)
     rubocop (1.86.2)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
@@ -663,11 +634,11 @@ DEPENDENCIES
   rodauth-tools (~> 0.3.1)
   rotp (~> 6.2)
   rqrcode (~> 3.1)
-  rspec!
-  rspec-core!
-  rspec-expectations!
-  rspec-mocks!
-  rspec-support!
+  rspec (= 4.0.0.beta1)
+  rspec-core (= 4.0.0.beta1)
+  rspec-expectations (= 4.0.0.beta1)
+  rspec-mocks (= 4.0.0.beta1)
+  rspec-support (= 4.0.0.beta1)
   rubocop (~> 1.86.0)
   rubocop-performance
   rubocop-rspec

--- a/install-test.sh
+++ b/install-test.sh
@@ -248,9 +248,10 @@ echo "---"
 if [[ -n "$pg_superuser_url" ]] && command -v psql &>/dev/null; then
     echo "Provisioning PostgreSQL test database (integration tests)..."
 
-    # Extract connection parts from the superuser URL.
-    # Parse: postgresql://user[:pass]@host[:port]/dbname
-    pg_db=$(echo "$pg_superuser_url" | sed -E 's|.*://[^/]*/||')
+    # Extract the database name from the superuser URL.
+    # Parse: postgresql://user[:pass]@host[:port]/dbname[?query]
+    # (URI parsing so query params like ?sslmode=require don't leak into the name)
+    pg_db=$(ruby -ruri -e 'puts URI(ARGV.fetch(0)).path.sub(%r{\A/}, "")' "$pg_superuser_url")
 
     # Create the database if it doesn't exist (createdb is idempotent-ish)
     if psql "$pg_superuser_url" -c "SELECT 1" &>/dev/null; then

--- a/install-test.sh
+++ b/install-test.sh
@@ -121,11 +121,13 @@ fi
 
 echo "---"
 echo "Generating merged locale files..."
-if command -v python3 &>/dev/null; then
-    python3 locales/scripts/i18n content compile --all --merged
+# Delegate to the canonical pnpm entry point (python3 i18n content compile --all)
+# so this stays in step with the project rather than re-spelling the CLI flags.
+if pnpm run locales:sync; then
     echo "OK:   Locales generated in generated/locales/"
 else
-    echo "Skip: python3 not found — skipping locale generation"
+    echo "Warning: locale generation failed (pnpm run locales:sync) — continuing."
+    echo "  Some i18n-dependent tests may fail until locales are generated."
 fi
 
 # --- Test datastore on port 2121 -------------------------------------
@@ -204,8 +206,17 @@ ENVRC
     touch .test-mode
     direnv allow .
 else
-    echo "Skip: direnv not installed — tests run without it."
-    echo "  (RACK_ENV=test is forced by spec_helper; the test config is self-contained.)"
+    echo "Skip: direnv not installed — the test suite runs fine without it"
+    echo "      (spec_helper forces RACK_ENV=test and the test config is self-contained)."
+    echo ""
+    echo "Recommended: install direnv to manage environment variables for everyday"
+    echo "  development. It auto-loads .env when you cd into the checkout (dev mode)"
+    echo "  and is the intended way to run the app, the console, and bin/ots:"
+    echo "    - dev setup:  ./install-dev.sh"
+    echo "    - dev server: bin/dev   (or bundle exec puma -C etc/puma.rb)"
+    echo "    - console:    bin/console"
+    echo "    - CLI:        bin/ots <command>"
+    echo "  Install direnv: https://direnv.net/docs/installation.html"
 fi
 
 # --- Optional: .env.test for integration tests -----------------------

--- a/install-test.sh
+++ b/install-test.sh
@@ -2,14 +2,30 @@
 
 # install-test.sh
 #
-# Switches this checkout to test mode:
-#   - Generates .envrc if missing
-#   - Verifies .env.test exists (symlinked from OTS_DEV_CONFIG or present)
-#   - Starts the test Valkey instance on port 2121 (no persistence)
-#   - Creates .test-mode marker so .envrc loads .env.test via direnv
+# Switches this checkout to test mode and makes the RSpec suite runnable on a
+# fresh clone, with no maintainer-private files required.
+#
+# What it does (in order):
+#   - Picks a datastore CLI/server: valkey-* if present, else redis-* (Valkey
+#     is wire-compatible with Redis, and the test config talks plain redis://)
+#   - Verifies the required toolchain (ruby, bundler, pnpm, a datastore)
+#   - Warns if Ruby is older than the Gemfile floor (>= 3.4.7)
+#   - Seeds etc/ config files from etc/defaults/ (mirrors CI)
+#   - Installs Ruby gems and Node dependencies if they are missing
+#   - Starts a throwaway test datastore on port 2121 (no persistence)
 #   - Smoke-tests that config resolves to the test database
 #
-# To switch back to dev mode, run install-dev.sh (removes .test-mode).
+# Optional, only when the relevant tooling/config is present:
+#   - direnv: generates .envrc + a .test-mode marker so `cd` into the checkout
+#     loads .env.test automatically (handy for switching dev/test lanes)
+#   - PostgreSQL: provisions the auth integration database when a superuser URL
+#     is available (via AUTH_DATABASE_URL_TEST_SUPERUSER or .env.test)
+#
+# After this script, the unit/fast suites just work:
+#   pnpm run test:rspec:fast      # RSpec
+#   pnpm test                     # Vitest
+#
+# To switch back to dev mode (removes .test-mode), run install-dev.sh.
 #
 # Idempotent: safe to re-run at any time.
 
@@ -21,10 +37,26 @@ if [[ ! -f "Gemfile" ]]; then
     exit 1
 fi
 
+# --- Datastore CLI/server: prefer Valkey, fall back to Redis ----------
+#
+# The test config (spec/config.test.yaml) connects to redis://127.0.0.1:2121,
+# and Valkey speaks the Redis wire protocol, so redis-server/redis-cli are a
+# drop-in substitute. Honor explicit VALKEY_SERVER/VALKEY_CLI overrides first;
+# the package.json database scripts read the same two variables.
+
+VALKEY_CLI="${VALKEY_CLI:-$(command -v valkey-cli   || command -v redis-cli    || true)}"
+VALKEY_SERVER="${VALKEY_SERVER:-$(command -v valkey-server || command -v redis-server || true)}"
+export VALKEY_CLI VALKEY_SERVER
+
+# --- Required tools ---------------------------------------------------
+
 missing_required=()
-command -v direnv &>/dev/null || missing_required+=("direnv  (Directory environments):  https://direnv.net/docs/installation.html")
+command -v ruby   &>/dev/null || missing_required+=("ruby    (>= 3.4.7):  https://www.ruby-lang.org/")
+command -v bundle &>/dev/null || missing_required+=("bundler (gem install bundler)")
 command -v pnpm   &>/dev/null || missing_required+=("pnpm    (Node package manager):  https://pnpm.io/installation")
-command -v "${VALKEY_CLI:-valkey-cli}" &>/dev/null || missing_required+=("valkey-cli (Valkey CLI client):  https://valkey.io/download/")
+if [[ -z "$VALKEY_CLI" || -z "$VALKEY_SERVER" ]]; then
+    missing_required+=("valkey-server/valkey-cli (or redis-server/redis-cli):  https://valkey.io/download/")
+fi
 if (( ${#missing_required[@]} > 0 )); then
     echo "Error: Required tools missing:"
     for tool in "${missing_required[@]}"; do
@@ -33,11 +65,109 @@ if (( ${#missing_required[@]} > 0 )); then
     exit 1
 fi
 
-# --- .envrc ---------------------------------------------------------
+echo "OK:   datastore -> server '$VALKEY_SERVER', cli '$VALKEY_CLI'"
 
-if [[ ! -f ".envrc" ]]; then
-    echo "Creating .envrc..."
-    cat > ".envrc" << 'ENVRC'
+# --- Ruby version (soft check) ---------------------------------------
+#
+# The Gemfile pins `ruby '>= 3.4.7'`; bundler will refuse to run on anything
+# older. Warn early with an actionable message instead of failing deep inside
+# `bundle install`.
+
+required_ruby="3.4.7"
+current_ruby="$(ruby -e 'print RUBY_VERSION')"
+if ! printf '%s\n%s\n' "$required_ruby" "$current_ruby" | sort -V -C; then
+    echo "Warning: Ruby $current_ruby is older than the Gemfile floor ($required_ruby)."
+    echo "  Install $required_ruby+ with rbenv/rvm/asdf and re-run, or gems will not install."
+else
+    echo "OK:   Ruby $current_ruby satisfies >= $required_ruby"
+fi
+
+# --- Config files from defaults (mirrors CI) -------------------------
+#
+# etc/defaults/*.defaults.<ext> are templates; the app reads etc/*.<ext>.
+# Seed any that are missing so config resolves on a clean checkout.
+
+echo "---"
+echo "Seeding etc/ config from defaults..."
+for file in etc/defaults/*.defaults.*; do
+    [[ -f "$file" ]] || continue
+    target="etc/$(basename "$file" | sed 's/\.defaults//')"
+    if [[ -f "$target" ]]; then
+        echo "OK:   $target exists"
+    else
+        cp "$file" "$target"
+        echo "Copy: $target (from $(basename "$file"))"
+    fi
+done
+
+# --- Dependencies -----------------------------------------------------
+
+echo "---"
+if bundle check &>/dev/null; then
+    echo "OK:   Ruby gems already installed"
+else
+    echo "Installing Ruby gems (bundle install)..."
+    bundle install
+fi
+
+if [[ -d node_modules ]]; then
+    echo "OK:   node_modules present"
+else
+    echo "Installing Node dependencies (pnpm install)..."
+    pnpm install
+fi
+
+# --- Generated locales ------------------------------------------------
+
+echo "---"
+echo "Generating merged locale files..."
+if command -v python3 &>/dev/null; then
+    python3 locales/scripts/i18n content compile --all --merged
+    echo "OK:   Locales generated in generated/locales/"
+else
+    echo "Skip: python3 not found — skipping locale generation"
+fi
+
+# --- Test datastore on port 2121 -------------------------------------
+
+echo "---"
+echo "Starting test datastore on port 2121..."
+
+if "$VALKEY_CLI" -p 2121 ping &>/dev/null; then
+    echo "OK:   Test datastore already running on port 2121"
+else
+    pnpm run test:database:start
+
+    started=false
+    for _i in 1 2 3 4 5 6 7 8 9 10; do
+        if "$VALKEY_CLI" -p 2121 ping &>/dev/null; then
+            started=true
+            break
+        fi
+        sleep 0.5
+    done
+
+    if $started; then
+        echo "OK:   Test datastore started on port 2121"
+    else
+        echo "Error: Test datastore did not start on port 2121"
+        echo "  Try manually: pnpm run test:database:start:fg"
+        exit 1
+    fi
+fi
+
+# --- Optional: direnv lane switching ---------------------------------
+#
+# direnv is a convenience, not a requirement. The RSpec suite forces
+# RACK_ENV=test in spec_helper and the test config hardcodes its values, so
+# tests run fine without it. When direnv IS installed we wire up the
+# .envrc/.test-mode flow so `cd` into the checkout selects the test lane.
+
+echo "---"
+if command -v direnv &>/dev/null; then
+    if [[ ! -f ".envrc" ]]; then
+        echo "Creating .envrc (direnv detected)..."
+        cat > ".envrc" << 'ENVRC'
 # .envrc — generated by install-test.sh
 #
 # direnv loads this automatically when you cd into the checkout.
@@ -65,12 +195,23 @@ else
   test -f .env.local && dotenv .env.local
 fi
 ENVRC
-    echo "Created: .envrc"
+        echo "Created: .envrc"
+    else
+        echo "OK:   .envrc already exists"
+    fi
+
+    echo "Activating test mode (.test-mode)..."
+    touch .test-mode
+    direnv allow .
 else
-    echo "OK:   .envrc already exists"
+    echo "Skip: direnv not installed — tests run without it."
+    echo "  (RACK_ENV=test is forced by spec_helper; the test config is self-contained.)"
 fi
 
-# --- .env.test -------------------------------------------------------
+# --- Optional: .env.test for integration tests -----------------------
+#
+# Only the PostgreSQL-backed integration tests need extra config. Seed a
+# starting point from the committed .env.test.example when nothing is present.
 
 OTS_DEV_CONFIG="${OTS_DEV_CONFIG:-$HOME/.config/onetimesecret-dev}"
 
@@ -79,28 +220,22 @@ if [[ -f ".env.test" ]]; then
 elif [[ -f "$OTS_DEV_CONFIG/.env.test" ]]; then
     ln -snf "$OTS_DEV_CONFIG/.env.test" .env.test
     echo "Link: .env.test -> $OTS_DEV_CONFIG/.env.test"
-else
-    echo "Error: .env.test not found"
-    echo "  Expected at: $OTS_DEV_CONFIG/.env.test (or a local file)"
-    exit 1
+elif [[ -f ".env.test.example" ]]; then
+    cp ".env.test.example" ".env.test"
+    echo "Copy: .env.test (from .env.test.example — fill in for integration tests)"
 fi
 
-# Verify .env.test sets RACK_ENV=test
-if ! grep -q '^RACK_ENV=test' .env.test; then
-    echo "Warning: .env.test does not set RACK_ENV=test"
-    echo "  Tests rely on RACK_ENV=test to load spec/*.test.yaml configs"
-fi
-
-# --- PostgreSQL test database -----------------------------------------
+# --- Optional: PostgreSQL integration database -----------------------
 
 pg_superuser_url="${AUTH_DATABASE_URL_TEST_SUPERUSER:-}"
-if [[ -z "$pg_superuser_url" ]]; then
+if [[ -z "$pg_superuser_url" && -f ".env.test" ]]; then
     # Fall back to .env.test if direnv hasn't loaded yet
     pg_superuser_url=$(grep '^AUTH_DATABASE_URL_TEST_SUPERUSER=' .env.test 2>/dev/null | cut -d= -f2- || true)
 fi
 
+echo "---"
 if [[ -n "$pg_superuser_url" ]] && command -v psql &>/dev/null; then
-    echo "Provisioning PostgreSQL test database..."
+    echo "Provisioning PostgreSQL test database (integration tests)..."
 
     # Extract connection parts from the superuser URL.
     # Parse: postgresql://user[:pass]@host[:port]/dbname
@@ -127,74 +262,29 @@ if [[ -n "$pg_superuser_url" ]] && command -v psql &>/dev/null; then
     psql "$pg_superuser_url" -f apps/web/auth/migrations/schemas/postgres/initialize_test_db.sql -v ON_ERROR_STOP=1
     echo "OK:   PostgreSQL roles and grants provisioned"
 else
-    if [[ -n "$pg_superuser_url" ]]; then
-        echo "Skip: psql not found — skipping PostgreSQL setup"
-    else
-        echo "Skip: AUTH_DATABASE_URL_TEST_SUPERUSER not set — skipping PostgreSQL setup"
-    fi
+    echo "Skip: PostgreSQL setup (only needed for integration tests)."
+    echo "  Set AUTH_DATABASE_URL_TEST_SUPERUSER (or add it to .env.test) and install psql to enable."
 fi
-
-# --- Generated locales ------------------------------------------------
-
-echo "---"
-echo "Generating merged locale files..."
-if command -v python3 &>/dev/null; then
-    python3 locales/scripts/i18n content compile --all --merged
-    echo "OK:   Locales generated in generated/locales/"
-else
-    echo "Skip: python3 not found — skipping locale generation"
-fi
-
-# --- Test Valkey on port 2121 ----------------------------------------
-
-valkey_cli="${VALKEY_CLI:-valkey-cli}"
-
-echo "---"
-echo "Starting test Valkey on port 2121..."
-
-if $valkey_cli -p 2121 ping &>/dev/null; then
-    echo "OK:   Test Valkey already running on port 2121"
-else
-    pnpm run test:database:start
-
-    started=false
-    for _i in 1 2 3 4 5 6 7 8 9 10; do
-        if $valkey_cli -p 2121 ping &>/dev/null; then
-            started=true
-            break
-        fi
-        sleep 0.5
-    done
-
-    if $started; then
-        echo "OK:   Test Valkey started on port 2121"
-    else
-        echo "Error: Test Valkey did not start on port 2121"
-        echo "  Try manually: pnpm run test:database:start:fg"
-        exit 1
-    fi
-fi
-
-# --- Activate test mode ----------------------------------------------
-
-echo "---"
-echo "Activating test mode..."
-touch .test-mode
-direnv allow .
 
 # --- Smoke test ------------------------------------------------------
 
 echo "---"
 echo "Verifying test environment config..."
 
-test_uri=$(direnv exec . ruby -e '
+smoke_ruby='
   ENV["RACK_ENV"] = "test"
   require_relative "lib/onetime"
   OT::Config.before_load
   raw  = OT::Config.load
   conf = OT::Config.after_load(raw)
   puts conf.dig("redis", "uri")
-' || true)
+'
+
+if command -v direnv &>/dev/null && [[ -f ".test-mode" ]]; then
+    test_uri=$(direnv exec . ruby -e "$smoke_ruby" || true)
+else
+    test_uri=$(env RACK_ENV=test ruby -e "$smoke_ruby" || true)
+fi
 
 if [[ "$test_uri" == *":2121"* ]]; then
     echo "OK:   Config resolves to test database ($test_uri)"
@@ -207,4 +297,7 @@ fi
 # --- Done ------------------------------------------------------------
 
 echo "---"
-echo "Test environment ready. To switch back to dev mode: install-dev.sh"
+echo "Test environment ready."
+echo "  RSpec:  pnpm run test:rspec:fast"
+echo "  Vitest: pnpm test"
+echo "  Switch back to dev mode: install-dev.sh"


### PR DESCRIPTION
## Summary

Makes the RSpec and Vitest suites runnable on a fresh clone — no maintainer-private files, no `direnv` requirement — and removes the GitHub egress dependency from `bundle install`.

- **`install-test.sh`** — accept `redis-server`/`redis-cli` as a drop-in for `valkey-*` (Valkey is wire-compatible; the package.json scripts already honor the `VALKEY_SERVER`/`VALKEY_CLI` overrides this sets). Drop `direnv` and a private `.env.test` from the hard requirements: the `.envrc`/`.test-mode` lane flow still runs when direnv is present, otherwise the script prints a recommendation to install direnv for everyday dev work (dev mode, `bin/console`, `bin/ots`). Add a soft Ruby-version check (`>= 3.4.7`) with an actionable message, seed `etc/` from `etc/defaults/` and run `bundle install` + `pnpm install` when missing (mirrors CI), make the PostgreSQL provisioning fully optional, and fix the locale step (the `--merged` flag was removed) by delegating to the canonical `pnpm run locales:sync`.
- **`Gemfile` / `Gemfile.lock`** — pin rspec (and `-core`/`-expectations`/`-mocks`/`-support`) to the released `4.0.0.beta1` on rubygems instead of the `github.com/rspec/rspec` git source. `bundle install` no longer clones GitHub (which is slower, less reproducible, and fails under egress restrictions — a repo-scoped clone returns 403). Lockfile churn is rspec-only; no other dependencies changed.
- **`.env.test.example`** — new committed template documenting the optional integration-test variables, with a `.gitignore` exception so it can be tracked.

The RSpec unit/fast suites need very little: `spec_helper.rb` forces `RACK_ENV=test` and `spec/config.test.yaml` hardcodes its secrets and the datastore URI (`redis://127.0.0.1:2121/0`). The direnv / `.env.test` / Postgres machinery is only relevant to the PostgreSQL-backed integration tests — matching what CI already does.

## Related Issues

None.

## Test Plan

Verified locally under Ruby 3.4.9 with `redis-server` standing in for Valkey on port 2121:

- `bundle install` succeeds from rubygems (no GitHub clone).
- `bundle exec rake spec:fast` → **2506 examples, 1 failure, 23 pending**. The single failure (`spec/unit/onetime/mail/mailer_spec.rb:287`) is an artifact of the sandbox egress proxy, which rewrites AWS-credential-shaped fixture values to `proxy-injected`; it is unrelated to these changes and passes in a normal environment.
- `./install-test.sh` runs end to end (exit 0); the smoke test resolves `redis://127.0.0.1:2121/0`.
- Vitest (`pnpm test`) passes independently: 253 files, 6385 tests.

Net result for a fresh clone (Ruby ≥ 3.4.7): `./install-test.sh && pnpm run test:rspec:fast && pnpm test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FkqBEqG1AGVLS28SFKYQUj

---
_Generated by [Claude Code](https://claude.ai/code/session_01FkqBEqG1AGVLS28SFKYQUj)_