### PR TITLE
Consolidate brand identity to single authority (#3612)

### DIFF
--- a/.env.reference
+++ b/.env.reference
@@ -520,7 +520,8 @@ HELP_ENABLED=true
 # and omits the logo from email templates. Emails only emit absolute
 # http(s) URLs; a relative path still works for the masthead but degrades
 # emails to a text-only header. Values ending in .vue (the frontend's
-# component-sentinel convention) are ignored. Set to a full https:// URL.
+# component-sentinel convention) are ignored. Set to a full absolute URL
+# (https:// recommended).
 #BRAND_LOGO_URL=
 
 # Alt text for the brand logo (accessibility / hover title). Default when

--- a/.env.reference
+++ b/.env.reference
@@ -447,6 +447,9 @@ HELP_ENABLED=true
 # auto: shown, unless a custom brand logo is configured (custom logos usually
 # embed their own wordmark). Set 'true'/'false' to force either way; the
 # product name stays active in page titles and MFA labels regardless.
+# Migration note (#3612): unset previously meant always-on. If you relied on
+# the site name showing next to a custom LOGO_URL/BRAND_LOGO_URL, set
+# LOGO_SHOW_NAME=true to keep the wordmark.
 #LOGO_SHOW_NAME=
 
 # Render custom logos at a larger size in authenticated views

--- a/.env.reference
+++ b/.env.reference
@@ -422,29 +422,39 @@ DEFAULT_DISABLED_HOMEPAGE_VARIANT=
 # Show help modals on secret reveal/receipt pages. Set to 'false' to hide.
 HELP_ENABLED=true
 
-# One of: DefaultLogo.vue, LegacyLogo.vue, OnetimeSecretLogo.vue
+# Deprecated (#3612): use BRAND_LOGO_URL (brand.logo_url) instead. A value
+# set here is still honored as a fallback, with a deprecation warning at
+# boot. Vue component sentinels (e.g. the old DefaultLogo.vue default) are
+# ignored.
 #LOGO_URL=
 
-# Alt text for the masthead logo (accessibility / hover title).
-# Default when unset: "Share a Secret One-Time".
-#LOGO_ALT=Share a Secret One-Time
+# Deprecated (#3612): use BRAND_LOGO_ALT (brand.logo_alt) instead. A value
+# set here is still honored as a fallback, with a deprecation warning at
+# boot.
+#LOGO_ALT=
 
-# Click target for the masthead logo. Accepts a relative path or absolute
-# URL. Default when unset: / (home).
+# Click target for the masthead logo (site.interface.ui.header.logo.href).
+# Accepts a relative path or absolute URL. Default when unset: / (home).
 #LOGO_LINK=/
 
-# Company name used in page titles, MFA authenticator labels, and header logo text.
-#SITE_NAME=One-Time Secret
+# Deprecated (#3612): use BRAND_PRODUCT_NAME (brand.product_name) instead.
+# A value set here is still honored as a fallback, with a deprecation
+# warning at boot.
+#SITE_NAME=
 
-# Whether to show the site name text next to the logo icon in the masthead.
-# Set to 'false' to display icon-only while keeping SITE_NAME for titles and MFA.
-#LOGO_SHOW_NAME=true
+# Show the product name (BRAND_PRODUCT_NAME) as a text mark next to the logo
+# icon in the masthead (site.interface.ui.header.logo.show_name). Unset means
+# auto: shown, unless a custom brand logo is configured (custom logos usually
+# embed their own wordmark). Set 'true'/'false' to force either way; the
+# product name stays active in page titles and MFA labels regardless.
+#LOGO_SHOW_NAME=
 
-# Render custom logos at a larger size in authenticated views.
-# When true, authenticated users see an 80px logo instead of the compact 40px.
-# Useful for rasterized brand assets that need more visual presence alongside
-# the org/domain context switchers. Unauthenticated views always use the
-# prominent treatment (160px) for custom logos regardless of this setting.
+# Render custom logos at a larger size in authenticated views
+# (site.interface.ui.header.logo.prominent). When true, authenticated users
+# see an 80px logo instead of the compact 40px. Useful for rasterized brand
+# assets that need more visual presence alongside the org/domain context
+# switchers. Unauthenticated views always use the prominent treatment (160px)
+# for custom logos regardless of this setting.
 #LOGO_PROMINENT=false
 
 # Homepage UI toggle. Set to 'false' to show a disabled/API-only landing
@@ -480,9 +490,10 @@ HELP_ENABLED=true
 # Default when unset: #3B82F6 (neutral blue).
 #BRAND_PRIMARY_COLOR='#3B82F6'
 
-# Product name in emails, page titles, and logo alt text.
-# Default when unset: OTS.
-#BRAND_PRODUCT_NAME=OTS
+# Product name in emails, page titles, logo alt text, and (unless
+# BRAND_TOTP_ISSUER is set) MFA authenticator labels.
+# Default when unset: "Secure Links" (neutral).
+#BRAND_PRODUCT_NAME=
 
 # Canonical product domain stored in brand settings for per-domain
 # overrides. Not currently consumed by any template or component.
@@ -503,10 +514,18 @@ HELP_ENABLED=true
 # (e.g. light brand colors). Default: true.
 #BRAND_BUTTON_TEXT_LIGHT=true
 
-# Logo URL for outbound emails. No default — unset omits the logo from
-# email templates. The masthead uses LOGO_URL / per-domain branding, not
-# this value. Set to a full https:// URL.
+# Brand logo URL for the masthead and outbound emails. Never shown on
+# tenant custom domains — those render their own uploaded logo or the
+# neutral mark. No default — unset shows the neutral mark in the masthead
+# and omits the logo from email templates. Emails only emit absolute
+# http(s) URLs; a relative path still works for the masthead but degrades
+# emails to a text-only header. Values ending in .vue (the frontend's
+# component-sentinel convention) are ignored. Set to a full https:// URL.
 #BRAND_LOGO_URL=
+
+# Alt text for the brand logo (accessibility / hover title). Default when
+# unset: an i18n string derived from the product name.
+#BRAND_LOGO_ALT=
 
 # Favicon URL for the installation. Overrides the default /favicon.ico for
 # all domains that don't have their own per-domain icon. Set to a full
@@ -530,8 +549,8 @@ HELP_ENABLED=true
 
 # Issuer label shown in TOTP/MFA authenticator apps. Used by both the
 # frontend QR code and the server-side Rodauth OTP configuration.
-# Default when unset: OTS.
-#BRAND_TOTP_ISSUER=OTS
+# Default when unset: BRAND_PRODUCT_NAME, then OTS.
+#BRAND_TOTP_ISSUER=
 
 # Sign-off name on the closing line of transactional emails (welcome,
 # password reset, magic link, email-change, org invite, etc.). Kept separate
@@ -607,6 +626,9 @@ WORKER_HEARTBEAT_INTERVAL=600
 # strict (default): raise an error and refuse to start
 # warn:             log a migration message and continue
 # silent:           ignore
+# Soft deprecations whose legacy values still work via a fallback (e.g.
+# SITE_NAME/LOGO_URL/LOGO_ALT, #3612) only ever log — even under strict —
+# so a working install keeps booting; silent suppresses them too.
 DEPRECATED_CONFIG_MODE=strict
 
 

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -37,6 +37,12 @@ Lint/RedundantSafeNavigation:
 Metrics/MethodLength:
   Max: 168
 
+# Offense count: 1
+# Configuration parameters: CountComments, CountAsOne.
+Metrics/ModuleLength:
+  Exclude:
+    - 'lib/onetime/config.rb'
+
 # Offense count: 14
 # Configuration parameters: AllowedMethods, AllowedPatterns, Max.
 Metrics/PerceivedComplexity:

--- a/apps/api/domains/logic/sender_config/send_test_email.rb
+++ b/apps/api/domains/logic/sender_config/send_test_email.rb
@@ -193,11 +193,18 @@ module DomainsAPI
           end
         end
 
+        # Install-branded platform name for outbound copy — a hardcoded vendor
+        # literal here would leak into a white-label install's test emails.
+        def platform_name
+          Onetime::CustomDomain::BrandSettingsConstants.global_defaults[:product_name] ||
+            Onetime::CustomDomain::BrandSettingsConstants::NEUTRAL_PRODUCT_NAME
+        end
+
         def build_text_body(domain, from_name, from_address, reply_to)
           lines = []
           lines << "Test Email from #{domain}"
           lines << ''
-          lines << 'This is a test email sent via Onetime Secret to verify your'
+          lines << "This is a test email sent via #{platform_name} to verify your"
           lines << 'email sender configuration is working correctly.'
           lines << ''
           lines << 'Configuration details:'
@@ -221,7 +228,7 @@ module DomainsAPI
                 Test Email from #{escape_html(domain)}
               </h2>
               <p>
-                This is a test email sent via Onetime Secret to verify your
+                This is a test email sent via #{escape_html(platform_name)} to verify your
                 email sender configuration is working correctly.
               </p>
               <table style="border-collapse: collapse; margin: 20px 0; width: 100%;">

--- a/apps/web/core/spec/views/base_spec.rb
+++ b/apps/web/core/spec/views/base_spec.rb
@@ -50,10 +50,11 @@ RSpec.describe Core::Views::BaseView do
     it 'sets basic template variables' do
       expect(subject.view_vars['description']).to eq('Test Description')
       expect(subject.view_vars['keywords']).to eq('test,keywords')
-      # page_title falls through display_domain -> brand_product_name -> site_name;
-      # the test config stubs none of them, and GLOBAL_DEFAULTS[:product_name] is
-      # nil per #3049, so it resolves to nil here (not 'OTS').
-      expect(subject.view_vars['page_title']).to be_nil
+      # page_title falls through display_domain -> brand_product_name (the
+      # legacy site_name tier was retired in #3612); the test config stubs
+      # neither, so it resolves to the neutral NEUTRAL_PRODUCT_NAME terminal —
+      # the server-rendered <title> must never be empty, and never 'OTS'.
+      expect(subject.view_vars['page_title']).to eq('Secure Links')
     end
 
     it 'initializes JavaScript variables' do

--- a/apps/web/core/spec/views/serializers/config_serializer_spec.rb
+++ b/apps/web/core/spec/views/serializers/config_serializer_spec.rb
@@ -155,6 +155,7 @@ RSpec.describe Core::Views::ConfigSerializer do
           'brand_font_family' => 'serif',
           'brand_button_text_light' => false,
           'brand_logo_url' => 'https://acme.test/logo.svg',
+          'brand_logo_alt' => 'Acme Vault wordmark',
           'brand_favicon_url' => 'https://acme.test/favicon.png',
           'support_email' => 'help@acme.test',
           'docs_host' => 'https://docs.acme.test/'
@@ -201,6 +202,11 @@ RSpec.describe Core::Views::ConfigSerializer do
         expect(result['brand_logo_url']).to eq('https://acme.test/logo.svg')
       end
 
+      it 'copies brand_logo_alt from view_vars to output' do
+        result = described_class.serialize(brand_view_vars)
+        expect(result['brand_logo_alt']).to eq('Acme Vault wordmark')
+      end
+
       it 'copies brand_favicon_url from view_vars to output' do
         result = described_class.serialize(brand_view_vars)
         expect(result['brand_favicon_url']).to eq('https://acme.test/favicon.png')
@@ -227,6 +233,7 @@ RSpec.describe Core::Views::ConfigSerializer do
           brand_font_family
           brand_button_text_light
           brand_logo_url
+          brand_logo_alt
           brand_favicon_url
         ].each do |key|
           expect(result[key]).to be_nil, "expected #{key} to be nil when view_vars omits it"
@@ -244,6 +251,7 @@ RSpec.describe Core::Views::ConfigSerializer do
           brand_font_family
           brand_button_text_light
           brand_logo_url
+          brand_logo_alt
           brand_favicon_url
         ].each do |key|
           expect(template_keys).to include(key), "output_template missing #{key}"

--- a/apps/web/core/views/helpers/initialize_view_vars.rb
+++ b/apps/web/core/views/helpers/initialize_view_vars.rb
@@ -173,11 +173,15 @@ module Core
                                Onetime::CustomDomain::BrandSettingsConstants::GLOBAL_DEFAULTS[:product_name]
 
         # Use the display domain name for branded instances, otherwise the
-        # configured brand product name. site_name (the deprecated
-        # site.interface.ui.header.branding.site_name) is kept only as a tail
-        # fallback for instances mid-migration; remove once consumers update.
-        site_name            = site_config.dig('interface', 'ui', 'header', 'branding', 'site_name')
-        page_title           = display_domain || brand_product_name || site_name
+        # configured brand product name. The deprecated
+        # site.interface.ui.header.branding.site_name tier was retired in
+        # #3612 — a legacy SITE_NAME now reaches brand.product_name via the
+        # normalize_brand fallback, so this reads the brand block only. The
+        # neutral terminal keeps the server-rendered <title>/og:title from
+        # going empty on an unconfigured canonical install (display_domain
+        # can be nil there), matching the mail-surface fallback.
+        page_title           = display_domain || brand_product_name ||
+                               Onetime::CustomDomain::BrandSettingsConstants::NEUTRAL_PRODUCT_NAME
         no_cache             = false
         frontend_host        = development['frontend_host']
         frontend_development = development['enabled']
@@ -209,6 +213,7 @@ module Core
         brand_product_domain        = brand_config['product_domain']
         brand_support_email         = brand_config['support_email'] || brand_global_defaults[:support_email]
         brand_logo_url              = brand_config['logo_url'] || brand_global_defaults[:logo_url]
+        brand_logo_alt              = brand_config['logo_alt'] || brand_global_defaults[:logo_alt]
         brand_favicon_url           = brand_config['favicon_url'] || brand_global_defaults[:favicon_url]
         # Mobile/social variety-pack URLs used by the HTML head. Unlike the
         # fields above (which default to nil and fall through to the frontend
@@ -271,6 +276,7 @@ module Core
           'brand_product_domain' => brand_product_domain,
           'brand_support_email' => brand_support_email,
           'brand_logo_url' => brand_logo_url,
+          'brand_logo_alt' => brand_logo_alt,
           'brand_favicon_url' => brand_favicon_url,
           'brand_apple_touch_icon_url' => brand_apple_touch_icon_url,
           'brand_og_image_url' => brand_og_image_url,

--- a/apps/web/core/views/serializers/config_serializer.rb
+++ b/apps/web/core/views/serializers/config_serializer.rb
@@ -77,6 +77,7 @@ module Core
         output['brand_font_family']           = view_vars['brand_font_family']
         output['brand_button_text_light']     = view_vars['brand_button_text_light']
         output['brand_logo_url']              = view_vars['brand_logo_url']
+        output['brand_logo_alt']              = view_vars['brand_logo_alt']
         output['brand_favicon_url']           = view_vars['brand_favicon_url']
         output['support_email']               = view_vars['support_email']
         output['docs_host']                   = view_vars['docs_host']
@@ -129,6 +130,7 @@ module Core
             'brand_font_family' => nil,
             'brand_button_text_light' => nil,
             'brand_logo_url' => nil,
+            'brand_logo_alt' => nil,
             'brand_favicon_url' => nil,
             'd9s_enabled' => nil,
             'development' => nil,

--- a/changelog.d/20260703_000000_claude_brand_single_authority.rst
+++ b/changelog.d/20260703_000000_claude_brand_single_authority.rst
@@ -1,0 +1,46 @@
+.. A new scriv changelog fragment.
+
+Added
+-----
+
+- New ``BRAND_LOGO_ALT`` / ``brand.logo_alt`` setting for operator-supplied
+  brand-logo alt text; when unset, alt text falls back to an i18n string
+  derived from the product name. (#3612)
+
+Changed
+-------
+
+- The ``brand:`` config block is now the single authority for brand identity:
+  one documented path (``BRAND_PRODUCT_NAME``, ``BRAND_LOGO_URL``,
+  ``BRAND_LOGO_ALT``) brands the masthead, outbound emails, page titles, and
+  MFA labels. ``BRAND_LOGO_URL`` now drives the masthead operator logo too
+  (previously it was email-only); emails only emit absolute http(s) logo URLs,
+  degrading to a text-only header otherwise. (#3612)
+- The header config is reduced to masthead layout knobs under
+  ``site.interface.ui.header.logo`` — ``href`` (``LOGO_LINK``), ``show_name``
+  (``LOGO_SHOW_NAME``), and ``prominent`` (``LOGO_PROMINENT``); the env vars
+  are unchanged. ``show_name`` unset now means "show the wordmark unless a
+  custom brand logo is configured". (#3612)
+- Unconfigured installs now present a fully neutral identity — the "Secure
+  Links" name and keyhole mark in the masthead, emails, and page titles —
+  instead of the old "One-Time Secret" defaults. (#3612)
+- TOTP/MFA authenticator entries now use the configured product name as the
+  issuer label when ``BRAND_TOTP_ISSUER`` is unset, so renamed installs brand
+  new MFA enrollments too. (#3612)
+
+Deprecated
+----------
+
+- ``SITE_NAME``, ``LOGO_URL``, and ``LOGO_ALT`` (the
+  ``site.interface.ui.header.branding`` path) are deprecated in favor of
+  ``BRAND_PRODUCT_NAME``, ``BRAND_LOGO_URL``, and ``BRAND_LOGO_ALT``. Legacy
+  values are still honored as fallbacks; boot logs a warning naming the
+  replacement but never refuses to start, even under
+  ``DEPRECATED_CONFIG_MODE=strict``. (#3612)
+
+Fixed
+-----
+
+- The operator/install logo no longer leaks onto tenant custom domains: they
+  show their own uploaded logo or the neutral mark, matching the existing
+  wordmark guard. (#3612)

--- a/docs/architecture/branding.md
+++ b/docs/architecture/branding.md
@@ -18,6 +18,12 @@ Operator how-to (setting `BRAND_*`, favicon overrides):
 3. NEUTRAL_BRAND_DEFAULTS (frontend constants)
 ```
 
+The legacy `site.interface.ui.header.branding` rung (`SITE_NAME`, `LOGO_URL`,
+`LOGO_ALT`) is deprecated (#3612) and no longer a runtime tier:
+`Config#normalize_brand` absorbs any legacy values into step 2 at boot, so
+consumers only ever read the `brand:` block. See
+[Legacy migration](#legacy-migration-3612).
+
 **Step 1 — per-domain (Redis).** Custom domains store their own brand in
 `CustomDomain#branding` (`BrandSettings`, 22 fields, WCAG-AA validated).
 Delivered to the frontend as `domain_branding` in the bootstrap payload.
@@ -39,6 +45,16 @@ it re-reads the env vars in Ruby, normalizes blanks to `nil`, and coerces
 tolerant, disables it). An env-set field always wins; when a var is unset, any
 value set directly in a YAML config file is left intact.
 
+`normalize_brand` is also where the legacy branding sources land (#3612): when
+the `brand:` authority leaves `product_name` / `logo_url` / `logo_alt` nil, it
+adopts the deprecated `SITE_NAME` / `LOGO_URL` / `LOGO_ALT` env vars or the
+legacy `site.interface.ui.header.branding` YAML values — rejecting `*.vue`
+component sentinels (the old `LOGO_URL` default `DefaultLogo.vue` is a
+frontend marker, not an asset URL). `normalize_header_layout` runs next: it
+migrates the masthead layout knobs to `site.interface.ui.header.logo`
+(`link_to` → `href`, plus `show_name` / `prominent`) and deletes the
+`branding` subtree so it never reaches the bootstrap payload.
+
 **Step 3 — neutral fallback.** When no brand data is present (the common
 self-hosted case), the frontend uses `NEUTRAL_BRAND_DEFAULTS`
 (`src/shared/constants/brand.ts`): neutral blue `#3B82F6`, product name
@@ -51,22 +67,60 @@ the fallback — it is retained only where OTS-orange is specifically intended
 Each `BRAND_*` ENV var populates `OT.conf['brand'][...]` → a `brand_*` bootstrap
 field. No defaults shipped.
 
-| ENV var                                | Purpose                                      |
-| -------------------------------------- | -------------------------------------------- |
-| `BRAND_PRIMARY_COLOR`                  | base hue for the generated palette           |
-| `BRAND_PRODUCT_NAME`                   | product name / manifest name                 |
-| `BRAND_PRODUCT_DOMAIN`                 |                                              |
-| `BRAND_SUPPORT_EMAIL`                  |                                              |
-| `BRAND_CORNER_STYLE`                   | `rounded` \| `square` \| `pill`              |
-| `BRAND_FONT_FAMILY`                    | `sans` \| `serif` \| `mono`                  |
-| `BRAND_BUTTON_TEXT_LIGHT`              |                                              |
-| `BRAND_ALLOW_PUBLIC_HOMEPAGE` / `_API` |                                              |
-| `BRAND_LOGO_URL`                       |                                              |
-| `BRAND_FAVICON_URL`                    | `/favicon.ico` 302 redirect                  |
-| `BRAND_APPLE_TOUCH_ICON_URL`           | head `apple-touch-icon`                      |
-| `BRAND_OG_IMAGE_URL`                   | head `og:image` / `twitter:image` (absolute) |
-| `BRAND_TOTP_ISSUER`                    | MFA issuer label                             |
-| `BRAND_SIGNATURE_NAME`                 | email sign-off (see Special cases)           |
+| ENV var                      | Purpose                                            |
+| ---------------------------- | -------------------------------------------------- |
+| `BRAND_PRIMARY_COLOR`        | base hue for the generated palette                 |
+| `BRAND_PRODUCT_NAME`         | product name / manifest name                       |
+| `BRAND_PRODUCT_DOMAIN`       |                                                    |
+| `BRAND_SUPPORT_EMAIL`        |                                                    |
+| `BRAND_CORNER_STYLE`         | `rounded` \| `square` \| `pill`                    |
+| `BRAND_FONT_FAMILY`          | `sans` \| `serif` \| `mono`                        |
+| `BRAND_BUTTON_TEXT_LIGHT`    |                                                    |
+| `BRAND_LOGO_URL`             | masthead + email logo, per-domain default          |
+| `BRAND_LOGO_ALT`             | logo alt text (falls back to product-name i18n)    |
+| `BRAND_FAVICON_URL`          | `/favicon.ico` 302 redirect                        |
+| `BRAND_APPLE_TOUCH_ICON_URL` | head `apple-touch-icon`                            |
+| `BRAND_OG_IMAGE_URL`         | head `og:image` / `twitter:image` (absolute)       |
+| `BRAND_TOTP_ISSUER`          | MFA issuer label (falls back to product name)      |
+| `BRAND_SIGNATURE_NAME`       | email sign-off (see Special cases)                 |
+
+`BRAND_LOGO_URL` is the operator/install logo everywhere: the masthead, email
+templates, and the default for custom domains with no uploaded logo — but it is
+never rendered *as the operator's* on tenant custom domains (they get their own
+upload or the neutral mark, same guard as the wordmark). Emails only emit
+absolute `http(s)` URLs; a masthead-oriented relative path degrades emails to a
+text-only header.
+
+`brand.allow_public_homepage` / `brand.allow_public_api` are YAML-only keys
+(read by `initialize_view_vars.rb`, default `false`) — they have **no** env var
+wiring in `Config::BRAND_ENV`.
+
+The TOTP/MFA authenticator issuer resolves `brand.totp_issuer` →
+`brand.product_name` → `'OTS'`, so a configured product name brands new MFA
+enrollments without a separate issuer setting.
+
+### Legacy migration (#3612)
+
+The `brand:` block is the single authority for brand identity. The legacy
+`site.interface.ui.header.branding` path and its unprefixed env vars still work
+via the `normalize_brand` fallbacks above, but boot logs a deprecation warning
+naming the replacement. These are **soft** deprecations: they only ever warn —
+even under `DEPRECATED_CONFIG_MODE=strict` boot is never refused (`silent`
+suppresses the warning).
+
+| Legacy           | Replacement                                             |
+| ---------------- | ------------------------------------------------------- |
+| `SITE_NAME`      | `BRAND_PRODUCT_NAME` (`brand.product_name`)             |
+| `LOGO_URL`       | `BRAND_LOGO_URL` (`brand.logo_url`)                     |
+| `LOGO_ALT`       | `BRAND_LOGO_ALT` (`brand.logo_alt`)                     |
+| `LOGO_LINK`      | `site.interface.ui.header.logo.href` (env unchanged)    |
+| `LOGO_SHOW_NAME` | `…header.logo.show_name` (env unchanged)                |
+| `LOGO_PROMINENT` | `…header.logo.prominent` (env unchanged)                |
+
+The three layout knobs are *not* deprecated — only their YAML nesting moved
+(and `link_to` was renamed `href`). `show_name` is now explicit-only: unset
+means "show the wordmark unless a custom brand logo is configured" (custom
+logos usually embed their own wordmark).
 
 ## CSS palette
 
@@ -143,6 +197,8 @@ in that file.
       blue / `"Secure Links"`)
 - [ ] `BRAND_SUPPORT_EMAIL`, `BRAND_LOGO_URL` (or per-domain logo via the
       CustomDomain API)
+- [ ] Migrate any legacy `SITE_NAME` / `LOGO_URL` / `LOGO_ALT` to the `BRAND_*`
+      equivalents (deprecated since #3612 — still honored, but boot warns)
 - [ ] Clear `BRAND_*` → verify neutral theme appears (fallback works)
 - [ ] Confirm email templates render brand colour inline
 - [ ] WCAG-AA check on the chosen colour

--- a/docs/architecture/branding.md
+++ b/docs/architecture/branding.md
@@ -120,7 +120,9 @@ suppresses the warning).
 The three layout knobs are *not* deprecated — only their YAML nesting moved
 (and `link_to` was renamed `href`). `show_name` is now explicit-only: unset
 means "show the wordmark unless a custom brand logo is configured" (custom
-logos usually embed their own wordmark).
+logos usually embed their own wordmark). Previously, unset meant always-on —
+an install that set `LOGO_URL` and relied on the implicit wordmark should set
+`LOGO_SHOW_NAME=true` to keep it.
 
 ## CSS palette
 

--- a/docs/product/branding-favicon.md
+++ b/docs/product/branding-favicon.md
@@ -64,6 +64,12 @@ BRAND_LOGO_URL=https://cdn.example.com/logo.svg
 `BRAND_PRIMARY_COLOR` onto the neutral manifest, so those env vars also brand the
 Android install (icons still need a file).
 
+`BRAND_LOGO_URL` is not an icon-pack asset: it is the brand logo itself, shown
+in the masthead and in outbound emails (emails require an absolute `https://`
+URL). It appears above because it usually points at the same CDN. Pair it with
+`BRAND_LOGO_ALT` for the logo's alt text; unset falls back to an i18n string
+derived from the product name.
+
 **Option B — drop-in files at build.** Place replacement files in
 [`docker/public/`](../../docker/public/) before building; the `Dockerfile`
 copies them flat into `public/web/`. Empty by default. The right choice for

--- a/docs/product/branding-favicon.md
+++ b/docs/product/branding-favicon.md
@@ -65,8 +65,9 @@ BRAND_LOGO_URL=https://cdn.example.com/logo.svg
 Android install (icons still need a file).
 
 `BRAND_LOGO_URL` is not an icon-pack asset: it is the brand logo itself, shown
-in the masthead and in outbound emails (emails require an absolute `https://`
-URL). It appears above because it usually points at the same CDN. Pair it with
+in the masthead and in outbound emails (emails require an absolute `http(s)://`
+URL — https recommended; other values degrade emails to a text-only header).
+It appears above because it usually points at the same CDN. Pair it with
 `BRAND_LOGO_ALT` for the logo's alt text; unset falls back to an i18n string
 derived from the product name.
 

--- a/etc/defaults/config.defaults.yaml
+++ b/etc/defaults/config.defaults.yaml
@@ -82,37 +82,38 @@ site:
         receipt: <%= ENV['UI_CAPABILITIES_RECEIPT'] != 'false' %>
         recipient: <%= ENV['UI_CAPABILITIES_RECIPIENT'] != 'false' %>
       # Header configuration
-      # Controls branding and navigation in the site header
+      # Controls the site header and masthead layout. Brand identity — which
+      # logo asset renders and what the product is called — lives in the
+      # brand: block below (BRAND_LOGO_URL, BRAND_PRODUCT_NAME, BRAND_LOGO_ALT);
+      # the knobs here only control how the masthead presents it. The former
+      # header.branding nesting (LOGO_URL, LOGO_ALT, SITE_NAME) is deprecated
+      # and honored as a fallback by Config#normalize_brand (#3612).
       header:
         # Control switch to enable/disable header customization
         enabled: <%= ENV['HEADER_ENABLED'] != 'false' %>
-        # Branding configuration for the masthead logo and site identity
-        branding:
-          # Logo lockup: icon + optional text mark in the masthead
-          logo:
-            # Vue component name or image URL (e.g. DefaultLogo.vue, /img/logo.svg)
-            url: <%= ENV['LOGO_URL'] || 'DefaultLogo.vue' %>
-            alt: <%= ENV['LOGO_ALT'] || 'Share a Secret One-Time' %>
-            link_to: <%= ENV['LOGO_LINK'] || '/' %>
-            # Show the site name as a text mark next to the logo icon.
-            # Set false for icon-only display; SITE_NAME remains active
-            # in page titles, MFA labels, and emails regardless.
-            show_name: <%= ENV['LOGO_SHOW_NAME'] != 'false' %>
-            # Render the logo at a larger size in the authenticated header.
-            # Useful for rasterized brand assets (e.g. LOGO_URL=/img/brand.png)
-            # that need more visual presence alongside the org/domain switchers.
-            # The default (false) keeps the logo compact (40px) so context
-            # switchers fit on the same row. When true, custom logos render at
-            # 80px in authenticated views. Unauthenticated views (branded
-            # homepage / disabled page) always render the logo prominently.
-            prominent: <%= ENV['LOGO_PROMINENT'] == 'true' %>
-          # Product name used across the application:
-          #   - Masthead text mark (when logo.show_name is true)
-          #   - Browser page title
-          #   - MFA authenticator app issuer label
-          #   - Outbound email sender name
-          # Falls back to i18n key if not set.
-          site_name: <%= ENV['SITE_NAME'] || 'One-Time Secret' %>
+        # Masthead layout knobs (presentation only). All three treat an unset
+        # OR empty env var as "not specified" (YAML nil) so compose files with
+        # blank assignments don't accidentally pin an explicit value. href is
+        # JSON-quoted for the same reason as the brand block below: an
+        # operator URL with YAML-significant characters must survive parsing.
+        logo:
+          # Where the logo lockup links to. Unset uses '/'.
+          href: <%= (v = ENV['LOGO_LINK'].to_s).empty? ? nil : v.to_json %>
+          # Show the product name as a text mark next to the logo icon.
+          # Unset (default): shown, unless a custom brand logo is configured
+          # (custom logos usually embed their own wordmark). Set true/false
+          # to force either way. The product name itself comes from
+          # BRAND_PRODUCT_NAME and remains active in page titles, MFA labels,
+          # and emails regardless of this knob.
+          show_name: <%= (v = ENV['LOGO_SHOW_NAME'].to_s).empty? ? nil : v != 'false' %>
+          # Render the logo at a larger size in the authenticated header.
+          # Useful for rasterized brand assets (e.g. BRAND_LOGO_URL=/img/brand.png)
+          # that need more visual presence alongside the org/domain switchers.
+          # The default (unset/false) keeps the logo compact (40px) so context
+          # switchers fit on the same row. When true, custom logos render at
+          # 80px in authenticated views. Unauthenticated views (branded
+          # homepage / disabled page) always render the logo prominently.
+          prominent: <%= (v = ENV['LOGO_PROMINENT'].to_s).empty? ? nil : v == 'true' %>
         # Navigation configuration
         navigation:
           # Enable/disable header navigation entirely
@@ -432,6 +433,9 @@ brand:
   font_family: <%= ENV['BRAND_FONT_FAMILY']&.to_json %>
   button_text_light: <%= ENV['BRAND_BUTTON_TEXT_LIGHT']&.to_json %>
   logo_url: <%= ENV['BRAND_LOGO_URL']&.to_json %>
+  # Accessible name for the brand logo. Unset falls back to an i18n string
+  # derived from the product name.
+  logo_alt: <%= ENV['BRAND_LOGO_ALT']&.to_json %>
   favicon_url: <%= ENV['BRAND_FAVICON_URL']&.to_json %>
   # URL overrides for the mobile/social variety pack served in the HTML head.
   # When unset, neutral bundled defaults (public/web) are used; replacing the

--- a/lib/onetime/cli/email/test_command.rb
+++ b/lib/onetime/cli/email/test_command.rb
@@ -53,11 +53,16 @@ module Onetime
           hostname  = Socket.gethostname
           timestamp = Time.now.utc.iso8601
 
+          # Brand-aware copy: a hardcoded vendor literal would leak into a
+          # white-label install's outbound test email (#3612).
+          product_name = Onetime::CustomDomain::BrandSettingsConstants.global_defaults[:product_name] ||
+                         Onetime::CustomDomain::BrandSettingsConstants::NEUTRAL_PRODUCT_NAME
+
           email = {
             to: to,
             from: Onetime::Mail::Mailer.from_address,
-            subject: "[OTS] Email delivery test - #{timestamp}",
-            text_body: "This is a test email from Onetime Secret CLI.\n\nProvider: #{provider}\nTimestamp: #{timestamp}\nHost: #{hostname}",
+            subject: "[#{product_name}] Email delivery test - #{timestamp}",
+            text_body: "This is a test email from the #{product_name} CLI.\n\nProvider: #{provider}\nTimestamp: #{timestamp}\nHost: #{hostname}",
           }
 
           if format == 'json'

--- a/lib/onetime/config.rb
+++ b/lib/onetime/config.rb
@@ -639,7 +639,9 @@ module Onetime
       # surfaces differ: the web UI resolves a relative path fine, while mail
       # rendering requires an absolute URL and silently degrades to a
       # text-only header otherwise. Tell the operator at boot rather than
-      # letting them discover it in a delivered email.
+      # letting them discover it in a delivered email. Deliberately always
+      # logged: this is an operational notice about mail rendering, not a
+      # deprecation, so compatibility.deprecated_config_mode does not apply.
       logo_url = brand['logo_url']
       if logo_url && !logo_url.match?(%r{\Ahttps?://}i)
         OT.le "CONFIG NOTICE: brand.logo_url '#{logo_url}' is not an absolute http(s) URL; " \

--- a/lib/onetime/config.rb
+++ b/lib/onetime/config.rb
@@ -664,15 +664,16 @@ module Onetime
 
     # Digs a key path out of a config hash, tolerating malformed intermediate
     # nodes: a legacy subtree where e.g. header.branding.logo is a scalar
-    # would make Hash#dig raise TypeError and abort boot — for an optional
-    # fallback source, unreadable simply means absent.
+    # would make Hash#dig raise TypeError (or NoMethodError, depending on the
+    # node) and abort boot — for an optional fallback source, unreadable
+    # simply means absent.
     #
     # @param conf [Hash] configuration hash
     # @param path [Array<String>] key path
     # @return [Object, nil]
     def dig_path(conf, path)
       conf.dig(*path)
-    rescue TypeError
+    rescue TypeError, NoMethodError
       nil
     end
 

--- a/lib/onetime/config.rb
+++ b/lib/onetime/config.rb
@@ -140,7 +140,7 @@ module Onetime
         },
       }
 
-      # Declarative manifest of removed configuration keys.
+      # Declarative manifest of removed and deprecated configuration keys.
       #
       # Each entry maps a deprecated config path and/or the env var that
       # used to populate it to a migration message. check_deprecations
@@ -149,11 +149,16 @@ module Onetime
       # or is ignored ('silent').
       #
       # Fields:
-      #   path:    Array of keys to dig into conf (optional)
-      #   env:     Environment variable name (optional)
-      #   trigger: Proc that receives the path value; returns true to fire (optional)
-      #            When absent, any non-nil value triggers. Use for type-specific checks.
-      #   message: User-facing migration guidance
+      #   path:     Array of keys to dig into conf (optional)
+      #   env:      Environment variable name (optional)
+      #   trigger:  Proc that receives the path value; returns true to fire (optional)
+      #             When absent, any non-nil value triggers. Use for type-specific checks.
+      #   severity: :warn marks a soft deprecation — the legacy value still works
+      #             (via a fallback shim), so detection only ever logs, even under
+      #             the 'strict' policy ('silent' still suppresses it). Entries
+      #             without severity describe removed keys and follow the policy
+      #             as-is, raising under 'strict'.
+      #   message:  User-facing migration guidance
       DEPRECATIONS = [
         {
           path: %w[site interface ui homepage trusted_proxy_depth],
@@ -197,6 +202,47 @@ module Onetime
           message: <<~MSG.chomp,
             features.regions.jurisdictions array format is deprecated. Use JURISDICTIONS env var
             (format: EU:eu.example.com,CA:ca.example.com) instead.
+          MSG
+        },
+        # Brand identity consolidation (#3612): the brand: block is the single
+        # authority for brand identity. The legacy header.branding path and its
+        # unprefixed env vars still work via normalize_brand fallbacks, so these
+        # are soft (severity: :warn) — boot warns with the one-line fix but
+        # never refuses to start a working install.
+        {
+          env: 'SITE_NAME',
+          severity: :warn,
+          message: <<~MSG.chomp,
+            SITE_NAME is deprecated. Set BRAND_PRODUCT_NAME (brand.product_name) instead;
+            the SITE_NAME value is honored as a fallback for now.
+          MSG
+        },
+        {
+          env: 'LOGO_URL',
+          severity: :warn,
+          message: <<~MSG.chomp,
+            LOGO_URL is deprecated. Set BRAND_LOGO_URL (brand.logo_url) instead;
+            the LOGO_URL value is honored as a fallback for now.
+          MSG
+        },
+        {
+          env: 'LOGO_ALT',
+          severity: :warn,
+          message: <<~MSG.chomp,
+            LOGO_ALT is deprecated. Set BRAND_LOGO_ALT (brand.logo_alt) instead;
+            the LOGO_ALT value is honored as a fallback for now.
+          MSG
+        },
+        {
+          path: %w[site interface ui header branding],
+          env: nil,
+          severity: :warn,
+          message: <<~MSG.chomp,
+            site.interface.ui.header.branding is deprecated. Brand identity moved to the
+            brand: block (BRAND_PRODUCT_NAME, BRAND_LOGO_URL, BRAND_LOGO_ALT); masthead
+            layout knobs moved to site.interface.ui.header.logo (href, show_name,
+            prominent — LOGO_LINK, LOGO_SHOW_NAME, LOGO_PROMINENT are unchanged).
+            Legacy values are honored as fallbacks for now.
           MSG
         },
       ].freeze
@@ -442,7 +488,13 @@ module Onetime
       # Normalize the brand block from BRAND_* env vars. Done here (in Ruby)
       # rather than via ERB/YAML interpolation so values with YAML-significant
       # characters — notably the leading '#' in primary_color hex — survive.
+      # Runs after check_deprecations (so legacy branding config is reported
+      # before its values are absorbed) and before deep_freeze (so consumers
+      # never resolve fallbacks themselves). normalize_header_layout must
+      # follow normalize_brand: it deletes the legacy branding subtree that
+      # normalize_brand's fallbacks read.
       normalize_brand(conf)
+      normalize_header_layout(conf)
 
       # Ensure array jurisdiction entries have display_name_i18n_key
       # (String format already converted to Array above, before check_deprecations)
@@ -500,10 +552,40 @@ module Onetime
       'corner_style' => 'BRAND_CORNER_STYLE',
       'font_family' => 'BRAND_FONT_FAMILY',
       'logo_url' => 'BRAND_LOGO_URL',
+      'logo_alt' => 'BRAND_LOGO_ALT',
       'favicon_url' => 'BRAND_FAVICON_URL',
       'apple_touch_icon_url' => 'BRAND_APPLE_TOUCH_ICON_URL',
       'og_image_url' => 'BRAND_OG_IMAGE_URL',
       'totp_issuer' => 'BRAND_TOTP_ISSUER',
+    }.freeze
+
+    # Maps brand identity keys to their deprecated sources (#3612): the legacy
+    # unprefixed env var and the legacy site.interface.ui.header.branding YAML
+    # path. Consulted by normalize_brand only when the brand: authority (BRAND_*
+    # env or brand: YAML) leaves the key nil, so working installs keep working
+    # while check_deprecations names the one-line fix.
+    LEGACY_BRAND_FALLBACKS = {
+      'product_name' => {
+        env: 'SITE_NAME',
+        path: %w[site interface ui header branding site_name],
+      },
+      'logo_url' => {
+        env: 'LOGO_URL',
+        path: %w[site interface ui header branding logo url],
+      },
+      'logo_alt' => {
+        env: 'LOGO_ALT',
+        path: %w[site interface ui header branding logo alt],
+      },
+    }.freeze
+
+    # Masthead layout knobs that moved from the legacy branding nesting to
+    # site.interface.ui.header.logo (#3612). New-path key => legacy key under
+    # header.branding.logo. Booleans are honored as-is; href replaces link_to.
+    LEGACY_HEADER_LOGO_KEYS = {
+      'href' => 'link_to',
+      'show_name' => 'show_name',
+      'prominent' => 'prominent',
     }.freeze
 
     # Normalize the brand block, reading BRAND_* env vars directly so values
@@ -511,6 +593,15 @@ module Onetime
     # are not mangled by the ERB/YAML layer. An env var that is set always
     # wins; when unset, the value already present from YAML is left intact so
     # operators can still set brand keys directly in their config file.
+    #
+    # Identity keys with a legacy source (LEGACY_BRAND_FALLBACKS) fall back to
+    # the deprecated env var / header.branding path when the brand: authority
+    # leaves them nil. Sentinel component values (e.g. the legacy LOGO_URL
+    # default 'DefaultLogo.vue') are never adopted — they are frontend-only
+    # markers, not asset URLs, and would break consumers like email templates.
+    #
+    # All resolution happens here, before the config is deep-frozen, so
+    # consumers only ever read final values (never re-derive fallbacks).
     #
     # @param conf [Hash] the merged configuration (mutated in place)
     # @return [void]
@@ -529,6 +620,21 @@ module Onetime
         end
       end
 
+      # The logo asset must be an image URL: a Vue component reference (the
+      # frontend's neutral-sentinel convention) is meaningless to emails,
+      # favicon handling, and per-domain defaults, so it never enters the
+      # brand block — from any source, including an operator-set
+      # BRAND_LOGO_URL (hazard 1 of #3612).
+      brand['logo_url'] = nil if brand['logo_url'].is_a?(String) && brand['logo_url'].end_with?('.vue')
+
+      LEGACY_BRAND_FALLBACKS.each do |key, legacy|
+        next unless brand[key].nil?
+
+        candidate  = legacy_brand_value(ENV.fetch(legacy[:env], nil)) ||
+                     legacy_brand_value(dig_path(conf, legacy[:path]))
+        brand[key] = candidate if candidate
+      end
+
       # button_text_light: light text on brand-colored buttons. Default-on;
       # only an explicit 'false' (env or YAML) disables it. nil when unset.
       raw                        = ENV.fetch('BRAND_BUTTON_TEXT_LIGHT', nil)
@@ -542,6 +648,61 @@ module Onetime
         nil
       else
         raw.strip != 'false'
+      end
+    end
+
+    # Digs a key path out of a config hash, tolerating malformed intermediate
+    # nodes: a legacy subtree where e.g. header.branding.logo is a scalar
+    # would make Hash#dig raise TypeError and abort boot — for an optional
+    # fallback source, unreadable simply means absent.
+    #
+    # @param conf [Hash] configuration hash
+    # @param path [Array<String>] key path
+    # @return [Object, nil]
+    def dig_path(conf, path)
+      conf.dig(*path)
+    rescue TypeError
+      nil
+    end
+
+    # Normalizes a candidate value from a legacy branding source: trims,
+    # rejects blanks and non-strings, and rejects Vue component sentinels
+    # ('*.vue') so 'DefaultLogo.vue' never enters brand.logo_url (#3612).
+    #
+    # @param value [Object] raw legacy env var or YAML value
+    # @return [String, nil] usable value or nil
+    def legacy_brand_value(value)
+      return nil unless value.is_a?(String)
+
+      value = value.strip
+      return nil if value.empty? || value.end_with?('.vue')
+
+      value
+    end
+
+    # Migrates masthead layout knobs from the deprecated header.branding.logo
+    # nesting to site.interface.ui.header.logo (#3612), then removes the
+    # branding subtree so it never reaches the frontend bootstrap payload.
+    # Legacy values only fill knobs the new path leaves nil (env vars LOGO_LINK
+    # / LOGO_SHOW_NAME / LOGO_PROMINENT feed the new path via ERB already).
+    # Identity fields under branding (logo.url/.alt, site_name) are harvested
+    # by normalize_brand, which must run first.
+    #
+    # @param conf [Hash] the merged configuration (mutated in place)
+    # @return [void]
+    def normalize_header_layout(conf)
+      header = conf.dig('site', 'interface', 'ui', 'header')
+      return unless header.is_a?(Hash)
+
+      branding    = header.delete('branding')
+      legacy_logo = branding.is_a?(Hash) ? branding['logo'] : nil
+      return unless legacy_logo.is_a?(Hash)
+
+      logo = (header['logo'] ||= {})
+      LEGACY_HEADER_LOGO_KEYS.each do |new_key, legacy_key|
+        next if legacy_logo[legacy_key].nil? || !logo[new_key].nil?
+
+        logo[new_key] = legacy_logo[legacy_key]
       end
     end
 
@@ -599,17 +760,20 @@ module Onetime
     #   warn             - log each migration message and continue
     #   silent           - ignore
     #
-    # An unrecognized policy value is treated as strict.
+    # An unrecognized policy value is treated as strict. Entries marked
+    # severity: :warn are soft deprecations (the legacy value still works
+    # via a fallback shim): they log under both 'strict' and 'warn' and
+    # never raise, so a working install keeps booting.
     #
     # @param conf [Hash] The merged configuration
     # @return [void]
-    # @raise [OT::ConfigError] When a deprecated key is found under strict policy
+    # @raise [OT::ConfigError] When a removed key is found under strict policy
     def check_deprecations(conf)
       detected = DEPRECATIONS.select do |dep|
         env_set = !!(dep[:env] && !ENV[dep[:env]].to_s.empty?)
 
         # Check path, optionally with a trigger proc for type-specific detection
-        path_value = dep[:path] && conf.dig(*dep[:path])
+        path_value = dep[:path] && dig_path(conf, dep[:path])
         path_set   = if dep[:trigger] && path_value
           dep[:trigger].call(path_value)
         else
@@ -620,10 +784,14 @@ module Onetime
       end
       return if detected.empty?
 
-      policy   = (conf.dig('compatibility', 'deprecated_config_mode') || 'strict').to_s
-      messages = detected.map { |dep| dep[:message] }
+      policy = (conf.dig('compatibility', 'deprecated_config_mode') || 'strict').to_s
       return if policy == 'silent'
 
+      soft, hard = detected.partition { |dep| dep[:severity] == :warn }
+      soft.each { |dep| OT.le "CONFIG DEPRECATION: #{dep[:message]}" }
+      return if hard.empty?
+
+      messages = hard.map { |dep| dep[:message] }
       if policy == 'warn'
         messages.each { |msg| OT.le "CONFIG DEPRECATION: #{msg}" }
         return

--- a/lib/onetime/config.rb
+++ b/lib/onetime/config.rb
@@ -635,6 +635,17 @@ module Onetime
         brand[key] = candidate if candidate
       end
 
+      # brand.logo_url is now the one install logo for every surface, but the
+      # surfaces differ: the web UI resolves a relative path fine, while mail
+      # rendering requires an absolute URL and silently degrades to a
+      # text-only header otherwise. Tell the operator at boot rather than
+      # letting them discover it in a delivered email.
+      logo_url = brand['logo_url']
+      if logo_url && !logo_url.match?(%r{\Ahttps?://}i)
+        OT.le "CONFIG NOTICE: brand.logo_url '#{logo_url}' is not an absolute http(s) URL; " \
+              'it will render in the web UI but is omitted from outbound emails.'
+      end
+
       # button_text_light: light text on brand-colored buttons. Default-on;
       # only an explicit 'false' (env or YAML) disables it. nil when unset.
       raw                        = ENV.fetch('BRAND_BUTTON_TEXT_LIGHT', nil)
@@ -698,7 +709,11 @@ module Onetime
       legacy_logo = branding.is_a?(Hash) ? branding['logo'] : nil
       return unless legacy_logo.is_a?(Hash)
 
-      logo = (header['logo'] ||= {})
+      # Coerce a malformed scalar (e.g. `logo: "oops"`) to an empty hash —
+      # this path exists to tolerate legacy/hand-edited configs, so it must
+      # not abort boot on one.
+      logo = header['logo']
+      logo = header['logo'] = {} unless logo.is_a?(Hash)
       LEGACY_HEADER_LOGO_KEYS.each do |new_key, legacy_key|
         next if legacy_logo[legacy_key].nil? || !logo[new_key].nil?
 

--- a/lib/onetime/mail/templates/layout.html.erb
+++ b/lib/onetime/mail/templates/layout.html.erb
@@ -41,7 +41,7 @@
                     or email-client level, so a broken <img> is a negative trust
                     signal. logo_url presence prevents an empty src. %>
                 <% if show_logo? && logo_url %>
-                <img alt="<%= h(product_name) %>" src="<%= logo_url %>" <%# herb:disable erb-prefer-image-tag-helper %>
+                <img alt="<%= h(logo_alt) %>" src="<%= logo_url %>" <%# herb:disable erb-prefer-image-tag-helper %>
                      style="border: 0; display: block; margin: 0 0 14px 0; height: 40px; width: 40px; background-color: <%= brand_color %>; border-radius: 8px;"
                      width="40" height="40">
                 <% end %>

--- a/lib/onetime/mail/views/base.rb
+++ b/lib/onetime/mail/views/base.rb
@@ -369,11 +369,15 @@ module Onetime
           end
 
           # Logo alt text helper - operator-supplied brand.logo_alt
-          # (BRAND_LOGO_ALT) when set, otherwise product_name so the logo's
-          # accessible name matches the surrounding brand identity.
+          # (BRAND_LOGO_ALT) when set, otherwise the install-level product
+          # name. Deliberately site_product_name, not product_name: the image
+          # this alt describes is always the install-wide brand.logo_url, so
+          # a per-message data[:product_name] (e.g. a tenant name) must not
+          # label the operator's logo — the same wrong-accessible-name rule
+          # the frontend applies to installLogoAlt.
           # @return [String]
           def logo_alt
-            conf_dig('brand', 'logo_alt') || product_name
+            conf_dig('brand', 'logo_alt') || site_product_name
           end
 
           # Logo URL helper - resolves from brand config; nil when no brand

--- a/lib/onetime/mail/views/base.rb
+++ b/lib/onetime/mail/views/base.rb
@@ -420,6 +420,12 @@ module Onetime
             end
           end
 
+          # Operator opt-in gate for rendering a logo <img> in mail at all.
+          # Templates require show_logo? AND a usable logo_url — an absolute
+          # brand.logo_url still renders text-only when emailer.show_logo is
+          # unset/false. The two gates are independent by design: show_logo?
+          # is the "do I trust images in mail clients" switch, logo_url is
+          # the asset (nil when unset or not absolute http(s)).
           def show_logo?
             conf_dig('emailer', 'show_logo') == true
           end

--- a/lib/onetime/mail/views/base.rb
+++ b/lib/onetime/mail/views/base.rb
@@ -201,10 +201,13 @@ module Onetime
           "#{scheme}#{site_host}"
         end
 
+        # Install-wide product name for mail copy. brand.product_name is the
+        # single authority (#3612); unconfigured installs fall through to the
+        # neutral NEUTRAL_PRODUCT_NAME — never nil, since templates interpolate
+        # the name into subjects and headers, and never an OTS-branded literal.
         def site_product_name
           OT.conf.dig('brand', 'product_name') ||
-            OT.conf.dig('site', 'interface', 'ui', 'header', 'branding', 'site_name') ||
-            Onetime::CustomDomain::BrandSettingsConstants::GLOBAL_DEFAULTS[:product_name]
+            Onetime::CustomDomain::BrandSettingsConstants::NEUTRAL_PRODUCT_NAME
         end
 
         # Product name with fallback to site config
@@ -365,11 +368,12 @@ module Onetime
                               conf_dig('brand', 'signature_name')
           end
 
-          # Logo alt text helper - delegates to product_name so the logo's
+          # Logo alt text helper - operator-supplied brand.logo_alt
+          # (BRAND_LOGO_ALT) when set, otherwise product_name so the logo's
           # accessible name matches the surrounding brand identity.
           # @return [String]
           def logo_alt
-            product_name
+            conf_dig('brand', 'logo_alt') || product_name
           end
 
           # Logo URL helper - resolves from brand config; nil when no brand
@@ -377,19 +381,29 @@ module Onetime
           # "#{baseuri}/img/onetime-logo-v3-xl.svg" has been neutralized so
           # shipped/private-label instances don't leak OTS branding. Templates
           # check truthiness and render a text-only header when nil.
+          #
+          # Only absolute http(s) URLs are emitted: mail clients cannot
+          # resolve relative paths or component references, and with the
+          # legacy LOGO_URL now feeding brand.logo_url as a fallback (#3612),
+          # a masthead-oriented relative path (e.g. /img/logo.png) must not
+          # break email rendering — such values degrade to the text-only
+          # header instead.
           # @return [String, nil]
           def logo_url
             return @logo_url if defined?(@logo_url)
 
-            @logo_url = conf_dig('brand', 'logo_url') ||
+            candidate = conf_dig('brand', 'logo_url') ||
                         Onetime::CustomDomain::BrandSettingsConstants::GLOBAL_DEFAULTS[:logo_url]
+            @logo_url = candidate.to_s.match?(%r{\Ahttps?://}i) ? candidate : nil
           end
 
+          # Mirrors Templates::Base#site_product_name: brand.product_name is
+          # the single authority (#3612), with the neutral NEUTRAL_PRODUCT_NAME
+          # terminal so layout copy never interpolates nil.
           def site_product_name
             @site_product_name ||=
               conf_dig('brand', 'product_name') ||
-              conf_dig('site', 'interface', 'ui', 'header', 'branding', 'site_name') ||
-              Onetime::CustomDomain::BrandSettingsConstants::GLOBAL_DEFAULTS[:product_name]
+              Onetime::CustomDomain::BrandSettingsConstants::NEUTRAL_PRODUCT_NAME
           end
 
           # Get host from site config

--- a/lib/onetime/models/custom_domain/brand_settings.rb
+++ b/lib/onetime/models/custom_domain/brand_settings.rb
@@ -50,8 +50,9 @@ module Onetime
       # defaults) — including product_name. Operators set BRAND_PRODUCT_NAME /
       # BRAND_SUPPORT_EMAIL / BRAND_LOGO_URL to populate; an unconfigured
       # install falls through to each consumer's own neutral default
-      # (frontend: NEUTRAL_BRAND_DEFAULTS.product_name = 'Secure Links'; mail/page
-      # title: the legacy site.interface.ui.header.branding.site_name value).
+      # (frontend: NEUTRAL_BRAND_DEFAULTS.product_name; mail: NEUTRAL_PRODUCT_NAME
+      # below — the legacy site.interface.ui.header.branding.site_name tier was
+      # retired in #3612).
       #
       # totp_issuer is the one deliberate exception, kept as 'OTS' rather
       # than nil: it's baked into already-provisioned authenticator-app
@@ -66,9 +67,18 @@ module Onetime
         product_name: nil,
         totp_issuer: 'OTS',
         logo_url: nil,
+        logo_alt: nil,
         favicon_url: nil,
         signature_name: nil,
       }.freeze
+
+      # Neutral, vendor-agnostic product name used as the terminal fallback on
+      # surfaces that must render *some* name even when brand.product_name is
+      # unconfigured (email subjects/headers interpolate it into copy). Must
+      # stay in lockstep with the frontend NEUTRAL_BRAND_DEFAULTS.product_name
+      # (src/shared/constants/brand.ts) so an unbranded install reads the same
+      # everywhere — and per #3049 it must NEVER be an OTS-branded literal.
+      NEUTRAL_PRODUCT_NAME = 'Secure Links'
 
       # Returns defaults with primary_color resolved from brand config.
       # Falls back to DEFAULTS when OT.conf is not available.
@@ -90,8 +100,13 @@ module Onetime
         {
           support_email: brand_conf['support_email'] || GLOBAL_DEFAULTS[:support_email],
           product_name: brand_conf['product_name'] || GLOBAL_DEFAULTS[:product_name],
-          totp_issuer: brand_conf['totp_issuer'] || GLOBAL_DEFAULTS[:totp_issuer],
+          # A configured product name brands new MFA enrollments too (#3612) —
+          # an authenticator entry labeled with the vendor default on a renamed
+          # install reads as a leak. The unconfigured 'OTS' default is unchanged,
+          # so pre-existing installs keep issuing consistent labels.
+          totp_issuer: brand_conf['totp_issuer'] || brand_conf['product_name'] || GLOBAL_DEFAULTS[:totp_issuer],
           logo_url: brand_conf['logo_url'] || GLOBAL_DEFAULTS[:logo_url],
+          logo_alt: brand_conf['logo_alt'] || GLOBAL_DEFAULTS[:logo_alt],
           favicon_url: brand_conf['favicon_url'] || GLOBAL_DEFAULTS[:favicon_url],
           signature_name: brand_conf['signature_name'] || GLOBAL_DEFAULTS[:signature_name],
         }

--- a/lib/onetime/models/custom_domain/brand_settings.rb
+++ b/lib/onetime/models/custom_domain/brand_settings.rb
@@ -92,6 +92,11 @@ module Onetime
       # Returns global defaults resolved from brand config at runtime.
       # Falls back to GLOBAL_DEFAULTS when OT.conf is not available.
       #
+      # Call-time safety: OT.conf is only ever assigned the *result* of
+      # Config.after_load (boot.rb), so a non-nil OT.conf['brand'] has
+      # already been through normalize_brand — legacy fallbacks (e.g.
+      # SITE_NAME -> product_name) are absorbed before any reader here.
+      #
       # @return [Hash<Symbol, Object>] Global brand settings with config overrides
       def self.global_defaults
         return GLOBAL_DEFAULTS unless defined?(OT) && OT.respond_to?(:conf) && OT.conf
@@ -122,6 +127,12 @@ module Onetime
       CORNERS = %w[rounded square pill].freeze
     end
 
+    # Per-domain (tenant, Redis-stored) brand settings. Deliberately NOT a
+    # mirror of the install-wide brand: block: logo_alt, for example, is
+    # install-only (GLOBAL_DEFAULTS above) — a tenant's uploaded logo takes
+    # its accessible name from the domain's display name, so a per-domain
+    # logo_alt supplied via from_hash is intentionally dropped by the
+    # members slice below.
     BrandSettings = Data.define(
       :logo,
       :primary_color,

--- a/lib/onetime/models/custom_domain/brand_settings.rb
+++ b/lib/onetime/models/custom_domain/brand_settings.rb
@@ -245,6 +245,12 @@ module Onetime
       end
 
       # @api private
+      #
+      # Write-path validation for PER-DOMAIN (tenant-uploaded) settings only:
+      # https or app-relative. The install-wide brand.logo_url is a separate,
+      # more permissive surface — the mail renderer gates it to absolute
+      # http(s) at render time (Mail::Views TemplateContext#logo_url) and the
+      # web UI accepts relative paths. The two policies intentionally differ.
       def self.validate_url_fields!(normalized)
         [:logo_url, :logo_dark_url, :favicon_url].each do |url_field|
           next unless normalized.key?(url_field) && !normalized[url_field].nil?

--- a/spec/integration/all/mail/show_logo_spec.rb
+++ b/spec/integration/all/mail/show_logo_spec.rb
@@ -187,6 +187,23 @@ RSpec.describe 'Email show_logo toggle', type: :integration do
       end
     end
 
+    context 'when show_logo is true but logo_url is a relative path' do
+      before do
+        conf = OT.conf.dup
+        conf['emailer'] = (conf['emailer'] || {}).merge('show_logo' => true)
+        # Mail clients cannot resolve relative paths; with legacy LOGO_URL
+        # feeding brand.logo_url as a fallback (#3612), a masthead-oriented
+        # path must degrade to the text-only header, not a broken image.
+        conf['brand'] = (conf['brand'] || {}).merge('logo_url' => '/img/logo.png')
+        OT.instance_variable_set(:@conf, conf)
+      end
+
+      it 'does not include an <img tag (absolute http(s) URLs only)' do
+        html = template.render_html
+        expect(html).not_to include('<img')
+      end
+    end
+
     # Verify the toggle across a second template to confirm the conditional
     # is wired consistently (not just in secret_link.html.erb).
     describe 'Welcome template' do

--- a/spec/integration/simple/rhales_migration_spec.rb
+++ b/spec/integration/simple/rhales_migration_spec.rb
@@ -45,18 +45,22 @@ RSpec.describe 'Rhales Migration Integration', type: :integration do
         'domain' => 'localhost',
         'ssl' => false,
         'secret' => 'test-secret-for-rhales-migration-spec',
-        # page_title falls through display_domain -> brand_product_name ->
-        # this legacy site_name when no domain/brand context is present
-        # (GLOBAL_DEFAULTS[:product_name] is nil per #3049, so this tier is
-        # what production's config.defaults.yaml actually supplies).
+        # Masthead layout knobs only — brand identity lives in the brand:
+        # block below (#3612 retired the header.branding nesting).
         'interface' => {
           'ui' => {
             'header' => {
-              'branding' => { 'site_name' => 'One-Time Secret' }
+              'enabled' => true,
+              'logo' => {}
             }
           }
         }
       },
+      # page_title falls through display_domain -> brand_product_name, which
+      # reads brand.product_name only (the legacy header.branding.site_name
+      # tier was retired in #3612). Without this the rendered <title> would
+      # be empty.
+      'brand' => { 'product_name' => 'One-Time Secret' },
       'development' => { 'enabled' => false },
       'diagnostics' => {},
       'billing' => { 'enabled' => false }

--- a/spec/unit/onetime/config/apply_config_spec.rb
+++ b/spec/unit/onetime/config/apply_config_spec.rb
@@ -17,13 +17,10 @@ RSpec.describe Onetime::Config do
               'enabled' => true,
               'header' => {
                 'enabled' => true,
-                'branding' => {
-                  'logo' => {
-                    'url' => '/img/logo.png',
-                    'alt' => 'OneTime Secret',
-                    'href' => '/',
-                  },
-                  'site_name' => 'OneTime Secret',
+                'logo' => {
+                  'href' => '/',
+                  'show_name' => nil,
+                  'prominent' => nil,
                 },
               },
             },
@@ -35,6 +32,11 @@ RSpec.describe Onetime::Config do
             'default_ttl' => 3600,
             'ttl_options' => [300, 3600, 86_400],
           },
+        },
+        'brand' => {
+          'product_name' => 'OneTime Secret',
+          'logo_url' => '/img/logo.png',
+          'logo_alt' => 'OneTime Secret',
         },
         'mail' => {
           'truemail' => {
@@ -64,8 +66,8 @@ RSpec.describe Onetime::Config do
             'ui' => {
               'enabled' => false,
               'header' => {
-                'branding' => {
-                  'site_name' => 'Custom Company',
+                'logo' => {
+                  'href' => '/custom',
                 },
               },
             },
@@ -73,6 +75,9 @@ RSpec.describe Onetime::Config do
           'secret_options' => {
             'default_ttl' => 7200,
           },
+        },
+        'brand' => {
+          'product_name' => 'Custom Company',
         },
       }
     end
@@ -95,6 +100,9 @@ RSpec.describe Onetime::Config do
                                                            'default_ttl' => 7200,
                                                          ),
                                                        ),
+                                                       'brand' => hash_including(
+                                                         'product_name' => 'Custom Company',
+                                                       ),
                                                      ))
 
         described_class.apply_config(override_config)
@@ -104,6 +112,9 @@ RSpec.describe Onetime::Config do
         expect(OT).to receive(:replace_config!) do |merged_config|
           expect(merged_config['site']['interface']['api']['enabled']).to eq(true)
           expect(merged_config['mail']['truemail']['verifier_email']).to eq('verifier@example.com')
+          # Sibling brand keys survive a partial brand override
+          expect(merged_config['brand']['logo_url']).to eq('/img/logo.png')
+          expect(merged_config['brand']['logo_alt']).to eq('OneTime Secret')
         end
 
         described_class.apply_config(override_config)

--- a/spec/unit/onetime/config/load_spec.rb
+++ b/spec/unit/onetime/config/load_spec.rb
@@ -144,6 +144,55 @@ RSpec.describe Onetime::Config do
         expect(config.dig('brand', 'product_name')).to eq('& Co: "special" *value')
       end
     end
+
+    context 'header layout knobs in the shipped defaults (#3612)' do
+      # The masthead layout knobs must render as YAML nil when their env vars
+      # are unset OR blank ("not specified" — show_name's auto-hide heuristic
+      # depends on the distinction), and as real values when set. Loads the
+      # real defaults file so the ERB ternaries themselves are pinned.
+      let(:defaults_path) { File.expand_path('../../../../etc/defaults/config.defaults.yaml', __dir__) }
+
+      around do |example|
+        saved = %w[LOGO_LINK LOGO_SHOW_NAME LOGO_PROMINENT].to_h { |k| [k, ENV.fetch(k, nil)] }
+        example.run
+      ensure
+        saved.each { |k, v| v.nil? ? ENV.delete(k) : (ENV[k] = v) }
+      end
+
+      it 'renders all three knobs as nil when the env vars are unset' do
+        %w[LOGO_LINK LOGO_SHOW_NAME LOGO_PROMINENT].each { |k| ENV.delete(k) }
+
+        logo = described_class.load(defaults_path).dig('site', 'interface', 'ui', 'header', 'logo')
+        expect(logo).to eq('href' => nil, 'show_name' => nil, 'prominent' => nil)
+      end
+
+      it 'treats blank env vars as unset (nil), not as explicit values' do
+        ENV['LOGO_LINK']      = ''
+        ENV['LOGO_SHOW_NAME'] = ''
+        ENV['LOGO_PROMINENT'] = ''
+
+        logo = described_class.load(defaults_path).dig('site', 'interface', 'ui', 'header', 'logo')
+        expect(logo).to eq('href' => nil, 'show_name' => nil, 'prominent' => nil)
+      end
+
+      it 'renders explicit values when the env vars are set' do
+        ENV['LOGO_LINK']      = '/home'
+        ENV['LOGO_SHOW_NAME'] = 'false'
+        ENV['LOGO_PROMINENT'] = 'true'
+
+        logo = described_class.load(defaults_path).dig('site', 'interface', 'ui', 'header', 'logo')
+        expect(logo).to eq('href' => '/home', 'show_name' => false, 'prominent' => true)
+      end
+
+      it 'ships no branding nesting, site_name, or vendor defaults in the header' do
+        %w[LOGO_LINK LOGO_SHOW_NAME LOGO_PROMINENT].each { |k| ENV.delete(k) }
+
+        header = described_class.load(defaults_path).dig('site', 'interface', 'ui', 'header')
+        expect(header).not_to have_key('branding')
+        expect(header.to_s).not_to include('One-Time Secret')
+        expect(header.to_s).not_to include('DefaultLogo.vue')
+      end
+    end
   end
 
   describe '.path' do

--- a/spec/unit/onetime/config/normalize_brand_spec.rb
+++ b/spec/unit/onetime/config/normalize_brand_spec.rb
@@ -221,6 +221,18 @@ RSpec.describe Onetime::Config do
         }.not_to raise_error
         expect(brand['logo_url']).to be_nil
       end
+
+      it 'logs a boot notice when the resolved logo_url is not absolute' do
+        # The web UI renders a relative path fine, but emails silently degrade
+        # to a text-only header — the operator should learn that at boot.
+        expect(OT).to receive(:le).with(/CONFIG NOTICE: brand\.logo_url/)
+        normalized({ 'brand' => {} }, 'LOGO_URL' => '/img/legacy.png')
+      end
+
+      it 'logs no notice for an absolute logo_url' do
+        expect(OT).not_to receive(:le).with(/CONFIG NOTICE: brand\.logo_url/)
+        normalized({ 'brand' => {} }, 'BRAND_LOGO_URL' => 'https://cdn.example.com/l.svg')
+      end
     end
   end
 
@@ -274,6 +286,23 @@ RSpec.describe Onetime::Config do
       conf = { 'site' => { 'interface' => { 'ui' => {} } } }
       expect { described_class.normalize_header_layout(conf) }.not_to raise_error
       expect(conf).to eq('site' => { 'interface' => { 'ui' => {} } })
+    end
+
+    it 'leaves the header untouched when no branding key exists (modern config)' do
+      conf = header_conf('enabled' => true, 'logo' => { 'href' => '/x' })
+      expect { described_class.normalize_header_layout(conf) }.not_to raise_error
+      expect(header_of(conf)).to eq('enabled' => true, 'logo' => { 'href' => '/x' })
+    end
+
+    it 'coerces a malformed non-Hash header.logo before migrating' do
+      # `logo: "oops"` in a hand-edited config must not abort boot with a
+      # String#[]= error — the migration replaces it with a proper hash.
+      conf = header_conf(
+        'logo' => 'oops',
+        'branding' => { 'logo' => { 'link_to' => '/legacy' } },
+      )
+      expect { described_class.normalize_header_layout(conf) }.not_to raise_error
+      expect(header_of(conf).dig('logo', 'href')).to eq('/legacy')
     end
 
     it 'strips a branding subtree that has no logo hash without adding one' do

--- a/spec/unit/onetime/config/normalize_brand_spec.rb
+++ b/spec/unit/onetime/config/normalize_brand_spec.rb
@@ -9,8 +9,12 @@ RSpec.describe Onetime::Config do
     # Render only matters as the "fallback" layer; these specs exercise the
     # Ruby normalization that is now the authority for the brand block.
     def normalized(conf, env)
-      # Strip any ambient BRAND_* (sourced from .env) so each case is isolated.
-      base = ENV.to_h.reject { |k, _| k.start_with?('BRAND_') }
+      # Strip any ambient BRAND_* and legacy brand env vars — SITE_NAME /
+      # LOGO_URL / LOGO_ALT feed LEGACY_BRAND_FALLBACKS (#3612) — sourced
+      # from .env, so each case is isolated.
+      base = ENV.to_h.reject do |k, _|
+        k.start_with?('BRAND_') || %w[SITE_NAME LOGO_URL LOGO_ALT].include?(k)
+      end
       stub_const('ENV', base.merge(env))
       described_class.normalize_brand(conf)
       conf['brand']
@@ -69,6 +73,214 @@ RSpec.describe Onetime::Config do
       it 'coerces a YAML-parsed boolean false when the env var is unset' do
         expect(normalized({ 'brand' => { 'button_text_light' => false } }, {})['button_text_light']).to be(false)
       end
+    end
+
+    context 'legacy brand fallbacks (#3612)' do
+      # Config carrying only the deprecated header.branding subtree.
+      def legacy_conf(branding)
+        {
+          'brand' => {},
+          'site' => {
+            'interface' => { 'ui' => { 'header' => { 'branding' => branding } } },
+          },
+        }
+      end
+
+      context 'product_name' do
+        it 'adopts SITE_NAME when BRAND_PRODUCT_NAME is unset' do
+          brand = normalized({ 'brand' => {} }, 'SITE_NAME' => 'Legacy Name')
+          expect(brand['product_name']).to eq('Legacy Name')
+        end
+
+        it 'prefers BRAND_PRODUCT_NAME when both env vars are set' do
+          brand = normalized({ 'brand' => {} },
+                             'BRAND_PRODUCT_NAME' => 'New Name',
+                             'SITE_NAME' => 'Legacy Name')
+          expect(brand['product_name']).to eq('New Name')
+        end
+
+        it 'prefers a brand: YAML value over the legacy SITE_NAME env var' do
+          brand = normalized({ 'brand' => { 'product_name' => 'X' } },
+                             'SITE_NAME' => 'Y')
+          expect(brand['product_name']).to eq('X')
+        end
+
+        it 'adopts the legacy YAML site_name when no env vars are set' do
+          brand = normalized(legacy_conf('site_name' => 'Yaml Name'), {})
+          expect(brand['product_name']).to eq('Yaml Name')
+        end
+
+        it 'prefers the legacy env var over the legacy YAML path' do
+          brand = normalized(legacy_conf('site_name' => 'Yaml Name'),
+                             'SITE_NAME' => 'Env Name')
+          expect(brand['product_name']).to eq('Env Name')
+        end
+      end
+
+      context 'logo_url' do
+        it 'adopts LOGO_URL when BRAND_LOGO_URL is unset' do
+          brand = normalized({ 'brand' => {} }, 'LOGO_URL' => '/img/legacy.png')
+          expect(brand['logo_url']).to eq('/img/legacy.png')
+        end
+
+        it 'prefers BRAND_LOGO_URL when both env vars are set' do
+          brand = normalized({ 'brand' => {} },
+                             'BRAND_LOGO_URL' => 'https://cdn.example.com/new.svg',
+                             'LOGO_URL' => '/img/legacy.png')
+          expect(brand['logo_url']).to eq('https://cdn.example.com/new.svg')
+        end
+
+        it 'never adopts the DefaultLogo.vue sentinel from the env var' do
+          # The legacy LOGO_URL default is a Vue component reference, not an
+          # asset URL — adopting it would break consumers like mail templates.
+          brand = normalized({ 'brand' => {} }, 'LOGO_URL' => 'DefaultLogo.vue')
+          expect(brand['logo_url']).to be_nil
+        end
+
+        it 'never adopts any *.vue component reference' do
+          brand = normalized({ 'brand' => {} }, 'LOGO_URL' => 'CustomLogo.vue')
+          expect(brand['logo_url']).to be_nil
+        end
+
+        it 'rejects a blank LOGO_URL' do
+          brand = normalized({ 'brand' => {} }, 'LOGO_URL' => '   ')
+          expect(brand['logo_url']).to be_nil
+        end
+
+        it 'adopts a usable value from the legacy YAML path' do
+          brand = normalized(legacy_conf('logo' => { 'url' => '/img/yaml.png' }), {})
+          expect(brand['logo_url']).to eq('/img/yaml.png')
+        end
+
+        it 'never adopts the sentinel from the legacy YAML path either' do
+          brand = normalized(legacy_conf('logo' => { 'url' => 'DefaultLogo.vue' }), {})
+          expect(brand['logo_url']).to be_nil
+        end
+
+        it 'rejects a *.vue value even from the BRAND_LOGO_URL authority itself' do
+          # Hazard 1 (#3612) applies to every source: a component reference is
+          # a frontend-only sentinel, never an asset URL for emails/favicons.
+          brand = normalized({ 'brand' => {} }, 'BRAND_LOGO_URL' => 'DefaultLogo.vue')
+          expect(brand['logo_url']).to be_nil
+        end
+
+        it 'rejects a *.vue value supplied via brand: YAML' do
+          brand = normalized({ 'brand' => { 'logo_url' => 'LegacyLogo.vue' } }, {})
+          expect(brand['logo_url']).to be_nil
+        end
+
+        it 'falls back to a usable legacy LOGO_URL when the brand value was a sentinel' do
+          brand = normalized({ 'brand' => {} },
+                             'BRAND_LOGO_URL' => 'DefaultLogo.vue',
+                             'LOGO_URL' => 'https://cdn.example.com/l.png')
+          expect(brand['logo_url']).to eq('https://cdn.example.com/l.png')
+        end
+      end
+
+      context 'logo_alt' do
+        it 'adopts LOGO_ALT when BRAND_LOGO_ALT is unset' do
+          brand = normalized({ 'brand' => {} }, 'LOGO_ALT' => 'Legacy Alt')
+          expect(brand['logo_alt']).to eq('Legacy Alt')
+        end
+
+        it 'prefers BRAND_LOGO_ALT when both env vars are set' do
+          brand = normalized({ 'brand' => {} },
+                             'BRAND_LOGO_ALT' => 'New Alt',
+                             'LOGO_ALT' => 'Legacy Alt')
+          expect(brand['logo_alt']).to eq('New Alt')
+        end
+
+        it 'adopts the legacy YAML logo alt when no env vars are set' do
+          brand = normalized(legacy_conf('logo' => { 'alt' => 'Yaml Alt' }), {})
+          expect(brand['logo_alt']).to eq('Yaml Alt')
+        end
+
+        it 'prefers the legacy env var over the legacy YAML path' do
+          brand = normalized(legacy_conf('logo' => { 'alt' => 'Yaml Alt' }),
+                             'LOGO_ALT' => 'Env Alt')
+          expect(brand['logo_alt']).to eq('Env Alt')
+        end
+      end
+
+      it 'keeps identity keys nil when nothing is configured (default posture)' do
+        # An unconfigured install must stay neutral: no env, no YAML branding
+        # means no product name / logo leaks in from anywhere (#3612).
+        brand = normalized({ 'brand' => {} }, {})
+        expect(brand['product_name']).to be_nil
+        expect(brand['logo_url']).to be_nil
+        expect(brand['logo_alt']).to be_nil
+      end
+
+      it 'tolerates a malformed legacy subtree (scalar where a hash is expected)' do
+        # A hand-edited config with e.g. `branding: { logo: "oops" }` must not
+        # abort boot with a TypeError from Hash#dig — an unreadable optional
+        # fallback source simply reads as absent.
+        brand = nil
+        expect {
+          brand = normalized(legacy_conf('logo' => 'oops-not-a-hash'), {})
+        }.not_to raise_error
+        expect(brand['logo_url']).to be_nil
+      end
+    end
+  end
+
+  describe '.normalize_header_layout' do
+    def header_conf(header)
+      { 'site' => { 'interface' => { 'ui' => { 'header' => header } } } }
+    end
+
+    def header_of(conf)
+      conf.dig('site', 'interface', 'ui', 'header')
+    end
+
+    it 'deletes the legacy branding subtree' do
+      conf = header_conf('branding' => { 'site_name' => 'Legacy' })
+      described_class.normalize_header_layout(conf)
+      expect(header_of(conf)).not_to have_key('branding')
+    end
+
+    it 'migrates branding.logo.link_to to header.logo.href when href is nil' do
+      conf = header_conf('branding' => { 'logo' => { 'link_to' => '/legacy' } })
+      described_class.normalize_header_layout(conf)
+      expect(header_of(conf).dig('logo', 'href')).to eq('/legacy')
+    end
+
+    it 'does not overwrite an already-set header.logo.href' do
+      conf = header_conf(
+        'logo' => { 'href' => '/new' },
+        'branding' => { 'logo' => { 'link_to' => '/legacy' } },
+      )
+      described_class.normalize_header_layout(conf)
+      expect(header_of(conf).dig('logo', 'href')).to eq('/new')
+    end
+
+    it 'migrates show_name and prominent only where the new value is nil' do
+      conf = header_conf(
+        'logo' => { 'show_name' => false },
+        'branding' => { 'logo' => { 'show_name' => true, 'prominent' => true } },
+      )
+      described_class.normalize_header_layout(conf)
+      expect(header_of(conf).dig('logo', 'show_name')).to be(false)
+      expect(header_of(conf).dig('logo', 'prominent')).to be(true)
+    end
+
+    it 'migrates a legacy boolean false (non-nil legacy values are honored)' do
+      conf = header_conf('branding' => { 'logo' => { 'show_name' => false } })
+      described_class.normalize_header_layout(conf)
+      expect(header_of(conf).dig('logo', 'show_name')).to be(false)
+    end
+
+    it 'is a no-op when the header block is absent' do
+      conf = { 'site' => { 'interface' => { 'ui' => {} } } }
+      expect { described_class.normalize_header_layout(conf) }.not_to raise_error
+      expect(conf).to eq('site' => { 'interface' => { 'ui' => {} } })
+    end
+
+    it 'strips a branding subtree that has no logo hash without adding one' do
+      conf = header_conf('branding' => { 'site_name' => 'Legacy' })
+      described_class.normalize_header_layout(conf)
+      expect(header_of(conf)).not_to have_key('branding')
+      expect(header_of(conf)).not_to have_key('logo')
     end
   end
 end

--- a/spec/unit/onetime/config_spec.rb
+++ b/spec/unit/onetime/config_spec.rb
@@ -494,6 +494,114 @@ RSpec.describe Onetime::Config do
       end
     end
 
+    context 'soft deprecations (severity: :warn) for legacy brand config (#3612)' do
+      def stub_env(env)
+        # Strip the legacy brand env vars from the base env so ambient values
+        # (e.g. from .env) don't bleed into cases.
+        base = ENV.to_h.reject { |k, _| %w[SITE_NAME LOGO_URL LOGO_ALT].include?(k) }
+        stub_const('ENV', base.merge(env))
+      end
+
+      def build_config(mode = nil)
+        conf = {
+          'site' => { 'secret' => 'test-secret' },
+          'mail' => { 'truemail' => {} },
+        }
+        conf['compatibility'] = { 'deprecated_config_mode' => mode } if mode
+        conf
+      end
+
+      it 'logs SITE_NAME under strict mode (default) and boot continues' do
+        stub_env('SITE_NAME' => 'Legacy Brand')
+
+        expect(OT).to receive(:le).with(/CONFIG DEPRECATION:.*SITE_NAME is deprecated/)
+
+        result = nil
+        expect {
+          result = described_class.after_load(build_config)
+        }.not_to raise_error
+        # The legacy value still works: normalize_brand adopts it as fallback.
+        expect(result.dig('brand', 'product_name')).to eq('Legacy Brand')
+      end
+
+      it 'logs the header.branding path under strict mode and strips the subtree' do
+        stub_env({})
+        config = build_config
+        config['site']['interface'] = {
+          'ui' => { 'header' => { 'branding' => { 'site_name' => 'Legacy' } } },
+        }
+
+        expect(OT).to receive(:le).with(/CONFIG DEPRECATION:.*header\.branding is deprecated/)
+
+        result = described_class.after_load(config)
+        expect(result.dig('site', 'interface', 'ui', 'header')).not_to have_key('branding')
+        expect(result.dig('brand', 'product_name')).to eq('Legacy')
+      end
+
+      it 'logs LOGO_URL and LOGO_ALT under strict mode and boot continues' do
+        stub_env('LOGO_URL' => 'https://cdn.example.com/legacy.svg',
+                 'LOGO_ALT' => 'Legacy mark')
+
+        expect(OT).to receive(:le).with(/CONFIG DEPRECATION:.*LOGO_URL is deprecated/)
+        expect(OT).to receive(:le).with(/CONFIG DEPRECATION:.*LOGO_ALT is deprecated/)
+
+        result = nil
+        expect {
+          result = described_class.after_load(build_config)
+        }.not_to raise_error
+        expect(result.dig('brand', 'logo_url')).to eq('https://cdn.example.com/legacy.svg')
+        expect(result.dig('brand', 'logo_alt')).to eq('Legacy mark')
+      end
+
+      it 'still raises for removed keys (site.domains) under strict mode' do
+        stub_env({})
+        config = build_config
+        config['site']['domains'] = { 'enabled' => true }
+
+        expect {
+          described_class.after_load(config)
+        }.to raise_error(OT::ConfigError, /site\.domains is ignored/)
+      end
+
+      it 'logs soft entries even when a hard entry raises under strict mode' do
+        stub_env('SITE_NAME' => 'Legacy Brand')
+        config = build_config
+        config['site']['domains'] = { 'enabled' => true }
+
+        expect(OT).to receive(:le).with(/CONFIG DEPRECATION:.*SITE_NAME is deprecated/)
+
+        expect {
+          described_class.after_load(config)
+        }.to raise_error(OT::ConfigError, /site\.domains is ignored/)
+      end
+
+      it 'logs both soft and hard entries under warn mode without raising' do
+        stub_env('SITE_NAME' => 'Legacy Brand')
+        config = build_config('warn')
+        config['site']['domains'] = { 'enabled' => true }
+
+        expect(OT).to receive(:le).with(/CONFIG DEPRECATION:.*SITE_NAME is deprecated/)
+        expect(OT).to receive(:le).with(/CONFIG DEPRECATION:.*site\.domains is ignored/)
+
+        expect {
+          described_class.after_load(config)
+        }.not_to raise_error
+      end
+
+      it 'suppresses soft warnings under silent mode' do
+        stub_env('SITE_NAME' => 'Legacy Brand')
+
+        expect(OT).not_to receive(:le).with(/CONFIG DEPRECATION/)
+
+        result = nil
+        expect {
+          result = described_class.after_load(build_config('silent'))
+        }.not_to raise_error
+        # Silent only mutes the report; the fallback shim still applies.
+        expect(result.dig('brand', 'product_name')).to eq('Legacy Brand')
+      end
+    end
+
     context 'site configuration validation' do
       it 'uses default values when site has minimal config' do
         raw_config = {

--- a/spec/unit/onetime/mail/templates_i18n_spec.rb
+++ b/spec/unit/onetime/mail/templates_i18n_spec.rb
@@ -121,10 +121,17 @@ RSpec.describe 'Email template i18n integration' do
         let(:data) { { recipient: 'user@example.com' } }
 
         it 'returns site_product_name fallback' do
-          # Falls back to site config or 'Onetime Secret'
+          # Falls back to brand.product_name, then the neutral
+          # NEUTRAL_PRODUCT_NAME ('Secure Links') — never nil (#3612).
           result = context.product_name
           expect(result).to be_a(String)
           expect(result).not_to be_empty
+        end
+
+        it 'resolves the neutral product name when brand.product_name is unconfigured' do
+          allow(OT).to receive(:conf).and_return(OT.conf.merge('brand' => {}))
+          expect(context.product_name)
+            .to eq(Onetime::CustomDomain::BrandSettingsConstants::NEUTRAL_PRODUCT_NAME)
         end
       end
     end
@@ -242,13 +249,17 @@ RSpec.describe 'Email template i18n integration' do
 
     describe '#render_text' do
       it 'includes translated content from locale file' do
+        # Pin an unconfigured brand block so the footer exercises the neutral
+        # NEUTRAL_PRODUCT_NAME fallback ('Secure Links'). The legacy
+        # site.interface.ui.header.branding.site_name tier was retired (#3612).
+        allow(OT).to receive(:conf).and_return(OT.conf.merge('brand' => {}))
         template = described_class.new(template_data)
         text = template.render_text
 
         # Check for translated strings
         expect(text).to include('sent you a secret')
         expect(text).to include('This link will only work once')
-        expect(text).to include('One-Time Secret')
+        expect(text).to include('Secure Links')
       end
 
       it 'includes the secret URL path' do
@@ -268,13 +279,15 @@ RSpec.describe 'Email template i18n integration' do
 
     describe '#render_html' do
       it 'includes translated content from locale file' do
+        # See render_text: unconfigured brand renders the neutral product name.
+        allow(OT).to receive(:conf).and_return(OT.conf.merge('brand' => {}))
         template = described_class.new(template_data)
         html = template.render_html
 
         expect(html).to include('sent you a secret')
         expect(html).to include('Important:')
         expect(html).to include('This link will only work once')
-        expect(html).to include('One-Time Secret')
+        expect(html).to include('Secure Links')
       end
 
       it 'includes properly escaped content' do
@@ -329,7 +342,7 @@ RSpec.describe 'Email template i18n integration' do
       it 'uses default product name when not provided' do
         data = template_data.except(:product_name)
         template = described_class.new(data)
-        # Falls back to site config or 'Onetime Secret'
+        # Falls back to brand.product_name or the neutral 'Secure Links' (#3612)
         expect(template.subject).to include('Welcome to')
         expect(template.subject).to include('Please verify your email')
       end

--- a/src/apps/secret/views/disabled/README.md
+++ b/src/apps/secret/views/disabled/README.md
@@ -137,5 +137,5 @@ elsewhere.
 
 `/disabled` route (`PreviewDisabled.vue`) renders the dispatcher with
 the live masthead and a "preview, not real" notice. Useful for
-verifying `LOGO_URL` / `SITE_NAME` / brand color without flipping
-`auth.required` on the backend.
+verifying `BRAND_LOGO_URL` / `BRAND_PRODUCT_NAME` / brand color without
+flipping `auth.required` on the backend.

--- a/src/router/public.routes.ts
+++ b/src/router/public.routes.ts
@@ -301,8 +301,8 @@ const routes: Array<RouteRecordRaw> = [
   // (not linked from navigation). Renders the same DisabledHomepage content the real
   // disabled-homepage mode shows, but with a prominent notice making clear the
   // site is not actually disabled. Useful for verifying branding env vars
-  // (LOGO_URL, LOGO_SHOW_NAME, SITE_NAME, LOGO_PROMINENT) without toggling
-  // UI_ENABLED or auth.required on the backend.
+  // (BRAND_LOGO_URL, LOGO_SHOW_NAME, BRAND_PRODUCT_NAME, LOGO_PROMINENT)
+  // without toggling UI_ENABLED or auth.required on the backend.
   {
     path: '/disabled',
     name: 'PreviewDisabled',

--- a/src/schemas/contracts/bootstrap.ts
+++ b/src/schemas/contracts/bootstrap.ts
@@ -72,22 +72,22 @@ export const footerLinksConfigSchema = z.object({
   groups: z.array(footerGroupSchema).default([]),
 });
 
+/**
+ * Masthead layout knobs (presentation only). Brand identity — the logo
+ * asset, its alt text, and the product name — comes from the flat
+ * `brand_*` bootstrap fields (the `brand:` config block), not the header
+ * (#3612). All knobs are nullable: unset means "use the surface default"
+ * ('/' for href; show_name falls to the custom-logo heuristic).
+ */
 export const headerLogoSchema = z.object({
-  url: z.string().default(''),
-  alt: z.string().default(''),
-  link_to: z.string().default('/'),
-  show_name: z.boolean().optional(),
+  href: z.string().nullish(),
+  show_name: z.boolean().nullish(),
   /**
    * When true, render the logo at a larger size in the authenticated header.
    * Useful for rasterized brand assets that need visual presence alongside
    * the org/domain switchers. Defaults to false (compact 40px logo).
    */
-  prominent: z.boolean().optional(),
-});
-
-export const headerBrandingSchema = z.object({
-  logo: headerLogoSchema.default(headerLogoSchema.parse({})),
-  site_name: z.string().optional(),
+  prominent: z.boolean().nullish(),
 });
 
 export const headerNavigationSchema = z.object({
@@ -96,7 +96,7 @@ export const headerNavigationSchema = z.object({
 
 export const headerConfigSchema = z.object({
   enabled: z.boolean().default(true),
-  branding: headerBrandingSchema.optional(),
+  logo: headerLogoSchema.optional(),
   navigation: headerNavigationSchema.optional(),
 });
 
@@ -108,15 +108,14 @@ export const headerConfigSchema = z.object({
  * const ui = { enabled: true };
  *
  * @example
- * // Full configuration with custom branding and footer links
+ * // Full configuration with masthead layout knobs and footer links
+ * // (brand identity — logo asset, product name — lives in the flat
+ * // brand_* bootstrap fields, not here)
  * const ui = {
  *   enabled: true,
  *   header: {
  *     enabled: true,
- *     branding: {
- *       logo: { url: '/images/logo.svg', alt: 'Company Logo', link_to: '/' },
- *       site_name: 'My Secret Sharing App',
- *     },
+ *     logo: { href: '/', show_name: true, prominent: false },
  *     navigation: { enabled: true },
  *   },
  *   footer_links: {
@@ -421,7 +420,6 @@ export type FooterGroup = z.infer<typeof footerGroupSchema>;
 export type FooterLinksConfig = z.infer<typeof footerLinksConfigSchema>;
 export type WorkspaceLinksConfig = z.infer<typeof workspaceLinksConfigSchema>;
 export type HeaderLogo = z.infer<typeof headerLogoSchema>;
-export type HeaderBranding = z.infer<typeof headerBrandingSchema>;
 export type HeaderNavigation = z.infer<typeof headerNavigationSchema>;
 export type HeaderConfig = z.infer<typeof headerConfigSchema>;
 export type UiCapabilities = z.infer<typeof uiCapabilitiesSchema>;
@@ -529,6 +527,7 @@ export const bootstrapSchema = z.object({
   brand_font_family: z.enum(fontFamilyValues).nullish(),
   brand_button_text_light: z.boolean().nullish(),
   brand_logo_url: z.string().nullish(),
+  brand_logo_alt: z.string().nullish(),
   brand_favicon_url: z.string().nullish(),
 
   // ─────────────────────────────────────────────────────────────────────────────

--- a/src/schemas/contracts/config/config.ts
+++ b/src/schemas/contracts/config/config.ts
@@ -66,18 +66,13 @@ export const apiInterfaceSchema = z.object({
       header: z
         .object({
           enabled: booleanOrString,
-          branding: z
+          logo: z
             .object({
-              logo: z
-                .object({
-                  url: z.string().optional(),
-                  alt: z.string().optional(),
-                  link_to: z.string().optional(),
-                  show_name: booleanOrString,
-                  prominent: booleanOrString,
-                })
-                .optional(),
-              site_name: z.string().optional(),
+              // Layout knobs ship as YAML nil when their env vars are unset
+              // (#3612), so each must accept null, not just absence.
+              href: z.string().nullable().optional(),
+              show_name: z.union([z.boolean(), z.string()]).nullable().optional(),
+              prominent: z.union([z.boolean(), z.string()]).nullable().optional(),
             })
             .optional(),
           navigation: z

--- a/src/schemas/contracts/config/section/brand.ts
+++ b/src/schemas/contracts/config/section/brand.ts
@@ -38,6 +38,7 @@ const brandSchema = z.object({
   signature_name: nullableString,
   footer_text: nullableString,
   logo_url: nullableString,
+  logo_alt: nullableString,
   logo_dark_url: nullableString,
   favicon_url: nullableString,
   apple_touch_icon_url: nullableString,

--- a/src/schemas/contracts/config/section/ui.ts
+++ b/src/schemas/contracts/config/section/ui.ts
@@ -13,22 +13,15 @@ import { z } from 'zod';
 import { nullableString } from '../shared/primitives';
 
 /**
- * Logo configuration
+ * Masthead logo layout knobs (presentation only). Brand identity — the
+ * logo asset, alt text, and product name — lives in the `brand:` section
+ * (#3612); the deprecated `header.branding` nesting is absorbed by
+ * `Config#normalize_brand` and never reaches the frontend.
  */
 const userInterfaceLogoSchema = z.object({
-  url: z.string().optional(),
-  alt: z.string().optional(),
-  href: z.string().optional(),
-  show_name: z.boolean().optional(),
-  prominent: z.boolean().optional(),
-});
-
-/**
- * Header branding configuration
- */
-const userInterfaceHeaderBrandingSchema = z.object({
-  logo: userInterfaceLogoSchema.optional(),
-  site_name: z.string().optional(),
+  href: z.string().nullable().optional(),
+  show_name: z.boolean().nullable().optional(),
+  prominent: z.boolean().nullable().optional(),
 });
 
 /**
@@ -65,7 +58,7 @@ const userInterfaceHomepageSchema = z.object({
  */
 const userInterfaceHeaderSchema = z.object({
   enabled: z.boolean().optional(),
-  branding: userInterfaceHeaderBrandingSchema.optional(),
+  logo: userInterfaceLogoSchema.optional(),
   navigation: userInterfaceHeaderNavigationSchema.optional(),
 });
 

--- a/src/shared/components/layout/MastHead.vue
+++ b/src/shared/components/layout/MastHead.vue
@@ -173,7 +173,10 @@
   // branding/logo resolution.
   const { headerEnabled, navigationEnabled } = useHeaderEnabled();
 
-  // Logo component handling
+  // Logo component handling. A `.vue`-suffixed URL can only be the neutral
+  // DEFAULT_LOGO_COMPONENT sentinel from logoSource, or a caller prop —
+  // Config#normalize_brand rejects component references in brand.logo_url,
+  // so config-supplied values are always real asset URLs.
   const isVueComponent = computed(() => logoConfig.value.url.endsWith('.vue'));
   const logoComponent = shallowRef<Component | null>(
     isVueComponent.value && logoConfig.value.url === DEFAULT_LOGO

--- a/src/shared/components/layout/MastHead.vue
+++ b/src/shared/components/layout/MastHead.vue
@@ -66,7 +66,10 @@
   // resolver's logoSource so the dynamic-import comparisons below stay in sync).
   const DEFAULT_LOGO = DEFAULT_LOGO_COMPONENT;
 
-  // Helper functions for logo configuration.
+  // Helper functions for logo configuration. These are plain functions whose
+  // reactivity comes solely from being called inside the logoConfig computed
+  // below — they must only close over refs/computeds (props, resolver refs,
+  // headerConfig), never a captured plain value, or updates stop propagating.
   // Priority: props.logo.url (caller) > identity.logoSource, which itself
   // resolves tenant logo > operator brand.logo_url (BRAND_LOGO_URL, custom
   // domains excepted) > neutral DefaultLogo terminal. The masthead no longer

--- a/src/shared/components/layout/MastHead.vue
+++ b/src/shared/components/layout/MastHead.vue
@@ -28,11 +28,20 @@
   // no raw brand/identity bootstrap fields directly. `productName` replaces the
   // hand-rolled `brand_product_name ?? NEUTRAL` snippet; `showPlatformIdentity`
   // is the base "may we show the platform wordmark?" decision (custom domains /
-  // per-tenant logos suppress it — the A3 leak); `logoUri`/`logoSource` supply
-  // the tenant-or-neutral logo image (replacing the raw `domain_logo` read).
+  // per-tenant logos suppress it — the A3 leak); `logoSource` supplies the
+  // logo image on the identity axis: tenant logo, else the operator's
+  // install-wide brand.logo_url (BRAND_LOGO_URL, suppressed on custom
+  // domains), else the neutral DefaultLogo sentinel (#3612 — the operator
+  // logo no longer comes from ui.header.branding).
   const identityStore = useProductIdentity();
-  const { productName, showPlatformIdentity, logoUri, logoSource } =
-    storeToRefs(identityStore);
+  const {
+    productName,
+    displayName,
+    showPlatformIdentity,
+    installLogoUri,
+    installLogoAlt,
+    logoSource,
+  } = storeToRefs(identityStore);
 
   const props = withDefaults(defineProps<LayoutProps>(), {
     displayMasthead: true,
@@ -58,26 +67,36 @@
   const DEFAULT_LOGO = DEFAULT_LOGO_COMPONENT;
 
   // Helper functions for logo configuration.
-  // Priority: props.logo.url (caller) > tenant logo (identity.logoUri) >
-  //           operator LOGO_URL (headerConfig) > neutral default (logoSource).
-  // A per-tenant uploaded logo wins over an operator-wide LOGO_URL; logoSource
-  // supplies the neutral DefaultLogo terminal (== DEFAULT_LOGO when no tenant
-  // logo, since the tenant rung already short-circuited).
-  const getLogoUrl = () => props.logo?.url || logoUri.value || headerConfig.value?.branding?.logo?.url || logoSource.value;
-  const getLogoAlt = () => props.logo?.alt || headerConfig.value?.branding?.logo?.alt || t('web.homepage.one_time_secret_literal', { product_name: productName.value });
-  const getLogoHref = () => props.logo?.href || headerConfig.value?.branding?.logo?.link_to || '/';
+  // Priority: props.logo.url (caller) > identity.logoSource, which itself
+  // resolves tenant logo > operator brand.logo_url (BRAND_LOGO_URL, custom
+  // domains excepted) > neutral DefaultLogo terminal. The masthead no longer
+  // holds an operator-logo rung of its own — config authority lives in the
+  // brand: block and resolution in the identity resolver (#3612).
+  const getLogoUrl = () => props.logo?.url || logoSource.value;
+  // Alt text: caller > operator BRAND_LOGO_ALT (only while the install logo
+  // is the asset being shown) > i18n string derived from the product name.
+  // When platform identity is suppressed (custom domain / tenant logo), the
+  // accessible name must not leak the operator's product name either — use
+  // the tenant-facing displayName (brand description or display domain),
+  // mirroring what BrandedMastHead does for the same surface.
+  const getLogoAlt = () =>
+    props.logo?.alt ||
+    installLogoAlt.value ||
+    (showPlatformIdentity.value
+      ? t('web.homepage.one_time_secret_literal', { product_name: productName.value })
+      : displayName.value);
+  const getLogoHref = () => props.logo?.href || headerConfig.value?.logo?.href || '/';
 
-  // Static-config custom logo: operator set LOGO_URL to anything other than the
-  // bundled DefaultLogo.vue. Distinct from the tenant logo (identity.logoUri),
-  // because the two have different override semantics for the site name.
-  const isCustomStaticLogo = computed(() =>
-    !!headerConfig.value?.branding?.logo?.url
-    && headerConfig.value.branding.logo.url !== DEFAULT_LOGO
-  );
+  // Custom install-wide logo: operator set BRAND_LOGO_URL. Distinct from the
+  // tenant logo (identity.logoUri), because the two have different override
+  // semantics for the site name. Sentinel comparison is gone: component
+  // sentinels can never enter brand.logo_url (Config#normalize_brand rejects
+  // them), so presence alone means "operator customized the logo".
+  const isCustomStaticLogo = computed(() => !!installLogoUri.value);
 
   // LOGO_PROMINENT opt-in for larger logo sizing.
   const isProminentLogo = computed(() =>
-    headerConfig.value?.branding?.logo?.prominent === true
+    headerConfig.value?.logo?.prominent === true
   );
 
   // Logo sizing: LOGO_PROMINENT controls size, auth state determines the tier.
@@ -93,26 +112,26 @@
   //   2. !identity.showPlatformIdentity     (resolver base guard: a per-tenant
   //                                          logo or any custom domain suppresses
   //                                          the platform wordmark — the A3 leak)
-  //   3. headerConfig.branding.logo.show_name  (LOGO_SHOW_NAME explicit config)
-  //   4. isCustomStaticLogo.value           (heuristic: custom LOGO_URL usually
-  //                                          embeds its own wordmark)
-  //   5. !!site_name                        (default visibility tied to SITE_NAME)
-  //
-  // Rung 2 replaces the former `domain_logo` check: showPlatformIdentity is
-  // `!isCustom && !logoUri`, so `!showPlatformIdentity` is `isCustom || logoUri`
-  // — the same per-tenant-logo suppression, now also covering custom domains
-  // with no uploaded logo. The caller/operator override rungs are unchanged.
+  //   3. headerConfig.logo.show_name        (LOGO_SHOW_NAME explicit layout knob;
+  //                                          unset ships as null so the heuristic
+  //                                          below can act)
+  //   4. isCustomStaticLogo.value           (heuristic: a custom BRAND_LOGO_URL
+  //                                          usually embeds its own wordmark)
+  //   5. true                               (default: show the resolver-supplied
+  //                                          product name next to the neutral mark)
   const getShowSiteName = () => {
     if (props.logo?.showSiteName != null) return props.logo.showSiteName;
     if (!showPlatformIdentity.value) return false;
 
-    const showName = headerConfig.value?.branding?.logo?.show_name;
+    const showName = headerConfig.value?.logo?.show_name;
     if (showName != null) return showName;
 
-    if (isCustomStaticLogo.value) return false;
-    return !!headerConfig.value?.branding?.site_name;
+    return !isCustomStaticLogo.value;
   };
-  const getSiteName = () => props.logo?.siteName || headerConfig.value?.branding?.site_name || t('web.homepage.one_time_secret_literal', { product_name: productName.value });
+  // The wordmark text is the resolver's productName (brand.product_name or
+  // the neutral default) — the deprecated header.branding.site_name is
+  // absorbed into brand.product_name by Config#normalize_brand (#3612).
+  const getSiteName = () => props.logo?.siteName || t('web.homepage.one_time_secret_literal', { product_name: productName.value });
   const getAriaLabel = () => props.logo?.ariaLabel;
   const getIsColonelArea = () => props.logo?.isColonelArea ?? props.colonel;
 

--- a/src/shared/stores/bootstrapStore.ts
+++ b/src/shared/stores/bootstrapStore.ts
@@ -55,6 +55,7 @@ const DEFAULTS: BootstrapPayload = {
   brand_font_family: undefined,
   brand_button_text_light: undefined,
   brand_logo_url: undefined,
+  brand_logo_alt: undefined,
   brand_favicon_url: undefined,
 };
 

--- a/src/shared/stores/identityStore.ts
+++ b/src/shared/stores/identityStore.ts
@@ -72,6 +72,8 @@ export const useProductIdentity = defineStore('productIdentity', () => {
     domain_branding,
     domain_logo,
     brand_product_name,
+    brand_logo_url,
+    brand_logo_alt,
     homepage_config,
   } = storeToRefs(bootstrapStore);
 
@@ -212,22 +214,49 @@ export const useProductIdentity = defineStore('productIdentity', () => {
   const showPlatformIdentity = computed(() => !isCustom.value && !logoUri.value);
 
   /**
+   * Operator-configured install-wide logo asset (BRAND_LOGO_URL /
+   * brand.logo_url, flattened to `brand_logo_url` in the bootstrap payload).
+   * This is the platform's own identity, so it is suppressed on custom
+   * domains for the same reason `showPlatformIdentity` suppresses the
+   * wordmark there: a tenant's domain shows the tenant's logo or the neutral
+   * mark, never the operator's (#3612 closes the logo-asset half of the A3
+   * leak). Null when unconfigured or on a custom domain.
+   *
+   * `||` (not `??`) so an empty-string config value reads as absent.
+   */
+  const installLogoUri = computed(() =>
+    isCustom.value ? null : brand_logo_url?.value || null
+  );
+
+  /**
+   * Operator-supplied alt text for the install logo (BRAND_LOGO_ALT /
+   * brand.logo_alt). Only meaningful while the install logo is the one being
+   * shown — it describes that asset — so it is null whenever installLogoUri
+   * is. Consumers fall back to their i18n productName-derived alt.
+   */
+  const installLogoAlt = computed(() =>
+    installLogoUri.value ? brand_logo_alt?.value || null : null
+  );
+
+  /**
    * Resolved logo source on the identity axis: the tenant's uploaded logo when
-   * present, otherwise the neutral `DefaultLogo` component sentinel. Never null
-   * or empty, so a consumer can render a lockup without its own "no logo"
-   * fallback.
+   * present, then the operator's install-wide logo (custom domains excepted,
+   * see installLogoUri), then the neutral `DefaultLogo` component sentinel.
+   * Never null or empty, so a consumer can render a lockup without its own
+   * "no logo" fallback.
    *
    * Uses `||` (not `??`): an empty-string `domain_logo` is treated as absent and
-   * falls through to the neutral sentinel, matching how the rest of the codebase
-   * reads the logo as a truthy/falsy signal (e.g. `!!domain_logo` in the router
-   * guards) and preserving the masthead's prior terminal fallback for `''`.
+   * falls through, matching how the rest of the codebase reads the logo as a
+   * truthy/falsy signal (e.g. `!!domain_logo` in the router guards) and
+   * preserving the masthead's prior terminal fallback for `''`.
    *
-   * This is the identity contribution only; the masthead still layers its own
-   * caller/operator rungs (props.logo.url, LOGO_URL) around it — a per-tenant
-   * logo must win over an operator-wide LOGO_URL, and LOGO_URL over the neutral
-   * default.
+   * This completes the #3612 consolidation: the masthead's only remaining
+   * rung above this is the caller prop (props.logo.url) — the operator logo
+   * is no longer read from `ui.header.branding`.
    */
-  const logoSource = computed(() => logoUri.value || DEFAULT_LOGO_COMPONENT);
+  const logoSource = computed(
+    () => logoUri.value || installLogoUri.value || DEFAULT_LOGO_COMPONENT
+  );
 
   const cornerClass = computed(() =>
     state.brand?.corner_style
@@ -268,6 +297,8 @@ export const useProductIdentity = defineStore('productIdentity', () => {
     displayName,
     productName,
     showPlatformIdentity,
+    installLogoUri,
+    installLogoAlt,
     logoSource,
     $reset,
 

--- a/src/shared/stores/identityStore.ts
+++ b/src/shared/stores/identityStore.ts
@@ -230,12 +230,15 @@ export const useProductIdentity = defineStore('productIdentity', () => {
 
   /**
    * Operator-supplied alt text for the install logo (BRAND_LOGO_ALT /
-   * brand.logo_alt). Only meaningful while the install logo is the one being
-   * shown — it describes that asset — so it is null whenever installLogoUri
-   * is. Consumers fall back to their i18n productName-derived alt.
+   * brand.logo_alt). Only meaningful while the install logo is the asset
+   * actually being rendered — it describes that image — so it is null when
+   * installLogoUri is null AND when a tenant logo outranks the install logo
+   * in logoSource (labeling the tenant's image with the operator's alt text
+   * would leak the wrong accessible name). Consumers fall back to their
+   * i18n productName-derived alt.
    */
   const installLogoAlt = computed(() =>
-    installLogoUri.value ? brand_logo_alt?.value || null : null
+    installLogoUri.value && !logoUri.value ? brand_logo_alt?.value || null : null
   );
 
   /**

--- a/src/tests/apps/secret/components/layout/BrandedHeader.spec.ts
+++ b/src/tests/apps/secret/components/layout/BrandedHeader.spec.ts
@@ -96,14 +96,17 @@ describe('BrandedHeader', () => {
           },
           homepage_config: storeOverrides.homepage_config ?? null,
           ui: {
+            // #3612: ui.header carries only layout knobs; brand identity
+            // (logo asset, product name) lives in the flat brand_* fields.
             header: storeOverrides.header ?? {
+              enabled: true,
+              logo: { href: null, show_name: null, prominent: null },
               navigation: { enabled: true },
-              branding: {
-                logo: { url: 'DefaultLogo.vue', alt: 'Onetime Secret' },
-                site_name: 'Onetime Secret',
-              },
             },
           },
+          brand_product_name: null,
+          brand_logo_url: null,
+          brand_logo_alt: null,
         },
       },
     });

--- a/src/tests/contracts/bootstrap-schema-contract.spec.ts
+++ b/src/tests/contracts/bootstrap-schema-contract.spec.ts
@@ -440,13 +440,12 @@ describe('Bootstrap realistic payload parsing', () => {
         },
         header: {
           enabled: true,
-          branding: {
-            logo: {
-              url: '/img/logo.svg',
-              alt: 'OTS',
-              link_to: '/',
-            },
-            site_name: 'One-Time Secret',
+          // #3612: header carries only layout knobs; the logo asset / alt /
+          // product name arrive via the flat brand_* bootstrap fields.
+          logo: {
+            href: '/',
+            show_name: true,
+            prominent: false,
           },
         },
         footer_links: {

--- a/src/tests/contracts/bootstrap-serializer-fields.ts
+++ b/src/tests/contracts/bootstrap-serializer-fields.ts
@@ -39,6 +39,7 @@ export const CONFIG_SERIALIZER_FIELDS = [
   'brand_font_family',
   'brand_button_text_light',
   'brand_logo_url',
+  'brand_logo_alt',
   'brand_favicon_url',
   'd9s_enabled',
   'development',

--- a/src/tests/fixtures/bootstrap.fixture.ts
+++ b/src/tests/fixtures/bootstrap.fixture.ts
@@ -138,6 +138,7 @@ export const baseBootstrap: BootstrapPayload = {
   brand_font_family: null,
   brand_button_text_light: null,
   brand_logo_url: null,
+  brand_logo_alt: null,
   brand_favicon_url: null,
 };
 

--- a/src/tests/schemas/shapes/config/ui.spec.ts
+++ b/src/tests/schemas/shapes/config/ui.spec.ts
@@ -71,13 +71,39 @@ describe('userInterfaceHeaderShape', () => {
     expect(userInterfaceHeaderShape.parse({}).enabled).toBe(true);
   });
 
-  it('preserves branding/navigation passthrough', () => {
+  it('preserves logo layout knobs / navigation passthrough (#3612)', () => {
+    // header.branding is gone — the header carries only presentation knobs
+    // (href / show_name / prominent); brand identity lives in the brand: block.
     const result = userInterfaceHeaderShape.parse({
-      branding: { site_name: 'OTS' },
+      logo: { href: '/dashboard', show_name: true, prominent: false },
       navigation: { enabled: false },
     });
-    expect(result.branding?.site_name).toBe('OTS');
+    expect(result.logo?.href).toBe('/dashboard');
+    expect(result.logo?.show_name).toBe(true);
+    expect(result.logo?.prominent).toBe(false);
     expect(result.navigation?.enabled).toBe(false);
+  });
+
+  it('accepts null logo knobs (unset means "use the surface default")', () => {
+    const result = userInterfaceHeaderShape.parse({
+      logo: { href: null, show_name: null, prominent: null },
+    });
+    expect(result.logo?.href).toBeNull();
+    expect(result.logo?.show_name).toBeNull();
+    expect(result.logo?.prominent).toBeNull();
+  });
+
+  it('strips a legacy branding nesting from the payload (#3612)', () => {
+    // A legacy operator payload with the retired header.branding shape must
+    // not survive parsing — brand identity is not modeled on the header.
+    const result = userInterfaceHeaderShape.parse({
+      branding: {
+        logo: { url: 'DefaultLogo.vue', alt: 'x', link_to: '/' },
+        site_name: 'One-Time Secret',
+      },
+    });
+    expect(result).not.toHaveProperty('branding');
+    expect(JSON.stringify(result)).not.toContain('One-Time Secret');
   });
 });
 
@@ -89,7 +115,8 @@ describe('userInterfaceFooterLinksShape', () => {
 
 describe('UI pass-through shapes (no augmentation)', () => {
   it('logo / capabilities / help parse populated input verbatim', () => {
-    expect(userInterfaceLogoShape.parse({ url: '/img/logo.svg' }).url).toBe('/img/logo.svg');
+    expect(userInterfaceLogoShape.parse({ show_name: true }).show_name).toBe(true);
+    expect(userInterfaceLogoShape.parse({ href: '/vault' }).href).toBe('/vault');
     expect(uiCapabilitiesShape.parse({ burn: true }).burn).toBe(true);
     expect(uiHelpShape.parse({ enabled: false }).enabled).toBe(false);
   });

--- a/src/tests/shared/brandingResolverConsolidation.guard.spec.ts
+++ b/src/tests/shared/brandingResolverConsolidation.guard.spec.ts
@@ -59,6 +59,7 @@ function stripComments(src: string): string {
 const MASTHEAD = 'src/shared/components/layout/MastHead.vue';
 const DEFAULT_LOGO = 'src/shared/components/logos/DefaultLogo.vue';
 const USE_PAGE_TITLE = 'src/shared/composables/usePageTitle.ts';
+const IDENTITY_STORE = 'src/shared/stores/identityStore.ts';
 
 describe('branding resolver consolidation guardrail', () => {
   describe('MastHead routes brand identity through identityStore', () => {
@@ -76,6 +77,15 @@ describe('branding resolver consolidation guardrail', () => {
       expect(code).not.toContain('domain_logo');
     });
 
+    it('reads the logo asset from the resolver, not header branding or the raw brand field (#3612)', () => {
+      // The operator's install logo comes from the resolver
+      // (installLogoUri/logoSource); ui.header keeps only layout knobs. Neither
+      // the removed header.branding nesting nor the raw brand_logo_url
+      // bootstrap field may reappear in masthead code.
+      expect(code).not.toContain('.branding');
+      expect(code).not.toContain('brand_logo_url');
+    });
+
     it('does not hardcode the OTS platform name', () => {
       expect(code).not.toContain('Onetime Secret');
     });
@@ -84,8 +94,30 @@ describe('branding resolver consolidation guardrail', () => {
       expect(raw).toContain('useProductIdentity');
       expect(raw).toContain('productName');
       expect(raw).toContain('showPlatformIdentity');
-      expect(raw).toContain('logoUri');
+      expect(raw).toContain('installLogoUri');
+      expect(raw).toContain('installLogoAlt');
       expect(raw).toContain('logoSource');
+    });
+  });
+
+  describe('identityStore is the one place the raw install-brand fields are read', () => {
+    // The resolver owns the raw brand_logo_url read and the custom-domain
+    // gate (installLogoUri nulls out when isCustom) — every surface above it
+    // consumes the resolved signals instead of re-deriving the leak rule.
+    const raw = read(IDENTITY_STORE);
+    const code = stripComments(raw);
+
+    it('reads the raw brand_logo_url field into installLogoUri', () => {
+      expect(raw).toContain('brand_logo_url');
+      expect(raw).toContain('installLogoUri');
+    });
+
+    it('gates the install logo on the custom-domain check (#3612 leak fix)', () => {
+      expect(raw).toContain('isCustom');
+    });
+
+    it('does not hardcode the OTS platform name', () => {
+      expect(code).not.toContain('Onetime Secret');
     });
   });
 

--- a/src/tests/shared/components/layout/MastHead.customDomain.spec.ts
+++ b/src/tests/shared/components/layout/MastHead.customDomain.spec.ts
@@ -10,7 +10,7 @@ import { createTestingPinia } from '@pinia/testing';
 import MastHead from '@/shared/components/layout/MastHead.vue';
 import { nextTick } from 'vue';
 import { useAuthStore } from '@/shared/stores/authStore';
-import { createTestI18n } from '@tests/setup';
+import { createI18n } from 'vue-i18n';
 
 // Mock DefaultLogo component
 vi.mock('@/shared/components/logos/DefaultLogo.vue', () => ({
@@ -51,7 +51,27 @@ vi.mock('vue-router', () => ({
   },
 }));
 
-const i18n = createTestI18n();
+// Interpolating i18n: unlike the pass-through createTestI18n, the wordmark
+// message renders the actual product_name so the "Onetime Secret must not
+// leak" assertions below observe the real rendered name, not an i18n key.
+// Unlisted keys still echo the key (missing handler), matching the
+// pass-through assertions elsewhere in this file.
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  missingWarn: false,
+  fallbackWarn: false,
+  missing: (_, key) => key,
+  messages: {
+    en: {
+      web: {
+        homepage: {
+          one_time_secret_literal: '{product_name}',
+        },
+      },
+    },
+  },
+});
 
 describe('MastHead — Custom Domain Logo Behavior', () => {
   let wrapper: VueWrapper;
@@ -83,6 +103,8 @@ describe('MastHead — Custom Domain Logo Behavior', () => {
     domain_strategy?: string;
     display_domain?: string;
     domain_id?: string;
+    brand_logo_url?: string | null;
+    brand_logo_alt?: string | null;
   };
 
   const buildBootstrapState = (s: StoreState) => ({
@@ -94,6 +116,8 @@ describe('MastHead — Custom Domain Logo Behavior', () => {
     domain_strategy: s.domain_strategy ?? 'canonical',
     display_domain: s.display_domain ?? 'onetimesecret.com',
     domain_id: s.domain_id ?? '',
+    brand_logo_url: s.brand_logo_url ?? null,
+    brand_logo_alt: s.brand_logo_alt ?? null,
   });
 
   const mountComponent = (props: Record<string, unknown> = {}, storeState: StoreState = {}) => {
@@ -103,13 +127,16 @@ describe('MastHead — Custom Domain Logo Behavior', () => {
       initialState: {
         bootstrap: {
           ...buildBootstrapState(storeState),
+          // #3612: brand identity flows through the flat brand_* fields;
+          // ui.header keeps only layout knobs. The platform name below is
+          // the operator's install identity that must never leak onto a
+          // tenant's custom domain.
+          brand_product_name: 'Onetime Secret',
           ui: {
             header: {
+              enabled: true,
+              logo: { href: null, show_name: null, prominent: null },
               navigation: { enabled: true },
-              branding: {
-                logo: { url: 'DefaultLogo.vue', alt: 'Onetime Secret' },
-                site_name: 'Onetime Secret',
-              },
             },
           },
           authentication: {
@@ -342,10 +369,38 @@ describe('MastHead — Custom Domain Logo Behavior', () => {
       );
 
       await nextTick();
-      // When domain_logo is null, MastHead falls back to the configured logo URL
-      // which defaults to 'DefaultLogo.vue' — this renders the OTS logo
+      // When domain_logo is null on a custom domain, the resolver's logoSource
+      // falls to the neutral DefaultLogo sentinel (never the operator's
+      // install logo — see the #3612 leak-fix test below).
       const defaultLogo = wrapper.find('.default-logo');
       expect(defaultLogo.exists()).toBe(true);
+    });
+
+    it('renders the neutral DefaultLogo even when brand_logo_url is set (install-logo leak fix #3612)', async () => {
+      // The operator's install-wide BRAND_LOGO_URL is the platform's own
+      // identity. On a tenant's custom domain it must NOT render — same
+      // semantics as showPlatformIdentity suppressing the wordmark. The
+      // resolver's installLogoUri nulls out on custom domains, so logoSource
+      // degrades to the neutral sentinel instead of leaking the install logo.
+      wrapper = mountComponent(
+        {},
+        {
+          authenticated: false,
+          domain_strategy: 'custom',
+          domain_logo: null,
+          brand_logo_url: '/img/install-brand.svg',
+          display_domain: 'secrets.acme.com',
+          domain_id: 'cd_acme',
+        }
+      );
+
+      await nextTick();
+      // Neutral mark renders...
+      const defaultLogo = wrapper.find('.default-logo');
+      expect(defaultLogo.exists()).toBe(true);
+      // ...and the install logo <img> does not.
+      const img = wrapper.find('img#logo');
+      expect(img.exists()).toBe(false);
     });
 
     it('suppresses the OTS site name when custom domain has no logo', async () => {
@@ -390,7 +445,7 @@ describe('MastHead — Custom Domain Logo Behavior', () => {
   // LOGO CONFIGURATION PRIORITY
   // ═══════════════════════════════════════════════════════════════════════════
 
-  describe('Logo configuration priority: props > domain_logo > config > default', () => {
+  describe('Logo configuration priority: props > domain_logo > brand_logo_url > default', () => {
     it('props override domain_logo when both are provided', async () => {
       wrapper = mountComponent(
         {
@@ -420,18 +475,23 @@ describe('MastHead — Custom Domain Logo Behavior', () => {
       expect(img.attributes('height')).toBe('48');
     });
 
-    it('domain_logo takes priority over header config logo URL', async () => {
+    it('domain_logo takes priority over brand_logo_url', async () => {
+      // On the canonical domain the install logo is allowed to show, so this
+      // is the one context where both rungs compete on equal footing: the
+      // tenant's uploaded logo must still win. (On custom domains the install
+      // logo never shows at all — see the #3612 leak-fix test above.)
       wrapper = mountComponent(
         {},
         {
           authenticated: false,
-          domain_strategy: 'custom',
+          domain_strategy: 'canonical',
           domain_logo: 'https://cdn.example.com/domain-logo.png',
+          brand_logo_url: '/img/install-brand.svg',
         }
       );
 
       await nextTick();
-      // Should use domain_logo, not the header config default
+      // Should use domain_logo, not the operator's install logo
       const img = wrapper.find('img#logo');
       expect(img.exists()).toBe(true);
       expect(img.attributes('src')).toBe('https://cdn.example.com/domain-logo.png');

--- a/src/tests/shared/components/layout/MastHead.spec.ts
+++ b/src/tests/shared/components/layout/MastHead.spec.ts
@@ -79,6 +79,12 @@ describe('MastHead', () => {
    * - authenticated=true && cust != null → isUserPresent=true
    * - awaiting_mfa=true && email != null → isUserPresent=true
    * - Otherwise → isUserPresent=false
+   *
+   * Brand identity is seeded through the flat `brand_*` bootstrap fields
+   * (BRAND_PRODUCT_NAME / BRAND_LOGO_URL / BRAND_LOGO_ALT); the header keeps
+   * only layout knobs at ui.header.logo (#3612 — the ui.header.branding
+   * nesting no longer exists). The defaults below model an unconfigured
+   * install: neutral DefaultLogo, no operator logo, no product name.
    */
   const mountComponent = (
     props: Record<string, unknown> = {},
@@ -88,6 +94,15 @@ describe('MastHead', () => {
       email?: string | null;
       cust?: typeof mockCustomer | null;
       domain_logo?: string | null;
+      domain_strategy?: string;
+      brand_product_name?: string | null;
+      brand_logo_url?: string | null;
+      brand_logo_alt?: string | null;
+      header_logo?: {
+        href?: string | null;
+        show_name?: boolean | null;
+        prominent?: boolean | null;
+      };
     } = {}
   ) => {
     const pinia = createTestingPinia({
@@ -100,13 +115,19 @@ describe('MastHead', () => {
           email: storeState.email ?? null,
           cust: storeState.cust ?? null,
           domain_logo: storeState.domain_logo ?? null,
+          domain_strategy: storeState.domain_strategy ?? 'canonical',
+          brand_product_name: storeState.brand_product_name ?? null,
+          brand_logo_url: storeState.brand_logo_url ?? null,
+          brand_logo_alt: storeState.brand_logo_alt ?? null,
           ui: {
             header: {
-              navigation: { enabled: true },
-              branding: {
-                logo: { url: 'DefaultLogo.vue', alt: 'Onetime Secret' },
-                site_name: 'Onetime Secret',
+              enabled: true,
+              logo: {
+                href: storeState.header_logo?.href ?? null,
+                show_name: storeState.header_logo?.show_name ?? null,
+                prominent: storeState.header_logo?.prominent ?? null,
               },
+              navigation: { enabled: true },
             },
           },
           authentication: {
@@ -319,61 +340,25 @@ describe('MastHead', () => {
     });
   });
 
-  describe('Static config logo (ui.header.branding.logo.url)', () => {
-    const mountWithStaticLogoUrl = (
-      logoUrl: string,
-      storeState: Parameters<typeof mountComponent>[1] = {}
-    ) => {
-      const pinia = createTestingPinia({
-        createSpy: vi.fn,
-        stubActions: false,
-        initialState: {
-          bootstrap: {
-            authenticated: storeState.authenticated ?? false,
-            awaiting_mfa: storeState.awaiting_mfa ?? false,
-            email: storeState.email ?? null,
-            cust: storeState.cust ?? null,
-            domain_logo: storeState.domain_logo ?? null,
-            ui: {
-              header: {
-                navigation: { enabled: true },
-                branding: {
-                  logo: { url: logoUrl, alt: 'Brand' },
-                  site_name: 'Brand',
-                },
-              },
-            },
-            authentication: { enabled: true, signin: true, signup: true },
-          },
-        },
-      });
+  describe('Install brand logo (brand_logo_url)', () => {
+    // The operator's install-wide logo now flows in through the flat
+    // brand_logo_url bootstrap field and the identity resolver
+    // (installLogoUri → logoSource) — not ui.header.branding.logo.url,
+    // which is gone (#3612).
 
-      const authStore = useAuthStore(pinia);
-      const hasAuthenticatedCustomer = storeState.authenticated && storeState.cust;
-      const hasMfaPendingEmail = storeState.awaiting_mfa && storeState.email;
-      (authStore as unknown as { isUserPresent: boolean }).isUserPresent = !!(
-        hasAuthenticatedCustomer || hasMfaPendingEmail
+    it('renders the install logo <img> from brand_logo_url with default sizing', async () => {
+      wrapper = mountComponent(
+        {},
+        {
+          authenticated: false,
+          brand_logo_url: '/img/brand.svg',
+        }
       );
-
-      return mount(MastHead, {
-        props: { displayMasthead: true, displayNavigation: true },
-        global: {
-          plugins: [i18n, pinia],
-          stubs: {
-            RouterLink: { template: '<a :href="to"><slot /></a>', props: ['to'] },
-          },
-        },
-      });
-    };
-
-    it('uses default sizing for static image URL when prominent is not set', async () => {
-      wrapper = mountWithStaticLogoUrl('/img/brand.svg', {
-        authenticated: false,
-      });
 
       await nextTick();
       const img = wrapper.find('img#logo');
       expect(img.exists()).toBe(true);
+      expect(img.attributes('src')).toBe('/img/brand.svg');
       // Without prominent=true, unauthenticated users get default 48px (h-12)
       expect(img.classes()).toContain('h-12');
       expect(img.classes()).not.toContain('h-24');
@@ -383,23 +368,80 @@ describe('MastHead', () => {
       expect(img.attributes('height')).toBe('48');
     });
 
-    it('hides the site name by default for non-default static config logos', async () => {
-      // Static-config custom branding typically embeds the wordmark in the image,
-      // so the site name text mark should not appear next to it (matches the
-      // long-standing behavior for per-domain uploaded logos).
-      wrapper = mountWithStaticLogoUrl('/img/brand.svg', {
-        authenticated: false,
-      });
+    it('links the logo lockup to ui.header.logo.href (LOGO_LINK)', async () => {
+      wrapper = mountComponent(
+        {},
+        {
+          authenticated: false,
+          brand_logo_url: '/img/brand.svg',
+          header_logo: { href: '/dashboard' },
+        }
+      );
 
       await nextTick();
-      // Site name span should not be rendered for a static custom image URL
+      const link = wrapper.find('[data-testid="header-logo-link"]');
+      expect(link.exists()).toBe(true);
+      expect(link.attributes('href')).toBe('/dashboard');
+    });
+
+    it('defaults the logo link to "/" when href is unset (null)', async () => {
+      wrapper = mountComponent(
+        {},
+        {
+          authenticated: false,
+          brand_logo_url: '/img/brand.svg',
+        }
+      );
+
+      await nextTick();
+      const link = wrapper.find('[data-testid="header-logo-link"]');
+      expect(link.exists()).toBe(true);
+      expect(link.attributes('href')).toBe('/');
+    });
+
+    it('hides the wordmark by default next to a custom install logo (heuristic)', async () => {
+      // A custom BRAND_LOGO_URL typically embeds its own wordmark, so the
+      // site-name text mark should not appear next to it (matches the
+      // long-standing behavior for per-domain uploaded logos).
+      wrapper = mountComponent(
+        {},
+        {
+          authenticated: false,
+          brand_logo_url: '/img/brand.svg',
+        }
+      );
+
+      await nextTick();
+      // Site name span should not be rendered for a custom install logo
       const siteName = wrapper.find('span.font-brand.text-lg');
       expect(siteName.exists()).toBe(false);
     });
 
-    it('does NOT treat the default DefaultLogo.vue config as a custom logo (regression)', async () => {
-      // Stock install: config.defaults.yaml ships branding.logo.url = 'DefaultLogo.vue'.
-      // This must continue to use the regular guest size (48px), not the 160px custom size.
+    it('shows the wordmark when ui.header.logo.show_name is explicitly true', async () => {
+      // LOGO_SHOW_NAME=true must beat the custom-logo heuristic (#3160 order,
+      // knob relocated from header.branding.logo to header.logo in #3612).
+      wrapper = mountComponent(
+        {},
+        {
+          authenticated: false,
+          brand_logo_url: '/img/brand.svg',
+          header_logo: { show_name: true },
+        }
+      );
+
+      await nextTick();
+      const img = wrapper.find('img#logo');
+      expect(img.exists()).toBe(true);
+
+      const siteName = wrapper.find('span.font-brand.text-lg');
+      expect(siteName.exists()).toBe(true);
+    });
+
+    it('renders the neutral DefaultLogo at guest size when no install logo is configured', async () => {
+      // Unconfigured install: brand_logo_url unset means the resolver falls
+      // to the DefaultLogo sentinel — regular guest size (48px), never a
+      // "custom logo" treatment. (Sentinel exclusion happens in Ruby:
+      // brand_logo_url can never carry the DefaultLogo.vue sentinel.)
       wrapper = mountComponent(
         {},
         {
@@ -416,58 +458,20 @@ describe('MastHead', () => {
     });
   });
 
-  describe('Prominent logo config (logo.prominent)', () => {
+  describe('Prominent logo config (ui.header.logo.prominent)', () => {
+    // LOGO_PROMINENT now lives at ui.header.logo.prominent (#3612); the
+    // logo asset itself arrives via domain_logo through the resolver.
     const mountWithProminentLogo = (
       prominent: boolean,
       storeState: Parameters<typeof mountComponent>[1] = {}
-    ) => {
-      const pinia = createTestingPinia({
-        createSpy: vi.fn,
-        stubActions: false,
-        initialState: {
-          bootstrap: {
-            authenticated: storeState.authenticated ?? false,
-            awaiting_mfa: storeState.awaiting_mfa ?? false,
-            email: storeState.email ?? null,
-            cust: storeState.cust ?? null,
-            domain_logo: storeState.domain_logo ?? null,
-            ui: {
-              header: {
-                navigation: { enabled: true },
-                branding: {
-                  logo: {
-                    url: storeState.domain_logo ?? 'DefaultLogo.vue',
-                    alt: 'Brand',
-                    prominent,
-                  },
-                  site_name: 'Brand',
-                },
-              },
-            },
-            authentication: { enabled: true, signin: true, signup: true },
-          },
-        },
-      });
-
-      // Manually set isUserPresent based on bootstrap state (same as mountComponent)
-      const authStore = useAuthStore(pinia);
-      const hasAuthenticatedCustomer = storeState.authenticated && storeState.cust;
-      const hasMfaPendingEmail = storeState.awaiting_mfa && storeState.email;
-      (authStore as unknown as { isUserPresent: boolean }).isUserPresent = !!(
-        hasAuthenticatedCustomer || hasMfaPendingEmail
+    ) =>
+      mountComponent(
+        {},
+        {
+          ...storeState,
+          header_logo: { ...storeState.header_logo, prominent },
+        }
       );
-
-      return mount(MastHead, {
-        global: {
-          plugins: [pinia, i18n],
-          stubs: { Teleport: true },
-        },
-        props: {},
-        slots: {
-          'context-switchers': '<span>test-context-switchers</span>',
-        },
-      });
-    };
 
     it('uses intermediate 80px sizing for authenticated users when prominent is true', async () => {
       wrapper = mountWithProminentLogo(true, {
@@ -689,31 +693,78 @@ describe('MastHead', () => {
         expect(logo.attributes('data-show-site-name')).toBe('true');
       }
     });
+
+    it('domain_logo wins over brand_logo_url (tenant beats install)', async () => {
+      // Both logos configured on the canonical domain: the tenant's uploaded
+      // logo outranks the operator's install logo in the resolver
+      // (logoSource = logoUri || installLogoUri || sentinel, #3612).
+      wrapper = mountComponent(
+        {},
+        {
+          authenticated: false,
+          domain_logo: 'https://example.com/tenant.png',
+          brand_logo_url: '/img/install.svg',
+        }
+      );
+
+      await nextTick();
+      const img = wrapper.find('img#logo');
+      expect(img.exists()).toBe(true);
+      expect(img.attributes('src')).toBe('https://example.com/tenant.png');
+    });
   });
 
-  describe('Site name visibility priority (regression #3160)', () => {
+  describe('Site name visibility priority (regression #3160, consolidated #3612)', () => {
     /**
      * Priority chain in getShowSiteName():
      *   1. props.logo.showSiteName            (caller-site override)
      *   2. !identity.showPlatformIdentity     (resolver base guard: any custom
      *                                          domain OR a per-tenant logo hides
      *                                          the platform wordmark)
-     *   3. headerConfig.branding.logo.show_name  (LOGO_SHOW_NAME explicit)
-     *   4. isCustomStaticLogo.value           (heuristic: non-default LOGO_URL)
-     *   5. !!site_name                        (default tied to SITE_NAME)
+     *   3. headerConfig.logo.show_name        (LOGO_SHOW_NAME explicit layout
+     *                                          knob; ships null when unset)
+     *   4. !isCustomStaticLogo                (heuristic: a custom BRAND_LOGO_URL
+     *                                          usually embeds its own wordmark)
      *
      * #3160: in v0.25.3 step 4 ran ahead of step 3, so operators setting
      * LOGO_URL + LOGO_SHOW_NAME=true silently lost their wordmark.
      *
-     * The tests below all use the canonical strategy with no domain_logo, so
-     * showPlatformIdentity is true and rung 2 falls through — exercising the
-     * operator/config rungs unchanged by the resolver consolidation.
+     * #3612: the wordmark text is now the resolver's productName
+     * (brand_product_name || 'Secure Links') — header.branding.site_name is
+     * gone — and the operator logo arrives via brand_logo_url, not
+     * header.branding.logo.url.
+     *
+     * The tests below all use the canonical strategy with no domain_logo
+     * unless stated, so showPlatformIdentity is true and rung 2 falls through.
      */
-    const mountWithBranding = (
-      branding: {
-        logoUrl: string;
-        showName: boolean;
-        siteName: string;
+    const nameI18n = createI18n({
+      legacy: false,
+      locale: 'en',
+      messages: {
+        en: {
+          web: {
+            homepage: {
+              one_time_secret_literal: '{product_name}',
+              signup_individual_and_business_plans: 'Sign up',
+              log_in_to_onetime_secret: 'Log in',
+            },
+            layout: {
+              main_navigation: 'Main Navigation',
+            },
+            COMMON: {
+              header_create_account: 'Create Account',
+              header_sign_in: 'Sign In',
+            },
+          },
+        },
+      },
+    });
+
+    const mountWithIdentity = (
+      identity: {
+        brandLogoUrl?: string | null;
+        showName?: boolean | null;
+        brandProductName?: string | null;
       },
       storeState: Parameters<typeof mountComponent>[1] = {},
       props: Record<string, unknown> = {}
@@ -728,17 +779,19 @@ describe('MastHead', () => {
             email: storeState.email ?? null,
             cust: storeState.cust ?? null,
             domain_logo: storeState.domain_logo ?? null,
+            domain_strategy: storeState.domain_strategy ?? 'canonical',
+            brand_product_name: identity.brandProductName ?? null,
+            brand_logo_url: identity.brandLogoUrl ?? null,
+            brand_logo_alt: null,
             ui: {
               header: {
-                navigation: { enabled: true },
-                branding: {
-                  logo: {
-                    url: branding.logoUrl,
-                    alt: 'Brand',
-                    show_name: branding.showName,
-                  },
-                  site_name: branding.siteName,
+                enabled: true,
+                logo: {
+                  href: null,
+                  show_name: identity.showName ?? null,
+                  prominent: null,
                 },
+                navigation: { enabled: true },
               },
             },
             authentication: { enabled: true, signin: true, signup: true },
@@ -756,7 +809,7 @@ describe('MastHead', () => {
       return mount(MastHead, {
         props: { displayMasthead: true, displayNavigation: true, ...props },
         global: {
-          plugins: [i18n, pinia],
+          plugins: [nameI18n, pinia],
           stubs: {
             RouterLink: { template: '<a :href="to"><slot /></a>', props: ['to'] },
           },
@@ -764,15 +817,16 @@ describe('MastHead', () => {
       });
     };
 
-    it('renders site name when LOGO_URL is custom AND show_name is true (core #3160 regression)', async () => {
+    it('renders the wordmark when BRAND_LOGO_URL is set AND show_name is true (core #3160 regression)', async () => {
       // The original bug: isCustomStaticLogo heuristic short-circuited ahead of
       // the explicit operator opt-in, so the wordmark vanished even though
-      // LOGO_SHOW_NAME=true was configured.
-      wrapper = mountWithBranding(
+      // LOGO_SHOW_NAME=true was configured. The wordmark text is the
+      // resolver's productName (brand_product_name), not a header site_name.
+      wrapper = mountWithIdentity(
         {
-          logoUrl: '/img/brand.svg',
+          brandLogoUrl: '/img/brand.svg',
           showName: true,
-          siteName: 'Acme Vault',
+          brandProductName: 'Acme Vault',
         },
         { authenticated: false }
       );
@@ -786,13 +840,13 @@ describe('MastHead', () => {
       expect(siteName.text()).toBe('Acme Vault');
     });
 
-    it('hides site name when LOGO_URL is custom AND show_name is false', async () => {
-      // Explicit operator opt-out must win over the SITE_NAME default.
-      wrapper = mountWithBranding(
+    it('hides the wordmark when BRAND_LOGO_URL is set AND show_name is false', async () => {
+      // Explicit operator opt-out must win over everything below it.
+      wrapper = mountWithIdentity(
         {
-          logoUrl: '/img/brand.svg',
+          brandLogoUrl: '/img/brand.svg',
           showName: false,
-          siteName: 'Acme Vault',
+          brandProductName: 'Acme Vault',
         },
         { authenticated: false }
       );
@@ -805,15 +859,61 @@ describe('MastHead', () => {
       expect(siteName.exists()).toBe(false);
     });
 
-    it('renders site name for the stock DefaultLogo when show_name is true', async () => {
+    it('hides the wordmark when show_name is unset and a custom install logo is present (heuristic)', async () => {
+      // Rung 4: LOGO_SHOW_NAME unset ships as null, so presence of a custom
+      // BRAND_LOGO_URL hides the wordmark (the asset embeds its own).
+      wrapper = mountWithIdentity(
+        {
+          brandLogoUrl: '/img/brand.svg',
+          showName: null,
+          brandProductName: 'Acme Vault',
+        },
+        { authenticated: false }
+      );
+
+      await nextTick();
+      const img = wrapper.find('img#logo');
+      expect(img.exists()).toBe(true);
+
+      const siteName = wrapper.find('span.font-brand.text-lg');
+      expect(siteName.exists()).toBe(false);
+    });
+
+    it('shows the neutral productName wordmark when show_name is unset and no install logo (default posture)', async () => {
+      // Unconfigured install: DefaultLogo renders with the resolver-supplied
+      // neutral product name visible — never "One-Time Secret" (#3612).
+      wrapper = mountWithIdentity(
+        { brandLogoUrl: null, showName: null, brandProductName: null },
+        { authenticated: false }
+      );
+
+      await nextTick();
+      const logo = wrapper.find('.default-logo');
+      expect(logo.exists()).toBe(true);
+      expect(logo.attributes('data-show-site-name')).toBe('true');
+      expect(logo.find('.site-name').text()).toBe(
+        NEUTRAL_BRAND_DEFAULTS.product_name
+      );
+    });
+
+    it('uses brand_product_name as the wordmark text when configured (no install logo)', async () => {
+      wrapper = mountWithIdentity(
+        { brandLogoUrl: null, showName: null, brandProductName: 'Acme Vault' },
+        { authenticated: false }
+      );
+
+      await nextTick();
+      const logo = wrapper.find('.default-logo');
+      expect(logo.exists()).toBe(true);
+      expect(logo.attributes('data-show-site-name')).toBe('true');
+      expect(logo.find('.site-name').text()).toBe('Acme Vault');
+    });
+
+    it('renders the wordmark for the stock DefaultLogo when show_name is true', async () => {
       // Default install (Vue component logo) must still honor an explicit
       // LOGO_SHOW_NAME=true; the stub exposes data-show-site-name for assertion.
-      wrapper = mountWithBranding(
-        {
-          logoUrl: 'DefaultLogo.vue',
-          showName: true,
-          siteName: 'Onetime Secret',
-        },
+      wrapper = mountWithIdentity(
+        { brandLogoUrl: null, showName: true, brandProductName: 'Acme Vault' },
         { authenticated: false }
       );
 
@@ -823,14 +923,14 @@ describe('MastHead', () => {
       expect(logo.attributes('data-show-site-name')).toBe('true');
     });
 
-    it('hides site name when domain_logo is set even if static show_name is true (multi-tenant invariant)', async () => {
+    it('hides the wordmark when domain_logo is set even if show_name is true (multi-tenant invariant)', async () => {
       // Per-tenant domain_logo (step 2) must override LOGO_SHOW_NAME (step 3):
-      // the platform-wide site name has no business appearing on a tenant page.
-      wrapper = mountWithBranding(
+      // the platform-wide wordmark has no business appearing on a tenant page.
+      wrapper = mountWithIdentity(
         {
-          logoUrl: '/img/brand.svg',
+          brandLogoUrl: '/img/brand.svg',
           showName: true,
-          siteName: 'Acme Vault',
+          brandProductName: 'Acme Vault',
         },
         {
           authenticated: false,
@@ -846,15 +946,15 @@ describe('MastHead', () => {
       expect(siteName.exists()).toBe(false);
     });
 
-    it('hides site name when props.logo.showSiteName=false even with LOGO_URL and show_name=true', async () => {
+    it('hides the wordmark when props.logo.showSiteName=false even with BRAND_LOGO_URL and show_name=true', async () => {
       // props.logo.showSiteName (step 1) is the top of the priority chain;
       // an explicit false from a caller must beat both LOGO_SHOW_NAME and the
       // custom-logo heuristic.
-      wrapper = mountWithBranding(
+      wrapper = mountWithIdentity(
         {
-          logoUrl: '/img/brand.svg',
+          brandLogoUrl: '/img/brand.svg',
           showName: true,
-          siteName: 'Acme Vault',
+          brandProductName: 'Acme Vault',
         },
         { authenticated: false },
         {
@@ -903,18 +1003,19 @@ describe('MastHead', () => {
     });
   });
 
-  describe('brand_product_name interpolation', () => {
+  describe('Logo alt text (brand_logo_alt / productName interpolation)', () => {
     /**
-     * These tests exercise the `t('...', { product_name })` interpolation
-     * path in getLogoAlt (line 51 of MastHead.vue).
+     * These tests exercise getLogoAlt():
+     *   props.logo.alt > identity.installLogoAlt (BRAND_LOGO_ALT, only while
+     *   the install logo is shown) > t('...', { product_name }).
      *
      * Key setup requirements:
      *   1. Own i18n instance with `{product_name}` placeholders — the
      *      module-level i18n uses static strings so interpolation is ignored.
-     *   2. branding.logo.alt and branding.site_name cleared — otherwise the
-     *      `||` chain in getLogoAlt/getSiteName short-circuits before t().
-     *   3. Non-.vue logo URL — so the <img :alt> branch renders (the
-     *      DefaultLogo mock doesn't expose alt).
+     *   2. brand_logo_url set to a non-.vue URL — so the <img :alt> branch
+     *      renders (the DefaultLogo mock doesn't expose alt).
+     *   3. brand_logo_alt cleared (unless under test) — otherwise the `||`
+     *      chain in getLogoAlt short-circuits before t().
      */
     const brandI18n = createI18n({
       legacy: false,
@@ -939,7 +1040,10 @@ describe('MastHead', () => {
       },
     });
 
-    const mountWithBrand = (brandProductName: string | null | undefined) => {
+    const mountWithBrand = (
+      brandProductName: string | null | undefined,
+      opts: { brandLogoAlt?: string | null } = {}
+    ) => {
       const pinia = createTestingPinia({
         createSpy: vi.fn,
         stubActions: false,
@@ -950,14 +1054,15 @@ describe('MastHead', () => {
             email: null,
             cust: null,
             domain_logo: null,
+            domain_strategy: 'canonical',
             brand_product_name: brandProductName,
+            brand_logo_url: '/static/brand.png',
+            brand_logo_alt: opts.brandLogoAlt ?? null,
             ui: {
               header: {
+                enabled: true,
+                logo: { href: null, show_name: null, prominent: null },
                 navigation: { enabled: true },
-                branding: {
-                  logo: { url: '/static/brand.png', alt: null },
-                  site_name: null,
-                },
               },
             },
             authentication: {
@@ -989,7 +1094,17 @@ describe('MastHead', () => {
       });
     };
 
-    it('interpolates brand_product_name into logo alt text', async () => {
+    it('uses brand_logo_alt when the install logo is the asset being shown', async () => {
+      wrapper = mountWithBrand('ACME', { brandLogoAlt: 'ACME Corp wordmark' });
+      await nextTick();
+
+      const img = wrapper.find('img#logo');
+      expect(img.exists()).toBe(true);
+      expect(img.attributes('src')).toBe('/static/brand.png');
+      expect(img.attributes('alt')).toBe('ACME Corp wordmark');
+    });
+
+    it('interpolates brand_product_name into logo alt text when brand_logo_alt is unset', async () => {
       wrapper = mountWithBrand('ACME');
       await nextTick();
 

--- a/src/tests/shared/components/layout/MastHead.spec.ts
+++ b/src/tests/shared/components/layout/MastHead.spec.ts
@@ -368,6 +368,27 @@ describe('MastHead', () => {
       expect(img.attributes('height')).toBe('48');
     });
 
+    it('does not apply BRAND_LOGO_ALT to a tenant logo that outranks the install logo', async () => {
+      // The operator's alt text describes the operator's image. When a tenant
+      // domain_logo wins the logoSource race, the rendered <img> must not
+      // carry BRAND_LOGO_ALT (wrong accessible name for the tenant's asset).
+      wrapper = mountComponent(
+        {},
+        {
+          authenticated: false,
+          domain_logo: '/imagine/ext123/logo.png',
+          brand_logo_url: '/img/install-brand.svg',
+          brand_logo_alt: 'Acme Corp wordmark',
+        }
+      );
+
+      await nextTick();
+      const img = wrapper.find('img#logo');
+      expect(img.exists()).toBe(true);
+      expect(img.attributes('src')).toBe('/imagine/ext123/logo.png');
+      expect(img.attributes('alt')).not.toBe('Acme Corp wordmark');
+    });
+
     it('links the logo lockup to ui.header.logo.href (LOGO_LINK)', async () => {
       wrapper = mountComponent(
         {},

--- a/src/tests/shared/components/layout/TransactionalHeader.customDomain.spec.ts
+++ b/src/tests/shared/components/layout/TransactionalHeader.customDomain.spec.ts
@@ -73,14 +73,17 @@ describe('TransactionalHeader — Custom Domain Leak Vector', () => {
             ? storeState.homepage_config
             : null,
           ui: {
+            // #3612: ui.header carries only layout knobs; brand identity
+            // (logo asset, product name) lives in the flat brand_* fields.
             header: storeState.header ?? {
+              enabled: true,
+              logo: { href: null, show_name: null, prominent: null },
               navigation: { enabled: true },
-              branding: {
-                logo: { url: 'DefaultLogo.vue', alt: 'Onetime Secret' },
-                site_name: 'Onetime Secret',
-              },
             },
           },
+          brand_product_name: null,
+          brand_logo_url: null,
+          brand_logo_alt: null,
           authentication: {
             enabled: true,
             signin: true,

--- a/src/tests/stores/bootstrapStore.spec.ts
+++ b/src/tests/stores/bootstrapStore.spec.ts
@@ -311,10 +311,9 @@ describe('bootstrapStore', () => {
         enabled: true,
         header: {
           enabled: true,
-          branding: {
-            logo: { url: '/logo.png', alt: 'Logo', link_to: '/' },
-            site_name: 'Custom Site',
-          },
+          // #3612: header carries only layout knobs (href/show_name/prominent);
+          // brand identity lives in the flat brand_* fields.
+          logo: { href: '/', show_name: true, prominent: false },
         },
         footer_links: {
           enabled: true,
@@ -749,22 +748,21 @@ describe('bootstrapStore', () => {
     });
 
     describe('headerConfig', () => {
-      it('returns header configuration from UI', () => {
+      it('returns header configuration from UI (logo layout knobs pass through)', () => {
         store.update({
           ui: {
             enabled: true,
             header: {
               enabled: true,
-              branding: {
-                logo: { url: '/logo.png', alt: 'Logo', link_to: '/' },
-                site_name: 'My Site',
-              },
+              logo: { href: '/dashboard', show_name: true, prominent: false },
             },
           },
         });
 
         expect(store.headerConfig?.enabled).toBe(true);
-        expect(store.headerConfig?.branding?.site_name).toBe('My Site');
+        expect(store.headerConfig?.logo?.href).toBe('/dashboard');
+        expect(store.headerConfig?.logo?.show_name).toBe(true);
+        expect(store.headerConfig?.logo?.prominent).toBe(false);
       });
 
       it('returns undefined when header not configured', () => {
@@ -928,10 +926,7 @@ describe('bootstrapStore', () => {
         enabled: true,
         header: {
           enabled: true,
-          branding: {
-            logo: { url: '/custom.png', alt: 'Custom', link_to: '/home' },
-            site_name: 'Complex Site',
-          },
+          logo: { href: '/home', show_name: true, prominent: true },
           navigation: { enabled: true },
         },
         footer_links: {
@@ -952,7 +947,9 @@ describe('bootstrapStore', () => {
       store.update({ ui: complexUi });
 
       expect(store.ui).toEqual(complexUi);
-      expect(store.ui.header?.branding?.site_name).toBe('Complex Site');
+      expect(store.ui.header?.logo?.href).toBe('/home');
+      expect(store.ui.header?.logo?.show_name).toBe(true);
+      expect(store.ui.header?.logo?.prominent).toBe(true);
       expect(store.ui.footer_links?.groups[0].links).toHaveLength(2);
     });
   });
@@ -1424,10 +1421,7 @@ describe('bootstrapStore', () => {
         enabled: true,
         header: {
           enabled: true,
-          branding: {
-            logo: { url: '/logo.png', alt: 'Logo', link_to: '/' },
-            site_name: 'Test Site',
-          },
+          logo: { href: '/', show_name: true, prominent: false },
           navigation: {
             enabled: true,
             links: [

--- a/src/tests/stores/identityStore.spec.ts
+++ b/src/tests/stores/identityStore.spec.ts
@@ -627,6 +627,24 @@ describe('identityStore installLogoAlt', () => {
 
     expect(identity.installLogoAlt).toBeNull();
   });
+
+  it('is null when a tenant logo outranks the install logo in logoSource', () => {
+    // The operator's alt text describes the operator's image. When a tenant
+    // domain_logo wins the logoSource race, applying BRAND_LOGO_ALT to the
+    // tenant's image would leak the wrong accessible name.
+    const bootstrap = useBootstrapStore();
+    bootstrap.$patch({
+      brand_logo_url: '/img/install-brand.svg',
+      brand_logo_alt: 'Acme Corp wordmark',
+      domain_logo: '/imagine/ext123/logo.png',
+      domain_strategy: 'canonical',
+    });
+
+    const identity = useProductIdentity();
+
+    expect(identity.logoSource).toBe('/imagine/ext123/logo.png');
+    expect(identity.installLogoAlt).toBeNull();
+  });
 });
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/src/tests/stores/identityStore.spec.ts
+++ b/src/tests/stores/identityStore.spec.ts
@@ -479,12 +479,164 @@ describe('identityStore showPlatformIdentity', () => {
 });
 
 // ═══════════════════════════════════════════════════════════════════════════
-// logoSource — resolved tenant-or-neutral logo image (Phase 4 consolidation)
+// installLogoUri — operator install-wide logo asset (BRAND_LOGO_URL, #3612)
 //
-// The tenant's uploaded logo when present, else the neutral DefaultLogo
-// component sentinel. Never null or empty (uses ||, so '' is treated as
-// absent), so the masthead can stop reading raw bootstrapStore.domain_logo and
-// route the logo image through the resolver too.
+// The flat brand_logo_url bootstrap field, read only here. It is the
+// platform's own identity, so it is suppressed on custom domains for the
+// same reason showPlatformIdentity suppresses the wordmark there (the
+// logo-asset half of the A3 leak). Empty string reads as absent (||).
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('identityStore installLogoUri', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  it('is null when brand_logo_url is unset', () => {
+    const bootstrap = useBootstrapStore();
+    bootstrap.$patch({ brand_logo_url: null, domain_strategy: 'canonical' });
+
+    const identity = useProductIdentity();
+
+    expect(identity.installLogoUri).toBeNull();
+  });
+
+  it('returns brand_logo_url on the canonical domain', () => {
+    const bootstrap = useBootstrapStore();
+    bootstrap.$patch({
+      brand_logo_url: '/img/install-brand.svg',
+      domain_strategy: 'canonical',
+    });
+
+    const identity = useProductIdentity();
+
+    expect(identity.installLogoUri).toBe('/img/install-brand.svg');
+  });
+
+  it('returns brand_logo_url on a subdomain (the subdomain IS the platform)', () => {
+    const bootstrap = useBootstrapStore();
+    bootstrap.$patch({
+      brand_logo_url: '/img/install-brand.svg',
+      domain_strategy: 'subdomain',
+    });
+
+    const identity = useProductIdentity();
+
+    expect(identity.installLogoUri).toBe('/img/install-brand.svg');
+  });
+
+  it('is null on a custom domain even when brand_logo_url is set (leak fix #3612)', () => {
+    const bootstrap = useBootstrapStore();
+    bootstrap.$patch({
+      brand_logo_url: '/img/install-brand.svg',
+      domain_strategy: 'custom',
+    });
+
+    const identity = useProductIdentity();
+
+    expect(identity.installLogoUri).toBeNull();
+  });
+
+  it('treats an empty-string brand_logo_url as unset (|| not ??)', () => {
+    const bootstrap = useBootstrapStore();
+    bootstrap.$patch({ brand_logo_url: '', domain_strategy: 'canonical' });
+
+    const identity = useProductIdentity();
+
+    expect(identity.installLogoUri).toBeNull();
+  });
+
+  it('reacts to the strategy flipping to custom (install logo withdraws)', async () => {
+    const bootstrap = useBootstrapStore();
+    bootstrap.$patch({
+      brand_logo_url: '/img/install-brand.svg',
+      domain_strategy: 'canonical',
+    });
+
+    const identity = useProductIdentity();
+    expect(identity.installLogoUri).toBe('/img/install-brand.svg');
+
+    bootstrap.$patch({ domain_strategy: 'custom' });
+    await nextTick();
+
+    expect(identity.installLogoUri).toBeNull();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// installLogoAlt — operator alt text for the install logo (BRAND_LOGO_ALT)
+//
+// Only meaningful while the install logo is the asset being shown: it
+// describes that asset, so it is null whenever installLogoUri is. Consumers
+// fall back to their i18n productName-derived alt.
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('identityStore installLogoAlt', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  it('returns brand_logo_alt when the install logo is present', () => {
+    const bootstrap = useBootstrapStore();
+    bootstrap.$patch({
+      brand_logo_url: '/img/install-brand.svg',
+      brand_logo_alt: 'Acme Corp wordmark',
+      domain_strategy: 'canonical',
+    });
+
+    const identity = useProductIdentity();
+
+    expect(identity.installLogoAlt).toBe('Acme Corp wordmark');
+  });
+
+  it('is null when brand_logo_alt is unset even with an install logo', () => {
+    const bootstrap = useBootstrapStore();
+    bootstrap.$patch({
+      brand_logo_url: '/img/install-brand.svg',
+      brand_logo_alt: null,
+      domain_strategy: 'canonical',
+    });
+
+    const identity = useProductIdentity();
+
+    expect(identity.installLogoAlt).toBeNull();
+  });
+
+  it('is null when brand_logo_alt is set but there is no install logo to describe', () => {
+    const bootstrap = useBootstrapStore();
+    bootstrap.$patch({
+      brand_logo_url: null,
+      brand_logo_alt: 'Acme Corp wordmark',
+      domain_strategy: 'canonical',
+    });
+
+    const identity = useProductIdentity();
+
+    expect(identity.installLogoAlt).toBeNull();
+  });
+
+  it('is null on a custom domain even when both fields are set (follows installLogoUri)', () => {
+    const bootstrap = useBootstrapStore();
+    bootstrap.$patch({
+      brand_logo_url: '/img/install-brand.svg',
+      brand_logo_alt: 'Acme Corp wordmark',
+      domain_strategy: 'custom',
+    });
+
+    const identity = useProductIdentity();
+
+    expect(identity.installLogoAlt).toBeNull();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// logoSource — resolved logo image on the identity axis (#3612)
+//
+// Tenant's uploaded logo > operator's install-wide brand_logo_url (custom
+// domains excepted, via installLogoUri) > the neutral DefaultLogo component
+// sentinel. Never null or empty (uses ||, so '' is treated as absent), so
+// the masthead can stop reading raw bootstrapStore.domain_logo /
+// brand_logo_url and route the logo image through the resolver too.
 // ═══════════════════════════════════════════════════════════════════════════
 
 describe('identityStore logoSource', () => {
@@ -534,5 +686,44 @@ describe('identityStore logoSource', () => {
     await nextTick();
 
     expect(identity.logoSource).toBe('https://cdn.example.com/acme.png');
+  });
+
+  it('prefers the tenant logo over the install brand_logo_url', () => {
+    const bootstrap = useBootstrapStore();
+    bootstrap.$patch({
+      domain_logo: 'https://cdn.example.com/acme.png',
+      brand_logo_url: '/img/install-brand.svg',
+      domain_strategy: 'canonical',
+    });
+
+    const identity = useProductIdentity();
+
+    expect(identity.logoSource).toBe('https://cdn.example.com/acme.png');
+  });
+
+  it('falls back to brand_logo_url when no tenant logo (canonical)', () => {
+    const bootstrap = useBootstrapStore();
+    bootstrap.$patch({
+      domain_logo: null,
+      brand_logo_url: '/img/install-brand.svg',
+      domain_strategy: 'canonical',
+    });
+
+    const identity = useProductIdentity();
+
+    expect(identity.logoSource).toBe('/img/install-brand.svg');
+  });
+
+  it('resolves to the neutral sentinel on a custom domain without a tenant logo, even when brand_logo_url is set (leak fix #3612)', () => {
+    const bootstrap = useBootstrapStore();
+    bootstrap.$patch({
+      domain_logo: null,
+      brand_logo_url: '/img/install-brand.svg',
+      domain_strategy: 'custom',
+    });
+
+    const identity = useProductIdentity();
+
+    expect(identity.logoSource).toBe(DEFAULT_LOGO_COMPONENT);
   });
 });

--- a/src/views/PreviewDisabled.vue
+++ b/src/views/PreviewDisabled.vue
@@ -47,9 +47,9 @@
             id="preview-disabled-details"
             class="mt-1">
             This route renders the disabled-homepage view with the live masthead so
-            operators can verify branding env vars (LOGO_URL, LOGO_SHOW_NAME,
-            SITE_NAME, LOGO_PROMINENT) without changing backend settings. The site
-            is fully operational.
+            operators can verify branding env vars (BRAND_LOGO_URL, LOGO_SHOW_NAME,
+            BRAND_PRODUCT_NAME, LOGO_PROMINENT) without changing backend settings.
+            The site is fully operational.
           </p>
         </div>
       </div>

--- a/try/unit/config/config_serializer_brand_color_try.rb
+++ b/try/unit/config/config_serializer_brand_color_try.rb
@@ -34,6 +34,7 @@ def minimal_view_vars(overrides = {})
     'brand_font_family' => 'sans',
     'brand_button_text_light' => false,
     'brand_logo_url' => nil,
+    'brand_logo_alt' => nil,
     'brand_favicon_url' => nil,
     'support_email' => nil,
     'docs_host' => 'https://docs.onetimesecret.com/',
@@ -62,3 +63,15 @@ result['brand_primary_color']
 ## output_template defaults brand_primary_color to nil
 Core::Views::ConfigSerializer.send(:output_template)['brand_primary_color']
 #=> nil
+
+## output_template includes brand_logo_alt defaulting to nil (#3612)
+template = Core::Views::ConfigSerializer.send(:output_template)
+[template.key?('brand_logo_alt'), template['brand_logo_alt']]
+#=> [true, nil]
+
+## brand_logo_alt passes through from view_vars to output
+result = Core::Views::ConfigSerializer.serialize(
+  minimal_view_vars('brand_logo_alt' => 'Acme wordmark')
+)
+result['brand_logo_alt']
+#=> "Acme wordmark"

--- a/try/unit/mail/templates_brand_color_try.rb
+++ b/try/unit/mail/templates_brand_color_try.rb
@@ -13,7 +13,7 @@
 #   - logo_url resolves brand conf -> nil (NOT the OTS logo path); only
 #     absolute http(s) URLs are emitted (#3612)
 #   - support_email resolves brand conf -> GLOBAL_DEFAULTS (NOT the OTS address)
-#   - logo_alt resolves brand.logo_alt -> product_name (#3612)
+#   - logo_alt resolves brand.logo_alt -> site_product_name (#3612)
 #   - site_product_name resolves brand.product_name -> NEUTRAL_PRODUCT_NAME
 #     ('Secure Links'); the legacy header.branding.site_name tier was retired
 #     in #3612 (normalize_brand absorbs it into brand.product_name at boot)
@@ -248,32 +248,38 @@ end
 #=> nil
 
 # ============================================================================
-# logo_alt resolves brand.logo_alt -> product_name (#3612)
+# logo_alt resolves brand.logo_alt -> site_product_name (#3612). The image it
+# describes is always the install-wide brand.logo_url, so a per-message
+# data[:product_name] (e.g. a tenant name) must never label the operator's
+# logo.
 # ============================================================================
 
-## logo_alt prefers the operator-supplied brand.logo_alt over product_name
+## logo_alt prefers the operator-supplied brand.logo_alt over product name
 with_brand_conf({ 'logo_alt' => 'Acme wordmark', 'product_name' => 'Acme Secrets' }) do
   ctx = @ctx_class.new({}, 'en')
   ctx.logo_alt
 end
 #=> 'Acme wordmark'
 
-## logo_alt returns the same value as product_name when product_name is from data
-ctx = @ctx_class.new({ product_name: 'Acme Secrets' }, 'en')
-[ctx.logo_alt, ctx.product_name]
-#=> ['Acme Secrets', 'Acme Secrets']
+## logo_alt ignores a per-message data product_name — the install logo keeps
+## its install-level accessible name
+with_brand_conf({ 'product_name' => 'Install Name' }) do
+  ctx = @ctx_class.new({ product_name: 'Tenant Name' }, 'en')
+  [ctx.logo_alt, ctx.product_name]
+end
+#=> ['Install Name', 'Tenant Name']
 
-## logo_alt falls back to product_name when brand.logo_alt is unset
+## logo_alt falls back to the install product name when brand.logo_alt is unset
 with_brand_conf({ 'product_name' => 'Acme Secrets' }) do
   ctx = @ctx_class.new({}, 'en')
   ctx.logo_alt
 end
 #=> 'Acme Secrets'
 
-## logo_alt delegates to product_name when falling through to site_product_name
+## logo_alt terminal-falls to the neutral name with no brand config at all
 without_brand_conf do
   ctx = @ctx_class.new({}, 'en')
-  ctx.logo_alt == ctx.product_name
+  ctx.logo_alt == ctx.site_product_name
 end
 #=> true
 

--- a/try/unit/mail/templates_brand_color_try.rb
+++ b/try/unit/mail/templates_brand_color_try.rb
@@ -10,10 +10,13 @@
 #
 # Critical assertions:
 #   - brand_color resolves data -> brand conf -> neutral blue (#3B82F6)
-#   - logo_url resolves brand conf -> nil (NOT the OTS logo path)
+#   - logo_url resolves brand conf -> nil (NOT the OTS logo path); only
+#     absolute http(s) URLs are emitted (#3612)
 #   - support_email resolves brand conf -> GLOBAL_DEFAULTS (NOT the OTS address)
-#   - logo_alt delegates to product_name
-#   - site_product_name resolves brand -> site_name -> nil (GLOBAL_DEFAULTS[:product_name], #3049)
+#   - logo_alt resolves brand.logo_alt -> product_name (#3612)
+#   - site_product_name resolves brand.product_name -> NEUTRAL_PRODUCT_NAME
+#     ('Secure Links'); the legacy header.branding.site_name tier was retired
+#     in #3612 (normalize_brand absorbs it into brand.product_name at boot)
 #   - The 12 shipped HTML templates contain no #dc4a22 or onetime-logo-v3-xl.svg
 #     (regression guard against re-introduction).
 #
@@ -108,12 +111,28 @@ end
 # logo_url fallback chain
 # ============================================================================
 
-## logo_url returns OT.conf['brand']['logo_url'] when set
+## logo_url returns OT.conf['brand']['logo_url'] when set to an absolute URL
 with_brand_conf({ 'logo_url' => 'https://example.test/logo.svg' }) do
   ctx = @ctx_class.new({}, 'en')
   ctx.logo_url
 end
 #=> 'https://example.test/logo.svg'
+
+## logo_url accepts plain http URLs too (absolute is what matters)
+with_brand_conf({ 'logo_url' => 'http://example.test/logo.png' }) do
+  ctx = @ctx_class.new({}, 'en')
+  ctx.logo_url
+end
+#=> 'http://example.test/logo.png'
+
+## logo_url rejects relative paths — mail clients cannot resolve them, so a
+## masthead-oriented legacy LOGO_URL (e.g. /img/logo.png) degrades to the
+## text-only email header instead of a broken image (#3612)
+with_brand_conf({ 'logo_url' => '/img/logo.png' }) do
+  ctx = @ctx_class.new({}, 'en')
+  ctx.logo_url
+end
+#=> nil
 
 ## logo_url returns nil when no brand config (neutralized fallback per #3049)
 without_brand_conf do
@@ -229,13 +248,27 @@ end
 #=> nil
 
 # ============================================================================
-# logo_alt delegates to product_name
+# logo_alt resolves brand.logo_alt -> product_name (#3612)
 # ============================================================================
+
+## logo_alt prefers the operator-supplied brand.logo_alt over product_name
+with_brand_conf({ 'logo_alt' => 'Acme wordmark', 'product_name' => 'Acme Secrets' }) do
+  ctx = @ctx_class.new({}, 'en')
+  ctx.logo_alt
+end
+#=> 'Acme wordmark'
 
 ## logo_alt returns the same value as product_name when product_name is from data
 ctx = @ctx_class.new({ product_name: 'Acme Secrets' }, 'en')
 [ctx.logo_alt, ctx.product_name]
 #=> ['Acme Secrets', 'Acme Secrets']
+
+## logo_alt falls back to product_name when brand.logo_alt is unset
+with_brand_conf({ 'product_name' => 'Acme Secrets' }) do
+  ctx = @ctx_class.new({}, 'en')
+  ctx.logo_alt
+end
+#=> 'Acme Secrets'
 
 ## logo_alt delegates to product_name when falling through to site_product_name
 without_brand_conf do
@@ -255,7 +288,10 @@ with_brand_conf({ 'product_name' => 'Acme' }) do
 end
 #=> 'Acme'
 
-## site_product_name falls through to site.interface.ui.header.site_name when brand absent
+## site_product_name does NOT read the legacy header.branding.site_name tier
+## at render time — it was retired in #3612. (A legacy SITE_NAME/site_name
+## still works at boot: normalize_brand absorbs it into brand.product_name
+## before the config is frozen, so the mail layer reads brand only.)
 saved = YAML.load(YAML.dump(OT.conf))
 begin
   conf_copy = YAML.load(YAML.dump(saved))
@@ -272,24 +308,28 @@ begin
 ensure
   OT.send(:conf=, saved) rescue nil
 end
-#=> 'LegacySiteName'
+#=> 'Secure Links'
 
-## site_product_name falls through to GLOBAL_DEFAULTS[:product_name] (= nil)
-saved = YAML.load(YAML.dump(OT.conf))
-begin
-  conf_copy = YAML.load(YAML.dump(saved))
-  conf_copy.delete('brand')
-  # Make sure no site_name is present so the third tier is exercised.
-  if conf_copy.dig('site', 'interface', 'ui', 'header', 'branding')
-    conf_copy['site']['interface']['ui']['header']['branding'].delete('site_name')
-  end
-  OT.send(:conf=, conf_copy)
+## site_product_name falls through to the neutral NEUTRAL_PRODUCT_NAME when
+## brand.product_name is unset — never nil, since templates interpolate it
+## into subjects and headers (#3612)
+without_brand_conf do
   ctx = @ctx_class.new({}, 'en')
   ctx.site_product_name
-ensure
-  OT.send(:conf=, saved) rescue nil
 end
-#=> nil
+#=> 'Secure Links'
+
+## site_product_name terminal fallback matches NEUTRAL_PRODUCT_NAME exactly
+without_brand_conf do
+  ctx = @ctx_class.new({}, 'en')
+  ctx.site_product_name == @constants::NEUTRAL_PRODUCT_NAME
+end
+#=> true
+
+## [regression guard] NEUTRAL_PRODUCT_NAME is the vendor-neutral 'Secure Links'
+## (lockstep with frontend NEUTRAL_BRAND_DEFAULTS.product_name)
+@constants::NEUTRAL_PRODUCT_NAME
+#=> 'Secure Links'
 
 ## [regression guard] GLOBAL_DEFAULTS[:product_name] is nil, not 'OTS' or 'Onetime Secret'
 @constants::GLOBAL_DEFAULTS[:product_name]
@@ -494,7 +534,8 @@ ensure
 end
 #=> nil
 
-## OT.conf=nil — site_product_name falls through to GLOBAL_DEFAULTS (nil)
+## OT.conf=nil — site_product_name degrades to the neutral NEUTRAL_PRODUCT_NAME
+## (never nil, #3612)
 @_saved_for_nil4 = OT.instance_variable_get(:@conf)
 begin
   OT.instance_variable_set(:@conf, nil)
@@ -503,7 +544,7 @@ begin
 ensure
   OT.instance_variable_set(:@conf, @_saved_for_nil4)
 end
-#=> nil
+#=> 'Secure Links'
 
 ## OT.conf=nil — signature_name degrades to nil without raising
 @_saved_for_nil_sig = OT.instance_variable_get(:@conf)

--- a/try/unit/mail/templates_welcome_try.rb
+++ b/try/unit/mail/templates_welcome_try.rb
@@ -54,10 +54,25 @@ template = Onetime::Mail::Templates::Welcome.new(@valid_data)
 template.class
 #=> Onetime::Mail::Templates::Welcome
 
-## Welcome subject is verification message
+## Welcome subject is verification message. With no brand.product_name
+## configured, the subject interpolates the neutral NEUTRAL_PRODUCT_NAME
+## ('Secure Links') — the legacy site_name tier was retired in #3612.
 template = Onetime::Mail::Templates::Welcome.new(@valid_data)
 template.subject
-#=> 'Welcome to One-Time Secret - Please verify your email'
+#=> 'Welcome to Secure Links - Please verify your email'
+
+## Welcome subject interpolates brand.product_name when configured
+saved = YAML.load(YAML.dump(OT.conf))
+begin
+  conf_copy = YAML.load(YAML.dump(saved))
+  conf_copy['brand'] = { 'product_name' => 'Acme Vault' }
+  OT.send(:conf=, conf_copy)
+  template = Onetime::Mail::Templates::Welcome.new(@valid_data)
+  template.subject
+ensure
+  OT.send(:conf=, saved) rescue nil
+end
+#=> 'Welcome to Acme Vault - Please verify your email'
 
 ## Welcome recipient_email returns email_address from data
 template = Onetime::Mail::Templates::Welcome.new(@valid_data)

--- a/try/unit/models/custom_domain/brand_global_defaults_try.rb
+++ b/try/unit/models/custom_domain/brand_global_defaults_try.rb
@@ -45,7 +45,9 @@ support.nil? || support != 'support@onetimesecret.com'
 @constants::GLOBAL_DEFAULTS[:support_email] != 'support@onetimesecret.com'
 #=> true
 
-## [forward] GLOBAL_DEFAULTS[:product_name] is nil (frontend 'Secure Links' / legacy site_name own the default)
+## [forward] GLOBAL_DEFAULTS[:product_name] is nil (each consumer owns its
+## neutral fallback: frontend NEUTRAL_BRAND_DEFAULTS / mail NEUTRAL_PRODUCT_NAME;
+## the legacy site_name tier was retired in #3612)
 @constants::GLOBAL_DEFAULTS[:product_name]
 #=> nil
 
@@ -73,3 +75,62 @@ support.nil? || support != 'support@onetimesecret.com'
 support = @constants.global_defaults[:support_email]
 support.nil? || support != 'support@onetimesecret.com'
 #=> true
+
+## GLOBAL_DEFAULTS includes a logo_alt key defaulting to nil (#3612)
+[@constants::GLOBAL_DEFAULTS.key?(:logo_alt), @constants::GLOBAL_DEFAULTS[:logo_alt]]
+#=> [true, nil]
+
+## runtime global_defaults exposes logo_alt (nil when unconfigured)
+[@constants.global_defaults.key?(:logo_alt), @constants.global_defaults[:logo_alt]]
+#=> [true, nil]
+
+## runtime global_defaults logo_alt reflects brand.logo_alt when configured
+@_saved_conf_alt = OT.instance_variable_get(:@conf)
+begin
+  OT.instance_variable_set(:@conf, { 'brand' => { 'logo_alt' => 'Acme wordmark' } })
+  @constants.global_defaults[:logo_alt]
+ensure
+  OT.instance_variable_set(:@conf, @_saved_conf_alt)
+end
+#=> 'Acme wordmark'
+
+## [regression guard] NEUTRAL_PRODUCT_NAME is 'Secure Links' — must stay in
+## lockstep with the frontend NEUTRAL_BRAND_DEFAULTS.product_name
+## (src/shared/constants/brand.ts) so an unbranded install reads the same
+## everywhere (#3612)
+@constants::NEUTRAL_PRODUCT_NAME
+#=> 'Secure Links'
+
+## totp_issuer falls back to brand.product_name when totp_issuer is unset —
+## a configured product name brands new MFA enrollments too (#3612)
+@_saved_conf_totp1 = OT.instance_variable_get(:@conf)
+begin
+  OT.instance_variable_set(:@conf, { 'brand' => { 'product_name' => 'Acme' } })
+  @constants.global_defaults[:totp_issuer]
+ensure
+  OT.instance_variable_set(:@conf, @_saved_conf_totp1)
+end
+#=> 'Acme'
+
+## totp_issuer stays 'OTS' when totp_issuer and product_name are both unset
+## (pre-existing MFA enrollments keep consistent otpauth:// issuer labels)
+@_saved_conf_totp2 = OT.instance_variable_get(:@conf)
+begin
+  OT.instance_variable_set(:@conf, { 'brand' => {} })
+  @constants.global_defaults[:totp_issuer]
+ensure
+  OT.instance_variable_set(:@conf, @_saved_conf_totp2)
+end
+#=> 'OTS'
+
+## an explicit brand.totp_issuer (BRAND_TOTP_ISSUER) wins over product_name
+@_saved_conf_totp3 = OT.instance_variable_get(:@conf)
+begin
+  OT.instance_variable_set(:@conf, {
+    'brand' => { 'totp_issuer' => 'AcmeAuth', 'product_name' => 'Acme' },
+  })
+  @constants.global_defaults[:totp_issuer]
+ensure
+  OT.instance_variable_set(:@conf, @_saved_conf_totp3)
+end
+#=> 'AcmeAuth'

--- a/try/unit/web/page_title_brand_fallback_try.rb
+++ b/try/unit/web/page_title_brand_fallback_try.rb
@@ -9,10 +9,13 @@
 # Specifically the page_title fallback chain change: the helper must
 # resolve page_title via the brand-aware chain
 #
-#   display_domain (request) -> brand_product_name -> site_name (deprecated)
+#   display_domain (request) -> brand_product_name
 #
-# and NEVER hardcode 'Onetime Secret' so that private-label / self-hosted
-# instances don't ship OTS branding by accident.
+# The legacy site.interface.ui.header.branding.site_name tier was retired in
+# #3612 — a legacy SITE_NAME/site_name is absorbed into brand.product_name by
+# Config#normalize_brand at boot, so the view layer reads the brand block
+# only. page_title must NEVER hardcode 'Onetime Secret' so that
+# private-label / self-hosted instances don't ship OTS branding by accident.
 #
 # Also asserts the 9 brand_* / brand-adjacent view vars exposed by the
 # helper are present with expected types.
@@ -89,22 +92,22 @@ with_brand_conf({ 'product_name' => 'Acme Vault' }) do
 end
 #=> 'vault.acme.test'
 
-# GLOBAL_DEFAULTS[:product_name] is nil per #3049, so this exercises the
-# shipped config.defaults.yaml site.interface.ui.header.branding.site_name
-# default rather than a brand-layer value.
-## page_title falls through to the legacy site_name when brand absent
-with_brand_conf(nil) do
-  vars = @host.initialize_view_vars(Rack::Request.new(build_env))
-  vars['page_title']
-end
-#=> 'One-Time Secret'
-
-## page_title falls through to GLOBAL_DEFAULTS[:product_name] (nil) when brand and legacy site_name are both absent
+# The legacy site.interface.ui.header.branding.site_name tier is retired
+# (#3612): the view reads brand.product_name only. A site_name injected into
+# the (post-normalize) config must NOT reach page_title — at a real boot the
+# legacy value would have been absorbed into brand.product_name by
+# normalize_brand and the branding subtree deleted by normalize_header_layout.
+## page_title ignores a conf-level legacy site_name when brand absent (tier retired)
 with_brand_conf(nil) do
   saved = YAML.load(YAML.dump(OT.conf))
   begin
     conf_copy = YAML.load(YAML.dump(OT.conf))
-    conf_copy.dig('site', 'interface', 'ui', 'header', 'branding')&.delete('site_name')
+    conf_copy.delete('brand')
+    conf_copy['site'] ||= {}
+    conf_copy['site']['interface'] ||= {}
+    conf_copy['site']['interface']['ui'] ||= {}
+    conf_copy['site']['interface']['ui']['header'] ||= {}
+    conf_copy['site']['interface']['ui']['header']['branding'] = { 'site_name' => 'LegacySiteName' }
     OT.send(:conf=, conf_copy)
     vars = @host.initialize_view_vars(Rack::Request.new(build_env))
     vars['page_title']
@@ -112,7 +115,16 @@ with_brand_conf(nil) do
     OT.send(:conf=, saved) rescue nil
   end
 end
-#=> nil
+#=> 'Secure Links'
+
+## page_title falls through to the neutral NEUTRAL_PRODUCT_NAME terminal when
+## brand and display_domain are both absent — the server-rendered <title> and
+## og:title must never go empty (hazard 2 of #3612: default posture is neutral)
+with_brand_conf(nil) do
+  vars = @host.initialize_view_vars(Rack::Request.new(build_env))
+  vars['page_title']
+end
+#=> 'Secure Links'
 
 ## [regression guard] page_title NEVER returns hardcoded 'Onetime Secret' when brand absent
 with_brand_conf(nil) do
@@ -188,6 +200,26 @@ with_brand_conf(nil) do
   vars['brand_font_family']
 end
 #=> 'sans'
+
+## initialize_view_vars exposes 'brand_logo_alt' (#3612)
+vars = @host.initialize_view_vars(Rack::Request.new(build_env))
+vars.key?('brand_logo_alt')
+#=> true
+
+## brand_logo_alt is nil when unset — frontend derives the accessible name
+## from the product name
+with_brand_conf(nil) do
+  vars = @host.initialize_view_vars(Rack::Request.new(build_env))
+  vars['brand_logo_alt']
+end
+#=> nil
+
+## brand_logo_alt reflects OT.conf['brand']['logo_alt'] when set
+with_brand_conf({ 'logo_alt' => 'Acme wordmark' }) do
+  vars = @host.initialize_view_vars(Rack::Request.new(build_env))
+  vars['brand_logo_alt']
+end
+#=> 'Acme wordmark'
 
 ## initialize_view_vars exposes 'brand_button_text_light'
 vars = @host.initialize_view_vars(Rack::Request.new(build_env))


### PR DESCRIPTION
## Summary

[#3612](https://github.com/onetimesecret/onetimesecret/issues/3612)

Consolidates brand identity configuration to a single `brand:` config block as the authoritative source. The `brand:` block now drives masthead branding, outbound emails, page titles, and MFA labels through flat `BRAND_*` environment variables (`BRAND_PRODUCT_NAME`, `BRAND_LOGO_URL`, `BRAND_LOGO_ALT`).

**Key changes:**

- **Brand identity authority**: The `brand:` config block is now the single source of truth for product name, logo URL, and logo alt text. Previously, these were scattered across `site.interface.ui.header.branding` (legacy) and email-only `BRAND_*` vars.

- **Masthead logo now uses `BRAND_LOGO_URL`**: The operator's install-wide logo flows through `brand_logo_url` (from `BRAND_LOGO_URL`) instead of `ui.header.branding.logo.url`. This closes the A3 leak on custom domains—the install logo is now suppressed there, just like the platform wordmark.

- **Header layout knobs relocated**: Masthead presentation controls (`href`, `show_name`, `prominent`) moved from `site.interface.ui.header.branding` to `site.interface.ui.header.logo`. The `branding` subtree is deprecated and absorbed into `brand:` at boot via `Config#normalize_brand`.

- **Legacy fallback shims**: The deprecated `SITE_NAME`, `LOGO_URL`, `LOGO_ALT` env vars and `site.interface.ui.header.branding` YAML path still work as fallbacks (soft deprecation with warnings), ensuring backward compatibility. Vue component sentinels (e.g., `DefaultLogo.vue`) are rejected to prevent asset-URL confusion.

- **New `brand_logo_alt` field**: Added `BRAND_LOGO_ALT` / `brand.logo_alt` for operator-supplied logo alt text; falls back to i18n product-name-derived alt when unset.

- **Email logo URLs**: Mail templates now only emit absolute http(s) logo URLs, degrading to text-only headers otherwise (relative paths cannot be resolved in email clients).

- **Identity resolver consolidation**: `identityStore` now exposes `installLogoUri` and `installLogoAlt` for the operator's brand logo, alongside the existing `logoSource` (tenant logo or neutral default).

## Related Issues

Fixes #3612

## Test Plan

Comprehensive unit and integration tests added:
- `MastHead.spec.ts`: Tests for install logo rendering, sizing, linking, wordmark visibility heuristics, and prominent mode
- `identityStore.spec.ts`: Tests for `installLogoUri` and `installLogoAlt` resolution across domain strategies
- `normalize_brand_spec.rb`: Tests for legacy fallback absorption (SITE_NAME → product_name, LOGO_URL → logo_url, etc.)
- `config_spec.rb`: Tests for soft deprecation warnings on legacy brand env vars
- `MastHead.customDomain.spec.ts`: Tests confirming install logo suppression on custom domains
- Schema and bootstrap contract tests updated to reflect new field structure

Existing tests pass; CI validates the consolidation.

https://claude.ai/code/session_01EYodcJSi2FaFYzz1CycNy9