### PR TITLE
i18n: update fr_FR translations

### DIFF
--- a/locales/content/fr_FR/00-common.json
+++ b/locales/content/fr_FR/00-common.json
@@ -1299,7 +1299,7 @@
     "source_hash": "fc78d9cb"
   },
   "web.INSTRUCTION.phishing_warning": {
-    "text": "Vérifiez toujours que vous êtes sur le site officiel de {product_name}. Des fraudeurs créent parfois de faux sites qui ressemblent exactement à {product_name} pour voler vos secrets. Pour éviter les attaques de phishing, vérifiez le domaine régional avant de créer de nouveaux liens.",
+    "text": "Vérifiez toujours que vous êtes sur le site officiel {product_name}. Des fraudeurs créent parfois de faux sites qui ressemblent exactement à {product_name} pour voler vos secrets. Pour éviter les attaques de hameçonnage, vérifiez le domaine de la région avant de créer de nouveaux liens.",
     "source_hash": "b588f5b2"
   },
   "web.pricing.title": {
@@ -1383,5 +1383,110 @@
     "text": "Mettre à niveau pour débloquer plus de fonctionnalités",
     "context": "Description shown for free plan users encouraging upgrade",
     "source_hash": "783f174c"
+  },
+  "api.errors.authentication_required": {
+    "text": "Authentification requise"
+  },
+  "api.errors.sso_only_action_blocked": {
+    "text": "Cette action n'est pas disponible en mode SSO uniquement"
+  },
+  "web.COMMON.configure": {
+    "text": "Configurer"
+  },
+  "web.COMMON.copy_to_clipboard": {
+    "text": "Copier dans le presse-papiers"
+  },
+  "web.COMMON.add": {
+    "text": "Ajouter"
+  },
+  "web.COMMON.enabled": {
+    "text": "Activé"
+  },
+  "web.COMMON.disabled": {
+    "text": "Désactivé"
+  },
+  "web.COMMON.yes_delete": {
+    "text": "Oui, supprimer"
+  },
+  "web.COMMON.error_code": {
+    "text": "Code d'erreur"
+  },
+  "web.COMMON.http_status": {
+    "text": "Statut HTTP"
+  },
+  "web.COMMON.details": {
+    "text": "Détails"
+  },
+  "web.COMMON.field_confirm_password": {
+    "text": "Confirmer le mot de passe"
+  },
+  "web.COMMON.passwords_must_match": {
+    "text": "Les mots de passe doivent correspondre"
+  },
+  "web.COMMON.and": {
+    "text": "et"
+  },
+  "web.COMMON.or": {
+    "text": "ou"
+  },
+  "web.COMMON.copied": {
+    "text": "Copié"
+  },
+  "web.COMMON.copy": {
+    "text": "Copier"
+  },
+  "web.COMMON.copy_email": {
+    "text": "Copier l'adresse e-mail"
+  },
+  "web.COMMON.copy_id": {
+    "text": "Copier l'ID du compte"
+  },
+  "web.COMMON.org_id_tooltip": {
+    "text": "L'identifiant unique de votre organisation"
+  },
+  "web.COMMON.success": {
+    "text": "Succès"
+  },
+  "web.COMMON.need_help": {
+    "text": "Besoin d'aide"
+  },
+  "web.COMMON.open_help_dialog": {
+    "text": "Ouvrir la boîte de dialogue d'aide"
+  },
+  "web.COMMON.focus_is_now_in_the_main_text_area": {
+    "text": "Le focus est maintenant dans la zone de texte principale"
+  },
+  "web.LABELS.show_passphrase": {
+    "text": "Afficher la phrase secrète"
+  },
+  "web.LABELS.hide_passphrase": {
+    "text": "Masquer la phrase secrète"
+  },
+  "web.LABELS.copy_icon": {
+    "text": "Icône de copie"
+  },
+  "web.LABELS.copied_icon": {
+    "text": "Icône de copie effectuée"
+  },
+  "web.STATUS.unverified": {
+    "text": "Non vérifié"
+  },
+  "web.TITLES.domain_detail": {
+    "text": "Paramètres du domaine"
+  },
+  "web.TITLES.domain_signin": {
+    "text": "Configuration de la connexion"
+  },
+  "web.TITLES.domain_sso": {
+    "text": "SSO du domaine"
+  },
+  "web.TITLES.domain_signup": {
+    "text": "Validation de l'inscription au domaine"
+  },
+  "web.TITLES.domain_email": {
+    "text": "Configuration de l'e-mail"
+  },
+  "web.TITLES.domain_incoming": {
+    "text": "Secrets entrants"
   }
 }

--- a/locales/content/fr_FR/10-layout.json
+++ b/locales/content/fr_FR/10-layout.json
@@ -148,7 +148,7 @@
     "source_hash": "b9766df3"
   },
   "web.help.secret_view_faq.what_am_i_looking_at.description": {
-    "text": "Vous consultez un message sécurisé qui vous a été partagé via {product_name}. Ce contenu n'est affiché qu'une seule fois puis est définitivement supprimé de nos serveurs.",
+    "text": "Vous consultez un message sécurisé qui vous a été partagé via {product_name}. Ce contenu n'est affiché qu'une seule fois, puis définitivement supprimé de nos serveurs.",
     "source_hash": "e0f1a10c"
   },
   "web.help.secret_view_faq.can_i_view_again.title": {
@@ -338,5 +338,11 @@
   "web.layout.workspace_context": {
     "text": "Contexte de l'espace de travail",
     "source_hash": "dc6fa4f5"
+  },
+  "web.footer.workspace": {
+    "text": "Espace de travail"
+  },
+  "web.help.default_content": {
+    "text": "Veuillez contacter le support pour obtenir de l'aide"
   }
 }

--- a/locales/content/fr_FR/admin-colonel.json
+++ b/locales/content/fr_FR/admin-colonel.json
@@ -634,5 +634,152 @@
   "web.colonel.feedback.when_you_submit_feedback_well_see": {
     "text": "Lorsque vous envoyez un commentaire, nous verrons :",
     "source_hash": "fe77172e"
+  },
+  "web.colonel.previewPlanMode": {
+    "text": "Mode d'aperçu du forfait"
+  },
+  "web.colonel.previewModeDescription": {
+    "text": "Prévisualisez l'application telle qu'elle apparaît aux clients sur un autre forfait. Cela n'affecte que votre vue et ne modifie pas le forfait réel d'une organisation."
+  },
+  "web.colonel.previewModeActive": {
+    "text": "Aperçu actif"
+  },
+  "web.colonel.bannedIps.empty": {
+    "text": "Aucune IP bannie"
+  },
+  "web.colonel.bannedIps.currentIp": {
+    "text": "Votre adresse IP actuelle"
+  },
+  "web.colonel.bannedIps.confirmUnban": {
+    "text": "Débannir {ip} ?"
+  },
+  "web.colonel.bannedIps.actions.ban": {
+    "text": "Bannir l'IP"
+  },
+  "web.colonel.bannedIps.actions.quickBan": {
+    "text": "Bannissement rapide"
+  },
+  "web.colonel.bannedIps.actions.unban": {
+    "text": "Débannir"
+  },
+  "web.colonel.bannedIps.actions.cancel": {
+    "text": "Annuler"
+  },
+  "web.colonel.bannedIps.columns.ipAddress": {
+    "text": "Adresse IP"
+  },
+  "web.colonel.bannedIps.columns.reason": {
+    "text": "Motif"
+  },
+  "web.colonel.bannedIps.columns.bannedAt": {
+    "text": "Banni le"
+  },
+  "web.colonel.bannedIps.columns.bannedBy": {
+    "text": "Banni par"
+  },
+  "web.colonel.bannedIps.error.banFailed": {
+    "text": "Échec du bannissement de l'adresse IP"
+  },
+  "web.colonel.bannedIps.error.unbanFailed": {
+    "text": "Échec du débannissement de l'adresse IP"
+  },
+  "web.colonel.bannedIps.form.title": {
+    "text": "Bannissement d'une adresse IP"
+  },
+  "web.colonel.bannedIps.form.ipLabel": {
+    "text": "Adresse IP"
+  },
+  "web.colonel.bannedIps.form.reasonLabel": {
+    "text": "Motif"
+  },
+  "web.colonel.bannedIps.form.reasonPlaceholder": {
+    "text": "Motif facultatif"
+  },
+  "web.colonel.bannedIps.success.banned": {
+    "text": "L'adresse IP {ip} a été bannie"
+  },
+  "web.colonel.bannedIps.success.unbanned": {
+    "text": "L'adresse IP {ip} a été débannie"
+  },
+  "web.colonel.customDomains.empty": {
+    "text": "Aucun domaine personnalisé configuré"
+  },
+  "web.colonel.customDomains.noLogo": {
+    "text": "Aucun logo"
+  },
+  "web.colonel.customDomains.labels.organization": {
+    "text": "Organisation"
+  },
+  "web.colonel.customDomains.labels.externalId": {
+    "text": "ID externe"
+  },
+  "web.colonel.customDomains.labels.created": {
+    "text": "Créé le"
+  },
+  "web.colonel.customDomains.labels.updated": {
+    "text": "Mis à jour le"
+  },
+  "web.colonel.customDomains.labels.favicon": {
+    "text": "Favicon"
+  },
+  "web.colonel.customDomains.status.verified": {
+    "text": "Vérifié"
+  },
+  "web.colonel.customDomains.status.resolving": {
+    "text": "Résolution en cours"
+  },
+  "web.colonel.customDomains.status.ready": {
+    "text": "Prêt"
+  },
+  "web.colonel.customDomains.status.publicHomepage": {
+    "text": "Page d'accueil publique"
+  },
+  "web.colonel.customDomains.status.publicApi": {
+    "text": "API publique"
+  },
+  "web.colonel.customDomains.status.pending": {
+    "text": "En attente"
+  },
+  "web.colonel.pagination.showing": {
+    "text": "Affichage de {start}–{end} sur {total}"
+  },
+  "web.colonel.pagination.itemsPerPage": {
+    "text": "Éléments par page"
+  },
+  "web.colonel.pagination.perPage": {
+    "text": "{count} par page"
+  },
+  "web.colonel.pagination.pageOf": {
+    "text": "Page {current} sur {total}"
+  },
+  "web.colonel.secrets.empty": {
+    "text": "Aucun secret trouvé"
+  },
+  "web.colonel.secrets.never": {
+    "text": "Jamais"
+  },
+  "web.colonel.secrets.columns.shortId": {
+    "text": "ID court"
+  },
+  "web.colonel.secrets.columns.state": {
+    "text": "État"
+  },
+  "web.colonel.secrets.columns.created": {
+    "text": "Créé le"
+  },
+  "web.colonel.secrets.columns.expiration": {
+    "text": "Expiration"
+  },
+  "web.colonel.secrets.columns.age": {
+    "text": "Âge (jours)"
+  },
+  "web.colonel.secrets.state.new": {
+    "text": "Nouveau"
+  },
+  "web.colonel.secrets.state.received": {
+    "text": "Reçu"
+  },
+  "web.colonel.secrets.state.viewed": {
+    "text": "Consulté"
   }
 }

--- a/locales/content/fr_FR/api-account-errors.json
+++ b/locales/content/fr_FR/api-account-errors.json
@@ -1,0 +1,8 @@
+{
+  "api.account.errors.invalid_email": {
+    "text": "Est-ce une adresse e-mail valide ?"
+  },
+  "api.account.errors.password_too_short": {
+    "text": "Le mot de passe est trop court"
+  }
+}

--- a/locales/content/fr_FR/api-domains-errors.json
+++ b/locales/content/fr_FR/api-domains-errors.json
@@ -1,0 +1,29 @@
+{
+  "api.domains.errors.domain_id_required": {
+    "text": "ID de domaine requis"
+  },
+  "api.domains.errors.domain_not_found": {
+    "text": "Domaine introuvable : %{extid}"
+  },
+  "api.domains.errors.organization_not_found": {
+    "text": "Organisation introuvable pour le domaine : %{domain}"
+  },
+  "api.domains.errors.incoming_secrets_disabled": {
+    "text": "Les secrets entrants ne sont pas activés sur cette instance"
+  },
+  "api.domains.errors.incoming_secrets_entitlement_required": {
+    "text": "La gestion des secrets entrants nécessite le droit incoming_secrets. Veuillez mettre à niveau votre forfait."
+  },
+  "api.domains.errors.incoming_config_not_found": {
+    "text": "Configuration entrante introuvable pour le domaine : %{extid}"
+  },
+  "api.domains.errors.recipients_max_exceeded": {
+    "text": "Maximum de %{max} destinataires autorisés"
+  },
+  "api.domains.errors.recipients_invalid_email": {
+    "text": "E-mail invalide : %{email}"
+  },
+  "api.domains.errors.recipients_duplicate": {
+    "text": "Les adresses e-mail de destinataires en double ne sont pas autorisées"
+  }
+}

--- a/locales/content/fr_FR/api-entitlements-errors.json
+++ b/locales/content/fr_FR/api-entitlements-errors.json
@@ -1,0 +1,71 @@
+{
+  "api.entitlements.errors.context_unavailable": {
+    "text": "Impossible de vérifier les droits (contexte d'organisation indisponible)"
+  },
+  "api.entitlements.errors.api_access_required": {
+    "text": "L'accès à l'API nécessite une mise à niveau du forfait"
+  },
+  "api.entitlements.errors.custom_privacy_defaults_required": {
+    "text": "Les paramètres de confidentialité par défaut personnalisés nécessitent une mise à niveau du forfait"
+  },
+  "api.entitlements.errors.extended_default_expiration_required": {
+    "text": "L'expiration par défaut prolongée nécessite une mise à niveau du forfait"
+  },
+  "api.entitlements.errors.custom_domains_required": {
+    "text": "Les domaines personnalisés nécessitent une mise à niveau du forfait"
+  },
+  "api.entitlements.errors.custom_branding_required": {
+    "text": "L'image de marque personnalisée nécessite une mise à niveau du forfait"
+  },
+  "api.entitlements.errors.homepage_secrets_required": {
+    "text": "Les secrets de la page d'accueil nécessitent une mise à niveau du forfait"
+  },
+  "api.entitlements.errors.incoming_secrets_required": {
+    "text": "Les secrets entrants nécessitent une mise à niveau du forfait"
+  },
+  "api.entitlements.errors.custom_mail_sender_required": {
+    "text": "L'expéditeur d'e-mail personnalisé nécessite une mise à niveau du forfait"
+  },
+  "api.entitlements.errors.flexible_from_domain_required": {
+    "text": "Le domaine d'expéditeur flexible nécessite une mise à niveau du forfait"
+  },
+  "api.entitlements.errors.manage_org_required": {
+    "text": "La gestion de l'organisation nécessite une mise à niveau du forfait"
+  },
+  "api.entitlements.errors.manage_teams_required": {
+    "text": "La gestion des équipes nécessite une mise à niveau du forfait"
+  },
+  "api.entitlements.errors.manage_members_required": {
+    "text": "La gestion des membres nécessite une mise à niveau du forfait"
+  },
+  "api.entitlements.errors.manage_sso_required": {
+    "text": "La gestion du SSO nécessite une mise à niveau du forfait"
+  },
+  "api.entitlements.errors.audit_logs_required": {
+    "text": "Les journaux d'audit nécessitent une mise à niveau du forfait"
+  },
+  "api.entitlements.errors.custom_signup_validation_required": {
+    "text": "La validation d'inscription personnalisée nécessite une mise à niveau du forfait"
+  },
+  "api.entitlements.errors.create_secrets_required": {
+    "text": "La création de secrets nécessite une mise à niveau du forfait"
+  },
+  "api.entitlements.errors.view_receipt_required": {
+    "text": "L'affichage des reçus nécessite une mise à niveau du forfait"
+  },
+  "api.entitlements.errors.notifications_required": {
+    "text": "Les notifications nécessitent une mise à niveau du forfait"
+  },
+  "api.entitlements.errors.workspace_branding_required": {
+    "text": "L'image de marque de l'espace de travail nécessite une mise à niveau du forfait"
+  },
+  "api.entitlements.errors.ip_access_rules_required": {
+    "text": "Les règles d'accès IP nécessitent une mise à niveau du forfait"
+  },
+  "api.entitlements.errors.manage_billing_required": {
+    "text": "La gestion de la facturation nécessite une mise à niveau du forfait"
+  },
+  "api.entitlements.errors.custom_signin_config_required": {
+    "text": "La configuration de connexion personnalisée nécessite une mise à niveau du forfait"
+  }
+}

--- a/locales/content/fr_FR/api-feedback-errors.json
+++ b/locales/content/fr_FR/api-feedback-errors.json
@@ -1,0 +1,5 @@
+{
+  "api.feedback.errors.rate_limit_exceeded": {
+    "text": "Trop de retours d'information envoyés. Veuillez réessayer plus tard."
+  }
+}

--- a/locales/content/fr_FR/api-incoming-errors.json
+++ b/locales/content/fr_FR/api-incoming-errors.json
@@ -1,0 +1,5 @@
+{
+  "api.incoming.errors.custom_domain_unresolved": {
+    "text": "Impossible de résoudre l'organisation du domaine personnalisé"
+  }
+}

--- a/locales/content/fr_FR/api-invite-errors.json
+++ b/locales/content/fr_FR/api-invite-errors.json
@@ -1,0 +1,23 @@
+{
+  "api.invite.errors.invitation_not_found_or_expired": {
+    "text": "Invitation introuvable ou expirée"
+  },
+  "api.invite.errors.token_required": {
+    "text": "Le jeton est requis"
+  },
+  "api.invite.errors.organization_no_longer_exists": {
+    "text": "L'organisation n'existe plus"
+  },
+  "api.invite.errors.invitation_already_processed": {
+    "text": "L'invitation a déjà été %{status}"
+  },
+  "api.invite.errors.invitation_expired": {
+    "text": "L'invitation a expiré"
+  },
+  "api.invite.errors.email_mismatch": {
+    "text": "Votre adresse e-mail ne correspond pas à l'invitation"
+  },
+  "api.invite.errors.already_member": {
+    "text": "Vous êtes déjà membre de cette organisation"
+  }
+}

--- a/locales/content/fr_FR/api-organizations-errors.json
+++ b/locales/content/fr_FR/api-organizations-errors.json
@@ -1,0 +1,107 @@
+{
+  "api.organizations.errors.domain_scoped_forbidden": {
+    "text": "Les membres limités à un domaine ne peuvent pas effectuer cette action"
+  },
+  "api.organizations.errors.organization_not_found": {
+    "text": "Organisation introuvable : %{extid}"
+  },
+  "api.organizations.errors.organization_owner_required": {
+    "text": "Seul le propriétaire de l'organisation peut effectuer cette action"
+  },
+  "api.organizations.errors.organization_member_required": {
+    "text": "Vous devez être membre de l'organisation pour effectuer cette action"
+  },
+  "api.organizations.errors.organization_admin_required": {
+    "text": "Seuls les propriétaires et les administrateurs de l'organisation peuvent effectuer cette action"
+  },
+  "api.organizations.errors.extid_required": {
+    "text": "ID d'organisation requis"
+  },
+  "api.organizations.errors.display_name_required": {
+    "text": "Le nom de l'organisation est requis"
+  },
+  "api.organizations.errors.display_name_too_long": {
+    "text": "Le nom de l'organisation doit comporter moins de %{max} caractères"
+  },
+  "api.organizations.errors.description_too_long": {
+    "text": "La description doit comporter moins de %{max} caractères"
+  },
+  "api.organizations.errors.contact_email_exists": {
+    "text": "Une organisation avec cet e-mail de contact existe déjà"
+  },
+  "api.organizations.errors.creation_in_progress": {
+    "text": "Création de l'organisation en cours. Veuillez réessayer."
+  },
+  "api.organizations.errors.organization_limit_reached": {
+    "text": "Limite d'organisations atteinte. Mettez à niveau votre forfait pour créer davantage d'organisations."
+  },
+  "api.organizations.invitations.errors.invitation_not_found": {
+    "text": "Invitation introuvable"
+  },
+  "api.organizations.invitations.errors.email_required": {
+    "text": "L'e-mail est requis"
+  },
+  "api.organizations.invitations.errors.invalid_email_format": {
+    "text": "Format d'e-mail invalide"
+  },
+  "api.organizations.invitations.errors.invalid_role": {
+    "text": "Le rôle doit être membre ou administrateur"
+  },
+  "api.organizations.invitations.errors.cannot_invite_as_owner": {
+    "text": "Impossible d'inviter en tant que propriétaire"
+  },
+  "api.organizations.invitations.errors.user_already_member": {
+    "text": "L'utilisateur est déjà membre de cette organisation"
+  },
+  "api.organizations.invitations.errors.invitation_already_pending": {
+    "text": "Une invitation est déjà en attente pour cet e-mail"
+  },
+  "api.organizations.invitations.errors.member_limit_reached": {
+    "text": "Limite de membres atteinte. Mettez à niveau votre forfait pour inviter davantage de membres."
+  },
+  "api.organizations.invitations.errors.resend_only_pending": {
+    "text": "Seules les invitations en attente peuvent être renvoyées"
+  },
+  "api.organizations.invitations.errors.resend_limit_reached": {
+    "text": "Limite maximale de renvois (%{max}) atteinte"
+  },
+  "api.organizations.invitations.errors.revoke_only_pending": {
+    "text": "Seules les invitations en attente peuvent être révoquées"
+  },
+  "api.organizations.members.errors.member_not_found": {
+    "text": "Membre introuvable : %{extid}"
+  },
+  "api.organizations.members.errors.member_not_in_organization": {
+    "text": "Membre introuvable dans cette organisation"
+  },
+  "api.organizations.members.errors.member_not_active": {
+    "text": "Le membre n'est pas actif"
+  },
+  "api.organizations.members.errors.invalid_role_value": {
+    "text": "Rôle invalide. Doit être l'un des suivants : %{roles}"
+  },
+  "api.organizations.members.errors.cannot_change_owner_role": {
+    "text": "Impossible de modifier le rôle du propriétaire. Utilisez plutôt le transfert de propriété."
+  },
+  "api.organizations.members.errors.member_already_has_role": {
+    "text": "Le membre possède déjà le rôle : %{role}"
+  },
+  "api.organizations.members.errors.cannot_promote_to_owner": {
+    "text": "Impossible de promouvoir au rang de propriétaire. Utilisez plutôt le transfert de propriété."
+  },
+  "api.organizations.members.errors.must_be_member": {
+    "text": "Vous devez être membre de cette organisation"
+  },
+  "api.organizations.members.errors.cannot_remove_owner": {
+    "text": "Impossible de retirer le propriétaire de l'organisation. Transférez d'abord la propriété."
+  },
+  "api.organizations.members.errors.cannot_remove_self": {
+    "text": "Impossible de vous retirer vous-même. Utilisez plutôt l'option de quitter l'organisation."
+  },
+  "api.organizations.members.errors.admin_cannot_remove_admin": {
+    "text": "Les administrateurs ne peuvent pas retirer d'autres administrateurs. Seuls les propriétaires le peuvent."
+  },
+  "api.organizations.members.errors.no_permission_to_remove": {
+    "text": "Vous n'avez pas la permission de retirer des membres"
+  }
+}

--- a/locales/content/fr_FR/api-secrets-errors.json
+++ b/locales/content/fr_FR/api-secrets-errors.json
@@ -1,0 +1,11 @@
+{
+  "api.secrets.errors.domain_permission_authenticated_non_owner": {
+    "text": "Vous n'avez pas la permission d'utiliser le domaine : %{domain}"
+  },
+  "api.secrets.errors.domain_public_sharing_disabled": {
+    "text": "Partage public désactivé pour le domaine : %{domain}"
+  },
+  "api.secrets.errors.domain_permission_anonymous_cross_domain": {
+    "text": "Vous n'avez pas la permission d'utiliser le domaine : %{domain}"
+  }
+}

--- a/locales/content/fr_FR/email.json
+++ b/locales/content/fr_FR/email.json
@@ -60,7 +60,7 @@
     "source_hash": "88c72144"
   },
   "email.welcome.signature": {
-    "text": "Delano",
+    "text": "L'équipe d'assistance",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -100,7 +100,7 @@
     "source_hash": "fbb7eb2d"
   },
   "email.password_request.signature": {
-    "text": "Delano",
+    "text": "L'équipe d'assistance",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -145,7 +145,7 @@
     "source_hash": "1863f5be"
   },
   "email.magic_link.signature": {
-    "text": "Delano",
+    "text": "L'équipe d'assistance",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -230,7 +230,7 @@
     "source_hash": "3f6b45dd"
   },
   "email.secret_revealed.signature": {
-    "text": "Delano",
+    "text": "L'équipe d'assistance",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -355,7 +355,7 @@
     "source_hash": "734882d2"
   },
   "email.organization_invitation.signature": {
-    "text": "Delano",
+    "text": "L'équipe d'assistance",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -395,7 +395,7 @@
     "source_hash": "be92cff3"
   },
   "email.password_changed.signature": {
-    "text": "Delano",
+    "text": "L'équipe d'assistance",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -445,7 +445,7 @@
     "source_hash": "f8d47b82"
   },
   "email.email_changed.signature": {
-    "text": "Delano",
+    "text": "L'équipe d'assistance",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -495,7 +495,7 @@
     "source_hash": "f8d47b82"
   },
   "email.email_change_requested.signature": {
-    "text": "Delano",
+    "text": "L'équipe d'assistance",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -550,7 +550,7 @@
     "source_hash": "d4d835fc"
   },
   "email.email_change_confirmation.signature": {
-    "text": "Delano",
+    "text": "L'équipe d'assistance",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -580,7 +580,7 @@
     "source_hash": "e7c11bb0"
   },
   "email.mfa_enabled.signature": {
-    "text": "Delano",
+    "text": "L'équipe d'assistance",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -605,7 +605,7 @@
     "source_hash": "97ef0a3e"
   },
   "email.mfa_disabled.signature": {
-    "text": "Delano",
+    "text": "L'équipe d'assistance",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -650,7 +650,7 @@
     "source_hash": "450c54c5"
   },
   "email.new_login_alert.signature": {
-    "text": "Delano",
+    "text": "L'équipe d'assistance",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -670,7 +670,7 @@
     "source_hash": "d442beed"
   },
   "email.member_removed.signature": {
-    "text": "Delano",
+    "text": "L'équipe d'assistance",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -690,7 +690,7 @@
     "source_hash": "c2280c0c"
   },
   "email.role_changed.signature": {
-    "text": "Delano",
+    "text": "L'équipe d'assistance",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -710,7 +710,7 @@
     "source_hash": "7095fc69"
   },
   "email.organization_deleted.signature": {
-    "text": "Delano",
+    "text": "L'équipe d'assistance",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -750,7 +750,7 @@
     "source_hash": "36008943"
   },
   "email.payment_receipt.signature": {
-    "text": "Delano",
+    "text": "L'équipe d'assistance",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -775,7 +775,7 @@
     "source_hash": "926406b1"
   },
   "email.payment_failed.signature": {
-    "text": "Delano",
+    "text": "L'équipe d'assistance",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -800,7 +800,7 @@
     "source_hash": "66a1419e"
   },
   "email.trial_expiring.signature": {
-    "text": "Delano",
+    "text": "L'équipe d'assistance",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -825,7 +825,7 @@
     "source_hash": "5a96ae38"
   },
   "email.subscription_changed.signature": {
-    "text": "Delano",
+    "text": "L'équipe d'assistance",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -853,5 +853,41 @@
     "text": "Onetime Secret",
     "renderer": "erb",
     "source_hash": "1cd0194a"
+  },
+  "email.common.secret_link_label": {
+    "text": "Lien du secret"
+  },
+  "email.common.automated_notice": {
+    "text": "Ceci est un message automatique de %{product_name}."
+  },
+  "email.common.support_label": {
+    "text": "Support"
+  },
+  "email.expiration_warning.signature": {
+    "text": "L'équipe d'assistance"
+  },
+  "email.expiration_warning.footer_note": {
+    "text": "Vous avez reçu ce message parce qu'un secret que vous avez créé sur %{product_name} est sur le point d'expirer."
+  },
+  "email.feedback_email.user_id_label": {
+    "text": "Utilisateur :"
+  },
+  "email.feedback_email.timezone_label": {
+    "text": "Fuseau horaire :"
+  },
+  "email.feedback_email.version_label": {
+    "text": "Version :"
+  },
+  "email.incoming_secret.footer_note": {
+    "text": "Vous avez reçu ce message parce que quelqu'un a utilisé %{product_name} pour vous envoyer un secret. Si vous ne l'attendiez pas, vous pouvez ignorer cet e-mail en toute sécurité."
+  },
+  "email.secret_link.passphrase_label": {
+    "text": "Phrase secrète requise :"
+  },
+  "email.secret_link.passphrase_required": {
+    "text": "Ce secret est protégé par une phrase secrète. L'expéditeur doit vous la communiquer séparément."
+  },
+  "email.secret_link.footer_note": {
+    "text": "Vous avez reçu ce message parce que %{sender_email} a utilisé %{product_name} pour partager un secret avec vous. Si vous ne l'attendiez pas, vous pouvez ignorer cet e-mail en toute sécurité."
   }
 }

--- a/locales/content/fr_FR/email.json
+++ b/locales/content/fr_FR/email.json
@@ -855,39 +855,60 @@
     "source_hash": "1cd0194a"
   },
   "email.common.secret_link_label": {
-    "text": "Lien du secret"
+    "text": "Lien du secret",
+    "renderer": "erb",
+    "source_hash": "18ddf44f"
   },
   "email.common.automated_notice": {
-    "text": "Ceci est un message automatique de %{product_name}."
+    "text": "Ceci est un message automatique de %{product_name}.",
+    "renderer": "erb",
+    "source_hash": "8fbabfba"
   },
   "email.common.support_label": {
     "text": "Support"
   },
   "email.expiration_warning.signature": {
-    "text": "L'équipe d'assistance"
+    "text": "L'équipe d'assistance",
+    "renderer": "erb"
   },
   "email.expiration_warning.footer_note": {
-    "text": "Vous avez reçu ce message parce qu'un secret que vous avez créé sur %{product_name} est sur le point d'expirer."
+    "text": "Vous avez reçu ce message parce qu'un secret que vous avez créé sur %{product_name} est sur le point d'expirer.",
+    "renderer": "erb",
+    "source_hash": "920779e4"
   },
   "email.feedback_email.user_id_label": {
-    "text": "Utilisateur :"
+    "text": "Utilisateur :",
+    "renderer": "erb",
+    "source_hash": "93d6b3e9"
   },
   "email.feedback_email.timezone_label": {
-    "text": "Fuseau horaire :"
+    "text": "Fuseau horaire :",
+    "renderer": "erb",
+    "source_hash": "39651ebf"
   },
   "email.feedback_email.version_label": {
-    "text": "Version :"
+    "text": "Version :",
+    "renderer": "erb",
+    "source_hash": "4c5726ee"
   },
   "email.incoming_secret.footer_note": {
-    "text": "Vous avez reçu ce message parce que quelqu'un a utilisé %{product_name} pour vous envoyer un secret. Si vous ne l'attendiez pas, vous pouvez ignorer cet e-mail en toute sécurité."
+    "text": "Vous avez reçu ce message parce que quelqu'un a utilisé %{product_name} pour vous envoyer un secret. Si vous ne l'attendiez pas, vous pouvez ignorer cet e-mail en toute sécurité.",
+    "renderer": "erb",
+    "source_hash": "91ee6e8d"
   },
   "email.secret_link.passphrase_label": {
-    "text": "Phrase secrète requise :"
+    "text": "Phrase secrète requise :",
+    "renderer": "erb",
+    "source_hash": "1ab9a20f"
   },
   "email.secret_link.passphrase_required": {
-    "text": "Ce secret est protégé par une phrase secrète. L'expéditeur doit vous la communiquer séparément."
+    "text": "Ce secret est protégé par une phrase secrète. L'expéditeur doit vous la communiquer séparément.",
+    "renderer": "erb",
+    "source_hash": "1e49826b"
   },
   "email.secret_link.footer_note": {
-    "text": "Vous avez reçu ce message parce que %{sender_email} a utilisé %{product_name} pour partager un secret avec vous. Si vous ne l'attendiez pas, vous pouvez ignorer cet e-mail en toute sécurité."
+    "text": "Vous avez reçu ce message parce que %{sender_email} a utilisé %{product_name} pour partager un secret avec vous. Si vous ne l'attendiez pas, vous pouvez ignorer cet e-mail en toute sécurité.",
+    "renderer": "erb",
+    "source_hash": "2d544dad"
   }
 }

--- a/locales/content/fr_FR/feature-feedback.json
+++ b/locales/content/fr_FR/feature-feedback.json
@@ -58,5 +58,14 @@
   "web.feedback.reason_email_change_unauthorized": {
     "text": "Il semble que vous signalez un changement d'e-mail non autorisé sur votre compte. Veuillez décrire ce qui s'est passé et nous enquêterons immédiatement.",
     "source_hash": "00e56551"
+  },
+  "web.feedback.anonymous_no_reply": {
+    "text": "Remarque : si vous souhaitez une réponse, veuillez signer ou inclure une adresse e-mail dans le message."
+  },
+  "web.feedback.characters_remaining": {
+    "text": "{count} caractères restants"
+  },
+  "web.feedback.character_limit_reached": {
+    "text": "Limite de caractères atteinte"
   }
 }

--- a/locales/content/fr_FR/feature-homepage-secrets.json
+++ b/locales/content/fr_FR/feature-homepage-secrets.json
@@ -1,0 +1,50 @@
+{
+  "homepage_secrets.disabled.members_only_eyebrow": {
+    "text": "Instance réservée aux membres"
+  },
+  "homepage_secrets.disabled.private_instance_eyebrow": {
+    "text": "Instance privée"
+  },
+  "homepage_secrets.disabled.team_link_headline": {
+    "text": "Ce lien est destiné à l'équipe {workspace}."
+  },
+  "homepage_secrets.disabled.signin_headline": {
+    "text": "Connectez-vous pour créer un {action}."
+  },
+  "homepage_secrets.disabled.signin_headline_action": {
+    "text": "lien secret"
+  },
+  "homepage_secrets.disabled.team_subtitle": {
+    "text": "Seuls les coéquipiers autorisés de {domain} peuvent créer de nouveaux liens à usage unique ici. Les destinataires peuvent toujours ouvrir tout lien qui leur a été envoyé."
+  },
+  "homepage_secrets.disabled.public_subtitle": {
+    "text": "Seuls les membres autorisés de cette instance peuvent créer de nouveaux liens à usage unique. Les destinataires peuvent toujours ouvrir tout lien qui leur a été envoyé."
+  },
+  "homepage_secrets.disabled.signin_cta": {
+    "text": "Connectez-vous à votre compte"
+  },
+  "homepage_secrets.disabled.what_is_this": {
+    "text": "Qu'est-ce que c'est ?"
+  },
+  "homepage_secrets.disabled.trust_viewed_once": {
+    "text": "Consulté une fois, puis supprimé"
+  },
+  "homepage_secrets.disabled.trust_zero_retained": {
+    "text": "Aucune donnée conservée"
+  },
+  "homepage_secrets.disabled.promo_title": {
+    "text": "Nouveau : les forfaits gratuits incluent désormais les domaines personnalisés."
+  },
+  "homepage_secrets.disabled.promo_subtitle": {
+    "text": "Pointez votre domaine vers Onetime Secret et diffusez des secrets sous votre propre marque."
+  },
+  "homepage_secrets.disabled.promo_learn_how": {
+    "text": "Découvrir comment"
+  },
+  "homepage_secrets.disabled.logo_alt": {
+    "text": "Logo {name}"
+  },
+  "homepage_secrets.disabled.opens_in_new_tab": {
+    "text": "(s'ouvre dans un nouvel onglet)"
+  }
+}

--- a/locales/content/fr_FR/feature-incoming.json
+++ b/locales/content/fr_FR/feature-incoming.json
@@ -130,5 +130,26 @@
   "incoming.receipt_link_text": {
     "text": "accusé de réception",
     "source_hash": "6f328609"
+  },
+  "incoming.upgrade_required_title": {
+    "text": "Mise à niveau requise"
+  },
+  "incoming.upgrade_required_description": {
+    "text": "Cette fonctionnalité nécessite une mise à niveau du forfait. Veuillez contacter le propriétaire du compte pour activer les secrets entrants."
+  },
+  "incoming.validation_memo_too_long": {
+    "text": "Le mémo doit comporter au maximum {max} caractères"
+  },
+  "incoming.validation_secret_required": {
+    "text": "Le contenu du secret est requis"
+  },
+  "incoming.validation_recipient_required": {
+    "text": "Veuillez sélectionner un destinataire"
+  },
+  "incoming.validation_feature_disabled": {
+    "text": "La fonctionnalité de secrets entrants n'est pas activée"
+  },
+  "incoming.validation_form_errors": {
+    "text": "Veuillez vérifier les erreurs dans le formulaire"
   }
 }

--- a/locales/content/fr_FR/feature-regions.json
+++ b/locales/content/fr_FR/feature-regions.json
@@ -186,5 +186,8 @@
   "web.regions.jurisdictions.apac.name": {
     "text": "Asia-Pacific",
     "source_hash": "7a757670"
+  },
+  "web.regions.no_region_configured": {
+    "text": "Aucune information de région n'est actuellement disponible pour votre compte."
   }
 }

--- a/locales/content/fr_FR/feature-translations.json
+++ b/locales/content/fr_FR/feature-translations.json
@@ -64,7 +64,7 @@
     "source_hash": "13131e36"
   },
   "web.translations.the_following_people_have_donated_their_time_to_": {
-    "text": "Les personnes suivantes ont donné de leur temps pour aider à étendre la portée de {product_name} :",
+    "text": "Les personnes suivantes ont donné de leur temps pour aider à étendre la portée de {product_name} :",
     "source_hash": "85a766af"
   },
   "web.translations.translations": {

--- a/locales/content/fr_FR/secret-homepage.json
+++ b/locales/content/fr_FR/secret-homepage.json
@@ -144,7 +144,7 @@
     "source_hash": "1cd0194a"
   },
   "web.homepage.one_time_secret_literal": {
-    "text": "Secret à usage unique",
+    "text": "{product_name}",
     "source_hash": "7872e050"
   },
   "web.homepage.onetime_secret_homepage": {

--- a/locales/content/fr_FR/secret-manage.json
+++ b/locales/content/fr_FR/secret-manage.json
@@ -470,5 +470,11 @@
   },
   "web.private.send_feedback": {
     "text": "Envoyer un commentaire"
+  },
+  "web.receipt.open_link": {
+    "text": "Ouvrir le lien"
+  },
+  "web.secrets.messageDeleted": {
+    "text": "Message supprimé"
   }
 }

--- a/locales/content/fr_FR/session-auth-extended.json
+++ b/locales/content/fr_FR/session-auth-extended.json
@@ -716,5 +716,20 @@
   },
   "web.auth.sessions._guidance.context": {
     "text": "Page de gestion des appareils/navigateurs connectés de l'utilisateur"
+  },
+  "web.auth.google": {
+    "text": "Google"
+  },
+  "web.auth.mfa.alternative_auth_options": {
+    "text": "Autres options d'authentification"
+  },
+  "web.auth.remember.enabled": {
+    "text": "Rester connecté"
+  },
+  "web.auth.sessions.session_singular": {
+    "text": "session"
+  },
+  "web.auth.sessions.session_plural": {
+    "text": "sessions"
   }
 }

--- a/locales/content/fr_FR/session-auth.json
+++ b/locales/content/fr_FR/session-auth.json
@@ -398,5 +398,32 @@
   },
   "web.auth.verify._guidance.context": {
     "text": "Flux de vérification d'e-mail après inscription"
+  },
+  "web.auth.account.sso_linked": {
+    "text": "Compte SSO"
+  },
+  "web.help.reset_password_link": {
+    "text": "Réinitialiser le mot de passe"
+  },
+  "web.login.custom_domain_sso_title": {
+    "text": "L'authentification unique est disponible pour ce domaine"
+  },
+  "web.login.custom_domain_sso_description": {
+    "text": "L'administrateur de l'organisation peut activer le SSO pour permettre aux membres de l'équipe de se connecter ici. Contactez l'administrateur pour obtenir l'accès."
+  },
+  "web.login.signin_disabled_heading": {
+    "text": "La connexion n'est pas disponible"
+  },
+  "web.login.signin_disabled_message": {
+    "text": "La connexion n'est actuellement pas disponible sur ce domaine."
+  },
+  "web.login.errors.sso_not_configured": {
+    "text": "L'authentification unique n'est pas configurée pour ce domaine. Veuillez contacter votre administrateur."
+  },
+  "web.login.errors.invalid_email": {
+    "text": "L'adresse e-mail provenant de votre fournisseur d'identité est invalide. Veuillez contacter votre administrateur."
+  },
+  "web.login.errors.domain_not_allowed": {
+    "text": "Votre domaine de messagerie n'est pas autorisé pour l'inscription via SSO. Veuillez contacter votre administrateur."
   }
 }

--- a/locales/content/fr_FR/workspace-account.json
+++ b/locales/content/fr_FR/workspace-account.json
@@ -682,5 +682,14 @@
   "web.settings.profile.didnt_receive_email": {
     "text": "Vous n'avez pas reçu l'e-mail ?",
     "source_hash": "fe3ac3ad"
+  },
+  "web.settings.api.api_disabled_notice": {
+    "text": "L'API est désactivée pour cette instance."
+  },
+  "web.settings.security.sso_managed_title": {
+    "text": "Sécurité gérée par le SSO"
+  },
+  "web.settings.security.sso_managed_description": {
+    "text": "Votre compte est authentifié via le fournisseur d'authentification unique de votre organisation. Le mot de passe, l'authentification multifacteur et les codes de récupération sont gérés par votre fournisseur d'identité."
   }
 }

--- a/locales/content/fr_FR/workspace-billing.json
+++ b/locales/content/fr_FR/workspace-billing.json
@@ -988,5 +988,47 @@
     "text": "Disponible uniquement dans votre région d'abonnement d'origine",
     "context": "Hint shown on plan cards when currency does not match active subscription",
     "source_hash": "10de32e5"
+  },
+  "web.billing.already_subscribed": {
+    "text": "Vous êtes déjà abonné à ce forfait."
+  },
+  "web.billing.cancel.reactivate_button": {
+    "text": "Réactiver l'abonnement"
+  },
+  "web.billing.cancel.reactivate_success": {
+    "text": "Votre abonnement a été réactivé. Vous continuerez à être facturé normalement."
+  },
+  "web.billing.cancel.reactivate_error": {
+    "text": "Échec de la réactivation de l'abonnement. Veuillez réessayer ou contacter l'assistance."
+  },
+  "web.billing.features.manage_orgs": {
+    "text": "Gestion de l'organisation"
+  },
+  "web.billing.features.flexible_from_domain": {
+    "text": "Domaine d'expéditeur d'e-mail flexible"
+  },
+  "web.billing.features.unlimited_admins": {
+    "text": "Administrateurs illimités"
+  },
+  "web.billing.features.manage_sso": {
+    "text": "SSO"
+  },
+  "web.billing.overview.entitlements.flexible_from_domain": {
+    "text": "Domaine d'expéditeur d'e-mail flexible"
+  },
+  "web.billing.overview.entitlements.manage_orgs": {
+    "text": "Gérer les organisations"
+  },
+  "web.billing.overview.entitlements.manage_sso": {
+    "text": "Authentification unique (SSO)"
+  },
+  "web.billing.overview.entitlements.manage_billing": {
+    "text": "Gérer la facturation"
+  },
+  "web.billing.overview.entitlements.custom_signup_validation": {
+    "text": "Validation d'inscription personnalisée"
+  },
+  "web.billing.plans.reactivate": {
+    "text": "Réactiver"
   }
 }

--- a/locales/content/fr_FR/workspace-branding.json
+++ b/locales/content/fr_FR/workspace-branding.json
@@ -178,5 +178,11 @@
   "web.branding.upgrade_to_customize": {
     "text": "Mettez votre forfait à niveau pour personnaliser l'image de marque de ce domaine.",
     "source_hash": "9077bf79"
+  },
+  "web.branding.saved_successfully": {
+    "text": "Paramètres de marque enregistrés avec succès"
+  },
+  "web.branding.keyhole_logo_icon": {
+    "text": "Icône de trou de serrure représentant un partage sécurisé et privé"
   }
 }

--- a/locales/content/fr_FR/workspace-dashboard.json
+++ b/locales/content/fr_FR/workspace-dashboard.json
@@ -22,5 +22,14 @@
   "web.dashboard.fetch_error_description": {
     "text": "Un problème est survenu lors du chargement de vos données. Veuillez réessayer.",
     "source_hash": "ff0d904e"
+  },
+  "web.teams.create_first_team_title": {
+    "text": "Créez votre première équipe"
+  },
+  "web.teams.create_first_team_description": {
+    "text": "Les équipes vous permettent de collaborer avec d'autres personnes dans un espace de travail partagé."
+  },
+  "web.teams.create_team": {
+    "text": "Créer une équipe"
   }
 }

--- a/locales/content/fr_FR/workspace-domains.json
+++ b/locales/content/fr_FR/workspace-domains.json
@@ -846,5 +846,389 @@
   "web.domains.sso.not_configured_notice": {
     "text": "Le SSO n'est pas encore configuré pour ce domaine. Activez l'authentification unique pour permettre aux membres de l'équipe de s'authentifier via le fournisseur d'identité de votre organisation.",
     "source_hash": "c439214b"
+  },
+  "api.domains.errors.add_admin_required": {
+    "text": "Seuls les propriétaires et les administrateurs de l'organisation peuvent ajouter des domaines personnalisés"
+  },
+  "web.domains.public_homepage": {
+    "text": "Page d'accueil publique"
+  },
+  "web.domains.status_tooltip_active": {
+    "text": "Domaine vérifié et actif"
+  },
+  "web.domains.status_tooltip_dns_incorrect": {
+    "text": "DNS non configuré — cliquez pour corriger"
+  },
+  "web.domains.status_tooltip_not_verified": {
+    "text": "Domaine non vérifié — cliquez pour vérifier"
+  },
+  "web.domains.status_tooltip_unverified": {
+    "text": "Statut du domaine non vérifié — cliquez pour actualiser"
+  },
+  "web.domains.last_check_failed": {
+    "text": "Échec de la dernière vérification"
+  },
+  "web.domains.last_check_failed_ago": {
+    "text": "dernière vérification échouée {0}"
+  },
+  "web.domains.verify_now": {
+    "text": "Vérifier maintenant"
+  },
+  "web.domains.click_to_verify": {
+    "text": "cliquez pour vérifier"
+  },
+  "web.domains.remove_domain_description": {
+    "text": "Supprimer définitivement ce domaine et toute sa configuration."
+  },
+  "web.domains.add_access_denied": {
+    "text": "Accès refusé"
+  },
+  "web.domains.add_access_denied_description": {
+    "text": "Vous n'avez pas la permission d'ajouter des domaines à cette organisation. Contactez l'administrateur de votre organisation."
+  },
+  "web.domains.dns_widget_load_failed": {
+    "text": "Échec du chargement du widget DNS"
+  },
+  "web.domains.dns_widget_not_available": {
+    "text": "Widget DNS non disponible"
+  },
+  "web.domains.dns_widget_init_failed": {
+    "text": "Échec de l'initialisation du widget DNS"
+  },
+  "web.domains.verified": {
+    "text": "Vérifié"
+  },
+  "web.domains.pending_verification": {
+    "text": "Vérification en attente"
+  },
+  "web.domains.unsaved_changes_confirmation": {
+    "text": "Vous avez des modifications non enregistrées. Êtes-vous sûr de vouloir quitter ?"
+  },
+  "web.domains.entitlement_required_owner": {
+    "text": "Cette fonctionnalité nécessite une mise à niveau du forfait."
+  },
+  "web.domains.entitlement_required_member": {
+    "text": "Cette fonctionnalité n'est pas disponible dans votre forfait actuel. Contactez le propriétaire de votre organisation."
+  },
+  "web.domains.detail.manage": {
+    "text": "Gérer"
+  },
+  "web.domains.detail.features": {
+    "text": "Fonctionnalités"
+  },
+  "web.domains.detail.homepage_title": {
+    "text": "Secrets de la page d'accueil"
+  },
+  "web.domains.detail.homepage_description": {
+    "text": "Autoriser l'accès public pour créer des secrets sur la page d'accueil de votre domaine"
+  },
+  "web.domains.detail.brand_description": {
+    "text": "Logo, couleurs et image de marque personnalisée"
+  },
+  "web.domains.detail.sso_description": {
+    "text": "Paramètres du fournisseur d'authentification unique"
+  },
+  "web.domains.detail.email_description": {
+    "text": "Configuration de l'expéditeur d'e-mail personnalisé"
+  },
+  "web.domains.detail.incoming_description": {
+    "text": "Paramètres des destinataires de secrets entrants"
+  },
+  "web.domains.detail.signup_description": {
+    "text": "Stratégie de validation d'inscription par domaine"
+  },
+  "web.domains.detail.signin_description": {
+    "text": "Configuration de la méthode de connexion par domaine"
+  },
+  "web.domains.email.dns_check_label": {
+    "text": "DNS"
+  },
+  "web.domains.email.provider_check_label": {
+    "text": "Fournisseur"
+  },
+  "web.domains.email.test_email_title": {
+    "text": "Tester la livraison des e-mails"
+  },
+  "web.domains.email.test_email_hint": {
+    "text": "Envoyez-vous un e-mail de test en utilisant la configuration enregistrée. Fonctionne même lorsque la fonctionnalité n'est pas encore activée."
+  },
+  "web.domains.email.send_test": {
+    "text": "Envoyer un test"
+  },
+  "web.domains.email.test_email_sent": {
+    "text": "E-mail de test envoyé avec succès"
+  },
+  "web.domains.email.test_email_failed": {
+    "text": "Échec de l'envoi de l'e-mail de test"
+  },
+  "web.domains.email.test_email_sent_to": {
+    "text": "Envoyé à {email}"
+  },
+  "web.domains.email.delivered_via": {
+    "text": "Livré via {provider}"
+  },
+  "web.domains.incoming.feature_disabled": {
+    "text": "Secrets entrants indisponibles"
+  },
+  "web.domains.incoming.feature_disabled_description": {
+    "text": "Les secrets entrants ne sont pas activés sur cette instance. Contactez votre administrateur."
+  },
+  "web.domains.signin.title": {
+    "text": "Configuration de la connexion"
+  },
+  "web.domains.signin.configure_signin": {
+    "text": "Configurer la connexion"
+  },
+  "web.domains.signin.config_description": {
+    "text": "Configurez les méthodes d'authentification de connexion pour ce domaine"
+  },
+  "web.domains.signin.access_denied": {
+    "text": "Accès refusé"
+  },
+  "web.domains.signin.upgrade_to_configure": {
+    "text": "Mettez à niveau votre forfait pour configurer les méthodes de connexion de ce domaine."
+  },
+  "web.domains.signin.not_configured_notice": {
+    "text": "La configuration de connexion n'est pas encore définie pour ce domaine. Configurez des remplacements pour contrôler quelles méthodes d'authentification sont disponibles sur la page de connexion de ce domaine."
+  },
+  "web.domains.signin.signin_enabled_label": {
+    "text": "Connexion activée"
+  },
+  "web.domains.signin.header_toggle_label": {
+    "text": "Connexion"
+  },
+  "web.domains.signin.signin_enabled_hint": {
+    "text": "Indique si les utilisateurs peuvent se connecter sur ce domaine"
+  },
+  "web.domains.signin.restrict_to_label": {
+    "text": "Restreindre la méthode de connexion"
+  },
+  "web.domains.signin.restrict_to_hint": {
+    "text": "Restreignez ce domaine à une seule méthode d'authentification. Lorsqu'elle est définie, seule la méthode choisie est affichée sur la page de connexion."
+  },
+  "web.domains.signin.all_methods": {
+    "text": "Toutes les méthodes"
+  },
+  "web.domains.signin.all_methods_description": {
+    "text": "Afficher toutes les méthodes d'authentification activées sur la page de connexion"
+  },
+  "web.domains.signin.method_password": {
+    "text": "Mot de passe"
+  },
+  "web.domains.signin.method_email_auth": {
+    "text": "Authentification par e-mail"
+  },
+  "web.domains.signin.method_webauthn": {
+    "text": "WebAuthn / Clés d'accès"
+  },
+  "web.domains.signin.method_sso": {
+    "text": "Authentification unique"
+  },
+  "web.domains.signin.method_overrides_label": {
+    "text": "Remplacements de méthode"
+  },
+  "web.domains.signin.method_overrides_hint": {
+    "text": "Activer ou désactiver des méthodes d'authentification individuelles pour ce domaine"
+  },
+  "web.domains.signin.mode_question": {
+    "text": "Comment les utilisateurs peuvent-ils se connecter ?"
+  },
+  "web.domains.signin.mode_any": {
+    "text": "N'importe quelle méthode disponible"
+  },
+  "web.domains.signin.mode_any_hint": {
+    "text": "Afficher toutes les méthodes disponibles sur ce domaine. Restreignez les méthodes individuelles ci-dessous."
+  },
+  "web.domains.signin.mode_one": {
+    "text": "Une méthode spécifique"
+  },
+  "web.domains.signin.mode_one_hint": {
+    "text": "Restreindre la page de connexion à une seule méthode. Seules les méthodes disponibles sur ce domaine sont répertoriées."
+  },
+  "web.domains.signin.mode_disabled": {
+    "text": "Connexion désactivée"
+  },
+  "web.domains.signin.mode_disabled_hint": {
+    "text": "Les utilisateurs ne peuvent pas se connecter sur ce domaine."
+  },
+  "web.domains.signin.mode_disabled_notice": {
+    "text": "Les visiteurs de la page de connexion de ce domaine voient un avis indiquant que la connexion n'est pas disponible, avec un lien de retour vers la page d'accueil. Vos paramètres de méthode précédents sont conservés et restaurés lorsque vous réactivez la connexion."
+  },
+  "web.domains.signin.methods_list_label": {
+    "text": "Méthodes affichées sur la page de connexion"
+  },
+  "web.domains.signin.restrict_picker_hint": {
+    "text": "Seules les méthodes disponibles sur ce domaine sont répertoriées."
+  },
+  "web.domains.signin.availability_always": {
+    "text": "Toujours disponible"
+  },
+  "web.domains.signin.availability_global_on": {
+    "text": "Suit la politique globale · Activé"
+  },
+  "web.domains.signin.availability_global_off": {
+    "text": "Non disponible"
+  },
+  "web.domains.signin.availability_unavailable": {
+    "text": "Indisponible sur tout le site"
+  },
+  "web.domains.signin.allow_on_domain": {
+    "text": "Autoriser sur ce domaine"
+  },
+  "web.domains.signin.method_password_blurb": {
+    "text": "Mot de passe uniquement"
+  },
+  "web.domains.signin.method_email_auth_blurb": {
+    "text": "Connexion par lien magique sans mot de passe"
+  },
+  "web.domains.signin.method_webauthn_blurb": {
+    "text": "Données biométriques et clés de sécurité"
+  },
+  "web.domains.signin.method_sso_blurb": {
+    "text": "Fournisseur d'identité externe"
+  },
+  "web.domains.signin.email_auth_label": {
+    "text": "Authentification par e-mail"
+  },
+  "web.domains.signin.email_auth_hint": {
+    "text": "Autoriser l'authentification par e-mail sans mot de passe sur ce domaine"
+  },
+  "web.domains.signin.sso_enabled_label": {
+    "text": "Authentification unique"
+  },
+  "web.domains.signin.sso_enabled_hint": {
+    "text": "Autoriser l'authentification SSO sur ce domaine"
+  },
+  "web.domains.signin.enabled_label": {
+    "text": "Activer la configuration de connexion"
+  },
+  "web.domains.signin.enabled_hint": {
+    "text": "Lorsqu'elle est activée, ce domaine utilise les paramètres de connexion configurés ci-dessus"
+  },
+  "web.domains.signin.save_config": {
+    "text": "Enregistrer la configuration"
+  },
+  "web.domains.signin.update_success": {
+    "text": "Configuration de connexion mise à jour avec succès"
+  },
+  "web.domains.signin.reset_to_defaults": {
+    "text": "Réinitialiser aux valeurs par défaut"
+  },
+  "web.domains.signin.reset_confirm": {
+    "text": "Réinitialiser la connexion aux valeurs par défaut globales ?"
+  },
+  "web.domains.signin.reset_keeps_sso": {
+    "text": "Vos identifiants SSO sont conservés. Supprimez-les séparément sur l'écran de configuration SSO."
+  },
+  "web.domains.signin.reset_action": {
+    "text": "Oui, réinitialiser"
+  },
+  "web.domains.signin.reset_success": {
+    "text": "Paramètres de connexion réinitialisés aux valeurs par défaut globales"
+  },
+  "web.domains.signup.title": {
+    "text": "Validation de l'inscription"
+  },
+  "web.domains.signup.config_description": {
+    "text": "Configurez la validation de l'inscription pour ce domaine"
+  },
+  "web.domains.signup.access_denied": {
+    "text": "Accès refusé"
+  },
+  "web.domains.signup.upgrade_to_configure": {
+    "text": "Mettez à niveau votre forfait pour configurer la validation de l'inscription par domaine."
+  },
+  "web.domains.signup.configure_signup": {
+    "text": "Configurer l'inscription"
+  },
+  "web.domains.signup.not_configured_notice": {
+    "text": "La validation de l'inscription n'est pas encore configurée pour ce domaine. Configurez une stratégie pour contrôler qui peut s'inscrire via ce domaine."
+  },
+  "web.domains.signup.site_signups_disabled_warning": {
+    "text": "Les inscriptions sont actuellement désactivées au niveau du site. Cette politique par domaine est configurée mais ne filtrera aucun trafic tant que les inscriptions ne seront pas activées au niveau du site."
+  },
+  "web.domains.signup.strategy_label": {
+    "text": "Stratégie de validation"
+  },
+  "web.domains.signup.strategy_description": {
+    "text": "Choisissez comment les adresses e-mail sont validées lorsque les utilisateurs s'inscrivent sur ce domaine."
+  },
+  "web.domains.signup.network_validation_warning": {
+    "text": "Cette stratégie effectue des appels réseau pendant l'inscription, ce qui peut ajouter de la latence ou être bloqué par certains fournisseurs."
+  },
+  "web.domains.signup.allowed_domains_label": {
+    "text": "Domaines d'inscription autorisés"
+  },
+  "web.domains.signup.allowed_domains_hint": {
+    "text": "Seuls ces domaines d'e-mail seront autorisés à s'inscrire. Ajoutez un domaine par entrée."
+  },
+  "web.domains.signup.domain_placeholder": {
+    "text": "example.com"
+  },
+  "web.domains.signup.invalid_domain": {
+    "text": "Veuillez saisir un domaine valide (par ex. example.com)"
+  },
+  "web.domains.signup.domain_exists": {
+    "text": "Ce domaine figure déjà dans la liste"
+  },
+  "web.domains.signup.remove_domain": {
+    "text": "Supprimer {domain}"
+  },
+  "web.domains.signup.enabled_label": {
+    "text": "Activer la validation par domaine"
+  },
+  "web.domains.signup.enabled_hint": {
+    "text": "Lorsqu'elle est activée, les inscriptions sur ce domaine utilisent la stratégie ci-dessus au lieu de la politique globale."
+  },
+  "web.domains.signup.delete_config": {
+    "text": "Supprimer la configuration"
+  },
+  "web.domains.signup.delete_confirm": {
+    "text": "Supprimer la configuration de validation de l'inscription ? Les inscriptions reviendront à la politique globale."
+  },
+  "web.domains.signup.save_config": {
+    "text": "Enregistrer la configuration"
+  },
+  "web.domains.signup.update_success": {
+    "text": "Validation de l'inscription mise à jour avec succès"
+  },
+  "web.domains.signup.delete_success": {
+    "text": "Configuration de validation de l'inscription supprimée avec succès"
+  },
+  "web.domains.signup.domain_overrides_label": {
+    "text": "Remplacements de domaine"
+  },
+  "web.domains.signup.domain_overrides_hint": {
+    "text": "Remplacer les paramètres d'inscription globaux pour ce domaine"
+  },
+  "web.domains.signup.signup_enabled_label": {
+    "text": "Inscription activée"
+  },
+  "web.domains.signup.signup_enabled_hint": {
+    "text": "Remplacer l'activation de l'inscription pour ce domaine"
+  },
+  "web.domains.signup.autoverify_label": {
+    "text": "Vérifier automatiquement les comptes"
+  },
+  "web.domains.signup.autoverify_hint": {
+    "text": "Remplacer la vérification automatique des nouveaux comptes sur ce domaine"
+  },
+  "web.domains.sso.test_success": {
+    "text": "Test de connexion réussi — le fournisseur a répondu correctement"
+  },
+  "web.domains.sso.test_failed": {
+    "text": "Échec du test de connexion"
+  },
+  "web.domains.sso.enforce_moved_notice": {
+    "text": "Pour exiger le SSO pour toutes les connexions sur ce domaine, configurez-le dans les paramètres de connexion du domaine. Le mode SSO uniquement restreint la page de connexion au fournisseur SSO configuré ici."
+  },
+  "web.domains.sso.edit_credentials": {
+    "text": "Modifier les identifiants"
+  },
+  "web.domains.sso.configure_button": {
+    "text": "Configurer"
+  },
+  "web.domains.sso.upgrade_required": {
+    "text": "Mettre à niveau pour configurer"
   }
 }

--- a/locales/content/fr_FR/workspace-organizations.json
+++ b/locales/content/fr_FR/workspace-organizations.json
@@ -770,5 +770,200 @@
   "web.organizations.sso.status_not_configured": {
     "text": "Non configuré",
     "source_hash": "bbea960e"
+  },
+  "api.organizations.errors.not_found": {
+    "text": "Organisation introuvable : %{extid}"
+  },
+  "api.organizations.errors.owner_required": {
+    "text": "Seul le propriétaire de l'organisation peut effectuer cette action"
+  },
+  "api.organizations.errors.admin_required": {
+    "text": "Seuls les propriétaires et les administrateurs de l'organisation peuvent effectuer cette action"
+  },
+  "api.organizations.errors.member_required": {
+    "text": "Vous devez être membre de l'organisation pour effectuer cette action"
+  },
+  "api.organizations.invitations.errors.create_admin_required": {
+    "text": "Seuls les propriétaires et les administrateurs de l'organisation peuvent créer des invitations"
+  },
+  "api.organizations.invitations.errors.resend_admin_required": {
+    "text": "Seuls les propriétaires et les administrateurs de l'organisation peuvent renvoyer des invitations"
+  },
+  "api.organizations.invitations.errors.view_admin_required": {
+    "text": "Seuls les propriétaires et les administrateurs de l'organisation peuvent consulter les invitations"
+  },
+  "api.organizations.invitations.errors.revoke_admin_required": {
+    "text": "Seuls les propriétaires et les administrateurs de l'organisation peuvent révoquer des invitations"
+  },
+  "api.organizations.invitations.errors.email_required": {
+    "text": "L'adresse e-mail est requise"
+  },
+  "api.organizations.invitations.errors.email_invalid": {
+    "text": "Format d'e-mail non valide"
+  },
+  "api.organizations.invitations.errors.role_invalid": {
+    "text": "Le rôle doit être membre ou administrateur"
+  },
+  "api.organizations.invitations.errors.cannot_invite_owner": {
+    "text": "Impossible d'inviter en tant que propriétaire"
+  },
+  "api.organizations.invitations.errors.already_member": {
+    "text": "L'utilisateur est déjà membre de cette organisation"
+  },
+  "api.organizations.invitations.errors.already_pending": {
+    "text": "Une invitation est déjà en attente pour cette adresse e-mail"
+  },
+  "api.organizations.invitations.errors.member_limit_reached": {
+    "text": "Limite de membres atteinte. Mettez à niveau votre forfait pour inviter davantage de membres."
+  },
+  "api.organizations.invitations.errors.not_found": {
+    "text": "Invitation introuvable"
+  },
+  "api.organizations.invitations.errors.cannot_resend_non_pending": {
+    "text": "Seules les invitations en attente peuvent être renvoyées"
+  },
+  "api.organizations.invitations.errors.cannot_revoke_non_pending": {
+    "text": "Seules les invitations en attente peuvent être révoquées"
+  },
+  "api.organizations.invitations.errors.resend_limit_reached": {
+    "text": "Limite maximale de renvois (%{max}) atteinte"
+  },
+  "api.organizations.invitations.errors.accept_token_required": {
+    "text": "Le jeton est requis"
+  },
+  "api.organizations.invitations.errors.accept_organization_gone": {
+    "text": "L'organisation n'existe plus"
+  },
+  "api.organizations.invitations.errors.accept_already_acted": {
+    "text": "L'invitation a déjà été %{status}"
+  },
+  "api.organizations.invitations.errors.accept_expired": {
+    "text": "L'invitation a expiré"
+  },
+  "api.organizations.invitations.errors.accept_email_mismatch": {
+    "text": "Votre adresse e-mail ne correspond pas à l'invitation"
+  },
+  "api.organizations.invitations.errors.accept_already_member": {
+    "text": "Vous êtes déjà membre de cette organisation"
+  },
+  "web.organizations.entitlements_title": {
+    "text": "Droits de l'organisation"
+  },
+  "web.organizations.page_description_short": {
+    "text": "Consultez et configurez vos espaces de travail"
+  },
+  "web.organizations.delete_organization_remove_domains_first": {
+    "text": "Supprimez tous les domaines personnalisés avant de supprimer cette organisation."
+  },
+  "web.organizations.default_org_delete_notice_title": {
+    "text": "Suppression de cette organisation"
+  },
+  "web.organizations.default_org_delete_notice_before": {
+    "text": "Il s'agit de votre organisation par défaut, qui ne peut pas être supprimée depuis le tableau de bord. Pour la supprimer, veuillez nous contacter via le"
+  },
+  "web.organizations.default_org_delete_notice_link": {
+    "text": "formulaire de retour d'information"
+  },
+  "web.organizations.default_org_delete_notice_after": {
+    "text": "."
+  },
+  "web.organizations.leave_organization": {
+    "text": "Quitter cette organisation"
+  },
+  "web.organizations.leave_organization_warning": {
+    "text": "Vous perdrez l'accès à cette organisation et à ses ressources."
+  },
+  "web.organizations.leave_organization_confirm_title": {
+    "text": "Quitter l'organisation"
+  },
+  "web.organizations.leave_organization_confirm_message": {
+    "text": "Voulez-vous vraiment quitter {name} ? Vous aurez besoin d'une nouvelle invitation pour la rejoindre."
+  },
+  "web.organizations.leave_organization_success": {
+    "text": "Vous avez quitté l'organisation."
+  },
+  "web.organizations.leave_error": {
+    "text": "Échec de la sortie de l'organisation"
+  },
+  "web.organizations.organizations": {
+    "text": "Organisations"
+  },
+  "web.organizations.invitations.invited_by_inline": {
+    "text": "par {email}"
+  },
+  "web.organizations.invitations.invited_as_inline": {
+    "text": "en tant que {role}"
+  },
+  "web.organizations.invitations.back_to_home": {
+    "text": "Retour à l'accueil"
+  },
+  "web.organizations.invitations.email_locked_hint": {
+    "text": "Cette invitation a été envoyée à cette adresse e-mail"
+  },
+  "web.organizations.invitations.signup_continue": {
+    "text": "Continuer"
+  },
+  "web.organizations.invitations.signin_continue": {
+    "text": "Se connecter"
+  },
+  "web.organizations.invitations.confirm_join_below": {
+    "text": "Presque terminé — confirmez ci-dessous pour rejoindre l'organisation."
+  },
+  "web.organizations.invitations.go_to_organizations": {
+    "text": "Accéder aux organisations"
+  },
+  "web.organizations.invitations.already_member": {
+    "text": "Vous êtes déjà membre de cette organisation"
+  },
+  "web.organizations.invitations.join_organization": {
+    "text": "Rejoindre {orgName}"
+  },
+  "web.organizations.invitations.sign_in_to_join": {
+    "text": "Connectez-vous pour rejoindre {orgName}"
+  },
+  "web.organizations.invitations.decline": {
+    "text": "Refuser"
+  },
+  "web.organizations.members.member_quota": {
+    "text": "{used} membres sur {limit}"
+  },
+  "web.organizations.members.pending_suffix": {
+    "text": "({count} en attente)"
+  },
+  "web.organizations.members.limit_reached_hint": {
+    "text": "Limite de membres atteinte."
+  },
+  "web.organizations.sso.view_discovery_document": {
+    "text": "Afficher le document de découverte"
+  },
+  "web.organizations.sso.callback_url": {
+    "text": "URL de rappel"
+  },
+  "web.organizations.sso.callback_url_hint": {
+    "text": "Ajoutez cette URL aux URI de redirection autorisés de votre fournisseur d'identité"
+  },
+  "web.organizations.sso.enforce_sso_only": {
+    "text": "Imposer le SSO uniquement"
+  },
+  "web.organizations.sso.enforce_sso_only_hint": {
+    "text": "Exigez le SSO pour toutes les connexions sur ce domaine. Lorsque cette option est activée, l'authentification par mot de passe est désactivée."
+  },
+  "web.organizations.sso.grant_org_scope": {
+    "text": "Accorder l'accès à toute l'organisation"
+  },
+  "web.organizations.sso.grant_org_scope_hint": {
+    "text": "Les nouveaux membres qui rejoignent via le SSO de ce domaine se verront accorder l'accès à tous les domaines de l'organisation. Les membres existants ne sont pas affectés. Lorsque cette option est désactivée (par défaut), les nouveaux membres ne peuvent accéder qu'à ce domaine."
+  },
+  "web.organizations.sso.no_domains": {
+    "text": "Aucun domaine vérifié"
+  },
+  "web.organizations.sso.no_domains_description": {
+    "text": "Ajoutez et vérifiez un domaine avant de configurer le SSO pour celui-ci."
+  },
+  "web.organizations.tabs.team": {
+    "text": "Équipe"
+  },
+  "web.organizations.tabs.sso": {
+    "text": "SSO"
   }
 }


### PR DESCRIPTION
## `fr_FR` translation update

Automated export of completed **fr_FR** translations from the translation task DB.
Scope: `locales/content/fr_FR/` only — 27 file(s), +1352/-23.

⚠️ `i18n validate variables` reports **1** variable mismatch(es) for `fr_FR` (empty values that drop source variables, renamed/extra vars, etc.) — see the review below.

---

### Local quality review

> Produced by a fresh, isolated `claude` review agent (model `claude-sonnet-5`, agent `saas-translator`) that read
> `locales/AGENT_TRANSLATION_PROTOCOL.md` and inspected this branch's diff before the PR was opened.

_Automated review did not complete (exit 124). Review this locale manually._

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
