### PR TITLE
Unify mail domain vocabulary: brand_* for links, display_domain for labels

### DIFF
--- a/lib/onetime/mail/templates/expiration_warning.html.erb
+++ b/lib/onetime/mail/templates/expiration_warning.html.erb
@@ -14,7 +14,7 @@
       <div style="font-family: Helvetica, Arial, sans-serif; font-size: 11px; font-weight: 700; letter-spacing: 0.6px; text-transform: uppercase; color: #97a1ab; margin: 0 0 8px 0;">
         <%= t('email.common.secret_link_label') %>
       </div>
-      <a href="<%= secret_uri %>" style="display: block; text-decoration: none; word-break: break-all; font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace; font-size: 14px; line-height: 22px;" rel="noopener noreferrer"><span style="color: <%= brand_color %>; font-weight: 700;"><%= h(secret_uri[%r{\Ahttps?://[^/]+}]) %></span><span style="color: #8a96a3;"><%= h(secret_uri.sub(%r{\Ahttps?://[^/]+}, '')) %></span></a>
+      <a href="<%= brand_baseuri %><%= uri_path %>" style="display: block; text-decoration: none; word-break: break-all; font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace; font-size: 14px; line-height: 22px;" rel="noopener noreferrer"><span style="color: <%= brand_color %>; font-weight: 700;"><%= h(brand_baseuri) %></span><span style="color: #8a96a3;"><%= h(uri_path) %></span></a>
     </td>
   </tr>
 </table>

--- a/lib/onetime/mail/templates/incoming_secret.html.erb
+++ b/lib/onetime/mail/templates/incoming_secret.html.erb
@@ -16,7 +16,9 @@
 <% end %>
 
 <p style="font-family: Helvetica, Arial, sans-serif; font-size: 14px; line-height: 21px; color: #5a6672; margin: 0 0 6px 0;">
-  <%= h(t('email.incoming_secret.someone_sent', display_domain: display_domain.sub(%r{\Ahttps?://}, ''))) %>
+  <%# The i18n interpolation key stays display_domain (locale files reference
+      it); brand_host supplies the bare host the secret was shared from. %>
+  <%= h(t('email.incoming_secret.someone_sent', display_domain: brand_host)) %>
 </p>
 <p style="font-family: Helvetica, Arial, sans-serif; font-size: 14px; line-height: 21px; color: #5a6672; margin: 0 0 16px 0;">
   <%= t('email.incoming_secret.view_instructions') %>
@@ -29,7 +31,7 @@
       <div style="font-family: Helvetica, Arial, sans-serif; font-size: 11px; font-weight: 700; letter-spacing: 0.6px; text-transform: uppercase; color: #97a1ab; margin: 0 0 8px 0;">
         <%= t('email.common.secret_link_label') %>
       </div>
-      <a href="<%= display_domain %><%= uri_path %>" style="display: block; text-decoration: none; word-break: break-all; font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace; font-size: 14px; line-height: 22px;" rel="noopener noreferrer"><span style="color: <%= brand_color %>; font-weight: 700;"><%= h(display_domain) %></span><span style="color: #8a96a3;"><%= h(uri_path) %></span></a>
+      <a href="<%= brand_baseuri %><%= uri_path %>" style="display: block; text-decoration: none; word-break: break-all; font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace; font-size: 14px; line-height: 22px;" rel="noopener noreferrer"><span style="color: <%= brand_color %>; font-weight: 700;"><%= h(brand_baseuri) %></span><span style="color: #8a96a3;"><%= h(uri_path) %></span></a>
     </td>
   </tr>
 </table>

--- a/lib/onetime/mail/templates/incoming_secret.txt.erb
+++ b/lib/onetime/mail/templates/incoming_secret.txt.erb
@@ -4,11 +4,11 @@
 <%= t('email.incoming_secret.memo_label') %> <%= memo %>
 <% end %>
 
-<%= t('email.incoming_secret.someone_sent', display_domain: display_domain.sub(%r{\Ahttps?://}, '')) %>
+<%= t('email.incoming_secret.someone_sent', display_domain: brand_host) %>
 
 <%= t('email.incoming_secret.view_instructions') %>
 
-<%= display_domain %><%= uri_path %>
+<%= brand_baseuri %><%= uri_path %>
 
 <%= t('email.incoming_secret.important_label') %> <%= t('email.incoming_secret.link_works_once') %>
 <% if has_passphrase %>

--- a/lib/onetime/mail/templates/secret_link.html.erb
+++ b/lib/onetime/mail/templates/secret_link.html.erb
@@ -11,7 +11,7 @@
       <div style="font-family: Helvetica, Arial, sans-serif; font-size: 11px; font-weight: 700; letter-spacing: 0.6px; text-transform: uppercase; color: #97a1ab; margin: 0 0 8px 0;">
         <%= t('email.common.secret_link_label') %>
       </div>
-      <a href="<%= display_domain %><%= uri_path %>" style="display: block; text-decoration: none; word-break: break-all; font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace; font-size: 14px; line-height: 22px;" rel="noopener noreferrer"><span style="color: <%= brand_color %>; font-weight: 700;"><%= h(display_domain) %></span><span style="color: #8a96a3;"><%= h(uri_path) %></span></a>
+      <a href="<%= brand_baseuri %><%= uri_path %>" style="display: block; text-decoration: none; word-break: break-all; font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace; font-size: 14px; line-height: 22px;" rel="noopener noreferrer"><span style="color: <%= brand_color %>; font-weight: 700;"><%= h(brand_baseuri) %></span><span style="color: #8a96a3;"><%= h(uri_path) %></span></a>
     </td>
   </tr>
 </table>

--- a/lib/onetime/mail/templates/secret_link.txt.erb
+++ b/lib/onetime/mail/templates/secret_link.txt.erb
@@ -1,6 +1,6 @@
 <%= custid %> <%= t('email.secret_link.sent_you_secret') %>
 
-<%= display_domain %><%= uri_path %>
+<%= brand_baseuri %><%= uri_path %>
 
 <%= t('email.secret_link.important_label') %> <%= t('email.secret_link.link_works_once') %>
 <% if has_passphrase %>

--- a/lib/onetime/mail/views/base.rb
+++ b/lib/onetime/mail/views/base.rb
@@ -178,6 +178,13 @@ module Onetime
           data[:recipient] || data[:email_address] || data[:to]
         end
 
+        # URL scheme ('https://' unless site.ssl is explicitly false). Shared
+        # by site_baseuri and brand_baseuri so both agree on http/https.
+        # @return [String]
+        def scheme
+          site_ssl? ? 'https://' : 'http://'
+        end
+
         # Site SSL configuration helper
         # @return [Boolean]
         def site_ssl?
@@ -197,8 +204,19 @@ module Onetime
         # Site base URI configuration helper
         # @return [String]
         def site_baseuri
-          scheme = site_ssl? ? 'https://' : 'http://'
           "#{scheme}#{site_host}"
+        end
+
+        # Full base URI for the domain this message concerns: the custom
+        # share_domain when the message carries one, otherwise the
+        # (overridable) canonical base URI. Ruby-side twin of
+        # TemplateContext#brand_baseuri — keep the two in sync.
+        # @return [String]
+        def brand_baseuri
+          host = data[:share_domain].to_s
+          return data[:baseuri] || site_baseuri if host.empty?
+
+          "#{scheme}#{host}"
         end
 
         def site_product_name
@@ -213,7 +231,11 @@ module Onetime
           data[:product_name] || site_product_name
         end
 
-        # Display domain with fallback to site host
+        # Bare host label naming the domain this message is about. Used by
+        # account/system emails (password_request, magic_link, ...) in
+        # subjects and i18n interpolations; data-driven with a canonical-host
+        # fallback. Not a link: URLs are built from brand_baseuri, which
+        # derives from share_domain rather than display_domain.
         # @return [String]
         def display_domain
           data[:display_domain] || site_host
@@ -322,10 +344,15 @@ module Onetime
             @data[:product_name] || site_product_name
           end
 
-          # Display domain helper (custom domain or canonical)
+          # Bare host label naming the domain this message is about. Prefers
+          # an explicit per-message display_domain (account/system emails
+          # inject it for subjects and body copy; feedback_email reports the
+          # domain feedback was submitted from), then falls back to
+          # brand_host so domain-bound messages label the domain they
+          # concern. Not a link: templates build URLs from brand_baseuri.
           # @return [String]
           def display_domain
-            @data[:display_domain] || @data[:share_domain] || site_host
+            @data[:display_domain] || brand_host
           end
 
           # Host the shared layout header/footer links to and displays. Prefers

--- a/lib/onetime/mail/views/expiration_warning.rb
+++ b/lib/onetime/mail/views/expiration_warning.rb
@@ -59,15 +59,14 @@ module Onetime
           end
         end
 
-        # Full URI to view the secret
-        def secret_uri
-          "#{display_domain}/secret/#{data[:secret_key]}"
+        def uri_path
+          "/secret/#{data[:secret_key]}"
         end
 
-        def display_domain
-          scheme = site_ssl? ? 'https://' : 'http://'
-          host   = data[:share_domain].to_s.empty? ? site_host : data[:share_domain]
-          "#{scheme}#{host}"
+        # Full URI to view the secret, on the domain the secret was shared
+        # from (share_domain when present, canonical host otherwise).
+        def secret_uri
+          "#{brand_baseuri}#{uri_path}"
         end
 
         def baseuri
@@ -81,7 +80,7 @@ module Onetime
           computed_data = data.merge(
             time_remaining: time_remaining,
             secret_uri: secret_uri,
-            display_domain: display_domain,
+            uri_path: uri_path,
             baseuri: baseuri,
           )
           TemplateContext.new(computed_data, locale).get_binding

--- a/lib/onetime/mail/views/incoming_secret.rb
+++ b/lib/onetime/mail/views/incoming_secret.rb
@@ -44,12 +44,6 @@ module Onetime
           data[:recipient]
         end
 
-        def display_domain
-          scheme = site_ssl? ? 'https://' : 'http://'
-          host   = data[:share_domain].to_s.empty? ? site_host : data[:share_domain]
-          "#{scheme}#{host}"
-        end
-
         def uri_path
           "/secret/#{data[:secret_key]}"
         end
@@ -76,9 +70,10 @@ module Onetime
           data[:has_passphrase] == true
         end
 
+        # The secret link itself is built in the template from brand_baseuri
+        # (a TemplateContext helper reading share_domain) plus uri_path.
         def template_binding
           computed_data = data.merge(
-            display_domain: display_domain,
             uri_path: uri_path,
             memo: memo,
             has_memo: has_memo?,

--- a/lib/onetime/mail/views/secret_link.rb
+++ b/lib/onetime/mail/views/secret_link.rb
@@ -44,13 +44,6 @@ module Onetime
           data[:recipient]
         end
 
-        # Computed template variables
-        def display_domain
-          scheme = site_ssl? ? 'https://' : 'http://'
-          host   = data[:share_domain].to_s.empty? ? site_host : data[:share_domain]
-          "#{scheme}#{host}"
-        end
-
         def uri_path
           "/secret/#{data[:secret_key]}"
         end
@@ -73,10 +66,11 @@ module Onetime
           data[:has_passphrase] == true
         end
 
-        # Override to include computed values in template context
+        # Override to include computed values in template context.
+        # The secret link itself is built in the template from brand_baseuri
+        # (a TemplateContext helper reading share_domain) plus uri_path.
         def template_binding
           computed_data = data.merge(
-            display_domain: display_domain,
             uri_path: uri_path,
             custid: custid,
             has_passphrase: has_passphrase?,

--- a/spec/integration/all/mail/template_rendering_spec.rb
+++ b/spec/integration/all/mail/template_rendering_spec.rb
@@ -801,8 +801,7 @@ RSpec.describe 'Email Template Rendering', type: :integration do
         sender_email: 's@b.com',
         share_domain: 'custom.example.com'
       })
-      expect(template.display_domain).to include('custom.example.com')
-      expect(template.render_text).to include('custom.example.com')
+      expect(template.render_text).to match(%r{https?://custom\.example\.com/secret/abc})
     end
 
     it 'ExpirationWarning uses share_domain when provided' do
@@ -812,7 +811,7 @@ RSpec.describe 'Email Template Rendering', type: :integration do
         expires_at: Time.now.to_i + 3600,
         share_domain: 'custom.example.com'
       })
-      expect(template.display_domain).to include('custom.example.com')
+      expect(template.secret_uri).to match(%r{\Ahttps?://custom\.example\.com/secret/abc\z})
       expect(template.render_text).to include('custom.example.com')
     end
   end

--- a/spec/unit/onetime/mail/views/incoming_secret_spec.rb
+++ b/spec/unit/onetime/mail/views/incoming_secret_spec.rb
@@ -85,36 +85,39 @@ RSpec.describe Onetime::Mail::Templates::IncomingSecret do
   end
 
   # ---------------------------------------------------------------------------
-  # display_domain
+  # Secret link domain selection (brand_baseuri via the template context)
   # ---------------------------------------------------------------------------
+  # The class no longer exposes a full-URI display_domain; the link's domain
+  # is chosen by TemplateContext#brand_baseuri at render time, so assert on
+  # the rendered secret link instead.
 
-  describe '#display_domain' do
+  describe 'secret link domain in rendered output' do
+    before do
+      allow(I18n).to receive(:t) { |key, **_opts| key.to_s }
+    end
+
     context 'when share_domain is nil' do
-      it 'falls back to the configured site host' do
-        result = template.display_domain
-        expect(result).to match(%r{\Ahttps?://})
+      it 'links to the configured site host' do
+        expect(template.render_text).to match(%r{https?://\S+/secret/abc123def456})
       end
     end
 
     context 'when share_domain is provided' do
       let(:valid_data) { super().merge(share_domain: 'secrets.example.com') }
 
-      it 'uses the share_domain in the URL' do
-        expect(template.display_domain).to include('secrets.example.com')
-      end
-
-      it 'starts with a scheme' do
-        expect(template.display_domain).to match(%r{\Ahttps?://secrets\.example\.com\z})
+      it 'builds the secret link on the share_domain, scheme included' do
+        expect(template.render_text)
+          .to match(%r{https?://secrets\.example\.com/secret/abc123def456})
       end
     end
 
     context 'when share_domain is an empty string' do
       let(:valid_data) { super().merge(share_domain: '') }
 
-      it 'falls back to the site host' do
-        result = template.display_domain
-        expect(result).to match(%r{\Ahttps?://})
-        expect(result).not_to match(%r{://\z})
+      it 'falls back to the site host rather than an empty authority' do
+        text = template.render_text
+        expect(text).to match(%r{https?://\S+/secret/abc123def456})
+        expect(text).not_to match(%r{https?:///})
       end
     end
   end

--- a/try/unit/mail/templates_base_try.rb
+++ b/try/unit/mail/templates_base_try.rb
@@ -165,6 +165,13 @@ context = Onetime::Mail::Templates::Base::TemplateContext.new({ share_domain: 's
 context.display_domain
 #=> 'share.com'
 
+## TemplateContext display_domain treats an empty share_domain as absent
+# Regression guard: display_domain now falls back through brand_host, which
+# maps '' to the canonical site host instead of returning the empty string.
+context = Onetime::Mail::Templates::Base::TemplateContext.new({ share_domain: '' }, 'en')
+context.display_domain == context.site_host
+#=> true
+
 ## TemplateContext display_domain falls back to site_host when neither provided
 context = Onetime::Mail::Templates::Base::TemplateContext.new({}, 'en')
 context.display_domain.is_a?(String) && !context.display_domain.empty?

--- a/try/unit/mail/templates_expiration_warning_try.rb
+++ b/try/unit/mail/templates_expiration_warning_try.rb
@@ -114,15 +114,17 @@ template = Onetime::Mail::Templates::ExpirationWarning.new(@valid_data)
 template.secret_uri
 #=~> /\/secret\/abc123def456/
 
-## ExpirationWarning display_domain uses site host by default
+## ExpirationWarning secret_uri links to the canonical host by default
+# secret_uri is built from brand_baseuri, which falls back to the canonical
+# site baseuri when the message carries no share_domain.
 template = Onetime::Mail::Templates::ExpirationWarning.new(@valid_data)
-template.display_domain
-#=~> /https?:\/\/.+/
+template.secret_uri
+#=~> /\Ahttps?:\/\/.+\/secret\/abc123def456\z/
 
-## ExpirationWarning display_domain uses share_domain when present
+## ExpirationWarning secret_uri links to the share_domain when present
 template = Onetime::Mail::Templates::ExpirationWarning.new(@valid_data_with_domain)
-template.display_domain
-#=~> /https?:\/\/custom\.example\.com/
+template.secret_uri
+#=> 'https://custom.example.com/secret/xyz789'
 
 ## ExpirationWarning baseuri uses site config by default
 template = Onetime::Mail::Templates::ExpirationWarning.new(@valid_data)
@@ -171,5 +173,5 @@ email[:text_body].is_a?(String) && !email[:text_body].empty?
 ## ExpirationWarning handles nil share_domain gracefully
 data = @valid_data.merge(share_domain: nil)
 template = Onetime::Mail::Templates::ExpirationWarning.new(data)
-template.display_domain
-#=~> /https?:\/\/.+/
+template.secret_uri
+#=~> /\Ahttps?:\/\/.+\/secret\/abc123def456\z/

--- a/try/unit/mail/templates_incoming_secret_try.rb
+++ b/try/unit/mail/templates_incoming_secret_try.rb
@@ -94,16 +94,20 @@ template = Onetime::Mail::Templates::IncomingSecret.new(data)
 template.has_memo?
 #=> false
 
-## IncomingSecret display_domain uses site host by default
+## IncomingSecret body links to the canonical host by default
+# The link is built in the template from brand_baseuri (a TemplateContext
+# helper), which falls back to the canonical site baseuri when the message
+# carries no share_domain.
+ctx = Onetime::Mail::Templates::Base::TemplateContext.new({}, 'en')
 template = Onetime::Mail::Templates::IncomingSecret.new(@valid_data)
-template.display_domain
-#=~> /https?:\/\/.+/
+template.render_text.include?("#{ctx.site_baseuri}/secret/incoming_key_abc")
+#=> true
 
-## IncomingSecret display_domain uses share_domain when present
+## IncomingSecret body links to the share_domain when present
 data = @valid_data.merge(share_domain: 'custom.example.com')
 template = Onetime::Mail::Templates::IncomingSecret.new(data)
-template.display_domain
-#=~> /https?:\/\/custom\.example\.com/
+template.render_text.include?('https://custom.example.com/secret/incoming_key_abc')
+#=> true
 
 ## IncomingSecret signature_link returns site baseuri
 template = Onetime::Mail::Templates::IncomingSecret.new(@valid_data)

--- a/try/unit/mail/templates_secret_link_try.rb
+++ b/try/unit/mail/templates_secret_link_try.rb
@@ -93,15 +93,19 @@ template = Onetime::Mail::Templates::SecretLink.new(@valid_data)
 template.custid
 #=> 'sender@example.com'
 
-## SecretLink display_domain uses site host by default
+## SecretLink body links to the canonical host when share_domain is nil
+# The link is built in the template from brand_baseuri (a TemplateContext
+# helper), which falls back to the canonical site baseuri when the message
+# carries no share_domain.
+ctx = Onetime::Mail::Templates::Base::TemplateContext.new({}, 'en')
 template = Onetime::Mail::Templates::SecretLink.new(@valid_data)
-template.display_domain
-#=~> /https?:\/\/.+/
+template.render_text.include?("#{ctx.site_baseuri}/secret/abc123def456")
+#=> true
 
-## SecretLink display_domain uses share_domain when present
+## SecretLink body links to the share_domain when present
 template = Onetime::Mail::Templates::SecretLink.new(@valid_data_with_domain)
-template.display_domain
-#=~> /https?:\/\/custom\.example\.com/
+template.render_text.include?('https://custom.example.com/secret/xyz789')
+#=> true
 
 ## SecretLink baseuri uses site config by default
 template = Onetime::Mail::Templates::SecretLink.new(@valid_data)
@@ -150,8 +154,8 @@ email[:text_body].is_a?(String) && !email[:text_body].empty?
 ## SecretLink handles nil share_domain gracefully
 data = @valid_data.merge(share_domain: nil)
 template = Onetime::Mail::Templates::SecretLink.new(data)
-template.display_domain
-#=~> /https?:\/\/.+/
+template.render_text
+#=~> /https?:\/\/.+\/secret\/abc123def456/
 
 ## SecretLink shared layout links header/footer to the custom share_domain
 html = Onetime::Mail::Templates::SecretLink.new(@valid_data_with_domain).render_html


### PR DESCRIPTION
## Summary

Stacked on #3617. Addresses the naming/cognitive-load smell claude-review flagged there: `display_domain` (body templates) and `brand_host`/`brand_baseuri` (layout chrome) were similarly-named methods with overlapping-but-different fallback semantics scattered across classes.

### The mess, concretely

`display_domain` meant three different things:

1. **`Base#display_domain`** — bare host *label* (`data[:display_domain] || site_host`), used by account/system emails (password_request, magic_link, ...) in subjects and i18n interpolations. Live and correct.
2. **`SecretLink` / `IncomingSecret` / `ExpirationWarning`** — three identical copy-pasted overrides returning a full `scheme + host` **URI** derived from `share_domain` — exactly the semantics #3617 introduced as `brand_baseuri` for the layout.
3. **`TemplateContext#display_domain`** — a third fallback chain (`display_domain || share_domain || site_host`) that returned `""` for an empty-string `share_domain`.

Plus two template hacks born of the URI/label confusion: `incoming_secret` stripped the scheme back off with `display_domain.sub(%r{\Ahttps?://}, '')`, and `expiration_warning.html.erb` regex-split `secret_uri` into host and path for the two-tone link.

### After this change, one meaning per name

- **`brand_baseuri` / `brand_host`**: the domain the message concerns — `share_domain` when present, canonical otherwise. Body secret links are now built from `brand_baseuri + uri_path`, matching the layout header/footer. A Ruby-side `Base#brand_baseuri` twin serves `ExpirationWarning#secret_uri`.
- **`display_domain`**: bare host *label* for account/system emails, documented as such at both definition sites. The three full-URI overrides are deleted; the scheme-strip and regex-split hacks are replaced by `brand_host` / `brand_baseuri + uri_path`.
- `TemplateContext#display_domain` now falls back through `brand_host`, so an empty-string `share_domain` yields the canonical host instead of an empty label (regression-tested).

### Behavior notes (reviewed deliberately)

- **Rendered output is unchanged in practice.** The only semantic delta: body secret links now honor a `data[:baseuri]` override when `share_domain` is absent, matching the layout's `brand_baseuri`. No caller passes `baseuri` to these three mailers (verified: `expiration_warning_job`, `create_incoming_secret`, the receipt share flow) — only the Rodauth account-email modules do, and those are unaffected.
- The i18n interpolation key `%{display_domain}` in `email.incoming_secret.someone_sent` is untouched (locale files unchanged); `brand_host` now supplies the value.

## Test Plan

- `try/unit/mail/` — **477/477** (includes a new regression test for the empty-string `share_domain` edge)
- `try/features/incoming/` — **266/266**
- `try/unit/cli/email/` — **37/37** (renders templates from sample data)
- Display-domain tests on the three secret-family mailers were converted from method-level assertions to rendered-output assertions (the methods no longer exist; the rendered link is what matters), using the CodeQL-safe full-URL/method-result comparison patterns established in #3617.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CAJveCqiKb8wX5fd76uvDi

---
_Generated by [Claude Code](https://claude.ai/code/session_01CAJveCqiKb8wX5fd76uvDi)_