### PR TITLE
fix(branding): stop brand logo from duplicating the custom-domain header

### DIFF
--- a/src/apps/secret/components/branded/SecretDisplayCase.vue
+++ b/src/apps/secret/components/branded/SecretDisplayCase.vue
@@ -67,9 +67,11 @@
   };
   const isCopiedText = computed(() => isCopied ? t('web.STATUS.copied') : t('web.LABELS.copy_to_clipboard') );
 
-  // Prepare the standardized path to the logo image.
-  // Note that the file extension needs to be present but is otherwise not used.
-  const logoImage = ref<string>(`/imagine/${props.domainId}/logo.png`);
+  // Brand logo for the reveal card. Use the backend-computed URL (built with
+  // the domain's public extid), not a client-side path from the internal
+  // domainId — the latter 404s, tripping @error and showing the placeholder
+  // lock icon even when a logo is configured. Null (no logo) → placeholder.
+  const logoImage = computed(() => productIdentity.logoUri);
 </script>
 
 <template>

--- a/src/apps/secret/conceal/IncomingForm.vue
+++ b/src/apps/secret/conceal/IncomingForm.vue
@@ -2,8 +2,10 @@
 
 <script setup lang="ts">
   import { computed, onMounted, ref } from 'vue';
+  import { storeToRefs } from 'pinia';
   import { useIncomingSecret } from '@/shared/composables/useIncomingSecret';
   import { useIncomingStore } from '@/shared/stores/incomingStore';
+  import { useProductIdentity } from '@/shared/stores/identityStore';
   import IncomingSecretFormBody from '@/apps/secret/components/incoming/IncomingSecretFormBody.vue';
   import LoadingOverlay from '@/shared/components/common/LoadingOverlay.vue';
   import EmptyState from '@/shared/components/ui/EmptyState.vue';
@@ -12,6 +14,16 @@
   const { t } = useI18n();
   const incomingStore = useIncomingStore();
   const { isFeatureEnabled, loadConfig } = useIncomingSecret();
+
+  // Custom-domain brand logo. The top masthead is suppressed on custom domains
+  // (see guards.routes.ts), so the page body owns the logo — mirroring
+  // BrandedHomepage. Hidden when no logo is configured or the asset 404s, so
+  // the no-logo page stays title + subtitle + form with no placeholder box.
+  const { logoUri, displayName } = storeToRefs(useProductIdentity());
+  const logoError = ref(false);
+  const handleLogoError = () => {
+    logoError.value = true;
+  };
 
   const isLoading = ref(true);
 
@@ -63,6 +75,13 @@
     <template v-else>
       <!-- Header -->
       <div class="mb-10">
+        <!-- Brand logo (custom domains) — hidden if unconfigured or 404s -->
+        <img
+          v-if="logoUri && !logoError"
+          :src="logoUri"
+          :alt="displayName"
+          class="mb-6 h-16 max-w-[200px] object-contain"
+          @error="handleLogoError" />
         <h1 class="text-3xl font-bold text-gray-900 dark:text-white sm:text-4xl">
           {{ t('incoming.page_title') }}
         </h1>

--- a/src/router/guards.routes.ts
+++ b/src/router/guards.routes.ts
@@ -34,15 +34,23 @@ export async function setupRouterGuards(router: Router): Promise<void> {
     // titleLogo in AuthView — don't override their layout props.
     if (to.meta.isAuthRoute) return true;
 
-    const hasDomainLogo = !!bootstrapStore.domain_logo;
     const existing = (to.meta.layoutProps ?? {}) as Record<string, unknown>;
 
     // Guard overrides win over route-defined static defaults.
     // Per-route beforeEnter guards run AFTER beforeEach and can
     // still override these values for route-specific needs.
+    //
+    // Masthead is always OFF on custom domains: the top masthead renders a
+    // duplicate logo/title/subtitle band, and each branded page body already
+    // owns its own centred logo + copy (BrandedHomepage, IncomingForm) or is
+    // intentionally distraction-free (secret reveal). This mirrors the
+    // custom-domain layout in public.routes.ts ("logo goes in page content").
+    // Gating it on logo presence previously produced a duplicate header on
+    // /incoming and leaked the masthead onto the reveal page whenever a brand
+    // logo was configured.
     to.meta.layoutProps = {
       ...existing,
-      displayMasthead: hasDomainLogo,
+      displayMasthead: false,
       displayNavigation: false,
       displayFooterLinks: false,
       displayFeedback: false,

--- a/src/tests/apps/secret/conceal/IncomingForm.spec.ts
+++ b/src/tests/apps/secret/conceal/IncomingForm.spec.ts
@@ -1,0 +1,103 @@
+// src/tests/apps/secret/conceal/IncomingForm.spec.ts
+//
+// Regression contract for the custom-domain /incoming page header.
+//
+// The top masthead is suppressed on custom domains (guards.routes.ts), so the
+// page body must own the brand logo. Two bugs this locks against:
+//   1. Duplicate header — when a logo was configured, the guard toggled the
+//      masthead ON, so its logo+title+subtitle rendered ABOVE IncomingForm's
+//      own title+subtitle. The page must show exactly one title block.
+//   2. Missing logo — the logo previously came only from the masthead, so
+//      suppressing the masthead must not lose it: the body renders it when a
+//      logo is configured, and hides it (no placeholder) when none is.
+
+import { flushPromises, mount } from '@vue/test-utils';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createPinia, setActivePinia } from 'pinia';
+import { ref } from 'vue';
+import { createTestI18n } from '@tests/setup';
+
+vi.mock('@/services/bootstrap.service', () => ({
+  getBootstrapSnapshot: vi.fn(() => null),
+  updateBootstrapSnapshot: vi.fn(),
+  _resetForTesting: vi.fn(),
+}));
+
+vi.mock('@/apps/secret/components/incoming/IncomingSecretFormBody.vue', () => ({
+  default: {
+    name: 'IncomingSecretFormBody',
+    template: '<div data-testid="stub-incoming-form-body" />',
+  },
+}));
+
+const loadConfigMock = vi.fn();
+const incomingSecretState = { isFeatureEnabled: ref(true) };
+
+vi.mock('@/shared/composables/useIncomingSecret', () => ({
+  useIncomingSecret: () => ({
+    isFeatureEnabled: incomingSecretState.isFeatureEnabled,
+    loadConfig: loadConfigMock,
+  }),
+}));
+
+const incomingState = { isEntitlementBlocked: false, configError: null as string | null };
+
+vi.mock('@/shared/stores/incomingStore', () => ({
+  useIncomingStore: () => ({
+    get isEntitlementBlocked() {
+      return incomingState.isEntitlementBlocked;
+    },
+    get configError() {
+      return incomingState.configError;
+    },
+  }),
+}));
+
+import { useBootstrapStore } from '@/shared/stores/bootstrapStore';
+import IncomingForm from '@/apps/secret/conceal/IncomingForm.vue';
+
+const LOGO_URL = 'https://cdn.example.com/imagine/ext123/logo.png';
+
+async function mountIncoming(domainLogo: string | null) {
+  const bootstrap = useBootstrapStore();
+  bootstrap.$patch({ domain_strategy: 'custom', domain_logo: domainLogo });
+  const wrapper = mount(IncomingForm, {
+    global: { plugins: [createTestI18n()] },
+  });
+  await flushPromises();
+  return wrapper;
+}
+
+describe('IncomingForm custom-domain header', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    loadConfigMock.mockReset().mockResolvedValue(undefined);
+    incomingSecretState.isFeatureEnabled = ref(true);
+    incomingState.isEntitlementBlocked = false;
+    incomingState.configError = null;
+  });
+
+  it('renders exactly one title block (no duplicate masthead header)', async () => {
+    const wrapper = await mountIncoming(LOGO_URL);
+
+    expect(wrapper.find('[data-testid="stub-incoming-form-body"]').exists()).toBe(true);
+    expect(wrapper.findAll('h1')).toHaveLength(1);
+    expect(wrapper.find('h1').text()).toContain('incoming.page_title');
+  });
+
+  it('renders the brand logo in the page body when a logo is configured', async () => {
+    const wrapper = await mountIncoming(LOGO_URL);
+
+    const img = wrapper.find('img');
+    expect(img.exists()).toBe(true);
+    expect(img.attributes('src')).toBe(LOGO_URL);
+  });
+
+  it('renders no logo image (and no placeholder) when no logo is configured', async () => {
+    const wrapper = await mountIncoming(null);
+
+    expect(wrapper.find('img').exists()).toBe(false);
+    // Title still renders — the no-logo page is title + subtitle + form.
+    expect(wrapper.findAll('h1')).toHaveLength(1);
+  });
+});

--- a/src/tests/router/guards.routes.spec.ts
+++ b/src/tests/router/guards.routes.spec.ts
@@ -218,13 +218,16 @@ describe('Router Guards', () => {
       guard(to);
       const layoutProps = to.meta.layoutProps as Record<string, unknown>;
       expect(layoutProps).toBeDefined();
-      expect(layoutProps.displayMasthead).toBe(true);
+      // Masthead is always off on custom domains, even with a logo configured:
+      // the page body owns the logo. Gating it on logo presence duplicated the
+      // /incoming header and leaked the masthead onto the reveal page.
+      expect(layoutProps.displayMasthead).toBe(false);
       expect(layoutProps.displayNavigation).toBe(false);
       expect(layoutProps.displayFooterLinks).toBe(false);
       expect(layoutProps.displayFeedback).toBe(false);
     });
 
-    it('sets displayMasthead to false when custom domain has no logo', () => {
+    it('keeps displayMasthead false when custom domain has no logo', () => {
       const bootstrapStore = useBootstrapStore();
       bootstrapStore.$patch({ domain_strategy: 'custom', domain_logo: null });
 


### PR DESCRIPTION
On custom domains the top masthead is force-OFF; each page body owns its own logo. The masthead visibility had been tied to `hasDomainLogo`, so branded domains rendered both the masthead logo and the page-body logo — a duplicate header.

## Changes
- `guards.routes.ts`: masthead is now unconditionally OFF on custom domains (decoupled from `hasDomainLogo`).
- `IncomingForm.vue`: restore the page-body logo so the incoming (Incoming Secrets) flow still shows branding.
- `SecretDisplayCase.vue`: fix the reveal-card logo placeholder.
- Tests: new `IncomingForm.spec.ts`; updated `guards.routes.spec.ts`.

## Test
332 frontend tests pass.