### PR TITLE
fix(a11y): make scope-switcher row a div to avoid nested buttons

### DIFF
--- a/src/shared/components/navigation/ScopeSwitcher.vue
+++ b/src/shared/components/navigation/ScopeSwitcher.vue
@@ -151,14 +151,22 @@ const onSettings = (item: ScopeSwitcherItem, event: MouseEvent, close: () => voi
         </div>
 
         <!-- Scope Options -->
+        <!--
+          The row element is a <div>, not a <button>. HeadlessUI's MenuItem
+          (as="template") applies role="menuitem" + its click/keyboard handlers
+          to whatever element we hand it, so the div is fully activatable. Using
+          a <div> is deliberate: the row hosts a nested "settings" (gear)
+          <button>, and a <button> inside a <button> is invalid HTML that
+          assistive tech reports as a single, ambiguous control. With a <div>
+          row the gear is the row's only real interactive control.
+        -->
         <MenuItem
           v-for="item in items"
           :key="item.id"
           v-slot="{ active }"
           :disabled="item.disabled"
           @click="onSelect(item, close)">
-          <button
-            type="button"
+          <div
             :data-testid="`${itemTestid}-${item.id}`"
             class="group/row relative w-full py-2 pr-9 pl-3 text-left transition-colors duration-150 select-none"
             :class="[
@@ -211,7 +219,7 @@ const onSettings = (item: ScopeSwitcherItem, event: MouseEvent, close: () => voi
                   aria-hidden="true" />
               </button>
             </span>
-          </button>
+          </div>
         </MenuItem>
 
         <!-- Divider + footer call to action (adapter-provided, gated by canManage) -->


### PR DESCRIPTION
Stacked on #3658 (base is `claude/scope-switcher-shared-component`, not `main`). This is the deliberately-deferred follow-up that #3658 documents under "out of scope".

### The defect
The shared `ScopeSwitcher` engine renders each scope row as a `<button>` that hosts a nested "settings" (gear) `<button>`. A `<button>` inside a `<button>` is invalid HTML; assistive technologies collapse it into a single, ambiguous control, and the gear can become unreachable/misannounced.

The consolidation in #3658 didn't introduce this — both copy-pasted switchers had it — but it moved the pattern into **one** place, which is exactly what makes it a safe, single-point fix now.

### The fix
Make the row's menuitem element a `<div>` instead of a `<button>`.

HeadlessUI's `MenuItem` uses `as="template"` by default, so it applies `role="menuitem"` and its own click/keyboard handlers to whatever single element we hand it. A `<div>` is therefore just as activatable as a `<button>` was (mouse click, Enter, arrow-key roving), but it's a valid container for the gear `<button>` — which is now the row's only real interactive control. HeadlessUI's `MenuItems` treewalker already rejects recursion into `menuitem` subtrees, so the gear's focus/roving behaviour is unchanged.

### Why it's safe
- No change to test ids, `aria-label`s, emits (`select` / `open-settings`), slot contract, or navigation.
- The real-HeadlessUI close-behaviour regression suites (the ones guarding the original "dropdown stays open" bug) pass unchanged, as do the mocked adapter suites and the engine unit tests — **25/25** across all four scope-switcher suites.
- `vue-tsc` clean; ESLint 0 errors (only pre-existing max-len warnings on long Tailwind class strings).

### Review order
Merge #3658 first (or review this against that base); this branch contains only the one-file structural change on top of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WxiCsDnAFVC6w6xvfvFZce

---
_Generated by [Claude Code](https://claude.ai/code/session_01WxiCsDnAFVC6w6xvfvFZce)_