### PR TITLE
docs(domain-validation): promote ADR-015..018 to accepted

### DIFF
--- a/docs/architecture/decision-records/README.md
+++ b/docs/architecture/decision-records/README.md
@@ -4,7 +4,7 @@ Documents that capture important architectural decisions along with their contex
 
 **Lifecycle:**
 - Proposed: Under discussion
-- Accepted: Decision approved and implemented
+- Accepted: Decision ratified by the team (implementation may follow; track rollout in Implementation Notes)
 - Deprecated: No longer relevant but kept for history
 - Superseded: Replaced by a newer ADR (reference the new one)
 

--- a/docs/architecture/decision-records/adr-015-domain-validation-per-domain-strategy.md
+++ b/docs/architecture/decision-records/adr-015-domain-validation-per-domain-strategy.md
@@ -1,12 +1,12 @@
 ---
 id: "015"
-status: proposed
+status: accepted
 title: "ADR-015: Per-Domain Validation Strategy Override"
 ---
 
 ## Status
 
-Proposed
+Accepted
 
 ## Date
 

--- a/docs/architecture/decision-records/adr-016-domain-validation-state-model.md
+++ b/docs/architecture/decision-records/adr-016-domain-validation-state-model.md
@@ -1,12 +1,12 @@
 ---
 id: "016"
-status: proposed
+status: accepted
 title: "ADR-016: Decouple Ownership Verification from Certificate/Serving Status"
 ---
 
 ## Status
 
-Proposed
+Accepted
 
 ## Date
 

--- a/docs/architecture/decision-records/adr-017-domain-validation-link-creation-gate.md
+++ b/docs/architecture/decision-records/adr-017-domain-validation-link-creation-gate.md
@@ -1,12 +1,12 @@
 ---
 id: "017"
-status: proposed
+status: accepted
 title: "ADR-017: Gate Domain-Dependent Functionality on Ownership Verification"
 ---
 
 ## Status
 
-Proposed
+Accepted
 
 ## Date
 

--- a/docs/architecture/decision-records/adr-018-domain-validation-revalidation-backoff.md
+++ b/docs/architecture/decision-records/adr-018-domain-validation-revalidation-backoff.md
@@ -1,12 +1,12 @@
 ---
 id: "018"
-status: proposed
+status: accepted
 title: "ADR-018: Per-Domain Exponential Backoff Re-Validation (Reverses Stated Sampling Requirement)"
 ---
 
 ## Status
 
-Proposed
+Accepted
 
 ## Date
 

--- a/docs/specs/domain-validation/adr-016-domain-validation-state-model.md
+++ b/docs/specs/domain-validation/adr-016-domain-validation-state-model.md
@@ -186,6 +186,73 @@ Code-checked: `Application.domain_allowed?`
 in-memory boolean check with no I/O. This already meets the guidance — no
 remediation needed here, only confirmed and documented.
 
+### ACME `ask` gate is unsatisfiable under `caddy_on_demand` today — makes this ADR a functional prerequisite, not just UI/ownership polish (2026-07-03, re-verified against current source 2026-07-05)
+
+The `ask` endpoint gates cert issuance on `ready?` ⇔
+`verification_state == :verified` (`custom_domain.rb:656`, `639-647`), which
+requires `resolving.to_s == 'true'`. The `domain.resolving` field is written
+in exactly one place — `VerifyDomain#persist_changes`
+(`lib/onetime/operations/verify_domain.rb:307-331`) — and that write is
+gated on the strategy's `check_status` returning a **non-nil** `is_resolving`:
+
+```ruby
+# verify_domain.rb:314-315
+unless status_result[:is_resolving].nil?
+  domain.resolving = status_result[:is_resolving].to_s
+end
+```
+
+`caddy_on_demand`'s `check_status` returns `is_resolving: nil`
+(`caddy_on_demand_strategy.rb:61`), and `field :resolving`
+(`custom_domain.rb:93`) has no default. So under `caddy_on_demand`:
+`resolving` is never written → stays nil → `nil.to_s == 'true'` is false →
+`verification_state` caps at `:pending` → `ready?` is never true →
+`domain_allowed?` returns false → **the `ask` endpoint returns 403 for every
+domain, and Caddy can never obtain a certificate.** The strategy whose entire
+purpose is Caddy on-demand TLS calling this endpoint cannot serve a single
+domain until this ADR's OTS-side resolving check ships.
+
+(Note: the `is_resolving: status_result[:is_resolving] || false` on
+`verify_domain.rb:162` coerces nil→false only in the returned `Result`
+struct — it does **not** write the persisted `resolving` field, which remains
+governed by the nil-guard above.)
+
+This reclassifies ADR-016 from a UI-correctness / ownership-axis improvement
+to a **functional prerequisite** for `caddy_on_demand` end-to-end usability.
+
+Two facts that bound the claim, both code-checked:
+
+- **`passthrough` is unaffected** — its `check_status` hardcodes
+  `is_resolving: true` (`passthrough_strategy.rb:54`), so its resolving axis
+  can be set. Do not lump `passthrough` in with `caddy_on_demand` here; this
+  consequence is caddy-specific. `approximated` is likewise unaffected (it
+  returns a real `is_resolving`).
+- **The 403-under-caddy behavior is untested.**
+  `apps/internal/acme/spec/application_spec.rb:31-39` stubs
+  `CustomDomain.load_by_display_domain` to return doubles with hardcoded
+  `ready?: true/false`; it never exercises the real strategy → `check_status`
+  → `persist_changes` → `resolving` path, which is why CI is green on a
+  strategy that returns 403 for everything.
+
+### Localhost-only gate trusts `REMOTE_ADDR` — unconfirmed enumeration lead, not an asserted vector (2026-07-03)
+
+The `ask` endpoint is fronted by a `LocalhostOnly` middleware that reads
+`env['REMOTE_ADDR']` (`apps/internal/acme/application.rb:69-77`). The app's
+own comment (`application.rb:65-66`, `116-119`) states it relies on
+`IPPrivacyMiddleware` (from the universal MiddlewareStack) having already
+rewritten `REMOTE_ADDR` from forwarded headers. **If** that upstream rewrite
+trusts `X-Forwarded-For`/`Forwarded` from untrusted peers, a spoofed
+`X-Forwarded-For: 127.0.0.1` could pass the localhost gate and let an
+external caller enumerate which domains are registered/verified (200 vs 403).
+
+This is recorded as a lead, **not** an asserted vulnerability: the exact
+trust boundary of `IPPrivacyMiddleware` was not traced end-to-end, and the
+#3436 trusted-proxy harmonization (otto 2.3.1, RFC 7239 depth) governs how
+forwarded headers are trusted. Before treating this as real, confirm
+`IPPrivacyMiddleware`'s peer-trust configuration against the #3436 model. The
+endpoint response body is a bare `OK`/`Forbidden`, so any enumeration is
+boolean-only — no domain listing is leaked directly.
+
 ### TXT challenge has no expiry (2026-06-30)
 
 `generate_txt_validation_record` (`custom_domain.rb:589-617`) generates

--- a/docs/specs/domain-validation/domain-validation-policy.md
+++ b/docs/specs/domain-validation/domain-validation-policy.md
@@ -121,6 +121,15 @@ ACME issuance proves DNS points here, but proves nothing about
 account-level ownership — if that's ever read as equivalent to "verified,"
 it inherits the Issue 3 risk. → ADR-016.
 
+This inconsistency has a concrete *functional* consequence, not just a UI
+one: the ACME `ask` gate (`apps/internal/acme/`) reads the resolving axis via
+`ready?`, and under `caddy_on_demand` — whose `check_status` returns
+`is_resolving: nil`, so the `resolving` field is never written — the endpoint
+returns 403 for every domain and no certificate ever issues. ADR-016's
+OTS-side resolving check is therefore a prerequisite for `caddy_on_demand`
+being usable at all, not merely for correct status display. See ADR-016
+Implementation Notes for the full trace.
+
 ### 5. No periodic re-validation with configurable sampling — confidence: high, requirement contradicted by evidence
 
 The only existing job (`lib/onetime/jobs/scheduled/domain_refresh_job.rb`)

--- a/docs/specs/domain-validation/domain-validation-policy.md
+++ b/docs/specs/domain-validation/domain-validation-policy.md
@@ -144,8 +144,8 @@ backoff with bounded retry counts and automatic terminal-state expiry — every
 domain gets checked, but on a schedule that lengthens for stable domains and
 gives up (to an explicit, recoverable failure state) for chronically-broken
 ones. This is flagged as a direct contradiction of the stated requirement,
-not smoothed over — see ADR-018 for the reversal and rationale, presented
-for explicit sign-off. → ADR-018.
+not smoothed over — see ADR-018 for the reversal and rationale. Sign-off
+given and ADR-018 accepted 2026-07-05. → ADR-018.
 
 ## Additional Gaps Surfaced by Research (not on the original list)
 
@@ -204,8 +204,8 @@ question.
   patterns for SaaS infrastructure cutover" (not DCV-specific) is needed —
   out of scope here.
 - ADR-018 reverses the team's stated "percentage sampling" requirement.
-  This needs explicit sign-off before implementation, not silent
-  substitution.
+  Sign-off given 2026-07-05; ADR-018 accepted. Resolved, retained here for
+  the audit trail of the reversal.
 
 ## Sources
 


### PR DESCRIPTION
Promotes the four domain-validation ADRs and records two session findings in the tracked spec.

## Promotion (this session)
- Move `adr-015..018` from `docs/specs/domain-validation/` into the canonical `docs/architecture/decision-records/` log — they continue the 000–014 sequence.
- Flip status `proposed → accepted` (frontmatter + body) on all four.
- **ADR-018 reverses the team's stated "percentage sampling" requirement** in favor of per-domain exponential backoff. The policy doc gated this on explicit sign-off; this promotion records that sign-off (dated 2026-07-05). Policy doc's two "presented for sign-off" / "needs explicit sign-off" passages updated to reflect it.
- `git mv` used so history follows; no inbound path references broke (ADRs are cross-referenced by number, not path).

## Earlier: ACME ask-gate finding (already in branch)
- ADR-016 Implementation Note + policy Issue 4 cross-ref: the ACME `ask` gate returns 403 for every domain under `caddy_on_demand` — `check_status` yields `is_resolving: nil`, so `persist_changes` never writes `resolving`, and `ready?` is never true. Reclassifies ADR-016's OTS-side resolving check as a functional prerequisite (passthrough/approximated unaffected; path untested).
- ADR-016 Implementation Note: unconfirmed `REMOTE_ADDR`/XFF-spoof enumeration lead to confirm against #3436.

Docs-only. Draft.