### PR TITLE
i18n: update es translations

### DIFF
--- a/locales/content/es/00-common.json
+++ b/locales/content/es/00-common.json
@@ -1299,7 +1299,7 @@
     "source_hash": "fc78d9cb"
   },
   "web.INSTRUCTION.phishing_warning": {
-    "text": "Siempre verifica que estás en el sitio web oficial de {product_name}. Los estafadores a veces crean sitios web falsos que se ven exactamente como {product_name} para robar tus secretos. Para evitar ataques de phishing, verifica el dominio de la región antes de crear nuevos enlaces.",
+    "text": "Verifica siempre que estás en el sitio web oficial de {product_name}. A veces los estafadores crean sitios web falsos que se parecen exactamente a {product_name} para robar tus secretos. Para evitar ataques de phishing, comprueba el dominio de la región antes de crear nuevos enlaces.",
     "source_hash": "b588f5b2"
   },
   "web.pricing.title": {
@@ -1383,5 +1383,110 @@
     "text": "Mejora tu plan para desbloquear más funciones",
     "context": "Description shown for free plan users encouraging upgrade",
     "source_hash": "783f174c"
+  },
+  "api.errors.authentication_required": {
+    "text": "Autenticación requerida"
+  },
+  "api.errors.sso_only_action_blocked": {
+    "text": "Esta acción no está disponible en el modo exclusivo de SSO"
+  },
+  "web.COMMON.configure": {
+    "text": "Configurar"
+  },
+  "web.COMMON.copy_to_clipboard": {
+    "text": "Copiar al portapapeles"
+  },
+  "web.COMMON.add": {
+    "text": "Añadir"
+  },
+  "web.COMMON.enabled": {
+    "text": "Activado"
+  },
+  "web.COMMON.disabled": {
+    "text": "Desactivado"
+  },
+  "web.COMMON.yes_delete": {
+    "text": "Sí, eliminar"
+  },
+  "web.COMMON.error_code": {
+    "text": "Código de error"
+  },
+  "web.COMMON.http_status": {
+    "text": "Estado HTTP"
+  },
+  "web.COMMON.details": {
+    "text": "Detalles"
+  },
+  "web.COMMON.field_confirm_password": {
+    "text": "Confirmar contraseña"
+  },
+  "web.COMMON.passwords_must_match": {
+    "text": "Las contraseñas deben coincidir"
+  },
+  "web.COMMON.and": {
+    "text": "y"
+  },
+  "web.COMMON.or": {
+    "text": "o"
+  },
+  "web.COMMON.copied": {
+    "text": "Copiado"
+  },
+  "web.COMMON.copy": {
+    "text": "Copiar"
+  },
+  "web.COMMON.copy_email": {
+    "text": "Copiar dirección de correo electrónico"
+  },
+  "web.COMMON.copy_id": {
+    "text": "Copiar ID de cuenta"
+  },
+  "web.COMMON.org_id_tooltip": {
+    "text": "El identificador único de tu organización"
+  },
+  "web.COMMON.success": {
+    "text": "Correcto"
+  },
+  "web.COMMON.need_help": {
+    "text": "¿Necesitas ayuda?"
+  },
+  "web.COMMON.open_help_dialog": {
+    "text": "Abrir el cuadro de diálogo de ayuda"
+  },
+  "web.COMMON.focus_is_now_in_the_main_text_area": {
+    "text": "El foco está ahora en el área de texto principal"
+  },
+  "web.LABELS.show_passphrase": {
+    "text": "Mostrar frase de contraseña"
+  },
+  "web.LABELS.hide_passphrase": {
+    "text": "Ocultar frase de contraseña"
+  },
+  "web.LABELS.copy_icon": {
+    "text": "Icono de copiar"
+  },
+  "web.LABELS.copied_icon": {
+    "text": "Icono de copiado"
+  },
+  "web.STATUS.unverified": {
+    "text": "Sin verificar"
+  },
+  "web.TITLES.domain_detail": {
+    "text": "Configuración del dominio"
+  },
+  "web.TITLES.domain_signin": {
+    "text": "Configuración de inicio de sesión"
+  },
+  "web.TITLES.domain_sso": {
+    "text": "SSO del dominio"
+  },
+  "web.TITLES.domain_signup": {
+    "text": "Validación de registro del dominio"
+  },
+  "web.TITLES.domain_email": {
+    "text": "Configuración del correo electrónico"
+  },
+  "web.TITLES.domain_incoming": {
+    "text": "Secretos entrantes"
   }
 }

--- a/locales/content/es/10-layout.json
+++ b/locales/content/es/10-layout.json
@@ -148,7 +148,7 @@
     "source_hash": "b9766df3"
   },
   "web.help.secret_view_faq.what_am_i_looking_at.description": {
-    "text": "Estás viendo un mensaje seguro que alguien compartió contigo a través de {product_name}. Este contenido se muestra solo una vez y luego se elimina permanentemente de nuestros servidores.",
+    "text": "Estás viendo un mensaje seguro que se compartió contigo a través de {product_name}. Este contenido se muestra una sola vez y luego se elimina permanentemente de nuestros servidores.",
     "source_hash": "e0f1a10c"
   },
   "web.help.secret_view_faq.can_i_view_again.title": {
@@ -338,5 +338,11 @@
   "web.layout.workspace_context": {
     "text": "Contexto del espacio de trabajo",
     "source_hash": "dc6fa4f5"
+  },
+  "web.footer.workspace": {
+    "text": "Espacio de trabajo"
+  },
+  "web.help.default_content": {
+    "text": "Contacta con soporte para obtener ayuda"
   }
 }

--- a/locales/content/es/admin-colonel.json
+++ b/locales/content/es/admin-colonel.json
@@ -634,5 +634,152 @@
   "web.colonel.feedback.when_you_submit_feedback_well_see": {
     "text": "Cuando envíes tus comentarios, veremos:",
     "source_hash": "fe77172e"
+  },
+  "web.colonel.previewPlanMode": {
+    "text": "Modo de vista previa del plan"
+  },
+  "web.colonel.previewModeDescription": {
+    "text": "Previsualiza la aplicación tal como la ven los clientes con un plan diferente. Esto afecta únicamente a tu vista y no cambia el plan real de ninguna organización."
+  },
+  "web.colonel.previewModeActive": {
+    "text": "Vista previa activa"
+  },
+  "web.colonel.bannedIps.empty": {
+    "text": "No hay IP bloqueadas"
+  },
+  "web.colonel.bannedIps.currentIp": {
+    "text": "Tu dirección IP actual"
+  },
+  "web.colonel.bannedIps.confirmUnban": {
+    "text": "¿Desbloquear {ip}?"
+  },
+  "web.colonel.bannedIps.actions.ban": {
+    "text": "Bloquear IP"
+  },
+  "web.colonel.bannedIps.actions.quickBan": {
+    "text": "Bloqueo rápido"
+  },
+  "web.colonel.bannedIps.actions.unban": {
+    "text": "Desbloquear"
+  },
+  "web.colonel.bannedIps.actions.cancel": {
+    "text": "Cancelar"
+  },
+  "web.colonel.bannedIps.columns.ipAddress": {
+    "text": "Dirección IP"
+  },
+  "web.colonel.bannedIps.columns.reason": {
+    "text": "Motivo"
+  },
+  "web.colonel.bannedIps.columns.bannedAt": {
+    "text": "Bloqueada el"
+  },
+  "web.colonel.bannedIps.columns.bannedBy": {
+    "text": "Bloqueada por"
+  },
+  "web.colonel.bannedIps.error.banFailed": {
+    "text": "No se pudo bloquear la dirección IP"
+  },
+  "web.colonel.bannedIps.error.unbanFailed": {
+    "text": "No se pudo desbloquear la dirección IP"
+  },
+  "web.colonel.bannedIps.form.title": {
+    "text": "Bloquear dirección IP"
+  },
+  "web.colonel.bannedIps.form.ipLabel": {
+    "text": "Dirección IP"
+  },
+  "web.colonel.bannedIps.form.reasonLabel": {
+    "text": "Motivo"
+  },
+  "web.colonel.bannedIps.form.reasonPlaceholder": {
+    "text": "Motivo opcional"
+  },
+  "web.colonel.bannedIps.success.banned": {
+    "text": "La dirección IP {ip} ha sido bloqueada"
+  },
+  "web.colonel.bannedIps.success.unbanned": {
+    "text": "La dirección IP {ip} ha sido desbloqueada"
+  },
+  "web.colonel.customDomains.empty": {
+    "text": "No hay dominios personalizados configurados"
+  },
+  "web.colonel.customDomains.noLogo": {
+    "text": "Sin logotipo"
+  },
+  "web.colonel.customDomains.labels.organization": {
+    "text": "Organización"
+  },
+  "web.colonel.customDomains.labels.externalId": {
+    "text": "ID externo"
+  },
+  "web.colonel.customDomains.labels.created": {
+    "text": "Creado"
+  },
+  "web.colonel.customDomains.labels.updated": {
+    "text": "Actualizado"
+  },
+  "web.colonel.customDomains.labels.favicon": {
+    "text": "Favicon"
+  },
+  "web.colonel.customDomains.status.verified": {
+    "text": "Verificado"
+  },
+  "web.colonel.customDomains.status.resolving": {
+    "text": "Resolviendo"
+  },
+  "web.colonel.customDomains.status.ready": {
+    "text": "Listo"
+  },
+  "web.colonel.customDomains.status.publicHomepage": {
+    "text": "Página de inicio pública"
+  },
+  "web.colonel.customDomains.status.publicApi": {
+    "text": "API pública"
+  },
+  "web.colonel.customDomains.status.pending": {
+    "text": "Pendiente"
+  },
+  "web.colonel.pagination.showing": {
+    "text": "Mostrando {start}–{end} de {total}"
+  },
+  "web.colonel.pagination.itemsPerPage": {
+    "text": "Elementos por página"
+  },
+  "web.colonel.pagination.perPage": {
+    "text": "{count} por página"
+  },
+  "web.colonel.pagination.pageOf": {
+    "text": "Página {current} de {total}"
+  },
+  "web.colonel.secrets.empty": {
+    "text": "No se encontraron secretos"
+  },
+  "web.colonel.secrets.never": {
+    "text": "Nunca"
+  },
+  "web.colonel.secrets.columns.shortId": {
+    "text": "ID corto"
+  },
+  "web.colonel.secrets.columns.state": {
+    "text": "Estado"
+  },
+  "web.colonel.secrets.columns.created": {
+    "text": "Creado"
+  },
+  "web.colonel.secrets.columns.expiration": {
+    "text": "Expiración"
+  },
+  "web.colonel.secrets.columns.age": {
+    "text": "Antigüedad (días)"
+  },
+  "web.colonel.secrets.state.new": {
+    "text": "Nuevo"
+  },
+  "web.colonel.secrets.state.received": {
+    "text": "Recibido"
+  },
+  "web.colonel.secrets.state.viewed": {
+    "text": "Visto"
   }
 }

--- a/locales/content/es/api-account-errors.json
+++ b/locales/content/es/api-account-errors.json
@@ -1,0 +1,8 @@
+{
+  "api.account.errors.invalid_email": {
+    "text": "¿Es esa una dirección de correo electrónico válida?"
+  },
+  "api.account.errors.password_too_short": {
+    "text": "La contraseña es demasiado corta"
+  }
+}

--- a/locales/content/es/api-domains-errors.json
+++ b/locales/content/es/api-domains-errors.json
@@ -1,0 +1,29 @@
+{
+  "api.domains.errors.domain_id_required": {
+    "text": "Se requiere el ID del dominio"
+  },
+  "api.domains.errors.domain_not_found": {
+    "text": "Dominio no encontrado: %{extid}"
+  },
+  "api.domains.errors.organization_not_found": {
+    "text": "No se encontró ninguna organización para el dominio: %{domain}"
+  },
+  "api.domains.errors.incoming_secrets_disabled": {
+    "text": "Los secretos entrantes no están habilitados en esta instancia"
+  },
+  "api.domains.errors.incoming_secrets_entitlement_required": {
+    "text": "La gestión de secretos entrantes requiere el derecho incoming_secrets. Mejora tu plan."
+  },
+  "api.domains.errors.incoming_config_not_found": {
+    "text": "No se encontró ninguna configuración de entrada para el dominio: %{extid}"
+  },
+  "api.domains.errors.recipients_max_exceeded": {
+    "text": "Se permite un máximo de %{max} destinatarios"
+  },
+  "api.domains.errors.recipients_invalid_email": {
+    "text": "Correo electrónico no válido: %{email}"
+  },
+  "api.domains.errors.recipients_duplicate": {
+    "text": "No se permiten correos electrónicos de destinatarios duplicados"
+  }
+}

--- a/locales/content/es/api-entitlements-errors.json
+++ b/locales/content/es/api-entitlements-errors.json
@@ -1,0 +1,71 @@
+{
+  "api.entitlements.errors.context_unavailable": {
+    "text": "No se pueden verificar los derechos (contexto de organización no disponible)"
+  },
+  "api.entitlements.errors.api_access_required": {
+    "text": "El acceso a la API requiere mejorar el plan"
+  },
+  "api.entitlements.errors.custom_privacy_defaults_required": {
+    "text": "Los valores predeterminados de privacidad personalizados requieren mejorar el plan"
+  },
+  "api.entitlements.errors.extended_default_expiration_required": {
+    "text": "La expiración predeterminada extendida requiere mejorar el plan"
+  },
+  "api.entitlements.errors.custom_domains_required": {
+    "text": "Los dominios personalizados requieren mejorar el plan"
+  },
+  "api.entitlements.errors.custom_branding_required": {
+    "text": "La marca personalizada requiere mejorar el plan"
+  },
+  "api.entitlements.errors.homepage_secrets_required": {
+    "text": "Los secretos en la página de inicio requieren mejorar el plan"
+  },
+  "api.entitlements.errors.incoming_secrets_required": {
+    "text": "Los secretos entrantes requieren mejorar el plan"
+  },
+  "api.entitlements.errors.custom_mail_sender_required": {
+    "text": "El remitente de correo personalizado requiere mejorar el plan"
+  },
+  "api.entitlements.errors.flexible_from_domain_required": {
+    "text": "El dominio de remitente flexible requiere mejorar el plan"
+  },
+  "api.entitlements.errors.manage_org_required": {
+    "text": "La gestión de la organización requiere mejorar el plan"
+  },
+  "api.entitlements.errors.manage_teams_required": {
+    "text": "La gestión de equipos requiere mejorar el plan"
+  },
+  "api.entitlements.errors.manage_members_required": {
+    "text": "La gestión de miembros requiere mejorar el plan"
+  },
+  "api.entitlements.errors.manage_sso_required": {
+    "text": "La gestión de SSO requiere mejorar el plan"
+  },
+  "api.entitlements.errors.audit_logs_required": {
+    "text": "Los registros de auditoría requieren mejorar el plan"
+  },
+  "api.entitlements.errors.custom_signup_validation_required": {
+    "text": "La validación de registro personalizada requiere mejorar el plan"
+  },
+  "api.entitlements.errors.create_secrets_required": {
+    "text": "La creación de secretos requiere mejorar el plan"
+  },
+  "api.entitlements.errors.view_receipt_required": {
+    "text": "La visualización de recibos requiere mejorar el plan"
+  },
+  "api.entitlements.errors.notifications_required": {
+    "text": "Las notificaciones requieren mejorar el plan"
+  },
+  "api.entitlements.errors.workspace_branding_required": {
+    "text": "La marca del espacio de trabajo requiere mejorar el plan"
+  },
+  "api.entitlements.errors.ip_access_rules_required": {
+    "text": "Las reglas de acceso por IP requieren mejorar el plan"
+  },
+  "api.entitlements.errors.manage_billing_required": {
+    "text": "La gestión de facturación requiere mejorar el plan"
+  },
+  "api.entitlements.errors.custom_signin_config_required": {
+    "text": "La configuración de inicio de sesión personalizada requiere mejorar el plan"
+  }
+}

--- a/locales/content/es/api-feedback-errors.json
+++ b/locales/content/es/api-feedback-errors.json
@@ -1,0 +1,5 @@
+{
+  "api.feedback.errors.rate_limit_exceeded": {
+    "text": "Demasiados envíos de comentarios. Vuelve a intentarlo más tarde."
+  }
+}

--- a/locales/content/es/api-incoming-errors.json
+++ b/locales/content/es/api-incoming-errors.json
@@ -1,0 +1,5 @@
+{
+  "api.incoming.errors.custom_domain_unresolved": {
+    "text": "No se pudo resolver la organización del dominio personalizado"
+  }
+}

--- a/locales/content/es/api-invite-errors.json
+++ b/locales/content/es/api-invite-errors.json
@@ -1,0 +1,23 @@
+{
+  "api.invite.errors.invitation_not_found_or_expired": {
+    "text": "Invitación no encontrada o expirada"
+  },
+  "api.invite.errors.token_required": {
+    "text": "Se requiere el token"
+  },
+  "api.invite.errors.organization_no_longer_exists": {
+    "text": "La organización ya no existe"
+  },
+  "api.invite.errors.invitation_already_processed": {
+    "text": "La invitación ya se ha %{status}"
+  },
+  "api.invite.errors.invitation_expired": {
+    "text": "La invitación ha expirado"
+  },
+  "api.invite.errors.email_mismatch": {
+    "text": "Tu dirección de correo electrónico no coincide con la invitación"
+  },
+  "api.invite.errors.already_member": {
+    "text": "Ya eres miembro de esta organización"
+  }
+}

--- a/locales/content/es/api-organizations-errors.json
+++ b/locales/content/es/api-organizations-errors.json
@@ -1,0 +1,107 @@
+{
+  "api.organizations.errors.domain_scoped_forbidden": {
+    "text": "Los miembros limitados a un dominio no pueden realizar esta acción"
+  },
+  "api.organizations.errors.organization_not_found": {
+    "text": "Organización no encontrada: %{extid}"
+  },
+  "api.organizations.errors.organization_owner_required": {
+    "text": "Solo el propietario de la organización puede realizar esta acción"
+  },
+  "api.organizations.errors.organization_member_required": {
+    "text": "Debes ser miembro de la organización para realizar esta acción"
+  },
+  "api.organizations.errors.organization_admin_required": {
+    "text": "Solo los propietarios y administradores de la organización pueden realizar esta acción"
+  },
+  "api.organizations.errors.extid_required": {
+    "text": "Se requiere el ID de la organización"
+  },
+  "api.organizations.errors.display_name_required": {
+    "text": "El nombre de la organización es obligatorio"
+  },
+  "api.organizations.errors.display_name_too_long": {
+    "text": "El nombre de la organización debe tener menos de %{max} caracteres"
+  },
+  "api.organizations.errors.description_too_long": {
+    "text": "La descripción debe tener menos de %{max} caracteres"
+  },
+  "api.organizations.errors.contact_email_exists": {
+    "text": "Ya existe una organización con este correo electrónico de contacto"
+  },
+  "api.organizations.errors.creation_in_progress": {
+    "text": "Creación de la organización en curso. Vuelve a intentarlo."
+  },
+  "api.organizations.errors.organization_limit_reached": {
+    "text": "Se alcanzó el límite de organizaciones. Mejora tu plan para crear más organizaciones."
+  },
+  "api.organizations.invitations.errors.invitation_not_found": {
+    "text": "Invitación no encontrada"
+  },
+  "api.organizations.invitations.errors.email_required": {
+    "text": "Se requiere el correo electrónico"
+  },
+  "api.organizations.invitations.errors.invalid_email_format": {
+    "text": "Formato de correo electrónico no válido"
+  },
+  "api.organizations.invitations.errors.invalid_role": {
+    "text": "El rol debe ser miembro o administrador"
+  },
+  "api.organizations.invitations.errors.cannot_invite_as_owner": {
+    "text": "No se puede invitar como propietario"
+  },
+  "api.organizations.invitations.errors.user_already_member": {
+    "text": "El usuario ya es miembro de esta organización"
+  },
+  "api.organizations.invitations.errors.invitation_already_pending": {
+    "text": "Ya hay una invitación pendiente para este correo electrónico"
+  },
+  "api.organizations.invitations.errors.member_limit_reached": {
+    "text": "Se alcanzó el límite de miembros. Mejora tu plan para invitar a más miembros."
+  },
+  "api.organizations.invitations.errors.resend_only_pending": {
+    "text": "Solo se pueden reenviar invitaciones pendientes"
+  },
+  "api.organizations.invitations.errors.resend_limit_reached": {
+    "text": "Se alcanzó el límite máximo de reenvíos (%{max})"
+  },
+  "api.organizations.invitations.errors.revoke_only_pending": {
+    "text": "Solo se pueden revocar invitaciones pendientes"
+  },
+  "api.organizations.members.errors.member_not_found": {
+    "text": "Miembro no encontrado: %{extid}"
+  },
+  "api.organizations.members.errors.member_not_in_organization": {
+    "text": "No se encontró ningún miembro en esta organización"
+  },
+  "api.organizations.members.errors.member_not_active": {
+    "text": "El miembro no está activo"
+  },
+  "api.organizations.members.errors.invalid_role_value": {
+    "text": "Rol no válido. Debe ser uno de: %{roles}"
+  },
+  "api.organizations.members.errors.cannot_change_owner_role": {
+    "text": "No se puede cambiar el rol del propietario. Usa la transferencia de propiedad en su lugar."
+  },
+  "api.organizations.members.errors.member_already_has_role": {
+    "text": "El miembro ya tiene el rol: %{role}"
+  },
+  "api.organizations.members.errors.cannot_promote_to_owner": {
+    "text": "No se puede ascender a propietario. Usa la transferencia de propiedad en su lugar."
+  },
+  "api.organizations.members.errors.must_be_member": {
+    "text": "Debes ser miembro de esta organización"
+  },
+  "api.organizations.members.errors.cannot_remove_owner": {
+    "text": "No se puede eliminar al propietario de la organización. Transfiere la propiedad primero."
+  },
+  "api.organizations.members.errors.cannot_remove_self": {
+    "text": "No puedes eliminarte a ti mismo. Usa la opción de abandonar la organización en su lugar."
+  },
+  "api.organizations.members.errors.admin_cannot_remove_admin": {
+    "text": "Los administradores no pueden eliminar a otros administradores. Solo los propietarios pueden hacerlo."
+  },
+  "api.organizations.members.errors.no_permission_to_remove": {
+    "text": "No tienes permiso para eliminar miembros"
+  }
+}

--- a/locales/content/es/api-secrets-errors.json
+++ b/locales/content/es/api-secrets-errors.json
@@ -1,0 +1,11 @@
+{
+  "api.secrets.errors.domain_permission_authenticated_non_owner": {
+    "text": "No tienes permiso para usar el dominio: %{domain}"
+  },
+  "api.secrets.errors.domain_public_sharing_disabled": {
+    "text": "El uso compartido público está deshabilitado para el dominio: %{domain}"
+  },
+  "api.secrets.errors.domain_permission_anonymous_cross_domain": {
+    "text": "No tienes permiso para usar el dominio: %{domain}"
+  }
+}

--- a/locales/content/es/email.json
+++ b/locales/content/es/email.json
@@ -60,7 +60,7 @@
     "source_hash": "88c72144"
   },
   "email.welcome.signature": {
-    "text": "Delano",
+    "text": "Equipo de soporte",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -100,7 +100,7 @@
     "source_hash": "fbb7eb2d"
   },
   "email.password_request.signature": {
-    "text": "Delano",
+    "text": "Equipo de soporte",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -145,7 +145,7 @@
     "source_hash": "1863f5be"
   },
   "email.magic_link.signature": {
-    "text": "Delano",
+    "text": "Equipo de soporte",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -230,7 +230,7 @@
     "source_hash": "3f6b45dd"
   },
   "email.secret_revealed.signature": {
-    "text": "Delano",
+    "text": "Equipo de soporte",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -355,7 +355,7 @@
     "source_hash": "734882d2"
   },
   "email.organization_invitation.signature": {
-    "text": "Delano",
+    "text": "Equipo de soporte",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -395,7 +395,7 @@
     "source_hash": "be92cff3"
   },
   "email.password_changed.signature": {
-    "text": "Delano",
+    "text": "Equipo de soporte",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -445,7 +445,7 @@
     "source_hash": "f8d47b82"
   },
   "email.email_changed.signature": {
-    "text": "Delano",
+    "text": "Equipo de soporte",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -495,7 +495,7 @@
     "source_hash": "f8d47b82"
   },
   "email.email_change_requested.signature": {
-    "text": "Delano",
+    "text": "Equipo de soporte",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -550,7 +550,7 @@
     "source_hash": "d4d835fc"
   },
   "email.email_change_confirmation.signature": {
-    "text": "Delano",
+    "text": "Equipo de soporte",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -580,7 +580,7 @@
     "source_hash": "e7c11bb0"
   },
   "email.mfa_enabled.signature": {
-    "text": "Delano",
+    "text": "Equipo de soporte",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -605,7 +605,7 @@
     "source_hash": "97ef0a3e"
   },
   "email.mfa_disabled.signature": {
-    "text": "Delano",
+    "text": "Equipo de soporte",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -650,7 +650,7 @@
     "source_hash": "450c54c5"
   },
   "email.new_login_alert.signature": {
-    "text": "Delano",
+    "text": "Equipo de soporte",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -670,7 +670,7 @@
     "source_hash": "d442beed"
   },
   "email.member_removed.signature": {
-    "text": "Delano",
+    "text": "Equipo de soporte",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -690,7 +690,7 @@
     "source_hash": "c2280c0c"
   },
   "email.role_changed.signature": {
-    "text": "Delano",
+    "text": "Equipo de soporte",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -710,7 +710,7 @@
     "source_hash": "7095fc69"
   },
   "email.organization_deleted.signature": {
-    "text": "Delano",
+    "text": "Equipo de soporte",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -750,7 +750,7 @@
     "source_hash": "36008943"
   },
   "email.payment_receipt.signature": {
-    "text": "Delano",
+    "text": "Equipo de soporte",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -775,7 +775,7 @@
     "source_hash": "926406b1"
   },
   "email.payment_failed.signature": {
-    "text": "Delano",
+    "text": "Equipo de soporte",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -800,7 +800,7 @@
     "source_hash": "66a1419e"
   },
   "email.trial_expiring.signature": {
-    "text": "Delano",
+    "text": "Equipo de soporte",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -825,7 +825,7 @@
     "source_hash": "5a96ae38"
   },
   "email.subscription_changed.signature": {
-    "text": "Delano",
+    "text": "Equipo de soporte",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -853,5 +853,41 @@
     "text": "Onetime Secret",
     "renderer": "erb",
     "source_hash": "1cd0194a"
+  },
+  "email.common.secret_link_label": {
+    "text": "Enlace secreto"
+  },
+  "email.common.automated_notice": {
+    "text": "Este es un mensaje automático de %{product_name}."
+  },
+  "email.common.support_label": {
+    "text": "Soporte"
+  },
+  "email.expiration_warning.signature": {
+    "text": "Equipo de soporte"
+  },
+  "email.expiration_warning.footer_note": {
+    "text": "Has recibido este mensaje porque un secreto que creaste en %{product_name} está a punto de expirar."
+  },
+  "email.feedback_email.user_id_label": {
+    "text": "Usuario:"
+  },
+  "email.feedback_email.timezone_label": {
+    "text": "Zona horaria:"
+  },
+  "email.feedback_email.version_label": {
+    "text": "Versión:"
+  },
+  "email.incoming_secret.footer_note": {
+    "text": "Has recibido este mensaje porque alguien usó %{product_name} para enviarte un secreto. Si no lo esperabas, puedes ignorar este correo electrónico con total tranquilidad."
+  },
+  "email.secret_link.passphrase_label": {
+    "text": "Frase de contraseña requerida:"
+  },
+  "email.secret_link.passphrase_required": {
+    "text": "Este secreto está protegido con una frase de contraseña. El remitente debe proporcionártela por separado."
+  },
+  "email.secret_link.footer_note": {
+    "text": "Has recibido este mensaje porque %{sender_email} usó %{product_name} para compartir un secreto contigo. Si no lo esperabas, puedes ignorar este correo electrónico con total tranquilidad."
   }
 }

--- a/locales/content/es/feature-feedback.json
+++ b/locales/content/es/feature-feedback.json
@@ -58,5 +58,14 @@
   "web.feedback.reason_email_change_unauthorized": {
     "text": "Parece que estás reportando un cambio de correo electrónico no autorizado en tu cuenta. Por favor, describe lo que ocurrió y lo investigaremos de inmediato.",
     "source_hash": "00e56551"
+  },
+  "web.feedback.anonymous_no_reply": {
+    "text": "Nota: si deseas una respuesta, firma el mensaje o incluye una dirección de correo electrónico en él."
+  },
+  "web.feedback.characters_remaining": {
+    "text": "{count} caracteres restantes"
+  },
+  "web.feedback.character_limit_reached": {
+    "text": "Se alcanzó el límite de caracteres"
   }
 }

--- a/locales/content/es/feature-homepage-secrets.json
+++ b/locales/content/es/feature-homepage-secrets.json
@@ -1,0 +1,50 @@
+{
+  "homepage_secrets.disabled.members_only_eyebrow": {
+    "text": "Instancia solo para miembros"
+  },
+  "homepage_secrets.disabled.private_instance_eyebrow": {
+    "text": "Instancia privada"
+  },
+  "homepage_secrets.disabled.team_link_headline": {
+    "text": "Este enlace es para el equipo de {workspace}."
+  },
+  "homepage_secrets.disabled.signin_headline": {
+    "text": "Inicia sesión para crear un {action}."
+  },
+  "homepage_secrets.disabled.signin_headline_action": {
+    "text": "enlace secreto"
+  },
+  "homepage_secrets.disabled.team_subtitle": {
+    "text": "Solo los compañeros de equipo autorizados en {domain} pueden generar nuevos enlaces de un solo uso aquí. Los destinatarios pueden seguir abriendo cualquier enlace que se les haya enviado."
+  },
+  "homepage_secrets.disabled.public_subtitle": {
+    "text": "Solo los miembros autorizados de esta instancia pueden generar nuevos enlaces de un solo uso. Los destinatarios pueden seguir abriendo cualquier enlace que se les haya enviado."
+  },
+  "homepage_secrets.disabled.signin_cta": {
+    "text": "Inicia sesión en tu cuenta"
+  },
+  "homepage_secrets.disabled.what_is_this": {
+    "text": "¿Qué es esto?"
+  },
+  "homepage_secrets.disabled.trust_viewed_once": {
+    "text": "Se ve una vez y desaparece"
+  },
+  "homepage_secrets.disabled.trust_zero_retained": {
+    "text": "Cero datos retenidos"
+  },
+  "homepage_secrets.disabled.promo_title": {
+    "text": "Novedad: los planes gratuitos ahora incluyen dominios personalizados."
+  },
+  "homepage_secrets.disabled.promo_subtitle": {
+    "text": "Apunta tu dominio a Onetime Secret y comparte secretos con tu propia marca."
+  },
+  "homepage_secrets.disabled.promo_learn_how": {
+    "text": "Descubre cómo"
+  },
+  "homepage_secrets.disabled.logo_alt": {
+    "text": "Logotipo de {name}"
+  },
+  "homepage_secrets.disabled.opens_in_new_tab": {
+    "text": "(se abre en una pestaña nueva)"
+  }
+}

--- a/locales/content/es/feature-incoming.json
+++ b/locales/content/es/feature-incoming.json
@@ -130,5 +130,26 @@
   "incoming.receipt_link_text": {
     "text": "recibo",
     "source_hash": "6f328609"
+  },
+  "incoming.upgrade_required_title": {
+    "text": "Se requiere mejorar el plan"
+  },
+  "incoming.upgrade_required_description": {
+    "text": "Esta función requiere mejorar el plan. Ponte en contacto con el propietario de la cuenta para habilitar los secretos entrantes."
+  },
+  "incoming.validation_memo_too_long": {
+    "text": "La nota debe tener {max} caracteres o menos"
+  },
+  "incoming.validation_secret_required": {
+    "text": "El contenido del secreto es obligatorio"
+  },
+  "incoming.validation_recipient_required": {
+    "text": "Selecciona un destinatario"
+  },
+  "incoming.validation_feature_disabled": {
+    "text": "La función de secretos entrantes no está habilitada"
+  },
+  "incoming.validation_form_errors": {
+    "text": "Revisa el formulario en busca de errores"
   }
 }

--- a/locales/content/es/feature-regions.json
+++ b/locales/content/es/feature-regions.json
@@ -186,5 +186,8 @@
   "web.regions.jurisdictions.apac.name": {
     "text": "Asia-Pacific",
     "source_hash": "7a757670"
+  },
+  "web.regions.no_region_configured": {
+    "text": "Actualmente no hay información de región disponible para tu cuenta."
   }
 }

--- a/locales/content/es/feature-translations.json
+++ b/locales/content/es/feature-translations.json
@@ -64,7 +64,7 @@
     "source_hash": "13131e36"
   },
   "web.translations.the_following_people_have_donated_their_time_to_": {
-    "text": "Las siguientes personas han donado su tiempo para ayudar a expandir el alcance de {product_name}:",
+    "text": "Las siguientes personas han donado su tiempo para ayudar a ampliar el alcance de {product_name}:",
     "source_hash": "85a766af"
   },
   "web.translations.translations": {
@@ -84,7 +84,7 @@
     "source_hash": "ba5c4395"
   },
   "web.translations.since_2012_onetime_secret_has_provided_a_secure_": {
-    "text": "Desde 2012, {product_name} ha proporcionado una forma segura de compartir información sensible en todo el mundo. Con usuarios en regiones donde el inglés no es el idioma principal, las traducciones precisas son esenciales para hacer que la comunicación segura sea accesible para todos.",
+    "text": "Desde 2012, {product_name} ha ofrecido una forma segura de compartir información sensible en todo el mundo. Con usuarios en regiones donde el inglés no es el idioma principal, las traducciones precisas son esenciales para que la comunicación segura sea accesible para todos.",
     "source_hash": "87a6e9af"
   },
   "web.translations.help_secure_communication_go_global": {

--- a/locales/content/es/secret-manage.json
+++ b/locales/content/es/secret-manage.json
@@ -476,5 +476,11 @@
   },
   "web.private.send_feedback": {
     "text": "Enviar comentarios"
+  },
+  "web.receipt.open_link": {
+    "text": "Abrir enlace"
+  },
+  "web.secrets.messageDeleted": {
+    "text": "Mensaje eliminado"
   }
 }

--- a/locales/content/es/session-auth-extended.json
+++ b/locales/content/es/session-auth-extended.json
@@ -716,5 +716,20 @@
   },
   "web.auth.sessions._guidance.context": {
     "text": "Página de gestión de dispositivos/navegadores con sesión iniciada"
+  },
+  "web.auth.google": {
+    "text": "Google"
+  },
+  "web.auth.mfa.alternative_auth_options": {
+    "text": "Opciones de autenticación alternativas"
+  },
+  "web.auth.remember.enabled": {
+    "text": "Mantener la sesión iniciada"
+  },
+  "web.auth.sessions.session_singular": {
+    "text": "sesión"
+  },
+  "web.auth.sessions.session_plural": {
+    "text": "sesiones"
   }
 }

--- a/locales/content/es/session-auth.json
+++ b/locales/content/es/session-auth.json
@@ -398,5 +398,32 @@
   },
   "web.auth.verify._guidance.context": {
     "text": "Flujo de verificación de correo electrónico después del registro"
+  },
+  "web.auth.account.sso_linked": {
+    "text": "Cuenta SSO"
+  },
+  "web.help.reset_password_link": {
+    "text": "Restablecer contraseña"
+  },
+  "web.login.custom_domain_sso_title": {
+    "text": "El inicio de sesión único (SSO) está disponible para este dominio"
+  },
+  "web.login.custom_domain_sso_description": {
+    "text": "El administrador de la organización puede habilitar el SSO para permitir que los miembros del equipo inicien sesión aquí. Contacta con el administrador para obtener acceso."
+  },
+  "web.login.signin_disabled_heading": {
+    "text": "El inicio de sesión no está disponible"
+  },
+  "web.login.signin_disabled_message": {
+    "text": "Actualmente, el inicio de sesión no está disponible en este dominio."
+  },
+  "web.login.errors.sso_not_configured": {
+    "text": "El inicio de sesión único (SSO) no está configurado para este dominio. Contacta con tu administrador."
+  },
+  "web.login.errors.invalid_email": {
+    "text": "La dirección de correo electrónico de tu proveedor de identidad no es válida. Contacta con tu administrador."
+  },
+  "web.login.errors.domain_not_allowed": {
+    "text": "Tu dominio de correo electrónico no está autorizado para registrarse mediante SSO. Contacta con tu administrador."
   }
 }

--- a/locales/content/es/workspace-account.json
+++ b/locales/content/es/workspace-account.json
@@ -682,5 +682,14 @@
   "web.settings.profile.didnt_receive_email": {
     "text": "¿No recibiste el correo electrónico?",
     "source_hash": "fe3ac3ad"
+  },
+  "web.settings.api.api_disabled_notice": {
+    "text": "La API está deshabilitada para esta instancia."
+  },
+  "web.settings.security.sso_managed_title": {
+    "text": "Seguridad gestionada por SSO"
+  },
+  "web.settings.security.sso_managed_description": {
+    "text": "Tu cuenta se autentica a través del proveedor de inicio de sesión único (SSO) de tu organización. La contraseña, la autenticación multifactor y los códigos de recuperación los gestiona tu proveedor de identidad."
   }
 }

--- a/locales/content/es/workspace-billing.json
+++ b/locales/content/es/workspace-billing.json
@@ -988,5 +988,47 @@
     "text": "Disponible solo en tu región de suscripción original",
     "context": "Hint shown on plan cards when currency does not match active subscription",
     "source_hash": "10de32e5"
+  },
+  "web.billing.already_subscribed": {
+    "text": "Ya estás suscrito a este plan."
+  },
+  "web.billing.cancel.reactivate_button": {
+    "text": "Reactivar suscripción"
+  },
+  "web.billing.cancel.reactivate_success": {
+    "text": "Tu suscripción se ha reactivado. Se te seguirá facturando con normalidad."
+  },
+  "web.billing.cancel.reactivate_error": {
+    "text": "No se pudo reactivar la suscripción. Inténtalo de nuevo o contacta con soporte."
+  },
+  "web.billing.features.manage_orgs": {
+    "text": "Gestión de organizaciones"
+  },
+  "web.billing.features.flexible_from_domain": {
+    "text": "Dominio de remitente de correo flexible"
+  },
+  "web.billing.features.unlimited_admins": {
+    "text": "Administradores ilimitados"
+  },
+  "web.billing.features.manage_sso": {
+    "text": "SSO"
+  },
+  "web.billing.overview.entitlements.flexible_from_domain": {
+    "text": "Dominio de remitente de correo flexible"
+  },
+  "web.billing.overview.entitlements.manage_orgs": {
+    "text": "Gestionar organizaciones"
+  },
+  "web.billing.overview.entitlements.manage_sso": {
+    "text": "Inicio de sesión único (SSO)"
+  },
+  "web.billing.overview.entitlements.manage_billing": {
+    "text": "Gestionar facturación"
+  },
+  "web.billing.overview.entitlements.custom_signup_validation": {
+    "text": "Validación de registro personalizada"
+  },
+  "web.billing.plans.reactivate": {
+    "text": "Reactivar"
   }
 }

--- a/locales/content/es/workspace-branding.json
+++ b/locales/content/es/workspace-branding.json
@@ -178,5 +178,11 @@
   "web.branding.upgrade_to_customize": {
     "text": "Mejora tu plan para personalizar la marca de este dominio.",
     "source_hash": "9077bf79"
+  },
+  "web.branding.saved_successfully": {
+    "text": "Configuración de marca guardada correctamente"
+  },
+  "web.branding.keyhole_logo_icon": {
+    "text": "Icono de ojo de cerradura que representa el uso compartido seguro y privado"
   }
 }

--- a/locales/content/es/workspace-dashboard.json
+++ b/locales/content/es/workspace-dashboard.json
@@ -22,5 +22,14 @@
   "web.dashboard.fetch_error_description": {
     "text": "Hubo un problema al cargar tus datos. Por favor, inténtalo de nuevo.",
     "source_hash": "ff0d904e"
+  },
+  "web.teams.create_first_team_title": {
+    "text": "Crea tu primer equipo"
+  },
+  "web.teams.create_first_team_description": {
+    "text": "Los equipos te permiten colaborar con otras personas en un espacio de trabajo compartido."
+  },
+  "web.teams.create_team": {
+    "text": "Crear equipo"
   }
 }

--- a/locales/content/es/workspace-domains.json
+++ b/locales/content/es/workspace-domains.json
@@ -504,11 +504,11 @@
     "source_hash": "8e37953d"
   },
   "web.domains.email.dns_optional_label": {
-    "text": "Recommended",
+    "text": "Recomendado",
     "source_hash": "d70604e8"
   },
   "web.domains.email.dns_optional_hint": {
-    "text": "This record is recommended but not required for verification. A DMARC policy at your organizational domain may already cover this subdomain.",
+    "text": "Este registro es recomendado pero no obligatorio para la verificación. Una política DMARC en tu dominio organizacional ya podría cubrir este subdominio.",
     "source_hash": "58e1a12b"
   },
   "web.domains.email.copy": {
@@ -1022,7 +1022,7 @@
     "text": "WebAuthn / claves de acceso"
   },
   "web.domains.signin.method_sso": {
-    "text": "Single Sign-On"
+    "text": "Inicio de sesión único (SSO)"
   },
   "web.domains.signin.method_overrides_label": {
     "text": "Anulaciones de método"
@@ -1094,7 +1094,7 @@
     "text": "Permitir la autenticación por correo electrónico sin contraseña en este dominio"
   },
   "web.domains.signin.sso_enabled_label": {
-    "text": "Single Sign-On"
+    "text": "Inicio de sesión único (SSO)"
   },
   "web.domains.signin.sso_enabled_hint": {
     "text": "Permitir la autenticación SSO en este dominio"

--- a/locales/content/es/workspace-domains.json
+++ b/locales/content/es/workspace-domains.json
@@ -846,5 +846,389 @@
   "web.domains.sso.not_configured_notice": {
     "text": "El SSO aún no está configurado para este dominio. Habilita el inicio de sesión único para permitir que los miembros del equipo se autentiquen usando el proveedor de identidad de tu organización.",
     "source_hash": "c439214b"
+  },
+  "api.domains.errors.add_admin_required": {
+    "text": "Solo los propietarios y administradores de la organización pueden añadir dominios personalizados"
+  },
+  "web.domains.public_homepage": {
+    "text": "Página de inicio pública"
+  },
+  "web.domains.status_tooltip_active": {
+    "text": "Dominio verificado y activo"
+  },
+  "web.domains.status_tooltip_dns_incorrect": {
+    "text": "DNS no configurado — haz clic para corregir"
+  },
+  "web.domains.status_tooltip_not_verified": {
+    "text": "Dominio no verificado — haz clic para verificar"
+  },
+  "web.domains.status_tooltip_unverified": {
+    "text": "Estado del dominio sin verificar — haz clic para actualizar"
+  },
+  "web.domains.last_check_failed": {
+    "text": "La última comprobación de verificación falló"
+  },
+  "web.domains.last_check_failed_ago": {
+    "text": "última comprobación fallida {0}"
+  },
+  "web.domains.verify_now": {
+    "text": "Verificar ahora"
+  },
+  "web.domains.click_to_verify": {
+    "text": "haz clic para verificar"
+  },
+  "web.domains.remove_domain_description": {
+    "text": "Elimina permanentemente este dominio y toda su configuración."
+  },
+  "web.domains.add_access_denied": {
+    "text": "Acceso denegado"
+  },
+  "web.domains.add_access_denied_description": {
+    "text": "No tienes permiso para añadir dominios a esta organización. Contacta con el administrador de tu organización."
+  },
+  "web.domains.dns_widget_load_failed": {
+    "text": "No se pudo cargar el widget de DNS"
+  },
+  "web.domains.dns_widget_not_available": {
+    "text": "El widget de DNS no está disponible"
+  },
+  "web.domains.dns_widget_init_failed": {
+    "text": "No se pudo inicializar el widget de DNS"
+  },
+  "web.domains.verified": {
+    "text": "Verificado"
+  },
+  "web.domains.pending_verification": {
+    "text": "Pendiente de verificación"
+  },
+  "web.domains.unsaved_changes_confirmation": {
+    "text": "Tienes cambios sin guardar. ¿Seguro que quieres salir?"
+  },
+  "web.domains.entitlement_required_owner": {
+    "text": "Esta función requiere mejorar el plan."
+  },
+  "web.domains.entitlement_required_member": {
+    "text": "Esta función no está disponible en tu plan actual. Contacta con el propietario de tu organización."
+  },
+  "web.domains.detail.manage": {
+    "text": "Gestionar"
+  },
+  "web.domains.detail.features": {
+    "text": "Funciones"
+  },
+  "web.domains.detail.homepage_title": {
+    "text": "Secretos en la página de inicio"
+  },
+  "web.domains.detail.homepage_description": {
+    "text": "Permite el acceso público para crear secretos en la página de inicio de tu dominio"
+  },
+  "web.domains.detail.brand_description": {
+    "text": "Logotipo, colores y marca personalizada"
+  },
+  "web.domains.detail.sso_description": {
+    "text": "Configuración del proveedor de inicio de sesión único (SSO)"
+  },
+  "web.domains.detail.email_description": {
+    "text": "Configuración personalizada del remitente de correo electrónico"
+  },
+  "web.domains.detail.incoming_description": {
+    "text": "Configuración de destinatarios de secretos entrantes"
+  },
+  "web.domains.detail.signup_description": {
+    "text": "Estrategia de validación de registro por dominio"
+  },
+  "web.domains.detail.signin_description": {
+    "text": "Configuración del método de inicio de sesión por dominio"
+  },
+  "web.domains.email.dns_check_label": {
+    "text": "DNS"
+  },
+  "web.domains.email.provider_check_label": {
+    "text": "Proveedor"
+  },
+  "web.domains.email.test_email_title": {
+    "text": "Probar la entrega de correo"
+  },
+  "web.domains.email.test_email_hint": {
+    "text": "Envíate un correo de prueba a ti mismo con la configuración guardada. Funciona incluso cuando la función aún no está habilitada."
+  },
+  "web.domains.email.send_test": {
+    "text": "Enviar prueba"
+  },
+  "web.domains.email.test_email_sent": {
+    "text": "Correo de prueba enviado correctamente"
+  },
+  "web.domains.email.test_email_failed": {
+    "text": "No se pudo enviar el correo de prueba"
+  },
+  "web.domains.email.test_email_sent_to": {
+    "text": "Enviado a {email}"
+  },
+  "web.domains.email.delivered_via": {
+    "text": "Entregado mediante {provider}"
+  },
+  "web.domains.incoming.feature_disabled": {
+    "text": "Secretos entrantes no disponibles"
+  },
+  "web.domains.incoming.feature_disabled_description": {
+    "text": "Los secretos entrantes no están habilitados en esta instancia. Contacta con tu administrador."
+  },
+  "web.domains.signin.title": {
+    "text": "Configuración de inicio de sesión"
+  },
+  "web.domains.signin.configure_signin": {
+    "text": "Configurar inicio de sesión"
+  },
+  "web.domains.signin.config_description": {
+    "text": "Configura los métodos de autenticación para iniciar sesión en este dominio"
+  },
+  "web.domains.signin.access_denied": {
+    "text": "Acceso denegado"
+  },
+  "web.domains.signin.upgrade_to_configure": {
+    "text": "Mejora tu plan para configurar los métodos de inicio de sesión de este dominio."
+  },
+  "web.domains.signin.not_configured_notice": {
+    "text": "Todavía no se ha establecido la configuración de inicio de sesión para este dominio. Configura las anulaciones para controlar qué métodos de autenticación están disponibles en la página de inicio de sesión de este dominio."
+  },
+  "web.domains.signin.signin_enabled_label": {
+    "text": "Inicio de sesión habilitado"
+  },
+  "web.domains.signin.header_toggle_label": {
+    "text": "Inicio de sesión"
+  },
+  "web.domains.signin.signin_enabled_hint": {
+    "text": "Si los usuarios pueden iniciar sesión en este dominio"
+  },
+  "web.domains.signin.restrict_to_label": {
+    "text": "Restringir el método de inicio de sesión"
+  },
+  "web.domains.signin.restrict_to_hint": {
+    "text": "Restringe este dominio a un único método de autenticación. Cuando se establece, solo se muestra el método elegido en la página de inicio de sesión."
+  },
+  "web.domains.signin.all_methods": {
+    "text": "Todos los métodos"
+  },
+  "web.domains.signin.all_methods_description": {
+    "text": "Mostrar todos los métodos de autenticación habilitados en la página de inicio de sesión"
+  },
+  "web.domains.signin.method_password": {
+    "text": "Contraseña"
+  },
+  "web.domains.signin.method_email_auth": {
+    "text": "Autenticación por correo electrónico"
+  },
+  "web.domains.signin.method_webauthn": {
+    "text": "WebAuthn / claves de acceso"
+  },
+  "web.domains.signin.method_sso": {
+    "text": "Single Sign-On"
+  },
+  "web.domains.signin.method_overrides_label": {
+    "text": "Anulaciones de método"
+  },
+  "web.domains.signin.method_overrides_hint": {
+    "text": "Habilita o deshabilita métodos de autenticación individuales para este dominio"
+  },
+  "web.domains.signin.mode_question": {
+    "text": "¿Cómo pueden iniciar sesión los usuarios?"
+  },
+  "web.domains.signin.mode_any": {
+    "text": "Cualquier método disponible"
+  },
+  "web.domains.signin.mode_any_hint": {
+    "text": "Muestra todos los métodos disponibles en este dominio. Limita los métodos individuales a continuación."
+  },
+  "web.domains.signin.mode_one": {
+    "text": "Un método específico"
+  },
+  "web.domains.signin.mode_one_hint": {
+    "text": "Restringe la página de inicio de sesión a un único método. Solo se enumeran los métodos disponibles en este dominio."
+  },
+  "web.domains.signin.mode_disabled": {
+    "text": "Inicio de sesión deshabilitado"
+  },
+  "web.domains.signin.mode_disabled_hint": {
+    "text": "Los usuarios no pueden iniciar sesión en este dominio."
+  },
+  "web.domains.signin.mode_disabled_notice": {
+    "text": "Los visitantes de la página de inicio de sesión de este dominio ven un aviso de que el inicio de sesión no está disponible, con un enlace de vuelta a la página de inicio. Tu configuración de métodos anterior se conserva y se restaura cuando vuelves a habilitar el inicio de sesión."
+  },
+  "web.domains.signin.methods_list_label": {
+    "text": "Métodos que se muestran en la página de inicio de sesión"
+  },
+  "web.domains.signin.restrict_picker_hint": {
+    "text": "Solo se enumeran los métodos disponibles en este dominio."
+  },
+  "web.domains.signin.availability_always": {
+    "text": "Siempre disponible"
+  },
+  "web.domains.signin.availability_global_on": {
+    "text": "Sigue la política global · Activado"
+  },
+  "web.domains.signin.availability_global_off": {
+    "text": "No disponible"
+  },
+  "web.domains.signin.availability_unavailable": {
+    "text": "No disponible en todo el sitio"
+  },
+  "web.domains.signin.allow_on_domain": {
+    "text": "Permitir en este dominio"
+  },
+  "web.domains.signin.method_password_blurb": {
+    "text": "Solo contraseña"
+  },
+  "web.domains.signin.method_email_auth_blurb": {
+    "text": "Inicio de sesión con enlace mágico sin contraseña"
+  },
+  "web.domains.signin.method_webauthn_blurb": {
+    "text": "Datos biométricos y llaves de seguridad"
+  },
+  "web.domains.signin.method_sso_blurb": {
+    "text": "Proveedor de identidad externo"
+  },
+  "web.domains.signin.email_auth_label": {
+    "text": "Autenticación por correo electrónico"
+  },
+  "web.domains.signin.email_auth_hint": {
+    "text": "Permitir la autenticación por correo electrónico sin contraseña en este dominio"
+  },
+  "web.domains.signin.sso_enabled_label": {
+    "text": "Single Sign-On"
+  },
+  "web.domains.signin.sso_enabled_hint": {
+    "text": "Permitir la autenticación SSO en este dominio"
+  },
+  "web.domains.signin.enabled_label": {
+    "text": "Habilitar la configuración de inicio de sesión"
+  },
+  "web.domains.signin.enabled_hint": {
+    "text": "Cuando está habilitada, este dominio utiliza la configuración de inicio de sesión definida arriba"
+  },
+  "web.domains.signin.save_config": {
+    "text": "Guardar configuración"
+  },
+  "web.domains.signin.update_success": {
+    "text": "La configuración de inicio de sesión se actualizó correctamente"
+  },
+  "web.domains.signin.reset_to_defaults": {
+    "text": "Restablecer los valores predeterminados"
+  },
+  "web.domains.signin.reset_confirm": {
+    "text": "¿Restablecer el inicio de sesión a los valores predeterminados globales?"
+  },
+  "web.domains.signin.reset_keeps_sso": {
+    "text": "Tus credenciales de SSO se conservan. Elimínalas por separado en la pantalla de configuración de SSO."
+  },
+  "web.domains.signin.reset_action": {
+    "text": "Sí, restablecer"
+  },
+  "web.domains.signin.reset_success": {
+    "text": "La configuración de inicio de sesión se restableció a los valores predeterminados globales"
+  },
+  "web.domains.signup.title": {
+    "text": "Validación de registro"
+  },
+  "web.domains.signup.config_description": {
+    "text": "Configura la validación de registro para este dominio"
+  },
+  "web.domains.signup.access_denied": {
+    "text": "Acceso denegado"
+  },
+  "web.domains.signup.upgrade_to_configure": {
+    "text": "Mejora tu plan para configurar la validación de registro por dominio."
+  },
+  "web.domains.signup.configure_signup": {
+    "text": "Configurar registro"
+  },
+  "web.domains.signup.not_configured_notice": {
+    "text": "La validación de registro aún no está configurada para este dominio. Configura una estrategia para controlar quién puede registrarse a través de este dominio."
+  },
+  "web.domains.signup.site_signups_disabled_warning": {
+    "text": "Los registros están actualmente deshabilitados a nivel de sitio. Esta política por dominio está configurada, pero no controlará ningún tráfico hasta que se habiliten los registros del sitio."
+  },
+  "web.domains.signup.strategy_label": {
+    "text": "Estrategia de validación"
+  },
+  "web.domains.signup.strategy_description": {
+    "text": "Elige cómo se validan las direcciones de correo electrónico cuando los usuarios se registran en este dominio."
+  },
+  "web.domains.signup.network_validation_warning": {
+    "text": "Esta estrategia realiza llamadas de red durante el registro, lo que puede añadir latencia o ser bloqueado por algunos proveedores."
+  },
+  "web.domains.signup.allowed_domains_label": {
+    "text": "Dominios de registro permitidos"
+  },
+  "web.domains.signup.allowed_domains_hint": {
+    "text": "Solo estos dominios de correo electrónico podrán registrarse. Añade un dominio por entrada."
+  },
+  "web.domains.signup.domain_placeholder": {
+    "text": "example.com"
+  },
+  "web.domains.signup.invalid_domain": {
+    "text": "Introduce un dominio válido (p. ej. example.com)"
+  },
+  "web.domains.signup.domain_exists": {
+    "text": "Este dominio ya está en la lista"
+  },
+  "web.domains.signup.remove_domain": {
+    "text": "Eliminar {domain}"
+  },
+  "web.domains.signup.enabled_label": {
+    "text": "Habilitar la validación por dominio"
+  },
+  "web.domains.signup.enabled_hint": {
+    "text": "Cuando está habilitada, los registros en este dominio utilizan la estrategia de arriba en lugar de la política global."
+  },
+  "web.domains.signup.delete_config": {
+    "text": "Eliminar configuración"
+  },
+  "web.domains.signup.delete_confirm": {
+    "text": "¿Eliminar la configuración de validación de registro? Los registros volverán a usar la política global."
+  },
+  "web.domains.signup.save_config": {
+    "text": "Guardar configuración"
+  },
+  "web.domains.signup.update_success": {
+    "text": "La validación de registro se actualizó correctamente"
+  },
+  "web.domains.signup.delete_success": {
+    "text": "La configuración de validación de registro se eliminó correctamente"
+  },
+  "web.domains.signup.domain_overrides_label": {
+    "text": "Anulaciones de dominio"
+  },
+  "web.domains.signup.domain_overrides_hint": {
+    "text": "Anula la configuración de registro global para este dominio"
+  },
+  "web.domains.signup.signup_enabled_label": {
+    "text": "Registro habilitado"
+  },
+  "web.domains.signup.signup_enabled_hint": {
+    "text": "Anula si el registro está habilitado para este dominio"
+  },
+  "web.domains.signup.autoverify_label": {
+    "text": "Verificar cuentas automáticamente"
+  },
+  "web.domains.signup.autoverify_hint": {
+    "text": "Anula si las cuentas nuevas se verifican automáticamente en este dominio"
+  },
+  "web.domains.sso.test_success": {
+    "text": "Prueba de conexión correcta — el proveedor respondió correctamente"
+  },
+  "web.domains.sso.test_failed": {
+    "text": "La prueba de conexión falló"
+  },
+  "web.domains.sso.enforce_moved_notice": {
+    "text": "Para exigir SSO en todos los inicios de sesión de este dominio, configúralo en los ajustes de inicio de sesión del dominio. El modo solo SSO restringe la página de inicio de sesión al proveedor de SSO configurado aquí."
+  },
+  "web.domains.sso.edit_credentials": {
+    "text": "Editar credenciales"
+  },
+  "web.domains.sso.configure_button": {
+    "text": "Configurar"
+  },
+  "web.domains.sso.upgrade_required": {
+    "text": "Mejora tu plan para configurar"
   }
 }

--- a/locales/content/es/workspace-organizations.json
+++ b/locales/content/es/workspace-organizations.json
@@ -770,5 +770,200 @@
   "web.organizations.sso.status_not_configured": {
     "text": "No configurado",
     "source_hash": "bbea960e"
+  },
+  "api.organizations.errors.not_found": {
+    "text": "Organización no encontrada: %{extid}"
+  },
+  "api.organizations.errors.owner_required": {
+    "text": "Solo el propietario de la organización puede realizar esta acción"
+  },
+  "api.organizations.errors.admin_required": {
+    "text": "Solo los propietarios y administradores de la organización pueden realizar esta acción"
+  },
+  "api.organizations.errors.member_required": {
+    "text": "Debes ser miembro de la organización para realizar esta acción"
+  },
+  "api.organizations.invitations.errors.create_admin_required": {
+    "text": "Solo los propietarios y administradores de la organización pueden crear invitaciones"
+  },
+  "api.organizations.invitations.errors.resend_admin_required": {
+    "text": "Solo los propietarios y administradores de la organización pueden reenviar invitaciones"
+  },
+  "api.organizations.invitations.errors.view_admin_required": {
+    "text": "Solo los propietarios y administradores de la organización pueden ver las invitaciones"
+  },
+  "api.organizations.invitations.errors.revoke_admin_required": {
+    "text": "Solo los propietarios y administradores de la organización pueden revocar invitaciones"
+  },
+  "api.organizations.invitations.errors.email_required": {
+    "text": "El correo electrónico es obligatorio"
+  },
+  "api.organizations.invitations.errors.email_invalid": {
+    "text": "Formato de correo electrónico no válido"
+  },
+  "api.organizations.invitations.errors.role_invalid": {
+    "text": "El rol debe ser miembro o administrador"
+  },
+  "api.organizations.invitations.errors.cannot_invite_owner": {
+    "text": "No se puede invitar como propietario"
+  },
+  "api.organizations.invitations.errors.already_member": {
+    "text": "El usuario ya es miembro de esta organización"
+  },
+  "api.organizations.invitations.errors.already_pending": {
+    "text": "Ya hay una invitación pendiente para este correo electrónico"
+  },
+  "api.organizations.invitations.errors.member_limit_reached": {
+    "text": "Se alcanzó el límite de miembros. Mejora tu plan para invitar a más miembros."
+  },
+  "api.organizations.invitations.errors.not_found": {
+    "text": "Invitación no encontrada"
+  },
+  "api.organizations.invitations.errors.cannot_resend_non_pending": {
+    "text": "Solo se pueden reenviar invitaciones pendientes"
+  },
+  "api.organizations.invitations.errors.cannot_revoke_non_pending": {
+    "text": "Solo se pueden revocar invitaciones pendientes"
+  },
+  "api.organizations.invitations.errors.resend_limit_reached": {
+    "text": "Se alcanzó el límite máximo de reenvíos (%{max})"
+  },
+  "api.organizations.invitations.errors.accept_token_required": {
+    "text": "El token es obligatorio"
+  },
+  "api.organizations.invitations.errors.accept_organization_gone": {
+    "text": "La organización ya no existe"
+  },
+  "api.organizations.invitations.errors.accept_already_acted": {
+    "text": "La invitación ya se ha %{status}"
+  },
+  "api.organizations.invitations.errors.accept_expired": {
+    "text": "La invitación ha caducado"
+  },
+  "api.organizations.invitations.errors.accept_email_mismatch": {
+    "text": "Tu dirección de correo electrónico no coincide con la invitación"
+  },
+  "api.organizations.invitations.errors.accept_already_member": {
+    "text": "Ya eres miembro de esta organización"
+  },
+  "web.organizations.entitlements_title": {
+    "text": "Derechos de la organización"
+  },
+  "web.organizations.page_description_short": {
+    "text": "Consulta y configura tus espacios de trabajo"
+  },
+  "web.organizations.delete_organization_remove_domains_first": {
+    "text": "Elimina todos los dominios personalizados antes de eliminar esta organización."
+  },
+  "web.organizations.default_org_delete_notice_title": {
+    "text": "Eliminar esta organización"
+  },
+  "web.organizations.default_org_delete_notice_before": {
+    "text": "Esta es tu organización predeterminada y no se puede eliminar desde el panel. Para eliminarla, ponte en contacto a través del"
+  },
+  "web.organizations.default_org_delete_notice_link": {
+    "text": "formulario de comentarios"
+  },
+  "web.organizations.default_org_delete_notice_after": {
+    "text": "."
+  },
+  "web.organizations.leave_organization": {
+    "text": "Abandonar esta organización"
+  },
+  "web.organizations.leave_organization_warning": {
+    "text": "Perderás el acceso a esta organización y a sus recursos."
+  },
+  "web.organizations.leave_organization_confirm_title": {
+    "text": "Abandonar la organización"
+  },
+  "web.organizations.leave_organization_confirm_message": {
+    "text": "¿Seguro que quieres abandonar {name}? Necesitarás una nueva invitación para volver a unirte."
+  },
+  "web.organizations.leave_organization_success": {
+    "text": "Has abandonado la organización."
+  },
+  "web.organizations.leave_error": {
+    "text": "No se pudo abandonar la organización"
+  },
+  "web.organizations.organizations": {
+    "text": "Organizaciones"
+  },
+  "web.organizations.invitations.invited_by_inline": {
+    "text": "por {email}"
+  },
+  "web.organizations.invitations.invited_as_inline": {
+    "text": "como {role}"
+  },
+  "web.organizations.invitations.back_to_home": {
+    "text": "Volver al inicio"
+  },
+  "web.organizations.invitations.email_locked_hint": {
+    "text": "Esta invitación se envió a esta dirección de correo electrónico"
+  },
+  "web.organizations.invitations.signup_continue": {
+    "text": "Continuar"
+  },
+  "web.organizations.invitations.signin_continue": {
+    "text": "Iniciar sesión"
+  },
+  "web.organizations.invitations.confirm_join_below": {
+    "text": "Casi listo — confirma a continuación para unirte a la organización."
+  },
+  "web.organizations.invitations.go_to_organizations": {
+    "text": "Ir a Organizaciones"
+  },
+  "web.organizations.invitations.already_member": {
+    "text": "Ya eres miembro de esta organización"
+  },
+  "web.organizations.invitations.join_organization": {
+    "text": "Unirse a {orgName}"
+  },
+  "web.organizations.invitations.sign_in_to_join": {
+    "text": "Inicia sesión para unirte a {orgName}"
+  },
+  "web.organizations.invitations.decline": {
+    "text": "Rechazar"
+  },
+  "web.organizations.members.member_quota": {
+    "text": "{used} de {limit} miembros"
+  },
+  "web.organizations.members.pending_suffix": {
+    "text": "({count} pendientes)"
+  },
+  "web.organizations.members.limit_reached_hint": {
+    "text": "Se alcanzó el límite de miembros."
+  },
+  "web.organizations.sso.view_discovery_document": {
+    "text": "Ver documento de descubrimiento"
+  },
+  "web.organizations.sso.callback_url": {
+    "text": "URL de retorno de llamada"
+  },
+  "web.organizations.sso.callback_url_hint": {
+    "text": "Añade esta URL a los URI de redirección permitidos de tu proveedor de identidad"
+  },
+  "web.organizations.sso.enforce_sso_only": {
+    "text": "Exigir solo SSO"
+  },
+  "web.organizations.sso.enforce_sso_only_hint": {
+    "text": "Exige SSO para todos los inicios de sesión en este dominio. Cuando está habilitado, la autenticación basada en contraseña queda deshabilitada."
+  },
+  "web.organizations.sso.grant_org_scope": {
+    "text": "Conceder acceso a toda la organización"
+  },
+  "web.organizations.sso.grant_org_scope_hint": {
+    "text": "Los nuevos miembros que se unan a través del SSO de este dominio recibirán acceso a todos los dominios de la organización. Los miembros existentes no se ven afectados. Cuando está deshabilitado (predeterminado), los nuevos miembros solo pueden acceder a este dominio."
+  },
+  "web.organizations.sso.no_domains": {
+    "text": "No hay dominios verificados"
+  },
+  "web.organizations.sso.no_domains_description": {
+    "text": "Añade y verifica un dominio antes de configurar SSO para él."
+  },
+  "web.organizations.tabs.team": {
+    "text": "Equipo"
+  },
+  "web.organizations.tabs.sso": {
+    "text": "SSO"
   }
 }


### PR DESCRIPTION
## `es` translation update

Automated export of completed **es** translations from the translation task DB.
Scope: `locales/content/es/` only — 26 file(s), +1352/-23.

⚠️ `i18n validate variables` reports **1** variable mismatch(es) for `es` (empty values that drop source variables, renamed/extra vars, etc.) — see the review below.

---

### Local quality review

> Produced by a fresh, isolated `claude` review agent (model `claude-sonnet-5`, agent `saas-translator`) that read
> `locales/AGENT_TRANSLATION_PROTOCOL.md` and inspected this branch's diff before the PR was opened.

**Verdict:** ⚠️ Needs review — one flagged variable mismatch, minor SSO inconsistency.

**Summary:** Bulk of this diff is new key additions (colonel, domains, billing, organizations, auth, email) plus signature rebrand from "Delano" to "Equipo de soporte" across all email templates. Variables and brand terms are preserved correctly in the added/changed strings I reviewed; the automated check flags one pre-existing variable defect in `email.json`.

**Critical (must fix):**
- `email.email_changed.body.text` (es-0701-error-1): translation contains an extra `%{date}` placeholder not present in the English source ("...has been changed to %{new_email_masked}."). This will raise a missing-interpolation error or render literally. Not visible as a changed line in this diff, but flagged by the variable-consistency check and must be fixed before merge.

**Warnings:**
- Inconsistent SSO terminology within `workspace-domains.json`: `web.domains.signin.method_sso` and `web.domains.signin.sso_enabled_label` are left as raw English "Single Sign-On", while sibling strings in the same file (`web.domains.detail.sso_description`, `web.login.custom_domain_sso_title`, `web.organizations.sso.*`) render it translated as "inicio de sesión único (SSO)". Pick one convention.

**Notes:**
- Signature change "Delano" → "Equipo de soporte" applied uniformly across all ~20 email templates — consistent with the pattern seen in other locale batches this session.
- Spot-checked variable tokens (`{ip}`, `{email}`, `%{extid}`, `%{max}`, `{domain}`, `{orgName}`, `{used}`/`{limit}`, `{0}`, etc.) across the new additions — all match source counts/names.
- No mistranslated brand terms, no mojibake, no leftover English strings found elsewhere in the diff.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
