### PR TITLE
i18n: update pt_PT translations

### DIFF
--- a/locales/content/pt_PT/00-common.json
+++ b/locales/content/pt_PT/00-common.json
@@ -1299,7 +1299,7 @@
     "source_hash": "fc78d9cb"
   },
   "web.INSTRUCTION.phishing_warning": {
-    "text": "Verifica sempre que estás no site oficial do {product_name}. Os burlões por vezes criam sites falsos que parecem exatamente iguais ao {product_name} para roubar as tuas mensagens confidenciais. Para evitar ataques de phishing, verifica o domínio da região antes de criar novos links.",
+    "text": "Verifica sempre se estás no site oficial do {product_name}. Os burlões criam por vezes sites falsos que parecem exatamente iguais ao {product_name} para roubar as tuas mensagens confidenciais. Para evitares ataques de phishing, confirma o domínio da região antes de criares novos links.",
     "source_hash": "b588f5b2"
   },
   "web.pricing.title": {
@@ -1383,5 +1383,110 @@
     "text": "Faz upgrade para desbloquear mais funcionalidades",
     "context": "Description shown for free plan users encouraging upgrade",
     "source_hash": "783f174c"
+  },
+  "api.errors.authentication_required": {
+    "text": "Autenticação necessária"
+  },
+  "api.errors.sso_only_action_blocked": {
+    "text": "Esta ação não está disponível no modo apenas SSO"
+  },
+  "web.COMMON.configure": {
+    "text": "Configurar"
+  },
+  "web.COMMON.copy_to_clipboard": {
+    "text": "Copiar para a área de transferência"
+  },
+  "web.COMMON.add": {
+    "text": "Adicionar"
+  },
+  "web.COMMON.enabled": {
+    "text": "Ativado"
+  },
+  "web.COMMON.disabled": {
+    "text": "Desativado"
+  },
+  "web.COMMON.yes_delete": {
+    "text": "Sim, eliminar"
+  },
+  "web.COMMON.error_code": {
+    "text": "Código de erro"
+  },
+  "web.COMMON.http_status": {
+    "text": "Estado HTTP"
+  },
+  "web.COMMON.details": {
+    "text": "Detalhes"
+  },
+  "web.COMMON.field_confirm_password": {
+    "text": "Confirmar palavra-passe"
+  },
+  "web.COMMON.passwords_must_match": {
+    "text": "As palavras-passe devem coincidir"
+  },
+  "web.COMMON.and": {
+    "text": "e"
+  },
+  "web.COMMON.or": {
+    "text": "ou"
+  },
+  "web.COMMON.copied": {
+    "text": "Copiado"
+  },
+  "web.COMMON.copy": {
+    "text": "Copiar"
+  },
+  "web.COMMON.copy_email": {
+    "text": "Copiar endereço de e-mail"
+  },
+  "web.COMMON.copy_id": {
+    "text": "Copiar ID da conta"
+  },
+  "web.COMMON.org_id_tooltip": {
+    "text": "O identificador único da tua organização"
+  },
+  "web.COMMON.success": {
+    "text": "Sucesso"
+  },
+  "web.COMMON.need_help": {
+    "text": "Precisas de ajuda"
+  },
+  "web.COMMON.open_help_dialog": {
+    "text": "Abrir caixa de diálogo de ajuda"
+  },
+  "web.COMMON.focus_is_now_in_the_main_text_area": {
+    "text": "O foco está agora na área de texto principal"
+  },
+  "web.LABELS.show_passphrase": {
+    "text": "Mostrar frase secreta"
+  },
+  "web.LABELS.hide_passphrase": {
+    "text": "Ocultar frase secreta"
+  },
+  "web.LABELS.copy_icon": {
+    "text": "Ícone de copiar"
+  },
+  "web.LABELS.copied_icon": {
+    "text": "Ícone de copiado"
+  },
+  "web.STATUS.unverified": {
+    "text": "Não verificado"
+  },
+  "web.TITLES.domain_detail": {
+    "text": "Definições do domínio"
+  },
+  "web.TITLES.domain_signin": {
+    "text": "Configuração de início de sessão"
+  },
+  "web.TITLES.domain_sso": {
+    "text": "SSO do domínio"
+  },
+  "web.TITLES.domain_signup": {
+    "text": "Validação de registo do domínio"
+  },
+  "web.TITLES.domain_email": {
+    "text": "Configuração de e-mail"
+  },
+  "web.TITLES.domain_incoming": {
+    "text": "Mensagens confidenciais recebidas"
   }
 }

--- a/locales/content/pt_PT/10-layout.json
+++ b/locales/content/pt_PT/10-layout.json
@@ -148,7 +148,7 @@
     "source_hash": "b9766df3"
   },
   "web.help.secret_view_faq.what_am_i_looking_at.description": {
-    "text": "Estás a ver uma mensagem segura que foi partilhada contigo através do {product_name}. Este conteúdo é mostrado apenas uma vez e depois é permanentemente eliminado dos nossos servidores.",
+    "text": "Estás a ver uma mensagem segura que foi partilhada contigo através do {product_name}. Este conteúdo é apresentado apenas uma vez e depois eliminado permanentemente dos nossos servidores.",
     "source_hash": "e0f1a10c"
   },
   "web.help.secret_view_faq.can_i_view_again.title": {
@@ -264,7 +264,7 @@
     "source_hash": "e2f124cd"
   },
   "web.layout.visit_onetime_secret_homepage": {
-    "text": "Visitar página inicial do {product_name}",
+    "text": "Visitar a página inicial do {product_name}",
     "source_hash": "625556d2"
   },
   "web.layout.footer_navigation": {
@@ -338,5 +338,11 @@
   "web.layout.workspace_context": {
     "text": "Contexto da área de trabalho",
     "source_hash": "dc6fa4f5"
+  },
+  "web.footer.workspace": {
+    "text": "Espaço de trabalho"
+  },
+  "web.help.default_content": {
+    "text": "Contacta o suporte para obteres assistência"
   }
 }

--- a/locales/content/pt_PT/admin-colonel.json
+++ b/locales/content/pt_PT/admin-colonel.json
@@ -634,5 +634,152 @@
   "web.colonel.feedback.when_you_submit_feedback_well_see": {
     "text": "Quando enviares feedback, veremos:",
     "source_hash": "fe77172e"
+  },
+  "web.colonel.previewPlanMode": {
+    "text": "Modo de pré-visualização de plano"
+  },
+  "web.colonel.previewModeDescription": {
+    "text": "Pré-visualiza a aplicação tal como aparece aos clientes num plano diferente. Isto afeta apenas a tua vista e não altera o plano real de nenhuma organização."
+  },
+  "web.colonel.previewModeActive": {
+    "text": "Pré-visualização ativa"
+  },
+  "web.colonel.bannedIps.empty": {
+    "text": "Nenhum IP banido"
+  },
+  "web.colonel.bannedIps.currentIp": {
+    "text": "O teu endereço IP atual"
+  },
+  "web.colonel.bannedIps.confirmUnban": {
+    "text": "Desbanir {ip}?"
+  },
+  "web.colonel.bannedIps.actions.ban": {
+    "text": "Banir IP"
+  },
+  "web.colonel.bannedIps.actions.quickBan": {
+    "text": "Banimento rápido"
+  },
+  "web.colonel.bannedIps.actions.unban": {
+    "text": "Desbanir"
+  },
+  "web.colonel.bannedIps.actions.cancel": {
+    "text": "Cancelar"
+  },
+  "web.colonel.bannedIps.columns.ipAddress": {
+    "text": "Endereço IP"
+  },
+  "web.colonel.bannedIps.columns.reason": {
+    "text": "Motivo"
+  },
+  "web.colonel.bannedIps.columns.bannedAt": {
+    "text": "Banido em"
+  },
+  "web.colonel.bannedIps.columns.bannedBy": {
+    "text": "Banido por"
+  },
+  "web.colonel.bannedIps.error.banFailed": {
+    "text": "Falha ao banir o endereço IP"
+  },
+  "web.colonel.bannedIps.error.unbanFailed": {
+    "text": "Falha ao desbanir o endereço IP"
+  },
+  "web.colonel.bannedIps.form.title": {
+    "text": "Banir endereço IP"
+  },
+  "web.colonel.bannedIps.form.ipLabel": {
+    "text": "Endereço IP"
+  },
+  "web.colonel.bannedIps.form.reasonLabel": {
+    "text": "Motivo"
+  },
+  "web.colonel.bannedIps.form.reasonPlaceholder": {
+    "text": "Motivo opcional"
+  },
+  "web.colonel.bannedIps.success.banned": {
+    "text": "O endereço IP {ip} foi banido"
+  },
+  "web.colonel.bannedIps.success.unbanned": {
+    "text": "O endereço IP {ip} foi desbanido"
+  },
+  "web.colonel.customDomains.empty": {
+    "text": "Nenhum domínio personalizado configurado"
+  },
+  "web.colonel.customDomains.noLogo": {
+    "text": "Sem logótipo"
+  },
+  "web.colonel.customDomains.labels.organization": {
+    "text": "Organização"
+  },
+  "web.colonel.customDomains.labels.externalId": {
+    "text": "ID externo"
+  },
+  "web.colonel.customDomains.labels.created": {
+    "text": "Criado"
+  },
+  "web.colonel.customDomains.labels.updated": {
+    "text": "Atualizado"
+  },
+  "web.colonel.customDomains.labels.favicon": {
+    "text": "Favicon"
+  },
+  "web.colonel.customDomains.status.verified": {
+    "text": "Verificado"
+  },
+  "web.colonel.customDomains.status.resolving": {
+    "text": "A resolver"
+  },
+  "web.colonel.customDomains.status.ready": {
+    "text": "Pronto"
+  },
+  "web.colonel.customDomains.status.publicHomepage": {
+    "text": "Página inicial pública"
+  },
+  "web.colonel.customDomains.status.publicApi": {
+    "text": "API pública"
+  },
+  "web.colonel.customDomains.status.pending": {
+    "text": "Pendente"
+  },
+  "web.colonel.pagination.showing": {
+    "text": "A mostrar {start}–{end} de {total}"
+  },
+  "web.colonel.pagination.itemsPerPage": {
+    "text": "Itens por página"
+  },
+  "web.colonel.pagination.perPage": {
+    "text": "{count} por página"
+  },
+  "web.colonel.pagination.pageOf": {
+    "text": "Página {current} de {total}"
+  },
+  "web.colonel.secrets.empty": {
+    "text": "Nenhuma mensagem confidencial encontrada"
+  },
+  "web.colonel.secrets.never": {
+    "text": "Nunca"
+  },
+  "web.colonel.secrets.columns.shortId": {
+    "text": "ID curto"
+  },
+  "web.colonel.secrets.columns.state": {
+    "text": "Estado"
+  },
+  "web.colonel.secrets.columns.created": {
+    "text": "Criado"
+  },
+  "web.colonel.secrets.columns.expiration": {
+    "text": "Expiração"
+  },
+  "web.colonel.secrets.columns.age": {
+    "text": "Idade (dias)"
+  },
+  "web.colonel.secrets.state.new": {
+    "text": "Novo"
+  },
+  "web.colonel.secrets.state.received": {
+    "text": "Recebido"
+  },
+  "web.colonel.secrets.state.viewed": {
+    "text": "Visto"
   }
 }

--- a/locales/content/pt_PT/api-account-errors.json
+++ b/locales/content/pt_PT/api-account-errors.json
@@ -1,0 +1,8 @@
+{
+  "api.account.errors.invalid_email": {
+    "text": "Esse é um endereço de e-mail válido?"
+  },
+  "api.account.errors.password_too_short": {
+    "text": "A palavra-passe é demasiado curta"
+  }
+}

--- a/locales/content/pt_PT/api-domains-errors.json
+++ b/locales/content/pt_PT/api-domains-errors.json
@@ -1,0 +1,29 @@
+{
+  "api.domains.errors.domain_id_required": {
+    "text": "ID do domínio obrigatório"
+  },
+  "api.domains.errors.domain_not_found": {
+    "text": "Domínio não encontrado: %{extid}"
+  },
+  "api.domains.errors.organization_not_found": {
+    "text": "Organização não encontrada para o domínio: %{domain}"
+  },
+  "api.domains.errors.incoming_secrets_disabled": {
+    "text": "As mensagens confidenciais recebidas não estão ativadas nesta instância"
+  },
+  "api.domains.errors.incoming_secrets_entitlement_required": {
+    "text": "A gestão de mensagens confidenciais recebidas requer o direito incoming_secrets. Faz upgrade do teu plano."
+  },
+  "api.domains.errors.incoming_config_not_found": {
+    "text": "Configuração de receção não encontrada para o domínio: %{extid}"
+  },
+  "api.domains.errors.recipients_max_exceeded": {
+    "text": "Máximo de %{max} destinatários permitidos"
+  },
+  "api.domains.errors.recipients_invalid_email": {
+    "text": "E-mail inválido: %{email}"
+  },
+  "api.domains.errors.recipients_duplicate": {
+    "text": "Não são permitidos e-mails de destinatário duplicados"
+  }
+}

--- a/locales/content/pt_PT/api-entitlements-errors.json
+++ b/locales/content/pt_PT/api-entitlements-errors.json
@@ -1,0 +1,71 @@
+{
+  "api.entitlements.errors.context_unavailable": {
+    "text": "Não foi possível verificar os direitos (contexto da organização indisponível)"
+  },
+  "api.entitlements.errors.api_access_required": {
+    "text": "O acesso à API requer um upgrade do plano"
+  },
+  "api.entitlements.errors.custom_privacy_defaults_required": {
+    "text": "As predefinições de privacidade personalizadas requerem um upgrade do plano"
+  },
+  "api.entitlements.errors.extended_default_expiration_required": {
+    "text": "A expiração predefinida alargada requer um upgrade do plano"
+  },
+  "api.entitlements.errors.custom_domains_required": {
+    "text": "Os domínios personalizados requerem um upgrade do plano"
+  },
+  "api.entitlements.errors.custom_branding_required": {
+    "text": "A marca personalizada requer um upgrade do plano"
+  },
+  "api.entitlements.errors.homepage_secrets_required": {
+    "text": "As mensagens confidenciais na página inicial requerem um upgrade do plano"
+  },
+  "api.entitlements.errors.incoming_secrets_required": {
+    "text": "As mensagens confidenciais recebidas requerem um upgrade do plano"
+  },
+  "api.entitlements.errors.custom_mail_sender_required": {
+    "text": "O remetente de e-mail personalizado requer um upgrade do plano"
+  },
+  "api.entitlements.errors.flexible_from_domain_required": {
+    "text": "O domínio de remetente flexível requer um upgrade do plano"
+  },
+  "api.entitlements.errors.manage_org_required": {
+    "text": "A gestão de organizações requer um upgrade do plano"
+  },
+  "api.entitlements.errors.manage_teams_required": {
+    "text": "A gestão de equipas requer um upgrade do plano"
+  },
+  "api.entitlements.errors.manage_members_required": {
+    "text": "A gestão de membros requer um upgrade do plano"
+  },
+  "api.entitlements.errors.manage_sso_required": {
+    "text": "A gestão de SSO requer um upgrade do plano"
+  },
+  "api.entitlements.errors.audit_logs_required": {
+    "text": "Os registos de auditoria requerem um upgrade do plano"
+  },
+  "api.entitlements.errors.custom_signup_validation_required": {
+    "text": "A validação de registo personalizada requer um upgrade do plano"
+  },
+  "api.entitlements.errors.create_secrets_required": {
+    "text": "A criação de mensagens confidenciais requer um upgrade do plano"
+  },
+  "api.entitlements.errors.view_receipt_required": {
+    "text": "A visualização de recibos requer um upgrade do plano"
+  },
+  "api.entitlements.errors.notifications_required": {
+    "text": "As notificações requerem um upgrade do plano"
+  },
+  "api.entitlements.errors.workspace_branding_required": {
+    "text": "A marca do espaço de trabalho requer um upgrade do plano"
+  },
+  "api.entitlements.errors.ip_access_rules_required": {
+    "text": "As regras de acesso por IP requerem um upgrade do plano"
+  },
+  "api.entitlements.errors.manage_billing_required": {
+    "text": "A gestão de faturação requer um upgrade do plano"
+  },
+  "api.entitlements.errors.custom_signin_config_required": {
+    "text": "A configuração de início de sessão personalizada requer um upgrade do plano"
+  }
+}

--- a/locales/content/pt_PT/api-feedback-errors.json
+++ b/locales/content/pt_PT/api-feedback-errors.json
@@ -1,0 +1,5 @@
+{
+  "api.feedback.errors.rate_limit_exceeded": {
+    "text": "Demasiados envios de feedback. Por favor tenta novamente mais tarde."
+  }
+}

--- a/locales/content/pt_PT/api-incoming-errors.json
+++ b/locales/content/pt_PT/api-incoming-errors.json
@@ -1,0 +1,5 @@
+{
+  "api.incoming.errors.custom_domain_unresolved": {
+    "text": "Não foi possível resolver a organização do domínio personalizado"
+  }
+}

--- a/locales/content/pt_PT/api-invite-errors.json
+++ b/locales/content/pt_PT/api-invite-errors.json
@@ -1,0 +1,23 @@
+{
+  "api.invite.errors.invitation_not_found_or_expired": {
+    "text": "Convite não encontrado ou expirado"
+  },
+  "api.invite.errors.token_required": {
+    "text": "O token é obrigatório"
+  },
+  "api.invite.errors.organization_no_longer_exists": {
+    "text": "A organização já não existe"
+  },
+  "api.invite.errors.invitation_already_processed": {
+    "text": "O convite já foi %{status}"
+  },
+  "api.invite.errors.invitation_expired": {
+    "text": "O convite expirou"
+  },
+  "api.invite.errors.email_mismatch": {
+    "text": "O teu endereço de e-mail não corresponde ao convite"
+  },
+  "api.invite.errors.already_member": {
+    "text": "Já és membro desta organização"
+  }
+}

--- a/locales/content/pt_PT/api-organizations-errors.json
+++ b/locales/content/pt_PT/api-organizations-errors.json
@@ -1,0 +1,107 @@
+{
+  "api.organizations.errors.domain_scoped_forbidden": {
+    "text": "Os membros com âmbito de domínio não podem realizar esta ação"
+  },
+  "api.organizations.errors.organization_not_found": {
+    "text": "Organização não encontrada: %{extid}"
+  },
+  "api.organizations.errors.organization_owner_required": {
+    "text": "Apenas o proprietário da organização pode realizar esta ação"
+  },
+  "api.organizations.errors.organization_member_required": {
+    "text": "Tens de ser membro da organização para realizar esta ação"
+  },
+  "api.organizations.errors.organization_admin_required": {
+    "text": "Apenas os proprietários e administradores da organização podem realizar esta ação"
+  },
+  "api.organizations.errors.extid_required": {
+    "text": "ID da organização obrigatório"
+  },
+  "api.organizations.errors.display_name_required": {
+    "text": "O nome da organização é obrigatório"
+  },
+  "api.organizations.errors.display_name_too_long": {
+    "text": "O nome da organização deve ter menos de %{max} caracteres"
+  },
+  "api.organizations.errors.description_too_long": {
+    "text": "A descrição deve ter menos de %{max} caracteres"
+  },
+  "api.organizations.errors.contact_email_exists": {
+    "text": "Já existe uma organização com este e-mail de contacto"
+  },
+  "api.organizations.errors.creation_in_progress": {
+    "text": "Criação da organização em curso. Por favor tenta novamente."
+  },
+  "api.organizations.errors.organization_limit_reached": {
+    "text": "Limite de organizações atingido. Faz upgrade do teu plano para criar mais organizações."
+  },
+  "api.organizations.invitations.errors.invitation_not_found": {
+    "text": "Convite não encontrado"
+  },
+  "api.organizations.invitations.errors.email_required": {
+    "text": "O e-mail é obrigatório"
+  },
+  "api.organizations.invitations.errors.invalid_email_format": {
+    "text": "Formato de e-mail inválido"
+  },
+  "api.organizations.invitations.errors.invalid_role": {
+    "text": "A função deve ser membro ou administrador"
+  },
+  "api.organizations.invitations.errors.cannot_invite_as_owner": {
+    "text": "Não é possível convidar como proprietário"
+  },
+  "api.organizations.invitations.errors.user_already_member": {
+    "text": "O utilizador já é membro desta organização"
+  },
+  "api.organizations.invitations.errors.invitation_already_pending": {
+    "text": "Já existe um convite pendente para este e-mail"
+  },
+  "api.organizations.invitations.errors.member_limit_reached": {
+    "text": "Limite de membros atingido. Faz upgrade do teu plano para convidar mais membros."
+  },
+  "api.organizations.invitations.errors.resend_only_pending": {
+    "text": "Só é possível reenviar convites pendentes"
+  },
+  "api.organizations.invitations.errors.resend_limit_reached": {
+    "text": "Limite máximo de reenvios (%{max}) atingido"
+  },
+  "api.organizations.invitations.errors.revoke_only_pending": {
+    "text": "Só é possível revogar convites pendentes"
+  },
+  "api.organizations.members.errors.member_not_found": {
+    "text": "Membro não encontrado: %{extid}"
+  },
+  "api.organizations.members.errors.member_not_in_organization": {
+    "text": "Membro não encontrado nesta organização"
+  },
+  "api.organizations.members.errors.member_not_active": {
+    "text": "O membro não está ativo"
+  },
+  "api.organizations.members.errors.invalid_role_value": {
+    "text": "Função inválida. Deve ser uma de: %{roles}"
+  },
+  "api.organizations.members.errors.cannot_change_owner_role": {
+    "text": "Não é possível alterar a função de proprietário. Usa antes a transferência de propriedade."
+  },
+  "api.organizations.members.errors.member_already_has_role": {
+    "text": "O membro já tem a função: %{role}"
+  },
+  "api.organizations.members.errors.cannot_promote_to_owner": {
+    "text": "Não é possível promover a proprietário. Usa antes a transferência de propriedade."
+  },
+  "api.organizations.members.errors.must_be_member": {
+    "text": "Tens de ser membro desta organização"
+  },
+  "api.organizations.members.errors.cannot_remove_owner": {
+    "text": "Não é possível remover o proprietário da organização. Transfere primeiro a propriedade."
+  },
+  "api.organizations.members.errors.cannot_remove_self": {
+    "text": "Não te podes remover a ti próprio. Usa antes a opção de sair da organização."
+  },
+  "api.organizations.members.errors.admin_cannot_remove_admin": {
+    "text": "Os administradores não podem remover outros administradores. Apenas os proprietários podem."
+  },
+  "api.organizations.members.errors.no_permission_to_remove": {
+    "text": "Não tens permissão para remover membros"
+  }
+}

--- a/locales/content/pt_PT/api-secrets-errors.json
+++ b/locales/content/pt_PT/api-secrets-errors.json
@@ -1,0 +1,11 @@
+{
+  "api.secrets.errors.domain_permission_authenticated_non_owner": {
+    "text": "Não tens permissão para usar o domínio: %{domain}"
+  },
+  "api.secrets.errors.domain_public_sharing_disabled": {
+    "text": "Partilha pública desativada para o domínio: %{domain}"
+  },
+  "api.secrets.errors.domain_permission_anonymous_cross_domain": {
+    "text": "Não tens permissão para usar o domínio: %{domain}"
+  }
+}

--- a/locales/content/pt_PT/email.json
+++ b/locales/content/pt_PT/email.json
@@ -60,7 +60,7 @@
     "source_hash": "88c72144"
   },
   "email.welcome.signature": {
-    "text": "Delano",
+    "text": "Equipa de Suporte",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -100,7 +100,7 @@
     "source_hash": "fbb7eb2d"
   },
   "email.password_request.signature": {
-    "text": "Delano",
+    "text": "Equipa de Suporte",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -145,7 +145,7 @@
     "source_hash": "1863f5be"
   },
   "email.magic_link.signature": {
-    "text": "Delano",
+    "text": "Equipa de Suporte",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -230,7 +230,7 @@
     "source_hash": "3f6b45dd"
   },
   "email.secret_revealed.signature": {
-    "text": "Delano",
+    "text": "Equipa de Suporte",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -355,7 +355,7 @@
     "source_hash": "734882d2"
   },
   "email.organization_invitation.signature": {
-    "text": "Delano",
+    "text": "Equipa de Suporte",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -395,7 +395,7 @@
     "source_hash": "be92cff3"
   },
   "email.password_changed.signature": {
-    "text": "Delano",
+    "text": "Equipa de Suporte",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -445,7 +445,7 @@
     "source_hash": "f8d47b82"
   },
   "email.email_changed.signature": {
-    "text": "Delano",
+    "text": "Equipa de Suporte",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -495,7 +495,7 @@
     "source_hash": "f8d47b82"
   },
   "email.email_change_requested.signature": {
-    "text": "Delano",
+    "text": "Equipa de Suporte",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -550,7 +550,7 @@
     "source_hash": "d4d835fc"
   },
   "email.email_change_confirmation.signature": {
-    "text": "Delano",
+    "text": "Equipa de Suporte",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -580,7 +580,7 @@
     "source_hash": "e7c11bb0"
   },
   "email.mfa_enabled.signature": {
-    "text": "Delano",
+    "text": "Equipa de Suporte",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -605,7 +605,7 @@
     "source_hash": "97ef0a3e"
   },
   "email.mfa_disabled.signature": {
-    "text": "Delano",
+    "text": "Equipa de Suporte",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -650,7 +650,7 @@
     "source_hash": "450c54c5"
   },
   "email.new_login_alert.signature": {
-    "text": "Delano",
+    "text": "Equipa de Suporte",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -670,7 +670,7 @@
     "source_hash": "d442beed"
   },
   "email.member_removed.signature": {
-    "text": "Delano",
+    "text": "Equipa de Suporte",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -690,7 +690,7 @@
     "source_hash": "c2280c0c"
   },
   "email.role_changed.signature": {
-    "text": "Delano",
+    "text": "Equipa de Suporte",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -710,7 +710,7 @@
     "source_hash": "7095fc69"
   },
   "email.organization_deleted.signature": {
-    "text": "Delano",
+    "text": "Equipa de Suporte",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -750,7 +750,7 @@
     "source_hash": "36008943"
   },
   "email.payment_receipt.signature": {
-    "text": "Delano",
+    "text": "Equipa de Suporte",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -775,7 +775,7 @@
     "source_hash": "926406b1"
   },
   "email.payment_failed.signature": {
-    "text": "Delano",
+    "text": "Equipa de Suporte",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -800,7 +800,7 @@
     "source_hash": "66a1419e"
   },
   "email.trial_expiring.signature": {
-    "text": "Delano",
+    "text": "Equipa de Suporte",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -825,7 +825,7 @@
     "source_hash": "5a96ae38"
   },
   "email.subscription_changed.signature": {
-    "text": "Delano",
+    "text": "Equipa de Suporte",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -853,5 +853,41 @@
     "text": "Onetime Secret",
     "renderer": "erb",
     "source_hash": "1cd0194a"
+  },
+  "email.common.secret_link_label": {
+    "text": "Link confidencial"
+  },
+  "email.common.automated_notice": {
+    "text": "Esta é uma mensagem automática de %{product_name}."
+  },
+  "email.common.support_label": {
+    "text": "Suporte"
+  },
+  "email.expiration_warning.signature": {
+    "text": "Equipa de Suporte"
+  },
+  "email.expiration_warning.footer_note": {
+    "text": "Recebeste esta mensagem porque uma mensagem confidencial que criaste em %{product_name} está prestes a expirar."
+  },
+  "email.feedback_email.user_id_label": {
+    "text": "Utilizador:"
+  },
+  "email.feedback_email.timezone_label": {
+    "text": "Fuso horário:"
+  },
+  "email.feedback_email.version_label": {
+    "text": "Versão:"
+  },
+  "email.incoming_secret.footer_note": {
+    "text": "Recebeste esta mensagem porque alguém usou %{product_name} para te enviar uma mensagem confidencial. Se não estavas à espera dela, podes ignorar este e-mail com segurança."
+  },
+  "email.secret_link.passphrase_label": {
+    "text": "Frase secreta necessária:"
+  },
+  "email.secret_link.passphrase_required": {
+    "text": "Esta mensagem confidencial está protegida com uma frase secreta. O remetente deve fornecer-ta em separado."
+  },
+  "email.secret_link.footer_note": {
+    "text": "Recebeste esta mensagem porque %{sender_email} usou %{product_name} para partilhar uma mensagem confidencial contigo. Se não estavas à espera dela, podes ignorar este e-mail com segurança."
   }
 }

--- a/locales/content/pt_PT/feature-feedback.json
+++ b/locales/content/pt_PT/feature-feedback.json
@@ -58,5 +58,14 @@
   "web.feedback.reason_email_change_unauthorized": {
     "text": "Parece que está a reportar uma alteração de e-mail não autorizada na sua conta. Descreva o que aconteceu e iremos investigar de imediato.",
     "source_hash": "00e56551"
+  },
+  "web.feedback.anonymous_no_reply": {
+    "text": "Nota: se quiseres uma resposta, por favor assina ou inclui um endereço de e-mail na mensagem."
+  },
+  "web.feedback.characters_remaining": {
+    "text": "{count} caracteres restantes"
+  },
+  "web.feedback.character_limit_reached": {
+    "text": "Limite de caracteres atingido"
   }
 }

--- a/locales/content/pt_PT/feature-homepage-secrets.json
+++ b/locales/content/pt_PT/feature-homepage-secrets.json
@@ -1,0 +1,50 @@
+{
+  "homepage_secrets.disabled.members_only_eyebrow": {
+    "text": "Instância exclusiva para membros"
+  },
+  "homepage_secrets.disabled.private_instance_eyebrow": {
+    "text": "Instância privada"
+  },
+  "homepage_secrets.disabled.team_link_headline": {
+    "text": "Este link é para a equipa {workspace}."
+  },
+  "homepage_secrets.disabled.signin_headline": {
+    "text": "Inicia sessão para criar um {action}."
+  },
+  "homepage_secrets.disabled.signin_headline_action": {
+    "text": "link confidencial"
+  },
+  "homepage_secrets.disabled.team_subtitle": {
+    "text": "Apenas os colegas de equipa autorizados em {domain} podem gerar aqui novos links de uso único. Os destinatários continuam a poder abrir qualquer link que lhes tenha sido enviado."
+  },
+  "homepage_secrets.disabled.public_subtitle": {
+    "text": "Apenas os membros autorizados desta instância podem gerar novos links de uso único. Os destinatários continuam a poder abrir qualquer link que lhes tenha sido enviado."
+  },
+  "homepage_secrets.disabled.signin_cta": {
+    "text": "Inicia sessão na tua conta"
+  },
+  "homepage_secrets.disabled.what_is_this": {
+    "text": "O que é isto?"
+  },
+  "homepage_secrets.disabled.trust_viewed_once": {
+    "text": "Visto uma vez, depois desaparece"
+  },
+  "homepage_secrets.disabled.trust_zero_retained": {
+    "text": "Zero retido"
+  },
+  "homepage_secrets.disabled.promo_title": {
+    "text": "Novidade: os planos gratuitos incluem agora domínios personalizados."
+  },
+  "homepage_secrets.disabled.promo_subtitle": {
+    "text": "Aponta o teu domínio para Onetime Secret e envia mensagens confidenciais com a tua própria marca."
+  },
+  "homepage_secrets.disabled.promo_learn_how": {
+    "text": "Saber como"
+  },
+  "homepage_secrets.disabled.logo_alt": {
+    "text": "Logótipo de {name}"
+  },
+  "homepage_secrets.disabled.opens_in_new_tab": {
+    "text": "(abre num novo separador)"
+  }
+}

--- a/locales/content/pt_PT/feature-incoming.json
+++ b/locales/content/pt_PT/feature-incoming.json
@@ -130,5 +130,26 @@
   "incoming.receipt_link_text": {
     "text": "recibo",
     "source_hash": "6f328609"
+  },
+  "incoming.upgrade_required_title": {
+    "text": "Upgrade necessário"
+  },
+  "incoming.upgrade_required_description": {
+    "text": "Esta funcionalidade requer um upgrade do plano. Por favor contacta o proprietário da conta para ativar as mensagens confidenciais recebidas."
+  },
+  "incoming.validation_memo_too_long": {
+    "text": "A nota deve ter {max} caracteres ou menos"
+  },
+  "incoming.validation_secret_required": {
+    "text": "O conteúdo confidencial é obrigatório"
+  },
+  "incoming.validation_recipient_required": {
+    "text": "Por favor seleciona um destinatário"
+  },
+  "incoming.validation_feature_disabled": {
+    "text": "A funcionalidade de mensagens confidenciais recebidas não está ativada"
+  },
+  "incoming.validation_form_errors": {
+    "text": "Por favor verifica se o formulário tem erros"
   }
 }

--- a/locales/content/pt_PT/feature-regions.json
+++ b/locales/content/pt_PT/feature-regions.json
@@ -152,7 +152,7 @@
     "source_hash": "1d97f6bd"
   },
   "web.regions.changing_regions_billing_note": {
-    "text": "Se o seu e-mail de contacto de faturação for diferente do e-mail da sua conta {product_name}, utilize o e-mail de contacto de faturação para a conta na nova região para manter os benefícios da sua subscrição.",
+    "text": "Se o teu e-mail de contacto de faturação for diferente do e-mail da tua conta {product_name}, utiliza o e-mail de contacto de faturação da conta da nova região para manter os benefícios da tua subscrição.",
     "source_hash": "dac1cc28"
   },
   "web.regions.changing_regions_subscription_note": {
@@ -186,5 +186,8 @@
   "web.regions.jurisdictions.apac.name": {
     "text": "Asia-Pacific",
     "source_hash": "7a757670"
+  },
+  "web.regions.no_region_configured": {
+    "text": "Não existem atualmente informações de região disponíveis para a tua conta."
   }
 }

--- a/locales/content/pt_PT/feature-translations.json
+++ b/locales/content/pt_PT/feature-translations.json
@@ -64,7 +64,7 @@
     "source_hash": "13131e36"
   },
   "web.translations.the_following_people_have_donated_their_time_to_": {
-    "text": "As seguintes pessoas doaram o seu tempo para ajudar a expandir o alcance do {product_name}:",
+    "text": "As seguintes pessoas doaram o seu tempo para ajudar a ampliar o alcance do {product_name}:",
     "source_hash": "85a766af"
   },
   "web.translations.translations": {
@@ -84,7 +84,7 @@
     "source_hash": "ba5c4395"
   },
   "web.translations.since_2012_onetime_secret_has_provided_a_secure_": {
-    "text": "Desde 2012, {product_name} fornece uma forma segura de partilhar informações sensíveis em todo o mundo. Com utilizadores em regiões onde o inglês não é o idioma principal, traduções precisas são essenciais para tornar a comunicação segura acessível a todos.",
+    "text": "Desde 2012, o {product_name} oferece uma forma segura de partilhar informação sensível em todo o mundo. Com utilizadores em regiões onde o inglês não é a língua principal, traduções rigorosas são essenciais para tornar a comunicação segura acessível a todos.",
     "source_hash": "87a6e9af"
   },
   "web.translations.help_secure_communication_go_global": {

--- a/locales/content/pt_PT/secret-homepage.json
+++ b/locales/content/pt_PT/secret-homepage.json
@@ -56,7 +56,7 @@
     "source_hash": "5e218489"
   },
   "web.homepage.visit_onetime_secret_home": {
-    "text": "Visitar página inicial do {product_name}",
+    "text": "Visitar a página inicial do {product_name}",
     "source_hash": "625556d2"
   },
   "web.homepage.password_generation_title": {
@@ -108,7 +108,7 @@
     "source_hash": "107093e4"
   },
   "web.homepage.about_onetime_secret_0": {
-    "text": "Sobre o {product_name}",
+    "text": "Acerca do {product_name}",
     "source_hash": "971c50da"
   },
   "web.homepage.log_in_to_onetime_secret": {
@@ -116,7 +116,7 @@
     "source_hash": "bd6be8d6"
   },
   "web.homepage.about_onetime_secret": {
-    "text": "Sobre o {product_name}",
+    "text": "Acerca do {product_name}",
     "source_hash": "971c50da"
   },
   "web.homepage.signup_individual_and_business_plans": {
@@ -172,7 +172,7 @@
     "source_hash": "0990d163"
   },
   "web.homepage.onetime_secret_helps_us_share_sensitive_informat": {
-    "text": "{product_name} ajuda-nos a partilhar informações sensíveis com segurança, mantendo a nossa fachada profissional.",
+    "text": "O {product_name} ajuda-nos a partilhar informação sensível de forma segura, mantendo a nossa fachada profissional.",
     "source_hash": "986a0856"
   },
   "web.homepage.information_shared_through_this_service_can_only": {

--- a/locales/content/pt_PT/secret-manage.json
+++ b/locales/content/pt_PT/secret-manage.json
@@ -128,7 +128,7 @@
     "source_hash": "07fe1b84"
   },
   "web.secrets.onetime_secret_is_a_secure_way_to_share_sensitiv": {
-    "text": "{product_name} é uma forma segura de partilhar informações sensíveis que se autodestruem após uma única visualização.",
+    "text": "O {product_name} é uma forma segura de partilhar informação sensível que se autodestrói após uma única visualização.",
     "source_hash": "8a163297"
   },
   "web.secrets.what_is_this": {
@@ -398,5 +398,11 @@
   "web.secrets.errors.access_denied_to_domain": {
     "text": "Acesso negado ao domínio",
     "source_hash": "cd441eea"
+  },
+  "web.receipt.open_link": {
+    "text": "Abrir link"
+  },
+  "web.secrets.messageDeleted": {
+    "text": "Mensagem eliminada"
   }
 }

--- a/locales/content/pt_PT/session-auth-extended.json
+++ b/locales/content/pt_PT/session-auth-extended.json
@@ -710,5 +710,26 @@
   "web.auth.recovery_codes.link_title": {
     "text": "Códigos de recuperação",
     "source_hash": "579c7f4e"
+  },
+  "web.auth.google": {
+    "text": "Google"
+  },
+  "web.auth.mfa.alternative_auth_options": {
+    "text": "Opções de autenticação alternativas"
+  },
+  "web.auth.remember.enabled": {
+    "text": "Manter sessão iniciada"
+  },
+  "web.auth.security._guidance.context": {
+    "text": "⚠️ SECURITY-CRITICAL: Messages prevent information disclosure. See src/locales/SECURITY-TRANSLATION-GUIDE.md"
+  },
+  "web.auth.sessions.session_singular": {
+    "text": "sessão"
+  },
+  "web.auth.sessions.session_plural": {
+    "text": "sessões"
+  },
+  "web.auth.sessions._guidance.context": {
+    "text": "User's logged-in devices/browsers management page"
   }
 }

--- a/locales/content/pt_PT/session-auth.json
+++ b/locales/content/pt_PT/session-auth.json
@@ -395,5 +395,35 @@
   "web.help.contact_support": {
     "text": "Contactar Suporte",
     "source_hash": "f8d47b82"
+  },
+  "web.auth.account.sso_linked": {
+    "text": "Conta SSO"
+  },
+  "web.auth.verify._guidance.context": {
+    "text": "Email verification flow after signup"
+  },
+  "web.help.reset_password_link": {
+    "text": "Redefinir palavra-passe"
+  },
+  "web.login.custom_domain_sso_title": {
+    "text": "O início de sessão único está disponível para este domínio"
+  },
+  "web.login.custom_domain_sso_description": {
+    "text": "O administrador da organização pode ativar o SSO para permitir que os membros da equipa iniciem sessão aqui. Contacta o administrador para obteres acesso."
+  },
+  "web.login.signin_disabled_heading": {
+    "text": "O início de sessão não está disponível"
+  },
+  "web.login.signin_disabled_message": {
+    "text": "O início de sessão não está disponível neste domínio de momento."
+  },
+  "web.login.errors.sso_not_configured": {
+    "text": "O início de sessão único não está configurado para este domínio. Contacta o teu administrador."
+  },
+  "web.login.errors.invalid_email": {
+    "text": "O endereço de e-mail do teu fornecedor de identidade é inválido. Contacta o teu administrador."
+  },
+  "web.login.errors.domain_not_allowed": {
+    "text": "O teu domínio de e-mail não está autorizado para o registo via SSO. Contacta o teu administrador."
   }
 }

--- a/locales/content/pt_PT/workspace-account.json
+++ b/locales/content/pt_PT/workspace-account.json
@@ -476,7 +476,7 @@
     "source_hash": "1cc77e60"
   },
   "web.settings.api.documentation_description": {
-    "text": "Saiba como integrar o {product_name} nas suas aplicações",
+    "text": "Saber como integrar o {product_name} nas tuas aplicações",
     "source_hash": "6e8f910f"
   },
   "web.settings.api.rest_api_reference": {
@@ -682,5 +682,14 @@
   "web.settings.profile.didnt_receive_email": {
     "text": "Não recebeu o e-mail?",
     "source_hash": "fe3ac3ad"
+  },
+  "web.settings.api.api_disabled_notice": {
+    "text": "A API está desativada para esta instância."
+  },
+  "web.settings.security.sso_managed_title": {
+    "text": "Segurança gerida por SSO"
+  },
+  "web.settings.security.sso_managed_description": {
+    "text": "A tua conta é autenticada através do fornecedor de início de sessão único da tua organização. A palavra-passe, a autenticação multifator e os códigos de recuperação são geridos pelo teu fornecedor de identidade."
   }
 }

--- a/locales/content/pt_PT/workspace-billing.json
+++ b/locales/content/pt_PT/workspace-billing.json
@@ -988,5 +988,47 @@
     "text": "Disponível apenas na sua região de subscrição original",
     "context": "Hint shown on plan cards when currency does not match active subscription",
     "source_hash": "10de32e5"
+  },
+  "web.billing.already_subscribed": {
+    "text": "Já subscreveste este plano."
+  },
+  "web.billing.cancel.reactivate_button": {
+    "text": "Reativar subscrição"
+  },
+  "web.billing.cancel.reactivate_success": {
+    "text": "A tua subscrição foi reativada. Vais continuar a ser faturado normalmente."
+  },
+  "web.billing.cancel.reactivate_error": {
+    "text": "Não foi possível reativar a subscrição. Tenta novamente ou contacta o suporte."
+  },
+  "web.billing.features.manage_orgs": {
+    "text": "Gestão de Organizações"
+  },
+  "web.billing.features.flexible_from_domain": {
+    "text": "Domínio de Remetente de E-mail Flexível"
+  },
+  "web.billing.features.unlimited_admins": {
+    "text": "Administradores Ilimitados"
+  },
+  "web.billing.features.manage_sso": {
+    "text": "SSO"
+  },
+  "web.billing.overview.entitlements.flexible_from_domain": {
+    "text": "Domínio de Remetente de E-mail Flexível"
+  },
+  "web.billing.overview.entitlements.manage_orgs": {
+    "text": "Gerir Organizações"
+  },
+  "web.billing.overview.entitlements.manage_sso": {
+    "text": "Single Sign-On (SSO)"
+  },
+  "web.billing.overview.entitlements.manage_billing": {
+    "text": "Gerir Faturação"
+  },
+  "web.billing.overview.entitlements.custom_signup_validation": {
+    "text": "Validação de Registo Personalizada"
+  },
+  "web.billing.plans.reactivate": {
+    "text": "Reativar"
   }
 }

--- a/locales/content/pt_PT/workspace-branding.json
+++ b/locales/content/pt_PT/workspace-branding.json
@@ -178,5 +178,11 @@
   "web.branding.upgrade_to_customize": {
     "text": "Faça upgrade do seu plano para personalizar a marca deste domínio.",
     "source_hash": "9077bf79"
+  },
+  "web.branding.saved_successfully": {
+    "text": "Definições da marca guardadas com sucesso"
+  },
+  "web.branding.keyhole_logo_icon": {
+    "text": "Ícone de buraco de fechadura que representa a partilha segura e privada"
   }
 }

--- a/locales/content/pt_PT/workspace-dashboard.json
+++ b/locales/content/pt_PT/workspace-dashboard.json
@@ -22,5 +22,14 @@
   "web.dashboard.fetch_error_description": {
     "text": "Ocorreu um problema ao carregar os seus dados. Por favor, tente novamente.",
     "source_hash": "ff0d904e"
+  },
+  "web.teams.create_first_team_title": {
+    "text": "Cria a tua primeira equipa"
+  },
+  "web.teams.create_first_team_description": {
+    "text": "As equipas permitem-te colaborar com outras pessoas num espaço de trabalho partilhado."
+  },
+  "web.teams.create_team": {
+    "text": "Criar equipa"
   }
 }

--- a/locales/content/pt_PT/workspace-domains.json
+++ b/locales/content/pt_PT/workspace-domains.json
@@ -790,7 +790,7 @@
     "text": "Mensagens confidenciais recebidas não configuradas - os utilizadores externos não podem enviar mensagens confidenciais para este domínio"
   },
   "web.domains.incoming.tooltip_configured": {
-    "text": "Mensagens confidenciais recebidas ativadas com {count} destinatário(s)"
+    "text": "Mensagens confidenciais recebidas ativadas com {count} destinatário | Mensagens confidenciais recebidas ativadas com {count} destinatários"
   },
   "web.domains.incoming.tooltip_disabled": {
     "text": "A funcionalidade de mensagens confidenciais recebidas está desativada para este domínio"

--- a/locales/content/pt_PT/workspace-domains.json
+++ b/locales/content/pt_PT/workspace-domains.json
@@ -398,5 +398,725 @@
   "web.domains.dns_widget_description": {
     "text": "Use a ferramenta abaixo para detetar automaticamente o seu fornecedor de DNS e obter instruções passo a passo para configurar o seu domínio.",
     "source_hash": "91c1af2e"
+  },
+  "api.domains.errors.add_admin_required": {
+    "text": "Apenas os proprietários e administradores da organização podem adicionar domínios personalizados"
+  },
+  "web.domains.public_homepage": {
+    "text": "Página inicial pública"
+  },
+  "web.domains.status_tooltip_active": {
+    "text": "Domínio verificado e ativo"
+  },
+  "web.domains.status_tooltip_dns_incorrect": {
+    "text": "DNS não configurado — clica para corrigir"
+  },
+  "web.domains.status_tooltip_not_verified": {
+    "text": "Domínio não verificado — clica para verificar"
+  },
+  "web.domains.status_tooltip_unverified": {
+    "text": "Estado do domínio não verificado — clica para atualizar"
+  },
+  "web.domains.last_check_failed": {
+    "text": "A última verificação falhou"
+  },
+  "web.domains.last_check_failed_ago": {
+    "text": "última verificação falhou {0}"
+  },
+  "web.domains.verify_now": {
+    "text": "Verificar agora"
+  },
+  "web.domains.click_to_verify": {
+    "text": "clica para verificar"
+  },
+  "web.domains.remove_domain_description": {
+    "text": "Remover permanentemente este domínio e toda a sua configuração."
+  },
+  "web.domains.add_access_denied": {
+    "text": "Acesso negado"
+  },
+  "web.domains.add_access_denied_description": {
+    "text": "Não tens permissão para adicionar domínios a esta organização. Contacta o administrador da tua organização."
+  },
+  "web.domains.dns_widget_load_failed": {
+    "text": "Falha ao carregar o widget de DNS"
+  },
+  "web.domains.dns_widget_not_available": {
+    "text": "Widget de DNS não disponível"
+  },
+  "web.domains.dns_widget_init_failed": {
+    "text": "Falha ao inicializar o widget de DNS"
+  },
+  "web.domains.verified": {
+    "text": "Verificado"
+  },
+  "web.domains.pending_verification": {
+    "text": "Verificação pendente"
+  },
+  "web.domains.unsaved_changes_confirmation": {
+    "text": "Tens alterações não guardadas. Tens a certeza de que queres sair?"
+  },
+  "web.domains.entitlement_required_owner": {
+    "text": "Esta funcionalidade requer um upgrade do plano."
+  },
+  "web.domains.entitlement_required_member": {
+    "text": "Esta funcionalidade não está disponível no teu plano atual. Contacta o proprietário da tua organização."
+  },
+  "web.domains.detail.manage": {
+    "text": "Gerir"
+  },
+  "web.domains.detail.features": {
+    "text": "Funcionalidades"
+  },
+  "web.domains.detail.homepage_title": {
+    "text": "Mensagens Confidenciais na Página Inicial"
+  },
+  "web.domains.detail.homepage_description": {
+    "text": "Permitir o acesso público para criar mensagens confidenciais na página inicial do teu domínio"
+  },
+  "web.domains.detail.brand_description": {
+    "text": "Logótipo, cores e personalização da marca"
+  },
+  "web.domains.detail.sso_description": {
+    "text": "Definições do fornecedor de início de sessão único"
+  },
+  "web.domains.detail.email_description": {
+    "text": "Configuração personalizada do remetente de e-mail"
+  },
+  "web.domains.detail.incoming_description": {
+    "text": "Definições do destinatário de mensagens confidenciais recebidas"
+  },
+  "web.domains.detail.signup_description": {
+    "text": "Estratégia de validação de registo por domínio"
+  },
+  "web.domains.detail.signin_description": {
+    "text": "Configuração do método de início de sessão por domínio"
+  },
+  "web.domains.email.title": {
+    "text": "Envio de e-mail"
+  },
+  "web.domains.email.config_title": {
+    "text": "Configuração de e-mail"
+  },
+  "web.domains.email.config_description": {
+    "text": "Configurar o envio de e-mail para este domínio"
+  },
+  "web.domains.email.provider_label": {
+    "text": "Fornecedor de e-mail"
+  },
+  "web.domains.email.provider_placeholder": {
+    "text": "Seleciona um fornecedor de e-mail"
+  },
+  "web.domains.email.from_name_label": {
+    "text": "Nome do remetente"
+  },
+  "web.domains.email.from_name_placeholder": {
+    "text": "p. ex. Acme Security"
+  },
+  "web.domains.email.from_address_label": {
+    "text": "Endereço do remetente"
+  },
+  "web.domains.email.from_address_placeholder": {
+    "text": "p. ex. secrets{'@'}exemplo.com"
+  },
+  "web.domains.email.reply_to_label": {
+    "text": "Endereço de resposta"
+  },
+  "web.domains.email.reply_to_placeholder": {
+    "text": "p. ex. support{'@'}exemplo.com"
+  },
+  "web.domains.email.save_changes": {
+    "text": "Guardar alterações"
+  },
+  "web.domains.email.discard_changes": {
+    "text": "Descartar alterações"
+  },
+  "web.domains.email.provider_ses": {
+    "text": "Amazon SES"
+  },
+  "web.domains.email.provider_sendgrid": {
+    "text": "SendGrid"
+  },
+  "web.domains.email.provider_lettermint": {
+    "text": "Lettermint"
+  },
+  "web.domains.email.provider_inherit": {
+    "text": "Usar predefinições da conta"
+  },
+  "web.domains.email.provider_ses_description": {
+    "text": "Requer a verificação do domínio através de registos DKIM e SPF"
+  },
+  "web.domains.email.provider_sendgrid_description": {
+    "text": "Requer a configuração da autenticação do domínio"
+  },
+  "web.domains.email.provider_lettermint_description": {
+    "text": "Requer a verificação do domínio"
+  },
+  "web.domains.email.provider_inherit_description": {
+    "text": "Usa a configuração de envio de e-mail predefinida da tua conta"
+  },
+  "web.domains.email.dns_records_title": {
+    "text": "Registos DNS"
+  },
+  "web.domains.email.dns_records_description": {
+    "text": "Adiciona os seguintes registos DNS para verificar o teu domínio para o envio de e-mail."
+  },
+  "web.domains.email.dns_column_type": {
+    "text": "Tipo"
+  },
+  "web.domains.email.dns_column_name": {
+    "text": "Nome"
+  },
+  "web.domains.email.dns_column_value": {
+    "text": "Valor"
+  },
+  "web.domains.email.dns_check_label": {
+    "text": "DNS"
+  },
+  "web.domains.email.provider_check_label": {
+    "text": "Fornecedor"
+  },
+  "web.domains.email.dns_optional_label": {
+    "text": "Recomendado"
+  },
+  "web.domains.email.dns_optional_hint": {
+    "text": "Este registo é recomendado mas não é obrigatório para a verificação. Uma política DMARC no domínio da tua organização pode já abranger este subdomínio."
+  },
+  "web.domains.email.copy": {
+    "text": "Copiar"
+  },
+  "web.domains.email.copied": {
+    "text": "Copiado"
+  },
+  "web.domains.email.status_verified": {
+    "text": "Verificado"
+  },
+  "web.domains.email.status_pending": {
+    "text": "Pendente"
+  },
+  "web.domains.email.status_failed": {
+    "text": "Falhou"
+  },
+  "web.domains.email.revalidate": {
+    "text": "Revalidar"
+  },
+  "web.domains.email.validating": {
+    "text": "A validar..."
+  },
+  "web.domains.email.domain_verified": {
+    "text": "Domínio verificado"
+  },
+  "web.domains.email.validation_failed": {
+    "text": "A validação falhou"
+  },
+  "web.domains.email.last_validated": {
+    "text": "Última validação"
+  },
+  "web.domains.email.upgrade_to_configure": {
+    "text": "Faz upgrade do teu plano para configurar o envio de e-mail para este domínio."
+  },
+  "web.domains.email.configure_email": {
+    "text": "Configurar e-mail"
+  },
+  "web.domains.email.access_denied": {
+    "text": "Acesso negado"
+  },
+  "web.domains.email.access_denied_description": {
+    "text": "Não tens permissão para gerir as definições de e-mail deste domínio. Contacta o administrador da tua organização."
+  },
+  "web.domains.email.update_success": {
+    "text": "Configuração de e-mail guardada com sucesso"
+  },
+  "web.domains.email.delete_success": {
+    "text": "Configuração de e-mail removida com sucesso"
+  },
+  "web.domains.email.default_sender_notice": {
+    "text": "Os e-mails para este domínio são atualmente enviados a partir do remetente global. Conclui a configuração de e-mail para usar a tua própria identidade de remetente."
+  },
+  "web.domains.email.disabled_notice": {
+    "text": "O envio de e-mail personalizado está atualmente desativado. Os e-mails serão enviados a partir do remetente global. Ativa a funcionalidade abaixo para usar a tua identidade de remetente personalizada."
+  },
+  "web.domains.email.test_email_title": {
+    "text": "Testar a entrega de e-mail"
+  },
+  "web.domains.email.test_email_hint": {
+    "text": "Envia um e-mail de teste para ti próprio usando a configuração guardada. Funciona mesmo quando a funcionalidade ainda não está ativada."
+  },
+  "web.domains.email.send_test": {
+    "text": "Enviar teste"
+  },
+  "web.domains.email.test_email_sent": {
+    "text": "E-mail de teste enviado com sucesso"
+  },
+  "web.domains.email.test_email_failed": {
+    "text": "Falha ao enviar o e-mail de teste"
+  },
+  "web.domains.email.test_email_sent_to": {
+    "text": "Enviado para {email}"
+  },
+  "web.domains.email.delivered_via": {
+    "text": "Entregue através de {provider}"
+  },
+  "web.domains.email.badge_not_configured": {
+    "text": "Não configurado"
+  },
+  "web.domains.email.badge_default_sender": {
+    "text": "A usar o remetente predefinido"
+  },
+  "web.domains.email.badge_verified": {
+    "text": "Verificado"
+  },
+  "web.domains.email.badge_pending": {
+    "text": "Verificação pendente"
+  },
+  "web.domains.email.badge_disabled": {
+    "text": "Desativado"
+  },
+  "web.domains.email.tooltip_not_configured": {
+    "text": "Nenhum remetente de e-mail configurado — os e-mails usam o remetente predefinido da plataforma"
+  },
+  "web.domains.email.tooltip_pending": {
+    "text": "A configuração do remetente de e-mail está pendente de verificação — os e-mails usam o remetente predefinido da plataforma"
+  },
+  "web.domains.email.tooltip_disabled": {
+    "text": "O remetente de e-mail está desativado — os e-mails usam o remetente predefinido da plataforma"
+  },
+  "web.domains.email.tooltip_verified": {
+    "text": "Remetente de e-mail verificado — os e-mails são enviados a partir deste domínio"
+  },
+  "web.domains.incoming.title": {
+    "text": "Mensagens Confidenciais Recebidas"
+  },
+  "web.domains.incoming.config_title": {
+    "text": "Configuração de Mensagens Confidenciais Recebidas"
+  },
+  "web.domains.incoming.config_description": {
+    "text": "Permitir que utilizadores externos enviem mensagens confidenciais diretamente para destinatários designados neste domínio"
+  },
+  "web.domains.incoming.feature_disabled": {
+    "text": "Mensagens Confidenciais Recebidas Indisponíveis"
+  },
+  "web.domains.incoming.feature_disabled_description": {
+    "text": "As mensagens confidenciais recebidas não estão ativadas nesta instância. Contacta o teu administrador."
+  },
+  "web.domains.incoming.access_denied": {
+    "text": "Acesso negado"
+  },
+  "web.domains.incoming.access_denied_description": {
+    "text": "Não tens permissão para gerir as definições de mensagens confidenciais recebidas deste domínio. Contacta o administrador da tua organização."
+  },
+  "web.domains.incoming.upgrade_to_configure": {
+    "text": "Faz upgrade do teu plano para configurar as mensagens confidenciais recebidas neste domínio."
+  },
+  "web.domains.incoming.configure_incoming": {
+    "text": "Configurar Mensagens Confidenciais Recebidas"
+  },
+  "web.domains.incoming.not_configured_notice": {
+    "text": "As mensagens confidenciais recebidas não estão configuradas para este domínio. Adiciona destinatários para permitir que utilizadores externos enviem mensagens confidenciais à tua equipa."
+  },
+  "web.domains.incoming.disabled_notice": {
+    "text": "As mensagens confidenciais recebidas estão atualmente desativadas. Os utilizadores externos não podem enviar mensagens confidenciais para destinatários neste domínio. Ativa a funcionalidade abaixo para permitir mensagens confidenciais recebidas."
+  },
+  "web.domains.incoming.recipients_title": {
+    "text": "Destinatários"
+  },
+  "web.domains.incoming.recipients_description": {
+    "text": "Define quem pode receber mensagens confidenciais recebidas neste domínio. Os destinatários receberão notificações por e-mail quando lhes for enviada uma mensagem confidencial."
+  },
+  "web.domains.incoming.add_recipient": {
+    "text": "Adicionar destinatário"
+  },
+  "web.domains.incoming.remove_recipient": {
+    "text": "Remover"
+  },
+  "web.domains.incoming.email_label": {
+    "text": "Endereço de e-mail"
+  },
+  "web.domains.incoming.email_placeholder": {
+    "text": "destinatario{'@'}exemplo.com"
+  },
+  "web.domains.incoming.name_label": {
+    "text": "Nome a apresentar"
+  },
+  "web.domains.incoming.name_placeholder": {
+    "text": "p. ex. Equipa de Segurança"
+  },
+  "web.domains.incoming.empty_state": {
+    "text": "Nenhum destinatário configurado"
+  },
+  "web.domains.incoming.empty_state_description": {
+    "text": "Adiciona destinatários para permitir que utilizadores externos enviem mensagens confidenciais à tua equipa."
+  },
+  "web.domains.incoming.validation_invalid_email": {
+    "text": "Endereço de e-mail inválido"
+  },
+  "web.domains.incoming.validation_duplicate_email": {
+    "text": "Este endereço de e-mail já foi adicionado"
+  },
+  "web.domains.incoming.validation_max_recipients": {
+    "text": "Máximo de {max} destinatários permitidos"
+  },
+  "web.domains.incoming.validation_name_required": {
+    "text": "O nome a apresentar é obrigatório"
+  },
+  "web.domains.incoming.validation_email_required": {
+    "text": "O endereço de e-mail é obrigatório"
+  },
+  "web.domains.incoming.save_changes": {
+    "text": "Guardar alterações"
+  },
+  "web.domains.incoming.discard_changes": {
+    "text": "Descartar alterações"
+  },
+  "web.domains.incoming.update_success": {
+    "text": "Configuração de mensagens confidenciais recebidas guardada com sucesso"
+  },
+  "web.domains.incoming.delete_success": {
+    "text": "Configuração de mensagens confidenciais recebidas removida com sucesso"
+  },
+  "web.domains.incoming.recipient_count": {
+    "text": "{count} destinatário | {count} destinatários"
+  },
+  "web.domains.incoming.badge_not_configured": {
+    "text": "Não configurado"
+  },
+  "web.domains.incoming.badge_configured": {
+    "text": "Configurado"
+  },
+  "web.domains.incoming.badge_disabled": {
+    "text": "Desativado"
+  },
+  "web.domains.incoming.tooltip_not_configured": {
+    "text": "Mensagens confidenciais recebidas não configuradas - os utilizadores externos não podem enviar mensagens confidenciais para este domínio"
+  },
+  "web.domains.incoming.tooltip_configured": {
+    "text": "Mensagens confidenciais recebidas ativadas com {count} destinatário(s)"
+  },
+  "web.domains.incoming.tooltip_disabled": {
+    "text": "A funcionalidade de mensagens confidenciais recebidas está desativada para este domínio"
+  },
+  "web.domains.incoming.enabled_label": {
+    "text": "Ativar Mensagens Confidenciais Recebidas"
+  },
+  "web.domains.incoming.enabled_hint": {
+    "text": "Permitir que utilizadores externos enviem mensagens confidenciais para destinatários neste domínio"
+  },
+  "web.domains.incoming.public_url_label": {
+    "text": "URL pública"
+  },
+  "web.domains.incoming.public_url_description": {
+    "text": "Partilha esta URL com utilizadores externos para lhes permitir enviar mensagens confidenciais"
+  },
+  "web.domains.incoming.copy_url": {
+    "text": "Copiar URL"
+  },
+  "web.domains.incoming.url_copied": {
+    "text": "URL copiada para a área de transferência"
+  },
+  "web.domains.incoming.remove_all_confirmation": {
+    "text": "Tens a certeza de que queres remover todos os destinatários? Os utilizadores externos deixarão de poder enviar mensagens confidenciais para este domínio."
+  },
+  "web.domains.incoming.max_recipients_reached": {
+    "text": "Número máximo de destinatários atingido"
+  },
+  "web.domains.incoming.duplicate_recipient": {
+    "text": "Este endereço de e-mail já foi adicionado"
+  },
+  "web.domains.incoming.save_will_replace_confirmation": {
+    "text": "Ao guardar, todos os destinatários existentes serão substituídos pelas tuas alterações pendentes. Tens a certeza?"
+  },
+  "web.domains.incoming.delete_all_recipients": {
+    "text": "Eliminar Todos os Destinatários"
+  },
+  "web.domains.signin.title": {
+    "text": "Configuração de Início de Sessão"
+  },
+  "web.domains.signin.configure_signin": {
+    "text": "Configurar Início de Sessão"
+  },
+  "web.domains.signin.config_description": {
+    "text": "Configurar os métodos de autenticação de início de sessão para este domínio"
+  },
+  "web.domains.signin.access_denied": {
+    "text": "Acesso negado"
+  },
+  "web.domains.signin.upgrade_to_configure": {
+    "text": "Faz upgrade do teu plano para configurar os métodos de início de sessão para este domínio."
+  },
+  "web.domains.signin.not_configured_notice": {
+    "text": "A configuração de início de sessão ainda não está definida para este domínio. Configura substituições para controlar que métodos de autenticação estão disponíveis na página de início de sessão deste domínio."
+  },
+  "web.domains.signin.signin_enabled_label": {
+    "text": "Início de sessão ativado"
+  },
+  "web.domains.signin.header_toggle_label": {
+    "text": "Início de sessão"
+  },
+  "web.domains.signin.signin_enabled_hint": {
+    "text": "Se os utilizadores podem iniciar sessão neste domínio"
+  },
+  "web.domains.signin.restrict_to_label": {
+    "text": "Restringir o método de início de sessão"
+  },
+  "web.domains.signin.restrict_to_hint": {
+    "text": "Restringe este domínio a um único método de autenticação. Quando definido, apenas o método escolhido é apresentado na página de início de sessão."
+  },
+  "web.domains.signin.all_methods": {
+    "text": "Todos os métodos"
+  },
+  "web.domains.signin.all_methods_description": {
+    "text": "Apresentar todos os métodos de autenticação ativados na página de início de sessão"
+  },
+  "web.domains.signin.method_password": {
+    "text": "Palavra-passe"
+  },
+  "web.domains.signin.method_email_auth": {
+    "text": "Autenticação por e-mail"
+  },
+  "web.domains.signin.method_webauthn": {
+    "text": "WebAuthn / Chaves de acesso"
+  },
+  "web.domains.signin.method_sso": {
+    "text": "Single Sign-On"
+  },
+  "web.domains.signin.method_overrides_label": {
+    "text": "Substituições de método"
+  },
+  "web.domains.signin.method_overrides_hint": {
+    "text": "Ativar ou desativar métodos de autenticação individuais para este domínio"
+  },
+  "web.domains.signin.mode_question": {
+    "text": "Como podem os utilizadores iniciar sessão?"
+  },
+  "web.domains.signin.mode_any": {
+    "text": "Qualquer método disponível"
+  },
+  "web.domains.signin.mode_any_hint": {
+    "text": "Apresentar todos os métodos disponíveis neste domínio. Restringe métodos individuais abaixo."
+  },
+  "web.domains.signin.mode_one": {
+    "text": "Um método específico"
+  },
+  "web.domains.signin.mode_one_hint": {
+    "text": "Restringir a página de início de sessão a um único método. Apenas os métodos disponíveis neste domínio são listados."
+  },
+  "web.domains.signin.mode_disabled": {
+    "text": "Início de sessão desativado"
+  },
+  "web.domains.signin.mode_disabled_hint": {
+    "text": "Os utilizadores não podem iniciar sessão neste domínio."
+  },
+  "web.domains.signin.mode_disabled_notice": {
+    "text": "Os visitantes da página de início de sessão deste domínio veem um aviso de que o início de sessão não está disponível, com uma ligação de regresso à página inicial. As tuas definições de método anteriores são mantidas e restauradas quando reativares o início de sessão."
+  },
+  "web.domains.signin.methods_list_label": {
+    "text": "Métodos apresentados na página de início de sessão"
+  },
+  "web.domains.signin.restrict_picker_hint": {
+    "text": "Apenas os métodos disponíveis neste domínio são listados."
+  },
+  "web.domains.signin.availability_always": {
+    "text": "Sempre disponível"
+  },
+  "web.domains.signin.availability_global_on": {
+    "text": "Segue a política global · Ativo"
+  },
+  "web.domains.signin.availability_global_off": {
+    "text": "Não disponível"
+  },
+  "web.domains.signin.availability_unavailable": {
+    "text": "Indisponível em todo o site"
+  },
+  "web.domains.signin.allow_on_domain": {
+    "text": "Permitir neste domínio"
+  },
+  "web.domains.signin.method_password_blurb": {
+    "text": "Apenas palavra-passe"
+  },
+  "web.domains.signin.method_email_auth_blurb": {
+    "text": "Início de sessão sem palavra-passe por link mágico"
+  },
+  "web.domains.signin.method_webauthn_blurb": {
+    "text": "Biometria e chaves de segurança"
+  },
+  "web.domains.signin.method_sso_blurb": {
+    "text": "Fornecedor de identidade externo"
+  },
+  "web.domains.signin.email_auth_label": {
+    "text": "Autenticação por e-mail"
+  },
+  "web.domains.signin.email_auth_hint": {
+    "text": "Permitir a autenticação por e-mail sem palavra-passe neste domínio"
+  },
+  "web.domains.signin.sso_enabled_label": {
+    "text": "Single Sign-On"
+  },
+  "web.domains.signin.sso_enabled_hint": {
+    "text": "Permitir a autenticação SSO neste domínio"
+  },
+  "web.domains.signin.enabled_label": {
+    "text": "Ativar a configuração de início de sessão"
+  },
+  "web.domains.signin.enabled_hint": {
+    "text": "Quando ativado, este domínio usa as definições de início de sessão configuradas acima"
+  },
+  "web.domains.signin.save_config": {
+    "text": "Guardar configuração"
+  },
+  "web.domains.signin.update_success": {
+    "text": "Configuração de início de sessão atualizada com sucesso"
+  },
+  "web.domains.signin.reset_to_defaults": {
+    "text": "Repor predefinições"
+  },
+  "web.domains.signin.reset_confirm": {
+    "text": "Repor o início de sessão para as predefinições globais?"
+  },
+  "web.domains.signin.reset_keeps_sso": {
+    "text": "As tuas credenciais SSO são mantidas. Remove-as separadamente no ecrã de configuração do SSO."
+  },
+  "web.domains.signin.reset_action": {
+    "text": "Sim, repor"
+  },
+  "web.domains.signin.reset_success": {
+    "text": "Definições de início de sessão repostas para as predefinições globais"
+  },
+  "web.domains.signup.title": {
+    "text": "Validação de Registo"
+  },
+  "web.domains.signup.config_description": {
+    "text": "Configurar a validação de registo para este domínio"
+  },
+  "web.domains.signup.access_denied": {
+    "text": "Acesso negado"
+  },
+  "web.domains.signup.upgrade_to_configure": {
+    "text": "Faz upgrade do teu plano para configurar a validação de registo por domínio."
+  },
+  "web.domains.signup.configure_signup": {
+    "text": "Configurar Registo"
+  },
+  "web.domains.signup.not_configured_notice": {
+    "text": "A validação de registo ainda não está configurada para este domínio. Configura uma estratégia para controlar quem se pode registar através deste domínio."
+  },
+  "web.domains.signup.site_signups_disabled_warning": {
+    "text": "Os registos estão atualmente desativados ao nível do site. Esta política por domínio está configurada, mas não filtrará qualquer tráfego até os registos do site serem ativados."
+  },
+  "web.domains.signup.strategy_label": {
+    "text": "Estratégia de validação"
+  },
+  "web.domains.signup.strategy_description": {
+    "text": "Escolhe como os endereços de e-mail são validados quando os utilizadores se registam neste domínio."
+  },
+  "web.domains.signup.network_validation_warning": {
+    "text": "Esta estratégia realiza chamadas de rede durante o registo, o que pode aumentar a latência ou ser bloqueado por alguns fornecedores."
+  },
+  "web.domains.signup.allowed_domains_label": {
+    "text": "Domínios de registo permitidos"
+  },
+  "web.domains.signup.allowed_domains_hint": {
+    "text": "Apenas estes domínios de e-mail terão permissão para se registar. Adiciona um domínio por entrada."
+  },
+  "web.domains.signup.domain_placeholder": {
+    "text": "example.com"
+  },
+  "web.domains.signup.invalid_domain": {
+    "text": "Introduz um domínio válido (p. ex. example.com)"
+  },
+  "web.domains.signup.domain_exists": {
+    "text": "Este domínio já está na lista"
+  },
+  "web.domains.signup.remove_domain": {
+    "text": "Remover {domain}"
+  },
+  "web.domains.signup.enabled_label": {
+    "text": "Ativar a validação por domínio"
+  },
+  "web.domains.signup.enabled_hint": {
+    "text": "Quando ativado, os registos neste domínio usam a estratégia acima em vez da política global."
+  },
+  "web.domains.signup.delete_config": {
+    "text": "Eliminar configuração"
+  },
+  "web.domains.signup.delete_confirm": {
+    "text": "Eliminar a configuração de validação de registo? Os registos passarão a usar a política global."
+  },
+  "web.domains.signup.save_config": {
+    "text": "Guardar configuração"
+  },
+  "web.domains.signup.update_success": {
+    "text": "Validação de registo atualizada com sucesso"
+  },
+  "web.domains.signup.delete_success": {
+    "text": "Configuração de validação de registo removida com sucesso"
+  },
+  "web.domains.signup.domain_overrides_label": {
+    "text": "Substituições do domínio"
+  },
+  "web.domains.signup.domain_overrides_hint": {
+    "text": "Substituir as definições de registo globais para este domínio"
+  },
+  "web.domains.signup.signup_enabled_label": {
+    "text": "Registo ativado"
+  },
+  "web.domains.signup.signup_enabled_hint": {
+    "text": "Substituir se o registo está ativado para este domínio"
+  },
+  "web.domains.signup.autoverify_label": {
+    "text": "Verificar contas automaticamente"
+  },
+  "web.domains.signup.autoverify_hint": {
+    "text": "Substituir se as novas contas são automaticamente verificadas neste domínio"
+  },
+  "web.domains.sso.title": {
+    "text": "Single Sign-On"
+  },
+  "web.domains.sso.config_title": {
+    "text": "Configuração de SSO"
+  },
+  "web.domains.sso.config_description": {
+    "text": "Configurar a autenticação de início de sessão único para este domínio"
+  },
+  "web.domains.sso.access_denied": {
+    "text": "Acesso negado"
+  },
+  "web.domains.sso.access_denied_description": {
+    "text": "Não tens permissão para gerir as definições de SSO deste domínio. Contacta o administrador da tua organização."
+  },
+  "web.domains.sso.upgrade_to_configure": {
+    "text": "Faz upgrade do teu plano para configurar o início de sessão único para este domínio."
+  },
+  "web.domains.sso.create_success": {
+    "text": "Configuração de SSO criada com sucesso"
+  },
+  "web.domains.sso.update_success": {
+    "text": "Configuração de SSO atualizada com sucesso"
+  },
+  "web.domains.sso.delete_success": {
+    "text": "Configuração de SSO removida com sucesso"
+  },
+  "web.domains.sso.test_success": {
+    "text": "Teste de ligação bem-sucedido — o fornecedor respondeu corretamente"
+  },
+  "web.domains.sso.test_failed": {
+    "text": "O teste de ligação falhou"
+  },
+  "web.domains.sso.enforce_moved_notice": {
+    "text": "Para exigir SSO em todos os inícios de sessão neste domínio, configura-o nas definições de início de sessão do domínio. O modo exclusivo de SSO restringe a página de início de sessão ao fornecedor de SSO configurado aqui."
+  },
+  "web.domains.sso.configure_sso": {
+    "text": "Configurar SSO"
+  },
+  "web.domains.sso.not_configured_notice": {
+    "text": "O SSO ainda não está configurado para este domínio. Ativa o início de sessão único para permitir que os membros da equipa se autentiquem usando o fornecedor de identidade da tua organização."
+  },
+  "web.domains.sso.edit_credentials": {
+    "text": "Editar credenciais"
+  },
+  "web.domains.sso.configure_button": {
+    "text": "Configurar"
+  },
+  "web.domains.sso.upgrade_required": {
+    "text": "Faz upgrade para configurar"
   }
 }

--- a/locales/content/pt_PT/workspace-organizations.json
+++ b/locales/content/pt_PT/workspace-organizations.json
@@ -578,5 +578,344 @@
   "web.organizations.invitations.expires_soon": {
     "text": "Expira em breve",
     "source_hash": "a5dcfef9"
+  },
+  "api.organizations.errors.not_found": {
+    "text": "Organização não encontrada: %{extid}"
+  },
+  "api.organizations.errors.owner_required": {
+    "text": "Apenas o proprietário da organização pode realizar esta ação"
+  },
+  "api.organizations.errors.admin_required": {
+    "text": "Apenas os proprietários e administradores da organização podem realizar esta ação"
+  },
+  "api.organizations.errors.member_required": {
+    "text": "Tens de ser membro da organização para realizar esta ação"
+  },
+  "api.organizations.invitations.errors.create_admin_required": {
+    "text": "Apenas os proprietários e administradores da organização podem criar convites"
+  },
+  "api.organizations.invitations.errors.resend_admin_required": {
+    "text": "Apenas os proprietários e administradores da organização podem reenviar convites"
+  },
+  "api.organizations.invitations.errors.view_admin_required": {
+    "text": "Apenas os proprietários e administradores da organização podem ver convites"
+  },
+  "api.organizations.invitations.errors.revoke_admin_required": {
+    "text": "Apenas os proprietários e administradores da organização podem revogar convites"
+  },
+  "api.organizations.invitations.errors.email_required": {
+    "text": "O e-mail é obrigatório"
+  },
+  "api.organizations.invitations.errors.email_invalid": {
+    "text": "Formato de e-mail inválido"
+  },
+  "api.organizations.invitations.errors.role_invalid": {
+    "text": "A função deve ser membro ou administrador"
+  },
+  "api.organizations.invitations.errors.cannot_invite_owner": {
+    "text": "Não é possível convidar como proprietário"
+  },
+  "api.organizations.invitations.errors.already_member": {
+    "text": "O utilizador já é membro desta organização"
+  },
+  "api.organizations.invitations.errors.already_pending": {
+    "text": "Já existe um convite pendente para este e-mail"
+  },
+  "api.organizations.invitations.errors.member_limit_reached": {
+    "text": "Limite de membros atingido. Faz upgrade do teu plano para convidar mais membros."
+  },
+  "api.organizations.invitations.errors.not_found": {
+    "text": "Convite não encontrado"
+  },
+  "api.organizations.invitations.errors.cannot_resend_non_pending": {
+    "text": "Só é possível reenviar convites pendentes"
+  },
+  "api.organizations.invitations.errors.cannot_revoke_non_pending": {
+    "text": "Só é possível revogar convites pendentes"
+  },
+  "api.organizations.invitations.errors.resend_limit_reached": {
+    "text": "Limite máximo de reenvios (%{max}) atingido"
+  },
+  "api.organizations.invitations.errors.accept_token_required": {
+    "text": "O token é obrigatório"
+  },
+  "api.organizations.invitations.errors.accept_organization_gone": {
+    "text": "A organização já não existe"
+  },
+  "api.organizations.invitations.errors.accept_already_acted": {
+    "text": "O convite já foi %{status}"
+  },
+  "api.organizations.invitations.errors.accept_expired": {
+    "text": "O convite expirou"
+  },
+  "api.organizations.invitations.errors.accept_email_mismatch": {
+    "text": "O teu endereço de e-mail não corresponde ao convite"
+  },
+  "api.organizations.invitations.errors.accept_already_member": {
+    "text": "Já és membro desta organização"
+  },
+  "web.organizations.entitlements_title": {
+    "text": "Direitos da Organização"
+  },
+  "web.organizations.page_description_short": {
+    "text": "Ver e configurar os teus espaços de trabalho"
+  },
+  "web.organizations.delete_organization_remove_domains_first": {
+    "text": "Remove todos os domínios personalizados antes de eliminar esta organização."
+  },
+  "web.organizations.default_org_delete_notice_title": {
+    "text": "Eliminar esta organização"
+  },
+  "web.organizations.default_org_delete_notice_before": {
+    "text": "Esta é a tua organização predefinida e não pode ser removida a partir do painel. Para a eliminar, contacta-nos através do"
+  },
+  "web.organizations.default_org_delete_notice_link": {
+    "text": "formulário de feedback"
+  },
+  "web.organizations.default_org_delete_notice_after": {
+    "text": "."
+  },
+  "web.organizations.leave_organization": {
+    "text": "Sair desta organização"
+  },
+  "web.organizations.leave_organization_warning": {
+    "text": "Perderás o acesso a esta organização e aos seus recursos."
+  },
+  "web.organizations.leave_organization_confirm_title": {
+    "text": "Sair da Organização"
+  },
+  "web.organizations.leave_organization_confirm_message": {
+    "text": "Tens a certeza de que queres sair de {name}? Precisarás de um novo convite para voltar a aderir."
+  },
+  "web.organizations.leave_organization_success": {
+    "text": "Saíste da organização."
+  },
+  "web.organizations.leave_error": {
+    "text": "Falha ao sair da organização"
+  },
+  "web.organizations.organizations": {
+    "text": "Organizações"
+  },
+  "web.organizations.invitations.invited_by_inline": {
+    "text": "por {email}"
+  },
+  "web.organizations.invitations.invited_as_inline": {
+    "text": "como {role}"
+  },
+  "web.organizations.invitations.back_to_home": {
+    "text": "Voltar ao início"
+  },
+  "web.organizations.invitations.email_locked_hint": {
+    "text": "Este convite foi enviado para este endereço de e-mail"
+  },
+  "web.organizations.invitations.signup_continue": {
+    "text": "Continuar"
+  },
+  "web.organizations.invitations.signin_continue": {
+    "text": "Iniciar sessão"
+  },
+  "web.organizations.invitations.confirm_join_below": {
+    "text": "Quase concluído — confirma abaixo para aderir à organização."
+  },
+  "web.organizations.invitations.go_to_organizations": {
+    "text": "Ir para as Organizações"
+  },
+  "web.organizations.invitations.already_member": {
+    "text": "Já és membro desta organização"
+  },
+  "web.organizations.invitations.join_organization": {
+    "text": "Aderir a {orgName}"
+  },
+  "web.organizations.invitations.sign_in_to_join": {
+    "text": "Inicia sessão para aderir a {orgName}"
+  },
+  "web.organizations.invitations.decline": {
+    "text": "Recusar"
+  },
+  "web.organizations.members.member_quota": {
+    "text": "{used} de {limit} membros"
+  },
+  "web.organizations.members.pending_suffix": {
+    "text": "({count} pendentes)"
+  },
+  "web.organizations.members.limit_reached_hint": {
+    "text": "Limite de membros atingido."
+  },
+  "web.organizations.sso.title": {
+    "text": "Single Sign-On (SSO)"
+  },
+  "web.organizations.sso.description": {
+    "text": "Configura o SSO para permitir que os membros iniciem sessão com o fornecedor de identidade da tua organização"
+  },
+  "web.organizations.sso.provider_type": {
+    "text": "Tipo de fornecedor"
+  },
+  "web.organizations.sso.provider_type_description": {
+    "text": "Seleciona o fornecedor de identidade da tua organização"
+  },
+  "web.organizations.sso.display_name": {
+    "text": "Nome a apresentar"
+  },
+  "web.organizations.sso.display_name_hint": {
+    "text": "Um nome amigável apresentado aos utilizadores ao iniciar sessão"
+  },
+  "web.organizations.sso.display_name_placeholder": {
+    "text": "p. ex. Acme Corp SSO"
+  },
+  "web.organizations.sso.client_id": {
+    "text": "Client ID"
+  },
+  "web.organizations.sso.client_id_placeholder": {
+    "text": "O teu client ID de OAuth"
+  },
+  "web.organizations.sso.client_secret": {
+    "text": "Client Secret"
+  },
+  "web.organizations.sso.client_secret_placeholder": {
+    "text": "O teu client secret de OAuth"
+  },
+  "web.organizations.sso.client_secret_update_hint": {
+    "text": "Deixa em branco para manter o secret existente"
+  },
+  "web.organizations.sso.tenant_id": {
+    "text": "Tenant ID"
+  },
+  "web.organizations.sso.tenant_id_hint": {
+    "text": "O identificador de tenant do teu Azure AD / Entra ID"
+  },
+  "web.organizations.sso.tenant_id_placeholder": {
+    "text": "p. ex. 12345678-1234-1234-1234-123456789abc"
+  },
+  "web.organizations.sso.issuer": {
+    "text": "URL do emissor"
+  },
+  "web.organizations.sso.issuer_hint": {
+    "text": "O URL de descoberta OIDC do teu fornecedor de identidade"
+  },
+  "web.organizations.sso.issuer_placeholder": {
+    "text": "p. ex. https://login.example.com"
+  },
+  "web.organizations.sso.view_discovery_document": {
+    "text": "Ver documento de descoberta"
+  },
+  "web.organizations.sso.callback_url": {
+    "text": "URL de callback"
+  },
+  "web.organizations.sso.callback_url_hint": {
+    "text": "Adiciona este URL aos URIs de redirecionamento permitidos do teu fornecedor de identidade"
+  },
+  "web.organizations.sso.allowed_domains": {
+    "text": "Domínios de E-mail Permitidos"
+  },
+  "web.organizations.sso.allowed_domains_hint": {
+    "text": "Apenas os utilizadores com endereços de e-mail destes domínios podem iniciar sessão. Deixa vazio para permitir todos os domínios."
+  },
+  "web.organizations.sso.domain_placeholder": {
+    "text": "p. ex. acme.com"
+  },
+  "web.organizations.sso.invalid_domain": {
+    "text": "Introduz um domínio válido (p. ex. example.com)"
+  },
+  "web.organizations.sso.domain_exists": {
+    "text": "Este domínio já está na lista"
+  },
+  "web.organizations.sso.remove_domain": {
+    "text": "Remover {domain}"
+  },
+  "web.organizations.sso.enabled": {
+    "text": "Ativar SSO"
+  },
+  "web.organizations.sso.enabled_hint": {
+    "text": "Quando ativado, os membros da organização podem iniciar sessão usando este fornecedor de SSO"
+  },
+  "web.organizations.sso.enforce_sso_only": {
+    "text": "Impor apenas SSO"
+  },
+  "web.organizations.sso.enforce_sso_only_hint": {
+    "text": "Exigir SSO para todos os inícios de sessão neste domínio. Quando ativado, a autenticação baseada em palavra-passe é desativada."
+  },
+  "web.organizations.sso.grant_org_scope": {
+    "text": "Conceder acesso a toda a organização"
+  },
+  "web.organizations.sso.grant_org_scope_hint": {
+    "text": "Os novos membros que aderirem através do SSO deste domínio terão acesso a todos os domínios da organização. Os membros existentes não são afetados. Quando desativado (predefinição), os novos membros só podem aceder a este domínio."
+  },
+  "web.organizations.sso.save_config": {
+    "text": "Guardar Configuração de SSO"
+  },
+  "web.organizations.sso.delete_config": {
+    "text": "Eliminar Configuração"
+  },
+  "web.organizations.sso.delete_confirm": {
+    "text": "Tens a certeza? Isto desativará o SSO para a tua organização."
+  },
+  "web.organizations.sso.load_error": {
+    "text": "Falha ao carregar a configuração de SSO"
+  },
+  "web.organizations.sso.save_error": {
+    "text": "Falha ao guardar a configuração de SSO"
+  },
+  "web.organizations.sso.create_success": {
+    "text": "Configuração de SSO criada com sucesso"
+  },
+  "web.organizations.sso.update_success": {
+    "text": "Configuração de SSO atualizada com sucesso"
+  },
+  "web.organizations.sso.delete_success": {
+    "text": "Configuração de SSO eliminada com sucesso"
+  },
+  "web.organizations.sso.delete_error": {
+    "text": "Falha ao eliminar a configuração de SSO"
+  },
+  "web.organizations.sso.test_connection": {
+    "text": "Testar Ligação"
+  },
+  "web.organizations.sso.test_connection_hint": {
+    "text": "Verifica se o fornecedor de identidade está acessível (não valida as credenciais)"
+  },
+  "web.organizations.sso.test_button": {
+    "text": "Testar Ligação"
+  },
+  "web.organizations.sso.testing": {
+    "text": "A testar..."
+  },
+  "web.organizations.sso.test_error": {
+    "text": "Falha ao testar a ligação"
+  },
+  "web.organizations.sso.auth_endpoint": {
+    "text": "Endpoint de autorização"
+  },
+  "web.organizations.sso.missing_fields": {
+    "text": "Campos em Falta"
+  },
+  "web.organizations.sso.status_enabled": {
+    "text": "Ativado"
+  },
+  "web.organizations.sso.status_configured": {
+    "text": "Configurado"
+  },
+  "web.organizations.sso.domain_sso_title": {
+    "text": "SSO de Domínio"
+  },
+  "web.organizations.sso.domain_sso_description": {
+    "text": "Configura o SSO para cada domínio verificado"
+  },
+  "web.organizations.sso.provider_type_locked_hint": {
+    "text": "Para alterar o fornecedor, elimina primeiro esta configuração"
+  },
+  "web.organizations.sso.status_not_configured": {
+    "text": "Não Configurado"
+  },
+  "web.organizations.sso.no_domains": {
+    "text": "Nenhum domínio verificado"
+  },
+  "web.organizations.sso.no_domains_description": {
+    "text": "Adiciona e verifica um domínio antes de configurar o SSO para o mesmo."
+  },
+  "web.organizations.tabs.team": {
+    "text": "Equipa"
+  },
+  "web.organizations.tabs.sso": {
+    "text": "SSO"
   }
 }


### PR DESCRIPTION
## `pt_PT` translation update

Automated export of completed **pt_PT** translations from the translation task DB.
Scope: `locales/content/pt_PT/` only — 27 file(s), +1849/-31.

✅ `i18n validate variables`: no variable mismatches.

---

### Local quality review

> Produced by a fresh, isolated `claude` review agent (model `claude-sonnet-5`, agent `saas-translator`) that read
> `locales/AGENT_TRANSLATION_PROTOCOL.md` and inspected this branch's diff before the PR was opened.

**Verdict:** ✅ Looks good — no variable defects, minor consistency nits only.

**Summary:** Large batch of new SSO/domains/organizations/billing/colonel strings plus refinements to existing phishing/homepage/translations copy. Variables (`{var}`, `%{var}`, pipe-plurals) are preserved correctly throughout, brand terms (Onetime Secret, SSO, Google, Amazon SES, SendGrid) are untouched, and the automated variable-consistency check reported no findings. The "Delano" → "Equipa de Suporte" email-signature swap is applied uniformly across all touched templates.

**Critical (must fix):** None.

**Warnings:**
- Placeholder domain inconsistency in `workspace-domains.json`: some email placeholder examples were localized to `exemplo.com` (`web.domains.email.from_address_placeholder`, `reply_to_placeholder`, `web.domains.incoming.email_placeholder`), while sibling validation-message examples keep the reserved `example.com` (`web.domains.signup.domain_placeholder`, `invalid_domain`, `web.organizations.sso.invalid_domain`). Worth normalizing to one convention — `example.com` is the RFC-reserved placeholder domain and shouldn't be translated in some spots but not others.
- `web.domains.incoming.recipient_count` uses a pipe-plural (`{count} destinatário | {count} destinatários`) while `web.domains.incoming.tooltip_configured` uses a parenthetical plural (`destinatário(s)`) for the same concept — stylistically inconsistent within the same file, though not a functional error.

**Notes:**
- `_guidance.context` keys correctly left in English (doc metadata convention).
- Refinements like "Sobre" → "Acerca de", "informações sensíveis" → "informação sensível", and added definite articles before `{product_name}` are stylistic tightening, not defects.
- New keys correctly omit `source_hash` (to be populated by the hashing script, per protocol).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
