### PR TITLE
Reduce redundant HomepageConfig reads in domain validation

### DIFF
--- a/apps/api/v1/logic/secrets/base_secret_action.rb
+++ b/apps/api/v1/logic/secrets/base_secret_action.rb
@@ -432,17 +432,24 @@ module V1::Logic
         domain_record = Onetime::CustomDomain.from_display_domain(domain)
         raise_form_error "Unknown domain: #{domain}" if domain_record.nil?
 
+        # Resolve the anonymous-creation gate once and pass it to
+        # validate_domain_permissions so the debug line and the permission check
+        # share a single HomepageConfig read instead of two (#3631). Not memoized
+        # on the domain instance: an instance cache goes stale after an in-request
+        # HomepageConfig write, which is why the model predicate stays read-through.
+        allow_public = domain_record.allow_public_secret_creation?
+
         OT.ld <<~DEBUG
           [BaseSecretAction]
             class:     #{self.class}
             share_domain:   #{@share_domain}
             custom_domain?:  #{custom_domain?}
-            allow_public?:   #{domain_record.allow_public_secret_creation?}
+            allow_public?:   #{allow_public}
             accessible?:     #{domain_record.accessible_by?(@cust)}
             verified?:       #{domain_record.verified}
         DEBUG
 
-        validate_domain_permissions(domain_record)
+        validate_domain_permissions(domain_record, allow_public)
         validate_domain_verification(domain_record)
       end
 
@@ -464,6 +471,11 @@ module V1::Logic
       # Validates domain permissions based on context and configuration.
       #
       # @param domain_record [CustomDomain] The domain record to validate
+      # @param allow_public [Boolean, nil] Pre-resolved
+      #   domain_record.allow_public_secret_creation? from the caller, to avoid
+      #   a second HomepageConfig read (#3631). nil means "not resolved yet" —
+      #   the anonymous custom-domain branch computes it on demand, so direct
+      #   callers may still pass just the record.
       # @raise [FormError] If access is not permitted
       # @see docs/specs/domain-permissions/domain-permissions.md for the full truth table
       #
@@ -473,7 +485,7 @@ module V1::Logic
       #   gates anonymous public intake only.
       # - Anonymous on a custom domain: gated by the Homepage Secrets toggle.
       # - Anonymous on canonical with share_domain set: not permitted.
-      def validate_domain_permissions(domain_record)
+      def validate_domain_permissions(domain_record, allow_public = nil)
         # Any org member can always use the domain.
         return if domain_record.accessible_by?(@cust)
 
@@ -487,7 +499,11 @@ module V1::Logic
         # AND the homepage secrets_mode — 'incoming' mode does not authorize
         # anonymous secret creation (visitors use the incoming API instead).
         if custom_domain?
-          return if domain_record.allow_public_secret_creation?
+          # Reuse the caller-resolved gate when present; recompute only for
+          # direct callers that pass just the record. Guard on nil since false
+          # is a valid pre-resolved value.
+          allow_public = domain_record.allow_public_secret_creation? if allow_public.nil?
+          return if allow_public
           raise_form_error "Public sharing disabled for domain: #{share_domain}"
         end
 

--- a/apps/api/v1/spec/logic/secrets/base_secret_action_spec.rb
+++ b/apps/api/v1/spec/logic/secrets/base_secret_action_spec.rb
@@ -410,3 +410,76 @@ RSpec.describe 'V1 BaseSecretAction validate_anonymous_share_domain' do
     end
   end
 end
+
+# ============================================================================
+# Single HomepageConfig read per request (issue #3631, PR #3665)
+#
+# Parity with V2: allow_public_secret_creation? is a read-through predicate, so
+# each call is an independent HomepageConfig lookup. validate_domain_access
+# resolves the gate once and threads it into validate_domain_permissions so the
+# debug line and the permission check share a single read instead of two.
+#
+# Regression guards: pin the read count so the double-read cannot creep back in
+# (e.g. by dropping the threaded argument).
+# ============================================================================
+RSpec.describe 'V1 BaseSecretAction HomepageConfig read count (issue #3631)' do
+  using Familia::Refinements::TimeLiterals
+
+  before(:all) { OT.boot!(:test) }
+
+  before do
+    allow(Truemail).to receive(:validate).and_return(
+      double('Validator', result: double('Result', valid?: true), as_json: '{}'),
+    )
+  end
+
+  # A non-owner public custom-domain record whose allow_public_secret_creation?
+  # we can count. accessible_by? is false so the anonymous branch consults the
+  # gate; verified 'true' clears validate_domain_verification.
+  def build_counting_domain_record(allow_public: true)
+    double('CustomDomain',
+      accessible_by?: false,
+      allow_public_secret_creation?: allow_public,
+      verified: 'true')
+  end
+
+  # Anonymous guest on a custom domain, with @share_domain seeded and the domain
+  # lookup stubbed to the counting record.
+  def build_v1_access_subject(domain_record, share_domain: 'secrets.acme.com')
+    cust = double('Customer', anonymous?: true, custid: nil, objid: nil, planid: 'anonymous')
+    sess = double('Session', anonymous?: true, custid: nil)
+    action = V1ShareDomainTestAction.new(sess, cust, { 'share_domain' => '', 'recipient' => [] })
+    action.instance_variable_set(:@share_domain, share_domain)
+    action.domain_strategy = 'custom'
+    allow(Onetime::CustomDomain).to receive(:from_display_domain)
+      .with(share_domain).and_return(domain_record)
+    action
+  end
+
+  it 'reads allow_public_secret_creation? exactly once through validate_domain_access' do
+    domain_record = build_counting_domain_record(allow_public: true)
+    subject = build_v1_access_subject(domain_record)
+
+    subject.send(:validate_domain_access, 'secrets.acme.com')
+
+    expect(domain_record).to have_received(:allow_public_secret_creation?).once
+  end
+
+  it 'does not re-read the gate inside validate_domain_permissions when the resolved value is threaded in' do
+    domain_record = build_counting_domain_record(allow_public: true)
+    subject = build_v1_access_subject(domain_record)
+
+    subject.send(:validate_domain_permissions, domain_record, true)
+
+    expect(domain_record).not_to have_received(:allow_public_secret_creation?)
+  end
+
+  it 'still resolves the gate on demand for direct callers that omit the argument' do
+    domain_record = build_counting_domain_record(allow_public: true)
+    subject = build_v1_access_subject(domain_record)
+
+    subject.send(:validate_domain_permissions, domain_record)
+
+    expect(domain_record).to have_received(:allow_public_secret_creation?).once
+  end
+end

--- a/apps/api/v2/logic/secrets/base_secret_action.rb
+++ b/apps/api/v2/logic/secrets/base_secret_action.rb
@@ -427,16 +427,28 @@ module V2::Logic
         domain_record = Onetime::CustomDomain.from_display_domain(domain)
         raise_form_error "Unknown domain: #{domain}" if domain_record.nil?
 
+        # Resolve the anonymous-creation gate once and thread it into the
+        # permission check below. Both this debug line and
+        # validate_domain_permissions consult allow_public_secret_creation?, and
+        # each call is an independent HomepageConfig read (one Redis HGETALL of
+        # the same record) — two reads per anonymous custom-domain request
+        # (#3631). Passing the resolved value down collapses that to one read
+        # WITHOUT memoizing on the CustomDomain instance: an instance memo goes
+        # stale after an in-request HomepageConfig write, which is why a prior
+        # per-instance cache was reverted and the model predicate stays
+        # read-through.
+        allow_public = domain_record.allow_public_secret_creation?
+
         secret_logger.debug 'Validating domain access',
           {
             domain: domain,
             custom_domain: custom_domain?,
-            allow_public: domain_record.allow_public_secret_creation?,
+            allow_public: allow_public,
             accessible: domain_record.accessible_by?(@cust),
             user_id: @cust&.objid,
           }
 
-        validate_domain_permissions(domain_record)
+        validate_domain_permissions(domain_record, allow_public)
         validate_domain_verification(domain_record)
       end
 
@@ -466,6 +478,11 @@ module V2::Logic
       # Validates domain permissions based on context and configuration.
       #
       # @param domain_record [CustomDomain] The domain record to validate
+      # @param allow_public [Boolean, nil] Pre-resolved
+      #   domain_record.allow_public_secret_creation? from the caller, to avoid
+      #   a second HomepageConfig read (#3631). nil means "not resolved yet" —
+      #   the anonymous custom-domain branch computes it on demand, so direct
+      #   callers (specs, other logic) may still pass just the record.
       # @raise [Onetime::Forbidden] If access is not permitted
       # @see docs/specs/domain-permissions/domain-permissions.md for the full truth table
       #
@@ -477,7 +494,7 @@ module V2::Logic
       # - Anonymous on a custom domain: gated by the Homepage Secrets toggle.
       # - Anonymous on the canonical domain (with share_domain set to a custom
       #   domain): not permitted.
-      def validate_domain_permissions(domain_record)
+      def validate_domain_permissions(domain_record, allow_public = nil)
         # Any org member can always use the domain.
         return if domain_record.accessible_by?(@cust)
 
@@ -504,7 +521,11 @@ module V2::Logic
         # form ('incoming' mode) is public but does not authorize anonymous
         # secret CREATION (visitors send secrets via the incoming API instead).
         if custom_domain?
-          return if domain_record.allow_public_secret_creation?
+          # Reuse the gate resolved by validate_domain_access when present;
+          # recompute only for direct callers that pass just the record. `false`
+          # is a valid pre-resolved value, so guard on nil, not falsiness.
+          allow_public = domain_record.allow_public_secret_creation? if allow_public.nil?
+          return if allow_public
 
           secret_logger.warn 'Public sharing disabled for domain',
             {

--- a/apps/api/v2/spec/logic/secrets/base_secret_action_spec.rb
+++ b/apps/api/v2/spec/logic/secrets/base_secret_action_spec.rb
@@ -360,6 +360,83 @@ RSpec.describe 'V2 BaseSecretAction config path bug' do
   end
 
   # ============================================================================
+  # Single HomepageConfig read per request (issue #3631, PR #3665)
+  #
+  # allow_public_secret_creation? is a read-through predicate: each call is an
+  # independent HomepageConfig lookup (a Redis HGETALL of the same record).
+  # Before #3631, validate_domain_access called it once for the debug log and
+  # validate_domain_permissions called it again for the gate — two reads per
+  # anonymous custom-domain request. The fix resolves the value once in
+  # validate_domain_access and threads it into validate_domain_permissions.
+  #
+  # These are regression guards: they pin the read count so the double-read
+  # cannot be silently reintroduced (e.g. by dropping the threaded argument).
+  # ============================================================================
+  describe 'HomepageConfig read count (issue #3631)' do
+    let(:anonymous_customer) do
+      double('Customer',
+        anonymous?: true,
+        custid: nil,
+        objid: nil,
+        planid: 'anonymous',
+        email: nil,
+        organization_instances: [])
+    end
+
+    # A domain record whose allow_public_secret_creation? we can count. It is a
+    # non-owner public custom domain, so the anonymous branch consults the gate
+    # and passes.
+    def build_counting_domain_record(allow_public: true)
+      double('CustomDomain',
+        accessible_by?: false,
+        allow_public_secret_creation?: allow_public,
+        verified: 'true')
+    end
+
+    def build_access_subject(domain_record, share_domain: 'secrets.acme.com')
+      action = V2ConfigTestAction.new(strategy_result, base_params)
+      action.instance_variable_set(:@cust, anonymous_customer)
+      action.instance_variable_set(:@share_domain, share_domain)
+      allow(action).to receive(:custom_domain?).and_return(true)
+      allow(action).to receive(:secret_logger).and_return(double('Logger').as_null_object)
+      allow(Onetime::CustomDomain).to receive(:from_display_domain)
+        .with(share_domain).and_return(domain_record)
+      action
+    end
+
+    it 'reads allow_public_secret_creation? exactly once through validate_domain_access' do
+      domain_record = build_counting_domain_record(allow_public: true)
+      subject = build_access_subject(domain_record)
+
+      subject.send(:validate_domain_access, 'secrets.acme.com')
+
+      expect(domain_record).to have_received(:allow_public_secret_creation?).once
+    end
+
+    it 'does not re-read the gate inside validate_domain_permissions when the resolved value is threaded in' do
+      domain_record = build_counting_domain_record(allow_public: true)
+      subject = build_access_subject(domain_record)
+
+      # Simulate validate_domain_access having already resolved the gate: pass
+      # the value directly. The permission check must trust it and not re-read.
+      subject.send(:validate_domain_permissions, domain_record, true)
+
+      expect(domain_record).not_to have_received(:allow_public_secret_creation?)
+    end
+
+    it 'still resolves the gate on demand for direct callers that omit the argument' do
+      # Backward-compat path: a direct caller (spec/other logic) passes only the
+      # record. The nil default triggers a single on-demand read.
+      domain_record = build_counting_domain_record(allow_public: true)
+      subject = build_access_subject(domain_record)
+
+      subject.send(:validate_domain_permissions, domain_record)
+
+      expect(domain_record).to have_received(:allow_public_secret_creation?).once
+    end
+  end
+
+  # ============================================================================
   # process_share_domain — ingestion (records the requested domain)
   #
   # process_share_domain only sanitizes and records the *requested* domain; it is


### PR DESCRIPTION
## Summary

[#3631](https://github.com/onetimesecret/onetimesecret/issues/3631)

Optimize domain validation to eliminate redundant Redis reads by resolving the `allow_public_secret_creation?` gate once in `validate_domain_access` and passing the result to `validate_domain_permissions`, rather than calling the method twice independently.

Both the debug logging and permission check were consulting `allow_public_secret_creation?`, resulting in two separate HomepageConfig reads (Redis HGETALL operations on the same record) per anonymous custom-domain request. This change collapses that to a single read by threading the resolved value through the call chain.

The implementation avoids instance-level memoization (which goes stale after in-request HomepageConfig writes) by passing the value as a parameter with a sensible default for backward compatibility with direct callers.

## Related Issues

Fixes #3631

## Test Plan

Existing tests pass. The change is a performance optimization with no behavioral changes—the same permission logic is executed, just with fewer redundant reads.

https://claude.ai/code/session_01Cws7KwuAqeVn7Zg5i9Nde9