### PR TITLE
i18n: update vi translations

### DIFF
--- a/locales/content/vi/00-common.json
+++ b/locales/content/vi/00-common.json
@@ -1299,7 +1299,7 @@
     "source_hash": "fc78d9cb"
   },
   "web.INSTRUCTION.phishing_warning": {
-    "text": "Luôn xác minh bạn đang ở trên trang web chính thức của {product_name}. Kẻ lừa đảo đôi khi tạo các trang web giả trông giống hệt {product_name} để đánh cắp bí mật của bạn. Để tránh các cuộc tấn công lừa đảo, hãy kiểm tra tên miền trước khi tạo liên kết mới.",
+    "text": "Luôn xác minh rằng bạn đang ở trên trang web chính thức của {product_name}. Kẻ gian đôi khi tạo ra các trang web giả mạo trông giống hệt {product_name} để đánh cắp bí mật của bạn. Để tránh các cuộc tấn công lừa đảo (phishing), hãy kiểm tra tên miền khu vực trước khi tạo liên kết mới.",
     "source_hash": "b588f5b2"
   },
   "web.pricing.title": {
@@ -1383,5 +1383,110 @@
     "text": "Nâng cấp để mở khóa thêm tính năng",
     "context": "Description shown for free plan users encouraging upgrade",
     "source_hash": "783f174c"
+  },
+  "api.errors.authentication_required": {
+    "text": "Yêu cầu xác thực"
+  },
+  "api.errors.sso_only_action_blocked": {
+    "text": "Hành động này không khả dụng ở chế độ chỉ SSO"
+  },
+  "web.COMMON.configure": {
+    "text": "Cấu hình"
+  },
+  "web.COMMON.copy_to_clipboard": {
+    "text": "Sao chép vào clipboard"
+  },
+  "web.COMMON.add": {
+    "text": "Thêm"
+  },
+  "web.COMMON.enabled": {
+    "text": "Đã bật"
+  },
+  "web.COMMON.disabled": {
+    "text": "Đã tắt"
+  },
+  "web.COMMON.yes_delete": {
+    "text": "Có, xóa"
+  },
+  "web.COMMON.error_code": {
+    "text": "Mã lỗi"
+  },
+  "web.COMMON.http_status": {
+    "text": "Trạng thái HTTP"
+  },
+  "web.COMMON.details": {
+    "text": "Chi tiết"
+  },
+  "web.COMMON.field_confirm_password": {
+    "text": "Xác nhận mật khẩu"
+  },
+  "web.COMMON.passwords_must_match": {
+    "text": "Mật khẩu phải khớp nhau"
+  },
+  "web.COMMON.and": {
+    "text": "và"
+  },
+  "web.COMMON.or": {
+    "text": "hoặc"
+  },
+  "web.COMMON.copied": {
+    "text": "Đã sao chép"
+  },
+  "web.COMMON.copy": {
+    "text": "Sao chép"
+  },
+  "web.COMMON.copy_email": {
+    "text": "Sao chép địa chỉ email"
+  },
+  "web.COMMON.copy_id": {
+    "text": "Sao chép ID tài khoản"
+  },
+  "web.COMMON.org_id_tooltip": {
+    "text": "Mã định danh duy nhất của tổ chức bạn"
+  },
+  "web.COMMON.success": {
+    "text": "Thành công"
+  },
+  "web.COMMON.need_help": {
+    "text": "Cần trợ giúp"
+  },
+  "web.COMMON.open_help_dialog": {
+    "text": "Mở hộp thoại trợ giúp"
+  },
+  "web.COMMON.focus_is_now_in_the_main_text_area": {
+    "text": "Con trỏ hiện đang ở vùng văn bản chính"
+  },
+  "web.LABELS.show_passphrase": {
+    "text": "Hiển thị cụm mật khẩu"
+  },
+  "web.LABELS.hide_passphrase": {
+    "text": "Ẩn cụm mật khẩu"
+  },
+  "web.LABELS.copy_icon": {
+    "text": "Biểu tượng sao chép"
+  },
+  "web.LABELS.copied_icon": {
+    "text": "Biểu tượng đã sao chép"
+  },
+  "web.STATUS.unverified": {
+    "text": "Chưa xác minh"
+  },
+  "web.TITLES.domain_detail": {
+    "text": "Cài đặt tên miền"
+  },
+  "web.TITLES.domain_signin": {
+    "text": "Cấu hình đăng nhập"
+  },
+  "web.TITLES.domain_sso": {
+    "text": "SSO tên miền"
+  },
+  "web.TITLES.domain_signup": {
+    "text": "Xác thực đăng ký tên miền"
+  },
+  "web.TITLES.domain_email": {
+    "text": "Cấu hình email"
+  },
+  "web.TITLES.domain_incoming": {
+    "text": "Bí mật đến"
   }
 }

--- a/locales/content/vi/10-layout.json
+++ b/locales/content/vi/10-layout.json
@@ -148,7 +148,7 @@
     "source_hash": "b9766df3"
   },
   "web.help.secret_view_faq.what_am_i_looking_at.description": {
-    "text": "Bạn đang xem một tin nhắn an toàn được chia sẻ với bạn thông qua {product_name}. Nội dung này chỉ được hiển thị một lần và sau đó sẽ bị xóa vĩnh viễn khỏi máy chủ của chúng tôi.",
+    "text": "Bạn đang xem một tin nhắn an toàn được chia sẻ với bạn qua {product_name}. Nội dung này chỉ được hiển thị một lần và sau đó bị xóa vĩnh viễn khỏi máy chủ của chúng tôi.",
     "source_hash": "e0f1a10c"
   },
   "web.help.secret_view_faq.can_i_view_again.title": {
@@ -338,5 +338,11 @@
   "web.layout.workspace_context": {
     "text": "Ngữ cảnh không gian làm việc",
     "source_hash": "dc6fa4f5"
+  },
+  "web.footer.workspace": {
+    "text": "Không gian làm việc"
+  },
+  "web.help.default_content": {
+    "text": "Vui lòng liên hệ bộ phận hỗ trợ để được trợ giúp"
   }
 }

--- a/locales/content/vi/admin-colonel.json
+++ b/locales/content/vi/admin-colonel.json
@@ -634,5 +634,152 @@
   "web.colonel.feedback.when_you_submit_feedback_well_see": {
     "text": "Khi bạn gửi phản hồi, chúng tôi sẽ thấy:",
     "source_hash": "fe77172e"
+  },
+  "web.colonel.previewPlanMode": {
+    "text": "Chế độ xem trước gói"
+  },
+  "web.colonel.previewModeDescription": {
+    "text": "Xem trước ứng dụng theo cách nó hiển thị với khách hàng đang dùng một gói khác. Điều này chỉ ảnh hưởng đến chế độ xem của bạn và không thay đổi gói thực tế của bất kỳ tổ chức nào."
+  },
+  "web.colonel.previewModeActive": {
+    "text": "Đang xem trước"
+  },
+  "web.colonel.bannedIps.empty": {
+    "text": "Không có IP nào bị chặn"
+  },
+  "web.colonel.bannedIps.currentIp": {
+    "text": "Địa chỉ IP hiện tại của bạn"
+  },
+  "web.colonel.bannedIps.confirmUnban": {
+    "text": "Bỏ chặn {ip}?"
+  },
+  "web.colonel.bannedIps.actions.ban": {
+    "text": "Chặn IP"
+  },
+  "web.colonel.bannedIps.actions.quickBan": {
+    "text": "Chặn nhanh"
+  },
+  "web.colonel.bannedIps.actions.unban": {
+    "text": "Bỏ chặn"
+  },
+  "web.colonel.bannedIps.actions.cancel": {
+    "text": "Hủy"
+  },
+  "web.colonel.bannedIps.columns.ipAddress": {
+    "text": "Địa chỉ IP"
+  },
+  "web.colonel.bannedIps.columns.reason": {
+    "text": "Lý do"
+  },
+  "web.colonel.bannedIps.columns.bannedAt": {
+    "text": "Chặn lúc"
+  },
+  "web.colonel.bannedIps.columns.bannedBy": {
+    "text": "Chặn bởi"
+  },
+  "web.colonel.bannedIps.error.banFailed": {
+    "text": "Không thể chặn địa chỉ IP"
+  },
+  "web.colonel.bannedIps.error.unbanFailed": {
+    "text": "Không thể bỏ chặn địa chỉ IP"
+  },
+  "web.colonel.bannedIps.form.title": {
+    "text": "Chặn địa chỉ IP"
+  },
+  "web.colonel.bannedIps.form.ipLabel": {
+    "text": "Địa chỉ IP"
+  },
+  "web.colonel.bannedIps.form.reasonLabel": {
+    "text": "Lý do"
+  },
+  "web.colonel.bannedIps.form.reasonPlaceholder": {
+    "text": "Lý do (tùy chọn)"
+  },
+  "web.colonel.bannedIps.success.banned": {
+    "text": "Địa chỉ IP {ip} đã bị chặn"
+  },
+  "web.colonel.bannedIps.success.unbanned": {
+    "text": "Địa chỉ IP {ip} đã được bỏ chặn"
+  },
+  "web.colonel.customDomains.empty": {
+    "text": "Chưa cấu hình tên miền tùy chỉnh nào"
+  },
+  "web.colonel.customDomains.noLogo": {
+    "text": "Không có logo"
+  },
+  "web.colonel.customDomains.labels.organization": {
+    "text": "Tổ chức"
+  },
+  "web.colonel.customDomains.labels.externalId": {
+    "text": "ID bên ngoài"
+  },
+  "web.colonel.customDomains.labels.created": {
+    "text": "Ngày tạo"
+  },
+  "web.colonel.customDomains.labels.updated": {
+    "text": "Ngày cập nhật"
+  },
+  "web.colonel.customDomains.labels.favicon": {
+    "text": "Favicon"
+  },
+  "web.colonel.customDomains.status.verified": {
+    "text": "Đã xác minh"
+  },
+  "web.colonel.customDomains.status.resolving": {
+    "text": "Đang phân giải"
+  },
+  "web.colonel.customDomains.status.ready": {
+    "text": "Sẵn sàng"
+  },
+  "web.colonel.customDomains.status.publicHomepage": {
+    "text": "Trang chủ công khai"
+  },
+  "web.colonel.customDomains.status.publicApi": {
+    "text": "API công khai"
+  },
+  "web.colonel.customDomains.status.pending": {
+    "text": "Đang chờ"
+  },
+  "web.colonel.pagination.showing": {
+    "text": "Đang hiển thị {start}–{end} trong số {total}"
+  },
+  "web.colonel.pagination.itemsPerPage": {
+    "text": "Số mục mỗi trang"
+  },
+  "web.colonel.pagination.perPage": {
+    "text": "{count} mỗi trang"
+  },
+  "web.colonel.pagination.pageOf": {
+    "text": "Trang {current} trên {total}"
+  },
+  "web.colonel.secrets.empty": {
+    "text": "Không tìm thấy bí mật nào"
+  },
+  "web.colonel.secrets.never": {
+    "text": "Không bao giờ"
+  },
+  "web.colonel.secrets.columns.shortId": {
+    "text": "ID ngắn"
+  },
+  "web.colonel.secrets.columns.state": {
+    "text": "Trạng thái"
+  },
+  "web.colonel.secrets.columns.created": {
+    "text": "Ngày tạo"
+  },
+  "web.colonel.secrets.columns.expiration": {
+    "text": "Ngày hết hạn"
+  },
+  "web.colonel.secrets.columns.age": {
+    "text": "Tuổi (ngày)"
+  },
+  "web.colonel.secrets.state.new": {
+    "text": "Mới"
+  },
+  "web.colonel.secrets.state.received": {
+    "text": "Đã nhận"
+  },
+  "web.colonel.secrets.state.viewed": {
+    "text": "Đã xem"
   }
 }

--- a/locales/content/vi/api-account-errors.json
+++ b/locales/content/vi/api-account-errors.json
@@ -1,0 +1,8 @@
+{
+  "api.account.errors.invalid_email": {
+    "text": "Đó có phải là địa chỉ email hợp lệ không?"
+  },
+  "api.account.errors.password_too_short": {
+    "text": "Mật khẩu quá ngắn"
+  }
+}

--- a/locales/content/vi/api-domains-errors.json
+++ b/locales/content/vi/api-domains-errors.json
@@ -1,0 +1,29 @@
+{
+  "api.domains.errors.domain_id_required": {
+    "text": "Cần có ID tên miền"
+  },
+  "api.domains.errors.domain_not_found": {
+    "text": "Không tìm thấy tên miền: %{extid}"
+  },
+  "api.domains.errors.organization_not_found": {
+    "text": "Không tìm thấy tổ chức cho tên miền: %{domain}"
+  },
+  "api.domains.errors.incoming_secrets_disabled": {
+    "text": "Bí mật đến chưa được bật trên phiên bản này"
+  },
+  "api.domains.errors.incoming_secrets_entitlement_required": {
+    "text": "Quản lý bí mật đến yêu cầu quyền lợi incoming_secrets. Vui lòng nâng cấp gói của bạn."
+  },
+  "api.domains.errors.incoming_config_not_found": {
+    "text": "Không tìm thấy cấu hình bí mật đến cho tên miền: %{extid}"
+  },
+  "api.domains.errors.recipients_max_exceeded": {
+    "text": "Cho phép tối đa %{max} người nhận"
+  },
+  "api.domains.errors.recipients_invalid_email": {
+    "text": "Email không hợp lệ: %{email}"
+  },
+  "api.domains.errors.recipients_duplicate": {
+    "text": "Không cho phép email người nhận trùng lặp"
+  }
+}

--- a/locales/content/vi/api-entitlements-errors.json
+++ b/locales/content/vi/api-entitlements-errors.json
@@ -1,0 +1,71 @@
+{
+  "api.entitlements.errors.context_unavailable": {
+    "text": "Không thể xác minh quyền lợi (ngữ cảnh tổ chức không khả dụng)"
+  },
+  "api.entitlements.errors.api_access_required": {
+    "text": "Truy cập API yêu cầu nâng cấp gói"
+  },
+  "api.entitlements.errors.custom_privacy_defaults_required": {
+    "text": "Mặc định quyền riêng tư tùy chỉnh yêu cầu nâng cấp gói"
+  },
+  "api.entitlements.errors.extended_default_expiration_required": {
+    "text": "Thời gian hết hạn mặc định mở rộng yêu cầu nâng cấp gói"
+  },
+  "api.entitlements.errors.custom_domains_required": {
+    "text": "Tên miền tùy chỉnh yêu cầu nâng cấp gói"
+  },
+  "api.entitlements.errors.custom_branding_required": {
+    "text": "Thương hiệu tùy chỉnh yêu cầu nâng cấp gói"
+  },
+  "api.entitlements.errors.homepage_secrets_required": {
+    "text": "Bí mật trên trang chủ yêu cầu nâng cấp gói"
+  },
+  "api.entitlements.errors.incoming_secrets_required": {
+    "text": "Bí mật đến yêu cầu nâng cấp gói"
+  },
+  "api.entitlements.errors.custom_mail_sender_required": {
+    "text": "Người gửi thư tùy chỉnh yêu cầu nâng cấp gói"
+  },
+  "api.entitlements.errors.flexible_from_domain_required": {
+    "text": "Tên miền gửi linh hoạt yêu cầu nâng cấp gói"
+  },
+  "api.entitlements.errors.manage_org_required": {
+    "text": "Quản lý tổ chức yêu cầu nâng cấp gói"
+  },
+  "api.entitlements.errors.manage_teams_required": {
+    "text": "Quản lý nhóm yêu cầu nâng cấp gói"
+  },
+  "api.entitlements.errors.manage_members_required": {
+    "text": "Quản lý thành viên yêu cầu nâng cấp gói"
+  },
+  "api.entitlements.errors.manage_sso_required": {
+    "text": "Quản lý SSO yêu cầu nâng cấp gói"
+  },
+  "api.entitlements.errors.audit_logs_required": {
+    "text": "Nhật ký kiểm tra yêu cầu nâng cấp gói"
+  },
+  "api.entitlements.errors.custom_signup_validation_required": {
+    "text": "Xác thực đăng ký tùy chỉnh yêu cầu nâng cấp gói"
+  },
+  "api.entitlements.errors.create_secrets_required": {
+    "text": "Tạo bí mật yêu cầu nâng cấp gói"
+  },
+  "api.entitlements.errors.view_receipt_required": {
+    "text": "Xem biên nhận yêu cầu nâng cấp gói"
+  },
+  "api.entitlements.errors.notifications_required": {
+    "text": "Thông báo yêu cầu nâng cấp gói"
+  },
+  "api.entitlements.errors.workspace_branding_required": {
+    "text": "Thương hiệu không gian làm việc yêu cầu nâng cấp gói"
+  },
+  "api.entitlements.errors.ip_access_rules_required": {
+    "text": "Quy tắc truy cập IP yêu cầu nâng cấp gói"
+  },
+  "api.entitlements.errors.manage_billing_required": {
+    "text": "Quản lý thanh toán yêu cầu nâng cấp gói"
+  },
+  "api.entitlements.errors.custom_signin_config_required": {
+    "text": "Cấu hình đăng nhập tùy chỉnh yêu cầu nâng cấp gói"
+  }
+}

--- a/locales/content/vi/api-feedback-errors.json
+++ b/locales/content/vi/api-feedback-errors.json
@@ -1,0 +1,5 @@
+{
+  "api.feedback.errors.rate_limit_exceeded": {
+    "text": "Quá nhiều lượt gửi phản hồi. Vui lòng thử lại sau."
+  }
+}

--- a/locales/content/vi/api-incoming-errors.json
+++ b/locales/content/vi/api-incoming-errors.json
@@ -1,0 +1,5 @@
+{
+  "api.incoming.errors.custom_domain_unresolved": {
+    "text": "Không thể phân giải tổ chức của tên miền tùy chỉnh"
+  }
+}

--- a/locales/content/vi/api-invite-errors.json
+++ b/locales/content/vi/api-invite-errors.json
@@ -1,0 +1,23 @@
+{
+  "api.invite.errors.invitation_not_found_or_expired": {
+    "text": "Không tìm thấy lời mời hoặc lời mời đã hết hạn"
+  },
+  "api.invite.errors.token_required": {
+    "text": "Cần có token"
+  },
+  "api.invite.errors.organization_no_longer_exists": {
+    "text": "Tổ chức không còn tồn tại"
+  },
+  "api.invite.errors.invitation_already_processed": {
+    "text": "Lời mời đã được %{status}"
+  },
+  "api.invite.errors.invitation_expired": {
+    "text": "Lời mời đã hết hạn"
+  },
+  "api.invite.errors.email_mismatch": {
+    "text": "Địa chỉ email của bạn không khớp với lời mời"
+  },
+  "api.invite.errors.already_member": {
+    "text": "Bạn đã là thành viên của tổ chức này"
+  }
+}

--- a/locales/content/vi/api-organizations-errors.json
+++ b/locales/content/vi/api-organizations-errors.json
@@ -1,0 +1,107 @@
+{
+  "api.organizations.errors.domain_scoped_forbidden": {
+    "text": "Thành viên trong phạm vi tên miền không thể thực hiện hành động này"
+  },
+  "api.organizations.errors.organization_not_found": {
+    "text": "Không tìm thấy tổ chức: %{extid}"
+  },
+  "api.organizations.errors.organization_owner_required": {
+    "text": "Chỉ chủ sở hữu tổ chức mới có thể thực hiện hành động này"
+  },
+  "api.organizations.errors.organization_member_required": {
+    "text": "Bạn phải là thành viên của tổ chức để thực hiện hành động này"
+  },
+  "api.organizations.errors.organization_admin_required": {
+    "text": "Chỉ chủ sở hữu và quản trị viên tổ chức mới có thể thực hiện hành động này"
+  },
+  "api.organizations.errors.extid_required": {
+    "text": "Cần có ID tổ chức"
+  },
+  "api.organizations.errors.display_name_required": {
+    "text": "Tên tổ chức là bắt buộc"
+  },
+  "api.organizations.errors.display_name_too_long": {
+    "text": "Tên tổ chức phải ít hơn %{max} ký tự"
+  },
+  "api.organizations.errors.description_too_long": {
+    "text": "Mô tả phải ít hơn %{max} ký tự"
+  },
+  "api.organizations.errors.contact_email_exists": {
+    "text": "Đã tồn tại một tổ chức với email liên hệ này"
+  },
+  "api.organizations.errors.creation_in_progress": {
+    "text": "Đang tạo tổ chức. Vui lòng thử lại."
+  },
+  "api.organizations.errors.organization_limit_reached": {
+    "text": "Đã đạt giới hạn tổ chức. Nâng cấp gói của bạn để tạo thêm tổ chức."
+  },
+  "api.organizations.invitations.errors.invitation_not_found": {
+    "text": "Không tìm thấy lời mời"
+  },
+  "api.organizations.invitations.errors.email_required": {
+    "text": "Email là bắt buộc"
+  },
+  "api.organizations.invitations.errors.invalid_email_format": {
+    "text": "Định dạng email không hợp lệ"
+  },
+  "api.organizations.invitations.errors.invalid_role": {
+    "text": "Vai trò phải là thành viên hoặc quản trị viên"
+  },
+  "api.organizations.invitations.errors.cannot_invite_as_owner": {
+    "text": "Không thể mời với vai trò chủ sở hữu"
+  },
+  "api.organizations.invitations.errors.user_already_member": {
+    "text": "Người dùng đã là thành viên của tổ chức này"
+  },
+  "api.organizations.invitations.errors.invitation_already_pending": {
+    "text": "Đã có lời mời đang chờ xử lý cho email này"
+  },
+  "api.organizations.invitations.errors.member_limit_reached": {
+    "text": "Đã đạt giới hạn thành viên. Nâng cấp gói của bạn để mời thêm thành viên."
+  },
+  "api.organizations.invitations.errors.resend_only_pending": {
+    "text": "Chỉ có thể gửi lại các lời mời đang chờ xử lý"
+  },
+  "api.organizations.invitations.errors.resend_limit_reached": {
+    "text": "Đã đạt giới hạn gửi lại tối đa (%{max})"
+  },
+  "api.organizations.invitations.errors.revoke_only_pending": {
+    "text": "Chỉ có thể thu hồi các lời mời đang chờ xử lý"
+  },
+  "api.organizations.members.errors.member_not_found": {
+    "text": "Không tìm thấy thành viên: %{extid}"
+  },
+  "api.organizations.members.errors.member_not_in_organization": {
+    "text": "Không tìm thấy thành viên trong tổ chức này"
+  },
+  "api.organizations.members.errors.member_not_active": {
+    "text": "Thành viên không hoạt động"
+  },
+  "api.organizations.members.errors.invalid_role_value": {
+    "text": "Vai trò không hợp lệ. Phải là một trong: %{roles}"
+  },
+  "api.organizations.members.errors.cannot_change_owner_role": {
+    "text": "Không thể thay đổi vai trò chủ sở hữu. Thay vào đó hãy chuyển quyền sở hữu."
+  },
+  "api.organizations.members.errors.member_already_has_role": {
+    "text": "Thành viên đã có vai trò: %{role}"
+  },
+  "api.organizations.members.errors.cannot_promote_to_owner": {
+    "text": "Không thể thăng cấp thành chủ sở hữu. Thay vào đó hãy chuyển quyền sở hữu."
+  },
+  "api.organizations.members.errors.must_be_member": {
+    "text": "Bạn phải là thành viên của tổ chức này"
+  },
+  "api.organizations.members.errors.cannot_remove_owner": {
+    "text": "Không thể xóa chủ sở hữu tổ chức. Hãy chuyển quyền sở hữu trước."
+  },
+  "api.organizations.members.errors.cannot_remove_self": {
+    "text": "Không thể tự xóa chính mình. Thay vào đó hãy rời khỏi tổ chức."
+  },
+  "api.organizations.members.errors.admin_cannot_remove_admin": {
+    "text": "Quản trị viên không thể xóa quản trị viên khác. Chỉ chủ sở hữu mới có thể."
+  },
+  "api.organizations.members.errors.no_permission_to_remove": {
+    "text": "Bạn không có quyền xóa thành viên"
+  }
+}

--- a/locales/content/vi/api-secrets-errors.json
+++ b/locales/content/vi/api-secrets-errors.json
@@ -1,0 +1,11 @@
+{
+  "api.secrets.errors.domain_permission_authenticated_non_owner": {
+    "text": "Bạn không có quyền sử dụng tên miền: %{domain}"
+  },
+  "api.secrets.errors.domain_public_sharing_disabled": {
+    "text": "Chia sẻ công khai đã bị tắt cho tên miền: %{domain}"
+  },
+  "api.secrets.errors.domain_permission_anonymous_cross_domain": {
+    "text": "Bạn không có quyền sử dụng tên miền: %{domain}"
+  }
+}

--- a/locales/content/vi/email.json
+++ b/locales/content/vi/email.json
@@ -853,5 +853,41 @@
     "text": "Onetime Secret",
     "renderer": "erb",
     "source_hash": "1cd0194a"
+  },
+  "email.common.secret_link_label": {
+    "text": "Liên kết bí mật"
+  },
+  "email.common.automated_notice": {
+    "text": "Đây là tin nhắn tự động từ %{product_name}."
+  },
+  "email.common.support_label": {
+    "text": "Hỗ trợ"
+  },
+  "email.expiration_warning.signature": {
+    "text": "Delano"
+  },
+  "email.expiration_warning.footer_note": {
+    "text": "Bạn nhận được email này vì một bí mật bạn đã tạo trên %{product_name} sắp hết hạn."
+  },
+  "email.feedback_email.user_id_label": {
+    "text": "Người dùng:"
+  },
+  "email.feedback_email.timezone_label": {
+    "text": "Múi giờ:"
+  },
+  "email.feedback_email.version_label": {
+    "text": "Phiên bản:"
+  },
+  "email.incoming_secret.footer_note": {
+    "text": "Bạn nhận được email này vì có người đã sử dụng %{product_name} để gửi cho bạn một bí mật. Nếu bạn không mong đợi điều này, bạn có thể yên tâm bỏ qua email này."
+  },
+  "email.secret_link.passphrase_label": {
+    "text": "Cần có cụm mật khẩu:"
+  },
+  "email.secret_link.passphrase_required": {
+    "text": "Bí mật này được bảo vệ bằng cụm mật khẩu. Người gửi sẽ cung cấp cụm mật khẩu cho bạn một cách riêng biệt."
+  },
+  "email.secret_link.footer_note": {
+    "text": "Bạn nhận được email này vì %{sender_email} đã sử dụng %{product_name} để chia sẻ một bí mật với bạn. Nếu bạn không mong đợi điều này, bạn có thể yên tâm bỏ qua email này."
   }
 }

--- a/locales/content/vi/feature-feedback.json
+++ b/locales/content/vi/feature-feedback.json
@@ -58,5 +58,14 @@
   "web.feedback.reason_email_change_unauthorized": {
     "text": "Có vẻ như bạn đang báo cáo một thay đổi email trái phép trên tài khoản của bạn. Vui lòng mô tả những gì đã xảy ra và chúng tôi sẽ điều tra ngay.",
     "source_hash": "00e56551"
+  },
+  "web.feedback.anonymous_no_reply": {
+    "text": "Lưu ý: nếu bạn muốn nhận phản hồi, vui lòng ký tên hoặc đưa địa chỉ email vào tin nhắn."
+  },
+  "web.feedback.characters_remaining": {
+    "text": "Còn lại {count} ký tự"
+  },
+  "web.feedback.character_limit_reached": {
+    "text": "Đã đạt giới hạn ký tự"
   }
 }

--- a/locales/content/vi/feature-homepage-secrets.json
+++ b/locales/content/vi/feature-homepage-secrets.json
@@ -1,0 +1,50 @@
+{
+  "homepage_secrets.disabled.members_only_eyebrow": {
+    "text": "Phiên bản chỉ dành cho thành viên"
+  },
+  "homepage_secrets.disabled.private_instance_eyebrow": {
+    "text": "Phiên bản riêng tư"
+  },
+  "homepage_secrets.disabled.team_link_headline": {
+    "text": "Liên kết này dành cho nhóm {workspace}."
+  },
+  "homepage_secrets.disabled.signin_headline": {
+    "text": "Đăng nhập để tạo {action}."
+  },
+  "homepage_secrets.disabled.signin_headline_action": {
+    "text": "liên kết bí mật"
+  },
+  "homepage_secrets.disabled.team_subtitle": {
+    "text": "Chỉ các đồng đội được ủy quyền tại {domain} mới có thể tạo các liên kết một lần mới tại đây. Người nhận vẫn có thể mở bất kỳ liên kết nào đã được gửi cho họ."
+  },
+  "homepage_secrets.disabled.public_subtitle": {
+    "text": "Chỉ các thành viên được ủy quyền của phiên bản này mới có thể tạo các liên kết một lần mới. Người nhận vẫn có thể mở bất kỳ liên kết nào đã được gửi cho họ."
+  },
+  "homepage_secrets.disabled.signin_cta": {
+    "text": "Đăng nhập vào tài khoản của bạn"
+  },
+  "homepage_secrets.disabled.what_is_this": {
+    "text": "Đây là gì?"
+  },
+  "homepage_secrets.disabled.trust_viewed_once": {
+    "text": "Xem một lần, rồi biến mất"
+  },
+  "homepage_secrets.disabled.trust_zero_retained": {
+    "text": "Không lưu giữ gì"
+  },
+  "homepage_secrets.disabled.promo_title": {
+    "text": "Mới: các gói miễn phí giờ đã bao gồm tên miền tùy chỉnh."
+  },
+  "homepage_secrets.disabled.promo_subtitle": {
+    "text": "Trỏ tên miền của bạn về Onetime Secret và gửi bí mật dưới thương hiệu của riêng bạn."
+  },
+  "homepage_secrets.disabled.promo_learn_how": {
+    "text": "Tìm hiểu cách"
+  },
+  "homepage_secrets.disabled.logo_alt": {
+    "text": "Logo {name}"
+  },
+  "homepage_secrets.disabled.opens_in_new_tab": {
+    "text": "(mở trong tab mới)"
+  }
+}

--- a/locales/content/vi/feature-incoming.json
+++ b/locales/content/vi/feature-incoming.json
@@ -130,5 +130,26 @@
   "incoming.receipt_link_text": {
     "text": "biên lai",
     "source_hash": "6f328609"
+  },
+  "incoming.upgrade_required_title": {
+    "text": "Yêu cầu nâng cấp"
+  },
+  "incoming.upgrade_required_description": {
+    "text": "Tính năng này yêu cầu nâng cấp gói. Vui lòng liên hệ chủ sở hữu tài khoản để bật tính năng bí mật đến."
+  },
+  "incoming.validation_memo_too_long": {
+    "text": "Ghi chú phải có {max} ký tự hoặc ít hơn"
+  },
+  "incoming.validation_secret_required": {
+    "text": "Nội dung bí mật là bắt buộc"
+  },
+  "incoming.validation_recipient_required": {
+    "text": "Vui lòng chọn người nhận"
+  },
+  "incoming.validation_feature_disabled": {
+    "text": "Tính năng bí mật đến chưa được bật"
+  },
+  "incoming.validation_form_errors": {
+    "text": "Vui lòng kiểm tra biểu mẫu để tìm lỗi"
   }
 }

--- a/locales/content/vi/feature-regions.json
+++ b/locales/content/vi/feature-regions.json
@@ -152,7 +152,7 @@
     "source_hash": "1d97f6bd"
   },
   "web.regions.changing_regions_billing_note": {
-    "text": "Nếu email liên hệ thanh toán khác với email tài khoản {product_name}, hãy sử dụng email liên hệ thanh toán cho tài khoản khu vực mới để duy trì quyền lợi đăng ký.",
+    "text": "Nếu email liên hệ thanh toán của bạn khác với email tài khoản {product_name}, hãy sử dụng email liên hệ thanh toán cho tài khoản khu vực mới để duy trì các quyền lợi đăng ký của bạn.",
     "source_hash": "dac1cc28"
   },
   "web.regions.changing_regions_subscription_note": {
@@ -186,5 +186,8 @@
   "web.regions.jurisdictions.apac.name": {
     "text": "Asia-Pacific",
     "source_hash": "7a757670"
+  },
+  "web.regions.no_region_configured": {
+    "text": "Hiện không có thông tin khu vực cho tài khoản của bạn."
   }
 }

--- a/locales/content/vi/feature-translations.json
+++ b/locales/content/vi/feature-translations.json
@@ -84,7 +84,7 @@
     "source_hash": "ba5c4395"
   },
   "web.translations.since_2012_onetime_secret_has_provided_a_secure_": {
-    "text": "Từ năm 2012, {product_name} đã cung cấp một cách an toàn để chia sẻ thông tin nhạy cảm trên toàn thế giới. Với người dùng ở các khu vực mà tiếng Anh không phải là ngôn ngữ chính, bản dịch chính xác là điều cần thiết để làm cho giao tiếp an toàn có thể tiếp cận được với mọi người.",
+    "text": "Từ năm 2012, {product_name} đã cung cấp cách an toàn để chia sẻ thông tin nhạy cảm trên toàn thế giới. Với người dùng ở các khu vực mà tiếng Anh không phải là ngôn ngữ chính, các bản dịch chính xác là điều cần thiết để giao tiếp an toàn trở nên dễ tiếp cận với mọi người.",
     "source_hash": "87a6e9af"
   },
   "web.translations.help_secure_communication_go_global": {

--- a/locales/content/vi/secret-homepage.json
+++ b/locales/content/vi/secret-homepage.json
@@ -108,7 +108,7 @@
     "source_hash": "107093e4"
   },
   "web.homepage.about_onetime_secret_0": {
-    "text": "Về {product_name}",
+    "text": "Giới thiệu về {product_name}",
     "source_hash": "971c50da"
   },
   "web.homepage.log_in_to_onetime_secret": {
@@ -116,7 +116,7 @@
     "source_hash": "bd6be8d6"
   },
   "web.homepage.about_onetime_secret": {
-    "text": "Về {product_name}",
+    "text": "Giới thiệu về {product_name}",
     "source_hash": "971c50da"
   },
   "web.homepage.signup_individual_and_business_plans": {
@@ -168,11 +168,11 @@
     "source_hash": "e1073c60"
   },
   "web.homepage.welcome_to_onetime_secret": {
-    "text": "Chào mừng đến với {product_name}.",
+    "text": "Chào mừng bạn đến với {product_name}.",
     "source_hash": "0990d163"
   },
   "web.homepage.onetime_secret_helps_us_share_sensitive_informat": {
-    "text": "{product_name} giúp chúng tôi chia sẻ thông tin nhạy cảm một cách an toàn trong khi duy trì vẻ ngoài chuyên nghiệp của chúng tôi.",
+    "text": "{product_name} giúp chúng tôi chia sẻ thông tin nhạy cảm một cách an toàn trong khi vẫn duy trì hình ảnh chuyên nghiệp.",
     "source_hash": "986a0856"
   },
   "web.homepage.information_shared_through_this_service_can_only": {

--- a/locales/content/vi/secret-manage.json
+++ b/locales/content/vi/secret-manage.json
@@ -128,7 +128,7 @@
     "source_hash": "07fe1b84"
   },
   "web.secrets.onetime_secret_is_a_secure_way_to_share_sensitiv": {
-    "text": "{product_name} là một cách an toàn để chia sẻ thông tin nhạy cảm tự hủy sau một lần xem.",
+    "text": "{product_name} là cách an toàn để chia sẻ thông tin nhạy cảm tự hủy sau một lần xem.",
     "source_hash": "8a163297"
   },
   "web.secrets.what_is_this": {
@@ -398,5 +398,11 @@
   "web.secrets.errors.access_denied_to_domain": {
     "text": "Quyền truy cập vào tên miền bị từ chối",
     "source_hash": "cd441eea"
+  },
+  "web.receipt.open_link": {
+    "text": "Mở liên kết"
+  },
+  "web.secrets.messageDeleted": {
+    "text": "Tin nhắn đã bị xóa"
   }
 }

--- a/locales/content/vi/session-auth-extended.json
+++ b/locales/content/vi/session-auth-extended.json
@@ -710,5 +710,26 @@
   "web.auth.recovery_codes.link_title": {
     "text": "Mã khôi phục",
     "source_hash": "579c7f4e"
+  },
+  "web.auth.google": {
+    "text": "Google"
+  },
+  "web.auth.mfa.alternative_auth_options": {
+    "text": "Tùy chọn xác thực thay thế"
+  },
+  "web.auth.remember.enabled": {
+    "text": "Duy trì đăng nhập"
+  },
+  "web.auth.security._guidance.context": {
+    "text": "⚠️ SECURITY-CRITICAL: Messages prevent information disclosure. See src/locales/SECURITY-TRANSLATION-GUIDE.md"
+  },
+  "web.auth.sessions.session_singular": {
+    "text": "phiên"
+  },
+  "web.auth.sessions.session_plural": {
+    "text": "phiên"
+  },
+  "web.auth.sessions._guidance.context": {
+    "text": "User's logged-in devices/browsers management page"
   }
 }

--- a/locales/content/vi/session-auth.json
+++ b/locales/content/vi/session-auth.json
@@ -395,5 +395,35 @@
   "web.help.contact_support": {
     "text": "Liên hệ hỗ trợ",
     "source_hash": "f8d47b82"
+  },
+  "web.auth.account.sso_linked": {
+    "text": "Tài khoản SSO"
+  },
+  "web.auth.verify._guidance.context": {
+    "text": "Email verification flow after signup"
+  },
+  "web.help.reset_password_link": {
+    "text": "Đặt lại mật khẩu"
+  },
+  "web.login.custom_domain_sso_title": {
+    "text": "Đăng nhập một lần (SSO) khả dụng cho tên miền này"
+  },
+  "web.login.custom_domain_sso_description": {
+    "text": "Quản trị viên của tổ chức có thể bật SSO để cho phép các thành viên nhóm đăng nhập tại đây. Liên hệ quản trị viên để được cấp quyền truy cập."
+  },
+  "web.login.signin_disabled_heading": {
+    "text": "Đăng nhập không khả dụng"
+  },
+  "web.login.signin_disabled_message": {
+    "text": "Đăng nhập hiện không khả dụng trên tên miền này."
+  },
+  "web.login.errors.sso_not_configured": {
+    "text": "Đăng nhập một lần (SSO) chưa được cấu hình cho tên miền này. Vui lòng liên hệ quản trị viên của bạn."
+  },
+  "web.login.errors.invalid_email": {
+    "text": "Địa chỉ email từ nhà cung cấp danh tính của bạn không hợp lệ. Vui lòng liên hệ quản trị viên của bạn."
+  },
+  "web.login.errors.domain_not_allowed": {
+    "text": "Tên miền email của bạn không được phép đăng ký bằng SSO. Vui lòng liên hệ quản trị viên của bạn."
   }
 }

--- a/locales/content/vi/workspace-account.json
+++ b/locales/content/vi/workspace-account.json
@@ -682,5 +682,14 @@
   "web.settings.profile.didnt_receive_email": {
     "text": "Không nhận được email?",
     "source_hash": "fe3ac3ad"
+  },
+  "web.settings.api.api_disabled_notice": {
+    "text": "API đã bị vô hiệu hóa cho phiên bản này."
+  },
+  "web.settings.security.sso_managed_title": {
+    "text": "Bảo mật được quản lý bởi SSO"
+  },
+  "web.settings.security.sso_managed_description": {
+    "text": "Tài khoản của bạn được xác thực thông qua nhà cung cấp đăng nhập một lần (SSO) của tổ chức. Mật khẩu, xác thực đa yếu tố và mã khôi phục được quản lý bởi nhà cung cấp danh tính của bạn."
   }
 }

--- a/locales/content/vi/workspace-billing.json
+++ b/locales/content/vi/workspace-billing.json
@@ -988,5 +988,47 @@
     "text": "Chỉ khả dụng trong khu vực đăng ký ban đầu",
     "context": "Hint shown on plan cards when currency does not match active subscription",
     "source_hash": "10de32e5"
+  },
+  "web.billing.already_subscribed": {
+    "text": "Bạn đã đăng ký gói này rồi."
+  },
+  "web.billing.cancel.reactivate_button": {
+    "text": "Kích hoạt lại đăng ký"
+  },
+  "web.billing.cancel.reactivate_success": {
+    "text": "Đăng ký của bạn đã được kích hoạt lại. Bạn sẽ tiếp tục bị tính phí như bình thường."
+  },
+  "web.billing.cancel.reactivate_error": {
+    "text": "Không thể kích hoạt lại đăng ký. Vui lòng thử lại hoặc liên hệ bộ phận hỗ trợ."
+  },
+  "web.billing.features.manage_orgs": {
+    "text": "Quản lý tổ chức"
+  },
+  "web.billing.features.flexible_from_domain": {
+    "text": "Tên miền người gửi email linh hoạt"
+  },
+  "web.billing.features.unlimited_admins": {
+    "text": "Quản trị viên không giới hạn"
+  },
+  "web.billing.features.manage_sso": {
+    "text": "SSO"
+  },
+  "web.billing.overview.entitlements.flexible_from_domain": {
+    "text": "Tên miền người gửi email linh hoạt"
+  },
+  "web.billing.overview.entitlements.manage_orgs": {
+    "text": "Quản lý tổ chức"
+  },
+  "web.billing.overview.entitlements.manage_sso": {
+    "text": "Đăng nhập một lần (SSO)"
+  },
+  "web.billing.overview.entitlements.manage_billing": {
+    "text": "Quản lý thanh toán"
+  },
+  "web.billing.overview.entitlements.custom_signup_validation": {
+    "text": "Xác thực đăng ký tùy chỉnh"
+  },
+  "web.billing.plans.reactivate": {
+    "text": "Kích hoạt lại"
   }
 }

--- a/locales/content/vi/workspace-branding.json
+++ b/locales/content/vi/workspace-branding.json
@@ -144,7 +144,7 @@
     "source_hash": "1e04ba2e"
   },
   "web.branding.powered_by_onetime_secret": {
-    "text": "Cung cấp bởi {product_name}",
+    "text": "Được cung cấp bởi {product_name}",
     "source_hash": "d8e9f0a1"
   },
   "web.branding.low_contrast_warning": {
@@ -178,5 +178,11 @@
   "web.branding.upgrade_to_customize": {
     "text": "Nâng cấp gói để tùy chỉnh thương hiệu cho tên miền này.",
     "source_hash": "9077bf79"
+  },
+  "web.branding.saved_successfully": {
+    "text": "Đã lưu cài đặt thương hiệu thành công"
+  },
+  "web.branding.keyhole_logo_icon": {
+    "text": "Biểu tượng lỗ khóa đại diện cho chia sẻ an toàn, riêng tư"
   }
 }

--- a/locales/content/vi/workspace-dashboard.json
+++ b/locales/content/vi/workspace-dashboard.json
@@ -22,5 +22,14 @@
   "web.dashboard.fetch_error_description": {
     "text": "Đã xảy ra lỗi khi tải dữ liệu. Vui lòng thử lại.",
     "source_hash": "ff0d904e"
+  },
+  "web.teams.create_first_team_title": {
+    "text": "Tạo nhóm đầu tiên của bạn"
+  },
+  "web.teams.create_first_team_description": {
+    "text": "Nhóm cho phép bạn cộng tác với những người khác trong một không gian làm việc chung."
+  },
+  "web.teams.create_team": {
+    "text": "Tạo nhóm"
   }
 }

--- a/locales/content/vi/workspace-domains.json
+++ b/locales/content/vi/workspace-domains.json
@@ -398,5 +398,725 @@
   "web.domains.dns_widget_description": {
     "text": "Sử dụng công cụ bên dưới để tự động phát hiện nhà cung cấp DNS và nhận hướng dẫn từng bước để cấu hình tên miền.",
     "source_hash": "91c1af2e"
+  },
+  "api.domains.errors.add_admin_required": {
+    "text": "Chỉ chủ sở hữu và quản trị viên của tổ chức mới có thể thêm tên miền tùy chỉnh"
+  },
+  "web.domains.public_homepage": {
+    "text": "Trang chủ công khai"
+  },
+  "web.domains.status_tooltip_active": {
+    "text": "Tên miền đã xác minh và đang hoạt động"
+  },
+  "web.domains.status_tooltip_dns_incorrect": {
+    "text": "Chưa cấu hình DNS — nhấp để khắc phục"
+  },
+  "web.domains.status_tooltip_not_verified": {
+    "text": "Tên miền chưa được xác minh — nhấp để xác minh"
+  },
+  "web.domains.status_tooltip_unverified": {
+    "text": "Trạng thái tên miền chưa được xác minh — nhấp để làm mới"
+  },
+  "web.domains.last_check_failed": {
+    "text": "Lần kiểm tra xác minh gần nhất đã thất bại"
+  },
+  "web.domains.last_check_failed_ago": {
+    "text": "lần kiểm tra gần nhất thất bại {0}"
+  },
+  "web.domains.verify_now": {
+    "text": "Xác minh ngay"
+  },
+  "web.domains.click_to_verify": {
+    "text": "nhấp để xác minh"
+  },
+  "web.domains.remove_domain_description": {
+    "text": "Xóa vĩnh viễn tên miền này và toàn bộ cấu hình của nó."
+  },
+  "web.domains.add_access_denied": {
+    "text": "Truy cập bị từ chối"
+  },
+  "web.domains.add_access_denied_description": {
+    "text": "Bạn không có quyền thêm tên miền vào tổ chức này. Vui lòng liên hệ quản trị viên tổ chức của bạn."
+  },
+  "web.domains.dns_widget_load_failed": {
+    "text": "Không thể tải tiện ích DNS"
+  },
+  "web.domains.dns_widget_not_available": {
+    "text": "Tiện ích DNS không khả dụng"
+  },
+  "web.domains.dns_widget_init_failed": {
+    "text": "Không thể khởi tạo tiện ích DNS"
+  },
+  "web.domains.verified": {
+    "text": "Đã xác minh"
+  },
+  "web.domains.pending_verification": {
+    "text": "Đang chờ xác minh"
+  },
+  "web.domains.unsaved_changes_confirmation": {
+    "text": "Bạn có các thay đổi chưa được lưu. Bạn có chắc chắn muốn rời đi không?"
+  },
+  "web.domains.entitlement_required_owner": {
+    "text": "Tính năng này yêu cầu nâng cấp gói."
+  },
+  "web.domains.entitlement_required_member": {
+    "text": "Tính năng này không khả dụng trên gói hiện tại của bạn. Vui lòng liên hệ chủ sở hữu tổ chức của bạn."
+  },
+  "web.domains.detail.manage": {
+    "text": "Quản lý"
+  },
+  "web.domains.detail.features": {
+    "text": "Tính năng"
+  },
+  "web.domains.detail.homepage_title": {
+    "text": "Bí mật trang chủ"
+  },
+  "web.domains.detail.homepage_description": {
+    "text": "Cho phép truy cập công khai để tạo bí mật trên trang chủ tên miền của bạn"
+  },
+  "web.domains.detail.brand_description": {
+    "text": "Logo, màu sắc và thương hiệu tùy chỉnh"
+  },
+  "web.domains.detail.sso_description": {
+    "text": "Cài đặt nhà cung cấp đăng nhập một lần"
+  },
+  "web.domains.detail.email_description": {
+    "text": "Cấu hình người gửi email tùy chỉnh"
+  },
+  "web.domains.detail.incoming_description": {
+    "text": "Cài đặt người nhận bí mật đến"
+  },
+  "web.domains.detail.signup_description": {
+    "text": "Chiến lược xác thực đăng ký theo từng tên miền"
+  },
+  "web.domains.detail.signin_description": {
+    "text": "Cấu hình phương thức đăng nhập theo từng tên miền"
+  },
+  "web.domains.email.title": {
+    "text": "Gửi email"
+  },
+  "web.domains.email.config_title": {
+    "text": "Cấu hình email"
+  },
+  "web.domains.email.config_description": {
+    "text": "Cấu hình việc gửi email cho tên miền này"
+  },
+  "web.domains.email.provider_label": {
+    "text": "Nhà cung cấp email"
+  },
+  "web.domains.email.provider_placeholder": {
+    "text": "Chọn một nhà cung cấp email"
+  },
+  "web.domains.email.from_name_label": {
+    "text": "Tên người gửi"
+  },
+  "web.domains.email.from_name_placeholder": {
+    "text": "ví dụ: Acme Security"
+  },
+  "web.domains.email.from_address_label": {
+    "text": "Địa chỉ người gửi"
+  },
+  "web.domains.email.from_address_placeholder": {
+    "text": "ví dụ: secrets{'@'}example.com"
+  },
+  "web.domains.email.reply_to_label": {
+    "text": "Địa chỉ trả lời (Reply-To)"
+  },
+  "web.domains.email.reply_to_placeholder": {
+    "text": "ví dụ: support{'@'}example.com"
+  },
+  "web.domains.email.save_changes": {
+    "text": "Lưu thay đổi"
+  },
+  "web.domains.email.discard_changes": {
+    "text": "Hủy thay đổi"
+  },
+  "web.domains.email.provider_ses": {
+    "text": "Amazon SES"
+  },
+  "web.domains.email.provider_sendgrid": {
+    "text": "SendGrid"
+  },
+  "web.domains.email.provider_lettermint": {
+    "text": "Lettermint"
+  },
+  "web.domains.email.provider_inherit": {
+    "text": "Dùng mặc định của tài khoản"
+  },
+  "web.domains.email.provider_ses_description": {
+    "text": "Yêu cầu xác minh tên miền qua bản ghi DKIM và SPF"
+  },
+  "web.domains.email.provider_sendgrid_description": {
+    "text": "Yêu cầu thiết lập xác thực tên miền"
+  },
+  "web.domains.email.provider_lettermint_description": {
+    "text": "Yêu cầu xác minh tên miền"
+  },
+  "web.domains.email.provider_inherit_description": {
+    "text": "Sử dụng cấu hình gửi email mặc định của tài khoản bạn"
+  },
+  "web.domains.email.dns_records_title": {
+    "text": "Bản ghi DNS"
+  },
+  "web.domains.email.dns_records_description": {
+    "text": "Thêm các bản ghi DNS sau để xác minh tên miền của bạn cho việc gửi email."
+  },
+  "web.domains.email.dns_column_type": {
+    "text": "Loại"
+  },
+  "web.domains.email.dns_column_name": {
+    "text": "Tên"
+  },
+  "web.domains.email.dns_column_value": {
+    "text": "Giá trị"
+  },
+  "web.domains.email.dns_check_label": {
+    "text": "DNS"
+  },
+  "web.domains.email.provider_check_label": {
+    "text": "Nhà cung cấp"
+  },
+  "web.domains.email.dns_optional_label": {
+    "text": "Khuyến nghị"
+  },
+  "web.domains.email.dns_optional_hint": {
+    "text": "Bản ghi này được khuyến nghị nhưng không bắt buộc để xác minh. Một chính sách DMARC tại tên miền tổ chức của bạn có thể đã bao gồm tên miền phụ này."
+  },
+  "web.domains.email.copy": {
+    "text": "Sao chép"
+  },
+  "web.domains.email.copied": {
+    "text": "Đã sao chép"
+  },
+  "web.domains.email.status_verified": {
+    "text": "Đã xác minh"
+  },
+  "web.domains.email.status_pending": {
+    "text": "Đang chờ"
+  },
+  "web.domains.email.status_failed": {
+    "text": "Thất bại"
+  },
+  "web.domains.email.revalidate": {
+    "text": "Xác thực lại"
+  },
+  "web.domains.email.validating": {
+    "text": "Đang xác thực..."
+  },
+  "web.domains.email.domain_verified": {
+    "text": "Tên miền đã được xác minh"
+  },
+  "web.domains.email.validation_failed": {
+    "text": "Xác thực thất bại"
+  },
+  "web.domains.email.last_validated": {
+    "text": "Lần xác thực gần nhất"
+  },
+  "web.domains.email.upgrade_to_configure": {
+    "text": "Nâng cấp gói của bạn để cấu hình việc gửi email cho tên miền này."
+  },
+  "web.domains.email.configure_email": {
+    "text": "Cấu hình email"
+  },
+  "web.domains.email.access_denied": {
+    "text": "Truy cập bị từ chối"
+  },
+  "web.domains.email.access_denied_description": {
+    "text": "Bạn không có quyền quản lý cài đặt email cho tên miền này. Vui lòng liên hệ quản trị viên tổ chức của bạn."
+  },
+  "web.domains.email.update_success": {
+    "text": "Đã lưu cấu hình email thành công"
+  },
+  "web.domains.email.delete_success": {
+    "text": "Đã xóa cấu hình email thành công"
+  },
+  "web.domains.email.default_sender_notice": {
+    "text": "Email cho tên miền này hiện đang được gửi từ người gửi toàn cục. Hoàn tất cấu hình email để sử dụng danh tính người gửi của riêng bạn."
+  },
+  "web.domains.email.disabled_notice": {
+    "text": "Việc gửi email tùy chỉnh hiện đang bị vô hiệu hóa. Email sẽ được gửi từ người gửi toàn cục. Bật tính năng bên dưới để sử dụng danh tính người gửi tùy chỉnh của bạn."
+  },
+  "web.domains.email.test_email_title": {
+    "text": "Kiểm tra việc gửi email"
+  },
+  "web.domains.email.test_email_hint": {
+    "text": "Gửi một email kiểm tra cho chính bạn bằng cấu hình đã lưu. Hoạt động ngay cả khi tính năng chưa được bật."
+  },
+  "web.domains.email.send_test": {
+    "text": "Gửi thử"
+  },
+  "web.domains.email.test_email_sent": {
+    "text": "Đã gửi email kiểm tra thành công"
+  },
+  "web.domains.email.test_email_failed": {
+    "text": "Không thể gửi email kiểm tra"
+  },
+  "web.domains.email.test_email_sent_to": {
+    "text": "Đã gửi đến {email}"
+  },
+  "web.domains.email.delivered_via": {
+    "text": "Được gửi qua {provider}"
+  },
+  "web.domains.email.badge_not_configured": {
+    "text": "Chưa cấu hình"
+  },
+  "web.domains.email.badge_default_sender": {
+    "text": "Đang dùng người gửi mặc định"
+  },
+  "web.domains.email.badge_verified": {
+    "text": "Đã xác minh"
+  },
+  "web.domains.email.badge_pending": {
+    "text": "Đang chờ xác minh"
+  },
+  "web.domains.email.badge_disabled": {
+    "text": "Đã vô hiệu hóa"
+  },
+  "web.domains.email.tooltip_not_configured": {
+    "text": "Chưa cấu hình người gửi email — email sử dụng người gửi mặc định của nền tảng"
+  },
+  "web.domains.email.tooltip_pending": {
+    "text": "Cấu hình người gửi email đang chờ xác minh — email sử dụng người gửi mặc định của nền tảng"
+  },
+  "web.domains.email.tooltip_disabled": {
+    "text": "Người gửi email đã bị vô hiệu hóa — email sử dụng người gửi mặc định của nền tảng"
+  },
+  "web.domains.email.tooltip_verified": {
+    "text": "Người gửi email đã được xác minh — email được gửi từ tên miền này"
+  },
+  "web.domains.incoming.title": {
+    "text": "Bí mật đến"
+  },
+  "web.domains.incoming.config_title": {
+    "text": "Cấu hình bí mật đến"
+  },
+  "web.domains.incoming.config_description": {
+    "text": "Cho phép người dùng bên ngoài gửi bí mật trực tiếp đến những người nhận được chỉ định trên tên miền này"
+  },
+  "web.domains.incoming.feature_disabled": {
+    "text": "Bí mật đến không khả dụng"
+  },
+  "web.domains.incoming.feature_disabled_description": {
+    "text": "Bí mật đến chưa được bật trên phiên bản này. Vui lòng liên hệ quản trị viên của bạn."
+  },
+  "web.domains.incoming.access_denied": {
+    "text": "Truy cập bị từ chối"
+  },
+  "web.domains.incoming.access_denied_description": {
+    "text": "Bạn không có quyền quản lý cài đặt bí mật đến cho tên miền này. Vui lòng liên hệ quản trị viên tổ chức của bạn."
+  },
+  "web.domains.incoming.upgrade_to_configure": {
+    "text": "Nâng cấp gói của bạn để cấu hình bí mật đến cho tên miền này."
+  },
+  "web.domains.incoming.configure_incoming": {
+    "text": "Cấu hình bí mật đến"
+  },
+  "web.domains.incoming.not_configured_notice": {
+    "text": "Bí mật đến chưa được cấu hình cho tên miền này. Thêm người nhận để cho phép người dùng bên ngoài gửi bí mật đến nhóm của bạn."
+  },
+  "web.domains.incoming.disabled_notice": {
+    "text": "Bí mật đến hiện đang bị vô hiệu hóa. Người dùng bên ngoài không thể gửi bí mật đến những người nhận trên tên miền này. Bật tính năng bên dưới để cho phép bí mật đến."
+  },
+  "web.domains.incoming.recipients_title": {
+    "text": "Người nhận"
+  },
+  "web.domains.incoming.recipients_description": {
+    "text": "Xác định ai có thể nhận bí mật đến trên tên miền này. Người nhận sẽ nhận được thông báo qua email khi một bí mật được gửi đến họ."
+  },
+  "web.domains.incoming.add_recipient": {
+    "text": "Thêm người nhận"
+  },
+  "web.domains.incoming.remove_recipient": {
+    "text": "Xóa"
+  },
+  "web.domains.incoming.email_label": {
+    "text": "Địa chỉ email"
+  },
+  "web.domains.incoming.email_placeholder": {
+    "text": "recipient{'@'}example.com"
+  },
+  "web.domains.incoming.name_label": {
+    "text": "Tên hiển thị"
+  },
+  "web.domains.incoming.name_placeholder": {
+    "text": "ví dụ: Security Team"
+  },
+  "web.domains.incoming.empty_state": {
+    "text": "Chưa cấu hình người nhận"
+  },
+  "web.domains.incoming.empty_state_description": {
+    "text": "Thêm người nhận để cho phép người dùng bên ngoài gửi bí mật đến nhóm của bạn."
+  },
+  "web.domains.incoming.validation_invalid_email": {
+    "text": "Địa chỉ email không hợp lệ"
+  },
+  "web.domains.incoming.validation_duplicate_email": {
+    "text": "Địa chỉ email này đã được thêm"
+  },
+  "web.domains.incoming.validation_max_recipients": {
+    "text": "Cho phép tối đa {max} người nhận"
+  },
+  "web.domains.incoming.validation_name_required": {
+    "text": "Tên hiển thị là bắt buộc"
+  },
+  "web.domains.incoming.validation_email_required": {
+    "text": "Địa chỉ email là bắt buộc"
+  },
+  "web.domains.incoming.save_changes": {
+    "text": "Lưu thay đổi"
+  },
+  "web.domains.incoming.discard_changes": {
+    "text": "Hủy thay đổi"
+  },
+  "web.domains.incoming.update_success": {
+    "text": "Đã lưu cấu hình bí mật đến thành công"
+  },
+  "web.domains.incoming.delete_success": {
+    "text": "Đã xóa cấu hình bí mật đến thành công"
+  },
+  "web.domains.incoming.recipient_count": {
+    "text": "{count} người nhận | {count} người nhận"
+  },
+  "web.domains.incoming.badge_not_configured": {
+    "text": "Chưa cấu hình"
+  },
+  "web.domains.incoming.badge_configured": {
+    "text": "Đã cấu hình"
+  },
+  "web.domains.incoming.badge_disabled": {
+    "text": "Đã vô hiệu hóa"
+  },
+  "web.domains.incoming.tooltip_not_configured": {
+    "text": "Bí mật đến chưa được cấu hình - người dùng bên ngoài không thể gửi bí mật đến tên miền này"
+  },
+  "web.domains.incoming.tooltip_configured": {
+    "text": "Bí mật đến đã được bật với {count} người nhận"
+  },
+  "web.domains.incoming.tooltip_disabled": {
+    "text": "Tính năng bí mật đến đã bị vô hiệu hóa cho tên miền này"
+  },
+  "web.domains.incoming.enabled_label": {
+    "text": "Bật bí mật đến"
+  },
+  "web.domains.incoming.enabled_hint": {
+    "text": "Cho phép người dùng bên ngoài gửi bí mật đến những người nhận trên tên miền này"
+  },
+  "web.domains.incoming.public_url_label": {
+    "text": "URL công khai"
+  },
+  "web.domains.incoming.public_url_description": {
+    "text": "Chia sẻ URL này với người dùng bên ngoài để cho phép họ gửi bí mật"
+  },
+  "web.domains.incoming.copy_url": {
+    "text": "Sao chép URL"
+  },
+  "web.domains.incoming.url_copied": {
+    "text": "Đã sao chép URL vào clipboard"
+  },
+  "web.domains.incoming.remove_all_confirmation": {
+    "text": "Bạn có chắc chắn muốn xóa tất cả người nhận không? Người dùng bên ngoài sẽ không còn có thể gửi bí mật đến tên miền này."
+  },
+  "web.domains.incoming.max_recipients_reached": {
+    "text": "Đã đạt số lượng người nhận tối đa"
+  },
+  "web.domains.incoming.duplicate_recipient": {
+    "text": "Địa chỉ email này đã được thêm"
+  },
+  "web.domains.incoming.save_will_replace_confirmation": {
+    "text": "Việc lưu sẽ thay thế tất cả người nhận hiện có bằng các thay đổi đang chờ của bạn. Bạn có chắc chắn không?"
+  },
+  "web.domains.incoming.delete_all_recipients": {
+    "text": "Xóa tất cả người nhận"
+  },
+  "web.domains.signin.title": {
+    "text": "Cấu hình đăng nhập"
+  },
+  "web.domains.signin.configure_signin": {
+    "text": "Cấu hình đăng nhập"
+  },
+  "web.domains.signin.config_description": {
+    "text": "Cấu hình các phương thức xác thực đăng nhập cho tên miền này"
+  },
+  "web.domains.signin.access_denied": {
+    "text": "Truy cập bị từ chối"
+  },
+  "web.domains.signin.upgrade_to_configure": {
+    "text": "Nâng cấp gói của bạn để cấu hình các phương thức đăng nhập cho tên miền này."
+  },
+  "web.domains.signin.not_configured_notice": {
+    "text": "Cấu hình đăng nhập chưa được thiết lập cho tên miền này. Cấu hình các tùy chỉnh để kiểm soát những phương thức xác thực nào khả dụng trên trang đăng nhập của tên miền này."
+  },
+  "web.domains.signin.signin_enabled_label": {
+    "text": "Đã bật đăng nhập"
+  },
+  "web.domains.signin.header_toggle_label": {
+    "text": "Đăng nhập"
+  },
+  "web.domains.signin.signin_enabled_hint": {
+    "text": "Người dùng có thể đăng nhập trên tên miền này hay không"
+  },
+  "web.domains.signin.restrict_to_label": {
+    "text": "Giới hạn phương thức đăng nhập"
+  },
+  "web.domains.signin.restrict_to_hint": {
+    "text": "Giới hạn tên miền này ở một phương thức xác thực duy nhất. Khi được thiết lập, chỉ phương thức đã chọn được hiển thị trên trang đăng nhập."
+  },
+  "web.domains.signin.all_methods": {
+    "text": "Tất cả phương thức"
+  },
+  "web.domains.signin.all_methods_description": {
+    "text": "Hiển thị tất cả các phương thức xác thực đã bật trên trang đăng nhập"
+  },
+  "web.domains.signin.method_password": {
+    "text": "Mật khẩu"
+  },
+  "web.domains.signin.method_email_auth": {
+    "text": "Xác thực qua email"
+  },
+  "web.domains.signin.method_webauthn": {
+    "text": "WebAuthn / Passkeys"
+  },
+  "web.domains.signin.method_sso": {
+    "text": "Đăng nhập một lần"
+  },
+  "web.domains.signin.method_overrides_label": {
+    "text": "Tùy chỉnh phương thức"
+  },
+  "web.domains.signin.method_overrides_hint": {
+    "text": "Bật hoặc tắt từng phương thức xác thực riêng lẻ cho tên miền này"
+  },
+  "web.domains.signin.mode_question": {
+    "text": "Người dùng có thể đăng nhập như thế nào?"
+  },
+  "web.domains.signin.mode_any": {
+    "text": "Bất kỳ phương thức khả dụng nào"
+  },
+  "web.domains.signin.mode_any_hint": {
+    "text": "Hiển thị mọi phương thức khả dụng trên tên miền này. Thu hẹp từng phương thức riêng lẻ bên dưới."
+  },
+  "web.domains.signin.mode_one": {
+    "text": "Một phương thức cụ thể"
+  },
+  "web.domains.signin.mode_one_hint": {
+    "text": "Giới hạn trang đăng nhập ở một phương thức duy nhất. Chỉ những phương thức khả dụng trên tên miền này được liệt kê."
+  },
+  "web.domains.signin.mode_disabled": {
+    "text": "Đã tắt đăng nhập"
+  },
+  "web.domains.signin.mode_disabled_hint": {
+    "text": "Người dùng không thể đăng nhập trên tên miền này."
+  },
+  "web.domains.signin.mode_disabled_notice": {
+    "text": "Khách truy cập trang đăng nhập của tên miền này sẽ thấy thông báo rằng đăng nhập không khả dụng, kèm theo một liên kết quay lại trang chủ. Cài đặt phương thức trước đó của bạn được giữ lại và khôi phục khi bạn bật lại đăng nhập."
+  },
+  "web.domains.signin.methods_list_label": {
+    "text": "Các phương thức hiển thị trên trang đăng nhập"
+  },
+  "web.domains.signin.restrict_picker_hint": {
+    "text": "Chỉ những phương thức khả dụng trên tên miền này được liệt kê."
+  },
+  "web.domains.signin.availability_always": {
+    "text": "Luôn khả dụng"
+  },
+  "web.domains.signin.availability_global_on": {
+    "text": "Tuân theo chính sách toàn cục · Bật"
+  },
+  "web.domains.signin.availability_global_off": {
+    "text": "Không khả dụng"
+  },
+  "web.domains.signin.availability_unavailable": {
+    "text": "Không khả dụng trên toàn trang"
+  },
+  "web.domains.signin.allow_on_domain": {
+    "text": "Cho phép trên tên miền này"
+  },
+  "web.domains.signin.method_password_blurb": {
+    "text": "Chỉ mật khẩu"
+  },
+  "web.domains.signin.method_email_auth_blurb": {
+    "text": "Đăng nhập bằng liên kết không cần mật khẩu"
+  },
+  "web.domains.signin.method_webauthn_blurb": {
+    "text": "Sinh trắc học và khóa bảo mật"
+  },
+  "web.domains.signin.method_sso_blurb": {
+    "text": "Nhà cung cấp danh tính bên ngoài"
+  },
+  "web.domains.signin.email_auth_label": {
+    "text": "Xác thực qua email"
+  },
+  "web.domains.signin.email_auth_hint": {
+    "text": "Cho phép xác thực qua email không cần mật khẩu trên tên miền này"
+  },
+  "web.domains.signin.sso_enabled_label": {
+    "text": "Đăng nhập một lần"
+  },
+  "web.domains.signin.sso_enabled_hint": {
+    "text": "Cho phép xác thực SSO trên tên miền này"
+  },
+  "web.domains.signin.enabled_label": {
+    "text": "Bật cấu hình đăng nhập"
+  },
+  "web.domains.signin.enabled_hint": {
+    "text": "Khi được bật, tên miền này sử dụng các cài đặt đăng nhập đã cấu hình ở trên"
+  },
+  "web.domains.signin.save_config": {
+    "text": "Lưu cấu hình"
+  },
+  "web.domains.signin.update_success": {
+    "text": "Đã cập nhật cấu hình đăng nhập thành công"
+  },
+  "web.domains.signin.reset_to_defaults": {
+    "text": "Đặt lại về mặc định"
+  },
+  "web.domains.signin.reset_confirm": {
+    "text": "Đặt lại đăng nhập về mặc định toàn cục?"
+  },
+  "web.domains.signin.reset_keeps_sso": {
+    "text": "Thông tin xác thực SSO của bạn được giữ lại. Hãy xóa chúng riêng trên màn hình cấu hình SSO."
+  },
+  "web.domains.signin.reset_action": {
+    "text": "Có, đặt lại"
+  },
+  "web.domains.signin.reset_success": {
+    "text": "Đã đặt lại cài đặt đăng nhập về mặc định toàn cục"
+  },
+  "web.domains.signup.title": {
+    "text": "Xác thực đăng ký"
+  },
+  "web.domains.signup.config_description": {
+    "text": "Cấu hình xác thực đăng ký cho tên miền này"
+  },
+  "web.domains.signup.access_denied": {
+    "text": "Truy cập bị từ chối"
+  },
+  "web.domains.signup.upgrade_to_configure": {
+    "text": "Nâng cấp gói của bạn để cấu hình xác thực đăng ký theo từng tên miền."
+  },
+  "web.domains.signup.configure_signup": {
+    "text": "Cấu hình đăng ký"
+  },
+  "web.domains.signup.not_configured_notice": {
+    "text": "Xác thực đăng ký chưa được cấu hình cho tên miền này. Cấu hình một chiến lược để kiểm soát ai có thể đăng ký qua tên miền này."
+  },
+  "web.domains.signup.site_signups_disabled_warning": {
+    "text": "Việc đăng ký hiện đang bị tắt ở cấp độ trang. Chính sách theo từng tên miền này đã được cấu hình nhưng sẽ không kiểm soát lưu lượng nào cho đến khi việc đăng ký trên trang được bật."
+  },
+  "web.domains.signup.strategy_label": {
+    "text": "Chiến lược xác thực"
+  },
+  "web.domains.signup.strategy_description": {
+    "text": "Chọn cách các địa chỉ email được xác thực khi người dùng đăng ký trên tên miền này."
+  },
+  "web.domains.signup.network_validation_warning": {
+    "text": "Chiến lược này thực hiện các lệnh gọi mạng trong quá trình đăng ký, điều này có thể làm tăng độ trễ hoặc bị một số nhà cung cấp chặn."
+  },
+  "web.domains.signup.allowed_domains_label": {
+    "text": "Các tên miền đăng ký được phép"
+  },
+  "web.domains.signup.allowed_domains_hint": {
+    "text": "Chỉ những tên miền email này mới được phép đăng ký. Thêm một tên miền cho mỗi mục."
+  },
+  "web.domains.signup.domain_placeholder": {
+    "text": "example.com"
+  },
+  "web.domains.signup.invalid_domain": {
+    "text": "Vui lòng nhập một tên miền hợp lệ (ví dụ: example.com)"
+  },
+  "web.domains.signup.domain_exists": {
+    "text": "Tên miền này đã có trong danh sách"
+  },
+  "web.domains.signup.remove_domain": {
+    "text": "Xóa {domain}"
+  },
+  "web.domains.signup.enabled_label": {
+    "text": "Bật xác thực theo từng tên miền"
+  },
+  "web.domains.signup.enabled_hint": {
+    "text": "Khi được bật, việc đăng ký trên tên miền này sử dụng chiến lược ở trên thay vì chính sách toàn cục."
+  },
+  "web.domains.signup.delete_config": {
+    "text": "Xóa cấu hình"
+  },
+  "web.domains.signup.delete_confirm": {
+    "text": "Xóa cấu hình xác thực đăng ký? Việc đăng ký sẽ quay về chính sách toàn cục."
+  },
+  "web.domains.signup.save_config": {
+    "text": "Lưu cấu hình"
+  },
+  "web.domains.signup.update_success": {
+    "text": "Đã cập nhật xác thực đăng ký thành công"
+  },
+  "web.domains.signup.delete_success": {
+    "text": "Đã xóa cấu hình xác thực đăng ký thành công"
+  },
+  "web.domains.signup.domain_overrides_label": {
+    "text": "Tùy chỉnh tên miền"
+  },
+  "web.domains.signup.domain_overrides_hint": {
+    "text": "Ghi đè cài đặt đăng ký toàn cục cho tên miền này"
+  },
+  "web.domains.signup.signup_enabled_label": {
+    "text": "Đã bật đăng ký"
+  },
+  "web.domains.signup.signup_enabled_hint": {
+    "text": "Ghi đè việc đăng ký có được bật cho tên miền này hay không"
+  },
+  "web.domains.signup.autoverify_label": {
+    "text": "Tự động xác minh tài khoản"
+  },
+  "web.domains.signup.autoverify_hint": {
+    "text": "Ghi đè việc các tài khoản mới có được tự động xác minh trên tên miền này hay không"
+  },
+  "web.domains.sso.title": {
+    "text": "Đăng nhập một lần"
+  },
+  "web.domains.sso.config_title": {
+    "text": "Cấu hình SSO"
+  },
+  "web.domains.sso.config_description": {
+    "text": "Cấu hình xác thực đăng nhập một lần cho tên miền này"
+  },
+  "web.domains.sso.access_denied": {
+    "text": "Truy cập bị từ chối"
+  },
+  "web.domains.sso.access_denied_description": {
+    "text": "Bạn không có quyền quản lý cài đặt SSO cho tên miền này. Vui lòng liên hệ quản trị viên tổ chức của bạn."
+  },
+  "web.domains.sso.upgrade_to_configure": {
+    "text": "Nâng cấp gói của bạn để cấu hình đăng nhập một lần cho tên miền này."
+  },
+  "web.domains.sso.create_success": {
+    "text": "Đã tạo cấu hình SSO thành công"
+  },
+  "web.domains.sso.update_success": {
+    "text": "Đã cập nhật cấu hình SSO thành công"
+  },
+  "web.domains.sso.delete_success": {
+    "text": "Đã xóa cấu hình SSO thành công"
+  },
+  "web.domains.sso.test_success": {
+    "text": "Kiểm tra kết nối thành công — nhà cung cấp đã phản hồi chính xác"
+  },
+  "web.domains.sso.test_failed": {
+    "text": "Kiểm tra kết nối thất bại"
+  },
+  "web.domains.sso.enforce_moved_notice": {
+    "text": "Để yêu cầu SSO cho mọi lần đăng nhập trên tên miền này, hãy cấu hình nó trong cài đặt đăng nhập của tên miền. Chế độ chỉ SSO giới hạn trang đăng nhập ở nhà cung cấp SSO được cấu hình tại đây."
+  },
+  "web.domains.sso.configure_sso": {
+    "text": "Cấu hình SSO"
+  },
+  "web.domains.sso.not_configured_notice": {
+    "text": "SSO chưa được cấu hình cho tên miền này. Bật đăng nhập một lần để cho phép các thành viên nhóm xác thực bằng nhà cung cấp danh tính của tổ chức bạn."
+  },
+  "web.domains.sso.edit_credentials": {
+    "text": "Chỉnh sửa thông tin xác thực"
+  },
+  "web.domains.sso.configure_button": {
+    "text": "Cấu hình"
+  },
+  "web.domains.sso.upgrade_required": {
+    "text": "Nâng cấp để cấu hình"
   }
 }

--- a/locales/content/vi/workspace-organizations.json
+++ b/locales/content/vi/workspace-organizations.json
@@ -578,5 +578,344 @@
   "web.organizations.invitations.expires_soon": {
     "text": "Sắp hết hạn",
     "source_hash": "a5dcfef9"
+  },
+  "api.organizations.errors.not_found": {
+    "text": "Không tìm thấy tổ chức: %{extid}"
+  },
+  "api.organizations.errors.owner_required": {
+    "text": "Chỉ chủ sở hữu tổ chức mới có thể thực hiện hành động này"
+  },
+  "api.organizations.errors.admin_required": {
+    "text": "Chỉ chủ sở hữu và quản trị viên của tổ chức mới có thể thực hiện hành động này"
+  },
+  "api.organizations.errors.member_required": {
+    "text": "Bạn phải là thành viên của tổ chức để thực hiện hành động này"
+  },
+  "api.organizations.invitations.errors.create_admin_required": {
+    "text": "Chỉ chủ sở hữu và quản trị viên của tổ chức mới có thể tạo lời mời"
+  },
+  "api.organizations.invitations.errors.resend_admin_required": {
+    "text": "Chỉ chủ sở hữu và quản trị viên của tổ chức mới có thể gửi lại lời mời"
+  },
+  "api.organizations.invitations.errors.view_admin_required": {
+    "text": "Chỉ chủ sở hữu và quản trị viên của tổ chức mới có thể xem lời mời"
+  },
+  "api.organizations.invitations.errors.revoke_admin_required": {
+    "text": "Chỉ chủ sở hữu và quản trị viên của tổ chức mới có thể thu hồi lời mời"
+  },
+  "api.organizations.invitations.errors.email_required": {
+    "text": "Email là bắt buộc"
+  },
+  "api.organizations.invitations.errors.email_invalid": {
+    "text": "Định dạng email không hợp lệ"
+  },
+  "api.organizations.invitations.errors.role_invalid": {
+    "text": "Vai trò phải là thành viên hoặc quản trị viên"
+  },
+  "api.organizations.invitations.errors.cannot_invite_owner": {
+    "text": "Không thể mời với vai trò chủ sở hữu"
+  },
+  "api.organizations.invitations.errors.already_member": {
+    "text": "Người dùng đã là thành viên của tổ chức này"
+  },
+  "api.organizations.invitations.errors.already_pending": {
+    "text": "Đã có lời mời đang chờ cho email này"
+  },
+  "api.organizations.invitations.errors.member_limit_reached": {
+    "text": "Đã đạt giới hạn thành viên. Nâng cấp gói của bạn để mời thêm thành viên."
+  },
+  "api.organizations.invitations.errors.not_found": {
+    "text": "Không tìm thấy lời mời"
+  },
+  "api.organizations.invitations.errors.cannot_resend_non_pending": {
+    "text": "Chỉ có thể gửi lại các lời mời đang chờ"
+  },
+  "api.organizations.invitations.errors.cannot_revoke_non_pending": {
+    "text": "Chỉ có thể thu hồi các lời mời đang chờ"
+  },
+  "api.organizations.invitations.errors.resend_limit_reached": {
+    "text": "Đã đạt giới hạn gửi lại tối đa (%{max})"
+  },
+  "api.organizations.invitations.errors.accept_token_required": {
+    "text": "Token là bắt buộc"
+  },
+  "api.organizations.invitations.errors.accept_organization_gone": {
+    "text": "Tổ chức không còn tồn tại"
+  },
+  "api.organizations.invitations.errors.accept_already_acted": {
+    "text": "Lời mời đã được %{status}"
+  },
+  "api.organizations.invitations.errors.accept_expired": {
+    "text": "Lời mời đã hết hạn"
+  },
+  "api.organizations.invitations.errors.accept_email_mismatch": {
+    "text": "Địa chỉ email của bạn không khớp với lời mời"
+  },
+  "api.organizations.invitations.errors.accept_already_member": {
+    "text": "Bạn đã là thành viên của tổ chức này"
+  },
+  "web.organizations.entitlements_title": {
+    "text": "Quyền lợi của tổ chức"
+  },
+  "web.organizations.page_description_short": {
+    "text": "Xem và cấu hình các không gian làm việc của bạn"
+  },
+  "web.organizations.delete_organization_remove_domains_first": {
+    "text": "Xóa tất cả các tên miền tùy chỉnh trước khi xóa tổ chức này."
+  },
+  "web.organizations.default_org_delete_notice_title": {
+    "text": "Xóa tổ chức này"
+  },
+  "web.organizations.default_org_delete_notice_before": {
+    "text": "Đây là tổ chức mặc định của bạn và không thể bị xóa khỏi bảng điều khiển. Để xóa nó, vui lòng liên hệ qua"
+  },
+  "web.organizations.default_org_delete_notice_link": {
+    "text": "biểu mẫu phản hồi"
+  },
+  "web.organizations.default_org_delete_notice_after": {
+    "text": "."
+  },
+  "web.organizations.leave_organization": {
+    "text": "Rời khỏi tổ chức này"
+  },
+  "web.organizations.leave_organization_warning": {
+    "text": "Bạn sẽ mất quyền truy cập vào tổ chức này và các tài nguyên của nó."
+  },
+  "web.organizations.leave_organization_confirm_title": {
+    "text": "Rời khỏi tổ chức"
+  },
+  "web.organizations.leave_organization_confirm_message": {
+    "text": "Bạn có chắc chắn muốn rời khỏi {name} không? Bạn sẽ cần một lời mời mới để tham gia lại."
+  },
+  "web.organizations.leave_organization_success": {
+    "text": "Bạn đã rời khỏi tổ chức."
+  },
+  "web.organizations.leave_error": {
+    "text": "Không thể rời khỏi tổ chức"
+  },
+  "web.organizations.organizations": {
+    "text": "Tổ chức"
+  },
+  "web.organizations.invitations.invited_by_inline": {
+    "text": "bởi {email}"
+  },
+  "web.organizations.invitations.invited_as_inline": {
+    "text": "với vai trò {role}"
+  },
+  "web.organizations.invitations.back_to_home": {
+    "text": "Quay lại trang chủ"
+  },
+  "web.organizations.invitations.email_locked_hint": {
+    "text": "Lời mời này đã được gửi đến địa chỉ email này"
+  },
+  "web.organizations.invitations.signup_continue": {
+    "text": "Tiếp tục"
+  },
+  "web.organizations.invitations.signin_continue": {
+    "text": "Đăng nhập"
+  },
+  "web.organizations.invitations.confirm_join_below": {
+    "text": "Sắp hoàn tất — xác nhận bên dưới để tham gia tổ chức."
+  },
+  "web.organizations.invitations.go_to_organizations": {
+    "text": "Đi đến Tổ chức"
+  },
+  "web.organizations.invitations.already_member": {
+    "text": "Bạn đã là thành viên của tổ chức này"
+  },
+  "web.organizations.invitations.join_organization": {
+    "text": "Tham gia {orgName}"
+  },
+  "web.organizations.invitations.sign_in_to_join": {
+    "text": "Đăng nhập để tham gia {orgName}"
+  },
+  "web.organizations.invitations.decline": {
+    "text": "Từ chối"
+  },
+  "web.organizations.members.member_quota": {
+    "text": "{used} trên {limit} thành viên"
+  },
+  "web.organizations.members.pending_suffix": {
+    "text": "({count} đang chờ)"
+  },
+  "web.organizations.members.limit_reached_hint": {
+    "text": "Đã đạt giới hạn thành viên."
+  },
+  "web.organizations.sso.title": {
+    "text": "Đăng nhập một lần (SSO)"
+  },
+  "web.organizations.sso.description": {
+    "text": "Cấu hình SSO để cho phép các thành viên đăng nhập bằng nhà cung cấp danh tính của tổ chức bạn"
+  },
+  "web.organizations.sso.provider_type": {
+    "text": "Loại nhà cung cấp"
+  },
+  "web.organizations.sso.provider_type_description": {
+    "text": "Chọn nhà cung cấp danh tính của tổ chức bạn"
+  },
+  "web.organizations.sso.display_name": {
+    "text": "Tên hiển thị"
+  },
+  "web.organizations.sso.display_name_hint": {
+    "text": "Một tên thân thiện được hiển thị cho người dùng khi đăng nhập"
+  },
+  "web.organizations.sso.display_name_placeholder": {
+    "text": "ví dụ: Acme Corp SSO"
+  },
+  "web.organizations.sso.client_id": {
+    "text": "Client ID"
+  },
+  "web.organizations.sso.client_id_placeholder": {
+    "text": "Client ID OAuth của bạn"
+  },
+  "web.organizations.sso.client_secret": {
+    "text": "Client Secret"
+  },
+  "web.organizations.sso.client_secret_placeholder": {
+    "text": "Client Secret OAuth của bạn"
+  },
+  "web.organizations.sso.client_secret_update_hint": {
+    "text": "Để trống để giữ lại secret hiện có"
+  },
+  "web.organizations.sso.tenant_id": {
+    "text": "Tenant ID"
+  },
+  "web.organizations.sso.tenant_id_hint": {
+    "text": "Định danh tenant Azure AD / Entra ID của bạn"
+  },
+  "web.organizations.sso.tenant_id_placeholder": {
+    "text": "ví dụ: 12345678-1234-1234-1234-123456789abc"
+  },
+  "web.organizations.sso.issuer": {
+    "text": "Issuer URL"
+  },
+  "web.organizations.sso.issuer_hint": {
+    "text": "URL khám phá OIDC cho nhà cung cấp danh tính của bạn"
+  },
+  "web.organizations.sso.issuer_placeholder": {
+    "text": "ví dụ: https://login.example.com"
+  },
+  "web.organizations.sso.view_discovery_document": {
+    "text": "Xem tài liệu khám phá"
+  },
+  "web.organizations.sso.callback_url": {
+    "text": "Callback URL"
+  },
+  "web.organizations.sso.callback_url_hint": {
+    "text": "Thêm URL này vào các URI chuyển hướng được phép của nhà cung cấp danh tính của bạn"
+  },
+  "web.organizations.sso.allowed_domains": {
+    "text": "Các tên miền email được phép"
+  },
+  "web.organizations.sso.allowed_domains_hint": {
+    "text": "Chỉ những người dùng có địa chỉ email từ các tên miền này mới có thể đăng nhập. Để trống để cho phép tất cả các tên miền."
+  },
+  "web.organizations.sso.domain_placeholder": {
+    "text": "ví dụ: acme.com"
+  },
+  "web.organizations.sso.invalid_domain": {
+    "text": "Vui lòng nhập một tên miền hợp lệ (ví dụ: example.com)"
+  },
+  "web.organizations.sso.domain_exists": {
+    "text": "Tên miền này đã có trong danh sách"
+  },
+  "web.organizations.sso.remove_domain": {
+    "text": "Xóa {domain}"
+  },
+  "web.organizations.sso.enabled": {
+    "text": "Bật SSO"
+  },
+  "web.organizations.sso.enabled_hint": {
+    "text": "Khi được bật, các thành viên tổ chức có thể đăng nhập bằng nhà cung cấp SSO này"
+  },
+  "web.organizations.sso.enforce_sso_only": {
+    "text": "Bắt buộc chỉ SSO"
+  },
+  "web.organizations.sso.enforce_sso_only_hint": {
+    "text": "Yêu cầu SSO cho mọi lần đăng nhập trên tên miền này. Khi được bật, xác thực dựa trên mật khẩu sẽ bị vô hiệu hóa."
+  },
+  "web.organizations.sso.grant_org_scope": {
+    "text": "Cấp quyền truy cập toàn tổ chức"
+  },
+  "web.organizations.sso.grant_org_scope_hint": {
+    "text": "Các thành viên mới tham gia qua SSO của tên miền này sẽ được cấp quyền truy cập vào tất cả các tên miền của tổ chức. Các thành viên hiện có không bị ảnh hưởng. Khi bị tắt (mặc định), các thành viên mới chỉ có thể truy cập tên miền này."
+  },
+  "web.organizations.sso.save_config": {
+    "text": "Lưu cấu hình SSO"
+  },
+  "web.organizations.sso.delete_config": {
+    "text": "Xóa cấu hình"
+  },
+  "web.organizations.sso.delete_confirm": {
+    "text": "Bạn có chắc chắn không? Điều này sẽ vô hiệu hóa SSO cho tổ chức của bạn."
+  },
+  "web.organizations.sso.load_error": {
+    "text": "Không thể tải cấu hình SSO"
+  },
+  "web.organizations.sso.save_error": {
+    "text": "Không thể lưu cấu hình SSO"
+  },
+  "web.organizations.sso.create_success": {
+    "text": "Đã tạo cấu hình SSO thành công"
+  },
+  "web.organizations.sso.update_success": {
+    "text": "Đã cập nhật cấu hình SSO thành công"
+  },
+  "web.organizations.sso.delete_success": {
+    "text": "Đã xóa cấu hình SSO thành công"
+  },
+  "web.organizations.sso.delete_error": {
+    "text": "Không thể xóa cấu hình SSO"
+  },
+  "web.organizations.sso.test_connection": {
+    "text": "Kiểm tra kết nối"
+  },
+  "web.organizations.sso.test_connection_hint": {
+    "text": "Xác minh rằng nhà cung cấp danh tính có thể truy cập được (không xác thực thông tin xác thực)"
+  },
+  "web.organizations.sso.test_button": {
+    "text": "Kiểm tra kết nối"
+  },
+  "web.organizations.sso.testing": {
+    "text": "Đang kiểm tra..."
+  },
+  "web.organizations.sso.test_error": {
+    "text": "Không thể kiểm tra kết nối"
+  },
+  "web.organizations.sso.auth_endpoint": {
+    "text": "Điểm cuối ủy quyền"
+  },
+  "web.organizations.sso.missing_fields": {
+    "text": "Thiếu trường"
+  },
+  "web.organizations.sso.status_enabled": {
+    "text": "Đã bật"
+  },
+  "web.organizations.sso.status_configured": {
+    "text": "Đã cấu hình"
+  },
+  "web.organizations.sso.domain_sso_title": {
+    "text": "SSO tên miền"
+  },
+  "web.organizations.sso.domain_sso_description": {
+    "text": "Cấu hình SSO cho từng tên miền đã xác minh"
+  },
+  "web.organizations.sso.provider_type_locked_hint": {
+    "text": "Để thay đổi nhà cung cấp, hãy xóa cấu hình này trước"
+  },
+  "web.organizations.sso.status_not_configured": {
+    "text": "Chưa cấu hình"
+  },
+  "web.organizations.sso.no_domains": {
+    "text": "Không có tên miền đã xác minh"
+  },
+  "web.organizations.sso.no_domains_description": {
+    "text": "Thêm và xác minh một tên miền trước khi cấu hình SSO cho nó."
+  },
+  "web.organizations.tabs.team": {
+    "text": "Nhóm"
+  },
+  "web.organizations.tabs.sso": {
+    "text": "SSO"
   }
 }


### PR DESCRIPTION
## `vi` translation update

Automated export of completed **vi** translations from the translation task DB.
Scope: `locales/content/vi/` only — 27 file(s), +1828/-10.

✅ `i18n validate variables`: no variable mismatches.

---

### Local quality review

> Produced by a fresh, isolated `claude` review agent (model `claude-sonnet-5`, agent `saas-translator`) that read
> `locales/AGENT_TRANSLATION_PROTOCOL.md` and inspected this branch's diff before the PR was opened.

**Verdict:** ✅ Looks good — no variable/brand defects found.

**Summary:** Large addition of ~700+ new strings (SSO/domain config, organizations, billing, colonel admin, email) plus light copy-edits to existing strings. Variables (`{var}`, `%{var}`, pipe-plurals, `{'@'}` escapes) all preserved correctly, and brand terms are untouched.

**Critical (must fix):** None.

**Warnings:**
- `web.INSTRUCTION.phishing_warning`: translated "check the region domain" as "kiểm tra tên miền khu vực" — verified this matches the (unusually worded) English source exactly, so not a defect, but flagging since the English source itself reads oddly and may warrant a source-side fix.
- Minor SSO heading inconsistency: some keys render "Đăng nhập một lần (SSO)" with the parenthetical (e.g. `web.organizations.sso.title`, `web.login.custom_domain_sso_title`) while sibling keys use "Đăng nhập một lần" alone (e.g. `web.domains.sso.title`, `web.domains.signin.sso_enabled_label`). Likely intentional per context length, but worth a maintainer glance for consistency.

**Notes:**
- OAuth/technical field labels (`Client ID`, `Client Secret`, `Tenant ID`, `Issuer URL`, `Callback URL`) are correctly left untranslated, consistent with this project's cross-locale convention for technical field names.
- `Delano` email signature kept as a literal name (not swapped to "Support Team" translation), consistent with vi's established convention (differs from several other locales reviewed this session).
- Pipe-plural forms (e.g. `recipient_count`) are identical on both sides, correct since Vietnamese has no plural marking.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
