### PR TITLE
Add macOS companion design specification

### DIFF
--- a/docs/specs/macos-companion/01-problem-space.md
+++ b/docs/specs/macos-companion/01-problem-space.md
@@ -13,6 +13,44 @@ the model is unchanged). Every password, 2FA code, API token, address,
 screenshot, and half-written paragraph passes through it — and the user's
 mental model of "where that thing is right now" is a coin flip.
 
+### Sidebar: fifty years of prior art at the system level
+
+"Least-designed" is not the same as "never attempted" — the lineage is
+worth having on the record, because it shows the gap is a *declined*
+design, not an overlooked one.
+
+- **Origin.** Cut/copy/paste comes from Larry Tesler and Tim Mott's Gypsy
+  editor at Xerox PARC (1975), the names taken literally from paper-era
+  manuscript editing; Tesler credited Pentti Kanerva's earlier insight
+  that a deletion buffer could double as a transfer mechanism. Apple's
+  Lisa and Macintosh (1983–84) made it system-wide, named it "the
+  Clipboard", and fixed the ⌘X/C/V bindings. The model — one anonymous
+  slot, no expiry, no sensitivity — has not changed since.
+- **Before it.** Delete buffers and yank registers in line editors: TECO,
+  vi's named registers, the Emacs kill ring. The kill ring is a
+  *multi-slot* clipboard from the 1970s — the "clipboard manager" idea
+  predates the single-slot design that won.
+- **System-level attempts, mostly dead.** Apple's Scrapbook (a persistent
+  multi-item store, shipped in System 1, quietly abandoned); System 7's
+  Publish & Subscribe and Windows DDE/OLE (live links instead of copies —
+  a mental model users never adopted); NeXTSTEP's Shelf (spatial staging,
+  the direct ancestor of today's shelf apps); X11's ownership model,
+  where the "clipboard" is a pointer into the source app and the data
+  dies when that app quits.
+- **The integration that *did* happen — and its hedges.** OS vendors
+  eventually shipped clipboard history: Windows added Win+V history and
+  cloud sync in 2018, KDE has bundled Klipper for decades, Apple did
+  Universal Clipboard across devices. But Windows ships history **off by
+  default**, and Apple has conspicuously never added history at all —
+  adding *counter*-features instead (`org.nspasteboard.ConcealedType`,
+  iOS paste-access prompts). Clipboard traffic is dense with credentials,
+  and retention turns a transfer mechanism into a liability archive. The
+  vendors aren't overlooking retention; they're declining it.
+
+So the unsolved quadrant is not *remember more* — that has been tried,
+integrated, and deliberately hobbled. It is *hold briefly, then verifiably
+forget*, and nobody has shipped it at the system level.
+
 Because the clipboard is so inadequate, people improvise **staging areas**
 — places to put content that is *between* an origin and a destination:
 

--- a/docs/specs/macos-companion/01-problem-space.md
+++ b/docs/specs/macos-companion/01-problem-space.md
@@ -1,0 +1,146 @@
+# docs/specs/macos-companion/01-problem-space.md
+---
+
+# Problem Space
+
+## The busiest, least-designed surface on the desktop
+
+The clipboard is the highest-traffic data conduit on any computer, and it
+has barely been designed at all. It is a single anonymous register: one
+slot, no history, no expiry, no notion of sensitivity, silently readable
+by any foreground application (macOS 15 finally added paste prompts, but
+the model is unchanged). Every password, 2FA code, API token, address,
+screenshot, and half-written paragraph passes through it — and the user's
+mental model of "where that thing is right now" is a coin flip.
+
+Because the clipboard is so inadequate, people improvise **staging areas**
+— places to put content that is *between* an origin and a destination:
+
+- A password copied from a vault, needed again in ninety seconds for the
+  confirmation field.
+- A 2FA recovery code that must survive a reboot but not the week.
+- A screenshot of an error dialog, en route from one machine or one
+  conversation to another.
+- A license key mid-way through a reinstall.
+- A paragraph cut from one document, destined for another that isn't open
+  yet.
+- An address, a booking reference, a Wi-Fi password read aloud from a
+  phone.
+
+The improvised staging areas are all wrong in the same direction — they
+**retain**:
+
+| Improvised staging area | What goes wrong |
+| --- | --- |
+| Clipboard manager history | Records *everything*, indefinitely, searchable — a liability, not a convenience, the moment a secret passes through |
+| Notes app / stickies | Permanent by default; secrets fossilize in "Untitled 47", synced to a cloud account |
+| Slack/email message to self | Persists on someone else's servers, indexed, discoverable |
+| A TextEdit window never saved | Lost on crash or restart — or worse, auto-saved somewhere |
+| Files on the Desktop | Pile up, get backed up, get screen-shared |
+| The clipboard itself | One slot; the next copy destroys the thing you were staging |
+
+The problem is not storage. Storage is solved, oversolved. The problem is
+**staging**: a place designed for content whose defining property is that
+it is *in transition* and should stop existing when the transition ends.
+
+## The cache analogy, taken seriously
+
+The brief frames the app as "an L1/L2 cache for the clipboard", and the
+analogy holds up under weight — it is the spec in miniature:
+
+1. **Small.** A cache holds a working set, not an archive. A dozen cells,
+   not a thousand rows of history. Smallness is what keeps the whole state
+   legible at a glance.
+2. **Close.** One keystroke or one glance away, docked at the edge of the
+   screen — in peripheral vision, adjacent to the work, never in front of
+   it.
+3. **Evicts by policy, not by user labour.** Nobody "cleans up" a CPU
+   cache. Every entry has a TTL from the moment it arrives; expiry is the
+   default lifecycle, and *keeping* something is the action that requires
+   intent (resetting or extending the TTL).
+4. **Never authoritative.** A cache never owns the data; the source of
+   truth is elsewhere. Losing a cell is at worst a minor re-fetch, never a
+   catastrophe. This single property is what lets the app stay calm — no
+   sync, no backup, no versioning, no anxiety.
+5. **Optimized for one access pattern.** Caches win by refusing
+   generality. This app is optimized for *put → brief hold → copy out →
+   forget*, and declines every workload outside that pattern.
+
+The one place the analogy is deliberately extended: a cache line can be
+**written back** to a slower, more durable tier. Here the write-back path
+is promotion to a Onetime Secret link — the moment content stops being
+"mine, in transit between my own contexts" and becomes "shared, in transit
+to someone else". Same lifecycle philosophy (one view, then gone), one
+tier further out.
+
+## Ephemerality is the feature, not the compromise
+
+Every neighbouring product treats retention as the value and expiry as a
+setting. This product inverts that: **the guarantee of disappearance is
+the value.**
+
+That inversion is what makes it trustworthy for sensitive content.
+Clipboard managers must *exclude* password managers (via
+`org.nspasteboard.ConcealedType`) because their retention makes them a
+hazard. A staging area that provably forgets is the one place on the
+desktop where a password in transit is *supposed* to be. Users don't have
+to weigh convenience against hygiene — the convenient thing and the
+hygienic thing are the same thing.
+
+It also removes the accumulation tax. Tools that retain accrue baggage:
+the 4,000-item history, the graveyard of stickies, the "someday I'll sort
+this" folder. Each is a small standing debt of attention. A tool where
+everything self-cleans owes the user nothing and asks nothing back. Empty
+is its natural, healthy state — an empty panel is the system working, not
+the product failing at engagement.
+
+## Present, but not centre stage
+
+The app lives in the menu bar with a panel docked adjacent to a screen
+edge. It is furniture: glanceable, reachable, and otherwise invisible. It
+never demands attention — no badges, no counters, no notifications begging
+for interaction. Content plays "second or third fiddle": cells *summarize*
+what they hold (a snippet, a thumbnail, a size); they are handles for
+moving content, not a reading or editing surface.
+
+The honest success metric is *seconds of user attention consumed per
+transfer*, minimized — the opposite of engagement. A perfect session is:
+drop, glance, copy, and the app is forgotten until next time.
+
+## Who it's for, concretely
+
+Not personas — moments. The same person hits all of these in a week:
+
+- **The relay.** Copy from A, but B isn't ready yet. (Vault → form that
+  needs three fields; terminal → ticket being written; phone photo →
+  document.)
+- **The multi-paste.** One source, several destinations over ten minutes,
+  with other copying happening in between. The single-slot clipboard makes
+  this a juggling act.
+- **The overnight hold.** Needed tomorrow morning, radioactive by Friday.
+  (Recovery code during a device migration; credentials during onboarding
+  week.)
+- **The hand-off.** The content must leave the machine — to a colleague, a
+  client, another device. This is the promotion moment, and the only
+  moment the network appears.
+
+## Anti-goals
+
+Stated early because scope discipline *is* the product:
+
+- **Not a clipboard history.** No automatic capture of clipboard changes.
+  Everything in the panel was placed there deliberately. (Automatic
+  capture is precisely the liability this app exists to avoid.)
+- **Not a notes app.** No editing beyond trivial trimming, no formatting,
+  no organization, no folders, no tags.
+- **Not a search index.** A dozen glanceable cells need eyes, not a query
+  language. If it needs search, it has failed the "small" property.
+- **Not a sync service.** No cloud, no accounts for the core loop, no
+  state that outlives the machine (initially, no state that outlives the
+  process — see open questions).
+- **Not sticky.** No streaks, no counters, no upsell surface area, no
+  reasons to open it beyond having content in hand. Comfortable being
+  forgotten between uses.
+- **Not a second Onetime Secret client first.** Link creation is the
+  secondary interaction, deliberately subordinate. A full-featured API
+  client (receipts, burn, metadata browsing) is future scope at most.

--- a/docs/specs/macos-companion/02-overlooked-opportunities.md
+++ b/docs/specs/macos-companion/02-overlooked-opportunities.md
@@ -1,0 +1,184 @@
+# docs/specs/macos-companion/02-overlooked-opportunities.md
+---
+
+# Overlooked Opportunities
+
+What the neighbours do, what they systematically miss, and the position
+that leaves open.
+
+## The landscape
+
+Four families of apps border this space. None occupies it.
+
+### Clipboard managers — Paste, Maccy, CopyClip, Raycast clipboard history
+
+Retention is their point: capture every copy, keep history, make the past
+searchable. Excellent at what they do, and structurally unable to do what
+we need:
+
+- **History is a liability surface.** Every secret that transits the
+  clipboard is recorded, indexed, and often synced. Their own mitigation —
+  honouring `org.nspasteboard.ConcealedType` to *skip* password-manager
+  content — is an admission that sensitive content and retention don't
+  mix. Their answer is to look away; ours is to be the right place.
+- **Automatic capture means zero intent.** The history is full of noise
+  precisely because nothing in it was placed deliberately. Signal requires
+  search, which requires an interface, which requires attention.
+- **No time model.** Items age by scrolling out of relevance, not by
+  expiring. Nothing in the UI answers "when does this stop existing?"
+  because the answer is "never".
+
+### Shelf apps — Yoink, Dropover, Unclutter
+
+The closest neighbours in *ergonomics*: a drop target appears, holds files
+and snippets mid-drag, and gets out of the way. They validated the
+edge-docked, drag-first, present-not-centre-stage interaction. What they
+miss:
+
+- **No time model.** A shelf holds items until you remove them. In
+  practice shelves silt up like any other surface.
+- **No security posture.** No sensitivity semantics, no memory hygiene, no
+  screen-capture awareness. Fine for dragging a PDF between windows; not a
+  place anyone would stage a credential.
+- **No exit ramp off the machine.** A shelf ends at the desktop's edge.
+  The moment content must reach another person, you're back to Slack.
+
+### Password managers — 1Password, Bitwarden, Keychain
+
+The durable tier: encrypted, audited, permanent, correct. Their gap is
+temporal and by design:
+
+- They are archives, not staging areas. Creating a vault item for a
+   90-second hold is category error, and everyone feels it — which is why
+  those items end up in Notes instead.
+- Their sharing flows are heavyweight (vaults, invitations, accounts on
+  both ends) for the "send this one string to this one human once" case —
+  the case Onetime Secret exists for.
+
+### Secure senders — Onetime Secret itself, wormhole/croc, AirDrop
+
+Point-to-point transfer, done well. Their gap is the *approach* to the
+send:
+
+- The web flow starts at a browser tab. The content is already in your
+  clipboard — there's a copy-paste-navigate ritual between "I have the
+  thing" and "I have the link", and the thing sits exposed in the
+  single-slot clipboard the whole way.
+- They are moments, not places. Nothing holds the content during the
+  minutes or hours *before* it's ready to send, or the versions that
+  accumulate along the way.
+
+## The open position
+
+Plotting the neighbours on two axes — **retention** (moment → forever) and
+**sensitivity-fitness** (hostile to secrets → built for them) — the
+quadrant *short-lived + secret-safe* is empty. Clipboard managers and
+shelves sit in long-lived/hostile. Password managers sit in
+forever/built-for-it. Secure senders are a point at moment/built-for-it
+with no dwell time. **A visible, time-boxed, secret-safe staging area with
+a one-click exit to secure transfer has no incumbent.**
+
+## The overlooked opportunities, specifically
+
+### 1. Time-remaining as the primary visual state
+
+Everywhere else, expiry is buried metadata (a tooltip, a settings page).
+Making the TTL the most prominent thing about each cell — a draining
+visual cue plus a natural-time label — changes what the interface *is*: a
+glance at the panel answers "what is in flight and how long does it have",
+which is the only question a staging area needs to answer. No other app
+renders time as the content's principal attribute.
+
+### 2. TTL as direct manipulation, not configuration
+
+The interactive label (click to cycle `1h → 3h → 8h → 24h → 3d → 7d`,
+resetting the clock) collapses what would elsewhere be a preferences pane,
+a per-item settings sheet, and a date picker into one affordance on the
+cell itself. Two properties worth protecting: the vocabulary is *natural
+time* (humans plan in "3 days", not timestamps), and the ceiling is low
+(7 days is the maximum life; there is no "forever" on the wheel — the
+absence of a keep-forever option is a design statement, not a missing
+feature).
+
+### 3. Deliberate placement as the privacy model
+
+Because nothing is captured automatically, everything in the panel is
+there by an intentional act. That single decision eliminates the entire
+"my clipboard manager recorded my password" class of problem, makes the
+panel's contents meaningful (100% signal), and keeps the mental model
+honest: the user always knows what the app holds, because they put every
+item there.
+
+### 4. The promotion gradient
+
+Local cell → Onetime Secret link is a *gradient of the same idea* —
+ephemeral, view-limited content — extended from one machine to two
+parties. Overlooked by everyone: senders have no staging, stagers have no
+sending. Concretely: the cell's remaining TTL seeds the secret's TTL, the
+API call is `POST /api/v3/secret/conceal`, the returned link lands in the
+clipboard, and the local cell can offer to burn itself now that the
+content has a better home. One click from "held here" to "en route,
+one-time, encrypted" — with the content never passing through a browser
+tab or sitting exposed in the clipboard along the way.
+
+### 5. Ephemerality as the trust story for open source
+
+"Secure scratch space" lives or dies on trust, and trust here is cheap to
+earn honestly: the app is open source, the default store is memory-only,
+there is no telemetry, no account, no server in the core loop. The claim
+"it forgets" is auditable. A closed-source incumbent can't match that
+posture cheaply; the web app's existing open-source credibility transfers.
+
+### 6. Frugality as a differentiator, not a constraint
+
+2026 desktop utilities trend toward 300 MB Electron residents. A Rust
+menu-bar app that idles at near-zero CPU (no polling — TTL expiry
+scheduled, not ticked), tens of MB of memory, single-digit MB download, no
+background indexing, and no network until the user promotes something is a
+felt difference on a laptop battery. Frugal also means frugal with
+*attention* (no notifications by default) and *scope* (the anti-goals in
+doc 01). See doc 03.
+
+### 7. macOS security surface, actually used
+
+The platform provides hooks that neighbours ignore or merely comply with;
+this app can treat them as product features: mark its own copies with
+`ConcealedType` (and a transient pasteboard type) so clipboard managers
+ignore content leaving the panel; exclude the panel from screen capture
+and screen sharing (`NSWindow.sharingType = .none`); offer clipboard
+clear-after-copy with a countdown; hold cell contents in zeroized,
+non-swappable memory. Individually small; together they make "the right
+place to put a secret for an hour" a defensible technical claim, not a
+slogan. Details in doc 05.
+
+### 8. Accessibility in a category that ignores it
+
+Menu-bar utilities are, as a class, keyboard-hostile and screen-reader
+opaque — drag-and-drop-only interactions, unlabelled canvases, colour-only
+state. A staging area whose every operation (add, inspect, extend, copy,
+promote, discard) is keyboard-complete and VoiceOver-legible — with
+time-remaining exposed as an accessibility value, not just a shrinking
+ring — would be nearly alone in the category. Cheap to do from day one,
+prohibitive to retrofit. Details in doc 05.
+
+## Why incumbents won't follow
+
+Worth writing down, since "empty quadrant" usually means either
+opportunity or graveyard:
+
+- Clipboard managers can add TTLs (some have auto-clear settings) but
+  cannot abandon automatic capture and history — it *is* their product.
+  Deliberate-placement-only is a rewrite of their value proposition, not a
+  feature.
+- Shelf apps could add timers, but without a security posture and an
+  off-machine exit ramp they'd have a decaying shelf, not a staging area.
+- Password managers adding a "temporary" tier would undermine their own
+  archive-of-record positioning, and their trust model (everything in the
+  vault, forever, audited) is the opposite promise.
+
+And the graveyard risk is real: this quadrant is empty partly because it
+resists monetization (nothing accrues, no lock-in, no data gravity). That
+is survivable here precisely because the app is an open-source companion
+whose strategic job is to make Onetime Secret more useful and more
+present, not to be a business by itself. The absence of a business model
+is the moat.

--- a/docs/specs/macos-companion/03-design-principles.md
+++ b/docs/specs/macos-companion/03-design-principles.md
@@ -1,0 +1,90 @@
+# docs/specs/macos-companion/03-design-principles.md
+---
+
+# Design Principles
+
+Six principles, each earning its place by settling real design arguments.
+Every one traces back to the problem restatement (doc 01) or an overlooked
+opportunity (doc 02). When two principles conflict, the earlier-numbered
+one wins.
+
+## 1. Comfortable being temporary
+
+Expiry is the promise, not a limitation to soften. The app never
+apologizes for deleting things, never adds a safety net that quietly
+becomes an archive, never grows a "recently expired" bin beyond (at most)
+a brief, capped undo window for misclicks.
+
+*Settles:* "Should we warn before expiry?" — No notification by default; the
+draining cue *is* the warning, and the user chose the TTL. "Should
+expired items be recoverable?" — No; recoverable expiry is retention with
+extra steps. "Trash can?" — No.
+
+## 2. Present, not centre stage
+
+The app is furniture. It occupies peripheral vision (menu bar +
+edge-docked panel), never steals focus, never interrupts, and is at its
+best when the user forgets it exists between uses. Attention consumed per
+transfer is the metric, minimized.
+
+*Settles:* "Badge with cell count?" — No. "Bounce/notify when a drop
+succeeds?" — No; the cell appearing is the confirmation. "Should the panel
+take keyboard focus on drop?" — No; the user's work stays frontmost. "Dock
+icon?" — No; menu bar only.
+
+## 3. Content plays second fiddle
+
+Cells are handles for content in motion, not a display of the content. A
+cell shows the minimum needed for recognition — a trimmed first line or a
+thumbnail, a kind glyph, a size — and the time remaining. No rich
+previews, no in-place editing, no syntax highlighting, no image zoom.
+Recognition, not consumption.
+
+*Settles:* "Markdown rendering?" — No. "Expandable preview?" — At most a
+quick-look-style peek; never an editor. "Show full text on hover?" — No;
+hover reveals actions, not content (shoulder-surfing surface).
+
+## 4. Frugal
+
+In resources: native code, memory-only store, tens of MB resident,
+near-zero idle CPU (expiry is scheduled, never polled), no network in the
+core loop, single-digit MB download. In attention: principle 2. In scope:
+the anti-goals of doc 01 are load-bearing; features that add retention,
+organization, or engagement are declined by default.
+
+*Settles:* "Electron/Chromium bundle?" — No. "Auto-update daemon always
+resident?" — No; check on launch. "Analytics to guide the roadmap?" — No
+telemetry, period. "iCloud sync of cells?" — No.
+
+## 5. Trust through legibility
+
+The user can always answer, at a glance and without a manual: what does it
+hold, when does each item die, and does anything ever leave this machine
+(only on explicit promotion, and the UI makes that boundary visible).
+No hidden state, no background capture, no surprise persistence. The
+codebase is open source so every one of these claims is auditable; the
+security posture (doc 05) exists to make them true, not merely plausible.
+
+*Settles:* "Capture clipboard automatically for convenience?" — Never;
+deliberate placement is the privacy model. "Cache promoted-secret
+metadata for a history view?" — No local record beyond the active cell.
+"Phone home for feature flags?" — No.
+
+## 6. Escalate deliberately
+
+Local first; remote by explicit choice. The promote-to-link CTA is
+subtle — discoverable on every cell, prominent on none. Promotion is the
+only network operation, it is unmistakably an action (never a side
+effect), and it composes with the lifecycle: remaining local TTL seeds the
+secret TTL, and a successful promotion offers to burn the local copy.
+
+*Settles:* "Auto-create a link for large content?" — No. "Preemptively
+upload so promotion is instant?" — Absolutely not. "Require an account at
+install?" — No; the core loop works forever without one.
+
+## Tone
+
+Follows from the principles: quiet, precise, slightly warm, never cute
+about deletion and never guilt-tripping ("3 items expiring soon!" is
+banned). Empty state is a single calm sentence, not an illustration
+campaign. The app speaks when spoken to.

--- a/docs/specs/macos-companion/04-interaction-model.md
+++ b/docs/specs/macos-companion/04-interaction-model.md
@@ -1,0 +1,155 @@
+# docs/specs/macos-companion/04-interaction-model.md
+---
+
+# Interaction Model (draft)
+
+Supporting material for milestone 1 — a concrete sketch so the principles
+in doc 03 can be argued against, not a finalized interface. Everything
+here is revisable; the open questions it generates live in doc 06.
+
+## Surfaces
+
+### Menu bar item
+
+The app's only permanent presence. Monochrome template icon, no badge, no
+count. Click toggles the panel; drag-hover onto the icon opens the panel
+to receive the drop. The menu (right-click) carries the boring necessities:
+Settings, About, Quit — not features.
+
+### The panel
+
+A single column docked adjacent to a user-chosen screen edge (right edge
+default), sized like a sidebar, visually quiet (system materials, respects
+light/dark). Behaviour:
+
+- **Non-activating.** Opening the panel does not deactivate the user's app
+  (NSPanel semantics). Copy-out and TTL clicks work without the user
+  losing their place; keyboard focus is taken only when explicitly
+  summoned via hotkey.
+- **Summon/dismiss.** Menu bar click, a global hotkey (configurable,
+  keyboard-first users are first-class), and appearing automatically
+  during any drag that hovers the docked edge (shelf-app convention).
+  Dismisses on Esc, on click-outside, or stays pinned if the user pins it.
+- **Excluded from capture.** The panel is invisible to screen sharing and
+  screenshots by default (`sharingType = .none`); a visible indicator
+  states this, and it is a setting, not a hidden behaviour.
+
+### Layout, top to bottom
+
+1. **Drop zone** — a generous, always-present target strip at the top.
+   Also acts as the paste target: with the panel focused, ⌘V lands here.
+2. **SleeperCells** — newest at top, a vertical stack of uniform cells.
+3. **Footer whisper** — a single line: connection state to the Onetime
+   Secret account *iff* one is configured; otherwise nothing.
+
+The empty state is one sentence ("Drop or paste something on its way
+somewhere else.") and dimmed keyboard-shortcut hints. No illustrations, no
+onboarding carousel.
+
+## Getting content in
+
+| Route | Gesture | Notes |
+| --- | --- | --- |
+| Drag & drop | Onto panel, drop zone, or menu-bar icon | Text, RTF (flattened to plain), images, and promoted-file *contents* (small text/image files); not a file shelf — files themselves are out of scope initially |
+| Paste | ⌘V with panel focused; global "paste to panel" hotkey | The global hotkey is the power path: stage the current clipboard without touching the mouse |
+| Services / share ext. | "Stage in ‹app›" from selection | Later milestone |
+
+On arrival a cell is created with the default TTL (proposed: **8h** — a
+working day; see doc 06). No dialog, no naming step, no confirmation. The
+cell appearing *is* the receipt.
+
+## The SleeperCell
+
+The unit of the interface. Anatomy, left to right:
+
+```
+┌────────────────────────────────────────────────┐
+│ ◔  Aa  "postgres://ops:•••@db-3.internal…"     │
+│        142 chars · pasted 14:02        [ 8h ]  │
+│                                        ↗ link  │
+└────────────────────────────────────────────────┘
+  │   │   │                               │  └── promote CTA (subtle, hover/focus-revealed)
+  │   │   └── recognition line: trimmed   └── interactive TTL label
+  │   │       snippet or image thumbnail
+  │   └── kind glyph (text / image / concealed)
+  └── time-remaining cue (draining ring)
+```
+
+- **Time-remaining cue.** A small ring (or edge gauge) that visibly
+  drains over the cell's life. Continuous, ambient, honest — the primary
+  visual state per doc 02 §1. In the final hour it shifts along a second
+  channel besides colour (thickness/texture) so urgency is not
+  colour-only.
+- **Recognition line.** First ~60 chars of text (middle-ellipsized) or an
+  image thumbnail, plus a metadata whisper (size, arrival time). Content
+  detected as secret-shaped (arrived with `ConcealedType`, or matches
+  key/token patterns) renders masked by default with a reveal-on-hold.
+- **Interactive TTL label.** Reads as natural time remaining ("8h",
+  "3d"). Click to cycle the ladder `1h → 3h → 8h → 24h → 3d → 7d → 1h`,
+  each click *resetting* the clock to the shown value. One affordance for
+  extend, shorten, and reset; no menus, no pickers. Scroll/arrow-keys on
+  the focused label also step it.
+- **Promote CTA.** A quiet "↗ link" revealed on hover/focus (always
+  present to assistive tech). See promotion flow below.
+
+### Cell interactions
+
+| Intent | Mouse | Keyboard (panel focused) |
+| --- | --- | --- |
+| Copy back out | Click cell body | ↑/↓ to select, ⏎ to copy |
+| Copy + auto-clear clipboard | ⌥-click | ⌥⏎ |
+| Cycle TTL | Click label | T, or ←/→ on label |
+| Peek (read-only overlay) | Space / long-hover *action*, not content-on-hover | Space |
+| Promote to secret link | Click "↗ link" | L |
+| Discard now | Hover ✕, or drag out of panel | ⌫ (with brief inline undo) |
+
+Copy-out places the content on the clipboard marked with
+`org.nspasteboard.ConcealedType` + a transient type, so clipboard
+managers ignore it. Copy-out does **not** consume the cell (multi-paste is
+a core moment, doc 01) — the cell simply keeps draining.
+
+### Cell lifecycle
+
+`staged → draining → last-hour (urgency cue) → expired (removed; content
+zeroized)`. Expiry is silent by default: the cell is simply gone at next
+glance. A cell being promoted passes through `promoting → promoted`
+(shows the one-time link was copied, offers **Burn local copy**) and then
+resumes draining if kept.
+
+The panel holds a small working set — soft cap around a dozen cells
+(exact number: doc 06). At the cap, the panel refuses gently and asks the
+user to let something expire or discard, rather than silently evicting
+the oldest: silent eviction of deliberately-placed content would break
+trust (doc 03 §5) — the cache analogy yields eviction *by policy*, and
+here the policy is the TTL the user chose, never LRU surprise.
+
+## Promotion flow (secondary interaction)
+
+One click from cell to shareable one-time link:
+
+1. Click "↗ link" (or L). If no account is configured, this is the single
+   place the app ever mentions accounts: an inline hint linking to
+   Settings → Connection, plus a guest-mode option where the server
+   allows it.
+2. An inline, in-cell confirmation (not a modal): destination
+   (`share_domain`), TTL (seeded from the cell's remaining time, snapped
+   to the server's allowed values), optional passphrase, optional
+   recipient. One confirming click. The network boundary is explicit —
+   this is the app's only outbound action (doc 03 §6).
+3. `POST /api/v3/secret/conceal` (Basic auth: org `extid` + API token,
+   until PASETO lands). On success the link is on the clipboard, the cell
+   shows `promoted` with the receipt identifier, and offers **Burn local
+   copy**.
+4. Failure is inline in the cell (offline, auth, entitlement/TTL
+   rejection) with a retry; content never leaves the cell on failure.
+
+Deliberately absent from v1: browsing receipts, burning remote secrets
+from the panel, secret generation. The panel is a staging area with an
+exit ramp, not an API console.
+
+## Settings (one small window)
+
+Connection (server URL, org `extid` + API token, share domain, test
+button), default TTL, dock edge, hotkeys, clipboard clear-after-copy
+timing, screen-capture exclusion toggle, launch at login. That's the
+whole list; growth here is a smell.

--- a/docs/specs/macos-companion/05-technical-direction.md
+++ b/docs/specs/macos-companion/05-technical-direction.md
@@ -65,13 +65,19 @@ The claims in docs 02–03, made implementable:
   memory-hygienic: `String`/`Data` are copy-on-write, ARC/autorelease and
   `NSString` bridging create uncontrolled copies, and there is no blessed
   way to zeroize a `String`. Rust ownership makes the wipe deterministic.
-  Consequences: (a) secret bytes stay in the Rust core — only handles
-  cross the FFI, plaintext crossing only at the pasteboard moment;
-  (b) a webview shell must answer for rendered copies of secrets in the
-  WebKit process heap — a *gate* on the shell decision (doc 06 §9), not
-  a scoring criterion. Platform security APIs (Keychain, CryptoKit,
-  `sharingType`, Sandbox) are equally reachable from any shell and don't
-  differentiate; buffer lifecycle does.
+  Platform security APIs (Keychain, CryptoKit, `sharingType`, Sandbox)
+  are equally reachable from any shell and don't differentiate; buffer
+  lifecycle does.
+- **Rendering vs residence.** Displaying a secret in a UI layer for the
+  moments a human reads it is a normal, accepted exposure — browsers do
+  secure work all day, including Onetime Secret itself. The rule is about
+  *residence*: the authoritative copy lives at rest only in the zeroizing
+  core; any shell's UI layer (DOM included) receives plaintext
+  transiently, on demand, for display, and never retains it in frontend
+  state for the cell's lifetime. Copy-out goes core → pasteboard
+  directly, not through the UI layer. Residual heap/crash-dump copies in
+  a webview process are a real but marginal exposure under the threat
+  model below — a scoring criterion for the shell decision, not a gate.
 - **Pasteboard hygiene.** Outbound copies marked
   `org.nspasteboard.ConcealedType` + transient; inbound `ConcealedType`
   respected by masking the cell by default. Optional clear-after-copy

--- a/docs/specs/macos-companion/05-technical-direction.md
+++ b/docs/specs/macos-companion/05-technical-direction.md
@@ -1,0 +1,135 @@
+# docs/specs/macos-companion/05-technical-direction.md
+---
+
+# Technical Direction (draft — survey, not decisions)
+
+Milestone-1 supporting material. Records the option space and provisional
+leanings so milestone 2 can make decisions against something written down.
+
+## Architecture shape (held constant across all options)
+
+A UI-agnostic core crate plus a thin shell:
+
+```
+┌─────────────────────────────────────────────┐
+│ shell (one of the options below)            │
+│   panel window · tray · drag-drop · a11y    │
+├─────────────────────────────────────────────┤
+│ core crate (pure Rust, no UI deps)          │
+│   cell store (memory-only, zeroizing)       │
+│   TTL scheduler (timer wheel, no polling)   │
+│   pasteboard adapter (NSPasteboard, kinds,  │
+│     ConcealedType read/write)               │
+│   ots-client (v3 API, auth strategies)      │
+│   secret-shape detection (heuristics)       │
+└─────────────────────────────────────────────┘
+```
+
+The core crate is testable headless and survives a shell swap — which is
+exactly the hedge the framework question needs.
+
+## Shell options (Rust, macOS, 2026)
+
+| Option | What it is | For | Against |
+| --- | --- | --- | --- |
+| **Tauri 2.x** | System-WebKit shell, Rust backend | Mature tray + window APIs; tiny bundle vs Electron; a11y inherits WebKit/ARIA (strong); huge ecosystem; team's web skills (Vue/TS in this repo) transfer to the panel UI | Webview memory floor (~tens of MB); NSPanel non-activating behaviour needs objc2 side-door; JS layer to keep honest with the frugality principle |
+| **Swift/AppKit shell + Rust core (UniFFI/swift-bridge)** | Native shell, Rust logic | Best-in-class NSPanel, menu bar, drag-drop, VoiceOver — the exact surfaces this app lives on; smallest resident footprint | Two languages/toolchains; contributors need both; "Rust-based" becomes "Rust-cored"; more release engineering |
+| **gpui** | Zed's GPU-native Rust UI | Truly native-feeling Rust UI, proven at Zed scale; excellent perf | Young as a third-party dependency; a11y story still maturing; menu-bar/panel patterns less trodden |
+| **egui/eframe + AccessKit** | Immediate-mode Rust UI | Simple, small, AccessKit gives real a11y; fast to prototype | Non-native look (fights "furniture" goal); immediate-mode repaint vs near-zero idle CPU needs care |
+| **Slint / Dioxus native** | Declarative Rust UI | Clean component model; Slint has decent a11y | Neither is battle-tested for menu-bar utility UX on macOS |
+
+**Provisional leaning:** Tauri 2.x shell with `objc2` for the few native
+behaviours it lacks (non-activating NSPanel, `sharingType`,
+pasteboard types), on the strength of maturity + a11y + contributor
+accessibility — with the Swift-shell option kept live as the
+better-native fallback, made cheap by the core-crate architecture.
+Decision belongs to milestone 2 after a two-way spike: the panel
+experience (non-activating, edge-docked, drag-in) is the make-or-break
+surface to prototype in both.
+
+Non-negotiables regardless of shell: signed + notarized, universal binary
+(arm64 first), sandboxed if feasible (pasteboard and network entitlements
+are compatible; verify against capture-exclusion APIs), single-digit MB
+download as a target, no always-resident helper processes.
+
+## Security posture
+
+The claims in docs 02–03, made implementable:
+
+- **Memory-only by default.** Cells live in RAM; process exit is total
+  amnesia (v1 behaviour; persistence across restart is an open question).
+  Buffers zeroized on expiry/discard (`zeroize`), `mlock` where practical
+  for small secret-shaped payloads; large images excluded from `mlock`
+  and documented as such.
+- **Pasteboard hygiene.** Outbound copies marked
+  `org.nspasteboard.ConcealedType` + transient; inbound `ConcealedType`
+  respected by masking the cell by default. Optional clear-after-copy
+  (clear the system clipboard N seconds after a copy-out, only if the
+  clipboard still holds our change-count).
+- **Capture exclusion.** Panel `NSWindow.sharingType = .none` by default,
+  surfaced honestly in the UI as a toggle.
+- **Network boundary.** Exactly one outbound destination (the configured
+  OTS server), TLS-only, only on explicit promotion. No telemetry, no
+  update pings beyond a launch-time check against the release feed.
+- **Credential storage.** API token in the macOS Keychain, never in
+  config files.
+- **Threat honesty.** Out of scope and said so: a compromised local user
+  account, kernel-level attackers, and other apps with screen-recording +
+  accessibility permissions granted. The app hardens the common cases
+  (shoulder surfing, screen sharing, clipboard-manager retention, swap,
+  crash dumps) and does not pretend to be an enclave.
+
+## Onetime Secret v3 API integration
+
+Grounded in the current repo (`apps/api/v3/routes.txt`,
+`src/schemas/api/v3/`):
+
+- **Promotion** → `POST /api/v3/secret/conceal` with
+  `{ kind: "conceal", secret, ttl, share_domain, passphrase?, recipient? }`.
+  Cell-remaining-TTL seeds `ttl`, snapped to server-permitted values;
+  entitlement rejections (cf. `secret_ttl_entitlement_spec.rb`) surface
+  inline with the nearest allowed value offered.
+- **Auth, phase 1:** HTTP Basic (`basicauth` strategy — API key + secret
+  pair, configured alongside the organization `extid`), stored in
+  Keychain. **Phase 2:** PASETO bearer tokens when v3 auth ships; the
+  `ots-client` crate isolates auth as a strategy trait so the swap is
+  additive.
+- **Guest mode:** where the server enables guest route gating,
+  `POST /api/v3/guest/secret/conceal` allows promotion with no account —
+  worth supporting so the open-source app is fully useful against
+  self-hosted instances with zero setup.
+- **Post-promotion:** store only the receipt identifier on the live cell
+  (for a "burn remote" affordance on that cell alone). No receipt
+  browsing, no local history of promoted secrets (doc 03 §5).
+- **Server config:** `GET /api/v3/status` + config endpoints at
+  connection-test time to learn allowed TTLs and share domains, cached in
+  memory only.
+
+## Accessibility commitments
+
+Category-defying per doc 02 §8; committed now because retrofits fail:
+
+- **Keyboard-complete.** Every operation in doc 04's table has a binding;
+  the global summon hotkey focuses the panel for full keyboard operation.
+- **VoiceOver-legible.** Each cell is one accessibility element with a
+  composed label ("Text, postgres URL, 142 characters, expires in 7
+  hours"); the TTL label is an adjustable control (VO-arrows step the
+  ladder); the draining ring mirrors into an accessibility value that
+  announces at coarse thresholds only (no chatter).
+- **Not colour-only.** Urgency encoded in ring geometry + label text, not
+  hue alone; WCAG 2.2 AA contrast against both system materials.
+- **Motion-respectful.** `prefers-reduced-motion` swaps the draining
+  animation for stepped states; no parallax, no bounce.
+- **Text scaling.** Cells reflow with system text size; the panel is a
+  column, so this is layout-cheap if honoured from the first sketch.
+
+## Frugality budget (v1 targets, measured in CI once real)
+
+| Metric | Target |
+| --- | --- |
+| Download size | < 10 MB |
+| Resident memory, idle w/ 5 cells | < 60 MB (Tauri) / < 25 MB (native shell) |
+| Idle CPU | ~0% (no timers ticking; TTL expiry scheduled) |
+| Wakeups | No periodic wakeups while panel hidden |
+| Network at rest | Zero connections |
+| Cold launch to usable panel | < 300 ms |

--- a/docs/specs/macos-companion/05-technical-direction.md
+++ b/docs/specs/macos-companion/05-technical-direction.md
@@ -85,14 +85,25 @@ The claims in docs 02–03, made implementable:
   clipboard still holds our change-count).
 - **Capture exclusion.** Panel `NSWindow.sharingType = .none` by default,
   surfaced honestly in the UI as a toggle.
+- **Runtime memory dumping.** Unlike Linux (`ptrace`, `/proc/pid/mem` —
+  trivial with same UID), macOS blocks `task_for_pid` against a Hardened
+  Runtime binary without `get-task-allow` — even for root, unless SIP is
+  disabled via Recovery. Hardened Runtime is already required for
+  notarization; the discipline is shipping **zero** weakening
+  entitlements (`allow-jit`, `disable-library-validation`, …). Tauri
+  clears this where Electron can't: JS runs out-of-process in Apple's
+  SIP-protected `WebContent`, so the binary holding resident secrets can
+  be fully hardened. Note this guarantee is macOS-specific — it does not
+  transfer to a Linux/Windows sibling (doc 06 §15).
 - **Network boundary.** Exactly one outbound destination (the configured
   OTS server), TLS-only, only on explicit promotion. No telemetry, no
   update pings beyond a launch-time check against the release feed.
 - **Credential storage.** API token in the macOS Keychain, never in
   config files.
 - **Threat honesty.** Out of scope and said so: a compromised local user
-  account, kernel-level attackers, and other apps with screen-recording +
-  accessibility permissions granted. The app hardens the common cases
+  account, kernel-level attackers, machines with SIP disabled (common on
+  dev boxes — the anti-dumping guarantee above evaporates there), and
+  other apps with screen-recording + accessibility permissions granted. The app hardens the common cases
   (shoulder surfing, screen sharing, clipboard-manager retention, swap,
   crash dumps) and does not pretend to be an enclave.
 

--- a/docs/specs/macos-companion/05-technical-direction.md
+++ b/docs/specs/macos-companion/05-technical-direction.md
@@ -61,6 +61,17 @@ The claims in docs 02–03, made implementable:
   Buffers zeroized on expiry/discard (`zeroize`), `mlock` where practical
   for small secret-shaped payloads; large images excluded from `mlock`
   and documented as such.
+- **Zeroization is why the core is Rust.** Swift is memory-safe but not
+  memory-hygienic: `String`/`Data` are copy-on-write, ARC/autorelease and
+  `NSString` bridging create uncontrolled copies, and there is no blessed
+  way to zeroize a `String`. Rust ownership makes the wipe deterministic.
+  Consequences: (a) secret bytes stay in the Rust core — only handles
+  cross the FFI, plaintext crossing only at the pasteboard moment;
+  (b) a webview shell must answer for rendered copies of secrets in the
+  WebKit process heap — a *gate* on the shell decision (doc 06 §9), not
+  a scoring criterion. Platform security APIs (Keychain, CryptoKit,
+  `sharingType`, Sandbox) are equally reachable from any shell and don't
+  differentiate; buffer lifecycle does.
 - **Pasteboard hygiene.** Outbound copies marked
   `org.nspasteboard.ConcealedType` + transient; inbound `ConcealedType`
   respected by masking the cell by default. Optional clear-after-copy

--- a/docs/specs/macos-companion/06-open-questions.md
+++ b/docs/specs/macos-companion/06-open-questions.md
@@ -1,0 +1,68 @@
+# docs/specs/macos-companion/06-open-questions.md
+---
+
+# Open Questions
+
+Unresolved by design at milestone 1. Each has a current leaning where one
+exists, so disagreement has a target.
+
+## Product
+
+1. **Default TTL.** Proposed 8h (a working day; short enough to be honest
+   about the cache framing, long enough for the relay/multi-paste
+   moments). Alternatives: 1h (purist) or 24h (forgiving). The default is
+   the app's single most-felt setting.
+2. **Does the TTL ladder wrap?** `…→ 7d → 1h` wrap is one-affordance-clean
+   but makes "one click past max" a 168→1 hour cliff on deliberately
+   staged content. Alternatives: stop at 7d with shift-click to shorten,
+   or ←/→ semantics with click = reset only. Needs a prototype in hand.
+3. **Cell cap.** Soft cap ~12 proposed, refuse-don't-evict at the limit
+   (doc 04). Is refusal at the cap the right call under a fast triage
+   workload, or does it interrupt exactly when the user is busiest?
+4. **Persistence across restart.** v1 leaning: none — quit is amnesia,
+   which is the cleanest trust story and the cache-true behaviour. But the
+   "overnight hold" moment (doc 01) collides with an OS update reboot. If
+   ever added: encrypted spill keyed via Keychain/Secure Enclave, off by
+   default, and it must not soften the expiry contract.
+5. **Expired-cell undo.** Discard has inline undo (misclick insurance).
+   Does *expiry* deserve a seconds-long tombstone, or is silent removal
+   (doc 03 §1) the promise? Leaning: silent; the user set the clock.
+6. **Image support depth.** Thumbnails + copy-out in v1, but images fight
+   the memory-hygiene story (size, mlock exclusion) and the v3 conceal
+   payload is text-shaped. Ship text-first with images close behind, or
+   together?
+7. **Secret-shape detection.** Masking on `ConcealedType` is free; regex
+   heuristics for keys/tokens risk false confidence both ways. How much
+   detection is honest?
+8. **Name.** "Airlock" collides with Airlock Digital. Shortlist and
+   trademark pass needed before any public artifact.
+
+## Platform & technical
+
+9. **Shell decision.** Tauri 2.x vs Swift-shell-Rust-core (doc 05).
+   Requires the two-way spike on the non-activating edge-docked panel —
+   the one surface that can disqualify a framework.
+10. **Sandbox + capture exclusion.** Verify App Sandbox coexists with
+    `sharingType = .none` and the pasteboard patterns we need; sandboxing
+    is worth real effort but not worth losing capture exclusion.
+11. **Distribution.** Direct download + Homebrew cask (leaning), or also
+    Mac App Store (sandbox implications, review friction vs reach)?
+12. **Guest-mode prominence.** Where servers allow guest conceal, does the
+    panel offer promotion with zero configuration out of the box (great
+    for self-hosters, but link provenance/trust questions for
+    onetimesecret.com defaults)?
+13. **TTL semantics across promotion.** Snap cell-remaining time to
+    server-allowed TTLs — up, down, or nearest? Down is the conservative
+    (never outlive intent) leaning.
+14. **Multi-display / multiple edges.** One panel on one edge of one
+    display in v1; is that acceptable for the docked-monitor crowd?
+
+## Ecosystem
+
+15. **Windows/Linux siblings.** The core-crate split keeps the door open;
+    naming it "macOS companion" closes it rhetorically. Decide posture
+    before announcing.
+16. **Relationship to future v3 PASETO work.** The desktop app is a
+    real first consumer of v3 auth — should its needs (long-lived org
+    tokens, device-ish identity, offline grace) feed back into that
+    design now, while it's unbuilt?

--- a/docs/specs/macos-companion/06-open-questions.md
+++ b/docs/specs/macos-companion/06-open-questions.md
@@ -41,11 +41,12 @@ exists, so disagreement has a target.
 
 9. **Shell decision.** Tauri 2.x vs Swift-shell-Rust-core (doc 05).
    Requires the two-way spike on the non-activating edge-docked panel —
-   the one surface that can disqualify a framework. Added gate: the
-   zeroization promise (doc 05, security posture) — a webview shell must
-   show that rendered secrets don't accumulate uncontrolled copies in the
-   WebKit process heap. This re-weights the leaning toward
-   Swift-shell-Rust-core; "Rust-based" honestly becomes "Rust-cored".
+   the one surface that can disqualify a framework. Added design rule
+   (doc 05, "rendering vs residence"): plaintext resides at rest only in
+   the zeroizing Rust core, and the UI layer renders it transiently
+   without retaining it in frontend state — a discipline any shell can
+   meet, so it's a scoring criterion, not a gate. Either way,
+   "Rust-based" honestly means "Rust-cored".
 10. **Sandbox + capture exclusion.** Verify App Sandbox coexists with
     `sharingType = .none` and the pasteboard patterns we need; sandboxing
     is worth real effort but not worth losing capture exclusion.

--- a/docs/specs/macos-companion/06-open-questions.md
+++ b/docs/specs/macos-companion/06-open-questions.md
@@ -41,7 +41,11 @@ exists, so disagreement has a target.
 
 9. **Shell decision.** Tauri 2.x vs Swift-shell-Rust-core (doc 05).
    Requires the two-way spike on the non-activating edge-docked panel —
-   the one surface that can disqualify a framework.
+   the one surface that can disqualify a framework. Added gate: the
+   zeroization promise (doc 05, security posture) — a webview shell must
+   show that rendered secrets don't accumulate uncontrolled copies in the
+   WebKit process heap. This re-weights the leaning toward
+   Swift-shell-Rust-core; "Rust-based" honestly becomes "Rust-cored".
 10. **Sandbox + capture exclusion.** Verify App Sandbox coexists with
     `sharingType = .none` and the pasteboard patterns we need; sandboxing
     is worth real effort but not worth losing capture exclusion.

--- a/docs/specs/macos-companion/07-repo-skeleton.md
+++ b/docs/specs/macos-companion/07-repo-skeleton.md
@@ -1,0 +1,152 @@
+# docs/specs/macos-companion/07-repo-skeleton.md
+---
+
+# Repo Skeleton — Initialization Prescription
+
+How to initialize the application repository, written before doing it.
+This is a prescription, not implementation: executing it is the first act
+of milestone 2. Everything here is chosen to be cheap now and hard to
+retrofit later — the same logic as the accessibility commitments in doc 05.
+
+## Ground rules
+
+- **A new repository, not this one.** The companion is standalone-useful
+  and independently versioned; it does not live in the web app's monorepo.
+  Initialize as `onetimesecret/macos-companion` — a deliberately unbranded
+  name, because the product name is unresolved (doc 06 §8) and GitHub
+  renames redirect. The product name must appear only as a UI string and
+  a bundle display name, never as an identifier (crate names, bundle id,
+  repo name), so the eventual rename is a one-file change.
+- **Public from the first commit.** An open-source companion has no
+  private incubation period to leak secrets from — and starting public
+  enforces the no-credentials-in-repo discipline from day one.
+- **The spec moves in.** `docs/specs/macos-companion/` from this repo is
+  imported as `docs/spec/` in the new one; the copy here is then replaced
+  by a pointer. The spec belongs with the code it governs.
+
+## Layout
+
+```
+macos-companion/
+├── Cargo.toml               # virtual workspace, resolver = "3"
+├── Cargo.lock               # committed — this is an application
+├── rust-toolchain.toml      # pinned stable + rustfmt + clippy
+├── rustfmt.toml
+├── deny.toml                # cargo-deny: advisories + license allowlist
+├── .editorconfig
+├── .gitignore               # target/, .DS_Store, *.p12, *.provisionprofile
+├── crates/
+│   ├── core/                # cell store, TTL wheel, zeroizing buffers,
+│   │                        #   secret-shape heuristics — no macOS deps
+│   ├── ots-client/          # v3 API + auth strategy trait — no macOS deps
+│   └── pasteboard/          # NSPasteboard adapter (objc2) — macOS-only
+├── shell/                   # empty until ADR-0002 (the milestone-2 decision)
+├── spikes/
+│   ├── tauri-panel/         # the two-way spike, doc 05 — disposable
+│   └── swift-panel/         #   by construction, excluded from workspace
+├── docs/
+│   ├── spec/                # imported from this repo
+│   └── adr/
+│       ├── template.md      # context / decision / eject triggers
+│       └── 0001-rust-core-thin-shell.md
+├── .github/
+│   ├── workflows/ci.yml
+│   └── ISSUE_TEMPLATE/      # bug + question only; no feature-farm forms
+├── LICENSE                  # MIT, matching the parent project
+├── README.md                # honest pre-alpha: "design-first, no releases"
+├── SECURITY.md              # points at Onetime Secret's disclosure process
+├── CONTRIBUTING.md
+└── CHANGELOG.md             # Keep a Changelog, seeded with [Unreleased]
+```
+
+One refinement over the doc 05 diagram: the pasteboard adapter is its own
+crate rather than a module of `core`. This keeps `core` and `ots-client`
+free of macOS dependencies, so the crates that hold all the logic build
+and test on cheap Linux CI runners — the macOS runner is reserved for
+`pasteboard`, the shell, and eventually the frugality-budget assertions.
+
+## Workspace manifest decisions
+
+- **Edition 2024, `resolver = "3"`,** current stable pinned in
+  `rust-toolchain.toml` (bump deliberately, not ambiently).
+- **`[workspace.lints]`:** `clippy::all` + a curated pedantic subset at
+  `deny`; `unsafe_code = "deny"` in `core` and `ots-client`. Only
+  `pasteboard` (and later the shell glue) may write `unsafe`, so the FFI
+  surface is auditable by crate boundary, not by grep.
+- **`panic = "unwind"` in release, on purpose.** `panic = "abort"` is the
+  usual size win, but aborting skips `Drop` — and zeroize-on-drop *is* the
+  security posture (doc 05). Unwinding panics scrub buffers on the way
+  down. Record this in the manifest as a comment so nobody "optimizes" it
+  away.
+- **Release profile:** `lto = "thin"`, `strip = "symbols"`,
+  `opt-level = "s"` as the starting point for the <10 MB budget.
+- **Dependencies at init: `zeroize` in `core`. Nothing else.** Every
+  further dependency arrives with the code that needs it; the skeleton
+  ships no speculative deps. `cargo-deny` gates from commit one:
+  advisories deny, licenses allowlisted to permissive
+  (MIT/Apache-2.0/BSD/ISC/Zlib) so distribution stays simple.
+
+`ots-client` is written as if it will be published to crates.io someday
+(a general Rust client for the v3 API is independently useful); `core`
+and `pasteboard` are `publish = false`.
+
+## CI from the first push
+
+Two lanes in one workflow, both required:
+
+| Lane | Runner | Jobs |
+| --- | --- | --- |
+| Logic | `ubuntu-latest` | `fmt --check`, `clippy -D warnings`, `test -p core -p ots-client`, `cargo-deny` |
+| Platform | `macos-latest` (arm64) | full-workspace clippy + test, incl. `pasteboard` |
+
+Not in CI at init, recorded as future jobs in the workflow file as
+comments: signing/notarization (a release-engineering ADR of its own) and
+the frugality-budget assertions from doc 05, which become measurable only
+once a binary exists.
+
+## Governance files
+
+- **LICENSE:** MIT, same as the parent project.
+- **SECURITY.md:** no parallel process — point at Onetime Secret's
+  existing disclosure channel, with a note that memory-hygiene claims
+  (doc 05) are explicitly in scope for reports.
+- **CONTRIBUTING.md:** short. Spec-first (changes to behaviour start in
+  `docs/spec/`), decisions land as ADRs, anti-goals (doc 01) are the
+  review bar for feature PRs.
+- **README.md:** states plainly that this is a design-first project with
+  no releases yet, links the spec's reading order, and repeats the
+  one-paragraph summary. No screenshots of vaporware.
+
+## ADR practice, seeded
+
+`docs/adr/template.md` carries four sections: context, decision,
+consequences, **eject triggers** — the observable conditions under which
+the decision gets revisited. Two ADRs exist at init:
+
+- **ADR-0001, accepted:** UI-agnostic Rust core + thin shell (doc 05's
+  architecture shape) — the one decision milestone 1 actually made.
+- **ADR-0002, proposed & empty:** shell selection. Filled in only after
+  the two-way panel spike; `spikes/` exists so the evidence has a home
+  that is visibly not product code.
+
+## Identifiers reserved at init
+
+- Bundle id placeholder: `com.onetimesecret.companion` (safe to change
+  any time before first notarized release, painful after).
+- Crate names: `companion-core`, `companion-pasteboard`, `ots-client`.
+- No trademark-sensitive strings ("Airlock" or successors) anywhere but
+  `README.md`'s naming note.
+
+## Definition of done
+
+The skeleton is initialized when:
+
+1. `cargo test` passes on a Linux machine with no macOS SDK present.
+2. CI is green on both lanes with zero warnings.
+3. `cargo deny check` passes.
+4. The repo contains no binary assets, no signing material, and no
+   credentials — verified by eyeball and by `.gitignore` before the
+   first push, not after.
+5. Both ADR files exist; ADR-0002 is honestly empty.
+6. `README.md` would not embarrass anyone if linked from Hacker News an
+   hour after the push.

--- a/docs/specs/macos-companion/README.md
+++ b/docs/specs/macos-companion/README.md
@@ -1,0 +1,54 @@
+# docs/specs/macos-companion/README.md
+---
+
+# macOS Companion — Design Spec
+
+An open-source, Rust-based macOS desktop companion to Onetime Secret.
+Working title: **Airlock** (see naming note below). Its cells of pasted
+content are called **SleeperCells**.
+
+This is a *design* spec, produced ahead of any implementation. Milestone 1
+is deliberately narrow: restate the problem space in our own words, and map
+the opportunities that neighbouring applications overlook. Interaction and
+technical direction documents are included as supporting material — they
+record current thinking, not decisions.
+
+## One-paragraph summary
+
+A menu-bar-resident staging area for content in transition. Drag or paste
+text and images into a small edge-docked panel; each item becomes a
+SleeperCell with a visible, limited time-to-live. Cells exist to be copied
+back out and then forgotten — like a CPU's L1/L2 cache, the value is in
+being small, close, and evicted by policy, never in being a system of
+record. Secondarily, any cell can be promoted into a Onetime Secret link
+(v3 API) when the content needs to travel to another person or machine.
+
+## Reading order
+
+| Doc | Contents | Milestone-1 status |
+| --- | --- | --- |
+| [01-problem-space.md](01-problem-space.md) | Restatement of the problem, the cache analogy taken seriously, anti-goals | **Core deliverable** |
+| [02-overlooked-opportunities.md](02-overlooked-opportunities.md) | Landscape of neighbouring apps and the gaps they leave | **Core deliverable** |
+| [03-design-principles.md](03-design-principles.md) | The principles that fall out of 01 + 02 | Supporting |
+| [04-interaction-model.md](04-interaction-model.md) | SleeperCell anatomy, TTL cycling, panel behaviour, promotion flow | Supporting — draft |
+| [05-technical-direction.md](05-technical-direction.md) | Rust framework survey, v3 API integration, security posture, a11y | Supporting — draft, no decisions |
+| [06-open-questions.md](06-open-questions.md) | Everything unresolved, honestly | Supporting |
+
+## Naming note
+
+**Airlock** is a working title only: a small chamber between two
+environments that things pass through but never live in — which is the
+product in one image. It collides with at least one existing security
+vendor (Airlock Digital), so it will not survive to release without a
+trademark check. Alternatives considered: Layover, Vestibule, Foyer,
+Waypoint, Holdover. The name matters less than the metaphor; every
+candidate is a word for *a place you pass through*.
+
+## Relationship to the web application
+
+The companion is open source and standalone-useful: the core loop (paste,
+hold briefly, copy out, forget) requires no account and no network. The
+Onetime Secret v3 API appears only at the promotion step — turning a local
+ephemeral cell into a one-time link. Authentication starts with HTTP Basic
+(organization `extid` + API token pair) and migrates to PASETO when the v3
+auth work lands. See [05-technical-direction.md](05-technical-direction.md).

--- a/docs/specs/macos-companion/README.md
+++ b/docs/specs/macos-companion/README.md
@@ -33,6 +33,7 @@ record. Secondarily, any cell can be promoted into a Onetime Secret link
 | [04-interaction-model.md](04-interaction-model.md) | SleeperCell anatomy, TTL cycling, panel behaviour, promotion flow | Supporting — draft |
 | [05-technical-direction.md](05-technical-direction.md) | Rust framework survey, v3 API integration, security posture, a11y | Supporting — draft, no decisions |
 | [06-open-questions.md](06-open-questions.md) | Everything unresolved, honestly | Supporting |
+| [07-repo-skeleton.md](07-repo-skeleton.md) | Prescription for initializing the app repository | Supporting — prescription, not yet executed |
 
 ## Naming note
 


### PR DESCRIPTION
## Summary

This adds a comprehensive design specification for the macOS companion application to Onetime Secret. The spec consists of six documents that establish the problem space, identify market opportunities, define design principles, sketch the interaction model, survey technical direction, and enumerate open questions.

**Core deliverables (docs 01–02):**
- **Problem Space**: Reframes the clipboard as an inadequate data conduit and positions the app as an L1/L2 cache for ephemeral content staging, grounded in the cache analogy (small, close, evicts by policy, never authoritative, optimized for one access pattern).
- **Overlooked Opportunities**: Maps four neighbouring product families (clipboard managers, shelf apps, password managers, secure senders), identifies the empty quadrant they leave (short-lived + secret-safe), and articulates eight specific opportunities no incumbent can easily follow.

**Supporting material (docs 03–06):**
- **Design Principles**: Six load-bearing principles (comfortable being temporary, present not centre stage, content plays second fiddle, frugal, trust through legibility, escalate deliberately) that settle recurring design arguments.
- **Interaction Model**: Concrete sketch of the menu-bar item, edge-docked panel, SleeperCell anatomy (time-remaining cue, recognition line, interactive TTL label), cell lifecycle, and promotion flow to Onetime Secret v3 API.
- **Technical Direction**: Survey of shell options (Tauri 2.x leaning, with Swift-shell fallback), security posture (memory-only, zeroizing, pasteboard hygiene, capture exclusion), v3 API integration strategy, and accessibility commitments.
- **Open Questions**: 16 unresolved questions across product, platform, and ecosystem dimensions, each with current leanings where they exist.

The spec is written to be argued against, not finalized. Milestone 1 is deliberately narrow: restate the problem in our own words and map the opportunities. Implementation decisions are deferred to milestone 2 after prototyping the critical surfaces (non-activating edge-docked panel).

## Related Issues

This is foundational specification work for the macOS companion project.

## Test Plan

N/A — This is design documentation, not code. The spec is intended for review and discussion to validate the problem framing and opportunity analysis before implementation begins.

https://claude.ai/code/session_011dRtAwASqwFvTqgMy3sM93