### PR TITLE
i18n: update hu translations

### DIFF
--- a/locales/content/hu/00-common.json
+++ b/locales/content/hu/00-common.json
@@ -1299,7 +1299,7 @@
     "source_hash": "fc78d9cb"
   },
   "web.INSTRUCTION.phishing_warning": {
-    "text": "Mindig ellenőrizze, hogy a hivatalos {product_name} weboldalon van-e. A csalók néha hamis weboldalakat hoznak létre, amelyek pontosan úgy néznek ki, mint az {product_name}, hogy ellopják titkait. Az adathalász támadások elkerülése érdekében ellenőrizze a domain-t új linkek létrehozása előtt.",
+    "text": "Mindig ellenőrizze, hogy a hivatalos {product_name} weboldalon van-e. A csalók néha hamis weboldalakat hoznak létre, amelyek pontosan úgy néznek ki, mint az {product_name}, hogy ellopják titkait. Az adathalász támadások elkerülése érdekében ellenőrizze a régió domain-t új linkek létrehozása előtt.",
     "source_hash": "b588f5b2"
   },
   "web.pricing.title": {
@@ -1383,5 +1383,110 @@
     "text": "Frissítsen a további funkciók eléréséhez",
     "context": "Description shown for free plan users encouraging upgrade",
     "source_hash": "783f174c"
+  },
+  "api.errors.authentication_required": {
+    "text": "Hitelesítés szükséges"
+  },
+  "api.errors.sso_only_action_blocked": {
+    "text": "Ez a művelet nem érhető el csak SSO módban"
+  },
+  "web.COMMON.configure": {
+    "text": "Beállítás"
+  },
+  "web.COMMON.copy_to_clipboard": {
+    "text": "Másolás vágólapra"
+  },
+  "web.COMMON.add": {
+    "text": "Hozzáadás"
+  },
+  "web.COMMON.enabled": {
+    "text": "Engedélyezve"
+  },
+  "web.COMMON.disabled": {
+    "text": "Letiltva"
+  },
+  "web.COMMON.yes_delete": {
+    "text": "Igen, törlés"
+  },
+  "web.COMMON.error_code": {
+    "text": "Hibakód"
+  },
+  "web.COMMON.http_status": {
+    "text": "HTTP-állapot"
+  },
+  "web.COMMON.details": {
+    "text": "Részletek"
+  },
+  "web.COMMON.field_confirm_password": {
+    "text": "Jelszó megerősítése"
+  },
+  "web.COMMON.passwords_must_match": {
+    "text": "A jelszavaknak egyezniük kell"
+  },
+  "web.COMMON.and": {
+    "text": "és"
+  },
+  "web.COMMON.or": {
+    "text": "vagy"
+  },
+  "web.COMMON.copied": {
+    "text": "Másolva"
+  },
+  "web.COMMON.copy": {
+    "text": "Másolás"
+  },
+  "web.COMMON.copy_email": {
+    "text": "E-mail-cím másolása"
+  },
+  "web.COMMON.copy_id": {
+    "text": "Fiókazonosító másolása"
+  },
+  "web.COMMON.org_id_tooltip": {
+    "text": "A szervezet egyedi azonosítója"
+  },
+  "web.COMMON.success": {
+    "text": "Sikeres"
+  },
+  "web.COMMON.need_help": {
+    "text": "Segítségre van szüksége"
+  },
+  "web.COMMON.open_help_dialog": {
+    "text": "Súgóablak megnyitása"
+  },
+  "web.COMMON.focus_is_now_in_the_main_text_area": {
+    "text": "A fókusz most a fő szövegmezőn van"
+  },
+  "web.LABELS.show_passphrase": {
+    "text": "Hozzáférési mondat megjelenítése"
+  },
+  "web.LABELS.hide_passphrase": {
+    "text": "Hozzáférési mondat elrejtése"
+  },
+  "web.LABELS.copy_icon": {
+    "text": "Másolás ikon"
+  },
+  "web.LABELS.copied_icon": {
+    "text": "Másolva ikon"
+  },
+  "web.STATUS.unverified": {
+    "text": "Nem ellenőrzött"
+  },
+  "web.TITLES.domain_detail": {
+    "text": "Doménbeállítások"
+  },
+  "web.TITLES.domain_signin": {
+    "text": "Bejelentkezési konfiguráció"
+  },
+  "web.TITLES.domain_sso": {
+    "text": "Domén SSO"
+  },
+  "web.TITLES.domain_signup": {
+    "text": "Domén regisztrációs ellenőrzés"
+  },
+  "web.TITLES.domain_email": {
+    "text": "E-mail-konfiguráció"
+  },
+  "web.TITLES.domain_incoming": {
+    "text": "Bejövő titkok"
   }
 }

--- a/locales/content/hu/10-layout.json
+++ b/locales/content/hu/10-layout.json
@@ -148,7 +148,7 @@
     "source_hash": "b9766df3"
   },
   "web.help.secret_view_faq.what_am_i_looking_at.description": {
-    "text": "Egy biztonságos üzenetet tekint meg, amelyet az {product_name}-en keresztül osztottak meg Önnel. Ez a tartalom csak egyszer jelenik meg, majd véglegesen törlődik szervereinkről.",
+    "text": "Egy biztonságos üzenetet tekint meg, amelyet a {product_name} szolgáltatáson keresztül osztottak meg Önnel. Ez a tartalom csak egyszer jelenik meg, majd véglegesen törlődik a szervereinkről.",
     "source_hash": "e0f1a10c"
   },
   "web.help.secret_view_faq.can_i_view_again.title": {
@@ -264,7 +264,7 @@
     "source_hash": "e2f124cd"
   },
   "web.layout.visit_onetime_secret_homepage": {
-    "text": "{product_name} főoldal meglátogatása",
+    "text": "A {product_name} kezdőlapjának megtekintése",
     "source_hash": "625556d2"
   },
   "web.layout.footer_navigation": {
@@ -338,5 +338,11 @@
   "web.layout.workspace_context": {
     "text": "Munkaterület kontextus",
     "source_hash": "dc6fa4f5"
+  },
+  "web.footer.workspace": {
+    "text": "Munkaterület"
+  },
+  "web.help.default_content": {
+    "text": "Segítségért kérjük, vegye fel a kapcsolatot az ügyfélszolgálattal"
   }
 }

--- a/locales/content/hu/admin-colonel.json
+++ b/locales/content/hu/admin-colonel.json
@@ -634,5 +634,152 @@
   "web.colonel.feedback.when_you_submit_feedback_well_see": {
     "text": "A visszajelzés beküldésekor a következőket látjuk:",
     "source_hash": "fe77172e"
+  },
+  "web.colonel.previewPlanMode": {
+    "text": "Csomag-előnézeti mód"
+  },
+  "web.colonel.previewModeDescription": {
+    "text": "Megtekintheti az alkalmazást úgy, ahogyan az egy másik csomagon lévő ügyfelek számára megjelenik. Ez csak az Ön nézetét érinti, és nem módosítja egyetlen szervezet tényleges csomagját sem."
+  },
+  "web.colonel.previewModeActive": {
+    "text": "Előnézet aktív"
+  },
+  "web.colonel.bannedIps.empty": {
+    "text": "Nincsenek letiltott IP-címek"
+  },
+  "web.colonel.bannedIps.currentIp": {
+    "text": "Az Ön jelenlegi IP-címe"
+  },
+  "web.colonel.bannedIps.confirmUnban": {
+    "text": "Feloldja a letiltást a következőhöz: {ip}?"
+  },
+  "web.colonel.bannedIps.actions.ban": {
+    "text": "IP-cím letiltása"
+  },
+  "web.colonel.bannedIps.actions.quickBan": {
+    "text": "Gyors letiltás"
+  },
+  "web.colonel.bannedIps.actions.unban": {
+    "text": "Letiltás feloldása"
+  },
+  "web.colonel.bannedIps.actions.cancel": {
+    "text": "Mégse"
+  },
+  "web.colonel.bannedIps.columns.ipAddress": {
+    "text": "IP-cím"
+  },
+  "web.colonel.bannedIps.columns.reason": {
+    "text": "Indok"
+  },
+  "web.colonel.bannedIps.columns.bannedAt": {
+    "text": "Letiltva ekkor"
+  },
+  "web.colonel.bannedIps.columns.bannedBy": {
+    "text": "Letiltotta"
+  },
+  "web.colonel.bannedIps.error.banFailed": {
+    "text": "Nem sikerült letiltani az IP-címet"
+  },
+  "web.colonel.bannedIps.error.unbanFailed": {
+    "text": "Nem sikerült feloldani az IP-cím letiltását"
+  },
+  "web.colonel.bannedIps.form.title": {
+    "text": "IP-cím letiltása"
+  },
+  "web.colonel.bannedIps.form.ipLabel": {
+    "text": "IP-cím"
+  },
+  "web.colonel.bannedIps.form.reasonLabel": {
+    "text": "Indok"
+  },
+  "web.colonel.bannedIps.form.reasonPlaceholder": {
+    "text": "Nem kötelező indok"
+  },
+  "web.colonel.bannedIps.success.banned": {
+    "text": "Az {ip} IP-cím le lett tiltva"
+  },
+  "web.colonel.bannedIps.success.unbanned": {
+    "text": "Az {ip} IP-cím letiltása fel lett oldva"
+  },
+  "web.colonel.customDomains.empty": {
+    "text": "Nincsenek beállított egyéni domének"
+  },
+  "web.colonel.customDomains.noLogo": {
+    "text": "Nincs logó"
+  },
+  "web.colonel.customDomains.labels.organization": {
+    "text": "Szervezet"
+  },
+  "web.colonel.customDomains.labels.externalId": {
+    "text": "Külső azonosító"
+  },
+  "web.colonel.customDomains.labels.created": {
+    "text": "Létrehozva"
+  },
+  "web.colonel.customDomains.labels.updated": {
+    "text": "Frissítve"
+  },
+  "web.colonel.customDomains.labels.favicon": {
+    "text": "Favicon"
+  },
+  "web.colonel.customDomains.status.verified": {
+    "text": "Ellenőrizve"
+  },
+  "web.colonel.customDomains.status.resolving": {
+    "text": "Feloldás folyamatban"
+  },
+  "web.colonel.customDomains.status.ready": {
+    "text": "Kész"
+  },
+  "web.colonel.customDomains.status.publicHomepage": {
+    "text": "Nyilvános kezdőlap"
+  },
+  "web.colonel.customDomains.status.publicApi": {
+    "text": "Nyilvános API"
+  },
+  "web.colonel.customDomains.status.pending": {
+    "text": "Függőben"
+  },
+  "web.colonel.pagination.showing": {
+    "text": "{start}–{end} megjelenítése, összesen {total}"
+  },
+  "web.colonel.pagination.itemsPerPage": {
+    "text": "Elemek oldalanként"
+  },
+  "web.colonel.pagination.perPage": {
+    "text": "{count} oldalanként"
+  },
+  "web.colonel.pagination.pageOf": {
+    "text": "{current}. oldal, összesen {total}"
+  },
+  "web.colonel.secrets.empty": {
+    "text": "Nem található titok"
+  },
+  "web.colonel.secrets.never": {
+    "text": "Soha"
+  },
+  "web.colonel.secrets.columns.shortId": {
+    "text": "Rövid azonosító"
+  },
+  "web.colonel.secrets.columns.state": {
+    "text": "Állapot"
+  },
+  "web.colonel.secrets.columns.created": {
+    "text": "Létrehozva"
+  },
+  "web.colonel.secrets.columns.expiration": {
+    "text": "Lejárat"
+  },
+  "web.colonel.secrets.columns.age": {
+    "text": "Életkor (napokban)"
+  },
+  "web.colonel.secrets.state.new": {
+    "text": "Új"
+  },
+  "web.colonel.secrets.state.received": {
+    "text": "Megkapva"
+  },
+  "web.colonel.secrets.state.viewed": {
+    "text": "Megtekintve"
   }
 }

--- a/locales/content/hu/api-account-errors.json
+++ b/locales/content/hu/api-account-errors.json
@@ -1,0 +1,8 @@
+{
+  "api.account.errors.invalid_email": {
+    "text": "Érvényes ez az e-mail-cím?"
+  },
+  "api.account.errors.password_too_short": {
+    "text": "A jelszó túl rövid"
+  }
+}

--- a/locales/content/hu/api-domains-errors.json
+++ b/locales/content/hu/api-domains-errors.json
@@ -1,0 +1,29 @@
+{
+  "api.domains.errors.domain_id_required": {
+    "text": "Doménazonosító szükséges"
+  },
+  "api.domains.errors.domain_not_found": {
+    "text": "A domén nem található: %{extid}"
+  },
+  "api.domains.errors.organization_not_found": {
+    "text": "Nem található szervezet a doménhez: %{domain}"
+  },
+  "api.domains.errors.incoming_secrets_disabled": {
+    "text": "A bejövő titkok nincsenek engedélyezve ezen a példányon"
+  },
+  "api.domains.errors.incoming_secrets_entitlement_required": {
+    "text": "A bejövő titkok kezeléséhez az incoming_secrets jogosultság szükséges. Kérjük, frissítse a csomagját."
+  },
+  "api.domains.errors.incoming_config_not_found": {
+    "text": "Nem található bejövő konfiguráció a doménhez: %{extid}"
+  },
+  "api.domains.errors.recipients_max_exceeded": {
+    "text": "Legfeljebb %{max} címzett engedélyezett"
+  },
+  "api.domains.errors.recipients_invalid_email": {
+    "text": "Érvénytelen e-mail-cím: %{email}"
+  },
+  "api.domains.errors.recipients_duplicate": {
+    "text": "Ismétlődő címzett e-mail-címek nem engedélyezettek"
+  }
+}

--- a/locales/content/hu/api-entitlements-errors.json
+++ b/locales/content/hu/api-entitlements-errors.json
@@ -1,0 +1,71 @@
+{
+  "api.entitlements.errors.context_unavailable": {
+    "text": "A jogosultságok nem ellenőrizhetők (a szervezet kontextusa nem érhető el)"
+  },
+  "api.entitlements.errors.api_access_required": {
+    "text": "Az API-hozzáférés csomagfrissítést igényel"
+  },
+  "api.entitlements.errors.custom_privacy_defaults_required": {
+    "text": "Az egyéni adatvédelmi alapértékek csomagfrissítést igényelnek"
+  },
+  "api.entitlements.errors.extended_default_expiration_required": {
+    "text": "A kibővített alapértelmezett lejárat csomagfrissítést igényel"
+  },
+  "api.entitlements.errors.custom_domains_required": {
+    "text": "Az egyéni domének csomagfrissítést igényelnek"
+  },
+  "api.entitlements.errors.custom_branding_required": {
+    "text": "Az egyéni arculat csomagfrissítést igényel"
+  },
+  "api.entitlements.errors.homepage_secrets_required": {
+    "text": "A kezdőlapi titkok csomagfrissítést igényelnek"
+  },
+  "api.entitlements.errors.incoming_secrets_required": {
+    "text": "A bejövő titkok csomagfrissítést igényelnek"
+  },
+  "api.entitlements.errors.custom_mail_sender_required": {
+    "text": "Az egyéni levélküldő csomagfrissítést igényel"
+  },
+  "api.entitlements.errors.flexible_from_domain_required": {
+    "text": "A rugalmas feladódomén csomagfrissítést igényel"
+  },
+  "api.entitlements.errors.manage_org_required": {
+    "text": "A szervezetkezelés csomagfrissítést igényel"
+  },
+  "api.entitlements.errors.manage_teams_required": {
+    "text": "A csapatkezelés csomagfrissítést igényel"
+  },
+  "api.entitlements.errors.manage_members_required": {
+    "text": "A tagkezelés csomagfrissítést igényel"
+  },
+  "api.entitlements.errors.manage_sso_required": {
+    "text": "Az SSO-kezelés csomagfrissítést igényel"
+  },
+  "api.entitlements.errors.audit_logs_required": {
+    "text": "Az auditnaplók csomagfrissítést igényelnek"
+  },
+  "api.entitlements.errors.custom_signup_validation_required": {
+    "text": "Az egyéni regisztrációs ellenőrzés csomagfrissítést igényel"
+  },
+  "api.entitlements.errors.create_secrets_required": {
+    "text": "A titkok létrehozása csomagfrissítést igényel"
+  },
+  "api.entitlements.errors.view_receipt_required": {
+    "text": "A nyugták megtekintése csomagfrissítést igényel"
+  },
+  "api.entitlements.errors.notifications_required": {
+    "text": "Az értesítések csomagfrissítést igényelnek"
+  },
+  "api.entitlements.errors.workspace_branding_required": {
+    "text": "A munkaterület arculata csomagfrissítést igényel"
+  },
+  "api.entitlements.errors.ip_access_rules_required": {
+    "text": "Az IP-hozzáférési szabályok csomagfrissítést igényelnek"
+  },
+  "api.entitlements.errors.manage_billing_required": {
+    "text": "A számlázáskezelés csomagfrissítést igényel"
+  },
+  "api.entitlements.errors.custom_signin_config_required": {
+    "text": "Az egyéni bejelentkezési konfiguráció csomagfrissítést igényel"
+  }
+}

--- a/locales/content/hu/api-feedback-errors.json
+++ b/locales/content/hu/api-feedback-errors.json
@@ -1,0 +1,5 @@
+{
+  "api.feedback.errors.rate_limit_exceeded": {
+    "text": "Túl sok visszajelzés-beküldés. Kérjük, próbálja meg később."
+  }
+}

--- a/locales/content/hu/api-incoming-errors.json
+++ b/locales/content/hu/api-incoming-errors.json
@@ -1,0 +1,5 @@
+{
+  "api.incoming.errors.custom_domain_unresolved": {
+    "text": "Az egyéni domén szervezete nem volt feloldható"
+  }
+}

--- a/locales/content/hu/api-invite-errors.json
+++ b/locales/content/hu/api-invite-errors.json
@@ -1,0 +1,23 @@
+{
+  "api.invite.errors.invitation_not_found_or_expired": {
+    "text": "A meghívás nem található vagy lejárt"
+  },
+  "api.invite.errors.token_required": {
+    "text": "Token szükséges"
+  },
+  "api.invite.errors.organization_no_longer_exists": {
+    "text": "A szervezet már nem létezik"
+  },
+  "api.invite.errors.invitation_already_processed": {
+    "text": "A meghívás állapota már: %{status}"
+  },
+  "api.invite.errors.invitation_expired": {
+    "text": "A meghívás lejárt"
+  },
+  "api.invite.errors.email_mismatch": {
+    "text": "Az Ön e-mail-címe nem egyezik a meghívással"
+  },
+  "api.invite.errors.already_member": {
+    "text": "Ön már tagja ennek a szervezetnek"
+  }
+}

--- a/locales/content/hu/api-organizations-errors.json
+++ b/locales/content/hu/api-organizations-errors.json
@@ -1,0 +1,107 @@
+{
+  "api.organizations.errors.domain_scoped_forbidden": {
+    "text": "A doménre korlátozott tagok nem hajthatják végre ezt a műveletet"
+  },
+  "api.organizations.errors.organization_not_found": {
+    "text": "A szervezet nem található: %{extid}"
+  },
+  "api.organizations.errors.organization_owner_required": {
+    "text": "Ezt a műveletet csak a szervezet tulajdonosa hajthatja végre"
+  },
+  "api.organizations.errors.organization_member_required": {
+    "text": "A művelet végrehajtásához a szervezet tagjának kell lennie"
+  },
+  "api.organizations.errors.organization_admin_required": {
+    "text": "Ezt a műveletet csak a szervezet tulajdonosai és adminisztrátorai hajthatják végre"
+  },
+  "api.organizations.errors.extid_required": {
+    "text": "Szervezetazonosító szükséges"
+  },
+  "api.organizations.errors.display_name_required": {
+    "text": "A szervezet neve kötelező"
+  },
+  "api.organizations.errors.display_name_too_long": {
+    "text": "A szervezet nevének rövidebbnek kell lennie %{max} karakternél"
+  },
+  "api.organizations.errors.description_too_long": {
+    "text": "A leírásnak rövidebbnek kell lennie %{max} karakternél"
+  },
+  "api.organizations.errors.contact_email_exists": {
+    "text": "Már létezik szervezet ezzel a kapcsolattartási e-mail-címmel"
+  },
+  "api.organizations.errors.creation_in_progress": {
+    "text": "A szervezet létrehozása folyamatban van. Kérjük, próbálja meg újra."
+  },
+  "api.organizations.errors.organization_limit_reached": {
+    "text": "Elérte a szervezetek korlátját. Frissítse a csomagját további szervezetek létrehozásához."
+  },
+  "api.organizations.invitations.errors.invitation_not_found": {
+    "text": "A meghívás nem található"
+  },
+  "api.organizations.invitations.errors.email_required": {
+    "text": "Az e-mail-cím kötelező"
+  },
+  "api.organizations.invitations.errors.invalid_email_format": {
+    "text": "Érvénytelen e-mail-formátum"
+  },
+  "api.organizations.invitations.errors.invalid_role": {
+    "text": "A szerepkörnek tagnak vagy adminisztrátornak kell lennie"
+  },
+  "api.organizations.invitations.errors.cannot_invite_as_owner": {
+    "text": "Nem lehet tulajdonosként meghívni"
+  },
+  "api.organizations.invitations.errors.user_already_member": {
+    "text": "A felhasználó már tagja ennek a szervezetnek"
+  },
+  "api.organizations.invitations.errors.invitation_already_pending": {
+    "text": "Már van függőben lévő meghívás ehhez az e-mail-címhez"
+  },
+  "api.organizations.invitations.errors.member_limit_reached": {
+    "text": "Elérte a tagok korlátját. Frissítse a csomagját további tagok meghívásához."
+  },
+  "api.organizations.invitations.errors.resend_only_pending": {
+    "text": "Csak függőben lévő meghívások küldhetők újra"
+  },
+  "api.organizations.invitations.errors.resend_limit_reached": {
+    "text": "Elérte az újraküldés maximális korlátját (%{max})"
+  },
+  "api.organizations.invitations.errors.revoke_only_pending": {
+    "text": "Csak függőben lévő meghívások vonhatók vissza"
+  },
+  "api.organizations.members.errors.member_not_found": {
+    "text": "A tag nem található: %{extid}"
+  },
+  "api.organizations.members.errors.member_not_in_organization": {
+    "text": "A tag nem található ebben a szervezetben"
+  },
+  "api.organizations.members.errors.member_not_active": {
+    "text": "A tag nem aktív"
+  },
+  "api.organizations.members.errors.invalid_role_value": {
+    "text": "Érvénytelen szerepkör. A következők egyike lehet: %{roles}"
+  },
+  "api.organizations.members.errors.cannot_change_owner_role": {
+    "text": "A tulajdonos szerepköre nem módosítható. Helyette használja a tulajdonjog átruházását."
+  },
+  "api.organizations.members.errors.member_already_has_role": {
+    "text": "A tag már rendelkezik a következő szerepkörrel: %{role}"
+  },
+  "api.organizations.members.errors.cannot_promote_to_owner": {
+    "text": "Nem léptethető elő tulajdonossá. Helyette használja a tulajdonjog átruházását."
+  },
+  "api.organizations.members.errors.must_be_member": {
+    "text": "Tagja kell lennie ennek a szervezetnek"
+  },
+  "api.organizations.members.errors.cannot_remove_owner": {
+    "text": "A szervezet tulajdonosa nem távolítható el. Először ruházza át a tulajdonjogot."
+  },
+  "api.organizations.members.errors.cannot_remove_self": {
+    "text": "Saját magát nem távolíthatja el. Helyette használja a szervezet elhagyása lehetőséget."
+  },
+  "api.organizations.members.errors.admin_cannot_remove_admin": {
+    "text": "Az adminisztrátorok nem távolíthatnak el más adminisztrátorokat. Erre csak a tulajdonosok jogosultak."
+  },
+  "api.organizations.members.errors.no_permission_to_remove": {
+    "text": "Nincs jogosultsága tagok eltávolítására"
+  }
+}

--- a/locales/content/hu/api-secrets-errors.json
+++ b/locales/content/hu/api-secrets-errors.json
@@ -1,0 +1,11 @@
+{
+  "api.secrets.errors.domain_permission_authenticated_non_owner": {
+    "text": "Nincs jogosultsága a domén használatára: %{domain}"
+  },
+  "api.secrets.errors.domain_public_sharing_disabled": {
+    "text": "A nyilvános megosztás le van tiltva ehhez a doménhez: %{domain}"
+  },
+  "api.secrets.errors.domain_permission_anonymous_cross_domain": {
+    "text": "Nincs jogosultsága a domén használatára: %{domain}"
+  }
+}

--- a/locales/content/hu/email.json
+++ b/locales/content/hu/email.json
@@ -60,7 +60,7 @@
     "source_hash": "88c72144"
   },
   "email.welcome.signature": {
-    "text": "Delano",
+    "text": "Támogatási csapat",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -100,7 +100,7 @@
     "source_hash": "fbb7eb2d"
   },
   "email.password_request.signature": {
-    "text": "Delano",
+    "text": "Támogatási csapat",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -145,7 +145,7 @@
     "source_hash": "1863f5be"
   },
   "email.magic_link.signature": {
-    "text": "Delano",
+    "text": "Támogatási csapat",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -230,7 +230,7 @@
     "source_hash": "3f6b45dd"
   },
   "email.secret_revealed.signature": {
-    "text": "Delano",
+    "text": "Támogatási csapat",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -355,7 +355,7 @@
     "source_hash": "734882d2"
   },
   "email.organization_invitation.signature": {
-    "text": "Delano",
+    "text": "Támogatási csapat",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -395,7 +395,7 @@
     "source_hash": "be92cff3"
   },
   "email.password_changed.signature": {
-    "text": "Delano",
+    "text": "Támogatási csapat",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -445,7 +445,7 @@
     "source_hash": "f8d47b82"
   },
   "email.email_changed.signature": {
-    "text": "Delano",
+    "text": "Támogatási csapat",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -495,7 +495,7 @@
     "source_hash": "f8d47b82"
   },
   "email.email_change_requested.signature": {
-    "text": "Delano",
+    "text": "Támogatási csapat",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -550,7 +550,7 @@
     "source_hash": "d4d835fc"
   },
   "email.email_change_confirmation.signature": {
-    "text": "Delano",
+    "text": "Támogatási csapat",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -580,7 +580,7 @@
     "source_hash": "e7c11bb0"
   },
   "email.mfa_enabled.signature": {
-    "text": "Delano",
+    "text": "Támogatási csapat",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -605,7 +605,7 @@
     "source_hash": "97ef0a3e"
   },
   "email.mfa_disabled.signature": {
-    "text": "Delano",
+    "text": "Támogatási csapat",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -650,7 +650,7 @@
     "source_hash": "450c54c5"
   },
   "email.new_login_alert.signature": {
-    "text": "Delano",
+    "text": "Támogatási csapat",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -670,7 +670,7 @@
     "source_hash": "d442beed"
   },
   "email.member_removed.signature": {
-    "text": "Delano",
+    "text": "Támogatási csapat",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -690,7 +690,7 @@
     "source_hash": "c2280c0c"
   },
   "email.role_changed.signature": {
-    "text": "Delano",
+    "text": "Támogatási csapat",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -710,7 +710,7 @@
     "source_hash": "7095fc69"
   },
   "email.organization_deleted.signature": {
-    "text": "Delano",
+    "text": "Támogatási csapat",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -750,7 +750,7 @@
     "source_hash": "36008943"
   },
   "email.payment_receipt.signature": {
-    "text": "Delano",
+    "text": "Támogatási csapat",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -775,7 +775,7 @@
     "source_hash": "926406b1"
   },
   "email.payment_failed.signature": {
-    "text": "Delano",
+    "text": "Támogatási csapat",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -800,7 +800,7 @@
     "source_hash": "66a1419e"
   },
   "email.trial_expiring.signature": {
-    "text": "Delano",
+    "text": "Támogatási csapat",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -825,7 +825,7 @@
     "source_hash": "5a96ae38"
   },
   "email.subscription_changed.signature": {
-    "text": "Delano",
+    "text": "Támogatási csapat",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -853,5 +853,41 @@
     "text": "Onetime Secret",
     "renderer": "erb",
     "source_hash": "1cd0194a"
+  },
+  "email.common.secret_link_label": {
+    "text": "Titokhivatkozás"
+  },
+  "email.common.automated_notice": {
+    "text": "Ez egy automatikus üzenet a(z) %{product_name} szolgáltatástól."
+  },
+  "email.common.support_label": {
+    "text": "Támogatás"
+  },
+  "email.expiration_warning.signature": {
+    "text": "Támogatási csapat"
+  },
+  "email.expiration_warning.footer_note": {
+    "text": "Azért kapta ezt az értesítést, mert egy titok, amelyet a(z) %{product_name} szolgáltatásban hozott létre, hamarosan lejár."
+  },
+  "email.feedback_email.user_id_label": {
+    "text": "Felhasználó:"
+  },
+  "email.feedback_email.timezone_label": {
+    "text": "Időzóna:"
+  },
+  "email.feedback_email.version_label": {
+    "text": "Verzió:"
+  },
+  "email.incoming_secret.footer_note": {
+    "text": "Azért kapta ezt az értesítést, mert valaki a(z) %{product_name} szolgáltatással küldött Önnek egy titkot. Ha nem számított rá, nyugodtan figyelmen kívül hagyhatja ezt az e-mailt."
+  },
+  "email.secret_link.passphrase_label": {
+    "text": "Hozzáférési mondat szükséges:"
+  },
+  "email.secret_link.passphrase_required": {
+    "text": "Ezt a titkot hozzáférési mondat védi. A feladónak külön kell megadnia azt Önnek."
+  },
+  "email.secret_link.footer_note": {
+    "text": "Azért kapta ezt az értesítést, mert %{sender_email} a(z) %{product_name} szolgáltatással osztott meg Önnel egy titkot. Ha nem számított rá, nyugodtan figyelmen kívül hagyhatja ezt az e-mailt."
   }
 }

--- a/locales/content/hu/feature-feedback.json
+++ b/locales/content/hu/feature-feedback.json
@@ -58,5 +58,14 @@
   "web.feedback.reason_email_change_unauthorized": {
     "text": "Úgy tűnik, hogy jogosulatlan e-mail módosítást jelent a fiókján. Kérjük, írja le, mi történt, és azonnal kivizsgáljuk.",
     "source_hash": "00e56551"
+  },
+  "web.feedback.anonymous_no_reply": {
+    "text": "Megjegyzés: ha választ szeretne, kérjük, írja alá az üzenetet, vagy adjon meg benne egy e-mail-címet."
+  },
+  "web.feedback.characters_remaining": {
+    "text": "{count} karakter maradt"
+  },
+  "web.feedback.character_limit_reached": {
+    "text": "Elérte a karakterkorlátot"
   }
 }

--- a/locales/content/hu/feature-homepage-secrets.json
+++ b/locales/content/hu/feature-homepage-secrets.json
@@ -1,0 +1,50 @@
+{
+  "homepage_secrets.disabled.members_only_eyebrow": {
+    "text": "Csak tagok számára elérhető példány"
+  },
+  "homepage_secrets.disabled.private_instance_eyebrow": {
+    "text": "Privát példány"
+  },
+  "homepage_secrets.disabled.team_link_headline": {
+    "text": "Ez a hivatkozás a(z) {workspace} csapat számára készült."
+  },
+  "homepage_secrets.disabled.signin_headline": {
+    "text": "Jelentkezzen be {action} létrehozásához."
+  },
+  "homepage_secrets.disabled.signin_headline_action": {
+    "text": "titokhivatkozás"
+  },
+  "homepage_secrets.disabled.team_subtitle": {
+    "text": "Csak a(z) {domain} címen lévő jogosult csapattagok hozhatnak létre itt új, egyszer használatos hivatkozásokat. A címzettek továbbra is megnyithatják a nekik küldött hivatkozásokat."
+  },
+  "homepage_secrets.disabled.public_subtitle": {
+    "text": "Csak a példány jogosult tagjai hozhatnak létre új, egyszer használatos hivatkozásokat. A címzettek továbbra is megnyithatják a nekik küldött hivatkozásokat."
+  },
+  "homepage_secrets.disabled.signin_cta": {
+    "text": "Jelentkezzen be a fiókjába"
+  },
+  "homepage_secrets.disabled.what_is_this": {
+    "text": "Mi ez?"
+  },
+  "homepage_secrets.disabled.trust_viewed_once": {
+    "text": "Egyszer megtekinthető, majd eltűnik"
+  },
+  "homepage_secrets.disabled.trust_zero_retained": {
+    "text": "Semmi sem kerül megőrzésre"
+  },
+  "homepage_secrets.disabled.promo_title": {
+    "text": "Újdonság: az ingyenes csomagok mostantól egyéni doméneket is tartalmaznak."
+  },
+  "homepage_secrets.disabled.promo_subtitle": {
+    "text": "Irányítsa a doménjét az Onetime Secretre, és küldjön titkokat a saját arculata alatt."
+  },
+  "homepage_secrets.disabled.promo_learn_how": {
+    "text": "Tudja meg, hogyan"
+  },
+  "homepage_secrets.disabled.logo_alt": {
+    "text": "{name} logó"
+  },
+  "homepage_secrets.disabled.opens_in_new_tab": {
+    "text": "(új lapon nyílik meg)"
+  }
+}

--- a/locales/content/hu/feature-incoming.json
+++ b/locales/content/hu/feature-incoming.json
@@ -130,5 +130,26 @@
   "incoming.receipt_link_text": {
     "text": "visszaigazolás",
     "source_hash": "6f328609"
+  },
+  "incoming.upgrade_required_title": {
+    "text": "Csomagfrissítés szükséges"
+  },
+  "incoming.upgrade_required_description": {
+    "text": "Ez a funkció csomagfrissítést igényel. A bejövő titkok engedélyezéséhez kérjük, vegye fel a kapcsolatot a fiók tulajdonosával."
+  },
+  "incoming.validation_memo_too_long": {
+    "text": "A jegyzet legfeljebb {max} karakter lehet"
+  },
+  "incoming.validation_secret_required": {
+    "text": "A titok tartalma kötelező"
+  },
+  "incoming.validation_recipient_required": {
+    "text": "Kérjük, válasszon ki egy címzettet"
+  },
+  "incoming.validation_feature_disabled": {
+    "text": "A bejövő titkok funkció nincs engedélyezve"
+  },
+  "incoming.validation_form_errors": {
+    "text": "Kérjük, ellenőrizze az űrlapot a hibák miatt"
   }
 }

--- a/locales/content/hu/feature-regions.json
+++ b/locales/content/hu/feature-regions.json
@@ -152,7 +152,7 @@
     "source_hash": "1d97f6bd"
   },
   "web.regions.changing_regions_billing_note": {
-    "text": "Ha a számlázási kapcsolattartó e-mail címe eltér az {product_name} fiókjának e-mail címétől, használja a számlázási kapcsolattartó e-mail címét az új régiós fiókhoz az előfizetési előnyök megtartásához.",
+    "text": "Ha a számlázási kapcsolattartó e-mail-címe eltér a(z) {product_name} fiókjához tartozó e-mail-címtől, használja az új régió fiókjához tartozó számlázási kapcsolattartó e-mail-címet az előfizetése előnyeinek megtartásához.",
     "source_hash": "dac1cc28"
   },
   "web.regions.changing_regions_subscription_note": {
@@ -186,5 +186,8 @@
   "web.regions.jurisdictions.apac.name": {
     "text": "Asia-Pacific",
     "source_hash": "7a757670"
+  },
+  "web.regions.no_region_configured": {
+    "text": "Jelenleg nem áll rendelkezésre régióinformáció az Ön fiókjához."
   }
 }

--- a/locales/content/hu/feature-translations.json
+++ b/locales/content/hu/feature-translations.json
@@ -64,7 +64,7 @@
     "source_hash": "13131e36"
   },
   "web.translations.the_following_people_have_donated_their_time_to_": {
-    "text": "A következő emberek adományozták idejüket az {product_name} elérésének kiterjesztéséhez:",
+    "text": "A következő személyek áldozták idejüket arra, hogy bővítsék a(z) {product_name} elérhetőségét:",
     "source_hash": "85a766af"
   },
   "web.translations.translations": {
@@ -84,7 +84,7 @@
     "source_hash": "ba5c4395"
   },
   "web.translations.since_2012_onetime_secret_has_provided_a_secure_": {
-    "text": "2012 óta az {product_name} biztonságos módot nyújt érzékeny információk megosztásához világszerte. Mivel felhasználóink olyan régiókban vannak, ahol az angol nem az elsődleges nyelv, a pontos fordítások elengedhetetlenek a biztonságos kommunikáció mindenki számára elérhetővé tételéhez.",
+    "text": "2012 óta a(z) {product_name} biztonságos módot kínál bizalmas információk megosztására világszerte. Mivel a felhasználók olyan régiókban élnek, ahol nem az angol az elsődleges nyelv, a pontos fordítások elengedhetetlenek ahhoz, hogy a biztonságos kommunikáció mindenki számára elérhető legyen.",
     "source_hash": "87a6e9af"
   },
   "web.translations.help_secure_communication_go_global": {

--- a/locales/content/hu/secret-homepage.json
+++ b/locales/content/hu/secret-homepage.json
@@ -56,7 +56,7 @@
     "source_hash": "5e218489"
   },
   "web.homepage.visit_onetime_secret_home": {
-    "text": "{product_name} főoldal meglátogatása",
+    "text": "A(z) {product_name} kezdőlapjának megtekintése",
     "source_hash": "625556d2"
   },
   "web.homepage.password_generation_title": {
@@ -108,15 +108,15 @@
     "source_hash": "107093e4"
   },
   "web.homepage.about_onetime_secret_0": {
-    "text": "Az {product_name}-ről",
+    "text": "A(z) {product_name} névjegye",
     "source_hash": "971c50da"
   },
   "web.homepage.log_in_to_onetime_secret": {
-    "text": "Bejelentkezés az {product_name}-be",
+    "text": "Bejelentkezés ide: {product_name}",
     "source_hash": "bd6be8d6"
   },
   "web.homepage.about_onetime_secret": {
-    "text": "Az {product_name}-ről",
+    "text": "A(z) {product_name} névjegye",
     "source_hash": "971c50da"
   },
   "web.homepage.signup_individual_and_business_plans": {
@@ -148,7 +148,7 @@
     "source_hash": "7872e050"
   },
   "web.homepage.onetime_secret_homepage": {
-    "text": "{product_name} főoldal",
+    "text": "A(z) {product_name} kezdőlapja",
     "source_hash": "44bb0581"
   },
   "web.homepage.send_sensitive_information_that_can_only_be_viewed_once": {
@@ -168,11 +168,11 @@
     "source_hash": "e1073c60"
   },
   "web.homepage.welcome_to_onetime_secret": {
-    "text": "Üdvözöljük az {product_name}-ben.",
+    "text": "Üdvözöljük a(z) {product_name} szolgáltatásban.",
     "source_hash": "0990d163"
   },
   "web.homepage.onetime_secret_helps_us_share_sensitive_informat": {
-    "text": "Az {product_name} segít biztonságosan megosztani érzékeny információkat, miközben fenntartjuk professzionális homlokzatunkat.",
+    "text": "A(z) {product_name} segít, hogy biztonságosan osszunk meg bizalmas információkat, miközben megőrizzük szakmai látszatunkat.",
     "source_hash": "986a0856"
   },
   "web.homepage.information_shared_through_this_service_can_only": {

--- a/locales/content/hu/secret-manage.json
+++ b/locales/content/hu/secret-manage.json
@@ -128,7 +128,7 @@
     "source_hash": "07fe1b84"
   },
   "web.secrets.onetime_secret_is_a_secure_way_to_share_sensitiv": {
-    "text": "Az {product_name} biztonságos módja az érzékeny információk megosztásának, amely egyetlen megtekintés után önmegsemmisül.",
+    "text": "A(z) {product_name} biztonságos módja a bizalmas információk megosztásának, amely egyetlen megtekintés után önmegsemmisül.",
     "source_hash": "8a163297"
   },
   "web.secrets.what_is_this": {
@@ -398,5 +398,11 @@
   "web.secrets.errors.access_denied_to_domain": {
     "text": "Hozzáférés megtagadva a domainhez",
     "source_hash": "cd441eea"
+  },
+  "web.receipt.open_link": {
+    "text": "Hivatkozás megnyitása"
+  },
+  "web.secrets.messageDeleted": {
+    "text": "Üzenet törölve"
   }
 }

--- a/locales/content/hu/session-auth-extended.json
+++ b/locales/content/hu/session-auth-extended.json
@@ -710,5 +710,26 @@
   "web.auth.recovery_codes.link_title": {
     "text": "Helyreállítási kódok",
     "source_hash": "579c7f4e"
+  },
+  "web.auth.google": {
+    "text": "Google"
+  },
+  "web.auth.mfa.alternative_auth_options": {
+    "text": "Alternatív hitelesítési lehetőségek"
+  },
+  "web.auth.remember.enabled": {
+    "text": "Maradjon bejelentkezve"
+  },
+  "web.auth.security._guidance.context": {
+    "text": "⚠️ SECURITY-CRITICAL: Messages prevent information disclosure. See src/locales/SECURITY-TRANSLATION-GUIDE.md"
+  },
+  "web.auth.sessions.session_singular": {
+    "text": "munkamenet"
+  },
+  "web.auth.sessions.session_plural": {
+    "text": "munkamenet"
+  },
+  "web.auth.sessions._guidance.context": {
+    "text": "User's logged-in devices/browsers management page"
   }
 }

--- a/locales/content/hu/session-auth.json
+++ b/locales/content/hu/session-auth.json
@@ -395,5 +395,35 @@
   "web.help.contact_support": {
     "text": "Kapcsolatfelvétel az ügyfélszolgálattal",
     "source_hash": "f8d47b82"
+  },
+  "web.auth.account.sso_linked": {
+    "text": "SSO-fiók"
+  },
+  "web.auth.verify._guidance.context": {
+    "text": "Email verification flow after signup"
+  },
+  "web.help.reset_password_link": {
+    "text": "Jelszó visszaállítása"
+  },
+  "web.login.custom_domain_sso_title": {
+    "text": "Az egyszeri bejelentkezés elérhető ehhez a doménhez"
+  },
+  "web.login.custom_domain_sso_description": {
+    "text": "A szervezet adminisztrátora engedélyezheti az SSO-t, hogy a csapattagok itt bejelentkezhessenek. A hozzáférésért forduljon az adminisztrátorhoz."
+  },
+  "web.login.signin_disabled_heading": {
+    "text": "A bejelentkezés nem érhető el"
+  },
+  "web.login.signin_disabled_message": {
+    "text": "A bejelentkezés jelenleg nem érhető el ezen a doménen."
+  },
+  "web.login.errors.sso_not_configured": {
+    "text": "Az egyszeri bejelentkezés nincs beállítva ehhez a doménhez. Kérjük, forduljon az adminisztrátorhoz."
+  },
+  "web.login.errors.invalid_email": {
+    "text": "Az identitásszolgáltatótól kapott e-mail-cím érvénytelen. Kérjük, forduljon az adminisztrátorhoz."
+  },
+  "web.login.errors.domain_not_allowed": {
+    "text": "Az Ön e-mail-doménje nem jogosult az SSO-regisztrációra. Kérjük, forduljon az adminisztrátorhoz."
   }
 }

--- a/locales/content/hu/workspace-account.json
+++ b/locales/content/hu/workspace-account.json
@@ -476,7 +476,7 @@
     "source_hash": "1cc77e60"
   },
   "web.settings.api.documentation_description": {
-    "text": "Ismerje meg, hogyan integrálhatja az {product_name}-et alkalmazásaiba",
+    "text": "Tudja meg, hogyan integrálhatja a(z) {product_name} szolgáltatást az alkalmazásaiba",
     "source_hash": "6e8f910f"
   },
   "web.settings.api.rest_api_reference": {
@@ -682,5 +682,14 @@
   "web.settings.profile.didnt_receive_email": {
     "text": "Nem kapta meg az e-mailt?",
     "source_hash": "fe3ac3ad"
+  },
+  "web.settings.api.api_disabled_notice": {
+    "text": "Az API le van tiltva ehhez a példányhoz."
+  },
+  "web.settings.security.sso_managed_title": {
+    "text": "A biztonságot az SSO kezeli"
+  },
+  "web.settings.security.sso_managed_description": {
+    "text": "Az Ön fiókját a szervezete egyszeri bejelentkezési szolgáltatóján keresztül hitelesítik. A jelszót, a többfaktoros hitelesítést és a helyreállítási kódokat az identitásszolgáltató kezeli."
   }
 }

--- a/locales/content/hu/workspace-billing.json
+++ b/locales/content/hu/workspace-billing.json
@@ -988,5 +988,47 @@
     "text": "Csak az eredeti előfizetési régiójában érhető el",
     "context": "Hint shown on plan cards when currency does not match active subscription",
     "source_hash": "10de32e5"
+  },
+  "web.billing.already_subscribed": {
+    "text": "Ön már előfizetett erre a csomagra."
+  },
+  "web.billing.cancel.reactivate_button": {
+    "text": "Előfizetés újraaktiválása"
+  },
+  "web.billing.cancel.reactivate_success": {
+    "text": "Az előfizetését újraaktiválták. A számlázás a szokásos módon folytatódik."
+  },
+  "web.billing.cancel.reactivate_error": {
+    "text": "Nem sikerült újraaktiválni az előfizetést. Kérjük, próbálja újra, vagy forduljon a támogatáshoz."
+  },
+  "web.billing.features.manage_orgs": {
+    "text": "Szervezetkezelés"
+  },
+  "web.billing.features.flexible_from_domain": {
+    "text": "Rugalmas e-mail-feladó domén"
+  },
+  "web.billing.features.unlimited_admins": {
+    "text": "Korlátlan számú adminisztrátor"
+  },
+  "web.billing.features.manage_sso": {
+    "text": "SSO"
+  },
+  "web.billing.overview.entitlements.flexible_from_domain": {
+    "text": "Rugalmas e-mail-feladó domén"
+  },
+  "web.billing.overview.entitlements.manage_orgs": {
+    "text": "Szervezetek kezelése"
+  },
+  "web.billing.overview.entitlements.manage_sso": {
+    "text": "Egyszeri bejelentkezés (SSO)"
+  },
+  "web.billing.overview.entitlements.manage_billing": {
+    "text": "Számlázás kezelése"
+  },
+  "web.billing.overview.entitlements.custom_signup_validation": {
+    "text": "Egyéni regisztrációs ellenőrzés"
+  },
+  "web.billing.plans.reactivate": {
+    "text": "Újraaktiválás"
   }
 }

--- a/locales/content/hu/workspace-branding.json
+++ b/locales/content/hu/workspace-branding.json
@@ -144,7 +144,7 @@
     "source_hash": "1e04ba2e"
   },
   "web.branding.powered_by_onetime_secret": {
-    "text": "Szolgáltatja a {product_name}",
+    "text": "Üzemelteti: {product_name}",
     "source_hash": "d8e9f0a1"
   },
   "web.branding.low_contrast_warning": {
@@ -178,5 +178,11 @@
   "web.branding.upgrade_to_customize": {
     "text": "Frissítse csomagját a domén márkajelzésének testreszabásához.",
     "source_hash": "9077bf79"
+  },
+  "web.branding.saved_successfully": {
+    "text": "A márkabeállítások sikeresen mentve"
+  },
+  "web.branding.keyhole_logo_icon": {
+    "text": "Kulcslyuk ikon, amely a biztonságos, privát megosztást jelképezi"
   }
 }

--- a/locales/content/hu/workspace-dashboard.json
+++ b/locales/content/hu/workspace-dashboard.json
@@ -22,5 +22,14 @@
   "web.dashboard.fetch_error_description": {
     "text": "Probléma merült fel az adatok betöltése során. Kérjük, próbálja újra.",
     "source_hash": "ff0d904e"
+  },
+  "web.teams.create_first_team_title": {
+    "text": "Hozza létre első csapatát"
+  },
+  "web.teams.create_first_team_description": {
+    "text": "A csapatok lehetővé teszik, hogy másokkal együttműködjön egy közös munkaterületen."
+  },
+  "web.teams.create_team": {
+    "text": "Csapat létrehozása"
   }
 }

--- a/locales/content/hu/workspace-domains.json
+++ b/locales/content/hu/workspace-domains.json
@@ -398,5 +398,725 @@
   "web.domains.dns_widget_description": {
     "text": "Használja az alábbi eszközt a DNS szolgáltatója automatikus felismeréséhez és lépésről lépésre útmutatások megjelenítéséhez a doménje konfigurálásához.",
     "source_hash": "91c1af2e"
+  },
+  "api.domains.errors.add_admin_required": {
+    "text": "Csak a szervezeti tulajdonosok és adminisztrátorok adhatnak hozzá egyéni doméneket"
+  },
+  "web.domains.public_homepage": {
+    "text": "Nyilvános kezdőlap"
+  },
+  "web.domains.status_tooltip_active": {
+    "text": "A domén ellenőrizve és aktív"
+  },
+  "web.domains.status_tooltip_dns_incorrect": {
+    "text": "A DNS nincs beállítva — kattintson a javításhoz"
+  },
+  "web.domains.status_tooltip_not_verified": {
+    "text": "A domén nincs ellenőrizve — kattintson az ellenőrzéshez"
+  },
+  "web.domains.status_tooltip_unverified": {
+    "text": "A domén állapota nincs ellenőrizve — kattintson a frissítéshez"
+  },
+  "web.domains.last_check_failed": {
+    "text": "Az utolsó ellenőrzés sikertelen volt"
+  },
+  "web.domains.last_check_failed_ago": {
+    "text": "az utolsó ellenőrzés sikertelen volt: {0}"
+  },
+  "web.domains.verify_now": {
+    "text": "Ellenőrzés most"
+  },
+  "web.domains.click_to_verify": {
+    "text": "kattintson az ellenőrzéshez"
+  },
+  "web.domains.remove_domain_description": {
+    "text": "A domén és minden konfigurációjának végleges eltávolítása."
+  },
+  "web.domains.add_access_denied": {
+    "text": "Hozzáférés megtagadva"
+  },
+  "web.domains.add_access_denied_description": {
+    "text": "Nincs jogosultsága domének hozzáadásához ehhez a szervezethez. Forduljon a szervezet adminisztrátorához."
+  },
+  "web.domains.dns_widget_load_failed": {
+    "text": "A DNS-widget betöltése sikertelen"
+  },
+  "web.domains.dns_widget_not_available": {
+    "text": "A DNS-widget nem érhető el"
+  },
+  "web.domains.dns_widget_init_failed": {
+    "text": "A DNS-widget inicializálása sikertelen"
+  },
+  "web.domains.verified": {
+    "text": "Ellenőrizve"
+  },
+  "web.domains.pending_verification": {
+    "text": "Ellenőrzésre vár"
+  },
+  "web.domains.unsaved_changes_confirmation": {
+    "text": "Nem mentett módosításai vannak. Biztosan el szeretné hagyni az oldalt?"
+  },
+  "web.domains.entitlement_required_owner": {
+    "text": "Ez a funkció csomagfrissítést igényel."
+  },
+  "web.domains.entitlement_required_member": {
+    "text": "Ez a funkció nem érhető el a jelenlegi csomagjában. Forduljon a szervezet tulajdonosához."
+  },
+  "web.domains.detail.manage": {
+    "text": "Kezelés"
+  },
+  "web.domains.detail.features": {
+    "text": "Funkciók"
+  },
+  "web.domains.detail.homepage_title": {
+    "text": "Kezdőlapi titkok"
+  },
+  "web.domains.detail.homepage_description": {
+    "text": "Nyilvános hozzáférés engedélyezése titkok létrehozásához a domén kezdőlapján"
+  },
+  "web.domains.detail.brand_description": {
+    "text": "Logó, színek és egyéni márkajelzés"
+  },
+  "web.domains.detail.sso_description": {
+    "text": "Egyszeri bejelentkezési szolgáltató beállításai"
+  },
+  "web.domains.detail.email_description": {
+    "text": "Egyéni e-mail-feladó konfigurációja"
+  },
+  "web.domains.detail.incoming_description": {
+    "text": "Bejövő titkok címzettjeinek beállításai"
+  },
+  "web.domains.detail.signup_description": {
+    "text": "Doménenkénti regisztrációs ellenőrzési stratégia"
+  },
+  "web.domains.detail.signin_description": {
+    "text": "Doménenkénti bejelentkezési mód konfigurációja"
+  },
+  "web.domains.email.title": {
+    "text": "E-mail-küldés"
+  },
+  "web.domains.email.config_title": {
+    "text": "E-mail-konfiguráció"
+  },
+  "web.domains.email.config_description": {
+    "text": "E-mail-küldés beállítása ehhez a doménhez"
+  },
+  "web.domains.email.provider_label": {
+    "text": "E-mail-szolgáltató"
+  },
+  "web.domains.email.provider_placeholder": {
+    "text": "Válasszon e-mail-szolgáltatót"
+  },
+  "web.domains.email.from_name_label": {
+    "text": "Feladó neve"
+  },
+  "web.domains.email.from_name_placeholder": {
+    "text": "pl. Acme Security"
+  },
+  "web.domains.email.from_address_label": {
+    "text": "Feladó címe"
+  },
+  "web.domains.email.from_address_placeholder": {
+    "text": "pl. secrets{'@'}example.com"
+  },
+  "web.domains.email.reply_to_label": {
+    "text": "Válaszcím"
+  },
+  "web.domains.email.reply_to_placeholder": {
+    "text": "pl. support{'@'}example.com"
+  },
+  "web.domains.email.save_changes": {
+    "text": "Módosítások mentése"
+  },
+  "web.domains.email.discard_changes": {
+    "text": "Módosítások elvetése"
+  },
+  "web.domains.email.provider_ses": {
+    "text": "Amazon SES"
+  },
+  "web.domains.email.provider_sendgrid": {
+    "text": "SendGrid"
+  },
+  "web.domains.email.provider_lettermint": {
+    "text": "Lettermint"
+  },
+  "web.domains.email.provider_inherit": {
+    "text": "Fiók alapértelmezéseinek használata"
+  },
+  "web.domains.email.provider_ses_description": {
+    "text": "Doménellenőrzést igényel DKIM- és SPF-rekordokkal"
+  },
+  "web.domains.email.provider_sendgrid_description": {
+    "text": "Doménhitelesítés beállítását igényli"
+  },
+  "web.domains.email.provider_lettermint_description": {
+    "text": "Doménellenőrzést igényel"
+  },
+  "web.domains.email.provider_inherit_description": {
+    "text": "A fiók alapértelmezett e-mail-küldési konfigurációját használja"
+  },
+  "web.domains.email.dns_records_title": {
+    "text": "DNS-rekordok"
+  },
+  "web.domains.email.dns_records_description": {
+    "text": "Adja hozzá a következő DNS-rekordokat, hogy ellenőrizze a doménjét az e-mail-küldéshez."
+  },
+  "web.domains.email.dns_column_type": {
+    "text": "Típus"
+  },
+  "web.domains.email.dns_column_name": {
+    "text": "Név"
+  },
+  "web.domains.email.dns_column_value": {
+    "text": "Érték"
+  },
+  "web.domains.email.dns_check_label": {
+    "text": "DNS"
+  },
+  "web.domains.email.provider_check_label": {
+    "text": "Szolgáltató"
+  },
+  "web.domains.email.dns_optional_label": {
+    "text": "Ajánlott"
+  },
+  "web.domains.email.dns_optional_hint": {
+    "text": "Ez a rekord ajánlott, de nem kötelező az ellenőrzéshez. Előfordulhat, hogy a szervezeti doménjén lévő DMARC-házirend már lefedi ezt az aldomént."
+  },
+  "web.domains.email.copy": {
+    "text": "Másolás"
+  },
+  "web.domains.email.copied": {
+    "text": "Másolva"
+  },
+  "web.domains.email.status_verified": {
+    "text": "Ellenőrizve"
+  },
+  "web.domains.email.status_pending": {
+    "text": "Függőben"
+  },
+  "web.domains.email.status_failed": {
+    "text": "Sikertelen"
+  },
+  "web.domains.email.revalidate": {
+    "text": "Újraérvényesítés"
+  },
+  "web.domains.email.validating": {
+    "text": "Érvényesítés folyamatban..."
+  },
+  "web.domains.email.domain_verified": {
+    "text": "A domén ellenőrizve"
+  },
+  "web.domains.email.validation_failed": {
+    "text": "Az érvényesítés sikertelen"
+  },
+  "web.domains.email.last_validated": {
+    "text": "Utoljára érvényesítve"
+  },
+  "web.domains.email.upgrade_to_configure": {
+    "text": "Frissítse a csomagját az e-mail-küldés beállításához ehhez a doménhez."
+  },
+  "web.domains.email.configure_email": {
+    "text": "E-mail beállítása"
+  },
+  "web.domains.email.access_denied": {
+    "text": "Hozzáférés megtagadva"
+  },
+  "web.domains.email.access_denied_description": {
+    "text": "Nincs jogosultsága a domén e-mail-beállításainak kezeléséhez. Forduljon a szervezet adminisztrátorához."
+  },
+  "web.domains.email.update_success": {
+    "text": "Az e-mail-konfiguráció sikeresen mentve"
+  },
+  "web.domains.email.delete_success": {
+    "text": "Az e-mail-konfiguráció sikeresen eltávolítva"
+  },
+  "web.domains.email.default_sender_notice": {
+    "text": "Az ehhez a doménhez tartozó e-maileket jelenleg a globális feladó küldi. Fejezze be az e-mail-konfigurációt a saját feladói azonosságának használatához."
+  },
+  "web.domains.email.disabled_notice": {
+    "text": "Az egyéni e-mail-küldés jelenleg le van tiltva. Az e-maileket a globális feladó küldi. Engedélyezze az alábbi funkciót a saját feladói azonosságának használatához."
+  },
+  "web.domains.email.test_email_title": {
+    "text": "E-mail-kézbesítés tesztelése"
+  },
+  "web.domains.email.test_email_hint": {
+    "text": "Küldjön magának egy teszt e-mailt a mentett konfigurációval. Akkor is működik, ha a funkció még nincs engedélyezve."
+  },
+  "web.domains.email.send_test": {
+    "text": "Teszt küldése"
+  },
+  "web.domains.email.test_email_sent": {
+    "text": "A teszt e-mail sikeresen elküldve"
+  },
+  "web.domains.email.test_email_failed": {
+    "text": "Nem sikerült elküldeni a teszt e-mailt"
+  },
+  "web.domains.email.test_email_sent_to": {
+    "text": "Elküldve a következő címre: {email}"
+  },
+  "web.domains.email.delivered_via": {
+    "text": "Kézbesítve a következővel: {provider}"
+  },
+  "web.domains.email.badge_not_configured": {
+    "text": "Nincs beállítva"
+  },
+  "web.domains.email.badge_default_sender": {
+    "text": "Alapértelmezett feladó használata"
+  },
+  "web.domains.email.badge_verified": {
+    "text": "Ellenőrizve"
+  },
+  "web.domains.email.badge_pending": {
+    "text": "Ellenőrzésre vár"
+  },
+  "web.domains.email.badge_disabled": {
+    "text": "Letiltva"
+  },
+  "web.domains.email.tooltip_not_configured": {
+    "text": "Nincs beállítva e-mail-feladó — az e-maileket a platform alapértelmezett feladója küldi"
+  },
+  "web.domains.email.tooltip_pending": {
+    "text": "Az e-mail-feladó konfigurációja ellenőrzésre vár — az e-maileket a platform alapértelmezett feladója küldi"
+  },
+  "web.domains.email.tooltip_disabled": {
+    "text": "Az e-mail-feladó le van tiltva — az e-maileket a platform alapértelmezett feladója küldi"
+  },
+  "web.domains.email.tooltip_verified": {
+    "text": "Az e-mail-feladó ellenőrizve — az e-maileket erről a doménről küldjük"
+  },
+  "web.domains.incoming.title": {
+    "text": "Bejövő titkok"
+  },
+  "web.domains.incoming.config_title": {
+    "text": "Bejövő titkok konfigurációja"
+  },
+  "web.domains.incoming.config_description": {
+    "text": "Engedélyezze, hogy külső felhasználók titkokat küldjenek közvetlenül a kijelölt címzetteknek ezen a doménen"
+  },
+  "web.domains.incoming.feature_disabled": {
+    "text": "A bejövő titkok nem érhetők el"
+  },
+  "web.domains.incoming.feature_disabled_description": {
+    "text": "A bejövő titkok funkció nincs engedélyezve ezen a példányon. Forduljon az adminisztrátorához."
+  },
+  "web.domains.incoming.access_denied": {
+    "text": "Hozzáférés megtagadva"
+  },
+  "web.domains.incoming.access_denied_description": {
+    "text": "Nincs jogosultsága a domén bejövő titkok beállításainak kezeléséhez. Forduljon a szervezet adminisztrátorához."
+  },
+  "web.domains.incoming.upgrade_to_configure": {
+    "text": "Frissítse a csomagját a bejövő titkok beállításához ehhez a doménhez."
+  },
+  "web.domains.incoming.configure_incoming": {
+    "text": "Bejövő titkok beállítása"
+  },
+  "web.domains.incoming.not_configured_notice": {
+    "text": "A bejövő titkok nincsenek beállítva ehhez a doménhez. Adjon hozzá címzetteket, hogy a külső felhasználók titkokat küldhessenek a csapatának."
+  },
+  "web.domains.incoming.disabled_notice": {
+    "text": "A bejövő titkok jelenleg le vannak tiltva. A külső felhasználók nem küldhetnek titkokat a domén címzettjeinek. Engedélyezze az alábbi funkciót a bejövő titkok engedélyezéséhez."
+  },
+  "web.domains.incoming.recipients_title": {
+    "text": "Címzettek"
+  },
+  "web.domains.incoming.recipients_description": {
+    "text": "Határozza meg, ki kaphat bejövő titkokat ezen a doménen. A címzettek e-mail-értesítést kapnak, amikor titkot küldenek nekik."
+  },
+  "web.domains.incoming.add_recipient": {
+    "text": "Címzett hozzáadása"
+  },
+  "web.domains.incoming.remove_recipient": {
+    "text": "Eltávolítás"
+  },
+  "web.domains.incoming.email_label": {
+    "text": "E-mail-cím"
+  },
+  "web.domains.incoming.email_placeholder": {
+    "text": "recipient{'@'}example.com"
+  },
+  "web.domains.incoming.name_label": {
+    "text": "Megjelenített név"
+  },
+  "web.domains.incoming.name_placeholder": {
+    "text": "pl. Security Team"
+  },
+  "web.domains.incoming.empty_state": {
+    "text": "Nincsenek beállított címzettek"
+  },
+  "web.domains.incoming.empty_state_description": {
+    "text": "Adjon hozzá címzetteket, hogy a külső felhasználók titkokat küldhessenek a csapatának."
+  },
+  "web.domains.incoming.validation_invalid_email": {
+    "text": "Érvénytelen e-mail-cím"
+  },
+  "web.domains.incoming.validation_duplicate_email": {
+    "text": "Ez az e-mail-cím már hozzá van adva"
+  },
+  "web.domains.incoming.validation_max_recipients": {
+    "text": "Legfeljebb {max} címzett engedélyezett"
+  },
+  "web.domains.incoming.validation_name_required": {
+    "text": "A megjelenített név megadása kötelező"
+  },
+  "web.domains.incoming.validation_email_required": {
+    "text": "Az e-mail-cím megadása kötelező"
+  },
+  "web.domains.incoming.save_changes": {
+    "text": "Módosítások mentése"
+  },
+  "web.domains.incoming.discard_changes": {
+    "text": "Módosítások elvetése"
+  },
+  "web.domains.incoming.update_success": {
+    "text": "A bejövő titkok konfigurációja sikeresen mentve"
+  },
+  "web.domains.incoming.delete_success": {
+    "text": "A bejövő titkok konfigurációja sikeresen eltávolítva"
+  },
+  "web.domains.incoming.recipient_count": {
+    "text": "{count} címzett | {count} címzett"
+  },
+  "web.domains.incoming.badge_not_configured": {
+    "text": "Nincs beállítva"
+  },
+  "web.domains.incoming.badge_configured": {
+    "text": "Beállítva"
+  },
+  "web.domains.incoming.badge_disabled": {
+    "text": "Letiltva"
+  },
+  "web.domains.incoming.tooltip_not_configured": {
+    "text": "A bejövő titkok nincsenek beállítva - a külső felhasználók nem küldhetnek titkokat erre a doménre"
+  },
+  "web.domains.incoming.tooltip_configured": {
+    "text": "A bejövő titkok engedélyezve, {count} címzettel"
+  },
+  "web.domains.incoming.tooltip_disabled": {
+    "text": "A bejövő titkok funkció le van tiltva ehhez a doménhez"
+  },
+  "web.domains.incoming.enabled_label": {
+    "text": "Bejövő titkok engedélyezése"
+  },
+  "web.domains.incoming.enabled_hint": {
+    "text": "Engedélyezze, hogy külső felhasználók titkokat küldjenek a domén címzettjeinek"
+  },
+  "web.domains.incoming.public_url_label": {
+    "text": "Nyilvános URL"
+  },
+  "web.domains.incoming.public_url_description": {
+    "text": "Ossza meg ezt az URL-t külső felhasználókkal, hogy titkokat küldhessenek"
+  },
+  "web.domains.incoming.copy_url": {
+    "text": "URL másolása"
+  },
+  "web.domains.incoming.url_copied": {
+    "text": "URL a vágólapra másolva"
+  },
+  "web.domains.incoming.remove_all_confirmation": {
+    "text": "Biztosan eltávolít minden címzettet? A külső felhasználók többé nem küldhetnek titkokat erre a doménre."
+  },
+  "web.domains.incoming.max_recipients_reached": {
+    "text": "Elérte a címzettek maximális számát"
+  },
+  "web.domains.incoming.duplicate_recipient": {
+    "text": "Ez az e-mail-cím már hozzá lett adva"
+  },
+  "web.domains.incoming.save_will_replace_confirmation": {
+    "text": "A mentés az összes meglévő címzettet lecseréli a függőben lévő módosításaira. Biztos benne?"
+  },
+  "web.domains.incoming.delete_all_recipients": {
+    "text": "Az összes címzett törlése"
+  },
+  "web.domains.signin.title": {
+    "text": "Bejelentkezési konfiguráció"
+  },
+  "web.domains.signin.configure_signin": {
+    "text": "Bejelentkezés beállítása"
+  },
+  "web.domains.signin.config_description": {
+    "text": "Bejelentkezési hitelesítési módok beállítása ehhez a doménhez"
+  },
+  "web.domains.signin.access_denied": {
+    "text": "Hozzáférés megtagadva"
+  },
+  "web.domains.signin.upgrade_to_configure": {
+    "text": "Frissítse a csomagját a bejelentkezési módok beállításához ehhez a doménhez."
+  },
+  "web.domains.signin.not_configured_notice": {
+    "text": "A bejelentkezési konfiguráció még nincs beállítva ehhez a doménhez. Állítson be felülbírálásokat annak szabályozására, hogy mely hitelesítési módok érhetők el ennek a doménnek a bejelentkezési oldalán."
+  },
+  "web.domains.signin.signin_enabled_label": {
+    "text": "Bejelentkezés engedélyezve"
+  },
+  "web.domains.signin.header_toggle_label": {
+    "text": "Bejelentkezés"
+  },
+  "web.domains.signin.signin_enabled_hint": {
+    "text": "Hogy a felhasználók bejelentkezhetnek-e ezen a doménen"
+  },
+  "web.domains.signin.restrict_to_label": {
+    "text": "Bejelentkezési mód korlátozása"
+  },
+  "web.domains.signin.restrict_to_hint": {
+    "text": "Korlátozza ezt a domént egyetlen hitelesítési módra. Beállítás esetén csak a kiválasztott mód jelenik meg a bejelentkezési oldalon."
+  },
+  "web.domains.signin.all_methods": {
+    "text": "Minden mód"
+  },
+  "web.domains.signin.all_methods_description": {
+    "text": "Az összes engedélyezett hitelesítési mód megjelenítése a bejelentkezési oldalon"
+  },
+  "web.domains.signin.method_password": {
+    "text": "Jelszó"
+  },
+  "web.domains.signin.method_email_auth": {
+    "text": "E-mailes hitelesítés"
+  },
+  "web.domains.signin.method_webauthn": {
+    "text": "WebAuthn / Hozzáférési kulcsok"
+  },
+  "web.domains.signin.method_sso": {
+    "text": "Egyszeri bejelentkezés"
+  },
+  "web.domains.signin.method_overrides_label": {
+    "text": "Mód felülbírálásai"
+  },
+  "web.domains.signin.method_overrides_hint": {
+    "text": "Egyes hitelesítési módok engedélyezése vagy letiltása ehhez a doménhez"
+  },
+  "web.domains.signin.mode_question": {
+    "text": "Hogyan jelentkezhetnek be a felhasználók?"
+  },
+  "web.domains.signin.mode_any": {
+    "text": "Bármely elérhető mód"
+  },
+  "web.domains.signin.mode_any_hint": {
+    "text": "Az ezen a doménen elérhető összes mód megjelenítése. Az egyes módokat alább szűkítheti."
+  },
+  "web.domains.signin.mode_one": {
+    "text": "Egy adott mód"
+  },
+  "web.domains.signin.mode_one_hint": {
+    "text": "Korlátozza a bejelentkezési oldalt egyetlen módra. Csak az ezen a doménen elérhető módok szerepelnek a listában."
+  },
+  "web.domains.signin.mode_disabled": {
+    "text": "Bejelentkezés letiltva"
+  },
+  "web.domains.signin.mode_disabled_hint": {
+    "text": "A felhasználók nem jelentkezhetnek be ezen a doménen."
+  },
+  "web.domains.signin.mode_disabled_notice": {
+    "text": "Ennek a doménnek a bejelentkezési oldalára látogatók egy értesítést látnak, hogy a bejelentkezés nem érhető el, a kezdőlapra visszamutató hivatkozással. A korábbi módbeállításai megmaradnak, és a bejelentkezés újbóli engedélyezésekor visszaállnak."
+  },
+  "web.domains.signin.methods_list_label": {
+    "text": "A bejelentkezési oldalon megjelenő módok"
+  },
+  "web.domains.signin.restrict_picker_hint": {
+    "text": "Csak az ezen a doménen elérhető módok szerepelnek a listában."
+  },
+  "web.domains.signin.availability_always": {
+    "text": "Mindig elérhető"
+  },
+  "web.domains.signin.availability_global_on": {
+    "text": "Globális szabályzatot követi · Be"
+  },
+  "web.domains.signin.availability_global_off": {
+    "text": "Nem érhető el"
+  },
+  "web.domains.signin.availability_unavailable": {
+    "text": "Webhelyszerte nem érhető el"
+  },
+  "web.domains.signin.allow_on_domain": {
+    "text": "Engedélyezés ezen a doménen"
+  },
+  "web.domains.signin.method_password_blurb": {
+    "text": "Csak jelszó"
+  },
+  "web.domains.signin.method_email_auth_blurb": {
+    "text": "Jelszó nélküli bejelentkezés varázshivatkozással"
+  },
+  "web.domains.signin.method_webauthn_blurb": {
+    "text": "Biometria és biztonsági kulcsok"
+  },
+  "web.domains.signin.method_sso_blurb": {
+    "text": "Külső identitásszolgáltató"
+  },
+  "web.domains.signin.email_auth_label": {
+    "text": "E-mailes hitelesítés"
+  },
+  "web.domains.signin.email_auth_hint": {
+    "text": "Jelszó nélküli e-mailes hitelesítés engedélyezése ezen a doménen"
+  },
+  "web.domains.signin.sso_enabled_label": {
+    "text": "Egyszeri bejelentkezés"
+  },
+  "web.domains.signin.sso_enabled_hint": {
+    "text": "SSO-hitelesítés engedélyezése ezen a doménen"
+  },
+  "web.domains.signin.enabled_label": {
+    "text": "Bejelentkezési konfiguráció engedélyezése"
+  },
+  "web.domains.signin.enabled_hint": {
+    "text": "Ha engedélyezve van, ez a domén a fent beállított bejelentkezési beállításokat használja"
+  },
+  "web.domains.signin.save_config": {
+    "text": "Konfiguráció mentése"
+  },
+  "web.domains.signin.update_success": {
+    "text": "A bejelentkezési konfiguráció sikeresen frissítve"
+  },
+  "web.domains.signin.reset_to_defaults": {
+    "text": "Visszaállítás az alapértelmezésekre"
+  },
+  "web.domains.signin.reset_confirm": {
+    "text": "Visszaállítja a bejelentkezést a globális alapértelmezésekre?"
+  },
+  "web.domains.signin.reset_keeps_sso": {
+    "text": "Az SSO-hitelesítő adatai megmaradnak. Ezeket külön távolítsa el az SSO-konfigurációs képernyőn."
+  },
+  "web.domains.signin.reset_action": {
+    "text": "Igen, visszaállítás"
+  },
+  "web.domains.signin.reset_success": {
+    "text": "A bejelentkezési beállítások visszaállítva a globális alapértelmezésekre"
+  },
+  "web.domains.signup.title": {
+    "text": "Regisztrációs ellenőrzés"
+  },
+  "web.domains.signup.config_description": {
+    "text": "Regisztrációs ellenőrzés beállítása ehhez a doménhez"
+  },
+  "web.domains.signup.access_denied": {
+    "text": "Hozzáférés megtagadva"
+  },
+  "web.domains.signup.upgrade_to_configure": {
+    "text": "Frissítse a csomagját a doménenkénti regisztrációs ellenőrzés beállításához."
+  },
+  "web.domains.signup.configure_signup": {
+    "text": "Regisztráció beállítása"
+  },
+  "web.domains.signup.not_configured_notice": {
+    "text": "A regisztrációs ellenőrzés még nincs beállítva ehhez a doménhez. Állítson be egy stratégiát annak szabályozására, hogy ki regisztrálhat ezen a doménen keresztül."
+  },
+  "web.domains.signup.site_signups_disabled_warning": {
+    "text": "A regisztrációk jelenleg le vannak tiltva a webhely szintjén. Ez a doménenkénti szabályzat be van állítva, de nem szabályoz semmilyen forgalmat, amíg a webhelyszintű regisztrációk nincsenek engedélyezve."
+  },
+  "web.domains.signup.strategy_label": {
+    "text": "Ellenőrzési stratégia"
+  },
+  "web.domains.signup.strategy_description": {
+    "text": "Válassza ki, hogyan ellenőrizzük az e-mail-címeket, amikor a felhasználók regisztrálnak ezen a doménen."
+  },
+  "web.domains.signup.network_validation_warning": {
+    "text": "Ez a stratégia hálózati hívásokat végez a regisztráció során, ami késleltetést okozhat, vagy egyes szolgáltatók blokkolhatják."
+  },
+  "web.domains.signup.allowed_domains_label": {
+    "text": "Engedélyezett regisztrációs domének"
+  },
+  "web.domains.signup.allowed_domains_hint": {
+    "text": "Csak ezek az e-mail-domének regisztrálhatnak. Bejegyzésenként egy domént adjon meg."
+  },
+  "web.domains.signup.domain_placeholder": {
+    "text": "example.com"
+  },
+  "web.domains.signup.invalid_domain": {
+    "text": "Adjon meg egy érvényes domént (pl. example.com)"
+  },
+  "web.domains.signup.domain_exists": {
+    "text": "Ez a domén már szerepel a listában"
+  },
+  "web.domains.signup.remove_domain": {
+    "text": "{domain} eltávolítása"
+  },
+  "web.domains.signup.enabled_label": {
+    "text": "Doménenkénti ellenőrzés engedélyezése"
+  },
+  "web.domains.signup.enabled_hint": {
+    "text": "Ha engedélyezve van, az ezen a doménen történő regisztrációk a globális szabályzat helyett a fenti stratégiát használják."
+  },
+  "web.domains.signup.delete_config": {
+    "text": "Konfiguráció törlése"
+  },
+  "web.domains.signup.delete_confirm": {
+    "text": "Törli a regisztrációs ellenőrzés konfigurációját? A regisztrációk visszatérnek a globális szabályzathoz."
+  },
+  "web.domains.signup.save_config": {
+    "text": "Konfiguráció mentése"
+  },
+  "web.domains.signup.update_success": {
+    "text": "A regisztrációs ellenőrzés sikeresen frissítve"
+  },
+  "web.domains.signup.delete_success": {
+    "text": "A regisztrációs ellenőrzés konfigurációja sikeresen eltávolítva"
+  },
+  "web.domains.signup.domain_overrides_label": {
+    "text": "Domén felülbírálásai"
+  },
+  "web.domains.signup.domain_overrides_hint": {
+    "text": "A globális regisztrációs beállítások felülbírálása ehhez a doménhez"
+  },
+  "web.domains.signup.signup_enabled_label": {
+    "text": "Regisztráció engedélyezve"
+  },
+  "web.domains.signup.signup_enabled_hint": {
+    "text": "Felülbírálja, hogy a regisztráció engedélyezve van-e ehhez a doménhez"
+  },
+  "web.domains.signup.autoverify_label": {
+    "text": "Fiókok automatikus ellenőrzése"
+  },
+  "web.domains.signup.autoverify_hint": {
+    "text": "Felülbírálja, hogy az új fiókok automatikusan ellenőrizve legyenek-e ezen a doménen"
+  },
+  "web.domains.sso.title": {
+    "text": "Egyszeri bejelentkezés"
+  },
+  "web.domains.sso.config_title": {
+    "text": "SSO-konfiguráció"
+  },
+  "web.domains.sso.config_description": {
+    "text": "Egyszeri bejelentkezéses hitelesítés beállítása ehhez a doménhez"
+  },
+  "web.domains.sso.access_denied": {
+    "text": "Hozzáférés megtagadva"
+  },
+  "web.domains.sso.access_denied_description": {
+    "text": "Nincs jogosultsága a domén SSO-beállításainak kezeléséhez. Forduljon a szervezet adminisztrátorához."
+  },
+  "web.domains.sso.upgrade_to_configure": {
+    "text": "Frissítse a csomagját az egyszeri bejelentkezés beállításához ehhez a doménhez."
+  },
+  "web.domains.sso.create_success": {
+    "text": "Az SSO-konfiguráció sikeresen létrehozva"
+  },
+  "web.domains.sso.update_success": {
+    "text": "Az SSO-konfiguráció sikeresen frissítve"
+  },
+  "web.domains.sso.delete_success": {
+    "text": "Az SSO-konfiguráció sikeresen eltávolítva"
+  },
+  "web.domains.sso.test_success": {
+    "text": "A kapcsolatteszt sikeres — a szolgáltató helyesen válaszolt"
+  },
+  "web.domains.sso.test_failed": {
+    "text": "A kapcsolatteszt sikertelen"
+  },
+  "web.domains.sso.enforce_moved_notice": {
+    "text": "Ha minden bejelentkezéshez SSO-t szeretne megkövetelni ezen a doménen, állítsa be a domén bejelentkezési beállításaiban. A csak SSO mód a bejelentkezési oldalt az itt beállított SSO-szolgáltatóra korlátozza."
+  },
+  "web.domains.sso.configure_sso": {
+    "text": "SSO beállítása"
+  },
+  "web.domains.sso.not_configured_notice": {
+    "text": "Az SSO még nincs beállítva ehhez a doménhez. Engedélyezze az egyszeri bejelentkezést, hogy a csapattagok a szervezete identitásszolgáltatójával hitelesíthessék magukat."
+  },
+  "web.domains.sso.edit_credentials": {
+    "text": "Hitelesítő adatok szerkesztése"
+  },
+  "web.domains.sso.configure_button": {
+    "text": "Beállítás"
+  },
+  "web.domains.sso.upgrade_required": {
+    "text": "Frissítés a beállításhoz"
   }
 }

--- a/locales/content/hu/workspace-organizations.json
+++ b/locales/content/hu/workspace-organizations.json
@@ -578,5 +578,344 @@
   "web.organizations.invitations.expires_soon": {
     "text": "Hamarosan lejár",
     "source_hash": "a5dcfef9"
+  },
+  "api.organizations.errors.not_found": {
+    "text": "A szervezet nem található: %{extid}"
+  },
+  "api.organizations.errors.owner_required": {
+    "text": "Csak a szervezet tulajdonosa hajthatja végre ezt a műveletet"
+  },
+  "api.organizations.errors.admin_required": {
+    "text": "Csak a szervezet tulajdonosai és adminisztrátorai hajthatják végre ezt a műveletet"
+  },
+  "api.organizations.errors.member_required": {
+    "text": "A művelet végrehajtásához a szervezet tagjának kell lennie"
+  },
+  "api.organizations.invitations.errors.create_admin_required": {
+    "text": "Csak a szervezet tulajdonosai és adminisztrátorai hozhatnak létre meghívásokat"
+  },
+  "api.organizations.invitations.errors.resend_admin_required": {
+    "text": "Csak a szervezet tulajdonosai és adminisztrátorai küldhetnek újra meghívásokat"
+  },
+  "api.organizations.invitations.errors.view_admin_required": {
+    "text": "Csak a szervezet tulajdonosai és adminisztrátorai tekinthetik meg a meghívásokat"
+  },
+  "api.organizations.invitations.errors.revoke_admin_required": {
+    "text": "Csak a szervezet tulajdonosai és adminisztrátorai vonhatnak vissza meghívásokat"
+  },
+  "api.organizations.invitations.errors.email_required": {
+    "text": "Az e-mail-cím megadása kötelező"
+  },
+  "api.organizations.invitations.errors.email_invalid": {
+    "text": "Érvénytelen e-mail-formátum"
+  },
+  "api.organizations.invitations.errors.role_invalid": {
+    "text": "A szerepkörnek tagnak vagy adminisztrátornak kell lennie"
+  },
+  "api.organizations.invitations.errors.cannot_invite_owner": {
+    "text": "Nem lehet tulajdonosként meghívni"
+  },
+  "api.organizations.invitations.errors.already_member": {
+    "text": "A felhasználó már tagja ennek a szervezetnek"
+  },
+  "api.organizations.invitations.errors.already_pending": {
+    "text": "Már van függőben lévő meghívás ehhez az e-mail-címhez"
+  },
+  "api.organizations.invitations.errors.member_limit_reached": {
+    "text": "Elérte a tagok korlátját. Frissítse a csomagját további tagok meghívásához."
+  },
+  "api.organizations.invitations.errors.not_found": {
+    "text": "A meghívás nem található"
+  },
+  "api.organizations.invitations.errors.cannot_resend_non_pending": {
+    "text": "Csak függőben lévő meghívásokat lehet újraküldeni"
+  },
+  "api.organizations.invitations.errors.cannot_revoke_non_pending": {
+    "text": "Csak függőben lévő meghívásokat lehet visszavonni"
+  },
+  "api.organizations.invitations.errors.resend_limit_reached": {
+    "text": "Elérte az újraküldések maximális korlátját (%{max})"
+  },
+  "api.organizations.invitations.errors.accept_token_required": {
+    "text": "Token szükséges"
+  },
+  "api.organizations.invitations.errors.accept_organization_gone": {
+    "text": "A szervezet már nem létezik"
+  },
+  "api.organizations.invitations.errors.accept_already_acted": {
+    "text": "A meghívás állapota már: %{status}"
+  },
+  "api.organizations.invitations.errors.accept_expired": {
+    "text": "A meghívás lejárt"
+  },
+  "api.organizations.invitations.errors.accept_email_mismatch": {
+    "text": "Az e-mail-címe nem egyezik a meghívással"
+  },
+  "api.organizations.invitations.errors.accept_already_member": {
+    "text": "Ön már tagja ennek a szervezetnek"
+  },
+  "web.organizations.entitlements_title": {
+    "text": "Szervezeti jogosultságok"
+  },
+  "web.organizations.page_description_short": {
+    "text": "Munkaterületeinek megtekintése és beállítása"
+  },
+  "web.organizations.delete_organization_remove_domains_first": {
+    "text": "Távolítson el minden egyéni domént a szervezet törlése előtt."
+  },
+  "web.organizations.default_org_delete_notice_title": {
+    "text": "A szervezet törlése"
+  },
+  "web.organizations.default_org_delete_notice_before": {
+    "text": "Ez az alapértelmezett szervezete, és nem távolítható el a vezérlőpultról. A törléséhez kérjük, forduljon hozzánk a következőn keresztül:"
+  },
+  "web.organizations.default_org_delete_notice_link": {
+    "text": "visszajelzési űrlap"
+  },
+  "web.organizations.default_org_delete_notice_after": {
+    "text": "."
+  },
+  "web.organizations.leave_organization": {
+    "text": "Kilépés ebből a szervezetből"
+  },
+  "web.organizations.leave_organization_warning": {
+    "text": "Elveszíti a hozzáférését ehhez a szervezethez és annak erőforrásaihoz."
+  },
+  "web.organizations.leave_organization_confirm_title": {
+    "text": "Kilépés a szervezetből"
+  },
+  "web.organizations.leave_organization_confirm_message": {
+    "text": "Biztosan kilép a következőből: {name}? Az újbóli csatlakozáshoz új meghívásra lesz szüksége."
+  },
+  "web.organizations.leave_organization_success": {
+    "text": "Kilépett a szervezetből."
+  },
+  "web.organizations.leave_error": {
+    "text": "Nem sikerült kilépni a szervezetből"
+  },
+  "web.organizations.organizations": {
+    "text": "Szervezetek"
+  },
+  "web.organizations.invitations.invited_by_inline": {
+    "text": "ettől: {email}"
+  },
+  "web.organizations.invitations.invited_as_inline": {
+    "text": "a következő szerepkörben: {role}"
+  },
+  "web.organizations.invitations.back_to_home": {
+    "text": "Vissza a kezdőlapra"
+  },
+  "web.organizations.invitations.email_locked_hint": {
+    "text": "Ezt a meghívást erre az e-mail-címre küldték"
+  },
+  "web.organizations.invitations.signup_continue": {
+    "text": "Folytatás"
+  },
+  "web.organizations.invitations.signin_continue": {
+    "text": "Bejelentkezés"
+  },
+  "web.organizations.invitations.confirm_join_below": {
+    "text": "Majdnem kész — erősítse meg alább a szervezethez való csatlakozást."
+  },
+  "web.organizations.invitations.go_to_organizations": {
+    "text": "Ugrás a Szervezetekhez"
+  },
+  "web.organizations.invitations.already_member": {
+    "text": "Ön már tagja ennek a szervezetnek"
+  },
+  "web.organizations.invitations.join_organization": {
+    "text": "Csatlakozás: {orgName}"
+  },
+  "web.organizations.invitations.sign_in_to_join": {
+    "text": "Jelentkezzen be a csatlakozáshoz: {orgName}"
+  },
+  "web.organizations.invitations.decline": {
+    "text": "Elutasítás"
+  },
+  "web.organizations.members.member_quota": {
+    "text": "{used} / {limit} tag"
+  },
+  "web.organizations.members.pending_suffix": {
+    "text": "({count} függőben)"
+  },
+  "web.organizations.members.limit_reached_hint": {
+    "text": "Elérte a tagok korlátját."
+  },
+  "web.organizations.sso.title": {
+    "text": "Egyszeri bejelentkezés (SSO)"
+  },
+  "web.organizations.sso.description": {
+    "text": "Állítsa be az SSO-t, hogy a tagok bejelentkezhessenek a szervezete identitásszolgáltatójával"
+  },
+  "web.organizations.sso.provider_type": {
+    "text": "Szolgáltató típusa"
+  },
+  "web.organizations.sso.provider_type_description": {
+    "text": "Válassza ki a szervezete identitásszolgáltatóját"
+  },
+  "web.organizations.sso.display_name": {
+    "text": "Megjelenített név"
+  },
+  "web.organizations.sso.display_name_hint": {
+    "text": "A felhasználóknak bejelentkezéskor megjelenő barátságos név"
+  },
+  "web.organizations.sso.display_name_placeholder": {
+    "text": "pl. Acme Corp SSO"
+  },
+  "web.organizations.sso.client_id": {
+    "text": "Ügyfélazonosító"
+  },
+  "web.organizations.sso.client_id_placeholder": {
+    "text": "Az Ön OAuth-ügyfélazonosítója"
+  },
+  "web.organizations.sso.client_secret": {
+    "text": "Ügyféltitok"
+  },
+  "web.organizations.sso.client_secret_placeholder": {
+    "text": "Az Ön OAuth-ügyféltitka"
+  },
+  "web.organizations.sso.client_secret_update_hint": {
+    "text": "Hagyja üresen a meglévő titok megtartásához"
+  },
+  "web.organizations.sso.tenant_id": {
+    "text": "Bérlőazonosító"
+  },
+  "web.organizations.sso.tenant_id_hint": {
+    "text": "Az Ön Azure AD / Entra ID bérlőazonosítója"
+  },
+  "web.organizations.sso.tenant_id_placeholder": {
+    "text": "pl. 12345678-1234-1234-1234-123456789abc"
+  },
+  "web.organizations.sso.issuer": {
+    "text": "Kibocsátó URL-je"
+  },
+  "web.organizations.sso.issuer_hint": {
+    "text": "Az identitásszolgáltatójának OIDC-felderítési URL-je"
+  },
+  "web.organizations.sso.issuer_placeholder": {
+    "text": "pl. https://login.example.com"
+  },
+  "web.organizations.sso.view_discovery_document": {
+    "text": "Felderítési dokumentum megtekintése"
+  },
+  "web.organizations.sso.callback_url": {
+    "text": "Visszahívási URL"
+  },
+  "web.organizations.sso.callback_url_hint": {
+    "text": "Adja hozzá ezt az URL-t az identitásszolgáltatójának engedélyezett átirányítási URI-jaihoz"
+  },
+  "web.organizations.sso.allowed_domains": {
+    "text": "Engedélyezett e-mail-domének"
+  },
+  "web.organizations.sso.allowed_domains_hint": {
+    "text": "Csak az ezekről a doménekről származó e-mail-címmel rendelkező felhasználók jelentkezhetnek be. Hagyja üresen az összes domén engedélyezéséhez."
+  },
+  "web.organizations.sso.domain_placeholder": {
+    "text": "pl. acme.com"
+  },
+  "web.organizations.sso.invalid_domain": {
+    "text": "Adjon meg egy érvényes domént (pl. example.com)"
+  },
+  "web.organizations.sso.domain_exists": {
+    "text": "Ez a domén már szerepel a listában"
+  },
+  "web.organizations.sso.remove_domain": {
+    "text": "{domain} eltávolítása"
+  },
+  "web.organizations.sso.enabled": {
+    "text": "SSO engedélyezése"
+  },
+  "web.organizations.sso.enabled_hint": {
+    "text": "Ha engedélyezve van, a szervezet tagjai bejelentkezhetnek ezzel az SSO-szolgáltatóval"
+  },
+  "web.organizations.sso.enforce_sso_only": {
+    "text": "Csak SSO kényszerítése"
+  },
+  "web.organizations.sso.enforce_sso_only_hint": {
+    "text": "Minden bejelentkezéshez SSO-t követel meg ezen a doménen. Ha engedélyezve van, a jelszó alapú hitelesítés le van tiltva."
+  },
+  "web.organizations.sso.grant_org_scope": {
+    "text": "Szervezetszintű hozzáférés biztosítása"
+  },
+  "web.organizations.sso.grant_org_scope_hint": {
+    "text": "Azok az új tagok, akik ennek a doménnek az SSO-ján keresztül csatlakoznak, hozzáférést kapnak a szervezet összes doménjéhez. A meglévő tagokat ez nem érinti. Ha le van tiltva (alapértelmezett), az új tagok csak ehhez a doménhez férhetnek hozzá."
+  },
+  "web.organizations.sso.save_config": {
+    "text": "SSO-konfiguráció mentése"
+  },
+  "web.organizations.sso.delete_config": {
+    "text": "Konfiguráció törlése"
+  },
+  "web.organizations.sso.delete_confirm": {
+    "text": "Biztos benne? Ez letiltja az SSO-t a szervezete számára."
+  },
+  "web.organizations.sso.load_error": {
+    "text": "Nem sikerült betölteni az SSO-konfigurációt"
+  },
+  "web.organizations.sso.save_error": {
+    "text": "Nem sikerült menteni az SSO-konfigurációt"
+  },
+  "web.organizations.sso.create_success": {
+    "text": "Az SSO-konfiguráció sikeresen létrehozva"
+  },
+  "web.organizations.sso.update_success": {
+    "text": "Az SSO-konfiguráció sikeresen frissítve"
+  },
+  "web.organizations.sso.delete_success": {
+    "text": "Az SSO-konfiguráció sikeresen törölve"
+  },
+  "web.organizations.sso.delete_error": {
+    "text": "Nem sikerült törölni az SSO-konfigurációt"
+  },
+  "web.organizations.sso.test_connection": {
+    "text": "Kapcsolat tesztelése"
+  },
+  "web.organizations.sso.test_connection_hint": {
+    "text": "Ellenőrizze, hogy az identitásszolgáltató elérhető-e (nem ellenőrzi a hitelesítő adatokat)"
+  },
+  "web.organizations.sso.test_button": {
+    "text": "Kapcsolat tesztelése"
+  },
+  "web.organizations.sso.testing": {
+    "text": "Tesztelés..."
+  },
+  "web.organizations.sso.test_error": {
+    "text": "Nem sikerült tesztelni a kapcsolatot"
+  },
+  "web.organizations.sso.auth_endpoint": {
+    "text": "Engedélyezési végpont"
+  },
+  "web.organizations.sso.missing_fields": {
+    "text": "Hiányzó mezők"
+  },
+  "web.organizations.sso.status_enabled": {
+    "text": "Engedélyezve"
+  },
+  "web.organizations.sso.status_configured": {
+    "text": "Beállítva"
+  },
+  "web.organizations.sso.domain_sso_title": {
+    "text": "Domén SSO"
+  },
+  "web.organizations.sso.domain_sso_description": {
+    "text": "Állítsa be az SSO-t minden ellenőrzött doménhez"
+  },
+  "web.organizations.sso.provider_type_locked_hint": {
+    "text": "A szolgáltató módosításához először törölje ezt a konfigurációt"
+  },
+  "web.organizations.sso.status_not_configured": {
+    "text": "Nincs beállítva"
+  },
+  "web.organizations.sso.no_domains": {
+    "text": "Nincsenek ellenőrzött domének"
+  },
+  "web.organizations.sso.no_domains_description": {
+    "text": "Adjon hozzá és ellenőrizzen egy domént, mielőtt beállítaná hozzá az SSO-t."
+  },
+  "web.organizations.tabs.team": {
+    "text": "Csapat"
+  },
+  "web.organizations.tabs.sso": {
+    "text": "SSO"
   }
 }


### PR DESCRIPTION
## `hu` translation update

Automated export of completed **hu** translations from the translation task DB.
Scope: `locales/content/hu/` only — 27 file(s), +1853/-35.

✅ `i18n validate variables`: no variable mismatches.

---

### Local quality review

> Produced by a fresh, isolated `claude` review agent (model `claude-sonnet-5`, agent `saas-translator`) that read
> `locales/AGENT_TRANSLATION_PROTOCOL.md` and inspected this branch's diff before the PR was opened.

Confirmed identical to source with `"skip": true` — expected doc-metadata carve-out, not a leak. All checks clean: token/brand consistency (0 mismatches across every changed key), no mojibake, no JSON errors, no untranslated-leak candidates, signature swap matches source's own Delano→Support Team change.

**Verdict:** ✅ Looks good — clean batch, no defects found.

**Summary:** Large hu update (new API-error files, colonel/domains/SSO/billing/org features, ~19 email signature swaps) checked against English source; all variable tokens, brand terms, and JSON structure are intact.

**Critical (must fix):** None

**Warnings:** None

**Notes:**
- 3 `_guidance.context` keys (`web.auth.security`, `web.auth.sessions`, `web.auth.verify`) are left in English — correct, matches source verbatim, doc-metadata carve-out (`"skip": true`).
- `email.*.signature` (~19 keys) changed "Delano" → "Támogatási csapat", matching the English source's own "Support Team" change — consistent, not a drift.
- `web.INSTRUCTION.phishing_warning` gained "régió domain-t" ("region domain"), correctly matching an English source update, not an injected artifact.
- `web.domains.incoming.recipient_count` pipe-plural uses identical Hungarian text for both forms — correct per Hungarian singular-after-numeral convention.
- New keys (e.g. `api-account-errors.json`, `feature-homepage-secrets.json`) lack `source_hash`; expected until `locales:hashes` runs, not a defect.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
