### PR TITLE
fix(receipt): guard state transitions with atomic CAS to stop TTL-evicted resurrection (#3625)

### DIFF
--- a/apps/api/v2/spec/logic/secrets/state_backward_compat_spec.rb
+++ b/apps/api/v2/spec/logic/secrets/state_backward_compat_spec.rb
@@ -60,8 +60,11 @@ RSpec.describe 'V2 API State Backward Compatibility' do
       end
     end
 
-    context 'when previewed (new internal state)' do
-      before { receipt.previewed! }
+    context 'when previewed (telemetry-derived, #3633)' do
+      # previewed! was retired: viewing a link no longer mutates lifecycle
+      # state. A receipt now reads as "previewed" once its link has been
+      # fetched, i.e. once an access-timeline event exists.
+      before { receipt.record_access_event('secret_get') }
 
       it 'viewed timestamp is populated' do
         dump = receipt.safe_dump
@@ -117,7 +120,7 @@ RSpec.describe 'V2 API State Backward Compatibility' do
 
     context 'when previewed then revealed' do
       before do
-        receipt.previewed!
+        receipt.record_access_event('secret_get')
         @viewed_timestamp = receipt.safe_dump[:viewed]
         receipt.revealed!
       end
@@ -151,22 +154,10 @@ RSpec.describe 'V2 API State Backward Compatibility' do
       receipt.destroy! if receipt.exists?
     end
 
-    describe '#previewed!' do
-      it 'sets state and timestamp' do
-        receipt.previewed!
-        expect(receipt.state).to eq('previewed').or eq('viewed')
-        # Check the new canonical field (safe_dump provides backward compat for :viewed)
-        expect(receipt.previewed.to_i).to be > 0
-      end
-
-      it 'only transitions from :new state' do
-        receipt.state = 'burned'
-        receipt.save
-        receipt.previewed!
-        # Should not change since guard prevents it
-        expect(receipt.state).to eq('burned')
-      end
-    end
+    # #previewed! was retired in #3633: viewing a secret link no longer mutates
+    # lifecycle state. The telemetry-derived "previewed" signal (is_viewed /
+    # viewed timestamp) is covered by the safe_dump contexts above; the
+    # receipt-page-view audit event is covered in organization_audit_trail_spec.
 
     describe '#revealed!' do
       it 'sets state and timestamp' do
@@ -186,8 +177,13 @@ RSpec.describe 'V2 API State Backward Compatibility' do
         expect(receipt.state?(:revealed) || receipt.state?(:received)).to be true
       end
 
-      it 'transitions from :previewed state' do
-        receipt.previewed!
+      it 'transitions from a legacy :previewed state' do
+        # :previewed remains an accepted reveal from-state for legacy receipts
+        # even though no method advances into it anymore (#3633); the CAS still
+        # allows new -> revealed and previewed -> revealed, so construct the
+        # legacy precondition directly.
+        receipt.state = 'previewed'
+        receipt.save
         receipt.revealed!
         expect(receipt.state?(:revealed) || receipt.state?(:received)).to be true
       end
@@ -211,19 +207,9 @@ RSpec.describe 'V2 API State Backward Compatibility' do
       secret.destroy! if secret&.respond_to?(:exists?) && secret.exists?
     end
 
-    describe '#previewed!' do
-      it 'transitions from :new to previewed' do
-        secret.previewed!
-        expect(secret.state?(:previewed) || secret.state?(:viewed)).to be true
-      end
-
-      it 'is idempotent (calling twice is safe)' do
-        secret.previewed!
-        first_state = secret.state
-        secret.previewed!
-        expect(secret.state).to eq(first_state)
-      end
-    end
+    # #previewed! was retired in #3633; a secret no longer advances to a
+    # 'previewed' state on access. Only :new and (legacy) :previewed remain
+    # accepted reveal from-states, exercised below.
 
     describe '#revealed!' do
       it 'transitions from :new and destroys secret' do
@@ -231,8 +217,10 @@ RSpec.describe 'V2 API State Backward Compatibility' do
         expect(secret.state?(:revealed) || secret.state?(:received)).to be true
       end
 
-      it 'transitions from :previewed and destroys secret' do
-        secret.previewed!
+      it 'transitions from a legacy :previewed state and destroys secret' do
+        # See note above: construct the legacy :previewed precondition directly.
+        secret.state = 'previewed'
+        secret.save
         secret.revealed!
         expect(secret.state?(:revealed) || secret.state?(:received)).to be true
       end

--- a/apps/api/v2/spec/models/organization_audit_trail_spec.rb
+++ b/apps/api/v2/spec/models/organization_audit_trail_spec.rb
@@ -150,8 +150,8 @@ RSpec.describe Onetime::Organization, type: :integration do
     before { link_to_org!(receipt, org) }
 
     it 'records the receipt view exactly once, under its unambiguous audit kind' do
-      receipt.previewed!
-      receipt.previewed! # guard: state is no longer :new
+      receipt.record_receipt_view!
+      receipt.record_receipt_view! # guard: claim_once! already stamped receipt_viewed_at
 
       # 'preview' is UI language; the trail records what mechanically
       # happened: the receipt page was loaded.

--- a/docs/architecture/encryption-at-rest-dpa-audit.md
+++ b/docs/architecture/encryption-at-rest-dpa-audit.md
@@ -128,8 +128,9 @@ the empty-passphrase preview never accrues attempts.
 Reveal used to load → check `viewable?` → decrypt → `destroy!` with no
 WATCH/Lua/lock, so two concurrent requests inside the window could both
 receive plaintext. `Secret#revealed!`/`#burned!` now perform a Lua
-compare-and-set on the `state` field (`STATE_CAS_SCRIPT` in
-`secret_state_management.rb`), and the plaintext-returning `#reveal!`
+compare-and-set on the `state` field (`STATE_CAS_SCRIPT` in the shared
+`state_cas` feature, `lib/onetime/models/features/state_cas.rb`, used by both
+Secret and Receipt), and the plaintext-returning `#reveal!`
 decrypts only inside the won claim, so a losing racer never computes it.
 All read/burn controllers gate their success path and counters on the
 claim's return value.

--- a/lib/onetime/models/features/state_cas.rb
+++ b/lib/onetime/models/features/state_cas.rb
@@ -1,0 +1,91 @@
+# lib/onetime/models/features/state_cas.rb
+#
+# frozen_string_literal: true
+
+module Onetime
+  module Models
+    module Features
+      # Atomic compare-and-set on a Horreum model's +state+ field.
+      #
+      # This is the single concurrency primitive behind every lifecycle state
+      # transition on both Secret and Receipt. Redis runs the Lua script inside
+      # its single-threaded command loop, so of any number of racing callers
+      # exactly one observes an allowed +from+ value and flips it -- there is no
+      # read-modify-write window in which two callers can both advance the same
+      # record.
+      #
+      # It fails closed. A missing key (destroyed, or TTL-evicted) makes HGET
+      # yield a Lua +false+ that matches no +from+ value, so the claim loses and
+      # nothing is written -- a gone record is never resurrected as a TTL-less
+      # "immortal" key (#3625). An already-advanced state also matches nothing,
+      # so a stale instance can never revert a terminal record. The single
+      # winner's HSET lands on the confirmed-live key, leaving its TTL untouched.
+      #
+      # Secret and Receipt each grew their own byte-identical copy of this
+      # primitive (SecretStateManagement and DeprecatedFields); this feature is
+      # the shared home so both models transition through one audited idiom. Each
+      # model's transition methods still live in their own feature and document
+      # what their individual guards protect; this feature owns only the
+      # mechanism.
+      #
+      # Enable with +feature :state_cas+. Requires a +state+ field and the
+      # Horreum base methods +dbclient+/+dbkey+/+serialize_value+.
+      #
+      # TODO: Replace with a transaction (MULTI/EXEC) once the follow-up field
+      # writes each transition performs can be folded into the same atomic unit.
+      module StateCas
+        Familia::Base.add_feature self, :state_cas
+
+        def self.included(base)
+          OT.ld "[features] #{base}: #{name}"
+          base.include InstanceMethods
+        end
+
+        module InstanceMethods
+          # Lua compare-and-set on the +state+ field, run atomically by Redis.
+          # Sets state to ARGV[1] iff the current value equals one of ARGV[2..].
+          # Returns 1 to the single caller that performs the flip, 0 to everyone
+          # else -- including when the key/field is gone (HGET yields a Lua false
+          # that matches nothing) and when the state has already advanced.
+          STATE_CAS_SCRIPT = <<~LUA
+            local current = redis.call('HGET', KEYS[1], 'state')
+            for i = 2, #ARGV do
+              if current == ARGV[i] then
+                redis.call('HSET', KEYS[1], 'state', ARGV[1])
+                return 1
+              end
+            end
+            return 0
+          LUA
+
+          private
+
+          # Atomically transition the persisted +state+ field from one of
+          # +from_states+ to +to_state+, returning whether THIS caller performed
+          # the flip. See the module comment for the atomicity and fail-closed
+          # guarantees; each transition method documents what its own guard
+          # protects.
+          #
+          # Operands are produced with #serialize_value so they match how +state+
+          # is encoded at rest (Familia JSON-encodes scalar fields for type
+          # preservation), rather than hard-coding the on-disk representation
+          # here. The eval uses the keyword +keys:+/+argv:+ form (the convention
+          # used elsewhere, e.g. claim_once! and the rate limiters) so it does
+          # not depend on positional-argument compatibility across Redis client
+          # versions.
+          #
+          # @param to_state [Symbol, String] state to set on success.
+          # @param from_states [Array<Symbol, String>] states the flip may fire
+          #   from.
+          # @return [Boolean] true iff this caller performed the transition.
+          def compare_and_set_state!(to_state, from_states)
+            argv = [serialize_value(to_state.to_s)]
+            from_states.each { |from_state| argv << serialize_value(from_state.to_s) }
+
+            dbclient.eval(STATE_CAS_SCRIPT, keys: [dbkey], argv: argv).to_i == 1
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/onetime/models/features/state_cas.rb
+++ b/lib/onetime/models/features/state_cas.rb
@@ -36,28 +36,32 @@ module Onetime
       module StateCas
         Familia::Base.add_feature self, :state_cas
 
+        # Lua compare-and-set on the +state+ field, run atomically by Redis.
+        # Sets state to ARGV[1] iff the current value equals one of ARGV[2..].
+        # Returns 1 to the single caller that performs the flip, 0 to everyone
+        # else -- including when the key/field is gone (HGET yields a Lua false
+        # that matches nothing) and when the state has already advanced.
+        #
+        # Held at the module level (not inside InstanceMethods) so it is
+        # reachable as StateCas::STATE_CAS_SCRIPT for discovery and so a future
+        # SCRIPT LOAD / EVALSHA path has a single canonical source to hash.
+        STATE_CAS_SCRIPT = <<~LUA
+          local current = redis.call('HGET', KEYS[1], 'state')
+          for i = 2, #ARGV do
+            if current == ARGV[i] then
+              redis.call('HSET', KEYS[1], 'state', ARGV[1])
+              return 1
+            end
+          end
+          return 0
+        LUA
+
         def self.included(base)
           OT.ld "[features] #{base}: #{name}"
           base.include InstanceMethods
         end
 
         module InstanceMethods
-          # Lua compare-and-set on the +state+ field, run atomically by Redis.
-          # Sets state to ARGV[1] iff the current value equals one of ARGV[2..].
-          # Returns 1 to the single caller that performs the flip, 0 to everyone
-          # else -- including when the key/field is gone (HGET yields a Lua false
-          # that matches nothing) and when the state has already advanced.
-          STATE_CAS_SCRIPT = <<~LUA
-            local current = redis.call('HGET', KEYS[1], 'state')
-            for i = 2, #ARGV do
-              if current == ARGV[i] then
-                redis.call('HSET', KEYS[1], 'state', ARGV[1])
-                return 1
-              end
-            end
-            return 0
-          LUA
-
           private
 
           # Atomically transition the persisted +state+ field from one of

--- a/lib/onetime/models/receipt.rb
+++ b/lib/onetime/models/receipt.rb
@@ -19,6 +19,7 @@ module Onetime
     feature :relationships
     feature :required_fields
     feature :housekeeping
+    feature :state_cas
     feature :deprecated_fields
 
     # Migration features - REMOVE after v1→v2 migration complete

--- a/lib/onetime/models/receipt/features/deprecated_fields.rb
+++ b/lib/onetime/models/receipt/features/deprecated_fields.rb
@@ -271,9 +271,8 @@ module Onetime::Receipt::Features
         truncate.to_s == 'true'
       end
 
-      # The atomic +state+ compare-and-set every transition above claims through
-      # (+compare_and_set_state!+) is provided by the shared +state_cas+ feature;
-      # see Onetime::Models::Features::StateCas.
+      # See Onetime::Models::Features::StateCas for +compare_and_set_state!+,
+      # the shared atomic guard each transition above claims through.
     end
   end
 end

--- a/lib/onetime/models/receipt/features/deprecated_fields.rb
+++ b/lib/onetime/models/receipt/features/deprecated_fields.rb
@@ -116,16 +116,37 @@ module Onetime::Receipt::Features
       # we pass update_expiration: false to save so that changing this receipt
       # object's state doesn't affect its original expiration time.
       #
+      # Every transition is gated by an atomic compare-and-set on the persisted
+      # +state+ field ({#compare_and_set_state!}) so it FAILS CLOSED. If the
+      # receipt's Redis key was TTL-evicted between the time this instance was
+      # loaded and the time the transition runs, the CAS's HGET matches nothing,
+      # the claim loses, and the unconditional `save` never fires -- so an
+      # evicted receipt is not resurrected as a TTL-less "immortal" key (#3625).
+      # If a concurrent caller already advanced the state, the CAS also loses, so
+      # a stale instance can never revert an already-terminal receipt. Only the
+      # caller that wins the claim persists the accompanying fields and emits the
+      # log/audit side effects.
+      #
+      # The winner's follow-up field writes still go through
+      # `save update_expiration: false` so advancing state never resets the
+      # receipt's original expiration. That write lands on the key the CAS just
+      # confirmed exists, so an HSET/HMSET on a live key leaves its TTL untouched
+      # -- exactly the guarantee `update_expiration: false` was approximating.
+      #
       # TODO: Replace with transaction (i.e. MULTI/EXEC command)
 
       # MIGRATION NOTE: Replaces legacy `received!` method.
       # - Sets state to 'revealed' (was 'received')
       # - Sets `revealed` timestamp (legacy `received` kept for backward compat in safe_dump)
       # - Clears secret_identifier
+      #
+      # @return [Boolean, nil] true if THIS caller performed the transition;
+      #   a falsy value if the in-memory guard or the atomic claim lost.
       def revealed!
-        # A guard to allow only a fresh secret to be revealed. Also ensures
-        # that we don't support going from revealed back to something else.
+        # In-memory fast-path: short-circuit an already-terminal instance before
+        # touching Redis. The authoritative, resurrection-proof guard is the CAS.
         return unless state?(:new) || state?(:previewed)
+        return unless compare_and_set_state!(:revealed, [:new, :previewed])
 
         previous_state         = state
         original_secret_id     = secret_identifier
@@ -144,6 +165,7 @@ module Onetime::Receipt::Features
           }
 
         record_org_audit_event('revealed')
+        true
       end
 
       # We use this method in special cases where a receipt record exists with
@@ -156,6 +178,7 @@ module Onetime::Receipt::Features
         return if secret_identifier.to_s.empty?
         # Only new or previewed secrets can be orphaned (was state?(:viewed))
         return unless state?(:new) || state?(:previewed)
+        return unless compare_and_set_state!(:orphaned, [:new, :previewed])
 
         previous_state         = state
         original_secret_id     = secret_identifier
@@ -174,11 +197,13 @@ module Onetime::Receipt::Features
           }
 
         record_org_audit_event('orphaned')
+        true
       end
 
       def burned!
         # See guard comment on `revealed!` (was `received!`)
         return unless state?(:new) || state?(:previewed)
+        return unless compare_and_set_state!(:burned, [:new, :previewed])
 
         previous_state         = state
         original_secret_id     = secret_identifier
@@ -197,6 +222,7 @@ module Onetime::Receipt::Features
           }
 
         record_org_audit_event('burned')
+        true
       end
 
       def expired!
@@ -209,6 +235,7 @@ module Onetime::Receipt::Features
         # so every later view of an expired receipt re-ran the transition
         # (redundant save, duplicate logs, duplicate audit events).
         return unless state?(:new) || state?(:previewed)
+        return unless compare_and_set_state!(:expired, [:new, :previewed])
 
         previous_state         = state
         original_secret_id     = secret_identifier
@@ -230,6 +257,7 @@ module Onetime::Receipt::Features
           }
 
         record_org_audit_event('expired')
+        true
       end
 
       def state?(guess)
@@ -241,6 +269,56 @@ module Onetime::Receipt::Features
 
       def truncated?
         truncate.to_s == 'true'
+      end
+
+      # Lua compare-and-set on the +state+ field, run atomically by Redis (its
+      # command loop is single-threaded). Sets state to ARGV[1] iff the current
+      # value equals one of ARGV[2..]. Returns 1 to the single caller that
+      # performs the flip, 0 to everyone else -- including when the key/field is
+      # gone (HGET yields a Lua false that matches nothing, so a TTL-evicted
+      # receipt is never resurrected) and when the state has already advanced
+      # (so a terminal receipt is never reverted). This mirrors the Secret's
+      # STATE_CAS_SCRIPT (SecretStateManagement) so both models share one
+      # concurrency idiom.
+      STATE_CAS_SCRIPT = <<~LUA
+        local current = redis.call('HGET', KEYS[1], 'state')
+        for i = 2, #ARGV do
+          if current == ARGV[i] then
+            redis.call('HSET', KEYS[1], 'state', ARGV[1])
+            return 1
+          end
+        end
+        return 0
+      LUA
+
+      private
+
+      # Atomically transition the persisted +state+ field from one of
+      # +from_states+ to +to_state+, returning whether THIS caller performed the
+      # flip. This is the single concurrency primitive behind every receipt state
+      # transition; each transition documents what its own guard protects.
+      #
+      # Because Redis runs the Lua script atomically, of any number of racing
+      # callers exactly one observes an allowed +from+ value and flips it. It
+      # fails closed: a missing key (TTL-evicted) or an already-advanced state
+      # simply loses, so a transition can neither resurrect an immortal, TTL-less
+      # receipt (#3625) nor revert a terminal one. On a win, the HSET lands on
+      # the live key, preserving its TTL.
+      #
+      # Operands are produced with #serialize_value so they match how +state+ is
+      # encoded at rest (Familia JSON-encodes scalar fields), and the eval uses
+      # the keyword +keys:+/+argv:+ form (as in claim_once! and the Secret CAS)
+      # so it does not depend on positional-argument compatibility across Redis
+      # client versions.
+      #
+      # @param to_state [Symbol, String] state to set on success.
+      # @param from_states [Array<Symbol, String>] states the flip may fire from.
+      # @return [Boolean] true iff this caller performed the transition.
+      def compare_and_set_state!(to_state, from_states)
+        argv = [serialize_value(to_state.to_s)]
+        from_states.each { |from_state| argv << serialize_value(from_state.to_s) }
+
+        dbclient.eval(STATE_CAS_SCRIPT, keys: [dbkey], argv: argv).to_i == 1
       end
     end
   end

--- a/lib/onetime/models/receipt/features/deprecated_fields.rb
+++ b/lib/onetime/models/receipt/features/deprecated_fields.rb
@@ -271,55 +271,9 @@ module Onetime::Receipt::Features
         truncate.to_s == 'true'
       end
 
-      # Lua compare-and-set on the +state+ field, run atomically by Redis (its
-      # command loop is single-threaded). Sets state to ARGV[1] iff the current
-      # value equals one of ARGV[2..]. Returns 1 to the single caller that
-      # performs the flip, 0 to everyone else -- including when the key/field is
-      # gone (HGET yields a Lua false that matches nothing, so a TTL-evicted
-      # receipt is never resurrected) and when the state has already advanced
-      # (so a terminal receipt is never reverted). This mirrors the Secret's
-      # STATE_CAS_SCRIPT (SecretStateManagement) so both models share one
-      # concurrency idiom.
-      STATE_CAS_SCRIPT = <<~LUA
-        local current = redis.call('HGET', KEYS[1], 'state')
-        for i = 2, #ARGV do
-          if current == ARGV[i] then
-            redis.call('HSET', KEYS[1], 'state', ARGV[1])
-            return 1
-          end
-        end
-        return 0
-      LUA
-
-      private
-
-      # Atomically transition the persisted +state+ field from one of
-      # +from_states+ to +to_state+, returning whether THIS caller performed the
-      # flip. This is the single concurrency primitive behind every receipt state
-      # transition; each transition documents what its own guard protects.
-      #
-      # Because Redis runs the Lua script atomically, of any number of racing
-      # callers exactly one observes an allowed +from+ value and flips it. It
-      # fails closed: a missing key (TTL-evicted) or an already-advanced state
-      # simply loses, so a transition can neither resurrect an immortal, TTL-less
-      # receipt (#3625) nor revert a terminal one. On a win, the HSET lands on
-      # the live key, preserving its TTL.
-      #
-      # Operands are produced with #serialize_value so they match how +state+ is
-      # encoded at rest (Familia JSON-encodes scalar fields), and the eval uses
-      # the keyword +keys:+/+argv:+ form (as in claim_once! and the Secret CAS)
-      # so it does not depend on positional-argument compatibility across Redis
-      # client versions.
-      #
-      # @param to_state [Symbol, String] state to set on success.
-      # @param from_states [Array<Symbol, String>] states the flip may fire from.
-      # @return [Boolean] true iff this caller performed the transition.
-      def compare_and_set_state!(to_state, from_states)
-        argv = [serialize_value(to_state.to_s)]
-        from_states.each { |from_state| argv << serialize_value(from_state.to_s) }
-
-        dbclient.eval(STATE_CAS_SCRIPT, keys: [dbkey], argv: argv).to_i == 1
-      end
+      # The atomic +state+ compare-and-set every transition above claims through
+      # (+compare_and_set_state!+) is provided by the shared +state_cas+ feature;
+      # see Onetime::Models::Features::StateCas.
     end
   end
 end

--- a/lib/onetime/models/secret.rb
+++ b/lib/onetime/models/secret.rb
@@ -20,6 +20,7 @@ module Onetime
     feature :required_fields
     feature :encrypted_fields
     feature :transient_fields
+    feature :state_cas
     feature :secret_state_management
     feature :passphrase_hashing
     feature :deprecated_fields

--- a/lib/onetime/models/secret/features/secret_state_management.rb
+++ b/lib/onetime/models/secret/features/secret_state_management.rb
@@ -118,25 +118,11 @@ module Onetime::Secret::Features
       # Backward compatibility aliases for legacy method names
       alias received! revealed!
 
-      # Lua compare-and-set on the +state+ field, run atomically by Redis (its
-      # command loop is single-threaded). Sets state to ARGV[1] iff the current
-      # value equals one of ARGV[2..]. Returns 1 to the single caller that
-      # performs the flip, 0 to everyone else -- including when the key/field is
-      # gone (HGET yields a Lua false that matches nothing, so a destroyed
-      # record is never resurrected) and when the state has already advanced
-      # (so a terminal state is never reverted).
-      STATE_CAS_SCRIPT = <<~LUA
-        local current = redis.call('HGET', KEYS[1], 'state')
-        for i = 2, #ARGV do
-          if current == ARGV[i] then
-            redis.call('HSET', KEYS[1], 'state', ARGV[1])
-            return 1
-          end
-        end
-        return 0
-      LUA
-
       private
+
+      # The atomic +state+ compare-and-set these transitions claim through
+      # (+compare_and_set_state!+) is provided by the shared +state_cas+
+      # feature; see Onetime::Models::Features::StateCas.
 
       # Atomic claim shared by {#revealed!} and {#reveal!}. Returns true iff
       # THIS caller won the one-and-only reveal. This is the recipient-reveal
@@ -188,41 +174,6 @@ module Onetime::Secret::Features
         @ciphertext      = nil
         @passphrase_temp = nil
         destroy!
-      end
-
-      # Atomically transition the persisted +state+ field from one of
-      # +from_states+ to +to_state+, returning whether THIS caller performed
-      # the flip. This is the single concurrency primitive behind every state
-      # transition on a Secret; each caller documents what its own transition
-      # guards against.
-      #
-      # Because Redis executes the Lua script atomically, of any number of
-      # racing callers exactly one observes an allowed +from+ value and flips
-      # it. This is the same compare-and-set idiom Familia's
-      # {Familia::Lock#release} uses, reached through the connection resolver
-      # via +dbclient+ -- but on the record's own +state+ field rather than a
-      # separate lock key, so there is no second key, no TTL, and no expiry
-      # window where a slow critical section outlives the lock and a second
-      # caller slips in. It fails closed: a missing key (destroyed) or an
-      # already-advanced state simply loses, so the transition can neither
-      # resurrect nor revert a record.
-      #
-      # Operands are produced with #serialize_value so they match how +state+
-      # is encoded at rest (Familia JSON-encodes scalar fields for type
-      # preservation), rather than hard-coding the on-disk representation here.
-      # The eval uses the keyword +keys:+/+argv:+ form (the convention used
-      # elsewhere in the codebase, e.g. error_handler and the rate limiters) so
-      # it does not depend on positional-argument compatibility across Redis
-      # client versions.
-      #
-      # @param to_state [Symbol, String] state to set on success.
-      # @param from_states [Array<Symbol, String>] states the flip may fire from.
-      # @return [Boolean] true iff this caller performed the transition.
-      def compare_and_set_state!(to_state, from_states)
-        argv = [serialize_value(to_state.to_s)]
-        from_states.each { |state| argv << serialize_value(state.to_s) }
-
-        dbclient.eval(STATE_CAS_SCRIPT, keys: [dbkey], argv: argv).to_i == 1
       end
     end
   end

--- a/try/unit/models/receipt_ttl_resurrection_race_try.rb
+++ b/try/unit/models/receipt_ttl_resurrection_race_try.rb
@@ -54,6 +54,17 @@ result = receipt.orphaned!
 [!!result, receipt.dbclient.exists(receipt.dbkey)]
 #=> [false, 0]
 
+## expired! on a TTL-evicted key also fails closed. Unlike its siblings this
+## transition first clears the secret_expired? time gate; back-dating the
+## in-memory created stamp puts secret_expiration in the past so that gate
+## passes -- proving the CAS, not the guard, is what stops the resurrection.
+receipt, _secret = Onetime::Receipt.spawn_pair('anon', 3600, 'content')
+receipt.created = 1                          # force secret_expiration into the past
+receipt.dbclient.del(receipt.dbkey)          # simulate TTL eviction
+result = receipt.expired!
+[receipt.secret_expired?, !!result, receipt.dbclient.exists(receipt.dbkey)]
+#=> [true, false, 0]
+
 ## A live revealed! still works: returns true, persists state=revealed, clears
 ## the secret_identifier, and PRESERVES the original TTL (never resets it).
 receipt, _secret = Onetime::Receipt.spawn_pair('anon', 3600, 'content')

--- a/try/unit/models/receipt_ttl_resurrection_race_try.rb
+++ b/try/unit/models/receipt_ttl_resurrection_race_try.rb
@@ -13,7 +13,8 @@
 # hash with NO TTL -- an immortal receipt, re-registered in the instances index.
 #
 # The transitions now gate on an atomic compare-and-set on the persisted `state`
-# field (DeprecatedFields#compare_and_set_state!). It FAILS CLOSED: a missing
+# field (the shared state_cas feature's #compare_and_set_state!). It FAILS
+# CLOSED: a missing
 # key's HGET matches nothing so the claim loses and nothing is recreated; an
 # already-advanced state also loses so a terminal receipt is never reverted. The
 # winner's HSET lands on the live key, preserving its TTL.

--- a/try/unit/models/receipt_ttl_resurrection_race_try.rb
+++ b/try/unit/models/receipt_ttl_resurrection_race_try.rb
@@ -1,0 +1,89 @@
+# try/unit/models/receipt_ttl_resurrection_race_try.rb
+#
+# frozen_string_literal: true
+
+# Regression tryouts for the immortal-receipt resurrection bug (#3625).
+#
+# Receipt state transitions (revealed!, orphaned!, burned!, expired!) persist
+# via `save update_expiration: false` so that advancing state never resets a
+# receipt's original expiration. But `save` issues an unconditional HMSET, and
+# HMSET on a MISSING key CREATES it. If the receipt's Redis key was TTL-evicted
+# between the time an instance was loaded and the time a transition runs, the
+# in-memory `state?(:new)` fast-path still passed and the old save recreated the
+# hash with NO TTL -- an immortal receipt, re-registered in the instances index.
+#
+# The transitions now gate on an atomic compare-and-set on the persisted `state`
+# field (DeprecatedFields#compare_and_set_state!). It FAILS CLOSED: a missing
+# key's HGET matches nothing so the claim loses and nothing is recreated; an
+# already-advanced state also loses so a terminal receipt is never reverted. The
+# winner's HSET lands on the live key, preserving its TTL.
+#
+# These tryouts reproduce the eviction window (DEL the key while an in-memory
+# instance still believes it is :new) and assert the fail-closed outcome.
+
+require_relative '../../support/test_models'
+
+OT.boot! :test, true
+
+## A fresh receipt has a positive TTL.
+receipt, _secret = Onetime::Receipt.spawn_pair('anon', 3600, 'content')
+receipt.dbclient.ttl(receipt.dbkey).positive?
+#=> true
+
+## revealed! on a TTL-evicted key does NOT resurrect it (no immortal receipt).
+## The loaded instance still believes state?(:new), so the old unconditional
+## save would have recreated a TTL-less hash; the CAS makes it fail closed.
+receipt, _secret = Onetime::Receipt.spawn_pair('anon', 3600, 'content')
+receipt.dbclient.del(receipt.dbkey)          # simulate TTL eviction
+result = receipt.revealed!
+[!!result, receipt.dbclient.exists(receipt.dbkey), receipt.dbclient.ttl(receipt.dbkey)]
+#=> [false, 0, -2]
+
+## burned! on a TTL-evicted key also fails closed.
+receipt, _secret = Onetime::Receipt.spawn_pair('anon', 3600, 'content')
+receipt.dbclient.del(receipt.dbkey)
+result = receipt.burned!
+[!!result, receipt.dbclient.exists(receipt.dbkey)]
+#=> [false, 0]
+
+## orphaned! on a TTL-evicted key also fails closed.
+receipt, _secret = Onetime::Receipt.spawn_pair('anon', 3600, 'content')
+receipt.dbclient.del(receipt.dbkey)
+result = receipt.orphaned!
+[!!result, receipt.dbclient.exists(receipt.dbkey)]
+#=> [false, 0]
+
+## A live revealed! still works: returns true, persists state=revealed, clears
+## the secret_identifier, and PRESERVES the original TTL (never resets it).
+receipt, _secret = Onetime::Receipt.spawn_pair('anon', 3600, 'content')
+before_ttl = receipt.dbclient.ttl(receipt.dbkey)
+won        = receipt.revealed!
+reloaded   = Onetime::Receipt.load(receipt.objid)
+after_ttl  = receipt.dbclient.ttl(receipt.dbkey)
+[won, reloaded.state.to_s, reloaded.secret_identifier.to_s.empty?, after_ttl.positive? && after_ttl <= before_ttl]
+#=> [true, 'revealed', true, true]
+
+## No state reversion: a stale :new instance loses to an already-advanced
+## persisted state, so a terminal receipt is never rolled back.
+receipt, _secret = Onetime::Receipt.spawn_pair('anon', 3600, 'content')
+stale    = Onetime::Receipt.load(receipt.objid)  # in-memory state is :new
+receipt.burned!                                   # another caller advances it
+reverted = stale.revealed!                        # stale tries to revert
+[!!reverted, Onetime::Receipt.load(receipt.objid).state.to_s]
+#=> [false, 'burned']
+
+## True concurrency: many threads race revealed! on separately-loaded instances
+## of one receipt. Redis runs the Lua claim atomically, so exactly one wins.
+receipt, _secret = Onetime::Receipt.spawn_pair('anon', 3600, 'content')
+instances = Array.new(8) { Onetime::Receipt.load(receipt.objid) }
+outcomes  = instances.map { |r| Thread.new { r.revealed! } }.map(&:value)
+[outcomes.count { |o| o }, Onetime::Receipt.load(receipt.objid).state.to_s]
+#=> [1, 'revealed']
+
+## A double revealed! transitions once: the second call loses the CAS (state
+## already advanced) and returns falsy without re-firing side effects.
+receipt, _secret = Onetime::Receipt.spawn_pair('anon', 3600, 'content')
+first  = receipt.revealed!
+second = Onetime::Receipt.load(receipt.objid).revealed!
+[!!first, !!second]
+#=> [true, false]


### PR DESCRIPTION
Receipt state transitions (revealed!, orphaned!, burned!, expired!)
persisted via `save update_expiration: false`, which issues an
unconditional HMSET. HMSET on a missing key CREATES it, and with the
EXPIRE step suppressed the recreated hash had no TTL. If a receipt's
Redis key was TTL-evicted between load and transition, the in-memory
`state?(:new)` fast-path still passed and the save resurrected the hash
as an immortal (TTL-less) key, re-registering it in receipt:instances.
A stale instance could likewise revert an already-advanced state.

Gate each transition on an atomic compare-and-set on the persisted
`state` field, mirroring the Secret STATE_CAS_SCRIPT from #3615. The
Lua HGET matches nothing on a missing key, so the claim fails closed:
an evicted receipt is never recreated and a terminal state is never
reverted. Only the winner persists the accompanying fields; its HSET
lands on the live key, preserving the original TTL.

Add regression tryouts reproducing the eviction window and asserting
the fail-closed outcome (no resurrection, no reversion, single winner
under concurrency).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MaKi63TWxNMcTKS9x7JMrN