### PR TITLE
i18n: update he translations

### DIFF
--- a/locales/content/he/00-common.json
+++ b/locales/content/he/00-common.json
@@ -173,7 +173,7 @@
     "source_hash": "77322879"
   },
   "web.COMMON.click_to_continue": {
-    "text": "לחץ לחשיפה →",
+    "text": "← לחץ לחשיפה",
     "source_hash": "41658f99"
   },
   "web.COMMON.click_to_verify": {

--- a/locales/content/he/00-common.json
+++ b/locales/content/he/00-common.json
@@ -1299,7 +1299,7 @@
     "source_hash": "fc78d9cb"
   },
   "web.INSTRUCTION.phishing_warning": {
-    "text": "תמיד ודא שאתה באתר הרשמי של {product_name}. נוכלים לפעמים יוצרים אתרים מזויפים שנראים בדיוק כמו {product_name} כדי לגנוב את הסודות שלך. כדי להימנע מהתקפות פישינג, בדוק את הדומיין לפני יצירת קישורים חדשים.",
+    "text": "ודא תמיד שאתה נמצא באתר הרשמי של {product_name}. רמאים יוצרים לעיתים אתרים מזויפים שנראים בדיוק כמו {product_name} כדי לגנוב את הסודות שלך. כדי להימנע מהתקפות דיוג, בדוק את דומיין האזור לפני יצירת קישורים חדשים.",
     "source_hash": "b588f5b2"
   },
   "web.pricing.title": {
@@ -1383,5 +1383,110 @@
     "text": "שדרג כדי לפתוח תכונות נוספות",
     "context": "Description shown for free plan users encouraging upgrade",
     "source_hash": "783f174c"
+  },
+  "api.errors.authentication_required": {
+    "text": "נדרש אימות"
+  },
+  "api.errors.sso_only_action_blocked": {
+    "text": "פעולה זו אינה זמינה במצב SSO בלבד"
+  },
+  "web.COMMON.configure": {
+    "text": "הגדרה"
+  },
+  "web.COMMON.copy_to_clipboard": {
+    "text": "העתקה ללוח"
+  },
+  "web.COMMON.add": {
+    "text": "הוספה"
+  },
+  "web.COMMON.enabled": {
+    "text": "מופעל"
+  },
+  "web.COMMON.disabled": {
+    "text": "מושבת"
+  },
+  "web.COMMON.yes_delete": {
+    "text": "כן, מחק"
+  },
+  "web.COMMON.error_code": {
+    "text": "קוד שגיאה"
+  },
+  "web.COMMON.http_status": {
+    "text": "סטטוס HTTP"
+  },
+  "web.COMMON.details": {
+    "text": "פרטים"
+  },
+  "web.COMMON.field_confirm_password": {
+    "text": "אישור סיסמה"
+  },
+  "web.COMMON.passwords_must_match": {
+    "text": "הסיסמאות חייבות להיות זהות"
+  },
+  "web.COMMON.and": {
+    "text": "וגם"
+  },
+  "web.COMMON.or": {
+    "text": "או"
+  },
+  "web.COMMON.copied": {
+    "text": "הועתק"
+  },
+  "web.COMMON.copy": {
+    "text": "העתקה"
+  },
+  "web.COMMON.copy_email": {
+    "text": "העתק כתובת דוא״ל"
+  },
+  "web.COMMON.copy_id": {
+    "text": "העתק מזהה חשבון"
+  },
+  "web.COMMON.org_id_tooltip": {
+    "text": "המזהה הייחודי של הארגון שלך"
+  },
+  "web.COMMON.success": {
+    "text": "הצלחה"
+  },
+  "web.COMMON.need_help": {
+    "text": "צריך עזרה"
+  },
+  "web.COMMON.open_help_dialog": {
+    "text": "פתח את חלון העזרה"
+  },
+  "web.COMMON.focus_is_now_in_the_main_text_area": {
+    "text": "המיקוד נמצא כעת באזור הטקסט הראשי"
+  },
+  "web.LABELS.show_passphrase": {
+    "text": "הצג ביטוי סיסמה"
+  },
+  "web.LABELS.hide_passphrase": {
+    "text": "הסתר ביטוי סיסמה"
+  },
+  "web.LABELS.copy_icon": {
+    "text": "סמל העתקה"
+  },
+  "web.LABELS.copied_icon": {
+    "text": "סמל הועתק"
+  },
+  "web.STATUS.unverified": {
+    "text": "לא מאומת"
+  },
+  "web.TITLES.domain_detail": {
+    "text": "הגדרות דומיין"
+  },
+  "web.TITLES.domain_signin": {
+    "text": "הגדרת התחברות"
+  },
+  "web.TITLES.domain_sso": {
+    "text": "SSO לדומיין"
+  },
+  "web.TITLES.domain_signup": {
+    "text": "אימות הרשמה לדומיין"
+  },
+  "web.TITLES.domain_email": {
+    "text": "הגדרת דוא״ל"
+  },
+  "web.TITLES.domain_incoming": {
+    "text": "סודות נכנסים"
   }
 }

--- a/locales/content/he/10-layout.json
+++ b/locales/content/he/10-layout.json
@@ -148,7 +148,7 @@
     "source_hash": "b9766df3"
   },
   "web.help.secret_view_faq.what_am_i_looking_at.description": {
-    "text": "אתה צופה בהודעה מאובטחת ששותפה איתך דרך {product_name}. תוכן זה מוצג פעם אחת בלבד ולאחר מכן נמחק לצמיתות מהשרתים שלנו.",
+    "text": "אתה צופה בהודעה מאובטחת ששותפה אִתך באמצעות {product_name}. תוכן זה מוצג פעם אחת בלבד ולאחר מכן נמחק לצמיתות מהשרתים שלנו.",
     "source_hash": "e0f1a10c"
   },
   "web.help.secret_view_faq.can_i_view_again.title": {
@@ -264,7 +264,7 @@
     "source_hash": "e2f124cd"
   },
   "web.layout.visit_onetime_secret_homepage": {
-    "text": "ביקור בדף הבית של {product_name}",
+    "text": "בקר בדף הבית של {product_name}",
     "source_hash": "625556d2"
   },
   "web.layout.footer_navigation": {
@@ -338,5 +338,11 @@
   "web.layout.workspace_context": {
     "text": "הקשר סביבת העבודה",
     "source_hash": "dc6fa4f5"
+  },
+  "web.footer.workspace": {
+    "text": "סביבת עבודה"
+  },
+  "web.help.default_content": {
+    "text": "אנא פנה לתמיכה לקבלת סיוע"
   }
 }

--- a/locales/content/he/admin-colonel.json
+++ b/locales/content/he/admin-colonel.json
@@ -634,5 +634,152 @@
   "web.colonel.feedback.when_you_submit_feedback_well_see": {
     "text": "כאשר תשלח משוב, נראה:",
     "source_hash": "fe77172e"
+  },
+  "web.colonel.previewPlanMode": {
+    "text": "מצב תצוגה מקדימה של תוכנית"
+  },
+  "web.colonel.previewModeDescription": {
+    "text": "הצג תצוגה מקדימה של האפליקציה כפי שהיא מופיעה ללקוחות בתוכנית אחרת. הדבר משפיע על התצוגה שלך בלבד ואינו משנה את התוכנית בפועל של אף ארגון."
+  },
+  "web.colonel.previewModeActive": {
+    "text": "תצוגה מקדימה פעילה"
+  },
+  "web.colonel.bannedIps.empty": {
+    "text": "אין כתובות IP חסומות"
+  },
+  "web.colonel.bannedIps.currentIp": {
+    "text": "כתובת ה-IP הנוכחית שלך"
+  },
+  "web.colonel.bannedIps.confirmUnban": {
+    "text": "לבטל את החסימה של {ip}?"
+  },
+  "web.colonel.bannedIps.actions.ban": {
+    "text": "חסום IP"
+  },
+  "web.colonel.bannedIps.actions.quickBan": {
+    "text": "חסימה מהירה"
+  },
+  "web.colonel.bannedIps.actions.unban": {
+    "text": "בטל חסימה"
+  },
+  "web.colonel.bannedIps.actions.cancel": {
+    "text": "ביטול"
+  },
+  "web.colonel.bannedIps.columns.ipAddress": {
+    "text": "כתובת IP"
+  },
+  "web.colonel.bannedIps.columns.reason": {
+    "text": "סיבה"
+  },
+  "web.colonel.bannedIps.columns.bannedAt": {
+    "text": "נחסם בתאריך"
+  },
+  "web.colonel.bannedIps.columns.bannedBy": {
+    "text": "נחסם על ידי"
+  },
+  "web.colonel.bannedIps.error.banFailed": {
+    "text": "חסימת כתובת ה-IP נכשלה"
+  },
+  "web.colonel.bannedIps.error.unbanFailed": {
+    "text": "ביטול חסימת כתובת ה-IP נכשל"
+  },
+  "web.colonel.bannedIps.form.title": {
+    "text": "חסימת כתובת IP"
+  },
+  "web.colonel.bannedIps.form.ipLabel": {
+    "text": "כתובת IP"
+  },
+  "web.colonel.bannedIps.form.reasonLabel": {
+    "text": "סיבה"
+  },
+  "web.colonel.bannedIps.form.reasonPlaceholder": {
+    "text": "סיבה (אופציונלי)"
+  },
+  "web.colonel.bannedIps.success.banned": {
+    "text": "כתובת ה-IP {ip} נחסמה"
+  },
+  "web.colonel.bannedIps.success.unbanned": {
+    "text": "חסימת כתובת ה-IP {ip} בוטלה"
+  },
+  "web.colonel.customDomains.empty": {
+    "text": "לא הוגדרו דומיינים מותאמים אישית"
+  },
+  "web.colonel.customDomains.noLogo": {
+    "text": "אין לוגו"
+  },
+  "web.colonel.customDomains.labels.organization": {
+    "text": "ארגון"
+  },
+  "web.colonel.customDomains.labels.externalId": {
+    "text": "מזהה חיצוני"
+  },
+  "web.colonel.customDomains.labels.created": {
+    "text": "נוצר"
+  },
+  "web.colonel.customDomains.labels.updated": {
+    "text": "עודכן"
+  },
+  "web.colonel.customDomains.labels.favicon": {
+    "text": "Favicon"
+  },
+  "web.colonel.customDomains.status.verified": {
+    "text": "מאומת"
+  },
+  "web.colonel.customDomains.status.resolving": {
+    "text": "בתהליך פתרון"
+  },
+  "web.colonel.customDomains.status.ready": {
+    "text": "מוכן"
+  },
+  "web.colonel.customDomains.status.publicHomepage": {
+    "text": "דף בית ציבורי"
+  },
+  "web.colonel.customDomains.status.publicApi": {
+    "text": "API ציבורי"
+  },
+  "web.colonel.customDomains.status.pending": {
+    "text": "ממתין"
+  },
+  "web.colonel.pagination.showing": {
+    "text": "מציג {start}–{end} מתוך {total}"
+  },
+  "web.colonel.pagination.itemsPerPage": {
+    "text": "פריטים לעמוד"
+  },
+  "web.colonel.pagination.perPage": {
+    "text": "{count} לעמוד"
+  },
+  "web.colonel.pagination.pageOf": {
+    "text": "עמוד {current} מתוך {total}"
+  },
+  "web.colonel.secrets.empty": {
+    "text": "לא נמצאו סודות"
+  },
+  "web.colonel.secrets.never": {
+    "text": "אף פעם"
+  },
+  "web.colonel.secrets.columns.shortId": {
+    "text": "מזהה קצר"
+  },
+  "web.colonel.secrets.columns.state": {
+    "text": "מצב"
+  },
+  "web.colonel.secrets.columns.created": {
+    "text": "נוצר"
+  },
+  "web.colonel.secrets.columns.expiration": {
+    "text": "תפוגה"
+  },
+  "web.colonel.secrets.columns.age": {
+    "text": "גיל (ימים)"
+  },
+  "web.colonel.secrets.state.new": {
+    "text": "חדש"
+  },
+  "web.colonel.secrets.state.received": {
+    "text": "התקבל"
+  },
+  "web.colonel.secrets.state.viewed": {
+    "text": "נצפה"
   }
 }

--- a/locales/content/he/api-account-errors.json
+++ b/locales/content/he/api-account-errors.json
@@ -1,0 +1,8 @@
+{
+  "api.account.errors.invalid_email": {
+    "text": "האם זו כתובת דוא״ל תקינה?"
+  },
+  "api.account.errors.password_too_short": {
+    "text": "הסיסמה קצרה מדי"
+  }
+}

--- a/locales/content/he/api-domains-errors.json
+++ b/locales/content/he/api-domains-errors.json
@@ -1,0 +1,29 @@
+{
+  "api.domains.errors.domain_id_required": {
+    "text": "נדרש מזהה דומיין"
+  },
+  "api.domains.errors.domain_not_found": {
+    "text": "הדומיין לא נמצא: %{extid}"
+  },
+  "api.domains.errors.organization_not_found": {
+    "text": "הארגון לא נמצא עבור הדומיין: %{domain}"
+  },
+  "api.domains.errors.incoming_secrets_disabled": {
+    "text": "סודות נכנסים אינם מופעלים במופע זה"
+  },
+  "api.domains.errors.incoming_secrets_entitlement_required": {
+    "text": "ניהול סודות נכנסים מחייב את הזכאות incoming_secrets. אנא שדרג את התוכנית שלך."
+  },
+  "api.domains.errors.incoming_config_not_found": {
+    "text": "תצורת סודות נכנסים לא נמצאה עבור הדומיין: %{extid}"
+  },
+  "api.domains.errors.recipients_max_exceeded": {
+    "text": "מותרים %{max} נמענים לכל היותר"
+  },
+  "api.domains.errors.recipients_invalid_email": {
+    "text": "כתובת דוא״ל לא תקינה: %{email}"
+  },
+  "api.domains.errors.recipients_duplicate": {
+    "text": "לא ניתן להזין כתובות דוא״ל כפולות של נמענים"
+  }
+}

--- a/locales/content/he/api-entitlements-errors.json
+++ b/locales/content/he/api-entitlements-errors.json
@@ -1,0 +1,71 @@
+{
+  "api.entitlements.errors.context_unavailable": {
+    "text": "לא ניתן לאמת זכאויות (הקשר הארגון אינו זמין)"
+  },
+  "api.entitlements.errors.api_access_required": {
+    "text": "גישה ל-API מחייבת שדרוג תוכנית"
+  },
+  "api.entitlements.errors.custom_privacy_defaults_required": {
+    "text": "ברירות מחדל מותאמות אישית לפרטיות מחייבות שדרוג תוכנית"
+  },
+  "api.entitlements.errors.extended_default_expiration_required": {
+    "text": "תפוגת ברירת מחדל מורחבת מחייבת שדרוג תוכנית"
+  },
+  "api.entitlements.errors.custom_domains_required": {
+    "text": "דומיינים מותאמים אישית מחייבים שדרוג תוכנית"
+  },
+  "api.entitlements.errors.custom_branding_required": {
+    "text": "מיתוג מותאם אישית מחייב שדרוג תוכנית"
+  },
+  "api.entitlements.errors.homepage_secrets_required": {
+    "text": "סודות בדף הבית מחייבים שדרוג תוכנית"
+  },
+  "api.entitlements.errors.incoming_secrets_required": {
+    "text": "סודות נכנסים מחייבים שדרוג תוכנית"
+  },
+  "api.entitlements.errors.custom_mail_sender_required": {
+    "text": "שולח דוא״ל מותאם אישית מחייב שדרוג תוכנית"
+  },
+  "api.entitlements.errors.flexible_from_domain_required": {
+    "text": "דומיין שולח גמיש מחייב שדרוג תוכנית"
+  },
+  "api.entitlements.errors.manage_org_required": {
+    "text": "ניהול ארגון מחייב שדרוג תוכנית"
+  },
+  "api.entitlements.errors.manage_teams_required": {
+    "text": "ניהול צוותים מחייב שדרוג תוכנית"
+  },
+  "api.entitlements.errors.manage_members_required": {
+    "text": "ניהול חברים מחייב שדרוג תוכנית"
+  },
+  "api.entitlements.errors.manage_sso_required": {
+    "text": "ניהול SSO מחייב שדרוג תוכנית"
+  },
+  "api.entitlements.errors.audit_logs_required": {
+    "text": "יומני ביקורת מחייבים שדרוג תוכנית"
+  },
+  "api.entitlements.errors.custom_signup_validation_required": {
+    "text": "אימות הרשמה מותאם אישית מחייב שדרוג תוכנית"
+  },
+  "api.entitlements.errors.create_secrets_required": {
+    "text": "יצירת סודות מחייבת שדרוג תוכנית"
+  },
+  "api.entitlements.errors.view_receipt_required": {
+    "text": "צפייה בקבלות מחייבת שדרוג תוכנית"
+  },
+  "api.entitlements.errors.notifications_required": {
+    "text": "התראות מחייבות שדרוג תוכנית"
+  },
+  "api.entitlements.errors.workspace_branding_required": {
+    "text": "מיתוג סביבת עבודה מחייב שדרוג תוכנית"
+  },
+  "api.entitlements.errors.ip_access_rules_required": {
+    "text": "כללי גישת IP מחייבים שדרוג תוכנית"
+  },
+  "api.entitlements.errors.manage_billing_required": {
+    "text": "ניהול חיובים מחייב שדרוג תוכנית"
+  },
+  "api.entitlements.errors.custom_signin_config_required": {
+    "text": "הגדרת התחברות מותאמת אישית מחייבת שדרוג תוכנית"
+  }
+}

--- a/locales/content/he/api-feedback-errors.json
+++ b/locales/content/he/api-feedback-errors.json
@@ -1,0 +1,5 @@
+{
+  "api.feedback.errors.rate_limit_exceeded": {
+    "text": "יותר מדי הגשות משוב. אנא נסה שוב מאוחר יותר."
+  }
+}

--- a/locales/content/he/api-incoming-errors.json
+++ b/locales/content/he/api-incoming-errors.json
@@ -1,0 +1,5 @@
+{
+  "api.incoming.errors.custom_domain_unresolved": {
+    "text": "לא ניתן היה לפתור את ארגון הדומיין המותאם אישית"
+  }
+}

--- a/locales/content/he/api-invite-errors.json
+++ b/locales/content/he/api-invite-errors.json
@@ -1,0 +1,23 @@
+{
+  "api.invite.errors.invitation_not_found_or_expired": {
+    "text": "ההזמנה לא נמצאה או פג תוקפה"
+  },
+  "api.invite.errors.token_required": {
+    "text": "נדרש אסימון"
+  },
+  "api.invite.errors.organization_no_longer_exists": {
+    "text": "הארגון כבר אינו קיים"
+  },
+  "api.invite.errors.invitation_already_processed": {
+    "text": "ההזמנה כבר %{status}"
+  },
+  "api.invite.errors.invitation_expired": {
+    "text": "תוקף ההזמנה פג"
+  },
+  "api.invite.errors.email_mismatch": {
+    "text": "כתובת הדוא״ל שלך אינה תואמת להזמנה"
+  },
+  "api.invite.errors.already_member": {
+    "text": "אתה כבר חבר בארגון זה"
+  }
+}

--- a/locales/content/he/api-organizations-errors.json
+++ b/locales/content/he/api-organizations-errors.json
@@ -1,0 +1,107 @@
+{
+  "api.organizations.errors.domain_scoped_forbidden": {
+    "text": "חברים המוגבלים לדומיין אינם יכולים לבצע פעולה זו"
+  },
+  "api.organizations.errors.organization_not_found": {
+    "text": "הארגון לא נמצא: %{extid}"
+  },
+  "api.organizations.errors.organization_owner_required": {
+    "text": "רק בעל הארגון יכול לבצע פעולה זו"
+  },
+  "api.organizations.errors.organization_member_required": {
+    "text": "עליך להיות חבר בארגון כדי לבצע פעולה זו"
+  },
+  "api.organizations.errors.organization_admin_required": {
+    "text": "רק בעלי הארגון ומנהליו יכולים לבצע פעולה זו"
+  },
+  "api.organizations.errors.extid_required": {
+    "text": "נדרש מזהה ארגון"
+  },
+  "api.organizations.errors.display_name_required": {
+    "text": "נדרש שם ארגון"
+  },
+  "api.organizations.errors.display_name_too_long": {
+    "text": "שם הארגון חייב להיות קצר מ-%{max} תווים"
+  },
+  "api.organizations.errors.description_too_long": {
+    "text": "התיאור חייב להיות קצר מ-%{max} תווים"
+  },
+  "api.organizations.errors.contact_email_exists": {
+    "text": "כבר קיים ארגון עם כתובת דוא״ל ליצירת קשר זו"
+  },
+  "api.organizations.errors.creation_in_progress": {
+    "text": "יצירת הארגון מתבצעת. אנא נסה שוב."
+  },
+  "api.organizations.errors.organization_limit_reached": {
+    "text": "הגעת למגבלת הארגונים. שדרג את התוכנית שלך כדי ליצור ארגונים נוספים."
+  },
+  "api.organizations.invitations.errors.invitation_not_found": {
+    "text": "ההזמנה לא נמצאה"
+  },
+  "api.organizations.invitations.errors.email_required": {
+    "text": "נדרש דוא״ל"
+  },
+  "api.organizations.invitations.errors.invalid_email_format": {
+    "text": "פורמט דוא״ל לא תקין"
+  },
+  "api.organizations.invitations.errors.invalid_role": {
+    "text": "התפקיד חייב להיות חבר או מנהל"
+  },
+  "api.organizations.invitations.errors.cannot_invite_as_owner": {
+    "text": "לא ניתן להזמין בתפקיד בעלים"
+  },
+  "api.organizations.invitations.errors.user_already_member": {
+    "text": "המשתמש כבר חבר בארגון זה"
+  },
+  "api.organizations.invitations.errors.invitation_already_pending": {
+    "text": "כבר קיימת הזמנה ממתינה לכתובת דוא״ל זו"
+  },
+  "api.organizations.invitations.errors.member_limit_reached": {
+    "text": "הגעת למגבלת החברים. שדרג את התוכנית שלך כדי להזמין חברים נוספים."
+  },
+  "api.organizations.invitations.errors.resend_only_pending": {
+    "text": "ניתן לשלוח מחדש רק הזמנות ממתינות"
+  },
+  "api.organizations.invitations.errors.resend_limit_reached": {
+    "text": "הגעת למגבלת השליחה מחדש המרבית (%{max})"
+  },
+  "api.organizations.invitations.errors.revoke_only_pending": {
+    "text": "ניתן לבטל רק הזמנות ממתינות"
+  },
+  "api.organizations.members.errors.member_not_found": {
+    "text": "החבר לא נמצא: %{extid}"
+  },
+  "api.organizations.members.errors.member_not_in_organization": {
+    "text": "החבר לא נמצא בארגון זה"
+  },
+  "api.organizations.members.errors.member_not_active": {
+    "text": "החבר אינו פעיל"
+  },
+  "api.organizations.members.errors.invalid_role_value": {
+    "text": "תפקיד לא תקין. חייב להיות אחד מ: %{roles}"
+  },
+  "api.organizations.members.errors.cannot_change_owner_role": {
+    "text": "לא ניתן לשנות את תפקיד הבעלים. השתמש בהעברת בעלות במקום."
+  },
+  "api.organizations.members.errors.member_already_has_role": {
+    "text": "לחבר כבר יש את התפקיד: %{role}"
+  },
+  "api.organizations.members.errors.cannot_promote_to_owner": {
+    "text": "לא ניתן לקדם לתפקיד בעלים. השתמש בהעברת בעלות במקום."
+  },
+  "api.organizations.members.errors.must_be_member": {
+    "text": "עליך להיות חבר בארגון זה"
+  },
+  "api.organizations.members.errors.cannot_remove_owner": {
+    "text": "לא ניתן להסיר את בעל הארגון. העבר תחילה את הבעלות."
+  },
+  "api.organizations.members.errors.cannot_remove_self": {
+    "text": "לא ניתן להסיר את עצמך. השתמש ביציאה מהארגון במקום."
+  },
+  "api.organizations.members.errors.admin_cannot_remove_admin": {
+    "text": "מנהלים אינם יכולים להסיר מנהלים אחרים. רק בעלים יכולים."
+  },
+  "api.organizations.members.errors.no_permission_to_remove": {
+    "text": "אין לך הרשאה להסיר חברים"
+  }
+}

--- a/locales/content/he/api-secrets-errors.json
+++ b/locales/content/he/api-secrets-errors.json
@@ -1,0 +1,11 @@
+{
+  "api.secrets.errors.domain_permission_authenticated_non_owner": {
+    "text": "אין לך הרשאה להשתמש בדומיין: %{domain}"
+  },
+  "api.secrets.errors.domain_public_sharing_disabled": {
+    "text": "שיתוף ציבורי מושבת עבור הדומיין: %{domain}"
+  },
+  "api.secrets.errors.domain_permission_anonymous_cross_domain": {
+    "text": "אין לך הרשאה להשתמש בדומיין: %{domain}"
+  }
+}

--- a/locales/content/he/email.json
+++ b/locales/content/he/email.json
@@ -315,7 +315,7 @@
     "source_hash": "f5394f72"
   },
   "email.feedback_email.signature": {
-    "text": "Secret Support",
+    "text": "צוות התמיכה",
     "renderer": "erb",
     "source_hash": "f6a6c90f"
   },

--- a/locales/content/he/email.json
+++ b/locales/content/he/email.json
@@ -60,7 +60,7 @@
     "source_hash": "88c72144"
   },
   "email.welcome.signature": {
-    "text": "Delano",
+    "text": "צוות התמיכה",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -100,7 +100,7 @@
     "source_hash": "fbb7eb2d"
   },
   "email.password_request.signature": {
-    "text": "Delano",
+    "text": "צוות התמיכה",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -145,7 +145,7 @@
     "source_hash": "1863f5be"
   },
   "email.magic_link.signature": {
-    "text": "Delano",
+    "text": "צוות התמיכה",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -230,7 +230,7 @@
     "source_hash": "3f6b45dd"
   },
   "email.secret_revealed.signature": {
-    "text": "Delano",
+    "text": "צוות התמיכה",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -355,7 +355,7 @@
     "source_hash": "734882d2"
   },
   "email.organization_invitation.signature": {
-    "text": "Delano",
+    "text": "צוות התמיכה",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -395,7 +395,7 @@
     "source_hash": "be92cff3"
   },
   "email.password_changed.signature": {
-    "text": "Delano",
+    "text": "צוות התמיכה",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -445,7 +445,7 @@
     "source_hash": "f8d47b82"
   },
   "email.email_changed.signature": {
-    "text": "Delano",
+    "text": "צוות התמיכה",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -495,7 +495,7 @@
     "source_hash": "f8d47b82"
   },
   "email.email_change_requested.signature": {
-    "text": "Delano",
+    "text": "צוות התמיכה",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -550,7 +550,7 @@
     "source_hash": "d4d835fc"
   },
   "email.email_change_confirmation.signature": {
-    "text": "Delano",
+    "text": "צוות התמיכה",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -580,7 +580,7 @@
     "source_hash": "e7c11bb0"
   },
   "email.mfa_enabled.signature": {
-    "text": "Delano",
+    "text": "צוות התמיכה",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -605,7 +605,7 @@
     "source_hash": "97ef0a3e"
   },
   "email.mfa_disabled.signature": {
-    "text": "Delano",
+    "text": "צוות התמיכה",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -650,7 +650,7 @@
     "source_hash": "450c54c5"
   },
   "email.new_login_alert.signature": {
-    "text": "Delano",
+    "text": "צוות התמיכה",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -670,7 +670,7 @@
     "source_hash": "d442beed"
   },
   "email.member_removed.signature": {
-    "text": "Delano",
+    "text": "צוות התמיכה",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -690,7 +690,7 @@
     "source_hash": "c2280c0c"
   },
   "email.role_changed.signature": {
-    "text": "Delano",
+    "text": "צוות התמיכה",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -710,7 +710,7 @@
     "source_hash": "7095fc69"
   },
   "email.organization_deleted.signature": {
-    "text": "Delano",
+    "text": "צוות התמיכה",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -750,7 +750,7 @@
     "source_hash": "36008943"
   },
   "email.payment_receipt.signature": {
-    "text": "Delano",
+    "text": "צוות התמיכה",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -775,7 +775,7 @@
     "source_hash": "926406b1"
   },
   "email.payment_failed.signature": {
-    "text": "Delano",
+    "text": "צוות התמיכה",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -800,7 +800,7 @@
     "source_hash": "66a1419e"
   },
   "email.trial_expiring.signature": {
-    "text": "Delano",
+    "text": "צוות התמיכה",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -825,7 +825,7 @@
     "source_hash": "5a96ae38"
   },
   "email.subscription_changed.signature": {
-    "text": "Delano",
+    "text": "צוות התמיכה",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -853,5 +853,41 @@
     "text": "Onetime Secret",
     "renderer": "erb",
     "source_hash": "1cd0194a"
+  },
+  "email.common.secret_link_label": {
+    "text": "קישור לסוד"
+  },
+  "email.common.automated_notice": {
+    "text": "זוהי הודעה אוטומטית מ-%{product_name}."
+  },
+  "email.common.support_label": {
+    "text": "תמיכה"
+  },
+  "email.expiration_warning.signature": {
+    "text": "צוות התמיכה"
+  },
+  "email.expiration_warning.footer_note": {
+    "text": "קיבלת הודעה זו מכיוון שתוקפו של סוד שיצרת ב-%{product_name} עומד לפוג."
+  },
+  "email.feedback_email.user_id_label": {
+    "text": "משתמש:"
+  },
+  "email.feedback_email.timezone_label": {
+    "text": "אזור זמן:"
+  },
+  "email.feedback_email.version_label": {
+    "text": "גרסה:"
+  },
+  "email.incoming_secret.footer_note": {
+    "text": "קיבלת הודעה זו מכיוון שמישהו השתמש ב-%{product_name} כדי לשלוח לך סוד. אם לא ציפית לכך, באפשרותך להתעלם מהודעת דוא״ל זו בבטחה."
+  },
+  "email.secret_link.passphrase_label": {
+    "text": "נדרש ביטוי סיסמה:"
+  },
+  "email.secret_link.passphrase_required": {
+    "text": "סוד זה מוגן בביטוי סיסמה. על השולח לספק לך אותו בנפרד."
+  },
+  "email.secret_link.footer_note": {
+    "text": "קיבלת הודעה זו מכיוון ש-%{sender_email} השתמש ב-%{product_name} כדי לשתף איתך סוד. אם לא ציפית לכך, באפשרותך להתעלם מהודעת דוא״ל זו בבטחה."
   }
 }

--- a/locales/content/he/feature-feedback.json
+++ b/locales/content/he/feature-feedback.json
@@ -58,5 +58,14 @@
   "web.feedback.reason_email_change_unauthorized": {
     "text": "נראה שאתה מדווח על שינוי דואר אלקטרוני בלתי מורשה בחשבונך. תאר מה קרה ואנחנו נחקור מיד.",
     "source_hash": "00e56551"
+  },
+  "web.feedback.anonymous_no_reply": {
+    "text": "הערה: אם ברצונך לקבל תגובה, אנא חתום או כלול כתובת דוא״ל בהודעה."
+  },
+  "web.feedback.characters_remaining": {
+    "text": "נותרו {count} תווים"
+  },
+  "web.feedback.character_limit_reached": {
+    "text": "הגעת למגבלת התווים"
   }
 }

--- a/locales/content/he/feature-homepage-secrets.json
+++ b/locales/content/he/feature-homepage-secrets.json
@@ -1,0 +1,50 @@
+{
+  "homepage_secrets.disabled.members_only_eyebrow": {
+    "text": "מופע לחברים בלבד"
+  },
+  "homepage_secrets.disabled.private_instance_eyebrow": {
+    "text": "מופע פרטי"
+  },
+  "homepage_secrets.disabled.team_link_headline": {
+    "text": "קישור זה מיועד לצוות {workspace}."
+  },
+  "homepage_secrets.disabled.signin_headline": {
+    "text": "התחבר כדי ליצור {action}."
+  },
+  "homepage_secrets.disabled.signin_headline_action": {
+    "text": "קישור לסוד"
+  },
+  "homepage_secrets.disabled.team_subtitle": {
+    "text": "רק חברי צוות מורשים ב-{domain} יכולים ליצור כאן קישורים חד-פעמיים חדשים. נמענים עדיין יכולים לפתוח כל קישור שנשלח אליהם."
+  },
+  "homepage_secrets.disabled.public_subtitle": {
+    "text": "רק חברים מורשים של מופע זה יכולים ליצור קישורים חד-פעמיים חדשים. נמענים עדיין יכולים לפתוח כל קישור שנשלח אליהם."
+  },
+  "homepage_secrets.disabled.signin_cta": {
+    "text": "התחבר לחשבון שלך"
+  },
+  "homepage_secrets.disabled.what_is_this": {
+    "text": "מה זה?"
+  },
+  "homepage_secrets.disabled.trust_viewed_once": {
+    "text": "נצפה פעם אחת, ואז נעלם"
+  },
+  "homepage_secrets.disabled.trust_zero_retained": {
+    "text": "אפס שמירה"
+  },
+  "homepage_secrets.disabled.promo_title": {
+    "text": "חדש: תוכניות חינמיות כוללות כעת דומיינים מותאמים אישית."
+  },
+  "homepage_secrets.disabled.promo_subtitle": {
+    "text": "הפנה את הדומיין שלך אל Onetime Secret ושלח סודות תחת המותג שלך."
+  },
+  "homepage_secrets.disabled.promo_learn_how": {
+    "text": "למד כיצד"
+  },
+  "homepage_secrets.disabled.logo_alt": {
+    "text": "הלוגו של {name}"
+  },
+  "homepage_secrets.disabled.opens_in_new_tab": {
+    "text": "(נפתח בכרטיסייה חדשה)"
+  }
+}

--- a/locales/content/he/feature-incoming.json
+++ b/locales/content/he/feature-incoming.json
@@ -130,5 +130,26 @@
   "incoming.receipt_link_text": {
     "text": "קבלה",
     "source_hash": "6f328609"
+  },
+  "incoming.upgrade_required_title": {
+    "text": "נדרש שדרוג"
+  },
+  "incoming.upgrade_required_description": {
+    "text": "תכונה זו מחייבת שדרוג תוכנית. אנא פנה לבעל החשבון כדי להפעיל סודות נכנסים."
+  },
+  "incoming.validation_memo_too_long": {
+    "text": "התזכיר חייב להכיל {max} תווים או פחות"
+  },
+  "incoming.validation_secret_required": {
+    "text": "נדרש תוכן סוד"
+  },
+  "incoming.validation_recipient_required": {
+    "text": "אנא בחר נמען"
+  },
+  "incoming.validation_feature_disabled": {
+    "text": "תכונת הסודות הנכנסים אינה מופעלת"
+  },
+  "incoming.validation_form_errors": {
+    "text": "אנא בדוק את הטופס לאיתור שגיאות"
   }
 }

--- a/locales/content/he/feature-regions.json
+++ b/locales/content/he/feature-regions.json
@@ -152,7 +152,7 @@
     "source_hash": "1d97f6bd"
   },
   "web.regions.changing_regions_billing_note": {
-    "text": "אם דואר אלקטרוני של איש הקשר לחיוב שלך שונה מדואר אלקטרוני של חשבון {product_name} שלך, השתמש בדואר האלקטרוני של איש הקשר לחיוב לחשבון באזור החדש כדי לשמור על הטבות המנוי שלך.",
+    "text": "אם כתובת הדוא״ל של איש הקשר לחיובים שונה מכתובת הדוא״ל של חשבון {product_name} שלך, השתמש בכתובת הדוא״ל של איש הקשר לחיובים עבור חשבון האזור החדש כדי לשמור על הטבות המנוי שלך.",
     "source_hash": "dac1cc28"
   },
   "web.regions.changing_regions_subscription_note": {
@@ -186,5 +186,8 @@
   "web.regions.jurisdictions.apac.name": {
     "text": "Asia-Pacific",
     "source_hash": "7a757670"
+  },
+  "web.regions.no_region_configured": {
+    "text": "כרגע אין מידע על אזורים זמין עבור החשבון שלך."
   }
 }

--- a/locales/content/he/feature-translations.json
+++ b/locales/content/he/feature-translations.json
@@ -64,7 +64,7 @@
     "source_hash": "13131e36"
   },
   "web.translations.the_following_people_have_donated_their_time_to_": {
-    "text": "האנשים הבאים תרמו מזמנם כדי לעזור להרחיב את טווח ההגעה של {product_name}:",
+    "text": "האנשים הבאים תרמו מזמנם כדי לסייע בהרחבת טווח ההגעה של {product_name}:",
     "source_hash": "85a766af"
   },
   "web.translations.translations": {
@@ -84,7 +84,7 @@
     "source_hash": "ba5c4395"
   },
   "web.translations.since_2012_onetime_secret_has_provided_a_secure_": {
-    "text": "מאז 2012, {product_name} סיפק דרך מאובטחת לשתף מידע רגיש ברחבי העולם. עם משתמשים באזורים שבהם אנגלית אינה השפה העיקרית, תרגומים מדויקים חיוניים להפיכת תקשורת מאובטחת לנגישה לכולם.",
+    "text": "מאז 2012, {product_name} מספק דרך מאובטחת לשיתוף מידע רגיש ברחבי העולם. עם משתמשים באזורים שבהם אנגלית אינה השפה העיקרית, תרגומים מדויקים חיוניים כדי להפוך תקשורת מאובטחת לנגישה לכולם.",
     "source_hash": "87a6e9af"
   },
   "web.translations.help_secure_communication_go_global": {

--- a/locales/content/he/secret-manage.json
+++ b/locales/content/he/secret-manage.json
@@ -128,7 +128,7 @@
     "source_hash": "07fe1b84"
   },
   "web.secrets.onetime_secret_is_a_secure_way_to_share_sensitiv": {
-    "text": "{product_name} היא דרך מאובטחת לשתף מידע רגיש שמשמיד את עצמו לאחר צפייה יחידה.",
+    "text": "{product_name} הוא דרך מאובטחת לשתף מידע רגיש שנמחק מעצמו לאחר צפייה אחת.",
     "source_hash": "8a163297"
   },
   "web.secrets.what_is_this": {
@@ -398,5 +398,11 @@
   "web.secrets.errors.access_denied_to_domain": {
     "text": "הגישה לדומיין נדחתה",
     "source_hash": "cd441eea"
+  },
+  "web.receipt.open_link": {
+    "text": "פתח קישור"
+  },
+  "web.secrets.messageDeleted": {
+    "text": "ההודעה נמחקה"
   }
 }

--- a/locales/content/he/session-auth-extended.json
+++ b/locales/content/he/session-auth-extended.json
@@ -710,5 +710,26 @@
   "web.auth.recovery_codes.link_title": {
     "text": "קודי שחזור",
     "source_hash": "579c7f4e"
+  },
+  "web.auth.google": {
+    "text": "Google"
+  },
+  "web.auth.mfa.alternative_auth_options": {
+    "text": "אפשרויות אימות חלופיות"
+  },
+  "web.auth.remember.enabled": {
+    "text": "השאר אותי מחובר"
+  },
+  "web.auth.security._guidance.context": {
+    "text": "⚠️ SECURITY-CRITICAL: Messages prevent information disclosure. See src/locales/SECURITY-TRANSLATION-GUIDE.md"
+  },
+  "web.auth.sessions.session_singular": {
+    "text": "הפעלה"
+  },
+  "web.auth.sessions.session_plural": {
+    "text": "הפעלות"
+  },
+  "web.auth.sessions._guidance.context": {
+    "text": "User's logged-in devices/browsers management page"
   }
 }

--- a/locales/content/he/session-auth.json
+++ b/locales/content/he/session-auth.json
@@ -395,5 +395,35 @@
   "web.help.contact_support": {
     "text": "צור קשר עם התמיכה",
     "source_hash": "f8d47b82"
+  },
+  "web.auth.account.sso_linked": {
+    "text": "חשבון SSO"
+  },
+  "web.auth.verify._guidance.context": {
+    "text": "Email verification flow after signup"
+  },
+  "web.help.reset_password_link": {
+    "text": "איפוס סיסמה"
+  },
+  "web.login.custom_domain_sso_title": {
+    "text": "כניסה יחידה (SSO) זמינה עבור דומיין זה"
+  },
+  "web.login.custom_domain_sso_description": {
+    "text": "מנהל הארגון יכול להפעיל SSO כדי לאפשר לחברי הצוות להתחבר כאן. פנה למנהל לקבלת גישה."
+  },
+  "web.login.signin_disabled_heading": {
+    "text": "ההתחברות אינה זמינה"
+  },
+  "web.login.signin_disabled_message": {
+    "text": "ההתחברות אינה זמינה כעת בדומיין זה."
+  },
+  "web.login.errors.sso_not_configured": {
+    "text": "כניסה יחידה (SSO) אינה מוגדרת עבור דומיין זה. אנא פנה למנהל המערכת שלך."
+  },
+  "web.login.errors.invalid_email": {
+    "text": "כתובת הדוא״ל מספק הזהויות שלך אינה תקינה. אנא פנה למנהל המערכת שלך."
+  },
+  "web.login.errors.domain_not_allowed": {
+    "text": "דומיין הדוא״ל שלך אינו מורשה להרשמה באמצעות SSO. אנא פנה למנהל המערכת שלך."
   }
 }

--- a/locales/content/he/workspace-account.json
+++ b/locales/content/he/workspace-account.json
@@ -476,7 +476,7 @@
     "source_hash": "1cc77e60"
   },
   "web.settings.api.documentation_description": {
-    "text": "למד כיצד לשלב את {product_name} באפליקציות שלך",
+    "text": "למד כיצד לשלב את {product_name} ביישומים שלך",
     "source_hash": "6e8f910f"
   },
   "web.settings.api.rest_api_reference": {
@@ -682,5 +682,14 @@
   "web.settings.profile.didnt_receive_email": {
     "text": "לא קיבלת את הדואר האלקטרוני?",
     "source_hash": "fe3ac3ad"
+  },
+  "web.settings.api.api_disabled_notice": {
+    "text": "ה-API מושבת עבור מופע זה."
+  },
+  "web.settings.security.sso_managed_title": {
+    "text": "האבטחה מנוהלת באמצעות SSO"
+  },
+  "web.settings.security.sso_managed_description": {
+    "text": "החשבון שלך מאומת באמצעות ספק הכניסה היחידה (SSO) של הארגון שלך. סיסמה, אימות רב-שלבי וקודי שחזור מנוהלים על ידי ספק הזהויות שלך."
   }
 }

--- a/locales/content/he/workspace-billing.json
+++ b/locales/content/he/workspace-billing.json
@@ -988,5 +988,47 @@
     "text": "זמין באזור המנוי המקורי שלך בלבד",
     "context": "Hint shown on plan cards when currency does not match active subscription",
     "source_hash": "10de32e5"
+  },
+  "web.billing.already_subscribed": {
+    "text": "אתה כבר מנוי על תוכנית זו."
+  },
+  "web.billing.cancel.reactivate_button": {
+    "text": "הפעלת מנוי מחדש"
+  },
+  "web.billing.cancel.reactivate_success": {
+    "text": "המנוי שלך הופעל מחדש. החיוב יימשך כרגיל."
+  },
+  "web.billing.cancel.reactivate_error": {
+    "text": "הפעלת המנוי מחדש נכשלה. נסה שוב או פנה לתמיכה."
+  },
+  "web.billing.features.manage_orgs": {
+    "text": "ניהול ארגונים"
+  },
+  "web.billing.features.flexible_from_domain": {
+    "text": "דומיין שולח גמיש לדואר אלקטרוני"
+  },
+  "web.billing.features.unlimited_admins": {
+    "text": "מנהלים ללא הגבלה"
+  },
+  "web.billing.features.manage_sso": {
+    "text": "SSO"
+  },
+  "web.billing.overview.entitlements.flexible_from_domain": {
+    "text": "דומיין שולח גמיש לדואר אלקטרוני"
+  },
+  "web.billing.overview.entitlements.manage_orgs": {
+    "text": "ניהול ארגונים"
+  },
+  "web.billing.overview.entitlements.manage_sso": {
+    "text": "כניסה יחידה (SSO)"
+  },
+  "web.billing.overview.entitlements.manage_billing": {
+    "text": "ניהול חיוב"
+  },
+  "web.billing.overview.entitlements.custom_signup_validation": {
+    "text": "אימות הרשמה מותאם אישית"
+  },
+  "web.billing.plans.reactivate": {
+    "text": "הפעל מחדש"
   }
 }

--- a/locales/content/he/workspace-branding.json
+++ b/locales/content/he/workspace-branding.json
@@ -178,5 +178,11 @@
   "web.branding.upgrade_to_customize": {
     "text": "שדרג את התוכנית שלך כדי להתאים אישית את המיתוג לדומיין זה.",
     "source_hash": "9077bf79"
+  },
+  "web.branding.saved_successfully": {
+    "text": "הגדרות המיתוג נשמרו בהצלחה"
+  },
+  "web.branding.keyhole_logo_icon": {
+    "text": "סמל חור מנעול המייצג שיתוף מאובטח ופרטי"
   }
 }

--- a/locales/content/he/workspace-dashboard.json
+++ b/locales/content/he/workspace-dashboard.json
@@ -22,5 +22,14 @@
   "web.dashboard.fetch_error_description": {
     "text": "אירעה בעיה בטעינת הנתונים שלך. אנא נסה שוב.",
     "source_hash": "ff0d904e"
+  },
+  "web.teams.create_first_team_title": {
+    "text": "צור את הצוות הראשון שלך"
+  },
+  "web.teams.create_first_team_description": {
+    "text": "צוותים מאפשרים לך לשתף פעולה עם אחרים במרחב עבודה משותף."
+  },
+  "web.teams.create_team": {
+    "text": "צור צוות"
   }
 }

--- a/locales/content/he/workspace-domains.json
+++ b/locales/content/he/workspace-domains.json
@@ -398,5 +398,725 @@
   "web.domains.dns_widget_description": {
     "text": "השתמש בכלי למטה כדי לזהות אוטומטית את ספק ה-DNS שלך ולקבל הוראות צעד אחר צעד להגדרת הדומיין שלך.",
     "source_hash": "91c1af2e"
+  },
+  "api.domains.errors.add_admin_required": {
+    "text": "רק בעלי ארגון ומנהלים יכולים להוסיף דומיינים מותאמים אישית"
+  },
+  "web.domains.public_homepage": {
+    "text": "דף בית ציבורי"
+  },
+  "web.domains.status_tooltip_active": {
+    "text": "הדומיין אומת והוא פעיל"
+  },
+  "web.domains.status_tooltip_dns_incorrect": {
+    "text": "DNS לא מוגדר — לחץ לתיקון"
+  },
+  "web.domains.status_tooltip_not_verified": {
+    "text": "הדומיין לא אומת — לחץ לאימות"
+  },
+  "web.domains.status_tooltip_unverified": {
+    "text": "סטטוס הדומיין לא אומת — לחץ לרענון"
+  },
+  "web.domains.last_check_failed": {
+    "text": "בדיקת האימות האחרונה נכשלה"
+  },
+  "web.domains.last_check_failed_ago": {
+    "text": "הבדיקה האחרונה נכשלה {0}"
+  },
+  "web.domains.verify_now": {
+    "text": "אמת עכשיו"
+  },
+  "web.domains.click_to_verify": {
+    "text": "לחץ לאימות"
+  },
+  "web.domains.remove_domain_description": {
+    "text": "הסרה סופית של דומיין זה וכל התצורה שלו."
+  },
+  "web.domains.add_access_denied": {
+    "text": "הגישה נדחתה"
+  },
+  "web.domains.add_access_denied_description": {
+    "text": "אין לך הרשאה להוסיף דומיינים לארגון זה. פנה למנהל הארגון שלך."
+  },
+  "web.domains.dns_widget_load_failed": {
+    "text": "טעינת רכיב ה-DNS נכשלה"
+  },
+  "web.domains.dns_widget_not_available": {
+    "text": "רכיב ה-DNS אינו זמין"
+  },
+  "web.domains.dns_widget_init_failed": {
+    "text": "אתחול רכיב ה-DNS נכשל"
+  },
+  "web.domains.verified": {
+    "text": "אומת"
+  },
+  "web.domains.pending_verification": {
+    "text": "ממתין לאימות"
+  },
+  "web.domains.unsaved_changes_confirmation": {
+    "text": "יש לך שינויים שלא נשמרו. האם אתה בטוח שברצונך לצאת?"
+  },
+  "web.domains.entitlement_required_owner": {
+    "text": "תכונה זו דורשת שדרוג תוכנית."
+  },
+  "web.domains.entitlement_required_member": {
+    "text": "תכונה זו אינה זמינה בתוכנית הנוכחית שלך. פנה לבעל הארגון שלך."
+  },
+  "web.domains.detail.manage": {
+    "text": "ניהול"
+  },
+  "web.domains.detail.features": {
+    "text": "תכונות"
+  },
+  "web.domains.detail.homepage_title": {
+    "text": "סודות בדף הבית"
+  },
+  "web.domains.detail.homepage_description": {
+    "text": "אפשר גישה ציבורית ליצירת סודות בדף הבית של הדומיין שלך"
+  },
+  "web.domains.detail.brand_description": {
+    "text": "לוגו, צבעים ומיתוג מותאם אישית"
+  },
+  "web.domains.detail.sso_description": {
+    "text": "הגדרות ספק כניסה יחידה (SSO)"
+  },
+  "web.domains.detail.email_description": {
+    "text": "תצורת שולח דואר אלקטרוני מותאם אישית"
+  },
+  "web.domains.detail.incoming_description": {
+    "text": "הגדרות נמען לסודות נכנסים"
+  },
+  "web.domains.detail.signup_description": {
+    "text": "אסטרטגיית אימות הרשמה לכל דומיין"
+  },
+  "web.domains.detail.signin_description": {
+    "text": "תצורת שיטת כניסה לכל דומיין"
+  },
+  "web.domains.email.title": {
+    "text": "שליחת דואר אלקטרוני"
+  },
+  "web.domains.email.config_title": {
+    "text": "תצורת דואר אלקטרוני"
+  },
+  "web.domains.email.config_description": {
+    "text": "הגדר שליחת דואר אלקטרוני עבור דומיין זה"
+  },
+  "web.domains.email.provider_label": {
+    "text": "ספק דואר אלקטרוני"
+  },
+  "web.domains.email.provider_placeholder": {
+    "text": "בחר ספק דואר אלקטרוני"
+  },
+  "web.domains.email.from_name_label": {
+    "text": "שם השולח"
+  },
+  "web.domains.email.from_name_placeholder": {
+    "text": "לדוגמה Acme Security"
+  },
+  "web.domains.email.from_address_label": {
+    "text": "כתובת השולח"
+  },
+  "web.domains.email.from_address_placeholder": {
+    "text": "לדוגמה secrets{'@'}example.com"
+  },
+  "web.domains.email.reply_to_label": {
+    "text": "כתובת למענה"
+  },
+  "web.domains.email.reply_to_placeholder": {
+    "text": "לדוגמה support{'@'}example.com"
+  },
+  "web.domains.email.save_changes": {
+    "text": "שמור שינויים"
+  },
+  "web.domains.email.discard_changes": {
+    "text": "בטל שינויים"
+  },
+  "web.domains.email.provider_ses": {
+    "text": "Amazon SES"
+  },
+  "web.domains.email.provider_sendgrid": {
+    "text": "SendGrid"
+  },
+  "web.domains.email.provider_lettermint": {
+    "text": "Lettermint"
+  },
+  "web.domains.email.provider_inherit": {
+    "text": "השתמש בברירות המחדל של החשבון"
+  },
+  "web.domains.email.provider_ses_description": {
+    "text": "דורש אימות דומיין באמצעות רשומות DKIM ו-SPF"
+  },
+  "web.domains.email.provider_sendgrid_description": {
+    "text": "דורש הגדרת אימות דומיין"
+  },
+  "web.domains.email.provider_lettermint_description": {
+    "text": "דורש אימות דומיין"
+  },
+  "web.domains.email.provider_inherit_description": {
+    "text": "משתמש בתצורת שליחת הדואר האלקטרוני שהיא ברירת המחדל של חשבונך"
+  },
+  "web.domains.email.dns_records_title": {
+    "text": "רשומות DNS"
+  },
+  "web.domains.email.dns_records_description": {
+    "text": "הוסף את רשומות ה-DNS הבאות כדי לאמת את הדומיין שלך לשליחת דואר אלקטרוני."
+  },
+  "web.domains.email.dns_column_type": {
+    "text": "סוג"
+  },
+  "web.domains.email.dns_column_name": {
+    "text": "שם"
+  },
+  "web.domains.email.dns_column_value": {
+    "text": "ערך"
+  },
+  "web.domains.email.dns_check_label": {
+    "text": "DNS"
+  },
+  "web.domains.email.provider_check_label": {
+    "text": "ספק"
+  },
+  "web.domains.email.dns_optional_label": {
+    "text": "מומלץ"
+  },
+  "web.domains.email.dns_optional_hint": {
+    "text": "רשומה זו מומלצת אך אינה נדרשת לאימות. ייתכן שמדיניות DMARC בדומיין הארגוני שלך כבר מכסה תת-דומיין זה."
+  },
+  "web.domains.email.copy": {
+    "text": "העתק"
+  },
+  "web.domains.email.copied": {
+    "text": "הועתק"
+  },
+  "web.domains.email.status_verified": {
+    "text": "אומת"
+  },
+  "web.domains.email.status_pending": {
+    "text": "ממתין"
+  },
+  "web.domains.email.status_failed": {
+    "text": "נכשל"
+  },
+  "web.domains.email.revalidate": {
+    "text": "אמת מחדש"
+  },
+  "web.domains.email.validating": {
+    "text": "מאמת..."
+  },
+  "web.domains.email.domain_verified": {
+    "text": "הדומיין אומת"
+  },
+  "web.domains.email.validation_failed": {
+    "text": "האימות נכשל"
+  },
+  "web.domains.email.last_validated": {
+    "text": "אומת לאחרונה"
+  },
+  "web.domains.email.upgrade_to_configure": {
+    "text": "שדרג את התוכנית שלך כדי להגדיר שליחת דואר אלקטרוני עבור דומיין זה."
+  },
+  "web.domains.email.configure_email": {
+    "text": "הגדר דואר אלקטרוני"
+  },
+  "web.domains.email.access_denied": {
+    "text": "הגישה נדחתה"
+  },
+  "web.domains.email.access_denied_description": {
+    "text": "אין לך הרשאה לנהל את הגדרות הדואר האלקטרוני עבור דומיין זה. פנה למנהל הארגון שלך."
+  },
+  "web.domains.email.update_success": {
+    "text": "תצורת הדואר האלקטרוני נשמרה בהצלחה"
+  },
+  "web.domains.email.delete_success": {
+    "text": "תצורת הדואר האלקטרוני הוסרה בהצלחה"
+  },
+  "web.domains.email.default_sender_notice": {
+    "text": "הודעות הדואר האלקטרוני עבור דומיין זה נשלחות כעת מהשולח הגלובלי. השלם את תצורת הדואר האלקטרוני כדי להשתמש בזהות השולח שלך."
+  },
+  "web.domains.email.disabled_notice": {
+    "text": "שליחת דואר אלקטרוני מותאם אישית מושבתת כעת. הודעות הדואר האלקטרוני יישלחו מהשולח הגלובלי. הפעל את התכונה למטה כדי להשתמש בזהות השולח המותאמת אישית שלך."
+  },
+  "web.domains.email.test_email_title": {
+    "text": "בדיקת מסירת דואר אלקטרוני"
+  },
+  "web.domains.email.test_email_hint": {
+    "text": "שלח לעצמך הודעת דואר אלקטרוני לבדיקה באמצעות התצורה השמורה. פועל גם כאשר התכונה עדיין אינה מופעלת."
+  },
+  "web.domains.email.send_test": {
+    "text": "שלח בדיקה"
+  },
+  "web.domains.email.test_email_sent": {
+    "text": "הודעת הבדיקה נשלחה בהצלחה"
+  },
+  "web.domains.email.test_email_failed": {
+    "text": "שליחת הודעת הבדיקה נכשלה"
+  },
+  "web.domains.email.test_email_sent_to": {
+    "text": "נשלח אל {email}"
+  },
+  "web.domains.email.delivered_via": {
+    "text": "נמסר באמצעות {provider}"
+  },
+  "web.domains.email.badge_not_configured": {
+    "text": "לא מוגדר"
+  },
+  "web.domains.email.badge_default_sender": {
+    "text": "משתמש בשולח ברירת המחדל"
+  },
+  "web.domains.email.badge_verified": {
+    "text": "אומת"
+  },
+  "web.domains.email.badge_pending": {
+    "text": "ממתין לאימות"
+  },
+  "web.domains.email.badge_disabled": {
+    "text": "מושבת"
+  },
+  "web.domains.email.tooltip_not_configured": {
+    "text": "לא הוגדר שולח דואר אלקטרוני — ההודעות משתמשות בשולח ברירת המחדל של הפלטפורמה"
+  },
+  "web.domains.email.tooltip_pending": {
+    "text": "תצורת שולח הדואר האלקטרוני ממתינה לאימות — ההודעות משתמשות בשולח ברירת המחדל של הפלטפורמה"
+  },
+  "web.domains.email.tooltip_disabled": {
+    "text": "שולח הדואר האלקטרוני מושבת — ההודעות משתמשות בשולח ברירת המחדל של הפלטפורמה"
+  },
+  "web.domains.email.tooltip_verified": {
+    "text": "שולח הדואר האלקטרוני אומת — ההודעות נשלחות מדומיין זה"
+  },
+  "web.domains.incoming.title": {
+    "text": "סודות נכנסים"
+  },
+  "web.domains.incoming.config_title": {
+    "text": "תצורת סודות נכנסים"
+  },
+  "web.domains.incoming.config_description": {
+    "text": "אפשר למשתמשים חיצוניים לשלוח סודות ישירות לנמענים ייעודיים בדומיין זה"
+  },
+  "web.domains.incoming.feature_disabled": {
+    "text": "סודות נכנסים אינם זמינים"
+  },
+  "web.domains.incoming.feature_disabled_description": {
+    "text": "סודות נכנסים אינם מופעלים במופע זה. פנה למנהל שלך."
+  },
+  "web.domains.incoming.access_denied": {
+    "text": "הגישה נדחתה"
+  },
+  "web.domains.incoming.access_denied_description": {
+    "text": "אין לך הרשאה לנהל את הגדרות הסודות הנכנסים עבור דומיין זה. פנה למנהל הארגון שלך."
+  },
+  "web.domains.incoming.upgrade_to_configure": {
+    "text": "שדרג את התוכנית שלך כדי להגדיר סודות נכנסים עבור דומיין זה."
+  },
+  "web.domains.incoming.configure_incoming": {
+    "text": "הגדר סודות נכנסים"
+  },
+  "web.domains.incoming.not_configured_notice": {
+    "text": "סודות נכנסים אינם מוגדרים עבור דומיין זה. הוסף נמענים כדי לאפשר למשתמשים חיצוניים לשלוח סודות לצוות שלך."
+  },
+  "web.domains.incoming.disabled_notice": {
+    "text": "סודות נכנסים מושבתים כעת. משתמשים חיצוניים אינם יכולים לשלוח סודות לנמענים בדומיין זה. הפעל את התכונה למטה כדי לאפשר סודות נכנסים."
+  },
+  "web.domains.incoming.recipients_title": {
+    "text": "נמענים"
+  },
+  "web.domains.incoming.recipients_description": {
+    "text": "הגדר מי יכול לקבל סודות נכנסים בדומיין זה. הנמענים יקבלו התראות בדואר אלקטרוני כאשר נשלח אליהם סוד."
+  },
+  "web.domains.incoming.add_recipient": {
+    "text": "הוסף נמען"
+  },
+  "web.domains.incoming.remove_recipient": {
+    "text": "הסר"
+  },
+  "web.domains.incoming.email_label": {
+    "text": "כתובת דואר אלקטרוני"
+  },
+  "web.domains.incoming.email_placeholder": {
+    "text": "recipient{'@'}example.com"
+  },
+  "web.domains.incoming.name_label": {
+    "text": "שם תצוגה"
+  },
+  "web.domains.incoming.name_placeholder": {
+    "text": "לדוגמה Security Team"
+  },
+  "web.domains.incoming.empty_state": {
+    "text": "לא הוגדרו נמענים"
+  },
+  "web.domains.incoming.empty_state_description": {
+    "text": "הוסף נמענים כדי לאפשר למשתמשים חיצוניים לשלוח סודות לצוות שלך."
+  },
+  "web.domains.incoming.validation_invalid_email": {
+    "text": "כתובת דואר אלקטרוני לא תקינה"
+  },
+  "web.domains.incoming.validation_duplicate_email": {
+    "text": "כתובת דואר אלקטרוני זו כבר נוספה"
+  },
+  "web.domains.incoming.validation_max_recipients": {
+    "text": "מותר עד {max} נמענים"
+  },
+  "web.domains.incoming.validation_name_required": {
+    "text": "שם תצוגה הוא שדה חובה"
+  },
+  "web.domains.incoming.validation_email_required": {
+    "text": "כתובת דואר אלקטרוני היא שדה חובה"
+  },
+  "web.domains.incoming.save_changes": {
+    "text": "שמור שינויים"
+  },
+  "web.domains.incoming.discard_changes": {
+    "text": "בטל שינויים"
+  },
+  "web.domains.incoming.update_success": {
+    "text": "תצורת הסודות הנכנסים נשמרה בהצלחה"
+  },
+  "web.domains.incoming.delete_success": {
+    "text": "תצורת הסודות הנכנסים הוסרה בהצלחה"
+  },
+  "web.domains.incoming.recipient_count": {
+    "text": "נמען {count} | {count} נמענים"
+  },
+  "web.domains.incoming.badge_not_configured": {
+    "text": "לא מוגדר"
+  },
+  "web.domains.incoming.badge_configured": {
+    "text": "מוגדר"
+  },
+  "web.domains.incoming.badge_disabled": {
+    "text": "מושבת"
+  },
+  "web.domains.incoming.tooltip_not_configured": {
+    "text": "סודות נכנסים אינם מוגדרים - משתמשים חיצוניים אינם יכולים לשלוח סודות לדומיין זה"
+  },
+  "web.domains.incoming.tooltip_configured": {
+    "text": "סודות נכנסים מופעלים עם {count} נמענים"
+  },
+  "web.domains.incoming.tooltip_disabled": {
+    "text": "תכונת הסודות הנכנסים מושבתת עבור דומיין זה"
+  },
+  "web.domains.incoming.enabled_label": {
+    "text": "הפעל סודות נכנסים"
+  },
+  "web.domains.incoming.enabled_hint": {
+    "text": "אפשר למשתמשים חיצוניים לשלוח סודות לנמענים בדומיין זה"
+  },
+  "web.domains.incoming.public_url_label": {
+    "text": "כתובת URL ציבורית"
+  },
+  "web.domains.incoming.public_url_description": {
+    "text": "שתף כתובת URL זו עם משתמשים חיצוניים כדי לאפשר להם לשלוח סודות"
+  },
+  "web.domains.incoming.copy_url": {
+    "text": "העתק כתובת URL"
+  },
+  "web.domains.incoming.url_copied": {
+    "text": "כתובת ה-URL הועתקה ללוח"
+  },
+  "web.domains.incoming.remove_all_confirmation": {
+    "text": "האם אתה בטוח שברצונך להסיר את כל הנמענים? משתמשים חיצוניים לא יוכלו עוד לשלוח סודות לדומיין זה."
+  },
+  "web.domains.incoming.max_recipients_reached": {
+    "text": "הגעת למספר המרבי של נמענים"
+  },
+  "web.domains.incoming.duplicate_recipient": {
+    "text": "כתובת דואר אלקטרוני זו כבר נוספה"
+  },
+  "web.domains.incoming.save_will_replace_confirmation": {
+    "text": "השמירה תחליף את כל הנמענים הקיימים בשינויים הממתינים שלך. האם אתה בטוח?"
+  },
+  "web.domains.incoming.delete_all_recipients": {
+    "text": "מחק את כל הנמענים"
+  },
+  "web.domains.signin.title": {
+    "text": "תצורת כניסה"
+  },
+  "web.domains.signin.configure_signin": {
+    "text": "הגדר כניסה"
+  },
+  "web.domains.signin.config_description": {
+    "text": "הגדר שיטות אימות כניסה עבור דומיין זה"
+  },
+  "web.domains.signin.access_denied": {
+    "text": "הגישה נדחתה"
+  },
+  "web.domains.signin.upgrade_to_configure": {
+    "text": "שדרג את התוכנית שלך כדי להגדיר שיטות כניסה עבור דומיין זה."
+  },
+  "web.domains.signin.not_configured_notice": {
+    "text": "תצורת הכניסה עדיין לא הוגדרה עבור דומיין זה. הגדר עקיפות כדי לשלוט אילו שיטות אימות זמינות בדף הכניסה של דומיין זה."
+  },
+  "web.domains.signin.signin_enabled_label": {
+    "text": "כניסה מופעלת"
+  },
+  "web.domains.signin.header_toggle_label": {
+    "text": "כניסה"
+  },
+  "web.domains.signin.signin_enabled_hint": {
+    "text": "האם משתמשים יכולים להיכנס בדומיין זה"
+  },
+  "web.domains.signin.restrict_to_label": {
+    "text": "הגבל שיטת כניסה"
+  },
+  "web.domains.signin.restrict_to_hint": {
+    "text": "הגבל דומיין זה לשיטת אימות אחת. כאשר מוגדר, רק השיטה הנבחרת מוצגת בדף הכניסה."
+  },
+  "web.domains.signin.all_methods": {
+    "text": "כל השיטות"
+  },
+  "web.domains.signin.all_methods_description": {
+    "text": "הצג את כל שיטות האימות המופעלות בדף הכניסה"
+  },
+  "web.domains.signin.method_password": {
+    "text": "סיסמה"
+  },
+  "web.domains.signin.method_email_auth": {
+    "text": "אימות בדואר אלקטרוני"
+  },
+  "web.domains.signin.method_webauthn": {
+    "text": "WebAuthn / מפתחות גישה"
+  },
+  "web.domains.signin.method_sso": {
+    "text": "כניסה יחידה (SSO)"
+  },
+  "web.domains.signin.method_overrides_label": {
+    "text": "עקיפות שיטה"
+  },
+  "web.domains.signin.method_overrides_hint": {
+    "text": "הפעל או השבת שיטות אימות בודדות עבור דומיין זה"
+  },
+  "web.domains.signin.mode_question": {
+    "text": "כיצד משתמשים יכולים להיכנס?"
+  },
+  "web.domains.signin.mode_any": {
+    "text": "כל שיטה זמינה"
+  },
+  "web.domains.signin.mode_any_hint": {
+    "text": "הצג כל שיטה הזמינה בדומיין זה. צמצם שיטות בודדות למטה."
+  },
+  "web.domains.signin.mode_one": {
+    "text": "שיטה ספציפית אחת"
+  },
+  "web.domains.signin.mode_one_hint": {
+    "text": "הגבל את דף הכניסה לשיטה אחת. רק שיטות הזמינות בדומיין זה מוצגות."
+  },
+  "web.domains.signin.mode_disabled": {
+    "text": "כניסה מושבתת"
+  },
+  "web.domains.signin.mode_disabled_hint": {
+    "text": "משתמשים אינם יכולים להיכנס בדומיין זה."
+  },
+  "web.domains.signin.mode_disabled_notice": {
+    "text": "מבקרים בדף הכניסה של דומיין זה רואים הודעה שהכניסה אינה זמינה, עם קישור חזרה לדף הבית. הגדרות השיטה הקודמות שלך נשמרות ומשוחזרות כאשר תפעיל מחדש את הכניסה."
+  },
+  "web.domains.signin.methods_list_label": {
+    "text": "שיטות המוצגות בדף הכניסה"
+  },
+  "web.domains.signin.restrict_picker_hint": {
+    "text": "רק שיטות הזמינות בדומיין זה מוצגות."
+  },
+  "web.domains.signin.availability_always": {
+    "text": "זמין תמיד"
+  },
+  "web.domains.signin.availability_global_on": {
+    "text": "עוקב אחר מדיניות גלובלית · מופעל"
+  },
+  "web.domains.signin.availability_global_off": {
+    "text": "לא זמין"
+  },
+  "web.domains.signin.availability_unavailable": {
+    "text": "לא זמין בכל האתר"
+  },
+  "web.domains.signin.allow_on_domain": {
+    "text": "אפשר בדומיין זה"
+  },
+  "web.domains.signin.method_password_blurb": {
+    "text": "סיסמה בלבד"
+  },
+  "web.domains.signin.method_email_auth_blurb": {
+    "text": "כניסה ללא סיסמה באמצעות קישור קסם"
+  },
+  "web.domains.signin.method_webauthn_blurb": {
+    "text": "אמצעים ביומטריים ומפתחות אבטחה"
+  },
+  "web.domains.signin.method_sso_blurb": {
+    "text": "ספק זהויות חיצוני"
+  },
+  "web.domains.signin.email_auth_label": {
+    "text": "אימות בדואר אלקטרוני"
+  },
+  "web.domains.signin.email_auth_hint": {
+    "text": "אפשר אימות בדואר אלקטרוני ללא סיסמה בדומיין זה"
+  },
+  "web.domains.signin.sso_enabled_label": {
+    "text": "כניסה יחידה (SSO)"
+  },
+  "web.domains.signin.sso_enabled_hint": {
+    "text": "אפשר אימות SSO בדומיין זה"
+  },
+  "web.domains.signin.enabled_label": {
+    "text": "הפעל תצורת כניסה"
+  },
+  "web.domains.signin.enabled_hint": {
+    "text": "כאשר מופעל, דומיין זה משתמש בהגדרות הכניסה שהוגדרו למעלה"
+  },
+  "web.domains.signin.save_config": {
+    "text": "שמור תצורה"
+  },
+  "web.domains.signin.update_success": {
+    "text": "תצורת הכניסה עודכנה בהצלחה"
+  },
+  "web.domains.signin.reset_to_defaults": {
+    "text": "אפס לברירות המחדל"
+  },
+  "web.domains.signin.reset_confirm": {
+    "text": "לאפס את הכניסה לברירות המחדל הגלובליות?"
+  },
+  "web.domains.signin.reset_keeps_sso": {
+    "text": "פרטי הכניסה של SSO שלך נשמרים. הסר אותם בנפרד במסך תצורת SSO."
+  },
+  "web.domains.signin.reset_action": {
+    "text": "כן, אפס"
+  },
+  "web.domains.signin.reset_success": {
+    "text": "הגדרות הכניסה אופסו לברירות המחדל הגלובליות"
+  },
+  "web.domains.signup.title": {
+    "text": "אימות הרשמה"
+  },
+  "web.domains.signup.config_description": {
+    "text": "הגדר אימות הרשמה עבור דומיין זה"
+  },
+  "web.domains.signup.access_denied": {
+    "text": "הגישה נדחתה"
+  },
+  "web.domains.signup.upgrade_to_configure": {
+    "text": "שדרג את התוכנית שלך כדי להגדיר אימות הרשמה לכל דומיין."
+  },
+  "web.domains.signup.configure_signup": {
+    "text": "הגדר הרשמה"
+  },
+  "web.domains.signup.not_configured_notice": {
+    "text": "אימות הרשמה עדיין לא הוגדר עבור דומיין זה. הגדר אסטרטגיה כדי לשלוט מי יכול להירשם דרך דומיין זה."
+  },
+  "web.domains.signup.site_signups_disabled_warning": {
+    "text": "ההרשמות מושבתות כעת ברמת האתר. מדיניות זו לכל דומיין מוגדרת אך לא תסנן תעבורה כלשהי עד שההרשמות באתר יופעלו."
+  },
+  "web.domains.signup.strategy_label": {
+    "text": "אסטרטגיית אימות"
+  },
+  "web.domains.signup.strategy_description": {
+    "text": "בחר כיצד מאומתות כתובות דואר אלקטרוני כאשר משתמשים נרשמים בדומיין זה."
+  },
+  "web.domains.signup.network_validation_warning": {
+    "text": "אסטרטגיה זו מבצעת קריאות רשת במהלך ההרשמה, מה שעלול להוסיף השהיה או להיחסם על ידי ספקים מסוימים."
+  },
+  "web.domains.signup.allowed_domains_label": {
+    "text": "דומיינים מורשים להרשמה"
+  },
+  "web.domains.signup.allowed_domains_hint": {
+    "text": "רק דומייני הדואר האלקטרוני האלה יורשו להירשם. הוסף דומיין אחד לכל ערך."
+  },
+  "web.domains.signup.domain_placeholder": {
+    "text": "example.com"
+  },
+  "web.domains.signup.invalid_domain": {
+    "text": "הזן דומיין תקין (לדוגמה example.com)"
+  },
+  "web.domains.signup.domain_exists": {
+    "text": "דומיין זה כבר נמצא ברשימה"
+  },
+  "web.domains.signup.remove_domain": {
+    "text": "הסר את {domain}"
+  },
+  "web.domains.signup.enabled_label": {
+    "text": "הפעל אימות לכל דומיין"
+  },
+  "web.domains.signup.enabled_hint": {
+    "text": "כאשר מופעל, הרשמות בדומיין זה משתמשות באסטרטגיה שלמעלה במקום במדיניות הגלובלית."
+  },
+  "web.domains.signup.delete_config": {
+    "text": "מחק תצורה"
+  },
+  "web.domains.signup.delete_confirm": {
+    "text": "למחוק את תצורת אימות ההרשמה? ההרשמות יחזרו למדיניות הגלובלית."
+  },
+  "web.domains.signup.save_config": {
+    "text": "שמור תצורה"
+  },
+  "web.domains.signup.update_success": {
+    "text": "אימות ההרשמה עודכן בהצלחה"
+  },
+  "web.domains.signup.delete_success": {
+    "text": "תצורת אימות ההרשמה הוסרה בהצלחה"
+  },
+  "web.domains.signup.domain_overrides_label": {
+    "text": "עקיפות דומיין"
+  },
+  "web.domains.signup.domain_overrides_hint": {
+    "text": "עקוף את הגדרות ההרשמה הגלובליות עבור דומיין זה"
+  },
+  "web.domains.signup.signup_enabled_label": {
+    "text": "הרשמה מופעלת"
+  },
+  "web.domains.signup.signup_enabled_hint": {
+    "text": "עקוף האם ההרשמה מופעלת עבור דומיין זה"
+  },
+  "web.domains.signup.autoverify_label": {
+    "text": "אמת חשבונות אוטומטית"
+  },
+  "web.domains.signup.autoverify_hint": {
+    "text": "עקוף האם חשבונות חדשים מאומתים אוטומטית בדומיין זה"
+  },
+  "web.domains.sso.title": {
+    "text": "כניסה יחידה (SSO)"
+  },
+  "web.domains.sso.config_title": {
+    "text": "תצורת SSO"
+  },
+  "web.domains.sso.config_description": {
+    "text": "הגדר אימות כניסה יחידה עבור דומיין זה"
+  },
+  "web.domains.sso.access_denied": {
+    "text": "הגישה נדחתה"
+  },
+  "web.domains.sso.access_denied_description": {
+    "text": "אין לך הרשאה לנהל את הגדרות ה-SSO עבור דומיין זה. פנה למנהל הארגון שלך."
+  },
+  "web.domains.sso.upgrade_to_configure": {
+    "text": "שדרג את התוכנית שלך כדי להגדיר כניסה יחידה עבור דומיין זה."
+  },
+  "web.domains.sso.create_success": {
+    "text": "תצורת ה-SSO נוצרה בהצלחה"
+  },
+  "web.domains.sso.update_success": {
+    "text": "תצורת ה-SSO עודכנה בהצלחה"
+  },
+  "web.domains.sso.delete_success": {
+    "text": "תצורת ה-SSO הוסרה בהצלחה"
+  },
+  "web.domains.sso.test_success": {
+    "text": "בדיקת החיבור הצליחה — הספק הגיב כראוי"
+  },
+  "web.domains.sso.test_failed": {
+    "text": "בדיקת החיבור נכשלה"
+  },
+  "web.domains.sso.enforce_moved_notice": {
+    "text": "כדי לחייב SSO לכל הכניסות בדומיין זה, הגדר זאת בהגדרות הכניסה של הדומיין. מצב SSO-בלבד מגביל את דף הכניסה לספק ה-SSO שהוגדר כאן."
+  },
+  "web.domains.sso.configure_sso": {
+    "text": "הגדר SSO"
+  },
+  "web.domains.sso.not_configured_notice": {
+    "text": "SSO עדיין לא הוגדר עבור דומיין זה. הפעל כניסה יחידה כדי לאפשר לחברי הצוות לבצע אימות באמצעות ספק הזהויות של הארגון שלך."
+  },
+  "web.domains.sso.edit_credentials": {
+    "text": "ערוך פרטי כניסה"
+  },
+  "web.domains.sso.configure_button": {
+    "text": "הגדר"
+  },
+  "web.domains.sso.upgrade_required": {
+    "text": "שדרג כדי להגדיר"
   }
 }

--- a/locales/content/he/workspace-organizations.json
+++ b/locales/content/he/workspace-organizations.json
@@ -578,5 +578,344 @@
   "web.organizations.invitations.expires_soon": {
     "text": "פג תוקף בקרוב",
     "source_hash": "a5dcfef9"
+  },
+  "api.organizations.errors.not_found": {
+    "text": "הארגון לא נמצא: %{extid}"
+  },
+  "api.organizations.errors.owner_required": {
+    "text": "רק בעל הארגון יכול לבצע פעולה זו"
+  },
+  "api.organizations.errors.admin_required": {
+    "text": "רק בעלי ארגון ומנהלים יכולים לבצע פעולה זו"
+  },
+  "api.organizations.errors.member_required": {
+    "text": "עליך להיות חבר בארגון כדי לבצע פעולה זו"
+  },
+  "api.organizations.invitations.errors.create_admin_required": {
+    "text": "רק בעלי ארגון ומנהלים יכולים ליצור הזמנות"
+  },
+  "api.organizations.invitations.errors.resend_admin_required": {
+    "text": "רק בעלי ארגון ומנהלים יכולים לשלוח הזמנות מחדש"
+  },
+  "api.organizations.invitations.errors.view_admin_required": {
+    "text": "רק בעלי ארגון ומנהלים יכולים לצפות בהזמנות"
+  },
+  "api.organizations.invitations.errors.revoke_admin_required": {
+    "text": "רק בעלי ארגון ומנהלים יכולים לבטל הזמנות"
+  },
+  "api.organizations.invitations.errors.email_required": {
+    "text": "דואר אלקטרוני הוא שדה חובה"
+  },
+  "api.organizations.invitations.errors.email_invalid": {
+    "text": "תבנית דואר אלקטרוני לא תקינה"
+  },
+  "api.organizations.invitations.errors.role_invalid": {
+    "text": "התפקיד חייב להיות חבר או מנהל"
+  },
+  "api.organizations.invitations.errors.cannot_invite_owner": {
+    "text": "לא ניתן להזמין כבעלים"
+  },
+  "api.organizations.invitations.errors.already_member": {
+    "text": "המשתמש כבר חבר בארגון זה"
+  },
+  "api.organizations.invitations.errors.already_pending": {
+    "text": "כבר קיימת הזמנה ממתינה עבור כתובת דואר אלקטרוני זו"
+  },
+  "api.organizations.invitations.errors.member_limit_reached": {
+    "text": "הגעת למגבלת החברים. שדרג את התוכנית שלך כדי להזמין חברים נוספים."
+  },
+  "api.organizations.invitations.errors.not_found": {
+    "text": "ההזמנה לא נמצאה"
+  },
+  "api.organizations.invitations.errors.cannot_resend_non_pending": {
+    "text": "ניתן לשלוח מחדש רק הזמנות ממתינות"
+  },
+  "api.organizations.invitations.errors.cannot_revoke_non_pending": {
+    "text": "ניתן לבטל רק הזמנות ממתינות"
+  },
+  "api.organizations.invitations.errors.resend_limit_reached": {
+    "text": "הגעת למגבלת השליחה המרבית מחדש (%{max})"
+  },
+  "api.organizations.invitations.errors.accept_token_required": {
+    "text": "אסימון הוא שדה חובה"
+  },
+  "api.organizations.invitations.errors.accept_organization_gone": {
+    "text": "הארגון כבר אינו קיים"
+  },
+  "api.organizations.invitations.errors.accept_already_acted": {
+    "text": "ההזמנה כבר %{status}"
+  },
+  "api.organizations.invitations.errors.accept_expired": {
+    "text": "תוקף ההזמנה פג"
+  },
+  "api.organizations.invitations.errors.accept_email_mismatch": {
+    "text": "כתובת הדואר האלקטרוני שלך אינה תואמת להזמנה"
+  },
+  "api.organizations.invitations.errors.accept_already_member": {
+    "text": "אתה כבר חבר בארגון זה"
+  },
+  "web.organizations.entitlements_title": {
+    "text": "הרשאות הארגון"
+  },
+  "web.organizations.page_description_short": {
+    "text": "צפה והגדר את מרחבי העבודה שלך"
+  },
+  "web.organizations.delete_organization_remove_domains_first": {
+    "text": "הסר את כל הדומיינים המותאמים אישית לפני מחיקת ארגון זה."
+  },
+  "web.organizations.default_org_delete_notice_title": {
+    "text": "מחיקת ארגון זה"
+  },
+  "web.organizations.default_org_delete_notice_before": {
+    "text": "זהו ארגון ברירת המחדל שלך ולא ניתן להסירו מלוח הבקרה. כדי למחוק אותו, פנה אלינו באמצעות"
+  },
+  "web.organizations.default_org_delete_notice_link": {
+    "text": "טופס המשוב"
+  },
+  "web.organizations.default_org_delete_notice_after": {
+    "text": "."
+  },
+  "web.organizations.leave_organization": {
+    "text": "עזוב ארגון זה"
+  },
+  "web.organizations.leave_organization_warning": {
+    "text": "תאבד את הגישה לארגון זה ולמשאביו."
+  },
+  "web.organizations.leave_organization_confirm_title": {
+    "text": "עזיבת ארגון"
+  },
+  "web.organizations.leave_organization_confirm_message": {
+    "text": "האם אתה בטוח שברצונך לעזוב את {name}? תזדקק להזמנה חדשה כדי להצטרף מחדש."
+  },
+  "web.organizations.leave_organization_success": {
+    "text": "עזבת את הארגון."
+  },
+  "web.organizations.leave_error": {
+    "text": "עזיבת הארגון נכשלה"
+  },
+  "web.organizations.organizations": {
+    "text": "ארגונים"
+  },
+  "web.organizations.invitations.invited_by_inline": {
+    "text": "על ידי {email}"
+  },
+  "web.organizations.invitations.invited_as_inline": {
+    "text": "בתפקיד {role}"
+  },
+  "web.organizations.invitations.back_to_home": {
+    "text": "חזרה לדף הבית"
+  },
+  "web.organizations.invitations.email_locked_hint": {
+    "text": "הזמנה זו נשלחה לכתובת דואר אלקטרוני זו"
+  },
+  "web.organizations.invitations.signup_continue": {
+    "text": "המשך"
+  },
+  "web.organizations.invitations.signin_continue": {
+    "text": "התחברות"
+  },
+  "web.organizations.invitations.confirm_join_below": {
+    "text": "כמעט סיימת — אשר למטה כדי להצטרף לארגון."
+  },
+  "web.organizations.invitations.go_to_organizations": {
+    "text": "עבור לארגונים"
+  },
+  "web.organizations.invitations.already_member": {
+    "text": "אתה כבר חבר בארגון זה"
+  },
+  "web.organizations.invitations.join_organization": {
+    "text": "הצטרף אל {orgName}"
+  },
+  "web.organizations.invitations.sign_in_to_join": {
+    "text": "התחבר כדי להצטרף אל {orgName}"
+  },
+  "web.organizations.invitations.decline": {
+    "text": "דחה"
+  },
+  "web.organizations.members.member_quota": {
+    "text": "{used} מתוך {limit} חברים"
+  },
+  "web.organizations.members.pending_suffix": {
+    "text": "({count} ממתינים)"
+  },
+  "web.organizations.members.limit_reached_hint": {
+    "text": "הגעת למגבלת החברים."
+  },
+  "web.organizations.sso.title": {
+    "text": "כניסה יחידה (SSO)"
+  },
+  "web.organizations.sso.description": {
+    "text": "הגדר SSO כדי לאפשר לחברים להיכנס באמצעות ספק הזהויות של הארגון שלך"
+  },
+  "web.organizations.sso.provider_type": {
+    "text": "סוג ספק"
+  },
+  "web.organizations.sso.provider_type_description": {
+    "text": "בחר את ספק הזהויות של הארגון שלך"
+  },
+  "web.organizations.sso.display_name": {
+    "text": "שם תצוגה"
+  },
+  "web.organizations.sso.display_name_hint": {
+    "text": "שם ידידותי המוצג למשתמשים בעת הכניסה"
+  },
+  "web.organizations.sso.display_name_placeholder": {
+    "text": "לדוגמה Acme Corp SSO"
+  },
+  "web.organizations.sso.client_id": {
+    "text": "Client ID"
+  },
+  "web.organizations.sso.client_id_placeholder": {
+    "text": "ה-Client ID של OAuth שלך"
+  },
+  "web.organizations.sso.client_secret": {
+    "text": "Client Secret"
+  },
+  "web.organizations.sso.client_secret_placeholder": {
+    "text": "ה-Client Secret של OAuth שלך"
+  },
+  "web.organizations.sso.client_secret_update_hint": {
+    "text": "השאר ריק כדי לשמור על הסוד הקיים"
+  },
+  "web.organizations.sso.tenant_id": {
+    "text": "Tenant ID"
+  },
+  "web.organizations.sso.tenant_id_hint": {
+    "text": "מזהה ה-tenant של Azure AD / Entra ID שלך"
+  },
+  "web.organizations.sso.tenant_id_placeholder": {
+    "text": "לדוגמה 12345678-1234-1234-1234-123456789abc"
+  },
+  "web.organizations.sso.issuer": {
+    "text": "Issuer URL"
+  },
+  "web.organizations.sso.issuer_hint": {
+    "text": "כתובת ה-URL לגילוי OIDC של ספק הזהויות שלך"
+  },
+  "web.organizations.sso.issuer_placeholder": {
+    "text": "לדוגמה https://login.example.com"
+  },
+  "web.organizations.sso.view_discovery_document": {
+    "text": "הצג מסמך גילוי"
+  },
+  "web.organizations.sso.callback_url": {
+    "text": "Callback URL"
+  },
+  "web.organizations.sso.callback_url_hint": {
+    "text": "הוסף כתובת URL זו לכתובות ההפניה המורשות של ספק הזהויות שלך"
+  },
+  "web.organizations.sso.allowed_domains": {
+    "text": "דומייני דואר אלקטרוני מורשים"
+  },
+  "web.organizations.sso.allowed_domains_hint": {
+    "text": "רק משתמשים עם כתובות דואר אלקטרוני מדומיינים אלה יכולים להיכנס. השאר ריק כדי לאפשר את כל הדומיינים."
+  },
+  "web.organizations.sso.domain_placeholder": {
+    "text": "לדוגמה acme.com"
+  },
+  "web.organizations.sso.invalid_domain": {
+    "text": "הזן דומיין תקין (לדוגמה example.com)"
+  },
+  "web.organizations.sso.domain_exists": {
+    "text": "דומיין זה כבר נמצא ברשימה"
+  },
+  "web.organizations.sso.remove_domain": {
+    "text": "הסר את {domain}"
+  },
+  "web.organizations.sso.enabled": {
+    "text": "הפעל SSO"
+  },
+  "web.organizations.sso.enabled_hint": {
+    "text": "כאשר מופעל, חברי הארגון יכולים להיכנס באמצעות ספק SSO זה"
+  },
+  "web.organizations.sso.enforce_sso_only": {
+    "text": "אכוף SSO בלבד"
+  },
+  "web.organizations.sso.enforce_sso_only_hint": {
+    "text": "חייב SSO לכל הכניסות בדומיין זה. כאשר מופעל, אימות מבוסס סיסמה מושבת."
+  },
+  "web.organizations.sso.grant_org_scope": {
+    "text": "הענק גישה לכל הארגון"
+  },
+  "web.organizations.sso.grant_org_scope_hint": {
+    "text": "חברים חדשים שמצטרפים באמצעות ה-SSO של דומיין זה יקבלו גישה לכל דומייני הארגון. חברים קיימים אינם מושפעים. כאשר מושבת (ברירת מחדל), חברים חדשים יכולים לגשת רק לדומיין זה."
+  },
+  "web.organizations.sso.save_config": {
+    "text": "שמור תצורת SSO"
+  },
+  "web.organizations.sso.delete_config": {
+    "text": "מחק תצורה"
+  },
+  "web.organizations.sso.delete_confirm": {
+    "text": "האם אתה בטוח? פעולה זו תשבית את ה-SSO עבור הארגון שלך."
+  },
+  "web.organizations.sso.load_error": {
+    "text": "טעינת תצורת ה-SSO נכשלה"
+  },
+  "web.organizations.sso.save_error": {
+    "text": "שמירת תצורת ה-SSO נכשלה"
+  },
+  "web.organizations.sso.create_success": {
+    "text": "תצורת ה-SSO נוצרה בהצלחה"
+  },
+  "web.organizations.sso.update_success": {
+    "text": "תצורת ה-SSO עודכנה בהצלחה"
+  },
+  "web.organizations.sso.delete_success": {
+    "text": "תצורת ה-SSO נמחקה בהצלחה"
+  },
+  "web.organizations.sso.delete_error": {
+    "text": "מחיקת תצורת ה-SSO נכשלה"
+  },
+  "web.organizations.sso.test_connection": {
+    "text": "בדוק חיבור"
+  },
+  "web.organizations.sso.test_connection_hint": {
+    "text": "ודא שספק הזהויות נגיש (אינו מאמת פרטי כניסה)"
+  },
+  "web.organizations.sso.test_button": {
+    "text": "בדוק חיבור"
+  },
+  "web.organizations.sso.testing": {
+    "text": "בודק..."
+  },
+  "web.organizations.sso.test_error": {
+    "text": "בדיקת החיבור נכשלה"
+  },
+  "web.organizations.sso.auth_endpoint": {
+    "text": "נקודת קצה לאישור"
+  },
+  "web.organizations.sso.missing_fields": {
+    "text": "שדות חסרים"
+  },
+  "web.organizations.sso.status_enabled": {
+    "text": "מופעל"
+  },
+  "web.organizations.sso.status_configured": {
+    "text": "מוגדר"
+  },
+  "web.organizations.sso.domain_sso_title": {
+    "text": "SSO של דומיין"
+  },
+  "web.organizations.sso.domain_sso_description": {
+    "text": "הגדר SSO עבור כל דומיין מאומת"
+  },
+  "web.organizations.sso.provider_type_locked_hint": {
+    "text": "כדי לשנות ספק, מחק תחילה תצורה זו"
+  },
+  "web.organizations.sso.status_not_configured": {
+    "text": "לא מוגדר"
+  },
+  "web.organizations.sso.no_domains": {
+    "text": "אין דומיינים מאומתים"
+  },
+  "web.organizations.sso.no_domains_description": {
+    "text": "הוסף ואמת דומיין לפני הגדרת SSO עבורו."
+  },
+  "web.organizations.tabs.team": {
+    "text": "צוות"
+  },
+  "web.organizations.tabs.sso": {
+    "text": "SSO"
   }
 }


### PR DESCRIPTION
## `he` translation update

Automated export of completed **he** translations from the translation task DB.
Scope: `locales/content/he/` only — 26 file(s), +1845/-27.

✅ `i18n validate variables`: no variable mismatches.

---

### Local quality review

> Produced by a fresh, isolated `claude` review agent (model `claude-sonnet-5`, agent `saas-translator`) that read
> `locales/AGENT_TRANSLATION_PROTOCOL.md` and inspected this branch's diff before the PR was opened.

_Automated review did not complete (exit 124). Review this locale manually._

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
