### PR TITLE
i18n: update ko translations

### DIFF
--- a/locales/content/ko/00-common.json
+++ b/locales/content/ko/00-common.json
@@ -1383,5 +1383,110 @@
     "text": "업그레이드하여 더 많은 기능을 사용하세요",
     "context": "Description shown for free plan users encouraging upgrade",
     "source_hash": "783f174c"
+  },
+  "api.errors.authentication_required": {
+    "text": "인증이 필요합니다"
+  },
+  "api.errors.sso_only_action_blocked": {
+    "text": "이 작업은 SSO 전용 모드에서 사용할 수 없습니다"
+  },
+  "web.COMMON.configure": {
+    "text": "구성"
+  },
+  "web.COMMON.copy_to_clipboard": {
+    "text": "클립보드에 복사"
+  },
+  "web.COMMON.add": {
+    "text": "추가"
+  },
+  "web.COMMON.enabled": {
+    "text": "활성화됨"
+  },
+  "web.COMMON.disabled": {
+    "text": "비활성화됨"
+  },
+  "web.COMMON.yes_delete": {
+    "text": "예, 삭제합니다"
+  },
+  "web.COMMON.error_code": {
+    "text": "오류 코드"
+  },
+  "web.COMMON.http_status": {
+    "text": "HTTP 상태"
+  },
+  "web.COMMON.details": {
+    "text": "세부 정보"
+  },
+  "web.COMMON.field_confirm_password": {
+    "text": "비밀번호 확인"
+  },
+  "web.COMMON.passwords_must_match": {
+    "text": "비밀번호가 일치해야 합니다"
+  },
+  "web.COMMON.and": {
+    "text": "및"
+  },
+  "web.COMMON.or": {
+    "text": "또는"
+  },
+  "web.COMMON.copied": {
+    "text": "복사됨"
+  },
+  "web.COMMON.copy": {
+    "text": "복사"
+  },
+  "web.COMMON.copy_email": {
+    "text": "이메일 주소 복사"
+  },
+  "web.COMMON.copy_id": {
+    "text": "계정 ID 복사"
+  },
+  "web.COMMON.org_id_tooltip": {
+    "text": "조직의 고유 식별자"
+  },
+  "web.COMMON.success": {
+    "text": "성공"
+  },
+  "web.COMMON.need_help": {
+    "text": "도움이 필요하세요"
+  },
+  "web.COMMON.open_help_dialog": {
+    "text": "도움말 대화 상자 열기"
+  },
+  "web.COMMON.focus_is_now_in_the_main_text_area": {
+    "text": "이제 본문 입력 영역에 포커스가 있습니다"
+  },
+  "web.LABELS.show_passphrase": {
+    "text": "접근 문구 표시"
+  },
+  "web.LABELS.hide_passphrase": {
+    "text": "접근 문구 숨기기"
+  },
+  "web.LABELS.copy_icon": {
+    "text": "복사 아이콘"
+  },
+  "web.LABELS.copied_icon": {
+    "text": "복사됨 아이콘"
+  },
+  "web.STATUS.unverified": {
+    "text": "미확인"
+  },
+  "web.TITLES.domain_detail": {
+    "text": "도메인 설정"
+  },
+  "web.TITLES.domain_signin": {
+    "text": "로그인 구성"
+  },
+  "web.TITLES.domain_sso": {
+    "text": "도메인 SSO"
+  },
+  "web.TITLES.domain_signup": {
+    "text": "도메인 가입 검증"
+  },
+  "web.TITLES.domain_email": {
+    "text": "이메일 구성"
+  },
+  "web.TITLES.domain_incoming": {
+    "text": "수신 비밀 메시지"
   }
 }

--- a/locales/content/ko/10-layout.json
+++ b/locales/content/ko/10-layout.json
@@ -338,5 +338,11 @@
   "web.layout.workspace_context": {
     "text": "작업 공간 컨텍스트",
     "source_hash": "dc6fa4f5"
+  },
+  "web.footer.workspace": {
+    "text": "워크스페이스"
+  },
+  "web.help.default_content": {
+    "text": "도움이 필요하시면 지원팀에 문의해 주세요"
   }
 }

--- a/locales/content/ko/admin-colonel.json
+++ b/locales/content/ko/admin-colonel.json
@@ -634,5 +634,152 @@
   "web.colonel.feedback.when_you_submit_feedback_well_see": {
     "text": "의견을 제출하시면 다음 정보를 확인할 수 있습니다:",
     "source_hash": "fe77172e"
+  },
+  "web.colonel.previewPlanMode": {
+    "text": "요금제 미리보기 모드"
+  },
+  "web.colonel.previewModeDescription": {
+    "text": "다른 요금제를 사용하는 고객에게 표시되는 모습으로 애플리케이션을 미리 봅니다. 이 설정은 본인의 화면에만 적용되며 어떤 조직의 실제 요금제도 변경하지 않습니다."
+  },
+  "web.colonel.previewModeActive": {
+    "text": "미리보기 활성화됨"
+  },
+  "web.colonel.bannedIps.empty": {
+    "text": "차단된 IP 없음"
+  },
+  "web.colonel.bannedIps.currentIp": {
+    "text": "현재 IP 주소"
+  },
+  "web.colonel.bannedIps.confirmUnban": {
+    "text": "{ip}의 차단을 해제하시겠습니까?"
+  },
+  "web.colonel.bannedIps.actions.ban": {
+    "text": "IP 차단"
+  },
+  "web.colonel.bannedIps.actions.quickBan": {
+    "text": "빠른 차단"
+  },
+  "web.colonel.bannedIps.actions.unban": {
+    "text": "차단 해제"
+  },
+  "web.colonel.bannedIps.actions.cancel": {
+    "text": "취소"
+  },
+  "web.colonel.bannedIps.columns.ipAddress": {
+    "text": "IP 주소"
+  },
+  "web.colonel.bannedIps.columns.reason": {
+    "text": "사유"
+  },
+  "web.colonel.bannedIps.columns.bannedAt": {
+    "text": "차단 일시"
+  },
+  "web.colonel.bannedIps.columns.bannedBy": {
+    "text": "차단한 사람"
+  },
+  "web.colonel.bannedIps.error.banFailed": {
+    "text": "IP 주소를 차단하지 못했습니다"
+  },
+  "web.colonel.bannedIps.error.unbanFailed": {
+    "text": "IP 주소 차단을 해제하지 못했습니다"
+  },
+  "web.colonel.bannedIps.form.title": {
+    "text": "IP 주소 차단"
+  },
+  "web.colonel.bannedIps.form.ipLabel": {
+    "text": "IP 주소"
+  },
+  "web.colonel.bannedIps.form.reasonLabel": {
+    "text": "사유"
+  },
+  "web.colonel.bannedIps.form.reasonPlaceholder": {
+    "text": "사유 (선택 사항)"
+  },
+  "web.colonel.bannedIps.success.banned": {
+    "text": "IP 주소 {ip}이(가) 차단되었습니다"
+  },
+  "web.colonel.bannedIps.success.unbanned": {
+    "text": "IP 주소 {ip}의 차단이 해제되었습니다"
+  },
+  "web.colonel.customDomains.empty": {
+    "text": "구성된 사용자 정의 도메인이 없습니다"
+  },
+  "web.colonel.customDomains.noLogo": {
+    "text": "로고 없음"
+  },
+  "web.colonel.customDomains.labels.organization": {
+    "text": "조직"
+  },
+  "web.colonel.customDomains.labels.externalId": {
+    "text": "외부 ID"
+  },
+  "web.colonel.customDomains.labels.created": {
+    "text": "생성됨"
+  },
+  "web.colonel.customDomains.labels.updated": {
+    "text": "업데이트됨"
+  },
+  "web.colonel.customDomains.labels.favicon": {
+    "text": "파비콘"
+  },
+  "web.colonel.customDomains.status.verified": {
+    "text": "확인됨"
+  },
+  "web.colonel.customDomains.status.resolving": {
+    "text": "조회 중"
+  },
+  "web.colonel.customDomains.status.ready": {
+    "text": "준비됨"
+  },
+  "web.colonel.customDomains.status.publicHomepage": {
+    "text": "공개 홈페이지"
+  },
+  "web.colonel.customDomains.status.publicApi": {
+    "text": "공개 API"
+  },
+  "web.colonel.customDomains.status.pending": {
+    "text": "대기 중"
+  },
+  "web.colonel.pagination.showing": {
+    "text": "총 {total}개 중 {start}–{end} 표시"
+  },
+  "web.colonel.pagination.itemsPerPage": {
+    "text": "페이지당 항목 수"
+  },
+  "web.colonel.pagination.perPage": {
+    "text": "페이지당 {count}개"
+  },
+  "web.colonel.pagination.pageOf": {
+    "text": "{total}페이지 중 {current}페이지"
+  },
+  "web.colonel.secrets.empty": {
+    "text": "비밀 메시지가 없습니다"
+  },
+  "web.colonel.secrets.never": {
+    "text": "없음"
+  },
+  "web.colonel.secrets.columns.shortId": {
+    "text": "짧은 ID"
+  },
+  "web.colonel.secrets.columns.state": {
+    "text": "상태"
+  },
+  "web.colonel.secrets.columns.created": {
+    "text": "생성됨"
+  },
+  "web.colonel.secrets.columns.expiration": {
+    "text": "만료"
+  },
+  "web.colonel.secrets.columns.age": {
+    "text": "경과 시간(일)"
+  },
+  "web.colonel.secrets.state.new": {
+    "text": "새 항목"
+  },
+  "web.colonel.secrets.state.received": {
+    "text": "수신됨"
+  },
+  "web.colonel.secrets.state.viewed": {
+    "text": "열람됨"
   }
 }

--- a/locales/content/ko/api-account-errors.json
+++ b/locales/content/ko/api-account-errors.json
@@ -1,0 +1,8 @@
+{
+  "api.account.errors.invalid_email": {
+    "text": "유효한 이메일 주소가 맞나요?"
+  },
+  "api.account.errors.password_too_short": {
+    "text": "비밀번호가 너무 짧습니다"
+  }
+}

--- a/locales/content/ko/api-domains-errors.json
+++ b/locales/content/ko/api-domains-errors.json
@@ -1,0 +1,29 @@
+{
+  "api.domains.errors.domain_id_required": {
+    "text": "도메인 ID가 필요합니다"
+  },
+  "api.domains.errors.domain_not_found": {
+    "text": "도메인을 찾을 수 없습니다: %{extid}"
+  },
+  "api.domains.errors.organization_not_found": {
+    "text": "해당 도메인의 조직을 찾을 수 없습니다: %{domain}"
+  },
+  "api.domains.errors.incoming_secrets_disabled": {
+    "text": "이 인스턴스에서는 수신 비밀 메시지가 활성화되어 있지 않습니다"
+  },
+  "api.domains.errors.incoming_secrets_entitlement_required": {
+    "text": "수신 비밀 메시지 관리에는 incoming_secrets 권한이 필요합니다. 요금제를 업그레이드해 주세요."
+  },
+  "api.domains.errors.incoming_config_not_found": {
+    "text": "해당 도메인의 수신 구성을 찾을 수 없습니다: %{extid}"
+  },
+  "api.domains.errors.recipients_max_exceeded": {
+    "text": "최대 %{max}명의 수신자만 허용됩니다"
+  },
+  "api.domains.errors.recipients_invalid_email": {
+    "text": "유효하지 않은 이메일: %{email}"
+  },
+  "api.domains.errors.recipients_duplicate": {
+    "text": "중복된 수신자 이메일은 허용되지 않습니다"
+  }
+}

--- a/locales/content/ko/api-entitlements-errors.json
+++ b/locales/content/ko/api-entitlements-errors.json
@@ -1,0 +1,71 @@
+{
+  "api.entitlements.errors.context_unavailable": {
+    "text": "권한을 확인할 수 없습니다 (조직 컨텍스트를 사용할 수 없음)"
+  },
+  "api.entitlements.errors.api_access_required": {
+    "text": "API 액세스에는 요금제 업그레이드가 필요합니다"
+  },
+  "api.entitlements.errors.custom_privacy_defaults_required": {
+    "text": "사용자 정의 개인정보 기본값에는 요금제 업그레이드가 필요합니다"
+  },
+  "api.entitlements.errors.extended_default_expiration_required": {
+    "text": "기본 만료 시간 연장에는 요금제 업그레이드가 필요합니다"
+  },
+  "api.entitlements.errors.custom_domains_required": {
+    "text": "사용자 정의 도메인에는 요금제 업그레이드가 필요합니다"
+  },
+  "api.entitlements.errors.custom_branding_required": {
+    "text": "맞춤형 브랜딩에는 요금제 업그레이드가 필요합니다"
+  },
+  "api.entitlements.errors.homepage_secrets_required": {
+    "text": "홈페이지 비밀 메시지에는 요금제 업그레이드가 필요합니다"
+  },
+  "api.entitlements.errors.incoming_secrets_required": {
+    "text": "수신 비밀 메시지에는 요금제 업그레이드가 필요합니다"
+  },
+  "api.entitlements.errors.custom_mail_sender_required": {
+    "text": "사용자 정의 메일 발신자에는 요금제 업그레이드가 필요합니다"
+  },
+  "api.entitlements.errors.flexible_from_domain_required": {
+    "text": "유연한 발신 도메인에는 요금제 업그레이드가 필요합니다"
+  },
+  "api.entitlements.errors.manage_org_required": {
+    "text": "조직 관리에는 요금제 업그레이드가 필요합니다"
+  },
+  "api.entitlements.errors.manage_teams_required": {
+    "text": "팀 관리에는 요금제 업그레이드가 필요합니다"
+  },
+  "api.entitlements.errors.manage_members_required": {
+    "text": "멤버 관리에는 요금제 업그레이드가 필요합니다"
+  },
+  "api.entitlements.errors.manage_sso_required": {
+    "text": "SSO 관리에는 요금제 업그레이드가 필요합니다"
+  },
+  "api.entitlements.errors.audit_logs_required": {
+    "text": "감사 로그에는 요금제 업그레이드가 필요합니다"
+  },
+  "api.entitlements.errors.custom_signup_validation_required": {
+    "text": "사용자 정의 가입 검증에는 요금제 업그레이드가 필요합니다"
+  },
+  "api.entitlements.errors.create_secrets_required": {
+    "text": "비밀 메시지 생성에는 요금제 업그레이드가 필요합니다"
+  },
+  "api.entitlements.errors.view_receipt_required": {
+    "text": "수신확인 보기에는 요금제 업그레이드가 필요합니다"
+  },
+  "api.entitlements.errors.notifications_required": {
+    "text": "알림에는 요금제 업그레이드가 필요합니다"
+  },
+  "api.entitlements.errors.workspace_branding_required": {
+    "text": "워크스페이스 브랜딩에는 요금제 업그레이드가 필요합니다"
+  },
+  "api.entitlements.errors.ip_access_rules_required": {
+    "text": "IP 액세스 규칙에는 요금제 업그레이드가 필요합니다"
+  },
+  "api.entitlements.errors.manage_billing_required": {
+    "text": "결제 관리에는 요금제 업그레이드가 필요합니다"
+  },
+  "api.entitlements.errors.custom_signin_config_required": {
+    "text": "사용자 정의 로그인 구성에는 요금제 업그레이드가 필요합니다"
+  }
+}

--- a/locales/content/ko/api-feedback-errors.json
+++ b/locales/content/ko/api-feedback-errors.json
@@ -1,0 +1,5 @@
+{
+  "api.feedback.errors.rate_limit_exceeded": {
+    "text": "피드백 제출이 너무 많습니다. 잠시 후 다시 시도해 주세요."
+  }
+}

--- a/locales/content/ko/api-incoming-errors.json
+++ b/locales/content/ko/api-incoming-errors.json
@@ -1,0 +1,5 @@
+{
+  "api.incoming.errors.custom_domain_unresolved": {
+    "text": "사용자 정의 도메인의 조직을 확인할 수 없습니다"
+  }
+}

--- a/locales/content/ko/api-invite-errors.json
+++ b/locales/content/ko/api-invite-errors.json
@@ -1,0 +1,23 @@
+{
+  "api.invite.errors.invitation_not_found_or_expired": {
+    "text": "초대를 찾을 수 없거나 만료되었습니다"
+  },
+  "api.invite.errors.token_required": {
+    "text": "토큰이 필요합니다"
+  },
+  "api.invite.errors.organization_no_longer_exists": {
+    "text": "조직이 더 이상 존재하지 않습니다"
+  },
+  "api.invite.errors.invitation_already_processed": {
+    "text": "이 초대는 이미 %{status} 상태입니다"
+  },
+  "api.invite.errors.invitation_expired": {
+    "text": "초대가 만료되었습니다"
+  },
+  "api.invite.errors.email_mismatch": {
+    "text": "이메일 주소가 초대와 일치하지 않습니다"
+  },
+  "api.invite.errors.already_member": {
+    "text": "이미 이 조직의 멤버입니다"
+  }
+}

--- a/locales/content/ko/api-organizations-errors.json
+++ b/locales/content/ko/api-organizations-errors.json
@@ -1,0 +1,107 @@
+{
+  "api.organizations.errors.domain_scoped_forbidden": {
+    "text": "도메인 범위 멤버는 이 작업을 수행할 수 없습니다"
+  },
+  "api.organizations.errors.organization_not_found": {
+    "text": "조직을 찾을 수 없습니다: %{extid}"
+  },
+  "api.organizations.errors.organization_owner_required": {
+    "text": "조직 소유자만 이 작업을 수행할 수 있습니다"
+  },
+  "api.organizations.errors.organization_member_required": {
+    "text": "이 작업을 수행하려면 조직 멤버여야 합니다"
+  },
+  "api.organizations.errors.organization_admin_required": {
+    "text": "조직 소유자와 관리자만 이 작업을 수행할 수 있습니다"
+  },
+  "api.organizations.errors.extid_required": {
+    "text": "조직 ID가 필요합니다"
+  },
+  "api.organizations.errors.display_name_required": {
+    "text": "조직 이름은 필수입니다"
+  },
+  "api.organizations.errors.display_name_too_long": {
+    "text": "조직 이름은 %{max}자 미만이어야 합니다"
+  },
+  "api.organizations.errors.description_too_long": {
+    "text": "설명은 %{max}자 미만이어야 합니다"
+  },
+  "api.organizations.errors.contact_email_exists": {
+    "text": "이 연락처 이메일을 사용하는 조직이 이미 존재합니다"
+  },
+  "api.organizations.errors.creation_in_progress": {
+    "text": "조직 생성이 진행 중입니다. 다시 시도해 주세요."
+  },
+  "api.organizations.errors.organization_limit_reached": {
+    "text": "조직 한도에 도달했습니다. 조직을 더 만들려면 요금제를 업그레이드하세요."
+  },
+  "api.organizations.invitations.errors.invitation_not_found": {
+    "text": "초대를 찾을 수 없습니다"
+  },
+  "api.organizations.invitations.errors.email_required": {
+    "text": "이메일은 필수입니다"
+  },
+  "api.organizations.invitations.errors.invalid_email_format": {
+    "text": "유효하지 않은 이메일 형식입니다"
+  },
+  "api.organizations.invitations.errors.invalid_role": {
+    "text": "역할은 멤버 또는 관리자여야 합니다"
+  },
+  "api.organizations.invitations.errors.cannot_invite_as_owner": {
+    "text": "소유자로 초대할 수 없습니다"
+  },
+  "api.organizations.invitations.errors.user_already_member": {
+    "text": "사용자가 이미 이 조직의 멤버입니다"
+  },
+  "api.organizations.invitations.errors.invitation_already_pending": {
+    "text": "이 이메일에 대한 초대가 이미 대기 중입니다"
+  },
+  "api.organizations.invitations.errors.member_limit_reached": {
+    "text": "멤버 한도에 도달했습니다. 더 많은 멤버를 초대하려면 요금제를 업그레이드하세요."
+  },
+  "api.organizations.invitations.errors.resend_only_pending": {
+    "text": "대기 중인 초대만 다시 보낼 수 있습니다"
+  },
+  "api.organizations.invitations.errors.resend_limit_reached": {
+    "text": "최대 재전송 한도(%{max})에 도달했습니다"
+  },
+  "api.organizations.invitations.errors.revoke_only_pending": {
+    "text": "대기 중인 초대만 철회할 수 있습니다"
+  },
+  "api.organizations.members.errors.member_not_found": {
+    "text": "멤버를 찾을 수 없습니다: %{extid}"
+  },
+  "api.organizations.members.errors.member_not_in_organization": {
+    "text": "이 조직에서 멤버를 찾을 수 없습니다"
+  },
+  "api.organizations.members.errors.member_not_active": {
+    "text": "멤버가 활성 상태가 아닙니다"
+  },
+  "api.organizations.members.errors.invalid_role_value": {
+    "text": "유효하지 않은 역할입니다. 다음 중 하나여야 합니다: %{roles}"
+  },
+  "api.organizations.members.errors.cannot_change_owner_role": {
+    "text": "소유자 역할은 변경할 수 없습니다. 대신 소유권 이전을 사용하세요."
+  },
+  "api.organizations.members.errors.member_already_has_role": {
+    "text": "멤버에게 이미 다음 역할이 있습니다: %{role}"
+  },
+  "api.organizations.members.errors.cannot_promote_to_owner": {
+    "text": "소유자로 승격할 수 없습니다. 대신 소유권 이전을 사용하세요."
+  },
+  "api.organizations.members.errors.must_be_member": {
+    "text": "이 조직의 멤버여야 합니다"
+  },
+  "api.organizations.members.errors.cannot_remove_owner": {
+    "text": "조직 소유자는 제거할 수 없습니다. 먼저 소유권을 이전하세요."
+  },
+  "api.organizations.members.errors.cannot_remove_self": {
+    "text": "본인은 제거할 수 없습니다. 대신 조직 나가기를 사용하세요."
+  },
+  "api.organizations.members.errors.admin_cannot_remove_admin": {
+    "text": "관리자는 다른 관리자를 제거할 수 없습니다. 소유자만 가능합니다."
+  },
+  "api.organizations.members.errors.no_permission_to_remove": {
+    "text": "멤버를 제거할 권한이 없습니다"
+  }
+}

--- a/locales/content/ko/api-secrets-errors.json
+++ b/locales/content/ko/api-secrets-errors.json
@@ -1,0 +1,11 @@
+{
+  "api.secrets.errors.domain_permission_authenticated_non_owner": {
+    "text": "이 도메인을 사용할 권한이 없습니다: %{domain}"
+  },
+  "api.secrets.errors.domain_public_sharing_disabled": {
+    "text": "이 도메인에서는 공개 공유가 비활성화되어 있습니다: %{domain}"
+  },
+  "api.secrets.errors.domain_permission_anonymous_cross_domain": {
+    "text": "이 도메인을 사용할 권한이 없습니다: %{domain}"
+  }
+}

--- a/locales/content/ko/email.json
+++ b/locales/content/ko/email.json
@@ -60,7 +60,7 @@
     "source_hash": "88c72144"
   },
   "email.welcome.signature": {
-    "text": "Delano",
+    "text": "지원팀",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -100,7 +100,7 @@
     "source_hash": "fbb7eb2d"
   },
   "email.password_request.signature": {
-    "text": "Delano",
+    "text": "지원팀",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -145,7 +145,7 @@
     "source_hash": "1863f5be"
   },
   "email.magic_link.signature": {
-    "text": "Delano",
+    "text": "지원팀",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -230,7 +230,7 @@
     "source_hash": "3f6b45dd"
   },
   "email.secret_revealed.signature": {
-    "text": "Delano",
+    "text": "지원팀",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -355,7 +355,7 @@
     "source_hash": "734882d2"
   },
   "email.organization_invitation.signature": {
-    "text": "Delano",
+    "text": "지원팀",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -395,7 +395,7 @@
     "source_hash": "be92cff3"
   },
   "email.password_changed.signature": {
-    "text": "Delano",
+    "text": "지원팀",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -445,7 +445,7 @@
     "source_hash": "f8d47b82"
   },
   "email.email_changed.signature": {
-    "text": "Delano",
+    "text": "지원팀",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -495,7 +495,7 @@
     "source_hash": "f8d47b82"
   },
   "email.email_change_requested.signature": {
-    "text": "Delano",
+    "text": "지원팀",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -550,7 +550,7 @@
     "source_hash": "d4d835fc"
   },
   "email.email_change_confirmation.signature": {
-    "text": "Delano",
+    "text": "지원팀",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -580,7 +580,7 @@
     "source_hash": "e7c11bb0"
   },
   "email.mfa_enabled.signature": {
-    "text": "Delano",
+    "text": "지원팀",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -605,7 +605,7 @@
     "source_hash": "97ef0a3e"
   },
   "email.mfa_disabled.signature": {
-    "text": "Delano",
+    "text": "지원팀",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -650,7 +650,7 @@
     "source_hash": "450c54c5"
   },
   "email.new_login_alert.signature": {
-    "text": "Delano",
+    "text": "지원팀",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -670,7 +670,7 @@
     "source_hash": "d442beed"
   },
   "email.member_removed.signature": {
-    "text": "Delano",
+    "text": "지원팀",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -690,7 +690,7 @@
     "source_hash": "c2280c0c"
   },
   "email.role_changed.signature": {
-    "text": "Delano",
+    "text": "지원팀",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -710,7 +710,7 @@
     "source_hash": "7095fc69"
   },
   "email.organization_deleted.signature": {
-    "text": "Delano",
+    "text": "지원팀",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -750,7 +750,7 @@
     "source_hash": "36008943"
   },
   "email.payment_receipt.signature": {
-    "text": "Delano",
+    "text": "지원팀",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -775,7 +775,7 @@
     "source_hash": "926406b1"
   },
   "email.payment_failed.signature": {
-    "text": "Delano",
+    "text": "지원팀",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -800,7 +800,7 @@
     "source_hash": "66a1419e"
   },
   "email.trial_expiring.signature": {
-    "text": "Delano",
+    "text": "지원팀",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -825,7 +825,7 @@
     "source_hash": "5a96ae38"
   },
   "email.subscription_changed.signature": {
-    "text": "Delano",
+    "text": "지원팀",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -853,5 +853,41 @@
     "text": "Onetime Secret",
     "renderer": "erb",
     "source_hash": "1cd0194a"
+  },
+  "email.common.secret_link_label": {
+    "text": "비밀 링크"
+  },
+  "email.common.automated_notice": {
+    "text": "이것은 %{product_name}에서 자동으로 발송된 메시지입니다."
+  },
+  "email.common.support_label": {
+    "text": "지원"
+  },
+  "email.expiration_warning.signature": {
+    "text": "지원팀"
+  },
+  "email.expiration_warning.footer_note": {
+    "text": "%{product_name}에서 생성하신 비밀 메시지가 곧 만료되기 때문에 이 메시지를 받으셨습니다."
+  },
+  "email.feedback_email.user_id_label": {
+    "text": "사용자:"
+  },
+  "email.feedback_email.timezone_label": {
+    "text": "시간대:"
+  },
+  "email.feedback_email.version_label": {
+    "text": "버전:"
+  },
+  "email.incoming_secret.footer_note": {
+    "text": "누군가 %{product_name}을(를) 사용하여 비밀 메시지를 보냈기 때문에 이 메시지를 받으셨습니다. 예상하지 못한 메시지라면 이 이메일을 무시하셔도 안전합니다."
+  },
+  "email.secret_link.passphrase_label": {
+    "text": "접근 문구 필요:"
+  },
+  "email.secret_link.passphrase_required": {
+    "text": "이 비밀 메시지는 접근 문구로 보호되어 있습니다. 보낸 사람이 접근 문구를 별도로 알려드릴 것입니다."
+  },
+  "email.secret_link.footer_note": {
+    "text": "%{sender_email}님이 %{product_name}을(를) 사용하여 비밀 메시지를 공유했기 때문에 이 메시지를 받으셨습니다. 예상하지 못한 메시지라면 이 이메일을 무시하셔도 안전합니다."
   }
 }

--- a/locales/content/ko/feature-feedback.json
+++ b/locales/content/ko/feature-feedback.json
@@ -58,5 +58,14 @@
   "web.feedback.reason_email_change_unauthorized": {
     "text": "계정에서 승인되지 않은 이메일 변경을 신고하시는 것으로 보입니다. 상황을 설명해 주시면 즉시 조사하겠습니다.",
     "source_hash": "00e56551"
+  },
+  "web.feedback.anonymous_no_reply": {
+    "text": "참고: 답변을 원하시면 메시지에 서명하거나 이메일 주소를 포함해 주세요."
+  },
+  "web.feedback.characters_remaining": {
+    "text": "{count}자 남음"
+  },
+  "web.feedback.character_limit_reached": {
+    "text": "글자 수 제한에 도달했습니다"
   }
 }

--- a/locales/content/ko/feature-homepage-secrets.json
+++ b/locales/content/ko/feature-homepage-secrets.json
@@ -1,0 +1,50 @@
+{
+  "homepage_secrets.disabled.members_only_eyebrow": {
+    "text": "회원 전용 인스턴스"
+  },
+  "homepage_secrets.disabled.private_instance_eyebrow": {
+    "text": "비공개 인스턴스"
+  },
+  "homepage_secrets.disabled.team_link_headline": {
+    "text": "이 링크는 {workspace} 팀을 위한 것입니다."
+  },
+  "homepage_secrets.disabled.signin_headline": {
+    "text": "{action}을(를) 생성하려면 로그인하세요."
+  },
+  "homepage_secrets.disabled.signin_headline_action": {
+    "text": "비밀 링크"
+  },
+  "homepage_secrets.disabled.team_subtitle": {
+    "text": "{domain}의 승인된 팀원만 이곳에서 새로운 일회성 링크를 만들 수 있습니다. 받는 사람은 전달받은 링크를 계속 열 수 있습니다."
+  },
+  "homepage_secrets.disabled.public_subtitle": {
+    "text": "이 인스턴스의 승인된 회원만 새로운 일회성 링크를 만들 수 있습니다. 받는 사람은 전달받은 링크를 계속 열 수 있습니다."
+  },
+  "homepage_secrets.disabled.signin_cta": {
+    "text": "계정에 로그인"
+  },
+  "homepage_secrets.disabled.what_is_this": {
+    "text": "이것은 무엇인가요?"
+  },
+  "homepage_secrets.disabled.trust_viewed_once": {
+    "text": "한 번 열람 후 사라짐"
+  },
+  "homepage_secrets.disabled.trust_zero_retained": {
+    "text": "보관 안 함"
+  },
+  "homepage_secrets.disabled.promo_title": {
+    "text": "새 소식: 이제 무료 요금제에도 사용자 정의 도메인이 포함됩니다."
+  },
+  "homepage_secrets.disabled.promo_subtitle": {
+    "text": "도메인을 Onetime Secret에 연결하고 자신만의 브랜드로 비밀 메시지를 전달하세요."
+  },
+  "homepage_secrets.disabled.promo_learn_how": {
+    "text": "방법 알아보기"
+  },
+  "homepage_secrets.disabled.logo_alt": {
+    "text": "{name} 로고"
+  },
+  "homepage_secrets.disabled.opens_in_new_tab": {
+    "text": "(새 탭에서 열림)"
+  }
+}

--- a/locales/content/ko/feature-incoming.json
+++ b/locales/content/ko/feature-incoming.json
@@ -130,5 +130,26 @@
   "incoming.receipt_link_text": {
     "text": "수신확인",
     "source_hash": "6f328609"
+  },
+  "incoming.upgrade_required_title": {
+    "text": "업그레이드 필요"
+  },
+  "incoming.upgrade_required_description": {
+    "text": "이 기능을 사용하려면 요금제 업그레이드가 필요합니다. 수신 비밀 메시지를 활성화하려면 계정 소유자에게 문의하세요."
+  },
+  "incoming.validation_memo_too_long": {
+    "text": "메모는 {max}자 이하여야 합니다"
+  },
+  "incoming.validation_secret_required": {
+    "text": "비밀 메시지 내용을 입력해야 합니다"
+  },
+  "incoming.validation_recipient_required": {
+    "text": "받는 사람을 선택해 주세요"
+  },
+  "incoming.validation_feature_disabled": {
+    "text": "수신 비밀 메시지 기능이 활성화되어 있지 않습니다"
+  },
+  "incoming.validation_form_errors": {
+    "text": "양식에 오류가 없는지 확인해 주세요"
   }
 }

--- a/locales/content/ko/feature-regions.json
+++ b/locales/content/ko/feature-regions.json
@@ -152,7 +152,7 @@
     "source_hash": "1d97f6bd"
   },
   "web.regions.changing_regions_billing_note": {
-    "text": "결제 연락처 이메일이 {product_name} 계정 이메일과 다른 경우, 구독 혜택을 유지하려면 새 지역 계정에 결제 연락처 이메일을 사용하세요.",
+    "text": "결제 담당자 이메일이 {product_name} 계정 이메일과 다른 경우, 구독 혜택을 유지하려면 새 지역 계정에 결제 담당자 이메일을 사용하세요.",
     "source_hash": "dac1cc28"
   },
   "web.regions.changing_regions_subscription_note": {
@@ -186,5 +186,8 @@
   "web.regions.jurisdictions.apac.name": {
     "text": "Asia-Pacific",
     "source_hash": "7a757670"
+  },
+  "web.regions.no_region_configured": {
+    "text": "현재 계정에 대한 지역 정보가 없습니다."
   }
 }

--- a/locales/content/ko/feature-translations.json
+++ b/locales/content/ko/feature-translations.json
@@ -64,7 +64,7 @@
     "source_hash": "13131e36"
   },
   "web.translations.the_following_people_have_donated_their_time_to_": {
-    "text": "다음 분들이 {product_name}의 도달 범위를 확장하는 데 시간을 기부해 주셨습니다:",
+    "text": "다음 분들이 {product_name}의 도달 범위를 넓히는 데 시간을 기부해 주셨습니다:",
     "source_hash": "85a766af"
   },
   "web.translations.translations": {
@@ -84,7 +84,7 @@
     "source_hash": "ba5c4395"
   },
   "web.translations.since_2012_onetime_secret_has_provided_a_secure_": {
-    "text": "2012년부터 {product_name}은 전 세계적으로 민감한 정보를 안전하게 공유하는 방법을 제공해 왔습니다. 영어가 주요 언어가 아닌 지역의 사용자들이 있어, 정확한 번역은 모든 사람이 안전한 통신에 접근할 수 있도록 하는 데 필수적입니다.",
+    "text": "2012년부터 {product_name}은 전 세계에 민감한 정보를 안전하게 공유할 수 있는 방법을 제공해 왔습니다. 영어가 주요 언어가 아닌 지역의 사용자들이 있기에, 정확한 번역은 모든 사람이 안전한 커뮤니케이션에 접근할 수 있도록 하는 데 필수적입니다.",
     "source_hash": "87a6e9af"
   },
   "web.translations.help_secure_communication_go_global": {

--- a/locales/content/ko/secret-homepage.json
+++ b/locales/content/ko/secret-homepage.json
@@ -172,7 +172,7 @@
     "source_hash": "0990d163"
   },
   "web.homepage.onetime_secret_helps_us_share_sensitive_informat": {
-    "text": "{product_name}은 전문적인 모습을 유지하면서 민감한 정보를 안전하게 공유하는 데 도움을 줍니다.",
+    "text": "{product_name}은 전문적인 이미지를 유지하면서 민감한 정보를 안전하게 공유할 수 있도록 도와줍니다.",
     "source_hash": "986a0856"
   },
   "web.homepage.information_shared_through_this_service_can_only": {

--- a/locales/content/ko/secret-manage.json
+++ b/locales/content/ko/secret-manage.json
@@ -128,7 +128,7 @@
     "source_hash": "07fe1b84"
   },
   "web.secrets.onetime_secret_is_a_secure_way_to_share_sensitiv": {
-    "text": "{product_name}은 열람 후 자동으로 파기되는, 민감한 정보를 공유하는 안전한 방법입니다.",
+    "text": "{product_name}은 한 번 열람 후 자동으로 삭제되는 민감한 정보를 안전하게 공유하는 방법입니다.",
     "source_hash": "8a163297"
   },
   "web.secrets.what_is_this": {
@@ -470,5 +470,11 @@
   },
   "web.private.send_feedback": {
     "text": "의견 보내기"
+  },
+  "web.receipt.open_link": {
+    "text": "링크 열기"
+  },
+  "web.secrets.messageDeleted": {
+    "text": "메시지가 삭제되었습니다"
   }
 }

--- a/locales/content/ko/session-auth-extended.json
+++ b/locales/content/ko/session-auth-extended.json
@@ -716,5 +716,20 @@
   },
   "web.auth.sessions._guidance.context": {
     "text": "사용자의 로그인된 기기/브라우저 관리 페이지"
+  },
+  "web.auth.google": {
+    "text": "Google"
+  },
+  "web.auth.mfa.alternative_auth_options": {
+    "text": "대체 인증 옵션"
+  },
+  "web.auth.remember.enabled": {
+    "text": "로그인 상태 유지"
+  },
+  "web.auth.sessions.session_singular": {
+    "text": "세션"
+  },
+  "web.auth.sessions.session_plural": {
+    "text": "세션"
   }
 }

--- a/locales/content/ko/session-auth.json
+++ b/locales/content/ko/session-auth.json
@@ -398,5 +398,32 @@
   },
   "web.auth.verify._guidance.context": {
     "text": "가입 후 이메일 인증 흐름"
+  },
+  "web.auth.account.sso_linked": {
+    "text": "SSO 계정"
+  },
+  "web.help.reset_password_link": {
+    "text": "비밀번호 재설정"
+  },
+  "web.login.custom_domain_sso_title": {
+    "text": "이 도메인에서 Single Sign-On을 사용할 수 있습니다"
+  },
+  "web.login.custom_domain_sso_description": {
+    "text": "조직 관리자는 팀원이 이곳에서 로그인할 수 있도록 SSO를 활성화할 수 있습니다. 접근 권한은 관리자에게 문의하세요."
+  },
+  "web.login.signin_disabled_heading": {
+    "text": "로그인을 사용할 수 없습니다"
+  },
+  "web.login.signin_disabled_message": {
+    "text": "현재 이 도메인에서는 로그인을 사용할 수 없습니다."
+  },
+  "web.login.errors.sso_not_configured": {
+    "text": "이 도메인에는 Single Sign-On이 설정되어 있지 않습니다. 관리자에게 문의하세요."
+  },
+  "web.login.errors.invalid_email": {
+    "text": "ID 공급자에서 제공한 이메일 주소가 유효하지 않습니다. 관리자에게 문의하세요."
+  },
+  "web.login.errors.domain_not_allowed": {
+    "text": "회원님의 이메일 도메인은 SSO 가입이 허용되지 않습니다. 관리자에게 문의하세요."
   }
 }

--- a/locales/content/ko/workspace-account.json
+++ b/locales/content/ko/workspace-account.json
@@ -476,7 +476,7 @@
     "source_hash": "1cc77e60"
   },
   "web.settings.api.documentation_description": {
-    "text": "{product_name}을 애플리케이션에 통합하는 방법 알아보기",
+    "text": "{product_name}을 애플리케이션에 통합하는 방법을 알아보세요",
     "source_hash": "6e8f910f"
   },
   "web.settings.api.rest_api_reference": {
@@ -682,5 +682,14 @@
   "web.settings.profile.didnt_receive_email": {
     "text": "이메일을 받지 못하셨나요?",
     "source_hash": "fe3ac3ad"
+  },
+  "web.settings.api.api_disabled_notice": {
+    "text": "이 인스턴스에서 API가 비활성화되어 있습니다."
+  },
+  "web.settings.security.sso_managed_title": {
+    "text": "SSO로 관리되는 보안"
+  },
+  "web.settings.security.sso_managed_description": {
+    "text": "회원님의 계정은 조직의 Single Sign-On 공급자를 통해 인증됩니다. 비밀번호, 다단계 인증, 복구 코드는 ID 공급자가 관리합니다."
   }
 }

--- a/locales/content/ko/workspace-billing.json
+++ b/locales/content/ko/workspace-billing.json
@@ -988,5 +988,47 @@
     "text": "기존 구독 지역에서만 사용 가능",
     "context": "Hint shown on plan cards when currency does not match active subscription",
     "source_hash": "10de32e5"
+  },
+  "web.billing.already_subscribed": {
+    "text": "이미 이 요금제를 구독하고 계십니다."
+  },
+  "web.billing.cancel.reactivate_button": {
+    "text": "구독 재활성화"
+  },
+  "web.billing.cancel.reactivate_success": {
+    "text": "구독이 재활성화되었습니다. 평소대로 계속 청구됩니다."
+  },
+  "web.billing.cancel.reactivate_error": {
+    "text": "구독을 재활성화하지 못했습니다. 다시 시도하거나 지원팀에 문의하세요."
+  },
+  "web.billing.features.manage_orgs": {
+    "text": "조직 관리"
+  },
+  "web.billing.features.flexible_from_domain": {
+    "text": "유연한 이메일 발신자 도메인"
+  },
+  "web.billing.features.unlimited_admins": {
+    "text": "무제한 관리자"
+  },
+  "web.billing.features.manage_sso": {
+    "text": "SSO"
+  },
+  "web.billing.overview.entitlements.flexible_from_domain": {
+    "text": "유연한 이메일 발신자 도메인"
+  },
+  "web.billing.overview.entitlements.manage_orgs": {
+    "text": "조직 관리"
+  },
+  "web.billing.overview.entitlements.manage_sso": {
+    "text": "Single Sign-On (SSO)"
+  },
+  "web.billing.overview.entitlements.manage_billing": {
+    "text": "결제 관리"
+  },
+  "web.billing.overview.entitlements.custom_signup_validation": {
+    "text": "사용자 정의 가입 검증"
+  },
+  "web.billing.plans.reactivate": {
+    "text": "재활성화"
   }
 }

--- a/locales/content/ko/workspace-branding.json
+++ b/locales/content/ko/workspace-branding.json
@@ -178,5 +178,11 @@
   "web.branding.upgrade_to_customize": {
     "text": "이 도메인의 브랜딩을 맞춤 설정하려면 플랜을 업그레이드하세요.",
     "source_hash": "9077bf79"
+  },
+  "web.branding.saved_successfully": {
+    "text": "브랜드 설정이 저장되었습니다"
+  },
+  "web.branding.keyhole_logo_icon": {
+    "text": "안전한 비공개 공유를 나타내는 열쇠구멍 아이콘"
   }
 }

--- a/locales/content/ko/workspace-dashboard.json
+++ b/locales/content/ko/workspace-dashboard.json
@@ -22,5 +22,14 @@
   "web.dashboard.fetch_error_description": {
     "text": "데이터를 로드하는 데 문제가 발생했습니다. 다시 시도해 주세요.",
     "source_hash": "ff0d904e"
+  },
+  "web.teams.create_first_team_title": {
+    "text": "첫 번째 팀 만들기"
+  },
+  "web.teams.create_first_team_description": {
+    "text": "팀을 통해 공유 워크스페이스에서 다른 사람들과 협업할 수 있습니다."
+  },
+  "web.teams.create_team": {
+    "text": "팀 만들기"
   }
 }

--- a/locales/content/ko/workspace-domains.json
+++ b/locales/content/ko/workspace-domains.json
@@ -846,5 +846,389 @@
   "web.domains.sso.not_configured_notice": {
     "text": "이 도메인에 SSO가 아직 설정되지 않았습니다. 팀원들이 조직의 ID 공급자를 사용하여 인증할 수 있도록 Single Sign-On을 활성화하세요.",
     "source_hash": "c439214b"
+  },
+  "api.domains.errors.add_admin_required": {
+    "text": "조직 소유자와 관리자만 사용자 정의 도메인을 추가할 수 있습니다"
+  },
+  "web.domains.public_homepage": {
+    "text": "공개 홈페이지"
+  },
+  "web.domains.status_tooltip_active": {
+    "text": "도메인 확인 완료 및 활성 상태"
+  },
+  "web.domains.status_tooltip_dns_incorrect": {
+    "text": "DNS가 구성되지 않음 — 클릭하여 수정"
+  },
+  "web.domains.status_tooltip_not_verified": {
+    "text": "도메인이 확인되지 않음 — 클릭하여 확인"
+  },
+  "web.domains.status_tooltip_unverified": {
+    "text": "도메인 상태 미확인 — 클릭하여 새로고침"
+  },
+  "web.domains.last_check_failed": {
+    "text": "마지막 확인 검사 실패"
+  },
+  "web.domains.last_check_failed_ago": {
+    "text": "마지막 검사 실패 {0}"
+  },
+  "web.domains.verify_now": {
+    "text": "지금 확인"
+  },
+  "web.domains.click_to_verify": {
+    "text": "클릭하여 확인"
+  },
+  "web.domains.remove_domain_description": {
+    "text": "이 도메인과 모든 구성을 영구적으로 제거합니다."
+  },
+  "web.domains.add_access_denied": {
+    "text": "접근 거부됨"
+  },
+  "web.domains.add_access_denied_description": {
+    "text": "이 조직에 도메인을 추가할 권한이 없습니다. 조직 관리자에게 문의하세요."
+  },
+  "web.domains.dns_widget_load_failed": {
+    "text": "DNS 위젯을 불러오지 못했습니다"
+  },
+  "web.domains.dns_widget_not_available": {
+    "text": "DNS 위젯을 사용할 수 없습니다"
+  },
+  "web.domains.dns_widget_init_failed": {
+    "text": "DNS 위젯을 초기화하지 못했습니다"
+  },
+  "web.domains.verified": {
+    "text": "확인됨"
+  },
+  "web.domains.pending_verification": {
+    "text": "확인 대기 중"
+  },
+  "web.domains.unsaved_changes_confirmation": {
+    "text": "저장되지 않은 변경 사항이 있습니다. 정말 나가시겠습니까?"
+  },
+  "web.domains.entitlement_required_owner": {
+    "text": "이 기능에는 요금제 업그레이드가 필요합니다."
+  },
+  "web.domains.entitlement_required_member": {
+    "text": "이 기능은 현재 요금제에서 사용할 수 없습니다. 조직 소유자에게 문의하세요."
+  },
+  "web.domains.detail.manage": {
+    "text": "관리"
+  },
+  "web.domains.detail.features": {
+    "text": "기능"
+  },
+  "web.domains.detail.homepage_title": {
+    "text": "홈페이지 비밀 메시지"
+  },
+  "web.domains.detail.homepage_description": {
+    "text": "도메인 홈페이지에서 비밀 메시지를 생성하도록 공개 접근을 허용합니다"
+  },
+  "web.domains.detail.brand_description": {
+    "text": "로고, 색상 및 맞춤형 브랜딩"
+  },
+  "web.domains.detail.sso_description": {
+    "text": "SSO 공급자 설정"
+  },
+  "web.domains.detail.email_description": {
+    "text": "맞춤형 이메일 발신자 구성"
+  },
+  "web.domains.detail.incoming_description": {
+    "text": "수신 비밀 메시지 수신자 설정"
+  },
+  "web.domains.detail.signup_description": {
+    "text": "도메인별 가입 검증 전략"
+  },
+  "web.domains.detail.signin_description": {
+    "text": "도메인별 로그인 방법 구성"
+  },
+  "web.domains.email.dns_check_label": {
+    "text": "DNS"
+  },
+  "web.domains.email.provider_check_label": {
+    "text": "공급자"
+  },
+  "web.domains.email.test_email_title": {
+    "text": "이메일 전송 테스트"
+  },
+  "web.domains.email.test_email_hint": {
+    "text": "저장된 구성을 사용하여 자신에게 테스트 이메일을 보냅니다. 이 기능이 아직 활성화되지 않은 경우에도 작동합니다."
+  },
+  "web.domains.email.send_test": {
+    "text": "테스트 전송"
+  },
+  "web.domains.email.test_email_sent": {
+    "text": "테스트 이메일이 성공적으로 전송되었습니다"
+  },
+  "web.domains.email.test_email_failed": {
+    "text": "테스트 이메일 전송에 실패했습니다"
+  },
+  "web.domains.email.test_email_sent_to": {
+    "text": "{email}(으)로 전송됨"
+  },
+  "web.domains.email.delivered_via": {
+    "text": "{provider}을(를) 통해 전송됨"
+  },
+  "web.domains.incoming.feature_disabled": {
+    "text": "수신 비밀 메시지를 사용할 수 없음"
+  },
+  "web.domains.incoming.feature_disabled_description": {
+    "text": "이 인스턴스에서는 수신 비밀 메시지가 활성화되어 있지 않습니다. 관리자에게 문의하세요."
+  },
+  "web.domains.signin.title": {
+    "text": "로그인 구성"
+  },
+  "web.domains.signin.configure_signin": {
+    "text": "로그인 구성"
+  },
+  "web.domains.signin.config_description": {
+    "text": "이 도메인의 로그인 인증 방법을 구성합니다"
+  },
+  "web.domains.signin.access_denied": {
+    "text": "접근 거부됨"
+  },
+  "web.domains.signin.upgrade_to_configure": {
+    "text": "이 도메인의 로그인 방법을 구성하려면 요금제를 업그레이드하세요."
+  },
+  "web.domains.signin.not_configured_notice": {
+    "text": "이 도메인에 대한 로그인 구성이 아직 설정되지 않았습니다. 재정의를 구성하여 이 도메인의 로그인 페이지에서 사용할 수 있는 인증 방법을 제어하세요."
+  },
+  "web.domains.signin.signin_enabled_label": {
+    "text": "로그인 활성화됨"
+  },
+  "web.domains.signin.header_toggle_label": {
+    "text": "로그인"
+  },
+  "web.domains.signin.signin_enabled_hint": {
+    "text": "사용자가 이 도메인에서 로그인할 수 있는지 여부"
+  },
+  "web.domains.signin.restrict_to_label": {
+    "text": "로그인 방법 제한"
+  },
+  "web.domains.signin.restrict_to_hint": {
+    "text": "이 도메인을 단일 인증 방법으로 제한합니다. 설정하면 선택한 방법만 로그인 페이지에 표시됩니다."
+  },
+  "web.domains.signin.all_methods": {
+    "text": "모든 방법"
+  },
+  "web.domains.signin.all_methods_description": {
+    "text": "활성화된 모든 인증 방법을 로그인 페이지에 표시합니다"
+  },
+  "web.domains.signin.method_password": {
+    "text": "비밀번호"
+  },
+  "web.domains.signin.method_email_auth": {
+    "text": "이메일 인증"
+  },
+  "web.domains.signin.method_webauthn": {
+    "text": "WebAuthn / 패스키"
+  },
+  "web.domains.signin.method_sso": {
+    "text": "Single Sign-On"
+  },
+  "web.domains.signin.method_overrides_label": {
+    "text": "방법 재정의"
+  },
+  "web.domains.signin.method_overrides_hint": {
+    "text": "이 도메인에 대해 개별 인증 방법을 활성화하거나 비활성화합니다"
+  },
+  "web.domains.signin.mode_question": {
+    "text": "사용자가 어떻게 로그인할 수 있나요?"
+  },
+  "web.domains.signin.mode_any": {
+    "text": "사용 가능한 모든 방법"
+  },
+  "web.domains.signin.mode_any_hint": {
+    "text": "이 도메인에서 사용할 수 있는 모든 방법을 표시합니다. 아래에서 개별 방법을 좁힐 수 있습니다."
+  },
+  "web.domains.signin.mode_one": {
+    "text": "특정 방법 하나"
+  },
+  "web.domains.signin.mode_one_hint": {
+    "text": "로그인 페이지를 단일 방법으로 제한합니다. 이 도메인에서 사용할 수 있는 방법만 나열됩니다."
+  },
+  "web.domains.signin.mode_disabled": {
+    "text": "로그인 비활성화됨"
+  },
+  "web.domains.signin.mode_disabled_hint": {
+    "text": "사용자가 이 도메인에서 로그인할 수 없습니다."
+  },
+  "web.domains.signin.mode_disabled_notice": {
+    "text": "이 도메인의 로그인 페이지를 방문하는 사용자는 로그인을 사용할 수 없다는 안내와 함께 홈페이지로 돌아가는 링크를 보게 됩니다. 이전 방법 설정은 유지되며 로그인을 다시 활성화하면 복원됩니다."
+  },
+  "web.domains.signin.methods_list_label": {
+    "text": "로그인 페이지에 표시되는 방법"
+  },
+  "web.domains.signin.restrict_picker_hint": {
+    "text": "이 도메인에서 사용할 수 있는 방법만 나열됩니다."
+  },
+  "web.domains.signin.availability_always": {
+    "text": "항상 사용 가능"
+  },
+  "web.domains.signin.availability_global_on": {
+    "text": "전역 정책을 따름 · 켜짐"
+  },
+  "web.domains.signin.availability_global_off": {
+    "text": "사용할 수 없음"
+  },
+  "web.domains.signin.availability_unavailable": {
+    "text": "사이트 전체에서 사용할 수 없음"
+  },
+  "web.domains.signin.allow_on_domain": {
+    "text": "이 도메인에서 허용"
+  },
+  "web.domains.signin.method_password_blurb": {
+    "text": "비밀번호만"
+  },
+  "web.domains.signin.method_email_auth_blurb": {
+    "text": "비밀번호 없는 매직 링크 로그인"
+  },
+  "web.domains.signin.method_webauthn_blurb": {
+    "text": "생체 인증 및 보안 키"
+  },
+  "web.domains.signin.method_sso_blurb": {
+    "text": "외부 ID 공급자"
+  },
+  "web.domains.signin.email_auth_label": {
+    "text": "이메일 인증"
+  },
+  "web.domains.signin.email_auth_hint": {
+    "text": "이 도메인에서 비밀번호 없는 이메일 인증을 허용합니다"
+  },
+  "web.domains.signin.sso_enabled_label": {
+    "text": "Single Sign-On"
+  },
+  "web.domains.signin.sso_enabled_hint": {
+    "text": "이 도메인에서 SSO 인증을 허용합니다"
+  },
+  "web.domains.signin.enabled_label": {
+    "text": "로그인 구성 활성화"
+  },
+  "web.domains.signin.enabled_hint": {
+    "text": "활성화하면 이 도메인은 위에서 구성한 로그인 설정을 사용합니다"
+  },
+  "web.domains.signin.save_config": {
+    "text": "구성 저장"
+  },
+  "web.domains.signin.update_success": {
+    "text": "로그인 구성이 성공적으로 업데이트되었습니다"
+  },
+  "web.domains.signin.reset_to_defaults": {
+    "text": "기본값으로 재설정"
+  },
+  "web.domains.signin.reset_confirm": {
+    "text": "로그인을 전역 기본값으로 재설정하시겠습니까?"
+  },
+  "web.domains.signin.reset_keeps_sso": {
+    "text": "SSO 자격 증명은 유지됩니다. SSO 구성 화면에서 별도로 제거하세요."
+  },
+  "web.domains.signin.reset_action": {
+    "text": "예, 재설정합니다"
+  },
+  "web.domains.signin.reset_success": {
+    "text": "로그인 설정이 전역 기본값으로 재설정되었습니다"
+  },
+  "web.domains.signup.title": {
+    "text": "가입 검증"
+  },
+  "web.domains.signup.config_description": {
+    "text": "이 도메인의 가입 검증을 구성합니다"
+  },
+  "web.domains.signup.access_denied": {
+    "text": "접근 거부됨"
+  },
+  "web.domains.signup.upgrade_to_configure": {
+    "text": "도메인별 가입 검증을 구성하려면 요금제를 업그레이드하세요."
+  },
+  "web.domains.signup.configure_signup": {
+    "text": "가입 구성"
+  },
+  "web.domains.signup.not_configured_notice": {
+    "text": "이 도메인에 대한 가입 검증이 아직 구성되지 않았습니다. 전략을 구성하여 이 도메인을 통해 가입할 수 있는 사용자를 제어하세요."
+  },
+  "web.domains.signup.site_signups_disabled_warning": {
+    "text": "현재 사이트 수준에서 가입이 비활성화되어 있습니다. 이 도메인별 정책은 구성되어 있지만 사이트 가입이 활성화될 때까지 어떤 트래픽도 제어하지 않습니다."
+  },
+  "web.domains.signup.strategy_label": {
+    "text": "검증 전략"
+  },
+  "web.domains.signup.strategy_description": {
+    "text": "사용자가 이 도메인에서 가입할 때 이메일 주소를 검증하는 방식을 선택하세요."
+  },
+  "web.domains.signup.network_validation_warning": {
+    "text": "이 전략은 가입 중에 네트워크 호출을 수행하므로 지연이 발생하거나 일부 공급자에 의해 차단될 수 있습니다."
+  },
+  "web.domains.signup.allowed_domains_label": {
+    "text": "허용된 가입 도메인"
+  },
+  "web.domains.signup.allowed_domains_hint": {
+    "text": "이 이메일 도메인만 가입이 허용됩니다. 항목당 하나의 도메인을 추가하세요."
+  },
+  "web.domains.signup.domain_placeholder": {
+    "text": "example.com"
+  },
+  "web.domains.signup.invalid_domain": {
+    "text": "유효한 도메인을 입력하세요(예: example.com)"
+  },
+  "web.domains.signup.domain_exists": {
+    "text": "이 도메인은 이미 목록에 있습니다"
+  },
+  "web.domains.signup.remove_domain": {
+    "text": "{domain} 제거"
+  },
+  "web.domains.signup.enabled_label": {
+    "text": "도메인별 검증 활성화"
+  },
+  "web.domains.signup.enabled_hint": {
+    "text": "활성화하면 이 도메인의 가입은 전역 정책 대신 위의 전략을 사용합니다."
+  },
+  "web.domains.signup.delete_config": {
+    "text": "구성 삭제"
+  },
+  "web.domains.signup.delete_confirm": {
+    "text": "가입 검증 구성을 삭제하시겠습니까? 가입은 전역 정책으로 되돌아갑니다."
+  },
+  "web.domains.signup.save_config": {
+    "text": "구성 저장"
+  },
+  "web.domains.signup.update_success": {
+    "text": "가입 검증이 성공적으로 업데이트되었습니다"
+  },
+  "web.domains.signup.delete_success": {
+    "text": "가입 검증 구성이 성공적으로 제거되었습니다"
+  },
+  "web.domains.signup.domain_overrides_label": {
+    "text": "도메인 재정의"
+  },
+  "web.domains.signup.domain_overrides_hint": {
+    "text": "이 도메인에 대한 전역 가입 설정을 재정의합니다"
+  },
+  "web.domains.signup.signup_enabled_label": {
+    "text": "가입 활성화됨"
+  },
+  "web.domains.signup.signup_enabled_hint": {
+    "text": "이 도메인에 대해 가입 활성화 여부를 재정의합니다"
+  },
+  "web.domains.signup.autoverify_label": {
+    "text": "계정 자동 확인"
+  },
+  "web.domains.signup.autoverify_hint": {
+    "text": "이 도메인에서 신규 계정이 자동으로 확인되는지 여부를 재정의합니다"
+  },
+  "web.domains.sso.test_success": {
+    "text": "연결 테스트 성공 — 공급자가 올바르게 응답했습니다"
+  },
+  "web.domains.sso.test_failed": {
+    "text": "연결 테스트 실패"
+  },
+  "web.domains.sso.enforce_moved_notice": {
+    "text": "이 도메인의 모든 로그인에 SSO를 요구하려면 도메인의 로그인 설정에서 구성하세요. SSO 전용 모드는 로그인 페이지를 여기서 구성한 SSO 공급자로 제한합니다."
+  },
+  "web.domains.sso.edit_credentials": {
+    "text": "자격 증명 편집"
+  },
+  "web.domains.sso.configure_button": {
+    "text": "구성"
+  },
+  "web.domains.sso.upgrade_required": {
+    "text": "구성하려면 업그레이드"
   }
 }

--- a/locales/content/ko/workspace-organizations.json
+++ b/locales/content/ko/workspace-organizations.json
@@ -770,5 +770,200 @@
   "web.organizations.sso.status_not_configured": {
     "text": "설정되지 않음",
     "source_hash": "bbea960e"
+  },
+  "api.organizations.errors.not_found": {
+    "text": "조직을 찾을 수 없습니다: %{extid}"
+  },
+  "api.organizations.errors.owner_required": {
+    "text": "조직 소유자만 이 작업을 수행할 수 있습니다"
+  },
+  "api.organizations.errors.admin_required": {
+    "text": "조직 소유자와 관리자만 이 작업을 수행할 수 있습니다"
+  },
+  "api.organizations.errors.member_required": {
+    "text": "이 작업을 수행하려면 조직 멤버여야 합니다"
+  },
+  "api.organizations.invitations.errors.create_admin_required": {
+    "text": "조직 소유자와 관리자만 초대를 생성할 수 있습니다"
+  },
+  "api.organizations.invitations.errors.resend_admin_required": {
+    "text": "조직 소유자와 관리자만 초대를 다시 보낼 수 있습니다"
+  },
+  "api.organizations.invitations.errors.view_admin_required": {
+    "text": "조직 소유자와 관리자만 초대를 볼 수 있습니다"
+  },
+  "api.organizations.invitations.errors.revoke_admin_required": {
+    "text": "조직 소유자와 관리자만 초대를 취소할 수 있습니다"
+  },
+  "api.organizations.invitations.errors.email_required": {
+    "text": "이메일이 필요합니다"
+  },
+  "api.organizations.invitations.errors.email_invalid": {
+    "text": "잘못된 이메일 형식입니다"
+  },
+  "api.organizations.invitations.errors.role_invalid": {
+    "text": "역할은 멤버 또는 관리자여야 합니다"
+  },
+  "api.organizations.invitations.errors.cannot_invite_owner": {
+    "text": "소유자로 초대할 수 없습니다"
+  },
+  "api.organizations.invitations.errors.already_member": {
+    "text": "사용자는 이미 이 조직의 멤버입니다"
+  },
+  "api.organizations.invitations.errors.already_pending": {
+    "text": "이 이메일에 대한 초대가 이미 대기 중입니다"
+  },
+  "api.organizations.invitations.errors.member_limit_reached": {
+    "text": "멤버 한도에 도달했습니다. 더 많은 멤버를 초대하려면 요금제를 업그레이드하세요."
+  },
+  "api.organizations.invitations.errors.not_found": {
+    "text": "초대를 찾을 수 없습니다"
+  },
+  "api.organizations.invitations.errors.cannot_resend_non_pending": {
+    "text": "대기 중인 초대만 다시 보낼 수 있습니다"
+  },
+  "api.organizations.invitations.errors.cannot_revoke_non_pending": {
+    "text": "대기 중인 초대만 취소할 수 있습니다"
+  },
+  "api.organizations.invitations.errors.resend_limit_reached": {
+    "text": "최대 재전송 한도(%{max})에 도달했습니다"
+  },
+  "api.organizations.invitations.errors.accept_token_required": {
+    "text": "토큰이 필요합니다"
+  },
+  "api.organizations.invitations.errors.accept_organization_gone": {
+    "text": "조직이 더 이상 존재하지 않습니다"
+  },
+  "api.organizations.invitations.errors.accept_already_acted": {
+    "text": "이 초대는 이미 %{status} 상태입니다"
+  },
+  "api.organizations.invitations.errors.accept_expired": {
+    "text": "초대가 만료되었습니다"
+  },
+  "api.organizations.invitations.errors.accept_email_mismatch": {
+    "text": "이메일 주소가 초대와 일치하지 않습니다"
+  },
+  "api.organizations.invitations.errors.accept_already_member": {
+    "text": "이미 이 조직의 멤버입니다"
+  },
+  "web.organizations.entitlements_title": {
+    "text": "조직 권한"
+  },
+  "web.organizations.page_description_short": {
+    "text": "워크스페이스를 보고 구성하세요"
+  },
+  "web.organizations.delete_organization_remove_domains_first": {
+    "text": "이 조직을 삭제하기 전에 모든 사용자 정의 도메인을 제거하세요."
+  },
+  "web.organizations.default_org_delete_notice_title": {
+    "text": "이 조직 삭제"
+  },
+  "web.organizations.default_org_delete_notice_before": {
+    "text": "이것은 기본 조직이며 대시보드에서 제거할 수 없습니다. 삭제하려면 다음을 통해 문의해 주세요:"
+  },
+  "web.organizations.default_org_delete_notice_link": {
+    "text": "피드백 양식"
+  },
+  "web.organizations.default_org_delete_notice_after": {
+    "text": "."
+  },
+  "web.organizations.leave_organization": {
+    "text": "이 조직 나가기"
+  },
+  "web.organizations.leave_organization_warning": {
+    "text": "이 조직과 해당 리소스에 대한 접근 권한을 잃게 됩니다."
+  },
+  "web.organizations.leave_organization_confirm_title": {
+    "text": "조직 나가기"
+  },
+  "web.organizations.leave_organization_confirm_message": {
+    "text": "정말 {name}에서 나가시겠습니까? 다시 참여하려면 새 초대가 필요합니다."
+  },
+  "web.organizations.leave_organization_success": {
+    "text": "조직에서 나갔습니다."
+  },
+  "web.organizations.leave_error": {
+    "text": "조직 나가기에 실패했습니다"
+  },
+  "web.organizations.organizations": {
+    "text": "조직"
+  },
+  "web.organizations.invitations.invited_by_inline": {
+    "text": "{email}님이"
+  },
+  "web.organizations.invitations.invited_as_inline": {
+    "text": "{role} 역할로"
+  },
+  "web.organizations.invitations.back_to_home": {
+    "text": "홈으로 돌아가기"
+  },
+  "web.organizations.invitations.email_locked_hint": {
+    "text": "이 초대는 이 이메일 주소로 전송되었습니다"
+  },
+  "web.organizations.invitations.signup_continue": {
+    "text": "계속"
+  },
+  "web.organizations.invitations.signin_continue": {
+    "text": "로그인"
+  },
+  "web.organizations.invitations.confirm_join_below": {
+    "text": "거의 다 됐습니다 — 아래에서 확인하여 조직에 참여하세요."
+  },
+  "web.organizations.invitations.go_to_organizations": {
+    "text": "조직으로 이동"
+  },
+  "web.organizations.invitations.already_member": {
+    "text": "이미 이 조직의 멤버입니다"
+  },
+  "web.organizations.invitations.join_organization": {
+    "text": "{orgName} 참여"
+  },
+  "web.organizations.invitations.sign_in_to_join": {
+    "text": "{orgName}에 참여하려면 로그인"
+  },
+  "web.organizations.invitations.decline": {
+    "text": "거절"
+  },
+  "web.organizations.members.member_quota": {
+    "text": "멤버 {limit}명 중 {used}명"
+  },
+  "web.organizations.members.pending_suffix": {
+    "text": "(대기 중 {count}명)"
+  },
+  "web.organizations.members.limit_reached_hint": {
+    "text": "멤버 한도에 도달했습니다."
+  },
+  "web.organizations.sso.view_discovery_document": {
+    "text": "디스커버리 문서 보기"
+  },
+  "web.organizations.sso.callback_url": {
+    "text": "콜백 URL"
+  },
+  "web.organizations.sso.callback_url_hint": {
+    "text": "이 URL을 ID 공급자의 허용된 리디렉션 URI에 추가하세요"
+  },
+  "web.organizations.sso.enforce_sso_only": {
+    "text": "SSO 전용 적용"
+  },
+  "web.organizations.sso.enforce_sso_only_hint": {
+    "text": "이 도메인의 모든 로그인에 SSO를 요구합니다. 활성화하면 비밀번호 기반 인증이 비활성화됩니다."
+  },
+  "web.organizations.sso.grant_org_scope": {
+    "text": "조직 전체 접근 권한 부여"
+  },
+  "web.organizations.sso.grant_org_scope_hint": {
+    "text": "이 도메인의 SSO를 통해 참여하는 신규 멤버에게 모든 조직 도메인에 대한 접근 권한이 부여됩니다. 기존 멤버는 영향을 받지 않습니다. 비활성화(기본값)하면 신규 멤버는 이 도메인에만 접근할 수 있습니다."
+  },
+  "web.organizations.sso.no_domains": {
+    "text": "확인된 도메인 없음"
+  },
+  "web.organizations.sso.no_domains_description": {
+    "text": "SSO를 구성하기 전에 도메인을 추가하고 확인하세요."
+  },
+  "web.organizations.tabs.team": {
+    "text": "팀"
+  },
+  "web.organizations.tabs.sso": {
+    "text": "SSO"
   }
 }


### PR DESCRIPTION
## `ko` translation update

Automated export of completed **ko** translations from the translation task DB.
Scope: `locales/content/ko/` only — 27 file(s), +1354/-25.

⚠️ `i18n validate variables` reports **1** variable mismatch(es) for `ko` (empty values that drop source variables, renamed/extra vars, etc.) — see the review below.

---

### Local quality review

> Produced by a fresh, isolated `claude` review agent (model `claude-sonnet-5`, agent `saas-translator`) that read
> `locales/AGENT_TRANSLATION_PROTOCOL.md` and inspected this branch's diff before the PR was opened.

**Verdict:** ⚠️ Needs review — one invented variable, otherwise solid

**Summary:** Large batch (SSO/domains/billing/colonel/errors, ~2000+ new/changed keys) is well-translated with consistent Korean particle handling around interpolated variables and a uniform `Delano` → `지원팀` signature swap across all email templates. One pre-existing variable-consistency defect was flagged by the automated check.

**Critical (must fix):**
- `email.email_changed.body.text`: locale text inserts `%{date}` which does not exist in the English source (`"The email address for your %{product_name} account has been changed to %{new_email_masked}."`). Extra/invented variable — must be removed or sourced from the English string. (Same defect pattern seen across other locales in this batch — likely a shared source issue upstream, not ko-specific, but still blocks this file.)

**Warnings:**
- None. Variable sets in all newly added keys (e.g. `%{extid}`, `%{max}`, `{ip}`, `{email}`, `{workspace}`, `{provider}`, `%{roles}`) match source placeholders and counts.

**Notes:**
- Korean particle alternation (이/가, 을/를, 은/는) is correctly applied around variables (e.g. `{ip}이(가)`, `{provider}을(를)`), which is the right pattern for this script.
- `SSO`, `WebAuthn`, `Onetime Secret`, `Single Sign-On (SSO)` brand/tech terms left untranslated or partially untranslated consistently with prior ko convention.
- Minor rewording-only diffs (e.g. "도달 범위를 확장" → "넓히는", "결제 연락처" → "결제 담당자") appear to be style polish, not regressions.
- No mojibake, empty strings, or leftover English placeholders detected elsewhere in the diff.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
