### PR TITLE
feat(security): redacting CSP violation report endpoint + wire report-only policy (#3498)

### DIFF
--- a/apps/api/v1/controllers/index.rb
+++ b/apps/api/v1/controllers/index.rb
@@ -4,6 +4,8 @@
 
 require 'v1/refinements'
 
+require 'onetime/security/csp_report'
+
 require_relative 'base'
 require_relative 'settings'
 
@@ -207,8 +209,108 @@ module V1
         end
       end
 
+      # Receive browser-posted Content-Security-Policy violation reports.
+      #
+      # This endpoint is the destination of the report-only CSP emitted by the
+      # Core web app (apps/web/core/middleware/request_setup.rb). It is mounted
+      # under /api/ so the AuthenticityToken middleware auto-bypasses CSRF
+      # (lib/onetime/middleware/security.rb), which is correct: browsers POST CSP
+      # reports unauthenticated and without a CSRF token. It is intentionally
+      # ANONYMOUS and PUBLIC.
+      #
+      # Behavior (all mandatory):
+      # - STRICT size cap: bodies larger than CspReport::MAX_BODY_BYTES are
+      #   skipped without parsing (cheap defense against abuse of a public,
+      #   unauthenticated endpoint).
+      # - Parses BOTH wire formats: legacy application/csp-report and the
+      #   Reporting API application/reports+json. Malformed/empty JSON is
+      #   tolerated (logged at debug).
+      # - REDACTS every URL-ish field BEFORE logging. This is a secret-sharing
+      #   app: document-uri/blocked-uri/referrer/source-file can contain a secret
+      #   link (https://host/secret/<KEY>?...). Onetime::Security::CspReport
+      #   strips query strings and collapses paths so a secret key can never reach
+      #   a log line or Sentry.
+      # - NEVER writes to the database and NEVER raises to the client. Always
+      #   responds 204 No Content (browsers ignore the response body).
+      #
+      # Rate limiting: kept deliberately cheap (size cap + no DB + no heavy work)
+      # so it is safe to leave unauthenticated. A dedicated per-IP limiter (like
+      # check_rate_limit! used elsewhere in this controller) can be layered on as
+      # a follow-up if report volume warrants it; infrastructure-layer limiting
+      # already fronts the app.
+      def csp_report
+        body         = read_capped_body
+        content_type = req.env['CONTENT_TYPE'] || req.env['HTTP_CONTENT_TYPE']
+
+        summaries = Onetime::Security::CspReport.parse(body, content_type)
+        if summaries.empty?
+          OT.ld '[csp-report] no parseable violation reports (empty/malformed/oversized)'
+        else
+          summaries.each { |summary| log_csp_violation(summary) }
+        end
+      rescue StandardError => ex
+        # A violation-report receiver must never surface errors to the browser.
+        OT.le "[csp-report] #{ex.class}: #{ex.message}"
+      ensure
+        res.status = 204
+        res.headers.delete('content-type') if res.headers.respond_to?(:delete)
+        res.body   = []
+      end
+
       require_relative 'class_methods'
       extend V1::Controllers::ClassMethods
+
+      private
+
+      # Read at most CspReport::MAX_BODY_BYTES + 1 from the request body so an
+      # oversized body is detected (and skipped) without ever materializing more
+      # than the cap in memory. Returns nil when there is no readable body.
+      def read_capped_body
+        input = req.env['rack.input'] || req.body
+        return nil if input.nil?
+
+        cap   = Onetime::Security::CspReport::MAX_BODY_BYTES
+        chunk = input.read(cap + 1)
+        input.rewind if input.respond_to?(:rewind)
+        chunk
+      rescue StandardError => ex
+        OT.ld "[csp-report] body read failed: #{ex.class}: #{ex.message}"
+        nil
+      end
+
+      # Emit ONE redacted, structured log line for a single violation summary.
+      # Every value here has already passed through Onetime::Security::CspReport
+      # redaction, so no field can carry a secret token. Optionally mirrors the
+      # SAME redacted summary to Sentry when available (never raw data).
+      def log_csp_violation(summary)
+        OT.lw('[csp-report] violation', **csp_log_payload(summary))
+
+        # Optionally mirror the SAME redacted summary to Sentry. Mirrors the
+        # sentry_available? guard in lib/onetime/error_handler.rb (that method is
+        # private, so we inline the identical check). Never forwards raw data.
+        return unless OT.d9s_enabled && defined?(Sentry) && Sentry.initialized?
+
+        Sentry.capture_message('CSP violation report', level: :info) do |scope|
+          scope.set_context('csp_report', summary)
+        end
+      rescue StandardError => ex
+        OT.le "[csp-report] logging failed: #{ex.class}: #{ex.message}"
+      end
+
+      # Map the redacted summary to a symbol-keyed payload for the structured
+      # logger. Only safe fields are included.
+      def csp_log_payload(summary)
+        {
+          violated_directive: summary['violated-directive'],
+          effective_directive: summary['effective-directive'],
+          disposition: summary['disposition'],
+          document_uri: summary['document-uri'],
+          blocked_uri: summary['blocked-uri'],
+          source_file: summary['source-file'],
+          line_number: summary['line-number'],
+          column_number: summary['column-number'],
+        }.compact
+      end
     end
   end
 end

--- a/apps/api/v1/routes.txt
+++ b/apps/api/v1/routes.txt
@@ -22,6 +22,12 @@ POST   /create                               V1::Controllers::Index#create      
 
 POST   /secret/:key                          V1::Controllers::Index#show_secret openapi_auth=basic,anonymous content=form response=default sensitive=true
 
+# CSP violation report receiver. Anonymous + public: browsers POST here
+# unauthenticated and without a CSRF token (CSRF is auto-bypassed for /api/*).
+# Reads a size-capped body, redacts secret-bearing URLs, logs a summary, and
+# always responds 204. Never writes to the database. See Index#csp_report.
+POST   /csp-report                           V1::Controllers::Index#csp_report  openapi_auth=anonymous response=default
+
 # Canonical receipt paths
 # NOTE: Specific sub-paths (burn) must precede the :key wildcard so
 # Otto's first-match-wins dynamic routing resolves them correctly.

--- a/apps/web/core/middleware/request_setup.rb
+++ b/apps/web/core/middleware/request_setup.rb
@@ -33,6 +33,16 @@ module Core
       CSP_REPORT_ONLY_HEADER = 'content-security-policy-report-only'
       CSP_ENFORCING_HEADER   = 'content-security-policy'
 
+      # Absolute path of the V1 API CSP violation report receiver
+      # (V1::Controllers::Index#csp_report, mounted at /api/v1). The report-only
+      # policy points the browser here via report-uri/report-to so violations are
+      # actually collected; without it report-only mode gathers no data.
+      CSP_REPORT_PATH = '/api/v1/csp-report'
+
+      # Reporting API endpoint group name, matched by the 'report-to
+      # csp-endpoint;' directive in the policy and defined by this header.
+      CSP_REPORTING_ENDPOINTS_HEADER = 'reporting-endpoints'
+
       def call(env)
         setup_request(env)
         status, headers, body = @app.call(env)
@@ -95,7 +105,13 @@ module Core
       headers[CSP_REPORT_ONLY_HEADER] = Onetime::Security::Csp.policy(
         nonce: nonce,
         development: OT.conf.dig('development', 'enabled'),
+        report_uri: CSP_REPORT_PATH,
       )
+
+      # Define the 'csp-endpoint' group referenced by the policy's
+      # 'report-to csp-endpoint;' directive (modern Reporting API). Browsers that
+      # only understand the legacy 'report-uri' directive ignore this header.
+      headers[CSP_REPORTING_ENDPOINTS_HEADER] ||= "csp-endpoint=\"#{CSP_REPORT_PATH}\""
     end
     end
   end

--- a/changelog.d/20260630_120000_claude_csp_report_endpoint.rst
+++ b/changelog.d/20260630_120000_claude_csp_report_endpoint.rst
@@ -1,0 +1,6 @@
+.. A new scriv changelog fragment.
+
+Security
+--------
+
+- Added a Content-Security-Policy violation report receiver at ``POST /api/v1/csp-report`` and pointed the Core web app's report-only CSP at it (``report-uri`` plus a modern ``report-to``/``Reporting-Endpoints`` pair). Previously the report-only policy carried no reporting directive, so browser violation reports went nowhere and report-only mode collected no data. The endpoint is anonymous and public (browsers POST reports unauthenticated and without a CSRF token, which ``/api/*`` already bypasses), reads a size-capped body (≤ 64 KiB), parses both the legacy ``application/csp-report`` and the Reporting API ``application/reports+json`` formats, tolerates malformed input, never touches the database, and always responds ``204 No Content``. Because this is a secret-sharing app, a report's ``document-uri`` / ``blocked-uri`` / ``referrer`` / ``source-file`` can contain a secret link such as ``https://host/secret/<KEY>``; all such URLs are REDACTED (query strings and path collapsed to ``[redacted-path]``, origin only) before anything is logged or forwarded to Sentry, so secret tokens can never leak into logs. (#3498)

--- a/lib/onetime/security/csp.rb
+++ b/lib/onetime/security/csp.rb
@@ -30,10 +30,17 @@ module Onetime
       # @param development [Boolean] truthy when running in development mode
       #   (OT.conf.dig('development','enabled')); selects the permissive
       #   connect-src needed for hot module replacement.
+      # @param report_uri [String, nil] OPTIONAL path/URL to a CSP violation
+      #   report receiver. When provided, a "report-uri <path>;" directive (and a
+      #   "report-to csp-endpoint;" directive for the modern Reporting API) is
+      #   appended so the browser knows where to POST violation reports. When nil
+      #   (the default), NO reporting directive is emitted and the output is
+      #   byte-identical to the historical policy — see
+      #   spec/unit/api/v1/csp_header_spec.rb.
       # @return [String] the full policy string, directives space-joined in a
       #   stable order. Byte-identical to the policy previously inlined in the V1
-      #   API helper.
-      def policy(nonce:, development:)
+      #   API helper when report_uri is omitted.
+      def policy(nonce:, development:, report_uri: nil)
         directives =
           if development
             [
@@ -68,6 +75,17 @@ module Onetime
               "worker-src 'self';",
             ]
           end
+
+        # OPTIONAL reporting directives. Appended only when a report_uri is
+        # supplied so the default (no report_uri) output stays byte-identical.
+        # report-uri is the legacy directive (widely supported); report-to is the
+        # modern Reporting API directive whose endpoint name ('csp-endpoint') is
+        # defined by a separate Reporting-Endpoints response header emitted at the
+        # web layer.
+        unless report_uri.nil? || report_uri.to_s.empty?
+          directives << "report-uri #{report_uri};"
+          directives << 'report-to csp-endpoint;'
+        end
 
         directives.join(' ')
       end

--- a/lib/onetime/security/csp_report.rb
+++ b/lib/onetime/security/csp_report.rb
@@ -1,0 +1,209 @@
+# lib/onetime/security/csp_report.rb
+#
+# frozen_string_literal: true
+
+require 'json'
+require 'uri'
+
+module Onetime
+  module Security
+    # Parsing and REDACTION for inbound Content-Security-Policy violation
+    # reports.
+    #
+    # This is a SECRET-SHARING application. A CSP violation report's URL fields
+    # (document-uri, blocked-uri, referrer, source-file) routinely contain the
+    # full page URL the browser was on — which for this app can be a secret link
+    # such as https://host/secret/<SECRET_KEY>?... Logging those values verbatim
+    # would LEAK secret tokens into logs and (if configured) Sentry. Every value
+    # that reaches a log MUST therefore pass through #redact_url first, which
+    # discards the query string and collapses the path so a secret key can never
+    # survive into the log line.
+    #
+    # Layer-agnostic: no Rack/Otto dependency. The controller passes in the raw
+    # request body + content-type and gets back a list of safe, structured
+    # summaries ready to log.
+    module CspReport
+      extend self
+
+      # Hard cap on the request body we are willing to parse. Browsers send tiny
+      # JSON documents; anything larger is abuse and is skipped without parsing.
+      MAX_BODY_BYTES = 64 * 1024 # 64 KiB
+
+      # URL-ish report fields that may contain a secret token and must be
+      # redacted before they are allowed anywhere near a log.
+      URL_FIELDS = %w[document-uri blocked-uri referrer source-file].freeze
+
+      # Parse a CSP report body into a list of REDACTED, log-safe summary hashes.
+      #
+      # Tolerates malformed/empty JSON and both wire formats. Never raises.
+      #
+      # @param body [String, nil] the raw request body.
+      # @param content_type [String, nil] the request Content-Type header.
+      # @return [Array<Hash>] zero or more redacted summaries. Empty when the
+      #   body is missing, oversized, malformed, or contains no recognizable
+      #   violation reports.
+      def parse(body, content_type)
+        return [] if body.nil?
+
+        bytes = body.bytesize
+        return [] if bytes.zero? || bytes > MAX_BODY_BYTES
+
+        data =
+          begin
+            JSON.parse(body)
+          rescue JSON::ParserError, EncodingError
+            nil
+          end
+        return [] if data.nil?
+
+        raw_reports = extract_reports(data, content_type)
+        raw_reports.filter_map { |report| summarize(report) }
+      end
+
+      # Pull the per-violation hashes out of either wire format.
+      #
+      # Legacy 'application/csp-report': a single object {"csp-report": {...}}.
+      # Reporting API 'application/reports+json': an ARRAY of
+      #   {"type": "csp-violation", "body": {...}} (we tolerate other shapes too,
+      #   keying off content rather than trusting the declared content-type).
+      #
+      # @return [Array<Hash>] raw (un-redacted) per-violation field hashes.
+      def extract_reports(data, _content_type)
+        case data
+        when Array
+          # Reporting API batch. Keep only csp-violation entries with a body.
+          data.filter_map do |entry|
+            next unless entry.is_a?(Hash)
+
+            type = entry['type']
+            body = entry['body']
+            next unless body.is_a?(Hash)
+            # Accept entries explicitly typed as csp-violation, or untyped
+            # bodies that still look like a CSP report.
+            next unless type.nil? || type == 'csp-violation'
+
+            body
+          end
+        when Hash
+          if data['csp-report'].is_a?(Hash)
+            [data['csp-report']] # legacy single report
+          elsif data['body'].is_a?(Hash)
+            [data['body']]       # a single Reporting API object (not in an array)
+          else
+            []
+          end
+        else
+          []
+        end
+      end
+
+      # Reduce one raw report hash to a small, REDACTED, structured summary that
+      # is safe to log. Only non-secret-bearing scalar fields survive verbatim
+      # (directive names, disposition, line/column numbers, status code). Every
+      # URL-ish field is collapsed via #redact_url.
+      #
+      # @param report [Hash] a raw per-violation field hash.
+      # @return [Hash, nil] a redacted summary, or nil when the input is not a
+      #   usable report hash.
+      def summarize(report)
+        return nil unless report.is_a?(Hash)
+
+        {
+          'violated-directive' => safe_token(report['violated-directive'] || report['violatedDirective']),
+          'effective-directive' => safe_token(report['effective-directive'] || report['effectiveDirective']),
+          'disposition' => safe_token(report['disposition']),
+          'document-uri' => redact_url(report['document-uri'] || report['documentURL']),
+          'blocked-uri' => redact_url(report['blocked-uri'] || report['blockedURL']),
+          'referrer' => redact_url(report['referrer']),
+          'source-file' => redact_url(report['source-file'] || report['sourceFile']),
+          'line-number' => safe_int(report['line-number'] || report['lineNumber']),
+          'column-number' => safe_int(report['column-number'] || report['columnNumber']),
+          'status-code' => safe_int(report['status-code'] || report['statusCode']),
+        }.compact
+      end
+
+      # Redact a URL-ish report value down to a form that CANNOT reveal a secret
+      # token. Strategy: keep ONLY scheme + host (+ non-default port), drop the
+      # query string, fragment, AND the entire path. We deliberately do NOT keep
+      # even the first path segment: in this app a secret link can be as shallow
+      # as https://host/<KEY> (or a custom-domain root), so any retained path
+      # component risks being the secret itself. Non-URL CSP keyword sources
+      # ('inline', 'eval', 'self', 'data', etc.) are passed through unchanged
+      # since they carry no secret.
+      #
+      # Examples:
+      #   https://host/secret/abc123?x=y -> "https://host/[redacted-path]"
+      #   https://host/abc123            -> "https://host/[redacted-path]"
+      #   https://host/                  -> "https://host/"
+      #   inline                         -> "inline"
+      #   data                           -> "data"
+      #
+      # @param value [Object] the raw field value.
+      # @return [String, nil] a redacted string, or nil when value is blank.
+      def redact_url(value)
+        return nil if value.nil?
+
+        str = value.to_s
+        return nil if str.empty?
+
+        # CSP keyword sources (not URLs) are safe verbatim and short.
+        return str if CSP_KEYWORDS.include?(str)
+
+        uri =
+          begin
+            URI.parse(str)
+          rescue URI::InvalidURIError
+            nil
+          end
+
+        # If it doesn't parse into something with a scheme+host we can't reason
+        # about it safely — refuse to log the raw value.
+        return '[redacted]' if uri.nil? || uri.scheme.nil? || uri.host.nil?
+
+        origin = "#{uri.scheme}://#{uri.host}"
+        origin = "#{origin}:#{uri.port}" if explicit_port?(uri)
+
+        # Never emit any path segment — only signal whether a path was present.
+        path = uri.path.to_s
+        path.empty? || path == '/' ? "#{origin}/" : "#{origin}/[redacted-path]"
+      end
+
+      # CSP source keywords that may appear in blocked-uri / document-uri and are
+      # not URLs (so cannot leak a secret). Browsers sometimes send these with
+      # surrounding single quotes and sometimes without, so both forms are listed.
+      CSP_KEYWORDS = [
+        'inline', 'eval', 'self', 'data', 'blob', 'filesystem', 'about', 'wasm-eval',
+        "'inline'", "'eval'", "'self'"
+      ].freeze
+
+      private
+
+      # A short, non-URL scalar (directive name, disposition). Truncated
+      # defensively so a hostile/oversized value can't bloat the log line.
+      def safe_token(value)
+        return nil if value.nil?
+
+        str = value.to_s.strip
+        return nil if str.empty?
+
+        str.length > 128 ? "#{str[0, 128]}…" : str
+      end
+
+      def safe_int(value)
+        return nil if value.nil?
+        return value if value.is_a?(Integer)
+
+        str = value.to_s
+        str.match?(/\A\d{1,9}\z/) ? str.to_i : nil
+      end
+
+      # True when the URI carries a non-default port we should preserve.
+      def explicit_port?(uri)
+        return false if uri.port.nil?
+
+        default = URI.scheme_list[uri.scheme.upcase]&.default_port
+        uri.port != default
+      end
+    end
+  end
+end

--- a/spec/unit/api/v1/csp_report_endpoint_spec.rb
+++ b/spec/unit/api/v1/csp_report_endpoint_spec.rb
@@ -1,0 +1,179 @@
+# spec/unit/api/v1/csp_report_endpoint_spec.rb
+#
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'json'
+require 'stringio'
+
+# Coverage for the V1 CSP violation report receiver
+# (V1::Controllers::Index#csp_report), the destination of the Core web app's
+# report-only Content-Security-Policy.
+#
+# Security properties under test (this is a SECRET-SHARING app):
+#   - The endpoint REDACTS secret-bearing URLs before logging. A document-uri or
+#     blocked-uri like https://host/secret/<SECRET_KEY> MUST NOT appear in the
+#     log output; the violated-directive (a safe field) MUST.
+#   - It tolerates both wire formats (legacy application/csp-report and the
+#     Reporting API array), malformed JSON, and oversized bodies — always
+#     responding 204 and never writing to the database.
+
+require_relative '../../../../apps/api/v1/controllers/index'
+
+RSpec.describe V1::Controllers::Index, '#csp_report' do
+  # A planted secret token we expect NEVER to appear in any log line.
+  SECRET_KEY = 'supersecrettoken0123456789abcdef0123456789'
+
+  # Capture every structured log call the action makes.
+  let(:log_lines) { [] }
+
+  # Minimal request/response doubles driving the REAL action. We build a real
+  # Rack-ish request env so read_capped_body exercises rack.input.
+  def build_request(body:, content_type: 'application/csp-report')
+    env = {
+      'CONTENT_TYPE' => content_type,
+      'rack.input'   => StringIO.new(body.to_s),
+      'REMOTE_ADDR'  => '127.0.0.1',
+    }
+    req = instance_double('Otto::Request', env: env, body: env['rack.input'])
+    req
+  end
+
+  let(:response) do
+    headers = { 'content-type' => 'application/json' }
+    res = instance_double('Otto::Response')
+    allow(res).to receive(:headers).and_return(headers)
+    allow(res).to receive(:status=)
+    allow(res).to receive(:body=)
+    res
+  end
+
+  # Build the controller, stubbing req/res to our doubles.
+  def build_controller(req)
+    controller = described_class.allocate
+    allow(controller).to receive(:req).and_return(req)
+    allow(controller).to receive(:res).and_return(response)
+    controller
+  end
+
+  before do
+    # Capture structured logs. OT.lw/OT.ld/OT.le take (*msgs, **payload).
+    allow(OT).to receive(:lw) { |*msgs, **payload| log_lines << [msgs.join(' '), payload].inspect }
+    allow(OT).to receive(:ld) { |*msgs, **payload| log_lines << [msgs.join(' '), payload].inspect }
+    allow(OT).to receive(:le) { |*msgs, **payload| log_lines << [msgs.join(' '), payload].inspect }
+    # Diagnostics/Sentry off in this unit context.
+    allow(OT).to receive(:d9s_enabled).and_return(false)
+  end
+
+  def all_logs
+    log_lines.join("\n")
+  end
+
+  context 'legacy application/csp-report body' do
+    let(:body) do
+      {
+        'csp-report' => {
+          'document-uri'       => "https://example.com/secret/#{SECRET_KEY}?foo=bar",
+          'blocked-uri'        => "https://evil.example/steal/#{SECRET_KEY}",
+          'referrer'           => "https://example.com/private/#{SECRET_KEY}",
+          'violated-directive' => 'script-src',
+          'effective-directive' => 'script-src',
+          'disposition'        => 'report',
+          'line-number'        => 42,
+          'column-number'      => 7,
+        },
+      }.to_json
+    end
+
+    it 'responds 204 and never raises to the client' do
+      req = build_request(body: body)
+      controller = build_controller(req)
+
+      expect(response).to receive(:status=).with(204)
+      expect { controller.csp_report }.not_to raise_error
+    end
+
+    it 'logs the safe violated-directive' do
+      req = build_request(body: body)
+      build_controller(req).csp_report
+      expect(all_logs).to include('script-src')
+    end
+
+    it 'REDACTS the planted secret key out of every logged URL field' do
+      req = build_request(body: body)
+      build_controller(req).csp_report
+
+      expect(all_logs).not_to include(SECRET_KEY)
+      expect(all_logs).not_to include('foo=bar')         # query string stripped
+      expect(all_logs).to include('[redacted-path]')     # path collapsed
+    end
+  end
+
+  context 'Reporting API application/reports+json array body' do
+    let(:body) do
+      [
+        {
+          'type' => 'csp-violation',
+          'body' => {
+            'documentURL'       => "https://example.com/secret/#{SECRET_KEY}",
+            'blockedURL'        => "https://cdn.evil/#{SECRET_KEY}",
+            'effectiveDirective' => 'img-src',
+            'disposition'       => 'report',
+          },
+        },
+      ].to_json
+    end
+
+    it 'responds 204, logs the directive, and redacts the secret' do
+      req = build_request(body: body, content_type: 'application/reports+json')
+      controller = build_controller(req)
+
+      expect(response).to receive(:status=).with(204)
+      controller.csp_report
+
+      expect(all_logs).to include('img-src')
+      expect(all_logs).not_to include(SECRET_KEY)
+    end
+  end
+
+  context 'oversized body' do
+    let(:body) do
+      # > 64 KiB so it is skipped without parsing. Plant the secret to prove it
+      # is never logged.
+      "{\"csp-report\":{\"document-uri\":\"https://h/secret/#{SECRET_KEY}\",\"pad\":\"#{'x' * (70 * 1024)}\"}}"
+    end
+
+    it 'responds 204, does NOT parse, and never logs the secret' do
+      req = build_request(body: body)
+      controller = build_controller(req)
+
+      expect(response).to receive(:status=).with(204)
+      controller.csp_report
+
+      expect(all_logs).not_to include(SECRET_KEY)
+      # The "no parseable reports" debug line should have fired.
+      expect(all_logs).to include('no parseable violation reports')
+    end
+  end
+
+  context 'malformed JSON body' do
+    it 'responds 204 and logs nothing secret' do
+      req = build_request(body: '{not valid json')
+      controller = build_controller(req)
+
+      expect(response).to receive(:status=).with(204)
+      expect { controller.csp_report }.not_to raise_error
+      expect(all_logs).to include('no parseable violation reports')
+    end
+  end
+
+  context 'empty body' do
+    it 'responds 204' do
+      req = build_request(body: '')
+      controller = build_controller(req)
+
+      expect(response).to receive(:status=).with(204)
+      expect { controller.csp_report }.not_to raise_error
+    end
+  end
+end

--- a/spec/unit/security/csp_report_spec.rb
+++ b/spec/unit/security/csp_report_spec.rb
@@ -1,0 +1,96 @@
+# spec/unit/security/csp_report_spec.rb
+#
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'json'
+
+require_relative '../../../lib/onetime/security/csp_report'
+
+RSpec.describe Onetime::Security::CspReport do
+  SECRET = 'supersecrettoken0123456789abcdef0123456789'
+
+  describe '.redact_url' do
+    it 'strips the path entirely so a shallow secret link cannot leak' do
+      out = described_class.redact_url("https://host/#{SECRET}")
+      expect(out).to eq('https://host/[redacted-path]')
+      expect(out).not_to include(SECRET)
+    end
+
+    it 'strips the query string and deep path' do
+      out = described_class.redact_url("https://host/secret/#{SECRET}?x=y")
+      expect(out).to eq('https://host/[redacted-path]')
+      expect(out).not_to include(SECRET)
+      expect(out).not_to include('x=y')
+    end
+
+    it 'keeps a bare origin when there is no path' do
+      expect(described_class.redact_url('https://host/')).to eq('https://host/')
+    end
+
+    it 'preserves a non-default port' do
+      out = described_class.redact_url("https://host:8443/secret/#{SECRET}")
+      expect(out).to eq('https://host:8443/[redacted-path]')
+    end
+
+    it 'passes CSP keyword sources through unchanged' do
+      expect(described_class.redact_url('inline')).to eq('inline')
+      expect(described_class.redact_url('eval')).to eq('eval')
+      expect(described_class.redact_url('data')).to eq('data')
+    end
+
+    it 'refuses to echo an unparseable / schemeless value' do
+      expect(described_class.redact_url('::::nonsense')).to eq('[redacted]')
+    end
+
+    it 'returns nil for blank input' do
+      expect(described_class.redact_url(nil)).to be_nil
+      expect(described_class.redact_url('')).to be_nil
+    end
+  end
+
+  describe '.parse' do
+    it 'parses a legacy {"csp-report": {...}} document' do
+      body = { 'csp-report' => {
+        'document-uri' => "https://host/secret/#{SECRET}",
+        'violated-directive' => 'script-src',
+      } }.to_json
+
+      summaries = described_class.parse(body, 'application/csp-report')
+      expect(summaries.length).to eq(1)
+      expect(summaries.first['violated-directive']).to eq('script-src')
+      expect(summaries.first['document-uri']).not_to include(SECRET)
+    end
+
+    it 'parses a Reporting API array of csp-violation entries' do
+      body = [{ 'type' => 'csp-violation', 'body' => {
+        'documentURL' => "https://host/secret/#{SECRET}",
+        'effectiveDirective' => 'img-src',
+      } }].to_json
+
+      summaries = described_class.parse(body, 'application/reports+json')
+      expect(summaries.length).to eq(1)
+      expect(summaries.first['effective-directive']).to eq('img-src')
+      expect(summaries.first['document-uri']).not_to include(SECRET)
+    end
+
+    it 'returns [] for an oversized body (never parsed)' do
+      big = "{\"pad\":\"#{'x' * (described_class::MAX_BODY_BYTES + 10)}\"}"
+      expect(described_class.parse(big, 'application/csp-report')).to eq([])
+    end
+
+    it 'returns [] for malformed JSON' do
+      expect(described_class.parse('{not json', 'application/csp-report')).to eq([])
+    end
+
+    it 'returns [] for nil/empty bodies' do
+      expect(described_class.parse(nil, 'application/csp-report')).to eq([])
+      expect(described_class.parse('', 'application/csp-report')).to eq([])
+    end
+
+    it 'ignores non-csp-violation Reporting API entries' do
+      body = [{ 'type' => 'deprecation', 'body' => { 'id' => 'x' } }].to_json
+      expect(described_class.parse(body, 'application/reports+json')).to eq([])
+    end
+  end
+end

--- a/spec/unit/web/core/csp_report_only_spec.rb
+++ b/spec/unit/web/core/csp_report_only_spec.rb
@@ -26,6 +26,8 @@ require_relative '../../../../apps/web/core/middleware/request_setup'
 RSpec.describe Core::Middleware::RequestSetup, '#finalize_response (CSP report-only)' do
   RO_HEADER  = 'content-security-policy-report-only'
   ENF_HEADER = 'content-security-policy'
+  REPORTING_ENDPOINTS_HEADER = 'reporting-endpoints'
+  REPORT_PATH = '/api/v1/csp-report'
 
   let(:conf) { double('OT.conf') }
 
@@ -77,6 +79,22 @@ RSpec.describe Core::Middleware::RequestSetup, '#finalize_response (CSP report-o
       _status, headers, _body = run
       expect(headers[RO_HEADER]).to include("connect-src 'self' wss: https:;")
     end
+
+    it 'points the report-only policy at the V1 CSP report receiver' do
+      _status, headers, _body = run
+      csp = headers[RO_HEADER]
+
+      # Legacy report-uri directive points at the /api/ receiver.
+      expect(csp).to include("report-uri #{REPORT_PATH};")
+      # Modern Reporting API directive references the named endpoint group.
+      expect(csp).to include('report-to csp-endpoint;')
+    end
+
+    it 'defines the csp-endpoint group via a Reporting-Endpoints header' do
+      _status, headers, _body = run
+      expect(headers[REPORTING_ENDPOINTS_HEADER])
+        .to eq(%(csp-endpoint="#{REPORT_PATH}"))
+    end
   end
 
   context 'when CSP is enabled and development.enabled is true' do
@@ -95,6 +113,7 @@ RSpec.describe Core::Middleware::RequestSetup, '#finalize_response (CSP report-o
 
       expect(headers[RO_HEADER]).to be_nil
       expect(headers[ENF_HEADER]).to be_nil
+      expect(headers[REPORTING_ENDPOINTS_HEADER]).to be_nil
     end
 
     it 'treats a truthy-but-not-true value as disabled (strict ==)' do


### PR DESCRIPTION
## Summary

[#3498](https://github.com/onetimesecret/onetimesecret/issues/3498)

**Stacked on #3544** (base branch `claude/security-hardening-coord-e9ipeo`). Review/merge that one first; this PR shows only the report-endpoint diff on top of it.

The Core web app now emits a `Content-Security-Policy-Report-Only` header (in #3544), but the policy carried no `report-uri`/`report-to`, so browser violation reports went nowhere — report-only mode collected no data. This adds the receiver and points the policy at it.

**Receiver — `POST /api/v1/csp-report` (`V1::Controllers::Index#csp_report`):**
- Anonymous/public. Mounted under `/api/`, so the `AuthenticityToken` middleware auto-bypasses CSRF (`lib/onetime/middleware/security.rb`) — correct, since browsers POST CSP reports unauthenticated and without a CSRF token.
- Reads a size-capped body (≤ 64 KiB; oversized bodies are detected via a `cap+1` read and skipped without parsing). Parses **both** the legacy `application/csp-report` and the Reporting API `application/reports+json` formats. Tolerates malformed/empty input. Never writes to the database, never raises to the client, always responds `204 No Content`.

**Mandatory redaction (this is a secret-sharing app):**
- A report's `document-uri` / `blocked-uri` / `referrer` / `source-file` can contain a secret link such as `https://host/secret/<KEY>`. The new `Onetime::Security::CspReport` collapses every URL field to scheme+host (plus non-default port) and replaces the entire path with `[redacted-path]`, dropping the query string and fragment. It does **not** retain even the first path segment, because a shallow secret link can be as short as `https://host/<KEY>`. Only safe scalar fields (directive names, disposition, line/column/status numbers, redacted origins) are logged, via `OT.lw`. The same redacted summary is optionally mirrored to Sentry, guarded by the existing `sentry_available?` check; raw report data is never forwarded.

**Policy wiring:**
- `Onetime::Security::Csp.policy` gains an optional `report_uri:` keyword. It appends `report-uri <path>;` and `report-to csp-endpoint;` only when supplied; the default output (and the V1 API enforcing path, left unchanged) is **byte-identical** to before — `spec/unit/api/v1/csp_header_spec.rb` stays green.
- The web emission point (`apps/web/core/middleware/request_setup.rb`) now passes `report_uri: '/api/v1/csp-report'` and emits a `Reporting-Endpoints` response header defining the `csp-endpoint` group.

## Related Issues

Part of #3498. Does not close it — the broader CSP enforcing work is tracked separately in #3558.

## Test Plan

- New endpoint spec (`spec/unit/api/v1/csp_report_endpoint_spec.rb`): both wire formats → 204; asserts the `violated-directive` is logged while a planted 42-char secret (and the query string) **never** appears in captured log output; oversized/malformed/empty bodies → 204.
- New redaction/parsing unit spec (`spec/unit/security/csp_report_spec.rb`).
- Updated `spec/unit/web/core/csp_report_only_spec.rb` to assert the `report-uri`/`report-to` directives and the `Reporting-Endpoints` header.
- scriv `Security` changelog fragment added.

Verification: 46 CSP examples + 23 `spec/unit/api/v1` examples pass; `rubocop --fail-level warning` clean on all changed production files; no `Gemfile`/`Gemfile.lock` changes. Reviewed by a code reviewer and a security specialist (both approved, no must-fix items). The 14 pre-existing failures under `spec/api/v1/` (TTL entitlement / auth-status) are present on the base tip and are unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017trt2xM4hEQr3zLqddcEeV)_