### PR TITLE
i18n: update eo translations

### DIFF
--- a/locales/content/eo/00-common.json
+++ b/locales/content/eo/00-common.json
@@ -1299,7 +1299,7 @@
     "source_hash": "fc78d9cb"
   },
   "web.INSTRUCTION.phishing_warning": {
-    "text": "Ĉiam kontrolu, ke vi estas sur la oficiala retejo de {product_name}. Frauduloj foje kreas falsajn retejojn, kiuj aspektas ekzakte kiel {product_name} por ŝteli viajn sekretojn. Por eviti phishing-atakojn, kontrolu la regiona domajno antaŭ krei novajn ligilojn.",
+    "text": "Ĉiam kontrolu ke vi estas sur la oficiala retejo de {product_name}. Friponoj foje kreas falsajn retejojn kiuj aspektas ekzakte kiel {product_name} por ŝteli viajn sekretojn. Por eviti phishing-atakojn, kontrolu la regionan domajnon antaŭ ol krei novajn ligilojn.",
     "source_hash": "b588f5b2"
   },
   "web.pricing.title": {
@@ -1383,5 +1383,110 @@
     "text": "Altigu vian planon por malŝlosi pliajn funkciojn",
     "context": "Description shown for free plan users encouraging upgrade",
     "source_hash": "783f174c"
+  },
+  "api.errors.authentication_required": {
+    "text": "Aŭtentikigo necesa"
+  },
+  "api.errors.sso_only_action_blocked": {
+    "text": "Ĉi tiu ago ne disponeblas en nur-SSO reĝimo"
+  },
+  "web.COMMON.configure": {
+    "text": "Agordi"
+  },
+  "web.COMMON.copy_to_clipboard": {
+    "text": "Kopii al tondujo"
+  },
+  "web.COMMON.add": {
+    "text": "Aldoni"
+  },
+  "web.COMMON.enabled": {
+    "text": "Ŝaltita"
+  },
+  "web.COMMON.disabled": {
+    "text": "Malŝaltita"
+  },
+  "web.COMMON.yes_delete": {
+    "text": "Jes, forigi"
+  },
+  "web.COMMON.error_code": {
+    "text": "Erarkodo"
+  },
+  "web.COMMON.http_status": {
+    "text": "HTTP-stato"
+  },
+  "web.COMMON.details": {
+    "text": "Detaloj"
+  },
+  "web.COMMON.field_confirm_password": {
+    "text": "Konfirmu pasvorton"
+  },
+  "web.COMMON.passwords_must_match": {
+    "text": "La pasvortoj devas kongrui"
+  },
+  "web.COMMON.and": {
+    "text": "kaj"
+  },
+  "web.COMMON.or": {
+    "text": "aŭ"
+  },
+  "web.COMMON.copied": {
+    "text": "Kopiita"
+  },
+  "web.COMMON.copy": {
+    "text": "Kopii"
+  },
+  "web.COMMON.copy_email": {
+    "text": "Kopii retpoŝtadreson"
+  },
+  "web.COMMON.copy_id": {
+    "text": "Kopii konto-ID"
+  },
+  "web.COMMON.org_id_tooltip": {
+    "text": "La unika identigilo de via organizo"
+  },
+  "web.COMMON.success": {
+    "text": "Sukceso"
+  },
+  "web.COMMON.need_help": {
+    "text": "Ĉu vi bezonas helpon"
+  },
+  "web.COMMON.open_help_dialog": {
+    "text": "Malfermi helpdialogon"
+  },
+  "web.COMMON.focus_is_now_in_the_main_text_area": {
+    "text": "La fokuso nun estas en la ĉefa tekstkampo"
+  },
+  "web.LABELS.show_passphrase": {
+    "text": "Montri sekretan frazon"
+  },
+  "web.LABELS.hide_passphrase": {
+    "text": "Kaŝi sekretan frazon"
+  },
+  "web.LABELS.copy_icon": {
+    "text": "Kopia piktogramo"
+  },
+  "web.LABELS.copied_icon": {
+    "text": "Kopiita piktogramo"
+  },
+  "web.STATUS.unverified": {
+    "text": "Nekontrolita"
+  },
+  "web.TITLES.domain_detail": {
+    "text": "Domajnaj Agordoj"
+  },
+  "web.TITLES.domain_signin": {
+    "text": "Agordo de Ensaluto"
+  },
+  "web.TITLES.domain_sso": {
+    "text": "Domajna SSO"
+  },
+  "web.TITLES.domain_signup": {
+    "text": "Validigo de Domajna Registriĝo"
+  },
+  "web.TITLES.domain_email": {
+    "text": "Retpoŝta Agordo"
+  },
+  "web.TITLES.domain_incoming": {
+    "text": "Alvenantaj Sekretoj"
   }
 }

--- a/locales/content/eo/10-layout.json
+++ b/locales/content/eo/10-layout.json
@@ -124,11 +124,11 @@
     "source_hash": "4d4a570f"
   },
   "web.meta.were_making_onetime_secret_available_in_multiple": {
-    "text": "",
+    "text": "Ni igas {onetime-secret} disponebla en pluraj lingvoj. Ĉar tio estas nova funkcio, vi eble renkontos tradukerarojn aŭ mallertan frazadon. Via reago helpas nin pliboniĝi - se vi rimarkas iujn problemojn, bonvolu {send-feedback}",
     "source_hash": "3b482d7f"
   },
   "web.meta.translations_are_new_spotted_an_error": {
-    "text": "",
+    "text": "La tradukoj estas novaj. Ĉu vi rimarkis eraron? {send-feedback}",
     "source_hash": "31eca08d"
   },
   "web.meta.we_recently_added_translations": {
@@ -136,7 +136,7 @@
     "source_hash": "6e2455c1"
   },
   "web.meta.privacy_and_security_should_be_accessible": {
-    "text": "",
+    "text": "Privateco kaj sekureco devus esti alireblaj por ĉiuj, sendepende de lingvo. Ni aldonas tradukojn por helpi kaj niajn uzantojn kaj iliajn mesaĝricevantojn pli bone kompreni kiel sekure uzi kaj aliri sekurajn mesaĝojn kaj ligilojn. Ĉar tio estas nova funkcio, vi eble renkontos kelkajn tradukerarojn aŭ neklarajn instrukciojn. Por helpi nin plibonigi la klarecon kaj precizecon de niaj tradukoj, precipe por kritika sekureco-rilata enhavo, bonvolu {send-feedback} se vi rimarkas iujn problemojn",
     "source_hash": "1b8bb38f"
   },
   "web.help.learn_more": {
@@ -240,7 +240,7 @@
     "source_hash": "e26d51d3"
   },
   "web.layout.customize_your_app_preferences_and_settings": {
-    "text": "",
+    "text": "Personecigu viajn aplikaĵajn preferojn kaj agordojn",
     "source_hash": "00d74c98"
   },
   "web.layout.return_home": {
@@ -264,7 +264,7 @@
     "source_hash": "e2f124cd"
   },
   "web.layout.visit_onetime_secret_homepage": {
-    "text": "Viziti {product_name} hejmpaĝon",
+    "text": "Vizitu la hejmpaĝon de {product_name}",
     "source_hash": "625556d2"
   },
   "web.layout.footer_navigation": {
@@ -338,5 +338,11 @@
   "web.layout.workspace_context": {
     "text": "Laborspaca kunteksto",
     "source_hash": "dc6fa4f5"
+  },
+  "web.footer.workspace": {
+    "text": "Laborspaco"
+  },
+  "web.help.default_content": {
+    "text": "Bonvolu kontakti subtenon por helpo"
   }
 }

--- a/locales/content/eo/admin-colonel.json
+++ b/locales/content/eo/admin-colonel.json
@@ -634,5 +634,152 @@
   "web.colonel.feedback.when_you_submit_feedback_well_see": {
     "text": "Kiam vi sendos retrosciigon, ni vidos:",
     "source_hash": "fe77172e"
+  },
+  "web.colonel.previewPlanMode": {
+    "text": "Antaŭrigarda plana reĝimo"
+  },
+  "web.colonel.previewModeDescription": {
+    "text": "Antaŭrigardu la aplikaĵon kiel ĝi aperas al klientoj kun malsama plano. Tio efikas nur al via vido kaj ne ŝanĝas la efektivan planon de iu ajn organizo."
+  },
+  "web.colonel.previewModeActive": {
+    "text": "Antaŭrigardo aktiva"
+  },
+  "web.colonel.bannedIps.empty": {
+    "text": "Neniuj malpermesitaj IP-oj"
+  },
+  "web.colonel.bannedIps.currentIp": {
+    "text": "Via aktuala IP-adreso"
+  },
+  "web.colonel.bannedIps.confirmUnban": {
+    "text": "Ĉu nuligi malpermeson de {ip}?"
+  },
+  "web.colonel.bannedIps.actions.ban": {
+    "text": "Malpermesi IP-on"
+  },
+  "web.colonel.bannedIps.actions.quickBan": {
+    "text": "Rapida malpermeso"
+  },
+  "web.colonel.bannedIps.actions.unban": {
+    "text": "Nuligi malpermeson"
+  },
+  "web.colonel.bannedIps.actions.cancel": {
+    "text": "Nuligi"
+  },
+  "web.colonel.bannedIps.columns.ipAddress": {
+    "text": "IP-adreso"
+  },
+  "web.colonel.bannedIps.columns.reason": {
+    "text": "Kialo"
+  },
+  "web.colonel.bannedIps.columns.bannedAt": {
+    "text": "Malpermesita je"
+  },
+  "web.colonel.bannedIps.columns.bannedBy": {
+    "text": "Malpermesita de"
+  },
+  "web.colonel.bannedIps.error.banFailed": {
+    "text": "Malsukcesis malpermesi la IP-adreson"
+  },
+  "web.colonel.bannedIps.error.unbanFailed": {
+    "text": "Malsukcesis nuligi la malpermeson de la IP-adreso"
+  },
+  "web.colonel.bannedIps.form.title": {
+    "text": "Malpermesi IP-adreson"
+  },
+  "web.colonel.bannedIps.form.ipLabel": {
+    "text": "IP-adreso"
+  },
+  "web.colonel.bannedIps.form.reasonLabel": {
+    "text": "Kialo"
+  },
+  "web.colonel.bannedIps.form.reasonPlaceholder": {
+    "text": "Nedeviga kialo"
+  },
+  "web.colonel.bannedIps.success.banned": {
+    "text": "La IP-adreso {ip} estas malpermesita"
+  },
+  "web.colonel.bannedIps.success.unbanned": {
+    "text": "La malpermeso de la IP-adreso {ip} estas nuligita"
+  },
+  "web.colonel.customDomains.empty": {
+    "text": "Neniuj propraj domajnoj agorditaj"
+  },
+  "web.colonel.customDomains.noLogo": {
+    "text": "Neniu logo"
+  },
+  "web.colonel.customDomains.labels.organization": {
+    "text": "Organizo"
+  },
+  "web.colonel.customDomains.labels.externalId": {
+    "text": "Ekstera ID"
+  },
+  "web.colonel.customDomains.labels.created": {
+    "text": "Kreita"
+  },
+  "web.colonel.customDomains.labels.updated": {
+    "text": "Ĝisdatigita"
+  },
+  "web.colonel.customDomains.labels.favicon": {
+    "text": "Favicon"
+  },
+  "web.colonel.customDomains.status.verified": {
+    "text": "Kontrolita"
+  },
+  "web.colonel.customDomains.status.resolving": {
+    "text": "Solvanta"
+  },
+  "web.colonel.customDomains.status.ready": {
+    "text": "Preta"
+  },
+  "web.colonel.customDomains.status.publicHomepage": {
+    "text": "Publika hejmpaĝo"
+  },
+  "web.colonel.customDomains.status.publicApi": {
+    "text": "Publika API"
+  },
+  "web.colonel.customDomains.status.pending": {
+    "text": "Atendanta"
+  },
+  "web.colonel.pagination.showing": {
+    "text": "Montrante {start}–{end} el {total}"
+  },
+  "web.colonel.pagination.itemsPerPage": {
+    "text": "Eroj por paĝo"
+  },
+  "web.colonel.pagination.perPage": {
+    "text": "{count} por paĝo"
+  },
+  "web.colonel.pagination.pageOf": {
+    "text": "Paĝo {current} el {total}"
+  },
+  "web.colonel.secrets.empty": {
+    "text": "Neniuj sekretoj trovitaj"
+  },
+  "web.colonel.secrets.never": {
+    "text": "Neniam"
+  },
+  "web.colonel.secrets.columns.shortId": {
+    "text": "Mallonga ID"
+  },
+  "web.colonel.secrets.columns.state": {
+    "text": "Stato"
+  },
+  "web.colonel.secrets.columns.created": {
+    "text": "Kreita"
+  },
+  "web.colonel.secrets.columns.expiration": {
+    "text": "Eksvalidiĝo"
+  },
+  "web.colonel.secrets.columns.age": {
+    "text": "Aĝo (tagoj)"
+  },
+  "web.colonel.secrets.state.new": {
+    "text": "Nova"
+  },
+  "web.colonel.secrets.state.received": {
+    "text": "Ricevita"
+  },
+  "web.colonel.secrets.state.viewed": {
+    "text": "Vidita"
   }
 }

--- a/locales/content/eo/api-account-errors.json
+++ b/locales/content/eo/api-account-errors.json
@@ -1,0 +1,8 @@
+{
+  "api.account.errors.invalid_email": {
+    "text": "Ĉu tio estas valida retpoŝtadreso?"
+  },
+  "api.account.errors.password_too_short": {
+    "text": "La pasvorto estas tro mallonga"
+  }
+}

--- a/locales/content/eo/api-domains-errors.json
+++ b/locales/content/eo/api-domains-errors.json
@@ -1,0 +1,29 @@
+{
+  "api.domains.errors.domain_id_required": {
+    "text": "Domajna ID necesas"
+  },
+  "api.domains.errors.domain_not_found": {
+    "text": "Domajno ne trovita: %{extid}"
+  },
+  "api.domains.errors.organization_not_found": {
+    "text": "Organizo ne trovita por domajno: %{domain}"
+  },
+  "api.domains.errors.incoming_secrets_disabled": {
+    "text": "Envenantaj sekretoj ne estas ebligitaj sur ĉi tiu instanco"
+  },
+  "api.domains.errors.incoming_secrets_entitlement_required": {
+    "text": "Administrado de envenantaj sekretoj postulas la rajtigon incoming_secrets. Bonvolu altniveligi vian planon."
+  },
+  "api.domains.errors.incoming_config_not_found": {
+    "text": "Envenanta agordo ne trovita por domajno: %{extid}"
+  },
+  "api.domains.errors.recipients_max_exceeded": {
+    "text": "Maksimume %{max} ricevantoj permesataj"
+  },
+  "api.domains.errors.recipients_invalid_email": {
+    "text": "Nevalida retpoŝtadreso: %{email}"
+  },
+  "api.domains.errors.recipients_duplicate": {
+    "text": "Duobligitaj retpoŝtadresoj de ricevantoj ne permesataj"
+  }
+}

--- a/locales/content/eo/api-entitlements-errors.json
+++ b/locales/content/eo/api-entitlements-errors.json
@@ -1,0 +1,71 @@
+{
+  "api.entitlements.errors.context_unavailable": {
+    "text": "Ne eblas kontroli rajtigojn (organiza kunteksto ne disponebla)"
+  },
+  "api.entitlements.errors.api_access_required": {
+    "text": "API-aliro postulas plibonigon de la plano"
+  },
+  "api.entitlements.errors.custom_privacy_defaults_required": {
+    "text": "Propraj privatecaj defaŭltoj postulas plibonigon de la plano"
+  },
+  "api.entitlements.errors.extended_default_expiration_required": {
+    "text": "Plilongigita defaŭlta eksvalidiĝo postulas plibonigon de la plano"
+  },
+  "api.entitlements.errors.custom_domains_required": {
+    "text": "Propraj domajnoj postulas plibonigon de la plano"
+  },
+  "api.entitlements.errors.custom_branding_required": {
+    "text": "Propra marko postulas plibonigon de la plano"
+  },
+  "api.entitlements.errors.homepage_secrets_required": {
+    "text": "Hejmpaĝaj sekretoj postulas plibonigon de la plano"
+  },
+  "api.entitlements.errors.incoming_secrets_required": {
+    "text": "Envenantaj sekretoj postulas plibonigon de la plano"
+  },
+  "api.entitlements.errors.custom_mail_sender_required": {
+    "text": "Propra poŝtsendilo postulas plibonigon de la plano"
+  },
+  "api.entitlements.errors.flexible_from_domain_required": {
+    "text": "Fleksebla sendint-domajno postulas plibonigon de la plano"
+  },
+  "api.entitlements.errors.manage_org_required": {
+    "text": "Organiza administrado postulas plibonigon de la plano"
+  },
+  "api.entitlements.errors.manage_teams_required": {
+    "text": "Team-administrado postulas plibonigon de la plano"
+  },
+  "api.entitlements.errors.manage_members_required": {
+    "text": "Membro-administrado postulas plibonigon de la plano"
+  },
+  "api.entitlements.errors.manage_sso_required": {
+    "text": "SSO-administrado postulas plibonigon de la plano"
+  },
+  "api.entitlements.errors.audit_logs_required": {
+    "text": "Kontrolaj protokoloj postulas plibonigon de la plano"
+  },
+  "api.entitlements.errors.custom_signup_validation_required": {
+    "text": "Propra registriĝa validigo postulas plibonigon de la plano"
+  },
+  "api.entitlements.errors.create_secrets_required": {
+    "text": "Krei sekretojn postulas plibonigon de la plano"
+  },
+  "api.entitlements.errors.view_receipt_required": {
+    "text": "Vidi kvitancojn postulas plibonigon de la plano"
+  },
+  "api.entitlements.errors.notifications_required": {
+    "text": "Sciigoj postulas plibonigon de la plano"
+  },
+  "api.entitlements.errors.workspace_branding_required": {
+    "text": "Laborspaco-marko postulas plibonigon de la plano"
+  },
+  "api.entitlements.errors.ip_access_rules_required": {
+    "text": "IP-aliraj reguloj postulas plibonigon de la plano"
+  },
+  "api.entitlements.errors.manage_billing_required": {
+    "text": "Fakturada administrado postulas plibonigon de la plano"
+  },
+  "api.entitlements.errors.custom_signin_config_required": {
+    "text": "Propra ensaluta agordo postulas plibonigon de la plano"
+  }
+}

--- a/locales/content/eo/api-feedback-errors.json
+++ b/locales/content/eo/api-feedback-errors.json
@@ -1,0 +1,5 @@
+{
+  "api.feedback.errors.rate_limit_exceeded": {
+    "text": "Tro multaj sendoj de komentoj. Bonvolu reprovi poste."
+  }
+}

--- a/locales/content/eo/api-incoming-errors.json
+++ b/locales/content/eo/api-incoming-errors.json
@@ -1,0 +1,5 @@
+{
+  "api.incoming.errors.custom_domain_unresolved": {
+    "text": "La organizo de la propra domajno ne povis esti solvita"
+  }
+}

--- a/locales/content/eo/api-invite-errors.json
+++ b/locales/content/eo/api-invite-errors.json
@@ -1,0 +1,23 @@
+{
+  "api.invite.errors.invitation_not_found_or_expired": {
+    "text": "Invito ne trovita aŭ eksvalidiĝinta"
+  },
+  "api.invite.errors.token_required": {
+    "text": "Ĵetono necesas"
+  },
+  "api.invite.errors.organization_no_longer_exists": {
+    "text": "La organizo ne plu ekzistas"
+  },
+  "api.invite.errors.invitation_already_processed": {
+    "text": "La invito jam estis %{status}"
+  },
+  "api.invite.errors.invitation_expired": {
+    "text": "La invito eksvalidiĝis"
+  },
+  "api.invite.errors.email_mismatch": {
+    "text": "Via retpoŝtadreso ne kongruas kun la invito"
+  },
+  "api.invite.errors.already_member": {
+    "text": "Vi jam estas membro de ĉi tiu organizo"
+  }
+}

--- a/locales/content/eo/api-organizations-errors.json
+++ b/locales/content/eo/api-organizations-errors.json
@@ -1,0 +1,107 @@
+{
+  "api.organizations.errors.domain_scoped_forbidden": {
+    "text": "Membroj limigitaj al domajno ne povas plenumi ĉi tiun agon"
+  },
+  "api.organizations.errors.organization_not_found": {
+    "text": "Organizo ne trovita: %{extid}"
+  },
+  "api.organizations.errors.organization_owner_required": {
+    "text": "Nur la posedanto de la organizo povas plenumi ĉi tiun agon"
+  },
+  "api.organizations.errors.organization_member_required": {
+    "text": "Vi devas esti membro de la organizo por plenumi ĉi tiun agon"
+  },
+  "api.organizations.errors.organization_admin_required": {
+    "text": "Nur posedantoj kaj administrantoj de la organizo povas plenumi ĉi tiun agon"
+  },
+  "api.organizations.errors.extid_required": {
+    "text": "Organiza ID necesas"
+  },
+  "api.organizations.errors.display_name_required": {
+    "text": "Organiznomo necesas"
+  },
+  "api.organizations.errors.display_name_too_long": {
+    "text": "Organiznomo devas esti malpli ol %{max} signoj"
+  },
+  "api.organizations.errors.description_too_long": {
+    "text": "Priskribo devas esti malpli ol %{max} signoj"
+  },
+  "api.organizations.errors.contact_email_exists": {
+    "text": "Organizo kun ĉi tiu kontakta retpoŝtadreso jam ekzistas"
+  },
+  "api.organizations.errors.creation_in_progress": {
+    "text": "Kreado de organizo en progreso. Bonvolu reprovi."
+  },
+  "api.organizations.errors.organization_limit_reached": {
+    "text": "Limo de organizoj atingita. Altniveligu vian planon por krei pli da organizoj."
+  },
+  "api.organizations.invitations.errors.invitation_not_found": {
+    "text": "Invito ne trovita"
+  },
+  "api.organizations.invitations.errors.email_required": {
+    "text": "Retpoŝtadreso necesas"
+  },
+  "api.organizations.invitations.errors.invalid_email_format": {
+    "text": "Nevalida formato de retpoŝtadreso"
+  },
+  "api.organizations.invitations.errors.invalid_role": {
+    "text": "Rolo devas esti membro aŭ administranto"
+  },
+  "api.organizations.invitations.errors.cannot_invite_as_owner": {
+    "text": "Ne eblas inviti kiel posedanto"
+  },
+  "api.organizations.invitations.errors.user_already_member": {
+    "text": "La uzanto jam estas membro de ĉi tiu organizo"
+  },
+  "api.organizations.invitations.errors.invitation_already_pending": {
+    "text": "Invito jam atendanta por ĉi tiu retpoŝtadreso"
+  },
+  "api.organizations.invitations.errors.member_limit_reached": {
+    "text": "Limo de membroj atingita. Altniveligu vian planon por inviti pli da membroj."
+  },
+  "api.organizations.invitations.errors.resend_only_pending": {
+    "text": "Eblas resendi nur atendantajn invitojn"
+  },
+  "api.organizations.invitations.errors.resend_limit_reached": {
+    "text": "Maksimuma limo de resendoj (%{max}) atingita"
+  },
+  "api.organizations.invitations.errors.revoke_only_pending": {
+    "text": "Eblas revoki nur atendantajn invitojn"
+  },
+  "api.organizations.members.errors.member_not_found": {
+    "text": "Membro ne trovita: %{extid}"
+  },
+  "api.organizations.members.errors.member_not_in_organization": {
+    "text": "Membro ne trovita en ĉi tiu organizo"
+  },
+  "api.organizations.members.errors.member_not_active": {
+    "text": "La membro ne estas aktiva"
+  },
+  "api.organizations.members.errors.invalid_role_value": {
+    "text": "Nevalida rolo. Devas esti unu el: %{roles}"
+  },
+  "api.organizations.members.errors.cannot_change_owner_role": {
+    "text": "Ne eblas ŝanĝi la rolon de posedanto. Anstataŭe uzu transdonon de posedo."
+  },
+  "api.organizations.members.errors.member_already_has_role": {
+    "text": "La membro jam havas la rolon: %{role}"
+  },
+  "api.organizations.members.errors.cannot_promote_to_owner": {
+    "text": "Ne eblas promocii al posedanto. Anstataŭe uzu transdonon de posedo."
+  },
+  "api.organizations.members.errors.must_be_member": {
+    "text": "Vi devas esti membro de ĉi tiu organizo"
+  },
+  "api.organizations.members.errors.cannot_remove_owner": {
+    "text": "Ne eblas forigi la posedanton de la organizo. Unue transdonu la posedon."
+  },
+  "api.organizations.members.errors.cannot_remove_self": {
+    "text": "Ne eblas forigi vin mem. Anstataŭe uzu forlasi la organizon."
+  },
+  "api.organizations.members.errors.admin_cannot_remove_admin": {
+    "text": "Administrantoj ne povas forigi aliajn administrantojn. Nur posedantoj povas."
+  },
+  "api.organizations.members.errors.no_permission_to_remove": {
+    "text": "Vi ne havas permeson forigi membrojn"
+  }
+}

--- a/locales/content/eo/api-secrets-errors.json
+++ b/locales/content/eo/api-secrets-errors.json
@@ -1,0 +1,11 @@
+{
+  "api.secrets.errors.domain_permission_authenticated_non_owner": {
+    "text": "Vi ne havas permeson uzi la domajnon: %{domain}"
+  },
+  "api.secrets.errors.domain_public_sharing_disabled": {
+    "text": "Publika kunhavigo malŝaltita por la domajno: %{domain}"
+  },
+  "api.secrets.errors.domain_permission_anonymous_cross_domain": {
+    "text": "Vi ne havas permeson uzi la domajnon: %{domain}"
+  }
+}

--- a/locales/content/eo/email.json
+++ b/locales/content/eo/email.json
@@ -60,7 +60,7 @@
     "source_hash": "88c72144"
   },
   "email.welcome.signature": {
-    "text": "Delano",
+    "text": "Subtena teamo",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -100,7 +100,7 @@
     "source_hash": "fbb7eb2d"
   },
   "email.password_request.signature": {
-    "text": "Delano",
+    "text": "Subtena teamo",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -145,7 +145,7 @@
     "source_hash": "1863f5be"
   },
   "email.magic_link.signature": {
-    "text": "Delano",
+    "text": "Subtena teamo",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -230,7 +230,7 @@
     "source_hash": "3f6b45dd"
   },
   "email.secret_revealed.signature": {
-    "text": "Delano",
+    "text": "Subtena teamo",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -355,7 +355,7 @@
     "source_hash": "734882d2"
   },
   "email.organization_invitation.signature": {
-    "text": "Delano",
+    "text": "Subtena teamo",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -395,7 +395,7 @@
     "source_hash": "be92cff3"
   },
   "email.password_changed.signature": {
-    "text": "Delano",
+    "text": "Subtena teamo",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -445,7 +445,7 @@
     "source_hash": "f8d47b82"
   },
   "email.email_changed.signature": {
-    "text": "Delano",
+    "text": "Subtena teamo",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -495,7 +495,7 @@
     "source_hash": "f8d47b82"
   },
   "email.email_change_requested.signature": {
-    "text": "Delano",
+    "text": "Subtena teamo",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -550,7 +550,7 @@
     "source_hash": "d4d835fc"
   },
   "email.email_change_confirmation.signature": {
-    "text": "Delano",
+    "text": "Subtena teamo",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -580,7 +580,7 @@
     "source_hash": "e7c11bb0"
   },
   "email.mfa_enabled.signature": {
-    "text": "Delano",
+    "text": "Subtena teamo",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -605,7 +605,7 @@
     "source_hash": "97ef0a3e"
   },
   "email.mfa_disabled.signature": {
-    "text": "Delano",
+    "text": "Subtena teamo",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -650,7 +650,7 @@
     "source_hash": "450c54c5"
   },
   "email.new_login_alert.signature": {
-    "text": "Delano",
+    "text": "Subtena teamo",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -670,7 +670,7 @@
     "source_hash": "d442beed"
   },
   "email.member_removed.signature": {
-    "text": "Delano",
+    "text": "Subtena teamo",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -690,7 +690,7 @@
     "source_hash": "c2280c0c"
   },
   "email.role_changed.signature": {
-    "text": "Delano",
+    "text": "Subtena teamo",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -710,7 +710,7 @@
     "source_hash": "7095fc69"
   },
   "email.organization_deleted.signature": {
-    "text": "Delano",
+    "text": "Subtena teamo",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -750,7 +750,7 @@
     "source_hash": "36008943"
   },
   "email.payment_receipt.signature": {
-    "text": "Delano",
+    "text": "Subtena teamo",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -775,7 +775,7 @@
     "source_hash": "926406b1"
   },
   "email.payment_failed.signature": {
-    "text": "Delano",
+    "text": "Subtena teamo",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -800,7 +800,7 @@
     "source_hash": "66a1419e"
   },
   "email.trial_expiring.signature": {
-    "text": "Delano",
+    "text": "Subtena teamo",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -825,7 +825,7 @@
     "source_hash": "5a96ae38"
   },
   "email.subscription_changed.signature": {
-    "text": "Delano",
+    "text": "Subtena teamo",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -853,5 +853,41 @@
     "text": "Onetime Secret",
     "renderer": "erb",
     "source_hash": "1cd0194a"
+  },
+  "email.common.secret_link_label": {
+    "text": "Sekreta ligilo"
+  },
+  "email.common.automated_notice": {
+    "text": "Ĉi tio estas aŭtomata mesaĝo de %{product_name}."
+  },
+  "email.common.support_label": {
+    "text": "Subteno"
+  },
+  "email.expiration_warning.signature": {
+    "text": "Subtena teamo"
+  },
+  "email.expiration_warning.footer_note": {
+    "text": "Vi ricevis ĉi tion ĉar sekreto kiun vi kreis sur %{product_name} baldaŭ eksvalidiĝos."
+  },
+  "email.feedback_email.user_id_label": {
+    "text": "Uzanto:"
+  },
+  "email.feedback_email.timezone_label": {
+    "text": "Horzono:"
+  },
+  "email.feedback_email.version_label": {
+    "text": "Versio:"
+  },
+  "email.incoming_secret.footer_note": {
+    "text": "Vi ricevis ĉi tion ĉar iu uzis %{product_name} por sendi al vi sekreton. Se vi ne atendis ĝin, vi povas sekure ignori ĉi tiun retmesaĝon."
+  },
+  "email.secret_link.passphrase_label": {
+    "text": "Sekreta frazo necesa:"
+  },
+  "email.secret_link.passphrase_required": {
+    "text": "Ĉi tiu sekreto estas protektita per sekreta frazo. La sendinto devus provizi ĝin al vi aparte."
+  },
+  "email.secret_link.footer_note": {
+    "text": "Vi ricevis ĉi tion ĉar %{sender_email} uzis %{product_name} por kunhavigi sekreton kun vi. Se vi ne atendis ĝin, vi povas sekure ignori ĉi tiun retmesaĝon."
   }
 }

--- a/locales/content/eo/feature-feedback.json
+++ b/locales/content/eo/feature-feedback.json
@@ -58,5 +58,14 @@
   "web.feedback.reason_email_change_unauthorized": {
     "text": "Ŝajnas, ke vi raportas neaŭtorizitan retpoŝtan ŝanĝon en via konto. Bonvolu priskribi kio okazis kaj ni esploros tuj.",
     "source_hash": "00e56551"
+  },
+  "web.feedback.anonymous_no_reply": {
+    "text": "Noto: se vi ŝatus respondon, bonvolu subskribi aŭ inkluzivi retpoŝtadreson en la mesaĝo."
+  },
+  "web.feedback.characters_remaining": {
+    "text": "{count} signoj restantaj"
+  },
+  "web.feedback.character_limit_reached": {
+    "text": "Limo de signoj atingita"
   }
 }

--- a/locales/content/eo/feature-homepage-secrets.json
+++ b/locales/content/eo/feature-homepage-secrets.json
@@ -1,0 +1,50 @@
+{
+  "homepage_secrets.disabled.members_only_eyebrow": {
+    "text": "Nur-membra instanco"
+  },
+  "homepage_secrets.disabled.private_instance_eyebrow": {
+    "text": "Privata instanco"
+  },
+  "homepage_secrets.disabled.team_link_headline": {
+    "text": "Ĉi tiu ligilo estas por la teamo {workspace}."
+  },
+  "homepage_secrets.disabled.signin_headline": {
+    "text": "Ensalutu por krei {action}."
+  },
+  "homepage_secrets.disabled.signin_headline_action": {
+    "text": "sekretan ligilon"
+  },
+  "homepage_secrets.disabled.team_subtitle": {
+    "text": "Nur rajtigitaj teamanoj ĉe {domain} povas generi novajn unufojajn ligilojn ĉi tie. Ricevantoj ankoraŭ povas malfermi iun ajn ligilon kiun oni sendis al ili."
+  },
+  "homepage_secrets.disabled.public_subtitle": {
+    "text": "Nur rajtigitaj membroj de ĉi tiu instanco povas generi novajn unufojajn ligilojn. Ricevantoj ankoraŭ povas malfermi iun ajn ligilon kiun oni sendis al ili."
+  },
+  "homepage_secrets.disabled.signin_cta": {
+    "text": "Ensalutu al via konto"
+  },
+  "homepage_secrets.disabled.what_is_this": {
+    "text": "Kio estas ĉi tio?"
+  },
+  "homepage_secrets.disabled.trust_viewed_once": {
+    "text": "Vidita unufoje, poste for"
+  },
+  "homepage_secrets.disabled.trust_zero_retained": {
+    "text": "Nenio konservita"
+  },
+  "homepage_secrets.disabled.promo_title": {
+    "text": "Nova: senpagaj planoj nun inkluzivas proprajn domajnojn."
+  },
+  "homepage_secrets.disabled.promo_subtitle": {
+    "text": "Direktu vian domajnon al Onetime Secret kaj ekspedu sekretojn sub via propra marko."
+  },
+  "homepage_secrets.disabled.promo_learn_how": {
+    "text": "Lernu kiel"
+  },
+  "homepage_secrets.disabled.logo_alt": {
+    "text": "{name} emblemo"
+  },
+  "homepage_secrets.disabled.opens_in_new_tab": {
+    "text": "(malfermiĝas en nova langeto)"
+  }
+}

--- a/locales/content/eo/feature-incoming.json
+++ b/locales/content/eo/feature-incoming.json
@@ -130,5 +130,26 @@
   "incoming.receipt_link_text": {
     "text": "kvitanco",
     "source_hash": "6f328609"
+  },
+  "incoming.upgrade_required_title": {
+    "text": "Plibonigo bezonata"
+  },
+  "incoming.upgrade_required_description": {
+    "text": "Ĉi tiu funkcio postulas plibonigon de la plano. Bonvolu kontakti la posedanton de la konto por ebligi envenantajn sekretojn."
+  },
+  "incoming.validation_memo_too_long": {
+    "text": "Memorando devas esti {max} signoj aŭ malpli"
+  },
+  "incoming.validation_secret_required": {
+    "text": "Sekreta enhavo necesas"
+  },
+  "incoming.validation_recipient_required": {
+    "text": "Bonvolu elekti ricevanton"
+  },
+  "incoming.validation_feature_disabled": {
+    "text": "Funkcio de envenantaj sekretoj ne estas ebligita"
+  },
+  "incoming.validation_form_errors": {
+    "text": "Bonvolu kontroli la formularon pri eraroj"
   }
 }

--- a/locales/content/eo/feature-regions.json
+++ b/locales/content/eo/feature-regions.json
@@ -186,5 +186,8 @@
   "web.regions.jurisdictions.apac.name": {
     "text": "Asia-Pacific",
     "source_hash": "7a757670"
+  },
+  "web.regions.no_region_configured": {
+    "text": "Neniu regiona informo estas nuntempe disponebla por via konto."
   }
 }

--- a/locales/content/eo/feature-testimonials.json
+++ b/locales/content/eo/feature-testimonials.json
@@ -36,7 +36,7 @@
     "source_hash": "7879a747"
   },
   "web.testimonials.it_was_based_on_the_content_of_the_page_and_does": {
-    "text": "",
+    "text": "Ĝi baziĝis sur la enhavo de la paĝo kaj ne reprezentas realan personon aŭ firmaon.",
     "source_hash": "8b290e9a"
   },
   "web.testimonials.artificial_feedback": {
@@ -44,7 +44,7 @@
     "source_hash": "4c8d20ba"
   },
   "web.testimonials.this_content_is_ai_generated_based_on_the_conten": {
-    "text": "",
+    "text": "Ĉi tiu enhavo estas AI-generita surbaze de la enhavo de ĉi tiu paĝo kaj ne reprezentas realan personon aŭ firmaon.",
     "source_hash": "03c16436"
   }
 }

--- a/locales/content/eo/feature-translations.json
+++ b/locales/content/eo/feature-translations.json
@@ -1,6 +1,6 @@
 {
   "web.translations.welcomes_contributors_for_both_existing_and_new_": {
-    "text": "",
+    "text": "bonvenigas kontribuantojn por ekzistantaj kaj novaj lingvoj.",
     "source_hash": "87abcdeb"
   },
   "web.translations.our_github_project": {
@@ -12,7 +12,7 @@
     "source_hash": "10056bff"
   },
   "web.translations.whove_helped_with_translations_as_we_continue_to": {
-    "text": "",
+    "text": "kiuj helpis pri tradukoj dum ni daŭre disvolvas novajn funkciojn.",
     "source_hash": "d629cc71"
   },
   "web.translations.25_contributors": {
@@ -24,11 +24,11 @@
     "source_hash": "cf446287"
   },
   "web.translations.as_we_add_new_features_our_translations_graduall": {
-    "text": "",
+    "text": "Dum ni aldonas novajn funkciojn, niaj tradukoj iom post iom bezonas ĝisdatigojn por resti aktualaj. Ĉi tio influas kaj onetimesecret.com kaj milojn da memgastigitaj instalaĵoj tutmonde.",
     "source_hash": "c6fb1cf5"
   },
   "web.translations.remember_to_include_your_email_if_youre_not_logg": {
-    "text": "",
+    "text": "- memoru inkluzivi vian retpoŝtadreson se vi ne estas ensalutinta. Ĉiu traduko helpas pli da homoj komuniki sekure.",
     "source_hash": "1a8ccc7d"
   },
   "web.translations.reach_out_to_us": {
@@ -52,11 +52,11 @@
     "source_hash": "b963b7e9"
   },
   "web.translations.update_a_language_directly_through_our_github_pr": {
-    "text": "",
+    "text": "Ĝisdatigu lingvon rekte tra nia GitHub-projekto",
     "source_hash": "449cde87"
   },
   "web.translations.review_existing_translations_using_the_language_": {
-    "text": "",
+    "text": "Reviziu ekzistantajn tradukojn uzante la lingvoelektilon supre",
     "source_hash": "74ea57e9"
   },
   "web.translations.ready_to_help_some_ways_to_contribute": {
@@ -64,7 +64,7 @@
     "source_hash": "13131e36"
   },
   "web.translations.the_following_people_have_donated_their_time_to_": {
-    "text": "",
+    "text": "La jenaj homoj donacis sian tempon por helpi vastigi la atingon de {product_name}:",
     "source_hash": "85a766af"
   },
   "web.translations.translations": {
@@ -76,15 +76,15 @@
     "source_hash": "bb60a45d"
   },
   "web.translations.your_language_skills_can_help_expand_access_to_s": {
-    "text": "",
+    "text": "Viaj lingvaj kapabloj povas helpi vastigi aliron al sekura komunikado.",
     "source_hash": "ad22076b"
   },
   "web.translations.thanks_to_our_community_we_support_over_20_langu": {
-    "text": "",
+    "text": "Danke al nia komunumo, ni subtenas pli ol 20 lingvojn hodiaŭ. Tamen, pro nia rapida disvolva ritmo, multaj tradukoj bezonas ĝisdatigojn por resti aktualaj. Ĉi tio influas kaj onetimesecret.com kaj la milojn da memgastigitaj instalaĵoj tutmonde.",
     "source_hash": "ba5c4395"
   },
   "web.translations.since_2012_onetime_secret_has_provided_a_secure_": {
-    "text": "",
+    "text": "Ekde 2012, {product_name} provizis sekuran manieron kunhavigi sentemajn informojn tutmonde. Kun uzantoj tra regionoj kie la angla ne estas la ĉefa lingvo, precizaj tradukoj estas esencaj por fari sekuran komunikadon alirebla por ĉiuj.",
     "source_hash": "87a6e9af"
   },
   "web.translations.help_secure_communication_go_global": {

--- a/locales/content/eo/secret-homepage.json
+++ b/locales/content/eo/secret-homepage.json
@@ -144,7 +144,7 @@
     "source_hash": "1cd0194a"
   },
   "web.homepage.one_time_secret_literal": {
-    "text": "Unufoja Sekreto",
+    "text": "{product_name}",
     "source_hash": "7872e050"
   },
   "web.homepage.onetime_secret_homepage": {

--- a/locales/content/eo/secret-manage.json
+++ b/locales/content/eo/secret-manage.json
@@ -56,7 +56,7 @@
     "source_hash": "2e5a27e1"
   },
   "web.secrets.sample_secret_content_this_could_be_sensitive_data": {
-    "text": "",
+    "text": "Ekzempla sekreta enhavo. Ĉi tio povus esti sentema datumo\n\nAŭ plurlinia mesaĝo",
     "source_hash": "b3be3902"
   },
   "web.secrets.sample_secret_content": {
@@ -112,7 +112,7 @@
     "source_hash": "8b450877"
   },
   "web.secrets.when_ready_click_the_view_secret_button_at_the_t": {
-    "text": "",
+    "text": "Kiam preta, klaku la butonon ĉe la supro de la paĝo por malkaŝi vian unufojan mesaĝon.",
     "source_hash": "7a65b13e"
   },
   "web.secrets.what_happens_next": {
@@ -120,7 +120,7 @@
     "source_hash": "c72895ba"
   },
   "web.secrets.yes_after_viewing_the_secret_is_permanently_dele": {
-    "text": "",
+    "text": "Jes. Post vidado, la sekreto estas por ĉiam forigita el niaj serviloj, certigante vian privatecon.",
     "source_hash": "15e6ab70"
   },
   "web.secrets.is_it_secure": {
@@ -128,7 +128,7 @@
     "source_hash": "07fe1b84"
   },
   "web.secrets.onetime_secret_is_a_secure_way_to_share_sensitiv": {
-    "text": "",
+    "text": "{product_name} estas sekura maniero kunhavigi sentemajn informojn, kiu memdetruiĝas post ununura vidado.",
     "source_hash": "8a163297"
   },
   "web.secrets.what_is_this": {
@@ -260,7 +260,7 @@
     "source_hash": "aadb8006"
   },
   "web.receipt.the_burn_feature_lets_you_permanently_delete_a_s": {
-    "text": "",
+    "text": "La forbrulig-funkcio permesas al vi por ĉiam forigi sekreton antaŭ ol iu ajn vidas ĝin. Ĉi tio estas utila se vi bezonas revoki aliron aŭ kunhavigis la malĝustan informon. Post forbruligo, la sekreto ne povas esti rekuperita.",
     "source_hash": "8f82008b"
   },
   "web.receipt.whats_the_burn_feature": {
@@ -276,7 +276,7 @@
     "source_hash": "b69dacd2"
   },
   "web.receipt.for_security_reasons_we_cant_recover_lost_secret": {
-    "text": "",
+    "text": "Pro sekurecaj kialoj, ni ne povas rekuperi perditajn sekretajn ligilojn. Vi devos krei novan sekreton kaj generi novan ligilon. Ni rekomendas kopii la ligilon tuj post la kreo.",
     "source_hash": "3b229db9"
   },
   "web.receipt.lost_your_secret_link": {
@@ -288,7 +288,7 @@
     "source_hash": "1dceeb03"
   },
   "web.receipt.we_display_the_value_for_you_so_that_you_can_ver": {
-    "text": "",
+    "text": "Ni montras la valoron al vi por ke vi povu kontroli ĝin, sed ni faras tion unufoje, por ke se iu ricevas ĉi tiun privatan paĝon (en via retumila historio aŭ se vi hazarde sendas la privatan ligilon anstataŭ la sekretan), li ne vidu la sekretan valoron.",
     "source_hash": "cc1facdd"
   },
   "web.receipt.why_can_i_only_see_the_secret_value_once": {
@@ -296,7 +296,7 @@
     "source_hash": "b2e497d6"
   },
   "web.receipt.burning_a_secret_permanently_deletes_it_before_a": {
-    "text": "",
+    "text": "Forbruligo de sekreto por ĉiam forigas ĝin antaŭ ol iu povas legi ĝin. La ricevanto vidos mesaĝon indikantan ke la sekreto ne ekzistas. Ĉi tio estas utila se vi hazarde kunhavigas la malĝustan informon aŭ bezonas malebligi aliron.",
     "source_hash": "f3fa5bbb"
   },
   "web.receipt.what_happens_when_i_burn_a_secret": {
@@ -304,7 +304,7 @@
     "source_hash": "cfc61708"
   },
   "web.receipt.and_never_stored_in_its_original_form_this_appro": {
-    "text": "",
+    "text": "kaj neniam konservita en sia originala formo. Ĉi tiu aliro signifas ke ni ne povas aliri aŭ rekuperi vian sekreton - nur iu kun la ĝusta sekreta frazo povas.",
     "source_hash": "9b760dad"
   },
   "web.receipt.passphrase_protection": {
@@ -312,7 +312,7 @@
     "source_hash": "0a6c3735"
   },
   "web.receipt.each_secret_can_only_be_viewed_once_after_viewin": {
-    "text": "",
+    "text": "Ĉiu sekreto povas esti vidita nur unufoje. Post vidado, ĝi estas por ĉiam forigita de niaj serviloj. Ĉi tio certigas ke viaj sentemaj informoj ne estas hazarde malkaŝitaj per retumila historio aŭ erare kunhavigitaj privataj ligiloj.",
     "source_hash": "581b5abf"
   },
   "web.receipt.one_time_access": {
@@ -372,7 +372,7 @@
     "source_hash": "edae5139"
   },
   "web.secrets.workspace_mode_disabled_for_generate": {
-    "text": "",
+    "text": "Malŝaltita por generitaj pasvortoj - vi devas vidi la kvitancon por vidi la pasvorton",
     "source_hash": "29969ba9"
   },
   "web.secrets.scope_org": {
@@ -473,5 +473,11 @@
   },
   "web.private.send_feedback": {
     "text": "Sendi retrosciiĝon"
+  },
+  "web.receipt.open_link": {
+    "text": "Malfermi ligilon"
+  },
+  "web.secrets.messageDeleted": {
+    "text": "Mesaĝo forigita"
   }
 }

--- a/locales/content/eo/session-auth-extended.json
+++ b/locales/content/eo/session-auth-extended.json
@@ -716,5 +716,20 @@
   },
   "web.auth.sessions._guidance.context": {
     "text": "Administra paĝo por ensalutitaj aparatoj/folumiloj de uzanto"
+  },
+  "web.auth.google": {
+    "text": "Google"
+  },
+  "web.auth.mfa.alternative_auth_options": {
+    "text": "Alternativaj aŭtentikigaj opcioj"
+  },
+  "web.auth.remember.enabled": {
+    "text": "Resti ensalutinta"
+  },
+  "web.auth.sessions.session_singular": {
+    "text": "seanco"
+  },
+  "web.auth.sessions.session_plural": {
+    "text": "seancoj"
   }
 }

--- a/locales/content/eo/session-auth.json
+++ b/locales/content/eo/session-auth.json
@@ -398,5 +398,32 @@
   },
   "web.auth.verify._guidance.context": {
     "text": "Retpoŝta konfirmfluo post registriĝo"
+  },
+  "web.auth.account.sso_linked": {
+    "text": "SSO-konto"
+  },
+  "web.help.reset_password_link": {
+    "text": "Restarigi pasvorton"
+  },
+  "web.login.custom_domain_sso_title": {
+    "text": "Unuopa ensaluto estas disponebla por ĉi tiu domajno"
+  },
+  "web.login.custom_domain_sso_description": {
+    "text": "La organiza administranto povas ŝalti SSO por permesi al teamanoj ensaluti ĉi tie. Kontaktu la administranton por aliro."
+  },
+  "web.login.signin_disabled_heading": {
+    "text": "Ensaluto ne estas disponebla"
+  },
+  "web.login.signin_disabled_message": {
+    "text": "Ensaluto nuntempe ne estas disponebla en ĉi tiu domajno."
+  },
+  "web.login.errors.sso_not_configured": {
+    "text": "Unuopa ensaluto ne estas agordita por ĉi tiu domajno. Bonvolu kontakti vian administranton."
+  },
+  "web.login.errors.invalid_email": {
+    "text": "La retpoŝtadreso de via identeca provizanto estas nevalida. Bonvolu kontakti vian administranton."
+  },
+  "web.login.errors.domain_not_allowed": {
+    "text": "Via retpoŝta domajno ne estas rajtigita por SSO-registriĝo. Bonvolu kontakti vian administranton."
   }
 }

--- a/locales/content/eo/workspace-account.json
+++ b/locales/content/eo/workspace-account.json
@@ -682,5 +682,14 @@
   "web.settings.profile.didnt_receive_email": {
     "text": "Ĉu vi ne ricevis la retpoŝton?",
     "source_hash": "fe3ac3ad"
+  },
+  "web.settings.api.api_disabled_notice": {
+    "text": "La API estas malŝaltita por ĉi tiu instanco."
+  },
+  "web.settings.security.sso_managed_title": {
+    "text": "Sekureco administrata de SSO"
+  },
+  "web.settings.security.sso_managed_description": {
+    "text": "Via konto estas aŭtentikigita tra la unuopa ensaluta provizanto de via organizo. Pasvorto, plurfaktora aŭtentikigo kaj restaŭraj kodoj estas administrataj de via identeca provizanto."
   }
 }

--- a/locales/content/eo/workspace-billing.json
+++ b/locales/content/eo/workspace-billing.json
@@ -988,5 +988,47 @@
     "text": "Disponebla nur en via origina abona regiono",
     "context": "Hint shown on plan cards when currency does not match active subscription",
     "source_hash": "10de32e5"
+  },
+  "web.billing.already_subscribed": {
+    "text": "Vi jam estas abonita al ĉi tiu plano."
+  },
+  "web.billing.cancel.reactivate_button": {
+    "text": "Reaktivigi Abonon"
+  },
+  "web.billing.cancel.reactivate_success": {
+    "text": "Via abono estis reaktivigita. Vi daŭre estos fakturita kiel normale."
+  },
+  "web.billing.cancel.reactivate_error": {
+    "text": "Malsukcesis reaktivigi abonon. Bonvolu reprovi aŭ kontakti subtenon."
+  },
+  "web.billing.features.manage_orgs": {
+    "text": "Organiz-administrado"
+  },
+  "web.billing.features.flexible_from_domain": {
+    "text": "Fleksebla retpoŝta sendint-domajno"
+  },
+  "web.billing.features.unlimited_admins": {
+    "text": "Senlimaj administrantoj"
+  },
+  "web.billing.features.manage_sso": {
+    "text": "SSO"
+  },
+  "web.billing.overview.entitlements.flexible_from_domain": {
+    "text": "Fleksebla retpoŝta sendint-domajno"
+  },
+  "web.billing.overview.entitlements.manage_orgs": {
+    "text": "Administri organizojn"
+  },
+  "web.billing.overview.entitlements.manage_sso": {
+    "text": "Unuopa Ensaluto (SSO)"
+  },
+  "web.billing.overview.entitlements.manage_billing": {
+    "text": "Administri fakturadon"
+  },
+  "web.billing.overview.entitlements.custom_signup_validation": {
+    "text": "Propra registriĝa validigo"
+  },
+  "web.billing.plans.reactivate": {
+    "text": "Reaktivigi"
   }
 }

--- a/locales/content/eo/workspace-branding.json
+++ b/locales/content/eo/workspace-branding.json
@@ -178,5 +178,11 @@
   "web.branding.upgrade_to_customize": {
     "text": "Altigu vian planon por personecigi la markadon por ĉi tiu domajno.",
     "source_hash": "9077bf79"
+  },
+  "web.branding.saved_successfully": {
+    "text": "Markaj agordoj sukcese konservitaj"
+  },
+  "web.branding.keyhole_logo_icon": {
+    "text": "Ŝlosiltrua piktogramo reprezentanta sekuran, privatan kunhavigon"
   }
 }

--- a/locales/content/eo/workspace-dashboard.json
+++ b/locales/content/eo/workspace-dashboard.json
@@ -22,5 +22,14 @@
   "web.dashboard.fetch_error_description": {
     "text": "Estis problemo ŝargante viajn datumojn. Bonvolu reprovi.",
     "source_hash": "ff0d904e"
+  },
+  "web.teams.create_first_team_title": {
+    "text": "Kreu vian unuan teamon"
+  },
+  "web.teams.create_first_team_description": {
+    "text": "Teamoj ebligas al vi kunlabori kun aliaj en komuna laborspaco."
+  },
+  "web.teams.create_team": {
+    "text": "Krei teamon"
   }
 }

--- a/locales/content/eo/workspace-domains.json
+++ b/locales/content/eo/workspace-domains.json
@@ -846,5 +846,389 @@
   "web.domains.sso.not_configured_notice": {
     "text": "SSO ankoraŭ ne estas agordita por ĉi tiu domajno. Ebligu unuopan ensaluton por permesi al teamanoj aŭtentikiĝi uzante la identecan provizanton de via organizo.",
     "source_hash": "c439214b"
+  },
+  "api.domains.errors.add_admin_required": {
+    "text": "Nur posedantoj kaj administrantoj de la organizo povas aldoni proprajn domajnojn"
+  },
+  "web.domains.public_homepage": {
+    "text": "Publika Hejmpaĝo"
+  },
+  "web.domains.status_tooltip_active": {
+    "text": "Domajno kontrolita kaj aktiva"
+  },
+  "web.domains.status_tooltip_dns_incorrect": {
+    "text": "DNS ne agordita — klaku por ripari"
+  },
+  "web.domains.status_tooltip_not_verified": {
+    "text": "Domajno ne kontrolita — klaku por kontroli"
+  },
+  "web.domains.status_tooltip_unverified": {
+    "text": "Domajna stato nekontrolita — klaku por refreŝigi"
+  },
+  "web.domains.last_check_failed": {
+    "text": "Lasta kontrolo malsukcesis"
+  },
+  "web.domains.last_check_failed_ago": {
+    "text": "lasta kontrolo malsukcesis {0}"
+  },
+  "web.domains.verify_now": {
+    "text": "Kontroli nun"
+  },
+  "web.domains.click_to_verify": {
+    "text": "klaku por kontroli"
+  },
+  "web.domains.remove_domain_description": {
+    "text": "Por ĉiam forigi ĉi tiun domajnon kaj ĝian tutan agordon."
+  },
+  "web.domains.add_access_denied": {
+    "text": "Aliro Rifuzita"
+  },
+  "web.domains.add_access_denied_description": {
+    "text": "Vi ne havas permeson aldoni domajnojn al ĉi tiu organizo. Kontaktu vian administranton de la organizo."
+  },
+  "web.domains.dns_widget_load_failed": {
+    "text": "Malsukcesis ŝargi la DNS-ilon"
+  },
+  "web.domains.dns_widget_not_available": {
+    "text": "DNS-ilo ne disponebla"
+  },
+  "web.domains.dns_widget_init_failed": {
+    "text": "Malsukcesis pravalorizi la DNS-ilon"
+  },
+  "web.domains.verified": {
+    "text": "Kontrolita"
+  },
+  "web.domains.pending_verification": {
+    "text": "Atendanta Kontrolon"
+  },
+  "web.domains.unsaved_changes_confirmation": {
+    "text": "Vi havas nekonservitajn ŝanĝojn. Ĉu vi certas, ke vi volas foriri?"
+  },
+  "web.domains.entitlement_required_owner": {
+    "text": "Ĉi tiu funkcio postulas plibonigon de la plano."
+  },
+  "web.domains.entitlement_required_member": {
+    "text": "Ĉi tiu funkcio ne disponeblas en via nuna plano. Kontaktu la posedanton de via organizo."
+  },
+  "web.domains.detail.manage": {
+    "text": "Administri"
+  },
+  "web.domains.detail.features": {
+    "text": "Funkcioj"
+  },
+  "web.domains.detail.homepage_title": {
+    "text": "Hejmpaĝaj Sekretoj"
+  },
+  "web.domains.detail.homepage_description": {
+    "text": "Permesi publikan aliron por krei sekretojn sur la hejmpaĝo de via domajno"
+  },
+  "web.domains.detail.brand_description": {
+    "text": "Emblemo, koloroj kaj propra marko"
+  },
+  "web.domains.detail.sso_description": {
+    "text": "Agordoj de la unuopa-ensaluta provizanto"
+  },
+  "web.domains.detail.email_description": {
+    "text": "Agordo de propra retpoŝta sendilo"
+  },
+  "web.domains.detail.incoming_description": {
+    "text": "Agordoj de ricevanto de envenantaj sekretoj"
+  },
+  "web.domains.detail.signup_description": {
+    "text": "Strategio de registriĝa validigo por la domajno"
+  },
+  "web.domains.detail.signin_description": {
+    "text": "Agordo de ensalutmetodo por la domajno"
+  },
+  "web.domains.email.dns_check_label": {
+    "text": "DNS"
+  },
+  "web.domains.email.provider_check_label": {
+    "text": "Provizanto"
+  },
+  "web.domains.email.test_email_title": {
+    "text": "Testi retpoŝtan liveradon"
+  },
+  "web.domains.email.test_email_hint": {
+    "text": "Sendu testan retmesaĝon al vi mem uzante la konservitan agordon. Funkcias eĉ kiam la funkcio ankoraŭ ne estas ŝaltita."
+  },
+  "web.domains.email.send_test": {
+    "text": "Sendi teston"
+  },
+  "web.domains.email.test_email_sent": {
+    "text": "Testa retmesaĝo sendita sukcese"
+  },
+  "web.domains.email.test_email_failed": {
+    "text": "Malsukcesis sendi testan retmesaĝon"
+  },
+  "web.domains.email.test_email_sent_to": {
+    "text": "Sendita al {email}"
+  },
+  "web.domains.email.delivered_via": {
+    "text": "Liverita per {provider}"
+  },
+  "web.domains.incoming.feature_disabled": {
+    "text": "Envenantaj Sekretoj Nedisponeblaj"
+  },
+  "web.domains.incoming.feature_disabled_description": {
+    "text": "Envenantaj sekretoj ne estas ŝaltitaj sur ĉi tiu instanco. Kontaktu vian administranton."
+  },
+  "web.domains.signin.title": {
+    "text": "Agordo de Ensaluto"
+  },
+  "web.domains.signin.configure_signin": {
+    "text": "Agordi Ensaluton"
+  },
+  "web.domains.signin.config_description": {
+    "text": "Agordi ensalutajn aŭtentikigmetodojn por ĉi tiu domajno"
+  },
+  "web.domains.signin.access_denied": {
+    "text": "Aliro Rifuzita"
+  },
+  "web.domains.signin.upgrade_to_configure": {
+    "text": "Altniveligu vian planon por agordi ensalutmetodojn por ĉi tiu domajno."
+  },
+  "web.domains.signin.not_configured_notice": {
+    "text": "Ensaluta agordo ankoraŭ ne estas fiksita por ĉi tiu domajno. Agordu superregojn por regi kiuj aŭtentikigmetodoj disponeblas sur la ensaluta paĝo de ĉi tiu domajno."
+  },
+  "web.domains.signin.signin_enabled_label": {
+    "text": "Ensaluto ŝaltita"
+  },
+  "web.domains.signin.header_toggle_label": {
+    "text": "Ensaluto"
+  },
+  "web.domains.signin.signin_enabled_hint": {
+    "text": "Ĉu uzantoj povas ensaluti sur ĉi tiu domajno"
+  },
+  "web.domains.signin.restrict_to_label": {
+    "text": "Limigi ensalutmetodon"
+  },
+  "web.domains.signin.restrict_to_hint": {
+    "text": "Limigi ĉi tiun domajnon al unu sola aŭtentikigmetodo. Kiam fiksita, nur la elektita metodo montriĝas sur la ensaluta paĝo."
+  },
+  "web.domains.signin.all_methods": {
+    "text": "Ĉiuj metodoj"
+  },
+  "web.domains.signin.all_methods_description": {
+    "text": "Montri ĉiujn ŝaltitajn aŭtentikigmetodojn sur la ensaluta paĝo"
+  },
+  "web.domains.signin.method_password": {
+    "text": "Pasvorto"
+  },
+  "web.domains.signin.method_email_auth": {
+    "text": "Retpoŝta aŭtentikigo"
+  },
+  "web.domains.signin.method_webauthn": {
+    "text": "WebAuthn / Pasŝlosiloj"
+  },
+  "web.domains.signin.method_sso": {
+    "text": "Unuopa Ensaluto (SSO)"
+  },
+  "web.domains.signin.method_overrides_label": {
+    "text": "Metodaj superregoj"
+  },
+  "web.domains.signin.method_overrides_hint": {
+    "text": "Ŝalti aŭ malŝalti individuajn aŭtentikigmetodojn por ĉi tiu domajno"
+  },
+  "web.domains.signin.mode_question": {
+    "text": "Kiel uzantoj povas ensaluti?"
+  },
+  "web.domains.signin.mode_any": {
+    "text": "Iu ajn disponebla metodo"
+  },
+  "web.domains.signin.mode_any_hint": {
+    "text": "Montri ĉiun metodon disponeblan sur ĉi tiu domajno. Limigu individuajn metodojn sube."
+  },
+  "web.domains.signin.mode_one": {
+    "text": "Unu specifa metodo"
+  },
+  "web.domains.signin.mode_one_hint": {
+    "text": "Limigi la ensalutan paĝon al unu sola metodo. Nur metodoj disponeblaj sur ĉi tiu domajno estas listigitaj."
+  },
+  "web.domains.signin.mode_disabled": {
+    "text": "Ensaluto malŝaltita"
+  },
+  "web.domains.signin.mode_disabled_hint": {
+    "text": "Uzantoj ne povas ensaluti sur ĉi tiu domajno."
+  },
+  "web.domains.signin.mode_disabled_notice": {
+    "text": "Vizitantoj de la ensaluta paĝo de ĉi tiu domajno vidas sciigon, ke ensaluto ne disponeblas, kun ligilo reen al la hejmpaĝo. Viaj antaŭaj metodaj agordoj estas konservitaj kaj restarigitaj kiam vi reŝaltas ensaluton."
+  },
+  "web.domains.signin.methods_list_label": {
+    "text": "Metodoj montritaj sur la ensaluta paĝo"
+  },
+  "web.domains.signin.restrict_picker_hint": {
+    "text": "Nur metodoj disponeblaj sur ĉi tiu domajno estas listigitaj."
+  },
+  "web.domains.signin.availability_always": {
+    "text": "Ĉiam disponebla"
+  },
+  "web.domains.signin.availability_global_on": {
+    "text": "Sekvas tutmondan politikon · Ŝaltita"
+  },
+  "web.domains.signin.availability_global_off": {
+    "text": "Nedisponebla"
+  },
+  "web.domains.signin.availability_unavailable": {
+    "text": "Nedisponebla en la tuta retejo"
+  },
+  "web.domains.signin.allow_on_domain": {
+    "text": "Permesi sur ĉi tiu domajno"
+  },
+  "web.domains.signin.method_password_blurb": {
+    "text": "Nur pasvorto"
+  },
+  "web.domains.signin.method_email_auth_blurb": {
+    "text": "Senpasvorta ensaluto per magia ligilo"
+  },
+  "web.domains.signin.method_webauthn_blurb": {
+    "text": "Biometrio kaj sekurecaj ŝlosiloj"
+  },
+  "web.domains.signin.method_sso_blurb": {
+    "text": "Ekstera identeca provizanto"
+  },
+  "web.domains.signin.email_auth_label": {
+    "text": "Retpoŝta aŭtentikigo"
+  },
+  "web.domains.signin.email_auth_hint": {
+    "text": "Permesi senpasvortan retpoŝtan aŭtentikigon sur ĉi tiu domajno"
+  },
+  "web.domains.signin.sso_enabled_label": {
+    "text": "Unuopa Ensaluto (SSO)"
+  },
+  "web.domains.signin.sso_enabled_hint": {
+    "text": "Permesi SSO-aŭtentikigon sur ĉi tiu domajno"
+  },
+  "web.domains.signin.enabled_label": {
+    "text": "Ŝalti ensalutan agordon"
+  },
+  "web.domains.signin.enabled_hint": {
+    "text": "Kiam ŝaltita, ĉi tiu domajno uzas la ensalutajn agordojn agorditajn supre"
+  },
+  "web.domains.signin.save_config": {
+    "text": "Konservi agordon"
+  },
+  "web.domains.signin.update_success": {
+    "text": "Ensaluta agordo ĝisdatigita sukcese"
+  },
+  "web.domains.signin.reset_to_defaults": {
+    "text": "Restarigi al defaŭltoj"
+  },
+  "web.domains.signin.reset_confirm": {
+    "text": "Ĉu restarigi ensaluton al la tutmondaj defaŭltoj?"
+  },
+  "web.domains.signin.reset_keeps_sso": {
+    "text": "Viaj SSO-akreditaĵoj estas konservitaj. Forigu ilin aparte sur la ekrano de SSO-agordo."
+  },
+  "web.domains.signin.reset_action": {
+    "text": "Jes, restarigi"
+  },
+  "web.domains.signin.reset_success": {
+    "text": "Ensalutaj agordoj restarigitaj al la tutmondaj defaŭltoj"
+  },
+  "web.domains.signup.title": {
+    "text": "Registriĝa Validigo"
+  },
+  "web.domains.signup.config_description": {
+    "text": "Agordi registriĝan validigon por ĉi tiu domajno"
+  },
+  "web.domains.signup.access_denied": {
+    "text": "Aliro Rifuzita"
+  },
+  "web.domains.signup.upgrade_to_configure": {
+    "text": "Altniveligu vian planon por agordi registriĝan validigon laŭ domajno."
+  },
+  "web.domains.signup.configure_signup": {
+    "text": "Agordi Registriĝon"
+  },
+  "web.domains.signup.not_configured_notice": {
+    "text": "Registriĝa validigo ankoraŭ ne estas agordita por ĉi tiu domajno. Agordu strategion por regi kiu povas registriĝi per ĉi tiu domajno."
+  },
+  "web.domains.signup.site_signups_disabled_warning": {
+    "text": "Registriĝoj estas nuntempe malŝaltitaj je la nivelo de la retejo. Ĉi tiu laŭdomajna politiko estas agordita, sed ĝi ne limigos ajnan trafikon ĝis registriĝoj de la retejo estos ŝaltitaj."
+  },
+  "web.domains.signup.strategy_label": {
+    "text": "Validig-strategio"
+  },
+  "web.domains.signup.strategy_description": {
+    "text": "Elektu kiel retpoŝtadresoj estas validigataj kiam uzantoj registriĝas sur ĉi tiu domajno."
+  },
+  "web.domains.signup.network_validation_warning": {
+    "text": "Ĉi tiu strategio faras retajn vokojn dum registriĝo, kio povas aldoni latentecon aŭ esti blokita de kelkaj provizantoj."
+  },
+  "web.domains.signup.allowed_domains_label": {
+    "text": "Permesataj registriĝaj domajnoj"
+  },
+  "web.domains.signup.allowed_domains_hint": {
+    "text": "Nur ĉi tiuj retpoŝtaj domajnoj estos permesataj registriĝi. Aldonu unu domajnon por ĉiu enskribo."
+  },
+  "web.domains.signup.domain_placeholder": {
+    "text": "example.com"
+  },
+  "web.domains.signup.invalid_domain": {
+    "text": "Bonvolu enigi validan domajnon (ekz. example.com)"
+  },
+  "web.domains.signup.domain_exists": {
+    "text": "Ĉi tiu domajno jam estas en la listo"
+  },
+  "web.domains.signup.remove_domain": {
+    "text": "Forigi {domain}"
+  },
+  "web.domains.signup.enabled_label": {
+    "text": "Ŝalti laŭdomajnan validigon"
+  },
+  "web.domains.signup.enabled_hint": {
+    "text": "Kiam ŝaltita, registriĝoj sur ĉi tiu domajno uzas la supran strategion anstataŭ la tutmonda politiko."
+  },
+  "web.domains.signup.delete_config": {
+    "text": "Forigi agordon"
+  },
+  "web.domains.signup.delete_confirm": {
+    "text": "Ĉu forigi la registriĝan validig-agordon? Registriĝoj retroiros al la tutmonda politiko."
+  },
+  "web.domains.signup.save_config": {
+    "text": "Konservi agordon"
+  },
+  "web.domains.signup.update_success": {
+    "text": "Registriĝa validigo ĝisdatigita sukcese"
+  },
+  "web.domains.signup.delete_success": {
+    "text": "Registriĝa validig-agordo forigita sukcese"
+  },
+  "web.domains.signup.domain_overrides_label": {
+    "text": "Domajnaj superregoj"
+  },
+  "web.domains.signup.domain_overrides_hint": {
+    "text": "Superregi tutmondajn registriĝajn agordojn por ĉi tiu domajno"
+  },
+  "web.domains.signup.signup_enabled_label": {
+    "text": "Registriĝo ŝaltita"
+  },
+  "web.domains.signup.signup_enabled_hint": {
+    "text": "Superregi ĉu registriĝo estas ŝaltita por ĉi tiu domajno"
+  },
+  "web.domains.signup.autoverify_label": {
+    "text": "Aŭtomate konfirmi kontojn"
+  },
+  "web.domains.signup.autoverify_hint": {
+    "text": "Superregi ĉu novaj kontoj estas aŭtomate konfirmataj sur ĉi tiu domajno"
+  },
+  "web.domains.sso.test_success": {
+    "text": "Konektotesto sukcesa — la provizanto respondis ĝuste"
+  },
+  "web.domains.sso.test_failed": {
+    "text": "Konektotesto malsukcesis"
+  },
+  "web.domains.sso.enforce_moved_notice": {
+    "text": "Por postuli SSO por ĉiuj ensalutoj sur ĉi tiu domajno, agordu ĝin en la ensalutaj agordoj de la domajno. Nur-SSO reĝimo limigas la ensalutan paĝon al la SSO-provizanto agordita ĉi tie."
+  },
+  "web.domains.sso.edit_credentials": {
+    "text": "Redakti akreditaĵojn"
+  },
+  "web.domains.sso.configure_button": {
+    "text": "Agordi"
+  },
+  "web.domains.sso.upgrade_required": {
+    "text": "Altniveligu por agordi"
   }
 }

--- a/locales/content/eo/workspace-organizations.json
+++ b/locales/content/eo/workspace-organizations.json
@@ -770,5 +770,200 @@
   "web.organizations.sso.status_not_configured": {
     "text": "Ne Agordita",
     "source_hash": "bbea960e"
+  },
+  "api.organizations.errors.not_found": {
+    "text": "Organizo ne trovita: %{extid}"
+  },
+  "api.organizations.errors.owner_required": {
+    "text": "Nur la posedanto de la organizo povas plenumi ĉi tiun agon"
+  },
+  "api.organizations.errors.admin_required": {
+    "text": "Nur posedantoj kaj administrantoj de la organizo povas plenumi ĉi tiun agon"
+  },
+  "api.organizations.errors.member_required": {
+    "text": "Vi devas esti membro de la organizo por plenumi ĉi tiun agon"
+  },
+  "api.organizations.invitations.errors.create_admin_required": {
+    "text": "Nur posedantoj kaj administrantoj de la organizo povas krei invitojn"
+  },
+  "api.organizations.invitations.errors.resend_admin_required": {
+    "text": "Nur posedantoj kaj administrantoj de la organizo povas resendi invitojn"
+  },
+  "api.organizations.invitations.errors.view_admin_required": {
+    "text": "Nur posedantoj kaj administrantoj de la organizo povas vidi invitojn"
+  },
+  "api.organizations.invitations.errors.revoke_admin_required": {
+    "text": "Nur posedantoj kaj administrantoj de la organizo povas revoki invitojn"
+  },
+  "api.organizations.invitations.errors.email_required": {
+    "text": "Retpoŝto necesas"
+  },
+  "api.organizations.invitations.errors.email_invalid": {
+    "text": "Nevalida retpoŝta formato"
+  },
+  "api.organizations.invitations.errors.role_invalid": {
+    "text": "Rolo devas esti membro aŭ administranto"
+  },
+  "api.organizations.invitations.errors.cannot_invite_owner": {
+    "text": "Ne eblas inviti kiel posedanton"
+  },
+  "api.organizations.invitations.errors.already_member": {
+    "text": "La uzanto jam estas membro de ĉi tiu organizo"
+  },
+  "api.organizations.invitations.errors.already_pending": {
+    "text": "Invito jam atendas por ĉi tiu retpoŝto"
+  },
+  "api.organizations.invitations.errors.member_limit_reached": {
+    "text": "Limo de membroj atingita. Altniveligu vian planon por inviti pliajn membrojn."
+  },
+  "api.organizations.invitations.errors.not_found": {
+    "text": "Invito ne trovita"
+  },
+  "api.organizations.invitations.errors.cannot_resend_non_pending": {
+    "text": "Eblas resendi nur atendantajn invitojn"
+  },
+  "api.organizations.invitations.errors.cannot_revoke_non_pending": {
+    "text": "Eblas revoki nur atendantajn invitojn"
+  },
+  "api.organizations.invitations.errors.resend_limit_reached": {
+    "text": "Maksimuma resendlimo (%{max}) atingita"
+  },
+  "api.organizations.invitations.errors.accept_token_required": {
+    "text": "Ĵetono necesas"
+  },
+  "api.organizations.invitations.errors.accept_organization_gone": {
+    "text": "La organizo ne plu ekzistas"
+  },
+  "api.organizations.invitations.errors.accept_already_acted": {
+    "text": "La invito jam estis %{status}"
+  },
+  "api.organizations.invitations.errors.accept_expired": {
+    "text": "La invito eksvalidiĝis"
+  },
+  "api.organizations.invitations.errors.accept_email_mismatch": {
+    "text": "Via retpoŝtadreso ne kongruas kun la invito"
+  },
+  "api.organizations.invitations.errors.accept_already_member": {
+    "text": "Vi jam estas membro de ĉi tiu organizo"
+  },
+  "web.organizations.entitlements_title": {
+    "text": "Rajtigoj de la Organizo"
+  },
+  "web.organizations.page_description_short": {
+    "text": "Vidi kaj agordi viajn laborspacojn"
+  },
+  "web.organizations.delete_organization_remove_domains_first": {
+    "text": "Forigu ĉiujn proprajn domajnojn antaŭ ol forigi ĉi tiun organizon."
+  },
+  "web.organizations.default_org_delete_notice_title": {
+    "text": "Forigo de ĉi tiu organizo"
+  },
+  "web.organizations.default_org_delete_notice_before": {
+    "text": "Ĉi tio estas via defaŭlta organizo kaj ne povas esti forigita el la panelo. Por forigi ĝin, bonvolu kontakti per la"
+  },
+  "web.organizations.default_org_delete_notice_link": {
+    "text": "komenta formularo"
+  },
+  "web.organizations.default_org_delete_notice_after": {
+    "text": "."
+  },
+  "web.organizations.leave_organization": {
+    "text": "Forlasi ĉi tiun organizon"
+  },
+  "web.organizations.leave_organization_warning": {
+    "text": "Vi perdos aliron al ĉi tiu organizo kaj ĝiaj rimedoj."
+  },
+  "web.organizations.leave_organization_confirm_title": {
+    "text": "Forlasi Organizon"
+  },
+  "web.organizations.leave_organization_confirm_message": {
+    "text": "Ĉu vi certas, ke vi volas forlasi {name}? Vi bezonos novan inviton por realiĝi."
+  },
+  "web.organizations.leave_organization_success": {
+    "text": "Vi forlasis la organizon."
+  },
+  "web.organizations.leave_error": {
+    "text": "Malsukcesis forlasi la organizon"
+  },
+  "web.organizations.organizations": {
+    "text": "Organizoj"
+  },
+  "web.organizations.invitations.invited_by_inline": {
+    "text": "de {email}"
+  },
+  "web.organizations.invitations.invited_as_inline": {
+    "text": "kiel {role}"
+  },
+  "web.organizations.invitations.back_to_home": {
+    "text": "Reen al hejmo"
+  },
+  "web.organizations.invitations.email_locked_hint": {
+    "text": "Ĉi tiu invito estis sendita al ĉi tiu retpoŝtadreso"
+  },
+  "web.organizations.invitations.signup_continue": {
+    "text": "Daŭrigi"
+  },
+  "web.organizations.invitations.signin_continue": {
+    "text": "Ensaluti"
+  },
+  "web.organizations.invitations.confirm_join_below": {
+    "text": "Preskaŭ farite — konfirmu sube por aliĝi al la organizo."
+  },
+  "web.organizations.invitations.go_to_organizations": {
+    "text": "Iri al Organizoj"
+  },
+  "web.organizations.invitations.already_member": {
+    "text": "Vi jam estas membro de ĉi tiu organizo"
+  },
+  "web.organizations.invitations.join_organization": {
+    "text": "Aliĝi al {orgName}"
+  },
+  "web.organizations.invitations.sign_in_to_join": {
+    "text": "Ensalutu por aliĝi al {orgName}"
+  },
+  "web.organizations.invitations.decline": {
+    "text": "Rifuzi"
+  },
+  "web.organizations.members.member_quota": {
+    "text": "{used} el {limit} membroj"
+  },
+  "web.organizations.members.pending_suffix": {
+    "text": "({count} atendantaj)"
+  },
+  "web.organizations.members.limit_reached_hint": {
+    "text": "Limo de membroj atingita."
+  },
+  "web.organizations.sso.view_discovery_document": {
+    "text": "Vidi malkovran dokumenton"
+  },
+  "web.organizations.sso.callback_url": {
+    "text": "Retroalvoka URL"
+  },
+  "web.organizations.sso.callback_url_hint": {
+    "text": "Aldonu ĉi tiun URL al la permesataj alidirektaj URI-oj de via identeca provizanto"
+  },
+  "web.organizations.sso.enforce_sso_only": {
+    "text": "Devigi nur SSO"
+  },
+  "web.organizations.sso.enforce_sso_only_hint": {
+    "text": "Postuli SSO por ĉiuj ensalutoj sur ĉi tiu domajno. Kiam ŝaltita, pasvort-bazita aŭtentikigo estas malŝaltita."
+  },
+  "web.organizations.sso.grant_org_scope": {
+    "text": "Doni tutorganizan aliron"
+  },
+  "web.organizations.sso.grant_org_scope_hint": {
+    "text": "Novaj membroj, kiuj aliĝas per la SSO de ĉi tiu domajno, ricevos aliron al ĉiuj domajnoj de la organizo. Ekzistantaj membroj ne estas tuŝataj. Kiam malŝaltita (defaŭlte), novaj membroj povas aliri nur ĉi tiun domajnon."
+  },
+  "web.organizations.sso.no_domains": {
+    "text": "Neniuj kontrolitaj domajnoj"
+  },
+  "web.organizations.sso.no_domains_description": {
+    "text": "Aldonu kaj kontrolu domajnon antaŭ ol agordi SSO por ĝi."
+  },
+  "web.organizations.tabs.team": {
+    "text": "Teamo"
+  },
+  "web.organizations.tabs.sso": {
+    "text": "SSO"
   }
 }

--- a/locales/content/eo/workspace-organizations.json
+++ b/locales/content/eo/workspace-organizations.json
@@ -64,7 +64,7 @@
     "source_hash": "f2204373"
   },
   "web.organizations.organization_name": {
-    "text": "Organioznomo",
+    "text": "Organiznomo",
     "source_hash": "4cbd9073"
   },
   "web.organizations.organization_name_placeholder": {
@@ -72,7 +72,7 @@
     "source_hash": "ac1c804b"
   },
   "web.organizations.display_name": {
-    "text": "Organioznomo",
+    "text": "Organiznomo",
     "source_hash": "4cbd9073"
   },
   "web.organizations.description": {


### PR DESCRIPTION
## `eo` translation update

Automated export of completed **eo** translations from the translation task DB.
Scope: `locales/content/eo/` only — 28 file(s), +1378/-49.

⚠️ `i18n validate variables` reports **1** variable mismatch(es) for `eo` (empty values that drop source variables, renamed/extra vars, etc.) — see the review below.

---

### Local quality review

> Produced by a fresh, isolated `claude` review agent (model `claude-sonnet-5`, agent `saas-translator`) that read
> `locales/AGENT_TRANSLATION_PROTOCOL.md` and inspected this branch's diff before the PR was opened.

Good — no issues. I've now cross-checked the highest-risk token classes across the diff and confirmed they're clean. Writing the review.

**Verdict:** ⚠️ Needs review — pre-existing `%{date}` var bug in touched file.

**Summary:** This batch adds ~250 new eo strings (colonel admin, API errors, domains, billing, auth, email) and fills in previously-empty strings; spot-checked token sets (`{var}`, `%{var}`, `{0}`, hyphenated `{onetime-secret}`/`{send-feedback}`) across the highest-risk keys all match the English source exactly.

**Critical (must fix):**
- `email.email_changed.body.text` carries an extra `%{date}` not present in the English source (`"...to %{new_email_masked}."` vs eo `"...al %{new_email_masked} je %{date}."`). This is **pre-existing, not introduced by this diff** (the key isn't touched here), but `email.json` is otherwise heavily edited in this PR — flagging so it isn't merged as "reviewed clean." File a follow-up fix.

**Warnings:**
- `web.INSTRUCTION.phishing_warning`: reworded significantly (Frauduloj→Friponoj, punctuation/comma changes, "antaŭ krei"→"antaŭ ol krei"). Reads as a style/grammar pass rather than a fix; worth a second pair of eyes to confirm nothing was lost in meaning, though `{product_name}` tokens are intact (2/2 both occurrences).
- `web.homepage.one_time_secret_literal`: changed from translated "Unufoja Sekreto" to bare `{product_name}` — correct per current English source, but confirm this isn't reverting an earlier intentional literal-text rendering.

**Notes:**
- Signature change `Delano` → `Subtena teamo` across ~20 email templates is consistent with the English source's `Support Team` and matches the pattern seen in other locales this session.
- New `api-*.json` files (account/domains/entitlements/feedback/incoming/invite/organizations/secrets) and duplicated `api.organizations.errors.*` keys in `workspace-organizations.json` were checked for `%{var}` token parity against English — all clean.
- Several previously-empty `text` values (testimonials, translations, secret-manage, layout) are now filled in — good, matches protocol expectation that empty strings get populated.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
