### PR TITLE
i18n: remove orphaned email.email_changed.body key (fixes stray %{date})

### DIFF
--- a/locales/content/ar/email.json
+++ b/locales/content/ar/email.json
@@ -409,11 +409,6 @@
     "renderer": "erb",
     "source_hash": "62b07299"
   },
-  "email.email_changed.body": {
-    "text": "تم تغيير البريد الإلكتروني لحسابك في %{product_name} إلى %{new_email_masked}.",
-    "renderer": "erb",
-    "source_hash": "6f3419d1"
-  },
   "email.email_changed.security_notice": {
     "text": "إذا لم تقم بهذا التغيير، يرجى الاتصال بالدعم فوراً لأن حسابك قد يكون مخترقاً.",
     "renderer": "erb",

--- a/locales/content/bg/email.json
+++ b/locales/content/bg/email.json
@@ -409,11 +409,6 @@
     "renderer": "erb",
     "source_hash": "62b07299"
   },
-  "email.email_changed.body": {
-    "text": "Имейл адресът за вашия %{product_name} акаунт беше променен на %{new_email_masked}.",
-    "renderer": "erb",
-    "source_hash": "6f3419d1"
-  },
   "email.email_changed.security_notice": {
     "text": "Ако не сте направили тази промяна, моля, свържете се с поддръжката незабавно, тъй като акаунтът ви може да е компрометиран.",
     "renderer": "erb",

--- a/locales/content/ca_ES/email.json
+++ b/locales/content/ca_ES/email.json
@@ -409,11 +409,6 @@
     "renderer": "erb",
     "source_hash": "62b07299"
   },
-  "email.email_changed.body": {
-    "text": "L'adreça de correu electrònic del teu compte de %{product_name} s'ha canviat a %{new_email_masked}.",
-    "renderer": "erb",
-    "source_hash": "6f3419d1"
-  },
   "email.email_changed.security_notice": {
     "text": "Si no has fet aquest canvi, si us plau contacta amb el suport immediatament ja que el teu compte pot estar compromès.",
     "renderer": "erb",

--- a/locales/content/cs/email.json
+++ b/locales/content/cs/email.json
@@ -409,11 +409,6 @@
     "renderer": "erb",
     "source_hash": "62b07299"
   },
-  "email.email_changed.body": {
-    "text": "E-mailová adresa tvého účtu %{product_name} byla změněna na %{new_email_masked}.",
-    "renderer": "erb",
-    "source_hash": "6f3419d1"
-  },
   "email.email_changed.security_notice": {
     "text": "Pokud jsi tuto změnu neprovedli, kontaktuj okamžitě podporu, protože tvůj účet může být kompromitován.",
     "renderer": "erb",

--- a/locales/content/da_DK/email.json
+++ b/locales/content/da_DK/email.json
@@ -409,11 +409,6 @@
     "renderer": "erb",
     "source_hash": "62b07299"
   },
-  "email.email_changed.body": {
-    "text": "E-mailadressen for din %{product_name}-konto blev ændret til %{new_email_masked}.",
-    "renderer": "erb",
-    "source_hash": "6f3419d1"
-  },
   "email.email_changed.security_notice": {
     "text": "Hvis du ikke har foretaget denne ændring, kontakt venligst support med det samme, da din konto kan være kompromitteret.",
     "renderer": "erb",

--- a/locales/content/de/email.json
+++ b/locales/content/de/email.json
@@ -409,11 +409,6 @@
     "renderer": "erb",
     "source_hash": "62b07299"
   },
-  "email.email_changed.body": {
-    "text": "Die E-Mail-Adresse für dein %{product_name}-Konto wurde am %{date} auf %{new_email_masked} geändert.",
-    "renderer": "erb",
-    "source_hash": "6f3419d1"
-  },
   "email.email_changed.security_notice": {
     "text": "Wenn du diese Änderung nicht vorgenommen hast, kontaktiere bitte sofort den Support, da dein Konto möglicherweise kompromittiert wurde.",
     "renderer": "erb",

--- a/locales/content/de_AT/email.json
+++ b/locales/content/de_AT/email.json
@@ -409,11 +409,6 @@
     "renderer": "erb",
     "source_hash": "62b07299"
   },
-  "email.email_changed.body": {
-    "text": "Die E-Mail-Adresse für Ihr %{product_name}-Konto wurde auf %{new_email_masked} geändert.",
-    "renderer": "erb",
-    "source_hash": "6f3419d1"
-  },
   "email.email_changed.security_notice": {
     "text": "Wenn Sie diese Änderung nicht vorgenommen haben, kontaktieren Sie bitte umgehend den Support, da Ihr Konto möglicherweise kompromittiert wurde.",
     "renderer": "erb",

--- a/locales/content/el_GR/email.json
+++ b/locales/content/el_GR/email.json
@@ -409,11 +409,6 @@
     "renderer": "erb",
     "source_hash": "62b07299"
   },
-  "email.email_changed.body": {
-    "text": "Η διεύθυνση email του λογαριασμού σας στο %{product_name} άλλαξε σε %{new_email_masked}.",
-    "renderer": "erb",
-    "source_hash": "6f3419d1"
-  },
   "email.email_changed.security_notice": {
     "text": "Εάν δεν κάνατε εσείς αυτήν την αλλαγή, επικοινωνήστε αμέσως με την υποστήριξη καθώς ο λογαριασμός σας μπορεί να έχει παραβιαστεί.",
     "renderer": "erb",

--- a/locales/content/en/email.json
+++ b/locales/content/en/email.json
@@ -453,11 +453,6 @@
     "renderer": "erb",
     "content_hash": "db70f965"
   },
-  "email.email_changed.body": {
-    "text": "The email address for your %{product_name} account has been changed to %{new_email_masked}.",
-    "renderer": "erb",
-    "content_hash": "aadf015b"
-  },
   "email.email_changed.security_notice": {
     "text": "If you did not make this change, please contact support immediately as your account may be compromised.",
     "renderer": "erb",

--- a/locales/content/eo/email.json
+++ b/locales/content/eo/email.json
@@ -409,11 +409,6 @@
     "renderer": "erb",
     "source_hash": "62b07299"
   },
-  "email.email_changed.body": {
-    "text": "La retpoŝta adreso por via konto %{product_name} estis ŝanĝita al %{new_email_masked} je %{date}.",
-    "renderer": "erb",
-    "source_hash": "6f3419d1"
-  },
   "email.email_changed.security_notice": {
     "text": "Se vi ne faris ĉi tiun ŝanĝon, bonvolu tuj kontakti subtenon ĉar via konto eble estas kompromitita.",
     "renderer": "erb",

--- a/locales/content/es/email.json
+++ b/locales/content/es/email.json
@@ -409,11 +409,6 @@
     "renderer": "erb",
     "source_hash": "62b07299"
   },
-  "email.email_changed.body": {
-    "text": "La dirección de correo de tu cuenta de %{product_name} fue cambiada a %{new_email_masked} el %{date}.",
-    "renderer": "erb",
-    "source_hash": "6f3419d1"
-  },
   "email.email_changed.security_notice": {
     "text": "Si no realizaste este cambio, contacta con soporte inmediatamente ya que tu cuenta puede estar comprometida.",
     "renderer": "erb",

--- a/locales/content/fr_CA/email.json
+++ b/locales/content/fr_CA/email.json
@@ -409,11 +409,6 @@
     "renderer": "erb",
     "source_hash": "62b07299"
   },
-  "email.email_changed.body": {
-    "text": "L'adresse courriel de votre compte %{product_name} a été changée pour %{new_email_masked} le %{date}.",
-    "renderer": "erb",
-    "source_hash": "6f3419d1"
-  },
   "email.email_changed.security_notice": {
     "text": "Si vous n'avez pas effectué cette modification, veuillez contacter le soutien immédiatement, car votre compte pourrait être compromis.",
     "renderer": "erb",

--- a/locales/content/fr_FR/email.json
+++ b/locales/content/fr_FR/email.json
@@ -409,11 +409,6 @@
     "renderer": "erb",
     "source_hash": "62b07299"
   },
-  "email.email_changed.body": {
-    "text": "L'adresse e-mail de votre compte %{product_name} a été modifiée en %{new_email_masked} le %{date}.",
-    "renderer": "erb",
-    "source_hash": "6f3419d1"
-  },
   "email.email_changed.security_notice": {
     "text": "Si vous n'avez pas effectué cette modification, veuillez contacter immédiatement le support car votre compte pourrait être compromis.",
     "renderer": "erb",

--- a/locales/content/he/email.json
+++ b/locales/content/he/email.json
@@ -409,11 +409,6 @@
     "renderer": "erb",
     "source_hash": "62b07299"
   },
-  "email.email_changed.body": {
-    "text": "כתובת הדוא״ל עבור חשבון %{product_name} שלך שונתה ל-%{new_email_masked}.",
-    "renderer": "erb",
-    "source_hash": "6f3419d1"
-  },
   "email.email_changed.security_notice": {
     "text": "אם לא ביצעת שינוי זה, אנא צור קשר עם התמיכה מיד מכיוון שהחשבון שלך עשוי להיות פרוץ.",
     "renderer": "erb",

--- a/locales/content/hu/email.json
+++ b/locales/content/hu/email.json
@@ -409,11 +409,6 @@
     "renderer": "erb",
     "source_hash": "62b07299"
   },
-  "email.email_changed.body": {
-    "text": "A %{product_name} fiókjához tartozó e-mail cím megváltozott erre: %{new_email_masked}.",
-    "renderer": "erb",
-    "source_hash": "6f3419d1"
-  },
   "email.email_changed.security_notice": {
     "text": "Ha nem Ön kezdeményezte ezt a módosítást, kérjük, azonnal lépjen kapcsolatba az ügyfélszolgálattal, mert fiókja veszélybe kerülhetett.",
     "renderer": "erb",

--- a/locales/content/it_IT/email.json
+++ b/locales/content/it_IT/email.json
@@ -409,11 +409,6 @@
     "renderer": "erb",
     "source_hash": "62b07299"
   },
-  "email.email_changed.body": {
-    "text": "L'indirizzo email del tuo account %{product_name} è stato modificato in %{new_email_masked}.",
-    "renderer": "erb",
-    "source_hash": "6f3419d1"
-  },
   "email.email_changed.security_notice": {
     "text": "Se non hai effettuato questa modifica, contatta immediatamente il supporto poiché il tuo account potrebbe essere stato compromesso.",
     "renderer": "erb",

--- a/locales/content/ja/email.json
+++ b/locales/content/ja/email.json
@@ -409,11 +409,6 @@
     "renderer": "erb",
     "source_hash": "62b07299"
   },
-  "email.email_changed.body": {
-    "text": "%{product_name}アカウントのメールアドレスは、%{date}に%{new_email_masked}に変更されました。",
-    "renderer": "erb",
-    "source_hash": "6f3419d1"
-  },
   "email.email_changed.security_notice": {
     "text": "この変更を行っていない場合は、アカウントが侵害されている可能性がありますので、すぐにサポートにご連絡ください。",
     "renderer": "erb",

--- a/locales/content/ko/email.json
+++ b/locales/content/ko/email.json
@@ -409,11 +409,6 @@
     "renderer": "erb",
     "source_hash": "62b07299"
   },
-  "email.email_changed.body": {
-    "text": "%{product_name} 계정의 이메일 주소가 %{date}에 %{new_email_masked}(으)로 변경되었습니다.",
-    "renderer": "erb",
-    "source_hash": "6f3419d1"
-  },
   "email.email_changed.security_notice": {
     "text": "본인이 변경하지 않았다면 계정이 손상되었을 수 있으니 즉시 고객 지원에 문의해 주세요.",
     "renderer": "erb",

--- a/locales/content/mi_NZ/email.json
+++ b/locales/content/mi_NZ/email.json
@@ -409,11 +409,6 @@
     "renderer": "erb",
     "source_hash": "62b07299"
   },
-  "email.email_changed.body": {
-    "text": "Kua hurihia te wāhitau īmēra mō tō pūkete %{product_name} ki %{new_email_masked}.",
-    "renderer": "erb",
-    "source_hash": "6f3419d1"
-  },
   "email.email_changed.security_notice": {
     "text": "Mēnā ehara i a koe i huri i tēnei, tēnā whakapā tere ki te tautoko nā te mea tērā pea kua whakaekea tō pūkete.",
     "renderer": "erb",

--- a/locales/content/nl/email.json
+++ b/locales/content/nl/email.json
@@ -409,11 +409,6 @@
     "renderer": "erb",
     "source_hash": "62b07299"
   },
-  "email.email_changed.body": {
-    "text": "Het e-mailadres voor je %{product_name}-account is gewijzigd naar %{new_email_masked} op %{date}.",
-    "renderer": "erb",
-    "source_hash": "6f3419d1"
-  },
   "email.email_changed.security_notice": {
     "text": "Als je deze wijziging niet hebt aangebracht, neem dan onmiddellijk contact op met de ondersteuning, omdat je account mogelijk is gehackt.",
     "renderer": "erb",

--- a/locales/content/pl/email.json
+++ b/locales/content/pl/email.json
@@ -409,11 +409,6 @@
     "renderer": "erb",
     "source_hash": "62b07299"
   },
-  "email.email_changed.body": {
-    "text": "Adres e-mail Twojego konta %{product_name} został zmieniony na %{new_email_masked}.",
-    "renderer": "erb",
-    "source_hash": "6f3419d1"
-  },
   "email.email_changed.security_notice": {
     "text": "Jeśli nie dokonałeś tej zmiany, skontaktuj się natychmiast z pomocą techniczną, ponieważ Twoje konto może być zagrożone.",
     "renderer": "erb",

--- a/locales/content/pt_BR/email.json
+++ b/locales/content/pt_BR/email.json
@@ -409,11 +409,6 @@
     "renderer": "erb",
     "source_hash": "62b07299"
   },
-  "email.email_changed.body": {
-    "text": "O endereço de e-mail da sua conta %{product_name} foi alterado para %{new_email_masked} em %{date}.",
-    "renderer": "erb",
-    "source_hash": "6f3419d1"
-  },
   "email.email_changed.security_notice": {
     "text": "Se você não fez esta alteração, entre em contato com o suporte imediatamente, pois sua conta pode estar comprometida.",
     "renderer": "erb",

--- a/locales/content/pt_PT/email.json
+++ b/locales/content/pt_PT/email.json
@@ -409,11 +409,6 @@
     "renderer": "erb",
     "source_hash": "62b07299"
   },
-  "email.email_changed.body": {
-    "text": "O endereço de e-mail da tua conta %{product_name} foi alterado para %{new_email_masked}.",
-    "renderer": "erb",
-    "source_hash": "6f3419d1"
-  },
   "email.email_changed.security_notice": {
     "text": "Se não fizeste esta alteração, por favor contacta o suporte imediatamente pois a tua conta pode estar comprometida.",
     "renderer": "erb",

--- a/locales/content/ru/email.json
+++ b/locales/content/ru/email.json
@@ -409,11 +409,6 @@
     "renderer": "erb",
     "source_hash": "62b07299"
   },
-  "email.email_changed.body": {
-    "text": "Адрес электронной почты Вашего аккаунта %{product_name} был изменён на %{new_email_masked} %{date}.",
-    "renderer": "erb",
-    "source_hash": "6f3419d1"
-  },
   "email.email_changed.security_notice": {
     "text": "Если Вы не вносили это изменение, немедленно свяжитесь со службой поддержки, так как Ваш аккаунт может быть скомпрометирован.",
     "renderer": "erb",

--- a/locales/content/sl_SI/email.json
+++ b/locales/content/sl_SI/email.json
@@ -409,11 +409,6 @@
     "renderer": "erb",
     "source_hash": "62b07299"
   },
-  "email.email_changed.body": {
-    "text": "E-poštni naslov za vaš račun %{product_name} je bil spremenjen na %{new_email_masked}.",
-    "renderer": "erb",
-    "source_hash": "6f3419d1"
-  },
   "email.email_changed.security_notice": {
     "text": "Če te spremembe niste opravili vi, nemudoma kontaktirajte podporo, saj je vaš račun morda ogrožen.",
     "renderer": "erb",

--- a/locales/content/sv_SE/email.json
+++ b/locales/content/sv_SE/email.json
@@ -409,11 +409,6 @@
     "renderer": "erb",
     "source_hash": "62b07299"
   },
-  "email.email_changed.body": {
-    "text": "E-postadressen för ditt %{product_name}-konto ändrades till %{new_email_masked}.",
-    "renderer": "erb",
-    "source_hash": "6f3419d1"
-  },
   "email.email_changed.security_notice": {
     "text": "Om du inte gjorde denna ändring, vänligen kontakta supporten omedelbart eftersom ditt konto kan vara komprometterat.",
     "renderer": "erb",

--- a/locales/content/tr/email.json
+++ b/locales/content/tr/email.json
@@ -409,11 +409,6 @@
     "renderer": "erb",
     "source_hash": "62b07299"
   },
-  "email.email_changed.body": {
-    "text": "%{product_name} hesabınızın e-posta adresi %{new_email_masked} olarak değiştirildi.",
-    "renderer": "erb",
-    "source_hash": "6f3419d1"
-  },
   "email.email_changed.security_notice": {
     "text": "Bu değişikliği siz yapmadıysanız, hesabınız tehlikede olabileceğinden lütfen derhal destekle iletişime geçin.",
     "renderer": "erb",

--- a/locales/content/uk/email.json
+++ b/locales/content/uk/email.json
@@ -409,11 +409,6 @@
     "renderer": "erb",
     "source_hash": "62b07299"
   },
-  "email.email_changed.body": {
-    "text": "Електронну адресу для Вашого облікового запису %{product_name} було змінено на %{new_email_masked}.",
-    "renderer": "erb",
-    "source_hash": "6f3419d1"
-  },
   "email.email_changed.security_notice": {
     "text": "Якщо Ви не робили цієї зміни, будь ласка, негайно зверніться до служби підтримки, оскільки Ваш обліковий запис може бути скомпрометовано.",
     "renderer": "erb",

--- a/locales/content/vi/email.json
+++ b/locales/content/vi/email.json
@@ -409,11 +409,6 @@
     "renderer": "erb",
     "source_hash": "62b07299"
   },
-  "email.email_changed.body": {
-    "text": "Địa chỉ email cho tài khoản %{product_name} của bạn đã được thay đổi thành %{new_email_masked}.",
-    "renderer": "erb",
-    "source_hash": "6f3419d1"
-  },
   "email.email_changed.security_notice": {
     "text": "Nếu bạn không thực hiện thay đổi này, vui lòng liên hệ hỗ trợ ngay lập tức vì tài khoản của bạn có thể đã bị xâm phạm.",
     "renderer": "erb",

--- a/locales/content/zh/email.json
+++ b/locales/content/zh/email.json
@@ -409,11 +409,6 @@
     "renderer": "erb",
     "source_hash": "62b07299"
   },
-  "email.email_changed.body": {
-    "text": "您 %{product_name} 账户的邮箱地址已于 %{date} 更改为 %{new_email_masked}。",
-    "renderer": "erb",
-    "source_hash": "6f3419d1"
-  },
   "email.email_changed.security_notice": {
     "text": "如果这不是您本人操作，请立即联系支持团队，您的账户可能已被盗用。",
     "renderer": "erb",


### PR DESCRIPTION
## Summary

Removes the orphaned `email.email_changed.body` locale key from the English source and all 30 locales.

`email.email_changed.body` is **never rendered**. Both `email_changed.txt.erb` and `email_changed.html.erb` use `email.email_changed.change_notice`, and the change timestamp is shown as its own labeled field (`changed_at_formatted`) — never interpolated as `%{date}`. The key is a superseded near-duplicate of `change_notice`.

Because it is dead, **11 locales** (`de, eo, es, fr_CA, fr_FR, ja, ko, nl, pt_BR, ru, zh`) had drifted to add a stray `%{date}` to `body.text` that the English source does not have, which `i18n validate variables` flags as an extra-variable mismatch. Removing the key clears those mismatches at the source instead of hand-editing a date clause out of 11 languages.

**Why it's safe to remove:**
- No code or template references `email_changed.body` (repo-wide grep excluding `locales/` is empty).
- The cross-locale consistency tests are report-only — they `expect(true).toBe(true)` on key parity, so removing a key breaks nothing.
- The committed `locales/db/checksums.sha256` covers only `.sql` files, not content JSON.
- The `email_changed` unit test asserts `changed_at` / `changed_at_formatted`, not `body`.

Diff: **30 files, 150 deletions, 0 insertions** — one 5-line block per file, no reformatting.

## Related Issues

No tracked issue. Surfaced during review of the i18n update PRs (#3577, #3592); this is independent of them and fixes the source of truth on `main`.

## Test Plan

- `python3 locales/scripts/i18n validate variables --json --locale <loc>` for the affected locales now reports **0** `email_changed.body` mismatches (e.g. `nl` 27 → 26, `de` 27 → 26; the residual counts are unrelated pre-existing untranslated-empty strings that the i18n update PRs fill in).
- All 30 `email.json` files still parse as JSON, and `email.email_changed.change_notice` (the live key) is intact in every locale.
- No template or code references the removed key, so the rendered "email changed" message is unchanged.

**Follow-up (not in this PR):** the translation task DB may still carry a task for this key, so a future export could reintroduce it — the corresponding task should be dropped as well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BvU1T8qRspHdFjTTHXWznF)_