### PR TITLE
i18n: update it_IT translations

### DIFF
--- a/locales/content/it_IT/00-common.json
+++ b/locales/content/it_IT/00-common.json
@@ -1299,7 +1299,7 @@
     "source_hash": "fc78d9cb"
   },
   "web.INSTRUCTION.phishing_warning": {
-    "text": "Verifica sempre di essere sul sito ufficiale di {product_name}. I truffatori a volte creano siti falsi che sembrano identici a {product_name} per rubare i tuoi segreti. Per evitare attacchi di phishing, controlla il dominio prima di creare nuovi link.",
+    "text": "Verifica sempre di trovarti sul sito ufficiale di {product_name}. A volte i truffatori creano siti web falsi identici a {product_name} per rubare i tuoi segreti. Per evitare gli attacchi di phishing, controlla il dominio della regione prima di creare nuovi link.",
     "source_hash": "b588f5b2"
   },
   "web.pricing.title": {
@@ -1383,5 +1383,110 @@
     "text": "Effettua l'upgrade per sbloccare più funzionalità",
     "context": "Description shown for free plan users encouraging upgrade",
     "source_hash": "783f174c"
+  },
+  "api.errors.authentication_required": {
+    "text": "Autenticazione richiesta"
+  },
+  "api.errors.sso_only_action_blocked": {
+    "text": "Questa azione non è disponibile in modalità solo SSO"
+  },
+  "web.COMMON.configure": {
+    "text": "Configura"
+  },
+  "web.COMMON.copy_to_clipboard": {
+    "text": "Copia negli appunti"
+  },
+  "web.COMMON.add": {
+    "text": "Aggiungi"
+  },
+  "web.COMMON.enabled": {
+    "text": "Abilitato"
+  },
+  "web.COMMON.disabled": {
+    "text": "Disabilitato"
+  },
+  "web.COMMON.yes_delete": {
+    "text": "Sì, elimina"
+  },
+  "web.COMMON.error_code": {
+    "text": "Codice errore"
+  },
+  "web.COMMON.http_status": {
+    "text": "Stato HTTP"
+  },
+  "web.COMMON.details": {
+    "text": "Dettagli"
+  },
+  "web.COMMON.field_confirm_password": {
+    "text": "Conferma password"
+  },
+  "web.COMMON.passwords_must_match": {
+    "text": "Le password devono corrispondere"
+  },
+  "web.COMMON.and": {
+    "text": "e"
+  },
+  "web.COMMON.or": {
+    "text": "o"
+  },
+  "web.COMMON.copied": {
+    "text": "Copiato"
+  },
+  "web.COMMON.copy": {
+    "text": "Copia"
+  },
+  "web.COMMON.copy_email": {
+    "text": "Copia indirizzo email"
+  },
+  "web.COMMON.copy_id": {
+    "text": "Copia ID account"
+  },
+  "web.COMMON.org_id_tooltip": {
+    "text": "Identificatore univoco della tua organizzazione"
+  },
+  "web.COMMON.success": {
+    "text": "Operazione completata"
+  },
+  "web.COMMON.need_help": {
+    "text": "Hai bisogno di aiuto"
+  },
+  "web.COMMON.open_help_dialog": {
+    "text": "Apri finestra di aiuto"
+  },
+  "web.COMMON.focus_is_now_in_the_main_text_area": {
+    "text": "Il focus è ora nell'area di testo principale"
+  },
+  "web.LABELS.show_passphrase": {
+    "text": "Mostra frase di sicurezza"
+  },
+  "web.LABELS.hide_passphrase": {
+    "text": "Nascondi frase di sicurezza"
+  },
+  "web.LABELS.copy_icon": {
+    "text": "Icona copia"
+  },
+  "web.LABELS.copied_icon": {
+    "text": "Icona copiato"
+  },
+  "web.STATUS.unverified": {
+    "text": "Non verificato"
+  },
+  "web.TITLES.domain_detail": {
+    "text": "Impostazioni dominio"
+  },
+  "web.TITLES.domain_signin": {
+    "text": "Configurazione accesso"
+  },
+  "web.TITLES.domain_sso": {
+    "text": "SSO dominio"
+  },
+  "web.TITLES.domain_signup": {
+    "text": "Convalida della registrazione del dominio"
+  },
+  "web.TITLES.domain_email": {
+    "text": "Configurazione email"
+  },
+  "web.TITLES.domain_incoming": {
+    "text": "Segreti in arrivo"
   }
 }

--- a/locales/content/it_IT/10-layout.json
+++ b/locales/content/it_IT/10-layout.json
@@ -148,7 +148,7 @@
     "source_hash": "b9766df3"
   },
   "web.help.secret_view_faq.what_am_i_looking_at.description": {
-    "text": "Stai visualizzando un messaggio sicuro che è stato condiviso con te tramite {product_name}. Questo contenuto viene mostrato una sola volta e poi eliminato permanentemente dai nostri server.",
+    "text": "Stai visualizzando un messaggio sicuro che è stato condiviso con te tramite {product_name}. Questo contenuto viene mostrato una sola volta e poi eliminato definitivamente dai nostri server.",
     "source_hash": "e0f1a10c"
   },
   "web.help.secret_view_faq.can_i_view_again.title": {
@@ -264,7 +264,7 @@
     "source_hash": "e2f124cd"
   },
   "web.layout.visit_onetime_secret_homepage": {
-    "text": "Visita la home page di {product_name}",
+    "text": "Vai alla homepage di {product_name}",
     "source_hash": "625556d2"
   },
   "web.layout.footer_navigation": {
@@ -338,5 +338,11 @@
   "web.layout.workspace_context": {
     "text": "Contesto area di lavoro",
     "source_hash": "dc6fa4f5"
+  },
+  "web.footer.workspace": {
+    "text": "Workspace"
+  },
+  "web.help.default_content": {
+    "text": "Contatta il supporto per ricevere assistenza"
   }
 }

--- a/locales/content/it_IT/admin-colonel.json
+++ b/locales/content/it_IT/admin-colonel.json
@@ -634,5 +634,152 @@
   "web.colonel.feedback.when_you_submit_feedback_well_see": {
     "text": "Quando invii un feedback, vedremo:",
     "source_hash": "fe77172e"
+  },
+  "web.colonel.previewPlanMode": {
+    "text": "Modalità anteprima piano"
+  },
+  "web.colonel.previewModeDescription": {
+    "text": "Visualizza l'anteprima dell'applicazione come appare ai clienti con un piano diverso. Questo influisce solo sulla tua visualizzazione e non modifica il piano effettivo di alcuna organizzazione."
+  },
+  "web.colonel.previewModeActive": {
+    "text": "Anteprima attiva"
+  },
+  "web.colonel.bannedIps.empty": {
+    "text": "Nessun IP bloccato"
+  },
+  "web.colonel.bannedIps.currentIp": {
+    "text": "Il tuo indirizzo IP attuale"
+  },
+  "web.colonel.bannedIps.confirmUnban": {
+    "text": "Sbloccare {ip}?"
+  },
+  "web.colonel.bannedIps.actions.ban": {
+    "text": "Blocca IP"
+  },
+  "web.colonel.bannedIps.actions.quickBan": {
+    "text": "Blocco rapido"
+  },
+  "web.colonel.bannedIps.actions.unban": {
+    "text": "Sblocca"
+  },
+  "web.colonel.bannedIps.actions.cancel": {
+    "text": "Annulla"
+  },
+  "web.colonel.bannedIps.columns.ipAddress": {
+    "text": "Indirizzo IP"
+  },
+  "web.colonel.bannedIps.columns.reason": {
+    "text": "Motivo"
+  },
+  "web.colonel.bannedIps.columns.bannedAt": {
+    "text": "Bloccato il"
+  },
+  "web.colonel.bannedIps.columns.bannedBy": {
+    "text": "Bloccato da"
+  },
+  "web.colonel.bannedIps.error.banFailed": {
+    "text": "Impossibile bloccare l'indirizzo IP"
+  },
+  "web.colonel.bannedIps.error.unbanFailed": {
+    "text": "Impossibile sbloccare l'indirizzo IP"
+  },
+  "web.colonel.bannedIps.form.title": {
+    "text": "Blocca indirizzo IP"
+  },
+  "web.colonel.bannedIps.form.ipLabel": {
+    "text": "Indirizzo IP"
+  },
+  "web.colonel.bannedIps.form.reasonLabel": {
+    "text": "Motivo"
+  },
+  "web.colonel.bannedIps.form.reasonPlaceholder": {
+    "text": "Motivo facoltativo"
+  },
+  "web.colonel.bannedIps.success.banned": {
+    "text": "L'indirizzo IP {ip} è stato bloccato"
+  },
+  "web.colonel.bannedIps.success.unbanned": {
+    "text": "L'indirizzo IP {ip} è stato sbloccato"
+  },
+  "web.colonel.customDomains.empty": {
+    "text": "Nessun dominio personalizzato configurato"
+  },
+  "web.colonel.customDomains.noLogo": {
+    "text": "Nessun logo"
+  },
+  "web.colonel.customDomains.labels.organization": {
+    "text": "Organizzazione"
+  },
+  "web.colonel.customDomains.labels.externalId": {
+    "text": "ID esterno"
+  },
+  "web.colonel.customDomains.labels.created": {
+    "text": "Creato"
+  },
+  "web.colonel.customDomains.labels.updated": {
+    "text": "Aggiornato"
+  },
+  "web.colonel.customDomains.labels.favicon": {
+    "text": "Favicon"
+  },
+  "web.colonel.customDomains.status.verified": {
+    "text": "Verificato"
+  },
+  "web.colonel.customDomains.status.resolving": {
+    "text": "Risoluzione in corso"
+  },
+  "web.colonel.customDomains.status.ready": {
+    "text": "Pronto"
+  },
+  "web.colonel.customDomains.status.publicHomepage": {
+    "text": "Homepage pubblica"
+  },
+  "web.colonel.customDomains.status.publicApi": {
+    "text": "API pubblica"
+  },
+  "web.colonel.customDomains.status.pending": {
+    "text": "In sospeso"
+  },
+  "web.colonel.pagination.showing": {
+    "text": "Visualizzazione {start}–{end} di {total}"
+  },
+  "web.colonel.pagination.itemsPerPage": {
+    "text": "Elementi per pagina"
+  },
+  "web.colonel.pagination.perPage": {
+    "text": "{count} per pagina"
+  },
+  "web.colonel.pagination.pageOf": {
+    "text": "Pagina {current} di {total}"
+  },
+  "web.colonel.secrets.empty": {
+    "text": "Nessun segreto trovato"
+  },
+  "web.colonel.secrets.never": {
+    "text": "Mai"
+  },
+  "web.colonel.secrets.columns.shortId": {
+    "text": "ID breve"
+  },
+  "web.colonel.secrets.columns.state": {
+    "text": "Stato"
+  },
+  "web.colonel.secrets.columns.created": {
+    "text": "Creato"
+  },
+  "web.colonel.secrets.columns.expiration": {
+    "text": "Scadenza"
+  },
+  "web.colonel.secrets.columns.age": {
+    "text": "Età (giorni)"
+  },
+  "web.colonel.secrets.state.new": {
+    "text": "Nuovo"
+  },
+  "web.colonel.secrets.state.received": {
+    "text": "Ricevuto"
+  },
+  "web.colonel.secrets.state.viewed": {
+    "text": "Visualizzato"
   }
 }

--- a/locales/content/it_IT/api-account-errors.json
+++ b/locales/content/it_IT/api-account-errors.json
@@ -1,0 +1,8 @@
+{
+  "api.account.errors.invalid_email": {
+    "text": "È un indirizzo email valido?"
+  },
+  "api.account.errors.password_too_short": {
+    "text": "La password è troppo corta"
+  }
+}

--- a/locales/content/it_IT/api-domains-errors.json
+++ b/locales/content/it_IT/api-domains-errors.json
@@ -1,0 +1,29 @@
+{
+  "api.domains.errors.domain_id_required": {
+    "text": "ID dominio obbligatorio"
+  },
+  "api.domains.errors.domain_not_found": {
+    "text": "Dominio non trovato: %{extid}"
+  },
+  "api.domains.errors.organization_not_found": {
+    "text": "Organizzazione non trovata per il dominio: %{domain}"
+  },
+  "api.domains.errors.incoming_secrets_disabled": {
+    "text": "I segreti in arrivo non sono abilitati su questa istanza"
+  },
+  "api.domains.errors.incoming_secrets_entitlement_required": {
+    "text": "La gestione dei segreti in arrivo richiede il diritto incoming_secrets. Esegui l'upgrade del tuo piano."
+  },
+  "api.domains.errors.incoming_config_not_found": {
+    "text": "Configurazione dei segreti in arrivo non trovata per il dominio: %{extid}"
+  },
+  "api.domains.errors.recipients_max_exceeded": {
+    "text": "Sono consentiti al massimo %{max} destinatari"
+  },
+  "api.domains.errors.recipients_invalid_email": {
+    "text": "Email non valida: %{email}"
+  },
+  "api.domains.errors.recipients_duplicate": {
+    "text": "Non sono consentiti indirizzi email destinatari duplicati"
+  }
+}

--- a/locales/content/it_IT/api-entitlements-errors.json
+++ b/locales/content/it_IT/api-entitlements-errors.json
@@ -1,0 +1,71 @@
+{
+  "api.entitlements.errors.context_unavailable": {
+    "text": "Impossibile verificare i diritti (contesto dell'organizzazione non disponibile)"
+  },
+  "api.entitlements.errors.api_access_required": {
+    "text": "L'accesso API richiede l'upgrade del piano"
+  },
+  "api.entitlements.errors.custom_privacy_defaults_required": {
+    "text": "Le impostazioni predefinite di privacy personalizzate richiedono l'upgrade del piano"
+  },
+  "api.entitlements.errors.extended_default_expiration_required": {
+    "text": "La scadenza predefinita estesa richiede l'upgrade del piano"
+  },
+  "api.entitlements.errors.custom_domains_required": {
+    "text": "I domini personalizzati richiedono l'upgrade del piano"
+  },
+  "api.entitlements.errors.custom_branding_required": {
+    "text": "Il branding personalizzato richiede l'upgrade del piano"
+  },
+  "api.entitlements.errors.homepage_secrets_required": {
+    "text": "I segreti nella homepage richiedono l'upgrade del piano"
+  },
+  "api.entitlements.errors.incoming_secrets_required": {
+    "text": "I segreti in arrivo richiedono l'upgrade del piano"
+  },
+  "api.entitlements.errors.custom_mail_sender_required": {
+    "text": "Il mittente email personalizzato richiede l'upgrade del piano"
+  },
+  "api.entitlements.errors.flexible_from_domain_required": {
+    "text": "Il dominio mittente flessibile richiede l'upgrade del piano"
+  },
+  "api.entitlements.errors.manage_org_required": {
+    "text": "La gestione dell'organizzazione richiede l'upgrade del piano"
+  },
+  "api.entitlements.errors.manage_teams_required": {
+    "text": "La gestione dei team richiede l'upgrade del piano"
+  },
+  "api.entitlements.errors.manage_members_required": {
+    "text": "La gestione dei membri richiede l'upgrade del piano"
+  },
+  "api.entitlements.errors.manage_sso_required": {
+    "text": "La gestione SSO richiede l'upgrade del piano"
+  },
+  "api.entitlements.errors.audit_logs_required": {
+    "text": "I log di audit richiedono l'upgrade del piano"
+  },
+  "api.entitlements.errors.custom_signup_validation_required": {
+    "text": "La convalida della registrazione personalizzata richiede l'upgrade del piano"
+  },
+  "api.entitlements.errors.create_secrets_required": {
+    "text": "La creazione di segreti richiede l'upgrade del piano"
+  },
+  "api.entitlements.errors.view_receipt_required": {
+    "text": "La visualizzazione delle ricevute richiede l'upgrade del piano"
+  },
+  "api.entitlements.errors.notifications_required": {
+    "text": "Le notifiche richiedono l'upgrade del piano"
+  },
+  "api.entitlements.errors.workspace_branding_required": {
+    "text": "Il branding del Workspace richiede l'upgrade del piano"
+  },
+  "api.entitlements.errors.ip_access_rules_required": {
+    "text": "Le regole di accesso IP richiedono l'upgrade del piano"
+  },
+  "api.entitlements.errors.manage_billing_required": {
+    "text": "La gestione della fatturazione richiede l'upgrade del piano"
+  },
+  "api.entitlements.errors.custom_signin_config_required": {
+    "text": "La configurazione di accesso personalizzata richiede l'upgrade del piano"
+  }
+}

--- a/locales/content/it_IT/api-feedback-errors.json
+++ b/locales/content/it_IT/api-feedback-errors.json
@@ -1,0 +1,5 @@
+{
+  "api.feedback.errors.rate_limit_exceeded": {
+    "text": "Troppi invii di feedback. Riprova più tardi."
+  }
+}

--- a/locales/content/it_IT/api-incoming-errors.json
+++ b/locales/content/it_IT/api-incoming-errors.json
@@ -1,0 +1,5 @@
+{
+  "api.incoming.errors.custom_domain_unresolved": {
+    "text": "Impossibile risolvere l'organizzazione del dominio personalizzato"
+  }
+}

--- a/locales/content/it_IT/api-invite-errors.json
+++ b/locales/content/it_IT/api-invite-errors.json
@@ -1,0 +1,23 @@
+{
+  "api.invite.errors.invitation_not_found_or_expired": {
+    "text": "Invito non trovato o scaduto"
+  },
+  "api.invite.errors.token_required": {
+    "text": "Il token è obbligatorio"
+  },
+  "api.invite.errors.organization_no_longer_exists": {
+    "text": "L'organizzazione non esiste più"
+  },
+  "api.invite.errors.invitation_already_processed": {
+    "text": "L'invito è già stato %{status}"
+  },
+  "api.invite.errors.invitation_expired": {
+    "text": "L'invito è scaduto"
+  },
+  "api.invite.errors.email_mismatch": {
+    "text": "Il tuo indirizzo email non corrisponde all'invito"
+  },
+  "api.invite.errors.already_member": {
+    "text": "Sei già membro di questa organizzazione"
+  }
+}

--- a/locales/content/it_IT/api-organizations-errors.json
+++ b/locales/content/it_IT/api-organizations-errors.json
@@ -1,0 +1,107 @@
+{
+  "api.organizations.errors.domain_scoped_forbidden": {
+    "text": "I membri con ambito di dominio non possono eseguire questa azione"
+  },
+  "api.organizations.errors.organization_not_found": {
+    "text": "Organizzazione non trovata: %{extid}"
+  },
+  "api.organizations.errors.organization_owner_required": {
+    "text": "Solo il proprietario dell'organizzazione può eseguire questa azione"
+  },
+  "api.organizations.errors.organization_member_required": {
+    "text": "Devi essere membro dell'organizzazione per eseguire questa azione"
+  },
+  "api.organizations.errors.organization_admin_required": {
+    "text": "Solo i proprietari e gli amministratori dell'organizzazione possono eseguire questa azione"
+  },
+  "api.organizations.errors.extid_required": {
+    "text": "ID organizzazione obbligatorio"
+  },
+  "api.organizations.errors.display_name_required": {
+    "text": "Il nome dell'organizzazione è obbligatorio"
+  },
+  "api.organizations.errors.display_name_too_long": {
+    "text": "Il nome dell'organizzazione deve contenere meno di %{max} caratteri"
+  },
+  "api.organizations.errors.description_too_long": {
+    "text": "La descrizione deve contenere meno di %{max} caratteri"
+  },
+  "api.organizations.errors.contact_email_exists": {
+    "text": "Esiste già un'organizzazione con questa email di contatto"
+  },
+  "api.organizations.errors.creation_in_progress": {
+    "text": "Creazione dell'organizzazione in corso. Riprova."
+  },
+  "api.organizations.errors.organization_limit_reached": {
+    "text": "Limite di organizzazioni raggiunto. Esegui l'upgrade del tuo piano per creare altre organizzazioni."
+  },
+  "api.organizations.invitations.errors.invitation_not_found": {
+    "text": "Invito non trovato"
+  },
+  "api.organizations.invitations.errors.email_required": {
+    "text": "L'email è obbligatoria"
+  },
+  "api.organizations.invitations.errors.invalid_email_format": {
+    "text": "Formato email non valido"
+  },
+  "api.organizations.invitations.errors.invalid_role": {
+    "text": "Il ruolo deve essere membro o amministratore"
+  },
+  "api.organizations.invitations.errors.cannot_invite_as_owner": {
+    "text": "Impossibile invitare come proprietario"
+  },
+  "api.organizations.invitations.errors.user_already_member": {
+    "text": "L'utente è già membro di questa organizzazione"
+  },
+  "api.organizations.invitations.errors.invitation_already_pending": {
+    "text": "Esiste già un invito in sospeso per questa email"
+  },
+  "api.organizations.invitations.errors.member_limit_reached": {
+    "text": "Limite di membri raggiunto. Esegui l'upgrade del tuo piano per invitare altri membri."
+  },
+  "api.organizations.invitations.errors.resend_only_pending": {
+    "text": "È possibile inviare nuovamente solo gli inviti in sospeso"
+  },
+  "api.organizations.invitations.errors.resend_limit_reached": {
+    "text": "Limite massimo di nuovi invii (%{max}) raggiunto"
+  },
+  "api.organizations.invitations.errors.revoke_only_pending": {
+    "text": "È possibile revocare solo gli inviti in sospeso"
+  },
+  "api.organizations.members.errors.member_not_found": {
+    "text": "Membro non trovato: %{extid}"
+  },
+  "api.organizations.members.errors.member_not_in_organization": {
+    "text": "Membro non trovato in questa organizzazione"
+  },
+  "api.organizations.members.errors.member_not_active": {
+    "text": "Il membro non è attivo"
+  },
+  "api.organizations.members.errors.invalid_role_value": {
+    "text": "Ruolo non valido. Deve essere uno tra: %{roles}"
+  },
+  "api.organizations.members.errors.cannot_change_owner_role": {
+    "text": "Impossibile modificare il ruolo del proprietario. Utilizza invece il trasferimento di proprietà."
+  },
+  "api.organizations.members.errors.member_already_has_role": {
+    "text": "Il membro ha già il ruolo: %{role}"
+  },
+  "api.organizations.members.errors.cannot_promote_to_owner": {
+    "text": "Impossibile promuovere a proprietario. Utilizza invece il trasferimento di proprietà."
+  },
+  "api.organizations.members.errors.must_be_member": {
+    "text": "Devi essere membro di questa organizzazione"
+  },
+  "api.organizations.members.errors.cannot_remove_owner": {
+    "text": "Impossibile rimuovere il proprietario dell'organizzazione. Trasferisci prima la proprietà."
+  },
+  "api.organizations.members.errors.cannot_remove_self": {
+    "text": "Impossibile rimuovere te stesso. Utilizza invece l'opzione per abbandonare l'organizzazione."
+  },
+  "api.organizations.members.errors.admin_cannot_remove_admin": {
+    "text": "Gli amministratori non possono rimuovere altri amministratori. Solo i proprietari possono farlo."
+  },
+  "api.organizations.members.errors.no_permission_to_remove": {
+    "text": "Non disponi dell'autorizzazione per rimuovere i membri"
+  }
+}

--- a/locales/content/it_IT/api-secrets-errors.json
+++ b/locales/content/it_IT/api-secrets-errors.json
@@ -1,0 +1,11 @@
+{
+  "api.secrets.errors.domain_permission_authenticated_non_owner": {
+    "text": "Non disponi dell'autorizzazione per utilizzare il dominio: %{domain}"
+  },
+  "api.secrets.errors.domain_public_sharing_disabled": {
+    "text": "Condivisione pubblica disabilitata per il dominio: %{domain}"
+  },
+  "api.secrets.errors.domain_permission_anonymous_cross_domain": {
+    "text": "Non disponi dell'autorizzazione per utilizzare il dominio: %{domain}"
+  }
+}

--- a/locales/content/it_IT/email.json
+++ b/locales/content/it_IT/email.json
@@ -60,7 +60,7 @@
     "source_hash": "88c72144"
   },
   "email.welcome.signature": {
-    "text": "Delano",
+    "text": "Team di supporto",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -100,7 +100,7 @@
     "source_hash": "fbb7eb2d"
   },
   "email.password_request.signature": {
-    "text": "Delano",
+    "text": "Team di supporto",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -145,7 +145,7 @@
     "source_hash": "1863f5be"
   },
   "email.magic_link.signature": {
-    "text": "Delano",
+    "text": "Team di supporto",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -230,7 +230,7 @@
     "source_hash": "3f6b45dd"
   },
   "email.secret_revealed.signature": {
-    "text": "Delano",
+    "text": "Team di supporto",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -355,7 +355,7 @@
     "source_hash": "734882d2"
   },
   "email.organization_invitation.signature": {
-    "text": "Delano",
+    "text": "Team di supporto",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -395,7 +395,7 @@
     "source_hash": "be92cff3"
   },
   "email.password_changed.signature": {
-    "text": "Delano",
+    "text": "Team di supporto",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -445,7 +445,7 @@
     "source_hash": "f8d47b82"
   },
   "email.email_changed.signature": {
-    "text": "Delano",
+    "text": "Team di supporto",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -495,7 +495,7 @@
     "source_hash": "f8d47b82"
   },
   "email.email_change_requested.signature": {
-    "text": "Delano",
+    "text": "Team di supporto",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -550,7 +550,7 @@
     "source_hash": "d4d835fc"
   },
   "email.email_change_confirmation.signature": {
-    "text": "Delano",
+    "text": "Team di supporto",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -580,7 +580,7 @@
     "source_hash": "e7c11bb0"
   },
   "email.mfa_enabled.signature": {
-    "text": "Delano",
+    "text": "Team di supporto",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -605,7 +605,7 @@
     "source_hash": "97ef0a3e"
   },
   "email.mfa_disabled.signature": {
-    "text": "Delano",
+    "text": "Team di supporto",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -650,7 +650,7 @@
     "source_hash": "450c54c5"
   },
   "email.new_login_alert.signature": {
-    "text": "Delano",
+    "text": "Team di supporto",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -670,7 +670,7 @@
     "source_hash": "d442beed"
   },
   "email.member_removed.signature": {
-    "text": "Delano",
+    "text": "Team di supporto",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -690,7 +690,7 @@
     "source_hash": "c2280c0c"
   },
   "email.role_changed.signature": {
-    "text": "Delano",
+    "text": "Team di supporto",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -710,7 +710,7 @@
     "source_hash": "7095fc69"
   },
   "email.organization_deleted.signature": {
-    "text": "Delano",
+    "text": "Team di supporto",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -750,7 +750,7 @@
     "source_hash": "36008943"
   },
   "email.payment_receipt.signature": {
-    "text": "Delano",
+    "text": "Team di supporto",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -775,7 +775,7 @@
     "source_hash": "926406b1"
   },
   "email.payment_failed.signature": {
-    "text": "Delano",
+    "text": "Team di supporto",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -800,7 +800,7 @@
     "source_hash": "66a1419e"
   },
   "email.trial_expiring.signature": {
-    "text": "Delano",
+    "text": "Team di supporto",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -825,7 +825,7 @@
     "source_hash": "5a96ae38"
   },
   "email.subscription_changed.signature": {
-    "text": "Delano",
+    "text": "Team di supporto",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -853,5 +853,41 @@
     "text": "Onetime Secret",
     "renderer": "erb",
     "source_hash": "1cd0194a"
+  },
+  "email.common.secret_link_label": {
+    "text": "Link segreto"
+  },
+  "email.common.automated_notice": {
+    "text": "Questo è un messaggio automatico da %{product_name}."
+  },
+  "email.common.support_label": {
+    "text": "Supporto"
+  },
+  "email.expiration_warning.signature": {
+    "text": "Team di supporto"
+  },
+  "email.expiration_warning.footer_note": {
+    "text": "Hai ricevuto questo messaggio perché un segreto che hai creato su %{product_name} sta per scadere."
+  },
+  "email.feedback_email.user_id_label": {
+    "text": "Utente:"
+  },
+  "email.feedback_email.timezone_label": {
+    "text": "Fuso orario:"
+  },
+  "email.feedback_email.version_label": {
+    "text": "Versione:"
+  },
+  "email.incoming_secret.footer_note": {
+    "text": "Hai ricevuto questo messaggio perché qualcuno ha usato %{product_name} per inviarti un segreto. Se non te lo aspettavi, puoi ignorare questa email senza problemi."
+  },
+  "email.secret_link.passphrase_label": {
+    "text": "Frase di sicurezza richiesta:"
+  },
+  "email.secret_link.passphrase_required": {
+    "text": "Questo segreto è protetto da una frase di sicurezza. Il mittente dovrebbe fornirtela separatamente."
+  },
+  "email.secret_link.footer_note": {
+    "text": "Hai ricevuto questo messaggio perché %{sender_email} ha usato %{product_name} per condividere un segreto con te. Se non te lo aspettavi, puoi ignorare questa email senza problemi."
   }
 }

--- a/locales/content/it_IT/feature-feedback.json
+++ b/locales/content/it_IT/feature-feedback.json
@@ -58,5 +58,14 @@
   "web.feedback.reason_email_change_unauthorized": {
     "text": "Sembra che tu stia segnalando una modifica non autorizzata dell'email del tuo account. Descrivi cosa è successo e indagheremo immediatamente.",
     "source_hash": "00e56551"
+  },
+  "web.feedback.anonymous_no_reply": {
+    "text": "Nota: se desideri una risposta, firma o includi un indirizzo email nel messaggio."
+  },
+  "web.feedback.characters_remaining": {
+    "text": "{count} caratteri rimanenti"
+  },
+  "web.feedback.character_limit_reached": {
+    "text": "Limite di caratteri raggiunto"
   }
 }

--- a/locales/content/it_IT/feature-homepage-secrets.json
+++ b/locales/content/it_IT/feature-homepage-secrets.json
@@ -1,0 +1,50 @@
+{
+  "homepage_secrets.disabled.members_only_eyebrow": {
+    "text": "Istanza riservata ai membri"
+  },
+  "homepage_secrets.disabled.private_instance_eyebrow": {
+    "text": "Istanza privata"
+  },
+  "homepage_secrets.disabled.team_link_headline": {
+    "text": "Questo link è per il team {workspace}."
+  },
+  "homepage_secrets.disabled.signin_headline": {
+    "text": "Accedi per creare un {action}."
+  },
+  "homepage_secrets.disabled.signin_headline_action": {
+    "text": "link segreto"
+  },
+  "homepage_secrets.disabled.team_subtitle": {
+    "text": "Solo i membri del team autorizzati su {domain} possono creare nuovi link monouso qui. I destinatari possono comunque aprire qualsiasi link ricevuto."
+  },
+  "homepage_secrets.disabled.public_subtitle": {
+    "text": "Solo i membri autorizzati di questa istanza possono creare nuovi link monouso. I destinatari possono comunque aprire qualsiasi link ricevuto."
+  },
+  "homepage_secrets.disabled.signin_cta": {
+    "text": "Accedi al tuo account"
+  },
+  "homepage_secrets.disabled.what_is_this": {
+    "text": "Cos'è?"
+  },
+  "homepage_secrets.disabled.trust_viewed_once": {
+    "text": "Visualizzato una volta, poi sparisce"
+  },
+  "homepage_secrets.disabled.trust_zero_retained": {
+    "text": "Nessun dato conservato"
+  },
+  "homepage_secrets.disabled.promo_title": {
+    "text": "Novità: i piani gratuiti ora includono i domini personalizzati."
+  },
+  "homepage_secrets.disabled.promo_subtitle": {
+    "text": "Indirizza il tuo dominio verso Onetime Secret e invia segreti con il tuo brand."
+  },
+  "homepage_secrets.disabled.promo_learn_how": {
+    "text": "Scopri come"
+  },
+  "homepage_secrets.disabled.logo_alt": {
+    "text": "Logo {name}"
+  },
+  "homepage_secrets.disabled.opens_in_new_tab": {
+    "text": "(si apre in una nuova scheda)"
+  }
+}

--- a/locales/content/it_IT/feature-incoming.json
+++ b/locales/content/it_IT/feature-incoming.json
@@ -130,5 +130,26 @@
   "incoming.receipt_link_text": {
     "text": "ricevuta",
     "source_hash": "6f328609"
+  },
+  "incoming.upgrade_required_title": {
+    "text": "Upgrade richiesto"
+  },
+  "incoming.upgrade_required_description": {
+    "text": "Questa funzionalità richiede l'upgrade del piano. Contatta il proprietario dell'account per abilitare i segreti in arrivo."
+  },
+  "incoming.validation_memo_too_long": {
+    "text": "La nota deve contenere al massimo {max} caratteri"
+  },
+  "incoming.validation_secret_required": {
+    "text": "Il contenuto del segreto è obbligatorio"
+  },
+  "incoming.validation_recipient_required": {
+    "text": "Seleziona un destinatario"
+  },
+  "incoming.validation_feature_disabled": {
+    "text": "La funzionalità dei segreti in arrivo non è abilitata"
+  },
+  "incoming.validation_form_errors": {
+    "text": "Controlla il modulo per individuare gli errori"
   }
 }

--- a/locales/content/it_IT/feature-regions.json
+++ b/locales/content/it_IT/feature-regions.json
@@ -186,5 +186,8 @@
   "web.regions.jurisdictions.apac.name": {
     "text": "Asia-Pacific",
     "source_hash": "7a757670"
+  },
+  "web.regions.no_region_configured": {
+    "text": "Al momento non sono disponibili informazioni sulla regione per il tuo account."
   }
 }

--- a/locales/content/it_IT/secret-homepage.json
+++ b/locales/content/it_IT/secret-homepage.json
@@ -172,7 +172,7 @@
     "source_hash": "0990d163"
   },
   "web.homepage.onetime_secret_helps_us_share_sensitive_informat": {
-    "text": "{product_name} ci aiuta a condividere informazioni sensibili in modo sicuro mantenendo la nostra facciata professionale",
+    "text": "{product_name} ci aiuta a condividere informazioni sensibili in modo sicuro mantenendo la nostra facciata professionale.",
     "source_hash": "986a0856"
   },
   "web.homepage.information_shared_through_this_service_can_only": {

--- a/locales/content/it_IT/secret-manage.json
+++ b/locales/content/it_IT/secret-manage.json
@@ -398,5 +398,11 @@
   "web.secrets.errors.access_denied_to_domain": {
     "text": "Accesso al dominio negato",
     "source_hash": "cd441eea"
+  },
+  "web.receipt.open_link": {
+    "text": "Apri link"
+  },
+  "web.secrets.messageDeleted": {
+    "text": "Messaggio eliminato"
   }
 }

--- a/locales/content/it_IT/session-auth-extended.json
+++ b/locales/content/it_IT/session-auth-extended.json
@@ -710,5 +710,26 @@
   "web.auth.recovery_codes.link_title": {
     "text": "Codici di recupero",
     "source_hash": "579c7f4e"
+  },
+  "web.auth.google": {
+    "text": "Google"
+  },
+  "web.auth.mfa.alternative_auth_options": {
+    "text": "Opzioni di autenticazione alternative"
+  },
+  "web.auth.remember.enabled": {
+    "text": "Resta connesso"
+  },
+  "web.auth.security._guidance.context": {
+    "text": "⚠️ SECURITY-CRITICAL: Messages prevent information disclosure. See src/locales/SECURITY-TRANSLATION-GUIDE.md"
+  },
+  "web.auth.sessions.session_singular": {
+    "text": "sessione"
+  },
+  "web.auth.sessions.session_plural": {
+    "text": "sessioni"
+  },
+  "web.auth.sessions._guidance.context": {
+    "text": "User's logged-in devices/browsers management page"
   }
 }

--- a/locales/content/it_IT/session-auth-extended.json
+++ b/locales/content/it_IT/session-auth-extended.json
@@ -720,16 +720,10 @@
   "web.auth.remember.enabled": {
     "text": "Resta connesso"
   },
-  "web.auth.security._guidance.context": {
-    "text": "⚠️ SECURITY-CRITICAL: Messages prevent information disclosure. See src/locales/SECURITY-TRANSLATION-GUIDE.md"
-  },
   "web.auth.sessions.session_singular": {
     "text": "sessione"
   },
   "web.auth.sessions.session_plural": {
     "text": "sessioni"
-  },
-  "web.auth.sessions._guidance.context": {
-    "text": "User's logged-in devices/browsers management page"
   }
 }

--- a/locales/content/it_IT/session-auth.json
+++ b/locales/content/it_IT/session-auth.json
@@ -399,9 +399,6 @@
   "web.auth.account.sso_linked": {
     "text": "Account SSO"
   },
-  "web.auth.verify._guidance.context": {
-    "text": "Email verification flow after signup"
-  },
   "web.help.reset_password_link": {
     "text": "Reimposta password"
   },

--- a/locales/content/it_IT/session-auth.json
+++ b/locales/content/it_IT/session-auth.json
@@ -395,5 +395,35 @@
   "web.help.contact_support": {
     "text": "Contatta il supporto",
     "source_hash": "f8d47b82"
+  },
+  "web.auth.account.sso_linked": {
+    "text": "Account SSO"
+  },
+  "web.auth.verify._guidance.context": {
+    "text": "Email verification flow after signup"
+  },
+  "web.help.reset_password_link": {
+    "text": "Reimposta password"
+  },
+  "web.login.custom_domain_sso_title": {
+    "text": "Single Sign-On è disponibile per questo dominio"
+  },
+  "web.login.custom_domain_sso_description": {
+    "text": "L'amministratore dell'organizzazione può abilitare l'SSO per consentire ai membri del team di accedere qui. Contatta l'amministratore per l'accesso."
+  },
+  "web.login.signin_disabled_heading": {
+    "text": "L'accesso non è disponibile"
+  },
+  "web.login.signin_disabled_message": {
+    "text": "Al momento l'accesso non è disponibile su questo dominio."
+  },
+  "web.login.errors.sso_not_configured": {
+    "text": "Single Sign-On non è configurato per questo dominio. Contatta il tuo amministratore."
+  },
+  "web.login.errors.invalid_email": {
+    "text": "L'indirizzo email del tuo provider di identità non è valido. Contatta il tuo amministratore."
+  },
+  "web.login.errors.domain_not_allowed": {
+    "text": "Il tuo dominio email non è autorizzato per la registrazione tramite SSO. Contatta il tuo amministratore."
   }
 }

--- a/locales/content/it_IT/workspace-account.json
+++ b/locales/content/it_IT/workspace-account.json
@@ -682,5 +682,14 @@
   "web.settings.profile.didnt_receive_email": {
     "text": "Non hai ricevuto l'email?",
     "source_hash": "fe3ac3ad"
+  },
+  "web.settings.api.api_disabled_notice": {
+    "text": "L'API è disabilitata per questa istanza."
+  },
+  "web.settings.security.sso_managed_title": {
+    "text": "Sicurezza gestita tramite SSO"
+  },
+  "web.settings.security.sso_managed_description": {
+    "text": "Il tuo account viene autenticato tramite il provider Single Sign-On della tua organizzazione. La password, l'autenticazione a più fattori e i codici di recupero sono gestiti dal tuo provider di identità."
   }
 }

--- a/locales/content/it_IT/workspace-billing.json
+++ b/locales/content/it_IT/workspace-billing.json
@@ -988,5 +988,47 @@
     "text": "Disponibile solo nella regione dell'abbonamento originale",
     "context": "Hint shown on plan cards when currency does not match active subscription",
     "source_hash": "10de32e5"
+  },
+  "web.billing.already_subscribed": {
+    "text": "Sei già abbonato a questo piano."
+  },
+  "web.billing.cancel.reactivate_button": {
+    "text": "Riattiva abbonamento"
+  },
+  "web.billing.cancel.reactivate_success": {
+    "text": "Il tuo abbonamento è stato riattivato. Continuerai a essere addebitato come di consueto."
+  },
+  "web.billing.cancel.reactivate_error": {
+    "text": "Riattivazione dell'abbonamento non riuscita. Riprova o contatta l'assistenza."
+  },
+  "web.billing.features.manage_orgs": {
+    "text": "Gestione dell'organizzazione"
+  },
+  "web.billing.features.flexible_from_domain": {
+    "text": "Dominio mittente email flessibile"
+  },
+  "web.billing.features.unlimited_admins": {
+    "text": "Amministratori illimitati"
+  },
+  "web.billing.features.manage_sso": {
+    "text": "SSO"
+  },
+  "web.billing.overview.entitlements.flexible_from_domain": {
+    "text": "Dominio mittente email flessibile"
+  },
+  "web.billing.overview.entitlements.manage_orgs": {
+    "text": "Gestisci organizzazioni"
+  },
+  "web.billing.overview.entitlements.manage_sso": {
+    "text": "Single Sign-On (SSO)"
+  },
+  "web.billing.overview.entitlements.manage_billing": {
+    "text": "Gestisci fatturazione"
+  },
+  "web.billing.overview.entitlements.custom_signup_validation": {
+    "text": "Convalida della registrazione personalizzata"
+  },
+  "web.billing.plans.reactivate": {
+    "text": "Riattiva"
   }
 }

--- a/locales/content/it_IT/workspace-branding.json
+++ b/locales/content/it_IT/workspace-branding.json
@@ -178,5 +178,11 @@
   "web.branding.upgrade_to_customize": {
     "text": "Effettua l'upgrade del piano per personalizzare il branding di questo dominio.",
     "source_hash": "9077bf79"
+  },
+  "web.branding.saved_successfully": {
+    "text": "Impostazioni del marchio salvate correttamente"
+  },
+  "web.branding.keyhole_logo_icon": {
+    "text": "Icona a forma di buco della serratura che rappresenta una condivisione sicura e privata"
   }
 }

--- a/locales/content/it_IT/workspace-dashboard.json
+++ b/locales/content/it_IT/workspace-dashboard.json
@@ -22,5 +22,14 @@
   "web.dashboard.fetch_error_description": {
     "text": "Si è verificato un problema nel caricamento dei dati. Riprova.",
     "source_hash": "ff0d904e"
+  },
+  "web.teams.create_first_team_title": {
+    "text": "Crea il tuo primo team"
+  },
+  "web.teams.create_first_team_description": {
+    "text": "I team ti permettono di collaborare con altri in un Workspace condiviso."
+  },
+  "web.teams.create_team": {
+    "text": "Crea team"
   }
 }

--- a/locales/content/it_IT/workspace-domains.json
+++ b/locales/content/it_IT/workspace-domains.json
@@ -398,5 +398,725 @@
   "web.domains.dns_widget_description": {
     "text": "Usa lo strumento qui sotto per rilevare automaticamente il tuo provider DNS e ottenere istruzioni passo passo per configurare il tuo dominio.",
     "source_hash": "91c1af2e"
+  },
+  "api.domains.errors.add_admin_required": {
+    "text": "Solo i proprietari e gli amministratori dell'organizzazione possono aggiungere domini personalizzati"
+  },
+  "web.domains.public_homepage": {
+    "text": "Homepage pubblica"
+  },
+  "web.domains.status_tooltip_active": {
+    "text": "Dominio verificato e attivo"
+  },
+  "web.domains.status_tooltip_dns_incorrect": {
+    "text": "DNS non configurato — clicca per correggere"
+  },
+  "web.domains.status_tooltip_not_verified": {
+    "text": "Dominio non verificato — clicca per verificare"
+  },
+  "web.domains.status_tooltip_unverified": {
+    "text": "Stato del dominio non verificato — clicca per aggiornare"
+  },
+  "web.domains.last_check_failed": {
+    "text": "Ultimo controllo di verifica non riuscito"
+  },
+  "web.domains.last_check_failed_ago": {
+    "text": "ultimo controllo non riuscito {0}"
+  },
+  "web.domains.verify_now": {
+    "text": "Verifica ora"
+  },
+  "web.domains.click_to_verify": {
+    "text": "clicca per verificare"
+  },
+  "web.domains.remove_domain_description": {
+    "text": "Rimuovi definitivamente questo dominio e tutta la sua configurazione."
+  },
+  "web.domains.add_access_denied": {
+    "text": "Accesso negato"
+  },
+  "web.domains.add_access_denied_description": {
+    "text": "Non hai l'autorizzazione per aggiungere domini a questa organizzazione. Contatta l'amministratore della tua organizzazione."
+  },
+  "web.domains.dns_widget_load_failed": {
+    "text": "Caricamento del widget DNS non riuscito"
+  },
+  "web.domains.dns_widget_not_available": {
+    "text": "Widget DNS non disponibile"
+  },
+  "web.domains.dns_widget_init_failed": {
+    "text": "Inizializzazione del widget DNS non riuscita"
+  },
+  "web.domains.verified": {
+    "text": "Verificato"
+  },
+  "web.domains.pending_verification": {
+    "text": "In attesa di verifica"
+  },
+  "web.domains.unsaved_changes_confirmation": {
+    "text": "Hai modifiche non salvate. Sei sicuro di voler uscire?"
+  },
+  "web.domains.entitlement_required_owner": {
+    "text": "Questa funzionalità richiede l'upgrade del piano."
+  },
+  "web.domains.entitlement_required_member": {
+    "text": "Questa funzionalità non è disponibile nel tuo piano attuale. Contatta il proprietario della tua organizzazione."
+  },
+  "web.domains.detail.manage": {
+    "text": "Gestisci"
+  },
+  "web.domains.detail.features": {
+    "text": "Funzionalità"
+  },
+  "web.domains.detail.homepage_title": {
+    "text": "Segreti homepage"
+  },
+  "web.domains.detail.homepage_description": {
+    "text": "Consenti l'accesso pubblico per creare segreti sulla homepage del tuo dominio"
+  },
+  "web.domains.detail.brand_description": {
+    "text": "Logo, colori e branding personalizzato"
+  },
+  "web.domains.detail.sso_description": {
+    "text": "Impostazioni del provider Single Sign-On"
+  },
+  "web.domains.detail.email_description": {
+    "text": "Configurazione del mittente email personalizzato"
+  },
+  "web.domains.detail.incoming_description": {
+    "text": "Impostazioni dei destinatari dei segreti in arrivo"
+  },
+  "web.domains.detail.signup_description": {
+    "text": "Strategia di convalida della registrazione per dominio"
+  },
+  "web.domains.detail.signin_description": {
+    "text": "Configurazione del metodo di accesso per dominio"
+  },
+  "web.domains.email.title": {
+    "text": "Invio email"
+  },
+  "web.domains.email.config_title": {
+    "text": "Configurazione email"
+  },
+  "web.domains.email.config_description": {
+    "text": "Configura l'invio di email per questo dominio"
+  },
+  "web.domains.email.provider_label": {
+    "text": "Provider email"
+  },
+  "web.domains.email.provider_placeholder": {
+    "text": "Seleziona un provider email"
+  },
+  "web.domains.email.from_name_label": {
+    "text": "Nome mittente"
+  },
+  "web.domains.email.from_name_placeholder": {
+    "text": "es. Acme Security"
+  },
+  "web.domains.email.from_address_label": {
+    "text": "Indirizzo mittente"
+  },
+  "web.domains.email.from_address_placeholder": {
+    "text": "es. secrets{'@'}example.com"
+  },
+  "web.domains.email.reply_to_label": {
+    "text": "Indirizzo di risposta"
+  },
+  "web.domains.email.reply_to_placeholder": {
+    "text": "es. support{'@'}example.com"
+  },
+  "web.domains.email.save_changes": {
+    "text": "Salva modifiche"
+  },
+  "web.domains.email.discard_changes": {
+    "text": "Annulla modifiche"
+  },
+  "web.domains.email.provider_ses": {
+    "text": "Amazon SES"
+  },
+  "web.domains.email.provider_sendgrid": {
+    "text": "SendGrid"
+  },
+  "web.domains.email.provider_lettermint": {
+    "text": "Lettermint"
+  },
+  "web.domains.email.provider_inherit": {
+    "text": "Usa le impostazioni predefinite dell'account"
+  },
+  "web.domains.email.provider_ses_description": {
+    "text": "Richiede la verifica del dominio tramite record DKIM e SPF"
+  },
+  "web.domains.email.provider_sendgrid_description": {
+    "text": "Richiede la configurazione dell'autenticazione del dominio"
+  },
+  "web.domains.email.provider_lettermint_description": {
+    "text": "Richiede la verifica del dominio"
+  },
+  "web.domains.email.provider_inherit_description": {
+    "text": "Usa la configurazione predefinita di invio email del tuo account"
+  },
+  "web.domains.email.dns_records_title": {
+    "text": "Record DNS"
+  },
+  "web.domains.email.dns_records_description": {
+    "text": "Aggiungi i seguenti record DNS per verificare il tuo dominio per l'invio di email."
+  },
+  "web.domains.email.dns_column_type": {
+    "text": "Tipo"
+  },
+  "web.domains.email.dns_column_name": {
+    "text": "Nome"
+  },
+  "web.domains.email.dns_column_value": {
+    "text": "Valore"
+  },
+  "web.domains.email.dns_check_label": {
+    "text": "DNS"
+  },
+  "web.domains.email.provider_check_label": {
+    "text": "Provider"
+  },
+  "web.domains.email.dns_optional_label": {
+    "text": "Consigliato"
+  },
+  "web.domains.email.dns_optional_hint": {
+    "text": "Questo record è consigliato ma non obbligatorio per la verifica. Una policy DMARC sul tuo dominio organizzativo potrebbe già coprire questo sottodominio."
+  },
+  "web.domains.email.copy": {
+    "text": "Copia"
+  },
+  "web.domains.email.copied": {
+    "text": "Copiato"
+  },
+  "web.domains.email.status_verified": {
+    "text": "Verificato"
+  },
+  "web.domains.email.status_pending": {
+    "text": "In sospeso"
+  },
+  "web.domains.email.status_failed": {
+    "text": "Non riuscito"
+  },
+  "web.domains.email.revalidate": {
+    "text": "Riconvalida"
+  },
+  "web.domains.email.validating": {
+    "text": "Convalida in corso..."
+  },
+  "web.domains.email.domain_verified": {
+    "text": "Dominio verificato"
+  },
+  "web.domains.email.validation_failed": {
+    "text": "Convalida non riuscita"
+  },
+  "web.domains.email.last_validated": {
+    "text": "Ultima convalida"
+  },
+  "web.domains.email.upgrade_to_configure": {
+    "text": "Esegui l'upgrade del tuo piano per configurare l'invio di email per questo dominio."
+  },
+  "web.domains.email.configure_email": {
+    "text": "Configura email"
+  },
+  "web.domains.email.access_denied": {
+    "text": "Accesso negato"
+  },
+  "web.domains.email.access_denied_description": {
+    "text": "Non hai l'autorizzazione per gestire le impostazioni email di questo dominio. Contatta l'amministratore della tua organizzazione."
+  },
+  "web.domains.email.update_success": {
+    "text": "Configurazione email salvata correttamente"
+  },
+  "web.domains.email.delete_success": {
+    "text": "Configurazione email rimossa correttamente"
+  },
+  "web.domains.email.default_sender_notice": {
+    "text": "Le email per questo dominio vengono attualmente inviate dal mittente globale. Completa la configurazione email per usare la tua identità mittente."
+  },
+  "web.domains.email.disabled_notice": {
+    "text": "L'invio di email personalizzato è attualmente disabilitato. Le email verranno inviate dal mittente globale. Abilita la funzionalità qui sotto per usare la tua identità mittente personalizzata."
+  },
+  "web.domains.email.test_email_title": {
+    "text": "Prova di consegna email"
+  },
+  "web.domains.email.test_email_hint": {
+    "text": "Invia un'email di prova a te stesso usando la configurazione salvata. Funziona anche quando la funzionalità non è ancora abilitata."
+  },
+  "web.domains.email.send_test": {
+    "text": "Invia prova"
+  },
+  "web.domains.email.test_email_sent": {
+    "text": "Email di prova inviata correttamente"
+  },
+  "web.domains.email.test_email_failed": {
+    "text": "Invio dell'email di prova non riuscito"
+  },
+  "web.domains.email.test_email_sent_to": {
+    "text": "Inviata a {email}"
+  },
+  "web.domains.email.delivered_via": {
+    "text": "Consegnata tramite {provider}"
+  },
+  "web.domains.email.badge_not_configured": {
+    "text": "Non configurato"
+  },
+  "web.domains.email.badge_default_sender": {
+    "text": "Mittente predefinito in uso"
+  },
+  "web.domains.email.badge_verified": {
+    "text": "Verificato"
+  },
+  "web.domains.email.badge_pending": {
+    "text": "In attesa di verifica"
+  },
+  "web.domains.email.badge_disabled": {
+    "text": "Disabilitato"
+  },
+  "web.domains.email.tooltip_not_configured": {
+    "text": "Nessun mittente email configurato — le email usano il mittente predefinito della piattaforma"
+  },
+  "web.domains.email.tooltip_pending": {
+    "text": "La configurazione del mittente email è in attesa di verifica — le email usano il mittente predefinito della piattaforma"
+  },
+  "web.domains.email.tooltip_disabled": {
+    "text": "Il mittente email è disabilitato — le email usano il mittente predefinito della piattaforma"
+  },
+  "web.domains.email.tooltip_verified": {
+    "text": "Mittente email verificato — le email vengono inviate da questo dominio"
+  },
+  "web.domains.incoming.title": {
+    "text": "Segreti in arrivo"
+  },
+  "web.domains.incoming.config_title": {
+    "text": "Configurazione dei segreti in arrivo"
+  },
+  "web.domains.incoming.config_description": {
+    "text": "Consenti agli utenti esterni di inviare segreti direttamente ai destinatari designati su questo dominio"
+  },
+  "web.domains.incoming.feature_disabled": {
+    "text": "Segreti in arrivo non disponibili"
+  },
+  "web.domains.incoming.feature_disabled_description": {
+    "text": "I segreti in arrivo non sono abilitati su questa istanza. Contatta il tuo amministratore."
+  },
+  "web.domains.incoming.access_denied": {
+    "text": "Accesso negato"
+  },
+  "web.domains.incoming.access_denied_description": {
+    "text": "Non hai l'autorizzazione per gestire le impostazioni dei segreti in arrivo di questo dominio. Contatta l'amministratore della tua organizzazione."
+  },
+  "web.domains.incoming.upgrade_to_configure": {
+    "text": "Esegui l'upgrade del tuo piano per configurare i segreti in arrivo per questo dominio."
+  },
+  "web.domains.incoming.configure_incoming": {
+    "text": "Configura segreti in arrivo"
+  },
+  "web.domains.incoming.not_configured_notice": {
+    "text": "I segreti in arrivo non sono configurati per questo dominio. Aggiungi destinatari per consentire agli utenti esterni di inviare segreti al tuo team."
+  },
+  "web.domains.incoming.disabled_notice": {
+    "text": "I segreti in arrivo sono attualmente disabilitati. Gli utenti esterni non possono inviare segreti ai destinatari su questo dominio. Abilita la funzionalità qui sotto per consentire i segreti in arrivo."
+  },
+  "web.domains.incoming.recipients_title": {
+    "text": "Destinatari"
+  },
+  "web.domains.incoming.recipients_description": {
+    "text": "Definisci chi può ricevere i segreti in arrivo su questo dominio. I destinatari riceveranno notifiche email quando viene inviato loro un segreto."
+  },
+  "web.domains.incoming.add_recipient": {
+    "text": "Aggiungi destinatario"
+  },
+  "web.domains.incoming.remove_recipient": {
+    "text": "Rimuovi"
+  },
+  "web.domains.incoming.email_label": {
+    "text": "Indirizzo email"
+  },
+  "web.domains.incoming.email_placeholder": {
+    "text": "recipient{'@'}example.com"
+  },
+  "web.domains.incoming.name_label": {
+    "text": "Nome visualizzato"
+  },
+  "web.domains.incoming.name_placeholder": {
+    "text": "es. Security Team"
+  },
+  "web.domains.incoming.empty_state": {
+    "text": "Nessun destinatario configurato"
+  },
+  "web.domains.incoming.empty_state_description": {
+    "text": "Aggiungi destinatari per consentire agli utenti esterni di inviare segreti al tuo team."
+  },
+  "web.domains.incoming.validation_invalid_email": {
+    "text": "Indirizzo email non valido"
+  },
+  "web.domains.incoming.validation_duplicate_email": {
+    "text": "Questo indirizzo email è già stato aggiunto"
+  },
+  "web.domains.incoming.validation_max_recipients": {
+    "text": "Sono consentiti al massimo {max} destinatari"
+  },
+  "web.domains.incoming.validation_name_required": {
+    "text": "Il nome visualizzato è obbligatorio"
+  },
+  "web.domains.incoming.validation_email_required": {
+    "text": "L'indirizzo email è obbligatorio"
+  },
+  "web.domains.incoming.save_changes": {
+    "text": "Salva modifiche"
+  },
+  "web.domains.incoming.discard_changes": {
+    "text": "Annulla modifiche"
+  },
+  "web.domains.incoming.update_success": {
+    "text": "Configurazione dei segreti in arrivo salvata correttamente"
+  },
+  "web.domains.incoming.delete_success": {
+    "text": "Configurazione dei segreti in arrivo rimossa correttamente"
+  },
+  "web.domains.incoming.recipient_count": {
+    "text": "{count} destinatario | {count} destinatari"
+  },
+  "web.domains.incoming.badge_not_configured": {
+    "text": "Non configurato"
+  },
+  "web.domains.incoming.badge_configured": {
+    "text": "Configurato"
+  },
+  "web.domains.incoming.badge_disabled": {
+    "text": "Disabilitato"
+  },
+  "web.domains.incoming.tooltip_not_configured": {
+    "text": "Segreti in arrivo non configurati - gli utenti esterni non possono inviare segreti a questo dominio"
+  },
+  "web.domains.incoming.tooltip_configured": {
+    "text": "Segreti in arrivo abilitati con {count} destinatario/i"
+  },
+  "web.domains.incoming.tooltip_disabled": {
+    "text": "La funzionalità dei segreti in arrivo è disabilitata per questo dominio"
+  },
+  "web.domains.incoming.enabled_label": {
+    "text": "Abilita segreti in arrivo"
+  },
+  "web.domains.incoming.enabled_hint": {
+    "text": "Consenti agli utenti esterni di inviare segreti ai destinatari su questo dominio"
+  },
+  "web.domains.incoming.public_url_label": {
+    "text": "URL pubblico"
+  },
+  "web.domains.incoming.public_url_description": {
+    "text": "Condividi questo URL con gli utenti esterni per consentire loro di inviare segreti"
+  },
+  "web.domains.incoming.copy_url": {
+    "text": "Copia URL"
+  },
+  "web.domains.incoming.url_copied": {
+    "text": "URL copiato negli appunti"
+  },
+  "web.domains.incoming.remove_all_confirmation": {
+    "text": "Sei sicuro di voler rimuovere tutti i destinatari? Gli utenti esterni non potranno più inviare segreti a questo dominio."
+  },
+  "web.domains.incoming.max_recipients_reached": {
+    "text": "Numero massimo di destinatari raggiunto"
+  },
+  "web.domains.incoming.duplicate_recipient": {
+    "text": "Questo indirizzo email è già stato aggiunto"
+  },
+  "web.domains.incoming.save_will_replace_confirmation": {
+    "text": "Il salvataggio sostituirà tutti i destinatari esistenti con le tue modifiche in sospeso. Sei sicuro?"
+  },
+  "web.domains.incoming.delete_all_recipients": {
+    "text": "Elimina tutti i destinatari"
+  },
+  "web.domains.signin.title": {
+    "text": "Configurazione dell'accesso"
+  },
+  "web.domains.signin.configure_signin": {
+    "text": "Configura accesso"
+  },
+  "web.domains.signin.config_description": {
+    "text": "Configura i metodi di autenticazione per l'accesso a questo dominio"
+  },
+  "web.domains.signin.access_denied": {
+    "text": "Accesso negato"
+  },
+  "web.domains.signin.upgrade_to_configure": {
+    "text": "Esegui l'upgrade del tuo piano per configurare i metodi di accesso per questo dominio."
+  },
+  "web.domains.signin.not_configured_notice": {
+    "text": "La configurazione dell'accesso non è ancora impostata per questo dominio. Configura le sostituzioni per controllare quali metodi di autenticazione sono disponibili nella pagina di accesso di questo dominio."
+  },
+  "web.domains.signin.signin_enabled_label": {
+    "text": "Accesso abilitato"
+  },
+  "web.domains.signin.header_toggle_label": {
+    "text": "Accesso"
+  },
+  "web.domains.signin.signin_enabled_hint": {
+    "text": "Indica se gli utenti possono accedere su questo dominio"
+  },
+  "web.domains.signin.restrict_to_label": {
+    "text": "Limita il metodo di accesso"
+  },
+  "web.domains.signin.restrict_to_hint": {
+    "text": "Limita questo dominio a un singolo metodo di autenticazione. Quando è impostato, nella pagina di accesso viene mostrato solo il metodo scelto."
+  },
+  "web.domains.signin.all_methods": {
+    "text": "Tutti i metodi"
+  },
+  "web.domains.signin.all_methods_description": {
+    "text": "Mostra tutti i metodi di autenticazione abilitati nella pagina di accesso"
+  },
+  "web.domains.signin.method_password": {
+    "text": "Password"
+  },
+  "web.domains.signin.method_email_auth": {
+    "text": "Autenticazione via email"
+  },
+  "web.domains.signin.method_webauthn": {
+    "text": "WebAuthn / Passkey"
+  },
+  "web.domains.signin.method_sso": {
+    "text": "Single Sign-On"
+  },
+  "web.domains.signin.method_overrides_label": {
+    "text": "Sostituzioni dei metodi"
+  },
+  "web.domains.signin.method_overrides_hint": {
+    "text": "Abilita o disabilita i singoli metodi di autenticazione per questo dominio"
+  },
+  "web.domains.signin.mode_question": {
+    "text": "Come possono accedere gli utenti?"
+  },
+  "web.domains.signin.mode_any": {
+    "text": "Qualsiasi metodo disponibile"
+  },
+  "web.domains.signin.mode_any_hint": {
+    "text": "Mostra ogni metodo disponibile su questo dominio. Restringi i singoli metodi qui sotto."
+  },
+  "web.domains.signin.mode_one": {
+    "text": "Un metodo specifico"
+  },
+  "web.domains.signin.mode_one_hint": {
+    "text": "Limita la pagina di accesso a un singolo metodo. Vengono elencati solo i metodi disponibili su questo dominio."
+  },
+  "web.domains.signin.mode_disabled": {
+    "text": "Accesso disabilitato"
+  },
+  "web.domains.signin.mode_disabled_hint": {
+    "text": "Gli utenti non possono accedere su questo dominio."
+  },
+  "web.domains.signin.mode_disabled_notice": {
+    "text": "I visitatori della pagina di accesso di questo dominio vedono un avviso che indica che l'accesso non è disponibile, con un link per tornare alla homepage. Le tue impostazioni precedenti dei metodi vengono conservate e ripristinate quando riabiliti l'accesso."
+  },
+  "web.domains.signin.methods_list_label": {
+    "text": "Metodi mostrati nella pagina di accesso"
+  },
+  "web.domains.signin.restrict_picker_hint": {
+    "text": "Vengono elencati solo i metodi disponibili su questo dominio."
+  },
+  "web.domains.signin.availability_always": {
+    "text": "Sempre disponibile"
+  },
+  "web.domains.signin.availability_global_on": {
+    "text": "Segue la policy globale · Attivo"
+  },
+  "web.domains.signin.availability_global_off": {
+    "text": "Non disponibile"
+  },
+  "web.domains.signin.availability_unavailable": {
+    "text": "Non disponibile su tutto il sito"
+  },
+  "web.domains.signin.allow_on_domain": {
+    "text": "Consenti su questo dominio"
+  },
+  "web.domains.signin.method_password_blurb": {
+    "text": "Solo password"
+  },
+  "web.domains.signin.method_email_auth_blurb": {
+    "text": "Accesso senza password tramite link magico"
+  },
+  "web.domains.signin.method_webauthn_blurb": {
+    "text": "Dati biometrici e chiavi di sicurezza"
+  },
+  "web.domains.signin.method_sso_blurb": {
+    "text": "Provider di identità esterno"
+  },
+  "web.domains.signin.email_auth_label": {
+    "text": "Autenticazione via email"
+  },
+  "web.domains.signin.email_auth_hint": {
+    "text": "Consenti l'autenticazione via email senza password su questo dominio"
+  },
+  "web.domains.signin.sso_enabled_label": {
+    "text": "Single Sign-On"
+  },
+  "web.domains.signin.sso_enabled_hint": {
+    "text": "Consenti l'autenticazione SSO su questo dominio"
+  },
+  "web.domains.signin.enabled_label": {
+    "text": "Abilita la configurazione dell'accesso"
+  },
+  "web.domains.signin.enabled_hint": {
+    "text": "Quando è abilitata, questo dominio usa le impostazioni di accesso configurate sopra"
+  },
+  "web.domains.signin.save_config": {
+    "text": "Salva configurazione"
+  },
+  "web.domains.signin.update_success": {
+    "text": "Configurazione dell'accesso aggiornata correttamente"
+  },
+  "web.domains.signin.reset_to_defaults": {
+    "text": "Ripristina i valori predefiniti"
+  },
+  "web.domains.signin.reset_confirm": {
+    "text": "Ripristinare l'accesso ai valori predefiniti globali?"
+  },
+  "web.domains.signin.reset_keeps_sso": {
+    "text": "Le tue credenziali SSO vengono conservate. Rimuovile separatamente nella schermata di configurazione SSO."
+  },
+  "web.domains.signin.reset_action": {
+    "text": "Sì, ripristina"
+  },
+  "web.domains.signin.reset_success": {
+    "text": "Impostazioni di accesso ripristinate ai valori predefiniti globali"
+  },
+  "web.domains.signup.title": {
+    "text": "Convalida della registrazione"
+  },
+  "web.domains.signup.config_description": {
+    "text": "Configura la convalida della registrazione per questo dominio"
+  },
+  "web.domains.signup.access_denied": {
+    "text": "Accesso negato"
+  },
+  "web.domains.signup.upgrade_to_configure": {
+    "text": "Esegui l'upgrade del tuo piano per configurare la convalida della registrazione per dominio."
+  },
+  "web.domains.signup.configure_signup": {
+    "text": "Configura registrazione"
+  },
+  "web.domains.signup.not_configured_notice": {
+    "text": "La convalida della registrazione non è ancora configurata per questo dominio. Configura una strategia per controllare chi può registrarsi tramite questo dominio."
+  },
+  "web.domains.signup.site_signups_disabled_warning": {
+    "text": "Le registrazioni sono attualmente disabilitate a livello di sito. Questa policy per dominio è configurata ma non filtrerà alcun traffico finché le registrazioni del sito non saranno abilitate."
+  },
+  "web.domains.signup.strategy_label": {
+    "text": "Strategia di convalida"
+  },
+  "web.domains.signup.strategy_description": {
+    "text": "Scegli come vengono convalidati gli indirizzi email quando gli utenti si registrano su questo dominio."
+  },
+  "web.domains.signup.network_validation_warning": {
+    "text": "Questa strategia esegue chiamate di rete durante la registrazione, il che può aumentare la latenza o essere bloccato da alcuni provider."
+  },
+  "web.domains.signup.allowed_domains_label": {
+    "text": "Domini consentiti per la registrazione"
+  },
+  "web.domains.signup.allowed_domains_hint": {
+    "text": "Solo questi domini email potranno registrarsi. Aggiungi un dominio per ogni voce."
+  },
+  "web.domains.signup.domain_placeholder": {
+    "text": "example.com"
+  },
+  "web.domains.signup.invalid_domain": {
+    "text": "Inserisci un dominio valido (es. example.com)"
+  },
+  "web.domains.signup.domain_exists": {
+    "text": "Questo dominio è già nell'elenco"
+  },
+  "web.domains.signup.remove_domain": {
+    "text": "Rimuovi {domain}"
+  },
+  "web.domains.signup.enabled_label": {
+    "text": "Abilita la convalida per dominio"
+  },
+  "web.domains.signup.enabled_hint": {
+    "text": "Quando è abilitata, le registrazioni su questo dominio usano la strategia sopra invece della policy globale."
+  },
+  "web.domains.signup.delete_config": {
+    "text": "Elimina configurazione"
+  },
+  "web.domains.signup.delete_confirm": {
+    "text": "Eliminare la configurazione di convalida della registrazione? Le registrazioni torneranno alla policy globale."
+  },
+  "web.domains.signup.save_config": {
+    "text": "Salva configurazione"
+  },
+  "web.domains.signup.update_success": {
+    "text": "Convalida della registrazione aggiornata correttamente"
+  },
+  "web.domains.signup.delete_success": {
+    "text": "Configurazione di convalida della registrazione rimossa correttamente"
+  },
+  "web.domains.signup.domain_overrides_label": {
+    "text": "Override del dominio"
+  },
+  "web.domains.signup.domain_overrides_hint": {
+    "text": "Sostituisci le impostazioni globali di registrazione per questo dominio"
+  },
+  "web.domains.signup.signup_enabled_label": {
+    "text": "Registrazione abilitata"
+  },
+  "web.domains.signup.signup_enabled_hint": {
+    "text": "Sostituisci se la registrazione è abilitata per questo dominio"
+  },
+  "web.domains.signup.autoverify_label": {
+    "text": "Verifica automatica degli account"
+  },
+  "web.domains.signup.autoverify_hint": {
+    "text": "Sostituisci se i nuovi account vengono verificati automaticamente su questo dominio"
+  },
+  "web.domains.sso.title": {
+    "text": "Single Sign-On"
+  },
+  "web.domains.sso.config_title": {
+    "text": "Configurazione SSO"
+  },
+  "web.domains.sso.config_description": {
+    "text": "Configura l'autenticazione Single Sign-On per questo dominio"
+  },
+  "web.domains.sso.access_denied": {
+    "text": "Accesso negato"
+  },
+  "web.domains.sso.access_denied_description": {
+    "text": "Non hai l'autorizzazione per gestire le impostazioni SSO di questo dominio. Contatta l'amministratore della tua organizzazione."
+  },
+  "web.domains.sso.upgrade_to_configure": {
+    "text": "Esegui l'upgrade del tuo piano per configurare il Single Sign-On per questo dominio."
+  },
+  "web.domains.sso.create_success": {
+    "text": "Configurazione SSO creata correttamente"
+  },
+  "web.domains.sso.update_success": {
+    "text": "Configurazione SSO aggiornata correttamente"
+  },
+  "web.domains.sso.delete_success": {
+    "text": "Configurazione SSO rimossa correttamente"
+  },
+  "web.domains.sso.test_success": {
+    "text": "Test di connessione riuscito — il provider ha risposto correttamente"
+  },
+  "web.domains.sso.test_failed": {
+    "text": "Test di connessione non riuscito"
+  },
+  "web.domains.sso.enforce_moved_notice": {
+    "text": "Per richiedere l'SSO per tutti gli accessi su questo dominio, configuralo nelle impostazioni di accesso del dominio. La modalità solo SSO limita la pagina di login al provider SSO configurato qui."
+  },
+  "web.domains.sso.configure_sso": {
+    "text": "Configura SSO"
+  },
+  "web.domains.sso.not_configured_notice": {
+    "text": "L'SSO non è ancora configurato per questo dominio. Abilita il Single Sign-On per consentire ai membri del team di autenticarsi usando il provider di identità della tua organizzazione."
+  },
+  "web.domains.sso.edit_credentials": {
+    "text": "Modifica credenziali"
+  },
+  "web.domains.sso.configure_button": {
+    "text": "Configura"
+  },
+  "web.domains.sso.upgrade_required": {
+    "text": "Esegui l'upgrade per configurare"
   }
 }

--- a/locales/content/it_IT/workspace-organizations.json
+++ b/locales/content/it_IT/workspace-organizations.json
@@ -578,5 +578,344 @@
   "web.organizations.invitations.expires_soon": {
     "text": "Scade presto",
     "source_hash": "a5dcfef9"
+  },
+  "api.organizations.errors.not_found": {
+    "text": "Organizzazione non trovata: %{extid}"
+  },
+  "api.organizations.errors.owner_required": {
+    "text": "Solo il proprietario dell'organizzazione può eseguire questa azione"
+  },
+  "api.organizations.errors.admin_required": {
+    "text": "Solo i proprietari e gli amministratori dell'organizzazione possono eseguire questa azione"
+  },
+  "api.organizations.errors.member_required": {
+    "text": "Devi essere un membro dell'organizzazione per eseguire questa azione"
+  },
+  "api.organizations.invitations.errors.create_admin_required": {
+    "text": "Solo i proprietari e gli amministratori dell'organizzazione possono creare inviti"
+  },
+  "api.organizations.invitations.errors.resend_admin_required": {
+    "text": "Solo i proprietari e gli amministratori dell'organizzazione possono inviare di nuovo gli inviti"
+  },
+  "api.organizations.invitations.errors.view_admin_required": {
+    "text": "Solo i proprietari e gli amministratori dell'organizzazione possono visualizzare gli inviti"
+  },
+  "api.organizations.invitations.errors.revoke_admin_required": {
+    "text": "Solo i proprietari e gli amministratori dell'organizzazione possono revocare gli inviti"
+  },
+  "api.organizations.invitations.errors.email_required": {
+    "text": "L'email è obbligatoria"
+  },
+  "api.organizations.invitations.errors.email_invalid": {
+    "text": "Formato email non valido"
+  },
+  "api.organizations.invitations.errors.role_invalid": {
+    "text": "Il ruolo deve essere membro o amministratore"
+  },
+  "api.organizations.invitations.errors.cannot_invite_owner": {
+    "text": "Impossibile invitare come proprietario"
+  },
+  "api.organizations.invitations.errors.already_member": {
+    "text": "L'utente è già un membro di questa organizzazione"
+  },
+  "api.organizations.invitations.errors.already_pending": {
+    "text": "C'è già un invito in sospeso per questa email"
+  },
+  "api.organizations.invitations.errors.member_limit_reached": {
+    "text": "Limite di membri raggiunto. Esegui l'upgrade del tuo piano per invitare altri membri."
+  },
+  "api.organizations.invitations.errors.not_found": {
+    "text": "Invito non trovato"
+  },
+  "api.organizations.invitations.errors.cannot_resend_non_pending": {
+    "text": "È possibile inviare di nuovo solo gli inviti in sospeso"
+  },
+  "api.organizations.invitations.errors.cannot_revoke_non_pending": {
+    "text": "È possibile revocare solo gli inviti in sospeso"
+  },
+  "api.organizations.invitations.errors.resend_limit_reached": {
+    "text": "Limite massimo di nuovi invii (%{max}) raggiunto"
+  },
+  "api.organizations.invitations.errors.accept_token_required": {
+    "text": "Il token è obbligatorio"
+  },
+  "api.organizations.invitations.errors.accept_organization_gone": {
+    "text": "L'organizzazione non esiste più"
+  },
+  "api.organizations.invitations.errors.accept_already_acted": {
+    "text": "L'invito è già stato %{status}"
+  },
+  "api.organizations.invitations.errors.accept_expired": {
+    "text": "L'invito è scaduto"
+  },
+  "api.organizations.invitations.errors.accept_email_mismatch": {
+    "text": "Il tuo indirizzo email non corrisponde all'invito"
+  },
+  "api.organizations.invitations.errors.accept_already_member": {
+    "text": "Sei già un membro di questa organizzazione"
+  },
+  "web.organizations.entitlements_title": {
+    "text": "Diritti dell'organizzazione"
+  },
+  "web.organizations.page_description_short": {
+    "text": "Visualizza e configura i tuoi Workspace"
+  },
+  "web.organizations.delete_organization_remove_domains_first": {
+    "text": "Rimuovi tutti i domini personalizzati prima di eliminare questa organizzazione."
+  },
+  "web.organizations.default_org_delete_notice_title": {
+    "text": "Eliminazione di questa organizzazione"
+  },
+  "web.organizations.default_org_delete_notice_before": {
+    "text": "Questa è la tua organizzazione predefinita e non può essere rimossa dal pannello. Per eliminarla, contattaci tramite il"
+  },
+  "web.organizations.default_org_delete_notice_link": {
+    "text": "modulo di feedback"
+  },
+  "web.organizations.default_org_delete_notice_after": {
+    "text": "."
+  },
+  "web.organizations.leave_organization": {
+    "text": "Abbandona questa organizzazione"
+  },
+  "web.organizations.leave_organization_warning": {
+    "text": "Perderai l'accesso a questa organizzazione e alle sue risorse."
+  },
+  "web.organizations.leave_organization_confirm_title": {
+    "text": "Abbandona organizzazione"
+  },
+  "web.organizations.leave_organization_confirm_message": {
+    "text": "Sei sicuro di voler abbandonare {name}? Avrai bisogno di un nuovo invito per rientrare."
+  },
+  "web.organizations.leave_organization_success": {
+    "text": "Hai abbandonato l'organizzazione."
+  },
+  "web.organizations.leave_error": {
+    "text": "Abbandono dell'organizzazione non riuscito"
+  },
+  "web.organizations.organizations": {
+    "text": "Organizzazioni"
+  },
+  "web.organizations.invitations.invited_by_inline": {
+    "text": "da {email}"
+  },
+  "web.organizations.invitations.invited_as_inline": {
+    "text": "come {role}"
+  },
+  "web.organizations.invitations.back_to_home": {
+    "text": "Torna alla home"
+  },
+  "web.organizations.invitations.email_locked_hint": {
+    "text": "Questo invito è stato inviato a questo indirizzo email"
+  },
+  "web.organizations.invitations.signup_continue": {
+    "text": "Continua"
+  },
+  "web.organizations.invitations.signin_continue": {
+    "text": "Accedi"
+  },
+  "web.organizations.invitations.confirm_join_below": {
+    "text": "Quasi fatto — conferma qui sotto per unirti all'organizzazione."
+  },
+  "web.organizations.invitations.go_to_organizations": {
+    "text": "Vai a Organizzazioni"
+  },
+  "web.organizations.invitations.already_member": {
+    "text": "Sei già un membro di questa organizzazione"
+  },
+  "web.organizations.invitations.join_organization": {
+    "text": "Unisciti a {orgName}"
+  },
+  "web.organizations.invitations.sign_in_to_join": {
+    "text": "Accedi per unirti a {orgName}"
+  },
+  "web.organizations.invitations.decline": {
+    "text": "Rifiuta"
+  },
+  "web.organizations.members.member_quota": {
+    "text": "{used} di {limit} membri"
+  },
+  "web.organizations.members.pending_suffix": {
+    "text": "({count} in sospeso)"
+  },
+  "web.organizations.members.limit_reached_hint": {
+    "text": "Limite di membri raggiunto."
+  },
+  "web.organizations.sso.title": {
+    "text": "Single Sign-On (SSO)"
+  },
+  "web.organizations.sso.description": {
+    "text": "Configura l'SSO per consentire ai membri di accedere con il provider di identità della tua organizzazione"
+  },
+  "web.organizations.sso.provider_type": {
+    "text": "Tipo di provider"
+  },
+  "web.organizations.sso.provider_type_description": {
+    "text": "Seleziona il provider di identità della tua organizzazione"
+  },
+  "web.organizations.sso.display_name": {
+    "text": "Nome visualizzato"
+  },
+  "web.organizations.sso.display_name_hint": {
+    "text": "Un nome descrittivo mostrato agli utenti durante l'accesso"
+  },
+  "web.organizations.sso.display_name_placeholder": {
+    "text": "es. Acme Corp SSO"
+  },
+  "web.organizations.sso.client_id": {
+    "text": "Client ID"
+  },
+  "web.organizations.sso.client_id_placeholder": {
+    "text": "Il tuo Client ID OAuth"
+  },
+  "web.organizations.sso.client_secret": {
+    "text": "Client Secret"
+  },
+  "web.organizations.sso.client_secret_placeholder": {
+    "text": "Il tuo Client Secret OAuth"
+  },
+  "web.organizations.sso.client_secret_update_hint": {
+    "text": "Lascia vuoto per mantenere il Client Secret esistente"
+  },
+  "web.organizations.sso.tenant_id": {
+    "text": "Tenant ID"
+  },
+  "web.organizations.sso.tenant_id_hint": {
+    "text": "L'identificatore del tenant Azure AD / Entra ID"
+  },
+  "web.organizations.sso.tenant_id_placeholder": {
+    "text": "es. 12345678-1234-1234-1234-123456789abc"
+  },
+  "web.organizations.sso.issuer": {
+    "text": "Issuer URL"
+  },
+  "web.organizations.sso.issuer_hint": {
+    "text": "L'URL di discovery OIDC del tuo provider di identità"
+  },
+  "web.organizations.sso.issuer_placeholder": {
+    "text": "es. https://login.example.com"
+  },
+  "web.organizations.sso.view_discovery_document": {
+    "text": "Visualizza il documento di discovery"
+  },
+  "web.organizations.sso.callback_url": {
+    "text": "Callback URL"
+  },
+  "web.organizations.sso.callback_url_hint": {
+    "text": "Aggiungi questo URL ai redirect URI consentiti del tuo provider di identità"
+  },
+  "web.organizations.sso.allowed_domains": {
+    "text": "Domini email consentiti"
+  },
+  "web.organizations.sso.allowed_domains_hint": {
+    "text": "Solo gli utenti con indirizzi email di questi domini possono accedere. Lascia vuoto per consentire tutti i domini."
+  },
+  "web.organizations.sso.domain_placeholder": {
+    "text": "es. acme.com"
+  },
+  "web.organizations.sso.invalid_domain": {
+    "text": "Inserisci un dominio valido (es. example.com)"
+  },
+  "web.organizations.sso.domain_exists": {
+    "text": "Questo dominio è già nell'elenco"
+  },
+  "web.organizations.sso.remove_domain": {
+    "text": "Rimuovi {domain}"
+  },
+  "web.organizations.sso.enabled": {
+    "text": "Abilita SSO"
+  },
+  "web.organizations.sso.enabled_hint": {
+    "text": "Quando è abilitato, i membri dell'organizzazione possono accedere usando questo provider SSO"
+  },
+  "web.organizations.sso.enforce_sso_only": {
+    "text": "Imponi solo SSO"
+  },
+  "web.organizations.sso.enforce_sso_only_hint": {
+    "text": "Richiedi l'SSO per tutti gli accessi su questo dominio. Quando è abilitato, l'autenticazione tramite password è disabilitata."
+  },
+  "web.organizations.sso.grant_org_scope": {
+    "text": "Concedi l'accesso a tutta l'organizzazione"
+  },
+  "web.organizations.sso.grant_org_scope_hint": {
+    "text": "I nuovi membri che si uniscono tramite l'SSO di questo dominio riceveranno l'accesso a tutti i domini dell'organizzazione. I membri esistenti non sono interessati. Quando è disabilitato (impostazione predefinita), i nuovi membri possono accedere solo a questo dominio."
+  },
+  "web.organizations.sso.save_config": {
+    "text": "Salva configurazione SSO"
+  },
+  "web.organizations.sso.delete_config": {
+    "text": "Elimina configurazione"
+  },
+  "web.organizations.sso.delete_confirm": {
+    "text": "Sei sicuro? Questo disabiliterà l'SSO per la tua organizzazione."
+  },
+  "web.organizations.sso.load_error": {
+    "text": "Caricamento della configurazione SSO non riuscito"
+  },
+  "web.organizations.sso.save_error": {
+    "text": "Salvataggio della configurazione SSO non riuscito"
+  },
+  "web.organizations.sso.create_success": {
+    "text": "Configurazione SSO creata correttamente"
+  },
+  "web.organizations.sso.update_success": {
+    "text": "Configurazione SSO aggiornata correttamente"
+  },
+  "web.organizations.sso.delete_success": {
+    "text": "Configurazione SSO eliminata correttamente"
+  },
+  "web.organizations.sso.delete_error": {
+    "text": "Eliminazione della configurazione SSO non riuscita"
+  },
+  "web.organizations.sso.test_connection": {
+    "text": "Prova connessione"
+  },
+  "web.organizations.sso.test_connection_hint": {
+    "text": "Verifica che il provider di identità sia raggiungibile (non convalida le credenziali)"
+  },
+  "web.organizations.sso.test_button": {
+    "text": "Prova connessione"
+  },
+  "web.organizations.sso.testing": {
+    "text": "Prova in corso..."
+  },
+  "web.organizations.sso.test_error": {
+    "text": "Prova della connessione non riuscita"
+  },
+  "web.organizations.sso.auth_endpoint": {
+    "text": "Authorization Endpoint"
+  },
+  "web.organizations.sso.missing_fields": {
+    "text": "Campi mancanti"
+  },
+  "web.organizations.sso.status_enabled": {
+    "text": "Abilitato"
+  },
+  "web.organizations.sso.status_configured": {
+    "text": "Configurato"
+  },
+  "web.organizations.sso.domain_sso_title": {
+    "text": "SSO del dominio"
+  },
+  "web.organizations.sso.domain_sso_description": {
+    "text": "Configura l'SSO per ogni dominio verificato"
+  },
+  "web.organizations.sso.provider_type_locked_hint": {
+    "text": "Per cambiare provider, elimina prima questa configurazione"
+  },
+  "web.organizations.sso.status_not_configured": {
+    "text": "Non configurato"
+  },
+  "web.organizations.sso.no_domains": {
+    "text": "Nessun dominio verificato"
+  },
+  "web.organizations.sso.no_domains_description": {
+    "text": "Aggiungi e verifica un dominio prima di configurare l'SSO per esso."
+  },
+  "web.organizations.tabs.team": {
+    "text": "Team"
+  },
+  "web.organizations.tabs.sso": {
+    "text": "SSO"
   }
 }


### PR DESCRIPTION
## `it_IT` translation update

Automated export of completed **it_IT** translations from the translation task DB.
Scope: `locales/content/it_IT/` only — 26 file(s), +1841/-23.

✅ `i18n validate variables`: no variable mismatches.

---

### Local quality review

> Produced by a fresh, isolated `claude` review agent (model `claude-sonnet-5`, agent `saas-translator`) that read
> `locales/AGENT_TRANSLATION_PROTOCOL.md` and inspected this branch's diff before the PR was opened.

**Verdict:** ⚠️ Needs review — minor key-structure artifact, no data-safety blockers.

**Summary:** Verified all 600 added/changed keys in this branch against the English source: variable/placeholder tokens match exactly (0 mismatches), phishing_warning and the `Delano`→`Team di supporto` signature changes both match the English source verbatim. One structural artifact needs a maintainer decision before merge.

**Critical (must fix):** None.

**Warnings:**
- Three new keys are duplicates of pre-existing nested `_guidance` objects, flattened into bogus dotted-literal keys not present in the English key set: `web.auth.security._guidance.context` and `web.auth.sessions._guidance.context` (session-auth-extended.json), and `web.auth.verify._guidance.context` (session-auth.json). English has `web.auth.verify._guidance: {"context": "..."}` — a nested object — not a flat `web.auth.verify._guidance.context` key. This is an automation artifact that adds keys with no EN counterpart (violates the "exact source key set" rule). Content itself is harmless (untranslated doc metadata, correctly left in English), but the extra keys should be removed or the export logic fixed so it doesn't recur across other locales.

**Notes:**
- `web.INSTRUCTION.phishing_warning`: "il dominio della regione" correctly reflects the English source's "check the region domain" — not a mistranslation, confirmed against `locales/content/en/00-common.json`.
- All 20 email `.signature` changes (`Delano` → `Team di supporto`) match the English source's `Support Team` update.
- Brand/tech terms (Onetime Secret, SSO, Single Sign-On, Client ID/Secret, Tenant ID, `{'@'}` literals) correctly left untranslated.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
