### PR TITLE
fix(branding): stop GLOBAL_DEFAULTS[:product_name] leaking 'OTS'

### DIFF
--- a/apps/web/core/spec/views/base_spec.rb
+++ b/apps/web/core/spec/views/base_spec.rb
@@ -50,8 +50,10 @@ RSpec.describe Core::Views::BaseView do
     it 'sets basic template variables' do
       expect(subject.view_vars['description']).to eq('Test Description')
       expect(subject.view_vars['keywords']).to eq('test,keywords')
-      # page_title defaults to BrandSettingsConstants::GLOBAL_DEFAULTS[:product_name]
-      expect(subject.view_vars['page_title']).to eq('OTS')
+      # page_title falls through display_domain -> brand_product_name -> site_name;
+      # the test config stubs none of them, and GLOBAL_DEFAULTS[:product_name] is
+      # nil per #3049, so it resolves to nil here (not 'OTS').
+      expect(subject.view_vars['page_title']).to be_nil
     end
 
     it 'initializes JavaScript variables' do

--- a/lib/onetime/models/custom_domain/brand_settings.rb
+++ b/lib/onetime/models/custom_domain/brand_settings.rb
@@ -47,16 +47,23 @@ module Onetime
       # views, and initializers.
       #
       # All values default to nil per #3049 (no OTS branding leaks into shipped
-      # defaults). Operators set BRAND_SUPPORT_EMAIL / BRAND_LOGO_URL /
-      # BRAND_TOTP_ISSUER to populate. 'OTS' is acceptable as a neutral
-      # abbreviation per the issue body.
+      # defaults) — including product_name. Operators set BRAND_PRODUCT_NAME /
+      # BRAND_SUPPORT_EMAIL / BRAND_LOGO_URL to populate; an unconfigured
+      # install falls through to each consumer's own neutral default
+      # (frontend: NEUTRAL_BRAND_DEFAULTS.product_name = 'My App'; mail/page
+      # title: the legacy site.interface.ui.header.branding.site_name value).
+      #
+      # totp_issuer is the one deliberate exception, kept as 'OTS' rather
+      # than nil: it's baked into already-provisioned authenticator-app
+      # entries (otpauth:// issuer label, see mfa.rb / totp.rb), so changing
+      # the unconfigured default risks confusing existing MFA enrollments.
       # signature_name defaults to nil: when unset, the email sign-off falls
       # through to the neutral i18n default (email.*.signature, "Support Team")
       # rather than a hardcoded person's name. Operators set
       # BRAND_SIGNATURE_NAME to sign mail with their own name or team.
       GLOBAL_DEFAULTS = {
         support_email: nil,
-        product_name: 'OTS',
+        product_name: nil,
         totp_issuer: 'OTS',
         logo_url: nil,
         favicon_url: nil,

--- a/try/unit/mail/templates_brand_color_try.rb
+++ b/try/unit/mail/templates_brand_color_try.rb
@@ -13,7 +13,7 @@
 #   - logo_url resolves brand conf -> nil (NOT the OTS logo path)
 #   - support_email resolves brand conf -> GLOBAL_DEFAULTS (NOT the OTS address)
 #   - logo_alt delegates to product_name
-#   - site_product_name resolves brand -> site_name -> 'OTS'
+#   - site_product_name resolves brand -> site_name -> nil (GLOBAL_DEFAULTS[:product_name], #3049)
 #   - The 12 shipped HTML templates contain no #dc4a22 or onetime-logo-v3-xl.svg
 #     (regression guard against re-introduction).
 #
@@ -274,7 +274,7 @@ ensure
 end
 #=> 'LegacySiteName'
 
-## site_product_name falls through to GLOBAL_DEFAULTS[:product_name] (= 'OTS')
+## site_product_name falls through to GLOBAL_DEFAULTS[:product_name] (= nil)
 saved = YAML.load(YAML.dump(OT.conf))
 begin
   conf_copy = YAML.load(YAML.dump(saved))
@@ -289,11 +289,11 @@ begin
 ensure
   OT.send(:conf=, saved) rescue nil
 end
-#=> 'OTS'
+#=> nil
 
-## [regression guard] GLOBAL_DEFAULTS[:product_name] is 'OTS', not 'Onetime Secret'
+## [regression guard] GLOBAL_DEFAULTS[:product_name] is nil, not 'OTS' or 'Onetime Secret'
 @constants::GLOBAL_DEFAULTS[:product_name]
-#=> 'OTS'
+#=> nil
 
 # ============================================================================
 # Carried-forward helpers — verify they still work post-port
@@ -494,7 +494,7 @@ ensure
 end
 #=> nil
 
-## OT.conf=nil — site_product_name falls through to GLOBAL_DEFAULTS ('OTS')
+## OT.conf=nil — site_product_name falls through to GLOBAL_DEFAULTS (nil)
 @_saved_for_nil4 = OT.instance_variable_get(:@conf)
 begin
   OT.instance_variable_set(:@conf, nil)
@@ -503,7 +503,7 @@ begin
 ensure
   OT.instance_variable_set(:@conf, @_saved_for_nil4)
 end
-#=> 'OTS'
+#=> nil
 
 ## OT.conf=nil — signature_name degrades to nil without raising
 @_saved_for_nil_sig = OT.instance_variable_get(:@conf)

--- a/try/unit/models/custom_domain/brand_global_defaults_try.rb
+++ b/try/unit/models/custom_domain/brand_global_defaults_try.rb
@@ -7,7 +7,8 @@
 #
 # Critical assertions:
 #   - GLOBAL_DEFAULTS[:support_email] is neutral or nil (NOT 'support@onetimesecret.com')
-#   - GLOBAL_DEFAULTS[:product_name] is 'OTS' (acceptable neutral abbreviation per issue)
+#   - GLOBAL_DEFAULTS[:product_name] is nil (the #3049 stamp picked 'My App' as the
+#     neutral product name, not 'OTS' — each consumer owns its own neutral fallback)
 #
 # These tests are the regression guard against #dc4a22-style OTS-branding
 # leaking into the shipped neutral defaults.
@@ -44,12 +45,17 @@ support.nil? || support != 'support@onetimesecret.com'
 @constants::GLOBAL_DEFAULTS[:support_email] != 'support@onetimesecret.com'
 #=> true
 
-## [forward] GLOBAL_DEFAULTS[:product_name] is 'OTS' (acceptable neutral abbreviation)
+## [forward] GLOBAL_DEFAULTS[:product_name] is nil — frontend NEUTRAL_BRAND_DEFAULTS
+## ('My App') and the legacy site_name fallback own the neutral default instead
 @constants::GLOBAL_DEFAULTS[:product_name]
-#=> 'OTS'
+#=> nil
 
 ## [forward / regression guard] GLOBAL_DEFAULTS[:product_name] is NOT 'Onetime Secret'
 @constants::GLOBAL_DEFAULTS[:product_name] != 'Onetime Secret'
+#=> true
+
+## [forward / regression guard] GLOBAL_DEFAULTS[:product_name] is NOT 'OTS'
+@constants::GLOBAL_DEFAULTS[:product_name] != 'OTS'
 #=> true
 
 ## [forward] runtime global_defaults reader exists on BrandSettingsConstants
@@ -60,9 +66,9 @@ support.nil? || support != 'support@onetimesecret.com'
 @constants.global_defaults.is_a?(Hash)
 #=> true
 
-## [forward] runtime global_defaults product_name resolves to 'OTS' by default
+## [forward] runtime global_defaults product_name resolves to nil by default
 @constants.global_defaults[:product_name]
-#=> 'OTS'
+#=> nil
 
 ## [forward / regression guard] runtime global_defaults support_email is neutral or nil
 support = @constants.global_defaults[:support_email]

--- a/try/unit/models/custom_domain/brand_global_defaults_try.rb
+++ b/try/unit/models/custom_domain/brand_global_defaults_try.rb
@@ -45,8 +45,7 @@ support.nil? || support != 'support@onetimesecret.com'
 @constants::GLOBAL_DEFAULTS[:support_email] != 'support@onetimesecret.com'
 #=> true
 
-## [forward] GLOBAL_DEFAULTS[:product_name] is nil — frontend NEUTRAL_BRAND_DEFAULTS
-## ('My App') and the legacy site_name fallback own the neutral default instead
+## [forward] GLOBAL_DEFAULTS[:product_name] is nil (frontend 'My App' / legacy site_name own the default)
 @constants::GLOBAL_DEFAULTS[:product_name]
 #=> nil
 

--- a/try/unit/web/page_title_brand_fallback_try.rb
+++ b/try/unit/web/page_title_brand_fallback_try.rb
@@ -89,18 +89,17 @@ with_brand_conf({ 'product_name' => 'Acme Vault' }) do
 end
 #=> 'vault.acme.test'
 
+# GLOBAL_DEFAULTS[:product_name] is nil per #3049, so this exercises the
+# shipped config.defaults.yaml site.interface.ui.header.branding.site_name
+# default rather than a brand-layer value.
 ## page_title falls through to the legacy site_name when brand absent
-## (GLOBAL_DEFAULTS[:product_name] is nil per #3049, so this exercises the
-## shipped config.defaults.yaml site.interface.ui.header.branding.site_name
-## default rather than a brand-layer value)
 with_brand_conf(nil) do
   vars = @host.initialize_view_vars(Rack::Request.new(build_env))
   vars['page_title']
 end
 #=> 'One-Time Secret'
 
-## page_title falls through to GLOBAL_DEFAULTS[:product_name] (nil) when both
-## brand config and the legacy site_name are absent
+## page_title falls through to GLOBAL_DEFAULTS[:product_name] (nil) when brand and legacy site_name are both absent
 with_brand_conf(nil) do
   saved = YAML.load(YAML.dump(OT.conf))
   begin

--- a/try/unit/web/page_title_brand_fallback_try.rb
+++ b/try/unit/web/page_title_brand_fallback_try.rb
@@ -89,12 +89,31 @@ with_brand_conf({ 'product_name' => 'Acme Vault' }) do
 end
 #=> 'vault.acme.test'
 
-## page_title falls through to GLOBAL_DEFAULTS[:product_name] when brand absent
+## page_title falls through to the legacy site_name when brand absent
+## (GLOBAL_DEFAULTS[:product_name] is nil per #3049, so this exercises the
+## shipped config.defaults.yaml site.interface.ui.header.branding.site_name
+## default rather than a brand-layer value)
 with_brand_conf(nil) do
   vars = @host.initialize_view_vars(Rack::Request.new(build_env))
   vars['page_title']
 end
-#=> 'OTS'
+#=> 'One-Time Secret'
+
+## page_title falls through to GLOBAL_DEFAULTS[:product_name] (nil) when both
+## brand config and the legacy site_name are absent
+with_brand_conf(nil) do
+  saved = YAML.load(YAML.dump(OT.conf))
+  begin
+    conf_copy = YAML.load(YAML.dump(OT.conf))
+    conf_copy.dig('site', 'interface', 'ui', 'header', 'branding')&.delete('site_name')
+    OT.send(:conf=, conf_copy)
+    vars = @host.initialize_view_vars(Rack::Request.new(build_env))
+    vars['page_title']
+  ensure
+    OT.send(:conf=, saved) rescue nil
+  end
+end
+#=> nil
 
 ## [regression guard] page_title NEVER returns hardcoded 'Onetime Secret' when brand absent
 with_brand_conf(nil) do
@@ -103,9 +122,9 @@ with_brand_conf(nil) do
 end
 #=> true
 
-## [regression guard] GLOBAL_DEFAULTS[:product_name] is 'OTS', not 'Onetime Secret'
+## [regression guard] GLOBAL_DEFAULTS[:product_name] is nil, not 'OTS' or 'Onetime Secret'
 Onetime::CustomDomain::BrandSettingsConstants::GLOBAL_DEFAULTS[:product_name]
-#=> 'OTS'
+#=> nil
 
 # ============================================================================
 # 9 brand_* / brand-adjacent view var keys exist
@@ -135,9 +154,16 @@ vars = @host.initialize_view_vars(Rack::Request.new(build_env))
 vars.key?('brand_product_name')
 #=> true
 
-## brand_product_name is a String
+## brand_product_name is nil when unset — frontend NEUTRAL_BRAND_DEFAULTS owns the default (#3049)
 vars = @host.initialize_view_vars(Rack::Request.new(build_env))
-vars['brand_product_name'].is_a?(String)
+vars['brand_product_name']
+#=> nil
+
+## brand_product_name is a String once BRAND_PRODUCT_NAME / brand.product_name is configured
+with_brand_conf({ 'product_name' => 'Acme Vault' }) do
+  vars = @host.initialize_view_vars(Rack::Request.new(build_env))
+  vars['brand_product_name'].is_a?(String)
+end
 #=> true
 
 ## initialize_view_vars exposes 'brand_corner_style'


### PR DESCRIPTION
## Summary

[#3049](https://github.com/onetimesecret/onetimesecret/issues/3049)

Continuation of #3553. That PR's review surfaced a screenshot of the custom-domain-disabled homepage footer reading "Powered by OTS" instead of falling through to a neutral name. This PR fixes the root cause and stacks on top of `claude/branding-features-polish-4pk7bg`.

`BrandSettingsConstants::GLOBAL_DEFAULTS[:product_name]` was hardcoded to `'OTS'`, which shadowed the frontend's neutral `NEUTRAL_BRAND_DEFAULTS.product_name` (`'My App'`) fallback whenever `brand_product_name` was sent to the bootstrap payload. The existing code comment defended `'OTS'` as "acceptable... per the issue body," but issue #3049's actual stamped decision explicitly picked `'My App'` as the neutral product name, and its investigation table separately confirmed the frontend's `'My App'` default needed no changes. `docs/architecture/branding.md` and `get_webmanifest.rb` already implement the `nil` → neutral-default pattern correctly; only this one constant had drifted from it.

- Set `GLOBAL_DEFAULTS[:product_name]` to `nil`, matching `support_email` / `logo_url` / `favicon_url` / `signature_name`.
- Left `totp_issuer` as `'OTS'` deliberately — it's baked into already-provisioned authenticator-app entries via `BRAND_TOTP_ISSUER`, so changing its default risks confusing existing MFA enrollments. That's a separate, unrelated decision.
- Updated the try/rspec assertions that pinned the old `'OTS'` value, tracing each fallback chain (`page_title`, `site_product_name`, `brand_product_name`) through to its corrected next tier (the legacy `site.interface.ui.header.branding.site_name` default, `'One-Time Secret'`, in practice).

## Related Issues

Refs #3049 (follow-up from #3553 review)

## Test Plan

- `try/unit/web/page_title_brand_fallback_try.rb` — 33/33
- `try/unit/mail/templates_brand_color_try.rb` — 52/52
- `try/unit/models/custom_domain/brand_global_defaults_try.rb` — 12/12
- `apps/web/core/spec/views/base_spec.rb` — 26/26
- `apps/web/core/spec/views/serializers/config_serializer_spec.rb` — 61/61
- `apps/web/auth/spec/config/features/mfa_spec.rb` + `mfa_provisioning_uri_spec.rb` — 24/24 (confirms `totp_issuer` is unaffected)

All run locally against a redis instance with `rspec` pulled from rubygems (post-#3551 merge).


---
_Generated by [Claude Code](https://claude.ai/code/session_011zrgGzGvHo2yQtRtSTsz5J)_