### PR TITLE
* Add route-level error boundary to prevent blank pages on render failures

### DIFF
--- a/changelog.d/20260703_120000_claude_domain_homepage_auth_links_default_off.rst
+++ b/changelog.d/20260703_120000_claude_domain_homepage_auth_links_default_off.rst
@@ -1,0 +1,26 @@
+.. A new scriv changelog fragment.
+
+Changed
+-------
+
+- Custom-domain homepages no longer show the **Create Account** and **Sign In**
+  nav links by default. The per-domain ``signup_enabled`` / ``signin_enabled``
+  toggles on ``CustomDomain::HomepageConfig`` now default to *off*, matching the
+  conservative default of the sibling ``SigninConfig`` / ``SignupConfig``
+  models, so recipients and employees arriving via a shared secret link no
+  longer see account chrome that isn't meant for them. Operators re-enable the
+  links per domain via ``PUT /homepage-config`` (domain homepage settings). The
+  authentication kill switch (``resolve_signin_enabled`` /
+  ``resolve_signup_enabled`` and the serializer's ``effective_*`` gates) is
+  unchanged — this only narrows what is displayed, never widens capability.
+  (#3618)
+
+- **Action Required**: existing custom domains have these flags persisted as
+  ``true`` (written by ``CustomDomain.create!`` and the #3023 backfill), so a
+  code-only default change cannot reach them. A data migration resets the stored
+  values to ``false``; run it during deployment::
+
+      bin/ots migrate --run 20260703_01_disable_homepage_auth_links
+
+  The migration is idempotent (already-off records are skipped) and preserves
+  each domain's homepage ``enabled`` (public secret form) setting. (#3618)

--- a/lib/onetime/models/custom_domain/homepage_config.rb
+++ b/lib/onetime/models/custom_domain/homepage_config.rb
@@ -39,11 +39,14 @@ module Onetime
       # Whether homepage secrets is enabled for this domain
       field :enabled
 
-      # Per-domain UI toggles for the homepage auth nav. Both default to true
-      # so existing records (no field set) render the links. The system-level
-      # site.authentication.{signup,signin} flags remain the master switch:
-      # the frontend ANDs both layers, so toggling a system flag off hides
-      # the link regardless of this domain-level value.
+      # Per-domain UI toggles for the homepage auth nav. Both default to false
+      # (conservative, mirroring SigninConfig/SignupConfig): a freshly created
+      # domain hides the Create Account / Sign In links until an operator
+      # explicitly opts in via PUT /homepage-config. A missing field (legacy
+      # records that pre-date this feature) also reads as disabled. The
+      # system-level site.authentication.{signup,signin} flags remain the
+      # master switch — the frontend ANDs both layers, so toggling a system
+      # flag off hides the link regardless of this domain-level value.
       field :signup_enabled
       field :signin_enabled
 
@@ -59,8 +62,8 @@ module Onetime
 
       def init
         self.enabled      ||= 'false'
-        self.signup_enabled = true if signup_enabled.nil?
-        self.signin_enabled = true if signin_enabled.nil?
+        self.signup_enabled = false if signup_enabled.nil?
+        self.signin_enabled = false if signin_enabled.nil?
       end
 
       # Check if homepage secrets is enabled for this domain.
@@ -71,15 +74,18 @@ module Onetime
       end
 
       # Whether the Sign Up link should render on this domain's homepage.
-      # Records pre-dating this field return nil, which we treat as enabled
-      # (only an explicit `false` hides the link).
+      # Conservative default: only an explicit boolean `true` shows the link.
+      # A missing/nil field (legacy records pre-dating this field) reads as
+      # false, so the link stays hidden until an operator opts in. A stray
+      # string value ('true'/'false') is likewise treated as disabled.
       def signup_enabled?
-        signup_enabled != false
+        signup_enabled == true
       end
 
       # Whether the Sign In link should render on this domain's homepage.
+      # Conservative default: only an explicit boolean `true` shows the link.
       def signin_enabled?
-        signin_enabled != false
+        signin_enabled == true
       end
 
       # Recognised disabled-homepage variant for this domain, or nil to fall
@@ -207,8 +213,8 @@ module Onetime
             config = new(
               domain_id: domain_id,
               enabled: enabled.to_s,
-              signup_enabled: signup_enabled.nil? || signup_enabled,
-              signin_enabled: signin_enabled.nil? || signin_enabled,
+              signup_enabled: signup_enabled.nil? ? false : signup_enabled,
+              signin_enabled: signin_enabled.nil? ? false : signin_enabled,
               disabled_homepage_variant: coerce_disabled_homepage_variant(disabled_homepage_variant),
               created: now,
               updated: now,
@@ -240,8 +246,8 @@ module Onetime
           config = new(
             domain_id: domain_id,
             enabled: enabled.to_s,
-            signup_enabled: signup_enabled.nil? || signup_enabled,
-            signin_enabled: signin_enabled.nil? || signin_enabled,
+            signup_enabled: signup_enabled.nil? ? false : signup_enabled,
+            signin_enabled: signin_enabled.nil? ? false : signin_enabled,
             created: now,
             updated: now,
           )

--- a/migrations/2026-07-03/20260703_01_disable_homepage_auth_links.rb
+++ b/migrations/2026-07-03/20260703_01_disable_homepage_auth_links.rb
@@ -1,0 +1,155 @@
+# migrations/2026-07-03/20260703_01_disable_homepage_auth_links.rb
+#
+# frozen_string_literal: true
+
+#
+# Disable the homepage auth nav links (Create Account / Sign In) on all
+# existing custom domains.
+#
+# The per-domain signup_enabled/signin_enabled toggles on
+# CustomDomain::HomepageConfig originally defaulted to ON: the #3023 backfill
+# and CustomDomain.create! both persisted a literal `true` into every record,
+# and the model/serializer/frontend all read that value as "show the link".
+# The result was that the Create Account and Sign In links appeared on every
+# custom-domain homepage — confusing for recipients and employees who only
+# ever arrive via a shared secret link.
+#
+# The default was flipped to OFF (conservative, mirroring
+# SigninConfig/SignupConfig): new domains now hide the links until an operator
+# opts in via PUT /homepage-config. But existing domains carry a persisted
+# `true`, so a code-only default change cannot reach them — the stored value
+# still wins at read time. This migration resets that persisted value.
+#
+# For every CustomDomain that has a HomepageConfig record, this flips
+# signup_enabled/signin_enabled from true to false. A deliberate opt-in is
+# indistinguishable from the historical default (both are a bare `true`), so
+# all currently-enabled records are reset; operators re-enable the links per
+# domain via the existing PUT /homepage-config endpoint afterwards.
+#
+# Idempotent: records already fully off (both flags false/nil) are skipped, so
+# re-running touches nothing.
+#
+# Usage:
+#   bin/ots migrate 20260703_01_disable_homepage_auth_links           # Preview
+#   bin/ots migrate --run 20260703_01_disable_homepage_auth_links     # Execute
+#
+require 'familia/migration'
+
+module Onetime
+  module Migrations
+    # Reset persisted HomepageConfig signup_enabled/signin_enabled to false so
+    # the homepage auth nav links default to hidden on existing custom domains.
+    class DisableHomepageAuthLinks < Familia::Migration::Base
+      self.migration_id = '20260703_01_disable_homepage_auth_links'
+      self.description  = 'Disable homepage Create Account / Sign In links on existing custom domains'
+      self.dependencies = []
+
+      def prepare
+        @model_class  = Onetime::CustomDomain
+        @config_class = Onetime::CustomDomain::HomepageConfig
+      end
+
+      # Migration is needed while any domain's HomepageConfig still reports an
+      # enabled signup or signin link. Predicates are conservative (only a
+      # literal boolean true reads as enabled), so this is stable once applied.
+      def migration_needed?
+        @model_class.instances.each do |domain_id|
+          config = @config_class.find_by_domain_id(domain_id)
+          next unless config
+
+          return true if config.signup_enabled? || config.signin_enabled?
+        rescue StandardError => ex
+          # Surface the discovery error but keep scanning so one corrupt
+          # record cannot mask a genuine pending migration.
+          error "migration_needed? error for #{domain_id}: #{ex.message}"
+        end
+
+        false
+      end
+
+      # Progress reporting threshold: emit a running breakdown every N domains
+      # processed. Matches the 250-domain step used by the #3023 backfill so
+      # operator output stays consistent across the homepage-config migrations.
+      PROGRESS_STEP = 250
+
+      def migrate
+        run_mode_banner
+
+        # ZCARD on CustomDomain.instances — O(1), worth the one-time cost so
+        # progress output can show current/total.
+        total     = @model_class.instances.count
+        processed = 0
+
+        @model_class.instances.each do |domain_id|
+          process_domain(domain_id)
+        rescue StandardError => ex
+          track_stat(:errors)
+          error "Error processing domain #{domain_id}: #{ex.message}"
+        ensure
+          processed += 1
+          report_progress(processed, total)
+        end
+
+        print_summary do |mode|
+          @stats.each { |key, value| info "  #{key}: #{value}" }
+          info ''
+          info(mode == :dry_run ? 'Re-run with --run to apply changes.' : 'Homepage auth links disabled.')
+        end
+
+        true
+      end
+
+      private
+
+      # Emit a periodic progress line with a running stat breakdown so
+      # operators can watch long-running resets. Only logs at the step
+      # boundary or the final iteration; stays silent below the threshold
+      # to avoid noise on small datasets.
+      def report_progress(processed, total)
+        return unless total >= PROGRESS_STEP
+        return unless (processed % PROGRESS_STEP).zero? || processed == total
+
+        breakdown = @stats.map { |k, v| "#{k}=#{v}" }.join(', ')
+        info "Progress: #{processed}/#{total} (#{breakdown})"
+      end
+
+      def process_domain(domain_id)
+        config = @config_class.find_by_domain_id(domain_id)
+        unless config
+          # Post-#3023 every domain should carry a HomepageConfig; a missing
+          # record means nothing to reset (the read path already fails closed).
+          track_stat(:skipped_missing_config)
+          return
+        end
+
+        # Already-off records (both flags false or nil) need no write — keeps
+        # the migration idempotent and preserves their `updated` timestamp.
+        unless config.signup_enabled? || config.signin_enabled?
+          track_stat(:already_off)
+          return
+        end
+
+        if dry_run?
+          track_stat(:would_disable)
+          info "[DRY RUN] would disable homepage auth links for #{domain_id} " \
+               "(signup=#{config.signup_enabled?}, signin=#{config.signin_enabled?})"
+          return
+        end
+
+        config.signup_enabled = false
+        config.signin_enabled = false
+        config.updated        = Familia.now.to_i
+        config.save
+
+        track_stat(:disabled)
+        info "Disabled homepage auth links for #{domain_id}"
+      end
+    end
+  end
+end
+
+# Run directly
+if __FILE__ == $0
+  OT.boot! :cli
+  exit(Onetime::Migrations::DisableHomepageAuthLinks.cli_run)
+end

--- a/src/App.vue
+++ b/src/App.vue
@@ -5,6 +5,7 @@
   import { iconLibraryComponents } from '@/shared/components/icons/sprites';
   import CriticalSprites from '@/shared/components/icons/sprites/CriticalSprites.vue';
   import { NotificationHost } from '@/shared/components/ui/notifications';
+  import RouteErrorBoundary from '@/shared/components/errors/RouteErrorBoundary.vue';
   import QuietLayout from '@/shared/layouts/MinimalLayout.vue';
   import { useBrandTheme } from '@/shared/composables/useBrandTheme';
   import type { LayoutProps } from '@/types/ui/layouts';
@@ -126,13 +127,18 @@
     :is="layout"
     :lang="locale"
     v-bind="layoutProps">
-    <!-- Router view with forced component recreation on route changes -->
+    <!-- Router view with forced component recreation on route changes.
+         RouteErrorBoundary swaps a thrown route subtree for a visible error
+         panel so a render/setup failure never leaves a silent blank page
+         (the global errorHandler only logs). Keyed + reset on route change. -->
     <router-view
       v-slot="{ Component }"
       class="rounded-md">
-      <component
-        :is="Component"
-        :key="$route.fullPath" />
+      <RouteErrorBoundary :reset-key="$route.fullPath">
+        <component
+          :is="Component"
+          :key="$route.fullPath" />
+      </RouteErrorBoundary>
     </router-view>
 
     <NotificationHost />

--- a/src/apps/secret/components/layout/BrandedMastHead.vue
+++ b/src/apps/secret/components/layout/BrandedMastHead.vue
@@ -17,13 +17,15 @@
   const imageError = ref(false);
 
   /**
-   * Per-domain narrowing for the auth nav links. Defaults to enabled when
-   * no homepage_config exists for the domain. The frontend ANDs the system
+   * Per-domain gate for the auth nav links. Defaults to disabled — the links
+   * stay hidden unless the domain's homepage_config explicitly opts in
+   * (signup_enabled/signin_enabled === true). A missing homepage_config (or a
+   * missing field) reads as disabled. The frontend still ANDs the system
    * authentication flags with these domain-level toggles — the domain owner
    * can only narrow, never broaden.
    */
-  const domainSignupEnabled = computed(() => homepage_config.value?.signup_enabled !== false);
-  const domainSigninEnabled = computed(() => homepage_config.value?.signin_enabled !== false);
+  const domainSignupEnabled = computed(() => homepage_config.value?.signup_enabled === true);
+  const domainSigninEnabled = computed(() => homepage_config.value?.signin_enabled === true);
 
   /**
    * Show Sign In link when signin route is available AND the domain hasn't

--- a/src/apps/secret/views/DisabledHomepage.vue
+++ b/src/apps/secret/views/DisabledHomepage.vue
@@ -40,7 +40,10 @@
   };
 
   const { variant, props } = useDisabledConfig();
-  const ActiveVariant = computed(() => VARIANTS[variant.value]);
+  // Fall back to a known variant if `variant` is ever an unmapped id, so the
+  // dispatcher can never resolve to `undefined` (which would render nothing —
+  // a blank page). useDisabledConfig already validates, this is defence in depth.
+  const ActiveVariant = computed(() => VARIANTS[variant.value] ?? DisabledClosed);
 </script>
 
 <template>

--- a/src/apps/secret/views/disabled/useDisabledConfig.ts
+++ b/src/apps/secret/views/disabled/useDisabledConfig.ts
@@ -134,6 +134,20 @@ function resolveSsoOneClickProvider(
   return restrictedToSso || (isCustom && enforcedForDomain) ? providers[0] : null;
 }
 
+/**
+ * Validate a resolved variant id against the enum, collapsing every invalid
+ * case (null, undefined, empty string, unknown/legacy id) to the default.
+ *
+ * `??` in the resolution chain only skips null/undefined, so an empty-string or
+ * unrecognised store value would otherwise reach the dispatcher's
+ * `VARIANTS[variant]` as an unknown key -> `<component :is=undefined>` -> a
+ * blank page. This guard prevents that.
+ */
+function coerceDisabledVariant(candidate: unknown): DisabledHomepageVariant {
+  const parsed = disabledHomepageVariantSchema.safeParse(candidate);
+  return parsed.success ? parsed.data : DEFAULT_DISABLED_HOMEPAGE_VARIANT;
+}
+
 export function useDisabledConfig(): DisabledHomepageBindings {
   const identityStore = useProductIdentity();
   const { isCustom, primaryColor, logoUri, displayName, displayDomain, brand, siteHost } =
@@ -221,12 +235,14 @@ export function useDisabledConfig(): DisabledHomepageBindings {
   // domain or site config still flips the variant. homepage_config is null on
   // the canonical site and on any custom domain that hasn't opted in.
   const urlOverride = readUrlVariantOverride();
-  const variant = computed<DisabledHomepageVariant>(
-    () =>
+  // Wrap the ?? precedence chain in coerceDisabledVariant so an invalid/empty
+  // store value falls back to the default instead of blanking the dispatcher.
+  const variant = computed<DisabledHomepageVariant>(() =>
+    coerceDisabledVariant(
       urlOverride ??
-      homepage_config.value?.disabled_homepage_variant ??
-      ui.value?.homepage?.disabled_variant ??
-      DEFAULT_DISABLED_HOMEPAGE_VARIANT
+        homepage_config.value?.disabled_homepage_variant ??
+        ui.value?.homepage?.disabled_variant
+    )
   );
 
   // Getter object: `v-bind="props"` evaluates each property on every render,

--- a/src/schemas/contracts/custom-domain/homepage-config.ts
+++ b/src/schemas/contracts/custom-domain/homepage-config.ts
@@ -31,17 +31,19 @@ export const homepageConfigCanonical = z.object({
 
   /**
    * Whether the Sign Up link renders on this domain's homepage.
-   * Defaults to true (link visible). The site-level authentication.signup
-   * flag remains the master switch — the frontend ANDs both layers.
+   * Defaults to false (link hidden) — operators opt in per-domain via
+   * PUT /homepage-config. The site-level authentication.signup flag
+   * remains the master switch — the frontend ANDs both layers.
    */
-  signup_enabled: z.boolean().default(true),
+  signup_enabled: z.boolean().default(false),
 
   /**
    * Whether the Sign In link renders on this domain's homepage.
-   * Defaults to true (link visible). The site-level authentication.signin
-   * flag remains the master switch — the frontend ANDs both layers.
+   * Defaults to false (link hidden) — operators opt in per-domain via
+   * PUT /homepage-config. The site-level authentication.signin flag
+   * remains the master switch — the frontend ANDs both layers.
    */
-  signin_enabled: z.boolean().default(true),
+  signin_enabled: z.boolean().default(false),
 
   /**
    * Which disabled-homepage variant this domain renders when the homepage

--- a/src/shared/components/errors/RouteErrorBoundary.vue
+++ b/src/shared/components/errors/RouteErrorBoundary.vue
@@ -104,6 +104,13 @@
         d="M12 9v3.75m9-.75a9 9 0 11-18 0 9 9 0 0118 0zm-9 3.75h.008v.008H12v-.008z" />
     </svg>
 
+    <!--
+      Fallback copy is intentionally hardcoded (not i18n-wrapped). This is a
+      last-resort render boundary: the failure it catches may itself be a
+      broken i18n/bootstrap state, so calling t() here risks throwing while
+      handling an error. Plain English keeps the panel dependency-free and
+      guaranteed to render.
+    -->
     <h1 class="mt-4 text-lg font-semibold text-gray-900 dark:text-white">Something went wrong</h1>
     <p class="mt-2 text-sm text-gray-600 dark:text-gray-400">
       This page couldn’t be displayed. Reloading usually fixes it.
@@ -126,9 +133,10 @@
       </button>
     </div>
 
-    <!-- Error detail: development only, to avoid surfacing internals in prod. -->
+    <!-- Error detail: development only, to avoid surfacing internals in prod.
+         caughtError is always truthy inside the outer v-if, so isDev alone gates this. -->
     <pre
-      v-if="isDev && caughtError"
+      v-if="isDev"
       class="mt-6 max-w-full overflow-x-auto rounded-md bg-gray-100 p-3 text-left text-xs text-red-700 dark:bg-gray-800 dark:text-red-300"
       >{{ caughtError.message }}</pre
     >

--- a/src/shared/components/errors/RouteErrorBoundary.vue
+++ b/src/shared/components/errors/RouteErrorBoundary.vue
@@ -1,0 +1,138 @@
+<!-- src/shared/components/errors/RouteErrorBoundary.vue -->
+
+<!--
+  Route-level render error boundary.
+
+  WHY THIS EXISTS
+  ---------------
+  Vue's `app.config.errorHandler` (wired in src/plugins/core/globalErrorBoundary.ts)
+  only *logs* render/setup errors to Sentry — it renders no fallback. When a
+  route component throws synchronously during setup()/render, Vue tears that
+  subtree down and the `<router-view>` slot is left empty. With no fallback,
+  the user sees a silent BLANK PAGE instead of an error.
+
+  This boundary wraps the active route component and, via `onErrorCaptured`,
+  swaps a thrown subtree for a visible "something went wrong" panel with a
+  reload affordance — so a render failure is never a blank screen.
+
+  It reports the error to Sentry itself (mirroring the global handler) and
+  returns `false` from `onErrorCaptured` to stop propagation — the boundary
+  has fully handled the failure by rendering a fallback, so there is nothing
+  left for `app.config.errorHandler` to do, and double-reporting the same
+  error is avoided.
+
+  The boundary resets whenever the route changes (`resetKey`), so navigating
+  away from a broken route recovers without a hard reload.
+-->
+
+<script setup lang="ts">
+  import { captureException, isDiagnosticsEnabled } from '@/services/diagnostics.service';
+  import { loggingService } from '@/services/logging.service';
+  import { onErrorCaptured, ref, watch } from 'vue';
+
+  interface Props {
+    /**
+     * Changes on every navigation (pass `$route.fullPath`). Watching it clears
+     * a captured error so a subsequent, healthy route renders normally.
+     */
+    resetKey?: string;
+  }
+
+  const props = defineProps<Props>();
+
+  const caughtError = ref<Error | null>(null);
+  const isDev = import.meta.env.DEV;
+
+  onErrorCaptured((err, _instance, info) => {
+    // Record the error so the template swaps in the fallback panel.
+    const normalized = err instanceof Error ? err : new Error(String(err));
+    caughtError.value = normalized;
+
+    // Best-effort log + Sentry report; never let reporting throw out of the
+    // hook (the boundary must not fail while handling a failure).
+    try {
+      loggingService.error(normalized);
+      if (isDiagnosticsEnabled()) {
+        captureException(normalized, { boundary: 'RouteErrorBoundary', componentInfo: info });
+      }
+    } catch {
+      /* no-op */
+    }
+
+    // Return false: the boundary has handled the error by rendering a
+    // fallback, so stop propagation to app.config.errorHandler (avoids a
+    // duplicate Sentry event for the same failure).
+    return false;
+  });
+
+  // Recover on navigation: a new route gets a clean render.
+  watch(
+    () => props.resetKey,
+    () => {
+      caughtError.value = null;
+    }
+  );
+
+  const reload = () => {
+    window.location.reload();
+  };
+
+  const goHome = () => {
+    // Hard navigation (not router.push) so we leave the broken component tree
+    // entirely rather than risk re-entering the same failing route via the SPA.
+    window.location.assign('/');
+  };
+</script>
+
+<template>
+  <div
+    v-if="caughtError"
+    role="alert"
+    data-testid="route-error-boundary"
+    class="mx-auto flex min-h-[60vh] max-w-md flex-col items-center justify-center px-4 text-center">
+    <svg
+      class="size-12 text-amber-500 dark:text-amber-400"
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      aria-hidden="true">
+      <path
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        d="M12 9v3.75m9-.75a9 9 0 11-18 0 9 9 0 0118 0zm-9 3.75h.008v.008H12v-.008z" />
+    </svg>
+
+    <h1 class="mt-4 text-lg font-semibold text-gray-900 dark:text-white">Something went wrong</h1>
+    <p class="mt-2 text-sm text-gray-600 dark:text-gray-400">
+      This page couldn’t be displayed. Reloading usually fixes it.
+    </p>
+
+    <div class="mt-6 flex flex-wrap items-center justify-center gap-3">
+      <button
+        type="button"
+        data-testid="route-error-reload"
+        @click="reload"
+        class="rounded-md bg-brand-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-brand-500 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2 dark:bg-brand-500 dark:hover:bg-brand-400">
+        Reload page
+      </button>
+      <button
+        type="button"
+        data-testid="route-error-home"
+        @click="goHome"
+        class="rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600">
+        Go to homepage
+      </button>
+    </div>
+
+    <!-- Error detail: development only, to avoid surfacing internals in prod. -->
+    <pre
+      v-if="isDev && caughtError"
+      class="mt-6 max-w-full overflow-x-auto rounded-md bg-gray-100 p-3 text-left text-xs text-red-700 dark:bg-gray-800 dark:text-red-300"
+      >{{ caughtError.message }}</pre
+    >
+  </div>
+
+  <slot v-else></slot>
+</template>

--- a/src/shared/components/layout/TransactionalHeader.vue
+++ b/src/shared/components/layout/TransactionalHeader.vue
@@ -31,9 +31,21 @@
   // concern); both must hold to render (see template v-if).
   const { headerEnabled } = useHeaderEnabled();
 
-  // Per-domain link toggles (custom-domain homepage). Default to enabled
-  // when no domain config exists. System-level flags remain the master
-  // switch — both layers must be true for the link to render.
+  // Per-domain link toggles. This header renders on BOTH the canonical site
+  // and custom-domain transactional pages, so the null case must mean "show":
+  // canonical has no homepage_config (null) and MUST keep its Sign Up / Sign In
+  // links. Custom domains carry an explicit record whose flags default to false
+  // (see HomepageConfig / the 20260703_01 migration), so `!== false` hides the
+  // links there while leaving canonical's null untouched.
+  //
+  // DO NOT change this to `=== true` to match BrandedMastHead. BrandedMastHead
+  // is custom-domain-only (never null), so it can fail closed; this component
+  // is not. Flipping to `=== true` would strip Sign In/Sign Up from the
+  // canonical homepage. The regression is guarded by the "homepage_config is
+  // null → both links render" case in TransactionalHeader.customDomain.spec.ts.
+  //
+  // System-level authentication flags remain the master switch — both layers
+  // must be true for the link to render.
   const showDomainSignup = computed(() => homepage_config.value?.signup_enabled !== false);
   const showDomainSignin = computed(() => homepage_config.value?.signin_enabled !== false);
 

--- a/src/tests/apps/secret/components/layout/BrandedMastHead.spec.ts
+++ b/src/tests/apps/secret/components/layout/BrandedMastHead.spec.ts
@@ -1,8 +1,13 @@
 // src/tests/apps/secret/components/layout/BrandedMastHead.spec.ts
 //
-// Guards the accessibility of the custom-domain logo image: it must carry a
-// meaningful alt (the brand/workspace display name) rather than an empty alt,
-// so screen-reader users hear the brand instead of skipping the image.
+// Guards two behaviours of the custom-domain masthead:
+//   1. Logo accessibility: the logo image must carry a meaningful alt (the
+//      brand/workspace display name) rather than an empty alt.
+//   2. Auth nav links default OFF: the Create Account / Sign In links only
+//      render when the domain's homepage_config explicitly opts in
+//      (signup_enabled/signin_enabled === true). A null homepage_config or a
+//      false flag keeps them hidden — recipients and employees arriving via a
+//      shared link should not see account chrome unless an operator enabled it.
 
 import { mount, VueWrapper } from '@vue/test-utils';
 import { describe, it, expect, vi, afterEach } from 'vitest';
@@ -11,11 +16,29 @@ import { createTestI18n } from '@tests/setup';
 import { nextTick } from 'vue';
 import BrandedMastHead from '@/apps/secret/components/layout/BrandedMastHead.vue';
 
+// Neutralise the SSO feature helpers so showSignIn depends purely on the
+// platform auth flags and the domain-level homepage_config toggle under test.
+vi.mock('@/utils/features', () => ({
+  isSsoEnabled: () => false,
+  isOrgsSsoEnabled: () => false,
+}));
+
 const i18n = createTestI18n();
+
+type HomepageConfigState = {
+  domain_id?: string;
+  enabled?: boolean;
+  signup_enabled?: boolean;
+  signin_enabled?: boolean;
+  created_at?: number | null;
+  updated_at?: number | null;
+} | null;
 
 interface Overrides {
   domain_logo?: string | null;
   domain_branding?: Record<string, unknown>;
+  authentication?: { enabled?: boolean; signin?: boolean; signup?: boolean };
+  homepage_config?: HomepageConfigState;
 }
 
 const mountBranded = (overrides: Overrides = {}): VueWrapper => {
@@ -38,7 +61,8 @@ const mountBranded = (overrides: Overrides = {}): VueWrapper => {
           font_family: 'sans',
           button_text_light: true,
         },
-        homepage_config: null,
+        authentication: overrides.authentication,
+        homepage_config: overrides.homepage_config ?? null,
       },
     },
   });
@@ -75,5 +99,73 @@ describe('BrandedMastHead logo accessibility', () => {
     await nextTick();
 
     expect(wrapper.find('img').attributes('alt')).toBe('secrets.acme.com');
+  });
+});
+
+describe('BrandedMastHead auth nav links (default-off)', () => {
+  let wrapper: VueWrapper;
+
+  afterEach(() => {
+    if (wrapper) wrapper.unmount();
+  });
+
+  // Platform auth is fully enabled in every case below so the domain-level
+  // homepage_config toggle is the only variable under test.
+  const authOn = { enabled: true, signin: true, signup: true };
+
+  const config = (overrides: Partial<NonNullable<HomepageConfigState>>) => ({
+    domain_id: 'cd_acme',
+    enabled: true,
+    signup_enabled: false,
+    signin_enabled: false,
+    created_at: null,
+    updated_at: null,
+    ...overrides,
+  });
+
+  it('hides both links (and the nav) when homepage_config is null', async () => {
+    wrapper = mountBranded({ authentication: authOn, homepage_config: null });
+    await nextTick();
+
+    expect(wrapper.find('[data-testid="branded-signup-link"]').exists()).toBe(false);
+    expect(wrapper.find('[data-testid="branded-signin-link"]').exists()).toBe(false);
+    // The whole nav collapses when neither link is shown.
+    expect(wrapper.find('nav').exists()).toBe(false);
+  });
+
+  it('keeps both links hidden when homepage_config flags are false', async () => {
+    wrapper = mountBranded({
+      authentication: authOn,
+      homepage_config: config({ signup_enabled: false, signin_enabled: false }),
+    });
+    await nextTick();
+
+    expect(wrapper.find('[data-testid="branded-signup-link"]').exists()).toBe(false);
+    expect(wrapper.find('[data-testid="branded-signin-link"]').exists()).toBe(false);
+  });
+
+  it('shows both links only when homepage_config explicitly opts in (=== true)', async () => {
+    wrapper = mountBranded({
+      authentication: authOn,
+      homepage_config: config({ signup_enabled: true, signin_enabled: true }),
+    });
+    await nextTick();
+
+    expect(wrapper.find('[data-testid="branded-signup-link"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="branded-signin-link"]').exists()).toBe(true);
+    expect(wrapper.find('[role="separator"]').exists()).toBe(true);
+  });
+
+  it('shows only Sign In when signin_enabled opts in but signup_enabled stays off', async () => {
+    wrapper = mountBranded({
+      authentication: authOn,
+      homepage_config: config({ signup_enabled: false, signin_enabled: true }),
+    });
+    await nextTick();
+
+    expect(wrapper.find('[data-testid="branded-signup-link"]').exists()).toBe(false);
+    expect(wrapper.find('[data-testid="branded-signin-link"]').exists()).toBe(true);
+    // Separator only renders when both sides are visible.
+    expect(wrapper.find('[role="separator"]').exists()).toBe(false);
   });
 });

--- a/src/tests/apps/secret/views/useDisabledConfig.spec.ts
+++ b/src/tests/apps/secret/views/useDisabledConfig.spec.ts
@@ -212,6 +212,31 @@ describe('useDisabledConfig', () => {
       expect(config.variant.value).toBe('minimal');
     });
 
+    it('falls back to the default when homepage_config carries an empty-string variant', () => {
+      // A stored '' would slip past `??` (which only skips null/undefined) and
+      // reach the dispatcher as an unknown VARIANTS key → blank page. The
+      // schema validation must collapse it to the default instead.
+      const { config, bootstrap } = setup({ homepageVariant: 'v1' });
+      bootstrap.$patch({
+        homepage_config: {
+          ...bootstrap.homepage_config!,
+          disabled_homepage_variant: '' as unknown as 'closed',
+        },
+      });
+      expect(config.variant.value).toBe('closed');
+    });
+
+    it('falls back to the default when homepage_config carries an unrecognised variant', () => {
+      const { config, bootstrap } = setup({ homepageVariant: 'v1' });
+      bootstrap.$patch({
+        homepage_config: {
+          ...bootstrap.homepage_config!,
+          disabled_homepage_variant: 'legacy_v0' as unknown as 'closed',
+        },
+      });
+      expect(config.variant.value).toBe('closed');
+    });
+
     it('?variant override is read at composable-call time, not reactively', () => {
       // Intentional: a mid-session URL mutation doesn't flip the variant
       // without re-mounting. Mirrors how operators use the override —

--- a/src/tests/components/RouteErrorBoundary.spec.ts
+++ b/src/tests/components/RouteErrorBoundary.spec.ts
@@ -1,0 +1,94 @@
+// src/tests/components/RouteErrorBoundary.spec.ts
+//
+// Verifies the render error boundary converts a thrown child subtree into a
+// visible fallback panel (never a blank page) and recovers when the route
+// (resetKey) changes to a healthy component.
+
+import { mount, flushPromises } from '@vue/test-utils';
+import { describe, it, expect, vi } from 'vitest';
+import { defineComponent, h, ref, nextTick } from 'vue';
+import RouteErrorBoundary from '@/shared/components/errors/RouteErrorBoundary.vue';
+
+// Mirror production: the app installs `app.config.errorHandler`
+// (src/plugins/core/globalErrorBoundary.ts) which absorbs the error the
+// boundary re-propagates for Sentry. Without it, Vue re-throws and the test
+// runner reports the (expected) error as a failure.
+const withGlobalHandler = { global: { config: { errorHandler: () => {} } } };
+
+// A child that throws synchronously during setup() — the exact shape that
+// leaves <router-view> blank without a boundary.
+const Exploding = defineComponent({
+  name: 'Exploding',
+  setup() {
+    throw new Error('kaboom');
+  },
+  render: () => h('div', 'never rendered'),
+});
+
+const Healthy = defineComponent({
+  name: 'Healthy',
+  render: () => h('div', { 'data-testid': 'healthy' }, 'all good'),
+});
+
+describe('RouteErrorBoundary', () => {
+  it('renders the fallback panel instead of a blank page when a child throws', async () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const wrapper = mount(RouteErrorBoundary, {
+      ...withGlobalHandler,
+      props: { resetKey: '/dashboard' },
+      slots: { default: () => h(Exploding) },
+    });
+    await flushPromises();
+
+    expect(wrapper.find('[data-testid="route-error-boundary"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="route-error-reload"]').exists()).toBe(true);
+    expect(wrapper.text()).not.toContain('never rendered');
+
+    errSpy.mockRestore();
+  });
+
+  it('renders children normally when nothing throws', () => {
+    const wrapper = mount(RouteErrorBoundary, {
+      props: { resetKey: '/dashboard' },
+      slots: { default: () => h(Healthy) },
+    });
+
+    expect(wrapper.find('[data-testid="healthy"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="route-error-boundary"]').exists()).toBe(false);
+  });
+
+  it('recovers on navigation: clears the error and renders the next healthy route', async () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    // Harness mimics <router-view>: resetKey + the active component change
+    // together on navigation.
+    const routeKey = ref('/broken');
+    const broken = ref(true);
+    const Harness = defineComponent({
+      render: () =>
+        h(
+          RouteErrorBoundary,
+          { resetKey: routeKey.value },
+          {
+            default: () => (broken.value ? h(Exploding) : h(Healthy)),
+          }
+        ),
+    });
+
+    const wrapper = mount(Harness, withGlobalHandler);
+    await flushPromises();
+    expect(wrapper.find('[data-testid="route-error-boundary"]').exists()).toBe(true);
+
+    // Navigate to a healthy route.
+    broken.value = false;
+    routeKey.value = '/dashboard';
+    await nextTick();
+    await flushPromises();
+
+    expect(wrapper.find('[data-testid="route-error-boundary"]').exists()).toBe(false);
+    expect(wrapper.find('[data-testid="healthy"]').exists()).toBe(true);
+
+    errSpy.mockRestore();
+  });
+});

--- a/src/tests/components/RouteErrorBoundary.spec.ts
+++ b/src/tests/components/RouteErrorBoundary.spec.ts
@@ -6,7 +6,13 @@
 
 import { mount, flushPromises } from '@vue/test-utils';
 import { describe, it, expect, vi } from 'vitest';
-import { defineComponent, h, ref, nextTick } from 'vue';
+import { defineComponent, h, ref, nextTick, type Component } from 'vue';
+import {
+  createRouter,
+  createMemoryHistory,
+  RouterView,
+  useRoute,
+} from 'vue-router';
 import RouteErrorBoundary from '@/shared/components/errors/RouteErrorBoundary.vue';
 
 // Mirror production: the app installs `app.config.errorHandler`
@@ -84,6 +90,72 @@ describe('RouteErrorBoundary', () => {
     broken.value = false;
     routeKey.value = '/dashboard';
     await nextTick();
+    await flushPromises();
+
+    expect(wrapper.find('[data-testid="route-error-boundary"]').exists()).toBe(false);
+    expect(wrapper.find('[data-testid="healthy"]').exists()).toBe(true);
+
+    errSpy.mockRestore();
+  });
+
+  // Real-router integration mirroring App.vue's exact wiring:
+  //   <router-view v-slot="{ Component }">
+  //     <RouteErrorBoundary :reset-key="$route.fullPath">
+  //       <component :is="Component" :key="$route.fullPath" />
+  //     </RouteErrorBoundary>
+  //   </router-view>
+  // The hand-rolled Harness above swaps the slot with a fresh unkeyed vnode and
+  // awaits several ticks, so it can't catch a render-ordering regression in the
+  // reset. This drives an actual vue-router navigation (broken -> healthy) so a
+  // stuck boundary would surface here. Guards the T-Rex-reported recovery bug.
+  it('recovers through a real router-view when navigating off a broken route', async () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const router = createRouter({
+      history: createMemoryHistory(),
+      routes: [
+        { path: '/broken', component: Exploding },
+        { path: '/healthy', component: Healthy },
+      ],
+    });
+
+    // Faithful copy of App.vue's router-view slot: unkeyed boundary persists
+    // across navigation; the child is keyed and reset by $route.fullPath.
+    const AppLikeHarness = defineComponent({
+      setup() {
+        const route = useRoute();
+        return () =>
+          h(RouterView, null, {
+            default: ({ Component }: { Component: Component | undefined }) =>
+              h(
+                RouteErrorBoundary,
+                { resetKey: route.fullPath },
+                { default: () => (Component ? h(Component, { key: route.fullPath }) : null) }
+              ),
+          });
+      },
+    });
+
+    router.push('/broken');
+    await router.isReady();
+
+    const wrapper = mount(AppLikeHarness, {
+      global: {
+        plugins: [router],
+        // Render the real RouterView; @vue/test-utils auto-stubs it otherwise,
+        // which would collapse the slot and make this a hollow test.
+        stubs: { RouterView: false },
+        config: { errorHandler: () => {} },
+      },
+    });
+    await flushPromises();
+
+    // Broken route -> fallback panel, no blank page.
+    expect(wrapper.find('[data-testid="route-error-boundary"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="healthy"]').exists()).toBe(false);
+
+    // Navigate to the healthy route -> the boundary must clear and render it.
+    await router.push('/healthy');
     await flushPromises();
 
     expect(wrapper.find('[data-testid="route-error-boundary"]').exists()).toBe(false);

--- a/src/tests/schemas/contracts/custom-domain/homepage-config.spec.ts
+++ b/src/tests/schemas/contracts/custom-domain/homepage-config.spec.ts
@@ -16,6 +16,40 @@ describe('homepageConfigCanonical', () => {
     updated_at: 1700000000,
   };
 
+  describe('signup_enabled / signin_enabled defaults', () => {
+    // Both auth-link toggles default OFF: a payload that omits them parses to
+    // false so the homepage nav links stay hidden unless a domain opts in.
+    const payloadWithoutFlags = {
+      domain_id: 'd_123',
+      enabled: true,
+      created_at: 1700000000,
+      updated_at: 1700000000,
+    };
+
+    it('defaults signup_enabled to false when omitted', () => {
+      const result = homepageConfigCanonical.safeParse(payloadWithoutFlags);
+      expect(result.success).toBe(true);
+      expect(result.success && result.data.signup_enabled).toBe(false);
+    });
+
+    it('defaults signin_enabled to false when omitted', () => {
+      const result = homepageConfigCanonical.safeParse(payloadWithoutFlags);
+      expect(result.success).toBe(true);
+      expect(result.success && result.data.signin_enabled).toBe(false);
+    });
+
+    it('honours an explicit true opt-in', () => {
+      const result = homepageConfigCanonical.safeParse({
+        ...payloadWithoutFlags,
+        signup_enabled: true,
+        signin_enabled: true,
+      });
+      expect(result.success).toBe(true);
+      expect(result.success && result.data.signup_enabled).toBe(true);
+      expect(result.success && result.data.signin_enabled).toBe(true);
+    });
+  });
+
   describe('disabled_homepage_variant', () => {
     it('accepts a known variant', () => {
       const result = homepageConfigCanonical.safeParse({

--- a/src/tests/shared/components/layout/TransactionalHeader.customDomain.spec.ts
+++ b/src/tests/shared/components/layout/TransactionalHeader.customDomain.spec.ts
@@ -289,6 +289,14 @@ describe('TransactionalHeader — Custom Domain Leak Vector', () => {
         expect(wrapper.find('[role="separator"]').exists()).toBe(false);
       });
 
+      // INVARIANT GUARD: null homepage_config must mean "show the links".
+      // TransactionalHeader renders on the canonical site too, where there is
+      // no per-domain config (null). If someone changes the component's
+      // `!== false` gate to `=== true` (to match BrandedMastHead's stricter
+      // custom-only rule), this case fails — that failure is intentional. Do
+      // not relax this expectation to make such a change pass; canonical relies
+      // on null → visible. See the comment on showDomainSignin in
+      // TransactionalHeader.vue.
       it('renders both links when homepage_config is null (canonical domain, no restriction)', async () => {
         wrapper = mountComponent(minimalNavProps, {
           domain_strategy: 'custom',

--- a/try/migrations/disable_homepage_auth_links_try.rb
+++ b/try/migrations/disable_homepage_auth_links_try.rb
@@ -1,0 +1,174 @@
+# try/migrations/disable_homepage_auth_links_try.rb
+#
+# frozen_string_literal: true
+
+# Tests for migrations/2026-07-03/20260703_01_disable_homepage_auth_links.rb
+#
+# Covers:
+#   - migration_needed? is true while any HomepageConfig still reports an
+#     enabled signup or signin link
+#   - dry-run performs no writes and reports would_disable / already_off
+#   - actual run flips signup_enabled/signin_enabled true -> false, leaves
+#     already-off records untouched, and preserves the homepage `enabled` flag
+#   - re-running is idempotent (all domains reported as already_off)
+#   - domains without a HomepageConfig record are skipped
+#
+# Post-#3026 note:
+#   - CustomDomain.create! now bootstraps a HomepageConfig with both auth-link
+#     toggles OFF (the new conservative default), so the "links enabled" state
+#     this migration resets must be staged explicitly via upsert.
+
+require_relative '../support/test_models'
+require 'familia/migration'
+require_relative '../../migrations/2026-07-03/20260703_01_disable_homepage_auth_links'
+
+OT.boot! :test
+
+Familia.dbclient.flushdb
+OT.info 'Cleaned Redis for disable-homepage-auth-links migration test run'
+
+@ts      = Familia.now.to_i
+@entropy = SecureRandom.hex(4)
+@owner   = Onetime::Customer.create!(email: "hp_dis_owner_#{@ts}_#{@entropy}@test.com")
+@org     = Onetime::Organization.create!("HpDis Test Org #{@ts}", @owner, "hp_dis_#{@ts}@test.com")
+
+# Domain ON: both auth links enabled (simulates the historical persisted true).
+@domain_on = Onetime::CustomDomain.create!("hp-dis-on-#{@ts}.example.com", @org.objid)
+Onetime::CustomDomain::HomepageConfig.upsert(
+  domain_id: @domain_on.identifier, enabled: true, signup_enabled: true, signin_enabled: true
+)
+
+# Domain MIXED: signup on, signin off.
+@domain_mixed = Onetime::CustomDomain.create!("hp-dis-mixed-#{@ts}.example.com", @org.objid)
+Onetime::CustomDomain::HomepageConfig.upsert(
+  domain_id: @domain_mixed.identifier, enabled: true, signup_enabled: true, signin_enabled: false
+)
+
+# Domain OFF: both already off (the bootstrap default created by create!).
+@domain_off = Onetime::CustomDomain.create!("hp-dis-off-#{@ts}.example.com", @org.objid)
+
+## Setup: staged auth-link states are on / mixed / off
+[
+  [Onetime::CustomDomain::HomepageConfig.find_by_domain_id(@domain_on.identifier).signup_enabled?,
+   Onetime::CustomDomain::HomepageConfig.find_by_domain_id(@domain_on.identifier).signin_enabled?],
+  [Onetime::CustomDomain::HomepageConfig.find_by_domain_id(@domain_mixed.identifier).signup_enabled?,
+   Onetime::CustomDomain::HomepageConfig.find_by_domain_id(@domain_mixed.identifier).signin_enabled?],
+  [Onetime::CustomDomain::HomepageConfig.find_by_domain_id(@domain_off.identifier).signup_enabled?,
+   Onetime::CustomDomain::HomepageConfig.find_by_domain_id(@domain_off.identifier).signin_enabled?],
+]
+#=> [[true, true], [true, false], [false, false]]
+
+## migration_needed? is true before any run (on + mixed have enabled links)
+@migration = Onetime::Migrations::DisableHomepageAuthLinks.new
+@migration.prepare
+@migration.migration_needed?
+#=> true
+
+# --- Dry run ---
+
+## Dry run completes successfully
+@dry = Onetime::Migrations::DisableHomepageAuthLinks.new(run: false)
+@dry.prepare
+@dry.migrate
+#=> true
+
+## Dry run leaves the on-domain untouched (still enabled)
+[Onetime::CustomDomain::HomepageConfig.find_by_domain_id(@domain_on.identifier).signup_enabled?,
+ Onetime::CustomDomain::HomepageConfig.find_by_domain_id(@domain_on.identifier).signin_enabled?]
+#=> [true, true]
+
+## Dry run reports the on + mixed domains under would_disable
+@dry.stats[:would_disable]
+#=> 2
+
+## Dry run reports the already-off domain under already_off
+@dry.stats[:already_off]
+#=> 1
+
+## Dry run performs no writes and reports zero errors
+[@dry.stats[:disabled], @dry.stats[:errors]]
+#=> [0, 0]
+
+# --- Actual run ---
+
+## Actual run completes successfully
+@run = Onetime::Migrations::DisableHomepageAuthLinks.new(run: true)
+@run.prepare
+@run.migrate
+#=> true
+
+## On-domain now has both auth links disabled
+@cfg_on = Onetime::CustomDomain::HomepageConfig.find_by_domain_id(@domain_on.identifier)
+[@cfg_on.signup_enabled?, @cfg_on.signin_enabled?]
+#=> [false, false]
+
+## Mixed-domain now has both auth links disabled
+@cfg_mixed = Onetime::CustomDomain::HomepageConfig.find_by_domain_id(@domain_mixed.identifier)
+[@cfg_mixed.signup_enabled?, @cfg_mixed.signin_enabled?]
+#=> [false, false]
+
+## Already-off domain is unchanged (still off)
+@cfg_off = Onetime::CustomDomain::HomepageConfig.find_by_domain_id(@domain_off.identifier)
+[@cfg_off.signup_enabled?, @cfg_off.signin_enabled?]
+#=> [false, false]
+
+## The homepage `enabled` (public secret form) flag is preserved, not touched
+@cfg_on.enabled?
+#=> true
+
+## Actual run counts: two disabled, one already_off, zero errors
+[@run.stats[:disabled], @run.stats[:already_off], @run.stats[:errors]]
+#=> [2, 1, 0]
+
+# --- Idempotency ---
+
+## After apply, migration_needed? returns false
+@check = Onetime::Migrations::DisableHomepageAuthLinks.new
+@check.prepare
+@check.migration_needed?
+#=> false
+
+## Re-running reports all three domains as already_off with no writes
+@rerun = Onetime::Migrations::DisableHomepageAuthLinks.new(run: true)
+@rerun.prepare
+@rerun.migrate
+[@rerun.stats[:already_off], @rerun.stats[:disabled], @rerun.stats[:errors]]
+#=> [3, 0, 0]
+
+# --- Missing HomepageConfig is skipped ---
+
+## Setup: a domain whose HomepageConfig record has been removed
+@domain_nocfg = Onetime::CustomDomain.create!("hp-dis-nocfg-#{@ts}.example.com", @org.objid)
+Onetime::CustomDomain::HomepageConfig.delete_for_domain!(@domain_nocfg.identifier)
+Onetime::CustomDomain::HomepageConfig.exists_for_domain?(@domain_nocfg.identifier)
+#=> false
+
+## migrate skips the record-less domain and still reports no errors
+@skip_run = Onetime::Migrations::DisableHomepageAuthLinks.new(run: true)
+@skip_run.prepare
+@skip_run.migrate
+[@skip_run.stats[:skipped_missing_config], @skip_run.stats[:errors]]
+#=> [1, 0]
+
+# --- Empty instances set ---
+
+## Setup: flush Redis so CustomDomain.instances is empty
+Familia.dbclient.flushdb
+Onetime::CustomDomain.instances.to_a
+#=> []
+
+## migration_needed? is false with zero domains
+@empty_check = Onetime::Migrations::DisableHomepageAuthLinks.new
+@empty_check.prepare
+@empty_check.migration_needed?
+#=> false
+
+## migrate returns true without raising and writes nothing
+@empty_run = Onetime::Migrations::DisableHomepageAuthLinks.new(run: true)
+@empty_run.prepare
+@empty_run.migrate
+[@empty_run.stats[:disabled], @empty_run.stats[:already_off], @empty_run.stats[:errors]]
+#=> [0, 0, 0]
+
+# Teardown
+Familia.dbclient.flushdb

--- a/try/unit/models/custom_domain_homepage_config_try.rb
+++ b/try/unit/models/custom_domain_homepage_config_try.rb
@@ -231,14 +231,14 @@ Onetime::CustomDomain::HomepageConfig.delete_for_domain!(@su_domain.identifier)
 Onetime::CustomDomain::HomepageConfig.exists_for_domain?(@su_domain.identifier)
 #=> false
 
-## upsert without signup_enabled/signin_enabled defaults signup_enabled? to true
+## upsert without signup_enabled/signin_enabled defaults signup_enabled? to false (conservative)
 @su_cfg = Onetime::CustomDomain::HomepageConfig.upsert(domain_id: @su_domain.identifier, enabled: false)
 @su_cfg.signup_enabled?
-#=> true
+#=> false
 
-## upsert without signup_enabled/signin_enabled defaults signin_enabled? to true
+## upsert without signup_enabled/signin_enabled defaults signin_enabled? to false (conservative)
 @su_cfg.signin_enabled?
-#=> true
+#=> false
 
 # --- upsert: explicit false persists ---
 
@@ -278,24 +278,25 @@ Onetime::CustomDomain::HomepageConfig.upsert(domain_id: @su_domain.identifier, e
 @noclobber.signin_enabled?
 #=> false
 
-# --- predicate: nil field treated as enabled ---
+# --- predicate: nil field treated as disabled (conservative default) ---
 # Familia's instantiate_from_hash uses allocate (no initialize), so init() is
 # NOT called on load. A record saved without signup_enabled/signin_enabled will
-# have those fields as nil when read back from Redis.
+# have those fields as nil when read back from Redis. Only an explicit boolean
+# true shows the link, so a nil field reads as disabled.
 # We simulate this by directly constructing an in-memory instance with nil fields.
 
-## signup_enabled? returns true when field is nil (legacy record, no field in Redis)
+## signup_enabled? returns false when field is nil (legacy record, no field in Redis)
 @legacy = Onetime::CustomDomain::HomepageConfig.new(domain_id: @su_domain.identifier)
 @legacy.signup_enabled = nil
 @legacy.signup_enabled?
-#=> true
+#=> false
 
-## signin_enabled? returns true when field is nil (legacy record)
+## signin_enabled? returns false when field is nil (legacy record)
 @legacy.signin_enabled = nil
 @legacy.signin_enabled?
-#=> true
+#=> false
 
-# --- CustomDomain.create! bootstrap includes signup/signin enabled ---
+# --- CustomDomain.create! bootstrap defaults signup/signin links off ---
 
 ## Setup: fresh domain, bootstrap record created by create!
 @boot_domain = Onetime::CustomDomain.create!("hp-cfg-boot-#{@ts}-#{@entropy}.example.com", @org.objid)
@@ -303,13 +304,13 @@ Onetime::CustomDomain::HomepageConfig.upsert(domain_id: @su_domain.identifier, e
 @boot_cfg.nil?
 #=> false
 
-## Bootstrapped record has signup_enabled? true
+## Bootstrapped record has signup_enabled? false (links hidden until opt-in)
 @boot_cfg.signup_enabled?
-#=> true
+#=> false
 
-## Bootstrapped record has signin_enabled? true
+## Bootstrapped record has signin_enabled? false (links hidden until opt-in)
 @boot_cfg.signin_enabled?
-#=> true
+#=> false
 
 # --- find_or_create_for_domain: persists new fields; preserves existing ---
 


### PR DESCRIPTION
## Summary

> [!IMPORTANT]
> Data migration after deployment:
> `bin/ots migrate --run 20260703_01_disable_homepage_auth_links`


Adds a `RouteErrorBoundary` component that wraps the active route and converts render/setup errors into a visible error panel with recovery affordances (reload or go home), preventing silent blank pages when route components throw.

### Problem
Vue's global `errorHandler` only logs errors to Sentry—it doesn't render a fallback. When a route component throws synchronously during setup/render, Vue tears down that subtree and leaves `<router-view>` empty, resulting in a blank page with no indication of failure.

### Solution
- **RouteErrorBoundary**: A new component using `onErrorCaptured` to catch errors in route subtrees and swap them for a user-friendly error panel
- Logs and reports errors to Sentry (mirroring the global handler) then returns `false` to prevent double-reporting
- Automatically recovers when the route changes (via `resetKey` prop watching)
- Integrated into `App.vue` wrapping `<router-view>` with the route's `fullPath` as the reset key

### Additional Safeguards
- **useDisabledConfig**: Added `coerceDisabledVariant()` to validate the resolved variant against the enum schema, collapsing invalid/empty values to the default instead of passing unknown keys to the component dispatcher
- **DisabledHomepage**: Added defensive fallback (`?? DisabledClosed`) when resolving the variant component, ensuring the dispatcher never receives `undefined`

These changes prevent blank pages from both render errors and invalid component resolution.

## Test Plan

Added comprehensive unit tests in `RouteErrorBoundary.spec.ts`:
- Verifies the fallback panel renders when a child throws during setup
- Confirms healthy children render normally without the error panel
- Tests recovery on navigation: error clears and the next healthy route renders

Added test cases in `useDisabledConfig.spec.ts`:
- Validates that empty-string variants fall back to the default
- Validates that unrecognized variants fall back to the default

All tests pass with the global error handler installed to mirror production behavior.

https://claude.ai/code/session_012cgRgRBcuEtb5Sug84CPuy