### PR TITLE
Refactor domain add/manage UX based on custom domain count

### DIFF
--- a/docs/product/README.md
+++ b/docs/product/README.md
@@ -21,6 +21,7 @@ Frontend architecture and design documentation for Onetime Secret.
 | [Request Lifecycle](request-lifecycle.md) | How requests flow through the system (routing → rendering) |
 | [Secret Lifecycle](secret-lifecycle.md) | FSM states for secret entities (idle → revealed → burned) |
 | [Organization Invites](organization-invites.md) | Invite lifecycle, API surface, anti-abuse posture |
+| [Context Switcher Visibility](context-switcher-visibility.md) | When the org/domain switchers and user-menu identity chip appear |
 | [URI Path Mapping](uri-paths-to-views-structure.md) | URL → Vue component mapping table |
 
 ## Key Concepts

--- a/docs/product/README.md
+++ b/docs/product/README.md
@@ -22,6 +22,7 @@ Frontend architecture and design documentation for Onetime Secret.
 | [Secret Lifecycle](secret-lifecycle.md) | FSM states for secret entities (idle → revealed → burned) |
 | [Organization Invites](organization-invites.md) | Invite lifecycle, API surface, anti-abuse posture |
 | [Context Switcher Visibility](context-switcher-visibility.md) | When the org/domain switchers and user-menu identity chip appear |
+| [Organization / Workspace Terminology](workspace-terminology.md) | Which UI surfaces say "Workspace" vs. "Organization", and why |
 | [URI Path Mapping](uri-paths-to-views-structure.md) | URL → Vue component mapping table |
 
 ## Key Concepts

--- a/docs/product/context-switcher-visibility.md
+++ b/docs/product/context-switcher-visibility.md
@@ -1,0 +1,78 @@
+---
+title: Context Switcher Visibility
+type: reference
+status: current
+updated: 2026-07-04
+---
+
+# Context Switcher Visibility
+
+How the organization and domain context switchers — and the user-menu identity
+chip — adapt to a user's role, plan, and workspace shape. The aim is a clean
+surface for a brand-new self-signup user, with progressive disclosure as they
+add domains, collaborators, or organizations.
+
+Implemented in:
+
+- `src/shared/composables/useScopeSwitcherVisibility.ts` — org switcher gating
+- `src/shared/components/navigation/DomainContextSwitcher.vue` — domain CTA
+- `src/apps/workspace/components/navigation/OrganizationContextBar.vue` — static fallback
+- `src/shared/components/navigation/UserMenu.vue` — identity chip
+
+## Domain context dropdown — Add vs. Manage
+
+The call-to-action depends on whether the user can manage domains (owner or
+admin of the active organization) and how many custom domains already exist.
+
+| User state | Affordance |
+|------------|-----------|
+| Owner/admin, 0 custom domains | Prominent **"Add domain"** link in the dropdown footer |
+| Owner/admin, ≥1 custom domain | Compact **`[+]` icon** in the dropdown header + **"Manage Domains"** footer link |
+| Member (cannot manage domains) | Neither affordance |
+
+Rationale: "Manage Domains" is meaningless with nothing to manage, so a
+zero-domain owner is steered straight to adding one. Once a domain exists, the
+add action demotes to an icon — the user has already learned the flow, and an
+admin's job is administering rather than adding.
+
+## Organization context dropdown — hidden for solo users
+
+The org switcher is **hidden** for a brand-new self-signup user and reappears
+once there is something to switch between or administer. It shows only when all
+of these hold (`showOrgSwitcher`):
+
+- Not on a custom domain (there the domain *is* the org scope)
+- The route allows it (`scopesAvailable.organization !== 'hide'`)
+- The org-switcher feature is enabled
+- The user **can manage orgs** (`canManageOrgs`):
+  - billing disabled → owner role is sufficient
+  - billing enabled → owner **and** the `manage_orgs` entitlement
+- The context is **not a trivial solo default** (`isSoloDefaultContext`): the
+  user has exactly one organization (their auto-created "Default Workspace") and
+  is its only member
+
+When the switcher is hidden because the context is solo, the static org-name
+chip in the context bar is suppressed too — nothing about the lone default
+workspace is surfaced.
+
+## User-menu identity chip
+
+The chip beside the domain in the user-menu header follows the **same** solo /
+`manage_orgs` logic, so it appears and disappears in step with the org switcher.
+
+| Context | Chip |
+|---------|------|
+| Non-solo org context (multi-member or multi-org) | **Role badge** — `Owner` / `Admin` |
+| Solo default, billing enabled, no `manage_orgs` | **`Free`** chip, links to `/billing` |
+| Solo default, billing enabled, has `manage_orgs` | Role badge |
+| Solo default, billing **disabled** | **Hidden** — matches the hidden org switcher |
+
+Rationale: an "Owner" badge is noise for a lone free user. On a billing install
+it becomes a subtle plan indicator and upsell; on a standalone install — where
+there is no plan tier or billing page — it simply disappears, so the chip only
+ever shows alongside the org context dropdown.
+
+## Related
+
+- [Membership Entitlements](../authorizations/membership-entitlements.md)
+- [Organization Invites](organization-invites.md)

--- a/docs/product/workspace-terminology.md
+++ b/docs/product/workspace-terminology.md
@@ -1,0 +1,97 @@
+---
+title: Organization / Workspace Terminology
+type: reference
+status: current
+updated: 2026-07-04
+---
+
+# Organization / Workspace Terminology
+
+The product calls the same entity **"Workspace"** in some UI copy and
+**"Organization"** in other UI copy, API responses, and code (`Organization`
+type, `useOrganizationStore`, `web.organizations.*` i18n keys, `/org/:extid`
+routes). This is intentional, not drift: the rename is being rolled out
+**display-text only**, and only where progressive disclosure calls for it.
+
+Nothing in code changes — identifiers, routes, store names, and i18n key IDs
+stay `organization`/`org` throughout. Only the rendered `text` value in the
+locale content files (`locales/content/en/*.json`) changes per surface below.
+
+## Rationale: progressive disclosure
+
+> Limit exposure of the "organization" concept on the onboarding experience
+> and, to a greater extent, the free-plan user's experience.
+
+A brand-new or solo free user has one auto-created "Default Workspace" and no
+reason to think in terms of a multi-tenant "organization" — that word implies
+team administration they haven't opted into yet. "Workspace" reads as *your
+place to work*; "Organization" reads as *a legal/administrative entity you
+manage*. The further a surface sits from onboarding — real team management,
+billing administration, API/backend errors — the more acceptable "Organization"
+becomes, since by that point the user has opted into the concept it names.
+
+This mirrors the same progressive-disclosure principle already documented in
+[Context Switcher Visibility](context-switcher-visibility.md): both the org
+switcher's visibility *and* its label follow "don't show a solo/free user
+machinery they don't need yet."
+
+## Renamed to "Workspace" (done)
+
+| Surface | File(s) | Notes |
+|---|---|---|
+| Org context dropdown | `OrganizationScopeSwitcher.vue` + `workspace-organizations.json` | Header, "Manage Workspaces", "Select a workspace", locked/fallback text |
+| `/orgs` list page | `OrganizationsSettings.vue` | H1, empty-state copy, tab title |
+| Create-organization modal | `CreateOrganizationModal.vue` | Title now reuses the `create_workspace` key; description/label/error retexted |
+| Billing zero-org empty state | `BillingOverview.vue` | "No Workspaces" heading + reuses `create_workspace` for the CTA. Not reachable today (every account gets a default org on signup) — fixed for consistency/future-proofing |
+
+## Still "Organization" — onboarding-adjacent, not yet renamed
+
+| Surface | Key | Why it's still open |
+|---|---|---|
+| Org settings → General tab field label | `web.organizations.display_name` = "Organization Name" | A solo/free user *can* reach `/org/:extid`; this label is the one remaining "organization" word on that page (tabs read Domains/Members/SSO/Settings; the H1 is the workspace's own name). Left as-is pending explicit scope confirmation — it's shared with the settings form only, low risk to rename next. |
+
+## Intentionally left as "Organization" — deeper / admin surfaces
+
+These only appear once a user has opted into multi-member or paid
+administration — past the point progressive disclosure is protecting:
+
+- **Org settings page**: `general_settings` ("General Settings"),
+  `entitlements_title` ("Organization Entitlements")
+- **Danger zone**: `delete_organization`, `delete_organization_warning`,
+  `leave_organization*`, `default_org_delete_notice_*`
+- **Members**: `members.title`/`members.description` (`MembersTable.vue`),
+  role descriptions ("...organization settings", "...organization
+  resources"), removal/leave confirmation strings
+- **Gear icon** in the context dropdown: `organization_settings` used only
+  as its aria-label ("Organization Settings") — kept to match the
+  destination page it links to
+
+## Intentionally left as "Organization" — API / backend-facing
+
+Not renamed because they're consumed by API clients and/or matched by
+tests, not just displayed:
+
+- `api.invite.errors.organization_no_longer_exists`, `...already a member of
+  this organization`
+- `api-entitlements-errors.json`: "Unable to verify entitlements
+  (organization context unavailable)", "Organization management requires a
+  plan upgrade"
+- `api-incoming-errors.json`: "Custom domain organization could not be
+  resolved"
+- `secret-manage.errors.no_organization_context`
+
+## Orphaned — zero user exposure, not rendered anywhere
+
+Found during the audit but not referenced by any `.vue` template; safe to
+batch-clean later without user-facing effect: `about_title`,
+`about_description`, `getting_started_title`, `getting_started_description`,
+`single_user_info_title`, `single_user_info_description`,
+`organizations_description`, `organization_plural`, `new_organization`, the
+long-form `page_description`, `organization_information`,
+`organization_settings_description`, and `invitations.title` ("Organization
+Invitations" — the members page itself doesn't render this heading).
+
+## Related
+
+- [Context Switcher Visibility](context-switcher-visibility.md)
+- [Organization Invites](organization-invites.md)

--- a/e2e/full/scope-switcher.spec.ts
+++ b/e2e/full/scope-switcher.spec.ts
@@ -36,7 +36,7 @@ import { expect, Page, test } from '@playwright/test';
  *   - data-testid="org-scope-switcher-dropdown" - Dropdown menu
  *   - data-testid="org-scope-item-{orgId}"      - Individual org menu item
  *   - data-testid="org-scope-settings-{orgId}"  - Gear icon for org settings
- *   - data-testid="org-scope-manage-link"       - "Manage Organizations" link
+ *   - data-testid="org-scope-manage-link"       - "Manage Workspaces" link
  *
  * Domain Scope Switcher:
  *   - data-testid="domain-context-switcher"         - Main switcher container
@@ -67,7 +67,7 @@ const orgSwitcher = {
     ),
   dropdown: (page: Page) =>
     page.locator('[data-testid="org-scope-switcher-dropdown"], [role="menu"]').filter({
-      has: page.locator('text=/my organizations/i'),
+      has: page.locator('text=/workspaces/i'),
     }),
   menuItems: (page: Page) => page.locator('[role="menuitem"]'),
   gearIcon: (page: Page) =>
@@ -75,7 +75,7 @@ const orgSwitcher = {
       '[data-testid^="org-scope-settings"], button[aria-label*="organization settings" i]'
     ),
   manageLink: (page: Page) =>
-    page.locator('[data-testid="org-scope-manage-link"], button:has-text("Manage Organizations")'),
+    page.locator('[data-testid="org-scope-manage-link"], button:has-text("Manage Workspaces")'),
   checkmark: (page: Page) => page.locator('[class*="check"]'),
 };
 
@@ -580,7 +580,7 @@ test.describe('Scope Switcher - Switching Behavior', () => {
       }
     });
 
-    test('TC-SS-024: Manage Organizations link navigates to /orgs', async ({ page }) => {
+    test('TC-SS-024: Manage Workspaces link navigates to /orgs', async ({ page }) => {
       await page.goto('/dashboard');
       await expect(page.locator('html[data-app-ready="true"]')).toBeAttached();
 
@@ -590,7 +590,7 @@ test.describe('Scope Switcher - Switching Behavior', () => {
 
       await trigger.click();
 
-      const manageLink = page.locator('[role="menuitem"]:has-text("Manage Organizations")');
+      const manageLink = page.locator('[role="menuitem"]:has-text("Manage Workspaces")');
       const hasLink = await manageLink.isVisible().catch(() => false);
 
       if (hasLink) {
@@ -1080,7 +1080,7 @@ test.describe('Scope Switcher - Accessibility', () => {
  * | TC-SS-021  | Dropdown shows current org highlighted             | High     | Automated  |
  * | TC-SS-022  | Selecting org updates page context                 | Critical | Automated  |
  * | TC-SS-023  | Gear icon navigates to org settings                | High     | Automated  |
- * | TC-SS-024  | Manage Organizations link works                    | Medium   | Automated  |
+ * | TC-SS-024  | Manage Workspaces link works                       | Medium   | Automated  |
  * | TC-SS-030  | Domain dropdown opens on click                     | High     | Automated  |
  * | TC-SS-031  | Selecting domain updates scope                     | Critical | Automated  |
  * | TC-SS-032  | Domain scope persists to sessionStorage            | High     | Automated  |

--- a/locales/content/en/00-common.json
+++ b/locales/content/en/00-common.json
@@ -1319,8 +1319,8 @@
     "content_hash": "cb2f00d1"
   },
   "web.TITLES.organizations_settings": {
-    "text": "Organizations",
-    "content_hash": "2730183d"
+    "text": "Workspaces",
+    "content_hash": "1377264b"
   },
   "web.TITLES.organization_settings": {
     "text": "Organization Settings",

--- a/locales/content/en/workspace-billing.json
+++ b/locales/content/en/workspace-billing.json
@@ -144,12 +144,12 @@
     "content_hash": "1f981aaf"
   },
   "web.billing.overview.no_organizations_title": {
-    "text": "No Organizations",
-    "content_hash": "12420110"
+    "text": "No Workspaces",
+    "content_hash": "c7f70723"
   },
   "web.billing.overview.no_organizations_description": {
-    "text": "Create an organization to manage your billing and subscription",
-    "content_hash": "41e922d2"
+    "text": "Create a workspace to manage your billing and subscription",
+    "content_hash": "e0fd27a5"
   },
   "web.billing.overview.load_error": {
     "text": "Failed to load billing information",

--- a/locales/content/en/workspace-organizations.json
+++ b/locales/content/en/workspace-organizations.json
@@ -56,20 +56,20 @@
     "content_hash": "98a583b4"
   },
   "web.organizations.create_organization_description": {
-    "text": "Create a new organization",
-    "content_hash": "67cd5950"
+    "text": "Create a new workspace",
+    "content_hash": "6ac2b5fc"
   },
   "web.organizations.create": {
     "text": "Create",
     "content_hash": "4759498a"
   },
   "web.organizations.create_error": {
-    "text": "Failed to create organization",
-    "content_hash": "f2204373"
+    "text": "Failed to create workspace",
+    "content_hash": "0a8d4fd6"
   },
   "web.organizations.organization_name": {
-    "text": "Organization Name",
-    "content_hash": "4cbd9073"
+    "text": "Workspace Name",
+    "content_hash": "6fa5a5b1"
   },
   "web.organizations.organization_name_placeholder": {
     "text": "e.g. Acme Corporation",

--- a/locales/content/en/workspace-organizations.json
+++ b/locales/content/en/workspace-organizations.json
@@ -4,8 +4,8 @@
     "content_hash": "2730183d"
   },
   "web.organizations.organization": {
-    "text": "Organization",
-    "content_hash": "d764d425"
+    "text": "Workspace",
+    "content_hash": "87bb59ba"
   },
   "web.organizations.organization_plural": {
     "text": "Organizations",
@@ -16,24 +16,24 @@
     "content_hash": "dbaa4f92"
   },
   "web.organizations.my_organizations": {
-    "text": "Organizations",
-    "content_hash": "2730183d"
+    "text": "Workspaces",
+    "content_hash": "1377264b"
   },
   "web.organizations.manage_organizations": {
-    "text": "Manage Organizations",
-    "content_hash": "be0fe4c3"
+    "text": "Manage Workspaces",
+    "content_hash": "cc2d65f8"
   },
   "web.organizations.new_organization": {
     "text": "New Organization",
     "content_hash": "4876e647"
   },
   "web.organizations.no_organizations": {
-    "text": "No organizations yet",
-    "content_hash": "5b7a7cbd"
+    "text": "No workspaces yet",
+    "content_hash": "97d0b117"
   },
   "web.organizations.no_organizations_description": {
-    "text": "Organizations provide unified billing and administration. Get started by creating your first organization.",
-    "content_hash": "deab4304"
+    "text": "Workspaces provide unified billing and administration. Get started by creating your first workspace.",
+    "content_hash": "f09d4987"
   },
   "web.organizations.no_description": {
     "text": "No description provided",
@@ -47,9 +47,13 @@
     "text": "Create Organization",
     "content_hash": "e27f4540"
   },
+  "web.organizations.create_workspace": {
+    "text": "Create Workspace",
+    "content_hash": "c63c14cf"
+  },
   "web.organizations.create_first_organization": {
-    "text": "Create First Organization",
-    "content_hash": "27bae486"
+    "text": "Create First Workspace",
+    "content_hash": "98a583b4"
   },
   "web.organizations.create_organization_description": {
     "text": "Create a new organization",
@@ -92,12 +96,12 @@
     "content_hash": "ee81c03d"
   },
   "web.organizations.select_organization": {
-    "text": "Select an organization",
-    "content_hash": "48326f52"
+    "text": "Select a workspace",
+    "content_hash": "70a8ce66"
   },
   "web.organizations.switcher_locked": {
-    "text": "Organization switching not available on this page",
-    "content_hash": "da0cf810"
+    "text": "Workspace switching not available on this page",
+    "content_hash": "c34114ac"
   },
   "web.organizations.not_found": {
     "text": "Organization not found",

--- a/src/apps/workspace/account/settings/OrganizationsSettings.vue
+++ b/src/apps/workspace/account/settings/OrganizationsSettings.vue
@@ -130,7 +130,7 @@
             name="plus"
             class="size-4"
             aria-hidden="true" />
-          {{ t('web.organizations.create_organization') }}
+          {{ t('web.organizations.create_workspace') }}
         </button>
       </div>
     </div>

--- a/src/apps/workspace/billing/BillingOverview.vue
+++ b/src/apps/workspace/billing/BillingOverview.vue
@@ -242,7 +242,7 @@ onMounted(async () => {
       <!-- Loading State -->
       <SettingsSkeleton v-if="isLoading" />
 
-      <!-- Empty State: No Organizations -->
+      <!-- Empty State: No Workspaces -->
       <div v-else-if="organizations.length === 0" class="rounded-lg border border-gray-200/60 bg-white/60 p-12 text-center shadow-sm backdrop-blur-sm dark:border-gray-700/60 dark:bg-gray-800/60">
         <OIcon
           collection="heroicons"
@@ -264,7 +264,7 @@ onMounted(async () => {
               name="plus"
               class="size-4"
               aria-hidden="true" />
-            {{ t('web.organizations.create_organization') }}
+            {{ t('web.organizations.create_workspace') }}
           </router-link>
         </div>
       </div>

--- a/src/apps/workspace/components/navigation/OrganizationContextBar.vue
+++ b/src/apps/workspace/components/navigation/OrganizationContextBar.vue
@@ -33,12 +33,17 @@ const {
   lockOrgSwitcher,
   showDomainSwitcher,
   lockDomainSwitcher,
+  isSoloDefaultContext,
 } = useScopeSwitcherVisibility();
 
+// The static org-name chip is the fallback when the switcher is hidden by role
+// (admins/members still need workspace context). It is suppressed for a solo
+// default org, where the switcher is hidden to declutter the new-user surface.
 const showStaticOrgName = computed(() =>
   isLoaded.value &&
   visibility.value.organization !== 'hide' &&
   !showOrgSwitcher.value &&
+  !isSoloDefaultContext.value &&
   isOrganizationSwitcherEnabled() &&
   organizationStore.hasOrganizations &&
   !!organizationStore.currentOrganization

--- a/src/apps/workspace/components/organizations/CreateOrganizationModal.vue
+++ b/src/apps/workspace/components/organizations/CreateOrganizationModal.vue
@@ -133,7 +133,7 @@ const handleSubmit = async () => {
                   <DialogTitle
                     as="h3"
                     class="text-base font-semibold leading-6 text-gray-900 dark:text-white">
-                    {{ t('web.organizations.create_organization') }}
+                    {{ t('web.organizations.create_workspace') }}
                   </DialogTitle>
                   <div class="mt-2">
                     <p class="text-sm text-gray-500 dark:text-gray-400">

--- a/src/shared/components/navigation/DomainContextSwitcher.vue
+++ b/src/shared/components/navigation/DomainContextSwitcher.vue
@@ -398,58 +398,58 @@ const navigateToDomainSettings = (domain: string, event: MouseEvent): void => {
 
         <!-- Divider + footer call to action (owners and admins only) -->
         <template v-if="canManageDomains">
-        <div
-          class="my-1 border-t border-gray-200 dark:border-gray-700"
-          role="separator"
-          aria-hidden="true" ></div>
+          <div
+            class="my-1 border-t border-gray-200 dark:border-gray-700"
+            role="separator"
+            aria-hidden="true" ></div>
 
-        <!-- No custom domains yet: prominent "Add Domain" call to action.
-             "Manage Domains" makes no sense when there is nothing to manage. -->
-        <MenuItem
-          v-if="!hasCustomDomains"
-          v-slot="{ active }"
-          @click="navigateToAddDomain">
-          <button
-            type="button"
-            class="mx-2 w-[calc(100%-1rem)] cursor-pointer select-none rounded-md px-2 py-2 text-left transition-colors duration-150"
-            :class="active ? 'bg-gray-100 dark:bg-gray-700' : ''"
-            data-testid="domain-context-add-link">
-            <span class="flex items-center gap-2">
-              <OIcon
-                collection="heroicons"
-                name="plus-20-solid"
-                class="size-4 text-gray-500 dark:text-gray-400"
-                aria-hidden="true" />
-              <span class="text-sm text-gray-700 dark:text-gray-300">
-                {{ t('web.domains.add_domain') }}
+          <!-- No custom domains yet: prominent "Add Domain" call to action.
+               "Manage Domains" makes no sense when there is nothing to manage. -->
+          <MenuItem
+            v-if="!hasCustomDomains"
+            v-slot="{ active }"
+            @click="navigateToAddDomain">
+            <button
+              type="button"
+              class="mx-2 w-[calc(100%-1rem)] cursor-pointer select-none rounded-md px-2 py-2 text-left transition-colors duration-150"
+              :class="active ? 'bg-gray-100 dark:bg-gray-700' : ''"
+              data-testid="domain-context-add-link">
+              <span class="flex items-center gap-2">
+                <OIcon
+                  collection="heroicons"
+                  name="plus-20-solid"
+                  class="size-4 text-gray-500 dark:text-gray-400"
+                  aria-hidden="true" />
+                <span class="text-sm text-gray-700 dark:text-gray-300">
+                  {{ t('web.domains.add_domain') }}
+                </span>
               </span>
-            </span>
-          </button>
-        </MenuItem>
+            </button>
+          </MenuItem>
 
-        <!-- Has custom domains: keep the "Manage Domains" link
-             (the "Add Domain" action lives in the header [+] icon). -->
-        <MenuItem
-          v-else
-          v-slot="{ active }"
-          @click="navigateToManageDomains">
-          <button
-            type="button"
-            class="mx-2 w-[calc(100%-1rem)] cursor-pointer select-none rounded-md px-2 py-2 text-left transition-colors duration-150"
-            :class="active ? 'bg-gray-100 dark:bg-gray-700' : ''"
-            data-testid="domain-context-manage-link">
-            <span class="flex items-center gap-2">
-              <OIcon
-                collection="heroicons"
-                name="cog-6-tooth"
-                class="size-4 text-gray-500 dark:text-gray-400"
-                aria-hidden="true" />
-              <span class="text-sm text-gray-700 dark:text-gray-300">
-                {{ t('web.domains.manage_domains') }}
+          <!-- Has custom domains: keep the "Manage Domains" link
+               (the "Add Domain" action lives in the header [+] icon). -->
+          <MenuItem
+            v-else
+            v-slot="{ active }"
+            @click="navigateToManageDomains">
+            <button
+              type="button"
+              class="mx-2 w-[calc(100%-1rem)] cursor-pointer select-none rounded-md px-2 py-2 text-left transition-colors duration-150"
+              :class="active ? 'bg-gray-100 dark:bg-gray-700' : ''"
+              data-testid="domain-context-manage-link">
+              <span class="flex items-center gap-2">
+                <OIcon
+                  collection="heroicons"
+                  name="cog-6-tooth"
+                  class="size-4 text-gray-500 dark:text-gray-400"
+                  aria-hidden="true" />
+                <span class="text-sm text-gray-700 dark:text-gray-300">
+                  {{ t('web.domains.manage_domains') }}
+                </span>
               </span>
-            </span>
-          </button>
-        </MenuItem>
+            </button>
+          </MenuItem>
         </template>
       </MenuItems>
     </transition>

--- a/src/shared/components/navigation/DomainContextSwitcher.vue
+++ b/src/shared/components/navigation/DomainContextSwitcher.vue
@@ -162,6 +162,24 @@ const canManageDomains = computed(() => {
 });
 
 /**
+ * Number of custom (non-canonical) domains in the current org context.
+ * Custom domains always carry an extid; the canonical domain never does.
+ */
+const customDomainCount = computed(
+  () => availableDomains.value.filter((domain) => getExtidByDomain(domain)).length
+);
+
+/**
+ * Whether the current org context has at least one custom domain.
+ *
+ * Drives the add/manage call-to-action for owners and admins:
+ * - No custom domains  → prominent "Add Domain" link (nothing to manage yet).
+ * - Has custom domains → compact [+] icon in the dropdown header (add another),
+ *   with the existing "Manage Domains" link retained below.
+ */
+const hasCustomDomains = computed(() => customDomainCount.value > 0);
+
+/**
  * Should component be visible
  */
 const shouldShow = computed(() => isContextActive.value);
@@ -190,6 +208,18 @@ const navigateToManageDomains = (): void => {
 };
 
 /**
+ * Navigate to the add-domain page (org-qualified).
+ * Falls back to the /domains/add redirect when no org context is available.
+ */
+const navigateToAddDomain = (): void => {
+  if (currentOrgExtid.value) {
+    router.push(`/org/${currentOrgExtid.value}/domains/add`);
+  } else {
+    router.push('/domains/add');
+  }
+};
+
+/**
  * Navigate to edit a specific domain (uses org-qualified routes)
  */
 const navigateToDomainSettings = (domain: string, event: MouseEvent): void => {
@@ -208,7 +238,7 @@ const navigateToDomainSettings = (domain: string, event: MouseEvent): void => {
     as="div"
     class="relative inline-flex"
     data-testid="domain-context-switcher"
-    v-slot="{ open }">
+    v-slot="{ open, close }">
     <!-- Trigger Button -->
     <MenuButton
       class="group inline-flex h-10 items-center gap-2 rounded-lg bg-gray-100 px-3 text-sm font-medium text-gray-700 transition-colors duration-150 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:ring-offset-2 dark:bg-gray-800 dark:text-gray-300 dark:focus:ring-offset-gray-900"
@@ -266,9 +296,28 @@ const navigateToDomainSettings = (domain: string, event: MouseEvent): void => {
         class="absolute left-0 top-full z-50 mt-1 max-h-60 w-max min-w-[220px] max-w-xs overflow-auto rounded-lg bg-white py-1 text-sm shadow-lg ring-1 ring-black/5 focus:outline-none dark:bg-gray-800 dark:ring-gray-700"
         data-testid="domain-context-switcher-dropdown">
         <!-- Header -->
-        <div
-          class="px-3 py-2 font-brand text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
-          {{ t('web.domains.scope_header') }}
+        <div class="flex items-center justify-between px-3 py-2">
+          <span
+            class="font-brand text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
+            {{ t('web.domains.scope_header') }}
+          </span>
+
+          <!-- Compact add-domain action: shown once an owner/admin already has
+               a domain, so the "Add Domain" call to action demotes to an icon. -->
+          <button
+            v-if="canManageDomains && hasCustomDomains"
+            type="button"
+            class="-my-1 -mr-1 rounded p-1 text-gray-400 transition-colors hover:bg-gray-100 hover:text-brand-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 dark:text-gray-500 dark:hover:bg-gray-700 dark:hover:text-brand-400"
+            :title="t('web.domains.add_domain')"
+            :aria-label="t('web.domains.add_domain')"
+            data-testid="domain-context-add-icon"
+            @click="() => { close?.(); navigateToAddDomain(); }">
+            <OIcon
+              collection="heroicons"
+              name="plus-20-solid"
+              class="size-4"
+              aria-hidden="true" />
+          </button>
         </div>
 
         <!-- Domain Options -->
@@ -347,14 +396,43 @@ const navigateToDomainSettings = (domain: string, event: MouseEvent): void => {
           </button>
         </MenuItem>
 
-        <!-- Divider + Manage Domains Link (owners and admins only) -->
+        <!-- Divider + footer call to action (owners and admins only) -->
         <template v-if="canManageDomains">
         <div
           class="my-1 border-t border-gray-200 dark:border-gray-700"
           role="separator"
           aria-hidden="true" ></div>
 
-        <MenuItem v-slot="{ active }" @click="navigateToManageDomains">
+        <!-- No custom domains yet: prominent "Add Domain" call to action.
+             "Manage Domains" makes no sense when there is nothing to manage. -->
+        <MenuItem
+          v-if="!hasCustomDomains"
+          v-slot="{ active }"
+          @click="navigateToAddDomain">
+          <button
+            type="button"
+            class="mx-2 w-[calc(100%-1rem)] cursor-pointer select-none rounded-md px-2 py-2 text-left transition-colors duration-150"
+            :class="active ? 'bg-gray-100 dark:bg-gray-700' : ''"
+            data-testid="domain-context-add-link">
+            <span class="flex items-center gap-2">
+              <OIcon
+                collection="heroicons"
+                name="plus-20-solid"
+                class="size-4 text-gray-500 dark:text-gray-400"
+                aria-hidden="true" />
+              <span class="text-sm text-gray-700 dark:text-gray-300">
+                {{ t('web.domains.add_domain') }}
+              </span>
+            </span>
+          </button>
+        </MenuItem>
+
+        <!-- Has custom domains: keep the "Manage Domains" link
+             (the "Add Domain" action lives in the header [+] icon). -->
+        <MenuItem
+          v-else
+          v-slot="{ active }"
+          @click="navigateToManageDomains">
           <button
             type="button"
             class="mx-2 w-[calc(100%-1rem)] cursor-pointer select-none rounded-md px-2 py-2 text-left transition-colors duration-150"

--- a/src/shared/components/navigation/UserMenu.vue
+++ b/src/shared/components/navigation/UserMenu.vue
@@ -32,7 +32,9 @@ import { useAuth } from '@/shared/composables/useAuth';
 import { useTheme } from '@/shared/composables/useTheme';
 import { useDomainContext } from '@/shared/composables/useDomainContext';
 import { usePreviewPlanMode } from '@/shared/composables/usePreviewPlanMode';
+import { useScopeSwitcherVisibility } from '@/shared/composables/useScopeSwitcherVisibility';
 import { type Customer } from '@/schemas/shapes/v3';
+import { ENTITLEMENTS } from '@/types/organization';
 import { useBootstrapStore } from '@/shared/stores/bootstrapStore';
 import { useProductIdentity } from '@/shared/stores/identityStore';
 import { useOrganizationStore } from '@/shared/stores/organizationStore';
@@ -104,6 +106,31 @@ const isCustomDomainMember = computed(() => isCustom.value && !!userRole.value &
 const isElevatedRole = computed(() =>
   userRole.value === 'owner' || userRole.value === 'admin'
 );
+
+// Reuse the org-switcher visibility logic so the header identity chip appears
+// and disappears in step with the organization context dropdown.
+const { isSoloDefaultContext } = useScopeSwitcherVisibility();
+
+// Whether the current org carries the manage_orgs entitlement (the same gate
+// the org switcher uses under billing). Absent entitlements → not granted.
+const hasManageOrgs = computed(() => {
+  const ents = currentOrganization.value?.entitlements;
+  return Array.isArray(ents) && ents.includes(ENTITLEMENTS.MANAGE_ORGS);
+});
+
+// The identity chip shown next to the domain in the menu header:
+// - 'role'  : the Owner/Admin badge — a real multi-user / multi-org context
+// - 'free'  : a "Free" plan chip linking to billing — a solo user without the
+//             manage_orgs entitlement on a billing-enabled install (plan hint)
+// - 'hidden': nothing — a solo user on a standalone (billing-disabled) install,
+//             so the chip only appears when the org switcher would too
+type IdentityChip = 'role' | 'free' | 'hidden';
+const identityChip = computed<IdentityChip>(() => {
+  if (!isElevatedRole.value || props.awaitingMfa) return 'hidden';
+  if (!isSoloDefaultContext.value) return 'role';
+  if (!billing_enabled.value) return 'hidden';
+  return hasManageOrgs.value ? 'role' : 'free';
+});
 
 // Domain context display in menu header
 const { currentContext, isContextActive } = useDomainContext();
@@ -380,9 +407,9 @@ onUnmounted(() => {
             :title="cust?.email">
             {{ cust?.email }}
           </p>
-          <!-- Domain context + Role badge -->
+          <!-- Domain context + identity chip (role badge or Free plan chip) -->
           <div
-            v-if="showDomainContext || (isElevatedRole && !awaitingMfa)"
+            v-if="showDomainContext || identityChip !== 'hidden'"
             class="group/domain mt-1 flex items-center gap-2">
             <p
               v-if="showDomainContext"
@@ -404,9 +431,10 @@ onUnmounted(() => {
                 class="size-3"
                 aria-hidden="true" />
             </button>
-            <!-- Role badge -->
+            <!-- Role badge (owner/admin) -->
             <span
-              v-if="isElevatedRole && !awaitingMfa"
+              v-if="identityChip === 'role'"
+              data-testid="user-menu-role-badge"
               :class="[
                 'shrink-0 inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider',
                 'border shadow-xs',
@@ -424,6 +452,24 @@ onUnmounted(() => {
                 aria-hidden="true"></span>
               {{ t(`web.organizations.members.roles.${userRole}`) }}
             </span>
+            <!-- Free plan chip: solo user on a billing-enabled install; links to billing -->
+            <router-link
+              v-else-if="identityChip === 'free'"
+              to="/billing"
+              data-testid="user-menu-plan-chip"
+              :title="t('web.navigation.billing')"
+              @click="closeMenu"
+              :class="[
+                'shrink-0 inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider',
+                'border shadow-xs transition-colors',
+                'border-gray-200/70 bg-gray-50 text-gray-500 hover:border-brand-300 hover:bg-brand-50 hover:text-brand-600',
+                'dark:border-gray-600/50 dark:bg-gray-700/40 dark:text-gray-400 dark:hover:border-brand-700/50 dark:hover:bg-brand-950/40 dark:hover:text-brand-400'
+              ]">
+              <span
+                class="size-1.5 rounded-full bg-gray-400 dark:bg-gray-500"
+                aria-hidden="true"></span>
+              {{ t('web.billing.plans.free_plan') }}
+            </router-link>
           </div>
           <!-- MFA Required Notice -->
           <div

--- a/src/shared/composables/useScopeSwitcherVisibility.ts
+++ b/src/shared/composables/useScopeSwitcherVisibility.ts
@@ -63,12 +63,31 @@ export function useScopeSwitcherVisibility() {
     return ents.includes(ENTITLEMENTS.MANAGE_ORGS);
   });
 
-  // Hide org switcher on custom domains (the domain IS the org scope)
+  /**
+   * "Trivial solo" org context: the user has exactly one organization (their
+   * auto-created default) and is its only member. There is nothing to switch
+   * between and no collaborators to manage, so both the org switcher and the
+   * static org-name fallback are suppressed for a cleaner new-user surface.
+   *
+   * member_count comes from the organizations list safe_dump. When the list
+   * hasn't loaded yet (length 0) or the count is unknown, this stays false so
+   * the switcher is never hidden prematurely.
+   */
+  const isSoloDefaultContext = computed(() => {
+    const orgs = organizationStore.organizations;
+    if (orgs.length !== 1) return false;
+    const memberCount = orgs[0].member_count;
+    return typeof memberCount === 'number' && memberCount <= 1;
+  });
+
+  // Hide org switcher on custom domains (the domain IS the org scope), and for
+  // a brand-new self-signup user whose only org is their solo default.
   const showOrgSwitcher = computed(
     () => !isCustom.value
       && visibility.value.organization !== 'hide'
       && isOrganizationSwitcherEnabled()
       && canManageOrgs.value
+      && !isSoloDefaultContext.value
   );
   const lockOrgSwitcher = computed(() => visibility.value.organization === 'locked');
 
@@ -81,5 +100,6 @@ export function useScopeSwitcherVisibility() {
     lockOrgSwitcher,
     showDomainSwitcher,
     lockDomainSwitcher,
+    isSoloDefaultContext,
   };
 }

--- a/src/shared/composables/useScopeSwitcherVisibility.ts
+++ b/src/shared/composables/useScopeSwitcherVisibility.ts
@@ -64,10 +64,14 @@ export function useScopeSwitcherVisibility() {
   });
 
   /**
-   * "Trivial solo" org context: the user has exactly one organization (their
-   * auto-created default) and is its only member. There is nothing to switch
+   * "Trivial solo" org context: the user has exactly one organization — their
+   * auto-created default — and is its only member. There is nothing to switch
    * between and no collaborators to manage, so both the org switcher and the
    * static org-name fallback are suppressed for a cleaner new-user surface.
+   *
+   * Requires is_default so a user who belongs to exactly one self-created
+   * (non-default) org still sees the switcher and org chip — that org is a
+   * deliberate choice, not a trivial artifact of signup.
    *
    * member_count comes from the organizations list safe_dump. When the list
    * hasn't loaded yet (length 0) or the count is unknown, this stays false so
@@ -76,6 +80,7 @@ export function useScopeSwitcherVisibility() {
   const isSoloDefaultContext = computed(() => {
     const orgs = organizationStore.organizations;
     if (orgs.length !== 1) return false;
+    if (!orgs[0].is_default) return false;
     const memberCount = orgs[0].member_count;
     return typeof memberCount === 'number' && memberCount <= 1;
   });

--- a/src/tests/apps/workspace/components/OrganizationContextBar.spec.ts
+++ b/src/tests/apps/workspace/components/OrganizationContextBar.spec.ts
@@ -28,14 +28,27 @@ const mockShowOrgSwitcher = ref(true);
 const mockLockOrgSwitcher = ref(false);
 const mockShowDomainSwitcher = ref(true);
 const mockLockDomainSwitcher = ref(false);
+const mockIsSoloDefaultContext = ref(false);
+const mockVisibility = ref<{ organization: string; domain: string }>({
+  organization: 'show',
+  domain: 'hide',
+});
 
 vi.mock('@/shared/composables/useScopeSwitcherVisibility', () => ({
   useScopeSwitcherVisibility: () => ({
+    visibility: mockVisibility,
     showOrgSwitcher: mockShowOrgSwitcher,
     lockOrgSwitcher: mockLockOrgSwitcher,
     showDomainSwitcher: mockShowDomainSwitcher,
     lockDomainSwitcher: mockLockDomainSwitcher,
+    isSoloDefaultContext: mockIsSoloDefaultContext,
   }),
+}));
+
+// Enable the org switcher feature flag so the static-org-name fallback path
+// (gated on isOrganizationSwitcherEnabled) can be exercised.
+vi.mock('@/utils/features', () => ({
+  isOrganizationSwitcherEnabled: () => true,
 }));
 
 // Mock axios
@@ -68,6 +81,8 @@ describe('OrganizationContextBar', () => {
     mockLockOrgSwitcher.value = false;
     mockShowDomainSwitcher.value = true;
     mockLockDomainSwitcher.value = false;
+    mockIsSoloDefaultContext.value = false;
+    mockVisibility.value = { organization: 'show', domain: 'hide' };
   });
 
   afterEach(() => {
@@ -152,6 +167,42 @@ describe('OrganizationContextBar', () => {
 
       const domainSwitcher = wrapper.find('.domain-switcher');
       expect(domainSwitcher.attributes('data-locked')).toBe('true');
+    });
+  });
+
+  describe('Solo default org context', () => {
+    it('hides the static org-name chip when isSoloDefaultContext is true', async () => {
+      mockShowOrgSwitcher.value = false;
+      mockShowDomainSwitcher.value = true;
+      mockIsSoloDefaultContext.value = true;
+
+      wrapper = mountComponent({
+        organizations: [mockOrganization],
+        currentOrganization: mockOrganization,
+        isListFetched: true,
+      });
+
+      await flushPromises();
+
+      expect(wrapper.find('[data-testid="org-context-static"]').exists()).toBe(false);
+      // The domain switcher still shows for these users.
+      expect(wrapper.find('.domain-switcher').exists()).toBe(true);
+    });
+
+    it('shows the static org-name chip when the switcher is hidden but context is not solo', async () => {
+      mockShowOrgSwitcher.value = false;
+      mockShowDomainSwitcher.value = true;
+      mockIsSoloDefaultContext.value = false;
+
+      wrapper = mountComponent({
+        organizations: [mockOrganization],
+        currentOrganization: mockOrganization,
+        isListFetched: true,
+      });
+
+      await flushPromises();
+
+      expect(wrapper.find('[data-testid="org-context-static"]').exists()).toBe(true);
     });
   });
 

--- a/src/tests/composables/useScopeSwitcherVisibility.spec.ts
+++ b/src/tests/composables/useScopeSwitcherVisibility.spec.ts
@@ -43,14 +43,22 @@ vi.mock('@/shared/stores/identityStore', () => ({
   }),
 }));
 
-// Mock organizationStore — composable reads currentOrganization for role + entitlements.
-// Wrap in reactive() so ref auto-unwraps when accessed as organizationStore.currentOrganization.
+// Mock organizationStore — composable reads currentOrganization for role +
+// entitlements, and the organizations list for solo-context detection.
+// Wrap in reactive() so refs auto-unwrap when accessed as store properties.
 type MockOrg = { current_user_role?: string | null; entitlements?: string[] | null } | null;
+type MockListOrg = { member_count?: number; is_default?: boolean };
 const mockCurrentOrganization = ref<MockOrg>({
   current_user_role: 'owner',
   entitlements: null,
 });
-const mockOrgStore = reactive({ currentOrganization: mockCurrentOrganization });
+// Default to a non-trivial context (single org with multiple members) so
+// existing owner-visibility tests continue to show the switcher.
+const mockOrganizations = ref<MockListOrg[]>([{ member_count: 2, is_default: true }]);
+const mockOrgStore = reactive({
+  currentOrganization: mockCurrentOrganization,
+  organizations: mockOrganizations,
+});
 vi.mock('@/shared/stores/organizationStore', () => ({
   useOrganizationStore: () => mockOrgStore,
 }));
@@ -73,6 +81,8 @@ describe('useScopeSwitcherVisibility', () => {
     mockIsOrganizationSwitcherEnabled.mockReturnValue(true);
     // Default: owner with no entitlements loaded, billing disabled (standalone)
     mockCurrentOrganization.value = { current_user_role: 'owner', entitlements: null };
+    // Default: single org with multiple members (non-trivial → switcher shows)
+    mockOrganizations.value = [{ member_count: 2, is_default: true }];
     mockBillingEnabled.value = false;
     mockIsCustomRef.value = false;
     vi.clearAllMocks();
@@ -515,6 +525,68 @@ describe('useScopeSwitcherVisibility', () => {
       await nextTick();
 
       expect(showOrgSwitcher.value).toBe(false);
+    });
+  });
+
+  describe('org switcher solo-default-context gating', () => {
+    beforeEach(() => {
+      mockRoute.meta = { scopesAvailable: { organization: 'show' } };
+      mockCurrentOrganization.value = { current_user_role: 'owner', entitlements: null };
+      mockBillingEnabled.value = false;
+    });
+
+    it('hides the switcher when the owner has a single default org with only themselves', () => {
+      mockOrganizations.value = [{ member_count: 1, is_default: true }];
+
+      const { showOrgSwitcher, isSoloDefaultContext } = useScopeSwitcherVisibility();
+      expect(isSoloDefaultContext.value).toBe(true);
+      expect(showOrgSwitcher.value).toBe(false);
+    });
+
+    it('shows the switcher when the single org has more than one member', () => {
+      mockOrganizations.value = [{ member_count: 3, is_default: true }];
+
+      const { showOrgSwitcher, isSoloDefaultContext } = useScopeSwitcherVisibility();
+      expect(isSoloDefaultContext.value).toBe(false);
+      expect(showOrgSwitcher.value).toBe(true);
+    });
+
+    it('shows the switcher when the user belongs to more than one org', () => {
+      mockOrganizations.value = [
+        { member_count: 1, is_default: true },
+        { member_count: 1, is_default: false },
+      ];
+
+      const { showOrgSwitcher, isSoloDefaultContext } = useScopeSwitcherVisibility();
+      expect(isSoloDefaultContext.value).toBe(false);
+      expect(showOrgSwitcher.value).toBe(true);
+    });
+
+    it('does not hide prematurely when member_count is unknown', () => {
+      mockOrganizations.value = [{ is_default: true }]; // list not fully loaded
+
+      const { showOrgSwitcher, isSoloDefaultContext } = useScopeSwitcherVisibility();
+      expect(isSoloDefaultContext.value).toBe(false);
+      expect(showOrgSwitcher.value).toBe(true);
+    });
+
+    it('does not hide when the organizations list is empty (still loading)', () => {
+      mockOrganizations.value = [];
+
+      const { isSoloDefaultContext } = useScopeSwitcherVisibility();
+      expect(isSoloDefaultContext.value).toBe(false);
+    });
+
+    it('reveals the switcher reactively when a second member joins the solo org', async () => {
+      mockOrganizations.value = [{ member_count: 1, is_default: true }];
+
+      const { showOrgSwitcher } = useScopeSwitcherVisibility();
+      expect(showOrgSwitcher.value).toBe(false);
+
+      mockOrganizations.value = [{ member_count: 2, is_default: true }];
+      await nextTick();
+
+      expect(showOrgSwitcher.value).toBe(true);
     });
   });
 });

--- a/src/tests/composables/useScopeSwitcherVisibility.spec.ts
+++ b/src/tests/composables/useScopeSwitcherVisibility.spec.ts
@@ -302,6 +302,7 @@ describe('useScopeSwitcherVisibility', () => {
       expect(result).toHaveProperty('lockOrgSwitcher');
       expect(result).toHaveProperty('showDomainSwitcher');
       expect(result).toHaveProperty('lockDomainSwitcher');
+      expect(result).toHaveProperty('isSoloDefaultContext');
     });
   });
 
@@ -556,6 +557,14 @@ describe('useScopeSwitcherVisibility', () => {
         { member_count: 1, is_default: true },
         { member_count: 1, is_default: false },
       ];
+
+      const { showOrgSwitcher, isSoloDefaultContext } = useScopeSwitcherVisibility();
+      expect(isSoloDefaultContext.value).toBe(false);
+      expect(showOrgSwitcher.value).toBe(true);
+    });
+
+    it('shows the switcher for a single non-default (self-created) org with only themselves', () => {
+      mockOrganizations.value = [{ member_count: 1, is_default: false }];
 
       const { showOrgSwitcher, isSoloDefaultContext } = useScopeSwitcherVisibility();
       expect(isSoloDefaultContext.value).toBe(false);

--- a/src/tests/shared/components/navigation/DomainContextSwitcher.spec.ts
+++ b/src/tests/shared/components/navigation/DomainContextSwitcher.spec.ts
@@ -1,0 +1,183 @@
+// src/tests/shared/components/navigation/DomainContextSwitcher.spec.ts
+
+/**
+ * Tests for the Domain Context Switcher's add/manage call-to-action logic.
+ *
+ * Behaviour under test:
+ * - Owner/admin with 0 custom domains  -> prominent "Add Domain" footer link
+ *   (no header [+] icon, no "Manage Domains" link).
+ * - Owner/admin with >=1 custom domain -> compact header [+] icon AND the
+ *   "Manage Domains" footer link (no prominent "Add Domain" link).
+ * - Members (cannot manage domains)     -> none of the above.
+ *
+ * HeadlessUI is stubbed so the dropdown contents always render, independent of
+ * the real open/close state machine.
+ */
+
+import { mount, VueWrapper } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { reactive, ref } from 'vue';
+import DomainContextSwitcher from '@/shared/components/navigation/DomainContextSwitcher.vue';
+
+// --- HeadlessUI: render slot content unconditionally -------------------------
+vi.mock('@headlessui/vue', () => ({
+  Menu: {
+    name: 'Menu',
+    template: '<div class="menu"><slot :open="false" :close="() => {}" /></div>',
+    props: ['as'],
+  },
+  MenuButton: {
+    name: 'MenuButton',
+    template: '<button><slot /></button>',
+    props: ['as', 'disabled'],
+  },
+  MenuItems: {
+    name: 'MenuItems',
+    template: '<div role="menu"><slot /></div>',
+    props: ['as', 'class'],
+  },
+  MenuItem: {
+    name: 'MenuItem',
+    template: '<div role="menuitem"><slot :active="false" /></div>',
+    props: ['as', 'disabled'],
+  },
+}));
+
+// --- OIcon: lightweight stub -------------------------------------------------
+vi.mock('@/shared/components/icons/OIcon.vue', () => ({
+  default: {
+    name: 'OIcon',
+    template: '<span class="o-icon" :data-icon="name" />',
+    props: ['collection', 'name', 'class', 'ariaLabel'],
+  },
+}));
+
+// --- i18n --------------------------------------------------------------------
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}));
+
+// --- router ------------------------------------------------------------------
+const mockPush = vi.fn();
+const mockRoute = reactive<{ meta: Record<string, unknown>; params: Record<string, unknown>; matched: unknown[] }>({
+  meta: {},
+  params: {},
+  matched: [],
+});
+vi.mock('vue-router', () => ({
+  useRoute: () => mockRoute,
+  useRouter: () => ({ push: mockPush }),
+}));
+
+// --- organization + bootstrap stores ----------------------------------------
+const mockCurrentOrganization = ref<{ current_user_role: string; extid?: string } | null>({
+  current_user_role: 'owner',
+  extid: 'org1',
+});
+const mockOrgStore = reactive({ currentOrganization: mockCurrentOrganization });
+vi.mock('@/shared/stores/organizationStore', () => ({
+  useOrganizationStore: () => mockOrgStore,
+}));
+
+const mockBillingEnabled = ref(false);
+const mockBootstrapStore = reactive({ billing_enabled: mockBillingEnabled });
+vi.mock('@/shared/stores/bootstrapStore', () => ({
+  useBootstrapStore: () => mockBootstrapStore,
+}));
+
+// --- domain context ----------------------------------------------------------
+const mockAvailableDomains = ref<string[]>(['canonical.example.com']);
+const mockGetExtidByDomain = vi.fn((domain: string) =>
+  domain === 'acme.example.com' ? 'cd1' : undefined
+);
+const mockCurrentContext = ref({
+  domain: 'canonical.example.com',
+  displayName: 'canonical.example.com',
+  isCanonical: true,
+  extid: undefined as string | undefined,
+});
+const mockIsContextActive = ref(true);
+vi.mock('@/shared/composables/useDomainContext', () => ({
+  useDomainContext: () => ({
+    currentContext: mockCurrentContext,
+    availableDomains: mockAvailableDomains,
+    isContextActive: mockIsContextActive,
+    setContext: vi.fn(),
+    getDomainDisplayName: (domain: string) => domain,
+    getExtidByDomain: mockGetExtidByDomain,
+    setContextByExtid: vi.fn(),
+    initialized: Promise.resolve(),
+  }),
+}));
+
+const addLink = (w: VueWrapper) => w.find('[data-testid="domain-context-add-link"]');
+const addIcon = (w: VueWrapper) => w.find('[data-testid="domain-context-add-icon"]');
+const manageLink = (w: VueWrapper) => w.find('[data-testid="domain-context-manage-link"]');
+
+describe('DomainContextSwitcher add/manage call-to-action', () => {
+  let wrapper: VueWrapper;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRoute.meta = {};
+    mockRoute.params = {};
+    mockRoute.matched = [];
+    mockCurrentOrganization.value = { current_user_role: 'owner', extid: 'org1' };
+    mockBillingEnabled.value = false;
+    mockAvailableDomains.value = ['canonical.example.com'];
+    mockIsContextActive.value = true;
+  });
+
+  afterEach(() => {
+    if (wrapper) wrapper.unmount();
+  });
+
+  it('shows the "Add Domain" link (and no [+] icon / Manage link) when owner has no custom domains', () => {
+    mockAvailableDomains.value = ['canonical.example.com'];
+
+    wrapper = mount(DomainContextSwitcher);
+
+    expect(addLink(wrapper).exists()).toBe(true);
+    expect(addIcon(wrapper).exists()).toBe(false);
+    expect(manageLink(wrapper).exists()).toBe(false);
+  });
+
+  it('shows the [+] icon and Manage link (and no prominent Add link) when owner has a custom domain', () => {
+    mockAvailableDomains.value = ['acme.example.com', 'canonical.example.com'];
+
+    wrapper = mount(DomainContextSwitcher);
+
+    expect(addIcon(wrapper).exists()).toBe(true);
+    expect(manageLink(wrapper).exists()).toBe(true);
+    expect(addLink(wrapper).exists()).toBe(false);
+  });
+
+  it('shows no add/manage affordances for members who cannot manage domains', () => {
+    mockCurrentOrganization.value = { current_user_role: 'member', extid: 'org1' };
+    mockAvailableDomains.value = ['acme.example.com', 'canonical.example.com'];
+
+    wrapper = mount(DomainContextSwitcher);
+
+    expect(addLink(wrapper).exists()).toBe(false);
+    expect(addIcon(wrapper).exists()).toBe(false);
+    expect(manageLink(wrapper).exists()).toBe(false);
+  });
+
+  it('navigates to the org-qualified add-domain page from the "Add Domain" link', async () => {
+    mockAvailableDomains.value = ['canonical.example.com'];
+
+    wrapper = mount(DomainContextSwitcher);
+    await addLink(wrapper).trigger('click');
+
+    expect(mockPush).toHaveBeenCalledWith('/org/org1/domains/add');
+  });
+
+  it('navigates to the org-qualified add-domain page from the header [+] icon', async () => {
+    mockAvailableDomains.value = ['acme.example.com', 'canonical.example.com'];
+
+    wrapper = mount(DomainContextSwitcher);
+    await addIcon(wrapper).trigger('click');
+
+    expect(mockPush).toHaveBeenCalledWith('/org/org1/domains/add');
+  });
+});

--- a/src/tests/shared/components/navigation/UserMenu.spec.ts
+++ b/src/tests/shared/components/navigation/UserMenu.spec.ts
@@ -109,11 +109,22 @@ vi.mock('vue-router', () => ({
 const mockCurrentOrganizationRef = ref<{
   current_user_role: string | null;
   extid?: string;
+  entitlements?: string[];
 } | null>(null);
 
 vi.mock('@/shared/stores/organizationStore', () => ({
   useOrganizationStore: () => ({
     currentOrganization: mockCurrentOrganizationRef,
+  }),
+}));
+
+// Mock the scope-switcher visibility composable. UserMenu only consumes
+// isSoloDefaultContext (the same gate the org switcher uses); mocking it keeps
+// the route-aware composable out of the unit test.
+const mockIsSoloDefaultContext = ref(false);
+vi.mock('@/shared/composables/useScopeSwitcherVisibility', () => ({
+  useScopeSwitcherVisibility: () => ({
+    isSoloDefaultContext: mockIsSoloDefaultContext,
   }),
 }));
 
@@ -147,6 +158,7 @@ describe('UserMenu', () => {
     // Reset mock store states to defaults
     mockCurrentOrganizationRef.value = null;
     mockIsCustomRef.value = false;
+    mockIsSoloDefaultContext.value = false;
   });
 
   afterEach(() => {
@@ -517,6 +529,59 @@ describe('UserMenu', () => {
 
       const menuItems = wrapper.findAll('[role="menuitem"]');
       expect(menuItems.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('Identity chip (role badge vs. Free plan chip)', () => {
+    const openMenu = async () => {
+      const trigger = wrapper.find('button[aria-haspopup="true"]');
+      await trigger.trigger('click');
+      await nextTick();
+    };
+
+    it('shows the Free plan chip linking to billing for a solo owner without manage_orgs when billing is enabled', async () => {
+      mockCurrentOrganizationRef.value = { current_user_role: 'owner', entitlements: [] };
+      mockIsSoloDefaultContext.value = true;
+      wrapper = mountComponent({}, { billing_enabled: true });
+      await openMenu();
+
+      const chip = wrapper.find('[data-testid="user-menu-plan-chip"]');
+      expect(chip.exists()).toBe(true);
+      expect(chip.attributes('href')).toBe('/billing');
+      expect(wrapper.find('[data-testid="user-menu-role-badge"]').exists()).toBe(false);
+    });
+
+    it('hides the identity chip entirely for a solo owner when billing is disabled', async () => {
+      mockCurrentOrganizationRef.value = { current_user_role: 'owner', entitlements: [] };
+      mockIsSoloDefaultContext.value = true;
+      wrapper = mountComponent({}, { billing_enabled: false });
+      await openMenu();
+
+      expect(wrapper.find('[data-testid="user-menu-plan-chip"]').exists()).toBe(false);
+      expect(wrapper.find('[data-testid="user-menu-role-badge"]').exists()).toBe(false);
+    });
+
+    it('shows the role badge (not the Free chip) for an owner with a non-solo org context', async () => {
+      mockCurrentOrganizationRef.value = { current_user_role: 'owner', entitlements: [] };
+      mockIsSoloDefaultContext.value = false;
+      wrapper = mountComponent({}, { billing_enabled: true });
+      await openMenu();
+
+      expect(wrapper.find('[data-testid="user-menu-role-badge"]').exists()).toBe(true);
+      expect(wrapper.find('[data-testid="user-menu-plan-chip"]').exists()).toBe(false);
+    });
+
+    it('shows the role badge for a solo owner that still holds the manage_orgs entitlement', async () => {
+      mockCurrentOrganizationRef.value = {
+        current_user_role: 'owner',
+        entitlements: ['manage_orgs'],
+      };
+      mockIsSoloDefaultContext.value = true;
+      wrapper = mountComponent({}, { billing_enabled: true });
+      await openMenu();
+
+      expect(wrapper.find('[data-testid="user-menu-role-badge"]').exists()).toBe(true);
+      expect(wrapper.find('[data-testid="user-menu-plan-chip"]').exists()).toBe(false);
     });
   });
 


### PR DESCRIPTION
## Summary

Improves the domain management call-to-action in the DomainContextSwitcher by making it context-aware:

- **No custom domains yet**: Shows a prominent "Add Domain" footer link (nothing to manage)
- **Has custom domains**: Hides the footer link and shows a compact [+] icon in the dropdown header instead, with "Manage Domains" retained below
- **Non-owners/admins**: No add/manage affordances shown

Also implements "solo default context" gating for the organization switcher to declutter the new-user surface: when a user has exactly one auto-created default organization and is its only member, both the org switcher and static org-name fallback are hidden.

## Changes

### DomainContextSwitcher.vue
- Added `customDomainCount` and `hasCustomDomains` computed properties to detect custom domains (those with an extid)
- Added `navigateToAddDomain()` method for org-qualified routing to the add-domain page
- Refactored footer call-to-action: shows "Add Domain" link when no custom domains exist, "Manage Domains" when they do
- Added compact [+] icon button in the dropdown header (shown only when owner/admin has custom domains)
- Updated dropdown header layout to flex with space-between for icon placement

### useScopeSwitcherVisibility.ts
- Added `isSoloDefaultContext` computed property that detects single default org with ≤1 member
- Updated `showOrgSwitcher` to hide switcher for solo default contexts
- Exported `isSoloDefaultContext` for use in OrganizationContextBar

### OrganizationContextBar.vue
- Updated `showStaticOrgName` to also suppress the static org-name chip for solo default contexts
- Added feature flag mock to enable org switcher testing

### Test Coverage
- Added comprehensive DomainContextSwitcher.spec.ts with 5 test cases covering:
  - Owner with no custom domains → shows "Add Domain" link
  - Owner with custom domains → shows [+] icon and "Manage Domains" link
  - Members → no add/manage affordances
  - Navigation from both "Add Domain" link and [+] icon
- Extended useScopeSwitcherVisibility.spec.ts with 6 tests for solo default context detection
- Extended OrganizationContextBar.spec.ts with 2 tests for solo context UI behavior

## Test Plan

All new functionality is covered by unit tests:
- DomainContextSwitcher add/manage logic: 5 new tests
- Solo default context detection: 6 new tests  
- OrganizationContextBar solo context rendering: 2 new tests

Existing tests continue to pass with updated mocks for the organizations list.

https://claude.ai/code/session_016kaAPu4bJysWFwHouhn6YP