### PR TITLE
i18n: update ca_ES translations

### DIFF
--- a/locales/content/ca_ES/00-common.json
+++ b/locales/content/ca_ES/00-common.json
@@ -1299,7 +1299,7 @@
     "source_hash": "fc78d9cb"
   },
   "web.INSTRUCTION.phishing_warning": {
-    "text": "Verifica sempre que estàs al lloc web oficial d'{product_name}. Els estafadors de vegades creen llocs web falsos que semblen exactament {product_name} per robar els teus secrets. Per evitar atacs de phishing, comprova el domini de la regió abans de crear nous enllaços.",
+    "text": "Verifica sempre que estàs al lloc web oficial de {product_name}. De vegades, els estafadors creen llocs web falsos que semblen exactament {product_name} per robar-te els secrets. Per evitar atacs de pesca de credencials, comprova el domini de la regió abans de crear nous enllaços.",
     "source_hash": "b588f5b2"
   },
   "web.pricing.title": {
@@ -1383,5 +1383,110 @@
     "text": "Actualitza per desbloquejar més funcions",
     "context": "Description shown for free plan users encouraging upgrade",
     "source_hash": "783f174c"
+  },
+  "api.errors.authentication_required": {
+    "text": "Cal autenticació"
+  },
+  "api.errors.sso_only_action_blocked": {
+    "text": "Aquesta acció no està disponible en mode només SSO"
+  },
+  "web.COMMON.configure": {
+    "text": "Configura"
+  },
+  "web.COMMON.copy_to_clipboard": {
+    "text": "Copia al porta-retalls"
+  },
+  "web.COMMON.add": {
+    "text": "Afegeix"
+  },
+  "web.COMMON.enabled": {
+    "text": "Activat"
+  },
+  "web.COMMON.disabled": {
+    "text": "Desactivat"
+  },
+  "web.COMMON.yes_delete": {
+    "text": "Sí, elimina"
+  },
+  "web.COMMON.error_code": {
+    "text": "Codi d'error"
+  },
+  "web.COMMON.http_status": {
+    "text": "Estat HTTP"
+  },
+  "web.COMMON.details": {
+    "text": "Detalls"
+  },
+  "web.COMMON.field_confirm_password": {
+    "text": "Confirma la contrasenya"
+  },
+  "web.COMMON.passwords_must_match": {
+    "text": "Les contrasenyes han de coincidir"
+  },
+  "web.COMMON.and": {
+    "text": "i"
+  },
+  "web.COMMON.or": {
+    "text": "o"
+  },
+  "web.COMMON.copied": {
+    "text": "Copiat"
+  },
+  "web.COMMON.copy": {
+    "text": "Copia"
+  },
+  "web.COMMON.copy_email": {
+    "text": "Copia l'adreça de correu electrònic"
+  },
+  "web.COMMON.copy_id": {
+    "text": "Copia l'identificador del compte"
+  },
+  "web.COMMON.org_id_tooltip": {
+    "text": "L'identificador únic de la teva organització"
+  },
+  "web.COMMON.success": {
+    "text": "Èxit"
+  },
+  "web.COMMON.need_help": {
+    "text": "Necessites ajuda"
+  },
+  "web.COMMON.open_help_dialog": {
+    "text": "Obre el diàleg d'ajuda"
+  },
+  "web.COMMON.focus_is_now_in_the_main_text_area": {
+    "text": "El focus ara és a l'àrea de text principal"
+  },
+  "web.LABELS.show_passphrase": {
+    "text": "Mostra la frase de contrasenya"
+  },
+  "web.LABELS.hide_passphrase": {
+    "text": "Amaga la frase de contrasenya"
+  },
+  "web.LABELS.copy_icon": {
+    "text": "Icona de copiar"
+  },
+  "web.LABELS.copied_icon": {
+    "text": "Icona de copiat"
+  },
+  "web.STATUS.unverified": {
+    "text": "No verificat"
+  },
+  "web.TITLES.domain_detail": {
+    "text": "Configuració del domini"
+  },
+  "web.TITLES.domain_signin": {
+    "text": "Configuració de l'inici de sessió"
+  },
+  "web.TITLES.domain_sso": {
+    "text": "SSO del domini"
+  },
+  "web.TITLES.domain_signup": {
+    "text": "Validació del registre del domini"
+  },
+  "web.TITLES.domain_email": {
+    "text": "Configuració del correu electrònic"
+  },
+  "web.TITLES.domain_incoming": {
+    "text": "Secrets entrants"
   }
 }

--- a/locales/content/ca_ES/10-layout.json
+++ b/locales/content/ca_ES/10-layout.json
@@ -148,7 +148,7 @@
     "source_hash": "b9766df3"
   },
   "web.help.secret_view_faq.what_am_i_looking_at.description": {
-    "text": "Estàs veient un missatge segur que s'ha compartit amb tu a través d'{product_name}. Aquest contingut es mostra només una vegada i després s'elimina permanentment dels nostres servidors.",
+    "text": "Estàs veient un missatge segur que t'han compartit a través de {product_name}. Aquest contingut es mostra només una vegada i després s'elimina permanentment dels nostres servidors.",
     "source_hash": "e0f1a10c"
   },
   "web.help.secret_view_faq.can_i_view_again.title": {
@@ -264,7 +264,7 @@
     "source_hash": "e2f124cd"
   },
   "web.layout.visit_onetime_secret_homepage": {
-    "text": "Visitar la pàgina d'inici d'{product_name}",
+    "text": "Visita la pàgina d'inici de {product_name}",
     "source_hash": "625556d2"
   },
   "web.layout.footer_navigation": {
@@ -338,5 +338,11 @@
   "web.layout.workspace_context": {
     "text": "Context de l'espai de treball",
     "source_hash": "dc6fa4f5"
+  },
+  "web.footer.workspace": {
+    "text": "Espai de treball"
+  },
+  "web.help.default_content": {
+    "text": "Contacta amb el servei d'assistència per obtenir ajuda"
   }
 }

--- a/locales/content/ca_ES/admin-colonel.json
+++ b/locales/content/ca_ES/admin-colonel.json
@@ -634,5 +634,152 @@
   "web.colonel.feedback.when_you_submit_feedback_well_see": {
     "text": "Quan enviïs comentaris, veurem:",
     "source_hash": "fe77172e"
+  },
+  "web.colonel.previewPlanMode": {
+    "text": "Mode de previsualització del pla"
+  },
+  "web.colonel.previewModeDescription": {
+    "text": "Previsualitza l'aplicació tal com la veuen els clients amb un pla diferent. Això només afecta la teva vista i no canvia el pla real de cap organització."
+  },
+  "web.colonel.previewModeActive": {
+    "text": "Previsualització activa"
+  },
+  "web.colonel.bannedIps.empty": {
+    "text": "No hi ha cap IP bloquejada"
+  },
+  "web.colonel.bannedIps.currentIp": {
+    "text": "La teva adreça IP actual"
+  },
+  "web.colonel.bannedIps.confirmUnban": {
+    "text": "Vols desbloquejar {ip}?"
+  },
+  "web.colonel.bannedIps.actions.ban": {
+    "text": "Bloqueja la IP"
+  },
+  "web.colonel.bannedIps.actions.quickBan": {
+    "text": "Bloqueig ràpid"
+  },
+  "web.colonel.bannedIps.actions.unban": {
+    "text": "Desbloqueja"
+  },
+  "web.colonel.bannedIps.actions.cancel": {
+    "text": "Cancel·la"
+  },
+  "web.colonel.bannedIps.columns.ipAddress": {
+    "text": "Adreça IP"
+  },
+  "web.colonel.bannedIps.columns.reason": {
+    "text": "Motiu"
+  },
+  "web.colonel.bannedIps.columns.bannedAt": {
+    "text": "Bloquejada el"
+  },
+  "web.colonel.bannedIps.columns.bannedBy": {
+    "text": "Bloquejada per"
+  },
+  "web.colonel.bannedIps.error.banFailed": {
+    "text": "No s'ha pogut bloquejar l'adreça IP"
+  },
+  "web.colonel.bannedIps.error.unbanFailed": {
+    "text": "No s'ha pogut desbloquejar l'adreça IP"
+  },
+  "web.colonel.bannedIps.form.title": {
+    "text": "Bloqueja l'adreça IP"
+  },
+  "web.colonel.bannedIps.form.ipLabel": {
+    "text": "Adreça IP"
+  },
+  "web.colonel.bannedIps.form.reasonLabel": {
+    "text": "Motiu"
+  },
+  "web.colonel.bannedIps.form.reasonPlaceholder": {
+    "text": "Motiu opcional"
+  },
+  "web.colonel.bannedIps.success.banned": {
+    "text": "L'adreça IP {ip} s'ha bloquejat"
+  },
+  "web.colonel.bannedIps.success.unbanned": {
+    "text": "L'adreça IP {ip} s'ha desbloquejat"
+  },
+  "web.colonel.customDomains.empty": {
+    "text": "No hi ha cap domini personalitzat configurat"
+  },
+  "web.colonel.customDomains.noLogo": {
+    "text": "Sense logotip"
+  },
+  "web.colonel.customDomains.labels.organization": {
+    "text": "Organització"
+  },
+  "web.colonel.customDomains.labels.externalId": {
+    "text": "ID extern"
+  },
+  "web.colonel.customDomains.labels.created": {
+    "text": "Creat"
+  },
+  "web.colonel.customDomains.labels.updated": {
+    "text": "Actualitzat"
+  },
+  "web.colonel.customDomains.labels.favicon": {
+    "text": "Favicon"
+  },
+  "web.colonel.customDomains.status.verified": {
+    "text": "Verificat"
+  },
+  "web.colonel.customDomains.status.resolving": {
+    "text": "Resolent"
+  },
+  "web.colonel.customDomains.status.ready": {
+    "text": "A punt"
+  },
+  "web.colonel.customDomains.status.publicHomepage": {
+    "text": "Pàgina d'inici pública"
+  },
+  "web.colonel.customDomains.status.publicApi": {
+    "text": "API pública"
+  },
+  "web.colonel.customDomains.status.pending": {
+    "text": "Pendent"
+  },
+  "web.colonel.pagination.showing": {
+    "text": "Es mostren {start}–{end} de {total}"
+  },
+  "web.colonel.pagination.itemsPerPage": {
+    "text": "Elements per pàgina"
+  },
+  "web.colonel.pagination.perPage": {
+    "text": "{count} per pàgina"
+  },
+  "web.colonel.pagination.pageOf": {
+    "text": "Pàgina {current} de {total}"
+  },
+  "web.colonel.secrets.empty": {
+    "text": "No s'ha trobat cap secret"
+  },
+  "web.colonel.secrets.never": {
+    "text": "Mai"
+  },
+  "web.colonel.secrets.columns.shortId": {
+    "text": "ID curt"
+  },
+  "web.colonel.secrets.columns.state": {
+    "text": "Estat"
+  },
+  "web.colonel.secrets.columns.created": {
+    "text": "Creat"
+  },
+  "web.colonel.secrets.columns.expiration": {
+    "text": "Caducitat"
+  },
+  "web.colonel.secrets.columns.age": {
+    "text": "Antiguitat (dies)"
+  },
+  "web.colonel.secrets.state.new": {
+    "text": "Nou"
+  },
+  "web.colonel.secrets.state.received": {
+    "text": "Rebut"
+  },
+  "web.colonel.secrets.state.viewed": {
+    "text": "Vist"
   }
 }

--- a/locales/content/ca_ES/api-account-errors.json
+++ b/locales/content/ca_ES/api-account-errors.json
@@ -1,0 +1,8 @@
+{
+  "api.account.errors.invalid_email": {
+    "text": "És una adreça de correu electrònic vàlida?"
+  },
+  "api.account.errors.password_too_short": {
+    "text": "La contrasenya és massa curta"
+  }
+}

--- a/locales/content/ca_ES/api-domains-errors.json
+++ b/locales/content/ca_ES/api-domains-errors.json
@@ -1,0 +1,29 @@
+{
+  "api.domains.errors.domain_id_required": {
+    "text": "Es requereix l'ID del domini"
+  },
+  "api.domains.errors.domain_not_found": {
+    "text": "No s'ha trobat el domini: %{extid}"
+  },
+  "api.domains.errors.organization_not_found": {
+    "text": "No s'ha trobat cap organització per al domini: %{domain}"
+  },
+  "api.domains.errors.incoming_secrets_disabled": {
+    "text": "Els secrets entrants no estan habilitats en aquesta instància"
+  },
+  "api.domains.errors.incoming_secrets_entitlement_required": {
+    "text": "La gestió de secrets entrants requereix el dret incoming_secrets. Si us plau, millora el teu pla."
+  },
+  "api.domains.errors.incoming_config_not_found": {
+    "text": "No s'ha trobat la configuració de secrets entrants per al domini: %{extid}"
+  },
+  "api.domains.errors.recipients_max_exceeded": {
+    "text": "Es permeten un màxim de %{max} destinataris"
+  },
+  "api.domains.errors.recipients_invalid_email": {
+    "text": "Correu electrònic no vàlid: %{email}"
+  },
+  "api.domains.errors.recipients_duplicate": {
+    "text": "No es permeten adreces de correu electrònic de destinataris duplicades"
+  }
+}

--- a/locales/content/ca_ES/api-entitlements-errors.json
+++ b/locales/content/ca_ES/api-entitlements-errors.json
@@ -1,0 +1,71 @@
+{
+  "api.entitlements.errors.context_unavailable": {
+    "text": "No s'han pogut verificar els drets (context de l'organització no disponible)"
+  },
+  "api.entitlements.errors.api_access_required": {
+    "text": "L'accés a l'API requereix una millora del pla"
+  },
+  "api.entitlements.errors.custom_privacy_defaults_required": {
+    "text": "Els valors predeterminats de privadesa personalitzats requereixen una millora del pla"
+  },
+  "api.entitlements.errors.extended_default_expiration_required": {
+    "text": "L'expiració predeterminada ampliada requereix una millora del pla"
+  },
+  "api.entitlements.errors.custom_domains_required": {
+    "text": "Els dominis personalitzats requereixen una millora del pla"
+  },
+  "api.entitlements.errors.custom_branding_required": {
+    "text": "La marca personalitzada requereix una millora del pla"
+  },
+  "api.entitlements.errors.homepage_secrets_required": {
+    "text": "Els secrets a la pàgina d'inici requereixen una millora del pla"
+  },
+  "api.entitlements.errors.incoming_secrets_required": {
+    "text": "Els secrets entrants requereixen una millora del pla"
+  },
+  "api.entitlements.errors.custom_mail_sender_required": {
+    "text": "El remitent de correu personalitzat requereix una millora del pla"
+  },
+  "api.entitlements.errors.flexible_from_domain_required": {
+    "text": "El domini de remitent flexible requereix una millora del pla"
+  },
+  "api.entitlements.errors.manage_org_required": {
+    "text": "La gestió d'organitzacions requereix una millora del pla"
+  },
+  "api.entitlements.errors.manage_teams_required": {
+    "text": "La gestió d'equips requereix una millora del pla"
+  },
+  "api.entitlements.errors.manage_members_required": {
+    "text": "La gestió de membres requereix una millora del pla"
+  },
+  "api.entitlements.errors.manage_sso_required": {
+    "text": "La gestió de l'SSO requereix una millora del pla"
+  },
+  "api.entitlements.errors.audit_logs_required": {
+    "text": "Els registres d'auditoria requereixen una millora del pla"
+  },
+  "api.entitlements.errors.custom_signup_validation_required": {
+    "text": "La validació de registre personalitzada requereix una millora del pla"
+  },
+  "api.entitlements.errors.create_secrets_required": {
+    "text": "Crear secrets requereix una millora del pla"
+  },
+  "api.entitlements.errors.view_receipt_required": {
+    "text": "Veure rebuts requereix una millora del pla"
+  },
+  "api.entitlements.errors.notifications_required": {
+    "text": "Les notificacions requereixen una millora del pla"
+  },
+  "api.entitlements.errors.workspace_branding_required": {
+    "text": "La marca de l'espai de treball requereix una millora del pla"
+  },
+  "api.entitlements.errors.ip_access_rules_required": {
+    "text": "Les regles d'accés per IP requereixen una millora del pla"
+  },
+  "api.entitlements.errors.manage_billing_required": {
+    "text": "La gestió de la facturació requereix una millora del pla"
+  },
+  "api.entitlements.errors.custom_signin_config_required": {
+    "text": "La configuració d'inici de sessió personalitzada requereix una millora del pla"
+  }
+}

--- a/locales/content/ca_ES/api-feedback-errors.json
+++ b/locales/content/ca_ES/api-feedback-errors.json
@@ -1,0 +1,5 @@
+{
+  "api.feedback.errors.rate_limit_exceeded": {
+    "text": "Hi ha hagut massa enviaments de comentaris. Si us plau, torna-ho a provar més tard."
+  }
+}

--- a/locales/content/ca_ES/api-incoming-errors.json
+++ b/locales/content/ca_ES/api-incoming-errors.json
@@ -1,0 +1,5 @@
+{
+  "api.incoming.errors.custom_domain_unresolved": {
+    "text": "No s'ha pogut resoldre l'organització del domini personalitzat"
+  }
+}

--- a/locales/content/ca_ES/api-invite-errors.json
+++ b/locales/content/ca_ES/api-invite-errors.json
@@ -1,0 +1,23 @@
+{
+  "api.invite.errors.invitation_not_found_or_expired": {
+    "text": "No s'ha trobat la invitació o ha caducat"
+  },
+  "api.invite.errors.token_required": {
+    "text": "Es requereix el testimoni"
+  },
+  "api.invite.errors.organization_no_longer_exists": {
+    "text": "L'organització ja no existeix"
+  },
+  "api.invite.errors.invitation_already_processed": {
+    "text": "La invitació ja consta com a %{status}"
+  },
+  "api.invite.errors.invitation_expired": {
+    "text": "La invitació ha caducat"
+  },
+  "api.invite.errors.email_mismatch": {
+    "text": "La teva adreça de correu electrònic no coincideix amb la invitació"
+  },
+  "api.invite.errors.already_member": {
+    "text": "Ja ets membre d'aquesta organització"
+  }
+}

--- a/locales/content/ca_ES/api-organizations-errors.json
+++ b/locales/content/ca_ES/api-organizations-errors.json
@@ -1,0 +1,107 @@
+{
+  "api.organizations.errors.domain_scoped_forbidden": {
+    "text": "Els membres limitats al domini no poden dur a terme aquesta acció"
+  },
+  "api.organizations.errors.organization_not_found": {
+    "text": "No s'ha trobat l'organització: %{extid}"
+  },
+  "api.organizations.errors.organization_owner_required": {
+    "text": "Només el propietari de l'organització pot dur a terme aquesta acció"
+  },
+  "api.organizations.errors.organization_member_required": {
+    "text": "Has de ser membre de l'organització per dur a terme aquesta acció"
+  },
+  "api.organizations.errors.organization_admin_required": {
+    "text": "Només els propietaris i administradors de l'organització poden dur a terme aquesta acció"
+  },
+  "api.organizations.errors.extid_required": {
+    "text": "Es requereix l'ID de l'organització"
+  },
+  "api.organizations.errors.display_name_required": {
+    "text": "El nom de l'organització és obligatori"
+  },
+  "api.organizations.errors.display_name_too_long": {
+    "text": "El nom de l'organització ha de tenir menys de %{max} caràcters"
+  },
+  "api.organizations.errors.description_too_long": {
+    "text": "La descripció ha de tenir menys de %{max} caràcters"
+  },
+  "api.organizations.errors.contact_email_exists": {
+    "text": "Ja existeix una organització amb aquest correu electrònic de contacte"
+  },
+  "api.organizations.errors.creation_in_progress": {
+    "text": "Creació de l'organització en curs. Si us plau, torna-ho a provar."
+  },
+  "api.organizations.errors.organization_limit_reached": {
+    "text": "S'ha assolit el límit d'organitzacions. Millora el teu pla per crear-ne més."
+  },
+  "api.organizations.invitations.errors.invitation_not_found": {
+    "text": "No s'ha trobat la invitació"
+  },
+  "api.organizations.invitations.errors.email_required": {
+    "text": "Es requereix el correu electrònic"
+  },
+  "api.organizations.invitations.errors.invalid_email_format": {
+    "text": "Format de correu electrònic no vàlid"
+  },
+  "api.organizations.invitations.errors.invalid_role": {
+    "text": "El rol ha de ser membre o administrador"
+  },
+  "api.organizations.invitations.errors.cannot_invite_as_owner": {
+    "text": "No es pot convidar com a propietari"
+  },
+  "api.organizations.invitations.errors.user_already_member": {
+    "text": "L'usuari ja és membre d'aquesta organització"
+  },
+  "api.organizations.invitations.errors.invitation_already_pending": {
+    "text": "Ja hi ha una invitació pendent per a aquest correu electrònic"
+  },
+  "api.organizations.invitations.errors.member_limit_reached": {
+    "text": "S'ha assolit el límit de membres. Millora el teu pla per convidar-ne més."
+  },
+  "api.organizations.invitations.errors.resend_only_pending": {
+    "text": "Només es poden reenviar les invitacions pendents"
+  },
+  "api.organizations.invitations.errors.resend_limit_reached": {
+    "text": "S'ha assolit el límit màxim de reenviaments (%{max})"
+  },
+  "api.organizations.invitations.errors.revoke_only_pending": {
+    "text": "Només es poden revocar les invitacions pendents"
+  },
+  "api.organizations.members.errors.member_not_found": {
+    "text": "No s'ha trobat el membre: %{extid}"
+  },
+  "api.organizations.members.errors.member_not_in_organization": {
+    "text": "No s'ha trobat el membre en aquesta organització"
+  },
+  "api.organizations.members.errors.member_not_active": {
+    "text": "El membre no està actiu"
+  },
+  "api.organizations.members.errors.invalid_role_value": {
+    "text": "Rol no vàlid. Ha de ser un dels següents: %{roles}"
+  },
+  "api.organizations.members.errors.cannot_change_owner_role": {
+    "text": "No es pot canviar el rol del propietari. Fes servir la transferència de propietat."
+  },
+  "api.organizations.members.errors.member_already_has_role": {
+    "text": "El membre ja té el rol: %{role}"
+  },
+  "api.organizations.members.errors.cannot_promote_to_owner": {
+    "text": "No es pot promoure a propietari. Fes servir la transferència de propietat."
+  },
+  "api.organizations.members.errors.must_be_member": {
+    "text": "Has de ser membre d'aquesta organització"
+  },
+  "api.organizations.members.errors.cannot_remove_owner": {
+    "text": "No es pot eliminar el propietari de l'organització. Primer transfereix la propietat."
+  },
+  "api.organizations.members.errors.cannot_remove_self": {
+    "text": "No et pots eliminar a tu mateix. Fes servir abandonar l'organització."
+  },
+  "api.organizations.members.errors.admin_cannot_remove_admin": {
+    "text": "Els administradors no poden eliminar altres administradors. Només els propietaris poden fer-ho."
+  },
+  "api.organizations.members.errors.no_permission_to_remove": {
+    "text": "No tens permís per eliminar membres"
+  }
+}

--- a/locales/content/ca_ES/api-secrets-errors.json
+++ b/locales/content/ca_ES/api-secrets-errors.json
@@ -1,0 +1,11 @@
+{
+  "api.secrets.errors.domain_permission_authenticated_non_owner": {
+    "text": "No tens permís per fer servir el domini: %{domain}"
+  },
+  "api.secrets.errors.domain_public_sharing_disabled": {
+    "text": "S'ha desactivat la compartició pública per al domini: %{domain}"
+  },
+  "api.secrets.errors.domain_permission_anonymous_cross_domain": {
+    "text": "No tens permís per fer servir el domini: %{domain}"
+  }
+}

--- a/locales/content/ca_ES/email.json
+++ b/locales/content/ca_ES/email.json
@@ -60,7 +60,7 @@
     "source_hash": "88c72144"
   },
   "email.welcome.signature": {
-    "text": "Delano",
+    "text": "Equip de suport",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -100,7 +100,7 @@
     "source_hash": "fbb7eb2d"
   },
   "email.password_request.signature": {
-    "text": "Delano",
+    "text": "Equip de suport",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -145,7 +145,7 @@
     "source_hash": "1863f5be"
   },
   "email.magic_link.signature": {
-    "text": "Delano",
+    "text": "Equip de suport",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -230,7 +230,7 @@
     "source_hash": "3f6b45dd"
   },
   "email.secret_revealed.signature": {
-    "text": "Delano",
+    "text": "Equip de suport",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -355,7 +355,7 @@
     "source_hash": "734882d2"
   },
   "email.organization_invitation.signature": {
-    "text": "Delano",
+    "text": "Equip de suport",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -395,7 +395,7 @@
     "source_hash": "be92cff3"
   },
   "email.password_changed.signature": {
-    "text": "Delano",
+    "text": "Equip de suport",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -445,7 +445,7 @@
     "source_hash": "f8d47b82"
   },
   "email.email_changed.signature": {
-    "text": "Delano",
+    "text": "Equip de suport",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -495,7 +495,7 @@
     "source_hash": "f8d47b82"
   },
   "email.email_change_requested.signature": {
-    "text": "Delano",
+    "text": "Equip de suport",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -550,7 +550,7 @@
     "source_hash": "d4d835fc"
   },
   "email.email_change_confirmation.signature": {
-    "text": "Delano",
+    "text": "Equip de suport",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -580,7 +580,7 @@
     "source_hash": "e7c11bb0"
   },
   "email.mfa_enabled.signature": {
-    "text": "Delano",
+    "text": "Equip de suport",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -605,7 +605,7 @@
     "source_hash": "97ef0a3e"
   },
   "email.mfa_disabled.signature": {
-    "text": "Delano",
+    "text": "Equip de suport",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -650,7 +650,7 @@
     "source_hash": "450c54c5"
   },
   "email.new_login_alert.signature": {
-    "text": "Delano",
+    "text": "Equip de suport",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -670,7 +670,7 @@
     "source_hash": "d442beed"
   },
   "email.member_removed.signature": {
-    "text": "Delano",
+    "text": "Equip de suport",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -690,7 +690,7 @@
     "source_hash": "c2280c0c"
   },
   "email.role_changed.signature": {
-    "text": "Delano",
+    "text": "Equip de suport",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -710,7 +710,7 @@
     "source_hash": "7095fc69"
   },
   "email.organization_deleted.signature": {
-    "text": "Delano",
+    "text": "Equip de suport",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -750,7 +750,7 @@
     "source_hash": "36008943"
   },
   "email.payment_receipt.signature": {
-    "text": "Delano",
+    "text": "Equip de suport",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -775,7 +775,7 @@
     "source_hash": "926406b1"
   },
   "email.payment_failed.signature": {
-    "text": "Delano",
+    "text": "Equip de suport",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -800,7 +800,7 @@
     "source_hash": "66a1419e"
   },
   "email.trial_expiring.signature": {
-    "text": "Delano",
+    "text": "Equip de suport",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -825,7 +825,7 @@
     "source_hash": "5a96ae38"
   },
   "email.subscription_changed.signature": {
-    "text": "Delano",
+    "text": "Equip de suport",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -853,5 +853,41 @@
     "text": "Onetime Secret",
     "renderer": "erb",
     "source_hash": "1cd0194a"
+  },
+  "email.common.secret_link_label": {
+    "text": "Enllaç secret"
+  },
+  "email.common.automated_notice": {
+    "text": "Aquest és un missatge automatitzat de %{product_name}."
+  },
+  "email.common.support_label": {
+    "text": "Suport"
+  },
+  "email.expiration_warning.signature": {
+    "text": "Equip de suport"
+  },
+  "email.expiration_warning.footer_note": {
+    "text": "Has rebut això perquè un secret que has creat a %{product_name} està a punt de caducar."
+  },
+  "email.feedback_email.user_id_label": {
+    "text": "Usuari:"
+  },
+  "email.feedback_email.timezone_label": {
+    "text": "Zona horària:"
+  },
+  "email.feedback_email.version_label": {
+    "text": "Versió:"
+  },
+  "email.incoming_secret.footer_note": {
+    "text": "Has rebut això perquè algú ha utilitzat %{product_name} per enviar-te un secret. Si no l'esperaves, pots ignorar aquest correu electrònic amb tota tranquil·litat."
+  },
+  "email.secret_link.passphrase_label": {
+    "text": "Cal una frase de contrasenya:"
+  },
+  "email.secret_link.passphrase_required": {
+    "text": "Aquest secret està protegit amb una frase de contrasenya. El remitent te l'hauria de proporcionar per separat."
+  },
+  "email.secret_link.footer_note": {
+    "text": "Has rebut això perquè %{sender_email} ha utilitzat %{product_name} per compartir un secret amb tu. Si no l'esperaves, pots ignorar aquest correu electrònic amb tota tranquil·litat."
   }
 }

--- a/locales/content/ca_ES/feature-feedback.json
+++ b/locales/content/ca_ES/feature-feedback.json
@@ -58,5 +58,14 @@
   "web.feedback.reason_email_change_unauthorized": {
     "text": "Sembla que estàs informant d'un canvi de correu electrònic no autoritzat al teu compte. Si us plau, descriu què ha passat i ho investigarem de seguida.",
     "source_hash": "00e56551"
+  },
+  "web.feedback.anonymous_no_reply": {
+    "text": "Nota: si vols rebre una resposta, signa o inclou una adreça de correu electrònic al missatge."
+  },
+  "web.feedback.characters_remaining": {
+    "text": "{count} caràcters restants"
+  },
+  "web.feedback.character_limit_reached": {
+    "text": "S'ha assolit el límit de caràcters"
   }
 }

--- a/locales/content/ca_ES/feature-homepage-secrets.json
+++ b/locales/content/ca_ES/feature-homepage-secrets.json
@@ -1,0 +1,50 @@
+{
+  "homepage_secrets.disabled.members_only_eyebrow": {
+    "text": "Instància només per a membres"
+  },
+  "homepage_secrets.disabled.private_instance_eyebrow": {
+    "text": "Instància privada"
+  },
+  "homepage_secrets.disabled.team_link_headline": {
+    "text": "Aquest enllaç és per a l'equip de {workspace}."
+  },
+  "homepage_secrets.disabled.signin_headline": {
+    "text": "Inicia la sessió per crear un {action}."
+  },
+  "homepage_secrets.disabled.signin_headline_action": {
+    "text": "enllaç secret"
+  },
+  "homepage_secrets.disabled.team_subtitle": {
+    "text": "Només els companys d'equip autoritzats a {domain} poden generar aquí nous enllaços d'un sol ús. Els destinataris encara poden obrir qualsevol enllaç que se'ls hagi enviat."
+  },
+  "homepage_secrets.disabled.public_subtitle": {
+    "text": "Només els membres autoritzats d'aquesta instància poden generar nous enllaços d'un sol ús. Els destinataris encara poden obrir qualsevol enllaç que se'ls hagi enviat."
+  },
+  "homepage_secrets.disabled.signin_cta": {
+    "text": "Inicia la sessió al teu compte"
+  },
+  "homepage_secrets.disabled.what_is_this": {
+    "text": "Què és això?"
+  },
+  "homepage_secrets.disabled.trust_viewed_once": {
+    "text": "Es visualitza una vegada i després desapareix"
+  },
+  "homepage_secrets.disabled.trust_zero_retained": {
+    "text": "Zero dades retingudes"
+  },
+  "homepage_secrets.disabled.promo_title": {
+    "text": "Novetat: els plans gratuïts ara inclouen dominis personalitzats."
+  },
+  "homepage_secrets.disabled.promo_subtitle": {
+    "text": "Apunta el teu domini a Onetime Secret i envia secrets amb la teva pròpia marca."
+  },
+  "homepage_secrets.disabled.promo_learn_how": {
+    "text": "Descobreix com"
+  },
+  "homepage_secrets.disabled.logo_alt": {
+    "text": "Logotip de {name}"
+  },
+  "homepage_secrets.disabled.opens_in_new_tab": {
+    "text": "(s'obre en una pestanya nova)"
+  }
+}

--- a/locales/content/ca_ES/feature-incoming.json
+++ b/locales/content/ca_ES/feature-incoming.json
@@ -130,5 +130,26 @@
   "incoming.receipt_link_text": {
     "text": "rebut",
     "source_hash": "6f328609"
+  },
+  "incoming.upgrade_required_title": {
+    "text": "Cal millorar el pla"
+  },
+  "incoming.upgrade_required_description": {
+    "text": "Aquesta funció requereix una millora del pla. Si us plau, contacta amb el propietari del compte per habilitar els secrets entrants."
+  },
+  "incoming.validation_memo_too_long": {
+    "text": "La nota ha de tenir {max} caràcters o menys"
+  },
+  "incoming.validation_secret_required": {
+    "text": "El contingut del secret és obligatori"
+  },
+  "incoming.validation_recipient_required": {
+    "text": "Si us plau, selecciona un destinatari"
+  },
+  "incoming.validation_feature_disabled": {
+    "text": "La funció de secrets entrants no està habilitada"
+  },
+  "incoming.validation_form_errors": {
+    "text": "Si us plau, comprova si hi ha errors al formulari"
   }
 }

--- a/locales/content/ca_ES/feature-regions.json
+++ b/locales/content/ca_ES/feature-regions.json
@@ -186,5 +186,8 @@
   "web.regions.jurisdictions.apac.name": {
     "text": "Asia-Pacific",
     "source_hash": "7a757670"
+  },
+  "web.regions.no_region_configured": {
+    "text": "Actualment no hi ha informació de regió disponible per al teu compte."
   }
 }

--- a/locales/content/ca_ES/feature-translations.json
+++ b/locales/content/ca_ES/feature-translations.json
@@ -64,7 +64,7 @@
     "source_hash": "13131e36"
   },
   "web.translations.the_following_people_have_donated_their_time_to_": {
-    "text": "Les persones següents han dedicat el seu temps per ajudar a expandir l'abast d'{product_name}:",
+    "text": "Les persones següents han dedicat el seu temps a ajudar a ampliar l'abast d'{product_name}:",
     "source_hash": "85a766af"
   },
   "web.translations.translations": {
@@ -84,7 +84,7 @@
     "source_hash": "ba5c4395"
   },
   "web.translations.since_2012_onetime_secret_has_provided_a_secure_": {
-    "text": "Des de 2012, {product_name} ha proporcionat una manera segura de compartir informació sensible arreu del món. Amb usuaris a regions on l'anglès no és l'idioma principal, les traduccions precises són essencials per fer que la comunicació segura sigui accessible per a tothom.",
+    "text": "Des del 2012, {product_name} ha proporcionat una manera segura de compartir informació sensible arreu del món. Amb usuaris en regions on l'anglès no és la llengua principal, unes traduccions precises són essencials per fer que la comunicació segura sigui accessible per a tothom.",
     "source_hash": "87a6e9af"
   },
   "web.translations.help_secure_communication_go_global": {

--- a/locales/content/ca_ES/secret-homepage.json
+++ b/locales/content/ca_ES/secret-homepage.json
@@ -56,7 +56,7 @@
     "source_hash": "5e218489"
   },
   "web.homepage.visit_onetime_secret_home": {
-    "text": "Visita la pàgina d'inici d'{product_name}",
+    "text": "Visita la pàgina d'inici de {product_name}",
     "source_hash": "625556d2"
   },
   "web.homepage.password_generation_title": {
@@ -148,7 +148,7 @@
     "source_hash": "7872e050"
   },
   "web.homepage.onetime_secret_homepage": {
-    "text": "Pàgina d'inici d'{product_name}",
+    "text": "Pàgina d'inici de {product_name}",
     "source_hash": "44bb0581"
   },
   "web.homepage.send_sensitive_information_that_can_only_be_viewed_once": {

--- a/locales/content/ca_ES/secret-homepage.json
+++ b/locales/content/ca_ES/secret-homepage.json
@@ -56,7 +56,7 @@
     "source_hash": "5e218489"
   },
   "web.homepage.visit_onetime_secret_home": {
-    "text": "Visitar la pàgina d'inici d'{product_name}",
+    "text": "Visita la pàgina d'inici d'{product_name}",
     "source_hash": "625556d2"
   },
   "web.homepage.password_generation_title": {
@@ -108,15 +108,15 @@
     "source_hash": "107093e4"
   },
   "web.homepage.about_onetime_secret_0": {
-    "text": "Quant a {product_name}",
+    "text": "Sobre {product_name}",
     "source_hash": "971c50da"
   },
   "web.homepage.log_in_to_onetime_secret": {
-    "text": "Iniciar sessió a {product_name}",
+    "text": "Inicia la sessió a {product_name}",
     "source_hash": "bd6be8d6"
   },
   "web.homepage.about_onetime_secret": {
-    "text": "Quant a {product_name}",
+    "text": "Sobre {product_name}",
     "source_hash": "971c50da"
   },
   "web.homepage.signup_individual_and_business_plans": {
@@ -168,7 +168,7 @@
     "source_hash": "e1073c60"
   },
   "web.homepage.welcome_to_onetime_secret": {
-    "text": "Benvingut a {product_name}.",
+    "text": "Et donem la benvinguda a {product_name}.",
     "source_hash": "0990d163"
   },
   "web.homepage.onetime_secret_helps_us_share_sensitive_informat": {

--- a/locales/content/ca_ES/secret-manage.json
+++ b/locales/content/ca_ES/secret-manage.json
@@ -398,5 +398,11 @@
   "web.secrets.errors.access_denied_to_domain": {
     "text": "Accés denegat al domini",
     "source_hash": "cd441eea"
+  },
+  "web.receipt.open_link": {
+    "text": "Obre l'enllaç"
+  },
+  "web.secrets.messageDeleted": {
+    "text": "Missatge eliminat"
   }
 }

--- a/locales/content/ca_ES/session-auth-extended.json
+++ b/locales/content/ca_ES/session-auth-extended.json
@@ -710,5 +710,26 @@
   "web.auth.recovery_codes.link_title": {
     "text": "Codis de recuperació",
     "source_hash": "579c7f4e"
+  },
+  "web.auth.google": {
+    "text": "Google"
+  },
+  "web.auth.mfa.alternative_auth_options": {
+    "text": "Opcions d'autenticació alternatives"
+  },
+  "web.auth.remember.enabled": {
+    "text": "Mantén la sessió iniciada"
+  },
+  "web.auth.security._guidance.context": {
+    "text": "⚠️ SECURITY-CRITICAL: Messages prevent information disclosure. See src/locales/SECURITY-TRANSLATION-GUIDE.md"
+  },
+  "web.auth.sessions.session_singular": {
+    "text": "sessió"
+  },
+  "web.auth.sessions.session_plural": {
+    "text": "sessions"
+  },
+  "web.auth.sessions._guidance.context": {
+    "text": "User's logged-in devices/browsers management page"
   }
 }

--- a/locales/content/ca_ES/session-auth.json
+++ b/locales/content/ca_ES/session-auth.json
@@ -395,5 +395,35 @@
   "web.help.contact_support": {
     "text": "Contactar amb el suport",
     "source_hash": "f8d47b82"
+  },
+  "web.auth.account.sso_linked": {
+    "text": "Compte SSO"
+  },
+  "web.auth.verify._guidance.context": {
+    "text": "Email verification flow after signup"
+  },
+  "web.help.reset_password_link": {
+    "text": "Restableix la contrasenya"
+  },
+  "web.login.custom_domain_sso_title": {
+    "text": "L'inici de sessió únic està disponible per a aquest domini"
+  },
+  "web.login.custom_domain_sso_description": {
+    "text": "L'administrador de l'organització pot activar l'SSO per permetre que els membres de l'equip iniciïn la sessió aquí. Contacta amb l'administrador per obtenir accés."
+  },
+  "web.login.signin_disabled_heading": {
+    "text": "L'inici de sessió no està disponible"
+  },
+  "web.login.signin_disabled_message": {
+    "text": "Actualment, l'inici de sessió no està disponible en aquest domini."
+  },
+  "web.login.errors.sso_not_configured": {
+    "text": "L'inici de sessió únic no està configurat per a aquest domini. Si us plau, contacta amb el teu administrador."
+  },
+  "web.login.errors.invalid_email": {
+    "text": "L'adreça de correu electrònic del teu proveïdor d'identitat no és vàlida. Si us plau, contacta amb el teu administrador."
+  },
+  "web.login.errors.domain_not_allowed": {
+    "text": "El domini del teu correu electrònic no està autoritzat per al registre amb SSO. Si us plau, contacta amb el teu administrador."
   }
 }

--- a/locales/content/ca_ES/workspace-account.json
+++ b/locales/content/ca_ES/workspace-account.json
@@ -682,5 +682,14 @@
   "web.settings.profile.didnt_receive_email": {
     "text": "No has rebut el correu electrònic?",
     "source_hash": "fe3ac3ad"
+  },
+  "web.settings.api.api_disabled_notice": {
+    "text": "L'API està desactivada per a aquesta instància."
+  },
+  "web.settings.security.sso_managed_title": {
+    "text": "Seguretat gestionada per SSO"
+  },
+  "web.settings.security.sso_managed_description": {
+    "text": "El teu compte s'autentica mitjançant el proveïdor d'inici de sessió únic de la teva organització. La contrasenya, l'autenticació multifactor i els codis de recuperació els gestiona el teu proveïdor d'identitat."
   }
 }

--- a/locales/content/ca_ES/workspace-billing.json
+++ b/locales/content/ca_ES/workspace-billing.json
@@ -988,5 +988,47 @@
     "text": "Disponible només a la teva regió de subscripció original",
     "context": "Hint shown on plan cards when currency does not match active subscription",
     "source_hash": "10de32e5"
+  },
+  "web.billing.already_subscribed": {
+    "text": "Ja estàs subscrit a aquest pla."
+  },
+  "web.billing.cancel.reactivate_button": {
+    "text": "Reactiva la subscripció"
+  },
+  "web.billing.cancel.reactivate_success": {
+    "text": "S'ha reactivat la teva subscripció. Se't continuarà facturant amb normalitat."
+  },
+  "web.billing.cancel.reactivate_error": {
+    "text": "No s'ha pogut reactivar la subscripció. Si us plau, torna-ho a provar o contacta amb el suport."
+  },
+  "web.billing.features.manage_orgs": {
+    "text": "Gestió d'organitzacions"
+  },
+  "web.billing.features.flexible_from_domain": {
+    "text": "Domini remitent de correu flexible"
+  },
+  "web.billing.features.unlimited_admins": {
+    "text": "Administradors il·limitats"
+  },
+  "web.billing.features.manage_sso": {
+    "text": "SSO"
+  },
+  "web.billing.overview.entitlements.flexible_from_domain": {
+    "text": "Domini remitent de correu flexible"
+  },
+  "web.billing.overview.entitlements.manage_orgs": {
+    "text": "Gestionar organitzacions"
+  },
+  "web.billing.overview.entitlements.manage_sso": {
+    "text": "Inici de sessió únic (SSO)"
+  },
+  "web.billing.overview.entitlements.manage_billing": {
+    "text": "Gestionar facturació"
+  },
+  "web.billing.overview.entitlements.custom_signup_validation": {
+    "text": "Validació de registre personalitzada"
+  },
+  "web.billing.plans.reactivate": {
+    "text": "Reactiva"
   }
 }

--- a/locales/content/ca_ES/workspace-branding.json
+++ b/locales/content/ca_ES/workspace-branding.json
@@ -178,5 +178,11 @@
   "web.branding.upgrade_to_customize": {
     "text": "Actualitza el teu pla per personalitzar la marca d'aquest domini.",
     "source_hash": "9077bf79"
+  },
+  "web.branding.saved_successfully": {
+    "text": "S'ha desat la configuració de la marca correctament"
+  },
+  "web.branding.keyhole_logo_icon": {
+    "text": "Icona de pany que representa la compartició segura i privada"
   }
 }

--- a/locales/content/ca_ES/workspace-dashboard.json
+++ b/locales/content/ca_ES/workspace-dashboard.json
@@ -22,5 +22,14 @@
   "web.dashboard.fetch_error_description": {
     "text": "Hi ha hagut un problema en carregar les teves dades. Torna-ho a provar.",
     "source_hash": "ff0d904e"
+  },
+  "web.teams.create_first_team_title": {
+    "text": "Crea el teu primer equip"
+  },
+  "web.teams.create_first_team_description": {
+    "text": "Els equips et permeten col·laborar amb altres persones en un espai de treball compartit."
+  },
+  "web.teams.create_team": {
+    "text": "Crea un equip"
   }
 }

--- a/locales/content/ca_ES/workspace-domains.json
+++ b/locales/content/ca_ES/workspace-domains.json
@@ -398,5 +398,725 @@
   "web.domains.dns_widget_description": {
     "text": "Utilitza l'eina de sota per detectar automàticament el teu proveïdor de DNS i obtenir instruccions pas a pas per configurar el teu domini.",
     "source_hash": "91c1af2e"
+  },
+  "api.domains.errors.add_admin_required": {
+    "text": "Només els propietaris i els administradors de l'organització poden afegir dominis personalitzats"
+  },
+  "web.domains.public_homepage": {
+    "text": "Pàgina d'inici pública"
+  },
+  "web.domains.status_tooltip_active": {
+    "text": "Domini verificat i actiu"
+  },
+  "web.domains.status_tooltip_dns_incorrect": {
+    "text": "DNS no configurat — fes clic per corregir-ho"
+  },
+  "web.domains.status_tooltip_not_verified": {
+    "text": "Domini no verificat — fes clic per verificar-lo"
+  },
+  "web.domains.status_tooltip_unverified": {
+    "text": "Estat del domini no verificat — fes clic per actualitzar"
+  },
+  "web.domains.last_check_failed": {
+    "text": "La darrera comprovació de verificació ha fallat"
+  },
+  "web.domains.last_check_failed_ago": {
+    "text": "darrera comprovació fallida {0}"
+  },
+  "web.domains.verify_now": {
+    "text": "Verifica ara"
+  },
+  "web.domains.click_to_verify": {
+    "text": "fes clic per verificar"
+  },
+  "web.domains.remove_domain_description": {
+    "text": "Elimina permanentment aquest domini i tota la seva configuració."
+  },
+  "web.domains.add_access_denied": {
+    "text": "Accés denegat"
+  },
+  "web.domains.add_access_denied_description": {
+    "text": "No tens permís per afegir dominis a aquesta organització. Contacta amb l'administrador de la teva organització."
+  },
+  "web.domains.dns_widget_load_failed": {
+    "text": "No s'ha pogut carregar el giny de DNS"
+  },
+  "web.domains.dns_widget_not_available": {
+    "text": "El giny de DNS no està disponible"
+  },
+  "web.domains.dns_widget_init_failed": {
+    "text": "No s'ha pogut inicialitzar el giny de DNS"
+  },
+  "web.domains.verified": {
+    "text": "Verificat"
+  },
+  "web.domains.pending_verification": {
+    "text": "Pendent de verificació"
+  },
+  "web.domains.unsaved_changes_confirmation": {
+    "text": "Tens canvis sense desar. Segur que vols sortir?"
+  },
+  "web.domains.entitlement_required_owner": {
+    "text": "Aquesta funció requereix una millora del pla."
+  },
+  "web.domains.entitlement_required_member": {
+    "text": "Aquesta funció no està disponible en el teu pla actual. Contacta amb el propietari de la teva organització."
+  },
+  "web.domains.detail.manage": {
+    "text": "Gestiona"
+  },
+  "web.domains.detail.features": {
+    "text": "Funcions"
+  },
+  "web.domains.detail.homepage_title": {
+    "text": "Secrets a la pàgina d'inici"
+  },
+  "web.domains.detail.homepage_description": {
+    "text": "Permet l'accés públic per crear secrets a la pàgina d'inici del teu domini"
+  },
+  "web.domains.detail.brand_description": {
+    "text": "Logotip, colors i marca personalitzada"
+  },
+  "web.domains.detail.sso_description": {
+    "text": "Configuració del proveïdor d'inici de sessió únic"
+  },
+  "web.domains.detail.email_description": {
+    "text": "Configuració personalitzada del remitent de correu"
+  },
+  "web.domains.detail.incoming_description": {
+    "text": "Configuració del destinatari de secrets entrants"
+  },
+  "web.domains.detail.signup_description": {
+    "text": "Estratègia de validació de registre per domini"
+  },
+  "web.domains.detail.signin_description": {
+    "text": "Configuració del mètode d'inici de sessió per domini"
+  },
+  "web.domains.email.title": {
+    "text": "Enviament de correu"
+  },
+  "web.domains.email.config_title": {
+    "text": "Configuració del correu"
+  },
+  "web.domains.email.config_description": {
+    "text": "Configura l'enviament de correu per a aquest domini"
+  },
+  "web.domains.email.provider_label": {
+    "text": "Proveïdor de correu"
+  },
+  "web.domains.email.provider_placeholder": {
+    "text": "Selecciona un proveïdor de correu"
+  },
+  "web.domains.email.from_name_label": {
+    "text": "Nom del remitent"
+  },
+  "web.domains.email.from_name_placeholder": {
+    "text": "p. ex. Acme Security"
+  },
+  "web.domains.email.from_address_label": {
+    "text": "Adreça del remitent"
+  },
+  "web.domains.email.from_address_placeholder": {
+    "text": "p. ex. secrets{'@'}example.com"
+  },
+  "web.domains.email.reply_to_label": {
+    "text": "Adreça de resposta"
+  },
+  "web.domains.email.reply_to_placeholder": {
+    "text": "p. ex. support{'@'}example.com"
+  },
+  "web.domains.email.save_changes": {
+    "text": "Desa els canvis"
+  },
+  "web.domains.email.discard_changes": {
+    "text": "Descarta els canvis"
+  },
+  "web.domains.email.provider_ses": {
+    "text": "Amazon SES"
+  },
+  "web.domains.email.provider_sendgrid": {
+    "text": "SendGrid"
+  },
+  "web.domains.email.provider_lettermint": {
+    "text": "Lettermint"
+  },
+  "web.domains.email.provider_inherit": {
+    "text": "Usa els valors per defecte del compte"
+  },
+  "web.domains.email.provider_ses_description": {
+    "text": "Requereix la verificació del domini mitjançant registres DKIM i SPF"
+  },
+  "web.domains.email.provider_sendgrid_description": {
+    "text": "Requereix la configuració de l'autenticació del domini"
+  },
+  "web.domains.email.provider_lettermint_description": {
+    "text": "Requereix la verificació del domini"
+  },
+  "web.domains.email.provider_inherit_description": {
+    "text": "Usa la configuració d'enviament de correu per defecte del teu compte"
+  },
+  "web.domains.email.dns_records_title": {
+    "text": "Registres DNS"
+  },
+  "web.domains.email.dns_records_description": {
+    "text": "Afegeix els registres DNS següents per verificar el teu domini per a l'enviament de correu."
+  },
+  "web.domains.email.dns_column_type": {
+    "text": "Tipus"
+  },
+  "web.domains.email.dns_column_name": {
+    "text": "Nom"
+  },
+  "web.domains.email.dns_column_value": {
+    "text": "Valor"
+  },
+  "web.domains.email.dns_check_label": {
+    "text": "DNS"
+  },
+  "web.domains.email.provider_check_label": {
+    "text": "Proveïdor"
+  },
+  "web.domains.email.dns_optional_label": {
+    "text": "Recomanat"
+  },
+  "web.domains.email.dns_optional_hint": {
+    "text": "Aquest registre és recomanat però no obligatori per a la verificació. Una política DMARC al teu domini organitzatiu pot cobrir ja aquest subdomini."
+  },
+  "web.domains.email.copy": {
+    "text": "Copia"
+  },
+  "web.domains.email.copied": {
+    "text": "Copiat"
+  },
+  "web.domains.email.status_verified": {
+    "text": "Verificat"
+  },
+  "web.domains.email.status_pending": {
+    "text": "Pendent"
+  },
+  "web.domains.email.status_failed": {
+    "text": "Fallit"
+  },
+  "web.domains.email.revalidate": {
+    "text": "Torna a validar"
+  },
+  "web.domains.email.validating": {
+    "text": "S'està validant..."
+  },
+  "web.domains.email.domain_verified": {
+    "text": "Domini verificat"
+  },
+  "web.domains.email.validation_failed": {
+    "text": "La validació ha fallat"
+  },
+  "web.domains.email.last_validated": {
+    "text": "Darrera validació"
+  },
+  "web.domains.email.upgrade_to_configure": {
+    "text": "Millora el teu pla per configurar l'enviament de correu per a aquest domini."
+  },
+  "web.domains.email.configure_email": {
+    "text": "Configura el correu"
+  },
+  "web.domains.email.access_denied": {
+    "text": "Accés denegat"
+  },
+  "web.domains.email.access_denied_description": {
+    "text": "No tens permís per gestionar la configuració de correu d'aquest domini. Contacta amb l'administrador de la teva organització."
+  },
+  "web.domains.email.update_success": {
+    "text": "La configuració del correu s'ha desat correctament"
+  },
+  "web.domains.email.delete_success": {
+    "text": "La configuració del correu s'ha eliminat correctament"
+  },
+  "web.domains.email.default_sender_notice": {
+    "text": "Els correus d'aquest domini s'envien actualment des del remitent global. Completa la configuració del correu per usar la teva pròpia identitat de remitent."
+  },
+  "web.domains.email.disabled_notice": {
+    "text": "L'enviament de correu personalitzat està desactivat actualment. Els correus s'enviaran des del remitent global. Activa la funció de sota per usar la teva identitat de remitent personalitzada."
+  },
+  "web.domains.email.test_email_title": {
+    "text": "Prova el lliurament de correu"
+  },
+  "web.domains.email.test_email_hint": {
+    "text": "Envia't un correu de prova a tu mateix usant la configuració desada. Funciona fins i tot quan la funció encara no està activada."
+  },
+  "web.domains.email.send_test": {
+    "text": "Envia una prova"
+  },
+  "web.domains.email.test_email_sent": {
+    "text": "El correu de prova s'ha enviat correctament"
+  },
+  "web.domains.email.test_email_failed": {
+    "text": "No s'ha pogut enviar el correu de prova"
+  },
+  "web.domains.email.test_email_sent_to": {
+    "text": "Enviat a {email}"
+  },
+  "web.domains.email.delivered_via": {
+    "text": "Lliurat mitjançant {provider}"
+  },
+  "web.domains.email.badge_not_configured": {
+    "text": "Sense configurar"
+  },
+  "web.domains.email.badge_default_sender": {
+    "text": "S'usa el remitent per defecte"
+  },
+  "web.domains.email.badge_verified": {
+    "text": "Verificat"
+  },
+  "web.domains.email.badge_pending": {
+    "text": "Verificació pendent"
+  },
+  "web.domains.email.badge_disabled": {
+    "text": "Desactivat"
+  },
+  "web.domains.email.tooltip_not_configured": {
+    "text": "No hi ha cap remitent de correu configurat — els correus usen el remitent per defecte de la plataforma"
+  },
+  "web.domains.email.tooltip_pending": {
+    "text": "La configuració del remitent de correu està pendent de verificació — els correus usen el remitent per defecte de la plataforma"
+  },
+  "web.domains.email.tooltip_disabled": {
+    "text": "El remitent de correu està desactivat — els correus usen el remitent per defecte de la plataforma"
+  },
+  "web.domains.email.tooltip_verified": {
+    "text": "El remitent de correu està verificat — els correus s'envien des d'aquest domini"
+  },
+  "web.domains.incoming.title": {
+    "text": "Secrets entrants"
+  },
+  "web.domains.incoming.config_title": {
+    "text": "Configuració dels secrets entrants"
+  },
+  "web.domains.incoming.config_description": {
+    "text": "Permet que usuaris externs enviïn secrets directament a destinataris designats en aquest domini"
+  },
+  "web.domains.incoming.feature_disabled": {
+    "text": "Secrets entrants no disponibles"
+  },
+  "web.domains.incoming.feature_disabled_description": {
+    "text": "Els secrets entrants no estan activats en aquesta instància. Contacta amb el teu administrador."
+  },
+  "web.domains.incoming.access_denied": {
+    "text": "Accés denegat"
+  },
+  "web.domains.incoming.access_denied_description": {
+    "text": "No tens permís per gestionar la configuració dels secrets entrants d'aquest domini. Contacta amb l'administrador de la teva organització."
+  },
+  "web.domains.incoming.upgrade_to_configure": {
+    "text": "Millora el teu pla per configurar els secrets entrants per a aquest domini."
+  },
+  "web.domains.incoming.configure_incoming": {
+    "text": "Configura els secrets entrants"
+  },
+  "web.domains.incoming.not_configured_notice": {
+    "text": "Els secrets entrants no estan configurats per a aquest domini. Afegeix destinataris per permetre que usuaris externs enviïn secrets al teu equip."
+  },
+  "web.domains.incoming.disabled_notice": {
+    "text": "Els secrets entrants estan desactivats actualment. Els usuaris externs no poden enviar secrets a destinataris d'aquest domini. Activa la funció de sota per permetre els secrets entrants."
+  },
+  "web.domains.incoming.recipients_title": {
+    "text": "Destinataris"
+  },
+  "web.domains.incoming.recipients_description": {
+    "text": "Defineix qui pot rebre secrets entrants en aquest domini. Els destinataris rebran notificacions per correu quan se'ls enviï un secret."
+  },
+  "web.domains.incoming.add_recipient": {
+    "text": "Afegeix un destinatari"
+  },
+  "web.domains.incoming.remove_recipient": {
+    "text": "Elimina"
+  },
+  "web.domains.incoming.email_label": {
+    "text": "Adreça de correu"
+  },
+  "web.domains.incoming.email_placeholder": {
+    "text": "recipient{'@'}example.com"
+  },
+  "web.domains.incoming.name_label": {
+    "text": "Nom visible"
+  },
+  "web.domains.incoming.name_placeholder": {
+    "text": "p. ex. Security Team"
+  },
+  "web.domains.incoming.empty_state": {
+    "text": "No hi ha cap destinatari configurat"
+  },
+  "web.domains.incoming.empty_state_description": {
+    "text": "Afegeix destinataris per permetre que usuaris externs enviïn secrets al teu equip."
+  },
+  "web.domains.incoming.validation_invalid_email": {
+    "text": "Adreça de correu no vàlida"
+  },
+  "web.domains.incoming.validation_duplicate_email": {
+    "text": "Aquesta adreça de correu ja s'ha afegit"
+  },
+  "web.domains.incoming.validation_max_recipients": {
+    "text": "Es permeten {max} destinataris com a màxim"
+  },
+  "web.domains.incoming.validation_name_required": {
+    "text": "El nom visible és obligatori"
+  },
+  "web.domains.incoming.validation_email_required": {
+    "text": "L'adreça de correu és obligatòria"
+  },
+  "web.domains.incoming.save_changes": {
+    "text": "Desa els canvis"
+  },
+  "web.domains.incoming.discard_changes": {
+    "text": "Descarta els canvis"
+  },
+  "web.domains.incoming.update_success": {
+    "text": "La configuració dels secrets entrants s'ha desat correctament"
+  },
+  "web.domains.incoming.delete_success": {
+    "text": "La configuració dels secrets entrants s'ha eliminat correctament"
+  },
+  "web.domains.incoming.recipient_count": {
+    "text": "{count} destinatari | {count} destinataris"
+  },
+  "web.domains.incoming.badge_not_configured": {
+    "text": "Sense configurar"
+  },
+  "web.domains.incoming.badge_configured": {
+    "text": "Configurat"
+  },
+  "web.domains.incoming.badge_disabled": {
+    "text": "Desactivat"
+  },
+  "web.domains.incoming.tooltip_not_configured": {
+    "text": "Secrets entrants sense configurar - els usuaris externs no poden enviar secrets a aquest domini"
+  },
+  "web.domains.incoming.tooltip_configured": {
+    "text": "Secrets entrants activats amb {count} destinatari(s)"
+  },
+  "web.domains.incoming.tooltip_disabled": {
+    "text": "La funció de secrets entrants està desactivada per a aquest domini"
+  },
+  "web.domains.incoming.enabled_label": {
+    "text": "Activa els secrets entrants"
+  },
+  "web.domains.incoming.enabled_hint": {
+    "text": "Permet que usuaris externs enviïn secrets a destinataris d'aquest domini"
+  },
+  "web.domains.incoming.public_url_label": {
+    "text": "URL pública"
+  },
+  "web.domains.incoming.public_url_description": {
+    "text": "Comparteix aquesta URL amb usuaris externs perquè puguin enviar secrets"
+  },
+  "web.domains.incoming.copy_url": {
+    "text": "Copia l'URL"
+  },
+  "web.domains.incoming.url_copied": {
+    "text": "URL copiada al porta-retalls"
+  },
+  "web.domains.incoming.remove_all_confirmation": {
+    "text": "Segur que vols eliminar tots els destinataris? Els usuaris externs ja no podran enviar secrets a aquest domini."
+  },
+  "web.domains.incoming.max_recipients_reached": {
+    "text": "S'ha assolit el nombre màxim de destinataris"
+  },
+  "web.domains.incoming.duplicate_recipient": {
+    "text": "Aquesta adreça de correu ja s'ha afegit"
+  },
+  "web.domains.incoming.save_will_replace_confirmation": {
+    "text": "En desar es reemplaçaran tots els destinataris existents pels teus canvis pendents. Segur que vols continuar?"
+  },
+  "web.domains.incoming.delete_all_recipients": {
+    "text": "Elimina tots els destinataris"
+  },
+  "web.domains.signin.title": {
+    "text": "Configuració de l'inici de sessió"
+  },
+  "web.domains.signin.configure_signin": {
+    "text": "Configura l'inici de sessió"
+  },
+  "web.domains.signin.config_description": {
+    "text": "Configura els mètodes d'autenticació per iniciar la sessió en aquest domini"
+  },
+  "web.domains.signin.access_denied": {
+    "text": "Accés denegat"
+  },
+  "web.domains.signin.upgrade_to_configure": {
+    "text": "Millora el teu pla per configurar els mètodes d'inici de sessió per a aquest domini."
+  },
+  "web.domains.signin.not_configured_notice": {
+    "text": "Encara no s'ha definit la configuració de l'inici de sessió per a aquest domini. Configura les substitucions per controlar quins mètodes d'autenticació estan disponibles a la pàgina d'inici de sessió d'aquest domini."
+  },
+  "web.domains.signin.signin_enabled_label": {
+    "text": "Inici de sessió activat"
+  },
+  "web.domains.signin.header_toggle_label": {
+    "text": "Inici de sessió"
+  },
+  "web.domains.signin.signin_enabled_hint": {
+    "text": "Si els usuaris poden iniciar la sessió en aquest domini"
+  },
+  "web.domains.signin.restrict_to_label": {
+    "text": "Restringeix el mètode d'inici de sessió"
+  },
+  "web.domains.signin.restrict_to_hint": {
+    "text": "Restringeix aquest domini a un únic mètode d'autenticació. Quan s'estableix, només es mostra el mètode escollit a la pàgina d'inici de sessió."
+  },
+  "web.domains.signin.all_methods": {
+    "text": "Tots els mètodes"
+  },
+  "web.domains.signin.all_methods_description": {
+    "text": "Mostra tots els mètodes d'autenticació activats a la pàgina d'inici de sessió"
+  },
+  "web.domains.signin.method_password": {
+    "text": "Contrasenya"
+  },
+  "web.domains.signin.method_email_auth": {
+    "text": "Autenticació per correu"
+  },
+  "web.domains.signin.method_webauthn": {
+    "text": "WebAuthn / Claus d'accés"
+  },
+  "web.domains.signin.method_sso": {
+    "text": "Inici de sessió únic"
+  },
+  "web.domains.signin.method_overrides_label": {
+    "text": "Substitucions de mètode"
+  },
+  "web.domains.signin.method_overrides_hint": {
+    "text": "Activa o desactiva mètodes d'autenticació individuals per a aquest domini"
+  },
+  "web.domains.signin.mode_question": {
+    "text": "Com poden iniciar la sessió els usuaris?"
+  },
+  "web.domains.signin.mode_any": {
+    "text": "Qualsevol mètode disponible"
+  },
+  "web.domains.signin.mode_any_hint": {
+    "text": "Mostra tots els mètodes disponibles en aquest domini. Restringeix mètodes individuals a sota."
+  },
+  "web.domains.signin.mode_one": {
+    "text": "Un mètode específic"
+  },
+  "web.domains.signin.mode_one_hint": {
+    "text": "Restringeix la pàgina d'inici de sessió a un únic mètode. Només es llisten els mètodes disponibles en aquest domini."
+  },
+  "web.domains.signin.mode_disabled": {
+    "text": "Inici de sessió desactivat"
+  },
+  "web.domains.signin.mode_disabled_hint": {
+    "text": "Els usuaris no poden iniciar la sessió en aquest domini."
+  },
+  "web.domains.signin.mode_disabled_notice": {
+    "text": "Els visitants de la pàgina d'inici de sessió d'aquest domini veuen un avís que l'inici de sessió no està disponible, amb un enllaç de tornada a la pàgina d'inici. La teva configuració de mètodes anterior es conserva i es restaura quan tornes a activar l'inici de sessió."
+  },
+  "web.domains.signin.methods_list_label": {
+    "text": "Mètodes mostrats a la pàgina d'inici de sessió"
+  },
+  "web.domains.signin.restrict_picker_hint": {
+    "text": "Només es llisten els mètodes disponibles en aquest domini."
+  },
+  "web.domains.signin.availability_always": {
+    "text": "Sempre disponible"
+  },
+  "web.domains.signin.availability_global_on": {
+    "text": "Segueix la política global · Activat"
+  },
+  "web.domains.signin.availability_global_off": {
+    "text": "No disponible"
+  },
+  "web.domains.signin.availability_unavailable": {
+    "text": "No disponible a tot el lloc"
+  },
+  "web.domains.signin.allow_on_domain": {
+    "text": "Permet en aquest domini"
+  },
+  "web.domains.signin.method_password_blurb": {
+    "text": "Només contrasenya"
+  },
+  "web.domains.signin.method_email_auth_blurb": {
+    "text": "Inici de sessió sense contrasenya amb enllaç màgic"
+  },
+  "web.domains.signin.method_webauthn_blurb": {
+    "text": "Biometria i claus de seguretat"
+  },
+  "web.domains.signin.method_sso_blurb": {
+    "text": "Proveïdor d'identitat extern"
+  },
+  "web.domains.signin.email_auth_label": {
+    "text": "Autenticació per correu"
+  },
+  "web.domains.signin.email_auth_hint": {
+    "text": "Permet l'autenticació per correu sense contrasenya en aquest domini"
+  },
+  "web.domains.signin.sso_enabled_label": {
+    "text": "Inici de sessió únic"
+  },
+  "web.domains.signin.sso_enabled_hint": {
+    "text": "Permet l'autenticació per SSO en aquest domini"
+  },
+  "web.domains.signin.enabled_label": {
+    "text": "Activa la configuració de l'inici de sessió"
+  },
+  "web.domains.signin.enabled_hint": {
+    "text": "Quan està activat, aquest domini usa la configuració d'inici de sessió definida més amunt"
+  },
+  "web.domains.signin.save_config": {
+    "text": "Desa la configuració"
+  },
+  "web.domains.signin.update_success": {
+    "text": "La configuració de l'inici de sessió s'ha actualitzat correctament"
+  },
+  "web.domains.signin.reset_to_defaults": {
+    "text": "Restableix els valors per defecte"
+  },
+  "web.domains.signin.reset_confirm": {
+    "text": "Vols restablir l'inici de sessió als valors per defecte globals?"
+  },
+  "web.domains.signin.reset_keeps_sso": {
+    "text": "Les teves credencials d'SSO es conserven. Elimina-les per separat a la pantalla de configuració de l'SSO."
+  },
+  "web.domains.signin.reset_action": {
+    "text": "Sí, restableix"
+  },
+  "web.domains.signin.reset_success": {
+    "text": "La configuració de l'inici de sessió s'ha restablert als valors per defecte globals"
+  },
+  "web.domains.signup.title": {
+    "text": "Validació del registre"
+  },
+  "web.domains.signup.config_description": {
+    "text": "Configura la validació del registre per a aquest domini"
+  },
+  "web.domains.signup.access_denied": {
+    "text": "Accés denegat"
+  },
+  "web.domains.signup.upgrade_to_configure": {
+    "text": "Millora el teu pla per configurar la validació del registre per domini."
+  },
+  "web.domains.signup.configure_signup": {
+    "text": "Configura el registre"
+  },
+  "web.domains.signup.not_configured_notice": {
+    "text": "Encara no s'ha configurat la validació del registre per a aquest domini. Configura una estratègia per controlar qui es pot registrar mitjançant aquest domini."
+  },
+  "web.domains.signup.site_signups_disabled_warning": {
+    "text": "Els registres estan desactivats actualment a escala de lloc. Aquesta política per domini està configurada però no filtrarà cap trànsit fins que s'activin els registres del lloc."
+  },
+  "web.domains.signup.strategy_label": {
+    "text": "Estratègia de validació"
+  },
+  "web.domains.signup.strategy_description": {
+    "text": "Tria com es validen les adreces de correu quan els usuaris es registren en aquest domini."
+  },
+  "web.domains.signup.network_validation_warning": {
+    "text": "Aquesta estratègia fa crides de xarxa durant el registre, cosa que pot afegir latència o ser bloquejada per alguns proveïdors."
+  },
+  "web.domains.signup.allowed_domains_label": {
+    "text": "Dominis de registre permesos"
+  },
+  "web.domains.signup.allowed_domains_hint": {
+    "text": "Només aquests dominis de correu podran registrar-se. Afegeix un domini per entrada."
+  },
+  "web.domains.signup.domain_placeholder": {
+    "text": "example.com"
+  },
+  "web.domains.signup.invalid_domain": {
+    "text": "Si us plau, introdueix un domini vàlid (p. ex. example.com)"
+  },
+  "web.domains.signup.domain_exists": {
+    "text": "Aquest domini ja és a la llista"
+  },
+  "web.domains.signup.remove_domain": {
+    "text": "Elimina {domain}"
+  },
+  "web.domains.signup.enabled_label": {
+    "text": "Activa la validació per domini"
+  },
+  "web.domains.signup.enabled_hint": {
+    "text": "Quan està activada, els registres en aquest domini usen l'estratègia anterior en lloc de la política global."
+  },
+  "web.domains.signup.delete_config": {
+    "text": "Elimina la configuració"
+  },
+  "web.domains.signup.delete_confirm": {
+    "text": "Vols eliminar la configuració de validació del registre? Els registres tornaran a la política global."
+  },
+  "web.domains.signup.save_config": {
+    "text": "Desa la configuració"
+  },
+  "web.domains.signup.update_success": {
+    "text": "La validació del registre s'ha actualitzat correctament"
+  },
+  "web.domains.signup.delete_success": {
+    "text": "La configuració de validació del registre s'ha eliminat correctament"
+  },
+  "web.domains.signup.domain_overrides_label": {
+    "text": "Substitucions de domini"
+  },
+  "web.domains.signup.domain_overrides_hint": {
+    "text": "Substitueix la configuració global de registre per a aquest domini"
+  },
+  "web.domains.signup.signup_enabled_label": {
+    "text": "Registre activat"
+  },
+  "web.domains.signup.signup_enabled_hint": {
+    "text": "Substitueix si el registre està activat per a aquest domini"
+  },
+  "web.domains.signup.autoverify_label": {
+    "text": "Verifica els comptes automàticament"
+  },
+  "web.domains.signup.autoverify_hint": {
+    "text": "Substitueix si els comptes nous es verifiquen automàticament en aquest domini"
+  },
+  "web.domains.sso.title": {
+    "text": "Inici de sessió únic"
+  },
+  "web.domains.sso.config_title": {
+    "text": "Configuració de l'SSO"
+  },
+  "web.domains.sso.config_description": {
+    "text": "Configura l'autenticació amb inici de sessió únic per a aquest domini"
+  },
+  "web.domains.sso.access_denied": {
+    "text": "Accés denegat"
+  },
+  "web.domains.sso.access_denied_description": {
+    "text": "No tens permís per gestionar la configuració de l'SSO d'aquest domini. Contacta amb l'administrador de la teva organització."
+  },
+  "web.domains.sso.upgrade_to_configure": {
+    "text": "Millora el teu pla per configurar l'inici de sessió únic per a aquest domini."
+  },
+  "web.domains.sso.create_success": {
+    "text": "La configuració de l'SSO s'ha creat correctament"
+  },
+  "web.domains.sso.update_success": {
+    "text": "La configuració de l'SSO s'ha actualitzat correctament"
+  },
+  "web.domains.sso.delete_success": {
+    "text": "La configuració de l'SSO s'ha eliminat correctament"
+  },
+  "web.domains.sso.test_success": {
+    "text": "Prova de connexió correcta — el proveïdor ha respost correctament"
+  },
+  "web.domains.sso.test_failed": {
+    "text": "La prova de connexió ha fallat"
+  },
+  "web.domains.sso.enforce_moved_notice": {
+    "text": "Per exigir l'SSO a tots els inicis de sessió d'aquest domini, configura-ho a la configuració d'inici de sessió del domini. El mode només SSO restringeix la pàgina d'inici de sessió al proveïdor d'SSO configurat aquí."
+  },
+  "web.domains.sso.configure_sso": {
+    "text": "Configura l'SSO"
+  },
+  "web.domains.sso.not_configured_notice": {
+    "text": "L'SSO encara no està configurat per a aquest domini. Activa l'inici de sessió únic per permetre que els membres de l'equip s'autentiquin amb el proveïdor d'identitat de la teva organització."
+  },
+  "web.domains.sso.edit_credentials": {
+    "text": "Edita les credencials"
+  },
+  "web.domains.sso.configure_button": {
+    "text": "Configura"
+  },
+  "web.domains.sso.upgrade_required": {
+    "text": "Millora el pla per configurar"
   }
 }

--- a/locales/content/ca_ES/workspace-organizations.json
+++ b/locales/content/ca_ES/workspace-organizations.json
@@ -578,5 +578,344 @@
   "web.organizations.invitations.expires_soon": {
     "text": "Caduca aviat",
     "source_hash": "a5dcfef9"
+  },
+  "api.organizations.errors.not_found": {
+    "text": "No s'ha trobat l'organització: %{extid}"
+  },
+  "api.organizations.errors.owner_required": {
+    "text": "Només el propietari de l'organització pot dur a terme aquesta acció"
+  },
+  "api.organizations.errors.admin_required": {
+    "text": "Només els propietaris i administradors de l'organització poden dur a terme aquesta acció"
+  },
+  "api.organizations.errors.member_required": {
+    "text": "Has de ser membre de l'organització per dur a terme aquesta acció"
+  },
+  "api.organizations.invitations.errors.create_admin_required": {
+    "text": "Només els propietaris i administradors de l'organització poden crear invitacions"
+  },
+  "api.organizations.invitations.errors.resend_admin_required": {
+    "text": "Només els propietaris i administradors de l'organització poden reenviar invitacions"
+  },
+  "api.organizations.invitations.errors.view_admin_required": {
+    "text": "Només els propietaris i administradors de l'organització poden veure les invitacions"
+  },
+  "api.organizations.invitations.errors.revoke_admin_required": {
+    "text": "Només els propietaris i administradors de l'organització poden revocar invitacions"
+  },
+  "api.organizations.invitations.errors.email_required": {
+    "text": "El correu és obligatori"
+  },
+  "api.organizations.invitations.errors.email_invalid": {
+    "text": "Format de correu no vàlid"
+  },
+  "api.organizations.invitations.errors.role_invalid": {
+    "text": "El rol ha de ser membre o administrador"
+  },
+  "api.organizations.invitations.errors.cannot_invite_owner": {
+    "text": "No es pot convidar com a propietari"
+  },
+  "api.organizations.invitations.errors.already_member": {
+    "text": "L'usuari ja és membre d'aquesta organització"
+  },
+  "api.organizations.invitations.errors.already_pending": {
+    "text": "Ja hi ha una invitació pendent per a aquest correu"
+  },
+  "api.organizations.invitations.errors.member_limit_reached": {
+    "text": "S'ha assolit el límit de membres. Millora el teu pla per convidar més membres."
+  },
+  "api.organizations.invitations.errors.not_found": {
+    "text": "No s'ha trobat la invitació"
+  },
+  "api.organizations.invitations.errors.cannot_resend_non_pending": {
+    "text": "Només es poden reenviar invitacions pendents"
+  },
+  "api.organizations.invitations.errors.cannot_revoke_non_pending": {
+    "text": "Només es poden revocar invitacions pendents"
+  },
+  "api.organizations.invitations.errors.resend_limit_reached": {
+    "text": "S'ha assolit el límit màxim de reenviaments (%{max})"
+  },
+  "api.organizations.invitations.errors.accept_token_required": {
+    "text": "El testimoni és obligatori"
+  },
+  "api.organizations.invitations.errors.accept_organization_gone": {
+    "text": "L'organització ja no existeix"
+  },
+  "api.organizations.invitations.errors.accept_already_acted": {
+    "text": "La invitació ja consta com a %{status}"
+  },
+  "api.organizations.invitations.errors.accept_expired": {
+    "text": "La invitació ha caducat"
+  },
+  "api.organizations.invitations.errors.accept_email_mismatch": {
+    "text": "La teva adreça de correu no coincideix amb la invitació"
+  },
+  "api.organizations.invitations.errors.accept_already_member": {
+    "text": "Ja ets membre d'aquesta organització"
+  },
+  "web.organizations.entitlements_title": {
+    "text": "Drets de l'organització"
+  },
+  "web.organizations.page_description_short": {
+    "text": "Visualitza i configura els teus espais de treball"
+  },
+  "web.organizations.delete_organization_remove_domains_first": {
+    "text": "Elimina tots els dominis personalitzats abans de suprimir aquesta organització."
+  },
+  "web.organizations.default_org_delete_notice_title": {
+    "text": "Suprimir aquesta organització"
+  },
+  "web.organizations.default_org_delete_notice_before": {
+    "text": "Aquesta és la teva organització per defecte i no es pot eliminar des del tauler de control. Per suprimir-la, posa't en contacte a través del"
+  },
+  "web.organizations.default_org_delete_notice_link": {
+    "text": "formulari de comentaris"
+  },
+  "web.organizations.default_org_delete_notice_after": {
+    "text": "."
+  },
+  "web.organizations.leave_organization": {
+    "text": "Abandona aquesta organització"
+  },
+  "web.organizations.leave_organization_warning": {
+    "text": "Perdràs l'accés a aquesta organització i als seus recursos."
+  },
+  "web.organizations.leave_organization_confirm_title": {
+    "text": "Abandonar l'organització"
+  },
+  "web.organizations.leave_organization_confirm_message": {
+    "text": "Segur que vols abandonar «{name}»? Necessitaràs una nova invitació per tornar a unir-t'hi."
+  },
+  "web.organizations.leave_organization_success": {
+    "text": "Has abandonat l'organització."
+  },
+  "web.organizations.leave_error": {
+    "text": "No s'ha pogut abandonar l'organització"
+  },
+  "web.organizations.organizations": {
+    "text": "Organitzacions"
+  },
+  "web.organizations.invitations.invited_by_inline": {
+    "text": "per {email}"
+  },
+  "web.organizations.invitations.invited_as_inline": {
+    "text": "com a {role}"
+  },
+  "web.organizations.invitations.back_to_home": {
+    "text": "Torna a l'inici"
+  },
+  "web.organizations.invitations.email_locked_hint": {
+    "text": "Aquesta invitació es va enviar a aquesta adreça de correu"
+  },
+  "web.organizations.invitations.signup_continue": {
+    "text": "Continua"
+  },
+  "web.organizations.invitations.signin_continue": {
+    "text": "Inicia la sessió"
+  },
+  "web.organizations.invitations.confirm_join_below": {
+    "text": "Gairebé fet — confirma a sota per unir-te a l'organització."
+  },
+  "web.organizations.invitations.go_to_organizations": {
+    "text": "Vés a Organitzacions"
+  },
+  "web.organizations.invitations.already_member": {
+    "text": "Ja ets membre d'aquesta organització"
+  },
+  "web.organizations.invitations.join_organization": {
+    "text": "Uneix-te a «{orgName}»"
+  },
+  "web.organizations.invitations.sign_in_to_join": {
+    "text": "Inicia la sessió per unir-te a «{orgName}»"
+  },
+  "web.organizations.invitations.decline": {
+    "text": "Rebutja"
+  },
+  "web.organizations.members.member_quota": {
+    "text": "{used} de {limit} membres"
+  },
+  "web.organizations.members.pending_suffix": {
+    "text": "({count} pendents)"
+  },
+  "web.organizations.members.limit_reached_hint": {
+    "text": "S'ha assolit el límit de membres."
+  },
+  "web.organizations.sso.title": {
+    "text": "Inici de sessió únic (SSO)"
+  },
+  "web.organizations.sso.description": {
+    "text": "Configura l'SSO per permetre que els membres iniciïn la sessió amb el proveïdor d'identitat de la teva organització"
+  },
+  "web.organizations.sso.provider_type": {
+    "text": "Tipus de proveïdor"
+  },
+  "web.organizations.sso.provider_type_description": {
+    "text": "Selecciona el proveïdor d'identitat de la teva organització"
+  },
+  "web.organizations.sso.display_name": {
+    "text": "Nom visible"
+  },
+  "web.organizations.sso.display_name_hint": {
+    "text": "Un nom amigable que es mostra als usuaris en iniciar la sessió"
+  },
+  "web.organizations.sso.display_name_placeholder": {
+    "text": "p. ex. Acme Corp SSO"
+  },
+  "web.organizations.sso.client_id": {
+    "text": "Client ID"
+  },
+  "web.organizations.sso.client_id_placeholder": {
+    "text": "El teu Client ID d'OAuth"
+  },
+  "web.organizations.sso.client_secret": {
+    "text": "Client Secret"
+  },
+  "web.organizations.sso.client_secret_placeholder": {
+    "text": "El teu Client Secret d'OAuth"
+  },
+  "web.organizations.sso.client_secret_update_hint": {
+    "text": "Deixa-ho en blanc per conservar el secret existent"
+  },
+  "web.organizations.sso.tenant_id": {
+    "text": "Tenant ID"
+  },
+  "web.organizations.sso.tenant_id_hint": {
+    "text": "L'identificador de tenant d'Azure AD / Entra ID"
+  },
+  "web.organizations.sso.tenant_id_placeholder": {
+    "text": "p. ex. 12345678-1234-1234-1234-123456789abc"
+  },
+  "web.organizations.sso.issuer": {
+    "text": "URL de l'emissor"
+  },
+  "web.organizations.sso.issuer_hint": {
+    "text": "L'URL de descobriment OIDC del teu proveïdor d'identitat"
+  },
+  "web.organizations.sso.issuer_placeholder": {
+    "text": "p. ex. https://login.example.com"
+  },
+  "web.organizations.sso.view_discovery_document": {
+    "text": "Mostra el document de descobriment"
+  },
+  "web.organizations.sso.callback_url": {
+    "text": "URL de retorn"
+  },
+  "web.organizations.sso.callback_url_hint": {
+    "text": "Afegeix aquesta URL als URI de redirecció permesos del teu proveïdor d'identitat"
+  },
+  "web.organizations.sso.allowed_domains": {
+    "text": "Dominis de correu permesos"
+  },
+  "web.organizations.sso.allowed_domains_hint": {
+    "text": "Només els usuaris amb adreces de correu d'aquests dominis poden iniciar la sessió. Deixa-ho buit per permetre tots els dominis."
+  },
+  "web.organizations.sso.domain_placeholder": {
+    "text": "p. ex. acme.com"
+  },
+  "web.organizations.sso.invalid_domain": {
+    "text": "Si us plau, introdueix un domini vàlid (p. ex. example.com)"
+  },
+  "web.organizations.sso.domain_exists": {
+    "text": "Aquest domini ja és a la llista"
+  },
+  "web.organizations.sso.remove_domain": {
+    "text": "Elimina {domain}"
+  },
+  "web.organizations.sso.enabled": {
+    "text": "Activa l'SSO"
+  },
+  "web.organizations.sso.enabled_hint": {
+    "text": "Quan està activat, els membres de l'organització poden iniciar la sessió amb aquest proveïdor d'SSO"
+  },
+  "web.organizations.sso.enforce_sso_only": {
+    "text": "Exigeix només SSO"
+  },
+  "web.organizations.sso.enforce_sso_only_hint": {
+    "text": "Exigeix l'SSO per a tots els inicis de sessió en aquest domini. Quan està activat, l'autenticació basada en contrasenya queda desactivada."
+  },
+  "web.organizations.sso.grant_org_scope": {
+    "text": "Concedeix accés a tota l'organització"
+  },
+  "web.organizations.sso.grant_org_scope_hint": {
+    "text": "Els membres nous que s'uneixin mitjançant l'SSO d'aquest domini rebran accés a tots els dominis de l'organització. Els membres existents no es veuen afectats. Quan està desactivat (per defecte), els membres nous només poden accedir a aquest domini."
+  },
+  "web.organizations.sso.save_config": {
+    "text": "Desa la configuració de l'SSO"
+  },
+  "web.organizations.sso.delete_config": {
+    "text": "Elimina la configuració"
+  },
+  "web.organizations.sso.delete_confirm": {
+    "text": "Segur que vols continuar? Això desactivarà l'SSO de la teva organització."
+  },
+  "web.organizations.sso.load_error": {
+    "text": "No s'ha pogut carregar la configuració de l'SSO"
+  },
+  "web.organizations.sso.save_error": {
+    "text": "No s'ha pogut desar la configuració de l'SSO"
+  },
+  "web.organizations.sso.create_success": {
+    "text": "La configuració de l'SSO s'ha creat correctament"
+  },
+  "web.organizations.sso.update_success": {
+    "text": "La configuració de l'SSO s'ha actualitzat correctament"
+  },
+  "web.organizations.sso.delete_success": {
+    "text": "La configuració de l'SSO s'ha eliminat correctament"
+  },
+  "web.organizations.sso.delete_error": {
+    "text": "No s'ha pogut eliminar la configuració de l'SSO"
+  },
+  "web.organizations.sso.test_connection": {
+    "text": "Prova la connexió"
+  },
+  "web.organizations.sso.test_connection_hint": {
+    "text": "Verifica que el proveïdor d'identitat és accessible (no valida les credencials)"
+  },
+  "web.organizations.sso.test_button": {
+    "text": "Prova la connexió"
+  },
+  "web.organizations.sso.testing": {
+    "text": "S'està provant..."
+  },
+  "web.organizations.sso.test_error": {
+    "text": "No s'ha pogut provar la connexió"
+  },
+  "web.organizations.sso.auth_endpoint": {
+    "text": "Punt de connexió d'autorització"
+  },
+  "web.organizations.sso.missing_fields": {
+    "text": "Camps que falten"
+  },
+  "web.organizations.sso.status_enabled": {
+    "text": "Activat"
+  },
+  "web.organizations.sso.status_configured": {
+    "text": "Configurat"
+  },
+  "web.organizations.sso.domain_sso_title": {
+    "text": "SSO de domini"
+  },
+  "web.organizations.sso.domain_sso_description": {
+    "text": "Configura l'SSO per a cada domini verificat"
+  },
+  "web.organizations.sso.provider_type_locked_hint": {
+    "text": "Per canviar de proveïdor, elimina primer aquesta configuració"
+  },
+  "web.organizations.sso.status_not_configured": {
+    "text": "Sense configurar"
+  },
+  "web.organizations.sso.no_domains": {
+    "text": "No hi ha dominis verificats"
+  },
+  "web.organizations.sso.no_domains_description": {
+    "text": "Afegeix i verifica un domini abans de configurar-hi l'SSO."
+  },
+  "web.organizations.tabs.team": {
+    "text": "Equip"
+  },
+  "web.organizations.tabs.sso": {
+    "text": "SSO"
   }
 }


### PR DESCRIPTION
## `ca_ES` translation update

Automated export of completed **ca_ES** translations from the translation task DB.
Scope: `locales/content/ca_ES/` only — 27 file(s), +1847/-29.

✅ `i18n validate variables`: no variable mismatches.

---

### Local quality review

> Produced by a fresh, isolated `claude` review agent (model `claude-sonnet-5`, agent `saas-translator`) that read
> `locales/AGENT_TRANSLATION_PROTOCOL.md` and inspected this branch's diff before the PR was opened.

**Verdict:** ⚠️ Needs review — elision inconsistency, thin validation data.

**Summary:** Large addition of ~700 new/updated ca_ES strings (new SSO, domains, colonel, billing, and error-message namespaces) plus a global email signature rename. No variable/placeholder mismatches or brand mistranslations found in spot-checks, but a few consistency issues warrant a second look before merge.

**Critical (must fix):** None.

**Warnings:**
- Inconsistent `d'`/`de` elision before `{product_name}`: three strings changed `"d'{product_name}"` → `"de {product_name}"` (`web.INSTRUCTION.phishing_warning`, `web.help.secret_view_faq.what_am_i_looking_at.description`, `web.layout.visit_onetime_secret_homepage`), while near-identical strings elsewhere kept the elided form (`web.homepage.visit_onetime_secret_home`, the translators-credit line). If this is a deliberate policy change (e.g. to stay safe for white-label `product_name` values that may not start with a vowel), it should be applied uniformly, not partially.
- `web.billing.features.manage_sso` is just `"SSO"`, while the parallel `web.billing.overview.entitlements.manage_sso` renders the fuller `"Inici de sessió únic (SSO)"`. Confirm against the English source — may be an incomplete translation rather than an intentional short label.
- The automated variable-consistency check returned no data (`"summary":{},"details":{}`), so placeholder preservation across this diff has only been manually spot-checked, not tool-verified.

**Notes:**
- `"Delano"` → `"Equip de suport"` applied uniformly across all ~20 email signature keys — consistent.
- New `_guidance.context` keys correctly left in English (doc-metadata convention).
- `{'@'}` email-placeholder tokens and OAuth field labels (Client ID/Secret, Tenant ID) correctly kept verbatim/English.
- Punt volat (`col·laborar`, `il·limitats`), guillemets (`«»`), and straight apostrophes used consistently.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
