### PR TITLE
chore: stop copying scripts/ into the runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -256,7 +256,6 @@ COPY --chown=appuser:appuser migrations ./migrations
 COPY --chown=appuser:appuser docker/entrypoints/entrypoint.sh ./bin/
 COPY --chown=appuser:appuser docker/entrypoints/healthcheck.sh ./bin/
 COPY --chown=appuser:appuser install.sh ./
-COPY --chown=appuser:appuser scripts ./scripts
 COPY --chown=appuser:appuser --from=dependencies ${APP_DIR}/bin/puma ./bin/puma
 COPY --chown=appuser:appuser --from=build ${APP_DIR}/package.json ./
 COPY --chown=appuser:appuser config.ru Gemfile Gemfile.lock ./
@@ -367,7 +366,6 @@ COPY --chown=appuser:appuser migrations ./migrations
 COPY --chown=appuser:appuser docker/entrypoints/entrypoint.sh ./bin/
 COPY --chown=appuser:appuser docker/entrypoints/healthcheck.sh ./bin/
 COPY --chown=appuser:appuser install.sh ./
-COPY --chown=appuser:appuser scripts ./scripts
 COPY --chown=appuser:appuser --from=dependencies ${APP_DIR}/bin/puma ./bin/puma
 COPY --chown=appuser:appuser --from=build ${APP_DIR}/package.json ./
 COPY --chown=appuser:appuser config.ru Gemfile Gemfile.lock ./


### PR DESCRIPTION
Drops the two runtime-stage `COPY --chown=appuser:appuser scripts ./scripts` lines from the Dockerfile (the `final-s6` and `final` stages).

Nothing in the running container executes anything under `scripts/`: the entrypoints, healthcheck, and s6 service definitions have no references, and every `scripts/` mention in `lib/` is a documentation comment pointing at operator-run diagnostics. Migrations run from `migrations/` (copied separately), and the JSON-schema generator now lives under `src/schemas/scripts/` and runs in the build stage — so the whole `scripts/` tree (dev/build tooling: openapi, favicons, api-validation, branch reports, etc.) was being baked into production for nothing.

This is the runtime counterpart to the build-stage `COPY scripts` removal that already landed with #3563/#3564; those only dropped the build-stage copy.

- Runtime-only change; no Ruby, entrypoint, or s6 path touched.
- Verified against current `main`: no runtime code references `scripts/`, both COPY lines still present.

Related to #3563.