### PR TITLE
Extract email defaults logic and localize no-reply placeholder

### DIFF
--- a/changelog.d/20260701_000100_claude_email_local_part_placeholder_i18n.rst
+++ b/changelog.d/20260701_000100_claude_email_local_part_placeholder_i18n.rst
@@ -1,0 +1,6 @@
+.. A new scriv changelog fragment.
+
+Changed
+-------
+
+- The custom email sender's address-field placeholder is now localizable.

--- a/locales/content/en/workspace-domains.json
+++ b/locales/content/en/workspace-domains.json
@@ -655,6 +655,10 @@
     "text": "e.g. secrets{'@'}example.com",
     "content_hash": "a09b3928"
   },
+  "web.domains.email.from_address_local_placeholder": {
+    "text": "no-reply",
+    "context": "Placeholder for the local part (before the @) of the sender email address. 'no-reply' is a reserved technical mailbox name (RFC 2142) — keep it as-is, do not translate."
+  },
   "web.domains.email.reply_to_label": {
     "text": "Reply-To Address",
     "content_hash": "4538ea9c"

--- a/src/apps/workspace/components/domains/DomainEmailConfigForm.vue
+++ b/src/apps/workspace/components/domains/DomainEmailConfigForm.vue
@@ -202,7 +202,7 @@ const providerDisplayName = computed(() => {
             type="text"
             required
             autocomplete="off"
-            placeholder="no-reply"
+            :placeholder="t('web.domains.email.from_address_local_placeholder')"
             class="block w-full min-w-0 flex-1 rounded-l-md border-gray-300 shadow-sm focus:border-brand-500 focus:ring-brand-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:placeholder:text-gray-400 sm:text-sm"
             @input="fromAddressLocalPart = ($event.target as HTMLInputElement).value" />
           <span

--- a/src/apps/workspace/domains/DomainEmail.vue
+++ b/src/apps/workspace/domains/DomainEmail.vue
@@ -8,22 +8,25 @@
  * form component, and DNS records display. Follows the DomainSso page
  * structure: header -> entitlement gate -> fallback notice -> form -> DNS.
  */
-import { useI18n } from 'vue-i18n';
-import { computed, onMounted, watch } from 'vue';
-import { useRouter } from 'vue-router';
-import { storeToRefs } from 'pinia';
-import OIcon from '@/shared/components/icons/OIcon.vue';
-import BasicFormAlerts from '@/shared/components/forms/BasicFormAlerts.vue';
 import DomainHeader from '@/apps/workspace/components/dashboard/DomainHeader.vue';
 import DomainEmailConfigForm from '@/apps/workspace/components/domains/DomainEmailConfigForm.vue';
 import DomainEmailDnsRecords from '@/apps/workspace/components/domains/DomainEmailDnsRecords.vue';
 import SettingsSkeleton from '@/shared/components/closet/SettingsSkeleton.vue';
+import BasicFormAlerts from '@/shared/components/forms/BasicFormAlerts.vue';
+import OIcon from '@/shared/components/icons/OIcon.vue';
 import { useDomain } from '@/shared/composables/useDomain';
-
-import { useEmailConfig, buildDomainEmailDefaults } from '@/shared/composables/useEmailConfig';
+import {
+  useEmailConfig,
+  buildDomainEmailDefaults,
+  type EmailConfigFormState,
+} from '@/shared/composables/useEmailConfig';
 import { useEntitlements } from '@/shared/composables/useEntitlements';
 import { useOrganizationStore } from '@/shared/stores/organizationStore';
 import { ENTITLEMENTS } from '@/types/organization';
+import { storeToRefs } from 'pinia';
+import { computed, onMounted, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { useRouter } from 'vue-router';
 import { onBeforeRouteLeave } from 'vue-router';
 
 const { t } = useI18n();
@@ -104,8 +107,6 @@ const {
 // ---------------------------------------------------------------------------
 // Form state handler
 // ---------------------------------------------------------------------------
-
-import type { EmailConfigFormState } from '@/shared/composables/useEmailConfig';
 
 const handleFormStateUpdate = (state: EmailConfigFormState) => {
   formState.value = state;
@@ -242,14 +243,13 @@ watch(hasEntitlement, async (entitled) => {
             </div>
           </div>
 
-          <div class="p-6 space-y-8">
+          <div class="space-y-8 p-6">
             <!-- Email config loading -->
             <SettingsSkeleton
               v-if="emailLoading && !isInitialized"
               :heading="false" />
 
             <template v-else>
-
               <!-- Email Configuration Form -->
               <DomainEmailConfigForm
                 :form-state="formState"

--- a/src/apps/workspace/domains/DomainEmail.vue
+++ b/src/apps/workspace/domains/DomainEmail.vue
@@ -20,7 +20,7 @@ import DomainEmailDnsRecords from '@/apps/workspace/components/domains/DomainEma
 import SettingsSkeleton from '@/shared/components/closet/SettingsSkeleton.vue';
 import { useDomain } from '@/shared/composables/useDomain';
 
-import { useEmailConfig } from '@/shared/composables/useEmailConfig';
+import { useEmailConfig, buildDomainEmailDefaults } from '@/shared/composables/useEmailConfig';
 import { useEntitlements } from '@/shared/composables/useEntitlements';
 import { useOrganizationStore } from '@/shared/stores/organizationStore';
 import { ENTITLEMENTS } from '@/types/organization';
@@ -61,21 +61,13 @@ const billingRoute = computed(() => `/billing/${props.orgid}/plans`);
 const displayDomain = computed(() => customDomainRecord.value?.display_domain);
 
 /**
- * Sender defaults for a domain that has no saved email config yet. Pre-filling
- * `no-reply@<domain>` and a display name lets the operator enable the custom
- * sender by flipping the toggle and saving — without first having to choose an
- * address. They can still override either field before saving.
+ * Sender defaults for a domain that has no saved email config yet, derived by
+ * the shared `buildDomainEmailDefaults` helper (pre-fills `no-reply@<domain>`
+ * and the organization name). Both fields remain editable before saving.
  */
-const emailDefaults = computed(() => {
-  const domain = displayDomain.value;
-  // from_name is capped at 100 chars server-side; the input's maxlength only
-  // bounds typed values, so truncate the programmatic default to match.
-  const fromName = (organization.value?.display_name || domain || '').slice(0, 100);
-  return {
-    fromAddress: domain ? `no-reply@${domain}` : '',
-    fromName,
-  };
-});
+const emailDefaults = computed(() =>
+  buildDomainEmailDefaults(displayDomain.value, organization.value?.display_name)
+);
 
 // ---------------------------------------------------------------------------
 // Email config composable

--- a/src/shared/composables/useEmailConfig.ts
+++ b/src/shared/composables/useEmailConfig.ts
@@ -74,17 +74,22 @@ const FROM_NAME_MAX_LENGTH = 100;
  *   absent the address is left blank — there is nothing to anchor `no-reply@`
  *   to, and a bare local part is not a valid sender address.
  * @param senderName - Preferred display name (e.g. the organization name);
- *   falls back to the domain, then to empty. Capped at 100 chars to match the
- *   from_name input's maxlength and the server-side limit.
+ *   falls back to the domain, then to empty. A whitespace-only name counts as
+ *   empty (it is free-text user input) so the fallback still applies. Capped at
+ *   100 chars to match the from_name input's maxlength and the server-side limit.
  */
 export function buildDomainEmailDefaults(
   displayDomain?: string,
   senderName?: string
 ): EmailConfigDefaults {
   const domain = displayDomain ?? '';
+  // Trim before the fallback: a whitespace-only sender name would otherwise be
+  // truthy here, survive as the from_name, and then get trimmed away by
+  // createDefaultFormState — leaving a blank name even when a domain is present.
+  const name = senderName?.trim() || domain;
   return {
     fromAddress: domain ? `${NO_REPLY_LOCAL_PART}@${domain}` : '',
-    fromName: (senderName || domain).slice(0, FROM_NAME_MAX_LENGTH),
+    fromName: name.slice(0, FROM_NAME_MAX_LENGTH),
   };
 }
 

--- a/src/shared/composables/useEmailConfig.ts
+++ b/src/shared/composables/useEmailConfig.ts
@@ -50,6 +50,44 @@ export interface EmailConfigDefaults {
   fromAddress?: string;
 }
 
+/**
+ * Canonical local part for the default sender address. A reserved, well-known
+ * mailbox name (RFC 2142); kept here as the single source of truth so the
+ * pre-filled default (`buildDomainEmailDefaults`) and the form's placeholder
+ * i18n text stay in lockstep. See the consistency test in useEmailConfig.spec.
+ */
+export const NO_REPLY_LOCAL_PART = 'no-reply';
+
+/** Sender display name is capped at 100 chars server-side; match that here. */
+const FROM_NAME_MAX_LENGTH = 100;
+
+/**
+ * Build the sender defaults for a domain that has no saved email config yet.
+ * Pre-fills `no-reply@<domain>` and a display name so the operator can enable
+ * the custom sender by flipping the toggle and saving — without first having to
+ * choose an address. Both fields remain editable.
+ *
+ * Kept as a pure function (rather than inline in the page component) so the
+ * default-derivation rules are unit-testable in isolation.
+ *
+ * @param displayDomain - The custom domain (e.g. `mail.acme.example`). When
+ *   absent the address is left blank — there is nothing to anchor `no-reply@`
+ *   to, and a bare local part is not a valid sender address.
+ * @param senderName - Preferred display name (e.g. the organization name);
+ *   falls back to the domain, then to empty. Capped at 100 chars to match the
+ *   from_name input's maxlength and the server-side limit.
+ */
+export function buildDomainEmailDefaults(
+  displayDomain?: string,
+  senderName?: string
+): EmailConfigDefaults {
+  const domain = displayDomain ?? '';
+  return {
+    fromAddress: domain ? `${NO_REPLY_LOCAL_PART}@${domain}` : '',
+    fromName: (senderName || domain).slice(0, FROM_NAME_MAX_LENGTH),
+  };
+}
+
 function createDefaultFormState(defaults: EmailConfigDefaults = {}): EmailConfigFormState {
   return {
     from_name: defaults.fromName?.trim() || '',

--- a/src/tests/apps/workspace/components/domains/DomainEmailConfigForm.spec.ts
+++ b/src/tests/apps/workspace/components/domains/DomainEmailConfigForm.spec.ts
@@ -678,6 +678,20 @@ describe('DomainEmailConfigForm', () => {
       expect(emailInput.attributes('type')).toBe('text');
     });
 
+    it('renders the pre-filled no-reply default as the split-input local part', () => {
+      // End-to-end for the B1 default: buildDomainEmailDefaults produces
+      // `no-reply@<domain>`, and the split-input getter surfaces just the local
+      // part — so an operator sees "no-reply" ready to save, not the full address.
+      wrapper = mountComponent({
+        formState: { ...configuredFormState, from_address: 'no-reply@example.com' },
+        displayDomain: 'example.com',
+        flexibleFromDomain: false,
+      });
+
+      const localPartInput = wrapper.find('#email-from-address');
+      expect((localPartInput.element as HTMLInputElement).value).toBe('no-reply');
+    });
+
     it('shows full email input when flexibleFromDomain=true', () => {
       wrapper = mountComponent({
         formState: configuredFormState,

--- a/src/tests/composables/useEmailConfig.spec.ts
+++ b/src/tests/composables/useEmailConfig.spec.ts
@@ -10,12 +10,17 @@
 // 7. reply_to always included in payload (bug fix coverage)
 // 8. validateDomain: triggers DNS record verification
 
-import { useEmailConfig } from '@/shared/composables/useEmailConfig';
+import {
+  buildDomainEmailDefaults,
+  NO_REPLY_LOCAL_PART,
+  useEmailConfig,
+} from '@/shared/composables/useEmailConfig';
 import { createPinia, setActivePinia } from 'pinia';
 import { flushPromises } from '@vue/test-utils';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { CustomDomainEmailConfig } from '@/schemas/shapes/domains/email-config';
+import enWorkspaceDomains from '@locales/content/en/workspace-domains.json';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Mock Setup
@@ -1080,5 +1085,75 @@ describe('useEmailConfig', () => {
       const composable = useEmailConfig('dm-ext-123');
       expect(composable.emailConfig.value).toBeNull();
     });
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// buildDomainEmailDefaults — pure default-derivation helper
+//
+// This is the logic that used to live inline in DomainEmail.vue's `emailDefaults`
+// computed (untestable without mounting the whole page). Extracting it makes the
+// no-reply@<domain> / display-name rules directly assertable.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('buildDomainEmailDefaults', () => {
+  it('pre-fills no-reply@<domain> and prefers the sender name', () => {
+    expect(buildDomainEmailDefaults('acme.example', 'Acme Inc')).toEqual({
+      fromAddress: 'no-reply@acme.example',
+      fromName: 'Acme Inc',
+    });
+  });
+
+  it('falls back to the domain as the display name when no sender name is given', () => {
+    expect(buildDomainEmailDefaults('acme.example')).toEqual({
+      fromAddress: 'no-reply@acme.example',
+      fromName: 'acme.example',
+    });
+  });
+
+  it('falls back to the domain when the sender name is an empty string', () => {
+    expect(buildDomainEmailDefaults('acme.example', '').fromName).toBe('acme.example');
+  });
+
+  it('leaves the address blank when the domain is unknown', () => {
+    // No domain → nothing to anchor `no-reply@` to; a bare local part is not a
+    // valid sender address, so the form stays (correctly) unsaveable.
+    expect(buildDomainEmailDefaults(undefined, 'Acme Inc')).toEqual({
+      fromAddress: '',
+      fromName: 'Acme Inc',
+    });
+  });
+
+  it('returns fully blank defaults when neither domain nor name is known', () => {
+    expect(buildDomainEmailDefaults()).toEqual({ fromAddress: '', fromName: '' });
+  });
+
+  it('caps the display name at 100 characters to match the server-side limit', () => {
+    expect(buildDomainEmailDefaults('acme.example', 'x'.repeat(150)).fromName).toBe(
+      'x'.repeat(100)
+    );
+  });
+
+  it('derives the address local part from NO_REPLY_LOCAL_PART', () => {
+    expect(buildDomainEmailDefaults('acme.example', 'Acme').fromAddress).toBe(
+      `${NO_REPLY_LOCAL_PART}@acme.example`
+    );
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Canonical no-reply local part — single source of truth
+//
+// "no-reply" is expressed twice: as the pre-filled default (NO_REPLY_LOCAL_PART,
+// via buildDomainEmailDefaults) and as the split-input placeholder's i18n text.
+// This test binds the two so a change to one without the other fails CI.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('no-reply canonical local part', () => {
+  it('the split-input placeholder i18n text matches NO_REPLY_LOCAL_PART', () => {
+    const entry = (enWorkspaceDomains as Record<string, { text: string }>)[
+      'web.domains.email.from_address_local_placeholder'
+    ];
+    expect(entry?.text).toBe(NO_REPLY_LOCAL_PART);
   });
 });

--- a/src/tests/composables/useEmailConfig.spec.ts
+++ b/src/tests/composables/useEmailConfig.spec.ts
@@ -1162,9 +1162,11 @@ describe('buildDomainEmailDefaults', () => {
 
 describe('no-reply canonical local part', () => {
   it('the split-input placeholder i18n text matches NO_REPLY_LOCAL_PART', () => {
-    const entry = (enWorkspaceDomains as Record<string, { text: string }>)[
-      'web.domains.email.from_address_local_placeholder'
-    ];
-    expect(entry?.text).toBe(NO_REPLY_LOCAL_PART);
+    const key = 'web.domains.email.from_address_local_placeholder';
+    const entry = (enWorkspaceDomains as Record<string, { text?: string }>)[key];
+    // Assert the entry (and its `text` shape) exists first, so a renamed key or
+    // changed JSON format fails with a clear message instead of `undefined`.
+    expect(entry, `Missing i18n entry "${key}" in en/workspace-domains.json`).toBeDefined();
+    expect(entry.text).toBe(NO_REPLY_LOCAL_PART);
   });
 });

--- a/src/tests/composables/useEmailConfig.spec.ts
+++ b/src/tests/composables/useEmailConfig.spec.ts
@@ -1115,6 +1115,17 @@ describe('buildDomainEmailDefaults', () => {
     expect(buildDomainEmailDefaults('acme.example', '').fromName).toBe('acme.example');
   });
 
+  it('treats a whitespace-only sender name as empty and falls back to the domain', () => {
+    // Regression: without trimming before the fallback, "   " survives as the
+    // from_name and is later trimmed to '' by createDefaultFormState, blanking
+    // the pre-filled name even though a domain is present.
+    expect(buildDomainEmailDefaults('acme.example', '   ').fromName).toBe('acme.example');
+  });
+
+  it('trims surrounding whitespace from a real sender name', () => {
+    expect(buildDomainEmailDefaults('acme.example', '  Acme Inc  ').fromName).toBe('Acme Inc');
+  });
+
   it('leaves the address blank when the domain is unknown', () => {
     // No domain → nothing to anchor `no-reply@` to; a bare local part is not a
     // valid sender address, so the form stays (correctly) unsaveable.


### PR DESCRIPTION
## Summary

Refactor the email sender defaults logic into a testable pure function and make the no-reply placeholder text localizable.

### Changes

- **Extract `buildDomainEmailDefaults()`**: Moved the inline email defaults computation from `DomainEmail.vue` into a pure, unit-testable helper function in `useEmailConfig.ts`. This function pre-fills `no-reply@<domain>` and derives the display name from the organization name or domain, with proper fallbacks and a 100-character cap.

- **Export `NO_REPLY_LOCAL_PART` constant**: Created a single source of truth for the "no-reply" local part, ensuring consistency between the pre-filled default and the form placeholder text.

- **Localize the placeholder**: Changed the hardcoded `placeholder="no-reply"` in `DomainEmailConfigForm.vue` to use the i18n key `web.domains.email.from_address_local_placeholder`, with a new entry in `workspace-domains.json` that includes context for translators.

- **Add comprehensive test coverage**: 
  - 6 new unit tests for `buildDomainEmailDefaults()` covering domain/name fallbacks, character limits, and edge cases
  - 1 consistency test binding the exported constant to the i18n placeholder text
  - 1 integration test verifying the split-input renders the pre-filled local part correctly

### Why

This refactoring improves testability (the default-derivation rules were previously untestable without mounting the entire page component) and maintainability by establishing a single source of truth for the no-reply convention. Localizing the placeholder makes the UI more accessible to non-English users while the consistency test prevents accidental drift between the two uses of "no-reply".

## Test Plan

All new unit tests pass, covering the default-derivation logic in isolation. Existing integration tests verify the split-input correctly surfaces the local part from the pre-filled address. CI passes.

https://claude.ai/code/session_01SCAuNxLQVsgGY2Ff2GWwU6