### PR TITLE
i18n: update sl_SI translations

### DIFF
--- a/locales/content/sl_SI/00-common.json
+++ b/locales/content/sl_SI/00-common.json
@@ -1299,7 +1299,7 @@
     "source_hash": "fc78d9cb"
   },
   "web.INSTRUCTION.phishing_warning": {
-    "text": "Vedno preverite, da ste na uradni spletni strani {product_name}. Goljufi včasih ustvarijo lažne spletne strani, ki izgledajo točno kot {product_name}, da vam ukradejo skrivnosti. Da se izognete phishing napadom, pred ustvarjanjem novih povezav preverite regionalno domeno.",
+    "text": "Vedno preverite, ali ste na uradnem spletnem mestu {product_name}. Goljufi včasih ustvarijo lažna spletna mesta, ki so videti popolnoma enaka kot {product_name}, da bi vam ukradli skrivnosti. Da se izognete napadom z lažnim predstavljanjem, pred ustvarjanjem novih povezav preverite domeno regije.",
     "source_hash": "b588f5b2"
   },
   "web.pricing.title": {
@@ -1383,5 +1383,110 @@
     "text": "Nadgradite za odklepanje več funkcij",
     "context": "Description shown for free plan users encouraging upgrade",
     "source_hash": "783f174c"
+  },
+  "api.errors.authentication_required": {
+    "text": "Zahtevana je avtentikacija"
+  },
+  "api.errors.sso_only_action_blocked": {
+    "text": "To dejanje ni na voljo v načinu samo SSO"
+  },
+  "web.COMMON.configure": {
+    "text": "Nastavi"
+  },
+  "web.COMMON.copy_to_clipboard": {
+    "text": "Kopiraj v odložišče"
+  },
+  "web.COMMON.add": {
+    "text": "Dodaj"
+  },
+  "web.COMMON.enabled": {
+    "text": "Omogočeno"
+  },
+  "web.COMMON.disabled": {
+    "text": "Onemogočeno"
+  },
+  "web.COMMON.yes_delete": {
+    "text": "Da, izbriši"
+  },
+  "web.COMMON.error_code": {
+    "text": "Koda napake"
+  },
+  "web.COMMON.http_status": {
+    "text": "Stanje HTTP"
+  },
+  "web.COMMON.details": {
+    "text": "Podrobnosti"
+  },
+  "web.COMMON.field_confirm_password": {
+    "text": "Potrdite geslo"
+  },
+  "web.COMMON.passwords_must_match": {
+    "text": "Gesli se morata ujemati"
+  },
+  "web.COMMON.and": {
+    "text": "in"
+  },
+  "web.COMMON.or": {
+    "text": "ali"
+  },
+  "web.COMMON.copied": {
+    "text": "Kopirano"
+  },
+  "web.COMMON.copy": {
+    "text": "Kopiraj"
+  },
+  "web.COMMON.copy_email": {
+    "text": "Kopiraj e-poštni naslov"
+  },
+  "web.COMMON.copy_id": {
+    "text": "Kopiraj ID računa"
+  },
+  "web.COMMON.org_id_tooltip": {
+    "text": "Enolični identifikator vaše organizacije"
+  },
+  "web.COMMON.success": {
+    "text": "Uspeh"
+  },
+  "web.COMMON.need_help": {
+    "text": "Potrebujete pomoč"
+  },
+  "web.COMMON.open_help_dialog": {
+    "text": "Odpri pogovorno okno za pomoč"
+  },
+  "web.COMMON.focus_is_now_in_the_main_text_area": {
+    "text": "Pozornost je zdaj v glavnem polju z besedilom"
+  },
+  "web.LABELS.show_passphrase": {
+    "text": "Pokaži pristopno frazo"
+  },
+  "web.LABELS.hide_passphrase": {
+    "text": "Skrij pristopno frazo"
+  },
+  "web.LABELS.copy_icon": {
+    "text": "Ikona za kopiranje"
+  },
+  "web.LABELS.copied_icon": {
+    "text": "Ikona kopirano"
+  },
+  "web.STATUS.unverified": {
+    "text": "Nepreverjeno"
+  },
+  "web.TITLES.domain_detail": {
+    "text": "Nastavitve domene"
+  },
+  "web.TITLES.domain_signin": {
+    "text": "Konfiguracija prijave"
+  },
+  "web.TITLES.domain_sso": {
+    "text": "SSO domene"
+  },
+  "web.TITLES.domain_signup": {
+    "text": "Preverjanje registracije domene"
+  },
+  "web.TITLES.domain_email": {
+    "text": "Konfiguracija e-pošte"
+  },
+  "web.TITLES.domain_incoming": {
+    "text": "Dohodne skrivnosti"
   }
 }

--- a/locales/content/sl_SI/10-layout.json
+++ b/locales/content/sl_SI/10-layout.json
@@ -148,7 +148,7 @@
     "source_hash": "b9766df3"
   },
   "web.help.secret_view_faq.what_am_i_looking_at.description": {
-    "text": "Gledate varno sporočilo, ki vam je bilo posredovano prek {product_name}. Ta vsebina se prikaže samo enkrat in je nato trajno izbrisana z naših strežnikov.",
+    "text": "Ogledujete si varno sporočilo, ki je bilo z vami deljeno prek storitve {product_name}. Ta vsebina je prikazana samo enkrat in nato trajno izbrisana z naših strežnikov.",
     "source_hash": "e0f1a10c"
   },
   "web.help.secret_view_faq.can_i_view_again.title": {
@@ -338,5 +338,11 @@
   "web.layout.workspace_context": {
     "text": "Kontekst delovnega prostora",
     "source_hash": "dc6fa4f5"
+  },
+  "web.footer.workspace": {
+    "text": "Delovni prostor"
+  },
+  "web.help.default_content": {
+    "text": "Za pomoč se obrnite na podporo"
   }
 }

--- a/locales/content/sl_SI/admin-colonel.json
+++ b/locales/content/sl_SI/admin-colonel.json
@@ -634,5 +634,152 @@
   "web.colonel.feedback.when_you_submit_feedback_well_see": {
     "text": "Ko pošljete povratne informacije, bomo videli:",
     "source_hash": "fe77172e"
+  },
+  "web.colonel.previewPlanMode": {
+    "text": "Način predogleda paketa"
+  },
+  "web.colonel.previewModeDescription": {
+    "text": "Predoglejte si aplikacijo, kot je videti strankam na drugem paketu. To vpliva samo na vaš pogled in ne spremeni dejanskega paketa nobene organizacije."
+  },
+  "web.colonel.previewModeActive": {
+    "text": "Predogled aktiven"
+  },
+  "web.colonel.bannedIps.empty": {
+    "text": "Ni blokiranih naslovov IP"
+  },
+  "web.colonel.bannedIps.currentIp": {
+    "text": "Vaš trenutni naslov IP"
+  },
+  "web.colonel.bannedIps.confirmUnban": {
+    "text": "Odblokiraj {ip}?"
+  },
+  "web.colonel.bannedIps.actions.ban": {
+    "text": "Blokiraj IP"
+  },
+  "web.colonel.bannedIps.actions.quickBan": {
+    "text": "Hitra blokada"
+  },
+  "web.colonel.bannedIps.actions.unban": {
+    "text": "Odblokiraj"
+  },
+  "web.colonel.bannedIps.actions.cancel": {
+    "text": "Prekliči"
+  },
+  "web.colonel.bannedIps.columns.ipAddress": {
+    "text": "Naslov IP"
+  },
+  "web.colonel.bannedIps.columns.reason": {
+    "text": "Razlog"
+  },
+  "web.colonel.bannedIps.columns.bannedAt": {
+    "text": "Blokirano dne"
+  },
+  "web.colonel.bannedIps.columns.bannedBy": {
+    "text": "Blokiral"
+  },
+  "web.colonel.bannedIps.error.banFailed": {
+    "text": "Blokiranje naslova IP ni uspelo"
+  },
+  "web.colonel.bannedIps.error.unbanFailed": {
+    "text": "Odblokiranje naslova IP ni uspelo"
+  },
+  "web.colonel.bannedIps.form.title": {
+    "text": "Blokiraj naslov IP"
+  },
+  "web.colonel.bannedIps.form.ipLabel": {
+    "text": "Naslov IP"
+  },
+  "web.colonel.bannedIps.form.reasonLabel": {
+    "text": "Razlog"
+  },
+  "web.colonel.bannedIps.form.reasonPlaceholder": {
+    "text": "Neobvezen razlog"
+  },
+  "web.colonel.bannedIps.success.banned": {
+    "text": "Naslov IP {ip} je bil blokiran"
+  },
+  "web.colonel.bannedIps.success.unbanned": {
+    "text": "Naslov IP {ip} je bil odblokiran"
+  },
+  "web.colonel.customDomains.empty": {
+    "text": "Ni nastavljenih domen po meri"
+  },
+  "web.colonel.customDomains.noLogo": {
+    "text": "Brez logotipa"
+  },
+  "web.colonel.customDomains.labels.organization": {
+    "text": "Organizacija"
+  },
+  "web.colonel.customDomains.labels.externalId": {
+    "text": "Zunanji ID"
+  },
+  "web.colonel.customDomains.labels.created": {
+    "text": "Ustvarjeno"
+  },
+  "web.colonel.customDomains.labels.updated": {
+    "text": "Posodobljeno"
+  },
+  "web.colonel.customDomains.labels.favicon": {
+    "text": "Favicon"
+  },
+  "web.colonel.customDomains.status.verified": {
+    "text": "Preverjeno"
+  },
+  "web.colonel.customDomains.status.resolving": {
+    "text": "Razreševanje"
+  },
+  "web.colonel.customDomains.status.ready": {
+    "text": "Pripravljeno"
+  },
+  "web.colonel.customDomains.status.publicHomepage": {
+    "text": "Javna domača stran"
+  },
+  "web.colonel.customDomains.status.publicApi": {
+    "text": "Javni API"
+  },
+  "web.colonel.customDomains.status.pending": {
+    "text": "V čakanju"
+  },
+  "web.colonel.pagination.showing": {
+    "text": "Prikaz {start}–{end} od {total}"
+  },
+  "web.colonel.pagination.itemsPerPage": {
+    "text": "Elementov na stran"
+  },
+  "web.colonel.pagination.perPage": {
+    "text": "{count} na stran"
+  },
+  "web.colonel.pagination.pageOf": {
+    "text": "Stran {current} od {total}"
+  },
+  "web.colonel.secrets.empty": {
+    "text": "Ni najdenih skrivnosti"
+  },
+  "web.colonel.secrets.never": {
+    "text": "Nikoli"
+  },
+  "web.colonel.secrets.columns.shortId": {
+    "text": "Kratki ID"
+  },
+  "web.colonel.secrets.columns.state": {
+    "text": "Stanje"
+  },
+  "web.colonel.secrets.columns.created": {
+    "text": "Ustvarjeno"
+  },
+  "web.colonel.secrets.columns.expiration": {
+    "text": "Potek"
+  },
+  "web.colonel.secrets.columns.age": {
+    "text": "Starost (dni)"
+  },
+  "web.colonel.secrets.state.new": {
+    "text": "Novo"
+  },
+  "web.colonel.secrets.state.received": {
+    "text": "Prejeto"
+  },
+  "web.colonel.secrets.state.viewed": {
+    "text": "Ogledano"
   }
 }

--- a/locales/content/sl_SI/api-account-errors.json
+++ b/locales/content/sl_SI/api-account-errors.json
@@ -1,0 +1,8 @@
+{
+  "api.account.errors.invalid_email": {
+    "text": "Je to veljaven e-poštni naslov?"
+  },
+  "api.account.errors.password_too_short": {
+    "text": "Geslo je prekratko"
+  }
+}

--- a/locales/content/sl_SI/api-domains-errors.json
+++ b/locales/content/sl_SI/api-domains-errors.json
@@ -1,0 +1,29 @@
+{
+  "api.domains.errors.domain_id_required": {
+    "text": "Zahtevan je ID domene"
+  },
+  "api.domains.errors.domain_not_found": {
+    "text": "Domena ni najdena: %{extid}"
+  },
+  "api.domains.errors.organization_not_found": {
+    "text": "Organizacija za domeno ni najdena: %{domain}"
+  },
+  "api.domains.errors.incoming_secrets_disabled": {
+    "text": "Dohodne skrivnosti niso omogočene na tej namestitvi"
+  },
+  "api.domains.errors.incoming_secrets_entitlement_required": {
+    "text": "Upravljanje dohodnih skrivnosti zahteva upravičenje incoming_secrets. Nadgradite svoj paket."
+  },
+  "api.domains.errors.incoming_config_not_found": {
+    "text": "Konfiguracija dohodnih skrivnosti za domeno ni najdena: %{extid}"
+  },
+  "api.domains.errors.recipients_max_exceeded": {
+    "text": "Dovoljenih je največ %{max} prejemnikov"
+  },
+  "api.domains.errors.recipients_invalid_email": {
+    "text": "Neveljaven e-poštni naslov: %{email}"
+  },
+  "api.domains.errors.recipients_duplicate": {
+    "text": "Podvojeni e-poštni naslovi prejemnikov niso dovoljeni"
+  }
+}

--- a/locales/content/sl_SI/api-entitlements-errors.json
+++ b/locales/content/sl_SI/api-entitlements-errors.json
@@ -1,0 +1,71 @@
+{
+  "api.entitlements.errors.context_unavailable": {
+    "text": "Upravičenj ni mogoče preveriti (kontekst organizacije ni na voljo)"
+  },
+  "api.entitlements.errors.api_access_required": {
+    "text": "Dostop do API-ja zahteva nadgradnjo paketa"
+  },
+  "api.entitlements.errors.custom_privacy_defaults_required": {
+    "text": "Privzete nastavitve zasebnosti po meri zahtevajo nadgradnjo paketa"
+  },
+  "api.entitlements.errors.extended_default_expiration_required": {
+    "text": "Razširjen privzeti rok poteka zahteva nadgradnjo paketa"
+  },
+  "api.entitlements.errors.custom_domains_required": {
+    "text": "Lastne domene zahtevajo nadgradnjo paketa"
+  },
+  "api.entitlements.errors.custom_branding_required": {
+    "text": "Blagovna znamka po meri zahteva nadgradnjo paketa"
+  },
+  "api.entitlements.errors.homepage_secrets_required": {
+    "text": "Skrivnosti na domači strani zahtevajo nadgradnjo paketa"
+  },
+  "api.entitlements.errors.incoming_secrets_required": {
+    "text": "Dohodne skrivnosti zahtevajo nadgradnjo paketa"
+  },
+  "api.entitlements.errors.custom_mail_sender_required": {
+    "text": "Lasten pošiljatelj e-pošte zahteva nadgradnjo paketa"
+  },
+  "api.entitlements.errors.flexible_from_domain_required": {
+    "text": "Prilagodljiva domena pošiljatelja zahteva nadgradnjo paketa"
+  },
+  "api.entitlements.errors.manage_org_required": {
+    "text": "Upravljanje organizacije zahteva nadgradnjo paketa"
+  },
+  "api.entitlements.errors.manage_teams_required": {
+    "text": "Upravljanje ekip zahteva nadgradnjo paketa"
+  },
+  "api.entitlements.errors.manage_members_required": {
+    "text": "Upravljanje članov zahteva nadgradnjo paketa"
+  },
+  "api.entitlements.errors.manage_sso_required": {
+    "text": "Upravljanje SSO zahteva nadgradnjo paketa"
+  },
+  "api.entitlements.errors.audit_logs_required": {
+    "text": "Revizijski dnevniki zahtevajo nadgradnjo paketa"
+  },
+  "api.entitlements.errors.custom_signup_validation_required": {
+    "text": "Preverjanje registracije po meri zahteva nadgradnjo paketa"
+  },
+  "api.entitlements.errors.create_secrets_required": {
+    "text": "Ustvarjanje skrivnosti zahteva nadgradnjo paketa"
+  },
+  "api.entitlements.errors.view_receipt_required": {
+    "text": "Ogled potrdil zahteva nadgradnjo paketa"
+  },
+  "api.entitlements.errors.notifications_required": {
+    "text": "Obvestila zahtevajo nadgradnjo paketa"
+  },
+  "api.entitlements.errors.workspace_branding_required": {
+    "text": "Blagovna znamka delovnega prostora zahteva nadgradnjo paketa"
+  },
+  "api.entitlements.errors.ip_access_rules_required": {
+    "text": "Pravila dostopa po IP zahtevajo nadgradnjo paketa"
+  },
+  "api.entitlements.errors.manage_billing_required": {
+    "text": "Upravljanje obračunavanja zahteva nadgradnjo paketa"
+  },
+  "api.entitlements.errors.custom_signin_config_required": {
+    "text": "Konfiguracija prijave po meri zahteva nadgradnjo paketa"
+  }
+}

--- a/locales/content/sl_SI/api-feedback-errors.json
+++ b/locales/content/sl_SI/api-feedback-errors.json
@@ -1,0 +1,5 @@
+{
+  "api.feedback.errors.rate_limit_exceeded": {
+    "text": "Preveč oddanih povratnih informacij. Poskusite znova pozneje."
+  }
+}

--- a/locales/content/sl_SI/api-incoming-errors.json
+++ b/locales/content/sl_SI/api-incoming-errors.json
@@ -1,0 +1,5 @@
+{
+  "api.incoming.errors.custom_domain_unresolved": {
+    "text": "Organizacije lastne domene ni bilo mogoče razrešiti"
+  }
+}

--- a/locales/content/sl_SI/api-invite-errors.json
+++ b/locales/content/sl_SI/api-invite-errors.json
@@ -1,0 +1,23 @@
+{
+  "api.invite.errors.invitation_not_found_or_expired": {
+    "text": "Povabilo ni najdeno ali je poteklo"
+  },
+  "api.invite.errors.token_required": {
+    "text": "Žeton je obvezen"
+  },
+  "api.invite.errors.organization_no_longer_exists": {
+    "text": "Organizacija ne obstaja več"
+  },
+  "api.invite.errors.invitation_already_processed": {
+    "text": "Povabilo je bilo že %{status}"
+  },
+  "api.invite.errors.invitation_expired": {
+    "text": "Povabilo je poteklo"
+  },
+  "api.invite.errors.email_mismatch": {
+    "text": "Vaš e-poštni naslov se ne ujema s povabilom"
+  },
+  "api.invite.errors.already_member": {
+    "text": "Ste že član te organizacije"
+  }
+}

--- a/locales/content/sl_SI/api-organizations-errors.json
+++ b/locales/content/sl_SI/api-organizations-errors.json
@@ -1,0 +1,107 @@
+{
+  "api.organizations.errors.domain_scoped_forbidden": {
+    "text": "Člani, omejeni na domeno, ne morejo izvesti tega dejanja"
+  },
+  "api.organizations.errors.organization_not_found": {
+    "text": "Organizacija ni najdena: %{extid}"
+  },
+  "api.organizations.errors.organization_owner_required": {
+    "text": "To dejanje lahko izvede samo lastnik organizacije"
+  },
+  "api.organizations.errors.organization_member_required": {
+    "text": "Za izvedbo tega dejanja morate biti član organizacije"
+  },
+  "api.organizations.errors.organization_admin_required": {
+    "text": "To dejanje lahko izvedejo samo lastniki in skrbniki organizacije"
+  },
+  "api.organizations.errors.extid_required": {
+    "text": "Zahtevan je ID organizacije"
+  },
+  "api.organizations.errors.display_name_required": {
+    "text": "Ime organizacije je obvezno"
+  },
+  "api.organizations.errors.display_name_too_long": {
+    "text": "Ime organizacije mora vsebovati manj kot %{max} znakov"
+  },
+  "api.organizations.errors.description_too_long": {
+    "text": "Opis mora vsebovati manj kot %{max} znakov"
+  },
+  "api.organizations.errors.contact_email_exists": {
+    "text": "Organizacija s tem kontaktnim e-poštnim naslovom že obstaja"
+  },
+  "api.organizations.errors.creation_in_progress": {
+    "text": "Ustvarjanje organizacije je v teku. Poskusite znova."
+  },
+  "api.organizations.errors.organization_limit_reached": {
+    "text": "Dosežena je omejitev števila organizacij. Nadgradite svoj paket za ustvarjanje več organizacij."
+  },
+  "api.organizations.invitations.errors.invitation_not_found": {
+    "text": "Povabilo ni najdeno"
+  },
+  "api.organizations.invitations.errors.email_required": {
+    "text": "E-poštni naslov je obvezen"
+  },
+  "api.organizations.invitations.errors.invalid_email_format": {
+    "text": "Neveljavna oblika e-poštnega naslova"
+  },
+  "api.organizations.invitations.errors.invalid_role": {
+    "text": "Vloga mora biti član ali skrbnik"
+  },
+  "api.organizations.invitations.errors.cannot_invite_as_owner": {
+    "text": "Povabilo z vlogo lastnika ni mogoče"
+  },
+  "api.organizations.invitations.errors.user_already_member": {
+    "text": "Uporabnik je že član te organizacije"
+  },
+  "api.organizations.invitations.errors.invitation_already_pending": {
+    "text": "Za ta e-poštni naslov že obstaja čakajoče povabilo"
+  },
+  "api.organizations.invitations.errors.member_limit_reached": {
+    "text": "Dosežena je omejitev števila članov. Nadgradite svoj paket za povabilo več članov."
+  },
+  "api.organizations.invitations.errors.resend_only_pending": {
+    "text": "Znova je mogoče poslati samo čakajoča povabila"
+  },
+  "api.organizations.invitations.errors.resend_limit_reached": {
+    "text": "Dosežena je največja omejitev ponovnih pošiljanj (%{max})"
+  },
+  "api.organizations.invitations.errors.revoke_only_pending": {
+    "text": "Preklicati je mogoče samo čakajoča povabila"
+  },
+  "api.organizations.members.errors.member_not_found": {
+    "text": "Član ni najden: %{extid}"
+  },
+  "api.organizations.members.errors.member_not_in_organization": {
+    "text": "Član v tej organizaciji ni najden"
+  },
+  "api.organizations.members.errors.member_not_active": {
+    "text": "Član ni aktiven"
+  },
+  "api.organizations.members.errors.invalid_role_value": {
+    "text": "Neveljavna vloga. Mora biti ena od: %{roles}"
+  },
+  "api.organizations.members.errors.cannot_change_owner_role": {
+    "text": "Vloge lastnika ni mogoče spremeniti. Namesto tega uporabite prenos lastništva."
+  },
+  "api.organizations.members.errors.member_already_has_role": {
+    "text": "Član že ima vlogo: %{role}"
+  },
+  "api.organizations.members.errors.cannot_promote_to_owner": {
+    "text": "Povišanje v lastnika ni mogoče. Namesto tega uporabite prenos lastništva."
+  },
+  "api.organizations.members.errors.must_be_member": {
+    "text": "Biti morate član te organizacije"
+  },
+  "api.organizations.members.errors.cannot_remove_owner": {
+    "text": "Lastnika organizacije ni mogoče odstraniti. Najprej prenesite lastništvo."
+  },
+  "api.organizations.members.errors.cannot_remove_self": {
+    "text": "Sebe ne morete odstraniti. Namesto tega zapustite organizacijo."
+  },
+  "api.organizations.members.errors.admin_cannot_remove_admin": {
+    "text": "Skrbniki ne morejo odstraniti drugih skrbnikov. To lahko storijo samo lastniki."
+  },
+  "api.organizations.members.errors.no_permission_to_remove": {
+    "text": "Nimate dovoljenja za odstranjevanje članov"
+  }
+}

--- a/locales/content/sl_SI/api-secrets-errors.json
+++ b/locales/content/sl_SI/api-secrets-errors.json
@@ -1,0 +1,11 @@
+{
+  "api.secrets.errors.domain_permission_authenticated_non_owner": {
+    "text": "Nimate dovoljenja za uporabo domene: %{domain}"
+  },
+  "api.secrets.errors.domain_public_sharing_disabled": {
+    "text": "Javno deljenje je onemogočeno za domeno: %{domain}"
+  },
+  "api.secrets.errors.domain_permission_anonymous_cross_domain": {
+    "text": "Nimate dovoljenja za uporabo domene: %{domain}"
+  }
+}

--- a/locales/content/sl_SI/email.json
+++ b/locales/content/sl_SI/email.json
@@ -60,7 +60,7 @@
     "source_hash": "88c72144"
   },
   "email.welcome.signature": {
-    "text": "Delano",
+    "text": "Ekipa za podporo",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -100,7 +100,7 @@
     "source_hash": "fbb7eb2d"
   },
   "email.password_request.signature": {
-    "text": "Delano",
+    "text": "Ekipa za podporo",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -145,7 +145,7 @@
     "source_hash": "1863f5be"
   },
   "email.magic_link.signature": {
-    "text": "Delano",
+    "text": "Ekipa za podporo",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -230,7 +230,7 @@
     "source_hash": "3f6b45dd"
   },
   "email.secret_revealed.signature": {
-    "text": "Delano",
+    "text": "Ekipa za podporo",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -355,7 +355,7 @@
     "source_hash": "734882d2"
   },
   "email.organization_invitation.signature": {
-    "text": "Delano",
+    "text": "Ekipa za podporo",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -395,7 +395,7 @@
     "source_hash": "be92cff3"
   },
   "email.password_changed.signature": {
-    "text": "Delano",
+    "text": "Ekipa za podporo",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -445,7 +445,7 @@
     "source_hash": "f8d47b82"
   },
   "email.email_changed.signature": {
-    "text": "Delano",
+    "text": "Ekipa za podporo",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -495,7 +495,7 @@
     "source_hash": "f8d47b82"
   },
   "email.email_change_requested.signature": {
-    "text": "Delano",
+    "text": "Ekipa za podporo",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -550,7 +550,7 @@
     "source_hash": "d4d835fc"
   },
   "email.email_change_confirmation.signature": {
-    "text": "Delano",
+    "text": "Ekipa za podporo",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -580,7 +580,7 @@
     "source_hash": "e7c11bb0"
   },
   "email.mfa_enabled.signature": {
-    "text": "Delano",
+    "text": "Ekipa za podporo",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -605,7 +605,7 @@
     "source_hash": "97ef0a3e"
   },
   "email.mfa_disabled.signature": {
-    "text": "Delano",
+    "text": "Ekipa za podporo",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -650,7 +650,7 @@
     "source_hash": "450c54c5"
   },
   "email.new_login_alert.signature": {
-    "text": "Delano",
+    "text": "Ekipa za podporo",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -670,7 +670,7 @@
     "source_hash": "d442beed"
   },
   "email.member_removed.signature": {
-    "text": "Delano",
+    "text": "Ekipa za podporo",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -690,7 +690,7 @@
     "source_hash": "c2280c0c"
   },
   "email.role_changed.signature": {
-    "text": "Delano",
+    "text": "Ekipa za podporo",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -710,7 +710,7 @@
     "source_hash": "7095fc69"
   },
   "email.organization_deleted.signature": {
-    "text": "Delano",
+    "text": "Ekipa za podporo",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -750,7 +750,7 @@
     "source_hash": "36008943"
   },
   "email.payment_receipt.signature": {
-    "text": "Delano",
+    "text": "Ekipa za podporo",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -775,7 +775,7 @@
     "source_hash": "926406b1"
   },
   "email.payment_failed.signature": {
-    "text": "Delano",
+    "text": "Ekipa za podporo",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -800,7 +800,7 @@
     "source_hash": "66a1419e"
   },
   "email.trial_expiring.signature": {
-    "text": "Delano",
+    "text": "Ekipa za podporo",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -825,7 +825,7 @@
     "source_hash": "5a96ae38"
   },
   "email.subscription_changed.signature": {
-    "text": "Delano",
+    "text": "Ekipa za podporo",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -853,5 +853,41 @@
     "text": "Onetime Secret",
     "renderer": "erb",
     "source_hash": "1cd0194a"
+  },
+  "email.common.secret_link_label": {
+    "text": "Povezava do skrivnosti"
+  },
+  "email.common.automated_notice": {
+    "text": "To je samodejno sporočilo storitve %{product_name}."
+  },
+  "email.common.support_label": {
+    "text": "Podpora"
+  },
+  "email.expiration_warning.signature": {
+    "text": "Ekipa za podporo"
+  },
+  "email.expiration_warning.footer_note": {
+    "text": "To sporočilo ste prejeli, ker bo skrivnost, ki ste jo ustvarili v storitvi %{product_name}, kmalu potekla."
+  },
+  "email.feedback_email.user_id_label": {
+    "text": "Uporabnik:"
+  },
+  "email.feedback_email.timezone_label": {
+    "text": "Časovni pas:"
+  },
+  "email.feedback_email.version_label": {
+    "text": "Različica:"
+  },
+  "email.incoming_secret.footer_note": {
+    "text": "To sporočilo ste prejeli, ker je nekdo prek storitve %{product_name} poslal skrivnost vam. Če tega niste pričakovali, lahko to e-poštno sporočilo mirno prezrete."
+  },
+  "email.secret_link.passphrase_label": {
+    "text": "Zahtevana je pristopna fraza:"
+  },
+  "email.secret_link.passphrase_required": {
+    "text": "Ta skrivnost je zaščitena s pristopno frazo. Pošiljatelj naj vam jo posreduje ločeno."
+  },
+  "email.secret_link.footer_note": {
+    "text": "To sporočilo ste prejeli, ker je %{sender_email} prek storitve %{product_name} z vami delil skrivnost. Če tega niste pričakovali, lahko to e-poštno sporočilo mirno prezrete."
   }
 }

--- a/locales/content/sl_SI/email.json
+++ b/locales/content/sl_SI/email.json
@@ -315,7 +315,7 @@
     "source_hash": "f5394f72"
   },
   "email.feedback_email.signature": {
-    "text": "Secret Support",
+    "text": "Ekipa za podporo",
     "renderer": "erb",
     "source_hash": "f6a6c90f"
   },

--- a/locales/content/sl_SI/feature-feedback.json
+++ b/locales/content/sl_SI/feature-feedback.json
@@ -58,5 +58,14 @@
   "web.feedback.reason_email_change_unauthorized": {
     "text": "Videti je, da prijavljate nepooblaščeno spremembo e-pošte na vašem računu. Prosimo, opišite, kaj se je zgodilo, in takoj bomo preiskali zadevo.",
     "source_hash": "00e56551"
+  },
+  "web.feedback.anonymous_no_reply": {
+    "text": "Opomba: če želite odgovor, se podpišite ali v sporočilo dodajte e-poštni naslov."
+  },
+  "web.feedback.characters_remaining": {
+    "text": "Preostalo znakov: {count}"
+  },
+  "web.feedback.character_limit_reached": {
+    "text": "Dosežena je omejitev znakov"
   }
 }

--- a/locales/content/sl_SI/feature-homepage-secrets.json
+++ b/locales/content/sl_SI/feature-homepage-secrets.json
@@ -1,0 +1,50 @@
+{
+  "homepage_secrets.disabled.members_only_eyebrow": {
+    "text": "Namestitev samo za člane"
+  },
+  "homepage_secrets.disabled.private_instance_eyebrow": {
+    "text": "Zasebna namestitev"
+  },
+  "homepage_secrets.disabled.team_link_headline": {
+    "text": "Ta povezava je namenjena ekipi {workspace}."
+  },
+  "homepage_secrets.disabled.signin_headline": {
+    "text": "Prijavite se in ustvarite {action}."
+  },
+  "homepage_secrets.disabled.signin_headline_action": {
+    "text": "povezavo do skrivnosti"
+  },
+  "homepage_secrets.disabled.team_subtitle": {
+    "text": "Samo pooblaščeni člani ekipe pri {domain} lahko tukaj ustvarjajo nove enkratne povezave. Prejemniki lahko še naprej odprejo katero koli povezavo, ki so jo prejeli."
+  },
+  "homepage_secrets.disabled.public_subtitle": {
+    "text": "Samo pooblaščeni člani te namestitve lahko ustvarjajo nove enkratne povezave. Prejemniki lahko še naprej odprejo katero koli povezavo, ki so jo prejeli."
+  },
+  "homepage_secrets.disabled.signin_cta": {
+    "text": "Prijavite se v svoj račun"
+  },
+  "homepage_secrets.disabled.what_is_this": {
+    "text": "Kaj je to?"
+  },
+  "homepage_secrets.disabled.trust_viewed_once": {
+    "text": "Ogledano enkrat, nato izbrisano"
+  },
+  "homepage_secrets.disabled.trust_zero_retained": {
+    "text": "Nič shranjenega"
+  },
+  "homepage_secrets.disabled.promo_title": {
+    "text": "Novo: brezplačni paketi zdaj vključujejo lastne domene."
+  },
+  "homepage_secrets.disabled.promo_subtitle": {
+    "text": "Usmerite svojo domeno na Onetime Secret in pošiljajte skrivnosti pod lastno blagovno znamko."
+  },
+  "homepage_secrets.disabled.promo_learn_how": {
+    "text": "Preberite, kako"
+  },
+  "homepage_secrets.disabled.logo_alt": {
+    "text": "Logotip {name}"
+  },
+  "homepage_secrets.disabled.opens_in_new_tab": {
+    "text": "(odpre se v novem zavihku)"
+  }
+}

--- a/locales/content/sl_SI/feature-incoming.json
+++ b/locales/content/sl_SI/feature-incoming.json
@@ -130,5 +130,26 @@
   "incoming.receipt_link_text": {
     "text": "potrdilo",
     "source_hash": "6f328609"
+  },
+  "incoming.upgrade_required_title": {
+    "text": "Potrebna nadgradnja"
+  },
+  "incoming.upgrade_required_description": {
+    "text": "Ta funkcija zahteva nadgradnjo paketa. Za omogočanje dohodnih skrivnosti se obrnite na lastnika računa."
+  },
+  "incoming.validation_memo_too_long": {
+    "text": "Zaznamek lahko vsebuje največ {max} znakov"
+  },
+  "incoming.validation_secret_required": {
+    "text": "Vsebina skrivnosti je obvezna"
+  },
+  "incoming.validation_recipient_required": {
+    "text": "Izberite prejemnika"
+  },
+  "incoming.validation_feature_disabled": {
+    "text": "Funkcija dohodnih skrivnosti ni omogočena"
+  },
+  "incoming.validation_form_errors": {
+    "text": "Preverite, ali so v obrazcu napake"
   }
 }

--- a/locales/content/sl_SI/feature-regions.json
+++ b/locales/content/sl_SI/feature-regions.json
@@ -152,7 +152,7 @@
     "source_hash": "1d97f6bd"
   },
   "web.regions.changing_regions_billing_note": {
-    "text": "Če se vaš kontaktni e-poštni naslov za obračun razlikuje od e-poštnega naslova računa {product_name}, za račun v novi regiji uporabite kontaktni e-poštni naslov za obračun, da obdržite ugodnosti naročnine.",
+    "text": "Če se tvoj e-poštni naslov za obračunavanje razlikuje od e-poštnega naslova računa {product_name}, uporabi e-poštni naslov za obračunavanje za novi regijski račun, da ohranite ugodnosti naročnine.",
     "source_hash": "dac1cc28"
   },
   "web.regions.changing_regions_subscription_note": {
@@ -186,5 +186,8 @@
   "web.regions.jurisdictions.apac.name": {
     "text": "Asia-Pacific",
     "source_hash": "7a757670"
+  },
+  "web.regions.no_region_configured": {
+    "text": "Za tvoj račun trenutno ni na voljo nobenih informacij o regiji."
   }
 }

--- a/locales/content/sl_SI/feature-translations.json
+++ b/locales/content/sl_SI/feature-translations.json
@@ -64,7 +64,7 @@
     "source_hash": "13131e36"
   },
   "web.translations.the_following_people_have_donated_their_time_to_": {
-    "text": "Naslednje osebe so darovale svoj čas, da bi pomagale razširiti doseg {product_name}:",
+    "text": "Naslednje osebe so podarile svoj čas, da bi pomagale razširiti doseg {product_name}:",
     "source_hash": "85a766af"
   },
   "web.translations.translations": {
@@ -84,7 +84,7 @@
     "source_hash": "ba5c4395"
   },
   "web.translations.since_2012_onetime_secret_has_provided_a_secure_": {
-    "text": "Od leta 2012 {product_name} zagotavlja varen način deljenja občutljivih informacij po vsem svetu. Z uporabniki v regijah, kjer angleščina ni primarni jezik, so natančni prevodi bistvenega pomena za dostopnost varne komunikacije vsakomur.",
+    "text": "Od leta 2012 {product_name} ponuja varen način deljenja občutljivih informacij po vsem svetu. Z uporabniki v regijah, kjer angleščina ni primarni jezik, so natančni prevodi ključni za dostopnost varne komunikacije za vse.",
     "source_hash": "87a6e9af"
   },
   "web.translations.help_secure_communication_go_global": {

--- a/locales/content/sl_SI/secret-homepage.json
+++ b/locales/content/sl_SI/secret-homepage.json
@@ -56,7 +56,7 @@
     "source_hash": "5e218489"
   },
   "web.homepage.visit_onetime_secret_home": {
-    "text": "Obiščite domačo stran {product_name}",
+    "text": "Obišči domačo stran {product_name}",
     "source_hash": "625556d2"
   },
   "web.homepage.password_generation_title": {
@@ -108,7 +108,7 @@
     "source_hash": "107093e4"
   },
   "web.homepage.about_onetime_secret_0": {
-    "text": "O {product_name}",
+    "text": "O storitvi {product_name}",
     "source_hash": "971c50da"
   },
   "web.homepage.log_in_to_onetime_secret": {
@@ -116,7 +116,7 @@
     "source_hash": "bd6be8d6"
   },
   "web.homepage.about_onetime_secret": {
-    "text": "O {product_name}",
+    "text": "O storitvi {product_name}",
     "source_hash": "971c50da"
   },
   "web.homepage.signup_individual_and_business_plans": {
@@ -172,7 +172,7 @@
     "source_hash": "0990d163"
   },
   "web.homepage.onetime_secret_helps_us_share_sensitive_informat": {
-    "text": "{product_name} nam pomaga varno deliti občutljive informacije, medtem ko ohranjamo našo profesionalno fasado.",
+    "text": "{product_name} nam pomaga varno deliti občutljive informacije, medtem ko ohranjamo našo profesionalno podobo.",
     "source_hash": "986a0856"
   },
   "web.homepage.information_shared_through_this_service_can_only": {

--- a/locales/content/sl_SI/secret-manage.json
+++ b/locales/content/sl_SI/secret-manage.json
@@ -128,7 +128,7 @@
     "source_hash": "07fe1b84"
   },
   "web.secrets.onetime_secret_is_a_secure_way_to_share_sensitiv": {
-    "text": "{product_name} je varen način deljenja občutljivih informacij, ki se samouniči po enkratnem ogledu.",
+    "text": "{product_name} je varen način deljenja občutljivih informacij, ki se samodejno uničijo po enkratnem ogledu.",
     "source_hash": "8a163297"
   },
   "web.secrets.what_is_this": {
@@ -398,5 +398,11 @@
   "web.secrets.errors.access_denied_to_domain": {
     "text": "Dostop do domene zavrnjen",
     "source_hash": "cd441eea"
+  },
+  "web.receipt.open_link": {
+    "text": "Odpri povezavo"
+  },
+  "web.secrets.messageDeleted": {
+    "text": "Sporočilo izbrisano"
   }
 }

--- a/locales/content/sl_SI/session-auth-extended.json
+++ b/locales/content/sl_SI/session-auth-extended.json
@@ -710,5 +710,26 @@
   "web.auth.recovery_codes.link_title": {
     "text": "Obnovitvene kode",
     "source_hash": "579c7f4e"
+  },
+  "web.auth.google": {
+    "text": "Google"
+  },
+  "web.auth.mfa.alternative_auth_options": {
+    "text": "Druge možnosti avtentikacije"
+  },
+  "web.auth.remember.enabled": {
+    "text": "Ostani prijavljen"
+  },
+  "web.auth.security._guidance.context": {
+    "text": "⚠️ SECURITY-CRITICAL: Messages prevent information disclosure. See src/locales/SECURITY-TRANSLATION-GUIDE.md"
+  },
+  "web.auth.sessions.session_singular": {
+    "text": "seja"
+  },
+  "web.auth.sessions.session_plural": {
+    "text": "seje"
+  },
+  "web.auth.sessions._guidance.context": {
+    "text": "User's logged-in devices/browsers management page"
   }
 }

--- a/locales/content/sl_SI/session-auth.json
+++ b/locales/content/sl_SI/session-auth.json
@@ -395,5 +395,35 @@
   "web.help.contact_support": {
     "text": "Obrnite se na podporo",
     "source_hash": "f8d47b82"
+  },
+  "web.auth.account.sso_linked": {
+    "text": "Račun SSO"
+  },
+  "web.auth.verify._guidance.context": {
+    "text": "Email verification flow after signup"
+  },
+  "web.help.reset_password_link": {
+    "text": "Ponastavi geslo"
+  },
+  "web.login.custom_domain_sso_title": {
+    "text": "Enotna prijava (SSO) je na voljo za to domeno"
+  },
+  "web.login.custom_domain_sso_description": {
+    "text": "Skrbnik organizacije lahko omogoči SSO, da se člani ekipe lahko prijavijo tukaj. Za dostop se obrnite na skrbnika."
+  },
+  "web.login.signin_disabled_heading": {
+    "text": "Prijava ni na voljo"
+  },
+  "web.login.signin_disabled_message": {
+    "text": "Prijava trenutno ni na voljo na tej domeni."
+  },
+  "web.login.errors.sso_not_configured": {
+    "text": "Enotna prijava (SSO) za to domeno ni nastavljena. Obrnite se na svojega skrbnika."
+  },
+  "web.login.errors.invalid_email": {
+    "text": "E-poštni naslov vašega ponudnika identitete ni veljaven. Obrnite se na svojega skrbnika."
+  },
+  "web.login.errors.domain_not_allowed": {
+    "text": "Vaša e-poštna domena ni pooblaščena za registracijo prek SSO. Obrnite se na svojega skrbnika."
   }
 }

--- a/locales/content/sl_SI/workspace-account.json
+++ b/locales/content/sl_SI/workspace-account.json
@@ -476,7 +476,7 @@
     "source_hash": "1cc77e60"
   },
   "web.settings.api.documentation_description": {
-    "text": "Naučite se, kako integrirati {product_name} v svoje aplikacije",
+    "text": "Nauči se, kako integrirati {product_name} v svoje aplikacije",
     "source_hash": "6e8f910f"
   },
   "web.settings.api.rest_api_reference": {
@@ -682,5 +682,14 @@
   "web.settings.profile.didnt_receive_email": {
     "text": "Niste prejeli e-sporočila?",
     "source_hash": "fe3ac3ad"
+  },
+  "web.settings.api.api_disabled_notice": {
+    "text": "API je onemogočen za to instanco."
+  },
+  "web.settings.security.sso_managed_title": {
+    "text": "Varnost upravlja SSO"
+  },
+  "web.settings.security.sso_managed_description": {
+    "text": "Vaš račun je overjen prek ponudnika enotne prijave (SSO) vaše organizacije. Geslo, večstopenjsko avtentikacijo in obnovitvene kode upravlja vaš ponudnik identitete."
   }
 }

--- a/locales/content/sl_SI/workspace-billing.json
+++ b/locales/content/sl_SI/workspace-billing.json
@@ -988,5 +988,47 @@
     "text": "Na voljo samo v regiji vaše prvotne naročnine",
     "context": "Hint shown on plan cards when currency does not match active subscription",
     "source_hash": "10de32e5"
+  },
+  "web.billing.already_subscribed": {
+    "text": "Na ta paket ste že naročeni."
+  },
+  "web.billing.cancel.reactivate_button": {
+    "text": "Ponovno aktiviraj naročnino"
+  },
+  "web.billing.cancel.reactivate_success": {
+    "text": "Vaša naročnina je bila ponovno aktivirana. Obračunavanje se bo nadaljevalo kot običajno."
+  },
+  "web.billing.cancel.reactivate_error": {
+    "text": "Ponovna aktivacija naročnine ni uspela. Poskusite znova ali se obrnite na podporo."
+  },
+  "web.billing.features.manage_orgs": {
+    "text": "Upravljanje organizacij"
+  },
+  "web.billing.features.flexible_from_domain": {
+    "text": "Prilagodljiva domena pošiljatelja e-pošte"
+  },
+  "web.billing.features.unlimited_admins": {
+    "text": "Neomejeno skrbnikov"
+  },
+  "web.billing.features.manage_sso": {
+    "text": "Enotna prijava (SSO)"
+  },
+  "web.billing.overview.entitlements.flexible_from_domain": {
+    "text": "Prilagodljiva domena pošiljatelja e-pošte"
+  },
+  "web.billing.overview.entitlements.manage_orgs": {
+    "text": "Upravljanje organizacij"
+  },
+  "web.billing.overview.entitlements.manage_sso": {
+    "text": "Enotna prijava (SSO)"
+  },
+  "web.billing.overview.entitlements.manage_billing": {
+    "text": "Upravljanje obračunavanja"
+  },
+  "web.billing.overview.entitlements.custom_signup_validation": {
+    "text": "Preverjanje registracije po meri"
+  },
+  "web.billing.plans.reactivate": {
+    "text": "Ponovno aktiviraj"
   }
 }

--- a/locales/content/sl_SI/workspace-branding.json
+++ b/locales/content/sl_SI/workspace-branding.json
@@ -178,5 +178,11 @@
   "web.branding.upgrade_to_customize": {
     "text": "Nadgradite svoj načrt, da prilagodite blagovno znamko za to domeno.",
     "source_hash": "9077bf79"
+  },
+  "web.branding.saved_successfully": {
+    "text": "Nastavitve blagovne znamke uspešno shranjene"
+  },
+  "web.branding.keyhole_logo_icon": {
+    "text": "Ikona ključavnice, ki predstavlja varno, zasebno deljenje"
   }
 }

--- a/locales/content/sl_SI/workspace-dashboard.json
+++ b/locales/content/sl_SI/workspace-dashboard.json
@@ -22,5 +22,14 @@
   "web.dashboard.fetch_error_description": {
     "text": "Pri nalaganju vaših podatkov je prišlo do težave. Poskusite znova.",
     "source_hash": "ff0d904e"
+  },
+  "web.teams.create_first_team_title": {
+    "text": "Ustvarite svojo prvo ekipo"
+  },
+  "web.teams.create_first_team_description": {
+    "text": "Ekipe vam omogočajo sodelovanje z drugimi v skupnem delovnem prostoru."
+  },
+  "web.teams.create_team": {
+    "text": "Ustvari ekipo"
   }
 }

--- a/locales/content/sl_SI/workspace-domains.json
+++ b/locales/content/sl_SI/workspace-domains.json
@@ -398,5 +398,725 @@
   "web.domains.dns_widget_description": {
     "text": "Uporabite spodnje orodje za samodejno zaznavo vašega ponudnika DNS in pridobite navodila po korakih za konfiguracijo vaše domene.",
     "source_hash": "91c1af2e"
+  },
+  "api.domains.errors.add_admin_required": {
+    "text": "Samo lastniki in skrbniki organizacije lahko dodajo domene po meri"
+  },
+  "web.domains.public_homepage": {
+    "text": "Javna domača stran"
+  },
+  "web.domains.status_tooltip_active": {
+    "text": "Domena preverjena in aktivna"
+  },
+  "web.domains.status_tooltip_dns_incorrect": {
+    "text": "DNS ni konfiguriran — kliknite za popravilo"
+  },
+  "web.domains.status_tooltip_not_verified": {
+    "text": "Domena ni preverjena — kliknite za preverjanje"
+  },
+  "web.domains.status_tooltip_unverified": {
+    "text": "Stanje domene ni preverjeno — kliknite za osvežitev"
+  },
+  "web.domains.last_check_failed": {
+    "text": "Zadnje preverjanje ni uspelo"
+  },
+  "web.domains.last_check_failed_ago": {
+    "text": "zadnje preverjanje ni uspelo {0}"
+  },
+  "web.domains.verify_now": {
+    "text": "Preveri zdaj"
+  },
+  "web.domains.click_to_verify": {
+    "text": "kliknite za preverjanje"
+  },
+  "web.domains.remove_domain_description": {
+    "text": "Trajno odstranite to domeno in vso njeno konfiguracijo."
+  },
+  "web.domains.add_access_denied": {
+    "text": "Dostop zavrnjen"
+  },
+  "web.domains.add_access_denied_description": {
+    "text": "Nimate dovoljenja za dodajanje domen v to organizacijo. Obrnite se na skrbnika svoje organizacije."
+  },
+  "web.domains.dns_widget_load_failed": {
+    "text": "Orodja DNS ni bilo mogoče naložiti"
+  },
+  "web.domains.dns_widget_not_available": {
+    "text": "Orodje DNS ni na voljo"
+  },
+  "web.domains.dns_widget_init_failed": {
+    "text": "Orodja DNS ni bilo mogoče inicializirati"
+  },
+  "web.domains.verified": {
+    "text": "Preverjeno"
+  },
+  "web.domains.pending_verification": {
+    "text": "Čaka na preverjanje"
+  },
+  "web.domains.unsaved_changes_confirmation": {
+    "text": "Imate neshranjene spremembe. Ali ste prepričani, da želite zapustiti stran?"
+  },
+  "web.domains.entitlement_required_owner": {
+    "text": "Ta funkcija zahteva nadgradnjo paketa."
+  },
+  "web.domains.entitlement_required_member": {
+    "text": "Ta funkcija ni na voljo v vašem trenutnem paketu. Obrnite se na lastnika svoje organizacije."
+  },
+  "web.domains.detail.manage": {
+    "text": "Upravljanje"
+  },
+  "web.domains.detail.features": {
+    "text": "Funkcije"
+  },
+  "web.domains.detail.homepage_title": {
+    "text": "Skrivnosti na domači strani"
+  },
+  "web.domains.detail.homepage_description": {
+    "text": "Dovolite javni dostop za ustvarjanje skrivnosti na domači strani vaše domene"
+  },
+  "web.domains.detail.brand_description": {
+    "text": "Logotip, barve in lastna blagovna znamka"
+  },
+  "web.domains.detail.sso_description": {
+    "text": "Nastavitve ponudnika enotne prijave (SSO)"
+  },
+  "web.domains.detail.email_description": {
+    "text": "Konfiguracija pošiljatelja e-pošte po meri"
+  },
+  "web.domains.detail.incoming_description": {
+    "text": "Nastavitve prejemnika dohodnih skrivnosti"
+  },
+  "web.domains.detail.signup_description": {
+    "text": "Strategija preverjanja registracije za posamezno domeno"
+  },
+  "web.domains.detail.signin_description": {
+    "text": "Konfiguracija načina prijave za posamezno domeno"
+  },
+  "web.domains.email.title": {
+    "text": "Pošiljanje e-pošte"
+  },
+  "web.domains.email.config_title": {
+    "text": "Konfiguracija e-pošte"
+  },
+  "web.domains.email.config_description": {
+    "text": "Konfigurirajte pošiljanje e-pošte za to domeno"
+  },
+  "web.domains.email.provider_label": {
+    "text": "Ponudnik e-pošte"
+  },
+  "web.domains.email.provider_placeholder": {
+    "text": "Izberite ponudnika e-pošte"
+  },
+  "web.domains.email.from_name_label": {
+    "text": "Ime pošiljatelja"
+  },
+  "web.domains.email.from_name_placeholder": {
+    "text": "npr. Acme Security"
+  },
+  "web.domains.email.from_address_label": {
+    "text": "Naslov pošiljatelja"
+  },
+  "web.domains.email.from_address_placeholder": {
+    "text": "npr. secrets{'@'}example.com"
+  },
+  "web.domains.email.reply_to_label": {
+    "text": "Naslov za odgovor"
+  },
+  "web.domains.email.reply_to_placeholder": {
+    "text": "npr. support{'@'}example.com"
+  },
+  "web.domains.email.save_changes": {
+    "text": "Shrani spremembe"
+  },
+  "web.domains.email.discard_changes": {
+    "text": "Zavrzi spremembe"
+  },
+  "web.domains.email.provider_ses": {
+    "text": "Amazon SES"
+  },
+  "web.domains.email.provider_sendgrid": {
+    "text": "SendGrid"
+  },
+  "web.domains.email.provider_lettermint": {
+    "text": "Lettermint"
+  },
+  "web.domains.email.provider_inherit": {
+    "text": "Uporabi privzete nastavitve računa"
+  },
+  "web.domains.email.provider_ses_description": {
+    "text": "Zahteva preverjanje domene prek zapisov DKIM in SPF"
+  },
+  "web.domains.email.provider_sendgrid_description": {
+    "text": "Zahteva nastavitev avtentikacije domene"
+  },
+  "web.domains.email.provider_lettermint_description": {
+    "text": "Zahteva preverjanje domene"
+  },
+  "web.domains.email.provider_inherit_description": {
+    "text": "Uporablja privzeto konfiguracijo pošiljanja e-pošte vašega računa"
+  },
+  "web.domains.email.dns_records_title": {
+    "text": "Zapisi DNS"
+  },
+  "web.domains.email.dns_records_description": {
+    "text": "Dodajte naslednje zapise DNS za preverjanje svoje domene za pošiljanje e-pošte."
+  },
+  "web.domains.email.dns_column_type": {
+    "text": "Tip"
+  },
+  "web.domains.email.dns_column_name": {
+    "text": "Ime"
+  },
+  "web.domains.email.dns_column_value": {
+    "text": "Vrednost"
+  },
+  "web.domains.email.dns_check_label": {
+    "text": "DNS"
+  },
+  "web.domains.email.provider_check_label": {
+    "text": "Ponudnik"
+  },
+  "web.domains.email.dns_optional_label": {
+    "text": "Priporočeno"
+  },
+  "web.domains.email.dns_optional_hint": {
+    "text": "Ta zapis je priporočen, vendar ni obvezen za preverjanje. Pravilnik DMARC pri vaši organizacijski domeni morda že pokriva to poddomeno."
+  },
+  "web.domains.email.copy": {
+    "text": "Kopiraj"
+  },
+  "web.domains.email.copied": {
+    "text": "Kopirano"
+  },
+  "web.domains.email.status_verified": {
+    "text": "Preverjeno"
+  },
+  "web.domains.email.status_pending": {
+    "text": "V obdelavi"
+  },
+  "web.domains.email.status_failed": {
+    "text": "Neuspešno"
+  },
+  "web.domains.email.revalidate": {
+    "text": "Ponovno preveri"
+  },
+  "web.domains.email.validating": {
+    "text": "Preverjanje ..."
+  },
+  "web.domains.email.domain_verified": {
+    "text": "Domena preverjena"
+  },
+  "web.domains.email.validation_failed": {
+    "text": "Preverjanje ni uspelo"
+  },
+  "web.domains.email.last_validated": {
+    "text": "Zadnjič preverjeno"
+  },
+  "web.domains.email.upgrade_to_configure": {
+    "text": "Nadgradite svoj paket za konfiguracijo pošiljanja e-pošte za to domeno."
+  },
+  "web.domains.email.configure_email": {
+    "text": "Konfiguriraj e-pošto"
+  },
+  "web.domains.email.access_denied": {
+    "text": "Dostop zavrnjen"
+  },
+  "web.domains.email.access_denied_description": {
+    "text": "Nimate dovoljenja za upravljanje nastavitev e-pošte za to domeno. Obrnite se na skrbnika svoje organizacije."
+  },
+  "web.domains.email.update_success": {
+    "text": "Konfiguracija e-pošte uspešno shranjena"
+  },
+  "web.domains.email.delete_success": {
+    "text": "Konfiguracija e-pošte uspešno odstranjena"
+  },
+  "web.domains.email.default_sender_notice": {
+    "text": "E-poštna sporočila za to domeno se trenutno pošiljajo z globalnega pošiljatelja. Dokončajte konfiguracijo e-pošte, da uporabite lastno identiteto pošiljatelja."
+  },
+  "web.domains.email.disabled_notice": {
+    "text": "Pošiljanje e-pošte po meri je trenutno onemogočeno. E-poštna sporočila bodo poslana z globalnega pošiljatelja. Omogočite spodnjo funkcijo, da uporabite svojo lastno identiteto pošiljatelja."
+  },
+  "web.domains.email.test_email_title": {
+    "text": "Preizkus dostave e-pošte"
+  },
+  "web.domains.email.test_email_hint": {
+    "text": "Pošljite si preizkusno e-poštno sporočilo z uporabo shranjene konfiguracije. Deluje tudi, ko funkcija še ni omogočena."
+  },
+  "web.domains.email.send_test": {
+    "text": "Pošlji preizkus"
+  },
+  "web.domains.email.test_email_sent": {
+    "text": "Preizkusno e-poštno sporočilo uspešno poslano"
+  },
+  "web.domains.email.test_email_failed": {
+    "text": "Preizkusnega e-poštnega sporočila ni bilo mogoče poslati"
+  },
+  "web.domains.email.test_email_sent_to": {
+    "text": "Poslano na {email}"
+  },
+  "web.domains.email.delivered_via": {
+    "text": "Dostavljeno prek {provider}"
+  },
+  "web.domains.email.badge_not_configured": {
+    "text": "Ni konfigurirano"
+  },
+  "web.domains.email.badge_default_sender": {
+    "text": "Uporablja privzetega pošiljatelja"
+  },
+  "web.domains.email.badge_verified": {
+    "text": "Preverjeno"
+  },
+  "web.domains.email.badge_pending": {
+    "text": "Čaka na preverjanje"
+  },
+  "web.domains.email.badge_disabled": {
+    "text": "Onemogočeno"
+  },
+  "web.domains.email.tooltip_not_configured": {
+    "text": "Pošiljatelj e-pošte ni konfiguriran — e-poštna sporočila uporabljajo privzetega pošiljatelja platforme"
+  },
+  "web.domains.email.tooltip_pending": {
+    "text": "Konfiguracija pošiljatelja e-pošte čaka na preverjanje — e-poštna sporočila uporabljajo privzetega pošiljatelja platforme"
+  },
+  "web.domains.email.tooltip_disabled": {
+    "text": "Pošiljatelj e-pošte je onemogočen — e-poštna sporočila uporabljajo privzetega pošiljatelja platforme"
+  },
+  "web.domains.email.tooltip_verified": {
+    "text": "Pošiljatelj e-pošte je preverjen — e-poštna sporočila se pošiljajo s te domene"
+  },
+  "web.domains.incoming.title": {
+    "text": "Dohodne skrivnosti"
+  },
+  "web.domains.incoming.config_title": {
+    "text": "Konfiguracija dohodnih skrivnosti"
+  },
+  "web.domains.incoming.config_description": {
+    "text": "Zunanjim uporabnikom omogočite, da pošljejo skrivnosti neposredno določenim prejemnikom na tej domeni"
+  },
+  "web.domains.incoming.feature_disabled": {
+    "text": "Dohodne skrivnosti niso na voljo"
+  },
+  "web.domains.incoming.feature_disabled_description": {
+    "text": "Dohodne skrivnosti na tej instanci niso omogočene. Obrnite se na svojega skrbnika."
+  },
+  "web.domains.incoming.access_denied": {
+    "text": "Dostop zavrnjen"
+  },
+  "web.domains.incoming.access_denied_description": {
+    "text": "Nimate dovoljenja za upravljanje nastavitev dohodnih skrivnosti za to domeno. Obrnite se na skrbnika svoje organizacije."
+  },
+  "web.domains.incoming.upgrade_to_configure": {
+    "text": "Nadgradite paket, da boste lahko konfigurirali dohodne skrivnosti za to domeno."
+  },
+  "web.domains.incoming.configure_incoming": {
+    "text": "Konfiguriraj dohodne skrivnosti"
+  },
+  "web.domains.incoming.not_configured_notice": {
+    "text": "Dohodne skrivnosti za to domeno niso konfigurirane. Dodajte prejemnike, da boste zunanjim uporabnikom omogočili pošiljanje skrivnosti vaši ekipi."
+  },
+  "web.domains.incoming.disabled_notice": {
+    "text": "Dohodne skrivnosti so trenutno onemogočene. Zunanji uporabniki ne morejo pošiljati skrivnosti prejemnikom na tej domeni. Spodaj omogočite funkcijo, da dovolite dohodne skrivnosti."
+  },
+  "web.domains.incoming.recipients_title": {
+    "text": "Prejemniki"
+  },
+  "web.domains.incoming.recipients_description": {
+    "text": "Določite, kdo lahko prejema dohodne skrivnosti na tej domeni. Prejemniki bodo prejeli e-poštno obvestilo, ko jim bo poslana skrivnost."
+  },
+  "web.domains.incoming.add_recipient": {
+    "text": "Dodaj prejemnika"
+  },
+  "web.domains.incoming.remove_recipient": {
+    "text": "Odstrani"
+  },
+  "web.domains.incoming.email_label": {
+    "text": "E-poštni naslov"
+  },
+  "web.domains.incoming.email_placeholder": {
+    "text": "recipient{'@'}example.com"
+  },
+  "web.domains.incoming.name_label": {
+    "text": "Prikazno ime"
+  },
+  "web.domains.incoming.name_placeholder": {
+    "text": "npr. Varnostna ekipa"
+  },
+  "web.domains.incoming.empty_state": {
+    "text": "Ni konfiguriranih prejemnikov"
+  },
+  "web.domains.incoming.empty_state_description": {
+    "text": "Dodajte prejemnike, da boste zunanjim uporabnikom omogočili pošiljanje skrivnosti vaši ekipi."
+  },
+  "web.domains.incoming.validation_invalid_email": {
+    "text": "Neveljaven e-poštni naslov"
+  },
+  "web.domains.incoming.validation_duplicate_email": {
+    "text": "Ta e-poštni naslov je že dodan"
+  },
+  "web.domains.incoming.validation_max_recipients": {
+    "text": "Dovoljenih je največ {max} prejemnikov"
+  },
+  "web.domains.incoming.validation_name_required": {
+    "text": "Prikazno ime je obvezno"
+  },
+  "web.domains.incoming.validation_email_required": {
+    "text": "E-poštni naslov je obvezen"
+  },
+  "web.domains.incoming.save_changes": {
+    "text": "Shrani spremembe"
+  },
+  "web.domains.incoming.discard_changes": {
+    "text": "Zavrzi spremembe"
+  },
+  "web.domains.incoming.update_success": {
+    "text": "Konfiguracija dohodnih skrivnosti je bila uspešno shranjena"
+  },
+  "web.domains.incoming.delete_success": {
+    "text": "Konfiguracija dohodnih skrivnosti je bila uspešno odstranjena"
+  },
+  "web.domains.incoming.recipient_count": {
+    "text": "{count} prejemnik | {count} prejemnikov"
+  },
+  "web.domains.incoming.badge_not_configured": {
+    "text": "Ni konfigurirano"
+  },
+  "web.domains.incoming.badge_configured": {
+    "text": "Konfigurirano"
+  },
+  "web.domains.incoming.badge_disabled": {
+    "text": "Onemogočeno"
+  },
+  "web.domains.incoming.tooltip_not_configured": {
+    "text": "Dohodne skrivnosti niso konfigurirane – zunanji uporabniki ne morejo pošiljati skrivnosti na to domeno"
+  },
+  "web.domains.incoming.tooltip_configured": {
+    "text": "Dohodne skrivnosti so omogočene z {count} prejemniki"
+  },
+  "web.domains.incoming.tooltip_disabled": {
+    "text": "Funkcija dohodnih skrivnosti je za to domeno onemogočena"
+  },
+  "web.domains.incoming.enabled_label": {
+    "text": "Omogoči dohodne skrivnosti"
+  },
+  "web.domains.incoming.enabled_hint": {
+    "text": "Zunanjim uporabnikom omogočite pošiljanje skrivnosti prejemnikom na tej domeni"
+  },
+  "web.domains.incoming.public_url_label": {
+    "text": "Javni URL"
+  },
+  "web.domains.incoming.public_url_description": {
+    "text": "Ta URL delite z zunanjimi uporabniki, da jim omogočite pošiljanje skrivnosti"
+  },
+  "web.domains.incoming.copy_url": {
+    "text": "Kopiraj URL"
+  },
+  "web.domains.incoming.url_copied": {
+    "text": "URL kopiran v odložišče"
+  },
+  "web.domains.incoming.remove_all_confirmation": {
+    "text": "Ali ste prepričani, da želite odstraniti vse prejemnike? Zunanji uporabniki ne bodo več mogli pošiljati skrivnosti na to domeno."
+  },
+  "web.domains.incoming.max_recipients_reached": {
+    "text": "Doseženo je največje število prejemnikov"
+  },
+  "web.domains.incoming.duplicate_recipient": {
+    "text": "Ta e-poštni naslov je že dodan"
+  },
+  "web.domains.incoming.save_will_replace_confirmation": {
+    "text": "S shranjevanjem boste vse obstoječe prejemnike zamenjali s svojimi neshranjenimi spremembami. Ali ste prepričani?"
+  },
+  "web.domains.incoming.delete_all_recipients": {
+    "text": "Izbriši vse prejemnike"
+  },
+  "web.domains.signin.title": {
+    "text": "Konfiguracija prijave"
+  },
+  "web.domains.signin.configure_signin": {
+    "text": "Konfiguriraj prijavo"
+  },
+  "web.domains.signin.config_description": {
+    "text": "Konfigurirajte metode avtentikacije za prijavo na tej domeni"
+  },
+  "web.domains.signin.access_denied": {
+    "text": "Dostop zavrnjen"
+  },
+  "web.domains.signin.upgrade_to_configure": {
+    "text": "Nadgradite paket, da boste lahko konfigurirali metode prijave za to domeno."
+  },
+  "web.domains.signin.not_configured_notice": {
+    "text": "Konfiguracija prijave za to domeno še ni nastavljena. Konfigurirajte preglasitve, da nadzorujete, katere metode avtentikacije so na voljo na prijavni strani te domene."
+  },
+  "web.domains.signin.signin_enabled_label": {
+    "text": "Prijava omogočena"
+  },
+  "web.domains.signin.header_toggle_label": {
+    "text": "Prijava"
+  },
+  "web.domains.signin.signin_enabled_hint": {
+    "text": "Ali se lahko uporabniki prijavijo na tej domeni"
+  },
+  "web.domains.signin.restrict_to_label": {
+    "text": "Omeji metodo prijave"
+  },
+  "web.domains.signin.restrict_to_hint": {
+    "text": "Omejite to domeno na eno samo metodo avtentikacije. Ko je nastavljena, je na prijavni strani prikazana samo izbrana metoda."
+  },
+  "web.domains.signin.all_methods": {
+    "text": "Vse metode"
+  },
+  "web.domains.signin.all_methods_description": {
+    "text": "Na prijavni strani prikaži vse omogočene metode avtentikacije"
+  },
+  "web.domains.signin.method_password": {
+    "text": "Geslo"
+  },
+  "web.domains.signin.method_email_auth": {
+    "text": "Avtentikacija po e-pošti"
+  },
+  "web.domains.signin.method_webauthn": {
+    "text": "WebAuthn / Ključi za dostop"
+  },
+  "web.domains.signin.method_sso": {
+    "text": "Enotna prijava (SSO)"
+  },
+  "web.domains.signin.method_overrides_label": {
+    "text": "Preglasitve metod"
+  },
+  "web.domains.signin.method_overrides_hint": {
+    "text": "Omogočite ali onemogočite posamezne metode avtentikacije za to domeno"
+  },
+  "web.domains.signin.mode_question": {
+    "text": "Kako se lahko uporabniki prijavijo?"
+  },
+  "web.domains.signin.mode_any": {
+    "text": "Katera koli razpoložljiva metoda"
+  },
+  "web.domains.signin.mode_any_hint": {
+    "text": "Prikaži vsako metodo, ki je na voljo na tej domeni. Spodaj omejite posamezne metode."
+  },
+  "web.domains.signin.mode_one": {
+    "text": "Ena določena metoda"
+  },
+  "web.domains.signin.mode_one_hint": {
+    "text": "Omejite prijavno stran na eno samo metodo. Naštete so samo metode, ki so na voljo na tej domeni."
+  },
+  "web.domains.signin.mode_disabled": {
+    "text": "Prijava onemogočena"
+  },
+  "web.domains.signin.mode_disabled_hint": {
+    "text": "Uporabniki se na tej domeni ne morejo prijaviti."
+  },
+  "web.domains.signin.mode_disabled_notice": {
+    "text": "Obiskovalci prijavne strani te domene vidijo obvestilo, da prijava ni na voljo, s povezavo nazaj na domačo stran. Vaše prejšnje nastavitve metod se ohranijo in obnovijo, ko ponovno omogočite prijavo."
+  },
+  "web.domains.signin.methods_list_label": {
+    "text": "Metode, prikazane na prijavni strani"
+  },
+  "web.domains.signin.restrict_picker_hint": {
+    "text": "Naštete so samo metode, ki so na voljo na tej domeni."
+  },
+  "web.domains.signin.availability_always": {
+    "text": "Vedno na voljo"
+  },
+  "web.domains.signin.availability_global_on": {
+    "text": "Sledi globalnemu pravilniku · Vklopljeno"
+  },
+  "web.domains.signin.availability_global_off": {
+    "text": "Ni na voljo"
+  },
+  "web.domains.signin.availability_unavailable": {
+    "text": "Ni na voljo na celotnem spletnem mestu"
+  },
+  "web.domains.signin.allow_on_domain": {
+    "text": "Dovoli na tej domeni"
+  },
+  "web.domains.signin.method_password_blurb": {
+    "text": "Samo geslo"
+  },
+  "web.domains.signin.method_email_auth_blurb": {
+    "text": "Prijava brez gesla z magično povezavo"
+  },
+  "web.domains.signin.method_webauthn_blurb": {
+    "text": "Biometrija in varnostni ključi"
+  },
+  "web.domains.signin.method_sso_blurb": {
+    "text": "Zunanji ponudnik identitete"
+  },
+  "web.domains.signin.email_auth_label": {
+    "text": "Avtentikacija po e-pošti"
+  },
+  "web.domains.signin.email_auth_hint": {
+    "text": "Dovoli avtentikacijo po e-pošti brez gesla na tej domeni"
+  },
+  "web.domains.signin.sso_enabled_label": {
+    "text": "Enotna prijava (SSO)"
+  },
+  "web.domains.signin.sso_enabled_hint": {
+    "text": "Dovoli avtentikacijo SSO na tej domeni"
+  },
+  "web.domains.signin.enabled_label": {
+    "text": "Omogoči konfiguracijo prijave"
+  },
+  "web.domains.signin.enabled_hint": {
+    "text": "Ko je omogočeno, ta domena uporablja zgoraj konfigurirane nastavitve prijave"
+  },
+  "web.domains.signin.save_config": {
+    "text": "Shrani konfiguracijo"
+  },
+  "web.domains.signin.update_success": {
+    "text": "Konfiguracija prijave je bila uspešno posodobljena"
+  },
+  "web.domains.signin.reset_to_defaults": {
+    "text": "Ponastavi na privzete vrednosti"
+  },
+  "web.domains.signin.reset_confirm": {
+    "text": "Ponastavi prijavo na globalne privzete vrednosti?"
+  },
+  "web.domains.signin.reset_keeps_sso": {
+    "text": "Vaše poverilnice SSO se ohranijo. Odstranite jih ločeno na zaslonu za konfiguracijo SSO."
+  },
+  "web.domains.signin.reset_action": {
+    "text": "Da, ponastavi"
+  },
+  "web.domains.signin.reset_success": {
+    "text": "Nastavitve prijave so bile ponastavljene na globalne privzete vrednosti"
+  },
+  "web.domains.signup.title": {
+    "text": "Preverjanje registracije"
+  },
+  "web.domains.signup.config_description": {
+    "text": "Konfigurirajte preverjanje registracije za to domeno"
+  },
+  "web.domains.signup.access_denied": {
+    "text": "Dostop zavrnjen"
+  },
+  "web.domains.signup.upgrade_to_configure": {
+    "text": "Nadgradite paket, da boste lahko konfigurirali preverjanje registracije za posamezno domeno."
+  },
+  "web.domains.signup.configure_signup": {
+    "text": "Konfiguriraj registracijo"
+  },
+  "web.domains.signup.not_configured_notice": {
+    "text": "Preverjanje registracije za to domeno še ni konfigurirano. Konfigurirajte strategijo, da nadzorujete, kdo se lahko registrira prek te domene."
+  },
+  "web.domains.signup.site_signups_disabled_warning": {
+    "text": "Registracije so trenutno onemogočene na ravni spletnega mesta. Ta pravilnik za posamezno domeno je konfiguriran, vendar ne bo omejeval nobenega prometa, dokler registracije spletnega mesta niso omogočene."
+  },
+  "web.domains.signup.strategy_label": {
+    "text": "Strategija preverjanja"
+  },
+  "web.domains.signup.strategy_description": {
+    "text": "Izberite, kako se e-poštni naslovi preverjajo, ko se uporabniki registrirajo na tej domeni."
+  },
+  "web.domains.signup.network_validation_warning": {
+    "text": "Ta strategija med registracijo izvaja omrežne klice, kar lahko poveča zakasnitev ali ga nekateri ponudniki blokirajo."
+  },
+  "web.domains.signup.allowed_domains_label": {
+    "text": "Dovoljene domene za registracijo"
+  },
+  "web.domains.signup.allowed_domains_hint": {
+    "text": "Registracija bo dovoljena samo s teh e-poštnih domen. Dodajte eno domeno na vnos."
+  },
+  "web.domains.signup.domain_placeholder": {
+    "text": "example.com"
+  },
+  "web.domains.signup.invalid_domain": {
+    "text": "Vnesite veljavno domeno (npr. example.com)"
+  },
+  "web.domains.signup.domain_exists": {
+    "text": "Ta domena je že na seznamu"
+  },
+  "web.domains.signup.remove_domain": {
+    "text": "Odstrani {domain}"
+  },
+  "web.domains.signup.enabled_label": {
+    "text": "Omogoči preverjanje za posamezno domeno"
+  },
+  "web.domains.signup.enabled_hint": {
+    "text": "Ko je omogočeno, registracije na tej domeni namesto globalnega pravilnika uporabljajo zgornjo strategijo."
+  },
+  "web.domains.signup.delete_config": {
+    "text": "Izbriši konfiguracijo"
+  },
+  "web.domains.signup.delete_confirm": {
+    "text": "Izbriši konfiguracijo preverjanja registracije? Registracije se bodo vrnile na globalni pravilnik."
+  },
+  "web.domains.signup.save_config": {
+    "text": "Shrani konfiguracijo"
+  },
+  "web.domains.signup.update_success": {
+    "text": "Preverjanje registracije je bilo uspešno posodobljeno"
+  },
+  "web.domains.signup.delete_success": {
+    "text": "Konfiguracija preverjanja registracije je bila uspešno odstranjena"
+  },
+  "web.domains.signup.domain_overrides_label": {
+    "text": "Preglasitve domene"
+  },
+  "web.domains.signup.domain_overrides_hint": {
+    "text": "Preglasi globalne nastavitve registracije za to domeno"
+  },
+  "web.domains.signup.signup_enabled_label": {
+    "text": "Registracija omogočena"
+  },
+  "web.domains.signup.signup_enabled_hint": {
+    "text": "Preglasi, ali je registracija omogočena za to domeno"
+  },
+  "web.domains.signup.autoverify_label": {
+    "text": "Samodejno preveri račune"
+  },
+  "web.domains.signup.autoverify_hint": {
+    "text": "Preglasi, ali se novi računi na tej domeni samodejno preverijo"
+  },
+  "web.domains.sso.title": {
+    "text": "Enotna prijava (SSO)"
+  },
+  "web.domains.sso.config_title": {
+    "text": "Konfiguracija SSO"
+  },
+  "web.domains.sso.config_description": {
+    "text": "Konfigurirajte avtentikacijo z enotno prijavo (SSO) za to domeno"
+  },
+  "web.domains.sso.access_denied": {
+    "text": "Dostop zavrnjen"
+  },
+  "web.domains.sso.access_denied_description": {
+    "text": "Nimate dovoljenja za upravljanje nastavitev SSO za to domeno. Obrnite se na skrbnika svoje organizacije."
+  },
+  "web.domains.sso.upgrade_to_configure": {
+    "text": "Nadgradite paket, da boste lahko konfigurirali enotno prijavo (SSO) za to domeno."
+  },
+  "web.domains.sso.create_success": {
+    "text": "Konfiguracija SSO je bila uspešno ustvarjena"
+  },
+  "web.domains.sso.update_success": {
+    "text": "Konfiguracija SSO je bila uspešno posodobljena"
+  },
+  "web.domains.sso.delete_success": {
+    "text": "Konfiguracija SSO je bila uspešno odstranjena"
+  },
+  "web.domains.sso.test_success": {
+    "text": "Preizkus povezave je uspel — ponudnik se je pravilno odzval"
+  },
+  "web.domains.sso.test_failed": {
+    "text": "Preizkus povezave ni uspel"
+  },
+  "web.domains.sso.enforce_moved_notice": {
+    "text": "Če želite zahtevati SSO za vse prijave na tej domeni, ga konfigurirajte v nastavitvah prijave za domeno. Način samo SSO omeji prijavno stran na ponudnika SSO, konfiguriranega tukaj."
+  },
+  "web.domains.sso.configure_sso": {
+    "text": "Konfiguriraj SSO"
+  },
+  "web.domains.sso.not_configured_notice": {
+    "text": "SSO za to domeno še ni konfiguriran. Omogočite enotno prijavo (SSO), da članom ekipe omogočite avtentikacijo prek ponudnika identitete vaše organizacije."
+  },
+  "web.domains.sso.edit_credentials": {
+    "text": "Uredi poverilnice"
+  },
+  "web.domains.sso.configure_button": {
+    "text": "Konfiguriraj"
+  },
+  "web.domains.sso.upgrade_required": {
+    "text": "Nadgradi za konfiguracijo"
   }
 }

--- a/locales/content/sl_SI/workspace-organizations.json
+++ b/locales/content/sl_SI/workspace-organizations.json
@@ -578,5 +578,344 @@
   "web.organizations.invitations.expires_soon": {
     "text": "Kmalu poteče",
     "source_hash": "a5dcfef9"
+  },
+  "api.organizations.errors.not_found": {
+    "text": "Organizacija ni najdena: %{extid}"
+  },
+  "api.organizations.errors.owner_required": {
+    "text": "To dejanje lahko izvede samo lastnik organizacije"
+  },
+  "api.organizations.errors.admin_required": {
+    "text": "To dejanje lahko izvedejo samo lastniki in skrbniki organizacije"
+  },
+  "api.organizations.errors.member_required": {
+    "text": "Za izvedbo tega dejanja morate biti član organizacije"
+  },
+  "api.organizations.invitations.errors.create_admin_required": {
+    "text": "Povabila lahko ustvarjajo samo lastniki in skrbniki organizacije"
+  },
+  "api.organizations.invitations.errors.resend_admin_required": {
+    "text": "Povabila lahko ponovno pošljejo samo lastniki in skrbniki organizacije"
+  },
+  "api.organizations.invitations.errors.view_admin_required": {
+    "text": "Povabila si lahko ogledajo samo lastniki in skrbniki organizacije"
+  },
+  "api.organizations.invitations.errors.revoke_admin_required": {
+    "text": "Povabila lahko prekličejo samo lastniki in skrbniki organizacije"
+  },
+  "api.organizations.invitations.errors.email_required": {
+    "text": "E-pošta je obvezna"
+  },
+  "api.organizations.invitations.errors.email_invalid": {
+    "text": "Neveljavna oblika e-pošte"
+  },
+  "api.organizations.invitations.errors.role_invalid": {
+    "text": "Vloga mora biti član ali skrbnik"
+  },
+  "api.organizations.invitations.errors.cannot_invite_owner": {
+    "text": "Povabilo z vlogo lastnika ni mogoče"
+  },
+  "api.organizations.invitations.errors.already_member": {
+    "text": "Uporabnik je že član te organizacije"
+  },
+  "api.organizations.invitations.errors.already_pending": {
+    "text": "Povabilo za ta e-poštni naslov že čaka na obravnavo"
+  },
+  "api.organizations.invitations.errors.member_limit_reached": {
+    "text": "Dosežena je omejitev števila članov. Nadgradite paket, da povabite več članov."
+  },
+  "api.organizations.invitations.errors.not_found": {
+    "text": "Povabilo ni najdeno"
+  },
+  "api.organizations.invitations.errors.cannot_resend_non_pending": {
+    "text": "Ponovno je mogoče poslati samo povabila, ki čakajo na obravnavo"
+  },
+  "api.organizations.invitations.errors.cannot_revoke_non_pending": {
+    "text": "Preklicati je mogoče samo povabila, ki čakajo na obravnavo"
+  },
+  "api.organizations.invitations.errors.resend_limit_reached": {
+    "text": "Dosežena je največja omejitev ponovnih pošiljanj (%{max})"
+  },
+  "api.organizations.invitations.errors.accept_token_required": {
+    "text": "Žeton je obvezen"
+  },
+  "api.organizations.invitations.errors.accept_organization_gone": {
+    "text": "Organizacija ne obstaja več"
+  },
+  "api.organizations.invitations.errors.accept_already_acted": {
+    "text": "Povabilo je bilo že %{status}"
+  },
+  "api.organizations.invitations.errors.accept_expired": {
+    "text": "Povabilo je poteklo"
+  },
+  "api.organizations.invitations.errors.accept_email_mismatch": {
+    "text": "Vaš e-poštni naslov se ne ujema s povabilom"
+  },
+  "api.organizations.invitations.errors.accept_already_member": {
+    "text": "Ste že član te organizacije"
+  },
+  "web.organizations.entitlements_title": {
+    "text": "Upravičenja organizacije"
+  },
+  "web.organizations.page_description_short": {
+    "text": "Ogled in konfiguracija vaših delovnih prostorov"
+  },
+  "web.organizations.delete_organization_remove_domains_first": {
+    "text": "Pred izbrisom te organizacije odstranite vse domene po meri."
+  },
+  "web.organizations.default_org_delete_notice_title": {
+    "text": "Brisanje te organizacije"
+  },
+  "web.organizations.default_org_delete_notice_before": {
+    "text": "To je vaša privzeta organizacija in je ni mogoče odstraniti z nadzorne plošče. Če jo želite izbrisati, se obrnite prek"
+  },
+  "web.organizations.default_org_delete_notice_link": {
+    "text": "obrazca za povratne informacije"
+  },
+  "web.organizations.default_org_delete_notice_after": {
+    "text": "."
+  },
+  "web.organizations.leave_organization": {
+    "text": "Zapusti to organizacijo"
+  },
+  "web.organizations.leave_organization_warning": {
+    "text": "Izgubili boste dostop do te organizacije in njenih virov."
+  },
+  "web.organizations.leave_organization_confirm_title": {
+    "text": "Zapusti organizacijo"
+  },
+  "web.organizations.leave_organization_confirm_message": {
+    "text": "Ali ste prepričani, da želite zapustiti {name}? Za ponovno pridružitev boste potrebovali novo povabilo."
+  },
+  "web.organizations.leave_organization_success": {
+    "text": "Zapustili ste organizacijo."
+  },
+  "web.organizations.leave_error": {
+    "text": "Organizacije ni bilo mogoče zapustiti"
+  },
+  "web.organizations.organizations": {
+    "text": "Organizacije"
+  },
+  "web.organizations.invitations.invited_by_inline": {
+    "text": "od {email}"
+  },
+  "web.organizations.invitations.invited_as_inline": {
+    "text": "kot {role}"
+  },
+  "web.organizations.invitations.back_to_home": {
+    "text": "Nazaj na domačo stran"
+  },
+  "web.organizations.invitations.email_locked_hint": {
+    "text": "To povabilo je bilo poslano na ta e-poštni naslov"
+  },
+  "web.organizations.invitations.signup_continue": {
+    "text": "Nadaljuj"
+  },
+  "web.organizations.invitations.signin_continue": {
+    "text": "Prijava"
+  },
+  "web.organizations.invitations.confirm_join_below": {
+    "text": "Skoraj končano — spodaj potrdite, da se pridružite organizaciji."
+  },
+  "web.organizations.invitations.go_to_organizations": {
+    "text": "Pojdi na Organizacije"
+  },
+  "web.organizations.invitations.already_member": {
+    "text": "Ste že član te organizacije"
+  },
+  "web.organizations.invitations.join_organization": {
+    "text": "Pridruži se {orgName}"
+  },
+  "web.organizations.invitations.sign_in_to_join": {
+    "text": "Prijavite se, da se pridružite {orgName}"
+  },
+  "web.organizations.invitations.decline": {
+    "text": "Zavrni"
+  },
+  "web.organizations.members.member_quota": {
+    "text": "{used} od {limit} članov"
+  },
+  "web.organizations.members.pending_suffix": {
+    "text": "({count} v obravnavi)"
+  },
+  "web.organizations.members.limit_reached_hint": {
+    "text": "Dosežena je omejitev števila članov."
+  },
+  "web.organizations.sso.title": {
+    "text": "Enotna prijava (SSO)"
+  },
+  "web.organizations.sso.description": {
+    "text": "Konfigurirajte SSO, da članom omogočite prijavo prek ponudnika identitete vaše organizacije"
+  },
+  "web.organizations.sso.provider_type": {
+    "text": "Vrsta ponudnika"
+  },
+  "web.organizations.sso.provider_type_description": {
+    "text": "Izberite ponudnika identitete vaše organizacije"
+  },
+  "web.organizations.sso.display_name": {
+    "text": "Prikazno ime"
+  },
+  "web.organizations.sso.display_name_hint": {
+    "text": "Prijazno ime, prikazano uporabnikom ob prijavi"
+  },
+  "web.organizations.sso.display_name_placeholder": {
+    "text": "npr. Acme Corp SSO"
+  },
+  "web.organizations.sso.client_id": {
+    "text": "ID odjemalca"
+  },
+  "web.organizations.sso.client_id_placeholder": {
+    "text": "Vaš ID odjemalca OAuth"
+  },
+  "web.organizations.sso.client_secret": {
+    "text": "Skrivni ključ odjemalca"
+  },
+  "web.organizations.sso.client_secret_placeholder": {
+    "text": "Vaš skrivni ključ odjemalca OAuth"
+  },
+  "web.organizations.sso.client_secret_update_hint": {
+    "text": "Pustite prazno, da obdržite obstoječi skrivni ključ"
+  },
+  "web.organizations.sso.tenant_id": {
+    "text": "ID najemnika"
+  },
+  "web.organizations.sso.tenant_id_hint": {
+    "text": "Identifikator najemnika Azure AD / Entra ID"
+  },
+  "web.organizations.sso.tenant_id_placeholder": {
+    "text": "npr. 12345678-1234-1234-1234-123456789abc"
+  },
+  "web.organizations.sso.issuer": {
+    "text": "Issuer URL"
+  },
+  "web.organizations.sso.issuer_hint": {
+    "text": "Odkrivni URL OIDC za vašega ponudnika identitete"
+  },
+  "web.organizations.sso.issuer_placeholder": {
+    "text": "npr. https://login.example.com"
+  },
+  "web.organizations.sso.view_discovery_document": {
+    "text": "Ogled odkrivnega dokumenta"
+  },
+  "web.organizations.sso.callback_url": {
+    "text": "Callback URL"
+  },
+  "web.organizations.sso.callback_url_hint": {
+    "text": "Dodajte ta URL med dovoljene preusmeritvene URI-je vašega ponudnika identitete"
+  },
+  "web.organizations.sso.allowed_domains": {
+    "text": "Dovoljene e-poštne domene"
+  },
+  "web.organizations.sso.allowed_domains_hint": {
+    "text": "Prijavijo se lahko samo uporabniki z e-poštnimi naslovi s teh domen. Pustite prazno, da dovolite vse domene."
+  },
+  "web.organizations.sso.domain_placeholder": {
+    "text": "npr. acme.com"
+  },
+  "web.organizations.sso.invalid_domain": {
+    "text": "Vnesite veljavno domeno (npr. example.com)"
+  },
+  "web.organizations.sso.domain_exists": {
+    "text": "Ta domena je že na seznamu"
+  },
+  "web.organizations.sso.remove_domain": {
+    "text": "Odstrani {domain}"
+  },
+  "web.organizations.sso.enabled": {
+    "text": "Omogoči SSO"
+  },
+  "web.organizations.sso.enabled_hint": {
+    "text": "Ko je omogočeno, se lahko člani organizacije prijavijo s tem ponudnikom SSO"
+  },
+  "web.organizations.sso.enforce_sso_only": {
+    "text": "Vsili samo SSO"
+  },
+  "web.organizations.sso.enforce_sso_only_hint": {
+    "text": "Zahtevajte SSO za vse prijave na tej domeni. Ko je omogočeno, je avtentikacija z geslom onemogočena."
+  },
+  "web.organizations.sso.grant_org_scope": {
+    "text": "Dodeli dostop za celotno organizacijo"
+  },
+  "web.organizations.sso.grant_org_scope_hint": {
+    "text": "Novi člani, ki se pridružijo prek SSO te domene, bodo dobili dostop do vseh domen organizacije. To ne vpliva na obstoječe člane. Ko je onemogočeno (privzeto), lahko novi člani dostopajo samo do te domene."
+  },
+  "web.organizations.sso.save_config": {
+    "text": "Shrani konfiguracijo SSO"
+  },
+  "web.organizations.sso.delete_config": {
+    "text": "Izbriši konfiguracijo"
+  },
+  "web.organizations.sso.delete_confirm": {
+    "text": "Ali ste prepričani? S tem boste onemogočili SSO za svojo organizacijo."
+  },
+  "web.organizations.sso.load_error": {
+    "text": "Konfiguracije SSO ni bilo mogoče naložiti"
+  },
+  "web.organizations.sso.save_error": {
+    "text": "Konfiguracije SSO ni bilo mogoče shraniti"
+  },
+  "web.organizations.sso.create_success": {
+    "text": "Konfiguracija SSO je bila uspešno ustvarjena"
+  },
+  "web.organizations.sso.update_success": {
+    "text": "Konfiguracija SSO je bila uspešno posodobljena"
+  },
+  "web.organizations.sso.delete_success": {
+    "text": "Konfiguracija SSO je bila uspešno izbrisana"
+  },
+  "web.organizations.sso.delete_error": {
+    "text": "Konfiguracije SSO ni bilo mogoče izbrisati"
+  },
+  "web.organizations.sso.test_connection": {
+    "text": "Preizkusi povezavo"
+  },
+  "web.organizations.sso.test_connection_hint": {
+    "text": "Preverite, ali je ponudnik identitete dosegljiv (ne preverja poverilnic)"
+  },
+  "web.organizations.sso.test_button": {
+    "text": "Preizkusi povezavo"
+  },
+  "web.organizations.sso.testing": {
+    "text": "Preizkušanje ..."
+  },
+  "web.organizations.sso.test_error": {
+    "text": "Povezave ni bilo mogoče preizkusiti"
+  },
+  "web.organizations.sso.auth_endpoint": {
+    "text": "Authorization Endpoint"
+  },
+  "web.organizations.sso.missing_fields": {
+    "text": "Manjkajoča polja"
+  },
+  "web.organizations.sso.status_enabled": {
+    "text": "Omogočeno"
+  },
+  "web.organizations.sso.status_configured": {
+    "text": "Konfigurirano"
+  },
+  "web.organizations.sso.domain_sso_title": {
+    "text": "SSO domene"
+  },
+  "web.organizations.sso.domain_sso_description": {
+    "text": "Konfigurirajte SSO za vsako preverjeno domeno"
+  },
+  "web.organizations.sso.provider_type_locked_hint": {
+    "text": "Če želite zamenjati ponudnika, najprej izbrišite to konfiguracijo"
+  },
+  "web.organizations.sso.status_not_configured": {
+    "text": "Ni konfigurirano"
+  },
+  "web.organizations.sso.no_domains": {
+    "text": "Ni preverjenih domen"
+  },
+  "web.organizations.sso.no_domains_description": {
+    "text": "Pred konfiguracijo SSO dodajte in preverite domeno."
+  },
+  "web.organizations.tabs.team": {
+    "text": "Ekipa"
+  },
+  "web.organizations.tabs.sso": {
+    "text": "SSO"
   }
 }


### PR DESCRIPTION
## `sl_SI` translation update

Automated export of completed **sl_SI** translations from the translation task DB.
Scope: `locales/content/sl_SI/` only — 27 file(s), +1848/-30.

✅ `i18n validate variables`: no variable mismatches.

---

### Local quality review

> Produced by a fresh, isolated `claude` review agent (model `claude-sonnet-5`, agent `saas-translator`) that read
> `locales/AGENT_TRANSLATION_PROTOCOL.md` and inspected this branch's diff before the PR was opened.

_Automated review did not complete (exit 124). Review this locale manually._

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
