### PR TITLE
i18n: update nl translations

### DIFF
--- a/locales/content/nl/00-common.json
+++ b/locales/content/nl/00-common.json
@@ -1299,7 +1299,7 @@
     "source_hash": "fc78d9cb"
   },
   "web.INSTRUCTION.phishing_warning": {
-    "text": "Controleer altijd of je op de officiële {product_name}-website bent. Fraudeurs maken soms nepwebsites die er precies uitzien als {product_name} om je berichten te stelen. Om phishing-aanvallen te voorkomen, controleer het domein voordat je nieuwe links aanmaakt.",
+    "text": "Controleer altijd of je je op de officiële website van {product_name} bevindt. Fraudeurs maken soms nepwebsites die er precies uitzien als {product_name} om je berichten te stelen. Controleer het regiodomein voordat je nieuwe links aanmaakt om phishingaanvallen te voorkomen.",
     "source_hash": "b588f5b2"
   },
   "web.pricing.title": {
@@ -1383,5 +1383,110 @@
     "text": "Upgrade om meer functies te ontgrendelen",
     "context": "Description shown for free plan users encouraging upgrade",
     "source_hash": "783f174c"
+  },
+  "api.errors.authentication_required": {
+    "text": "Authenticatie vereist"
+  },
+  "api.errors.sso_only_action_blocked": {
+    "text": "Deze actie is niet beschikbaar in SSO-only-modus"
+  },
+  "web.COMMON.configure": {
+    "text": "Configureren"
+  },
+  "web.COMMON.copy_to_clipboard": {
+    "text": "Kopiëren naar klembord"
+  },
+  "web.COMMON.add": {
+    "text": "Toevoegen"
+  },
+  "web.COMMON.enabled": {
+    "text": "Ingeschakeld"
+  },
+  "web.COMMON.disabled": {
+    "text": "Uitgeschakeld"
+  },
+  "web.COMMON.yes_delete": {
+    "text": "Ja, verwijderen"
+  },
+  "web.COMMON.error_code": {
+    "text": "Foutcode"
+  },
+  "web.COMMON.http_status": {
+    "text": "HTTP-status"
+  },
+  "web.COMMON.details": {
+    "text": "Details"
+  },
+  "web.COMMON.field_confirm_password": {
+    "text": "Wachtwoord bevestigen"
+  },
+  "web.COMMON.passwords_must_match": {
+    "text": "Wachtwoorden moeten overeenkomen"
+  },
+  "web.COMMON.and": {
+    "text": "en"
+  },
+  "web.COMMON.or": {
+    "text": "of"
+  },
+  "web.COMMON.copied": {
+    "text": "Gekopieerd"
+  },
+  "web.COMMON.copy": {
+    "text": "Kopiëren"
+  },
+  "web.COMMON.copy_email": {
+    "text": "E-mailadres kopiëren"
+  },
+  "web.COMMON.copy_id": {
+    "text": "Account-ID kopiëren"
+  },
+  "web.COMMON.org_id_tooltip": {
+    "text": "De unieke identificatie van je organisatie"
+  },
+  "web.COMMON.success": {
+    "text": "Gelukt"
+  },
+  "web.COMMON.need_help": {
+    "text": "Hulp nodig"
+  },
+  "web.COMMON.open_help_dialog": {
+    "text": "Hulpvenster openen"
+  },
+  "web.COMMON.focus_is_now_in_the_main_text_area": {
+    "text": "De focus ligt nu in het hoofdtekstvak"
+  },
+  "web.LABELS.show_passphrase": {
+    "text": "Wachtwoordzin tonen"
+  },
+  "web.LABELS.hide_passphrase": {
+    "text": "Wachtwoordzin verbergen"
+  },
+  "web.LABELS.copy_icon": {
+    "text": "Kopieerpictogram"
+  },
+  "web.LABELS.copied_icon": {
+    "text": "Gekopieerd-pictogram"
+  },
+  "web.STATUS.unverified": {
+    "text": "Niet geverifieerd"
+  },
+  "web.TITLES.domain_detail": {
+    "text": "Domeininstellingen"
+  },
+  "web.TITLES.domain_signin": {
+    "text": "Inlogconfiguratie"
+  },
+  "web.TITLES.domain_sso": {
+    "text": "Domein-SSO"
+  },
+  "web.TITLES.domain_signup": {
+    "text": "Validatie van domeinaanmelding"
+  },
+  "web.TITLES.domain_email": {
+    "text": "E-mailconfiguratie"
+  },
+  "web.TITLES.domain_incoming": {
+    "text": "Inkomende berichten"
   }
 }

--- a/locales/content/nl/10-layout.json
+++ b/locales/content/nl/10-layout.json
@@ -148,7 +148,7 @@
     "source_hash": "b9766df3"
   },
   "web.help.secret_view_faq.what_am_i_looking_at.description": {
-    "text": "Je bekijkt een beveiligd bericht dat met je is gedeeld via {product_name}. Deze inhoud wordt slechts één keer getoond en daarna permanent van onze servers verwijderd.",
+    "text": "Je bekijkt een beveiligd bericht dat via {product_name} met je is gedeeld. Deze inhoud wordt slechts één keer weergegeven en daarna permanent van onze servers verwijderd.",
     "source_hash": "e0f1a10c"
   },
   "web.help.secret_view_faq.can_i_view_again.title": {
@@ -264,7 +264,7 @@
     "source_hash": "e2f124cd"
   },
   "web.layout.visit_onetime_secret_homepage": {
-    "text": "Bezoek de {product_name}-homepage",
+    "text": "Bezoek de homepage van {product_name}",
     "source_hash": "625556d2"
   },
   "web.layout.footer_navigation": {
@@ -338,5 +338,11 @@
   "web.layout.workspace_context": {
     "text": "Werkruimtecontext",
     "source_hash": "dc6fa4f5"
+  },
+  "web.footer.workspace": {
+    "text": "Workspace"
+  },
+  "web.help.default_content": {
+    "text": "Neem contact op met support voor hulp"
   }
 }

--- a/locales/content/nl/10-layout.json
+++ b/locales/content/nl/10-layout.json
@@ -340,7 +340,7 @@
     "source_hash": "dc6fa4f5"
   },
   "web.footer.workspace": {
-    "text": "Workspace"
+    "text": "Werkruimte"
   },
   "web.help.default_content": {
     "text": "Neem contact op met support voor hulp"

--- a/locales/content/nl/admin-colonel.json
+++ b/locales/content/nl/admin-colonel.json
@@ -634,5 +634,152 @@
   "web.colonel.feedback.when_you_submit_feedback_well_see": {
     "text": "Wanneer je feedback verstuurt, zien wij:",
     "source_hash": "fe77172e"
+  },
+  "web.colonel.previewPlanMode": {
+    "text": "Planvoorbeeldmodus"
+  },
+  "web.colonel.previewModeDescription": {
+    "text": "Bekijk de applicatie zoals deze verschijnt voor klanten met een ander plan. Dit beïnvloedt alleen jouw weergave en verandert niets aan het werkelijke plan van een organisatie."
+  },
+  "web.colonel.previewModeActive": {
+    "text": "Voorbeeld actief"
+  },
+  "web.colonel.bannedIps.empty": {
+    "text": "Geen geblokkeerde IP's"
+  },
+  "web.colonel.bannedIps.currentIp": {
+    "text": "Je huidige IP-adres"
+  },
+  "web.colonel.bannedIps.confirmUnban": {
+    "text": "{ip} deblokkeren?"
+  },
+  "web.colonel.bannedIps.actions.ban": {
+    "text": "IP blokkeren"
+  },
+  "web.colonel.bannedIps.actions.quickBan": {
+    "text": "Snel blokkeren"
+  },
+  "web.colonel.bannedIps.actions.unban": {
+    "text": "Deblokkeren"
+  },
+  "web.colonel.bannedIps.actions.cancel": {
+    "text": "Annuleren"
+  },
+  "web.colonel.bannedIps.columns.ipAddress": {
+    "text": "IP-adres"
+  },
+  "web.colonel.bannedIps.columns.reason": {
+    "text": "Reden"
+  },
+  "web.colonel.bannedIps.columns.bannedAt": {
+    "text": "Geblokkeerd op"
+  },
+  "web.colonel.bannedIps.columns.bannedBy": {
+    "text": "Geblokkeerd door"
+  },
+  "web.colonel.bannedIps.error.banFailed": {
+    "text": "Blokkeren van IP-adres mislukt"
+  },
+  "web.colonel.bannedIps.error.unbanFailed": {
+    "text": "Deblokkeren van IP-adres mislukt"
+  },
+  "web.colonel.bannedIps.form.title": {
+    "text": "IP-adres blokkeren"
+  },
+  "web.colonel.bannedIps.form.ipLabel": {
+    "text": "IP-adres"
+  },
+  "web.colonel.bannedIps.form.reasonLabel": {
+    "text": "Reden"
+  },
+  "web.colonel.bannedIps.form.reasonPlaceholder": {
+    "text": "Optionele reden"
+  },
+  "web.colonel.bannedIps.success.banned": {
+    "text": "IP-adres {ip} is geblokkeerd"
+  },
+  "web.colonel.bannedIps.success.unbanned": {
+    "text": "IP-adres {ip} is gedeblokkeerd"
+  },
+  "web.colonel.customDomains.empty": {
+    "text": "Geen aangepaste domeinen geconfigureerd"
+  },
+  "web.colonel.customDomains.noLogo": {
+    "text": "Geen logo"
+  },
+  "web.colonel.customDomains.labels.organization": {
+    "text": "Organisatie"
+  },
+  "web.colonel.customDomains.labels.externalId": {
+    "text": "Externe ID"
+  },
+  "web.colonel.customDomains.labels.created": {
+    "text": "Aangemaakt"
+  },
+  "web.colonel.customDomains.labels.updated": {
+    "text": "Bijgewerkt"
+  },
+  "web.colonel.customDomains.labels.favicon": {
+    "text": "Favicon"
+  },
+  "web.colonel.customDomains.status.verified": {
+    "text": "Geverifieerd"
+  },
+  "web.colonel.customDomains.status.resolving": {
+    "text": "Bezig met oplossen"
+  },
+  "web.colonel.customDomains.status.ready": {
+    "text": "Gereed"
+  },
+  "web.colonel.customDomains.status.publicHomepage": {
+    "text": "Openbare homepage"
+  },
+  "web.colonel.customDomains.status.publicApi": {
+    "text": "Openbare API"
+  },
+  "web.colonel.customDomains.status.pending": {
+    "text": "In behandeling"
+  },
+  "web.colonel.pagination.showing": {
+    "text": "{start}–{end} van {total} weergegeven"
+  },
+  "web.colonel.pagination.itemsPerPage": {
+    "text": "Items per pagina"
+  },
+  "web.colonel.pagination.perPage": {
+    "text": "{count} per pagina"
+  },
+  "web.colonel.pagination.pageOf": {
+    "text": "Pagina {current} van {total}"
+  },
+  "web.colonel.secrets.empty": {
+    "text": "Geen berichten gevonden"
+  },
+  "web.colonel.secrets.never": {
+    "text": "Nooit"
+  },
+  "web.colonel.secrets.columns.shortId": {
+    "text": "Korte ID"
+  },
+  "web.colonel.secrets.columns.state": {
+    "text": "Status"
+  },
+  "web.colonel.secrets.columns.created": {
+    "text": "Aangemaakt"
+  },
+  "web.colonel.secrets.columns.expiration": {
+    "text": "Vervaldatum"
+  },
+  "web.colonel.secrets.columns.age": {
+    "text": "Leeftijd (dagen)"
+  },
+  "web.colonel.secrets.state.new": {
+    "text": "Nieuw"
+  },
+  "web.colonel.secrets.state.received": {
+    "text": "Ontvangen"
+  },
+  "web.colonel.secrets.state.viewed": {
+    "text": "Bekeken"
   }
 }

--- a/locales/content/nl/api-account-errors.json
+++ b/locales/content/nl/api-account-errors.json
@@ -1,0 +1,8 @@
+{
+  "api.account.errors.invalid_email": {
+    "text": "Is dat een geldig e-mailadres?"
+  },
+  "api.account.errors.password_too_short": {
+    "text": "Wachtwoord is te kort"
+  }
+}

--- a/locales/content/nl/api-domains-errors.json
+++ b/locales/content/nl/api-domains-errors.json
@@ -1,0 +1,29 @@
+{
+  "api.domains.errors.domain_id_required": {
+    "text": "Domein-ID vereist"
+  },
+  "api.domains.errors.domain_not_found": {
+    "text": "Domein niet gevonden: %{extid}"
+  },
+  "api.domains.errors.organization_not_found": {
+    "text": "Geen organisatie gevonden voor domein: %{domain}"
+  },
+  "api.domains.errors.incoming_secrets_disabled": {
+    "text": "Inkomende berichten zijn niet ingeschakeld op deze instance"
+  },
+  "api.domains.errors.incoming_secrets_entitlement_required": {
+    "text": "Beheer van inkomende berichten vereist de incoming_secrets-entitlement. Upgrade je plan."
+  },
+  "api.domains.errors.incoming_config_not_found": {
+    "text": "Geen inkomende-configuratie gevonden voor domein: %{extid}"
+  },
+  "api.domains.errors.recipients_max_exceeded": {
+    "text": "Maximaal %{max} ontvangers toegestaan"
+  },
+  "api.domains.errors.recipients_invalid_email": {
+    "text": "Ongeldig e-mailadres: %{email}"
+  },
+  "api.domains.errors.recipients_duplicate": {
+    "text": "Dubbele ontvanger-e-mailadressen zijn niet toegestaan"
+  }
+}

--- a/locales/content/nl/api-entitlements-errors.json
+++ b/locales/content/nl/api-entitlements-errors.json
@@ -1,0 +1,71 @@
+{
+  "api.entitlements.errors.context_unavailable": {
+    "text": "Kan entitlements niet verifiëren (organisatiecontext niet beschikbaar)"
+  },
+  "api.entitlements.errors.api_access_required": {
+    "text": "API-toegang vereist een planupgrade"
+  },
+  "api.entitlements.errors.custom_privacy_defaults_required": {
+    "text": "Aangepaste privacystandaarden vereisen een planupgrade"
+  },
+  "api.entitlements.errors.extended_default_expiration_required": {
+    "text": "Verlengde standaardvervaltijd vereist een planupgrade"
+  },
+  "api.entitlements.errors.custom_domains_required": {
+    "text": "Aangepaste domeinen vereisen een planupgrade"
+  },
+  "api.entitlements.errors.custom_branding_required": {
+    "text": "Aangepaste branding vereist een planupgrade"
+  },
+  "api.entitlements.errors.homepage_secrets_required": {
+    "text": "Homepageberichten vereisen een planupgrade"
+  },
+  "api.entitlements.errors.incoming_secrets_required": {
+    "text": "Inkomende berichten vereisen een planupgrade"
+  },
+  "api.entitlements.errors.custom_mail_sender_required": {
+    "text": "Aangepaste e-mailafzender vereist een planupgrade"
+  },
+  "api.entitlements.errors.flexible_from_domain_required": {
+    "text": "Flexibel from-domein vereist een planupgrade"
+  },
+  "api.entitlements.errors.manage_org_required": {
+    "text": "Organisatiebeheer vereist een planupgrade"
+  },
+  "api.entitlements.errors.manage_teams_required": {
+    "text": "Teambeheer vereist een planupgrade"
+  },
+  "api.entitlements.errors.manage_members_required": {
+    "text": "Ledenbeheer vereist een planupgrade"
+  },
+  "api.entitlements.errors.manage_sso_required": {
+    "text": "SSO-beheer vereist een planupgrade"
+  },
+  "api.entitlements.errors.audit_logs_required": {
+    "text": "Auditlogboeken vereisen een planupgrade"
+  },
+  "api.entitlements.errors.custom_signup_validation_required": {
+    "text": "Aangepaste aanmeldvalidatie vereist een planupgrade"
+  },
+  "api.entitlements.errors.create_secrets_required": {
+    "text": "Het aanmaken van berichten vereist een planupgrade"
+  },
+  "api.entitlements.errors.view_receipt_required": {
+    "text": "Het bekijken van ontvangstbewijzen vereist een planupgrade"
+  },
+  "api.entitlements.errors.notifications_required": {
+    "text": "Meldingen vereisen een planupgrade"
+  },
+  "api.entitlements.errors.workspace_branding_required": {
+    "text": "Workspace-branding vereist een planupgrade"
+  },
+  "api.entitlements.errors.ip_access_rules_required": {
+    "text": "IP-toegangsregels vereisen een planupgrade"
+  },
+  "api.entitlements.errors.manage_billing_required": {
+    "text": "Facturatiebeheer vereist een planupgrade"
+  },
+  "api.entitlements.errors.custom_signin_config_required": {
+    "text": "Aangepaste inlogconfiguratie vereist een planupgrade"
+  }
+}

--- a/locales/content/nl/api-feedback-errors.json
+++ b/locales/content/nl/api-feedback-errors.json
@@ -1,0 +1,5 @@
+{
+  "api.feedback.errors.rate_limit_exceeded": {
+    "text": "Te veel feedbackinzendingen. Probeer het later opnieuw."
+  }
+}

--- a/locales/content/nl/api-incoming-errors.json
+++ b/locales/content/nl/api-incoming-errors.json
@@ -1,0 +1,5 @@
+{
+  "api.incoming.errors.custom_domain_unresolved": {
+    "text": "Organisatie van aangepast domein kon niet worden bepaald"
+  }
+}

--- a/locales/content/nl/api-invite-errors.json
+++ b/locales/content/nl/api-invite-errors.json
@@ -1,0 +1,23 @@
+{
+  "api.invite.errors.invitation_not_found_or_expired": {
+    "text": "Uitnodiging niet gevonden of verlopen"
+  },
+  "api.invite.errors.token_required": {
+    "text": "Token is vereist"
+  },
+  "api.invite.errors.organization_no_longer_exists": {
+    "text": "Organisatie bestaat niet meer"
+  },
+  "api.invite.errors.invitation_already_processed": {
+    "text": "Uitnodiging is al %{status}"
+  },
+  "api.invite.errors.invitation_expired": {
+    "text": "Uitnodiging is verlopen"
+  },
+  "api.invite.errors.email_mismatch": {
+    "text": "Je e-mailadres komt niet overeen met de uitnodiging"
+  },
+  "api.invite.errors.already_member": {
+    "text": "Je bent al lid van deze organisatie"
+  }
+}

--- a/locales/content/nl/api-organizations-errors.json
+++ b/locales/content/nl/api-organizations-errors.json
@@ -1,0 +1,107 @@
+{
+  "api.organizations.errors.domain_scoped_forbidden": {
+    "text": "Domeingebonden leden kunnen deze actie niet uitvoeren"
+  },
+  "api.organizations.errors.organization_not_found": {
+    "text": "Organisatie niet gevonden: %{extid}"
+  },
+  "api.organizations.errors.organization_owner_required": {
+    "text": "Alleen de eigenaar van de organisatie kan deze actie uitvoeren"
+  },
+  "api.organizations.errors.organization_member_required": {
+    "text": "Je moet lid van de organisatie zijn om deze actie uit te voeren"
+  },
+  "api.organizations.errors.organization_admin_required": {
+    "text": "Alleen eigenaren en beheerders van de organisatie kunnen deze actie uitvoeren"
+  },
+  "api.organizations.errors.extid_required": {
+    "text": "Organisatie-ID vereist"
+  },
+  "api.organizations.errors.display_name_required": {
+    "text": "Organisatienaam is vereist"
+  },
+  "api.organizations.errors.display_name_too_long": {
+    "text": "Organisatienaam moet minder dan %{max} tekens bevatten"
+  },
+  "api.organizations.errors.description_too_long": {
+    "text": "Beschrijving moet minder dan %{max} tekens bevatten"
+  },
+  "api.organizations.errors.contact_email_exists": {
+    "text": "Er bestaat al een organisatie met dit contact-e-mailadres"
+  },
+  "api.organizations.errors.creation_in_progress": {
+    "text": "Organisatie wordt aangemaakt. Probeer het opnieuw."
+  },
+  "api.organizations.errors.organization_limit_reached": {
+    "text": "Organisatielimiet bereikt. Upgrade je plan om meer organisaties aan te maken."
+  },
+  "api.organizations.invitations.errors.invitation_not_found": {
+    "text": "Uitnodiging niet gevonden"
+  },
+  "api.organizations.invitations.errors.email_required": {
+    "text": "E-mailadres is vereist"
+  },
+  "api.organizations.invitations.errors.invalid_email_format": {
+    "text": "Ongeldig e-mailformaat"
+  },
+  "api.organizations.invitations.errors.invalid_role": {
+    "text": "Rol moet lid of beheerder zijn"
+  },
+  "api.organizations.invitations.errors.cannot_invite_as_owner": {
+    "text": "Kan niet uitnodigen als eigenaar"
+  },
+  "api.organizations.invitations.errors.user_already_member": {
+    "text": "Gebruiker is al lid van deze organisatie"
+  },
+  "api.organizations.invitations.errors.invitation_already_pending": {
+    "text": "Er is al een uitnodiging in behandeling voor dit e-mailadres"
+  },
+  "api.organizations.invitations.errors.member_limit_reached": {
+    "text": "Ledenlimiet bereikt. Upgrade je plan om meer leden uit te nodigen."
+  },
+  "api.organizations.invitations.errors.resend_only_pending": {
+    "text": "Alleen uitnodigingen in behandeling kunnen opnieuw worden verzonden"
+  },
+  "api.organizations.invitations.errors.resend_limit_reached": {
+    "text": "Maximale limiet voor opnieuw verzenden (%{max}) bereikt"
+  },
+  "api.organizations.invitations.errors.revoke_only_pending": {
+    "text": "Alleen uitnodigingen in behandeling kunnen worden ingetrokken"
+  },
+  "api.organizations.members.errors.member_not_found": {
+    "text": "Lid niet gevonden: %{extid}"
+  },
+  "api.organizations.members.errors.member_not_in_organization": {
+    "text": "Lid niet gevonden in deze organisatie"
+  },
+  "api.organizations.members.errors.member_not_active": {
+    "text": "Lid is niet actief"
+  },
+  "api.organizations.members.errors.invalid_role_value": {
+    "text": "Ongeldige rol. Moet een van de volgende zijn: %{roles}"
+  },
+  "api.organizations.members.errors.cannot_change_owner_role": {
+    "text": "Kan de rol van eigenaar niet wijzigen. Gebruik in plaats daarvan eigendomsoverdracht."
+  },
+  "api.organizations.members.errors.member_already_has_role": {
+    "text": "Lid heeft de rol al: %{role}"
+  },
+  "api.organizations.members.errors.cannot_promote_to_owner": {
+    "text": "Kan niet promoveren tot eigenaar. Gebruik in plaats daarvan eigendomsoverdracht."
+  },
+  "api.organizations.members.errors.must_be_member": {
+    "text": "Je moet lid van deze organisatie zijn"
+  },
+  "api.organizations.members.errors.cannot_remove_owner": {
+    "text": "Kan de eigenaar van de organisatie niet verwijderen. Draag eerst het eigendom over."
+  },
+  "api.organizations.members.errors.cannot_remove_self": {
+    "text": "Kan jezelf niet verwijderen. Verlaat in plaats daarvan de organisatie."
+  },
+  "api.organizations.members.errors.admin_cannot_remove_admin": {
+    "text": "Beheerders kunnen geen andere beheerders verwijderen. Alleen eigenaren kunnen dat."
+  },
+  "api.organizations.members.errors.no_permission_to_remove": {
+    "text": "Je hebt geen toestemming om leden te verwijderen"
+  }
+}

--- a/locales/content/nl/api-secrets-errors.json
+++ b/locales/content/nl/api-secrets-errors.json
@@ -1,0 +1,11 @@
+{
+  "api.secrets.errors.domain_permission_authenticated_non_owner": {
+    "text": "Je hebt geen toestemming om domein te gebruiken: %{domain}"
+  },
+  "api.secrets.errors.domain_public_sharing_disabled": {
+    "text": "Openbaar delen uitgeschakeld voor domein: %{domain}"
+  },
+  "api.secrets.errors.domain_permission_anonymous_cross_domain": {
+    "text": "Je hebt geen toestemming om domein te gebruiken: %{domain}"
+  }
+}

--- a/locales/content/nl/email.json
+++ b/locales/content/nl/email.json
@@ -60,7 +60,7 @@
     "source_hash": "88c72144"
   },
   "email.welcome.signature": {
-    "text": "Delano",
+    "text": "Supportteam",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -100,7 +100,7 @@
     "source_hash": "fbb7eb2d"
   },
   "email.password_request.signature": {
-    "text": "Delano",
+    "text": "Supportteam",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -145,7 +145,7 @@
     "source_hash": "1863f5be"
   },
   "email.magic_link.signature": {
-    "text": "Delano",
+    "text": "Supportteam",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -230,7 +230,7 @@
     "source_hash": "3f6b45dd"
   },
   "email.secret_revealed.signature": {
-    "text": "Delano",
+    "text": "Supportteam",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -355,7 +355,7 @@
     "source_hash": "734882d2"
   },
   "email.organization_invitation.signature": {
-    "text": "Delano",
+    "text": "Supportteam",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -395,7 +395,7 @@
     "source_hash": "be92cff3"
   },
   "email.password_changed.signature": {
-    "text": "Delano",
+    "text": "Supportteam",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -445,7 +445,7 @@
     "source_hash": "f8d47b82"
   },
   "email.email_changed.signature": {
-    "text": "Delano",
+    "text": "Supportteam",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -495,7 +495,7 @@
     "source_hash": "f8d47b82"
   },
   "email.email_change_requested.signature": {
-    "text": "Delano",
+    "text": "Supportteam",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -550,7 +550,7 @@
     "source_hash": "d4d835fc"
   },
   "email.email_change_confirmation.signature": {
-    "text": "Delano",
+    "text": "Supportteam",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -580,7 +580,7 @@
     "source_hash": "e7c11bb0"
   },
   "email.mfa_enabled.signature": {
-    "text": "Delano",
+    "text": "Supportteam",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -605,7 +605,7 @@
     "source_hash": "97ef0a3e"
   },
   "email.mfa_disabled.signature": {
-    "text": "Delano",
+    "text": "Supportteam",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -650,7 +650,7 @@
     "source_hash": "450c54c5"
   },
   "email.new_login_alert.signature": {
-    "text": "Delano",
+    "text": "Supportteam",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -670,7 +670,7 @@
     "source_hash": "d442beed"
   },
   "email.member_removed.signature": {
-    "text": "Delano",
+    "text": "Supportteam",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -690,7 +690,7 @@
     "source_hash": "c2280c0c"
   },
   "email.role_changed.signature": {
-    "text": "Delano",
+    "text": "Supportteam",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -710,7 +710,7 @@
     "source_hash": "7095fc69"
   },
   "email.organization_deleted.signature": {
-    "text": "Delano",
+    "text": "Supportteam",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -750,7 +750,7 @@
     "source_hash": "36008943"
   },
   "email.payment_receipt.signature": {
-    "text": "Delano",
+    "text": "Supportteam",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -775,7 +775,7 @@
     "source_hash": "926406b1"
   },
   "email.payment_failed.signature": {
-    "text": "Delano",
+    "text": "Supportteam",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -800,7 +800,7 @@
     "source_hash": "66a1419e"
   },
   "email.trial_expiring.signature": {
-    "text": "Delano",
+    "text": "Supportteam",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -825,7 +825,7 @@
     "source_hash": "5a96ae38"
   },
   "email.subscription_changed.signature": {
-    "text": "Delano",
+    "text": "Supportteam",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -853,5 +853,41 @@
     "text": "Onetime Secret",
     "renderer": "erb",
     "source_hash": "1cd0194a"
+  },
+  "email.common.secret_link_label": {
+    "text": "Beveiligde link"
+  },
+  "email.common.automated_notice": {
+    "text": "Dit is een geautomatiseerd bericht van %{product_name}."
+  },
+  "email.common.support_label": {
+    "text": "Support"
+  },
+  "email.expiration_warning.signature": {
+    "text": "Supportteam"
+  },
+  "email.expiration_warning.footer_note": {
+    "text": "Je hebt dit ontvangen omdat een bericht dat je op %{product_name} hebt aangemaakt binnenkort verloopt."
+  },
+  "email.feedback_email.user_id_label": {
+    "text": "Gebruiker:"
+  },
+  "email.feedback_email.timezone_label": {
+    "text": "Tijdzone:"
+  },
+  "email.feedback_email.version_label": {
+    "text": "Versie:"
+  },
+  "email.incoming_secret.footer_note": {
+    "text": "Je hebt dit ontvangen omdat iemand %{product_name} heeft gebruikt om je een bericht te sturen. Als je dit niet verwachtte, kun je deze e-mail veilig negeren."
+  },
+  "email.secret_link.passphrase_label": {
+    "text": "Wachtwoordzin vereist:"
+  },
+  "email.secret_link.passphrase_required": {
+    "text": "Dit bericht is beveiligd met een wachtwoordzin. De afzender hoort deze apart aan je te verstrekken."
+  },
+  "email.secret_link.footer_note": {
+    "text": "Je hebt dit ontvangen omdat %{sender_email} %{product_name} heeft gebruikt om een bericht met je te delen. Als je dit niet verwachtte, kun je deze e-mail veilig negeren."
   }
 }

--- a/locales/content/nl/feature-feedback.json
+++ b/locales/content/nl/feature-feedback.json
@@ -58,5 +58,14 @@
   "web.feedback.reason_email_change_unauthorized": {
     "text": "Het lijkt erop dat je een ongeautoriseerde wijziging van het e-mailadres op je account meldt. Beschrijf wat er is gebeurd en we onderzoeken het direct.",
     "source_hash": "00e56551"
+  },
+  "web.feedback.anonymous_no_reply": {
+    "text": "Let op: als je een reactie wilt, onderteken het bericht dan of vermeld een e-mailadres erin."
+  },
+  "web.feedback.characters_remaining": {
+    "text": "Nog {count} tekens"
+  },
+  "web.feedback.character_limit_reached": {
+    "text": "Tekenlimiet bereikt"
   }
 }

--- a/locales/content/nl/feature-homepage-secrets.json
+++ b/locales/content/nl/feature-homepage-secrets.json
@@ -1,0 +1,50 @@
+{
+  "homepage_secrets.disabled.members_only_eyebrow": {
+    "text": "Instance alleen voor leden"
+  },
+  "homepage_secrets.disabled.private_instance_eyebrow": {
+    "text": "Privé-instance"
+  },
+  "homepage_secrets.disabled.team_link_headline": {
+    "text": "Deze link is voor het team van {workspace}."
+  },
+  "homepage_secrets.disabled.signin_headline": {
+    "text": "Log in om een {action} aan te maken."
+  },
+  "homepage_secrets.disabled.signin_headline_action": {
+    "text": "beveiligde link"
+  },
+  "homepage_secrets.disabled.team_subtitle": {
+    "text": "Alleen geautoriseerde teamleden bij {domain} kunnen hier nieuwe eenmalige links aanmaken. Ontvangers kunnen nog steeds elke link openen die ze hebben ontvangen."
+  },
+  "homepage_secrets.disabled.public_subtitle": {
+    "text": "Alleen geautoriseerde leden van deze instance kunnen nieuwe eenmalige links aanmaken. Ontvangers kunnen nog steeds elke link openen die ze hebben ontvangen."
+  },
+  "homepage_secrets.disabled.signin_cta": {
+    "text": "Log in op je account"
+  },
+  "homepage_secrets.disabled.what_is_this": {
+    "text": "Wat is dit?"
+  },
+  "homepage_secrets.disabled.trust_viewed_once": {
+    "text": "Eén keer bekeken, daarna weg"
+  },
+  "homepage_secrets.disabled.trust_zero_retained": {
+    "text": "Niets bewaard"
+  },
+  "homepage_secrets.disabled.promo_title": {
+    "text": "Nieuw: gratis plannen bevatten nu aangepaste domeinen."
+  },
+  "homepage_secrets.disabled.promo_subtitle": {
+    "text": "Wijs je domein toe aan Onetime Secret en verstuur berichten onder je eigen merk."
+  },
+  "homepage_secrets.disabled.promo_learn_how": {
+    "text": "Ontdek hoe"
+  },
+  "homepage_secrets.disabled.logo_alt": {
+    "text": "{name}-logo"
+  },
+  "homepage_secrets.disabled.opens_in_new_tab": {
+    "text": "(opent in een nieuw tabblad)"
+  }
+}

--- a/locales/content/nl/feature-incoming.json
+++ b/locales/content/nl/feature-incoming.json
@@ -130,5 +130,26 @@
   "incoming.receipt_link_text": {
     "text": "ontvangstbewijs",
     "source_hash": "6f328609"
+  },
+  "incoming.upgrade_required_title": {
+    "text": "Upgrade vereist"
+  },
+  "incoming.upgrade_required_description": {
+    "text": "Deze functie vereist een planupgrade. Neem contact op met de accounteigenaar om inkomende berichten in te schakelen."
+  },
+  "incoming.validation_memo_too_long": {
+    "text": "Memo mag maximaal {max} tekens bevatten"
+  },
+  "incoming.validation_secret_required": {
+    "text": "Berichtinhoud is vereist"
+  },
+  "incoming.validation_recipient_required": {
+    "text": "Selecteer een ontvanger"
+  },
+  "incoming.validation_feature_disabled": {
+    "text": "Functie voor inkomende berichten is niet ingeschakeld"
+  },
+  "incoming.validation_form_errors": {
+    "text": "Controleer het formulier op fouten"
   }
 }

--- a/locales/content/nl/feature-regions.json
+++ b/locales/content/nl/feature-regions.json
@@ -152,7 +152,7 @@
     "source_hash": "1d97f6bd"
   },
   "web.regions.changing_regions_billing_note": {
-    "text": "Als je factuurcontact-e-mailadres verschilt van je {product_name}-account-e-mailadres, gebruik dan het factuurcontact-e-mailadres voor het nieuwe regio-account om je abonnementsvoordelen te behouden.",
+    "text": "Als je e-mailadres voor facturatie afwijkt van het e-mailadres van je {product_name}-account, gebruik dan het e-mailadres voor facturatie voor het account in de nieuwe regio om de voordelen van je abonnement te behouden.",
     "source_hash": "dac1cc28"
   },
   "web.regions.changing_regions_subscription_note": {
@@ -186,5 +186,8 @@
   "web.regions.jurisdictions.apac.name": {
     "text": "Asia-Pacific",
     "source_hash": "7a757670"
+  },
+  "web.regions.no_region_configured": {
+    "text": "Er is momenteel geen regio-informatie beschikbaar voor je account."
   }
 }

--- a/locales/content/nl/feature-translations.json
+++ b/locales/content/nl/feature-translations.json
@@ -64,7 +64,7 @@
     "source_hash": "13131e36"
   },
   "web.translations.the_following_people_have_donated_their_time_to_": {
-    "text": "De volgende mensen hebben hun tijd gedoneerd om het bereik van {product_name} te helpen uitbreiden:",
+    "text": "De volgende mensen hebben hun tijd gedoneerd om het bereik van {product_name} te helpen vergroten:",
     "source_hash": "85a766af"
   },
   "web.translations.translations": {
@@ -84,7 +84,7 @@
     "source_hash": "ba5c4395"
   },
   "web.translations.since_2012_onetime_secret_has_provided_a_secure_": {
-    "text": "Sinds 2012 biedt {product_name} wereldwijd een veilige manier om gevoelige informatie te delen. Met gebruikers in regio's waar Engels niet de primaire taal is, zijn nauwkeurige vertalingen essentieel om veilige communicatie voor iedereen toegankelijk te maken.",
+    "text": "Sinds 2012 biedt {product_name} een beveiligde manier om gevoelige informatie wereldwijd te delen. Met gebruikers in regio's waar Engels niet de hoofdtaal is, zijn nauwkeurige vertalingen essentieel om beveiligde communicatie voor iedereen toegankelijk te maken.",
     "source_hash": "87a6e9af"
   },
   "web.translations.help_secure_communication_go_global": {

--- a/locales/content/nl/secret-homepage.json
+++ b/locales/content/nl/secret-homepage.json
@@ -56,7 +56,7 @@
     "source_hash": "5e218489"
   },
   "web.homepage.visit_onetime_secret_home": {
-    "text": "Bezoek {product_name} homepage",
+    "text": "Bezoek de homepage van {product_name}",
     "source_hash": "625556d2"
   },
   "web.homepage.password_generation_title": {
@@ -112,7 +112,7 @@
     "source_hash": "971c50da"
   },
   "web.homepage.log_in_to_onetime_secret": {
-    "text": "Log in bij {product_name}",
+    "text": "Inloggen bij {product_name}",
     "source_hash": "bd6be8d6"
   },
   "web.homepage.about_onetime_secret": {
@@ -148,7 +148,7 @@
     "source_hash": "7872e050"
   },
   "web.homepage.onetime_secret_homepage": {
-    "text": "{product_name} homepage",
+    "text": "{product_name} Homepage",
     "source_hash": "44bb0581"
   },
   "web.homepage.send_sensitive_information_that_can_only_be_viewed_once": {
@@ -172,7 +172,7 @@
     "source_hash": "0990d163"
   },
   "web.homepage.onetime_secret_helps_us_share_sensitive_informat": {
-    "text": "{product_name} helpt ons gevoelige informatie veilig te delen terwijl we onze professionele uitstraling behouden.",
+    "text": "{product_name} helpt ons gevoelige informatie veilig te delen met behoud van onze professionele uitstraling.",
     "source_hash": "986a0856"
   },
   "web.homepage.information_shared_through_this_service_can_only": {

--- a/locales/content/nl/secret-manage.json
+++ b/locales/content/nl/secret-manage.json
@@ -128,7 +128,7 @@
     "source_hash": "07fe1b84"
   },
   "web.secrets.onetime_secret_is_a_secure_way_to_share_sensitiv": {
-    "text": "{product_name} is een veilige manier om gevoelige informatie te delen die zichzelf vernietigt na één keer bekijken.",
+    "text": "{product_name} is een beveiligde manier om gevoelige informatie te delen die zichzelf vernietigt na één keer bekijken.",
     "source_hash": "8a163297"
   },
   "web.secrets.what_is_this": {
@@ -470,5 +470,11 @@
   },
   "web.private.send_feedback": {
     "text": "Feedback verzenden"
+  },
+  "web.receipt.open_link": {
+    "text": "Link openen"
+  },
+  "web.secrets.messageDeleted": {
+    "text": "Bericht verwijderd"
   }
 }

--- a/locales/content/nl/session-auth-extended.json
+++ b/locales/content/nl/session-auth-extended.json
@@ -716,5 +716,20 @@
   },
   "web.auth.sessions._guidance.context": {
     "text": "Beheerpagina voor ingelogde apparaten/browsers van de gebruiker"
+  },
+  "web.auth.google": {
+    "text": "Google"
+  },
+  "web.auth.mfa.alternative_auth_options": {
+    "text": "Alternatieve authenticatieopties"
+  },
+  "web.auth.remember.enabled": {
+    "text": "Ingelogd blijven"
+  },
+  "web.auth.sessions.session_singular": {
+    "text": "sessie"
+  },
+  "web.auth.sessions.session_plural": {
+    "text": "sessies"
   }
 }

--- a/locales/content/nl/session-auth.json
+++ b/locales/content/nl/session-auth.json
@@ -398,5 +398,32 @@
   },
   "web.auth.verify._guidance.context": {
     "text": "E-mailverificatieproces na aanmelden"
+  },
+  "web.auth.account.sso_linked": {
+    "text": "SSO-account"
+  },
+  "web.help.reset_password_link": {
+    "text": "Wachtwoord opnieuw instellen"
+  },
+  "web.login.custom_domain_sso_title": {
+    "text": "Single sign-on is beschikbaar voor dit domein"
+  },
+  "web.login.custom_domain_sso_description": {
+    "text": "De beheerder van de organisatie kan SSO inschakelen zodat teamleden hier kunnen inloggen. Neem contact op met de beheerder voor toegang."
+  },
+  "web.login.signin_disabled_heading": {
+    "text": "Inloggen is niet beschikbaar"
+  },
+  "web.login.signin_disabled_message": {
+    "text": "Inloggen is momenteel niet beschikbaar op dit domein."
+  },
+  "web.login.errors.sso_not_configured": {
+    "text": "Single sign-on is niet geconfigureerd voor dit domein. Neem contact op met je beheerder."
+  },
+  "web.login.errors.invalid_email": {
+    "text": "Het e-mailadres van je identity provider is ongeldig. Neem contact op met je beheerder."
+  },
+  "web.login.errors.domain_not_allowed": {
+    "text": "Je e-maildomein is niet geautoriseerd voor SSO-aanmelding. Neem contact op met je beheerder."
   }
 }

--- a/locales/content/nl/workspace-account.json
+++ b/locales/content/nl/workspace-account.json
@@ -476,7 +476,7 @@
     "source_hash": "1cc77e60"
   },
   "web.settings.api.documentation_description": {
-    "text": "Leer hoe je {product_name} integreert in je applicaties",
+    "text": "Ontdek hoe je {product_name} in je applicaties integreert",
     "source_hash": "6e8f910f"
   },
   "web.settings.api.rest_api_reference": {
@@ -682,5 +682,14 @@
   "web.settings.profile.didnt_receive_email": {
     "text": "E-mail niet ontvangen?",
     "source_hash": "fe3ac3ad"
+  },
+  "web.settings.api.api_disabled_notice": {
+    "text": "De API is uitgeschakeld voor deze instance."
+  },
+  "web.settings.security.sso_managed_title": {
+    "text": "Beveiliging beheerd door SSO"
+  },
+  "web.settings.security.sso_managed_description": {
+    "text": "Je account wordt geverifieerd via de single sign-on-provider van je organisatie. Wachtwoord, multifactorauthenticatie en herstelcodes worden beheerd door je identity provider."
   }
 }

--- a/locales/content/nl/workspace-billing.json
+++ b/locales/content/nl/workspace-billing.json
@@ -988,5 +988,47 @@
     "text": "Alleen beschikbaar in je oorspronkelijke abonnementsregio",
     "context": "Hint shown on plan cards when currency does not match active subscription",
     "source_hash": "10de32e5"
+  },
+  "web.billing.already_subscribed": {
+    "text": "Je bent al geabonneerd op dit plan."
+  },
+  "web.billing.cancel.reactivate_button": {
+    "text": "Abonnement opnieuw activeren"
+  },
+  "web.billing.cancel.reactivate_success": {
+    "text": "Je abonnement is opnieuw geactiveerd. Je wordt op de normale manier verder gefactureerd."
+  },
+  "web.billing.cancel.reactivate_error": {
+    "text": "Opnieuw activeren van het abonnement is mislukt. Probeer het opnieuw of neem contact op met support."
+  },
+  "web.billing.features.manage_orgs": {
+    "text": "Organisatiebeheer"
+  },
+  "web.billing.features.flexible_from_domain": {
+    "text": "Flexibel e-mailafzenderdomein"
+  },
+  "web.billing.features.unlimited_admins": {
+    "text": "Onbeperkt aantal beheerders"
+  },
+  "web.billing.features.manage_sso": {
+    "text": "SSO"
+  },
+  "web.billing.overview.entitlements.flexible_from_domain": {
+    "text": "Flexibel e-mailafzenderdomein"
+  },
+  "web.billing.overview.entitlements.manage_orgs": {
+    "text": "Organisaties beheren"
+  },
+  "web.billing.overview.entitlements.manage_sso": {
+    "text": "Single sign-on (SSO)"
+  },
+  "web.billing.overview.entitlements.manage_billing": {
+    "text": "Facturatie beheren"
+  },
+  "web.billing.overview.entitlements.custom_signup_validation": {
+    "text": "Aangepaste aanmeldingsvalidatie"
+  },
+  "web.billing.plans.reactivate": {
+    "text": "Opnieuw activeren"
   }
 }

--- a/locales/content/nl/workspace-branding.json
+++ b/locales/content/nl/workspace-branding.json
@@ -178,5 +178,11 @@
   "web.branding.upgrade_to_customize": {
     "text": "Upgrade je plan om de branding voor dit domein aan te passen.",
     "source_hash": "9077bf79"
+  },
+  "web.branding.saved_successfully": {
+    "text": "Brandinginstellingen succesvol opgeslagen"
+  },
+  "web.branding.keyhole_logo_icon": {
+    "text": "Sleutelgatpictogram dat beveiligd, privé delen voorstelt"
   }
 }

--- a/locales/content/nl/workspace-dashboard.json
+++ b/locales/content/nl/workspace-dashboard.json
@@ -22,5 +22,14 @@
   "web.dashboard.fetch_error_description": {
     "text": "Er was een probleem bij het laden van je gegevens. Probeer het opnieuw.",
     "source_hash": "ff0d904e"
+  },
+  "web.teams.create_first_team_title": {
+    "text": "Maak je eerste team aan"
+  },
+  "web.teams.create_first_team_description": {
+    "text": "Met teams kun je samenwerken met anderen in een gedeelde workspace."
+  },
+  "web.teams.create_team": {
+    "text": "Team aanmaken"
   }
 }

--- a/locales/content/nl/workspace-dashboard.json
+++ b/locales/content/nl/workspace-dashboard.json
@@ -27,7 +27,7 @@
     "text": "Maak je eerste team aan"
   },
   "web.teams.create_first_team_description": {
-    "text": "Met teams kun je samenwerken met anderen in een gedeelde workspace."
+    "text": "Met teams kun je samenwerken met anderen in een gedeelde werkruimte."
   },
   "web.teams.create_team": {
     "text": "Team aanmaken"

--- a/locales/content/nl/workspace-domains.json
+++ b/locales/content/nl/workspace-domains.json
@@ -846,5 +846,389 @@
   "web.domains.sso.not_configured_notice": {
     "text": "SSO is nog niet geconfigureerd voor dit domein. Schakel single sign-on in om teamleden te laten authenticeren via de identiteitsprovider van je organisatie.",
     "source_hash": "c439214b"
+  },
+  "api.domains.errors.add_admin_required": {
+    "text": "Alleen eigenaren en beheerders van de organisatie kunnen aangepaste domeinen toevoegen"
+  },
+  "web.domains.public_homepage": {
+    "text": "Openbare homepage"
+  },
+  "web.domains.status_tooltip_active": {
+    "text": "Domein geverifieerd en actief"
+  },
+  "web.domains.status_tooltip_dns_incorrect": {
+    "text": "DNS niet geconfigureerd — klik om te herstellen"
+  },
+  "web.domains.status_tooltip_not_verified": {
+    "text": "Domein niet geverifieerd — klik om te verifiëren"
+  },
+  "web.domains.status_tooltip_unverified": {
+    "text": "Domeinstatus niet geverifieerd — klik om te vernieuwen"
+  },
+  "web.domains.last_check_failed": {
+    "text": "Laatste verificatiecontrole mislukt"
+  },
+  "web.domains.last_check_failed_ago": {
+    "text": "laatste controle mislukt {0}"
+  },
+  "web.domains.verify_now": {
+    "text": "Nu verifiëren"
+  },
+  "web.domains.click_to_verify": {
+    "text": "klik om te verifiëren"
+  },
+  "web.domains.remove_domain_description": {
+    "text": "Verwijder dit domein en alle bijbehorende configuratie permanent."
+  },
+  "web.domains.add_access_denied": {
+    "text": "Toegang geweigerd"
+  },
+  "web.domains.add_access_denied_description": {
+    "text": "Je hebt geen toestemming om domeinen aan deze organisatie toe te voegen. Neem contact op met de beheerder van je organisatie."
+  },
+  "web.domains.dns_widget_load_failed": {
+    "text": "Laden van DNS-widget mislukt"
+  },
+  "web.domains.dns_widget_not_available": {
+    "text": "DNS-widget niet beschikbaar"
+  },
+  "web.domains.dns_widget_init_failed": {
+    "text": "Initialiseren van DNS-widget mislukt"
+  },
+  "web.domains.verified": {
+    "text": "Geverifieerd"
+  },
+  "web.domains.pending_verification": {
+    "text": "Verificatie in behandeling"
+  },
+  "web.domains.unsaved_changes_confirmation": {
+    "text": "Je hebt niet-opgeslagen wijzigingen. Weet je zeker dat je wilt vertrekken?"
+  },
+  "web.domains.entitlement_required_owner": {
+    "text": "Deze functie vereist een planupgrade."
+  },
+  "web.domains.entitlement_required_member": {
+    "text": "Deze functie is niet beschikbaar in je huidige plan. Neem contact op met de eigenaar van je organisatie."
+  },
+  "web.domains.detail.manage": {
+    "text": "Beheren"
+  },
+  "web.domains.detail.features": {
+    "text": "Functies"
+  },
+  "web.domains.detail.homepage_title": {
+    "text": "Homepageberichten"
+  },
+  "web.domains.detail.homepage_description": {
+    "text": "Sta openbare toegang toe om berichten aan te maken op de homepage van je domein"
+  },
+  "web.domains.detail.brand_description": {
+    "text": "Logo, kleuren en aangepaste branding"
+  },
+  "web.domains.detail.sso_description": {
+    "text": "Instellingen voor single sign-on-provider"
+  },
+  "web.domains.detail.email_description": {
+    "text": "Configuratie voor aangepaste e-mailafzender"
+  },
+  "web.domains.detail.incoming_description": {
+    "text": "Instellingen voor ontvangers van inkomende berichten"
+  },
+  "web.domains.detail.signup_description": {
+    "text": "Aanmeldingsvalidatiestrategie per domein"
+  },
+  "web.domains.detail.signin_description": {
+    "text": "Configuratie van inlogmethode per domein"
+  },
+  "web.domains.email.dns_check_label": {
+    "text": "DNS"
+  },
+  "web.domains.email.provider_check_label": {
+    "text": "Provider"
+  },
+  "web.domains.email.test_email_title": {
+    "text": "E-mailbezorging testen"
+  },
+  "web.domains.email.test_email_hint": {
+    "text": "Stuur jezelf een test-e-mail met de opgeslagen configuratie. Werkt zelfs wanneer de functie nog niet is ingeschakeld."
+  },
+  "web.domains.email.send_test": {
+    "text": "Test versturen"
+  },
+  "web.domains.email.test_email_sent": {
+    "text": "Test-e-mail succesvol verstuurd"
+  },
+  "web.domains.email.test_email_failed": {
+    "text": "Versturen van test-e-mail mislukt"
+  },
+  "web.domains.email.test_email_sent_to": {
+    "text": "Verstuurd naar {email}"
+  },
+  "web.domains.email.delivered_via": {
+    "text": "Bezorgd via {provider}"
+  },
+  "web.domains.incoming.feature_disabled": {
+    "text": "Inkomende berichten niet beschikbaar"
+  },
+  "web.domains.incoming.feature_disabled_description": {
+    "text": "Inkomende berichten is niet ingeschakeld op deze instance. Neem contact op met je beheerder."
+  },
+  "web.domains.signin.title": {
+    "text": "Inlogconfiguratie"
+  },
+  "web.domains.signin.configure_signin": {
+    "text": "Inloggen configureren"
+  },
+  "web.domains.signin.config_description": {
+    "text": "Configureer authenticatiemethoden voor inloggen op dit domein"
+  },
+  "web.domains.signin.access_denied": {
+    "text": "Toegang geweigerd"
+  },
+  "web.domains.signin.upgrade_to_configure": {
+    "text": "Upgrade je plan om inlogmethoden voor dit domein te configureren."
+  },
+  "web.domains.signin.not_configured_notice": {
+    "text": "De inlogconfiguratie is nog niet ingesteld voor dit domein. Configureer overrides om te bepalen welke authenticatiemethoden beschikbaar zijn op de inlogpagina van dit domein."
+  },
+  "web.domains.signin.signin_enabled_label": {
+    "text": "Inloggen ingeschakeld"
+  },
+  "web.domains.signin.header_toggle_label": {
+    "text": "Inloggen"
+  },
+  "web.domains.signin.signin_enabled_hint": {
+    "text": "Of gebruikers kunnen inloggen op dit domein"
+  },
+  "web.domains.signin.restrict_to_label": {
+    "text": "Inlogmethode beperken"
+  },
+  "web.domains.signin.restrict_to_hint": {
+    "text": "Beperk dit domein tot één authenticatiemethode. Wanneer ingesteld, wordt alleen de gekozen methode op de inlogpagina getoond."
+  },
+  "web.domains.signin.all_methods": {
+    "text": "Alle methoden"
+  },
+  "web.domains.signin.all_methods_description": {
+    "text": "Toon alle ingeschakelde authenticatiemethoden op de inlogpagina"
+  },
+  "web.domains.signin.method_password": {
+    "text": "Wachtwoord"
+  },
+  "web.domains.signin.method_email_auth": {
+    "text": "E-mailauthenticatie"
+  },
+  "web.domains.signin.method_webauthn": {
+    "text": "WebAuthn / Passkeys"
+  },
+  "web.domains.signin.method_sso": {
+    "text": "Single sign-on"
+  },
+  "web.domains.signin.method_overrides_label": {
+    "text": "Methode-overrides"
+  },
+  "web.domains.signin.method_overrides_hint": {
+    "text": "Schakel individuele authenticatiemethoden voor dit domein in of uit"
+  },
+  "web.domains.signin.mode_question": {
+    "text": "Hoe kunnen gebruikers inloggen?"
+  },
+  "web.domains.signin.mode_any": {
+    "text": "Elke beschikbare methode"
+  },
+  "web.domains.signin.mode_any_hint": {
+    "text": "Toon elke methode die op dit domein beschikbaar is. Beperk individuele methoden hieronder."
+  },
+  "web.domains.signin.mode_one": {
+    "text": "Eén specifieke methode"
+  },
+  "web.domains.signin.mode_one_hint": {
+    "text": "Beperk de inlogpagina tot één methode. Alleen methoden die op dit domein beschikbaar zijn, worden vermeld."
+  },
+  "web.domains.signin.mode_disabled": {
+    "text": "Inloggen uitgeschakeld"
+  },
+  "web.domains.signin.mode_disabled_hint": {
+    "text": "Gebruikers kunnen niet inloggen op dit domein."
+  },
+  "web.domains.signin.mode_disabled_notice": {
+    "text": "Bezoekers van de inlogpagina van dit domein zien een melding dat inloggen niet beschikbaar is, met een link terug naar de homepage. Je vorige methode-instellingen worden bewaard en hersteld wanneer je inloggen opnieuw inschakelt."
+  },
+  "web.domains.signin.methods_list_label": {
+    "text": "Methoden getoond op de inlogpagina"
+  },
+  "web.domains.signin.restrict_picker_hint": {
+    "text": "Alleen methoden die op dit domein beschikbaar zijn, worden vermeld."
+  },
+  "web.domains.signin.availability_always": {
+    "text": "Altijd beschikbaar"
+  },
+  "web.domains.signin.availability_global_on": {
+    "text": "Volgt globaal beleid · Aan"
+  },
+  "web.domains.signin.availability_global_off": {
+    "text": "Niet beschikbaar"
+  },
+  "web.domains.signin.availability_unavailable": {
+    "text": "Niet beschikbaar voor de hele site"
+  },
+  "web.domains.signin.allow_on_domain": {
+    "text": "Toestaan op dit domein"
+  },
+  "web.domains.signin.method_password_blurb": {
+    "text": "Alleen wachtwoord"
+  },
+  "web.domains.signin.method_email_auth_blurb": {
+    "text": "Wachtwoordloos inloggen met magic link"
+  },
+  "web.domains.signin.method_webauthn_blurb": {
+    "text": "Biometrie en beveiligingssleutels"
+  },
+  "web.domains.signin.method_sso_blurb": {
+    "text": "Externe identity provider"
+  },
+  "web.domains.signin.email_auth_label": {
+    "text": "E-mailauthenticatie"
+  },
+  "web.domains.signin.email_auth_hint": {
+    "text": "Sta wachtwoordloze e-mailauthenticatie toe op dit domein"
+  },
+  "web.domains.signin.sso_enabled_label": {
+    "text": "Single sign-on"
+  },
+  "web.domains.signin.sso_enabled_hint": {
+    "text": "Sta SSO-authenticatie toe op dit domein"
+  },
+  "web.domains.signin.enabled_label": {
+    "text": "Inlogconfiguratie inschakelen"
+  },
+  "web.domains.signin.enabled_hint": {
+    "text": "Wanneer ingeschakeld, gebruikt dit domein de hierboven geconfigureerde inloginstellingen"
+  },
+  "web.domains.signin.save_config": {
+    "text": "Configuratie opslaan"
+  },
+  "web.domains.signin.update_success": {
+    "text": "Inlogconfiguratie succesvol bijgewerkt"
+  },
+  "web.domains.signin.reset_to_defaults": {
+    "text": "Terugzetten naar standaardwaarden"
+  },
+  "web.domains.signin.reset_confirm": {
+    "text": "Inloggen terugzetten naar de globale standaardwaarden?"
+  },
+  "web.domains.signin.reset_keeps_sso": {
+    "text": "Je SSO-inloggegevens worden bewaard. Verwijder ze apart op het SSO-configuratiescherm."
+  },
+  "web.domains.signin.reset_action": {
+    "text": "Ja, terugzetten"
+  },
+  "web.domains.signin.reset_success": {
+    "text": "Inloginstellingen teruggezet naar de globale standaardwaarden"
+  },
+  "web.domains.signup.title": {
+    "text": "Aanmeldingsvalidatie"
+  },
+  "web.domains.signup.config_description": {
+    "text": "Configureer aanmeldingsvalidatie voor dit domein"
+  },
+  "web.domains.signup.access_denied": {
+    "text": "Toegang geweigerd"
+  },
+  "web.domains.signup.upgrade_to_configure": {
+    "text": "Upgrade je plan om aanmeldingsvalidatie per domein te configureren."
+  },
+  "web.domains.signup.configure_signup": {
+    "text": "Aanmelding configureren"
+  },
+  "web.domains.signup.not_configured_notice": {
+    "text": "Aanmeldingsvalidatie is nog niet geconfigureerd voor dit domein. Configureer een strategie om te bepalen wie zich via dit domein kan aanmelden."
+  },
+  "web.domains.signup.site_signups_disabled_warning": {
+    "text": "Aanmeldingen zijn momenteel uitgeschakeld op siteniveau. Dit beleid per domein is geconfigureerd, maar zal geen verkeer beperken totdat aanmeldingen op de site zijn ingeschakeld."
+  },
+  "web.domains.signup.strategy_label": {
+    "text": "Validatiestrategie"
+  },
+  "web.domains.signup.strategy_description": {
+    "text": "Kies hoe e-mailadressen worden gevalideerd wanneer gebruikers zich op dit domein aanmelden."
+  },
+  "web.domains.signup.network_validation_warning": {
+    "text": "Deze strategie voert netwerkaanroepen uit tijdens de aanmelding, wat extra latentie kan veroorzaken of door sommige providers kan worden geblokkeerd."
+  },
+  "web.domains.signup.allowed_domains_label": {
+    "text": "Toegestane aanmeldingsdomeinen"
+  },
+  "web.domains.signup.allowed_domains_hint": {
+    "text": "Alleen deze e-maildomeinen mogen zich aanmelden. Voeg één domein per item toe."
+  },
+  "web.domains.signup.domain_placeholder": {
+    "text": "example.com"
+  },
+  "web.domains.signup.invalid_domain": {
+    "text": "Voer een geldig domein in (bijv. example.com)"
+  },
+  "web.domains.signup.domain_exists": {
+    "text": "Dit domein staat al in de lijst"
+  },
+  "web.domains.signup.remove_domain": {
+    "text": "{domain} verwijderen"
+  },
+  "web.domains.signup.enabled_label": {
+    "text": "Validatie per domein inschakelen"
+  },
+  "web.domains.signup.enabled_hint": {
+    "text": "Wanneer ingeschakeld, gebruiken aanmeldingen op dit domein de bovenstaande strategie in plaats van het globale beleid."
+  },
+  "web.domains.signup.delete_config": {
+    "text": "Configuratie verwijderen"
+  },
+  "web.domains.signup.delete_confirm": {
+    "text": "Configuratie voor aanmeldingsvalidatie verwijderen? Aanmeldingen vallen terug op het globale beleid."
+  },
+  "web.domains.signup.save_config": {
+    "text": "Configuratie opslaan"
+  },
+  "web.domains.signup.update_success": {
+    "text": "Aanmeldingsvalidatie succesvol bijgewerkt"
+  },
+  "web.domains.signup.delete_success": {
+    "text": "Configuratie voor aanmeldingsvalidatie succesvol verwijderd"
+  },
+  "web.domains.signup.domain_overrides_label": {
+    "text": "Domein-overrides"
+  },
+  "web.domains.signup.domain_overrides_hint": {
+    "text": "Overschrijf globale aanmeldingsinstellingen voor dit domein"
+  },
+  "web.domains.signup.signup_enabled_label": {
+    "text": "Aanmelding ingeschakeld"
+  },
+  "web.domains.signup.signup_enabled_hint": {
+    "text": "Overschrijf of aanmelding is ingeschakeld voor dit domein"
+  },
+  "web.domains.signup.autoverify_label": {
+    "text": "Accounts automatisch verifiëren"
+  },
+  "web.domains.signup.autoverify_hint": {
+    "text": "Overschrijf of nieuwe accounts automatisch worden geverifieerd op dit domein"
+  },
+  "web.domains.sso.test_success": {
+    "text": "Verbindingstest geslaagd — provider reageerde correct"
+  },
+  "web.domains.sso.test_failed": {
+    "text": "Verbindingstest mislukt"
+  },
+  "web.domains.sso.enforce_moved_notice": {
+    "text": "Om SSO te vereisen voor alle inlogpogingen op dit domein, configureer je dit in de inloginstellingen van het domein. De SSO-only-modus beperkt de inlogpagina tot de hier geconfigureerde SSO-provider."
+  },
+  "web.domains.sso.edit_credentials": {
+    "text": "Inloggegevens bewerken"
+  },
+  "web.domains.sso.configure_button": {
+    "text": "Configureren"
+  },
+  "web.domains.sso.upgrade_required": {
+    "text": "Upgrade om te configureren"
   }
 }

--- a/locales/content/nl/workspace-organizations.json
+++ b/locales/content/nl/workspace-organizations.json
@@ -850,7 +850,7 @@
     "text": "Organisatie-entitlements"
   },
   "web.organizations.page_description_short": {
-    "text": "Bekijk en configureer je workspaces"
+    "text": "Bekijk en configureer je werkruimtes"
   },
   "web.organizations.delete_organization_remove_domains_first": {
     "text": "Verwijder alle aangepaste domeinen voordat je deze organisatie verwijdert."

--- a/locales/content/nl/workspace-organizations.json
+++ b/locales/content/nl/workspace-organizations.json
@@ -770,5 +770,200 @@
   "web.organizations.sso.status_not_configured": {
     "text": "Niet geconfigureerd",
     "source_hash": "bbea960e"
+  },
+  "api.organizations.errors.not_found": {
+    "text": "Organisatie niet gevonden: %{extid}"
+  },
+  "api.organizations.errors.owner_required": {
+    "text": "Alleen de eigenaar van de organisatie kan deze actie uitvoeren"
+  },
+  "api.organizations.errors.admin_required": {
+    "text": "Alleen eigenaren en beheerders van de organisatie kunnen deze actie uitvoeren"
+  },
+  "api.organizations.errors.member_required": {
+    "text": "Je moet lid zijn van de organisatie om deze actie uit te voeren"
+  },
+  "api.organizations.invitations.errors.create_admin_required": {
+    "text": "Alleen eigenaren en beheerders van de organisatie kunnen uitnodigingen aanmaken"
+  },
+  "api.organizations.invitations.errors.resend_admin_required": {
+    "text": "Alleen eigenaren en beheerders van de organisatie kunnen uitnodigingen opnieuw versturen"
+  },
+  "api.organizations.invitations.errors.view_admin_required": {
+    "text": "Alleen eigenaren en beheerders van de organisatie kunnen uitnodigingen bekijken"
+  },
+  "api.organizations.invitations.errors.revoke_admin_required": {
+    "text": "Alleen eigenaren en beheerders van de organisatie kunnen uitnodigingen intrekken"
+  },
+  "api.organizations.invitations.errors.email_required": {
+    "text": "E-mail is verplicht"
+  },
+  "api.organizations.invitations.errors.email_invalid": {
+    "text": "Ongeldige e-mailindeling"
+  },
+  "api.organizations.invitations.errors.role_invalid": {
+    "text": "Rol moet lid of beheerder zijn"
+  },
+  "api.organizations.invitations.errors.cannot_invite_owner": {
+    "text": "Kan niet uitnodigen als eigenaar"
+  },
+  "api.organizations.invitations.errors.already_member": {
+    "text": "Gebruiker is al lid van deze organisatie"
+  },
+  "api.organizations.invitations.errors.already_pending": {
+    "text": "Er is al een uitnodiging in behandeling voor dit e-mailadres"
+  },
+  "api.organizations.invitations.errors.member_limit_reached": {
+    "text": "Ledenlimiet bereikt. Upgrade je plan om meer leden uit te nodigen."
+  },
+  "api.organizations.invitations.errors.not_found": {
+    "text": "Uitnodiging niet gevonden"
+  },
+  "api.organizations.invitations.errors.cannot_resend_non_pending": {
+    "text": "Alleen uitnodigingen in behandeling kunnen opnieuw worden verstuurd"
+  },
+  "api.organizations.invitations.errors.cannot_revoke_non_pending": {
+    "text": "Alleen uitnodigingen in behandeling kunnen worden ingetrokken"
+  },
+  "api.organizations.invitations.errors.resend_limit_reached": {
+    "text": "Maximale limiet voor opnieuw versturen (%{max}) bereikt"
+  },
+  "api.organizations.invitations.errors.accept_token_required": {
+    "text": "Token is verplicht"
+  },
+  "api.organizations.invitations.errors.accept_organization_gone": {
+    "text": "Organisatie bestaat niet meer"
+  },
+  "api.organizations.invitations.errors.accept_already_acted": {
+    "text": "Uitnodiging is al %{status}"
+  },
+  "api.organizations.invitations.errors.accept_expired": {
+    "text": "Uitnodiging is verlopen"
+  },
+  "api.organizations.invitations.errors.accept_email_mismatch": {
+    "text": "Je e-mailadres komt niet overeen met de uitnodiging"
+  },
+  "api.organizations.invitations.errors.accept_already_member": {
+    "text": "Je bent al lid van deze organisatie"
+  },
+  "web.organizations.entitlements_title": {
+    "text": "Organisatie-entitlements"
+  },
+  "web.organizations.page_description_short": {
+    "text": "Bekijk en configureer je workspaces"
+  },
+  "web.organizations.delete_organization_remove_domains_first": {
+    "text": "Verwijder alle aangepaste domeinen voordat je deze organisatie verwijdert."
+  },
+  "web.organizations.default_org_delete_notice_title": {
+    "text": "Deze organisatie verwijderen"
+  },
+  "web.organizations.default_org_delete_notice_before": {
+    "text": "Dit is je standaardorganisatie en kan niet vanuit het dashboard worden verwijderd. Neem voor het verwijderen contact op via het"
+  },
+  "web.organizations.default_org_delete_notice_link": {
+    "text": "feedbackformulier"
+  },
+  "web.organizations.default_org_delete_notice_after": {
+    "text": "."
+  },
+  "web.organizations.leave_organization": {
+    "text": "Deze organisatie verlaten"
+  },
+  "web.organizations.leave_organization_warning": {
+    "text": "Je verliest de toegang tot deze organisatie en haar resources."
+  },
+  "web.organizations.leave_organization_confirm_title": {
+    "text": "Organisatie verlaten"
+  },
+  "web.organizations.leave_organization_confirm_message": {
+    "text": "Weet je zeker dat je {name} wilt verlaten? Je hebt een nieuwe uitnodiging nodig om opnieuw lid te worden."
+  },
+  "web.organizations.leave_organization_success": {
+    "text": "Je hebt de organisatie verlaten."
+  },
+  "web.organizations.leave_error": {
+    "text": "Organisatie verlaten is mislukt"
+  },
+  "web.organizations.organizations": {
+    "text": "Organisaties"
+  },
+  "web.organizations.invitations.invited_by_inline": {
+    "text": "door {email}"
+  },
+  "web.organizations.invitations.invited_as_inline": {
+    "text": "als {role}"
+  },
+  "web.organizations.invitations.back_to_home": {
+    "text": "Terug naar home"
+  },
+  "web.organizations.invitations.email_locked_hint": {
+    "text": "Deze uitnodiging is naar dit e-mailadres verzonden"
+  },
+  "web.organizations.invitations.signup_continue": {
+    "text": "Doorgaan"
+  },
+  "web.organizations.invitations.signin_continue": {
+    "text": "Inloggen"
+  },
+  "web.organizations.invitations.confirm_join_below": {
+    "text": "Bijna klaar — bevestig hieronder om lid te worden van de organisatie."
+  },
+  "web.organizations.invitations.go_to_organizations": {
+    "text": "Naar Organisaties"
+  },
+  "web.organizations.invitations.already_member": {
+    "text": "Je bent al lid van deze organisatie"
+  },
+  "web.organizations.invitations.join_organization": {
+    "text": "Lid worden van {orgName}"
+  },
+  "web.organizations.invitations.sign_in_to_join": {
+    "text": "Log in om lid te worden van {orgName}"
+  },
+  "web.organizations.invitations.decline": {
+    "text": "Afwijzen"
+  },
+  "web.organizations.members.member_quota": {
+    "text": "{used} van {limit} leden"
+  },
+  "web.organizations.members.pending_suffix": {
+    "text": "({count} in behandeling)"
+  },
+  "web.organizations.members.limit_reached_hint": {
+    "text": "Ledenlimiet bereikt."
+  },
+  "web.organizations.sso.view_discovery_document": {
+    "text": "Discovery-document bekijken"
+  },
+  "web.organizations.sso.callback_url": {
+    "text": "Callback URL"
+  },
+  "web.organizations.sso.callback_url_hint": {
+    "text": "Voeg deze URL toe aan de toegestane redirect-URI's van je identity provider"
+  },
+  "web.organizations.sso.enforce_sso_only": {
+    "text": "Alleen SSO afdwingen"
+  },
+  "web.organizations.sso.enforce_sso_only_hint": {
+    "text": "Vereis SSO voor alle aanmeldingen op dit domein. Wanneer ingeschakeld, wordt authenticatie met wachtwoord uitgeschakeld."
+  },
+  "web.organizations.sso.grant_org_scope": {
+    "text": "Organisatiebrede toegang verlenen"
+  },
+  "web.organizations.sso.grant_org_scope_hint": {
+    "text": "Nieuwe leden die via de SSO van dit domein lid worden, krijgen toegang tot alle domeinen van de organisatie. Bestaande leden worden niet beïnvloed. Wanneer uitgeschakeld (standaard), hebben nieuwe leden alleen toegang tot dit domein."
+  },
+  "web.organizations.sso.no_domains": {
+    "text": "Geen geverifieerde domeinen"
+  },
+  "web.organizations.sso.no_domains_description": {
+    "text": "Voeg een domein toe en verifieer het voordat je er SSO voor configureert."
+  },
+  "web.organizations.tabs.team": {
+    "text": "Team"
+  },
+  "web.organizations.tabs.sso": {
+    "text": "SSO"
   }
 }


### PR DESCRIPTION
## `nl` translation update

Automated export of completed **nl** translations from the translation task DB.
Scope: `locales/content/nl/` only — 27 file(s), +1360/-31.

⚠️ `i18n validate variables` reports **1** variable mismatch(es) for `nl` (empty values that drop source variables, renamed/extra vars, etc.) — see the review below.

> ⚠️ `main` has also modified `locales/content/nl/` since this branch was cut — it may need a rebase/merge before it is conflict-free.

---

### Local quality review

> Produced by a fresh, isolated `claude` review agent (model `claude-sonnet-5`, agent `saas-translator`) that read
> `locales/AGENT_TRANSLATION_PROTOCOL.md` and inspected this branch's diff before the PR was opened.

**Verdict:** ⚠️ Needs review — pre-existing var defect, terminology drift

**Summary:** New keys (~1,400 strings across colonel, domains, orgs, billing, entitlements, auth) preserve variables and brand terms correctly, and the `Delano` → `Supportteam` signature swap is applied uniformly. One pre-existing critical variable defect surfaces via the automated check but is not introduced by this diff; one terminology inconsistency was introduced.

**Critical (must fix):**
- `email.email_changed.body.text` (email.json, not touched by this diff) carries an extra `%{date}` not present in the English source. Pre-existing defect, validator-surfaced — fix separately from this branch, but should not ship unaddressed.

**Warnings:**
- "Workspace" left untranslated in new keys (`web.footer.workspace`: "Workspace", `web.teams.create_first_team_description`: "...gedeelde workspace", `web.organizations.page_description_short`: "...je workspaces") while the existing `web.layout.workspace_context` uses "Werkruimtecontext". Confirm intended glossary term — pick one rendering and apply consistently.

**Notes:**
- `web.homepage.onetime_secret_homepage` changed from "{product_name} homepage" to "{product_name} Homepage" (capital H) — Dutch doesn't capitalize common nouns mid-sentence; likely unintentional style drift, low impact.
- All newly added interpolation tokens ({ip}, {start}/{end}/{total}, {count}, %{extid}, %{max}, {domain}, {0}, %{sender_email}, {product_name}, etc.) verified present and matched in count/order.
- SSO kept as loanword/partially translated ("Single sign-on") consistent with existing nl usage elsewhere in the file set.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
