### PR TITLE
i18n: update ja translations

### DIFF
--- a/locales/content/ja/00-common.json
+++ b/locales/content/ja/00-common.json
@@ -1299,7 +1299,7 @@
     "source_hash": "fc78d9cb"
   },
   "web.INSTRUCTION.phishing_warning": {
-    "text": "常に{product_name}公式サイトにアクセスしていることを確認してください。詐欺師が{product_name}と同じように見せかけた偽サイトを作成し、シークレットを盗もうとすることがあります。フィッシング攻撃を防ぐため、新しいリンクを作成する前にドメインを確認してください。",
+    "text": "常に公式の{product_name}ウェブサイトにアクセスしていることを確認してください。詐欺師は、シークレットを盗むために{product_name}とまったく同じように見える偽のウェブサイトを作成することがあります。フィッシング攻撃を回避するため、新しいリンクを作成する前にリージョンのドメインを確認してください。",
     "source_hash": "b588f5b2"
   },
   "web.pricing.title": {
@@ -1383,5 +1383,110 @@
     "text": "アップグレードしてより多くの機能を利用する",
     "context": "Description shown for free plan users encouraging upgrade",
     "source_hash": "783f174c"
+  },
+  "api.errors.authentication_required": {
+    "text": "認証が必要です"
+  },
+  "api.errors.sso_only_action_blocked": {
+    "text": "このアクションはSSO専用モードでは利用できません"
+  },
+  "web.COMMON.configure": {
+    "text": "設定"
+  },
+  "web.COMMON.copy_to_clipboard": {
+    "text": "クリップボードにコピー"
+  },
+  "web.COMMON.add": {
+    "text": "追加"
+  },
+  "web.COMMON.enabled": {
+    "text": "有効"
+  },
+  "web.COMMON.disabled": {
+    "text": "無効"
+  },
+  "web.COMMON.yes_delete": {
+    "text": "はい、削除します"
+  },
+  "web.COMMON.error_code": {
+    "text": "エラーコード"
+  },
+  "web.COMMON.http_status": {
+    "text": "HTTPステータス"
+  },
+  "web.COMMON.details": {
+    "text": "詳細"
+  },
+  "web.COMMON.field_confirm_password": {
+    "text": "パスワードの確認"
+  },
+  "web.COMMON.passwords_must_match": {
+    "text": "パスワードが一致している必要があります"
+  },
+  "web.COMMON.and": {
+    "text": "および"
+  },
+  "web.COMMON.or": {
+    "text": "または"
+  },
+  "web.COMMON.copied": {
+    "text": "コピーしました"
+  },
+  "web.COMMON.copy": {
+    "text": "コピー"
+  },
+  "web.COMMON.copy_email": {
+    "text": "メールアドレスをコピー"
+  },
+  "web.COMMON.copy_id": {
+    "text": "アカウントIDをコピー"
+  },
+  "web.COMMON.org_id_tooltip": {
+    "text": "組織の一意の識別子"
+  },
+  "web.COMMON.success": {
+    "text": "成功"
+  },
+  "web.COMMON.need_help": {
+    "text": "サポートが必要ですか"
+  },
+  "web.COMMON.open_help_dialog": {
+    "text": "ヘルプダイアログを開く"
+  },
+  "web.COMMON.focus_is_now_in_the_main_text_area": {
+    "text": "フォーカスがメインのテキストエリアに移動しました"
+  },
+  "web.LABELS.show_passphrase": {
+    "text": "パスフレーズを表示"
+  },
+  "web.LABELS.hide_passphrase": {
+    "text": "パスフレーズを非表示"
+  },
+  "web.LABELS.copy_icon": {
+    "text": "コピーアイコン"
+  },
+  "web.LABELS.copied_icon": {
+    "text": "コピー済みアイコン"
+  },
+  "web.STATUS.unverified": {
+    "text": "未検証"
+  },
+  "web.TITLES.domain_detail": {
+    "text": "ドメイン設定"
+  },
+  "web.TITLES.domain_signin": {
+    "text": "サインイン設定"
+  },
+  "web.TITLES.domain_sso": {
+    "text": "ドメインSSO"
+  },
+  "web.TITLES.domain_signup": {
+    "text": "ドメインサインアップ検証"
+  },
+  "web.TITLES.domain_email": {
+    "text": "メール設定"
+  },
+  "web.TITLES.domain_incoming": {
+    "text": "受信シークレット"
   }
 }

--- a/locales/content/ja/10-layout.json
+++ b/locales/content/ja/10-layout.json
@@ -148,7 +148,7 @@
     "source_hash": "b9766df3"
   },
   "web.help.secret_view_faq.what_am_i_looking_at.description": {
-    "text": "{product_name}を通じて共有された安全なメッセージを閲覧しています。この内容は1回のみ表示され、その後サーバーから完全に削除されます。",
+    "text": "{product_name}を通じてあなたに共有された安全なメッセージを表示しています。このコンテンツは一度だけ表示され、その後サーバーから完全に削除されます。",
     "source_hash": "e0f1a10c"
   },
   "web.help.secret_view_faq.can_i_view_again.title": {
@@ -264,7 +264,7 @@
     "source_hash": "e2f124cd"
   },
   "web.layout.visit_onetime_secret_homepage": {
-    "text": "{product_name}ホームページへ",
+    "text": "{product_name}のホームページにアクセス",
     "source_hash": "625556d2"
   },
   "web.layout.footer_navigation": {
@@ -338,5 +338,11 @@
   "web.layout.workspace_context": {
     "text": "ワークスペースコンテキスト",
     "source_hash": "dc6fa4f5"
+  },
+  "web.footer.workspace": {
+    "text": "ワークスペース"
+  },
+  "web.help.default_content": {
+    "text": "サポートが必要な場合はサポートにお問い合わせください"
   }
 }

--- a/locales/content/ja/admin-colonel.json
+++ b/locales/content/ja/admin-colonel.json
@@ -634,5 +634,152 @@
   "web.colonel.feedback.when_you_submit_feedback_well_see": {
     "text": "フィードバックを送信すると、以下の情報が送信されます:",
     "source_hash": "fe77172e"
+  },
+  "web.colonel.previewPlanMode": {
+    "text": "プランプレビューモード"
+  },
+  "web.colonel.previewModeDescription": {
+    "text": "別のプランの顧客に表示されるアプリケーションをプレビューします。これはあなたの表示にのみ影響し、組織の実際のプランは変更されません。"
+  },
+  "web.colonel.previewModeActive": {
+    "text": "プレビュー有効"
+  },
+  "web.colonel.bannedIps.empty": {
+    "text": "禁止されたIPはありません"
+  },
+  "web.colonel.bannedIps.currentIp": {
+    "text": "現在のIPアドレス"
+  },
+  "web.colonel.bannedIps.confirmUnban": {
+    "text": "{ip}の禁止を解除しますか？"
+  },
+  "web.colonel.bannedIps.actions.ban": {
+    "text": "IPを禁止"
+  },
+  "web.colonel.bannedIps.actions.quickBan": {
+    "text": "クイック禁止"
+  },
+  "web.colonel.bannedIps.actions.unban": {
+    "text": "禁止を解除"
+  },
+  "web.colonel.bannedIps.actions.cancel": {
+    "text": "キャンセル"
+  },
+  "web.colonel.bannedIps.columns.ipAddress": {
+    "text": "IPアドレス"
+  },
+  "web.colonel.bannedIps.columns.reason": {
+    "text": "理由"
+  },
+  "web.colonel.bannedIps.columns.bannedAt": {
+    "text": "禁止日時"
+  },
+  "web.colonel.bannedIps.columns.bannedBy": {
+    "text": "禁止者"
+  },
+  "web.colonel.bannedIps.error.banFailed": {
+    "text": "IPアドレスの禁止に失敗しました"
+  },
+  "web.colonel.bannedIps.error.unbanFailed": {
+    "text": "IPアドレスの禁止解除に失敗しました"
+  },
+  "web.colonel.bannedIps.form.title": {
+    "text": "IPアドレスを禁止"
+  },
+  "web.colonel.bannedIps.form.ipLabel": {
+    "text": "IPアドレス"
+  },
+  "web.colonel.bannedIps.form.reasonLabel": {
+    "text": "理由"
+  },
+  "web.colonel.bannedIps.form.reasonPlaceholder": {
+    "text": "理由（任意）"
+  },
+  "web.colonel.bannedIps.success.banned": {
+    "text": "IPアドレス {ip} を禁止しました"
+  },
+  "web.colonel.bannedIps.success.unbanned": {
+    "text": "IPアドレス {ip} の禁止を解除しました"
+  },
+  "web.colonel.customDomains.empty": {
+    "text": "カスタムドメインが設定されていません"
+  },
+  "web.colonel.customDomains.noLogo": {
+    "text": "ロゴなし"
+  },
+  "web.colonel.customDomains.labels.organization": {
+    "text": "組織"
+  },
+  "web.colonel.customDomains.labels.externalId": {
+    "text": "外部ID"
+  },
+  "web.colonel.customDomains.labels.created": {
+    "text": "作成日"
+  },
+  "web.colonel.customDomains.labels.updated": {
+    "text": "更新日"
+  },
+  "web.colonel.customDomains.labels.favicon": {
+    "text": "ファビコン"
+  },
+  "web.colonel.customDomains.status.verified": {
+    "text": "検証済み"
+  },
+  "web.colonel.customDomains.status.resolving": {
+    "text": "解決中"
+  },
+  "web.colonel.customDomains.status.ready": {
+    "text": "準備完了"
+  },
+  "web.colonel.customDomains.status.publicHomepage": {
+    "text": "公開ホームページ"
+  },
+  "web.colonel.customDomains.status.publicApi": {
+    "text": "公開API"
+  },
+  "web.colonel.customDomains.status.pending": {
+    "text": "保留中"
+  },
+  "web.colonel.pagination.showing": {
+    "text": "{total}件中 {start}–{end}件を表示"
+  },
+  "web.colonel.pagination.itemsPerPage": {
+    "text": "1ページあたりの件数"
+  },
+  "web.colonel.pagination.perPage": {
+    "text": "1ページあたり{count}件"
+  },
+  "web.colonel.pagination.pageOf": {
+    "text": "{total}ページ中{current}ページ"
+  },
+  "web.colonel.secrets.empty": {
+    "text": "シークレットが見つかりません"
+  },
+  "web.colonel.secrets.never": {
+    "text": "なし"
+  },
+  "web.colonel.secrets.columns.shortId": {
+    "text": "短縮ID"
+  },
+  "web.colonel.secrets.columns.state": {
+    "text": "状態"
+  },
+  "web.colonel.secrets.columns.created": {
+    "text": "作成日"
+  },
+  "web.colonel.secrets.columns.expiration": {
+    "text": "有効期限"
+  },
+  "web.colonel.secrets.columns.age": {
+    "text": "経過日数（日）"
+  },
+  "web.colonel.secrets.state.new": {
+    "text": "新規"
+  },
+  "web.colonel.secrets.state.received": {
+    "text": "受信済み"
+  },
+  "web.colonel.secrets.state.viewed": {
+    "text": "閲覧済み"
   }
 }

--- a/locales/content/ja/api-account-errors.json
+++ b/locales/content/ja/api-account-errors.json
@@ -1,0 +1,8 @@
+{
+  "api.account.errors.invalid_email": {
+    "text": "有効なメールアドレスを入力してください"
+  },
+  "api.account.errors.password_too_short": {
+    "text": "パスワードが短すぎます"
+  }
+}

--- a/locales/content/ja/api-domains-errors.json
+++ b/locales/content/ja/api-domains-errors.json
@@ -1,0 +1,29 @@
+{
+  "api.domains.errors.domain_id_required": {
+    "text": "ドメインIDが必要です"
+  },
+  "api.domains.errors.domain_not_found": {
+    "text": "ドメインが見つかりません: %{extid}"
+  },
+  "api.domains.errors.organization_not_found": {
+    "text": "ドメインの組織が見つかりません: %{domain}"
+  },
+  "api.domains.errors.incoming_secrets_disabled": {
+    "text": "このインスタンスでは受信シークレットが有効になっていません"
+  },
+  "api.domains.errors.incoming_secrets_entitlement_required": {
+    "text": "受信シークレットの管理にはincoming_secretsエンタイトルメントが必要です。プランをアップグレードしてください。"
+  },
+  "api.domains.errors.incoming_config_not_found": {
+    "text": "ドメインの受信設定が見つかりません: %{extid}"
+  },
+  "api.domains.errors.recipients_max_exceeded": {
+    "text": "受信者は最大%{max}名まで指定できます"
+  },
+  "api.domains.errors.recipients_invalid_email": {
+    "text": "無効なメールアドレス: %{email}"
+  },
+  "api.domains.errors.recipients_duplicate": {
+    "text": "受信者のメールアドレスを重複して指定することはできません"
+  }
+}

--- a/locales/content/ja/api-entitlements-errors.json
+++ b/locales/content/ja/api-entitlements-errors.json
@@ -1,0 +1,71 @@
+{
+  "api.entitlements.errors.context_unavailable": {
+    "text": "エンタイトルメントを検証できません（組織のコンテキストが利用できません）"
+  },
+  "api.entitlements.errors.api_access_required": {
+    "text": "APIアクセスにはプランのアップグレードが必要です"
+  },
+  "api.entitlements.errors.custom_privacy_defaults_required": {
+    "text": "カスタムプライバシーのデフォルト設定にはプランのアップグレードが必要です"
+  },
+  "api.entitlements.errors.extended_default_expiration_required": {
+    "text": "デフォルト有効期限の延長にはプランのアップグレードが必要です"
+  },
+  "api.entitlements.errors.custom_domains_required": {
+    "text": "カスタムドメインにはプランのアップグレードが必要です"
+  },
+  "api.entitlements.errors.custom_branding_required": {
+    "text": "カスタムブランディングにはプランのアップグレードが必要です"
+  },
+  "api.entitlements.errors.homepage_secrets_required": {
+    "text": "ホームページシークレットにはプランのアップグレードが必要です"
+  },
+  "api.entitlements.errors.incoming_secrets_required": {
+    "text": "受信シークレットにはプランのアップグレードが必要です"
+  },
+  "api.entitlements.errors.custom_mail_sender_required": {
+    "text": "カスタムメール送信者にはプランのアップグレードが必要です"
+  },
+  "api.entitlements.errors.flexible_from_domain_required": {
+    "text": "柔軟な送信元ドメインにはプランのアップグレードが必要です"
+  },
+  "api.entitlements.errors.manage_org_required": {
+    "text": "組織の管理にはプランのアップグレードが必要です"
+  },
+  "api.entitlements.errors.manage_teams_required": {
+    "text": "チームの管理にはプランのアップグレードが必要です"
+  },
+  "api.entitlements.errors.manage_members_required": {
+    "text": "メンバーの管理にはプランのアップグレードが必要です"
+  },
+  "api.entitlements.errors.manage_sso_required": {
+    "text": "シングルサインオン (SSO) の管理にはプランのアップグレードが必要です"
+  },
+  "api.entitlements.errors.audit_logs_required": {
+    "text": "監査ログにはプランのアップグレードが必要です"
+  },
+  "api.entitlements.errors.custom_signup_validation_required": {
+    "text": "カスタムサインアップ検証にはプランのアップグレードが必要です"
+  },
+  "api.entitlements.errors.create_secrets_required": {
+    "text": "シークレットの作成にはプランのアップグレードが必要です"
+  },
+  "api.entitlements.errors.view_receipt_required": {
+    "text": "受信確認の表示にはプランのアップグレードが必要です"
+  },
+  "api.entitlements.errors.notifications_required": {
+    "text": "通知にはプランのアップグレードが必要です"
+  },
+  "api.entitlements.errors.workspace_branding_required": {
+    "text": "ワークスペースブランディングにはプランのアップグレードが必要です"
+  },
+  "api.entitlements.errors.ip_access_rules_required": {
+    "text": "IPアクセスルールにはプランのアップグレードが必要です"
+  },
+  "api.entitlements.errors.manage_billing_required": {
+    "text": "請求の管理にはプランのアップグレードが必要です"
+  },
+  "api.entitlements.errors.custom_signin_config_required": {
+    "text": "カスタムサインイン設定にはプランのアップグレードが必要です"
+  }
+}

--- a/locales/content/ja/api-feedback-errors.json
+++ b/locales/content/ja/api-feedback-errors.json
@@ -1,0 +1,5 @@
+{
+  "api.feedback.errors.rate_limit_exceeded": {
+    "text": "フィードバックの送信回数が多すぎます。しばらくしてからもう一度お試しください。"
+  }
+}

--- a/locales/content/ja/api-incoming-errors.json
+++ b/locales/content/ja/api-incoming-errors.json
@@ -1,0 +1,5 @@
+{
+  "api.incoming.errors.custom_domain_unresolved": {
+    "text": "カスタムドメインの組織を解決できませんでした"
+  }
+}

--- a/locales/content/ja/api-invite-errors.json
+++ b/locales/content/ja/api-invite-errors.json
@@ -1,0 +1,23 @@
+{
+  "api.invite.errors.invitation_not_found_or_expired": {
+    "text": "招待が見つからないか、有効期限が切れています"
+  },
+  "api.invite.errors.token_required": {
+    "text": "トークンが必要です"
+  },
+  "api.invite.errors.organization_no_longer_exists": {
+    "text": "組織は存在しなくなりました"
+  },
+  "api.invite.errors.invitation_already_processed": {
+    "text": "この招待はすでに処理されています(%{status})"
+  },
+  "api.invite.errors.invitation_expired": {
+    "text": "招待の有効期限が切れています"
+  },
+  "api.invite.errors.email_mismatch": {
+    "text": "メールアドレスが招待と一致しません"
+  },
+  "api.invite.errors.already_member": {
+    "text": "すでにこの組織のメンバーです"
+  }
+}

--- a/locales/content/ja/api-organizations-errors.json
+++ b/locales/content/ja/api-organizations-errors.json
@@ -1,0 +1,107 @@
+{
+  "api.organizations.errors.domain_scoped_forbidden": {
+    "text": "ドメインに限定されたメンバーはこの操作を実行できません"
+  },
+  "api.organizations.errors.organization_not_found": {
+    "text": "組織が見つかりません: %{extid}"
+  },
+  "api.organizations.errors.organization_owner_required": {
+    "text": "この操作を実行できるのは組織のオーナーのみです"
+  },
+  "api.organizations.errors.organization_member_required": {
+    "text": "この操作を実行するには組織のメンバーである必要があります"
+  },
+  "api.organizations.errors.organization_admin_required": {
+    "text": "この操作を実行できるのは組織のオーナーと管理者のみです"
+  },
+  "api.organizations.errors.extid_required": {
+    "text": "組織IDが必要です"
+  },
+  "api.organizations.errors.display_name_required": {
+    "text": "組織名は必須です"
+  },
+  "api.organizations.errors.display_name_too_long": {
+    "text": "組織名は%{max}文字未満である必要があります"
+  },
+  "api.organizations.errors.description_too_long": {
+    "text": "説明は%{max}文字未満である必要があります"
+  },
+  "api.organizations.errors.contact_email_exists": {
+    "text": "この連絡先メールアドレスの組織はすでに存在します"
+  },
+  "api.organizations.errors.creation_in_progress": {
+    "text": "組織を作成しています。もう一度お試しください。"
+  },
+  "api.organizations.errors.organization_limit_reached": {
+    "text": "組織数の上限に達しました。さらに組織を作成するにはプランをアップグレードしてください。"
+  },
+  "api.organizations.invitations.errors.invitation_not_found": {
+    "text": "招待が見つかりません"
+  },
+  "api.organizations.invitations.errors.email_required": {
+    "text": "メールアドレスは必須です"
+  },
+  "api.organizations.invitations.errors.invalid_email_format": {
+    "text": "メールアドレスの形式が無効です"
+  },
+  "api.organizations.invitations.errors.invalid_role": {
+    "text": "ロールはメンバーまたは管理者である必要があります"
+  },
+  "api.organizations.invitations.errors.cannot_invite_as_owner": {
+    "text": "オーナーとして招待することはできません"
+  },
+  "api.organizations.invitations.errors.user_already_member": {
+    "text": "ユーザーはすでにこの組織のメンバーです"
+  },
+  "api.organizations.invitations.errors.invitation_already_pending": {
+    "text": "このメールアドレス宛の招待はすでに保留中です"
+  },
+  "api.organizations.invitations.errors.member_limit_reached": {
+    "text": "メンバー数の上限に達しました。さらにメンバーを招待するにはプランをアップグレードしてください。"
+  },
+  "api.organizations.invitations.errors.resend_only_pending": {
+    "text": "再送信できるのは保留中の招待のみです"
+  },
+  "api.organizations.invitations.errors.resend_limit_reached": {
+    "text": "再送信回数の上限(%{max})に達しました"
+  },
+  "api.organizations.invitations.errors.revoke_only_pending": {
+    "text": "取り消せるのは保留中の招待のみです"
+  },
+  "api.organizations.members.errors.member_not_found": {
+    "text": "メンバーが見つかりません: %{extid}"
+  },
+  "api.organizations.members.errors.member_not_in_organization": {
+    "text": "この組織にメンバーが見つかりません"
+  },
+  "api.organizations.members.errors.member_not_active": {
+    "text": "メンバーは有効ではありません"
+  },
+  "api.organizations.members.errors.invalid_role_value": {
+    "text": "無効なロールです。次のいずれかである必要があります: %{roles}"
+  },
+  "api.organizations.members.errors.cannot_change_owner_role": {
+    "text": "オーナーのロールは変更できません。代わりに所有権の譲渡を使用してください。"
+  },
+  "api.organizations.members.errors.member_already_has_role": {
+    "text": "メンバーはすでに次のロールを持っています: %{role}"
+  },
+  "api.organizations.members.errors.cannot_promote_to_owner": {
+    "text": "オーナーに昇格させることはできません。代わりに所有権の譲渡を使用してください。"
+  },
+  "api.organizations.members.errors.must_be_member": {
+    "text": "この組織のメンバーである必要があります"
+  },
+  "api.organizations.members.errors.cannot_remove_owner": {
+    "text": "組織のオーナーは削除できません。先に所有権を譲渡してください。"
+  },
+  "api.organizations.members.errors.cannot_remove_self": {
+    "text": "自分自身を削除することはできません。代わりに組織からの退出を使用してください。"
+  },
+  "api.organizations.members.errors.admin_cannot_remove_admin": {
+    "text": "管理者は他の管理者を削除できません。オーナーのみが削除できます。"
+  },
+  "api.organizations.members.errors.no_permission_to_remove": {
+    "text": "メンバーを削除する権限がありません"
+  }
+}

--- a/locales/content/ja/api-secrets-errors.json
+++ b/locales/content/ja/api-secrets-errors.json
@@ -1,0 +1,11 @@
+{
+  "api.secrets.errors.domain_permission_authenticated_non_owner": {
+    "text": "このドメインを使用する権限がありません: %{domain}"
+  },
+  "api.secrets.errors.domain_public_sharing_disabled": {
+    "text": "このドメインでは公開共有が無効になっています: %{domain}"
+  },
+  "api.secrets.errors.domain_permission_anonymous_cross_domain": {
+    "text": "このドメインを使用する権限がありません: %{domain}"
+  }
+}

--- a/locales/content/ja/email.json
+++ b/locales/content/ja/email.json
@@ -60,7 +60,7 @@
     "source_hash": "88c72144"
   },
   "email.welcome.signature": {
-    "text": "Delano",
+    "text": "サポートチーム",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -100,7 +100,7 @@
     "source_hash": "fbb7eb2d"
   },
   "email.password_request.signature": {
-    "text": "Delano",
+    "text": "サポートチーム",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -145,7 +145,7 @@
     "source_hash": "1863f5be"
   },
   "email.magic_link.signature": {
-    "text": "Delano",
+    "text": "サポートチーム",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -230,7 +230,7 @@
     "source_hash": "3f6b45dd"
   },
   "email.secret_revealed.signature": {
-    "text": "Delano",
+    "text": "サポートチーム",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -355,7 +355,7 @@
     "source_hash": "734882d2"
   },
   "email.organization_invitation.signature": {
-    "text": "Delano",
+    "text": "サポートチーム",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -395,7 +395,7 @@
     "source_hash": "be92cff3"
   },
   "email.password_changed.signature": {
-    "text": "Delano",
+    "text": "サポートチーム",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -445,7 +445,7 @@
     "source_hash": "f8d47b82"
   },
   "email.email_changed.signature": {
-    "text": "Delano",
+    "text": "サポートチーム",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -495,7 +495,7 @@
     "source_hash": "f8d47b82"
   },
   "email.email_change_requested.signature": {
-    "text": "Delano",
+    "text": "サポートチーム",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -550,7 +550,7 @@
     "source_hash": "d4d835fc"
   },
   "email.email_change_confirmation.signature": {
-    "text": "Delano",
+    "text": "サポートチーム",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -580,7 +580,7 @@
     "source_hash": "e7c11bb0"
   },
   "email.mfa_enabled.signature": {
-    "text": "Delano",
+    "text": "サポートチーム",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -605,7 +605,7 @@
     "source_hash": "97ef0a3e"
   },
   "email.mfa_disabled.signature": {
-    "text": "Delano",
+    "text": "サポートチーム",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -650,7 +650,7 @@
     "source_hash": "450c54c5"
   },
   "email.new_login_alert.signature": {
-    "text": "Delano",
+    "text": "サポートチーム",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -670,7 +670,7 @@
     "source_hash": "d442beed"
   },
   "email.member_removed.signature": {
-    "text": "Delano",
+    "text": "サポートチーム",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -690,7 +690,7 @@
     "source_hash": "c2280c0c"
   },
   "email.role_changed.signature": {
-    "text": "Delano",
+    "text": "サポートチーム",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -710,7 +710,7 @@
     "source_hash": "7095fc69"
   },
   "email.organization_deleted.signature": {
-    "text": "Delano",
+    "text": "サポートチーム",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -750,7 +750,7 @@
     "source_hash": "36008943"
   },
   "email.payment_receipt.signature": {
-    "text": "Delano",
+    "text": "サポートチーム",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -775,7 +775,7 @@
     "source_hash": "926406b1"
   },
   "email.payment_failed.signature": {
-    "text": "Delano",
+    "text": "サポートチーム",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -800,7 +800,7 @@
     "source_hash": "66a1419e"
   },
   "email.trial_expiring.signature": {
-    "text": "Delano",
+    "text": "サポートチーム",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -825,7 +825,7 @@
     "source_hash": "5a96ae38"
   },
   "email.subscription_changed.signature": {
-    "text": "Delano",
+    "text": "サポートチーム",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -853,5 +853,41 @@
     "text": "Onetime Secret",
     "renderer": "erb",
     "source_hash": "1cd0194a"
+  },
+  "email.common.secret_link_label": {
+    "text": "シークレットリンク"
+  },
+  "email.common.automated_notice": {
+    "text": "これは%{product_name}からの自動送信メッセージです。"
+  },
+  "email.common.support_label": {
+    "text": "サポート"
+  },
+  "email.expiration_warning.signature": {
+    "text": "サポートチーム"
+  },
+  "email.expiration_warning.footer_note": {
+    "text": "%{product_name}で作成したシークレットの有効期限が近づいているため、このメールが送信されました。"
+  },
+  "email.feedback_email.user_id_label": {
+    "text": "ユーザー:"
+  },
+  "email.feedback_email.timezone_label": {
+    "text": "タイムゾーン:"
+  },
+  "email.feedback_email.version_label": {
+    "text": "バージョン:"
+  },
+  "email.incoming_secret.footer_note": {
+    "text": "誰かが%{product_name}を使用してシークレットを送信したため、このメールが送信されました。心当たりがない場合は、このメールを無視していただいて問題ありません。"
+  },
+  "email.secret_link.passphrase_label": {
+    "text": "パスフレーズが必要です:"
+  },
+  "email.secret_link.passphrase_required": {
+    "text": "このシークレットはパスフレーズで保護されています。送信者から別途お知らせがあるはずです。"
+  },
+  "email.secret_link.footer_note": {
+    "text": "%{sender_email}が%{product_name}を使用してシークレットを共有したため、このメールが送信されました。心当たりがない場合は、このメールを無視していただいて問題ありません。"
   }
 }

--- a/locales/content/ja/feature-feedback.json
+++ b/locales/content/ja/feature-feedback.json
@@ -58,5 +58,14 @@
   "web.feedback.reason_email_change_unauthorized": {
     "text": "アカウントでの不正なメールアドレス変更を報告されているようです。何が起きたかをご説明ください。すぐに調査いたします。",
     "source_hash": "00e56551"
+  },
+  "web.feedback.anonymous_no_reply": {
+    "text": "注意: 返信をご希望の場合は、メッセージに署名するか、メールアドレスを記載してください。"
+  },
+  "web.feedback.characters_remaining": {
+    "text": "残り{count}文字"
+  },
+  "web.feedback.character_limit_reached": {
+    "text": "文字数の上限に達しました"
   }
 }

--- a/locales/content/ja/feature-homepage-secrets.json
+++ b/locales/content/ja/feature-homepage-secrets.json
@@ -1,0 +1,50 @@
+{
+  "homepage_secrets.disabled.members_only_eyebrow": {
+    "text": "メンバー限定インスタンス"
+  },
+  "homepage_secrets.disabled.private_instance_eyebrow": {
+    "text": "プライベートインスタンス"
+  },
+  "homepage_secrets.disabled.team_link_headline": {
+    "text": "このリンクは{workspace}チーム用です。"
+  },
+  "homepage_secrets.disabled.signin_headline": {
+    "text": "{action}を作成するにはログインしてください。"
+  },
+  "homepage_secrets.disabled.signin_headline_action": {
+    "text": "シークレットリンク"
+  },
+  "homepage_secrets.disabled.team_subtitle": {
+    "text": "{domain}の権限のあるチームメンバーのみが、ここで新しいワンタイムリンクを作成できます。受信者は送信されたリンクをこれまで通り開くことができます。"
+  },
+  "homepage_secrets.disabled.public_subtitle": {
+    "text": "このインスタンスの権限のあるメンバーのみが、新しいワンタイムリンクを作成できます。受信者は送信されたリンクをこれまで通り開くことができます。"
+  },
+  "homepage_secrets.disabled.signin_cta": {
+    "text": "アカウントにログイン"
+  },
+  "homepage_secrets.disabled.what_is_this": {
+    "text": "これは何ですか?"
+  },
+  "homepage_secrets.disabled.trust_viewed_once": {
+    "text": "一度表示されたら消去"
+  },
+  "homepage_secrets.disabled.trust_zero_retained": {
+    "text": "データを一切保持しません"
+  },
+  "homepage_secrets.disabled.promo_title": {
+    "text": "新着: 無料プランにカスタムドメインが含まれるようになりました。"
+  },
+  "homepage_secrets.disabled.promo_subtitle": {
+    "text": "ドメインをOnetime Secretに向けて、自社ブランドでシークレットを送信しましょう。"
+  },
+  "homepage_secrets.disabled.promo_learn_how": {
+    "text": "詳しく見る"
+  },
+  "homepage_secrets.disabled.logo_alt": {
+    "text": "{name}のロゴ"
+  },
+  "homepage_secrets.disabled.opens_in_new_tab": {
+    "text": "(新しいタブで開きます)"
+  }
+}

--- a/locales/content/ja/feature-incoming.json
+++ b/locales/content/ja/feature-incoming.json
@@ -130,5 +130,26 @@
   "incoming.receipt_link_text": {
     "text": "受信確認",
     "source_hash": "6f328609"
+  },
+  "incoming.upgrade_required_title": {
+    "text": "アップグレードが必要です"
+  },
+  "incoming.upgrade_required_description": {
+    "text": "この機能にはプランのアップグレードが必要です。受信シークレットを有効にするには、アカウントのオーナーにお問い合わせください。"
+  },
+  "incoming.validation_memo_too_long": {
+    "text": "メモは{max}文字以下である必要があります"
+  },
+  "incoming.validation_secret_required": {
+    "text": "シークレットの内容は必須です"
+  },
+  "incoming.validation_recipient_required": {
+    "text": "受信者を選択してください"
+  },
+  "incoming.validation_feature_disabled": {
+    "text": "受信シークレット機能が有効になっていません"
+  },
+  "incoming.validation_form_errors": {
+    "text": "フォームにエラーがないか確認してください"
   }
 }

--- a/locales/content/ja/feature-regions.json
+++ b/locales/content/ja/feature-regions.json
@@ -186,5 +186,8 @@
   "web.regions.jurisdictions.apac.name": {
     "text": "Asia-Pacific",
     "source_hash": "7a757670"
+  },
+  "web.regions.no_region_configured": {
+    "text": "現在、お客様のアカウントで利用可能なリージョン情報はありません。"
   }
 }

--- a/locales/content/ja/feature-translations.json
+++ b/locales/content/ja/feature-translations.json
@@ -84,7 +84,7 @@
     "source_hash": "ba5c4395"
   },
   "web.translations.since_2012_onetime_secret_has_provided_a_secure_": {
-    "text": "2012年以来、{product_name}は世界中で機密情報を安全に共有する方法を提供してきました。英語が主要言語ではない地域のユーザーがいるため、正確な翻訳は、安全なコミュニケーションを誰もがアクセスできるようにするために不可欠です。",
+    "text": "2012年以来、{product_name}は世界中で機密情報を安全に共有する手段を提供してきました。英語が主要言語ではない地域のユーザーも多いため、正確な翻訳は、誰もが安全なコミュニケーションを利用できるようにするうえで不可欠です。",
     "source_hash": "87a6e9af"
   },
   "web.translations.help_secure_communication_go_global": {

--- a/locales/content/ja/secret-homepage.json
+++ b/locales/content/ja/secret-homepage.json
@@ -144,7 +144,7 @@
     "source_hash": "1cd0194a"
   },
   "web.homepage.one_time_secret_literal": {
-    "text": "ワンタイムシークレット",
+    "text": "{product_name}",
     "source_hash": "7872e050"
   },
   "web.homepage.onetime_secret_homepage": {

--- a/locales/content/ja/secret-manage.json
+++ b/locales/content/ja/secret-manage.json
@@ -470,5 +470,11 @@
   },
   "web.private.send_feedback": {
     "text": "フィードバックを送信"
+  },
+  "web.receipt.open_link": {
+    "text": "リンクを開く"
+  },
+  "web.secrets.messageDeleted": {
+    "text": "メッセージを削除しました"
   }
 }

--- a/locales/content/ja/session-auth-extended.json
+++ b/locales/content/ja/session-auth-extended.json
@@ -716,5 +716,20 @@
   },
   "web.auth.sessions._guidance.context": {
     "text": "ユーザーのログイン済みデバイス/ブラウザ管理ページ"
+  },
+  "web.auth.google": {
+    "text": "Google"
+  },
+  "web.auth.mfa.alternative_auth_options": {
+    "text": "別の認証方法"
+  },
+  "web.auth.remember.enabled": {
+    "text": "ログイン状態を保持する"
+  },
+  "web.auth.sessions.session_singular": {
+    "text": "セッション"
+  },
+  "web.auth.sessions.session_plural": {
+    "text": "セッション"
   }
 }

--- a/locales/content/ja/session-auth.json
+++ b/locales/content/ja/session-auth.json
@@ -398,5 +398,32 @@
   },
   "web.auth.verify._guidance.context": {
     "text": "サインアップ後のメール認証フロー"
+  },
+  "web.auth.account.sso_linked": {
+    "text": "SSOアカウント"
+  },
+  "web.help.reset_password_link": {
+    "text": "パスワードをリセット"
+  },
+  "web.login.custom_domain_sso_title": {
+    "text": "このドメインではシングルサインオンを利用できます"
+  },
+  "web.login.custom_domain_sso_description": {
+    "text": "組織の管理者がSSOを有効にすると、チームメンバーはここからログインできるようになります。アクセスについては管理者にお問い合わせください。"
+  },
+  "web.login.signin_disabled_heading": {
+    "text": "ログインは利用できません"
+  },
+  "web.login.signin_disabled_message": {
+    "text": "このドメインでは現在ログインを利用できません。"
+  },
+  "web.login.errors.sso_not_configured": {
+    "text": "このドメインではシングルサインオンが設定されていません。管理者にお問い合わせください。"
+  },
+  "web.login.errors.invalid_email": {
+    "text": "IDプロバイダーから取得したメールアドレスが無効です。管理者にお問い合わせください。"
+  },
+  "web.login.errors.domain_not_allowed": {
+    "text": "お使いのメールドメインはSSO登録の対象として許可されていません。管理者にお問い合わせください。"
   }
 }

--- a/locales/content/ja/workspace-account.json
+++ b/locales/content/ja/workspace-account.json
@@ -682,5 +682,14 @@
   "web.settings.profile.didnt_receive_email": {
     "text": "メールが届きませんか？",
     "source_hash": "fe3ac3ad"
+  },
+  "web.settings.api.api_disabled_notice": {
+    "text": "このインスタンスではAPIが無効になっています。"
+  },
+  "web.settings.security.sso_managed_title": {
+    "text": "SSOによって管理されるセキュリティ"
+  },
+  "web.settings.security.sso_managed_description": {
+    "text": "お使いのアカウントは、組織のシングルサインオンプロバイダーを通じて認証されます。パスワード、多要素認証、リカバリーコードはIDプロバイダーによって管理されます。"
   }
 }

--- a/locales/content/ja/workspace-billing.json
+++ b/locales/content/ja/workspace-billing.json
@@ -988,5 +988,47 @@
     "text": "元のサブスクリプションリージョンでのみ利用可能",
     "context": "Hint shown on plan cards when currency does not match active subscription",
     "source_hash": "10de32e5"
+  },
+  "web.billing.already_subscribed": {
+    "text": "すでにこのプランに登録済みです。"
+  },
+  "web.billing.cancel.reactivate_button": {
+    "text": "サブスクリプションを再開"
+  },
+  "web.billing.cancel.reactivate_success": {
+    "text": "サブスクリプションが再開されました。通常どおり請求が継続されます。"
+  },
+  "web.billing.cancel.reactivate_error": {
+    "text": "サブスクリプションの再開に失敗しました。もう一度お試しいただくか、サポートにお問い合わせください。"
+  },
+  "web.billing.features.manage_orgs": {
+    "text": "組織管理"
+  },
+  "web.billing.features.flexible_from_domain": {
+    "text": "柔軟な送信元メールドメイン"
+  },
+  "web.billing.features.unlimited_admins": {
+    "text": "管理者数無制限"
+  },
+  "web.billing.features.manage_sso": {
+    "text": "SSO"
+  },
+  "web.billing.overview.entitlements.flexible_from_domain": {
+    "text": "柔軟な送信元メールドメイン"
+  },
+  "web.billing.overview.entitlements.manage_orgs": {
+    "text": "組織を管理"
+  },
+  "web.billing.overview.entitlements.manage_sso": {
+    "text": "シングルサインオン (SSO)"
+  },
+  "web.billing.overview.entitlements.manage_billing": {
+    "text": "請求を管理"
+  },
+  "web.billing.overview.entitlements.custom_signup_validation": {
+    "text": "カスタム登録検証"
+  },
+  "web.billing.plans.reactivate": {
+    "text": "再開"
   }
 }

--- a/locales/content/ja/workspace-branding.json
+++ b/locales/content/ja/workspace-branding.json
@@ -178,5 +178,11 @@
   "web.branding.upgrade_to_customize": {
     "text": "このドメインのブランディングをカスタマイズするにはプランをアップグレードしてください。",
     "source_hash": "9077bf79"
+  },
+  "web.branding.saved_successfully": {
+    "text": "ブランド設定を保存しました"
+  },
+  "web.branding.keyhole_logo_icon": {
+    "text": "安全でプライベートな共有を表す鍵穴アイコン"
   }
 }

--- a/locales/content/ja/workspace-dashboard.json
+++ b/locales/content/ja/workspace-dashboard.json
@@ -22,5 +22,14 @@
   "web.dashboard.fetch_error_description": {
     "text": "データの読み込み中に問題が発生しました。もう一度お試しください。",
     "source_hash": "ff0d904e"
+  },
+  "web.teams.create_first_team_title": {
+    "text": "最初のチームを作成"
+  },
+  "web.teams.create_first_team_description": {
+    "text": "チームを使うと、共有ワークスペースで他のメンバーと共同作業ができます。"
+  },
+  "web.teams.create_team": {
+    "text": "チームを作成"
   }
 }

--- a/locales/content/ja/workspace-domains.json
+++ b/locales/content/ja/workspace-domains.json
@@ -846,5 +846,389 @@
   "web.domains.sso.not_configured_notice": {
     "text": "このドメインではSSOがまだ設定されていません。シングルサインオンを有効にして、チームメンバーが組織のIDプロバイダーを使用して認証できるようにしましょう。",
     "source_hash": "c439214b"
+  },
+  "api.domains.errors.add_admin_required": {
+    "text": "カスタムドメインを追加できるのは、組織のオーナーと管理者のみです"
+  },
+  "web.domains.public_homepage": {
+    "text": "公開ホームページ"
+  },
+  "web.domains.status_tooltip_active": {
+    "text": "ドメインは検証済みで有効です"
+  },
+  "web.domains.status_tooltip_dns_incorrect": {
+    "text": "DNSが設定されていません — クリックして修正"
+  },
+  "web.domains.status_tooltip_not_verified": {
+    "text": "ドメインが未検証です — クリックして検証"
+  },
+  "web.domains.status_tooltip_unverified": {
+    "text": "ドメインの状態が未確認です — クリックして更新"
+  },
+  "web.domains.last_check_failed": {
+    "text": "前回の検証チェックに失敗しました"
+  },
+  "web.domains.last_check_failed_ago": {
+    "text": "前回のチェックに失敗しました {0}"
+  },
+  "web.domains.verify_now": {
+    "text": "今すぐ検証"
+  },
+  "web.domains.click_to_verify": {
+    "text": "クリックして検証"
+  },
+  "web.domains.remove_domain_description": {
+    "text": "このドメインとそのすべての設定を完全に削除します。"
+  },
+  "web.domains.add_access_denied": {
+    "text": "アクセスが拒否されました"
+  },
+  "web.domains.add_access_denied_description": {
+    "text": "この組織にドメインを追加する権限がありません。組織の管理者にお問い合わせください。"
+  },
+  "web.domains.dns_widget_load_failed": {
+    "text": "DNSウィジェットの読み込みに失敗しました"
+  },
+  "web.domains.dns_widget_not_available": {
+    "text": "DNSウィジェットを利用できません"
+  },
+  "web.domains.dns_widget_init_failed": {
+    "text": "DNSウィジェットの初期化に失敗しました"
+  },
+  "web.domains.verified": {
+    "text": "検証済み"
+  },
+  "web.domains.pending_verification": {
+    "text": "検証待ち"
+  },
+  "web.domains.unsaved_changes_confirmation": {
+    "text": "保存されていない変更があります。このページから移動してもよろしいですか?"
+  },
+  "web.domains.entitlement_required_owner": {
+    "text": "この機能にはプランのアップグレードが必要です。"
+  },
+  "web.domains.entitlement_required_member": {
+    "text": "この機能は現在のプランではご利用いただけません。組織のオーナーにお問い合わせください。"
+  },
+  "web.domains.detail.manage": {
+    "text": "管理"
+  },
+  "web.domains.detail.features": {
+    "text": "機能"
+  },
+  "web.domains.detail.homepage_title": {
+    "text": "ホームページシークレット"
+  },
+  "web.domains.detail.homepage_description": {
+    "text": "ドメインのホームページでのシークレット作成を一般公開で許可します"
+  },
+  "web.domains.detail.brand_description": {
+    "text": "ロゴ、配色、カスタムブランディング"
+  },
+  "web.domains.detail.sso_description": {
+    "text": "シングルサインオンプロバイダーの設定"
+  },
+  "web.domains.detail.email_description": {
+    "text": "カスタムメール送信元の設定"
+  },
+  "web.domains.detail.incoming_description": {
+    "text": "受信シークレットの受信者設定"
+  },
+  "web.domains.detail.signup_description": {
+    "text": "ドメインごとの登録検証の方式"
+  },
+  "web.domains.detail.signin_description": {
+    "text": "ドメインごとのログイン方法の設定"
+  },
+  "web.domains.email.dns_check_label": {
+    "text": "DNS"
+  },
+  "web.domains.email.provider_check_label": {
+    "text": "プロバイダー"
+  },
+  "web.domains.email.test_email_title": {
+    "text": "メール配信のテスト"
+  },
+  "web.domains.email.test_email_hint": {
+    "text": "保存された設定を使用して、自分宛てにテストメールを送信します。機能がまだ有効になっていない場合でも動作します。"
+  },
+  "web.domains.email.send_test": {
+    "text": "テスト送信"
+  },
+  "web.domains.email.test_email_sent": {
+    "text": "テストメールが正常に送信されました"
+  },
+  "web.domains.email.test_email_failed": {
+    "text": "テストメールの送信に失敗しました"
+  },
+  "web.domains.email.test_email_sent_to": {
+    "text": "{email}に送信しました"
+  },
+  "web.domains.email.delivered_via": {
+    "text": "{provider}経由で配信されました"
+  },
+  "web.domains.incoming.feature_disabled": {
+    "text": "受信シークレットは利用できません"
+  },
+  "web.domains.incoming.feature_disabled_description": {
+    "text": "このインスタンスでは受信シークレットが有効になっていません。管理者にお問い合わせください。"
+  },
+  "web.domains.signin.title": {
+    "text": "ログイン設定"
+  },
+  "web.domains.signin.configure_signin": {
+    "text": "ログインを設定"
+  },
+  "web.domains.signin.config_description": {
+    "text": "このドメインのログイン認証方法を設定します"
+  },
+  "web.domains.signin.access_denied": {
+    "text": "アクセスが拒否されました"
+  },
+  "web.domains.signin.upgrade_to_configure": {
+    "text": "このドメインのログイン方法を設定するには、プランをアップグレードしてください。"
+  },
+  "web.domains.signin.not_configured_notice": {
+    "text": "このドメインのログイン設定はまだ行われていません。上書き設定を構成して、このドメインのログインページで利用できる認証方法を制御してください。"
+  },
+  "web.domains.signin.signin_enabled_label": {
+    "text": "ログインを有効化"
+  },
+  "web.domains.signin.header_toggle_label": {
+    "text": "ログイン"
+  },
+  "web.domains.signin.signin_enabled_hint": {
+    "text": "このドメインでユーザーがログインできるかどうか"
+  },
+  "web.domains.signin.restrict_to_label": {
+    "text": "ログイン方法を制限"
+  },
+  "web.domains.signin.restrict_to_hint": {
+    "text": "このドメインを単一の認証方法に制限します。設定すると、選択した方法のみがログインページに表示されます。"
+  },
+  "web.domains.signin.all_methods": {
+    "text": "すべての方法"
+  },
+  "web.domains.signin.all_methods_description": {
+    "text": "有効なすべての認証方法をログインページに表示します"
+  },
+  "web.domains.signin.method_password": {
+    "text": "パスワード"
+  },
+  "web.domains.signin.method_email_auth": {
+    "text": "メール認証"
+  },
+  "web.domains.signin.method_webauthn": {
+    "text": "WebAuthn / パスキー"
+  },
+  "web.domains.signin.method_sso": {
+    "text": "シングルサインオン"
+  },
+  "web.domains.signin.method_overrides_label": {
+    "text": "方法の上書き設定"
+  },
+  "web.domains.signin.method_overrides_hint": {
+    "text": "このドメインの個々の認証方法を有効または無効にします"
+  },
+  "web.domains.signin.mode_question": {
+    "text": "ユーザーはどのようにログインできますか?"
+  },
+  "web.domains.signin.mode_any": {
+    "text": "利用可能な任意の方法"
+  },
+  "web.domains.signin.mode_any_hint": {
+    "text": "このドメインで利用可能なすべての方法を表示します。個々の方法は以下で絞り込めます。"
+  },
+  "web.domains.signin.mode_one": {
+    "text": "特定の1つの方法"
+  },
+  "web.domains.signin.mode_one_hint": {
+    "text": "ログインページを単一の方法に制限します。このドメインで利用可能な方法のみが表示されます。"
+  },
+  "web.domains.signin.mode_disabled": {
+    "text": "ログインを無効化"
+  },
+  "web.domains.signin.mode_disabled_hint": {
+    "text": "このドメインではユーザーはログインできません。"
+  },
+  "web.domains.signin.mode_disabled_notice": {
+    "text": "このドメインのログインページへの訪問者には、ログインが利用できない旨の通知と、ホームページに戻るリンクが表示されます。以前の方法の設定は保持され、ログインを再度有効にすると復元されます。"
+  },
+  "web.domains.signin.methods_list_label": {
+    "text": "ログインページに表示される方法"
+  },
+  "web.domains.signin.restrict_picker_hint": {
+    "text": "このドメインで利用可能な方法のみが表示されます。"
+  },
+  "web.domains.signin.availability_always": {
+    "text": "常に利用可能"
+  },
+  "web.domains.signin.availability_global_on": {
+    "text": "グローバルポリシーに従う · オン"
+  },
+  "web.domains.signin.availability_global_off": {
+    "text": "利用不可"
+  },
+  "web.domains.signin.availability_unavailable": {
+    "text": "サイト全体で利用不可"
+  },
+  "web.domains.signin.allow_on_domain": {
+    "text": "このドメインで許可"
+  },
+  "web.domains.signin.method_password_blurb": {
+    "text": "パスワードのみ"
+  },
+  "web.domains.signin.method_email_auth_blurb": {
+    "text": "パスワードなしのマジックリンクログイン"
+  },
+  "web.domains.signin.method_webauthn_blurb": {
+    "text": "生体認証とセキュリティキー"
+  },
+  "web.domains.signin.method_sso_blurb": {
+    "text": "外部IDプロバイダー"
+  },
+  "web.domains.signin.email_auth_label": {
+    "text": "メール認証"
+  },
+  "web.domains.signin.email_auth_hint": {
+    "text": "このドメインでパスワードなしのメール認証を許可します"
+  },
+  "web.domains.signin.sso_enabled_label": {
+    "text": "シングルサインオン"
+  },
+  "web.domains.signin.sso_enabled_hint": {
+    "text": "このドメインでSSO認証を許可します"
+  },
+  "web.domains.signin.enabled_label": {
+    "text": "ログイン設定を有効化"
+  },
+  "web.domains.signin.enabled_hint": {
+    "text": "有効にすると、このドメインは上記で構成したログイン設定を使用します"
+  },
+  "web.domains.signin.save_config": {
+    "text": "設定を保存"
+  },
+  "web.domains.signin.update_success": {
+    "text": "ログイン設定が正常に更新されました"
+  },
+  "web.domains.signin.reset_to_defaults": {
+    "text": "デフォルトにリセット"
+  },
+  "web.domains.signin.reset_confirm": {
+    "text": "ログインをグローバルのデフォルトにリセットしますか?"
+  },
+  "web.domains.signin.reset_keeps_sso": {
+    "text": "SSO認証情報は保持されます。削除する場合は、SSO設定画面で個別に行ってください。"
+  },
+  "web.domains.signin.reset_action": {
+    "text": "はい、リセットします"
+  },
+  "web.domains.signin.reset_success": {
+    "text": "ログイン設定がグローバルのデフォルトにリセットされました"
+  },
+  "web.domains.signup.title": {
+    "text": "登録検証"
+  },
+  "web.domains.signup.config_description": {
+    "text": "このドメインの登録検証を設定します"
+  },
+  "web.domains.signup.access_denied": {
+    "text": "アクセスが拒否されました"
+  },
+  "web.domains.signup.upgrade_to_configure": {
+    "text": "ドメインごとの登録検証を設定するには、プランをアップグレードしてください。"
+  },
+  "web.domains.signup.configure_signup": {
+    "text": "登録を設定"
+  },
+  "web.domains.signup.not_configured_notice": {
+    "text": "このドメインの登録検証はまだ設定されていません。方式を構成して、このドメイン経由で登録できるユーザーを制御してください。"
+  },
+  "web.domains.signup.site_signups_disabled_warning": {
+    "text": "現在、サイトレベルで登録が無効になっています。このドメインごとのポリシーは構成されていますが、サイトの登録が有効になるまでトラフィックを制御しません。"
+  },
+  "web.domains.signup.strategy_label": {
+    "text": "検証方式"
+  },
+  "web.domains.signup.strategy_description": {
+    "text": "このドメインでユーザーが登録する際に、メールアドレスをどのように検証するかを選択します。"
+  },
+  "web.domains.signup.network_validation_warning": {
+    "text": "この方式は登録時にネットワーク通信を行うため、遅延が発生したり、一部のプロバイダーによってブロックされたりする場合があります。"
+  },
+  "web.domains.signup.allowed_domains_label": {
+    "text": "登録を許可するドメイン"
+  },
+  "web.domains.signup.allowed_domains_hint": {
+    "text": "これらのメールドメインのみが登録を許可されます。1行につき1つのドメインを追加してください。"
+  },
+  "web.domains.signup.domain_placeholder": {
+    "text": "example.com"
+  },
+  "web.domains.signup.invalid_domain": {
+    "text": "有効なドメインを入力してください (例: example.com)"
+  },
+  "web.domains.signup.domain_exists": {
+    "text": "このドメインはすでにリストに含まれています"
+  },
+  "web.domains.signup.remove_domain": {
+    "text": "{domain}を削除"
+  },
+  "web.domains.signup.enabled_label": {
+    "text": "ドメインごとの検証を有効化"
+  },
+  "web.domains.signup.enabled_hint": {
+    "text": "有効にすると、このドメインの登録はグローバルポリシーではなく上記の方式を使用します。"
+  },
+  "web.domains.signup.delete_config": {
+    "text": "設定を削除"
+  },
+  "web.domains.signup.delete_confirm": {
+    "text": "登録検証の設定を削除しますか? 登録はグローバルポリシーに戻ります。"
+  },
+  "web.domains.signup.save_config": {
+    "text": "設定を保存"
+  },
+  "web.domains.signup.update_success": {
+    "text": "登録検証が正常に更新されました"
+  },
+  "web.domains.signup.delete_success": {
+    "text": "登録検証の設定が正常に削除されました"
+  },
+  "web.domains.signup.domain_overrides_label": {
+    "text": "ドメインの上書き設定"
+  },
+  "web.domains.signup.domain_overrides_hint": {
+    "text": "このドメインのグローバル登録設定を上書きします"
+  },
+  "web.domains.signup.signup_enabled_label": {
+    "text": "登録を有効化"
+  },
+  "web.domains.signup.signup_enabled_hint": {
+    "text": "このドメインで登録を有効にするかどうかを上書きします"
+  },
+  "web.domains.signup.autoverify_label": {
+    "text": "アカウントの自動検証"
+  },
+  "web.domains.signup.autoverify_hint": {
+    "text": "このドメインで新規アカウントを自動的に検証するかどうかを上書きします"
+  },
+  "web.domains.sso.test_success": {
+    "text": "接続テストに成功しました — プロバイダーが正しく応答しました"
+  },
+  "web.domains.sso.test_failed": {
+    "text": "接続テストに失敗しました"
+  },
+  "web.domains.sso.enforce_moved_notice": {
+    "text": "このドメインのすべてのログインでSSOを必須にするには、ドメインのログイン設定で構成してください。SSO専用モードでは、ログインページがここで構成したSSOプロバイダーに制限されます。"
+  },
+  "web.domains.sso.edit_credentials": {
+    "text": "認証情報を編集"
+  },
+  "web.domains.sso.configure_button": {
+    "text": "設定"
+  },
+  "web.domains.sso.upgrade_required": {
+    "text": "アップグレードして設定"
   }
 }

--- a/locales/content/ja/workspace-organizations.json
+++ b/locales/content/ja/workspace-organizations.json
@@ -770,5 +770,200 @@
   "web.organizations.sso.status_not_configured": {
     "text": "未設定",
     "source_hash": "bbea960e"
+  },
+  "api.organizations.errors.not_found": {
+    "text": "組織が見つかりません: %{extid}"
+  },
+  "api.organizations.errors.owner_required": {
+    "text": "この操作を実行できるのは、組織のオーナーのみです"
+  },
+  "api.organizations.errors.admin_required": {
+    "text": "この操作を実行できるのは、組織のオーナーと管理者のみです"
+  },
+  "api.organizations.errors.member_required": {
+    "text": "この操作を実行するには、組織のメンバーである必要があります"
+  },
+  "api.organizations.invitations.errors.create_admin_required": {
+    "text": "招待を作成できるのは、組織のオーナーと管理者のみです"
+  },
+  "api.organizations.invitations.errors.resend_admin_required": {
+    "text": "招待を再送信できるのは、組織のオーナーと管理者のみです"
+  },
+  "api.organizations.invitations.errors.view_admin_required": {
+    "text": "招待を表示できるのは、組織のオーナーと管理者のみです"
+  },
+  "api.organizations.invitations.errors.revoke_admin_required": {
+    "text": "招待を取り消せるのは、組織のオーナーと管理者のみです"
+  },
+  "api.organizations.invitations.errors.email_required": {
+    "text": "メールアドレスは必須です"
+  },
+  "api.organizations.invitations.errors.email_invalid": {
+    "text": "メールアドレスの形式が無効です"
+  },
+  "api.organizations.invitations.errors.role_invalid": {
+    "text": "役割はメンバーまたは管理者のいずれかである必要があります"
+  },
+  "api.organizations.invitations.errors.cannot_invite_owner": {
+    "text": "オーナーとして招待することはできません"
+  },
+  "api.organizations.invitations.errors.already_member": {
+    "text": "ユーザーはすでにこの組織のメンバーです"
+  },
+  "api.organizations.invitations.errors.already_pending": {
+    "text": "このメールアドレスへの招待はすでに保留中です"
+  },
+  "api.organizations.invitations.errors.member_limit_reached": {
+    "text": "メンバー数の上限に達しました。さらにメンバーを招待するには、プランをアップグレードしてください。"
+  },
+  "api.organizations.invitations.errors.not_found": {
+    "text": "招待が見つかりません"
+  },
+  "api.organizations.invitations.errors.cannot_resend_non_pending": {
+    "text": "再送信できるのは保留中の招待のみです"
+  },
+  "api.organizations.invitations.errors.cannot_revoke_non_pending": {
+    "text": "取り消せるのは保留中の招待のみです"
+  },
+  "api.organizations.invitations.errors.resend_limit_reached": {
+    "text": "再送信の上限回数 (%{max}) に達しました"
+  },
+  "api.organizations.invitations.errors.accept_token_required": {
+    "text": "トークンは必須です"
+  },
+  "api.organizations.invitations.errors.accept_organization_gone": {
+    "text": "組織はすでに存在しません"
+  },
+  "api.organizations.invitations.errors.accept_already_acted": {
+    "text": "この招待はすでに処理されています(%{status})"
+  },
+  "api.organizations.invitations.errors.accept_expired": {
+    "text": "招待の有効期限が切れています"
+  },
+  "api.organizations.invitations.errors.accept_email_mismatch": {
+    "text": "お使いのメールアドレスが招待と一致しません"
+  },
+  "api.organizations.invitations.errors.accept_already_member": {
+    "text": "あなたはすでにこの組織のメンバーです"
+  },
+  "web.organizations.entitlements_title": {
+    "text": "組織のエンタイトルメント"
+  },
+  "web.organizations.page_description_short": {
+    "text": "ワークスペースの表示と設定"
+  },
+  "web.organizations.delete_organization_remove_domains_first": {
+    "text": "この組織を削除する前に、すべてのカスタムドメインを削除してください。"
+  },
+  "web.organizations.default_org_delete_notice_title": {
+    "text": "この組織の削除"
+  },
+  "web.organizations.default_org_delete_notice_before": {
+    "text": "これはデフォルトの組織であり、ダッシュボードから削除することはできません。削除するには、"
+  },
+  "web.organizations.default_org_delete_notice_link": {
+    "text": "フィードバックフォーム"
+  },
+  "web.organizations.default_org_delete_notice_after": {
+    "text": "からご連絡ください。"
+  },
+  "web.organizations.leave_organization": {
+    "text": "この組織から退出"
+  },
+  "web.organizations.leave_organization_warning": {
+    "text": "この組織とそのリソースへのアクセス権を失います。"
+  },
+  "web.organizations.leave_organization_confirm_title": {
+    "text": "組織から退出"
+  },
+  "web.organizations.leave_organization_confirm_message": {
+    "text": "{name}から退出してもよろしいですか? 再参加するには新しい招待が必要になります。"
+  },
+  "web.organizations.leave_organization_success": {
+    "text": "組織から退出しました。"
+  },
+  "web.organizations.leave_error": {
+    "text": "組織からの退出に失敗しました"
+  },
+  "web.organizations.organizations": {
+    "text": "組織"
+  },
+  "web.organizations.invitations.invited_by_inline": {
+    "text": "{email}より"
+  },
+  "web.organizations.invitations.invited_as_inline": {
+    "text": "{role}として"
+  },
+  "web.organizations.invitations.back_to_home": {
+    "text": "ホームに戻る"
+  },
+  "web.organizations.invitations.email_locked_hint": {
+    "text": "この招待はこのメールアドレス宛てに送信されました"
+  },
+  "web.organizations.invitations.signup_continue": {
+    "text": "続ける"
+  },
+  "web.organizations.invitations.signin_continue": {
+    "text": "ログイン"
+  },
+  "web.organizations.invitations.confirm_join_below": {
+    "text": "あと少しです — 以下で確認して組織に参加してください。"
+  },
+  "web.organizations.invitations.go_to_organizations": {
+    "text": "組織へ移動"
+  },
+  "web.organizations.invitations.already_member": {
+    "text": "あなたはすでにこの組織のメンバーです"
+  },
+  "web.organizations.invitations.join_organization": {
+    "text": "{orgName}に参加"
+  },
+  "web.organizations.invitations.sign_in_to_join": {
+    "text": "ログインして{orgName}に参加"
+  },
+  "web.organizations.invitations.decline": {
+    "text": "辞退"
+  },
+  "web.organizations.members.member_quota": {
+    "text": "{limit}人中{used}人のメンバー"
+  },
+  "web.organizations.members.pending_suffix": {
+    "text": "({count}件保留中)"
+  },
+  "web.organizations.members.limit_reached_hint": {
+    "text": "メンバー数の上限に達しました。"
+  },
+  "web.organizations.sso.view_discovery_document": {
+    "text": "ディスカバリードキュメントを表示"
+  },
+  "web.organizations.sso.callback_url": {
+    "text": "コールバックURL"
+  },
+  "web.organizations.sso.callback_url_hint": {
+    "text": "このURLをIDプロバイダーの許可されたリダイレクトURIに追加してください"
+  },
+  "web.organizations.sso.enforce_sso_only": {
+    "text": "SSOのみを強制"
+  },
+  "web.organizations.sso.enforce_sso_only_hint": {
+    "text": "このドメインのすべてのログインでSSOを必須にします。有効にすると、パスワードによる認証は無効になります。"
+  },
+  "web.organizations.sso.grant_org_scope": {
+    "text": "組織全体へのアクセスを付与"
+  },
+  "web.organizations.sso.grant_org_scope_hint": {
+    "text": "このドメインのSSO経由で参加した新規メンバーには、すべての組織ドメインへのアクセス権が付与されます。既存のメンバーには影響しません。無効にした場合(デフォルト)、新規メンバーはこのドメインにのみアクセスできます。"
+  },
+  "web.organizations.sso.no_domains": {
+    "text": "検証済みのドメインがありません"
+  },
+  "web.organizations.sso.no_domains_description": {
+    "text": "SSOを設定する前に、ドメインを追加して検証してください。"
+  },
+  "web.organizations.tabs.team": {
+    "text": "チーム"
+  },
+  "web.organizations.tabs.sso": {
+    "text": "SSO"
   }
 }


### PR DESCRIPTION
## `ja` translation update

Automated export of completed **ja** translations from the translation task DB.
Scope: `locales/content/ja/` only — 27 file(s), +1353/-24.

⚠️ `i18n validate variables` reports **1** variable mismatch(es) for `ja` (empty values that drop source variables, renamed/extra vars, etc.) — see the review below.

---

### Local quality review

> Produced by a fresh, isolated `claude` review agent (model `claude-sonnet-5`, agent `saas-translator`) that read
> `locales/AGENT_TRANSLATION_PROTOCOL.md` and inspected this branch's diff before the PR was opened.

**Verdict:** ⚠️ Needs review — pre-existing `%{date}` variable defect

**Summary:** This is a large, well-formed ja update (new API error namespaces, colonel/domains/billing/org strings, email signature swap). Spot-checked variable tokens, brand terms, and phrasing are consistent and idiomatic; one variable-consistency failure was flagged by the automated checker, though it is not part of this diff.

**Critical (must fix):**
- `email.json` → `email.email_changed.body.text`: ja text includes `%{date}` (「%{date}に」) which does not exist in the English source (`"...has been changed to %{new_email_masked}."`). Flagged by the variable-consistency check (`ja-0701-error-1`). Note: this key is **not** touched by this diff — it's pre-existing repo state — but it will still fail the gate and should be fixed (drop `%{date}` or confirm source should add it) before/alongside merge.

**Warnings:**
- Minor punctuation-style inconsistency: some entries use full-width parentheses for glosses (`経過日数（日）`) while others use half-width with a space for acronym expansions (`シングルサインオン (SSO)`). Not a defect, just inconsistent style across the batch.

**Notes:**
- All `email.*.signature` entries consistently changed `Delano` → `サポートチーム` ("Support Team"), matching the pattern seen in other locales this round.
- `web.homepage.one_time_secret_literal` changed from a translated literal (`ワンタイムシークレット`) to `{product_name}`, which now correctly matches the English source (source is literally `"{product_name}"`) — this is a fix, not a regression.
- `web.INSTRUCTION.phishing_warning` retranslation preserves both `{product_name}` occurrences and reads naturally; "region domain" → リージョンのドメイン is accurate.
- No untranslated English, empty values, or mojibake observed in the sampled content; brand terms (Onetime Secret, Google, SSO, API, IP) left correctly untranslated.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
