### PR TITLE
i18n: update mi_NZ translations

### DIFF
--- a/locales/content/mi_NZ/00-common.json
+++ b/locales/content/mi_NZ/00-common.json
@@ -1299,7 +1299,7 @@
     "source_hash": "fc78d9cb"
   },
   "web.INSTRUCTION.phishing_warning": {
-    "text": "Me manatoko koe kei runga koe i te paetukutuku mana o {product_name}. I ētahi wā ka hangaia e ngā kaihangarau ngā paetukutuku teka e rite ana ki a {product_name} ki te tāhae i ō karere huna. Kia karo i ngā whakaekehanga tīpako, tirohia te rohe i mua i te hanga hononga hou.",
+    "text": "Me manatoko tonu koe kei runga koe i te paetukutuku mana o {product_name}. He wā tā ngā tāhae e waihanga ana i ngā paetukutuku tinihanga e tino rite ana ki {product_name} hei tāhae i āu karere huna. Hei karo i ngā whakaeke phishing, tirohia te rohe ā-takiwā i mua i te waihanga hononga hou.",
     "source_hash": "b588f5b2"
   },
   "web.pricing.title": {
@@ -1383,5 +1383,110 @@
     "text": "Whakapikinga hei whakatuwhera āhuatanga anō",
     "context": "Description shown for free plan users encouraging upgrade",
     "source_hash": "783f174c"
+  },
+  "api.errors.authentication_required": {
+    "text": "E hiahiatia ana te motuhēhēnga"
+  },
+  "api.errors.sso_only_action_blocked": {
+    "text": "Kāore tēnei mahi e wātea i te aratau SSO-anake"
+  },
+  "web.COMMON.configure": {
+    "text": "Whirihora"
+  },
+  "web.COMMON.copy_to_clipboard": {
+    "text": "Tāruatia ki te papatopenga"
+  },
+  "web.COMMON.add": {
+    "text": "Tāpiri"
+  },
+  "web.COMMON.enabled": {
+    "text": "Kua whakahohea"
+  },
+  "web.COMMON.disabled": {
+    "text": "Kua monokia"
+  },
+  "web.COMMON.yes_delete": {
+    "text": "Āe, mukua"
+  },
+  "web.COMMON.error_code": {
+    "text": "Waehere Hapa"
+  },
+  "web.COMMON.http_status": {
+    "text": "Tūnga HTTP"
+  },
+  "web.COMMON.details": {
+    "text": "Ngā taipitopito"
+  },
+  "web.COMMON.field_confirm_password": {
+    "text": "Whakaū Kupuhipa"
+  },
+  "web.COMMON.passwords_must_match": {
+    "text": "Me ōrite ngā kupuhipa"
+  },
+  "web.COMMON.and": {
+    "text": "me"
+  },
+  "web.COMMON.or": {
+    "text": "rānei"
+  },
+  "web.COMMON.copied": {
+    "text": "Kua tāruatia"
+  },
+  "web.COMMON.copy": {
+    "text": "Tāruatia"
+  },
+  "web.COMMON.copy_email": {
+    "text": "Tāruatia te wāhitau īmēra"
+  },
+  "web.COMMON.copy_id": {
+    "text": "Tāruatia te ID pūkete"
+  },
+  "web.COMMON.org_id_tooltip": {
+    "text": "Te tautohu ahurei o tō whakahaere"
+  },
+  "web.COMMON.success": {
+    "text": "Angitu"
+  },
+  "web.COMMON.need_help": {
+    "text": "E hiahia āwhina ana"
+  },
+  "web.COMMON.open_help_dialog": {
+    "text": "Huakina te kōrerorero āwhina"
+  },
+  "web.COMMON.focus_is_now_in_the_main_text_area": {
+    "text": "Kei te wāhi tuhinga matua te aronga ināianei"
+  },
+  "web.LABELS.show_passphrase": {
+    "text": "Whakaatu kupu karapa"
+  },
+  "web.LABELS.hide_passphrase": {
+    "text": "Hunaia te kupu karapa"
+  },
+  "web.LABELS.copy_icon": {
+    "text": "Ata tārua"
+  },
+  "web.LABELS.copied_icon": {
+    "text": "Ata kua tāruatia"
+  },
+  "web.STATUS.unverified": {
+    "text": "Kāore anō kia manatokona"
+  },
+  "web.TITLES.domain_detail": {
+    "text": "Ngā Tautuhinga Rohe"
+  },
+  "web.TITLES.domain_signin": {
+    "text": "Whirihoranga Takiuru"
+  },
+  "web.TITLES.domain_sso": {
+    "text": "SSO Rohe"
+  },
+  "web.TITLES.domain_signup": {
+    "text": "Whakamana Rēhitatanga Rohe"
+  },
+  "web.TITLES.domain_email": {
+    "text": "Whirihoranga Īmēra"
+  },
+  "web.TITLES.domain_incoming": {
+    "text": "Ngā Karere Huna Taemai"
   }
 }

--- a/locales/content/mi_NZ/10-layout.json
+++ b/locales/content/mi_NZ/10-layout.json
@@ -148,7 +148,7 @@
     "source_hash": "b9766df3"
   },
   "web.help.secret_view_faq.what_am_i_looking_at.description": {
-    "text": "E tiro ana koe i tētahi karere haumaru i tohatohaina ki a koe mā {product_name}. Kotahi noa te wā e whakaatuhia ai tēnei ihirangi, kātahi ka mukua pūmau mai i ā mātou tūmau.",
+    "text": "Kei te tiro koe i tētahi karere haumaru i tohatohaina ki a koe mā {product_name}. Ka whakaaturia tēnei ihirangi kotahi anake, kātahi ka murua rawatia i ā mātou tūmau.",
     "source_hash": "e0f1a10c"
   },
   "web.help.secret_view_faq.can_i_view_again.title": {
@@ -264,7 +264,7 @@
     "source_hash": "e2f124cd"
   },
   "web.layout.visit_onetime_secret_homepage": {
-    "text": "Toro atu ki te whārangi kāinga o {product_name}",
+    "text": "Toro ki te whārangi kāinga o {product_name}",
     "source_hash": "625556d2"
   },
   "web.layout.footer_navigation": {
@@ -338,5 +338,11 @@
   "web.layout.workspace_context": {
     "text": "Horopaki wāhi mahi",
     "source_hash": "dc6fa4f5"
+  },
+  "web.footer.workspace": {
+    "text": "Wāhi Mahi"
+  },
+  "web.help.default_content": {
+    "text": "Tēnā whakapā atu ki te tautoko mō te āwhina"
   }
 }

--- a/locales/content/mi_NZ/admin-colonel.json
+++ b/locales/content/mi_NZ/admin-colonel.json
@@ -634,5 +634,152 @@
   "web.colonel.feedback.when_you_submit_feedback_well_see": {
     "text": "I te wā e tuku urupare ana koe, ka kite mātou i:",
     "source_hash": "fe77172e"
+  },
+  "web.colonel.previewPlanMode": {
+    "text": "Aratau arokite mahere"
+  },
+  "web.colonel.previewModeDescription": {
+    "text": "Arokitea te taupānga e rite ana ki tā ngā kiritaki e kite ai i runga i tētahi mahere rerekē. Ka pā tēnei ki tāu tirohanga anake, kāore e huri i te mahere tūturu o tētahi whakahaere."
+  },
+  "web.colonel.previewModeActive": {
+    "text": "Arokite hohe"
+  },
+  "web.colonel.bannedIps.empty": {
+    "text": "Kāore he IP aukati"
+  },
+  "web.colonel.bannedIps.currentIp": {
+    "text": "Tō Wāhitau IP o Nāianei"
+  },
+  "web.colonel.bannedIps.confirmUnban": {
+    "text": "Whakawāteatia a {ip}?"
+  },
+  "web.colonel.bannedIps.actions.ban": {
+    "text": "Aukati IP"
+  },
+  "web.colonel.bannedIps.actions.quickBan": {
+    "text": "Aukati Tere"
+  },
+  "web.colonel.bannedIps.actions.unban": {
+    "text": "Whakawātea"
+  },
+  "web.colonel.bannedIps.actions.cancel": {
+    "text": "Whakakore"
+  },
+  "web.colonel.bannedIps.columns.ipAddress": {
+    "text": "Wāhitau IP"
+  },
+  "web.colonel.bannedIps.columns.reason": {
+    "text": "Take"
+  },
+  "web.colonel.bannedIps.columns.bannedAt": {
+    "text": "I Aukatia i"
+  },
+  "web.colonel.bannedIps.columns.bannedBy": {
+    "text": "Nā Wai i Aukati"
+  },
+  "web.colonel.bannedIps.error.banFailed": {
+    "text": "I rahu te aukati i te wāhitau IP"
+  },
+  "web.colonel.bannedIps.error.unbanFailed": {
+    "text": "I rahu te whakawātea i te wāhitau IP"
+  },
+  "web.colonel.bannedIps.form.title": {
+    "text": "Aukati Wāhitau IP"
+  },
+  "web.colonel.bannedIps.form.ipLabel": {
+    "text": "Wāhitau IP"
+  },
+  "web.colonel.bannedIps.form.reasonLabel": {
+    "text": "Take"
+  },
+  "web.colonel.bannedIps.form.reasonPlaceholder": {
+    "text": "Take kōwhiri"
+  },
+  "web.colonel.bannedIps.success.banned": {
+    "text": "Kua aukatia te wāhitau IP {ip}"
+  },
+  "web.colonel.bannedIps.success.unbanned": {
+    "text": "Kua whakawāteatia te wāhitau IP {ip}"
+  },
+  "web.colonel.customDomains.empty": {
+    "text": "Kāore he rohe ritenga kua whirihorahia"
+  },
+  "web.colonel.customDomains.noLogo": {
+    "text": "Kāore he Moko"
+  },
+  "web.colonel.customDomains.labels.organization": {
+    "text": "Whakahaere"
+  },
+  "web.colonel.customDomains.labels.externalId": {
+    "text": "ID o Waho"
+  },
+  "web.colonel.customDomains.labels.created": {
+    "text": "I Hangaia"
+  },
+  "web.colonel.customDomains.labels.updated": {
+    "text": "I Whakahōutia"
+  },
+  "web.colonel.customDomains.labels.favicon": {
+    "text": "Favicon"
+  },
+  "web.colonel.customDomains.status.verified": {
+    "text": "Kua manatokona"
+  },
+  "web.colonel.customDomains.status.resolving": {
+    "text": "Te whakatau"
+  },
+  "web.colonel.customDomains.status.ready": {
+    "text": "Kua rite"
+  },
+  "web.colonel.customDomains.status.publicHomepage": {
+    "text": "Whārangi Kāinga Tūmatanui"
+  },
+  "web.colonel.customDomains.status.publicApi": {
+    "text": "API Tūmatanui"
+  },
+  "web.colonel.customDomains.status.pending": {
+    "text": "Tārewa"
+  },
+  "web.colonel.pagination.showing": {
+    "text": "E whakaatu ana i te {start}–{end} o te {total}"
+  },
+  "web.colonel.pagination.itemsPerPage": {
+    "text": "Tūemi ia whārangi"
+  },
+  "web.colonel.pagination.perPage": {
+    "text": "{count} ia whārangi"
+  },
+  "web.colonel.pagination.pageOf": {
+    "text": "Whārangi {current} o te {total}"
+  },
+  "web.colonel.secrets.empty": {
+    "text": "Kāore he karere huna i kitea"
+  },
+  "web.colonel.secrets.never": {
+    "text": "Kāore rawa"
+  },
+  "web.colonel.secrets.columns.shortId": {
+    "text": "ID Poto"
+  },
+  "web.colonel.secrets.columns.state": {
+    "text": "Tūnga"
+  },
+  "web.colonel.secrets.columns.created": {
+    "text": "I Hangaia"
+  },
+  "web.colonel.secrets.columns.expiration": {
+    "text": "Paunga"
+  },
+  "web.colonel.secrets.columns.age": {
+    "text": "Pakeke (ngā rā)"
+  },
+  "web.colonel.secrets.state.new": {
+    "text": "Hou"
+  },
+  "web.colonel.secrets.state.received": {
+    "text": "Kua Whiwhia"
+  },
+  "web.colonel.secrets.state.viewed": {
+    "text": "Kua Tirohia"
   }
 }

--- a/locales/content/mi_NZ/api-account-errors.json
+++ b/locales/content/mi_NZ/api-account-errors.json
@@ -1,0 +1,8 @@
+{
+  "api.account.errors.invalid_email": {
+    "text": "He wāhitau īmēra whaimana tēnā?"
+  },
+  "api.account.errors.password_too_short": {
+    "text": "He poto rawa te kupuhipa"
+  }
+}

--- a/locales/content/mi_NZ/api-domains-errors.json
+++ b/locales/content/mi_NZ/api-domains-errors.json
@@ -1,0 +1,29 @@
+{
+  "api.domains.errors.domain_id_required": {
+    "text": "E hiahiatia ana te ID rohe"
+  },
+  "api.domains.errors.domain_not_found": {
+    "text": "Kāore i kitea te rohe: %{extid}"
+  },
+  "api.domains.errors.organization_not_found": {
+    "text": "Kāore i kitea te whakahaere mō te rohe: %{domain}"
+  },
+  "api.domains.errors.incoming_secrets_disabled": {
+    "text": "Kāore ngā karere huna taemai i te whakahohea i runga i tēnei taupānga"
+  },
+  "api.domains.errors.incoming_secrets_entitlement_required": {
+    "text": "Me whai i te whakaaetanga incoming_secrets te whakahaere i ngā karere huna taemai. Tēnā whakapikihia tō mahere."
+  },
+  "api.domains.errors.incoming_config_not_found": {
+    "text": "Kāore i kitea te whirihoranga taemai mō te rohe: %{extid}"
+  },
+  "api.domains.errors.recipients_max_exceeded": {
+    "text": "%{max} kaiwhiwhi te mōrahi e whakaaetia ana"
+  },
+  "api.domains.errors.recipients_invalid_email": {
+    "text": "Īmēra muhu: %{email}"
+  },
+  "api.domains.errors.recipients_duplicate": {
+    "text": "Kāore e whakaaetia ngā īmēra kaiwhiwhi tārua"
+  }
+}

--- a/locales/content/mi_NZ/api-entitlements-errors.json
+++ b/locales/content/mi_NZ/api-entitlements-errors.json
@@ -1,0 +1,71 @@
+{
+  "api.entitlements.errors.context_unavailable": {
+    "text": "Kāore e taea te manatoko i ngā whakaaetanga (kāore te horopaki whakahaere e wātea)"
+  },
+  "api.entitlements.errors.api_access_required": {
+    "text": "Me whakapiki mahere mō te urunga API"
+  },
+  "api.entitlements.errors.custom_privacy_defaults_required": {
+    "text": "Me whakapiki mahere mō ngā taunoa tūmataiti ritenga"
+  },
+  "api.entitlements.errors.extended_default_expiration_required": {
+    "text": "Me whakapiki mahere mō te paunga taunoa roa ake"
+  },
+  "api.entitlements.errors.custom_domains_required": {
+    "text": "Me whakapiki mahere mō ngā rohe ritenga"
+  },
+  "api.entitlements.errors.custom_branding_required": {
+    "text": "Me whakapiki mahere mō te waitohu ritenga"
+  },
+  "api.entitlements.errors.homepage_secrets_required": {
+    "text": "Me whakapiki mahere mō ngā karere huna whārangi kāinga"
+  },
+  "api.entitlements.errors.incoming_secrets_required": {
+    "text": "Me whakapiki mahere mō ngā karere huna taemai"
+  },
+  "api.entitlements.errors.custom_mail_sender_required": {
+    "text": "Me whakapiki mahere mō te kaituku mēra ritenga"
+  },
+  "api.entitlements.errors.flexible_from_domain_required": {
+    "text": "Me whakapiki mahere mō te rohe-mai ngāwari"
+  },
+  "api.entitlements.errors.manage_org_required": {
+    "text": "Me whakapiki mahere mō te whakahaere rōpū"
+  },
+  "api.entitlements.errors.manage_teams_required": {
+    "text": "Me whakapiki mahere mō te whakahaere tīma"
+  },
+  "api.entitlements.errors.manage_members_required": {
+    "text": "Me whakapiki mahere mō te whakahaere mema"
+  },
+  "api.entitlements.errors.manage_sso_required": {
+    "text": "Me whakapiki mahere mō te whakahaere SSO"
+  },
+  "api.entitlements.errors.audit_logs_required": {
+    "text": "Me whakapiki mahere mō ngā rangitaki arotake"
+  },
+  "api.entitlements.errors.custom_signup_validation_required": {
+    "text": "Me whakapiki mahere mō te whakamana rēhitatanga ritenga"
+  },
+  "api.entitlements.errors.create_secrets_required": {
+    "text": "Me whakapiki mahere mō te waihanga karere huna"
+  },
+  "api.entitlements.errors.view_receipt_required": {
+    "text": "Me whakapiki mahere mō te tiro rīhiti"
+  },
+  "api.entitlements.errors.notifications_required": {
+    "text": "Me whakapiki mahere mō ngā whakamōhiotanga"
+  },
+  "api.entitlements.errors.workspace_branding_required": {
+    "text": "Me whakapiki mahere mō te waitohu wāhi mahi"
+  },
+  "api.entitlements.errors.ip_access_rules_required": {
+    "text": "Me whakapiki mahere mō ngā ture urunga IP"
+  },
+  "api.entitlements.errors.manage_billing_required": {
+    "text": "Me whakapiki mahere mō te whakahaere nama"
+  },
+  "api.entitlements.errors.custom_signin_config_required": {
+    "text": "Me whakapiki mahere mō te whirihoranga takiuru ritenga"
+  }
+}

--- a/locales/content/mi_NZ/api-feedback-errors.json
+++ b/locales/content/mi_NZ/api-feedback-errors.json
@@ -1,0 +1,5 @@
+{
+  "api.feedback.errors.rate_limit_exceeded": {
+    "text": "He nui rawa ngā tukunga urupare. Tēnā ngana anō ā muri ake."
+  }
+}

--- a/locales/content/mi_NZ/api-incoming-errors.json
+++ b/locales/content/mi_NZ/api-incoming-errors.json
@@ -1,0 +1,5 @@
+{
+  "api.incoming.errors.custom_domain_unresolved": {
+    "text": "Kāore i taea te whakatau i te whakahaere rohe ritenga"
+  }
+}

--- a/locales/content/mi_NZ/api-invite-errors.json
+++ b/locales/content/mi_NZ/api-invite-errors.json
@@ -1,0 +1,23 @@
+{
+  "api.invite.errors.invitation_not_found_or_expired": {
+    "text": "Kāore i kitea te tono, kua pau rānei"
+  },
+  "api.invite.errors.token_required": {
+    "text": "E hiahiatia ana te tokena"
+  },
+  "api.invite.errors.organization_no_longer_exists": {
+    "text": "Kāore te whakahaere e noho tonu"
+  },
+  "api.invite.errors.invitation_already_processed": {
+    "text": "Kua %{status} kētia te tono"
+  },
+  "api.invite.errors.invitation_expired": {
+    "text": "Kua pau te tono"
+  },
+  "api.invite.errors.email_mismatch": {
+    "text": "Kāore tō wāhitau īmēra e hāngai ki te tono"
+  },
+  "api.invite.errors.already_member": {
+    "text": "He mema kē koe nō tēnei whakahaere"
+  }
+}

--- a/locales/content/mi_NZ/api-organizations-errors.json
+++ b/locales/content/mi_NZ/api-organizations-errors.json
@@ -1,0 +1,107 @@
+{
+  "api.organizations.errors.domain_scoped_forbidden": {
+    "text": "Kāore e taea e ngā mema kua herea ki te rohe te mahi i tēnei"
+  },
+  "api.organizations.errors.organization_not_found": {
+    "text": "Kāore i kitea te whakahaere: %{extid}"
+  },
+  "api.organizations.errors.organization_owner_required": {
+    "text": "Ko te rangatira whakahaere anake e taea ai te mahi i tēnei"
+  },
+  "api.organizations.errors.organization_member_required": {
+    "text": "Me noho koe hei mema whakahaere kia taea ai te mahi i tēnei"
+  },
+  "api.organizations.errors.organization_admin_required": {
+    "text": "Ko ngā rangatira me ngā kaiwhakahaere whakahaere anake e taea ai te mahi i tēnei"
+  },
+  "api.organizations.errors.extid_required": {
+    "text": "E hiahiatia ana te ID whakahaere"
+  },
+  "api.organizations.errors.display_name_required": {
+    "text": "E hiahiatia ana te ingoa whakahaere"
+  },
+  "api.organizations.errors.display_name_too_long": {
+    "text": "Me iti iho te ingoa whakahaere i te %{max} pūāhua"
+  },
+  "api.organizations.errors.description_too_long": {
+    "text": "Me iti iho te whakaahuatanga i te %{max} pūāhua"
+  },
+  "api.organizations.errors.contact_email_exists": {
+    "text": "Kei te ora kē tētahi whakahaere me tēnei īmēra whakapā"
+  },
+  "api.organizations.errors.creation_in_progress": {
+    "text": "Kei te haere tonu te waihanga whakahaere. Tēnā ngana anō."
+  },
+  "api.organizations.errors.organization_limit_reached": {
+    "text": "Kua eke ki te tepe whakahaere. Whakapikihia tō mahere ki te waihanga whakahaere anō."
+  },
+  "api.organizations.invitations.errors.invitation_not_found": {
+    "text": "Kāore i kitea te tono"
+  },
+  "api.organizations.invitations.errors.email_required": {
+    "text": "E hiahiatia ana te īmēra"
+  },
+  "api.organizations.invitations.errors.invalid_email_format": {
+    "text": "Hōputu īmēra muhu"
+  },
+  "api.organizations.invitations.errors.invalid_role": {
+    "text": "Me noho te tūranga hei mema, hei kaiwhakahaere rānei"
+  },
+  "api.organizations.invitations.errors.cannot_invite_as_owner": {
+    "text": "Kāore e taea te tono hei rangatira"
+  },
+  "api.organizations.invitations.errors.user_already_member": {
+    "text": "He mema kē te kaiwhakamahi nō tēnei whakahaere"
+  },
+  "api.organizations.invitations.errors.invitation_already_pending": {
+    "text": "Kei te tārewa kē tētahi tono mō tēnei īmēra"
+  },
+  "api.organizations.invitations.errors.member_limit_reached": {
+    "text": "Kua eke ki te tepe mema. Whakapikihia tō mahere ki te tono mema anō."
+  },
+  "api.organizations.invitations.errors.resend_only_pending": {
+    "text": "Ka taea anake te tuku anō i ngā tono tārewa"
+  },
+  "api.organizations.invitations.errors.resend_limit_reached": {
+    "text": "Kua eke ki te tepe tuku-anō mōrahi (%{max})"
+  },
+  "api.organizations.invitations.errors.revoke_only_pending": {
+    "text": "Ka taea anake te whakakore i ngā tono tārewa"
+  },
+  "api.organizations.members.errors.member_not_found": {
+    "text": "Kāore i kitea te mema: %{extid}"
+  },
+  "api.organizations.members.errors.member_not_in_organization": {
+    "text": "Kāore i kitea te mema i tēnei whakahaere"
+  },
+  "api.organizations.members.errors.member_not_active": {
+    "text": "Kāore te mema e kaha"
+  },
+  "api.organizations.members.errors.invalid_role_value": {
+    "text": "Tūranga muhu. Me noho ko tētahi o: %{roles}"
+  },
+  "api.organizations.members.errors.cannot_change_owner_role": {
+    "text": "Kāore e taea te huri i te tūranga rangatira. Whakamahia te whakawhiti rangatiratanga."
+  },
+  "api.organizations.members.errors.member_already_has_role": {
+    "text": "Kei te mema kē te tūranga: %{role}"
+  },
+  "api.organizations.members.errors.cannot_promote_to_owner": {
+    "text": "Kāore e taea te whakatairanga ki te rangatira. Whakamahia te whakawhiti rangatiratanga."
+  },
+  "api.organizations.members.errors.must_be_member": {
+    "text": "Me noho koe hei mema o tēnei whakahaere"
+  },
+  "api.organizations.members.errors.cannot_remove_owner": {
+    "text": "Kāore e taea te tango i te rangatira whakahaere. Whakawhitihia te rangatiratanga i te tuatahi."
+  },
+  "api.organizations.members.errors.cannot_remove_self": {
+    "text": "Kāore e taea te tango i a koe anō. Whakamahia te wehe whakahaere."
+  },
+  "api.organizations.members.errors.admin_cannot_remove_admin": {
+    "text": "Kāore e taea e ngā kaiwhakahaere te tango i ētahi atu kaiwhakahaere. Ko ngā rangatira anake."
+  },
+  "api.organizations.members.errors.no_permission_to_remove": {
+    "text": "Kāore ōu whaimana ki te tango mema"
+  }
+}

--- a/locales/content/mi_NZ/api-secrets-errors.json
+++ b/locales/content/mi_NZ/api-secrets-errors.json
@@ -1,0 +1,11 @@
+{
+  "api.secrets.errors.domain_permission_authenticated_non_owner": {
+    "text": "Kāore ōu whaimana ki te whakamahi i te rohe: %{domain}"
+  },
+  "api.secrets.errors.domain_public_sharing_disabled": {
+    "text": "Kua monokia te tiri tūmatanui mō te rohe: %{domain}"
+  },
+  "api.secrets.errors.domain_permission_anonymous_cross_domain": {
+    "text": "Kāore ōu whaimana ki te whakamahi i te rohe: %{domain}"
+  }
+}

--- a/locales/content/mi_NZ/email.json
+++ b/locales/content/mi_NZ/email.json
@@ -864,7 +864,7 @@
     "text": "Tautoko"
   },
   "email.expiration_warning.signature": {
-    "text": "Tīma Tautoko"
+    "text": "Te Kapa Tautoko"
   },
   "email.expiration_warning.footer_note": {
     "text": "I whiwhi koe i tēnei nā te mea ka tata pau tētahi karere huna i hangaia e koe i runga i %{product_name}."

--- a/locales/content/mi_NZ/email.json
+++ b/locales/content/mi_NZ/email.json
@@ -60,7 +60,7 @@
     "source_hash": "88c72144"
   },
   "email.welcome.signature": {
-    "text": "Delano",
+    "text": "Te Kapa Tautoko",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -100,7 +100,7 @@
     "source_hash": "fbb7eb2d"
   },
   "email.password_request.signature": {
-    "text": "Delano",
+    "text": "Te Kapa Tautoko",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -145,7 +145,7 @@
     "source_hash": "1863f5be"
   },
   "email.magic_link.signature": {
-    "text": "Delano",
+    "text": "Te Kapa Tautoko",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -230,7 +230,7 @@
     "source_hash": "3f6b45dd"
   },
   "email.secret_revealed.signature": {
-    "text": "Delano",
+    "text": "Te Kapa Tautoko",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -355,7 +355,7 @@
     "source_hash": "734882d2"
   },
   "email.organization_invitation.signature": {
-    "text": "Delano",
+    "text": "Te Kapa Tautoko",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -395,7 +395,7 @@
     "source_hash": "be92cff3"
   },
   "email.password_changed.signature": {
-    "text": "Delano",
+    "text": "Te Kapa Tautoko",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -445,7 +445,7 @@
     "source_hash": "f8d47b82"
   },
   "email.email_changed.signature": {
-    "text": "Delano",
+    "text": "Te Kapa Tautoko",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -495,7 +495,7 @@
     "source_hash": "f8d47b82"
   },
   "email.email_change_requested.signature": {
-    "text": "Delano",
+    "text": "Te Kapa Tautoko",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -550,7 +550,7 @@
     "source_hash": "d4d835fc"
   },
   "email.email_change_confirmation.signature": {
-    "text": "Delano",
+    "text": "Te Kapa Tautoko",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -580,7 +580,7 @@
     "source_hash": "e7c11bb0"
   },
   "email.mfa_enabled.signature": {
-    "text": "Delano",
+    "text": "Te Kapa Tautoko",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -605,7 +605,7 @@
     "source_hash": "97ef0a3e"
   },
   "email.mfa_disabled.signature": {
-    "text": "Delano",
+    "text": "Te Kapa Tautoko",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -650,7 +650,7 @@
     "source_hash": "450c54c5"
   },
   "email.new_login_alert.signature": {
-    "text": "Delano",
+    "text": "Te Kapa Tautoko",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -670,7 +670,7 @@
     "source_hash": "d442beed"
   },
   "email.member_removed.signature": {
-    "text": "Delano",
+    "text": "Te Kapa Tautoko",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -690,7 +690,7 @@
     "source_hash": "c2280c0c"
   },
   "email.role_changed.signature": {
-    "text": "Delano",
+    "text": "Te Kapa Tautoko",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -710,7 +710,7 @@
     "source_hash": "7095fc69"
   },
   "email.organization_deleted.signature": {
-    "text": "Delano",
+    "text": "Te Kapa Tautoko",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -750,7 +750,7 @@
     "source_hash": "36008943"
   },
   "email.payment_receipt.signature": {
-    "text": "Delano",
+    "text": "Te Kapa Tautoko",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -775,7 +775,7 @@
     "source_hash": "926406b1"
   },
   "email.payment_failed.signature": {
-    "text": "Delano",
+    "text": "Te Kapa Tautoko",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -800,7 +800,7 @@
     "source_hash": "66a1419e"
   },
   "email.trial_expiring.signature": {
-    "text": "Delano",
+    "text": "Te Kapa Tautoko",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -825,7 +825,7 @@
     "source_hash": "5a96ae38"
   },
   "email.subscription_changed.signature": {
-    "text": "Delano",
+    "text": "Te Kapa Tautoko",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -853,5 +853,41 @@
     "text": "Onetime Secret",
     "renderer": "erb",
     "source_hash": "1cd0194a"
+  },
+  "email.common.secret_link_label": {
+    "text": "Hononga karere huna"
+  },
+  "email.common.automated_notice": {
+    "text": "He karere aunoa tēnei nā %{product_name}."
+  },
+  "email.common.support_label": {
+    "text": "Tautoko"
+  },
+  "email.expiration_warning.signature": {
+    "text": "Tīma Tautoko"
+  },
+  "email.expiration_warning.footer_note": {
+    "text": "I whiwhi koe i tēnei nā te mea ka tata pau tētahi karere huna i hangaia e koe i runga i %{product_name}."
+  },
+  "email.feedback_email.user_id_label": {
+    "text": "Kaiwhakamahi:"
+  },
+  "email.feedback_email.timezone_label": {
+    "text": "Rohe wā:"
+  },
+  "email.feedback_email.version_label": {
+    "text": "Putanga:"
+  },
+  "email.incoming_secret.footer_note": {
+    "text": "I whiwhi koe i tēnei nā te mea i whakamahi tētahi i %{product_name} ki te tuku karere huna ki a koe. Ki te kore koe i te tatari ki tēnei, ka taea e koe te waiho noa i tēnei īmēra."
+  },
+  "email.secret_link.passphrase_label": {
+    "text": "E hiahiatia ana te kupu karapa:"
+  },
+  "email.secret_link.passphrase_required": {
+    "text": "Kua tiakina tēnei karere huna ki tētahi kupu karapa. Me hoatu e te kaituku ki a koe i tētahi ara motuhake."
+  },
+  "email.secret_link.footer_note": {
+    "text": "I whiwhi koe i tēnei nā te mea i whakamahi a %{sender_email} i %{product_name} ki te tiri karere huna ki a koe. Ki te kore koe i te tatari ki tēnei, ka taea e koe te waiho noa i tēnei īmēra."
   }
 }

--- a/locales/content/mi_NZ/feature-feedback.json
+++ b/locales/content/mi_NZ/feature-feedback.json
@@ -58,5 +58,14 @@
   "web.feedback.reason_email_change_unauthorized": {
     "text": "Te āhua nei e pūrongo ana koe mō te huringa īmēra kāore i whakaaetia i tō pūkete. Whakamāramatia mai he aha i puta ai, ā ka āta tirotiro mātou.",
     "source_hash": "00e56551"
+  },
+  "web.feedback.anonymous_no_reply": {
+    "text": "Tuhipoka: mēnā e hiahia ana koe ki tētahi whakautu, tēnā hainahia, whakauruhia rānei tētahi wāhitau īmēra ki te karere."
+  },
+  "web.feedback.characters_remaining": {
+    "text": "{count} pūāhua e toe ana"
+  },
+  "web.feedback.character_limit_reached": {
+    "text": "Kua eke ki te tepe pūāhua"
   }
 }

--- a/locales/content/mi_NZ/feature-homepage-secrets.json
+++ b/locales/content/mi_NZ/feature-homepage-secrets.json
@@ -1,0 +1,50 @@
+{
+  "homepage_secrets.disabled.members_only_eyebrow": {
+    "text": "Taupānga mema-anake"
+  },
+  "homepage_secrets.disabled.private_instance_eyebrow": {
+    "text": "Taupānga tūmataiti"
+  },
+  "homepage_secrets.disabled.team_link_headline": {
+    "text": "Mō te tīma {workspace} tēnei hononga."
+  },
+  "homepage_secrets.disabled.signin_headline": {
+    "text": "Takiuru ki te waihanga {action}."
+  },
+  "homepage_secrets.disabled.signin_headline_action": {
+    "text": "hononga karere huna"
+  },
+  "homepage_secrets.disabled.team_subtitle": {
+    "text": "Ko ngā hoa tīma whaimana i {domain} anake e taea ai te hanga hononga kotahi-wā hou ki konei. Ka taea tonu e ngā kaiwhiwhi te huaki i tētahi hononga kua tukuna ki a rātou."
+  },
+  "homepage_secrets.disabled.public_subtitle": {
+    "text": "Ko ngā mema whaimana o tēnei taupānga anake e taea ai te hanga hononga kotahi-wā hou. Ka taea tonu e ngā kaiwhiwhi te huaki i tētahi hononga kua tukuna ki a rātou."
+  },
+  "homepage_secrets.disabled.signin_cta": {
+    "text": "Takiuru ki tō pūkete"
+  },
+  "homepage_secrets.disabled.what_is_this": {
+    "text": "He aha tēnei?"
+  },
+  "homepage_secrets.disabled.trust_viewed_once": {
+    "text": "Kua tirohia kotahitia, kātahi ka ngaro"
+  },
+  "homepage_secrets.disabled.trust_zero_retained": {
+    "text": "Kāore he mea i pupurihia"
+  },
+  "homepage_secrets.disabled.promo_title": {
+    "text": "Hou: kei roto i ngā mahere kore-utu ngā rohe ritenga ināianei."
+  },
+  "homepage_secrets.disabled.promo_subtitle": {
+    "text": "Tohua tō rohe ki Onetime Secret, ka tuku karere huna i raro i tō ake waitohu."
+  },
+  "homepage_secrets.disabled.promo_learn_how": {
+    "text": "Akona pēhea"
+  },
+  "homepage_secrets.disabled.logo_alt": {
+    "text": "Moko {name}"
+  },
+  "homepage_secrets.disabled.opens_in_new_tab": {
+    "text": "(ka tuwhera ki tētahi ripa hou)"
+  }
+}

--- a/locales/content/mi_NZ/feature-incoming.json
+++ b/locales/content/mi_NZ/feature-incoming.json
@@ -130,5 +130,26 @@
   "incoming.receipt_link_text": {
     "text": "rihīti",
     "source_hash": "6f328609"
+  },
+  "incoming.upgrade_required_title": {
+    "text": "Me Whakapiki"
+  },
+  "incoming.upgrade_required_description": {
+    "text": "Me whakapiki mahere mō tēnei āhuatanga. Tēnā whakapā atu ki te rangatira pūkete ki te whakahohe i ngā karere huna taemai."
+  },
+  "incoming.validation_memo_too_long": {
+    "text": "Me noho te memo ki te {max} pūāhua, iti iho rānei"
+  },
+  "incoming.validation_secret_required": {
+    "text": "E hiahiatia ana te ihirangi karere huna"
+  },
+  "incoming.validation_recipient_required": {
+    "text": "Tēnā tīpakohia tētahi kaiwhiwhi"
+  },
+  "incoming.validation_feature_disabled": {
+    "text": "Kāore te āhuatanga karere huna taemai i te whakahohea"
+  },
+  "incoming.validation_form_errors": {
+    "text": "Tēnā tirohia te puka mō ngā hapa"
   }
 }

--- a/locales/content/mi_NZ/feature-regions.json
+++ b/locales/content/mi_NZ/feature-regions.json
@@ -152,7 +152,7 @@
     "source_hash": "1d97f6bd"
   },
   "web.regions.changing_regions_billing_note": {
-    "text": "Mēnā he rerekē tō īmēra nama ki tō īmēra pūkete {product_name}, whakamahia te īmēra nama mō te pūkete rohe hou hei pupuri i ō painga ohaurunga.",
+    "text": "Mēnā he rerekē tō īmēra whakapā nama i tō īmēra pūkete {product_name}, whakamahia te īmēra whakapā nama mō te pūkete rohe hou kia pupuri ai i ngā painga o tō ohaurunga.",
     "source_hash": "dac1cc28"
   },
   "web.regions.changing_regions_subscription_note": {
@@ -186,5 +186,8 @@
   "web.regions.jurisdictions.apac.name": {
     "text": "Asia-Pacific",
     "source_hash": "7a757670"
+  },
+  "web.regions.no_region_configured": {
+    "text": "Kāore he mōhiohio rohe e wātea ana mō tō pūkete i tēnei wā."
   }
 }

--- a/locales/content/mi_NZ/feature-translations.json
+++ b/locales/content/mi_NZ/feature-translations.json
@@ -64,7 +64,7 @@
     "source_hash": "13131e36"
   },
   "web.translations.the_following_people_have_donated_their_time_to_": {
-    "text": "Kua koha te hunga e whai ake nei i tō rātou wā ki te āwhina i te horopaki o {product_name}:",
+    "text": "Kua tukua e ngā tāngata e whai ake nei tō rātou wā hei āwhina ki te whakawhānui i te toronga o {product_name}:",
     "source_hash": "85a766af"
   },
   "web.translations.translations": {
@@ -84,7 +84,7 @@
     "source_hash": "ba5c4395"
   },
   "web.translations.since_2012_onetime_secret_has_provided_a_secure_": {
-    "text": "Mai i te tau 2012, kua whakarato a {product_name} i tētahi huarahi haumaru ki te tuari i ngā mōhiohio tairongo puta noa i te ao. Me ngā kaiwhakamahi puta noa i ngā rohe kāore te reo Pākehā i te reo matua, he mea nui ngā whakamaoritanga tika mō te whakarite i te whakawhitiwhiti haumaru ki te katoa.",
+    "text": "Mai i te tau 2012, kua tuku {product_name} i tētahi ara haumaru ki te tohatoha mōhiohio tūmataiti puta noa i te ao. I te mea kei ngā rohe maha ngā kaiwhakamahi kāore te reo Ingarihi e noho hei reo matua, he mea waiwai ngā whakamāoritanga tika kia wātea ai te whakawhitiwhiti kōrero haumaru ki te katoa.",
     "source_hash": "87a6e9af"
   },
   "web.translations.help_secure_communication_go_global": {

--- a/locales/content/mi_NZ/secret-homepage.json
+++ b/locales/content/mi_NZ/secret-homepage.json
@@ -56,7 +56,7 @@
     "source_hash": "5e218489"
   },
   "web.homepage.visit_onetime_secret_home": {
-    "text": "Toro atu ki te whārangi kāinga {product_name}",
+    "text": "Toro ki te whārangi kāinga o {product_name}",
     "source_hash": "625556d2"
   },
   "web.homepage.password_generation_title": {
@@ -144,7 +144,7 @@
     "source_hash": "1cd0194a"
   },
   "web.homepage.one_time_secret_literal": {
-    "text": "Karere Huna Kotahi-Wā",
+    "text": "{product_name}",
     "source_hash": "7872e050"
   },
   "web.homepage.onetime_secret_homepage": {
@@ -172,7 +172,7 @@
     "source_hash": "0990d163"
   },
   "web.homepage.onetime_secret_helps_us_share_sensitive_informat": {
-    "text": "Ka āwhina a {product_name} i a mātou ki te tuari i ngā mōhiohio tairongo i runga i te haumaru me te pupuri tonu i tō mātou kanohi ngaio.",
+    "text": "Ka āwhina {product_name} i a mātou ki te tohatoha mōhiohio tūmataiti i runga i te āhua haumaru, me te pupuri tonu i tō mātou āhua ngaio.",
     "source_hash": "986a0856"
   },
   "web.homepage.information_shared_through_this_service_can_only": {

--- a/locales/content/mi_NZ/secret-manage.json
+++ b/locales/content/mi_NZ/secret-manage.json
@@ -128,7 +128,7 @@
     "source_hash": "07fe1b84"
   },
   "web.secrets.onetime_secret_is_a_secure_way_to_share_sensitiv": {
-    "text": "Ko {product_name} te huarahi haumaru ki te tuari i ngā mōhiohio tairongo e whakangaromia-anō whai muri i te tirohanga kotahi.",
+    "text": "Ko {product_name} he huarahi haumaru ki te tohatoha mōhiohio whakatakariri ka whakangaro ā-māia i muri i te tirohanga kotahi.",
     "source_hash": "8a163297"
   },
   "web.secrets.what_is_this": {
@@ -398,5 +398,11 @@
   "web.secrets.errors.access_denied_to_domain": {
     "text": "Kua whakakāhoretia te urunga ki te rohe",
     "source_hash": "cd441eea"
+  },
+  "web.receipt.open_link": {
+    "text": "Huaki hononga"
+  },
+  "web.secrets.messageDeleted": {
+    "text": "Kua mukua te karere"
   }
 }

--- a/locales/content/mi_NZ/session-auth-extended.json
+++ b/locales/content/mi_NZ/session-auth-extended.json
@@ -710,5 +710,26 @@
   "web.auth.recovery_codes.link_title": {
     "text": "Ngā Waehere Whakaora",
     "source_hash": "579c7f4e"
+  },
+  "web.auth.google": {
+    "text": "Google"
+  },
+  "web.auth.mfa.alternative_auth_options": {
+    "text": "Ngā kōwhiringa motuhēhēnga kē"
+  },
+  "web.auth.remember.enabled": {
+    "text": "Noho takiuru tonu"
+  },
+  "web.auth.security._guidance.context": {
+    "text": "⚠️ SECURITY-CRITICAL: Messages prevent information disclosure. See src/locales/SECURITY-TRANSLATION-GUIDE.md"
+  },
+  "web.auth.sessions.session_singular": {
+    "text": "wātū"
+  },
+  "web.auth.sessions.session_plural": {
+    "text": "ngā wātū"
+  },
+  "web.auth.sessions._guidance.context": {
+    "text": "User's logged-in devices/browsers management page"
   }
 }

--- a/locales/content/mi_NZ/session-auth.json
+++ b/locales/content/mi_NZ/session-auth.json
@@ -395,5 +395,35 @@
   "web.help.contact_support": {
     "text": "Whakapā ki te Tautoko",
     "source_hash": "f8d47b82"
+  },
+  "web.auth.account.sso_linked": {
+    "text": "Pūkete SSO"
+  },
+  "web.auth.verify._guidance.context": {
+    "text": "Email verification flow after signup"
+  },
+  "web.help.reset_password_link": {
+    "text": "Tautuhi kupuhipa anō"
+  },
+  "web.login.custom_domain_sso_title": {
+    "text": "Kei te wātea te takiuru kotahi (SSO) mō tēnei rohe"
+  },
+  "web.login.custom_domain_sso_description": {
+    "text": "Ka taea e te kaiwhakahaere o te whakahaere te whakahohe i te SSO kia āhei ai ngā mema o te rōpū ki te takiuru ki konei. Whakapā atu ki te kaiwhakahaere mō te urunga."
+  },
+  "web.login.signin_disabled_heading": {
+    "text": "Kāore te takiuru e wātea ana"
+  },
+  "web.login.signin_disabled_message": {
+    "text": "Kāore te takiuru e wātea ana i tēnei rohe i tēnei wā."
+  },
+  "web.login.errors.sso_not_configured": {
+    "text": "Kāore te takiuru kotahi (SSO) i whirihorahia mō tēnei rohe. Tēnā whakapā atu ki tō kaiwhakahaere."
+  },
+  "web.login.errors.invalid_email": {
+    "text": "He muhu te wāhitau īmēra mai i tō kaiwhakarato tuakiri. Tēnā whakapā atu ki tō kaiwhakahaere."
+  },
+  "web.login.errors.domain_not_allowed": {
+    "text": "Kāore tō rohe īmēra i whakaaetia mō te rēhitatanga SSO. Tēnā whakapā atu ki tō kaiwhakahaere."
   }
 }

--- a/locales/content/mi_NZ/workspace-account.json
+++ b/locales/content/mi_NZ/workspace-account.json
@@ -476,7 +476,7 @@
     "source_hash": "1cc77e60"
   },
   "web.settings.api.documentation_description": {
-    "text": "Akohia me pēhea te whakahono i a {product_name} ki ō taupānga",
+    "text": "Akohia me pēhea te whakakotahi i a {product_name} ki ō taupānga",
     "source_hash": "6e8f910f"
   },
   "web.settings.api.rest_api_reference": {
@@ -682,5 +682,14 @@
   "web.settings.profile.didnt_receive_email": {
     "text": "Kāore i tae te īmēra?",
     "source_hash": "fe3ac3ad"
+  },
+  "web.settings.security.sso_managed_title": {
+    "text": "Haumaru e whakahaerea ana e te SSO"
+  },
+  "web.settings.security.sso_managed_description": {
+    "text": "Ka whakamanatia tō pūkete mā te kaiwhakarato takiuru kotahi (SSO) o tō whakahaere. Ko te kupuhipa, te whakamotuhēhētanga āhuatanga-maha, me ngā waehere whakaora ka whakahaerea e tō kaiwhakarato tuakiri."
+  },
+  "web.settings.api.api_disabled_notice": {
+    "text": "Kua monokia te API mō tēnei taupānga."
   }
 }

--- a/locales/content/mi_NZ/workspace-billing.json
+++ b/locales/content/mi_NZ/workspace-billing.json
@@ -988,5 +988,47 @@
     "text": "Ka wātea i tō rohe ohaurunga taketake anake",
     "context": "Hint shown on plan cards when currency does not match active subscription",
     "source_hash": "10de32e5"
+  },
+  "web.billing.already_subscribed": {
+    "text": "Kua ohauru kē koe ki tēnei mahere."
+  },
+  "web.billing.cancel.reactivate_button": {
+    "text": "Whakahohe Anō i te Ohaurunga"
+  },
+  "web.billing.cancel.reactivate_success": {
+    "text": "Kua whakahohea anō tō ohaurunga. Ka namahia tonu koe i te āhua noa."
+  },
+  "web.billing.cancel.reactivate_error": {
+    "text": "I rahua te whakahohe anō i te ohaurunga. Tēnā whakamātauria anō, whakapā atu rānei ki te tautoko."
+  },
+  "web.billing.features.manage_orgs": {
+    "text": "Whakahaere i ngā Whakahaere"
+  },
+  "web.billing.features.flexible_from_domain": {
+    "text": "Rohe Kaituku Īmēra Ngāwari"
+  },
+  "web.billing.features.unlimited_admins": {
+    "text": "Ngā Kaiwhakahaere Kore-mutunga"
+  },
+  "web.billing.features.manage_sso": {
+    "text": "SSO"
+  },
+  "web.billing.overview.entitlements.flexible_from_domain": {
+    "text": "Rohe Kaituku Īmēra Ngāwari"
+  },
+  "web.billing.overview.entitlements.manage_orgs": {
+    "text": "Whakahaere ngā Whakahaere"
+  },
+  "web.billing.overview.entitlements.manage_sso": {
+    "text": "Takiuru Kotahi (SSO)"
+  },
+  "web.billing.overview.entitlements.manage_billing": {
+    "text": "Whakahaere Pire"
+  },
+  "web.billing.overview.entitlements.custom_signup_validation": {
+    "text": "Whakamana Rēhitatanga Ritenga"
+  },
+  "web.billing.plans.reactivate": {
+    "text": "Whakahohe Anō"
   }
 }

--- a/locales/content/mi_NZ/workspace-branding.json
+++ b/locales/content/mi_NZ/workspace-branding.json
@@ -144,7 +144,7 @@
     "source_hash": "1e04ba2e"
   },
   "web.branding.powered_by_onetime_secret": {
-    "text": "Nā {product_name} te mana",
+    "text": "Whakahohea e {product_name}",
     "source_hash": "d8e9f0a1"
   },
   "web.branding.low_contrast_warning": {
@@ -178,5 +178,11 @@
   "web.branding.upgrade_to_customize": {
     "text": "Whakapikia tō mahere hei whakariterite i te waitohu mō tēnei rohe.",
     "source_hash": "9077bf79"
+  },
+  "web.branding.saved_successfully": {
+    "text": "Kua tiakina ngā tautuhinga waitohu"
+  },
+  "web.branding.keyhole_logo_icon": {
+    "text": "Ata pūwhare e tohu ana i te tohatoha haumaru, tūmataiti"
   }
 }

--- a/locales/content/mi_NZ/workspace-dashboard.json
+++ b/locales/content/mi_NZ/workspace-dashboard.json
@@ -22,5 +22,14 @@
   "web.dashboard.fetch_error_description": {
     "text": "I puta he raru i te utanga o ō raraunga. Tēnā whakamātauria anō.",
     "source_hash": "ff0d904e"
+  },
+  "web.teams.create_first_team_title": {
+    "text": "Waihanga i tō rōpū tuatahi"
+  },
+  "web.teams.create_first_team_description": {
+    "text": "Mā ngā rōpū koe e āhei ai ki te mahi tahi me ētahi atu i tētahi wāhi mahi tohatohahia."
+  },
+  "web.teams.create_team": {
+    "text": "Waihanga rōpū"
   }
 }

--- a/locales/content/mi_NZ/workspace-domains.json
+++ b/locales/content/mi_NZ/workspace-domains.json
@@ -398,5 +398,725 @@
   "web.domains.dns_widget_description": {
     "text": "Whakamahia te utauta kei raro hei kite aunoa i tō kaiwhakarato DNS me te whiwhi tohutohu hipanga-ki-hipanga mō te tautuhi i tō rohe.",
     "source_hash": "91c1af2e"
+  },
+  "api.domains.errors.add_admin_required": {
+    "text": "Ko ngā rangatira me ngā kaiwhakahaere o te whakahaere anake ka taea te tāpiri rohe ritenga"
+  },
+  "web.domains.public_homepage": {
+    "text": "Whārangi Kāinga Tūmatanui"
+  },
+  "web.domains.status_tooltip_active": {
+    "text": "Kua manatokohia, kua hohe te rohe"
+  },
+  "web.domains.status_tooltip_dns_incorrect": {
+    "text": "Kāore te DNS i whirihorahia — pāwhiri ki te whakatika"
+  },
+  "web.domains.status_tooltip_not_verified": {
+    "text": "Kāore te rohe i manatokohia — pāwhiri ki te manatoko"
+  },
+  "web.domains.status_tooltip_unverified": {
+    "text": "Kāore i manatokohia te tūnga rohe — pāwhiri ki te tāmata"
+  },
+  "web.domains.last_check_failed": {
+    "text": "I rahua te manatoko whakamutunga"
+  },
+  "web.domains.last_check_failed_ago": {
+    "text": "i rahua te manatoko whakamutunga {0}"
+  },
+  "web.domains.verify_now": {
+    "text": "Manatoko ināianei"
+  },
+  "web.domains.click_to_verify": {
+    "text": "pāwhiri ki te manatoko"
+  },
+  "web.domains.remove_domain_description": {
+    "text": "Tango pūmautia i tēnei rohe me ōna whirihoranga katoa."
+  },
+  "web.domains.add_access_denied": {
+    "text": "Kua Whakakāhoretia te Urunga"
+  },
+  "web.domains.add_access_denied_description": {
+    "text": "Kāore ō whakaaetanga ki te tāpiri rohe ki tēnei whakahaere. Whakapā atu ki tō kaiwhakahaere whakahaere."
+  },
+  "web.domains.dns_widget_load_failed": {
+    "text": "I rahua te uta i te utauta DNS"
+  },
+  "web.domains.dns_widget_not_available": {
+    "text": "Kāore te utauta DNS e wātea ana"
+  },
+  "web.domains.dns_widget_init_failed": {
+    "text": "I rahua te tīmata i te utauta DNS"
+  },
+  "web.domains.verified": {
+    "text": "Kua Manatokohia"
+  },
+  "web.domains.pending_verification": {
+    "text": "E Tatari ana te Manatoko"
+  },
+  "web.domains.unsaved_changes_confirmation": {
+    "text": "Kei a koe ngā huringa kāore anō kia tiakina. Kei te tino hiahia koe ki te wehe?"
+  },
+  "web.domains.entitlement_required_owner": {
+    "text": "Me whakapiki tō mahere mō tēnei āhuatanga."
+  },
+  "web.domains.entitlement_required_member": {
+    "text": "Kāore tēnei āhuatanga i tō mahere o nāianei. Whakapā atu ki tō rangatira whakahaere."
+  },
+  "web.domains.detail.manage": {
+    "text": "Whakahaere"
+  },
+  "web.domains.detail.features": {
+    "text": "Ngā Āhuatanga"
+  },
+  "web.domains.detail.homepage_title": {
+    "text": "Karere Huna Whārangi Kāinga"
+  },
+  "web.domains.detail.homepage_description": {
+    "text": "Whakaae i te urunga tūmatanui ki te waihanga karere huna i tō whārangi kāinga rohe"
+  },
+  "web.domains.detail.brand_description": {
+    "text": "Tohu, tae, me te waitohu ritenga"
+  },
+  "web.domains.detail.sso_description": {
+    "text": "Tautuhinga kaiwhakarato takiuru kotahi (SSO)"
+  },
+  "web.domains.detail.email_description": {
+    "text": "Whirihoranga kaituku īmēra ritenga"
+  },
+  "web.domains.detail.incoming_description": {
+    "text": "Tautuhinga kaiwhiwhi karere huna tae mai"
+  },
+  "web.domains.detail.signup_description": {
+    "text": "Rautaki whakamana rēhitatanga ia-rohe"
+  },
+  "web.domains.detail.signin_description": {
+    "text": "Whirihoranga tikanga takiuru ia-rohe"
+  },
+  "web.domains.email.title": {
+    "text": "Tuku Īmēra"
+  },
+  "web.domains.email.config_title": {
+    "text": "Whirihoranga Īmēra"
+  },
+  "web.domains.email.config_description": {
+    "text": "Whirihora i te tuku īmēra mō tēnei rohe"
+  },
+  "web.domains.email.provider_label": {
+    "text": "Kaiwhakarato Īmēra"
+  },
+  "web.domains.email.provider_placeholder": {
+    "text": "Kōwhiria he kaiwhakarato īmēra"
+  },
+  "web.domains.email.from_name_label": {
+    "text": "Ingoa Nā"
+  },
+  "web.domains.email.from_name_placeholder": {
+    "text": "hei tauira, Acme Security"
+  },
+  "web.domains.email.from_address_label": {
+    "text": "Wāhitau Nā"
+  },
+  "web.domains.email.from_address_placeholder": {
+    "text": "hei tauira, secrets{'@'}example.com"
+  },
+  "web.domains.email.reply_to_label": {
+    "text": "Wāhitau Whakautu-Ki"
+  },
+  "web.domains.email.reply_to_placeholder": {
+    "text": "hei tauira, support{'@'}example.com"
+  },
+  "web.domains.email.save_changes": {
+    "text": "Tiaki Huringa"
+  },
+  "web.domains.email.discard_changes": {
+    "text": "Whakakore Huringa"
+  },
+  "web.domains.email.provider_ses": {
+    "text": "Amazon SES"
+  },
+  "web.domains.email.provider_sendgrid": {
+    "text": "SendGrid"
+  },
+  "web.domains.email.provider_lettermint": {
+    "text": "Lettermint"
+  },
+  "web.domains.email.provider_inherit": {
+    "text": "Whakamahi taunoa pūkete"
+  },
+  "web.domains.email.provider_ses_description": {
+    "text": "E hiahiatia ana te manatoko rohe mā ngā tuhinga DKIM me SPF"
+  },
+  "web.domains.email.provider_sendgrid_description": {
+    "text": "E hiahiatia ana te tatūnga whakamotuhēhē rohe"
+  },
+  "web.domains.email.provider_lettermint_description": {
+    "text": "E hiahiatia ana te manatoko rohe"
+  },
+  "web.domains.email.provider_inherit_description": {
+    "text": "Ka whakamahi i te whirihoranga tuku īmēra taunoa o tō pūkete"
+  },
+  "web.domains.email.dns_records_title": {
+    "text": "Ngā Tuhinga DNS"
+  },
+  "web.domains.email.dns_records_description": {
+    "text": "Tāpiria ngā tuhinga DNS e whai ake nei hei manatoko i tō rohe mō te tuku īmēra."
+  },
+  "web.domains.email.dns_column_type": {
+    "text": "Momo"
+  },
+  "web.domains.email.dns_column_name": {
+    "text": "Ingoa"
+  },
+  "web.domains.email.dns_column_value": {
+    "text": "Uara"
+  },
+  "web.domains.email.dns_check_label": {
+    "text": "DNS"
+  },
+  "web.domains.email.provider_check_label": {
+    "text": "Kaiwhakarato"
+  },
+  "web.domains.email.dns_optional_label": {
+    "text": "Tūtohua"
+  },
+  "web.domains.email.dns_optional_hint": {
+    "text": "Ka tūtohua tēnei tuhinga engari kāore e hiahiatia ana mō te manatoko. Tērā pea kua hipoki kē tētahi kaupapahere DMARC i tō rohe whakahaere i tēnei rohe-iti."
+  },
+  "web.domains.email.copy": {
+    "text": "Tārua"
+  },
+  "web.domains.email.copied": {
+    "text": "Kua Tāruatia"
+  },
+  "web.domains.email.status_verified": {
+    "text": "Kua Manatokohia"
+  },
+  "web.domains.email.status_pending": {
+    "text": "Tārewa"
+  },
+  "web.domains.email.status_failed": {
+    "text": "I Rahu"
+  },
+  "web.domains.email.revalidate": {
+    "text": "Whakamana Anō"
+  },
+  "web.domains.email.validating": {
+    "text": "E whakamana ana..."
+  },
+  "web.domains.email.domain_verified": {
+    "text": "Kua manatokohia te rohe"
+  },
+  "web.domains.email.validation_failed": {
+    "text": "I rahua te whakamana"
+  },
+  "web.domains.email.last_validated": {
+    "text": "Whakamana whakamutunga"
+  },
+  "web.domains.email.upgrade_to_configure": {
+    "text": "Whakapikia tō mahere hei whirihora i te tuku īmēra mō tēnei rohe."
+  },
+  "web.domains.email.configure_email": {
+    "text": "Whirihora Īmēra"
+  },
+  "web.domains.email.access_denied": {
+    "text": "Kua Whakakāhoretia te Urunga"
+  },
+  "web.domains.email.access_denied_description": {
+    "text": "Kāore ō whakaaetanga ki te whakahaere i ngā tautuhinga īmēra mō tēnei rohe. Whakapā atu ki tō kaiwhakahaere whakahaere."
+  },
+  "web.domains.email.update_success": {
+    "text": "Kua tiakina pai te whirihoranga īmēra"
+  },
+  "web.domains.email.delete_success": {
+    "text": "Kua tangohia pai te whirihoranga īmēra"
+  },
+  "web.domains.email.default_sender_notice": {
+    "text": "Ko ngā īmēra mō tēnei rohe ka tukuna mai i te kaituku ao i tēnei wā. Whakaotia te whirihoranga īmēra hei whakamahi i tō ake tuakiri kaituku."
+  },
+  "web.domains.email.disabled_notice": {
+    "text": "Kua monokia te tuku īmēra ritenga i tēnei wā. Ka tukuna ngā īmēra mai i te kaituku ao. Whakahohea te āhuatanga kei raro nei hei whakamahi i tō tuakiri kaituku ritenga."
+  },
+  "web.domains.email.test_email_title": {
+    "text": "Whakamātautau i te tuku īmēra"
+  },
+  "web.domains.email.test_email_hint": {
+    "text": "Tukuna he īmēra whakamātautau ki a koe anō mā te whirihoranga kua tiakina. Ka mahi ahakoa kāore anō te āhuatanga kia whakahohea."
+  },
+  "web.domains.email.send_test": {
+    "text": "Tuku whakamātautau"
+  },
+  "web.domains.email.test_email_sent": {
+    "text": "Kua tukuna pai te īmēra whakamātautau"
+  },
+  "web.domains.email.test_email_failed": {
+    "text": "I rahua te tuku i te īmēra whakamātautau"
+  },
+  "web.domains.email.test_email_sent_to": {
+    "text": "Kua tukuna ki a {email}"
+  },
+  "web.domains.email.delivered_via": {
+    "text": "Kua tukuna mā {provider}"
+  },
+  "web.domains.email.badge_not_configured": {
+    "text": "Kāore i whirihorahia"
+  },
+  "web.domains.email.badge_default_sender": {
+    "text": "Te whakamahi i te kaituku taunoa"
+  },
+  "web.domains.email.badge_verified": {
+    "text": "Kua Manatokohia"
+  },
+  "web.domains.email.badge_pending": {
+    "text": "E tatari ana te manatoko"
+  },
+  "web.domains.email.badge_disabled": {
+    "text": "Kua monokia"
+  },
+  "web.domains.email.tooltip_not_configured": {
+    "text": "Kāore he kaituku īmēra i whirihorahia — ka whakamahi ngā īmēra i te kaituku taunoa o te pātengi"
+  },
+  "web.domains.email.tooltip_pending": {
+    "text": "E tatari ana te manatoko o te whirihoranga kaituku īmēra — ka whakamahi ngā īmēra i te kaituku taunoa o te pātengi"
+  },
+  "web.domains.email.tooltip_disabled": {
+    "text": "Kua monokia te kaituku īmēra — ka whakamahi ngā īmēra i te kaituku taunoa o te pātengi"
+  },
+  "web.domains.email.tooltip_verified": {
+    "text": "Kua manatokohia te kaituku īmēra — ka tukuna ngā īmēra mai i tēnei rohe"
+  },
+  "web.domains.incoming.title": {
+    "text": "Karere Huna Tae Mai"
+  },
+  "web.domains.incoming.config_title": {
+    "text": "Whirihoranga Karere Huna Tae Mai"
+  },
+  "web.domains.incoming.config_description": {
+    "text": "Whakaae i ngā kaiwhakamahi o waho ki te tuku karere huna tika tonu ki ngā kaiwhiwhi kua tohua i tēnei rohe"
+  },
+  "web.domains.incoming.feature_disabled": {
+    "text": "Kāore ngā Karere Huna Tae Mai e Wātea ana"
+  },
+  "web.domains.incoming.feature_disabled_description": {
+    "text": "Kāore ngā karere huna tae mai i whakahohea i tēnei taupānga. Whakapā atu ki tō kaiwhakahaere."
+  },
+  "web.domains.incoming.access_denied": {
+    "text": "Kua Whakakāhoretia te Urunga"
+  },
+  "web.domains.incoming.access_denied_description": {
+    "text": "Kāore ō whakaaetanga ki te whakahaere i ngā tautuhinga karere huna tae mai mō tēnei rohe. Whakapā atu ki tō kaiwhakahaere whakahaere."
+  },
+  "web.domains.incoming.upgrade_to_configure": {
+    "text": "Whakapikia tō mahere hei whirihora i ngā karere huna tae mai mō tēnei rohe."
+  },
+  "web.domains.incoming.configure_incoming": {
+    "text": "Whirihora Karere Huna Tae Mai"
+  },
+  "web.domains.incoming.not_configured_notice": {
+    "text": "Kāore ngā karere huna tae mai i whirihorahia mō tēnei rohe. Tāpiria ngā kaiwhiwhi kia āhei ai ngā kaiwhakamahi o waho ki te tuku karere huna ki tō rōpū."
+  },
+  "web.domains.incoming.disabled_notice": {
+    "text": "Kua monokia ngā karere huna tae mai i tēnei wā. Kāore e taea e ngā kaiwhakamahi o waho te tuku karere huna ki ngā kaiwhiwhi i tēnei rohe. Whakahohea te āhuatanga kei raro nei hei whakaae i ngā karere huna tae mai."
+  },
+  "web.domains.incoming.recipients_title": {
+    "text": "Ngā Kaiwhiwhi"
+  },
+  "web.domains.incoming.recipients_description": {
+    "text": "Tautuhia ko wai ka āhei ki te whiwhi karere huna tae mai i tēnei rohe. Ka whiwhi ngā kaiwhiwhi i ngā whakamōhiotanga īmēra ina tukuna he karere huna ki a rātou."
+  },
+  "web.domains.incoming.add_recipient": {
+    "text": "Tāpiri Kaiwhiwhi"
+  },
+  "web.domains.incoming.remove_recipient": {
+    "text": "Tango"
+  },
+  "web.domains.incoming.email_label": {
+    "text": "Wāhitau Īmēra"
+  },
+  "web.domains.incoming.email_placeholder": {
+    "text": "recipient{'@'}example.com"
+  },
+  "web.domains.incoming.name_label": {
+    "text": "Ingoa Whakaatu"
+  },
+  "web.domains.incoming.name_placeholder": {
+    "text": "hei tauira, Security Team"
+  },
+  "web.domains.incoming.empty_state": {
+    "text": "Kāore he kaiwhiwhi i whirihorahia"
+  },
+  "web.domains.incoming.empty_state_description": {
+    "text": "Tāpiria ngā kaiwhiwhi kia āhei ai ngā kaiwhakamahi o waho ki te tuku karere huna ki tō rōpū."
+  },
+  "web.domains.incoming.validation_invalid_email": {
+    "text": "He muhu te wāhitau īmēra"
+  },
+  "web.domains.incoming.validation_duplicate_email": {
+    "text": "Kua tāpiritia kē tēnei wāhitau īmēra"
+  },
+  "web.domains.incoming.validation_max_recipients": {
+    "text": "{max} kaiwhiwhi te maha mōrahi e whakaaetia ana"
+  },
+  "web.domains.incoming.validation_name_required": {
+    "text": "E hiahiatia ana te ingoa whakaatu"
+  },
+  "web.domains.incoming.validation_email_required": {
+    "text": "E hiahiatia ana te wāhitau īmēra"
+  },
+  "web.domains.incoming.save_changes": {
+    "text": "Tiaki Huringa"
+  },
+  "web.domains.incoming.discard_changes": {
+    "text": "Whakakore Huringa"
+  },
+  "web.domains.incoming.update_success": {
+    "text": "Kua tiakina pai te whirihoranga karere huna tae mai"
+  },
+  "web.domains.incoming.delete_success": {
+    "text": "Kua tangohia pai te whirihoranga karere huna tae mai"
+  },
+  "web.domains.incoming.recipient_count": {
+    "text": "{count} kaiwhiwhi | {count} kaiwhiwhi"
+  },
+  "web.domains.incoming.badge_not_configured": {
+    "text": "Kāore i whirihorahia"
+  },
+  "web.domains.incoming.badge_configured": {
+    "text": "Kua whirihorahia"
+  },
+  "web.domains.incoming.badge_disabled": {
+    "text": "Kua monokia"
+  },
+  "web.domains.incoming.tooltip_not_configured": {
+    "text": "Kāore ngā karere huna tae mai i whirihorahia - kāore e taea e ngā kaiwhakamahi o waho te tuku karere huna ki tēnei rohe"
+  },
+  "web.domains.incoming.tooltip_configured": {
+    "text": "Kua whakahohea ngā karere huna tae mai me ngā kaiwhiwhi {count}"
+  },
+  "web.domains.incoming.tooltip_disabled": {
+    "text": "Kua monokia te āhuatanga karere huna tae mai mō tēnei rohe"
+  },
+  "web.domains.incoming.enabled_label": {
+    "text": "Whakahohe Karere Huna Tae Mai"
+  },
+  "web.domains.incoming.enabled_hint": {
+    "text": "Whakaae i ngā kaiwhakamahi o waho ki te tuku karere huna ki ngā kaiwhiwhi i tēnei rohe"
+  },
+  "web.domains.incoming.public_url_label": {
+    "text": "URL Tūmatanui"
+  },
+  "web.domains.incoming.public_url_description": {
+    "text": "Tohatohaina tēnei URL ki ngā kaiwhakamahi o waho kia āhei ai rātou ki te tuku karere huna"
+  },
+  "web.domains.incoming.copy_url": {
+    "text": "Tārua URL"
+  },
+  "web.domains.incoming.url_copied": {
+    "text": "Kua tāruatia te URL ki te papatopenga"
+  },
+  "web.domains.incoming.remove_all_confirmation": {
+    "text": "Kei te tino hiahia koe ki te tango i ngā kaiwhiwhi katoa? Kāore e taea e ngā kaiwhakamahi o waho te tuku karere huna ki tēnei rohe ā muri ake."
+  },
+  "web.domains.incoming.max_recipients_reached": {
+    "text": "Kua eke ki te maha mōrahi o ngā kaiwhiwhi"
+  },
+  "web.domains.incoming.duplicate_recipient": {
+    "text": "Kua tāpiritia kē tēnei wāhitau īmēra"
+  },
+  "web.domains.incoming.save_will_replace_confirmation": {
+    "text": "Mā te tiaki ka whakakapia ngā kaiwhiwhi katoa o nāianei ki ō huringa tārewa. Kei te tino hiahia koe?"
+  },
+  "web.domains.incoming.delete_all_recipients": {
+    "text": "Mukua ngā Kaiwhiwhi Katoa"
+  },
+  "web.domains.signin.title": {
+    "text": "Whirihoranga Takiuru"
+  },
+  "web.domains.signin.configure_signin": {
+    "text": "Whirihora Takiuru"
+  },
+  "web.domains.signin.config_description": {
+    "text": "Whirihora i ngā tikanga whakamotuhēhē takiuru mō tēnei rohe"
+  },
+  "web.domains.signin.access_denied": {
+    "text": "Kua Whakakāhoretia te Urunga"
+  },
+  "web.domains.signin.upgrade_to_configure": {
+    "text": "Whakapikia tō mahere hei whirihora i ngā tikanga takiuru mō tēnei rohe."
+  },
+  "web.domains.signin.not_configured_notice": {
+    "text": "Kāore anō te whirihoranga takiuru kia tautuhia mō tēnei rohe. Whirihora ngā whakakapinga hei whakahaere i ngā tikanga whakamotuhēhē e wātea ana i te whārangi takiuru o tēnei rohe."
+  },
+  "web.domains.signin.signin_enabled_label": {
+    "text": "Kua whakahohea te takiuru"
+  },
+  "web.domains.signin.header_toggle_label": {
+    "text": "Takiuru"
+  },
+  "web.domains.signin.signin_enabled_hint": {
+    "text": "Mēnā ka taea e ngā kaiwhakamahi te takiuru i tēnei rohe"
+  },
+  "web.domains.signin.restrict_to_label": {
+    "text": "Whakawhāiti i te tikanga takiuru"
+  },
+  "web.domains.signin.restrict_to_hint": {
+    "text": "Whakawhāitihia tēnei rohe ki tētahi tikanga whakamotuhēhē kotahi. Ina tautuhia, ko te tikanga kua kōwhiria anake ka whakaaturia i te whārangi takiuru."
+  },
+  "web.domains.signin.all_methods": {
+    "text": "Ngā tikanga katoa"
+  },
+  "web.domains.signin.all_methods_description": {
+    "text": "Whakaatu i ngā tikanga whakamotuhēhē katoa kua whakahohea i te whārangi takiuru"
+  },
+  "web.domains.signin.method_password": {
+    "text": "Kupuhipa"
+  },
+  "web.domains.signin.method_email_auth": {
+    "text": "Whakamotuhēhē īmēra"
+  },
+  "web.domains.signin.method_webauthn": {
+    "text": "WebAuthn / Ngā Matua Karapa"
+  },
+  "web.domains.signin.method_sso": {
+    "text": "Takiuru Kotahi"
+  },
+  "web.domains.signin.method_overrides_label": {
+    "text": "Ngā whakakapinga tikanga"
+  },
+  "web.domains.signin.method_overrides_hint": {
+    "text": "Whakahohe, whakamono rānei i ngā tikanga whakamotuhēhē takitahi mō tēnei rohe"
+  },
+  "web.domains.signin.mode_question": {
+    "text": "Me pēhea te takiuru a ngā kaiwhakamahi?"
+  },
+  "web.domains.signin.mode_any": {
+    "text": "Tētahi tikanga e wātea ana"
+  },
+  "web.domains.signin.mode_any_hint": {
+    "text": "Whakaatu i ngā tikanga katoa e wātea ana i tēnei rohe. Whakawhāitihia ngā tikanga takitahi kei raro nei."
+  },
+  "web.domains.signin.mode_one": {
+    "text": "Kotahi tikanga motuhake"
+  },
+  "web.domains.signin.mode_one_hint": {
+    "text": "Whakawhāitihia te whārangi takiuru ki tētahi tikanga kotahi. Ko ngā tikanga e wātea ana i tēnei rohe anake ka rārangihia."
+  },
+  "web.domains.signin.mode_disabled": {
+    "text": "Kua monokia te takiuru"
+  },
+  "web.domains.signin.mode_disabled_hint": {
+    "text": "Kāore e taea e ngā kaiwhakamahi te takiuru i tēnei rohe."
+  },
+  "web.domains.signin.mode_disabled_notice": {
+    "text": "Ka kite ngā manuhiri ki te whārangi takiuru o tēnei rohe i tētahi pānui kāore te takiuru e wātea ana, me te hononga ki muri ki te whārangi kāinga. Ka puritia ō tautuhinga tikanga o mua, ka whakaorangia ina whakahohea anō e koe te takiuru."
+  },
+  "web.domains.signin.methods_list_label": {
+    "text": "Ngā tikanga ka whakaaturia i te whārangi takiuru"
+  },
+  "web.domains.signin.restrict_picker_hint": {
+    "text": "Ko ngā tikanga e wātea ana i tēnei rohe anake ka rārangihia."
+  },
+  "web.domains.signin.availability_always": {
+    "text": "E wātea ana i ngā wā katoa"
+  },
+  "web.domains.signin.availability_global_on": {
+    "text": "Ka whai i te kaupapahere ao · Kā"
+  },
+  "web.domains.signin.availability_global_off": {
+    "text": "Kāore e wātea ana"
+  },
+  "web.domains.signin.availability_unavailable": {
+    "text": "Kāore e wātea ana puta noa i te pae"
+  },
+  "web.domains.signin.allow_on_domain": {
+    "text": "Whakaae i tēnei rohe"
+  },
+  "web.domains.signin.method_password_blurb": {
+    "text": "Kupuhipa anake"
+  },
+  "web.domains.signin.method_email_auth_blurb": {
+    "text": "Takiuru hononga-mākutu kore-kupuhipa"
+  },
+  "web.domains.signin.method_webauthn_blurb": {
+    "text": "Koiora-tautohu me ngā matua haumaru"
+  },
+  "web.domains.signin.method_sso_blurb": {
+    "text": "Kaiwhakarato tuakiri o waho"
+  },
+  "web.domains.signin.email_auth_label": {
+    "text": "Whakamotuhēhē īmēra"
+  },
+  "web.domains.signin.email_auth_hint": {
+    "text": "Whakaae i te whakamotuhēhē īmēra kore-kupuhipa i tēnei rohe"
+  },
+  "web.domains.signin.sso_enabled_label": {
+    "text": "Takiuru Kotahi"
+  },
+  "web.domains.signin.sso_enabled_hint": {
+    "text": "Whakaae i te whakamotuhēhē SSO i tēnei rohe"
+  },
+  "web.domains.signin.enabled_label": {
+    "text": "Whakahohe i te whirihoranga takiuru"
+  },
+  "web.domains.signin.enabled_hint": {
+    "text": "Ina whakahohea, ka whakamahi tēnei rohe i ngā tautuhinga takiuru i whirihorahia i runga ake"
+  },
+  "web.domains.signin.save_config": {
+    "text": "Tiaki whirihoranga"
+  },
+  "web.domains.signin.update_success": {
+    "text": "Kua whakahoutia pai te whirihoranga takiuru"
+  },
+  "web.domains.signin.reset_to_defaults": {
+    "text": "Tautuhi anō ki ngā taunoa"
+  },
+  "web.domains.signin.reset_confirm": {
+    "text": "Tautuhi anō te takiuru ki ngā taunoa ao?"
+  },
+  "web.domains.signin.reset_keeps_sso": {
+    "text": "Ka puritia ō pūnga whaimana SSO. Tangohia motuhake rātou i te mata whirihoranga SSO."
+  },
+  "web.domains.signin.reset_action": {
+    "text": "Āe, tautuhi anō"
+  },
+  "web.domains.signin.reset_success": {
+    "text": "Kua tautuhia anō ngā tautuhinga takiuru ki ngā taunoa ao"
+  },
+  "web.domains.signup.title": {
+    "text": "Whakamana Rēhitatanga"
+  },
+  "web.domains.signup.config_description": {
+    "text": "Whirihorahia te whakamana rēhitatanga mō tēnei rohe"
+  },
+  "web.domains.signup.access_denied": {
+    "text": "Kua Whakakāhoretia te Urunga"
+  },
+  "web.domains.signup.upgrade_to_configure": {
+    "text": "Whakapikihia tō mahere kia whirihora ai i te whakamana rēhitatanga ā-rohe."
+  },
+  "web.domains.signup.configure_signup": {
+    "text": "Whirihora Rēhitatanga"
+  },
+  "web.domains.signup.not_configured_notice": {
+    "text": "Kāore anō te whakamana rēhitatanga kia whirihorahia mō tēnei rohe. Whirihorahia tētahi rautaki hei whakahaere i te hunga ka taea te rēhita mā tēnei rohe."
+  },
+  "web.domains.signup.site_signups_disabled_warning": {
+    "text": "Kua monokia ngā rēhitatanga i te taumata o te pae i tēnei wā. Kua whirihorahia tēnei kaupapahere ā-rohe engari e kore e aukati i tētahi hokohoko kia whakahohea ra anō ngā rēhitatanga o te pae."
+  },
+  "web.domains.signup.strategy_label": {
+    "text": "Rautaki whakamana"
+  },
+  "web.domains.signup.strategy_description": {
+    "text": "Tīpakohia me pēhea e whakamanahia ai ngā wāhitau īmēra ina rēhita ngā kaiwhakamahi ki tēnei rohe."
+  },
+  "web.domains.signup.network_validation_warning": {
+    "text": "Ka mahi tēnei rautaki i ngā waea whatunga i te wā rēhita, ka taea pea te tāpiri takaroa, ka aukatihia rānei e ētahi kaiwhakarato."
+  },
+  "web.domains.signup.allowed_domains_label": {
+    "text": "Ngā rohe rēhita kua whakaaetia"
+  },
+  "web.domains.signup.allowed_domains_hint": {
+    "text": "Ko ēnei rohe īmēra anake ka whakaaetia kia rēhita. Tāpirihia kotahi te rohe mō ia urunga."
+  },
+  "web.domains.signup.domain_placeholder": {
+    "text": "example.com"
+  },
+  "web.domains.signup.invalid_domain": {
+    "text": "Tēnā whakaurua tētahi rohe whaimana (hei tauira example.com)"
+  },
+  "web.domains.signup.domain_exists": {
+    "text": "Kei te rārangi kē tēnei rohe"
+  },
+  "web.domains.signup.remove_domain": {
+    "text": "Tangohia {domain}"
+  },
+  "web.domains.signup.enabled_label": {
+    "text": "Whakahohea te whakamana ā-rohe"
+  },
+  "web.domains.signup.enabled_hint": {
+    "text": "Ina whakahohea, ka whakamahi ngā rēhitatanga o tēnei rohe i te rautaki kei runga ake nei, kaua ko te kaupapahere ao whānui."
+  },
+  "web.domains.signup.delete_config": {
+    "text": "Mukua te whirihoranga"
+  },
+  "web.domains.signup.delete_confirm": {
+    "text": "Mukua te whirihoranga whakamana rēhitatanga? Ka hoki ngā rēhitatanga ki te kaupapahere ao whānui."
+  },
+  "web.domains.signup.save_config": {
+    "text": "Tiaki whirihoranga"
+  },
+  "web.domains.signup.update_success": {
+    "text": "Kua angitu te whakahou i te whakamana rēhitatanga"
+  },
+  "web.domains.signup.delete_success": {
+    "text": "Kua angitu te tango i te whirihoranga whakamana rēhitatanga"
+  },
+  "web.domains.signup.domain_overrides_label": {
+    "text": "Ngā whakakapinga rohe"
+  },
+  "web.domains.signup.domain_overrides_hint": {
+    "text": "Whakakapia ngā tautuhinga rēhitatanga ao whānui mō tēnei rohe"
+  },
+  "web.domains.signup.signup_enabled_label": {
+    "text": "Kua whakahohea te rēhitatanga"
+  },
+  "web.domains.signup.signup_enabled_hint": {
+    "text": "Whakakapia mēnā kua whakahohea te rēhitatanga mō tēnei rohe"
+  },
+  "web.domains.signup.autoverify_label": {
+    "text": "Whakamanatoko aunoa i ngā pūkete"
+  },
+  "web.domains.signup.autoverify_hint": {
+    "text": "Whakakapia mēnā ka whakamanatokohia aunoatia ngā pūkete hou i tēnei rohe"
+  },
+  "web.domains.sso.title": {
+    "text": "Takiuru Kotahi (SSO)"
+  },
+  "web.domains.sso.config_title": {
+    "text": "Whirihoranga SSO"
+  },
+  "web.domains.sso.config_description": {
+    "text": "Whirihorahia te motuhēhēnga takiuru kotahi mō tēnei rohe"
+  },
+  "web.domains.sso.access_denied": {
+    "text": "Kua Whakakāhoretia te Urunga"
+  },
+  "web.domains.sso.access_denied_description": {
+    "text": "Kāore ō whakaaetanga ki te whakahaere i ngā tautuhinga SSO mō tēnei rohe. Whakapā atu ki tō kaiwhakahaere whakahaere."
+  },
+  "web.domains.sso.upgrade_to_configure": {
+    "text": "Whakapikihia tō mahere kia whirihora ai i te takiuru kotahi mō tēnei rohe."
+  },
+  "web.domains.sso.create_success": {
+    "text": "Kua angitu te waihanga i te whirihoranga SSO"
+  },
+  "web.domains.sso.update_success": {
+    "text": "Kua angitu te whakahou i te whirihoranga SSO"
+  },
+  "web.domains.sso.delete_success": {
+    "text": "Kua angitu te tango i te whirihoranga SSO"
+  },
+  "web.domains.sso.test_success": {
+    "text": "Kua angitu te whakamātautau hononga — i tika te whakautu a te kaiwhakarato"
+  },
+  "web.domains.sso.test_failed": {
+    "text": "I rahu te whakamātautau hononga"
+  },
+  "web.domains.sso.enforce_moved_notice": {
+    "text": "Hei whakarite kia hiahiatia te SSO mō ngā takiuru katoa o tēnei rohe, whirihorahia i roto i ngā tautuhinga takiuru o te rohe. Ka whakawhāiti te aratau SSO-anake i te whārangi takiuru ki te kaiwhakarato SSO kua whirihorahia ki konei."
+  },
+  "web.domains.sso.configure_sso": {
+    "text": "Whirihora SSO"
+  },
+  "web.domains.sso.not_configured_notice": {
+    "text": "Kāore anō te SSO kia whirihorahia mō tēnei rohe. Whakahohea te takiuru kotahi kia āhei ai ngā mema kapa ki te whakamotuhēhē mā te kaiwhakarato tuakiri o tō whakahaere."
+  },
+  "web.domains.sso.edit_credentials": {
+    "text": "Whakatika pūnga whaimana"
+  },
+  "web.domains.sso.configure_button": {
+    "text": "Whirihora"
+  },
+  "web.domains.sso.upgrade_required": {
+    "text": "Whakapiki kia whirihora"
   }
 }

--- a/locales/content/mi_NZ/workspace-organizations.json
+++ b/locales/content/mi_NZ/workspace-organizations.json
@@ -578,5 +578,344 @@
   "web.organizations.invitations.expires_soon": {
     "text": "Ka pau tata",
     "source_hash": "a5dcfef9"
+  },
+  "api.organizations.errors.not_found": {
+    "text": "Kāore i kitea te whakahaere: %{extid}"
+  },
+  "api.organizations.errors.owner_required": {
+    "text": "Ko te rangatira whakahaere anake ka taea te mahi i tēnei"
+  },
+  "api.organizations.errors.admin_required": {
+    "text": "Ko ngā rangatira me ngā kaiwhakahaere whakahaere anake ka taea te mahi i tēnei"
+  },
+  "api.organizations.errors.member_required": {
+    "text": "Me noho koe hei mema whakahaere kia taea ai e koe te mahi i tēnei"
+  },
+  "api.organizations.invitations.errors.create_admin_required": {
+    "text": "Ko ngā rangatira me ngā kaiwhakahaere whakahaere anake ka taea te waihanga tono"
+  },
+  "api.organizations.invitations.errors.resend_admin_required": {
+    "text": "Ko ngā rangatira me ngā kaiwhakahaere whakahaere anake ka taea te tuku anō i ngā tono"
+  },
+  "api.organizations.invitations.errors.view_admin_required": {
+    "text": "Ko ngā rangatira me ngā kaiwhakahaere whakahaere anake ka taea te tiro i ngā tono"
+  },
+  "api.organizations.invitations.errors.revoke_admin_required": {
+    "text": "Ko ngā rangatira me ngā kaiwhakahaere whakahaere anake ka taea te whakakore i ngā tono"
+  },
+  "api.organizations.invitations.errors.email_required": {
+    "text": "E hiahiatia ana te īmēra"
+  },
+  "api.organizations.invitations.errors.email_invalid": {
+    "text": "Hōputu īmēra muhu"
+  },
+  "api.organizations.invitations.errors.role_invalid": {
+    "text": "Me noho te tūranga hei mema, hei kaiwhakahaere rānei"
+  },
+  "api.organizations.invitations.errors.cannot_invite_owner": {
+    "text": "Kāore e taea te tono hei rangatira"
+  },
+  "api.organizations.invitations.errors.already_member": {
+    "text": "He mema kē te kaiwhakamahi o tēnei whakahaere"
+  },
+  "api.organizations.invitations.errors.already_pending": {
+    "text": "Kei te tārewa kē tētahi tono mō tēnei īmēra"
+  },
+  "api.organizations.invitations.errors.member_limit_reached": {
+    "text": "Kua tae ki te tepe mema. Whakapikihia tō mahere kia tono ai i ētahi atu mema."
+  },
+  "api.organizations.invitations.errors.not_found": {
+    "text": "Kāore i kitea te tono"
+  },
+  "api.organizations.invitations.errors.cannot_resend_non_pending": {
+    "text": "Ka taea anake te tuku anō i ngā tono tārewa"
+  },
+  "api.organizations.invitations.errors.cannot_revoke_non_pending": {
+    "text": "Ka taea anake te whakakore i ngā tono tārewa"
+  },
+  "api.organizations.invitations.errors.resend_limit_reached": {
+    "text": "Kua tae ki te tepe tuku-anō mōrahi (%{max})"
+  },
+  "api.organizations.invitations.errors.accept_token_required": {
+    "text": "E hiahiatia ana te tokena"
+  },
+  "api.organizations.invitations.errors.accept_organization_gone": {
+    "text": "Kāore te whakahaere e noho tonu ana"
+  },
+  "api.organizations.invitations.errors.accept_already_acted": {
+    "text": "Kua %{status} kē te tono"
+  },
+  "api.organizations.invitations.errors.accept_expired": {
+    "text": "Kua pau te tono"
+  },
+  "api.organizations.invitations.errors.accept_email_mismatch": {
+    "text": "Kāore tō wāhitau īmēra e ōrite ana ki te tono"
+  },
+  "api.organizations.invitations.errors.accept_already_member": {
+    "text": "He mema kē koe o tēnei whakahaere"
+  },
+  "web.organizations.entitlements_title": {
+    "text": "Ngā Whaimana Whakahaere"
+  },
+  "web.organizations.page_description_short": {
+    "text": "Tirohia, whirihorahia hoki ō wāhi mahi"
+  },
+  "web.organizations.delete_organization_remove_domains_first": {
+    "text": "Tangohia ngā rohe ritenga katoa i mua i te muku i tēnei whakahaere."
+  },
+  "web.organizations.default_org_delete_notice_title": {
+    "text": "Te muku i tēnei whakahaere"
+  },
+  "web.organizations.default_org_delete_notice_before": {
+    "text": "Koinei tō whakahaere taunoa, ā, kāore e taea te tango i te papatohu. Hei muku i a ia, tēnā whakapā mai mā te"
+  },
+  "web.organizations.default_org_delete_notice_link": {
+    "text": "puka urupare"
+  },
+  "web.organizations.default_org_delete_notice_after": {
+    "text": "."
+  },
+  "web.organizations.leave_organization": {
+    "text": "Wehe i tēnei whakahaere"
+  },
+  "web.organizations.leave_organization_warning": {
+    "text": "Ka ngaro i a koe te urunga ki tēnei whakahaere me ōna rauemi."
+  },
+  "web.organizations.leave_organization_confirm_title": {
+    "text": "Wehe i te Whakahaere"
+  },
+  "web.organizations.leave_organization_confirm_message": {
+    "text": "E tino hiahia ana koe ki te wehe i a {name}? Ka hiahiatia e koe tētahi tono hou kia hono anō."
+  },
+  "web.organizations.leave_organization_success": {
+    "text": "Kua wehe koe i te whakahaere."
+  },
+  "web.organizations.leave_error": {
+    "text": "I rahu te wehe i te whakahaere"
+  },
+  "web.organizations.organizations": {
+    "text": "Ngā Whakahaere"
+  },
+  "web.organizations.invitations.invited_by_inline": {
+    "text": "nā {email}"
+  },
+  "web.organizations.invitations.invited_as_inline": {
+    "text": "hei {role}"
+  },
+  "web.organizations.invitations.back_to_home": {
+    "text": "Hoki ki te kāinga"
+  },
+  "web.organizations.invitations.email_locked_hint": {
+    "text": "I tukuna tēnei tono ki tēnei wāhitau īmēra"
+  },
+  "web.organizations.invitations.signup_continue": {
+    "text": "Haere tonu"
+  },
+  "web.organizations.invitations.signin_continue": {
+    "text": "Takiuru"
+  },
+  "web.organizations.invitations.confirm_join_below": {
+    "text": "Kua tata oti — whakaūngia kei raro nei kia hono ai ki te whakahaere."
+  },
+  "web.organizations.invitations.go_to_organizations": {
+    "text": "Haere ki ngā Whakahaere"
+  },
+  "web.organizations.invitations.already_member": {
+    "text": "He mema kē koe o tēnei whakahaere"
+  },
+  "web.organizations.invitations.join_organization": {
+    "text": "Hono ki {orgName}"
+  },
+  "web.organizations.invitations.sign_in_to_join": {
+    "text": "Takiuru kia hono ai ki {orgName}"
+  },
+  "web.organizations.invitations.decline": {
+    "text": "Whakakāhore"
+  },
+  "web.organizations.members.member_quota": {
+    "text": "{used} o {limit} mema"
+  },
+  "web.organizations.members.pending_suffix": {
+    "text": "({count} e tārewa ana)"
+  },
+  "web.organizations.members.limit_reached_hint": {
+    "text": "Kua tae ki te tepe mema."
+  },
+  "web.organizations.sso.title": {
+    "text": "Takiuru Kotahi (SSO)"
+  },
+  "web.organizations.sso.description": {
+    "text": "Whirihorahia te SSO kia āhei ai ngā mema ki te takiuru mā te kaiwhakarato tuakiri o tō whakahaere"
+  },
+  "web.organizations.sso.provider_type": {
+    "text": "Momo Kaiwhakarato"
+  },
+  "web.organizations.sso.provider_type_description": {
+    "text": "Tīpakohia te kaiwhakarato tuakiri o tō whakahaere"
+  },
+  "web.organizations.sso.display_name": {
+    "text": "Ingoa Whakaatu"
+  },
+  "web.organizations.sso.display_name_hint": {
+    "text": "He ingoa hoa ka whakaatuhia ki ngā kaiwhakamahi ina takiuru"
+  },
+  "web.organizations.sso.display_name_placeholder": {
+    "text": "hei tauira Acme Corp SSO"
+  },
+  "web.organizations.sso.client_id": {
+    "text": "Client ID"
+  },
+  "web.organizations.sso.client_id_placeholder": {
+    "text": "Tō Client ID OAuth"
+  },
+  "web.organizations.sso.client_secret": {
+    "text": "Client Secret"
+  },
+  "web.organizations.sso.client_secret_placeholder": {
+    "text": "Tō Client Secret OAuth"
+  },
+  "web.organizations.sso.client_secret_update_hint": {
+    "text": "Waiho wātea kia mau ai te secret o nāianei"
+  },
+  "web.organizations.sso.tenant_id": {
+    "text": "Tenant ID"
+  },
+  "web.organizations.sso.tenant_id_hint": {
+    "text": "Tō tautohu tenant Azure AD / Entra ID"
+  },
+  "web.organizations.sso.tenant_id_placeholder": {
+    "text": "hei tauira 12345678-1234-1234-1234-123456789abc"
+  },
+  "web.organizations.sso.issuer": {
+    "text": "Issuer URL"
+  },
+  "web.organizations.sso.issuer_hint": {
+    "text": "Te URL kitenga OIDC mō tō kaiwhakarato tuakiri"
+  },
+  "web.organizations.sso.issuer_placeholder": {
+    "text": "hei tauira https://login.example.com"
+  },
+  "web.organizations.sso.view_discovery_document": {
+    "text": "Tirohia te tuhinga kitenga"
+  },
+  "web.organizations.sso.callback_url": {
+    "text": "Callback URL"
+  },
+  "web.organizations.sso.callback_url_hint": {
+    "text": "Tāpirihia tēnei URL ki ngā URI whakahuri kua whakaaetia a tō kaiwhakarato tuakiri"
+  },
+  "web.organizations.sso.allowed_domains": {
+    "text": "Ngā Rohe Īmēra Kua Whakaaetia"
+  },
+  "web.organizations.sso.allowed_domains_hint": {
+    "text": "Ko ngā kaiwhakamahi anake he wāhitau īmēra nō ēnei rohe ka taea te takiuru. Waiho wātea kia whakaaetia ai ngā rohe katoa."
+  },
+  "web.organizations.sso.domain_placeholder": {
+    "text": "hei tauira acme.com"
+  },
+  "web.organizations.sso.invalid_domain": {
+    "text": "Tēnā whakaurua tētahi rohe whaimana (hei tauira example.com)"
+  },
+  "web.organizations.sso.domain_exists": {
+    "text": "Kei te rārangi kē tēnei rohe"
+  },
+  "web.organizations.sso.remove_domain": {
+    "text": "Tangohia {domain}"
+  },
+  "web.organizations.sso.enabled": {
+    "text": "Whakahohea te SSO"
+  },
+  "web.organizations.sso.enabled_hint": {
+    "text": "Ina whakahohea, ka taea e ngā mema whakahaere te takiuru mā tēnei kaiwhakarato SSO"
+  },
+  "web.organizations.sso.enforce_sso_only": {
+    "text": "Whakaū SSO-anake"
+  },
+  "web.organizations.sso.enforce_sso_only_hint": {
+    "text": "Whakarite kia hiahiatia te SSO mō ngā takiuru katoa o tēnei rohe. Ina whakahohea, ka monokia te motuhēhēnga ā-kupuhipa."
+  },
+  "web.organizations.sso.grant_org_scope": {
+    "text": "Tuku urunga puta noa i te whakahaere"
+  },
+  "web.organizations.sso.grant_org_scope_hint": {
+    "text": "Ko ngā mema hou ka hono mā te SSO o tēnei rohe, ka tukuna te urunga ki ngā rohe katoa o te whakahaere. Kāore ngā mema o nāianei e pā. Ina monokia (taunoa), ka taea e ngā mema hou te urunga ki tēnei rohe anake."
+  },
+  "web.organizations.sso.save_config": {
+    "text": "Tiaki Whirihoranga SSO"
+  },
+  "web.organizations.sso.delete_config": {
+    "text": "Mukua te Whirihoranga"
+  },
+  "web.organizations.sso.delete_confirm": {
+    "text": "E tino hiahia ana koe? Ka monokia tēnei i te SSO mō tō whakahaere."
+  },
+  "web.organizations.sso.load_error": {
+    "text": "I rahu te uta i te whirihoranga SSO"
+  },
+  "web.organizations.sso.save_error": {
+    "text": "I rahu te tiaki i te whirihoranga SSO"
+  },
+  "web.organizations.sso.create_success": {
+    "text": "Kua angitu te waihanga i te whirihoranga SSO"
+  },
+  "web.organizations.sso.update_success": {
+    "text": "Kua angitu te whakahou i te whirihoranga SSO"
+  },
+  "web.organizations.sso.delete_success": {
+    "text": "Kua angitu te muku i te whirihoranga SSO"
+  },
+  "web.organizations.sso.delete_error": {
+    "text": "I rahu te muku i te whirihoranga SSO"
+  },
+  "web.organizations.sso.test_connection": {
+    "text": "Whakamātau Hononga"
+  },
+  "web.organizations.sso.test_connection_hint": {
+    "text": "Manatokohia ka taea te kaiwhakarato tuakiri (kāore e whakamana i ngā pūnga whaimana)"
+  },
+  "web.organizations.sso.test_button": {
+    "text": "Whakamātau Hononga"
+  },
+  "web.organizations.sso.testing": {
+    "text": "E whakamātau ana..."
+  },
+  "web.organizations.sso.test_error": {
+    "text": "I rahu te whakamātau hononga"
+  },
+  "web.organizations.sso.auth_endpoint": {
+    "text": "Pito Mutunga Whakaaetanga"
+  },
+  "web.organizations.sso.missing_fields": {
+    "text": "Ngā Āpure Ngaro"
+  },
+  "web.organizations.sso.status_enabled": {
+    "text": "Kua Whakahohea"
+  },
+  "web.organizations.sso.status_configured": {
+    "text": "Kua Whirihorahia"
+  },
+  "web.organizations.sso.domain_sso_title": {
+    "text": "SSO Rohe"
+  },
+  "web.organizations.sso.domain_sso_description": {
+    "text": "Whirihorahia te SSO mō ia rohe kua manatokona"
+  },
+  "web.organizations.sso.provider_type_locked_hint": {
+    "text": "Hei whakarerekē i te kaiwhakarato, mukua tēnei whirihoranga i te tuatahi"
+  },
+  "web.organizations.sso.status_not_configured": {
+    "text": "Kāore Anō Kia Whirihorahia"
+  },
+  "web.organizations.sso.no_domains": {
+    "text": "Kāore he rohe kua manatokona"
+  },
+  "web.organizations.sso.no_domains_description": {
+    "text": "Tāpirihia, manatokohia hoki tētahi rohe i mua i te whirihora SSO mōna."
+  },
+  "web.organizations.tabs.team": {
+    "text": "Kapa"
+  },
+  "web.organizations.tabs.sso": {
+    "text": "SSO"
   }
 }


### PR DESCRIPTION
## `mi_NZ` translation update

Automated export of completed **mi_NZ** translations from the translation task DB.
Scope: `locales/content/mi_NZ/` only — 27 file(s), +1849/-31.

✅ `i18n validate variables`: no variable mismatches.

---

### Local quality review

> Produced by a fresh, isolated `claude` review agent (model `claude-sonnet-5`, agent `saas-translator`) that read
> `locales/AGENT_TRANSLATION_PROTOCOL.md` and inspected this branch's diff before the PR was opened.

All "Delano" instances replaced consistently; confirms the one outlier `"Tīma Tautoko"` (line 872, `email.expiration_warning.signature`) is a genuine one-off inconsistency against the established "Te Kapa Tautoko" pattern.

**Verdict:** ✅ Looks good — no blockers, one terminology nit.

**Summary:** Large batch (SSO, domains, orgs, billing, colonel, email) adds ~1000 new keys and revises several existing ones; all variable tokens (`{var}`, `%{var}`, `{0}`) match source exactly, key sets are complete, brand terms and stay-English items (Client ID/Secret, SSO, provider names) are preserved, and the `Delano`→support-team signature migration is applied uniformly.

**Critical (must fix):** None.

**Warnings:**
- `email.expiration_warning.signature` uses "Tīma Tautoko" while all 20 other converted signatures use "Te Kapa Tautoko" for the same English source "Support Team" — inconsistent, should be normalized.

**Notes:**
- `web.homepage.one_time_secret_literal` changed from a mistranslated fixed phrase to `{product_name}`, now correctly matching the English source (which is itself just the variable) — this is a fix, not a regression.
- Several files show only key-reordering diffs (e.g. `00-common`, `admin-colonel`, `workspace-domains`) with identical content — no functional change, just insertion order.
- Three flat `*._guidance.context` keys (`web.auth.security`, `web.auth.sessions`, `web.auth.verify`) exist in mi_NZ but not as flat keys in the English source (English nests them under `_guidance`); consistent with the same benign doc-metadata pattern seen in other locales' audits — not user-facing, no action needed.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
