### PR TITLE
i18n: update cs translations

### DIFF
--- a/locales/content/cs/00-common.json
+++ b/locales/content/cs/00-common.json
@@ -1299,7 +1299,7 @@
     "source_hash": "fc78d9cb"
   },
   "web.INSTRUCTION.phishing_warning": {
-    "text": "Vždy si ověř, že jsi na oficiálních stránkách {product_name}. Podvodníci někdy vytvářejí falešné weby, které vypadají přesně jako {product_name}, aby ukradli tvoje tajemství. Abys předešel/a phishingovým útokům, zkontroluj doménu před vytvořením nových odkazů.",
+    "text": "Vždy si ověř, že jsi na oficiálním webu {product_name}. Podvodníci někdy vytvářejí falešné weby, které vypadají úplně stejně jako {product_name}, aby ti ukradli tajemství. Abys předešel phishingovým útokům, před vytvořením nových odkazů zkontroluj doménu regionu.",
     "source_hash": "b588f5b2"
   },
   "web.pricing.title": {
@@ -1383,5 +1383,110 @@
     "text": "Upgraduj pro odemknutí dalších funkcí",
     "context": "Description shown for free plan users encouraging upgrade",
     "source_hash": "783f174c"
+  },
+  "api.errors.authentication_required": {
+    "text": "Je vyžadováno ověření"
+  },
+  "api.errors.sso_only_action_blocked": {
+    "text": "Tato akce není v režimu pouze SSO dostupná"
+  },
+  "web.COMMON.configure": {
+    "text": "Konfigurovat"
+  },
+  "web.COMMON.copy_to_clipboard": {
+    "text": "Zkopírovat do schránky"
+  },
+  "web.COMMON.add": {
+    "text": "Přidat"
+  },
+  "web.COMMON.enabled": {
+    "text": "Povoleno"
+  },
+  "web.COMMON.disabled": {
+    "text": "Zakázáno"
+  },
+  "web.COMMON.yes_delete": {
+    "text": "Ano, smazat"
+  },
+  "web.COMMON.error_code": {
+    "text": "Kód chyby"
+  },
+  "web.COMMON.http_status": {
+    "text": "HTTP status"
+  },
+  "web.COMMON.details": {
+    "text": "Podrobnosti"
+  },
+  "web.COMMON.field_confirm_password": {
+    "text": "Potvrdit heslo"
+  },
+  "web.COMMON.passwords_must_match": {
+    "text": "Hesla se musí shodovat"
+  },
+  "web.COMMON.and": {
+    "text": "a"
+  },
+  "web.COMMON.or": {
+    "text": "nebo"
+  },
+  "web.COMMON.copied": {
+    "text": "Zkopírováno"
+  },
+  "web.COMMON.copy": {
+    "text": "Kopírovat"
+  },
+  "web.COMMON.copy_email": {
+    "text": "Zkopírovat e-mailovou adresu"
+  },
+  "web.COMMON.copy_id": {
+    "text": "Zkopírovat ID účtu"
+  },
+  "web.COMMON.org_id_tooltip": {
+    "text": "Jedinečný identifikátor tvé organizace"
+  },
+  "web.COMMON.success": {
+    "text": "Úspěch"
+  },
+  "web.COMMON.need_help": {
+    "text": "Potřebujete pomoc"
+  },
+  "web.COMMON.open_help_dialog": {
+    "text": "Otevřít dialog nápovědy"
+  },
+  "web.COMMON.focus_is_now_in_the_main_text_area": {
+    "text": "Zaměření je nyní v hlavní textové oblasti"
+  },
+  "web.LABELS.show_passphrase": {
+    "text": "Zobrazit přístupovou frázi"
+  },
+  "web.LABELS.hide_passphrase": {
+    "text": "Skrýt přístupovou frázi"
+  },
+  "web.LABELS.copy_icon": {
+    "text": "Ikona kopírování"
+  },
+  "web.LABELS.copied_icon": {
+    "text": "Ikona zkopírováno"
+  },
+  "web.STATUS.unverified": {
+    "text": "Neověřeno"
+  },
+  "web.TITLES.domain_detail": {
+    "text": "Nastavení domény"
+  },
+  "web.TITLES.domain_signin": {
+    "text": "Konfigurace přihlášení"
+  },
+  "web.TITLES.domain_sso": {
+    "text": "SSO domény"
+  },
+  "web.TITLES.domain_signup": {
+    "text": "Ověření registrace domény"
+  },
+  "web.TITLES.domain_email": {
+    "text": "Konfigurace e-mailu"
+  },
+  "web.TITLES.domain_incoming": {
+    "text": "Příchozí tajemství"
   }
 }

--- a/locales/content/cs/10-layout.json
+++ b/locales/content/cs/10-layout.json
@@ -148,7 +148,7 @@
     "source_hash": "b9766df3"
   },
   "web.help.secret_view_faq.what_am_i_looking_at.description": {
-    "text": "Zobrazujete zabezpečenou zprávu, která s tebou byla sdílena prostřednictvím {product_name}. Tento obsah se zobrazí pouze jednou a poté je trvale smazán z našich serverů.",
+    "text": "Prohlížíš si zabezpečenou zprávu, která ti byla sdílena prostřednictvím {product_name}. Tento obsah se zobrazí pouze jednou a poté je trvale smazán z našich serverů.",
     "source_hash": "e0f1a10c"
   },
   "web.help.secret_view_faq.can_i_view_again.title": {
@@ -264,7 +264,7 @@
     "source_hash": "e2f124cd"
   },
   "web.layout.visit_onetime_secret_homepage": {
-    "text": "Navštívit domovskou stránku {product_name}",
+    "text": "Přejít na domovskou stránku {product_name}",
     "source_hash": "625556d2"
   },
   "web.layout.footer_navigation": {
@@ -338,5 +338,11 @@
   "web.layout.workspace_context": {
     "text": "Kontext pracovního prostoru",
     "source_hash": "dc6fa4f5"
+  },
+  "web.footer.workspace": {
+    "text": "Pracovní prostor"
+  },
+  "web.help.default_content": {
+    "text": "Pro pomoc kontaktujte podporu"
   }
 }

--- a/locales/content/cs/admin-colonel.json
+++ b/locales/content/cs/admin-colonel.json
@@ -634,5 +634,152 @@
   "web.colonel.feedback.when_you_submit_feedback_well_see": {
     "text": "Když odešli zpětnou vazbu, uvidíme:",
     "source_hash": "fe77172e"
+  },
+  "web.colonel.previewPlanMode": {
+    "text": "Režim náhledu plánu"
+  },
+  "web.colonel.previewModeDescription": {
+    "text": "Zobraz si náhled aplikace tak, jak ji vidí zákazníci na jiném plánu. Ovlivní to pouze tvé zobrazení a nezmění skutečný plán žádné organizace."
+  },
+  "web.colonel.previewModeActive": {
+    "text": "Náhled aktivní"
+  },
+  "web.colonel.bannedIps.empty": {
+    "text": "Žádné zablokované IP adresy"
+  },
+  "web.colonel.bannedIps.currentIp": {
+    "text": "Tvoje aktuální IP adresa"
+  },
+  "web.colonel.bannedIps.confirmUnban": {
+    "text": "Odblokovat {ip}?"
+  },
+  "web.colonel.bannedIps.actions.ban": {
+    "text": "Zablokovat IP"
+  },
+  "web.colonel.bannedIps.actions.quickBan": {
+    "text": "Rychlé zablokování"
+  },
+  "web.colonel.bannedIps.actions.unban": {
+    "text": "Odblokovat"
+  },
+  "web.colonel.bannedIps.actions.cancel": {
+    "text": "Zrušit"
+  },
+  "web.colonel.bannedIps.columns.ipAddress": {
+    "text": "IP adresa"
+  },
+  "web.colonel.bannedIps.columns.reason": {
+    "text": "Důvod"
+  },
+  "web.colonel.bannedIps.columns.bannedAt": {
+    "text": "Zablokováno dne"
+  },
+  "web.colonel.bannedIps.columns.bannedBy": {
+    "text": "Zablokoval"
+  },
+  "web.colonel.bannedIps.error.banFailed": {
+    "text": "Zablokování IP adresy se nezdařilo"
+  },
+  "web.colonel.bannedIps.error.unbanFailed": {
+    "text": "Odblokování IP adresy se nezdařilo"
+  },
+  "web.colonel.bannedIps.form.title": {
+    "text": "Zablokovat IP adresu"
+  },
+  "web.colonel.bannedIps.form.ipLabel": {
+    "text": "IP adresa"
+  },
+  "web.colonel.bannedIps.form.reasonLabel": {
+    "text": "Důvod"
+  },
+  "web.colonel.bannedIps.form.reasonPlaceholder": {
+    "text": "Nepovinný důvod"
+  },
+  "web.colonel.bannedIps.success.banned": {
+    "text": "IP adresa {ip} byla zablokována"
+  },
+  "web.colonel.bannedIps.success.unbanned": {
+    "text": "IP adresa {ip} byla odblokována"
+  },
+  "web.colonel.customDomains.empty": {
+    "text": "Nejsou nakonfigurovány žádné vlastní domény"
+  },
+  "web.colonel.customDomains.noLogo": {
+    "text": "Bez loga"
+  },
+  "web.colonel.customDomains.labels.organization": {
+    "text": "Organizace"
+  },
+  "web.colonel.customDomains.labels.externalId": {
+    "text": "Externí ID"
+  },
+  "web.colonel.customDomains.labels.created": {
+    "text": "Vytvořeno"
+  },
+  "web.colonel.customDomains.labels.updated": {
+    "text": "Aktualizováno"
+  },
+  "web.colonel.customDomains.labels.favicon": {
+    "text": "Favicon"
+  },
+  "web.colonel.customDomains.status.verified": {
+    "text": "Ověřeno"
+  },
+  "web.colonel.customDomains.status.resolving": {
+    "text": "Překládá se"
+  },
+  "web.colonel.customDomains.status.ready": {
+    "text": "Připraveno"
+  },
+  "web.colonel.customDomains.status.publicHomepage": {
+    "text": "Veřejná domovská stránka"
+  },
+  "web.colonel.customDomains.status.publicApi": {
+    "text": "Veřejné API"
+  },
+  "web.colonel.customDomains.status.pending": {
+    "text": "Nevyřízeno"
+  },
+  "web.colonel.pagination.showing": {
+    "text": "Zobrazeno {start}–{end} z {total}"
+  },
+  "web.colonel.pagination.itemsPerPage": {
+    "text": "Položek na stránku"
+  },
+  "web.colonel.pagination.perPage": {
+    "text": "{count} na stránku"
+  },
+  "web.colonel.pagination.pageOf": {
+    "text": "Stránka {current} z {total}"
+  },
+  "web.colonel.secrets.empty": {
+    "text": "Nebyla nalezena žádná tajemství"
+  },
+  "web.colonel.secrets.never": {
+    "text": "Nikdy"
+  },
+  "web.colonel.secrets.columns.shortId": {
+    "text": "Krátké ID"
+  },
+  "web.colonel.secrets.columns.state": {
+    "text": "Stav"
+  },
+  "web.colonel.secrets.columns.created": {
+    "text": "Vytvořeno"
+  },
+  "web.colonel.secrets.columns.expiration": {
+    "text": "Vypršení"
+  },
+  "web.colonel.secrets.columns.age": {
+    "text": "Stáří (dny)"
+  },
+  "web.colonel.secrets.state.new": {
+    "text": "Nové"
+  },
+  "web.colonel.secrets.state.received": {
+    "text": "Přijato"
+  },
+  "web.colonel.secrets.state.viewed": {
+    "text": "Zobrazeno"
   }
 }

--- a/locales/content/cs/api-account-errors.json
+++ b/locales/content/cs/api-account-errors.json
@@ -1,0 +1,8 @@
+{
+  "api.account.errors.invalid_email": {
+    "text": "Je to platná e-mailová adresa?"
+  },
+  "api.account.errors.password_too_short": {
+    "text": "Heslo je příliš krátké"
+  }
+}

--- a/locales/content/cs/api-domains-errors.json
+++ b/locales/content/cs/api-domains-errors.json
@@ -1,0 +1,29 @@
+{
+  "api.domains.errors.domain_id_required": {
+    "text": "Je vyžadováno ID domény"
+  },
+  "api.domains.errors.domain_not_found": {
+    "text": "Doména nenalezena: %{extid}"
+  },
+  "api.domains.errors.organization_not_found": {
+    "text": "Pro doménu nebyla nalezena organizace: %{domain}"
+  },
+  "api.domains.errors.incoming_secrets_disabled": {
+    "text": "Příchozí tajemství nejsou na této instanci povolena"
+  },
+  "api.domains.errors.incoming_secrets_entitlement_required": {
+    "text": "Správa příchozích tajemství vyžaduje oprávnění incoming_secrets. Přejdi na vyšší plán."
+  },
+  "api.domains.errors.incoming_config_not_found": {
+    "text": "Pro doménu nebyla nalezena konfigurace příchozích tajemství: %{extid}"
+  },
+  "api.domains.errors.recipients_max_exceeded": {
+    "text": "Maximální povolený počet příjemců je %{max}"
+  },
+  "api.domains.errors.recipients_invalid_email": {
+    "text": "Neplatný e-mail: %{email}"
+  },
+  "api.domains.errors.recipients_duplicate": {
+    "text": "Duplicitní e-maily příjemců nejsou povoleny"
+  }
+}

--- a/locales/content/cs/api-entitlements-errors.json
+++ b/locales/content/cs/api-entitlements-errors.json
@@ -1,0 +1,71 @@
+{
+  "api.entitlements.errors.context_unavailable": {
+    "text": "Nelze ověřit oprávnění (kontext organizace není dostupný)"
+  },
+  "api.entitlements.errors.api_access_required": {
+    "text": "Přístup k API vyžaduje přechod na vyšší plán"
+  },
+  "api.entitlements.errors.custom_privacy_defaults_required": {
+    "text": "Vlastní výchozí nastavení soukromí vyžaduje přechod na vyšší plán"
+  },
+  "api.entitlements.errors.extended_default_expiration_required": {
+    "text": "Prodloužené výchozí vypršení vyžaduje přechod na vyšší plán"
+  },
+  "api.entitlements.errors.custom_domains_required": {
+    "text": "Vlastní domény vyžadují přechod na vyšší plán"
+  },
+  "api.entitlements.errors.custom_branding_required": {
+    "text": "Vlastní branding vyžaduje přechod na vyšší plán"
+  },
+  "api.entitlements.errors.homepage_secrets_required": {
+    "text": "Tajemství na domovské stránce vyžadují přechod na vyšší plán"
+  },
+  "api.entitlements.errors.incoming_secrets_required": {
+    "text": "Příchozí tajemství vyžadují přechod na vyšší plán"
+  },
+  "api.entitlements.errors.custom_mail_sender_required": {
+    "text": "Vlastní odesílatel e-mailů vyžaduje přechod na vyšší plán"
+  },
+  "api.entitlements.errors.flexible_from_domain_required": {
+    "text": "Flexibilní doména odesílatele vyžaduje přechod na vyšší plán"
+  },
+  "api.entitlements.errors.manage_org_required": {
+    "text": "Správa organizace vyžaduje přechod na vyšší plán"
+  },
+  "api.entitlements.errors.manage_teams_required": {
+    "text": "Správa týmů vyžaduje přechod na vyšší plán"
+  },
+  "api.entitlements.errors.manage_members_required": {
+    "text": "Správa členů vyžaduje přechod na vyšší plán"
+  },
+  "api.entitlements.errors.manage_sso_required": {
+    "text": "Správa SSO vyžaduje přechod na vyšší plán"
+  },
+  "api.entitlements.errors.audit_logs_required": {
+    "text": "Protokoly auditu vyžadují přechod na vyšší plán"
+  },
+  "api.entitlements.errors.custom_signup_validation_required": {
+    "text": "Vlastní ověření registrace vyžaduje přechod na vyšší plán"
+  },
+  "api.entitlements.errors.create_secrets_required": {
+    "text": "Vytváření tajemství vyžaduje přechod na vyšší plán"
+  },
+  "api.entitlements.errors.view_receipt_required": {
+    "text": "Zobrazení potvrzení vyžaduje přechod na vyšší plán"
+  },
+  "api.entitlements.errors.notifications_required": {
+    "text": "Oznámení vyžadují přechod na vyšší plán"
+  },
+  "api.entitlements.errors.workspace_branding_required": {
+    "text": "Branding pracovního prostoru vyžaduje přechod na vyšší plán"
+  },
+  "api.entitlements.errors.ip_access_rules_required": {
+    "text": "Pravidla přístupu podle IP vyžadují přechod na vyšší plán"
+  },
+  "api.entitlements.errors.manage_billing_required": {
+    "text": "Správa fakturace vyžaduje přechod na vyšší plán"
+  },
+  "api.entitlements.errors.custom_signin_config_required": {
+    "text": "Vlastní konfigurace přihlášení vyžaduje přechod na vyšší plán"
+  }
+}

--- a/locales/content/cs/api-feedback-errors.json
+++ b/locales/content/cs/api-feedback-errors.json
@@ -1,0 +1,5 @@
+{
+  "api.feedback.errors.rate_limit_exceeded": {
+    "text": "Příliš mnoho odeslání zpětné vazby. Zkus to prosím později."
+  }
+}

--- a/locales/content/cs/api-incoming-errors.json
+++ b/locales/content/cs/api-incoming-errors.json
@@ -1,0 +1,5 @@
+{
+  "api.incoming.errors.custom_domain_unresolved": {
+    "text": "Organizaci vlastní domény se nepodařilo přeložit"
+  }
+}

--- a/locales/content/cs/api-invite-errors.json
+++ b/locales/content/cs/api-invite-errors.json
@@ -1,0 +1,23 @@
+{
+  "api.invite.errors.invitation_not_found_or_expired": {
+    "text": "Pozvánka nebyla nalezena nebo vypršela"
+  },
+  "api.invite.errors.token_required": {
+    "text": "Je vyžadován token"
+  },
+  "api.invite.errors.organization_no_longer_exists": {
+    "text": "Organizace již neexistuje"
+  },
+  "api.invite.errors.invitation_already_processed": {
+    "text": "Pozvánka již má stav: %{status}"
+  },
+  "api.invite.errors.invitation_expired": {
+    "text": "Platnost pozvánky vypršela"
+  },
+  "api.invite.errors.email_mismatch": {
+    "text": "Tvoje e-mailová adresa neodpovídá pozvánce"
+  },
+  "api.invite.errors.already_member": {
+    "text": "Již jsi členem této organizace"
+  }
+}

--- a/locales/content/cs/api-organizations-errors.json
+++ b/locales/content/cs/api-organizations-errors.json
@@ -1,0 +1,107 @@
+{
+  "api.organizations.errors.domain_scoped_forbidden": {
+    "text": "Členové omezení na doménu nemohou tuto akci provést"
+  },
+  "api.organizations.errors.organization_not_found": {
+    "text": "Organizace nenalezena: %{extid}"
+  },
+  "api.organizations.errors.organization_owner_required": {
+    "text": "Tuto akci může provést pouze vlastník organizace"
+  },
+  "api.organizations.errors.organization_member_required": {
+    "text": "Pro provedení této akce musíš být členem organizace"
+  },
+  "api.organizations.errors.organization_admin_required": {
+    "text": "Tuto akci mohou provést pouze vlastníci a správci organizace"
+  },
+  "api.organizations.errors.extid_required": {
+    "text": "Je vyžadováno ID organizace"
+  },
+  "api.organizations.errors.display_name_required": {
+    "text": "Název organizace je povinný"
+  },
+  "api.organizations.errors.display_name_too_long": {
+    "text": "Název organizace musí být kratší než %{max} znaků"
+  },
+  "api.organizations.errors.description_too_long": {
+    "text": "Popis musí být kratší než %{max} znaků"
+  },
+  "api.organizations.errors.contact_email_exists": {
+    "text": "Organizace s tímto kontaktním e-mailem již existuje"
+  },
+  "api.organizations.errors.creation_in_progress": {
+    "text": "Probíhá vytváření organizace. Zkus to prosím znovu."
+  },
+  "api.organizations.errors.organization_limit_reached": {
+    "text": "Byl dosažen limit organizací. Pro vytvoření dalších organizací přejdi na vyšší plán."
+  },
+  "api.organizations.invitations.errors.invitation_not_found": {
+    "text": "Pozvánka nebyla nalezena"
+  },
+  "api.organizations.invitations.errors.email_required": {
+    "text": "E-mail je povinný"
+  },
+  "api.organizations.invitations.errors.invalid_email_format": {
+    "text": "Neplatný formát e-mailu"
+  },
+  "api.organizations.invitations.errors.invalid_role": {
+    "text": "Role musí být člen nebo správce"
+  },
+  "api.organizations.invitations.errors.cannot_invite_as_owner": {
+    "text": "Nelze pozvat jako vlastníka"
+  },
+  "api.organizations.invitations.errors.user_already_member": {
+    "text": "Uživatel je již členem této organizace"
+  },
+  "api.organizations.invitations.errors.invitation_already_pending": {
+    "text": "Pro tento e-mail již existuje nevyřízená pozvánka"
+  },
+  "api.organizations.invitations.errors.member_limit_reached": {
+    "text": "Byl dosažen limit členů. Pro pozvání dalších členů přejdi na vyšší plán."
+  },
+  "api.organizations.invitations.errors.resend_only_pending": {
+    "text": "Znovu odeslat lze pouze nevyřízené pozvánky"
+  },
+  "api.organizations.invitations.errors.resend_limit_reached": {
+    "text": "Byl dosažen maximální limit opětovných odeslání (%{max})"
+  },
+  "api.organizations.invitations.errors.revoke_only_pending": {
+    "text": "Zrušit lze pouze nevyřízené pozvánky"
+  },
+  "api.organizations.members.errors.member_not_found": {
+    "text": "Člen nenalezen: %{extid}"
+  },
+  "api.organizations.members.errors.member_not_in_organization": {
+    "text": "Člen nebyl v této organizaci nalezen"
+  },
+  "api.organizations.members.errors.member_not_active": {
+    "text": "Člen není aktivní"
+  },
+  "api.organizations.members.errors.invalid_role_value": {
+    "text": "Neplatná role. Musí být jedna z: %{roles}"
+  },
+  "api.organizations.members.errors.cannot_change_owner_role": {
+    "text": "Roli vlastníka nelze změnit. Použij místo toho převod vlastnictví."
+  },
+  "api.organizations.members.errors.member_already_has_role": {
+    "text": "Člen již má roli: %{role}"
+  },
+  "api.organizations.members.errors.cannot_promote_to_owner": {
+    "text": "Nelze povýšit na vlastníka. Použij místo toho převod vlastnictví."
+  },
+  "api.organizations.members.errors.must_be_member": {
+    "text": "Musíš být členem této organizace"
+  },
+  "api.organizations.members.errors.cannot_remove_owner": {
+    "text": "Vlastníka organizace nelze odebrat. Nejprve převeď vlastnictví."
+  },
+  "api.organizations.members.errors.cannot_remove_self": {
+    "text": "Sám sebe nemůžeš odebrat. Použij místo toho možnost opustit organizaci."
+  },
+  "api.organizations.members.errors.admin_cannot_remove_admin": {
+    "text": "Správci nemohou odebírat jiné správce. Mohou to pouze vlastníci."
+  },
+  "api.organizations.members.errors.no_permission_to_remove": {
+    "text": "Nemáš oprávnění odebírat členy"
+  }
+}

--- a/locales/content/cs/api-secrets-errors.json
+++ b/locales/content/cs/api-secrets-errors.json
@@ -1,0 +1,11 @@
+{
+  "api.secrets.errors.domain_permission_authenticated_non_owner": {
+    "text": "Nemáš oprávnění používat doménu: %{domain}"
+  },
+  "api.secrets.errors.domain_public_sharing_disabled": {
+    "text": "Veřejné sdílení je pro doménu zakázáno: %{domain}"
+  },
+  "api.secrets.errors.domain_permission_anonymous_cross_domain": {
+    "text": "Nemáš oprávnění používat doménu: %{domain}"
+  }
+}

--- a/locales/content/cs/email.json
+++ b/locales/content/cs/email.json
@@ -60,7 +60,7 @@
     "source_hash": "88c72144"
   },
   "email.welcome.signature": {
-    "text": "Delano",
+    "text": "Tým podpory",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -100,7 +100,7 @@
     "source_hash": "fbb7eb2d"
   },
   "email.password_request.signature": {
-    "text": "Delano",
+    "text": "Tým podpory",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -145,7 +145,7 @@
     "source_hash": "1863f5be"
   },
   "email.magic_link.signature": {
-    "text": "Delano",
+    "text": "Tým podpory",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -230,7 +230,7 @@
     "source_hash": "3f6b45dd"
   },
   "email.secret_revealed.signature": {
-    "text": "Delano",
+    "text": "Tým podpory",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -355,7 +355,7 @@
     "source_hash": "734882d2"
   },
   "email.organization_invitation.signature": {
-    "text": "Delano",
+    "text": "Tým podpory",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -395,7 +395,7 @@
     "source_hash": "be92cff3"
   },
   "email.password_changed.signature": {
-    "text": "Delano",
+    "text": "Tým podpory",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -445,7 +445,7 @@
     "source_hash": "f8d47b82"
   },
   "email.email_changed.signature": {
-    "text": "Delano",
+    "text": "Tým podpory",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -495,7 +495,7 @@
     "source_hash": "f8d47b82"
   },
   "email.email_change_requested.signature": {
-    "text": "Delano",
+    "text": "Tým podpory",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -550,7 +550,7 @@
     "source_hash": "d4d835fc"
   },
   "email.email_change_confirmation.signature": {
-    "text": "Delano",
+    "text": "Tým podpory",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -580,7 +580,7 @@
     "source_hash": "e7c11bb0"
   },
   "email.mfa_enabled.signature": {
-    "text": "Delano",
+    "text": "Tým podpory",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -605,7 +605,7 @@
     "source_hash": "97ef0a3e"
   },
   "email.mfa_disabled.signature": {
-    "text": "Delano",
+    "text": "Tým podpory",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -650,7 +650,7 @@
     "source_hash": "450c54c5"
   },
   "email.new_login_alert.signature": {
-    "text": "Delano",
+    "text": "Tým podpory",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -670,7 +670,7 @@
     "source_hash": "d442beed"
   },
   "email.member_removed.signature": {
-    "text": "Delano",
+    "text": "Tým podpory",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -690,7 +690,7 @@
     "source_hash": "c2280c0c"
   },
   "email.role_changed.signature": {
-    "text": "Delano",
+    "text": "Tým podpory",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -710,7 +710,7 @@
     "source_hash": "7095fc69"
   },
   "email.organization_deleted.signature": {
-    "text": "Delano",
+    "text": "Tým podpory",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -750,7 +750,7 @@
     "source_hash": "36008943"
   },
   "email.payment_receipt.signature": {
-    "text": "Delano",
+    "text": "Tým podpory",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -775,7 +775,7 @@
     "source_hash": "926406b1"
   },
   "email.payment_failed.signature": {
-    "text": "Delano",
+    "text": "Tým podpory",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -800,7 +800,7 @@
     "source_hash": "66a1419e"
   },
   "email.trial_expiring.signature": {
-    "text": "Delano",
+    "text": "Tým podpory",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -825,7 +825,7 @@
     "source_hash": "5a96ae38"
   },
   "email.subscription_changed.signature": {
-    "text": "Delano",
+    "text": "Tým podpory",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -853,5 +853,41 @@
     "text": "Onetime Secret",
     "renderer": "erb",
     "source_hash": "1cd0194a"
+  },
+  "email.common.secret_link_label": {
+    "text": "Odkaz na tajemství"
+  },
+  "email.common.automated_notice": {
+    "text": "Toto je automatická zpráva od %{product_name}."
+  },
+  "email.common.support_label": {
+    "text": "Podpora"
+  },
+  "email.expiration_warning.signature": {
+    "text": "Tým podpory"
+  },
+  "email.expiration_warning.footer_note": {
+    "text": "Tuto zprávu jsi obdržel, protože platnost tajemství, které jsi vytvořil na %{product_name}, brzy vyprší."
+  },
+  "email.feedback_email.user_id_label": {
+    "text": "Uživatel:"
+  },
+  "email.feedback_email.timezone_label": {
+    "text": "Časové pásmo:"
+  },
+  "email.feedback_email.version_label": {
+    "text": "Verze:"
+  },
+  "email.incoming_secret.footer_note": {
+    "text": "Tuto zprávu jsi obdržel, protože ti někdo prostřednictvím %{product_name} poslal tajemství. Pokud jsi ji nečekal, můžeš tento e-mail bez obav ignorovat."
+  },
+  "email.secret_link.passphrase_label": {
+    "text": "Vyžadována přístupová fráze:"
+  },
+  "email.secret_link.passphrase_required": {
+    "text": "Toto tajemství je chráněno přístupovou frází. Odesílatel by ti ji měl poskytnout samostatně."
+  },
+  "email.secret_link.footer_note": {
+    "text": "Tuto zprávu jsi obdržel, protože %{sender_email} s tebou prostřednictvím %{product_name} sdílel tajemství. Pokud jsi ji nečekal, můžeš tento e-mail bez obav ignorovat."
   }
 }

--- a/locales/content/cs/feature-feedback.json
+++ b/locales/content/cs/feature-feedback.json
@@ -58,5 +58,14 @@
   "web.feedback.reason_email_change_unauthorized": {
     "text": "Vypadá to, že hlásíš neoprávněnou změnu e-mailu na tvém účtu. Popiš prosím, co se stalo, a hned to prošetříme.",
     "source_hash": "00e56551"
+  },
+  "web.feedback.anonymous_no_reply": {
+    "text": "Poznámka: pokud chceš odpověď, podepiš se prosím nebo do zprávy uveď e-mailovou adresu."
+  },
+  "web.feedback.characters_remaining": {
+    "text": "Zbývající znaky: {count}"
+  },
+  "web.feedback.character_limit_reached": {
+    "text": "Byl dosažen limit znaků"
   }
 }

--- a/locales/content/cs/feature-homepage-secrets.json
+++ b/locales/content/cs/feature-homepage-secrets.json
@@ -1,0 +1,50 @@
+{
+  "homepage_secrets.disabled.members_only_eyebrow": {
+    "text": "Instance pouze pro členy"
+  },
+  "homepage_secrets.disabled.private_instance_eyebrow": {
+    "text": "Soukromá instance"
+  },
+  "homepage_secrets.disabled.team_link_headline": {
+    "text": "Tento odkaz je určen pro tým {workspace}."
+  },
+  "homepage_secrets.disabled.signin_headline": {
+    "text": "Přihlas se a vytvoř {action}."
+  },
+  "homepage_secrets.disabled.signin_headline_action": {
+    "text": "odkaz na tajemství"
+  },
+  "homepage_secrets.disabled.team_subtitle": {
+    "text": "Nové jednorázové odkazy zde mohou vytvářet pouze oprávnění členové týmu na {domain}. Příjemci stále mohou otevřít jakýkoli odkaz, který jim byl zaslán."
+  },
+  "homepage_secrets.disabled.public_subtitle": {
+    "text": "Nové jednorázové odkazy mohou vytvářet pouze oprávnění členové této instance. Příjemci stále mohou otevřít jakýkoli odkaz, který jim byl zaslán."
+  },
+  "homepage_secrets.disabled.signin_cta": {
+    "text": "Přihlas se ke svému účtu"
+  },
+  "homepage_secrets.disabled.what_is_this": {
+    "text": "Co to je?"
+  },
+  "homepage_secrets.disabled.trust_viewed_once": {
+    "text": "Zobrazeno jednou, pak zmizí"
+  },
+  "homepage_secrets.disabled.trust_zero_retained": {
+    "text": "Nic se neuchovává"
+  },
+  "homepage_secrets.disabled.promo_title": {
+    "text": "Novinka: bezplatné plány nyní zahrnují vlastní domény."
+  },
+  "homepage_secrets.disabled.promo_subtitle": {
+    "text": "Nasměruj svou doménu na Onetime Secret a odesílej tajemství pod vlastní značkou."
+  },
+  "homepage_secrets.disabled.promo_learn_how": {
+    "text": "Zjisti jak"
+  },
+  "homepage_secrets.disabled.logo_alt": {
+    "text": "Logo {name}"
+  },
+  "homepage_secrets.disabled.opens_in_new_tab": {
+    "text": "(otevře se na nové kartě)"
+  }
+}

--- a/locales/content/cs/feature-incoming.json
+++ b/locales/content/cs/feature-incoming.json
@@ -130,5 +130,26 @@
   "incoming.receipt_link_text": {
     "text": "potvrzení",
     "source_hash": "6f328609"
+  },
+  "incoming.upgrade_required_title": {
+    "text": "Vyžadován přechod na vyšší plán"
+  },
+  "incoming.upgrade_required_description": {
+    "text": "Tato funkce vyžaduje přechod na vyšší plán. Pro povolení příchozích tajemství kontaktuj prosím vlastníka účtu."
+  },
+  "incoming.validation_memo_too_long": {
+    "text": "Poznámka musí mít {max} znaků nebo méně"
+  },
+  "incoming.validation_secret_required": {
+    "text": "Obsah tajemství je povinný"
+  },
+  "incoming.validation_recipient_required": {
+    "text": "Vyber prosím příjemce"
+  },
+  "incoming.validation_feature_disabled": {
+    "text": "Funkce příchozích tajemství není povolena"
+  },
+  "incoming.validation_form_errors": {
+    "text": "Zkontroluj prosím formulář kvůli chybám"
   }
 }

--- a/locales/content/cs/feature-regions.json
+++ b/locales/content/cs/feature-regions.json
@@ -152,7 +152,7 @@
     "source_hash": "1d97f6bd"
   },
   "web.regions.changing_regions_billing_note": {
-    "text": "Pokud se tvůj fakturační kontaktní e-mail liší od e-mailu tvého účtu {product_name}, použij fakturační kontaktní e-mail pro účet v novém regionu, aby se zachovaly výhody tvého předplatného.",
+    "text": "Pokud se tvůj fakturační kontaktní e-mail liší od e-mailu tvého účtu {product_name}, použij pro účet v novém regionu fakturační kontaktní e-mail, aby zůstaly zachovány výhody tvého předplatného.",
     "source_hash": "dac1cc28"
   },
   "web.regions.changing_regions_subscription_note": {
@@ -186,5 +186,8 @@
   "web.regions.jurisdictions.apac.name": {
     "text": "Asia-Pacific",
     "source_hash": "7a757670"
+  },
+  "web.regions.no_region_configured": {
+    "text": "Pro tvůj účet nejsou momentálně k dispozici žádné informace o regionu."
   }
 }

--- a/locales/content/cs/feature-translations.json
+++ b/locales/content/cs/feature-translations.json
@@ -64,7 +64,7 @@
     "source_hash": "13131e36"
   },
   "web.translations.the_following_people_have_donated_their_time_to_": {
-    "text": "Následující lidé věnovali svůj čas k rozšíření dosahu {product_name}:",
+    "text": "Následující lidé věnovali svůj čas, aby pomohli rozšířit dosah {product_name}:",
     "source_hash": "85a766af"
   },
   "web.translations.translations": {
@@ -84,7 +84,7 @@
     "source_hash": "ba5c4395"
   },
   "web.translations.since_2012_onetime_secret_has_provided_a_secure_": {
-    "text": "Od roku 2012 poskytuje {product_name} bezpečný způsob sdílení citlivých informací po celém světě. S uživateli v regionech, kde angličtina není primárním jazykem, jsou přesné překlady zásadní pro zpřístupnění bezpečné komunikace všem.",
+    "text": "Od roku 2012 poskytuje {product_name} bezpečný způsob, jak sdílet citlivé informace po celém světě. Vzhledem k uživatelům v regionech, kde angličtina není hlavním jazykem, jsou přesné překlady nezbytné k tomu, aby byla bezpečná komunikace dostupná všem.",
     "source_hash": "87a6e9af"
   },
   "web.translations.help_secure_communication_go_global": {

--- a/locales/content/cs/secret-homepage.json
+++ b/locales/content/cs/secret-homepage.json
@@ -168,11 +168,11 @@
     "source_hash": "e1073c60"
   },
   "web.homepage.welcome_to_onetime_secret": {
-    "text": "Vítejte v {product_name}.",
+    "text": "Vítej v {product_name}.",
     "source_hash": "0990d163"
   },
   "web.homepage.onetime_secret_helps_us_share_sensitive_informat": {
-    "text": "{product_name} nám pomáhá bezpečně sdílet citlivé informace při zachování naší profesionální tváře.",
+    "text": "{product_name} nám pomáhá bezpečně sdílet citlivé informace a zároveň zachovávat naši profesionální tvář.",
     "source_hash": "986a0856"
   },
   "web.homepage.information_shared_through_this_service_can_only": {

--- a/locales/content/cs/secret-manage.json
+++ b/locales/content/cs/secret-manage.json
@@ -128,7 +128,7 @@
     "source_hash": "07fe1b84"
   },
   "web.secrets.onetime_secret_is_a_secure_way_to_share_sensitiv": {
-    "text": "{product_name} je bezpečný způsob sdílení citlivých informací, které se po jednorázovém zobrazení samy zničí.",
+    "text": "{product_name} je bezpečný způsob, jak sdílet citlivé informace, které se po jediném zobrazení samy zničí.",
     "source_hash": "8a163297"
   },
   "web.secrets.what_is_this": {
@@ -398,5 +398,11 @@
   "web.secrets.errors.access_denied_to_domain": {
     "text": "Přístup k doméně zamítnut",
     "source_hash": "cd441eea"
+  },
+  "web.receipt.open_link": {
+    "text": "Otevřít odkaz"
+  },
+  "web.secrets.messageDeleted": {
+    "text": "Zpráva smazána"
   }
 }

--- a/locales/content/cs/session-auth-extended.json
+++ b/locales/content/cs/session-auth-extended.json
@@ -710,5 +710,26 @@
   "web.auth.recovery_codes.link_title": {
     "text": "Obnovovací kódy",
     "source_hash": "579c7f4e"
+  },
+  "web.auth.google": {
+    "text": "Google"
+  },
+  "web.auth.mfa.alternative_auth_options": {
+    "text": "Alternativní možnosti ověření"
+  },
+  "web.auth.remember.enabled": {
+    "text": "Zůstat přihlášen"
+  },
+  "web.auth.security._guidance.context": {
+    "text": "⚠️ SECURITY-CRITICAL: Messages prevent information disclosure. See src/locales/SECURITY-TRANSLATION-GUIDE.md"
+  },
+  "web.auth.sessions.session_singular": {
+    "text": "relace"
+  },
+  "web.auth.sessions.session_plural": {
+    "text": "relace"
+  },
+  "web.auth.sessions._guidance.context": {
+    "text": "User's logged-in devices/browsers management page"
   }
 }

--- a/locales/content/cs/session-auth.json
+++ b/locales/content/cs/session-auth.json
@@ -395,5 +395,35 @@
   "web.help.contact_support": {
     "text": "Kontaktovat podporu",
     "source_hash": "f8d47b82"
+  },
+  "web.auth.account.sso_linked": {
+    "text": "Účet SSO"
+  },
+  "web.auth.verify._guidance.context": {
+    "text": "Email verification flow after signup"
+  },
+  "web.help.reset_password_link": {
+    "text": "Obnovit heslo"
+  },
+  "web.login.custom_domain_sso_title": {
+    "text": "Pro tuto doménu je k dispozici jednotné přihlášení"
+  },
+  "web.login.custom_domain_sso_description": {
+    "text": "Správce organizace může povolit SSO, aby se zde mohli přihlašovat členové týmu. Pro přístup kontaktuj správce."
+  },
+  "web.login.signin_disabled_heading": {
+    "text": "Přihlášení není k dispozici"
+  },
+  "web.login.signin_disabled_message": {
+    "text": "Přihlášení na této doméně momentálně není k dispozici."
+  },
+  "web.login.errors.sso_not_configured": {
+    "text": "Jednotné přihlášení není pro tuto doménu nakonfigurováno. Kontaktuj prosím svého správce."
+  },
+  "web.login.errors.invalid_email": {
+    "text": "E-mailová adresa z tvého poskytovatele identity je neplatná. Kontaktuj prosím svého správce."
+  },
+  "web.login.errors.domain_not_allowed": {
+    "text": "Tvoje e-mailová doména není autorizována pro registraci přes SSO. Kontaktuj prosím svého správce."
   }
 }

--- a/locales/content/cs/workspace-account.json
+++ b/locales/content/cs/workspace-account.json
@@ -476,7 +476,7 @@
     "source_hash": "1cc77e60"
   },
   "web.settings.api.documentation_description": {
-    "text": "Naučte se, jak integrovat {product_name} do tvých aplikací",
+    "text": "Zjisti, jak integrovat {product_name} do svých aplikací",
     "source_hash": "6e8f910f"
   },
   "web.settings.api.rest_api_reference": {
@@ -682,5 +682,14 @@
   "web.settings.profile.didnt_receive_email": {
     "text": "Nedostal/a jsi e-mail?",
     "source_hash": "fe3ac3ad"
+  },
+  "web.settings.api.api_disabled_notice": {
+    "text": "Rozhraní API je pro tuto instanci zakázáno."
+  },
+  "web.settings.security.sso_managed_title": {
+    "text": "Zabezpečení spravované přes SSO"
+  },
+  "web.settings.security.sso_managed_description": {
+    "text": "Tvůj účet je ověřován prostřednictvím poskytovatele jednotného přihlášení tvé organizace. Heslo, vícefaktorové ověření a obnovovací kódy spravuje tvůj poskytovatel identity."
   }
 }

--- a/locales/content/cs/workspace-billing.json
+++ b/locales/content/cs/workspace-billing.json
@@ -988,5 +988,47 @@
     "text": "Dostupné pouze v tvém původním regionu předplatného",
     "context": "Hint shown on plan cards when currency does not match active subscription",
     "source_hash": "10de32e5"
+  },
+  "web.billing.already_subscribed": {
+    "text": "K tomuto plánu už máš předplatné."
+  },
+  "web.billing.cancel.reactivate_button": {
+    "text": "Znovu aktivovat předplatné"
+  },
+  "web.billing.cancel.reactivate_success": {
+    "text": "Tvoje předplatné bylo znovu aktivováno. Bude ti dál účtováno jako obvykle."
+  },
+  "web.billing.cancel.reactivate_error": {
+    "text": "Opětovná aktivace předplatného se nezdařila. Zkus to prosím znovu nebo kontaktuj podporu."
+  },
+  "web.billing.features.manage_orgs": {
+    "text": "Správa organizace"
+  },
+  "web.billing.features.flexible_from_domain": {
+    "text": "Flexibilní doména odesílatele e-mailů"
+  },
+  "web.billing.features.unlimited_admins": {
+    "text": "Neomezený počet správců"
+  },
+  "web.billing.features.manage_sso": {
+    "text": "SSO"
+  },
+  "web.billing.overview.entitlements.flexible_from_domain": {
+    "text": "Flexibilní doména odesílatele e-mailů"
+  },
+  "web.billing.overview.entitlements.manage_orgs": {
+    "text": "Spravovat organizace"
+  },
+  "web.billing.overview.entitlements.manage_sso": {
+    "text": "Jednotné přihlášení (SSO)"
+  },
+  "web.billing.overview.entitlements.manage_billing": {
+    "text": "Spravovat fakturaci"
+  },
+  "web.billing.overview.entitlements.custom_signup_validation": {
+    "text": "Vlastní ověření registrace"
+  },
+  "web.billing.plans.reactivate": {
+    "text": "Znovu aktivovat"
   }
 }

--- a/locales/content/cs/workspace-branding.json
+++ b/locales/content/cs/workspace-branding.json
@@ -144,7 +144,7 @@
     "source_hash": "1e04ba2e"
   },
   "web.branding.powered_by_onetime_secret": {
-    "text": "Provozováno službou {product_name}",
+    "text": "Využívá {product_name}",
     "source_hash": "d8e9f0a1"
   },
   "web.branding.low_contrast_warning": {
@@ -178,5 +178,11 @@
   "web.branding.upgrade_to_customize": {
     "text": "Upgraduj svůj plán pro přizpůsobení značky této domény.",
     "source_hash": "9077bf79"
+  },
+  "web.branding.saved_successfully": {
+    "text": "Nastavení značky bylo úspěšně uloženo"
+  },
+  "web.branding.keyhole_logo_icon": {
+    "text": "Ikona klíčové dírky symbolizující bezpečné, soukromé sdílení"
   }
 }

--- a/locales/content/cs/workspace-dashboard.json
+++ b/locales/content/cs/workspace-dashboard.json
@@ -22,5 +22,14 @@
   "web.dashboard.fetch_error_description": {
     "text": "Při načítání tvých dat došlo k problému. Zkus to prosím znovu.",
     "source_hash": "ff0d904e"
+  },
+  "web.teams.create_first_team_title": {
+    "text": "Vytvoř svůj první tým"
+  },
+  "web.teams.create_first_team_description": {
+    "text": "Týmy ti umožňují spolupracovat s ostatními ve sdíleném pracovním prostoru."
+  },
+  "web.teams.create_team": {
+    "text": "Vytvořit tým"
   }
 }

--- a/locales/content/cs/workspace-domains.json
+++ b/locales/content/cs/workspace-domains.json
@@ -398,5 +398,725 @@
   "web.domains.dns_widget_description": {
     "text": "Použij nástroj níže k automatické detekci tvého poskytovatele DNS a získání podrobných pokynů pro konfiguraci tvojí domény.",
     "source_hash": "91c1af2e"
+  },
+  "api.domains.errors.add_admin_required": {
+    "text": "Vlastní domény mohou přidávat pouze vlastníci a správci organizace"
+  },
+  "web.domains.public_homepage": {
+    "text": "Veřejná domovská stránka"
+  },
+  "web.domains.status_tooltip_active": {
+    "text": "Doména ověřena a aktivní"
+  },
+  "web.domains.status_tooltip_dns_incorrect": {
+    "text": "DNS není nakonfigurováno — klikni pro opravu"
+  },
+  "web.domains.status_tooltip_not_verified": {
+    "text": "Doména není ověřena — klikni pro ověření"
+  },
+  "web.domains.status_tooltip_unverified": {
+    "text": "Stav domény není ověřen — klikni pro obnovení"
+  },
+  "web.domains.last_check_failed": {
+    "text": "Poslední kontrola ověření se nezdařila"
+  },
+  "web.domains.last_check_failed_ago": {
+    "text": "poslední kontrola se nezdařila {0}"
+  },
+  "web.domains.verify_now": {
+    "text": "Ověřit nyní"
+  },
+  "web.domains.click_to_verify": {
+    "text": "klikni pro ověření"
+  },
+  "web.domains.remove_domain_description": {
+    "text": "Trvale odeber tuto doménu a veškerou její konfiguraci."
+  },
+  "web.domains.add_access_denied": {
+    "text": "Přístup odepřen"
+  },
+  "web.domains.add_access_denied_description": {
+    "text": "Nemáš oprávnění přidávat domény do této organizace. Kontaktuj správce své organizace."
+  },
+  "web.domains.dns_widget_load_failed": {
+    "text": "Načtení DNS widgetu se nezdařilo"
+  },
+  "web.domains.dns_widget_not_available": {
+    "text": "DNS widget není k dispozici"
+  },
+  "web.domains.dns_widget_init_failed": {
+    "text": "Inicializace DNS widgetu se nezdařila"
+  },
+  "web.domains.verified": {
+    "text": "Ověřeno"
+  },
+  "web.domains.pending_verification": {
+    "text": "Čeká na ověření"
+  },
+  "web.domains.unsaved_changes_confirmation": {
+    "text": "Máš neuložené změny. Opravdu chceš odejít?"
+  },
+  "web.domains.entitlement_required_owner": {
+    "text": "Tato funkce vyžaduje přechod na vyšší plán."
+  },
+  "web.domains.entitlement_required_member": {
+    "text": "Tato funkce není ve tvém aktuálním plánu k dispozici. Kontaktuj vlastníka své organizace."
+  },
+  "web.domains.detail.manage": {
+    "text": "Spravovat"
+  },
+  "web.domains.detail.features": {
+    "text": "Funkce"
+  },
+  "web.domains.detail.homepage_title": {
+    "text": "Tajemství na domovské stránce"
+  },
+  "web.domains.detail.homepage_description": {
+    "text": "Povolit veřejný přístup k vytváření tajemství na domovské stránce tvé domény"
+  },
+  "web.domains.detail.brand_description": {
+    "text": "Logo, barvy a vlastní branding"
+  },
+  "web.domains.detail.sso_description": {
+    "text": "Nastavení poskytovatele jednotného přihlášení"
+  },
+  "web.domains.detail.email_description": {
+    "text": "Konfigurace vlastního odesílatele e-mailů"
+  },
+  "web.domains.detail.incoming_description": {
+    "text": "Nastavení příjemců příchozích tajemství"
+  },
+  "web.domains.detail.signup_description": {
+    "text": "Strategie ověření registrace pro jednotlivé domény"
+  },
+  "web.domains.detail.signin_description": {
+    "text": "Konfigurace metody přihlášení pro jednotlivé domény"
+  },
+  "web.domains.email.title": {
+    "text": "Odesílání e-mailů"
+  },
+  "web.domains.email.config_title": {
+    "text": "Konfigurace e-mailu"
+  },
+  "web.domains.email.config_description": {
+    "text": "Nakonfiguruj odesílání e-mailů pro tuto doménu"
+  },
+  "web.domains.email.provider_label": {
+    "text": "Poskytovatel e-mailu"
+  },
+  "web.domains.email.provider_placeholder": {
+    "text": "Vyber poskytovatele e-mailu"
+  },
+  "web.domains.email.from_name_label": {
+    "text": "Jméno odesílatele"
+  },
+  "web.domains.email.from_name_placeholder": {
+    "text": "např. Acme Security"
+  },
+  "web.domains.email.from_address_label": {
+    "text": "Adresa odesílatele"
+  },
+  "web.domains.email.from_address_placeholder": {
+    "text": "např. secrets{'@'}example.com"
+  },
+  "web.domains.email.reply_to_label": {
+    "text": "Adresa pro odpověď"
+  },
+  "web.domains.email.reply_to_placeholder": {
+    "text": "např. support{'@'}example.com"
+  },
+  "web.domains.email.save_changes": {
+    "text": "Uložit změny"
+  },
+  "web.domains.email.discard_changes": {
+    "text": "Zahodit změny"
+  },
+  "web.domains.email.provider_ses": {
+    "text": "Amazon SES"
+  },
+  "web.domains.email.provider_sendgrid": {
+    "text": "SendGrid"
+  },
+  "web.domains.email.provider_lettermint": {
+    "text": "Lettermint"
+  },
+  "web.domains.email.provider_inherit": {
+    "text": "Použít výchozí nastavení účtu"
+  },
+  "web.domains.email.provider_ses_description": {
+    "text": "Vyžaduje ověření domény pomocí záznamů DKIM a SPF"
+  },
+  "web.domains.email.provider_sendgrid_description": {
+    "text": "Vyžaduje nastavení autentizace domény"
+  },
+  "web.domains.email.provider_lettermint_description": {
+    "text": "Vyžaduje ověření domény"
+  },
+  "web.domains.email.provider_inherit_description": {
+    "text": "Použije výchozí konfiguraci odesílání e-mailů tvého účtu"
+  },
+  "web.domains.email.dns_records_title": {
+    "text": "DNS záznamy"
+  },
+  "web.domains.email.dns_records_description": {
+    "text": "Přidej následující DNS záznamy pro ověření tvé domény pro odesílání e-mailů."
+  },
+  "web.domains.email.dns_column_type": {
+    "text": "Typ"
+  },
+  "web.domains.email.dns_column_name": {
+    "text": "Název"
+  },
+  "web.domains.email.dns_column_value": {
+    "text": "Hodnota"
+  },
+  "web.domains.email.dns_check_label": {
+    "text": "DNS"
+  },
+  "web.domains.email.provider_check_label": {
+    "text": "Poskytovatel"
+  },
+  "web.domains.email.dns_optional_label": {
+    "text": "Doporučeno"
+  },
+  "web.domains.email.dns_optional_hint": {
+    "text": "Tento záznam je doporučený, ale není pro ověření vyžadován. Zásady DMARC na tvé organizační doméně mohou tuto subdoménu již pokrývat."
+  },
+  "web.domains.email.copy": {
+    "text": "Kopírovat"
+  },
+  "web.domains.email.copied": {
+    "text": "Zkopírováno"
+  },
+  "web.domains.email.status_verified": {
+    "text": "Ověřeno"
+  },
+  "web.domains.email.status_pending": {
+    "text": "Nevyřízeno"
+  },
+  "web.domains.email.status_failed": {
+    "text": "Selhalo"
+  },
+  "web.domains.email.revalidate": {
+    "text": "Znovu ověřit"
+  },
+  "web.domains.email.validating": {
+    "text": "Probíhá ověřování..."
+  },
+  "web.domains.email.domain_verified": {
+    "text": "Doména ověřena"
+  },
+  "web.domains.email.validation_failed": {
+    "text": "Ověření se nezdařilo"
+  },
+  "web.domains.email.last_validated": {
+    "text": "Naposledy ověřeno"
+  },
+  "web.domains.email.upgrade_to_configure": {
+    "text": "Pro konfiguraci odesílání e-mailů pro tuto doménu přejdi na vyšší plán."
+  },
+  "web.domains.email.configure_email": {
+    "text": "Nakonfigurovat e-mail"
+  },
+  "web.domains.email.access_denied": {
+    "text": "Přístup odepřen"
+  },
+  "web.domains.email.access_denied_description": {
+    "text": "Nemáš oprávnění spravovat nastavení e-mailů pro tuto doménu. Kontaktuj správce své organizace."
+  },
+  "web.domains.email.update_success": {
+    "text": "Konfigurace e-mailu byla úspěšně uložena"
+  },
+  "web.domains.email.delete_success": {
+    "text": "Konfigurace e-mailu byla úspěšně odebrána"
+  },
+  "web.domains.email.default_sender_notice": {
+    "text": "E-maily pro tuto doménu se aktuálně odesílají z globálního odesílatele. Dokonči konfiguraci e-mailu, abys mohl používat vlastní identitu odesílatele."
+  },
+  "web.domains.email.disabled_notice": {
+    "text": "Vlastní odesílání e-mailů je momentálně zakázáno. E-maily budou odesílány z globálního odesílatele. Povol níže tuto funkci, abys mohl používat vlastní identitu odesílatele."
+  },
+  "web.domains.email.test_email_title": {
+    "text": "Otestovat doručení e-mailu"
+  },
+  "web.domains.email.test_email_hint": {
+    "text": "Odešli si testovací e-mail s uloženou konfigurací. Funguje, i když funkce ještě není povolena."
+  },
+  "web.domains.email.send_test": {
+    "text": "Odeslat test"
+  },
+  "web.domains.email.test_email_sent": {
+    "text": "Testovací e-mail byl úspěšně odeslán"
+  },
+  "web.domains.email.test_email_failed": {
+    "text": "Odeslání testovacího e-mailu se nezdařilo"
+  },
+  "web.domains.email.test_email_sent_to": {
+    "text": "Odesláno na {email}"
+  },
+  "web.domains.email.delivered_via": {
+    "text": "Doručeno přes {provider}"
+  },
+  "web.domains.email.badge_not_configured": {
+    "text": "Nenakonfigurováno"
+  },
+  "web.domains.email.badge_default_sender": {
+    "text": "Používá se výchozí odesílatel"
+  },
+  "web.domains.email.badge_verified": {
+    "text": "Ověřeno"
+  },
+  "web.domains.email.badge_pending": {
+    "text": "Čeká na ověření"
+  },
+  "web.domains.email.badge_disabled": {
+    "text": "Zakázáno"
+  },
+  "web.domains.email.tooltip_not_configured": {
+    "text": "Není nakonfigurován žádný odesílatel e-mailů — e-maily používají výchozího odesílatele platformy"
+  },
+  "web.domains.email.tooltip_pending": {
+    "text": "Konfigurace odesílatele e-mailů čeká na ověření — e-maily používají výchozího odesílatele platformy"
+  },
+  "web.domains.email.tooltip_disabled": {
+    "text": "Odesílatel e-mailů je zakázán — e-maily používají výchozího odesílatele platformy"
+  },
+  "web.domains.email.tooltip_verified": {
+    "text": "Odesílatel e-mailů ověřen — e-maily se odesílají z této domény"
+  },
+  "web.domains.incoming.title": {
+    "text": "Příchozí tajemství"
+  },
+  "web.domains.incoming.config_title": {
+    "text": "Konfigurace příchozích tajemství"
+  },
+  "web.domains.incoming.config_description": {
+    "text": "Umožni externím uživatelům posílat tajemství přímo určeným příjemcům na této doméně"
+  },
+  "web.domains.incoming.feature_disabled": {
+    "text": "Příchozí tajemství nejsou k dispozici"
+  },
+  "web.domains.incoming.feature_disabled_description": {
+    "text": "Příchozí tajemství nejsou na této instanci povolena. Kontaktuj svého správce."
+  },
+  "web.domains.incoming.access_denied": {
+    "text": "Přístup odepřen"
+  },
+  "web.domains.incoming.access_denied_description": {
+    "text": "Nemáš oprávnění spravovat nastavení příchozích tajemství pro tuto doménu. Kontaktuj správce své organizace."
+  },
+  "web.domains.incoming.upgrade_to_configure": {
+    "text": "Pro konfiguraci příchozích tajemství pro tuto doménu přejdi na vyšší plán."
+  },
+  "web.domains.incoming.configure_incoming": {
+    "text": "Nakonfigurovat příchozí tajemství"
+  },
+  "web.domains.incoming.not_configured_notice": {
+    "text": "Příchozí tajemství nejsou pro tuto doménu nakonfigurována. Přidej příjemce, aby externí uživatelé mohli posílat tajemství tvému týmu."
+  },
+  "web.domains.incoming.disabled_notice": {
+    "text": "Příchozí tajemství jsou momentálně zakázána. Externí uživatelé nemohou posílat tajemství příjemcům na této doméně. Povol níže tuto funkci, abys umožnil příchozí tajemství."
+  },
+  "web.domains.incoming.recipients_title": {
+    "text": "Příjemci"
+  },
+  "web.domains.incoming.recipients_description": {
+    "text": "Urči, kdo může na této doméně přijímat příchozí tajemství. Příjemci obdrží e-mailová oznámení, když jim bude odesláno tajemství."
+  },
+  "web.domains.incoming.add_recipient": {
+    "text": "Přidat příjemce"
+  },
+  "web.domains.incoming.remove_recipient": {
+    "text": "Odebrat"
+  },
+  "web.domains.incoming.email_label": {
+    "text": "E-mailová adresa"
+  },
+  "web.domains.incoming.email_placeholder": {
+    "text": "recipient{'@'}example.com"
+  },
+  "web.domains.incoming.name_label": {
+    "text": "Zobrazované jméno"
+  },
+  "web.domains.incoming.name_placeholder": {
+    "text": "např. Security Team"
+  },
+  "web.domains.incoming.empty_state": {
+    "text": "Nejsou nakonfigurováni žádní příjemci"
+  },
+  "web.domains.incoming.empty_state_description": {
+    "text": "Přidej příjemce, aby externí uživatelé mohli posílat tajemství tvému týmu."
+  },
+  "web.domains.incoming.validation_invalid_email": {
+    "text": "Neplatná e-mailová adresa"
+  },
+  "web.domains.incoming.validation_duplicate_email": {
+    "text": "Tato e-mailová adresa už byla přidána"
+  },
+  "web.domains.incoming.validation_max_recipients": {
+    "text": "Maximální povolený počet příjemců je {max}"
+  },
+  "web.domains.incoming.validation_name_required": {
+    "text": "Zobrazované jméno je povinné"
+  },
+  "web.domains.incoming.validation_email_required": {
+    "text": "E-mailová adresa je povinná"
+  },
+  "web.domains.incoming.save_changes": {
+    "text": "Uložit změny"
+  },
+  "web.domains.incoming.discard_changes": {
+    "text": "Zahodit změny"
+  },
+  "web.domains.incoming.update_success": {
+    "text": "Konfigurace příchozích tajemství byla úspěšně uložena"
+  },
+  "web.domains.incoming.delete_success": {
+    "text": "Konfigurace příchozích tajemství byla úspěšně odebrána"
+  },
+  "web.domains.incoming.recipient_count": {
+    "text": "{count} příjemce | {count} příjemci"
+  },
+  "web.domains.incoming.badge_not_configured": {
+    "text": "Nenakonfigurováno"
+  },
+  "web.domains.incoming.badge_configured": {
+    "text": "Nakonfigurováno"
+  },
+  "web.domains.incoming.badge_disabled": {
+    "text": "Zakázáno"
+  },
+  "web.domains.incoming.tooltip_not_configured": {
+    "text": "Příchozí tajemství nejsou nakonfigurována – externí uživatelé nemohou na tuto doménu posílat tajemství"
+  },
+  "web.domains.incoming.tooltip_configured": {
+    "text": "Příchozí tajemství povolena s {count} příjemci"
+  },
+  "web.domains.incoming.tooltip_disabled": {
+    "text": "Funkce příchozích tajemství je pro tuto doménu zakázána"
+  },
+  "web.domains.incoming.enabled_label": {
+    "text": "Povolit příchozí tajemství"
+  },
+  "web.domains.incoming.enabled_hint": {
+    "text": "Umožni externím uživatelům posílat tajemství příjemcům na této doméně"
+  },
+  "web.domains.incoming.public_url_label": {
+    "text": "Veřejná URL"
+  },
+  "web.domains.incoming.public_url_description": {
+    "text": "Sdílej tuto URL s externími uživateli, aby mohli posílat tajemství"
+  },
+  "web.domains.incoming.copy_url": {
+    "text": "Zkopírovat URL"
+  },
+  "web.domains.incoming.url_copied": {
+    "text": "URL zkopírována do schránky"
+  },
+  "web.domains.incoming.remove_all_confirmation": {
+    "text": "Opravdu chceš odebrat všechny příjemce? Externí uživatelé pak již nebudou moci posílat tajemství na tuto doménu."
+  },
+  "web.domains.incoming.max_recipients_reached": {
+    "text": "Byl dosažen maximální počet příjemců"
+  },
+  "web.domains.incoming.duplicate_recipient": {
+    "text": "Tato e-mailová adresa už byla přidána"
+  },
+  "web.domains.incoming.save_will_replace_confirmation": {
+    "text": "Uložením nahradíš všechny stávající příjemce svými nevyřízenými změnami. Jsi si jistý?"
+  },
+  "web.domains.incoming.delete_all_recipients": {
+    "text": "Smazat všechny příjemce"
+  },
+  "web.domains.signin.title": {
+    "text": "Konfigurace přihlášení"
+  },
+  "web.domains.signin.configure_signin": {
+    "text": "Nakonfigurovat přihlášení"
+  },
+  "web.domains.signin.config_description": {
+    "text": "Nakonfiguruj metody ověření přihlášení pro tuto doménu"
+  },
+  "web.domains.signin.access_denied": {
+    "text": "Přístup odepřen"
+  },
+  "web.domains.signin.upgrade_to_configure": {
+    "text": "Pro konfiguraci metod přihlášení pro tuto doménu přejdi na vyšší plán."
+  },
+  "web.domains.signin.not_configured_notice": {
+    "text": "Konfigurace přihlášení pro tuto doménu zatím není nastavena. Nakonfiguruj přepsání, abys určil, které metody ověření jsou na přihlašovací stránce této domény k dispozici."
+  },
+  "web.domains.signin.signin_enabled_label": {
+    "text": "Přihlášení povoleno"
+  },
+  "web.domains.signin.header_toggle_label": {
+    "text": "Přihlášení"
+  },
+  "web.domains.signin.signin_enabled_hint": {
+    "text": "Zda se uživatelé mohou na této doméně přihlásit"
+  },
+  "web.domains.signin.restrict_to_label": {
+    "text": "Omezit metodu přihlášení"
+  },
+  "web.domains.signin.restrict_to_hint": {
+    "text": "Omez tuto doménu na jedinou metodu ověření. Po nastavení se na přihlašovací stránce zobrazí pouze zvolená metoda."
+  },
+  "web.domains.signin.all_methods": {
+    "text": "Všechny metody"
+  },
+  "web.domains.signin.all_methods_description": {
+    "text": "Zobrazit na přihlašovací stránce všechny povolené metody ověření"
+  },
+  "web.domains.signin.method_password": {
+    "text": "Heslo"
+  },
+  "web.domains.signin.method_email_auth": {
+    "text": "Ověření e-mailem"
+  },
+  "web.domains.signin.method_webauthn": {
+    "text": "WebAuthn / Passkeys"
+  },
+  "web.domains.signin.method_sso": {
+    "text": "Jednotné přihlášení"
+  },
+  "web.domains.signin.method_overrides_label": {
+    "text": "Přepsání metod"
+  },
+  "web.domains.signin.method_overrides_hint": {
+    "text": "Povol nebo zakaž jednotlivé metody ověření pro tuto doménu"
+  },
+  "web.domains.signin.mode_question": {
+    "text": "Jak se mohou uživatelé přihlásit?"
+  },
+  "web.domains.signin.mode_any": {
+    "text": "Jakákoli dostupná metoda"
+  },
+  "web.domains.signin.mode_any_hint": {
+    "text": "Zobrazit každou metodu dostupnou na této doméně. Jednotlivé metody upřesni níže."
+  },
+  "web.domains.signin.mode_one": {
+    "text": "Jedna konkrétní metoda"
+  },
+  "web.domains.signin.mode_one_hint": {
+    "text": "Omez přihlašovací stránku na jedinou metodu. Uvedeny jsou pouze metody dostupné na této doméně."
+  },
+  "web.domains.signin.mode_disabled": {
+    "text": "Přihlášení zakázáno"
+  },
+  "web.domains.signin.mode_disabled_hint": {
+    "text": "Uživatelé se na této doméně nemohou přihlásit."
+  },
+  "web.domains.signin.mode_disabled_notice": {
+    "text": "Návštěvníci přihlašovací stránky této domény uvidí upozornění, že přihlášení není k dispozici, s odkazem zpět na domovskou stránku. Tvá předchozí nastavení metod jsou uchována a obnovena, jakmile přihlášení znovu povolíš."
+  },
+  "web.domains.signin.methods_list_label": {
+    "text": "Metody zobrazené na přihlašovací stránce"
+  },
+  "web.domains.signin.restrict_picker_hint": {
+    "text": "Uvedeny jsou pouze metody dostupné na této doméně."
+  },
+  "web.domains.signin.availability_always": {
+    "text": "Vždy dostupné"
+  },
+  "web.domains.signin.availability_global_on": {
+    "text": "Řídí se globálními zásadami · Zapnuto"
+  },
+  "web.domains.signin.availability_global_off": {
+    "text": "Není dostupné"
+  },
+  "web.domains.signin.availability_unavailable": {
+    "text": "Nedostupné v celém webu"
+  },
+  "web.domains.signin.allow_on_domain": {
+    "text": "Povolit na této doméně"
+  },
+  "web.domains.signin.method_password_blurb": {
+    "text": "Pouze heslo"
+  },
+  "web.domains.signin.method_email_auth_blurb": {
+    "text": "Přihlášení magickým odkazem bez hesla"
+  },
+  "web.domains.signin.method_webauthn_blurb": {
+    "text": "Biometrie a bezpečnostní klíče"
+  },
+  "web.domains.signin.method_sso_blurb": {
+    "text": "Externí poskytovatel identity"
+  },
+  "web.domains.signin.email_auth_label": {
+    "text": "Ověření e-mailem"
+  },
+  "web.domains.signin.email_auth_hint": {
+    "text": "Povolit na této doméně ověření e-mailem bez hesla"
+  },
+  "web.domains.signin.sso_enabled_label": {
+    "text": "Jednotné přihlášení"
+  },
+  "web.domains.signin.sso_enabled_hint": {
+    "text": "Povolit na této doméně ověření přes SSO"
+  },
+  "web.domains.signin.enabled_label": {
+    "text": "Povolit konfiguraci přihlášení"
+  },
+  "web.domains.signin.enabled_hint": {
+    "text": "Pokud je povoleno, tato doména používá výše nakonfigurovaná nastavení přihlášení"
+  },
+  "web.domains.signin.save_config": {
+    "text": "Uložit konfiguraci"
+  },
+  "web.domains.signin.update_success": {
+    "text": "Konfigurace přihlášení byla úspěšně aktualizována"
+  },
+  "web.domains.signin.reset_to_defaults": {
+    "text": "Obnovit výchozí nastavení"
+  },
+  "web.domains.signin.reset_confirm": {
+    "text": "Obnovit přihlášení na globální výchozí nastavení?"
+  },
+  "web.domains.signin.reset_keeps_sso": {
+    "text": "Tvé přihlašovací údaje SSO jsou uchovány. Odeber je samostatně na obrazovce konfigurace SSO."
+  },
+  "web.domains.signin.reset_action": {
+    "text": "Ano, obnovit"
+  },
+  "web.domains.signin.reset_success": {
+    "text": "Nastavení přihlášení obnoveno na globální výchozí hodnoty"
+  },
+  "web.domains.signup.title": {
+    "text": "Ověření registrace"
+  },
+  "web.domains.signup.config_description": {
+    "text": "Nakonfiguruj ověření registrace pro tuto doménu"
+  },
+  "web.domains.signup.access_denied": {
+    "text": "Přístup odepřen"
+  },
+  "web.domains.signup.upgrade_to_configure": {
+    "text": "Pro konfiguraci ověření registrace pro jednotlivé domény přejdi na vyšší plán."
+  },
+  "web.domains.signup.configure_signup": {
+    "text": "Nakonfigurovat registraci"
+  },
+  "web.domains.signup.not_configured_notice": {
+    "text": "Ověření registrace pro tuto doménu zatím není nakonfigurováno. Nakonfiguruj strategii, abys určil, kdo se může prostřednictvím této domény zaregistrovat."
+  },
+  "web.domains.signup.site_signups_disabled_warning": {
+    "text": "Registrace jsou momentálně zakázány na úrovni webu. Tyto zásady pro jednotlivou doménu jsou nakonfigurovány, ale nebudou žádný provoz omezovat, dokud nebudou registrace na webu povoleny."
+  },
+  "web.domains.signup.strategy_label": {
+    "text": "Strategie ověření"
+  },
+  "web.domains.signup.strategy_description": {
+    "text": "Zvol, jak se ověřují e-mailové adresy, když se uživatelé na této doméně registrují."
+  },
+  "web.domains.signup.network_validation_warning": {
+    "text": "Tato strategie během registrace provádí síťová volání, což může přidat latenci nebo může být některými poskytovateli blokováno."
+  },
+  "web.domains.signup.allowed_domains_label": {
+    "text": "Povolené domény pro registraci"
+  },
+  "web.domains.signup.allowed_domains_hint": {
+    "text": "Zaregistrovat se budou moci pouze tyto e-mailové domény. Přidej jednu doménu na položku."
+  },
+  "web.domains.signup.domain_placeholder": {
+    "text": "example.com"
+  },
+  "web.domains.signup.invalid_domain": {
+    "text": "Zadej prosím platnou doménu (např. example.com)"
+  },
+  "web.domains.signup.domain_exists": {
+    "text": "Tato doména už je v seznamu"
+  },
+  "web.domains.signup.remove_domain": {
+    "text": "Odebrat {domain}"
+  },
+  "web.domains.signup.enabled_label": {
+    "text": "Povolit ověření pro jednotlivé domény"
+  },
+  "web.domains.signup.enabled_hint": {
+    "text": "Pokud je povoleno, registrace na této doméně používají výše uvedenou strategii místo globálních zásad."
+  },
+  "web.domains.signup.delete_config": {
+    "text": "Smazat konfiguraci"
+  },
+  "web.domains.signup.delete_confirm": {
+    "text": "Smazat konfiguraci ověření registrace? Registrace se vrátí ke globálním zásadám."
+  },
+  "web.domains.signup.save_config": {
+    "text": "Uložit konfiguraci"
+  },
+  "web.domains.signup.update_success": {
+    "text": "Ověření registrace bylo úspěšně aktualizováno"
+  },
+  "web.domains.signup.delete_success": {
+    "text": "Konfigurace ověření registrace byla úspěšně odebrána"
+  },
+  "web.domains.signup.domain_overrides_label": {
+    "text": "Přepsání domény"
+  },
+  "web.domains.signup.domain_overrides_hint": {
+    "text": "Přepsat globální nastavení registrace pro tuto doménu"
+  },
+  "web.domains.signup.signup_enabled_label": {
+    "text": "Registrace povolena"
+  },
+  "web.domains.signup.signup_enabled_hint": {
+    "text": "Přepsat, zda je pro tuto doménu povolena registrace"
+  },
+  "web.domains.signup.autoverify_label": {
+    "text": "Automaticky ověřovat účty"
+  },
+  "web.domains.signup.autoverify_hint": {
+    "text": "Přepsat, zda jsou nové účty na této doméně automaticky ověřovány"
+  },
+  "web.domains.sso.title": {
+    "text": "Jednotné přihlášení"
+  },
+  "web.domains.sso.config_title": {
+    "text": "Konfigurace SSO"
+  },
+  "web.domains.sso.config_description": {
+    "text": "Nakonfiguruj ověření jednotným přihlášením pro tuto doménu"
+  },
+  "web.domains.sso.access_denied": {
+    "text": "Přístup odepřen"
+  },
+  "web.domains.sso.access_denied_description": {
+    "text": "Nemáš oprávnění spravovat nastavení SSO pro tuto doménu. Kontaktuj správce své organizace."
+  },
+  "web.domains.sso.upgrade_to_configure": {
+    "text": "Pro konfiguraci jednotného přihlášení pro tuto doménu přejdi na vyšší plán."
+  },
+  "web.domains.sso.create_success": {
+    "text": "Konfigurace SSO byla úspěšně vytvořena"
+  },
+  "web.domains.sso.update_success": {
+    "text": "Konfigurace SSO byla úspěšně aktualizována"
+  },
+  "web.domains.sso.delete_success": {
+    "text": "Konfigurace SSO byla úspěšně odebrána"
+  },
+  "web.domains.sso.test_success": {
+    "text": "Test připojení byl úspěšný — poskytovatel odpověděl správně"
+  },
+  "web.domains.sso.test_failed": {
+    "text": "Test připojení se nezdařil"
+  },
+  "web.domains.sso.enforce_moved_notice": {
+    "text": "Chceš-li vyžadovat SSO pro všechna přihlášení na této doméně, nakonfiguruj to v nastavení přihlášení dané domény. Režim pouze SSO omezuje přihlašovací stránku na poskytovatele SSO nakonfigurovaného zde."
+  },
+  "web.domains.sso.configure_sso": {
+    "text": "Nakonfigurovat SSO"
+  },
+  "web.domains.sso.not_configured_notice": {
+    "text": "SSO pro tuto doménu zatím není nakonfigurováno. Povol jednotné přihlášení, aby se členové týmu mohli ověřovat pomocí poskytovatele identity tvé organizace."
+  },
+  "web.domains.sso.edit_credentials": {
+    "text": "Upravit přihlašovací údaje"
+  },
+  "web.domains.sso.configure_button": {
+    "text": "Nakonfigurovat"
+  },
+  "web.domains.sso.upgrade_required": {
+    "text": "Pro konfiguraci přejdi na vyšší plán"
   }
 }

--- a/locales/content/cs/workspace-organizations.json
+++ b/locales/content/cs/workspace-organizations.json
@@ -578,5 +578,344 @@
   "web.organizations.invitations.expires_soon": {
     "text": "Brzy vyprší",
     "source_hash": "a5dcfef9"
+  },
+  "api.organizations.errors.not_found": {
+    "text": "Organizace nenalezena: %{extid}"
+  },
+  "api.organizations.errors.owner_required": {
+    "text": "Tuto akci může provést pouze vlastník organizace"
+  },
+  "api.organizations.errors.admin_required": {
+    "text": "Tuto akci mohou provést pouze vlastníci a správci organizace"
+  },
+  "api.organizations.errors.member_required": {
+    "text": "Pro provedení této akce musíš být členem organizace"
+  },
+  "api.organizations.invitations.errors.create_admin_required": {
+    "text": "Pozvánky mohou vytvářet pouze vlastníci a správci organizace"
+  },
+  "api.organizations.invitations.errors.resend_admin_required": {
+    "text": "Pozvánky mohou znovu odesílat pouze vlastníci a správci organizace"
+  },
+  "api.organizations.invitations.errors.view_admin_required": {
+    "text": "Pozvánky mohou zobrazit pouze vlastníci a správci organizace"
+  },
+  "api.organizations.invitations.errors.revoke_admin_required": {
+    "text": "Pozvánky mohou zrušit pouze vlastníci a správci organizace"
+  },
+  "api.organizations.invitations.errors.email_required": {
+    "text": "E-mail je povinný"
+  },
+  "api.organizations.invitations.errors.email_invalid": {
+    "text": "Neplatný formát e-mailu"
+  },
+  "api.organizations.invitations.errors.role_invalid": {
+    "text": "Role musí být člen nebo správce"
+  },
+  "api.organizations.invitations.errors.cannot_invite_owner": {
+    "text": "Nelze pozvat jako vlastníka"
+  },
+  "api.organizations.invitations.errors.already_member": {
+    "text": "Uživatel je již členem této organizace"
+  },
+  "api.organizations.invitations.errors.already_pending": {
+    "text": "Pro tento e-mail již existuje nevyřízená pozvánka"
+  },
+  "api.organizations.invitations.errors.member_limit_reached": {
+    "text": "Byl dosažen limit členů. Pro pozvání dalších členů přejdi na vyšší plán."
+  },
+  "api.organizations.invitations.errors.not_found": {
+    "text": "Pozvánka nebyla nalezena"
+  },
+  "api.organizations.invitations.errors.cannot_resend_non_pending": {
+    "text": "Znovu odeslat lze pouze nevyřízené pozvánky"
+  },
+  "api.organizations.invitations.errors.cannot_revoke_non_pending": {
+    "text": "Zrušit lze pouze nevyřízené pozvánky"
+  },
+  "api.organizations.invitations.errors.resend_limit_reached": {
+    "text": "Byl dosažen maximální limit opětovných odeslání (%{max})"
+  },
+  "api.organizations.invitations.errors.accept_token_required": {
+    "text": "Je vyžadován token"
+  },
+  "api.organizations.invitations.errors.accept_organization_gone": {
+    "text": "Organizace již neexistuje"
+  },
+  "api.organizations.invitations.errors.accept_already_acted": {
+    "text": "Pozvánka již má stav: %{status}"
+  },
+  "api.organizations.invitations.errors.accept_expired": {
+    "text": "Platnost pozvánky vypršela"
+  },
+  "api.organizations.invitations.errors.accept_email_mismatch": {
+    "text": "Tvoje e-mailová adresa neodpovídá pozvánce"
+  },
+  "api.organizations.invitations.errors.accept_already_member": {
+    "text": "Již jsi členem této organizace"
+  },
+  "web.organizations.entitlements_title": {
+    "text": "Oprávnění organizace"
+  },
+  "web.organizations.page_description_short": {
+    "text": "Zobraz a nakonfiguruj své pracovní prostory"
+  },
+  "web.organizations.delete_organization_remove_domains_first": {
+    "text": "Před smazáním této organizace odeber všechny vlastní domény."
+  },
+  "web.organizations.default_org_delete_notice_title": {
+    "text": "Smazání této organizace"
+  },
+  "web.organizations.default_org_delete_notice_before": {
+    "text": "Toto je tvá výchozí organizace a nelze ji z přehledu odebrat. Chceš-li ji smazat, kontaktuj nás prosím prostřednictvím"
+  },
+  "web.organizations.default_org_delete_notice_link": {
+    "text": "formuláře zpětné vazby"
+  },
+  "web.organizations.default_org_delete_notice_after": {
+    "text": "."
+  },
+  "web.organizations.leave_organization": {
+    "text": "Opustit tuto organizaci"
+  },
+  "web.organizations.leave_organization_warning": {
+    "text": "Ztratíš přístup k této organizaci a jejím zdrojům."
+  },
+  "web.organizations.leave_organization_confirm_title": {
+    "text": "Opustit organizaci"
+  },
+  "web.organizations.leave_organization_confirm_message": {
+    "text": "Opravdu chceš opustit {name}? K opětovnému připojení budeš potřebovat novou pozvánku."
+  },
+  "web.organizations.leave_organization_success": {
+    "text": "Opustil jsi organizaci."
+  },
+  "web.organizations.leave_error": {
+    "text": "Opuštění organizace se nezdařilo"
+  },
+  "web.organizations.organizations": {
+    "text": "Organizace"
+  },
+  "web.organizations.invitations.invited_by_inline": {
+    "text": "od {email}"
+  },
+  "web.organizations.invitations.invited_as_inline": {
+    "text": "jako {role}"
+  },
+  "web.organizations.invitations.back_to_home": {
+    "text": "Zpět na domovskou stránku"
+  },
+  "web.organizations.invitations.email_locked_hint": {
+    "text": "Tato pozvánka byla zaslána na tuto e-mailovou adresu"
+  },
+  "web.organizations.invitations.signup_continue": {
+    "text": "Pokračovat"
+  },
+  "web.organizations.invitations.signin_continue": {
+    "text": "Přihlásit se"
+  },
+  "web.organizations.invitations.confirm_join_below": {
+    "text": "Téměř hotovo — potvrď níže připojení k organizaci."
+  },
+  "web.organizations.invitations.go_to_organizations": {
+    "text": "Přejít na Organizace"
+  },
+  "web.organizations.invitations.already_member": {
+    "text": "Již jsi členem této organizace"
+  },
+  "web.organizations.invitations.join_organization": {
+    "text": "Připojit se k {orgName}"
+  },
+  "web.organizations.invitations.sign_in_to_join": {
+    "text": "Přihlas se a připoj se k {orgName}"
+  },
+  "web.organizations.invitations.decline": {
+    "text": "Odmítnout"
+  },
+  "web.organizations.members.member_quota": {
+    "text": "{used} z {limit} členů"
+  },
+  "web.organizations.members.pending_suffix": {
+    "text": "(nevyřízeno: {count})"
+  },
+  "web.organizations.members.limit_reached_hint": {
+    "text": "Byl dosažen limit členů."
+  },
+  "web.organizations.sso.title": {
+    "text": "Jednotné přihlášení (SSO)"
+  },
+  "web.organizations.sso.description": {
+    "text": "Nakonfiguruj SSO, aby se členové mohli přihlašovat pomocí poskytovatele identity tvé organizace"
+  },
+  "web.organizations.sso.provider_type": {
+    "text": "Typ poskytovatele"
+  },
+  "web.organizations.sso.provider_type_description": {
+    "text": "Vyber poskytovatele identity své organizace"
+  },
+  "web.organizations.sso.display_name": {
+    "text": "Zobrazované jméno"
+  },
+  "web.organizations.sso.display_name_hint": {
+    "text": "Přátelský název zobrazený uživatelům při přihlašování"
+  },
+  "web.organizations.sso.display_name_placeholder": {
+    "text": "např. Acme Corp SSO"
+  },
+  "web.organizations.sso.client_id": {
+    "text": "Client ID"
+  },
+  "web.organizations.sso.client_id_placeholder": {
+    "text": "Tvé OAuth client ID"
+  },
+  "web.organizations.sso.client_secret": {
+    "text": "Client Secret"
+  },
+  "web.organizations.sso.client_secret_placeholder": {
+    "text": "Tvé OAuth client secret"
+  },
+  "web.organizations.sso.client_secret_update_hint": {
+    "text": "Ponech prázdné pro zachování stávajícího secretu"
+  },
+  "web.organizations.sso.tenant_id": {
+    "text": "Tenant ID"
+  },
+  "web.organizations.sso.tenant_id_hint": {
+    "text": "Identifikátor tvého tenanta Azure AD / Entra ID"
+  },
+  "web.organizations.sso.tenant_id_placeholder": {
+    "text": "např. 12345678-1234-1234-1234-123456789abc"
+  },
+  "web.organizations.sso.issuer": {
+    "text": "Issuer URL"
+  },
+  "web.organizations.sso.issuer_hint": {
+    "text": "OIDC discovery URL tvého poskytovatele identity"
+  },
+  "web.organizations.sso.issuer_placeholder": {
+    "text": "např. https://login.example.com"
+  },
+  "web.organizations.sso.view_discovery_document": {
+    "text": "Zobrazit discovery dokument"
+  },
+  "web.organizations.sso.callback_url": {
+    "text": "Callback URL"
+  },
+  "web.organizations.sso.callback_url_hint": {
+    "text": "Přidej tuto URL do povolených redirect URI svého poskytovatele identity"
+  },
+  "web.organizations.sso.allowed_domains": {
+    "text": "Povolené e-mailové domény"
+  },
+  "web.organizations.sso.allowed_domains_hint": {
+    "text": "Přihlásit se mohou pouze uživatelé s e-mailovými adresami z těchto domén. Ponech prázdné pro povolení všech domén."
+  },
+  "web.organizations.sso.domain_placeholder": {
+    "text": "např. acme.com"
+  },
+  "web.organizations.sso.invalid_domain": {
+    "text": "Zadej prosím platnou doménu (např. example.com)"
+  },
+  "web.organizations.sso.domain_exists": {
+    "text": "Tato doména už je v seznamu"
+  },
+  "web.organizations.sso.remove_domain": {
+    "text": "Odebrat {domain}"
+  },
+  "web.organizations.sso.enabled": {
+    "text": "Povolit SSO"
+  },
+  "web.organizations.sso.enabled_hint": {
+    "text": "Pokud je povoleno, členové organizace se mohou přihlašovat pomocí tohoto poskytovatele SSO"
+  },
+  "web.organizations.sso.enforce_sso_only": {
+    "text": "Vynutit pouze SSO"
+  },
+  "web.organizations.sso.enforce_sso_only_hint": {
+    "text": "Vyžadovat SSO pro všechna přihlášení na této doméně. Pokud je povoleno, ověření pomocí hesla je zakázáno."
+  },
+  "web.organizations.sso.grant_org_scope": {
+    "text": "Udělit přístup k celé organizaci"
+  },
+  "web.organizations.sso.grant_org_scope_hint": {
+    "text": "Novým členům, kteří se připojí prostřednictvím SSO této domény, bude udělen přístup ke všem doménám organizace. Stávajících členů se to netýká. Pokud je zakázáno (výchozí), noví členové mají přístup pouze k této doméně."
+  },
+  "web.organizations.sso.save_config": {
+    "text": "Uložit konfiguraci SSO"
+  },
+  "web.organizations.sso.delete_config": {
+    "text": "Smazat konfiguraci"
+  },
+  "web.organizations.sso.delete_confirm": {
+    "text": "Jsi si jistý? Tímto zakážeš SSO pro svou organizaci."
+  },
+  "web.organizations.sso.load_error": {
+    "text": "Načtení konfigurace SSO se nezdařilo"
+  },
+  "web.organizations.sso.save_error": {
+    "text": "Uložení konfigurace SSO se nezdařilo"
+  },
+  "web.organizations.sso.create_success": {
+    "text": "Konfigurace SSO byla úspěšně vytvořena"
+  },
+  "web.organizations.sso.update_success": {
+    "text": "Konfigurace SSO byla úspěšně aktualizována"
+  },
+  "web.organizations.sso.delete_success": {
+    "text": "Konfigurace SSO byla úspěšně smazána"
+  },
+  "web.organizations.sso.delete_error": {
+    "text": "Smazání konfigurace SSO se nezdařilo"
+  },
+  "web.organizations.sso.test_connection": {
+    "text": "Otestovat připojení"
+  },
+  "web.organizations.sso.test_connection_hint": {
+    "text": "Ověř, že je poskytovatel identity dostupný (neověřuje přihlašovací údaje)"
+  },
+  "web.organizations.sso.test_button": {
+    "text": "Otestovat připojení"
+  },
+  "web.organizations.sso.testing": {
+    "text": "Probíhá testování..."
+  },
+  "web.organizations.sso.test_error": {
+    "text": "Test připojení se nezdařil"
+  },
+  "web.organizations.sso.auth_endpoint": {
+    "text": "Autorizační endpoint"
+  },
+  "web.organizations.sso.missing_fields": {
+    "text": "Chybějící pole"
+  },
+  "web.organizations.sso.status_enabled": {
+    "text": "Povoleno"
+  },
+  "web.organizations.sso.status_configured": {
+    "text": "Nakonfigurováno"
+  },
+  "web.organizations.sso.domain_sso_title": {
+    "text": "SSO domény"
+  },
+  "web.organizations.sso.domain_sso_description": {
+    "text": "Nakonfiguruj SSO pro každou ověřenou doménu"
+  },
+  "web.organizations.sso.provider_type_locked_hint": {
+    "text": "Chceš-li změnit poskytovatele, nejprve smaž tuto konfiguraci"
+  },
+  "web.organizations.sso.status_not_configured": {
+    "text": "Nenakonfigurováno"
+  },
+  "web.organizations.sso.no_domains": {
+    "text": "Žádné ověřené domény"
+  },
+  "web.organizations.sso.no_domains_description": {
+    "text": "Před konfigurací SSO přidej a ověř doménu."
+  },
+  "web.organizations.tabs.team": {
+    "text": "Tým"
+  },
+  "web.organizations.tabs.sso": {
+    "text": "SSO"
   }
 }


### PR DESCRIPTION
## `cs` translation update

Automated export of completed **cs** translations from the translation task DB.
Scope: `locales/content/cs/` only — 27 file(s), +1848/-30.

✅ `i18n validate variables`: no variable mismatches.

> ⚠️ `main` has also modified `locales/content/cs/` since this branch was cut — it may need a rebase/merge before it is conflict-free.

---

### Local quality review

> Produced by a fresh, isolated `claude` review agent (model `claude-sonnet-5`, agent `saas-translator`) that read
> `locales/AGENT_TRANSLATION_PROTOCOL.md` and inspected this branch's diff before the PR was opened.

Good enough. I have sufficient evidence now. Let me finalize the review.

**Verdict:** ⚠️ Needs review — 6 keys missing entirely from cs

**Summary:** Token/variable preservation is clean across all touched files (zero mismatches), and the Delano→"Tým podpory" signature migration is applied consistently. However, three files are missing keys that exist in the English source, meaning the task queue wasn't fully drained before this diff was cut.

**Critical (must fix):**
- `web.layout.colonels_only_badge` (en: "Colonels Only") — entirely absent from `cs/10-layout.json`.
- `web.auth.verify.resend_help_text`, `.resend_button`, `.resend_sent`, `.resend_error` — all four absent from `cs/session-auth.json` (resend-verification-email UI has no Czech strings).
- `web.domains.email.from_address_local_placeholder` — absent from `cs/workspace-domains.json` (en: "no-reply", verbatim-carveout string, but the key itself is missing).

**Warnings:** None.

**Notes:**
- `web.INSTRUCTION.phishing_warning`: "zkontroluj doménu regionu" correctly reflects the English source's "check the region domain" — not a mistranslation, verified against source.
- The `*._guidance.context` entries (session-auth-extended.json ×2, session-auth.json ×1) are synthetic keys not present in the English flat key set, but they duplicate the English `_guidance.context` metadata verbatim — consistent with this project's established doc-metadata carve-out pattern seen in other locales.
- ~70 identical cs/en leaves are legitimate carve-outs (brand names, icon-library names, SSO/DNS/tech labels, placeholders, punctuation-only strings).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
