### PR TITLE
pr-per-locale.sh: strip leaked agent preamble from review output

### DIFF
--- a/locales/scripts/pr-per-locale.sh
+++ b/locales/scripts/pr-per-locale.sh
@@ -347,7 +347,16 @@ process_locale() {
       echo "[$locale] review did not complete (exit $rc); PR body will note it"
       review_md="_Automated review did not complete (exit $rc). Review this locale manually._"
     else
-      review_md="$raw"
+      # Strip any agent preamble/reasoning that leaked ahead of the structured
+      # review (some agent profiles emit a "thinking out loud" line first). The
+      # prompt mandates the output begin with "**Verdict:**", so drop everything
+      # before the first line containing that marker. If the marker is absent
+      # (unexpected format), keep the raw output untouched.
+      if grep -q '\*\*Verdict:\*\*' <<<"$raw"; then
+        review_md="$(awk 'seen || /\*\*Verdict:\*\*/ { seen=1; print }' <<<"$raw")"
+      else
+        review_md="$raw"
+      fi
     fi
     # Persist the review artifact (matches locales/reviews/<date>/<locale>.md).
     { echo "# $locale review — $(basename "$RESULTS_DIR")"; echo; echo "$review_md"; } >"$review_file"


### PR DESCRIPTION
## Summary

Follow-up to #3573 (already merged). `pr-per-locale.sh` builds each i18n PR body from a local `claude` review whose prompt mandates the output begin with `**Verdict:**`. Some agent profiles emit a "thinking out loud" line first — e.g. #3577's body opened with *"Good enough. I have sufficient evidence now. Let me finalize the review."* ahead of the verdict.

This drops everything before the first line containing `**Verdict:**`, so leaked preamble never reaches a PR body. If the marker is absent (unexpected format), the raw output is kept untouched.

One-file change (+10/-1).

## Related Issues

Follow-up to #3573. No tracked issue.

## Test Plan

Unit-tested the filter logic standalone:
- Input carrying the exact #3577 preamble → output starts at `**Verdict:**` (preamble + blank line dropped).
- Input with no `**Verdict:**` marker → returned unchanged (fallback path).
- `bash -n` syntax check passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BvU1T8qRspHdFjTTHXWznF)_