### PR TITLE
Fix branding leaks on custom domains and page titles

### DIFF
--- a/changelog.d/20260701_000000_claude_masthead_pagetitle_neutral_fallback.rst
+++ b/changelog.d/20260701_000000_claude_masthead_pagetitle_neutral_fallback.rst
@@ -1,0 +1,10 @@
+.. A new scriv changelog fragment.
+
+Fixed
+-----
+
+- Custom domains with no uploaded logo no longer show the platform site name
+  beside the fallback logo.
+
+- Page titles and social-share meta tags fall back to the configured brand
+  name instead of a hardcoded "Onetime Secret".

--- a/src/shared/components/layout/MastHead.vue
+++ b/src/shared/components/layout/MastHead.vue
@@ -21,6 +21,7 @@
     cust,
     ui,
     domain_logo,
+    domain_strategy,
     brand_product_name,
   } = storeToRefs(bootstrapStore);
 
@@ -76,13 +77,23 @@
   // Priority:
   //   1. props.logo.showSiteName            (caller-site override)
   //   2. domain_logo.value                  (per-tenant: always hide platform name)
-  //   3. headerConfig.branding.logo.show_name  (LOGO_SHOW_NAME explicit config)
-  //   4. isCustomStaticLogo.value           (heuristic: custom LOGO_URL usually
+  //   3. domain_strategy === 'custom'       (custom domain, no uploaded logo:
+  //                                          never leak the platform site name)
+  //   4. headerConfig.branding.logo.show_name  (LOGO_SHOW_NAME explicit config)
+  //   5. isCustomStaticLogo.value           (heuristic: custom LOGO_URL usually
   //                                          embeds its own wordmark)
-  //   5. !!site_name                        (default visibility tied to SITE_NAME)
+  //   6. !!site_name                        (default visibility tied to SITE_NAME)
   const getShowSiteName = () => {
     if (props.logo?.showSiteName != null) return props.logo.showSiteName;
     if (domain_logo.value) return false;
+
+    // A3 custom-domain branding leak: on a custom domain with no uploaded
+    // domain_logo we fall back to DefaultLogo's neutral mark. Rendering the
+    // platform SITE_NAME next to it would leak our identity onto another
+    // company's domain (transactional routes reach here via
+    // TransactionalHeader → MastHead with no domain-aware switching), so
+    // suppress the site name entirely.
+    if (domain_strategy.value === 'custom') return false;
 
     const showName = headerConfig.value?.branding?.logo?.show_name;
     if (showName != null) return showName;

--- a/src/shared/composables/usePageTitle.ts
+++ b/src/shared/composables/usePageTitle.ts
@@ -1,6 +1,7 @@
 // src/shared/composables/usePageTitle.ts
 
 import { globalComposer } from '@/i18n';
+import { NEUTRAL_BRAND_DEFAULTS } from '@/shared/constants/brand';
 import { useBootstrapStore } from '@/shared/stores/bootstrapStore';
 import { storeToRefs } from 'pinia';
 import { computed, watch } from 'vue';
@@ -33,7 +34,6 @@ import { computed, watch } from 'vue';
  * });
  */
 
-const APP_NAME = 'Onetime Secret';
 const TITLE_SEPARATOR = ' - ';
 
 export function usePageTitle() {
@@ -43,16 +43,30 @@ export function usePageTitle() {
   const { t, te } = globalComposer;
 
   const bootstrapStore = useBootstrapStore();
-  const { display_domain } = storeToRefs(bootstrapStore);
+  const { display_domain, brand_product_name } = storeToRefs(bootstrapStore);
 
   // Cache DOM elements to avoid repeated queries
   let ogTitleMeta: HTMLMetaElement | null | undefined;
   let twitterTitleMeta: HTMLMetaElement | null | undefined;
 
   /**
-   * Gets the branded app name from domain settings or defaults to APP_NAME
+   * Resolves the app name used in the document title, og:title and
+   * twitter:title, following the neutral brand fallback chain:
+   *   1. display_domain        - the active (custom) domain, when set
+   *   2. brand_product_name    - the per-installation product name from OT.conf
+   *   3. NEUTRAL_BRAND_DEFAULTS.product_name - the neutral 'My App' default
+   *
+   * This must NEVER emit OTS branding. Mirroring the philosophy in
+   * constants/brand.ts, when neither a domain nor a configured product name is
+   * available the title degrades to the neutral default rather than leaking
+   * "Onetime Secret" into browser tabs or social-share previews. This supports
+   * private-label deployments.
+   *
+   * Reads `.value` on each call so the resolved name stays reactive to store
+   * changes (do not hoist the raw values out of the refs).
    */
-  const getAppName = (): string => display_domain.value || APP_NAME;
+  const getAppName = (): string =>
+    display_domain.value || brand_product_name.value || NEUTRAL_BRAND_DEFAULTS.product_name;
 
   /**
    * Translates a title if it's an i18n key, otherwise returns the raw string

--- a/src/tests/shared/components/layout/MastHead.customDomain.spec.ts
+++ b/src/tests/shared/components/layout/MastHead.customDomain.spec.ts
@@ -348,7 +348,7 @@ describe('MastHead — Custom Domain Logo Behavior', () => {
       expect(defaultLogo.exists()).toBe(true);
     });
 
-    it('shows OTS site name when custom domain has no logo', async () => {
+    it('suppresses the OTS site name when custom domain has no logo', async () => {
       wrapper = mountComponent(
         {},
         {
@@ -360,11 +360,11 @@ describe('MastHead — Custom Domain Logo Behavior', () => {
       );
 
       await nextTick();
-      // Without domain_logo, the site name logic does NOT suppress the name
-      // This means the OTS site name "Onetime Secret" appears on a custom domain
+      // A3 fix: on a custom domain the DefaultLogo neutral mark still renders,
+      // but the platform site name "Onetime Secret" must NOT leak next to it.
       const logo = wrapper.find('.default-logo');
       expect(logo.exists()).toBe(true);
-      expect(logo.attributes('data-show-site-name')).toBe('true');
+      expect(logo.attributes('data-show-site-name')).toBe('false');
     });
 
     it('uses standard sizing (not 80px) when no custom logo is set', async () => {
@@ -492,24 +492,29 @@ describe('MastHead — Custom Domain Logo Behavior', () => {
   });
 
   // ═══════════════════════════════════════════════════════════════════════════
-  // BUG DOCUMENTATION: Default logo leaks on custom domains
+  // A3 FIX: Default logo no longer leaks the platform name on custom domains
   //
-  // MastHead's logo logic is driven by `domain_logo` (URL or null), not
-  // `domain_strategy`. When domain_strategy='custom' but domain_logo is null
-  // (e.g., customer hasn't uploaded a logo), MastHead renders the OTS default
-  // logo with "Onetime Secret" branding — which is wrong for custom domains.
+  // Previously MastHead's site-name logic was driven only by `domain_logo`
+  // (URL or null), not `domain_strategy`. When domain_strategy='custom' but
+  // domain_logo was null (e.g., customer hasn't uploaded a logo), MastHead fell
+  // back to the DefaultLogo AND still rendered the platform "Onetime Secret"
+  // site name — leaking our identity onto another company's custom domain.
   //
   // Leak routes: /incoming, /feedback, /help, /pricing — these use
   // TransactionalHeader → MastHead directly, with no domain-aware switching.
   //
   // Non-leaking routes: homepage (BrandedHeader switches), reveal (hides
   // masthead entirely), receipt (beforeEnter guard patches props).
+  //
+  // The fix: getShowSiteName() now returns false when domain_strategy='custom'
+  // and there is no domain_logo. The neutral DefaultLogo mark still renders;
+  // only the platform site name is suppressed.
   // ═══════════════════════════════════════════════════════════════════════════
 
-  describe('Bug: MastHead ignores domain_strategy when domain_logo is null', () => {
-    it('shows OTS default logo on custom domain when no logo uploaded (current behavior)', async () => {
-      // This documents the bug: a customer on secrets.acme.com sees the
-      // Onetime Secret logo because MastHead only checks domain_logo, not domain_strategy
+  describe('A3 fix: MastHead is domain_strategy-aware when domain_logo is null', () => {
+    it('shows the neutral DefaultLogo mark but no OTS site name on custom domain when no logo uploaded', async () => {
+      // A customer on secrets.acme.com falls back to the neutral DefaultLogo
+      // mark, but the platform "Onetime Secret" site name must not leak.
       wrapper = mountComponent(
         {},
         {
@@ -523,12 +528,13 @@ describe('MastHead — Custom Domain Logo Behavior', () => {
 
       await nextTick();
 
-      // BUG: DefaultLogo renders even though we're on a custom domain
+      // The neutral DefaultLogo mark still renders (DefaultLogo shows the
+      // brand-agnostic KeyholeIcon, so the mark itself is safe).
       const defaultLogo = wrapper.find('.default-logo');
       expect(defaultLogo.exists()).toBe(true);
 
-      // BUG: "Onetime Secret" site name shows on another company's domain
-      expect(defaultLogo.attributes('data-show-site-name')).toBe('true');
+      // FIXED: "Onetime Secret" site name is suppressed on another company's domain
+      expect(defaultLogo.attributes('data-show-site-name')).toBe('false');
     });
 
     it('does not suppress auth navigation on custom domain (correct: auth nav should remain)', async () => {
@@ -551,18 +557,102 @@ describe('MastHead — Custom Domain Logo Behavior', () => {
   });
 
   // ═══════════════════════════════════════════════════════════════════════════
-  // EXPECTED BEHAVIOR AFTER FIX (these should pass once the fix lands)
+  // A3 REGRESSION GUARDS: MastHead is domain_strategy-aware
+  //
+  // The fix makes MastHead check domain_strategy='custom':
+  // 1. If domain_logo is set → show the custom logo (unchanged).
+  // 2. If domain_logo is null → render the neutral DefaultLogo mark WITHOUT the
+  //    platform "Onetime Secret" site name (no branding leak).
+  // Canonical domains are unaffected — the site name still shows there.
   // ═══════════════════════════════════════════════════════════════════════════
 
-  describe.todo('Expected: MastHead should be domain_strategy-aware', () => {
-    // Once fixed, MastHead should check domain_strategy='custom' and:
-    // 1. If domain_logo is set → show custom logo (already works)
-    // 2. If domain_logo is null → hide logo entirely or show a neutral placeholder
-    //    (NOT the OTS default logo with "Onetime Secret" branding)
-    //
-    // Test stubs for when the fix is implemented:
-    // it('hides DefaultLogo when domain_strategy=custom and no domain_logo', ...)
-    // it('does not show "Onetime Secret" site name on custom domain', ...)
-    // it('shows neutral placeholder when custom domain has no logo', ...)
+  describe('A3 regression: MastHead should be domain_strategy-aware', () => {
+    it('does not leak the "Onetime Secret" site name when domain_strategy=custom and domain_logo is null', async () => {
+      wrapper = mountComponent(
+        {},
+        {
+          authenticated: false,
+          domain_strategy: 'custom',
+          domain_logo: null,
+          display_domain: 'secrets.acme.com',
+          domain_id: 'cd_acme',
+        }
+      );
+
+      await nextTick();
+
+      const logo = wrapper.find('.default-logo');
+      expect(logo.exists()).toBe(true);
+      // Site name is suppressed...
+      expect(logo.attributes('data-show-site-name')).toBe('false');
+      // ...and the DefaultLogo mock only renders the site-name span when
+      // showSiteName is true, so "Onetime Secret" must be absent from the DOM.
+      const siteName = wrapper.find('.default-logo .site-name');
+      expect(siteName.exists()).toBe(false);
+      expect(wrapper.text()).not.toContain('Onetime Secret');
+    });
+
+    it('still renders the neutral DefaultLogo mark when domain_strategy=custom and domain_logo is null', async () => {
+      wrapper = mountComponent(
+        {},
+        {
+          authenticated: false,
+          domain_strategy: 'custom',
+          domain_logo: null,
+          display_domain: 'secrets.acme.com',
+          domain_id: 'cd_acme',
+        }
+      );
+
+      await nextTick();
+
+      // The neutral mark itself is safe (KeyholeIcon), so DefaultLogo must
+      // still render — we suppress the wordmark, not the whole lockup.
+      const defaultLogo = wrapper.find('.default-logo');
+      expect(defaultLogo.exists()).toBe(true);
+      const logoIcon = wrapper.find('.default-logo .logo-icon');
+      expect(logoIcon.exists()).toBe(true);
+    });
+
+    it('sanity: still shows the site name on a canonical domain (fix scoped to custom)', async () => {
+      wrapper = mountComponent(
+        {},
+        {
+          authenticated: false,
+          domain_strategy: 'canonical',
+          domain_logo: null,
+        }
+      );
+
+      await nextTick();
+
+      const logo = wrapper.find('.default-logo');
+      expect(logo.exists()).toBe(true);
+      // Canonical domains are unaffected: the platform site name still shows.
+      expect(logo.attributes('data-show-site-name')).toBe('true');
+    });
+
+    it('leaves custom-domain-WITH-logo behavior unchanged (img renders, no site name)', async () => {
+      wrapper = mountComponent(
+        {},
+        {
+          authenticated: false,
+          domain_strategy: 'custom',
+          domain_logo: 'https://cdn.example.com/logos/acme-logo.png',
+          display_domain: 'secrets.acme.com',
+          domain_id: 'cd_acme',
+        }
+      );
+
+      await nextTick();
+
+      // Custom logo renders as an <img>, not the DefaultLogo component.
+      const img = wrapper.find('img#logo');
+      expect(img.exists()).toBe(true);
+      expect(img.attributes('src')).toBe('https://cdn.example.com/logos/acme-logo.png');
+      // And the site name text mark is not rendered next to it.
+      const siteName = wrapper.find('span.font-brand.text-lg');
+      expect(siteName.exists()).toBe(false);
+    });
   });
 });

--- a/src/tests/shared/composables/usePageTitle.spec.ts
+++ b/src/tests/shared/composables/usePageTitle.spec.ts
@@ -1,0 +1,135 @@
+// src/tests/shared/composables/usePageTitle.spec.ts
+//
+// A4 fix: the page-title composable must never leak OTS branding into the
+// document <title>, og:title or twitter:title. When no display domain is
+// available it falls back to the configured brand product name, and finally to
+// the neutral default ('My App') — never the hardcoded "Onetime Secret".
+//
+// These tests exercise getAppName()'s fallback chain via the public
+// formatTitle() and setTitle() API and assert on the resulting jsdom
+// document.title.
+
+import { NEUTRAL_BRAND_DEFAULTS } from '@/shared/constants/brand';
+import { usePageTitle } from '@/shared/composables/usePageTitle';
+import { createTestingPinia } from '@pinia/testing';
+import { setActivePinia } from 'pinia';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// usePageTitle reads `const { t, te } = globalComposer` from '@/i18n' at the
+// top of the composable (so it can run outside a component setup context).
+// Mock the module to supply a deterministic, pass-through composer:
+//   - te() returns false so titles are treated as plain strings, not i18n keys
+//   - t() echoes the key back (never reached here, kept for completeness)
+// This keeps the tests focused on the brand fallback chain.
+vi.mock('@/i18n', () => ({
+  globalComposer: {
+    t: (key: string) => key,
+    te: () => false,
+  },
+}));
+
+/**
+ * Installs a fresh testing Pinia with the given bootstrap fields and makes it
+ * the active instance so useBootstrapStore() (called inside usePageTitle)
+ * resolves against it.
+ */
+const setupPinia = (bootstrap: {
+  display_domain?: string;
+  brand_product_name?: string | null;
+}) => {
+  const pinia = createTestingPinia({
+    createSpy: vi.fn,
+    stubActions: false,
+    initialState: {
+      bootstrap,
+    },
+  });
+  setActivePinia(pinia);
+  return pinia;
+};
+
+describe('usePageTitle — brand fallback (A4 branding leak)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Reset the jsdom title between cases so assertions are deterministic.
+    document.title = '';
+  });
+
+  describe('getAppName fallback chain via formatTitle', () => {
+    it('uses the display domain when it is set', () => {
+      setupPinia({ display_domain: 'secrets.acme.com', brand_product_name: 'Acme Vault' });
+      const { formatTitle } = usePageTitle();
+
+      // The active domain wins over both the product name and the neutral default.
+      expect(formatTitle('Dashboard')).toBe('Dashboard - secrets.acme.com');
+    });
+
+    it('falls back to brand_product_name when display_domain is empty', () => {
+      setupPinia({ display_domain: '', brand_product_name: 'Acme Vault' });
+      const { formatTitle } = usePageTitle();
+
+      const title = formatTitle('Dashboard');
+      expect(title).toBe('Dashboard - Acme Vault');
+      // Must not leak the platform name.
+      expect(title).not.toContain('Onetime Secret');
+    });
+
+    it('falls back to the neutral default when both domain and product name are unset', () => {
+      setupPinia({ display_domain: '', brand_product_name: null });
+      const { formatTitle } = usePageTitle();
+
+      const title = formatTitle('Dashboard');
+      expect(title).toBe(`Dashboard - ${NEUTRAL_BRAND_DEFAULTS.product_name}`);
+      expect(title).toContain('My App');
+      // The core A4 guarantee: never emit OTS branding.
+      expect(title).not.toContain('Onetime Secret');
+    });
+
+    it('falls back to the neutral default when brand_product_name is an empty string', () => {
+      // An empty string is falsy and must fall through to the neutral default,
+      // not produce a dangling separator or a blank app name.
+      setupPinia({ display_domain: '', brand_product_name: '' });
+      const { formatTitle } = usePageTitle();
+
+      expect(formatTitle('Dashboard')).toBe(`Dashboard - ${NEUTRAL_BRAND_DEFAULTS.product_name}`);
+    });
+  });
+
+  describe('setTitle updates document.title and meta with the resolved app name', () => {
+    it('sets document.title to "Page - <displayDomain>" when a page title is given', () => {
+      setupPinia({ display_domain: 'secrets.acme.com', brand_product_name: null });
+      const { setTitle } = usePageTitle();
+
+      setTitle('Some Page');
+      expect(document.title).toBe('Some Page - secrets.acme.com');
+    });
+
+    it('setTitle(null) yields just the app name (brand_product_name fallback)', () => {
+      setupPinia({ display_domain: '', brand_product_name: 'Acme Vault' });
+      const { setTitle } = usePageTitle();
+
+      setTitle(null);
+      expect(document.title).toBe('Acme Vault');
+      expect(document.title).not.toContain('Onetime Secret');
+    });
+
+    it('setTitle(undefined) yields just the neutral default when nothing is configured', () => {
+      setupPinia({ display_domain: '', brand_product_name: null });
+      const { setTitle } = usePageTitle();
+
+      setTitle(undefined);
+      expect(document.title).toBe(NEUTRAL_BRAND_DEFAULTS.product_name);
+      expect(document.title).not.toContain('Onetime Secret');
+    });
+  });
+
+  describe('formatTitle app-name-only collapsing', () => {
+    it('returns just the app name when the page title equals the app name', () => {
+      setupPinia({ display_domain: 'secrets.acme.com', brand_product_name: null });
+      const { formatTitle } = usePageTitle();
+
+      // Avoids "secrets.acme.com - secrets.acme.com" duplication.
+      expect(formatTitle('secrets.acme.com')).toBe('secrets.acme.com');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes two branding leaks that expose "Onetime Secret" platform identity on custom domains and in page titles:

1. **MastHead (A3)**: When a custom domain has no uploaded logo, MastHead now suppresses the platform site name ("Onetime Secret") that was leaking beside the fallback DefaultLogo mark. The neutral logo icon still renders, but the wordmark is hidden.

2. **Page Title (A4)**: The `usePageTitle` composable now follows a neutral brand fallback chain: display domain → configured brand product name → neutral default ("My App"). Previously it would hardcode "Onetime Secret" when no domain was available, leaking platform branding into browser tabs and social-share meta tags.

## Changes

- **MastHead.vue**: Updated `getShowSiteName()` to check `domain_strategy === 'custom'` and suppress the site name when no custom logo is uploaded, preventing branding leaks on transactional routes (`/incoming`, `/feedback`, `/help`, `/pricing`).

- **usePageTitle.ts**: Replaced hardcoded `APP_NAME = 'Onetime Secret'` with a fallback chain that respects `brand_product_name` from the bootstrap store and degrades to `NEUTRAL_BRAND_DEFAULTS.product_name` ('My App') when neither domain nor configured product name is available.

- **MastHead.customDomain.spec.ts**: Updated test descriptions and assertions to reflect the fix. Converted `describe.todo` stubs into active regression tests that verify the site name is suppressed on custom domains without uploaded logos, while canonical domains remain unaffected.

- **usePageTitle.spec.ts** (new): Added comprehensive unit tests covering the brand fallback chain via `formatTitle()` and `setTitle()`, ensuring "Onetime Secret" never leaks into document titles or meta tags.

## Related Issues

Fixes branding leak issues on custom domains and page titles (A3, A4).

## Test Plan

All changes are covered by automated tests:
- MastHead regression suite verifies site name suppression on custom domains and that canonical domains are unaffected
- New usePageTitle tests exercise the fallback chain and assert "Onetime Secret" is never emitted
- Existing tests pass; no manual testing required

https://claude.ai/code/session_01CZi2qTc7axNicijYMNBaLV