### PR TITLE
refactor(branding): route the masthead logo image through the resolver (Phase 4)

### DIFF
--- a/src/shared/components/layout/MastHead.vue
+++ b/src/shared/components/layout/MastHead.vue
@@ -5,6 +5,7 @@
   import DefaultLogo from '@/shared/components/logos/DefaultLogo.vue';
   import UserMenu from '@/shared/components/navigation/UserMenu.vue';
   import { useHeaderEnabled } from '@/shared/composables/useHeaderEnabled';
+  import { DEFAULT_LOGO_COMPONENT } from '@/shared/constants/brand';
   import { useAuthStore } from '@/shared/stores/authStore';
   import { useBootstrapStore } from '@/shared/stores/bootstrapStore';
   import { useProductIdentity } from '@/shared/stores/identityStore';
@@ -20,16 +21,18 @@
     email,
     cust,
     ui,
-    domain_logo,
   } = storeToRefs(bootstrapStore);
 
   // Brand identity resolves through the central resolver so the masthead shares
-  // one neutral-safe source of truth with every other surface. `productName`
-  // replaces the hand-rolled `brand_product_name ?? NEUTRAL` snippet;
-  // `showPlatformIdentity` is the base "may we show the platform wordmark?"
-  // decision (custom domains / per-tenant logos suppress it — the A3 leak).
+  // one neutral-safe source of truth with every other surface — the header reads
+  // no raw brand/identity bootstrap fields directly. `productName` replaces the
+  // hand-rolled `brand_product_name ?? NEUTRAL` snippet; `showPlatformIdentity`
+  // is the base "may we show the platform wordmark?" decision (custom domains /
+  // per-tenant logos suppress it — the A3 leak); `logoUri`/`logoSource` supply
+  // the tenant-or-neutral logo image (replacing the raw `domain_logo` read).
   const identityStore = useProductIdentity();
-  const { productName, showPlatformIdentity } = storeToRefs(identityStore);
+  const { productName, showPlatformIdentity, logoUri, logoSource } =
+    storeToRefs(identityStore);
 
   const props = withDefaults(defineProps<LayoutProps>(), {
     displayMasthead: true,
@@ -50,17 +53,22 @@
   // Header configuration
   const headerConfig = computed(() => ui.value?.header);
 
-  // Default logo component for fallback
-  const DEFAULT_LOGO = 'DefaultLogo.vue';
+  // Default logo component for fallback (shared sentinel, also used by the
+  // resolver's logoSource so the dynamic-import comparisons below stay in sync).
+  const DEFAULT_LOGO = DEFAULT_LOGO_COMPONENT;
 
-  // Helper functions for logo configuration
-  // Priority: props > custom domain logo > static config > default
-  const getLogoUrl = () => props.logo?.url || domain_logo.value || headerConfig.value?.branding?.logo?.url || DEFAULT_LOGO;
+  // Helper functions for logo configuration.
+  // Priority: props.logo.url (caller) > tenant logo (identity.logoUri) >
+  //           operator LOGO_URL (headerConfig) > neutral default (logoSource).
+  // A per-tenant uploaded logo wins over an operator-wide LOGO_URL; logoSource
+  // supplies the neutral DefaultLogo terminal (== DEFAULT_LOGO when no tenant
+  // logo, since the tenant rung already short-circuited).
+  const getLogoUrl = () => props.logo?.url || logoUri.value || headerConfig.value?.branding?.logo?.url || logoSource.value;
   const getLogoAlt = () => props.logo?.alt || headerConfig.value?.branding?.logo?.alt || t('web.homepage.one_time_secret_literal', { product_name: productName.value });
   const getLogoHref = () => props.logo?.href || headerConfig.value?.branding?.logo?.link_to || '/';
 
   // Static-config custom logo: operator set LOGO_URL to anything other than the
-  // bundled DefaultLogo.vue. Distinct from domain_logo (per-tenant runtime signal),
+  // bundled DefaultLogo.vue. Distinct from the tenant logo (identity.logoUri),
   // because the two have different override semantics for the site name.
   const isCustomStaticLogo = computed(() =>
     !!headerConfig.value?.branding?.logo?.url

--- a/src/shared/constants/brand.ts
+++ b/src/shared/constants/brand.ts
@@ -78,3 +78,14 @@ export function resolveProductName(
 ): string {
   return brandProductName || NEUTRAL_BRAND_DEFAULTS.product_name;
 }
+
+/**
+ * Sentinel for the neutral, brand-agnostic default logo component.
+ *
+ * The masthead's logo loader treats a `.vue` URL as a component to dynamically
+ * import; this value points at the bundled neutral `DefaultLogo.vue` (the
+ * keyhole mark — the OTS-company maruhi 秘 mark is never the default). Centralized
+ * here so the resolver (`identityStore.logoSource`) and its consumers agree on
+ * one sentinel rather than each hardcoding the string.
+ */
+export const DEFAULT_LOGO_COMPONENT = 'DefaultLogo.vue';

--- a/src/shared/stores/identityStore.ts
+++ b/src/shared/stores/identityStore.ts
@@ -213,15 +213,21 @@ export const useProductIdentity = defineStore('productIdentity', () => {
 
   /**
    * Resolved logo source on the identity axis: the tenant's uploaded logo when
-   * present, otherwise the neutral `DefaultLogo` component sentinel. Never null,
-   * so a consumer can render a lockup without its own "no logo" fallback.
+   * present, otherwise the neutral `DefaultLogo` component sentinel. Never null
+   * or empty, so a consumer can render a lockup without its own "no logo"
+   * fallback.
+   *
+   * Uses `||` (not `??`): an empty-string `domain_logo` is treated as absent and
+   * falls through to the neutral sentinel, matching how the rest of the codebase
+   * reads the logo as a truthy/falsy signal (e.g. `!!domain_logo` in the router
+   * guards) and preserving the masthead's prior terminal fallback for `''`.
    *
    * This is the identity contribution only; the masthead still layers its own
    * caller/operator rungs (props.logo.url, LOGO_URL) around it — a per-tenant
    * logo must win over an operator-wide LOGO_URL, and LOGO_URL over the neutral
    * default.
    */
-  const logoSource = computed(() => logoUri.value ?? DEFAULT_LOGO_COMPONENT);
+  const logoSource = computed(() => logoUri.value || DEFAULT_LOGO_COMPONENT);
 
   const cornerClass = computed(() =>
     state.brand?.corner_style

--- a/src/shared/stores/identityStore.ts
+++ b/src/shared/stores/identityStore.ts
@@ -4,7 +4,11 @@ import {
   brandSettingsSchema,
   type BrandSettings,
 } from '@/schemas/shapes/v3/custom-domain';
-import { NEUTRAL_BRAND_DEFAULTS, resolveProductName } from '@/shared/constants/brand';
+import {
+  DEFAULT_LOGO_COMPONENT,
+  NEUTRAL_BRAND_DEFAULTS,
+  resolveProductName,
+} from '@/shared/constants/brand';
 import { cornerStyleClasses, fontFamilyClasses } from '@/shared/utils/brand-helpers';
 import { gracefulParse } from '@/utils/schemaValidation';
 import { defineStore, storeToRefs } from 'pinia';
@@ -207,6 +211,18 @@ export const useProductIdentity = defineStore('productIdentity', () => {
    */
   const showPlatformIdentity = computed(() => !isCustom.value && !logoUri.value);
 
+  /**
+   * Resolved logo source on the identity axis: the tenant's uploaded logo when
+   * present, otherwise the neutral `DefaultLogo` component sentinel. Never null,
+   * so a consumer can render a lockup without its own "no logo" fallback.
+   *
+   * This is the identity contribution only; the masthead still layers its own
+   * caller/operator rungs (props.logo.url, LOGO_URL) around it — a per-tenant
+   * logo must win over an operator-wide LOGO_URL, and LOGO_URL over the neutral
+   * default.
+   */
+  const logoSource = computed(() => logoUri.value ?? DEFAULT_LOGO_COMPONENT);
+
   const cornerClass = computed(() =>
     state.brand?.corner_style
       ? cornerStyleClasses[state.brand.corner_style] ?? DEFAULT_CORNER_CLASS
@@ -246,6 +262,7 @@ export const useProductIdentity = defineStore('productIdentity', () => {
     displayName,
     productName,
     showPlatformIdentity,
+    logoSource,
     $reset,
 
     ...toRefs(state),

--- a/src/tests/shared/brandingResolverConsolidation.guard.spec.ts
+++ b/src/tests/shared/brandingResolverConsolidation.guard.spec.ts
@@ -47,14 +47,22 @@ describe('branding resolver consolidation guardrail', () => {
       expect(code).not.toContain('NEUTRAL_BRAND_DEFAULTS');
     });
 
+    it('does not read the raw domain_logo bootstrap field (routes via the resolver)', () => {
+      // The header must not reach into raw identity fields — the tenant logo
+      // comes from identity.logoUri / identity.logoSource, not domain_logo.
+      expect(code).not.toContain('domain_logo');
+    });
+
     it('does not hardcode the OTS platform name', () => {
       expect(code).not.toContain('Onetime Secret');
     });
 
-    it('consumes the resolver (useProductIdentity + productName + showPlatformIdentity)', () => {
+    it('consumes the resolver (identity signals, not raw bootstrap identity)', () => {
       expect(raw).toContain('useProductIdentity');
       expect(raw).toContain('productName');
       expect(raw).toContain('showPlatformIdentity');
+      expect(raw).toContain('logoUri');
+      expect(raw).toContain('logoSource');
     });
   });
 

--- a/src/tests/stores/identityStore.spec.ts
+++ b/src/tests/stores/identityStore.spec.ts
@@ -18,7 +18,7 @@ import {
 } from 'vitest';
 import { nextTick } from 'vue';
 import { createPinia, setActivePinia } from 'pinia';
-import { NEUTRAL_BRAND_DEFAULTS } from '@/shared/constants/brand';
+import { DEFAULT_LOGO_COMPONENT, NEUTRAL_BRAND_DEFAULTS } from '@/shared/constants/brand';
 import { readFileSync } from 'fs';
 import { resolve } from 'path';
 
@@ -475,5 +475,50 @@ describe('identityStore showPlatformIdentity', () => {
     await nextTick();
 
     expect(identity.showPlatformIdentity).toBe(false);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// logoSource — resolved tenant-or-neutral logo image (Phase 4 consolidation)
+//
+// The tenant's uploaded logo when present, else the neutral DefaultLogo
+// component sentinel. Never null, so the masthead can stop reading raw
+// bootstrapStore.domain_logo and route the logo image through the resolver too.
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('identityStore logoSource', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  it('returns the tenant logo URL when an uploaded logo is present', () => {
+    const bootstrap = useBootstrapStore();
+    bootstrap.$patch({ domain_logo: 'https://cdn.example.com/acme.png' });
+
+    const identity = useProductIdentity();
+
+    expect(identity.logoSource).toBe('https://cdn.example.com/acme.png');
+  });
+
+  it('falls back to the neutral DefaultLogo component when no tenant logo', () => {
+    const bootstrap = useBootstrapStore();
+    bootstrap.$patch({ domain_logo: null });
+
+    const identity = useProductIdentity();
+
+    expect(identity.logoSource).toBe(DEFAULT_LOGO_COMPONENT);
+  });
+
+  it('reacts to a tenant logo being uploaded', async () => {
+    const bootstrap = useBootstrapStore();
+    bootstrap.$patch({ domain_logo: null });
+
+    const identity = useProductIdentity();
+    expect(identity.logoSource).toBe(DEFAULT_LOGO_COMPONENT);
+
+    bootstrap.$patch({ domain_logo: 'https://cdn.example.com/acme.png' });
+    await nextTick();
+
+    expect(identity.logoSource).toBe('https://cdn.example.com/acme.png');
   });
 });

--- a/src/tests/stores/identityStore.spec.ts
+++ b/src/tests/stores/identityStore.spec.ts
@@ -482,8 +482,9 @@ describe('identityStore showPlatformIdentity', () => {
 // logoSource — resolved tenant-or-neutral logo image (Phase 4 consolidation)
 //
 // The tenant's uploaded logo when present, else the neutral DefaultLogo
-// component sentinel. Never null, so the masthead can stop reading raw
-// bootstrapStore.domain_logo and route the logo image through the resolver too.
+// component sentinel. Never null or empty (uses ||, so '' is treated as
+// absent), so the masthead can stop reading raw bootstrapStore.domain_logo and
+// route the logo image through the resolver too.
 // ═══════════════════════════════════════════════════════════════════════════
 
 describe('identityStore logoSource', () => {
@@ -503,6 +504,19 @@ describe('identityStore logoSource', () => {
   it('falls back to the neutral DefaultLogo component when no tenant logo', () => {
     const bootstrap = useBootstrapStore();
     bootstrap.$patch({ domain_logo: null });
+
+    const identity = useProductIdentity();
+
+    expect(identity.logoSource).toBe(DEFAULT_LOGO_COMPONENT);
+  });
+
+  it('treats an empty-string tenant logo as absent (falls back to the sentinel)', () => {
+    // domain_logo is schema-allowed to be '' and is read as a truthy/falsy
+    // signal elsewhere (e.g. !!domain_logo in router guards). Using `||`, an
+    // empty logo degrades to the neutral sentinel rather than surfacing '' as a
+    // broken logo URL through the masthead's terminal fallback.
+    const bootstrap = useBootstrapStore();
+    bootstrap.$patch({ domain_logo: '' });
 
     const identity = useProductIdentity();
 


### PR DESCRIPTION
## Summary

Stacked follow-up to #3568 (the brand-identity resolver consolidation). This finishes the header's migration onto `identityStore`: `MastHead`'s `getLogoUrl` no longer reads the raw `bootstrapStore.domain_logo` field, so the header now reads **zero** raw brand/identity bootstrap fields — the last remaining direct read is gone.

- **`brand.ts`** — add a `DEFAULT_LOGO_COMPONENT` sentinel for the neutral default logo component, so the resolver and the masthead's dynamic-import comparisons share one definition instead of hardcoding `'DefaultLogo.vue'`.
- **`identityStore`** — add `logoSource = logoUri ?? DEFAULT_LOGO_COMPONENT` (the tenant's uploaded logo, else the neutral `DefaultLogo` sentinel; never null).
- **`MastHead`** — `getLogoUrl` becomes `props.logo.url || identity.logoUri || LOGO_URL || identity.logoSource`, preserving the **exact** existing precedence: a per-tenant uploaded logo still beats an operator-wide `LOGO_URL`, which still beats the neutral default.
- **Guardrail** — the consolidation guard now also asserts `MastHead` contains no raw `domain_logo` read and consumes `logoUri`/`logoSource`, closing the proposal's final guardrail item (no direct `domain_logo` reads outside the resolver).

This is a **behavior-preserving** internal refactor: `identity.logoUri === domain_logo`, so the rendered logo is unchanged in every case. The fuller `logoSource` abstraction from the proposal is realized as a resolver signal, but the masthead keeps its own caller/operator rungs around it — the operator `LOGO_URL` rung sits between the tenant logo and the neutral default, so it cannot be folded into a single store value without changing precedence.

## Related Issues

- Stacks on #3568 (parent branch `claude/branding-resolver-consolidation-ztwzcp`); merge that first.
- Completes Phase 4 of the brand-identity consolidation plan and the "no direct `domain_logo` reads" guardrail item. No issues auto-closed.

## Test Plan

- `identityStore.spec.ts` — new `logoSource` tests (tenant URL, neutral-default fallback, reactivity).
- Guardrail spec extended to forbid raw `domain_logo` in `MastHead` and require `logoUri`/`logoSource` consumption.
- Existing masthead logo-URL suites (`MastHead.spec`, `MastHead.customDomain.spec`) pass unchanged — precedence is preserved.
- Full local run of `src/tests/shared`, `src/tests/apps/secret`, `src/tests/stores` (1306 passing) plus `type-check` clean and lint 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MvR9x1zU2TBnmgQV43bD2p

---
_Generated by [Claude Code](https://claude.ai/code/session_01MvR9x1zU2TBnmgQV43bD2p)_