### PR TITLE
branding: rename neutral default product name 'My App' → 'Secure Links'

### DIFF
--- a/apps/web/core/logic/page/get_webmanifest.rb
+++ b/apps/web/core/logic/page/get_webmanifest.rb
@@ -19,7 +19,7 @@ module Core
       #
       # When no brand config is present the neutral file is served unchanged, so
       # a vanilla self-hosted install still gets a valid, brand-agnostic manifest
-      # ("My App"). Icons are left as the on-disk paths (override by replacing the
+      # ("Secure Links"). Icons are left as the on-disk paths (override by replacing the
       # files). This mirrors the favicon precedence: per-deployment brand config
       # over neutral defaults, without OTS branding ever shipping as the default.
       class GetWebmanifest < Core::Logic::Base
@@ -29,8 +29,8 @@ module Core
 
         # Minimal neutral fallback if the on-disk manifest is missing/corrupt.
         NEUTRAL_FALLBACK = {
-          'name' => 'My App',
-          'short_name' => 'My App',
+          'name' => 'Secure Links',
+          'short_name' => 'Secure Links',
           'icons' => [
             { 'src' => '/icon-192.png', 'sizes' => '192x192', 'type' => 'image/png', 'purpose' => 'any' },
             { 'src' => '/icon-512.png', 'sizes' => '512x512', 'type' => 'image/png', 'purpose' => 'any' },

--- a/changelog.d/20260701_130000_claude_neutral_default_secure_links.rst
+++ b/changelog.d/20260701_130000_claude_neutral_default_secure_links.rst
@@ -1,0 +1,9 @@
+.. A new scriv changelog fragment.
+
+Changed
+-------
+
+- The neutral product name shown on unbranded / private-label installs is now
+  "Secure Links" instead of "My App", across the UI and the PWA manifest.
+  Installs that configure ``BRAND_PRODUCT_NAME`` or per-domain branding are
+  unaffected.

--- a/docs/architecture/branding.md
+++ b/docs/architecture/branding.md
@@ -31,7 +31,7 @@ Ruby resolvers (#3049), and an absent section falls through to step 3.
 **Step 3 — neutral fallback.** When no brand data is present (the common
 self-hosted case), the frontend uses `NEUTRAL_BRAND_DEFAULTS`
 (`src/shared/constants/brand.ts`): neutral blue `#3B82F6`, product name
-`"My App"`. The deprecated `DEFAULT_BRAND_HEX` (`#dc4a22`, OTS orange) is **not**
+`"Secure Links"`. The deprecated `DEFAULT_BRAND_HEX` (`#dc4a22`, OTS orange) is **not**
 the fallback — it is retained only where OTS-orange is specifically intended
 (e.g. palette-generator tests).
 
@@ -129,7 +129,7 @@ in that file.
 ## Private-label checklist
 
 - [ ] `BRAND_PRIMARY_COLOR`, `BRAND_PRODUCT_NAME` (required to override neutral
-      blue / `"My App"`)
+      blue / `"Secure Links"`)
 - [ ] `BRAND_SUPPORT_EMAIL`, `BRAND_LOGO_URL` (or per-domain logo via the
       CustomDomain API)
 - [ ] Clear `BRAND_*` → verify neutral theme appears (fallback works)

--- a/lib/onetime/models/custom_domain/brand_settings.rb
+++ b/lib/onetime/models/custom_domain/brand_settings.rb
@@ -50,7 +50,7 @@ module Onetime
       # defaults) — including product_name. Operators set BRAND_PRODUCT_NAME /
       # BRAND_SUPPORT_EMAIL / BRAND_LOGO_URL to populate; an unconfigured
       # install falls through to each consumer's own neutral default
-      # (frontend: NEUTRAL_BRAND_DEFAULTS.product_name = 'My App'; mail/page
+      # (frontend: NEUTRAL_BRAND_DEFAULTS.product_name = 'Secure Links'; mail/page
       # title: the legacy site.interface.ui.header.branding.site_name value).
       #
       # totp_issuer is the one deliberate exception, kept as 'OTS' rather

--- a/public/web/site.webmanifest
+++ b/public/web/site.webmanifest
@@ -1,6 +1,6 @@
 {
-  "name": "My App",
-  "short_name": "My App",
+  "name": "Secure Links",
+  "short_name": "Secure Links",
   "icons": [
     {
       "src": "/icon-192.png",

--- a/scripts/branding/mark.mjs
+++ b/scripts/branding/mark.mjs
@@ -21,7 +21,7 @@
 //   MARK_PRIMARY_COLOR        tile / gradient colour       (default: #3B82F6)
 //   MARK_BACKGROUND_COLOR     mark colour                  (default: #FFFFFF)
 //   MARK_OG_GRADIENT_DARK     social-card top gradient stop (default: #1E3A8A)
-//   MARK_PRODUCT_NAME         webmanifest name             (default: My App)
+//   MARK_PRODUCT_NAME         webmanifest name             (default: Secure Links)
 //   MARK_SHORT_NAME           webmanifest short_name       (default: product name)
 //   MARK_COVERAGE             icon glyph height ratio       (default: 0.58)
 //   MARK_MASK_COVERAGE        pinned-tab glyph height ratio (default: 0.70)
@@ -61,7 +61,7 @@ const OG_GRADIENT_DARK = process.env.MARK_OG_GRADIENT_DARK || '#1E3A8A';
 
 // Web manifest text. Neutral defaults are deliberately generic (the runtime
 // /site.webmanifest route overlays the real brand.product_name when configured).
-const PRODUCT_NAME = process.env.MARK_PRODUCT_NAME || 'My App';
+const PRODUCT_NAME = process.env.MARK_PRODUCT_NAME || 'Secure Links';
 const SHORT_NAME = process.env.MARK_SHORT_NAME || PRODUCT_NAME;
 
 // Optional licensing/credit line for a swapped-in glyph. When set, it is emitted

--- a/scripts/branding/mark.test.mjs
+++ b/scripts/branding/mark.test.mjs
@@ -87,7 +87,7 @@ test('ogImageSvg: fixed 1200x630 card with a two-stop gradient', () => {
 
 test('webmanifest: valid JSON with neutral defaults', () => {
   const m = JSON.parse(webmanifest());
-  assert.equal(m.name, 'My App');
+  assert.equal(m.name, 'Secure Links');
   assert.equal(m.theme_color, PRIMARY_COLOUR);
   assert.equal(m.icons.length, 3);
 });

--- a/src/shared/components/logos/DefaultLogo.vue
+++ b/src/shared/components/logos/DefaultLogo.vue
@@ -25,7 +25,7 @@
 
   /**
    * Brand-aware aria-label. Falls back to the neutral-safe product name
-   * (a generic "My App") via the shared `resolveProductName` helper when
+   * (a generic "Secure Links") via the shared `resolveProductName` helper when
    * bootstrap config has not provided a brand name. Never defaults to OTS
    * branding — keeps private-label deployments neutral (#3048 / #3049).
    *

--- a/src/shared/composables/usePageTitle.ts
+++ b/src/shared/composables/usePageTitle.ts
@@ -54,7 +54,7 @@ export function usePageTitle() {
    * twitter:title, following the neutral brand fallback chain:
    *   1. display_domain     - the active (custom) domain, when set
    *   2. brand_product_name - the per-installation product name from OT.conf
-   *   3. neutral default    - 'My App' via resolveProductName
+   *   3. neutral default    - 'Secure Links' via resolveProductName
    *
    * This must NEVER emit OTS branding. Mirroring constants/brand.ts, when
    * neither a domain nor a configured product name is available the title

--- a/src/shared/constants/brand.ts
+++ b/src/shared/constants/brand.ts
@@ -10,7 +10,7 @@
 //   3. NEUTRAL_BRAND_DEFAULTS  - Generic neutral theme when bootstrap is absent
 //
 // Philosophy: step 3 must NEVER show OTS branding. If bootstrap fails to
-// provide brand data, the UI degrades to a neutral "My App" blue, not
+// provide brand data, the UI degrades to a neutral "Secure Links" blue, not
 // accidentally advertising OTS. This supports private-label deployments.
 //
 // See identityStore.ts for the implementation of this fallback chain.
@@ -41,7 +41,7 @@ export const DEFAULT_CORNER_CLASS = 'rounded-lg';
  * brand values.
  *
  * - `primary_color: '#3B82F6'` — generic blue, avoids OTS orange
- * - `product_name: 'My App'` — neutral placeholder for customization
+ * - `product_name: 'Secure Links'` — neutral placeholder for customization
  *
  * Values for enum-typed fields are derived from the schema enums to
  * prevent drift between constants and schema definitions.
@@ -50,7 +50,7 @@ export const DEFAULT_CORNER_CLASS = 'rounded-lg';
  */
 export const NEUTRAL_BRAND_DEFAULTS = {
   primary_color: '#3B82F6',
-  product_name: 'My App',
+  product_name: 'Secure Links',
   button_text_light: DEFAULT_BUTTON_TEXT_LIGHT,
   corner_style: CornerStyle.ROUNDED,
   font_family: FontFamily.SANS,
@@ -63,7 +63,7 @@ export type NeutralBrandDefaults = typeof NEUTRAL_BRAND_DEFAULTS;
  *
  * Applies step 2 → step 3 of the fallback chain for the product name:
  * the per-installation `brand_product_name` (from OT.conf) when set, otherwise
- * the neutral `NEUTRAL_BRAND_DEFAULTS.product_name` ('My App'). Per the
+ * the neutral `NEUTRAL_BRAND_DEFAULTS.product_name` ('Secure Links'). Per the
  * philosophy above it MUST NEVER emit OTS branding — an unbranded install
  * degrades to the neutral default, never a hardcoded "Onetime Secret".
  *

--- a/src/tests/shared/components/layout/MastHead.spec.ts
+++ b/src/tests/shared/components/layout/MastHead.spec.ts
@@ -1024,7 +1024,7 @@ describe('MastHead', () => {
       expect(img.exists()).toBe(true);
       // Consolidation routes the alt text through identityStore.productName,
       // which uses `||` (not `??`): a blank product-name config degrades to the
-      // neutral 'My App' instead of rendering an empty alt — matching
+      // neutral 'Secure Links' instead of rendering an empty alt — matching
       // DefaultLogo and usePageTitle.
       expect(img.attributes('alt')).toBe(NEUTRAL_BRAND_DEFAULTS.product_name);
     });

--- a/src/tests/shared/components/logos/DefaultLogo.spec.ts
+++ b/src/tests/shared/components/logos/DefaultLogo.spec.ts
@@ -243,8 +243,8 @@ describe('DefaultLogo', () => {
     it('falls back to neutral brand aria-label when no prop', () => {
       wrapper = mountComponent({});
 
-      // Falls back to NEUTRAL_BRAND_DEFAULTS.product_name ("My App")
-      const container = wrapper.find('[aria-label="My App"]');
+      // Falls back to NEUTRAL_BRAND_DEFAULTS.product_name ("Secure Links")
+      const container = wrapper.find('[aria-label="Secure Links"]');
       expect(container.exists()).toBe(true);
     });
 

--- a/src/tests/shared/composables/usePageTitle.spec.ts
+++ b/src/tests/shared/composables/usePageTitle.spec.ts
@@ -3,7 +3,7 @@
 // A4 fix: the page-title composable must never leak OTS branding into the
 // document <title>, og:title or twitter:title. When no display domain is
 // available it falls back to the configured brand product name, and finally to
-// the neutral default ('My App') — never the hardcoded "Onetime Secret".
+// the neutral default ('Secure Links') — never the hardcoded "Onetime Secret".
 //
 // The product-name fallback goes through the shared resolveProductName helper
 // (the same one identityStore.productName uses) rather than the store itself,
@@ -80,7 +80,7 @@ describe('usePageTitle — brand fallback (A4 branding leak)', () => {
 
       const title = formatTitle('Dashboard');
       expect(title).toBe(`Dashboard - ${NEUTRAL_BRAND_DEFAULTS.product_name}`);
-      expect(title).toContain('My App');
+      expect(title).toContain('Secure Links');
       // The core A4 guarantee: never emit OTS branding.
       expect(title).not.toContain('Onetime Secret');
     });

--- a/src/tests/stores/identityStore.spec.ts
+++ b/src/tests/stores/identityStore.spec.ts
@@ -335,7 +335,7 @@ describe('identityStore primaryColor resolution', () => {
 //
 // The store is the single source of truth for the product-name fallback that
 // MastHead and DefaultLogo previously re-derived by hand. It must degrade to
-// the neutral default ('My App'), never a hardcoded "Onetime Secret", and must
+// the neutral default ('Secure Links'), never a hardcoded "Onetime Secret", and must
 // treat an empty string as unset (|| not ??).
 // ═══════════════════════════════════════════════════════════════════════════
 
@@ -378,7 +378,7 @@ describe('identityStore productName resolution', () => {
 
     const identity = useProductIdentity();
 
-    // `||` (not `??`) — a blank product-name config degrades to 'My App'
+    // `||` (not `??`) — a blank product-name config degrades to 'Secure Links'
     // rather than rendering an empty name.
     expect(identity.productName).toBe(NEUTRAL_BRAND_DEFAULTS.product_name);
   });

--- a/try/unit/models/custom_domain/brand_global_defaults_try.rb
+++ b/try/unit/models/custom_domain/brand_global_defaults_try.rb
@@ -7,7 +7,7 @@
 #
 # Critical assertions:
 #   - GLOBAL_DEFAULTS[:support_email] is neutral or nil (NOT 'support@onetimesecret.com')
-#   - GLOBAL_DEFAULTS[:product_name] is nil (the #3049 stamp picked 'My App' as the
+#   - GLOBAL_DEFAULTS[:product_name] is nil (the #3049 stamp picked 'Secure Links' as the
 #     neutral product name, not 'OTS' — each consumer owns its own neutral fallback)
 #
 # These tests are the regression guard against #dc4a22-style OTS-branding
@@ -45,7 +45,7 @@ support.nil? || support != 'support@onetimesecret.com'
 @constants::GLOBAL_DEFAULTS[:support_email] != 'support@onetimesecret.com'
 #=> true
 
-## [forward] GLOBAL_DEFAULTS[:product_name] is nil (frontend 'My App' / legacy site_name own the default)
+## [forward] GLOBAL_DEFAULTS[:product_name] is nil (frontend 'Secure Links' / legacy site_name own the default)
 @constants::GLOBAL_DEFAULTS[:product_name]
 #=> nil
 

--- a/try/web/core/logic/page/get_webmanifest_try.rb
+++ b/try/web/core/logic/page/get_webmanifest_try.rb
@@ -10,7 +10,7 @@
 # a self-hosted install never ships OTS branding in its manifest.
 #
 # Behaviours covered:
-# 1. Neutral default name ("My App") + neutral theme colour when brand absent.
+# 1. Neutral default name ("Secure Links") + neutral theme colour when brand absent.
 # 2. brand.product_name overrides name and short_name.
 # 3. brand.primary_color overrides theme_color.
 # 4. content_type is application/manifest+json.
@@ -42,12 +42,12 @@ def build_logic
   logic
 end
 
-## Neutral default: name is the bundled "My App", theme is neutral blue, correct content-type
+## Neutral default: name is the bundled "Secure Links", theme is neutral blue, correct content-type
 OT.conf['brand'] = {}
 logic = build_logic
 m = JSON.parse(logic.manifest_json)
 [m['name'], m['theme_color'], logic.content_type]
-#=> ['My App', '#3B82F6', 'application/manifest+json']
+#=> ['Secure Links', '#3B82F6', 'application/manifest+json']
 
 ## brand.product_name overrides name and short_name
 OT.conf['brand'] = { 'product_name' => 'Acme Vault' }
@@ -64,7 +64,7 @@ JSON.parse(build_logic.manifest_json)['theme_color']
 OT.conf['brand'] = { 'product_name' => '', 'primary_color' => '  ' }
 m = JSON.parse(build_logic.manifest_json)
 [m['name'], m['theme_color']]
-#=> ['My App', '#3B82F6']
+#=> ['Secure Links', '#3B82F6']
 
 ## [regression guard] neutral default manifest name is never OTS-branded
 OT.conf['brand'] = {}


### PR DESCRIPTION
## Summary

Renames the **neutral default product name** — shown on unbranded / private-label installs when neither per-domain branding nor `BRAND_PRODUCT_NAME` is configured — from the placeholder `My App` to `Secure Links`.

`My App` was a cross-stack sentinel, so this changes it consistently everywhere so the in-app name and the installed PWA name agree:

- **Frontend** — `NEUTRAL_BRAND_DEFAULTS.product_name` (`src/shared/constants/brand.ts`)
- **Backend / PWA manifest** — `NEUTRAL_FALLBACK` (`apps/web/core/logic/page/get_webmanifest.rb`), the shipped `public/web/site.webmanifest`, and its generator (`scripts/branding/mark.mjs`, the `MARK_PRODUCT_NAME` default)
- **Tests** — `DefaultLogo`, `usePageTitle`, `identityStore`, and `MastHead` specs; `scripts/branding/mark.test.mjs`; and the `get_webmanifest` / `brand_global_defaults` Ruby tryout expectations
- **Docs / comments** — `docs/architecture/branding.md` and inline comments in `brand.ts`, `DefaultLogo.vue`, `usePageTitle.ts`, `brand_settings.rb`

Installs that configure `BRAND_PRODUCT_NAME` or per-domain branding are unaffected. The two sample brand fixtures (`brand-roundtrip.spec.ts`, `domainBranding.fixture.ts`) keep `My App` as arbitrary configured-brand data — it's not the neutral default there — so they're intentionally left unchanged.

### Rebased onto current `main`

This branched before #3568 (resolver consolidation) and #3570 (reusable favicon generator) merged. It's now rebased onto `main` (`ede3a32`), which surfaced two conflicts, both resolved by keeping `main`'s structure and applying only the rename:

- **`scripts/branding/mark.mjs`** — #3570 lifted the hardcoded manifest name into an env-overridable `PRODUCT_NAME` / `SHORT_NAME` constant. Kept that refactor and set the `PRODUCT_NAME` default to `Secure Links` (updated `mark.test.mjs` to match; the favicon drift check stays in sync).
- **`src/shared/components/logos/DefaultLogo.vue`** — #3568 rewrote the aria-label to resolve via `resolveProductName`. Kept that logic; renamed only the `My App` reference in its doc comment.

The rebase also absorbed the `My App` references #3568 introduced on `main` (the `usePageTitle.spec.ts` `toContain` assertion and several comments), so the earlier "coupling note" is now handled directly here — nothing is left outstanding on a separate branch.

## Related Issues

Follow-up to the neutral-default branding work (#3048 / #3049). No auto-close.

## Test Plan

- `npx vitest run` on `usePageTitle.spec.ts`, `DefaultLogo.spec.ts`, `identityStore.spec.ts`, `MastHead.spec.ts` → **106 passed**.
- `node --test scripts/branding/mark.test.mjs` → **13 passed**.
- `node scripts/branding/check.mjs` (favicon drift) → **in sync** (committed `site.webmanifest` matches the generator's `Secure Links` default).
- `npx eslint` on changed frontend files → **0 errors** (pre-existing warnings only).
- `ruby -c` on all changed Ruby files → **Syntax OK**. The `get_webmanifest` / `brand_global_defaults` tryouts assert `Secure Links` and run in CI (the `tryouts` gem isn't installed locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MvR9x1zU2TBnmgQV43bD2p