### PR TITLE
i18n: update pl translations

### DIFF
--- a/locales/content/pl/00-common.json
+++ b/locales/content/pl/00-common.json
@@ -1383,5 +1383,110 @@
     "text": "Ulepsz plan, aby odblokować więcej funkcji",
     "context": "Description shown for free plan users encouraging upgrade",
     "source_hash": "783f174c"
+  },
+  "api.errors.authentication_required": {
+    "text": "Wymagane uwierzytelnienie"
+  },
+  "api.errors.sso_only_action_blocked": {
+    "text": "Ta akcja nie jest dostępna w trybie wyłącznie SSO"
+  },
+  "web.COMMON.configure": {
+    "text": "Konfiguruj"
+  },
+  "web.COMMON.copy_to_clipboard": {
+    "text": "Kopiuj do schowka"
+  },
+  "web.COMMON.add": {
+    "text": "Dodaj"
+  },
+  "web.COMMON.enabled": {
+    "text": "Włączone"
+  },
+  "web.COMMON.disabled": {
+    "text": "Wyłączone"
+  },
+  "web.COMMON.yes_delete": {
+    "text": "Tak, usuń"
+  },
+  "web.COMMON.error_code": {
+    "text": "Kod błędu"
+  },
+  "web.COMMON.http_status": {
+    "text": "Status HTTP"
+  },
+  "web.COMMON.details": {
+    "text": "Szczegóły"
+  },
+  "web.COMMON.field_confirm_password": {
+    "text": "Potwierdź hasło"
+  },
+  "web.COMMON.passwords_must_match": {
+    "text": "Hasła muszą być takie same"
+  },
+  "web.COMMON.and": {
+    "text": "i"
+  },
+  "web.COMMON.or": {
+    "text": "lub"
+  },
+  "web.COMMON.copied": {
+    "text": "Skopiowano"
+  },
+  "web.COMMON.copy": {
+    "text": "Kopiuj"
+  },
+  "web.COMMON.copy_email": {
+    "text": "Kopiuj adres e-mail"
+  },
+  "web.COMMON.copy_id": {
+    "text": "Kopiuj identyfikator konta"
+  },
+  "web.COMMON.org_id_tooltip": {
+    "text": "Unikalny identyfikator Twojej organizacji"
+  },
+  "web.COMMON.success": {
+    "text": "Sukces"
+  },
+  "web.COMMON.need_help": {
+    "text": "Potrzebujesz pomocy"
+  },
+  "web.COMMON.open_help_dialog": {
+    "text": "Otwórz okno pomocy"
+  },
+  "web.COMMON.focus_is_now_in_the_main_text_area": {
+    "text": "Fokus znajduje się teraz w głównym obszarze tekstowym"
+  },
+  "web.LABELS.show_passphrase": {
+    "text": "Pokaż frazę dostępową"
+  },
+  "web.LABELS.hide_passphrase": {
+    "text": "Ukryj frazę dostępową"
+  },
+  "web.LABELS.copy_icon": {
+    "text": "Ikona kopiowania"
+  },
+  "web.LABELS.copied_icon": {
+    "text": "Ikona skopiowania"
+  },
+  "web.STATUS.unverified": {
+    "text": "Niezweryfikowany"
+  },
+  "web.TITLES.domain_detail": {
+    "text": "Ustawienia domeny"
+  },
+  "web.TITLES.domain_signin": {
+    "text": "Konfiguracja logowania"
+  },
+  "web.TITLES.domain_sso": {
+    "text": "SSO domeny"
+  },
+  "web.TITLES.domain_signup": {
+    "text": "Walidacja rejestracji w domenie"
+  },
+  "web.TITLES.domain_email": {
+    "text": "Konfiguracja e-mail"
+  },
+  "web.TITLES.domain_incoming": {
+    "text": "Przychodzące sekrety"
   }
 }

--- a/locales/content/pl/10-layout.json
+++ b/locales/content/pl/10-layout.json
@@ -338,5 +338,11 @@
   "web.layout.workspace_context": {
     "text": "Kontekst przestrzeni roboczej",
     "source_hash": "dc6fa4f5"
+  },
+  "web.footer.workspace": {
+    "text": "Obszar roboczy"
+  },
+  "web.help.default_content": {
+    "text": "Skontaktuj się z pomocą techniczną, aby uzyskać wsparcie"
   }
 }

--- a/locales/content/pl/admin-colonel.json
+++ b/locales/content/pl/admin-colonel.json
@@ -634,5 +634,152 @@
   "web.colonel.feedback.when_you_submit_feedback_well_see": {
     "text": "Gdy wyślesz opinię, zobaczymy:",
     "source_hash": "fe77172e"
+  },
+  "web.colonel.previewPlanMode": {
+    "text": "Tryb podglądu planu"
+  },
+  "web.colonel.previewModeDescription": {
+    "text": "Podejrzyj aplikację w takiej postaci, w jakiej widzą ją klienci korzystający z innego planu. Wpływa to wyłącznie na Twój widok i nie zmienia rzeczywistego planu żadnej organizacji."
+  },
+  "web.colonel.previewModeActive": {
+    "text": "Podgląd aktywny"
+  },
+  "web.colonel.bannedIps.empty": {
+    "text": "Brak zablokowanych adresów IP"
+  },
+  "web.colonel.bannedIps.currentIp": {
+    "text": "Twój bieżący adres IP"
+  },
+  "web.colonel.bannedIps.confirmUnban": {
+    "text": "Odblokować {ip}?"
+  },
+  "web.colonel.bannedIps.actions.ban": {
+    "text": "Zablokuj IP"
+  },
+  "web.colonel.bannedIps.actions.quickBan": {
+    "text": "Szybka blokada"
+  },
+  "web.colonel.bannedIps.actions.unban": {
+    "text": "Odblokuj"
+  },
+  "web.colonel.bannedIps.actions.cancel": {
+    "text": "Anuluj"
+  },
+  "web.colonel.bannedIps.columns.ipAddress": {
+    "text": "Adres IP"
+  },
+  "web.colonel.bannedIps.columns.reason": {
+    "text": "Powód"
+  },
+  "web.colonel.bannedIps.columns.bannedAt": {
+    "text": "Zablokowano"
+  },
+  "web.colonel.bannedIps.columns.bannedBy": {
+    "text": "Zablokowane przez"
+  },
+  "web.colonel.bannedIps.error.banFailed": {
+    "text": "Nie udało się zablokować adresu IP"
+  },
+  "web.colonel.bannedIps.error.unbanFailed": {
+    "text": "Nie udało się odblokować adresu IP"
+  },
+  "web.colonel.bannedIps.form.title": {
+    "text": "Zablokuj adres IP"
+  },
+  "web.colonel.bannedIps.form.ipLabel": {
+    "text": "Adres IP"
+  },
+  "web.colonel.bannedIps.form.reasonLabel": {
+    "text": "Powód"
+  },
+  "web.colonel.bannedIps.form.reasonPlaceholder": {
+    "text": "Opcjonalny powód"
+  },
+  "web.colonel.bannedIps.success.banned": {
+    "text": "Adres IP {ip} został zablokowany"
+  },
+  "web.colonel.bannedIps.success.unbanned": {
+    "text": "Adres IP {ip} został odblokowany"
+  },
+  "web.colonel.customDomains.empty": {
+    "text": "Nie skonfigurowano żadnych domen niestandardowych"
+  },
+  "web.colonel.customDomains.noLogo": {
+    "text": "Brak logo"
+  },
+  "web.colonel.customDomains.labels.organization": {
+    "text": "Organizacja"
+  },
+  "web.colonel.customDomains.labels.externalId": {
+    "text": "Identyfikator zewnętrzny"
+  },
+  "web.colonel.customDomains.labels.created": {
+    "text": "Utworzono"
+  },
+  "web.colonel.customDomains.labels.updated": {
+    "text": "Zaktualizowano"
+  },
+  "web.colonel.customDomains.labels.favicon": {
+    "text": "Favicon"
+  },
+  "web.colonel.customDomains.status.verified": {
+    "text": "Zweryfikowano"
+  },
+  "web.colonel.customDomains.status.resolving": {
+    "text": "Rozwiązywanie"
+  },
+  "web.colonel.customDomains.status.ready": {
+    "text": "Gotowe"
+  },
+  "web.colonel.customDomains.status.publicHomepage": {
+    "text": "Publiczna strona główna"
+  },
+  "web.colonel.customDomains.status.publicApi": {
+    "text": "Publiczne API"
+  },
+  "web.colonel.customDomains.status.pending": {
+    "text": "Oczekuje"
+  },
+  "web.colonel.pagination.showing": {
+    "text": "Wyświetlanie {start}–{end} z {total}"
+  },
+  "web.colonel.pagination.itemsPerPage": {
+    "text": "Elementów na stronę"
+  },
+  "web.colonel.pagination.perPage": {
+    "text": "{count} na stronę"
+  },
+  "web.colonel.pagination.pageOf": {
+    "text": "Strona {current} z {total}"
+  },
+  "web.colonel.secrets.empty": {
+    "text": "Nie znaleziono żadnych sekretów"
+  },
+  "web.colonel.secrets.never": {
+    "text": "Nigdy"
+  },
+  "web.colonel.secrets.columns.shortId": {
+    "text": "Krótki identyfikator"
+  },
+  "web.colonel.secrets.columns.state": {
+    "text": "Stan"
+  },
+  "web.colonel.secrets.columns.created": {
+    "text": "Utworzono"
+  },
+  "web.colonel.secrets.columns.expiration": {
+    "text": "Wygaśnięcie"
+  },
+  "web.colonel.secrets.columns.age": {
+    "text": "Wiek (dni)"
+  },
+  "web.colonel.secrets.state.new": {
+    "text": "Nowy"
+  },
+  "web.colonel.secrets.state.received": {
+    "text": "Otrzymany"
+  },
+  "web.colonel.secrets.state.viewed": {
+    "text": "Wyświetlony"
   }
 }

--- a/locales/content/pl/api-account-errors.json
+++ b/locales/content/pl/api-account-errors.json
@@ -1,0 +1,8 @@
+{
+  "api.account.errors.invalid_email": {
+    "text": "Czy to prawidłowy adres e-mail?"
+  },
+  "api.account.errors.password_too_short": {
+    "text": "Hasło jest za krótkie"
+  }
+}

--- a/locales/content/pl/api-domains-errors.json
+++ b/locales/content/pl/api-domains-errors.json
@@ -1,0 +1,29 @@
+{
+  "api.domains.errors.domain_id_required": {
+    "text": "Wymagany identyfikator domeny"
+  },
+  "api.domains.errors.domain_not_found": {
+    "text": "Nie znaleziono domeny: %{extid}"
+  },
+  "api.domains.errors.organization_not_found": {
+    "text": "Nie znaleziono organizacji dla domeny: %{domain}"
+  },
+  "api.domains.errors.incoming_secrets_disabled": {
+    "text": "Przychodzące sekrety nie są włączone w tej instancji"
+  },
+  "api.domains.errors.incoming_secrets_entitlement_required": {
+    "text": "Zarządzanie przychodzącymi sekretami wymaga uprawnienia incoming_secrets. Ulepsz swój plan."
+  },
+  "api.domains.errors.incoming_config_not_found": {
+    "text": "Nie znaleziono konfiguracji przychodzącej dla domeny: %{extid}"
+  },
+  "api.domains.errors.recipients_max_exceeded": {
+    "text": "Maksymalna liczba dozwolonych odbiorców: %{max}"
+  },
+  "api.domains.errors.recipients_invalid_email": {
+    "text": "Nieprawidłowy adres e-mail: %{email}"
+  },
+  "api.domains.errors.recipients_duplicate": {
+    "text": "Zduplikowane adresy e-mail odbiorców są niedozwolone"
+  }
+}

--- a/locales/content/pl/api-entitlements-errors.json
+++ b/locales/content/pl/api-entitlements-errors.json
@@ -1,0 +1,71 @@
+{
+  "api.entitlements.errors.context_unavailable": {
+    "text": "Nie można zweryfikować uprawnień (kontekst organizacji niedostępny)"
+  },
+  "api.entitlements.errors.api_access_required": {
+    "text": "Dostęp do API wymaga ulepszenia planu"
+  },
+  "api.entitlements.errors.custom_privacy_defaults_required": {
+    "text": "Niestandardowe domyślne ustawienia prywatności wymagają ulepszenia planu"
+  },
+  "api.entitlements.errors.extended_default_expiration_required": {
+    "text": "Rozszerzone domyślne wygaśnięcie wymaga ulepszenia planu"
+  },
+  "api.entitlements.errors.custom_domains_required": {
+    "text": "Domeny niestandardowe wymagają ulepszenia planu"
+  },
+  "api.entitlements.errors.custom_branding_required": {
+    "text": "Niestandardowy branding wymaga ulepszenia planu"
+  },
+  "api.entitlements.errors.homepage_secrets_required": {
+    "text": "Sekrety na stronie głównej wymagają ulepszenia planu"
+  },
+  "api.entitlements.errors.incoming_secrets_required": {
+    "text": "Przychodzące sekrety wymagają ulepszenia planu"
+  },
+  "api.entitlements.errors.custom_mail_sender_required": {
+    "text": "Niestandardowy nadawca poczty wymaga ulepszenia planu"
+  },
+  "api.entitlements.errors.flexible_from_domain_required": {
+    "text": "Elastyczna domena nadawcy wymaga ulepszenia planu"
+  },
+  "api.entitlements.errors.manage_org_required": {
+    "text": "Zarządzanie organizacją wymaga ulepszenia planu"
+  },
+  "api.entitlements.errors.manage_teams_required": {
+    "text": "Zarządzanie zespołami wymaga ulepszenia planu"
+  },
+  "api.entitlements.errors.manage_members_required": {
+    "text": "Zarządzanie członkami wymaga ulepszenia planu"
+  },
+  "api.entitlements.errors.manage_sso_required": {
+    "text": "Zarządzanie SSO wymaga ulepszenia planu"
+  },
+  "api.entitlements.errors.audit_logs_required": {
+    "text": "Logi audytu wymagają ulepszenia planu"
+  },
+  "api.entitlements.errors.custom_signup_validation_required": {
+    "text": "Niestandardowa walidacja rejestracji wymaga ulepszenia planu"
+  },
+  "api.entitlements.errors.create_secrets_required": {
+    "text": "Tworzenie sekretów wymaga ulepszenia planu"
+  },
+  "api.entitlements.errors.view_receipt_required": {
+    "text": "Wyświetlanie potwierdzeń wymaga ulepszenia planu"
+  },
+  "api.entitlements.errors.notifications_required": {
+    "text": "Powiadomienia wymagają ulepszenia planu"
+  },
+  "api.entitlements.errors.workspace_branding_required": {
+    "text": "Branding obszaru roboczego wymaga ulepszenia planu"
+  },
+  "api.entitlements.errors.ip_access_rules_required": {
+    "text": "Reguły dostępu IP wymagają ulepszenia planu"
+  },
+  "api.entitlements.errors.manage_billing_required": {
+    "text": "Zarządzanie płatnościami wymaga ulepszenia planu"
+  },
+  "api.entitlements.errors.custom_signin_config_required": {
+    "text": "Niestandardowa konfiguracja logowania wymaga ulepszenia planu"
+  }
+}

--- a/locales/content/pl/api-feedback-errors.json
+++ b/locales/content/pl/api-feedback-errors.json
@@ -1,0 +1,5 @@
+{
+  "api.feedback.errors.rate_limit_exceeded": {
+    "text": "Zbyt wiele przesłanych opinii. Spróbuj ponownie później."
+  }
+}

--- a/locales/content/pl/api-incoming-errors.json
+++ b/locales/content/pl/api-incoming-errors.json
@@ -1,0 +1,5 @@
+{
+  "api.incoming.errors.custom_domain_unresolved": {
+    "text": "Nie można ustalić organizacji dla domeny niestandardowej"
+  }
+}

--- a/locales/content/pl/api-invite-errors.json
+++ b/locales/content/pl/api-invite-errors.json
@@ -9,7 +9,7 @@
     "text": "Organizacja już nie istnieje"
   },
   "api.invite.errors.invitation_already_processed": {
-    "text": "Zaproszenie zostało już %{status}"
+    "text": "Zaproszenie zostało już obsłużone: %{status}"
   },
   "api.invite.errors.invitation_expired": {
     "text": "Zaproszenie wygasło"

--- a/locales/content/pl/api-invite-errors.json
+++ b/locales/content/pl/api-invite-errors.json
@@ -1,0 +1,23 @@
+{
+  "api.invite.errors.invitation_not_found_or_expired": {
+    "text": "Nie znaleziono zaproszenia lub wygasło"
+  },
+  "api.invite.errors.token_required": {
+    "text": "Token jest wymagany"
+  },
+  "api.invite.errors.organization_no_longer_exists": {
+    "text": "Organizacja już nie istnieje"
+  },
+  "api.invite.errors.invitation_already_processed": {
+    "text": "Zaproszenie zostało już %{status}"
+  },
+  "api.invite.errors.invitation_expired": {
+    "text": "Zaproszenie wygasło"
+  },
+  "api.invite.errors.email_mismatch": {
+    "text": "Twój adres e-mail nie pasuje do zaproszenia"
+  },
+  "api.invite.errors.already_member": {
+    "text": "Jesteś już członkiem tej organizacji"
+  }
+}

--- a/locales/content/pl/api-organizations-errors.json
+++ b/locales/content/pl/api-organizations-errors.json
@@ -1,0 +1,107 @@
+{
+  "api.organizations.errors.domain_scoped_forbidden": {
+    "text": "Członkowie ograniczeni do domeny nie mogą wykonać tej akcji"
+  },
+  "api.organizations.errors.organization_not_found": {
+    "text": "Nie znaleziono organizacji: %{extid}"
+  },
+  "api.organizations.errors.organization_owner_required": {
+    "text": "Tylko właściciel organizacji może wykonać tę akcję"
+  },
+  "api.organizations.errors.organization_member_required": {
+    "text": "Aby wykonać tę akcję, musisz być członkiem organizacji"
+  },
+  "api.organizations.errors.organization_admin_required": {
+    "text": "Tylko właściciele i administratorzy organizacji mogą wykonać tę akcję"
+  },
+  "api.organizations.errors.extid_required": {
+    "text": "Wymagany jest identyfikator organizacji"
+  },
+  "api.organizations.errors.display_name_required": {
+    "text": "Nazwa organizacji jest wymagana"
+  },
+  "api.organizations.errors.display_name_too_long": {
+    "text": "Nazwa organizacji musi mieć mniej niż %{max} znaków"
+  },
+  "api.organizations.errors.description_too_long": {
+    "text": "Opis musi mieć mniej niż %{max} znaków"
+  },
+  "api.organizations.errors.contact_email_exists": {
+    "text": "Organizacja z tym kontaktowym adresem e-mail już istnieje"
+  },
+  "api.organizations.errors.creation_in_progress": {
+    "text": "Trwa tworzenie organizacji. Spróbuj ponownie."
+  },
+  "api.organizations.errors.organization_limit_reached": {
+    "text": "Osiągnięto limit organizacji. Ulepsz swój plan, aby utworzyć więcej organizacji."
+  },
+  "api.organizations.invitations.errors.invitation_not_found": {
+    "text": "Nie znaleziono zaproszenia"
+  },
+  "api.organizations.invitations.errors.email_required": {
+    "text": "Adres e-mail jest wymagany"
+  },
+  "api.organizations.invitations.errors.invalid_email_format": {
+    "text": "Nieprawidłowy format adresu e-mail"
+  },
+  "api.organizations.invitations.errors.invalid_role": {
+    "text": "Rola musi być członek lub administrator"
+  },
+  "api.organizations.invitations.errors.cannot_invite_as_owner": {
+    "text": "Nie można zaprosić jako właściciel"
+  },
+  "api.organizations.invitations.errors.user_already_member": {
+    "text": "Użytkownik jest już członkiem tej organizacji"
+  },
+  "api.organizations.invitations.errors.invitation_already_pending": {
+    "text": "Zaproszenie dla tego adresu e-mail już oczekuje"
+  },
+  "api.organizations.invitations.errors.member_limit_reached": {
+    "text": "Osiągnięto limit członków. Ulepsz swój plan, aby zaprosić więcej członków."
+  },
+  "api.organizations.invitations.errors.resend_only_pending": {
+    "text": "Można ponownie wysłać tylko oczekujące zaproszenia"
+  },
+  "api.organizations.invitations.errors.resend_limit_reached": {
+    "text": "Osiągnięto maksymalny limit ponownych wysyłek (%{max})"
+  },
+  "api.organizations.invitations.errors.revoke_only_pending": {
+    "text": "Można cofnąć tylko oczekujące zaproszenia"
+  },
+  "api.organizations.members.errors.member_not_found": {
+    "text": "Nie znaleziono członka: %{extid}"
+  },
+  "api.organizations.members.errors.member_not_in_organization": {
+    "text": "Nie znaleziono członka w tej organizacji"
+  },
+  "api.organizations.members.errors.member_not_active": {
+    "text": "Członek nie jest aktywny"
+  },
+  "api.organizations.members.errors.invalid_role_value": {
+    "text": "Nieprawidłowa rola. Musi być jedną z: %{roles}"
+  },
+  "api.organizations.members.errors.cannot_change_owner_role": {
+    "text": "Nie można zmienić roli właściciela. Zamiast tego użyj przeniesienia własności."
+  },
+  "api.organizations.members.errors.member_already_has_role": {
+    "text": "Członek ma już rolę: %{role}"
+  },
+  "api.organizations.members.errors.cannot_promote_to_owner": {
+    "text": "Nie można awansować do roli właściciela. Zamiast tego użyj przeniesienia własności."
+  },
+  "api.organizations.members.errors.must_be_member": {
+    "text": "Musisz być członkiem tej organizacji"
+  },
+  "api.organizations.members.errors.cannot_remove_owner": {
+    "text": "Nie można usunąć właściciela organizacji. Najpierw przenieś własność."
+  },
+  "api.organizations.members.errors.cannot_remove_self": {
+    "text": "Nie możesz usunąć samego siebie. Zamiast tego opuść organizację."
+  },
+  "api.organizations.members.errors.admin_cannot_remove_admin": {
+    "text": "Administratorzy nie mogą usuwać innych administratorów. Mogą to robić tylko właściciele."
+  },
+  "api.organizations.members.errors.no_permission_to_remove": {
+    "text": "Nie masz uprawnień do usuwania członków"
+  }
+}

--- a/locales/content/pl/api-secrets-errors.json
+++ b/locales/content/pl/api-secrets-errors.json
@@ -1,0 +1,11 @@
+{
+  "api.secrets.errors.domain_permission_authenticated_non_owner": {
+    "text": "Nie masz uprawnień do używania domeny: %{domain}"
+  },
+  "api.secrets.errors.domain_public_sharing_disabled": {
+    "text": "Udostępnianie publiczne wyłączone dla domeny: %{domain}"
+  },
+  "api.secrets.errors.domain_permission_anonymous_cross_domain": {
+    "text": "Nie masz uprawnień do używania domeny: %{domain}"
+  }
+}

--- a/locales/content/pl/email.json
+++ b/locales/content/pl/email.json
@@ -60,7 +60,7 @@
     "source_hash": "88c72144"
   },
   "email.welcome.signature": {
-    "text": "Delano",
+    "text": "Zespół pomocy technicznej",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -100,7 +100,7 @@
     "source_hash": "fbb7eb2d"
   },
   "email.password_request.signature": {
-    "text": "Delano",
+    "text": "Zespół pomocy technicznej",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -145,7 +145,7 @@
     "source_hash": "1863f5be"
   },
   "email.magic_link.signature": {
-    "text": "Delano",
+    "text": "Zespół pomocy technicznej",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -230,7 +230,7 @@
     "source_hash": "3f6b45dd"
   },
   "email.secret_revealed.signature": {
-    "text": "Delano",
+    "text": "Zespół pomocy technicznej",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -355,7 +355,7 @@
     "source_hash": "734882d2"
   },
   "email.organization_invitation.signature": {
-    "text": "Delano",
+    "text": "Zespół pomocy technicznej",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -395,7 +395,7 @@
     "source_hash": "be92cff3"
   },
   "email.password_changed.signature": {
-    "text": "Delano",
+    "text": "Zespół pomocy technicznej",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -445,7 +445,7 @@
     "source_hash": "f8d47b82"
   },
   "email.email_changed.signature": {
-    "text": "Delano",
+    "text": "Zespół pomocy technicznej",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -495,7 +495,7 @@
     "source_hash": "f8d47b82"
   },
   "email.email_change_requested.signature": {
-    "text": "Delano",
+    "text": "Zespół pomocy technicznej",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -550,7 +550,7 @@
     "source_hash": "d4d835fc"
   },
   "email.email_change_confirmation.signature": {
-    "text": "Delano",
+    "text": "Zespół pomocy technicznej",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -580,7 +580,7 @@
     "source_hash": "e7c11bb0"
   },
   "email.mfa_enabled.signature": {
-    "text": "Delano",
+    "text": "Zespół pomocy technicznej",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -605,7 +605,7 @@
     "source_hash": "97ef0a3e"
   },
   "email.mfa_disabled.signature": {
-    "text": "Delano",
+    "text": "Zespół pomocy technicznej",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -650,7 +650,7 @@
     "source_hash": "450c54c5"
   },
   "email.new_login_alert.signature": {
-    "text": "Delano",
+    "text": "Zespół pomocy technicznej",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -670,7 +670,7 @@
     "source_hash": "d442beed"
   },
   "email.member_removed.signature": {
-    "text": "Delano",
+    "text": "Zespół pomocy technicznej",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -690,7 +690,7 @@
     "source_hash": "c2280c0c"
   },
   "email.role_changed.signature": {
-    "text": "Delano",
+    "text": "Zespół pomocy technicznej",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -710,7 +710,7 @@
     "source_hash": "7095fc69"
   },
   "email.organization_deleted.signature": {
-    "text": "Delano",
+    "text": "Zespół pomocy technicznej",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -750,7 +750,7 @@
     "source_hash": "36008943"
   },
   "email.payment_receipt.signature": {
-    "text": "Delano",
+    "text": "Zespół pomocy technicznej",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -775,7 +775,7 @@
     "source_hash": "926406b1"
   },
   "email.payment_failed.signature": {
-    "text": "Delano",
+    "text": "Zespół pomocy technicznej",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -800,7 +800,7 @@
     "source_hash": "66a1419e"
   },
   "email.trial_expiring.signature": {
-    "text": "Delano",
+    "text": "Zespół pomocy technicznej",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -825,7 +825,7 @@
     "source_hash": "5a96ae38"
   },
   "email.subscription_changed.signature": {
-    "text": "Delano",
+    "text": "Zespół pomocy technicznej",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -853,5 +853,41 @@
     "text": "Onetime Secret",
     "renderer": "erb",
     "source_hash": "1cd0194a"
+  },
+  "email.common.secret_link_label": {
+    "text": "Link do sekretu"
+  },
+  "email.common.automated_notice": {
+    "text": "To jest automatyczna wiadomość od %{product_name}."
+  },
+  "email.common.support_label": {
+    "text": "Pomoc techniczna"
+  },
+  "email.expiration_warning.signature": {
+    "text": "Zespół pomocy technicznej"
+  },
+  "email.expiration_warning.footer_note": {
+    "text": "Otrzymujesz tę wiadomość, ponieważ sekret utworzony przez Ciebie w %{product_name} wkrótce wygaśnie."
+  },
+  "email.feedback_email.user_id_label": {
+    "text": "Użytkownik:"
+  },
+  "email.feedback_email.timezone_label": {
+    "text": "Strefa czasowa:"
+  },
+  "email.feedback_email.version_label": {
+    "text": "Wersja:"
+  },
+  "email.incoming_secret.footer_note": {
+    "text": "Otrzymujesz tę wiadomość, ponieważ ktoś użył %{product_name}, aby wysłać Ci sekret. Jeśli się tego nie spodziewałeś, możesz bezpiecznie zignorować tę wiadomość."
+  },
+  "email.secret_link.passphrase_label": {
+    "text": "Wymagana fraza dostępowa:"
+  },
+  "email.secret_link.passphrase_required": {
+    "text": "Ten sekret jest chroniony frazą dostępową. Nadawca powinien przekazać Ci ją oddzielnie."
+  },
+  "email.secret_link.footer_note": {
+    "text": "Otrzymujesz tę wiadomość, ponieważ %{sender_email} użył %{product_name}, aby udostępnić Ci sekret. Jeśli się tego nie spodziewałeś, możesz bezpiecznie zignorować tę wiadomość."
   }
 }

--- a/locales/content/pl/feature-feedback.json
+++ b/locales/content/pl/feature-feedback.json
@@ -58,5 +58,14 @@
   "web.feedback.reason_email_change_unauthorized": {
     "text": "Wygląda na to, że zgłaszasz nieautoryzowaną zmianę adresu e-mail na swoim koncie. Opisz, co się stało, a my natychmiast to zbadamy.",
     "source_hash": "00e56551"
+  },
+  "web.feedback.anonymous_no_reply": {
+    "text": "Uwaga: jeśli chcesz otrzymać odpowiedź, podpisz się lub podaj adres e-mail w wiadomości."
+  },
+  "web.feedback.characters_remaining": {
+    "text": "Pozostało znaków: {count}"
+  },
+  "web.feedback.character_limit_reached": {
+    "text": "Osiągnięto limit znaków"
   }
 }

--- a/locales/content/pl/feature-homepage-secrets.json
+++ b/locales/content/pl/feature-homepage-secrets.json
@@ -1,0 +1,50 @@
+{
+  "homepage_secrets.disabled.members_only_eyebrow": {
+    "text": "Instancja tylko dla członków"
+  },
+  "homepage_secrets.disabled.private_instance_eyebrow": {
+    "text": "Prywatna instancja"
+  },
+  "homepage_secrets.disabled.team_link_headline": {
+    "text": "Ten link jest przeznaczony dla zespołu {workspace}."
+  },
+  "homepage_secrets.disabled.signin_headline": {
+    "text": "Zaloguj się, aby utworzyć {action}."
+  },
+  "homepage_secrets.disabled.signin_headline_action": {
+    "text": "link do sekretu"
+  },
+  "homepage_secrets.disabled.team_subtitle": {
+    "text": "Tylko upoważnieni członkowie zespołu w {domain} mogą tworzyć tutaj nowe jednorazowe linki. Odbiorcy nadal mogą otwierać każdy otrzymany link."
+  },
+  "homepage_secrets.disabled.public_subtitle": {
+    "text": "Tylko upoważnieni członkowie tej instancji mogą tworzyć nowe jednorazowe linki. Odbiorcy nadal mogą otwierać każdy otrzymany link."
+  },
+  "homepage_secrets.disabled.signin_cta": {
+    "text": "Zaloguj się do swojego konta"
+  },
+  "homepage_secrets.disabled.what_is_this": {
+    "text": "Co to jest?"
+  },
+  "homepage_secrets.disabled.trust_viewed_once": {
+    "text": "Wyświetlany raz, potem znika"
+  },
+  "homepage_secrets.disabled.trust_zero_retained": {
+    "text": "Zero przechowywanych danych"
+  },
+  "homepage_secrets.disabled.promo_title": {
+    "text": "Nowość: plany bezpłatne obejmują teraz domeny niestandardowe."
+  },
+  "homepage_secrets.disabled.promo_subtitle": {
+    "text": "Skieruj swoją domenę na Onetime Secret i udostępniaj sekrety pod własną marką."
+  },
+  "homepage_secrets.disabled.promo_learn_how": {
+    "text": "Dowiedz się jak"
+  },
+  "homepage_secrets.disabled.logo_alt": {
+    "text": "Logo {name}"
+  },
+  "homepage_secrets.disabled.opens_in_new_tab": {
+    "text": "(otwiera się w nowej karcie)"
+  }
+}

--- a/locales/content/pl/feature-incoming.json
+++ b/locales/content/pl/feature-incoming.json
@@ -130,5 +130,26 @@
   "incoming.receipt_link_text": {
     "text": "potwierdzenie",
     "source_hash": "6f328609"
+  },
+  "incoming.upgrade_required_title": {
+    "text": "Wymagane ulepszenie planu"
+  },
+  "incoming.upgrade_required_description": {
+    "text": "Ta funkcja wymaga ulepszenia planu. Skontaktuj się z właścicielem konta, aby włączyć przychodzące sekrety."
+  },
+  "incoming.validation_memo_too_long": {
+    "text": "Notatka musi mieć maksymalnie {max} znaków"
+  },
+  "incoming.validation_secret_required": {
+    "text": "Treść sekretu jest wymagana"
+  },
+  "incoming.validation_recipient_required": {
+    "text": "Wybierz odbiorcę"
+  },
+  "incoming.validation_feature_disabled": {
+    "text": "Funkcja przychodzących sekretów nie jest włączona"
+  },
+  "incoming.validation_form_errors": {
+    "text": "Sprawdź formularz pod kątem błędów"
   }
 }

--- a/locales/content/pl/feature-regions.json
+++ b/locales/content/pl/feature-regions.json
@@ -186,5 +186,8 @@
   "web.regions.jurisdictions.apac.name": {
     "text": "Asia-Pacific",
     "source_hash": "7a757670"
+  },
+  "web.regions.no_region_configured": {
+    "text": "Obecnie brak dostępnych informacji o regionie dla Twojego konta."
   }
 }

--- a/locales/content/pl/secret-manage.json
+++ b/locales/content/pl/secret-manage.json
@@ -128,7 +128,7 @@
     "source_hash": "07fe1b84"
   },
   "web.secrets.onetime_secret_is_a_secure_way_to_share_sensitiv": {
-    "text": "{product_name} to bezpieczny sposób udostępniania poufnych informacji, które ulegają samozniszczeniu po jednym wyświetleniu.",
+    "text": "{product_name} to bezpieczny sposób na udostępnianie poufnych informacji, które ulegają samozniszczeniu po jednokrotnym wyświetleniu.",
     "source_hash": "8a163297"
   },
   "web.secrets.what_is_this": {
@@ -398,5 +398,11 @@
   "web.secrets.errors.access_denied_to_domain": {
     "text": "Odmowa dostępu do domeny",
     "source_hash": "cd441eea"
+  },
+  "web.receipt.open_link": {
+    "text": "Otwórz link"
+  },
+  "web.secrets.messageDeleted": {
+    "text": "Wiadomość usunięta"
   }
 }

--- a/locales/content/pl/session-auth-extended.json
+++ b/locales/content/pl/session-auth-extended.json
@@ -710,5 +710,26 @@
   "web.auth.recovery_codes.link_title": {
     "text": "Kody odzyskiwania",
     "source_hash": "579c7f4e"
+  },
+  "web.auth.google": {
+    "text": "Google"
+  },
+  "web.auth.mfa.alternative_auth_options": {
+    "text": "Alternatywne opcje uwierzytelniania"
+  },
+  "web.auth.remember.enabled": {
+    "text": "Pozostań zalogowany"
+  },
+  "web.auth.security._guidance.context": {
+    "text": "⚠️ SECURITY-CRITICAL: Messages prevent information disclosure. See src/locales/SECURITY-TRANSLATION-GUIDE.md"
+  },
+  "web.auth.sessions.session_singular": {
+    "text": "sesja"
+  },
+  "web.auth.sessions.session_plural": {
+    "text": "sesje"
+  },
+  "web.auth.sessions._guidance.context": {
+    "text": "User's logged-in devices/browsers management page"
   }
 }

--- a/locales/content/pl/session-auth.json
+++ b/locales/content/pl/session-auth.json
@@ -395,5 +395,35 @@
   "web.help.contact_support": {
     "text": "Skontaktuj się z pomocą techniczną",
     "source_hash": "f8d47b82"
+  },
+  "web.auth.account.sso_linked": {
+    "text": "Konto SSO"
+  },
+  "web.auth.verify._guidance.context": {
+    "text": "Email verification flow after signup"
+  },
+  "web.help.reset_password_link": {
+    "text": "Zresetuj hasło"
+  },
+  "web.login.custom_domain_sso_title": {
+    "text": "Jednokrotne logowanie jest dostępne dla tej domeny"
+  },
+  "web.login.custom_domain_sso_description": {
+    "text": "Administrator organizacji może włączyć SSO, aby umożliwić członkom zespołu logowanie się tutaj. Skontaktuj się z administratorem, aby uzyskać dostęp."
+  },
+  "web.login.signin_disabled_heading": {
+    "text": "Logowanie jest niedostępne"
+  },
+  "web.login.signin_disabled_message": {
+    "text": "Logowanie jest obecnie niedostępne w tej domenie."
+  },
+  "web.login.errors.sso_not_configured": {
+    "text": "Jednokrotne logowanie nie jest skonfigurowane dla tej domeny. Skontaktuj się z administratorem."
+  },
+  "web.login.errors.invalid_email": {
+    "text": "Adres e-mail z Twojego dostawcy tożsamości jest nieprawidłowy. Skontaktuj się z administratorem."
+  },
+  "web.login.errors.domain_not_allowed": {
+    "text": "Twoja domena e-mail nie jest autoryzowana do rejestracji przez SSO. Skontaktuj się z administratorem."
   }
 }

--- a/locales/content/pl/workspace-account.json
+++ b/locales/content/pl/workspace-account.json
@@ -682,5 +682,14 @@
   "web.settings.profile.didnt_receive_email": {
     "text": "Nie otrzymałeś e-maila?",
     "source_hash": "fe3ac3ad"
+  },
+  "web.settings.api.api_disabled_notice": {
+    "text": "API jest wyłączone dla tej instancji."
+  },
+  "web.settings.security.sso_managed_title": {
+    "text": "Zabezpieczenia zarządzane przez SSO"
+  },
+  "web.settings.security.sso_managed_description": {
+    "text": "Twoje konto jest uwierzytelniane za pośrednictwem dostawcy jednokrotnego logowania Twojej organizacji. Hasło, uwierzytelnianie wieloskładnikowe oraz kody odzyskiwania są zarządzane przez Twojego dostawcę tożsamości."
   }
 }

--- a/locales/content/pl/workspace-billing.json
+++ b/locales/content/pl/workspace-billing.json
@@ -988,5 +988,47 @@
     "text": "Dostępne tylko w Twoim oryginalnym regionie subskrypcji",
     "context": "Hint shown on plan cards when currency does not match active subscription",
     "source_hash": "10de32e5"
+  },
+  "web.billing.already_subscribed": {
+    "text": "Masz już subskrypcję tego planu."
+  },
+  "web.billing.cancel.reactivate_button": {
+    "text": "Reaktywuj subskrypcję"
+  },
+  "web.billing.cancel.reactivate_success": {
+    "text": "Twoja subskrypcja została reaktywowana. Opłaty będą naliczane jak zwykle."
+  },
+  "web.billing.cancel.reactivate_error": {
+    "text": "Nie udało się reaktywować subskrypcji. Spróbuj ponownie lub skontaktuj się z pomocą techniczną."
+  },
+  "web.billing.features.manage_orgs": {
+    "text": "Zarządzanie organizacjami"
+  },
+  "web.billing.features.flexible_from_domain": {
+    "text": "Elastyczna domena nadawcy e-mail"
+  },
+  "web.billing.features.unlimited_admins": {
+    "text": "Nieograniczona liczba administratorów"
+  },
+  "web.billing.features.manage_sso": {
+    "text": "SSO"
+  },
+  "web.billing.overview.entitlements.flexible_from_domain": {
+    "text": "Elastyczna domena nadawcy e-mail"
+  },
+  "web.billing.overview.entitlements.manage_orgs": {
+    "text": "Zarządzanie organizacjami"
+  },
+  "web.billing.overview.entitlements.manage_sso": {
+    "text": "Jednokrotne logowanie (SSO)"
+  },
+  "web.billing.overview.entitlements.manage_billing": {
+    "text": "Zarządzanie płatnościami"
+  },
+  "web.billing.overview.entitlements.custom_signup_validation": {
+    "text": "Niestandardowa walidacja rejestracji"
+  },
+  "web.billing.plans.reactivate": {
+    "text": "Reaktywuj"
   }
 }

--- a/locales/content/pl/workspace-branding.json
+++ b/locales/content/pl/workspace-branding.json
@@ -178,5 +178,11 @@
   "web.branding.upgrade_to_customize": {
     "text": "Ulepsz swój plan, aby dostosować branding dla tej domeny.",
     "source_hash": "9077bf79"
+  },
+  "web.branding.saved_successfully": {
+    "text": "Ustawienia marki zostały pomyślnie zapisane"
+  },
+  "web.branding.keyhole_logo_icon": {
+    "text": "Ikona dziurki od klucza symbolizująca bezpieczne, prywatne udostępnianie"
   }
 }

--- a/locales/content/pl/workspace-dashboard.json
+++ b/locales/content/pl/workspace-dashboard.json
@@ -22,5 +22,14 @@
   "web.dashboard.fetch_error_description": {
     "text": "Wystąpił problem z ładowaniem Twoich danych. Spróbuj ponownie.",
     "source_hash": "ff0d904e"
+  },
+  "web.teams.create_first_team_title": {
+    "text": "Utwórz swój pierwszy zespół"
+  },
+  "web.teams.create_first_team_description": {
+    "text": "Zespoły umożliwiają współpracę z innymi we wspólnym obszarze roboczym."
+  },
+  "web.teams.create_team": {
+    "text": "Utwórz zespół"
   }
 }

--- a/locales/content/pl/workspace-domains.json
+++ b/locales/content/pl/workspace-domains.json
@@ -398,5 +398,725 @@
   "web.domains.dns_widget_description": {
     "text": "Użyj narzędzia poniżej, aby automatycznie wykryć dostawcę DNS i uzyskać instrukcje krok po kroku dotyczące konfiguracji domeny.",
     "source_hash": "91c1af2e"
+  },
+  "api.domains.errors.add_admin_required": {
+    "text": "Tylko właściciele i administratorzy organizacji mogą dodawać domeny niestandardowe"
+  },
+  "web.domains.public_homepage": {
+    "text": "Publiczna strona główna"
+  },
+  "web.domains.status_tooltip_active": {
+    "text": "Domena zweryfikowana i aktywna"
+  },
+  "web.domains.status_tooltip_dns_incorrect": {
+    "text": "DNS nieskonfigurowany — kliknij, aby naprawić"
+  },
+  "web.domains.status_tooltip_not_verified": {
+    "text": "Domena niezweryfikowana — kliknij, aby zweryfikować"
+  },
+  "web.domains.status_tooltip_unverified": {
+    "text": "Status domeny niezweryfikowany — kliknij, aby odświeżyć"
+  },
+  "web.domains.last_check_failed": {
+    "text": "Ostatnia weryfikacja nie powiodła się"
+  },
+  "web.domains.last_check_failed_ago": {
+    "text": "ostatnia weryfikacja nie powiodła się {0}"
+  },
+  "web.domains.verify_now": {
+    "text": "Zweryfikuj teraz"
+  },
+  "web.domains.click_to_verify": {
+    "text": "kliknij, aby zweryfikować"
+  },
+  "web.domains.remove_domain_description": {
+    "text": "Trwale usuń tę domenę i całą jej konfigurację."
+  },
+  "web.domains.add_access_denied": {
+    "text": "Odmowa dostępu"
+  },
+  "web.domains.add_access_denied_description": {
+    "text": "Nie masz uprawnień do dodawania domen do tej organizacji. Skontaktuj się z administratorem organizacji."
+  },
+  "web.domains.dns_widget_load_failed": {
+    "text": "Nie udało się załadować widżetu DNS"
+  },
+  "web.domains.dns_widget_not_available": {
+    "text": "Widżet DNS jest niedostępny"
+  },
+  "web.domains.dns_widget_init_failed": {
+    "text": "Nie udało się zainicjować widżetu DNS"
+  },
+  "web.domains.verified": {
+    "text": "Zweryfikowano"
+  },
+  "web.domains.pending_verification": {
+    "text": "Oczekuje na weryfikację"
+  },
+  "web.domains.unsaved_changes_confirmation": {
+    "text": "Masz niezapisane zmiany. Czy na pewno chcesz wyjść?"
+  },
+  "web.domains.entitlement_required_owner": {
+    "text": "Ta funkcja wymaga ulepszenia planu."
+  },
+  "web.domains.entitlement_required_member": {
+    "text": "Ta funkcja jest niedostępna w Twoim obecnym planie. Skontaktuj się z właścicielem organizacji."
+  },
+  "web.domains.detail.manage": {
+    "text": "Zarządzaj"
+  },
+  "web.domains.detail.features": {
+    "text": "Funkcje"
+  },
+  "web.domains.detail.homepage_title": {
+    "text": "Sekrety na stronie głównej"
+  },
+  "web.domains.detail.homepage_description": {
+    "text": "Zezwól na publiczny dostęp w celu tworzenia sekretów na stronie głównej Twojej domeny"
+  },
+  "web.domains.detail.brand_description": {
+    "text": "Logo, kolory i niestandardowy branding"
+  },
+  "web.domains.detail.sso_description": {
+    "text": "Ustawienia dostawcy jednokrotnego logowania"
+  },
+  "web.domains.detail.email_description": {
+    "text": "Niestandardowa konfiguracja nadawcy e-mail"
+  },
+  "web.domains.detail.incoming_description": {
+    "text": "Ustawienia odbiorców przychodzących sekretów"
+  },
+  "web.domains.detail.signup_description": {
+    "text": "Strategia walidacji rejestracji dla poszczególnych domen"
+  },
+  "web.domains.detail.signin_description": {
+    "text": "Konfiguracja metody logowania dla poszczególnych domen"
+  },
+  "web.domains.email.title": {
+    "text": "Wysyłanie e-maili"
+  },
+  "web.domains.email.config_title": {
+    "text": "Konfiguracja e-mail"
+  },
+  "web.domains.email.config_description": {
+    "text": "Skonfiguruj wysyłanie e-maili dla tej domeny"
+  },
+  "web.domains.email.provider_label": {
+    "text": "Dostawca poczty e-mail"
+  },
+  "web.domains.email.provider_placeholder": {
+    "text": "Wybierz dostawcę poczty e-mail"
+  },
+  "web.domains.email.from_name_label": {
+    "text": "Nazwa nadawcy"
+  },
+  "web.domains.email.from_name_placeholder": {
+    "text": "np. Acme Security"
+  },
+  "web.domains.email.from_address_label": {
+    "text": "Adres nadawcy"
+  },
+  "web.domains.email.from_address_placeholder": {
+    "text": "np. secrets{'@'}example.com"
+  },
+  "web.domains.email.reply_to_label": {
+    "text": "Adres zwrotny (Reply-To)"
+  },
+  "web.domains.email.reply_to_placeholder": {
+    "text": "np. support{'@'}example.com"
+  },
+  "web.domains.email.save_changes": {
+    "text": "Zapisz zmiany"
+  },
+  "web.domains.email.discard_changes": {
+    "text": "Odrzuć zmiany"
+  },
+  "web.domains.email.provider_ses": {
+    "text": "Amazon SES"
+  },
+  "web.domains.email.provider_sendgrid": {
+    "text": "SendGrid"
+  },
+  "web.domains.email.provider_lettermint": {
+    "text": "Lettermint"
+  },
+  "web.domains.email.provider_inherit": {
+    "text": "Użyj ustawień domyślnych konta"
+  },
+  "web.domains.email.provider_ses_description": {
+    "text": "Wymaga weryfikacji domeny za pomocą rekordów DKIM i SPF"
+  },
+  "web.domains.email.provider_sendgrid_description": {
+    "text": "Wymaga konfiguracji uwierzytelniania domeny"
+  },
+  "web.domains.email.provider_lettermint_description": {
+    "text": "Wymaga weryfikacji domeny"
+  },
+  "web.domains.email.provider_inherit_description": {
+    "text": "Używa domyślnej konfiguracji wysyłania e-maili z Twojego konta"
+  },
+  "web.domains.email.dns_records_title": {
+    "text": "Rekordy DNS"
+  },
+  "web.domains.email.dns_records_description": {
+    "text": "Dodaj poniższe rekordy DNS, aby zweryfikować swoją domenę do wysyłania e-maili."
+  },
+  "web.domains.email.dns_column_type": {
+    "text": "Typ"
+  },
+  "web.domains.email.dns_column_name": {
+    "text": "Nazwa"
+  },
+  "web.domains.email.dns_column_value": {
+    "text": "Wartość"
+  },
+  "web.domains.email.dns_check_label": {
+    "text": "DNS"
+  },
+  "web.domains.email.provider_check_label": {
+    "text": "Dostawca"
+  },
+  "web.domains.email.dns_optional_label": {
+    "text": "Zalecane"
+  },
+  "web.domains.email.dns_optional_hint": {
+    "text": "Ten rekord jest zalecany, ale nie jest wymagany do weryfikacji. Polityka DMARC w Twojej domenie organizacyjnej może już obejmować tę poddomenę."
+  },
+  "web.domains.email.copy": {
+    "text": "Kopiuj"
+  },
+  "web.domains.email.copied": {
+    "text": "Skopiowano"
+  },
+  "web.domains.email.status_verified": {
+    "text": "Zweryfikowano"
+  },
+  "web.domains.email.status_pending": {
+    "text": "Oczekuje"
+  },
+  "web.domains.email.status_failed": {
+    "text": "Niepowodzenie"
+  },
+  "web.domains.email.revalidate": {
+    "text": "Zweryfikuj ponownie"
+  },
+  "web.domains.email.validating": {
+    "text": "Weryfikowanie..."
+  },
+  "web.domains.email.domain_verified": {
+    "text": "Domena zweryfikowana"
+  },
+  "web.domains.email.validation_failed": {
+    "text": "Weryfikacja nie powiodła się"
+  },
+  "web.domains.email.last_validated": {
+    "text": "Ostatnio zweryfikowano"
+  },
+  "web.domains.email.upgrade_to_configure": {
+    "text": "Ulepsz swój plan, aby skonfigurować wysyłanie e-maili dla tej domeny."
+  },
+  "web.domains.email.configure_email": {
+    "text": "Konfiguruj e-mail"
+  },
+  "web.domains.email.access_denied": {
+    "text": "Odmowa dostępu"
+  },
+  "web.domains.email.access_denied_description": {
+    "text": "Nie masz uprawnień do zarządzania ustawieniami e-mail dla tej domeny. Skontaktuj się z administratorem swojej organizacji."
+  },
+  "web.domains.email.update_success": {
+    "text": "Konfiguracja e-mail została pomyślnie zapisana"
+  },
+  "web.domains.email.delete_success": {
+    "text": "Konfiguracja e-mail została pomyślnie usunięta"
+  },
+  "web.domains.email.default_sender_notice": {
+    "text": "E-maile dla tej domeny są obecnie wysyłane od globalnego nadawcy. Uzupełnij konfigurację e-mail, aby używać własnej tożsamości nadawcy."
+  },
+  "web.domains.email.disabled_notice": {
+    "text": "Niestandardowe wysyłanie e-maili jest obecnie wyłączone. E-maile będą wysyłane od globalnego nadawcy. Włącz tę funkcję poniżej, aby używać własnej tożsamości nadawcy."
+  },
+  "web.domains.email.test_email_title": {
+    "text": "Testuj dostarczanie e-maili"
+  },
+  "web.domains.email.test_email_hint": {
+    "text": "Wyślij testowy e-mail do siebie, używając zapisanej konfiguracji. Działa nawet wtedy, gdy funkcja nie jest jeszcze włączona."
+  },
+  "web.domains.email.send_test": {
+    "text": "Wyślij test"
+  },
+  "web.domains.email.test_email_sent": {
+    "text": "Testowy e-mail został pomyślnie wysłany"
+  },
+  "web.domains.email.test_email_failed": {
+    "text": "Nie udało się wysłać testowego e-maila"
+  },
+  "web.domains.email.test_email_sent_to": {
+    "text": "Wysłano do {email}"
+  },
+  "web.domains.email.delivered_via": {
+    "text": "Dostarczono przez {provider}"
+  },
+  "web.domains.email.badge_not_configured": {
+    "text": "Nieskonfigurowano"
+  },
+  "web.domains.email.badge_default_sender": {
+    "text": "Używa domyślnego nadawcy"
+  },
+  "web.domains.email.badge_verified": {
+    "text": "Zweryfikowano"
+  },
+  "web.domains.email.badge_pending": {
+    "text": "Oczekuje na weryfikację"
+  },
+  "web.domains.email.badge_disabled": {
+    "text": "Wyłączono"
+  },
+  "web.domains.email.tooltip_not_configured": {
+    "text": "Nie skonfigurowano nadawcy e-mail — e-maile używają domyślnego nadawcy platformy"
+  },
+  "web.domains.email.tooltip_pending": {
+    "text": "Konfiguracja nadawcy e-mail oczekuje na weryfikację — e-maile używają domyślnego nadawcy platformy"
+  },
+  "web.domains.email.tooltip_disabled": {
+    "text": "Nadawca e-mail jest wyłączony — e-maile używają domyślnego nadawcy platformy"
+  },
+  "web.domains.email.tooltip_verified": {
+    "text": "Nadawca e-mail zweryfikowany — e-maile są wysyłane z tej domeny"
+  },
+  "web.domains.incoming.title": {
+    "text": "Przychodzące sekrety"
+  },
+  "web.domains.incoming.config_title": {
+    "text": "Konfiguracja przychodzących sekretów"
+  },
+  "web.domains.incoming.config_description": {
+    "text": "Zezwól użytkownikom zewnętrznym na wysyłanie sekretów bezpośrednio do wyznaczonych odbiorców w tej domenie"
+  },
+  "web.domains.incoming.feature_disabled": {
+    "text": "Przychodzące sekrety niedostępne"
+  },
+  "web.domains.incoming.feature_disabled_description": {
+    "text": "Przychodzące sekrety nie są włączone w tej instancji. Skontaktuj się z administratorem."
+  },
+  "web.domains.incoming.access_denied": {
+    "text": "Odmowa dostępu"
+  },
+  "web.domains.incoming.access_denied_description": {
+    "text": "Nie masz uprawnień do zarządzania ustawieniami przychodzących sekretów dla tej domeny. Skontaktuj się z administratorem swojej organizacji."
+  },
+  "web.domains.incoming.upgrade_to_configure": {
+    "text": "Ulepsz swój plan, aby skonfigurować przychodzące sekrety dla tej domeny."
+  },
+  "web.domains.incoming.configure_incoming": {
+    "text": "Konfiguruj przychodzące sekrety"
+  },
+  "web.domains.incoming.not_configured_notice": {
+    "text": "Przychodzące sekrety nie są skonfigurowane dla tej domeny. Dodaj odbiorców, aby umożliwić użytkownikom zewnętrznym wysyłanie sekretów do Twojego zespołu."
+  },
+  "web.domains.incoming.disabled_notice": {
+    "text": "Przychodzące sekrety są obecnie wyłączone. Użytkownicy zewnętrzni nie mogą wysyłać sekretów do odbiorców w tej domenie. Włącz tę funkcję poniżej, aby zezwolić na przychodzące sekrety."
+  },
+  "web.domains.incoming.recipients_title": {
+    "text": "Odbiorcy"
+  },
+  "web.domains.incoming.recipients_description": {
+    "text": "Określ, kto może otrzymywać przychodzące sekrety w tej domenie. Odbiorcy otrzymają powiadomienia e-mail, gdy zostanie do nich wysłany sekret."
+  },
+  "web.domains.incoming.add_recipient": {
+    "text": "Dodaj odbiorcę"
+  },
+  "web.domains.incoming.remove_recipient": {
+    "text": "Usuń"
+  },
+  "web.domains.incoming.email_label": {
+    "text": "Adres e-mail"
+  },
+  "web.domains.incoming.email_placeholder": {
+    "text": "recipient{'@'}example.com"
+  },
+  "web.domains.incoming.name_label": {
+    "text": "Nazwa wyświetlana"
+  },
+  "web.domains.incoming.name_placeholder": {
+    "text": "np. Security Team"
+  },
+  "web.domains.incoming.empty_state": {
+    "text": "Nie skonfigurowano odbiorców"
+  },
+  "web.domains.incoming.empty_state_description": {
+    "text": "Dodaj odbiorców, aby umożliwić użytkownikom zewnętrznym wysyłanie sekretów do Twojego zespołu."
+  },
+  "web.domains.incoming.validation_invalid_email": {
+    "text": "Nieprawidłowy adres e-mail"
+  },
+  "web.domains.incoming.validation_duplicate_email": {
+    "text": "Ten adres e-mail został już dodany"
+  },
+  "web.domains.incoming.validation_max_recipients": {
+    "text": "Maksymalna liczba dozwolonych odbiorców: {max}"
+  },
+  "web.domains.incoming.validation_name_required": {
+    "text": "Nazwa wyświetlana jest wymagana"
+  },
+  "web.domains.incoming.validation_email_required": {
+    "text": "Adres e-mail jest wymagany"
+  },
+  "web.domains.incoming.save_changes": {
+    "text": "Zapisz zmiany"
+  },
+  "web.domains.incoming.discard_changes": {
+    "text": "Odrzuć zmiany"
+  },
+  "web.domains.incoming.update_success": {
+    "text": "Konfiguracja przychodzących sekretów została pomyślnie zapisana"
+  },
+  "web.domains.incoming.delete_success": {
+    "text": "Konfiguracja przychodzących sekretów została pomyślnie usunięta"
+  },
+  "web.domains.incoming.recipient_count": {
+    "text": "{count} odbiorca | {count} odbiorców"
+  },
+  "web.domains.incoming.badge_not_configured": {
+    "text": "Nieskonfigurowano"
+  },
+  "web.domains.incoming.badge_configured": {
+    "text": "Skonfigurowano"
+  },
+  "web.domains.incoming.badge_disabled": {
+    "text": "Wyłączono"
+  },
+  "web.domains.incoming.tooltip_not_configured": {
+    "text": "Przychodzące sekrety nie są skonfigurowane - użytkownicy zewnętrzni nie mogą wysyłać sekretów do tej domeny"
+  },
+  "web.domains.incoming.tooltip_configured": {
+    "text": "Przychodzące sekrety włączone, liczba odbiorców: {count}"
+  },
+  "web.domains.incoming.tooltip_disabled": {
+    "text": "Funkcja przychodzących sekretów jest wyłączona dla tej domeny"
+  },
+  "web.domains.incoming.enabled_label": {
+    "text": "Włącz przychodzące sekrety"
+  },
+  "web.domains.incoming.enabled_hint": {
+    "text": "Zezwól użytkownikom zewnętrznym na wysyłanie sekretów do odbiorców w tej domenie"
+  },
+  "web.domains.incoming.public_url_label": {
+    "text": "Publiczny adres URL"
+  },
+  "web.domains.incoming.public_url_description": {
+    "text": "Udostępnij ten adres URL użytkownikom zewnętrznym, aby umożliwić im wysyłanie sekretów"
+  },
+  "web.domains.incoming.copy_url": {
+    "text": "Kopiuj adres URL"
+  },
+  "web.domains.incoming.url_copied": {
+    "text": "Adres URL skopiowano do schowka"
+  },
+  "web.domains.incoming.remove_all_confirmation": {
+    "text": "Czy na pewno chcesz usunąć wszystkich odbiorców? Użytkownicy zewnętrzni nie będą już mogli wysyłać sekretów do tej domeny."
+  },
+  "web.domains.incoming.max_recipients_reached": {
+    "text": "Osiągnięto maksymalną liczbę odbiorców"
+  },
+  "web.domains.incoming.duplicate_recipient": {
+    "text": "Ten adres e-mail został już dodany"
+  },
+  "web.domains.incoming.save_will_replace_confirmation": {
+    "text": "Zapisanie zastąpi wszystkich istniejących odbiorców Twoimi oczekującymi zmianami. Czy na pewno?"
+  },
+  "web.domains.incoming.delete_all_recipients": {
+    "text": "Usuń wszystkich odbiorców"
+  },
+  "web.domains.signin.title": {
+    "text": "Konfiguracja logowania"
+  },
+  "web.domains.signin.configure_signin": {
+    "text": "Konfiguruj logowanie"
+  },
+  "web.domains.signin.config_description": {
+    "text": "Skonfiguruj metody uwierzytelniania przy logowaniu dla tej domeny"
+  },
+  "web.domains.signin.access_denied": {
+    "text": "Odmowa dostępu"
+  },
+  "web.domains.signin.upgrade_to_configure": {
+    "text": "Ulepsz swój plan, aby skonfigurować metody logowania dla tej domeny."
+  },
+  "web.domains.signin.not_configured_notice": {
+    "text": "Konfiguracja logowania nie została jeszcze ustawiona dla tej domeny. Skonfiguruj nadpisania, aby kontrolować, które metody uwierzytelniania są dostępne na stronie logowania tej domeny."
+  },
+  "web.domains.signin.signin_enabled_label": {
+    "text": "Logowanie włączone"
+  },
+  "web.domains.signin.header_toggle_label": {
+    "text": "Logowanie"
+  },
+  "web.domains.signin.signin_enabled_hint": {
+    "text": "Określa, czy użytkownicy mogą logować się w tej domenie"
+  },
+  "web.domains.signin.restrict_to_label": {
+    "text": "Ogranicz metodę logowania"
+  },
+  "web.domains.signin.restrict_to_hint": {
+    "text": "Ogranicz tę domenę do jednej metody uwierzytelniania. Po ustawieniu na stronie logowania wyświetlana jest tylko wybrana metoda."
+  },
+  "web.domains.signin.all_methods": {
+    "text": "Wszystkie metody"
+  },
+  "web.domains.signin.all_methods_description": {
+    "text": "Pokaż wszystkie włączone metody uwierzytelniania na stronie logowania"
+  },
+  "web.domains.signin.method_password": {
+    "text": "Hasło"
+  },
+  "web.domains.signin.method_email_auth": {
+    "text": "Uwierzytelnianie e-mail"
+  },
+  "web.domains.signin.method_webauthn": {
+    "text": "WebAuthn / Klucze dostępu"
+  },
+  "web.domains.signin.method_sso": {
+    "text": "Jednokrotne logowanie"
+  },
+  "web.domains.signin.method_overrides_label": {
+    "text": "Nadpisania metod"
+  },
+  "web.domains.signin.method_overrides_hint": {
+    "text": "Włącz lub wyłącz poszczególne metody uwierzytelniania dla tej domeny"
+  },
+  "web.domains.signin.mode_question": {
+    "text": "Jak użytkownicy mogą się logować?"
+  },
+  "web.domains.signin.mode_any": {
+    "text": "Dowolna dostępna metoda"
+  },
+  "web.domains.signin.mode_any_hint": {
+    "text": "Pokaż każdą metodę dostępną w tej domenie. Zawęź poszczególne metody poniżej."
+  },
+  "web.domains.signin.mode_one": {
+    "text": "Jedna konkretna metoda"
+  },
+  "web.domains.signin.mode_one_hint": {
+    "text": "Ogranicz stronę logowania do jednej metody. Wymienione są tylko metody dostępne w tej domenie."
+  },
+  "web.domains.signin.mode_disabled": {
+    "text": "Logowanie wyłączone"
+  },
+  "web.domains.signin.mode_disabled_hint": {
+    "text": "Użytkownicy nie mogą logować się w tej domenie."
+  },
+  "web.domains.signin.mode_disabled_notice": {
+    "text": "Odwiedzający stronę logowania tej domeny widzą informację, że logowanie jest niedostępne, wraz z linkiem powrotnym do strony głównej. Twoje poprzednie ustawienia metod są zachowywane i przywracane po ponownym włączeniu logowania."
+  },
+  "web.domains.signin.methods_list_label": {
+    "text": "Metody wyświetlane na stronie logowania"
+  },
+  "web.domains.signin.restrict_picker_hint": {
+    "text": "Wymienione są tylko metody dostępne w tej domenie."
+  },
+  "web.domains.signin.availability_always": {
+    "text": "Zawsze dostępne"
+  },
+  "web.domains.signin.availability_global_on": {
+    "text": "Zgodne z polityką globalną · Wł."
+  },
+  "web.domains.signin.availability_global_off": {
+    "text": "Niedostępne"
+  },
+  "web.domains.signin.availability_unavailable": {
+    "text": "Niedostępne w całej witrynie"
+  },
+  "web.domains.signin.allow_on_domain": {
+    "text": "Zezwól w tej domenie"
+  },
+  "web.domains.signin.method_password_blurb": {
+    "text": "Tylko hasło"
+  },
+  "web.domains.signin.method_email_auth_blurb": {
+    "text": "Logowanie bez hasła za pomocą magicznego linku"
+  },
+  "web.domains.signin.method_webauthn_blurb": {
+    "text": "Dane biometryczne i klucze bezpieczeństwa"
+  },
+  "web.domains.signin.method_sso_blurb": {
+    "text": "Zewnętrzny dostawca tożsamości"
+  },
+  "web.domains.signin.email_auth_label": {
+    "text": "Uwierzytelnianie e-mail"
+  },
+  "web.domains.signin.email_auth_hint": {
+    "text": "Zezwól na uwierzytelnianie e-mail bez hasła w tej domenie"
+  },
+  "web.domains.signin.sso_enabled_label": {
+    "text": "Jednokrotne logowanie"
+  },
+  "web.domains.signin.sso_enabled_hint": {
+    "text": "Zezwól na uwierzytelnianie SSO w tej domenie"
+  },
+  "web.domains.signin.enabled_label": {
+    "text": "Włącz konfigurację logowania"
+  },
+  "web.domains.signin.enabled_hint": {
+    "text": "Po włączeniu ta domena korzysta z ustawień logowania skonfigurowanych powyżej"
+  },
+  "web.domains.signin.save_config": {
+    "text": "Zapisz konfigurację"
+  },
+  "web.domains.signin.update_success": {
+    "text": "Konfiguracja logowania została pomyślnie zaktualizowana"
+  },
+  "web.domains.signin.reset_to_defaults": {
+    "text": "Przywróć ustawienia domyślne"
+  },
+  "web.domains.signin.reset_confirm": {
+    "text": "Przywrócić logowanie do globalnych ustawień domyślnych?"
+  },
+  "web.domains.signin.reset_keeps_sso": {
+    "text": "Twoje poświadczenia SSO są zachowywane. Usuń je osobno na ekranie konfiguracji SSO."
+  },
+  "web.domains.signin.reset_action": {
+    "text": "Tak, przywróć"
+  },
+  "web.domains.signin.reset_success": {
+    "text": "Ustawienia logowania przywrócono do globalnych ustawień domyślnych"
+  },
+  "web.domains.signup.title": {
+    "text": "Walidacja rejestracji"
+  },
+  "web.domains.signup.config_description": {
+    "text": "Skonfiguruj walidację rejestracji dla tej domeny"
+  },
+  "web.domains.signup.access_denied": {
+    "text": "Odmowa dostępu"
+  },
+  "web.domains.signup.upgrade_to_configure": {
+    "text": "Ulepsz swój plan, aby skonfigurować walidację rejestracji dla poszczególnych domen."
+  },
+  "web.domains.signup.configure_signup": {
+    "text": "Konfiguruj rejestrację"
+  },
+  "web.domains.signup.not_configured_notice": {
+    "text": "Walidacja rejestracji nie jest jeszcze skonfigurowana dla tej domeny. Skonfiguruj strategię, aby kontrolować, kto może rejestrować się za pośrednictwem tej domeny."
+  },
+  "web.domains.signup.site_signups_disabled_warning": {
+    "text": "Rejestracje są obecnie wyłączone na poziomie witryny. Ta polityka dla poszczególnych domen jest skonfigurowana, ale nie będzie ograniczać żadnego ruchu, dopóki rejestracje w witrynie nie zostaną włączone."
+  },
+  "web.domains.signup.strategy_label": {
+    "text": "Strategia walidacji"
+  },
+  "web.domains.signup.strategy_description": {
+    "text": "Wybierz, w jaki sposób adresy e-mail są walidowane podczas rejestracji użytkowników w tej domenie."
+  },
+  "web.domains.signup.network_validation_warning": {
+    "text": "Ta strategia wykonuje połączenia sieciowe podczas rejestracji, co może zwiększać opóźnienia lub być blokowane przez niektórych dostawców."
+  },
+  "web.domains.signup.allowed_domains_label": {
+    "text": "Dozwolone domeny rejestracji"
+  },
+  "web.domains.signup.allowed_domains_hint": {
+    "text": "Tylko te domeny e-mail będą mogły się rejestrować. Dodaj jedną domenę na wpis."
+  },
+  "web.domains.signup.domain_placeholder": {
+    "text": "example.com"
+  },
+  "web.domains.signup.invalid_domain": {
+    "text": "Wprowadź prawidłową domenę (np. example.com)"
+  },
+  "web.domains.signup.domain_exists": {
+    "text": "Ta domena jest już na liście"
+  },
+  "web.domains.signup.remove_domain": {
+    "text": "Usuń {domain}"
+  },
+  "web.domains.signup.enabled_label": {
+    "text": "Włącz walidację dla poszczególnych domen"
+  },
+  "web.domains.signup.enabled_hint": {
+    "text": "Po włączeniu rejestracje w tej domenie używają powyższej strategii zamiast polityki globalnej."
+  },
+  "web.domains.signup.delete_config": {
+    "text": "Usuń konfigurację"
+  },
+  "web.domains.signup.delete_confirm": {
+    "text": "Usunąć konfigurację walidacji rejestracji? Rejestracje będą korzystać z polityki globalnej."
+  },
+  "web.domains.signup.save_config": {
+    "text": "Zapisz konfigurację"
+  },
+  "web.domains.signup.update_success": {
+    "text": "Walidacja rejestracji została pomyślnie zaktualizowana"
+  },
+  "web.domains.signup.delete_success": {
+    "text": "Konfiguracja walidacji rejestracji została pomyślnie usunięta"
+  },
+  "web.domains.signup.domain_overrides_label": {
+    "text": "Nadpisania domeny"
+  },
+  "web.domains.signup.domain_overrides_hint": {
+    "text": "Zastąp globalne ustawienia rejestracji dla tej domeny"
+  },
+  "web.domains.signup.signup_enabled_label": {
+    "text": "Rejestracja włączona"
+  },
+  "web.domains.signup.signup_enabled_hint": {
+    "text": "Zastąp ustawienie, czy rejestracja jest włączona dla tej domeny"
+  },
+  "web.domains.signup.autoverify_label": {
+    "text": "Automatyczna weryfikacja kont"
+  },
+  "web.domains.signup.autoverify_hint": {
+    "text": "Zastąp ustawienie, czy nowe konta są automatycznie weryfikowane w tej domenie"
+  },
+  "web.domains.sso.title": {
+    "text": "Jednokrotne logowanie"
+  },
+  "web.domains.sso.config_title": {
+    "text": "Konfiguracja SSO"
+  },
+  "web.domains.sso.config_description": {
+    "text": "Skonfiguruj uwierzytelnianie jednokrotnym logowaniem dla tej domeny"
+  },
+  "web.domains.sso.access_denied": {
+    "text": "Odmowa dostępu"
+  },
+  "web.domains.sso.access_denied_description": {
+    "text": "Nie masz uprawnień do zarządzania ustawieniami SSO dla tej domeny. Skontaktuj się z administratorem swojej organizacji."
+  },
+  "web.domains.sso.upgrade_to_configure": {
+    "text": "Ulepsz swój plan, aby skonfigurować jednokrotne logowanie dla tej domeny."
+  },
+  "web.domains.sso.create_success": {
+    "text": "Konfiguracja SSO została pomyślnie utworzona"
+  },
+  "web.domains.sso.update_success": {
+    "text": "Konfiguracja SSO została pomyślnie zaktualizowana"
+  },
+  "web.domains.sso.delete_success": {
+    "text": "Konfiguracja SSO została pomyślnie usunięta"
+  },
+  "web.domains.sso.test_success": {
+    "text": "Test połączenia zakończony powodzeniem — dostawca odpowiedział prawidłowo"
+  },
+  "web.domains.sso.test_failed": {
+    "text": "Test połączenia nie powiódł się"
+  },
+  "web.domains.sso.enforce_moved_notice": {
+    "text": "Aby wymagać SSO dla wszystkich logowań w tej domenie, skonfiguruj to w ustawieniach logowania domeny. Tryb wyłącznie SSO ogranicza stronę logowania do dostawcy SSO skonfigurowanego tutaj."
+  },
+  "web.domains.sso.configure_sso": {
+    "text": "Konfiguruj SSO"
+  },
+  "web.domains.sso.not_configured_notice": {
+    "text": "SSO nie jest jeszcze skonfigurowane dla tej domeny. Włącz jednokrotne logowanie, aby umożliwić członkom zespołu uwierzytelnianie za pomocą dostawcy tożsamości Twojej organizacji."
+  },
+  "web.domains.sso.edit_credentials": {
+    "text": "Edytuj poświadczenia"
+  },
+  "web.domains.sso.configure_button": {
+    "text": "Konfiguruj"
+  },
+  "web.domains.sso.upgrade_required": {
+    "text": "Ulepsz, aby skonfigurować"
   }
 }

--- a/locales/content/pl/workspace-domains.json
+++ b/locales/content/pl/workspace-domains.json
@@ -658,7 +658,7 @@
     "text": "Dostarczono przez {provider}"
   },
   "web.domains.email.badge_not_configured": {
-    "text": "Nieskonfigurowano"
+    "text": "Nie skonfigurowano"
   },
   "web.domains.email.badge_default_sender": {
     "text": "Używa domyślnego nadawcy"
@@ -778,7 +778,7 @@
     "text": "{count} odbiorca | {count} odbiorców"
   },
   "web.domains.incoming.badge_not_configured": {
-    "text": "Nieskonfigurowano"
+    "text": "Nie skonfigurowano"
   },
   "web.domains.incoming.badge_configured": {
     "text": "Skonfigurowano"

--- a/locales/content/pl/workspace-organizations.json
+++ b/locales/content/pl/workspace-organizations.json
@@ -578,5 +578,344 @@
   "web.organizations.invitations.expires_soon": {
     "text": "Wkrótce wygasa",
     "source_hash": "a5dcfef9"
+  },
+  "api.organizations.errors.not_found": {
+    "text": "Nie znaleziono organizacji: %{extid}"
+  },
+  "api.organizations.errors.owner_required": {
+    "text": "Tylko właściciel organizacji może wykonać tę akcję"
+  },
+  "api.organizations.errors.admin_required": {
+    "text": "Tylko właściciele i administratorzy organizacji mogą wykonać tę akcję"
+  },
+  "api.organizations.errors.member_required": {
+    "text": "Aby wykonać tę akcję, musisz być członkiem organizacji"
+  },
+  "api.organizations.invitations.errors.create_admin_required": {
+    "text": "Tylko właściciele i administratorzy organizacji mogą tworzyć zaproszenia"
+  },
+  "api.organizations.invitations.errors.resend_admin_required": {
+    "text": "Tylko właściciele i administratorzy organizacji mogą ponownie wysyłać zaproszenia"
+  },
+  "api.organizations.invitations.errors.view_admin_required": {
+    "text": "Tylko właściciele i administratorzy organizacji mogą wyświetlać zaproszenia"
+  },
+  "api.organizations.invitations.errors.revoke_admin_required": {
+    "text": "Tylko właściciele i administratorzy organizacji mogą cofać zaproszenia"
+  },
+  "api.organizations.invitations.errors.email_required": {
+    "text": "Adres e-mail jest wymagany"
+  },
+  "api.organizations.invitations.errors.email_invalid": {
+    "text": "Nieprawidłowy format adresu e-mail"
+  },
+  "api.organizations.invitations.errors.role_invalid": {
+    "text": "Rola musi być członek lub administrator"
+  },
+  "api.organizations.invitations.errors.cannot_invite_owner": {
+    "text": "Nie można zaprosić jako właściciel"
+  },
+  "api.organizations.invitations.errors.already_member": {
+    "text": "Użytkownik jest już członkiem tej organizacji"
+  },
+  "api.organizations.invitations.errors.already_pending": {
+    "text": "Zaproszenie dla tego adresu e-mail już oczekuje"
+  },
+  "api.organizations.invitations.errors.member_limit_reached": {
+    "text": "Osiągnięto limit członków. Ulepsz swój plan, aby zaprosić więcej członków."
+  },
+  "api.organizations.invitations.errors.not_found": {
+    "text": "Nie znaleziono zaproszenia"
+  },
+  "api.organizations.invitations.errors.cannot_resend_non_pending": {
+    "text": "Można ponownie wysyłać tylko oczekujące zaproszenia"
+  },
+  "api.organizations.invitations.errors.cannot_revoke_non_pending": {
+    "text": "Można cofać tylko oczekujące zaproszenia"
+  },
+  "api.organizations.invitations.errors.resend_limit_reached": {
+    "text": "Osiągnięto maksymalny limit ponownych wysyłek (%{max})"
+  },
+  "api.organizations.invitations.errors.accept_token_required": {
+    "text": "Token jest wymagany"
+  },
+  "api.organizations.invitations.errors.accept_organization_gone": {
+    "text": "Organizacja już nie istnieje"
+  },
+  "api.organizations.invitations.errors.accept_already_acted": {
+    "text": "Zaproszenie zostało już obsłużone: %{status}"
+  },
+  "api.organizations.invitations.errors.accept_expired": {
+    "text": "Zaproszenie wygasło"
+  },
+  "api.organizations.invitations.errors.accept_email_mismatch": {
+    "text": "Twój adres e-mail nie pasuje do zaproszenia"
+  },
+  "api.organizations.invitations.errors.accept_already_member": {
+    "text": "Jesteś już członkiem tej organizacji"
+  },
+  "web.organizations.entitlements_title": {
+    "text": "Uprawnienia organizacji"
+  },
+  "web.organizations.page_description_short": {
+    "text": "Wyświetlaj i konfiguruj swoje obszary robocze"
+  },
+  "web.organizations.delete_organization_remove_domains_first": {
+    "text": "Usuń wszystkie domeny niestandardowe przed usunięciem tej organizacji."
+  },
+  "web.organizations.default_org_delete_notice_title": {
+    "text": "Usuwanie tej organizacji"
+  },
+  "web.organizations.default_org_delete_notice_before": {
+    "text": "To jest Twoja domyślna organizacja i nie można jej usunąć z panelu. Aby ją usunąć, skontaktuj się za pośrednictwem"
+  },
+  "web.organizations.default_org_delete_notice_link": {
+    "text": "formularza opinii"
+  },
+  "web.organizations.default_org_delete_notice_after": {
+    "text": "."
+  },
+  "web.organizations.leave_organization": {
+    "text": "Opuść tę organizację"
+  },
+  "web.organizations.leave_organization_warning": {
+    "text": "Utracisz dostęp do tej organizacji i jej zasobów."
+  },
+  "web.organizations.leave_organization_confirm_title": {
+    "text": "Opuść organizację"
+  },
+  "web.organizations.leave_organization_confirm_message": {
+    "text": "Czy na pewno chcesz opuścić {name}? Aby ponownie dołączyć, będziesz potrzebować nowego zaproszenia."
+  },
+  "web.organizations.leave_organization_success": {
+    "text": "Opuściłeś organizację."
+  },
+  "web.organizations.leave_error": {
+    "text": "Nie udało się opuścić organizacji"
+  },
+  "web.organizations.organizations": {
+    "text": "Organizacje"
+  },
+  "web.organizations.invitations.invited_by_inline": {
+    "text": "przez {email}"
+  },
+  "web.organizations.invitations.invited_as_inline": {
+    "text": "jako {role}"
+  },
+  "web.organizations.invitations.back_to_home": {
+    "text": "Powrót do strony głównej"
+  },
+  "web.organizations.invitations.email_locked_hint": {
+    "text": "To zaproszenie zostało wysłane na ten adres e-mail"
+  },
+  "web.organizations.invitations.signup_continue": {
+    "text": "Kontynuuj"
+  },
+  "web.organizations.invitations.signin_continue": {
+    "text": "Zaloguj się"
+  },
+  "web.organizations.invitations.confirm_join_below": {
+    "text": "Już prawie gotowe — potwierdź poniżej, aby dołączyć do organizacji."
+  },
+  "web.organizations.invitations.go_to_organizations": {
+    "text": "Przejdź do organizacji"
+  },
+  "web.organizations.invitations.already_member": {
+    "text": "Jesteś już członkiem tej organizacji"
+  },
+  "web.organizations.invitations.join_organization": {
+    "text": "Dołącz do {orgName}"
+  },
+  "web.organizations.invitations.sign_in_to_join": {
+    "text": "Zaloguj się, aby dołączyć do {orgName}"
+  },
+  "web.organizations.invitations.decline": {
+    "text": "Odrzuć"
+  },
+  "web.organizations.members.member_quota": {
+    "text": "{used} z {limit} członków"
+  },
+  "web.organizations.members.pending_suffix": {
+    "text": "(oczekujących: {count})"
+  },
+  "web.organizations.members.limit_reached_hint": {
+    "text": "Osiągnięto limit członków."
+  },
+  "web.organizations.sso.title": {
+    "text": "Jednokrotne logowanie (SSO)"
+  },
+  "web.organizations.sso.description": {
+    "text": "Skonfiguruj SSO, aby umożliwić członkom logowanie za pomocą dostawcy tożsamości Twojej organizacji"
+  },
+  "web.organizations.sso.provider_type": {
+    "text": "Typ dostawcy"
+  },
+  "web.organizations.sso.provider_type_description": {
+    "text": "Wybierz dostawcę tożsamości swojej organizacji"
+  },
+  "web.organizations.sso.display_name": {
+    "text": "Nazwa wyświetlana"
+  },
+  "web.organizations.sso.display_name_hint": {
+    "text": "Przyjazna nazwa wyświetlana użytkownikom podczas logowania"
+  },
+  "web.organizations.sso.display_name_placeholder": {
+    "text": "np. Acme Corp SSO"
+  },
+  "web.organizations.sso.client_id": {
+    "text": "Client ID"
+  },
+  "web.organizations.sso.client_id_placeholder": {
+    "text": "Twój identyfikator klienta OAuth"
+  },
+  "web.organizations.sso.client_secret": {
+    "text": "Client Secret"
+  },
+  "web.organizations.sso.client_secret_placeholder": {
+    "text": "Twój sekret klienta OAuth"
+  },
+  "web.organizations.sso.client_secret_update_hint": {
+    "text": "Pozostaw puste, aby zachować istniejący sekret"
+  },
+  "web.organizations.sso.tenant_id": {
+    "text": "Tenant ID"
+  },
+  "web.organizations.sso.tenant_id_hint": {
+    "text": "Identyfikator dzierżawy Azure AD / Entra ID"
+  },
+  "web.organizations.sso.tenant_id_placeholder": {
+    "text": "np. 12345678-1234-1234-1234-123456789abc"
+  },
+  "web.organizations.sso.issuer": {
+    "text": "Issuer URL"
+  },
+  "web.organizations.sso.issuer_hint": {
+    "text": "Adres URL wykrywania OIDC dla Twojego dostawcy tożsamości"
+  },
+  "web.organizations.sso.issuer_placeholder": {
+    "text": "np. https://login.example.com"
+  },
+  "web.organizations.sso.view_discovery_document": {
+    "text": "Wyświetl dokument wykrywania"
+  },
+  "web.organizations.sso.callback_url": {
+    "text": "Callback URL"
+  },
+  "web.organizations.sso.callback_url_hint": {
+    "text": "Dodaj ten adres URL do dozwolonych identyfikatorów URI przekierowania u swojego dostawcy tożsamości"
+  },
+  "web.organizations.sso.allowed_domains": {
+    "text": "Dozwolone domeny e-mail"
+  },
+  "web.organizations.sso.allowed_domains_hint": {
+    "text": "Tylko użytkownicy z adresami e-mail z tych domen mogą się logować. Pozostaw puste, aby zezwolić na wszystkie domeny."
+  },
+  "web.organizations.sso.domain_placeholder": {
+    "text": "np. acme.com"
+  },
+  "web.organizations.sso.invalid_domain": {
+    "text": "Wprowadź prawidłową domenę (np. example.com)"
+  },
+  "web.organizations.sso.domain_exists": {
+    "text": "Ta domena jest już na liście"
+  },
+  "web.organizations.sso.remove_domain": {
+    "text": "Usuń {domain}"
+  },
+  "web.organizations.sso.enabled": {
+    "text": "Włącz SSO"
+  },
+  "web.organizations.sso.enabled_hint": {
+    "text": "Po włączeniu członkowie organizacji mogą logować się za pomocą tego dostawcy SSO"
+  },
+  "web.organizations.sso.enforce_sso_only": {
+    "text": "Wymuś tylko SSO"
+  },
+  "web.organizations.sso.enforce_sso_only_hint": {
+    "text": "Wymagaj SSO dla wszystkich logowań w tej domenie. Po włączeniu uwierzytelnianie oparte na haśle jest wyłączone."
+  },
+  "web.organizations.sso.grant_org_scope": {
+    "text": "Przyznaj dostęp do całej organizacji"
+  },
+  "web.organizations.sso.grant_org_scope_hint": {
+    "text": "Nowi członkowie dołączający za pośrednictwem SSO tej domeny otrzymają dostęp do wszystkich domen organizacji. Nie wpływa to na istniejących członków. Po wyłączeniu (domyślnie) nowi członkowie mają dostęp tylko do tej domeny."
+  },
+  "web.organizations.sso.save_config": {
+    "text": "Zapisz konfigurację SSO"
+  },
+  "web.organizations.sso.delete_config": {
+    "text": "Usuń konfigurację"
+  },
+  "web.organizations.sso.delete_confirm": {
+    "text": "Czy na pewno? Spowoduje to wyłączenie SSO dla Twojej organizacji."
+  },
+  "web.organizations.sso.load_error": {
+    "text": "Nie udało się załadować konfiguracji SSO"
+  },
+  "web.organizations.sso.save_error": {
+    "text": "Nie udało się zapisać konfiguracji SSO"
+  },
+  "web.organizations.sso.create_success": {
+    "text": "Konfiguracja SSO została pomyślnie utworzona"
+  },
+  "web.organizations.sso.update_success": {
+    "text": "Konfiguracja SSO została pomyślnie zaktualizowana"
+  },
+  "web.organizations.sso.delete_success": {
+    "text": "Konfiguracja SSO została pomyślnie usunięta"
+  },
+  "web.organizations.sso.delete_error": {
+    "text": "Nie udało się usunąć konfiguracji SSO"
+  },
+  "web.organizations.sso.test_connection": {
+    "text": "Testuj połączenie"
+  },
+  "web.organizations.sso.test_connection_hint": {
+    "text": "Sprawdź, czy dostawca tożsamości jest osiągalny (nie weryfikuje poświadczeń)"
+  },
+  "web.organizations.sso.test_button": {
+    "text": "Testuj połączenie"
+  },
+  "web.organizations.sso.testing": {
+    "text": "Testowanie..."
+  },
+  "web.organizations.sso.test_error": {
+    "text": "Nie udało się przetestować połączenia"
+  },
+  "web.organizations.sso.auth_endpoint": {
+    "text": "Punkt końcowy autoryzacji"
+  },
+  "web.organizations.sso.missing_fields": {
+    "text": "Brakujące pola"
+  },
+  "web.organizations.sso.status_enabled": {
+    "text": "Włączone"
+  },
+  "web.organizations.sso.status_configured": {
+    "text": "Skonfigurowano"
+  },
+  "web.organizations.sso.domain_sso_title": {
+    "text": "SSO domeny"
+  },
+  "web.organizations.sso.domain_sso_description": {
+    "text": "Skonfiguruj SSO dla każdej zweryfikowanej domeny"
+  },
+  "web.organizations.sso.provider_type_locked_hint": {
+    "text": "Aby zmienić dostawcę, najpierw usuń tę konfigurację"
+  },
+  "web.organizations.sso.status_not_configured": {
+    "text": "Nieskonfigurowano"
+  },
+  "web.organizations.sso.no_domains": {
+    "text": "Brak zweryfikowanych domen"
+  },
+  "web.organizations.sso.no_domains_description": {
+    "text": "Dodaj i zweryfikuj domenę przed skonfigurowaniem dla niej SSO."
+  },
+  "web.organizations.tabs.team": {
+    "text": "Zespół"
+  },
+  "web.organizations.tabs.sso": {
+    "text": "SSO"
   }
 }

--- a/locales/content/pl/workspace-organizations.json
+++ b/locales/content/pl/workspace-organizations.json
@@ -904,7 +904,7 @@
     "text": "Aby zmienić dostawcę, najpierw usuń tę konfigurację"
   },
   "web.organizations.sso.status_not_configured": {
-    "text": "Nieskonfigurowano"
+    "text": "Nie skonfigurowano"
   },
   "web.organizations.sso.no_domains": {
     "text": "Brak zweryfikowanych domen"


### PR DESCRIPTION
## `pl` translation update

Automated export of completed **pl** translations from the translation task DB.
Scope: `locales/content/pl/` only — 25 file(s), +1838/-20.

✅ `i18n validate variables`: no variable mismatches.

---

### Local quality review

> Produced by a fresh, isolated `claude` review agent (model `claude-sonnet-5`, agent `saas-translator`) that read
> `locales/AGENT_TRANSLATION_PROTOCOL.md` and inspected this branch's diff before the PR was opened.

**Verdict:** ⚠️ Needs review — minor grammar/consistency issues, no broken variables.

**Summary:** Large addition of new keys (organizations, domains, billing, colonel, email) across pl locale; all placeholder tokens ({var}, %{var}, pipe-plurals) are preserved correctly and brand names are untouched. A few Polish-specific wording issues are worth a maintainer's attention before merge.

**Critical (must fix):** None.

**Warnings:**
- `api.invite.errors.invitation_already_processed`: "Zaproszenie zostało już %{status}" injects a raw status value directly into a Polish sentence without grammatical agreement — likely to render as awkward/mixed-language text (e.g. an English enum value dropped mid-sentence). Compare `api.organizations.invitations.errors.accept_already_acted`, which sidesteps this with a label pattern ("...obsłużone: %{status}"); the invite-errors file should use the same safe pattern.
- `Nieskonfigurowano` (used in `web.domains.email.badge_not_configured`, `web.domains.incoming.badge_not_configured`, `web.organizations.sso.status_not_configured`) is not standard Polish — should be either "Nieskonfigurowane" (adjective, matches badge/status usage) or "Nie skonfigurowano" (two words, impersonal verb). Same typo repeated 3×, so a single fix + consistency check would resolve all.
- `web.billing.features.manage_sso` translates the SSO feature label as bare "SSO" while `web.billing.overview.entitlements.manage_sso` uses "Jednokrotne logowanie (SSO)" for what appears to be the same feature — confirm both should differ, or align.

**Notes:**
- `email.*.signature` bulk change "Delano" → "Zespół pomocy technicznej" is consistent across ~24 templates, matching the source rebrand.
- `_guidance.context` keys correctly left in English (doc metadata, per convention).
- New entries lack `source_hash`/`content_hash` — expected until the hash-generation script runs.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
