### PR TITLE
i18n: update de_AT translations

### DIFF
--- a/locales/content/de_AT/00-common.json
+++ b/locales/content/de_AT/00-common.json
@@ -1299,7 +1299,7 @@
     "source_hash": "fc78d9cb"
   },
   "web.INSTRUCTION.phishing_warning": {
-    "text": "Vergewissern Sie sich immer, dass Sie sich auf der offiziellen {product_name}-Website befinden. Betrüger erstellen manchmal gefälschte Websites, die genauso aussehen wie {product_name}, um Ihre Geheimnisse zu stehlen. Um Phishing-Angriffe zu vermeiden, überprüfen Sie die Domain, bevor Sie neue Links erstellen.",
+    "text": "Vergewissern Sie sich immer, dass Sie sich auf der offiziellen {product_name}-Website befinden. Betrüger erstellen mitunter gefälschte Websites, die genau wie {product_name} aussehen, um Ihre Geheimnisse zu stehlen. Um Phishing-Angriffe zu vermeiden, überprüfen Sie den Regionen-Bereich, bevor Sie neue Links erstellen.",
     "source_hash": "b588f5b2"
   },
   "web.pricing.title": {
@@ -1383,5 +1383,110 @@
     "text": "Upgraden Sie, um weitere Funktionen freizuschalten",
     "context": "Description shown for free plan users encouraging upgrade",
     "source_hash": "783f174c"
+  },
+  "api.errors.authentication_required": {
+    "text": "Authentifizierung erforderlich"
+  },
+  "api.errors.sso_only_action_blocked": {
+    "text": "Diese Aktion ist im reinen SSO-Modus nicht verfügbar"
+  },
+  "web.COMMON.configure": {
+    "text": "Konfigurieren"
+  },
+  "web.COMMON.copy_to_clipboard": {
+    "text": "In die Zwischenablage kopieren"
+  },
+  "web.COMMON.add": {
+    "text": "Hinzufügen"
+  },
+  "web.COMMON.enabled": {
+    "text": "Aktiviert"
+  },
+  "web.COMMON.disabled": {
+    "text": "Deaktiviert"
+  },
+  "web.COMMON.yes_delete": {
+    "text": "Ja, löschen"
+  },
+  "web.COMMON.error_code": {
+    "text": "Fehlercode"
+  },
+  "web.COMMON.http_status": {
+    "text": "HTTP-Status"
+  },
+  "web.COMMON.details": {
+    "text": "Details"
+  },
+  "web.COMMON.field_confirm_password": {
+    "text": "Passwort bestätigen"
+  },
+  "web.COMMON.passwords_must_match": {
+    "text": "Die Passwörter müssen übereinstimmen"
+  },
+  "web.COMMON.and": {
+    "text": "und"
+  },
+  "web.COMMON.or": {
+    "text": "oder"
+  },
+  "web.COMMON.copied": {
+    "text": "Kopiert"
+  },
+  "web.COMMON.copy": {
+    "text": "Kopieren"
+  },
+  "web.COMMON.copy_email": {
+    "text": "E-Mail-Adresse kopieren"
+  },
+  "web.COMMON.copy_id": {
+    "text": "Konto-ID kopieren"
+  },
+  "web.COMMON.org_id_tooltip": {
+    "text": "Die eindeutige Kennung Ihrer Organisation"
+  },
+  "web.COMMON.success": {
+    "text": "Erfolg"
+  },
+  "web.COMMON.need_help": {
+    "text": "Brauchen Sie Hilfe"
+  },
+  "web.COMMON.open_help_dialog": {
+    "text": "Hilfe-Dialog öffnen"
+  },
+  "web.COMMON.focus_is_now_in_the_main_text_area": {
+    "text": "Der Fokus befindet sich jetzt im Haupttextbereich"
+  },
+  "web.LABELS.show_passphrase": {
+    "text": "Sicherheitsphrase anzeigen"
+  },
+  "web.LABELS.hide_passphrase": {
+    "text": "Sicherheitsphrase verbergen"
+  },
+  "web.LABELS.copy_icon": {
+    "text": "Symbol zum Kopieren"
+  },
+  "web.LABELS.copied_icon": {
+    "text": "Symbol für kopiert"
+  },
+  "web.STATUS.unverified": {
+    "text": "Nicht verifiziert"
+  },
+  "web.TITLES.domain_detail": {
+    "text": "Bereichseinstellungen"
+  },
+  "web.TITLES.domain_signin": {
+    "text": "Anmeldekonfiguration"
+  },
+  "web.TITLES.domain_sso": {
+    "text": "Bereichs-SSO"
+  },
+  "web.TITLES.domain_signup": {
+    "text": "Bereichs-Registrierungsvalidierung"
+  },
+  "web.TITLES.domain_email": {
+    "text": "E-Mail-Konfiguration"
+  },
+  "web.TITLES.domain_incoming": {
+    "text": "Eingehende Nachrichten"
   }
 }

--- a/locales/content/de_AT/00-common.json
+++ b/locales/content/de_AT/00-common.json
@@ -1299,7 +1299,7 @@
     "source_hash": "fc78d9cb"
   },
   "web.INSTRUCTION.phishing_warning": {
-    "text": "Vergewissern Sie sich immer, dass Sie sich auf der offiziellen {product_name}-Website befinden. Betrüger erstellen mitunter gefälschte Websites, die genau wie {product_name} aussehen, um Ihre Geheimnisse zu stehlen. Um Phishing-Angriffe zu vermeiden, überprüfen Sie den Regionen-Bereich, bevor Sie neue Links erstellen.",
+    "text": "Vergewissern Sie sich immer, dass Sie sich auf der offiziellen {product_name}-Website befinden. Betrüger erstellen mitunter gefälschte Websites, die genau wie {product_name} aussehen, um Ihre Geheimnisse zu stehlen. Um Phishing-Angriffe zu vermeiden, überprüfen Sie die Domain der Region, bevor Sie neue Links erstellen.",
     "source_hash": "b588f5b2"
   },
   "web.pricing.title": {

--- a/locales/content/de_AT/10-layout.json
+++ b/locales/content/de_AT/10-layout.json
@@ -148,7 +148,7 @@
     "source_hash": "b9766df3"
   },
   "web.help.secret_view_faq.what_am_i_looking_at.description": {
-    "text": "Sie sehen eine sichere Nachricht, die über {product_name} mit Ihnen geteilt wurde. Dieser Inhalt wird nur einmal angezeigt und dann dauerhaft von unseren Servern gelöscht.",
+    "text": "Sie sehen eine sichere Nachricht, die über {product_name} mit Ihnen geteilt wurde. Dieser Inhalt wird nur einmal angezeigt und anschließend dauerhaft von unseren Servern gelöscht.",
     "source_hash": "e0f1a10c"
   },
   "web.help.secret_view_faq.can_i_view_again.title": {
@@ -338,5 +338,11 @@
   "web.layout.workspace_context": {
     "text": "Arbeitsbereich-Kontext",
     "source_hash": "dc6fa4f5"
+  },
+  "web.footer.workspace": {
+    "text": "Workspace"
+  },
+  "web.help.default_content": {
+    "text": "Bitte wenden Sie sich an den Support, um Unterstützung zu erhalten"
   }
 }

--- a/locales/content/de_AT/admin-colonel.json
+++ b/locales/content/de_AT/admin-colonel.json
@@ -634,5 +634,152 @@
   "web.colonel.feedback.when_you_submit_feedback_well_see": {
     "text": "Wenn Sie Rückmeldung senden, sehen wir:",
     "source_hash": "fe77172e"
+  },
+  "web.colonel.previewPlanMode": {
+    "text": "Tarif-Vorschaumodus"
+  },
+  "web.colonel.previewModeDescription": {
+    "text": "Sehen Sie sich die Anwendung so an, wie sie Kunden mit einem anderen Tarif angezeigt wird. Dies betrifft nur Ihre Ansicht und ändert nicht den tatsächlichen Tarif einer Organisation."
+  },
+  "web.colonel.previewModeActive": {
+    "text": "Vorschau aktiv"
+  },
+  "web.colonel.bannedIps.empty": {
+    "text": "Keine gesperrten IPs"
+  },
+  "web.colonel.bannedIps.currentIp": {
+    "text": "Ihre aktuelle IP-Adresse"
+  },
+  "web.colonel.bannedIps.confirmUnban": {
+    "text": "Sperre für {ip} aufheben?"
+  },
+  "web.colonel.bannedIps.actions.ban": {
+    "text": "IP sperren"
+  },
+  "web.colonel.bannedIps.actions.quickBan": {
+    "text": "Schnellsperre"
+  },
+  "web.colonel.bannedIps.actions.unban": {
+    "text": "Sperre aufheben"
+  },
+  "web.colonel.bannedIps.actions.cancel": {
+    "text": "Abbrechen"
+  },
+  "web.colonel.bannedIps.columns.ipAddress": {
+    "text": "IP-Adresse"
+  },
+  "web.colonel.bannedIps.columns.reason": {
+    "text": "Grund"
+  },
+  "web.colonel.bannedIps.columns.bannedAt": {
+    "text": "Gesperrt am"
+  },
+  "web.colonel.bannedIps.columns.bannedBy": {
+    "text": "Gesperrt von"
+  },
+  "web.colonel.bannedIps.error.banFailed": {
+    "text": "IP-Adresse konnte nicht gesperrt werden"
+  },
+  "web.colonel.bannedIps.error.unbanFailed": {
+    "text": "Sperre der IP-Adresse konnte nicht aufgehoben werden"
+  },
+  "web.colonel.bannedIps.form.title": {
+    "text": "IP-Adresse sperren"
+  },
+  "web.colonel.bannedIps.form.ipLabel": {
+    "text": "IP-Adresse"
+  },
+  "web.colonel.bannedIps.form.reasonLabel": {
+    "text": "Grund"
+  },
+  "web.colonel.bannedIps.form.reasonPlaceholder": {
+    "text": "Optionaler Grund"
+  },
+  "web.colonel.bannedIps.success.banned": {
+    "text": "Die IP-Adresse {ip} wurde gesperrt"
+  },
+  "web.colonel.bannedIps.success.unbanned": {
+    "text": "Die Sperre der IP-Adresse {ip} wurde aufgehoben"
+  },
+  "web.colonel.customDomains.empty": {
+    "text": "Keine benutzerdefinierten Bereiche konfiguriert"
+  },
+  "web.colonel.customDomains.noLogo": {
+    "text": "Kein Logo"
+  },
+  "web.colonel.customDomains.labels.organization": {
+    "text": "Organisation"
+  },
+  "web.colonel.customDomains.labels.externalId": {
+    "text": "Externe ID"
+  },
+  "web.colonel.customDomains.labels.created": {
+    "text": "Erstellt"
+  },
+  "web.colonel.customDomains.labels.updated": {
+    "text": "Aktualisiert"
+  },
+  "web.colonel.customDomains.labels.favicon": {
+    "text": "Favicon"
+  },
+  "web.colonel.customDomains.status.verified": {
+    "text": "Verifiziert"
+  },
+  "web.colonel.customDomains.status.resolving": {
+    "text": "Wird aufgelöst"
+  },
+  "web.colonel.customDomains.status.ready": {
+    "text": "Bereit"
+  },
+  "web.colonel.customDomains.status.publicHomepage": {
+    "text": "Öffentliche Homepage"
+  },
+  "web.colonel.customDomains.status.publicApi": {
+    "text": "Öffentliche API"
+  },
+  "web.colonel.customDomains.status.pending": {
+    "text": "Ausstehend"
+  },
+  "web.colonel.pagination.showing": {
+    "text": "{start}–{end} von {total} werden angezeigt"
+  },
+  "web.colonel.pagination.itemsPerPage": {
+    "text": "Einträge pro Seite"
+  },
+  "web.colonel.pagination.perPage": {
+    "text": "{count} pro Seite"
+  },
+  "web.colonel.pagination.pageOf": {
+    "text": "Seite {current} von {total}"
+  },
+  "web.colonel.secrets.empty": {
+    "text": "Keine Nachrichten gefunden"
+  },
+  "web.colonel.secrets.never": {
+    "text": "Nie"
+  },
+  "web.colonel.secrets.columns.shortId": {
+    "text": "Kurz-ID"
+  },
+  "web.colonel.secrets.columns.state": {
+    "text": "Status"
+  },
+  "web.colonel.secrets.columns.created": {
+    "text": "Erstellt"
+  },
+  "web.colonel.secrets.columns.expiration": {
+    "text": "Ablauf"
+  },
+  "web.colonel.secrets.columns.age": {
+    "text": "Alter (Tage)"
+  },
+  "web.colonel.secrets.state.new": {
+    "text": "Neu"
+  },
+  "web.colonel.secrets.state.received": {
+    "text": "Empfangen"
+  },
+  "web.colonel.secrets.state.viewed": {
+    "text": "Angesehen"
   }
 }

--- a/locales/content/de_AT/api-account-errors.json
+++ b/locales/content/de_AT/api-account-errors.json
@@ -1,0 +1,8 @@
+{
+  "api.account.errors.invalid_email": {
+    "text": "Ist das eine gültige E-Mail-Adresse?"
+  },
+  "api.account.errors.password_too_short": {
+    "text": "Das Passwort ist zu kurz"
+  }
+}

--- a/locales/content/de_AT/api-domains-errors.json
+++ b/locales/content/de_AT/api-domains-errors.json
@@ -1,0 +1,29 @@
+{
+  "api.domains.errors.domain_id_required": {
+    "text": "Bereichs-ID erforderlich"
+  },
+  "api.domains.errors.domain_not_found": {
+    "text": "Bereich nicht gefunden: %{extid}"
+  },
+  "api.domains.errors.organization_not_found": {
+    "text": "Keine Organisation für Bereich gefunden: %{domain}"
+  },
+  "api.domains.errors.incoming_secrets_disabled": {
+    "text": "Eingehende Nachrichten sind auf dieser Instanz nicht aktiviert"
+  },
+  "api.domains.errors.incoming_secrets_entitlement_required": {
+    "text": "Die Verwaltung eingehender Nachrichten erfordert die Berechtigung incoming_secrets. Bitte führen Sie ein Upgrade Ihres Tarifs durch."
+  },
+  "api.domains.errors.incoming_config_not_found": {
+    "text": "Konfiguration für eingehende Nachrichten nicht gefunden für Bereich: %{extid}"
+  },
+  "api.domains.errors.recipients_max_exceeded": {
+    "text": "Maximal %{max} Empfänger erlaubt"
+  },
+  "api.domains.errors.recipients_invalid_email": {
+    "text": "Ungültige E-Mail-Adresse: %{email}"
+  },
+  "api.domains.errors.recipients_duplicate": {
+    "text": "Doppelte Empfänger-E-Mail-Adressen sind nicht erlaubt"
+  }
+}

--- a/locales/content/de_AT/api-entitlements-errors.json
+++ b/locales/content/de_AT/api-entitlements-errors.json
@@ -1,0 +1,71 @@
+{
+  "api.entitlements.errors.context_unavailable": {
+    "text": "Berechtigungen können nicht überprüft werden (Organisationskontext nicht verfügbar)"
+  },
+  "api.entitlements.errors.api_access_required": {
+    "text": "API-Zugriff erfordert ein Upgrade Ihres Tarifs"
+  },
+  "api.entitlements.errors.custom_privacy_defaults_required": {
+    "text": "Benutzerdefinierte Datenschutz-Voreinstellungen erfordern ein Upgrade Ihres Tarifs"
+  },
+  "api.entitlements.errors.extended_default_expiration_required": {
+    "text": "Eine erweiterte Standard-Ablaufzeit erfordert ein Upgrade Ihres Tarifs"
+  },
+  "api.entitlements.errors.custom_domains_required": {
+    "text": "Benutzerdefinierte Bereiche erfordern ein Upgrade Ihres Tarifs"
+  },
+  "api.entitlements.errors.custom_branding_required": {
+    "text": "Benutzerdefiniertes Branding erfordert ein Upgrade Ihres Tarifs"
+  },
+  "api.entitlements.errors.homepage_secrets_required": {
+    "text": "Nachrichten auf der Startseite erfordern ein Upgrade Ihres Tarifs"
+  },
+  "api.entitlements.errors.incoming_secrets_required": {
+    "text": "Eingehende Nachrichten erfordern ein Upgrade Ihres Tarifs"
+  },
+  "api.entitlements.errors.custom_mail_sender_required": {
+    "text": "Ein benutzerdefinierter E-Mail-Absender erfordert ein Upgrade Ihres Tarifs"
+  },
+  "api.entitlements.errors.flexible_from_domain_required": {
+    "text": "Eine flexible Absender-Domäne erfordert ein Upgrade Ihres Tarifs"
+  },
+  "api.entitlements.errors.manage_org_required": {
+    "text": "Die Organisationsverwaltung erfordert ein Upgrade Ihres Tarifs"
+  },
+  "api.entitlements.errors.manage_teams_required": {
+    "text": "Die Teamverwaltung erfordert ein Upgrade Ihres Tarifs"
+  },
+  "api.entitlements.errors.manage_members_required": {
+    "text": "Die Mitgliederverwaltung erfordert ein Upgrade Ihres Tarifs"
+  },
+  "api.entitlements.errors.manage_sso_required": {
+    "text": "Die SSO-Verwaltung erfordert ein Upgrade Ihres Tarifs"
+  },
+  "api.entitlements.errors.audit_logs_required": {
+    "text": "Audit-Logs erfordern ein Upgrade Ihres Tarifs"
+  },
+  "api.entitlements.errors.custom_signup_validation_required": {
+    "text": "Eine benutzerdefinierte Registrierungsvalidierung erfordert ein Upgrade Ihres Tarifs"
+  },
+  "api.entitlements.errors.create_secrets_required": {
+    "text": "Das Erstellen von Nachrichten erfordert ein Upgrade Ihres Tarifs"
+  },
+  "api.entitlements.errors.view_receipt_required": {
+    "text": "Das Anzeigen von Belegen erfordert ein Upgrade Ihres Tarifs"
+  },
+  "api.entitlements.errors.notifications_required": {
+    "text": "Benachrichtigungen erfordern ein Upgrade Ihres Tarifs"
+  },
+  "api.entitlements.errors.workspace_branding_required": {
+    "text": "Workspace-Branding erfordert ein Upgrade Ihres Tarifs"
+  },
+  "api.entitlements.errors.ip_access_rules_required": {
+    "text": "IP-Zugriffsregeln erfordern ein Upgrade Ihres Tarifs"
+  },
+  "api.entitlements.errors.manage_billing_required": {
+    "text": "Die Abrechnungsverwaltung erfordert ein Upgrade Ihres Tarifs"
+  },
+  "api.entitlements.errors.custom_signin_config_required": {
+    "text": "Eine benutzerdefinierte Anmeldekonfiguration erfordert ein Upgrade Ihres Tarifs"
+  }
+}

--- a/locales/content/de_AT/api-feedback-errors.json
+++ b/locales/content/de_AT/api-feedback-errors.json
@@ -1,0 +1,5 @@
+{
+  "api.feedback.errors.rate_limit_exceeded": {
+    "text": "Zu viele Feedback-Einreichungen. Bitte versuchen Sie es später erneut."
+  }
+}

--- a/locales/content/de_AT/api-incoming-errors.json
+++ b/locales/content/de_AT/api-incoming-errors.json
@@ -1,0 +1,5 @@
+{
+  "api.incoming.errors.custom_domain_unresolved": {
+    "text": "Die Organisation des benutzerdefinierten Bereichs konnte nicht aufgelöst werden"
+  }
+}

--- a/locales/content/de_AT/api-invite-errors.json
+++ b/locales/content/de_AT/api-invite-errors.json
@@ -1,0 +1,23 @@
+{
+  "api.invite.errors.invitation_not_found_or_expired": {
+    "text": "Einladung nicht gefunden oder abgelaufen"
+  },
+  "api.invite.errors.token_required": {
+    "text": "Token ist erforderlich"
+  },
+  "api.invite.errors.organization_no_longer_exists": {
+    "text": "Organisation existiert nicht mehr"
+  },
+  "api.invite.errors.invitation_already_processed": {
+    "text": "Die Einladung wurde bereits %{status}"
+  },
+  "api.invite.errors.invitation_expired": {
+    "text": "Die Einladung ist abgelaufen"
+  },
+  "api.invite.errors.email_mismatch": {
+    "text": "Ihre E-Mail-Adresse stimmt nicht mit der Einladung überein"
+  },
+  "api.invite.errors.already_member": {
+    "text": "Sie sind bereits Mitglied dieser Organisation"
+  }
+}

--- a/locales/content/de_AT/api-organizations-errors.json
+++ b/locales/content/de_AT/api-organizations-errors.json
@@ -1,0 +1,107 @@
+{
+  "api.organizations.errors.domain_scoped_forbidden": {
+    "text": "Bereichsbezogene Mitglieder können diese Aktion nicht durchführen"
+  },
+  "api.organizations.errors.organization_not_found": {
+    "text": "Organisation nicht gefunden: %{extid}"
+  },
+  "api.organizations.errors.organization_owner_required": {
+    "text": "Nur der Organisationsinhaber kann diese Aktion durchführen"
+  },
+  "api.organizations.errors.organization_member_required": {
+    "text": "Sie müssen Mitglied der Organisation sein, um diese Aktion durchzuführen"
+  },
+  "api.organizations.errors.organization_admin_required": {
+    "text": "Nur Organisationsinhaber und Administratoren können diese Aktion durchführen"
+  },
+  "api.organizations.errors.extid_required": {
+    "text": "Organisations-ID erforderlich"
+  },
+  "api.organizations.errors.display_name_required": {
+    "text": "Der Organisationsname ist erforderlich"
+  },
+  "api.organizations.errors.display_name_too_long": {
+    "text": "Der Organisationsname muss weniger als %{max} Zeichen lang sein"
+  },
+  "api.organizations.errors.description_too_long": {
+    "text": "Die Beschreibung muss weniger als %{max} Zeichen lang sein"
+  },
+  "api.organizations.errors.contact_email_exists": {
+    "text": "Es existiert bereits eine Organisation mit dieser Kontakt-E-Mail-Adresse"
+  },
+  "api.organizations.errors.creation_in_progress": {
+    "text": "Die Organisation wird gerade erstellt. Bitte versuchen Sie es erneut."
+  },
+  "api.organizations.errors.organization_limit_reached": {
+    "text": "Organisationslimit erreicht. Führen Sie ein Upgrade Ihres Tarifs durch, um mehr Organisationen zu erstellen."
+  },
+  "api.organizations.invitations.errors.invitation_not_found": {
+    "text": "Einladung nicht gefunden"
+  },
+  "api.organizations.invitations.errors.email_required": {
+    "text": "E-Mail-Adresse ist erforderlich"
+  },
+  "api.organizations.invitations.errors.invalid_email_format": {
+    "text": "Ungültiges E-Mail-Format"
+  },
+  "api.organizations.invitations.errors.invalid_role": {
+    "text": "Die Rolle muss Mitglied oder Administrator sein"
+  },
+  "api.organizations.invitations.errors.cannot_invite_as_owner": {
+    "text": "Eine Einladung als Inhaber ist nicht möglich"
+  },
+  "api.organizations.invitations.errors.user_already_member": {
+    "text": "Der Benutzer ist bereits Mitglied dieser Organisation"
+  },
+  "api.organizations.invitations.errors.invitation_already_pending": {
+    "text": "Für diese E-Mail-Adresse steht bereits eine Einladung aus"
+  },
+  "api.organizations.invitations.errors.member_limit_reached": {
+    "text": "Mitgliederlimit erreicht. Führen Sie ein Upgrade Ihres Tarifs durch, um mehr Mitglieder einzuladen."
+  },
+  "api.organizations.invitations.errors.resend_only_pending": {
+    "text": "Nur ausstehende Einladungen können erneut gesendet werden"
+  },
+  "api.organizations.invitations.errors.resend_limit_reached": {
+    "text": "Maximales Limit für erneutes Senden (%{max}) erreicht"
+  },
+  "api.organizations.invitations.errors.revoke_only_pending": {
+    "text": "Nur ausstehende Einladungen können widerrufen werden"
+  },
+  "api.organizations.members.errors.member_not_found": {
+    "text": "Mitglied nicht gefunden: %{extid}"
+  },
+  "api.organizations.members.errors.member_not_in_organization": {
+    "text": "Mitglied in dieser Organisation nicht gefunden"
+  },
+  "api.organizations.members.errors.member_not_active": {
+    "text": "Mitglied ist nicht aktiv"
+  },
+  "api.organizations.members.errors.invalid_role_value": {
+    "text": "Ungültige Rolle. Muss eine der folgenden sein: %{roles}"
+  },
+  "api.organizations.members.errors.cannot_change_owner_role": {
+    "text": "Die Rolle des Inhabers kann nicht geändert werden. Verwenden Sie stattdessen die Inhaberschaftsübertragung."
+  },
+  "api.organizations.members.errors.member_already_has_role": {
+    "text": "Mitglied hat bereits die Rolle: %{role}"
+  },
+  "api.organizations.members.errors.cannot_promote_to_owner": {
+    "text": "Eine Beförderung zum Inhaber ist nicht möglich. Verwenden Sie stattdessen die Inhaberschaftsübertragung."
+  },
+  "api.organizations.members.errors.must_be_member": {
+    "text": "Sie müssen Mitglied dieser Organisation sein"
+  },
+  "api.organizations.members.errors.cannot_remove_owner": {
+    "text": "Der Organisationsinhaber kann nicht entfernt werden. Übertragen Sie zuerst die Inhaberschaft."
+  },
+  "api.organizations.members.errors.cannot_remove_self": {
+    "text": "Sie können sich nicht selbst entfernen. Verlassen Sie stattdessen die Organisation."
+  },
+  "api.organizations.members.errors.admin_cannot_remove_admin": {
+    "text": "Administratoren können keine anderen Administratoren entfernen. Nur Inhaber können das."
+  },
+  "api.organizations.members.errors.no_permission_to_remove": {
+    "text": "Sie haben keine Berechtigung, Mitglieder zu entfernen"
+  }
+}

--- a/locales/content/de_AT/api-secrets-errors.json
+++ b/locales/content/de_AT/api-secrets-errors.json
@@ -1,0 +1,11 @@
+{
+  "api.secrets.errors.domain_permission_authenticated_non_owner": {
+    "text": "Sie haben keine Berechtigung, den Bereich zu verwenden: %{domain}"
+  },
+  "api.secrets.errors.domain_public_sharing_disabled": {
+    "text": "Öffentliche Freigabe für den Bereich deaktiviert: %{domain}"
+  },
+  "api.secrets.errors.domain_permission_anonymous_cross_domain": {
+    "text": "Sie haben keine Berechtigung, den Bereich zu verwenden: %{domain}"
+  }
+}

--- a/locales/content/de_AT/email.json
+++ b/locales/content/de_AT/email.json
@@ -60,7 +60,7 @@
     "source_hash": "88c72144"
   },
   "email.welcome.signature": {
-    "text": "Delano",
+    "text": "Support-Team",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -100,7 +100,7 @@
     "source_hash": "fbb7eb2d"
   },
   "email.password_request.signature": {
-    "text": "Delano",
+    "text": "Support-Team",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -145,7 +145,7 @@
     "source_hash": "1863f5be"
   },
   "email.magic_link.signature": {
-    "text": "Delano",
+    "text": "Support-Team",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -230,7 +230,7 @@
     "source_hash": "3f6b45dd"
   },
   "email.secret_revealed.signature": {
-    "text": "Delano",
+    "text": "Support-Team",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -355,7 +355,7 @@
     "source_hash": "734882d2"
   },
   "email.organization_invitation.signature": {
-    "text": "Delano",
+    "text": "Support-Team",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -395,7 +395,7 @@
     "source_hash": "be92cff3"
   },
   "email.password_changed.signature": {
-    "text": "Delano",
+    "text": "Support-Team",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -445,7 +445,7 @@
     "source_hash": "f8d47b82"
   },
   "email.email_changed.signature": {
-    "text": "Delano",
+    "text": "Support-Team",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -495,7 +495,7 @@
     "source_hash": "f8d47b82"
   },
   "email.email_change_requested.signature": {
-    "text": "Delano",
+    "text": "Support-Team",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -550,7 +550,7 @@
     "source_hash": "d4d835fc"
   },
   "email.email_change_confirmation.signature": {
-    "text": "Delano",
+    "text": "Support-Team",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -580,7 +580,7 @@
     "source_hash": "e7c11bb0"
   },
   "email.mfa_enabled.signature": {
-    "text": "Delano",
+    "text": "Support-Team",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -605,7 +605,7 @@
     "source_hash": "97ef0a3e"
   },
   "email.mfa_disabled.signature": {
-    "text": "Delano",
+    "text": "Support-Team",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -650,7 +650,7 @@
     "source_hash": "450c54c5"
   },
   "email.new_login_alert.signature": {
-    "text": "Delano",
+    "text": "Support-Team",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -670,7 +670,7 @@
     "source_hash": "d442beed"
   },
   "email.member_removed.signature": {
-    "text": "Delano",
+    "text": "Support-Team",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -690,7 +690,7 @@
     "source_hash": "c2280c0c"
   },
   "email.role_changed.signature": {
-    "text": "Delano",
+    "text": "Support-Team",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -710,7 +710,7 @@
     "source_hash": "7095fc69"
   },
   "email.organization_deleted.signature": {
-    "text": "Delano",
+    "text": "Support-Team",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -750,7 +750,7 @@
     "source_hash": "36008943"
   },
   "email.payment_receipt.signature": {
-    "text": "Delano",
+    "text": "Support-Team",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -775,7 +775,7 @@
     "source_hash": "926406b1"
   },
   "email.payment_failed.signature": {
-    "text": "Delano",
+    "text": "Support-Team",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -800,7 +800,7 @@
     "source_hash": "66a1419e"
   },
   "email.trial_expiring.signature": {
-    "text": "Delano",
+    "text": "Support-Team",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -825,7 +825,7 @@
     "source_hash": "5a96ae38"
   },
   "email.subscription_changed.signature": {
-    "text": "Delano",
+    "text": "Support-Team",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -853,5 +853,41 @@
     "text": "Onetime Secret",
     "renderer": "erb",
     "source_hash": "1cd0194a"
+  },
+  "email.common.secret_link_label": {
+    "text": "Nachrichten-Link"
+  },
+  "email.common.automated_notice": {
+    "text": "Dies ist eine automatisierte Nachricht von %{product_name}."
+  },
+  "email.common.support_label": {
+    "text": "Support"
+  },
+  "email.expiration_warning.signature": {
+    "text": "Support-Team"
+  },
+  "email.expiration_warning.footer_note": {
+    "text": "Sie haben diese Nachricht erhalten, weil eine von Ihnen auf %{product_name} erstellte Nachricht bald abläuft."
+  },
+  "email.feedback_email.user_id_label": {
+    "text": "Benutzer:"
+  },
+  "email.feedback_email.timezone_label": {
+    "text": "Zeitzone:"
+  },
+  "email.feedback_email.version_label": {
+    "text": "Version:"
+  },
+  "email.incoming_secret.footer_note": {
+    "text": "Sie haben diese Nachricht erhalten, weil jemand %{product_name} verwendet hat, um Ihnen eine Nachricht zu senden. Falls Sie sie nicht erwartet haben, können Sie diese E-Mail bedenkenlos ignorieren."
+  },
+  "email.secret_link.passphrase_label": {
+    "text": "Sicherheitsphrase erforderlich:"
+  },
+  "email.secret_link.passphrase_required": {
+    "text": "Diese Nachricht ist mit einer Sicherheitsphrase geschützt. Der Absender sollte sie Ihnen separat mitteilen."
+  },
+  "email.secret_link.footer_note": {
+    "text": "Sie haben diese Nachricht erhalten, weil %{sender_email} %{product_name} verwendet hat, um eine Nachricht mit Ihnen zu teilen. Falls Sie sie nicht erwartet haben, können Sie diese E-Mail bedenkenlos ignorieren."
   }
 }

--- a/locales/content/de_AT/feature-feedback.json
+++ b/locales/content/de_AT/feature-feedback.json
@@ -58,5 +58,14 @@
   "web.feedback.reason_email_change_unauthorized": {
     "text": "Es sieht so aus, als würden Sie eine nicht autorisierte E-Mail-Änderung an Ihrem Konto melden. Bitte beschreiben Sie, was passiert ist, und wir werden dies umgehend untersuchen.",
     "source_hash": "00e56551"
+  },
+  "web.feedback.anonymous_no_reply": {
+    "text": "Hinweis: Wenn Sie eine Antwort wünschen, unterschreiben Sie bitte oder geben Sie eine E-Mail-Adresse in der Nachricht an."
+  },
+  "web.feedback.characters_remaining": {
+    "text": "{count} Zeichen übrig"
+  },
+  "web.feedback.character_limit_reached": {
+    "text": "Zeichenlimit erreicht"
   }
 }

--- a/locales/content/de_AT/feature-homepage-secrets.json
+++ b/locales/content/de_AT/feature-homepage-secrets.json
@@ -1,0 +1,50 @@
+{
+  "homepage_secrets.disabled.members_only_eyebrow": {
+    "text": "Instanz nur für Mitglieder"
+  },
+  "homepage_secrets.disabled.private_instance_eyebrow": {
+    "text": "Private Instanz"
+  },
+  "homepage_secrets.disabled.team_link_headline": {
+    "text": "Dieser Link ist für das Team {workspace}."
+  },
+  "homepage_secrets.disabled.signin_headline": {
+    "text": "Tragen Sie sich ein, um einen {action} zu erstellen."
+  },
+  "homepage_secrets.disabled.signin_headline_action": {
+    "text": "Nachrichten-Link"
+  },
+  "homepage_secrets.disabled.team_subtitle": {
+    "text": "Nur autorisierte Teammitglieder bei {domain} können hier neue Einmal-Links erstellen. Empfänger können jeden ihnen gesendeten Link weiterhin öffnen."
+  },
+  "homepage_secrets.disabled.public_subtitle": {
+    "text": "Nur autorisierte Mitglieder dieser Instanz können neue Einmal-Links erstellen. Empfänger können jeden ihnen gesendeten Link weiterhin öffnen."
+  },
+  "homepage_secrets.disabled.signin_cta": {
+    "text": "Tragen Sie sich in Ihr Konto ein"
+  },
+  "homepage_secrets.disabled.what_is_this": {
+    "text": "Was ist das?"
+  },
+  "homepage_secrets.disabled.trust_viewed_once": {
+    "text": "Einmal angesehen, dann verschwunden"
+  },
+  "homepage_secrets.disabled.trust_zero_retained": {
+    "text": "Nichts gespeichert"
+  },
+  "homepage_secrets.disabled.promo_title": {
+    "text": "Neu: Kostenlose Tarife enthalten jetzt benutzerdefinierte Bereiche."
+  },
+  "homepage_secrets.disabled.promo_subtitle": {
+    "text": "Richten Sie Ihren Bereich auf Onetime Secret aus und versenden Sie Nachrichten unter Ihrer eigenen Marke."
+  },
+  "homepage_secrets.disabled.promo_learn_how": {
+    "text": "Erfahren Sie, wie"
+  },
+  "homepage_secrets.disabled.logo_alt": {
+    "text": "Logo von {name}"
+  },
+  "homepage_secrets.disabled.opens_in_new_tab": {
+    "text": "(wird in einem neuen Tab geöffnet)"
+  }
+}

--- a/locales/content/de_AT/feature-incoming.json
+++ b/locales/content/de_AT/feature-incoming.json
@@ -130,5 +130,26 @@
   "incoming.receipt_link_text": {
     "text": "Beleg",
     "source_hash": "6f328609"
+  },
+  "incoming.upgrade_required_title": {
+    "text": "Upgrade erforderlich"
+  },
+  "incoming.upgrade_required_description": {
+    "text": "Diese Funktion erfordert ein Upgrade Ihres Tarifs. Bitte wenden Sie sich an den Kontoinhaber, um eingehende Nachrichten zu aktivieren."
+  },
+  "incoming.validation_memo_too_long": {
+    "text": "Die Notiz darf höchstens {max} Zeichen lang sein"
+  },
+  "incoming.validation_secret_required": {
+    "text": "Nachrichteninhalt ist erforderlich"
+  },
+  "incoming.validation_recipient_required": {
+    "text": "Bitte wählen Sie einen Empfänger aus"
+  },
+  "incoming.validation_feature_disabled": {
+    "text": "Die Funktion für eingehende Nachrichten ist nicht aktiviert"
+  },
+  "incoming.validation_form_errors": {
+    "text": "Bitte überprüfen Sie das Formular auf Fehler"
   }
 }

--- a/locales/content/de_AT/feature-regions.json
+++ b/locales/content/de_AT/feature-regions.json
@@ -152,7 +152,7 @@
     "source_hash": "1d97f6bd"
   },
   "web.regions.changing_regions_billing_note": {
-    "text": "Wenn Ihre Rechnungskontakt-E-Mail von Ihrer {product_name}-Konto-E-Mail abweicht, verwenden Sie die Rechnungskontakt-E-Mail für das neue Regionskonto, um Ihre Abonnementvorteile beizubehalten.",
+    "text": "Wenn sich Ihre E-Mail-Adresse für die Abrechnung von der E-Mail-Adresse Ihres {product_name}-Kontos unterscheidet, verwenden Sie die Abrechnungs-E-Mail-Adresse für das Konto der neuen Region, um Ihre Abonnementvorteile zu behalten.",
     "source_hash": "dac1cc28"
   },
   "web.regions.changing_regions_subscription_note": {
@@ -186,5 +186,8 @@
   "web.regions.jurisdictions.apac.name": {
     "text": "Asia-Pacific",
     "source_hash": "7a757670"
+  },
+  "web.regions.no_region_configured": {
+    "text": "Derzeit sind keine Regionsinformationen für Ihr Konto verfügbar."
   }
 }

--- a/locales/content/de_AT/feature-translations.json
+++ b/locales/content/de_AT/feature-translations.json
@@ -64,7 +64,7 @@
     "source_hash": "13131e36"
   },
   "web.translations.the_following_people_have_donated_their_time_to_": {
-    "text": "Die folgenden Personen haben ihre Zeit gespendet, um die Reichweite von {product_name} zu vergrößern:",
+    "text": "Die folgenden Personen haben ihre Zeit gespendet, um die Reichweite von {product_name} zu erweitern:",
     "source_hash": "85a766af"
   },
   "web.translations.translations": {
@@ -84,7 +84,7 @@
     "source_hash": "ba5c4395"
   },
   "web.translations.since_2012_onetime_secret_has_provided_a_secure_": {
-    "text": "Seit 2012 bietet {product_name} eine sichere Möglichkeit, sensible Informationen weltweit auszutauschen. Mit Nutzern in Regionen, in denen Englisch nicht die Hauptsprache ist, sind genaue Übersetzungen unerlässlich, um sichere Kommunikation für alle zugänglich zu machen.",
+    "text": "Seit 2012 bietet {product_name} eine sichere Möglichkeit, vertrauliche Informationen weltweit zu teilen. Da es Benutzer in Regionen gibt, in denen Englisch nicht die primäre Sprache ist, sind genaue Übersetzungen unerlässlich, um sichere Kommunikation für alle zugänglich zu machen.",
     "source_hash": "87a6e9af"
   },
   "web.translations.help_secure_communication_go_global": {

--- a/locales/content/de_AT/secret-homepage.json
+++ b/locales/content/de_AT/secret-homepage.json
@@ -56,7 +56,7 @@
     "source_hash": "5e218489"
   },
   "web.homepage.visit_onetime_secret_home": {
-    "text": "{product_name} Startseite besuchen",
+    "text": "{product_name}-Startseite besuchen",
     "source_hash": "625556d2"
   },
   "web.homepage.password_generation_title": {
@@ -112,7 +112,7 @@
     "source_hash": "971c50da"
   },
   "web.homepage.log_in_to_onetime_secret": {
-    "text": "Bei {product_name} anmelden",
+    "text": "Melden Sie sich bei {product_name} an",
     "source_hash": "bd6be8d6"
   },
   "web.homepage.about_onetime_secret": {
@@ -144,11 +144,11 @@
     "source_hash": "1cd0194a"
   },
   "web.homepage.one_time_secret_literal": {
-    "text": "Einmal-Geheimnis",
+    "text": "{product_name}",
     "source_hash": "7872e050"
   },
   "web.homepage.onetime_secret_homepage": {
-    "text": "{product_name} Startseite",
+    "text": "{product_name} Homepage",
     "source_hash": "44bb0581"
   },
   "web.homepage.send_sensitive_information_that_can_only_be_viewed_once": {
@@ -172,7 +172,7 @@
     "source_hash": "0990d163"
   },
   "web.homepage.onetime_secret_helps_us_share_sensitive_informat": {
-    "text": "Mit {product_name} können wir sensible Informationen sicher weitergeben und gleichzeitig unsere professionelle Fassade wahren.",
+    "text": "{product_name} hilft uns, vertrauliche Informationen sicher zu teilen und dabei unsere professionelle Fassade zu wahren.",
     "source_hash": "986a0856"
   },
   "web.homepage.information_shared_through_this_service_can_only": {

--- a/locales/content/de_AT/secret-homepage.json
+++ b/locales/content/de_AT/secret-homepage.json
@@ -148,7 +148,7 @@
     "source_hash": "7872e050"
   },
   "web.homepage.onetime_secret_homepage": {
-    "text": "{product_name} Homepage",
+    "text": "{product_name} Startseite",
     "source_hash": "44bb0581"
   },
   "web.homepage.send_sensitive_information_that_can_only_be_viewed_once": {

--- a/locales/content/de_AT/secret-manage.json
+++ b/locales/content/de_AT/secret-manage.json
@@ -128,7 +128,7 @@
     "source_hash": "07fe1b84"
   },
   "web.secrets.onetime_secret_is_a_secure_way_to_share_sensitiv": {
-    "text": "{product_name} ist eine sichere Methode zur Freigabe vertraulicher Informationen, die sich nach einmaliger Betrachtung selbst vernichtet.",
+    "text": "{product_name} ist eine sichere Möglichkeit, vertrauliche Informationen zu teilen, die sich nach einmaligem Ansehen selbst zerstören.",
     "source_hash": "8a163297"
   },
   "web.secrets.what_is_this": {
@@ -398,5 +398,11 @@
   "web.secrets.errors.access_denied_to_domain": {
     "text": "Zugriff auf Domain verweigert",
     "source_hash": "cd441eea"
+  },
+  "web.receipt.open_link": {
+    "text": "Link öffnen"
+  },
+  "web.secrets.messageDeleted": {
+    "text": "Nachricht gelöscht"
   }
 }

--- a/locales/content/de_AT/session-auth-extended.json
+++ b/locales/content/de_AT/session-auth-extended.json
@@ -710,5 +710,26 @@
   "web.auth.recovery_codes.link_title": {
     "text": "Wiederherstellungscodes",
     "source_hash": "579c7f4e"
+  },
+  "web.auth.google": {
+    "text": "Google"
+  },
+  "web.auth.mfa.alternative_auth_options": {
+    "text": "Alternative Authentifizierungsoptionen"
+  },
+  "web.auth.remember.enabled": {
+    "text": "Eingetragen bleiben"
+  },
+  "web.auth.security._guidance.context": {
+    "text": "⚠️ SECURITY-CRITICAL: Messages prevent information disclosure. See src/locales/SECURITY-TRANSLATION-GUIDE.md"
+  },
+  "web.auth.sessions.session_singular": {
+    "text": "Sitzung"
+  },
+  "web.auth.sessions.session_plural": {
+    "text": "Sitzungen"
+  },
+  "web.auth.sessions._guidance.context": {
+    "text": "User's logged-in devices/browsers management page"
   }
 }

--- a/locales/content/de_AT/session-auth.json
+++ b/locales/content/de_AT/session-auth.json
@@ -395,5 +395,35 @@
   "web.help.contact_support": {
     "text": "Support kontaktieren",
     "source_hash": "f8d47b82"
+  },
+  "web.auth.account.sso_linked": {
+    "text": "SSO-Konto"
+  },
+  "web.auth.verify._guidance.context": {
+    "text": "Email verification flow after signup"
+  },
+  "web.help.reset_password_link": {
+    "text": "Passwort zurücksetzen"
+  },
+  "web.login.custom_domain_sso_title": {
+    "text": "Single Sign-On ist für diesen Bereich verfügbar"
+  },
+  "web.login.custom_domain_sso_description": {
+    "text": "Der Organisationsadministrator kann SSO aktivieren, damit sich Teammitglieder hier eintragen können. Wenden Sie sich für den Zugriff an den Administrator."
+  },
+  "web.login.signin_disabled_heading": {
+    "text": "Anmeldung nicht verfügbar"
+  },
+  "web.login.signin_disabled_message": {
+    "text": "Die Anmeldung ist auf diesem Bereich derzeit nicht verfügbar."
+  },
+  "web.login.errors.sso_not_configured": {
+    "text": "Single Sign-On ist für diesen Bereich nicht konfiguriert. Bitte wenden Sie sich an Ihren Administrator."
+  },
+  "web.login.errors.invalid_email": {
+    "text": "Die E-Mail-Adresse von Ihrem Identitätsanbieter ist ungültig. Bitte wenden Sie sich an Ihren Administrator."
+  },
+  "web.login.errors.domain_not_allowed": {
+    "text": "Ihr E-Mail-Bereich ist nicht für die SSO-Registrierung autorisiert. Bitte wenden Sie sich an Ihren Administrator."
   }
 }

--- a/locales/content/de_AT/workspace-account.json
+++ b/locales/content/de_AT/workspace-account.json
@@ -682,5 +682,14 @@
   "web.settings.profile.didnt_receive_email": {
     "text": "E-Mail nicht erhalten?",
     "source_hash": "fe3ac3ad"
+  },
+  "web.settings.api.api_disabled_notice": {
+    "text": "Die API ist für diese Instanz deaktiviert."
+  },
+  "web.settings.security.sso_managed_title": {
+    "text": "Sicherheit über SSO verwaltet"
+  },
+  "web.settings.security.sso_managed_description": {
+    "text": "Ihr Konto wird über den Single-Sign-On-Anbieter Ihrer Organisation authentifiziert. Passwort, Multi-Faktor-Authentifizierung und Wiederherstellungscodes werden von Ihrem Identitätsanbieter verwaltet."
   }
 }

--- a/locales/content/de_AT/workspace-billing.json
+++ b/locales/content/de_AT/workspace-billing.json
@@ -988,5 +988,47 @@
     "text": "Nur in Ihrer ursprünglichen Abonnementregion verfügbar",
     "context": "Hint shown on plan cards when currency does not match active subscription",
     "source_hash": "10de32e5"
+  },
+  "web.billing.already_subscribed": {
+    "text": "Sie haben diesen Tarif bereits abonniert."
+  },
+  "web.billing.cancel.reactivate_button": {
+    "text": "Abonnement reaktivieren"
+  },
+  "web.billing.cancel.reactivate_success": {
+    "text": "Ihr Abonnement wurde reaktiviert. Die Abrechnung erfolgt weiterhin wie gewohnt."
+  },
+  "web.billing.cancel.reactivate_error": {
+    "text": "Reaktivierung des Abonnements fehlgeschlagen. Bitte versuchen Sie es erneut oder wenden Sie sich an den Support."
+  },
+  "web.billing.features.manage_orgs": {
+    "text": "Organisationsverwaltung"
+  },
+  "web.billing.features.flexible_from_domain": {
+    "text": "Flexible Absender-Domäne für E-Mails"
+  },
+  "web.billing.features.unlimited_admins": {
+    "text": "Unbegrenzte Administratoren"
+  },
+  "web.billing.features.manage_sso": {
+    "text": "SSO"
+  },
+  "web.billing.overview.entitlements.flexible_from_domain": {
+    "text": "Flexible Absender-Domäne für E-Mails"
+  },
+  "web.billing.overview.entitlements.manage_orgs": {
+    "text": "Organisationen verwalten"
+  },
+  "web.billing.overview.entitlements.manage_sso": {
+    "text": "Single Sign-On (SSO)"
+  },
+  "web.billing.overview.entitlements.manage_billing": {
+    "text": "Abrechnung verwalten"
+  },
+  "web.billing.overview.entitlements.custom_signup_validation": {
+    "text": "Benutzerdefinierte Registrierungsvalidierung"
+  },
+  "web.billing.plans.reactivate": {
+    "text": "Reaktivieren"
   }
 }

--- a/locales/content/de_AT/workspace-branding.json
+++ b/locales/content/de_AT/workspace-branding.json
@@ -178,5 +178,11 @@
   "web.branding.upgrade_to_customize": {
     "text": "Upgraden Sie Ihren Tarif, um das Branding für diese Domäne anzupassen.",
     "source_hash": "9077bf79"
+  },
+  "web.branding.saved_successfully": {
+    "text": "Branding-Einstellungen erfolgreich gespeichert"
+  },
+  "web.branding.keyhole_logo_icon": {
+    "text": "Schlüsselloch-Symbol, das sicheres, privates Teilen darstellt"
   }
 }

--- a/locales/content/de_AT/workspace-dashboard.json
+++ b/locales/content/de_AT/workspace-dashboard.json
@@ -22,5 +22,14 @@
   "web.dashboard.fetch_error_description": {
     "text": "Beim Laden Ihrer Daten ist ein Problem aufgetreten. Bitte versuchen Sie es erneut.",
     "source_hash": "ff0d904e"
+  },
+  "web.teams.create_first_team_title": {
+    "text": "Erstellen Sie Ihr erstes Team"
+  },
+  "web.teams.create_first_team_description": {
+    "text": "Mit Teams können Sie in einem gemeinsamen Workspace mit anderen zusammenarbeiten."
+  },
+  "web.teams.create_team": {
+    "text": "Team erstellen"
   }
 }

--- a/locales/content/de_AT/workspace-domains.json
+++ b/locales/content/de_AT/workspace-domains.json
@@ -499,7 +499,7 @@
     "text": "E-Mail-Konfiguration"
   },
   "web.domains.email.config_description": {
-    "text": "E-Mail-Versand für diese Domäne konfigurieren"
+    "text": "E-Mail-Versand für diesen Bereich konfigurieren"
   },
   "web.domains.email.provider_label": {
     "text": "E-Mail-Anbieter"
@@ -544,13 +544,13 @@
     "text": "Kontostandards verwenden"
   },
   "web.domains.email.provider_ses_description": {
-    "text": "Erfordert Domänenverifizierung über DKIM- und SPF-Einträge"
+    "text": "Erfordert Bereichsverifizierung über DKIM- und SPF-Einträge"
   },
   "web.domains.email.provider_sendgrid_description": {
-    "text": "Erfordert Einrichtung der Domänenauthentifizierung"
+    "text": "Erfordert Einrichtung der Bereichsauthentifizierung"
   },
   "web.domains.email.provider_lettermint_description": {
-    "text": "Erfordert Domänenverifizierung"
+    "text": "Erfordert Bereichsverifizierung"
   },
   "web.domains.email.provider_inherit_description": {
     "text": "Verwendet die Standardkonfiguration für den E-Mail-Versand Ihres Kontos"
@@ -559,7 +559,7 @@
     "text": "DNS-Einträge"
   },
   "web.domains.email.dns_records_description": {
-    "text": "Fügen Sie die folgenden DNS-Einträge hinzu, um Ihre Domäne für den E-Mail-Versand zu verifizieren."
+    "text": "Fügen Sie die folgenden DNS-Einträge hinzu, um Ihren Bereich für den E-Mail-Versand zu verifizieren."
   },
   "web.domains.email.dns_column_type": {
     "text": "Typ"
@@ -604,7 +604,7 @@
     "text": "Wird validiert..."
   },
   "web.domains.email.domain_verified": {
-    "text": "Domäne verifiziert"
+    "text": "Bereich verifiziert"
   },
   "web.domains.email.validation_failed": {
     "text": "Validierung fehlgeschlagen"
@@ -613,7 +613,7 @@
     "text": "Zuletzt validiert"
   },
   "web.domains.email.upgrade_to_configure": {
-    "text": "Führen Sie ein Upgrade Ihres Tarifs durch, um den E-Mail-Versand für diese Domäne zu konfigurieren."
+    "text": "Führen Sie ein Upgrade Ihres Tarifs durch, um den E-Mail-Versand für diesen Bereich zu konfigurieren."
   },
   "web.domains.email.configure_email": {
     "text": "E-Mail konfigurieren"
@@ -622,7 +622,7 @@
     "text": "Zugriff verweigert"
   },
   "web.domains.email.access_denied_description": {
-    "text": "Sie haben keine Berechtigung, die E-Mail-Einstellungen für diese Domäne zu verwalten. Wenden Sie sich an Ihren Organisationsadministrator."
+    "text": "Sie haben keine Berechtigung, die E-Mail-Einstellungen für diesen Bereich zu verwalten. Wenden Sie sich an Ihren Organisationsadministrator."
   },
   "web.domains.email.update_success": {
     "text": "E-Mail-Konfiguration erfolgreich gespeichert"
@@ -631,7 +631,7 @@
     "text": "E-Mail-Konfiguration erfolgreich entfernt"
   },
   "web.domains.email.default_sender_notice": {
-    "text": "E-Mails für diese Domäne werden derzeit vom globalen Absender gesendet. Schließen Sie die E-Mail-Konfiguration ab, um Ihre eigene Absenderidentität zu verwenden."
+    "text": "E-Mails für diesen Bereich werden derzeit vom globalen Absender gesendet. Schließen Sie die E-Mail-Konfiguration ab, um Ihre eigene Absenderidentität zu verwenden."
   },
   "web.domains.email.disabled_notice": {
     "text": "Der benutzerdefinierte E-Mail-Versand ist derzeit deaktiviert. E-Mails werden vom globalen Absender gesendet. Aktivieren Sie die Funktion unten, um Ihre benutzerdefinierte Absenderidentität zu verwenden."
@@ -682,7 +682,7 @@
     "text": "E-Mail-Absender ist deaktiviert — E-Mails verwenden den Standardabsender der Plattform"
   },
   "web.domains.email.tooltip_verified": {
-    "text": "E-Mail-Absender verifiziert — E-Mails werden von dieser Domäne gesendet"
+    "text": "E-Mail-Absender verifiziert — E-Mails werden von diesem Bereich gesendet"
   },
   "web.domains.incoming.title": {
     "text": "Eingehende Nachrichten"
@@ -1051,7 +1051,7 @@
     "text": "Konfiguration der Registrierungsvalidierung erfolgreich entfernt"
   },
   "web.domains.signup.domain_overrides_label": {
-    "text": "Bereich-Überschreibungen"
+    "text": "Bereichs-Überschreibungen"
   },
   "web.domains.signup.domain_overrides_hint": {
     "text": "Globale Registrierungseinstellungen für diesen Bereich überschreiben"

--- a/locales/content/de_AT/workspace-domains.json
+++ b/locales/content/de_AT/workspace-domains.json
@@ -398,5 +398,725 @@
   "web.domains.dns_widget_description": {
     "text": "Verwenden Sie das Tool unten, um Ihren DNS-Anbieter automatisch zu erkennen und Schritt-für-Schritt-Anleitungen zur Konfiguration Ihrer Domain zu erhalten.",
     "source_hash": "91c1af2e"
+  },
+  "api.domains.errors.add_admin_required": {
+    "text": "Nur Organisationsinhaber und Administratoren können benutzerdefinierte Bereiche hinzufügen"
+  },
+  "web.domains.public_homepage": {
+    "text": "Öffentliche Startseite"
+  },
+  "web.domains.status_tooltip_active": {
+    "text": "Bereich verifiziert und aktiv"
+  },
+  "web.domains.status_tooltip_dns_incorrect": {
+    "text": "DNS nicht konfiguriert — zum Beheben klicken"
+  },
+  "web.domains.status_tooltip_not_verified": {
+    "text": "Bereich nicht verifiziert — zum Verifizieren klicken"
+  },
+  "web.domains.status_tooltip_unverified": {
+    "text": "Bereichsstatus nicht verifiziert — zum Aktualisieren klicken"
+  },
+  "web.domains.last_check_failed": {
+    "text": "Letzte Verifizierungsprüfung fehlgeschlagen"
+  },
+  "web.domains.last_check_failed_ago": {
+    "text": "letzte Prüfung fehlgeschlagen {0}"
+  },
+  "web.domains.verify_now": {
+    "text": "Jetzt verifizieren"
+  },
+  "web.domains.click_to_verify": {
+    "text": "zum Verifizieren klicken"
+  },
+  "web.domains.remove_domain_description": {
+    "text": "Diesen Bereich und seine gesamte Konfiguration dauerhaft entfernen."
+  },
+  "web.domains.add_access_denied": {
+    "text": "Zugriff verweigert"
+  },
+  "web.domains.add_access_denied_description": {
+    "text": "Sie haben keine Berechtigung, Bereiche zu dieser Organisation hinzuzufügen. Wenden Sie sich an Ihren Organisationsadministrator."
+  },
+  "web.domains.dns_widget_load_failed": {
+    "text": "DNS-Widget konnte nicht geladen werden"
+  },
+  "web.domains.dns_widget_not_available": {
+    "text": "DNS-Widget nicht verfügbar"
+  },
+  "web.domains.dns_widget_init_failed": {
+    "text": "DNS-Widget konnte nicht initialisiert werden"
+  },
+  "web.domains.verified": {
+    "text": "Verifiziert"
+  },
+  "web.domains.pending_verification": {
+    "text": "Verifizierung ausstehend"
+  },
+  "web.domains.unsaved_changes_confirmation": {
+    "text": "Sie haben nicht gespeicherte Änderungen. Möchten Sie die Seite wirklich verlassen?"
+  },
+  "web.domains.entitlement_required_owner": {
+    "text": "Diese Funktion erfordert ein Upgrade Ihres Tarifs."
+  },
+  "web.domains.entitlement_required_member": {
+    "text": "Diese Funktion ist in Ihrem aktuellen Tarif nicht verfügbar. Wenden Sie sich an Ihren Organisationsinhaber."
+  },
+  "web.domains.detail.manage": {
+    "text": "Verwalten"
+  },
+  "web.domains.detail.features": {
+    "text": "Funktionen"
+  },
+  "web.domains.detail.homepage_title": {
+    "text": "Nachrichten auf der Startseite"
+  },
+  "web.domains.detail.homepage_description": {
+    "text": "Öffentlichen Zugriff erlauben, um Nachrichten auf der Startseite Ihres Bereichs zu erstellen"
+  },
+  "web.domains.detail.brand_description": {
+    "text": "Logo, Farben und benutzerdefiniertes Branding"
+  },
+  "web.domains.detail.sso_description": {
+    "text": "Einstellungen des Single-Sign-On-Anbieters"
+  },
+  "web.domains.detail.email_description": {
+    "text": "Konfiguration des benutzerdefinierten E-Mail-Absenders"
+  },
+  "web.domains.detail.incoming_description": {
+    "text": "Empfängereinstellungen für eingehende Nachrichten"
+  },
+  "web.domains.detail.signup_description": {
+    "text": "Strategie zur Registrierungsvalidierung pro Bereich"
+  },
+  "web.domains.detail.signin_description": {
+    "text": "Konfiguration der Anmeldemethode pro Bereich"
+  },
+  "web.domains.email.title": {
+    "text": "E-Mail-Versand"
+  },
+  "web.domains.email.config_title": {
+    "text": "E-Mail-Konfiguration"
+  },
+  "web.domains.email.config_description": {
+    "text": "E-Mail-Versand für diese Domäne konfigurieren"
+  },
+  "web.domains.email.provider_label": {
+    "text": "E-Mail-Anbieter"
+  },
+  "web.domains.email.provider_placeholder": {
+    "text": "Wählen Sie einen E-Mail-Anbieter"
+  },
+  "web.domains.email.from_name_label": {
+    "text": "Absendername"
+  },
+  "web.domains.email.from_name_placeholder": {
+    "text": "z. B. Acme Security"
+  },
+  "web.domains.email.from_address_label": {
+    "text": "Absenderadresse"
+  },
+  "web.domains.email.from_address_placeholder": {
+    "text": "z. B. secrets{'@'}example.com"
+  },
+  "web.domains.email.reply_to_label": {
+    "text": "Antwort-an-Adresse"
+  },
+  "web.domains.email.reply_to_placeholder": {
+    "text": "z. B. support{'@'}example.com"
+  },
+  "web.domains.email.save_changes": {
+    "text": "Änderungen speichern"
+  },
+  "web.domains.email.discard_changes": {
+    "text": "Änderungen verwerfen"
+  },
+  "web.domains.email.provider_ses": {
+    "text": "Amazon SES"
+  },
+  "web.domains.email.provider_sendgrid": {
+    "text": "SendGrid"
+  },
+  "web.domains.email.provider_lettermint": {
+    "text": "Lettermint"
+  },
+  "web.domains.email.provider_inherit": {
+    "text": "Kontostandards verwenden"
+  },
+  "web.domains.email.provider_ses_description": {
+    "text": "Erfordert Domänenverifizierung über DKIM- und SPF-Einträge"
+  },
+  "web.domains.email.provider_sendgrid_description": {
+    "text": "Erfordert Einrichtung der Domänenauthentifizierung"
+  },
+  "web.domains.email.provider_lettermint_description": {
+    "text": "Erfordert Domänenverifizierung"
+  },
+  "web.domains.email.provider_inherit_description": {
+    "text": "Verwendet die Standardkonfiguration für den E-Mail-Versand Ihres Kontos"
+  },
+  "web.domains.email.dns_records_title": {
+    "text": "DNS-Einträge"
+  },
+  "web.domains.email.dns_records_description": {
+    "text": "Fügen Sie die folgenden DNS-Einträge hinzu, um Ihre Domäne für den E-Mail-Versand zu verifizieren."
+  },
+  "web.domains.email.dns_column_type": {
+    "text": "Typ"
+  },
+  "web.domains.email.dns_column_name": {
+    "text": "Name"
+  },
+  "web.domains.email.dns_column_value": {
+    "text": "Wert"
+  },
+  "web.domains.email.dns_check_label": {
+    "text": "DNS"
+  },
+  "web.domains.email.provider_check_label": {
+    "text": "Anbieter"
+  },
+  "web.domains.email.dns_optional_label": {
+    "text": "Empfohlen"
+  },
+  "web.domains.email.dns_optional_hint": {
+    "text": "Dieser Eintrag wird empfohlen, ist aber für die Verifizierung nicht erforderlich. Eine DMARC-Richtlinie auf Ihrer Organisationsdomäne deckt diese Subdomäne möglicherweise bereits ab."
+  },
+  "web.domains.email.copy": {
+    "text": "Kopieren"
+  },
+  "web.domains.email.copied": {
+    "text": "Kopiert"
+  },
+  "web.domains.email.status_verified": {
+    "text": "Verifiziert"
+  },
+  "web.domains.email.status_pending": {
+    "text": "Ausstehend"
+  },
+  "web.domains.email.status_failed": {
+    "text": "Fehlgeschlagen"
+  },
+  "web.domains.email.revalidate": {
+    "text": "Erneut validieren"
+  },
+  "web.domains.email.validating": {
+    "text": "Wird validiert..."
+  },
+  "web.domains.email.domain_verified": {
+    "text": "Domäne verifiziert"
+  },
+  "web.domains.email.validation_failed": {
+    "text": "Validierung fehlgeschlagen"
+  },
+  "web.domains.email.last_validated": {
+    "text": "Zuletzt validiert"
+  },
+  "web.domains.email.upgrade_to_configure": {
+    "text": "Führen Sie ein Upgrade Ihres Tarifs durch, um den E-Mail-Versand für diese Domäne zu konfigurieren."
+  },
+  "web.domains.email.configure_email": {
+    "text": "E-Mail konfigurieren"
+  },
+  "web.domains.email.access_denied": {
+    "text": "Zugriff verweigert"
+  },
+  "web.domains.email.access_denied_description": {
+    "text": "Sie haben keine Berechtigung, die E-Mail-Einstellungen für diese Domäne zu verwalten. Wenden Sie sich an Ihren Organisationsadministrator."
+  },
+  "web.domains.email.update_success": {
+    "text": "E-Mail-Konfiguration erfolgreich gespeichert"
+  },
+  "web.domains.email.delete_success": {
+    "text": "E-Mail-Konfiguration erfolgreich entfernt"
+  },
+  "web.domains.email.default_sender_notice": {
+    "text": "E-Mails für diese Domäne werden derzeit vom globalen Absender gesendet. Schließen Sie die E-Mail-Konfiguration ab, um Ihre eigene Absenderidentität zu verwenden."
+  },
+  "web.domains.email.disabled_notice": {
+    "text": "Der benutzerdefinierte E-Mail-Versand ist derzeit deaktiviert. E-Mails werden vom globalen Absender gesendet. Aktivieren Sie die Funktion unten, um Ihre benutzerdefinierte Absenderidentität zu verwenden."
+  },
+  "web.domains.email.test_email_title": {
+    "text": "E-Mail-Zustellung testen"
+  },
+  "web.domains.email.test_email_hint": {
+    "text": "Senden Sie sich selbst eine Test-E-Mail mit der gespeicherten Konfiguration. Funktioniert auch, wenn die Funktion noch nicht aktiviert ist."
+  },
+  "web.domains.email.send_test": {
+    "text": "Test senden"
+  },
+  "web.domains.email.test_email_sent": {
+    "text": "Test-E-Mail erfolgreich gesendet"
+  },
+  "web.domains.email.test_email_failed": {
+    "text": "Test-E-Mail konnte nicht gesendet werden"
+  },
+  "web.domains.email.test_email_sent_to": {
+    "text": "Gesendet an {email}"
+  },
+  "web.domains.email.delivered_via": {
+    "text": "Zugestellt über {provider}"
+  },
+  "web.domains.email.badge_not_configured": {
+    "text": "Nicht konfiguriert"
+  },
+  "web.domains.email.badge_default_sender": {
+    "text": "Standardabsender wird verwendet"
+  },
+  "web.domains.email.badge_verified": {
+    "text": "Verifiziert"
+  },
+  "web.domains.email.badge_pending": {
+    "text": "Verifizierung ausstehend"
+  },
+  "web.domains.email.badge_disabled": {
+    "text": "Deaktiviert"
+  },
+  "web.domains.email.tooltip_not_configured": {
+    "text": "Kein E-Mail-Absender konfiguriert — E-Mails verwenden den Standardabsender der Plattform"
+  },
+  "web.domains.email.tooltip_pending": {
+    "text": "Die Konfiguration des E-Mail-Absenders wartet auf Verifizierung — E-Mails verwenden den Standardabsender der Plattform"
+  },
+  "web.domains.email.tooltip_disabled": {
+    "text": "E-Mail-Absender ist deaktiviert — E-Mails verwenden den Standardabsender der Plattform"
+  },
+  "web.domains.email.tooltip_verified": {
+    "text": "E-Mail-Absender verifiziert — E-Mails werden von dieser Domäne gesendet"
+  },
+  "web.domains.incoming.title": {
+    "text": "Eingehende Nachrichten"
+  },
+  "web.domains.incoming.config_title": {
+    "text": "Konfiguration für eingehende Nachrichten"
+  },
+  "web.domains.incoming.config_description": {
+    "text": "Externen Benutzern erlauben, Nachrichten direkt an festgelegte Empfänger in diesem Bereich zu senden"
+  },
+  "web.domains.incoming.feature_disabled": {
+    "text": "Eingehende Nachrichten nicht verfügbar"
+  },
+  "web.domains.incoming.feature_disabled_description": {
+    "text": "Eingehende Nachrichten sind auf dieser Instanz nicht aktiviert. Wenden Sie sich an Ihren Administrator."
+  },
+  "web.domains.incoming.access_denied": {
+    "text": "Zugriff verweigert"
+  },
+  "web.domains.incoming.access_denied_description": {
+    "text": "Sie haben keine Berechtigung, die Einstellungen für eingehende Nachrichten in diesem Bereich zu verwalten. Wenden Sie sich an Ihren Organisationsadministrator."
+  },
+  "web.domains.incoming.upgrade_to_configure": {
+    "text": "Führen Sie ein Upgrade Ihres Tarifs durch, um eingehende Nachrichten für diesen Bereich zu konfigurieren."
+  },
+  "web.domains.incoming.configure_incoming": {
+    "text": "Eingehende Nachrichten konfigurieren"
+  },
+  "web.domains.incoming.not_configured_notice": {
+    "text": "Eingehende Nachrichten sind für diesen Bereich nicht konfiguriert. Fügen Sie Empfänger hinzu, damit externe Benutzer Nachrichten an Ihr Team senden können."
+  },
+  "web.domains.incoming.disabled_notice": {
+    "text": "Eingehende Nachrichten sind derzeit deaktiviert. Externe Benutzer können keine Nachrichten an Empfänger in diesem Bereich senden. Aktivieren Sie die Funktion unten, um eingehende Nachrichten zu erlauben."
+  },
+  "web.domains.incoming.recipients_title": {
+    "text": "Empfänger"
+  },
+  "web.domains.incoming.recipients_description": {
+    "text": "Legen Sie fest, wer in diesem Bereich eingehende Nachrichten empfangen kann. Empfänger erhalten E-Mail-Benachrichtigungen, wenn ihnen eine Nachricht gesendet wird."
+  },
+  "web.domains.incoming.add_recipient": {
+    "text": "Empfänger hinzufügen"
+  },
+  "web.domains.incoming.remove_recipient": {
+    "text": "Entfernen"
+  },
+  "web.domains.incoming.email_label": {
+    "text": "E-Mail-Adresse"
+  },
+  "web.domains.incoming.email_placeholder": {
+    "text": "recipient{'@'}example.com"
+  },
+  "web.domains.incoming.name_label": {
+    "text": "Anzeigename"
+  },
+  "web.domains.incoming.name_placeholder": {
+    "text": "z. B. Security Team"
+  },
+  "web.domains.incoming.empty_state": {
+    "text": "Keine Empfänger konfiguriert"
+  },
+  "web.domains.incoming.empty_state_description": {
+    "text": "Fügen Sie Empfänger hinzu, damit externe Benutzer Nachrichten an Ihr Team senden können."
+  },
+  "web.domains.incoming.validation_invalid_email": {
+    "text": "Ungültige E-Mail-Adresse"
+  },
+  "web.domains.incoming.validation_duplicate_email": {
+    "text": "Diese E-Mail-Adresse wurde bereits hinzugefügt"
+  },
+  "web.domains.incoming.validation_max_recipients": {
+    "text": "Maximal {max} Empfänger erlaubt"
+  },
+  "web.domains.incoming.validation_name_required": {
+    "text": "Anzeigename ist erforderlich"
+  },
+  "web.domains.incoming.validation_email_required": {
+    "text": "E-Mail-Adresse ist erforderlich"
+  },
+  "web.domains.incoming.save_changes": {
+    "text": "Änderungen speichern"
+  },
+  "web.domains.incoming.discard_changes": {
+    "text": "Änderungen verwerfen"
+  },
+  "web.domains.incoming.update_success": {
+    "text": "Konfiguration für eingehende Nachrichten erfolgreich gespeichert"
+  },
+  "web.domains.incoming.delete_success": {
+    "text": "Konfiguration für eingehende Nachrichten erfolgreich entfernt"
+  },
+  "web.domains.incoming.recipient_count": {
+    "text": "{count} Empfänger | {count} Empfänger"
+  },
+  "web.domains.incoming.badge_not_configured": {
+    "text": "Nicht konfiguriert"
+  },
+  "web.domains.incoming.badge_configured": {
+    "text": "Konfiguriert"
+  },
+  "web.domains.incoming.badge_disabled": {
+    "text": "Deaktiviert"
+  },
+  "web.domains.incoming.tooltip_not_configured": {
+    "text": "Eingehende Nachrichten nicht konfiguriert - externe Benutzer können keine Nachrichten an diesen Bereich senden"
+  },
+  "web.domains.incoming.tooltip_configured": {
+    "text": "Eingehende Nachrichten mit {count} Empfänger(n) aktiviert"
+  },
+  "web.domains.incoming.tooltip_disabled": {
+    "text": "Die Funktion für eingehende Nachrichten ist für diesen Bereich deaktiviert"
+  },
+  "web.domains.incoming.enabled_label": {
+    "text": "Eingehende Nachrichten aktivieren"
+  },
+  "web.domains.incoming.enabled_hint": {
+    "text": "Externen Benutzern erlauben, Nachrichten an Empfänger in diesem Bereich zu senden"
+  },
+  "web.domains.incoming.public_url_label": {
+    "text": "Öffentliche URL"
+  },
+  "web.domains.incoming.public_url_description": {
+    "text": "Teilen Sie diese URL mit externen Benutzern, damit sie Nachrichten senden können"
+  },
+  "web.domains.incoming.copy_url": {
+    "text": "URL kopieren"
+  },
+  "web.domains.incoming.url_copied": {
+    "text": "URL in die Zwischenablage kopiert"
+  },
+  "web.domains.incoming.remove_all_confirmation": {
+    "text": "Möchten Sie wirklich alle Empfänger entfernen? Externe Benutzer können dann keine Nachrichten mehr an diesen Bereich senden."
+  },
+  "web.domains.incoming.max_recipients_reached": {
+    "text": "Maximale Anzahl an Empfängern erreicht"
+  },
+  "web.domains.incoming.duplicate_recipient": {
+    "text": "Diese E-Mail-Adresse wurde bereits hinzugefügt"
+  },
+  "web.domains.incoming.save_will_replace_confirmation": {
+    "text": "Beim Speichern werden alle vorhandenen Empfänger durch Ihre ausstehenden Änderungen ersetzt. Sind Sie sicher?"
+  },
+  "web.domains.incoming.delete_all_recipients": {
+    "text": "Alle Empfänger löschen"
+  },
+  "web.domains.signin.title": {
+    "text": "Anmeldekonfiguration"
+  },
+  "web.domains.signin.configure_signin": {
+    "text": "Anmeldung konfigurieren"
+  },
+  "web.domains.signin.config_description": {
+    "text": "Anmelde-Authentifizierungsmethoden für diesen Bereich konfigurieren"
+  },
+  "web.domains.signin.access_denied": {
+    "text": "Zugriff verweigert"
+  },
+  "web.domains.signin.upgrade_to_configure": {
+    "text": "Führen Sie ein Upgrade Ihres Tarifs durch, um Anmeldemethoden für diesen Bereich zu konfigurieren."
+  },
+  "web.domains.signin.not_configured_notice": {
+    "text": "Die Anmeldekonfiguration ist für diesen Bereich noch nicht festgelegt. Konfigurieren Sie Überschreibungen, um zu steuern, welche Authentifizierungsmethoden auf der Anmeldeseite dieses Bereichs verfügbar sind."
+  },
+  "web.domains.signin.signin_enabled_label": {
+    "text": "Anmeldung aktiviert"
+  },
+  "web.domains.signin.header_toggle_label": {
+    "text": "Anmeldung"
+  },
+  "web.domains.signin.signin_enabled_hint": {
+    "text": "Ob sich Benutzer in diesem Bereich eintragen können"
+  },
+  "web.domains.signin.restrict_to_label": {
+    "text": "Anmeldemethode einschränken"
+  },
+  "web.domains.signin.restrict_to_hint": {
+    "text": "Diesen Bereich auf eine einzige Authentifizierungsmethode einschränken. Wenn festgelegt, wird auf der Anmeldeseite nur die gewählte Methode angezeigt."
+  },
+  "web.domains.signin.all_methods": {
+    "text": "Alle Methoden"
+  },
+  "web.domains.signin.all_methods_description": {
+    "text": "Alle aktivierten Authentifizierungsmethoden auf der Anmeldeseite anzeigen"
+  },
+  "web.domains.signin.method_password": {
+    "text": "Passwort"
+  },
+  "web.domains.signin.method_email_auth": {
+    "text": "E-Mail-Authentifizierung"
+  },
+  "web.domains.signin.method_webauthn": {
+    "text": "WebAuthn / Passkeys"
+  },
+  "web.domains.signin.method_sso": {
+    "text": "Single Sign-On"
+  },
+  "web.domains.signin.method_overrides_label": {
+    "text": "Methoden-Überschreibungen"
+  },
+  "web.domains.signin.method_overrides_hint": {
+    "text": "Einzelne Authentifizierungsmethoden für diesen Bereich aktivieren oder deaktivieren"
+  },
+  "web.domains.signin.mode_question": {
+    "text": "Wie können sich Benutzer eintragen?"
+  },
+  "web.domains.signin.mode_any": {
+    "text": "Jede verfügbare Methode"
+  },
+  "web.domains.signin.mode_any_hint": {
+    "text": "Jede in diesem Bereich verfügbare Methode anzeigen. Schränken Sie einzelne Methoden unten ein."
+  },
+  "web.domains.signin.mode_one": {
+    "text": "Eine bestimmte Methode"
+  },
+  "web.domains.signin.mode_one_hint": {
+    "text": "Die Anmeldeseite auf eine einzige Methode einschränken. Es werden nur die in diesem Bereich verfügbaren Methoden aufgeführt."
+  },
+  "web.domains.signin.mode_disabled": {
+    "text": "Anmeldung deaktiviert"
+  },
+  "web.domains.signin.mode_disabled_hint": {
+    "text": "Benutzer können sich in diesem Bereich nicht eintragen."
+  },
+  "web.domains.signin.mode_disabled_notice": {
+    "text": "Besucher der Anmeldeseite dieses Bereichs sehen einen Hinweis, dass die Anmeldung nicht verfügbar ist, mit einem Link zurück zur Startseite. Ihre vorherigen Methodeneinstellungen werden beibehalten und wiederhergestellt, wenn Sie die Anmeldung wieder aktivieren."
+  },
+  "web.domains.signin.methods_list_label": {
+    "text": "Auf der Anmeldeseite angezeigte Methoden"
+  },
+  "web.domains.signin.restrict_picker_hint": {
+    "text": "Es werden nur die in diesem Bereich verfügbaren Methoden aufgeführt."
+  },
+  "web.domains.signin.availability_always": {
+    "text": "Immer verfügbar"
+  },
+  "web.domains.signin.availability_global_on": {
+    "text": "Folgt globaler Richtlinie · Ein"
+  },
+  "web.domains.signin.availability_global_off": {
+    "text": "Nicht verfügbar"
+  },
+  "web.domains.signin.availability_unavailable": {
+    "text": "Standortweit nicht verfügbar"
+  },
+  "web.domains.signin.allow_on_domain": {
+    "text": "In diesem Bereich erlauben"
+  },
+  "web.domains.signin.method_password_blurb": {
+    "text": "Nur Passwort"
+  },
+  "web.domains.signin.method_email_auth_blurb": {
+    "text": "Passwortlose Anmeldung per Magic Link"
+  },
+  "web.domains.signin.method_webauthn_blurb": {
+    "text": "Biometrie und Sicherheitsschlüssel"
+  },
+  "web.domains.signin.method_sso_blurb": {
+    "text": "Externer Identitätsanbieter"
+  },
+  "web.domains.signin.email_auth_label": {
+    "text": "E-Mail-Authentifizierung"
+  },
+  "web.domains.signin.email_auth_hint": {
+    "text": "Passwortlose E-Mail-Authentifizierung in diesem Bereich erlauben"
+  },
+  "web.domains.signin.sso_enabled_label": {
+    "text": "Single Sign-On"
+  },
+  "web.domains.signin.sso_enabled_hint": {
+    "text": "SSO-Authentifizierung in diesem Bereich erlauben"
+  },
+  "web.domains.signin.enabled_label": {
+    "text": "Anmeldekonfiguration aktivieren"
+  },
+  "web.domains.signin.enabled_hint": {
+    "text": "Wenn aktiviert, verwendet dieser Bereich die oben konfigurierten Anmeldeeinstellungen"
+  },
+  "web.domains.signin.save_config": {
+    "text": "Konfiguration speichern"
+  },
+  "web.domains.signin.update_success": {
+    "text": "Anmeldekonfiguration erfolgreich aktualisiert"
+  },
+  "web.domains.signin.reset_to_defaults": {
+    "text": "Auf Standardeinstellungen zurücksetzen"
+  },
+  "web.domains.signin.reset_confirm": {
+    "text": "Anmeldung auf die globalen Standardeinstellungen zurücksetzen?"
+  },
+  "web.domains.signin.reset_keeps_sso": {
+    "text": "Ihre SSO-Anmeldedaten werden beibehalten. Entfernen Sie diese separat auf dem SSO-Konfigurationsbildschirm."
+  },
+  "web.domains.signin.reset_action": {
+    "text": "Ja, zurücksetzen"
+  },
+  "web.domains.signin.reset_success": {
+    "text": "Anmeldeeinstellungen auf die globalen Standardeinstellungen zurückgesetzt"
+  },
+  "web.domains.signup.title": {
+    "text": "Registrierungsvalidierung"
+  },
+  "web.domains.signup.config_description": {
+    "text": "Registrierungsvalidierung für diesen Bereich konfigurieren"
+  },
+  "web.domains.signup.access_denied": {
+    "text": "Zugriff verweigert"
+  },
+  "web.domains.signup.upgrade_to_configure": {
+    "text": "Führen Sie ein Upgrade Ihres Tarifs durch, um die Registrierungsvalidierung pro Bereich zu konfigurieren."
+  },
+  "web.domains.signup.configure_signup": {
+    "text": "Registrierung konfigurieren"
+  },
+  "web.domains.signup.not_configured_notice": {
+    "text": "Die Registrierungsvalidierung ist für diesen Bereich noch nicht konfiguriert. Konfigurieren Sie eine Strategie, um zu steuern, wer sich über diesen Bereich registrieren kann."
+  },
+  "web.domains.signup.site_signups_disabled_warning": {
+    "text": "Registrierungen sind derzeit auf Standortebene deaktiviert. Diese Richtlinie pro Bereich ist konfiguriert, wird den Datenverkehr aber erst regulieren, wenn die Standort-Registrierungen aktiviert sind."
+  },
+  "web.domains.signup.strategy_label": {
+    "text": "Validierungsstrategie"
+  },
+  "web.domains.signup.strategy_description": {
+    "text": "Wählen Sie, wie E-Mail-Adressen validiert werden, wenn sich Benutzer in diesem Bereich registrieren."
+  },
+  "web.domains.signup.network_validation_warning": {
+    "text": "Diese Strategie führt während der Registrierung Netzwerkaufrufe durch, was zu Verzögerungen führen oder von einigen Anbietern blockiert werden kann."
+  },
+  "web.domains.signup.allowed_domains_label": {
+    "text": "Erlaubte Bereiche für die Registrierung"
+  },
+  "web.domains.signup.allowed_domains_hint": {
+    "text": "Nur diese E-Mail-Bereiche dürfen sich registrieren. Fügen Sie einen Bereich pro Eintrag hinzu."
+  },
+  "web.domains.signup.domain_placeholder": {
+    "text": "example.com"
+  },
+  "web.domains.signup.invalid_domain": {
+    "text": "Bitte geben Sie einen gültigen Bereich ein (z. B. example.com)"
+  },
+  "web.domains.signup.domain_exists": {
+    "text": "Dieser Bereich ist bereits in der Liste"
+  },
+  "web.domains.signup.remove_domain": {
+    "text": "{domain} entfernen"
+  },
+  "web.domains.signup.enabled_label": {
+    "text": "Validierung pro Bereich aktivieren"
+  },
+  "web.domains.signup.enabled_hint": {
+    "text": "Wenn aktiviert, verwenden Registrierungen in diesem Bereich die obige Strategie anstelle der globalen Richtlinie."
+  },
+  "web.domains.signup.delete_config": {
+    "text": "Konfiguration löschen"
+  },
+  "web.domains.signup.delete_confirm": {
+    "text": "Konfiguration der Registrierungsvalidierung löschen? Registrierungen greifen dann auf die globale Richtlinie zurück."
+  },
+  "web.domains.signup.save_config": {
+    "text": "Konfiguration speichern"
+  },
+  "web.domains.signup.update_success": {
+    "text": "Registrierungsvalidierung erfolgreich aktualisiert"
+  },
+  "web.domains.signup.delete_success": {
+    "text": "Konfiguration der Registrierungsvalidierung erfolgreich entfernt"
+  },
+  "web.domains.signup.domain_overrides_label": {
+    "text": "Bereich-Überschreibungen"
+  },
+  "web.domains.signup.domain_overrides_hint": {
+    "text": "Globale Registrierungseinstellungen für diesen Bereich überschreiben"
+  },
+  "web.domains.signup.signup_enabled_label": {
+    "text": "Registrierung aktiviert"
+  },
+  "web.domains.signup.signup_enabled_hint": {
+    "text": "Überschreiben, ob die Registrierung für diesen Bereich aktiviert ist"
+  },
+  "web.domains.signup.autoverify_label": {
+    "text": "Konten automatisch verifizieren"
+  },
+  "web.domains.signup.autoverify_hint": {
+    "text": "Überschreiben, ob neue Konten in diesem Bereich automatisch verifiziert werden"
+  },
+  "web.domains.sso.title": {
+    "text": "Single Sign-On"
+  },
+  "web.domains.sso.config_title": {
+    "text": "SSO-Konfiguration"
+  },
+  "web.domains.sso.config_description": {
+    "text": "Single-Sign-On-Authentifizierung für diesen Bereich konfigurieren"
+  },
+  "web.domains.sso.access_denied": {
+    "text": "Zugriff verweigert"
+  },
+  "web.domains.sso.access_denied_description": {
+    "text": "Sie haben keine Berechtigung, die SSO-Einstellungen für diesen Bereich zu verwalten. Wenden Sie sich an Ihren Organisationsadministrator."
+  },
+  "web.domains.sso.upgrade_to_configure": {
+    "text": "Führen Sie ein Upgrade Ihres Tarifs durch, um Single Sign-On für diesen Bereich zu konfigurieren."
+  },
+  "web.domains.sso.create_success": {
+    "text": "SSO-Konfiguration erfolgreich erstellt"
+  },
+  "web.domains.sso.update_success": {
+    "text": "SSO-Konfiguration erfolgreich aktualisiert"
+  },
+  "web.domains.sso.delete_success": {
+    "text": "SSO-Konfiguration erfolgreich entfernt"
+  },
+  "web.domains.sso.test_success": {
+    "text": "Verbindungstest erfolgreich — Anbieter hat korrekt geantwortet"
+  },
+  "web.domains.sso.test_failed": {
+    "text": "Verbindungstest fehlgeschlagen"
+  },
+  "web.domains.sso.enforce_moved_notice": {
+    "text": "Um SSO für alle Anmeldungen in diesem Bereich vorzuschreiben, konfigurieren Sie es in den Anmeldeeinstellungen des Bereichs. Der reine SSO-Modus beschränkt die Anmeldeseite auf den hier konfigurierten SSO-Anbieter."
+  },
+  "web.domains.sso.configure_sso": {
+    "text": "SSO konfigurieren"
+  },
+  "web.domains.sso.not_configured_notice": {
+    "text": "SSO ist für diesen Bereich noch nicht konfiguriert. Aktivieren Sie Single Sign-On, damit sich Teammitglieder über den Identitätsanbieter Ihrer Organisation authentifizieren können."
+  },
+  "web.domains.sso.edit_credentials": {
+    "text": "Anmeldedaten bearbeiten"
+  },
+  "web.domains.sso.configure_button": {
+    "text": "Konfigurieren"
+  },
+  "web.domains.sso.upgrade_required": {
+    "text": "Upgrade zum Konfigurieren"
   }
 }

--- a/locales/content/de_AT/workspace-organizations.json
+++ b/locales/content/de_AT/workspace-organizations.json
@@ -578,5 +578,344 @@
   "web.organizations.invitations.expires_soon": {
     "text": "Läuft bald ab",
     "source_hash": "a5dcfef9"
+  },
+  "api.organizations.errors.not_found": {
+    "text": "Organisation nicht gefunden: %{extid}"
+  },
+  "api.organizations.errors.owner_required": {
+    "text": "Nur der Organisationsinhaber kann diese Aktion ausführen"
+  },
+  "api.organizations.errors.admin_required": {
+    "text": "Nur Organisationsinhaber und Administratoren können diese Aktion ausführen"
+  },
+  "api.organizations.errors.member_required": {
+    "text": "Sie müssen Mitglied der Organisation sein, um diese Aktion auszuführen"
+  },
+  "api.organizations.invitations.errors.create_admin_required": {
+    "text": "Nur Organisationsinhaber und Administratoren können Einladungen erstellen"
+  },
+  "api.organizations.invitations.errors.resend_admin_required": {
+    "text": "Nur Organisationsinhaber und Administratoren können Einladungen erneut senden"
+  },
+  "api.organizations.invitations.errors.view_admin_required": {
+    "text": "Nur Organisationsinhaber und Administratoren können Einladungen anzeigen"
+  },
+  "api.organizations.invitations.errors.revoke_admin_required": {
+    "text": "Nur Organisationsinhaber und Administratoren können Einladungen widerrufen"
+  },
+  "api.organizations.invitations.errors.email_required": {
+    "text": "E-Mail ist erforderlich"
+  },
+  "api.organizations.invitations.errors.email_invalid": {
+    "text": "Ungültiges E-Mail-Format"
+  },
+  "api.organizations.invitations.errors.role_invalid": {
+    "text": "Die Rolle muss Mitglied oder Administrator sein"
+  },
+  "api.organizations.invitations.errors.cannot_invite_owner": {
+    "text": "Einladung als Inhaber nicht möglich"
+  },
+  "api.organizations.invitations.errors.already_member": {
+    "text": "Der Benutzer ist bereits Mitglied dieser Organisation"
+  },
+  "api.organizations.invitations.errors.already_pending": {
+    "text": "Für diese E-Mail-Adresse ist bereits eine Einladung ausstehend"
+  },
+  "api.organizations.invitations.errors.member_limit_reached": {
+    "text": "Mitgliederlimit erreicht. Führen Sie ein Upgrade Ihres Tarifs durch, um weitere Mitglieder einzuladen."
+  },
+  "api.organizations.invitations.errors.not_found": {
+    "text": "Einladung nicht gefunden"
+  },
+  "api.organizations.invitations.errors.cannot_resend_non_pending": {
+    "text": "Es können nur ausstehende Einladungen erneut gesendet werden"
+  },
+  "api.organizations.invitations.errors.cannot_revoke_non_pending": {
+    "text": "Es können nur ausstehende Einladungen widerrufen werden"
+  },
+  "api.organizations.invitations.errors.resend_limit_reached": {
+    "text": "Maximales Limit für erneutes Senden (%{max}) erreicht"
+  },
+  "api.organizations.invitations.errors.accept_token_required": {
+    "text": "Token ist erforderlich"
+  },
+  "api.organizations.invitations.errors.accept_organization_gone": {
+    "text": "Die Organisation existiert nicht mehr"
+  },
+  "api.organizations.invitations.errors.accept_already_acted": {
+    "text": "Die Einladung wurde bereits %{status}"
+  },
+  "api.organizations.invitations.errors.accept_expired": {
+    "text": "Die Einladung ist abgelaufen"
+  },
+  "api.organizations.invitations.errors.accept_email_mismatch": {
+    "text": "Ihre E-Mail-Adresse stimmt nicht mit der Einladung überein"
+  },
+  "api.organizations.invitations.errors.accept_already_member": {
+    "text": "Sie sind bereits Mitglied dieser Organisation"
+  },
+  "web.organizations.entitlements_title": {
+    "text": "Organisationsberechtigungen"
+  },
+  "web.organizations.page_description_short": {
+    "text": "Ihre Workspaces anzeigen und konfigurieren"
+  },
+  "web.organizations.delete_organization_remove_domains_first": {
+    "text": "Entfernen Sie alle benutzerdefinierten Bereiche, bevor Sie diese Organisation löschen."
+  },
+  "web.organizations.default_org_delete_notice_title": {
+    "text": "Diese Organisation löschen"
+  },
+  "web.organizations.default_org_delete_notice_before": {
+    "text": "Dies ist Ihre Standardorganisation und kann nicht über das Konto entfernt werden. Um sie zu löschen, wenden Sie sich bitte über das"
+  },
+  "web.organizations.default_org_delete_notice_link": {
+    "text": "Feedback-Formular"
+  },
+  "web.organizations.default_org_delete_notice_after": {
+    "text": "."
+  },
+  "web.organizations.leave_organization": {
+    "text": "Diese Organisation verlassen"
+  },
+  "web.organizations.leave_organization_warning": {
+    "text": "Sie verlieren den Zugriff auf diese Organisation und ihre Ressourcen."
+  },
+  "web.organizations.leave_organization_confirm_title": {
+    "text": "Organisation verlassen"
+  },
+  "web.organizations.leave_organization_confirm_message": {
+    "text": "Möchten Sie {name} wirklich verlassen? Sie benötigen eine neue Einladung, um erneut beizutreten."
+  },
+  "web.organizations.leave_organization_success": {
+    "text": "Sie haben die Organisation verlassen."
+  },
+  "web.organizations.leave_error": {
+    "text": "Verlassen der Organisation fehlgeschlagen"
+  },
+  "web.organizations.organizations": {
+    "text": "Organisationen"
+  },
+  "web.organizations.invitations.invited_by_inline": {
+    "text": "von {email}"
+  },
+  "web.organizations.invitations.invited_as_inline": {
+    "text": "als {role}"
+  },
+  "web.organizations.invitations.back_to_home": {
+    "text": "Zurück zur Startseite"
+  },
+  "web.organizations.invitations.email_locked_hint": {
+    "text": "Diese Einladung wurde an diese E-Mail-Adresse gesendet"
+  },
+  "web.organizations.invitations.signup_continue": {
+    "text": "Weiter"
+  },
+  "web.organizations.invitations.signin_continue": {
+    "text": "Eintragen"
+  },
+  "web.organizations.invitations.confirm_join_below": {
+    "text": "Fast geschafft — bestätigen Sie unten, um der Organisation beizutreten."
+  },
+  "web.organizations.invitations.go_to_organizations": {
+    "text": "Zu den Organisationen"
+  },
+  "web.organizations.invitations.already_member": {
+    "text": "Sie sind bereits Mitglied dieser Organisation"
+  },
+  "web.organizations.invitations.join_organization": {
+    "text": "{orgName} beitreten"
+  },
+  "web.organizations.invitations.sign_in_to_join": {
+    "text": "Eintragen, um {orgName} beizutreten"
+  },
+  "web.organizations.invitations.decline": {
+    "text": "Ablehnen"
+  },
+  "web.organizations.members.member_quota": {
+    "text": "{used} von {limit} Mitgliedern"
+  },
+  "web.organizations.members.pending_suffix": {
+    "text": "({count} ausstehend)"
+  },
+  "web.organizations.members.limit_reached_hint": {
+    "text": "Mitgliederlimit erreicht."
+  },
+  "web.organizations.sso.title": {
+    "text": "Single Sign-On (SSO)"
+  },
+  "web.organizations.sso.description": {
+    "text": "Konfigurieren Sie SSO, damit sich Mitglieder über den Identitätsanbieter Ihrer Organisation eintragen können"
+  },
+  "web.organizations.sso.provider_type": {
+    "text": "Anbietertyp"
+  },
+  "web.organizations.sso.provider_type_description": {
+    "text": "Wählen Sie den Identitätsanbieter Ihrer Organisation"
+  },
+  "web.organizations.sso.display_name": {
+    "text": "Anzeigename"
+  },
+  "web.organizations.sso.display_name_hint": {
+    "text": "Ein benutzerfreundlicher Name, der Benutzern beim Eintragen angezeigt wird"
+  },
+  "web.organizations.sso.display_name_placeholder": {
+    "text": "z. B. Acme Corp SSO"
+  },
+  "web.organizations.sso.client_id": {
+    "text": "Client ID"
+  },
+  "web.organizations.sso.client_id_placeholder": {
+    "text": "Ihre OAuth-Client-ID"
+  },
+  "web.organizations.sso.client_secret": {
+    "text": "Client Secret"
+  },
+  "web.organizations.sso.client_secret_placeholder": {
+    "text": "Ihr OAuth-Client-Secret"
+  },
+  "web.organizations.sso.client_secret_update_hint": {
+    "text": "Leer lassen, um das vorhandene Client Secret beizubehalten"
+  },
+  "web.organizations.sso.tenant_id": {
+    "text": "Tenant ID"
+  },
+  "web.organizations.sso.tenant_id_hint": {
+    "text": "Ihre Azure AD / Entra ID Tenant-Kennung"
+  },
+  "web.organizations.sso.tenant_id_placeholder": {
+    "text": "z. B. 12345678-1234-1234-1234-123456789abc"
+  },
+  "web.organizations.sso.issuer": {
+    "text": "Issuer-URL"
+  },
+  "web.organizations.sso.issuer_hint": {
+    "text": "Die OIDC-Discovery-URL für Ihren Identitätsanbieter"
+  },
+  "web.organizations.sso.issuer_placeholder": {
+    "text": "z. B. https://login.example.com"
+  },
+  "web.organizations.sso.view_discovery_document": {
+    "text": "Discovery-Dokument anzeigen"
+  },
+  "web.organizations.sso.callback_url": {
+    "text": "Callback-URL"
+  },
+  "web.organizations.sso.callback_url_hint": {
+    "text": "Fügen Sie diese URL zu den erlaubten Redirect-URIs Ihres Identitätsanbieters hinzu"
+  },
+  "web.organizations.sso.allowed_domains": {
+    "text": "Erlaubte E-Mail-Bereiche"
+  },
+  "web.organizations.sso.allowed_domains_hint": {
+    "text": "Nur Benutzer mit E-Mail-Adressen aus diesen Bereichen können sich eintragen. Leer lassen, um alle Bereiche zu erlauben."
+  },
+  "web.organizations.sso.domain_placeholder": {
+    "text": "z. B. acme.com"
+  },
+  "web.organizations.sso.invalid_domain": {
+    "text": "Bitte geben Sie einen gültigen Bereich ein (z. B. example.com)"
+  },
+  "web.organizations.sso.domain_exists": {
+    "text": "Dieser Bereich ist bereits in der Liste"
+  },
+  "web.organizations.sso.remove_domain": {
+    "text": "{domain} entfernen"
+  },
+  "web.organizations.sso.enabled": {
+    "text": "SSO aktivieren"
+  },
+  "web.organizations.sso.enabled_hint": {
+    "text": "Wenn aktiviert, können sich Organisationsmitglieder über diesen SSO-Anbieter eintragen"
+  },
+  "web.organizations.sso.enforce_sso_only": {
+    "text": "Nur SSO erzwingen"
+  },
+  "web.organizations.sso.enforce_sso_only_hint": {
+    "text": "SSO für alle Anmeldungen in diesem Bereich vorschreiben. Wenn aktiviert, ist die passwortbasierte Authentifizierung deaktiviert."
+  },
+  "web.organizations.sso.grant_org_scope": {
+    "text": "Organisationsweiten Zugriff gewähren"
+  },
+  "web.organizations.sso.grant_org_scope_hint": {
+    "text": "Neue Mitglieder, die über das SSO dieses Bereichs beitreten, erhalten Zugriff auf alle Bereiche der Organisation. Bestehende Mitglieder sind nicht betroffen. Wenn deaktiviert (Standard), können neue Mitglieder nur auf diesen Bereich zugreifen."
+  },
+  "web.organizations.sso.save_config": {
+    "text": "SSO-Konfiguration speichern"
+  },
+  "web.organizations.sso.delete_config": {
+    "text": "Konfiguration löschen"
+  },
+  "web.organizations.sso.delete_confirm": {
+    "text": "Sind Sie sicher? Dadurch wird SSO für Ihre Organisation deaktiviert."
+  },
+  "web.organizations.sso.load_error": {
+    "text": "SSO-Konfiguration konnte nicht geladen werden"
+  },
+  "web.organizations.sso.save_error": {
+    "text": "SSO-Konfiguration konnte nicht gespeichert werden"
+  },
+  "web.organizations.sso.create_success": {
+    "text": "SSO-Konfiguration erfolgreich erstellt"
+  },
+  "web.organizations.sso.update_success": {
+    "text": "SSO-Konfiguration erfolgreich aktualisiert"
+  },
+  "web.organizations.sso.delete_success": {
+    "text": "SSO-Konfiguration erfolgreich gelöscht"
+  },
+  "web.organizations.sso.delete_error": {
+    "text": "SSO-Konfiguration konnte nicht gelöscht werden"
+  },
+  "web.organizations.sso.test_connection": {
+    "text": "Verbindung testen"
+  },
+  "web.organizations.sso.test_connection_hint": {
+    "text": "Überprüfen, ob der Identitätsanbieter erreichbar ist (validiert keine Anmeldedaten)"
+  },
+  "web.organizations.sso.test_button": {
+    "text": "Verbindung testen"
+  },
+  "web.organizations.sso.testing": {
+    "text": "Wird getestet..."
+  },
+  "web.organizations.sso.test_error": {
+    "text": "Verbindung konnte nicht getestet werden"
+  },
+  "web.organizations.sso.auth_endpoint": {
+    "text": "Autorisierungsendpunkt"
+  },
+  "web.organizations.sso.missing_fields": {
+    "text": "Fehlende Felder"
+  },
+  "web.organizations.sso.status_enabled": {
+    "text": "Aktiviert"
+  },
+  "web.organizations.sso.status_configured": {
+    "text": "Konfiguriert"
+  },
+  "web.organizations.sso.domain_sso_title": {
+    "text": "Bereichs-SSO"
+  },
+  "web.organizations.sso.domain_sso_description": {
+    "text": "SSO für jeden verifizierten Bereich konfigurieren"
+  },
+  "web.organizations.sso.provider_type_locked_hint": {
+    "text": "Um den Anbieter zu ändern, löschen Sie zuerst diese Konfiguration"
+  },
+  "web.organizations.sso.status_not_configured": {
+    "text": "Nicht konfiguriert"
+  },
+  "web.organizations.sso.no_domains": {
+    "text": "Keine verifizierten Bereiche"
+  },
+  "web.organizations.sso.no_domains_description": {
+    "text": "Fügen Sie einen Bereich hinzu und verifizieren Sie ihn, bevor Sie SSO dafür konfigurieren."
+  },
+  "web.organizations.tabs.team": {
+    "text": "Team"
+  },
+  "web.organizations.tabs.sso": {
+    "text": "SSO"
   }
 }


### PR DESCRIPTION
## `de_AT` translation update

Automated export of completed **de_AT** translations from the translation task DB.
Scope: `locales/content/de_AT/` only — 27 file(s), +1848/-30.

✅ `i18n validate variables`: no variable mismatches.

---

### Local quality review

> Produced by a fresh, isolated `claude` review agent (model `claude-sonnet-5`, agent `saas-translator`) that read
> `locales/AGENT_TRANSLATION_PROTOCOL.md` and inspected this branch's diff before the PR was opened.

The protocol file doesn't exist in this checkout — proceeding with the general rules stated in the task.

**Verdict:** ❌ Blockers — security-critical mistranslation + variable defect

**Summary:** Most of this large de_AT batch (SSO/domains/billing/colonel/email strings) is solid, consistent, and correctly formal-register, but one security-critical string was mistranslated and one "literal" brand string had an unmatched variable substituted in.

**Critical (must fix):**
- `web.INSTRUCTION.phishing_warning`: "überprüfen Sie den Regionen-Bereich" is nonsensical — the source instructs users to check the **domain**, not a "Regionen-Bereich" (regions area). This is the anti-phishing instruction itself; a garbled instruction defeats its purpose. Must be corrected to something like "überprüfen Sie die Domain/den Bereich".
- `web.homepage.one_time_secret_literal`: text changed from "Einmal-Geheimnis" to bare `{product_name}`, but `source_hash` (7872e050) is unchanged, meaning the English source wasn't touched. Given the key name (`_literal`), the source is almost certainly a hardcoded string with no variable — introducing `{product_name}` here is very likely an unmatched/invented variable. Needs verification against the English source before merge.

**Warnings:**
- Domain terminology is inconsistent within `workspace-domains.json`: most new strings use "Bereich" (matching de_AT's established Domain→Bereich convention), but the `web.domains.email.*` group repeatedly uses "Domäne" instead (e.g. `config_description`, `dns_records_description`, `provider_ses_description`). Pick one term.
- `web.homepage.onetime_secret_homepage`: "{product_name} Startseite" → "{product_name} Homepage" reintroduces the English loanword "Homepage" where "Startseite" was already correct German — a stylistic regression.
- `web.domains.signup.domain_overrides_label`: "Bereich-Überschreibungen" is missing the genitive -s used elsewhere in the same batch ("Bereichs-SSO", "Bereichs-Registrierungsvalidierung").

**Notes:**
- "Delano" → "Support-Team" signature swap applied consistently across all ~30 email templates — matches the pattern seen in other locale reviews this session.
- `_guidance.context` keys correctly left untranslated (doc metadata, per convention).
- Variable placeholders (`{ip}`, `{max}`, `{count}`, `%{extid}`, etc.) otherwise appear correctly preserved throughout the new keys; the automated consistency check produced no usable output (empty JSON), so this was checked manually and not exhaustively.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
