### PR TITLE
i18n: update zh translations

### DIFF
--- a/locales/content/zh/00-common.json
+++ b/locales/content/zh/00-common.json
@@ -1299,7 +1299,7 @@
     "source_hash": "fc78d9cb"
   },
   "web.INSTRUCTION.phishing_warning": {
-    "text": "请确认您访问的是 {product_name} 官方网站。不法分子有时会创建与 {product_name} 外观完全相同的虚假网站来窃取您的信息。为避免钓鱼攻击，请在创建新链接前核实域名。",
+    "text": "请始终确认您访问的是 {product_name} 官方网站。诈骗者有时会创建与 {product_name} 完全相同的虚假网站，以窃取您的机密内容。为避免网络钓鱼攻击，请在创建新链接前核对区域域名。",
     "source_hash": "b588f5b2"
   },
   "web.pricing.title": {
@@ -1383,5 +1383,110 @@
     "text": "升级以解锁更多功能",
     "context": "Description shown for free plan users encouraging upgrade",
     "source_hash": "783f174c"
+  },
+  "api.errors.authentication_required": {
+    "text": "需要身份验证"
+  },
+  "api.errors.sso_only_action_blocked": {
+    "text": "此操作在仅 SSO 模式下不可用"
+  },
+  "web.COMMON.configure": {
+    "text": "配置"
+  },
+  "web.COMMON.copy_to_clipboard": {
+    "text": "复制"
+  },
+  "web.COMMON.add": {
+    "text": "添加"
+  },
+  "web.COMMON.enabled": {
+    "text": "已启用"
+  },
+  "web.COMMON.disabled": {
+    "text": "已禁用"
+  },
+  "web.COMMON.yes_delete": {
+    "text": "是的，删除"
+  },
+  "web.COMMON.error_code": {
+    "text": "错误代码"
+  },
+  "web.COMMON.http_status": {
+    "text": "HTTP 状态"
+  },
+  "web.COMMON.details": {
+    "text": "详细信息"
+  },
+  "web.COMMON.field_confirm_password": {
+    "text": "确认密码"
+  },
+  "web.COMMON.passwords_must_match": {
+    "text": "密码必须匹配"
+  },
+  "web.COMMON.and": {
+    "text": "和"
+  },
+  "web.COMMON.or": {
+    "text": "或"
+  },
+  "web.COMMON.copied": {
+    "text": "已复制"
+  },
+  "web.COMMON.copy": {
+    "text": "复制"
+  },
+  "web.COMMON.copy_email": {
+    "text": "复制邮箱地址"
+  },
+  "web.COMMON.copy_id": {
+    "text": "复制账户 ID"
+  },
+  "web.COMMON.org_id_tooltip": {
+    "text": "您组织的唯一标识符"
+  },
+  "web.COMMON.success": {
+    "text": "成功"
+  },
+  "web.COMMON.need_help": {
+    "text": "需要帮助"
+  },
+  "web.COMMON.open_help_dialog": {
+    "text": "打开帮助对话框"
+  },
+  "web.COMMON.focus_is_now_in_the_main_text_area": {
+    "text": "焦点现在位于主文本区域"
+  },
+  "web.LABELS.show_passphrase": {
+    "text": "显示口令"
+  },
+  "web.LABELS.hide_passphrase": {
+    "text": "隐藏口令"
+  },
+  "web.LABELS.copy_icon": {
+    "text": "复制图标"
+  },
+  "web.LABELS.copied_icon": {
+    "text": "已复制图标"
+  },
+  "web.STATUS.unverified": {
+    "text": "未验证"
+  },
+  "web.TITLES.domain_detail": {
+    "text": "域名设置"
+  },
+  "web.TITLES.domain_signin": {
+    "text": "登录配置"
+  },
+  "web.TITLES.domain_sso": {
+    "text": "域名 SSO"
+  },
+  "web.TITLES.domain_signup": {
+    "text": "域名注册验证"
+  },
+  "web.TITLES.domain_email": {
+    "text": "邮件配置"
+  },
+  "web.TITLES.domain_incoming": {
+    "text": "接收的内容"
   }
 }

--- a/locales/content/zh/10-layout.json
+++ b/locales/content/zh/10-layout.json
@@ -148,7 +148,7 @@
     "source_hash": "b9766df3"
   },
   "web.help.secret_view_faq.what_am_i_looking_at.description": {
-    "text": "您正在查看通过 {product_name} 分享给您的安全信息。此内容仅显示一次，然后将从我们的服务器永久删除。",
+    "text": "您正在查看通过 {product_name} 与您分享的安全内容。该内容仅显示一次，随后会从我们的服务器上永久删除。",
     "source_hash": "e0f1a10c"
   },
   "web.help.secret_view_faq.can_i_view_again.title": {
@@ -338,5 +338,11 @@
   "web.layout.workspace_context": {
     "text": "工作区上下文",
     "source_hash": "dc6fa4f5"
+  },
+  "web.footer.workspace": {
+    "text": "工作区"
+  },
+  "web.help.default_content": {
+    "text": "请联系支持团队寻求帮助"
   }
 }

--- a/locales/content/zh/admin-colonel.json
+++ b/locales/content/zh/admin-colonel.json
@@ -634,5 +634,152 @@
   "web.colonel.feedback.when_you_submit_feedback_well_see": {
     "text": "当您提交反馈时，我们会看到：",
     "source_hash": "fe77172e"
+  },
+  "web.colonel.previewPlanMode": {
+    "text": "方案预览模式"
+  },
+  "web.colonel.previewModeDescription": {
+    "text": "以其他方案下客户看到的样子预览应用程序。这仅影响您的视图，不会更改任何组织的实际方案。"
+  },
+  "web.colonel.previewModeActive": {
+    "text": "预览已启用"
+  },
+  "web.colonel.bannedIps.empty": {
+    "text": "没有被封禁的 IP"
+  },
+  "web.colonel.bannedIps.currentIp": {
+    "text": "您当前的 IP 地址"
+  },
+  "web.colonel.bannedIps.confirmUnban": {
+    "text": "解封 {ip}？"
+  },
+  "web.colonel.bannedIps.actions.ban": {
+    "text": "封禁 IP"
+  },
+  "web.colonel.bannedIps.actions.quickBan": {
+    "text": "快速封禁"
+  },
+  "web.colonel.bannedIps.actions.unban": {
+    "text": "解封"
+  },
+  "web.colonel.bannedIps.actions.cancel": {
+    "text": "取消"
+  },
+  "web.colonel.bannedIps.columns.ipAddress": {
+    "text": "IP 地址"
+  },
+  "web.colonel.bannedIps.columns.reason": {
+    "text": "原因"
+  },
+  "web.colonel.bannedIps.columns.bannedAt": {
+    "text": "封禁时间"
+  },
+  "web.colonel.bannedIps.columns.bannedBy": {
+    "text": "封禁者"
+  },
+  "web.colonel.bannedIps.error.banFailed": {
+    "text": "封禁 IP 地址失败"
+  },
+  "web.colonel.bannedIps.error.unbanFailed": {
+    "text": "解封 IP 地址失败"
+  },
+  "web.colonel.bannedIps.form.title": {
+    "text": "封禁 IP 地址"
+  },
+  "web.colonel.bannedIps.form.ipLabel": {
+    "text": "IP 地址"
+  },
+  "web.colonel.bannedIps.form.reasonLabel": {
+    "text": "原因"
+  },
+  "web.colonel.bannedIps.form.reasonPlaceholder": {
+    "text": "可选原因"
+  },
+  "web.colonel.bannedIps.success.banned": {
+    "text": "IP 地址 {ip} 已被封禁"
+  },
+  "web.colonel.bannedIps.success.unbanned": {
+    "text": "IP 地址 {ip} 已被解封"
+  },
+  "web.colonel.customDomains.empty": {
+    "text": "未配置自定义域名"
+  },
+  "web.colonel.customDomains.noLogo": {
+    "text": "无徽标"
+  },
+  "web.colonel.customDomains.labels.organization": {
+    "text": "组织"
+  },
+  "web.colonel.customDomains.labels.externalId": {
+    "text": "外部 ID"
+  },
+  "web.colonel.customDomains.labels.created": {
+    "text": "创建时间"
+  },
+  "web.colonel.customDomains.labels.updated": {
+    "text": "更新时间"
+  },
+  "web.colonel.customDomains.labels.favicon": {
+    "text": "Favicon"
+  },
+  "web.colonel.customDomains.status.verified": {
+    "text": "已验证"
+  },
+  "web.colonel.customDomains.status.resolving": {
+    "text": "解析中"
+  },
+  "web.colonel.customDomains.status.ready": {
+    "text": "就绪"
+  },
+  "web.colonel.customDomains.status.publicHomepage": {
+    "text": "公开主页"
+  },
+  "web.colonel.customDomains.status.publicApi": {
+    "text": "公开 API"
+  },
+  "web.colonel.customDomains.status.pending": {
+    "text": "待处理"
+  },
+  "web.colonel.pagination.showing": {
+    "text": "显示第 {start}–{end} 项，共 {total} 项"
+  },
+  "web.colonel.pagination.itemsPerPage": {
+    "text": "每页项数"
+  },
+  "web.colonel.pagination.perPage": {
+    "text": "每页 {count} 项"
+  },
+  "web.colonel.pagination.pageOf": {
+    "text": "第 {current} 页，共 {total} 页"
+  },
+  "web.colonel.secrets.empty": {
+    "text": "未找到内容"
+  },
+  "web.colonel.secrets.never": {
+    "text": "从不"
+  },
+  "web.colonel.secrets.columns.shortId": {
+    "text": "短 ID"
+  },
+  "web.colonel.secrets.columns.state": {
+    "text": "状态"
+  },
+  "web.colonel.secrets.columns.created": {
+    "text": "创建时间"
+  },
+  "web.colonel.secrets.columns.expiration": {
+    "text": "过期时间"
+  },
+  "web.colonel.secrets.columns.age": {
+    "text": "存在天数"
+  },
+  "web.colonel.secrets.state.new": {
+    "text": "新建"
+  },
+  "web.colonel.secrets.state.received": {
+    "text": "已接收"
+  },
+  "web.colonel.secrets.state.viewed": {
+    "text": "已查看"
   }
 }

--- a/locales/content/zh/api-account-errors.json
+++ b/locales/content/zh/api-account-errors.json
@@ -1,0 +1,8 @@
+{
+  "api.account.errors.invalid_email": {
+    "text": "这是有效的邮箱地址吗？"
+  },
+  "api.account.errors.password_too_short": {
+    "text": "密码太短"
+  }
+}

--- a/locales/content/zh/api-domains-errors.json
+++ b/locales/content/zh/api-domains-errors.json
@@ -1,0 +1,29 @@
+{
+  "api.domains.errors.domain_id_required": {
+    "text": "需要域名 ID"
+  },
+  "api.domains.errors.domain_not_found": {
+    "text": "未找到域名：%{extid}"
+  },
+  "api.domains.errors.organization_not_found": {
+    "text": "未找到该域名对应的组织：%{domain}"
+  },
+  "api.domains.errors.incoming_secrets_disabled": {
+    "text": "此实例未启用接收内容功能"
+  },
+  "api.domains.errors.incoming_secrets_entitlement_required": {
+    "text": "接收内容管理需要 incoming_secrets 权益。请升级方案。"
+  },
+  "api.domains.errors.incoming_config_not_found": {
+    "text": "未找到该域名的接收配置：%{extid}"
+  },
+  "api.domains.errors.recipients_max_exceeded": {
+    "text": "最多允许 %{max} 个收件人"
+  },
+  "api.domains.errors.recipients_invalid_email": {
+    "text": "无效的邮箱地址：%{email}"
+  },
+  "api.domains.errors.recipients_duplicate": {
+    "text": "不允许重复的收件人邮箱地址"
+  }
+}

--- a/locales/content/zh/api-entitlements-errors.json
+++ b/locales/content/zh/api-entitlements-errors.json
@@ -1,0 +1,71 @@
+{
+  "api.entitlements.errors.context_unavailable": {
+    "text": "无法验证权益（组织上下文不可用）"
+  },
+  "api.entitlements.errors.api_access_required": {
+    "text": "API 访问需要升级方案"
+  },
+  "api.entitlements.errors.custom_privacy_defaults_required": {
+    "text": "自定义隐私默认设置需要升级方案"
+  },
+  "api.entitlements.errors.extended_default_expiration_required": {
+    "text": "延长默认过期时间需要升级方案"
+  },
+  "api.entitlements.errors.custom_domains_required": {
+    "text": "自定义域名需要升级方案"
+  },
+  "api.entitlements.errors.custom_branding_required": {
+    "text": "自定义品牌需要升级方案"
+  },
+  "api.entitlements.errors.homepage_secrets_required": {
+    "text": "主页内容需要升级方案"
+  },
+  "api.entitlements.errors.incoming_secrets_required": {
+    "text": "接收内容需要升级方案"
+  },
+  "api.entitlements.errors.custom_mail_sender_required": {
+    "text": "自定义邮件发件人需要升级方案"
+  },
+  "api.entitlements.errors.flexible_from_domain_required": {
+    "text": "灵活的发件域名需要升级方案"
+  },
+  "api.entitlements.errors.manage_org_required": {
+    "text": "组织管理需要升级方案"
+  },
+  "api.entitlements.errors.manage_teams_required": {
+    "text": "团队管理需要升级方案"
+  },
+  "api.entitlements.errors.manage_members_required": {
+    "text": "成员管理需要升级方案"
+  },
+  "api.entitlements.errors.manage_sso_required": {
+    "text": "SSO 管理需要升级方案"
+  },
+  "api.entitlements.errors.audit_logs_required": {
+    "text": "审计日志需要升级方案"
+  },
+  "api.entitlements.errors.custom_signup_validation_required": {
+    "text": "自定义注册验证需要升级方案"
+  },
+  "api.entitlements.errors.create_secrets_required": {
+    "text": "创建内容需要升级方案"
+  },
+  "api.entitlements.errors.view_receipt_required": {
+    "text": "查看回执需要升级方案"
+  },
+  "api.entitlements.errors.notifications_required": {
+    "text": "通知需要升级方案"
+  },
+  "api.entitlements.errors.workspace_branding_required": {
+    "text": "工作区品牌需要升级方案"
+  },
+  "api.entitlements.errors.ip_access_rules_required": {
+    "text": "IP 访问规则需要升级方案"
+  },
+  "api.entitlements.errors.manage_billing_required": {
+    "text": "账单管理需要升级方案"
+  },
+  "api.entitlements.errors.custom_signin_config_required": {
+    "text": "自定义登录配置需要升级方案"
+  }
+}

--- a/locales/content/zh/api-feedback-errors.json
+++ b/locales/content/zh/api-feedback-errors.json
@@ -1,0 +1,5 @@
+{
+  "api.feedback.errors.rate_limit_exceeded": {
+    "text": "反馈提交次数过多。请稍后重试。"
+  }
+}

--- a/locales/content/zh/api-incoming-errors.json
+++ b/locales/content/zh/api-incoming-errors.json
@@ -1,0 +1,5 @@
+{
+  "api.incoming.errors.custom_domain_unresolved": {
+    "text": "无法解析自定义域名所属的组织"
+  }
+}

--- a/locales/content/zh/api-invite-errors.json
+++ b/locales/content/zh/api-invite-errors.json
@@ -1,0 +1,23 @@
+{
+  "api.invite.errors.invitation_not_found_or_expired": {
+    "text": "邀请未找到或已过期"
+  },
+  "api.invite.errors.token_required": {
+    "text": "需要令牌"
+  },
+  "api.invite.errors.organization_no_longer_exists": {
+    "text": "组织已不存在"
+  },
+  "api.invite.errors.invitation_already_processed": {
+    "text": "邀请已被%{status}"
+  },
+  "api.invite.errors.invitation_expired": {
+    "text": "邀请已过期"
+  },
+  "api.invite.errors.email_mismatch": {
+    "text": "您的邮箱地址与邀请不匹配"
+  },
+  "api.invite.errors.already_member": {
+    "text": "您已是该组织的成员"
+  }
+}

--- a/locales/content/zh/api-organizations-errors.json
+++ b/locales/content/zh/api-organizations-errors.json
@@ -1,0 +1,107 @@
+{
+  "api.organizations.errors.domain_scoped_forbidden": {
+    "text": "域名范围内的成员无法执行此操作"
+  },
+  "api.organizations.errors.organization_not_found": {
+    "text": "未找到组织：%{extid}"
+  },
+  "api.organizations.errors.organization_owner_required": {
+    "text": "只有组织所有者才能执行此操作"
+  },
+  "api.organizations.errors.organization_member_required": {
+    "text": "您必须是组织成员才能执行此操作"
+  },
+  "api.organizations.errors.organization_admin_required": {
+    "text": "只有组织所有者和管理员才能执行此操作"
+  },
+  "api.organizations.errors.extid_required": {
+    "text": "需要组织 ID"
+  },
+  "api.organizations.errors.display_name_required": {
+    "text": "组织名称为必填项"
+  },
+  "api.organizations.errors.display_name_too_long": {
+    "text": "组织名称必须少于 %{max} 个字符"
+  },
+  "api.organizations.errors.description_too_long": {
+    "text": "描述必须少于 %{max} 个字符"
+  },
+  "api.organizations.errors.contact_email_exists": {
+    "text": "已存在使用此联系邮箱的组织"
+  },
+  "api.organizations.errors.creation_in_progress": {
+    "text": "正在创建组织。请重试。"
+  },
+  "api.organizations.errors.organization_limit_reached": {
+    "text": "已达到组织数量上限。升级方案以创建更多组织。"
+  },
+  "api.organizations.invitations.errors.invitation_not_found": {
+    "text": "未找到邀请"
+  },
+  "api.organizations.invitations.errors.email_required": {
+    "text": "邮箱地址为必填项"
+  },
+  "api.organizations.invitations.errors.invalid_email_format": {
+    "text": "邮箱地址格式无效"
+  },
+  "api.organizations.invitations.errors.invalid_role": {
+    "text": "角色必须是成员或管理员"
+  },
+  "api.organizations.invitations.errors.cannot_invite_as_owner": {
+    "text": "无法以所有者身份邀请"
+  },
+  "api.organizations.invitations.errors.user_already_member": {
+    "text": "用户已是该组织的成员"
+  },
+  "api.organizations.invitations.errors.invitation_already_pending": {
+    "text": "已存在针对此邮箱的待处理邀请"
+  },
+  "api.organizations.invitations.errors.member_limit_reached": {
+    "text": "已达到成员数量上限。升级方案以邀请更多成员。"
+  },
+  "api.organizations.invitations.errors.resend_only_pending": {
+    "text": "只能重新发送待处理的邀请"
+  },
+  "api.organizations.invitations.errors.resend_limit_reached": {
+    "text": "已达到重新发送次数上限（%{max}）"
+  },
+  "api.organizations.invitations.errors.revoke_only_pending": {
+    "text": "只能撤销待处理的邀请"
+  },
+  "api.organizations.members.errors.member_not_found": {
+    "text": "未找到成员：%{extid}"
+  },
+  "api.organizations.members.errors.member_not_in_organization": {
+    "text": "在此组织中未找到该成员"
+  },
+  "api.organizations.members.errors.member_not_active": {
+    "text": "成员未处于活跃状态"
+  },
+  "api.organizations.members.errors.invalid_role_value": {
+    "text": "无效的角色。必须是以下之一：%{roles}"
+  },
+  "api.organizations.members.errors.cannot_change_owner_role": {
+    "text": "无法更改所有者角色。请改用所有权转移。"
+  },
+  "api.organizations.members.errors.member_already_has_role": {
+    "text": "成员已拥有角色：%{role}"
+  },
+  "api.organizations.members.errors.cannot_promote_to_owner": {
+    "text": "无法提升为所有者。请改用所有权转移。"
+  },
+  "api.organizations.members.errors.must_be_member": {
+    "text": "您必须是该组织的成员"
+  },
+  "api.organizations.members.errors.cannot_remove_owner": {
+    "text": "无法移除组织所有者。请先转移所有权。"
+  },
+  "api.organizations.members.errors.cannot_remove_self": {
+    "text": "无法移除您自己。请改用退出组织。"
+  },
+  "api.organizations.members.errors.admin_cannot_remove_admin": {
+    "text": "管理员无法移除其他管理员。只有所有者才能移除。"
+  },
+  "api.organizations.members.errors.no_permission_to_remove": {
+    "text": "您没有移除成员的权限"
+  }
+}

--- a/locales/content/zh/api-secrets-errors.json
+++ b/locales/content/zh/api-secrets-errors.json
@@ -1,0 +1,11 @@
+{
+  "api.secrets.errors.domain_permission_authenticated_non_owner": {
+    "text": "您没有使用该域名的权限：%{domain}"
+  },
+  "api.secrets.errors.domain_public_sharing_disabled": {
+    "text": "该域名已禁用公开分享：%{domain}"
+  },
+  "api.secrets.errors.domain_permission_anonymous_cross_domain": {
+    "text": "您没有使用该域名的权限：%{domain}"
+  }
+}

--- a/locales/content/zh/email.json
+++ b/locales/content/zh/email.json
@@ -60,7 +60,7 @@
     "source_hash": "88c72144"
   },
   "email.welcome.signature": {
-    "text": "Delano",
+    "text": "支持团队",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -100,7 +100,7 @@
     "source_hash": "fbb7eb2d"
   },
   "email.password_request.signature": {
-    "text": "Delano",
+    "text": "支持团队",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -145,7 +145,7 @@
     "source_hash": "1863f5be"
   },
   "email.magic_link.signature": {
-    "text": "Delano",
+    "text": "支持团队",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -230,7 +230,7 @@
     "source_hash": "3f6b45dd"
   },
   "email.secret_revealed.signature": {
-    "text": "Delano",
+    "text": "支持团队",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -355,7 +355,7 @@
     "source_hash": "734882d2"
   },
   "email.organization_invitation.signature": {
-    "text": "Delano",
+    "text": "支持团队",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -395,7 +395,7 @@
     "source_hash": "be92cff3"
   },
   "email.password_changed.signature": {
-    "text": "Delano",
+    "text": "支持团队",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -445,7 +445,7 @@
     "source_hash": "f8d47b82"
   },
   "email.email_changed.signature": {
-    "text": "Delano",
+    "text": "支持团队",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -495,7 +495,7 @@
     "source_hash": "f8d47b82"
   },
   "email.email_change_requested.signature": {
-    "text": "Delano",
+    "text": "支持团队",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -550,7 +550,7 @@
     "source_hash": "d4d835fc"
   },
   "email.email_change_confirmation.signature": {
-    "text": "Delano",
+    "text": "支持团队",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -580,7 +580,7 @@
     "source_hash": "e7c11bb0"
   },
   "email.mfa_enabled.signature": {
-    "text": "Delano",
+    "text": "支持团队",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -605,7 +605,7 @@
     "source_hash": "97ef0a3e"
   },
   "email.mfa_disabled.signature": {
-    "text": "Delano",
+    "text": "支持团队",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -650,7 +650,7 @@
     "source_hash": "450c54c5"
   },
   "email.new_login_alert.signature": {
-    "text": "Delano",
+    "text": "支持团队",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -670,7 +670,7 @@
     "source_hash": "d442beed"
   },
   "email.member_removed.signature": {
-    "text": "Delano",
+    "text": "支持团队",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -690,7 +690,7 @@
     "source_hash": "c2280c0c"
   },
   "email.role_changed.signature": {
-    "text": "Delano",
+    "text": "支持团队",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -710,7 +710,7 @@
     "source_hash": "7095fc69"
   },
   "email.organization_deleted.signature": {
-    "text": "Delano",
+    "text": "支持团队",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -750,7 +750,7 @@
     "source_hash": "36008943"
   },
   "email.payment_receipt.signature": {
-    "text": "Delano",
+    "text": "支持团队",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -775,7 +775,7 @@
     "source_hash": "926406b1"
   },
   "email.payment_failed.signature": {
-    "text": "Delano",
+    "text": "支持团队",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -800,7 +800,7 @@
     "source_hash": "66a1419e"
   },
   "email.trial_expiring.signature": {
-    "text": "Delano",
+    "text": "支持团队",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -825,7 +825,7 @@
     "source_hash": "5a96ae38"
   },
   "email.subscription_changed.signature": {
-    "text": "Delano",
+    "text": "支持团队",
     "renderer": "erb",
     "source_hash": "f58154f7"
   },
@@ -853,5 +853,41 @@
     "text": "Onetime Secret",
     "renderer": "erb",
     "source_hash": "1cd0194a"
+  },
+  "email.common.secret_link_label": {
+    "text": "一次性链接"
+  },
+  "email.common.automated_notice": {
+    "text": "这是来自 %{product_name} 的自动消息。"
+  },
+  "email.common.support_label": {
+    "text": "支持"
+  },
+  "email.expiration_warning.signature": {
+    "text": "支持团队"
+  },
+  "email.expiration_warning.footer_note": {
+    "text": "您收到此消息是因为您在 %{product_name} 上创建的机密内容即将过期。"
+  },
+  "email.feedback_email.user_id_label": {
+    "text": "用户："
+  },
+  "email.feedback_email.timezone_label": {
+    "text": "时区："
+  },
+  "email.feedback_email.version_label": {
+    "text": "版本："
+  },
+  "email.incoming_secret.footer_note": {
+    "text": "您收到此消息是因为有人使用 %{product_name} 向您发送了机密内容。如果这不是您所预期的，您可以放心忽略此邮件。"
+  },
+  "email.secret_link.passphrase_label": {
+    "text": "需要口令："
+  },
+  "email.secret_link.passphrase_required": {
+    "text": "此机密内容受口令保护。发送者应另行向您提供口令。"
+  },
+  "email.secret_link.footer_note": {
+    "text": "您收到此消息是因为 %{sender_email} 使用 %{product_name} 向您分享了机密内容。如果这不是您所预期的，您可以放心忽略此邮件。"
   }
 }

--- a/locales/content/zh/feature-feedback.json
+++ b/locales/content/zh/feature-feedback.json
@@ -58,5 +58,14 @@
   "web.feedback.reason_email_change_unauthorized": {
     "text": "您似乎在报告账户邮箱被未授权更改的情况。请描述发生了什么，我们将立即调查。",
     "source_hash": "00e56551"
+  },
+  "web.feedback.anonymous_no_reply": {
+    "text": "注意：如果您希望得到回复，请在消息中署名或附上邮箱地址。"
+  },
+  "web.feedback.characters_remaining": {
+    "text": "还剩 {count} 个字符"
+  },
+  "web.feedback.character_limit_reached": {
+    "text": "已达到字符上限"
   }
 }

--- a/locales/content/zh/feature-homepage-secrets.json
+++ b/locales/content/zh/feature-homepage-secrets.json
@@ -1,0 +1,50 @@
+{
+  "homepage_secrets.disabled.members_only_eyebrow": {
+    "text": "仅限成员的实例"
+  },
+  "homepage_secrets.disabled.private_instance_eyebrow": {
+    "text": "私有实例"
+  },
+  "homepage_secrets.disabled.team_link_headline": {
+    "text": "此链接面向 {workspace} 团队。"
+  },
+  "homepage_secrets.disabled.signin_headline": {
+    "text": "登录以创建{action}。"
+  },
+  "homepage_secrets.disabled.signin_headline_action": {
+    "text": "一次性链接"
+  },
+  "homepage_secrets.disabled.team_subtitle": {
+    "text": "只有 {domain} 上经过授权的团队成员才能在此创建新的一次性链接。收件人仍可打开收到的任何链接。"
+  },
+  "homepage_secrets.disabled.public_subtitle": {
+    "text": "只有此实例上经过授权的成员才能创建新的一次性链接。收件人仍可打开收到的任何链接。"
+  },
+  "homepage_secrets.disabled.signin_cta": {
+    "text": "登录您的账户"
+  },
+  "homepage_secrets.disabled.what_is_this": {
+    "text": "这是什么？"
+  },
+  "homepage_secrets.disabled.trust_viewed_once": {
+    "text": "查看一次后即消失"
+  },
+  "homepage_secrets.disabled.trust_zero_retained": {
+    "text": "零保留"
+  },
+  "homepage_secrets.disabled.promo_title": {
+    "text": "新功能：免费方案现已包含自定义域名。"
+  },
+  "homepage_secrets.disabled.promo_subtitle": {
+    "text": "将您的域名指向 Onetime Secret，以您自己的品牌发送机密信息。"
+  },
+  "homepage_secrets.disabled.promo_learn_how": {
+    "text": "了解方法"
+  },
+  "homepage_secrets.disabled.logo_alt": {
+    "text": "{name} 徽标"
+  },
+  "homepage_secrets.disabled.opens_in_new_tab": {
+    "text": "（在新标签页中打开）"
+  }
+}

--- a/locales/content/zh/feature-incoming.json
+++ b/locales/content/zh/feature-incoming.json
@@ -130,5 +130,26 @@
   "incoming.receipt_link_text": {
     "text": "回执",
     "source_hash": "6f328609"
+  },
+  "incoming.upgrade_required_title": {
+    "text": "需要升级"
+  },
+  "incoming.upgrade_required_description": {
+    "text": "此功能需要升级方案。请联系账户所有者以启用接收内容功能。"
+  },
+  "incoming.validation_memo_too_long": {
+    "text": "备注必须不超过 {max} 个字符"
+  },
+  "incoming.validation_secret_required": {
+    "text": "内容为必填项"
+  },
+  "incoming.validation_recipient_required": {
+    "text": "请选择一位收件人"
+  },
+  "incoming.validation_feature_disabled": {
+    "text": "接收内容功能未启用"
+  },
+  "incoming.validation_form_errors": {
+    "text": "请检查表单中的错误"
   }
 }

--- a/locales/content/zh/feature-regions.json
+++ b/locales/content/zh/feature-regions.json
@@ -152,7 +152,7 @@
     "source_hash": "1d97f6bd"
   },
   "web.regions.changing_regions_billing_note": {
-    "text": "如果您的账单联系邮箱与 {product_name} 账户邮箱不同，请使用账单联系邮箱创建新区域账户，以保留您的订阅权益。",
+    "text": "如果您的账单联系邮箱与 {product_name} 账户邮箱不同，请使用账单联系邮箱在新地区创建账户，以保留您的订阅权益。",
     "source_hash": "dac1cc28"
   },
   "web.regions.changing_regions_subscription_note": {
@@ -186,5 +186,8 @@
   "web.regions.jurisdictions.apac.name": {
     "text": "Asia-Pacific",
     "source_hash": "7a757670"
+  },
+  "web.regions.no_region_configured": {
+    "text": "您的账户目前没有可用的地区信息。"
   }
 }

--- a/locales/content/zh/feature-translations.json
+++ b/locales/content/zh/feature-translations.json
@@ -64,7 +64,7 @@
     "source_hash": "13131e36"
   },
   "web.translations.the_following_people_have_donated_their_time_to_": {
-    "text": "以下人员捐献了他们的时间来帮助扩大 {product_name} 的覆盖范围：",
+    "text": "以下人员贡献了他们的时间，帮助扩大 {product_name} 的覆盖范围：",
     "source_hash": "85a766af"
   },
   "web.translations.translations": {
@@ -84,7 +84,7 @@
     "source_hash": "ba5c4395"
   },
   "web.translations.since_2012_onetime_secret_has_provided_a_secure_": {
-    "text": "自 2012 年以来，{product_name} 一直在全球提供安全的方式来分享敏感信息。由于用户遍布英语不是主要语言的地区，准确的翻译对于让每个人都能使用安全通信至关重要。",
+    "text": "自2012年以来，{product_name} 为全球用户提供了安全分享敏感信息的方式。在非英语为主要语言的地区拥有大量用户，准确的翻译对于让每个人都能使用安全通信至关重要。",
     "source_hash": "87a6e9af"
   },
   "web.translations.help_secure_communication_go_global": {

--- a/locales/content/zh/secret-homepage.json
+++ b/locales/content/zh/secret-homepage.json
@@ -144,7 +144,7 @@
     "source_hash": "1cd0194a"
   },
   "web.homepage.one_time_secret_literal": {
-    "text": "一次性内容",
+    "text": "{product_name}",
     "source_hash": "7872e050"
   },
   "web.homepage.onetime_secret_homepage": {
@@ -172,7 +172,7 @@
     "source_hash": "0990d163"
   },
   "web.homepage.onetime_secret_helps_us_share_sensitive_informat": {
-    "text": "{product_name} 帮助我们安全地分享敏感信息，同时保持我们的专业形象。",
+    "text": "{product_name} 帮助我们安全地分享敏感信息，同时保持专业形象。",
     "source_hash": "986a0856"
   },
   "web.homepage.information_shared_through_this_service_can_only": {

--- a/locales/content/zh/secret-manage.json
+++ b/locales/content/zh/secret-manage.json
@@ -128,7 +128,7 @@
     "source_hash": "07fe1b84"
   },
   "web.secrets.onetime_secret_is_a_secure_way_to_share_sensitiv": {
-    "text": "{product_name} 是一种安全的方式来分享查看一次后自毁的敏感信息。",
+    "text": "{product_name} 是一种安全分享敏感信息的方式，信息在被查看一次后会自动销毁。",
     "source_hash": "8a163297"
   },
   "web.secrets.what_is_this": {
@@ -470,5 +470,11 @@
   },
   "web.private.send_feedback": {
     "text": "发送反馈"
+  },
+  "web.receipt.open_link": {
+    "text": "打开链接"
+  },
+  "web.secrets.messageDeleted": {
+    "text": "消息已删除"
   }
 }

--- a/locales/content/zh/session-auth-extended.json
+++ b/locales/content/zh/session-auth-extended.json
@@ -716,5 +716,20 @@
   },
   "web.auth.sessions._guidance.context": {
     "text": "用户已登录设备/浏览器管理页面"
+  },
+  "web.auth.google": {
+    "text": "Google"
+  },
+  "web.auth.mfa.alternative_auth_options": {
+    "text": "其他身份验证方式"
+  },
+  "web.auth.remember.enabled": {
+    "text": "保持登录状态"
+  },
+  "web.auth.sessions.session_singular": {
+    "text": "会话"
+  },
+  "web.auth.sessions.session_plural": {
+    "text": "会话"
   }
 }

--- a/locales/content/zh/session-auth.json
+++ b/locales/content/zh/session-auth.json
@@ -398,5 +398,32 @@
   },
   "web.auth.verify._guidance.context": {
     "text": "注册后的邮箱验证流程"
+  },
+  "web.auth.account.sso_linked": {
+    "text": "SSO 账户"
+  },
+  "web.help.reset_password_link": {
+    "text": "重置密码"
+  },
+  "web.login.custom_domain_sso_title": {
+    "text": "此域名可使用单点登录"
+  },
+  "web.login.custom_domain_sso_description": {
+    "text": "组织管理员可启用 SSO，以允许团队成员在此登录。请联系管理员获取访问权限。"
+  },
+  "web.login.signin_disabled_heading": {
+    "text": "登录不可用"
+  },
+  "web.login.signin_disabled_message": {
+    "text": "此域名当前不可登录。"
+  },
+  "web.login.errors.sso_not_configured": {
+    "text": "此域名尚未配置单点登录。请联系您的管理员。"
+  },
+  "web.login.errors.invalid_email": {
+    "text": "来自您身份提供商的邮箱地址无效。请联系您的管理员。"
+  },
+  "web.login.errors.domain_not_allowed": {
+    "text": "您的邮箱域名未获授权使用 SSO 注册。请联系您的管理员。"
   }
 }

--- a/locales/content/zh/workspace-account.json
+++ b/locales/content/zh/workspace-account.json
@@ -682,5 +682,14 @@
   "web.settings.profile.didnt_receive_email": {
     "text": "没有收到邮件？",
     "source_hash": "fe3ac3ad"
+  },
+  "web.settings.api.api_disabled_notice": {
+    "text": "此实例已禁用 API。"
+  },
+  "web.settings.security.sso_managed_title": {
+    "text": "安全设置由 SSO 管理"
+  },
+  "web.settings.security.sso_managed_description": {
+    "text": "您的账户通过组织的单点登录提供商进行身份验证。密码、多重身份验证和恢复代码由您的身份提供商管理。"
   }
 }

--- a/locales/content/zh/workspace-billing.json
+++ b/locales/content/zh/workspace-billing.json
@@ -988,5 +988,47 @@
     "text": "仅在您的原始订阅区域可用",
     "context": "Hint shown on plan cards when currency does not match active subscription",
     "source_hash": "10de32e5"
+  },
+  "web.billing.already_subscribed": {
+    "text": "您已订阅此方案。"
+  },
+  "web.billing.cancel.reactivate_button": {
+    "text": "重新激活订阅"
+  },
+  "web.billing.cancel.reactivate_success": {
+    "text": "您的订阅已重新激活。我们将继续按正常方式向您收费。"
+  },
+  "web.billing.cancel.reactivate_error": {
+    "text": "重新激活订阅失败。请重试或联系支持团队。"
+  },
+  "web.billing.features.manage_orgs": {
+    "text": "组织管理"
+  },
+  "web.billing.features.flexible_from_domain": {
+    "text": "灵活的邮件发件域名"
+  },
+  "web.billing.features.unlimited_admins": {
+    "text": "无限管理员"
+  },
+  "web.billing.features.manage_sso": {
+    "text": "SSO"
+  },
+  "web.billing.overview.entitlements.flexible_from_domain": {
+    "text": "灵活的邮件发件域名"
+  },
+  "web.billing.overview.entitlements.manage_orgs": {
+    "text": "管理组织"
+  },
+  "web.billing.overview.entitlements.manage_sso": {
+    "text": "单点登录 (SSO)"
+  },
+  "web.billing.overview.entitlements.manage_billing": {
+    "text": "管理账单"
+  },
+  "web.billing.overview.entitlements.custom_signup_validation": {
+    "text": "自定义注册验证"
+  },
+  "web.billing.plans.reactivate": {
+    "text": "重新激活"
   }
 }

--- a/locales/content/zh/workspace-branding.json
+++ b/locales/content/zh/workspace-branding.json
@@ -178,5 +178,11 @@
   "web.branding.upgrade_to_customize": {
     "text": "升级方案以自定义此域名的品牌。",
     "source_hash": "9077bf79"
+  },
+  "web.branding.saved_successfully": {
+    "text": "品牌设置已成功保存"
+  },
+  "web.branding.keyhole_logo_icon": {
+    "text": "代表安全私密分享的钥匙孔图标"
   }
 }

--- a/locales/content/zh/workspace-dashboard.json
+++ b/locales/content/zh/workspace-dashboard.json
@@ -22,5 +22,14 @@
   "web.dashboard.fetch_error_description": {
     "text": "加载数据时出现问题，请重试。",
     "source_hash": "ff0d904e"
+  },
+  "web.teams.create_first_team_title": {
+    "text": "创建您的第一个团队"
+  },
+  "web.teams.create_first_team_description": {
+    "text": "团队让您在共享工作区中与他人协作。"
+  },
+  "web.teams.create_team": {
+    "text": "创建团队"
   }
 }

--- a/locales/content/zh/workspace-domains.json
+++ b/locales/content/zh/workspace-domains.json
@@ -846,5 +846,389 @@
   "web.domains.sso.not_configured_notice": {
     "text": "此域名尚未配置 SSO。启用单点登录以允许团队成员使用您组织的身份提供商进行认证。",
     "source_hash": "c439214b"
+  },
+  "api.domains.errors.add_admin_required": {
+    "text": "只有组织所有者和管理员才能添加自定义域名"
+  },
+  "web.domains.public_homepage": {
+    "text": "公开主页"
+  },
+  "web.domains.status_tooltip_active": {
+    "text": "域名已验证并处于活跃状态"
+  },
+  "web.domains.status_tooltip_dns_incorrect": {
+    "text": "DNS 未配置 — 点击修复"
+  },
+  "web.domains.status_tooltip_not_verified": {
+    "text": "域名未验证 — 点击验证"
+  },
+  "web.domains.status_tooltip_unverified": {
+    "text": "域名状态未验证 — 点击刷新"
+  },
+  "web.domains.last_check_failed": {
+    "text": "上次验证检查失败"
+  },
+  "web.domains.last_check_failed_ago": {
+    "text": "上次检查失败于 {0}"
+  },
+  "web.domains.verify_now": {
+    "text": "立即验证"
+  },
+  "web.domains.click_to_verify": {
+    "text": "点击验证"
+  },
+  "web.domains.remove_domain_description": {
+    "text": "永久移除此域名及其全部配置。"
+  },
+  "web.domains.add_access_denied": {
+    "text": "访问被拒绝"
+  },
+  "web.domains.add_access_denied_description": {
+    "text": "您无权向此组织添加域名。请联系您的组织管理员。"
+  },
+  "web.domains.dns_widget_load_failed": {
+    "text": "加载 DNS 小组件失败"
+  },
+  "web.domains.dns_widget_not_available": {
+    "text": "DNS 小组件不可用"
+  },
+  "web.domains.dns_widget_init_failed": {
+    "text": "初始化 DNS 小组件失败"
+  },
+  "web.domains.verified": {
+    "text": "已验证"
+  },
+  "web.domains.pending_verification": {
+    "text": "等待验证"
+  },
+  "web.domains.unsaved_changes_confirmation": {
+    "text": "您有未保存的更改。确定要离开吗？"
+  },
+  "web.domains.entitlement_required_owner": {
+    "text": "此功能需要升级方案。"
+  },
+  "web.domains.entitlement_required_member": {
+    "text": "此功能在您当前的方案中不可用。请联系您的组织所有者。"
+  },
+  "web.domains.detail.manage": {
+    "text": "管理"
+  },
+  "web.domains.detail.features": {
+    "text": "功能"
+  },
+  "web.domains.detail.homepage_title": {
+    "text": "主页内容"
+  },
+  "web.domains.detail.homepage_description": {
+    "text": "允许公众访问以在您的域名主页上创建内容"
+  },
+  "web.domains.detail.brand_description": {
+    "text": "Logo、颜色和自定义品牌"
+  },
+  "web.domains.detail.sso_description": {
+    "text": "单点登录提供商设置"
+  },
+  "web.domains.detail.email_description": {
+    "text": "自定义邮件发件人配置"
+  },
+  "web.domains.detail.incoming_description": {
+    "text": "接收内容的收件人设置"
+  },
+  "web.domains.detail.signup_description": {
+    "text": "按域名设置的注册验证策略"
+  },
+  "web.domains.detail.signin_description": {
+    "text": "按域名设置的登录方式配置"
+  },
+  "web.domains.email.dns_check_label": {
+    "text": "DNS"
+  },
+  "web.domains.email.provider_check_label": {
+    "text": "提供商"
+  },
+  "web.domains.email.test_email_title": {
+    "text": "测试邮件投递"
+  },
+  "web.domains.email.test_email_hint": {
+    "text": "使用已保存的配置向自己发送一封测试邮件。即使该功能尚未启用也可使用。"
+  },
+  "web.domains.email.send_test": {
+    "text": "发送测试"
+  },
+  "web.domains.email.test_email_sent": {
+    "text": "测试邮件发送成功"
+  },
+  "web.domains.email.test_email_failed": {
+    "text": "测试邮件发送失败"
+  },
+  "web.domains.email.test_email_sent_to": {
+    "text": "已发送至 {email}"
+  },
+  "web.domains.email.delivered_via": {
+    "text": "通过 {provider} 投递"
+  },
+  "web.domains.incoming.feature_disabled": {
+    "text": "接收内容功能不可用"
+  },
+  "web.domains.incoming.feature_disabled_description": {
+    "text": "此实例未启用接收内容功能。请联系您的管理员。"
+  },
+  "web.domains.signin.title": {
+    "text": "登录配置"
+  },
+  "web.domains.signin.configure_signin": {
+    "text": "配置登录"
+  },
+  "web.domains.signin.config_description": {
+    "text": "为此域名配置登录身份验证方式"
+  },
+  "web.domains.signin.access_denied": {
+    "text": "访问被拒绝"
+  },
+  "web.domains.signin.upgrade_to_configure": {
+    "text": "升级方案以便为此域名配置登录方式。"
+  },
+  "web.domains.signin.not_configured_notice": {
+    "text": "尚未为此域名设置登录配置。配置覆盖项可控制此域名登录页面上提供哪些身份验证方式。"
+  },
+  "web.domains.signin.signin_enabled_label": {
+    "text": "已启用登录"
+  },
+  "web.domains.signin.header_toggle_label": {
+    "text": "登录"
+  },
+  "web.domains.signin.signin_enabled_hint": {
+    "text": "用户是否可以在此域名上登录"
+  },
+  "web.domains.signin.restrict_to_label": {
+    "text": "限制登录方式"
+  },
+  "web.domains.signin.restrict_to_hint": {
+    "text": "将此域名限制为单一身份验证方式。设置后，登录页面仅显示所选方式。"
+  },
+  "web.domains.signin.all_methods": {
+    "text": "全部方式"
+  },
+  "web.domains.signin.all_methods_description": {
+    "text": "在登录页面显示所有已启用的身份验证方式"
+  },
+  "web.domains.signin.method_password": {
+    "text": "密码"
+  },
+  "web.domains.signin.method_email_auth": {
+    "text": "邮件身份验证"
+  },
+  "web.domains.signin.method_webauthn": {
+    "text": "WebAuthn / 通行密钥"
+  },
+  "web.domains.signin.method_sso": {
+    "text": "单点登录"
+  },
+  "web.domains.signin.method_overrides_label": {
+    "text": "方式覆盖项"
+  },
+  "web.domains.signin.method_overrides_hint": {
+    "text": "为此域名启用或禁用各个身份验证方式"
+  },
+  "web.domains.signin.mode_question": {
+    "text": "用户如何登录？"
+  },
+  "web.domains.signin.mode_any": {
+    "text": "任何可用方式"
+  },
+  "web.domains.signin.mode_any_hint": {
+    "text": "显示此域名上的所有可用方式。可在下方收窄各个方式。"
+  },
+  "web.domains.signin.mode_one": {
+    "text": "一种指定方式"
+  },
+  "web.domains.signin.mode_one_hint": {
+    "text": "将登录页面限制为单一方式。仅列出此域名上的可用方式。"
+  },
+  "web.domains.signin.mode_disabled": {
+    "text": "已禁用登录"
+  },
+  "web.domains.signin.mode_disabled_hint": {
+    "text": "用户无法在此域名上登录。"
+  },
+  "web.domains.signin.mode_disabled_notice": {
+    "text": "访问此域名登录页面的访客会看到一条提示，说明登录不可用，并附有返回主页的链接。您之前的方式设置将被保留，并在您重新启用登录时恢复。"
+  },
+  "web.domains.signin.methods_list_label": {
+    "text": "登录页面显示的方式"
+  },
+  "web.domains.signin.restrict_picker_hint": {
+    "text": "仅列出此域名上的可用方式。"
+  },
+  "web.domains.signin.availability_always": {
+    "text": "始终可用"
+  },
+  "web.domains.signin.availability_global_on": {
+    "text": "遵循全局策略 · 开启"
+  },
+  "web.domains.signin.availability_global_off": {
+    "text": "不可用"
+  },
+  "web.domains.signin.availability_unavailable": {
+    "text": "全站不可用"
+  },
+  "web.domains.signin.allow_on_domain": {
+    "text": "在此域名上允许"
+  },
+  "web.domains.signin.method_password_blurb": {
+    "text": "仅密码"
+  },
+  "web.domains.signin.method_email_auth_blurb": {
+    "text": "无密码魔法链接登录"
+  },
+  "web.domains.signin.method_webauthn_blurb": {
+    "text": "生物识别和安全密钥"
+  },
+  "web.domains.signin.method_sso_blurb": {
+    "text": "外部身份提供商"
+  },
+  "web.domains.signin.email_auth_label": {
+    "text": "邮件身份验证"
+  },
+  "web.domains.signin.email_auth_hint": {
+    "text": "在此域名上允许无密码邮件身份验证"
+  },
+  "web.domains.signin.sso_enabled_label": {
+    "text": "单点登录"
+  },
+  "web.domains.signin.sso_enabled_hint": {
+    "text": "在此域名上允许 SSO 身份验证"
+  },
+  "web.domains.signin.enabled_label": {
+    "text": "启用登录配置"
+  },
+  "web.domains.signin.enabled_hint": {
+    "text": "启用后，此域名将使用上方配置的登录设置"
+  },
+  "web.domains.signin.save_config": {
+    "text": "保存配置"
+  },
+  "web.domains.signin.update_success": {
+    "text": "登录配置更新成功"
+  },
+  "web.domains.signin.reset_to_defaults": {
+    "text": "重置为默认值"
+  },
+  "web.domains.signin.reset_confirm": {
+    "text": "将登录重置为全局默认值？"
+  },
+  "web.domains.signin.reset_keeps_sso": {
+    "text": "您的 SSO 凭据将被保留。请在 SSO 配置界面单独移除它们。"
+  },
+  "web.domains.signin.reset_action": {
+    "text": "是，重置"
+  },
+  "web.domains.signin.reset_success": {
+    "text": "登录设置已重置为全局默认值"
+  },
+  "web.domains.signup.title": {
+    "text": "注册验证"
+  },
+  "web.domains.signup.config_description": {
+    "text": "为此域名配置注册验证"
+  },
+  "web.domains.signup.access_denied": {
+    "text": "访问被拒绝"
+  },
+  "web.domains.signup.upgrade_to_configure": {
+    "text": "升级方案以便配置按域名设置的注册验证。"
+  },
+  "web.domains.signup.configure_signup": {
+    "text": "配置注册"
+  },
+  "web.domains.signup.not_configured_notice": {
+    "text": "尚未为此域名配置注册验证。配置一项策略可控制谁能通过此域名注册。"
+  },
+  "web.domains.signup.site_signups_disabled_warning": {
+    "text": "目前已在站点级别禁用注册。此按域名设置的策略虽已配置，但在启用站点注册之前不会对任何流量生效。"
+  },
+  "web.domains.signup.strategy_label": {
+    "text": "验证策略"
+  },
+  "web.domains.signup.strategy_description": {
+    "text": "选择用户在此域名上注册时如何验证邮箱地址。"
+  },
+  "web.domains.signup.network_validation_warning": {
+    "text": "此策略在注册过程中会执行网络调用，可能增加延迟或被某些提供商屏蔽。"
+  },
+  "web.domains.signup.allowed_domains_label": {
+    "text": "允许注册的域名"
+  },
+  "web.domains.signup.allowed_domains_hint": {
+    "text": "仅允许这些邮箱域名注册。每行添加一个域名。"
+  },
+  "web.domains.signup.domain_placeholder": {
+    "text": "example.com"
+  },
+  "web.domains.signup.invalid_domain": {
+    "text": "请输入有效的域名（例如 example.com）"
+  },
+  "web.domains.signup.domain_exists": {
+    "text": "此域名已在列表中"
+  },
+  "web.domains.signup.remove_domain": {
+    "text": "移除 {domain}"
+  },
+  "web.domains.signup.enabled_label": {
+    "text": "启用按域名设置的验证"
+  },
+  "web.domains.signup.enabled_hint": {
+    "text": "启用后，此域名上的注册将使用上方的策略，而非全局策略。"
+  },
+  "web.domains.signup.delete_config": {
+    "text": "删除配置"
+  },
+  "web.domains.signup.delete_confirm": {
+    "text": "删除注册验证配置？注册将回退到全局策略。"
+  },
+  "web.domains.signup.save_config": {
+    "text": "保存配置"
+  },
+  "web.domains.signup.update_success": {
+    "text": "注册验证更新成功"
+  },
+  "web.domains.signup.delete_success": {
+    "text": "注册验证配置移除成功"
+  },
+  "web.domains.signup.domain_overrides_label": {
+    "text": "域名覆盖项"
+  },
+  "web.domains.signup.domain_overrides_hint": {
+    "text": "为此域名覆盖全局注册设置"
+  },
+  "web.domains.signup.signup_enabled_label": {
+    "text": "已启用注册"
+  },
+  "web.domains.signup.signup_enabled_hint": {
+    "text": "覆盖此域名是否启用注册"
+  },
+  "web.domains.signup.autoverify_label": {
+    "text": "自动验证账户"
+  },
+  "web.domains.signup.autoverify_hint": {
+    "text": "覆盖此域名上的新账户是否自动验证"
+  },
+  "web.domains.sso.test_success": {
+    "text": "连接测试成功 — 提供商响应正常"
+  },
+  "web.domains.sso.test_failed": {
+    "text": "连接测试失败"
+  },
+  "web.domains.sso.enforce_moved_notice": {
+    "text": "要在此域名的所有登录中强制使用 SSO，请在域名的登录设置中进行配置。仅 SSO 模式会将登录页面限制为此处配置的 SSO 提供商。"
+  },
+  "web.domains.sso.edit_credentials": {
+    "text": "编辑凭据"
+  },
+  "web.domains.sso.configure_button": {
+    "text": "配置"
+  },
+  "web.domains.sso.upgrade_required": {
+    "text": "升级以配置"
   }
 }

--- a/locales/content/zh/workspace-organizations.json
+++ b/locales/content/zh/workspace-organizations.json
@@ -770,5 +770,200 @@
   "web.organizations.sso.status_not_configured": {
     "text": "未配置",
     "source_hash": "bbea960e"
+  },
+  "api.organizations.errors.not_found": {
+    "text": "未找到组织：%{extid}"
+  },
+  "api.organizations.errors.owner_required": {
+    "text": "只有组织所有者才能执行此操作"
+  },
+  "api.organizations.errors.admin_required": {
+    "text": "只有组织所有者和管理员才能执行此操作"
+  },
+  "api.organizations.errors.member_required": {
+    "text": "您必须是组织成员才能执行此操作"
+  },
+  "api.organizations.invitations.errors.create_admin_required": {
+    "text": "只有组织所有者和管理员才能创建邀请"
+  },
+  "api.organizations.invitations.errors.resend_admin_required": {
+    "text": "只有组织所有者和管理员才能重新发送邀请"
+  },
+  "api.organizations.invitations.errors.view_admin_required": {
+    "text": "只有组织所有者和管理员才能查看邀请"
+  },
+  "api.organizations.invitations.errors.revoke_admin_required": {
+    "text": "只有组织所有者和管理员才能撤销邀请"
+  },
+  "api.organizations.invitations.errors.email_required": {
+    "text": "邮箱为必填项"
+  },
+  "api.organizations.invitations.errors.email_invalid": {
+    "text": "邮箱格式无效"
+  },
+  "api.organizations.invitations.errors.role_invalid": {
+    "text": "角色必须是成员或管理员"
+  },
+  "api.organizations.invitations.errors.cannot_invite_owner": {
+    "text": "无法以所有者身份邀请"
+  },
+  "api.organizations.invitations.errors.already_member": {
+    "text": "用户已是此组织的成员"
+  },
+  "api.organizations.invitations.errors.already_pending": {
+    "text": "此邮箱已有待处理的邀请"
+  },
+  "api.organizations.invitations.errors.member_limit_reached": {
+    "text": "已达到成员上限。升级方案以邀请更多成员。"
+  },
+  "api.organizations.invitations.errors.not_found": {
+    "text": "未找到邀请"
+  },
+  "api.organizations.invitations.errors.cannot_resend_non_pending": {
+    "text": "只能重新发送待处理的邀请"
+  },
+  "api.organizations.invitations.errors.cannot_revoke_non_pending": {
+    "text": "只能撤销待处理的邀请"
+  },
+  "api.organizations.invitations.errors.resend_limit_reached": {
+    "text": "已达到重新发送的上限（%{max}）"
+  },
+  "api.organizations.invitations.errors.accept_token_required": {
+    "text": "令牌为必填项"
+  },
+  "api.organizations.invitations.errors.accept_organization_gone": {
+    "text": "组织不再存在"
+  },
+  "api.organizations.invitations.errors.accept_already_acted": {
+    "text": "邀请已被%{status}"
+  },
+  "api.organizations.invitations.errors.accept_expired": {
+    "text": "邀请已过期"
+  },
+  "api.organizations.invitations.errors.accept_email_mismatch": {
+    "text": "您的邮箱地址与邀请不匹配"
+  },
+  "api.organizations.invitations.errors.accept_already_member": {
+    "text": "您已是此组织的成员"
+  },
+  "web.organizations.entitlements_title": {
+    "text": "组织权益"
+  },
+  "web.organizations.page_description_short": {
+    "text": "查看和配置您的工作区"
+  },
+  "web.organizations.delete_organization_remove_domains_first": {
+    "text": "删除此组织前，请先移除所有自定义域名。"
+  },
+  "web.organizations.default_org_delete_notice_title": {
+    "text": "删除此组织"
+  },
+  "web.organizations.default_org_delete_notice_before": {
+    "text": "这是您的默认组织，无法从仪表板移除。要删除它，请通过"
+  },
+  "web.organizations.default_org_delete_notice_link": {
+    "text": "反馈表单"
+  },
+  "web.organizations.default_org_delete_notice_after": {
+    "text": "联系我们。"
+  },
+  "web.organizations.leave_organization": {
+    "text": "退出此组织"
+  },
+  "web.organizations.leave_organization_warning": {
+    "text": "您将失去对此组织及其资源的访问权限。"
+  },
+  "web.organizations.leave_organization_confirm_title": {
+    "text": "退出组织"
+  },
+  "web.organizations.leave_organization_confirm_message": {
+    "text": "确定要退出 {name} 吗？您需要新的邀请才能重新加入。"
+  },
+  "web.organizations.leave_organization_success": {
+    "text": "您已退出该组织。"
+  },
+  "web.organizations.leave_error": {
+    "text": "退出组织失败"
+  },
+  "web.organizations.organizations": {
+    "text": "组织"
+  },
+  "web.organizations.invitations.invited_by_inline": {
+    "text": "由 {email} 邀请"
+  },
+  "web.organizations.invitations.invited_as_inline": {
+    "text": "作为{role}"
+  },
+  "web.organizations.invitations.back_to_home": {
+    "text": "返回主页"
+  },
+  "web.organizations.invitations.email_locked_hint": {
+    "text": "此邀请已发送至此邮箱地址"
+  },
+  "web.organizations.invitations.signup_continue": {
+    "text": "继续"
+  },
+  "web.organizations.invitations.signin_continue": {
+    "text": "登录"
+  },
+  "web.organizations.invitations.confirm_join_below": {
+    "text": "即将完成 — 在下方确认以加入组织。"
+  },
+  "web.organizations.invitations.go_to_organizations": {
+    "text": "前往组织"
+  },
+  "web.organizations.invitations.already_member": {
+    "text": "您已是此组织的成员"
+  },
+  "web.organizations.invitations.join_organization": {
+    "text": "加入 {orgName}"
+  },
+  "web.organizations.invitations.sign_in_to_join": {
+    "text": "登录以加入 {orgName}"
+  },
+  "web.organizations.invitations.decline": {
+    "text": "拒绝"
+  },
+  "web.organizations.members.member_quota": {
+    "text": "{limit} 名成员中的 {used} 名"
+  },
+  "web.organizations.members.pending_suffix": {
+    "text": "（{count} 个待处理）"
+  },
+  "web.organizations.members.limit_reached_hint": {
+    "text": "已达到成员上限。"
+  },
+  "web.organizations.sso.view_discovery_document": {
+    "text": "查看发现文档"
+  },
+  "web.organizations.sso.callback_url": {
+    "text": "回调 URL"
+  },
+  "web.organizations.sso.callback_url_hint": {
+    "text": "将此 URL 添加到您身份提供商的允许重定向 URI 中"
+  },
+  "web.organizations.sso.enforce_sso_only": {
+    "text": "强制仅 SSO"
+  },
+  "web.organizations.sso.enforce_sso_only_hint": {
+    "text": "在此域名的所有登录中要求使用 SSO。启用后，将禁用基于密码的身份验证。"
+  },
+  "web.organizations.sso.grant_org_scope": {
+    "text": "授予组织范围的访问权限"
+  },
+  "web.organizations.sso.grant_org_scope_hint": {
+    "text": "通过此域名 SSO 加入的新成员将获得对所有组织域名的访问权限。现有成员不受影响。禁用时（默认），新成员只能访问此域名。"
+  },
+  "web.organizations.sso.no_domains": {
+    "text": "没有已验证的域名"
+  },
+  "web.organizations.sso.no_domains_description": {
+    "text": "在为某个域名配置 SSO 之前，请先添加并验证该域名。"
+  },
+  "web.organizations.tabs.team": {
+    "text": "团队"
+  },
+  "web.organizations.tabs.sso": {
+    "text": "SSO"
   }
 }


### PR DESCRIPTION
## `zh` translation update

Automated export of completed **zh** translations from the translation task DB.
Scope: `locales/content/zh/` only — 27 file(s), +1356/-27.

⚠️ `i18n validate variables` reports **1** variable mismatch(es) for `zh` (empty values that drop source variables, renamed/extra vars, etc.) — see the review below.

---

### Local quality review

> Produced by a fresh, isolated `claude` review agent (model `claude-sonnet-5`, agent `saas-translator`) that read
> `locales/AGENT_TRANSLATION_PROTOCOL.md` and inspected this branch's diff before the PR was opened.

**Verdict:** ⚠️ Needs review — spurious %{date} variable in email.email_changed

**Summary:** Large, mostly well-formed batch (SSO/domains/orgs/billing/colonel/errors) with correct brand preservation and consistent "Delano → 支持团队" signature swap across all email templates. One variable-consistency defect flagged by the automated check, matching a recurring shared bug seen across many other locales in this same translation batch.

**Critical (must fix):**
- `email.email_changed.body.text`: locale text inserts `%{date}` (`...已于 %{date} 更改为...`) which does not exist in the English source (`"The email address for your %{product_name} account has been changed to %{new_email_masked}."`). This will fail interpolation/render. Same defect already flagged in de, es, fr_CA, fr_FR, ja, ko, pt_BR, ru in this batch — likely a shared upstream template issue, but still blocks this locale too.

**Warnings:**
- `api.invite.errors.invitation_already_processed` and `api.organizations.invitations.errors.accept_already_acted`: `"邀请已被%{status}"` — `%{status}` is presumably an English enum value (e.g. "accepted"/"declined") inserted directly with no translation/spacing; verify this reads sensibly at runtime.
- Minor spacing inconsistency around embedded variables (e.g. `"您 %{product_name} 账户"` has space before but not after the token) — cosmetic, not blocking per prior zh convention.

**Notes:**
- `web.homepage.one_time_secret_literal` correctly changed from a mistranslated literal ("一次性内容") back to `{product_name}`, consistent with the same fix applied in other locales this round.
- Brand terms (Onetime Secret, SSO, HTTP, Favicon, IP) correctly left untranslated throughout.
- No mojibake, no leftover English prose, no HTML/tag issues observed.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
