### PR TITLE
i18n: update sv_SE translations

### DIFF
--- a/locales/content/sv_SE/00-common.json
+++ b/locales/content/sv_SE/00-common.json
@@ -1299,7 +1299,7 @@
     "source_hash": "fc78d9cb"
   },
   "web.INSTRUCTION.phishing_warning": {
-    "text": "Verifiera alltid att du är på den officiella {product_name}-webbplatsen. Bedragare skapar ibland falska webbplatser som ser exakt ut som {product_name} för att stjäla dina hemligheter. För att undvika nätfiskeattacker, kontrollera regiondomänen innan du skapar nya länkar.",
+    "text": "Verifiera alltid att du befinner dig på den officiella {product_name}-webbplatsen. Bedragare skapar ibland falska webbplatser som ser exakt ut som {product_name} för att stjäla dina hemligheter. Kontrollera regiondomänen innan du skapar nya länkar för att undvika nätfiskeattacker.",
     "source_hash": "b588f5b2"
   },
   "web.pricing.title": {
@@ -1383,5 +1383,110 @@
     "text": "Uppgradera för att låsa upp fler funktioner",
     "context": "Description shown for free plan users encouraging upgrade",
     "source_hash": "783f174c"
+  },
+  "api.errors.authentication_required": {
+    "text": "Autentisering krävs"
+  },
+  "api.errors.sso_only_action_blocked": {
+    "text": "Den här åtgärden är inte tillgänglig i läget med endast SSO"
+  },
+  "web.COMMON.configure": {
+    "text": "Konfigurera"
+  },
+  "web.COMMON.copy_to_clipboard": {
+    "text": "Kopiera till urklipp"
+  },
+  "web.COMMON.add": {
+    "text": "Lägg till"
+  },
+  "web.COMMON.enabled": {
+    "text": "Aktiverad"
+  },
+  "web.COMMON.disabled": {
+    "text": "Inaktiverad"
+  },
+  "web.COMMON.yes_delete": {
+    "text": "Ja, ta bort"
+  },
+  "web.COMMON.error_code": {
+    "text": "Felkod"
+  },
+  "web.COMMON.http_status": {
+    "text": "HTTP-status"
+  },
+  "web.COMMON.details": {
+    "text": "Detaljer"
+  },
+  "web.COMMON.field_confirm_password": {
+    "text": "Bekräfta lösenord"
+  },
+  "web.COMMON.passwords_must_match": {
+    "text": "Lösenorden måste matcha"
+  },
+  "web.COMMON.and": {
+    "text": "och"
+  },
+  "web.COMMON.or": {
+    "text": "eller"
+  },
+  "web.COMMON.copied": {
+    "text": "Kopierad"
+  },
+  "web.COMMON.copy": {
+    "text": "Kopiera"
+  },
+  "web.COMMON.copy_email": {
+    "text": "Kopiera e-postadress"
+  },
+  "web.COMMON.copy_id": {
+    "text": "Kopiera konto-ID"
+  },
+  "web.COMMON.org_id_tooltip": {
+    "text": "Din organisations unika identifierare"
+  },
+  "web.COMMON.success": {
+    "text": "Lyckades"
+  },
+  "web.COMMON.need_help": {
+    "text": "Behöver du hjälp"
+  },
+  "web.COMMON.open_help_dialog": {
+    "text": "Öppna hjälpdialogruta"
+  },
+  "web.COMMON.focus_is_now_in_the_main_text_area": {
+    "text": "Fokus är nu i huvudtextområdet"
+  },
+  "web.LABELS.show_passphrase": {
+    "text": "Visa lösenfras"
+  },
+  "web.LABELS.hide_passphrase": {
+    "text": "Dölj lösenfras"
+  },
+  "web.LABELS.copy_icon": {
+    "text": "Kopiera-ikon"
+  },
+  "web.LABELS.copied_icon": {
+    "text": "Kopierad-ikon"
+  },
+  "web.STATUS.unverified": {
+    "text": "Overifierad"
+  },
+  "web.TITLES.domain_detail": {
+    "text": "Domäninställningar"
+  },
+  "web.TITLES.domain_signin": {
+    "text": "Inloggningskonfiguration"
+  },
+  "web.TITLES.domain_sso": {
+    "text": "Domän-SSO"
+  },
+  "web.TITLES.domain_signup": {
+    "text": "Validering av domänregistrering"
+  },
+  "web.TITLES.domain_email": {
+    "text": "E-postkonfiguration"
+  },
+  "web.TITLES.domain_incoming": {
+    "text": "Inkommande hemligheter"
   }
 }

--- a/locales/content/sv_SE/10-layout.json
+++ b/locales/content/sv_SE/10-layout.json
@@ -148,7 +148,7 @@
     "source_hash": "b9766df3"
   },
   "web.help.secret_view_faq.what_am_i_looking_at.description": {
-    "text": "Du ser ett säkert meddelande som delades med dig via {product_name}. Detta innehåll visas endast en gång och raderas sedan permanent från våra servrar.",
+    "text": "Du tittar på ett säkert meddelande som har delats med dig via {product_name}. Det här innehållet visas endast en gång och raderas sedan permanent från våra servrar.",
     "source_hash": "e0f1a10c"
   },
   "web.help.secret_view_faq.can_i_view_again.title": {
@@ -338,5 +338,11 @@
   "web.layout.workspace_context": {
     "text": "Arbetsytekontext",
     "source_hash": "dc6fa4f5"
+  },
+  "web.footer.workspace": {
+    "text": "Arbetsyta"
+  },
+  "web.help.default_content": {
+    "text": "Kontakta supporten för hjälp"
   }
 }

--- a/locales/content/sv_SE/admin-colonel.json
+++ b/locales/content/sv_SE/admin-colonel.json
@@ -634,5 +634,152 @@
   "web.colonel.feedback.when_you_submit_feedback_well_see": {
     "text": "När du skickar återkoppling ser vi:",
     "source_hash": "fe77172e"
+  },
+  "web.colonel.previewPlanMode": {
+    "text": "Förhandsgranska planläge"
+  },
+  "web.colonel.previewModeDescription": {
+    "text": "Förhandsgranska applikationen så som den visas för kunder på en annan plan. Detta påverkar endast din vy och ändrar inte någon organisations faktiska plan."
+  },
+  "web.colonel.previewModeActive": {
+    "text": "Förhandsgranskning aktiv"
+  },
+  "web.colonel.bannedIps.empty": {
+    "text": "Inga blockerade IP-adresser"
+  },
+  "web.colonel.bannedIps.currentIp": {
+    "text": "Din aktuella IP-adress"
+  },
+  "web.colonel.bannedIps.confirmUnban": {
+    "text": "Ta bort blockering av {ip}?"
+  },
+  "web.colonel.bannedIps.actions.ban": {
+    "text": "Blockera IP"
+  },
+  "web.colonel.bannedIps.actions.quickBan": {
+    "text": "Snabblockering"
+  },
+  "web.colonel.bannedIps.actions.unban": {
+    "text": "Ta bort blockering"
+  },
+  "web.colonel.bannedIps.actions.cancel": {
+    "text": "Avbryt"
+  },
+  "web.colonel.bannedIps.columns.ipAddress": {
+    "text": "IP-adress"
+  },
+  "web.colonel.bannedIps.columns.reason": {
+    "text": "Orsak"
+  },
+  "web.colonel.bannedIps.columns.bannedAt": {
+    "text": "Blockerad den"
+  },
+  "web.colonel.bannedIps.columns.bannedBy": {
+    "text": "Blockerad av"
+  },
+  "web.colonel.bannedIps.error.banFailed": {
+    "text": "Det gick inte att blockera IP-adressen"
+  },
+  "web.colonel.bannedIps.error.unbanFailed": {
+    "text": "Det gick inte att ta bort blockeringen av IP-adressen"
+  },
+  "web.colonel.bannedIps.form.title": {
+    "text": "Blockera IP-adress"
+  },
+  "web.colonel.bannedIps.form.ipLabel": {
+    "text": "IP-adress"
+  },
+  "web.colonel.bannedIps.form.reasonLabel": {
+    "text": "Orsak"
+  },
+  "web.colonel.bannedIps.form.reasonPlaceholder": {
+    "text": "Valfri orsak"
+  },
+  "web.colonel.bannedIps.success.banned": {
+    "text": "IP-adressen {ip} har blockerats"
+  },
+  "web.colonel.bannedIps.success.unbanned": {
+    "text": "Blockeringen av IP-adressen {ip} har tagits bort"
+  },
+  "web.colonel.customDomains.empty": {
+    "text": "Inga anpassade domäner konfigurerade"
+  },
+  "web.colonel.customDomains.noLogo": {
+    "text": "Ingen logotyp"
+  },
+  "web.colonel.customDomains.labels.organization": {
+    "text": "Organisation"
+  },
+  "web.colonel.customDomains.labels.externalId": {
+    "text": "Externt ID"
+  },
+  "web.colonel.customDomains.labels.created": {
+    "text": "Skapad"
+  },
+  "web.colonel.customDomains.labels.updated": {
+    "text": "Uppdaterad"
+  },
+  "web.colonel.customDomains.labels.favicon": {
+    "text": "Favicon"
+  },
+  "web.colonel.customDomains.status.verified": {
+    "text": "Verifierad"
+  },
+  "web.colonel.customDomains.status.resolving": {
+    "text": "Slår upp"
+  },
+  "web.colonel.customDomains.status.ready": {
+    "text": "Redo"
+  },
+  "web.colonel.customDomains.status.publicHomepage": {
+    "text": "Offentlig startsida"
+  },
+  "web.colonel.customDomains.status.publicApi": {
+    "text": "Offentligt API"
+  },
+  "web.colonel.customDomains.status.pending": {
+    "text": "Väntar"
+  },
+  "web.colonel.pagination.showing": {
+    "text": "Visar {start}–{end} av {total}"
+  },
+  "web.colonel.pagination.itemsPerPage": {
+    "text": "Objekt per sida"
+  },
+  "web.colonel.pagination.perPage": {
+    "text": "{count} per sida"
+  },
+  "web.colonel.pagination.pageOf": {
+    "text": "Sida {current} av {total}"
+  },
+  "web.colonel.secrets.empty": {
+    "text": "Inga hemligheter hittades"
+  },
+  "web.colonel.secrets.never": {
+    "text": "Aldrig"
+  },
+  "web.colonel.secrets.columns.shortId": {
+    "text": "Kort ID"
+  },
+  "web.colonel.secrets.columns.state": {
+    "text": "Tillstånd"
+  },
+  "web.colonel.secrets.columns.created": {
+    "text": "Skapad"
+  },
+  "web.colonel.secrets.columns.expiration": {
+    "text": "Utgång"
+  },
+  "web.colonel.secrets.columns.age": {
+    "text": "Ålder (dagar)"
+  },
+  "web.colonel.secrets.state.new": {
+    "text": "Ny"
+  },
+  "web.colonel.secrets.state.received": {
+    "text": "Mottagen"
+  },
+  "web.colonel.secrets.state.viewed": {
+    "text": "Visad"
   }
 }

--- a/locales/content/sv_SE/api-account-errors.json
+++ b/locales/content/sv_SE/api-account-errors.json
@@ -1,0 +1,8 @@
+{
+  "api.account.errors.invalid_email": {
+    "text": "Är det en giltig e-postadress?"
+  },
+  "api.account.errors.password_too_short": {
+    "text": "Lösenordet är för kort"
+  }
+}

--- a/locales/content/sv_SE/api-domains-errors.json
+++ b/locales/content/sv_SE/api-domains-errors.json
@@ -1,0 +1,29 @@
+{
+  "api.domains.errors.domain_id_required": {
+    "text": "Domän-ID krävs"
+  },
+  "api.domains.errors.domain_not_found": {
+    "text": "Domänen hittades inte: %{extid}"
+  },
+  "api.domains.errors.organization_not_found": {
+    "text": "Ingen organisation hittades för domänen: %{domain}"
+  },
+  "api.domains.errors.incoming_secrets_disabled": {
+    "text": "Inkommande hemligheter är inte aktiverat på den här instansen"
+  },
+  "api.domains.errors.incoming_secrets_entitlement_required": {
+    "text": "Hantering av inkommande hemligheter kräver behörigheten incoming_secrets. Uppgradera din plan."
+  },
+  "api.domains.errors.incoming_config_not_found": {
+    "text": "Ingen konfiguration för inkommande hittades för domänen: %{extid}"
+  },
+  "api.domains.errors.recipients_max_exceeded": {
+    "text": "Högst %{max} mottagare tillåtna"
+  },
+  "api.domains.errors.recipients_invalid_email": {
+    "text": "Ogiltig e-postadress: %{email}"
+  },
+  "api.domains.errors.recipients_duplicate": {
+    "text": "Dubblerade mottagar-e-postadresser är inte tillåtna"
+  }
+}

--- a/locales/content/sv_SE/api-entitlements-errors.json
+++ b/locales/content/sv_SE/api-entitlements-errors.json
@@ -1,0 +1,71 @@
+{
+  "api.entitlements.errors.context_unavailable": {
+    "text": "Det går inte att verifiera behörigheter (organisationskontext ej tillgänglig)"
+  },
+  "api.entitlements.errors.api_access_required": {
+    "text": "API-åtkomst kräver en planuppgradering"
+  },
+  "api.entitlements.errors.custom_privacy_defaults_required": {
+    "text": "Anpassade integritetsstandarder kräver en planuppgradering"
+  },
+  "api.entitlements.errors.extended_default_expiration_required": {
+    "text": "Förlängd standardförfallotid kräver en planuppgradering"
+  },
+  "api.entitlements.errors.custom_domains_required": {
+    "text": "Anpassade domäner kräver en planuppgradering"
+  },
+  "api.entitlements.errors.custom_branding_required": {
+    "text": "Anpassad varumärkesprofilering kräver en planuppgradering"
+  },
+  "api.entitlements.errors.homepage_secrets_required": {
+    "text": "Hemligheter på startsidan kräver en planuppgradering"
+  },
+  "api.entitlements.errors.incoming_secrets_required": {
+    "text": "Inkommande hemligheter kräver en planuppgradering"
+  },
+  "api.entitlements.errors.custom_mail_sender_required": {
+    "text": "Anpassad e-postavsändare kräver en planuppgradering"
+  },
+  "api.entitlements.errors.flexible_from_domain_required": {
+    "text": "Flexibel från-domän kräver en planuppgradering"
+  },
+  "api.entitlements.errors.manage_org_required": {
+    "text": "Organisationshantering kräver en planuppgradering"
+  },
+  "api.entitlements.errors.manage_teams_required": {
+    "text": "Teamhantering kräver en planuppgradering"
+  },
+  "api.entitlements.errors.manage_members_required": {
+    "text": "Medlemshantering kräver en planuppgradering"
+  },
+  "api.entitlements.errors.manage_sso_required": {
+    "text": "SSO-hantering kräver en planuppgradering"
+  },
+  "api.entitlements.errors.audit_logs_required": {
+    "text": "Granskningsloggar kräver en planuppgradering"
+  },
+  "api.entitlements.errors.custom_signup_validation_required": {
+    "text": "Anpassad registreringsvalidering kräver en planuppgradering"
+  },
+  "api.entitlements.errors.create_secrets_required": {
+    "text": "Att skapa hemligheter kräver en planuppgradering"
+  },
+  "api.entitlements.errors.view_receipt_required": {
+    "text": "Att visa kvitton kräver en planuppgradering"
+  },
+  "api.entitlements.errors.notifications_required": {
+    "text": "Aviseringar kräver en planuppgradering"
+  },
+  "api.entitlements.errors.workspace_branding_required": {
+    "text": "Varumärkesprofilering för arbetsyta kräver en planuppgradering"
+  },
+  "api.entitlements.errors.ip_access_rules_required": {
+    "text": "IP-åtkomstregler kräver en planuppgradering"
+  },
+  "api.entitlements.errors.manage_billing_required": {
+    "text": "Faktureringshantering kräver en planuppgradering"
+  },
+  "api.entitlements.errors.custom_signin_config_required": {
+    "text": "Anpassad inloggningskonfiguration kräver en planuppgradering"
+  }
+}

--- a/locales/content/sv_SE/api-feedback-errors.json
+++ b/locales/content/sv_SE/api-feedback-errors.json
@@ -1,0 +1,5 @@
+{
+  "api.feedback.errors.rate_limit_exceeded": {
+    "text": "För många inskickade återkopplingar. Försök igen senare."
+  }
+}

--- a/locales/content/sv_SE/api-incoming-errors.json
+++ b/locales/content/sv_SE/api-incoming-errors.json
@@ -1,0 +1,5 @@
+{
+  "api.incoming.errors.custom_domain_unresolved": {
+    "text": "Organisationen för den anpassade domänen kunde inte fastställas"
+  }
+}

--- a/locales/content/sv_SE/api-invite-errors.json
+++ b/locales/content/sv_SE/api-invite-errors.json
@@ -1,0 +1,23 @@
+{
+  "api.invite.errors.invitation_not_found_or_expired": {
+    "text": "Inbjudan hittades inte eller har gått ut"
+  },
+  "api.invite.errors.token_required": {
+    "text": "Token krävs"
+  },
+  "api.invite.errors.organization_no_longer_exists": {
+    "text": "Organisationen finns inte längre"
+  },
+  "api.invite.errors.invitation_already_processed": {
+    "text": "Inbjudan har redan %{status}"
+  },
+  "api.invite.errors.invitation_expired": {
+    "text": "Inbjudan har gått ut"
+  },
+  "api.invite.errors.email_mismatch": {
+    "text": "Din e-postadress matchar inte inbjudan"
+  },
+  "api.invite.errors.already_member": {
+    "text": "Du är redan medlem i den här organisationen"
+  }
+}

--- a/locales/content/sv_SE/api-organizations-errors.json
+++ b/locales/content/sv_SE/api-organizations-errors.json
@@ -1,0 +1,107 @@
+{
+  "api.organizations.errors.domain_scoped_forbidden": {
+    "text": "Domänbegränsade medlemmar kan inte utföra den här åtgärden"
+  },
+  "api.organizations.errors.organization_not_found": {
+    "text": "Organisationen hittades inte: %{extid}"
+  },
+  "api.organizations.errors.organization_owner_required": {
+    "text": "Endast organisationens ägare kan utföra den här åtgärden"
+  },
+  "api.organizations.errors.organization_member_required": {
+    "text": "Du måste vara medlem i organisationen för att utföra den här åtgärden"
+  },
+  "api.organizations.errors.organization_admin_required": {
+    "text": "Endast organisationens ägare och administratörer kan utföra den här åtgärden"
+  },
+  "api.organizations.errors.extid_required": {
+    "text": "Organisations-ID krävs"
+  },
+  "api.organizations.errors.display_name_required": {
+    "text": "Organisationsnamn krävs"
+  },
+  "api.organizations.errors.display_name_too_long": {
+    "text": "Organisationsnamnet får vara högst %{max} tecken"
+  },
+  "api.organizations.errors.description_too_long": {
+    "text": "Beskrivningen får vara högst %{max} tecken"
+  },
+  "api.organizations.errors.contact_email_exists": {
+    "text": "En organisation med denna kontakt-e-postadress finns redan"
+  },
+  "api.organizations.errors.creation_in_progress": {
+    "text": "Skapande av organisation pågår. Försök igen."
+  },
+  "api.organizations.errors.organization_limit_reached": {
+    "text": "Organisationsgränsen har nåtts. Uppgradera din plan för att skapa fler organisationer."
+  },
+  "api.organizations.invitations.errors.invitation_not_found": {
+    "text": "Inbjudan hittades inte"
+  },
+  "api.organizations.invitations.errors.email_required": {
+    "text": "E-postadress krävs"
+  },
+  "api.organizations.invitations.errors.invalid_email_format": {
+    "text": "Ogiltigt e-postformat"
+  },
+  "api.organizations.invitations.errors.invalid_role": {
+    "text": "Rollen måste vara medlem eller administratör"
+  },
+  "api.organizations.invitations.errors.cannot_invite_as_owner": {
+    "text": "Det går inte att bjuda in som ägare"
+  },
+  "api.organizations.invitations.errors.user_already_member": {
+    "text": "Användaren är redan medlem i den här organisationen"
+  },
+  "api.organizations.invitations.errors.invitation_already_pending": {
+    "text": "En inbjudan väntar redan för den här e-postadressen"
+  },
+  "api.organizations.invitations.errors.member_limit_reached": {
+    "text": "Medlemsgränsen har nåtts. Uppgradera din plan för att bjuda in fler medlemmar."
+  },
+  "api.organizations.invitations.errors.resend_only_pending": {
+    "text": "Endast väntande inbjudningar kan skickas igen"
+  },
+  "api.organizations.invitations.errors.resend_limit_reached": {
+    "text": "Maxgränsen för att skicka igen (%{max}) har nåtts"
+  },
+  "api.organizations.invitations.errors.revoke_only_pending": {
+    "text": "Endast väntande inbjudningar kan återkallas"
+  },
+  "api.organizations.members.errors.member_not_found": {
+    "text": "Medlemmen hittades inte: %{extid}"
+  },
+  "api.organizations.members.errors.member_not_in_organization": {
+    "text": "Medlemmen hittades inte i den här organisationen"
+  },
+  "api.organizations.members.errors.member_not_active": {
+    "text": "Medlemmen är inte aktiv"
+  },
+  "api.organizations.members.errors.invalid_role_value": {
+    "text": "Ogiltig roll. Måste vara en av: %{roles}"
+  },
+  "api.organizations.members.errors.cannot_change_owner_role": {
+    "text": "Det går inte att ändra ägarrollen. Använd ägarskapsöverföring i stället."
+  },
+  "api.organizations.members.errors.member_already_has_role": {
+    "text": "Medlemmen har redan rollen: %{role}"
+  },
+  "api.organizations.members.errors.cannot_promote_to_owner": {
+    "text": "Det går inte att befordra till ägare. Använd ägarskapsöverföring i stället."
+  },
+  "api.organizations.members.errors.must_be_member": {
+    "text": "Du måste vara medlem i den här organisationen"
+  },
+  "api.organizations.members.errors.cannot_remove_owner": {
+    "text": "Det går inte att ta bort organisationens ägare. Överför ägarskapet först."
+  },
+  "api.organizations.members.errors.cannot_remove_self": {
+    "text": "Du kan inte ta bort dig själv. Använd lämna organisation i stället."
+  },
+  "api.organizations.members.errors.admin_cannot_remove_admin": {
+    "text": "Administratörer kan inte ta bort andra administratörer. Endast ägare kan."
+  },
+  "api.organizations.members.errors.no_permission_to_remove": {
+    "text": "Du har inte behörighet att ta bort medlemmar"
+  }
+}

--- a/locales/content/sv_SE/api-secrets-errors.json
+++ b/locales/content/sv_SE/api-secrets-errors.json
@@ -1,0 +1,11 @@
+{
+  "api.secrets.errors.domain_permission_authenticated_non_owner": {
+    "text": "Du har inte behörighet att använda domänen: %{domain}"
+  },
+  "api.secrets.errors.domain_public_sharing_disabled": {
+    "text": "Offentlig delning är inaktiverad för domänen: %{domain}"
+  },
+  "api.secrets.errors.domain_permission_anonymous_cross_domain": {
+    "text": "Du har inte behörighet att använda domänen: %{domain}"
+  }
+}

--- a/locales/content/sv_SE/email.json
+++ b/locales/content/sv_SE/email.json
@@ -315,7 +315,7 @@
     "source_hash": "f5394f72"
   },
   "email.feedback_email.signature": {
-    "text": "Secret Support",
+    "text": "Hemlig Support",
     "renderer": "erb",
     "source_hash": "f6a6c90f"
   },

--- a/locales/content/sv_SE/email.json
+++ b/locales/content/sv_SE/email.json
@@ -60,7 +60,7 @@
     "source_hash": "88c72144"
   },
   "email.welcome.signature": {
-    "text": "Delano",
+    "text": "Supportteamet",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -100,7 +100,7 @@
     "source_hash": "fbb7eb2d"
   },
   "email.password_request.signature": {
-    "text": "Delano",
+    "text": "Supportteamet",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -145,7 +145,7 @@
     "source_hash": "1863f5be"
   },
   "email.magic_link.signature": {
-    "text": "Delano",
+    "text": "Supportteamet",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -230,7 +230,7 @@
     "source_hash": "3f6b45dd"
   },
   "email.secret_revealed.signature": {
-    "text": "Delano",
+    "text": "Supportteamet",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -355,7 +355,7 @@
     "source_hash": "734882d2"
   },
   "email.organization_invitation.signature": {
-    "text": "Delano",
+    "text": "Supportteamet",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -395,7 +395,7 @@
     "source_hash": "be92cff3"
   },
   "email.password_changed.signature": {
-    "text": "Delano",
+    "text": "Supportteamet",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -445,7 +445,7 @@
     "source_hash": "f8d47b82"
   },
   "email.email_changed.signature": {
-    "text": "Delano",
+    "text": "Supportteamet",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -495,7 +495,7 @@
     "source_hash": "f8d47b82"
   },
   "email.email_change_requested.signature": {
-    "text": "Delano",
+    "text": "Supportteamet",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -550,7 +550,7 @@
     "source_hash": "d4d835fc"
   },
   "email.email_change_confirmation.signature": {
-    "text": "Delano",
+    "text": "Supportteamet",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -580,7 +580,7 @@
     "source_hash": "e7c11bb0"
   },
   "email.mfa_enabled.signature": {
-    "text": "Delano",
+    "text": "Supportteamet",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -605,7 +605,7 @@
     "source_hash": "97ef0a3e"
   },
   "email.mfa_disabled.signature": {
-    "text": "Delano",
+    "text": "Supportteamet",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -650,7 +650,7 @@
     "source_hash": "450c54c5"
   },
   "email.new_login_alert.signature": {
-    "text": "Delano",
+    "text": "Supportteamet",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -670,7 +670,7 @@
     "source_hash": "d442beed"
   },
   "email.member_removed.signature": {
-    "text": "Delano",
+    "text": "Supportteamet",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -690,7 +690,7 @@
     "source_hash": "c2280c0c"
   },
   "email.role_changed.signature": {
-    "text": "Delano",
+    "text": "Supportteamet",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -710,7 +710,7 @@
     "source_hash": "7095fc69"
   },
   "email.organization_deleted.signature": {
-    "text": "Delano",
+    "text": "Supportteamet",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -750,7 +750,7 @@
     "source_hash": "36008943"
   },
   "email.payment_receipt.signature": {
-    "text": "Delano",
+    "text": "Supportteamet",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -775,7 +775,7 @@
     "source_hash": "926406b1"
   },
   "email.payment_failed.signature": {
-    "text": "Delano",
+    "text": "Supportteamet",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -800,7 +800,7 @@
     "source_hash": "66a1419e"
   },
   "email.trial_expiring.signature": {
-    "text": "Delano",
+    "text": "Supportteamet",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -825,7 +825,7 @@
     "source_hash": "5a96ae38"
   },
   "email.subscription_changed.signature": {
-    "text": "Delano",
+    "text": "Supportteamet",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -853,5 +853,41 @@
     "text": "Onetime Secret",
     "renderer": "erb",
     "source_hash": "1cd0194a"
+  },
+  "email.common.secret_link_label": {
+    "text": "Hemlighetslänk"
+  },
+  "email.common.automated_notice": {
+    "text": "Det här är ett automatiserat meddelande från %{product_name}."
+  },
+  "email.common.support_label": {
+    "text": "Support"
+  },
+  "email.expiration_warning.signature": {
+    "text": "Supportteamet"
+  },
+  "email.expiration_warning.footer_note": {
+    "text": "Du fick det här eftersom en hemlighet du skapade på %{product_name} snart går ut."
+  },
+  "email.feedback_email.user_id_label": {
+    "text": "Användare:"
+  },
+  "email.feedback_email.timezone_label": {
+    "text": "Tidszon:"
+  },
+  "email.feedback_email.version_label": {
+    "text": "Version:"
+  },
+  "email.incoming_secret.footer_note": {
+    "text": "Du fick det här eftersom någon använde %{product_name} för att skicka en hemlighet till dig. Om du inte väntade dig det kan du tryggt ignorera det här e-postmeddelandet."
+  },
+  "email.secret_link.passphrase_label": {
+    "text": "Lösenfras krävs:"
+  },
+  "email.secret_link.passphrase_required": {
+    "text": "Den här hemligheten är skyddad med en lösenfras. Avsändaren bör förmedla den till dig separat."
+  },
+  "email.secret_link.footer_note": {
+    "text": "Du fick det här eftersom %{sender_email} använde %{product_name} för att dela en hemlighet med dig. Om du inte väntade dig det kan du tryggt ignorera det här e-postmeddelandet."
   }
 }

--- a/locales/content/sv_SE/feature-feedback.json
+++ b/locales/content/sv_SE/feature-feedback.json
@@ -58,5 +58,14 @@
   "web.feedback.reason_email_change_unauthorized": {
     "text": "Det verkar som att du rapporterar en obehörig e-poständring på ditt konto. Beskriv vad som hände så utreder vi det omedelbart.",
     "source_hash": "00e56551"
+  },
+  "web.feedback.anonymous_no_reply": {
+    "text": "Obs! Om du vill ha ett svar, signera eller ange en e-postadress i meddelandet."
+  },
+  "web.feedback.characters_remaining": {
+    "text": "{count} tecken kvar"
+  },
+  "web.feedback.character_limit_reached": {
+    "text": "Teckengränsen har nåtts"
   }
 }

--- a/locales/content/sv_SE/feature-homepage-secrets.json
+++ b/locales/content/sv_SE/feature-homepage-secrets.json
@@ -1,0 +1,50 @@
+{
+  "homepage_secrets.disabled.members_only_eyebrow": {
+    "text": "Instans endast för medlemmar"
+  },
+  "homepage_secrets.disabled.private_instance_eyebrow": {
+    "text": "Privat instans"
+  },
+  "homepage_secrets.disabled.team_link_headline": {
+    "text": "Den här länken är för teamet {workspace}."
+  },
+  "homepage_secrets.disabled.signin_headline": {
+    "text": "Logga in för att skapa en {action}."
+  },
+  "homepage_secrets.disabled.signin_headline_action": {
+    "text": "hemlighetslänk"
+  },
+  "homepage_secrets.disabled.team_subtitle": {
+    "text": "Endast behöriga teammedlemmar på {domain} kan skapa nya engångslänkar här. Mottagare kan fortfarande öppna alla länkar de fått."
+  },
+  "homepage_secrets.disabled.public_subtitle": {
+    "text": "Endast behöriga medlemmar på den här instansen kan skapa nya engångslänkar. Mottagare kan fortfarande öppna alla länkar de fått."
+  },
+  "homepage_secrets.disabled.signin_cta": {
+    "text": "Logga in på ditt konto"
+  },
+  "homepage_secrets.disabled.what_is_this": {
+    "text": "Vad är det här?"
+  },
+  "homepage_secrets.disabled.trust_viewed_once": {
+    "text": "Visas en gång, sedan borta"
+  },
+  "homepage_secrets.disabled.trust_zero_retained": {
+    "text": "Inget sparas"
+  },
+  "homepage_secrets.disabled.promo_title": {
+    "text": "Nytt: gratisplaner inkluderar nu anpassade domäner."
+  },
+  "homepage_secrets.disabled.promo_subtitle": {
+    "text": "Peka din domän mot Onetime Secret och skicka hemligheter under ditt eget varumärke."
+  },
+  "homepage_secrets.disabled.promo_learn_how": {
+    "text": "Läs hur"
+  },
+  "homepage_secrets.disabled.logo_alt": {
+    "text": "{name}-logotyp"
+  },
+  "homepage_secrets.disabled.opens_in_new_tab": {
+    "text": "(öppnas i en ny flik)"
+  }
+}

--- a/locales/content/sv_SE/feature-incoming.json
+++ b/locales/content/sv_SE/feature-incoming.json
@@ -130,5 +130,26 @@
   "incoming.receipt_link_text": {
     "text": "kvitto",
     "source_hash": "6f328609"
+  },
+  "incoming.upgrade_required_title": {
+    "text": "Uppgradering krävs"
+  },
+  "incoming.upgrade_required_description": {
+    "text": "Den här funktionen kräver en planuppgradering. Kontakta kontots ägare för att aktivera inkommande hemligheter."
+  },
+  "incoming.validation_memo_too_long": {
+    "text": "Notisen får vara högst {max} tecken"
+  },
+  "incoming.validation_secret_required": {
+    "text": "Hemlighetens innehåll krävs"
+  },
+  "incoming.validation_recipient_required": {
+    "text": "Välj en mottagare"
+  },
+  "incoming.validation_feature_disabled": {
+    "text": "Funktionen inkommande hemligheter är inte aktiverad"
+  },
+  "incoming.validation_form_errors": {
+    "text": "Kontrollera formuläret för fel"
   }
 }

--- a/locales/content/sv_SE/feature-regions.json
+++ b/locales/content/sv_SE/feature-regions.json
@@ -186,5 +186,8 @@
   "web.regions.jurisdictions.apac.name": {
     "text": "Asia-Pacific",
     "source_hash": "7a757670"
+  },
+  "web.regions.no_region_configured": {
+    "text": "Ingen regioninformation är för närvarande tillgänglig för ditt konto."
   }
 }

--- a/locales/content/sv_SE/feature-translations.json
+++ b/locales/content/sv_SE/feature-translations.json
@@ -84,7 +84,7 @@
     "source_hash": "ba5c4395"
   },
   "web.translations.since_2012_onetime_secret_has_provided_a_secure_": {
-    "text": "Sedan 2012 har {product_name} tillhandahållit ett säkert sätt att dela känslig information världen över. Med användare i regioner där engelska inte är huvudspråket är korrekta översättningar avgörande för att göra säker kommunikation tillgänglig för alla.",
+    "text": "Sedan 2012 har {product_name} erbjudit ett säkert sätt att dela känslig information över hela världen. Med användare i regioner där engelska inte är det primära språket är korrekta översättningar avgörande för att göra säker kommunikation tillgänglig för alla.",
     "source_hash": "87a6e9af"
   },
   "web.translations.help_secure_communication_go_global": {

--- a/locales/content/sv_SE/secret-homepage.json
+++ b/locales/content/sv_SE/secret-homepage.json
@@ -144,11 +144,11 @@
     "source_hash": "1cd0194a"
   },
   "web.homepage.one_time_secret_literal": {
-    "text": "Engångshemlighet",
+    "text": "{product_name}",
     "source_hash": "7872e050"
   },
   "web.homepage.onetime_secret_homepage": {
-    "text": "{product_name} startsida",
+    "text": "{product_name} – Startsida",
     "source_hash": "44bb0581"
   },
   "web.homepage.send_sensitive_information_that_can_only_be_viewed_once": {
@@ -172,7 +172,7 @@
     "source_hash": "0990d163"
   },
   "web.homepage.onetime_secret_helps_us_share_sensitive_informat": {
-    "text": "{product_name} hjälper oss att dela känslig information säkert samtidigt som vi bibehåller vår professionella fasad.",
+    "text": "{product_name} hjälper oss att dela känslig information säkert samtidigt som vi behåller vår professionella fasad.",
     "source_hash": "986a0856"
   },
   "web.homepage.information_shared_through_this_service_can_only": {

--- a/locales/content/sv_SE/secret-manage.json
+++ b/locales/content/sv_SE/secret-manage.json
@@ -128,7 +128,7 @@
     "source_hash": "07fe1b84"
   },
   "web.secrets.onetime_secret_is_a_secure_way_to_share_sensitiv": {
-    "text": "{product_name} är ett säkert sätt att dela känslig information som självförstörs efter en enda visning.",
+    "text": "{product_name} är ett säkert sätt att dela känslig information som förstörs automatiskt efter en enda visning.",
     "source_hash": "8a163297"
   },
   "web.secrets.what_is_this": {
@@ -398,5 +398,11 @@
   "web.secrets.errors.access_denied_to_domain": {
     "text": "Åtkomst nekad till domän",
     "source_hash": "cd441eea"
+  },
+  "web.receipt.open_link": {
+    "text": "Öppna länk"
+  },
+  "web.secrets.messageDeleted": {
+    "text": "Meddelande raderat"
   }
 }

--- a/locales/content/sv_SE/session-auth-extended.json
+++ b/locales/content/sv_SE/session-auth-extended.json
@@ -710,5 +710,26 @@
   "web.auth.recovery_codes.link_title": {
     "text": "Återställningskoder",
     "source_hash": "579c7f4e"
+  },
+  "web.auth.google": {
+    "text": "Google"
+  },
+  "web.auth.mfa.alternative_auth_options": {
+    "text": "Andra autentiseringsalternativ"
+  },
+  "web.auth.remember.enabled": {
+    "text": "Förbli inloggad"
+  },
+  "web.auth.security._guidance.context": {
+    "text": "⚠️ SECURITY-CRITICAL: Messages prevent information disclosure. See src/locales/SECURITY-TRANSLATION-GUIDE.md"
+  },
+  "web.auth.sessions.session_singular": {
+    "text": "session"
+  },
+  "web.auth.sessions.session_plural": {
+    "text": "sessioner"
+  },
+  "web.auth.sessions._guidance.context": {
+    "text": "User's logged-in devices/browsers management page"
   }
 }

--- a/locales/content/sv_SE/session-auth.json
+++ b/locales/content/sv_SE/session-auth.json
@@ -399,9 +399,6 @@
   "web.auth.account.sso_linked": {
     "text": "SSO-konto"
   },
-  "web.auth.verify._guidance.context": {
-    "text": "Email verification flow after signup"
-  },
   "web.help.reset_password_link": {
     "text": "Återställ lösenord"
   },

--- a/locales/content/sv_SE/session-auth.json
+++ b/locales/content/sv_SE/session-auth.json
@@ -395,5 +395,35 @@
   "web.help.contact_support": {
     "text": "Kontakta support",
     "source_hash": "f8d47b82"
+  },
+  "web.auth.account.sso_linked": {
+    "text": "SSO-konto"
+  },
+  "web.auth.verify._guidance.context": {
+    "text": "Email verification flow after signup"
+  },
+  "web.help.reset_password_link": {
+    "text": "Återställ lösenord"
+  },
+  "web.login.custom_domain_sso_title": {
+    "text": "Single sign-on är tillgängligt för den här domänen"
+  },
+  "web.login.custom_domain_sso_description": {
+    "text": "Organisationsadministratören kan aktivera SSO så att teammedlemmar kan logga in här. Kontakta administratören för åtkomst."
+  },
+  "web.login.signin_disabled_heading": {
+    "text": "Inloggning är inte tillgänglig"
+  },
+  "web.login.signin_disabled_message": {
+    "text": "Inloggning är för närvarande inte tillgänglig på den här domänen."
+  },
+  "web.login.errors.sso_not_configured": {
+    "text": "Single sign-on är inte konfigurerat för den här domänen. Kontakta din administratör."
+  },
+  "web.login.errors.invalid_email": {
+    "text": "E-postadressen från din identitetsleverantör är ogiltig. Kontakta din administratör."
+  },
+  "web.login.errors.domain_not_allowed": {
+    "text": "Din e-postdomän är inte behörig för SSO-registrering. Kontakta din administratör."
   }
 }

--- a/locales/content/sv_SE/workspace-account.json
+++ b/locales/content/sv_SE/workspace-account.json
@@ -476,7 +476,7 @@
     "source_hash": "1cc77e60"
   },
   "web.settings.api.documentation_description": {
-    "text": "Lär dig integrera {product_name} i dina applikationer",
+    "text": "Lär dig hur du integrerar {product_name} i dina applikationer",
     "source_hash": "6e8f910f"
   },
   "web.settings.api.rest_api_reference": {
@@ -682,5 +682,14 @@
   "web.settings.profile.didnt_receive_email": {
     "text": "Fick du inte e-postmeddelandet?",
     "source_hash": "fe3ac3ad"
+  },
+  "web.settings.api.api_disabled_notice": {
+    "text": "API:et är inaktiverat för den här instansen."
+  },
+  "web.settings.security.sso_managed_title": {
+    "text": "Säkerhet hanteras av SSO"
+  },
+  "web.settings.security.sso_managed_description": {
+    "text": "Ditt konto autentiseras via din organisations single sign-on-leverantör. Lösenord, flerfaktorsautentisering och återställningskoder hanteras av din identitetsleverantör."
   }
 }

--- a/locales/content/sv_SE/workspace-billing.json
+++ b/locales/content/sv_SE/workspace-billing.json
@@ -988,5 +988,47 @@
     "text": "Tillgänglig endast i din ursprungliga prenumerationsregion",
     "context": "Hint shown on plan cards when currency does not match active subscription",
     "source_hash": "10de32e5"
+  },
+  "web.billing.already_subscribed": {
+    "text": "Du prenumererar redan på den här planen."
+  },
+  "web.billing.cancel.reactivate_button": {
+    "text": "Återaktivera prenumeration"
+  },
+  "web.billing.cancel.reactivate_success": {
+    "text": "Din prenumeration har återaktiverats. Du kommer att faktureras som vanligt."
+  },
+  "web.billing.cancel.reactivate_error": {
+    "text": "Det gick inte att återaktivera prenumerationen. Försök igen eller kontakta supporten."
+  },
+  "web.billing.features.manage_orgs": {
+    "text": "Organisationshantering"
+  },
+  "web.billing.features.flexible_from_domain": {
+    "text": "Flexibel avsändardomän för e-post"
+  },
+  "web.billing.features.unlimited_admins": {
+    "text": "Obegränsat antal administratörer"
+  },
+  "web.billing.features.manage_sso": {
+    "text": "SSO"
+  },
+  "web.billing.overview.entitlements.flexible_from_domain": {
+    "text": "Flexibel avsändardomän för e-post"
+  },
+  "web.billing.overview.entitlements.manage_orgs": {
+    "text": "Hantera organisationer"
+  },
+  "web.billing.overview.entitlements.manage_sso": {
+    "text": "Enkel inloggning (SSO)"
+  },
+  "web.billing.overview.entitlements.manage_billing": {
+    "text": "Hantera fakturering"
+  },
+  "web.billing.overview.entitlements.custom_signup_validation": {
+    "text": "Anpassad registreringsvalidering"
+  },
+  "web.billing.plans.reactivate": {
+    "text": "Återaktivera"
   }
 }

--- a/locales/content/sv_SE/workspace-branding.json
+++ b/locales/content/sv_SE/workspace-branding.json
@@ -178,5 +178,11 @@
   "web.branding.upgrade_to_customize": {
     "text": "Uppgradera din plan för att anpassa varumärkesprofilen för denna domän.",
     "source_hash": "9077bf79"
+  },
+  "web.branding.saved_successfully": {
+    "text": "Varumärkesinställningarna har sparats"
+  },
+  "web.branding.keyhole_logo_icon": {
+    "text": "Nyckelhålsikon som representerar säker, privat delning"
   }
 }

--- a/locales/content/sv_SE/workspace-dashboard.json
+++ b/locales/content/sv_SE/workspace-dashboard.json
@@ -22,5 +22,14 @@
   "web.dashboard.fetch_error_description": {
     "text": "Det uppstod ett problem vid laddning av din data. Försök igen.",
     "source_hash": "ff0d904e"
+  },
+  "web.teams.create_first_team_title": {
+    "text": "Skapa ditt första team"
+  },
+  "web.teams.create_first_team_description": {
+    "text": "Med team kan du samarbeta med andra i en delad arbetsyta."
+  },
+  "web.teams.create_team": {
+    "text": "Skapa team"
   }
 }

--- a/locales/content/sv_SE/workspace-domains.json
+++ b/locales/content/sv_SE/workspace-domains.json
@@ -398,5 +398,725 @@
   "web.domains.dns_widget_description": {
     "text": "Använd verktyget nedan för att automatiskt upptäcka din DNS-leverantör och få steg-för-steg-instruktioner för att konfigurera din domän.",
     "source_hash": "91c1af2e"
+  },
+  "api.domains.errors.add_admin_required": {
+    "text": "Endast organisationsägare och administratörer kan lägga till anpassade domäner"
+  },
+  "web.domains.public_homepage": {
+    "text": "Offentlig startsida"
+  },
+  "web.domains.status_tooltip_active": {
+    "text": "Domänen verifierad och aktiv"
+  },
+  "web.domains.status_tooltip_dns_incorrect": {
+    "text": "DNS inte konfigurerat – klicka för att åtgärda"
+  },
+  "web.domains.status_tooltip_not_verified": {
+    "text": "Domänen inte verifierad – klicka för att verifiera"
+  },
+  "web.domains.status_tooltip_unverified": {
+    "text": "Domänstatus overifierad – klicka för att uppdatera"
+  },
+  "web.domains.last_check_failed": {
+    "text": "Den senaste verifieringskontrollen misslyckades"
+  },
+  "web.domains.last_check_failed_ago": {
+    "text": "senaste kontrollen misslyckades {0}"
+  },
+  "web.domains.verify_now": {
+    "text": "Verifiera nu"
+  },
+  "web.domains.click_to_verify": {
+    "text": "klicka för att verifiera"
+  },
+  "web.domains.remove_domain_description": {
+    "text": "Ta bort den här domänen och hela dess konfiguration permanent."
+  },
+  "web.domains.add_access_denied": {
+    "text": "Åtkomst nekad"
+  },
+  "web.domains.add_access_denied_description": {
+    "text": "Du har inte behörighet att lägga till domäner i den här organisationen. Kontakta din organisationsadministratör."
+  },
+  "web.domains.dns_widget_load_failed": {
+    "text": "Det gick inte att läsa in DNS-widgeten"
+  },
+  "web.domains.dns_widget_not_available": {
+    "text": "DNS-widgeten är inte tillgänglig"
+  },
+  "web.domains.dns_widget_init_failed": {
+    "text": "Det gick inte att initiera DNS-widgeten"
+  },
+  "web.domains.verified": {
+    "text": "Verifierad"
+  },
+  "web.domains.pending_verification": {
+    "text": "Väntar på verifiering"
+  },
+  "web.domains.unsaved_changes_confirmation": {
+    "text": "Du har osparade ändringar. Är du säker på att du vill lämna sidan?"
+  },
+  "web.domains.entitlement_required_owner": {
+    "text": "Den här funktionen kräver en uppgradering av planen."
+  },
+  "web.domains.entitlement_required_member": {
+    "text": "Den här funktionen är inte tillgänglig i din nuvarande plan. Kontakta din organisationsägare."
+  },
+  "web.domains.detail.manage": {
+    "text": "Hantera"
+  },
+  "web.domains.detail.features": {
+    "text": "Funktioner"
+  },
+  "web.domains.detail.homepage_title": {
+    "text": "Hemligheter på startsidan"
+  },
+  "web.domains.detail.homepage_description": {
+    "text": "Tillåt offentlig åtkomst för att skapa hemligheter på din domäns startsida"
+  },
+  "web.domains.detail.brand_description": {
+    "text": "Logotyp, färger och anpassad varumärkesprofilering"
+  },
+  "web.domains.detail.sso_description": {
+    "text": "Inställningar för single sign-on-leverantör"
+  },
+  "web.domains.detail.email_description": {
+    "text": "Konfiguration av anpassad e-postavsändare"
+  },
+  "web.domains.detail.incoming_description": {
+    "text": "Inställningar för mottagare av inkommande hemligheter"
+  },
+  "web.domains.detail.signup_description": {
+    "text": "Strategi för registreringsvalidering per domän"
+  },
+  "web.domains.detail.signin_description": {
+    "text": "Konfiguration av inloggningsmetod per domän"
+  },
+  "web.domains.email.title": {
+    "text": "E-postutskick"
+  },
+  "web.domains.email.config_title": {
+    "text": "E-postkonfiguration"
+  },
+  "web.domains.email.config_description": {
+    "text": "Konfigurera e-postutskick för den här domänen"
+  },
+  "web.domains.email.provider_label": {
+    "text": "E-postleverantör"
+  },
+  "web.domains.email.provider_placeholder": {
+    "text": "Välj en e-postleverantör"
+  },
+  "web.domains.email.from_name_label": {
+    "text": "Från-namn"
+  },
+  "web.domains.email.from_name_placeholder": {
+    "text": "t.ex. Acme Security"
+  },
+  "web.domains.email.from_address_label": {
+    "text": "Från-adress"
+  },
+  "web.domains.email.from_address_placeholder": {
+    "text": "t.ex. secrets{'@'}example.com"
+  },
+  "web.domains.email.reply_to_label": {
+    "text": "Reply-To-adress"
+  },
+  "web.domains.email.reply_to_placeholder": {
+    "text": "t.ex. support{'@'}example.com"
+  },
+  "web.domains.email.save_changes": {
+    "text": "Spara ändringar"
+  },
+  "web.domains.email.discard_changes": {
+    "text": "Ångra ändringar"
+  },
+  "web.domains.email.provider_ses": {
+    "text": "Amazon SES"
+  },
+  "web.domains.email.provider_sendgrid": {
+    "text": "SendGrid"
+  },
+  "web.domains.email.provider_lettermint": {
+    "text": "Lettermint"
+  },
+  "web.domains.email.provider_inherit": {
+    "text": "Använd kontots standardinställningar"
+  },
+  "web.domains.email.provider_ses_description": {
+    "text": "Kräver domänverifiering via DKIM- och SPF-poster"
+  },
+  "web.domains.email.provider_sendgrid_description": {
+    "text": "Kräver konfiguration av domänautentisering"
+  },
+  "web.domains.email.provider_lettermint_description": {
+    "text": "Kräver domänverifiering"
+  },
+  "web.domains.email.provider_inherit_description": {
+    "text": "Använder ditt kontos standardkonfiguration för e-postutskick"
+  },
+  "web.domains.email.dns_records_title": {
+    "text": "DNS-poster"
+  },
+  "web.domains.email.dns_records_description": {
+    "text": "Lägg till följande DNS-poster för att verifiera din domän för e-postutskick."
+  },
+  "web.domains.email.dns_column_type": {
+    "text": "Typ"
+  },
+  "web.domains.email.dns_column_name": {
+    "text": "Namn"
+  },
+  "web.domains.email.dns_column_value": {
+    "text": "Värde"
+  },
+  "web.domains.email.dns_check_label": {
+    "text": "DNS"
+  },
+  "web.domains.email.provider_check_label": {
+    "text": "Leverantör"
+  },
+  "web.domains.email.dns_optional_label": {
+    "text": "Rekommenderas"
+  },
+  "web.domains.email.dns_optional_hint": {
+    "text": "Den här posten rekommenderas men krävs inte för verifiering. En DMARC-policy på din organisationsdomän kan redan täcka den här underdomänen."
+  },
+  "web.domains.email.copy": {
+    "text": "Kopiera"
+  },
+  "web.domains.email.copied": {
+    "text": "Kopierad"
+  },
+  "web.domains.email.status_verified": {
+    "text": "Verifierad"
+  },
+  "web.domains.email.status_pending": {
+    "text": "Väntar"
+  },
+  "web.domains.email.status_failed": {
+    "text": "Misslyckades"
+  },
+  "web.domains.email.revalidate": {
+    "text": "Validera igen"
+  },
+  "web.domains.email.validating": {
+    "text": "Validerar..."
+  },
+  "web.domains.email.domain_verified": {
+    "text": "Domänen verifierad"
+  },
+  "web.domains.email.validation_failed": {
+    "text": "Valideringen misslyckades"
+  },
+  "web.domains.email.last_validated": {
+    "text": "Senast validerad"
+  },
+  "web.domains.email.upgrade_to_configure": {
+    "text": "Uppgradera din plan för att konfigurera e-postutskick för den här domänen."
+  },
+  "web.domains.email.configure_email": {
+    "text": "Konfigurera e-post"
+  },
+  "web.domains.email.access_denied": {
+    "text": "Åtkomst nekad"
+  },
+  "web.domains.email.access_denied_description": {
+    "text": "Du har inte behörighet att hantera e-postinställningar för den här domänen. Kontakta din organisationsadministratör."
+  },
+  "web.domains.email.update_success": {
+    "text": "E-postkonfigurationen har sparats"
+  },
+  "web.domains.email.delete_success": {
+    "text": "E-postkonfigurationen har tagits bort"
+  },
+  "web.domains.email.default_sender_notice": {
+    "text": "E-post för den här domänen skickas för närvarande från den globala avsändaren. Slutför e-postkonfigurationen för att använda din egen avsändaridentitet."
+  },
+  "web.domains.email.disabled_notice": {
+    "text": "Anpassat e-postutskick är för närvarande inaktiverat. E-post skickas från den globala avsändaren. Aktivera funktionen nedan för att använda din anpassade avsändaridentitet."
+  },
+  "web.domains.email.test_email_title": {
+    "text": "Testa e-postleverans"
+  },
+  "web.domains.email.test_email_hint": {
+    "text": "Skicka ett test-e-postmeddelande till dig själv med den sparade konfigurationen. Fungerar även när funktionen ännu inte är aktiverad."
+  },
+  "web.domains.email.send_test": {
+    "text": "Skicka test"
+  },
+  "web.domains.email.test_email_sent": {
+    "text": "Test-e-postmeddelandet har skickats"
+  },
+  "web.domains.email.test_email_failed": {
+    "text": "Det gick inte att skicka test-e-postmeddelandet"
+  },
+  "web.domains.email.test_email_sent_to": {
+    "text": "Skickat till {email}"
+  },
+  "web.domains.email.delivered_via": {
+    "text": "Levererat via {provider}"
+  },
+  "web.domains.email.badge_not_configured": {
+    "text": "Inte konfigurerad"
+  },
+  "web.domains.email.badge_default_sender": {
+    "text": "Använder standardavsändare"
+  },
+  "web.domains.email.badge_verified": {
+    "text": "Verifierad"
+  },
+  "web.domains.email.badge_pending": {
+    "text": "Väntar på verifiering"
+  },
+  "web.domains.email.badge_disabled": {
+    "text": "Inaktiverad"
+  },
+  "web.domains.email.tooltip_not_configured": {
+    "text": "Ingen e-postavsändare konfigurerad – e-post använder plattformens standardavsändare"
+  },
+  "web.domains.email.tooltip_pending": {
+    "text": "E-postavsändarens konfiguration väntar på verifiering – e-post använder plattformens standardavsändare"
+  },
+  "web.domains.email.tooltip_disabled": {
+    "text": "E-postavsändaren är inaktiverad – e-post använder plattformens standardavsändare"
+  },
+  "web.domains.email.tooltip_verified": {
+    "text": "E-postavsändaren verifierad – e-post skickas från den här domänen"
+  },
+  "web.domains.incoming.title": {
+    "text": "Inkommande hemligheter"
+  },
+  "web.domains.incoming.config_title": {
+    "text": "Konfiguration av inkommande hemligheter"
+  },
+  "web.domains.incoming.config_description": {
+    "text": "Tillåt externa användare att skicka hemligheter direkt till angivna mottagare på den här domänen"
+  },
+  "web.domains.incoming.feature_disabled": {
+    "text": "Inkommande hemligheter är inte tillgängligt"
+  },
+  "web.domains.incoming.feature_disabled_description": {
+    "text": "Inkommande hemligheter är inte aktiverat på den här instansen. Kontakta din administratör."
+  },
+  "web.domains.incoming.access_denied": {
+    "text": "Åtkomst nekad"
+  },
+  "web.domains.incoming.access_denied_description": {
+    "text": "Du har inte behörighet att hantera inställningar för inkommande hemligheter för den här domänen. Kontakta din organisationsadministratör."
+  },
+  "web.domains.incoming.upgrade_to_configure": {
+    "text": "Uppgradera din plan för att konfigurera inkommande hemligheter för den här domänen."
+  },
+  "web.domains.incoming.configure_incoming": {
+    "text": "Konfigurera inkommande hemligheter"
+  },
+  "web.domains.incoming.not_configured_notice": {
+    "text": "Inkommande hemligheter är inte konfigurerat för den här domänen. Lägg till mottagare för att tillåta externa användare att skicka hemligheter till ditt team."
+  },
+  "web.domains.incoming.disabled_notice": {
+    "text": "Inkommande hemligheter är för närvarande inaktiverat. Externa användare kan inte skicka hemligheter till mottagare på den här domänen. Aktivera funktionen nedan för att tillåta inkommande hemligheter."
+  },
+  "web.domains.incoming.recipients_title": {
+    "text": "Mottagare"
+  },
+  "web.domains.incoming.recipients_description": {
+    "text": "Ange vem som kan ta emot inkommande hemligheter på den här domänen. Mottagare får e-postaviseringar när en hemlighet skickas till dem."
+  },
+  "web.domains.incoming.add_recipient": {
+    "text": "Lägg till mottagare"
+  },
+  "web.domains.incoming.remove_recipient": {
+    "text": "Ta bort"
+  },
+  "web.domains.incoming.email_label": {
+    "text": "E-postadress"
+  },
+  "web.domains.incoming.email_placeholder": {
+    "text": "recipient{'@'}example.com"
+  },
+  "web.domains.incoming.name_label": {
+    "text": "Visningsnamn"
+  },
+  "web.domains.incoming.name_placeholder": {
+    "text": "t.ex. Security Team"
+  },
+  "web.domains.incoming.empty_state": {
+    "text": "Inga mottagare konfigurerade"
+  },
+  "web.domains.incoming.empty_state_description": {
+    "text": "Lägg till mottagare för att tillåta externa användare att skicka hemligheter till ditt team."
+  },
+  "web.domains.incoming.validation_invalid_email": {
+    "text": "Ogiltig e-postadress"
+  },
+  "web.domains.incoming.validation_duplicate_email": {
+    "text": "Den här e-postadressen är redan tillagd"
+  },
+  "web.domains.incoming.validation_max_recipients": {
+    "text": "Högst {max} mottagare tillåtna"
+  },
+  "web.domains.incoming.validation_name_required": {
+    "text": "Visningsnamn krävs"
+  },
+  "web.domains.incoming.validation_email_required": {
+    "text": "E-postadress krävs"
+  },
+  "web.domains.incoming.save_changes": {
+    "text": "Spara ändringar"
+  },
+  "web.domains.incoming.discard_changes": {
+    "text": "Ångra ändringar"
+  },
+  "web.domains.incoming.update_success": {
+    "text": "Konfigurationen för inkommande hemligheter har sparats"
+  },
+  "web.domains.incoming.delete_success": {
+    "text": "Konfigurationen för inkommande hemligheter har tagits bort"
+  },
+  "web.domains.incoming.recipient_count": {
+    "text": "{count} mottagare | {count} mottagare"
+  },
+  "web.domains.incoming.badge_not_configured": {
+    "text": "Inte konfigurerad"
+  },
+  "web.domains.incoming.badge_configured": {
+    "text": "Konfigurerad"
+  },
+  "web.domains.incoming.badge_disabled": {
+    "text": "Inaktiverad"
+  },
+  "web.domains.incoming.tooltip_not_configured": {
+    "text": "Inkommande hemligheter inte konfigurerat – externa användare kan inte skicka hemligheter till den här domänen"
+  },
+  "web.domains.incoming.tooltip_configured": {
+    "text": "Inkommande hemligheter aktiverat med {count} mottagare"
+  },
+  "web.domains.incoming.tooltip_disabled": {
+    "text": "Funktionen för inkommande hemligheter är inaktiverad för den här domänen"
+  },
+  "web.domains.incoming.enabled_label": {
+    "text": "Aktivera inkommande hemligheter"
+  },
+  "web.domains.incoming.enabled_hint": {
+    "text": "Tillåt externa användare att skicka hemligheter till mottagare på den här domänen"
+  },
+  "web.domains.incoming.public_url_label": {
+    "text": "Offentlig URL"
+  },
+  "web.domains.incoming.public_url_description": {
+    "text": "Dela den här URL:en med externa användare så att de kan skicka hemligheter"
+  },
+  "web.domains.incoming.copy_url": {
+    "text": "Kopiera URL"
+  },
+  "web.domains.incoming.url_copied": {
+    "text": "URL kopierad till urklipp"
+  },
+  "web.domains.incoming.remove_all_confirmation": {
+    "text": "Är du säker på att du vill ta bort alla mottagare? Externa användare kommer inte längre att kunna skicka hemligheter till den här domänen."
+  },
+  "web.domains.incoming.max_recipients_reached": {
+    "text": "Det maximala antalet mottagare har nåtts"
+  },
+  "web.domains.incoming.duplicate_recipient": {
+    "text": "Den här e-postadressen har redan lagts till"
+  },
+  "web.domains.incoming.save_will_replace_confirmation": {
+    "text": "Om du sparar ersätts alla befintliga mottagare med dina väntande ändringar. Är du säker?"
+  },
+  "web.domains.incoming.delete_all_recipients": {
+    "text": "Ta bort alla mottagare"
+  },
+  "web.domains.signin.title": {
+    "text": "Inloggningskonfiguration"
+  },
+  "web.domains.signin.configure_signin": {
+    "text": "Konfigurera inloggning"
+  },
+  "web.domains.signin.config_description": {
+    "text": "Konfigurera autentiseringsmetoder för inloggning på den här domänen"
+  },
+  "web.domains.signin.access_denied": {
+    "text": "Åtkomst nekad"
+  },
+  "web.domains.signin.upgrade_to_configure": {
+    "text": "Uppgradera din plan för att konfigurera inloggningsmetoder för den här domänen."
+  },
+  "web.domains.signin.not_configured_notice": {
+    "text": "Inloggningskonfiguration har ännu inte angetts för den här domänen. Konfigurera åsidosättningar för att styra vilka autentiseringsmetoder som är tillgängliga på den här domänens inloggningssida."
+  },
+  "web.domains.signin.signin_enabled_label": {
+    "text": "Inloggning aktiverad"
+  },
+  "web.domains.signin.header_toggle_label": {
+    "text": "Inloggning"
+  },
+  "web.domains.signin.signin_enabled_hint": {
+    "text": "Om användare kan logga in på den här domänen"
+  },
+  "web.domains.signin.restrict_to_label": {
+    "text": "Begränsa inloggningsmetod"
+  },
+  "web.domains.signin.restrict_to_hint": {
+    "text": "Begränsa den här domänen till en enda autentiseringsmetod. När detta är angivet visas endast den valda metoden på inloggningssidan."
+  },
+  "web.domains.signin.all_methods": {
+    "text": "Alla metoder"
+  },
+  "web.domains.signin.all_methods_description": {
+    "text": "Visa alla aktiverade autentiseringsmetoder på inloggningssidan"
+  },
+  "web.domains.signin.method_password": {
+    "text": "Lösenord"
+  },
+  "web.domains.signin.method_email_auth": {
+    "text": "E-postautentisering"
+  },
+  "web.domains.signin.method_webauthn": {
+    "text": "WebAuthn / Lösenordsnycklar"
+  },
+  "web.domains.signin.method_sso": {
+    "text": "Enkel inloggning"
+  },
+  "web.domains.signin.method_overrides_label": {
+    "text": "Metodåsidosättningar"
+  },
+  "web.domains.signin.method_overrides_hint": {
+    "text": "Aktivera eller inaktivera enskilda autentiseringsmetoder för den här domänen"
+  },
+  "web.domains.signin.mode_question": {
+    "text": "Hur kan användare logga in?"
+  },
+  "web.domains.signin.mode_any": {
+    "text": "Valfri tillgänglig metod"
+  },
+  "web.domains.signin.mode_any_hint": {
+    "text": "Visa alla metoder som är tillgängliga på den här domänen. Begränsa enskilda metoder nedan."
+  },
+  "web.domains.signin.mode_one": {
+    "text": "En specifik metod"
+  },
+  "web.domains.signin.mode_one_hint": {
+    "text": "Begränsa inloggningssidan till en enda metod. Endast metoder som är tillgängliga på den här domänen listas."
+  },
+  "web.domains.signin.mode_disabled": {
+    "text": "Inloggning inaktiverad"
+  },
+  "web.domains.signin.mode_disabled_hint": {
+    "text": "Användare kan inte logga in på den här domänen."
+  },
+  "web.domains.signin.mode_disabled_notice": {
+    "text": "Besökare på den här domänens inloggningssida ser ett meddelande om att inloggning inte är tillgänglig, med en länk tillbaka till startsidan. Dina tidigare metodinställningar behålls och återställs när du återaktiverar inloggning."
+  },
+  "web.domains.signin.methods_list_label": {
+    "text": "Metoder som visas på inloggningssidan"
+  },
+  "web.domains.signin.restrict_picker_hint": {
+    "text": "Endast metoder som är tillgängliga på den här domänen listas."
+  },
+  "web.domains.signin.availability_always": {
+    "text": "Alltid tillgänglig"
+  },
+  "web.domains.signin.availability_global_on": {
+    "text": "Följer global policy · På"
+  },
+  "web.domains.signin.availability_global_off": {
+    "text": "Inte tillgänglig"
+  },
+  "web.domains.signin.availability_unavailable": {
+    "text": "Inte tillgänglig på hela webbplatsen"
+  },
+  "web.domains.signin.allow_on_domain": {
+    "text": "Tillåt på den här domänen"
+  },
+  "web.domains.signin.method_password_blurb": {
+    "text": "Endast lösenord"
+  },
+  "web.domains.signin.method_email_auth_blurb": {
+    "text": "Lösenordslös inloggning med magisk länk"
+  },
+  "web.domains.signin.method_webauthn_blurb": {
+    "text": "Biometri och säkerhetsnycklar"
+  },
+  "web.domains.signin.method_sso_blurb": {
+    "text": "Extern identitetsleverantör"
+  },
+  "web.domains.signin.email_auth_label": {
+    "text": "E-postautentisering"
+  },
+  "web.domains.signin.email_auth_hint": {
+    "text": "Tillåt lösenordslös e-postautentisering på den här domänen"
+  },
+  "web.domains.signin.sso_enabled_label": {
+    "text": "Enkel inloggning"
+  },
+  "web.domains.signin.sso_enabled_hint": {
+    "text": "Tillåt SSO-autentisering på den här domänen"
+  },
+  "web.domains.signin.enabled_label": {
+    "text": "Aktivera inloggningskonfiguration"
+  },
+  "web.domains.signin.enabled_hint": {
+    "text": "När detta är aktiverat använder den här domänen inloggningsinställningarna som konfigurerats ovan"
+  },
+  "web.domains.signin.save_config": {
+    "text": "Spara konfiguration"
+  },
+  "web.domains.signin.update_success": {
+    "text": "Inloggningskonfigurationen har uppdaterats"
+  },
+  "web.domains.signin.reset_to_defaults": {
+    "text": "Återställ till standardinställningar"
+  },
+  "web.domains.signin.reset_confirm": {
+    "text": "Återställ inloggning till de globala standardinställningarna?"
+  },
+  "web.domains.signin.reset_keeps_sso": {
+    "text": "Dina SSO-uppgifter behålls. Ta bort dem separat på skärmen för SSO-konfiguration."
+  },
+  "web.domains.signin.reset_action": {
+    "text": "Ja, återställ"
+  },
+  "web.domains.signin.reset_success": {
+    "text": "Inloggningsinställningarna har återställts till de globala standardinställningarna"
+  },
+  "web.domains.signup.title": {
+    "text": "Registreringsvalidering"
+  },
+  "web.domains.signup.config_description": {
+    "text": "Konfigurera registreringsvalidering för denna domän"
+  },
+  "web.domains.signup.access_denied": {
+    "text": "Åtkomst nekad"
+  },
+  "web.domains.signup.upgrade_to_configure": {
+    "text": "Uppgradera din plan för att konfigurera registreringsvalidering per domän."
+  },
+  "web.domains.signup.configure_signup": {
+    "text": "Konfigurera registrering"
+  },
+  "web.domains.signup.not_configured_notice": {
+    "text": "Registreringsvalidering är ännu inte konfigurerad för denna domän. Konfigurera en strategi för att styra vem som kan registrera sig via denna domän."
+  },
+  "web.domains.signup.site_signups_disabled_warning": {
+    "text": "Registreringar är för närvarande inaktiverade på webbplatsnivå. Den här policyn per domän är konfigurerad men kommer inte att filtrera någon trafik förrän registreringar på webbplatsen aktiveras."
+  },
+  "web.domains.signup.strategy_label": {
+    "text": "Valideringsstrategi"
+  },
+  "web.domains.signup.strategy_description": {
+    "text": "Välj hur e-postadresser valideras när användare registrerar sig på denna domän."
+  },
+  "web.domains.signup.network_validation_warning": {
+    "text": "Den här strategin gör nätverksanrop under registreringen, vilket kan öka fördröjningen eller blockeras av vissa leverantörer."
+  },
+  "web.domains.signup.allowed_domains_label": {
+    "text": "Tillåtna registreringsdomäner"
+  },
+  "web.domains.signup.allowed_domains_hint": {
+    "text": "Endast dessa e-postdomäner tillåts att registrera sig. Lägg till en domän per post."
+  },
+  "web.domains.signup.domain_placeholder": {
+    "text": "example.com"
+  },
+  "web.domains.signup.invalid_domain": {
+    "text": "Ange en giltig domän (t.ex. example.com)"
+  },
+  "web.domains.signup.domain_exists": {
+    "text": "Den här domänen finns redan i listan"
+  },
+  "web.domains.signup.remove_domain": {
+    "text": "Ta bort {domain}"
+  },
+  "web.domains.signup.enabled_label": {
+    "text": "Aktivera validering per domän"
+  },
+  "web.domains.signup.enabled_hint": {
+    "text": "När detta är aktiverat använder registreringar på denna domän strategin ovan i stället för den globala policyn."
+  },
+  "web.domains.signup.delete_config": {
+    "text": "Ta bort konfiguration"
+  },
+  "web.domains.signup.delete_confirm": {
+    "text": "Ta bort konfigurationen för registreringsvalidering? Registreringar återgår till den globala policyn."
+  },
+  "web.domains.signup.save_config": {
+    "text": "Spara konfiguration"
+  },
+  "web.domains.signup.update_success": {
+    "text": "Registreringsvalideringen uppdaterades"
+  },
+  "web.domains.signup.delete_success": {
+    "text": "Konfigurationen för registreringsvalidering togs bort"
+  },
+  "web.domains.signup.domain_overrides_label": {
+    "text": "Domänåsidosättningar"
+  },
+  "web.domains.signup.domain_overrides_hint": {
+    "text": "Åsidosätt globala registreringsinställningar för denna domän"
+  },
+  "web.domains.signup.signup_enabled_label": {
+    "text": "Registrering aktiverad"
+  },
+  "web.domains.signup.signup_enabled_hint": {
+    "text": "Åsidosätt om registrering är aktiverad för denna domän"
+  },
+  "web.domains.signup.autoverify_label": {
+    "text": "Verifiera konton automatiskt"
+  },
+  "web.domains.signup.autoverify_hint": {
+    "text": "Åsidosätt om nya konton verifieras automatiskt på denna domän"
+  },
+  "web.domains.sso.title": {
+    "text": "Enkel inloggning"
+  },
+  "web.domains.sso.config_title": {
+    "text": "SSO-konfiguration"
+  },
+  "web.domains.sso.config_description": {
+    "text": "Konfigurera autentisering med single sign-on för denna domän"
+  },
+  "web.domains.sso.access_denied": {
+    "text": "Åtkomst nekad"
+  },
+  "web.domains.sso.access_denied_description": {
+    "text": "Du har inte behörighet att hantera SSO-inställningar för denna domän. Kontakta din organisationsadministratör."
+  },
+  "web.domains.sso.upgrade_to_configure": {
+    "text": "Uppgradera din plan för att konfigurera single sign-on för denna domän."
+  },
+  "web.domains.sso.create_success": {
+    "text": "SSO-konfigurationen skapades"
+  },
+  "web.domains.sso.update_success": {
+    "text": "SSO-konfigurationen uppdaterades"
+  },
+  "web.domains.sso.delete_success": {
+    "text": "SSO-konfigurationen togs bort"
+  },
+  "web.domains.sso.test_success": {
+    "text": "Anslutningstestet lyckades – leverantören svarade korrekt"
+  },
+  "web.domains.sso.test_failed": {
+    "text": "Anslutningstestet misslyckades"
+  },
+  "web.domains.sso.enforce_moved_notice": {
+    "text": "För att kräva SSO för alla inloggningar på denna domän konfigurerar du det i domänens inloggningsinställningar. Läget med enbart SSO begränsar inloggningssidan till den SSO-leverantör som konfigurerats här."
+  },
+  "web.domains.sso.configure_sso": {
+    "text": "Konfigurera SSO"
+  },
+  "web.domains.sso.not_configured_notice": {
+    "text": "SSO är ännu inte konfigurerat för denna domän. Aktivera single sign-on för att låta teammedlemmar autentisera sig med din organisations identitetsleverantör."
+  },
+  "web.domains.sso.edit_credentials": {
+    "text": "Redigera autentiseringsuppgifter"
+  },
+  "web.domains.sso.configure_button": {
+    "text": "Konfigurera"
+  },
+  "web.domains.sso.upgrade_required": {
+    "text": "Uppgradera för att konfigurera"
   }
 }

--- a/locales/content/sv_SE/workspace-organizations.json
+++ b/locales/content/sv_SE/workspace-organizations.json
@@ -578,5 +578,344 @@
   "web.organizations.invitations.expires_soon": {
     "text": "Går snart ut",
     "source_hash": "a5dcfef9"
+  },
+  "api.organizations.errors.not_found": {
+    "text": "Organisationen hittades inte: %{extid}"
+  },
+  "api.organizations.errors.owner_required": {
+    "text": "Endast organisationens ägare kan utföra denna åtgärd"
+  },
+  "api.organizations.errors.admin_required": {
+    "text": "Endast organisationens ägare och administratörer kan utföra denna åtgärd"
+  },
+  "api.organizations.errors.member_required": {
+    "text": "Du måste vara medlem i organisationen för att utföra denna åtgärd"
+  },
+  "api.organizations.invitations.errors.create_admin_required": {
+    "text": "Endast organisationens ägare och administratörer kan skapa inbjudningar"
+  },
+  "api.organizations.invitations.errors.resend_admin_required": {
+    "text": "Endast organisationens ägare och administratörer kan skicka inbjudningar igen"
+  },
+  "api.organizations.invitations.errors.view_admin_required": {
+    "text": "Endast organisationens ägare och administratörer kan visa inbjudningar"
+  },
+  "api.organizations.invitations.errors.revoke_admin_required": {
+    "text": "Endast organisationens ägare och administratörer kan återkalla inbjudningar"
+  },
+  "api.organizations.invitations.errors.email_required": {
+    "text": "E-post krävs"
+  },
+  "api.organizations.invitations.errors.email_invalid": {
+    "text": "Ogiltigt e-postformat"
+  },
+  "api.organizations.invitations.errors.role_invalid": {
+    "text": "Rollen måste vara medlem eller administratör"
+  },
+  "api.organizations.invitations.errors.cannot_invite_owner": {
+    "text": "Det går inte att bjuda in som ägare"
+  },
+  "api.organizations.invitations.errors.already_member": {
+    "text": "Användaren är redan medlem i denna organisation"
+  },
+  "api.organizations.invitations.errors.already_pending": {
+    "text": "En inbjudan väntar redan för den här e-postadressen"
+  },
+  "api.organizations.invitations.errors.member_limit_reached": {
+    "text": "Medlemsgränsen har nåtts. Uppgradera din plan för att bjuda in fler medlemmar."
+  },
+  "api.organizations.invitations.errors.not_found": {
+    "text": "Inbjudan hittades inte"
+  },
+  "api.organizations.invitations.errors.cannot_resend_non_pending": {
+    "text": "Det går bara att skicka väntande inbjudningar igen"
+  },
+  "api.organizations.invitations.errors.cannot_revoke_non_pending": {
+    "text": "Det går bara att återkalla väntande inbjudningar"
+  },
+  "api.organizations.invitations.errors.resend_limit_reached": {
+    "text": "Maxgränsen för att skicka igen (%{max}) har nåtts"
+  },
+  "api.organizations.invitations.errors.accept_token_required": {
+    "text": "Token krävs"
+  },
+  "api.organizations.invitations.errors.accept_organization_gone": {
+    "text": "Organisationen finns inte längre"
+  },
+  "api.organizations.invitations.errors.accept_already_acted": {
+    "text": "Inbjudan har redan blivit %{status}"
+  },
+  "api.organizations.invitations.errors.accept_expired": {
+    "text": "Inbjudan har gått ut"
+  },
+  "api.organizations.invitations.errors.accept_email_mismatch": {
+    "text": "Din e-postadress matchar inte inbjudan"
+  },
+  "api.organizations.invitations.errors.accept_already_member": {
+    "text": "Du är redan medlem i denna organisation"
+  },
+  "web.organizations.entitlements_title": {
+    "text": "Organisationsbehörigheter"
+  },
+  "web.organizations.page_description_short": {
+    "text": "Visa och konfigurera dina arbetsytor"
+  },
+  "web.organizations.delete_organization_remove_domains_first": {
+    "text": "Ta bort alla anpassade domäner innan du tar bort denna organisation."
+  },
+  "web.organizations.default_org_delete_notice_title": {
+    "text": "Ta bort denna organisation"
+  },
+  "web.organizations.default_org_delete_notice_before": {
+    "text": "Detta är din standardorganisation och kan inte tas bort från instrumentpanelen. För att ta bort den, kontakta oss via"
+  },
+  "web.organizations.default_org_delete_notice_link": {
+    "text": "återkopplingsformuläret"
+  },
+  "web.organizations.default_org_delete_notice_after": {
+    "text": "."
+  },
+  "web.organizations.leave_organization": {
+    "text": "Lämna denna organisation"
+  },
+  "web.organizations.leave_organization_warning": {
+    "text": "Du förlorar åtkomst till denna organisation och dess resurser."
+  },
+  "web.organizations.leave_organization_confirm_title": {
+    "text": "Lämna organisationen"
+  },
+  "web.organizations.leave_organization_confirm_message": {
+    "text": "Är du säker på att du vill lämna {name}? Du behöver en ny inbjudan för att gå med igen."
+  },
+  "web.organizations.leave_organization_success": {
+    "text": "Du har lämnat organisationen."
+  },
+  "web.organizations.leave_error": {
+    "text": "Det gick inte att lämna organisationen"
+  },
+  "web.organizations.organizations": {
+    "text": "Organisationer"
+  },
+  "web.organizations.invitations.invited_by_inline": {
+    "text": "av {email}"
+  },
+  "web.organizations.invitations.invited_as_inline": {
+    "text": "som {role}"
+  },
+  "web.organizations.invitations.back_to_home": {
+    "text": "Tillbaka till startsidan"
+  },
+  "web.organizations.invitations.email_locked_hint": {
+    "text": "Den här inbjudan skickades till denna e-postadress"
+  },
+  "web.organizations.invitations.signup_continue": {
+    "text": "Fortsätt"
+  },
+  "web.organizations.invitations.signin_continue": {
+    "text": "Logga in"
+  },
+  "web.organizations.invitations.confirm_join_below": {
+    "text": "Nästan klart – bekräfta nedan för att gå med i organisationen."
+  },
+  "web.organizations.invitations.go_to_organizations": {
+    "text": "Gå till organisationer"
+  },
+  "web.organizations.invitations.already_member": {
+    "text": "Du är redan medlem i denna organisation"
+  },
+  "web.organizations.invitations.join_organization": {
+    "text": "Gå med i {orgName}"
+  },
+  "web.organizations.invitations.sign_in_to_join": {
+    "text": "Logga in för att gå med i {orgName}"
+  },
+  "web.organizations.invitations.decline": {
+    "text": "Avböj"
+  },
+  "web.organizations.members.member_quota": {
+    "text": "{used} av {limit} medlemmar"
+  },
+  "web.organizations.members.pending_suffix": {
+    "text": "({count} väntande)"
+  },
+  "web.organizations.members.limit_reached_hint": {
+    "text": "Medlemsgränsen har nåtts."
+  },
+  "web.organizations.sso.title": {
+    "text": "Enkel inloggning (SSO)"
+  },
+  "web.organizations.sso.description": {
+    "text": "Konfigurera SSO för att låta medlemmar logga in med din organisations identitetsleverantör"
+  },
+  "web.organizations.sso.provider_type": {
+    "text": "Leverantörstyp"
+  },
+  "web.organizations.sso.provider_type_description": {
+    "text": "Välj din organisations identitetsleverantör"
+  },
+  "web.organizations.sso.display_name": {
+    "text": "Visningsnamn"
+  },
+  "web.organizations.sso.display_name_hint": {
+    "text": "Ett vänligt namn som visas för användare vid inloggning"
+  },
+  "web.organizations.sso.display_name_placeholder": {
+    "text": "t.ex. Acme Corp SSO"
+  },
+  "web.organizations.sso.client_id": {
+    "text": "Client ID"
+  },
+  "web.organizations.sso.client_id_placeholder": {
+    "text": "Ditt OAuth-client-ID"
+  },
+  "web.organizations.sso.client_secret": {
+    "text": "Client Secret"
+  },
+  "web.organizations.sso.client_secret_placeholder": {
+    "text": "Din OAuth-client-secret"
+  },
+  "web.organizations.sso.client_secret_update_hint": {
+    "text": "Lämna tomt för att behålla den befintliga hemligheten"
+  },
+  "web.organizations.sso.tenant_id": {
+    "text": "Tenant ID"
+  },
+  "web.organizations.sso.tenant_id_hint": {
+    "text": "Din identifierare för Azure AD / Entra ID-tenant"
+  },
+  "web.organizations.sso.tenant_id_placeholder": {
+    "text": "t.ex. 12345678-1234-1234-1234-123456789abc"
+  },
+  "web.organizations.sso.issuer": {
+    "text": "Issuer-URL"
+  },
+  "web.organizations.sso.issuer_hint": {
+    "text": "OIDC-discovery-URL för din identitetsleverantör"
+  },
+  "web.organizations.sso.issuer_placeholder": {
+    "text": "t.ex. https://login.example.com"
+  },
+  "web.organizations.sso.view_discovery_document": {
+    "text": "Visa discovery-dokument"
+  },
+  "web.organizations.sso.callback_url": {
+    "text": "Callback-URL"
+  },
+  "web.organizations.sso.callback_url_hint": {
+    "text": "Lägg till denna URL bland din identitetsleverantörs tillåtna omdirigerings-URI:er"
+  },
+  "web.organizations.sso.allowed_domains": {
+    "text": "Tillåtna e-postdomäner"
+  },
+  "web.organizations.sso.allowed_domains_hint": {
+    "text": "Endast användare med e-postadresser från dessa domäner kan logga in. Lämna tomt för att tillåta alla domäner."
+  },
+  "web.organizations.sso.domain_placeholder": {
+    "text": "t.ex. acme.com"
+  },
+  "web.organizations.sso.invalid_domain": {
+    "text": "Ange en giltig domän (t.ex. example.com)"
+  },
+  "web.organizations.sso.domain_exists": {
+    "text": "Den här domänen finns redan i listan"
+  },
+  "web.organizations.sso.remove_domain": {
+    "text": "Ta bort {domain}"
+  },
+  "web.organizations.sso.enabled": {
+    "text": "Aktivera SSO"
+  },
+  "web.organizations.sso.enabled_hint": {
+    "text": "När detta är aktiverat kan organisationens medlemmar logga in med denna SSO-leverantör"
+  },
+  "web.organizations.sso.enforce_sso_only": {
+    "text": "Tvinga endast SSO"
+  },
+  "web.organizations.sso.enforce_sso_only_hint": {
+    "text": "Kräv SSO för alla inloggningar på denna domän. När detta är aktiverat inaktiveras lösenordsbaserad autentisering."
+  },
+  "web.organizations.sso.grant_org_scope": {
+    "text": "Bevilja åtkomst till hela organisationen"
+  },
+  "web.organizations.sso.grant_org_scope_hint": {
+    "text": "Nya medlemmar som går med via denna domäns SSO får åtkomst till alla organisationens domäner. Befintliga medlemmar påverkas inte. När detta är inaktiverat (standard) får nya medlemmar endast åtkomst till denna domän."
+  },
+  "web.organizations.sso.save_config": {
+    "text": "Spara SSO-konfiguration"
+  },
+  "web.organizations.sso.delete_config": {
+    "text": "Ta bort konfiguration"
+  },
+  "web.organizations.sso.delete_confirm": {
+    "text": "Är du säker? Detta inaktiverar SSO för din organisation."
+  },
+  "web.organizations.sso.load_error": {
+    "text": "Det gick inte att läsa in SSO-konfigurationen"
+  },
+  "web.organizations.sso.save_error": {
+    "text": "Det gick inte att spara SSO-konfigurationen"
+  },
+  "web.organizations.sso.create_success": {
+    "text": "SSO-konfigurationen skapades"
+  },
+  "web.organizations.sso.update_success": {
+    "text": "SSO-konfigurationen uppdaterades"
+  },
+  "web.organizations.sso.delete_success": {
+    "text": "SSO-konfigurationen togs bort"
+  },
+  "web.organizations.sso.delete_error": {
+    "text": "Det gick inte att ta bort SSO-konfigurationen"
+  },
+  "web.organizations.sso.test_connection": {
+    "text": "Testa anslutning"
+  },
+  "web.organizations.sso.test_connection_hint": {
+    "text": "Verifiera att identitetsleverantören är nåbar (validerar inte autentiseringsuppgifter)"
+  },
+  "web.organizations.sso.test_button": {
+    "text": "Testa anslutning"
+  },
+  "web.organizations.sso.testing": {
+    "text": "Testar ..."
+  },
+  "web.organizations.sso.test_error": {
+    "text": "Det gick inte att testa anslutningen"
+  },
+  "web.organizations.sso.auth_endpoint": {
+    "text": "Auktoriseringsslutpunkt"
+  },
+  "web.organizations.sso.missing_fields": {
+    "text": "Saknade fält"
+  },
+  "web.organizations.sso.status_enabled": {
+    "text": "Aktiverad"
+  },
+  "web.organizations.sso.status_configured": {
+    "text": "Konfigurerad"
+  },
+  "web.organizations.sso.domain_sso_title": {
+    "text": "Domän-SSO"
+  },
+  "web.organizations.sso.domain_sso_description": {
+    "text": "Konfigurera SSO för varje verifierad domän"
+  },
+  "web.organizations.sso.provider_type_locked_hint": {
+    "text": "För att byta leverantör måste du först ta bort denna konfiguration"
+  },
+  "web.organizations.sso.status_not_configured": {
+    "text": "Inte konfigurerad"
+  },
+  "web.organizations.sso.no_domains": {
+    "text": "Inga verifierade domäner"
+  },
+  "web.organizations.sso.no_domains_description": {
+    "text": "Lägg till och verifiera en domän innan du konfigurerar SSO för den."
+  },
+  "web.organizations.tabs.team": {
+    "text": "Team"
+  },
+  "web.organizations.tabs.sso": {
+    "text": "SSO"
   }
 }


### PR DESCRIPTION
## `sv_SE` translation update

Automated export of completed **sv_SE** translations from the translation task DB.
Scope: `locales/content/sv_SE/` only — 27 file(s), +1845/-27.

✅ `i18n validate variables`: no variable mismatches.

---

### Local quality review

> Produced by a fresh, isolated `claude` review agent (model `claude-sonnet-5`, agent `saas-translator`) that read
> `locales/AGENT_TRANSLATION_PROTOCOL.md` and inspected this branch's diff before the PR was opened.

_Automated review did not complete (exit 124). Review this locale manually._

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
