### PR TITLE
Fix double-reveal race on burn-after-reading secrets with atomic CAS

### DIFF
--- a/apps/api/v1/logic/secrets/burn_secret.rb
+++ b/apps/api/v1/logic/secrets/burn_secret.rb
@@ -39,10 +39,14 @@ module V1::Logic
           @greenlighted = viewable && correct_passphrase && continue
 
           if greenlighted
-            @secret = potential_secret
-            owner = secret.load_owner
-            secret.burned!
-            owner.increment_field(:secrets_burned) if owner && !owner.anonymous?
+            @secret       = potential_secret
+            owner         = secret.load_owner
+            # Gate on winning the atomic burn claim: when a concurrent reveal
+            # or burn already consumed the secret, burned! returns false and
+            # this request must not count the burn nor report success (the
+            # controller then renders its standard not-found response).
+            @greenlighted = secret.burned!
+            owner.increment_field(:secrets_burned) if greenlighted && owner && !owner.anonymous?
             # TODO:
             # Onetime::Customer.global.increment_field :secrets_burned
 

--- a/apps/api/v1/logic/secrets/show_secret.rb
+++ b/apps/api/v1/logic/secrets/show_secret.rb
@@ -36,6 +36,12 @@ module V1::Logic
         owner = secret.load_owner
 
         if show_secret
+          # Legacy v1 ordering: the plaintext is decrypted here, BEFORE the
+          # atomic revealed! claim below. A losing racer never sends it -- the
+          # claim gate suppresses @secret_value -- but it is still computed in
+          # memory. v2 avoids this by decrypting only inside the won claim
+          # (Secret#reveal!); v1 is maintenance-only, so the decoupled ordering
+          # is kept by design.
           @secret_value = secret.decrypted_secret_value(passphrase_input: passphrase)
           @is_truncated = secret.truncated?
           @original_size = secret.respond_to?(:original_size) ? secret.original_size : nil
@@ -53,10 +59,6 @@ module V1::Logic
             end
           else
 
-            owner.increment_field(:secrets_shared) if owner && !owner.anonymous?
-            # TODO:
-            # Onetime::Customer.global.increment_field :secrets_shared
-
             # Immediately mark the secret as revealed, so that it
             # can't be shown again. If there's a network failure
             # that prevents the client from receiving the response,
@@ -69,6 +71,14 @@ module V1::Logic
             # bug but it means that all return values need to be
             # pluck out of the secret object before this is called.
             @revealed = secret.revealed!
+
+            # Gate the shared-secret metric on winning the atomic claim:
+            # revealed! returns false to a request that lost the burn-after-
+            # reading race, which revealed nothing and must not inflate the
+            # owner's counter (mirrors the v2 controllers).
+            owner.increment_field(:secrets_shared) if @revealed && owner && !owner.anonymous?
+            # TODO:
+            # Onetime::Customer.global.increment_field :secrets_shared
 
           end
 

--- a/apps/api/v1/logic/secrets/show_secret.rb
+++ b/apps/api/v1/logic/secrets/show_secret.rb
@@ -47,7 +47,7 @@ module V1::Logic
               owner.verified! "true"
               # Skip for stateless auth (BasicAuth provides empty session)
               sess.clear unless sess.empty?
-              secret.revealed!
+              @revealed = secret.revealed!
             else
               raise_form_error "You can't verify an account when you're already logged in."
             end
@@ -68,8 +68,17 @@ module V1::Logic
             # happens in success_data). This is a feature, not a
             # bug but it means that all return values need to be
             # pluck out of the secret object before this is called.
-            secret.revealed!
+            @revealed = secret.revealed!
 
+          end
+
+          # revealed! performs an atomic claim: it returns true only for the
+          # single caller that won the burn-after-reading race. If a concurrent
+          # request beat us to it, we must NOT disclose the plaintext -- suppress
+          # it so success_data omits secret_value. Prevents a double-reveal.
+          unless @revealed
+            @show_secret  = false
+            @secret_value = nil
           end
 
         elsif continue && secret.has_passphrase? && !correct_passphrase

--- a/apps/api/v1/spec/logic/secrets/burn_secret_spec.rb
+++ b/apps/api/v1/spec/logic/secrets/burn_secret_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe V1::Logic::Secrets::BurnSecret do
   describe '#process' do
     context 'when secret is viewable and passphrase is correct' do
       before do
-        allow(secret).to receive(:burned!)
+        allow(secret).to receive(:burned!).and_return(true)
       end
 
       it 'calls load_owner on the secret to retrieve the owner' do
@@ -79,6 +79,33 @@ RSpec.describe V1::Logic::Secrets::BurnSecret do
       end
     end
 
+    # The double-reveal race, burn variant: Secret#burned! performs an atomic
+    # compare-and-set claim and returns true only to the caller that won it. A
+    # burn that loses the claim (a concurrent reveal or burn already consumed
+    # the secret) must not count the burn nor report success.
+    context 'when the burn loses the race to a concurrent reveal or burn' do
+      before do
+        allow(secret).to receive(:burned!).and_return(false)
+      end
+
+      it 'does not increment secrets_burned on the owner' do
+        subject.process
+
+        expect(secret).to have_received(:burned!)
+        expect(owner).not_to have_received(:increment_field)
+      end
+
+      it 'is not greenlighted' do
+        subject.process
+
+        expect(subject.greenlighted).to be false
+        # Proves it was the gate (burned! returning false), not the
+        # viewable?/continue guard, that withheld the greenlight -- the guard
+        # path never calls burned! at all.
+        expect(secret).to have_received(:burned!)
+      end
+    end
+
     # Regression: the greenlight must honor the parsed `continue` boolean, not
     # the raw param. The string "false" is truthy in Ruby, so the previous
     # `continue_result = params['continue']` would burn a secret even when the
@@ -87,7 +114,7 @@ RSpec.describe V1::Logic::Secrets::BurnSecret do
       subject { described_class.new(session, customer, base_params.merge('continue' => 'false')) }
 
       before do
-        allow(secret).to receive(:burned!)
+        allow(secret).to receive(:burned!).and_return(true)
       end
 
       it 'does not burn the secret' do

--- a/apps/api/v1/spec/logic/secrets/show_secret_spec.rb
+++ b/apps/api/v1/spec/logic/secrets/show_secret_spec.rb
@@ -53,8 +53,10 @@ RSpec.describe V1::Logic::Secrets::ShowSecret do
         allow(secret).to receive(:truncated?).and_return(false)
         allow(secret).to receive(:original_size).and_return(100)
         allow(secret).to receive(:viewed!)
-        allow(secret).to receive(:received!)
-        allow(secret).to receive(:revealed!)
+        # revealed!/received! now return true for the caller that wins the
+        # atomic reveal claim; the controller gates the plaintext on that value.
+        allow(secret).to receive(:received!).and_return(true)
+        allow(secret).to receive(:revealed!).and_return(true)
         allow(secret).to receive(:previewed!)
         allow(secret).to receive(:verification).and_return('false')
         allow(secret).to receive(:state?).with(:new).and_return(true)

--- a/apps/api/v2/logic/secrets/burn_secret.rb
+++ b/apps/api/v2/logic/secrets/burn_secret.rb
@@ -70,21 +70,38 @@ module V2::Logic
           }
 
         if greenlighted
-          @secret = potential_secret
-          secret.burned!
-          owner   = secret.load_owner
-          owner&.increment_field :secrets_burned unless owner&.anonymous?
-          Onetime::Customer.secrets_burned.increment
+          # Gate all bookkeeping on winning the atomic burn claim: burned!
+          # returns true only for the single caller that flips the state. When
+          # a concurrent reveal or burn already consumed the secret, this
+          # request lost the race -- it must not count the burn, log success,
+          # or report success to the client.
+          @secret       = potential_secret
+          @greenlighted = secret.burned!
 
-          secret_logger.info 'Secret burned successfully',
-            {
-              secret_identifier: secret.shortid,
-              receipt_identifier: receipt.identifier,
-              owner_id: owner&.custid,
-              user_id: cust&.custid,
-              action: 'burn',
-              result: :success,
-            }
+          if greenlighted
+            owner = secret.load_owner
+            owner&.increment_field :secrets_burned unless owner&.anonymous?
+            Onetime::Customer.secrets_burned.increment
+
+            secret_logger.info 'Secret burned successfully',
+              {
+                secret_identifier: secret.shortid,
+                receipt_identifier: receipt.identifier,
+                owner_id: owner&.custid,
+                user_id: cust&.custid,
+                action: 'burn',
+                result: :success,
+              }
+          else
+            secret_logger.warn 'Burn failed - secret already consumed',
+              {
+                secret_identifier: secret.shortid,
+                receipt_identifier: receipt.identifier,
+                user_id: cust&.custid,
+                action: 'burn',
+                result: :already_consumed,
+              }
+          end
 
         elsif !correct_passphrase
           secret_logger.warn 'Burn failed - incorrect passphrase',

--- a/apps/api/v2/logic/secrets/reveal_secret.rb
+++ b/apps/api/v2/logic/secrets/reveal_secret.rb
@@ -90,9 +90,9 @@ module V2::Logic
           # Clear any rate limit state on successful passphrase entry
           clear_passphrase_rate_limit!(secret.identifier) if secret.has_passphrase?
 
-          # If we can't decrypt that's great! We just set secret_value to
-          # the encrypted string.
-          @secret_value = secret.decrypted_secret_value(passphrase_input: @passphrase)
+          # Decryption is deferred to secret.reveal! below: it decrypts ONLY on
+          # the caller that wins the atomic reveal claim, so a request that lost
+          # the burn-after-reading race never even computes the plaintext.
 
           if verification
 
@@ -127,10 +127,11 @@ module V2::Logic
               # multiple verification secrets? Or who sent a verification secret
               # even though the account was already verified?
               #
-              # In any case, we logged it as an error but mark the secret as
-              # having been revealed (which updates the receipt record and then
-              # expunges the secret record) and allows the user to carry on.
-              @revealed = secret.revealed!
+              # In any case, we logged it as an error but reveal the secret
+              # (which updates the receipt record and then expunges the secret
+              # record) and allow the user to carry on. reveal! returns the
+              # plaintext only if this caller won the one-shot claim.
+              @secret_value = secret.reveal!(passphrase_input: @passphrase)
 
             elsif owner && (cust&.anonymous? || (cust&.custid == owner.custid && !owner.verified?))
               secret_logger.info 'Owner verification successful',
@@ -146,7 +147,7 @@ module V2::Logic
               owner.reset_secret.delete!
               # Skip for stateless auth (BasicAuth provides empty session)
               sess.clear unless sess.empty?
-              @revealed         = secret.revealed!
+              @secret_value     = secret.reveal!(passphrase_input: @passphrase)
 
             else
               secret_logger.error 'Invalid verification - user already logged in',
@@ -163,40 +164,36 @@ module V2::Logic
               )
             end
           else
-            secret_logger.info 'Secret revealed successfully',
-              {
-                secret_identifier: secret.shortid,
-                owner_id: owner&.objid,
-                action: 'reveal',
-                result: :success,
-              }
-
-            owner.increment_field :secrets_shared if !owner.nil? && !owner.anonymous?
-
-            Onetime::Customer.secrets_shared.increment
-
-            # Immediately mark the secret as revealed, so that it
-            # can't be shown again. If there's a network failure
-            # that prevents the client from receiving the response,
-            # we're not able to show it again. This is a feature
-            # not a bug.
+            # Reveal-and-consume the secret so it can't be shown again. If a
+            # network failure prevents the client from receiving the response,
+            # we deliberately cannot show it again -- a feature, not a bug.
+            # reveal! is destructive and runs before the response is generated,
+            # so every returned value must be plucked from the secret first.
             #
-            # NOTE: This destructive action is called before the
-            # response is returned or even fully generated (which
-            # happens in success_data). This is a feature, not a
-            # bug but it means that all return values need to be
-            # pluck out of the secret object before this is called.
-            @revealed = secret.revealed!
+            # reveal! returns the plaintext ONLY to the caller that won the
+            # atomic claim; a request that lost the burn-after-reading race gets
+            # nil. The success log and the shared-secret counters are therefore
+            # gated on winning, so a losing request neither claims success nor
+            # inflates the metrics.
+            @secret_value = secret.reveal!(passphrase_input: @passphrase)
+
+            if @secret_value
+              secret_logger.info 'Secret revealed successfully',
+                {
+                  secret_identifier: secret.shortid,
+                  owner_id: owner&.objid,
+                  action: 'reveal',
+                  result: :success,
+                }
+
+              owner.increment_field :secrets_shared if !owner.nil? && !owner.anonymous?
+              Onetime::Customer.secrets_shared.increment
+            end
           end
 
-          # revealed! performs an atomic claim: it returns true only for the
-          # single caller that won the burn-after-reading race. If a concurrent
-          # request beat us to it, we must NOT disclose the plaintext -- suppress
-          # it so success_data omits secret_value. Prevents a double-reveal.
-          unless @revealed
-            @show_secret  = false
-            @secret_value = nil
-          end
+          # No plaintext means we did not win the reveal (a concurrent request
+          # already consumed the secret): do not present it as viewable.
+          @show_secret = false if @secret_value.nil?
 
         elsif secret.has_passphrase? && !correct_passphrase
           # Record failed attempt for rate limiting

--- a/apps/api/v2/logic/secrets/reveal_secret.rb
+++ b/apps/api/v2/logic/secrets/reveal_secret.rb
@@ -130,7 +130,7 @@ module V2::Logic
               # In any case, we logged it as an error but mark the secret as
               # having been revealed (which updates the receipt record and then
               # expunges the secret record) and allows the user to carry on.
-              secret.revealed!
+              @revealed = secret.revealed!
 
             elsif owner && (cust&.anonymous? || (cust&.custid == owner.custid && !owner.verified?))
               secret_logger.info 'Owner verification successful',
@@ -146,7 +146,7 @@ module V2::Logic
               owner.reset_secret.delete!
               # Skip for stateless auth (BasicAuth provides empty session)
               sess.clear unless sess.empty?
-              secret.revealed!
+              @revealed         = secret.revealed!
 
             else
               secret_logger.error 'Invalid verification - user already logged in',
@@ -186,7 +186,16 @@ module V2::Logic
             # happens in success_data). This is a feature, not a
             # bug but it means that all return values need to be
             # pluck out of the secret object before this is called.
-            secret.revealed!
+            @revealed = secret.revealed!
+          end
+
+          # revealed! performs an atomic claim: it returns true only for the
+          # single caller that won the burn-after-reading race. If a concurrent
+          # request beat us to it, we must NOT disclose the plaintext -- suppress
+          # it so success_data omits secret_value. Prevents a double-reveal.
+          unless @revealed
+            @show_secret  = false
+            @secret_value = nil
           end
 
         elsif secret.has_passphrase? && !correct_passphrase

--- a/apps/api/v2/logic/secrets/show_secret.rb
+++ b/apps/api/v2/logic/secrets/show_secret.rb
@@ -71,24 +71,21 @@ module V2::Logic
         end
 
         if show_secret
-          @secret_value = secret.decrypted_secret_value(passphrase_input: passphrase)
-          owner         = secret.load_owner
+          owner = secret.load_owner
 
-          # verify_owner/reveal_secret return the value of secret.revealed!,
-          # whose atomic claim yields true only for the single caller that won
-          # the burn-after-reading race.
-          @revealed = if verification
-                        verify_owner(owner)
-                      else
-                        reveal_secret(owner)
-                      end
+          # verify_owner/reveal_secret return secret.reveal!, which decrypts and
+          # returns the plaintext ONLY to the single caller that won the atomic
+          # burn-after-reading claim; a losing request gets nil and never
+          # computes the plaintext at all.
+          @secret_value = if verification
+                            verify_owner(owner)
+                          else
+                            reveal_secret(owner)
+                          end
 
-          # If a concurrent request beat us to the reveal, we must NOT disclose
-          # the plaintext -- suppress it so success_data omits secret_value.
-          unless @revealed
-            @show_secret  = false
-            @secret_value = nil
-          end
+          # No plaintext means we did not win the reveal (a concurrent request
+          # already consumed the secret): do not present it as viewable.
+          @show_secret = false if @secret_value.nil?
         end
 
         resolve_share_domain
@@ -141,27 +138,28 @@ module V2::Logic
           # which exposes no public destroy method. clear is the correct call.
           # Skip for stateless auth (BasicAuth provides empty session)
           sess.clear unless sess.empty?
-          secret.received!
+          secret.reveal!(passphrase_input: passphrase)
         else
           raise_form_error "You can't verify an account when you're already logged in."
         end
       end
 
-      # Immediately mark the secret as viewed, so that it
-      # can't be shown again. If there's a network failure
-      # that prevents the client from receiving the response,
-      # we're not able to show it again. This is a feature
-      # not a bug.
+      # Reveal-and-consume the secret so it can't be shown again. If a network
+      # failure prevents the client from receiving the response, we deliberately
+      # cannot show it again -- a feature, not a bug.
       #
-      # NOTE: This destructive action is called before the
-      # response is returned or even fully generated (which
-      # happens in success_data). This is a feature, not a
-      # bug but it means that all return values need to be
-      # plucked out of the secret object before this is called.
+      # NOTE: reveal! is destructive and runs before the response is generated,
+      # so every returned value must be plucked from the secret before this
+      # point. It returns the plaintext ONLY to the caller that won the atomic
+      # reveal claim; a request that lost the race gets nil, so the shared-secret
+      # counters are gated on winning to avoid inflating them on a lost race.
       def reveal_secret(owner)
+        plaintext = secret.reveal!(passphrase_input: passphrase)
+        return plaintext if plaintext.nil?
+
         owner&.increment_field :secrets_shared unless owner&.anonymous?
         Onetime::Customer.secrets_shared.increment
-        secret.revealed!
+        plaintext
       end
 
       def resolve_share_domain

--- a/apps/api/v2/logic/secrets/show_secret.rb
+++ b/apps/api/v2/logic/secrets/show_secret.rb
@@ -74,10 +74,20 @@ module V2::Logic
           @secret_value = secret.decrypted_secret_value(passphrase_input: passphrase)
           owner         = secret.load_owner
 
-          if verification
-            verify_owner(owner)
-          else
-            reveal_secret(owner)
+          # verify_owner/reveal_secret return the value of secret.revealed!,
+          # whose atomic claim yields true only for the single caller that won
+          # the burn-after-reading race.
+          @revealed = if verification
+                        verify_owner(owner)
+                      else
+                        reveal_secret(owner)
+                      end
+
+          # If a concurrent request beat us to the reveal, we must NOT disclose
+          # the plaintext -- suppress it so success_data omits secret_value.
+          unless @revealed
+            @show_secret  = false
+            @secret_value = nil
           end
         end
 

--- a/apps/api/v2/spec/logic/secrets/burn_secret_spec.rb
+++ b/apps/api/v2/spec/logic/secrets/burn_secret_spec.rb
@@ -12,6 +12,10 @@ require_relative File.join(Onetime::HOME, 'spec', 'spec_helper')
 # string — every non-empty string is truthy in Ruby, so reading the raw param
 # would burn the secret even when the caller explicitly sent continue=false.
 #
+# Also covers the burn variant of the double-reveal race: Secret#burned!
+# performs an atomic compare-and-set claim and returns true only to the caller
+# that won it; process must gate counters/success on that boolean.
+#
 # Uses real Receipt/Secret objects (spawn_pair) so process -> success_data runs
 # end-to-end without stubbing the URL/serialization helpers.
 RSpec.describe V2::Logic::Secrets::BurnSecret, type: :integration do
@@ -46,6 +50,22 @@ RSpec.describe V2::Logic::Secrets::BurnSecret, type: :integration do
     described_class.new(strategy_result, params)
   end
 
+  # Hold the race window open: both requests loaded the secret before the
+  # winner consumed it. BurnSecret loads its secret inside process via
+  # receipt.load_secret, which returns nil once a winner destroys the record
+  # and would short-circuit process at the potential_secret guard, testing
+  # nothing -- so pin the stale pre-race instance, holding viewable? true so
+  # it is secret.burned! (not a guard) that must withhold the success path by
+  # losing the atomic claim. load_owner is spied to prove the win-branch
+  # bookkeeping never ran. Must run BEFORE the winner consumes.
+  def pin_stale_secret_on(logic)
+    stale = Onetime::Secret.load(secret.identifier)
+    allow(stale).to receive(:viewable?).and_return(true)
+    allow(stale).to receive(:load_owner).and_call_original
+    allow(logic.receipt).to receive(:load_secret).and_return(stale)
+    stale
+  end
+
   let!(:pair)    { Onetime::Receipt.spawn_pair(nil, 3600, 'a secret value') }
   let(:receipt)  { pair.first }
   let(:secret)   { pair.last }
@@ -64,12 +84,71 @@ RSpec.describe V2::Logic::Secrets::BurnSecret, type: :integration do
   end
 
   context 'when continue is "true"' do
-    it 'greenlights and burns the secret' do
-      logic = build_logic('identifier' => receipt.identifier, 'continue' => 'true')
+    it 'greenlights, burns, and counts the burn exactly once' do
+      logic        = build_logic('identifier' => receipt.identifier, 'continue' => 'true')
       logic.process_params
+      before_count = Onetime::Customer.secrets_burned.value
+
       logic.process
 
       expect(logic.greenlighted).to be true
+      expect(logic.success_data[:success]).to be true
+      # The class counter moves by exactly one for the single winning burn.
+      # (Owner increment is a no-op here: spawn_pair(nil, ...) has no owner.)
+      expect(Onetime::Customer.secrets_burned.value).to eq(before_count + 1)
+    end
+  end
+
+  # The double-reveal race, burn variant: Secret#burned! performs an atomic
+  # compare-and-set claim and returns true only to the caller that won it. A
+  # burn that loses the claim must not increment burn counters, log success,
+  # or report success to the client.
+  context 'when a concurrent reveal already consumed the secret (this burn loses)' do
+    it 'does not count the burn and reports success: false' do
+      logic = build_logic('identifier' => receipt.identifier, 'continue' => 'true')
+      logic.process_params
+      stale = pin_stale_secret_on(logic)
+
+      # A concurrent request wins the atomic claim and consumes the secret.
+      expect(Onetime::Secret.load(secret.identifier).revealed!).to be true
+      before_count = Onetime::Customer.secrets_burned.value
+
+      logic.process
+
+      expect(logic.greenlighted).to be false
+      expect(logic.success_data[:success]).to be false
+      expect(Onetime::Customer.secrets_burned.value).to eq(before_count)
+      # No owner bookkeeping ran -- the whole win-branch was skipped, not just
+      # the global counter.
+      expect(stale).not_to have_received(:load_owner)
+      # Identity-pins that process ENTERED the greenlighted branch (@secret is
+      # assigned the pinned stale instance immediately before burned!), so it
+      # was the lost atomic claim -- not a collapsed race window at the
+      # viewable?/continue guard -- that produced the false greenlight.
+      expect(logic.secret).to be(stale)
+    end
+  end
+
+  context 'when a concurrent burn already consumed the secret (this burn loses)' do
+    it 'does not count the burn and reports success: false' do
+      logic = build_logic('identifier' => receipt.identifier, 'continue' => 'true')
+      logic.process_params
+      stale = pin_stale_secret_on(logic)
+
+      # A concurrent request wins the atomic claim and burns the secret. With
+      # the winner case above this pins burned!'s promise: caller-side
+      # bookkeeping happens exactly once across N racing burns.
+      expect(Onetime::Secret.load(secret.identifier).burned!).to be true
+      before_count = Onetime::Customer.secrets_burned.value
+
+      logic.process
+
+      expect(logic.greenlighted).to be false
+      expect(logic.success_data[:success]).to be false
+      expect(Onetime::Customer.secrets_burned.value).to eq(before_count)
+      expect(stale).not_to have_received(:load_owner)
+      # Branch-entry pin -- see the concurrent-reveal case above.
+      expect(logic.secret).to be(stale)
     end
   end
 end

--- a/apps/api/v2/spec/logic/secrets/reveal_secret_spec.rb
+++ b/apps/api/v2/spec/logic/secrets/reveal_secret_spec.rb
@@ -70,15 +70,18 @@ RSpec.describe V2::Logic::Secrets::RevealSecret, type: :integration do
       logic.process_params # loads this request's own :new instance
 
       # A concurrent request wins the atomic claim and consumes the secret
-      # between our load and our reveal.
+      # AFTER this request has already passed its viewability check but BEFORE
+      # it reveals -- the exact race window. Hold viewable? true so process
+      # takes the reveal path and it is secret.reveal! (not the viewable? guard)
+      # that must withhold the plaintext by losing the atomic claim.
+      allow(logic.secret).to receive(:viewable?).and_return(true)
       winner = Onetime::Secret.load(secret.identifier)
       expect(winner.revealed!).to be true
 
       logic.process
 
-      # The losing request must withhold the plaintext, even though it had
-      # already decrypted its in-memory ciphertext before the reveal.
       expect(logic.show_secret).to be false
+      expect(logic.secret_value).to be_nil
       expect(logic.success_data[:record]).not_to have_key(:secret_value)
     end
   end

--- a/apps/api/v2/spec/logic/secrets/reveal_secret_spec.rb
+++ b/apps/api/v2/spec/logic/secrets/reveal_secret_spec.rb
@@ -34,8 +34,11 @@ RSpec.describe V2::Logic::Secrets::RevealSecret, type: :integration do
 
   # Build a RevealSecret over a real secret. process derives cust from
   # strategy_result.user and never needs org (that is a raise_concerns concern).
-  def build_logic(params)
-    customer = double('Customer', custid: 'anon', anonymous?: true, objid: nil)
+  # customer: overrides the default anonymous caller for the verification
+  # branches that depend on who is logged in. Pass params as a braced hash --
+  # the customer: kwarg would otherwise swallow a bare trailing hash.
+  def build_logic(params, customer: nil)
+    customer ||= double('Customer', custid: 'anon', anonymous?: true, objid: nil)
     org      = double('Organization', objid: "org_#{SecureRandom.hex(4)}")
     allow(org).to receive(:can?).and_return(true)
 
@@ -48,13 +51,26 @@ RSpec.describe V2::Logic::Secrets::RevealSecret, type: :integration do
     described_class.new(strategy_result, params)
   end
 
+  # Mark a spawned secret as a verification secret the way production does it
+  # post-creation (lib/onetime/logic/base.rb send_verification_email,
+  # apps/api/account/logic/account/request_email_change.rb:119-126). Partial
+  # write on purpose -- save_fields HSETs only :verification and never
+  # re-serializes the already-persisted ciphertext (house convention, cf.
+  # lib/onetime/models/features/passphrase_hashing.rb:23-26). Must run BEFORE
+  # build_logic: process_params fires in the Base constructor and loads its
+  # own instance from Redis.
+  def flag_as_verification!(secret)
+    secret.verification = 'true'
+    secret.save_fields(:verification)
+  end
+
   let!(:pair)   { Onetime::Receipt.spawn_pair(nil, 3600, 'a secret value') }
   let(:receipt) { pair.first }
   let(:secret)  { pair.last }
 
   context 'when this request wins the reveal (the normal case)' do
     it 'returns the decrypted plaintext' do
-      logic = build_logic('identifier' => secret.identifier, 'continue' => 'true')
+      logic = build_logic({ 'identifier' => secret.identifier, 'continue' => 'true' })
       logic.process_params
       logic.process
 
@@ -66,7 +82,7 @@ RSpec.describe V2::Logic::Secrets::RevealSecret, type: :integration do
 
   context 'when a concurrent request already won the reveal (this request loses)' do
     it 'does NOT emit the plaintext' do
-      logic = build_logic('identifier' => secret.identifier, 'continue' => 'true')
+      logic = build_logic({ 'identifier' => secret.identifier, 'continue' => 'true' })
       logic.process_params # loads this request's own :new instance
 
       # A concurrent request wins the atomic claim and consumes the secret
@@ -83,6 +99,167 @@ RSpec.describe V2::Logic::Secrets::RevealSecret, type: :integration do
       expect(logic.show_secret).to be false
       expect(logic.secret_value).to be_nil
       expect(logic.success_data[:record]).not_to have_key(:secret_value)
+    end
+  end
+
+  # Verification-flow coverage. A verification secret carries the account
+  # confirmation for its owner: revealing it verifies the owner's account
+  # (reveal_secret.rb lines 97-165). Production sets the flag post-creation,
+  # so these specs do the same via flag_as_verification! before build_logic.
+  context 'when the secret is a verification secret' do
+    # Unverified by default. Unique email each run -- the customer email index
+    # in the shared test Redis persists across runs.
+    let(:owner) do
+      Onetime::Customer.create!(email: "reveal-verify-#{SecureRandom.hex(6)}@example.com")
+    end
+    let!(:pair) { Onetime::Receipt.spawn_pair(owner.objid, 3600, 'a secret value') }
+
+    before { flag_as_verification!(secret) }
+
+    context 'when an anonymous caller verifies the unverified owner' do
+      it 'verifies the owner and reveals the plaintext' do
+        owner.reset_secret = secret.identifier # standalone dbkey, writes immediately
+        logic = build_logic({ 'identifier' => secret.identifier, 'continue' => 'true' })
+        logic.process_params
+        logic.process
+
+        expect(logic.show_secret).to be true
+        expect(logic.secret_value).to eq('a secret value')
+        expect(logic.success_data[:record][:secret_value]).to eq('a secret value')
+
+        reloaded = Onetime::Customer.load(owner.objid)
+        expect(reloaded.verified?).to be true
+        expect(reloaded.verified_by).to eq('email')
+        # value (GET) rather than exists? -- StringKey#exists? stays truthy
+        # after delete! on familia 2.10.1 (Integer 0 from EXISTS is truthy).
+        expect(reloaded.reset_secret.value).to be_nil
+        expect(Onetime::Secret.load(secret.identifier)).to be_nil # consumed
+      end
+    end
+
+    context 'when logged in as the unverified owner' do
+      # Second half of the disjunction that gates the verify branch:
+      # cust.custid == owner.custid && !owner.verified?
+      it 'verifies the owner and reveals the plaintext' do
+        as_owner = double('Customer', custid: owner.custid, anonymous?: false, objid: owner.objid)
+        logic    = build_logic({ 'identifier' => secret.identifier, 'continue' => 'true' }, customer: as_owner)
+        logic.process_params
+        logic.process
+
+        expect(logic.show_secret).to be true
+        expect(logic.success_data[:record][:secret_value]).to eq('a secret value')
+
+        reloaded = Onetime::Customer.load(owner.objid)
+        expect(reloaded.verified?).to be true
+        expect(reloaded.verified_by).to eq('email')
+        expect(Onetime::Secret.load(secret.identifier)).to be_nil
+      end
+    end
+
+    context 'when the owner is already verified' do
+      it 'still reveals the plaintext and leaves the owner untouched' do
+        owner.verified    = true
+        owner.verified_by = 'stripe_payment' # non-email provenance so a rewrite would be visible
+        owner.save
+        logic = build_logic({ 'identifier' => secret.identifier, 'continue' => 'true' })
+        logic.process_params
+        logic.process
+
+        expect(logic.show_secret).to be true
+        expect(logic.secret_value).to eq('a secret value')
+        expect(logic.success_data[:record][:secret_value]).to eq('a secret value')
+        expect(Onetime::Secret.load(secret.identifier)).to be_nil
+
+        reloaded = Onetime::Customer.load(owner.objid)
+        expect(reloaded.verified?).to be true
+        expect(reloaded.verified_by).to eq('stripe_payment') # NOT overwritten to 'email'
+      end
+    end
+
+    context 'when the secret has no owner' do
+      let!(:pair) { Onetime::Receipt.spawn_pair(nil, 3600, 'a secret value') }
+
+      it 'raises a form error and does not consume the secret' do
+        logic = build_logic({ 'identifier' => secret.identifier, 'continue' => 'true' })
+        logic.process_params
+
+        # Message resolves through I18n with a default fallback ('Verification
+        # not valid'); pin only the class so locale files cannot flake this.
+        expect { logic.process }.to raise_error(Onetime::FormError)
+
+        reloaded = Onetime::Secret.load(secret.identifier)
+        expect(reloaded).not_to be_nil
+        expect(reloaded.state).to eq('new')
+        expect(reloaded.viewable?).to be true
+      end
+    end
+
+    context 'when the owner is anonymous' do
+      let!(:pair) { Onetime::Receipt.spawn_pair(nil, 3600, 'a secret value') }
+
+      it 'raises a form error and does not consume the secret' do
+        logic = build_logic({ 'identifier' => secret.identifier, 'continue' => 'true' })
+        logic.process_params
+
+        # The only owner double in these specs: Customer#save raises for
+        # anonymous customers, so an anonymous owner can never be loaded from
+        # Redis. Stub just the lookup -- viewable?/reveal! stay real so the
+        # raise must come from the branch itself.
+        anon_owner = double('AnonOwner', anonymous?: true)
+        allow(logic.secret).to receive(:load_owner).and_return(anon_owner)
+
+        expect { logic.process }.to raise_error(Onetime::FormError)
+
+        reloaded = Onetime::Secret.load(secret.identifier)
+        expect(reloaded).not_to be_nil
+        expect(reloaded.state).to eq('new')
+        expect(reloaded.viewable?).to be true
+      end
+    end
+
+    context 'when already logged in as a different user' do
+      it 'raises a form error, consumes nothing, and verifies no one' do
+        other = double('Customer', custid: 'cust_other', anonymous?: false, objid: 'objid_other')
+        logic = build_logic({ 'identifier' => secret.identifier, 'continue' => 'true' }, customer: other)
+        logic.process_params
+
+        # I18n default 'Cannot verify when logged in' -- pin only the class.
+        expect { logic.process }.to raise_error(Onetime::FormError)
+
+        reloaded = Onetime::Secret.load(secret.identifier)
+        expect(reloaded.state).to eq('new')
+        expect(reloaded.viewable?).to be true
+        expect(Onetime::Customer.load(owner.objid).verified?).to be false
+      end
+    end
+
+    context 'when a concurrent request already won the reveal (this request loses)' do
+      it 'still verifies the owner but does NOT emit the plaintext' do
+        logic = build_logic({ 'identifier' => secret.identifier, 'continue' => 'true' })
+        logic.process_params # loads this request's own :new instance
+
+        # Hold the race window open -- same recipe as the loser spec above: it
+        # must be reveal!'s atomic claim, not the viewable? guard, that
+        # withholds the plaintext.
+        allow(logic.secret).to receive(:viewable?).and_return(true)
+        winner = Onetime::Secret.load(secret.identifier)
+        expect(winner.revealed!).to be true
+
+        logic.process
+
+        expect(logic.show_secret).to be false
+        expect(logic.secret_value).to be_nil
+        expect(logic.success_data[:record]).not_to have_key(:secret_value)
+
+        # ASYMMETRY PIN -- intentional current behavior: the owner mutation
+        # runs BEFORE reveal!, so a losing racer still verifies the account.
+        # Verification is idempotent bookkeeping; only the PLAINTEXT is
+        # single-winner. If that ordering ever changes, these assertions force
+        # a conscious decision instead of a silent behavior shift.
+        reloaded = Onetime::Customer.load(owner.objid)
+        expect(reloaded.verified?).to be true
+        expect(reloaded.verified_by).to eq('email')
+      end
     end
   end
 end

--- a/apps/api/v2/spec/logic/secrets/reveal_secret_spec.rb
+++ b/apps/api/v2/spec/logic/secrets/reveal_secret_spec.rb
@@ -1,0 +1,85 @@
+# apps/api/v2/spec/logic/secrets/reveal_secret_spec.rb
+#
+# frozen_string_literal: true
+
+require_relative '../../../application'
+require_relative File.join(Onetime::HOME, 'spec', 'spec_helper')
+
+# Security regression coverage for the double-reveal race.
+#
+# Burn-after-reading requires that a secret's plaintext reach at most ONE
+# caller. Secret#revealed! performs an atomic compare-and-set claim and returns
+# true only to the caller that won it; RevealSecret#process must gate the
+# plaintext on that return value, so a request that LOST the race to a
+# concurrent reveal never emits secret_value.
+#
+# Uses real Receipt/Secret objects (spawn_pair) so the atomic claim runs
+# against Redis exactly as it does in production. process is exercised directly
+# (raise_concerns, which handles guest-gating/entitlements/rate-limits, is out
+# of scope here).
+RSpec.describe V2::Logic::Secrets::RevealSecret, type: :integration do
+  before(:all) do
+    require 'onetime'
+    Onetime.boot! :test
+  end
+
+  def mock_session
+    store = {}
+    session = double('Session')
+    allow(session).to receive(:[]) { |k| store[k] }
+    allow(session).to receive(:[]=) { |k, v| store[k] = v }
+    allow(session).to receive(:empty?).and_return(true)
+    session
+  end
+
+  # Build a RevealSecret over a real secret. process derives cust from
+  # strategy_result.user and never needs org (that is a raise_concerns concern).
+  def build_logic(params)
+    customer = double('Customer', custid: 'anon', anonymous?: true, objid: nil)
+    org      = double('Organization', objid: "org_#{SecureRandom.hex(4)}")
+    allow(org).to receive(:can?).and_return(true)
+
+    strategy_result = double('StrategyResult',
+      session: mock_session,
+      user: customer,
+      metadata: { organization: org },
+      auth_method: 'basicauth')
+
+    described_class.new(strategy_result, params)
+  end
+
+  let!(:pair)   { Onetime::Receipt.spawn_pair(nil, 3600, 'a secret value') }
+  let(:receipt) { pair.first }
+  let(:secret)  { pair.last }
+
+  context 'when this request wins the reveal (the normal case)' do
+    it 'returns the decrypted plaintext' do
+      logic = build_logic('identifier' => secret.identifier, 'continue' => 'true')
+      logic.process_params
+      logic.process
+
+      expect(logic.show_secret).to be true
+      expect(logic.secret_value).to eq('a secret value')
+      expect(logic.success_data[:record][:secret_value]).to eq('a secret value')
+    end
+  end
+
+  context 'when a concurrent request already won the reveal (this request loses)' do
+    it 'does NOT emit the plaintext' do
+      logic = build_logic('identifier' => secret.identifier, 'continue' => 'true')
+      logic.process_params # loads this request's own :new instance
+
+      # A concurrent request wins the atomic claim and consumes the secret
+      # between our load and our reveal.
+      winner = Onetime::Secret.load(secret.identifier)
+      expect(winner.revealed!).to be true
+
+      logic.process
+
+      # The losing request must withhold the plaintext, even though it had
+      # already decrypted its in-memory ciphertext before the reveal.
+      expect(logic.show_secret).to be false
+      expect(logic.success_data[:record]).not_to have_key(:secret_value)
+    end
+  end
+end

--- a/apps/api/v2/spec/logic/secrets/show_secret_spec.rb
+++ b/apps/api/v2/spec/logic/secrets/show_secret_spec.rb
@@ -1,0 +1,76 @@
+# apps/api/v2/spec/logic/secrets/show_secret_spec.rb
+#
+# frozen_string_literal: true
+
+require_relative '../../../application'
+require_relative File.join(Onetime::HOME, 'spec', 'spec_helper')
+
+# Security regression coverage for the double-reveal race (ShowSecret variant).
+#
+# ShowSecret#process reveals via its private reveal_secret/verify_owner helpers,
+# both of which return the value of Secret#revealed!. The gate must withhold the
+# plaintext whenever that atomic claim was lost to a concurrent reveal.
+#
+# See reveal_secret_spec.rb for the sibling RevealSecret coverage; the gate is
+# duplicated per controller by design (v1 legacy and each v2 endpoint own their
+# own copy rather than sharing a base implementation).
+RSpec.describe V2::Logic::Secrets::ShowSecret, type: :integration do
+  before(:all) do
+    require 'onetime'
+    Onetime.boot! :test
+  end
+
+  def mock_session
+    store = {}
+    session = double('Session')
+    allow(session).to receive(:[]) { |k| store[k] }
+    allow(session).to receive(:[]=) { |k, v| store[k] = v }
+    allow(session).to receive(:empty?).and_return(true)
+    session
+  end
+
+  def build_logic(params)
+    customer = double('Customer', custid: 'anon', anonymous?: true, objid: nil)
+    org      = double('Organization', objid: "org_#{SecureRandom.hex(4)}")
+    allow(org).to receive(:can?).and_return(true)
+
+    strategy_result = double('StrategyResult',
+      session: mock_session,
+      user: customer,
+      metadata: { organization: org },
+      auth_method: 'basicauth')
+
+    described_class.new(strategy_result, params)
+  end
+
+  let!(:pair)   { Onetime::Receipt.spawn_pair(nil, 3600, 'a secret value') }
+  let(:receipt) { pair.first }
+  let(:secret)  { pair.last }
+
+  context 'when this request wins the reveal (the normal case)' do
+    it 'returns the decrypted plaintext' do
+      logic = build_logic('identifier' => secret.identifier, 'continue' => 'true')
+      logic.process_params
+      logic.process
+
+      expect(logic.show_secret).to be true
+      expect(logic.secret_value).to eq('a secret value')
+      expect(logic.success_data[:record][:secret_value]).to eq('a secret value')
+    end
+  end
+
+  context 'when a concurrent request already won the reveal (this request loses)' do
+    it 'does NOT emit the plaintext' do
+      logic = build_logic('identifier' => secret.identifier, 'continue' => 'true')
+      logic.process_params # loads this request's own :new instance
+
+      winner = Onetime::Secret.load(secret.identifier)
+      expect(winner.revealed!).to be true
+
+      logic.process
+
+      expect(logic.show_secret).to be false
+      expect(logic.success_data[:record]).not_to have_key(:secret_value)
+    end
+  end
+end

--- a/apps/api/v2/spec/logic/secrets/show_secret_spec.rb
+++ b/apps/api/v2/spec/logic/secrets/show_secret_spec.rb
@@ -29,8 +29,11 @@ RSpec.describe V2::Logic::Secrets::ShowSecret, type: :integration do
     session
   end
 
-  def build_logic(params)
-    customer = double('Customer', custid: 'anon', anonymous?: true, objid: nil)
+  # customer: overrides the default anonymous caller for the verification
+  # branches that depend on who is logged in. Pass params as a braced hash --
+  # the customer: kwarg would otherwise swallow a bare trailing hash.
+  def build_logic(params, customer: nil)
+    customer ||= double('Customer', custid: 'anon', anonymous?: true, objid: nil)
     org      = double('Organization', objid: "org_#{SecureRandom.hex(4)}")
     allow(org).to receive(:can?).and_return(true)
 
@@ -43,13 +46,26 @@ RSpec.describe V2::Logic::Secrets::ShowSecret, type: :integration do
     described_class.new(strategy_result, params)
   end
 
+  # Mark a spawned secret as a verification secret the way production does it
+  # post-creation (lib/onetime/logic/base.rb send_verification_email,
+  # apps/api/account/logic/account/request_email_change.rb:119-126). Partial
+  # write on purpose -- save_fields HSETs only :verification and never
+  # re-serializes the already-persisted ciphertext (house convention, cf.
+  # lib/onetime/models/features/passphrase_hashing.rb:23-26). Must run BEFORE
+  # build_logic: process_params fires in the Base constructor and loads its
+  # own instance from Redis.
+  def flag_as_verification!(secret)
+    secret.verification = 'true'
+    secret.save_fields(:verification)
+  end
+
   let!(:pair)   { Onetime::Receipt.spawn_pair(nil, 3600, 'a secret value') }
   let(:receipt) { pair.first }
   let(:secret)  { pair.last }
 
   context 'when this request wins the reveal (the normal case)' do
     it 'returns the decrypted plaintext' do
-      logic = build_logic('identifier' => secret.identifier, 'continue' => 'true')
+      logic = build_logic({ 'identifier' => secret.identifier, 'continue' => 'true' })
       logic.process_params
       logic.process
 
@@ -61,7 +77,7 @@ RSpec.describe V2::Logic::Secrets::ShowSecret, type: :integration do
 
   context 'when a concurrent request already won the reveal (this request loses)' do
     it 'does NOT emit the plaintext' do
-      logic = build_logic('identifier' => secret.identifier, 'continue' => 'true')
+      logic = build_logic({ 'identifier' => secret.identifier, 'continue' => 'true' })
       logic.process_params # loads this request's own :new instance
 
       # Hold viewable? true so process takes the reveal path and it is
@@ -76,6 +92,142 @@ RSpec.describe V2::Logic::Secrets::ShowSecret, type: :integration do
       expect(logic.show_secret).to be false
       expect(logic.secret_value).to be_nil
       expect(logic.success_data[:record]).not_to have_key(:secret_value)
+    end
+  end
+
+  # Verification-flow coverage (verify_owner). verify_owner has no nil/
+  # anonymous-owner guards -- it dereferences owner unconditionally -- so
+  # every ShowSecret verification spec uses a real persisted owner. The
+  # owner-nil and owner-anonymous error branches exist only in RevealSecret;
+  # see reveal_secret_spec.rb for those.
+  context 'when the secret is a verification secret' do
+    # Unverified by default. Unique email each run -- the customer email index
+    # in the shared test Redis persists across runs.
+    let(:owner) do
+      Onetime::Customer.create!(email: "show-verify-#{SecureRandom.hex(6)}@example.com")
+    end
+    let!(:pair) { Onetime::Receipt.spawn_pair(owner.objid, 3600, 'a secret value') }
+
+    before { flag_as_verification!(secret) }
+
+    context 'when an anonymous caller verifies the unverified owner' do
+      it 'verifies the owner and reveals the plaintext' do
+        logic = build_logic({ 'identifier' => secret.identifier, 'continue' => 'true' })
+        logic.process_params
+        logic.process
+
+        expect(logic.show_secret).to be true
+        expect(logic.secret_value).to eq('a secret value')
+        expect(logic.success_data[:record][:secret_value]).to eq('a secret value')
+
+        # Unlike RevealSecret, verify_owner does not delete reset_secret.
+        reloaded = Onetime::Customer.load(owner.objid)
+        expect(reloaded.verified?).to be true
+        expect(reloaded.verified_by).to eq('email')
+
+        # Consumed: the won claim leaves the in-memory state 'revealed', so
+        # the trailing `previewed! if state?(:new)` cannot resurrect it.
+        expect(Onetime::Secret.load(secret.identifier)).to be_nil
+      end
+    end
+
+    context 'when logged in as the unverified owner' do
+      # Second half of verify_owner's disjunction (cust.custid == owner.custid
+      # && !owner.verified?). Covered here as well as in RevealSecret because
+      # the reveal gate is duplicated per controller by design -- ShowSecret's
+      # copy would otherwise be exercised nowhere.
+      it 'verifies the owner and reveals the plaintext' do
+        as_owner = double('Customer', custid: owner.custid, anonymous?: false, objid: owner.objid)
+        logic    = build_logic({ 'identifier' => secret.identifier, 'continue' => 'true' }, customer: as_owner)
+        logic.process_params
+        logic.process
+
+        expect(logic.show_secret).to be true
+        expect(logic.success_data[:record][:secret_value]).to eq('a secret value')
+
+        reloaded = Onetime::Customer.load(owner.objid)
+        expect(reloaded.verified?).to be true
+        expect(reloaded.verified_by).to eq('email')
+        expect(Onetime::Secret.load(secret.identifier)).to be_nil
+      end
+    end
+
+    context 'when the owner is already verified' do
+      # DIVERGENCE PIN -- current behavior, candidate for alignment:
+      # verify_owner has no already-verified guard (its condition passes on
+      # anonymous_user? alone), so an anonymous caller RE-verifies a verified
+      # owner and overwrites verified_by provenance with 'email'. RevealSecret
+      # treats the same input as an anomaly and leaves the owner untouched
+      # (reveal_secret_spec.rb pins 'stripe_payment' preserved there). If
+      # either controller changes, one of the two pins fails and forces a
+      # conscious decision instead of a silent behavior shift.
+      it 'reveals the plaintext and (unlike RevealSecret) overwrites verified_by' do
+        owner.verified    = true
+        owner.verified_by = 'stripe_payment'
+        owner.save
+        logic = build_logic({ 'identifier' => secret.identifier, 'continue' => 'true' })
+        logic.process_params
+        logic.process
+
+        expect(logic.show_secret).to be true
+        expect(logic.secret_value).to eq('a secret value')
+
+        reloaded = Onetime::Customer.load(owner.objid)
+        expect(reloaded.verified?).to be true
+        expect(reloaded.verified_by).to eq('email') # provenance rewritten
+        expect(Onetime::Secret.load(secret.identifier)).to be_nil
+      end
+    end
+
+    context 'when already logged in as a different user' do
+      it 'raises a form error and neither consumes nor previews the secret' do
+        other = double('Customer', custid: 'cust_other', anonymous?: false, objid: 'objid_other')
+        logic = build_logic({ 'identifier' => secret.identifier, 'continue' => 'true' }, customer: other)
+        logic.process_params
+
+        # Hardcoded message (not i18n) -- safe to match.
+        expect { logic.process }.to raise_error(Onetime::FormError, /already logged in/)
+
+        # The raise short-circuits before the trailing previewed!, so the
+        # secret stays :new and viewable.
+        reloaded = Onetime::Secret.load(secret.identifier)
+        expect(reloaded.state).to eq('new')
+        expect(reloaded.viewable?).to be true
+        expect(Onetime::Customer.load(owner.objid).verified?).to be false
+      end
+    end
+
+    context 'when a concurrent request already won the reveal (this request loses)' do
+      it 'still verifies the owner but does NOT emit the plaintext' do
+        logic = build_logic({ 'identifier' => secret.identifier, 'continue' => 'true' })
+        logic.process_params # loads this request's own :new instance
+
+        # Hold the race window open -- same recipe as the loser spec above: it
+        # must be reveal!'s atomic claim, not the viewable? guard, that
+        # withholds the plaintext.
+        allow(logic.secret).to receive(:viewable?).and_return(true)
+        winner = Onetime::Secret.load(secret.identifier)
+        expect(winner.revealed!).to be true
+
+        logic.process
+
+        expect(logic.show_secret).to be false
+        expect(logic.secret_value).to be_nil
+        expect(logic.success_data[:record]).not_to have_key(:secret_value)
+
+        # ASYMMETRY PIN -- intentional current behavior: verify_owner mutates
+        # the owner BEFORE secret.reveal!, so a losing racer still verifies
+        # the account. Verification is idempotent bookkeeping; only the
+        # PLAINTEXT is single-winner. If that ordering ever changes, these
+        # assertions force a conscious decision instead of a silent shift.
+        reloaded = Onetime::Customer.load(owner.objid)
+        expect(reloaded.verified?).to be true
+        expect(reloaded.verified_by).to eq('email')
+
+        # The lost claim marks the loser's in-memory state 'revealed', so the
+        # trailing previewed! is skipped -- the destroyed record stays gone.
+        expect(Onetime::Secret.load(secret.identifier)).to be_nil
+      end
     end
   end
 end

--- a/apps/api/v2/spec/logic/secrets/show_secret_spec.rb
+++ b/apps/api/v2/spec/logic/secrets/show_secret_spec.rb
@@ -64,12 +64,17 @@ RSpec.describe V2::Logic::Secrets::ShowSecret, type: :integration do
       logic = build_logic('identifier' => secret.identifier, 'continue' => 'true')
       logic.process_params # loads this request's own :new instance
 
+      # Hold viewable? true so process takes the reveal path and it is
+      # secret.reveal! (not the viewable? guard) that withholds the plaintext by
+      # losing the atomic claim to the concurrent winner. See reveal_secret_spec.
+      allow(logic.secret).to receive(:viewable?).and_return(true)
       winner = Onetime::Secret.load(secret.identifier)
       expect(winner.revealed!).to be true
 
       logic.process
 
       expect(logic.show_secret).to be false
+      expect(logic.secret_value).to be_nil
       expect(logic.success_data[:record]).not_to have_key(:secret_value)
     end
   end

--- a/changelog.d/20260702_191714_claude_double_reveal_race.rst
+++ b/changelog.d/20260702_191714_claude_double_reveal_race.rst
@@ -1,0 +1,27 @@
+.. A new scriv changelog fragment.
+
+Security
+--------
+
+- Fixed a double-reveal race on burn-after-reading secrets (CWE-362). Two
+  concurrent requests to the same secret link could both pass the viewability
+  check, decrypt, and return the plaintext before either destroyed the record,
+  so a "view once" secret could be disclosed to more than one recipient —
+  defeating the core product promise. Revealing or burning a secret now claims
+  it with an atomic compare-and-set in the datastore, so exactly one caller may
+  consume it; any request that loses the race receives no secret value.
+
+- Closed a related re-exposure window. Recording that a secret link had been
+  viewed wrote the secret's state unconditionally, which could momentarily
+  revert a just-revealed secret back to a viewable state while its ciphertext
+  still existed, and could recreate a secret that a concurrent reveal or burn
+  had already destroyed. The state transition is now atomic and can neither
+  revert a consumed secret nor recreate a destroyed one.
+
+Changed
+-------
+
+- Viewing a secret link no longer resets the secret's expiration. Previously
+  each view extended the time-to-live back to the full lifespan, so a
+  repeatedly-viewed link could outlive its intended expiry; secrets now always
+  expire on their original schedule regardless of how often the link is viewed.

--- a/changelog.d/20260702_191714_claude_double_reveal_race.rst
+++ b/changelog.d/20260702_191714_claude_double_reveal_race.rst
@@ -11,6 +11,9 @@ Security
   it with an atomic compare-and-set in the datastore, so exactly one caller may
   consume it; any request that loses the race receives no secret value.
 
+- A burn request that loses the race no longer counts toward burn metrics nor
+  reports success to the caller.
+
 - Closed a related re-exposure window. Recording that a secret link had been
   viewed wrote the secret's state unconditionally, which could momentarily
   revert a just-revealed secret back to a viewable state while its ciphertext

--- a/lib/onetime/models/secret/features/secret_state_management.rb
+++ b/lib/onetime/models/secret/features/secret_state_management.rb
@@ -177,11 +177,21 @@ module Onetime::Secret::Features
       # @return [Boolean] true iff this caller performed the state transition.
       def win_reveal_claim!
         return false unless state?(:new) || state?(:previewed)
-        return true if compare_and_set_state!(:revealed, [:new, :previewed])
 
-        @state      = 'revealed'
-        @ciphertext = nil
-        false
+        unless compare_and_set_state!(:revealed, [:new, :previewed])
+          # Lost the claim: mark the instance terminal so viewable?/safe_dump
+          # reflect reality and the ciphertext is withheld.
+          @state      = 'revealed'
+          @ciphertext = nil
+          return false
+        end
+
+        # Won the claim: reflect the persisted transition in memory now so a
+        # state?/viewable? read between the claim and consume_after_reveal! is
+        # accurate (no winner/loser asymmetry). Ciphertext is intentionally
+        # retained here so reveal! can still decrypt; consume clears it.
+        @state = 'revealed'
+        true
       end
 
       # Post-claim consumption shared by {#revealed!} and {#reveal!}: cascade
@@ -225,6 +235,10 @@ module Onetime::Secret::Features
       # Operands are produced with #serialize_value so they match how +state+
       # is encoded at rest (Familia JSON-encodes scalar fields for type
       # preservation), rather than hard-coding the on-disk representation here.
+      # The eval uses the keyword +keys:+/+argv:+ form (the convention used
+      # elsewhere in the codebase, e.g. error_handler and the rate limiters) so
+      # it does not depend on positional-argument compatibility across Redis
+      # client versions.
       #
       # @param to_state [Symbol, String] state to set on success.
       # @param from_states [Array<Symbol, String>] states the flip may fire from.
@@ -233,7 +247,7 @@ module Onetime::Secret::Features
         argv = [serialize_value(to_state.to_s)]
         from_states.each { |state| argv << serialize_value(state.to_s) }
 
-        dbclient.eval(STATE_CAS_SCRIPT, [dbkey], argv).to_i == 1
+        dbclient.eval(STATE_CAS_SCRIPT, keys: [dbkey], argv: argv).to_i == 1
       end
     end
   end

--- a/lib/onetime/models/secret/features/secret_state_management.rb
+++ b/lib/onetime/models/secret/features/secret_state_management.rb
@@ -159,6 +159,13 @@ module Onetime::Secret::Features
       # {Familia::Lock#release} uses, reached through the connection resolver
       # via +dbclient+.
       #
+      # A CAS on +state+ rather than a Familia::Lock because the +state+ field
+      # is its own winner token: no second key, no TTL, and no expiry window
+      # where a slow reveal outlives the lock and a second caller slips in.
+      # Once flipped, +state+ can never read as revealable again -- the guard
+      # fails closed, as a one-shot security transition must. A mutex would
+      # only serialize callers; it would still need this exact check inside it.
+      #
       # The comparison operands are produced with #serialize_value so they
       # match exactly how the +state+ field is encoded at rest (Familia
       # JSON-encodes scalar fields for type preservation), rather than

--- a/lib/onetime/models/secret/features/secret_state_management.rb
+++ b/lib/onetime/models/secret/features/secret_state_management.rb
@@ -82,40 +82,44 @@ module Onetime::Secret::Features
       # return value). The in-memory check is kept as a cheap fast-path that
       # short-circuits an already-terminal instance before touching Redis.
       #
+      # Consume the secret WITHOUT returning its plaintext. For callers that
+      # only need to mark the secret revealed and expunge it -- e.g. account
+      # verification, or the legacy v1 flow which decrypts separately and then
+      # gates its own output. Read controllers that must hand back the plaintext
+      # should prefer {#reveal!}, which cannot be decoupled from the claim.
+      #
       # @return [Boolean] true if THIS caller performed the reveal, false if a
       #   concurrent caller won the race or the secret was already terminal.
       def revealed!
-        # A guard to allow only a fresh, new secret to be revealed. Also ensures that
-        # we don't support going from :previewed back to something else.
-        return false unless state?(:new) || state?(:previewed)
+        return false unless win_reveal_claim!
 
-        # Atomic gate: only the caller that wins the compare-and-set proceeds.
-        unless compare_and_set_state!(:revealed, [:new, :previewed])
-          # Lost the race: a concurrent caller already terminalized this
-          # secret. Mark THIS in-memory instance terminal so its viewable? and
-          # safe_dump reflect reality; the plaintext is withheld by returning
-          # false, which the reveal controllers gate on. (previewed! is itself
-          # non-resurrecting now, so this is about presenting accurate loser
-          # state, not the sole guard against re-creating the destroyed key.)
-          @state      = 'revealed'
-          @ciphertext = nil
-          return false
-        end
-
-        md               = load_receipt
-        md.revealed! unless md.nil?
-        # It's important for the state to change here, even though we're about to
-        # destroy the secret. This is because the state is used to determine if
-        # the secret is viewable. If we don't change the state here, the secret
-        # will still be viewable b/c (state?(:new) || state?(:previewed) == true).
-        @state           = 'revealed'
-        # Clear ciphertext so the payload is not recoverable from this
-        # instance. We don't clear arbitrary fields because safe_dump
-        # and success_data still read state, lifespan, etc.
-        @ciphertext      = nil
-        @passphrase_temp = nil
-        destroy!
+        consume_after_reveal!
         true
+      end
+
+      # Reveal-and-fetch: atomically claim the one-shot reveal and, ONLY on
+      # winning, decrypt and return the plaintext; then cascade the receipt and
+      # destroy the record. A losing (or already-terminal) caller gets +nil+.
+      #
+      # This is the plaintext-returning sibling of {#revealed!} and the
+      # preferred entry point for read controllers: because decryption happens
+      # inside the won-claim branch, a caller cannot obtain the plaintext
+      # without also winning the single permitted reveal. There is no separate
+      # "decrypt" step for a controller to forget to gate -- the burn-after-
+      # reading invariant is enforced here by construction rather than by each
+      # call site remembering to check a boolean.
+      #
+      # @param passphrase_input [String, nil] passphrase supplied by the caller,
+      #   forwarded to decryption.
+      # @return [String, nil] the decrypted plaintext for the single winning
+      #   caller; nil for a loser or an already-terminal secret.
+      def reveal!(passphrase_input: nil)
+        return unless win_reveal_claim!
+
+        # Decrypt from the still-in-memory ciphertext BEFORE consume clears it.
+        plaintext = decrypted_secret_value(passphrase_input: passphrase_input)
+        consume_after_reveal!
+        plaintext
       end
 
       # @return [Boolean] true if THIS caller performed the burn, false if a
@@ -160,6 +164,46 @@ module Onetime::Secret::Features
       LUA
 
       private
+
+      # Atomic claim shared by {#revealed!} and {#reveal!}. Returns true iff
+      # THIS caller won the one-and-only reveal. On loss (a concurrent caller
+      # already terminalized the secret) it marks the in-memory instance
+      # terminal so its viewable?/safe_dump reflect reality and its plaintext
+      # stays withheld; the in-memory check above is a cheap fast-path before
+      # touching Redis. (previewed! is itself non-resurrecting, so marking
+      # state here is about presenting accurate loser state, not the sole guard
+      # against re-creating the destroyed key.)
+      #
+      # @return [Boolean] true iff this caller performed the state transition.
+      def win_reveal_claim!
+        return false unless state?(:new) || state?(:previewed)
+        return true if compare_and_set_state!(:revealed, [:new, :previewed])
+
+        @state      = 'revealed'
+        @ciphertext = nil
+        false
+      end
+
+      # Post-claim consumption shared by {#revealed!} and {#reveal!}: cascade
+      # the receipt to revealed and destroy the record. Assumes the caller has
+      # already won the claim via {#win_reveal_claim!}.
+      #
+      # The in-memory state is set to 'revealed' even though the record is about
+      # to be destroyed: state drives viewable?, so leaving it revealable would
+      # keep a just-consumed instance readable. Ciphertext is cleared so the
+      # payload is not recoverable from this instance; other fields (state,
+      # lifespan, ...) remain for safe_dump / success_data.
+      #
+      # @return [void]
+      def consume_after_reveal!
+        md = load_receipt
+        md.revealed! unless md.nil?
+
+        @state           = 'revealed'
+        @ciphertext      = nil
+        @passphrase_temp = nil
+        destroy!
+      end
 
       # Atomically transition the persisted +state+ field from one of
       # +from_states+ to +to_state+, returning whether THIS caller performed

--- a/lib/onetime/models/secret/features/secret_state_management.rb
+++ b/lib/onetime/models/secret/features/secret_state_management.rb
@@ -42,16 +42,27 @@ module Onetime::Secret::Features
       # MIGRATION NOTE: This method replaces the legacy `viewed!` method.
       # Existing data with state='viewed' should be migrated to state='previewed'.
       # The `viewed` timestamp field maps to the new `previewed` field.
+      #
+      # Records that the secret link was accessed (but not yet consumed) by
+      # flipping state :new -> :previewed with an atomic, NON-creating CAS.
+      # Unlike the former save_fields(:state) -- an unconditional HSET that
+      # recreates the key if absent -- this transition:
+      #   * cannot resurrect a secret a concurrent reveal/burn already
+      #     destroyed (HGET on a missing key matches nothing), and
+      #   * cannot revert a secret that has already reached a terminal state
+      #     (it fires only from :new); the old unconditional write could briefly
+      #     revert a revealed-but-not-yet-destroyed record to :previewed and
+      #     re-open viewability while its ciphertext still existed.
+      # It also no longer resets the secret's TTL on preview: a merely-viewed
+      # link must not extend a burn-after-reading secret's lifetime -- which is
+      # both safer and what this method's comment always claimed to do.
       def previewed!
-        # A guard to prevent regressing (e.g. from :burned back to :previewed)
+        # Fast-path guard on in-memory state; the CAS below is the authority.
         return unless state?(:new)
 
-        # The secret link has been accessed but the secret has not been consumed yet
+        return unless compare_and_set_state!(:previewed, [:new])
+
         @state = 'previewed'
-        # Only save the state field — a full save would re-serialize encrypted
-        # fields (ciphertext), corrupting them via double-encryption. Using
-        # save_fields also avoids resetting the TTL.
-        save_fields(:state)
       end
 
       # MIGRATION NOTE: This method replaces the legacy `received!` method.
@@ -64,7 +75,7 @@ module Onetime::Secret::Features
       # and -- without an atomic guard -- both pass the check below, both
       # decrypt, and both destroy, handing the plaintext to two clients.
       #
-      # {#claim_terminal_transition!} closes that race with an atomic
+      # {#compare_and_set_state!} closes that race with an atomic
       # compare-and-set in Redis: of any number of racing callers, exactly one
       # wins the claim and is permitted to reveal; the rest get +false+ and
       # must not emit the plaintext (the reveal controllers gate on this
@@ -79,14 +90,13 @@ module Onetime::Secret::Features
         return false unless state?(:new) || state?(:previewed)
 
         # Atomic gate: only the caller that wins the compare-and-set proceeds.
-        unless claim_terminal_transition!(:revealed)
-          # Lost the race: a concurrent caller already terminalized (and is
-          # destroying) this secret. Mark THIS in-memory instance terminal so
-          # (a) it is no longer viewable? and (b) a downstream
-          # `previewed! if state?(:new)` cannot fire -- that would HSET the
-          # `state` field and resurrect the key the winner just destroyed.
-          # The pre-atomic code left every caller with state='revealed' for
-          # the same reason; we preserve that invariant on the losing path.
+        unless compare_and_set_state!(:revealed, [:new, :previewed])
+          # Lost the race: a concurrent caller already terminalized this
+          # secret. Mark THIS in-memory instance terminal so its viewable? and
+          # safe_dump reflect reality; the plaintext is withheld by returning
+          # false, which the reveal controllers gate on. (previewed! is itself
+          # non-resurrecting now, so this is about presenting accurate loser
+          # state, not the sole guard against re-creating the destroyed key.)
           @state      = 'revealed'
           @ciphertext = nil
           return false
@@ -118,7 +128,7 @@ module Onetime::Secret::Features
         # Atomic gate: see revealed!. A double-burn is not a plaintext leak,
         # but the CAS still guarantees the receipt cascade and any caller-side
         # bookkeeping (e.g. secrets_burned counters) happen exactly once.
-        return false unless claim_terminal_transition!(:burned)
+        return false unless compare_and_set_state!(:burned, [:new, :previewed])
 
         md               = load_receipt
         md.burned! unless md.nil?
@@ -131,60 +141,55 @@ module Onetime::Secret::Features
       alias viewed! previewed!
       alias received! revealed!
 
-      # Lua compare-and-set, executed atomically by Redis. Returns 1 to the
-      # single caller that moves +state+ out of a revealable value, 0 to
-      # everyone else (including when the key or field is already gone, where
-      # HGET returns a Lua false that matches neither revealable marker).
-      CLAIM_TERMINAL_TRANSITION_SCRIPT = <<~LUA
+      # Lua compare-and-set on the +state+ field, run atomically by Redis (its
+      # command loop is single-threaded). Sets state to ARGV[1] iff the current
+      # value equals one of ARGV[2..]. Returns 1 to the single caller that
+      # performs the flip, 0 to everyone else -- including when the key/field is
+      # gone (HGET yields a Lua false that matches nothing, so a destroyed
+      # record is never resurrected) and when the state has already advanced
+      # (so a terminal state is never reverted).
+      STATE_CAS_SCRIPT = <<~LUA
         local current = redis.call('HGET', KEYS[1], 'state')
-        if current == ARGV[1] or current == ARGV[2] then
-          redis.call('HSET', KEYS[1], 'state', ARGV[3])
-          return 1
+        for i = 2, #ARGV do
+          if current == ARGV[i] then
+            redis.call('HSET', KEYS[1], 'state', ARGV[1])
+            return 1
+          end
         end
         return 0
       LUA
 
       private
 
-      # Atomically claims the one-and-only terminal transition for this
-      # secret, guarding against the double-reveal / double-burn race.
+      # Atomically transition the persisted +state+ field from one of
+      # +from_states+ to +to_state+, returning whether THIS caller performed
+      # the flip. This is the single concurrency primitive behind every state
+      # transition on a Secret; each caller documents what its own transition
+      # guards against.
       #
-      # Redis runs the Lua script atomically (its command loop is
-      # single-threaded), so of any number of concurrent callers exactly one
-      # can observe the persisted +state+ field as still revealable
-      # (:new / :previewed) and flip it to the terminal marker. Every other
-      # caller -- including one that arrives after the key has already been
-      # destroyed, where HGET yields no value -- sees a non-revealable state
-      # and loses. This is the same compare-and-set idiom Familia's
+      # Because Redis executes the Lua script atomically, of any number of
+      # racing callers exactly one observes an allowed +from+ value and flips
+      # it. This is the same compare-and-set idiom Familia's
       # {Familia::Lock#release} uses, reached through the connection resolver
-      # via +dbclient+.
+      # via +dbclient+ -- but on the record's own +state+ field rather than a
+      # separate lock key, so there is no second key, no TTL, and no expiry
+      # window where a slow critical section outlives the lock and a second
+      # caller slips in. It fails closed: a missing key (destroyed) or an
+      # already-advanced state simply loses, so the transition can neither
+      # resurrect nor revert a record.
       #
-      # A CAS on +state+ rather than a Familia::Lock because the +state+ field
-      # is its own winner token: no second key, no TTL, and no expiry window
-      # where a slow reveal outlives the lock and a second caller slips in.
-      # Once flipped, +state+ can never read as revealable again -- the guard
-      # fails closed, as a one-shot security transition must. A mutex would
-      # only serialize callers; it would still need this exact check inside it.
+      # Operands are produced with #serialize_value so they match how +state+
+      # is encoded at rest (Familia JSON-encodes scalar fields for type
+      # preservation), rather than hard-coding the on-disk representation here.
       #
-      # The comparison operands are produced with #serialize_value so they
-      # match exactly how the +state+ field is encoded at rest (Familia
-      # JSON-encodes scalar fields for type preservation), rather than
-      # hard-coding the on-disk representation here.
-      #
-      # @param claimed_state [Symbol, String] terminal marker to set
-      #   (:revealed / :burned).
-      # @return [Boolean] true if this caller won the claim, false otherwise.
-      def claim_terminal_transition!(claimed_state)
-        new_enc       = serialize_value('new')
-        previewed_enc = serialize_value('previewed')
-        claimed_enc   = serialize_value(claimed_state.to_s)
+      # @param to_state [Symbol, String] state to set on success.
+      # @param from_states [Array<Symbol, String>] states the flip may fire from.
+      # @return [Boolean] true iff this caller performed the transition.
+      def compare_and_set_state!(to_state, from_states)
+        argv = [serialize_value(to_state.to_s)]
+        from_states.each { |state| argv << serialize_value(state.to_s) }
 
-        outcome = dbclient.eval(
-          CLAIM_TERMINAL_TRANSITION_SCRIPT,
-          [dbkey],
-          [new_enc, previewed_enc, claimed_enc],
-        )
-        outcome.to_i == 1
+        dbclient.eval(STATE_CAS_SCRIPT, [dbkey], argv).to_i == 1
       end
     end
   end

--- a/lib/onetime/models/secret/features/secret_state_management.rb
+++ b/lib/onetime/models/secret/features/secret_state_management.rb
@@ -57,10 +57,40 @@ module Onetime::Secret::Features
       # MIGRATION NOTE: This method replaces the legacy `received!` method.
       # Existing data with state='received' should be migrated to state='revealed'.
       # The `received` timestamp field maps to the new `revealed` field.
+      #
+      # Burn-after-reading is the core product promise: a secret must be
+      # revealed to at most ONE caller. Two concurrent reveal requests both
+      # load the same secret, both read an in-memory state of :new/:previewed,
+      # and -- without an atomic guard -- both pass the check below, both
+      # decrypt, and both destroy, handing the plaintext to two clients.
+      #
+      # {#claim_terminal_transition!} closes that race with an atomic
+      # compare-and-set in Redis: of any number of racing callers, exactly one
+      # wins the claim and is permitted to reveal; the rest get +false+ and
+      # must not emit the plaintext (the reveal controllers gate on this
+      # return value). The in-memory check is kept as a cheap fast-path that
+      # short-circuits an already-terminal instance before touching Redis.
+      #
+      # @return [Boolean] true if THIS caller performed the reveal, false if a
+      #   concurrent caller won the race or the secret was already terminal.
       def revealed!
         # A guard to allow only a fresh, new secret to be revealed. Also ensures that
         # we don't support going from :previewed back to something else.
-        return unless state?(:new) || state?(:previewed)
+        return false unless state?(:new) || state?(:previewed)
+
+        # Atomic gate: only the caller that wins the compare-and-set proceeds.
+        unless claim_terminal_transition!(:revealed)
+          # Lost the race: a concurrent caller already terminalized (and is
+          # destroying) this secret. Mark THIS in-memory instance terminal so
+          # (a) it is no longer viewable? and (b) a downstream
+          # `previewed! if state?(:new)` cannot fire -- that would HSET the
+          # `state` field and resurrect the key the winner just destroyed.
+          # The pre-atomic code left every caller with state='revealed' for
+          # the same reason; we preserve that invariant on the losing path.
+          @state      = 'revealed'
+          @ciphertext = nil
+          return false
+        end
 
         md               = load_receipt
         md.revealed! unless md.nil?
@@ -75,22 +105,80 @@ module Onetime::Secret::Features
         @ciphertext      = nil
         @passphrase_temp = nil
         destroy!
+        true
       end
 
+      # @return [Boolean] true if THIS caller performed the burn, false if a
+      #   concurrent caller won the race or the secret was already terminal.
       def burned!
         # A guard to allow only a fresh, new secret to be burned. Also ensures that
         # we don't support going from :burned back to something else.
-        return unless state?(:new) || state?(:previewed)
+        return false unless state?(:new) || state?(:previewed)
+
+        # Atomic gate: see revealed!. A double-burn is not a plaintext leak,
+        # but the CAS still guarantees the receipt cascade and any caller-side
+        # bookkeeping (e.g. secrets_burned counters) happen exactly once.
+        return false unless claim_terminal_transition!(:burned)
 
         md               = load_receipt
         md.burned! unless md.nil?
         @passphrase_temp = nil
         destroy!
+        true
       end
 
       # Backward compatibility aliases for legacy method names
       alias viewed! previewed!
       alias received! revealed!
+
+      # Lua compare-and-set, executed atomically by Redis. Returns 1 to the
+      # single caller that moves +state+ out of a revealable value, 0 to
+      # everyone else (including when the key or field is already gone, where
+      # HGET returns a Lua false that matches neither revealable marker).
+      CLAIM_TERMINAL_TRANSITION_SCRIPT = <<~LUA
+        local current = redis.call('HGET', KEYS[1], 'state')
+        if current == ARGV[1] or current == ARGV[2] then
+          redis.call('HSET', KEYS[1], 'state', ARGV[3])
+          return 1
+        end
+        return 0
+      LUA
+
+      private
+
+      # Atomically claims the one-and-only terminal transition for this
+      # secret, guarding against the double-reveal / double-burn race.
+      #
+      # Redis runs the Lua script atomically (its command loop is
+      # single-threaded), so of any number of concurrent callers exactly one
+      # can observe the persisted +state+ field as still revealable
+      # (:new / :previewed) and flip it to the terminal marker. Every other
+      # caller -- including one that arrives after the key has already been
+      # destroyed, where HGET yields no value -- sees a non-revealable state
+      # and loses. This is the same compare-and-set idiom Familia's
+      # {Familia::Lock#release} uses, reached through the connection resolver
+      # via +dbclient+.
+      #
+      # The comparison operands are produced with #serialize_value so they
+      # match exactly how the +state+ field is encoded at rest (Familia
+      # JSON-encodes scalar fields for type preservation), rather than
+      # hard-coding the on-disk representation here.
+      #
+      # @param claimed_state [Symbol, String] terminal marker to set
+      #   (:revealed / :burned).
+      # @return [Boolean] true if this caller won the claim, false otherwise.
+      def claim_terminal_transition!(claimed_state)
+        new_enc       = serialize_value('new')
+        previewed_enc = serialize_value('previewed')
+        claimed_enc   = serialize_value(claimed_state.to_s)
+
+        outcome = dbclient.eval(
+          CLAIM_TERMINAL_TRANSITION_SCRIPT,
+          [dbkey],
+          [new_enc, previewed_enc, claimed_enc],
+        )
+        outcome.to_i == 1
+      end
     end
   end
 end

--- a/try/unit/models/secret_double_reveal_race_try.rb
+++ b/try/unit/models/secret_double_reveal_race_try.rb
@@ -115,3 +115,28 @@ Onetime::Secret.load(secret.identifier).previewed!       # persisted advances to
 stale.previewed!                                          # must be a no-op (persisted != new)
 Onetime::Secret.load(secret.identifier).state
 #=> 'previewed'
+
+# ----------------------------------------------------------------
+# reveal! couples the atomic claim with decryption: only the winner gets the
+# plaintext, so a caller cannot obtain it without winning the one-shot reveal.
+# ----------------------------------------------------------------
+
+## reveal! returns the decrypted plaintext to the sole winner and destroys it.
+receipt, secret = Onetime::Receipt.spawn_pair 'anon', 3600, 'top secret value'
+s = Onetime::Secret.load(secret.identifier)
+[s.reveal!, s.exists?]
+#=> ['top secret value', false]
+
+## concurrent reveal!: exactly one instance gets the plaintext, the other nil.
+receipt, secret = Onetime::Receipt.spawn_pair 'anon', 3600, 'top secret value'
+s1 = Onetime::Secret.load(secret.identifier)
+s2 = Onetime::Secret.load(secret.identifier)
+values = [s1.reveal!, s2.reveal!]
+[values.count('top secret value'), values.count(nil)]
+#=> [1, 1]
+
+## reveal! on an already-consumed secret returns nil (no second disclosure).
+receipt, secret = Onetime::Receipt.spawn_pair 'anon', 3600, 'top secret value'
+Onetime::Secret.load(secret.identifier).reveal!    # first (winning) reveal
+Onetime::Secret.load(secret.identifier)&.reveal!
+#=> nil

--- a/try/unit/models/secret_double_reveal_race_try.rb
+++ b/try/unit/models/secret_double_reveal_race_try.rb
@@ -1,0 +1,93 @@
+# try/unit/models/secret_double_reveal_race_try.rb
+#
+# frozen_string_literal: true
+
+# Regression tryouts for the double-reveal race on burn-after-reading secrets.
+#
+# Burn-after-reading is the core product promise: a secret may be revealed to
+# at most ONE caller. Before the atomic guard, two concurrent requests could
+# each load the same secret, each observe an in-memory state of :new/:previewed,
+# and each pass the guard in revealed!/burned! -- decrypting and destroying in
+# lockstep and handing the plaintext to BOTH clients.
+#
+# revealed!/burned! now perform an atomic compare-and-set in Redis
+# (SecretStateManagement#claim_terminal_transition!). Of any number of racing
+# callers exactly one wins the claim (returns true); the rest return false and
+# the reveal controllers gate the plaintext on that return value.
+#
+# These tryouts reproduce the race window (two instances that BOTH pass the
+# in-memory viewable? check) and assert the atomic outcome.
+
+require_relative '../../support/test_models'
+
+OT.boot! :test, true
+
+## Both loaded instances observe a viewable secret -- the race window exists --
+## yet exactly one revealed! wins the atomic claim.
+receipt, secret = Onetime::Receipt.spawn_pair 'anon', 3600, 'race secret'
+s1 = Onetime::Secret.load(secret.identifier)
+s2 = Onetime::Secret.load(secret.identifier)
+race_window = [s1.viewable?, s2.viewable?]
+results     = [s1.revealed!, s2.revealed!]
+[race_window, results.count(true), results.count(false)]
+#=> [[true, true], 1, 1]
+
+## After a concurrent reveal the secret is destroyed exactly once.
+receipt, secret = Onetime::Receipt.spawn_pair 'anon', 3600, 'race secret'
+s1 = Onetime::Secret.load(secret.identifier)
+s2 = Onetime::Secret.load(secret.identifier)
+r1 = s1.revealed!
+r2 = s2.revealed!
+[s1.exists?, [r1, r2].count(true)]
+#=> [false, 1]
+
+## The winning reveal decrypted the plaintext; the losing caller returns false,
+## so its controller never emits the value. (Winner: true, loser: false.)
+receipt, secret = Onetime::Receipt.spawn_pair 'anon', 3600, 'top secret value'
+plaintext = Onetime::Secret.load(secret.identifier).decrypted_secret_value
+s1 = Onetime::Secret.load(secret.identifier)
+s2 = Onetime::Secret.load(secret.identifier)
+r1 = s1.revealed!
+r2 = s2.revealed!
+[plaintext, r1 ^ r2] # exactly one of r1/r2 is truthy => XOR is true
+#=> ['top secret value', true]
+
+## A losing reveal leaves its instance terminal in-memory, so a trailing
+## `previewed! if state?(:new)` in the controller cannot resurrect the key the
+## winner just destroyed.
+receipt, secret = Onetime::Receipt.spawn_pair 'anon', 3600, 'race secret'
+s1 = Onetime::Secret.load(secret.identifier)
+s2 = Onetime::Secret.load(secret.identifier)
+r1    = s1.revealed!
+r2    = s2.revealed!
+loser = r1 ? s2 : s1
+loser.previewed! if loser.state?(:new) # must be a no-op -- would resurrect otherwise
+[loser.state?(:new), s1.exists?, s2.exists?]
+#=> [false, false, false]
+
+## Concurrent burn: exactly one burned! wins the atomic claim.
+receipt, secret = Onetime::Receipt.spawn_pair 'anon', 3600, 'race secret'
+s1 = Onetime::Secret.load(secret.identifier)
+s2 = Onetime::Secret.load(secret.identifier)
+results = [s1.burned!, s2.burned!]
+[results.count(true), results.count(false), s1.exists?]
+#=> [1, 1, false]
+
+## A reveal racing a burn on the same secret: exactly one wins, and the secret
+## is destroyed regardless of which action got there first.
+receipt, secret = Onetime::Receipt.spawn_pair 'anon', 3600, 'race secret'
+s1 = Onetime::Secret.load(secret.identifier)
+s2 = Onetime::Secret.load(secret.identifier)
+revealed = s1.revealed!
+burned   = s2.burned!
+[[revealed, burned].count(true), s1.exists?]
+#=> [1, false]
+
+## True concurrency: many threads race revealed! on separately-loaded
+## instances of one secret. Redis executes the Lua claim atomically, so exactly
+## one thread wins no matter how the threads interleave.
+receipt, secret = Onetime::Receipt.spawn_pair 'anon', 3600, 'race secret'
+instances = Array.new(8) { Onetime::Secret.load(secret.identifier) }
+outcomes  = instances.map { |s| Thread.new { s.revealed! } }.map(&:value)
+[outcomes.count(true), instances.first.exists?]
+#=> [1, false]

--- a/try/unit/models/secret_double_reveal_race_try.rb
+++ b/try/unit/models/secret_double_reveal_race_try.rb
@@ -91,3 +91,27 @@ instances = Array.new(8) { Onetime::Secret.load(secret.identifier) }
 outcomes  = instances.map { |s| Thread.new { s.revealed! } }.map(&:value)
 [outcomes.count(true), instances.first.exists?]
 #=> [1, false]
+
+# ----------------------------------------------------------------
+# previewed! is a non-creating, non-reverting CAS (see the method's docs).
+# The former save_fields(:state) was an unconditional HSET that could
+# resurrect a destroyed key or revert a terminal state.
+# ----------------------------------------------------------------
+
+## previewed! will not resurrect a secret a concurrent reveal already
+## destroyed: a stale in-memory :new instance whose key is gone stays gone.
+receipt, secret = Onetime::Receipt.spawn_pair 'anon', 3600, 'race secret'
+stale = Onetime::Secret.load(secret.identifier)    # loads with @state == 'new'
+Onetime::Secret.load(secret.identifier).revealed!  # a concurrent reveal destroys the key
+stale.previewed!                                   # stale still believes it is :new
+stale.exists?
+#=> false
+
+## previewed! reads the PERSISTED state, not just memory: a stale :new instance
+## cannot re-fire or downgrade a secret that has already advanced past :new.
+receipt, secret = Onetime::Receipt.spawn_pair 'anon', 3600, 'race secret'
+stale = Onetime::Secret.load(secret.identifier)          # stale @state == 'new'
+Onetime::Secret.load(secret.identifier).previewed!       # persisted advances to 'previewed'
+stale.previewed!                                          # must be a no-op (persisted != new)
+Onetime::Secret.load(secret.identifier).state
+#=> 'previewed'


### PR DESCRIPTION
## Summary

Fixes a critical double-reveal race condition (CWE-362) where two concurrent requests to the same secret link could both decrypt and return the plaintext, defeating the "view once" guarantee.

### The Problem

Before this change, two concurrent requests could:
1. Both load the same secret and observe `state == :new` in memory
2. Both pass the viewability check
3. Both decrypt the ciphertext and return the plaintext to different clients
4. Both destroy the record

This violated the core product promise that a secret is revealed to at most ONE caller.

### The Solution

Secret state transitions now use an atomic compare-and-set (CAS) operation in Redis via Lua script (`STATE_CAS_SCRIPT`). Of any number of racing callers, exactly one wins the claim and is permitted to consume the secret; the rest receive `false` and must not emit the plaintext.

**Key changes:**

- **`previewed!`**: Now uses atomic CAS instead of unconditional `HSET`. Cannot resurrect destroyed secrets or revert terminal states. No longer resets TTL on preview.

- **`revealed!`**: Returns boolean indicating whether THIS caller won the atomic claim. Callers that lose the race get `false` and must withhold the plaintext.

- **`reveal!`** (new): Couples the atomic claim with decryption. Only the winning caller gets the plaintext; losers get `nil`. This is the preferred entry point for read controllers since decryption happens inside the won-claim branch.

- **`burned!`**: Now uses atomic CAS and returns boolean like `revealed!`.

- **`compare_and_set_state!`** (new private method): The single concurrency primitive behind all state transitions. Executes atomically in Redis so a missing key (destroyed) or already-advanced state simply loses.

### Controller Updates

Both v1 and v2 reveal controllers now gate the plaintext response on the return value of `reveal!`:
- If the caller won the claim, emit the plaintext and log success
- If the caller lost the race, return `nil` and do not present the secret as viewable

This ensures a losing request neither claims success nor inflates shared-secret metrics.

## Related Issues

Fixes the double-reveal race condition (CWE-362)

## Test Plan

- Added comprehensive regression tryouts in `try/unit/models/secret_double_reveal_race_try.rb` covering:
  - Concurrent `revealed!` calls (exactly one wins)
  - Concurrent `burned!` calls (exactly one wins)
  - Reveal racing burn (exactly one wins regardless of order)
  - True concurrency with 8 threads (exactly one wins)
  - `previewed!` non-resurrection and non-reversion guarantees
  - `reveal!` plaintext coupling (only winner gets value)

- Added integration specs in `apps/api/v2/spec/logic/secrets/reveal_secret_spec.rb` and `show_secret_spec.rb` verifying that losing requests do not emit plaintext

- Existing unit tests updated to reflect new return values from `revealed!` and `burned!`

https://claude.ai/code/session_01KUSibuB5TNRUvPR1H6sDq5