### PR TITLE
i18n: update pt_BR translations

### DIFF
--- a/locales/content/pt_BR/00-common.json
+++ b/locales/content/pt_BR/00-common.json
@@ -1299,7 +1299,7 @@
     "source_hash": "fc78d9cb"
   },
   "web.INSTRUCTION.phishing_warning": {
-    "text": "Sempre verifique se você está no site oficial do {product_name}. Fraudadores às vezes criam sites falsos que parecem exatamente com o {product_name} para roubar suas informações confidenciais. Para evitar ataques de phishing, verifique o domínio da região antes de criar novos links.",
+    "text": "Sempre verifique se você está no site oficial do {product_name}. Fraudadores às vezes criam sites falsos idênticos ao {product_name} para roubar suas mensagens confidenciais. Para evitar ataques de phishing, confira o domínio da região antes de criar novos links.",
     "source_hash": "b588f5b2"
   },
   "web.pricing.title": {
@@ -1383,5 +1383,110 @@
     "text": "Faça upgrade para desbloquear mais recursos",
     "context": "Description shown for free plan users encouraging upgrade",
     "source_hash": "783f174c"
+  },
+  "api.errors.authentication_required": {
+    "text": "Autenticação necessária"
+  },
+  "api.errors.sso_only_action_blocked": {
+    "text": "Esta ação não está disponível no modo somente SSO"
+  },
+  "web.COMMON.configure": {
+    "text": "Configurar"
+  },
+  "web.COMMON.copy_to_clipboard": {
+    "text": "Copiar para a área de transferência"
+  },
+  "web.COMMON.add": {
+    "text": "Adicionar"
+  },
+  "web.COMMON.enabled": {
+    "text": "Ativado"
+  },
+  "web.COMMON.disabled": {
+    "text": "Desativado"
+  },
+  "web.COMMON.yes_delete": {
+    "text": "Sim, excluir"
+  },
+  "web.COMMON.error_code": {
+    "text": "Código de erro"
+  },
+  "web.COMMON.http_status": {
+    "text": "Status HTTP"
+  },
+  "web.COMMON.details": {
+    "text": "Detalhes"
+  },
+  "web.COMMON.field_confirm_password": {
+    "text": "Confirmar senha"
+  },
+  "web.COMMON.passwords_must_match": {
+    "text": "As senhas devem coincidir"
+  },
+  "web.COMMON.and": {
+    "text": "e"
+  },
+  "web.COMMON.or": {
+    "text": "ou"
+  },
+  "web.COMMON.copied": {
+    "text": "Copiado"
+  },
+  "web.COMMON.copy": {
+    "text": "Copiar"
+  },
+  "web.COMMON.copy_email": {
+    "text": "Copiar endereço de e-mail"
+  },
+  "web.COMMON.copy_id": {
+    "text": "Copiar ID da conta"
+  },
+  "web.COMMON.org_id_tooltip": {
+    "text": "O identificador exclusivo da sua organização"
+  },
+  "web.COMMON.success": {
+    "text": "Sucesso"
+  },
+  "web.COMMON.need_help": {
+    "text": "Precisa de ajuda"
+  },
+  "web.COMMON.open_help_dialog": {
+    "text": "Abrir caixa de diálogo de ajuda"
+  },
+  "web.COMMON.focus_is_now_in_the_main_text_area": {
+    "text": "O foco está agora na área de texto principal"
+  },
+  "web.LABELS.show_passphrase": {
+    "text": "Mostrar frase secreta"
+  },
+  "web.LABELS.hide_passphrase": {
+    "text": "Ocultar frase secreta"
+  },
+  "web.LABELS.copy_icon": {
+    "text": "Ícone de copiar"
+  },
+  "web.LABELS.copied_icon": {
+    "text": "Ícone de copiado"
+  },
+  "web.STATUS.unverified": {
+    "text": "Não verificado"
+  },
+  "web.TITLES.domain_detail": {
+    "text": "Configurações de domínio"
+  },
+  "web.TITLES.domain_signin": {
+    "text": "Configuração de entrada"
+  },
+  "web.TITLES.domain_sso": {
+    "text": "SSO do domínio"
+  },
+  "web.TITLES.domain_signup": {
+    "text": "Validação de cadastro do domínio"
+  },
+  "web.TITLES.domain_email": {
+    "text": "Configuração de e-mail"
+  },
+  "web.TITLES.domain_incoming": {
+    "text": "Mensagens confidenciais recebidas"
   }
 }

--- a/locales/content/pt_BR/10-layout.json
+++ b/locales/content/pt_BR/10-layout.json
@@ -148,7 +148,7 @@
     "source_hash": "b9766df3"
   },
   "web.help.secret_view_faq.what_am_i_looking_at.description": {
-    "text": "Você está visualizando uma mensagem segura que foi compartilhada com você através do {product_name}. Este conteúdo é exibido apenas uma vez e depois é permanentemente excluído dos nossos servidores.",
+    "text": "Você está visualizando uma mensagem segura que foi compartilhada com você por meio do {product_name}. Este conteúdo é exibido apenas uma vez e depois excluído permanentemente dos nossos servidores.",
     "source_hash": "e0f1a10c"
   },
   "web.help.secret_view_faq.can_i_view_again.title": {
@@ -264,7 +264,7 @@
     "source_hash": "e2f124cd"
   },
   "web.layout.visit_onetime_secret_homepage": {
-    "text": "Visitar página inicial do {product_name}",
+    "text": "Visitar a página inicial do {product_name}",
     "source_hash": "625556d2"
   },
   "web.layout.footer_navigation": {
@@ -338,5 +338,11 @@
   "web.layout.workspace_context": {
     "text": "Contexto da área de trabalho",
     "source_hash": "dc6fa4f5"
+  },
+  "web.footer.workspace": {
+    "text": "Workspace"
+  },
+  "web.help.default_content": {
+    "text": "Entre em contato com o suporte para obter ajuda"
   }
 }

--- a/locales/content/pt_BR/admin-colonel.json
+++ b/locales/content/pt_BR/admin-colonel.json
@@ -634,5 +634,152 @@
   "web.colonel.feedback.when_you_submit_feedback_well_see": {
     "text": "Quando você enviar seu feedback, veremos:",
     "source_hash": "fe77172e"
+  },
+  "web.colonel.previewPlanMode": {
+    "text": "Modo de visualização de plano"
+  },
+  "web.colonel.previewModeDescription": {
+    "text": "Visualize o aplicativo como ele aparece para os clientes em um plano diferente. Isso afeta apenas a sua visualização e não altera o plano real de nenhuma organização."
+  },
+  "web.colonel.previewModeActive": {
+    "text": "Visualização ativa"
+  },
+  "web.colonel.bannedIps.empty": {
+    "text": "Nenhum IP banido"
+  },
+  "web.colonel.bannedIps.currentIp": {
+    "text": "Seu endereço IP atual"
+  },
+  "web.colonel.bannedIps.confirmUnban": {
+    "text": "Desbanir {ip}?"
+  },
+  "web.colonel.bannedIps.actions.ban": {
+    "text": "Banir IP"
+  },
+  "web.colonel.bannedIps.actions.quickBan": {
+    "text": "Banimento rápido"
+  },
+  "web.colonel.bannedIps.actions.unban": {
+    "text": "Desbanir"
+  },
+  "web.colonel.bannedIps.actions.cancel": {
+    "text": "Cancelar"
+  },
+  "web.colonel.bannedIps.columns.ipAddress": {
+    "text": "Endereço IP"
+  },
+  "web.colonel.bannedIps.columns.reason": {
+    "text": "Motivo"
+  },
+  "web.colonel.bannedIps.columns.bannedAt": {
+    "text": "Banido em"
+  },
+  "web.colonel.bannedIps.columns.bannedBy": {
+    "text": "Banido por"
+  },
+  "web.colonel.bannedIps.error.banFailed": {
+    "text": "Falha ao banir o endereço IP"
+  },
+  "web.colonel.bannedIps.error.unbanFailed": {
+    "text": "Falha ao desbanir o endereço IP"
+  },
+  "web.colonel.bannedIps.form.title": {
+    "text": "Banir endereço IP"
+  },
+  "web.colonel.bannedIps.form.ipLabel": {
+    "text": "Endereço IP"
+  },
+  "web.colonel.bannedIps.form.reasonLabel": {
+    "text": "Motivo"
+  },
+  "web.colonel.bannedIps.form.reasonPlaceholder": {
+    "text": "Motivo opcional"
+  },
+  "web.colonel.bannedIps.success.banned": {
+    "text": "O endereço IP {ip} foi banido"
+  },
+  "web.colonel.bannedIps.success.unbanned": {
+    "text": "O endereço IP {ip} foi desbanido"
+  },
+  "web.colonel.customDomains.empty": {
+    "text": "Nenhum domínio personalizado configurado"
+  },
+  "web.colonel.customDomains.noLogo": {
+    "text": "Sem logotipo"
+  },
+  "web.colonel.customDomains.labels.organization": {
+    "text": "Organização"
+  },
+  "web.colonel.customDomains.labels.externalId": {
+    "text": "ID externo"
+  },
+  "web.colonel.customDomains.labels.created": {
+    "text": "Criado"
+  },
+  "web.colonel.customDomains.labels.updated": {
+    "text": "Atualizado"
+  },
+  "web.colonel.customDomains.labels.favicon": {
+    "text": "Favicon"
+  },
+  "web.colonel.customDomains.status.verified": {
+    "text": "Verificado"
+  },
+  "web.colonel.customDomains.status.resolving": {
+    "text": "Resolvendo"
+  },
+  "web.colonel.customDomains.status.ready": {
+    "text": "Pronto"
+  },
+  "web.colonel.customDomains.status.publicHomepage": {
+    "text": "Página inicial pública"
+  },
+  "web.colonel.customDomains.status.publicApi": {
+    "text": "API pública"
+  },
+  "web.colonel.customDomains.status.pending": {
+    "text": "Pendente"
+  },
+  "web.colonel.pagination.showing": {
+    "text": "Exibindo {start}–{end} de {total}"
+  },
+  "web.colonel.pagination.itemsPerPage": {
+    "text": "Itens por página"
+  },
+  "web.colonel.pagination.perPage": {
+    "text": "{count} por página"
+  },
+  "web.colonel.pagination.pageOf": {
+    "text": "Página {current} de {total}"
+  },
+  "web.colonel.secrets.empty": {
+    "text": "Nenhuma mensagem confidencial encontrada"
+  },
+  "web.colonel.secrets.never": {
+    "text": "Nunca"
+  },
+  "web.colonel.secrets.columns.shortId": {
+    "text": "ID curto"
+  },
+  "web.colonel.secrets.columns.state": {
+    "text": "Estado"
+  },
+  "web.colonel.secrets.columns.created": {
+    "text": "Criado"
+  },
+  "web.colonel.secrets.columns.expiration": {
+    "text": "Expiração"
+  },
+  "web.colonel.secrets.columns.age": {
+    "text": "Idade (dias)"
+  },
+  "web.colonel.secrets.state.new": {
+    "text": "Novo"
+  },
+  "web.colonel.secrets.state.received": {
+    "text": "Recebido"
+  },
+  "web.colonel.secrets.state.viewed": {
+    "text": "Visualizado"
   }
 }

--- a/locales/content/pt_BR/api-account-errors.json
+++ b/locales/content/pt_BR/api-account-errors.json
@@ -1,0 +1,8 @@
+{
+  "api.account.errors.invalid_email": {
+    "text": "Esse é um endereço de e-mail válido?"
+  },
+  "api.account.errors.password_too_short": {
+    "text": "A senha é muito curta"
+  }
+}

--- a/locales/content/pt_BR/api-domains-errors.json
+++ b/locales/content/pt_BR/api-domains-errors.json
@@ -1,0 +1,29 @@
+{
+  "api.domains.errors.domain_id_required": {
+    "text": "ID do domínio obrigatório"
+  },
+  "api.domains.errors.domain_not_found": {
+    "text": "Domínio não encontrado: %{extid}"
+  },
+  "api.domains.errors.organization_not_found": {
+    "text": "Organização não encontrada para o domínio: %{domain}"
+  },
+  "api.domains.errors.incoming_secrets_disabled": {
+    "text": "O recebimento de mensagens confidenciais não está habilitado nesta instância"
+  },
+  "api.domains.errors.incoming_secrets_entitlement_required": {
+    "text": "O gerenciamento de mensagens confidenciais recebidas requer o entitlement incoming_secrets. Faça upgrade do seu plano."
+  },
+  "api.domains.errors.incoming_config_not_found": {
+    "text": "Configuração de recebimento não encontrada para o domínio: %{extid}"
+  },
+  "api.domains.errors.recipients_max_exceeded": {
+    "text": "Máximo de %{max} destinatários permitidos"
+  },
+  "api.domains.errors.recipients_invalid_email": {
+    "text": "E-mail inválido: %{email}"
+  },
+  "api.domains.errors.recipients_duplicate": {
+    "text": "Não são permitidos e-mails de destinatários duplicados"
+  }
+}

--- a/locales/content/pt_BR/api-entitlements-errors.json
+++ b/locales/content/pt_BR/api-entitlements-errors.json
@@ -1,0 +1,71 @@
+{
+  "api.entitlements.errors.context_unavailable": {
+    "text": "Não foi possível verificar os entitlements (contexto da organização indisponível)"
+  },
+  "api.entitlements.errors.api_access_required": {
+    "text": "O acesso à API requer upgrade do plano"
+  },
+  "api.entitlements.errors.custom_privacy_defaults_required": {
+    "text": "Os padrões de privacidade personalizados requerem upgrade do plano"
+  },
+  "api.entitlements.errors.extended_default_expiration_required": {
+    "text": "A expiração padrão estendida requer upgrade do plano"
+  },
+  "api.entitlements.errors.custom_domains_required": {
+    "text": "Os domínios personalizados requerem upgrade do plano"
+  },
+  "api.entitlements.errors.custom_branding_required": {
+    "text": "A marca personalizada requer upgrade do plano"
+  },
+  "api.entitlements.errors.homepage_secrets_required": {
+    "text": "As mensagens confidenciais na página inicial requerem upgrade do plano"
+  },
+  "api.entitlements.errors.incoming_secrets_required": {
+    "text": "As mensagens confidenciais recebidas requerem upgrade do plano"
+  },
+  "api.entitlements.errors.custom_mail_sender_required": {
+    "text": "O remetente de e-mail personalizado requer upgrade do plano"
+  },
+  "api.entitlements.errors.flexible_from_domain_required": {
+    "text": "O domínio de origem flexível requer upgrade do plano"
+  },
+  "api.entitlements.errors.manage_org_required": {
+    "text": "O gerenciamento de organizações requer upgrade do plano"
+  },
+  "api.entitlements.errors.manage_teams_required": {
+    "text": "O gerenciamento de equipes requer upgrade do plano"
+  },
+  "api.entitlements.errors.manage_members_required": {
+    "text": "O gerenciamento de membros requer upgrade do plano"
+  },
+  "api.entitlements.errors.manage_sso_required": {
+    "text": "O gerenciamento de SSO requer upgrade do plano"
+  },
+  "api.entitlements.errors.audit_logs_required": {
+    "text": "Os logs de auditoria requerem upgrade do plano"
+  },
+  "api.entitlements.errors.custom_signup_validation_required": {
+    "text": "A validação de cadastro personalizada requer upgrade do plano"
+  },
+  "api.entitlements.errors.create_secrets_required": {
+    "text": "Criar mensagens confidenciais requer upgrade do plano"
+  },
+  "api.entitlements.errors.view_receipt_required": {
+    "text": "Ver recibos requer upgrade do plano"
+  },
+  "api.entitlements.errors.notifications_required": {
+    "text": "As notificações requerem upgrade do plano"
+  },
+  "api.entitlements.errors.workspace_branding_required": {
+    "text": "A marca do espaço de trabalho requer upgrade do plano"
+  },
+  "api.entitlements.errors.ip_access_rules_required": {
+    "text": "As regras de acesso por IP requerem upgrade do plano"
+  },
+  "api.entitlements.errors.manage_billing_required": {
+    "text": "O gerenciamento de cobrança requer upgrade do plano"
+  },
+  "api.entitlements.errors.custom_signin_config_required": {
+    "text": "A configuração de início de sessão personalizada requer upgrade do plano"
+  }
+}

--- a/locales/content/pt_BR/api-feedback-errors.json
+++ b/locales/content/pt_BR/api-feedback-errors.json
@@ -1,0 +1,5 @@
+{
+  "api.feedback.errors.rate_limit_exceeded": {
+    "text": "Muitos envios de feedback. Por favor, tente novamente mais tarde."
+  }
+}

--- a/locales/content/pt_BR/api-incoming-errors.json
+++ b/locales/content/pt_BR/api-incoming-errors.json
@@ -1,0 +1,5 @@
+{
+  "api.incoming.errors.custom_domain_unresolved": {
+    "text": "Não foi possível resolver a organização do domínio personalizado"
+  }
+}

--- a/locales/content/pt_BR/api-invite-errors.json
+++ b/locales/content/pt_BR/api-invite-errors.json
@@ -1,0 +1,23 @@
+{
+  "api.invite.errors.invitation_not_found_or_expired": {
+    "text": "Convite não encontrado ou expirado"
+  },
+  "api.invite.errors.token_required": {
+    "text": "O token é obrigatório"
+  },
+  "api.invite.errors.organization_no_longer_exists": {
+    "text": "A organização não existe mais"
+  },
+  "api.invite.errors.invitation_already_processed": {
+    "text": "O convite já foi %{status}"
+  },
+  "api.invite.errors.invitation_expired": {
+    "text": "O convite expirou"
+  },
+  "api.invite.errors.email_mismatch": {
+    "text": "Seu endereço de e-mail não corresponde ao convite"
+  },
+  "api.invite.errors.already_member": {
+    "text": "Você já é membro desta organização"
+  }
+}

--- a/locales/content/pt_BR/api-organizations-errors.json
+++ b/locales/content/pt_BR/api-organizations-errors.json
@@ -1,0 +1,107 @@
+{
+  "api.organizations.errors.domain_scoped_forbidden": {
+    "text": "Membros restritos a um domínio não podem realizar esta ação"
+  },
+  "api.organizations.errors.organization_not_found": {
+    "text": "Organização não encontrada: %{extid}"
+  },
+  "api.organizations.errors.organization_owner_required": {
+    "text": "Apenas o proprietário da organização pode realizar esta ação"
+  },
+  "api.organizations.errors.organization_member_required": {
+    "text": "Você precisa ser membro da organização para realizar esta ação"
+  },
+  "api.organizations.errors.organization_admin_required": {
+    "text": "Apenas proprietários e administradores da organização podem realizar esta ação"
+  },
+  "api.organizations.errors.extid_required": {
+    "text": "ID da organização obrigatório"
+  },
+  "api.organizations.errors.display_name_required": {
+    "text": "O nome da organização é obrigatório"
+  },
+  "api.organizations.errors.display_name_too_long": {
+    "text": "O nome da organização deve ter menos de %{max} caracteres"
+  },
+  "api.organizations.errors.description_too_long": {
+    "text": "A descrição deve ter menos de %{max} caracteres"
+  },
+  "api.organizations.errors.contact_email_exists": {
+    "text": "Já existe uma organização com este e-mail de contato"
+  },
+  "api.organizations.errors.creation_in_progress": {
+    "text": "Criação da organização em andamento. Por favor, tente novamente."
+  },
+  "api.organizations.errors.organization_limit_reached": {
+    "text": "Limite de organizações atingido. Faça upgrade do seu plano para criar mais organizações."
+  },
+  "api.organizations.invitations.errors.invitation_not_found": {
+    "text": "Convite não encontrado"
+  },
+  "api.organizations.invitations.errors.email_required": {
+    "text": "O e-mail é obrigatório"
+  },
+  "api.organizations.invitations.errors.invalid_email_format": {
+    "text": "Formato de e-mail inválido"
+  },
+  "api.organizations.invitations.errors.invalid_role": {
+    "text": "A função deve ser membro ou administrador"
+  },
+  "api.organizations.invitations.errors.cannot_invite_as_owner": {
+    "text": "Não é possível convidar como proprietário"
+  },
+  "api.organizations.invitations.errors.user_already_member": {
+    "text": "O usuário já é membro desta organização"
+  },
+  "api.organizations.invitations.errors.invitation_already_pending": {
+    "text": "Já existe um convite pendente para este e-mail"
+  },
+  "api.organizations.invitations.errors.member_limit_reached": {
+    "text": "Limite de membros atingido. Faça upgrade do seu plano para convidar mais membros."
+  },
+  "api.organizations.invitations.errors.resend_only_pending": {
+    "text": "Só é possível reenviar convites pendentes"
+  },
+  "api.organizations.invitations.errors.resend_limit_reached": {
+    "text": "Limite máximo de reenvios (%{max}) atingido"
+  },
+  "api.organizations.invitations.errors.revoke_only_pending": {
+    "text": "Só é possível revogar convites pendentes"
+  },
+  "api.organizations.members.errors.member_not_found": {
+    "text": "Membro não encontrado: %{extid}"
+  },
+  "api.organizations.members.errors.member_not_in_organization": {
+    "text": "Membro não encontrado nesta organização"
+  },
+  "api.organizations.members.errors.member_not_active": {
+    "text": "O membro não está ativo"
+  },
+  "api.organizations.members.errors.invalid_role_value": {
+    "text": "Função inválida. Deve ser uma das seguintes: %{roles}"
+  },
+  "api.organizations.members.errors.cannot_change_owner_role": {
+    "text": "Não é possível alterar a função do proprietário. Use a transferência de propriedade."
+  },
+  "api.organizations.members.errors.member_already_has_role": {
+    "text": "O membro já tem a função: %{role}"
+  },
+  "api.organizations.members.errors.cannot_promote_to_owner": {
+    "text": "Não é possível promover a proprietário. Use a transferência de propriedade."
+  },
+  "api.organizations.members.errors.must_be_member": {
+    "text": "Você precisa ser membro desta organização"
+  },
+  "api.organizations.members.errors.cannot_remove_owner": {
+    "text": "Não é possível remover o proprietário da organização. Transfira a propriedade primeiro."
+  },
+  "api.organizations.members.errors.cannot_remove_self": {
+    "text": "Não é possível remover a si mesmo. Use a opção de sair da organização."
+  },
+  "api.organizations.members.errors.admin_cannot_remove_admin": {
+    "text": "Administradores não podem remover outros administradores. Apenas proprietários podem."
+  },
+  "api.organizations.members.errors.no_permission_to_remove": {
+    "text": "Você não tem permissão para remover membros"
+  }
+}

--- a/locales/content/pt_BR/api-secrets-errors.json
+++ b/locales/content/pt_BR/api-secrets-errors.json
@@ -1,0 +1,11 @@
+{
+  "api.secrets.errors.domain_permission_authenticated_non_owner": {
+    "text": "Você não tem permissão para usar o domínio: %{domain}"
+  },
+  "api.secrets.errors.domain_public_sharing_disabled": {
+    "text": "Compartilhamento público desativado para o domínio: %{domain}"
+  },
+  "api.secrets.errors.domain_permission_anonymous_cross_domain": {
+    "text": "Você não tem permissão para usar o domínio: %{domain}"
+  }
+}

--- a/locales/content/pt_BR/email.json
+++ b/locales/content/pt_BR/email.json
@@ -60,7 +60,7 @@
     "source_hash": "88c72144"
   },
   "email.welcome.signature": {
-    "text": "Delano",
+    "text": "Equipe de Suporte",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -100,7 +100,7 @@
     "source_hash": "fbb7eb2d"
   },
   "email.password_request.signature": {
-    "text": "Delano",
+    "text": "Equipe de Suporte",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -145,7 +145,7 @@
     "source_hash": "1863f5be"
   },
   "email.magic_link.signature": {
-    "text": "Delano",
+    "text": "Equipe de Suporte",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -230,7 +230,7 @@
     "source_hash": "3f6b45dd"
   },
   "email.secret_revealed.signature": {
-    "text": "Delano",
+    "text": "Equipe de Suporte",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -355,7 +355,7 @@
     "source_hash": "734882d2"
   },
   "email.organization_invitation.signature": {
-    "text": "Delano",
+    "text": "Equipe de Suporte",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -395,7 +395,7 @@
     "source_hash": "be92cff3"
   },
   "email.password_changed.signature": {
-    "text": "Delano",
+    "text": "Equipe de Suporte",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -445,7 +445,7 @@
     "source_hash": "f8d47b82"
   },
   "email.email_changed.signature": {
-    "text": "Delano",
+    "text": "Equipe de Suporte",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -495,7 +495,7 @@
     "source_hash": "f8d47b82"
   },
   "email.email_change_requested.signature": {
-    "text": "Delano",
+    "text": "Equipe de Suporte",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -550,7 +550,7 @@
     "source_hash": "d4d835fc"
   },
   "email.email_change_confirmation.signature": {
-    "text": "Delano",
+    "text": "Equipe de Suporte",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -580,7 +580,7 @@
     "source_hash": "e7c11bb0"
   },
   "email.mfa_enabled.signature": {
-    "text": "Delano",
+    "text": "Equipe de Suporte",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -605,7 +605,7 @@
     "source_hash": "97ef0a3e"
   },
   "email.mfa_disabled.signature": {
-    "text": "Delano",
+    "text": "Equipe de Suporte",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -650,7 +650,7 @@
     "source_hash": "450c54c5"
   },
   "email.new_login_alert.signature": {
-    "text": "Delano",
+    "text": "Equipe de Suporte",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -670,7 +670,7 @@
     "source_hash": "d442beed"
   },
   "email.member_removed.signature": {
-    "text": "Delano",
+    "text": "Equipe de Suporte",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -690,7 +690,7 @@
     "source_hash": "c2280c0c"
   },
   "email.role_changed.signature": {
-    "text": "Delano",
+    "text": "Equipe de Suporte",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -710,7 +710,7 @@
     "source_hash": "7095fc69"
   },
   "email.organization_deleted.signature": {
-    "text": "Delano",
+    "text": "Equipe de Suporte",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -750,7 +750,7 @@
     "source_hash": "36008943"
   },
   "email.payment_receipt.signature": {
-    "text": "Delano",
+    "text": "Equipe de Suporte",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -775,7 +775,7 @@
     "source_hash": "926406b1"
   },
   "email.payment_failed.signature": {
-    "text": "Delano",
+    "text": "Equipe de Suporte",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -800,7 +800,7 @@
     "source_hash": "66a1419e"
   },
   "email.trial_expiring.signature": {
-    "text": "Delano",
+    "text": "Equipe de Suporte",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -825,7 +825,7 @@
     "source_hash": "5a96ae38"
   },
   "email.subscription_changed.signature": {
-    "text": "Delano",
+    "text": "Equipe de Suporte",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -853,5 +853,41 @@
     "text": "Onetime Secret",
     "renderer": "erb",
     "source_hash": "1cd0194a"
+  },
+  "email.common.secret_link_label": {
+    "text": "Link confidencial"
+  },
+  "email.common.automated_notice": {
+    "text": "Esta é uma mensagem automática de %{product_name}."
+  },
+  "email.common.support_label": {
+    "text": "Suporte"
+  },
+  "email.expiration_warning.signature": {
+    "text": "Equipe de Suporte"
+  },
+  "email.expiration_warning.footer_note": {
+    "text": "Você recebeu este e-mail porque uma mensagem confidencial que você criou no %{product_name} está prestes a expirar."
+  },
+  "email.feedback_email.user_id_label": {
+    "text": "Usuário:"
+  },
+  "email.feedback_email.timezone_label": {
+    "text": "Fuso horário:"
+  },
+  "email.feedback_email.version_label": {
+    "text": "Versão:"
+  },
+  "email.incoming_secret.footer_note": {
+    "text": "Você recebeu este e-mail porque alguém usou o %{product_name} para enviar uma mensagem confidencial a você. Se você não estava esperando por isso, pode ignorar este e-mail com segurança."
+  },
+  "email.secret_link.passphrase_label": {
+    "text": "Frase secreta necessária:"
+  },
+  "email.secret_link.passphrase_required": {
+    "text": "Esta mensagem confidencial está protegida por uma frase secreta. O remetente deve fornecê-la a você separadamente."
+  },
+  "email.secret_link.footer_note": {
+    "text": "Você recebeu este e-mail porque %{sender_email} usou o %{product_name} para compartilhar uma mensagem confidencial com você. Se você não estava esperando por isso, pode ignorar este e-mail com segurança."
   }
 }

--- a/locales/content/pt_BR/feature-feedback.json
+++ b/locales/content/pt_BR/feature-feedback.json
@@ -58,5 +58,14 @@
   "web.feedback.reason_email_change_unauthorized": {
     "text": "Parece que você está relatando uma alteração de e-mail não autorizada na sua conta. Descreva o que aconteceu e investigaremos imediatamente.",
     "source_hash": "00e56551"
+  },
+  "web.feedback.anonymous_no_reply": {
+    "text": "Observação: se você quiser uma resposta, assine ou inclua um endereço de e-mail na mensagem."
+  },
+  "web.feedback.characters_remaining": {
+    "text": "{count} caracteres restantes"
+  },
+  "web.feedback.character_limit_reached": {
+    "text": "Limite de caracteres atingido"
   }
 }

--- a/locales/content/pt_BR/feature-homepage-secrets.json
+++ b/locales/content/pt_BR/feature-homepage-secrets.json
@@ -1,0 +1,50 @@
+{
+  "homepage_secrets.disabled.members_only_eyebrow": {
+    "text": "Instância somente para membros"
+  },
+  "homepage_secrets.disabled.private_instance_eyebrow": {
+    "text": "Instância privada"
+  },
+  "homepage_secrets.disabled.team_link_headline": {
+    "text": "Este link é para a equipe {workspace}."
+  },
+  "homepage_secrets.disabled.signin_headline": {
+    "text": "Entre para criar um {action}."
+  },
+  "homepage_secrets.disabled.signin_headline_action": {
+    "text": "link confidencial"
+  },
+  "homepage_secrets.disabled.team_subtitle": {
+    "text": "Apenas membros autorizados da equipe em {domain} podem criar novos links de uso único aqui. Os destinatários ainda podem abrir qualquer link que tenham recebido."
+  },
+  "homepage_secrets.disabled.public_subtitle": {
+    "text": "Apenas membros autorizados desta instância podem criar novos links de uso único. Os destinatários ainda podem abrir qualquer link que tenham recebido."
+  },
+  "homepage_secrets.disabled.signin_cta": {
+    "text": "Entrar na sua conta"
+  },
+  "homepage_secrets.disabled.what_is_this": {
+    "text": "O que é isto?"
+  },
+  "homepage_secrets.disabled.trust_viewed_once": {
+    "text": "Visualizado uma vez e depois apagado"
+  },
+  "homepage_secrets.disabled.trust_zero_retained": {
+    "text": "Nada é retido"
+  },
+  "homepage_secrets.disabled.promo_title": {
+    "text": "Novidade: os planos gratuitos agora incluem domínios personalizados."
+  },
+  "homepage_secrets.disabled.promo_subtitle": {
+    "text": "Aponte seu domínio para o Onetime Secret e envie mensagens confidenciais com a sua própria marca."
+  },
+  "homepage_secrets.disabled.promo_learn_how": {
+    "text": "Saiba como"
+  },
+  "homepage_secrets.disabled.logo_alt": {
+    "text": "Logotipo de {name}"
+  },
+  "homepage_secrets.disabled.opens_in_new_tab": {
+    "text": "(abre em uma nova aba)"
+  }
+}

--- a/locales/content/pt_BR/feature-incoming.json
+++ b/locales/content/pt_BR/feature-incoming.json
@@ -130,5 +130,26 @@
   "incoming.receipt_link_text": {
     "text": "recibo",
     "source_hash": "6f328609"
+  },
+  "incoming.upgrade_required_title": {
+    "text": "Upgrade necessário"
+  },
+  "incoming.upgrade_required_description": {
+    "text": "Este recurso requer upgrade do plano. Por favor, entre em contato com o proprietário da conta para habilitar as mensagens confidenciais recebidas."
+  },
+  "incoming.validation_memo_too_long": {
+    "text": "A observação deve ter no máximo {max} caracteres"
+  },
+  "incoming.validation_secret_required": {
+    "text": "O conteúdo confidencial é obrigatório"
+  },
+  "incoming.validation_recipient_required": {
+    "text": "Por favor, selecione um destinatário"
+  },
+  "incoming.validation_feature_disabled": {
+    "text": "O recurso de mensagens confidenciais recebidas não está habilitado"
+  },
+  "incoming.validation_form_errors": {
+    "text": "Por favor, verifique se há erros no formulário"
   }
 }

--- a/locales/content/pt_BR/feature-regions.json
+++ b/locales/content/pt_BR/feature-regions.json
@@ -152,7 +152,7 @@
     "source_hash": "1d97f6bd"
   },
   "web.regions.changing_regions_billing_note": {
-    "text": "Se o seu e-mail de contato de cobrança for diferente do e-mail da sua conta {product_name}, use o e-mail de contato de cobrança para a conta na nova região para manter os benefícios da sua assinatura.",
+    "text": "Se o e-mail de contato de cobrança for diferente do e-mail da sua conta {product_name}, use o e-mail de contato de cobrança da conta da nova região para manter os benefícios da sua assinatura.",
     "source_hash": "dac1cc28"
   },
   "web.regions.changing_regions_subscription_note": {
@@ -186,5 +186,8 @@
   "web.regions.jurisdictions.apac.name": {
     "text": "Asia-Pacific",
     "source_hash": "7a757670"
+  },
+  "web.regions.no_region_configured": {
+    "text": "Nenhuma informação de região está disponível para sua conta no momento."
   }
 }

--- a/locales/content/pt_BR/feature-translations.json
+++ b/locales/content/pt_BR/feature-translations.json
@@ -64,7 +64,7 @@
     "source_hash": "13131e36"
   },
   "web.translations.the_following_people_have_donated_their_time_to_": {
-    "text": "As seguintes pessoas doaram seu tempo para ajudar a expandir o alcance do {product_name}:",
+    "text": "As seguintes pessoas dedicaram seu tempo para ajudar a ampliar o alcance do {product_name}:",
     "source_hash": "85a766af"
   },
   "web.translations.translations": {
@@ -84,7 +84,7 @@
     "source_hash": "ba5c4395"
   },
   "web.translations.since_2012_onetime_secret_has_provided_a_secure_": {
-    "text": "Desde 2012, {product_name} fornece uma forma segura de compartilhar informações sensíveis em todo o mundo. Com usuários em regiões onde o inglês não é o idioma principal, traduções precisas são essenciais para tornar a comunicação segura acessível a todos.",
+    "text": "Desde 2012, o {product_name} oferece uma forma segura de compartilhar informações sensíveis em todo o mundo. Com usuários em regiões onde o inglês não é o idioma principal, traduções precisas são essenciais para tornar a comunicação segura acessível a todos.",
     "source_hash": "87a6e9af"
   },
   "web.translations.help_secure_communication_go_global": {

--- a/locales/content/pt_BR/secret-homepage.json
+++ b/locales/content/pt_BR/secret-homepage.json
@@ -144,11 +144,11 @@
     "source_hash": "1cd0194a"
   },
   "web.homepage.one_time_secret_literal": {
-    "text": "Mensagem Confidencial de Uso Único",
+    "text": "{product_name}",
     "source_hash": "7872e050"
   },
   "web.homepage.onetime_secret_homepage": {
-    "text": "Página Inicial do {product_name}",
+    "text": "Página inicial do {product_name}",
     "source_hash": "44bb0581"
   },
   "web.homepage.send_sensitive_information_that_can_only_be_viewed_once": {
@@ -172,7 +172,7 @@
     "source_hash": "0990d163"
   },
   "web.homepage.onetime_secret_helps_us_share_sensitive_informat": {
-    "text": "{product_name} nos ajuda a compartilhar informações sensíveis com segurança, mantendo nossa imagem profissional.",
+    "text": "O {product_name} nos ajuda a compartilhar informações sensíveis com segurança, mantendo nossa imagem profissional.",
     "source_hash": "986a0856"
   },
   "web.homepage.information_shared_through_this_service_can_only": {

--- a/locales/content/pt_BR/secret-manage.json
+++ b/locales/content/pt_BR/secret-manage.json
@@ -128,7 +128,7 @@
     "source_hash": "07fe1b84"
   },
   "web.secrets.onetime_secret_is_a_secure_way_to_share_sensitiv": {
-    "text": "{product_name} é uma forma segura de compartilhar informações sensíveis que se autodestroem após uma única visualização.",
+    "text": "O {product_name} é uma forma segura de compartilhar informações sensíveis que se autodestrói após uma única visualização.",
     "source_hash": "8a163297"
   },
   "web.secrets.what_is_this": {
@@ -476,5 +476,11 @@
   },
   "web.private.send_feedback": {
     "text": "Enviar feedback"
+  },
+  "web.receipt.open_link": {
+    "text": "Abrir link"
+  },
+  "web.secrets.messageDeleted": {
+    "text": "Mensagem excluída"
   }
 }

--- a/locales/content/pt_BR/session-auth-extended.json
+++ b/locales/content/pt_BR/session-auth-extended.json
@@ -716,5 +716,20 @@
   },
   "web.auth.sessions._guidance.context": {
     "text": "Página de gerenciamento de dispositivos/navegadores conectados do usuário"
+  },
+  "web.auth.google": {
+    "text": "Google"
+  },
+  "web.auth.mfa.alternative_auth_options": {
+    "text": "Opções alternativas de autenticação"
+  },
+  "web.auth.remember.enabled": {
+    "text": "Manter conectado"
+  },
+  "web.auth.sessions.session_singular": {
+    "text": "sessão"
+  },
+  "web.auth.sessions.session_plural": {
+    "text": "sessões"
   }
 }

--- a/locales/content/pt_BR/session-auth.json
+++ b/locales/content/pt_BR/session-auth.json
@@ -398,5 +398,32 @@
   },
   "web.auth.verify._guidance.context": {
     "text": "Fluxo de verificação de e-mail após o cadastro"
+  },
+  "web.auth.account.sso_linked": {
+    "text": "Conta SSO"
+  },
+  "web.help.reset_password_link": {
+    "text": "Redefinir senha"
+  },
+  "web.login.custom_domain_sso_title": {
+    "text": "O single sign-on (SSO) está disponível para este domínio"
+  },
+  "web.login.custom_domain_sso_description": {
+    "text": "O administrador da organização pode habilitar o SSO para permitir que os membros da equipe entrem aqui. Entre em contato com o administrador para obter acesso."
+  },
+  "web.login.signin_disabled_heading": {
+    "text": "O início de sessão não está disponível"
+  },
+  "web.login.signin_disabled_message": {
+    "text": "No momento, o início de sessão não está disponível neste domínio."
+  },
+  "web.login.errors.sso_not_configured": {
+    "text": "O single sign-on (SSO) não está configurado para este domínio. Entre em contato com o seu administrador."
+  },
+  "web.login.errors.invalid_email": {
+    "text": "O endereço de e-mail do seu provedor de identidade é inválido. Entre em contato com o seu administrador."
+  },
+  "web.login.errors.domain_not_allowed": {
+    "text": "O domínio do seu e-mail não está autorizado para cadastro via SSO. Entre em contato com o seu administrador."
   }
 }

--- a/locales/content/pt_BR/workspace-account.json
+++ b/locales/content/pt_BR/workspace-account.json
@@ -476,7 +476,7 @@
     "source_hash": "1cc77e60"
   },
   "web.settings.api.documentation_description": {
-    "text": "Aprenda como integrar o {product_name} em seus aplicativos",
+    "text": "Saiba como integrar o {product_name} aos seus aplicativos",
     "source_hash": "6e8f910f"
   },
   "web.settings.api.rest_api_reference": {
@@ -682,5 +682,14 @@
   "web.settings.profile.didnt_receive_email": {
     "text": "Não recebeu o e-mail?",
     "source_hash": "fe3ac3ad"
+  },
+  "web.settings.api.api_disabled_notice": {
+    "text": "A API está desativada para esta instância."
+  },
+  "web.settings.security.sso_managed_title": {
+    "text": "Segurança gerenciada pelo SSO"
+  },
+  "web.settings.security.sso_managed_description": {
+    "text": "Sua conta é autenticada pelo provedor de single sign-on (SSO) da sua organização. A senha, a autenticação multifator e os códigos de recuperação são gerenciados pelo seu provedor de identidade."
   }
 }

--- a/locales/content/pt_BR/workspace-billing.json
+++ b/locales/content/pt_BR/workspace-billing.json
@@ -988,5 +988,47 @@
     "text": "Disponível apenas na sua região de assinatura original",
     "context": "Hint shown on plan cards when currency does not match active subscription",
     "source_hash": "10de32e5"
+  },
+  "web.billing.already_subscribed": {
+    "text": "Você já assinou este plano."
+  },
+  "web.billing.cancel.reactivate_button": {
+    "text": "Reativar assinatura"
+  },
+  "web.billing.cancel.reactivate_success": {
+    "text": "Sua assinatura foi reativada. Você continuará sendo cobrado normalmente."
+  },
+  "web.billing.cancel.reactivate_error": {
+    "text": "Falha ao reativar a assinatura. Tente novamente ou entre em contato com o suporte."
+  },
+  "web.billing.features.manage_orgs": {
+    "text": "Gerenciamento de Organizações"
+  },
+  "web.billing.features.flexible_from_domain": {
+    "text": "Domínio Flexível de Remetente de E-mail"
+  },
+  "web.billing.features.unlimited_admins": {
+    "text": "Administradores Ilimitados"
+  },
+  "web.billing.features.manage_sso": {
+    "text": "SSO"
+  },
+  "web.billing.overview.entitlements.flexible_from_domain": {
+    "text": "Domínio Flexível de Remetente de E-mail"
+  },
+  "web.billing.overview.entitlements.manage_orgs": {
+    "text": "Gerenciar Organizações"
+  },
+  "web.billing.overview.entitlements.manage_sso": {
+    "text": "Início de sessão único (SSO)"
+  },
+  "web.billing.overview.entitlements.manage_billing": {
+    "text": "Gerenciar Cobrança"
+  },
+  "web.billing.overview.entitlements.custom_signup_validation": {
+    "text": "Validação Personalizada de Cadastro"
+  },
+  "web.billing.plans.reactivate": {
+    "text": "Reativar"
   }
 }

--- a/locales/content/pt_BR/workspace-branding.json
+++ b/locales/content/pt_BR/workspace-branding.json
@@ -178,5 +178,11 @@
   "web.branding.upgrade_to_customize": {
     "text": "Faça upgrade do seu plano para personalizar a marca deste domínio.",
     "source_hash": "9077bf79"
+  },
+  "web.branding.saved_successfully": {
+    "text": "Configurações de marca salvas com sucesso"
+  },
+  "web.branding.keyhole_logo_icon": {
+    "text": "Ícone de fechadura representando compartilhamento seguro e privado"
   }
 }

--- a/locales/content/pt_BR/workspace-dashboard.json
+++ b/locales/content/pt_BR/workspace-dashboard.json
@@ -22,5 +22,14 @@
   "web.dashboard.fetch_error_description": {
     "text": "Houve um problema ao carregar seus dados. Por favor, tente novamente.",
     "source_hash": "ff0d904e"
+  },
+  "web.teams.create_first_team_title": {
+    "text": "Crie sua primeira equipe"
+  },
+  "web.teams.create_first_team_description": {
+    "text": "As equipes permitem que você colabore com outras pessoas em um Workspace compartilhado."
+  },
+  "web.teams.create_team": {
+    "text": "Criar equipe"
   }
 }

--- a/locales/content/pt_BR/workspace-domains.json
+++ b/locales/content/pt_BR/workspace-domains.json
@@ -846,5 +846,389 @@
   "web.domains.sso.not_configured_notice": {
     "text": "SSO ainda não está configurado para este domínio. Ative o login único para permitir que membros da equipe se autentiquem usando o provedor de identidade da sua organização.",
     "source_hash": "c439214b"
+  },
+  "api.domains.errors.add_admin_required": {
+    "text": "Apenas proprietários e administradores da organização podem adicionar domínios personalizados"
+  },
+  "web.domains.public_homepage": {
+    "text": "Página inicial pública"
+  },
+  "web.domains.status_tooltip_active": {
+    "text": "Domínio verificado e ativo"
+  },
+  "web.domains.status_tooltip_dns_incorrect": {
+    "text": "DNS não configurado — clique para corrigir"
+  },
+  "web.domains.status_tooltip_not_verified": {
+    "text": "Domínio não verificado — clique para verificar"
+  },
+  "web.domains.status_tooltip_unverified": {
+    "text": "Status do domínio não verificado — clique para atualizar"
+  },
+  "web.domains.last_check_failed": {
+    "text": "A última verificação falhou"
+  },
+  "web.domains.last_check_failed_ago": {
+    "text": "última verificação falhou {0}"
+  },
+  "web.domains.verify_now": {
+    "text": "Verificar agora"
+  },
+  "web.domains.click_to_verify": {
+    "text": "clique para verificar"
+  },
+  "web.domains.remove_domain_description": {
+    "text": "Remova permanentemente este domínio e toda a sua configuração."
+  },
+  "web.domains.add_access_denied": {
+    "text": "Acesso negado"
+  },
+  "web.domains.add_access_denied_description": {
+    "text": "Você não tem permissão para adicionar domínios a esta organização. Entre em contato com o administrador da sua organização."
+  },
+  "web.domains.dns_widget_load_failed": {
+    "text": "Falha ao carregar o widget de DNS"
+  },
+  "web.domains.dns_widget_not_available": {
+    "text": "Widget de DNS não disponível"
+  },
+  "web.domains.dns_widget_init_failed": {
+    "text": "Falha ao inicializar o widget de DNS"
+  },
+  "web.domains.verified": {
+    "text": "Verificado"
+  },
+  "web.domains.pending_verification": {
+    "text": "Verificação pendente"
+  },
+  "web.domains.unsaved_changes_confirmation": {
+    "text": "Você tem alterações não salvas. Tem certeza de que deseja sair?"
+  },
+  "web.domains.entitlement_required_owner": {
+    "text": "Este recurso requer upgrade do plano."
+  },
+  "web.domains.entitlement_required_member": {
+    "text": "Este recurso não está disponível no seu plano atual. Entre em contato com o proprietário da sua organização."
+  },
+  "web.domains.detail.manage": {
+    "text": "Gerenciar"
+  },
+  "web.domains.detail.features": {
+    "text": "Recursos"
+  },
+  "web.domains.detail.homepage_title": {
+    "text": "Mensagens Confidenciais na Página Inicial"
+  },
+  "web.domains.detail.homepage_description": {
+    "text": "Permitir acesso público para criar mensagens confidenciais na página inicial do seu domínio"
+  },
+  "web.domains.detail.brand_description": {
+    "text": "Logotipo, cores e marca personalizada"
+  },
+  "web.domains.detail.sso_description": {
+    "text": "Configurações do provedor de single sign-on (SSO)"
+  },
+  "web.domains.detail.email_description": {
+    "text": "Configuração de remetente de e-mail personalizado"
+  },
+  "web.domains.detail.incoming_description": {
+    "text": "Configurações de destinatário de mensagens confidenciais recebidas"
+  },
+  "web.domains.detail.signup_description": {
+    "text": "Estratégia de validação de cadastro por domínio"
+  },
+  "web.domains.detail.signin_description": {
+    "text": "Configuração do método de início de sessão por domínio"
+  },
+  "web.domains.email.dns_check_label": {
+    "text": "DNS"
+  },
+  "web.domains.email.provider_check_label": {
+    "text": "Provedor"
+  },
+  "web.domains.email.test_email_title": {
+    "text": "Testar envio de e-mail"
+  },
+  "web.domains.email.test_email_hint": {
+    "text": "Envie um e-mail de teste para você mesmo usando a configuração salva. Funciona mesmo quando o recurso ainda não está ativado."
+  },
+  "web.domains.email.send_test": {
+    "text": "Enviar teste"
+  },
+  "web.domains.email.test_email_sent": {
+    "text": "E-mail de teste enviado com sucesso"
+  },
+  "web.domains.email.test_email_failed": {
+    "text": "Falha ao enviar e-mail de teste"
+  },
+  "web.domains.email.test_email_sent_to": {
+    "text": "Enviado para {email}"
+  },
+  "web.domains.email.delivered_via": {
+    "text": "Entregue via {provider}"
+  },
+  "web.domains.incoming.feature_disabled": {
+    "text": "Mensagens Confidenciais Recebidas Indisponíveis"
+  },
+  "web.domains.incoming.feature_disabled_description": {
+    "text": "As mensagens confidenciais recebidas não estão ativadas nesta instância. Entre em contato com seu administrador."
+  },
+  "web.domains.signin.title": {
+    "text": "Configuração de início de sessão"
+  },
+  "web.domains.signin.configure_signin": {
+    "text": "Configurar início de sessão"
+  },
+  "web.domains.signin.config_description": {
+    "text": "Configure os métodos de autenticação de início de sessão para este domínio"
+  },
+  "web.domains.signin.access_denied": {
+    "text": "Acesso negado"
+  },
+  "web.domains.signin.upgrade_to_configure": {
+    "text": "Faça upgrade do seu plano para configurar os métodos de início de sessão para este domínio."
+  },
+  "web.domains.signin.not_configured_notice": {
+    "text": "A configuração de início de sessão ainda não foi definida para este domínio. Configure substituições para controlar quais métodos de autenticação estão disponíveis na página de início de sessão deste domínio."
+  },
+  "web.domains.signin.signin_enabled_label": {
+    "text": "Início de sessão ativado"
+  },
+  "web.domains.signin.header_toggle_label": {
+    "text": "Início de sessão"
+  },
+  "web.domains.signin.signin_enabled_hint": {
+    "text": "Se os usuários podem iniciar sessão neste domínio"
+  },
+  "web.domains.signin.restrict_to_label": {
+    "text": "Restringir método de início de sessão"
+  },
+  "web.domains.signin.restrict_to_hint": {
+    "text": "Restrinja este domínio a um único método de autenticação. Quando definido, apenas o método escolhido é exibido na página de início de sessão."
+  },
+  "web.domains.signin.all_methods": {
+    "text": "Todos os métodos"
+  },
+  "web.domains.signin.all_methods_description": {
+    "text": "Exibir todos os métodos de autenticação ativados na página de início de sessão"
+  },
+  "web.domains.signin.method_password": {
+    "text": "Senha"
+  },
+  "web.domains.signin.method_email_auth": {
+    "text": "Autenticação por e-mail"
+  },
+  "web.domains.signin.method_webauthn": {
+    "text": "WebAuthn / Passkeys"
+  },
+  "web.domains.signin.method_sso": {
+    "text": "Início de sessão único"
+  },
+  "web.domains.signin.method_overrides_label": {
+    "text": "Substituições de método"
+  },
+  "web.domains.signin.method_overrides_hint": {
+    "text": "Ativar ou desativar métodos de autenticação individuais para este domínio"
+  },
+  "web.domains.signin.mode_question": {
+    "text": "Como os usuários podem iniciar sessão?"
+  },
+  "web.domains.signin.mode_any": {
+    "text": "Qualquer método disponível"
+  },
+  "web.domains.signin.mode_any_hint": {
+    "text": "Exibir todos os métodos disponíveis neste domínio. Restrinja métodos individuais abaixo."
+  },
+  "web.domains.signin.mode_one": {
+    "text": "Um método específico"
+  },
+  "web.domains.signin.mode_one_hint": {
+    "text": "Restringir a página de início de sessão a um único método. Apenas os métodos disponíveis neste domínio são listados."
+  },
+  "web.domains.signin.mode_disabled": {
+    "text": "Início de sessão desativado"
+  },
+  "web.domains.signin.mode_disabled_hint": {
+    "text": "Os usuários não podem iniciar sessão neste domínio."
+  },
+  "web.domains.signin.mode_disabled_notice": {
+    "text": "Os visitantes da página de início de sessão deste domínio veem um aviso de que o início de sessão não está disponível, com um link de volta à página inicial. Suas configurações de método anteriores são mantidas e restauradas quando você reativa o início de sessão."
+  },
+  "web.domains.signin.methods_list_label": {
+    "text": "Métodos exibidos na página de início de sessão"
+  },
+  "web.domains.signin.restrict_picker_hint": {
+    "text": "Apenas os métodos disponíveis neste domínio são listados."
+  },
+  "web.domains.signin.availability_always": {
+    "text": "Sempre disponível"
+  },
+  "web.domains.signin.availability_global_on": {
+    "text": "Segue a política global · Ativado"
+  },
+  "web.domains.signin.availability_global_off": {
+    "text": "Não disponível"
+  },
+  "web.domains.signin.availability_unavailable": {
+    "text": "Indisponível em todo o site"
+  },
+  "web.domains.signin.allow_on_domain": {
+    "text": "Permitir neste domínio"
+  },
+  "web.domains.signin.method_password_blurb": {
+    "text": "Apenas senha"
+  },
+  "web.domains.signin.method_email_auth_blurb": {
+    "text": "Início de sessão sem senha via link mágico"
+  },
+  "web.domains.signin.method_webauthn_blurb": {
+    "text": "Biometria e chaves de segurança"
+  },
+  "web.domains.signin.method_sso_blurb": {
+    "text": "Provedor de identidade externo"
+  },
+  "web.domains.signin.email_auth_label": {
+    "text": "Autenticação por e-mail"
+  },
+  "web.domains.signin.email_auth_hint": {
+    "text": "Permitir autenticação por e-mail sem senha neste domínio"
+  },
+  "web.domains.signin.sso_enabled_label": {
+    "text": "Início de sessão único"
+  },
+  "web.domains.signin.sso_enabled_hint": {
+    "text": "Permitir autenticação SSO neste domínio"
+  },
+  "web.domains.signin.enabled_label": {
+    "text": "Ativar configuração de início de sessão"
+  },
+  "web.domains.signin.enabled_hint": {
+    "text": "Quando ativado, este domínio usa as configurações de início de sessão definidas acima"
+  },
+  "web.domains.signin.save_config": {
+    "text": "Salvar configuração"
+  },
+  "web.domains.signin.update_success": {
+    "text": "Configuração de início de sessão atualizada com sucesso"
+  },
+  "web.domains.signin.reset_to_defaults": {
+    "text": "Restaurar padrões"
+  },
+  "web.domains.signin.reset_confirm": {
+    "text": "Restaurar o início de sessão para os padrões globais?"
+  },
+  "web.domains.signin.reset_keeps_sso": {
+    "text": "Suas credenciais de SSO são mantidas. Remova-as separadamente na tela de configuração de SSO."
+  },
+  "web.domains.signin.reset_action": {
+    "text": "Sim, restaurar"
+  },
+  "web.domains.signin.reset_success": {
+    "text": "Configurações de início de sessão restauradas para os padrões globais"
+  },
+  "web.domains.signup.title": {
+    "text": "Validação de cadastro"
+  },
+  "web.domains.signup.config_description": {
+    "text": "Configure a validação de cadastro para este domínio"
+  },
+  "web.domains.signup.access_denied": {
+    "text": "Acesso negado"
+  },
+  "web.domains.signup.upgrade_to_configure": {
+    "text": "Faça upgrade do seu plano para configurar a validação de cadastro por domínio."
+  },
+  "web.domains.signup.configure_signup": {
+    "text": "Configurar cadastro"
+  },
+  "web.domains.signup.not_configured_notice": {
+    "text": "A validação de cadastro ainda não foi configurada para este domínio. Configure uma estratégia para controlar quem pode se cadastrar por meio deste domínio."
+  },
+  "web.domains.signup.site_signups_disabled_warning": {
+    "text": "Os cadastros estão atualmente desativados no nível do site. Esta política por domínio está configurada, mas não controlará nenhum tráfego até que os cadastros do site sejam ativados."
+  },
+  "web.domains.signup.strategy_label": {
+    "text": "Estratégia de validação"
+  },
+  "web.domains.signup.strategy_description": {
+    "text": "Escolha como os endereços de e-mail são validados quando os usuários se cadastram neste domínio."
+  },
+  "web.domains.signup.network_validation_warning": {
+    "text": "Esta estratégia realiza chamadas de rede durante o cadastro, o que pode aumentar a latência ou ser bloqueado por alguns provedores."
+  },
+  "web.domains.signup.allowed_domains_label": {
+    "text": "Domínios de cadastro permitidos"
+  },
+  "web.domains.signup.allowed_domains_hint": {
+    "text": "Apenas estes domínios de e-mail terão permissão para se cadastrar. Adicione um domínio por entrada."
+  },
+  "web.domains.signup.domain_placeholder": {
+    "text": "example.com"
+  },
+  "web.domains.signup.invalid_domain": {
+    "text": "Insira um domínio válido (ex. example.com)"
+  },
+  "web.domains.signup.domain_exists": {
+    "text": "Este domínio já está na lista"
+  },
+  "web.domains.signup.remove_domain": {
+    "text": "Remover {domain}"
+  },
+  "web.domains.signup.enabled_label": {
+    "text": "Ativar validação por domínio"
+  },
+  "web.domains.signup.enabled_hint": {
+    "text": "Quando ativado, os cadastros neste domínio usam a estratégia acima em vez da política global."
+  },
+  "web.domains.signup.delete_config": {
+    "text": "Excluir configuração"
+  },
+  "web.domains.signup.delete_confirm": {
+    "text": "Excluir a configuração de validação de cadastro? Os cadastros voltarão a usar a política global."
+  },
+  "web.domains.signup.save_config": {
+    "text": "Salvar configuração"
+  },
+  "web.domains.signup.update_success": {
+    "text": "Validação de cadastro atualizada com sucesso"
+  },
+  "web.domains.signup.delete_success": {
+    "text": "Configuração de validação de cadastro removida com sucesso"
+  },
+  "web.domains.signup.domain_overrides_label": {
+    "text": "Substituições de domínio"
+  },
+  "web.domains.signup.domain_overrides_hint": {
+    "text": "Substituir as configurações globais de cadastro para este domínio"
+  },
+  "web.domains.signup.signup_enabled_label": {
+    "text": "Cadastro ativado"
+  },
+  "web.domains.signup.signup_enabled_hint": {
+    "text": "Substituir se o cadastro está ativado para este domínio"
+  },
+  "web.domains.signup.autoverify_label": {
+    "text": "Verificar contas automaticamente"
+  },
+  "web.domains.signup.autoverify_hint": {
+    "text": "Substituir se novas contas são verificadas automaticamente neste domínio"
+  },
+  "web.domains.sso.test_success": {
+    "text": "Teste de conexão bem-sucedido — o provedor respondeu corretamente"
+  },
+  "web.domains.sso.test_failed": {
+    "text": "Falha no teste de conexão"
+  },
+  "web.domains.sso.enforce_moved_notice": {
+    "text": "Para exigir SSO em todos os inícios de sessão neste domínio, configure-o nas configurações de início de sessão do domínio. O modo somente SSO restringe a página de início de sessão ao provedor de SSO configurado aqui."
+  },
+  "web.domains.sso.edit_credentials": {
+    "text": "Editar credenciais"
+  },
+  "web.domains.sso.configure_button": {
+    "text": "Configurar"
+  },
+  "web.domains.sso.upgrade_required": {
+    "text": "Faça upgrade para configurar"
   }
 }

--- a/locales/content/pt_BR/workspace-organizations.json
+++ b/locales/content/pt_BR/workspace-organizations.json
@@ -770,5 +770,200 @@
   "web.organizations.sso.status_not_configured": {
     "text": "Não Configurado",
     "source_hash": "bbea960e"
+  },
+  "api.organizations.errors.not_found": {
+    "text": "Organização não encontrada: %{extid}"
+  },
+  "api.organizations.errors.owner_required": {
+    "text": "Apenas o proprietário da organização pode realizar esta ação"
+  },
+  "api.organizations.errors.admin_required": {
+    "text": "Apenas proprietários e administradores da organização podem realizar esta ação"
+  },
+  "api.organizations.errors.member_required": {
+    "text": "Você precisa ser membro da organização para realizar esta ação"
+  },
+  "api.organizations.invitations.errors.create_admin_required": {
+    "text": "Apenas proprietários e administradores da organização podem criar convites"
+  },
+  "api.organizations.invitations.errors.resend_admin_required": {
+    "text": "Apenas proprietários e administradores da organização podem reenviar convites"
+  },
+  "api.organizations.invitations.errors.view_admin_required": {
+    "text": "Apenas proprietários e administradores da organização podem visualizar convites"
+  },
+  "api.organizations.invitations.errors.revoke_admin_required": {
+    "text": "Apenas proprietários e administradores da organização podem revogar convites"
+  },
+  "api.organizations.invitations.errors.email_required": {
+    "text": "O e-mail é obrigatório"
+  },
+  "api.organizations.invitations.errors.email_invalid": {
+    "text": "Formato de e-mail inválido"
+  },
+  "api.organizations.invitations.errors.role_invalid": {
+    "text": "A função deve ser membro ou administrador"
+  },
+  "api.organizations.invitations.errors.cannot_invite_owner": {
+    "text": "Não é possível convidar como proprietário"
+  },
+  "api.organizations.invitations.errors.already_member": {
+    "text": "O usuário já é membro desta organização"
+  },
+  "api.organizations.invitations.errors.already_pending": {
+    "text": "Já existe um convite pendente para este e-mail"
+  },
+  "api.organizations.invitations.errors.member_limit_reached": {
+    "text": "Limite de membros atingido. Faça upgrade do seu plano para convidar mais membros."
+  },
+  "api.organizations.invitations.errors.not_found": {
+    "text": "Convite não encontrado"
+  },
+  "api.organizations.invitations.errors.cannot_resend_non_pending": {
+    "text": "Só é possível reenviar convites pendentes"
+  },
+  "api.organizations.invitations.errors.cannot_revoke_non_pending": {
+    "text": "Só é possível revogar convites pendentes"
+  },
+  "api.organizations.invitations.errors.resend_limit_reached": {
+    "text": "Limite máximo de reenvios (%{max}) atingido"
+  },
+  "api.organizations.invitations.errors.accept_token_required": {
+    "text": "O token é obrigatório"
+  },
+  "api.organizations.invitations.errors.accept_organization_gone": {
+    "text": "A organização não existe mais"
+  },
+  "api.organizations.invitations.errors.accept_already_acted": {
+    "text": "O convite já foi %{status}"
+  },
+  "api.organizations.invitations.errors.accept_expired": {
+    "text": "O convite expirou"
+  },
+  "api.organizations.invitations.errors.accept_email_mismatch": {
+    "text": "Seu endereço de e-mail não corresponde ao convite"
+  },
+  "api.organizations.invitations.errors.accept_already_member": {
+    "text": "Você já é membro desta organização"
+  },
+  "web.organizations.entitlements_title": {
+    "text": "Entitlements da organização"
+  },
+  "web.organizations.page_description_short": {
+    "text": "Visualize e configure seus Workspaces"
+  },
+  "web.organizations.delete_organization_remove_domains_first": {
+    "text": "Remova todos os domínios personalizados antes de excluir esta organização."
+  },
+  "web.organizations.default_org_delete_notice_title": {
+    "text": "Excluindo esta organização"
+  },
+  "web.organizations.default_org_delete_notice_before": {
+    "text": "Esta é a sua organização padrão e não pode ser removida pelo painel. Para excluí-la, entre em contato pelo"
+  },
+  "web.organizations.default_org_delete_notice_link": {
+    "text": "formulário de feedback"
+  },
+  "web.organizations.default_org_delete_notice_after": {
+    "text": "."
+  },
+  "web.organizations.leave_organization": {
+    "text": "Sair desta organização"
+  },
+  "web.organizations.leave_organization_warning": {
+    "text": "Você perderá o acesso a esta organização e aos seus recursos."
+  },
+  "web.organizations.leave_organization_confirm_title": {
+    "text": "Sair da organização"
+  },
+  "web.organizations.leave_organization_confirm_message": {
+    "text": "Tem certeza de que deseja sair de {name}? Você precisará de um novo convite para retornar."
+  },
+  "web.organizations.leave_organization_success": {
+    "text": "Você saiu da organização."
+  },
+  "web.organizations.leave_error": {
+    "text": "Falha ao sair da organização"
+  },
+  "web.organizations.organizations": {
+    "text": "Organizações"
+  },
+  "web.organizations.invitations.invited_by_inline": {
+    "text": "por {email}"
+  },
+  "web.organizations.invitations.invited_as_inline": {
+    "text": "como {role}"
+  },
+  "web.organizations.invitations.back_to_home": {
+    "text": "Voltar para a página inicial"
+  },
+  "web.organizations.invitations.email_locked_hint": {
+    "text": "Este convite foi enviado para este endereço de e-mail"
+  },
+  "web.organizations.invitations.signup_continue": {
+    "text": "Continuar"
+  },
+  "web.organizations.invitations.signin_continue": {
+    "text": "Entrar"
+  },
+  "web.organizations.invitations.confirm_join_below": {
+    "text": "Quase lá — confirme abaixo para entrar na organização."
+  },
+  "web.organizations.invitations.go_to_organizations": {
+    "text": "Ir para Organizações"
+  },
+  "web.organizations.invitations.already_member": {
+    "text": "Você já é membro desta organização"
+  },
+  "web.organizations.invitations.join_organization": {
+    "text": "Entrar em {orgName}"
+  },
+  "web.organizations.invitations.sign_in_to_join": {
+    "text": "Entre para participar de {orgName}"
+  },
+  "web.organizations.invitations.decline": {
+    "text": "Recusar"
+  },
+  "web.organizations.members.member_quota": {
+    "text": "{used} de {limit} membros"
+  },
+  "web.organizations.members.pending_suffix": {
+    "text": "({count} pendente)"
+  },
+  "web.organizations.members.limit_reached_hint": {
+    "text": "Limite de membros atingido."
+  },
+  "web.organizations.sso.view_discovery_document": {
+    "text": "Ver documento de descoberta"
+  },
+  "web.organizations.sso.callback_url": {
+    "text": "Callback URL"
+  },
+  "web.organizations.sso.callback_url_hint": {
+    "text": "Adicione esta URL aos URIs de redirecionamento permitidos do seu provedor de identidade"
+  },
+  "web.organizations.sso.enforce_sso_only": {
+    "text": "Aplicar somente SSO"
+  },
+  "web.organizations.sso.enforce_sso_only_hint": {
+    "text": "Exigir SSO para todos os inícios de sessão neste domínio. Quando ativado, a autenticação baseada em senha é desativada."
+  },
+  "web.organizations.sso.grant_org_scope": {
+    "text": "Conceder acesso a toda a organização"
+  },
+  "web.organizations.sso.grant_org_scope_hint": {
+    "text": "Novos membros que ingressarem por meio do SSO deste domínio receberão acesso a todos os domínios da organização. Os membros existentes não são afetados. Quando desativado (padrão), os novos membros só podem acessar este domínio."
+  },
+  "web.organizations.sso.no_domains": {
+    "text": "Nenhum domínio verificado"
+  },
+  "web.organizations.sso.no_domains_description": {
+    "text": "Adicione e verifique um domínio antes de configurar o SSO para ele."
+  },
+  "web.organizations.tabs.team": {
+    "text": "Equipe"
+  },
+  "web.organizations.tabs.sso": {
+    "text": "SSO"
   }
 }


### PR DESCRIPTION
## `pt_BR` translation update

Automated export of completed **pt_BR** translations from the translation task DB.
Scope: `locales/content/pt_BR/` only — 27 file(s), +1359/-30.

⚠️ `i18n validate variables` reports **1** variable mismatch(es) for `pt_BR` (empty values that drop source variables, renamed/extra vars, etc.) — see the review below.

---

### Local quality review

> Produced by a fresh, isolated `claude` review agent (model `claude-sonnet-5`, agent `saas-translator`) that read
> `locales/AGENT_TRANSLATION_PROTOCOL.md` and inspected this branch's diff before the PR was opened.

**Verdict:** ⚠️ Needs review — spurious variable added

**Summary:** Large, well-formed batch (new API-error and domain/SSO/billing/org strings) with consistent Delano→"Equipe de Suporte" signature swap and correct `{product_name}`/`%{...}` preservation almost everywhere. One flagged variable defect and a couple of terminology inconsistencies need a maintainer decision before merge.

**Critical (must fix):**
- `email.email_changed.body.text` adds `%{date}` which does not exist in the English source (`"...has been changed to %{new_email_masked}."`). This is a fabricated variable with no data to interpolate — will break rendering or leak a literal token. (Same bug seen across multiple other locales in this batch, per validator output.)

**Warnings:**
- Inconsistent handling of "Workspace": `10-layout.json`'s pre-existing `web.layout.workspace_context` translates it as "área de trabalho", but new keys in this same PR (`web.footer.workspace`, `web.organizations.page_description_short`, `web.teams.create_first_team_description`) leave it as the English loanword "Workspace". Confirm this is an intentional terminology shift (brand-like term) and not an oversight — if intentional, the older key should eventually be reconciled.
- `web.billing.features.*` / `web.billing.overview.entitlements.*` use English-style Title Case ("Gerenciamento de Organizações", "Domínio Flexível de Remetente de E-mail", "Administradores Ilimitados"), which is non-standard for Portuguese sentence casing. Likely mirrors English source styling for plan-feature badges — worth a quick confirm it's deliberate.

**Notes:**
- `web.homepage.one_time_secret_literal` correctly changed to `{product_name}` (matches the same fix applied in other locales this round).
- `Callback URL` and other SSO/tech labels intentionally left in English, consistent with pt_BR conventions.
- No mojibake, no empty strings, no untranslated leftover English prose spotted.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
