### PR TITLE
Consolidate brand identity resolution to prevent OTS branding leaks

### DIFF
--- a/changelog.d/20260701_010000_claude_branding_resolver_consolidation.rst
+++ b/changelog.d/20260701_010000_claude_branding_resolver_consolidation.rst
@@ -1,0 +1,20 @@
+.. A new scriv changelog fragment.
+
+Fixed
+-----
+
+- Custom domains with no uploaded logo no longer show the platform site name
+  beside the fallback logo, and page titles / social-share meta tags fall back
+  to the configured brand name instead of a hardcoded "Onetime Secret". Both
+  surfaces now resolve brand identity through the central resolver
+  (``identityStore``) instead of re-deriving it from raw bootstrap fields, so
+  the neutral-safe fallback is applied in one place. (#3566)
+
+Changed
+-------
+
+- The masthead, default logo and page-title composable now consume
+  ``identityStore.productName`` / ``showPlatformIdentity`` (and a shared
+  ``resolveProductName`` helper) rather than each re-implementing the
+  ``brand_product_name`` → neutral-default fallback, making private-label
+  branding leaks structurally hard rather than caught surface-by-surface.

--- a/changelog.d/20260701_010000_claude_branding_resolver_consolidation.rst
+++ b/changelog.d/20260701_010000_claude_branding_resolver_consolidation.rst
@@ -13,8 +13,8 @@ Fixed
 Changed
 -------
 
-- The masthead, default logo and page-title composable now consume
-  ``identityStore.productName`` / ``showPlatformIdentity`` (and a shared
-  ``resolveProductName`` helper) rather than each re-implementing the
+- The masthead now consumes ``identityStore.productName`` /
+  ``showPlatformIdentity``, while the default logo and page-title composable use
+  the shared ``resolveProductName`` helper directly — none re-implement the
   ``brand_product_name`` → neutral-default fallback, making private-label
   branding leaks structurally hard rather than caught surface-by-surface.

--- a/changelog.d/20260701_010000_claude_branding_resolver_consolidation.rst
+++ b/changelog.d/20260701_010000_claude_branding_resolver_consolidation.rst
@@ -3,18 +3,9 @@
 Fixed
 -----
 
-- Custom domains with no uploaded logo no longer show the platform site name
-  beside the fallback logo, and page titles / social-share meta tags fall back
+- Custom domains with no uploaded logo no longer show the platform's site name
+  beside the fallback logo, and page titles and social-share meta tags fall back
   to the configured brand name instead of a hardcoded "Onetime Secret". Both
-  surfaces now resolve brand identity through the central resolver
-  (``identityStore``) instead of re-deriving it from raw bootstrap fields, so
-  the neutral-safe fallback is applied in one place. (#3566)
-
-Changed
--------
-
-- The masthead now consumes ``identityStore.productName`` /
-  ``showPlatformIdentity``, while the default logo and page-title composable use
-  the shared ``resolveProductName`` helper directly — none re-implement the
-  ``brand_product_name`` → neutral-default fallback, making private-label
-  branding leaks structurally hard rather than caught surface-by-surface.
+  surfaces now resolve brand identity through the shared resolver, so the
+  neutral-safe fallback for private-label installs is applied consistently.
+  (#3566)

--- a/src/shared/components/layout/MastHead.vue
+++ b/src/shared/components/layout/MastHead.vue
@@ -5,6 +5,7 @@
   import DefaultLogo from '@/shared/components/logos/DefaultLogo.vue';
   import UserMenu from '@/shared/components/navigation/UserMenu.vue';
   import { useHeaderEnabled } from '@/shared/composables/useHeaderEnabled';
+  import { DEFAULT_LOGO_COMPONENT } from '@/shared/constants/brand';
   import { useAuthStore } from '@/shared/stores/authStore';
   import { useBootstrapStore } from '@/shared/stores/bootstrapStore';
   import { useProductIdentity } from '@/shared/stores/identityStore';
@@ -20,16 +21,18 @@
     email,
     cust,
     ui,
-    domain_logo,
   } = storeToRefs(bootstrapStore);
 
   // Brand identity resolves through the central resolver so the masthead shares
-  // one neutral-safe source of truth with every other surface. `productName`
-  // replaces the hand-rolled `brand_product_name ?? NEUTRAL` snippet;
-  // `showPlatformIdentity` is the base "may we show the platform wordmark?"
-  // decision (custom domains / per-tenant logos suppress it — the A3 leak).
+  // one neutral-safe source of truth with every other surface — the header reads
+  // no raw brand/identity bootstrap fields directly. `productName` replaces the
+  // hand-rolled `brand_product_name ?? NEUTRAL` snippet; `showPlatformIdentity`
+  // is the base "may we show the platform wordmark?" decision (custom domains /
+  // per-tenant logos suppress it — the A3 leak); `logoUri`/`logoSource` supply
+  // the tenant-or-neutral logo image (replacing the raw `domain_logo` read).
   const identityStore = useProductIdentity();
-  const { productName, showPlatformIdentity } = storeToRefs(identityStore);
+  const { productName, showPlatformIdentity, logoUri, logoSource } =
+    storeToRefs(identityStore);
 
   const props = withDefaults(defineProps<LayoutProps>(), {
     displayMasthead: true,
@@ -50,17 +53,22 @@
   // Header configuration
   const headerConfig = computed(() => ui.value?.header);
 
-  // Default logo component for fallback
-  const DEFAULT_LOGO = 'DefaultLogo.vue';
+  // Default logo component for fallback (shared sentinel, also used by the
+  // resolver's logoSource so the dynamic-import comparisons below stay in sync).
+  const DEFAULT_LOGO = DEFAULT_LOGO_COMPONENT;
 
-  // Helper functions for logo configuration
-  // Priority: props > custom domain logo > static config > default
-  const getLogoUrl = () => props.logo?.url || domain_logo.value || headerConfig.value?.branding?.logo?.url || DEFAULT_LOGO;
+  // Helper functions for logo configuration.
+  // Priority: props.logo.url (caller) > tenant logo (identity.logoUri) >
+  //           operator LOGO_URL (headerConfig) > neutral default (logoSource).
+  // A per-tenant uploaded logo wins over an operator-wide LOGO_URL; logoSource
+  // supplies the neutral DefaultLogo terminal (== DEFAULT_LOGO when no tenant
+  // logo, since the tenant rung already short-circuited).
+  const getLogoUrl = () => props.logo?.url || logoUri.value || headerConfig.value?.branding?.logo?.url || logoSource.value;
   const getLogoAlt = () => props.logo?.alt || headerConfig.value?.branding?.logo?.alt || t('web.homepage.one_time_secret_literal', { product_name: productName.value });
   const getLogoHref = () => props.logo?.href || headerConfig.value?.branding?.logo?.link_to || '/';
 
   // Static-config custom logo: operator set LOGO_URL to anything other than the
-  // bundled DefaultLogo.vue. Distinct from domain_logo (per-tenant runtime signal),
+  // bundled DefaultLogo.vue. Distinct from the tenant logo (identity.logoUri),
   // because the two have different override semantics for the site name.
   const isCustomStaticLogo = computed(() =>
     !!headerConfig.value?.branding?.logo?.url

--- a/src/shared/components/layout/MastHead.vue
+++ b/src/shared/components/layout/MastHead.vue
@@ -5,9 +5,9 @@
   import DefaultLogo from '@/shared/components/logos/DefaultLogo.vue';
   import UserMenu from '@/shared/components/navigation/UserMenu.vue';
   import { useHeaderEnabled } from '@/shared/composables/useHeaderEnabled';
-  import { NEUTRAL_BRAND_DEFAULTS } from '@/shared/constants/brand';
   import { useAuthStore } from '@/shared/stores/authStore';
   import { useBootstrapStore } from '@/shared/stores/bootstrapStore';
+  import { useProductIdentity } from '@/shared/stores/identityStore';
   import type { LayoutProps } from '@/types/ui/layouts';
   import { storeToRefs } from 'pinia';
   import { computed, watch, type Component, onMounted, shallowRef } from 'vue';
@@ -21,8 +21,15 @@
     cust,
     ui,
     domain_logo,
-    brand_product_name,
   } = storeToRefs(bootstrapStore);
+
+  // Brand identity resolves through the central resolver so the masthead shares
+  // one neutral-safe source of truth with every other surface. `productName`
+  // replaces the hand-rolled `brand_product_name ?? NEUTRAL` snippet;
+  // `showPlatformIdentity` is the base "may we show the platform wordmark?"
+  // decision (custom domains / per-tenant logos suppress it — the A3 leak).
+  const identityStore = useProductIdentity();
+  const { productName, showPlatformIdentity } = storeToRefs(identityStore);
 
   const props = withDefaults(defineProps<LayoutProps>(), {
     displayMasthead: true,
@@ -49,7 +56,7 @@
   // Helper functions for logo configuration
   // Priority: props > custom domain logo > static config > default
   const getLogoUrl = () => props.logo?.url || domain_logo.value || headerConfig.value?.branding?.logo?.url || DEFAULT_LOGO;
-  const getLogoAlt = () => props.logo?.alt || headerConfig.value?.branding?.logo?.alt || t('web.homepage.one_time_secret_literal', { product_name: brand_product_name?.value ?? NEUTRAL_BRAND_DEFAULTS.product_name });
+  const getLogoAlt = () => props.logo?.alt || headerConfig.value?.branding?.logo?.alt || t('web.homepage.one_time_secret_literal', { product_name: productName.value });
   const getLogoHref = () => props.logo?.href || headerConfig.value?.branding?.logo?.link_to || '/';
 
   // Static-config custom logo: operator set LOGO_URL to anything other than the
@@ -75,14 +82,21 @@
   };
   // Priority:
   //   1. props.logo.showSiteName            (caller-site override)
-  //   2. domain_logo.value                  (per-tenant: always hide platform name)
+  //   2. !identity.showPlatformIdentity     (resolver base guard: a per-tenant
+  //                                          logo or any custom domain suppresses
+  //                                          the platform wordmark — the A3 leak)
   //   3. headerConfig.branding.logo.show_name  (LOGO_SHOW_NAME explicit config)
   //   4. isCustomStaticLogo.value           (heuristic: custom LOGO_URL usually
   //                                          embeds its own wordmark)
   //   5. !!site_name                        (default visibility tied to SITE_NAME)
+  //
+  // Rung 2 replaces the former `domain_logo` check: showPlatformIdentity is
+  // `!isCustom && !logoUri`, so `!showPlatformIdentity` is `isCustom || logoUri`
+  // — the same per-tenant-logo suppression, now also covering custom domains
+  // with no uploaded logo. The caller/operator override rungs are unchanged.
   const getShowSiteName = () => {
     if (props.logo?.showSiteName != null) return props.logo.showSiteName;
-    if (domain_logo.value) return false;
+    if (!showPlatformIdentity.value) return false;
 
     const showName = headerConfig.value?.branding?.logo?.show_name;
     if (showName != null) return showName;
@@ -90,7 +104,7 @@
     if (isCustomStaticLogo.value) return false;
     return !!headerConfig.value?.branding?.site_name;
   };
-  const getSiteName = () => props.logo?.siteName || headerConfig.value?.branding?.site_name || t('web.homepage.one_time_secret_literal', { product_name: brand_product_name?.value ?? NEUTRAL_BRAND_DEFAULTS.product_name });
+  const getSiteName = () => props.logo?.siteName || headerConfig.value?.branding?.site_name || t('web.homepage.one_time_secret_literal', { product_name: productName.value });
   const getAriaLabel = () => props.logo?.ariaLabel;
   const getIsColonelArea = () => props.logo?.isColonelArea ?? props.colonel;
 
@@ -270,7 +284,7 @@
             <router-link
               v-if="authentication?.signin"
               to="/signin"
-              :title="t('web.homepage.log_in_to_onetime_secret', { product_name: brand_product_name ?? NEUTRAL_BRAND_DEFAULTS.product_name })"
+              :title="t('web.homepage.log_in_to_onetime_secret', { product_name: productName })"
               data-testid="header-signin-link"
               class="text-gray-600 transition-colors duration-200
                 hover:text-gray-800 dark:text-gray-300 dark:hover:text-white">

--- a/src/shared/components/logos/DefaultLogo.vue
+++ b/src/shared/components/logos/DefaultLogo.vue
@@ -3,7 +3,8 @@
 <script setup lang="ts">
   import { useI18n } from 'vue-i18n';
   import KeyholeIcon from '@/shared/components/icons/KeyholeIcon.vue';
-  import { useProductIdentity } from '@/shared/stores/identityStore';
+  import { resolveProductName } from '@/shared/constants/brand';
+  import { useBootstrapStore } from '@/shared/stores/bootstrapStore';
   import { type LogoConfig } from '@/types/ui/layouts';
   import { computed } from 'vue';
 
@@ -20,17 +21,24 @@
   );
 
   const { t } = useI18n();
-  const identity = useProductIdentity();
+  const bootstrapStore = useBootstrapStore();
 
   /**
-   * Brand-aware aria-label. Falls back to the resolver's neutral-safe
-   * `productName` (a generic "My App") when bootstrap config has not provided a
-   * brand name. Never defaults to OTS branding — keeps private-label
-   * deployments neutral (#3048 / #3049). Resolving the fallback through
-   * `identityStore.productName` keeps this in lockstep with every other
-   * name-rendering surface instead of re-deriving the chain here.
+   * Brand-aware aria-label. Falls back to the neutral-safe product name
+   * (a generic "My App") via the shared `resolveProductName` helper when
+   * bootstrap config has not provided a brand name. Never defaults to OTS
+   * branding — keeps private-label deployments neutral (#3048 / #3049).
+   *
+   * Resolves through the shared helper directly rather than
+   * `identityStore.productName` so this app-wide fallback mark stays
+   * lightweight: it needs only the product-name string, not the identity
+   * store's watchers / i18n init. (Same reasoning as `usePageTitle`, which also
+   * resolves via the helper.) The helper is still the single source of truth for
+   * the fallback, so this cannot drift from the other surfaces.
    */
-  const ariaLabel = computed(() => props.ariaLabel || identity.productName);
+  const ariaLabel = computed(
+    () => props.ariaLabel || resolveProductName(bootstrapStore.brand_product_name)
+  );
 
   const svgSize = computed(() =>
     typeof props.size === 'number' && props.size > 0 ? props.size : 64

--- a/src/shared/components/logos/DefaultLogo.vue
+++ b/src/shared/components/logos/DefaultLogo.vue
@@ -3,8 +3,7 @@
 <script setup lang="ts">
   import { useI18n } from 'vue-i18n';
   import KeyholeIcon from '@/shared/components/icons/KeyholeIcon.vue';
-  import { useBootstrapStore } from '@/shared/stores/bootstrapStore';
-  import { NEUTRAL_BRAND_DEFAULTS } from '@/shared/constants/brand';
+  import { useProductIdentity } from '@/shared/stores/identityStore';
   import { type LogoConfig } from '@/types/ui/layouts';
   import { computed } from 'vue';
 
@@ -21,17 +20,17 @@
   );
 
   const { t } = useI18n();
-  const bootstrapStore = useBootstrapStore();
+  const identity = useProductIdentity();
 
   /**
-   * Brand-aware aria-label. Falls back to NEUTRAL_BRAND_DEFAULTS.product_name
-   * (a generic "My App") when bootstrap config has not provided a brand name.
-   * Never defaults to OTS branding — keeps private-label deployments neutral
-   * (#3048 / #3049).
+   * Brand-aware aria-label. Falls back to the resolver's neutral-safe
+   * `productName` (a generic "My App") when bootstrap config has not provided a
+   * brand name. Never defaults to OTS branding — keeps private-label
+   * deployments neutral (#3048 / #3049). Resolving the fallback through
+   * `identityStore.productName` keeps this in lockstep with every other
+   * name-rendering surface instead of re-deriving the chain here.
    */
-  const ariaLabel = computed(
-    () => props.ariaLabel || bootstrapStore.brand_product_name || NEUTRAL_BRAND_DEFAULTS.product_name
-  );
+  const ariaLabel = computed(() => props.ariaLabel || identity.productName);
 
   const svgSize = computed(() =>
     typeof props.size === 'number' && props.size > 0 ? props.size : 64

--- a/src/shared/composables/usePageTitle.ts
+++ b/src/shared/composables/usePageTitle.ts
@@ -1,6 +1,7 @@
 // src/shared/composables/usePageTitle.ts
 
 import { globalComposer } from '@/i18n';
+import { resolveProductName } from '@/shared/constants/brand';
 import { useBootstrapStore } from '@/shared/stores/bootstrapStore';
 import { storeToRefs } from 'pinia';
 import { computed, watch } from 'vue';
@@ -33,7 +34,6 @@ import { computed, watch } from 'vue';
  * });
  */
 
-const APP_NAME = 'Onetime Secret';
 const TITLE_SEPARATOR = ' - ';
 
 export function usePageTitle() {
@@ -43,16 +43,33 @@ export function usePageTitle() {
   const { t, te } = globalComposer;
 
   const bootstrapStore = useBootstrapStore();
-  const { display_domain } = storeToRefs(bootstrapStore);
+  const { display_domain, brand_product_name } = storeToRefs(bootstrapStore);
 
   // Cache DOM elements to avoid repeated queries
   let ogTitleMeta: HTMLMetaElement | null | undefined;
   let twitterTitleMeta: HTMLMetaElement | null | undefined;
 
   /**
-   * Gets the branded app name from domain settings or defaults to APP_NAME
+   * Resolves the app name used in the document title, og:title and
+   * twitter:title, following the neutral brand fallback chain:
+   *   1. display_domain     - the active (custom) domain, when set
+   *   2. brand_product_name - the per-installation product name from OT.conf
+   *   3. neutral default    - 'My App' via resolveProductName
+   *
+   * This must NEVER emit OTS branding. Mirroring constants/brand.ts, when
+   * neither a domain nor a configured product name is available the title
+   * degrades to the neutral default rather than leaking "Onetime Secret" into
+   * browser tabs or social-share previews (the A4 leak). The product-name
+   * fallback goes through the shared `resolveProductName` helper — the same one
+   * `identityStore.productName` uses — rather than the store itself, because
+   * usePageTitle runs in router guards (see setupRouterGuards), outside the
+   * component/i18n context that identityStore initializes with.
+   *
+   * Reads `.value` on each call so the resolved name stays reactive to store
+   * changes (do not hoist the raw values out of the refs).
    */
-  const getAppName = (): string => display_domain.value || APP_NAME;
+  const getAppName = (): string =>
+    display_domain.value || resolveProductName(brand_product_name?.value);
 
   /**
    * Translates a title if it's an i18n key, otherwise returns the raw string

--- a/src/shared/constants/brand.ts
+++ b/src/shared/constants/brand.ts
@@ -57,3 +57,24 @@ export const NEUTRAL_BRAND_DEFAULTS = {
 } as const;
 
 export type NeutralBrandDefaults = typeof NEUTRAL_BRAND_DEFAULTS;
+
+/**
+ * Resolves the display product name, neutral-safe.
+ *
+ * Applies step 2 → step 3 of the fallback chain for the product name:
+ * the per-installation `brand_product_name` (from OT.conf) when set, otherwise
+ * the neutral `NEUTRAL_BRAND_DEFAULTS.product_name` ('My App'). Per the
+ * philosophy above it MUST NEVER emit OTS branding — an unbranded install
+ * degrades to the neutral default, never a hardcoded "Onetime Secret".
+ *
+ * An empty string is treated as unset (`||`, not `??`) so a blank product-name
+ * config falls through to the neutral default instead of rendering an empty
+ * name. This is the single source of truth for the product-name fallback that
+ * `identityStore.productName` (component surfaces) and `usePageTitle`
+ * (router-guard context, i18n-free) both build on.
+ */
+export function resolveProductName(
+  brandProductName: string | null | undefined
+): string {
+  return brandProductName || NEUTRAL_BRAND_DEFAULTS.product_name;
+}

--- a/src/shared/constants/brand.ts
+++ b/src/shared/constants/brand.ts
@@ -78,3 +78,14 @@ export function resolveProductName(
 ): string {
   return brandProductName || NEUTRAL_BRAND_DEFAULTS.product_name;
 }
+
+/**
+ * Sentinel for the neutral, brand-agnostic default logo component.
+ *
+ * The masthead's logo loader treats a `.vue` URL as a component to dynamically
+ * import; this value points at the bundled neutral `DefaultLogo.vue` (the
+ * keyhole mark — the OTS-company maruhi 秘 mark is never the default). Centralized
+ * here so the resolver (`identityStore.logoSource`) and its consumers agree on
+ * one sentinel rather than each hardcoding the string.
+ */
+export const DEFAULT_LOGO_COMPONENT = 'DefaultLogo.vue';

--- a/src/shared/stores/identityStore.ts
+++ b/src/shared/stores/identityStore.ts
@@ -213,15 +213,21 @@ export const useProductIdentity = defineStore('productIdentity', () => {
 
   /**
    * Resolved logo source on the identity axis: the tenant's uploaded logo when
-   * present, otherwise the neutral `DefaultLogo` component sentinel. Never null,
-   * so a consumer can render a lockup without its own "no logo" fallback.
+   * present, otherwise the neutral `DefaultLogo` component sentinel. Never null
+   * or empty, so a consumer can render a lockup without its own "no logo"
+   * fallback.
+   *
+   * Uses `||` (not `??`): an empty-string `domain_logo` is treated as absent and
+   * falls through to the neutral sentinel, matching how the rest of the codebase
+   * reads the logo as a truthy/falsy signal (e.g. `!!domain_logo` in the router
+   * guards) and preserving the masthead's prior terminal fallback for `''`.
    *
    * This is the identity contribution only; the masthead still layers its own
    * caller/operator rungs (props.logo.url, LOGO_URL) around it — a per-tenant
    * logo must win over an operator-wide LOGO_URL, and LOGO_URL over the neutral
    * default.
    */
-  const logoSource = computed(() => logoUri.value ?? DEFAULT_LOGO_COMPONENT);
+  const logoSource = computed(() => logoUri.value || DEFAULT_LOGO_COMPONENT);
 
   const cornerClass = computed(() =>
     state.brand?.corner_style

--- a/src/shared/stores/identityStore.ts
+++ b/src/shared/stores/identityStore.ts
@@ -4,7 +4,7 @@ import {
   brandSettingsSchema,
   type BrandSettings,
 } from '@/schemas/shapes/v3/custom-domain';
-import { NEUTRAL_BRAND_DEFAULTS } from '@/shared/constants/brand';
+import { NEUTRAL_BRAND_DEFAULTS, resolveProductName } from '@/shared/constants/brand';
 import { cornerStyleClasses, fontFamilyClasses } from '@/shared/utils/brand-helpers';
 import { gracefulParse } from '@/utils/schemaValidation';
 import { defineStore, storeToRefs } from 'pinia';
@@ -67,6 +67,7 @@ export const useProductIdentity = defineStore('productIdentity', () => {
     domain_id,
     domain_branding,
     domain_logo,
+    brand_product_name,
     homepage_config,
   } = storeToRefs(bootstrapStore);
 
@@ -171,6 +172,18 @@ export const useProductIdentity = defineStore('productIdentity', () => {
   /** Display name for current domain context */
   const displayName = computed(() => state.brand?.description || state.displayDomain);
 
+  /**
+   * Install product name, neutral-safe. Never the hardcoded OTS literal.
+   *
+   * Centralizes the `brand_product_name || NEUTRAL_BRAND_DEFAULTS.product_name`
+   * fallback that surfaces (MastHead, DefaultLogo) previously each re-derived by
+   * hand — so a new name-rendering surface has one safe source of truth instead
+   * of another chance to leak "Onetime Secret". Shares `resolveProductName` with
+   * `usePageTitle`, which cannot depend on this store (it runs in router guards,
+   * outside the i18n context this store initializes with).
+   */
+  const productName = computed(() => resolveProductName(brand_product_name?.value));
+
   /** Logo URL for custom domain, pre-computed by backend with correct extid */
   const logoUri = computed(() =>
     // Backend provides the correct logo URL using extid (external ID).
@@ -179,6 +192,20 @@ export const useProductIdentity = defineStore('productIdentity', () => {
     // the internal domainId, not the public extid needed for the /imagine route.
     domain_logo.value
   );
+
+  /**
+   * Whether a surface may show the platform's own name / wordmark.
+   *
+   * False on a custom domain — with or without an uploaded logo — and whenever a
+   * per-tenant logo is present: rendering the install's identity there would
+   * leak it onto another company's domain (the A3 masthead leak). Canonical and
+   * subdomain contexts are permitted to show it, subject to the consumer's own
+   * config (a `subdomain` IS the platform, so its name legitimately shows).
+   *
+   * This encodes only the base identity-leak guard; consumers keep their own
+   * override ladder (caller props, operator LOGO_SHOW_NAME, etc.) on top.
+   */
+  const showPlatformIdentity = computed(() => !isCustom.value && !logoUri.value);
 
   const cornerClass = computed(() =>
     state.brand?.corner_style
@@ -217,6 +244,8 @@ export const useProductIdentity = defineStore('productIdentity', () => {
     isCustom,
     isSubdomain,
     displayName,
+    productName,
+    showPlatformIdentity,
     $reset,
 
     ...toRefs(state),

--- a/src/shared/stores/identityStore.ts
+++ b/src/shared/stores/identityStore.ts
@@ -4,7 +4,11 @@ import {
   brandSettingsSchema,
   type BrandSettings,
 } from '@/schemas/shapes/v3/custom-domain';
-import { NEUTRAL_BRAND_DEFAULTS, resolveProductName } from '@/shared/constants/brand';
+import {
+  DEFAULT_LOGO_COMPONENT,
+  NEUTRAL_BRAND_DEFAULTS,
+  resolveProductName,
+} from '@/shared/constants/brand';
 import { cornerStyleClasses, fontFamilyClasses } from '@/shared/utils/brand-helpers';
 import { gracefulParse } from '@/utils/schemaValidation';
 import { defineStore, storeToRefs } from 'pinia';
@@ -207,6 +211,18 @@ export const useProductIdentity = defineStore('productIdentity', () => {
    */
   const showPlatformIdentity = computed(() => !isCustom.value && !logoUri.value);
 
+  /**
+   * Resolved logo source on the identity axis: the tenant's uploaded logo when
+   * present, otherwise the neutral `DefaultLogo` component sentinel. Never null,
+   * so a consumer can render a lockup without its own "no logo" fallback.
+   *
+   * This is the identity contribution only; the masthead still layers its own
+   * caller/operator rungs (props.logo.url, LOGO_URL) around it — a per-tenant
+   * logo must win over an operator-wide LOGO_URL, and LOGO_URL over the neutral
+   * default.
+   */
+  const logoSource = computed(() => logoUri.value ?? DEFAULT_LOGO_COMPONENT);
+
   const cornerClass = computed(() =>
     state.brand?.corner_style
       ? cornerStyleClasses[state.brand.corner_style] ?? DEFAULT_CORNER_CLASS
@@ -246,6 +262,7 @@ export const useProductIdentity = defineStore('productIdentity', () => {
     displayName,
     productName,
     showPlatformIdentity,
+    logoSource,
     $reset,
 
     ...toRefs(state),

--- a/src/tests/shared/brandingResolverConsolidation.guard.spec.ts
+++ b/src/tests/shared/brandingResolverConsolidation.guard.spec.ts
@@ -47,14 +47,22 @@ describe('branding resolver consolidation guardrail', () => {
       expect(code).not.toContain('NEUTRAL_BRAND_DEFAULTS');
     });
 
+    it('does not read the raw domain_logo bootstrap field (routes via the resolver)', () => {
+      // The header must not reach into raw identity fields — the tenant logo
+      // comes from identity.logoUri / identity.logoSource, not domain_logo.
+      expect(code).not.toContain('domain_logo');
+    });
+
     it('does not hardcode the OTS platform name', () => {
       expect(code).not.toContain('Onetime Secret');
     });
 
-    it('consumes the resolver (useProductIdentity + productName + showPlatformIdentity)', () => {
+    it('consumes the resolver (identity signals, not raw bootstrap identity)', () => {
       expect(raw).toContain('useProductIdentity');
       expect(raw).toContain('productName');
       expect(raw).toContain('showPlatformIdentity');
+      expect(raw).toContain('logoUri');
+      expect(raw).toContain('logoSource');
     });
   });
 

--- a/src/tests/shared/brandingResolverConsolidation.guard.spec.ts
+++ b/src/tests/shared/brandingResolverConsolidation.guard.spec.ts
@@ -1,0 +1,94 @@
+// src/tests/shared/brandingResolverConsolidation.guard.spec.ts
+//
+// Guardrail for the brand-identity resolver consolidation.
+//
+// The recurring "OTS branding leaked onto a neutral / custom-domain surface"
+// class of bug (A1/A3/A4) came from surfaces re-deriving brand identity from
+// raw bootstrap fields by hand instead of routing through the central resolver
+// (identityStore). This test pins the consolidation so a future edit cannot
+// silently re-introduce a hand-rolled product-name fallback or a hardcoded
+// "Onetime Secret" literal in the migrated surfaces.
+//
+// It is deliberately source-level rather than behavioral: the behavioral
+// guarantees live in identityStore.spec, MastHead(.customDomain).spec,
+// DefaultLogo.spec and usePageTitle.spec. This file protects the *structure*
+// that makes those guarantees hold in one place.
+
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import { describe, expect, it } from 'vitest';
+
+const read = (relPath: string): string =>
+  readFileSync(resolve(process.cwd(), relPath), 'utf-8');
+
+/**
+ * Strips comments so the "no re-derivation" assertions look only at executable
+ * code, not at documentation that legitimately names the very things we forbid
+ * in code (e.g. a comment explaining the A4 "Onetime Secret" leak).
+ */
+function stripComments(src: string): string {
+  return src
+    .replace(/<!--[\s\S]*?-->/g, '') // SFC HTML comments
+    .replace(/\/\*[\s\S]*?\*\//g, '') // block comments
+    .replace(/(^|[^:])\/\/[^\n]*/g, '$1'); // line comments (preserve `://`)
+}
+
+const MASTHEAD = 'src/shared/components/layout/MastHead.vue';
+const DEFAULT_LOGO = 'src/shared/components/logos/DefaultLogo.vue';
+const USE_PAGE_TITLE = 'src/shared/composables/usePageTitle.ts';
+
+describe('branding resolver consolidation guardrail', () => {
+  describe('MastHead routes brand identity through identityStore', () => {
+    const raw = read(MASTHEAD);
+    const code = stripComments(raw);
+
+    it('does not re-derive the product name from the raw bootstrap field', () => {
+      expect(code).not.toContain('brand_product_name');
+      expect(code).not.toContain('NEUTRAL_BRAND_DEFAULTS');
+    });
+
+    it('does not hardcode the OTS platform name', () => {
+      expect(code).not.toContain('Onetime Secret');
+    });
+
+    it('consumes the resolver (useProductIdentity + productName + showPlatformIdentity)', () => {
+      expect(raw).toContain('useProductIdentity');
+      expect(raw).toContain('productName');
+      expect(raw).toContain('showPlatformIdentity');
+    });
+  });
+
+  describe('DefaultLogo routes the product-name fallback through identityStore', () => {
+    const raw = read(DEFAULT_LOGO);
+    const code = stripComments(raw);
+
+    it('does not read brand_product_name or the neutral constant directly', () => {
+      expect(code).not.toContain('brand_product_name');
+      expect(code).not.toContain('NEUTRAL_BRAND_DEFAULTS');
+      expect(code).not.toContain('useBootstrapStore');
+    });
+
+    it('does not hardcode the OTS platform name', () => {
+      expect(code).not.toContain('Onetime Secret');
+    });
+
+    it('consumes identityStore.productName', () => {
+      expect(raw).toContain('useProductIdentity');
+      expect(raw).toContain('identity.productName');
+    });
+  });
+
+  describe('usePageTitle uses the shared neutral fallback, never a hardcoded literal', () => {
+    const raw = read(USE_PAGE_TITLE);
+    const code = stripComments(raw);
+
+    it('does not hardcode the OTS platform name', () => {
+      expect(code).not.toContain('Onetime Secret');
+      expect(code).not.toContain('APP_NAME');
+    });
+
+    it('resolves the product name through the shared resolveProductName helper', () => {
+      expect(raw).toContain('resolveProductName');
+    });
+  });
+});

--- a/src/tests/shared/brandingResolverConsolidation.guard.spec.ts
+++ b/src/tests/shared/brandingResolverConsolidation.guard.spec.ts
@@ -58,23 +58,24 @@ describe('branding resolver consolidation guardrail', () => {
     });
   });
 
-  describe('DefaultLogo routes the product-name fallback through identityStore', () => {
+  describe('DefaultLogo resolves the product-name fallback through the shared helper', () => {
+    // DefaultLogo is the app-wide fallback mark, so it stays lightweight and
+    // uses resolveProductName directly rather than pulling in the identity
+    // store. Reading the raw brand_product_name to feed the helper is fine —
+    // what we forbid is re-implementing the fallback or hardcoding the literal.
     const raw = read(DEFAULT_LOGO);
     const code = stripComments(raw);
 
-    it('does not read brand_product_name or the neutral constant directly', () => {
-      expect(code).not.toContain('brand_product_name');
+    it('does not re-derive the neutral fallback by hand', () => {
       expect(code).not.toContain('NEUTRAL_BRAND_DEFAULTS');
-      expect(code).not.toContain('useBootstrapStore');
     });
 
     it('does not hardcode the OTS platform name', () => {
       expect(code).not.toContain('Onetime Secret');
     });
 
-    it('consumes identityStore.productName', () => {
-      expect(raw).toContain('useProductIdentity');
-      expect(raw).toContain('identity.productName');
+    it('resolves the product name through the shared resolveProductName helper', () => {
+      expect(raw).toContain('resolveProductName');
     });
   });
 
@@ -90,5 +91,48 @@ describe('branding resolver consolidation guardrail', () => {
     it('resolves the product name through the shared resolveProductName helper', () => {
       expect(raw).toContain('resolveProductName');
     });
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// stripComments self-test
+//
+// The guardrail above is deliberately source-text based, so its correctness
+// hinges entirely on stripComments: it must remove documentation that names the
+// forbidden tokens while preserving real code — crucially, a `//` inside a
+// `://` URL is NOT a comment. These cases protect the regexes from a future
+// edit that would silently make the guard pass (stripping real code) or fail
+// (leaving a comment behind).
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('stripComments (guard helper)', () => {
+  it('strips a line comment but keeps the code before it', () => {
+    const out = stripComments("const x = 1; // brand_product_name in a comment");
+    expect(out).toContain('const x = 1;');
+    expect(out).not.toContain('brand_product_name');
+  });
+
+  it('strips a block comment', () => {
+    const out = stripComments('const a = 1; /* NEUTRAL_BRAND_DEFAULTS */ const b = 2;');
+    expect(out).not.toContain('NEUTRAL_BRAND_DEFAULTS');
+    expect(out).toContain('const a = 1;');
+    expect(out).toContain('const b = 2;');
+  });
+
+  it('strips an SFC/HTML comment', () => {
+    const out = stripComments('<!-- Onetime Secret --><div id="logo" />');
+    expect(out).not.toContain('Onetime Secret');
+    expect(out).toContain('<div id="logo" />');
+  });
+
+  it('preserves a `://` URL literal (the // is not a comment)', () => {
+    const out = stripComments("const u = 'https://cdn.example.com/logo.png';");
+    expect(out).toContain('https://cdn.example.com/logo.png');
+  });
+
+  it('strips a trailing line comment without eating a preceding URL', () => {
+    const out = stripComments("const u = 'https://cdn.example.com'; // domain_logo note");
+    expect(out).toContain('https://cdn.example.com');
+    expect(out).not.toContain('domain_logo');
   });
 });

--- a/src/tests/shared/brandingResolverConsolidation.guard.spec.ts
+++ b/src/tests/shared/brandingResolverConsolidation.guard.spec.ts
@@ -26,22 +26,34 @@ const read = (relPath: string): string =>
  * code, not at documentation that legitimately names the very things we forbid
  * in code (e.g. a comment explaining the A4 "Onetime Secret" leak).
  *
- * Delimited comments (SFC/HTML `<!-- -->` and C-style block) are removed to a
- * fixpoint — re-applied until the source stops changing — so a nested or
- * adjacent pair can never leave a dangling comment opener that a single pass
- * would miss (CodeQL js/incomplete-multi-character-sanitization). Line comments
- * are stripped last and preserve `://` so URL literals survive.
+ * Implemented as a single left-to-right scan rather than regex search-and-
+ * replace: it removes every comment region in one pass with no residue, and it
+ * sidesteps CodeQL's incomplete-multi-character-sanitization heuristic, which
+ * fires on `String.replace`-based comment strippers regardless of any surrounding
+ * fixpoint loop. (This helper only ever reads our own trusted source files, so
+ * there is no real injection surface either way — the scan just keeps the guard
+ * correct and the finding clear.) A `//` immediately preceded by `:` is treated
+ * as part of a `://` URL, not a line comment, so URL literals survive.
  */
 function stripComments(src: string): string {
-  let out = src;
-  let prev: string;
-  do {
-    prev = out;
-    out = out
-      .replace(/<!--[\s\S]*?-->/g, '') // SFC HTML comments
-      .replace(/\/\*[\s\S]*?\*\//g, ''); // block comments
-  } while (out !== prev);
-  return out.replace(/(^|[^:])\/\/[^\n]*/g, '$1'); // line comments (preserve `://`)
+  let out = '';
+  let i = 0;
+  while (i < src.length) {
+    if (src.startsWith('<!--', i)) {
+      const end = src.indexOf('-->', i + 4);
+      i = end === -1 ? src.length : end + 3;
+    } else if (src.startsWith('/*', i)) {
+      const end = src.indexOf('*/', i + 2);
+      i = end === -1 ? src.length : end + 2;
+    } else if (src.startsWith('//', i) && src[i - 1] !== ':') {
+      const nl = src.indexOf('\n', i);
+      i = nl === -1 ? src.length : nl; // keep the newline itself
+    } else {
+      out += src[i];
+      i += 1;
+    }
+  }
+  return out;
 }
 
 const MASTHEAD = 'src/shared/components/layout/MastHead.vue';
@@ -155,8 +167,8 @@ describe('stripComments (guard helper)', () => {
     expect(out).not.toContain('domain_logo');
   });
 
-  // Invariant guarded by the fixpoint loop: however comments nest, no forbidden
-  // token and no dangling comment opener may survive.
+  // Invariant guarded by the comment scanner: however comments nest, no
+  // forbidden token and no dangling comment opener may survive.
   it('removes nested HTML comments, leaving no forbidden token or `<!--` opener', () => {
     const out = stripComments('<!--<!-- brand_product_name -->--> keep');
     expect(out).not.toContain('brand_product_name');

--- a/src/tests/shared/brandingResolverConsolidation.guard.spec.ts
+++ b/src/tests/shared/brandingResolverConsolidation.guard.spec.ts
@@ -25,12 +25,23 @@ const read = (relPath: string): string =>
  * Strips comments so the "no re-derivation" assertions look only at executable
  * code, not at documentation that legitimately names the very things we forbid
  * in code (e.g. a comment explaining the A4 "Onetime Secret" leak).
+ *
+ * Delimited comments (SFC/HTML `<!-- -->` and C-style block) are removed to a
+ * fixpoint — re-applied until the source stops changing — so a nested or
+ * adjacent pair can never leave a dangling comment opener that a single pass
+ * would miss (CodeQL js/incomplete-multi-character-sanitization). Line comments
+ * are stripped last and preserve `://` so URL literals survive.
  */
 function stripComments(src: string): string {
-  return src
-    .replace(/<!--[\s\S]*?-->/g, '') // SFC HTML comments
-    .replace(/\/\*[\s\S]*?\*\//g, '') // block comments
-    .replace(/(^|[^:])\/\/[^\n]*/g, '$1'); // line comments (preserve `://`)
+  let out = src;
+  let prev: string;
+  do {
+    prev = out;
+    out = out
+      .replace(/<!--[\s\S]*?-->/g, '') // SFC HTML comments
+      .replace(/\/\*[\s\S]*?\*\//g, ''); // block comments
+  } while (out !== prev);
+  return out.replace(/(^|[^:])\/\/[^\n]*/g, '$1'); // line comments (preserve `://`)
 }
 
 const MASTHEAD = 'src/shared/components/layout/MastHead.vue';
@@ -142,5 +153,22 @@ describe('stripComments (guard helper)', () => {
     const out = stripComments("const u = 'https://cdn.example.com'; // domain_logo note");
     expect(out).toContain('https://cdn.example.com');
     expect(out).not.toContain('domain_logo');
+  });
+
+  // Invariant guarded by the fixpoint loop: however comments nest, no forbidden
+  // token and no dangling comment opener may survive.
+  it('removes nested HTML comments, leaving no forbidden token or `<!--` opener', () => {
+    const out = stripComments('<!--<!-- brand_product_name -->--> keep');
+    expect(out).not.toContain('brand_product_name');
+    expect(out).not.toContain('<!--');
+    expect(out).toContain('keep');
+  });
+
+  it('removes nested block comments, leaving no forbidden token or `/*` opener', () => {
+    const out = stripComments('a /* /* NEUTRAL_BRAND_DEFAULTS */ */ b');
+    expect(out).not.toContain('NEUTRAL_BRAND_DEFAULTS');
+    expect(out).not.toContain('/*');
+    expect(out).toContain('a');
+    expect(out).toContain('b');
   });
 });

--- a/src/tests/shared/components/layout/MastHead.customDomain.spec.ts
+++ b/src/tests/shared/components/layout/MastHead.customDomain.spec.ts
@@ -348,7 +348,7 @@ describe('MastHead — Custom Domain Logo Behavior', () => {
       expect(defaultLogo.exists()).toBe(true);
     });
 
-    it('shows OTS site name when custom domain has no logo', async () => {
+    it('suppresses the OTS site name when custom domain has no logo', async () => {
       wrapper = mountComponent(
         {},
         {
@@ -360,11 +360,12 @@ describe('MastHead — Custom Domain Logo Behavior', () => {
       );
 
       await nextTick();
-      // Without domain_logo, the site name logic does NOT suppress the name
-      // This means the OTS site name "Onetime Secret" appears on a custom domain
+      // A3 fix (via identityStore.showPlatformIdentity): on a custom domain the
+      // DefaultLogo neutral mark still renders, but the platform site name
+      // "Onetime Secret" must NOT leak next to it.
       const logo = wrapper.find('.default-logo');
       expect(logo.exists()).toBe(true);
-      expect(logo.attributes('data-show-site-name')).toBe('true');
+      expect(logo.attributes('data-show-site-name')).toBe('false');
     });
 
     it('uses standard sizing (not 80px) when no custom logo is set', async () => {
@@ -492,12 +493,18 @@ describe('MastHead — Custom Domain Logo Behavior', () => {
   });
 
   // ═══════════════════════════════════════════════════════════════════════════
-  // BUG DOCUMENTATION: Default logo leaks on custom domains
+  // A3 FIX: Default logo no longer leaks the platform name on custom domains
   //
-  // MastHead's logo logic is driven by `domain_logo` (URL or null), not
-  // `domain_strategy`. When domain_strategy='custom' but domain_logo is null
-  // (e.g., customer hasn't uploaded a logo), MastHead renders the OTS default
-  // logo with "Onetime Secret" branding — which is wrong for custom domains.
+  // Previously MastHead's site-name logic was driven only by `domain_logo`
+  // (URL or null), not the domain strategy. When the strategy was 'custom' but
+  // domain_logo was null (customer hasn't uploaded a logo), MastHead fell back
+  // to the DefaultLogo AND still rendered the platform "Onetime Secret" site
+  // name — leaking our identity onto another company's custom domain.
+  //
+  // The consolidation routes the base decision through
+  // identityStore.showPlatformIdentity (`!isCustom && !logoUri`), so any custom
+  // domain — logo or not — suppresses the wordmark while the neutral mark
+  // still renders. The caller/operator override rungs are untouched.
   //
   // Leak routes: /incoming, /feedback, /help, /pricing — these use
   // TransactionalHeader → MastHead directly, with no domain-aware switching.
@@ -506,10 +513,10 @@ describe('MastHead — Custom Domain Logo Behavior', () => {
   // masthead entirely), receipt (beforeEnter guard patches props).
   // ═══════════════════════════════════════════════════════════════════════════
 
-  describe('Bug: MastHead ignores domain_strategy when domain_logo is null', () => {
-    it('shows OTS default logo on custom domain when no logo uploaded (current behavior)', async () => {
-      // This documents the bug: a customer on secrets.acme.com sees the
-      // Onetime Secret logo because MastHead only checks domain_logo, not domain_strategy
+  describe('A3 fix: MastHead is domain-strategy-aware when domain_logo is null', () => {
+    it('shows the neutral DefaultLogo mark but no OTS site name on a custom domain with no logo', async () => {
+      // A customer on secrets.acme.com falls back to the neutral DefaultLogo
+      // mark, but the platform "Onetime Secret" site name must not leak.
       wrapper = mountComponent(
         {},
         {
@@ -523,12 +530,12 @@ describe('MastHead — Custom Domain Logo Behavior', () => {
 
       await nextTick();
 
-      // BUG: DefaultLogo renders even though we're on a custom domain
+      // The neutral DefaultLogo mark still renders (brand-agnostic KeyholeIcon).
       const defaultLogo = wrapper.find('.default-logo');
       expect(defaultLogo.exists()).toBe(true);
 
-      // BUG: "Onetime Secret" site name shows on another company's domain
-      expect(defaultLogo.attributes('data-show-site-name')).toBe('true');
+      // FIXED: "Onetime Secret" site name is suppressed on another company's domain
+      expect(defaultLogo.attributes('data-show-site-name')).toBe('false');
     });
 
     it('does not suppress auth navigation on custom domain (correct: auth nav should remain)', async () => {
@@ -551,18 +558,101 @@ describe('MastHead — Custom Domain Logo Behavior', () => {
   });
 
   // ═══════════════════════════════════════════════════════════════════════════
-  // EXPECTED BEHAVIOR AFTER FIX (these should pass once the fix lands)
+  // A3 REGRESSION GUARDS: MastHead is domain-strategy-aware via the resolver
+  //
+  // identityStore.showPlatformIdentity makes MastHead:
+  // 1. If domain_logo is set → show the custom logo (unchanged).
+  // 2. If domain_logo is null on a custom domain → render the neutral
+  //    DefaultLogo mark WITHOUT the platform "Onetime Secret" site name.
+  // Canonical domains are unaffected — the site name still shows there.
   // ═══════════════════════════════════════════════════════════════════════════
 
-  describe.todo('Expected: MastHead should be domain_strategy-aware', () => {
-    // Once fixed, MastHead should check domain_strategy='custom' and:
-    // 1. If domain_logo is set → show custom logo (already works)
-    // 2. If domain_logo is null → hide logo entirely or show a neutral placeholder
-    //    (NOT the OTS default logo with "Onetime Secret" branding)
-    //
-    // Test stubs for when the fix is implemented:
-    // it('hides DefaultLogo when domain_strategy=custom and no domain_logo', ...)
-    // it('does not show "Onetime Secret" site name on custom domain', ...)
-    // it('shows neutral placeholder when custom domain has no logo', ...)
+  describe('A3 regression: MastHead is domain-strategy-aware', () => {
+    it('does not leak the "Onetime Secret" site name when custom domain has no logo', async () => {
+      wrapper = mountComponent(
+        {},
+        {
+          authenticated: false,
+          domain_strategy: 'custom',
+          domain_logo: null,
+          display_domain: 'secrets.acme.com',
+          domain_id: 'cd_acme',
+        }
+      );
+
+      await nextTick();
+
+      const logo = wrapper.find('.default-logo');
+      expect(logo.exists()).toBe(true);
+      // Site name is suppressed...
+      expect(logo.attributes('data-show-site-name')).toBe('false');
+      // ...and the DefaultLogo mock only renders the site-name span when
+      // showSiteName is true, so "Onetime Secret" must be absent from the DOM.
+      const siteName = wrapper.find('.default-logo .site-name');
+      expect(siteName.exists()).toBe(false);
+      expect(wrapper.text()).not.toContain('Onetime Secret');
+    });
+
+    it('still renders the neutral DefaultLogo mark on a custom domain with no logo', async () => {
+      wrapper = mountComponent(
+        {},
+        {
+          authenticated: false,
+          domain_strategy: 'custom',
+          domain_logo: null,
+          display_domain: 'secrets.acme.com',
+          domain_id: 'cd_acme',
+        }
+      );
+
+      await nextTick();
+
+      // We suppress the wordmark, not the whole lockup — the mark itself is safe.
+      const defaultLogo = wrapper.find('.default-logo');
+      expect(defaultLogo.exists()).toBe(true);
+      const logoIcon = wrapper.find('.default-logo .logo-icon');
+      expect(logoIcon.exists()).toBe(true);
+    });
+
+    it('sanity: still shows the site name on a canonical domain (fix scoped to custom/tenant)', async () => {
+      wrapper = mountComponent(
+        {},
+        {
+          authenticated: false,
+          domain_strategy: 'canonical',
+          domain_logo: null,
+        }
+      );
+
+      await nextTick();
+
+      const logo = wrapper.find('.default-logo');
+      expect(logo.exists()).toBe(true);
+      // Canonical domains are unaffected: the platform site name still shows.
+      expect(logo.attributes('data-show-site-name')).toBe('true');
+    });
+
+    it('leaves custom-domain-WITH-logo behavior unchanged (img renders, no site name)', async () => {
+      wrapper = mountComponent(
+        {},
+        {
+          authenticated: false,
+          domain_strategy: 'custom',
+          domain_logo: 'https://cdn.example.com/logos/acme-logo.png',
+          display_domain: 'secrets.acme.com',
+          domain_id: 'cd_acme',
+        }
+      );
+
+      await nextTick();
+
+      // Custom logo renders as an <img>, not the DefaultLogo component.
+      const img = wrapper.find('img#logo');
+      expect(img.exists()).toBe(true);
+      expect(img.attributes('src')).toBe('https://cdn.example.com/logos/acme-logo.png');
+      // And the site name text mark is not rendered next to it.
+      const siteName = wrapper.find('span.font-brand.text-lg');
+      expect(siteName.exists()).toBe(false);
+    });
   });
 });

--- a/src/tests/shared/components/layout/MastHead.spec.ts
+++ b/src/tests/shared/components/layout/MastHead.spec.ts
@@ -695,13 +695,19 @@ describe('MastHead', () => {
     /**
      * Priority chain in getShowSiteName():
      *   1. props.logo.showSiteName            (caller-site override)
-     *   2. domain_logo.value                  (multi-tenant: always hide)
+     *   2. !identity.showPlatformIdentity     (resolver base guard: any custom
+     *                                          domain OR a per-tenant logo hides
+     *                                          the platform wordmark)
      *   3. headerConfig.branding.logo.show_name  (LOGO_SHOW_NAME explicit)
      *   4. isCustomStaticLogo.value           (heuristic: non-default LOGO_URL)
      *   5. !!site_name                        (default tied to SITE_NAME)
      *
      * #3160: in v0.25.3 step 4 ran ahead of step 3, so operators setting
      * LOGO_URL + LOGO_SHOW_NAME=true silently lost their wordmark.
+     *
+     * The tests below all use the canonical strategy with no domain_logo, so
+     * showPlatformIdentity is true and rung 2 falls through — exercising the
+     * operator/config rungs unchanged by the resolver consolidation.
      */
     const mountWithBranding = (
       branding: {
@@ -1010,14 +1016,17 @@ describe('MastHead', () => {
       expect(img.attributes('alt')).toBe(NEUTRAL_BRAND_DEFAULTS.product_name);
     });
 
-    it('passes empty string through (nullish coalescing does not catch it)', async () => {
+    it('falls back to NEUTRAL_BRAND_DEFAULTS.product_name for an empty string', async () => {
       wrapper = mountWithBrand('');
       await nextTick();
 
       const img = wrapper.find('img#logo');
       expect(img.exists()).toBe(true);
-      // ?? does not trigger on empty string — only on null/undefined
-      expect(img.attributes('alt')).toBe('');
+      // Consolidation routes the alt text through identityStore.productName,
+      // which uses `||` (not `??`): a blank product-name config degrades to the
+      // neutral 'My App' instead of rendering an empty alt — matching
+      // DefaultLogo and usePageTitle.
+      expect(img.attributes('alt')).toBe(NEUTRAL_BRAND_DEFAULTS.product_name);
     });
   });
 });

--- a/src/tests/shared/components/logos/DefaultLogo.spec.ts
+++ b/src/tests/shared/components/logos/DefaultLogo.spec.ts
@@ -3,6 +3,8 @@
 import { mount, VueWrapper } from '@vue/test-utils';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { createTestI18n } from '@tests/setup';
+import { NEUTRAL_BRAND_DEFAULTS } from '@/shared/constants/brand';
+import { useBootstrapStore } from '@/shared/stores/bootstrapStore';
 import DefaultLogo from '@/shared/components/logos/DefaultLogo.vue';
 
 // Mock KeyholeIcon component (the neutral default mark; the maruhi 秘 mark is
@@ -262,6 +264,47 @@ describe('DefaultLogo', () => {
       expect(wrapper.attributes('aria-label')).toBeUndefined();
       // The label still reaches the icon, so the link is still named.
       expect(wrapper.find('.logo-icon').attributes('aria-label')).toBe('Custom Label');
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // Brand-aware aria-label via identityStore.productName (A1 consolidation)
+  //
+  // The aria-label fallback now resolves through identityStore.productName
+  // instead of reading bootstrapStore.brand_product_name directly, so DefaultLogo
+  // shares the neutral-safe product-name source of truth with every other
+  // surface. (These rely on the global testing Pinia from setup-stores.ts.)
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  describe('productName fallback via identityStore', () => {
+    it('uses the configured brand_product_name when no ariaLabel prop is given', () => {
+      const bootstrap = useBootstrapStore();
+      bootstrap.$patch({ brand_product_name: 'Acme Vault' });
+
+      wrapper = mountComponent({});
+
+      expect(wrapper.find('[aria-label="Acme Vault"]').exists()).toBe(true);
+    });
+
+    it('never leaks OTS branding when unbranded — degrades to the neutral default', () => {
+      const bootstrap = useBootstrapStore();
+      bootstrap.$patch({ brand_product_name: null });
+
+      wrapper = mountComponent({});
+
+      expect(wrapper.find('[aria-label="Onetime Secret"]').exists()).toBe(false);
+      expect(
+        wrapper.find(`[aria-label="${NEUTRAL_BRAND_DEFAULTS.product_name}"]`).exists()
+      ).toBe(true);
+    });
+
+    it('an explicit ariaLabel prop still wins over the resolver', () => {
+      const bootstrap = useBootstrapStore();
+      bootstrap.$patch({ brand_product_name: 'Acme Vault' });
+
+      wrapper = mountComponent({ ariaLabel: 'Explicit Label' });
+
+      expect(wrapper.find('[aria-label="Explicit Label"]').exists()).toBe(true);
     });
   });
 });

--- a/src/tests/shared/components/logos/DefaultLogo.spec.ts
+++ b/src/tests/shared/components/logos/DefaultLogo.spec.ts
@@ -268,15 +268,17 @@ describe('DefaultLogo', () => {
   });
 
   // ═══════════════════════════════════════════════════════════════════════════
-  // Brand-aware aria-label via identityStore.productName (A1 consolidation)
+  // Brand-aware aria-label via the shared resolveProductName helper (A1)
   //
-  // The aria-label fallback now resolves through identityStore.productName
-  // instead of reading bootstrapStore.brand_product_name directly, so DefaultLogo
-  // shares the neutral-safe product-name source of truth with every other
-  // surface. (These rely on the global testing Pinia from setup-stores.ts.)
+  // The aria-label fallback resolves through the shared resolveProductName
+  // helper (the single source of truth for the neutral product-name fallback),
+  // so DefaultLogo stays neutral-safe and in lockstep with every other surface
+  // while remaining lightweight — the app-wide fallback mark does not pull in
+  // the identity store. (These rely on the global testing Pinia from
+  // setup-stores.ts.)
   // ═══════════════════════════════════════════════════════════════════════════
 
-  describe('productName fallback via identityStore', () => {
+  describe('productName fallback via resolveProductName', () => {
     it('uses the configured brand_product_name when no ariaLabel prop is given', () => {
       const bootstrap = useBootstrapStore();
       bootstrap.$patch({ brand_product_name: 'Acme Vault' });
@@ -298,7 +300,7 @@ describe('DefaultLogo', () => {
       ).toBe(true);
     });
 
-    it('an explicit ariaLabel prop still wins over the resolver', () => {
+    it('an explicit ariaLabel prop still wins over the resolved fallback', () => {
       const bootstrap = useBootstrapStore();
       bootstrap.$patch({ brand_product_name: 'Acme Vault' });
 

--- a/src/tests/shared/composables/usePageTitle.spec.ts
+++ b/src/tests/shared/composables/usePageTitle.spec.ts
@@ -1,0 +1,135 @@
+// src/tests/shared/composables/usePageTitle.spec.ts
+//
+// A4 fix: the page-title composable must never leak OTS branding into the
+// document <title>, og:title or twitter:title. When no display domain is
+// available it falls back to the configured brand product name, and finally to
+// the neutral default ('My App') — never the hardcoded "Onetime Secret".
+//
+// The product-name fallback goes through the shared resolveProductName helper
+// (the same one identityStore.productName uses) rather than the store itself,
+// because usePageTitle runs in router guards, outside a component/i18n context.
+// These tests exercise getAppName()'s fallback chain via the public
+// formatTitle() / setTitle() API and assert on the resulting jsdom document.title.
+
+import { NEUTRAL_BRAND_DEFAULTS } from '@/shared/constants/brand';
+import { usePageTitle } from '@/shared/composables/usePageTitle';
+import { createTestingPinia } from '@pinia/testing';
+import { setActivePinia } from 'pinia';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// usePageTitle reads `const { t, te } = globalComposer` from '@/i18n' at the
+// top of the composable (so it can run outside a component setup context).
+// Mock the module to supply a deterministic, pass-through composer:
+//   - te() returns false so titles are treated as plain strings, not i18n keys
+//   - t() echoes the key back (never reached here, kept for completeness)
+vi.mock('@/i18n', () => ({
+  globalComposer: {
+    t: (key: string) => key,
+    te: () => false,
+  },
+}));
+
+/**
+ * Installs a fresh testing Pinia with the given bootstrap fields and makes it
+ * the active instance so useBootstrapStore() (called inside usePageTitle)
+ * resolves against it.
+ */
+const setupPinia = (bootstrap: {
+  display_domain?: string;
+  brand_product_name?: string | null;
+}) => {
+  const pinia = createTestingPinia({
+    createSpy: vi.fn,
+    stubActions: false,
+    initialState: {
+      bootstrap,
+    },
+  });
+  setActivePinia(pinia);
+  return pinia;
+};
+
+describe('usePageTitle — brand fallback (A4 branding leak)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Reset the jsdom title between cases so assertions are deterministic.
+    document.title = '';
+  });
+
+  describe('getAppName fallback chain via formatTitle', () => {
+    it('uses the display domain when it is set', () => {
+      setupPinia({ display_domain: 'secrets.acme.com', brand_product_name: 'Acme Vault' });
+      const { formatTitle } = usePageTitle();
+
+      // The active domain wins over both the product name and the neutral default.
+      expect(formatTitle('Dashboard')).toBe('Dashboard - secrets.acme.com');
+    });
+
+    it('falls back to brand_product_name when display_domain is empty', () => {
+      setupPinia({ display_domain: '', brand_product_name: 'Acme Vault' });
+      const { formatTitle } = usePageTitle();
+
+      const title = formatTitle('Dashboard');
+      expect(title).toBe('Dashboard - Acme Vault');
+      expect(title).not.toContain('Onetime Secret');
+    });
+
+    it('falls back to the neutral default when both domain and product name are unset', () => {
+      setupPinia({ display_domain: '', brand_product_name: null });
+      const { formatTitle } = usePageTitle();
+
+      const title = formatTitle('Dashboard');
+      expect(title).toBe(`Dashboard - ${NEUTRAL_BRAND_DEFAULTS.product_name}`);
+      expect(title).toContain('My App');
+      // The core A4 guarantee: never emit OTS branding.
+      expect(title).not.toContain('Onetime Secret');
+    });
+
+    it('falls back to the neutral default when brand_product_name is an empty string', () => {
+      // An empty string is falsy and must fall through to the neutral default,
+      // not produce a dangling separator or a blank app name.
+      setupPinia({ display_domain: '', brand_product_name: '' });
+      const { formatTitle } = usePageTitle();
+
+      expect(formatTitle('Dashboard')).toBe(`Dashboard - ${NEUTRAL_BRAND_DEFAULTS.product_name}`);
+    });
+  });
+
+  describe('setTitle updates document.title with the resolved app name', () => {
+    it('sets "Page - <displayDomain>" when a page title is given', () => {
+      setupPinia({ display_domain: 'secrets.acme.com', brand_product_name: null });
+      const { setTitle } = usePageTitle();
+
+      setTitle('Some Page');
+      expect(document.title).toBe('Some Page - secrets.acme.com');
+    });
+
+    it('setTitle(null) yields just the app name (brand_product_name fallback)', () => {
+      setupPinia({ display_domain: '', brand_product_name: 'Acme Vault' });
+      const { setTitle } = usePageTitle();
+
+      setTitle(null);
+      expect(document.title).toBe('Acme Vault');
+      expect(document.title).not.toContain('Onetime Secret');
+    });
+
+    it('setTitle(undefined) yields the neutral default when nothing is configured', () => {
+      setupPinia({ display_domain: '', brand_product_name: null });
+      const { setTitle } = usePageTitle();
+
+      setTitle(undefined);
+      expect(document.title).toBe(NEUTRAL_BRAND_DEFAULTS.product_name);
+      expect(document.title).not.toContain('Onetime Secret');
+    });
+  });
+
+  describe('formatTitle app-name-only collapsing', () => {
+    it('returns just the app name when the page title equals the app name', () => {
+      setupPinia({ display_domain: 'secrets.acme.com', brand_product_name: null });
+      const { formatTitle } = usePageTitle();
+
+      // Avoids "secrets.acme.com - secrets.acme.com" duplication.
+      expect(formatTitle('secrets.acme.com')).toBe('secrets.acme.com');
+    });
+  });
+});

--- a/src/tests/stores/identityStore.spec.ts
+++ b/src/tests/stores/identityStore.spec.ts
@@ -18,7 +18,7 @@ import {
 } from 'vitest';
 import { nextTick } from 'vue';
 import { createPinia, setActivePinia } from 'pinia';
-import { NEUTRAL_BRAND_DEFAULTS } from '@/shared/constants/brand';
+import { DEFAULT_LOGO_COMPONENT, NEUTRAL_BRAND_DEFAULTS } from '@/shared/constants/brand';
 import { readFileSync } from 'fs';
 import { resolve } from 'path';
 
@@ -475,5 +475,50 @@ describe('identityStore showPlatformIdentity', () => {
     await nextTick();
 
     expect(identity.showPlatformIdentity).toBe(false);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// logoSource — resolved tenant-or-neutral logo image (Phase 4 consolidation)
+//
+// The tenant's uploaded logo when present, else the neutral DefaultLogo
+// component sentinel. Never null, so the masthead can stop reading raw
+// bootstrapStore.domain_logo and route the logo image through the resolver too.
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('identityStore logoSource', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  it('returns the tenant logo URL when an uploaded logo is present', () => {
+    const bootstrap = useBootstrapStore();
+    bootstrap.$patch({ domain_logo: 'https://cdn.example.com/acme.png' });
+
+    const identity = useProductIdentity();
+
+    expect(identity.logoSource).toBe('https://cdn.example.com/acme.png');
+  });
+
+  it('falls back to the neutral DefaultLogo component when no tenant logo', () => {
+    const bootstrap = useBootstrapStore();
+    bootstrap.$patch({ domain_logo: null });
+
+    const identity = useProductIdentity();
+
+    expect(identity.logoSource).toBe(DEFAULT_LOGO_COMPONENT);
+  });
+
+  it('reacts to a tenant logo being uploaded', async () => {
+    const bootstrap = useBootstrapStore();
+    bootstrap.$patch({ domain_logo: null });
+
+    const identity = useProductIdentity();
+    expect(identity.logoSource).toBe(DEFAULT_LOGO_COMPONENT);
+
+    bootstrap.$patch({ domain_logo: 'https://cdn.example.com/acme.png' });
+    await nextTick();
+
+    expect(identity.logoSource).toBe('https://cdn.example.com/acme.png');
   });
 });

--- a/src/tests/stores/identityStore.spec.ts
+++ b/src/tests/stores/identityStore.spec.ts
@@ -482,8 +482,9 @@ describe('identityStore showPlatformIdentity', () => {
 // logoSource — resolved tenant-or-neutral logo image (Phase 4 consolidation)
 //
 // The tenant's uploaded logo when present, else the neutral DefaultLogo
-// component sentinel. Never null, so the masthead can stop reading raw
-// bootstrapStore.domain_logo and route the logo image through the resolver too.
+// component sentinel. Never null or empty (uses ||, so '' is treated as
+// absent), so the masthead can stop reading raw bootstrapStore.domain_logo and
+// route the logo image through the resolver too.
 // ═══════════════════════════════════════════════════════════════════════════
 
 describe('identityStore logoSource', () => {
@@ -503,6 +504,19 @@ describe('identityStore logoSource', () => {
   it('falls back to the neutral DefaultLogo component when no tenant logo', () => {
     const bootstrap = useBootstrapStore();
     bootstrap.$patch({ domain_logo: null });
+
+    const identity = useProductIdentity();
+
+    expect(identity.logoSource).toBe(DEFAULT_LOGO_COMPONENT);
+  });
+
+  it('treats an empty-string tenant logo as absent (falls back to the sentinel)', () => {
+    // domain_logo is schema-allowed to be '' and is read as a truthy/falsy
+    // signal elsewhere (e.g. !!domain_logo in router guards). Using `||`, an
+    // empty logo degrades to the neutral sentinel rather than surfacing '' as a
+    // broken logo URL through the masthead's terminal fallback.
+    const bootstrap = useBootstrapStore();
+    bootstrap.$patch({ domain_logo: '' });
 
     const identity = useProductIdentity();
 

--- a/src/tests/stores/identityStore.spec.ts
+++ b/src/tests/stores/identityStore.spec.ts
@@ -329,3 +329,151 @@ describe('identityStore primaryColor resolution', () => {
     });
   });
 });
+
+// ═══════════════════════════════════════════════════════════════════════════
+// productName — neutral-safe install product name (A1 consolidation)
+//
+// The store is the single source of truth for the product-name fallback that
+// MastHead and DefaultLogo previously re-derived by hand. It must degrade to
+// the neutral default ('My App'), never a hardcoded "Onetime Secret", and must
+// treat an empty string as unset (|| not ??).
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('identityStore productName resolution', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  it('uses brand_product_name when set', () => {
+    const bootstrap = useBootstrapStore();
+    bootstrap.$patch({ brand_product_name: 'Acme Vault' });
+
+    const identity = useProductIdentity();
+
+    expect(identity.productName).toBe('Acme Vault');
+  });
+
+  it('falls back to the neutral default when undefined', () => {
+    const bootstrap = useBootstrapStore();
+    bootstrap.$patch({ brand_product_name: undefined });
+
+    const identity = useProductIdentity();
+
+    expect(identity.productName).toBe(NEUTRAL_BRAND_DEFAULTS.product_name);
+    expect(identity.productName).not.toBe('Onetime Secret');
+  });
+
+  it('falls back to the neutral default when null', () => {
+    const bootstrap = useBootstrapStore();
+    bootstrap.$patch({ brand_product_name: null });
+
+    const identity = useProductIdentity();
+
+    expect(identity.productName).toBe(NEUTRAL_BRAND_DEFAULTS.product_name);
+  });
+
+  it('treats an empty string as unset and falls back to the neutral default', () => {
+    const bootstrap = useBootstrapStore();
+    bootstrap.$patch({ brand_product_name: '' });
+
+    const identity = useProductIdentity();
+
+    // `||` (not `??`) — a blank product-name config degrades to 'My App'
+    // rather than rendering an empty name.
+    expect(identity.productName).toBe(NEUTRAL_BRAND_DEFAULTS.product_name);
+  });
+
+  it('reacts to brand_product_name changes', async () => {
+    const bootstrap = useBootstrapStore();
+    bootstrap.$patch({ brand_product_name: undefined });
+
+    const identity = useProductIdentity();
+    expect(identity.productName).toBe(NEUTRAL_BRAND_DEFAULTS.product_name);
+
+    bootstrap.$patch({ brand_product_name: 'Acme Vault' });
+    await nextTick();
+
+    expect(identity.productName).toBe('Acme Vault');
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// showPlatformIdentity — base "may we show the platform wordmark?" guard (A3)
+//
+// False on any custom domain and whenever a per-tenant logo is present, so a
+// consumer can suppress the platform name/wordmark without re-deriving the
+// leak rule. Canonical + subdomain contexts return true (subject to the
+// consumer's own config).
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('identityStore showPlatformIdentity', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  it('is true on the canonical domain with no logo', () => {
+    const bootstrap = useBootstrapStore();
+    bootstrap.$patch({ domain_strategy: 'canonical', domain_logo: null });
+
+    const identity = useProductIdentity();
+
+    expect(identity.showPlatformIdentity).toBe(true);
+  });
+
+  it('is true on a subdomain (the subdomain IS the platform)', () => {
+    const bootstrap = useBootstrapStore();
+    bootstrap.$patch({ domain_strategy: 'subdomain', domain_logo: null });
+
+    const identity = useProductIdentity();
+
+    expect(identity.showPlatformIdentity).toBe(true);
+  });
+
+  it('is false on a custom domain with no uploaded logo (A3 leak guard)', () => {
+    const bootstrap = useBootstrapStore();
+    bootstrap.$patch({ domain_strategy: 'custom', domain_logo: null });
+
+    const identity = useProductIdentity();
+
+    expect(identity.showPlatformIdentity).toBe(false);
+  });
+
+  it('is false on a custom domain that has an uploaded logo', () => {
+    const bootstrap = useBootstrapStore();
+    bootstrap.$patch({
+      domain_strategy: 'custom',
+      domain_logo: 'https://cdn.example.com/acme.png',
+    });
+
+    const identity = useProductIdentity();
+
+    expect(identity.showPlatformIdentity).toBe(false);
+  });
+
+  it('is false whenever a per-tenant logo is present, independent of strategy', () => {
+    // Defensive: a logo implies a tenant surface — never show the platform name
+    // beside it even if the strategy field says otherwise.
+    const bootstrap = useBootstrapStore();
+    bootstrap.$patch({
+      domain_strategy: 'canonical',
+      domain_logo: 'https://cdn.example.com/acme.png',
+    });
+
+    const identity = useProductIdentity();
+
+    expect(identity.showPlatformIdentity).toBe(false);
+  });
+
+  it('reacts to domain_strategy changing to custom', async () => {
+    const bootstrap = useBootstrapStore();
+    bootstrap.$patch({ domain_strategy: 'canonical', domain_logo: null });
+
+    const identity = useProductIdentity();
+    expect(identity.showPlatformIdentity).toBe(true);
+
+    bootstrap.$patch({ domain_strategy: 'custom' });
+    await nextTick();
+
+    expect(identity.showPlatformIdentity).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #3566

Centralizes brand identity resolution through `identityStore` to prevent "Onetime Secret" branding from leaking onto custom domains and unbranded installations. Previously, surfaces like MastHead, DefaultLogo, and page titles each re-derived the product-name fallback from raw bootstrap fields, creating multiple opportunities for the hardcoded OTS literal to appear where it shouldn't.

This change introduces:
- `identityStore.productName` — a neutral-safe product name resolver that replaces hand-rolled `brand_product_name ?? NEUTRAL_BRAND_DEFAULTS` snippets across surfaces
- `identityStore.showPlatformIdentity` — a base guard that suppresses the platform wordmark on custom domains (with or without uploaded logos) and whenever a per-tenant logo is present
- `resolveProductName()` helper in `constants/brand.ts` — shared by both component surfaces (via identityStore) and router guards (usePageTitle, which runs outside the i18n context)

## Key Changes

**identityStore.ts**
- Added `productName` computed property that applies the neutral-safe fallback chain
- Added `showPlatformIdentity` computed property that returns false for custom domains or when a per-tenant logo is present
- Both properties centralize decisions previously scattered across MastHead, DefaultLogo, and usePageTitle

**MastHead.vue**
- Now consumes `identity.productName` and `identity.showPlatformIdentity` instead of reading `brand_product_name` directly
- Removed hardcoded `NEUTRAL_BRAND_DEFAULTS` reference
- The `showPlatformIdentity` guard prevents the platform site name from appearing on custom domains

**DefaultLogo.vue**
- Now resolves the aria-label fallback through `identity.productName` instead of reading bootstrap fields directly
- Ensures the neutral default ("My App") is used when no brand name is configured, never "Onetime Secret"

**usePageTitle.ts**
- Removed hardcoded `APP_NAME = 'Onetime Secret'` constant
- Now uses `resolveProductName()` helper to apply the same neutral-safe fallback chain
- Ensures page titles, og:title, and twitter:title never leak OTS branding

**constants/brand.ts**
- Added `resolveProductName()` function as the single source of truth for the product-name fallback
- Used by both identityStore (component context) and usePageTitle (router-guard context)

## Test Plan

Comprehensive test coverage added:
- `identityStore.spec.ts`: Tests for `productName` and `showPlatformIdentity` resolution, including edge cases (empty string, null, undefined)
- `MastHead.customDomain.spec.ts`: Updated tests confirming the platform site name is suppressed on custom domains with no logo, while the neutral mark still renders
- `DefaultLogo.spec.ts`: Tests confirming the aria-label falls back to the neutral default via identityStore
- `usePageTitle.spec.ts`: Tests confirming page titles never emit OTS branding and properly fall back through the chain
- `brandingResolverConsolidation.guard.spec.ts`: Source-level guardrail tests ensuring surfaces don't re-derive brand identity or hardcode OTS literals

All existing tests pass; new tests verify the consolidation prevents the three leak classes (A1/A3/A4).

https://claude.ai/code/session_01MvR9x1zU2TBnmgQV43bD2p