### PR TITLE
i18n: update de translations

### DIFF
--- a/locales/content/de/00-common.json
+++ b/locales/content/de/00-common.json
@@ -1299,7 +1299,7 @@
     "source_hash": "fc78d9cb"
   },
   "web.INSTRUCTION.phishing_warning": {
-    "text": "Überprüfe immer, ob du auf der offiziellen {product_name}-Website bist. Betrüger erstellen manchmal gefälschte Websites, die genau wie {product_name} aussehen, um deine Geheimnisse zu stehlen. Um Phishing-Angriffe zu vermeiden, überprüfe die Domain, bevor du neue Links erstellst.",
+    "text": "Vergewissere dich immer, dass du dich auf der offiziellen {product_name}-Website befindest. Betrüger erstellen manchmal gefälschte Websites, die genau wie {product_name} aussehen, um deine Geheimnisse zu stehlen. Um Phishing-Angriffe zu vermeiden, überprüfe die Regions-Domain, bevor du neue Links erstellst.",
     "source_hash": "b588f5b2"
   },
   "web.pricing.title": {
@@ -1383,5 +1383,110 @@
     "text": "Upgrade, um weitere Funktionen freizuschalten",
     "context": "Description shown for free plan users encouraging upgrade",
     "source_hash": "783f174c"
+  },
+  "api.errors.authentication_required": {
+    "text": "Authentifizierung erforderlich"
+  },
+  "api.errors.sso_only_action_blocked": {
+    "text": "Diese Aktion ist im reinen SSO-Modus nicht verfügbar"
+  },
+  "web.COMMON.configure": {
+    "text": "Konfigurieren"
+  },
+  "web.COMMON.copy_to_clipboard": {
+    "text": "In die Zwischenablage kopieren"
+  },
+  "web.COMMON.add": {
+    "text": "Hinzufügen"
+  },
+  "web.COMMON.enabled": {
+    "text": "Aktiviert"
+  },
+  "web.COMMON.disabled": {
+    "text": "Deaktiviert"
+  },
+  "web.COMMON.yes_delete": {
+    "text": "Ja, löschen"
+  },
+  "web.COMMON.error_code": {
+    "text": "Fehlercode"
+  },
+  "web.COMMON.http_status": {
+    "text": "HTTP-Status"
+  },
+  "web.COMMON.details": {
+    "text": "Details"
+  },
+  "web.COMMON.field_confirm_password": {
+    "text": "Passwort bestätigen"
+  },
+  "web.COMMON.passwords_must_match": {
+    "text": "Die Passwörter müssen übereinstimmen"
+  },
+  "web.COMMON.and": {
+    "text": "und"
+  },
+  "web.COMMON.or": {
+    "text": "oder"
+  },
+  "web.COMMON.copied": {
+    "text": "Kopiert"
+  },
+  "web.COMMON.copy": {
+    "text": "Kopieren"
+  },
+  "web.COMMON.copy_email": {
+    "text": "E-Mail-Adresse kopieren"
+  },
+  "web.COMMON.copy_id": {
+    "text": "Konto-ID kopieren"
+  },
+  "web.COMMON.org_id_tooltip": {
+    "text": "Die eindeutige Kennung deiner Organisation"
+  },
+  "web.COMMON.success": {
+    "text": "Erfolg"
+  },
+  "web.COMMON.need_help": {
+    "text": "Brauchst du Hilfe"
+  },
+  "web.COMMON.open_help_dialog": {
+    "text": "Hilfedialog öffnen"
+  },
+  "web.COMMON.focus_is_now_in_the_main_text_area": {
+    "text": "Der Fokus befindet sich jetzt im Haupttextbereich"
+  },
+  "web.LABELS.show_passphrase": {
+    "text": "Passphrase anzeigen"
+  },
+  "web.LABELS.hide_passphrase": {
+    "text": "Passphrase ausblenden"
+  },
+  "web.LABELS.copy_icon": {
+    "text": "Kopiersymbol"
+  },
+  "web.LABELS.copied_icon": {
+    "text": "Kopiert-Symbol"
+  },
+  "web.STATUS.unverified": {
+    "text": "Nicht verifiziert"
+  },
+  "web.TITLES.domain_detail": {
+    "text": "Domain-Einstellungen"
+  },
+  "web.TITLES.domain_signin": {
+    "text": "Anmeldekonfiguration"
+  },
+  "web.TITLES.domain_sso": {
+    "text": "Domain-SSO"
+  },
+  "web.TITLES.domain_signup": {
+    "text": "Domain-Registrierungsvalidierung"
+  },
+  "web.TITLES.domain_email": {
+    "text": "E-Mail-Konfiguration"
+  },
+  "web.TITLES.domain_incoming": {
+    "text": "Eingehende Nachrichten"
   }
 }

--- a/locales/content/de/10-layout.json
+++ b/locales/content/de/10-layout.json
@@ -148,7 +148,7 @@
     "source_hash": "b9766df3"
   },
   "web.help.secret_view_faq.what_am_i_looking_at.description": {
-    "text": "Du siehst eine sichere Nachricht, die über {product_name} mit dir geteilt wurde. Dieser Inhalt wird nur einmal angezeigt und dann dauerhaft von unseren Servern gelöscht.",
+    "text": "Du siehst eine sichere Nachricht, die über {product_name} mit dir geteilt wurde. Dieser Inhalt wird nur einmal angezeigt und anschließend dauerhaft von unseren Servern gelöscht.",
     "source_hash": "e0f1a10c"
   },
   "web.help.secret_view_faq.can_i_view_again.title": {
@@ -338,5 +338,11 @@
   "web.layout.workspace_context": {
     "text": "Arbeitsbereichskontext",
     "source_hash": "dc6fa4f5"
+  },
+  "web.footer.workspace": {
+    "text": "Arbeitsbereich"
+  },
+  "web.help.default_content": {
+    "text": "Bitte wende dich an den Support, um Unterstützung zu erhalten"
   }
 }

--- a/locales/content/de/admin-colonel.json
+++ b/locales/content/de/admin-colonel.json
@@ -634,5 +634,152 @@
   "web.colonel.feedback.when_you_submit_feedback_well_see": {
     "text": "Wenn du Feedback sendest, sehen wir:",
     "source_hash": "fe77172e"
+  },
+  "web.colonel.previewPlanMode": {
+    "text": "Tarifvorschau-Modus"
+  },
+  "web.colonel.previewModeDescription": {
+    "text": "Sieh dir die Anwendung so an, wie sie Kunden mit einem anderen Tarif angezeigt wird. Dies wirkt sich nur auf deine Ansicht aus und ändert nicht den tatsächlichen Tarif einer Organisation."
+  },
+  "web.colonel.previewModeActive": {
+    "text": "Vorschau aktiv"
+  },
+  "web.colonel.bannedIps.empty": {
+    "text": "Keine gesperrten IPs"
+  },
+  "web.colonel.bannedIps.currentIp": {
+    "text": "Deine aktuelle IP-Adresse"
+  },
+  "web.colonel.bannedIps.confirmUnban": {
+    "text": "{ip} entsperren?"
+  },
+  "web.colonel.bannedIps.actions.ban": {
+    "text": "IP sperren"
+  },
+  "web.colonel.bannedIps.actions.quickBan": {
+    "text": "Schnellsperre"
+  },
+  "web.colonel.bannedIps.actions.unban": {
+    "text": "Entsperren"
+  },
+  "web.colonel.bannedIps.actions.cancel": {
+    "text": "Abbrechen"
+  },
+  "web.colonel.bannedIps.columns.ipAddress": {
+    "text": "IP-Adresse"
+  },
+  "web.colonel.bannedIps.columns.reason": {
+    "text": "Grund"
+  },
+  "web.colonel.bannedIps.columns.bannedAt": {
+    "text": "Gesperrt am"
+  },
+  "web.colonel.bannedIps.columns.bannedBy": {
+    "text": "Gesperrt von"
+  },
+  "web.colonel.bannedIps.error.banFailed": {
+    "text": "IP-Adresse konnte nicht gesperrt werden"
+  },
+  "web.colonel.bannedIps.error.unbanFailed": {
+    "text": "IP-Adresse konnte nicht entsperrt werden"
+  },
+  "web.colonel.bannedIps.form.title": {
+    "text": "IP-Adresse sperren"
+  },
+  "web.colonel.bannedIps.form.ipLabel": {
+    "text": "IP-Adresse"
+  },
+  "web.colonel.bannedIps.form.reasonLabel": {
+    "text": "Grund"
+  },
+  "web.colonel.bannedIps.form.reasonPlaceholder": {
+    "text": "Optionaler Grund"
+  },
+  "web.colonel.bannedIps.success.banned": {
+    "text": "Die IP-Adresse {ip} wurde gesperrt"
+  },
+  "web.colonel.bannedIps.success.unbanned": {
+    "text": "Die IP-Adresse {ip} wurde entsperrt"
+  },
+  "web.colonel.customDomains.empty": {
+    "text": "Keine benutzerdefinierten Domains konfiguriert"
+  },
+  "web.colonel.customDomains.noLogo": {
+    "text": "Kein Logo"
+  },
+  "web.colonel.customDomains.labels.organization": {
+    "text": "Organisation"
+  },
+  "web.colonel.customDomains.labels.externalId": {
+    "text": "Externe ID"
+  },
+  "web.colonel.customDomains.labels.created": {
+    "text": "Erstellt"
+  },
+  "web.colonel.customDomains.labels.updated": {
+    "text": "Aktualisiert"
+  },
+  "web.colonel.customDomains.labels.favicon": {
+    "text": "Favicon"
+  },
+  "web.colonel.customDomains.status.verified": {
+    "text": "Verifiziert"
+  },
+  "web.colonel.customDomains.status.resolving": {
+    "text": "Wird aufgelöst"
+  },
+  "web.colonel.customDomains.status.ready": {
+    "text": "Bereit"
+  },
+  "web.colonel.customDomains.status.publicHomepage": {
+    "text": "Öffentliche Startseite"
+  },
+  "web.colonel.customDomains.status.publicApi": {
+    "text": "Öffentliche API"
+  },
+  "web.colonel.customDomains.status.pending": {
+    "text": "Ausstehend"
+  },
+  "web.colonel.pagination.showing": {
+    "text": "{start}–{end} von {total} werden angezeigt"
+  },
+  "web.colonel.pagination.itemsPerPage": {
+    "text": "Einträge pro Seite"
+  },
+  "web.colonel.pagination.perPage": {
+    "text": "{count} pro Seite"
+  },
+  "web.colonel.pagination.pageOf": {
+    "text": "Seite {current} von {total}"
+  },
+  "web.colonel.secrets.empty": {
+    "text": "Keine Nachrichten gefunden"
+  },
+  "web.colonel.secrets.never": {
+    "text": "Nie"
+  },
+  "web.colonel.secrets.columns.shortId": {
+    "text": "Kurz-ID"
+  },
+  "web.colonel.secrets.columns.state": {
+    "text": "Status"
+  },
+  "web.colonel.secrets.columns.created": {
+    "text": "Erstellt"
+  },
+  "web.colonel.secrets.columns.expiration": {
+    "text": "Ablauf"
+  },
+  "web.colonel.secrets.columns.age": {
+    "text": "Alter (Tage)"
+  },
+  "web.colonel.secrets.state.new": {
+    "text": "Neu"
+  },
+  "web.colonel.secrets.state.received": {
+    "text": "Empfangen"
+  },
+  "web.colonel.secrets.state.viewed": {
+    "text": "Angesehen"
   }
 }

--- a/locales/content/de/api-account-errors.json
+++ b/locales/content/de/api-account-errors.json
@@ -1,0 +1,8 @@
+{
+  "api.account.errors.invalid_email": {
+    "text": "Ist das eine gültige E-Mail-Adresse?"
+  },
+  "api.account.errors.password_too_short": {
+    "text": "Das Passwort ist zu kurz"
+  }
+}

--- a/locales/content/de/api-domains-errors.json
+++ b/locales/content/de/api-domains-errors.json
@@ -1,0 +1,29 @@
+{
+  "api.domains.errors.domain_id_required": {
+    "text": "Domain-ID erforderlich"
+  },
+  "api.domains.errors.domain_not_found": {
+    "text": "Domain nicht gefunden: %{extid}"
+  },
+  "api.domains.errors.organization_not_found": {
+    "text": "Keine Organisation für die Domain gefunden: %{domain}"
+  },
+  "api.domains.errors.incoming_secrets_disabled": {
+    "text": "Eingehende Nachrichten sind auf dieser Instanz nicht aktiviert"
+  },
+  "api.domains.errors.incoming_secrets_entitlement_required": {
+    "text": "Die Verwaltung eingehender Nachrichten erfordert die Berechtigung „incoming_secrets“. Bitte führe ein Upgrade deines Tarifs durch."
+  },
+  "api.domains.errors.incoming_config_not_found": {
+    "text": "Keine Konfiguration für eingehende Nachrichten für die Domain gefunden: %{extid}"
+  },
+  "api.domains.errors.recipients_max_exceeded": {
+    "text": "Maximal %{max} Empfänger erlaubt"
+  },
+  "api.domains.errors.recipients_invalid_email": {
+    "text": "Ungültige E-Mail-Adresse: %{email}"
+  },
+  "api.domains.errors.recipients_duplicate": {
+    "text": "Doppelte Empfänger-E-Mail-Adressen sind nicht erlaubt"
+  }
+}

--- a/locales/content/de/api-entitlements-errors.json
+++ b/locales/content/de/api-entitlements-errors.json
@@ -1,0 +1,71 @@
+{
+  "api.entitlements.errors.context_unavailable": {
+    "text": "Berechtigungen können nicht überprüft werden (Organisationskontext nicht verfügbar)"
+  },
+  "api.entitlements.errors.api_access_required": {
+    "text": "Der API-Zugang erfordert ein Tarif-Upgrade"
+  },
+  "api.entitlements.errors.custom_privacy_defaults_required": {
+    "text": "Benutzerdefinierte Datenschutz-Voreinstellungen erfordern ein Tarif-Upgrade"
+  },
+  "api.entitlements.errors.extended_default_expiration_required": {
+    "text": "Eine verlängerte Standard-Ablaufzeit erfordert ein Tarif-Upgrade"
+  },
+  "api.entitlements.errors.custom_domains_required": {
+    "text": "Benutzerdefinierte Domains erfordern ein Tarif-Upgrade"
+  },
+  "api.entitlements.errors.custom_branding_required": {
+    "text": "Eigenes Branding erfordert ein Tarif-Upgrade"
+  },
+  "api.entitlements.errors.homepage_secrets_required": {
+    "text": "Nachrichten auf der Startseite erfordern ein Tarif-Upgrade"
+  },
+  "api.entitlements.errors.incoming_secrets_required": {
+    "text": "Eingehende Nachrichten erfordern ein Tarif-Upgrade"
+  },
+  "api.entitlements.errors.custom_mail_sender_required": {
+    "text": "Ein benutzerdefinierter Mail-Absender erfordert ein Tarif-Upgrade"
+  },
+  "api.entitlements.errors.flexible_from_domain_required": {
+    "text": "Eine flexible Absender-Domain erfordert ein Tarif-Upgrade"
+  },
+  "api.entitlements.errors.manage_org_required": {
+    "text": "Die Organisationsverwaltung erfordert ein Tarif-Upgrade"
+  },
+  "api.entitlements.errors.manage_teams_required": {
+    "text": "Die Teamverwaltung erfordert ein Tarif-Upgrade"
+  },
+  "api.entitlements.errors.manage_members_required": {
+    "text": "Die Mitgliederverwaltung erfordert ein Tarif-Upgrade"
+  },
+  "api.entitlements.errors.manage_sso_required": {
+    "text": "Die SSO-Verwaltung erfordert ein Tarif-Upgrade"
+  },
+  "api.entitlements.errors.audit_logs_required": {
+    "text": "Audit-Protokolle erfordern ein Tarif-Upgrade"
+  },
+  "api.entitlements.errors.custom_signup_validation_required": {
+    "text": "Eine benutzerdefinierte Registrierungsvalidierung erfordert ein Tarif-Upgrade"
+  },
+  "api.entitlements.errors.create_secrets_required": {
+    "text": "Das Erstellen von Nachrichten erfordert ein Tarif-Upgrade"
+  },
+  "api.entitlements.errors.view_receipt_required": {
+    "text": "Das Anzeigen von Belegen erfordert ein Tarif-Upgrade"
+  },
+  "api.entitlements.errors.notifications_required": {
+    "text": "Benachrichtigungen erfordern ein Tarif-Upgrade"
+  },
+  "api.entitlements.errors.workspace_branding_required": {
+    "text": "Arbeitsbereich-Branding erfordert ein Tarif-Upgrade"
+  },
+  "api.entitlements.errors.ip_access_rules_required": {
+    "text": "IP-Zugriffsregeln erfordern ein Tarif-Upgrade"
+  },
+  "api.entitlements.errors.manage_billing_required": {
+    "text": "Die Abrechnungsverwaltung erfordert ein Tarif-Upgrade"
+  },
+  "api.entitlements.errors.custom_signin_config_required": {
+    "text": "Eine benutzerdefinierte Anmeldekonfiguration erfordert ein Tarif-Upgrade"
+  }
+}

--- a/locales/content/de/api-feedback-errors.json
+++ b/locales/content/de/api-feedback-errors.json
@@ -1,0 +1,5 @@
+{
+  "api.feedback.errors.rate_limit_exceeded": {
+    "text": "Zu viele Feedback-Einsendungen. Bitte versuche es später erneut."
+  }
+}

--- a/locales/content/de/api-incoming-errors.json
+++ b/locales/content/de/api-incoming-errors.json
@@ -1,0 +1,5 @@
+{
+  "api.incoming.errors.custom_domain_unresolved": {
+    "text": "Die Organisation der benutzerdefinierten Domain konnte nicht aufgelöst werden"
+  }
+}

--- a/locales/content/de/api-invite-errors.json
+++ b/locales/content/de/api-invite-errors.json
@@ -1,0 +1,23 @@
+{
+  "api.invite.errors.invitation_not_found_or_expired": {
+    "text": "Einladung nicht gefunden oder abgelaufen"
+  },
+  "api.invite.errors.token_required": {
+    "text": "Token ist erforderlich"
+  },
+  "api.invite.errors.organization_no_longer_exists": {
+    "text": "Die Organisation existiert nicht mehr"
+  },
+  "api.invite.errors.invitation_already_processed": {
+    "text": "Die Einladung wurde bereits %{status}"
+  },
+  "api.invite.errors.invitation_expired": {
+    "text": "Die Einladung ist abgelaufen"
+  },
+  "api.invite.errors.email_mismatch": {
+    "text": "Deine E-Mail-Adresse stimmt nicht mit der Einladung überein"
+  },
+  "api.invite.errors.already_member": {
+    "text": "Du bist bereits Mitglied dieser Organisation"
+  }
+}

--- a/locales/content/de/api-organizations-errors.json
+++ b/locales/content/de/api-organizations-errors.json
@@ -1,0 +1,107 @@
+{
+  "api.organizations.errors.domain_scoped_forbidden": {
+    "text": "Domain-gebundene Mitglieder können diese Aktion nicht ausführen"
+  },
+  "api.organizations.errors.organization_not_found": {
+    "text": "Organisation nicht gefunden: %{extid}"
+  },
+  "api.organizations.errors.organization_owner_required": {
+    "text": "Nur der Inhaber der Organisation kann diese Aktion ausführen"
+  },
+  "api.organizations.errors.organization_member_required": {
+    "text": "Du musst Mitglied der Organisation sein, um diese Aktion auszuführen"
+  },
+  "api.organizations.errors.organization_admin_required": {
+    "text": "Nur Inhaber und Admins der Organisation können diese Aktion ausführen"
+  },
+  "api.organizations.errors.extid_required": {
+    "text": "Organisations-ID erforderlich"
+  },
+  "api.organizations.errors.display_name_required": {
+    "text": "Der Name der Organisation ist erforderlich"
+  },
+  "api.organizations.errors.display_name_too_long": {
+    "text": "Der Name der Organisation muss kürzer als %{max} Zeichen sein"
+  },
+  "api.organizations.errors.description_too_long": {
+    "text": "Die Beschreibung muss kürzer als %{max} Zeichen sein"
+  },
+  "api.organizations.errors.contact_email_exists": {
+    "text": "Eine Organisation mit dieser Kontakt-E-Mail-Adresse existiert bereits"
+  },
+  "api.organizations.errors.creation_in_progress": {
+    "text": "Die Organisation wird gerade erstellt. Bitte versuche es erneut."
+  },
+  "api.organizations.errors.organization_limit_reached": {
+    "text": "Das Limit für Organisationen ist erreicht. Führe ein Upgrade deines Tarifs durch, um weitere Organisationen zu erstellen."
+  },
+  "api.organizations.invitations.errors.invitation_not_found": {
+    "text": "Einladung nicht gefunden"
+  },
+  "api.organizations.invitations.errors.email_required": {
+    "text": "E-Mail-Adresse ist erforderlich"
+  },
+  "api.organizations.invitations.errors.invalid_email_format": {
+    "text": "Ungültiges E-Mail-Format"
+  },
+  "api.organizations.invitations.errors.invalid_role": {
+    "text": "Die Rolle muss Mitglied oder Admin sein"
+  },
+  "api.organizations.invitations.errors.cannot_invite_as_owner": {
+    "text": "Einladung als Inhaber nicht möglich"
+  },
+  "api.organizations.invitations.errors.user_already_member": {
+    "text": "Der Benutzer ist bereits Mitglied dieser Organisation"
+  },
+  "api.organizations.invitations.errors.invitation_already_pending": {
+    "text": "Für diese E-Mail-Adresse liegt bereits eine ausstehende Einladung vor"
+  },
+  "api.organizations.invitations.errors.member_limit_reached": {
+    "text": "Das Mitgliederlimit ist erreicht. Führe ein Upgrade deines Tarifs durch, um weitere Mitglieder einzuladen."
+  },
+  "api.organizations.invitations.errors.resend_only_pending": {
+    "text": "Nur ausstehende Einladungen können erneut gesendet werden"
+  },
+  "api.organizations.invitations.errors.resend_limit_reached": {
+    "text": "Maximales Limit für erneutes Senden (%{max}) erreicht"
+  },
+  "api.organizations.invitations.errors.revoke_only_pending": {
+    "text": "Nur ausstehende Einladungen können widerrufen werden"
+  },
+  "api.organizations.members.errors.member_not_found": {
+    "text": "Mitglied nicht gefunden: %{extid}"
+  },
+  "api.organizations.members.errors.member_not_in_organization": {
+    "text": "Mitglied in dieser Organisation nicht gefunden"
+  },
+  "api.organizations.members.errors.member_not_active": {
+    "text": "Das Mitglied ist nicht aktiv"
+  },
+  "api.organizations.members.errors.invalid_role_value": {
+    "text": "Ungültige Rolle. Muss eine der folgenden sein: %{roles}"
+  },
+  "api.organizations.members.errors.cannot_change_owner_role": {
+    "text": "Die Inhaberrolle kann nicht geändert werden. Verwende stattdessen die Eigentumsübertragung."
+  },
+  "api.organizations.members.errors.member_already_has_role": {
+    "text": "Das Mitglied hat bereits die Rolle: %{role}"
+  },
+  "api.organizations.members.errors.cannot_promote_to_owner": {
+    "text": "Eine Beförderung zum Inhaber ist nicht möglich. Verwende stattdessen die Eigentumsübertragung."
+  },
+  "api.organizations.members.errors.must_be_member": {
+    "text": "Du musst Mitglied dieser Organisation sein"
+  },
+  "api.organizations.members.errors.cannot_remove_owner": {
+    "text": "Der Inhaber der Organisation kann nicht entfernt werden. Übertrage zuerst das Eigentum."
+  },
+  "api.organizations.members.errors.cannot_remove_self": {
+    "text": "Du kannst dich nicht selbst entfernen. Verlasse stattdessen die Organisation."
+  },
+  "api.organizations.members.errors.admin_cannot_remove_admin": {
+    "text": "Admins können keine anderen Admins entfernen. Nur Inhaber können das."
+  },
+  "api.organizations.members.errors.no_permission_to_remove": {
+    "text": "Du hast keine Berechtigung, Mitglieder zu entfernen"
+  }
+}

--- a/locales/content/de/api-secrets-errors.json
+++ b/locales/content/de/api-secrets-errors.json
@@ -1,0 +1,11 @@
+{
+  "api.secrets.errors.domain_permission_authenticated_non_owner": {
+    "text": "Du hast keine Berechtigung, die Domain zu verwenden: %{domain}"
+  },
+  "api.secrets.errors.domain_public_sharing_disabled": {
+    "text": "Öffentliches Teilen ist für die Domain deaktiviert: %{domain}"
+  },
+  "api.secrets.errors.domain_permission_anonymous_cross_domain": {
+    "text": "Du hast keine Berechtigung, die Domain zu verwenden: %{domain}"
+  }
+}

--- a/locales/content/de/email.json
+++ b/locales/content/de/email.json
@@ -60,7 +60,7 @@
     "source_hash": "88c72144"
   },
   "email.welcome.signature": {
-    "text": "Delano",
+    "text": "Support-Team",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -100,7 +100,7 @@
     "source_hash": "fbb7eb2d"
   },
   "email.password_request.signature": {
-    "text": "Delano",
+    "text": "Support-Team",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -145,7 +145,7 @@
     "source_hash": "1863f5be"
   },
   "email.magic_link.signature": {
-    "text": "Delano",
+    "text": "Support-Team",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -230,7 +230,7 @@
     "source_hash": "3f6b45dd"
   },
   "email.secret_revealed.signature": {
-    "text": "Delano",
+    "text": "Support-Team",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -355,7 +355,7 @@
     "source_hash": "734882d2"
   },
   "email.organization_invitation.signature": {
-    "text": "Delano",
+    "text": "Support-Team",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -395,7 +395,7 @@
     "source_hash": "be92cff3"
   },
   "email.password_changed.signature": {
-    "text": "Delano",
+    "text": "Support-Team",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -445,7 +445,7 @@
     "source_hash": "f8d47b82"
   },
   "email.email_changed.signature": {
-    "text": "Delano",
+    "text": "Support-Team",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -495,7 +495,7 @@
     "source_hash": "f8d47b82"
   },
   "email.email_change_requested.signature": {
-    "text": "Delano",
+    "text": "Support-Team",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -550,7 +550,7 @@
     "source_hash": "d4d835fc"
   },
   "email.email_change_confirmation.signature": {
-    "text": "Delano",
+    "text": "Support-Team",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -580,7 +580,7 @@
     "source_hash": "e7c11bb0"
   },
   "email.mfa_enabled.signature": {
-    "text": "Delano",
+    "text": "Support-Team",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -605,7 +605,7 @@
     "source_hash": "97ef0a3e"
   },
   "email.mfa_disabled.signature": {
-    "text": "Delano",
+    "text": "Support-Team",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -650,7 +650,7 @@
     "source_hash": "450c54c5"
   },
   "email.new_login_alert.signature": {
-    "text": "Delano",
+    "text": "Support-Team",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -670,7 +670,7 @@
     "source_hash": "d442beed"
   },
   "email.member_removed.signature": {
-    "text": "Delano",
+    "text": "Support-Team",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -690,7 +690,7 @@
     "source_hash": "c2280c0c"
   },
   "email.role_changed.signature": {
-    "text": "Delano",
+    "text": "Support-Team",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -710,7 +710,7 @@
     "source_hash": "7095fc69"
   },
   "email.organization_deleted.signature": {
-    "text": "Delano",
+    "text": "Support-Team",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -750,7 +750,7 @@
     "source_hash": "36008943"
   },
   "email.payment_receipt.signature": {
-    "text": "Delano",
+    "text": "Support-Team",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -775,7 +775,7 @@
     "source_hash": "926406b1"
   },
   "email.payment_failed.signature": {
-    "text": "Delano",
+    "text": "Support-Team",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -800,7 +800,7 @@
     "source_hash": "66a1419e"
   },
   "email.trial_expiring.signature": {
-    "text": "Delano",
+    "text": "Support-Team",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -825,7 +825,7 @@
     "source_hash": "5a96ae38"
   },
   "email.subscription_changed.signature": {
-    "text": "Delano",
+    "text": "Support-Team",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -853,5 +853,41 @@
     "text": "Onetime Secret",
     "renderer": "erb",
     "source_hash": "1cd0194a"
+  },
+  "email.common.secret_link_label": {
+    "text": "Nachrichten-Link"
+  },
+  "email.common.automated_notice": {
+    "text": "Dies ist eine automatische Nachricht von %{product_name}."
+  },
+  "email.common.support_label": {
+    "text": "Support"
+  },
+  "email.expiration_warning.signature": {
+    "text": "Support-Team"
+  },
+  "email.expiration_warning.footer_note": {
+    "text": "Du hast diese Nachricht erhalten, weil eine von dir auf %{product_name} erstellte Nachricht bald abläuft."
+  },
+  "email.feedback_email.user_id_label": {
+    "text": "Benutzer:"
+  },
+  "email.feedback_email.timezone_label": {
+    "text": "Zeitzone:"
+  },
+  "email.feedback_email.version_label": {
+    "text": "Version:"
+  },
+  "email.incoming_secret.footer_note": {
+    "text": "Du hast diese E-Mail erhalten, weil dir jemand über %{product_name} eine Nachricht gesendet hat. Wenn du sie nicht erwartet hast, kannst du diese E-Mail bedenkenlos ignorieren."
+  },
+  "email.secret_link.passphrase_label": {
+    "text": "Passphrase erforderlich:"
+  },
+  "email.secret_link.passphrase_required": {
+    "text": "Diese Nachricht ist mit einer Passphrase geschützt. Der Absender sollte sie dir separat mitteilen."
+  },
+  "email.secret_link.footer_note": {
+    "text": "Du hast diese E-Mail erhalten, weil %{sender_email} über %{product_name} eine Nachricht mit dir geteilt hat. Wenn du sie nicht erwartet hast, kannst du diese E-Mail bedenkenlos ignorieren."
   }
 }

--- a/locales/content/de/feature-feedback.json
+++ b/locales/content/de/feature-feedback.json
@@ -58,5 +58,14 @@
   "web.feedback.reason_email_change_unauthorized": {
     "text": "Es sieht so aus, als würdest du eine unautorisierte E-Mail-Änderung an deinem Konto melden. Bitte beschreibe, was passiert ist, und wir werden es sofort untersuchen.",
     "source_hash": "00e56551"
+  },
+  "web.feedback.anonymous_no_reply": {
+    "text": "Hinweis: Wenn du eine Antwort möchtest, gib bitte deinen Namen oder eine E-Mail-Adresse in der Nachricht an."
+  },
+  "web.feedback.characters_remaining": {
+    "text": "{count} Zeichen übrig"
+  },
+  "web.feedback.character_limit_reached": {
+    "text": "Zeichenlimit erreicht"
   }
 }

--- a/locales/content/de/feature-homepage-secrets.json
+++ b/locales/content/de/feature-homepage-secrets.json
@@ -1,0 +1,50 @@
+{
+  "homepage_secrets.disabled.members_only_eyebrow": {
+    "text": "Instanz nur für Mitglieder"
+  },
+  "homepage_secrets.disabled.private_instance_eyebrow": {
+    "text": "Private Instanz"
+  },
+  "homepage_secrets.disabled.team_link_headline": {
+    "text": "Dieser Link ist für das Team von {workspace}."
+  },
+  "homepage_secrets.disabled.signin_headline": {
+    "text": "Melde dich an, um einen {action} zu erstellen."
+  },
+  "homepage_secrets.disabled.signin_headline_action": {
+    "text": "Nachrichten-Link"
+  },
+  "homepage_secrets.disabled.team_subtitle": {
+    "text": "Nur autorisierte Teammitglieder bei {domain} können hier neue Einmal-Links erstellen. Empfänger können weiterhin jeden Link öffnen, der ihnen gesendet wurde."
+  },
+  "homepage_secrets.disabled.public_subtitle": {
+    "text": "Nur autorisierte Mitglieder dieser Instanz können neue Einmal-Links erstellen. Empfänger können weiterhin jeden Link öffnen, der ihnen gesendet wurde."
+  },
+  "homepage_secrets.disabled.signin_cta": {
+    "text": "Melde dich bei deinem Konto an"
+  },
+  "homepage_secrets.disabled.what_is_this": {
+    "text": "Was ist das?"
+  },
+  "homepage_secrets.disabled.trust_viewed_once": {
+    "text": "Einmal angesehen, dann weg"
+  },
+  "homepage_secrets.disabled.trust_zero_retained": {
+    "text": "Nichts wird gespeichert"
+  },
+  "homepage_secrets.disabled.promo_title": {
+    "text": "Neu: Kostenlose Tarife enthalten jetzt benutzerdefinierte Domains."
+  },
+  "homepage_secrets.disabled.promo_subtitle": {
+    "text": "Richte deine Domain auf Onetime Secret aus und verschicke Nachrichten unter deiner eigenen Marke."
+  },
+  "homepage_secrets.disabled.promo_learn_how": {
+    "text": "Mehr erfahren"
+  },
+  "homepage_secrets.disabled.logo_alt": {
+    "text": "{name}-Logo"
+  },
+  "homepage_secrets.disabled.opens_in_new_tab": {
+    "text": "(wird in einem neuen Tab geöffnet)"
+  }
+}

--- a/locales/content/de/feature-incoming.json
+++ b/locales/content/de/feature-incoming.json
@@ -130,5 +130,26 @@
   "incoming.receipt_link_text": {
     "text": "Quittung",
     "source_hash": "6f328609"
+  },
+  "incoming.upgrade_required_title": {
+    "text": "Upgrade erforderlich"
+  },
+  "incoming.upgrade_required_description": {
+    "text": "Diese Funktion erfordert ein Tarif-Upgrade. Bitte wende dich an den Inhaber des Kontos, um eingehende Nachrichten zu aktivieren."
+  },
+  "incoming.validation_memo_too_long": {
+    "text": "Die Notiz darf höchstens {max} Zeichen lang sein"
+  },
+  "incoming.validation_secret_required": {
+    "text": "Der Inhalt der Nachricht ist erforderlich"
+  },
+  "incoming.validation_recipient_required": {
+    "text": "Bitte wähle einen Empfänger aus"
+  },
+  "incoming.validation_feature_disabled": {
+    "text": "Die Funktion für eingehende Nachrichten ist nicht aktiviert"
+  },
+  "incoming.validation_form_errors": {
+    "text": "Bitte überprüfe das Formular auf Fehler"
   }
 }

--- a/locales/content/de/feature-regions.json
+++ b/locales/content/de/feature-regions.json
@@ -152,7 +152,7 @@
     "source_hash": "1d97f6bd"
   },
   "web.regions.changing_regions_billing_note": {
-    "text": "Wenn deine Rechnungskontakt-E-Mail von deiner {product_name} Konto-E-Mail abweicht, verwende die Rechnungskontakt-E-Mail für das neue Regionskonto, um deine Abonnementvorteile beizubehalten.",
+    "text": "Wenn deine Abrechnungskontakt-E-Mail von der E-Mail-Adresse deines {product_name}-Kontos abweicht, verwende die Abrechnungskontakt-E-Mail für das Konto der neuen Region, um deine Abonnementvorteile zu behalten.",
     "source_hash": "dac1cc28"
   },
   "web.regions.changing_regions_subscription_note": {
@@ -186,5 +186,8 @@
   "web.regions.jurisdictions.apac.name": {
     "text": "Asia-Pacific",
     "source_hash": "7a757670"
+  },
+  "web.regions.no_region_configured": {
+    "text": "Für dein Konto sind derzeit keine Regionsinformationen verfügbar."
   }
 }

--- a/locales/content/de/feature-translations.json
+++ b/locales/content/de/feature-translations.json
@@ -84,7 +84,7 @@
     "source_hash": "ba5c4395"
   },
   "web.translations.since_2012_onetime_secret_has_provided_a_secure_": {
-    "text": "Seit 2012 bietet {product_name} eine sichere Möglichkeit, sensible Informationen weltweit zu teilen. Mit Benutzern in Regionen, in denen Englisch nicht die Hauptsprache ist, sind genaue Übersetzungen unerlässlich, um sichere Kommunikation für alle zugänglich zu machen.",
+    "text": "Seit 2012 bietet {product_name} eine sichere Möglichkeit, vertrauliche Informationen weltweit zu teilen. Da unsere Nutzerinnen und Nutzer aus Regionen kommen, in denen Englisch nicht die Hauptsprache ist, sind genaue Übersetzungen unerlässlich, um sichere Kommunikation für alle zugänglich zu machen.",
     "source_hash": "87a6e9af"
   },
   "web.translations.help_secure_communication_go_global": {

--- a/locales/content/de/secret-homepage.json
+++ b/locales/content/de/secret-homepage.json
@@ -56,7 +56,7 @@
     "source_hash": "5e218489"
   },
   "web.homepage.visit_onetime_secret_home": {
-    "text": "{product_name} Startseite besuchen",
+    "text": "{product_name}-Startseite besuchen",
     "source_hash": "625556d2"
   },
   "web.homepage.password_generation_title": {
@@ -148,7 +148,7 @@
     "source_hash": "7872e050"
   },
   "web.homepage.onetime_secret_homepage": {
-    "text": "{product_name} Startseite",
+    "text": "{product_name}-Startseite",
     "source_hash": "44bb0581"
   },
   "web.homepage.send_sensitive_information_that_can_only_be_viewed_once": {
@@ -172,7 +172,7 @@
     "source_hash": "0990d163"
   },
   "web.homepage.onetime_secret_helps_us_share_sensitive_informat": {
-    "text": "{product_name} hilft uns, sensible Informationen sicher zu teilen und gleichzeitig unsere professionelle Fassade zu wahren.",
+    "text": "{product_name} hilft uns, vertrauliche Informationen sicher zu teilen und dabei unsere professionelle Fassade zu wahren.",
     "source_hash": "986a0856"
   },
   "web.homepage.information_shared_through_this_service_can_only": {

--- a/locales/content/de/secret-manage.json
+++ b/locales/content/de/secret-manage.json
@@ -128,7 +128,7 @@
     "source_hash": "07fe1b84"
   },
   "web.secrets.onetime_secret_is_a_secure_way_to_share_sensitiv": {
-    "text": "{product_name} ist ein sicherer Weg, sensible Informationen zu teilen, die sich nach einer einzigen Ansicht selbst zerstören.",
+    "text": "{product_name} ist eine sichere Möglichkeit, vertrauliche Informationen zu teilen, die sich nach einmaligem Ansehen selbst zerstören.",
     "source_hash": "8a163297"
   },
   "web.secrets.what_is_this": {
@@ -470,5 +470,11 @@
   },
   "web.private.send_feedback": {
     "text": "Feedback senden"
+  },
+  "web.receipt.open_link": {
+    "text": "Link öffnen"
+  },
+  "web.secrets.messageDeleted": {
+    "text": "Nachricht gelöscht"
   }
 }

--- a/locales/content/de/session-auth-extended.json
+++ b/locales/content/de/session-auth-extended.json
@@ -716,5 +716,20 @@
   },
   "web.auth.sessions._guidance.context": {
     "text": "Verwaltungsseite für angemeldete Geräte/Browser des Benutzers"
+  },
+  "web.auth.google": {
+    "text": "Google"
+  },
+  "web.auth.mfa.alternative_auth_options": {
+    "text": "Alternative Authentifizierungsoptionen"
+  },
+  "web.auth.remember.enabled": {
+    "text": "Angemeldet bleiben"
+  },
+  "web.auth.sessions.session_singular": {
+    "text": "Sitzung"
+  },
+  "web.auth.sessions.session_plural": {
+    "text": "Sitzungen"
   }
 }

--- a/locales/content/de/session-auth.json
+++ b/locales/content/de/session-auth.json
@@ -398,5 +398,32 @@
   },
   "web.auth.verify._guidance.context": {
     "text": "E-Mail-Verifizierungsablauf nach der Registrierung"
+  },
+  "web.auth.account.sso_linked": {
+    "text": "SSO-Konto"
+  },
+  "web.help.reset_password_link": {
+    "text": "Passwort zurücksetzen"
+  },
+  "web.login.custom_domain_sso_title": {
+    "text": "Single Sign-On ist für diese Domain verfügbar"
+  },
+  "web.login.custom_domain_sso_description": {
+    "text": "Der Administrator der Organisation kann SSO aktivieren, damit sich Teammitglieder hier anmelden können. Wende dich für den Zugang an den Admin."
+  },
+  "web.login.signin_disabled_heading": {
+    "text": "Anmeldung ist nicht verfügbar"
+  },
+  "web.login.signin_disabled_message": {
+    "text": "Die Anmeldung ist auf dieser Domain derzeit nicht verfügbar."
+  },
+  "web.login.errors.sso_not_configured": {
+    "text": "Single Sign-On ist für diese Domain nicht konfiguriert. Bitte wende dich an deinen Administrator."
+  },
+  "web.login.errors.invalid_email": {
+    "text": "Die E-Mail-Adresse von deinem Identitätsanbieter ist ungültig. Bitte wende dich an deinen Administrator."
+  },
+  "web.login.errors.domain_not_allowed": {
+    "text": "Deine E-Mail-Domain ist nicht für die SSO-Registrierung autorisiert. Bitte wende dich an deinen Administrator."
   }
 }

--- a/locales/content/de/workspace-account.json
+++ b/locales/content/de/workspace-account.json
@@ -682,5 +682,14 @@
   "web.settings.profile.didnt_receive_email": {
     "text": "E-Mail nicht erhalten?",
     "source_hash": "fe3ac3ad"
+  },
+  "web.settings.api.api_disabled_notice": {
+    "text": "Die API ist für diese Instanz deaktiviert."
+  },
+  "web.settings.security.sso_managed_title": {
+    "text": "Sicherheit über SSO verwaltet"
+  },
+  "web.settings.security.sso_managed_description": {
+    "text": "Dein Konto wird über den Single-Sign-On-Anbieter deiner Organisation authentifiziert. Passwort, Multi-Faktor-Authentifizierung und Wiederherstellungscodes werden von deinem Identitätsanbieter verwaltet."
   }
 }

--- a/locales/content/de/workspace-billing.json
+++ b/locales/content/de/workspace-billing.json
@@ -988,5 +988,47 @@
     "text": "Nur in deiner ursprünglichen Abonnementregion verfügbar",
     "context": "Hint shown on plan cards when currency does not match active subscription",
     "source_hash": "10de32e5"
+  },
+  "web.billing.already_subscribed": {
+    "text": "Du hast diesen Tarif bereits abonniert."
+  },
+  "web.billing.cancel.reactivate_button": {
+    "text": "Abonnement reaktivieren"
+  },
+  "web.billing.cancel.reactivate_success": {
+    "text": "Dein Abonnement wurde reaktiviert. Dir wird wie gewohnt weiterhin in Rechnung gestellt."
+  },
+  "web.billing.cancel.reactivate_error": {
+    "text": "Das Abonnement konnte nicht reaktiviert werden. Bitte versuche es erneut oder wende dich an den Support."
+  },
+  "web.billing.features.manage_orgs": {
+    "text": "Organisationsverwaltung"
+  },
+  "web.billing.features.flexible_from_domain": {
+    "text": "Flexible Absender-Domain für E-Mails"
+  },
+  "web.billing.features.unlimited_admins": {
+    "text": "Unbegrenzte Administratoren"
+  },
+  "web.billing.features.manage_sso": {
+    "text": "SSO"
+  },
+  "web.billing.overview.entitlements.flexible_from_domain": {
+    "text": "Flexible Absender-Domain für E-Mails"
+  },
+  "web.billing.overview.entitlements.manage_orgs": {
+    "text": "Organisationen verwalten"
+  },
+  "web.billing.overview.entitlements.manage_sso": {
+    "text": "Single Sign-On (SSO)"
+  },
+  "web.billing.overview.entitlements.manage_billing": {
+    "text": "Abrechnung verwalten"
+  },
+  "web.billing.overview.entitlements.custom_signup_validation": {
+    "text": "Benutzerdefinierte Registrierungsvalidierung"
+  },
+  "web.billing.plans.reactivate": {
+    "text": "Reaktivieren"
   }
 }

--- a/locales/content/de/workspace-branding.json
+++ b/locales/content/de/workspace-branding.json
@@ -178,5 +178,11 @@
   "web.branding.upgrade_to_customize": {
     "text": "Upgrade deinen Tarif, um das Branding für diese Domain anzupassen.",
     "source_hash": "9077bf79"
+  },
+  "web.branding.saved_successfully": {
+    "text": "Branding-Einstellungen erfolgreich gespeichert"
+  },
+  "web.branding.keyhole_logo_icon": {
+    "text": "Schlüssellochsymbol, das für sicheres, privates Teilen steht"
   }
 }

--- a/locales/content/de/workspace-dashboard.json
+++ b/locales/content/de/workspace-dashboard.json
@@ -22,5 +22,14 @@
   "web.dashboard.fetch_error_description": {
     "text": "Beim Laden deiner Daten ist ein Problem aufgetreten. Bitte versuche es erneut.",
     "source_hash": "ff0d904e"
+  },
+  "web.teams.create_first_team_title": {
+    "text": "Erstelle dein erstes Team"
+  },
+  "web.teams.create_first_team_description": {
+    "text": "Mit Teams kannst du gemeinsam mit anderen in einem geteilten Arbeitsbereich zusammenarbeiten."
+  },
+  "web.teams.create_team": {
+    "text": "Team erstellen"
   }
 }

--- a/locales/content/de/workspace-domains.json
+++ b/locales/content/de/workspace-domains.json
@@ -846,5 +846,389 @@
   "web.domains.sso.not_configured_notice": {
     "text": "SSO ist für diese Domain noch nicht konfiguriert. Aktiviere Single Sign-On, um Teammitgliedern die Authentifizierung über den Identitätsanbieter deiner Organisation zu ermöglichen.",
     "source_hash": "c439214b"
+  },
+  "api.domains.errors.add_admin_required": {
+    "text": "Nur Inhaber und Admins der Organisation können benutzerdefinierte Domains hinzufügen"
+  },
+  "web.domains.public_homepage": {
+    "text": "Öffentliche Startseite"
+  },
+  "web.domains.status_tooltip_active": {
+    "text": "Domain verifiziert und aktiv"
+  },
+  "web.domains.status_tooltip_dns_incorrect": {
+    "text": "DNS nicht konfiguriert — zum Beheben klicken"
+  },
+  "web.domains.status_tooltip_not_verified": {
+    "text": "Domain nicht verifiziert — zum Verifizieren klicken"
+  },
+  "web.domains.status_tooltip_unverified": {
+    "text": "Domain-Status nicht verifiziert — zum Aktualisieren klicken"
+  },
+  "web.domains.last_check_failed": {
+    "text": "Letzte Verifizierungsprüfung fehlgeschlagen"
+  },
+  "web.domains.last_check_failed_ago": {
+    "text": "letzte Prüfung fehlgeschlagen {0}"
+  },
+  "web.domains.verify_now": {
+    "text": "Jetzt verifizieren"
+  },
+  "web.domains.click_to_verify": {
+    "text": "zum Verifizieren klicken"
+  },
+  "web.domains.remove_domain_description": {
+    "text": "Diese Domain und ihre gesamte Konfiguration dauerhaft entfernen."
+  },
+  "web.domains.add_access_denied": {
+    "text": "Zugriff verweigert"
+  },
+  "web.domains.add_access_denied_description": {
+    "text": "Du hast keine Berechtigung, Domains zu dieser Organisation hinzuzufügen. Wende dich an deinen Organisationsadministrator."
+  },
+  "web.domains.dns_widget_load_failed": {
+    "text": "DNS-Widget konnte nicht geladen werden"
+  },
+  "web.domains.dns_widget_not_available": {
+    "text": "DNS-Widget nicht verfügbar"
+  },
+  "web.domains.dns_widget_init_failed": {
+    "text": "DNS-Widget konnte nicht initialisiert werden"
+  },
+  "web.domains.verified": {
+    "text": "Verifiziert"
+  },
+  "web.domains.pending_verification": {
+    "text": "Verifizierung ausstehend"
+  },
+  "web.domains.unsaved_changes_confirmation": {
+    "text": "Du hast ungespeicherte Änderungen. Möchtest du die Seite wirklich verlassen?"
+  },
+  "web.domains.entitlement_required_owner": {
+    "text": "Diese Funktion erfordert ein Tarif-Upgrade."
+  },
+  "web.domains.entitlement_required_member": {
+    "text": "Diese Funktion ist in deinem aktuellen Tarif nicht verfügbar. Wende dich an den Inhaber deiner Organisation."
+  },
+  "web.domains.detail.manage": {
+    "text": "Verwalten"
+  },
+  "web.domains.detail.features": {
+    "text": "Features"
+  },
+  "web.domains.detail.homepage_title": {
+    "text": "Startseiten-Nachrichten"
+  },
+  "web.domains.detail.homepage_description": {
+    "text": "Öffentlichen Zugriff erlauben, um Nachrichten auf der Startseite deiner Domain zu erstellen"
+  },
+  "web.domains.detail.brand_description": {
+    "text": "Logo, Farben und eigenes Branding"
+  },
+  "web.domains.detail.sso_description": {
+    "text": "Einstellungen für den Single-Sign-On-Anbieter"
+  },
+  "web.domains.detail.email_description": {
+    "text": "Konfiguration für eigenen E-Mail-Absender"
+  },
+  "web.domains.detail.incoming_description": {
+    "text": "Empfängereinstellungen für eingehende Nachrichten"
+  },
+  "web.domains.detail.signup_description": {
+    "text": "Registrierungsvalidierungsstrategie pro Domain"
+  },
+  "web.domains.detail.signin_description": {
+    "text": "Konfiguration der Anmeldemethode pro Domain"
+  },
+  "web.domains.email.dns_check_label": {
+    "text": "DNS"
+  },
+  "web.domains.email.provider_check_label": {
+    "text": "Anbieter"
+  },
+  "web.domains.email.test_email_title": {
+    "text": "E-Mail-Zustellung testen"
+  },
+  "web.domains.email.test_email_hint": {
+    "text": "Sende dir mit der gespeicherten Konfiguration eine Test-E-Mail. Funktioniert auch, wenn die Funktion noch nicht aktiviert ist."
+  },
+  "web.domains.email.send_test": {
+    "text": "Test senden"
+  },
+  "web.domains.email.test_email_sent": {
+    "text": "Test-E-Mail erfolgreich gesendet"
+  },
+  "web.domains.email.test_email_failed": {
+    "text": "Test-E-Mail konnte nicht gesendet werden"
+  },
+  "web.domains.email.test_email_sent_to": {
+    "text": "Gesendet an {email}"
+  },
+  "web.domains.email.delivered_via": {
+    "text": "Zugestellt über {provider}"
+  },
+  "web.domains.incoming.feature_disabled": {
+    "text": "Eingehende Nachrichten nicht verfügbar"
+  },
+  "web.domains.incoming.feature_disabled_description": {
+    "text": "Eingehende Nachrichten sind auf dieser Instanz nicht aktiviert. Wende dich an deinen Administrator."
+  },
+  "web.domains.signin.title": {
+    "text": "Anmeldekonfiguration"
+  },
+  "web.domains.signin.configure_signin": {
+    "text": "Anmeldung konfigurieren"
+  },
+  "web.domains.signin.config_description": {
+    "text": "Konfiguriere die Anmelde-Authentifizierungsmethoden für diese Domain"
+  },
+  "web.domains.signin.access_denied": {
+    "text": "Zugriff verweigert"
+  },
+  "web.domains.signin.upgrade_to_configure": {
+    "text": "Führe ein Upgrade deines Tarifs durch, um Anmeldemethoden für diese Domain zu konfigurieren."
+  },
+  "web.domains.signin.not_configured_notice": {
+    "text": "Für diese Domain ist noch keine Anmeldekonfiguration festgelegt. Konfiguriere Überschreibungen, um zu steuern, welche Authentifizierungsmethoden auf der Anmeldeseite dieser Domain verfügbar sind."
+  },
+  "web.domains.signin.signin_enabled_label": {
+    "text": "Anmeldung aktiviert"
+  },
+  "web.domains.signin.header_toggle_label": {
+    "text": "Anmeldung"
+  },
+  "web.domains.signin.signin_enabled_hint": {
+    "text": "Ob Benutzer sich auf dieser Domain anmelden können"
+  },
+  "web.domains.signin.restrict_to_label": {
+    "text": "Anmeldemethode einschränken"
+  },
+  "web.domains.signin.restrict_to_hint": {
+    "text": "Beschränke diese Domain auf eine einzige Authentifizierungsmethode. Wenn festgelegt, wird auf der Anmeldeseite nur die gewählte Methode angezeigt."
+  },
+  "web.domains.signin.all_methods": {
+    "text": "Alle Methoden"
+  },
+  "web.domains.signin.all_methods_description": {
+    "text": "Alle aktivierten Authentifizierungsmethoden auf der Anmeldeseite anzeigen"
+  },
+  "web.domains.signin.method_password": {
+    "text": "Passwort"
+  },
+  "web.domains.signin.method_email_auth": {
+    "text": "E-Mail-Authentifizierung"
+  },
+  "web.domains.signin.method_webauthn": {
+    "text": "WebAuthn / Passkeys"
+  },
+  "web.domains.signin.method_sso": {
+    "text": "Single Sign-On"
+  },
+  "web.domains.signin.method_overrides_label": {
+    "text": "Methodenüberschreibungen"
+  },
+  "web.domains.signin.method_overrides_hint": {
+    "text": "Einzelne Authentifizierungsmethoden für diese Domain aktivieren oder deaktivieren"
+  },
+  "web.domains.signin.mode_question": {
+    "text": "Wie können sich Benutzer anmelden?"
+  },
+  "web.domains.signin.mode_any": {
+    "text": "Jede verfügbare Methode"
+  },
+  "web.domains.signin.mode_any_hint": {
+    "text": "Jede auf dieser Domain verfügbare Methode anzeigen. Schränke einzelne Methoden unten ein."
+  },
+  "web.domains.signin.mode_one": {
+    "text": "Eine bestimmte Methode"
+  },
+  "web.domains.signin.mode_one_hint": {
+    "text": "Beschränke die Anmeldeseite auf eine einzige Methode. Es werden nur die auf dieser Domain verfügbaren Methoden aufgeführt."
+  },
+  "web.domains.signin.mode_disabled": {
+    "text": "Anmeldung deaktiviert"
+  },
+  "web.domains.signin.mode_disabled_hint": {
+    "text": "Benutzer können sich auf dieser Domain nicht anmelden."
+  },
+  "web.domains.signin.mode_disabled_notice": {
+    "text": "Besucher der Anmeldeseite dieser Domain sehen einen Hinweis, dass die Anmeldung nicht verfügbar ist, mit einem Link zurück zur Startseite. Deine vorherigen Methodeneinstellungen bleiben erhalten und werden wiederhergestellt, wenn du die Anmeldung wieder aktivierst."
+  },
+  "web.domains.signin.methods_list_label": {
+    "text": "Auf der Anmeldeseite angezeigte Methoden"
+  },
+  "web.domains.signin.restrict_picker_hint": {
+    "text": "Es werden nur die auf dieser Domain verfügbaren Methoden aufgeführt."
+  },
+  "web.domains.signin.availability_always": {
+    "text": "Immer verfügbar"
+  },
+  "web.domains.signin.availability_global_on": {
+    "text": "Folgt der globalen Richtlinie · Ein"
+  },
+  "web.domains.signin.availability_global_off": {
+    "text": "Nicht verfügbar"
+  },
+  "web.domains.signin.availability_unavailable": {
+    "text": "Seitenweit nicht verfügbar"
+  },
+  "web.domains.signin.allow_on_domain": {
+    "text": "Auf dieser Domain erlauben"
+  },
+  "web.domains.signin.method_password_blurb": {
+    "text": "Nur Passwort"
+  },
+  "web.domains.signin.method_email_auth_blurb": {
+    "text": "Passwortlose Anmeldung per Magic-Link"
+  },
+  "web.domains.signin.method_webauthn_blurb": {
+    "text": "Biometrie und Sicherheitsschlüssel"
+  },
+  "web.domains.signin.method_sso_blurb": {
+    "text": "Externer Identitätsanbieter"
+  },
+  "web.domains.signin.email_auth_label": {
+    "text": "E-Mail-Authentifizierung"
+  },
+  "web.domains.signin.email_auth_hint": {
+    "text": "Passwortlose E-Mail-Authentifizierung auf dieser Domain erlauben"
+  },
+  "web.domains.signin.sso_enabled_label": {
+    "text": "Single Sign-On"
+  },
+  "web.domains.signin.sso_enabled_hint": {
+    "text": "SSO-Authentifizierung auf dieser Domain erlauben"
+  },
+  "web.domains.signin.enabled_label": {
+    "text": "Anmeldekonfiguration aktivieren"
+  },
+  "web.domains.signin.enabled_hint": {
+    "text": "Wenn aktiviert, verwendet diese Domain die oben konfigurierten Anmeldeeinstellungen"
+  },
+  "web.domains.signin.save_config": {
+    "text": "Konfiguration speichern"
+  },
+  "web.domains.signin.update_success": {
+    "text": "Anmeldekonfiguration erfolgreich aktualisiert"
+  },
+  "web.domains.signin.reset_to_defaults": {
+    "text": "Auf Standardwerte zurücksetzen"
+  },
+  "web.domains.signin.reset_confirm": {
+    "text": "Anmeldung auf die globalen Standardwerte zurücksetzen?"
+  },
+  "web.domains.signin.reset_keeps_sso": {
+    "text": "Deine SSO-Anmeldedaten bleiben erhalten. Entferne sie separat auf dem SSO-Konfigurationsbildschirm."
+  },
+  "web.domains.signin.reset_action": {
+    "text": "Ja, zurücksetzen"
+  },
+  "web.domains.signin.reset_success": {
+    "text": "Anmeldeeinstellungen auf die globalen Standardwerte zurückgesetzt"
+  },
+  "web.domains.signup.title": {
+    "text": "Registrierungsvalidierung"
+  },
+  "web.domains.signup.config_description": {
+    "text": "Konfiguriere die Registrierungsvalidierung für diese Domain"
+  },
+  "web.domains.signup.access_denied": {
+    "text": "Zugriff verweigert"
+  },
+  "web.domains.signup.upgrade_to_configure": {
+    "text": "Führe ein Upgrade deines Tarifs durch, um die Registrierungsvalidierung pro Domain zu konfigurieren."
+  },
+  "web.domains.signup.configure_signup": {
+    "text": "Registrierung konfigurieren"
+  },
+  "web.domains.signup.not_configured_notice": {
+    "text": "Für diese Domain ist die Registrierungsvalidierung noch nicht konfiguriert. Konfiguriere eine Strategie, um zu steuern, wer sich über diese Domain registrieren kann."
+  },
+  "web.domains.signup.site_signups_disabled_warning": {
+    "text": "Registrierungen sind derzeit auf Site-Ebene deaktiviert. Diese domainspezifische Richtlinie ist konfiguriert, steuert aber keinen Traffic, bis die Registrierungen auf Site-Ebene aktiviert sind."
+  },
+  "web.domains.signup.strategy_label": {
+    "text": "Validierungsstrategie"
+  },
+  "web.domains.signup.strategy_description": {
+    "text": "Wähle aus, wie E-Mail-Adressen validiert werden, wenn sich Benutzer auf dieser Domain registrieren."
+  },
+  "web.domains.signup.network_validation_warning": {
+    "text": "Diese Strategie führt während der Registrierung Netzwerkaufrufe durch, die zu Latenz führen oder von einigen Anbietern blockiert werden können."
+  },
+  "web.domains.signup.allowed_domains_label": {
+    "text": "Zugelassene Registrierungs-Domains"
+  },
+  "web.domains.signup.allowed_domains_hint": {
+    "text": "Nur diese E-Mail-Domains dürfen sich registrieren. Füge eine Domain pro Eintrag hinzu."
+  },
+  "web.domains.signup.domain_placeholder": {
+    "text": "example.com"
+  },
+  "web.domains.signup.invalid_domain": {
+    "text": "Bitte gib eine gültige Domain ein (z. B. example.com)"
+  },
+  "web.domains.signup.domain_exists": {
+    "text": "Diese Domain ist bereits in der Liste"
+  },
+  "web.domains.signup.remove_domain": {
+    "text": "{domain} entfernen"
+  },
+  "web.domains.signup.enabled_label": {
+    "text": "Domainspezifische Validierung aktivieren"
+  },
+  "web.domains.signup.enabled_hint": {
+    "text": "Wenn aktiviert, verwenden Registrierungen auf dieser Domain die obige Strategie anstelle der globalen Richtlinie."
+  },
+  "web.domains.signup.delete_config": {
+    "text": "Konfiguration löschen"
+  },
+  "web.domains.signup.delete_confirm": {
+    "text": "Konfiguration der Registrierungsvalidierung löschen? Registrierungen greifen dann auf die globale Richtlinie zurück."
+  },
+  "web.domains.signup.save_config": {
+    "text": "Konfiguration speichern"
+  },
+  "web.domains.signup.update_success": {
+    "text": "Registrierungsvalidierung erfolgreich aktualisiert"
+  },
+  "web.domains.signup.delete_success": {
+    "text": "Konfiguration der Registrierungsvalidierung erfolgreich entfernt"
+  },
+  "web.domains.signup.domain_overrides_label": {
+    "text": "Domain-Überschreibungen"
+  },
+  "web.domains.signup.domain_overrides_hint": {
+    "text": "Globale Registrierungseinstellungen für diese Domain überschreiben"
+  },
+  "web.domains.signup.signup_enabled_label": {
+    "text": "Registrierung aktiviert"
+  },
+  "web.domains.signup.signup_enabled_hint": {
+    "text": "Überschreiben, ob die Registrierung für diese Domain aktiviert ist"
+  },
+  "web.domains.signup.autoverify_label": {
+    "text": "Konten automatisch verifizieren"
+  },
+  "web.domains.signup.autoverify_hint": {
+    "text": "Überschreiben, ob neue Konten auf dieser Domain automatisch verifiziert werden"
+  },
+  "web.domains.sso.test_success": {
+    "text": "Verbindungstest erfolgreich — der Anbieter hat korrekt geantwortet"
+  },
+  "web.domains.sso.test_failed": {
+    "text": "Verbindungstest fehlgeschlagen"
+  },
+  "web.domains.sso.enforce_moved_notice": {
+    "text": "Um SSO für alle Anmeldungen auf dieser Domain zu erzwingen, konfiguriere es in den Anmeldeeinstellungen der Domain. Der Nur-SSO-Modus beschränkt die Anmeldeseite auf den hier konfigurierten SSO-Anbieter."
+  },
+  "web.domains.sso.edit_credentials": {
+    "text": "Anmeldedaten bearbeiten"
+  },
+  "web.domains.sso.configure_button": {
+    "text": "Konfigurieren"
+  },
+  "web.domains.sso.upgrade_required": {
+    "text": "Upgrade zum Konfigurieren"
   }
 }

--- a/locales/content/de/workspace-organizations.json
+++ b/locales/content/de/workspace-organizations.json
@@ -770,5 +770,200 @@
   "web.organizations.sso.status_not_configured": {
     "text": "Nicht konfiguriert",
     "source_hash": "bbea960e"
+  },
+  "api.organizations.errors.not_found": {
+    "text": "Organisation nicht gefunden: %{extid}"
+  },
+  "api.organizations.errors.owner_required": {
+    "text": "Nur der Inhaber der Organisation kann diese Aktion ausführen"
+  },
+  "api.organizations.errors.admin_required": {
+    "text": "Nur Inhaber und Admins der Organisation können diese Aktion ausführen"
+  },
+  "api.organizations.errors.member_required": {
+    "text": "Du musst Mitglied der Organisation sein, um diese Aktion auszuführen"
+  },
+  "api.organizations.invitations.errors.create_admin_required": {
+    "text": "Nur Inhaber und Admins der Organisation können Einladungen erstellen"
+  },
+  "api.organizations.invitations.errors.resend_admin_required": {
+    "text": "Nur Inhaber und Admins der Organisation können Einladungen erneut senden"
+  },
+  "api.organizations.invitations.errors.view_admin_required": {
+    "text": "Nur Inhaber und Admins der Organisation können Einladungen anzeigen"
+  },
+  "api.organizations.invitations.errors.revoke_admin_required": {
+    "text": "Nur Inhaber und Admins der Organisation können Einladungen widerrufen"
+  },
+  "api.organizations.invitations.errors.email_required": {
+    "text": "E-Mail ist erforderlich"
+  },
+  "api.organizations.invitations.errors.email_invalid": {
+    "text": "Ungültiges E-Mail-Format"
+  },
+  "api.organizations.invitations.errors.role_invalid": {
+    "text": "Die Rolle muss Mitglied oder Admin sein"
+  },
+  "api.organizations.invitations.errors.cannot_invite_owner": {
+    "text": "Einladung als Inhaber nicht möglich"
+  },
+  "api.organizations.invitations.errors.already_member": {
+    "text": "Der Benutzer ist bereits Mitglied dieser Organisation"
+  },
+  "api.organizations.invitations.errors.already_pending": {
+    "text": "Für diese E-Mail steht bereits eine Einladung aus"
+  },
+  "api.organizations.invitations.errors.member_limit_reached": {
+    "text": "Mitgliederlimit erreicht. Führe ein Upgrade deines Tarifs durch, um weitere Mitglieder einzuladen."
+  },
+  "api.organizations.invitations.errors.not_found": {
+    "text": "Einladung nicht gefunden"
+  },
+  "api.organizations.invitations.errors.cannot_resend_non_pending": {
+    "text": "Es können nur ausstehende Einladungen erneut gesendet werden"
+  },
+  "api.organizations.invitations.errors.cannot_revoke_non_pending": {
+    "text": "Es können nur ausstehende Einladungen widerrufen werden"
+  },
+  "api.organizations.invitations.errors.resend_limit_reached": {
+    "text": "Maximales Limit für erneutes Senden (%{max}) erreicht"
+  },
+  "api.organizations.invitations.errors.accept_token_required": {
+    "text": "Token ist erforderlich"
+  },
+  "api.organizations.invitations.errors.accept_organization_gone": {
+    "text": "Die Organisation existiert nicht mehr"
+  },
+  "api.organizations.invitations.errors.accept_already_acted": {
+    "text": "Die Einladung wurde bereits %{status}"
+  },
+  "api.organizations.invitations.errors.accept_expired": {
+    "text": "Die Einladung ist abgelaufen"
+  },
+  "api.organizations.invitations.errors.accept_email_mismatch": {
+    "text": "Deine E-Mail-Adresse stimmt nicht mit der Einladung überein"
+  },
+  "api.organizations.invitations.errors.accept_already_member": {
+    "text": "Du bist bereits Mitglied dieser Organisation"
+  },
+  "web.organizations.entitlements_title": {
+    "text": "Organisationsberechtigungen"
+  },
+  "web.organizations.page_description_short": {
+    "text": "Deine Arbeitsbereiche anzeigen und konfigurieren"
+  },
+  "web.organizations.delete_organization_remove_domains_first": {
+    "text": "Entferne alle benutzerdefinierten Domains, bevor du diese Organisation löschst."
+  },
+  "web.organizations.default_org_delete_notice_title": {
+    "text": "Diese Organisation löschen"
+  },
+  "web.organizations.default_org_delete_notice_before": {
+    "text": "Dies ist deine Standardorganisation und kann nicht über das Dashboard entfernt werden. Um sie zu löschen, wende dich bitte über das"
+  },
+  "web.organizations.default_org_delete_notice_link": {
+    "text": "Feedback-Formular"
+  },
+  "web.organizations.default_org_delete_notice_after": {
+    "text": "an uns."
+  },
+  "web.organizations.leave_organization": {
+    "text": "Diese Organisation verlassen"
+  },
+  "web.organizations.leave_organization_warning": {
+    "text": "Du verlierst den Zugriff auf diese Organisation und ihre Ressourcen."
+  },
+  "web.organizations.leave_organization_confirm_title": {
+    "text": "Organisation verlassen"
+  },
+  "web.organizations.leave_organization_confirm_message": {
+    "text": "Möchtest du {name} wirklich verlassen? Du benötigst eine neue Einladung, um wieder beizutreten."
+  },
+  "web.organizations.leave_organization_success": {
+    "text": "Du hast die Organisation verlassen."
+  },
+  "web.organizations.leave_error": {
+    "text": "Verlassen der Organisation fehlgeschlagen"
+  },
+  "web.organizations.organizations": {
+    "text": "Organisationen"
+  },
+  "web.organizations.invitations.invited_by_inline": {
+    "text": "von {email}"
+  },
+  "web.organizations.invitations.invited_as_inline": {
+    "text": "als {role}"
+  },
+  "web.organizations.invitations.back_to_home": {
+    "text": "Zurück zur Startseite"
+  },
+  "web.organizations.invitations.email_locked_hint": {
+    "text": "Diese Einladung wurde an diese E-Mail-Adresse gesendet"
+  },
+  "web.organizations.invitations.signup_continue": {
+    "text": "Fortfahren"
+  },
+  "web.organizations.invitations.signin_continue": {
+    "text": "Anmelden"
+  },
+  "web.organizations.invitations.confirm_join_below": {
+    "text": "Fast geschafft — bestätige unten, um der Organisation beizutreten."
+  },
+  "web.organizations.invitations.go_to_organizations": {
+    "text": "Zu den Organisationen"
+  },
+  "web.organizations.invitations.already_member": {
+    "text": "Du bist bereits Mitglied dieser Organisation"
+  },
+  "web.organizations.invitations.join_organization": {
+    "text": "{orgName} beitreten"
+  },
+  "web.organizations.invitations.sign_in_to_join": {
+    "text": "Melde dich an, um {orgName} beizutreten"
+  },
+  "web.organizations.invitations.decline": {
+    "text": "Ablehnen"
+  },
+  "web.organizations.members.member_quota": {
+    "text": "{used} von {limit} Mitgliedern"
+  },
+  "web.organizations.members.pending_suffix": {
+    "text": "({count} ausstehend)"
+  },
+  "web.organizations.members.limit_reached_hint": {
+    "text": "Mitgliederlimit erreicht."
+  },
+  "web.organizations.sso.view_discovery_document": {
+    "text": "Discovery-Dokument anzeigen"
+  },
+  "web.organizations.sso.callback_url": {
+    "text": "Callback-URL"
+  },
+  "web.organizations.sso.callback_url_hint": {
+    "text": "Füge diese URL zu den erlaubten Weiterleitungs-URIs deines Identitätsanbieters hinzu"
+  },
+  "web.organizations.sso.enforce_sso_only": {
+    "text": "Nur SSO erzwingen"
+  },
+  "web.organizations.sso.enforce_sso_only_hint": {
+    "text": "SSO für alle Anmeldungen auf dieser Domain erzwingen. Wenn aktiviert, ist die passwortbasierte Authentifizierung deaktiviert."
+  },
+  "web.organizations.sso.grant_org_scope": {
+    "text": "Organisationsweiten Zugriff gewähren"
+  },
+  "web.organizations.sso.grant_org_scope_hint": {
+    "text": "Neue Mitglieder, die über das SSO dieser Domain beitreten, erhalten Zugriff auf alle Domains der Organisation. Bestehende Mitglieder sind davon nicht betroffen. Wenn deaktiviert (Standard), können neue Mitglieder nur auf diese Domain zugreifen."
+  },
+  "web.organizations.sso.no_domains": {
+    "text": "Keine verifizierten Domains"
+  },
+  "web.organizations.sso.no_domains_description": {
+    "text": "Füge eine Domain hinzu und verifiziere sie, bevor du SSO dafür konfigurierst."
+  },
+  "web.organizations.tabs.team": {
+    "text": "Team"
+  },
+  "web.organizations.tabs.sso": {
+    "text": "SSO"
   }
 }


### PR DESCRIPTION
## `de` translation update

Automated export of completed **de** translations from the translation task DB.
Scope: `locales/content/de/` only — 27 file(s), +1356/-27.

⚠️ `i18n validate variables` reports **1** variable mismatch(es) for `de` (empty values that drop source variables, renamed/extra vars, etc.) — see the review below.

---

### Local quality review

> Produced by a fresh, isolated `claude` review agent (model `claude-sonnet-5`, agent `saas-translator`) that read
> `locales/AGENT_TRANSLATION_PROTOCOL.md` and inspected this branch's diff before the PR was opened.

Good, all consistent. That's sufficient sampling. Now I have enough to write the review.

**Verdict:** ⚠️ Needs review — one variable-consistency bug found

**Summary:** Large, mostly clean batch of new/updated German strings (SSO, domains, billing, colonel, email) with consistent brand/variable preservation and the expected "Delano" → "Support-Team" signature update matching the English source rename. One pre-existing string carries an extra, unsanctioned variable.

**Critical (must fix):**
- `email.email_changed.body` (de/email.json): translation reads "...wurde am %{date} auf %{new_email_masked} geändert." but the English source (`email.email_changed.body`, en/email.json) has no `%{date}` — only `%{product_name}` and `%{new_email_masked}`. `%{date}` is not supplied by the mailer and will render literally or raise. Flagged by the automated variable check (`de-0701-error-1`). Remove `am %{date}` or confirm the mailer now passes `date` and update the English source too.

**Warnings:**
- None found in sampled strings — spot-checked several new keys (`web.regions.no_region_configured`, `api.domains.errors.add_admin_required`, phishing_warning "Regions-Domain") against English source; all variables/brand tokens match.

**Notes:**
- "Delano" → "Support-Team" signature change is intentional and matches the English source rename (`email.welcome.signature` etc.), applied consistently across all ~20 email templates.
- Several stylistic smoothing edits (e.g. "sensible" → "vertrauliche/sensible Informationen", phrasing tweaks in phishing_warning/regions notes) — no variable or brand issues, read as normal copy polish.
- Large batch adds many brand-new flat keys (SSO, colonel, billing, domains); none inspected show missing/extra placeholders.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
