### PR TITLE
fix(nav): close scope-switcher dropdowns after navigation (domain + org)

### DIFF
--- a/src/apps/workspace/components/navigation/OrganizationScopeSwitcher.vue
+++ b/src/apps/workspace/components/navigation/OrganizationScopeSwitcher.vue
@@ -111,9 +111,18 @@ const isCurrentOrganization = (org: Organization): boolean =>
   currentOrganization.value?.objid === org.objid;
 
 /**
- * Handle organization selection with optional navigation
+ * Handle organization selection with optional navigation.
+ *
+ * `close` is the HeadlessUI Menu slot function. Selecting a MenuItem already
+ * auto-closes the menu, so this call is belt-and-suspenders here — it exists so
+ * that "every navigating action closes the dropdown" is a single, uniform
+ * invariant across this component rather than a per-handler judgement call. The
+ * case that genuinely *requires* an explicit close is the gear icon
+ * (navigateToManageOrganization), whose stopPropagation suppresses the built-in
+ * one.
  */
-const selectOrganization = (org: Organization): void => {
+const selectOrganization = (org: Organization, close?: () => void): void => {
+  close?.();
   // setCurrentOrganization triggers the store's watcher to persist to localStorage
   organizationStore.setCurrentOrganization(org);
 
@@ -148,8 +157,15 @@ const selectOrganization = (org: Organization): void => {
 /**
  * Navigate to organization management page (requires extid)
  */
-const navigateToManageOrganization = (org: Organization, event: MouseEvent): void => {
+const navigateToManageOrganization = (
+  org: Organization,
+  event: MouseEvent,
+  close?: () => void
+): void => {
   event.stopPropagation(); // Prevent row selection when clicking gear
+  // stopPropagation above suppresses HeadlessUI's built-in MenuItem close, so
+  // dismiss the dropdown explicitly before navigating.
+  close?.();
   if (!org.extid) {
     // Cannot navigate without extid - gear icon should be hidden for these orgs
     console.warn('[OrganizationScopeSwitcher] Cannot navigate: org missing extid', org.objid);
@@ -161,7 +177,8 @@ const navigateToManageOrganization = (org: Organization, event: MouseEvent): voi
 /**
  * Navigate to manage organizations page
  */
-const navigateToManageOrganizations = (): void => {
+const navigateToManageOrganizations = (close?: () => void): void => {
+  close?.();
   router.push('/orgs');
 };
 </script>
@@ -172,7 +189,7 @@ const navigateToManageOrganizations = (): void => {
     as="div"
     class="relative inline-flex"
     data-testid="org-scope-switcher"
-    v-slot="{ open }">
+    v-slot="{ open, close }">
     <!-- Trigger Button -->
     <MenuButton
       class="group inline-flex h-10 items-center gap-2 rounded-lg bg-gray-100 px-3 text-sm font-medium text-gray-700 transition-colors duration-150 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:ring-offset-2 dark:bg-gray-800 dark:text-gray-300 dark:focus:ring-offset-gray-900"
@@ -252,7 +269,7 @@ const navigateToManageOrganizations = (): void => {
           v-for="org in visibleOrganizations"
           :key="org.objid"
           v-slot="{ active }"
-          @click="selectOrganization(org)">
+          @click="selectOrganization(org, close)">
           <button
             type="button"
             :data-testid="`org-menu-item-${org.extid}`"
@@ -314,7 +331,7 @@ const navigateToManageOrganizations = (): void => {
                 type="button"
                 class="hidden rounded p-0.5 text-gray-400 transition-colors hover:bg-gray-200 hover:text-gray-600 group-hover/row:block dark:text-gray-500 dark:hover:bg-gray-600 dark:hover:text-gray-300"
                 :aria-label="t('web.organizations.organization_settings')"
-                @click="navigateToManageOrganization(org, $event)">
+                @click="navigateToManageOrganization(org, $event, close)">
                 <OIcon
                   collection="heroicons"
                   name="cog"
@@ -332,7 +349,7 @@ const navigateToManageOrganizations = (): void => {
           aria-hidden="true" ></div>
 
         <!-- Manage Organizations Link -->
-        <MenuItem v-slot="{ active }" @click="navigateToManageOrganizations">
+        <MenuItem v-slot="{ active }" @click="navigateToManageOrganizations(close)">
           <button
             type="button"
             class="mx-2 w-[calc(100%-1rem)] cursor-pointer select-none rounded-md px-2 py-2 text-left transition-colors duration-150"

--- a/src/shared/components/navigation/DomainContextSwitcher.vue
+++ b/src/shared/components/navigation/DomainContextSwitcher.vue
@@ -95,14 +95,21 @@ const isOptionDisabled = (domain: string): boolean => {
 };
 
 /**
- * Handle domain selection with optional navigation
+ * Handle domain selection with optional navigation.
+ *
+ * `close` is the HeadlessUI Menu slot function. We invoke it explicitly so the
+ * dropdown always dismisses on selection: HeadlessUI's automatic MenuItem close
+ * is not guaranteed here because navigation (router.push) runs in the same click
+ * tick, and sibling actions (the gear icon) call stopPropagation which suppresses
+ * the built-in close. Closing explicitly keeps every path deterministic.
  */
-const selectDomain = (domain: string): void => {
+const selectDomain = (domain: string, close?: () => void): void => {
   // Don't allow selection of disabled options
   if (isOptionDisabled(domain)) {
     return;
   }
 
+  close?.();
   setContext(domain);
 
   // Handle route-aware navigation based on onDomainSwitch meta
@@ -199,7 +206,8 @@ watch(
 /**
  * Navigate to domains management page (org-qualified)
  */
-const navigateToManageDomains = (): void => {
+const navigateToManageDomains = (close?: () => void): void => {
+  close?.();
   if (currentOrgExtid.value) {
     router.push(`/org/${currentOrgExtid.value}`);
   } else {
@@ -211,7 +219,8 @@ const navigateToManageDomains = (): void => {
  * Navigate to the add-domain page (org-qualified).
  * Falls back to the /domains/add redirect when no org context is available.
  */
-const navigateToAddDomain = (): void => {
+const navigateToAddDomain = (close?: () => void): void => {
+  close?.();
   if (currentOrgExtid.value) {
     router.push(`/org/${currentOrgExtid.value}/domains/add`);
   } else {
@@ -222,8 +231,15 @@ const navigateToAddDomain = (): void => {
 /**
  * Navigate to edit a specific domain (uses org-qualified routes)
  */
-const navigateToDomainSettings = (domain: string, event: MouseEvent): void => {
+const navigateToDomainSettings = (
+  domain: string,
+  event: MouseEvent,
+  close?: () => void
+): void => {
   event.stopPropagation(); // Prevent row selection when clicking gear
+  // stopPropagation above suppresses HeadlessUI's built-in MenuItem close, so
+  // dismiss the dropdown explicitly before navigating.
+  close?.();
   const extid = getExtidByDomain(domain);
   if (extid && currentOrgExtid.value) {
     router.push(`/org/${currentOrgExtid.value}/domains/${extid}`);
@@ -311,7 +327,7 @@ const navigateToDomainSettings = (domain: string, event: MouseEvent): void => {
             :title="t('web.domains.add_domain')"
             :aria-label="t('web.domains.add_domain')"
             data-testid="domain-context-add-icon"
-            @click="() => { close?.(); navigateToAddDomain(); }">
+            @click="navigateToAddDomain(close)">
             <OIcon
               collection="heroicons"
               name="plus-20-solid"
@@ -326,7 +342,7 @@ const navigateToDomainSettings = (domain: string, event: MouseEvent): void => {
           :key="domain"
           v-slot="{ active }"
           :disabled="isOptionDisabled(domain)"
-          @click="selectDomain(domain)">
+          @click="selectDomain(domain, close)">
           <button
             type="button"
             class="group/row relative w-full select-none py-2 pl-3 pr-9 text-left transition-colors duration-150"
@@ -385,7 +401,7 @@ const navigateToDomainSettings = (domain: string, event: MouseEvent): void => {
                 type="button"
                 class="hidden rounded p-0.5 text-gray-400 transition-colors hover:bg-gray-200 hover:text-gray-600 group-hover/row:block dark:text-gray-500 dark:hover:bg-gray-600 dark:hover:text-gray-300"
                 :aria-label="t('web.domains.domain_settings')"
-                @click="navigateToDomainSettings(domain, $event)">
+                @click="navigateToDomainSettings(domain, $event, close)">
                 <OIcon
                   collection="heroicons"
                   name="cog"
@@ -408,7 +424,7 @@ const navigateToDomainSettings = (domain: string, event: MouseEvent): void => {
           <MenuItem
             v-if="!hasCustomDomains"
             v-slot="{ active }"
-            @click="navigateToAddDomain">
+            @click="navigateToAddDomain(close)">
             <button
               type="button"
               class="mx-2 w-[calc(100%-1rem)] cursor-pointer select-none rounded-md px-2 py-2 text-left transition-colors duration-150"
@@ -432,7 +448,7 @@ const navigateToDomainSettings = (domain: string, event: MouseEvent): void => {
           <MenuItem
             v-else
             v-slot="{ active }"
-            @click="navigateToManageDomains">
+            @click="navigateToManageDomains(close)">
             <button
               type="button"
               class="mx-2 w-[calc(100%-1rem)] cursor-pointer select-none rounded-md px-2 py-2 text-left transition-colors duration-150"

--- a/src/shared/components/navigation/DomainContextSwitcher.vue
+++ b/src/shared/components/navigation/DomainContextSwitcher.vue
@@ -346,6 +346,7 @@ const navigateToDomainSettings = (
           @click="selectDomain(domain, close)">
           <button
             type="button"
+            :data-testid="`domain-menu-item-${getExtidByDomain(domain) ?? 'canonical'}`"
             class="group/row relative w-full select-none py-2 pl-3 pr-9 text-left transition-colors duration-150"
             :class="[
               isOptionDisabled(domain)

--- a/src/shared/components/navigation/DomainContextSwitcher.vue
+++ b/src/shared/components/navigation/DomainContextSwitcher.vue
@@ -320,7 +320,10 @@ const navigateToDomainSettings = (
           </span>
 
           <!-- Compact add-domain action: shown once an owner/admin already has
-               a domain, so the "Add Domain" call to action demotes to an icon. -->
+               a domain, so the "Add Domain" call to action demotes to an icon.
+               This is a plain button, NOT a <MenuItem>, so HeadlessUI does not
+               auto-close the menu on click — navigateToAddDomain(close) must
+               call close() explicitly here (required, not belt-and-suspenders). -->
           <button
             v-if="canManageDomains && hasCustomDomains"
             type="button"

--- a/src/shared/components/navigation/DomainContextSwitcher.vue
+++ b/src/shared/components/navigation/DomainContextSwitcher.vue
@@ -97,11 +97,12 @@ const isOptionDisabled = (domain: string): boolean => {
 /**
  * Handle domain selection with optional navigation.
  *
- * `close` is the HeadlessUI Menu slot function. We invoke it explicitly so the
- * dropdown always dismisses on selection: HeadlessUI's automatic MenuItem close
- * is not guaranteed here because navigation (router.push) runs in the same click
- * tick, and sibling actions (the gear icon) call stopPropagation which suppresses
- * the built-in close. Closing explicitly keeps every path deterministic.
+ * `close` is the HeadlessUI Menu slot function. Selecting a MenuItem already
+ * auto-closes the menu, so this call is belt-and-suspenders here — it exists so
+ * that "every navigating action closes the dropdown" is a single, uniform
+ * invariant across this component rather than a per-handler judgement call. The
+ * case that genuinely *requires* an explicit close is the gear icon
+ * (navigateToDomainSettings), whose stopPropagation suppresses the built-in one.
  */
 const selectDomain = (domain: string, close?: () => void): void => {
   // Don't allow selection of disabled options

--- a/src/tests/apps/workspace/components/navigation/OrganizationScopeSwitcher.close.spec.ts
+++ b/src/tests/apps/workspace/components/navigation/OrganizationScopeSwitcher.close.spec.ts
@@ -1,0 +1,134 @@
+// src/tests/apps/workspace/components/navigation/OrganizationScopeSwitcher.close.spec.ts
+
+/**
+ * End-to-end close-behaviour regression for the Organization Scope Switcher.
+ *
+ * Mirrors DomainContextSwitcher.close.spec.ts: it uses the REAL @headlessui/vue
+ * Menu so it exercises the actual open/close state machine, then drives the
+ * genuine user flow (open -> click -> assert the panel is gone). This guards the
+ * same class of bug the domain switcher had — the gear icon's stopPropagation
+ * suppressing HeadlessUI's built-in MenuItem close, leaving the dropdown open
+ * after navigation.
+ *
+ * Only the component's data dependencies are stubbed; HeadlessUI is real.
+ */
+
+import { flushPromises, mount, VueWrapper } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { nextTick, reactive, ref } from 'vue';
+import OrganizationScopeSwitcher from '@/apps/workspace/components/navigation/OrganizationScopeSwitcher.vue';
+
+// NOTE: no vi.mock('@headlessui/vue') here — that is the whole point.
+
+vi.mock('@/shared/components/icons/OIcon.vue', () => ({
+  default: {
+    name: 'OIcon',
+    template: '<span class="o-icon" :data-icon="name" />',
+    props: ['collection', 'name', 'class', 'ariaLabel'],
+  },
+}));
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}));
+
+const mockPush = vi.fn();
+const mockRoute = reactive<{ name?: string; meta: Record<string, unknown>; params: Record<string, unknown> }>({
+  name: 'dashboard',
+  meta: {},
+  params: {},
+});
+vi.mock('vue-router', () => ({
+  useRoute: () => mockRoute,
+  useRouter: () => ({ push: mockPush }),
+}));
+
+type TestOrg = {
+  objid: string;
+  extid?: string;
+  display_name: string;
+  is_default?: boolean;
+  planid?: string;
+};
+
+const acme: TestOrg = { objid: 'o1', extid: 'org1', display_name: 'Acme Inc' };
+const personal: TestOrg = { objid: 'o2', extid: 'org2', display_name: 'Personal', is_default: true };
+
+const mockOrganizations = ref<TestOrg[]>([acme, personal]);
+const mockCurrentOrganization = ref<TestOrg | null>(acme);
+const mockSetCurrentOrganization = vi.fn();
+const mockOrgStore = reactive({
+  organizations: mockOrganizations,
+  currentOrganization: mockCurrentOrganization,
+  hasOrganizations: true,
+  setCurrentOrganization: mockSetCurrentOrganization,
+});
+vi.mock('@/shared/stores/organizationStore', () => ({
+  useOrganizationStore: () => mockOrgStore,
+}));
+
+const dropdown = (w: VueWrapper) =>
+  w.find('[data-testid="org-scope-switcher-dropdown"]');
+
+async function openMenu(w: VueWrapper) {
+  await w.get('[data-testid="org-scope-switcher-trigger"]').trigger('click');
+  await nextTick();
+  await flushPromises();
+  expect(dropdown(w).exists()).toBe(true);
+}
+
+describe('OrganizationScopeSwitcher real-HeadlessUI close behaviour', () => {
+  let wrapper: VueWrapper;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRoute.name = 'dashboard';
+    mockRoute.meta = {};
+    mockRoute.params = {};
+    mockOrganizations.value = [acme, personal];
+    mockCurrentOrganization.value = acme;
+  });
+
+  afterEach(() => {
+    if (wrapper) wrapper.unmount();
+  });
+
+  it('closes the dropdown when the gear/settings icon is clicked (the twin bug)', async () => {
+    wrapper = mount(OrganizationScopeSwitcher, { attachTo: document.body });
+    await openMenu(wrapper);
+
+    // Gear for the non-current org avoids interference from the active row's
+    // checkmark; org2 has an extid so its gear renders.
+    await wrapper.get('[data-testid="org-menu-item-org2"] [aria-label="web.organizations.organization_settings"]')
+      .trigger('click');
+    await nextTick();
+    await flushPromises();
+
+    expect(mockPush).toHaveBeenCalledWith('/org/org2');
+    expect(dropdown(wrapper).exists()).toBe(false);
+  });
+
+  it('closes the dropdown when an organization row is selected', async () => {
+    wrapper = mount(OrganizationScopeSwitcher, { attachTo: document.body });
+    await openMenu(wrapper);
+
+    await wrapper.get('[data-testid="org-menu-item-org2"]').trigger('click');
+    await nextTick();
+    await flushPromises();
+
+    expect(mockSetCurrentOrganization).toHaveBeenCalled();
+    expect(dropdown(wrapper).exists()).toBe(false);
+  });
+
+  it('closes the dropdown when the "Manage Organizations" link is clicked', async () => {
+    wrapper = mount(OrganizationScopeSwitcher, { attachTo: document.body });
+    await openMenu(wrapper);
+
+    await wrapper.get('[data-testid="org-scope-manage-link"]').trigger('click');
+    await nextTick();
+    await flushPromises();
+
+    expect(mockPush).toHaveBeenCalledWith('/orgs');
+    expect(dropdown(wrapper).exists()).toBe(false);
+  });
+});

--- a/src/tests/shared/components/navigation/DomainContextSwitcher.close.spec.ts
+++ b/src/tests/shared/components/navigation/DomainContextSwitcher.close.spec.ts
@@ -129,12 +129,9 @@ describe('DomainContextSwitcher real-HeadlessUI close behaviour', () => {
     wrapper = mount(DomainContextSwitcher, { attachTo: document.body });
     await openMenu(wrapper);
 
-    const row = wrapper
-      .findAll('[data-testid="domain-context-switcher-dropdown"] button')
-      .find((b) => b.text().includes('acme.example.com'));
-    expect(row).toBeTruthy();
-
-    await row!.trigger('click');
+    // Select the row by its stable test id (extid 'cd1' for acme.example.com)
+    // rather than substring-matching the rendered domain text.
+    await wrapper.get('[data-testid="domain-menu-item-cd1"]').trigger('click');
     await nextTick();
     await flushPromises();
 

--- a/src/tests/shared/components/navigation/DomainContextSwitcher.close.spec.ts
+++ b/src/tests/shared/components/navigation/DomainContextSwitcher.close.spec.ts
@@ -149,4 +149,32 @@ describe('DomainContextSwitcher real-HeadlessUI close behaviour', () => {
     expect(mockPush).toHaveBeenCalledWith('/org/org1/domains/add');
     expect(dropdown(wrapper).exists()).toBe(false);
   });
+
+  it('closes the dropdown when the "Manage Domains" footer link is clicked', async () => {
+    // Owner + at least one custom domain renders the "Manage Domains" link.
+    wrapper = mount(DomainContextSwitcher, { attachTo: document.body });
+    await openMenu(wrapper);
+
+    await wrapper.get('[data-testid="domain-context-manage-link"]').trigger('click');
+    await nextTick();
+    await flushPromises();
+
+    expect(mockPush).toHaveBeenCalledWith('/org/org1');
+    expect(dropdown(wrapper).exists()).toBe(false);
+  });
+
+  it('closes the dropdown when the "Add Domain" footer link is clicked (no custom domains)', async () => {
+    // With no custom domains the footer shows the prominent "Add Domain" link.
+    mockAvailableDomains.value = ['canonical.example.com'];
+
+    wrapper = mount(DomainContextSwitcher, { attachTo: document.body });
+    await openMenu(wrapper);
+
+    await wrapper.get('[data-testid="domain-context-add-link"]').trigger('click');
+    await nextTick();
+    await flushPromises();
+
+    expect(mockPush).toHaveBeenCalledWith('/org/org1/domains/add');
+    expect(dropdown(wrapper).exists()).toBe(false);
+  });
 });

--- a/src/tests/shared/components/navigation/DomainContextSwitcher.close.spec.ts
+++ b/src/tests/shared/components/navigation/DomainContextSwitcher.close.spec.ts
@@ -1,0 +1,155 @@
+// src/tests/shared/components/navigation/DomainContextSwitcher.close.spec.ts
+
+/**
+ * End-to-end close-behaviour regression for the Domain Context Switcher.
+ *
+ * Unlike DomainContextSwitcher.spec.ts, this suite deliberately uses the REAL
+ * @headlessui/vue Menu so it exercises the actual open/close state machine.
+ * The mocked suite can only assert "the handler called close()"; it would keep
+ * passing even if the real dropdown stopped dismissing. This suite drives the
+ * genuine user flow — open the menu, click, assert the panel is gone — so a
+ * regression of the "dropdown stays open after navigation" bug (the gear icon's
+ * stopPropagation suppressing HeadlessUI's built-in close) would fail here.
+ *
+ * Only the component's data dependencies are stubbed; HeadlessUI is real.
+ */
+
+import { flushPromises, mount, VueWrapper } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { nextTick, reactive, ref } from 'vue';
+import DomainContextSwitcher from '@/shared/components/navigation/DomainContextSwitcher.vue';
+
+// NOTE: no vi.mock('@headlessui/vue') here — that is the whole point.
+
+vi.mock('@/shared/components/icons/OIcon.vue', () => ({
+  default: {
+    name: 'OIcon',
+    template: '<span class="o-icon" :data-icon="name" />',
+    props: ['collection', 'name', 'class', 'ariaLabel'],
+  },
+}));
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}));
+
+const mockPush = vi.fn();
+const mockRoute = reactive<{ meta: Record<string, unknown>; params: Record<string, unknown>; matched: unknown[] }>({
+  meta: {},
+  params: {},
+  matched: [],
+});
+vi.mock('vue-router', () => ({
+  useRoute: () => mockRoute,
+  useRouter: () => ({ push: mockPush }),
+}));
+
+const mockCurrentOrganization = ref<{ current_user_role: string; extid?: string } | null>({
+  current_user_role: 'owner',
+  extid: 'org1',
+});
+const mockOrgStore = reactive({ currentOrganization: mockCurrentOrganization });
+vi.mock('@/shared/stores/organizationStore', () => ({
+  useOrganizationStore: () => mockOrgStore,
+}));
+
+const mockBillingEnabled = ref(false);
+const mockBootstrapStore = reactive({ billing_enabled: mockBillingEnabled });
+vi.mock('@/shared/stores/bootstrapStore', () => ({
+  useBootstrapStore: () => mockBootstrapStore,
+}));
+
+const mockAvailableDomains = ref<string[]>(['acme.example.com', 'canonical.example.com']);
+const mockGetExtidByDomain = vi.fn((domain: string) =>
+  domain === 'acme.example.com' ? 'cd1' : undefined
+);
+const mockCurrentContext = ref({
+  domain: 'canonical.example.com',
+  displayName: 'canonical.example.com',
+  isCanonical: true,
+  extid: undefined as string | undefined,
+});
+const mockIsContextActive = ref(true);
+vi.mock('@/shared/composables/useDomainContext', () => ({
+  useDomainContext: () => ({
+    currentContext: mockCurrentContext,
+    availableDomains: mockAvailableDomains,
+    isContextActive: mockIsContextActive,
+    setContext: vi.fn(),
+    getDomainDisplayName: (domain: string) => domain,
+    getExtidByDomain: mockGetExtidByDomain,
+    setContextByExtid: vi.fn(),
+    initialized: Promise.resolve(),
+  }),
+}));
+
+const dropdown = (w: VueWrapper) =>
+  w.find('[data-testid="domain-context-switcher-dropdown"]');
+
+async function openMenu(w: VueWrapper) {
+  await w.get('[data-testid="domain-context-switcher-trigger"]').trigger('click');
+  await nextTick();
+  await flushPromises();
+  expect(dropdown(w).exists()).toBe(true);
+}
+
+describe('DomainContextSwitcher real-HeadlessUI close behaviour', () => {
+  let wrapper: VueWrapper;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRoute.meta = {};
+    mockRoute.params = {};
+    mockRoute.matched = [];
+    mockCurrentOrganization.value = { current_user_role: 'owner', extid: 'org1' };
+    mockBillingEnabled.value = false;
+    mockAvailableDomains.value = ['acme.example.com', 'canonical.example.com'];
+    mockIsContextActive.value = true;
+  });
+
+  afterEach(() => {
+    if (wrapper) wrapper.unmount();
+  });
+
+  it('closes the dropdown when the gear/config icon is clicked (the reported bug)', async () => {
+    wrapper = mount(DomainContextSwitcher, { attachTo: document.body });
+    await openMenu(wrapper);
+
+    await wrapper
+      .get('[aria-label="web.domains.domain_settings"]')
+      .trigger('click');
+    await nextTick();
+    await flushPromises();
+
+    expect(mockPush).toHaveBeenCalledWith('/org/org1/domains/cd1');
+    expect(dropdown(wrapper).exists()).toBe(false);
+  });
+
+  it('closes the dropdown when a domain row is selected', async () => {
+    wrapper = mount(DomainContextSwitcher, { attachTo: document.body });
+    await openMenu(wrapper);
+
+    const row = wrapper
+      .findAll('[data-testid="domain-context-switcher-dropdown"] button')
+      .find((b) => b.text().includes('acme.example.com'));
+    expect(row).toBeTruthy();
+
+    await row!.trigger('click');
+    await nextTick();
+    await flushPromises();
+
+    expect(dropdown(wrapper).exists()).toBe(false);
+  });
+
+  it('closes the dropdown when the header [+] icon is clicked', async () => {
+    wrapper = mount(DomainContextSwitcher, { attachTo: document.body });
+    await openMenu(wrapper);
+
+    await wrapper.get('[data-testid="domain-context-add-icon"]').trigger('click');
+    await nextTick();
+    await flushPromises();
+
+    expect(mockPush).toHaveBeenCalledWith('/org/org1/domains/add');
+    expect(dropdown(wrapper).exists()).toBe(false);
+  });
+});

--- a/src/tests/shared/components/navigation/DomainContextSwitcher.spec.ts
+++ b/src/tests/shared/components/navigation/DomainContextSwitcher.spec.ts
@@ -19,12 +19,18 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { reactive, ref } from 'vue';
 import DomainContextSwitcher from '@/shared/components/navigation/DomainContextSwitcher.vue';
 
+// Shared spy for HeadlessUI's Menu `close` slot function so tests can assert the
+// dropdown is dismissed on navigation. Hoisted so it is available inside the
+// (hoisted) vi.mock factory below.
+const { mockClose } = vi.hoisted(() => ({ mockClose: vi.fn() }));
+
 // --- HeadlessUI: render slot content unconditionally -------------------------
 vi.mock('@headlessui/vue', () => ({
   Menu: {
     name: 'Menu',
-    template: '<div class="menu"><slot :open="false" :close="() => {}" /></div>',
+    template: '<div class="menu"><slot :open="false" :close="mockClose" /></div>',
     props: ['as'],
+    setup: () => ({ mockClose }),
   },
   MenuButton: {
     name: 'MenuButton',
@@ -179,5 +185,81 @@ describe('DomainContextSwitcher add/manage call-to-action', () => {
     await addIcon(wrapper).trigger('click');
 
     expect(mockPush).toHaveBeenCalledWith('/org/org1/domains/add');
+  });
+});
+
+/**
+ * Regression coverage for the "dropdown stays open after navigation" bug.
+ *
+ * Every navigating interaction must dismiss the menu via HeadlessUI's `close`
+ * slot function. This is essential for the gear icon, whose handler calls
+ * event.stopPropagation() (to avoid triggering row selection) and thereby
+ * suppresses HeadlessUI's built-in MenuItem auto-close.
+ */
+describe('DomainContextSwitcher closes on navigation', () => {
+  let wrapper: VueWrapper;
+
+  const rowButtonFor = (w: VueWrapper, domain: string) =>
+    w
+      .findAll('[role="menuitem"] > button')
+      .find((b) => b.text().includes(domain));
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRoute.meta = {};
+    mockRoute.params = {};
+    mockRoute.matched = [];
+    mockCurrentOrganization.value = { current_user_role: 'owner', extid: 'org1' };
+    mockBillingEnabled.value = false;
+    mockAvailableDomains.value = ['acme.example.com', 'canonical.example.com'];
+    mockIsContextActive.value = true;
+  });
+
+  afterEach(() => {
+    if (wrapper) wrapper.unmount();
+  });
+
+  it('closes the dropdown when a domain row is selected', async () => {
+    wrapper = mount(DomainContextSwitcher);
+
+    await rowButtonFor(wrapper, 'acme.example.com')!.trigger('click');
+
+    expect(mockClose).toHaveBeenCalled();
+  });
+
+  it('closes the dropdown and navigates when the gear icon is clicked', async () => {
+    wrapper = mount(DomainContextSwitcher);
+
+    await wrapper
+      .find('[aria-label="web.domains.domain_settings"]')
+      .trigger('click');
+
+    expect(mockPush).toHaveBeenCalledWith('/org/org1/domains/cd1');
+    expect(mockClose).toHaveBeenCalled();
+  });
+
+  it('closes the dropdown when the header [+] icon is clicked', async () => {
+    wrapper = mount(DomainContextSwitcher);
+
+    await addIcon(wrapper).trigger('click');
+
+    expect(mockClose).toHaveBeenCalled();
+  });
+
+  it('closes the dropdown when the "Manage Domains" link is clicked', async () => {
+    wrapper = mount(DomainContextSwitcher);
+
+    await manageLink(wrapper).trigger('click');
+
+    expect(mockClose).toHaveBeenCalled();
+  });
+
+  it('closes the dropdown when the "Add Domain" link is clicked (no custom domains)', async () => {
+    mockAvailableDomains.value = ['canonical.example.com'];
+
+    wrapper = mount(DomainContextSwitcher);
+    await addLink(wrapper).trigger('click');
+
+    expect(mockClose).toHaveBeenCalled();
   });
 });

--- a/src/tests/shared/components/navigation/DomainContextSwitcher.spec.ts
+++ b/src/tests/shared/components/navigation/DomainContextSwitcher.spec.ts
@@ -199,10 +199,10 @@ describe('DomainContextSwitcher add/manage call-to-action', () => {
 describe('DomainContextSwitcher closes on navigation', () => {
   let wrapper: VueWrapper;
 
-  const rowButtonFor = (w: VueWrapper, domain: string) =>
-    w
-      .findAll('[role="menuitem"] > button')
-      .find((b) => b.text().includes(domain));
+  // Select a domain row by its stable test id (keyed by extid) rather than by
+  // matching rendered domain text.
+  const rowButtonFor = (w: VueWrapper, extid: string) =>
+    w.find(`[data-testid="domain-menu-item-${extid}"]`);
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -222,7 +222,7 @@ describe('DomainContextSwitcher closes on navigation', () => {
   it('closes the dropdown when a domain row is selected', async () => {
     wrapper = mount(DomainContextSwitcher);
 
-    await rowButtonFor(wrapper, 'acme.example.com')!.trigger('click');
+    await rowButtonFor(wrapper, 'cd1').trigger('click');
 
     expect(mockClose).toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary

Fixes a UI regression where the workspace context-switcher dropdowns stayed **open** after navigating. Opening the Domain switcher and clicking a domain — or a domain's gear/config icon — navigated correctly but left the menu open. The same latent defect existed in the Organization switcher.

Root cause: the gear/settings icon handler calls `event.stopPropagation()` (to stop a gear click from also selecting the row). That `stopPropagation` also prevents the click from reaching HeadlessUI's built-in `MenuItem` auto-close, so the dropdown never dismissed. It surfaced now because the Organization switcher was recently hidden for solo/new accounts, making the Domain switcher the primary context control users interact with.

## Changes

- **`DomainContextSwitcher.vue`** — thread HeadlessUI's `close` slot function into every navigating handler (`selectDomain`, `navigateToDomainSettings`, `navigateToAddDomain`, `navigateToManageDomains`) and invoke it explicitly, mirroring the header `[+]` button that already did this. This makes dismissal deterministic regardless of `stopPropagation` or same-tick router navigation. Also adds a stable `data-testid` per domain row (keyed by extid, matching the org switcher's row ids).
- **`OrganizationScopeSwitcher.vue`** — apply the identical `close()`-before-navigate fix to the twin component (org select, gear settings, manage link). Masked in practice because this switcher is hidden for solo/new accounts, but the bug was real for owners who still see it.

## Tests

- **`DomainContextSwitcher.spec.ts`** — mocked-HeadlessUI unit tests asserting `close()` is invoked on all five navigation paths.
- **`DomainContextSwitcher.close.spec.ts`** (new) and **`OrganizationScopeSwitcher.close.spec.ts`** (new) — end-to-end suites that mount the **real** `@headlessui/vue` Menu and drive the genuine flow (open → click → assert the panel is gone). The mocked suite alone can't catch a real regression because it stubs the entire open/close state machine; these were confirmed to **fail without the gear fix** and pass with it.

## Follow-up (out of scope here)

Both switchers are near-identical copy-paste (shell, row markup, and the buggy close/gear behavior duplicated). Automated review also flagged a pre-existing structural issue — the row renders a gear `<button>` nested inside the row `<button>` (invalid HTML / a11y). Both are best resolved by extracting a shared, featurized `ScopeSwitcher` engine in `shared/` with two thin adapters in `workspace/`, which is being done as a **separate PR** to keep this one a tight, reviewable bugfix.
