### PR TITLE
i18n: update tr translations

### DIFF
--- a/locales/content/tr/00-common.json
+++ b/locales/content/tr/00-common.json
@@ -1299,7 +1299,7 @@
     "source_hash": "fc78d9cb"
   },
   "web.INSTRUCTION.phishing_warning": {
-    "text": "Her zaman resmi {product_name} web sitesinde olduğunuzu doğrulayın. Dolandırıcılar bazen gizli mesajlarınızı çalmak için {product_name}'a tıpatıp benzeyen sahte web siteleri oluştururlar. Kimlik avı saldırılarından kaçınmak için yeni bağlantılar oluşturmadan önce alan adını kontrol edin.",
+    "text": "Her zaman resmi {product_name} web sitesinde olduğunuzu doğrulayın. Dolandırıcılar bazen gizli mesajlarınızı çalmak için {product_name}'a tıpatıp benzeyen sahte web siteleri oluştururlar. Kimlik avı saldırılarından kaçınmak için yeni bağlantılar oluşturmadan önce bölge alan adını kontrol edin.",
     "source_hash": "b588f5b2"
   },
   "web.pricing.title": {
@@ -1383,5 +1383,110 @@
     "text": "Daha fazla özelliğin kilidini açmak için yükseltin",
     "context": "Description shown for free plan users encouraging upgrade",
     "source_hash": "783f174c"
+  },
+  "api.errors.authentication_required": {
+    "text": "Kimlik doğrulama gerekli"
+  },
+  "api.errors.sso_only_action_blocked": {
+    "text": "Bu işlem yalnızca SSO modunda kullanılamaz"
+  },
+  "web.COMMON.configure": {
+    "text": "Yapılandır"
+  },
+  "web.COMMON.copy_to_clipboard": {
+    "text": "Panoya kopyala"
+  },
+  "web.COMMON.add": {
+    "text": "Ekle"
+  },
+  "web.COMMON.enabled": {
+    "text": "Etkin"
+  },
+  "web.COMMON.disabled": {
+    "text": "Devre dışı"
+  },
+  "web.COMMON.yes_delete": {
+    "text": "Evet, sil"
+  },
+  "web.COMMON.error_code": {
+    "text": "Hata Kodu"
+  },
+  "web.COMMON.http_status": {
+    "text": "HTTP Durumu"
+  },
+  "web.COMMON.details": {
+    "text": "Ayrıntılar"
+  },
+  "web.COMMON.field_confirm_password": {
+    "text": "Parolayı Onayla"
+  },
+  "web.COMMON.passwords_must_match": {
+    "text": "Parolalar eşleşmelidir"
+  },
+  "web.COMMON.and": {
+    "text": "ve"
+  },
+  "web.COMMON.or": {
+    "text": "veya"
+  },
+  "web.COMMON.copied": {
+    "text": "Kopyalandı"
+  },
+  "web.COMMON.copy": {
+    "text": "Kopyala"
+  },
+  "web.COMMON.copy_email": {
+    "text": "E-posta adresini kopyala"
+  },
+  "web.COMMON.copy_id": {
+    "text": "Hesap kimliğini kopyala"
+  },
+  "web.COMMON.org_id_tooltip": {
+    "text": "Kuruluşunuzun benzersiz tanımlayıcısı"
+  },
+  "web.COMMON.success": {
+    "text": "Başarılı"
+  },
+  "web.COMMON.need_help": {
+    "text": "Yardıma mı ihtiyacınız var"
+  },
+  "web.COMMON.open_help_dialog": {
+    "text": "Yardım iletişim kutusunu aç"
+  },
+  "web.COMMON.focus_is_now_in_the_main_text_area": {
+    "text": "Odak artık ana metin alanında"
+  },
+  "web.LABELS.show_passphrase": {
+    "text": "Güvenlik ifadesini göster"
+  },
+  "web.LABELS.hide_passphrase": {
+    "text": "Güvenlik ifadesini gizle"
+  },
+  "web.LABELS.copy_icon": {
+    "text": "Kopyalama simgesi"
+  },
+  "web.LABELS.copied_icon": {
+    "text": "Kopyalandı simgesi"
+  },
+  "web.STATUS.unverified": {
+    "text": "Doğrulanmadı"
+  },
+  "web.TITLES.domain_detail": {
+    "text": "Alan Adı Ayarları"
+  },
+  "web.TITLES.domain_signin": {
+    "text": "Giriş Yapılandırması"
+  },
+  "web.TITLES.domain_sso": {
+    "text": "Alan Adı SSO"
+  },
+  "web.TITLES.domain_signup": {
+    "text": "Alan Adı Kayıt Doğrulaması"
+  },
+  "web.TITLES.domain_email": {
+    "text": "E-posta Yapılandırması"
+  },
+  "web.TITLES.domain_incoming": {
+    "text": "Gelen Gizli Mesajlar"
   }
 }

--- a/locales/content/tr/10-layout.json
+++ b/locales/content/tr/10-layout.json
@@ -264,7 +264,7 @@
     "source_hash": "e2f124cd"
   },
   "web.layout.visit_onetime_secret_homepage": {
-    "text": "{product_name} ana sayfasını ziyaret et",
+    "text": "{product_name} ana sayfasını ziyaret edin",
     "source_hash": "625556d2"
   },
   "web.layout.footer_navigation": {
@@ -338,5 +338,11 @@
   "web.layout.workspace_context": {
     "text": "Çalışma alanı bağlamı",
     "source_hash": "dc6fa4f5"
+  },
+  "web.footer.workspace": {
+    "text": "Çalışma Alanı"
+  },
+  "web.help.default_content": {
+    "text": "Yardım için lütfen destekle iletişime geçin"
   }
 }

--- a/locales/content/tr/admin-colonel.json
+++ b/locales/content/tr/admin-colonel.json
@@ -634,5 +634,152 @@
   "web.colonel.feedback.when_you_submit_feedback_well_see": {
     "text": "Geri bildirim gönderdiğinizde şunları göreceğiz:",
     "source_hash": "fe77172e"
+  },
+  "web.colonel.previewPlanMode": {
+    "text": "Plan önizleme modu"
+  },
+  "web.colonel.previewModeDescription": {
+    "text": "Uygulamayı, farklı bir plandaki müşterilere göründüğü şekilde önizleyin. Bu yalnızca sizin görünümünüzü etkiler ve herhangi bir kuruluşun gerçek planını değiştirmez."
+  },
+  "web.colonel.previewModeActive": {
+    "text": "Önizleme etkin"
+  },
+  "web.colonel.bannedIps.empty": {
+    "text": "Yasaklı IP yok"
+  },
+  "web.colonel.bannedIps.currentIp": {
+    "text": "Mevcut IP Adresiniz"
+  },
+  "web.colonel.bannedIps.confirmUnban": {
+    "text": "{ip} adresinin yasağı kaldırılsın mı?"
+  },
+  "web.colonel.bannedIps.actions.ban": {
+    "text": "IP'yi Yasakla"
+  },
+  "web.colonel.bannedIps.actions.quickBan": {
+    "text": "Hızlı Yasakla"
+  },
+  "web.colonel.bannedIps.actions.unban": {
+    "text": "Yasağı Kaldır"
+  },
+  "web.colonel.bannedIps.actions.cancel": {
+    "text": "İptal"
+  },
+  "web.colonel.bannedIps.columns.ipAddress": {
+    "text": "IP Adresi"
+  },
+  "web.colonel.bannedIps.columns.reason": {
+    "text": "Neden"
+  },
+  "web.colonel.bannedIps.columns.bannedAt": {
+    "text": "Yasaklanma Tarihi"
+  },
+  "web.colonel.bannedIps.columns.bannedBy": {
+    "text": "Yasaklayan"
+  },
+  "web.colonel.bannedIps.error.banFailed": {
+    "text": "IP adresi yasaklanamadı"
+  },
+  "web.colonel.bannedIps.error.unbanFailed": {
+    "text": "IP adresinin yasağı kaldırılamadı"
+  },
+  "web.colonel.bannedIps.form.title": {
+    "text": "IP Adresini Yasakla"
+  },
+  "web.colonel.bannedIps.form.ipLabel": {
+    "text": "IP Adresi"
+  },
+  "web.colonel.bannedIps.form.reasonLabel": {
+    "text": "Neden"
+  },
+  "web.colonel.bannedIps.form.reasonPlaceholder": {
+    "text": "İsteğe bağlı neden"
+  },
+  "web.colonel.bannedIps.success.banned": {
+    "text": "{ip} IP adresi yasaklandı"
+  },
+  "web.colonel.bannedIps.success.unbanned": {
+    "text": "{ip} IP adresinin yasağı kaldırıldı"
+  },
+  "web.colonel.customDomains.empty": {
+    "text": "Yapılandırılmış özel alan adı yok"
+  },
+  "web.colonel.customDomains.noLogo": {
+    "text": "Logo Yok"
+  },
+  "web.colonel.customDomains.labels.organization": {
+    "text": "Kuruluş"
+  },
+  "web.colonel.customDomains.labels.externalId": {
+    "text": "Harici Kimlik"
+  },
+  "web.colonel.customDomains.labels.created": {
+    "text": "Oluşturuldu"
+  },
+  "web.colonel.customDomains.labels.updated": {
+    "text": "Güncellendi"
+  },
+  "web.colonel.customDomains.labels.favicon": {
+    "text": "Favicon"
+  },
+  "web.colonel.customDomains.status.verified": {
+    "text": "Doğrulandı"
+  },
+  "web.colonel.customDomains.status.resolving": {
+    "text": "Çözümleniyor"
+  },
+  "web.colonel.customDomains.status.ready": {
+    "text": "Hazır"
+  },
+  "web.colonel.customDomains.status.publicHomepage": {
+    "text": "Herkese Açık Ana Sayfa"
+  },
+  "web.colonel.customDomains.status.publicApi": {
+    "text": "Herkese Açık API"
+  },
+  "web.colonel.customDomains.status.pending": {
+    "text": "Beklemede"
+  },
+  "web.colonel.pagination.showing": {
+    "text": "{total} öğeden {start}–{end} arası gösteriliyor"
+  },
+  "web.colonel.pagination.itemsPerPage": {
+    "text": "Sayfa başına öğe"
+  },
+  "web.colonel.pagination.perPage": {
+    "text": "Sayfa başına {count}"
+  },
+  "web.colonel.pagination.pageOf": {
+    "text": "Sayfa {current} / {total}"
+  },
+  "web.colonel.secrets.empty": {
+    "text": "Gizli mesaj bulunamadı"
+  },
+  "web.colonel.secrets.never": {
+    "text": "Hiçbir zaman"
+  },
+  "web.colonel.secrets.columns.shortId": {
+    "text": "Kısa Kimlik"
+  },
+  "web.colonel.secrets.columns.state": {
+    "text": "Durum"
+  },
+  "web.colonel.secrets.columns.created": {
+    "text": "Oluşturuldu"
+  },
+  "web.colonel.secrets.columns.expiration": {
+    "text": "Son Kullanım Tarihi"
+  },
+  "web.colonel.secrets.columns.age": {
+    "text": "Yaş (gün)"
+  },
+  "web.colonel.secrets.state.new": {
+    "text": "Yeni"
+  },
+  "web.colonel.secrets.state.received": {
+    "text": "Alındı"
+  },
+  "web.colonel.secrets.state.viewed": {
+    "text": "Görüntülendi"
   }
 }

--- a/locales/content/tr/api-account-errors.json
+++ b/locales/content/tr/api-account-errors.json
@@ -1,0 +1,8 @@
+{
+  "api.account.errors.invalid_email": {
+    "text": "Bu geçerli bir e-posta adresi mi?"
+  },
+  "api.account.errors.password_too_short": {
+    "text": "Parola çok kısa"
+  }
+}

--- a/locales/content/tr/api-domains-errors.json
+++ b/locales/content/tr/api-domains-errors.json
@@ -1,0 +1,29 @@
+{
+  "api.domains.errors.domain_id_required": {
+    "text": "Alan adı kimliği gerekli"
+  },
+  "api.domains.errors.domain_not_found": {
+    "text": "Alan adı bulunamadı: %{extid}"
+  },
+  "api.domains.errors.organization_not_found": {
+    "text": "Şu alan adı için kuruluş bulunamadı: %{domain}"
+  },
+  "api.domains.errors.incoming_secrets_disabled": {
+    "text": "Gelen gizli mesajlar bu sunucuda etkin değil"
+  },
+  "api.domains.errors.incoming_secrets_entitlement_required": {
+    "text": "Gelen gizli mesaj yönetimi, incoming_secrets yetkisini gerektirir. Lütfen planınızı yükseltin."
+  },
+  "api.domains.errors.incoming_config_not_found": {
+    "text": "Şu alan adı için gelen yapılandırma bulunamadı: %{extid}"
+  },
+  "api.domains.errors.recipients_max_exceeded": {
+    "text": "En fazla %{max} alıcıya izin verilir"
+  },
+  "api.domains.errors.recipients_invalid_email": {
+    "text": "Geçersiz e-posta: %{email}"
+  },
+  "api.domains.errors.recipients_duplicate": {
+    "text": "Yinelenen alıcı e-postalarına izin verilmez"
+  }
+}

--- a/locales/content/tr/api-entitlements-errors.json
+++ b/locales/content/tr/api-entitlements-errors.json
@@ -1,0 +1,71 @@
+{
+  "api.entitlements.errors.context_unavailable": {
+    "text": "Yetkiler doğrulanamıyor (kuruluş bağlamı kullanılamıyor)"
+  },
+  "api.entitlements.errors.api_access_required": {
+    "text": "API erişimi için planınızı yükseltmeniz gerekir"
+  },
+  "api.entitlements.errors.custom_privacy_defaults_required": {
+    "text": "Özel gizlilik varsayılanları için planınızı yükseltmeniz gerekir"
+  },
+  "api.entitlements.errors.extended_default_expiration_required": {
+    "text": "Genişletilmiş varsayılan süre sonu için planınızı yükseltmeniz gerekir"
+  },
+  "api.entitlements.errors.custom_domains_required": {
+    "text": "Özel alan adları için planınızı yükseltmeniz gerekir"
+  },
+  "api.entitlements.errors.custom_branding_required": {
+    "text": "Özel markalama için planınızı yükseltmeniz gerekir"
+  },
+  "api.entitlements.errors.homepage_secrets_required": {
+    "text": "Ana sayfa gizli mesajları için planınızı yükseltmeniz gerekir"
+  },
+  "api.entitlements.errors.incoming_secrets_required": {
+    "text": "Gelen gizli mesajlar için planınızı yükseltmeniz gerekir"
+  },
+  "api.entitlements.errors.custom_mail_sender_required": {
+    "text": "Özel e-posta göndereni için planınızı yükseltmeniz gerekir"
+  },
+  "api.entitlements.errors.flexible_from_domain_required": {
+    "text": "Esnek gönderen alan adı için planınızı yükseltmeniz gerekir"
+  },
+  "api.entitlements.errors.manage_org_required": {
+    "text": "Kuruluş yönetimi için planınızı yükseltmeniz gerekir"
+  },
+  "api.entitlements.errors.manage_teams_required": {
+    "text": "Ekip yönetimi için planınızı yükseltmeniz gerekir"
+  },
+  "api.entitlements.errors.manage_members_required": {
+    "text": "Üye yönetimi için planınızı yükseltmeniz gerekir"
+  },
+  "api.entitlements.errors.manage_sso_required": {
+    "text": "SSO yönetimi için planınızı yükseltmeniz gerekir"
+  },
+  "api.entitlements.errors.audit_logs_required": {
+    "text": "Denetim günlükleri için planınızı yükseltmeniz gerekir"
+  },
+  "api.entitlements.errors.custom_signup_validation_required": {
+    "text": "Özel kayıt doğrulaması için planınızı yükseltmeniz gerekir"
+  },
+  "api.entitlements.errors.create_secrets_required": {
+    "text": "Gizli mesaj oluşturmak için planınızı yükseltmeniz gerekir"
+  },
+  "api.entitlements.errors.view_receipt_required": {
+    "text": "Makbuzları görüntülemek için planınızı yükseltmeniz gerekir"
+  },
+  "api.entitlements.errors.notifications_required": {
+    "text": "Bildirimler için planınızı yükseltmeniz gerekir"
+  },
+  "api.entitlements.errors.workspace_branding_required": {
+    "text": "Çalışma alanı markalaması için planınızı yükseltmeniz gerekir"
+  },
+  "api.entitlements.errors.ip_access_rules_required": {
+    "text": "IP erişim kuralları için planınızı yükseltmeniz gerekir"
+  },
+  "api.entitlements.errors.manage_billing_required": {
+    "text": "Faturalandırma yönetimi için planınızı yükseltmeniz gerekir"
+  },
+  "api.entitlements.errors.custom_signin_config_required": {
+    "text": "Özel giriş yapılandırması için planınızı yükseltmeniz gerekir"
+  }
+}

--- a/locales/content/tr/api-feedback-errors.json
+++ b/locales/content/tr/api-feedback-errors.json
@@ -1,0 +1,5 @@
+{
+  "api.feedback.errors.rate_limit_exceeded": {
+    "text": "Çok fazla geri bildirim gönderildi. Lütfen daha sonra tekrar deneyin."
+  }
+}

--- a/locales/content/tr/api-incoming-errors.json
+++ b/locales/content/tr/api-incoming-errors.json
@@ -1,0 +1,5 @@
+{
+  "api.incoming.errors.custom_domain_unresolved": {
+    "text": "Özel alan adı kuruluşu çözümlenemedi"
+  }
+}

--- a/locales/content/tr/api-invite-errors.json
+++ b/locales/content/tr/api-invite-errors.json
@@ -1,0 +1,23 @@
+{
+  "api.invite.errors.invitation_not_found_or_expired": {
+    "text": "Davet bulunamadı veya süresi doldu"
+  },
+  "api.invite.errors.token_required": {
+    "text": "Belirteç gerekli"
+  },
+  "api.invite.errors.organization_no_longer_exists": {
+    "text": "Kuruluş artık mevcut değil"
+  },
+  "api.invite.errors.invitation_already_processed": {
+    "text": "Davet zaten %{status} durumunda"
+  },
+  "api.invite.errors.invitation_expired": {
+    "text": "Davetin süresi doldu"
+  },
+  "api.invite.errors.email_mismatch": {
+    "text": "E-posta adresiniz davetle eşleşmiyor"
+  },
+  "api.invite.errors.already_member": {
+    "text": "Zaten bu kuruluşun üyesisiniz"
+  }
+}

--- a/locales/content/tr/api-organizations-errors.json
+++ b/locales/content/tr/api-organizations-errors.json
@@ -1,0 +1,107 @@
+{
+  "api.organizations.errors.domain_scoped_forbidden": {
+    "text": "Alan adı kapsamlı üyeler bu işlemi gerçekleştiremez"
+  },
+  "api.organizations.errors.organization_not_found": {
+    "text": "Kuruluş bulunamadı: %{extid}"
+  },
+  "api.organizations.errors.organization_owner_required": {
+    "text": "Bu işlemi yalnızca kuruluş sahibi gerçekleştirebilir"
+  },
+  "api.organizations.errors.organization_member_required": {
+    "text": "Bu işlemi gerçekleştirmek için bir kuruluş üyesi olmalısınız"
+  },
+  "api.organizations.errors.organization_admin_required": {
+    "text": "Bu işlemi yalnızca kuruluş sahipleri ve yöneticiler gerçekleştirebilir"
+  },
+  "api.organizations.errors.extid_required": {
+    "text": "Kuruluş kimliği gerekli"
+  },
+  "api.organizations.errors.display_name_required": {
+    "text": "Kuruluş adı gerekli"
+  },
+  "api.organizations.errors.display_name_too_long": {
+    "text": "Kuruluş adı %{max} karakterden kısa olmalıdır"
+  },
+  "api.organizations.errors.description_too_long": {
+    "text": "Açıklama %{max} karakterden kısa olmalıdır"
+  },
+  "api.organizations.errors.contact_email_exists": {
+    "text": "Bu iletişim e-postasına sahip bir kuruluş zaten mevcut"
+  },
+  "api.organizations.errors.creation_in_progress": {
+    "text": "Kuruluş oluşturma işlemi sürüyor. Lütfen tekrar deneyin."
+  },
+  "api.organizations.errors.organization_limit_reached": {
+    "text": "Kuruluş sınırına ulaşıldı. Daha fazla kuruluş oluşturmak için planınızı yükseltin."
+  },
+  "api.organizations.invitations.errors.invitation_not_found": {
+    "text": "Davet bulunamadı"
+  },
+  "api.organizations.invitations.errors.email_required": {
+    "text": "E-posta gerekli"
+  },
+  "api.organizations.invitations.errors.invalid_email_format": {
+    "text": "Geçersiz e-posta biçimi"
+  },
+  "api.organizations.invitations.errors.invalid_role": {
+    "text": "Rol üye veya yönetici olmalıdır"
+  },
+  "api.organizations.invitations.errors.cannot_invite_as_owner": {
+    "text": "Sahip olarak davet edilemez"
+  },
+  "api.organizations.invitations.errors.user_already_member": {
+    "text": "Kullanıcı zaten bu kuruluşun üyesi"
+  },
+  "api.organizations.invitations.errors.invitation_already_pending": {
+    "text": "Bu e-posta için zaten bekleyen bir davet var"
+  },
+  "api.organizations.invitations.errors.member_limit_reached": {
+    "text": "Üye sınırına ulaşıldı. Daha fazla üye davet etmek için planınızı yükseltin."
+  },
+  "api.organizations.invitations.errors.resend_only_pending": {
+    "text": "Yalnızca bekleyen davetler yeniden gönderilebilir"
+  },
+  "api.organizations.invitations.errors.resend_limit_reached": {
+    "text": "En fazla yeniden gönderme sınırına (%{max}) ulaşıldı"
+  },
+  "api.organizations.invitations.errors.revoke_only_pending": {
+    "text": "Yalnızca bekleyen davetler iptal edilebilir"
+  },
+  "api.organizations.members.errors.member_not_found": {
+    "text": "Üye bulunamadı: %{extid}"
+  },
+  "api.organizations.members.errors.member_not_in_organization": {
+    "text": "Bu kuruluşta üye bulunamadı"
+  },
+  "api.organizations.members.errors.member_not_active": {
+    "text": "Üye aktif değil"
+  },
+  "api.organizations.members.errors.invalid_role_value": {
+    "text": "Geçersiz rol. Şunlardan biri olmalıdır: %{roles}"
+  },
+  "api.organizations.members.errors.cannot_change_owner_role": {
+    "text": "Sahip rolü değiştirilemez. Bunun yerine sahiplik aktarımını kullanın."
+  },
+  "api.organizations.members.errors.member_already_has_role": {
+    "text": "Üye zaten şu role sahip: %{role}"
+  },
+  "api.organizations.members.errors.cannot_promote_to_owner": {
+    "text": "Sahip olarak yükseltilemez. Bunun yerine sahiplik aktarımını kullanın."
+  },
+  "api.organizations.members.errors.must_be_member": {
+    "text": "Bu kuruluşun bir üyesi olmalısınız"
+  },
+  "api.organizations.members.errors.cannot_remove_owner": {
+    "text": "Kuruluş sahibi kaldırılamaz. Önce sahipliği aktarın."
+  },
+  "api.organizations.members.errors.cannot_remove_self": {
+    "text": "Kendinizi kaldıramazsınız. Bunun yerine kuruluştan ayrılma seçeneğini kullanın."
+  },
+  "api.organizations.members.errors.admin_cannot_remove_admin": {
+    "text": "Yöneticiler diğer yöneticileri kaldıramaz. Yalnızca sahipler kaldırabilir."
+  },
+  "api.organizations.members.errors.no_permission_to_remove": {
+    "text": "Üyeleri kaldırma izniniz yok"
+  }
+}

--- a/locales/content/tr/api-secrets-errors.json
+++ b/locales/content/tr/api-secrets-errors.json
@@ -1,0 +1,11 @@
+{
+  "api.secrets.errors.domain_permission_authenticated_non_owner": {
+    "text": "Şu alan adını kullanma izniniz yok: %{domain}"
+  },
+  "api.secrets.errors.domain_public_sharing_disabled": {
+    "text": "Şu alan adı için herkese açık paylaşım devre dışı: %{domain}"
+  },
+  "api.secrets.errors.domain_permission_anonymous_cross_domain": {
+    "text": "Şu alan adını kullanma izniniz yok: %{domain}"
+  }
+}

--- a/locales/content/tr/email.json
+++ b/locales/content/tr/email.json
@@ -60,7 +60,7 @@
     "source_hash": "88c72144"
   },
   "email.welcome.signature": {
-    "text": "Delano",
+    "text": "Destek Ekibi",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -100,7 +100,7 @@
     "source_hash": "fbb7eb2d"
   },
   "email.password_request.signature": {
-    "text": "Delano",
+    "text": "Destek Ekibi",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -145,7 +145,7 @@
     "source_hash": "1863f5be"
   },
   "email.magic_link.signature": {
-    "text": "Delano",
+    "text": "Destek Ekibi",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -230,7 +230,7 @@
     "source_hash": "3f6b45dd"
   },
   "email.secret_revealed.signature": {
-    "text": "Delano",
+    "text": "Destek Ekibi",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -355,7 +355,7 @@
     "source_hash": "734882d2"
   },
   "email.organization_invitation.signature": {
-    "text": "Delano",
+    "text": "Destek Ekibi",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -395,7 +395,7 @@
     "source_hash": "be92cff3"
   },
   "email.password_changed.signature": {
-    "text": "Delano",
+    "text": "Destek Ekibi",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -445,7 +445,7 @@
     "source_hash": "f8d47b82"
   },
   "email.email_changed.signature": {
-    "text": "Delano",
+    "text": "Destek Ekibi",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -495,7 +495,7 @@
     "source_hash": "f8d47b82"
   },
   "email.email_change_requested.signature": {
-    "text": "Delano",
+    "text": "Destek Ekibi",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -550,7 +550,7 @@
     "source_hash": "d4d835fc"
   },
   "email.email_change_confirmation.signature": {
-    "text": "Delano",
+    "text": "Destek Ekibi",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -580,7 +580,7 @@
     "source_hash": "e7c11bb0"
   },
   "email.mfa_enabled.signature": {
-    "text": "Delano",
+    "text": "Destek Ekibi",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -605,7 +605,7 @@
     "source_hash": "97ef0a3e"
   },
   "email.mfa_disabled.signature": {
-    "text": "Delano",
+    "text": "Destek Ekibi",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -650,7 +650,7 @@
     "source_hash": "450c54c5"
   },
   "email.new_login_alert.signature": {
-    "text": "Delano",
+    "text": "Destek Ekibi",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -670,7 +670,7 @@
     "source_hash": "d442beed"
   },
   "email.member_removed.signature": {
-    "text": "Delano",
+    "text": "Destek Ekibi",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -690,7 +690,7 @@
     "source_hash": "c2280c0c"
   },
   "email.role_changed.signature": {
-    "text": "Delano",
+    "text": "Destek Ekibi",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -710,7 +710,7 @@
     "source_hash": "7095fc69"
   },
   "email.organization_deleted.signature": {
-    "text": "Delano",
+    "text": "Destek Ekibi",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -750,7 +750,7 @@
     "source_hash": "36008943"
   },
   "email.payment_receipt.signature": {
-    "text": "Delano",
+    "text": "Destek Ekibi",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -775,7 +775,7 @@
     "source_hash": "926406b1"
   },
   "email.payment_failed.signature": {
-    "text": "Delano",
+    "text": "Destek Ekibi",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -800,7 +800,7 @@
     "source_hash": "66a1419e"
   },
   "email.trial_expiring.signature": {
-    "text": "Delano",
+    "text": "Destek Ekibi",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -825,7 +825,7 @@
     "source_hash": "5a96ae38"
   },
   "email.subscription_changed.signature": {
-    "text": "Delano",
+    "text": "Destek Ekibi",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -853,5 +853,41 @@
     "text": "Onetime Secret",
     "renderer": "erb",
     "source_hash": "1cd0194a"
+  },
+  "email.common.secret_link_label": {
+    "text": "Gizli mesaj bağlantısı"
+  },
+  "email.common.automated_notice": {
+    "text": "Bu, %{product_name} tarafından gönderilen otomatik bir mesajdır."
+  },
+  "email.common.support_label": {
+    "text": "Destek"
+  },
+  "email.expiration_warning.signature": {
+    "text": "Destek Ekibi"
+  },
+  "email.expiration_warning.footer_note": {
+    "text": "Bu mesajı, %{product_name} üzerinde oluşturduğunuz bir gizli mesajın süresi dolmak üzere olduğu için aldınız."
+  },
+  "email.feedback_email.user_id_label": {
+    "text": "Kullanıcı:"
+  },
+  "email.feedback_email.timezone_label": {
+    "text": "Saat Dilimi:"
+  },
+  "email.feedback_email.version_label": {
+    "text": "Sürüm:"
+  },
+  "email.incoming_secret.footer_note": {
+    "text": "Bu mesajı, biri size gizli mesaj göndermek için %{product_name} kullandığı için aldınız. Beklemiyorsanız, bu e-postayı güvenle yok sayabilirsiniz."
+  },
+  "email.secret_link.passphrase_label": {
+    "text": "Güvenlik ifadesi gerekli:"
+  },
+  "email.secret_link.passphrase_required": {
+    "text": "Bu gizli mesaj bir güvenlik ifadesi ile korunmaktadır. Gönderen, bunu size ayrıca iletmelidir."
+  },
+  "email.secret_link.footer_note": {
+    "text": "Bu mesajı, %{sender_email} sizinle bir gizli mesaj paylaşmak için %{product_name} kullandığı için aldınız. Beklemiyorsanız, bu e-postayı güvenle yok sayabilirsiniz."
   }
 }

--- a/locales/content/tr/email.json
+++ b/locales/content/tr/email.json
@@ -315,7 +315,7 @@
     "source_hash": "f5394f72"
   },
   "email.feedback_email.signature": {
-    "text": "Secret Destek",
+    "text": "Destek Ekibi",
     "renderer": "erb",
     "source_hash": "f6a6c90f"
   },

--- a/locales/content/tr/feature-feedback.json
+++ b/locales/content/tr/feature-feedback.json
@@ -58,5 +58,14 @@
   "web.feedback.reason_email_change_unauthorized": {
     "text": "Hesabınızda yetkisiz bir e-posta değişikliği bildirdiğiniz anlaşılıyor. Lütfen ne olduğunu açıklayın, hemen araştıracağız.",
     "source_hash": "00e56551"
+  },
+  "web.feedback.anonymous_no_reply": {
+    "text": "Not: yanıt almak isterseniz, lütfen mesajı imzalayın veya mesaja bir e-posta adresi ekleyin."
+  },
+  "web.feedback.characters_remaining": {
+    "text": "{count} karakter kaldı"
+  },
+  "web.feedback.character_limit_reached": {
+    "text": "Karakter sınırına ulaşıldı"
   }
 }

--- a/locales/content/tr/feature-homepage-secrets.json
+++ b/locales/content/tr/feature-homepage-secrets.json
@@ -1,0 +1,50 @@
+{
+  "homepage_secrets.disabled.members_only_eyebrow": {
+    "text": "Yalnızca üyelere özel sunucu"
+  },
+  "homepage_secrets.disabled.private_instance_eyebrow": {
+    "text": "Özel sunucu"
+  },
+  "homepage_secrets.disabled.team_link_headline": {
+    "text": "Bu bağlantı {workspace} ekibi içindir."
+  },
+  "homepage_secrets.disabled.signin_headline": {
+    "text": "Bir {action} oluşturmak için giriş yapın."
+  },
+  "homepage_secrets.disabled.signin_headline_action": {
+    "text": "gizli mesaj bağlantısı"
+  },
+  "homepage_secrets.disabled.team_subtitle": {
+    "text": "{domain} adresindeki yalnızca yetkili ekip arkadaşları burada yeni tek kullanımlık bağlantılar oluşturabilir. Alıcılar yine de kendilerine gönderilen herhangi bir bağlantıyı açabilir."
+  },
+  "homepage_secrets.disabled.public_subtitle": {
+    "text": "Bu sunucunun yalnızca yetkili üyeleri yeni tek kullanımlık bağlantılar oluşturabilir. Alıcılar yine de kendilerine gönderilen herhangi bir bağlantıyı açabilir."
+  },
+  "homepage_secrets.disabled.signin_cta": {
+    "text": "Hesabınıza giriş yapın"
+  },
+  "homepage_secrets.disabled.what_is_this": {
+    "text": "Bu nedir?"
+  },
+  "homepage_secrets.disabled.trust_viewed_once": {
+    "text": "Bir kez görüntülenir, sonra kaybolur"
+  },
+  "homepage_secrets.disabled.trust_zero_retained": {
+    "text": "Hiçbir veri saklanmaz"
+  },
+  "homepage_secrets.disabled.promo_title": {
+    "text": "Yeni: ücretsiz planlar artık özel alan adları içeriyor."
+  },
+  "homepage_secrets.disabled.promo_subtitle": {
+    "text": "Alan adınızı Onetime Secret'a yönlendirin ve gizli mesajları kendi markanız altında gönderin."
+  },
+  "homepage_secrets.disabled.promo_learn_how": {
+    "text": "Nasıl yapıldığını öğrenin"
+  },
+  "homepage_secrets.disabled.logo_alt": {
+    "text": "{name} logosu"
+  },
+  "homepage_secrets.disabled.opens_in_new_tab": {
+    "text": "(yeni bir sekmede açılır)"
+  }
+}

--- a/locales/content/tr/feature-incoming.json
+++ b/locales/content/tr/feature-incoming.json
@@ -130,5 +130,26 @@
   "incoming.receipt_link_text": {
     "text": "makbuz",
     "source_hash": "6f328609"
+  },
+  "incoming.upgrade_required_title": {
+    "text": "Yükseltme Gerekli"
+  },
+  "incoming.upgrade_required_description": {
+    "text": "Bu özellik için planınızı yükseltmeniz gerekir. Gelen gizli mesajları etkinleştirmek için lütfen hesap sahibiyle iletişime geçin."
+  },
+  "incoming.validation_memo_too_long": {
+    "text": "Not en fazla {max} karakter olmalıdır"
+  },
+  "incoming.validation_secret_required": {
+    "text": "Gizli mesaj içeriği gerekli"
+  },
+  "incoming.validation_recipient_required": {
+    "text": "Lütfen bir alıcı seçin"
+  },
+  "incoming.validation_feature_disabled": {
+    "text": "Gelen gizli mesajlar özelliği etkin değil"
+  },
+  "incoming.validation_form_errors": {
+    "text": "Lütfen formu hatalara karşı kontrol edin"
   }
 }

--- a/locales/content/tr/feature-regions.json
+++ b/locales/content/tr/feature-regions.json
@@ -152,7 +152,7 @@
     "source_hash": "1d97f6bd"
   },
   "web.regions.changing_regions_billing_note": {
-    "text": "Fatura iletişim e-postanız {product_name} hesap e-postanızdan farklıysa, abonelik avantajlarınızı korumak için yeni bölge hesabında fatura iletişim e-postanızı kullanın.",
+    "text": "Fatura iletişim e-postanız {product_name} hesap e-postanızdan farklıysa, abonelik avantajlarınızı korumak için yeni bölge hesabında fatura iletişim e-postasını kullanın.",
     "source_hash": "dac1cc28"
   },
   "web.regions.changing_regions_subscription_note": {
@@ -186,5 +186,8 @@
   "web.regions.jurisdictions.apac.name": {
     "text": "Asia-Pacific",
     "source_hash": "7a757670"
+  },
+  "web.regions.no_region_configured": {
+    "text": "Hesabınız için şu anda bölge bilgisi mevcut değil."
   }
 }

--- a/locales/content/tr/feature-translations.json
+++ b/locales/content/tr/feature-translations.json
@@ -64,7 +64,7 @@
     "source_hash": "13131e36"
   },
   "web.translations.the_following_people_have_donated_their_time_to_": {
-    "text": "Aşağıdaki kişiler, {product_name}'ın erişimini genişletmeye yardımcı olmak için zamanlarını bağışladılar:",
+    "text": "Aşağıdaki kişiler {product_name} ürününün erişimini genişletmek için zamanlarını bağışladılar:",
     "source_hash": "85a766af"
   },
   "web.translations.translations": {
@@ -84,7 +84,7 @@
     "source_hash": "ba5c4395"
   },
   "web.translations.since_2012_onetime_secret_has_provided_a_secure_": {
-    "text": "2012'den beri {product_name}, dünya çapında hassas bilgileri paylaşmanın güvenli bir yolunu sunmaktadır. İngilizce'nin birincil dil olmadığı bölgelerdeki kullanıcılarla, güvenli iletişimi herkes için erişilebilir kılmak için doğru çeviriler esastır.",
+    "text": "2012 yılından bu yana {product_name}, dünya genelinde hassas bilgileri güvenli bir şekilde paylaşma imkanı sunmaktadır. İngilizcenin ana dil olmadığı bölgelerdeki kullanıcılarımız için doğru çeviriler, güvenli iletişimin herkes için erişilebilir olmasında büyük önem taşımaktadır.",
     "source_hash": "87a6e9af"
   },
   "web.translations.help_secure_communication_go_global": {

--- a/locales/content/tr/secret-homepage.json
+++ b/locales/content/tr/secret-homepage.json
@@ -108,15 +108,15 @@
     "source_hash": "107093e4"
   },
   "web.homepage.about_onetime_secret_0": {
-    "text": "{product_name} Hakkında",
+    "text": "{product_name} hakkında",
     "source_hash": "971c50da"
   },
   "web.homepage.log_in_to_onetime_secret": {
-    "text": "{product_name}'a giriş yapın",
+    "text": "{product_name} hesabına giriş yapın",
     "source_hash": "bd6be8d6"
   },
   "web.homepage.about_onetime_secret": {
-    "text": "{product_name} Hakkında",
+    "text": "{product_name} hakkında",
     "source_hash": "971c50da"
   },
   "web.homepage.signup_individual_and_business_plans": {
@@ -144,7 +144,7 @@
     "source_hash": "1cd0194a"
   },
   "web.homepage.one_time_secret_literal": {
-    "text": "Tek Kullanımlık Gizli Mesaj",
+    "text": "{product_name}",
     "source_hash": "7872e050"
   },
   "web.homepage.onetime_secret_homepage": {
@@ -168,11 +168,11 @@
     "source_hash": "e1073c60"
   },
   "web.homepage.welcome_to_onetime_secret": {
-    "text": "{product_name}'a hoş geldiniz.",
+    "text": "{product_name} uygulamasına hoş geldiniz.",
     "source_hash": "0990d163"
   },
   "web.homepage.onetime_secret_helps_us_share_sensitive_informat": {
-    "text": "{product_name}, profesyonel görünümümüzü korurken hassas bilgileri güvenli bir şekilde paylaşmamıza yardımcı olur.",
+    "text": "{product_name}, profesyonel imajımızı korurken hassas bilgileri güvenli bir şekilde paylaşmamıza yardımcı olur.",
     "source_hash": "986a0856"
   },
   "web.homepage.information_shared_through_this_service_can_only": {

--- a/locales/content/tr/secret-manage.json
+++ b/locales/content/tr/secret-manage.json
@@ -128,7 +128,7 @@
     "source_hash": "07fe1b84"
   },
   "web.secrets.onetime_secret_is_a_secure_way_to_share_sensitiv": {
-    "text": "{product_name}, tek bir görüntülemeden sonra kendi kendini imha eden hassas bilgileri paylaşmanın güvenli bir yoludur.",
+    "text": "{product_name}, tek görüntülemeden sonra kendini imha eden hassas bilgileri güvenli bir şekilde paylaşmanın yoludur.",
     "source_hash": "8a163297"
   },
   "web.secrets.what_is_this": {
@@ -398,5 +398,11 @@
   "web.secrets.errors.access_denied_to_domain": {
     "text": "Alan adına erişim reddedildi",
     "source_hash": "cd441eea"
+  },
+  "web.receipt.open_link": {
+    "text": "Bağlantıyı aç"
+  },
+  "web.secrets.messageDeleted": {
+    "text": "Mesaj silindi"
   }
 }

--- a/locales/content/tr/session-auth-extended.json
+++ b/locales/content/tr/session-auth-extended.json
@@ -710,5 +710,26 @@
   "web.auth.recovery_codes.link_title": {
     "text": "Kurtarma Kodları",
     "source_hash": "579c7f4e"
+  },
+  "web.auth.google": {
+    "text": "Google"
+  },
+  "web.auth.mfa.alternative_auth_options": {
+    "text": "Alternatif kimlik doğrulama seçenekleri"
+  },
+  "web.auth.remember.enabled": {
+    "text": "Oturumu açık tut"
+  },
+  "web.auth.security._guidance.context": {
+    "text": "⚠️ SECURITY-CRITICAL: Messages prevent information disclosure. See src/locales/SECURITY-TRANSLATION-GUIDE.md"
+  },
+  "web.auth.sessions.session_singular": {
+    "text": "oturum"
+  },
+  "web.auth.sessions.session_plural": {
+    "text": "oturum"
+  },
+  "web.auth.sessions._guidance.context": {
+    "text": "User's logged-in devices/browsers management page"
   }
 }

--- a/locales/content/tr/session-auth.json
+++ b/locales/content/tr/session-auth.json
@@ -395,5 +395,35 @@
   "web.help.contact_support": {
     "text": "Destekle İletişime Geç",
     "source_hash": "f8d47b82"
+  },
+  "web.auth.account.sso_linked": {
+    "text": "SSO Hesabı"
+  },
+  "web.auth.verify._guidance.context": {
+    "text": "Email verification flow after signup"
+  },
+  "web.help.reset_password_link": {
+    "text": "Parolayı sıfırla"
+  },
+  "web.login.custom_domain_sso_title": {
+    "text": "Bu alan adı için tek oturum açma (SSO) kullanılabilir"
+  },
+  "web.login.custom_domain_sso_description": {
+    "text": "Kuruluş yöneticisi, ekip üyelerinin buradan giriş yapabilmesi için SSO'yu etkinleştirebilir. Erişim için yöneticiyle iletişime geçin."
+  },
+  "web.login.signin_disabled_heading": {
+    "text": "Giriş yapılamıyor"
+  },
+  "web.login.signin_disabled_message": {
+    "text": "Bu alan adında şu anda giriş yapılamıyor."
+  },
+  "web.login.errors.sso_not_configured": {
+    "text": "Bu alan adı için tek oturum açma (SSO) yapılandırılmamış. Lütfen yöneticinizle iletişime geçin."
+  },
+  "web.login.errors.invalid_email": {
+    "text": "Kimlik sağlayıcınızdan gelen e-posta adresi geçersiz. Lütfen yöneticinizle iletişime geçin."
+  },
+  "web.login.errors.domain_not_allowed": {
+    "text": "E-posta alan adınız SSO ile kayıt için yetkili değil. Lütfen yöneticinizle iletişime geçin."
   }
 }

--- a/locales/content/tr/workspace-account.json
+++ b/locales/content/tr/workspace-account.json
@@ -212,7 +212,7 @@
     "source_hash": "2ff0853c"
   },
   "web.settings.manage_your_account_settings_and_preferences": {
-    "text": "",
+    "text": "Hesap ayarlarınızı ve tercihlerinizi yönetin",
     "source_hash": "2ff0853c"
   },
   "web.settings.back_to_dashboard": {
@@ -404,7 +404,7 @@
     "source_hash": "6beda528"
   },
   "web.settings.security.generate_recovery_codes_recommendation": {
-    "text": "",
+    "text": "Yedek olarak kurtarma kodları oluşturun",
     "source_hash": "eb5f3ebd"
   },
   "web.settings.security.configured": {
@@ -476,7 +476,7 @@
     "source_hash": "1cc77e60"
   },
   "web.settings.api.documentation_description": {
-    "text": "{product_name}'ı uygulamalarınıza nasıl entegre edeceğinizi öğrenin",
+    "text": "{product_name} ürününü uygulamalarınıza nasıl entegre edeceğinizi öğrenin",
     "source_hash": "6e8f910f"
   },
   "web.settings.api.rest_api_reference": {
@@ -682,5 +682,14 @@
   "web.settings.profile.didnt_receive_email": {
     "text": "E-postayı almadınız mı?",
     "source_hash": "fe3ac3ad"
+  },
+  "web.settings.api.api_disabled_notice": {
+    "text": "Bu örnek için API devre dışı bırakılmıştır."
+  },
+  "web.settings.security.sso_managed_title": {
+    "text": "Güvenlik SSO tarafından yönetiliyor"
+  },
+  "web.settings.security.sso_managed_description": {
+    "text": "Hesabınız, kuruluşunuzun tek oturum açma (SSO) sağlayıcısı aracılığıyla doğrulanır. Parola, çok faktörlü kimlik doğrulama ve kurtarma kodları kimlik sağlayıcınız tarafından yönetilir."
   }
 }

--- a/locales/content/tr/workspace-billing.json
+++ b/locales/content/tr/workspace-billing.json
@@ -988,5 +988,47 @@
     "text": "Yalnızca orijinal abonelik bölgenizde kullanılabilir",
     "context": "Hint shown on plan cards when currency does not match active subscription",
     "source_hash": "10de32e5"
+  },
+  "web.billing.already_subscribed": {
+    "text": "Bu plana zaten abonesiniz."
+  },
+  "web.billing.cancel.reactivate_button": {
+    "text": "Aboneliği yeniden etkinleştir"
+  },
+  "web.billing.cancel.reactivate_success": {
+    "text": "Aboneliğiniz yeniden etkinleştirildi. Normal şekilde ücretlendirilmeye devam edeceksiniz."
+  },
+  "web.billing.cancel.reactivate_error": {
+    "text": "Abonelik yeniden etkinleştirilemedi. Lütfen tekrar deneyin veya destek ekibiyle iletişime geçin."
+  },
+  "web.billing.features.manage_orgs": {
+    "text": "Kuruluş Yönetimi"
+  },
+  "web.billing.features.flexible_from_domain": {
+    "text": "Esnek E-posta Gönderen Alan Adı"
+  },
+  "web.billing.features.unlimited_admins": {
+    "text": "Sınırsız Yönetici"
+  },
+  "web.billing.features.manage_sso": {
+    "text": "SSO"
+  },
+  "web.billing.overview.entitlements.flexible_from_domain": {
+    "text": "Esnek E-posta Gönderen Alan Adı"
+  },
+  "web.billing.overview.entitlements.manage_orgs": {
+    "text": "Kuruluşları Yönet"
+  },
+  "web.billing.overview.entitlements.manage_sso": {
+    "text": "Tek Oturum Açma (SSO)"
+  },
+  "web.billing.overview.entitlements.manage_billing": {
+    "text": "Faturalandırmayı Yönet"
+  },
+  "web.billing.overview.entitlements.custom_signup_validation": {
+    "text": "Özel Kayıt Doğrulaması"
+  },
+  "web.billing.plans.reactivate": {
+    "text": "Yeniden etkinleştir"
   }
 }

--- a/locales/content/tr/workspace-branding.json
+++ b/locales/content/tr/workspace-branding.json
@@ -178,5 +178,11 @@
   "web.branding.upgrade_to_customize": {
     "text": "Bu alan adı için markalamayı özelleştirmek üzere planınızı yükseltin.",
     "source_hash": "9077bf79"
+  },
+  "web.branding.saved_successfully": {
+    "text": "Marka ayarları başarıyla kaydedildi"
+  },
+  "web.branding.keyhole_logo_icon": {
+    "text": "Güvenli ve gizli paylaşımı temsil eden anahtar deliği simgesi"
   }
 }

--- a/locales/content/tr/workspace-dashboard.json
+++ b/locales/content/tr/workspace-dashboard.json
@@ -22,5 +22,14 @@
   "web.dashboard.fetch_error_description": {
     "text": "Verileriniz yüklenirken bir sorun oluştu. Lütfen tekrar deneyin.",
     "source_hash": "ff0d904e"
+  },
+  "web.teams.create_first_team_title": {
+    "text": "İlk ekibinizi oluşturun"
+  },
+  "web.teams.create_first_team_description": {
+    "text": "Ekipler, paylaşılan bir çalışma alanında başkalarıyla iş birliği yapmanızı sağlar."
+  },
+  "web.teams.create_team": {
+    "text": "Ekip oluştur"
   }
 }

--- a/locales/content/tr/workspace-domains.json
+++ b/locales/content/tr/workspace-domains.json
@@ -398,5 +398,725 @@
   "web.domains.dns_widget_description": {
     "text": "DNS sağlayıcınızı otomatik olarak algılamak ve alan adınızı yapılandırmak için adım adım talimatlar almak üzere aşağıdaki aracı kullanın.",
     "source_hash": "91c1af2e"
+  },
+  "api.domains.errors.add_admin_required": {
+    "text": "Yalnızca kuruluş sahipleri ve yöneticileri özel alan adı ekleyebilir"
+  },
+  "web.domains.public_homepage": {
+    "text": "Genel Ana Sayfa"
+  },
+  "web.domains.status_tooltip_active": {
+    "text": "Alan adı doğrulandı ve aktif"
+  },
+  "web.domains.status_tooltip_dns_incorrect": {
+    "text": "DNS yapılandırılmamış — düzeltmek için tıklayın"
+  },
+  "web.domains.status_tooltip_not_verified": {
+    "text": "Alan adı doğrulanmadı — doğrulamak için tıklayın"
+  },
+  "web.domains.status_tooltip_unverified": {
+    "text": "Alan adı durumu doğrulanmamış — yenilemek için tıklayın"
+  },
+  "web.domains.last_check_failed": {
+    "text": "Son doğrulama kontrolü başarısız oldu"
+  },
+  "web.domains.last_check_failed_ago": {
+    "text": "son kontrol {0} başarısız oldu"
+  },
+  "web.domains.verify_now": {
+    "text": "Şimdi doğrula"
+  },
+  "web.domains.click_to_verify": {
+    "text": "doğrulamak için tıklayın"
+  },
+  "web.domains.remove_domain_description": {
+    "text": "Bu alan adını ve tüm yapılandırmasını kalıcı olarak kaldırın."
+  },
+  "web.domains.add_access_denied": {
+    "text": "Erişim Reddedildi"
+  },
+  "web.domains.add_access_denied_description": {
+    "text": "Bu kuruluşa alan adı ekleme izniniz yok. Kuruluş yöneticinizle iletişime geçin."
+  },
+  "web.domains.dns_widget_load_failed": {
+    "text": "DNS bileşeni yüklenemedi"
+  },
+  "web.domains.dns_widget_not_available": {
+    "text": "DNS bileşeni kullanılamıyor"
+  },
+  "web.domains.dns_widget_init_failed": {
+    "text": "DNS bileşeni başlatılamadı"
+  },
+  "web.domains.verified": {
+    "text": "Doğrulandı"
+  },
+  "web.domains.pending_verification": {
+    "text": "Doğrulama Bekliyor"
+  },
+  "web.domains.unsaved_changes_confirmation": {
+    "text": "Kaydedilmemiş değişiklikleriniz var. Ayrılmak istediğinizden emin misiniz?"
+  },
+  "web.domains.entitlement_required_owner": {
+    "text": "Bu özellik bir plan yükseltmesi gerektirir."
+  },
+  "web.domains.entitlement_required_member": {
+    "text": "Bu özellik mevcut planınızda kullanılamıyor. Kuruluş sahibinizle iletişime geçin."
+  },
+  "web.domains.detail.manage": {
+    "text": "Yönet"
+  },
+  "web.domains.detail.features": {
+    "text": "Özellikler"
+  },
+  "web.domains.detail.homepage_title": {
+    "text": "Ana Sayfa Gizli Mesajları"
+  },
+  "web.domains.detail.homepage_description": {
+    "text": "Alan adı ana sayfanızda gizli mesaj oluşturmaya genel erişime izin verin"
+  },
+  "web.domains.detail.brand_description": {
+    "text": "Logo, renkler ve özel markalama"
+  },
+  "web.domains.detail.sso_description": {
+    "text": "Tek oturum açma (SSO) sağlayıcı ayarları"
+  },
+  "web.domains.detail.email_description": {
+    "text": "Özel e-posta gönderen yapılandırması"
+  },
+  "web.domains.detail.incoming_description": {
+    "text": "Gelen gizli mesaj alıcı ayarları"
+  },
+  "web.domains.detail.signup_description": {
+    "text": "Alan adına özel kayıt doğrulama stratejisi"
+  },
+  "web.domains.detail.signin_description": {
+    "text": "Alan adına özel giriş yöntemi yapılandırması"
+  },
+  "web.domains.email.title": {
+    "text": "E-posta Gönderme"
+  },
+  "web.domains.email.config_title": {
+    "text": "E-posta Yapılandırması"
+  },
+  "web.domains.email.config_description": {
+    "text": "Bu alan adı için e-posta göndermeyi yapılandırın"
+  },
+  "web.domains.email.provider_label": {
+    "text": "E-posta Sağlayıcısı"
+  },
+  "web.domains.email.provider_placeholder": {
+    "text": "Bir e-posta sağlayıcısı seçin"
+  },
+  "web.domains.email.from_name_label": {
+    "text": "Gönderen Adı"
+  },
+  "web.domains.email.from_name_placeholder": {
+    "text": "örn. Acme Security"
+  },
+  "web.domains.email.from_address_label": {
+    "text": "Gönderen Adresi"
+  },
+  "web.domains.email.from_address_placeholder": {
+    "text": "örn. secrets{'@'}example.com"
+  },
+  "web.domains.email.reply_to_label": {
+    "text": "Yanıt Adresi"
+  },
+  "web.domains.email.reply_to_placeholder": {
+    "text": "örn. support{'@'}example.com"
+  },
+  "web.domains.email.save_changes": {
+    "text": "Değişiklikleri Kaydet"
+  },
+  "web.domains.email.discard_changes": {
+    "text": "Değişiklikleri At"
+  },
+  "web.domains.email.provider_ses": {
+    "text": "Amazon SES"
+  },
+  "web.domains.email.provider_sendgrid": {
+    "text": "SendGrid"
+  },
+  "web.domains.email.provider_lettermint": {
+    "text": "Lettermint"
+  },
+  "web.domains.email.provider_inherit": {
+    "text": "Hesap varsayılanlarını kullan"
+  },
+  "web.domains.email.provider_ses_description": {
+    "text": "DKIM ve SPF kayıtları aracılığıyla alan adı doğrulaması gerektirir"
+  },
+  "web.domains.email.provider_sendgrid_description": {
+    "text": "Alan adı kimlik doğrulaması kurulumu gerektirir"
+  },
+  "web.domains.email.provider_lettermint_description": {
+    "text": "Alan adı doğrulaması gerektirir"
+  },
+  "web.domains.email.provider_inherit_description": {
+    "text": "Hesabınızın varsayılan e-posta gönderme yapılandırmasını kullanır"
+  },
+  "web.domains.email.dns_records_title": {
+    "text": "DNS Kayıtları"
+  },
+  "web.domains.email.dns_records_description": {
+    "text": "E-posta göndermek için alan adınızı doğrulamak üzere aşağıdaki DNS kayıtlarını ekleyin."
+  },
+  "web.domains.email.dns_column_type": {
+    "text": "Tür"
+  },
+  "web.domains.email.dns_column_name": {
+    "text": "Ad"
+  },
+  "web.domains.email.dns_column_value": {
+    "text": "Değer"
+  },
+  "web.domains.email.dns_check_label": {
+    "text": "DNS"
+  },
+  "web.domains.email.provider_check_label": {
+    "text": "Sağlayıcı"
+  },
+  "web.domains.email.dns_optional_label": {
+    "text": "Önerilen"
+  },
+  "web.domains.email.dns_optional_hint": {
+    "text": "Bu kayıt önerilir ancak doğrulama için gerekli değildir. Kuruluş alan adınızdaki bir DMARC politikası bu alt alan adını zaten kapsıyor olabilir."
+  },
+  "web.domains.email.copy": {
+    "text": "Kopyala"
+  },
+  "web.domains.email.copied": {
+    "text": "Kopyalandı"
+  },
+  "web.domains.email.status_verified": {
+    "text": "Doğrulandı"
+  },
+  "web.domains.email.status_pending": {
+    "text": "Beklemede"
+  },
+  "web.domains.email.status_failed": {
+    "text": "Başarısız"
+  },
+  "web.domains.email.revalidate": {
+    "text": "Yeniden doğrula"
+  },
+  "web.domains.email.validating": {
+    "text": "Doğrulanıyor..."
+  },
+  "web.domains.email.domain_verified": {
+    "text": "Alan adı doğrulandı"
+  },
+  "web.domains.email.validation_failed": {
+    "text": "Doğrulama başarısız oldu"
+  },
+  "web.domains.email.last_validated": {
+    "text": "Son doğrulama"
+  },
+  "web.domains.email.upgrade_to_configure": {
+    "text": "Bu alan adı için e-posta göndermeyi yapılandırmak üzere planınızı yükseltin."
+  },
+  "web.domains.email.configure_email": {
+    "text": "E-postayı Yapılandır"
+  },
+  "web.domains.email.access_denied": {
+    "text": "Erişim Reddedildi"
+  },
+  "web.domains.email.access_denied_description": {
+    "text": "Bu alan adının e-posta ayarlarını yönetme izniniz yok. Kuruluş yöneticinizle iletişime geçin."
+  },
+  "web.domains.email.update_success": {
+    "text": "E-posta yapılandırması başarıyla kaydedildi"
+  },
+  "web.domains.email.delete_success": {
+    "text": "E-posta yapılandırması başarıyla kaldırıldı"
+  },
+  "web.domains.email.default_sender_notice": {
+    "text": "Bu alan adı için e-postalar şu anda genel göndericiden gönderiliyor. Kendi gönderici kimliğinizi kullanmak için e-posta yapılandırmasını tamamlayın."
+  },
+  "web.domains.email.disabled_notice": {
+    "text": "Özel e-posta gönderme şu anda devre dışı. E-postalar genel göndericiden gönderilecek. Kendi gönderici kimliğinizi kullanmak için aşağıdaki özelliği etkinleştirin."
+  },
+  "web.domains.email.test_email_title": {
+    "text": "E-posta teslimatını test edin"
+  },
+  "web.domains.email.test_email_hint": {
+    "text": "Kaydedilen yapılandırmayı kullanarak kendinize bir test e-postası gönderin. Özellik henüz etkinleştirilmemiş olsa bile çalışır."
+  },
+  "web.domains.email.send_test": {
+    "text": "Test gönder"
+  },
+  "web.domains.email.test_email_sent": {
+    "text": "Test e-postası başarıyla gönderildi"
+  },
+  "web.domains.email.test_email_failed": {
+    "text": "Test e-postası gönderilemedi"
+  },
+  "web.domains.email.test_email_sent_to": {
+    "text": "{email} adresine gönderildi"
+  },
+  "web.domains.email.delivered_via": {
+    "text": "{provider} aracılığıyla teslim edildi"
+  },
+  "web.domains.email.badge_not_configured": {
+    "text": "Yapılandırılmamış"
+  },
+  "web.domains.email.badge_default_sender": {
+    "text": "Varsayılan gönderici kullanılıyor"
+  },
+  "web.domains.email.badge_verified": {
+    "text": "Doğrulandı"
+  },
+  "web.domains.email.badge_pending": {
+    "text": "Doğrulama bekliyor"
+  },
+  "web.domains.email.badge_disabled": {
+    "text": "Devre dışı"
+  },
+  "web.domains.email.tooltip_not_configured": {
+    "text": "Yapılandırılmış e-posta göndericisi yok — e-postalar platformun varsayılan göndericisini kullanır"
+  },
+  "web.domains.email.tooltip_pending": {
+    "text": "E-posta göndericisi yapılandırması doğrulama bekliyor — e-postalar platformun varsayılan göndericisini kullanır"
+  },
+  "web.domains.email.tooltip_disabled": {
+    "text": "E-posta göndericisi devre dışı — e-postalar platformun varsayılan göndericisini kullanır"
+  },
+  "web.domains.email.tooltip_verified": {
+    "text": "E-posta göndericisi doğrulandı — e-postalar bu alan adından gönderilir"
+  },
+  "web.domains.incoming.title": {
+    "text": "Gelen Gizli Mesajlar"
+  },
+  "web.domains.incoming.config_title": {
+    "text": "Gelen Gizli Mesajlar Yapılandırması"
+  },
+  "web.domains.incoming.config_description": {
+    "text": "Harici kullanıcıların bu alan adındaki belirlenen alıcılara doğrudan gizli mesaj göndermesine izin verin"
+  },
+  "web.domains.incoming.feature_disabled": {
+    "text": "Gelen Gizli Mesajlar Kullanılamıyor"
+  },
+  "web.domains.incoming.feature_disabled_description": {
+    "text": "Bu örnekte gelen gizli mesajlar etkinleştirilmemiş. Yöneticinizle iletişime geçin."
+  },
+  "web.domains.incoming.access_denied": {
+    "text": "Erişim Reddedildi"
+  },
+  "web.domains.incoming.access_denied_description": {
+    "text": "Bu alan adının gelen gizli mesaj ayarlarını yönetme izniniz yok. Kuruluş yöneticinizle iletişime geçin."
+  },
+  "web.domains.incoming.upgrade_to_configure": {
+    "text": "Bu alan adı için gelen gizli mesajları yapılandırmak üzere planınızı yükseltin."
+  },
+  "web.domains.incoming.configure_incoming": {
+    "text": "Gelen Gizli Mesajları Yapılandır"
+  },
+  "web.domains.incoming.not_configured_notice": {
+    "text": "Bu alan adı için gelen gizli mesajlar yapılandırılmamış. Harici kullanıcıların ekibinize gizli mesaj göndermesine izin vermek için alıcılar ekleyin."
+  },
+  "web.domains.incoming.disabled_notice": {
+    "text": "Gelen gizli mesajlar şu anda devre dışı. Harici kullanıcılar bu alan adındaki alıcılara gizli mesaj gönderemez. Gelen gizli mesajlara izin vermek için aşağıdaki özelliği etkinleştirin."
+  },
+  "web.domains.incoming.recipients_title": {
+    "text": "Alıcılar"
+  },
+  "web.domains.incoming.recipients_description": {
+    "text": "Bu alan adında kimlerin gelen gizli mesaj alabileceğini belirleyin. Kendilerine bir gizli mesaj gönderildiğinde alıcılar e-posta bildirimleri alır."
+  },
+  "web.domains.incoming.add_recipient": {
+    "text": "Alıcı Ekle"
+  },
+  "web.domains.incoming.remove_recipient": {
+    "text": "Kaldır"
+  },
+  "web.domains.incoming.email_label": {
+    "text": "E-posta Adresi"
+  },
+  "web.domains.incoming.email_placeholder": {
+    "text": "recipient{'@'}example.com"
+  },
+  "web.domains.incoming.name_label": {
+    "text": "Görünen Ad"
+  },
+  "web.domains.incoming.name_placeholder": {
+    "text": "örn. Security Team"
+  },
+  "web.domains.incoming.empty_state": {
+    "text": "Yapılandırılmış alıcı yok"
+  },
+  "web.domains.incoming.empty_state_description": {
+    "text": "Harici kullanıcıların ekibinize gizli mesaj göndermesine izin vermek için alıcılar ekleyin."
+  },
+  "web.domains.incoming.validation_invalid_email": {
+    "text": "Geçersiz e-posta adresi"
+  },
+  "web.domains.incoming.validation_duplicate_email": {
+    "text": "Bu e-posta adresi zaten eklenmiş"
+  },
+  "web.domains.incoming.validation_max_recipients": {
+    "text": "En fazla {max} alıcıya izin verilir"
+  },
+  "web.domains.incoming.validation_name_required": {
+    "text": "Görünen ad gereklidir"
+  },
+  "web.domains.incoming.validation_email_required": {
+    "text": "E-posta adresi gereklidir"
+  },
+  "web.domains.incoming.save_changes": {
+    "text": "Değişiklikleri Kaydet"
+  },
+  "web.domains.incoming.discard_changes": {
+    "text": "Değişiklikleri At"
+  },
+  "web.domains.incoming.update_success": {
+    "text": "Gelen gizli mesajlar yapılandırması başarıyla kaydedildi"
+  },
+  "web.domains.incoming.delete_success": {
+    "text": "Gelen gizli mesajlar yapılandırması başarıyla kaldırıldı"
+  },
+  "web.domains.incoming.recipient_count": {
+    "text": "{count} alıcı | {count} alıcı"
+  },
+  "web.domains.incoming.badge_not_configured": {
+    "text": "Yapılandırılmamış"
+  },
+  "web.domains.incoming.badge_configured": {
+    "text": "Yapılandırılmış"
+  },
+  "web.domains.incoming.badge_disabled": {
+    "text": "Devre dışı"
+  },
+  "web.domains.incoming.tooltip_not_configured": {
+    "text": "Gelen gizli mesajlar yapılandırılmamış - harici kullanıcılar bu alan adına gizli mesaj gönderemez"
+  },
+  "web.domains.incoming.tooltip_configured": {
+    "text": "Gelen gizli mesajlar {count} alıcı ile etkinleştirildi"
+  },
+  "web.domains.incoming.tooltip_disabled": {
+    "text": "Gelen gizli mesajlar özelliği bu alan adı için devre dışı"
+  },
+  "web.domains.incoming.enabled_label": {
+    "text": "Gelen Gizli Mesajları Etkinleştir"
+  },
+  "web.domains.incoming.enabled_hint": {
+    "text": "Harici kullanıcıların bu alan adındaki alıcılara gizli mesaj göndermesine izin verin"
+  },
+  "web.domains.incoming.public_url_label": {
+    "text": "Genel URL"
+  },
+  "web.domains.incoming.public_url_description": {
+    "text": "Harici kullanıcıların gizli mesaj göndermesine izin vermek için bu URL'yi onlarla paylaşın"
+  },
+  "web.domains.incoming.copy_url": {
+    "text": "URL'yi Kopyala"
+  },
+  "web.domains.incoming.url_copied": {
+    "text": "URL panoya kopyalandı"
+  },
+  "web.domains.incoming.remove_all_confirmation": {
+    "text": "Tüm alıcıları kaldırmak istediğinizden emin misiniz? Harici kullanıcılar artık bu alan adına gizli mesaj gönderemeyecek."
+  },
+  "web.domains.incoming.max_recipients_reached": {
+    "text": "Maksimum alıcı sayısına ulaşıldı"
+  },
+  "web.domains.incoming.duplicate_recipient": {
+    "text": "Bu e-posta adresi zaten eklenmiş"
+  },
+  "web.domains.incoming.save_will_replace_confirmation": {
+    "text": "Kaydetmek, mevcut tüm alıcıları bekleyen değişikliklerinizle değiştirecek. Emin misiniz?"
+  },
+  "web.domains.incoming.delete_all_recipients": {
+    "text": "Tüm Alıcıları Sil"
+  },
+  "web.domains.signin.title": {
+    "text": "Giriş Yapılandırması"
+  },
+  "web.domains.signin.configure_signin": {
+    "text": "Girişi Yapılandır"
+  },
+  "web.domains.signin.config_description": {
+    "text": "Bu alan adı için giriş kimlik doğrulama yöntemlerini yapılandırın"
+  },
+  "web.domains.signin.access_denied": {
+    "text": "Erişim Reddedildi"
+  },
+  "web.domains.signin.upgrade_to_configure": {
+    "text": "Bu alan adı için giriş yöntemlerini yapılandırmak üzere planınızı yükseltin."
+  },
+  "web.domains.signin.not_configured_notice": {
+    "text": "Bu alan adı için giriş yapılandırması henüz ayarlanmamış. Bu alan adının giriş sayfasında hangi kimlik doğrulama yöntemlerinin kullanılabilir olduğunu denetlemek için geçersiz kılmaları yapılandırın."
+  },
+  "web.domains.signin.signin_enabled_label": {
+    "text": "Giriş etkin"
+  },
+  "web.domains.signin.header_toggle_label": {
+    "text": "Giriş"
+  },
+  "web.domains.signin.signin_enabled_hint": {
+    "text": "Kullanıcıların bu alan adında giriş yapıp yapamayacağı"
+  },
+  "web.domains.signin.restrict_to_label": {
+    "text": "Giriş yöntemini kısıtla"
+  },
+  "web.domains.signin.restrict_to_hint": {
+    "text": "Bu alan adını tek bir kimlik doğrulama yöntemiyle kısıtlayın. Ayarlandığında, giriş sayfasında yalnızca seçilen yöntem gösterilir."
+  },
+  "web.domains.signin.all_methods": {
+    "text": "Tüm yöntemler"
+  },
+  "web.domains.signin.all_methods_description": {
+    "text": "Giriş sayfasında etkinleştirilmiş tüm kimlik doğrulama yöntemlerini göster"
+  },
+  "web.domains.signin.method_password": {
+    "text": "Parola"
+  },
+  "web.domains.signin.method_email_auth": {
+    "text": "E-posta ile kimlik doğrulama"
+  },
+  "web.domains.signin.method_webauthn": {
+    "text": "WebAuthn / Passkeys"
+  },
+  "web.domains.signin.method_sso": {
+    "text": "Tek Oturum Açma (SSO)"
+  },
+  "web.domains.signin.method_overrides_label": {
+    "text": "Yöntem geçersiz kılmaları"
+  },
+  "web.domains.signin.method_overrides_hint": {
+    "text": "Bu alan adı için tek tek kimlik doğrulama yöntemlerini etkinleştirin veya devre dışı bırakın"
+  },
+  "web.domains.signin.mode_question": {
+    "text": "Kullanıcılar nasıl giriş yapabilir?"
+  },
+  "web.domains.signin.mode_any": {
+    "text": "Kullanılabilir herhangi bir yöntem"
+  },
+  "web.domains.signin.mode_any_hint": {
+    "text": "Bu alan adında kullanılabilen her yöntemi göster. Aşağıdan tek tek yöntemleri daraltın."
+  },
+  "web.domains.signin.mode_one": {
+    "text": "Belirli bir yöntem"
+  },
+  "web.domains.signin.mode_one_hint": {
+    "text": "Giriş sayfasını tek bir yöntemle kısıtlayın. Yalnızca bu alan adında kullanılabilen yöntemler listelenir."
+  },
+  "web.domains.signin.mode_disabled": {
+    "text": "Giriş devre dışı"
+  },
+  "web.domains.signin.mode_disabled_hint": {
+    "text": "Kullanıcılar bu alan adında giriş yapamaz."
+  },
+  "web.domains.signin.mode_disabled_notice": {
+    "text": "Bu alan adının giriş sayfasını ziyaret edenler, ana sayfaya geri dönen bir bağlantıyla birlikte girişin kullanılamadığına dair bir bildirim görür. Önceki yöntem ayarlarınız saklanır ve girişi yeniden etkinleştirdiğinizde geri yüklenir."
+  },
+  "web.domains.signin.methods_list_label": {
+    "text": "Giriş sayfasında gösterilen yöntemler"
+  },
+  "web.domains.signin.restrict_picker_hint": {
+    "text": "Yalnızca bu alan adında kullanılabilen yöntemler listelenir."
+  },
+  "web.domains.signin.availability_always": {
+    "text": "Her zaman kullanılabilir"
+  },
+  "web.domains.signin.availability_global_on": {
+    "text": "Genel politikayı izler · Açık"
+  },
+  "web.domains.signin.availability_global_off": {
+    "text": "Kullanılamıyor"
+  },
+  "web.domains.signin.availability_unavailable": {
+    "text": "Site genelinde kullanılamıyor"
+  },
+  "web.domains.signin.allow_on_domain": {
+    "text": "Bu alan adında izin ver"
+  },
+  "web.domains.signin.method_password_blurb": {
+    "text": "Yalnızca parola"
+  },
+  "web.domains.signin.method_email_auth_blurb": {
+    "text": "Parolasız sihirli bağlantı ile giriş"
+  },
+  "web.domains.signin.method_webauthn_blurb": {
+    "text": "Biyometri ve güvenlik anahtarları"
+  },
+  "web.domains.signin.method_sso_blurb": {
+    "text": "Harici kimlik sağlayıcı"
+  },
+  "web.domains.signin.email_auth_label": {
+    "text": "E-posta ile kimlik doğrulama"
+  },
+  "web.domains.signin.email_auth_hint": {
+    "text": "Bu alan adında parolasız e-posta kimlik doğrulamasına izin verin"
+  },
+  "web.domains.signin.sso_enabled_label": {
+    "text": "Tek Oturum Açma (SSO)"
+  },
+  "web.domains.signin.sso_enabled_hint": {
+    "text": "Bu alan adında SSO kimlik doğrulamasına izin verin"
+  },
+  "web.domains.signin.enabled_label": {
+    "text": "Giriş yapılandırmasını etkinleştir"
+  },
+  "web.domains.signin.enabled_hint": {
+    "text": "Etkinleştirildiğinde, bu alan adı yukarıda yapılandırılan giriş ayarlarını kullanır"
+  },
+  "web.domains.signin.save_config": {
+    "text": "Yapılandırmayı kaydet"
+  },
+  "web.domains.signin.update_success": {
+    "text": "Giriş yapılandırması başarıyla güncellendi"
+  },
+  "web.domains.signin.reset_to_defaults": {
+    "text": "Varsayılanlara sıfırla"
+  },
+  "web.domains.signin.reset_confirm": {
+    "text": "Giriş genel varsayılanlara sıfırlansın mı?"
+  },
+  "web.domains.signin.reset_keeps_sso": {
+    "text": "SSO kimlik bilgileriniz saklanır. Bunları SSO yapılandırma ekranında ayrıca kaldırın."
+  },
+  "web.domains.signin.reset_action": {
+    "text": "Evet, sıfırla"
+  },
+  "web.domains.signin.reset_success": {
+    "text": "Giriş ayarları genel varsayılanlara sıfırlandı"
+  },
+  "web.domains.signup.title": {
+    "text": "Kayıt Doğrulaması"
+  },
+  "web.domains.signup.config_description": {
+    "text": "Bu alan adı için kayıt doğrulamasını yapılandırın"
+  },
+  "web.domains.signup.access_denied": {
+    "text": "Erişim Reddedildi"
+  },
+  "web.domains.signup.upgrade_to_configure": {
+    "text": "Alan adına özel kayıt doğrulamasını yapılandırmak üzere planınızı yükseltin."
+  },
+  "web.domains.signup.configure_signup": {
+    "text": "Kaydı Yapılandır"
+  },
+  "web.domains.signup.not_configured_notice": {
+    "text": "Bu alan adı için kayıt doğrulaması henüz yapılandırılmamış. Bu alan adı üzerinden kimlerin kaydolabileceğini denetlemek için bir strateji yapılandırın."
+  },
+  "web.domains.signup.site_signups_disabled_warning": {
+    "text": "Kayıtlar şu anda site düzeyinde devre dışı. Bu alan adına özel politika yapılandırılmış ancak site kayıtları etkinleştirilene kadar herhangi bir trafiği denetlemeyecek."
+  },
+  "web.domains.signup.strategy_label": {
+    "text": "Doğrulama stratejisi"
+  },
+  "web.domains.signup.strategy_description": {
+    "text": "Kullanıcılar bu alan adında kaydolurken e-posta adreslerinin nasıl doğrulanacağını seçin."
+  },
+  "web.domains.signup.network_validation_warning": {
+    "text": "Bu strateji, kayıt sırasında ağ çağrıları gerçekleştirir; bu da gecikme ekleyebilir veya bazı sağlayıcılar tarafından engellenebilir."
+  },
+  "web.domains.signup.allowed_domains_label": {
+    "text": "İzin verilen kayıt alan adları"
+  },
+  "web.domains.signup.allowed_domains_hint": {
+    "text": "Yalnızca bu e-posta alan adlarının kaydolmasına izin verilir. Her giriş için bir alan adı ekleyin."
+  },
+  "web.domains.signup.domain_placeholder": {
+    "text": "example.com"
+  },
+  "web.domains.signup.invalid_domain": {
+    "text": "Lütfen geçerli bir alan adı girin (örn. example.com)"
+  },
+  "web.domains.signup.domain_exists": {
+    "text": "Bu alan adı zaten listede"
+  },
+  "web.domains.signup.remove_domain": {
+    "text": "{domain} adresini kaldır"
+  },
+  "web.domains.signup.enabled_label": {
+    "text": "Alan adına özel doğrulamayı etkinleştir"
+  },
+  "web.domains.signup.enabled_hint": {
+    "text": "Etkinleştirildiğinde, bu alan adındaki kayıtlar genel politika yerine yukarıdaki stratejiyi kullanır."
+  },
+  "web.domains.signup.delete_config": {
+    "text": "Yapılandırmayı sil"
+  },
+  "web.domains.signup.delete_confirm": {
+    "text": "Kayıt doğrulama yapılandırması silinsin mi? Kayıtlar genel politikaya geri dönecek."
+  },
+  "web.domains.signup.save_config": {
+    "text": "Yapılandırmayı kaydet"
+  },
+  "web.domains.signup.update_success": {
+    "text": "Kayıt doğrulaması başarıyla güncellendi"
+  },
+  "web.domains.signup.delete_success": {
+    "text": "Kayıt doğrulama yapılandırması başarıyla kaldırıldı"
+  },
+  "web.domains.signup.domain_overrides_label": {
+    "text": "Alan adı geçersiz kılmaları"
+  },
+  "web.domains.signup.domain_overrides_hint": {
+    "text": "Bu alan adı için genel kayıt ayarlarını geçersiz kılın"
+  },
+  "web.domains.signup.signup_enabled_label": {
+    "text": "Kayıt etkin"
+  },
+  "web.domains.signup.signup_enabled_hint": {
+    "text": "Bu alan adı için kaydın etkin olup olmadığını geçersiz kılın"
+  },
+  "web.domains.signup.autoverify_label": {
+    "text": "Hesapları otomatik doğrula"
+  },
+  "web.domains.signup.autoverify_hint": {
+    "text": "Bu alan adında yeni hesapların otomatik olarak doğrulanıp doğrulanmayacağını geçersiz kılın"
+  },
+  "web.domains.sso.title": {
+    "text": "Tek Oturum Açma (SSO)"
+  },
+  "web.domains.sso.config_title": {
+    "text": "SSO Yapılandırması"
+  },
+  "web.domains.sso.config_description": {
+    "text": "Bu alan adı için tek oturum açma kimlik doğrulamasını yapılandırın"
+  },
+  "web.domains.sso.access_denied": {
+    "text": "Erişim Reddedildi"
+  },
+  "web.domains.sso.access_denied_description": {
+    "text": "Bu alan adının SSO ayarlarını yönetme izniniz yok. Kuruluş yöneticinizle iletişime geçin."
+  },
+  "web.domains.sso.upgrade_to_configure": {
+    "text": "Bu alan adı için tek oturum açmayı yapılandırmak üzere planınızı yükseltin."
+  },
+  "web.domains.sso.create_success": {
+    "text": "SSO yapılandırması başarıyla oluşturuldu"
+  },
+  "web.domains.sso.update_success": {
+    "text": "SSO yapılandırması başarıyla güncellendi"
+  },
+  "web.domains.sso.delete_success": {
+    "text": "SSO yapılandırması başarıyla kaldırıldı"
+  },
+  "web.domains.sso.test_success": {
+    "text": "Bağlantı testi başarılı — sağlayıcı doğru yanıt verdi"
+  },
+  "web.domains.sso.test_failed": {
+    "text": "Bağlantı testi başarısız oldu"
+  },
+  "web.domains.sso.enforce_moved_notice": {
+    "text": "Bu alan adındaki tüm girişler için SSO'yu zorunlu kılmak istiyorsanız bunu alan adının giriş ayarlarında yapılandırın. Yalnızca SSO modu, giriş sayfasını burada yapılandırılan SSO sağlayıcısıyla kısıtlar."
+  },
+  "web.domains.sso.configure_sso": {
+    "text": "SSO'yu Yapılandır"
+  },
+  "web.domains.sso.not_configured_notice": {
+    "text": "Bu alan adı için SSO henüz yapılandırılmamış. Ekip üyelerinin kuruluşunuzun kimlik sağlayıcısını kullanarak kimlik doğrulaması yapmasına izin vermek için tek oturum açmayı etkinleştirin."
+  },
+  "web.domains.sso.edit_credentials": {
+    "text": "Kimlik bilgilerini düzenle"
+  },
+  "web.domains.sso.configure_button": {
+    "text": "Yapılandır"
+  },
+  "web.domains.sso.upgrade_required": {
+    "text": "Yapılandırmak için yükseltin"
   }
 }

--- a/locales/content/tr/workspace-organizations.json
+++ b/locales/content/tr/workspace-organizations.json
@@ -578,5 +578,344 @@
   "web.organizations.invitations.expires_soon": {
     "text": "Yakında sona erecek",
     "source_hash": "a5dcfef9"
+  },
+  "api.organizations.errors.not_found": {
+    "text": "Kuruluş bulunamadı: %{extid}"
+  },
+  "api.organizations.errors.owner_required": {
+    "text": "Bu işlemi yalnızca kuruluş sahibi gerçekleştirebilir"
+  },
+  "api.organizations.errors.admin_required": {
+    "text": "Bu işlemi yalnızca kuruluş sahipleri ve yöneticileri gerçekleştirebilir"
+  },
+  "api.organizations.errors.member_required": {
+    "text": "Bu işlemi gerçekleştirmek için bir kuruluş üyesi olmalısınız"
+  },
+  "api.organizations.invitations.errors.create_admin_required": {
+    "text": "Davetleri yalnızca kuruluş sahipleri ve yöneticileri oluşturabilir"
+  },
+  "api.organizations.invitations.errors.resend_admin_required": {
+    "text": "Davetleri yalnızca kuruluş sahipleri ve yöneticileri yeniden gönderebilir"
+  },
+  "api.organizations.invitations.errors.view_admin_required": {
+    "text": "Davetleri yalnızca kuruluş sahipleri ve yöneticileri görüntüleyebilir"
+  },
+  "api.organizations.invitations.errors.revoke_admin_required": {
+    "text": "Davetleri yalnızca kuruluş sahipleri ve yöneticileri iptal edebilir"
+  },
+  "api.organizations.invitations.errors.email_required": {
+    "text": "E-posta gereklidir"
+  },
+  "api.organizations.invitations.errors.email_invalid": {
+    "text": "Geçersiz e-posta biçimi"
+  },
+  "api.organizations.invitations.errors.role_invalid": {
+    "text": "Rol üye veya yönetici olmalıdır"
+  },
+  "api.organizations.invitations.errors.cannot_invite_owner": {
+    "text": "Sahip olarak davet edilemez"
+  },
+  "api.organizations.invitations.errors.already_member": {
+    "text": "Kullanıcı zaten bu kuruluşun üyesi"
+  },
+  "api.organizations.invitations.errors.already_pending": {
+    "text": "Bu e-posta için zaten bekleyen bir davet var"
+  },
+  "api.organizations.invitations.errors.member_limit_reached": {
+    "text": "Üye sınırına ulaşıldı. Daha fazla üye davet etmek için planınızı yükseltin."
+  },
+  "api.organizations.invitations.errors.not_found": {
+    "text": "Davet bulunamadı"
+  },
+  "api.organizations.invitations.errors.cannot_resend_non_pending": {
+    "text": "Yalnızca bekleyen davetler yeniden gönderilebilir"
+  },
+  "api.organizations.invitations.errors.cannot_revoke_non_pending": {
+    "text": "Yalnızca bekleyen davetler iptal edilebilir"
+  },
+  "api.organizations.invitations.errors.resend_limit_reached": {
+    "text": "Maksimum yeniden gönderme sınırına (%{max}) ulaşıldı"
+  },
+  "api.organizations.invitations.errors.accept_token_required": {
+    "text": "Token gereklidir"
+  },
+  "api.organizations.invitations.errors.accept_organization_gone": {
+    "text": "Kuruluş artık mevcut değil"
+  },
+  "api.organizations.invitations.errors.accept_already_acted": {
+    "text": "Davet zaten %{status}"
+  },
+  "api.organizations.invitations.errors.accept_expired": {
+    "text": "Davetin süresi doldu"
+  },
+  "api.organizations.invitations.errors.accept_email_mismatch": {
+    "text": "E-posta adresiniz davetle eşleşmiyor"
+  },
+  "api.organizations.invitations.errors.accept_already_member": {
+    "text": "Zaten bu kuruluşun üyesisiniz"
+  },
+  "web.organizations.entitlements_title": {
+    "text": "Kuruluş Yetkilendirmeleri"
+  },
+  "web.organizations.page_description_short": {
+    "text": "Çalışma alanlarınızı görüntüleyin ve yapılandırın"
+  },
+  "web.organizations.delete_organization_remove_domains_first": {
+    "text": "Bu kuruluşu silmeden önce tüm özel alan adlarını kaldırın."
+  },
+  "web.organizations.default_org_delete_notice_title": {
+    "text": "Bu kuruluşu silme"
+  },
+  "web.organizations.default_org_delete_notice_before": {
+    "text": "Bu, varsayılan kuruluşunuzdur ve kontrol panelinden kaldırılamaz. Silmek için lütfen şu yoldan bize ulaşın:"
+  },
+  "web.organizations.default_org_delete_notice_link": {
+    "text": "geri bildirim formu"
+  },
+  "web.organizations.default_org_delete_notice_after": {
+    "text": "."
+  },
+  "web.organizations.leave_organization": {
+    "text": "Bu kuruluştan ayrıl"
+  },
+  "web.organizations.leave_organization_warning": {
+    "text": "Bu kuruluşa ve kaynaklarına erişiminizi kaybedeceksiniz."
+  },
+  "web.organizations.leave_organization_confirm_title": {
+    "text": "Kuruluştan Ayrıl"
+  },
+  "web.organizations.leave_organization_confirm_message": {
+    "text": "{name} kuruluşundan ayrılmak istediğinizden emin misiniz? Yeniden katılmak için yeni bir davete ihtiyacınız olacak."
+  },
+  "web.organizations.leave_organization_success": {
+    "text": "Kuruluştan ayrıldınız."
+  },
+  "web.organizations.leave_error": {
+    "text": "Kuruluştan ayrılınamadı"
+  },
+  "web.organizations.organizations": {
+    "text": "Kuruluşlar"
+  },
+  "web.organizations.invitations.invited_by_inline": {
+    "text": "{email} tarafından"
+  },
+  "web.organizations.invitations.invited_as_inline": {
+    "text": "{role} olarak"
+  },
+  "web.organizations.invitations.back_to_home": {
+    "text": "Ana sayfaya dön"
+  },
+  "web.organizations.invitations.email_locked_hint": {
+    "text": "Bu davet bu e-posta adresine gönderildi"
+  },
+  "web.organizations.invitations.signup_continue": {
+    "text": "Devam et"
+  },
+  "web.organizations.invitations.signin_continue": {
+    "text": "Giriş yap"
+  },
+  "web.organizations.invitations.confirm_join_below": {
+    "text": "Neredeyse tamam — kuruluşa katılmak için aşağıdan onaylayın."
+  },
+  "web.organizations.invitations.go_to_organizations": {
+    "text": "Kuruluşlara git"
+  },
+  "web.organizations.invitations.already_member": {
+    "text": "Zaten bu kuruluşun üyesisiniz"
+  },
+  "web.organizations.invitations.join_organization": {
+    "text": "{orgName} kuruluşuna katıl"
+  },
+  "web.organizations.invitations.sign_in_to_join": {
+    "text": "{orgName} kuruluşuna katılmak için giriş yapın"
+  },
+  "web.organizations.invitations.decline": {
+    "text": "Reddet"
+  },
+  "web.organizations.members.member_quota": {
+    "text": "{limit} üyeden {used} tanesi"
+  },
+  "web.organizations.members.pending_suffix": {
+    "text": "({count} bekliyor)"
+  },
+  "web.organizations.members.limit_reached_hint": {
+    "text": "Üye sınırına ulaşıldı."
+  },
+  "web.organizations.sso.title": {
+    "text": "Tek Oturum Açma (SSO)"
+  },
+  "web.organizations.sso.description": {
+    "text": "Üyelerin kuruluşunuzun kimlik sağlayıcısıyla giriş yapmasına izin vermek için SSO'yu yapılandırın"
+  },
+  "web.organizations.sso.provider_type": {
+    "text": "Sağlayıcı Türü"
+  },
+  "web.organizations.sso.provider_type_description": {
+    "text": "Kuruluşunuzun kimlik sağlayıcısını seçin"
+  },
+  "web.organizations.sso.display_name": {
+    "text": "Görünen Ad"
+  },
+  "web.organizations.sso.display_name_hint": {
+    "text": "Giriş yaparken kullanıcılara gösterilen kullanıcı dostu bir ad"
+  },
+  "web.organizations.sso.display_name_placeholder": {
+    "text": "örn. Acme Corp SSO"
+  },
+  "web.organizations.sso.client_id": {
+    "text": "Client ID"
+  },
+  "web.organizations.sso.client_id_placeholder": {
+    "text": "OAuth client ID'niz"
+  },
+  "web.organizations.sso.client_secret": {
+    "text": "Client Secret"
+  },
+  "web.organizations.sso.client_secret_placeholder": {
+    "text": "OAuth client secret'ınız"
+  },
+  "web.organizations.sso.client_secret_update_hint": {
+    "text": "Mevcut secret'ı korumak için boş bırakın"
+  },
+  "web.organizations.sso.tenant_id": {
+    "text": "Tenant ID"
+  },
+  "web.organizations.sso.tenant_id_hint": {
+    "text": "Azure AD / Entra ID tenant tanımlayıcınız"
+  },
+  "web.organizations.sso.tenant_id_placeholder": {
+    "text": "örn. 12345678-1234-1234-1234-123456789abc"
+  },
+  "web.organizations.sso.issuer": {
+    "text": "Issuer URL"
+  },
+  "web.organizations.sso.issuer_hint": {
+    "text": "Kimlik sağlayıcınız için OIDC keşif URL'si"
+  },
+  "web.organizations.sso.issuer_placeholder": {
+    "text": "örn. https://login.example.com"
+  },
+  "web.organizations.sso.view_discovery_document": {
+    "text": "Keşif belgesini görüntüle"
+  },
+  "web.organizations.sso.callback_url": {
+    "text": "Callback URL"
+  },
+  "web.organizations.sso.callback_url_hint": {
+    "text": "Bu URL'yi kimlik sağlayıcınızın izin verilen yönlendirme URI'lerine ekleyin"
+  },
+  "web.organizations.sso.allowed_domains": {
+    "text": "İzin Verilen E-posta Alan Adları"
+  },
+  "web.organizations.sso.allowed_domains_hint": {
+    "text": "Yalnızca bu alan adlarından e-posta adresine sahip kullanıcılar giriş yapabilir. Tüm alan adlarına izin vermek için boş bırakın."
+  },
+  "web.organizations.sso.domain_placeholder": {
+    "text": "örn. acme.com"
+  },
+  "web.organizations.sso.invalid_domain": {
+    "text": "Lütfen geçerli bir alan adı girin (örn. example.com)"
+  },
+  "web.organizations.sso.domain_exists": {
+    "text": "Bu alan adı zaten listede"
+  },
+  "web.organizations.sso.remove_domain": {
+    "text": "{domain} adresini kaldır"
+  },
+  "web.organizations.sso.enabled": {
+    "text": "SSO'yu Etkinleştir"
+  },
+  "web.organizations.sso.enabled_hint": {
+    "text": "Etkinleştirildiğinde, kuruluş üyeleri bu SSO sağlayıcısını kullanarak giriş yapabilir"
+  },
+  "web.organizations.sso.enforce_sso_only": {
+    "text": "Yalnızca SSO'yu zorunlu kıl"
+  },
+  "web.organizations.sso.enforce_sso_only_hint": {
+    "text": "Bu alan adındaki tüm girişler için SSO'yu zorunlu kılın. Etkinleştirildiğinde, parola tabanlı kimlik doğrulama devre dışı bırakılır."
+  },
+  "web.organizations.sso.grant_org_scope": {
+    "text": "Kuruluş genelinde erişim ver"
+  },
+  "web.organizations.sso.grant_org_scope_hint": {
+    "text": "Bu alan adının SSO'su aracılığıyla katılan yeni üyelere tüm kuruluş alan adlarına erişim verilir. Mevcut üyeler etkilenmez. Devre dışı bırakıldığında (varsayılan), yeni üyeler yalnızca bu alan adına erişebilir."
+  },
+  "web.organizations.sso.save_config": {
+    "text": "SSO Yapılandırmasını Kaydet"
+  },
+  "web.organizations.sso.delete_config": {
+    "text": "Yapılandırmayı Sil"
+  },
+  "web.organizations.sso.delete_confirm": {
+    "text": "Emin misiniz? Bu, kuruluşunuz için SSO'yu devre dışı bırakacak."
+  },
+  "web.organizations.sso.load_error": {
+    "text": "SSO yapılandırması yüklenemedi"
+  },
+  "web.organizations.sso.save_error": {
+    "text": "SSO yapılandırması kaydedilemedi"
+  },
+  "web.organizations.sso.create_success": {
+    "text": "SSO yapılandırması başarıyla oluşturuldu"
+  },
+  "web.organizations.sso.update_success": {
+    "text": "SSO yapılandırması başarıyla güncellendi"
+  },
+  "web.organizations.sso.delete_success": {
+    "text": "SSO yapılandırması başarıyla silindi"
+  },
+  "web.organizations.sso.delete_error": {
+    "text": "SSO yapılandırması silinemedi"
+  },
+  "web.organizations.sso.test_connection": {
+    "text": "Bağlantıyı Test Et"
+  },
+  "web.organizations.sso.test_connection_hint": {
+    "text": "Kimlik sağlayıcısının erişilebilir olduğunu doğrulayın (kimlik bilgilerini doğrulamaz)"
+  },
+  "web.organizations.sso.test_button": {
+    "text": "Bağlantıyı Test Et"
+  },
+  "web.organizations.sso.testing": {
+    "text": "Test ediliyor..."
+  },
+  "web.organizations.sso.test_error": {
+    "text": "Bağlantı test edilemedi"
+  },
+  "web.organizations.sso.auth_endpoint": {
+    "text": "Yetkilendirme Uç Noktası"
+  },
+  "web.organizations.sso.missing_fields": {
+    "text": "Eksik Alanlar"
+  },
+  "web.organizations.sso.status_enabled": {
+    "text": "Etkin"
+  },
+  "web.organizations.sso.status_configured": {
+    "text": "Yapılandırılmış"
+  },
+  "web.organizations.sso.domain_sso_title": {
+    "text": "Alan Adı SSO'su"
+  },
+  "web.organizations.sso.domain_sso_description": {
+    "text": "Her doğrulanmış alan adı için SSO'yu yapılandırın"
+  },
+  "web.organizations.sso.provider_type_locked_hint": {
+    "text": "Sağlayıcıyı değiştirmek için önce bu yapılandırmayı silin"
+  },
+  "web.organizations.sso.status_not_configured": {
+    "text": "Yapılandırılmamış"
+  },
+  "web.organizations.sso.no_domains": {
+    "text": "Doğrulanmış alan adı yok"
+  },
+  "web.organizations.sso.no_domains_description": {
+    "text": "SSO'yu yapılandırmadan önce bir alan adı ekleyin ve doğrulayın."
+  },
+  "web.organizations.tabs.team": {
+    "text": "Ekip"
+  },
+  "web.organizations.tabs.sso": {
+    "text": "SSO"
   }
 }


### PR DESCRIPTION
## `tr` translation update

Automated export of completed **tr** translations from the translation task DB.
Scope: `locales/content/tr/` only — 27 file(s), +1852/-34.

✅ `i18n validate variables`: no variable mismatches.

---

### Local quality review

> Produced by a fresh, isolated `claude` review agent (model `claude-sonnet-5`, agent `saas-translator`) that read
> `locales/AGENT_TRANSLATION_PROTOCOL.md` and inspected this branch's diff before the PR was opened.

No mojibake found. This is clean. I have enough to write the review.

**Verdict:** ✅ Looks good — no critical issues found

**Summary:** Automated variable-consistency check (rebuilt against the actual source branch, since the local checkout wasn't on it) found zero placeholder/token mismatches, zero previously-empty-now-still-empty strings, and no leaked English or mojibake across all ~27 changed/added files.

**Critical (must fix):** None

**Warnings:**
- `web.auth.sessions.session_singular` and `session_plural` both translate to "oturum" — Turkish does have a plural form (oturumlar); worth confirming this is intentional (e.g. used only as a bare noun label, not with a count) rather than a missed plural.

**Notes:**
- Two previously-empty tr strings (`web.settings.manage_your_account_settings_and_preferences`, `web.settings.security.generate_recovery_codes_recommendation`) are now correctly filled in.
- Recurring stylistic cleanup: brand name + Turkish suffix now goes through a buffer noun (e.g. "{product_name} ürününün", "{product_name} uygulamasına") instead of an apostrophe+suffix directly on the English brand name — consistent and avoids awkward apostrophe constructions.
- Email `signature` fields consistently swapped from "Delano" to "Destek Ekibi" (Support Team) across all templates — matches the pattern used in other locales' equivalent PRs.
- `web.regions.changing_regions_billing_note` edit correctly drops an over-translated possessive suffix, now matching the English source's "the billing contact email" (not "your ... email" a second time).
- Three `_guidance.context` keys (doc metadata, not user-facing) have no English counterpart by design — expected and fine.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
